### PR TITLE
[Merged by Bors] - chore(category_theory/zero): lemmas for has_zero_morphisms.comp_zero|zero_comp

### DIFF
--- a/src/algebra/homology/exact.lean
+++ b/src/algebra/homology/exact.lean
@@ -50,7 +50,7 @@ attribute [instance] exact.epi
 
 lemma exact.w_assoc {A B C D : V} {f : A ⟶ B} {g : B ⟶ C} [exact f g] {h : C ⟶ D} :
   f ≫ g ≫ h = 0 :=
-by rw [←category.assoc, @exact.w _ _ _ _ _ _ _ _ _ f g, has_zero_morphisms.zero_comp]
+by rw [←category.assoc, @exact.w _ _ _ _ _ _ _ _ _ f g, zero_comp]
 
 instance exact_comp_iso {A B C C' : V} (f : A ⟶ B) (g : B ⟶ C) (h : C ≅ C') [exact f g] :
   exact f (g ≫ h.hom) :=
@@ -59,7 +59,7 @@ instance exact_comp_iso {A B C C' : V} (f : A ⟶ B) (g : B ⟶ C) (h : C ≅ C'
 
 instance exact_iso_comp {A A' B C : V} (h : A' ≅ A) (f : A ⟶ B) (g : B ⟶ C) [exact f g] :
   exact (h.hom ≫ f) g :=
-{ w := by rw [category.assoc, @exact.w _ _ _ _ _ _ _ _ _ f g, has_zero_morphisms.comp_zero],
+{ w := by rw [category.assoc, @exact.w _ _ _ _ _ _ _ _ _ f g, comp_zero],
   epi := by { simp only [image_to_kernel_map_iso_comp], apply epi_comp, } }
 
 section
@@ -72,7 +72,7 @@ zero_of_epi_comp (image_to_kernel_map f g exact.w) $ zero_of_epi_comp (factor_th
 lemma comp_eq_zero_of_exact [exact f g] {X Y : V} {ι : X ⟶ B} (hι : ι ≫ g = 0) {π : B ⟶ Y}
   (hπ : f ≫ π = 0) : ι ≫ π = 0 :=
 by rw [←kernel.lift_ι _ _ hι, ←cokernel.π_desc _ _ hπ, category.assoc, kernel_comp_cokernel_assoc,
-  has_zero_morphisms.zero_comp, has_zero_morphisms.comp_zero]
+  zero_comp, comp_zero]
 
 @[simp, reassoc] lemma fork_ι_comp_cofork_π [exact f g] (s : kernel_fork g)
   (t : cokernel_cofork f) : fork.ι s ≫ cofork.π t = 0 :=

--- a/src/algebra/homology/homology.lean
+++ b/src/algebra/homology/homology.lean
@@ -51,7 +51,7 @@ def kernel_map {C C' : homological_complex V b} (f : C ⟶ C') (i : β) :
   kernel (C.d i) ⟶ kernel (C'.d i) :=
 kernel.lift _ (kernel.ι _ ≫ f.f i)
 begin
-  rw [category.assoc, ←comm_at f, ←category.assoc, kernel.condition, has_zero_morphisms.zero_comp],
+  rw [category.assoc, ←comm_at f, ←category.assoc, kernel.condition, zero_comp],
 end
 
 @[simp, reassoc]

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -364,7 +364,7 @@ def is_colimit_biproduct_to_pushout : is_colimit (biproduct_to_pushout_cofork f 
 cofork.is_colimit.mk _
   (λ s, pushout.desc (biprod.inl ≫ cofork.π s) (biprod.inr ≫ cofork.π s) $
     sub_eq_zero.1 $ by rw [←category.assoc, ←category.assoc, ←sub_comp, sub_eq_add_neg, ←neg_comp,
-      ←biprod.lift_eq, cofork.condition s, has_zero_morphisms.zero_comp])
+      ←biprod.lift_eq, cofork.condition s, zero_comp])
   (λ s, by ext; simp)
   (λ s m h, by ext; simp [cofork.π_eq_app_one, ←h walking_parallel_pair.one] )
 
@@ -471,7 +471,7 @@ begin
     ... = (d ≫ biprod.lift f (-g)) ≫ biprod.snd : by rw ←hd
     ... = (0 ≫ biprod.lift f (-g)) ≫ biprod.snd : by rw this
     ... = 0 ≫ biprod.lift f (-g) ≫ biprod.snd : by rw category.assoc
-    ... = 0 : has_zero_morphisms.zero_comp _ _
+    ... = 0 : zero_comp
 end
 
 instance mono_pushout_of_mono_g [mono g] : mono (pushout.inl : Y ⟶ pushout f g) :=
@@ -494,7 +494,7 @@ begin
     ... = (d ≫ biprod.lift f (-g)) ≫ biprod.fst : by rw ←hd
     ... = (0 ≫ biprod.lift f (-g)) ≫ biprod.fst : by rw this
     ... = 0 ≫ biprod.lift f (-g) ≫ biprod.fst : by rw category.assoc
-    ... = 0 : has_zero_morphisms.zero_comp _ _
+    ... = 0 : zero_comp
 end
 
 end mono_pushout

--- a/src/category_theory/abelian/non_preadditive.lean
+++ b/src/category_theory/abelian/non_preadditive.lean
@@ -125,12 +125,12 @@ let ⟨a', ha'⟩ := kernel_fork.is_limit.lift' i (kernel.ι (prod.lift f g)) $
     calc kernel.ι (prod.lift f g) ≫ f
         = kernel.ι (prod.lift f g) ≫ prod.lift f g ≫ limits.prod.fst : by rw prod.lift_fst
     ... = (0 : kernel (prod.lift f g) ⟶ P ⨯ Q) ≫ limits.prod.fst : by rw kernel.condition_assoc
-    ... = 0 : has_zero_morphisms.zero_comp _ _ in
+    ... = 0 : zero_comp in
 let ⟨b', hb'⟩ := kernel_fork.is_limit.lift' i' (kernel.ι (prod.lift f g)) $
     calc kernel.ι (prod.lift f g) ≫ g
         = kernel.ι (prod.lift f g) ≫ (prod.lift f g) ≫ limits.prod.snd : by rw prod.lift_snd
     ... = (0 : kernel (prod.lift f g) ⟶ P ⨯ Q) ≫ limits.prod.snd : by rw kernel.condition_assoc
-    ... = 0 : has_zero_morphisms.zero_comp _ _ in
+    ... = 0 : zero_comp in
 has_limit.mk { cone := pullback_cone.mk a' b' $ by { simp at ha' hb', rw [ha', hb'] },
   is_limit := pullback_cone.is_limit.mk _ _ _
     (λ s, kernel.lift (prod.lift f g) (pullback_cone.snd s ≫ b) $ prod.hom_ext
@@ -139,12 +139,12 @@ has_limit.mk { cone := pullback_cone.mk a' b' $ by { simp at ha' hb', rw [ha', h
         ... = pullback_cone.fst s ≫ a ≫ f : by rw pullback_cone.condition_assoc
         ... = pullback_cone.fst s ≫ 0 : by rw haf
         ... = 0 ≫ limits.prod.fst :
-          by rw [has_zero_morphisms.comp_zero, has_zero_morphisms.zero_comp])
+          by rw [comp_zero, zero_comp])
       (calc ((pullback_cone.snd s ≫ b) ≫ prod.lift f g) ≫ limits.prod.snd
             = pullback_cone.snd s ≫ b ≫ g : by simp only [prod.lift_snd, category.assoc]
         ... = pullback_cone.snd s ≫ 0 : by rw hbg
         ... = 0 ≫ limits.prod.snd :
-          by rw [has_zero_morphisms.comp_zero, has_zero_morphisms.zero_comp]))
+          by rw [comp_zero, zero_comp]))
     (λ s, (cancel_mono a).1 $
       by { rw kernel_fork.ι_of_ι at ha', simp [ha', pullback_cone.condition s] })
     (λ s, (cancel_mono b).1 $
@@ -180,11 +180,11 @@ has_colimit.mk
           = f ≫ b ≫ pushout_cocone.inr s : by rw coprod.inl_desc_assoc
       ... = f ≫ a ≫ pushout_cocone.inl s : by rw pushout_cocone.condition
       ... = 0 ≫ pushout_cocone.inl s : by rw reassoc_of hfa
-      ... = coprod.inl ≫ 0 : by rw [has_zero_morphisms.comp_zero, has_zero_morphisms.zero_comp])
+      ... = coprod.inl ≫ 0 : by rw [comp_zero, zero_comp])
     (calc coprod.inr ≫ coprod.desc f g ≫ b ≫ pushout_cocone.inr s
           = g ≫ b ≫ pushout_cocone.inr s : by rw coprod.inr_desc_assoc
       ... = 0 ≫ pushout_cocone.inr s : by rw reassoc_of hgb
-      ... = coprod.inr ≫ 0 : by rw [has_zero_morphisms.comp_zero, has_zero_morphisms.zero_comp]))
+      ... = coprod.inr ≫ 0 : by rw [comp_zero, zero_comp]))
   (λ s, (cancel_epi a).1 $
     by { rw cokernel_cofork.π_of_π at ha', simp [reassoc_of ha', pushout_cocone.condition s] })
   (λ s, (cancel_epi b).1 $ by { rw cokernel_cofork.π_of_π at hb', simp [reassoc_of hb'] })
