### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space,geometry/euclidean): simplex centers and order of points

### DIFF
--- a/src/geometry/euclidean/circumcenter.lean
+++ b/src/geometry/euclidean/circumcenter.lean
@@ -418,6 +418,21 @@ begin
   rw [←range_face_points, orthogonal_projection_eq_circumcenter_of_exists_dist_eq _ hr]
 end
 
+/-- Two simplices with the same points have the same circumcenter. -/
+lemma circumcenter_eq_of_range_eq {n : ℕ} {s₁ s₂ : simplex ℝ P n}
+  (h : set.range s₁.points = set.range s₂.points) : s₁.circumcenter = s₂.circumcenter :=
+begin
+  have hs : s₁.circumcenter ∈ affine_span ℝ (set.range s₂.points) :=
+    h ▸ s₁.circumcenter_mem_affine_span,
+  have hr : ∀ i, dist (s₂.points i) s₁.circumcenter = s₁.circumradius,
+  { intro i,
+    have hi : s₂.points i ∈ set.range s₂.points := set.mem_range_self _,
+    rw [←h, set.mem_range] at hi,
+    rcases hi with ⟨j, hj⟩,
+    rw [←hj, s₁.dist_circumcenter_eq_circumradius j] },
+  exact s₂.eq_circumcenter_of_dist_eq hs hr
+end
+
 omit V
 
 /-- An index type for the vertices of a simplex plus its circumcenter.

--- a/src/geometry/euclidean/monge_point.lean
+++ b/src/geometry/euclidean/monge_point.lean
@@ -88,6 +88,12 @@ smul_vsub_vadd_mem _ _
   s.circumcenter_mem_affine_span
   s.circumcenter_mem_affine_span
 
+/-- Two simplices with the same points have the same Monge point. -/
+lemma monge_point_eq_of_range_eq {n : ℕ} {s₁ s₂ : simplex ℝ P n}
+  (h : set.range s₁.points = set.range s₂.points) : s₁.monge_point = s₂.monge_point :=
+by simp_rw [monge_point_eq_smul_vsub_vadd_circumcenter, centroid_eq_of_range_eq h,
+            circumcenter_eq_of_range_eq h]
+
 omit V
 
 /-- The weights for the Monge point of an (n+2)-simplex, in terms of
@@ -372,6 +378,11 @@ end
 lemma orthocenter_mem_affine_span (t : triangle ℝ P) :
   t.orthocenter ∈ affine_span ℝ (set.range t.points) :=
 t.monge_point_mem_affine_span
+
+/-- Two triangles with the same points have the same orthocenter. -/
+lemma orthocenter_eq_of_range_eq {t₁ t₂ : triangle ℝ P}
+  (h : set.range t₁.points = set.range t₂.points) : t₁.orthocenter = t₂.orthocenter :=
+monge_point_eq_of_range_eq h
 
 /-- In the case of a triangle, altitudes are the same thing as Monge
 planes. -/

--- a/src/linear_algebra/affine_space/combination.lean
+++ b/src/linear_algebra/affine_space/combination.lean
@@ -473,6 +473,49 @@ lemma centroid_eq_affine_combination_fintype [fintype ι] (p : ι → P) :
   s.centroid k p = univ.affine_combination p (s.centroid_weights_indicator k) :=
 affine_combination_indicator_subset _ _ (subset_univ _)
 
+/-- An indexed family of points that is injective on the given
+`finset` has the same centroid as the image of that `finset`.  This is
+stated in terms of a set equal to the image to provide control of
+definitional equality for the index type used for the centroid of the
+image. -/
+lemma centroid_eq_centroid_image_of_inj_on {p : ι → P} (hi : ∀ i j ∈ s, p i = p j → i = j)
+  {ps : set P} [fintype ps] (hps : ps = p '' ↑s) :
+  s.centroid k p = (univ : finset ps).centroid k (λ x, x) :=
+begin
+  let f : p '' ↑s → ι := λ x, x.property.some,
+  have hf : ∀ x, f x ∈ s ∧ p (f x) = x := λ x, x.property.some_spec,
+  let f' : ps → ι := λ x, f ⟨x, hps ▸ x.property⟩,
+  have hf' : ∀ x, f' x ∈ s ∧ p (f' x) = x := λ x, hf ⟨x, hps ▸ x.property⟩,
+  have hf'i : function.injective f',
+  { intros x y h,
+    rw [subtype.ext_iff, ←(hf' x).2, ←(hf' y).2, h] },
+  let f'e : ps ↪ ι := ⟨f', hf'i⟩,
+  have hu : finset.univ.map f'e = s,
+  { ext x,
+    rw mem_map,
+    split,
+    { rintros ⟨i, _, rfl⟩,
+      exact (hf' i).1 },
+    { intro hx,
+      use [⟨p x, hps.symm ▸ set.mem_image_of_mem _ hx⟩, mem_univ _],
+      refine hi _ _ (hf' _).1 hx _,
+      rw (hf' _).2,
+      refl } },
+  rw [←hu, centroid_map],
+  congr' with x,
+  change p (f' x) = ↑x,
+  rw (hf' x).2
+end
+
+/-- Two indexed families of points that are injective on the given
+`finset`s and with the same points in the image of those `finset`s
+have the same centroid. -/
+lemma centroid_eq_of_inj_on_of_image_eq {p : ι → P} (hi : ∀ i j ∈ s, p i = p j → i = j)
+  {p₂ : ι₂ → P} (hi₂ : ∀ i j ∈ s₂, p₂ i = p₂ j → i = j) (he : p '' ↑s = p₂ '' ↑s₂) :
+  s.centroid k p = s₂.centroid k p₂ :=
+by rw [s.centroid_eq_centroid_image_of_inj_on k hi rfl,
+       s₂.centroid_eq_centroid_image_of_inj_on k hi₂ he]
+
 end finset
 
 section affine_space'

--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -548,5 +548,16 @@ begin
   exact s.centroid_eq_iff h₁ h₂
 end
 
+/-- Two simplices with the same points have the same centroid. -/
+lemma centroid_eq_of_range_eq {n : ℕ} {s₁ s₂ : simplex k P n}
+  (h : set.range s₁.points = set.range s₂.points) :
+  finset.univ.centroid k s₁.points = finset.univ.centroid k s₂.points :=
+begin
+  rw [←set.image_univ, ←set.image_univ, ←finset.coe_univ] at h,
+  exact finset.univ.centroid_eq_of_inj_on_of_image_eq k _
+    (λ _ _ _ _ he, injective_of_affine_independent s₁.independent he)
+    (λ _ _ _ _ he, injective_of_affine_independent s₂.independent he) h
+end
+
 end simplex
 end affine


### PR DESCRIPTION
Add lemmas that the centroid of an injective indexed family of points
does not depend on the indices of those points, only on the set of
points in their image, and likewise that the centroid, circumcenter
and Monge point of a simplex and thus the orthocenter of a triangle do
not depend on the order in which the vertices are indexed by `fin (n + 1)`,
only on the set of vertices.


---
<!-- put comments you want to keep out of the PR commit here -->
