### PR TITLE
[Merged by Bors] - fix(conditionally_complete_lattice): add instance

### DIFF
--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -74,7 +74,7 @@ class conditionally_complete_linear_order (α : Type*)
   extends conditionally_complete_lattice α, decidable_linear_order α
 
 class conditionally_complete_linear_order_bot (α : Type*)
-  extends conditionally_complete_lattice α, decidable_linear_order α, order_bot α :=
+  extends conditionally_complete_linear_order α, order_bot α :=
 (cSup_empty : Sup ∅ = ⊥)
 
 /- A complete lattice is a conditionally complete lattice, as there are no restrictions


### PR DESCRIPTION
there was no instance from `conditionally_complete_linear_order_bot` to `conditionally_complete_linear_order`. It is added by this change.


---
<!-- put comments you want to keep out of the PR commit here -->
