### PR TITLE
[Merged by Bors] - chore(ci): teach bors and GitHub about new labels

### DIFF
--- a/.github/workflows/add_label_from_comment.yml
+++ b/.github/workflows/add_label_from_comment.yml
@@ -63,11 +63,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
-        id: remove_request_review
-        name: Remove "awaiting-review"
+        id: remove_labels
+        name: Remove "awaiting-review" and "awaiting-author"
         # we use curl rather than octokit/request-action so that the job won't fail
-        # (and send an annoying email) if the label doesn't exist
+        # (and send an annoying email) if the labels don't exist
         run: |
           curl --request DELETE \
-          --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/request-review \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-review \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+          curl --request DELETE \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-author \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/add_label_from_comment.yml
+++ b/.github/workflows/add_label_from_comment.yml
@@ -64,7 +64,7 @@ jobs:
 
       - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         id: remove_request_review
-        name: Remove "request-review"
+        name: Remove "awaiting-review"
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the label doesn't exist
         run: |

--- a/.github/workflows/add_label_from_review.yml
+++ b/.github/workflows/add_label_from_review.yml
@@ -63,11 +63,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
-        id: remove_request_review
-        name: Remove "awaiting-review"
+        id: remove_labels
+        name: Remove "awaiting-review" and "awaiting-author"
         # we use curl rather than octokit/request-action so that the job won't fail
-        # (and send an annoying email) if the label doesn't exist
+        # (and send an annoying email) if the labels don't exist
         run: |
           curl --request DELETE \
-          --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/request-review \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-review \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+          curl --request DELETE \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-author \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/add_label_from_review.yml
+++ b/.github/workflows/add_label_from_review.yml
@@ -64,7 +64,7 @@ jobs:
 
       - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         id: remove_request_review
-        name: Remove "request-review"
+        name: Remove "awaiting-review"
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the label doesn't exist
         run: |

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = ["Build mathlib", "Lint mathlib", "Run tests"]
 use_squash_merge = true
 timeout_sec = 21600
-block_labels = ["not-ready-to-merge", "WIP", "changes-requested", "blocked-by-other-PR"]
+block_labels = ["not-ready-to-merge", "WIP", "blocked-by-other-PR"]
 delete_merged_branches = true
 cut_body_after = "---"


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
I took the liberty of removing `changes-requested` (now `awaiting-author`) from the list of labels that blocks bors. In practice this is kind of annoying and doesn't help much. But if anyone feels strongly we can revert.

cc @bryangingechen 