### PR TITLE
[Merged by Bors] - chore(data/option): swap sides in `ne_none_iff_exists`

### DIFF
--- a/src/algebra/continued_fractions/computation/approximations.lean
+++ b/src/algebra/continued_fractions/computation/approximations.lean
@@ -194,7 +194,7 @@ begin
     have : ¬(n + 2 ≤ 1), by linarith,
     have not_terminated_at_n : ¬g.terminated_at n, from or.resolve_left hyp this,
     obtain ⟨gp, s_ppred_nth_eq⟩ : ∃ gp, g.s.nth n = some gp, from
-      option.ne_none_iff_exists.elim_left not_terminated_at_n,
+      option.ne_none_iff_exists'.mp not_terminated_at_n,
     set pconts := g.continuants_aux (n + 1) with pconts_eq,
     set ppconts := g.continuants_aux n with ppconts_eq,
     -- use the recurrence of continuants_aux
@@ -302,7 +302,7 @@ begin
       denominators_stable_of_terminated n.le_succ this,
     rw this },
   { obtain ⟨b, nth_part_denom_eq⟩ : ∃ b, g.partial_denominators.nth n = some b, from
-      option.ne_none_iff_exists.elim_left not_terminated,
+      option.ne_none_iff_exists'.mp not_terminated,
     have : 1 ≤ b, from of_one_le_nth_part_denom nth_part_denom_eq,
     calc
       (gcf.of v).denominators n ≤ b * (gcf.of v).denominators n   : by simpa using

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -95,7 +95,7 @@ begin
     replace nth_fr_ne_zero : ∀ ifp, int_fract_pair.stream v n = some ifp → ifp.fr ≠ 0, by
       simpa using nth_fr_ne_zero,
     obtain ⟨ifp_n, stream_nth_eq⟩ : ∃ ifp_n, int_fract_pair.stream v n = some ifp_n, from
-      option.ne_none_iff_exists.elim_left stream_nth_ne_none,
+      option.ne_none_iff_exists'.mp stream_nth_ne_none,
     existsi ifp_n,
     have ifp_n_fr_ne_zero : ifp_n.fr ≠ 0, from nth_fr_ne_zero ifp_n stream_nth_eq,
     cases ifp_n with _ ifp_n_fr,

--- a/src/algebra/continued_fractions/convergents_equiv.lean
+++ b/src/algebra/continued_fractions/convergents_equiv.lean
@@ -269,7 +269,7 @@ begin
   { have : squash_gcf g n = g, from squash_gcf_eq_self_of_terminated terminated_at_n,
     simp only [this, (convergents_stable_of_terminated n.le_succ terminated_at_n)] },
   { obtain ⟨⟨a, b⟩, s_nth_eq⟩ : ∃ gp_n, g.s.nth n = some gp_n, from
-      option.ne_none_iff_exists.elim_left not_terminated_at_n,
+      option.ne_none_iff_exists'.mp not_terminated_at_n,
     have b_ne_zero : b ≠ 0, from nth_part_denom_ne_zero (part_denom_eq_s_b s_nth_eq),
     cases n with n',
     case nat.zero
@@ -358,7 +358,7 @@ begin
           { -- the difficult case at the squashed position: we first obtain the values from
             -- the sequence
             obtain ⟨gp_succ_m, s_succ_mth_eq⟩ : ∃ gp_succ_m, g.s.nth (m + 1) = some gp_succ_m, from
-              option.ne_none_iff_exists.elim_left not_terminated_at_n,
+              option.ne_none_iff_exists'.mp not_terminated_at_n,
             obtain ⟨gp_m, mth_s_eq⟩ : ∃ gp_m, g.s.nth m = some gp_m, from
               g.s.ge_stable m.le_succ s_succ_mth_eq,
             -- we then plug them into the recurrence

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -33,17 +33,16 @@ instance : has_coe_t α (with_one α) := ⟨some⟩
 lemma some_eq_coe {a : α} : (some a : with_one α) = ↑a := rfl
 
 @[simp, to_additive]
-lemma one_ne_coe {a : α} : (1 : with_one α) ≠ a :=
-λ h, option.no_confusion h
+lemma coe_ne_one {a : α} : (a : with_one α) ≠ (1 : with_one α) :=
+option.some_ne_none a
 
 @[simp, to_additive]
-lemma coe_ne_one {a : α} : (a : with_one α) ≠ (1 : with_one α) :=
-λ h, option.no_confusion h
+lemma one_ne_coe {a : α} : (1 : with_one α) ≠ a :=
+coe_ne_one.symm
 
 @[to_additive]
-lemma ne_one_iff_exists : ∀ {x : with_one α}, x ≠ 1 ↔ ∃ (a : α), x = a
-| 1       := ⟨λ h, false.elim $ h rfl, by { rintros ⟨a,ha⟩ h, simpa using h }⟩
-| (a : α) := ⟨λ h, ⟨a, rfl⟩, λ h, with_one.coe_ne_one⟩
+lemma ne_one_iff_exists {x : with_one α} : x ≠ 1 ↔ ∃ (a : α), ↑a = x :=
+option.ne_none_iff_exists
 
 @[to_additive]
 lemma coe_inj {a b : α} : (a : with_one α) = b ↔ a = b :=

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -141,11 +141,11 @@ by cases o; simp
 lemma ne_none_iff_is_some {o : option α} : o ≠ none ↔ o.is_some :=
 by cases o; simp
 
-lemma ne_none_iff_exists {o : option α} : o ≠ none ↔ ∃ (x : α), o = some x :=
+lemma ne_none_iff_exists {o : option α} : o ≠ none ↔ ∃ (x : α), some x = o :=
 by {cases o; simp}
 
-lemma ne_none_iff_exists' {o : option α} : o ≠ none ↔ ∃ (x : α), o = x :=
-ne_none_iff_exists
+lemma ne_none_iff_exists' {o : option α} : o ≠ none ↔ ∃ (x : α), o = some x :=
+ne_none_iff_exists.trans $ exists_congr $ λ _, eq_comm
 
 lemma bex_ne_none {p : option α → Prop} :
   (∃ x ≠ none, p x) ↔ ∃ x, p (some x) :=

--- a/src/data/seq/seq.lean
+++ b/src/data/seq/seq.lean
@@ -73,7 +73,7 @@ instance : has_mem α (seq α) :=
 ⟨seq.mem⟩
 
 theorem le_stable (s : seq α) {m n} (h : m ≤ n) :
-  s.1 m = none → s.1 n = none :=
+  s.nth m = none → s.nth n = none :=
 by {cases s with f al, induction h with n h IH, exacts [id, λ h2, al (IH h2)]}
 
 /-- If a sequence terminated at position `n`, it also terminated at `m ≥ n `. -/
@@ -91,7 +91,7 @@ lemma ge_stable (s : seq α) {aₙ : α} {n m : ℕ} (m_le_n : m ≤ n)
   ∃ (aₘ : α), s.nth m = some aₘ :=
 have s.nth n ≠ none, by simp [s_nth_eq_some],
 have s.nth m ≠ none, from mt (s.le_stable m_le_n) this,
-option.ne_none_iff_exists.1 this
+option.ne_none_iff_exists'.mp this
 
 theorem not_mem_nil (a : α) : a ∉ @nil α :=
 λ ⟨n, (h : some a = none)⟩, by injection h


### PR DESCRIPTION
* swap lhs and rhs of the equality in `option.ne_none_iff_exists`; the new order matches, e.g., the definition of `set.range` and `can_lift.prf`;
* the same in `with_one.ne_one_iff_exists` and `with_zero.ne_zero_iff_exists`;
* remove `option.ne_none_iff_exists'`;
* restore the original `option.ne_none_iff_exists` as `option.ne_none_iff_exists'`
---
<!-- put comments you want to keep out of the PR commit here -->