@@ -298,7 +298,7 @@ lemma mono_of_zero_kernel {X Y : C} (f : X ⟶ Y) (Z : C)
   obtain ⟨W, w, hw, hl⟩ := non_preadditive_abelian.normal_epi (coequalizer.π u v),
   obtain ⟨m, hm⟩ := coequalizer.desc' f huv,
   have hwf : w ≫ f = 0,
-  { rw [←hm, reassoc_of hw, has_zero_morphisms.zero_comp] },
+  { rw [←hm, reassoc_of hw, zero_comp] },
   obtain ⟨n, hn⟩ := kernel_fork.is_limit.lift' l _ hwf,
   rw [fork.ι_of_ι, has_zero_morphisms.comp_zero] at hn,
   haveI : is_iso (coequalizer.π u v) :=
@@ -315,9 +315,9 @@ lemma epi_of_zero_cokernel {X Y : C} (f : X ⟶ Y) (Z : C)
   obtain ⟨W, w, hw, hl⟩ := non_preadditive_abelian.normal_mono (equalizer.ι u v),
   obtain ⟨m, hm⟩ := equalizer.lift' f huv,
   have hwf : f ≫ w = 0,
-  { rw [←hm, category.assoc, hw, has_zero_morphisms.comp_zero] },
+  { rw [←hm, category.assoc, hw, comp_zero] },
   obtain ⟨n, hn⟩ := cokernel_cofork.is_colimit.desc' l _ hwf,
