### PR TITLE
[Merged by Bors] - feat(linear_algebra): determinant of `matrix.block_diagonal`

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1014,7 +1014,7 @@ end finset
 
 namespace list
 
-@[to_additive, simp] lemma prod_to_finset {M : Type*} [decidable_eq α] [comm_monoid M]
+@[to_additive] lemma prod_to_finset {M : Type*} [decidable_eq α] [comm_monoid M]
   (f : α → M) {l : list α} (hl : l.nodup) : l.to_finset.prod f = (l.map f).prod :=
 begin
   revert hl,

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1083,3 +1083,15 @@ begin
 end
 
 end multiset
+
+@[simp, norm_cast] lemma nat.prod_coe {R : Type*} [comm_semiring R]
+  (f : α → ℕ) (s : finset α) : (↑∏ i in s, f i : R) = ∏ i in s, f i :=
+(nat.cast_ring_hom R).map_prod _ _
+
+@[simp, norm_cast] lemma int.prod_coe {R : Type*} [comm_ring R]
+  (f : α → ℤ) (s : finset α) : (↑∏ i in s, f i : R) = ∏ i in s, f i :=
+(int.cast_ring_hom R).map_prod _ _
+
+@[simp, norm_cast] lemma units.prod_coe {M : Type*} [comm_monoid M]
+  (f : α → units M) (s : finset α) : (↑∏ i in s, f i : M) = ∏ i in s, f i :=
+(units.coe_hom M).map_prod _ _

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1015,15 +1015,10 @@ end finset
 namespace list
 
 @[to_additive] lemma prod_to_finset {M : Type*} [decidable_eq α] [comm_monoid M]
-  (f : α → M) {l : list α} (hl : l.nodup) : l.to_finset.prod f = (l.map f).prod :=
-begin
-  revert hl,
-  apply l.rec_on,
-  { simp },
-  intros a l ih hl,
-  obtain ⟨not_mem, hl⟩ := list.nodup_cons.mp hl,
-  simp [finset.prod_insert (mt list.mem_to_finset.mp not_mem), ih hl]
-end
+  (f : α → M) : ∀ {l : list α} (hl : l.nodup), l.to_finset.prod f = (l.map f).prod
+| [] _ := by simp
+| (a :: l) hl := let ⟨not_mem, hl⟩ := list.nodup_cons.mp hl in
+  by simp [finset.prod_insert (mt list.mem_to_finset.mp not_mem), prod_to_finset hl]
 
 end list
 

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1079,14 +1079,14 @@ end
 
 end multiset
 
-@[simp, norm_cast] lemma nat.prod_coe {R : Type*} [comm_semiring R]
+@[simp, norm_cast] lemma nat.coe_prod {R : Type*} [comm_semiring R]
   (f : α → ℕ) (s : finset α) : (↑∏ i in s, f i : R) = ∏ i in s, f i :=
 (nat.cast_ring_hom R).map_prod _ _
 
-@[simp, norm_cast] lemma int.prod_coe {R : Type*} [comm_ring R]
+@[simp, norm_cast] lemma int.coe_prod {R : Type*} [comm_ring R]
   (f : α → ℤ) (s : finset α) : (↑∏ i in s, f i : R) = ∏ i in s, f i :=
 (int.cast_ring_hom R).map_prod _ _
 
-@[simp, norm_cast] lemma units.prod_coe {M : Type*} [comm_monoid M]
+@[simp, norm_cast] lemma units.coe_prod {M : Type*} [comm_monoid M]
   (f : α → units M) (s : finset α) : (↑∏ i in s, f i : M) = ∏ i in s, f i :=
 (units.coe_hom M).map_prod _ _

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1012,6 +1012,21 @@ end prod_eq_zero
 
 end finset
 
