### PR TITLE
[Merged by Bors] - feat(category_theory): Mon_.forget reflects isos

### DIFF
--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -69,7 +69,8 @@ class monoidal_category (C : Type u) [𝒞 : category.{v} C] :=
 restate_axiom monoidal_category.tensor_id'
 attribute [simp] monoidal_category.tensor_id
 restate_axiom monoidal_category.tensor_comp'
-attribute [simp, reassoc] monoidal_category.tensor_comp
+attribute [reassoc] monoidal_category.tensor_comp
+attribute [simp] monoidal_category.tensor_comp
 restate_axiom monoidal_category.associator_naturality'
 attribute [reassoc] monoidal_category.associator_naturality
 restate_axiom monoidal_category.left_unitor_naturality'

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -69,7 +69,7 @@ class monoidal_category (C : Type u) [𝒞 : category.{v} C] :=
 restate_axiom monoidal_category.tensor_id'
 attribute [simp] monoidal_category.tensor_id
 restate_axiom monoidal_category.tensor_comp'
-attribute [simp] monoidal_category.tensor_comp
+attribute [simp, reassoc] monoidal_category.tensor_comp
 restate_axiom monoidal_category.associator_naturality'
 attribute [reassoc] monoidal_category.associator_naturality
 restate_axiom monoidal_category.left_unitor_naturality'

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -69,7 +69,7 @@ class monoidal_category (C : Type u) [𝒞 : category.{v} C] :=
 restate_axiom monoidal_category.tensor_id'
 attribute [simp] monoidal_category.tensor_id
 restate_axiom monoidal_category.tensor_comp'
-attribute [reassoc] monoidal_category.tensor_comp
+attribute [reassoc] monoidal_category.tensor_comp -- This would be redundant in the simp set.
 attribute [simp] monoidal_category.tensor_comp
 restate_axiom monoidal_category.associator_naturality'
 attribute [reassoc] monoidal_category.associator_naturality

--- a/src/category_theory/monoidal/internal.lean
+++ b/src/category_theory/monoidal/internal.lean
@@ -108,7 +108,7 @@ def forget : Mon_ C ⥤ C :=
 
 instance {A B : Mon_ C} (f : A ⟶ B) [e : is_iso ((forget C).map f)] : is_iso (f.hom) := e
 
-/-- The forgetful functor from monoidal objects to the ambient category reflects isomorphisms. -/
+/-- The forgetful functor from monoid objects to the ambient category reflects isomorphisms. -/
 instance : reflects_isomorphisms (forget C) :=
 { reflects := λ X Y f e, by exactI
   { inv :=

--- a/src/category_theory/monoidal/internal.lean
+++ b/src/category_theory/monoidal/internal.lean
@@ -99,10 +99,25 @@ instance : category (Mon_ C) :=
 @[simp] lemma comp_hom' {M N K : Mon_ C} (f : M ⟶ N) (g : N ⟶ K) :
   (f ≫ g : hom M K).hom = f.hom ≫ g.hom := rfl
 
+variables (C)
+
 /-- The forgetful functor from monoid objects to the ambient category. -/
 def forget : Mon_ C ⥤ C :=
 { obj := λ A, A.X,
   map := λ A B f, f.hom, }
+
+instance {A B : Mon_ C} (f : A ⟶ B) [e : is_iso ((forget C).map f)] : is_iso (f.hom) := e
+
+/-- The forgetful functor from monoidal objects to the ambient category reflects isomorphisms. -/
+instance : reflects_isomorphisms (forget C) :=
+{ reflects := λ X Y f e, by exactI
+  { inv :=
+    { hom := inv f.hom,
+      mul_hom' :=
+      begin
+        simp only [is_iso.comp_inv_eq, hom.mul_hom, category.assoc, ←tensor_comp_assoc,
+          is_iso.inv_hom_id, tensor_id, category.id_comp],
+      end } } }
 
 instance (A : Mon_ C) : unique (trivial C ⟶ A) :=
 { default :=

--- a/src/category_theory/monoidal/internal.lean
+++ b/src/category_theory/monoidal/internal.lean
@@ -106,7 +106,7 @@ def forget : Mon_ C ⥤ C :=
 { obj := λ A, A.X,
   map := λ A B f, f.hom, }
 
-instance {A B : Mon_ C} (f : A ⟶ B) [e : is_iso ((forget C).map f)] : is_iso (f.hom) := e
+instance {A B : Mon_ C} (f : A ⟶ B) [e : is_iso ((forget C).map f)] : is_iso f.hom := e
 
 /-- The forgetful functor from monoid objects to the ambient category reflects isomorphisms. -/
 instance : reflects_isomorphisms (forget C) :=

--- a/src/category_theory/monoidal/internal/Module.lean
+++ b/src/category_theory/monoidal/internal/Module.lean
@@ -162,7 +162,8 @@ The equivalence `Mon_ (Module R) ≌ Algebra R`
 is naturally compatible with the forgetful functors to `Module R`.
 -/
 def Mon_Module_equivalence_Algebra_forget :
-  Mon_Module_equivalence_Algebra.functor ⋙ forget₂ (Algebra.{u} R) (Module.{u} R) ≅ Mon_.forget :=
+  Mon_Module_equivalence_Algebra.functor ⋙ forget₂ (Algebra.{u} R) (Module.{u} R) ≅
+    Mon_.forget (Module.{u} R) :=
 nat_iso.of_components (λ A,
 { hom :=
   { to_fun := id,

--- a/src/category_theory/monoidal/internal/types.lean
+++ b/src/category_theory/monoidal/internal/types.lean
@@ -73,7 +73,7 @@ The equivalence `Mon_ (Type u) ≌ Mon.{u}`
 is naturally compatible with the forgetful functors to `Type u`.
 -/
 def Mon_Type_equivalence_Mon_forget :
-  Mon_Type_equivalence_Mon.functor ⋙ forget Mon ≅ Mon_.forget :=
+  Mon_Type_equivalence_Mon.functor ⋙ forget Mon ≅ Mon_.forget (Type u) :=
 nat_iso.of_components (λ A, iso.refl _) (by tidy)
 
 instance Mon_Type_inhabited : inhabited (Mon_ (Type u)) :=


### PR DESCRIPTION
A step along the way to `sheaf X (Mon_ C) ~ Mon_ (sheaf X C)`.

---
<!-- put comments you want to keep out of the PR commit here -->
