### PR TITLE
[Merged by Bors] - feat(measure_theory): prove that more functions are measurable

### DIFF
--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -326,19 +326,24 @@ lemma continuous_linear_map.exists_right_inverse_of_surjective [finite_dimension
 let ⟨g, hg⟩ := (f : E →ₗ[𝕜] F).exists_right_inverse_of_surjective hf in
 ⟨g.to_continuous_linear_map, continuous_linear_map.ext $ linear_map.ext_iff.1 hg⟩
 
+lemma closed_embedding_smul_left {c : E} (hc : c ≠ 0) : closed_embedding (λ x : 𝕜, x • c) :=
+begin
+  haveI : finite_dimensional 𝕜 (submodule.span 𝕜 {c}) :=
+    finite_dimensional.span_of_finite 𝕜 (finite_singleton c),
+  have m1 : closed_embedding (coe : submodule.span 𝕜 {c} → E) :=
+  (submodule.span 𝕜 {c}).closed_of_finite_dimensional.closed_embedding_subtype_coe,
+  have m2 : closed_embedding
+    (linear_equiv.to_span_nonzero_singleton 𝕜 E c hc : 𝕜 → submodule.span 𝕜 {c}) :=
+  (continuous_linear_equiv.to_span_nonzero_singleton 𝕜 c hc).to_homeomorph.closed_embedding,
+  exact m1.comp m2
+end
+
 /- `smul` is a closed map in the first argument. -/
 lemma is_closed_map_smul_left (c : E) : is_closed_map (λ x : 𝕜, x • c) :=
 begin
   by_cases hc : c = 0,
   { simp_rw [hc, smul_zero], exact is_closed_map_const },
-  { haveI : finite_dimensional 𝕜 (submodule.span 𝕜 {c}) :=
-      finite_dimensional.span_of_finite 𝕜 (finite_singleton c),
-    have m1 : is_closed_map (coe : submodule.span 𝕜 {c} → E) :=
-    (submodule.span 𝕜 {c}).closed_of_finite_dimensional.closed_embedding_subtype_coe.is_closed_map,
-    have m2 : is_closed_map
-      (linear_equiv.to_span_nonzero_singleton 𝕜 E c hc : 𝕜 → submodule.span 𝕜 {c}) :=
-    (continuous_linear_equiv.to_span_nonzero_singleton 𝕜 c hc).to_homeomorph.is_closed_map,
-    exact m1.comp m2 }
+  { exact (closed_embedding_smul_left hc).is_closed_map }
 end
 
 end complete_field

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -326,6 +326,21 @@ lemma continuous_linear_map.exists_right_inverse_of_surjective [finite_dimension
 let ⟨g, hg⟩ := (f : E →ₗ[𝕜] F).exists_right_inverse_of_surjective hf in
 ⟨g.to_continuous_linear_map, continuous_linear_map.ext $ linear_map.ext_iff.1 hg⟩
 
+/- `smul` is a closed map in the first argument. -/
+lemma is_closed_map_smul_left (c : E) : is_closed_map (λ x : 𝕜, x • c) :=
+begin
+  by_cases hc : c = 0,
+  { simp_rw [hc, smul_zero], exact is_closed_map_const },
+  { haveI : finite_dimensional 𝕜 (submodule.span 𝕜 {c}) :=
+      finite_dimensional.span_of_finite 𝕜 (finite_singleton c),
+    have m1 : is_closed_map (coe : submodule.span 𝕜 {c} → E) :=
+    (submodule.span 𝕜 {c}).closed_of_finite_dimensional.closed_embedding_subtype_coe.is_closed_map,
+    have m2 : is_closed_map
+      (linear_equiv.to_span_nonzero_singleton 𝕜 E c hc : 𝕜 → submodule.span 𝕜 {c}) :=
+    (continuous_linear_equiv.to_span_nonzero_singleton 𝕜 c hc).to_homeomorph.is_closed_map,
+    exact m1.comp m2 }
+end
+
 end complete_field
 
 section proper_field

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -2096,22 +2096,24 @@ section
 noncomputable theory
 open_locale classical
 
+lemma ker_to_span_singleton {x : M} (h : x ≠ 0) : (to_span_singleton K M x).ker = ⊥ :=
+begin
+  ext c, split,
+  { intros hc, rw submodule.mem_bot, rw mem_ker at hc, by_contra hc',
+    have : x = 0,
+      calc x = c⁻¹ • (c • x) : by rw [← mul_smul, inv_mul_cancel hc', one_smul]
+      ... = c⁻¹ • ((to_span_singleton K M x) c) : rfl
+      ... = 0 : by rw [hc, smul_zero],
+    tauto },
+  { rw [mem_ker, submodule.mem_bot], intros h, rw h, simp }
+end
+
 /-- Given a nonzero element `x` of a vector space `M` over a field `K`, the natural
     map from `K` to the span of `x`, with invertibility check to consider it as an
     isomorphism.-/
 def to_span_nonzero_singleton (x : M) (h : x ≠ 0) : K ≃ₗ[K] (submodule.span K ({x} : set M)) :=
 linear_equiv.trans
-  ( linear_equiv.of_injective (to_span_singleton K M x)
-    begin
-      ext c, split,
-      { intros hc, rw submodule.mem_bot, rw mem_ker at hc, by_contra hc',
-        have : x = 0,
-          calc x = c⁻¹ • (c • x) : by rw [← mul_smul, inv_mul_cancel hc', one_smul]
-          ... = c⁻¹ • ((to_span_singleton K M x) c) : rfl
-          ... = 0 : by rw [hc, smul_zero],
-        tauto },
-      { rw [mem_ker, submodule.mem_bot], intros h, rw h, simp }
-    end )
+  (linear_equiv.of_injective (to_span_singleton K M x) (ker_to_span_singleton K M h))
   (of_eq (to_span_singleton K M x).range (submodule.span K {x}) (span_singleton_eq_range K M x).symm)
 
 lemma to_span_nonzero_singleton_one (x : M) (h : x ≠ 0) : to_span_nonzero_singleton K M x h 1

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
 import measure_theory.measure_space
-import analysis.normed_space.hahn_banach
+import analysis.normed_space.finite_dimension
 /-!
 # Borel (measurable) space
 
@@ -197,6 +197,9 @@ begin
   by_cases h2 : s = univ, { simp [h2] },
   exact hf s hs h1 h2
 end
+
+lemma is_pi_system_is_open : is_pi_system (is_open : set α → Prop) :=
+λ s t hs ht hst, is_open_inter hs ht
 
 instance nhds_is_measurably_generated (a : α) : (𝓝 a).is_measurably_generated :=
 begin
@@ -921,15 +924,17 @@ variables [second_countable_topology E] [normed_space ℝ E] [borel_space E]
 
 /-- Currently we only prove this lemma with `ℝ` as the base field, and use Hahn-Banach in the proof.
  In the future we might be able to generalize the statement and give a more elementary proof. -/
-lemma measurable_smul_const {f : α → ℝ} {c : E} (hc : c ≠ 0) :
+lemma measurable_smul_const {𝕜 : Type*} [nondiscrete_normed_field 𝕜] {E : Type*} [normed_group E]
+  [normed_space 𝕜 E] [complete_space 𝕜] [measurable_space 𝕜] [borel_space 𝕜] [second_countable_topology 𝕜] [measurable_space E] [borel_space E] [second_countable_topology E]
+  {f : α → 𝕜} {c : E} (hc : c ≠ 0) :
   measurable (λ x, f x • c) ↔ measurable f :=
 begin
   refine ⟨λ hf, _, λ hf, hf.smul measurable_const⟩,
-  obtain ⟨g : E →L[ℝ] ℝ, h1g, h2g⟩ := exists_dual_vector c hc; [skip, apply_instance, apply_instance],
-  have := (g.measurable.comp hf).mul measurable_const, swap, exact ∥c∥⁻¹,
-  convert this, ext x,
-  have : ∥c∥ ≠ 0 := mt norm_eq_zero.mp hc,
-  simp [h2g, mul_inv_cancel_right' this, norm'],
+  apply measurable_of_is_closed, intros s hs,
+  have : is_closed ((λ x, x • c) '' s) := is_closed_map_smul_left 𝕜 c s hs,
+  convert hf this.is_measurable, rw [@preimage_comp _ _ _ f (• c), preimage_image_eq],
+  show function.injective (λ x : 𝕜, x • c),
+  exact ker_eq_bot.mp (ker_to_span_singleton 𝕜 E hc)
 end
 end normed_space
 

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -919,13 +919,12 @@ L.measurable.comp φ_meas
 end continuous_linear_map
 
 section normed_space
-variables {E : Type*} [measurable_space E] [normed_group E]
-variables [second_countable_topology E] [normed_space ℝ E] [borel_space E]
+variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜] [complete_space 𝕜] [measurable_space 𝕜]
+variables [borel_space 𝕜] [second_countable_topology 𝕜]
+variables {E : Type*} [normed_group E] [normed_space 𝕜 E] [measurable_space E] [borel_space E]
+variables [second_countable_topology E]
 
-/-- Currently we only prove this lemma with `ℝ` as the base field, and use Hahn-Banach in the proof.
- In the future we might be able to generalize the statement and give a more elementary proof. -/
-lemma measurable_smul_const {𝕜 : Type*} [nondiscrete_normed_field 𝕜] {E : Type*} [normed_group E]
-  [normed_space 𝕜 E] [complete_space 𝕜] [measurable_space 𝕜] [borel_space 𝕜] [second_countable_topology 𝕜] [measurable_space E] [borel_space E] [second_countable_topology E]
+lemma measurable_smul_const
   {f : α → 𝕜} {c : E} (hc : c ≠ 0) :
   measurable (λ x, f x • c) ↔ measurable f :=
 begin
@@ -936,6 +935,7 @@ begin
   show function.injective (λ x : 𝕜, x • c),
   exact ker_eq_bot.mp (ker_to_span_singleton 𝕜 E hc)
 end
+
 end normed_space
 
 namespace measure_theory

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -32,7 +32,7 @@ import analysis.normed_space.finite_dimension
 
 noncomputable theory
 
-open classical set function
+open classical set
 open_locale classical big_operators topological_space
 
 universes u v w x y

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -414,6 +414,7 @@ lemma measurable.mul [has_mul α] [has_continuous_mul α] [second_countable_topo
   {f : δ → α} {g : δ → α} : measurable f → measurable g → measurable (λa, f a * g a) :=
 continuous_mul.measurable2
 
+/-- A variant of `measurable.mul` that uses `*` on functions -/
 @[to_additive]
 lemma measurable.mul' [has_mul α] [has_continuous_mul α] [second_countable_topology α]
   {f : δ → α} {g : δ → α} : measurable f → measurable g → measurable (f * g) :=
@@ -511,20 +512,6 @@ begin
   assumption
 end
 
-lemma measurable_of_is_measurable_lt {f : δ → α} (hf : ∀ y, is_measurable {x | f x < y}) :
-  measurable f :=
-begin
-  rw [‹borel_space α›.measurable_eq, borel_eq_generate_Iio],
-  apply measurable_generate_from, rintro _ ⟨y, rfl⟩, exact hf y
-end
-
-lemma measurable_of_is_measurable_le {f : δ → α} (hf : ∀ y, is_measurable {x | f x ≤ y}) :
-  measurable f :=
-begin
-  rw [‹borel_space α›.measurable_eq, borel_eq_generate_Ioi],
-  apply measurable_generate_from, rintro _ ⟨y, rfl⟩, convert (hf y).compl, simp [compl_set_of, Ioi]
-end
-
 lemma measurable.is_lub {ι} [encodable ι] {f : ι → δ → α} {g : δ → α} (hf : ∀ i, measurable (f i))
   (hg : ∀ b, is_lub {a | ∃ i, f i b = a} (g b)) :
   measurable g :=
@@ -599,11 +586,9 @@ lemma measurable_cSup {ι} {f : ι → δ → α} {s : set ι} (hs : s.countable
 begin
   cases eq_empty_or_nonempty s with h2s h2s,
   { simp [h2s, measurable_const] },
-  { apply measurable_of_is_measurable_le, intro y,
-    have : is_measurable {x : δ | ∀ (i : ι), i ∈ s → f i x ≤ y},
-    { simp_rw set_of_forall,
-      exact is_measurable.bInter hs (λ i hi, is_measurable_le (hf i) measurable_const) },
-    convert this, ext x, simp_rw [cSup_le_iff (bdd x) (h2s.image _), ball_image_iff] }
+  { apply measurable_of_Iic, intro y,
+    simp_rw [preimage, mem_Iic, cSup_le_iff (bdd _) (h2s.image _), ball_image_iff, set_of_forall],
+    exact is_measurable.bInter hs (λ i hi, is_measurable_le (hf i) measurable_const) }
 end
 
 end conditionally_complete_linear_order

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -82,7 +82,7 @@ le_antisymm
   (generate_from_le $ assume u hu, generate_measurable.basic _ $
     show t.is_open u, by rw [hs]; exact generate_open.basic _ hu)
 
-lemma is_pi_system_is_open : is_pi_system (is_open : set α → Prop) :=
+lemma is_pi_system_is_open [topological_space α] : is_pi_system (is_open : set α → Prop) :=
 λ s t hs ht hst, is_open_inter hs ht
 
 section order_topology

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -82,6 +82,9 @@ le_antisymm
   (generate_from_le $ assume u hu, generate_measurable.basic _ $
     show t.is_open u, by rw [hs]; exact generate_open.basic _ hu)
 
+lemma is_pi_system_is_open : is_pi_system (is_open : set α → Prop) :=
+λ s t hs ht hst, is_open_inter hs ht
+
 section order_topology
 
 variable (α)
@@ -198,9 +201,6 @@ begin
   by_cases h2 : s = univ, { simp [h2] },
   exact hf s hs h1 h2
 end
-
-lemma is_pi_system_is_open : is_pi_system (is_open : set α → Prop) :=
-λ s t hs ht hst, is_open_inter hs ht
 
 instance nhds_is_measurably_generated (a : α) : (𝓝 a).is_measurably_generated :=
 begin
@@ -932,9 +932,8 @@ end continuous_linear_map
 
 section normed_space
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜] [complete_space 𝕜] [measurable_space 𝕜]
-variables [borel_space 𝕜] [second_countable_topology 𝕜]
+variables [borel_space 𝕜]
 variables {E : Type*} [normed_group E] [normed_space 𝕜 E] [measurable_space E] [borel_space E]
-variables [second_countable_topology E]
 
 lemma measurable_smul_const {f : α → 𝕜} {c : E} (hc : c ≠ 0) :
   measurable (λ x, f x • c) ↔ measurable f :=

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -32,7 +32,7 @@ import analysis.normed_space.finite_dimension
 
 noncomputable theory
 
-open classical set
+open classical set function
 open_locale classical big_operators topological_space
 
 universes u v w x y
@@ -84,7 +84,8 @@ le_antisymm
 
 section order_topology
 
-variables (α) [topological_space α] [second_countable_topology α] [linear_order α] [order_topology α]
+variable (α)
+variables [topological_space α] [second_countable_topology α] [linear_order α] [order_topology α]
 
 lemma borel_eq_generate_Iio : borel α = generate_from (range Iio) :=
 begin
@@ -469,6 +470,15 @@ lemma measurable.sub [add_group α] [topological_add_group α] [second_countable
   measurable (λ x, f x - g x) :=
 hf.add hg.neg
 
+lemma measurable_comp_iff_of_closed_embedding {f : δ → β} (g : β → γ) (hg : closed_embedding g) :
+  measurable (g ∘ f) ↔ measurable f :=
+begin
+  refine ⟨λ hf, _, λ hf, hg.continuous.measurable.comp hf⟩,
+  apply measurable_of_is_closed, intros s hs,
+  convert hf (hg.is_closed_map s hs).is_measurable,
+  rw [@preimage_comp _ _ _ f g, preimage_image_eq _ hg.to_embedding.inj]
+end
+
 section linear_order
 
 variables [linear_order α] [order_topology α] [second_countable_topology α]
@@ -708,7 +718,8 @@ begin
     (subset.refl _) _ _ _ _,
   { simp only [is_pi_system, mem_Union, mem_singleton_iff],
     rintros _ _ ⟨a₁, b₁, h₁, rfl⟩ ⟨a₂, b₂, h₂, rfl⟩ ne,
-    simp only [Ioo_inter_Ioo, sup_eq_max, inf_eq_min, ← rat.cast_max, ← rat.cast_min, nonempty_Ioo] at ne ⊢,
+    simp only [Ioo_inter_Ioo, sup_eq_max, inf_eq_min, ← rat.cast_max, ← rat.cast_min,
+      nonempty_Ioo] at ne ⊢,
     refine ⟨_, _, _, rfl⟩,
     assumption_mod_cast },
   { exact countable_Union (λ a, (countable_encodable _).bUnion $ λ _ _, countable_singleton _) },
@@ -906,7 +917,8 @@ end normed_group
 namespace continuous_linear_map
 
 variables {𝕜 : Type*} [normed_field 𝕜]
-variables {E : Type*} [normed_group E] [normed_space 𝕜 E] [measurable_space E] [opens_measurable_space E]
+variables {E : Type*} [normed_group E] [normed_space 𝕜 E] [measurable_space E]
+variables [opens_measurable_space E]
 variables {F : Type*} [normed_group F] [normed_space 𝕜 F] [measurable_space F] [borel_space F]
 
 protected lemma measurable (L : E →L[𝕜] F) : measurable L :=
@@ -924,17 +936,9 @@ variables [borel_space 𝕜] [second_countable_topology 𝕜]
 variables {E : Type*} [normed_group E] [normed_space 𝕜 E] [measurable_space E] [borel_space E]
 variables [second_countable_topology E]
 
-lemma measurable_smul_const
-  {f : α → 𝕜} {c : E} (hc : c ≠ 0) :
+lemma measurable_smul_const {f : α → 𝕜} {c : E} (hc : c ≠ 0) :
   measurable (λ x, f x • c) ↔ measurable f :=
-begin
-  refine ⟨λ hf, _, λ hf, hf.smul measurable_const⟩,
-  apply measurable_of_is_closed, intros s hs,
-  have : is_closed ((λ x, x • c) '' s) := is_closed_map_smul_left 𝕜 c s hs,
-  convert hf this.is_measurable, rw [@preimage_comp _ _ _ f (• c), preimage_image_eq],
-  show function.injective (λ x : 𝕜, x • c),
-  exact ker_eq_bot.mp (ker_to_span_singleton 𝕜 E hc)
-end
+measurable_comp_iff_of_closed_embedding (λ y : 𝕜, y • c) (closed_embedding_smul_left hc)
 
 end normed_space
 

--- a/src/measure_theory/giry_monad.lean
+++ b/src/measure_theory/giry_monad.lean
@@ -53,6 +53,10 @@ lemma measurable_of_measurable_coe (f : β → measure α)
 measurable.of_le_map $ supr_le $ assume s, supr_le $ assume hs, measurable_space.comap_le_iff_le_map.2 $
   by rw [measurable_space.map_comp]; exact h s hs
 
+lemma measurable_measure {μ : α → measure β} :
+  measurable μ ↔ ∀(s : set β) (hs : is_measurable s), measurable (λb, μ b s) :=
+⟨λ hμ s hs, (measurable_coe hs).comp hμ, measurable_of_measurable_coe μ⟩
+
 lemma measurable_map (f : α → β) (hf : measurable f) :
   measurable (λμ : measure α, map f μ) :=
 measurable_of_measurable_coe _ $ assume s hs,

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -1279,7 +1279,7 @@ calc
      by simp only [liminf_eq_supr_infi_of_nat]
   ... = ⨆n:ℕ, ∫⁻ a, ⨅i≥n, f i a ∂μ :
     lintegral_supr
-      (assume n, measurable_binfi _ h_meas)
+      (assume n, measurable_binfi _ (countable_encodable _) h_meas)
       (assume n m hnm a, infi_le_infi_of_subset $ λ i hi, le_trans hnm hi)
   ... ≤ ⨆n:ℕ, ⨅i≥n, ∫⁻ a, f i a ∂μ :
     supr_le_supr $ λ n, le_infi2_lintegral _
@@ -1296,7 +1296,7 @@ calc
   ... = ∫⁻ a, ⨅n:ℕ, ⨆i≥n, f i a ∂μ :
     begin
       refine (lintegral_infi _ _ _).symm,
-      { assume n, exact measurable_bsupr _ hf_meas },
+      { assume n, exact measurable_bsupr _ (countable_encodable _) hf_meas },
       { assume n m hnm a, exact (supr_le_supr_of_subset $ λ i hi, le_trans hnm hi) },
       { refine lt_of_le_of_lt (lintegral_mono_ae _) h_fin,
         refine (ae_all_iff.2 h_bound).mono (λ n hn, _),

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -1127,7 +1127,7 @@ lemma induction_on_inter {C : set α → Prop} {s : set (set α)} [m : measurabl
   (h_empty : C ∅) (h_basic : ∀t∈s, C t) (h_compl : ∀t, is_measurable t → C t → C tᶜ)
   (h_union : ∀f:ℕ → set α, pairwise (disjoint on f) →
     (∀i, is_measurable (f i)) → (∀i, C (f i)) → C (⋃i, f i)) :
-  ∀{t}, is_measurable t → C t :=
+  ∀ ⦃t⦄, is_measurable t → C t :=
 have eq : is_measurable = dynkin_system.generate_has s,
   by { rw [h_eq, dynkin_system.generate_from_eq h_inter], refl },
 assume t ht,

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -62,7 +62,7 @@ measurable space, measurable function, dynkin system
 -/
 
 local attribute [instance] classical.prop_decidable
-open set encodable
+open set encodable function
 open_locale classical filter
 
 universes u v w x
@@ -608,9 +608,33 @@ measurable.of_le_map $ sup_le
   (by { rw [measurable_space.comap_le_iff_le_map, measurable_space.map_comp], exact hf₁ })
   (by { rw [measurable_space.comap_le_iff_le_map, measurable_space.map_comp], exact hf₂ })
 
+lemma measurable_prod {f : α → β × γ} : measurable f ↔
+  measurable (λa, (f a).1) ∧ measurable (λa, (f a).2) :=
+⟨λ hf, ⟨measurable_fst.comp hf, measurable_snd.comp hf⟩, λ h, measurable.prod h.1 h.2⟩
+
 lemma measurable.prod_mk {f : α → β} {g : α → γ} (hf : measurable f) (hg : measurable g) :
   measurable (λa:α, (f a, g a)) :=
 measurable.prod hf hg
+
+lemma measurable_prod_mk_left {x : α} : measurable (@prod.mk _ β x) :=
+measurable_const.prod_mk measurable_id
+
+lemma measurable_prod_mk_right {y : β} : measurable (λ x : α, (x, y)) :=
+measurable_id.prod_mk measurable_const
+
+lemma measurable.of_uncurry_left {f : α → β → γ} (hf : measurable (uncurry f)) {x : α} :
+  measurable (f x) :=
+hf.comp measurable_prod_mk_left
+
+lemma measurable.of_uncurry_right {f : α → β → γ} (hf : measurable (uncurry f)) {y : β} :
+  measurable (λ x, f x y) :=
+hf.comp measurable_prod_mk_right
+
+lemma measurable_swap : measurable (prod.swap : α × β → β × α) :=
+measurable.prod measurable_snd measurable_fst
+
+lemma measurable_swap_iff {f : α × β → γ} : measurable (f ∘ prod.swap) ↔ measurable f :=
+⟨λ hf, by { convert hf.comp measurable_swap, ext ⟨x, y⟩, refl }, λ hf, hf.comp measurable_swap⟩
 
 lemma is_measurable.prod {s : set α} {t : set β} (hs : is_measurable s) (ht : is_measurable t) :
   is_measurable (s.prod t) :=
@@ -633,6 +657,10 @@ begin
   { simp [h, prod_eq_empty_iff.mp h] },
   { simp [←not_nonempty_iff_eq_empty, prod_nonempty_iff.mp h, is_measurable_prod_of_nonempty h] }
 end
+
+lemma is_measurable_swap_iff {s : set (α × β)} :
+  is_measurable (prod.swap ⁻¹' s) ↔ is_measurable s :=
+⟨λ hs, by { convert measurable_swap hs, ext ⟨x, y⟩, refl }, λ hs, measurable_swap hs⟩
 
 end prod
 

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -268,9 +268,9 @@ begin
   refine ⟨λ hfg, _, λ h, h.1.add h.2⟩,
   rw [← indicator_add_eq_left h],
   conv { congr, skip, rw [← indicator_add_eq_right h] },
-  rw [integrable_indicator_iff _ (hf (is_measurable_singleton 0)).compl],
-  rw [integrable_indicator_iff _ (hg (is_measurable_singleton 0)).compl],
-  exact ⟨hfg.integrable_on, hfg.integrable_on⟩, exact hf.add hg, exact hf.add hg
+  rw [integrable_indicator_iff (hf.add' hg) (hf (is_measurable_singleton 0)).compl],
+  rw [integrable_indicator_iff (hf.add' hg) (hg (is_measurable_singleton 0)).compl],
+  exact ⟨hfg.integrable_on, hfg.integrable_on⟩
 end
 
 /-- To prove something for an arbitrary measurable + integrable function in a second countable

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -151,6 +151,10 @@ protected def homeomorph.smul_of_ne_zero (ha : a ≠ 0) : M ≃ₜ M :=
 lemma is_open_map_smul_of_ne_zero (ha : a ≠ 0) : is_open_map (λ (x : M), a • x) :=
 (homeomorph.smul_of_ne_zero ha).is_open_map
 
+/-- `smul` is a closed map in the second argument.
+
+The lemma that `smul` is a closed map in the first argument (in a special case) is
+`is_closed_map_smul_left` in `analysis.normed_space.finite_dimension`. -/
 lemma is_closed_map_smul_of_ne_zero (ha : a ≠ 0) : is_closed_map (λ (x : M), a • x) :=
 (homeomorph.smul_of_ne_zero ha).is_closed_map
 

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -153,8 +153,8 @@ lemma is_open_map_smul_of_ne_zero (ha : a ≠ 0) : is_open_map (λ (x : M), a �
 
 /-- `smul` is a closed map in the second argument.
 
-The lemma that `smul` is a closed map in the first argument (for a complete normed space) is
-`is_closed_map_smul_left` in `analysis.normed_space.finite_dimension`. -/
+The lemma that `smul` is a closed map in the first argument (for a normed space over a complete
+normed field) is `is_closed_map_smul_left` in `analysis.normed_space.finite_dimension`. -/
 lemma is_closed_map_smul_of_ne_zero (ha : a ≠ 0) : is_closed_map (λ (x : M), a • x) :=
 (homeomorph.smul_of_ne_zero ha).is_closed_map
 

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -153,7 +153,7 @@ lemma is_open_map_smul_of_ne_zero (ha : a ≠ 0) : is_open_map (λ (x : M), a �
 
 /-- `smul` is a closed map in the second argument.
 
-The lemma that `smul` is a closed map in the first argument (in a special case) is
+The lemma that `smul` is a closed map in the first argument (for a complete normed space) is
 `is_closed_map_smul_left` in `analysis.normed_space.finite_dimension`. -/
 lemma is_closed_map_smul_of_ne_zero (ha : a ≠ 0) : is_closed_map (λ (x : M), a • x) :=
 (homeomorph.smul_of_ne_zero ha).is_closed_map

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -123,6 +123,9 @@ begin
   exact continuous_iff_is_closed.1 (h.symm.continuous) _
 end
 
+protected lemma closed_embedding (h : α ≃ₜ β) : closed_embedding h :=
+closed_embedding_of_embedding_closed h.embedding h.is_closed_map
+
 @[simp] lemma is_open_preimage (h : α ≃ₜ β) {s : set β} : is_open (h ⁻¹' s) ↔ is_open s :=
 begin
   refine ⟨λ hs, _, h.continuous_to_fun s⟩,

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -271,6 +271,14 @@ assume s hs,
 have f' ⁻¹' s = f '' s, by ext x; simp [mem_image_iff_of_inverse r_inv l_inv],
 this ▸ continuous_iff_is_closed.mp h s hs
 
+lemma of_nonempty {f : α → β} (h : ∀ s, is_closed s → s.nonempty → is_closed (f '' s)) :
+  is_closed_map f :=
+begin
+  intros s hs, cases eq_empty_or_nonempty s with h2s h2s,
+  { simp_rw [h2s, image_empty, is_closed_empty] },
+  { exact h s hs h2s }
+end
+
 end is_closed_map
 
 section open_embedding

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -84,6 +84,12 @@ mem_nhds_sets is_closed_singleton $ by rwa [mem_compl_eq, mem_singleton_iff]
   closure ({a} : set α) = {a} :=
 is_closed_singleton.closure_eq
 
+lemma is_closed_map_const {α β} [topological_space α] [topological_space β] [t1_space β] {y : β} :
+  is_closed_map (function.const α y) :=
+begin
+  apply is_closed_map.of_nonempty, intros s hs h2s, simp_rw [h2s.image_const, is_closed_singleton]
+end
+
 /-- A T₂ space, also known as a Hausdorff space, is one in which for every
   `x ≠ y` there exists disjoint open sets around `x` and `y`. This is
   the most widely used of the separation axioms. -/


### PR DESCRIPTION
Mostly additions to `borel_space`.
Generalize `measurable_bsupr` and `measurable_binfi` to countable sets (instead of encodable underlying types). Use the lemma `countable_encodable` to get the original behavior.
Some cleanup in `borel_space`: more instances are in `variables`, and lemmas with the same instances a bit more.
One downside: there is a big import bump in `borel_space`, it currently imports `hahn_banach`. This is (only) used in `measurable_smul_const`. If someone has a proof sketch (in math) of `measurable_smul_const` that doesn't involve Hahn Banach (and that maybe generalizes `real` to a topological field or something), please let me know.

---
<!-- put comments you want to keep out of the PR commit here -->
