### PR TITLE
[Merged by Bors] - feat(tactic/tauto): optional closer tactic for `tauto`

### DIFF
--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -42,7 +42,7 @@ have hia : i a ≠ 0, from mt ((is_add_group_hom.injective_iff i).1
 or.inr $ λ g hg ⟨p, hp⟩, absurd hg.1 (not_not.2 (is_unit_iff_degree_eq_zero.2 $
   by have := congr_arg degree hp;
     simp [degree_C hia, @eq_comm (with_bot ℕ) 0,
-      nat.with_bot.add_eq_zero_iff] at this; clear _fun_match; tautology))
+      nat.with_bot.add_eq_zero_iff] at this; clear _fun_match; tauto))
 
 lemma splits_of_degree_eq_one {f : polynomial α} (hf : degree f = 1) : splits i f :=
 or.inr $ λ g hg ⟨p, hp⟩,

--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -38,7 +38,7 @@ do hs ← local_context,
          | _ := failed
          end
 
-/-
+/-!
   The following definitions maintain a path compression datastructure, i.e. a forest such that:
     - every node is the type of a hypothesis
     - there is a edge between two nodes only if they are provably equivalent

--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -184,7 +184,7 @@ meta structure tauto_cfg :=
                                            solve_by_elim,
                                            constructor_matching none
                                              [``(_ ∧ _),``(_ ↔ _),``(Exists _),``(true)]])
-(classic : bool                        := ff)
+(classical : bool                        := ff)
 (closer : tactic unit                  := pure ())
 
 meta def tautology (cfg : tauto_cfg := {}) : tactic unit := focus1 $