-  rw [cofork.π_of_π, has_zero_morphisms.zero_comp] at hn,
+  rw [cofork.π_of_π, zero_comp] at hn,
   haveI : is_iso (equalizer.ι u v) :=
     by apply is_iso_limit_cone_parallel_pair_of_eq hn.symm hl,
   apply (cancel_epi (equalizer.ι u v)).1,
@@ -331,7 +331,7 @@ def zero_kernel_of_cancel_zero {X Y : C} (f : X ⟶ Y)
   (hf : ∀ (Z : C) (g : Z ⟶ X) (hgf : g ≫ f = 0), g = 0) :
     is_limit (kernel_fork.of_ι (0 : 0 ⟶ X) (show 0 ≫ f = 0, by simp)) :=
 fork.is_limit.mk _ (λ s, 0)
-  (λ s, by rw [hf _ _ (kernel_fork.condition s), has_zero_morphisms.zero_comp])
+  (λ s, by rw [hf _ _ (kernel_fork.condition s), zero_comp])
   (λ s m h, by ext)
 
 /-- If `f ≫ g = 0` implies `g = 0` for all `g`, then `0 : Y ⟶ 0` is a cokernel of `f`. -/
@@ -339,7 +339,7 @@ def zero_cokernel_of_zero_cancel {X Y : C} (f : X ⟶ Y)
   (hf : ∀ (Z : C) (g : Y ⟶ Z) (hgf : f ≫ g = 0), g = 0) :
     is_colimit (cokernel_cofork.of_π (0 : Y ⟶ 0) (show f ≫ 0 = 0, by simp)) :=
 cofork.is_colimit.mk _ (λ s, 0)
