### PR TITLE
[Merged by Bors] - fix(simps): use coercion for algebra morphisms

### DIFF
--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -238,25 +238,16 @@ lemma findim_alg_hom (K : Type u) (V : Type v)
 fintype_card_le_findim_of_linear_independent $ linear_independent_to_linear_map K V
 
 namespace fixed_points
+-- `simps` needs to unfold these definitions to get the correct simp lemma for `to_alg_hom`.
+local attribute [simp] mul_semiring_action.to_semiring_hom distrib_mul_action.to_add_monoid_hom
 
 /-- Embedding produced from a faithful action. -/
+@[simps {simp_rhs := tt}, simps to_fun {fully_applied := ff}]
 def to_alg_hom (G : Type u) (F : Type v) [group G] [field F]
   [faithful_mul_semiring_action G F] : G ↪ (F →ₐ[fixed_points G F] F) :=
 { to_fun := λ g, { commutes' := λ x, x.2 g,
     .. mul_semiring_action.to_semiring_hom G F g },
   inj' := λ g₁ g₂ hg, injective_to_semiring_hom G F $ ring_hom.ext $ λ x, alg_hom.ext_iff.1 hg x, }
-
-@[simp] lemma coe_to_alg_hom (G : Type u) (F : Type v) [group G] [field F]
-  [faithful_mul_semiring_action G F] :
-  (to_alg_hom G F : G → F →ₐ[fixed_points G F] F) =
-    λ g, { commutes' := λ x, x.2 g,
-      .. mul_semiring_action.to_semiring_hom G F g } :=
-rfl
-
-lemma to_alg_hom_apply {G : Type u} {F : Type v} [group G] [field F]
-  [faithful_mul_semiring_action G F] (g : G) (x : F) :
-  to_alg_hom G F g x = g • x :=
-rfl
 
 theorem findim_eq_card (G : Type u) (F : Type v) [group G] [field F]
   [fintype G] [faithful_mul_semiring_action G F] :

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -238,16 +238,18 @@ lemma findim_alg_hom (K : Type u) (V : Type v)
 fintype_card_le_findim_of_linear_independent $ linear_independent_to_linear_map K V
 
 namespace fixed_points
--- `simps` needs to unfold these definitions to get the correct simp lemma for `to_alg_hom`.
-local attribute [simp] mul_semiring_action.to_semiring_hom distrib_mul_action.to_add_monoid_hom
-
 /-- Embedding produced from a faithful action. -/
-@[simps {simp_rhs := tt, attrs := []}, simps to_fun {fully_applied := ff}]
+@[simps to_fun {fully_applied := ff}]
 def to_alg_hom (G : Type u) (F : Type v) [group G] [field F]
   [faithful_mul_semiring_action G F] : G ↪ (F →ₐ[fixed_points G F] F) :=
 { to_fun := λ g, { commutes' := λ x, x.2 g,
     .. mul_semiring_action.to_semiring_hom G F g },
   inj' := λ g₁ g₂ hg, injective_to_semiring_hom G F $ ring_hom.ext $ λ x, alg_hom.ext_iff.1 hg x, }
+
+lemma to_alg_hom_apply {G : Type u} {F : Type v} [group G] [field F]
+  [faithful_mul_semiring_action G F] (g : G) (x : F) :
+  to_alg_hom G F g x = g • x :=
+rfl
 
 theorem findim_eq_card (G : Type u) (F : Type v) [group G] [field F]
   [fintype G] [faithful_mul_semiring_action G F] :

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -242,7 +242,7 @@ namespace fixed_points
 local attribute [simp] mul_semiring_action.to_semiring_hom distrib_mul_action.to_add_monoid_hom
 
 /-- Embedding produced from a faithful action. -/
-@[simps {simp_rhs := tt, atrrs := []}, simps to_fun {fully_applied := ff}]
+@[simps {simp_rhs := tt, attrs := []}, simps to_fun {fully_applied := ff}]
 def to_alg_hom (G : Type u) (F : Type v) [group G] [field F]
   [faithful_mul_semiring_action G F] : G ↪ (F →ₐ[fixed_points G F] F) :=
 { to_fun := λ g, { commutes' := λ x, x.2 g,

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -242,7 +242,7 @@ namespace fixed_points
 local attribute [simp] mul_semiring_action.to_semiring_hom distrib_mul_action.to_add_monoid_hom
 
 /-- Embedding produced from a faithful action. -/
-@[simps {simp_rhs := tt}, simps to_fun {fully_applied := ff}]
+@[simps {simp_rhs := tt, atrrs := []}, simps to_fun {fully_applied := ff}]
 def to_alg_hom (G : Type u) (F : Type v) [group G] [field F]
   [faithful_mul_semiring_action G F] : G ↪ (F →ₐ[fixed_points G F] F) :=
 { to_fun := λ g, { commutes' := λ x, x.2 g,

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -141,15 +141,15 @@ meta def simps_get_raw_projections (e : environment) (str : name) :
         (hyp, e_inst) ← try_for 1000 (mk_conditional_instance e_str e_inst_type),
         raw_expr ← mk_mapp proj_nm [args.head, e_inst],
         clear hyp,
-        raw_expr_lambda ← lambdas [hyp] raw_expr, -- expr.bind_lambda doesn't give the correct type
+        raw_expr_lambda ← lambdas [hyp] raw_expr, -- `expr.bind_lambda` doesn't give the correct type
         return (raw_expr, raw_expr_lambda.lambdas args))
       else (do
         e_inst_type ← to_expr ((expr.const class_nm []).app (pexpr.of_expr e_str)),
         e_inst ← try_for 1000 (mk_instance e_inst_type),
         raw_expr ← mk_mapp proj_nm [e_str, e_inst],
         return (raw_expr, raw_expr.lambdas args)),
-      raw_expr_whnf ← whnf raw_expr.binding_body,
-      let relevant_proj := raw_expr_whnf.get_app_fn.const_name,
+      raw_expr_whnf ← whnf raw_expr,
+      let relevant_proj := raw_expr_whnf.binding_body.get_app_fn.const_name,
       /- use this as projection, if the function reduces to a projection, and this projection has
         not been overrriden by the user. -/
       guard (projs.any (= relevant_proj) ∧ ¬ e.contains (str ++ `simps ++ relevant_proj.last)),

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -1,6 +1,6 @@
 import tactic.simps
 
-set_option trace.simps.verbose true
+-- set_option trace.simps.verbose true
 -- set_option trace.app_builder true
 
 open function tactic expr

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -1,6 +1,6 @@
 import tactic.simps
 
--- set_option trace.simps.verbose true
+set_option trace.simps.verbose true
 -- set_option trace.app_builder true
 
 open function tactic expr
@@ -497,8 +497,7 @@ run_cmd do e ← get_env, success_if_fail (simps_get_raw_projections e `faulty_m
 end failty_manual_coercion
 
 namespace manual_initialize
-/- defining a manual coercion. This should be made more easily. -/
-
+/- defining a manual coercion. -/
 variables {α β γ : Sort*}
 
 structure equiv (α : Sort*) (β : Sort*) :=
@@ -607,6 +606,7 @@ structure needs_prop_class (n : ℕ) [prop_class n] :=
 @[simps] def test_prop_class : needs_prop_class 1 :=
 { t := trivial }
 
+/- check that when the coercion is given in eta-expanded form, we can also find the coercion. -/
 structure alg_hom (R A B : Type*) :=
 (to_fun : A → B)
 

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -606,3 +606,23 @@ structure needs_prop_class (n : ℕ) [prop_class n] :=
 
 @[simps] def test_prop_class : needs_prop_class 1 :=
 { t := trivial }
+
+structure alg_hom (R A B : Type*) :=
+(to_fun : A → B)
+
+instance (R A B : Type*) : has_coe_to_fun (alg_hom R A B) := ⟨_, λ f, f.to_fun⟩
+
+@[simps] def my_alg_hom : alg_hom unit bool bool :=
+{ to_fun := id }
+
+example (x : bool) : my_alg_hom x = id x := by simp only [my_alg_hom_to_fun]
+
+structure ring_hom (A B : Type*) :=
+(to_fun : A → B)
+
+instance (A B : Type*) : has_coe_to_fun (ring_hom A B) := ⟨_, λ f, f.to_fun⟩
+
+@[simps] def my_ring_hom : ring_hom bool bool :=
+{ to_fun := id }
+
+example (x : bool) : my_ring_hom x = id x := by simp only [my_ring_hom_to_fun]


### PR DESCRIPTION
Previously it tried to apply whnf on an open expression, which failed, so it wouldn't find the coercion. Now it applied whnf before opening the expression.

Also use `simps` for `fixed_points.to_alg_hom`. The generated lemmas are
```lean
fixed_points.to_alg_hom_to_fun : ∀ (G : Type u) (F : Type v) [_inst_4 : group G] [_inst_5 : field F]
[_inst_6 : faithful_mul_semiring_action G F],
  ⇑(to_alg_hom G F) =
    λ (g : G),
      {to_fun := (mul_semiring_action.to_semiring_hom G F g).to_fun,
       map_one' := _,
       map_mul' := _,
       map_zero' := _,
       map_add' := _,
       commutes' := _}
```
---
<!-- put comments you want to keep out of the PR commit here -->

See https://github.com/leanprover-community/mathlib/pull/4125#discussion_r487682684

@jcommelin @kckennylau 
