### PR TITLE
[Merged by Bors] - docs(overview): expand analysis

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -274,14 +274,7 @@ Analysis:
     fundamental theorem of calculus, part 1: 'interval_integral.integral_has_fderiv_at_of_tendsto_ae'
 
 Geometry:
-  Differentiable manifolds:
-    smooth manifold (with boundary and corners): 'smooth_manifold_with_corners'
-    smooth map between manifolds: 'mdifferentiable_at'
-    tangent bundle: 'tangent_bundle'
-    tangent map: 'tangent_map'
-    Lie group: 'lie_group'
-
-  Affine and Euclidian geometry:
+  Affine and Euclidean geometry:
     affine spaces: 'add_torsor'
     affine functions: 'affine_map'
     affine subspaces: 'affine_subspace'
@@ -289,6 +282,13 @@ Geometry:
     affine spans: 'span_points'
     Euclidean affine space: 'normed_add_torsor'
     angles of vectors: ' inner_product_geometry.angle'
+
+  Differentiable manifolds:
+    smooth manifold (with boundary and corners): 'smooth_manifold_with_corners'
+    smooth map between manifolds: 'mdifferentiable_at'
+    tangent bundle: 'tangent_bundle'
+    tangent map: 'tangent_map'
+    Lie group: 'lie_group'
 
   Algebraic geometry:
     prime spectrum: 'prime_spectrum'

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -245,6 +245,8 @@ Analysis:
   Convexity:
     convex functions: 'convex_on'
     characterization of convexity: 'convex_on_of_deriv2_nonneg'
+    Jensen's inequality (finite sum version): 'convex_on.map_sum_le'
+    Jensen's inequality (integral version): 'convex_on.map_integral_le'
     convexity inequalities: 'analysis/mean_inequalities.html'
     Carathéodory's theorem: 'convex_hull_eq_union'
 

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -225,18 +225,20 @@ Analysis:
     Banach open mapping theorem: 'open_mapping'
     absolutely convergent series in Banach spaces: 'summable_of_summable_norm'
     Hahn-Banach theorem: 'exists_extension_norm_eq'
-    completeness of spaces of bounded continuous normed-space-valued functions: 'bounded_continuous_function.complete_space'
+    dual of a normed space: 'normed_space.dual'
+    isometric inclusion in double dual: 'normed_space.inclusion_in_double_dual_isometry'
+    completeness of spaces of bounded continuous functions: 'bounded_continuous_function.complete_space'
 
   Differentiability:
-    differentiable functions between normed vector spaces: 'has_deriv_at'
-    derivative of a composite function: 'deriv.comp'
-    derivative of a reciprocal function: 'has_strict_deriv_at.of_local_left_inverse'
+    differentiable functions between normed vector spaces: 'has_fderiv_at'
+    derivative of a composition of functions: 'has_fderiv_at.comp'
+    derivative of the inverse of a function: 'has_fderiv_at.of_local_left_inverse'
     Rolle's theorem: 'exists_deriv_eq_zero'
     mean value theorem: 'exists_ratio_deriv_eq_ratio_slope'
     $C^k$ functions: 'times_cont_diff'
-    Leibniz formula: 'deriv_mul'
+    Leibniz formula: 'fderiv_mul'
     local extrema: 'is_local_min.fderiv_eq_zero'
-    inverse function theorem: 'has_strict_deriv_at.to_local_inverse'
+    inverse function theorem: 'has_strict_fderiv_at.to_local_inverse'
     implicit function theorem: 'implicit_function_data.implicit_function'
     analytic function: 'analytic_at'
 
@@ -249,8 +251,10 @@ Analysis:
   Special functions:
     logarithms: 'real.log'
     exponential: 'real.exp'
-    circular trigonometric functions: 'real.sin'
+    trigonometric functions: 'real.sin'
+    inverse trigonometric functions: 'real.arcsin'
     hyperbolic trigonometric functions: 'real.sinh'
+    inverse hyperbolic trigonometric functions: 'real.arsinh'
 
   Measures and integral calculus:
     sigma-algebras: 'measurable_space'
@@ -272,8 +276,10 @@ Analysis:
 Geometry:
   Differentiable manifolds:
     smooth manifold (with boundary and corners): 'smooth_manifold_with_corners'
+    smooth map between manifolds: 'mdifferentiable_at'
     tangent bundle: 'tangent_bundle'
     tangent map: 'tangent_map'
+    Lie group: 'lie_group'
 
   Affine and Euclidian geometry:
     affine spaces: 'add_torsor'


### PR DESCRIPTION
A few additions to the "normed spaces", "convexity", "special functions" and "manifolds" sections of the overview.

---
<!-- put comments you want to keep out of the PR commit here -->

also change the lemmas cited in differentiability from `deriv` to `fderiv` versions (this overview is aimed at mathematicians, is that right?)