### PR TITLE
[Merged by Bors] - feat(ring_theory/algebra_tower): coefficients for a basis in an algebra tower

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -881,6 +881,13 @@ lemma linear_eq_on (s : set M) {f g : M →ₗ[R] M₂} (H : ∀x∈s, f x = g x
   f x = g x :=
 by apply span_induction h H; simp {contextual := tt}
 
+lemma linear_map.ext_on {v : ι → M} {f g : M →ₗ[R] M₂} (hv : span R (range v) = ⊤)
+  (h : ∀i, f (v i) = g (v i)) : f = g :=
+begin
+  apply linear_map.ext (λ x, linear_eq_on (range v) _ (eq_top_iff'.1 hv _)),
+  exact (λ y hy, exists.elim (set.mem_range.1 hy) (λ i hi, by rw ←hi; exact h i))
+end
+
 lemma supr_eq_span {ι : Sort w} (p : ι → submodule R M) :
   (⨆ (i : ι), p i) = submodule.span R (⋃ (i : ι), ↑(p i)) :=
 le_antisymm

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -801,7 +801,8 @@ end
 lemma is_basis.repr_apply_eq {f : M → ι → R}
   (hfin : ∀ x, ∃ (s : finset ι), ∀ i, f x i ≠ 0 → i ∈ s)
   (hadd : ∀ x y, f (x + y) = f x + f y) (hsmul : ∀ (c : R) (x : M), f (c • x) = c • f x)
-  (f_eq : ∀ i, f (v i) = finsupp.single i 1) (x : M) (i : ι) : hv.repr x i = f x i :=
+  (f_eq : ∀ i, f (v i) = finsupp.single i 1) (x : M) (i : ι) :
+  hv.repr x i = f x i :=
 begin
   set f' : M →ₗ[R] (ι →₀ R) :=
   { to_fun := λ x, finsupp.on_finset _ _ (classical.some_spec (hfin x)),

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -796,23 +796,24 @@ begin
 end
 
 lemma is_basis.repr_apply_eq {f : M → ι → R}
-  (hfin : ∀ x, ∃ (s : finset ι), ∀ i, f x i ≠ 0 → i ∈ s)
   (hadd : ∀ x y, f (x + y) = f x + f y) (hsmul : ∀ (c : R) (x : M), f (c • x) = c • f x)
   (f_eq : ∀ i, f (v i) = finsupp.single i 1) (x : M) (i : ι) :
   hv.repr x i = f x i :=
 begin
-  set f' : M →ₗ[R] (ι →₀ R) :=
-  { to_fun := λ x, finsupp.on_finset _ _ (classical.some_spec (hfin x)),
-    map_add' := λ x y, by { ext,
-      simp only [hadd, finsupp.on_finset_apply, pi.add_apply, finsupp.add_apply] },
-    map_smul' := λ c x, by { ext,
-      simp only [hsmul, finsupp.on_finset_apply, pi.smul_apply, finsupp.smul_apply] } }
+  set f' : M →ₗ[R] (ι → R) :=
+    { to_fun := f, map_add' := hadd, map_smul' := hsmul }
     with f'_eq,
   have hf' : ∀ i, f' (v i) = finsupp.single i 1,
   { intro i,
     ext j,
-    rw [f'_eq, linear_map.coe_mk, finsupp.on_finset_apply, f_eq] },
-  rw [hv.repr_eq_iff.mpr hf', f'_eq, linear_map.coe_mk, finsupp.on_finset_apply]
+    rw [f'_eq, linear_map.coe_mk, f_eq] },
+  show hv.repr x i = f' x i,
+  conv_rhs { rw ← hv.total_repr x },
+  simp_rw [finsupp.total_apply, finsupp_sum, finsupp.sum, finset.sum_apply, f'.map_smul, hf',
+           pi.smul_apply, finsupp.single_apply, smul_eq_mul, mul_boole, finset.sum_ite_eq',
+           finsupp.mem_support_iff],
+  split_ifs, { refl },
+  push_neg at h, exact h
 end
 
 /-- Construct a linear map given the value at the basis. -/

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -759,10 +759,7 @@ lemma is_basis.total_comp_repr : (finsupp.total ι M R v).comp hv.repr = linear_
 linear_map.ext hv.total_repr
 
 lemma is_basis.ext {f g : M →ₗ[R] M'} (hv : is_basis R v) (h : ∀i, f (v i) = g (v i)) : f = g :=
-begin
-  apply linear_map.ext (λ x, linear_eq_on (range v) _ (hv.mem_span x)),
-  exact (λ y hy, exists.elim (set.mem_range.1 hy) (λ i hi, by rw ←hi; exact h i))
-end
+linear_map.ext_on hv.2 h
 
 lemma is_basis.repr_ker : hv.repr.ker = ⊥ :=
 linear_map.ker_eq_bot.2 $ left_inverse.injective hv.total_repr

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -800,20 +800,15 @@ lemma is_basis.repr_apply_eq {f : M → ι → R}
   (f_eq : ∀ i, f (v i) = finsupp.single i 1) (x : M) (i : ι) :
   hv.repr x i = f x i :=
 begin
-  set f' : M →ₗ[R] (ι → R) :=
-    { to_fun := f, map_add' := hadd, map_smul' := hsmul }
-    with f'_eq,
-  have hf' : ∀ i, f' (v i) = finsupp.single i 1,
-  { intro i,
-    ext j,
-    rw [f'_eq, linear_map.coe_mk, f_eq] },
-  show hv.repr x i = f' x i,
-  conv_rhs { rw ← hv.total_repr x },
-  simp_rw [finsupp.total_apply, finsupp_sum, finsupp.sum, finset.sum_apply, f'.map_smul, hf',
-           pi.smul_apply, finsupp.single_apply, smul_eq_mul, mul_boole, finset.sum_ite_eq',
-           finsupp.mem_support_iff],
-  split_ifs, { refl },
-  push_neg at h, exact h
+  let f_i : M →ₗ[R] R :=
+  { to_fun := λ x, f x i,
+    map_add' := λ _ _, by rw [hadd, pi.add_apply],
+    map_smul' := λ _ _, by rw [hsmul, pi.smul_apply] },
+  show (finsupp.leval i).comp hv.repr x = f_i x,
+  congr' 1,
+  refine hv.ext (λ j, _),
+  show hv.repr (v j) i = f (v j) i,
+  rw [hv.repr_eq_single, f_eq]
 end
 
 /-- Construct a linear map given the value at the basis. -/

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -306,9 +306,9 @@ variables {R S A}
 variables [comm_ring R] [ring S] [add_comm_group A]
 variables [algebra R S] [module S A] [module R A] [is_scalar_tower R S A]
 
-theorem linear_independent_smul {ι : Type v₁} {b : ι → S} {κ : Type w₁} {c : κ → A}
+theorem linear_independent_smul {ι : Type v₁} {b : ι → S} {ι' : Type w₁} {c : ι' → A}
   (hb : linear_independent R b) (hc : linear_independent S c) :
-  linear_independent R (λ p : ι × κ, b p.1 • c p.2) :=
+  linear_independent R (λ p : ι × ι', b p.1 • c p.2) :=
 begin
   rw linear_independent_iff' at hb hc, rw linear_independent_iff'', rintros s g hg hsg ⟨i, k⟩,
   by_cases hik : (i, k) ∈ s,
@@ -321,15 +321,15 @@ begin
   exact hg _ hik
 end
 
-theorem is_basis.smul {ι : Type v₁} {b : ι → S} {κ : Type w₁} {c : κ → A}
-  (hb : is_basis R b) (hc : is_basis S c) : is_basis R (λ p : ι × κ, b p.1 • c p.2) :=
+theorem is_basis.smul {ι : Type v₁} {b : ι → S} {ι' : Type w₁} {c : ι' → A}
+  (hb : is_basis R b) (hc : is_basis S c) : is_basis R (λ p : ι × ι', b p.1 • c p.2) :=
 ⟨linear_independent_smul hb.1 hc.1,
 by rw [← set.range_smul_range, submodule.span_smul hb.2, ← submodule.restrict_scalars'_top R S A,
     submodule.restrict_scalars'_inj, hc.2]⟩
 
 theorem is_basis.smul_repr
-  {ι κ : Type*} {b : ι → S} {c : κ → A}
-  (hb : is_basis R b) (hc : is_basis S c) (x : A) (ij : ι × κ) :
+  {ι ι' : Type*} {b : ι → S} {c : ι' → A}
+  (hb : is_basis R b) (hc : is_basis S c) (x : A) (ij : ι × ι') :
   (hb.smul hc).repr x ij = hb.repr (hc.repr x ij.2) ij.1 :=
 begin
   apply (hb.smul hc).repr_apply_eq,
@@ -349,8 +349,8 @@ begin
 end
 
 theorem is_basis.smul_repr_mk
-  {ι κ : Type*} {b : ι → S} {c : κ → A}
-  (hb : is_basis R b) (hc : is_basis S c) (x : A) (i : ι) (j : κ) :
+  {ι ι' : Type*} {b : ι → S} {c : ι' → A}
+  (hb : is_basis R b) (hc : is_basis S c) (x : A) (i : ι) (j : ι') :
   (hb.smul hc).repr x (i, j) = hb.repr (hc.repr x j) i :=
 by simp [is_basis.smul_repr]
 

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -356,4 +356,10 @@ begin
   simp
 end
 
+theorem is_basis.smul_repr_mk
+  {ι κ : Type*} {b : ι → S} {c : κ → A}
+  (hb : is_basis R b) (hc : is_basis S c) (x : A) (i : ι) (j : κ) :
+  (hb.smul hc).repr x (i, j) = hb.repr (hc.repr x j) i :=
+by simp [is_basis.smul_repr]
+
 end ring

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -333,14 +333,6 @@ theorem is_basis.smul_repr
   (hb.smul hc).repr x ij = hb.repr (hc.repr x ij.2) ij.1 :=
 begin
   apply (hb.smul hc).repr_apply_eq,
-  { intro x,
-    use (hc.repr x).support.bind
-      (λ j, (hb.repr (hc.repr x j)).support.map (function.embedding.sectl ι j)),
-    rintros ⟨i, j⟩ hij,
-    rw finset.mem_bind,
-    use [j, mem_support_iff.mpr (λ h, hij (by rw [h, linear_map.map_zero, zero_apply]))],
-    rw finset.mem_map,
-    exact ⟨i, mem_support_iff.mpr hij, rfl⟩ },
   { intros x y, ext, simp only [linear_map.map_add, add_apply, pi.add_apply] },
   { intros c x, ext,
     simp only [← is_scalar_tower.algebra_map_smul S c x, linear_map.map_smul, smul_eq_mul,

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -298,6 +298,7 @@ end semiring
 
 section ring
 
+open finsupp
 open_locale big_operators classical
 universes v₁ w₁
 
@@ -325,5 +326,34 @@ theorem is_basis.smul {ι : Type v₁} {b : ι → S} {κ : Type w₁} {c : κ �
 ⟨linear_independent_smul hb.1 hc.1,
 by rw [← set.range_smul_range, submodule.span_smul hb.2, ← submodule.restrict_scalars'_top R S A,
     submodule.restrict_scalars'_inj, hc.2]⟩
+
+theorem is_basis.smul_repr
+  {ι κ : Type*} {b : ι → S} {c : κ → A}
+  (hb : is_basis R b) (hc : is_basis S c) (x : A) (ij : ι × κ) :
+  (hb.smul hc).repr x ij = hb.repr (hc.repr x ij.2) ij.1 :=
+begin
+  apply (hb.smul hc).repr_apply_eq,
+  { intro x,
+    use (hc.repr x).support.bind
+      (λ j, (hb.repr (hc.repr x j)).support.map (function.embedding.sectl ι j)),
+    rintros ⟨i, j⟩ hij,
+    rw finset.mem_bind,
+    use [j, mem_support_iff.mpr (λ h, hij (by rw [h, linear_map.map_zero, zero_apply]))],
+    rw finset.mem_map,
+    exact ⟨i, mem_support_iff.mpr hij, rfl⟩ },
+  { intros x y, ext, simp only [linear_map.map_add, add_apply, pi.add_apply] },
+  { intros c x, ext,
+    simp only [← is_scalar_tower.algebra_map_smul S c x, linear_map.map_smul, smul_eq_mul,
+               ← algebra.smul_def, smul_apply, pi.smul_apply] },
+  rintros ij,
+  ext ij',
+  rw single_apply,
+  split_ifs with hij,
+  { simp [hij] },
+  rw [linear_map.map_smul, smul_apply, hc.repr_self_apply],
+  split_ifs with hj,
+  { simp [hj, show ¬ (ij.1 = ij'.1), from λ hi, hij (prod.ext hi hj)] },
+  simp
+end
 
 end ring


### PR DESCRIPTION
This PR gives an expression for `(is_basis.smul hb hc).repr` in terms of `hb.repr` and `hc.repr`, useful if you have a field extension `L / K`, and `x y : L`, and want to write `y` in terms of the power basis of `K(x)`.

---
<!-- put comments you want to keep out of the PR commit here -->
