### PR TITLE
[Merged by Bors] - chore(*): cleanup imports, split off data/finset/preimage from data/set/finite

### DIFF
--- a/src/category_theory/concrete_category/bundled_hom.lean
+++ b/src/category_theory/concrete_category/bundled_hom.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison, Yury Kudryashov
 -/
 import category_theory.concrete_category.basic
 import category_theory.concrete_category.bundled
-import category_theory.fully_faithful
 
 /-!
 # Category instances for algebraic structures that use bundled homs.

--- a/src/data/finset/default.lean
+++ b/src/data/finset/default.lean
@@ -6,3 +6,4 @@ import data.finset.nat_antidiagonal
 import data.finset.pi
 import data.finset.powerset
 import data.finset.sort
+import data.finset.preimage

--- a/src/data/finset/preimage.lean
+++ b/src/data/finset/preimage.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro
+-/
+import data.set.finite
+import algebra.big_operators.basic
+
+/-!
+# Preimage of a `finset` under an injective map.
+-/
+
+open set function
+
+open_locale big_operators
+
+universes u v w x
+variables {α : Type u} {β : Type v} {ι : Sort w} {γ : Type x}
+
+namespace finset
+
+section preimage
+
+/-- Preimage of `s : finset β` under a map `f` injective of `f ⁻¹' s` as a `finset`.  -/
+noncomputable def preimage (s : finset β) (f : α → β)
+  (hf : set.inj_on f (f ⁻¹' ↑s)) : finset α :=
+(s.finite_to_set.preimage hf).to_finset
+
+@[simp] lemma mem_preimage {f : α → β} {s : finset β} {hf : set.inj_on f (f ⁻¹' ↑s)} {x : α} :
+  x ∈ preimage s f hf ↔ f x ∈ s :=
+set.finite.mem_to_finset
+
+@[simp, norm_cast] lemma coe_preimage {f : α → β} (s : finset β)
+  (hf : set.inj_on f (f ⁻¹' ↑s)) : (↑(preimage s f hf) : set α) = f ⁻¹' ↑s :=
+set.finite.coe_to_finset _
+
+lemma monotone_preimage {f : α → β} (h : injective f) :
+  monotone (λ s, preimage s f (h.inj_on _)) :=
+λ s t hst x hx, mem_preimage.2 (hst $ mem_preimage.1 hx)
+
+lemma image_subset_iff_subset_preimage [decidable_eq β] {f : α → β} {s : finset α} {t : finset β}
+  (hf : set.inj_on f (f ⁻¹' ↑t)) :
+  s.image f ⊆ t ↔ s ⊆ t.preimage f hf :=
+image_subset_iff.trans $ by simp only [subset_iff, mem_preimage]
+
+lemma map_subset_iff_subset_preimage {f : α ↪ β} {s : finset α} {t : finset β} :
+  s.map f ⊆ t ↔ s ⊆ t.preimage f (f.injective.inj_on _) :=
+by classical; rw [map_eq_image, image_subset_iff_subset_preimage]
+
+lemma image_preimage [decidable_eq β] (f : α → β) (s : finset β) [Π x, decidable (x ∈ set.range f)]
+  (hf : set.inj_on f (f ⁻¹' ↑s)) :
+  image f (preimage s f hf) = s.filter (λ x, x ∈ set.range f) :=
+finset.coe_inj.1 $ by simp only [coe_image, coe_preimage, coe_filter,
+  set.image_preimage_eq_inter_range, set.sep_mem_eq]
+
+lemma image_preimage_of_bij [decidable_eq β] (f : α → β) (s : finset β)
+  (hf : set.bij_on f (f ⁻¹' ↑s) ↑s) :
+  image f (preimage s f hf.inj_on) = s :=
+finset.coe_inj.1 $ by simpa using hf.image_eq
+
+lemma sigma_preimage_mk {β : α → Type*} [decidable_eq α] (s : finset (Σ a, β a)) (t : finset α) :
+  t.sigma (λ a, s.preimage (sigma.mk a) $ sigma_mk_injective.inj_on _) = s.filter (λ a, a.1 ∈ t) :=
+by { ext x, simp [and_comm] }
+
+lemma sigma_preimage_mk_of_subset {β : α → Type*} [decidable_eq α] (s : finset (Σ a, β a))
+  {t : finset α} (ht : s.image sigma.fst ⊆ t) :
+  t.sigma (λ a, s.preimage (sigma.mk a) $ sigma_mk_injective.inj_on _) = s :=
+by rw [sigma_preimage_mk, filter_true_of_mem $ image_subset_iff.1 ht]
+
+lemma sigma_image_fst_preimage_mk {β : α → Type*} [decidable_eq α] (s : finset (Σ a, β a)) :
+  (s.image sigma.fst).sigma (λ a, s.preimage (sigma.mk a) $ sigma_mk_injective.inj_on _) = s :=
+s.sigma_preimage_mk_of_subset (subset.refl _)
+
+end preimage
+
+@[to_additive]
+lemma prod_preimage' [comm_monoid β] (f : α → γ) [decidable_pred $ λ x, x ∈ set.range f]
+  (s : finset γ) (hf : set.inj_on f (f ⁻¹' ↑s)) (g : γ → β) :
+  ∏ x in s.preimage f hf, g (f x) = ∏ x in s.filter (λ x, x ∈ set.range f), g x :=
+by haveI := classical.dec_eq γ;
+calc ∏ x in preimage s f hf, g (f x) = ∏ x in image f (preimage s f hf), g x :
+  eq.symm $ prod_image $ by simpa only [mem_preimage, inj_on] using hf
+  ... = ∏ x in s.filter (λ x, x ∈ set.range f), g x : by rw [image_preimage]
+
+@[to_additive]
+lemma prod_preimage [comm_monoid β] (f : α → γ) (s : finset γ)
+  (hf : set.inj_on f (f ⁻¹' ↑s)) (g : γ → β) (hg : ∀ x ∈ s, x ∉ set.range f → g x = 1) :
+  ∏ x in s.preimage f hf, g (f x) = ∏ x in s, g x :=
+by { classical, rw [prod_preimage', prod_filter_of_ne], exact λ x hx, not.imp_symm (hg x hx) }
+
+@[to_additive]
+lemma prod_preimage_of_bij [comm_monoid β] (f : α → γ) (s : finset γ)
+  (hf : set.bij_on f (f ⁻¹' ↑s) ↑s) (g : γ → β) :
+  ∏ x in s.preimage f hf.inj_on, g (f x) = ∏ x in s, g x :=
+prod_preimage _ _ hf.inj_on g $ λ x hxs hxf, (hxf $ hf.subset_range hxs).elim
+
+end finset

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -6,7 +6,7 @@ Authors: Johannes Hölzl, Scott Morrison
 import algebra.big_operators.order
 import algebra.module.basic
 import data.fintype.card
-import data.set.finite
+import data.finset.preimage
 import data.multiset.antidiagonal
 
 /-!

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
 import data.fintype.basic
-import algebra.big_operators.basic
 
 /-!
 # Finite sets
@@ -14,7 +13,6 @@ basic facts about finite sets.
 -/
 
 open set function
-open_locale big_operators
 
 universes u v w x
 variables {α : Type u} {β : Type v} {ι : Sort w} {γ : Type x}
@@ -562,81 +560,6 @@ end
 end set
 
 namespace finset
-
-section preimage
-
-/-- Preimage of `s : finset β` under a map `f` injective of `f ⁻¹' s` as a `finset`.  -/
-noncomputable def preimage (s : finset β) (f : α → β)
-  (hf : set.inj_on f (f ⁻¹' ↑s)) : finset α :=
-(s.finite_to_set.preimage hf).to_finset
-
-@[simp] lemma mem_preimage {f : α → β} {s : finset β} {hf : set.inj_on f (f ⁻¹' ↑s)} {x : α} :
-  x ∈ preimage s f hf ↔ f x ∈ s :=
-set.finite.mem_to_finset
-
-@[simp, norm_cast] lemma coe_preimage {f : α → β} (s : finset β)
-  (hf : set.inj_on f (f ⁻¹' ↑s)) : (↑(preimage s f hf) : set α) = f ⁻¹' ↑s :=
-set.finite.coe_to_finset _
-
-lemma monotone_preimage {f : α → β} (h : injective f) :
-  monotone (λ s, preimage s f (h.inj_on _)) :=
-λ s t hst x hx, mem_preimage.2 (hst $ mem_preimage.1 hx)
-
-lemma image_subset_iff_subset_preimage [decidable_eq β] {f : α → β} {s : finset α} {t : finset β}
-  (hf : set.inj_on f (f ⁻¹' ↑t)) :
-  s.image f ⊆ t ↔ s ⊆ t.preimage f hf :=
-image_subset_iff.trans $ by simp only [subset_iff, mem_preimage]
-
-lemma map_subset_iff_subset_preimage {f : α ↪ β} {s : finset α} {t : finset β} :
-  s.map f ⊆ t ↔ s ⊆ t.preimage f (f.injective.inj_on _) :=
-by classical; rw [map_eq_image, image_subset_iff_subset_preimage]
-
-lemma image_preimage [decidable_eq β] (f : α → β) (s : finset β) [Π x, decidable (x ∈ set.range f)]
-  (hf : set.inj_on f (f ⁻¹' ↑s)) :
-  image f (preimage s f hf) = s.filter (λ x, x ∈ set.range f) :=
-finset.coe_inj.1 $ by simp only [coe_image, coe_preimage, coe_filter,
-  set.image_preimage_eq_inter_range, set.sep_mem_eq]
-
-lemma image_preimage_of_bij [decidable_eq β] (f : α → β) (s : finset β)
-  (hf : set.bij_on f (f ⁻¹' ↑s) ↑s) :
-  image f (preimage s f hf.inj_on) = s :=
-finset.coe_inj.1 $ by simpa using hf.image_eq
-
-lemma sigma_preimage_mk {β : α → Type*} [decidable_eq α] (s : finset (Σ a, β a)) (t : finset α) :
-  t.sigma (λ a, s.preimage (sigma.mk a) $ sigma_mk_injective.inj_on _) = s.filter (λ a, a.1 ∈ t) :=
-by { ext x, simp [and_comm] }
-
-lemma sigma_preimage_mk_of_subset {β : α → Type*} [decidable_eq α] (s : finset (Σ a, β a))
-  {t : finset α} (ht : s.image sigma.fst ⊆ t) :
-  t.sigma (λ a, s.preimage (sigma.mk a) $ sigma_mk_injective.inj_on _) = s :=
-by rw [sigma_preimage_mk, filter_true_of_mem $ image_subset_iff.1 ht]
-
-lemma sigma_image_fst_preimage_mk {β : α → Type*} [decidable_eq α] (s : finset (Σ a, β a)) :
-  (s.image sigma.fst).sigma (λ a, s.preimage (sigma.mk a) $ sigma_mk_injective.inj_on _) = s :=
-s.sigma_preimage_mk_of_subset (subset.refl _)
-
-end preimage
-
-@[to_additive]
-lemma prod_preimage' [comm_monoid β] (f : α → γ) [decidable_pred $ λ x, x ∈ set.range f]
-  (s : finset γ) (hf : set.inj_on f (f ⁻¹' ↑s)) (g : γ → β) :
-  ∏ x in s.preimage f hf, g (f x) = ∏ x in s.filter (λ x, x ∈ set.range f), g x :=
-by haveI := classical.dec_eq γ;
-calc ∏ x in preimage s f hf, g (f x) = ∏ x in image f (preimage s f hf), g x :
-  eq.symm $ prod_image $ by simpa only [mem_preimage, inj_on] using hf
-  ... = ∏ x in s.filter (λ x, x ∈ set.range f), g x : by rw [image_preimage]
-
-@[to_additive]
-lemma prod_preimage [comm_monoid β] (f : α → γ) (s : finset γ)
-  (hf : set.inj_on f (f ⁻¹' ↑s)) (g : γ → β) (hg : ∀ x ∈ s, x ∉ set.range f → g x = 1) :
-  ∏ x in s.preimage f hf, g (f x) = ∏ x in s, g x :=
-by { classical, rw [prod_preimage', prod_filter_of_ne], exact λ x hx, not.imp_symm (hg x hx) }
-
-@[to_additive]
-lemma prod_preimage_of_bij [comm_monoid β] (f : α → γ) (s : finset γ)
-  (hf : set.bij_on f (f ⁻¹' ↑s) ↑s) (g : γ → β) :
-  ∏ x in s.preimage f hf.inj_on, g (f x) = ∏ x in s, g x :=
-prod_preimage _ _ hf.inj_on g $ λ x hxs hxf, (hxf $ hf.subset_range hxs).elim
 
 /-- A finset is bounded above. -/
 protected lemma bdd_above [semilattice_sup α] [nonempty α] (s : finset α) :

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jeremy Avigad, Yury Kudryashov, Patrick Massot
 -/
 import order.filter.bases
+import data.finset.preimage
 
 /-!
 # `at_top` and `at_bot` filters on preorded sets, monoids and groups.

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl, Mario Carneiro
 
 Bases of topologies. Countability axioms.
 -/
-import topology.constructions
 import topology.continuous_on
 
 open set filter classical


### PR DESCRIPTION
Mostly this consists of moving some content from `data.set.finite` to `data.finset.preimage`, in order to reduce imports in `data.set.finite`.

---
<!-- put comments you want to keep out of the PR commit here -->
