### PR TITLE
[Merged by Bors] - fix(tactic/lint/simp): only head-beta reduce, don't whnf

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -172,7 +172,7 @@ instance : inhabited (finset α) := ⟨∅⟩
 
 @[simp] theorem not_mem_empty (a : α) : a ∉ (∅ : finset α) := id
 
-@[simp] theorem ne_empty_of_mem {a : α} {s : finset α} (h : a ∈ s) : s ≠ ∅ :=
+theorem ne_empty_of_mem {a : α} {s : finset α} (h : a ∈ s) : s ≠ ∅ :=
 λ e, not_mem_empty a $ e ▸ h
 
 theorem nonempty.ne_empty {s : finset α} (h : s.nonempty) : s ≠ ∅ :=

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -42,7 +42,7 @@ theorem tail_eq_of_cons_eq {h₁ h₂ : α} {t₁ t₂ : list α} :
       (h₁::t₁) = (h₂::t₂) → t₁ = t₂ :=
 assume Peq, list.no_confusion Peq (assume Pheq Pteq, Pteq)
 
-theorem cons_injective {a : α} : injective (cons a) :=
+@[simp] theorem cons_injective {a : α} : injective (cons a) :=
 assume l₁ l₂, assume Pe, tail_eq_of_cons_eq Pe
 
 theorem cons_inj (a : α) {l l' : list α} : a::l = a::l' ↔ l = l' :=
@@ -204,7 +204,7 @@ lemma exists_of_length_succ {n} :
 | [] H := absurd H.symm $ succ_ne_zero n
 | (h :: t) H := ⟨h, t, rfl⟩
 
-lemma length_injective_iff : injective (list.length : list α → ℕ) ↔ subsingleton α :=
+@[simp] lemma length_injective_iff : injective (list.length : list α → ℕ) ↔ subsingleton α :=
 begin
   split,
   { intro h, refine ⟨λ x y, _⟩, suffices : [x] = [y], { simpa using this }, apply h, refl },
@@ -213,7 +213,7 @@ begin
     congr, exactI subsingleton.elim _ _, apply l1_ih, simpa using hl }
 end
 
-lemma length_injective [subsingleton α] : injective (length : list α → ℕ) :=
+@[simp] lemma length_injective [subsingleton α] : injective (length : list α → ℕ) :=
 length_injective_iff.mpr $ by apply_instance
 
 /-! ### set-theoretic notation of lists -/
@@ -552,7 +552,7 @@ by rw [concat_eq_append, reverse_append, reverse_singleton, singleton_append]
 @[simp] theorem reverse_reverse (l : list α) : reverse (reverse l) = l :=
 by induction l; [refl, simp only [*, reverse_cons, reverse_append]]; refl
 
-theorem reverse_injective : injective (@reverse α) :=
+@[simp] theorem reverse_injective : injective (@reverse α) :=
 left_inverse.injective reverse_reverse
 
 @[simp] theorem reverse_inj {l₁ l₂ : list α} : reverse l₁ = reverse l₂ ↔ l₁ = l₂ :=

--- a/src/tactic/lint/simp.lean
+++ b/src/tactic/lint/simp.lean
@@ -19,7 +19,7 @@ open tactic expr
 
 /-- `simp_lhs_rhs ty` returns the left-hand and right-hand side of a simp lemma with type `ty`. -/
 private meta def simp_lhs_rhs : expr → tactic (expr × expr) | ty := do
-ty ← whnf ty transparency.reducible,
+ty ← head_beta ty,
 -- We only detect a fixed set of simp relations here.
 -- This is somewhat justified since for a custom simp relation R,
 -- the simp lemma `R a b` is implicitly converted to `R a b ↔ true` as well.
@@ -42,7 +42,7 @@ prod.fst <$> simp_lhs_rhs ty
 lemma, and `some lhs` otherwise.
 -/
 private meta def simp_is_conditional_core : expr → tactic (option expr) | ty := do
-ty ← whnf ty transparency.semireducible,
+ty ← head_beta ty,
 match ty with
 | `(¬ %%lhs) := pure lhs
 | `(%%lhs = _) := pure lhs

--- a/test/lint_simp_var_head.lean
+++ b/test/lint_simp_var_head.lean
@@ -22,3 +22,15 @@ decl ← get_decl ``const_zero_eq_zero,
 res ← linter.simp_var_head.test decl,
 -- linter complains
 guard $ res.is_some
+
+
+
+-- However injectivity lemmas can still be marked simp,
+-- even though injective is reducible and unfolds to a bad simp lemma:
+@[simp] axiom injective_succ : function.injective nat.succ
+
+run_cmd do
+decl ← get_decl ``injective_succ,
+res ← linter.simp_var_head.test decl,
+-- linter does not complain
+guard res.is_none


### PR DESCRIPTION
This is necessary to accept simp lemmas like `injective reverse`.

---

See #4222 for motivation.

I don't know if this will break anything.