### PR TITLE
[Merged by Bors] - fix(algebra/ring/basic): delete mul_self_sub_mul_self_eq

### DIFF
--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -582,11 +582,8 @@ protected def function.surjective.comm_ring [has_zero β] [has_one β] [has_add 
 
 local attribute [simp] add_assoc add_comm add_left_comm mul_comm
 
-lemma mul_self_sub_mul_self_eq (a b : α) : a * a - b * b = (a + b) * (a - b) :=
-by simp [right_distrib, left_distrib, sub_eq_add_neg]
-
 lemma mul_self_sub_one_eq (a : α) : a * a - 1 = (a + 1) * (a - 1) :=
-by rw [← mul_self_sub_mul_self_eq, mul_one]
+by rw [← mul_self_sub_mul_self, mul_one]
 
 theorem dvd_neg_of_dvd (h : a ∣ b) : (a ∣ -b) :=
 dvd.elim h

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -582,9 +582,6 @@ protected def function.surjective.comm_ring [has_zero β] [has_one β] [has_add 
 
 local attribute [simp] add_assoc add_comm add_left_comm mul_comm
 
-lemma mul_self_sub_one_eq (a : α) : a * a - 1 = (a + 1) * (a - 1) :=
-by rw [← mul_self_sub_mul_self, mul_one]
-
 theorem dvd_neg_of_dvd (h : a ∣ b) : (a ∣ -b) :=
 dvd.elim h
   (assume c, assume : b = a * c,
@@ -621,6 +618,9 @@ theorem two_dvd_bit1 : 2 ∣ bit1 a ↔ (2 : α) ∣ 1 := (dvd_add_iff_right (@t
 /-- Representation of a difference of two squares in a commutative ring as a product. -/
 theorem mul_self_sub_mul_self (a b : α) : a * a - b * b = (a + b) * (a - b) :=
 by rw [add_mul, mul_sub, mul_sub, mul_comm a b, sub_add_sub_cancel]
+
+lemma mul_self_sub_one_eq (a : α) : a * a - 1 = (a + 1) * (a - 1) :=
+by rw [← mul_self_sub_mul_self, mul_one]
 
 /-- An element a of a commutative ring divides the additive inverse of an element b iff a
   divides b. -/

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -619,7 +619,7 @@ theorem two_dvd_bit1 : 2 ∣ bit1 a ↔ (2 : α) ∣ 1 := (dvd_add_iff_right (@t
 theorem mul_self_sub_mul_self (a b : α) : a * a - b * b = (a + b) * (a - b) :=
 by rw [add_mul, mul_sub, mul_sub, mul_comm a b, sub_add_sub_cancel]
 
-lemma mul_self_sub_one_eq (a : α) : a * a - 1 = (a + 1) * (a - 1) :=
+lemma mul_self_sub_one (a : α) : a * a - 1 = (a + 1) * (a - 1) :=
 by rw [← mul_self_sub_mul_self, mul_one]
 
 /-- An element a of a commutative ring divides the additive inverse of an element b iff a


### PR DESCRIPTION
It's redundant with `mul_self_sub_mul_self`.

Also renamed `mul_self_sub_one_eq` to `mul_self_sub_one`.

---
<!-- put comments you want to keep out of the PR commit here -->

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/sq_sub_sq.20for.20nat).