+namespace list
+
+@[to_additive, simp] lemma prod_to_finset {M : Type*} [decidable_eq α] [comm_monoid M]
+  (f : α → M) {l : list α} (hl : l.nodup) : l.to_finset.prod f = (l.map f).prod :=
+begin
+  revert hl,
+  apply l.rec_on,
+  { simp },
+  intros a l ih hl,
+  obtain ⟨not_mem, hl⟩ := list.nodup_cons.mp hl,
+  simp [finset.prod_insert (mt list.mem_to_finset.mp not_mem), ih hl]
+end
+
+end list
+
 namespace multiset
 variables [decidable_eq α]
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -788,16 +788,16 @@ def prod_congr_right : α₁ × β₁ ≃ α₁ × β₂ :=
 @[simp] lemma prod_congr_right_apply (a : α₁) (b : β₁) :
   prod_congr_right e (a, b) = (a, e a b) := rfl
 
+lemma prod_congr_refl_left (e : β₁ ≃ β₂) :
+  prod_congr (equiv.refl α₁) e = prod_congr_right (λ _, e) :=
+by { ext ⟨a, b⟩ : 1, simp }
+
 @[simp] lemma prod_congr_left_trans_prod_comm :
   (prod_congr_left e).trans (prod_comm _ _) = (prod_comm _ _).trans (prod_congr_right e) :=
 by { ext ⟨a, b⟩ : 1, simp }
 
 @[simp] lemma prod_congr_right_trans_prod_comm :
   (prod_congr_right e).trans (prod_comm _ _) = (prod_comm _ _).trans (prod_congr_left e) :=
