### PR TITLE
[Merged by Bors] - doc(category_theory): add doc-strings and links to the stacks project

### DIFF
--- a/src/category_theory/adjunction/basic.lean
+++ b/src/category_theory/adjunction/basic.lean
@@ -25,6 +25,8 @@ there are also constructors `left_adjoint_of_equiv` and `adjunction_of_equiv_lef
 well as their duals) which can be simpler in practice.
 
 Uniqueness of adjoints is shown in `category_theory.adjunction.opposites`.
+
+See https://stacks.math.columbia.edu/tag/0037.
 -/
 structure adjunction (F : C ⥤ D) (G : D ⥤ C) :=
 (hom_equiv : Π (X Y), (F.obj X ⟶ Y) ≃ (X ⟶ G.obj Y))
@@ -293,7 +295,11 @@ def left_adjoint_of_nat_iso {F G : C ⥤ D} (h : F ≅ G) [r : is_left_adjoint F
 section
 variables {E : Type u₃} [ℰ : category.{v₃} E] (H : D ⥤ E) (I : E ⥤ D)
 
-/-- Show that adjunctions can be composed. -/
+/--
+Composition of adjunctions.
+
+See https://stacks.math.columbia.edu/tag/0DV0.
+-/
 def comp (adj₁ : F ⊣ G) (adj₂ : H ⊣ I) : F ⋙ H ⊣ I ⋙ G :=
 { hom_equiv := λ X Z, equiv.trans (adj₂.hom_equiv _ _) (adj₁.hom_equiv _ _),
   unit := adj₁.unit ≫

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -19,9 +19,14 @@ variables {C : Type u₁} [category.{v₁} C]
 variables {D : Type u₂} [category.{v₂} D]
 variables {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R)
 
--- Lemma 4.5.13 from [Riehl][riehl2017]
--- Proof in <https://stacks.math.columbia.edu/tag/0036>
--- or at <https://math.stackexchange.com/a/2727177>
+/--
+If the left adjoint is fully faithful, then the unit is an isomorphism.
+
+See
+* Lemma 4.5.13 from [Riehl][riehl2017]
+* https://math.stackexchange.com/a/2727177
+* https://stacks.math.columbia.edu/tag/07RB (we only prove the forward direction!)
+-/
 instance unit_is_iso_of_L_fully_faithful [full L] [faithful L] : is_iso (adjunction.unit h) :=
 @nat_iso.is_iso_of_is_iso_app _ _ _ _ _ _ (adjunction.unit h) $ λ X,
 @yoneda.is_iso _ _ _ _ ((adjunction.unit h).app X)
@@ -40,6 +45,11 @@ instance unit_is_iso_of_L_fully_faithful [full L] [faithful L] : is_iso (adjunct
     simp,
   end }.
 
+/--
+If the right adjoint is fully faithful, then the counit is an isomorphism.
+
+See https://stacks.math.columbia.edu/tag/07RB (we only prove the forward direction!)
+-/
 instance counit_is_iso_of_R_fully_faithful [full R] [faithful R] : is_iso (adjunction.counit h) :=
 @nat_iso.is_iso_of_is_iso_app _ _ _ _ _ _ (adjunction.counit h) $ λ X,
 @is_iso_of_op _ _ _ _ _ $

--- a/src/category_theory/adjunction/limits.lean
+++ b/src/category_theory/adjunction/limits.lean
@@ -42,7 +42,11 @@ def functoriality_is_left_adjoint :
   { unit := functoriality_unit adj K,
     counit := functoriality_counit adj K } }
 
-/-- A left adjoint preserves colimits. -/
+/--
+A left adjoint preserves colimits.
+
+See https://stacks.math.columbia.edu/tag/0038.
+-/
 def left_adjoint_preserves_colimits : preserves_colimits F :=
 { preserves_colimits_of_shape := λ J 𝒥,
   { preserves_colimit := λ F,
@@ -97,7 +101,11 @@ def functoriality_is_right_adjoint :
   { unit := functoriality_unit' adj K,
     counit := functoriality_counit' adj K } }
 
-/-- A right adjoint preserves limits. -/
+/--
+A right adjoint preserves limits.
+
+See https://stacks.math.columbia.edu/tag/0038.
+-/
 def right_adjoint_preserves_limits : preserves_limits G :=
 { preserves_limits_of_shape := λ J 𝒥,
   { preserves_limit := λ K,

--- a/src/category_theory/category/default.lean
+++ b/src/category_theory/category/default.lean
@@ -48,6 +48,8 @@ infixr ` ≫ `:80 := category_struct.comp -- type as \gg
 The typeclass `category C` describes morphisms associated to objects of type `C`.
 The universe levels of the objects and morphisms are unconstrained, and will often need to be
 specified explicitly, as `category.{v} C`. (See also `large_category` and `small_category`.)
+
+See https://stacks.math.columbia.edu/tag/0014.
 -/
 class category (obj : Type u)
 extends category_struct.{v} obj : Type (max u (v+1)) :=
@@ -119,6 +121,8 @@ by { split_ifs; refl }
 /--
 A morphism `f` is an epimorphism if it can be "cancelled" when precomposed:
 `f ≫ g = f ≫ h` implies `g = h`.
+
+See https://stacks.math.columbia.edu/tag/003B.
 -/
 class epi (f : X ⟶ Y) : Prop :=
 (left_cancellation : Π {Z : C} (g h : Y ⟶ Z) (w : f ≫ g = f ≫ h), g = h)
@@ -126,6 +130,8 @@ class epi (f : X ⟶ Y) : Prop :=
 /--
 A morphism `f` is a monomorphism if it can be "cancelled" when postcomposed:
 `g ≫ f = h ≫ f` implies `g = h`.
+
+See https://stacks.math.columbia.edu/tag/003B.
 -/
 class mono (f : X ⟶ Y) : Prop :=
 (right_cancellation : Π {Z : C} (g h : Z ⟶ X) (w : g ≫ f = h ≫ f), g = h)
@@ -218,6 +224,15 @@ namespace preorder
 
 variables (α : Type u)
 
+/--
+The category structure coming from a preorder. There is a morphism `X ⟶ Y` if and only if `X ≤ Y`.
+
+Because we don't allow morphisms to live in `Prop`,
+we have to define `X ⟶ Y` as `ulift (plift (X ≤ Y))`.
+See `category_theory.hom_of_le` and `category_theory.le_of_hom`.
+
+See https://stacks.math.columbia.edu/tag/00D3.
+-/
 @[priority 100] -- see Note [lower instance priority]
 instance small_category [preorder α] : small_category α :=
 { hom  := λ U V, ulift (plift (U ≤ V)),

--- a/src/category_theory/connected.lean
+++ b/src/category_theory/connected.lean
@@ -53,6 +53,8 @@ We instead are interested in categories with exactly one 'connected
 component'.
 
 This allows us to show that the functor X ⨯ - preserves connected limits.
+
+See https://stacks.math.columbia.edu/tag/002S
 -/
 class connected (J : Type v₂) [category.{v₁} J] extends inhabited J :=
 (iso_constant : Π {α : Type v₂} (F : J ⥤ discrete α), F ≅ (functor.const J).obj (F.obj default))

--- a/src/category_theory/discrete_category.lean
+++ b/src/category_theory/discrete_category.lean
@@ -15,6 +15,14 @@ with the only morphisms being equalities.
 -/
 def discrete (α : Type u₁) := α
 
+/--
+The "discrete" category on a type, whose morphisms are equalities.
+
+Because we do not allow morphisms in `Prop` (only in `Type`),
+somewhat annoyingly we have to define `X ⟶ Y` as `ulift (plift (X = Y))`.
+
+See https://stacks.math.columbia.edu/tag/001A
+-/
 instance discrete_category (α : Type u₁) : small_category (discrete α) :=
 { hom  := λ X Y, ulift (plift (X = Y)),
   id   := λ X, ulift.up (plift.up rfl),

--- a/src/category_theory/equivalence.lean
+++ b/src/category_theory/equivalence.lean
@@ -18,6 +18,8 @@ universes v₁ v₂ v₃ u₁ u₂ u₃ -- declare the `v`'s first; see `categor
   The triangle equation is written as a family of equalities between morphisms, it is more
   complicated if we write it as an equality of natural transformations, because then we would have
   to insert natural transformations like `F ⟶ F1`.
