### PR TITLE
[Merged by Bors] - feat(logic/basic): Add more simp lemmas for forall

### DIFF
--- a/src/computability/partrec_code.lean
+++ b/src/computability/partrec_code.lean
@@ -580,7 +580,7 @@ theorem evaln_bound : ∀ {k c n x}, x ∈ evaln k c n → n < k
 | (k+1) c n x h := begin
   suffices : ∀ {o : option ℕ}, x ∈ guard (n ≤ k) >> o → n < k + 1,
   { cases c; rw [evaln] at h; exact this h },
-  simp [(>>)], exact λ _ h _, nat.lt_succ_of_le h
+  simpa [(>>)] using nat.lt_succ_of_le
 end
 
 theorem evaln_mono : ∀ {k₁ k₂ c n x}, k₁ ≤ k₂ → x ∈ evaln k₁ c n → x ∈ evaln k₂ c n

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -767,6 +767,14 @@ by simp [@eq_comm _ a']
   (∀ b, ∀ a, f a = b → p b) ↔ (∀ a, p (f a)) :=
 by { rw forall_swap, simp }
 
+@[simp] theorem forall_eq_apply_imp_iff {f : α → β} {p : β → Prop} :
+  (∀ a, ∀ b, b = f a → p b) ↔ (∀ a, p (f a)) :=
+by simp [@eq_comm _ _ (f _)]
+
+@[simp] theorem forall_eq_apply_imp_iff' {f : α → β} {p : β → Prop} :
+  (∀ b, ∀ a, b = f a → p b) ↔ (∀ a, p (f a)) :=
+by { rw forall_swap, simp }
+
 @[simp] theorem exists_eq_left' {a' : α} : (∃ a, a' = a ∧ p a) ↔ p a' :=
 by simp [@eq_comm _ a']
 


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
This follows on from #4109

---

Removed the one causing a deterministic timeout,
```lean
/-- An implication whose LHS is independent of the forall can be brought outside -/
@[simp] theorem forall_imp_indep {p : Prop} {q : α → Prop} :
  (∀ a, p → q a) ↔ (p → ∀ a, q a) := forall_swap
```

Perhaps it can be added back in a future PR once I work out why it fails.