### PR TITLE
[Merged by Bors] - chore(data/mv_polynomial): aeval_rename -> aeval_id_rename

### DIFF
--- a/src/data/mv_polynomial/monad.lean
+++ b/src/data/mv_polynomial/monad.lean
@@ -172,20 +172,14 @@ lemma join₂_comp_map (f : R →+* mv_polynomial σ S) :
   join₂.comp (map f) = bind₂ f :=
 by { ext1, simp [join₂, bind₂] }
 
-lemma aeval_rename (f : σ → mv_polynomial τ R) (p : mv_polynomial σ R) :
+lemma aeval_id_rename (f : σ → mv_polynomial τ R) (p : mv_polynomial σ R) :
   aeval id (rename f p) = aeval f p :=
-begin
-  apply p.induction_on,
-  { simp only [aeval_C, forall_const, eq_self_iff_true, rename_C] },
-  { intros p q hp hq, simp only [hp, hq, alg_hom.map_add, ring_hom.map_add] },
-  { intros p n hp,
-    simp only [hp, rename_X, ring_hom.id_apply, aeval_X, ring_hom.map_mul, alg_hom.map_mul, id] }
-end
+by rw [aeval_rename, function.comp.left_id]
 
 @[simp]
 lemma join₁_rename (f : σ → mv_polynomial τ R) (φ : mv_polynomial σ R) :
   join₁ (rename f φ) = bind₁ f φ :=
-aeval_rename _ _
+aeval_id_rename _ _
 
 @[simp]
 lemma bind₁_id : bind₁ (@id (mv_polynomial σ R)) = join₁ := rfl

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -136,6 +136,9 @@ by apply mv_polynomial.induction_on p; { intros, simp [*] }
 lemma eval₂_hom_rename : eval₂_hom f g (rename k p) = eval₂_hom f (g ∘ k) p :=
 eval₂_rename _ _ _ _
 
+lemma aeval_rename [algebra R S] : aeval g (rename k p) = aeval (g ∘ k) p :=
+eval₂_hom_rename _ _ _ _
+
 lemma rename_eval₂ (g : τ → mv_polynomial σ R) :
   rename k (p.eval₂ C (g ∘ k)) = (rename k p).eval₂ C (rename k ∘ g) :=
 by apply mv_polynomial.induction_on p; { intros, simp [*] }


### PR DESCRIPTION
`aeval_rename` was not general enough, so it is renamed to
`aeval_id_rename`.

Also: state and prove the more general version of `aeval_rename`.



---
<!-- put comments you want to keep out of the PR commit here -->