### PR TITLE
[Merged by Bors] - feat(operator_norm): smul_right lemmas

### DIFF
--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -639,13 +639,6 @@ begin
       ... ≤ ∥smul_right c f∥ * ∥x∥ : le_op_norm _ _ } },
 end
 
-/-- Given `c : c : E →L[𝕜] 𝕜`, `c.smul_rightₗ` is the linear map from `F` to `E →L[𝕜] F`
-sending `f` to `λ e, c e • f`. See also `continuous_linear_map.smul_rightL`. -/
-def smul_rightₗ (c : E →L[𝕜] 𝕜) : F →ₗ[𝕜] (E →L[𝕜] F) :=
-{ to_fun := c.smul_right,
-  map_add' := λ x y, by { ext e, simp [smul_add] },
-  map_smul' := λ a x, by { ext e, simp [smul_comm] } }
-
 /-- Given `c : c : E →L[𝕜] 𝕜`, `c.smul_rightL` is the continuous linear map from `F` to `E →L[𝕜] F`
 sending `f` to `λ e, c e • f`. -/
 def smul_rightL (c : E →L[𝕜] 𝕜) : F →L[𝕜] (E →L[𝕜] F) :=

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -395,21 +395,26 @@ begin
     rw [dist_eq_norm, dist_eq_norm, ← f.map_sub, H] }
 end
 
-lemma homothety_norm [nontrivial E] (f : E →L[𝕜] F) {a : ℝ} (ha : 0 ≤ a) (hf : ∀x, ∥f x∥ = a * ∥x∥) :
+lemma homothety_norm [nontrivial E] (f : E →L[𝕜] F) {a : ℝ} (hf : ∀x, ∥f x∥ = a * ∥x∥) :
   ∥f∥ = a :=
 begin
+  obtain ⟨x, hx⟩ : ∃ (x : E), x ≠ 0 := exists_ne 0,
+  have ha : 0 ≤ a,
+  { apply nonneg_of_mul_nonneg_right,
+    rw ← hf x,
+    apply norm_nonneg,
+    exact norm_pos_iff.mpr hx },
   refine le_antisymm_iff.mpr ⟨_, _⟩,
   { exact continuous_linear_map.op_norm_le_bound f ha (λ y, le_of_eq (hf y)) },
   { rw continuous_linear_map.norm_def,
     apply real.lb_le_Inf _ continuous_linear_map.bounds_nonempty,
-    obtain ⟨x, hx⟩ : ∃ (x : E), x ≠ 0 := exists_ne 0,
     intros c h, rw mem_set_of_eq at h,
     apply (mul_le_mul_right (norm_pos_iff.mpr hx)).mp,
     rw ← hf x, exact h.2 x }
 end
 
 lemma to_span_singleton_norm (x : E) : ∥to_span_singleton 𝕜 x∥ = ∥x∥ :=
-homothety_norm _ (norm_nonneg x) (to_span_singleton_homothety 𝕜 x)
+homothety_norm _ (to_span_singleton_homothety 𝕜 x)
 
 variable (f)
 
@@ -650,7 +655,7 @@ by simp [continuous_linear_map.smul_rightL, continuous_linear_map.smul_rightₗ]
 
 @[simp] lemma norm_smul_rightL (c : E →L[𝕜] 𝕜) [nontrivial F] :
   ∥(c.smul_rightL : F →L[𝕜] (E →L[𝕜] F))∥ = ∥c∥ :=
-continuous_linear_map.homothety_norm _ (norm_nonneg _) c.norm_smul_right_apply
+continuous_linear_map.homothety_norm _ c.norm_smul_right_apply
 
 variables (𝕜 F)
 
@@ -878,7 +883,7 @@ lemma coord_norm (x : E) (h : x ≠ 0) : ∥coord 𝕜 x h∥ = ∥x∥⁻¹ :=
 begin
   have hx : 0 < ∥x∥ := (norm_pos_iff.mpr h),
   haveI : nontrivial (submodule.span 𝕜 ({x} : set E)) := submodule.nontrivial_span_singleton h,
-  exact continuous_linear_map.homothety_norm _ (le_of_lt (inv_pos.mpr hx))
+  exact continuous_linear_map.homothety_norm _
         (λ y, homothety_inverse _ hx _ (to_span_nonzero_singleton_homothety 𝕜 x h) _)
 end
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -402,7 +402,7 @@ begin
   { exact continuous_linear_map.op_norm_le_bound f ha (λ y, le_of_eq (hf y)) },
   { rw continuous_linear_map.norm_def,
     apply real.lb_le_Inf _ continuous_linear_map.bounds_nonempty,
-    cases dim_pos_iff_exists_ne_zero.mp (dim_pos : 0 < vector_space.dim 𝕜 E) with x hx,
+    obtain ⟨x, hx⟩ : ∃ (x : E), x ≠ 0 := exists_ne 0,
     intros c h, rw mem_set_of_eq at h,
     apply (mul_le_mul_right (norm_pos_iff.mpr hx)).mp,
     rw ← hf x, exact h.2 x }

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -395,24 +395,21 @@ begin
     rw [dist_eq_norm, dist_eq_norm, ← f.map_sub, H] }
 end
 