-  (λ s, by rw [hf _ _ (cokernel_cofork.condition s), has_zero_morphisms.comp_zero])
+  (λ s, by rw [hf _ _ (cokernel_cofork.condition s), comp_zero])
   (λ s m h, by ext)
 
 /-- If `g ≫ f = 0` implies `g = 0` for all `g`, then `f` is a monomorphism. -/
@@ -399,7 +399,7 @@ begin
   have hih : i ≫ h = 0, calc
     i ≫ h = i ≫ cokernel.π f ≫ l : hl ▸ rfl
        ... = 0 ≫ l : by rw [←category.assoc, kernel.condition]
-       ... = 0 : has_zero_morphisms.zero_comp _ _,
+       ... = 0 : zero_comp,
   -- i factors through u = ker h via some s.
   obtain ⟨s, hs⟩ := normal_mono.lift' u i hih,
   have hs' : (s ≫ kernel.ι g) ≫ i = 𝟙 I ≫ i, by rw [category.assoc, hs, category.id_comp],
@@ -447,13 +447,13 @@ begin
     ... = h ≫ (p ≫ (cokernel.π g ≫ t)) : ht ▸ rfl
     ... = h ≫ u ≫ t : by simp only [category.assoc]; conv_lhs { congr, skip, rw ←category.assoc }
     ... = 0 ≫ t : by rw [←category.assoc, hu.w]
-    ... = 0 : has_zero_morphisms.zero_comp _ _,
+    ... = 0 : zero_comp,
   -- h factors through the kernel of f via some l.
   obtain ⟨l, hl⟩ := kernel.lift' f h hf,
   have hhp : h ≫ p = 0, calc
     h ≫ p = (l ≫ kernel.ι f) ≫ p : hl ▸ rfl
     ... = l ≫ 0 : by rw [category.assoc, cokernel.condition]
-    ... = 0 : has_zero_morphisms.comp_zero _ _,
+    ... = 0 : comp_zero,
   -- p factors through u = coker h via some s.
   obtain ⟨s, hs⟩ := normal_epi.desc' u p hhp,
   have hs' : p ≫ cokernel.π g ≫ s = p ≫ 𝟙 I, by rw [←category.assoc, hs, category.comp_id],
@@ -523,7 +523,7 @@ begin
       category.assoc, prod.lift_snd, has_zero_morphisms.comp_zero] },
   haveI : mono (prod.lift (𝟙 A) (0 : A ⟶ A)) := mono_of_mono_fac (prod.lift_fst _ _),
   apply (cancel_mono (prod.lift (𝟙 A) (0 : A ⟶ A))).1,
-  rw [←hy, hyy, has_zero_morphisms.zero_comp, has_zero_morphisms.zero_comp]
+  rw [←hy, hyy, zero_comp, zero_comp]
 end
 
 instance epi_r {A : C} : epi (r A) :=
