### PR TITLE
[Merged by Bors] - feat(data/mv_polynomial): stub on invertible elements

### DIFF
--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -134,6 +134,15 @@ lemma inv_of_mul [monoid α] (a b : α) [invertible a] [invertible b] [invertibl
   ⅟(a * b) = ⅟b * ⅟a :=
 inv_of_eq_right_inv (by simp [←mul_assoc])
 
+/--
+If `r` is invertible and `s = r`, then `s` is invertible.
+-/
+def invertible.copy [monoid α] {r : α} (hr : invertible r) (s : α) (hs : s = r) : invertible s :=
+{ inv_of := ⅟r,
+  inv_of_mul_self := by rw [hs, inv_of_mul_self],
+  mul_inv_of_self := by rw [hs, mul_inv_of_self] }
+
+
 lemma commute_inv_of {M : Type*} [has_one M] [has_mul M] (m : M) [invertible m] :
   commute m (⅟m) :=
 calc m * ⅟m = 1       : mul_inv_of_self m

--- a/src/data/mv_polynomial/invertible.lean
+++ b/src/data/mv_polynomial/invertible.lean
@@ -26,7 +26,7 @@ invertible.copy (invertible.map (algebra_map R S : R →* S) p) p
 noncomputable instance mv_polynomial.invertible_C
   (σ : Type*) {R : Type*} [comm_semiring R] (r : R) [invertible r] :
   invertible (C r : mv_polynomial σ R) :=
-invertible.map ⟨C, C_1, λ x y, C_mul⟩ _
+invertible.map C.to_monoid_hom _
 
 /-- A natural number that is invertible when coerced to a commutative semiring `R` is also invertible
 when coerced to any polynomial ring with rational coefficients.

--- a/src/data/mv_polynomial/invertible.lean
+++ b/src/data/mv_polynomial/invertible.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2020 Johan Commelin and Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin and Robert Y. Lewis
+-/
+
+import data.mv_polynomial.basic
+import algebra.invertible
+
+/-!
+# Invertible polynomials
+
+This file is a stub containing some basic facts about invertible elements in the ring of polynomials.
+-/
+
+open mv_polynomial
+
+/-- A natural number that is invertible when coerced to `ℚ` is also invertible
+when coerced to any `ℚ`-algebra. -/
+def invertible_rat_algebra_coe_nat (R : Type*) (p : ℕ)
+  [semiring R] [algebra ℚ R] [invertible (p : ℚ)] :
+  invertible (p : R) :=
+invertible.copy (invertible.map (algebra_map ℚ R : ℚ →* R) p) p
+  (by simp only [ring_hom.map_nat_cast, coe_monoid_hom])
+
+noncomputable instance mv_polynomial.invertible_C
+  (σ : Type*) {R : Type*} [comm_semiring R] (r : R) [invertible r] :
+  invertible (C r : mv_polynomial σ R) :=
+invertible.map ⟨C, C_1, λ x y, C_mul⟩ _
+
+/-- A natural number that is invertible when coerced to `ℚ` is also invertible
+when coerced to any polynomial ring with rational coefficients.
+
+Short-cut for typeclass resolution. -/
+noncomputable instance mv_polynomial.invertible_rat_coe_nat
+  (σ : Type*) (p : ℕ) [invertible (p : ℚ)] :
+  invertible (p : mv_polynomial σ ℚ) :=
+invertible_rat_algebra_coe_nat _ _

--- a/src/data/mv_polynomial/invertible.lean
+++ b/src/data/mv_polynomial/invertible.lean
@@ -35,4 +35,4 @@ Short-cut for typeclass resolution. -/
 noncomputable instance mv_polynomial.invertible_coe_nat
   (σ R : Type*) (p : ℕ) [comm_semiring R] [invertible (p : R)] :
   invertible (p : mv_polynomial σ R) :=
-invertible_algebra_coe_nat _ _
+invertible_algebra_coe_nat R _ _

--- a/src/data/mv_polynomial/invertible.lean
+++ b/src/data/mv_polynomial/invertible.lean
@@ -15,12 +15,12 @@ This file is a stub containing some basic facts about invertible elements in the
 
 open mv_polynomial
 
-/-- A natural number that is invertible when coerced to `ℚ` is also invertible
-when coerced to any `ℚ`-algebra. -/
-def invertible_rat_algebra_coe_nat (R : Type*) (p : ℕ)
-  [semiring R] [algebra ℚ R] [invertible (p : ℚ)] :
-  invertible (p : R) :=
-invertible.copy (invertible.map (algebra_map ℚ R : ℚ →* R) p) p
+/-- A natural number that is invertible when coerced to `R` is also invertible
+when coerced to any `R`-algebra. -/
+def invertible_algebra_coe_nat (R S : Type*) (p : ℕ)
+  [comm_semiring R] [semiring S] [algebra R S] [invertible (p : R)] :
+  invertible (p : S) :=
+invertible.copy (invertible.map (algebra_map R S : R →* S) p) p
   (by simp only [ring_hom.map_nat_cast, coe_monoid_hom])
 
 noncomputable instance mv_polynomial.invertible_C
@@ -32,7 +32,7 @@ invertible.map ⟨C, C_1, λ x y, C_mul⟩ _
 when coerced to any polynomial ring with rational coefficients.
 
 Short-cut for typeclass resolution. -/
-noncomputable instance mv_polynomial.invertible_rat_coe_nat
-  (σ : Type*) (p : ℕ) [invertible (p : ℚ)] :
-  invertible (p : mv_polynomial σ ℚ) :=
-invertible_rat_algebra_coe_nat _ _
+noncomputable instance mv_polynomial.invertible_coe_nat
+  (σ R : Type*) (p : ℕ) [comm_semiring R] [invertible (p : R)] :
+  invertible (p : mv_polynomial σ R) :=
+invertible_algebra_coe_nat _ _

--- a/src/data/mv_polynomial/invertible.lean
+++ b/src/data/mv_polynomial/invertible.lean
@@ -28,7 +28,7 @@ noncomputable instance mv_polynomial.invertible_C
   invertible (C r : mv_polynomial σ R) :=
 invertible.map ⟨C, C_1, λ x y, C_mul⟩ _
 
-/-- A natural number that is invertible when coerced to `ℚ` is also invertible
+/-- A natural number that is invertible when coerced to a commutative semiring `R` is also invertible
 when coerced to any polynomial ring with rational coefficients.
 
 Short-cut for typeclass resolution. -/

--- a/src/data/mv_polynomial/invertible.lean
+++ b/src/data/mv_polynomial/invertible.lean
@@ -5,7 +5,7 @@ Authors: Johan Commelin and Robert Y. Lewis
 -/
 
 import data.mv_polynomial.basic
-import algebra.invertible
+import ring_theory.algebra_tower
 
 /-!
 # Invertible polynomials
@@ -14,14 +14,6 @@ This file is a stub containing some basic facts about invertible elements in the
 -/
 
 open mv_polynomial
-
-/-- A natural number that is invertible when coerced to `R` is also invertible
-when coerced to any `R`-algebra. -/
-def invertible_algebra_coe_nat (R S : Type*) (p : ℕ)
-  [comm_semiring R] [semiring S] [algebra R S] [invertible (p : R)] :
-  invertible (p : S) :=
-invertible.copy (invertible.map (algebra_map R S : R →* S) p) p
-  (by simp only [ring_hom.map_nat_cast, coe_monoid_hom])
 
 noncomputable instance mv_polynomial.invertible_C
   (σ : Type*) {R : Type*} [comm_semiring R] (r : R) [invertible r] :
@@ -35,4 +27,4 @@ Short-cut for typeclass resolution. -/
 noncomputable instance mv_polynomial.invertible_coe_nat
   (σ R : Type*) (p : ℕ) [comm_semiring R] [invertible (p : R)] :
   invertible (p : mv_polynomial σ R) :=
-invertible_algebra_coe_nat R _ _
+is_scalar_tower.invertible_algebra_coe_nat R _ _

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau
 -/
 
 import ring_theory.adjoin
+import algebra.invertible
 
 /-!
 # Towers of algebras
@@ -140,6 +141,19 @@ variables (R S A)
 theorem aeval_apply (x : A) (p : polynomial R) : polynomial.aeval x p =
   polynomial.aeval x (polynomial.map (algebra_map R S) p) :=
 by rw [polynomial.aeval_def, polynomial.aeval_def, polynomial.eval₂_map, algebra_map_eq R S A]
+
+/-- Suppose that `R -> S -> A` is a tower of algebras.
+If an element `r : R` is invertible in `S`, then it is invertible in `A`. -/
+def invertible.algebra_tower (r : R) [invertible (algebra_map R S r)] :
+  invertible (algebra_map R A r) :=
+invertible.copy (invertible.map (algebra_map S A : S →* A) (algebra_map R S r)) (algebra_map R A r)
+  (by rw [coe_monoid_hom, is_scalar_tower.algebra_map_apply R S A])
+
+/-- A natural number that is invertible when coerced to `R` is also invertible
+when coerced to any `R`-algebra. -/
+def invertible_algebra_coe_nat (n : ℕ) [inv : invertible (n : R)] :
+  invertible (n : A) :=
+by { haveI : invertible (algebra_map ℕ R n) := inv, exact invertible.algebra_tower ℕ R A n }
 
 end semiring
 


### PR DESCRIPTION
More from the Witt vector branch.

Co-authored-by: Johan Commelin <johan@commelin.net>

---
<!-- put comments you want to keep out of the PR commit here -->

I'm not committed to this location or these names -- I'm not really sure where these belong. Certainly `invertible_rat_algebra_coe_nat` isn't specific to polynomials. Any thoughts?

~~Blocked by #4318~~