### PR TITLE
[Merged by Bors] - chore(order/filter/archimedean): move&generalize a few lemmas

### DIFF
--- a/src/algebra/archimedean.lean
+++ b/src/algebra/archimedean.lean
@@ -21,6 +21,10 @@ let ⟨n, h⟩ := archimedean.arch x zero_lt_one in
 ⟨n+1, lt_of_le_of_lt (by rwa ← nsmul_one)
   (nat.cast_lt.2 (nat.lt_succ_self _))⟩
 
+theorem exists_nat_ge [linear_ordered_semiring α] [archimedean α] (x : α) :
+  ∃ n : ℕ, x ≤ n :=
+(exists_nat_gt x).imp $ λ n, le_of_lt
+
 lemma add_one_pow_unbounded_of_pos [linear_ordered_semiring α] [archimedean α] (x : α) {y : α}
   (hy : 0 < y) :
   ∃ n : ℕ, x < (y + 1) ^ n :=

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -2,13 +2,16 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
-
-A collection of specific limit computations.
 -/
 import analysis.normed_space.basic
 import algebra.geom_sum
+import order.filter.archimedean
 import topology.instances.ennreal
 import tactic.ring_exp
+
+/-!
+# A collection of specific limit computations
+-/
 
 noncomputable theory
 open_locale classical topological_space
@@ -32,7 +35,7 @@ lemma summable_of_absolute_convergence_real {f : ℕ → ℝ} :
   end
 
 lemma tendsto_inverse_at_top_nhds_0_nat : tendsto (λ n : ℕ, (n : ℝ)⁻¹) at_top (𝓝 0) :=
-tendsto_inv_at_top_zero.comp (tendsto_coe_nat_real_at_top_iff.2 tendsto_id)
+tendsto_inv_at_top_zero.comp tendsto_coe_nat_at_top_at_top
 
 lemma tendsto_const_div_at_top_nhds_0_nat (C : ℝ) : tendsto (λ n : ℕ, C / n) at_top (𝓝 0) :=
 by simpa only [mul_zero] using tendsto_const_nhds.mul tendsto_inverse_at_top_nhds_0_nat
@@ -617,5 +620,5 @@ begin
   apply tendsto_at_top_mono self_div_two_le_harmonic_two_pow,
   apply tendsto_at_top_div,
   norm_num,
-  exact tendsto_coe_nat_real_at_top_at_top
+  exact tendsto_coe_nat_at_top_at_top
 end

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -363,7 +363,7 @@ instance : char_zero ennreal := ⟨coe_nat_mono.injective⟩
 
 protected lemma exists_nat_gt {r : ennreal} (h : r ≠ ⊤) : ∃n:ℕ, r < n :=
 begin
-  rcases lt_iff_exists_coe.1 (lt_top_iff_ne_top.2 h) with ⟨r, rfl, hb⟩,
+  lift r to nnreal using h,
   rcases exists_nat_gt r with ⟨n, hn⟩,
   exact ⟨n, coe_lt_coe_nat.2 hn⟩,
 end