@@ -550,9 +550,9 @@ begin
   { rw [←category.id_comp t],
     change 𝟙 A ≫ t = 0,
     rw [←limits.prod.lift_snd (𝟙 A) (𝟙 A), category.assoc, ht, ←category.assoc,
-      cokernel.condition, has_zero_morphisms.zero_comp] },
+      cokernel.condition, zero_comp] },
   apply (cancel_epi (cokernel.π (Δ A))).1,
-  rw [←ht, htt, has_zero_morphisms.comp_zero, has_zero_morphisms.comp_zero]
+  rw [←ht, htt, comp_zero, comp_zero]
 end
 
 instance is_iso_r {A : C} : is_iso (r A) :=
@@ -567,7 +567,7 @@ abbreviation σ {A : C} : A ⨯ A ⟶ A := cokernel.π (Δ A) ≫ is_iso.inv (r 
 end
 
 @[simp, reassoc] lemma Δ_σ {X : C} : Δ X ≫ σ = 0 :=
-by rw [cokernel.condition_assoc, has_zero_morphisms.zero_comp]
+by rw [cokernel.condition_assoc, zero_comp]
 
 @[simp, reassoc] lemma lift_σ {X : C} : prod.lift (𝟙 X) 0 ≫ σ = 𝟙 X :=
 by rw [←category.assoc, is_iso.hom_inv_id]
@@ -701,10 +701,10 @@ lemma sub_comp {X Y Z : C} (f g : X ⟶ Y) (h : Y ⟶ Z) : (f - g) ≫ h = f ≫
 by rw [sub_def, category.assoc, σ_comp, ←category.assoc, prod.lift_map, sub_def]
 
 lemma comp_add (X Y Z : C) (f : X ⟶ Y) (g h : Y ⟶ Z) : f ≫ (g + h) = f ≫ g + f ≫ h :=
-by rw [add_def, comp_sub, neg_def, comp_sub, has_zero_morphisms.comp_zero, add_def, neg_def]
+by rw [add_def, comp_sub, neg_def, comp_sub, comp_zero, add_def, neg_def]
 
 lemma add_comp (X Y Z : C) (f g : X ⟶ Y) (h : Y ⟶ Z) : (f + g) ≫ h = f ≫ h + g ≫ h :=
-by rw [add_def, sub_comp, neg_def, sub_comp, has_zero_morphisms.zero_comp, add_def, neg_def]
+by rw [add_def, sub_comp, neg_def, sub_comp, zero_comp, add_def, neg_def]
 
 /-- Every `non_preadditive_abelian` category is preadditive. -/
 def preadditive : preadditive C :=

--- a/src/category_theory/limits/shapes/biproducts.lean
+++ b/src/category_theory/limits/shapes/biproducts.lean
@@ -632,13 +632,13 @@ begin
     ←binary_bicone.to_cone_π_app_left, ←binary_biproduct.bicone_fst,
     ←binary_bicone.to_cocone_ι_app_left, ←binary_biproduct.bicone_inl],
     simp },
-  { simp only [map_pair_left, ι_is_colimit_map, is_limit_map_π, has_zero_morphisms.zero_comp,
+  { simp only [map_pair_left, ι_is_colimit_map, is_limit_map_π, zero_comp,
       biprod.inl_snd_assoc, category.assoc,
       ←binary_bicone.to_cone_π_app_right, ←binary_biproduct.bicone_snd,
       ←binary_bicone.to_cocone_ι_app_left, ←binary_biproduct.bicone_inl],
     simp },
   { simp only [map_pair_right, biprod.inr_fst_assoc, ι_is_colimit_map, is_limit_map_π,
-      has_zero_morphisms.zero_comp, category.assoc,
+      zero_comp, category.assoc,
       ←binary_bicone.to_cone_π_app_left, ←binary_biproduct.bicone_fst,
       ←binary_bicone.to_cocone_ι_app_right, ←binary_biproduct.bicone_inr],
     simp },
@@ -826,7 +826,7 @@ begin
     limits.colimit.ι_desc, category.comp_id],
   dsimp,
   simp only [dite_comp, finset.sum_dite_eq, finset.mem_univ, if_true, category.id_comp,
-    eq_to_hom_refl, limits.has_zero_morphisms.zero_comp],
+    eq_to_hom_refl, zero_comp],
 end
 
 /-- A preadditive category with finite products has finite biproducts. -/