@@ -204,7 +204,7 @@ meta def tautology (cfg : tauto_cfg := {}) : tactic unit := focus1 $
          try (assumption_with r),
          gs' ← get_goals,
          guard (gs ≠ gs') ) in
-    do when cfg.classic classical,
+    do when cfg.classical classical,
        using_new_ref (expr_map.mk _) tauto_core;
        repeat (first cfg.basic_tauto_tacs); cfg.closer, done
 
@@ -223,7 +223,7 @@ The variant `tautology!` uses the law of excluded middle.
 that it is unable to solve before failing.
 -/
 meta def tautology (c : parse $ (tk "!")?) (cfg : tactic.tauto_cfg := {}) :=
-tactic.tautology $ { classic := c.is_some, ..cfg }
+tactic.tautology $ { classical := c.is_some, ..cfg }
 
 -- Now define a shorter name for the tactic `tautology`.
 

--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -200,6 +200,7 @@ do { ctx ← local_context,
 meta def assumption_symm :=
 using_new_ref (native.rb_map.mk _ _) assumption_with
 
+
 meta structure tauto_cfg :=
 (basic_tauto_tacs : list (tactic unit) := [reflexivity,
                                            solve_by_elim,
@@ -207,6 +208,8 @@ meta structure tauto_cfg :=
                                              [``(_ ∧ _),``(_ ↔ _),``(Exists _),``(true)]])
 (classical : bool                        := ff)
 (closer : tactic unit                  := pure ())
+
+attribute [nolint doc_blame] tauto_cfg
 
 meta def tautology (cfg : tauto_cfg := {}) : tactic unit := focus1 $
   let tauto_core (r : tauto_state) : tactic unit :=

--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -41,8 +41,9 @@ do hs ← local_context,
 /-
   The following definitions maintain a path compression datastructure, i.e. a forest such that:
     - every node is the type of a hypothesis
-    - there is a edge between two nodes if and only if they are provably equivalent
-    - every edge is labelled with a proof of equivalence for its vertices.
+    - there is a edge between two nodes if they are provably equivalent
+    - every edge is labelled with a proof of equivalence for its vertices
+    - edges are added when normalizing propositions.
 -/
 
 meta def tauto_state := ref $ expr_map (option (expr × expr))
@@ -56,6 +57,10 @@ do m ← read_ref r,
    write_ref r $ m.insert e none,
    return (e,p)
 
+/--
+  If there exists a symmetry lemma that can be applied to the hypothesis `e`,
+  store it.
+-/
 meta def add_symm_proof (r : tauto_state) (e : expr) : tactic (expr × expr) :=
 do env ← get_env,
    let rel := e.get_app_fn.const_name,

--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -41,7 +41,7 @@ do hs ← local_context,
 /-
   The following definitions maintain a path compression datastructure, i.e. a forest such that:
     - every node is the type of a hypothesis
-    - there is a edge between two nodes if they are provably equivalent
+    - there is a edge between two nodes only if they are provably equivalent
     - every edge is labelled with a proof of equivalence for its vertices
     - edges are added when normalizing propositions.
 -/

--- a/src/tactic/wlog.lean
+++ b/src/tactic/wlog.lean
@@ -156,7 +156,8 @@ meta def wlog
   (cases : parse (tk ":=" *> texpr)?)
   (perms : parse (tk "using" *> (list_of (ident*) <|> (λx, [x]) <$> ident*))?)
   (discharger : tactic unit :=
-    (tactic.solve_by_elim <|> tactic.tautology tt <|> using_smt (smt_tactic.intros >> smt_tactic.solve_goals))) :
+    (tactic.solve_by_elim <|> tactic.tautology {classic := tt} <|>
+      using_smt (smt_tactic.intros >> smt_tactic.solve_goals))) :
   tactic unit := do
 perms ← parse_permutations perms,
 (pat, cases_pr, cases_goal, vars, perms) ← (match cases with

--- a/src/tactic/wlog.lean
+++ b/src/tactic/wlog.lean
@@ -156,7 +156,7 @@ meta def wlog
   (cases : parse (tk ":=" *> texpr)?)
   (perms : parse (tk "using" *> (list_of (ident*) <|> (λx, [x]) <$> ident*))?)
   (discharger : tactic unit :=
-    (tactic.solve_by_elim <|> tactic.tautology {classic := tt} <|>
+    (tactic.solve_by_elim <|> tactic.tautology {classical := tt} <|>
       using_smt (smt_tactic.intros >> smt_tactic.solve_goals))) :
   tactic unit := do
 perms ← parse_permutations perms,

--- a/test/tauto.lean
+++ b/test/tauto.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 -/
 import tactic.tauto
+import tactic
 
 section tauto₀
 variables p q r : Prop
@@ -76,7 +77,27 @@ example (h' : p ∧ ¬ y = x) : p ∧ q := by tauto
 example : y = x := by tauto
 example (h' : ¬ x = y) : p ∧ q := by tauto
 example : x = y := by tauto
-
 end modulo_symmetry
 
 end tauto₃
+
+section closer
+
+example {α : Type*} {β : Type*} (a : α)
+  {s_1 : set α} :
+  (∃ (a_1 : α), a_1 = a ∨ a_1 ∈ s_1) :=
+begin
+  tauto {closer := `[simp]}
+end
+
+variables {p q r : Prop} {α : Type} {x y z w : α}
+variables (h : x = y) (h₁ : y = z) (h₂ : z = w)
+variables (h'' : (p ∧ q ↔ q ∨ r) ↔ (r ∧ p ↔ r ∨ q))
+include h h₁ h₂ h''
+
+example : (((r ∧ p ↔ r ∨ q) ∧ (q ∨ r)) → (p ∧ (x = w) ∧ (¬ x = w → p ∧ q ∧ r))) :=
+begin
+  tauto {closer := `[cc]}
+end
+
+end closer


### PR DESCRIPTION
`tauto` sometimes fails on easy subgoals; instead of backtracking
and discarding the work, the user can now supply a closer tactic
to the remaining goals, such as `cc`, `simp`, or `linarith`.

this also wraps `tauto` in a `focus1`, which allows for better
error messages.


---
<!-- put comments you want to keep out of the PR commit here -->
