### PR TITLE
[Merged by Bors] - feat(category_theory/internal): commutative monoid objects

### DIFF
--- a/src/category_theory/monad/equiv_mon.lean
+++ b/src/category_theory/monad/equiv_mon.lean
@@ -5,7 +5,7 @@ Authors: Adam Topaz
 -/
 import category_theory.monad.bundled
 import category_theory.monoidal.End
-import category_theory.monoidal.internal
+import category_theory.monoidal.Mon_
 import category_theory.category.Cat
 
 /-!

--- a/src/category_theory/monoidal/CommMon_.lean
+++ b/src/category_theory/monoidal/CommMon_.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2020 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import category_theory.monoidal.braided
+import category_theory.monoidal.Mon_
+
+/-!
+# The category of commutative monoids in a braided monoidal category.
+-/
+
+universes v₁ v₂ u₁ u₂
+
+open category_theory
+open category_theory.monoidal_category
+
+variables (C : Type u₁) [category.{v₁} C] [monoidal_category.{v₁} C] [braided_category.{v₁} C]
+
+/--
+A commutative monoid object internal to a monoidal category.
+-/
+structure CommMon_ extends Mon_ C :=
+(mul_comm' : (β_ _ _).hom ≫ mul = mul . obviously)
+
+restate_axiom CommMon_.mul_comm'
+attribute [simp, reassoc] CommMon_.mul_comm
+
+namespace CommMon_
+
+/--
+The trivial commutative monoid object. We later show this is initial in `CommMon_ C`.
+-/
+@[simps]
+def trivial : CommMon_ C :=
+{ mul_comm' := begin dsimp, rw [braiding_left_unitor, unitors_equal], end
+  ..Mon_.trivial C }
+
+instance : inhabited (CommMon_ C) := ⟨trivial C⟩
+
+variables {C} {M : CommMon_ C}
+
+instance : category (CommMon_ C) :=
+induced_category.category CommMon_.to_Mon_
+
+@[simp] lemma id_hom (A : CommMon_ C) : Mon_.hom.hom (𝟙 A) = 𝟙 A.X := rfl
+@[simp] lemma comp_hom {R S T : CommMon_ C} (f : R ⟶ S) (g : S ⟶ T) :
+  Mon_.hom.hom (f ≫ g) = f.hom ≫ g.hom := rfl
+
+section
+variables (C)
+
+/-- The forgetful functor from commutative monoid objects to monoid objects. -/
+@[derive [full, faithful]]
+def forget₂_Mon_ : CommMon_ C ⥤ Mon_ C :=
+induced_functor CommMon_.to_Mon_
+
+end
+
+instance unique_hom_from_trivial (A : CommMon_ C) : unique (trivial C ⟶ A) :=
+Mon_.unique_hom_from_trivial A.to_Mon_
+
+open category_theory.limits
+
+instance : has_initial (CommMon_ C) :=
+has_initial_of_unique (trivial C)
+
+end CommMon_
+
+namespace category_theory.lax_braided_functor
+
+variables {C} {D : Type u₂} [category.{v₂} D] [monoidal_category.{v₂} D] [braided_category.{v₂} D]
+
+/--
+A lax braided functor takes commutative monoid objects to commutative monoid objects.
+
+That is, a lax braided functor `F : C ⥤ D` induces a functor `CommMon_ C ⥤ CommMon_ D`.
+-/
+@[simps]
+def map_CommMon (F : lax_braided_functor C D) : CommMon_ C ⥤ CommMon_ D :=
+{ obj := λ A,
+  { mul_comm' :=
+    begin
+      dsimp,
+      have := F.braided,
+      slice_lhs 1 2 { rw ←this, },
+      slice_lhs 2 3 { rw [←category_theory.functor.map_comp, A.mul_comm], },
+    end,
+    ..F.to_lax_monoidal_functor.map_Mon.obj A.to_Mon_ },
+  map := λ A B f, F.to_lax_monoidal_functor.map_Mon.map f, }
+
+variables (C) (D)
+
+/-- `map_CommMon` is functorial in the lax braided functor. -/
+def map_CommMon_functor : (lax_braided_functor C D) ⥤ (CommMon_ C ⥤ CommMon_ D) :=
+{ obj := map_CommMon,
+  map := λ F G α,
+  { app := λ A,
+    { hom := α.app A.X, } } }
+
+end category_theory.lax_braided_functor
+
+namespace CommMon_
+
+open category_theory.lax_braided_functor
+
+namespace equiv_lax_braided_functor_punit
+
+/-- Implementation of `CommMon_.equiv_lax_braided_functor_punit`. -/
+@[simps]
+def lax_braided_to_CommMon : lax_braided_functor (discrete punit) C ⥤ CommMon_ C :=
+{ obj := λ F, (F.map_CommMon : CommMon_ _ ⥤ CommMon_ C).obj (trivial (discrete punit)),
+  map := λ F G α, ((map_CommMon_functor (discrete punit) C).map α).app _ }
+
+/-- Implementation of `CommMon_.equiv_lax_braided_functor_punit`. -/
+@[simps]
+def CommMon_to_lax_braided : CommMon_ C ⥤ lax_braided_functor (discrete punit) C :=
+{ obj := λ A,
+  { obj := λ _, A.X,
+    map := λ _ _ _, 𝟙 _,
+    ε := A.one,
+    μ := λ _ _, A.mul,
+    map_id' := λ _, rfl,
+    map_comp' := λ _ _ _ _ _, (category.id_comp (𝟙 A.X)).symm, },
+  map := λ A B f,
+  { app := λ _, f.hom,
+    naturality' := λ _ _ _, by { dsimp, rw [category.id_comp, category.comp_id], },
+    unit' := f.one_hom,
+    tensor' := λ _ _, f.mul_hom, }, }
+
+/-- Implementation of `CommMon_.equiv_lax_braided_functor_punit`. -/
+@[simps {rhs_md:=semireducible}]
+def unit_iso :
+  𝟭 (lax_braided_functor (discrete punit) C) ≅ lax_braided_to_CommMon C ⋙ CommMon_to_lax_braided C :=
+nat_iso.of_components (λ F, lax_braided_functor.mk_iso
+  (monoidal_nat_iso.of_components
+    (λ _, F.to_lax_monoidal_functor.to_functor.map_iso (eq_to_iso (by ext)))
+    (by tidy) (by tidy) (by tidy)))
+  sorry
+
+/-- Implementation of `CommMon_.equiv_lax_braided_functor_punit`. -/
+@[simps {rhs_md:=semireducible}]
+def counit_iso : CommMon_to_lax_braided C ⋙ lax_braided_to_CommMon C ≅ 𝟭 (CommMon_ C) :=
+nat_iso.of_components (λ F, { hom := { hom := 𝟙 _, }, inv := { hom := 𝟙 _, } })
+  (by tidy)
+
+end equiv_lax_braided_functor_punit
+
+open equiv_lax_braided_functor_punit
+
+/--
+Commutative monoid objects in `C` are "just" braided lax monoidal functors from the trivial
+braided monoidal category to `C`.
+-/
+@[simps]
+def equiv_lax_braided_functor_punit : lax_braided_functor (discrete punit) C ≌ CommMon_ C :=
+{ functor := lax_braided_to_CommMon C,
+  inverse := CommMon_to_lax_braided C,
+  unit_iso := unit_iso C,
+  counit_iso := counit_iso C, }
+
+end CommMon_

--- a/src/category_theory/monoidal/CommMon_.lean
+++ b/src/category_theory/monoidal/CommMon_.lean
@@ -55,6 +55,11 @@ variables (C)
 def forget₂_Mon_ : CommMon_ C ⥤ Mon_ C :=
 induced_functor CommMon_.to_Mon_
 
+@[simp] lemma forget₂_Mon_obj_one (A : CommMon_ C) : ((forget₂_Mon_ C).obj A).one = A.one := rfl
+@[simp] lemma forget₂_Mon_obj_mul (A : CommMon_ C) : ((forget₂_Mon_ C).obj A).mul = A.mul := rfl
+@[simp] lemma forget₂_Mon_map_hom {A B : CommMon_ C} (f : A ⟶ B) :
+  ((forget₂_Mon_ C).map f).hom = f.hom := rfl
+
 end
 
 instance unique_hom_from_trivial (A : CommMon_ C) : unique (trivial C ⟶ A) :=

--- a/src/category_theory/monoidal/CommMon_.lean
+++ b/src/category_theory/monoidal/CommMon_.lean
@@ -136,7 +136,7 @@ nat_iso.of_components (λ F, lax_braided_functor.mk_iso
   (monoidal_nat_iso.of_components
     (λ _, F.to_lax_monoidal_functor.to_functor.map_iso (eq_to_iso (by ext)))
     (by tidy) (by tidy) (by tidy)))
-  sorry
+  (by tidy)
 
 /-- Implementation of `CommMon_.equiv_lax_braided_functor_punit`. -/
 @[simps {rhs_md:=semireducible}]

--- a/src/category_theory/monoidal/Mod.lean
+++ b/src/category_theory/monoidal/Mod.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2020 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import category_theory.monoidal.Mon_
+
+/-!
+# The category of module objects over a monoid object.
+-/
+
+universes v₁ v₂ u₁ u₂
+
+open category_theory
+open category_theory.monoidal_category
+
+variables (C : Type u₁) [category.{v₁} C] [monoidal_category.{v₁} C]
+
+variables {C}
+
+/-- A module object for a monoid object, all internal to some monoidal category. -/
+structure Mod (A : Mon_ C) :=
+(X : C)
+(act : A.X ⊗ X ⟶ X)
+(one_act' : (A.one ⊗ 𝟙 X) ≫ act = (λ_ X).hom . obviously)
+(assoc' : (A.mul ⊗ 𝟙 X) ≫ act = (α_ A.X A.X X).hom ≫ (𝟙 A.X ⊗ act) ≫ act . obviously)
+
+restate_axiom Mod.one_act'
+restate_axiom Mod.assoc'
+attribute [simp, reassoc] Mod.one_act Mod.assoc
+
+namespace Mod
+
+variables {A : Mon_ C} (M : Mod A)
+
+lemma assoc_flip : (𝟙 A.X ⊗ M.act) ≫ M.act = (α_ A.X A.X M.X).inv ≫ (A.mul ⊗ 𝟙 M.X) ≫ M.act :=
+by simp
+
+/-- A morphism of module objects. -/
+@[ext]
+structure hom (M N : Mod A) :=
+(hom : M.X ⟶ N.X)
+(act_hom' : M.act ≫ hom = (𝟙 A.X ⊗ hom) ≫ N.act . obviously)
+
+restate_axiom hom.act_hom'
+attribute [simp, reassoc] hom.act_hom
+
+/-- The identity morphism on a module object. -/
+@[simps]
+def id (M : Mod A) : hom M M :=
+{ hom := 𝟙 M.X, }
+
+instance hom_inhabited (M : Mod A) : inhabited (hom M M) := ⟨id M⟩
+
+/-- Composition of module object morphisms. -/
+@[simps]
+def comp {M N O : Mod A} (f : hom M N) (g : hom N O) : hom M O :=
+{ hom := f.hom ≫ g.hom, }
+
+instance : category (Mod A) :=
+{ hom := λ M N, hom M N,
+  id := id,
+  comp := λ M N O f g, comp f g, }
+
+@[simp] lemma id_hom' (M : Mod A) : (𝟙 M : hom M M).hom = 𝟙 M.X := rfl
+@[simp] lemma comp_hom' {M N K : Mod A} (f : M ⟶ N) (g : N ⟶ K) :
+  (f ≫ g : hom M K).hom = f.hom ≫ g.hom := rfl
+
+variables (A)
+
+/-- A monoid object as a module over itself. -/
+@[simps]
+def regular : Mod A :=
+{ X := A.X,
+  act := A.mul, }
+
+instance : inhabited (Mod A) := ⟨regular A⟩
+
+/-- The forgetful functor from module objects to the ambient category. -/
+def forget : Mod A ⥤ C :=
+{ obj := λ A, A.X,
+  map := λ A B f, f.hom, }
+
+open category_theory.monoidal_category
+
+/--
+A morphism of monoid objects induces a "restriction" or "comap" functor
+between the categories of module objects.
+-/
+@[simps]
+def comap {A B : Mon_ C} (f : A ⟶ B) : Mod B ⥤ Mod A :=
+{ obj := λ M,
+  { X := M.X,
+    act := (f.hom ⊗ 𝟙 M.X) ≫ M.act,
+    one_act' :=
+    begin
+      slice_lhs 1 2 { rw [←comp_tensor_id], },
+      rw [f.one_hom, one_act],
+    end,
+    assoc' :=
+    begin
+      -- oh, for homotopy.io in a widget!
+      slice_rhs 2 3 { rw [id_tensor_comp_tensor_id, ←tensor_id_comp_id_tensor], },
+      rw id_tensor_comp,
+      slice_rhs 4 5 { rw Mod.assoc_flip, },
+      slice_rhs 3 4 { rw associator_inv_naturality, },
+      slice_rhs 2 3 { rw [←tensor_id, associator_inv_naturality], },
+      slice_rhs 1 3 { rw [iso.hom_inv_id_assoc], },
+      slice_rhs 1 2 { rw [←comp_tensor_id, tensor_id_comp_id_tensor], },
+      slice_rhs 1 2 { rw [←comp_tensor_id, ←f.mul_hom], },
+      rw [comp_tensor_id, category.assoc],
+    end, },
+  map := λ M N g,
+  { hom := g.hom,
+    act_hom' :=
+    begin
+      dsimp,
+      slice_rhs 1 2 { rw [id_tensor_comp_tensor_id, ←tensor_id_comp_id_tensor], },
+      slice_rhs 2 3 { rw ←g.act_hom, },
+      rw category.assoc,
+    end }, }
+
+-- Lots more could be said about `comap`, e.g. how it interacts with
+-- identities, compositions, and equalities of monoid object morphisms.
+
+end Mod

--- a/src/category_theory/monoidal/Mon_.lean
+++ b/src/category_theory/monoidal/Mon_.lean
@@ -9,7 +9,7 @@ import category_theory.limits.shapes.terminal
 import algebra.punit_instances
 
 /-!
-# The category of monoids in a monoidal category, and modules over an internal monoid.
+# The category of monoids in a monoidal category.
 -/
 
 universes v₁ v₂ u₁ u₂
@@ -269,115 +269,6 @@ def equiv_lax_monoidal_functor_punit : lax_monoidal_functor (discrete punit) C �
   counit_iso := counit_iso C, }
 
 end Mon_
-
-variables {C}
-
-/-- A module object for a monoid object, all internal to some monoidal category. -/
-structure Mod (A : Mon_ C) :=
-(X : C)
-(act : A.X ⊗ X ⟶ X)
-(one_act' : (A.one ⊗ 𝟙 X) ≫ act = (λ_ X).hom . obviously)
-(assoc' : (A.mul ⊗ 𝟙 X) ≫ act = (α_ A.X A.X X).hom ≫ (𝟙 A.X ⊗ act) ≫ act . obviously)
-
-restate_axiom Mod.one_act'
-restate_axiom Mod.assoc'
-attribute [simp, reassoc] Mod.one_act Mod.assoc
-
-namespace Mod
-
-variables {A : Mon_ C} (M : Mod A)
-
-lemma assoc_flip : (𝟙 A.X ⊗ M.act) ≫ M.act = (α_ A.X A.X M.X).inv ≫ (A.mul ⊗ 𝟙 M.X) ≫ M.act :=
-by simp
-
-/-- A morphism of module objects. -/
-@[ext]
-structure hom (M N : Mod A) :=
-(hom : M.X ⟶ N.X)
-(act_hom' : M.act ≫ hom = (𝟙 A.X ⊗ hom) ≫ N.act . obviously)
-
-restate_axiom hom.act_hom'
-attribute [simp, reassoc] hom.act_hom
-
-/-- The identity morphism on a module object. -/
-@[simps]
-def id (M : Mod A) : hom M M :=
-{ hom := 𝟙 M.X, }
-
-instance hom_inhabited (M : Mod A) : inhabited (hom M M) := ⟨id M⟩
-
-/-- Composition of module object morphisms. -/
-@[simps]
-def comp {M N O : Mod A} (f : hom M N) (g : hom N O) : hom M O :=
-{ hom := f.hom ≫ g.hom, }
-
-instance : category (Mod A) :=
-{ hom := λ M N, hom M N,
-  id := id,
-  comp := λ M N O f g, comp f g, }
-
-@[simp] lemma id_hom' (M : Mod A) : (𝟙 M : hom M M).hom = 𝟙 M.X := rfl
-@[simp] lemma comp_hom' {M N K : Mod A} (f : M ⟶ N) (g : N ⟶ K) :
-  (f ≫ g : hom M K).hom = f.hom ≫ g.hom := rfl
-
-variables (A)
-
-/-- A monoid object as a module over itself. -/
-@[simps]
-def regular : Mod A :=
-{ X := A.X,
-  act := A.mul, }
-
-instance : inhabited (Mod A) := ⟨regular A⟩
-
-/-- The forgetful functor from module objects to the ambient category. -/
-def forget : Mod A ⥤ C :=
-{ obj := λ A, A.X,
-  map := λ A B f, f.hom, }
-
-open category_theory.monoidal_category
-
-/--
-A morphism of monoid objects induces a "restriction" or "comap" functor
-between the categories of module objects.
--/
-@[simps]
-def comap {A B : Mon_ C} (f : A ⟶ B) : Mod B ⥤ Mod A :=
-{ obj := λ M,
-  { X := M.X,
-    act := (f.hom ⊗ 𝟙 M.X) ≫ M.act,
-    one_act' :=
-    begin
-      slice_lhs 1 2 { rw [←comp_tensor_id], },
-      rw [f.one_hom, one_act],
-    end,
-    assoc' :=
-    begin
-      -- oh, for homotopy.io in a widget!
-      slice_rhs 2 3 { rw [id_tensor_comp_tensor_id, ←tensor_id_comp_id_tensor], },
-      rw id_tensor_comp,
-      slice_rhs 4 5 { rw Mod.assoc_flip, },
-      slice_rhs 3 4 { rw associator_inv_naturality, },
-      slice_rhs 2 3 { rw [←tensor_id, associator_inv_naturality], },
-      slice_rhs 1 3 { rw [iso.hom_inv_id_assoc], },
-      slice_rhs 1 2 { rw [←comp_tensor_id, tensor_id_comp_id_tensor], },
-      slice_rhs 1 2 { rw [←comp_tensor_id, ←f.mul_hom], },
-      rw [comp_tensor_id, category.assoc],
-    end, },
-  map := λ M N g,
-  { hom := g.hom,
-    act_hom' :=
-    begin
-      dsimp,
-      slice_rhs 1 2 { rw [id_tensor_comp_tensor_id, ←tensor_id_comp_id_tensor], },
-      slice_rhs 2 3 { rw ←g.act_hom, },
-      rw category.assoc,
-    end }, }
-
--- Lots more could be said about `comap`, e.g. how it interacts with
--- identities, compositions, and equalities of monoid object morphisms.
-
-end Mod
 
 /-!
 Projects:

--- a/src/category_theory/monoidal/Mon_.lean
+++ b/src/category_theory/monoidal/Mon_.lean
@@ -123,7 +123,7 @@ instance : reflects_isomorphisms (forget C) :=
           is_iso.inv_hom_id, tensor_id, category.id_comp],
       end } } }
 
-instance (A : Mon_ C) : unique (trivial C ⟶ A) :=
+instance unique_hom_from_trivial (A : Mon_ C) : unique (trivial C ⟶ A) :=
 { default :=
   { hom := A.one,
     one_hom' := by { dsimp, simp, },

--- a/src/category_theory/monoidal/braided.lean
+++ b/src/category_theory/monoidal/braided.lean
@@ -3,7 +3,8 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.monoidal.functor
+import category_theory.monoidal.natural_transformation
+import category_theory.monoidal.discrete
 
 /-!
 # Braided and symmetric monoidal categories
@@ -103,6 +104,7 @@ calc ((β_ X (𝟙_ C)).hom ⊗ (𝟙 (𝟙_ C))) ≫ ((λ_ X).hom ⊗ (𝟙 (�
 ... = (ρ_ X).hom ⊗ (𝟙 (𝟙_ C))
          : by rw triangle
 
+@[simp]
 lemma braiding_left_unitor (X : C) : (β_ X (𝟙_ C)).hom ≫ (λ_ X).hom = (ρ_ X).hom :=
 by rw [←tensor_right_iff, comp_tensor_id, braiding_left_unitor_aux₂]
 
@@ -131,6 +133,7 @@ calc ((𝟙 (𝟙_ C)) ⊗ (β_ (𝟙_ C) X).hom) ≫ ((𝟙 (𝟙_ C)) ⊗ (ρ_
 ... = (𝟙 (𝟙_ C)) ⊗ (λ_ X).hom
          : by rw [triangle_assoc_comp_right]
 
+@[simp]
 lemma braiding_right_unitor (X : C) : (β_ (𝟙_ C) X).hom ≫ (ρ_ X).hom = (λ_ X).hom :=
 by rw [←tensor_left_iff, id_tensor_comp, braiding_right_unitor_aux₂]
 
@@ -154,25 +157,79 @@ variables (D : Type u₂) [category.{v₂} D] [monoidal_category D] [braided_cat
 variables (E : Type u₃) [category.{v₃} E] [monoidal_category E] [braided_category E]
 
 /--
+A lax braided functor between braided monoidal categories is a lax monoidal functor
+which preserves the braiding.
+-/
+structure lax_braided_functor extends lax_monoidal_functor C D :=
+(braided' : ∀ X Y : C, μ X Y ≫ map (β_ X Y).hom = (β_ (obj X) (obj Y)).hom ≫ μ Y X . obviously)
+
+restate_axiom lax_braided_functor.braided'
+
+namespace lax_braided_functor
+
+/-- The identity lax braided monoidal functor. -/
+@[simps] def id : lax_braided_functor C C :=
+{ .. monoidal_functor.id C }
+
+instance : inhabited (lax_braided_functor C C) := ⟨id C⟩
+
+variables {C D E}
+
+/-- The composition of lax braided monoidal functors. -/
+@[simps]
+def comp (F : lax_braided_functor C D) (G : lax_braided_functor D E) : lax_braided_functor C E :=
+{ braided' := λ X Y,
+  begin
+    dsimp,
+    slice_lhs 2 3 { rw [←category_theory.functor.map_comp, F.braided,
+      category_theory.functor.map_comp], },
+    slice_lhs 1 2 { rw [G.braided], },
+    simp only [category.assoc],
+  end,
+  ..(lax_monoidal_functor.comp F.to_lax_monoidal_functor G.to_lax_monoidal_functor) }
+
+instance category_lax_braided_functor : category (lax_braided_functor C D) :=
+induced_category.category lax_braided_functor.to_lax_monoidal_functor
+
+@[simp] lemma comp_to_nat_trans {F G H : lax_braided_functor C D} {α : F ⟶ G} {β : G ⟶ H} :
+  (α ≫ β).to_nat_trans =
+    @category_struct.comp (C ⥤ D) _ _ _ _ (α.to_nat_trans) (β.to_nat_trans) := rfl
+
+/--
+Interpret a natural isomorphism of the underlyling lax monoidal functors as an
+isomorphism of the lax braided monoidal functors.
+-/
+@[simps]
+def mk_iso {F G : lax_braided_functor C D}
+  (i : F.to_lax_monoidal_functor ≅ G.to_lax_monoidal_functor) : F ≅ G :=
+{ ..i }
+
+end lax_braided_functor
+
+/--
 A braided functor between braided monoidal categories is a monoidal functor
 which preserves the braiding.
 -/
 structure braided_functor extends monoidal_functor C D :=
+-- Note this is stated different than for `lax_braided_functor`.
+-- We move the `μ X Y` to the right hand side,
+-- so that this makes a good `@[simp]` lemma.
 (braided' : ∀ X Y : C, map (β_ X Y).hom = inv (μ X Y) ≫ (β_ (obj X) (obj Y)).hom ≫ μ Y X . obviously)
 
 restate_axiom braided_functor.braided'
--- It's not totally clear that `braided` deserves to be a `simp` lemma.
--- The principle being applied here is that `μ` "doesn't weigh much"
--- (similar to all the structural morphisms, e.g. associators and unitors)
--- and the `simp` normal form is determined by preferring `obj` over `map`.
 attribute [simp] braided_functor.braided
 
 namespace braided_functor
 
+/-- Turn a braided functor into a lax braided functor. -/
+@[simps]
+def to_lax_braided_functor (F : braided_functor C D) : lax_braided_functor C D :=
+{ braided' := λ X Y, by { rw F.braided, simp, }
+  .. F }
+
 /-- The identity braided monoidal functor. -/
 @[simps] def id : braided_functor C C :=
-{ braided' := λ X Y, by { dsimp, simp, },
-  .. monoidal_functor.id C }
+{ .. monoidal_functor.id C }
 
 instance : inhabited (braided_functor C C) := ⟨id C⟩
 
@@ -181,9 +238,46 @@ variables {C D E}
 /-- The composition of braided monoidal functors. -/
 @[simps]
 def comp (F : braided_functor C D) (G : braided_functor D E) : braided_functor C E :=
-{ braided' := λ X Y, by { dsimp, simp, },
-  ..(monoidal_functor.comp F.to_monoidal_functor G.to_monoidal_functor) }
+{ ..(monoidal_functor.comp F.to_monoidal_functor G.to_monoidal_functor) }
+
+instance category_braided_functor : category (braided_functor C D) :=
+induced_category.category braided_functor.to_monoidal_functor
+
+@[simp] lemma comp_to_nat_trans {F G H : braided_functor C D} {α : F ⟶ G} {β : G ⟶ H} :
+  (α ≫ β).to_nat_trans =
+    @category_struct.comp (C ⥤ D) _ _ _ _ (α.to_nat_trans) (β.to_nat_trans) := rfl
+
+/--
+Interpret a natural isomorphism of the underlyling monoidal functors as an
+isomorphism of the braided monoidal functors.
+-/
+@[simps]
+def mk_iso {F G : braided_functor C D}
+  (i : F.to_monoidal_functor ≅ G.to_monoidal_functor) : F ≅ G :=
+{ ..i }
+
 
 end braided_functor
+
+section comm_monoid
+
+variables (M : Type u) [comm_monoid M]
+
+instance comm_monoid_discrete : comm_monoid (discrete M) := by { dsimp [discrete], apply_instance }
+
+instance : braided_category (discrete M) :=
+{ braiding := λ X Y, eq_to_iso (mul_comm X Y), }
+
+variables {M} {N : Type u} [comm_monoid N]
+
+/--
+A multiplicative morphism between commutative monoids gives a braided functor between
+the corresponding discrete braided monoidal categories.
+-/
+@[simps]
+def discrete.braided_functor (F : M →* N) : braided_functor (discrete M) (discrete N) :=
+{ ..discrete.monoidal_functor F }
+
+end comm_monoid
 
 end category_theory

--- a/src/category_theory/monoidal/discrete.lean
+++ b/src/category_theory/monoidal/discrete.lean
@@ -39,6 +39,7 @@ variables {M} {N : Type u} [monoid N]
 A multiplicative morphism between monoids gives a monoidal functor between the corresponding
 discrete monoidal categories.
 -/
+@[simps]
 def discrete.monoidal_functor (F : M →* N) : monoidal_functor (discrete M) (discrete N) :=
 { obj := F,
   map := λ X Y f, eq_to_hom (F.congr_arg (eq_of_hom f)),

--- a/src/category_theory/monoidal/functor_category.lean
+++ b/src/category_theory/monoidal/functor_category.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.monoidal.category
+import category_theory.monoidal.braided
 import category_theory.functor_category
 import category_theory.const
 
@@ -122,5 +122,38 @@ lemma associator_hom_app {F G H : C ⥤ D} {X} :
 lemma associator_inv_app {F G H : C ⥤ D} {X} :
   ((α_ F G H).inv : F ⊗ (G ⊗ H) ⟶ (F ⊗ G) ⊗ H).app X = (α_ (F.obj X) (G.obj X) (H.obj X)).inv := rfl
 
+section braided_category
+
+open category_theory.braided_category
+variables [braided_category.{v₂} D]
+
+/--
+When `C` is any category, and `D` is a braided monoidal category,
+the natural pointwise monoidal structure on the functor category `C ⥤ D`
+is also braided.
+-/
+instance functor_category_braided : braided_category (C ⥤ D) :=
+{ braiding := λ F G, nat_iso.of_components (λ X, β_ _ _) (by tidy),
+  hexagon_forward' := λ F G H, by { ext X, apply hexagon_forward, },
+  hexagon_reverse' := λ F G H, by { ext X, apply hexagon_reverse, }, }
+
+example : braided_category (C ⥤ D) := category_theory.monoidal.functor_category_braided
+
+end braided_category
+
+section symmetric_category
+
+open category_theory.symmetric_category
+variables [symmetric_category.{v₂} D]
+
+/--
+When `C` is any category, and `D` is a symmetric monoidal category,
+the natural pointwise monoidal structure on the functor category `C ⥤ D`
+is also symmetric.
+-/
+instance functor_category_symmetric : symmetric_category (C ⥤ D) :=
+{ symmetry' := λ F G, by { ext X, apply symmetry, },}
+
+end symmetric_category
 
 end category_theory.monoidal

--- a/src/category_theory/monoidal/internal/Module.lean
+++ b/src/category_theory/monoidal/internal/Module.lean
@@ -5,7 +5,7 @@ Authors: Scott Morrison
 -/
 import algebra.category.Module.monoidal
 import algebra.category.Algebra.basic
-import category_theory.monoidal.internal
+import category_theory.monoidal.Mon_
 
 
 /-!

--- a/src/category_theory/monoidal/internal/functor_category.lean
+++ b/src/category_theory/monoidal/internal/functor_category.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.monoidal.internal
+import category_theory.monoidal.Mon_
 import category_theory.monoidal.functor_category
 
 /-!

--- a/src/category_theory/monoidal/internal/functor_category.lean
+++ b/src/category_theory/monoidal/internal/functor_category.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.monoidal.Mon_
+import category_theory.monoidal.CommMon_
 import category_theory.monoidal.functor_category
 
 /-!
@@ -32,10 +32,12 @@ open category_theory.monoidal_category
 
 namespace category_theory.monoidal
 
-variables {C : Type u₁} [category.{v₁} C]
-variables {D : Type u₂} [category.{v₂} D] [monoidal_category.{v₂} D]
+variables (C : Type u₁) [category.{v₁} C]
+variables (D : Type u₂) [category.{v₂} D] [monoidal_category.{v₂} D]
 
 namespace Mon_functor_category_equivalence
+
+variables {C D}
 
 /--
 Functor translating a monoid object in a functor category
@@ -95,13 +97,18 @@ def unit_iso : 𝟭 (Mon_ (C ⥤ D)) ≅ functor ⋙ inverse :=
 nat_iso.of_components (λ A,
   { hom :=
     { hom := { app := λ _, 𝟙 _ },
-      one_hom' := by { ext X, dsimp, simp, },
-      mul_hom' := by { ext X, dsimp, simp, }, },
+      one_hom' := by { ext X, dsimp, simp only [category.comp_id], },
+      mul_hom' := by { ext X, dsimp, simp only [tensor_id, category.id_comp, category.comp_id], }, },
     inv :=
     { hom := { app := λ _, 𝟙 _ },
-      one_hom' := by { ext X, dsimp, simp, },
-      mul_hom' := by { ext X, dsimp, simp, }, }, })
-  (by tidy)
+      one_hom' := by { ext X, dsimp, simp only [category.comp_id], },
+      mul_hom' := by { ext X, dsimp, simp only [tensor_id, category.id_comp, category.comp_id], }, }, })
+  (λ A B f,
+  begin
+    ext X,
+    simp only [functor.id_map, functor.comp_map, functor_map_app_hom, Mon_.comp_hom',
+      category.id_comp, category.comp_id, inverse_map_hom_app, nat_trans.comp_app],
+  end)
 
 /--
 The counit for the equivalence `Mon_ (C ⥤ D) ≌ C ⥤ Mon_ D`.
@@ -126,6 +133,86 @@ as functors from `C` into the monoid objects of `D`.
 -/
 @[simps]
 def Mon_functor_category_equivalence : Mon_ (C ⥤ D) ≌ C ⥤ Mon_ D :=
+{ functor := functor,
+  inverse := inverse,
+  unit_iso := unit_iso,
+  counit_iso := counit_iso, }
+
+variables [braided_category.{v₂} D]
+
+namespace CommMon_functor_category_equivalence
+
+variables {C D}
+
+/--
+Functor translating a commutative monoid object in a functor category
+to a functor into the category of commutative monoid objects.
+-/
+@[simps]
+def functor : CommMon_ (C ⥤ D) ⥤ (C ⥤ CommMon_ D) :=
+{ obj := λ A,
+  { obj := λ X,
+    { mul_comm' := congr_app A.mul_comm X,
+      ..((Mon_functor_category_equivalence C D).functor.obj A.to_Mon_).obj X, },
+    ..((Mon_functor_category_equivalence C D).functor.obj A.to_Mon_) },
+  map := λ A B f,
+  { app := λ X, ((Mon_functor_category_equivalence C D).functor.map f).app X, }, }
+
+/--
+Functor translating a functor into the category of commutative monoid objects
+to a commutative monoid object in the functor category
+-/
+@[simps]
+def inverse : (C ⥤ CommMon_ D) ⥤ CommMon_ (C ⥤ D) :=
+{ obj := λ F,
+  { mul_comm' := by { ext X, exact (F.obj X).mul_comm, },
+    ..(Mon_functor_category_equivalence C D).inverse.obj (F ⋙ CommMon_.forget₂_Mon_ D), },
+  map := λ F G α, (Mon_functor_category_equivalence C D).inverse.map (whisker_right α _), }
+
+/--
+The unit for the equivalence `CommMon_ (C ⥤ D) ≌ C ⥤ CommMon_ D`.
+-/
+@[simps {rhs_md := semireducible}]
+def unit_iso : 𝟭 (CommMon_ (C ⥤ D)) ≅ functor ⋙ inverse :=
+nat_iso.of_components (λ A,
+  { hom :=
+    { hom := { app := λ _, 𝟙 _ },
+      one_hom' := by { ext X, dsimp, simp only [category.comp_id], },
+      mul_hom' := by { ext X, dsimp, simp only [tensor_id, category.id_comp, category.comp_id], }, },
+    inv :=
+    { hom := { app := λ _, 𝟙 _ },
+      one_hom' := by { ext X, dsimp, simp only [category.comp_id], },
+      mul_hom' := by { ext X, dsimp, simp only [tensor_id, category.id_comp, category.comp_id], }, }, })
+  (λ A B f,
+  begin
+    ext X,
+    dsimp,
+    simp only [category.id_comp, category.comp_id],
+  end)
+
+/--
+The counit for the equivalence `CommMon_ (C ⥤ D) ≌ C ⥤ CommMon_ D`.
+-/
+@[simps {rhs_md := semireducible}]
+def counit_iso : inverse ⋙ functor ≅ 𝟭 (C ⥤ CommMon_ D) :=
+nat_iso.of_components (λ A,
+  nat_iso.of_components (λ X,
+  { hom := { hom := 𝟙 _ },
+    inv := { hom := 𝟙 _ } })
+  (by tidy))
+  (by tidy)
+
+end CommMon_functor_category_equivalence
+
+open CommMon_functor_category_equivalence
+
+/--
+When `D` is a braided monoidal category,
+commutative monoid objects in `C ⥤ D` are the same thing
+as functors from `C` into the commutative monoid objects of `D`.
+-/
+@[simps]
+def CommMon_functor_category_equivalence : CommMon_ (C ⥤ D) ≌ C ⥤ CommMon_ D :=
 { functor := functor,
   inverse := inverse,
   unit_iso := unit_iso,

--- a/src/category_theory/monoidal/internal/types.lean
+++ b/src/category_theory/monoidal/internal/types.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import algebra.category.Mon.basic
-import category_theory.monoidal.Mon_
+import category_theory.monoidal.CommMon_
 import category_theory.monoidal.types
 
 /-!
@@ -23,23 +23,25 @@ open category_theory.monoidal
 
 namespace Mon_Type_equivalence_Mon
 
+instance Mon_monoid (A : Mon_ (Type u)) : monoid (A.X) :=
+{ one := A.one punit.star,
+  mul := λ x y, A.mul (x, y),
+  one_mul := λ x, by convert congr_fun A.one_mul (punit.star, x),
+  mul_one := λ x, by convert congr_fun A.mul_one (x, punit.star),
+  mul_assoc := λ x y z, by convert congr_fun A.mul_assoc ((x, y), z), }
+
 /--
 Converting a monoid object in `Type` to a bundled monoid.
 -/
 def functor : Mon_ (Type u) ⥤ Mon.{u} :=
-{ obj := λ A, ⟨A.X,
-  { one := A.one punit.star,
-    mul := λ x y, A.mul (x, y),
-    one_mul := λ x, by convert congr_fun A.one_mul (punit.star, x),
-    mul_one := λ x, by convert congr_fun A.mul_one (x, punit.star),
-    mul_assoc := λ x y z, by convert congr_fun A.mul_assoc ((x, y), z), }⟩,
+{ obj := λ A, ⟨A.X⟩,
   map := λ A B f,
   { to_fun := f.hom,
     map_one' := congr_fun f.one_hom punit.star,
     map_mul' := λ x y, congr_fun f.mul_hom (x, y), }, }
 
 /--
-Converting bundled monoid to a monoid object in `Type`.
+Converting a bundled monoid to a monoid object in `Type`.
 -/
 def inverse : Mon.{u} ⥤ Mon_ (Type u) :=
 { obj := λ A,
@@ -78,3 +80,56 @@ nat_iso.of_components (λ A, iso.refl _) (by tidy)
 
 instance Mon_Type_inhabited : inhabited (Mon_ (Type u)) :=
 ⟨Mon_Type_equivalence_Mon.inverse.obj (Mon.of punit)⟩
+
+
+namespace CommMon_Type_equivalence_CommMon
+
+instance CommMon_comm_monoid (A : CommMon_ (Type u)) : comm_monoid (A.X) :=
+{ mul_comm := λ x y, by convert congr_fun A.mul_comm (y, x),
+  ..Mon_Type_equivalence_Mon.Mon_monoid A.to_Mon_ }
+
+/--
+Converting a commutative monoid object in `Type` to a bundled commutative monoid.
+-/
+def functor : CommMon_ (Type u) ⥤ CommMon.{u} :=
+{ obj := λ A, ⟨A.X⟩,
+  map := λ A B f, Mon_Type_equivalence_Mon.functor.map f, }
+
+/--
+Converting a bundled commutative monoid to a commutative monoid object in `Type`.
+-/
+def inverse : CommMon.{u} ⥤ CommMon_ (Type u) :=
+{ obj := λ A,
+  { mul_comm' := by { ext ⟨x, y⟩, exact comm_monoid.mul_comm y x, },
+    ..Mon_Type_equivalence_Mon.inverse.obj ((forget₂ CommMon Mon).obj A), },
+  map := λ A B f, Mon_Type_equivalence_Mon.inverse.map f, }
+
+end CommMon_Type_equivalence_CommMon
+
+open CommMon_Type_equivalence_CommMon
+
+/--
+The category of internal commutative monoid objects in `Type`
+is equivalent to the category of "native" bundled commutative monoids.
+-/
+def CommMon_Type_equivalence_CommMon : CommMon_ (Type u) ≌ CommMon.{u} :=
+{ functor := functor,
+  inverse := inverse,
+  unit_iso := nat_iso.of_components
+    (λ A, { hom := { hom := 𝟙 _, }, inv := { hom := 𝟙 _, }, })
+    (by tidy),
+  counit_iso := nat_iso.of_components (λ A,
+  { hom := { to_fun := id, map_one' := rfl, map_mul' := λ x y, rfl, },
+    inv := { to_fun := id, map_one' := rfl, map_mul' := λ x y, rfl, }, }) (by tidy), }
+
+/--
+The equivalences `Mon_ (Type u) ≌ Mon.{u}` and `CommMon_ (Type u) ≌ CommMon.{u}`
+are naturally compatible with the forgetful functors to `Mon` and `Mon_ (Type u)`.
+-/
+def CommMon_Type_equivalence_CommMon_forget :
+  CommMon_Type_equivalence_CommMon.functor ⋙ forget₂ CommMon Mon ≅
+  CommMon_.forget₂_Mon_ (Type u) ⋙ Mon_Type_equivalence_Mon.functor :=
+nat_iso.of_components (λ A, iso.refl _) (by tidy)
+
+instance CommMon_Type_inhabited : inhabited (CommMon_ (Type u)) :=
+⟨CommMon_Type_equivalence_CommMon.inverse.obj (CommMon.of punit)⟩

--- a/src/category_theory/monoidal/internal/types.lean
+++ b/src/category_theory/monoidal/internal/types.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import algebra.category.Mon.basic
-import category_theory.monoidal.internal
+import category_theory.monoidal.Mon_
 import category_theory.monoidal.types
 
 /-!

--- a/src/category_theory/monoidal/types.lean
+++ b/src/category_theory/monoidal/types.lean
@@ -43,4 +43,9 @@ symmetric_of_chosen_finite_products (types.terminal_limit_cone) (types.binary_pr
 @[simp] lemma associator_inv_apply {X Y Z : Type u} {x : X} {y : Y} {z : Z} :
   ((α_ X Y Z).inv : X ⊗ (Y ⊗ Z) → (X ⊗ Y) ⊗ Z) (x, (y, z)) = ((x, y), z) := rfl
 
+@[simp] lemma braiding_hom_apply {X Y : Type u} {x : X} {y : Y} :
+  ((β_ X Y).hom : X ⊗ Y → Y ⊗ X) (x, y) = (y, x) := rfl
+@[simp] lemma braiding_inv_apply {X Y : Type u} {x : X} {y : Y} :
+  ((β_ X Y).inv : Y ⊗ X → X ⊗ Y) (y, x) = (x, y) := rfl
+
 end category_theory.monoidal


### PR DESCRIPTION
This reprises a series of our recent PRs on monoid objects in monoidal categories, developing the same material for commutative monoid objects in braided categories.

---
<!-- put comments you want to keep out of the PR commit here -->