--- a/src/order/filter/archimedean.lean
+++ b/src/order/filter/archimedean.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2019 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Yury Kudryashov
+-/
+import order.filter.at_top_bot
+import algebra.archimedean
+
+/-!
+# `at_top` filter and archimedean (semi)rings/fields
+
+In this file we prove that for a linear ordered archimedean semiring `R` and a function `f : α → ℕ`,
+the function `coe ∘ f : α → R` tends to `at_top` along a filter `l` if and only if so does `f`.
+We also prove that `coe : ℕ → R` tends to `at_top` along `at_top`, as well as version of these
+two results for `ℤ` (and a ring `R`) and `ℚ` (and a field `R`).
+-/
+
+variables {α R : Type*}
+
+open filter
+
+lemma tendsto_coe_nat_at_top_iff [linear_ordered_semiring R] [archimedean R]
+  {f : α → ℕ} {l : filter α} :
+  tendsto (λ n, (f n : R)) l at_top ↔ tendsto f l at_top :=
+tendsto_at_top_embedding (assume a₁ a₂, nat.cast_le) exists_nat_ge
+
+lemma tendsto_coe_nat_at_top_at_top [linear_ordered_semiring R] [archimedean R] :
+  tendsto (coe : ℕ → R) at_top at_top :=
+tendsto_coe_nat_at_top_iff.2 tendsto_id
+
+lemma tendsto_coe_int_at_top_iff [linear_ordered_ring R] [archimedean R]
+  {f : α → ℤ} {l : filter α} :
+  tendsto (λ n, (f n : R)) l at_top ↔ tendsto f l at_top :=
+tendsto_at_top_embedding (assume a₁ a₂, int.cast_le) $
+  assume r, let ⟨n, hn⟩ := exists_nat_ge r in ⟨(n:ℤ), hn⟩
+
+lemma tendsto_coe_int_at_top_at_top [linear_ordered_ring R] [archimedean R] :
+  tendsto (coe : ℤ → R) at_top at_top :=
+tendsto_coe_int_at_top_iff.2 tendsto_id
+
+lemma tendsto_coe_rat_at_top_iff [linear_ordered_field R] [archimedean R]
+  {f : α → ℚ} {l : filter α} :
+  tendsto (λ n, (f n : R)) l at_top ↔ tendsto f l at_top :=
+tendsto_at_top_embedding (assume a₁ a₂, rat.cast_le) $
+  assume r, let ⟨n, hn⟩ := exists_nat_ge r in ⟨(n:ℚ), by assumption_mod_cast⟩

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -522,35 +522,6 @@ theorem tendsto_at_bot_principal [nonempty β] [semilattice_inf β] {f : β → 
 @tendsto_at_top_principal _ (order_dual β) _ _ _ _
 
 /-- A function `f` grows to `+∞` independent of an order-preserving embedding `e`. -/
-lemma tendsto_at_top_embedding [preorder β] [preorder γ]
-  {f : α → β} {e : β → γ} {l : filter α}
-  (hm : ∀b₁ b₂, e b₁ ≤ e b₂ ↔ b₁ ≤ b₂) (hu : ∀c, ∃b, c ≤ e b) :
-  tendsto (e ∘ f) l at_top ↔ tendsto f l at_top :=
-begin
-  rw [tendsto_at_top, tendsto_at_top],
-  split,
-  { assume hc b,
-    filter_upwards [hc (e b)] assume a, (hm b (f a)).1 },
-  { assume hb c,
-    rcases hu c with ⟨b, hc⟩,
-    filter_upwards [hb b] assume a ha, le_trans hc ((hm b (f a)).2 ha) }
-end
-
-/-- A function `f` goes to `-∞` independent of an order-preserving embedding `e`. -/
-lemma tendsto_at_bot_embedding [preorder β] [preorder γ]
-  {f : α → β} {e : β → γ} {l : filter α}
-  (hm : ∀b₁ b₂, e b₁ ≤ e b₂ ↔ b₁ ≤ b₂) (hu : ∀c, ∃b, e b ≤ c) :
-  tendsto (e ∘ f) l at_bot ↔ tendsto f l at_bot :=
-begin
-  rw [tendsto_at_bot, tendsto_at_bot],
-  split,
-  { assume hc b,
-    filter_upwards [hc (e b)] assume a, (hm (f a) b).1 },
-  { assume hb c,
-    rcases hu c with ⟨b, hc⟩,
-    filter_upwards [hb b] assume a ha, le_trans ((hm (f a) b).2 ha) hc }
-end
-
 lemma tendsto_at_top_at_top [nonempty α] [semilattice_sup α] [preorder β] (f : α → β) :
   tendsto f at_top at_top ↔ ∀ b : β, ∃ i : α, ∀ a : α, i ≤ a → b ≤ f a :=
 iff.trans tendsto_infi $ forall_congr $ assume b, tendsto_at_top_principal
@@ -595,6 +566,23 @@ alias tendsto_at_top_at_top_of_monotone ← monotone.tendsto_at_top_at_top
 alias tendsto_at_bot_at_bot_of_monotone ← monotone.tendsto_at_bot_at_bot
 alias tendsto_at_top_at_top_iff_of_monotone ← monotone.tendsto_at_top_at_top_iff
 alias tendsto_at_bot_at_bot_iff_of_monotone ← monotone.tendsto_at_bot_at_bot_iff
+
+lemma tendsto_at_top_embedding [preorder β] [preorder γ]
+  {f : α → β} {e : β → γ} {l : filter α}
+  (hm : ∀b₁ b₂, e b₁ ≤ e b₂ ↔ b₁ ≤ b₂) (hu : ∀c, ∃b, c ≤ e b) :
+  tendsto (e ∘ f) l at_top ↔ tendsto f l at_top :=
+begin
+  refine ⟨_, (tendsto_at_top_at_top_of_monotone (λ b₁ b₂, (hm b₁ b₂).2) hu).comp⟩,
+  rw [tendsto_at_top, tendsto_at_top],
+  exact λ hc b, (hc (e b)).mono (λ a, (hm b (f a)).1)
+end
+
+/-- A function `f` goes to `-∞` independent of an order-preserving embedding `e`. -/
+lemma tendsto_at_bot_embedding [preorder β] [preorder γ]
+  {f : α → β} {e : β → γ} {l : filter α}
+  (hm : ∀b₁ b₂, e b₁ ≤ e b₂ ↔ b₁ ≤ b₂) (hu : ∀c, ∃b, e b ≤ c) :
+  tendsto (e ∘ f) l at_bot ↔ tendsto f l at_bot :=
+@tendsto_at_top_embedding α (order_dual β) (order_dual γ) _ _ f e l (function.swap hm) hu
 
 lemma tendsto_finset_range : tendsto finset.range at_top at_top :=
 finset.range_mono.tendsto_at_top_at_top finset.exists_nat_subset_range

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -263,23 +263,6 @@ begin
   refine this.imp (λ N hN n hn, hε (hN n hn))
 end
 
-lemma tendsto_coe_nat_real_at_top_iff {f : α → ℕ} {l : filter α} :
-  tendsto (λ n, (f n : ℝ)) l at_top ↔ tendsto f l at_top :=
-tendsto_at_top_embedding (assume a₁ a₂, nat.cast_le) $
-  assume r, let ⟨n, hn⟩ := exists_nat_gt r in ⟨n, le_of_lt hn⟩
-
-lemma tendsto_coe_nat_real_at_top_at_top : tendsto (coe : ℕ → ℝ) at_top at_top :=
-tendsto_coe_nat_real_at_top_iff.2 tendsto_id
-
-lemma tendsto_coe_int_real_at_top_iff {f : α → ℤ} {l : filter α} :
-  tendsto (λ n, (f n : ℝ)) l at_top ↔ tendsto f l at_top :=
-tendsto_at_top_embedding (assume a₁ a₂, int.cast_le) $
-  assume r, let ⟨n, hn⟩ := exists_nat_gt r in
-  ⟨(n:ℤ), le_of_lt $ by rwa [int.cast_coe_nat]⟩
-
-lemma tendsto_coe_int_real_at_top_at_top : tendsto (coe : ℤ → ℝ) at_top at_top :=
-tendsto_coe_int_real_at_top_iff.2 tendsto_id
-
 section
 
 lemma closure_of_rat_image_lt {q : ℚ} : closure ((coe:ℚ → ℝ) '' {x | q < x}) = {r | ↑q ≤ r} :=


### PR DESCRIPTION
* `tendsto_coe_nat_real_at_top_iff`: `tendsto_coe_nat_at_top_iff`,
  generalize to a linear ordered archimedean semiring;
* `tendsto_coe_nat_real_at_top_at_top`: `tendsto_coe_nat_at_top_at_top`,
  generalize to a linear ordered archimedean semiring;
* `tendsto_coe_int_real_at_top_iff`: `tendsto_coe_int_at_top_iff`,
  generalize to a linear ordered archimedean ring;
* `tendsto_coe_int_real_at_top_at_top`: `tendsto_coe_int_at_top_at_top`,
  generalize to a linear ordered archimedean ring;
* add versions for `ℚ`;
* golf the proof of `tendsto_at_top_embedding`.

---
<!-- put comments you want to keep out of the PR commit here -->