### PR TITLE
[Merged by Bors] - feat(data/*/nat_antidiagonal): induction lemmas about antidiagonals

### DIFF
--- a/src/algebra/big_operators/default.lean
+++ b/src/algebra/big_operators/default.lean
@@ -3,3 +3,4 @@
 import algebra.big_operators.order
 import algebra.big_operators.intervals
 import algebra.big_operators.ring
+import algebra.big_operators.nat_antidiagonal

--- a/src/algebra/big_operators/nat_antidiagonal.lean
+++ b/src/algebra/big_operators/nat_antidiagonal.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2020 Aaron Anderson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Anderson
+-/
+
+import data.finset.nat_antidiagonal
+import algebra.big_operators
+
+/-!
+# Big operators for `nat_antidiagonal`
+
+This file contains theorems relevant to big operators over `finset.nat.antidiagonal`.
+-/
+
+open_locale big_operators
+
+variables {α : Type*} [add_comm_monoid α]
+
+namespace finset
+namespace nat
+
+lemma sum_antidiagonal_succ {n : ℕ} {f : ℕ × ℕ → α} :
+  (antidiagonal (n + 1)).sum f = f (0, n + 1) + ((antidiagonal n).map ⟨prod.map nat.succ id,
+    function.injective.prod_map nat.succ_injective function.injective_id⟩).sum f :=
+begin
+  rw [antidiagonal_succ, sum_insert],
+  intro con, rcases mem_map.1 con with ⟨⟨a,b⟩, ⟨h1, h2⟩⟩,
+  simp only [id.def, prod.mk.inj_iff, function.embedding.coe_fn_mk, prod.map_mk] at h2,
+  apply nat.succ_ne_zero a h2.1,
+end
+
+end nat
+end finset

--- a/src/algebra/big_operators/nat_antidiagonal.lean
+++ b/src/algebra/big_operators/nat_antidiagonal.lean
@@ -21,12 +21,13 @@ namespace finset
 namespace nat
 
 lemma sum_antidiagonal_succ {n : ℕ} {f : ℕ × ℕ → α} :
-  (antidiagonal (n + 1)).sum f = f (0, n + 1) + ((antidiagonal n).map ⟨prod.map nat.succ id,
-    function.injective.prod_map nat.succ_injective function.injective_id⟩).sum f :=
+  (antidiagonal (n + 1)).sum f = f (0, n + 1) + ((antidiagonal n).map
+  (function.embedding.prod_map ⟨nat.succ, nat.succ_injective⟩ (function.embedding.refl _))).sum f :=
 begin
   rw [antidiagonal_succ, sum_insert],
   intro con, rcases mem_map.1 con with ⟨⟨a,b⟩, ⟨h1, h2⟩⟩,
-  simp only [id.def, prod.mk.inj_iff, function.embedding.coe_fn_mk, prod.map_mk] at h2,
+  simp only [prod.mk.inj_iff, function.embedding.coe_fn_mk, function.embedding.refl_apply,
+               function.embedding.coe_prod_map, prod.map_mk] at h2,
   apply nat.succ_ne_zero a h2.1,
 end
 

--- a/src/algebra/big_operators/nat_antidiagonal.lean
+++ b/src/algebra/big_operators/nat_antidiagonal.lean
@@ -5,7 +5,7 @@ Authors: Aaron Anderson
 -/
 
 import data.finset.nat_antidiagonal
-import algebra.big_operators
+import algebra.big_operators.basic
 
 /-!
 # Big operators for `nat_antidiagonal`

--- a/src/data/finset/nat_antidiagonal.lean
+++ b/src/data/finset/nat_antidiagonal.lean
@@ -32,6 +32,42 @@ by simp [antidiagonal]
 @[simp] lemma antidiagonal_zero : antidiagonal 0 = {(0, 0)} :=
 rfl
 
+lemma antidiagonal_succ {n : ℕ} :
+  finset.nat.antidiagonal (n + 1) = insert (0,n + 1) ((finset.nat.antidiagonal n).map ⟨prod.map nat.succ id, function.injective.prod_map nat.succ_injective function.injective_id⟩ ) :=
+begin
+  apply finset.eq_of_veq,
+  rw [finset.insert_val_of_not_mem, finset.map_val],
+  {apply multiset.nat.antidiagonal_succ},
+  { intro con, rcases finset.mem_map.1 con with ⟨⟨a,b⟩, ⟨h1, h2⟩⟩,
+    simp only [id.def, prod.mk.inj_iff, function.embedding.coe_fn_mk, prod.map_mk] at h2,
+    apply nat.succ_ne_zero a h2.1, }
+end
+
+lemma sum_antidiagonal_succ {α : Type*} [add_comm_monoid α] {n : ℕ} {f : ℕ × ℕ → α} :
+  (finset.nat.antidiagonal (n + 1)).sum f = f (0, n + 1) + ((finset.nat.antidiagonal n).map ⟨prod.map nat.succ id, function.injective.prod_map nat.succ_injective function.injective_id⟩).sum f :=
+begin
+  rw [finset.nat.antidiagonal_succ, finset.sum_insert],
+  intro con, rcases finset.mem_map.1 con with ⟨⟨a,b⟩, ⟨h1, h2⟩⟩,
+  simp only [id.def, prod.mk.inj_iff, function.embedding.coe_fn_mk, prod.map_mk] at h2,
+  apply nat.succ_ne_zero a h2.1,
+end
+
+lemma map_swap_antidiagonal {n : ℕ} :
+  (finset.nat.antidiagonal n).map ⟨prod.swap, prod.swap_right_inverse.injective⟩ = finset.nat.antidiagonal n :=
+begin
+  ext,
+  simp only [exists_prop, finset.mem_map, finset.nat.mem_antidiagonal, function.embedding.coe_fn_mk, prod.swap_prod_mk,
+ prod.exists],
+  rw add_comm,
+  split,
+  { rintro ⟨b, c, ⟨rfl, rfl⟩⟩,
+    simp },
+  { rintro rfl,
+    use a.snd,
+    use a.fst,
+    simp }
+end
+
 end nat
 
 end finset

--- a/src/data/finset/nat_antidiagonal.lean
+++ b/src/data/finset/nat_antidiagonal.lean
@@ -34,13 +34,14 @@ rfl
 
 lemma antidiagonal_succ {n : ℕ} :
   antidiagonal (n + 1) = insert (0,n + 1) ((antidiagonal n).map
-  ⟨prod.map nat.succ id, function.injective.prod_map nat.succ_injective function.injective_id⟩ ) :=
+  (function.embedding.prod_map ⟨nat.succ, nat.succ_injective⟩ (function.embedding.refl _))) :=
 begin
   apply eq_of_veq,
   rw [insert_val_of_not_mem, map_val],
   {apply multiset.nat.antidiagonal_succ},
   { intro con, rcases mem_map.1 con with ⟨⟨a,b⟩, ⟨h1, h2⟩⟩,
-    simp only [id.def, prod.mk.inj_iff, function.embedding.coe_fn_mk, prod.map_mk] at h2,
+    simp only [prod.mk.inj_iff, function.embedding.coe_fn_mk, function.embedding.refl_apply,
+               function.embedding.coe_prod_map, prod.map_mk] at h2,
     apply nat.succ_ne_zero a h2.1, }
 end
 

--- a/src/data/finset/nat_antidiagonal.lean
+++ b/src/data/finset/nat_antidiagonal.lean
@@ -22,7 +22,7 @@ def antidiagonal (n : ℕ) : finset (ℕ × ℕ) :=
 /-- A pair (i,j) is contained in the antidiagonal of `n` if and only if `i+j=n`. -/
 @[simp] lemma mem_antidiagonal {n : ℕ} {x : ℕ × ℕ} :
   x ∈ antidiagonal n ↔ x.1 + x.2 = n :=
-by rw [antidiagonal, finset.mem_def, multiset.nat.mem_antidiagonal]
+by rw [antidiagonal, mem_def, multiset.nat.mem_antidiagonal]
 
 /-- The cardinality of the antidiagonal of `n` is `n+1`. -/
 @[simp] lemma card_antidiagonal (n : ℕ) : (antidiagonal n).card = n+1 :=
@@ -33,31 +33,23 @@ by simp [antidiagonal]
 rfl
 
 lemma antidiagonal_succ {n : ℕ} :
-  finset.nat.antidiagonal (n + 1) = insert (0,n + 1) ((finset.nat.antidiagonal n).map ⟨prod.map nat.succ id, function.injective.prod_map nat.succ_injective function.injective_id⟩ ) :=
+  antidiagonal (n + 1) = insert (0,n + 1) ((antidiagonal n).map
+  ⟨prod.map nat.succ id, function.injective.prod_map nat.succ_injective function.injective_id⟩ ) :=
 begin
-  apply finset.eq_of_veq,
-  rw [finset.insert_val_of_not_mem, finset.map_val],
+  apply eq_of_veq,
+  rw [insert_val_of_not_mem, map_val],
   {apply multiset.nat.antidiagonal_succ},
-  { intro con, rcases finset.mem_map.1 con with ⟨⟨a,b⟩, ⟨h1, h2⟩⟩,
+  { intro con, rcases mem_map.1 con with ⟨⟨a,b⟩, ⟨h1, h2⟩⟩,
     simp only [id.def, prod.mk.inj_iff, function.embedding.coe_fn_mk, prod.map_mk] at h2,
     apply nat.succ_ne_zero a h2.1, }
 end
 
-lemma sum_antidiagonal_succ {α : Type*} [add_comm_monoid α] {n : ℕ} {f : ℕ × ℕ → α} :
-  (finset.nat.antidiagonal (n + 1)).sum f = f (0, n + 1) + ((finset.nat.antidiagonal n).map ⟨prod.map nat.succ id, function.injective.prod_map nat.succ_injective function.injective_id⟩).sum f :=
-begin
-  rw [finset.nat.antidiagonal_succ, finset.sum_insert],
-  intro con, rcases finset.mem_map.1 con with ⟨⟨a,b⟩, ⟨h1, h2⟩⟩,
-  simp only [id.def, prod.mk.inj_iff, function.embedding.coe_fn_mk, prod.map_mk] at h2,
-  apply nat.succ_ne_zero a h2.1,
-end
-
 lemma map_swap_antidiagonal {n : ℕ} :
-  (finset.nat.antidiagonal n).map ⟨prod.swap, prod.swap_right_inverse.injective⟩ = finset.nat.antidiagonal n :=
+  (antidiagonal n).map ⟨prod.swap, prod.swap_right_inverse.injective⟩ = antidiagonal n :=
 begin
   ext,
-  simp only [exists_prop, finset.mem_map, finset.nat.mem_antidiagonal, function.embedding.coe_fn_mk, prod.swap_prod_mk,
- prod.exists],
+  simp only [exists_prop, mem_map, mem_antidiagonal,
+    function.embedding.coe_fn_mk, prod.swap_prod_mk, prod.exists],
   rw add_comm,
   split,
   { rintro ⟨b, c, ⟨rfl, rfl⟩⟩,

--- a/src/data/finset/nat_antidiagonal.lean
+++ b/src/data/finset/nat_antidiagonal.lean
@@ -33,7 +33,7 @@ by simp [antidiagonal]
 rfl
 
 lemma antidiagonal_succ {n : ℕ} :
-  antidiagonal (n + 1) = insert (0,n + 1) ((antidiagonal n).map
+  antidiagonal (n + 1) = insert (0, n + 1) ((antidiagonal n).map
   (function.embedding.prod_map ⟨nat.succ, nat.succ_injective⟩ (function.embedding.refl _))) :=
 begin
   apply eq_of_veq,
@@ -56,8 +56,7 @@ begin
   { rintro ⟨b, c, ⟨rfl, rfl⟩⟩,
     simp },
   { rintro rfl,
-    use a.snd,
-    use a.fst,
+    use [a.snd, a.fst],
     simp }
 end
 

--- a/src/data/list/nat_antidiagonal.lean
+++ b/src/data/list/nat_antidiagonal.lean
@@ -37,12 +37,11 @@ rfl
 lemma nodup_antidiagonal (n : ℕ) : nodup (antidiagonal n) :=
 nodup_map (@left_inverse.injective ℕ (ℕ × ℕ) prod.fst (λ i, (i, n-i)) $ λ i, rfl) (nodup_range _)
 
-@[simp]
-lemma antidiagonal_succ {n : ℕ} :
-  list.nat.antidiagonal (n + 1) = (0,n + 1) :: ((list.nat.antidiagonal n).map (prod.map nat.succ id) ) :=
+@[simp] lemma antidiagonal_succ {n : ℕ} :
+  antidiagonal (n + 1) = (0, n + 1) :: ((antidiagonal n).map (prod.map nat.succ id) ) :=
 begin
-  simp only [list.nat.antidiagonal, list.range_succ_eq_map, list.map_cons, true_and,
-    nat.add_succ_sub_one, add_zero, id.def, eq_self_iff_true, nat.sub_zero, list.map_map, prod.map_mk],
+  simp only [antidiagonal, range_succ_eq_map, map_cons, true_and, nat.add_succ_sub_one, add_zero, 
+    id.def, eq_self_iff_true, nat.sub_zero, map_map, prod.map_mk],
   apply congr (congr rfl _) rfl,
   ext; simp,
 end

--- a/src/data/list/nat_antidiagonal.lean
+++ b/src/data/list/nat_antidiagonal.lean
@@ -37,5 +37,15 @@ rfl
 lemma nodup_antidiagonal (n : ℕ) : nodup (antidiagonal n) :=
 nodup_map (@left_inverse.injective ℕ (ℕ × ℕ) prod.fst (λ i, (i, n-i)) $ λ i, rfl) (nodup_range _)
 
+@[simp]
+lemma antidiagonal_succ {n : ℕ} :
+  list.nat.antidiagonal (n + 1) = (0,n + 1) :: ((list.nat.antidiagonal n).map (prod.map nat.succ id) ) :=
+begin
+  simp only [list.nat.antidiagonal, list.range_succ_eq_map, list.map_cons, true_and,
+    nat.add_succ_sub_one, add_zero, id.def, eq_self_iff_true, nat.sub_zero, list.map_map, prod.map_mk],
+  apply congr (congr rfl _) rfl,
+  ext; simp,
+end
+
 end nat
 end list

--- a/src/data/multiset/nat_antidiagonal.lean
+++ b/src/data/multiset/nat_antidiagonal.lean
@@ -35,14 +35,9 @@ rfl
 @[simp] lemma nodup_antidiagonal (n : ℕ) : nodup (antidiagonal n) :=
 coe_nodup.2 $ list.nat.nodup_antidiagonal n
 
-@[simp]
-lemma antidiagonal_succ {n : ℕ} :
-  multiset.nat.antidiagonal (n + 1) = (0,n + 1) :: ((multiset.nat.antidiagonal n).map (prod.map nat.succ id) ) :=
-begin
-  unfold multiset.nat.antidiagonal,
-  rw list.nat.antidiagonal_succ,
-  simp only [multiset.coe_map, multiset.cons_coe, id.def, prod_map, list.perm_cons, multiset.coe_eq_coe, list.map],
-end
+@[simp] lemma antidiagonal_succ {n : ℕ} :
+  antidiagonal (n + 1) = (0, n + 1) :: ((antidiagonal n).map (prod.map nat.succ id)) :=
+by simp only [antidiagonal, list.nat.antidiagonal_succ, coe_map, cons_coe]
 
 end nat
 end multiset

--- a/src/data/multiset/nat_antidiagonal.lean
+++ b/src/data/multiset/nat_antidiagonal.lean
@@ -35,5 +35,14 @@ rfl
 @[simp] lemma nodup_antidiagonal (n : ℕ) : nodup (antidiagonal n) :=
 coe_nodup.2 $ list.nat.nodup_antidiagonal n
 
+@[simp]
+lemma antidiagonal_succ {n : ℕ} :
+  multiset.nat.antidiagonal (n + 1) = (0,n + 1) :: ((multiset.nat.antidiagonal n).map (prod.map nat.succ id) ) :=
+begin
+  unfold multiset.nat.antidiagonal,
+  rw list.nat.antidiagonal_succ,
+  simp only [multiset.coe_map, multiset.cons_coe, id.def, prod_map, list.perm_cons, multiset.coe_eq_coe, list.map],
+end
+
 end nat
 end multiset

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -275,3 +275,19 @@ def mul_right_embedding {G : Type u} [right_cancel_semigroup G] (g : G) : G ↪ 
 lemma mul_right_embedding_apply {G : Type u} [right_cancel_semigroup G] (g h : G) :
   mul_right_embedding g h = h * g :=
 rfl
+
+namespace embedding
+
+variables {α₁ : Type*} {α₂ : Type*} {β₁ : Type*} {β₂ : Type*} (f : α₁ ↪ α₂) (g : β₁ ↪ β₂)
+
+def prod_map : (α₁ × β₁) ↪ α₂ × β₂ :=
+{ to_fun := prod.map f g,
+  inj' := λ x y h, prod.ext (f.injective (prod.ext_iff.1 h).1) (g.injective (prod.ext_iff.1 h).2) }
+
+variables {f} {g}
+
+@[simp]
+def coe_prod_map :
+  ⇑(prod_map f g) = prod.map f g := rfl
+
+end embedding

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -275,19 +275,3 @@ def mul_right_embedding {G : Type u} [right_cancel_semigroup G] (g : G) : G ↪ 
 lemma mul_right_embedding_apply {G : Type u} [right_cancel_semigroup G] (g h : G) :
   mul_right_embedding g h = h * g :=
 rfl
-
-namespace embedding
-
-variables {α₁ : Type*} {α₂ : Type*} {β₁ : Type*} {β₂ : Type*} (f : α₁ ↪ α₂) (g : β₁ ↪ β₂)
-
-def prod_map : (α₁ × β₁) ↪ α₂ × β₂ :=
-{ to_fun := prod.map f g,
-  inj' := λ x y h, prod.ext (f.injective (prod.ext_iff.1 h).1) (g.injective (prod.ext_iff.1 h).2) }
-
-variables {f} {g}
-
-@[simp]
-def coe_prod_map :
-  ⇑(prod_map f g) = prod.map f g := rfl
-
-end embedding


### PR DESCRIPTION
Adds a `nat.antidiagonal_succ` lemma for `list`, `multiset`, and `finset`, useful for proving facts about power series derivatives

---