--- a/src/category_theory/limits/shapes/kernels.lean
+++ b/src/category_theory/limits/shapes/kernels.lean
@@ -274,7 +274,7 @@ def kernel.zero_cone : cone (parallel_pair f 0) :=
 /-- The map from the zero object is a kernel of a monomorphism -/
 def kernel.is_limit_cone_zero_cone [mono f] : is_limit (kernel.zero_cone f) :=
 fork.is_limit.mk _ (λ s, 0)
-  (λ s, by { erw has_zero_morphisms.zero_comp,
+  (λ s, by { erw zero_comp,
     convert (zero_of_comp_mono f _).symm,
     exact kernel_fork.condition _ })
   (λ _ _ _, zero_of_to_zero _)
@@ -341,14 +341,14 @@ abbreviation cokernel_cofork := cofork f 0
 variables {f}
 
 @[simp, reassoc] lemma cokernel_cofork.condition (s : cokernel_cofork f) : f ≫ cofork.π s = 0 :=
-by rw [cofork.condition, has_zero_morphisms.zero_comp]
+by rw [cofork.condition, zero_comp]
 
 @[simp] lemma cokernel_cofork.app_zero (s : cokernel_cofork f) : s.ι.app zero = 0 :=
 by rw [←cofork.left_app_one, cokernel_cofork.condition]
 
 /-- A morphism `π` satisfying `f ≫ π = 0` determines a cokernel cofork on `f`. -/
 abbreviation cokernel_cofork.of_π {Z : C} (π : Y ⟶ Z) (w : f ≫ π = 0) : cokernel_cofork f :=
-cofork.of_π π $ by rw [w, has_zero_morphisms.zero_comp]
+cofork.of_π π $ by rw [w, zero_comp]
 
 @[simp] lemma cokernel_cofork.π_of_π {X Y P : C} (f : X ⟶ Y) (π : Y ⟶ P) (w : f ≫ π = 0) :
   cofork.π (cokernel_cofork.of_π π w) = π := rfl
@@ -533,7 +533,7 @@ def cokernel.zero_cocone : cocone (parallel_pair f 0) :=
 /-- The morphism to the zero object is a cokernel of an epimorphism -/
 def cokernel.is_colimit_cocone_zero_cocone [epi f] : is_colimit (cokernel.zero_cocone f) :=
 cofork.is_colimit.mk _ (λ s, 0)
-  (λ s, by { erw has_zero_morphisms.zero_comp,
+  (λ s, by { erw zero_comp,
     convert (zero_of_epi_comp f _).symm,
     exact cokernel_cofork.condition _ })
   (λ _ _ _, zero_of_from_zero _)

--- a/src/category_theory/limits/shapes/regular_mono.lean
+++ b/src/category_theory/limits/shapes/regular_mono.lean
@@ -346,11 +346,11 @@ def normal_of_is_pushout_snd_of_normal {P Q R S : C} {f : P ⟶ Q} {g : P ⟶ R}
 normal_epi h :=
 { W := gn.W,
   g := gn.g ≫ f,
-  w := by rw [category.assoc, comm, reassoc_of gn.w, has_zero_morphisms.zero_comp],
+  w := by rw [category.assoc, comm, reassoc_of gn.w, zero_comp],
   is_colimit :=
   begin
     letI hn := regular_of_is_pushout_snd_of_regular comm t,
-    have q := (has_zero_morphisms.zero_comp gn.W f).symm,
+    have q := (@zero_comp _ _ _ gn.W _ _ f).symm,
     convert hn.is_colimit,
     dunfold cokernel_cofork.of_π cofork.of_π,
     congr, exact q, exact q, exact q, apply proof_irrel_heq,

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -44,9 +44,7 @@ class has_zero_morphisms :=
 
 attribute [instance] has_zero_morphisms.has_zero
 restate_axiom has_zero_morphisms.comp_zero'
-attribute [simp] has_zero_morphisms.comp_zero
 restate_axiom has_zero_morphisms.zero_comp'
-attribute [simp] has_zero_morphisms.zero_comp
 
 variables {C}
 

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -50,9 +50,9 @@ attribute [simp] has_zero_morphisms.zero_comp
 
 variables {C}
 
-lemma comp_zero [has_zero_morphisms C] {X Y : C} {f : X ⟶ Y} {Z : C} :
+@[simp] lemma comp_zero [has_zero_morphisms C] {X Y : C} {f : X ⟶ Y} {Z : C} :
   f ≫ (0 : Y ⟶ Z) = (0 : X ⟶ Z) := has_zero_morphisms.comp_zero f Z
-lemma zero_comp [has_zero_morphisms C] {X : C} {Y Z : C} {f : Y ⟶ Z} :
+@[simp] lemma zero_comp [has_zero_morphisms C] {X : C} {Y Z : C} {f : Y ⟶ Z} :
   (0 : X ⟶ Y) ≫ f = (0 : X ⟶ Z) := has_zero_morphisms.zero_comp X f
 
 instance has_zero_morphisms_pempty : has_zero_morphisms (discrete pempty) :=

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -46,7 +46,14 @@ attribute [instance] has_zero_morphisms.has_zero
 restate_axiom has_zero_morphisms.comp_zero'
 attribute [simp] has_zero_morphisms.comp_zero
 restate_axiom has_zero_morphisms.zero_comp'
-attribute [simp, reassoc] has_zero_morphisms.zero_comp
+attribute [simp] has_zero_morphisms.zero_comp
+
+variables {C}
+
+lemma comp_zero [has_zero_morphisms C] {X Y : C} {f : X ⟶ Y} {Z : C} :
+  f ≫ (0 : Y ⟶ Z) = (0 : X ⟶ Z) := has_zero_morphisms.comp_zero f Z
+lemma zero_comp [has_zero_morphisms C] {X : C} {Y Z : C} {f : Y ⟶ Z} :
+  (0 : X ⟶ Y) ≫ f = (0 : X ⟶ Z) := has_zero_morphisms.zero_comp X f
 
 instance has_zero_morphisms_pempty : has_zero_morphisms (discrete pempty) :=
 { has_zero := by tidy }
@@ -95,10 +102,10 @@ section
 variables {C} [has_zero_morphisms C]
 
 lemma zero_of_comp_mono {X Y Z : C} {f : X ⟶ Y} (g : Y ⟶ Z) [mono g] (h : f ≫ g = 0) : f = 0 :=
-by { rw [←zero_comp X g, cancel_mono] at h, exact h }
+by { rw [←zero_comp, cancel_mono] at h, exact h }
 
 lemma zero_of_epi_comp {X Y Z : C} (f : X ⟶ Y) {g : Y ⟶ Z} [epi f] (h : f ≫ g = 0) : g = 0 :=
-by { rw [←comp_zero f Z, cancel_epi] at h, exact h }
+by { rw [←comp_zero, cancel_epi] at h, exact h }
 
 lemma eq_zero_of_image_eq_zero {X Y : C} {f : X ⟶ Y} [has_image f] (w : image.ι f = 0) : f = 0 :=
 by rw [←image.fac f, w, has_zero_morphisms.comp_zero]
@@ -129,6 +136,8 @@ end
 by rw [←functor.as_equivalence_functor F, equivalence_preserves_zero_morphisms]
 
 end
+
+variables (C)
 
 /-- A category "has a zero object" if it has an object which is both initial and terminal. -/
 class has_zero_object :=
@@ -328,7 +337,7 @@ instance has_zero_object_of_has_terminal_object
   calc
     f = 𝟙 _ ≫ f : (category.id_comp _).symm
     ... = 0 ≫ f : by congr
-    ... = 0     : has_zero_morphisms.zero_comp _ _
+    ... = 0     : zero_comp
   ⟩ }
 
 

--- a/src/category_theory/preadditive/biproducts.lean
+++ b/src/category_theory/preadditive/biproducts.lean
@@ -153,7 +153,7 @@ begin
   simp only [add_comp, comp_add, add_comp_assoc, add_zero, zero_add,
     biprod.inl_fst, biprod.inl_snd, biprod.inr_fst, biprod.inr_snd,
     biprod.inl_fst_assoc, biprod.inl_snd_assoc, biprod.inr_fst_assoc, biprod.inr_snd_assoc,
-    has_zero_morphisms.comp_zero, has_zero_morphisms.zero_comp, has_zero_morphisms.zero_comp_assoc,
+    comp_zero, zero_comp,
     category.comp_id, category.assoc],
 end
 
@@ -263,9 +263,9 @@ begin
     simp only [category.assoc],
     rw [comp_add_assoc, add_comp],
     conv_lhs { congr, skip, slice 1 3, rw a₂, },
-    simp only [has_zero_morphisms.zero_comp, add_zero],
+    simp only [zero_comp, add_zero],
     conv_lhs { slice 1 3, rw a₁, },
-    simp only [has_zero_morphisms.zero_comp], },
+    simp only [zero_comp], },
   exact nz (h₁.symm.trans h₀),
 end
 

--- a/src/category_theory/preadditive/default.lean
+++ b/src/category_theory/preadditive/default.lean
@@ -145,7 +145,7 @@ lemma mono_iff_cancel_zero {Q R : C} (f : Q ⟶ R) :
 
 lemma mono_of_kernel_zero {X Y : C} {f : X ⟶ Y} [has_limit (parallel_pair f 0)]
   (w : kernel.ι f = 0) : mono f :=
-mono_of_cancel_zero f (λ P g h, by rw [←kernel.lift_ι f g h, w, has_zero_morphisms.comp_zero])
+mono_of_cancel_zero f (λ P g h, by rw [←kernel.lift_ι f g h, w, comp_zero])
 
 lemma epi_of_cancel_zero {P Q : C} (f : P ⟶ Q) (h : ∀ {R : C} (g : Q ⟶ R), f ≫ g = 0 → g = 0) :
   epi f :=
@@ -157,7 +157,7 @@ lemma epi_iff_cancel_zero {P Q : C} (f : P ⟶ Q) :
 
 lemma epi_of_cokernel_zero {X Y : C} (f : X ⟶ Y) [has_colimit (parallel_pair f 0 )]
   (w : cokernel.π f = 0) : epi f :=
-epi_of_cancel_zero f (λ P g h, by rw [←cokernel.π_desc f g h, w, has_zero_morphisms.zero_comp])
+epi_of_cancel_zero f (λ P g h, by rw [←cokernel.π_desc f g h, w, zero_comp])
 
 end preadditive
 

--- a/src/category_theory/preadditive/schur.lean
+++ b/src/category_theory/preadditive/schur.lean
@@ -55,7 +55,7 @@ def is_iso_equiv_nonzero {X Y : C} [simple.{v} X] [simple.{v} Y] {f : X ⟶ Y} :
   begin
     introI h,
     apply id_nonzero X,
-    simp only [←is_iso.hom_inv_id f, h, has_zero_morphisms.zero_comp],
+    simp only [←is_iso.hom_inv_id f, h, zero_comp],
   end,
   inv_fun := λ w, is_iso_of_hom_simple w,
   left_inv := λ I, subsingleton.elim _ _,


### PR DESCRIPTION
The axioms of `has_zero_morphisms` never had lemmas written for them, so everyone has been using the typeclass fields directly.


---
<!-- put comments you want to keep out of the PR commit here -->
