### PR TITLE
[Merged by Bors] - chore(data/mv_polynomial): Rename variables

### DIFF
--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -14,11 +14,11 @@ with variables from a general type `σ` (which could be infinite).
 
 ## Important definitions
 
-Let `R` be a commutative ring (or a semiring) and let `σ` be an arbitrary
-type. This file creates the type `mv_polynomial σ R`, which mathematicians
-might denote $R[X_i : i \in \sigma]$. It is the type of multivariate
+Let `α` be a commutative ring (or a semiring) and let `σ` be an arbitrary
+type. This file creates the type `mv_polynomial σ α`, which mathematicians
+might denote $R[X_i : i \in σ]$. It is the type of multivariate
 (a.k.a. multivariable) polynomials, with variables
-corresponding to the terms in `σ`, and coefficients in `R`.
+corresponding to the terms in `σ`, and coefficients in `α`.
 
 ### Notation
 
@@ -26,7 +26,7 @@ In the definitions below, we use the following notation:
 
 + `σ : Type*` (indexing the variables)
 
-+ `R : Type*` `[comm_semiring R]` (the coefficients)
++ `α : Type*` `[comm_semiring R]` (the coefficients)
 
 + `s : σ →₀ ℕ`, a function from `σ` to `ℕ` which is zero away from a finite set.
 This will give rise to a monomial in `mv_polynomial σ R` which mathematicians might call `X^s`
@@ -50,15 +50,15 @@ This will give rise to a monomial in `mv_polynomial σ R` which mathematicians m
 
 * `coeff s p` : the coefficient of `s` in `p`.
 
-* `eval₂ (f : R → S) (g : σ → S) p` : given a semiring homomorphism from `R` to another
-  semiring `S`, and a map `σ → S`, evaluates `p` at this valuation, returning a term of type `S`.
+* `eval₂ (f : α → β) (g : σ → β) p` : given a semiring homomorphism from `α` to another
+  semiring `β`, and a map `σ → β`, evaluates `p` at this valuation, returning a term of type `β`.
   Note that `eval₂` can be made using `eval` and `map` (see below), and it has been suggested
   that sticking to `eval` and `map` might make the code less brittle.
 
-* `eval (g : σ → R) p` : given a map `σ → R`, evaluates `p` at this valuation,
-  returning a term of type `R`
+* `eval (g : σ → α) p` : given a map `σ → α`, evaluates `p` at this valuation,
+  returning a term of type `α`
 
-* `map (f : R → S) p` : returns the multivariate polynomial obtained from `p` by the change of
+* `map (f : α → β) p` : returns the multivariate polynomial obtained from `p` by the change of
   coefficient semiring corresponding to `f`
 
 ## Implementation notes

--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -14,11 +14,11 @@ with variables from a general type `σ` (which could be infinite).
 
 ## Important definitions
 
-Let `α` be a commutative ring (or a semiring) and let `σ` be an arbitrary
-type. This file creates the type `mv_polynomial σ α`, which mathematicians
+Let `R` be a commutative ring (or a semiring) and let `σ` be an arbitrary
+type. This file creates the type `mv_polynomial σ R`, which mathematicians
 might denote $R[X_i : i \in σ]$. It is the type of multivariate
 (a.k.a. multivariable) polynomials, with variables
-corresponding to the terms in `σ`, and coefficients in `α`.
+corresponding to the terms in `σ`, and coefficients in `R`.
 
 ### Notation
 
@@ -26,7 +26,7 @@ In the definitions below, we use the following notation:
 
 + `σ : Type*` (indexing the variables)
 
-+ `α : Type*` `[comm_semiring α]` (the coefficients)
++ `R : Type*` `[comm_semiring R]` (the coefficients)
 
 + `s : σ →₀ ℕ`, a function from `σ` to `ℕ` which is zero away from a finite set.
 This will give rise to a monomial in `mv_polynomial σ R` which mathematicians might call `X^s`
@@ -50,23 +50,23 @@ This will give rise to a monomial in `mv_polynomial σ R` which mathematicians m
 
 * `coeff s p` : the coefficient of `s` in `p`.
 
-* `eval₂ (f : α → β) (g : σ → β) p` : given a semiring homomorphism from `α` to another
+* `eval₂ (f : R → β) (g : σ → β) p` : given a semiring homomorphism from `R` to another
   semiring `β`, and a map `σ → β`, evaluates `p` at this valuation, returning a term of type `β`.
   Note that `eval₂` can be made using `eval` and `map` (see below), and it has been suggested
   that sticking to `eval` and `map` might make the code less brittle.
 
-* `eval (g : σ → α) p` : given a map `σ → α`, evaluates `p` at this valuation,
-  returning a term of type `α`
+* `eval (g : σ → R) p` : given a map `σ → R`, evaluates `p` at this valuation,
+  returning a term of type `R`
 
-* `map (f : α → β) p` : returns the multivariate polynomial obtained from `p` by the change of
+* `map (f : R → β) p` : returns the multivariate polynomial obtained from `p` by the change of
   coefficient semiring corresponding to `f`
 
 ## Implementation notes
 
 Recall that if `Y` has a zero, then `X →₀ Y` is the type of functions from `X` to `Y` with finite
 support, i.e. such that only finitely many elements of `X` get sent to non-zero terms in `Y`.
-The definition of `mv_polynomial σ α` is `(σ →₀ ℕ) →₀ α` ; here `σ →₀ ℕ` denotes the space of all
-monomials in the variables, and the function to `α` sends a monomial to its coefficient in
+The definition of `mv_polynomial σ R` is `(σ →₀ ℕ) →₀ R` ; here `σ →₀ ℕ` denotes the space of all
+monomials in the variables, and the function to `R` sends a monomial to its coefficient in
 the polynomial being represented.
 
 ## Tags
@@ -82,62 +82,62 @@ open set function finsupp add_monoid_algebra
 open_locale big_operators
 
 universes u v w x
-variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
+variables {R : Type u} {β : Type v} {γ : Type w} {δ : Type x}
 
 /-- Multivariate polynomial, where `σ` is the index set of the variables and
-  `α` is the coefficient ring -/
-def mv_polynomial (σ : Type*) (α : Type*) [comm_semiring α] := add_monoid_algebra α (σ →₀ ℕ)
+  `R` is the coefficient ring -/
+def mv_polynomial (σ : Type*) (R : Type*) [comm_semiring R] := add_monoid_algebra R (σ →₀ ℕ)
 
 namespace mv_polynomial
