### PR TITLE
[Merged by Bors] - fix(scripts/mk_all): macOS compatibility fix

### DIFF
--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -8,7 +8,7 @@
 # Makes a mathlib/src/$directory/all.lean importing all files inside $directory.
 # If $directory is omitted, creates `mathlib/src/all.lean`.
 
-cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../src
+cd "$( dirname "${BASH_SOURCE[0]}" )"/../src
 if [[ $# = 1 ]]; then
   dir="$1"
 else


### PR DESCRIPTION
`readlink -f` doesn't work macOS unfortunately - there are alternatives but I think it's probably safe to remove it altogether? This assumes `mk_all.sh` isn't a symlink but I can't think of a reason why it should be - and `rm_all.sh` uses `dirname "${BASH_SOURCE[0]}"` directly 🙂 