### PR TITLE
[Merged by Bors] - fix(topology/path_connected): avoid a slow use of `continuity`

### DIFF
--- a/src/topology/path_connected.lean
+++ b/src/topology/path_connected.lean
@@ -468,6 +468,12 @@ lemma truncate_continuous_family {X : Type*} [topological_space X] {a b : X}
 (γ.continuous.comp continuous_proj_I).comp
   (((continuous_subtype_coe.comp (continuous_snd.comp continuous_snd)).max continuous_fst).min
     (continuous_fst.comp continuous_snd))
+/- TODO : When `continuity` gets quicker, change the proof back to :
+    `begin`
+      `simp only [has_coe_to_fun.coe, coe_fn, path.truncate],`
+      `continuity,`
+      `exact continuous_subtype_coe`
+    `end` -/
 
 lemma truncate_const_continuous_family {X : Type*} [topological_space X] {a b : X}
   (γ : path a b) (t : ℝ) : continuous ↿(γ.truncate t) :=

--- a/src/topology/path_connected.lean
+++ b/src/topology/path_connected.lean
@@ -465,11 +465,9 @@ end
   mean the uncurried function which maps `(t₀, t₁, s)` to `γ.truncate t₀ t₁ s` is continuous. -/
 lemma truncate_continuous_family {X : Type*} [topological_space X] {a b : X}
   (γ : path a b) : continuous (λ x, γ.truncate x.1 x.2.1 x.2.2 : ℝ × ℝ × I → X) :=
-begin
-  simp only [has_coe_to_fun.coe, coe_fn, path.truncate],
-  continuity,
-  exact continuous_subtype_coe
-end
+(γ.continuous.comp continuous_proj_I).comp
+  (((continuous_subtype_coe.comp (continuous_snd.comp continuous_snd)).max continuous_fst).min
+    (continuous_fst.comp continuous_snd))
 
 lemma truncate_const_continuous_family {X : Type*} [topological_space X] {a b : X}
   (γ : path a b) (t : ℝ) : continuous ↿(γ.truncate t) :=


### PR DESCRIPTION
This corrects the timeout experienced by @Nicknamen in #3641. See https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.233641/near/211107487