-variables {σ : Type*} {a a' a₁ a₂ : α} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
+variables {σ : Type*} {a a' a₁ a₂ : R} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
 
 section comm_semiring
-variables [comm_semiring α] {p q : mv_polynomial σ α}
+variables [comm_semiring R] {p q : mv_polynomial σ R}
 
-instance decidable_eq_mv_polynomial [decidable_eq σ] [decidable_eq α] :
-  decidable_eq (mv_polynomial σ α) := finsupp.decidable_eq
-instance : comm_semiring (mv_polynomial σ α) := add_monoid_algebra.comm_semiring
-instance : inhabited (mv_polynomial σ α) := ⟨0⟩
-instance : has_scalar α (mv_polynomial σ α) := add_monoid_algebra.has_scalar
-instance : semimodule α (mv_polynomial σ α) := add_monoid_algebra.semimodule
-instance : algebra α (mv_polynomial σ α) := add_monoid_algebra.algebra
+instance decidable_eq_mv_polynomial [decidable_eq σ] [decidable_eq R] :
+  decidable_eq (mv_polynomial σ R) := finsupp.decidable_eq
+instance : comm_semiring (mv_polynomial σ R) := add_monoid_algebra.comm_semiring
+instance : inhabited (mv_polynomial σ R) := ⟨0⟩
+instance : has_scalar R (mv_polynomial σ R) := add_monoid_algebra.has_scalar
+instance : semimodule R (mv_polynomial σ R) := add_monoid_algebra.semimodule
+instance : algebra R (mv_polynomial σ R) := add_monoid_algebra.algebra
 
 /-- the coercion turning an `mv_polynomial` into the function which reports the coefficient of a given monomial -/
-def coeff_coe_to_fun : has_coe_to_fun (mv_polynomial σ α) :=
+def coeff_coe_to_fun : has_coe_to_fun (mv_polynomial σ R) :=
 finsupp.has_coe_to_fun
 
 local attribute [instance] coeff_coe_to_fun
 
 /-- `monomial s a` is the monomial `a * X^s` -/
-def monomial (s : σ →₀ ℕ) (a : α) : mv_polynomial σ α := single s a
+def monomial (s : σ →₀ ℕ) (a : R) : mv_polynomial σ R := single s a
 
 /-- `C a` is the constant polynomial with value `a` -/
-def C : α →+* mv_polynomial σ α :=
+def C : R →+* mv_polynomial σ R :=
 { to_fun := monomial 0,
   map_zero' := by simp [monomial],
   map_one' := rfl,
   map_add' := λ a a', single_add,
   map_mul' := λ a a', by simp [monomial, single_mul_single] }
 
-variables (α σ)
-theorem algebra_map_eq : algebra_map α (mv_polynomial σ α) = C := rfl
-variables {α σ}
+variables (R σ)
+theorem algebra_map_eq : algebra_map R (mv_polynomial σ R) = C := rfl
+variables {R σ}
 
 /-- `X n` is the degree `1` monomial `1*n` -/
-def X (n : σ) : mv_polynomial σ α := monomial (single n 1) 1
+def X (n : σ) : mv_polynomial σ R := monomial (single n 1) 1
 
-@[simp] lemma C_0 : C 0 = (0 : mv_polynomial σ α) := by simp [C, monomial]; refl
+@[simp] lemma C_0 : C 0 = (0 : mv_polynomial σ R) := by simp [C, monomial]; refl
 
-@[simp] lemma C_1 : C 1 = (1 : mv_polynomial σ α) := rfl
+@[simp] lemma C_1 : C 1 = (1 : mv_polynomial σ R) := rfl
 
 lemma C_mul_monomial : C a * monomial s a' = monomial s (a * a') :=
 by simp [C, monomial, single_mul_single]
 
-@[simp] lemma C_add : (C (a + a') : mv_polynomial σ α) = C a + C a' := single_add
+@[simp] lemma C_add : (C (a + a') : mv_polynomial σ R) = C a + C a' := single_add
 
-@[simp] lemma C_mul : (C (a * a') : mv_polynomial σ α) = C a * C a' := C_mul_monomial.symm
+@[simp] lemma C_mul : (C (a * a') : mv_polynomial σ R) = C a * C a' := C_mul_monomial.symm
 
-@[simp] lemma C_pow (a : α) (n : ℕ) : (C (a^n) : mv_polynomial σ α) = (C a)^n :=
+@[simp] lemma C_pow (a : R) (n : ℕ) : (C (a^n) : mv_polynomial σ R) = (C a)^n :=
 by induction n; simp [pow_succ, *]
 
 lemma C_injective (σ : Type*) (R : Type*) [comm_ring R] :
@@ -148,15 +148,15 @@ finsupp.single_injective _
   (C r : mv_polynomial σ R) = C s ↔ r = s :=
 (C_injective σ R).eq_iff
 
-lemma C_eq_coe_nat (n : ℕ) : (C ↑n : mv_polynomial σ α) = n :=
+lemma C_eq_coe_nat (n : ℕ) : (C ↑n : mv_polynomial σ R) = n :=
 by induction n; simp [nat.succ_eq_add_one, *]
 
 theorem C_mul' : mv_polynomial.C a * p = a • p :=
 begin
   apply finsupp.induction p,
-  { exact (mul_zero $ mv_polynomial.C a).trans (@smul_zero α (mv_polynomial σ α) _ _ _ a).symm },
+  { exact (mul_zero $ mv_polynomial.C a).trans (@smul_zero R (mv_polynomial σ R) _ _ _ a).symm },
   intros p b f haf hb0 ih,
-  rw [mul_add, ih, @smul_add α (mv_polynomial σ α) _ _ _ a], congr' 1,
+  rw [mul_add, ih, @smul_add R (mv_polynomial σ R) _ _ _ a], congr' 1,
   rw [add_monoid_algebra.mul_def, finsupp.smul_single],
   simp only [mv_polynomial.C],
   dsimp [mv_polynomial.monomial],
@@ -166,9 +166,9 @@ begin
     all_goals { rw [zero_mul, finsupp.single_zero] }, }
 end
 
-lemma smul_eq_C_mul (p : mv_polynomial σ α) (a : α) : a • p = C a * p := C_mul'.symm
+lemma smul_eq_C_mul (p : mv_polynomial σ R) (a : R) : a • p = C a * p := C_mul'.symm
 
-lemma X_pow_eq_single : X n ^ e = monomial (single n e) (1 : α) :=
+lemma X_pow_eq_single : X n ^ e = monomial (single n e) (1 : R) :=
 begin
   induction e,
   { simp [X], refl },
@@ -182,27 +182,27 @@ by rw [X_pow_eq_single, monomial, monomial, monomial, single_mul_single]; simp
 lemma monomial_single_add : monomial (single n e + s) a = (X n ^ e * monomial s a) :=
 by rw [X_pow_eq_single, monomial, monomial, monomial, single_mul_single]; simp
 
-lemma single_eq_C_mul_X {s : σ} {a : α} {n : ℕ} :
+lemma single_eq_C_mul_X {s : σ} {a : R} {n : ℕ} :
   monomial (single s n) a = C a * (X s)^n :=
 by { rw [← zero_add (single s n), monomial_add_single, C], refl }
 
-@[simp] lemma monomial_add {s : σ →₀ ℕ} {a b : α} :
+@[simp] lemma monomial_add {s : σ →₀ ℕ} {a b : R} :
   monomial s a + monomial s b = monomial s (a + b) :=
 by simp [monomial]
 
-@[simp] lemma monomial_mul {s s' : σ →₀ ℕ} {a b : α} :
+@[simp] lemma monomial_mul {s s' : σ →₀ ℕ} {a b : R} :
   monomial s a * monomial s' b = monomial (s + s') (a * b) :=
 by rw [monomial, monomial, monomial, add_monoid_algebra.single_mul_single]
 
-@[simp] lemma monomial_zero {s : σ →₀ ℕ}: monomial s (0 : α) = 0 :=
+@[simp] lemma monomial_zero {s : σ →₀ ℕ}: monomial s (0 : R) = 0 :=
 by rw [monomial, single_zero]; refl
 
 @[simp] lemma sum_monomial  {A : Type*} [add_comm_monoid A]
-  {u : σ →₀ ℕ} {r : α} {b : (σ →₀ ℕ) → α → A} (w : b u 0 = 0) :
+  {u : σ →₀ ℕ} {r : R} {b : (σ →₀ ℕ) → R → A} (w : b u 0 = 0) :
   sum (monomial u r) b = b u r :=
 sum_single_index w
 
-lemma monomial_eq : monomial s a = C a * (s.prod $ λn e, X n ^ e : mv_polynomial σ α) :=
+lemma monomial_eq : monomial s a = C a * (s.prod $ λn e, X n ^ e : mv_polynomial σ R) :=
 begin
   apply @finsupp.induction σ ℕ _ _ s,
   { simp only [C, prod_zero_index]; exact (mul_one _).symm },
@@ -214,7 +214,7 @@ begin
 end
 
 @[recursor 5]
-lemma induction_on {M : mv_polynomial σ α → Prop} (p : mv_polynomial σ α)
+lemma induction_on {M : mv_polynomial σ R → Prop} (p : mv_polynomial σ R)
   (h_C : ∀a, M (C a)) (h_add : ∀p q, M p → M q → M (p + q)) (h_X : ∀p n, M p → M (p * X n)) :
   M p :=
 have ∀s a, M (monomial s a),
@@ -234,28 +234,28 @@ finsupp.induction p
   (by have : M (C 0) := h_C 0; rwa [C_0] at this)
   (assume s a p hsp ha hp, h_add _ _ (this s a) hp)
 
-theorem induction_on' {P : mv_polynomial σ α → Prop} (p : mv_polynomial σ α)
-    (h1 : ∀ (u : σ →₀ ℕ) (a : α), P (monomial u a))
-    (h2 : ∀ (p q : mv_polynomial σ α), P p → P q → P (p + q)) : P p :=
+theorem induction_on' {P : mv_polynomial σ R → Prop} (p : mv_polynomial σ R)
+    (h1 : ∀ (u : σ →₀ ℕ) (a : R), P (monomial u a))
+    (h2 : ∀ (p q : mv_polynomial σ R), P p → P q → P (p + q)) : P p :=
 finsupp.induction p (suffices P (monomial 0 0), by rwa monomial_zero at this,
                      show P (monomial 0 0), from h1 0 0)
                     (λ a b f ha hb hPf, h2 _ _ (h1 _ _) hPf)
 
 
 lemma hom_eq_hom [semiring γ]
-  (f g : mv_polynomial σ α →+* γ)
-  (hC : ∀a:α, f (C a) = g (C a)) (hX : ∀n:σ, f (X n) = g (X n)) (p : mv_polynomial σ α) :
+  (f g : mv_polynomial σ R →+* γ)
+  (hC : ∀a:R, f (C a) = g (C a)) (hX : ∀n:σ, f (X n) = g (X n)) (p : mv_polynomial σ R) :
   f p = g p :=
 mv_polynomial.induction_on p hC
   begin assume p q hp hq, rw [is_semiring_hom.map_add f, is_semiring_hom.map_add g, hp, hq] end
   begin assume p n hp, rw [is_semiring_hom.map_mul f, is_semiring_hom.map_mul g, hp, hX] end
 
-lemma is_id (f : mv_polynomial σ α →+* mv_polynomial σ α)
-  (hC : ∀a:α, f (C a) = (C a)) (hX : ∀n:σ, f (X n) = (X n)) (p : mv_polynomial σ α) :
+lemma is_id (f : mv_polynomial σ R →+* mv_polynomial σ R)
+  (hC : ∀a:R, f (C a) = (C a)) (hX : ∀n:σ, f (X n) = (X n)) (p : mv_polynomial σ R) :
   f p = p :=
 hom_eq_hom f (ring_hom.id _) hC hX p
 
-lemma ring_hom_ext {A : Type*} [comm_semiring A] (f g : mv_polynomial σ α →+* A)
+lemma ring_hom_ext {A : Type*} [comm_semiring A] (f g : mv_polynomial σ R →+* A)
   (hC : ∀ r, f (C r) = g (C r)) (hX : ∀ i, f (X i) = g (X i)) :
   f = g :=
 begin
@@ -266,19 +266,19 @@ begin
   { intros p q hp hq, simp only [ring_hom.map_add, hp, hq] }
 end
 
-lemma alg_hom_ext {A : Type*} [comm_semiring A] [algebra α A]
-  (f g : mv_polynomial σ α →ₐ[α] A) (hf : ∀ i : σ, f (X i) = g (X i)) :
+lemma alg_hom_ext {A : Type*} [comm_semiring A] [algebra R A]
+  (f g : mv_polynomial σ R →ₐ[R] A) (hf : ∀ i : σ, f (X i) = g (X i)) :
   f = g :=
 begin
   apply alg_hom.coe_ring_hom_injective,
   apply ring_hom_ext,
   { intro r,
-    calc f (C r) = algebra_map α A r : f.commutes r
+    calc f (C r) = algebra_map R A r : f.commutes r
              ... = g (C r)           : (g.commutes r).symm },
   { simpa only [hf] },
 end
 
-@[simp] lemma alg_hom_C (f : mv_polynomial σ α →ₐ[α] mv_polynomial σ α) (r : α) :
+@[simp] lemma alg_hom_C (f : mv_polynomial σ R →ₐ[R] mv_polynomial σ R) (r : R) :
   f (C r) = C r :=
 f.commutes r
 
@@ -289,63 +289,63 @@ section
 local attribute [reducible] mv_polynomial
 
 /-- The coefficient of the monomial `m` in the multi-variable polynomial `p`. -/
-def coeff (m : σ →₀ ℕ) (p : mv_polynomial σ α) : α := p m
+def coeff (m : σ →₀ ℕ) (p : mv_polynomial σ R) : R := p m
 end
 
-lemma ext (p q : mv_polynomial σ α) :
+lemma ext (p q : mv_polynomial σ R) :
   (∀ m, coeff m p = coeff m q) → p = q := ext
 
-lemma ext_iff (p q : mv_polynomial σ α) :
+lemma ext_iff (p q : mv_polynomial σ R) :
   p = q ↔ (∀ m, coeff m p = coeff m q) :=
 ⟨ λ h m, by rw h, ext p q⟩
 
-@[simp] lemma coeff_add (m : σ →₀ ℕ) (p q : mv_polynomial σ α) :
+@[simp] lemma coeff_add (m : σ →₀ ℕ) (p q : mv_polynomial σ R) :
   coeff m (p + q) = coeff m p + coeff m q := add_apply
 
 @[simp] lemma coeff_zero (m : σ →₀ ℕ) :
-  coeff m (0 : mv_polynomial σ α) = 0 := rfl
+  coeff m (0 : mv_polynomial σ R) = 0 := rfl
 
-@[simp] lemma coeff_zero_X (i : σ) : coeff 0 (X i : mv_polynomial σ α) = 0 :=
+@[simp] lemma coeff_zero_X (i : σ) : coeff 0 (X i : mv_polynomial σ R) = 0 :=
 single_eq_of_ne (λ h, by cases single_eq_zero.1 h)
 
 instance coeff.is_add_monoid_hom (m : σ →₀ ℕ) :
-  is_add_monoid_hom (coeff m : mv_polynomial σ α → α) :=
+  is_add_monoid_hom (coeff m : mv_polynomial σ R → R) :=
 { map_add := coeff_add m,
   map_zero := coeff_zero m }
 
-lemma coeff_sum {X : Type*} (s : finset X) (f : X → mv_polynomial σ α) (m : σ →₀ ℕ) :
+lemma coeff_sum {X : Type*} (s : finset X) (f : X → mv_polynomial σ R) (m : σ →₀ ℕ) :
   coeff m (∑ x in s, f x) = ∑ x in s, coeff m (f x) :=
 (s.sum_hom _).symm
 
-lemma monic_monomial_eq (m) : monomial m (1:α) = (m.prod $ λn e, X n ^ e : mv_polynomial σ α) :=
+lemma monic_monomial_eq (m) : monomial m (1:R) = (m.prod $ λn e, X n ^ e : mv_polynomial σ R) :=
 by simp [monomial_eq]
 
 @[simp] lemma coeff_monomial (m n) (a) :
-  coeff m (monomial n a : mv_polynomial σ α) = if n = m then a else 0 :=
+  coeff m (monomial n a : mv_polynomial σ R) = if n = m then a else 0 :=
 by convert single_apply
 
 @[simp] lemma coeff_C (m) (a) :
-  coeff m (C a : mv_polynomial σ α) = if 0 = m then a else 0 :=
+  coeff m (C a : mv_polynomial σ R) = if 0 = m then a else 0 :=
 by convert single_apply
 
 lemma coeff_X_pow (i : σ) (m) (k : ℕ) :
-  coeff m (X i ^ k : mv_polynomial σ α) = if single i k = m then 1 else 0 :=
+  coeff m (X i ^ k : mv_polynomial σ R) = if single i k = m then 1 else 0 :=
 begin
-  have := coeff_monomial m (finsupp.single i k) (1:α),
-  rwa [@monomial_eq _ _ (1:α) (finsupp.single i k) _,
+  have := coeff_monomial m (finsupp.single i k) (1:R),
+  rwa [@monomial_eq _ _ (1:R) (finsupp.single i k) _,
     C_1, one_mul, finsupp.prod_single_index] at this,
   exact pow_zero _
 end
 
 lemma coeff_X' (i : σ) (m) :
-  coeff m (X i : mv_polynomial σ α) = if single i 1 = m then 1 else 0 :=
+  coeff m (X i : mv_polynomial σ R) = if single i 1 = m then 1 else 0 :=
 by rw [← coeff_X_pow, pow_one]
 
 @[simp] lemma coeff_X (i : σ) :
-  coeff (single i 1) (X i : mv_polynomial σ α) = 1 :=
+  coeff (single i 1) (X i : mv_polynomial σ R) = 1 :=
 by rw [coeff_X', if_pos rfl]
 
-@[simp] lemma coeff_C_mul (m) (a : α) (p : mv_polynomial σ α) : coeff m (C a * p) = a * coeff m p :=
+@[simp] lemma coeff_C_mul (m) (a : R) (p : mv_polynomial σ R) : coeff m (C a * p) = a * coeff m p :=
 begin
   rw [mul_def], simp only [C, monomial], dsimp, rw [monomial],
   rw sum_single_index,
@@ -360,11 +360,11 @@ begin
   exact sum_zero, -- TODO doesn't work if we put this inside the simp
 end
 
-lemma coeff_mul (p q : mv_polynomial σ α) (n : σ →₀ ℕ) :
+lemma coeff_mul (p q : mv_polynomial σ R) (n : σ →₀ ℕ) :
   coeff n (p * q) = ∑ x in (antidiagonal n).support, coeff x.1 p * coeff x.2 q :=
 begin
   rw mul_def,
-  have := @finset.sum_sigma (σ →₀ ℕ) α _ _ p.support (λ _, q.support)
+  have := @finset.sum_sigma (σ →₀ ℕ) R _ _ p.support (λ _, q.support)
     (λ x, if (x.1 + x.2 = n) then coeff x.1 p * coeff x.2 q else 0),
   convert this.symm using 1; clear this,
   { rw [coeff],
@@ -397,7 +397,7 @@ begin
     all_goals { apply_instance } }
 end
 
-@[simp] lemma coeff_mul_X (m) (s : σ) (p : mv_polynomial σ α) :
+@[simp] lemma coeff_mul_X (m) (s : σ) (p : mv_polynomial σ R) :
   coeff (m + single s 1) (p * X s) = coeff m p :=
 begin
   have : (m, single s 1) ∈ (m + single s 1).antidiagonal.support := mem_antidiagonal_support.2 rfl,
@@ -410,7 +410,7 @@ begin
   { rw [coeff_X', if_neg H, mul_zero] },
 end
 
-lemma coeff_mul_X' (m) (s : σ) (p : mv_polynomial σ α) :
+lemma coeff_mul_X' (m) (s : σ) (p : mv_polynomial σ R) :
   coeff m (p * X s) = if s ∈ m.support then coeff (m - single s 1) p else 0 :=
 begin
   split_ifs with h h,
@@ -429,15 +429,15 @@ begin
     intro H, rw [_root_.add_eq_zero_iff] at H, exact one_ne_zero H.2 }
 end
 
-lemma eq_zero_iff {p : mv_polynomial σ α} :
+lemma eq_zero_iff {p : mv_polynomial σ R} :
   p = 0 ↔ ∀ d, coeff d p = 0 :=
 by { rw ext_iff, simp only [coeff_zero], }
 
-lemma ne_zero_iff {p : mv_polynomial σ α} :
+lemma ne_zero_iff {p : mv_polynomial σ R} :
   p ≠ 0 ↔ ∃ d, coeff d p ≠ 0 :=
 by { rw [ne.def, eq_zero_iff], push_neg, }
 
-lemma exists_coeff_ne_zero {p : mv_polynomial σ α} (h : p ≠ 0) :
+lemma exists_coeff_ne_zero {p : mv_polynomial σ R} (h : p ≠ 0) :
   ∃ d, coeff d p ≠ 0 :=
 ne_zero_iff.mp h
 
@@ -449,26 +449,26 @@ section constant_coeff
 `constant_coeff p` returns the constant term of the polynomial `p`, defined as `coeff 0 p`.
 This is a ring homomorphism.
 -/
-def constant_coeff : mv_polynomial σ α →+* α :=
+def constant_coeff : mv_polynomial σ R →+* R :=
 { to_fun := coeff 0,
   map_one' := by simp [coeff, add_monoid_algebra.one_def],
   map_mul' := by simp [coeff_mul, finsupp.support_single_ne_zero],
   map_zero' := coeff_zero _,
   map_add' := coeff_add _ }
 
-lemma constant_coeff_eq : (constant_coeff : mv_polynomial σ α → α) = coeff 0 := rfl
+lemma constant_coeff_eq : (constant_coeff : mv_polynomial σ R → R) = coeff 0 := rfl
 
 @[simp]
-lemma constant_coeff_C (r : α) :
-  constant_coeff (C r : mv_polynomial σ α) = r :=
+lemma constant_coeff_C (r : R) :
+  constant_coeff (C r : mv_polynomial σ R) = r :=
 by simp [constant_coeff_eq]
 
 @[simp]
 lemma constant_coeff_X (i : σ) :
-  constant_coeff (X i : mv_polynomial σ α) = 0 :=
+  constant_coeff (X i : mv_polynomial σ R) = 0 :=
 by simp [constant_coeff_eq]
 
-lemma constant_coeff_monomial (d : σ →₀ ℕ) (r : α) :
+lemma constant_coeff_monomial (d : σ →₀ ℕ) (r : R) :
   constant_coeff (monomial d r) = if d = 0 then r else 0 :=
 by rw [constant_coeff_eq, coeff_monomial]
 
@@ -477,10 +477,10 @@ end constant_coeff
 section as_sum
 
 @[simp]
-lemma support_sum_monomial_coeff (p : mv_polynomial σ α) : ∑ v in p.support, monomial v (coeff v p) = p :=
+lemma support_sum_monomial_coeff (p : mv_polynomial σ R) : ∑ v in p.support, monomial v (coeff v p) = p :=
 finsupp.sum_single p
 
-lemma as_sum (p : mv_polynomial σ α) : p = ∑ v in p.support, monomial v (coeff v p) :=
+lemma as_sum (p : mv_polynomial σ R) : p = ∑ v in p.support, monomial v (coeff v p) :=
 (support_sum_monomial_coeff p).symm
 
 end as_sum
@@ -488,22 +488,22 @@ end as_sum
 
 section eval₂
 variables [comm_semiring β]
-variables (f : α →+* β) (g : σ → β)
+variables (f : R →+* β) (g : σ → β)
 
 /-- Evaluate a polynomial `p` given a valuation `g` of all the variables
   and a ring hom `f` from the scalar ring to the target -/
-def eval₂ (p : mv_polynomial σ α) : β :=
+def eval₂ (p : mv_polynomial σ R) : β :=
 p.sum (λs a, f a * s.prod (λn e, g n ^ e))
 
-lemma eval₂_eq (g : α →+* β) (x : σ → β) (f : mv_polynomial σ α) :
+lemma eval₂_eq (g : R →+* β) (x : σ → β) (f : mv_polynomial σ R) :
   f.eval₂ g x = ∑ d in f.support, g (f.coeff d) * ∏ i in d.support, x i ^ d i :=
 rfl
 
-lemma eval₂_eq' [fintype σ] (g : α →+* β) (x : σ → β) (f : mv_polynomial σ α) :
+lemma eval₂_eq' [fintype σ] (g : R →+* β) (x : σ → β) (f : mv_polynomial σ R) :
   f.eval₂ g x = ∑ d in f.support, g (f.coeff d) * ∏ i, x i ^ d i :=
 by { simp only [eval₂_eq, ← finsupp.prod_pow], refl }
 
-@[simp] lemma eval₂_zero : (0 : mv_polynomial σ α).eval₂ f g = 0 :=
+@[simp] lemma eval₂_zero : (0 : mv_polynomial σ R).eval₂ f g = 0 :=
 finsupp.sum_zero_index
 
 section
@@ -519,7 +519,7 @@ finsupp.sum_single_index (by simp [is_semiring_hom.map_zero f])
 @[simp] lemma eval₂_C (a) : (C a).eval₂ f g = f a :=
 by simp [eval₂_monomial, C, prod_zero_index]
 
-@[simp] lemma eval₂_one : (1 : mv_polynomial σ α).eval₂ f g = 1 :=
+@[simp] lemma eval₂_one : (1 : mv_polynomial σ R).eval₂ f g = 1 :=
 (eval₂_C _ _ _).trans (is_semiring_hom.map_one f)
 
 @[simp] lemma eval₂_X (n) : (X n).eval₂ f g = g n :=
@@ -549,7 +549,7 @@ begin
   { simp [X, eval₂_monomial, eval₂_mul_monomial, (mul_assoc _ _ _).symm] { contextual := tt} }
 end
 
-@[simp] lemma eval₂_pow {p:mv_polynomial σ α} : ∀{n:ℕ}, (p ^ n).eval₂ f g = (p.eval₂ f g)^n
+@[simp] lemma eval₂_pow {p:mv_polynomial σ R} : ∀{n:ℕ}, (p ^ n).eval₂ f g = (p.eval₂ f g)^n
 | 0       := eval₂_one _ _
 | (n + 1) := by rw [pow_add, pow_one, pow_add, pow_one, eval₂_mul, eval₂_pow]
 
@@ -560,22 +560,22 @@ instance eval₂.is_semiring_hom : is_semiring_hom (eval₂ f g) :=
   map_mul := λ p q, eval₂_mul _ _ }
 
 /-- `mv_polynomial.eval₂` as a `ring_hom`. -/
-def eval₂_hom (f : α →+* β) (g : σ → β) : mv_polynomial σ α →+* β := ring_hom.of (eval₂ f g)
+def eval₂_hom (f : R →+* β) (g : σ → β) : mv_polynomial σ R →+* β := ring_hom.of (eval₂ f g)
 
-@[simp] lemma coe_eval₂_hom (f : α →+* β) (g : σ → β) : ⇑(eval₂_hom f g) = eval₂ f g := rfl
+@[simp] lemma coe_eval₂_hom (f : R →+* β) (g : σ → β) : ⇑(eval₂_hom f g) = eval₂ f g := rfl
 
-lemma eval₂_hom_congr  {f₁ f₂ : α →+* β} {g₁ g₂ : σ → β} {p₁ p₂ : mv_polynomial σ α} :
+lemma eval₂_hom_congr  {f₁ f₂ : R →+* β} {g₁ g₂ : σ → β} {p₁ p₂ : mv_polynomial σ R} :
   f₁ = f₂ → g₁ = g₂ → p₁ = p₂ →  eval₂_hom f₁ g₁ p₁ = eval₂_hom f₂ g₂ p₂ :=
 by rintros rfl rfl rfl; refl
 end
 
-@[simp] lemma eval₂_hom_C (f : α →+* β) (g : σ → β) (r : α) :
+@[simp] lemma eval₂_hom_C (f : R →+* β) (g : σ → β) (r : R) :
   eval₂_hom f g (C r) = f r := eval₂_C f g r
 
-@[simp] lemma eval₂_hom_X' (f : α →+* β) (g : σ → β) (i : σ) :
+@[simp] lemma eval₂_hom_X' (f : R →+* β) (g : σ → β) (i : σ) :
   eval₂_hom f g (X i) = g i := eval₂_X f g i
 
-@[simp] lemma comp_eval₂_hom [comm_semiring γ] (f : α →+* β) (g : σ → β) (φ : β →+* γ) :
+@[simp] lemma comp_eval₂_hom [comm_semiring γ] (f : R →+* β) (g : σ → β) (φ : β →+* γ) :
   φ.comp (eval₂_hom f g) = (eval₂_hom (φ.comp f) (λ i, φ (g i))) :=
 begin
   apply mv_polynomial.ring_hom_ext,
@@ -583,12 +583,12 @@ begin
   { intro i, rw [ring_hom.comp_apply, eval₂_hom_X', eval₂_hom_X'] }
 end
 
-lemma map_eval₂_hom  [comm_semiring γ] (f : α →+* β) (g : σ → β) (φ : β →+* γ)
-  (p : mv_polynomial σ α) :
+lemma map_eval₂_hom  [comm_semiring γ] (f : R →+* β) (g : σ → β) (φ : β →+* γ)
+  (p : mv_polynomial σ R) :
   φ (eval₂_hom f g p) = (eval₂_hom (φ.comp f) (λ i, φ (g i)) p) :=
 by { rw ← comp_eval₂_hom, refl }
 
-lemma eval₂_hom_monomial (f : α →+* β) (g : σ → β) (d : σ →₀ ℕ) (r : α) :
+lemma eval₂_hom_monomial (f : R →+* β) (g : σ → β) (d : σ →₀ ℕ) (r : R) :
   eval₂_hom f g (monomial d r) = f r * d.prod (λ i k, g i ^ k) :=
 by simp only [monomial_eq, ring_hom.map_mul, eval₂_hom_C, finsupp.prod,
   ring_hom.map_prod, ring_hom.map_pow, eval₂_hom_X']
@@ -596,14 +596,14 @@ by simp only [monomial_eq, ring_hom.map_mul, eval₂_hom_C, finsupp.prod,
 section
 local attribute [instance, priority 10] is_semiring_hom.comp
 lemma eval₂_comp_left {γ} [comm_semiring γ]
-  (k : β →+* γ) (f : α →+* β) (g : σ → β)
+  (k : β →+* γ) (f : R →+* β) (g : σ → β)
   (p) : k (eval₂ f g p) = eval₂ (k.comp f) (k ∘ g) p :=
 by apply mv_polynomial.induction_on p; simp [
   eval₂_add, k.map_add,
   eval₂_mul, k.map_mul] {contextual := tt}
 end
 
-@[simp] lemma eval₂_eta (p : mv_polynomial σ α) : eval₂ C X p = p :=
+@[simp] lemma eval₂_eta (p : mv_polynomial σ R) : eval₂ C X p = p :=
 by apply mv_polynomial.induction_on p;
    simp [eval₂_add, eval₂_mul] {contextual := tt}
 
@@ -619,17 +619,17 @@ begin
   rwa finsupp.mem_support_iff at hc
 end
 
-@[simp] lemma eval₂_prod (s : finset γ) (p : γ → mv_polynomial σ α) :
+@[simp] lemma eval₂_prod (s : finset γ) (p : γ → mv_polynomial σ R) :
   eval₂ f g (∏ x in s, p x) = ∏ x in s, eval₂ f g (p x) :=
 (s.prod_hom _).symm
 
-@[simp] lemma eval₂_sum (s : finset γ) (p : γ → mv_polynomial σ α) :
+@[simp] lemma eval₂_sum (s : finset γ) (p : γ → mv_polynomial σ R) :
   eval₂ f g (∑ x in s, p x) = ∑ x in s, eval₂ f g (p x) :=
 (s.sum_hom _).symm
 
 attribute [to_additive] eval₂_prod
 
-lemma eval₂_assoc (q : γ → mv_polynomial σ α) (p : mv_polynomial γ α) :
+lemma eval₂_assoc (q : γ → mv_polynomial σ R) (p : mv_polynomial γ R) :
   eval₂ f (λ t, eval₂ f g (q t)) p = eval₂ f g (eval₂ C q p) :=
 begin
   show _ = eval₂_hom f g (eval₂ C q p),
@@ -639,18 +639,18 @@ end
 end eval₂
 
 section eval
-variables {f : σ → α}
+variables {f : σ → R}
 
 /-- Evaluate a polynomial `p` given a valuation `f` of all the variables -/
-def eval (f : σ → α) : mv_polynomial σ α →+* α := eval₂_hom (ring_hom.id _) f
+def eval (f : σ → R) : mv_polynomial σ R →+* R := eval₂_hom (ring_hom.id _) f
 
-lemma eval_eq (x : σ → α) (f : mv_polynomial σ α) :
+lemma eval_eq (x : σ → R) (f : mv_polynomial σ R) :
   eval x f = ∑ d in f.support, f.coeff d * ∏ i in d.support, x i ^ d i :=
 rfl
 
-lemma eval_eq' [fintype σ] (x : σ → α) (f : mv_polynomial σ α) :
+lemma eval_eq' [fintype σ] (x : σ → R) (f : mv_polynomial σ R) :
   eval x f = ∑ d in f.support, f.coeff d * ∏ i, x i ^ d i :=
-eval₂_eq' (ring_hom.id α) x f
+eval₂_eq' (ring_hom.id R) x f
 
 lemma eval_monomial : eval f (monomial s a) = a * s.prod (λn e, f n ^ e) :=
 eval₂_monomial _ _
@@ -659,21 +659,21 @@ eval₂_monomial _ _
 
 @[simp] lemma eval_X : ∀ n, eval f (X n) = f n := eval₂_X _ _
 
-@[simp] lemma smul_eval (x) (p : mv_polynomial σ α) (s) : eval x (s • p) = s * eval x p :=
+@[simp] lemma smul_eval (x) (p : mv_polynomial σ R) (s) : eval x (s • p) = s * eval x p :=
 by rw [smul_eq_C_mul, (eval x).map_mul, eval_C]
 
-lemma eval_sum {ι : Type*} (s : finset ι) (f : ι → mv_polynomial σ α) (g : σ → α) :
+lemma eval_sum {ι : Type*} (s : finset ι) (f : ι → mv_polynomial σ R) (g : σ → R) :
   eval g (∑ i in s, f i) = ∑ i in s, eval g (f i) :=
 (eval g).map_sum _ _
 
 @[to_additive]
-lemma eval_prod {ι : Type*} (s : finset ι) (f : ι → mv_polynomial σ α) (g : σ → α) :
+lemma eval_prod {ι : Type*} (s : finset ι) (f : ι → mv_polynomial σ R) (g : σ → R) :
   eval g (∏ i in s, f i) = ∏ i in s, eval g (f i) :=
 (eval g).map_prod _ _
 
 theorem eval_assoc {τ}
-  (f : σ → mv_polynomial τ α) (g : τ → α)
-  (p : mv_polynomial σ α) :
+  (f : σ → mv_polynomial τ R) (g : τ → R)
+  (p : mv_polynomial σ R) :
   eval (eval g ∘ f) p = eval g (eval₂ C f p) :=
 begin
   rw eval₂_comp_left (eval g),
@@ -685,23 +685,23 @@ end eval
 
 section map
 variables [comm_semiring β]
-variables (f : α →+* β)
+variables (f : R →+* β)
 
 /-- `map f p` maps a polynomial `p` across a ring hom `f` -/
-def map : mv_polynomial σ α →+* mv_polynomial σ β := eval₂_hom (C.comp f) X
+def map : mv_polynomial σ R →+* mv_polynomial σ β := eval₂_hom (C.comp f) X
 
-@[simp] theorem map_monomial (s : σ →₀ ℕ) (a : α) : map f (monomial s a) = monomial s (f a) :=
+@[simp] theorem map_monomial (s : σ →₀ ℕ) (a : R) : map f (monomial s a) = monomial s (f a) :=
 (eval₂_monomial _ _).trans monomial_eq.symm
 
-@[simp] theorem map_C : ∀ (a : α), map f (C a : mv_polynomial σ α) = C (f a) := map_monomial _ _
+@[simp] theorem map_C : ∀ (a : R), map f (C a : mv_polynomial σ R) = C (f a) := map_monomial _ _
 
-@[simp] theorem map_X : ∀ (n : σ), map f (X n : mv_polynomial σ α) = X n := eval₂_X _ _
+@[simp] theorem map_X : ∀ (n : σ), map f (X n : mv_polynomial σ R) = X n := eval₂_X _ _
 
-theorem map_id : ∀ (p : mv_polynomial σ α), map (ring_hom.id α) p = p := eval₂_eta
+theorem map_id : ∀ (p : mv_polynomial σ R), map (ring_hom.id R) p = p := eval₂_eta
 
 theorem map_map [comm_semiring γ]
   (g : β →+* γ)
-  (p : mv_polynomial σ α) :
+  (p : mv_polynomial σ R) :
   map g (map f p) = map (g.comp f) p :=
 (eval₂_comp_left (map g) (C.comp f) X p).trans $
 begin
@@ -710,7 +710,7 @@ begin
   { ext1 n, simp only [map_X, comp_app], }
 end
 
-theorem eval₂_eq_eval_map (g : σ → β) (p : mv_polynomial σ α) :
+theorem eval₂_eq_eval_map (g : σ → β) (p : mv_polynomial σ R) :
   p.eval₂ f g = eval g (map f p) :=
 begin
   unfold map eval, simp only [coe_eval₂_hom],
@@ -723,7 +723,7 @@ begin
 end
 
 lemma eval₂_comp_right {γ} [comm_semiring γ]
-  (k : β →+* γ) (f : α →+* β) (g : σ → β)
+  (k : β →+* γ) (f : R →+* β) (g : σ → β)
   (p) : k (eval₂ f g p) = eval₂ k (k ∘ g) (map f p) :=
 begin
   apply mv_polynomial.induction_on p,
@@ -733,7 +733,7 @@ begin
     rw [eval₂_mul, k.map_mul, (map f).map_mul, eval₂_mul, map_X, hp, eval₂_X, eval₂_X] }
 end
 
-lemma map_eval₂ (f : α →+* β) (g : γ → mv_polynomial δ α) (p : mv_polynomial γ α) :
+lemma map_eval₂ (f : R →+* β) (g : γ → mv_polynomial δ R) (p : mv_polynomial γ R) :
   map f (eval₂ C g p) = eval₂ C (map f ∘ g) (map f p) :=
 begin
   apply mv_polynomial.induction_on p,
@@ -743,7 +743,7 @@ begin
     rw [eval₂_mul, (map f).map_mul, hp, (map f).map_mul, map_X, eval₂_mul, eval₂_X, eval₂_X] }
 end
 
-lemma coeff_map (p : mv_polynomial σ α) : ∀ (m : σ →₀ ℕ), coeff m (map f p) = f (coeff m p) :=
+lemma coeff_map (p : mv_polynomial σ R) : ∀ (m : σ →₀ ℕ), coeff m (map f p) = f (coeff m p) :=
 begin
   apply mv_polynomial.induction_on p; clear p,
   { intros r m, rw [map_C], simp only [coeff_C], split_ifs, {refl}, rw f.map_zero },
@@ -755,7 +755,7 @@ begin
 end
 
 lemma map_injective (hf : function.injective f) :
-  function.injective (map f : mv_polynomial σ α → mv_polynomial σ β) :=
+  function.injective (map f : mv_polynomial σ R → mv_polynomial σ β) :=
 begin
   intros p q h,
   simp only [ext_iff, coeff_map] at h ⊢,
@@ -763,29 +763,29 @@ begin
   exact hf (h m),
 end
 
-@[simp] lemma eval_map (f : α →+* β) (g : σ → β) (p : mv_polynomial σ α) :
+@[simp] lemma eval_map (f : R →+* β) (g : σ → β) (p : mv_polynomial σ R) :
   eval g (map f p) = eval₂ f g p :=
 by { apply mv_polynomial.induction_on p; { simp { contextual := tt } } }
 
-@[simp] lemma eval₂_map [comm_semiring γ] (f : α →+* β) (g : σ → γ) (φ : β →+* γ)
-  (p : mv_polynomial σ α) :
+@[simp] lemma eval₂_map [comm_semiring γ] (f : R →+* β) (g : σ → γ) (φ : β →+* γ)
+  (p : mv_polynomial σ R) :
   eval₂ φ g (map f p) = eval₂ (φ.comp f) g p :=
 by { rw [← eval_map, ← eval_map, map_map], }
 
-@[simp] lemma eval₂_hom_map_hom [comm_semiring γ] (f : α →+* β) (g : σ → γ) (φ : β →+* γ)
-  (p : mv_polynomial σ α) :
+@[simp] lemma eval₂_hom_map_hom [comm_semiring γ] (f : R →+* β) (g : σ → γ) (φ : β →+* γ)
+  (p : mv_polynomial σ R) :
   eval₂_hom φ g (map f p) = eval₂_hom (φ.comp f) g p :=
 eval₂_map f g φ p
 
-@[simp] lemma constant_coeff_map (f : α →+* β) (φ : mv_polynomial σ α) :
+@[simp] lemma constant_coeff_map (f : R →+* β) (φ : mv_polynomial σ R) :
   constant_coeff (mv_polynomial.map f φ) = f (constant_coeff φ) :=
 coeff_map f φ 0
 
-lemma constant_coeff_comp_map (f : α →+* β) :
+lemma constant_coeff_comp_map (f : R →+* β) :
   (constant_coeff : mv_polynomial σ β →+* β).comp (mv_polynomial.map f) = f.comp (constant_coeff) :=
 by { ext, apply constant_coeff_map }
 
-lemma support_map_subset (p : mv_polynomial σ α) : (map f p).support ⊆ p.support :=
+lemma support_map_subset (p : mv_polynomial σ R) : (map f p).support ⊆ p.support :=
 begin
   intro x,
   simp only [finsupp.mem_support_iff],
@@ -797,7 +797,7 @@ begin
   exact ring_hom.map_zero f
 end
 
-lemma support_map_of_injective (p : mv_polynomial σ α) {f : α →+* β} (hf : injective f) :
+lemma support_map_of_injective (p : mv_polynomial σ R) {f : R →+* β} (hf : injective f) :
   (map f p).support = p.support :=
 begin
   apply finset.subset.antisymm,
@@ -818,7 +818,7 @@ section aeval
 
 /-! ### The algebra of multivariate polynomials -/
 
-variables {R : Type u} {A : Type v} {S : Type w} (f : σ → A)
+variables {A : Type v} {S : Type w} (f : σ → A)
 variables [comm_semiring R] [comm_semiring A] [algebra R A] [comm_semiring S]
 
 /-- A map `σ → A` where `A` is an algebra over `R` generates an `R`-algebra homomorphism

--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -819,13 +819,15 @@ section aeval
 /-! ### The algebra of multivariate polynomials -/
 
 variables {A : Type v} {S : Type w} (f : σ → A)
-variables [comm_semiring R] [comm_semiring A] [algebra R A] [comm_semiring S]
+variables [comm_semiring A] [algebra R A] [comm_semiring S]
 
 /-- A map `σ → A` where `A` is an algebra over `R` generates an `R`-algebra homomorphism
 from multivariate polynomials over `σ` to `A`. -/
 def aeval : mv_polynomial σ R →ₐ[R] A :=
 { commutes' := λ r, eval₂_C _ _ _
   .. eval₂_hom (algebra_map R A) f }
+
+#check @aeval
 
 theorem aeval_def (p : mv_polynomial σ R) : aeval f p = eval₂ (algebra_map R A) f p := rfl
 

--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -827,8 +827,6 @@ def aeval : mv_polynomial σ R →ₐ[R] A :=
 { commutes' := λ r, eval₂_C _ _ _
   .. eval₂_hom (algebra_map R A) f }
 
-#check @aeval
-
 theorem aeval_def (p : mv_polynomial σ R) : aeval f p = eval₂ (algebra_map R A) f p := rfl
 
 lemma aeval_eq_eval₂_hom (p : mv_polynomial σ R) :

--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -26,7 +26,7 @@ In the definitions below, we use the following notation:
 
 + `σ : Type*` (indexing the variables)
 
-+ `α : Type*` `[comm_semiring R]` (the coefficients)
++ `α : Type*` `[comm_semiring α]` (the coefficients)
 
 + `s : σ →₀ ℕ`, a function from `σ` to `ℕ` which is zero away from a finite set.
 This will give rise to a monomial in `mv_polynomial σ R` which mathematicians might call `X^s`

--- a/src/data/mv_polynomial/comm_ring.lean
+++ b/src/data/mv_polynomial/comm_ring.lean
@@ -40,8 +40,8 @@ open_locale classical big_operators
 open set function finsupp add_monoid_algebra
 open_locale big_operators
 
-universes u v w x
-variables {R : Type u} {β : Type v} {γ : Type w} {δ : Type x}
+universes u v
+variables {R : Type u} {S : Type v}
 
 namespace mv_polynomial
 variables {σ : Type*} {a a' a₁ a₂ : R} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
@@ -107,20 +107,20 @@ end vars
 
 section eval₂
 
-variables [comm_ring β]
-variables (f : R →+* β) (g : σ → β)
+variables [comm_ring S]
+variables (f : R →+* S) (g : σ → S)
 
 @[simp] lemma eval₂_sub : (p - q).eval₂ f g = p.eval₂ f g - q.eval₂ f g := (eval₂_hom f g).map_sub _ _
 
 @[simp] lemma eval₂_neg : (-p).eval₂ f g = -(p.eval₂ f g) := (eval₂_hom f g).map_neg _
 
-lemma hom_C (f : mv_polynomial σ ℤ → β) [is_ring_hom f] (n : ℤ) : f (C n) = (n : β) :=
+lemma hom_C (f : mv_polynomial σ ℤ → S) [is_ring_hom f] (n : ℤ) : f (C n) = (n : S) :=
 ((ring_hom.of f).comp (ring_hom.of C)).eq_int_cast n
 
 /-- A ring homomorphism f : Z[X_1, X_2, ...] → R
 is determined by the evaluations f(X_1), f(X_2), ... -/
-@[simp] lemma eval₂_hom_X {R : Type u} (c : ℤ →+* β)
-  (f : mv_polynomial R ℤ →+* β) (x : mv_polynomial R ℤ) :
+@[simp] lemma eval₂_hom_X {R : Type u} (c : ℤ →+* S)
+  (f : mv_polynomial R ℤ →+* S) (x : mv_polynomial R ℤ) :
   eval₂ c (f ∘ X) x = f x :=
 mv_polynomial.induction_on x
 (λ n, by { rw [hom_C f, eval₂_C], exact (ring_hom.of c).eq_int_cast n })
@@ -129,9 +129,9 @@ mv_polynomial.induction_on x
 
 /-- Ring homomorphisms out of integer polynomials on a type `σ` are the same as
 functions out of the type `σ`, -/
-def hom_equiv : (mv_polynomial σ ℤ →+* β) ≃ (σ → β) :=
+def hom_equiv : (mv_polynomial σ ℤ →+* S) ≃ (σ → S) :=
 { to_fun := λ f, ⇑f ∘ X,
-  inv_fun := λ f, eval₂_hom (int.cast_ring_hom β) f,
+  inv_fun := λ f, eval₂_hom (int.cast_ring_hom S) f,
   left_inv := λ f, ring_hom.ext  $ eval₂_hom_X _ _,
   right_inv := λ f, funext $ λ x, by simp only [coe_eval₂_hom, function.comp_app, eval₂_X] }
 

--- a/src/data/mv_polynomial/comm_ring.lean
+++ b/src/data/mv_polynomial/comm_ring.lean
@@ -20,16 +20,16 @@ As in other polynomial files we typically use the notation:
 
 + `σ : Type*` (indexing the variables)
 
-+ `α : Type*` `[comm_ring α]` (the coefficients)
++ `R : Type*` `[comm_ring R]` (the coefficients)
 
 + `s : σ →₀ ℕ`, a function from `σ` to `ℕ` which is zero away from a finite set.
 This will give rise to a monomial in `mv_polynomial σ R` which mathematicians might call `X^s`
 
-+ `a : α`
++ `a : R`
 
 + `i : σ`, with corresponding monomial `X i`, often denoted `X_i` by mathematicians
 
-+ `p : mv_polynomial σ α`
++ `p : mv_polynomial σ R`
 
 -/
 
@@ -41,43 +41,43 @@ open set function finsupp add_monoid_algebra
 open_locale big_operators
 
 universes u v w x
-variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
+variables {R : Type u} {β : Type v} {γ : Type w} {δ : Type x}
 
 namespace mv_polynomial
-variables {σ : Type*} {a a' a₁ a₂ : α} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
+variables {σ : Type*} {a a' a₁ a₂ : R} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
 
 section comm_ring
-variable [comm_ring α]
-variables {p q : mv_polynomial σ α}
+variable [comm_ring R]
+variables {p q : mv_polynomial σ R}
 
-instance : comm_ring (mv_polynomial σ α) := add_monoid_algebra.comm_ring
+instance : comm_ring (mv_polynomial σ R) := add_monoid_algebra.comm_ring
 
-instance C.is_ring_hom : is_ring_hom (C : α → mv_polynomial σ α) :=
+instance C.is_ring_hom : is_ring_hom (C : R → mv_polynomial σ R) :=
 by apply is_ring_hom.of_semiring
 
 variables (σ a a')
-@[simp] lemma C_sub : (C (a - a') : mv_polynomial σ α) = C a - C a' := is_ring_hom.map_sub _
+@[simp] lemma C_sub : (C (a - a') : mv_polynomial σ R) = C a - C a' := is_ring_hom.map_sub _
 
-@[simp] lemma C_neg : (C (-a) : mv_polynomial σ α) = -C a := is_ring_hom.map_neg _
+@[simp] lemma C_neg : (C (-a) : mv_polynomial σ R) = -C a := is_ring_hom.map_neg _
 
-@[simp] lemma coeff_neg (m : σ →₀ ℕ) (p : mv_polynomial σ α) :
+@[simp] lemma coeff_neg (m : σ →₀ ℕ) (p : mv_polynomial σ R) :
   coeff m (-p) = -coeff m p := finsupp.neg_apply
 
-@[simp] lemma coeff_sub (m : σ →₀ ℕ) (p q : mv_polynomial σ α) :
+@[simp] lemma coeff_sub (m : σ →₀ ℕ) (p q : mv_polynomial σ R) :
   coeff m (p - q) = coeff m p - coeff m q := finsupp.sub_apply
 
 instance coeff.is_add_group_hom (m : σ →₀ ℕ) :
-  is_add_group_hom (coeff m : mv_polynomial σ α → α) :=
+  is_add_group_hom (coeff m : mv_polynomial σ R → R) :=
 { map_add := coeff_add m }
 
 variables {σ} (p)
 
 section degrees
 
-lemma degrees_neg (p : mv_polynomial σ α) : (- p).degrees = p.degrees :=
+lemma degrees_neg (p : mv_polynomial σ R) : (- p).degrees = p.degrees :=
 by rw [degrees, finsupp.support_neg]; refl
 
-lemma degrees_sub (p q : mv_polynomial σ α) :
+lemma degrees_sub (p q : mv_polynomial σ R) :
   (p - q).degrees ≤ p.degrees ⊔ q.degrees :=
 le_trans (degrees_add p (-q)) $ by rw [degrees_neg]
 
@@ -108,7 +108,7 @@ end vars
 section eval₂
 
 variables [comm_ring β]
-variables (f : α →+* β) (g : σ → β)
+variables (f : R →+* β) (g : σ → β)
 
 @[simp] lemma eval₂_sub : (p - q).eval₂ f g = p.eval₂ f g - q.eval₂ f g := (eval₂_hom f g).map_sub _ _
 
@@ -119,8 +119,8 @@ lemma hom_C (f : mv_polynomial σ ℤ → β) [is_ring_hom f] (n : ℤ) : f (C n
 
 /-- A ring homomorphism f : Z[X_1, X_2, ...] → R
 is determined by the evaluations f(X_1), f(X_2), ... -/
-@[simp] lemma eval₂_hom_X {α : Type u} (c : ℤ →+* β)
-  (f : mv_polynomial α ℤ →+* β) (x : mv_polynomial α ℤ) :
+@[simp] lemma eval₂_hom_X {R : Type u} (c : ℤ →+* β)
+  (f : mv_polynomial R ℤ →+* β) (x : mv_polynomial R ℤ) :
   eval₂ c (f ∘ X) x = f x :=
 mv_polynomial.induction_on x
 (λ n, by { rw [hom_C f, eval₂_C], exact (ring_hom.of c).eq_int_cast n })
@@ -139,11 +139,11 @@ end eval₂
 
 section total_degree
 
-@[simp] lemma total_degree_neg (a : mv_polynomial σ α) :
+@[simp] lemma total_degree_neg (a : mv_polynomial σ R) :
   (-a).total_degree = a.total_degree :=
 by simp only [total_degree, finsupp.support_neg]
 
-lemma total_degree_sub (a b : mv_polynomial σ α) :
+lemma total_degree_sub (a b : mv_polynomial σ R) :
   (a - b).total_degree ≤ max a.total_degree b.total_degree :=
 calc (a - b).total_degree = (a + -b).total_degree                : by rw sub_eq_add_neg
                       ... ≤ max a.total_degree (-b).total_degree : total_degree_add a (-b)

--- a/src/data/mv_polynomial/equiv.lean
+++ b/src/data/mv_polynomial/equiv.lean
@@ -44,7 +44,7 @@ open set function finsupp add_monoid_algebra
 open_locale big_operators
 
 universes u v w x
-variables {R : Type u} {β : Type v} {γ : Type w} {δ : Type x}
+variables {R : Type u} {S₁ : Type v} {S₂ : Type w} {S₃ : Type x}
 
 namespace mv_polynomial
 variables {σ : Type*} {a a' a₁ a₂ : R} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
@@ -91,7 +91,7 @@ def punit_ring_equiv : mv_polynomial punit R ≃+* polynomial R :=
   map_add'  := λ _ _, eval₂_add _ _ }
 
 /-- The ring isomorphism between multivariable polynomials induced by an equivalence of the variables.  -/
-def ring_equiv_of_equiv (e : β ≃ γ) : mv_polynomial β R ≃+* mv_polynomial γ R :=
+def ring_equiv_of_equiv (e : S₁ ≃ S₂) : mv_polynomial S₁ R ≃+* mv_polynomial S₂ R :=
 { to_fun    := rename e,
   inv_fun   := rename e.symm,
   left_inv  := λ p, by simp only [rename_rename, (∘), e.symm_apply_apply]; exact rename_id p,
@@ -100,22 +100,22 @@ def ring_equiv_of_equiv (e : β ≃ γ) : mv_polynomial β R ≃+* mv_polynomial
   map_add'  := (rename e).map_add }
 
 /-- The ring isomorphism between multivariable polynomials induced by a ring isomorphism of the ground ring. -/
-def ring_equiv_congr [comm_semiring γ] (e : R ≃+* γ) : mv_polynomial β R ≃+* mv_polynomial β γ :=
-{ to_fun    := map (e : R →+* γ),
-  inv_fun   := map (e.symm : γ →+* R),
+def ring_equiv_congr [comm_semiring S₂] (e : R ≃+* S₂) : mv_polynomial S₁ R ≃+* mv_polynomial S₁ S₂ :=
+{ to_fun    := map (e : R →+* S₂),
+  inv_fun   := map (e.symm : S₂ →+* R),
   left_inv  := assume p,
-    have (e.symm : γ →+* R).comp (e : R →+* γ) = ring_hom.id _,
+    have (e.symm : S₂ →+* R).comp (e : R →+* S₂) = ring_hom.id _,
     { ext a, exact e.symm_apply_apply a },
     by simp only [map_map, this, map_id],
   right_inv := assume p,
-    have (e : R →+* γ).comp (e.symm : γ →+* R) = ring_hom.id _,
+    have (e : R →+* S₂).comp (e.symm : S₂ →+* R) = ring_hom.id _,
     { ext a, exact e.apply_symm_apply a },
     by simp only [map_map, this, map_id],
   map_mul'  := ring_hom.map_mul _,
   map_add'  := ring_hom.map_add _ }
 
 section
-variables (β γ δ)
+variables (S₁ S₂ S₃)
 
 /--
 The function from multivariable polynomials in a sum of two types,
@@ -124,19 +124,19 @@ with coefficents in multivariable polynomials in the other type.
 
 See `sum_ring_equiv` for the ring isomorphism.
 -/
-def sum_to_iter : mv_polynomial (β ⊕ γ) R →+* mv_polynomial β (mv_polynomial γ R) :=
+def sum_to_iter : mv_polynomial (S₁ ⊕ S₂) R →+* mv_polynomial S₁ (mv_polynomial S₂ R) :=
 eval₂_hom (C.comp C) (λbc, sum.rec_on bc X (C ∘ X))
 
-instance is_semiring_hom_sum_to_iter : is_semiring_hom (sum_to_iter R β γ) :=
+instance is_semiring_hom_sum_to_iter : is_semiring_hom (sum_to_iter R S₁ S₂) :=
 eval₂.is_semiring_hom _ _
 
-lemma sum_to_iter_C (a : R) : sum_to_iter R β γ (C a) = C (C a) :=
+lemma sum_to_iter_C (a : R) : sum_to_iter R S₁ S₂ (C a) = C (C a) :=
 eval₂_C _ _ a
 
-lemma sum_to_iter_Xl (b : β) : sum_to_iter R β γ (X (sum.inl b)) = X b :=
+lemma sum_to_iter_Xl (b : S₁) : sum_to_iter R S₁ S₂ (X (sum.inl b)) = X b :=
 eval₂_X _ _ (sum.inl b)
 
-lemma sum_to_iter_Xr (c : γ) : sum_to_iter R β γ (X (sum.inr c)) = C (X c) :=
+lemma sum_to_iter_Xr (c : S₂) : sum_to_iter R S₁ S₂ (X (sum.inr c)) = C (X c) :=
 eval₂_X _ _ (sum.inr c)
 
 /--
@@ -146,27 +146,27 @@ to multivariable polynomials in the sum of the two types.
 
 See `sum_ring_equiv` for the ring isomorphism.
 -/
-def iter_to_sum : mv_polynomial β (mv_polynomial γ R) →+* mv_polynomial (β ⊕ γ) R :=
+def iter_to_sum : mv_polynomial S₁ (mv_polynomial S₂ R) →+* mv_polynomial (S₁ ⊕ S₂) R :=
 eval₂_hom (ring_hom.of (eval₂ C (X ∘ sum.inr))) (X ∘ sum.inl)
 
-lemma iter_to_sum_C_C (a : R) : iter_to_sum R β γ (C (C a)) = C a :=
+lemma iter_to_sum_C_C (a : R) : iter_to_sum R S₁ S₂ (C (C a)) = C a :=
 eq.trans (eval₂_C _ _ (C a)) (eval₂_C _ _ _)
 
-lemma iter_to_sum_X (b : β) : iter_to_sum R β γ (X b) = X (sum.inl b) :=
+lemma iter_to_sum_X (b : S₁) : iter_to_sum R S₁ S₂ (X b) = X (sum.inl b) :=
 eval₂_X _ _ _
 
-lemma iter_to_sum_C_X (c : γ) : iter_to_sum R β γ (C (X c)) = X (sum.inr c) :=
+lemma iter_to_sum_C_X (c : S₂) : iter_to_sum R S₁ S₂ (C (X c)) = X (sum.inr c) :=
 eq.trans (eval₂_C _ _ (X c)) (eval₂_X _ _ _)
 
 /-- A helper function for `sum_ring_equiv`. -/
-def mv_polynomial_equiv_mv_polynomial [comm_semiring δ]
-  (f : mv_polynomial β R →+* mv_polynomial γ δ)
-  (g : mv_polynomial γ δ →+* mv_polynomial β R)
+def mv_polynomial_equiv_mv_polynomial [comm_semiring S₃]
+  (f : mv_polynomial S₁ R →+* mv_polynomial S₂ S₃)
+  (g : mv_polynomial S₂ S₃ →+* mv_polynomial S₁ R)
   (hfgC : ∀a, f (g (C a)) = C a)
   (hfgX : ∀n, f (g (X n)) = X n)
   (hgfC : ∀a, g (f (C a)) = C a)
   (hgfX : ∀n, g (f (X n)) = X n) :
-  mv_polynomial β R ≃+* mv_polynomial γ δ :=
+  mv_polynomial S₁ R ≃+* mv_polynomial S₂ S₃ :=
 { to_fun    := f, inv_fun := g,
   left_inv  := is_id (ring_hom.comp _ _) hgfC hgfX,
   right_inv := is_id (ring_hom.comp _ _) hfgC hfgX,
@@ -178,37 +178,37 @@ The ring isomorphism between multivariable polynomials in a sum of two types,
 and multivariable polynomials in one of the types,
 with coefficents in multivariable polynomials in the other type.
 -/
-def sum_ring_equiv : mv_polynomial (β ⊕ γ) R ≃+* mv_polynomial β (mv_polynomial γ R) :=
+def sum_ring_equiv : mv_polynomial (S₁ ⊕ S₂) R ≃+* mv_polynomial S₁ (mv_polynomial S₂ R) :=
 begin
-  apply @mv_polynomial_equiv_mv_polynomial R (β ⊕ γ) _ _ _ _
-    (sum_to_iter R β γ) (iter_to_sum R β γ),
+  apply @mv_polynomial_equiv_mv_polynomial R (S₁ ⊕ S₂) _ _ _ _
+    (sum_to_iter R S₁ S₂) (iter_to_sum R S₁ S₂),
   { assume p,
-    convert hom_eq_hom ((sum_to_iter R β γ).comp ((iter_to_sum R β γ).comp C)) C _ _ p,
-    { assume a, dsimp, rw [iter_to_sum_C_C R β γ, sum_to_iter_C R β γ] },
-    { assume c, dsimp, rw [iter_to_sum_C_X R β γ, sum_to_iter_Xr R β γ] } },
-  { assume b, rw [iter_to_sum_X R β γ, sum_to_iter_Xl R β γ] },
-  { assume a, rw [sum_to_iter_C R β γ, iter_to_sum_C_C R β γ] },
+    convert hom_eq_hom ((sum_to_iter R S₁ S₂).comp ((iter_to_sum R S₁ S₂).comp C)) C _ _ p,
+    { assume a, dsimp, rw [iter_to_sum_C_C R S₁ S₂, sum_to_iter_C R S₁ S₂] },
+    { assume c, dsimp, rw [iter_to_sum_C_X R S₁ S₂, sum_to_iter_Xr R S₁ S₂] } },
+  { assume b, rw [iter_to_sum_X R S₁ S₂, sum_to_iter_Xl R S₁ S₂] },
+  { assume a, rw [sum_to_iter_C R S₁ S₂, iter_to_sum_C_C R S₁ S₂] },
   { assume n, cases n with b c,
     { rw [sum_to_iter_Xl, iter_to_sum_X] },
     { rw [sum_to_iter_Xr, iter_to_sum_C_X] } },
 end
 
 /--
-The ring isomorphism between multivariable polynomials in `option β` and
-polynomials with coefficients in `mv_polynomial β R`.
+The ring isomorphism between multivariable polynomials in `option S₁` and
+polynomials with coefficients in `mv_polynomial S₁ R`.
 -/
-def option_equiv_left : mv_polynomial (option β) R ≃+* polynomial (mv_polynomial β R) :=
-(ring_equiv_of_equiv R $ (equiv.option_equiv_sum_punit β).trans (equiv.sum_comm _ _)).trans $
+def option_equiv_left : mv_polynomial (option S₁) R ≃+* polynomial (mv_polynomial S₁ R) :=
+(ring_equiv_of_equiv R $ (equiv.option_equiv_sum_punit S₁).trans (equiv.sum_comm _ _)).trans $
 (sum_ring_equiv R _ _).trans $
 punit_ring_equiv _
 
 /--
-The ring isomorphism between multivariable polynomials in `option β` and
+The ring isomorphism between multivariable polynomials in `option S₁` and
 multivariable polynomials with coefficients in polynomials.
 -/
-def option_equiv_right : mv_polynomial (option β) R ≃+* mv_polynomial β (polynomial R) :=
-(ring_equiv_of_equiv R $ equiv.option_equiv_sum_punit.{0} β).trans $
-(sum_ring_equiv R β unit).trans $
+def option_equiv_right : mv_polynomial (option S₁) R ≃+* mv_polynomial S₁ (polynomial R) :=
+(ring_equiv_of_equiv R $ equiv.option_equiv_sum_punit.{0} S₁).trans $
+(sum_ring_equiv R S₁ unit).trans $
 ring_equiv_congr (mv_polynomial unit R) (punit_ring_equiv R)
 
 /--

--- a/src/data/mv_polynomial/equiv.lean
+++ b/src/data/mv_polynomial/equiv.lean
@@ -19,16 +19,16 @@ As in other polynomial files we typically use the notation:
 
 + `σ : Type*` (indexing the variables)
 
-+ `α : Type*` `[comm_semiring α]` (the coefficients)
++ `R : Type*` `[comm_semiring R]` (the coefficients)
 
 + `s : σ →₀ ℕ`, a function from `σ` to `ℕ` which is zero away from a finite set.
 This will give rise to a monomial in `mv_polynomial σ R` which mathematicians might call `X^s`
 
-+ `a : α`
++ `a : R`
 
 + `i : σ`, with corresponding monomial `X i`, often denoted `X_i` by mathematicians
 
-+ `p : mv_polynomial σ α`
++ `p : mv_polynomial σ R`
 
 ## Tags
 
@@ -44,21 +44,21 @@ open set function finsupp add_monoid_algebra
 open_locale big_operators
 
 universes u v w x
-variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
+variables {R : Type u} {β : Type v} {γ : Type w} {δ : Type x}
 
 namespace mv_polynomial
-variables {σ : Type*} {a a' a₁ a₂ : α} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
+variables {σ : Type*} {a a' a₁ a₂ : R} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
 
 section equiv
 
-variables (α) [comm_semiring α]
+variables (R) [comm_semiring R]
 
 /-- The ring isomorphism between multivariable polynomials in no variables and the ground ring. -/
-def pempty_ring_equiv : mv_polynomial pempty α ≃+* α :=
+def pempty_ring_equiv : mv_polynomial pempty R ≃+* R :=
 { to_fun    := mv_polynomial.eval₂ (ring_hom.id _) $ pempty.elim,
   inv_fun   := C,
   left_inv  := is_id (C.comp (eval₂_hom (ring_hom.id _) pempty.elim))
-    (assume a : α, by { dsimp, rw [eval₂_C], refl }) (assume a, a.elim),
+    (assume a : R, by { dsimp, rw [eval₂_C], refl }) (assume a, a.elim),
   right_inv := λ r, eval₂_C _ _ _,
   map_mul'  := λ _ _, eval₂_mul _ _,
   map_add'  := λ _ _, eval₂_add _ _ }
@@ -67,14 +67,14 @@ def pempty_ring_equiv : mv_polynomial pempty α ≃+* α :=
 The ring isomorphism between multivariable polynomials in a single variable and
 polynomials over the ground ring.
 -/
-def punit_ring_equiv : mv_polynomial punit α ≃+* polynomial α :=
+def punit_ring_equiv : mv_polynomial punit R ≃+* polynomial R :=
 { to_fun    := eval₂ polynomial.C (λu:punit, polynomial.X),
   inv_fun   := polynomial.eval₂ mv_polynomial.C (X punit.star),
   left_inv  :=
     begin
-      let f : polynomial α →+* mv_polynomial punit α :=
+      let f : polynomial R →+* mv_polynomial punit R :=
       ring_hom.of (polynomial.eval₂ mv_polynomial.C (X punit.star)),
-      let g : mv_polynomial punit α →+* polynomial α :=
+      let g : mv_polynomial punit R →+* polynomial R :=
       ring_hom.of (eval₂ polynomial.C (λu:punit, polynomial.X)),
       show ∀ p, f.comp g p = p,
       apply is_id,
@@ -91,7 +91,7 @@ def punit_ring_equiv : mv_polynomial punit α ≃+* polynomial α :=
   map_add'  := λ _ _, eval₂_add _ _ }
 
 /-- The ring isomorphism between multivariable polynomials induced by an equivalence of the variables.  -/
-def ring_equiv_of_equiv (e : β ≃ γ) : mv_polynomial β α ≃+* mv_polynomial γ α :=
+def ring_equiv_of_equiv (e : β ≃ γ) : mv_polynomial β R ≃+* mv_polynomial γ R :=
 { to_fun    := rename e,
   inv_fun   := rename e.symm,
   left_inv  := λ p, by simp only [rename_rename, (∘), e.symm_apply_apply]; exact rename_id p,
@@ -100,15 +100,15 @@ def ring_equiv_of_equiv (e : β ≃ γ) : mv_polynomial β α ≃+* mv_polynomia
   map_add'  := (rename e).map_add }
 
 /-- The ring isomorphism between multivariable polynomials induced by a ring isomorphism of the ground ring. -/
-def ring_equiv_congr [comm_semiring γ] (e : α ≃+* γ) : mv_polynomial β α ≃+* mv_polynomial β γ :=
-{ to_fun    := map (e : α →+* γ),
-  inv_fun   := map (e.symm : γ →+* α),
+def ring_equiv_congr [comm_semiring γ] (e : R ≃+* γ) : mv_polynomial β R ≃+* mv_polynomial β γ :=
+{ to_fun    := map (e : R →+* γ),
+  inv_fun   := map (e.symm : γ →+* R),
   left_inv  := assume p,
-    have (e.symm : γ →+* α).comp (e : α →+* γ) = ring_hom.id _,
+    have (e.symm : γ →+* R).comp (e : R →+* γ) = ring_hom.id _,
     { ext a, exact e.symm_apply_apply a },
     by simp only [map_map, this, map_id],
   right_inv := assume p,
-    have (e : α →+* γ).comp (e.symm : γ →+* α) = ring_hom.id _,
+    have (e : R →+* γ).comp (e.symm : γ →+* R) = ring_hom.id _,
     { ext a, exact e.apply_symm_apply a },
     by simp only [map_map, this, map_id],
   map_mul'  := ring_hom.map_mul _,
@@ -124,19 +124,19 @@ with coefficents in multivariable polynomials in the other type.
 
 See `sum_ring_equiv` for the ring isomorphism.
 -/
-def sum_to_iter : mv_polynomial (β ⊕ γ) α →+* mv_polynomial β (mv_polynomial γ α) :=
+def sum_to_iter : mv_polynomial (β ⊕ γ) R →+* mv_polynomial β (mv_polynomial γ R) :=
 eval₂_hom (C.comp C) (λbc, sum.rec_on bc X (C ∘ X))
 
-instance is_semiring_hom_sum_to_iter : is_semiring_hom (sum_to_iter α β γ) :=
+instance is_semiring_hom_sum_to_iter : is_semiring_hom (sum_to_iter R β γ) :=
 eval₂.is_semiring_hom _ _
 
-lemma sum_to_iter_C (a : α) : sum_to_iter α β γ (C a) = C (C a) :=
+lemma sum_to_iter_C (a : R) : sum_to_iter R β γ (C a) = C (C a) :=
 eval₂_C _ _ a
 
-lemma sum_to_iter_Xl (b : β) : sum_to_iter α β γ (X (sum.inl b)) = X b :=
+lemma sum_to_iter_Xl (b : β) : sum_to_iter R β γ (X (sum.inl b)) = X b :=
 eval₂_X _ _ (sum.inl b)
 
-lemma sum_to_iter_Xr (c : γ) : sum_to_iter α β γ (X (sum.inr c)) = C (X c) :=
+lemma sum_to_iter_Xr (c : γ) : sum_to_iter R β γ (X (sum.inr c)) = C (X c) :=
 eval₂_X _ _ (sum.inr c)
 
 /--
@@ -146,27 +146,27 @@ to multivariable polynomials in the sum of the two types.
 
 See `sum_ring_equiv` for the ring isomorphism.
 -/
-def iter_to_sum : mv_polynomial β (mv_polynomial γ α) →+* mv_polynomial (β ⊕ γ) α :=
+def iter_to_sum : mv_polynomial β (mv_polynomial γ R) →+* mv_polynomial (β ⊕ γ) R :=
 eval₂_hom (ring_hom.of (eval₂ C (X ∘ sum.inr))) (X ∘ sum.inl)
 
-lemma iter_to_sum_C_C (a : α) : iter_to_sum α β γ (C (C a)) = C a :=
+lemma iter_to_sum_C_C (a : R) : iter_to_sum R β γ (C (C a)) = C a :=
 eq.trans (eval₂_C _ _ (C a)) (eval₂_C _ _ _)
 
-lemma iter_to_sum_X (b : β) : iter_to_sum α β γ (X b) = X (sum.inl b) :=
+lemma iter_to_sum_X (b : β) : iter_to_sum R β γ (X b) = X (sum.inl b) :=
 eval₂_X _ _ _
 
-lemma iter_to_sum_C_X (c : γ) : iter_to_sum α β γ (C (X c)) = X (sum.inr c) :=
+lemma iter_to_sum_C_X (c : γ) : iter_to_sum R β γ (C (X c)) = X (sum.inr c) :=
 eq.trans (eval₂_C _ _ (X c)) (eval₂_X _ _ _)
 
 /-- A helper function for `sum_ring_equiv`. -/
 def mv_polynomial_equiv_mv_polynomial [comm_semiring δ]
-  (f : mv_polynomial β α →+* mv_polynomial γ δ)
-  (g : mv_polynomial γ δ →+* mv_polynomial β α)
+  (f : mv_polynomial β R →+* mv_polynomial γ δ)
+  (g : mv_polynomial γ δ →+* mv_polynomial β R)
   (hfgC : ∀a, f (g (C a)) = C a)
   (hfgX : ∀n, f (g (X n)) = X n)
   (hgfC : ∀a, g (f (C a)) = C a)
   (hgfX : ∀n, g (f (X n)) = X n) :
-  mv_polynomial β α ≃+* mv_polynomial γ δ :=
+  mv_polynomial β R ≃+* mv_polynomial γ δ :=
 { to_fun    := f, inv_fun := g,
   left_inv  := is_id (ring_hom.comp _ _) hgfC hgfX,
   right_inv := is_id (ring_hom.comp _ _) hfgC hfgX,
@@ -178,16 +178,16 @@ The ring isomorphism between multivariable polynomials in a sum of two types,
 and multivariable polynomials in one of the types,
 with coefficents in multivariable polynomials in the other type.
 -/
-def sum_ring_equiv : mv_polynomial (β ⊕ γ) α ≃+* mv_polynomial β (mv_polynomial γ α) :=
+def sum_ring_equiv : mv_polynomial (β ⊕ γ) R ≃+* mv_polynomial β (mv_polynomial γ R) :=
 begin
-  apply @mv_polynomial_equiv_mv_polynomial α (β ⊕ γ) _ _ _ _
-    (sum_to_iter α β γ) (iter_to_sum α β γ),
+  apply @mv_polynomial_equiv_mv_polynomial R (β ⊕ γ) _ _ _ _
+    (sum_to_iter R β γ) (iter_to_sum R β γ),
   { assume p,
-    convert hom_eq_hom ((sum_to_iter α β γ).comp ((iter_to_sum α β γ).comp C)) C _ _ p,
-    { assume a, dsimp, rw [iter_to_sum_C_C α β γ, sum_to_iter_C α β γ] },
-    { assume c, dsimp, rw [iter_to_sum_C_X α β γ, sum_to_iter_Xr α β γ] } },
-  { assume b, rw [iter_to_sum_X α β γ, sum_to_iter_Xl α β γ] },
-  { assume a, rw [sum_to_iter_C α β γ, iter_to_sum_C_C α β γ] },
+    convert hom_eq_hom ((sum_to_iter R β γ).comp ((iter_to_sum R β γ).comp C)) C _ _ p,
+    { assume a, dsimp, rw [iter_to_sum_C_C R β γ, sum_to_iter_C R β γ] },
+    { assume c, dsimp, rw [iter_to_sum_C_X R β γ, sum_to_iter_Xr R β γ] } },
+  { assume b, rw [iter_to_sum_X R β γ, sum_to_iter_Xl R β γ] },
+  { assume a, rw [sum_to_iter_C R β γ, iter_to_sum_C_C R β γ] },
   { assume n, cases n with b c,
     { rw [sum_to_iter_Xl, iter_to_sum_X] },
     { rw [sum_to_iter_Xr, iter_to_sum_C_X] } },
@@ -195,30 +195,30 @@ end
 
 /--
 The ring isomorphism between multivariable polynomials in `option β` and
-polynomials with coefficients in `mv_polynomial β α`.
+polynomials with coefficients in `mv_polynomial β R`.
 -/
-def option_equiv_left : mv_polynomial (option β) α ≃+* polynomial (mv_polynomial β α) :=
-(ring_equiv_of_equiv α $ (equiv.option_equiv_sum_punit β).trans (equiv.sum_comm _ _)).trans $
-(sum_ring_equiv α _ _).trans $
+def option_equiv_left : mv_polynomial (option β) R ≃+* polynomial (mv_polynomial β R) :=
+(ring_equiv_of_equiv R $ (equiv.option_equiv_sum_punit β).trans (equiv.sum_comm _ _)).trans $
+(sum_ring_equiv R _ _).trans $
 punit_ring_equiv _
 
 /--
 The ring isomorphism between multivariable polynomials in `option β` and
 multivariable polynomials with coefficients in polynomials.
 -/
-def option_equiv_right : mv_polynomial (option β) α ≃+* mv_polynomial β (polynomial α) :=
-(ring_equiv_of_equiv α $ equiv.option_equiv_sum_punit.{0} β).trans $
-(sum_ring_equiv α β unit).trans $
-ring_equiv_congr (mv_polynomial unit α) (punit_ring_equiv α)
+def option_equiv_right : mv_polynomial (option β) R ≃+* mv_polynomial β (polynomial R) :=
+(ring_equiv_of_equiv R $ equiv.option_equiv_sum_punit.{0} β).trans $
+(sum_ring_equiv R β unit).trans $
+ring_equiv_congr (mv_polynomial unit R) (punit_ring_equiv R)
 
 /--
 The ring isomorphism between multivariable polynomials in `fin (n + 1)` and
 polynomials over multivariable polynomials in `fin n`.
 -/
 def fin_succ_equiv (n : ℕ) :
-  mv_polynomial (fin (n + 1)) α ≃+* polynomial (mv_polynomial (fin n) α) :=
-(ring_equiv_of_equiv α (fin_succ_equiv n)).trans
-  (option_equiv_left α (fin n))
+  mv_polynomial (fin (n + 1)) R ≃+* polynomial (mv_polynomial (fin n) R) :=
+(ring_equiv_of_equiv R (fin_succ_equiv n)).trans
+  (option_equiv_left R (fin n))
 
 end
 

--- a/src/data/mv_polynomial/monad.lean
+++ b/src/data/mv_polynomial/monad.lean
@@ -291,7 +291,7 @@ lemma eval₂_hom_comp_bind₂ (f : S →+* T) (g : σ → T) (h : R →+* mv_po
 by { ext1, apply eval₂_hom_bind₂ }
 
 lemma aeval_bind₂ [algebra S T] (f : σ → T) (g : R →+* mv_polynomial σ S) (φ : mv_polynomial σ R) :
-  aeval f (bind₂ g φ) = eval₂_hom ((@aeval σ S T f _ _ _ : mv_polynomial σ S →+* T).comp g) f φ :=
+  aeval f (bind₂ g φ) = eval₂_hom ((@aeval S σ _ T f _ _ : mv_polynomial σ S →+* T).comp g) f φ :=
 eval₂_hom_bind₂ _ _ _ _
 
 lemma eval₂_hom_C_left (f : σ → mv_polynomial τ R) : eval₂_hom C f = bind₁ f := rfl

--- a/src/data/mv_polynomial/monad.lean
+++ b/src/data/mv_polynomial/monad.lean
@@ -291,7 +291,7 @@ lemma eval₂_hom_comp_bind₂ (f : S →+* T) (g : σ → T) (h : R →+* mv_po
 by { ext1, apply eval₂_hom_bind₂ }
 
 lemma aeval_bind₂ [algebra S T] (f : σ → T) (g : R →+* mv_polynomial σ S) (φ : mv_polynomial σ R) :
-  aeval f (bind₂ g φ) = eval₂_hom ((@aeval S σ _ T f _ _ : mv_polynomial σ S →+* T).comp g) f φ :=
+  aeval f (bind₂ g φ) = eval₂_hom ((@aeval S T σ _ f _ _ : mv_polynomial σ S →+* T).comp g) f φ :=
 eval₂_hom_bind₂ _ _ _ _
 
 lemma eval₂_hom_C_left (f : σ → mv_polynomial τ R) : eval₂_hom C f = bind₁ f := rfl

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -528,7 +528,7 @@ section eval_vars
 /-! ### `vars` and `eval` -/
 
 variables {S₁ : Type v} {S₂ : Type w} (f : σ → S₁)
-variables [comm_semiring R] [comm_semiring S₁] [algebra R S₁] [comm_semiring S₂]
+variables [comm_semiring S₁] [algebra R S₁] [comm_semiring S₂]
 
 lemma eval₂_hom_eq_constant_coeff_of_vars (f : R →+* S₂) {g : σ → S₂}
   {p : mv_polynomial σ R} (hp : ∀ i ∈ p.vars, g i = 0) :

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -40,16 +40,16 @@ As in other polynomial files we typically use the notation:
 
 + `σ : Type*` (indexing the variables)
 
-+ `α : Type*` `[comm_semiring α]` (the coefficients)
++ `R : Type*` `[comm_semiring R]` (the coefficients)
 
 + `s : σ →₀ ℕ`, a function from `σ` to `ℕ` which is zero away from a finite set.
 This will give rise to a monomial in `mv_polynomial σ R` which mathematicians might call `X^s`
 
-+ `a : α`
++ `a : R`
 
 + `i : σ`, with corresponding monomial `X i`, often denoted `X_i` by mathematicians
 
-+ `p : mv_polynomial σ α`
++ `p : mv_polynomial σ R`
 
 -/
 
@@ -61,13 +61,13 @@ open set function finsupp add_monoid_algebra
 open_locale big_operators
 
 universes u v w x
-variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
+variables {R : Type u} {β : Type v} {γ : Type w} {δ : Type x}
 
 namespace mv_polynomial
-variables {σ : Type*} {a a' a₁ a₂ : α} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
+variables {σ : Type*} {a a' a₁ a₂ : R} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
 
 section comm_semiring
-variables [comm_semiring α] {p q : mv_polynomial σ α}
+variables [comm_semiring R] {p q : mv_polynomial σ R}
 
 
 section degrees
@@ -79,10 +79,10 @@ The maximal degrees of each variable in a multi-variable polynomial, expressed a
 
 (For example, `degrees (x^2 * y + y^3)` would be `{x, x, y, y, y}`.)
 -/
-def degrees (p : mv_polynomial σ α) : multiset σ :=
+def degrees (p : mv_polynomial σ R) : multiset σ :=
 p.support.sup (λs:σ →₀ ℕ, s.to_multiset)
 
-lemma degrees_monomial (s : σ →₀ ℕ) (a : α) : degrees (monomial s a) ≤ s.to_multiset :=
+lemma degrees_monomial (s : σ →₀ ℕ) (a : R) : degrees (monomial s a) ≤ s.to_multiset :=
 finset.sup_le $ assume t h,
 begin
   have := finsupp.support_single_subset h,
@@ -90,23 +90,23 @@ begin
   rw this
 end
 
-lemma degrees_monomial_eq (s : σ →₀ ℕ) (a : α) (ha : a ≠ 0) :
+lemma degrees_monomial_eq (s : σ →₀ ℕ) (a : R) (ha : a ≠ 0) :
   degrees (monomial s a) = s.to_multiset :=
 le_antisymm (degrees_monomial s a) $ finset.le_sup $
   by rw [monomial, finsupp.support_single_ne_zero ha, finset.mem_singleton]
 
-lemma degrees_C (a : α) : degrees (C a : mv_polynomial σ α) = 0 :=
+lemma degrees_C (a : R) : degrees (C a : mv_polynomial σ R) = 0 :=
 multiset.le_zero.1 $ degrees_monomial _ _
 
-lemma degrees_X (n : σ) : degrees (X n : mv_polynomial σ α) ≤ {n} :=
+lemma degrees_X (n : σ) : degrees (X n : mv_polynomial σ R) ≤ {n} :=
 le_trans (degrees_monomial _ _) $ le_of_eq $ to_multiset_single _ _
 
-lemma degrees_zero : degrees (0 : mv_polynomial σ α) = 0 :=
+lemma degrees_zero : degrees (0 : mv_polynomial σ R) = 0 :=
 by { rw ← C_0, exact degrees_C 0 }
 
-lemma degrees_one : degrees (1 : mv_polynomial σ α) = 0 := degrees_C 1
+lemma degrees_one : degrees (1 : mv_polynomial σ R) = 0 := degrees_C 1
 
-lemma degrees_add (p q : mv_polynomial σ α) : (p + q).degrees ≤ p.degrees ⊔ q.degrees :=
+lemma degrees_add (p q : mv_polynomial σ R) : (p + q).degrees ≤ p.degrees ⊔ q.degrees :=
 begin
   refine finset.sup_le (assume b hb, _),
   have := finsupp.support_add hb, rw finset.mem_union at this,
@@ -115,7 +115,7 @@ begin
   { exact le_sup_right_of_le (finset.le_sup this) },
 end
 
-lemma degrees_sum {ι : Type*} (s : finset ι) (f : ι → mv_polynomial σ α) :
+lemma degrees_sum {ι : Type*} (s : finset ι) (f : ι → mv_polynomial σ R) :
   (∑ i in s, f i).degrees ≤ s.sup (λi, (f i).degrees) :=
 begin
   refine s.induction _ _,
@@ -125,7 +125,7 @@ begin
     exact le_trans (degrees_add _ _) (sup_le_sup_left ih _) }
 end
 
-lemma degrees_mul (p q : mv_polynomial σ α) : (p * q).degrees ≤ p.degrees + q.degrees :=
+lemma degrees_mul (p q : mv_polynomial σ R) : (p * q).degrees ≤ p.degrees + q.degrees :=
 begin
   refine finset.sup_le (assume b hb, _),
   have := support_mul p q hb,
@@ -135,7 +135,7 @@ begin
   exact add_le_add (finset.le_sup h₁) (finset.le_sup h₂)
 end
 
-lemma degrees_prod {ι : Type*} (s : finset ι) (f : ι → mv_polynomial σ α) :
+lemma degrees_prod {ι : Type*} (s : finset ι) (f : ι → mv_polynomial σ R) :
   (∏ i in s, f i).degrees ≤ ∑ i in s, (f i).degrees :=
 begin
   refine s.induction _ _,
@@ -145,17 +145,17 @@ begin
     exact le_trans (degrees_mul _ _) (add_le_add_left ih _) }
 end
 
-lemma degrees_pow (p : mv_polynomial σ α) :
+lemma degrees_pow (p : mv_polynomial σ R) :
   ∀(n : ℕ), (p^n).degrees ≤ n •ℕ p.degrees
 | 0       := begin rw [pow_zero, degrees_one], exact multiset.zero_le _ end
 | (n + 1) := le_trans (degrees_mul _ _) (add_le_add_left (degrees_pow n) _)
 
-lemma mem_degrees {p : mv_polynomial σ α} {i : σ} :
+lemma mem_degrees {p : mv_polynomial σ R} {i : σ} :
   i ∈ p.degrees ↔ ∃ d, p.coeff d ≠ 0 ∧ i ∈ d.support :=
 by simp only [degrees, finset.mem_sup, ← finsupp.mem_support_iff, coeff,
     finsupp.mem_to_multiset, exists_prop]
 
-lemma le_degrees_add {p q : mv_polynomial σ α} (h : p.degrees.disjoint q.degrees) :
+lemma le_degrees_add {p q : mv_polynomial σ R} (h : p.degrees.disjoint q.degrees) :
   p.degrees ≤ (p + q).degrees :=
 begin
   apply finset.sup_le,
@@ -179,7 +179,7 @@ begin
     all_goals { rw mem_degrees, refine ⟨d, _, hj⟩, assumption } }
 end
 
-lemma degrees_add_of_disjoint {p q : mv_polynomial σ α} (h : multiset.disjoint p.degrees q.degrees) :
+lemma degrees_add_of_disjoint {p q : mv_polynomial σ R} (h : multiset.disjoint p.degrees q.degrees) :
   (p + q).degrees = p.degrees ∪ q.degrees :=
 begin
   apply le_antisymm,
@@ -189,7 +189,7 @@ begin
     { rw add_comm, apply le_degrees_add h.symm } }
 end
 
-lemma degrees_map [comm_semiring β] (p : mv_polynomial σ α) (f : α →+* β) :
+lemma degrees_map [comm_semiring β] (p : mv_polynomial σ R) (f : R →+* β) :
   (map f p).degrees ⊆ p.degrees :=
 begin
   dsimp only [degrees],
@@ -198,8 +198,8 @@ begin
   apply mv_polynomial.support_map_subset
 end
 
-lemma degrees_map_of_injective [comm_semiring β] (p : mv_polynomial σ α)
-  {f : α →+* β} (hf : injective f) : (map f p).degrees = p.degrees :=
+lemma degrees_map_of_injective [comm_semiring β] (p : mv_polynomial σ R)
+  {f : R →+* β} (hf : injective f) : (map f p).degrees = p.degrees :=
 by simp only [degrees, mv_polynomial.support_map_of_injective _ hf]
 
 end degrees
@@ -209,25 +209,25 @@ section vars
 /-! ### `vars` -/
 
 /-- `vars p` is the set of variables appearing in the polynomial `p` -/
-def vars (p : mv_polynomial σ α) : finset σ := p.degrees.to_finset
+def vars (p : mv_polynomial σ R) : finset σ := p.degrees.to_finset
 
-@[simp] lemma vars_0 : (0 : mv_polynomial σ α).vars = ∅ :=
+@[simp] lemma vars_0 : (0 : mv_polynomial σ R).vars = ∅ :=
 by rw [vars, degrees_zero, multiset.to_finset_zero]
 
 @[simp] lemma vars_monomial (h : a ≠ 0) : (monomial s a).vars = s.support :=
 by rw [vars, degrees_monomial_eq _ _ h, finsupp.to_finset_to_multiset]
 
-@[simp] lemma vars_C : (C a : mv_polynomial σ α).vars = ∅ :=
+@[simp] lemma vars_C : (C a : mv_polynomial σ R).vars = ∅ :=
 by rw [vars, degrees_C, multiset.to_finset_zero]
 
-@[simp] lemma vars_X (h : 0 ≠ (1 : α)) : (X n : mv_polynomial σ α).vars = {n} :=
+@[simp] lemma vars_X (h : 0 ≠ (1 : R)) : (X n : mv_polynomial σ R).vars = {n} :=
 by rw [X, vars_monomial h.symm, finsupp.support_single_ne_zero (one_ne_zero : 1 ≠ 0)]
 
 lemma mem_vars (i : σ) :
   i ∈ p.vars ↔ ∃ (d : σ →₀ ℕ) (H : d ∈ p.support), i ∈ d.support :=
 by simp only [vars, multiset.mem_to_finset, mem_degrees, coeff, finsupp.mem_support_iff, exists_prop]
 
-lemma mem_support_not_mem_vars_zero {f : mv_polynomial σ α} {x : σ →₀ ℕ} (H : x ∈ f.support) {v : σ} (h : v ∉ vars f) :
+lemma mem_support_not_mem_vars_zero {f : mv_polynomial σ R} {x : σ →₀ ℕ} (H : x ∈ f.support) {v : σ} (h : v ∉ vars f) :
   x v = 0 :=
 begin
   rw [vars, multiset.mem_to_finset] at h,
@@ -241,7 +241,7 @@ begin
   rwa [←to_finset_to_multiset, multiset.mem_to_finset] at h,
 end
 
-lemma vars_add_subset (p q : mv_polynomial σ α) :
+lemma vars_add_subset (p q : mv_polynomial σ R) :
   (p + q).vars ⊆ p.vars ∪ q.vars :=
 begin
   intros x hx,
@@ -261,7 +261,7 @@ end
 
 section mul
 
-lemma vars_mul (φ ψ : mv_polynomial σ α) : (φ * ψ).vars ⊆ φ.vars ∪ ψ.vars :=
+lemma vars_mul (φ ψ : mv_polynomial σ R) : (φ * ψ).vars ⊆ φ.vars ∪ ψ.vars :=
 begin
   intro i,
   simp only [mem_vars, finset.mem_union],
@@ -280,10 +280,10 @@ begin
     rw [coeff, ← finsupp.not_mem_support_iff], intro, solve_by_elim, },
 end
 
-@[simp] lemma vars_one : (1 : mv_polynomial σ α).vars = ∅ :=
+@[simp] lemma vars_one : (1 : mv_polynomial σ R).vars = ∅ :=
 vars_C
 
-lemma vars_pow (φ : mv_polynomial σ α) (n : ℕ) : (φ ^ n).vars ⊆ φ.vars :=
+lemma vars_pow (φ : mv_polynomial σ R) (n : ℕ) : (φ ^ n).vars ⊆ φ.vars :=
 begin
   induction n with n ih,
   { simp },
@@ -296,7 +296,7 @@ end
 The variables of the product of a family of polynomials
 are a subset of the union of the sets of variables of each polynomial.
 -/
-lemma vars_prod {ι : Type*} {s : finset ι} (f : ι → mv_polynomial σ α) :
+lemma vars_prod {ι : Type*} {s : finset ι} (f : ι → mv_polynomial σ R) :
   (∏ i in s, f i).vars ⊆ s.bind (λ i, (f i).vars) :=
 begin
   apply s.induction_on,
@@ -326,7 +326,7 @@ end mul
 
 section sum
 
-variables {ι : Type*} (t : finset ι) (φ : ι → mv_polynomial σ α)
+variables {ι : Type*} (t : finset ι) (φ : ι → mv_polynomial σ R)
 
 lemma vars_sum_subset :
   (∑ i in t, φ i).vars ⊆ finset.bind t (λ i, (φ i).vars) :=
@@ -362,7 +362,7 @@ end sum
 
 section map
 
-variables [comm_semiring β] (f : α →+* β)
+variables [comm_semiring β] (f : R →+* β)
 variable (p)
 
 lemma vars_map : (map f p).vars ⊆ p.vars :=
@@ -373,7 +373,7 @@ lemma vars_map_of_injective (hf : injective f) :
   (map f p).vars = p.vars :=
 by simp [vars, degrees_map_of_injective _ hf]
 
-lemma vars_monomial_single (i : σ) {e : ℕ} {r : α} (he : e ≠ 0) (hr : r ≠ 0) :
+lemma vars_monomial_single (i : σ) {e : ℕ} {r : R} (he : e ≠ 0) (hr : r ≠ 0) :
   (monomial (finsupp.single i e) r).vars = {i} :=
 by rw [vars_monomial hr, finsupp.support_single_ne_zero he]
 
@@ -389,7 +389,7 @@ section degree_of
 /-! ### `degree_of` -/
 
 /-- `degree_of n p` gives the highest power of X_n that appears in `p` -/
-def degree_of (n : σ) (p : mv_polynomial σ α) : ℕ := p.degrees.count n
+def degree_of (n : σ) (p : mv_polynomial σ R) : ℕ := p.degrees.count n
 
 end degree_of
 
@@ -398,9 +398,9 @@ section total_degree
 /-! ### `total_degree` -/
 
 /-- `total_degree p` gives the maximum |s| over the monomials X^s in `p` -/
-def total_degree (p : mv_polynomial σ α) : ℕ := p.support.sup (λs, s.sum $ λn e, e)
+def total_degree (p : mv_polynomial σ R) : ℕ := p.support.sup (λs, s.sum $ λn e, e)
 
-lemma total_degree_eq (p : mv_polynomial σ α) :
+lemma total_degree_eq (p : mv_polynomial σ R) :
   p.total_degree = p.support.sup (λm, m.to_multiset.card) :=
 begin
   rw [total_degree],
@@ -408,14 +408,14 @@ begin
   exact (finsupp.card_to_multiset _).symm
 end
 
-lemma total_degree_le_degrees_card (p : mv_polynomial σ α) :
+lemma total_degree_le_degrees_card (p : mv_polynomial σ R) :
   p.total_degree ≤ p.degrees.card :=
 begin
   rw [total_degree_eq],
   exact finset.sup_le (assume s hs, multiset.card_le_of_le $ finset.le_sup hs)
 end
 
-@[simp] lemma total_degree_C (a : α) : (C a : mv_polynomial σ α).total_degree = 0 :=
+@[simp] lemma total_degree_C (a : R) : (C a : mv_polynomial σ R).total_degree = 0 :=
 nat.eq_zero_of_le_zero $ finset.sup_le $ assume n hn,
   have _ := finsupp.support_single_subset hn,
   begin
@@ -424,20 +424,20 @@ nat.eq_zero_of_le_zero $ finset.sup_le $ assume n hn,
     exact le_refl _
   end
 
-@[simp] lemma total_degree_zero : (0 : mv_polynomial σ α).total_degree = 0 :=
-by rw [← C_0]; exact total_degree_C (0 : α)
+@[simp] lemma total_degree_zero : (0 : mv_polynomial σ R).total_degree = 0 :=
+by rw [← C_0]; exact total_degree_C (0 : R)
 
-@[simp] lemma total_degree_one : (1 : mv_polynomial σ α).total_degree = 0 :=
-total_degree_C (1 : α)
+@[simp] lemma total_degree_one : (1 : mv_polynomial σ R).total_degree = 0 :=
+total_degree_C (1 : R)
 
-@[simp] lemma total_degree_X {α} [comm_semiring α] [nontrivial α] (s : σ) :
-  (X s : mv_polynomial σ α).total_degree = 1 :=
+@[simp] lemma total_degree_X {R} [comm_semiring R] [nontrivial R] (s : σ) :
+  (X s : mv_polynomial σ R).total_degree = 1 :=
 begin
-  rw [total_degree, X, monomial, finsupp.support_single_ne_zero (one_ne_zero : (1 : α) ≠ 0)],
+  rw [total_degree, X, monomial, finsupp.support_single_ne_zero (one_ne_zero : (1 : R) ≠ 0)],
   simp only [finset.sup, sum_single_index, finset.fold_singleton, sup_bot_eq],
 end
 
-lemma total_degree_add (a b : mv_polynomial σ α) :
+lemma total_degree_add (a b : mv_polynomial σ R) :
   (a + b).total_degree ≤ max a.total_degree b.total_degree :=
 finset.sup_le $ assume n hn,
   have _ := finsupp.support_add hn,
@@ -448,7 +448,7 @@ finset.sup_le $ assume n hn,
     { exact le_max_right_of_le (finset.le_sup this) }
   end
 
-lemma total_degree_mul (a b : mv_polynomial σ α) :
+lemma total_degree_mul (a b : mv_polynomial σ R) :
   (a * b).total_degree ≤ a.total_degree + b.total_degree :=
 finset.sup_le $ assume n hn,
   have _ := add_monoid_algebra.support_mul a b hn,
@@ -461,7 +461,7 @@ finset.sup_le $ assume n hn,
     { assume a b₁ b₂, refl }
   end
 
-lemma total_degree_pow (a : mv_polynomial σ α) (n : ℕ) :
+lemma total_degree_pow (a : mv_polynomial σ R) (n : ℕ) :
   (a ^ n).total_degree ≤ n * a.total_degree :=
 begin
   induction n with n ih,
@@ -473,15 +473,15 @@ begin
 end
 
 lemma total_degree_list_prod :
-  ∀(s : list (mv_polynomial σ α)), s.prod.total_degree ≤ (s.map mv_polynomial.total_degree).sum
-| []        := by rw [@list.prod_nil (mv_polynomial σ α) _, total_degree_one]; refl
+  ∀(s : list (mv_polynomial σ R)), s.prod.total_degree ≤ (s.map mv_polynomial.total_degree).sum
+| []        := by rw [@list.prod_nil (mv_polynomial σ R) _, total_degree_one]; refl
 | (p :: ps) :=
   begin
-    rw [@list.prod_cons (mv_polynomial σ α) _, list.map, list.sum_cons],
+    rw [@list.prod_cons (mv_polynomial σ R) _, list.map, list.sum_cons],
     exact le_trans (total_degree_mul _ _) (add_le_add_left (total_degree_list_prod ps) _)
   end
 
-lemma total_degree_multiset_prod (s : multiset (mv_polynomial σ α)) :
+lemma total_degree_multiset_prod (s : multiset (mv_polynomial σ R)) :
   s.prod.total_degree ≤ (s.map mv_polynomial.total_degree).sum :=
 begin
   refine quotient.induction_on s (assume l, _),
@@ -490,7 +490,7 @@ begin
 end
 
 lemma total_degree_finset_prod {ι : Type*}
-  (s : finset ι) (f : ι → mv_polynomial σ α) :
+  (s : finset ι) (f : ι → mv_polynomial σ R) :
   (s.prod f).total_degree ≤ ∑ i in s, (f i).total_degree :=
 begin
   refine le_trans (total_degree_multiset_prod _) _,
@@ -498,7 +498,7 @@ begin
   refl
 end
 
-lemma exists_degree_lt [fintype σ] (f : mv_polynomial σ α) (n : ℕ)
+lemma exists_degree_lt [fintype σ] (f : mv_polynomial σ R) (n : ℕ)
   (h : f.total_degree < n * fintype.card σ) {d : σ →₀ ℕ} (hd : d ∈ f.support) :
   ∃ i, d i < n :=
 begin
@@ -510,7 +510,7 @@ begin
     ... ≤ f.total_degree   : finset.le_sup hd,
 end
 
-lemma coeff_eq_zero_of_total_degree_lt {f : mv_polynomial σ α} {d : σ →₀ ℕ}
+lemma coeff_eq_zero_of_total_degree_lt {f : mv_polynomial σ R} {d : σ →₀ ℕ}
   (h : f.total_degree < ∑ i in d.support, d i) :
   coeff d f = 0 :=
 begin
@@ -527,7 +527,7 @@ section eval_vars
 
 /-! ### `vars` and `eval` -/
 
-variables {R : Type u} {A : Type v} {S : Type w} (f : σ → A)
+variables {A : Type v} {S : Type w} (f : σ → A)
 variables [comm_semiring R] [comm_semiring A] [algebra R A] [comm_semiring S]
 
 lemma eval₂_hom_eq_constant_coeff_of_vars (f : R →+* S) {g : σ → S}

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -60,8 +60,8 @@ open_locale classical big_operators
 open set function finsupp add_monoid_algebra
 open_locale big_operators
 
-universes u v w x
-variables {R : Type u} {β : Type v} {γ : Type w} {δ : Type x}
+universes u v w
+variables {R : Type u} {S : Type v}
 
 namespace mv_polynomial
 variables {σ : Type*} {a a' a₁ a₂ : R} {e : ℕ} {n m : σ} {s : σ →₀ ℕ}
@@ -189,7 +189,7 @@ begin
     { rw add_comm, apply le_degrees_add h.symm } }
 end
 
-lemma degrees_map [comm_semiring β] (p : mv_polynomial σ R) (f : R →+* β) :
+lemma degrees_map [comm_semiring S] (p : mv_polynomial σ R) (f : R →+* S) :
   (map f p).degrees ⊆ p.degrees :=
 begin
   dsimp only [degrees],
@@ -198,8 +198,8 @@ begin
   apply mv_polynomial.support_map_subset
 end
 
-lemma degrees_map_of_injective [comm_semiring β] (p : mv_polynomial σ R)
-  {f : R →+* β} (hf : injective f) : (map f p).degrees = p.degrees :=
+lemma degrees_map_of_injective [comm_semiring S] (p : mv_polynomial σ R)
+  {f : R →+* S} (hf : injective f) : (map f p).degrees = p.degrees :=
 by simp only [degrees, mv_polynomial.support_map_of_injective _ hf]
 
 end degrees
@@ -362,7 +362,7 @@ end sum
 
 section map
 
-variables [comm_semiring β] (f : R →+* β)
+variables [comm_semiring S] (f : R →+* S)
 variable (p)
 
 lemma vars_map : (map f p).vars ⊆ p.vars :=
@@ -527,10 +527,10 @@ section eval_vars
 
 /-! ### `vars` and `eval` -/
 
-variables {A : Type v} {S : Type w} (f : σ → A)
-variables [comm_semiring R] [comm_semiring A] [algebra R A] [comm_semiring S]
+variables {S₁ : Type v} {S₂ : Type w} (f : σ → S₁)
+variables [comm_semiring R] [comm_semiring S₁] [algebra R S₁] [comm_semiring S₂]
 
-lemma eval₂_hom_eq_constant_coeff_of_vars (f : R →+* S) {g : σ → S}
+lemma eval₂_hom_eq_constant_coeff_of_vars (f : R →+* S₂) {g : σ → S₂}
   {p : mv_polynomial σ R} (hp : ∀ i ∈ p.vars, g i = 0) :
   eval₂_hom f g p = f (constant_coeff p) :=
 begin
@@ -558,7 +558,7 @@ begin
     intro, contradiction }
 end
 
-lemma aeval_eq_constant_coeff_of_vars [algebra R S] {g : σ → S}
+lemma aeval_eq_constant_coeff_of_vars [algebra R S₂] {g : σ → S₂}
   {p : mv_polynomial σ R} (hp : ∀ i ∈ p.vars, g i = 0) :
   aeval g p = algebra_map _ _ (constant_coeff p) :=
 eval₂_hom_eq_constant_coeff_of_vars _ hp


### PR DESCRIPTION
I renamed `α` to `R` throughout. I also changed the `\sigma` to `σ` in `basic.lean`, see leanprover-community/doc-gen#62

---
<!-- put comments you want to keep out of the PR commit here -->

Formerly: ~~The file used `α` and `β` as the `semiring`s, not `R` and `S` as suggested by the original module doc string.~~
