### PR TITLE
Try to use composition to build add_con_gen from eqv_gen

### DIFF
--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -367,13 +367,14 @@ containing `r`."]
 theorem con_gen_eq (r : M → M → Prop) :
   con_gen r = Inf {s : con M | ∀ x y, r x y → s x y} :=
 le_antisymm
-  (λ x y H, con_gen.rel.rec
-    (λ _ _ h _ hs, hs _ _ h)
-    (con.refl _)
-    (λ _ _ _, con.symm _)
-    (λ _ _ _ _ _, con.trans _)
-    (λ w x y z _ _ h1 h2 c hc, c.mul (h1 c hc) $ h2 c hc)
-    H)
+  (λ x y H, by {
+    induction H,
+    case con_gen.rel.of : _ _ h {exact λ _ hs, hs _ _ h},
+    case con_gen.rel.refl : _ { exact con.refl _ _},
+    case con_gen.rel.symm : _ _ _ h { exact con.symm _ h },
+    case con_gen.rel.trans : _ _ _ _ _ ha hb { exact con.trans _ ha hb},
+    case con_gen.rel.mul : w x y z _ _ h1 h2 { exact λ c hc, c.mul (h1 c hc) $ h2 c hc},
+  })
   (Inf_le (λ _ _, con_gen.rel.of _ _))
 
 /-- The smallest congruence relation containing a binary relation `r` is contained in any

--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -367,9 +367,13 @@ containing `r`."]
 theorem con_gen_eq (r : M → M → Prop) :
   con_gen r = Inf {s : con M | ∀ x y, r x y → s x y} :=
 le_antisymm
-  (λ x y H, con_gen.rel.rec_on H (λ _ _ h _ hs, hs _ _ h) (con.refl _) (λ _ _ _, con.symm _)
+  (λ x y H, con_gen.rel.rec
+    (λ _ _ h _ hs, hs _ _ h)
+    (con.refl _)
+    (λ _ _ _, con.symm _)
     (λ _ _ _ _ _, con.trans _)
-    $ λ w x y z _ _ h1 h2 c hc, c.mul (h1 c hc) $ h2 c hc)
+    (λ w x y z _ _ h1 h2 c hc, c.mul (h1 c hc) $ h2 c hc)
+    H)
   (Inf_le (λ _ _, con_gen.rel.of _ _))
 
 /-- The smallest congruence relation containing a binary relation `r` is contained in any


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
This is in response to the comment in that file added in #1690,
```
The inductive definition of a congruence relation could be a nested inductive type, defined using
the equivalence closure of a binary relation `eqv_gen`, but the recursor generated does not work.
A nested inductive definition could conceivably shorten proofs, because they would allow invocation
of the corresponding lemmas about `eqv_gen`.
```

I'm not sure what exactly "the recursor generated does not work" means. Certainly, `add_con_gen.rec_on` no longer exists, presumably due to an inability to reorder dependent types. However, `add_con_gen.rec` is still around.
It seems at least plausible to me that this should be possible to work with, but I'm stuck on the `sorry` in this PR.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Nesting.20eqv_gen.20inside.20con_gen/near/210151159)