+
+See https://stacks.math.columbia.edu/tag/001J
 -/
 structure equivalence (C : Type u₁) [category.{v₁} C] (D : Type u₂) [category.{v₂} D] :=
 mk' ::
@@ -394,6 +396,14 @@ eq_of_inv_eq_inv (functor_unit_comp _ _)
 
 end is_equivalence
 
+/--
+A functor `F : C ⥤ D` is essentially surjective if for every `d : D`, there is some `c : C`
+so `F.obj c ≅ D`.
+
+See https://stacks.math.columbia.edu/tag/001C.
+-/
+-- TODO should we make this a `Prop` that merely asserts the existence of a preimage,
+-- rather than choosing one?
 class ess_surj (F : C ⥤ D) :=
 (obj_preimage (d : D) : C)
 (iso' (d : D) : F.obj (obj_preimage d) ≅ d . obviously)
@@ -408,9 +418,19 @@ end functor
 
 namespace equivalence
 
+/--
+An equivalence is essentially surjective.
+
+See https://stacks.math.columbia.edu/tag/02C3.
+-/
 def ess_surj_of_equivalence (F : C ⥤ D) [is_equivalence F] : ess_surj F :=
 ⟨ λ Y : D, F.inv.obj Y, λ Y : D, (F.inv_fun_id.app Y) ⟩
 
+/--
+An equivalence is faithful.
+
+See https://stacks.math.columbia.edu/tag/02C3.
+-/
 @[priority 100] -- see Note [lower instance priority]
 instance faithful_of_equivalence (F : C ⥤ D) [is_equivalence F] : faithful F :=
 { map_injective' := λ X Y f g w,
@@ -419,6 +439,11 @@ instance faithful_of_equivalence (F : C ⥤ D) [is_equivalence F] : faithful F :
     simpa only [cancel_epi, cancel_mono, is_equivalence.inv_fun_map] using p
   end }.
 
+/--
+An equivalence is full.
+
+See https://stacks.math.columbia.edu/tag/02C3.
+-/
 @[priority 100] -- see Note [lower instance priority]
 instance full_of_equivalence (F : C ⥤ D) [is_equivalence F] : full F :=
 { preimage := λ X Y f, F.fun_inv_id.inv.app X ≫ F.inv.map f ≫ F.fun_inv_id.hom.app Y,
@@ -431,6 +456,11 @@ instance full_of_equivalence (F : C ⥤ D) [is_equivalence F] : full F :=
   map_id' := λ X, begin apply F.map_injective, tidy end,
   map_comp' := λ X Y Z f g, by apply F.map_injective; simp }
 
+/--
+A functor which is full, faithful, and essentially surjective is an equivalence.
+
+See https://stacks.math.columbia.edu/tag/02C3.
+-/
 def equivalence_of_fully_faithfully_ess_surj
   (F : C ⥤ D) [full F] [faithful F] [ess_surj F] : is_equivalence F :=
 is_equivalence.mk (equivalence_inverse F)

--- a/src/category_theory/filtered.lean
+++ b/src/category_theory/filtered.lean
@@ -62,6 +62,8 @@ A category `is_filtered` if
 2. for every pair of parallel morphisms there exists a morphism to the right so the compositions
    are equal, and
 3. there exists some object.
+
+See https://stacks.math.columbia.edu/tag/002V. (They also define a diagram being filtered.)
 -/
 class is_filtered extends is_filtered_or_empty C : Prop :=
 [nonempty : nonempty C]

--- a/src/category_theory/full_subcategory.lean
+++ b/src/category_theory/full_subcategory.lean
@@ -87,6 +87,11 @@ section full_subcategory
 variables {C : Type u₂} [category.{v} C]
 variables (Z : C → Prop)
 
+/--
+The category structure on a subtype; morphisms just ignore the property.
+
+See https://stacks.math.columbia.edu/tag/001D. We do not define 'strictly full' subcategories.
+-/
 instance full_subcategory : category.{v} {X : C // Z X} :=
 induced_category.category subtype.val
 

--- a/src/category_theory/fully_faithful.lean
+++ b/src/category_theory/fully_faithful.lean
@@ -16,6 +16,8 @@ variables {C : Type u₁} [category.{v₁} C] {D : Type u₂} [category.{v₂} D
 A functor `F : C ⥤ D` is full if for each `X Y : C`, `F.map` is surjective.
 In fact, we use a constructive definition, so the `full F` typeclass contains data,
 specifying a particular preimage of each `f : F.obj X ⟶ F.obj Y`.
+
+See https://stacks.math.columbia.edu/tag/001C.
 -/
 class full (F : C ⥤ D) :=
 (preimage : ∀ {X Y : C} (f : (F.obj X) ⟶ (F.obj Y)), X ⟶ Y)
@@ -24,7 +26,11 @@ class full (F : C ⥤ D) :=
 restate_axiom full.witness'
 attribute [simp] full.witness
 
-/-- A functor `F : C ⥤ D` is faithful if for each `X Y : C`, `F.map` is injective.-/
+/--
+A functor `F : C ⥤ D` is faithful if for each `X Y : C`, `F.map` is injective.
+
+See https://stacks.math.columbia.edu/tag/001C.
+-/
 class faithful (F : C ⥤ D) : Prop :=
 (map_injective' [] : ∀ {X Y : C}, function.injective (@functor.map _ _ _ _ F X Y) . obviously)
 

--- a/src/category_theory/functor.lean
+++ b/src/category_theory/functor.lean
@@ -25,6 +25,8 @@ To apply a functor `F` to an object use `F.obj X`, and to a morphism use `F.map 
 
 The axiom `map_id` expresses preservation of identities, and
 `map_comp` expresses functoriality.
+
+See https://stacks.math.columbia.edu/tag/001B.
 -/
 structure functor (C : Type u₁) [category.{v₁} C] (D : Type u₂) [category.{v₂} D] :
   Type (max v₁ v₂ u₁ u₂) :=

--- a/src/category_theory/isomorphism.lean
+++ b/src/category_theory/isomorphism.lean
@@ -34,11 +34,15 @@ universes v u -- declare the `v`'s first; see `category_theory.category` for an 
 namespace category_theory
 open category
 
-/-- An isomorphism (a.k.a. an invertible morphism) between two objects of a category.
+/--
+An isomorphism (a.k.a. an invertible morphism) between two objects of a category.
 The inverse morphism is bundled.
 
 See also `category_theory.core` for the category with the same objects and isomorphisms playing
-the role of morphisms. -/
+the role of morphisms.
+
+See https://stacks.math.columbia.edu/tag/0017.
+-/
 structure iso {C : Type u} [category.{v} C] (X Y : C) :=
 (hom : X ⟶ Y)
 (inv : Y ⟶ X)

--- a/src/category_theory/limits/fubini.lean
+++ b/src/category_theory/limits/fubini.lean
@@ -20,8 +20,8 @@ In the first part, given a coherent family `D` of limit cones over the functors 
 and a cone `c` over `G`, we construct a cone over the cone points of `D`.
 We then show that if `c` is a limit cone, the constructed cone is also a limit cone.
 
-In the second part, we state the Fubini theorem in the setting where we have chosen limits
-provided by suitable `has_limit` classes.
+In the second part, we state the Fubini theorem in the setting where limits exist
+promised by `has_limit` classes.
 
 We construct
 `limit_uncurry_iso_limit_comp_lim F : limit (uncurry.obj F) ≅ limit (F ⋙ lim)`
@@ -29,6 +29,10 @@ and give simp lemmas characterising it.
 For convenience, we also provide
 `limit_iso_limit_curry_comp_lim G : limit G ≅ limit ((curry.obj G) ⋙ lim)`
 in terms of the uncurried functor.
+
+## Future work
+
+The dual statement.
 -/
 
 universes v u

--- a/src/category_theory/limits/limits.lean
+++ b/src/category_theory/limits/limits.lean
@@ -7,20 +7,60 @@ import category_theory.adjunction.basic
 import category_theory.limits.cones
 import category_theory.reflects_isomorphisms
 
+/-!
+# Limits and colimits
+
+We set up the general theory of limits and colimits in a category.
+In this introduction we only describe the setup for limits;
+it is repeated, with slightly different names, for colimits.
+
+The three main structures involved are
+* `is_limit c`, for `c : cone F`, `F : J ⥤ C`, expressing that `c` is a limit cone,
+* `limit_cone F`, which consists of a choice of cone for `F` and the fact it is a limit cone, and
+* `has_limit F`, asserting the mere existence of some limit cone for `F`.
+
+Typically there are two different ways one can use the limits library:
+1. working with particular cones, and terms of type `is_limit`
+2. working solely with `has_limit`.
+
+While `has_limit` only asserts the existence of a limit cone,
+we happily use the axiom of choice in mathlib,
+so there are convenience functions all depending on `has_limit F`:
+* `limit F : C`, producing some limit object
+* `limit.π F j : limit F ⟶ F.obj j`, the morphisms out of the limit,
+* `limit.lift F c : c.X ⟶ limit F`, the universal morphism from any other `c : cone F`, etc.
+
+There are abbreviations `has_limits_of_shape J C` and `has_limits C`
+asserting the existence of classes of limits.
+Later more are introduced, for finite limits, special shapes of limits, etc.
+
+## Implementation
+At present we simply say everything twice, in order to handle both limits and colimits.
+It would be highly desirable to have some automation support,
+e.g. a `@[dualize]` attribute that behaves similarly to `@[to_additive]`.
+
+## References
+* [Stacks: Limits and colimits](https://stacks.math.columbia.edu/tag/002D)
+
+-/
+
 open category_theory category_theory.category category_theory.functor opposite
 
 namespace category_theory.limits
 
 universes v u u' u'' w -- declare the `v`'s first; see `category_theory.category` for an explanation
 
--- See the notes at the top of cones.lean, explaining why we can't allow `J : Prop` here.
 variables {J K : Type v} [small_category J] [small_category K]
 variables {C : Type u} [category.{v} C]
 
 variables {F : J ⥤ C}
 
-/-- A cone `t` on `F` is a limit cone if each cone on `F` admits a unique
-  cone morphism to `t`. -/
+/--
+A cone `t` on `F` is a limit cone if each cone on `F` admits a unique
+cone morphism to `t`.
+
+See https://stacks.math.columbia.edu/tag/002E.
+  -/
 @[nolint has_inhabited_instance]
 structure is_limit (t : cone F) :=
 (lift  : Π (s : cone F), s.X ⟶ t.X)
@@ -371,8 +411,12 @@ end
 
 end is_limit
 
-/-- A cocone `t` on `F` is a colimit cocone if each cocone on `F` admits a unique
-  cocone morphism from `t`. -/
+/--
+A cocone `t` on `F` is a colimit cocone if each cocone on `F` admits a unique
+cocone morphism from `t`.
+
+See https://stacks.math.columbia.edu/tag/002F.
+-/
 @[nolint has_inhabited_instance]
 structure is_colimit (t : cocone F) :=
 (desc  : Π (s : cocone F), t.X ⟶ s.X)

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -20,6 +20,10 @@ of (co)limits shaped as walking pairs.
 
 We include lemmas for simplifying equations involving projections and coprojections, and define
 braiding and associating isomorphisms, and the product comparison morphism.
+
+## References
+* [Stacks: Products of pairs](https://stacks.math.columbia.edu/tag/001R)
+* [Stacks: coproducts of pairs](https://stacks.math.columbia.edu/tag/04AN)
 -/
 
 universes v u u₂
@@ -465,10 +469,18 @@ end coprod_lemmas
 
 variables (C)
 
-/-- `has_binary_products` represents a choice of product for every pair of objects. -/
+/--
+`has_binary_products` represents a choice of product for every pair of objects.
+
+See https://stacks.math.columbia.edu/tag/001T.
+-/
 abbreviation has_binary_products := has_limits_of_shape (discrete walking_pair) C
 
-/-- `has_binary_coproducts` represents a choice of coproduct for every pair of objects. -/
+/--
+`has_binary_coproducts` represents a choice of coproduct for every pair of objects.
+
+See https://stacks.math.columbia.edu/tag/04AP.
+-/
 abbreviation has_binary_coproducts := has_colimits_of_shape (discrete walking_pair) C
 
 /-- If `C` has all limits of diagrams `pair X Y`, then it has all binary products -/

--- a/src/category_theory/limits/shapes/constructions/limits_of_products_and_equalizers.lean
+++ b/src/category_theory/limits/shapes/constructions/limits_of_products_and_equalizers.lean
@@ -111,14 +111,23 @@ end has_limit_of_has_products_of_has_equalizers
 
 open has_limit_of_has_products_of_has_equalizers
 
-/-- Any category with products and equalizers has all limits. -/
+/--
+Any category with products and equalizers has all limits.
+
+See https://stacks.math.columbia.edu/tag/002N.
+-/
 -- This is not an instance, as it is not always how one wants to construct limits!
 def limits_from_equalizers_and_products
   [has_products C] [has_equalizers C] : has_limits C :=
 { has_limits_of_shape := λ J 𝒥, by exactI
   { has_limit := λ F, has_limit.of_cones_iso (diagram F) F (cones_iso F) } }
 
-/-- Any category with finite products and equalizers has all finite limits. -/
+/--
+Any category with finite products and equalizers has all finite limits.
+
+See https://stacks.math.columbia.edu/tag/002O.
+(We do not prove equivalence with the third condition.)
+-/
 -- This is not an instance, as it is not always how one wants to construct finite limits!
 def finite_limits_from_equalizers_and_finite_products
   [has_finite_products C] [has_equalizers C] : has_finite_limits C :=

--- a/src/category_theory/limits/shapes/constructions/over/connected.lean
+++ b/src/category_theory/limits/shapes/constructions/over/connected.lean
@@ -7,6 +7,11 @@ import category_theory.over
 import category_theory.limits.connected
 import category_theory.limits.creates
 
+/-!
+# `forget : over B ⥤ C` creates connected limits.
+
+-/
+
 universes v u -- declare the `v`'s first; see `category_theory.category` for an explanation
 
 open category_theory category_theory.limits

--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -14,6 +14,10 @@ for the given data for a pullback (resp. pushout) diagram. Convenience methods `
 and `span f g` construct functors from the walking (co)span, hitting the given morphisms.
 
 We define `pullback f g` and `pushout f g` as limits and colimits of such functors.
+
+## References
+* [Stacks: Fibre products](https://stacks.math.columbia.edu/tag/001U)
+* [Stacks: Pushouts](https://stacks.math.columbia.edu/tag/0025)
 -/
 
 open category_theory
@@ -530,7 +534,11 @@ instance pushout.inr_of_epi {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [has_pushout
 
 variables (C)
 
-/-- `has_pullbacks` represents a choice of pullback for every pair of morphisms -/
+/--
+`has_pullbacks` represents a choice of pullback for every pair of morphisms
+
+See https://stacks.math.columbia.edu/tag/001W.
+-/
 abbreviation has_pullbacks := has_limits_of_shape walking_cospan C
 
 /-- `has_pushouts` represents a choice of pushout for every pair of morphisms -/

--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -8,6 +8,9 @@ import category_theory.limits.limits
 
 /-!
 # Initial and terminal objects in a category.
+
+## References
+* [Stacks: Initial and final objects](https://stacks.math.columbia.edu/tag/002B)
 -/
 
 universes v u

--- a/src/category_theory/limits/types.lean
+++ b/src/category_theory/limits/types.lean
@@ -30,6 +30,11 @@ def limit_cone_is_limit (F : J ⥤ Type u) : is_limit (limit_cone F) :=
 { lift := λ s v, ⟨λ j, s.π.app j v, λ j j' f, congr_fun (cone.w s f) _⟩,
   uniq' := by { intros, ext x j, exact congr_fun (w j) x } }
 
+/--
+The category of types has all limits.
+
+See https://stacks.math.columbia.edu/tag/002U.
+-/
 instance : has_limits (Type u) :=
 { has_limits_of_shape := λ J 𝒥, by exactI
   { has_limit := λ F,
@@ -108,6 +113,11 @@ def colimit_cocone_is_colimit (F : J ⥤ Type u) : is_colimit (colimit_cocone F)
 { desc := λ s, quot.lift (λ (p : Σ j, F.obj j), s.ι.app p.1 p.2)
     (assume ⟨j, x⟩ ⟨j', x'⟩ ⟨f, hf⟩, by rw hf; exact (congr_fun (cocone.w s f) x).symm) }
 
+/--
+The category of types has all colimits.
+
+See https://stacks.math.columbia.edu/tag/002U.
+-/
 instance : has_colimits (Type u) :=
 { has_colimits_of_shape := λ J 𝒥, by exactI
   { has_colimit := λ F,

--- a/src/category_theory/monoidal/braided.lean
+++ b/src/category_theory/monoidal/braided.lean
@@ -62,6 +62,8 @@ notation `β_` := braiding
 
 /--
 A symmetric monoidal category is a braided monoidal category for which the braiding is symmetric.
+
+See https://stacks.math.columbia.edu/tag/0FFW.
 -/
 class symmetric_category (C : Type u) [category.{v} C] [monoidal_category.{v} C]
    extends braided_category.{v} C :=

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -21,6 +21,8 @@ Tensor product does not need to be strictly associative on objects, but there is
 specified associator, `α_ X Y Z : (X ⊗ Y) ⊗ Z ≅ X ⊗ (Y ⊗ Z)`. There is a tensor unit `𝟙_ C`,
 with specified left and right unitor isomorphisms `λ_ X : 𝟙_ C ⊗ X ≅ X` and `ρ_ X : X ⊗ 𝟙_ C ≅ X`.
 These associators and unitors satisfy the pentagon and triangle equations.
+
+See https://stacks.math.columbia.edu/tag/0FFK.
 -/
 class monoidal_category (C : Type u) [𝒞 : category.{v} C] :=
 -- curried tensor product of objects:

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -61,7 +61,11 @@ attribute [simp] lax_monoidal_functor.associativity
 -- lax_monoidal_functor.μ_natural lax_monoidal_functor.left_unitality
 -- lax_monoidal_functor.right_unitality lax_monoidal_functor.associativity
 
-/-- A monoidal functor is a lax monoidal functor for which the tensorator and unitor as isomorphisms. -/
+/--
+A monoidal functor is a lax monoidal functor for which the tensorator and unitor as isomorphisms.
+
+See https://stacks.math.columbia.edu/tag/0FFL.
+-/
 structure monoidal_functor
 extends lax_monoidal_functor.{v₁ v₂} C D :=
 (ε_is_iso            : is_iso ε . obviously)

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -47,6 +47,11 @@ end has_hom
 
 variables [category.{v₁} C]
 
+/--
+The opposite category.
+
+See https://stacks.math.columbia.edu/tag/001M.
+-/
 instance category.opposite : category.{v₁} Cᵒᵖ :=
 { comp := λ _ _ _ f g, (g.unop ≫ f.unop).op,
   id   := λ X, (𝟙 (unop X)).op }

--- a/src/category_theory/over.lean
+++ b/src/category_theory/over.lean
@@ -26,8 +26,12 @@ namespace category_theory
 universes v₁ v₂ u₁ u₂ -- declare the `v`'s first; see `category_theory.category` for an explanation
 variables {T : Type u₁} [category.{v₁} T]
 
-/-- The over category has as objects arrows in `T` with codomain `X` and as morphisms commutative
-    triangles. -/
+/--
+The over category has as objects arrows in `T` with codomain `X` and as morphisms commutative
+triangles.
+
+See https://stacks.math.columbia.edu/tag/001G.
+-/
 @[derive category]
 def over (X : T) := comma.{v₁ 0 v₁} (𝟭 T) (functor.from_punit X)
 
@@ -92,13 +96,21 @@ lemma iso_mk_hom_left {f g : over X} (hl : f.left ≅ g.left) (hw : hl.hom ≫ g
 lemma iso_mk_inv_left {f g : over X} (hl : f.left ≅ g.left) (hw : hl.hom ≫ g.hom = f.hom) :
   (iso_mk hl hw).inv.left = hl.inv := rfl
 
-/-- The forgetful functor mapping an arrow to its domain. -/
+/--
+The forgetful functor mapping an arrow to its domain.
+
+See https://stacks.math.columbia.edu/tag/001G.
+-/
 def forget : over X ⥤ T := comma.fst _ _
 
 @[simp] lemma forget_obj {U : over X} : forget.obj U = U.left := rfl
 @[simp] lemma forget_map {U V : over X} {f : U ⟶ V} : forget.map f = f.left := rfl
 
-/-- A morphism `f : X ⟶ Y` induces a functor `over X ⥤ over Y` in the obvious way. -/
+/--
+A morphism `f : X ⟶ Y` induces a functor `over X ⥤ over Y` in the obvious way.
+
+See https://stacks.math.columbia.edu/tag/001G.
+-/
 def map {Y : T} (f : X ⟶ Y) : over X ⥤ over Y := comma.map_right _ $ discrete.nat_trans (λ _, f)
 
 section

--- a/src/category_theory/products/basic.lean
+++ b/src/category_theory/products/basic.lean
@@ -14,6 +14,8 @@ variables (C : Type u₁) [category.{v₁} C] (D : Type u₂) [category.{v₂} D
 
 /--
 `prod C D` gives the cartesian product of two categories.
+
+See https://stacks.math.columbia.edu/tag/001K.
 -/
 instance prod : category.{max v₁ v₂} (C × D) :=
 { hom     := λ X Y, ((X.1) ⟶ (Y.1)) × ((X.2) ⟶ (Y.2)),

--- a/src/category_theory/single_obj.lean
+++ b/src/category_theory/single_obj.lean
@@ -56,7 +56,11 @@ instance category [monoid α] : category (single_obj α) :=
   id_comp' := λ _ _, mul_one,
   assoc' := λ _ _ _ _ x y z, (mul_assoc z y x).symm }
 
-/-- Groupoid structure on `single_obj α` -/
+/--
+Groupoid structure on `single_obj α`.
+
+See https://stacks.math.columbia.edu/tag/0019.
+-/
 instance groupoid [group α] : groupoid (single_obj α) :=
 { inv := λ _ _ x, x⁻¹,
   inv_comp' := λ _ _, mul_right_inv,
@@ -75,7 +79,11 @@ lemma to_End_def [monoid α] (x : α) : to_End α x = x := rfl
 
 /-- There is a 1-1 correspondence between monoid homomorphisms `α → β` and functors between the
     corresponding single-object categories. It means that `single_obj` is a fully faithful
-    functor. -/
+    functor.
+
+See https://stacks.math.columbia.edu/tag/001F --
+although we do not characterize when the functor is full or faithful.
+-/
 def map_hom (α : Type u) (β : Type v) [monoid α] [monoid β] :
   (α →* β) ≃ (single_obj α) ⥤ (single_obj β) :=
 { to_fun := λ f,

--- a/src/category_theory/types.lean
+++ b/src/category_theory/types.lean
@@ -139,6 +139,11 @@ lemma hom_of_element_eq_iff {X : Type u} (x y : X) :
   hom_of_element x = hom_of_element y ↔ x = y :=
 ⟨λ H, congr_fun H punit.star, by cc⟩
 
+/--
+A morphism in `Type` is a monomorphism if and only if it is injective.
+
+See https://stacks.math.columbia.edu/tag/003C.
+-/
 lemma mono_iff_injective {X Y : Type u} (f : X ⟶ Y) : mono f ↔ function.injective f :=
 begin
   split,
@@ -152,6 +157,11 @@ begin
     exact H H₂ }
 end
 
+/--
+A morphism in `Type` is an epimorphism if and only if it is surjective.
+
+See https://stacks.math.columbia.edu/tag/003C.
+-/
 lemma epi_iff_surjective {X Y : Type u} (f : X ⟶ Y) : epi f ↔ function.surjective f :=
 begin
   split,

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -12,6 +12,9 @@ The Yoneda embedding as a functor `yoneda : C ⥤ (Cᵒᵖ ⥤ Type v₁)`,
 along with an instance that it is `fully_faithful`.
 
 Also the Yoneda lemma, `yoneda_lemma : (yoneda_pairing C) ≅ (yoneda_evaluation C)`.
+
+## References
+* [Stacks: Opposite Categories and the Yoneda Lemma](https://stacks.math.columbia.edu/tag/001L)
 -/
 
 namespace category_theory
@@ -21,7 +24,13 @@ universes v₁ u₁ u₂ -- declare the `v`'s first; see `category_theory.catego
 
 variables {C : Type u₁} [category.{v₁} C]
 
-@[simps] def yoneda : C ⥤ (Cᵒᵖ ⥤ Type v₁) :=
+/--
+The Yoneda embedding, as a functor from `C` into presheaves on `C`.
+
+See https://stacks.math.columbia.edu/tag/001O.
+-/
+@[simps]
+def yoneda : C ⥤ (Cᵒᵖ ⥤ Type v₁) :=
 { obj := λ X,
   { obj := λ Y, unop Y ⟶ X,
     map := λ Y Y' f g, f.unop ≫ g,
@@ -29,6 +38,9 @@ variables {C : Type u₁} [category.{v₁} C]
     map_id' := λ Y, begin ext, dsimp, erw [category.id_comp] end },
   map := λ X X' f, { app := λ Y g, g ≫ f } }
 
+/--
+The co-Yoneda embedding, as a functor from `Cᵒᵖ` into co-presheaves on `C`.
+-/
 @[simps] def coyoneda : Cᵒᵖ ⥤ (C ⥤ Type v₁) :=
 { obj := λ X,
   { obj := λ Y, unop X ⟶ Y,
@@ -49,8 +61,19 @@ by obviously
   {Z Z' : C} (f : Z ⟶ Z') (h : Z' ⟶ X) : f ≫ α.app (op Z') h = α.app (op Z) (f ≫ h) :=
 (functor_to_types.naturality _ _ α f.op h).symm
 
+/--
+The Yoneda embedding is full.
+
+See https://stacks.math.columbia.edu/tag/001P.
+-/
 instance yoneda_full : full (@yoneda C _) :=
 { preimage := λ X Y f, (f.app (op X)) (𝟙 X) }
+
+/--
+The Yoneda embedding is faithful.
+
+See https://stacks.math.columbia.edu/tag/001P.
+-/
 instance yoneda_faithful : faithful (@yoneda C _) :=
 { map_injective' := λ X Y f g p,
   begin
@@ -86,6 +109,7 @@ begin erw [functor_to_types.naturality], refl end
 
 instance coyoneda_full : full (@coyoneda C _) :=
 { preimage := λ X Y f, ((f.app (unop X)) (𝟙 _)).op }
+
 instance coyoneda_faithful : faithful (@coyoneda C _) :=
 { map_injective' := λ X Y f g p,
   begin
@@ -99,6 +123,12 @@ is_iso_of_fully_faithful coyoneda f
 
 end coyoneda
 
+/--
+A presheaf `F` is representable if there is object `X` so `F ≅ yoneda.obj X`.
+
+See https://stacks.math.columbia.edu/tag/001Q.
+-/
+-- TODO should we make this a Prop, merely asserting existence of such an object?
 class representable (F : Cᵒᵖ ⥤ Type v₁) :=
 (X : C)
 (w : yoneda.obj X ≅ F)
@@ -138,6 +168,13 @@ functor.prod yoneda.op (𝟭 (Cᵒᵖ ⥤ Type v₁)) ⋙ functor.hom (Cᵒᵖ �
   (P Q : Cᵒᵖ × (Cᵒᵖ ⥤ Type v₁)) (α : P ⟶ Q) (β : (yoneda_pairing C).obj P) :
   (yoneda_pairing C).map α β = yoneda.map α.1.unop ≫ β ≫ α.2 := rfl
 
+/--
+The Yoneda lemma asserts that that the Yoneda pairing
+`(X : Cᵒᵖ, F : Cᵒᵖ ⥤ Type) ↦ (yoneda.obj (unop X) ⟶ F)`
+is naturally isomorphic to the evaluation `(X, F) ↦ F.obj X`.
+
+See https://stacks.math.columbia.edu/tag/001P.
+-/
 def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
 { hom :=
   { app := λ F x, ulift.up ((x.app F.1) (𝟙 (unop F.1))),

--- a/src/topology/sheaves/forget.lean
+++ b/src/topology/sheaves/forget.lean
@@ -118,6 +118,9 @@ that preserves limits and reflects isomorphisms.
 Then to check the sheaf condition it suffices to check it on the underlying sheaf of types.
 
 Another useful example is the forgetful functor `TopCommRing ⥤ Top`.
+
+See https://stacks.math.columbia.edu/tag/0073.
+In fact we prove a stronger version with arbitrary complete target category.
 -/
 def sheaf_condition_equiv_sheaf_condition_comp :
   sheaf_condition F ≃ sheaf_condition (F ⋙ G) :=


### PR DESCRIPTION
We'd been discussing adding a `@[stacks "007B"]` tag to add cross-references to the stacks project (and possibly include links back again -- they say they're keen).

I'm not certain that we actually have the documentation maintenance enthusiasm to make this viable, so this PR is a more lightweight solution: adding lots of links to the stacks project from doc-strings. I'd be very happy to switch back to the attribute approach later.

This is pretty close to exhaustive for the "category theory preliminaries" chapter of the stacks project, but doesn't attempt to go beyond that. I've only included links where we formalise all, or almost all (in which case I've usually left a note), of the corresponding tag.

---
<!-- put comments you want to keep out of the PR commit here -->
