### PR TITLE
[Merged by Bors] - feat(logic/basic): Add forall_apply_eq_imp_iff

### DIFF
--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -612,11 +612,7 @@ rel.core_inter _ s t
 
 lemma mem_core_res (f : α → β) (s : set α) (t : set β) (x : α) :
   x ∈ core (res f s) t ↔ (x ∈ s → f x ∈ t) :=
-begin
-  simp [mem_core, mem_res], split,
-  { intros h h', apply h _ h', reflexivity },
-  intros h y xs fxeq, rw ←fxeq, exact h xs
-end
+by simp [mem_core, mem_res]
 
 section
 open_locale classical

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1441,7 +1441,7 @@ def range (f : ι → α) : set α := {x | ∃y, f y = x}
 @[simp] theorem mem_range_self (i : ι) : f i ∈ range f := ⟨i, rfl⟩
 
 theorem forall_range_iff {p : α → Prop} : (∀ a ∈ range f, p a) ↔ (∀ i, p (f i)) :=
-⟨assume h i, h (f i) (mem_range_self _), assume h a ⟨i, (hi : f i = a)⟩, hi ▸ h i⟩
+by simp
 
 theorem exists_range_iff {p : α → Prop} : (∃ a ∈ range f, p a) ↔ (∃ i, p (f i)) :=
 by simp

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -732,6 +732,9 @@ by simp [and_comm]
 @[simp] theorem forall_eq {a' : α} : (∀a, a = a' → p a) ↔ p a' :=
 ⟨λ h, h a' rfl, λ h a e, e.symm ▸ h⟩
 
+@[simp] theorem forall_eq' {a' : α} : (∀a, a' = a → p a) ↔ p a' :=
+by simp [@eq_comm _ a']
+
 @[simp] theorem exists_eq {a' : α} : ∃ a, a = a' := ⟨_, rfl⟩
 
 @[simp] theorem exists_eq' {a' : α} : ∃ a, a' = a := ⟨_, rfl⟩
@@ -755,9 +758,6 @@ by simp [and_comm]
 @[simp] theorem exists_exists_eq_and {f : α → β} {p : β → Prop} :
   (∃ b, (∃ a, f a = b) ∧ p b) ↔ ∃ a, p (f a) :=
 ⟨λ ⟨b, ⟨a, ha⟩, hb⟩, ⟨a, ha.symm ▸ hb⟩, λ ⟨a, ha⟩, ⟨f a, ⟨a, rfl⟩, ha⟩⟩
-
-@[simp] theorem forall_eq' {a' : α} : (∀a, a' = a → p a) ↔ p a' :=
-by simp [@eq_comm _ a']
 
 @[simp] theorem exists_eq_left' {a' : α} : (∃ a, a' = a ∧ p a) ↔ p a' :=
 by simp [@eq_comm _ a']

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -759,6 +759,14 @@ by simp [@eq_comm _ a']
   (∃ b, (∃ a, f a = b) ∧ p b) ↔ ∃ a, p (f a) :=
 ⟨λ ⟨b, ⟨a, ha⟩, hb⟩, ⟨a, ha.symm ▸ hb⟩, λ ⟨a, ha⟩, ⟨f a, ⟨a, rfl⟩, ha⟩⟩
 
+@[simp] theorem forall_apply_eq_imp_iff {f : α → β} {p : β → Prop} :
+  (∀ a, ∀ b, f a = b → p b) ↔ (∀ a, p (f a)) :=
+⟨λ h a, h a (f a) rfl, λ h a b hab, hab ▸ h a⟩
+
+@[simp] theorem forall_apply_eq_imp_iff' {f : α → β} {p : β → Prop} :
+  (∀ b, ∀ a, f a = b → p b) ↔ (∀ a, p (f a)) :=
+by { rw forall_swap, simp }
+
 @[simp] theorem exists_eq_left' {a' : α} : (∃ a, a' = a ∧ p a) ↔ p a' :=
 by simp [@eq_comm _ a']
 

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -113,7 +113,8 @@ begin
       rw this, resetI,
       apply is_measurable.Union,
       exact λ _, (H _).compl _ } },
-  { simp, rintro _ a rfl,
+  { rw forall_range_iff,
+    intro a,
     exact generate_measurable.basic _ is_open_Iio }
 end
 


### PR DESCRIPTION
Also adds forall_apply_eq_imp_iff' for swapped forall arguments

This means that `forall_range_iff` can now be solved by `simp`.

This requires changes in data/pfun and measure_theory/borel_space, where non-terminal `simp`s broke.

---
<!-- put comments you want to keep out of the PR commit here -->
Discussed at https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Should.20.60set.2Eforall_range_iff.60.20be.20taged.20.60simp.60.3F