### PR TITLE
[Merged by Bors] - feat(algebra/quandle): racks and quandles

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -397,3 +397,17 @@ howpublished = {\url{https://leanprover.github.io/theorem_proving_in_lean/}},
   doi       = {10.1016/0022-4049(82)90077-9},
   publisher = {Elsevier {BV}}
 }
+
+@Article{FennRourke1992,
+  author    = {Fenn, Roger and Rourke, Colin},
+  journal   = {Journal of Knot Theory and its Ramifications},
+  title     = {Racks and links in codimension two},
+  year      = {1992},
+  issn      = {0218-2165},
+  number    = {4},
+  pages     = {343--406},
+  volume    = {1},
+  doi       = {10.1142/S0218216592000203},
+  keywords  = {57M25 (57N10)},
+  mrnumber  = {1194995}
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -384,3 +384,16 @@ howpublished = {\url{https://leanprover.github.io/theorem_proving_in_lean/}},
   year={1967},
   publisher={Academic Pr}
 }
+
+@Article{Joyce1982,
+  author    = {David Joyce},
+  title     = {A classifying invariant of knots, the knot quandle},
+  journal   = {Journal of Pure and Applied Algebra},
+  year      = {1982},
+  volume    = {23},
+  number    = {1},
+  month     = {1},
+  pages     = {37--65},
+  doi       = {10.1016/0022-4049(82)90077-9},
+  publisher = {Elsevier {BV}}
+}

--- a/src/algebra/group/conj.lean
+++ b/src/algebra/group/conj.lean
@@ -50,31 +50,3 @@ end
 
 protected lemma monoid_hom.map_is_conj (f : α →* β) {a b : α} : is_conj a b → is_conj (f a) (f b)
 | ⟨c, hc⟩ := ⟨f c, by rw [← f.map_mul, ← f.map_inv, ← f.map_mul, hc]⟩
-
-namespace group
-
-/--
-Inner automorphisms of a group.
--/
-def inner_aut (c : α) : α →* α :=
-{ to_fun := λ x, c * x * c⁻¹,
-  map_one' := by simp,
-  map_mul' := by simp }
-
-lemma inner_aut_left_inv (c : α) : function.left_inverse (inner_aut c⁻¹) (inner_aut c) :=
-by { intro x, dsimp [inner_aut], rw inv_inv,
-     apply mul_eq_of_eq_mul_inv, apply inv_mul_eq_of_eq_mul, apply mul_assoc, }
-
-lemma inner_aut_right_inv (c : α) : function.right_inverse (inner_aut c⁻¹) (inner_aut c) :=
-by { convert inner_aut_left_inv c⁻¹, rw inv_inv }
-
-/--
-The inner automorphism `inner_aut` as an equivalence.
--/
-def inner_aut_equiv (c : α) : α ≃ α :=
-{ to_fun := inner_aut c,
-  inv_fun := inner_aut c⁻¹,
-  left_inv := inner_aut_left_inv c,
-  right_inv := inner_aut_right_inv c }
-
-end group

--- a/src/algebra/group/conj.lean
+++ b/src/algebra/group/conj.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Chris Hughes, Michael Howes
 -/
 import algebra.group.hom
-import data.equiv.basic
 
 /-!
 # Conjugacy of group elements

--- a/src/algebra/group/conj.lean
+++ b/src/algebra/group/conj.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Chris Hughes, Michael Howes
 -/
 import algebra.group.hom
+import data.equiv.basic
 
 /-!
 # Conjugacy of group elements
@@ -49,3 +50,31 @@ end
 
 protected lemma monoid_hom.map_is_conj (f : α →* β) {a b : α} : is_conj a b → is_conj (f a) (f b)
 | ⟨c, hc⟩ := ⟨f c, by rw [← f.map_mul, ← f.map_inv, ← f.map_mul, hc]⟩
+
+namespace group
+
+/--
+Inner automorphisms of a group.
+-/
+def inner_aut (c : α) : α →* α :=
+{ to_fun := λ x, c * x * c⁻¹,
+  map_one' := by simp,
+  map_mul' := by simp }
+
+lemma inner_aut_left_inv (c : α) : function.left_inverse (inner_aut c⁻¹) (inner_aut c) :=
+by { intro x, dsimp [inner_aut], rw inv_inv,
+     apply mul_eq_of_eq_mul_inv, apply inv_mul_eq_of_eq_mul, apply mul_assoc, }
+
+lemma inner_aut_right_inv (c : α) : function.right_inverse (inner_aut c⁻¹) (inner_aut c) :=
+by { convert inner_aut_left_inv c⁻¹, rw inv_inv }
+
+/--
+The inner automorphism `inner_aut` as an equivalence.
+-/
+def inner_aut_equiv (c : α) : α ≃ α :=
+{ to_fun := inner_aut c,
+  inv_fun := inner_aut c⁻¹,
+  left_inv := inner_aut_left_inv c,
+  right_inv := inner_aut_right_inv c }
+
+end group

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -411,7 +411,7 @@ associativity of `trans`.  The `pre_envel_group_rel` relation is a
 `Prop`-valued version of `pre_envel_group_rel'`, and making it
 `Prop`-valued essentially introduces enough 3-isomorphisms so that
 every pair of compatible 2-morphisms is isomorphic.  Now, while
-composition in `pre_envel_group` does not stricly satisfy the category
+composition in `pre_envel_group` does not strictly satisfy the category
 axioms, `pre_envel_group` and `pre_envel_group_rel'` do form a weak
 2-category.
 
@@ -429,7 +429,9 @@ evaluate elements of `pre_envel_group` as expressions in `G` (this is
 `pre_envel_group'` as expressions of 2-morphisms of `G` (this is
 `to_envel_group.map_aux.well_def`).  That is to say,
 `to_envel_group.map_aux.well_def` recursively evaluates formal
-expressions of 2-morphisms as equality proofs in `G`.
+expressions of 2-morphisms as equality proofs in `G`.  Now that all
+morphisms are accounted for, the map descends to a homomorphism
+`envel_group R →* G`.
 
 Note: `Type`-valued relations are not common.  The fact it is
 `Type`-valued is what makes `to_envel_group.map_aux.well_def` have

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import algebra.group.basic
 import data.zmod.basic
 import data.equiv.mul_add
 import tactic.group

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -1,0 +1,452 @@
+/-
+Copyright (c) 2020 Aaron Anderson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Anderson, Kyle Miller
+-/
+import algebra
+import data.zmod.basic
+
+/-!
+# Racks and Quandles
+
+This file defines racks and quandles, algebraic structures for sets
+that can act on themselves with a self-distributivity property.  Their
+main application is encoding group conjugation and knot invariants.
+
+## Main definitions
+
+• `rack`
+• `quandle`
+• `quandle.conj` defines a quandle of a group acting on itself by conjugation.
+• `rack_hom` is homomorphisms of racks and quandles
+• `rack.to_envel_gp` gives the universal group the rack maps to as a conj quandle
+
+## Main statements
+• `rack.to_envel_gp` is universal (`to_envel_gp.univ` and `to_envel_gp.univ_uniq`)
+
+## Tags
+
+rack, quandle
+-/
+
+universes u v
+
+/--
+A rack is an automorphic set (a set with an action on itself) that is self-distributive.
+The `x ◃ y` and `x ◃⁻¹ y` notation is right associative.
+-/
+class rack (α : Type*) :=
+(op' : α → (α ≃ α))
+(self_distrib' : ∀ {x y z : α}, op' x (op' y z) = op' (op' x y) (op' x z))
+
+abbreviation rack.op {R : Type*} [rack R] (x y : R) : R := rack.op' x y
+abbreviation rack.inv_op {R : Type*} [rack R] (x y : R) : R := (rack.op' x).symm y
+
+local infixr ` ◃ ` : 65 := rack.op
+local infixr ` ◃⁻¹ ` : 65 := rack.inv_op
+
+namespace rack
+variables {R : Type*} [rack R]
+
+@[simp] lemma normalize_op (x y : R) : rack.op' x y = x ◃ y := rfl
+@[simp] lemma normalize_inv_op (x y : R) : (rack.op' x).symm y = x ◃⁻¹ y := rfl
+
+@[simp] lemma left_inv (x y : R) : x ◃⁻¹ x ◃ y = y :=
+(op' x).symm_apply_eq.mpr rfl
+@[simp] lemma right_inv (x y : R) : x ◃ x ◃⁻¹ y = y :=
+(op' x).eq_symm_apply.mp rfl
+
+lemma self_distrib {x y z : R} : x ◃ y ◃ z = (x ◃ y) ◃ (x ◃ z) :=
+rack.self_distrib'
+
+lemma left_cancel (x : R) {y y' : R} : x ◃ y = x ◃ y' ↔ y = y' :=
+by { split, apply (rack.op' x).injective, rintro rfl, refl }
+
+lemma left_cancel_inv (x : R) {y y' : R} : x ◃⁻¹ y = x ◃⁻¹ y' ↔ y = y' :=
+by { split, apply (rack.op' x).symm.injective, rintro rfl, refl }
+
+
+lemma self_distrib_inv {x y z : R} : x ◃⁻¹ y ◃⁻¹ z = (x ◃⁻¹ y) ◃⁻¹ (x ◃⁻¹ z) :=
+begin
+  rw [←left_cancel (x ◃⁻¹ y), right_inv, ←left_cancel x, right_inv, self_distrib],
+  repeat {rw right_inv },
+end
+
+/--
+The opposite rack, swapping the roles of `◃` and `◃⁻¹`.
+-/
+def opp (R : Type*) [rack R] := R
+
+instance opp.rack : rack (opp R) :=
+{ op' := λ (x : R), (rack.op' x).symm,
+  self_distrib' := λ (x y z : R), self_distrib_inv }
+
+
+@[simp]
+lemma self_op_op_eq {x y : R} : (x ◃ x) ◃ y = x ◃ y :=
+by { rw [←right_inv x y, ←self_distrib] }
+
+@[simp]
+lemma self_op_inv_op_inv_eq {x y : R} : (x ◃⁻¹ x) ◃⁻¹ y = x ◃⁻¹ y :=
+@self_op_op_eq (opp R) _ x y
+
+@[simp]
+lemma self_op_op_inv_eq {x y : R} : (x ◃ x) ◃⁻¹ y = x ◃⁻¹ y :=
+by { rw ←left_cancel (x ◃ x), rw right_inv, rw self_op_op_eq, rw right_inv }
+
+@[simp]
+lemma self_op_inv_op_eq {x y : R} : (x ◃⁻¹ x) ◃ y = x ◃ y :=
+@self_op_op_inv_eq (opp R) _ x y
+
+lemma self_op_eq_iff_eq {x y : R} : x ◃ x = y ◃ y ↔ x = y :=
+begin
+  split, swap, rintro rfl, refl,
+  intro h,
+  transitivity (x ◃ x) ◃⁻¹ (x ◃ x),
+  rw [←left_cancel (x ◃ x), right_inv, self_op_op_eq],
+  rw [h, ←left_cancel (y ◃ y), right_inv, self_op_op_eq],
+end
+
+lemma self_op_inv_eq_iff_eq {x y : R} : x ◃⁻¹ x = y ◃⁻¹ y ↔ x = y :=
+@self_op_eq_iff_eq (opp R) _ x y
+
+/--
+The map `x ↦ x ◃ x` is a bijection.
+-/
+def self_apply (R : Type*) [rack R] : R ≃ R :=
+{ to_fun := λ x, x ◃ x,
+  inv_fun := λ x, x ◃⁻¹ x,
+  left_inv := λ x, by simp,
+  right_inv := λ x, by simp }
+
+/--
+An involutory rack is one for which `rack.op R x` is an involution for every x.
+-/
+def is_involutory (R : Type*) [rack R] : Prop := ∀ x : R, function.involutive (rack.op' x)
+
+lemma involutory_op_inv_eq_op {R : Type*} [rack R] (h : is_involutory R) (x y : R) :
+  x ◃⁻¹ y = x ◃ y :=
+begin
+  rw [←left_cancel x, right_inv],
+  exact((h x).left_inverse y).symm,
+end
+
+/--
+An abelian rack is one for which the mediality axiom holds.
+-/
+def is_abelian (R : Type*) [rack R] : Prop :=
+∀ (x y z w : R), (x ◃ y) ◃ (z ◃ w) = (x ◃ z) ◃ (y ◃ w)
+
+lemma assoc_iff_drop {R : Type*} [rack R] {x y z : R} :
+  x ◃ y ◃ z = (x ◃ y) ◃ z ↔ x ◃ z = z :=
+by { rw self_distrib, rw left_cancel }
+
+end rack
+
+@[ext]
+structure rack_hom (R₁ : Type*) (R₂ : Type*) [rack R₁] [rack R₂] :=
+(to_fun : R₁ → R₂)
+(map_op' : ∀ {x y : R₁}, to_fun (x ◃ y) = to_fun x ◃ to_fun y)
+
+namespace rack_hom
+
+attribute [simp] rack_hom.map_op'
+
+instance (R₁ : Type*) (R₂ : Type*) [rack R₁] [rack R₂] : has_coe_to_fun (rack_hom R₁ R₂) :=
+⟨_, rack_hom.to_fun⟩
+
+@[simp]
+lemma map_op {R₁ : Type*} {R₂ : Type*} [rack R₁] [rack R₂] (f : rack_hom R₁ R₂)
+  (x y : R₁) : f (x ◃ y) = f x ◃ f y :=
+rack_hom.map_op' f
+
+def id (R : Type*) [rack R] : rack_hom R R :=
+{ to_fun := id,
+  map_op' := by simp }
+
+variables {R₁ : Type*} {R₂ : Type*} {R₃ : Type*} [rack R₁] [rack R₂] [rack R₃]
+
+def comp (g : rack_hom R₂ R₃) (f : rack_hom R₁ R₂) : rack_hom R₁ R₃ :=
+{ to_fun := g.to_fun ∘ f.to_fun,
+  map_op' := by simp }
+
+@[simp]
+lemma comp_apply (g : rack_hom R₂ R₃) (f : rack_hom R₁ R₂) (x : R₁) :
+  (g.comp f) x = g (f x) := rfl
+
+end rack_hom
+
+
+/--
+A quandle is a rack such that each automorphism fixes its corresponding element.
+-/
+class quandle (α : Type*) extends rack α :=
+(fix' : ∀ {x : α}, rack.op' x x = x)
+
+namespace quandle
+open rack
+variables {Q : Type*} [quandle Q]
+
+@[simp]
+lemma fix {x : Q} : x ◃ x = x :=
+quandle.fix'
+
+lemma fix_inv {x : Q} : x ◃⁻¹ x = x :=
+by { rw ←left_cancel x, simp }
+
+instance opp.quandle : quandle (opp Q) :=
+{ fix' := λ x, fix_inv }
+
+/--
+The conjugation quandle of a group.
+-/
+def conj (G : Type*) [group G] := G
+
+def group.inner {G : Type*} [group G] (c : G) : G ≃ G :=
+{ to_fun := λ x, c * x * c⁻¹,
+  inv_fun := λ x, c⁻¹ * x * c,
+  left_inv := λ x, by simp [←mul_assoc],
+  right_inv := λ x, by simp [←mul_assoc] }
+
+instance conj.quandle (G : Type*) [group G] : quandle (conj G) :=
+{ op' := @group.inner G _,
+  self_distrib' := λ x y z, by simp [group.inner],
+  fix' := λ x, by simp [group.inner] }
+
+@[simp]
+lemma conj_op_eq_conj {G : Type*} [group G] (x y : conj G) :
+  x ◃ y = ((x : G) * (y : G) * (x : G)⁻¹ : G) := rfl
+
+lemma conj_swap {G : Type*} [group G] (x y : conj G) :
+  x ◃ y = y ↔ y ◃ x = x :=
+begin
+  dsimp, split,
+  repeat { intro h, conv_rhs { rw eq_mul_inv_of_mul_eq (eq_mul_inv_of_mul_eq h) }, simp, },
+end
+
+/--
+`conj` is functorial
+-/
+def conj.map {G : Type*} {H : Type*} [group G] [group H] (f : G →* H) : rack_hom (conj G) (conj H) :=
+{ to_fun := f,
+  map_op' := by simp }
+
+instance  {G : Type*} {H : Type*} [group G] [group H] : has_lift (G →* H) (rack_hom (conj G) (conj H)) :=
+{ lift := conj.map }
+
+/--
+The dihedral quandle. This is the conjugation quandle of the dihedral group restrict to flips.
+
+Used for Fox n-colorings of knots.
+-/
+def dihedral (n : ℕ) := zmod n
+
+def dihedral_op (n : ℕ) (a : zmod n) : zmod n → zmod n :=
+λ b, 2 * a - b
+
+def dihedral_op.inv (n : ℕ) (a : zmod n) : function.involutive (dihedral_op n a) :=
+by { intro b, dsimp [dihedral_op], ring }
+
+instance (n : ℕ) : quandle (dihedral n) :=
+{ op' := λ a, function.involutive.to_equiv _ (dihedral_op.inv n a),
+  self_distrib' := λ x y z, begin
+    dsimp [function.involutive.to_equiv, dihedral_op], ring,
+  end,
+  fix' := λ x, begin
+    dsimp [op', function.involutive.to_equiv, dihedral_op], ring,
+  end }
+
+/-
+TODO: if g is the Lie algebra of a Lie group G, then (x ◃ y) = Ad (exp x) x forms a quandle
+-/
+
+/-
+TODO: if X is a symmetric space, then each point has a corresponding involution that acts on X, forming a quandle.
+-/
+
+/-
+TODO: Alexander quandle with `a ◃ b = t * b + (1 - t) * b`, with `a` and `b` elements of a module over Z[t,t⁻¹].
+-/
+
+end quandle
+
+
+namespace rack
+
+/-!
+## Universal enveloping group of a rack
+
+Joyce, for quandles, called this AdConj.
+-/
+
+inductive pre_envel_gp (R : Type u) : Type u
+| unit : pre_envel_gp
+| incl (x : R) : pre_envel_gp
+| mul (a b : pre_envel_gp) : pre_envel_gp
+| inv (a : pre_envel_gp) : pre_envel_gp
+
+open pre_envel_gp
+
+inductive pre_envel_gp_rel' (R : Type u) [rack R] : pre_envel_gp R → pre_envel_gp R → Type u
+| refl {a : pre_envel_gp R} : pre_envel_gp_rel' a a
+| symm {a b : pre_envel_gp R} (hab : pre_envel_gp_rel' a b) : pre_envel_gp_rel' b a
+| trans {a b c : pre_envel_gp R} (hab : pre_envel_gp_rel' a b) (hbc : pre_envel_gp_rel' b c) : pre_envel_gp_rel' a c
+| congr_mul (a b a' b' : pre_envel_gp R) (ha : pre_envel_gp_rel' a a') (hb : pre_envel_gp_rel' b b') : pre_envel_gp_rel' (mul a b) (mul a' b')
+| congr_inv (a a' : pre_envel_gp R) (ha : pre_envel_gp_rel' a a') : pre_envel_gp_rel' (inv a) (inv a')
+| assoc (a b c : pre_envel_gp R) : pre_envel_gp_rel' (mul (mul a b) c) (mul a (mul b c))
+| one_mul (a : pre_envel_gp R) : pre_envel_gp_rel' (mul unit a) a
+| mul_one (a : pre_envel_gp R) : pre_envel_gp_rel' (mul a unit) a
+| mul_left_inv (a : pre_envel_gp R) : pre_envel_gp_rel' (mul (inv a) a) unit
+| op_incl (x y : R) : pre_envel_gp_rel' (mul (mul (incl x) (incl y)) (inv (incl x))) (incl (x ◃ y))
+
+/--
+The above relation as a `Prop`.
+-/
+inductive pre_envel_gp_rel (R : Type u) [rack R] : pre_envel_gp R → pre_envel_gp R → Prop
+| rel {a b : pre_envel_gp R} (r : pre_envel_gp_rel' R a b) : pre_envel_gp_rel a b
+
+/--
+A quick way to convert a `pre_envel_gp_rel'` to a `pre_envel_gp_rel`.
+-/
+def pre_envel_gp_rel'.rel {R : Type u} [rack R] {a b : pre_envel_gp R} : pre_envel_gp_rel' R a b → pre_envel_gp_rel R a b :=
+pre_envel_gp_rel.rel
+
+@[refl]
+lemma pre_envel_gp_rel.refl {R : Type u} [rack R] {a : pre_envel_gp R} : pre_envel_gp_rel R a a :=
+pre_envel_gp_rel.rel pre_envel_gp_rel'.refl
+
+@[symm]
+lemma pre_envel_gp_rel.symm {R : Type u} [rack R] {a b : pre_envel_gp R} : pre_envel_gp_rel R a b → pre_envel_gp_rel R b a
+| ⟨r⟩ := r.symm.rel
+
+@[trans]
+lemma pre_envel_gp_rel.trans {R : Type u} [rack R] {a b c : pre_envel_gp R} :
+  pre_envel_gp_rel R a b → pre_envel_gp_rel R b c → pre_envel_gp_rel R a c
+| ⟨rab⟩ ⟨rbc⟩ := (rab.trans rbc).rel
+
+instance pre_envel_gp.setoid (R : Type*) [rack R] : setoid (pre_envel_gp R) :=
+{ r := pre_envel_gp_rel R,
+  iseqv := begin
+    split, apply pre_envel_gp_rel.refl,
+    split, apply pre_envel_gp_rel.symm,
+    apply pre_envel_gp_rel.trans
+  end }
+
+/--
+The universal enveloping group for the monoid M.
+-/
+def envel_gp (R : Type*) [rack R] := quotient (pre_envel_gp.setoid R)
+
+instance (R : Type*) [rack R] : group (envel_gp R) :=
+{ mul := λ a b, quotient.lift_on₂ a b
+                  (λ a b, ⟦pre_envel_gp.mul a b⟧)
+                  (λ a b a' b' ha hb,
+                    begin cases ha, cases hb, apply quotient.sound, apply (pre_envel_gp_rel'.congr_mul a b a' b' ha_r hb_r).rel end),
+  one := ⟦unit⟧,
+  inv := λ a, quotient.lift_on a
+                (λ a, ⟦pre_envel_gp.inv a⟧)
+                (λ a a' ha,
+                  begin cases ha, apply quotient.sound, apply (pre_envel_gp_rel'.congr_inv a a' ha_r).rel end),
+  mul_assoc := λ a b c, begin
+    refine quotient.ind (λ a, _) a,
+    refine quotient.ind (λ b, _) b,
+    refine quotient.ind (λ c, _) c,
+    apply quotient.sound, exact (pre_envel_gp_rel'.assoc a b c).rel,
+  end,
+  one_mul := λ a, begin
+    refine quotient.ind (λ a, _) a,
+    apply quotient.sound, exact (pre_envel_gp_rel'.one_mul a).rel,
+  end,
+  mul_one := λ a, begin
+    refine quotient.ind (λ a, _) a,
+    apply quotient.sound, exact (pre_envel_gp_rel'.mul_one a).rel,
+  end,
+  mul_left_inv := λ a, begin
+    refine quotient.ind (λ a, _) a,
+    apply quotient.sound, exact (pre_envel_gp_rel'.mul_left_inv a).rel,
+  end }
+
+/--
+The canonical homomorphism from a rack to its enveloping group.
+Satisfies universal properties defined by `to_envel_gp.map` and `to_envel_gp.univ`.
+-/
+def to_envel_gp (R : Type*) [rack R] : rack_hom R (quandle.conj (envel_gp R)) :=
+{ to_fun := λ x, ⟦incl x⟧,
+  map_op' := begin
+    intros x y,
+    apply quotient.sound, exact (pre_envel_gp_rel'.op_incl x y).symm.rel,
+  end }
+
+def to_envel_gp.map_aux {R : Type*} [rack R] {G : Type*} [group G] (f : rack_hom R (quandle.conj G)) : pre_envel_gp R → G
+| unit := 1
+| (incl x) := f x
+| (mul a b) := to_envel_gp.map_aux a * to_envel_gp.map_aux b
+| (inv a) := (to_envel_gp.map_aux a)⁻¹
+
+namespace to_envel_gp.map_aux
+open pre_envel_gp_rel'
+
+lemma well_def {R : Type*} [rack R] {G : Type*} [group G] (f : rack_hom R (quandle.conj G)) :
+  Π {a b : pre_envel_gp R}, pre_envel_gp_rel' R a b → to_envel_gp.map_aux f a = to_envel_gp.map_aux f b
+| a b refl := rfl
+| a b (symm h) := (well_def h).symm
+| a b (trans hac hcb) := eq.trans (well_def hac) (well_def hcb)
+| _ _ (congr_mul a b a' b' ha hb) := by { dsimp [to_envel_gp.map_aux], rw well_def ha, rw well_def hb, }
+| _ _ (congr_inv a a' ha) := by { dsimp [to_envel_gp.map_aux], rw well_def ha }
+| _ _ (assoc a b c) := by { apply mul_assoc }
+| _ _ (one_mul a) := by { dsimp [to_envel_gp.map_aux], simp, }
+| _ _ (mul_one a) := by { dsimp [to_envel_gp.map_aux], simp, }
+| _ _ (mul_left_inv a) := by { dsimp [to_envel_gp.map_aux], simp, }
+| _ _ (op_incl x y) := by { dsimp [to_envel_gp.map_aux], simp, }
+
+end to_envel_gp.map_aux
+
+/--
+Given a map from a monoid to a group, lift it to being a map from the enveloping group.
+-/
+def to_envel_gp.map {R : Type*} [rack R] {G : Type*} [group G] (f : rack_hom R (quandle.conj G)) : envel_gp R →* G :=
+{ to_fun := λ x, quotient.lift_on x (to_envel_gp.map_aux f) begin
+    intros a b hab, cases hab, apply to_envel_gp.map_aux.well_def f hab_r,
+  end,
+  map_one' := begin
+    change quotient.lift_on ⟦unit⟧ (to_envel_gp.map_aux f) _ = 1,
+    simp [to_envel_gp.map_aux],
+  end,
+  map_mul' := λ x y, begin
+    refine quotient.ind (λ x, _) x,
+    refine quotient.ind (λ y, _) y,
+    change quotient.lift_on ⟦mul x y⟧ (to_envel_gp.map_aux f) _ = _,
+    simp [to_envel_gp.map_aux],
+  end }
+
+/--
+Given a homomorphism from a monoid to a group, it factors through the enveloping group.
+-/
+lemma to_envel_gp.univ (R : Type*) [rack R] (G : Type*) [group G] (f : rack_hom R (quandle.conj G)) :
+  (quandle.conj.map (to_envel_gp.map f)).comp (to_envel_gp R) = f :=
+by { ext, refl }
+
+/--
+The homomorphism `to_envel_gp.map f` is the unique map that fits into the commutative
+triangle in `to_envel_gp.univ`.
+-/
+lemma to_envel_gp.univ_uniq (R : Type*) [rack R] (G : Type*) [group G] (f : rack_hom R (quandle.conj G))
+  (g : envel_gp R →* G) (h : f = (quandle.conj.map g).comp (to_envel_gp R)) :
+  g = to_envel_gp.map f :=
+begin
+  subst f, ext, refine quotient.ind (λ x, _) x,
+  induction x,
+  convert g.map_one, refl,
+  dunfold to_envel_gp.map, simp [to_envel_gp.map_aux, to_envel_gp],
+  have hm : ⟦x_a.mul x_b⟧ = @has_mul.mul (envel_gp R) _ ⟦x_a⟧ ⟦x_b⟧ := rfl,
+  rw hm, simpa [x_ih_a, x_ih_b],
+  have hm : ⟦x_a.inv⟧ = @has_inv.inv (envel_gp R) _ ⟦x_a⟧ := rfl,
+  rw hm, simp [x_ih],
+end
+
+/-
+TODO: the group action of `envel_gp R` on `R`, and it respects the operation of `R`.
+Hence, `R` is an enriched/augmented rack over `envel_gp R`.
+-/
+
+end rack

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -50,6 +50,7 @@ variables {R : Type*} [rack R]
 
 @[simp] lemma normalize_op (x y : R) : rack.op' x y = x ◃ y := rfl
 @[simp] lemma normalize_inv_op (x y : R) : (rack.op' x).symm y = x ◃⁻¹ y := rfl
+@[simp] lemma normalize_inv_op' (x y : R) : (rack.op' x)⁻¹ y = x ◃⁻¹ y := rfl
 
 @[simp] lemma left_inv (x y : R) : x ◃⁻¹ x ◃ y = y :=
 (op' x).symm_apply_eq.mpr rfl
@@ -273,6 +274,19 @@ end quandle
 
 namespace rack
 
+/--
+This is the natural rack homomorphism to the conjugation quandle of the group `R ≃ R`
+that acts on the rack.
+-/
+def to_action (R : Type*) [rack R] : rack_hom R (quandle.conj (R ≃ R)) :=
+{ to_fun := rack.op',
+  map_op' := λ x y, begin
+    apply @mul_right_cancel _ _ _ (op' x), ext z,
+    simp only [quandle.conj_op_eq_conj, normalize_op, equiv.perm.mul_apply, inv_mul_cancel_right],
+    apply self_distrib.symm,
+  end }
+
+
 /-!
 ## Universal enveloping group of a rack
 
@@ -444,9 +458,17 @@ begin
   rw hm, simp [x_ih],
 end
 
-/-
-TODO: the group action of `envel_gp R` on `R`, and it respects the operation of `R`.
-Hence, `R` is an enriched/augmented rack over `envel_gp R`.
+/--
+The induced group homomorphism from the enveloping group into bijections of the rack,
+using `rack.to_action`. Satisfies the property `envel_action_prop`.
+
+This gives the rack `R` the structure of an augmented rack over `envel_gp R`.
 -/
+def envel_action {R : Type*} [rack R] : envel_gp R →* (R ≃ R) :=
+to_envel_gp.map (to_action R)
+
+@[simp]
+lemma envel_action_prop {R : Type*} [rack R] (x y : R) :
+  envel_action (to_envel_gp R x) y = x ◃ y := rfl
 
 end rack

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -6,6 +6,7 @@ Authors: Kyle Miller
 import algebra
 import data.zmod.basic
 import data.equiv.mul_add
+import tactic.group
 
 /-!
 # Racks and Quandles
@@ -278,15 +279,12 @@ the corresponding inner automorphism.
 @[nolint has_inhabited_instance]
 def conj (G : Type*) := G
 
-@[simp] lemma conj_conj_inv {G : Type*} [group G] (g h : G) : g * (g⁻¹ * h * g) * g⁻¹ = h :=
-mul_inv_eq_of_eq_mul (mul_eq_of_eq_inv_mul (mul_assoc _ _ _))
-
-@[simp] lemma conj_inv_conj {G : Type*} [group G] (g h : G) : g⁻¹ * (g * h * g⁻¹) * g = h :=
-mul_eq_of_eq_mul_inv (inv_mul_eq_of_eq_mul (mul_assoc _ _ _))
-
 instance conj.quandle (G : Type*) [group G] : quandle (conj G) :=
 { op' := (λ x, (@mul_aut.conj G _ x).to_equiv),
-  self_distrib' := λ x y z, by simp,
+  self_distrib' := λ x y z, begin
+    dsimp only [mul_equiv.to_equiv_apply, mul_aut.conj_apply, conj],
+    group,
+  end,
   fix' := λ x, by simp }
 
 @[simp]

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -398,7 +398,7 @@ open pre_envel_group
 /--
 Relations for the enveloping group. This is a type-valued relation because
 `to_envel_group.map_aux.well_def` inducts on it to show `to_envel_group.map`
-is well-defined.  The relation `pre_envel_group_rel` is the Prop-valued version,
+is well-defined.  The relation `pre_envel_group_rel` is the `Prop`-valued version,
 which is used to define `envel_group` itself.
 -/
 inductive pre_envel_group_rel' (R : Type u) [rack R] : pre_envel_group R → pre_envel_group R → Type u
@@ -423,7 +423,7 @@ instance pre_envel_group_rel'.inhabited (R : Type u) [rack R] :
 ⟨pre_envel_group_rel'.refl⟩
 
 /--
-The above relation as a `Prop`.
+The `pre_envel_group_rel` relation as a `Prop`.  Used as the relation for `pre_envel_group.setoid`.
 -/
 inductive pre_envel_group_rel (R : Type u) [rack R] : pre_envel_group R → pre_envel_group R → Prop
 | rel {a b : pre_envel_group R} (r : pre_envel_group_rel' R a b) : pre_envel_group_rel a b

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -246,7 +246,6 @@ local infixr ` →◃ `:25 := shelf_hom
 
 namespace shelf_hom
 variables {S₁ : Type*} {S₂ : Type*} {S₃ : Type*} [shelf S₁] [shelf S₂] [shelf S₃]
-attribute [simp] map_act'
 
 instance : has_coe_to_fun (S₁ →◃ S₂) :=
 ⟨_, shelf_hom.to_fun⟩

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -50,9 +50,14 @@ group.
 * `rack.envel_group` is universal (`to_envel_group.univ` and `to_envel_group.univ_uniq`)
 
 ## Notation
-* `x ◃ y` is local notation for `shelf.act x y`
-* `x ◃⁻¹ y` is local notation for `rack.inv_act x y`
-* `S →◃ S'` is local notation for `shelf_hom S S'`
+
+The following notation is localized in `quandles`:
+
+* `x ◃ y` is `shelf.act x y`
+* `x ◃⁻¹ y` is `rack.inv_act x y`
+* `S →◃ S'` is `shelf_hom S S'`
+
+Use `open_locale quandles` to use these.
 
 ## Todo
 
@@ -81,11 +86,20 @@ class shelf (α : Type u) :=
 (self_distrib : ∀ {x y z : α}, act x (act y z) = act (act x y) (act x z))
 
 /--
+The type of homomorphisms between shelves.
+This is also the notion of rack and quandle homomorphisms.
+-/
+@[ext]
+structure shelf_hom (S₁ : Type*) (S₂ : Type*) [shelf S₁] [shelf S₂] :=
+(to_fun : S₁ → S₂)
+(map_act' : ∀ {x y : S₁}, to_fun (shelf.act x y) = shelf.act (to_fun x) (to_fun y))
+
+/--
 A *rack* is an automorphic set (a set with an action on itself by
 bijections) that is self-distributive.  It is a shelf such that each
 element's action is invertible.
 
-The local notations `x ◃ y` and `x ◃⁻¹ y` denote the action and the
+The notations `x ◃ y` and `x ◃⁻¹ y` denote the action and the
 inverse action, respectively, and they are right associative.
 -/
 class rack (α : Type u) extends shelf α :=
@@ -93,8 +107,11 @@ class rack (α : Type u) extends shelf α :=
 (left_inv : ∀ x, function.left_inverse (inv_act x) (act x))
 (right_inv : ∀ x, function.right_inverse (inv_act x) (act x))
 
-local infixr ` ◃ ` : 65 := shelf.act
-local infixr ` ◃⁻¹ ` : 65 := rack.inv_act
+localized "infixr ` ◃ `:65 := shelf.act" in quandles
+localized "infixr ` ◃⁻¹ `:65 := rack.inv_act" in quandles
+localized "infixr ` →◃ `:25 := shelf_hom" in quandles
+
+open_locale quandles
 
 namespace rack
 variables {R : Type*} [rack R]
@@ -231,17 +248,6 @@ lemma assoc_iff_id {R : Type*} [rack R] {x y z : R} :
 by { rw self_distrib, rw left_cancel }
 
 end rack
-
-/--
-The type of homomorphisms between shelves.
-This is also the notion of rack and quandle homomorphisms.
--/
-@[ext]
-structure shelf_hom (S₁ : Type*) (S₂ : Type*) [shelf S₁] [shelf S₂] :=
-(to_fun : S₁ → S₂)
-(map_act' : ∀ {x y : S₁}, to_fun (x ◃ y) = to_fun x ◃ to_fun y)
-
-local infixr ` →◃ `:25 := shelf_hom
 
 namespace shelf_hom
 variables {S₁ : Type*} {S₂ : Type*} {S₃ : Type*} [shelf S₁] [shelf S₂] [shelf S₃]

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -404,7 +404,7 @@ associativity, multiplication by the unit, multiplication by inverses,
 compatibility with multiplication and inverses (`congr_mul` and
 `congr_inv`), the axioms for an equivalence relation, and,
 importantly, the relationship between conjugation and the rack action
-(see `rack.ad_conj).
+(see `rack.ad_conj`).
 
 None of this forms a 2-category yet, for example due to lack of
 associativity of `trans`.  The `pre_envel_group_rel` relation is a

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -43,7 +43,7 @@ group.
 * `rack` is a shelf whose action for each element is invertible
 * `quandle` is a rack whose action for an element fixes that element
 * `quandle.conj` defines a quandle of a group acting on itself by conjugation.
-* `rack_hom` is homomorphisms of racks and quandles.
+* `shelf_hom` is homomorphisms of shelves, racks, and quandles.
 * `rack.envel_group` gives the universal group the rack maps to as a conjugation quandle.
 * `rack.opp` gives the rack with the action replaced by its inverse.
 
@@ -53,6 +53,7 @@ group.
 ## Notation
 * `x ◃ y` is local notation for `shelf.act x y`
 * `x ◃⁻¹ y` is local notation for `rack.inv_act x y`
+* `S →◃ S'` is local notation for `shelf_hom S S'`
 
 ## Todo
 
@@ -262,7 +263,7 @@ def id (S : Type*) [shelf S] : S →◃ S :=
 instance inhabited (S : Type*) [shelf S] : inhabited (S →◃ S) :=
 ⟨id S⟩
 
-/-- The composition of rack/quandle homomorphisms -/
+/-- The composition of shelf homomorphisms -/
 def comp (g : S₂ →◃ S₃) (f : S₁ →◃ S₂) : S₁ →◃ S₃ :=
 { to_fun := g.to_fun ∘ f.to_fun,
   map_act' := by simp }
@@ -272,7 +273,6 @@ lemma comp_apply (g : S₂ →◃ S₃) (f : S₁ →◃ S₂) (x : S₁) :
   (g.comp f) x = g (f x) := rfl
 
 end shelf_hom
-
 
 /--
 A quandle is a rack such that each automorphism fixes its corresponding element.
@@ -362,7 +362,6 @@ instance (n : ℕ) : quandle (dihedral n) :=
     dsimp [function.involutive.to_equiv, dihedral_act], ring,
   end }
 
-
 end quandle
 
 namespace rack
@@ -374,7 +373,6 @@ that acts on the rack.
 def to_conj (R : Type*) [rack R] : R →◃ quandle.conj (R ≃ R) :=
 { to_fun := act,
   map_act' := ad_conj }
-
 
 section envel_group
 

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -75,8 +75,7 @@ universes u v
 
 /--
 A *shelf* is a structure with a self-distributive binary operation.
-The binary operation is thought of as being a left action of the type
-on itself.
+The binary operation is regarded as a left action of the type on itself.
 -/
 class shelf (α : Type u) :=
 (act : α → α → α)
@@ -87,8 +86,8 @@ A *rack* is an automorphic set (a set with an action on itself by
 bijections) that is self-distributive.  It is a shelf such that each
 element's action is invertible.
 
-The local notation `x ◃ y` and `x ◃⁻¹ y` denote the action and the
-inverse action, respectively, and it is right associative.
+The local notations `x ◃ y` and `x ◃⁻¹ y` denote the action and the
+inverse action, respectively, and they are right associative.
 -/
 class rack (α : Type u) extends shelf α :=
 (inv_act : α → α → α)
@@ -513,13 +512,13 @@ lemma well_def {R : Type*} [rack R] {G : Type*} [group G] (f : R →◃ quandle.
 | a b refl := rfl
 | a b (symm h) := (well_def h).symm
 | a b (trans hac hcb) := eq.trans (well_def hac) (well_def hcb)
-| _ _ (congr_mul ha hb) := by { dsimp [to_envel_group.map_aux], rw well_def ha, rw well_def hb, }
-| _ _ (congr_inv ha) := by { dsimp [to_envel_group.map_aux], rw well_def ha }
+| _ _ (congr_mul ha hb) := by { simp [to_envel_group.map_aux, well_def ha, well_def hb] }
+| _ _ (congr_inv ha) := by { simp [to_envel_group.map_aux, well_def ha] }
 | _ _ (assoc a b c) := by { apply mul_assoc }
-| _ _ (one_mul a) := by { dsimp [to_envel_group.map_aux], simp, }
-| _ _ (mul_one a) := by { dsimp [to_envel_group.map_aux], simp, }
-| _ _ (mul_left_inv a) := by { dsimp [to_envel_group.map_aux], simp, }
-| _ _ (act_incl x y) := by { dsimp [to_envel_group.map_aux], simp, }
+| _ _ (one_mul a) := by { simp [to_envel_group.map_aux] }
+| _ _ (mul_one a) := by { simp [to_envel_group.map_aux] }
+| _ _ (mul_left_inv a) := by { simp [to_envel_group.map_aux] }
+| _ _ (act_incl x y) := by { simp [to_envel_group.map_aux] }
 
 end to_envel_group.map_aux
 

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -5,6 +5,7 @@ Authors: Kyle Miller
 -/
 import algebra
 import data.zmod.basic
+import data.equiv.mul_add
 
 /-!
 # Racks and Quandles
@@ -58,7 +59,7 @@ group.
 * If G is a group, H a subgroup, and z in H, then there is a quandle `(G/H;z)` defined by
   `yH ◃ Hx = yzy⁻¹xH`.  Every homogeneous quandle (i.e., a quandle Q whose automorphism group acts
   transitively on Q as a set) is isomorphic to such a quandle.
-  There is a generalization to this arbitrary quandles in Joyce's paper (Theorem 7.2).
+  There is a generalization to this arbitrary quandles in [Joyce's paper (Theorem 7.2)][Joyce1982].
 
 ## Tags
 
@@ -276,10 +277,16 @@ the corresponding inner automorphism.
 @[nolint has_inhabited_instance]
 def conj (G : Type*) := G
 
+@[simp] lemma conj_conj_inv {G : Type*} [group G] (g h : G) : g * (g⁻¹ * h * g) * g⁻¹ = h :=
+mul_inv_eq_of_eq_mul (mul_eq_of_eq_inv_mul (mul_assoc _ _ _))
+
+@[simp] lemma conj_inv_conj {G : Type*} [group G] (g h : G) : g⁻¹ * (g * h * g⁻¹) * g = h :=
+mul_eq_of_eq_mul_inv (inv_mul_eq_of_eq_mul (mul_assoc _ _ _))
+
 instance conj.quandle (G : Type*) [group G] : quandle (conj G) :=
-{ op' := @group.inner_aut_equiv G _,
-  self_distrib' := λ x y z, by simp [group.inner_aut_equiv, group.inner_aut],
-  fix' := λ x, by simp [group.inner_aut_equiv, group.inner_aut] }
+{ op' := (λ x, (@mul_aut.conj G _ x).to_equiv),
+  self_distrib' := λ x y z, by simp,
+  fix' := λ x, by simp }
 
 @[simp]
 lemma conj_op_eq_conj {G : Type*} [group G] (x y : conj G) :

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -381,9 +381,59 @@ def to_conj (R : Type*) [rack R] : R →◃ quandle.conj (R ≃ R) :=
 section envel_group
 
 /-!
-## Universal enveloping group of a rack
+### Universal enveloping group of a rack
 
-Joyce, for quandles, called this AdConj.
+The universal enveloping group `envel_group R` of a rack `R` is the
+universal group such that every rack homomorphism `R →◃ conj G` is
+induced by a unique group homomorphism `envel_group R →* G`.
+For quandles, Joyce called this group `AdConj R`.
+
+The `envel_group` functor is left adjoint to the `conj` forgetful
+functor, and the way we construct the enveloping group is via a
+technique that should work for left adjoints of forgetful functors in
+general.  It involves thinking a little about 2-categories, but the
+payoff is that the map `envel_group R →* G` has a nice description.
+
+Let's think of a group as being a one-object category.  The first step
+is to define `pre_envel_group`, which gives formal expressions for all
+the 1-morphisms and includes the unit element, elements of `R`,
+multiplication, and inverses.  To introduce relations, the second step
+is to define `pre_envel_group_rel'`, which gives formal expressions
+for all 2-morphisms between the 1-morphisms.  The 2-morphisms include
+associativity, multiplication by the unit, multiplication by inverses,
+compatibility with multiplication and inverses (`congr_mul` and
+`congr_inv`), the axioms for an equivalence relation, and,
+importantly, the relationship between conjugation and the rack action
+(see `rack.ad_conj).
+
+None of this forms a 2-category yet, for example due to lack of
+associativity of `trans`.  The `pre_envel_group_rel` relation is a
+`Prop`-valued version of `pre_envel_group_rel'`, and making it
+`Prop`-valued essentially introduces enough 3-isomorphisms so that
+every pair of compatible 2-morphisms is isomorphic.  Now, while
+composition in `pre_envel_group` does not stricly satisfy the category
+axioms, `pre_envel_group` and `pre_envel_group_rel'` do form a weak
+2-category.
+
+Since we just want a 1-category, the last step is to quotient
+`pre_envel_group` by `pre_envel_group_rel'`, and the result is the
+group `envel_group`.
+
+For a homomorphism `f : R →◃ conj G`, how does
+`envel_group.map f : envel_group R →* G` work?  Let's think of `G` as
+being a 2-category with one object, a 1-morphism per element of `G`,
+and a single 2-morphism called `eq.refl` for each 1-morphism.  We
+define the map using a "higher `quotient.lift`" -- not only do we
+evaluate elements of `pre_envel_group` as expressions in `G` (this is
+`to_envel_group.map_aux`), but we evaluate elements of
+`pre_envel_group'` as expressions of 2-morphisms of `G` (this is
+`to_envel_group.map_aux.well_def`).  That is to say,
+`to_envel_group.map_aux.well_def` recursively evaluates formal
+expressions of 2-morphisms as equality proofs in `G`.
+
+Note: `Type`-valued relations are not common.  The fact it is
+`Type`-valued is what makes `to_envel_group.map_aux.well_def` have
+well-founded recursion.
 -/
 
 /--

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import algebra
+import algebra.group.basic
 import data.zmod.basic
 import data.equiv.mul_add
 import tactic.group

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -61,7 +61,7 @@ group.
 * If X is a symmetric space, then each point has a corresponding involution that acts on X, forming a quandle.
 * Alexander quandle with `a ◃ b = t * b + (1 - t) * b`, with `a` and `b` elements of a module over Z[t,t⁻¹].
 * If G is a group, H a subgroup, and z in H, then there is a quandle `(G/H;z)` defined by
-  `yH ◃ Hx = yzy⁻¹xH`.  Every homogeneous quandle (i.e., a quandle Q whose automorphism group acts
+  `yH ◃ xH = yzy⁻¹xH`.  Every homogeneous quandle (i.e., a quandle Q whose automorphism group acts
   transitively on Q as a set) is isomorphic to such a quandle.
   There is a generalization to this arbitrary quandles in [Joyce's paper (Theorem 7.2)][Joyce1982].
 
@@ -396,7 +396,10 @@ instance pre_envel_group.inhabited (R : Type u) : inhabited (pre_envel_group R) 
 open pre_envel_group
 
 /--
-Relations for the enveloping group.
+Relations for the enveloping group. This is a type-valued relation because
+`to_envel_group.map_aux.well_def` inducts on it to show `to_envel_group.map`
+is well-defined.  The relation `pre_envel_group_rel` is the Prop-valued version,
+which is used to define `envel_group` itself.
 -/
 inductive pre_envel_group_rel' (R : Type u) [rack R] : pre_envel_group R → pre_envel_group R → Type u
 | refl {a : pre_envel_group R} : pre_envel_group_rel' a a

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -24,12 +24,13 @@ One example of a quandle is the action of a Lie algebra on itself,
 defined by `op x y = Ad (exp x) y`.
 
 Quandles and racks were independently developed by multiple
-mathematicians.  David Joyce introduced quandles in his thesis to
-define an algebraic invariant of knot and link complements that is
-analogous to the fundamental group of the exterior, and he showed that
-the quandle associated to an oriented knot is invariant up to
-orientation-reversed mirror image.  Racks were used by Fenn and Rourke
-for framed codimension-2 knots and links.
+mathematicians.  David Joyce introduced quandles in his thesis
+[Joyce1982] to define an algebraic invariant of knot and link
+complements that is analogous to the fundamental group of the
+exterior, and he showed that the quandle associated to an oriented
+knot is invariant up to orientation-reversed mirror image.  Racks were
+used by Fenn and Rourke for framed codimension-2 knots and
+links.[FennRourke1992]
 
 The name "rack" came from wordplay by Conway and Wraith for the "wrack
 and ruin" of forgetting everything but the conjugation operation for a

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2020 Aaron Anderson. All rights reserved.
+Copyright (c) 2020 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Aaron Anderson, Kyle Miller
+Authors: Kyle Miller
 -/
 import algebra
 import data.zmod.basic
@@ -10,19 +10,55 @@ import data.zmod.basic
 # Racks and Quandles
 
 This file defines racks and quandles, algebraic structures for sets
-that can act on themselves with a self-distributivity property.  Their
-main application is encoding group conjugation and knot invariants.
+that bijectively act on themselves with a self-distributivity
+property.  If `R` is a rack and `op : R → (R ≃ R)` is the self-action,
+then the self-distributivity is, equivalently, that
+```
+op (op x y) = op x * op y * (op x)⁻¹
+```
+where multiplication is composition in `R ≃ R` as a group.
+Quandles are racks such that `op x x = x` for all `x`.
+
+One example of a quandle is the action of a Lie algebra on itself,
+defined by `op x y = Ad (exp x) y`.
+
+Quandles and racks were independently developed by multiple
+mathematicians.  David Joyce introduced quandles in his thesis to
+define an algebraic invariant of knot and link complements that is
+analogous to the fundamental group of the exterior, and he showed that
+the quandle associated to an oriented knot is invariant up to
+orientation-reversed mirror image.  Racks were used by Fenn and Rourke
+for framed codimension-2 knots and links.
+
+The name "rack" came from wordplay by Conway and Wraith for the "wrack
+and ruin" of forgetting everything but the conjugation operation for a
+group.
 
 ## Main definitions
 
-• `rack`
-• `quandle`
-• `quandle.conj` defines a quandle of a group acting on itself by conjugation.
-• `rack_hom` is homomorphisms of racks and quandles
-• `rack.to_envel_gp` gives the universal group the rack maps to as a conj quandle
+* `rack`
+* `quandle`
+* `quandle.conj` defines a quandle of a group acting on itself by conjugation.
+* `rack_hom` is homomorphisms of racks and quandles.
+* `rack.envel_group` gives the universal group the rack maps to as a conjugation quandle.
+* `rack.opp` gives the rack with the action replaced by its inverse.
 
 ## Main statements
-• `rack.to_envel_gp` is universal (`to_envel_gp.univ` and `to_envel_gp.univ_uniq`)
+* `rack.envel_group` is universal (`to_envel_group.univ` and `to_envel_group.univ_uniq`)
+
+## Notation
+* `x ◃ y` is local notation for `rack.op x y`
+* `x ◃⁻¹ y` is local notation for `rack.inv_op x y`
+
+## Todo
+
+* If g is the Lie algebra of a Lie group G, then (x ◃ y) = Ad (exp x) x forms a quandle
+* If X is a symmetric space, then each point has a corresponding involution that acts on X, forming a quandle.
+* Alexander quandle with `a ◃ b = t * b + (1 - t) * b`, with `a` and `b` elements of a module over Z[t,t⁻¹].
+* If G is a group, H a subgroup, and z in H, then there is a quandle `(G/H;z)` defined by
+  `yH ◃ Hx = yzy⁻¹xH`.  Every homogeneous quandle (i.e., a quandle Q whose automorphism group acts
+  transitively on Q as a set) is isomorphic to such a quandle.
+  There is a generalization to this arbitrary quandles in Joyce's paper (Theorem 7.2).
 
 ## Tags
 
@@ -32,8 +68,10 @@ rack, quandle
 universes u v
 
 /--
-A rack is an automorphic set (a set with an action on itself) that is self-distributive.
+A *rack* is an automorphic set (a set with an action on itself) that is self-distributive.
 The `x ◃ y` and `x ◃⁻¹ y` notation is right associative.
+
+There is a weaker notion of a *shelf*, which would be from having `op' : α → α → α`.
 -/
 class rack (α : Type*) :=
 (op' : α → (α ≃ α))
@@ -79,9 +117,10 @@ end
 /--
 The *adjoint action* of a rack on itself is `op'`, and the adjoint
 action of `x ◃ y` is the conjugate of the action of `y` by the action
-of `x`.
+of `x`. It is another way to understand the self-distributivity axiom.
 
-This is another way to understand the self-distributivity axiom.
+This is used in the natural rack homomorphism `to_conj` from `R` to
+`conj (R ≃ R)` defined by `op'`.
 -/
 lemma ad_conj {R : Type*} [rack R] (x y : R) :
   op' (x ◃ y) = op' x * op' y * (op' x)⁻¹ :=
@@ -131,9 +170,10 @@ lemma self_op_inv_eq_iff_eq {x y : R} : x ◃⁻¹ x = y ◃⁻¹ y ↔ x = y :=
 @self_op_eq_iff_eq (opp R) _ x y
 
 /--
-The map `x ↦ x ◃ x` is a bijection.
+The map `x ↦ x ◃ x` is a bijection.  (This has applications for the
+regular isotopy version of the Reidemeister I move for knot diagrams.)
 -/
-def self_apply (R : Type*) [rack R] : R ≃ R :=
+def self_apply_equiv (R : Type*) [rack R] : R ≃ R :=
 { to_fun := λ x, x ◃ x,
   inv_fun := λ x, x ◃⁻¹ x,
   left_inv := λ x, by simp,
@@ -157,14 +197,18 @@ An abelian rack is one for which the mediality axiom holds.
 def is_abelian (R : Type*) [rack R] : Prop :=
 ∀ (x y z w : R), (x ◃ y) ◃ (z ◃ w) = (x ◃ z) ◃ (y ◃ w)
 
-lemma assoc_iff_drop {R : Type*} [rack R] {x y z : R} :
+/--
+Associative racks are uninteresting.
+-/
+lemma assoc_iff_id {R : Type*} [rack R] {x y z : R} :
   x ◃ y ◃ z = (x ◃ y) ◃ z ↔ x ◃ z = z :=
 by { rw self_distrib, rw left_cancel }
 
 end rack
 
 /--
-The type of homomorphisms between racks and quandles.
+The type of homomorphisms between racks.
+This is also the notion of a quandle homomorphism.
 -/
 @[ext]
 structure rack_hom (R₁ : Type*) (R₂ : Type*) [rack R₁] [rack R₂] :=
@@ -188,7 +232,7 @@ def id (R : Type*) [rack R] : rack_hom R R :=
 { to_fun := id,
   map_op' := by simp }
 
-instance rack_hom.inhabited (R : Type*) [rack R] : inhabited (rack_hom R R) :=
+instance inhabited (R : Type*) [rack R] : inhabited (rack_hom R R) :=
 ⟨id R⟩
 
 variables {R₁ : Type*} {R₂ : Type*} {R₃ : Type*} [rack R₁] [rack R₂] [rack R₃]
@@ -226,24 +270,16 @@ instance opp.quandle : quandle (opp Q) :=
 { fix' := λ x, fix_inv }
 
 /--
-The conjugation quandle of a group.
+The conjugation quandle of a group.  Each element of the group acts by
+the corresponding inner automorphism.
 -/
 @[nolint has_inhabited_instance]
 def conj (G : Type*) := G
 
-/--
-Inner automorphisms of a group.
--/
-def group.inner {G : Type*} [group G] (c : G) : G ≃ G :=
-{ to_fun := λ x, c * x * c⁻¹,
-  inv_fun := λ x, c⁻¹ * x * c,
-  left_inv := λ x, by simp [←mul_assoc],
-  right_inv := λ x, by simp [←mul_assoc] }
-
 instance conj.quandle (G : Type*) [group G] : quandle (conj G) :=
-{ op' := @group.inner G _,
-  self_distrib' := λ x y z, by simp [group.inner],
-  fix' := λ x, by simp [group.inner] }
+{ op' := @group.inner_aut_equiv G _,
+  self_distrib' := λ x y z, by simp [group.inner_aut_equiv, group.inner_aut],
+  fix' := λ x, by simp [group.inner_aut_equiv, group.inner_aut] }
 
 @[simp]
 lemma conj_op_eq_conj {G : Type*} [group G] (x y : conj G) :
@@ -263,7 +299,7 @@ def conj.map {G : Type*} {H : Type*} [group G] [group H] (f : G →* H) : rack_h
 { to_fun := f,
   map_op' := by simp }
 
-instance  {G : Type*} {H : Type*} [group G] [group H] : has_lift (G →* H) (rack_hom (conj G) (conj H)) :=
+instance {G : Type*} {H : Type*} [group G] [group H] : has_lift (G →* H) (rack_hom (conj G) (conj H)) :=
 { lift := conj.map }
 
 /--
@@ -276,7 +312,7 @@ def dihedral (n : ℕ) := zmod n
 
 /--
 The operation for the dihedral quandle.  It does not need to be an equivalence
-because it is an involution (`dihedral_op.inv`).
+because it is an involution (see `dihedral_op.inv`).
 -/
 def dihedral_op (n : ℕ) (a : zmod n) : zmod n → zmod n :=
 λ b, 2 * a - b
@@ -293,32 +329,21 @@ instance (n : ℕ) : quandle (dihedral n) :=
     dsimp [op', function.involutive.to_equiv, dihedral_op], ring,
   end }
 
-/-
-TODO: if g is the Lie algebra of a Lie group G, then (x ◃ y) = Ad (exp x) x forms a quandle
--/
-
-/-
-TODO: if X is a symmetric space, then each point has a corresponding involution that acts on X, forming a quandle.
--/
-
-/-
-TODO: Alexander quandle with `a ◃ b = t * b + (1 - t) * b`, with `a` and `b` elements of a module over Z[t,t⁻¹].
--/
 
 end quandle
 
-
 namespace rack
-
 
 /--
 This is the natural rack homomorphism to the conjugation quandle of the group `R ≃ R`
 that acts on the rack.
 -/
-def to_action (R : Type*) [rack R] : rack_hom R (quandle.conj (R ≃ R)) :=
+def to_conj (R : Type*) [rack R] : rack_hom R (quandle.conj (R ≃ R)) :=
 { to_fun := op',
   map_op' := ad_conj }
 
+
+section envel_group
 
 /-!
 ## Universal enveloping group of a rack
@@ -329,198 +354,200 @@ Joyce, for quandles, called this AdConj.
 /--
 Free generators of the enveloping group.
 -/
-inductive pre_envel_gp (R : Type u) : Type u
-| unit : pre_envel_gp
-| incl (x : R) : pre_envel_gp
-| mul (a b : pre_envel_gp) : pre_envel_gp
-| inv (a : pre_envel_gp) : pre_envel_gp
+inductive pre_envel_group (R : Type u) : Type u
+| unit : pre_envel_group
+| incl (x : R) : pre_envel_group
+| mul (a b : pre_envel_group) : pre_envel_group
+| inv (a : pre_envel_group) : pre_envel_group
 
-instance pre_envel_gp.inhabited (R : Type u) : inhabited (pre_envel_gp R) :=
-⟨pre_envel_gp.unit⟩
+instance pre_envel_group.inhabited (R : Type u) : inhabited (pre_envel_group R) :=
+⟨pre_envel_group.unit⟩
 
-open pre_envel_gp
+open pre_envel_group
 
 /--
 Relations for the enveloping group.
 -/
-inductive pre_envel_gp_rel' (R : Type u) [rack R] : pre_envel_gp R → pre_envel_gp R → Type u
-| refl {a : pre_envel_gp R} : pre_envel_gp_rel' a a
-| symm {a b : pre_envel_gp R} (hab : pre_envel_gp_rel' a b) : pre_envel_gp_rel' b a
-| trans {a b c : pre_envel_gp R} (hab : pre_envel_gp_rel' a b) (hbc : pre_envel_gp_rel' b c) : pre_envel_gp_rel' a c
-| congr_mul (a b a' b' : pre_envel_gp R) (ha : pre_envel_gp_rel' a a') (hb : pre_envel_gp_rel' b b') : pre_envel_gp_rel' (mul a b) (mul a' b')
-| congr_inv (a a' : pre_envel_gp R) (ha : pre_envel_gp_rel' a a') : pre_envel_gp_rel' (inv a) (inv a')
-| assoc (a b c : pre_envel_gp R) : pre_envel_gp_rel' (mul (mul a b) c) (mul a (mul b c))
-| one_mul (a : pre_envel_gp R) : pre_envel_gp_rel' (mul unit a) a
-| mul_one (a : pre_envel_gp R) : pre_envel_gp_rel' (mul a unit) a
-| mul_left_inv (a : pre_envel_gp R) : pre_envel_gp_rel' (mul (inv a) a) unit
-| op_incl (x y : R) : pre_envel_gp_rel' (mul (mul (incl x) (incl y)) (inv (incl x))) (incl (x ◃ y))
+inductive pre_envel_group_rel' (R : Type u) [rack R] : pre_envel_group R → pre_envel_group R → Type u
+| refl {a : pre_envel_group R} : pre_envel_group_rel' a a
+| symm {a b : pre_envel_group R} (hab : pre_envel_group_rel' a b) : pre_envel_group_rel' b a
+| trans {a b c : pre_envel_group R}
+  (hab : pre_envel_group_rel' a b) (hbc : pre_envel_group_rel' b c) : pre_envel_group_rel' a c
+| congr_mul {a b a' b' : pre_envel_group R}
+  (ha : pre_envel_group_rel' a a') (hb : pre_envel_group_rel' b b') :
+  pre_envel_group_rel' (mul a b) (mul a' b')
+| congr_inv {a a' : pre_envel_group R} (ha : pre_envel_group_rel' a a') :
+  pre_envel_group_rel' (inv a) (inv a')
+| assoc (a b c : pre_envel_group R) : pre_envel_group_rel' (mul (mul a b) c) (mul a (mul b c))
+| one_mul (a : pre_envel_group R) : pre_envel_group_rel' (mul unit a) a
+| mul_one (a : pre_envel_group R) : pre_envel_group_rel' (mul a unit) a
+| mul_left_inv (a : pre_envel_group R) : pre_envel_group_rel' (mul (inv a) a) unit
+| op_incl (x y : R) :
+  pre_envel_group_rel' (mul (mul (incl x) (incl y)) (inv (incl x))) (incl (x ◃ y))
 
-instance pre_envel_gp_rel'.inhabited (R : Type u) [rack R] : inhabited (pre_envel_gp_rel' R unit unit) :=
-⟨pre_envel_gp_rel'.refl⟩
+instance pre_envel_group_rel'.inhabited (R : Type u) [rack R] :
+  inhabited (pre_envel_group_rel' R unit unit) :=
+⟨pre_envel_group_rel'.refl⟩
 
 /--
 The above relation as a `Prop`.
 -/
-inductive pre_envel_gp_rel (R : Type u) [rack R] : pre_envel_gp R → pre_envel_gp R → Prop
-| rel {a b : pre_envel_gp R} (r : pre_envel_gp_rel' R a b) : pre_envel_gp_rel a b
+inductive pre_envel_group_rel (R : Type u) [rack R] : pre_envel_group R → pre_envel_group R → Prop
+| rel {a b : pre_envel_group R} (r : pre_envel_group_rel' R a b) : pre_envel_group_rel a b
 
 /--
-A quick way to convert a `pre_envel_gp_rel'` to a `pre_envel_gp_rel`.
+A quick way to convert a `pre_envel_group_rel'` to a `pre_envel_group_rel`.
 -/
-lemma pre_envel_gp_rel'.rel {R : Type u} [rack R] {a b : pre_envel_gp R} : pre_envel_gp_rel' R a b → pre_envel_gp_rel R a b :=
-pre_envel_gp_rel.rel
+lemma pre_envel_group_rel'.rel {R : Type u} [rack R] {a b : pre_envel_group R} :
+  pre_envel_group_rel' R a b → pre_envel_group_rel R a b :=
+pre_envel_group_rel.rel
 
 @[refl]
-lemma pre_envel_gp_rel.refl {R : Type u} [rack R] {a : pre_envel_gp R} : pre_envel_gp_rel R a a :=
-pre_envel_gp_rel.rel pre_envel_gp_rel'.refl
+lemma pre_envel_group_rel.refl {R : Type u} [rack R] {a : pre_envel_group R} :
+  pre_envel_group_rel R a a :=
+pre_envel_group_rel.rel pre_envel_group_rel'.refl
 
 @[symm]
-lemma pre_envel_gp_rel.symm {R : Type u} [rack R] {a b : pre_envel_gp R} : pre_envel_gp_rel R a b → pre_envel_gp_rel R b a
+lemma pre_envel_group_rel.symm {R : Type u} [rack R] {a b : pre_envel_group R} :
+  pre_envel_group_rel R a b → pre_envel_group_rel R b a
 | ⟨r⟩ := r.symm.rel
 
 @[trans]
-lemma pre_envel_gp_rel.trans {R : Type u} [rack R] {a b c : pre_envel_gp R} :
-  pre_envel_gp_rel R a b → pre_envel_gp_rel R b c → pre_envel_gp_rel R a c
+lemma pre_envel_group_rel.trans {R : Type u} [rack R] {a b c : pre_envel_group R} :
+  pre_envel_group_rel R a b → pre_envel_group_rel R b c → pre_envel_group_rel R a c
 | ⟨rab⟩ ⟨rbc⟩ := (rab.trans rbc).rel
 
-instance pre_envel_gp.setoid (R : Type*) [rack R] : setoid (pre_envel_gp R) :=
-{ r := pre_envel_gp_rel R,
+instance pre_envel_group.setoid (R : Type*) [rack R] : setoid (pre_envel_group R) :=
+{ r := pre_envel_group_rel R,
   iseqv := begin
-    split, apply pre_envel_gp_rel.refl,
-    split, apply pre_envel_gp_rel.symm,
-    apply pre_envel_gp_rel.trans
+    split, apply pre_envel_group_rel.refl,
+    split, apply pre_envel_group_rel.symm,
+    apply pre_envel_group_rel.trans
   end }
 
 /--
-The universal enveloping group for the monoid M.
+The universal enveloping group for the rack R.
 -/
-def envel_gp (R : Type*) [rack R] := quotient (pre_envel_gp.setoid R)
+def envel_group (R : Type*) [rack R] := quotient (pre_envel_group.setoid R)
 
-instance (R : Type*) [rack R] : group (envel_gp R) :=
+instance (R : Type*) [rack R] : group (envel_group R) :=
 { mul := λ a b, quotient.lift_on₂ a b
-                  (λ a b, ⟦pre_envel_gp.mul a b⟧)
-                  (λ a b a' b' ha hb,
-                    begin cases ha, cases hb, apply quotient.sound, apply (pre_envel_gp_rel'.congr_mul a b a' b' ha_r hb_r).rel end),
+                  (λ a b, ⟦pre_envel_group.mul a b⟧)
+                  (λ a b a' b' ⟨ha⟩ ⟨hb⟩,
+                    quotient.sound (pre_envel_group_rel'.congr_mul ha hb).rel),
   one := ⟦unit⟧,
   inv := λ a, quotient.lift_on a
-                (λ a, ⟦pre_envel_gp.inv a⟧)
-                (λ a a' ha,
-                  begin cases ha, apply quotient.sound, apply (pre_envel_gp_rel'.congr_inv a a' ha_r).rel end),
-  mul_assoc := λ a b c, begin
-    refine quotient.ind (λ a, _) a,
-    refine quotient.ind (λ b, _) b,
-    refine quotient.ind (λ c, _) c,
-    apply quotient.sound, exact (pre_envel_gp_rel'.assoc a b c).rel,
-  end,
-  one_mul := λ a, begin
-    refine quotient.ind (λ a, _) a,
-    apply quotient.sound, exact (pre_envel_gp_rel'.one_mul a).rel,
-  end,
-  mul_one := λ a, begin
-    refine quotient.ind (λ a, _) a,
-    apply quotient.sound, exact (pre_envel_gp_rel'.mul_one a).rel,
-  end,
-  mul_left_inv := λ a, begin
-    refine quotient.ind (λ a, _) a,
-    apply quotient.sound, exact (pre_envel_gp_rel'.mul_left_inv a).rel,
-  end }
+                (λ a, ⟦pre_envel_group.inv a⟧)
+                (λ a a' ⟨ha⟩,
+                  quotient.sound (pre_envel_group_rel'.congr_inv ha).rel),
+  mul_assoc := λ a b c,
+    quotient.induction_on₃ a b c (λ a b c, quotient.sound (pre_envel_group_rel'.assoc a b c).rel),
+  one_mul := λ a,
+    quotient.induction_on a (λ a, quotient.sound (pre_envel_group_rel'.one_mul a).rel),
+  mul_one := λ a,
+    quotient.induction_on a (λ a, quotient.sound (pre_envel_group_rel'.mul_one a).rel),
+  mul_left_inv := λ a,
+    quotient.induction_on a (λ a, quotient.sound (pre_envel_group_rel'.mul_left_inv a).rel) }
 
-instance envel_gp.inhabited (R : Type*) [rack R] : inhabited (envel_gp R) := ⟨1⟩
+instance envel_group.inhabited (R : Type*) [rack R] : inhabited (envel_group R) := ⟨1⟩
 
 /--
 The canonical homomorphism from a rack to its enveloping group.
-Satisfies universal properties defined by `to_envel_gp.map` and `to_envel_gp.univ`.
+Satisfies universal properties given by `to_envel_group.map` and `to_envel_group.univ`.
 -/
-def to_envel_gp (R : Type*) [rack R] : rack_hom R (quandle.conj (envel_gp R)) :=
+def to_envel_group (R : Type*) [rack R] : rack_hom R (quandle.conj (envel_group R)) :=
 { to_fun := λ x, ⟦incl x⟧,
-  map_op' := begin
-    intros x y,
-    apply quotient.sound, exact (pre_envel_gp_rel'.op_incl x y).symm.rel,
-  end }
+  map_op' := λ x y, quotient.sound (pre_envel_group_rel'.op_incl x y).symm.rel }
 
 /--
 The preliminary definition of the induced map from the enveloping group.
-See `to_envel_gp.map`.
+See `to_envel_group.map`.
 -/
-def to_envel_gp.map_aux {R : Type*} [rack R] {G : Type*} [group G]
-  (f : rack_hom R (quandle.conj G)) : pre_envel_gp R → G
+def to_envel_group.map_aux {R : Type*} [rack R] {G : Type*} [group G]
+  (f : rack_hom R (quandle.conj G)) : pre_envel_group R → G
 | unit := 1
 | (incl x) := f x
-| (mul a b) := to_envel_gp.map_aux a * to_envel_gp.map_aux b
-| (inv a) := (to_envel_gp.map_aux a)⁻¹
+| (mul a b) := to_envel_group.map_aux a * to_envel_group.map_aux b
+| (inv a) := (to_envel_group.map_aux a)⁻¹
 
-namespace to_envel_gp.map_aux
-open pre_envel_gp_rel'
+namespace to_envel_group.map_aux
+open pre_envel_group_rel'
 
+/--
+Show that `to_envel_group.map_aux` sends equivalent expressions to equal terms.
+-/
 lemma well_def {R : Type*} [rack R] {G : Type*} [group G] (f : rack_hom R (quandle.conj G)) :
-  Π {a b : pre_envel_gp R}, pre_envel_gp_rel' R a b → to_envel_gp.map_aux f a = to_envel_gp.map_aux f b
+  Π {a b : pre_envel_group R}, pre_envel_group_rel' R a b →
+  to_envel_group.map_aux f a = to_envel_group.map_aux f b
 | a b refl := rfl
 | a b (symm h) := (well_def h).symm
 | a b (trans hac hcb) := eq.trans (well_def hac) (well_def hcb)
-| _ _ (congr_mul a b a' b' ha hb) := by { dsimp [to_envel_gp.map_aux], rw well_def ha, rw well_def hb, }
-| _ _ (congr_inv a a' ha) := by { dsimp [to_envel_gp.map_aux], rw well_def ha }
+| _ _ (congr_mul ha hb) := by { dsimp [to_envel_group.map_aux], rw well_def ha, rw well_def hb, }
+| _ _ (congr_inv ha) := by { dsimp [to_envel_group.map_aux], rw well_def ha }
 | _ _ (assoc a b c) := by { apply mul_assoc }
-| _ _ (one_mul a) := by { dsimp [to_envel_gp.map_aux], simp, }
-| _ _ (mul_one a) := by { dsimp [to_envel_gp.map_aux], simp, }
-| _ _ (mul_left_inv a) := by { dsimp [to_envel_gp.map_aux], simp, }
-| _ _ (op_incl x y) := by { dsimp [to_envel_gp.map_aux], simp, }
+| _ _ (one_mul a) := by { dsimp [to_envel_group.map_aux], simp, }
+| _ _ (mul_one a) := by { dsimp [to_envel_group.map_aux], simp, }
+| _ _ (mul_left_inv a) := by { dsimp [to_envel_group.map_aux], simp, }
+| _ _ (op_incl x y) := by { dsimp [to_envel_group.map_aux], simp, }
 
-end to_envel_gp.map_aux
+end to_envel_group.map_aux
 
 /--
-Given a map from a monoid to a group, lift it to being a map from the enveloping group.
+Given a map from a rack to a group, lift it to being a map from the enveloping group.
 -/
-def to_envel_gp.map {R : Type*} [rack R] {G : Type*} [group G] (f : rack_hom R (quandle.conj G)) : envel_gp R →* G :=
-{ to_fun := λ x, quotient.lift_on x (to_envel_gp.map_aux f) begin
-    intros a b hab, cases hab, apply to_envel_gp.map_aux.well_def f hab_r,
-  end,
+def to_envel_group.map {R : Type*} [rack R] {G : Type*} [group G]
+  (f : rack_hom R (quandle.conj G)) : envel_group R →* G :=
+{ to_fun := λ x, quotient.lift_on x (to_envel_group.map_aux f)
+                   (λ a b ⟨hab⟩, to_envel_group.map_aux.well_def f hab),
   map_one' := begin
-    change quotient.lift_on ⟦unit⟧ (to_envel_gp.map_aux f) _ = 1,
-    simp [to_envel_gp.map_aux],
+    change quotient.lift_on ⟦unit⟧ (to_envel_group.map_aux f) _ = 1,
+    simp [to_envel_group.map_aux],
   end,
-  map_mul' := λ x y, begin
-    refine quotient.ind (λ x, _) x,
-    refine quotient.ind (λ y, _) y,
-    change quotient.lift_on ⟦mul x y⟧ (to_envel_gp.map_aux f) _ = _,
-    simp [to_envel_gp.map_aux],
-  end }
+  map_mul' := λ x y, quotient.induction_on₂ x y (λ x y, begin
+    change quotient.lift_on ⟦mul x y⟧ (to_envel_group.map_aux f) _ = _,
+    simp [to_envel_group.map_aux],
+  end) }
 
 /--
-Given a homomorphism from a monoid to a group, it factors through the enveloping group.
+Given a homomorphism from a rack to a group, it factors through the enveloping group.
 -/
-lemma to_envel_gp.univ (R : Type*) [rack R] (G : Type*) [group G] (f : rack_hom R (quandle.conj G)) :
-  (quandle.conj.map (to_envel_gp.map f)).comp (to_envel_gp R) = f :=
+lemma to_envel_group.univ (R : Type*) [rack R] (G : Type*) [group G]
+  (f : rack_hom R (quandle.conj G)) :
+  (quandle.conj.map (to_envel_group.map f)).comp (to_envel_group R) = f :=
 by { ext, refl }
 
 /--
-The homomorphism `to_envel_gp.map f` is the unique map that fits into the commutative
-triangle in `to_envel_gp.univ`.
+The homomorphism `to_envel_group.map f` is the unique map that fits into the commutative
+triangle in `to_envel_group.univ`.
 -/
-lemma to_envel_gp.univ_uniq (R : Type*) [rack R] (G : Type*) [group G] (f : rack_hom R (quandle.conj G))
-  (g : envel_gp R →* G) (h : f = (quandle.conj.map g).comp (to_envel_gp R)) :
-  g = to_envel_gp.map f :=
+lemma to_envel_group.univ_uniq (R : Type*) [rack R] (G : Type*) [group G]
+  (f : rack_hom R (quandle.conj G))
+  (g : envel_group R →* G) (h : f = (quandle.conj.map g).comp (to_envel_group R)) :
+  g = to_envel_group.map f :=
 begin
   subst f, ext, refine quotient.ind (λ x, _) x,
   induction x,
   convert g.map_one, refl,
-  dunfold to_envel_gp.map, simp [to_envel_gp.map_aux, to_envel_gp],
-  have hm : ⟦x_a.mul x_b⟧ = @has_mul.mul (envel_gp R) _ ⟦x_a⟧ ⟦x_b⟧ := rfl,
+  dunfold to_envel_group.map, simp [to_envel_group.map_aux, to_envel_group],
+  have hm : ⟦x_a.mul x_b⟧ = @has_mul.mul (envel_group R) _ ⟦x_a⟧ ⟦x_b⟧ := rfl,
   rw hm, simpa [x_ih_a, x_ih_b],
-  have hm : ⟦x_a.inv⟧ = @has_inv.inv (envel_gp R) _ ⟦x_a⟧ := rfl,
+  have hm : ⟦x_a.inv⟧ = @has_inv.inv (envel_group R) _ ⟦x_a⟧ := rfl,
   rw hm, simp [x_ih],
 end
 
 /--
 The induced group homomorphism from the enveloping group into bijections of the rack,
-using `rack.to_action`. Satisfies the property `envel_action_prop`.
+using `rack.to_conj`. Satisfies the property `envel_action_prop`.
 
-This gives the rack `R` the structure of an augmented rack over `envel_gp R`.
+This gives the rack `R` the structure of an augmented rack over `envel_group R`.
 -/
-def envel_action {R : Type*} [rack R] : envel_gp R →* (R ≃ R) :=
-to_envel_gp.map (to_action R)
+def envel_action {R : Type*} [rack R] : envel_group R →* (R ≃ R) :=
+to_envel_group.map (to_conj R)
 
 @[simp]
 lemma envel_action_prop {R : Type*} [rack R] (x y : R) :
-  envel_action (to_envel_gp R x) y = x ◃ y := rfl
+  envel_action (to_envel_group R x) y = x ◃ y := rfl
+
+end envel_group
 
 end rack

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -264,7 +264,7 @@ def conj [group G] : G →* mul_aut G :=
 
 @[simp] lemma conj_apply [group G] (g h : G) : conj g h = g * h * g⁻¹ := rfl
 @[simp] lemma conj_symm_apply [group G] (g h : G) : (conj g).symm h = g⁻¹ * h * g := rfl
-@[simp] lemma conj_inv_apply {G : Type*} [group G] (g h : G) : (mul_aut.conj g)⁻¹ h = g⁻¹ * h * g := rfl
+@[simp] lemma conj_inv_apply {G : Type*} [group G] (g h : G) : (conj g)⁻¹ h = g⁻¹ * h * g := rfl
 
 end mul_aut
 

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -64,6 +64,9 @@ variables [has_mul M] [has_mul N] [has_mul P]
 @[simp, to_additive]
 lemma to_fun_apply {f : M ≃* N} {m : M} : f.to_fun m = f m := rfl
 
+@[simp, to_additive]
+lemma to_equiv_apply {f : M ≃* N} {m : M} : f.to_equiv m = f m := rfl
+
 /-- A multiplicative isomorphism preserves multiplication (canonical form). -/
 @[simp, to_additive]
 lemma map_mul (f : M ≃* N) : ∀ x y, f (x * y) = f x * f y := f.map_mul'
@@ -261,6 +264,7 @@ def conj [group G] : G →* mul_aut G :=
 
 @[simp] lemma conj_apply [group G] (g h : G) : conj g h = g * h * g⁻¹ := rfl
 @[simp] lemma conj_symm_apply [group G] (g h : G) : (conj g).symm h = g⁻¹ * h * g := rfl
+@[simp] lemma conj_inv_apply {G : Type*} [group G] (g h : G) : (mul_aut.conj g)⁻¹ h = g⁻¹ * h * g := rfl
 
 end mul_aut
 


### PR DESCRIPTION
This adds the algebraic structures of racks and quandles, defines a few examples, and provides the universal enveloping group of a rack.

A rack is a set that acts on itself bijectively, and sort of the point is that the action `act : α → (α ≃ α)` satisfies
```
act (x ◃ y) = act x * act y * (act x)⁻¹
```
where `x ◃ y` is the usual rack/quandle notation for `act x y`.  (Note: racks do not use `has_scalar` because it's convenient having `x ◃⁻¹ y` for the inverse action of `x` on `y`.  Plus, associative racks have a trivial action.)

In knot theory, the universal enveloping group of the fundamental quandle is isomorphic to the fundamental group of the knot complement.  For oriented knots up to orientation-reversed mirror image, the fundamental quandle is a complete invariant, unlike the fundamental group, which fails to distinguish non-prime knots with chiral summands.

---
<!-- put comments you want to keep out of the PR commit here -->
