### PR TITLE
[Merged by Bors] - feat(category_theory/monad/algebra): Add faithful instances. 

### DIFF
--- a/src/category_theory/monad/algebra.lean
+++ b/src/category_theory/monad/algebra.lean
@@ -131,6 +131,8 @@ def algebra_iso_of_iso {A B : algebra T} (f : A ⟶ B) [i : is_iso f.f] : is_iso
 instance forget_reflects_iso : reflects_isomorphisms (forget T) :=
 { reflects := λ A B, algebra_iso_of_iso T }
 
+instance forget_faithful : faithful (forget T) := {}
+
 end monad
 
 namespace comonad
@@ -221,6 +223,8 @@ adjunction.mk_of_hom_equiv
       dsimp, simp
     end
     }}
+    
+instance forget_faithful : faithful (forget G) := {}
 
 end comonad
 


### PR DESCRIPTION
Adds a `faithful` instance for the forgetful functors from the Eilenberg Moore category associated to a (co)monad. 

---
<!-- put comments you want to keep out of the PR commit here -->