-by { ext ⟨a, b⟩ : 1, simp }
-
-lemma prod_congr_refl_left (e : β₁ ≃ β₂) :
-  prod_congr (equiv.refl α₁) e = prod_congr_right (λ _, e) :=
 by { ext ⟨a, b⟩ : 1, simp }
 
 lemma sigma_congr_right_sigma_equiv_prod :

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -758,9 +758,24 @@ def sigma_equiv_prod_of_equiv {α β} {β₁ : α → Sort*} (F : Π a, β₁ a 
 
 end
 
-section prod_congr_right
+section prod_congr
 
 variables {α₁ β₁ β₂ : Type*} (e : α₁ → β₁ ≃ β₂)
+
+/-- A family of equivalences `Π (a : α₁), β₁ ≃ β₂` generates an equivalence
+between `β₁ × α₁` and `β₂ × α₁`. -/
+def prod_congr_left : β₁ × α₁ ≃ β₂ × α₁ :=
+{ to_fun := λ ab, ⟨e ab.2 ab.1, ab.2⟩,
+  inv_fun := λ ab, ⟨(e ab.2).symm ab.1, ab.2⟩,
+  left_inv := by { rintros ⟨a, b⟩, simp },
+  right_inv := by { rintros ⟨a, b⟩, simp } }
+
+@[simp] lemma prod_congr_left_apply (b : β₁) (a : α₁) :
+prod_congr_left e (b, a) = (e a b, a) := rfl
+
+lemma prod_congr_refl_right (e : β₁ ≃ β₂) :
+  prod_congr e (equiv.refl α₁) = prod_congr_left (λ _, e) :=
+by { ext ⟨a, b⟩ : 1, simp }
 
 /-- A family of equivalences `Π (a : α₁), β₁ ≃ β₂` generates an equivalence
 between `α₁ × β₁` and `α₁ × β₂`. -/
@@ -773,7 +788,15 @@ def prod_congr_right : α₁ × β₁ ≃ α₁ × β₂ :=
 @[simp] lemma prod_congr_right_apply (a : α₁) (b : β₁) :
   prod_congr_right e (a, b) = (a, e a b) := rfl
 
-lemma prod_congr_refl (e : β₁ ≃ β₂) :
+@[simp] lemma prod_congr_left_trans_prod_comm :
+  (prod_congr_left e).trans (prod_comm _ _) = (prod_comm _ _).trans (prod_congr_right e) :=
+by { ext ⟨a, b⟩ : 1, simp }
+
+@[simp] lemma prod_congr_right_trans_prod_comm :
+  (prod_congr_right e).trans (prod_comm _ _) = (prod_comm _ _).trans (prod_congr_left e) :=
+by { ext ⟨a, b⟩ : 1, simp }
+
+lemma prod_congr_refl_left (e : β₁ ≃ β₂) :
   prod_congr (equiv.refl α₁) e = prod_congr_right (λ _, e) :=
 by { ext ⟨a, b⟩ : 1, simp }
 
@@ -787,7 +810,7 @@ lemma sigma_equiv_prod_sigma_congr_right :
     (prod_congr_right e).trans (sigma_equiv_prod α₁ β₂).symm :=
 by { ext ⟨a, b⟩ : 1, simp }
 
-end prod_congr_right
+end prod_congr
 
 namespace perm
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -816,28 +816,28 @@ namespace perm
 
 variables {α₁ β₁ β₂ : Type*} [decidable_eq α₁] (a : α₁) (e : perm β₁)
 
-/-- `extend a e` extends `e : perm β` to `perm (α × β)` by sending `(a, b)` to
+/-- `prod_extend_right a e` extends `e : perm β` to `perm (α × β)` by sending `(a, b)` to
 `(a, e b)` and keeping the other `(a', b)` fixed. -/
-def extend : perm (α₁ × β₁) :=
+def prod_extend_right : perm (α₁ × β₁) :=
 { to_fun := λ ab, if ab.fst = a then (a, e ab.snd) else ab,
   inv_fun := λ ab, if ab.fst = a then (a, e⁻¹ ab.snd) else ab,
   left_inv := by { rintros ⟨k', x⟩, simp only, split_ifs with h; simp [h] },
   right_inv := by { rintros ⟨k', x⟩, simp only, split_ifs with h; simp [h] } }
 
-@[simp] lemma extend_apply_eq (b : β₁) :
-extend a e (a, b) = (a, e b) := if_pos rfl
+@[simp] lemma prod_extend_right_apply_eq (b : β₁) :
+  prod_extend_right a e (a, b) = (a, e b) := if_pos rfl
 
-lemma extend_apply_ne {a a' : α₁} (h : a' ≠ a) (b : β₁) :
-extend a e (a', b) = (a', b) := if_neg h
+lemma prod_extend_right_apply_ne {a a' : α₁} (h : a' ≠ a) (b : β₁) :
+  prod_extend_right a e (a', b) = (a', b) := if_neg h
 
-lemma eq_of_extend_apply_ne {e : perm β₁} {a a' : α₁} {b : β₁}
-  (h : extend a e (a', b) ≠ (a', b)) : a' = a :=
-by { contrapose! h, exact extend_apply_ne _ h _ }
+lemma eq_of_prod_extend_right_ne {e : perm β₁} {a a' : α₁} {b : β₁}
+  (h : prod_extend_right a e (a', b) ≠ (a', b)) : a' = a :=
+by { contrapose! h, exact prod_extend_right_apply_ne _ h _ }
 
-@[simp] lemma fst_extend (ab : α₁ × β₁) :
-  (extend a e ab).fst = ab.fst :=
+@[simp] lemma fst_prod_extend_right (ab : α₁ × β₁) :
+  (prod_extend_right a e ab).fst = ab.fst :=
 begin
-  rw [extend, coe_fn_mk],
+  rw [prod_extend_right, coe_fn_mk],
   split_ifs with h,
   { rw h },
   { refl }

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -1675,17 +1675,3 @@ begin
       by { contrapose! h, have : (e j : α) ∈ s := (e j).2, rwa ← h at this },
     simp [h, this] }
 end
-
-namespace equiv
-
-section extend
-
-variables {α' β' γ' : Type*}
-
-lemma mk_eq_of_preserves_fst {f : α' × β' → α' × γ'} (hf : ∀ x, (f x).fst = x.fst)
-  (a : α') (b : β') : (a, (f (a, b)).snd) = f (a, b) :=
-by rw [← @prod.mk.eta _ _ (f (a, b)), hf (a, b)]
-
-end extend
-
-end equiv

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -769,6 +769,11 @@ instance pfun_fintype (p : Prop) [decidable p] (α : p → Type*)
 if hp : p then fintype.of_equiv (α hp) ⟨λ a _, a, λ f, f hp, λ _, rfl, λ _, rfl⟩
           else ⟨singleton (λ h, (hp h).elim), by simp [hp, function.funext_iff]⟩
 
+@[simp] lemma finset.univ_pi_univ {α : Type*} {β : α → Type*}
+  [decidable_eq α] [fintype α] [∀a, fintype (β a)] :
+  finset.univ.pi (λ a : α, (finset.univ : finset (β a))) = finset.univ :=
+by { ext, simp }
+
 lemma mem_image_univ_iff_mem_range
   {α β : Type*} [fintype α] [decidable_eq β] {f : α → β} {b : β} :
   b ∈ univ.image f ↔ b ∈ set.range f :=

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -576,7 +576,7 @@ calc sign f = sign (@subtype_perm _ f (λ x, f x ≠ x) (by simp)) :
 
 def is_cycle (f : perm β) := ∃ x, f x ≠ x ∧ ∀ y, f y ≠ y → ∃ i : ℤ, (f ^ i) x = y
 
-lemma is_cycle_swap {x y : α} (hxy : x ≠ y) : is_cycle (swap x y) :=
+lemma is_cycle_swap {α : Type*} [decidable_eq α] {x y : α} (hxy : x ≠ y) : is_cycle (swap x y) :=
 ⟨y, by rwa swap_apply_right,
   λ a (ha : ite (a = x) y (ite (a = y) x a) ≠ a),
     if hya : y = a then ⟨0, hya⟩
@@ -595,7 +595,7 @@ let ⟨a, ha⟩ := hg.2 x hx in
 let ⟨b, hb⟩ := hg.2 y hy in
 ⟨b - a, by rw [← ha, ← mul_apply, ← gpow_add, sub_add_cancel, hb]⟩
 
-lemma is_cycle_swap_mul_aux₁ : ∀ (n : ℕ) {b x : α} {f : perm α}
+lemma is_cycle_swap_mul_aux₁ {α : Type*} [decidable_eq α] : ∀ (n : ℕ) {b x : α} {f : perm α}
   (hb : (swap x (f x) * f) b ≠ b) (h : (f ^ n) (f x) = b),
   ∃ i : ℤ, ((swap x (f x) * f) ^ i) (f x) = b
 | 0         := λ b x f hb h, ⟨0, h⟩
@@ -614,7 +614,7 @@ lemma is_cycle_swap_mul_aux₁ : ∀ (n : ℕ) {b x : α} {f : perm α}
     ⟨i + 1, by rw [add_comm, gpow_add, mul_apply, hi, gpow_one, mul_apply, apply_inv_self,
         swap_apply_of_ne_of_ne (ne_and_ne_of_swap_mul_apply_ne_self hb).2 (ne.symm hfbx)]⟩
 
-lemma is_cycle_swap_mul_aux₂ : ∀ (n : ℤ) {b x : α} {f : perm α}
+lemma is_cycle_swap_mul_aux₂ {α : Type*} [decidable_eq α] : ∀ (n : ℤ) {b x : α} {f : perm α}
   (hb : (swap x (f x) * f) b ≠ b) (h : (f ^ n) (f x) = b),
   ∃ i : ℤ, ((swap x (f x) * f) ^ i) (f x) = b
 | (n : ℕ) := λ b x f, is_cycle_swap_mul_aux₁ n
@@ -636,7 +636,8 @@ lemma is_cycle_swap_mul_aux₂ : ∀ (n : ℤ) {b x : α} {f : perm α}
       mul_inv_rev, swap_inv, mul_swap_eq_swap_mul, inv_apply_self, swap_comm _ x, gpow_add, gpow_one,
       mul_apply, mul_apply (_ ^ i), h, hi, mul_apply, apply_inv_self, swap_apply_of_ne_of_ne this.2 (ne.symm hfbx')]⟩
 
-lemma eq_swap_of_is_cycle_of_apply_apply_eq_self {f : perm α} (hf : is_cycle f) {x : α}
+lemma eq_swap_of_is_cycle_of_apply_apply_eq_self {α : Type*} [decidable_eq α]
+  {f : perm α} (hf : is_cycle f) {x : α}
   (hfx : f x ≠ x) (hffx : f (f x) = x) : f = swap x (f x) :=
 equiv.ext $ λ y,
 let ⟨z, hz⟩ := hf in
@@ -653,7 +654,7 @@ else begin
   { rw [← hj, hji] at hfyx, cc }
 end
 
-lemma is_cycle_swap_mul {f : perm α} (hf : is_cycle f) {x : α}
+lemma is_cycle_swap_mul {α : Type*} [decidable_eq α] {f : perm α} (hf : is_cycle f) {x : α}
   (hx : f x ≠ x) (hffx : f (f x) ≠ x) : is_cycle (swap x (f x) * f) :=
 ⟨f x, by simp only [swap_apply_def, mul_apply];
         split_ifs; simp [injective.eq_iff f.injective] at *; cc,
@@ -664,14 +665,14 @@ lemma is_cycle_swap_mul {f : perm α} (hf : is_cycle f) {x : α}
     ... =  y : by rwa [← gpow_add, sub_add_cancel],
   is_cycle_swap_mul_aux₂ (i - 1) hy hi⟩
 
-@[simp] lemma support_swap [fintype α] {x y : α} (hxy : x ≠ y) : (swap x y).support = {x, y} :=
+@[simp] lemma support_swap {x y : α} (hxy : x ≠ y) : (swap x y).support = {x, y} :=
 finset.ext $ λ a, by simp [swap_apply_def]; split_ifs; cc
 
-lemma card_support_swap [fintype α] {x y : α} (hxy : x ≠ y) : (swap x y).support.card = 2 :=
+lemma card_support_swap {x y : α} (hxy : x ≠ y) : (swap x y).support.card = 2 :=
 show (swap x y).support.card = finset.card ⟨x::y::0, by simp [hxy]⟩,
 from congr_arg card $ by rw [support_swap hxy]; simp [*, finset.ext_iff]; cc
 
-lemma sign_cycle [fintype α] : ∀ {f : perm α} (hf : is_cycle f),
+lemma sign_cycle : ∀ {f : perm α} (hf : is_cycle f),
   sign f = -(-1) ^ f.support.card
 | f := λ hf,
 let ⟨x, hx⟩ := hf in
@@ -701,7 +702,7 @@ using_well_founded {rel_tac := λ _ _, `[exact ⟨_, measure_wf (λ f, f.support
 /-- If we have a list of all elements of `α`, we can write
 `equiv.prod_congr_right (e : α → perm β)` as `extend` applied to each element
 in turn. -/
-lemma prod_congr_right_eq_prod_extend (σ : α → perm β)
+lemma prod_congr_right_eq_prod_extend {α : Type*} [decidable_eq α] (σ : α → perm β)
   {l : list α} (hl : l.nodup) (mem_l : ∀ a, a ∈ l) :
   prod_congr_right σ = (l.map (λ a, extend a (σ a))).prod :=
 begin

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -699,18 +699,17 @@ calc sign f = sign (swap x (f x) * (swap x (f x) * f)) :
       pow_one, units.neg_mul_neg]
 using_well_founded {rel_tac := λ _ _, `[exact ⟨_, measure_wf (λ f, f.support.card)⟩]}
 
-/-- If we have a list of all elements of `α`, we can write
-`equiv.prod_congr_right (e : α → perm β)` as `extend` applied to each element
-in turn. -/
-lemma prod_congr_right_eq_prod_extend {α : Type*} [decidable_eq α] (σ : α → perm β)
+/-- If we apply `prod_extend_right a (σ a)` for all `a : α` in turn,
+we get `prod_congr_right σ`. -/
+lemma prod_prod_extend_right {α : Type*} [decidable_eq α] (σ : α → perm β)
   {l : list α} (hl : l.nodup) (mem_l : ∀ a, a ∈ l) :
-  prod_congr_right σ = (l.map (λ a, extend a (σ a))).prod :=
+  (l.map (λ a, prod_extend_right a (σ a))).prod = prod_congr_right σ :=
 begin
   ext ⟨a, b⟩ : 1,
   -- We'll use induction on the list of elements,
   -- but we have to keep track of whether we already passed `a` in the list.
-  suffices : (a ∈ l ∧ (l.map (λ a, extend a (σ a))).prod (a, b) = (a, σ a b)) ∨
-             (a ∉ l ∧ (l.map (λ a, extend a (σ a))).prod (a, b) = (a, b)),
+  suffices : (a ∈ l ∧ (l.map (λ a, prod_extend_right a (σ a))).prod (a, b) = (a, σ a b)) ∨
+             (a ∉ l ∧ (l.map (λ a, prod_extend_right a (σ a))).prod (a, b) = (a, b)),
   { obtain ⟨_, prod_eq⟩ := or.resolve_right this (not_and.mpr (λ h _, h (mem_l a))),
     rw [prod_eq, prod_congr_right_apply] },
   clear mem_l,
@@ -722,25 +721,25 @@ begin
   rw [list.map_cons, list.prod_cons, mul_apply],
   rcases ih (list.nodup_cons.mp hl).2 with ⟨mem_l, prod_eq⟩ | ⟨not_mem_l, prod_eq⟩; rw prod_eq,
   { refine or.inl ⟨list.mem_cons_of_mem _ mem_l, _⟩,
-    rw extend_apply_ne _ (λ (h : a = a'), (list.nodup_cons.mp hl).1 (h ▸ mem_l)) },
+    rw prod_extend_right_apply_ne _ (λ (h : a = a'), (list.nodup_cons.mp hl).1 (h ▸ mem_l)) },
   by_cases ha' : a = a',
   { rw ← ha' at *,
     refine or.inl ⟨l.mem_cons_self a, _⟩,
-    rw extend_apply_eq },
+    rw prod_extend_right_apply_eq },
   { refine or.inr ⟨λ h, not_or ha' not_mem_l ((list.mem_cons_iff _ _ _).mp h), _⟩,
-    rw extend_apply_ne _ ha' },
+    rw prod_extend_right_apply_ne _ ha' },
 end
 
 section
 
 open_locale classical
 
-lemma sign_extend [fintype β] (a : α) (σ : perm β) :
-  (extend a σ).sign = σ.sign :=
+lemma sign_prod_extend_right [fintype β] (a : α) (σ : perm β) :
+  (prod_extend_right a σ).sign = σ.sign :=
 sign_bij (λ (ab : α × β) _, ab.snd)
-  (λ ⟨a', b⟩ hab hab', by simp [eq_of_extend_apply_ne hab])
+  (λ ⟨a', b⟩ hab hab', by simp [eq_of_prod_extend_right_ne hab])
   (λ ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ hab₁ hab₂ h,
-    by simpa [eq_of_extend_apply_ne hab₁, eq_of_extend_apply_ne hab₂] using h)
+    by simpa [eq_of_prod_extend_right_ne hab₁, eq_of_prod_extend_right_ne hab₂] using h)
   (λ y hy, ⟨(a, y), by simpa, by simp⟩)
 
 lemma sign_prod_congr_right [fintype β] (σ : α → perm β) :
@@ -751,9 +750,9 @@ begin
   { apply eq_top_iff.mpr,
     intros b _,
     exact list.mem_to_finset.mpr (mem_l b) },
-  rw [prod_congr_right_eq_prod_extend σ hl mem_l, sign.map_list_prod,
+  rw [← prod_prod_extend_right σ hl mem_l, sign.map_list_prod,
       list.map_map, ← l_to_finset, list.prod_to_finset _ hl],
-  simp_rw ← λ a, sign_extend a (σ a)
+  simp_rw ← λ a, sign_prod_extend_right a (σ a)
 end
 
 lemma sign_prod_congr_left [fintype β] (σ : α → perm β) :

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -755,6 +755,14 @@ begin
   simp_rw ← λ a, sign_extend a (σ a)
 end
 
+lemma sign_prod_congr_left [fintype β] (σ : α → perm β) :
+  sign (prod_congr_left σ) = ∏ k, (σ k).sign :=
+begin
+  refine (sign_eq_sign_of_equiv _ _ (prod_comm β α) _).trans (sign_prod_congr_right σ),
+  rintro ⟨b, α⟩,
+  refl
+end
+
 end
 
 end sign


### PR DESCRIPTION
This PR shows the determinant of `matrix.block_diagonal` is the product of the determinant of each subblock.

The only contributing permutations in the expansion of the determinant are those which map each block to the same block. Each of those permutations has the form `equiv.prod_congr_left σ`. Using `equiv.perm.extend` and `equiv.prod_congr_right`, we can compute the sign of `equiv.prod_congr_left σ`, and with a bit of algebraic manipulation we reach the conclusion.

---
<!-- put comments you want to keep out of the PR commit here -->
