### PR TITLE
feat(docs/*.yaml): linking to minimal polynomials

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -140,6 +140,7 @@ Linear algebra:
     determinant: 'matrix.det'
     invertibility: 'matrix.nonsing_inv'
   Endomorphism polynomials:
+    minimal polynomial: 'minimal_polynomial f.is_integral'
     characteristic polynomial: 'char_poly'
     Cayley-Hamilton theorem: 'aeval_self_char_poly'
   Structure theory of endomorphisms:

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -52,7 +52,7 @@ Linear algebra:
     row-reduced matrices: ''
   Endomorphism polynomials:
     annihilating polynomials: ''
-    minimal polynomial: ''
+    minimal polynomial: 'minimal_polynomial f.is_integral'
     characteristic polynomial: 'char_poly'
     Cayley-Hamilton theorem: 'aeval_self_char_poly'
   Structure theory of endomorphisms:


### PR DESCRIPTION
adds `minimal_polynomial f.is_integral` as the decl for minimal polynomials in `overview.yaml` and `undergrad.yaml`

---
<!-- put comments you want to keep out of the PR commit here -->
