### PR TITLE
[Merged by Bors] - feat(data/*/gcd): adds gcd, lcm of finsets and multisets

### DIFF
--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -290,6 +290,16 @@ gcd_dvd_gcd (dvd_refl _) (dvd_mul_left _ _)
 theorem gcd_dvd_gcd_mul_right_right (m n k : α) : gcd m n ∣ gcd m (n * k) :=
 gcd_dvd_gcd (dvd_refl _) (dvd_mul_right _ _)
 
+theorem gcd_eq_of_associated_left {m n : α} (h : associated m n) (k : α) : gcd m k = gcd n k :=
+dvd_antisymm_of_normalize_eq (normalize_gcd _ _) (normalize_gcd _ _)
+  (gcd_dvd_gcd (dvd_of_associated h) (dvd_refl _))
+  (gcd_dvd_gcd (dvd_of_associated h.symm) (dvd_refl _))
+
+theorem gcd_eq_of_associated_right {m n : α} (h : associated m n) (k : α) : gcd k m = gcd k n :=
+dvd_antisymm_of_normalize_eq (normalize_gcd _ _) (normalize_gcd _ _)
+  (gcd_dvd_gcd (dvd_refl _) (dvd_of_associated h))
+  (gcd_dvd_gcd (dvd_refl _) (dvd_of_associated h.symm))
+
 end gcd
 
 section lcm
@@ -409,6 +419,16 @@ lcm_dvd_lcm (dvd_refl _) (dvd_mul_left _ _)
 
 theorem lcm_dvd_lcm_mul_right_right (m n k : α) : lcm m n ∣ lcm m (n * k) :=
 lcm_dvd_lcm (dvd_refl _) (dvd_mul_right _ _)
+
+theorem lcm_eq_of_associated_left {m n : α} (h : associated m n) (k : α) : lcm m k = lcm n k :=
+dvd_antisymm_of_normalize_eq (normalize_lcm _ _) (normalize_lcm _ _)
+  (lcm_dvd_lcm (dvd_of_associated h) (dvd_refl _))
+  (lcm_dvd_lcm (dvd_of_associated h.symm) (dvd_refl _))
+
+theorem lcm_eq_of_associated_right {m n : α} (h : associated m n) (k : α) : lcm k m = lcm k n :=
+dvd_antisymm_of_normalize_eq (normalize_lcm _ _) (normalize_lcm _ _)
+  (lcm_dvd_lcm (dvd_refl _) (dvd_of_associated h))
+  (lcm_dvd_lcm (dvd_refl _) (dvd_of_associated h.symm))
 
 end lcm
 

--- a/src/data/finset/gcd.lean
+++ b/src/data/finset/gcd.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2020 Aaron Anderson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Aaron Anderson
+-/
+import data.finset.fold
+import data.multiset.gcd
+
+/-!
+# GCD and LCM operations on finsets
+
+TODO: simplify with a tactic and `data.finset.lattice`
+-/
+
+variables {α β γ : Type*} [comm_cancel_monoid_with_zero α] [nontrivial α] [gcd_monoid α]
+
+namespace finset
+open multiset
+
+/-! ### lcm -/
+section lcm
+
+/-- Least common multiple of a finite set -/
+def lcm (s : finset β) (f : β → α) : α := s.fold gcd_monoid.lcm 1 f
+
+variables {s s₁ s₂ : finset β} {f : β → α}
+
+lemma lcm_def : s.lcm f = (s.1.map f).lcm := rfl
+
+@[simp] lemma lcm_empty : (∅ : finset β).lcm f = 1 :=
+fold_empty
+
+@[simp] lemma lcm_dvd_iff {a : α} : s.lcm f ∣ a ↔ (∀b ∈ s, f b ∣ a) :=
+begin
+  apply iff.trans multiset.lcm_dvd,
+  simp only [multiset.mem_map, and_imp, exists_imp_distrib],
+  exact ⟨λ k b hb, k _ _ hb rfl, λ k a' b hb h, h ▸ k _ hb⟩,
+end
+
+lemma lcm_dvd {a : α} : (∀b ∈ s, f b ∣ a) → s.lcm f ∣ a :=
+lcm_dvd_iff.2
+
+lemma dvd_lcm {b : β} (hb : b ∈ s) : f b ∣ s.lcm f :=
+lcm_dvd_iff.1 (dvd_refl _) _ hb
+
+@[simp] lemma lcm_insert [decidable_eq β] {b : β} :
+  (insert b s : finset β).lcm f = gcd_monoid.lcm (f b) (s.lcm f) :=
+begin
+  by_cases h : b ∈ s,
+  { rw [insert_eq_of_mem h,
+    (lcm_eq_right_iff (f b) (s.lcm f) (multiset.normalize_lcm (s.1.map f))).2 (dvd_lcm h)] },
+  apply fold_insert h,
+end
+
+@[simp] lemma lcm_singleton {b : β} : ({b} : finset β).lcm f = normalize (f b) :=
+lcm_singleton
+
+@[simp] lemma normalize_lcm : normalize (s.lcm f) = s.lcm f := by simp [lcm_def]
+
+lemma lcm_union [decidable_eq β] : (s₁ ∪ s₂).lcm f = gcd_monoid.lcm (s₁.lcm f) (s₂.lcm f) :=
+finset.induction_on s₁ (by rw [empty_union, lcm_empty, lcm_one_left, normalize_lcm]) $ λ a s has ih,
+by rw [insert_union, lcm_insert, lcm_insert, ih, lcm_assoc]
+
+theorem lcm_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀a∈s₂, f a = g a) : s₁.lcm f = s₂.lcm g :=
+by subst hs; exact finset.fold_congr hfg
+
+lemma lcm_mono_fun {g : β → α} (h : ∀b∈s, f b ∣ g b) : s.lcm f ∣ s.lcm g :=
+lcm_dvd (λ b hb, dvd_trans (h b hb) (dvd_lcm hb))
+
+lemma lcm_mono (h : s₁ ⊆ s₂) : s₁.lcm f ∣ s₂.lcm f :=
+lcm_dvd $ assume b hb, dvd_lcm (h hb)
+
+end lcm
+
+/-! ### gcd -/
+section gcd
+
+/-- Greatest common divisor of a finite set -/
+def gcd (s : finset β) (f : β → α) : α := s.fold gcd_monoid.gcd 0 f
+
+variables {s s₁ s₂ : finset β} {f : β → α}
+
+lemma gcd_def : s.gcd f = (s.1.map f).gcd := rfl
+
+@[simp] lemma gcd_empty : (∅ : finset β).gcd f = 0 :=
+fold_empty
+
+lemma dvd_gcd_iff {a : α} : a ∣ s.gcd f ↔ ∀b ∈ s, a ∣ f b :=
+begin
+  apply iff.trans multiset.dvd_gcd,
+  simp only [multiset.mem_map, and_imp, exists_imp_distrib],
+  exact ⟨λ k b hb, k _ _ hb rfl, λ k a' b hb h, h ▸ k _ hb⟩,
+end
+
+lemma gcd_dvd {b : β} (hb : b ∈ s) : s.gcd f ∣ f b :=
+dvd_gcd_iff.1 (dvd_refl _) _ hb
+
+lemma dvd_gcd {a : α} : (∀b ∈ s, a ∣ f b) → a ∣ s.gcd f :=
+dvd_gcd_iff.2
+
+@[simp] lemma gcd_insert [decidable_eq β] {b : β} :
+  (insert b s : finset β).gcd f = gcd_monoid.gcd (f b) (s.gcd f) :=
+begin
+  by_cases h : b ∈ s,
+  { rw [insert_eq_of_mem h,
+    (gcd_eq_right_iff (f b) (s.gcd f) (multiset.normalize_gcd (s.1.map f))).2 (gcd_dvd h)] ,},
+  apply fold_insert h,
+end
+
+@[simp] lemma gcd_singleton {b : β} : ({b} : finset β).gcd f = normalize (f b) :=
+gcd_singleton
+
+@[simp] lemma normalize_gcd : normalize (s.gcd f) = s.gcd f := by simp [gcd_def]
+
+lemma gcd_union [decidable_eq β] : (s₁ ∪ s₂).gcd f = gcd_monoid.gcd (s₁.gcd f) (s₂.gcd f) :=
+finset.induction_on s₁ (by rw [empty_union, gcd_empty, gcd_zero_left, normalize_gcd]) $ λ a s has ih,
+by rw [insert_union, gcd_insert, gcd_insert, ih, gcd_assoc]
+
+theorem gcd_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀a∈s₂, f a = g a) : s₁.gcd f = s₂.gcd g :=
+by subst hs; exact finset.fold_congr hfg
+
+lemma gcd_mono_fun {g : β → α} (h : ∀b∈s, f b ∣ g b) : s.gcd f ∣ s.gcd g :=
+dvd_gcd (λ b hb, dvd_trans (gcd_dvd hb) (h b hb))
+
+lemma gcd_mono (h : s₁ ⊆ s₂) : s₂.gcd f ∣ s₁.gcd f :=
+dvd_gcd $ assume b hb, gcd_dvd (h hb)
+
+end gcd
+end finset

--- a/src/data/finset/gcd.lean
+++ b/src/data/finset/gcd.lean
@@ -9,7 +9,21 @@ import data.multiset.gcd
 /-!
 # GCD and LCM operations on finsets
 
+## Main definitions
+
+- `finset.gcd` - the greatest common denominator of a `finset` of elements of a `gcd_monoid`
+- `finset.lcm` - the least common multiple of a `finset` of elements of a `gcd_monoid`
+
+## Implementation notes
+
+Many of the proofs use the lemmas `gcd.def` and `lcm.def`, which relate `finset.gcd`
+and `finset.lcm` to `multiset.gcd` and `multiset.lcm`.
+
 TODO: simplify with a tactic and `data.finset.lattice`
+
+## Tags
+
+finset, gcd
 -/
 
 variables {α β γ : Type*} [comm_cancel_monoid_with_zero α] [nontrivial α] [gcd_monoid α]

--- a/src/data/finset/gcd.lean
+++ b/src/data/finset/gcd.lean
@@ -62,23 +62,24 @@ lcm_dvd_iff.1 (dvd_refl _) _ hb
 begin
   by_cases h : b ∈ s,
   { rw [insert_eq_of_mem h,
-    (lcm_eq_right_iff (f b) (s.lcm f) (multiset.normalize_lcm (s.1.map f))).2 (dvd_lcm h)] },
+        (lcm_eq_right_iff (f b) (s.lcm f) (multiset.normalize_lcm (s.1.map f))).2 (dvd_lcm h)] },
   apply fold_insert h,
 end
 
 @[simp] lemma lcm_singleton {b : β} : ({b} : finset β).lcm f = normalize (f b) :=
-lcm_singleton
+multiset.lcm_singleton
 
 @[simp] lemma normalize_lcm : normalize (s.lcm f) = s.lcm f := by simp [lcm_def]
 
 lemma lcm_union [decidable_eq β] : (s₁ ∪ s₂).lcm f = gcd_monoid.lcm (s₁.lcm f) (s₂.lcm f) :=
 finset.induction_on s₁ (by rw [empty_union, lcm_empty, lcm_one_left, normalize_lcm]) $ λ a s has ih,
-by rw [insert_union, lcm_insert, lcm_insert, ih, lcm_assoc]
+  by rw [insert_union, lcm_insert, lcm_insert, ih, lcm_assoc]
 
-theorem lcm_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀a∈s₂, f a = g a) : s₁.lcm f = s₂.lcm g :=
-by subst hs; exact finset.fold_congr hfg
+theorem lcm_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀a ∈ s₂, f a = g a) :
+  s₁.lcm f = s₂.lcm g :=
+by { subst hs, exact finset.fold_congr hfg }
 
-lemma lcm_mono_fun {g : β → α} (h : ∀b∈s, f b ∣ g b) : s.lcm f ∣ s.lcm g :=
+lemma lcm_mono_fun {g : β → α} (h : ∀ b ∈ s, f b ∣ g b) : s.lcm f ∣ s.lcm g :=
 lcm_dvd (λ b hb, dvd_trans (h b hb) (dvd_lcm hb))
 
 lemma lcm_mono (h : s₁ ⊆ s₂) : s₁.lcm f ∣ s₂.lcm f :=
@@ -122,18 +123,19 @@ begin
 end
 
 @[simp] lemma gcd_singleton {b : β} : ({b} : finset β).gcd f = normalize (f b) :=
-gcd_singleton
+multiset.gcd_singleton
 
 @[simp] lemma normalize_gcd : normalize (s.gcd f) = s.gcd f := by simp [gcd_def]
 
 lemma gcd_union [decidable_eq β] : (s₁ ∪ s₂).gcd f = gcd_monoid.gcd (s₁.gcd f) (s₂.gcd f) :=
 finset.induction_on s₁ (by rw [empty_union, gcd_empty, gcd_zero_left, normalize_gcd]) $ λ a s has ih,
-by rw [insert_union, gcd_insert, gcd_insert, ih, gcd_assoc]
+  by rw [insert_union, gcd_insert, gcd_insert, ih, gcd_assoc]
 
-theorem gcd_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀a∈s₂, f a = g a) : s₁.gcd f = s₂.gcd g :=
-by subst hs; exact finset.fold_congr hfg
+theorem gcd_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀a ∈ s₂, f a = g a) :
+  s₁.gcd f = s₂.gcd g :=
+by { subst hs, exact finset.fold_congr hfg }
 
-lemma gcd_mono_fun {g : β → α} (h : ∀b∈s, f b ∣ g b) : s.gcd f ∣ s.gcd g :=
+lemma gcd_mono_fun {g : β → α} (h : ∀ b ∈ s, f b ∣ g b) : s.gcd f ∣ s.gcd g :=
 dvd_gcd (λ b hb, dvd_trans (gcd_dvd hb) (h b hb))
 
 lemma gcd_mono (h : s₁ ⊆ s₂) : s₂.gcd f ∣ s₁.gcd f :=

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -7,7 +7,7 @@ import data.finset.fold
 import data.multiset.lattice
 
 /-!
-# Lattice operations on multisets
+# Lattice operations on finsets
 -/
 
 variables {α β γ : Type*}

--- a/src/data/multiset/gcd.lean
+++ b/src/data/multiset/gcd.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2020 Aaron Anderson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Aaron Anderson
+-/
+import data.multiset.lattice
+import algebra.gcd_monoid
+
+/-!
+# GCD and LCM operations on multisets
+
+TODO: Replace all of this with a tactic and `data.multiset.lattice`
+-/
+
+namespace multiset
+variables {α : Type*} [comm_cancel_monoid_with_zero α] [nontrivial α] [gcd_monoid α]
+
+/-! ### lcm -/
+section lcm
+
+/-- Least common multiple of a multiset -/
+def lcm (s : multiset α) : α := s.fold gcd_monoid.lcm 1
+
+@[simp] lemma lcm_zero : (0 : multiset α).lcm = 1 :=
+fold_zero _ _
+
+@[simp] lemma lcm_cons (a : α) (s : multiset α) :
+  (a :: s).lcm = gcd_monoid.lcm a s.lcm :=
+fold_cons_left _ _ _ _
+
+@[simp] lemma lcm_singleton {a : α} : (a::0).lcm = normalize a := by simp
+
+@[simp] lemma lcm_add (s₁ s₂ : multiset α) : (s₁ + s₂).lcm = gcd_monoid.lcm s₁.lcm s₂.lcm :=
+eq.trans (by simp [lcm]) (fold_add _ _ _ _ _)
+
+lemma lcm_dvd {s : multiset α} {a : α} : s.lcm ∣ a ↔ (∀b ∈ s, b ∣ a) :=
+multiset.induction_on s (by simp)
+  (by simp [or_imp_distrib, forall_and_distrib, lcm_dvd_iff] {contextual := tt})
+
+lemma dvd_lcm {s : multiset α} {a : α} (h : a ∈ s) : a ∣ s.lcm :=
+lcm_dvd.1 (dvd_refl _) _ h
+
+lemma lcm_mono {s₁ s₂ : multiset α} (h : s₁ ⊆ s₂) : s₁.lcm ∣ s₂.lcm :=
+lcm_dvd.2 $ assume b hb, dvd_lcm (h hb)
+
+@[simp] lemma normalize_lcm (s : multiset α) : normalize (s.lcm) = s.lcm :=
+multiset.induction_on s (by simp) $ λ a s IH, by simp
+
+variables [decidable_eq α]
+
+@[simp] lemma lcm_erase_dup (s : multiset α) : (erase_dup s).lcm = s.lcm :=
+multiset.induction_on s (by simp) $ λ a s IH, begin
+  by_cases a ∈ s; simp [IH, h],
+  unfold lcm,
+  rw [← cons_erase h, fold_cons_left, ← lcm_assoc, lcm_same],
+  apply lcm_eq_of_associated_left associated_normalize,
+end
+
+@[simp] lemma lcm_ndunion (s₁ s₂ : multiset α) :
+  (ndunion s₁ s₂).lcm = gcd_monoid.lcm s₁.lcm s₂.lcm :=
+by rw [← lcm_erase_dup, erase_dup_ext.2, lcm_erase_dup, lcm_add]; simp
+
+@[simp] lemma lcm_union (s₁ s₂ : multiset α) :
+  (s₁ ∪ s₂).lcm = gcd_monoid.lcm s₁.lcm s₂.lcm :=
+by rw [← lcm_erase_dup, erase_dup_ext.2, lcm_erase_dup, lcm_add]; simp
+
+@[simp] lemma lcm_ndinsert (a : α) (s : multiset α) :
+  (ndinsert a s).lcm = gcd_monoid.lcm a s.lcm :=
+by rw [← lcm_erase_dup, erase_dup_ext.2, lcm_erase_dup, lcm_cons]; simp
+
+end lcm
+
+/-! ### gcd -/
+section gcd
+
+/-- Greatest common divisor of a multiset -/
+def gcd (s : multiset α) : α := s.fold gcd_monoid.gcd 0
+
+@[simp] lemma gcd_zero : (0 : multiset α).gcd = 0 :=
+fold_zero _ _
+
+@[simp] lemma gcd_cons (a : α) (s : multiset α) :
+  (a :: s).gcd = gcd_monoid.gcd a s.gcd :=
+fold_cons_left _ _ _ _
+
+@[simp] lemma gcd_singleton {a : α} : (a::0).gcd = normalize a := by simp
+
+@[simp] lemma gcd_add (s₁ s₂ : multiset α) : (s₁ + s₂).gcd = gcd_monoid.gcd s₁.gcd s₂.gcd :=
+eq.trans (by simp [gcd]) (fold_add _ _ _ _ _)
+
+lemma dvd_gcd {s : multiset α} {a : α} : a ∣ s.gcd ↔ (∀b ∈ s, a ∣ b) :=
+multiset.induction_on s (by simp)
+  (by simp [or_imp_distrib, forall_and_distrib, dvd_gcd_iff] {contextual := tt})
+
+lemma gcd_dvd {s : multiset α} {a : α} (h : a ∈ s) : s.gcd ∣ a :=
+dvd_gcd.1 (dvd_refl _) _ h
+
+lemma gcd_mono {s₁ s₂ : multiset α} (h : s₁ ⊆ s₂) : s₂.gcd ∣ s₁.gcd :=
+dvd_gcd.2 $ assume b hb, gcd_dvd (h hb)
+
+@[simp] lemma normalize_gcd (s : multiset α) : normalize (s.gcd) = s.gcd :=
+multiset.induction_on s (by simp) $ λ a s IH, by simp
+
+variables [decidable_eq α]
+
+@[simp] lemma gcd_erase_dup (s : multiset α) : (erase_dup s).gcd = s.gcd :=
+multiset.induction_on s (by simp) $ λ a s IH, begin
+  by_cases a ∈ s; simp [IH, h],
+  unfold gcd,
+  rw [← cons_erase h, fold_cons_left, ← gcd_assoc, gcd_same],
+  apply gcd_eq_of_associated_left associated_normalize,
+end
+
+@[simp] lemma gcd_ndunion (s₁ s₂ : multiset α) :
+  (ndunion s₁ s₂).gcd = gcd_monoid.gcd s₁.gcd s₂.gcd :=
+by rw [← gcd_erase_dup, erase_dup_ext.2, gcd_erase_dup, gcd_add]; simp
+
+@[simp] lemma gcd_union (s₁ s₂ : multiset α) :
+  (s₁ ∪ s₂).gcd = gcd_monoid.gcd s₁.gcd s₂.gcd :=
+by rw [← gcd_erase_dup, erase_dup_ext.2, gcd_erase_dup, gcd_add]; simp
+
+@[simp] lemma gcd_ndinsert (a : α) (s : multiset α) :
+  (ndinsert a s).gcd = gcd_monoid.gcd a s.gcd :=
+by rw [← gcd_erase_dup, erase_dup_ext.2, gcd_erase_dup, gcd_cons]; simp
+
+end gcd
+
+end multiset

--- a/src/data/multiset/gcd.lean
+++ b/src/data/multiset/gcd.lean
@@ -9,7 +9,18 @@ import algebra.gcd_monoid
 /-!
 # GCD and LCM operations on multisets
 
-TODO: Replace all of this with a tactic and `data.multiset.lattice`
+## Main definitions
+
+- `multiset.gcd` - the greatest common denominator of a `multiset` of elements of a `gcd_monoid`
+- `multiset.lcm` - the least common multiple of a `multiset` of elements of a `gcd_monoid`
+
+## Implementation notes
+
+TODO: simplify with a tactic and `data.multiset.lattice`
+
+## Tags
+
+multiset, gcd
 -/
 
 namespace multiset

--- a/src/data/multiset/gcd.lean
+++ b/src/data/multiset/gcd.lean
@@ -44,7 +44,7 @@ fold_cons_left _ _ _ _
 @[simp] lemma lcm_add (s₁ s₂ : multiset α) : (s₁ + s₂).lcm = gcd_monoid.lcm s₁.lcm s₂.lcm :=
 eq.trans (by simp [lcm]) (fold_add _ _ _ _ _)
 
-lemma lcm_dvd {s : multiset α} {a : α} : s.lcm ∣ a ↔ (∀b ∈ s, b ∣ a) :=
+lemma lcm_dvd {s : multiset α} {a : α} : s.lcm ∣ a ↔ (∀ b ∈ s, b ∣ a) :=
 multiset.induction_on s (by simp)
   (by simp [or_imp_distrib, forall_and_distrib, lcm_dvd_iff] {contextual := tt})
 
@@ -69,15 +69,15 @@ end
 
 @[simp] lemma lcm_ndunion (s₁ s₂ : multiset α) :
   (ndunion s₁ s₂).lcm = gcd_monoid.lcm s₁.lcm s₂.lcm :=
-by rw [← lcm_erase_dup, erase_dup_ext.2, lcm_erase_dup, lcm_add]; simp
+by { rw [← lcm_erase_dup, erase_dup_ext.2, lcm_erase_dup, lcm_add], simp }
 
 @[simp] lemma lcm_union (s₁ s₂ : multiset α) :
   (s₁ ∪ s₂).lcm = gcd_monoid.lcm s₁.lcm s₂.lcm :=
-by rw [← lcm_erase_dup, erase_dup_ext.2, lcm_erase_dup, lcm_add]; simp
+by { rw [← lcm_erase_dup, erase_dup_ext.2, lcm_erase_dup, lcm_add], simp }
 
 @[simp] lemma lcm_ndinsert (a : α) (s : multiset α) :
   (ndinsert a s).lcm = gcd_monoid.lcm a s.lcm :=
-by rw [← lcm_erase_dup, erase_dup_ext.2, lcm_erase_dup, lcm_cons]; simp
+by { rw [← lcm_erase_dup, erase_dup_ext.2, lcm_erase_dup, lcm_cons], simp }
 
 end lcm
 
@@ -99,7 +99,7 @@ fold_cons_left _ _ _ _
 @[simp] lemma gcd_add (s₁ s₂ : multiset α) : (s₁ + s₂).gcd = gcd_monoid.gcd s₁.gcd s₂.gcd :=
 eq.trans (by simp [gcd]) (fold_add _ _ _ _ _)
 
-lemma dvd_gcd {s : multiset α} {a : α} : a ∣ s.gcd ↔ (∀b ∈ s, a ∣ b) :=
+lemma dvd_gcd {s : multiset α} {a : α} : a ∣ s.gcd ↔ (∀ b ∈ s, a ∣ b) :=
 multiset.induction_on s (by simp)
   (by simp [or_imp_distrib, forall_and_distrib, dvd_gcd_iff] {contextual := tt})
 
@@ -124,15 +124,15 @@ end
 
 @[simp] lemma gcd_ndunion (s₁ s₂ : multiset α) :
   (ndunion s₁ s₂).gcd = gcd_monoid.gcd s₁.gcd s₂.gcd :=
-by rw [← gcd_erase_dup, erase_dup_ext.2, gcd_erase_dup, gcd_add]; simp
+by { rw [← gcd_erase_dup, erase_dup_ext.2, gcd_erase_dup, gcd_add], simp }
 
 @[simp] lemma gcd_union (s₁ s₂ : multiset α) :
   (s₁ ∪ s₂).gcd = gcd_monoid.gcd s₁.gcd s₂.gcd :=
-by rw [← gcd_erase_dup, erase_dup_ext.2, gcd_erase_dup, gcd_add]; simp
+by { rw [← gcd_erase_dup, erase_dup_ext.2, gcd_erase_dup, gcd_add], simp }
 
 @[simp] lemma gcd_ndinsert (a : α) (s : multiset α) :
   (ndinsert a s).gcd = gcd_monoid.gcd a s.gcd :=
-by rw [← gcd_erase_dup, erase_dup_ext.2, gcd_erase_dup, gcd_cons]; simp
+by { rw [← gcd_erase_dup, erase_dup_ext.2, gcd_erase_dup, gcd_cons], simp }
 
 end gcd
 


### PR DESCRIPTION
Defines `finset.gcd`, `finset.lcm`, `multiset.gcd`, `multiset.lcm`
Proves some basic facts about those, analogous to those in `data.multiset.lattice` and `data.finset.lattice`


---
<!-- put comments you want to keep out of the PR commit here -->
