### PR TITLE
[Merged by Bors] - chore(ring_theory/algebra): Mark algebra.mem_top as simp

### DIFF
--- a/src/ring_theory/algebra.lean
+++ b/src/ring_theory/algebra.lean
@@ -1117,7 +1117,7 @@ suffices (of_id R A).range = (⊥ : subalgebra R A),
 by { rw [← this, ← subalgebra.mem_coe, alg_hom.coe_range], refl },
 le_bot_iff.mp (λ x hx, subalgebra.range_le _ ((of_id R A).coe_range ▸ hx))
 
-theorem mem_top {x : A} : x ∈ (⊤ : subalgebra R A) :=
+@[simp] theorem mem_top {x : A} : x ∈ (⊤ : subalgebra R A) :=
 subsemiring.subset_closure $ or.inr trivial
 
 @[simp] theorem coe_top : ((⊤ : subalgebra R A) : submodule R A) = ⊤ :=


### PR DESCRIPTION
This is consistent with `subsemiring.mem_top` and `submonoid.mem_top`, both of which are marked simp.


---
<!-- put comments you want to keep out of the PR commit here -->

With this, I can prove ` (alg_hom.id R A).range = (⊤ : subalgebra R A)` `by {ext, simp}`, which is about as much work as I would expect to need for this statement. Perhaps that deserves a direct simp lemma too.
