### PR TITLE
feat(logic/basic): Push forall binders inside implications

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -775,6 +775,10 @@ by simp [@eq_comm _ _ (f _)]
   (∀ b, ∀ a, b = f a → p b) ↔ (∀ a, p (f a)) :=
 by { rw forall_swap, simp }
 
+/-- An implication whose LHS is independent of the forall can be brought outside -/
+@[simp] theorem forall_imp_indep {p : Prop} {q : α → Prop} :
+  (∀ a, p → q a) ↔ (p → ∀ a, q a) := forall_swap
+
 @[simp] theorem exists_eq_left' {a' : α} : (∃ a, a' = a ∧ p a) ↔ p a' :=
 by simp [@eq_comm _ a']
 
@@ -1179,3 +1183,5 @@ by { by_cases h : P; simp [h] }
 dite_not P (λ _, x) (λ _, y)
 
 end ite
+
+#lint


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
This causes a deterministic timeout at

https://github.com/leanprover-community/mathlib/blob/3419986967dad05d9f89b9c2b13011ee4313575c/src/data/set/basic.lean#L454-L455

It's possible this fails because of the finish approach of

> bring universal quantifiers to the outside (for ematching).

Which seems like the opposite of what this simp rule does.