-lemma homothety_norm (hE : 0 < vector_space.dim 𝕜 E) (f : E →L[𝕜] F) {a : ℝ} (ha : 0 ≤ a) (hf : ∀x, ∥f x∥ = a * ∥x∥) :
+lemma homothety_norm [nontrivial E] (f : E →L[𝕜] F) {a : ℝ} (ha : 0 ≤ a) (hf : ∀x, ∥f x∥ = a * ∥x∥) :
   ∥f∥ = a :=
 begin
   refine le_antisymm_iff.mpr ⟨_, _⟩,
   { exact continuous_linear_map.op_norm_le_bound f ha (λ y, le_of_eq (hf y)) },
   { rw continuous_linear_map.norm_def,
     apply real.lb_le_Inf _ continuous_linear_map.bounds_nonempty,
-    cases dim_pos_iff_exists_ne_zero.mp hE with x hx,
+    cases dim_pos_iff_exists_ne_zero.mp (dim_pos : 0 < vector_space.dim 𝕜 E) with x hx,
     intros c h, rw mem_set_of_eq at h,
     apply (mul_le_mul_right (norm_pos_iff.mpr hx)).mp,
     rw ← hf x, exact h.2 x }
 end
 
 lemma to_span_singleton_norm (x : E) : ∥to_span_singleton 𝕜 x∥ = ∥x∥ :=
-begin
-  refine homothety_norm _ _ (norm_nonneg x) (to_span_singleton_homothety 𝕜 x),
-  rw dim_of_field, exact cardinal.zero_lt_one,
-end
+homothety_norm _ (norm_nonneg x) (to_span_singleton_homothety 𝕜 x)
 
 variable (f)
 
@@ -642,14 +639,14 @@ begin
       ... ≤ ∥smul_right c f∥ * ∥x∥ : le_op_norm _ _ } },
 end
 
-/-- Given `c : c : E →L[𝕜] 𝕜`, `c.smul_rightₗ` is the linear map from `F` to `(E →L[𝕜] F)`
-sending `f` to `λ e, c e • f`. -/
+/-- Given `c : c : E →L[𝕜] 𝕜`, `c.smul_rightₗ` is the linear map from `F` to `E →L[𝕜] F`
+sending `f` to `λ e, c e • f`. See also `continuous_linear_map.smul_rightL`. -/
 def smul_rightₗ (c : E →L[𝕜] 𝕜) : F →ₗ[𝕜] (E →L[𝕜] F) :=
 { to_fun := c.smul_right,
   map_add' := λ x y, by { ext e, simp [smul_add] },
   map_smul' := λ a x, by { ext e, simp [smul_comm] } }
 
-/-- Given `c : c : E →L[𝕜] 𝕜`, `c.smul_rightL` is the continuous linear map from `F` to `(E →L[𝕜] F)`
+/-- Given `c : c : E →L[𝕜] 𝕜`, `c.smul_rightL` is the continuous linear map from `F` to `E →L[𝕜] F`
 sending `f` to `λ e, c e • f`. -/
 def smul_rightL (c : E →L[𝕜] 𝕜) : F →L[𝕜] (E →L[𝕜] F) :=
 (c.smul_rightₗ : F →ₗ[𝕜] (E →L[𝕜] F)).mk_continuous _ (λ f, le_of_eq $ c.norm_smul_right_apply f)
@@ -658,9 +655,9 @@ def smul_rightL (c : E →L[𝕜] 𝕜) : F →L[𝕜] (E →L[𝕜] F) :=
   ∥c.smul_rightL f∥ = ∥c∥ * ∥f∥ :=
 by simp [continuous_linear_map.smul_rightL, continuous_linear_map.smul_rightₗ]
 
-@[simp] lemma norm_smul_right (c : E →L[𝕜] 𝕜) (hF : 0 < vector_space.dim 𝕜 F) :
+@[simp] lemma norm_smul_rightL (c : E →L[𝕜] 𝕜) [nontrivial F] :
   ∥(c.smul_rightL : F →L[𝕜] (E →L[𝕜] F))∥ = ∥c∥ :=
-continuous_linear_map.homothety_norm hF _ (norm_nonneg _) c.norm_smul_right_apply
+continuous_linear_map.homothety_norm _ (norm_nonneg _) c.norm_smul_right_apply
 
 variables (𝕜 F)
 
@@ -887,15 +884,9 @@ abbreviation coord (x : E) (h : x ≠ 0) : (submodule.span 𝕜 ({x} : set E)) �
 lemma coord_norm (x : E) (h : x ≠ 0) : ∥coord 𝕜 x h∥ = ∥x∥⁻¹ :=
 begin
   have hx : 0 < ∥x∥ := (norm_pos_iff.mpr h),
-  refine continuous_linear_map.homothety_norm _ _ (le_of_lt (inv_pos.mpr hx)) _,
-  { rw ← finite_dimensional.findim_eq_dim,
-    rw ← linear_equiv.findim_eq (linear_equiv.to_span_nonzero_singleton 𝕜 E x h),
-    rw finite_dimensional.findim_of_field,
-    have : 0 = ((0:nat) : cardinal) := rfl,
-    rw this, apply cardinal.nat_cast_lt.mpr, norm_num },
-  { intros y,
-    have : (coord 𝕜 x h) y = (to_span_nonzero_singleton 𝕜 x h).symm y := rfl,
-    rw this, apply homothety_inverse, exact hx, exact to_span_nonzero_singleton_homothety 𝕜 x h, }
+  haveI : nontrivial (submodule.span 𝕜 ({x} : set E)) := submodule.nontrivial_span_singleton h,
+  exact continuous_linear_map.homothety_norm _ (le_of_lt (inv_pos.mpr hx))
+        (λ y, homothety_inverse _ hx _ (to_span_nonzero_singleton_homothety 𝕜 x h) _)
 end
 
 lemma coord_self (x : E) (h : x ≠ 0) :

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -621,7 +621,7 @@ namespace continuous_linear_map
 
 /-- The norm of the tensor product of a scalar linear map and of an element of a normed space
 is the product of the norms. -/
-@[simp] lemma smul_right_norm {c : E →L[𝕜] 𝕜} {f : F} :
+@[simp] lemma norm_smul_right_apply (c : E →L[𝕜] 𝕜) (f : F) :
   ∥smul_right c f∥ = ∥c∥ * ∥f∥ :=
 begin
   refine le_antisymm _ _,
@@ -641,6 +641,48 @@ begin
       ... = ∥((smul_right c f) : E → F) x∥ : rfl
       ... ≤ ∥smul_right c f∥ * ∥x∥ : le_op_norm _ _ } },
 end
