### PR TITLE
[Merged by Bors] - fix(data/list/basic): Ensure that ball_cons actually works as a simp lemma

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -233,10 +233,6 @@ by { rw [insert_neg, singleton_eq], rwa [singleton_eq, mem_singleton] }
 
 theorem forall_mem_nil (p : α → Prop) : ∀ x ∈ @nil α, p x.
 
-theorem forall_mem_cons' {p : α → Prop} {a : α} {l : list α} :
-  (∀ (x : α), x = a ∨ x ∈ l → p x) ↔ p a ∧ ∀ x ∈ l, p x :=
-@forall_eq_or_imp α p (∈ l) a
-
 theorem forall_mem_cons : ∀ {p : α → Prop} {a : α} {l : list α},
   (∀ x ∈ a :: l, p x) ↔ p a ∧ ∀ x ∈ l, p x :=
 ball_cons

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -233,11 +233,6 @@ by { rw [insert_neg, singleton_eq], rwa [singleton_eq, mem_singleton] }
 
 theorem forall_mem_nil (p : α → Prop) : ∀ x ∈ @nil α, p x.
 
--- this lemma is needed to simplify the output of list.mem_cons_iff
-@[simp] theorem forall_eq_or_imp {p : α → Prop} {q : α → Prop} {a : α} :
-  (∀ (x : α), x = a ∨ q x → p x) ↔ p a ∧ ∀ (x : α), q x → p x :=
-by simp only [or_imp_distrib, forall_and_distrib, forall_eq]
-
 theorem forall_mem_cons' {p : α → Prop} {a : α} {l : list α} :
   (∀ (x : α), x = a ∨ x ∈ l → p x) ↔ p a ∧ ∀ x ∈ l, p x :=
 @forall_eq_or_imp α p (∈ l) a

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -237,9 +237,9 @@ theorem forall_mem_nil (p : α → Prop) : ∀ x ∈ @nil α, p x.
   (∀ (x : α), x = a ∨ x ∈ l → p x) ↔ p a ∧ ∀ x ∈ l, p x :=
 by simp only [or_imp_distrib, forall_and_distrib, forall_eq]
 
-theorem forall_mem_cons {p : α → Prop} {a : α} {l : list α} :
+theorem forall_mem_cons : ∀ {p : α → Prop} {a : α} {l : list α},
   (∀ x ∈ a :: l, p x) ↔ p a ∧ ∀ x ∈ l, p x :=
-by simp only [mem_cons_iff, forall_mem_cons']
+ball_cons
 
 theorem forall_mem_of_forall_mem_cons {p : α → Prop} {a : α} {l : list α}
     (h : ∀ x ∈ a :: l, p x) :

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -233,9 +233,14 @@ by { rw [insert_neg, singleton_eq], rwa [singleton_eq, mem_singleton] }
 
 theorem forall_mem_nil (p : α → Prop) : ∀ x ∈ @nil α, p x.
 
-@[simp] theorem forall_mem_cons' {p : α → Prop} {a : α} {l : list α} :
-  (∀ (x : α), x = a ∨ x ∈ l → p x) ↔ p a ∧ ∀ x ∈ l, p x :=
+-- this lemma is needed to simplify the output of list.mem_cons_iff
+@[simp] theorem forall_eq_or_imp {p : α → Prop} {q : α → Prop} {a : α} :
+  (∀ (x : α), x = a ∨ q x → p x) ↔ p a ∧ ∀ (x : α), q x → p x :=
 by simp only [or_imp_distrib, forall_and_distrib, forall_eq]
+
+theorem forall_mem_cons' {p : α → Prop} {a : α} {l : list α} :
+  (∀ (x : α), x = a ∨ x ∈ l → p x) ↔ p a ∧ ∀ x ∈ l, p x :=
+@forall_eq_or_imp α p (∈ l) a
 
 theorem forall_mem_cons : ∀ {p : α → Prop} {a : α} {l : list α},
   (∀ x ∈ a :: l, p x) ↔ p a ∧ ∀ x ∈ l, p x :=

--- a/src/data/list/chain.lean
+++ b/src/data/list/chain.lean
@@ -84,7 +84,7 @@ theorem chain_iff_pairwise (tr : transitive R) {a : α} {l : list α} :
   chain R a l ↔ pairwise R (a::l) :=
 ⟨λ c, begin
   induction c with b b c l r p IH, {exact pairwise_singleton _ _},
-  apply IH.cons _, simp only [mem_cons_iff, forall_mem_cons', r, true_and],
+  apply IH.cons _, simp only [mem_cons_iff, forall_eq_or_imp, r, true_and],
   show ∀ x ∈ l, R b x, from λ x m, (tr r (rel_of_pairwise_cons IH m)),
 end, chain_of_pairwise⟩
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -254,8 +254,8 @@ library_note "decidable namespace"
 protected theorem decidable.not_not [decidable a] : ¬¬a ↔ a :=
 iff.intro decidable.by_contradiction not_not_intro
 
-/-- The Double Negation Theorem: `¬ ¬ P` is equivalent to `P`. 
-The left-to-right direction, double negation elimination (DNE), 
+/-- The Double Negation Theorem: `¬ ¬ P` is equivalent to `P`.
+The left-to-right direction, double negation elimination (DNE),
 is classically true but not constructively. -/
 @[simp] theorem not_not : ¬¬a ↔ a := decidable.not_not
 
@@ -736,6 +736,10 @@ by simp [and_comm]
 
 @[simp] theorem forall_eq' {a' : α} : (∀a, a' = a → p a) ↔ p a' :=
 by simp [@eq_comm _ a']
+
+-- this lemma is needed to simplify the output of `list.mem_cons_iff`
+@[simp] theorem forall_eq_or_imp {a' : α} : (∀ a, a = a' ∨ q a → p a) ↔ p a' ∧ ∀ a, q a → p a :=
+by simp only [or_imp_distrib, forall_and_distrib, forall_eq]
 
 @[simp] theorem exists_eq {a' : α} : ∃ a, a = a' := ⟨_, rfl⟩
 

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1288,7 +1288,7 @@ begin
   have b0 := ne_of_gt (lt_trans zero_lt_one b1),
   refine CNF_rec b0 (λ _, by rw [CNF_zero]; exact false.elim) _ o,
   intros o o0 H IH,
-  simp only [CNF_ne_zero b0 o0, list.mem_cons_iff, list.forall_mem_cons', iff_true_intro IH, and_true],
+  simp only [CNF_ne_zero b0 o0, list.mem_cons_iff, forall_eq_or_imp, iff_true_intro IH, and_true],
   rw [div_lt (power_ne_zero _ b0), ← power_succ],
   exact lt_power_succ_log b1 _,
 end


### PR DESCRIPTION
The LHS of the simp lemma `list.ball_cons` (aka `list.forall_mem_cons`) is not in simp-normal form, as `list.mem_cons_iff` rewrites it.
This adds a new simp lemma which is the form that `list.mem_cons_iff` rewrites it to.

---
<!-- put comments you want to keep out of the PR commit here -->
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Case-bashing.20.60list.2Epairwise.60.20with.20.60simp.60/near/211276203

First commit is #4279