### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/*): prove that `exp` etc are measurable

### DIFF
--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -6,7 +6,7 @@ Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne
 import data.complex.exponential
 import analysis.complex.basic
 import analysis.calculus.mean_value
-
+import measure_theory.borel_space
 
 /-!
 # Complex and real exponential, real logarithm
@@ -27,7 +27,6 @@ instead `trigonometric.lean`.
 
 exp, log
 -/
-
 
 noncomputable theory
 
@@ -70,10 +69,15 @@ funext $ λ x, (has_deriv_at_exp x).deriv
 lemma continuous_exp : continuous exp :=
 differentiable_exp.continuous
 
+lemma measurable_exp : measurable exp := continuous_exp.measurable
+
 end complex
 
 section
 variables {f : ℂ → ℂ} {f' x : ℂ} {s : set ℂ}
+
+lemma measurable.cexp (hf : measurable f) : measurable (λ x, complex.exp (f x)) :=
+complex.measurable_exp.comp hf
 
 lemma has_deriv_at.cexp (hf : has_deriv_at f f' x) :
   has_deriv_at (λ x, complex.exp (f x)) (complex.exp (f x) * f') x :=
@@ -133,6 +137,8 @@ funext $ λ x, (has_deriv_at_exp x).deriv
 lemma continuous_exp : continuous exp :=
 differentiable_exp.continuous
 
+lemma measurable_exp : measurable exp := continuous_exp.measurable
+
 end real
 
 
@@ -144,6 +150,9 @@ section
 variables {f : ℝ → ℝ} {f' x : ℝ} {s : set ℝ}
 
 /-! `real.exp`-/
+
+lemma measurable.exp (hf : measurable f) : measurable (λ x, real.exp (f x)) :=
+real.measurable_exp.comp hf
 
 lemma has_deriv_at.exp (hf : has_deriv_at f f' x) :
   has_deriv_at (λ x, real.exp (f x)) (real.exp (f x) * f') x :=
@@ -299,7 +308,7 @@ begin
       ... < ε : by { rw [neg_lt, ← exp_lt_exp, exp_log], assumption' } }
 end
 
-lemma continuous_log' : continuous (λx : {x:ℝ // 0 < x}, log x.val) :=
+lemma continuous_log' : continuous (λx : {x:ℝ // 0 < x}, log x) :=
 continuous_iff_continuous_at.2 $ λ x,
 begin
   rw continuous_at,
@@ -354,12 +363,20 @@ begin
   { field_simp [hx] }
 end
 
+lemma measurable_log : measurable log :=
+measurable_of_measurable_on_compl_singleton 0 $ continuous.measurable $
+  continuous_iff_continuous_at.2 $ λ x, (real.has_deriv_at_log x.2).continuous_at.comp
+    continuous_at_subtype_coe
+
 end real
 
 section log_differentiable
 open real
 
 variables {f : ℝ → ℝ} {x f' : ℝ} {s : set ℝ}
+
+lemma measurable.log (hf : measurable f) : measurable (λ x, log (f x)) :=
+measurable_log.comp hf
 
 lemma has_deriv_within_at.log (hf : has_deriv_within_at f f' s x) (hx : f x ≠ 0) :
   has_deriv_within_at (λ y, log (f y)) (f' / (f x)) s x :=

--- a/src/analysis/special_functions/trigonometric.lean
+++ b/src/analysis/special_functions/trigonometric.lean
@@ -56,6 +56,8 @@ funext $ λ x, (has_deriv_at_sin x).deriv
 lemma continuous_sin : continuous sin :=
 differentiable_sin.continuous
 
+lemma measurable_sin : measurable sin := continuous_sin.measurable
+
 /-- The complex cosine function is everywhere differentiable, with the derivative `-sin x`. -/
 lemma has_deriv_at_cos (x : ℂ) : has_deriv_at cos (-sin x) x :=
 begin
@@ -81,6 +83,8 @@ funext $ λ x, deriv_cos
 lemma continuous_cos : continuous cos :=
 differentiable_cos.continuous
 
+lemma measurable_cos : measurable cos := continuous_cos.measurable
+
 /-- The complex hyperbolic sine function is everywhere differentiable, with the derivative `cosh x`. -/
 lemma has_deriv_at_sinh (x : ℂ) : has_deriv_at sinh (cosh x) x :=
 begin
@@ -100,6 +104,8 @@ funext $ λ x, (has_deriv_at_sinh x).deriv
 
 lemma continuous_sinh : continuous sinh :=
 differentiable_sinh.continuous
+
+lemma measurable_sinh : measurable sinh := continuous_sinh.measurable
 
 /-- The complex hyperbolic cosine function is everywhere differentiable, with the derivative `sinh x`. -/
 lemma has_deriv_at_cosh (x : ℂ) : has_deriv_at cosh (sinh x) x :=
@@ -121,6 +127,8 @@ funext $ λ x, (has_deriv_at_cosh x).deriv
 lemma continuous_cosh : continuous cosh :=
 differentiable_cosh.continuous
 
+lemma measurable_cosh : measurable cosh := continuous_cosh.measurable
+
 end complex
 
 section
@@ -131,6 +139,9 @@ section
 variables {f : ℂ → ℂ} {f' x : ℂ} {s : set ℂ}
 
 /-! `complex.cos`-/
+
+lemma measurable.ccos (hf : measurable f) : measurable (λ x, complex.cos (f x)) :=
+complex.measurable_cos.comp hf
 
 lemma has_deriv_at.ccos (hf : has_deriv_at f f' x) :
   has_deriv_at (λ x, complex.cos (f x)) (- complex.sin (f x) * f') x :=
@@ -167,6 +178,9 @@ hc.has_deriv_at.ccos.deriv
 
 /-! `complex.sin`-/
 
+lemma measurable.csin (hf : measurable f) : measurable (λ x, complex.sin (f x)) :=
+complex.measurable_sin.comp hf
+
 lemma has_deriv_at.csin (hf : has_deriv_at f f' x) :
   has_deriv_at (λ x, complex.sin (f x)) (complex.cos (f x) * f') x :=
 (complex.has_deriv_at_sin (f x)).comp x hf
@@ -202,6 +216,9 @@ hc.has_deriv_at.csin.deriv
 
 /-! `complex.cosh`-/
 
+lemma measurable.ccosh (hf : measurable f) : measurable (λ x, complex.cosh (f x)) :=
+complex.measurable_cosh.comp hf
+
 lemma has_deriv_at.ccosh (hf : has_deriv_at f f' x) :
   has_deriv_at (λ x, complex.cosh (f x)) (complex.sinh (f x) * f') x :=
 (complex.has_deriv_at_cosh (f x)).comp x hf
@@ -236,6 +253,9 @@ hf.has_deriv_within_at.ccosh.deriv_within hxs
 hc.has_deriv_at.ccosh.deriv
 
 /-! `complex.sinh`-/
+
+lemma measurable.csinh (hf : measurable f) : measurable (λ x, complex.sinh (f x)) :=
+complex.measurable_sinh.comp hf
 
 lemma has_deriv_at.csinh (hf : has_deriv_at f f' x) :
   has_deriv_at (λ x, complex.sinh (f x)) (complex.cosh (f x) * f') x :=
@@ -291,6 +311,8 @@ funext $ λ x, (has_deriv_at_sin x).deriv
 lemma continuous_sin : continuous sin :=
 differentiable_sin.continuous
 
+lemma measurable_sin : measurable sin := continuous_sin.measurable
+
 lemma has_deriv_at_cos (x : ℝ) : has_deriv_at cos (-sin x) x :=
 (has_deriv_at_real_of_complex (complex.has_deriv_at_cos x) : _)
 
@@ -309,6 +331,8 @@ funext $ λ _, deriv_cos
 lemma continuous_cos : continuous cos :=
 differentiable_cos.continuous
 
+lemma measurable_cos : measurable cos := continuous_cos.measurable
+
 lemma has_deriv_at_sinh (x : ℝ) : has_deriv_at sinh (cosh x) x :=
 has_deriv_at_real_of_complex (complex.has_deriv_at_sinh x)
 
@@ -323,6 +347,8 @@ funext $ λ x, (has_deriv_at_sinh x).deriv
 
 lemma continuous_sinh : continuous sinh :=
 differentiable_sinh.continuous
+
+lemma measurable_sinh : measurable sinh := continuous_sinh.measurable
 
 lemma has_deriv_at_cosh (x : ℝ) : has_deriv_at cosh (sinh x) x :=
 has_deriv_at_real_of_complex (complex.has_deriv_at_cosh x)
@@ -339,6 +365,8 @@ funext $ λ x, (has_deriv_at_cosh x).deriv
 lemma continuous_cosh : continuous cosh :=
 differentiable_cosh.continuous
 
+lemma measurable_cosh : measurable cosh := continuous_cosh.measurable
+
 /-- `sinh` is strictly monotone. -/
 lemma sinh_strict_mono : strict_mono sinh :=
 strict_mono_of_deriv_pos differentiable_sinh (by { rw [real.deriv_sinh], exact cosh_pos })
@@ -354,6 +382,9 @@ variables {f : ℝ → ℝ} {f' x : ℝ} {s : set ℝ}
 
 
 /-! `real.cos`-/
+
+lemma measurable.cos (hf : measurable f) : measurable (λ x, real.cos (f x)) :=
+real.measurable_cos.comp hf
 
 lemma has_deriv_at.cos (hf : has_deriv_at f f' x) :
   has_deriv_at (λ x, real.cos (f x)) (- real.sin (f x) * f') x :=
@@ -390,6 +421,9 @@ hc.has_deriv_at.cos.deriv
 
 /-! `real.sin`-/
 
+lemma measurable.sin (hf : measurable f) : measurable (λ x, real.sin (f x)) :=
+real.measurable_sin.comp hf
+
 lemma has_deriv_at.sin (hf : has_deriv_at f f' x) :
   has_deriv_at (λ x, real.sin (f x)) (real.cos (f x) * f') x :=
 (real.has_deriv_at_sin (f x)).comp x hf
@@ -424,6 +458,9 @@ hf.has_deriv_within_at.sin.deriv_within hxs
 hc.has_deriv_at.sin.deriv
 
 /-! `real.cosh`-/
+
+lemma measurable.cosh (hf : measurable f) : measurable (λ x, real.cosh (f x)) :=
+real.measurable_cosh.comp hf
 
 lemma has_deriv_at.cosh (hf : has_deriv_at f f' x) :
   has_deriv_at (λ x, real.cosh (f x)) (real.sinh (f x) * f') x :=
@@ -460,6 +497,9 @@ hc.has_deriv_at.cosh.deriv
 
 /-! `real.sinh`-/
 
+lemma measurable.sinh (hf : measurable f) : measurable (λ x, real.sinh (f x)) :=
+real.measurable_sinh.comp hf
+
 lemma has_deriv_at.sinh (hf : has_deriv_at f f' x) :
   has_deriv_at (λ x, real.sinh (f x)) (real.cosh (f x) * f') x :=
 (real.has_deriv_at_sinh (f x)).comp x hf
@@ -494,7 +534,6 @@ hf.has_deriv_within_at.sinh.deriv_within hxs
 hc.has_deriv_at.sinh.deriv
 
 end
-
 
 namespace real
 
@@ -1313,8 +1352,6 @@ end
 by simp [arctan, neg_div]
 
 end real
-
-
 
 namespace complex
 

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -809,7 +809,7 @@ e.symm.measurable_coe_iff.1 $ measurable_sum H₁ (H₂.comp measurable_id.snd)
 lemma measurable_of_measurable_nnreal_nnreal [measurable_space β]
   {f : ennreal × ennreal → β} (h₁ : measurable (λp:nnreal × nnreal, f (p.1, p.2)))
   (h₂ : measurable (λr:nnreal, f (⊤, r))) (h₃ : measurable (λr:nnreal, f (r, ⊤))) :
-    measurable f :=
+  measurable f :=
 measurable_of_measurable_nnreal_prod
   (measurable_swap_iff.1 $ measurable_of_measurable_nnreal_prod (h₁.comp measurable_swap) h₃)
   (measurable_of_measurable_nnreal h₂)

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -618,6 +618,9 @@ instance nnreal.borel_space : borel_space nnreal := ⟨rfl⟩
 instance ennreal.measurable_space : measurable_space ennreal := borel ennreal
 instance ennreal.borel_space : borel_space ennreal := ⟨rfl⟩
 
+instance complex.measurable_space : measurable_space ℂ := borel ℂ
+instance complex.borel_space : borel_space ℂ := ⟨rfl⟩
+
 section metric_space
 
 variables [metric_space α] [measurable_space α] [opens_measurable_space α]
@@ -792,82 +795,73 @@ def ennreal_equiv_sum :
   measurable_inv_fun := measurable_sum measurable_coe (@measurable_const ennreal unit _ _ ⊤),
   .. equiv.option_equiv_sum_punit nnreal }
 
+open function (uncurry)
+
+lemma measurable_of_measurable_nnreal_prod [measurable_space β] [measurable_space γ]
+  {f : ennreal × β → γ} (H₁ : measurable (λ p : nnreal × β, f (p.1, p.2)))
+  (H₂ : measurable (λ x, f (⊤, x))) :
+  measurable f :=
+let e : measurable_equiv (ennreal × β) (nnreal × β ⊕ unit × β) :=
+  (ennreal_equiv_sum.prod_congr (measurable_equiv.refl β)).trans
+    (measurable_equiv.sum_prod_distrib _ _ _) in
+e.symm.measurable_coe_iff.1 $ measurable_sum H₁ (H₂.comp measurable_id.snd)
+
 lemma measurable_of_measurable_nnreal_nnreal [measurable_space β]
-  (f : ennreal → ennreal → β) {g : α → ennreal} {h : α → ennreal}
-  (h₁ : measurable (λp:nnreal × nnreal, f p.1 p.2))
-  (h₂ : measurable (λr:nnreal, f ⊤ r))
-  (h₃ : measurable (λr:nnreal, f r ⊤))
-  (hg : measurable g) (hh : measurable h) : measurable (λa, f (g a) (h a)) :=
-let e : measurable_equiv (ennreal × ennreal)
-  (((nnreal × nnreal) ⊕ (nnreal × unit)) ⊕ ((unit × nnreal) ⊕ (unit × unit))) :=
-  (measurable_equiv.prod_congr ennreal_equiv_sum ennreal_equiv_sum).trans
-    (measurable_equiv.sum_prod_sum _ _ _ _) in
-have measurable (λp:ennreal×ennreal, f p.1 p.2),
-begin
-  refine e.symm.measurable_coe_iff.1 (measurable_sum (measurable_sum _ _) (measurable_sum _ _)),
-  { show measurable (λp:nnreal × nnreal, f p.1 p.2),
-    exact h₁ },
-  { show measurable (λp:nnreal × unit, f p.1 ⊤),
-    exact h₃.comp (measurable.fst measurable_id) },
-  { show measurable ((λp:nnreal, f ⊤ p) ∘ (λp:unit × nnreal, p.2)),
-    exact h₂.comp (measurable.snd measurable_id) },
-  { show measurable (λp:unit × unit, f ⊤ ⊤),
-    exact measurable_const }
-end,
-this.comp (measurable.prod_mk hg hh)
+  {f : ennreal × ennreal → β} (h₁ : measurable (λp:nnreal × nnreal, f (p.1, p.2)))
+  (h₂ : measurable (λr:nnreal, f (⊤, r))) (h₃ : measurable (λr:nnreal, f (r, ⊤))) :
+    measurable f :=
+measurable_of_measurable_nnreal_prod
+  (measurable_swap_iff.1 $ measurable_of_measurable_nnreal_prod (h₁.comp measurable_swap) h₃)
+  (measurable_of_measurable_nnreal h₂)
 
 lemma measurable_of_real : measurable ennreal.of_real :=
 ennreal.continuous_of_real.measurable
 
-end ennreal
+lemma measurable_to_real : measurable ennreal.to_real :=
+ennreal.measurable_of_measurable_nnreal nnreal.measurable_coe
 
 lemma measurable_to_nnreal : measurable ennreal.to_nnreal :=
 ennreal.measurable_of_measurable_nnreal measurable_id
 
+lemma measurable_mul : measurable (λ p : ennreal × ennreal, p.1 * p.2) :=
+begin
+  apply measurable_of_measurable_nnreal_nnreal,
+  { simp only [← ennreal.coe_mul, measurable_mul.ennreal_coe] },
+  { simp only [ennreal.top_mul, ennreal.coe_eq_zero],
+    exact measurable_const.piecewise (is_measurable_singleton _) measurable_const },
+  { simp only [ennreal.mul_top, ennreal.coe_eq_zero],
+    exact measurable_const.piecewise (is_measurable_singleton _) measurable_const }
+end
+
+lemma measurable_sub : measurable (λ p : ennreal × ennreal, p.1 - p.2) :=
+by apply measurable_of_measurable_nnreal_nnreal;
+  simp [← ennreal.coe_sub, nnreal.continuous_sub.measurable.ennreal_coe]
+
+end ennreal
+
 lemma measurable.to_nnreal {f : α → ennreal} (hf : measurable f) :
   measurable (λ x, (f x).to_nnreal) :=
-measurable_to_nnreal.comp hf
+ennreal.measurable_to_nnreal.comp hf
 
 lemma measurable_ennreal_coe_iff {f : α → nnreal} :
   measurable (λ x, (f x : ennreal)) ↔ measurable f :=
 ⟨λ h, h.to_nnreal, λ h, h.ennreal_coe⟩
 
-lemma measurable_ennreal_to_real : measurable ennreal.to_real :=
-ennreal.measurable_of_measurable_nnreal nnreal.measurable_coe
-
 lemma measurable.to_real {f : α → ennreal} (hf : measurable f) :
   measurable (λ x, ennreal.to_real (f x)) :=
-measurable_ennreal_to_real.comp hf
+ennreal.measurable_to_real.comp hf
 
-lemma measurable.ennreal_mul {f g : α → ennreal} :
-  measurable f → measurable g → measurable (λa, f a * g a) :=
-begin
-  refine ennreal.measurable_of_measurable_nnreal_nnreal (*) _ _ _,
-  { simp only [ennreal.coe_mul.symm],
-    exact ennreal.measurable_coe.comp measurable_mul },
-  { simp [ennreal.top_mul],
-    exact measurable_const.piecewise
-      (is_closed_eq continuous_id continuous_const).is_measurable
-      measurable_const },
-  { simp [ennreal.mul_top],
-    exact measurable_const.piecewise
-      (is_closed_eq continuous_id continuous_const).is_measurable
-      measurable_const }
-end
+lemma measurable.ennreal_mul {f g : α → ennreal} (hf : measurable f) (hg : measurable g) :
+  measurable (λa, f a * g a) :=
+ennreal.measurable_mul.comp (hf.prod_mk hg)
 
 lemma measurable.ennreal_add {f g : α → ennreal}
   (hf : measurable f) (hg : measurable g) : measurable (λa, f a + g a) :=
 hf.add hg
 
-lemma measurable.ennreal_sub {f g : α → ennreal} :
-  measurable f → measurable g → measurable (λa, f a - g a) :=
-begin
-  refine ennreal.measurable_of_measurable_nnreal_nnreal (has_sub.sub) _ _ _,
-  { simp only [ennreal.coe_sub.symm],
-    exact ennreal.measurable_coe.comp nnreal.continuous_sub.measurable },
-  { simp [measurable_const] },
-  { simp [measurable_const] }
-end
+lemma measurable.ennreal_sub {f g : α → ennreal} (hf : measurable f) (hg : measurable g) :
+  measurable (λa, f a - g a) :=
+ennreal.measurable_sub.comp (hf.prod_mk hg)
 
 /-- note: `ennreal` can probably be generalized in a future version of this lemma. -/
 lemma measurable.ennreal_tsum {ι} [encodable ι] {f : ι → α → ennreal} (h : ∀ i, measurable (f i)) :

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -470,7 +470,7 @@ begin
   exact (hs.inter $ hf ht).union (hs.compl.inter $ hg ht)
 end
 
-lemma measurable_const {α β} [measurable_space α] [measurable_space β] {a : α} :
+@[simp] lemma measurable_const {α β} [measurable_space α] [measurable_space β] {a : α} :
   measurable (λb:β, a) :=
 by { intros s hs, by_cases a ∈ s; simp [*, preimage] }
 


### PR DESCRIPTION
The modifications in `measure_theory/borel_space` are a part of the
proof of measurability of `x^y`, `x : ennreal`, `y : ℝ`, but this
proof depends on a refactoring of `arcsin` I'm going to PR soon.

---
<!-- put comments you want to keep out of the PR commit here -->