+
+/-- Given `c : c : E →L[𝕜] 𝕜`, `c.smul_rightₗ` is the linear map from `F` to `(E →L[𝕜] F)`
+sending `f` to `λ e, c e • f`. -/
+def smul_rightₗ (c : E →L[𝕜] 𝕜) : F →ₗ[𝕜] (E →L[𝕜] F) :=
+{ to_fun := c.smul_right,
+  map_add' := λ x y, by { ext e, simp [smul_add] },
+  map_smul' := λ a x, by { ext e, simp [smul_comm] } }
+
+/-- Given `c : c : E →L[𝕜] 𝕜`, `c.smul_rightL` is the continuous linear map from `F` to `(E →L[𝕜] F)`
+sending `f` to `λ e, c e • f`. -/
+def smul_rightL (c : E →L[𝕜] 𝕜) : F →L[𝕜] (E →L[𝕜] F) :=
+(c.smul_rightₗ : F →ₗ[𝕜] (E →L[𝕜] F)).mk_continuous _ (λ f, le_of_eq $ c.norm_smul_right_apply f)
+
+@[simp] lemma norm_smul_rightL_apply (c : E →L[𝕜] 𝕜) (f : F) :
+  ∥c.smul_rightL f∥ = ∥c∥ * ∥f∥ :=
+by simp [continuous_linear_map.smul_rightL, continuous_linear_map.smul_rightₗ]
+
+@[simp] lemma norm_smul_right (c : E →L[𝕜] 𝕜) (hF : 0 < vector_space.dim 𝕜 F) :
+  ∥(c.smul_rightL : F →L[𝕜] (E →L[𝕜] F))∥ = ∥c∥ :=
+continuous_linear_map.homothety_norm hF _ (norm_nonneg _) c.norm_smul_right_apply
+
+variables (𝕜 F)
+
+/-- The linear map obtained by applying a continuous linear map at a given vector. -/
+def applyₗ (v : E) : (E →L[𝕜] F) →ₗ[𝕜] F :=
+{ to_fun := λ f, f v,
+  map_add' := λ f g, f.add_apply g v,
+  map_smul' := λ x f, f.smul_apply x v }
+
+lemma continuous_applyₗ (v : E) : continuous (continuous_linear_map.applyₗ 𝕜 F v) :=
+begin
+  apply (continuous_linear_map.applyₗ 𝕜 F v).continuous_of_bound,
+  intro f,
+  rw mul_comm,
+  exact f.le_op_norm v,
+end
+
+/-- The continuous linear map obtained by applying a continuous linear map at a given vector. -/
+def apply (v : E) : (E →L[𝕜] F) →L[𝕜] F :=
+⟨continuous_linear_map.applyₗ 𝕜 F v, continuous_linear_map.continuous_applyₗ _ _ _⟩
+
+variables {𝕜 F}
 
 section multiplication_linear
 variables (𝕜) (𝕜' : Type*) [normed_ring 𝕜'] [normed_algebra 𝕜 𝕜']

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -821,6 +821,14 @@ end
 
 lemma mem_span_singleton_self (x : M) : x ∈ span R ({x} : set M) := subset_span rfl
 
+lemma nontrivial_span_singleton {x : M} (h : x ≠ 0) : nontrivial (submodule.span R ({x} : set M)) :=
+⟨begin
+    use [0, x, submodule.mem_span_singleton_self x],
+    intros H,
+    rw [eq_comm, submodule.mk_eq_zero] at H,
+    exact h H
+end⟩
+
 lemma mem_span_singleton {y : M} : x ∈ span R ({y} : set M) ↔ ∃ a:R, a • y = x :=
 ⟨λ h, begin
   apply span_induction h,

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -455,7 +455,7 @@ variables [topological_space R] [topological_semimodule R M₂]
 
 /-- The linear map `λ x, c x • f`.  Associates to a scalar-valued linear map and an element of
 `M₂` the `M₂`-valued linear map obtained by multiplying the two (a.k.a. tensoring by `M₂`).
-See also `continuous_linear_map.smul_rightₗ` and `continuous_linear_map.smul_rightL`..-/
+See also `continuous_linear_map.smul_rightₗ` and `continuous_linear_map.smul_rightL`. -/
 def smul_right (c : M →L[R] R) (f : M₂) : M →L[R] M₂ :=
 { cont := c.2.smul continuous_const,
   ..c.to_linear_map.smul_right f }
@@ -657,7 +657,7 @@ instance : module R (M →L[R] M₂) :=
 instance : algebra R (M₂ →L[R] M₂) :=
 algebra.of_semimodule' (λ c f, ext $ λ x, rfl) (λ c f, ext $ λ x, f.map_smul c x)
 
-/-- Given `c : c : E →L[𝕜] 𝕜`, `c.smul_rightₗ` is the linear map from `F` to `E →L[𝕜] F`
+/-- Given `c : E →L[𝕜] 𝕜`, `c.smul_rightₗ` is the linear map from `F` to `E →L[𝕜] F`
 sending `f` to `λ e, c e • f`. See also `continuous_linear_map.smul_rightL`. -/
 def smul_rightₗ (c : M →L[R] R) : M₂ →ₗ[R] (M →L[R] M₂) :=
 { to_fun := c.smul_right,

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -454,7 +454,8 @@ rfl
 variables [topological_space R] [topological_semimodule R M₂]
 
 /-- The linear map `λ x, c x • f`.  Associates to a scalar-valued linear map and an element of
-`M₂` the `M₂`-valued linear map obtained by multiplying the two (a.k.a. tensoring by `M₂`) -/
+`M₂` the `M₂`-valued linear map obtained by multiplying the two (a.k.a. tensoring by `M₂`).
+See also `continuous_linear_map.smul_rightₗ` and `continuous_linear_map.smul_rightL`..-/
 def smul_right (c : M →L[R] R) (f : M₂) : M →L[R] M₂ :=
 { cont := c.2.smul continuous_const,
   ..c.to_linear_map.smul_right f }

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -657,6 +657,13 @@ instance : module R (M →L[R] M₂) :=
 instance : algebra R (M₂ →L[R] M₂) :=
 algebra.of_semimodule' (λ c f, ext $ λ x, rfl) (λ c f, ext $ λ x, f.map_smul c x)
 
+/-- Given `c : c : E →L[𝕜] 𝕜`, `c.smul_rightₗ` is the linear map from `F` to `E →L[𝕜] F`
+sending `f` to `λ e, c e • f`. See also `continuous_linear_map.smul_rightL`. -/
+def smul_rightₗ (c : M →L[R] R) : M₂ →ₗ[R] (M →L[R] M₂) :=
+{ to_fun := c.smul_right,
+  map_add' := λ x y, by { ext e, simp [smul_add] },
+  map_smul' := λ a x, by { ext e, simp [smul_comm] } }
+
 end comm_ring
 
 end continuous_linear_map


### PR DESCRIPTION
from the sphere eversion project

We need a version of `continuous_linear_map.smul_right` that is itself a continuous linear map from a normed space to a space of continuous linear maps. 

breaking changes:
* rename `smul_right_norm` to `norm_smul_right_apply`
* in `homothety_norm` remove useless sign assumption and switch from assuming positive dimension to `nontrivial`

---
<!-- put comments you want to keep out of the PR commit here -->
