### PR TITLE
[Merged by Bors] - refactor(category_theory): make `has_image` and friends a Prop

### DIFF
--- a/src/algebra/category/Group/images.lean
+++ b/src/algebra/category/Group/images.lean
@@ -86,6 +86,8 @@ def mono_factorisation : mono_factorisation f :=
   m := image.ι f,
   e := factor_thru_image f }
 
+/-- the factorisation of any morphism in AddCommGroup through a mono has the universal property of
+the image. -/
 noncomputable def is_image : is_image (mono_factorisation f) :=
 { lift := image.lift,
   lift_fac' := image.lift_fac }

--- a/src/algebra/category/Group/images.lean
+++ b/src/algebra/category/Group/images.lean
@@ -9,6 +9,8 @@ import category_theory.limits.types
 
 /-!
 # The category of commutative additive groups has images.
+
+Note that TODO TODO TODO
 -/
 
 open category_theory
@@ -83,40 +85,22 @@ def mono_factorisation : mono_factorisation f :=
   m := image.ι f,
   e := factor_thru_image f }
 
-noncomputable instance : has_image f :=
-{ F := mono_factorisation f,
-  is_image :=
-  { lift := image.lift,
-    lift_fac' := image.lift_fac } }
+noncomputable def is_image : is_image (mono_factorisation f) :=
+{ lift := image.lift,
+  lift_fac' := image.lift_fac }
 
-noncomputable instance : has_images AddCommGroup.{0} :=
-{ has_image := infer_instance }
+instance : has_image f :=
+has_image.mk ⟨_, is_image f⟩
 
--- We'll later get this as a consequence of `[abelian AddCommGroup]`.
--- Nevertheless this instance has the desired definitional behaviour,
--- and is useful in the meantime for doing cohomology.
-
--- When the `[abelian AddCommGroup]` instance is available
--- this instance should be reviewed, and ideally removed if the `[abelian]` instance
--- provides something definitionally equivalent.
-noncomputable instance : has_image_maps AddCommGroup.{0} :=
-{ has_image_map := λ f g st,
-  { map :=
-    { to_fun := image.map ((forget AddCommGroup).map_arrow.map st),
-      map_zero' := by { ext, simp, },
-      map_add' := λ x y, by { ext, simp, refl, } } } }
-
-@[simp] lemma image_map {f g : arrow AddCommGroup.{0}} (st : f ⟶ g) (x : image f.hom):
-  (image.map st x).val = st.right x.1 :=
-rfl
+instance : has_images AddCommGroup.{0} :=
+{ has_image := by apply_instance }
 
 /--
 The categorical image of a morphism in `AddCommGroup`
 agrees with the usual group-theoretical range.
 -/
-def image_iso_range {G H : AddCommGroup} (f : G ⟶ H) :
-  image f ≅ AddCommGroup.of f.range :=
-iso.refl _
-
+noncomputable def image_iso_range {G H : AddCommGroup.{0}} (f : G ⟶ H) :
+  limits.image f ≅ AddCommGroup.of f.range :=
+is_image.iso_ext (image.is_image f) (is_image f)
 
 end AddCommGroup

--- a/src/algebra/category/Group/images.lean
+++ b/src/algebra/category/Group/images.lean
@@ -3,14 +3,15 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import algebra.category.Group.basic
+import algebra.category.Group.abelian
 import category_theory.limits.shapes.images
 import category_theory.limits.types
 
 /-!
 # The category of commutative additive groups has images.
 
-Note that TODO TODO TODO
+Note that we don't need to register any of the constructions here as instances, because we get them
+from the fact that `AddCommGroup` is an abelian category.
 -/
 
 open category_theory
@@ -88,12 +89,6 @@ def mono_factorisation : mono_factorisation f :=
 noncomputable def is_image : is_image (mono_factorisation f) :=
 { lift := image.lift,
   lift_fac' := image.lift_fac }
-
-instance : has_image f :=
-has_image.mk ⟨_, is_image f⟩
-
-instance : has_images AddCommGroup.{0} :=
-{ has_image := by apply_instance }
 
 /--
 The categorical image of a morphism in `AddCommGroup`

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -252,6 +252,17 @@ abbreviation coimage_iso_image : coimages.coimage f ≅ images.image f :=
 is_image.iso_ext (coimages.coimage_strong_epi_mono_factorisation f).to_mono_is_image
   (images.image_strong_epi_mono_factorisation f).to_mono_is_image
 
+/-- There is a canonical isomorphism between the abelian image and the categorical image of a
+    morphism. -/
+abbreviation image_iso_image : images.image f ≅ image f :=
+is_image.iso_ext (images.image_strong_epi_mono_factorisation f).to_mono_is_image (image.is_image f)
+
+/-- There is a canonical isomorphism between the abelian coimage and the categorical image of a
+    morphism. -/
+abbreviation coimage_iso_image' : coimages.coimage f ≅ image f :=
+is_image.iso_ext (coimages.coimage_strong_epi_mono_factorisation f).to_mono_is_image
+  (image.is_image f)
+
 lemma full_image_factorisation : coimages.coimage.π f ≫ (coimage_iso_image f).hom ≫
   images.image.ι f = f :=
 by rw [limits.is_image.iso_ext_hom,

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -236,7 +236,7 @@ section has_strong_epi_mono_factorisations
 
 /-- An abelian category has strong epi-mono factorisations. -/
 @[priority 100] instance : has_strong_epi_mono_factorisations C :=
-has_strong_epi_mono_factorisations $ λ X Y f, images.image_strong_epi_mono_factorisation f
+has_strong_epi_mono_factorisations.mk $ λ X Y f, images.image_strong_epi_mono_factorisation f
 
 /- In particular, this means that it has well-behaved images. -/
 example : has_images C := by apply_instance
@@ -246,10 +246,6 @@ end has_strong_epi_mono_factorisations
 
 section images
 variables {X Y : C} (f : X ⟶ Y)
-
-lemma image_eq_image : limits.image f = images.image f := rfl
-lemma image_ι_eq_image_ι : limits.image.ι f = images.image.ι f := rfl
-lemma kernel_cokernel_eq_image_ι : kernel.ι (cokernel.π f) = images.image.ι f := rfl
 
 /-- There is a canonical isomorphism between the coimage and the image of a morphism. -/
 abbreviation coimage_iso_image : coimages.coimage f ≅ images.image f :=

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -236,7 +236,7 @@ section has_strong_epi_mono_factorisations
 
 /-- An abelian category has strong epi-mono factorisations. -/
 @[priority 100] instance : has_strong_epi_mono_factorisations C :=
-⟨λ X Y f, images.image_strong_epi_mono_factorisation f⟩
+has_strong_epi_mono_factorisations $ λ X Y f, images.image_strong_epi_mono_factorisation f
 
 /- In particular, this means that it has well-behaved images. -/
 example : has_images C := by apply_instance

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -177,6 +177,14 @@ kernel.lift_ι _ _ _
 instance : epi (images.factor_thru_image f) :=
 show epi (non_preadditive_abelian.factor_thru_image f), by apply_instance
 
+section
+variables {f}
+
+lemma image_ι_comp_eq_zero {R : C} {g : Q ⟶ R} (h : f ≫ g = 0) : images.image.ι f ≫ g = 0 :=
+zero_of_epi_comp (images.factor_thru_image f) $ by simp [h]
+
+end
+
 instance mono_factor_thru_image [mono f] : mono (images.factor_thru_image f) :=
 mono_of_mono_fac $ image.fac f
 

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -135,7 +135,7 @@ section strong
 local attribute [instance] abelian.normal_epi
 
 /-- In an abelian category, every epimorphism is strong. -/
-def strong_epi_of_epi {P Q : C} (f : P ⟶ Q) [epi f] : strong_epi f := by apply_instance
+lemma strong_epi_of_epi {P Q : C} (f : P ⟶ Q) [epi f] : strong_epi f := by apply_instance
 
 end strong
 

--- a/src/category_theory/abelian/exact.lean
+++ b/src/category_theory/abelian/exact.lean
@@ -43,10 +43,10 @@ begin
       rw this,
       apply_instance },
     refine is_limit.of_ι _ _ _ _ _,
-    { refine λ W u hu, kernel.lift (cokernel.π f) u _,
+    { refine λ W u hu, kernel.lift (cokernel.π f) u _ ≫ (image_iso_image f).hom,
       rw [←kernel.lift_ι g u hu, category.assoc, h.2, has_zero_morphisms.comp_zero] },
-    { exact λ _ _ _, kernel.lift_ι _ _ _ },
-    { tidy } }
+    { tidy },
+    { intros, simp [w, ←cancel_mono (image.ι f)] } }
 end
 
 theorem exact_iff' {cg : kernel_fork g} (hg : is_limit cg)
@@ -68,10 +68,10 @@ def is_limit_image [h : exact f g] :
 begin
   rw exact_iff at h,
   refine is_limit.of_ι _ _ _ _ _,
-  { refine λ W u hu, kernel.lift (cokernel.π f) u _,
+  { refine λ W u hu, kernel.lift (cokernel.π f) u _ ≫ (image_iso_image f).hom,
     rw [←kernel.lift_ι g u hu, category.assoc, h.2, has_zero_morphisms.comp_zero] },
-  { exact λ _ _ _, kernel.lift_ι _ _ _ },
-  { tidy }
+  { tidy },
+  { intros, simp [w, ←cancel_mono (image.ι f)] }
 end
 
 

--- a/src/category_theory/abelian/exact.lean
+++ b/src/category_theory/abelian/exact.lean
@@ -62,17 +62,20 @@ begin
     simp [h.2] }
 end
 
-/-- If `(f, g)` is exact, then `image.ι f` is a kernel of `g`. -/
+/-- If `(f, g)` is exact, then `images.image.ι f` is a kernel of `g`. -/
 def is_limit_image [h : exact f g] :
-  is_limit (kernel_fork.of_ι (image.ι f) (image_ι_comp_eq_zero h.1)) :=
+  is_limit (kernel_fork.of_ι (images.image.ι f) (images.image_ι_comp_eq_zero h.1) : kernel_fork g) :=
 begin
   rw exact_iff at h,
   refine is_limit.of_ι _ _ _ _ _,
-  { refine λ W u hu, kernel.lift (cokernel.π f) u _ ≫ (image_iso_image f).hom,
+  { refine λ W u hu, kernel.lift (cokernel.π f) u _,
     rw [←kernel.lift_ι g u hu, category.assoc, h.2, has_zero_morphisms.comp_zero] },
-  { tidy },
-  { intros, simp [w, ←cancel_mono (image.ι f)] }
+  tidy
 end
 
+/-- If `(f, g)` is exact, then `image.ι f` is a kernel of `g`. -/
+def is_limit_image' [h : exact f g] :
+  is_limit (kernel_fork.of_ι (image.ι f) (image_ι_comp_eq_zero h.1)) :=
+is_kernel.iso_kernel _ _ (is_limit_image f g) (image_iso_image f).symm $ is_image.lift_fac _ _
 
 end category_theory.abelian

--- a/src/category_theory/abelian/non_preadditive.lean
+++ b/src/category_theory/abelian/non_preadditive.lean
@@ -99,7 +99,7 @@ section strong
 local attribute [instance] non_preadditive_abelian.normal_epi
 
 /-- In a `non_preadditive_abelian` category, every epimorphism is strong. -/
-def strong_epi_of_epi {P Q : C} (f : P ⟶ Q) [epi f] : strong_epi f := by apply_instance
+lemma strong_epi_of_epi {P Q : C} (f : P ⟶ Q) [epi f] : strong_epi f := by apply_instance
 
 end strong
 

--- a/src/category_theory/abelian/pseudoelements.lean
+++ b/src/category_theory/abelian/pseudoelements.lean
@@ -288,20 +288,20 @@ theorem pseudo_exact_of_exact {P Q R : C} {f : P ⟶ Q} {g : Q ⟶ R} [exact f g
 
       -- We compute the pullback of the map into the image and c.
       -- The pseudoelement induced by the first pullback map will be our preimage.
-      use (pullback.fst : pullback (factor_thru_image f) c ⟶ P),
+      use (pullback.fst : pullback (images.factor_thru_image f) c ⟶ P),
 
       -- It remains to show that the image of this element under f is pseudo-equal to b.
       apply quotient.sound,
 
       -- pullback.snd is an epimorphism because the map onto the image is!
-      refine ⟨pullback (factor_thru_image f) c, 𝟙 _, pullback.snd,
+      refine ⟨pullback (images.factor_thru_image f) c, 𝟙 _, pullback.snd,
         by apply_instance, by apply_instance, _⟩,
 
       -- Now we can verify that the diagram commutes.
-      calc 𝟙 (pullback (factor_thru_image f) c) ≫ pullback.fst ≫ f = pullback.fst ≫ f
+      calc 𝟙 (pullback (images.factor_thru_image f) c) ≫ pullback.fst ≫ f = pullback.fst ≫ f
                 : category.id_comp _
-        ... = pullback.fst ≫ factor_thru_image f ≫ kernel.ι (cokernel.π f)
-                : by rw [kernel_cokernel_eq_image_ι, ←image_ι_eq_image_ι, image.fac]
+        ... = pullback.fst ≫ images.factor_thru_image f ≫ kernel.ι (cokernel.π f)
+                : by rw images.image.fac
         ... = (pullback.snd ≫ c) ≫ kernel.ι (cokernel.π f)
                 : by rw [←category.assoc, pullback.condition]
         ... = pullback.snd ≫ b.hom
@@ -336,9 +336,8 @@ begin
   -- The commutative diagram given by the pseudo-equality f a = b induces
   -- a cone over this pullback, so we get a factorization z.
   obtain ⟨z, hz₁, hz₂⟩ := @pullback.lift' _ _ _ _ _ _ (kernel.ι (cokernel.π f)) (kernel.ι g) _
-    (r ≫ a.hom ≫ factor_thru_image f) q
-      (by { simp only [category.assoc, kernel_cokernel_eq_image_ι, ←image_ι_eq_image_ι, image.fac],
-        exact comm }),
+    (r ≫ a.hom ≫ images.factor_thru_image f) q
+      (by { simp only [category.assoc, images.image.fac], exact comm }),
 
   -- Let's give a name to the second pullback morphism.
   let j : pullback (kernel.ι (cokernel.π f)) (kernel.ι g) ⟶ kernel g := pullback.snd,

--- a/src/category_theory/arrow.lean
+++ b/src/category_theory/arrow.lean
@@ -71,16 +71,25 @@ def hom_mk' {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y
 @[reassoc] lemma w {f g : arrow T} (sq : f ⟶ g) : sq.left ≫ g.hom = f.hom ≫ sq.right := sq.w
 
 /-- A lift of a commutative square is a diagonal morphism making the two triangles commute. -/
-@[ext] class has_lift {f g : arrow T} (sq : f ⟶ g) :=
+@[ext] structure lift_struct {f g : arrow T} (sq : f ⟶ g) :=
 (lift : f.right ⟶ g.left)
 (fac_left : f.hom ≫ lift = sq.left)
 (fac_right : lift ≫ g.hom = sq.right)
 
-attribute [simp, reassoc] has_lift.fac_left has_lift.fac_right
+class has_lift {f g : arrow T} (sq : f ⟶ g) : Prop :=
+mk' :: (exists_lift : nonempty (lift_struct sq))
+
+lemma has_lift.mk {f g : arrow T} {sq : f ⟶ g} (s : lift_struct sq) : has_lift sq :=
+⟨nonempty.intro s⟩
+
+attribute [simp, reassoc] lift_struct.fac_left lift_struct.fac_right
+
+noncomputable def has_lift.struct {f g : arrow T} (sq : f ⟶ g) [has_lift sq] : lift_struct sq :=
+classical.choice has_lift.exists_lift
 
 /-- If we have chosen a lift of a commutative square `sq`, we can access it by saying `lift sq`. -/
-abbreviation lift {f g : arrow T} (sq : f ⟶ g) [has_lift sq] : f.right ⟶ g.left :=
-has_lift.lift sq
+noncomputable abbreviation lift {f g : arrow T} (sq : f ⟶ g) [has_lift sq] : f.right ⟶ g.left :=
+(has_lift.struct sq).lift
 
 lemma lift.fac_left {f g : arrow T} (sq : f ⟶ g) [has_lift sq] : f.hom ≫ lift sq = sq.left :=
 by simp
@@ -100,13 +109,13 @@ by simp only [←arrow.mk_hom g, lift.fac_right, arrow.hom_mk'_right]
 
 section
 
-instance subsingleton_has_lift_of_epi {f g : arrow T} (sq : f ⟶ g) [epi f.hom] :
-  subsingleton (has_lift sq) :=
-subsingleton.intro $ λ a b, has_lift.ext a b $ (cancel_epi f.hom).1 $ by simp
+instance subsingleton_lift_struct_of_epi {f g : arrow T} (sq : f ⟶ g) [epi f.hom] :
+  subsingleton (lift_struct sq) :=
+subsingleton.intro $ λ a b, lift_struct.ext a b $ (cancel_epi f.hom).1 $ by simp
 
-instance subsingleton_has_lift_of_mono {f g : arrow T} (sq : f ⟶ g) [mono g.hom] :
-  subsingleton (has_lift sq) :=
-subsingleton.intro $ λ a b, has_lift.ext a b $ (cancel_mono g.hom).1 $ by simp
+instance subsingleton_lift_struct_of_mono {f g : arrow T} (sq : f ⟶ g) [mono g.hom] :
+  subsingleton (lift_struct sq) :=
+subsingleton.intro $ λ a b, lift_struct.ext a b $ (cancel_mono g.hom).1 $ by simp
 
 end
 

--- a/src/category_theory/arrow.lean
+++ b/src/category_theory/arrow.lean
@@ -76,6 +76,11 @@ def hom_mk' {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} {u : X ⟶ P} {v : Y
 (fac_left : f.hom ≫ lift = sq.left)
 (fac_right : lift ≫ g.hom = sq.right)
 
+instance lift_struct_inhabited {X : T} : inhabited (lift_struct (𝟙 (arrow.mk (𝟙 X)))) :=
+⟨⟨𝟙 _, category.id_comp _, category.comp_id _⟩⟩
+
+/-- `has_lift sq` says that there is some `lift_struct sq`, i.e., that it is possible to find a
+    diagonal morphism making the two triangles commute. -/
 class has_lift {f g : arrow T} (sq : f ⟶ g) : Prop :=
 mk' :: (exists_lift : nonempty (lift_struct sq))
 
@@ -84,10 +89,11 @@ lemma has_lift.mk {f g : arrow T} {sq : f ⟶ g} (s : lift_struct sq) : has_lift
 
 attribute [simp, reassoc] lift_struct.fac_left lift_struct.fac_right
 
+/-- Given `has_lift sq`, obtain a lift. -/
 noncomputable def has_lift.struct {f g : arrow T} (sq : f ⟶ g) [has_lift sq] : lift_struct sq :=
 classical.choice has_lift.exists_lift
 
-/-- If we have chosen a lift of a commutative square `sq`, we can access it by saying `lift sq`. -/
+/-- If there is a lift of a commutative square `sq`, we can access it by saying `lift sq`. -/
 noncomputable abbreviation lift {f g : arrow T} (sq : f ⟶ g) [has_lift sq] : f.right ⟶ g.left :=
 (has_lift.struct sq).lift
 

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -197,6 +197,11 @@ lemma image.lift_fac (F' : mono_factorisation f) : image.lift F' ≫ F'.m = imag
 lemma image.fac_lift (F' : mono_factorisation f) : factor_thru_image f ≫ image.lift F' = F'.e :=
 (image.is_image f).fac_lift F'
 
+@[simp, reassoc]
+lemma is_image.lift_ι {F : mono_factorisation f} (hF : is_image F) :
+  hF.lift (image.mono_factorisation f) ≫ image.ι f = F.m :=
+hF.lift_fac _
+
 -- TODO we could put a category structure on `mono_factorisation f`,
 -- with the morphisms being `g : I ⟶ I'` commuting with the `m`s
 -- (they then automatically commute with the `e`s)
@@ -406,12 +411,26 @@ lemma image_map.factor_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (
   factor_thru_image f.hom ≫ m.map = sq.left ≫ factor_thru_image g.hom :=
 (cancel_mono (image.ι g.hom)).1 $ by simp [arrow.w]
 
+/-- To give an image map for a commutative square with `f` at the top and `g` at the bottom, it
+    suffices to give a map between any mono factorisation of `f` and any image factorisation of
+    `g`. -/
+def image_map.transport {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g)
+  (F : mono_factorisation f.hom) {F' : mono_factorisation g.hom} (hF' : is_image F')
+  {map : F.I ⟶ F'.I} (map_ι : map ≫ F'.m = F.m ≫ sq.right) : image_map sq :=
+{ map := image.lift F ≫ map ≫ hF'.lift (image.mono_factorisation g.hom),
+  map_ι' := by simp [map_ι] }
+
 class has_image_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g) : Prop :=
 mk' :: (has_image_map : nonempty (image_map sq))
 
 lemma has_image_map.mk {f g : arrow C} [has_image f.hom] [has_image g.hom] {sq : f ⟶ g}
   (m : image_map sq) : has_image_map sq :=
 ⟨nonempty.intro m⟩
+
+lemma has_image_map.transport {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g)
+  (F : mono_factorisation f.hom) {F' : mono_factorisation g.hom} (hF' : is_image F')
+  (map : F.I ⟶ F'.I) (map_ι : map ≫ F'.m = F.m ≫ sq.right) : has_image_map sq :=
+has_image_map.mk $ image_map.transport sq F hF' map_ι
 
 def has_image_map.image_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g)
   [has_image_map sq] : image_map sq :=

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -155,6 +155,9 @@ structure image_factorisation (f : X ⟶ Y) :=
 (F : mono_factorisation f)
 (is_image : is_image F)
 
+instance inhabited_image_factorisation (f : X ⟶ Y) [mono f] : inhabited (image_factorisation f) :=
+⟨⟨_, is_image.self f⟩⟩
+
 /-- `has_image f` means that there exists an image factorisation of `f`. -/
 class has_image (f : X ⟶ Y) : Prop :=
 mk' :: (exists_image : nonempty (image_factorisation f))
@@ -401,6 +404,9 @@ section has_image_map
 structure image_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g) :=
 (map : image f.hom ⟶ image g.hom)
 (map_ι' : map ≫ image.ι g.hom = image.ι f.hom ≫ sq.right . obviously)
+
+instance inhabited_image_map {f : arrow C} [has_image f.hom] : inhabited (image_map (𝟙 f)) :=
+⟨⟨𝟙 _, by tidy⟩⟩
 
 restate_axiom image_map.map_ι'
 attribute [simp, reassoc] image_map.map_ι

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -420,6 +420,7 @@ def image_map.transport {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq 
 { map := image.lift F ≫ map ≫ hF'.lift (image.mono_factorisation g.hom),
   map_ι' := by simp [map_ι] }
 
+/-- `has_image_map sq` means that there is an `image_map` for the square `sq`. -/
 class has_image_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g) : Prop :=
 mk' :: (has_image_map : nonempty (image_map sq))
 
@@ -432,6 +433,7 @@ lemma has_image_map.transport {f g : arrow C} [has_image f.hom] [has_image g.hom
   (map : F.I ⟶ F'.I) (map_ι : map ≫ F'.m = F.m ≫ sq.right) : has_image_map sq :=
 has_image_map.mk $ image_map.transport sq F hF' map_ι
 
+/-- Obtain an `image_map` from a `has_image_map` instance. -/
 def has_image_map.image_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g)
   [has_image_map sq] : image_map sq :=
 classical.choice $ @has_image_map.has_image_map _ _ _ _ _ _ sq _

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -543,7 +543,14 @@ variable (C)
 /-- A category has strong epi-mono factorisations if every morphism admits a strong epi-mono
     factorisation. -/
 class has_strong_epi_mono_factorisations : Prop :=
-(has_fac : Π {X Y : C} (f : X ⟶ Y), nonempty (strong_epi_mono_factorisation f))
+mk' :: (has_fac : Π {X Y : C} (f : X ⟶ Y), nonempty (strong_epi_mono_factorisation f))
+
+variable {C}
+
+lemma has_strong_epi_mono_factorisations.mk
+  (d : Π {X Y : C} (f : X ⟶ Y), strong_epi_mono_factorisation f) :
+  has_strong_epi_mono_factorisations C :=
+⟨λ X Y f, nonempty.intro $ d f⟩
 
 @[priority 100]
 instance has_images_of_has_strong_epi_mono_factorisations

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -49,6 +49,8 @@ so that `m` factors through the `m'` in any other such factorisation.
 
 -/
 
+noncomputable theory
+
 universes v u
 
 open category_theory
@@ -139,20 +141,36 @@ def iso_ext {F F' : mono_factorisation f} (hF : is_image F) (hF' : is_image F') 
   hom_inv_id' := (cancel_mono F.m).1 (by simp),
   inv_hom_id' := (cancel_mono F'.m).1 (by simp) }
 
+variables {F F' : mono_factorisation f} (hF : is_image F) (hF' : is_image F')
+
+lemma iso_ext_hom_m : (iso_ext hF hF').hom ≫ F'.m = F.m := by simp
+lemma iso_ext_inv_m : (iso_ext hF hF').inv ≫ F.m = F'.m := by simp
+lemma e_iso_ext_hom : F.e ≫ (iso_ext hF hF').hom = F'.e := by simp
+lemma e_iso_ext_inv : F'.e ≫ (iso_ext hF hF').inv = F.e := by simp
+
 end is_image
 
 /-- Data exhibiting that a morphism `f` has an image. -/
-class has_image (f : X ⟶ Y) :=
+structure image_factorisation (f : X ⟶ Y) :=
 (F : mono_factorisation f)
 (is_image : is_image F)
+
+/-- `has_image f` means that there exists an image factorisation of `f`. -/
+class has_image (f : X ⟶ Y) : Prop :=
+mk' :: (exists_image : nonempty (image_factorisation f))
+
+lemma has_image.mk {f : X ⟶ Y} (F : image_factorisation f) : has_image f :=
+⟨nonempty.intro F⟩
 
 section
 variable [has_image f]
 
 /-- The chosen factorisation of `f` through a monomorphism. -/
-def image.mono_factorisation : mono_factorisation f := has_image.F
+def image.mono_factorisation : mono_factorisation f :=
+(classical.choice (has_image.exists_image)).F
 /-- The witness of the universal property for the chosen factorisation of `f` through a monomorphism. -/
-def image.is_image : is_image (image.mono_factorisation f) := has_image.is_image
+def image.is_image : is_image (image.mono_factorisation f) :=
+(classical.choice (has_image.exists_image)).is_image
 
 /-- The categorical image of a morphism. -/
 def image : C := (image.mono_factorisation f).I
@@ -375,34 +393,46 @@ section has_image_map
 
 /-- An image map is a morphism `image f → image g` fitting into a commutative square and satisfying
     the obvious commutativity conditions. -/
-class has_image_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g) :=
+structure image_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g) :=
 (map : image f.hom ⟶ image g.hom)
 (map_ι' : map ≫ image.ι g.hom = image.ι f.hom ≫ sq.right . obviously)
 
-restate_axiom has_image_map.map_ι'
-attribute [simp, reassoc] has_image_map.map_ι
+restate_axiom image_map.map_ι'
+attribute [simp, reassoc] image_map.map_ι
 
 @[simp, reassoc]
-lemma has_image_map.factor_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g)
-  [has_image_map sq] :
-  factor_thru_image f.hom ≫ has_image_map.map sq = sq.left ≫ factor_thru_image g.hom :=
+lemma image_map.factor_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g)
+  (m : image_map sq) :
+  factor_thru_image f.hom ≫ m.map = sq.left ≫ factor_thru_image g.hom :=
 (cancel_mono (image.ι g.hom)).1 $ by simp [arrow.w]
+
+class has_image_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g) : Prop :=
+mk' :: (has_image_map : nonempty (image_map sq))
+
+lemma has_image_map.mk {f g : arrow C} [has_image f.hom] [has_image g.hom] {sq : f ⟶ g}
+  (m : image_map sq) : has_image_map sq :=
+⟨nonempty.intro m⟩
+
+def has_image_map.image_map {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g)
+  [has_image_map sq] : image_map sq :=
+classical.choice $ @has_image_map.has_image_map _ _ _ _ _ _ sq _
 
 variables {f g : arrow C} [has_image f.hom] [has_image g.hom] (sq : f ⟶ g)
 
 section
-local attribute [ext] has_image_map
+local attribute [ext] image_map
 
-instance : subsingleton (has_image_map sq) :=
-subsingleton.intro $ λ a b, has_image_map.ext a b $ (cancel_mono (image.ι g.hom)).1 $
-  by simp only [has_image_map.map_ι]
+instance : subsingleton (image_map sq) :=
+subsingleton.intro $ λ a b, image_map.ext a b $ (cancel_mono (image.ι g.hom)).1 $
+  by simp only [image_map.map_ι]
 
 end
 
 variable [has_image_map sq]
 
 /-- The map on images induced by a commutative square. -/
-abbreviation image.map : image f.hom ⟶ image g.hom := has_image_map.map sq
+abbreviation image.map : image f.hom ⟶ image g.hom :=
+(has_image_map.image_map sq).map
 
 lemma image.factor_map :
   factor_thru_image f.hom ≫ image.map sq = sq.left ≫ factor_thru_image g.hom :=
@@ -419,13 +449,13 @@ variables {h : arrow C} [has_image h.hom] (sq' : g ⟶ h)
 variables [has_image_map sq']
 
 /-- Image maps for composable commutative squares induce an image map in the composite square. -/
-def has_image_map_comp : has_image_map (sq ≫ sq') :=
+def image_map_comp : image_map (sq ≫ sq') :=
 { map := image.map sq ≫ image.map sq' }
 
 @[simp]
 lemma image.map_comp [has_image_map (sq ≫ sq')] :
   image.map (sq ≫ sq') = image.map sq ≫ image.map sq' :=
-show (has_image_map.map (sq ≫ sq')) = (has_image_map_comp sq sq').map, by congr
+show (has_image_map.image_map (sq ≫ sq')).map = (image_map_comp sq sq').map, by congr
 
 end
 
@@ -434,12 +464,12 @@ variables (f)
 
 /-- The identity `image f ⟶ image f` fits into the commutative square represented by the identity
     morphism `𝟙 f` in the arrow category. -/
-def has_image_map_id : has_image_map (𝟙 f) :=
+def image_map_id : image_map (𝟙 f) :=
 { map := 𝟙 (image f.hom) }
 
 @[simp]
 lemma image.map_id [has_image_map (𝟙 f)] : image.map (𝟙 f) = 𝟙 (image f.hom) :=
-show (image.map (𝟙 f)) = (has_image_map_id f).map, by congr
+show (has_image_map.image_map (𝟙 f)).map = (image_map_id f).map, by congr
 
 end
 
@@ -493,16 +523,16 @@ variable (C)
 
 /-- A category has strong epi-mono factorisations if every morphism admits a strong epi-mono
     factorisation. -/
-class has_strong_epi_mono_factorisations :=
-(has_fac : Π {X Y : C} (f : X ⟶ Y), strong_epi_mono_factorisation f)
+class has_strong_epi_mono_factorisations : Prop :=
+(has_fac : Π {X Y : C} (f : X ⟶ Y), nonempty (strong_epi_mono_factorisation f))
 
 @[priority 100]
 instance has_images_of_has_strong_epi_mono_factorisations
   [has_strong_epi_mono_factorisations C] : has_images C :=
 { has_image := λ X Y f,
-  let F' := has_strong_epi_mono_factorisations.has_fac f in
-  { F := F'.to_mono_factorisation,
-    is_image := F'.to_mono_is_image } }
+  let F' := classical.choice (has_strong_epi_mono_factorisations.has_fac f) in
+  has_image.mk { F := F'.to_mono_factorisation,
+                 is_image := F'.to_mono_is_image } }
 
 end strong_epi_mono_factorisation
 
@@ -511,7 +541,7 @@ variables (C) [has_images C]
 
 /-- A category has strong epi images if it has all images and `factor_thru_image f` is a strong
     epimorphism for all `f`. -/
-class has_strong_epi_images :=
+class has_strong_epi_images : Prop :=
 (strong_factor_thru_image : Π {X Y : C} (f : X ⟶ Y), strong_epi (factor_thru_image f))
 
 attribute [instance] has_strong_epi_images.strong_factor_thru_image
@@ -519,13 +549,25 @@ end has_strong_epi_images
 
 section has_strong_epi_images
 
+/-- If there is a single strong epi-mono factorisation of `f`, then every image factorisation is a
+    strong epi-mono factorisation. -/
+lemma strong_epi_of_strong_epi_mono_factorisation {X Y : C} {f : X ⟶ Y}
+  (F : strong_epi_mono_factorisation f) {F' : mono_factorisation f} (hF' : is_image F') :
+  strong_epi F'.e :=
+by { rw ←is_image.e_iso_ext_hom F.to_mono_is_image hF', apply strong_epi_comp }
+
+lemma strong_epi_factor_thru_image_of_strong_epi_mono_factorisation {X Y : C} {f : X ⟶ Y}
+  [has_image f] (F : strong_epi_mono_factorisation f) : strong_epi (factor_thru_image f) :=
+strong_epi_of_strong_epi_mono_factorisation F $ image.is_image f
+
 /-- If we constructed our images from strong epi-mono factorisations, then these images are
     strong epi images. -/
 @[priority 100]
 instance has_strong_epi_images_of_has_strong_epi_mono_factorisations
   [has_strong_epi_mono_factorisations C] : has_strong_epi_images C :=
 { strong_factor_thru_image := λ X Y f,
-    (has_strong_epi_mono_factorisations.has_fac f).e_strong_epi }
+    strong_epi_factor_thru_image_of_strong_epi_mono_factorisation $
+      classical.choice $ has_strong_epi_mono_factorisations.has_fac f }
 
 end has_strong_epi_images
 
@@ -554,7 +596,7 @@ instance has_image_maps_of_has_strong_epi_images [has_strong_epi_images C] :
       e_strong_epi := by apply_instance,
       m_mono := mono_comp _ _ } in
     let s : I ⟶ I' := is_image.lift upper.to_mono_is_image lower.to_mono_factorisation in
-    { map := factor_thru_image (image.ι f.hom ≫ st.right) ≫ s ≫
+    has_image_map.mk { map := factor_thru_image (image.ι f.hom ≫ st.right) ≫ s ≫
         image.ι (st.left ≫ factor_thru_image g.hom),
       map_ι' := by rw [category.assoc, category.assoc,
         is_image.lift_fac upper.to_mono_is_image lower.to_mono_factorisation, image.fac] } }

--- a/src/category_theory/limits/shapes/regular_mono.lean
+++ b/src/category_theory/limits/shapes/regular_mono.lean
@@ -287,7 +287,7 @@ instance strong_epi_of_regular_epi (f : X ⟶ Y) [regular_epi f] : strong_epi f 
     { apply (cancel_mono z).1,
       simp only [category.assoc, h, regular_epi.w_assoc] },
     obtain ⟨t, ht⟩ := regular_epi.desc' f u this,
-    exact ⟨t, ht, (cancel_epi f).1
+    exact arrow.has_lift.mk ⟨t, ht, (cancel_epi f).1
       (by simp only [←category.assoc, ht, ←h, arrow.mk_hom, arrow.hom_mk'_right])⟩,
   end }
 

--- a/src/category_theory/limits/shapes/strong_epi.lean
+++ b/src/category_theory/limits/shapes/strong_epi.lean
@@ -52,7 +52,7 @@ section
 variables {R : C} (f : P ⟶ Q) (g : Q ⟶ R)
 
 /-- The composition of two strong epimorphisms is a strong epimorphism. -/
-def strong_epi_comp [strong_epi f] [strong_epi g] : strong_epi (f ≫ g) :=
+lemma strong_epi_comp [strong_epi f] [strong_epi g] : strong_epi (f ≫ g) :=
 { epi := epi_comp _ _,
   has_lift :=
   begin
@@ -64,7 +64,7 @@ def strong_epi_comp [strong_epi f] [strong_epi g] : strong_epi (f ≫ g) :=
   end }
 
 /-- If `f ≫ g` is a strong epimorphism, then so is g. -/
-def strong_epi_of_strong_epi [strong_epi (f ≫ g)] : strong_epi g :=
+lemma strong_epi_of_strong_epi [strong_epi (f ≫ g)] : strong_epi g :=
 { epi := epi_of_epi f g,
   has_lift :=
   begin

--- a/src/category_theory/limits/shapes/strong_epi.lean
+++ b/src/category_theory/limits/shapes/strong_epi.lean
@@ -38,7 +38,7 @@ variables {P Q : C}
 
 /-- A strong epimorphism `f` is an epimorphism such that every commutative square with `f` at the
     top and a monomorphism at the bottom has a lift. -/
-class strong_epi (f : P ⟶ Q) :=
+class strong_epi (f : P ⟶ Q) : Prop :=
 (epi : epi f)
 (has_lift : Π {X Y : C} {u : P ⟶ X} {v : Q ⟶ Y} {z : X ⟶ Y} [mono z] (h : u ≫ z = f ≫ v),
   arrow.has_lift $ arrow.hom_mk' h)
@@ -60,7 +60,7 @@ def strong_epi_comp [strong_epi f] [strong_epi g] : strong_epi (f ≫ g) :=
     have h₀ : u ≫ z = f ≫ g ≫ v, by simpa [category.assoc] using h,
     let w : Q ⟶ X := arrow.lift (arrow.hom_mk' h₀),
     have h₁ : w ≫ z = g ≫ v, by rw arrow.lift_mk'_right,
-    exact ⟨(arrow.lift (arrow.hom_mk' h₁) : R ⟶ X), by simp, by simp⟩
+    exact arrow.has_lift.mk ⟨(arrow.lift (arrow.hom_mk' h₁) : R ⟶ X), by simp, by simp⟩
   end }
 
 /-- If `f ≫ g` is a strong epimorphism, then so is g. -/
@@ -70,13 +70,19 @@ def strong_epi_of_strong_epi [strong_epi (f ≫ g)] : strong_epi g :=
   begin
     introsI,
     have h₀ : (f ≫ u) ≫ z = (f ≫ g) ≫ v, by simp only [category.assoc, h],
-    exact ⟨(arrow.lift (arrow.hom_mk' h₀) : R ⟶ X), (cancel_mono z).1 (by simp [h]), by simp⟩,
+    exact arrow.has_lift.mk
+      ⟨(arrow.lift (arrow.hom_mk' h₀) : R ⟶ X), (cancel_mono z).1 (by simp [h]), by simp⟩,
   end }
+
+/-- An isomorphism is in particular a strong epimorphism. -/
+@[priority 100] instance strong_epi_of_is_iso [is_iso f] : strong_epi f :=
+{ epi := by apply_instance,
+  has_lift := λ X Y u v z _ h, arrow.has_lift.mk ⟨inv f ≫ u, by simp, by simp [h]⟩ }
 
 end
 
 /-- A strong epimorphism that is a monomorphism is an isomorphism. -/
-def is_iso_of_mono_of_strong_epi (f : P ⟶ Q) [mono f] [strong_epi f] : is_iso f :=
+noncomputable def is_iso_of_mono_of_strong_epi (f : P ⟶ Q) [mono f] [strong_epi f] : is_iso f :=
 { inv := arrow.lift $ arrow.hom_mk' $ show 𝟙 P ≫ f = f ≫ 𝟙 Q, by simp }
 
 end category_theory

--- a/src/category_theory/limits/shapes/zero.lean
+++ b/src/category_theory/limits/shapes/zero.lean
@@ -357,24 +357,23 @@ def mono_factorisation_zero (X Y : C) : mono_factorisation (0 : X ⟶ Y) :=
 { I := 0, m := 0, e := 0, }
 
 /--
-Any zero morphism has an image.
-We don't set this as an instance, as it is only intended for use inside the following proofs.
+The factorisation through the zero object is an image factorisation.
 -/
-def has_image.zero (X Y : C) : has_image (0 : X ⟶ Y) :=
+def image_factorisation_zero (X Y : C) : image_factorisation (0 : X ⟶ Y) :=
 { F := mono_factorisation_zero X Y,
-  is_image :=
-  { lift := λ F', 0 }}
+  is_image := { lift := λ F', 0 } }
+
+
+instance has_image_zero {X Y : C} : has_image (0 : X ⟶ Y) :=
+has_image.mk $ image_factorisation_zero _ _
 
 /-- The image of a zero morphism is the zero object. -/
-def image_zero {X Y : C} [has_image (0 : X ⟶ Y)] : image (0 : X ⟶ Y) ≅ 0 :=
-is_image.iso_ext (image.is_image (0 : X ⟶ Y)) (has_image.zero X Y).is_image
+def image_zero {X Y : C} : image (0 : X ⟶ Y) ≅ 0 :=
+is_image.iso_ext (image.is_image (0 : X ⟶ Y)) (image_factorisation_zero X Y).is_image
 
 /-- The image of a morphism which is equal to zero is the zero object. -/
 def image_zero' {X Y : C} {f : X ⟶ Y} (h : f = 0) [has_image f] : image f ≅ 0 :=
-begin
-  haveI := has_image.zero X Y,
-  exact image.eq_to_iso h ≪≫ image_zero,
-end
+image.eq_to_iso h ≪≫ image_zero
 
 @[simp]
 lemma image.ι_zero {X Y : C} [has_image (0 : X ⟶ Y)] : image.ι (0 : X ⟶ Y) = 0 :=
@@ -391,11 +390,7 @@ because `f = g` only implies `image f ≅ image g`.
 @[simp]
 lemma image.ι_zero' [has_equalizers C] {X Y : C} {f : X ⟶ Y} (h : f = 0) [has_image f] :
   image.ι f = 0 :=
-begin
-  haveI := has_image.zero X Y,
-  rw image.eq_fac h,
-  simp,
-end
+by { rw image.eq_fac h, simp }
 
 end image
 

--- a/src/category_theory/limits/types.lean
+++ b/src/category_theory/limits/types.lean
@@ -364,33 +364,31 @@ begin
 end
 end
 
-/-- the factorisation of any morphism in AddCommGroup through a mono. -/
+/-- the factorisation of any morphism in Type through a mono. -/
 def mono_factorisation : mono_factorisation f :=
 { I := image f,
   m := image.ι f,
   e := set.range_factorization f }
 
-noncomputable instance : has_image f :=
-{ F := mono_factorisation f,
-  is_image :=
-  { lift := image.lift,
-    lift_fac' := image.lift_fac } }
+/-- the facorisation through a mono has the universal property of the image. -/
+noncomputable def is_image : is_image (mono_factorisation f) :=
+{ lift := image.lift,
+  lift_fac' := image.lift_fac }
 
-noncomputable instance : has_images (Type u) :=
-{ has_image := infer_instance }
+instance : has_image f :=
+has_image.mk ⟨_, is_image f⟩
 
-noncomputable instance : has_image_maps (Type u) :=
-{ has_image_map := λ f g st,
-  { map := λ x, ⟨st.right x.1, ⟨st.left (classical.some x.2),
+instance : has_images (Type u) :=
+{ has_image := by apply_instance }
+
+instance : has_image_maps (Type u) :=
+{ has_image_map := λ f g st, has_image_map.transport st (mono_factorisation f.hom) (is_image g.hom)
+    (λ x, ⟨st.right x.1, ⟨st.left (classical.some x.2),
       begin
         have p := st.w,
         replace p := congr_fun p (classical.some x.2),
         simp only [functor.id_map, types_comp_apply, subtype.val_eq_coe] at p,
         erw [p, classical.some_spec x.2],
-      end⟩⟩ } }
-
-@[simp] lemma image_map {f g : arrow (Type u)} (st : f ⟶ g) (x : image f.hom) :
-  (image.map st x).val = st.right x.1 :=
-rfl
+      end⟩⟩) rfl }
 
 end category_theory.limits.types

--- a/src/category_theory/simple.lean
+++ b/src/category_theory/simple.lean
@@ -7,6 +7,8 @@ import category_theory.limits.shapes.zero
 import category_theory.limits.shapes.kernels
 import category_theory.abelian.basic
 
+noncomputable theory
+
 open category_theory.limits
 
 namespace category_theory


### PR DESCRIPTION
This is an obious follow-up to #3995. It changes the following declarations to a `Prop`:
* `arrow.has_lift`
* `strong_epi`
* `has_image`/`has_images`
* `has_strong_epi_mono_factorisations`
* `has_image_map`/`has_image_maps`

The big win is that there is now precisely one notion of exactness in every category with kernels and images, not a (different but provably equal) notion of exactness per `has_kernels` and `has_images` instance like in the pre-#3995 era.

---
<!-- put comments you want to keep out of the PR commit here -->
