### PR TITLE
[Merged by Bors] - chore(data/list/basic): Make it clear that `forall_mem_cons` and `ball_cons` are synonyms

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -237,9 +237,9 @@ theorem forall_mem_nil (p : α → Prop) : ∀ x ∈ @nil α, p x.
   (∀ (x : α), x = a ∨ x ∈ l → p x) ↔ p a ∧ ∀ x ∈ l, p x :=
 by simp only [or_imp_distrib, forall_and_distrib, forall_eq]
 
-theorem forall_mem_cons {p : α → Prop} {a : α} {l : list α} :
+theorem forall_mem_cons : ∀ {p : α → Prop} {a : α} {l : list α},
   (∀ x ∈ a :: l, p x) ↔ p a ∧ ∀ x ∈ l, p x :=
-by simp only [mem_cons_iff, forall_mem_cons']
+ball_cons
 
 theorem forall_mem_of_forall_mem_cons {p : α → Prop} {a : α} {l : list α}
     (h : ∀ x ∈ a :: l, p x) :


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->
