### PR TITLE
[Merged by Bors] - chore(data/monoid_algebra): Make the style in `lift` consistent

### DIFF
--- a/src/data/monoid_algebra.lean
+++ b/src/data/monoid_algebra.lean
@@ -282,25 +282,36 @@ variables (k G) [comm_semiring k] [monoid G] (R : Type u₃) [semiring R] [algeb
 `monoid_algebra k G →ₐ[k] R`. -/
 def lift : (G →* R) ≃ (monoid_algebra k G →ₐ[k] R) :=
 { inv_fun := λ f, (f : monoid_algebra k G →* R).comp (of k G),
-  to_fun := λ F, { to_fun := λ f, f.sum (λ a b, b • F a),
+  to_fun := λ F, {
+    to_fun := λ f, f.sum (λ a b, b • F a),
     map_one' := by { rw [one_def, sum_single_index, one_smul, F.map_one], apply zero_smul },
-    map_mul' :=
+    map_mul' := λ f g,
       begin
-        intros f g,
-        rw [mul_def, finsupp.sum_mul, finsupp.sum_sum_index];
-          try { intros, simp only [zero_smul, add_smul], done },
-        refine finset.sum_congr rfl (λ a ha, _), simp only,
-        rw [finsupp.mul_sum, finsupp.sum_sum_index];
-          try { intros, simp only [zero_smul, add_smul], done },
-        refine finset.sum_congr rfl (λ a' ha', _), simp only,
-        rw [sum_single_index, F.map_mul, algebra.mul_smul_comm, algebra.smul_mul_assoc,
-          smul_smul, mul_comm],
-        apply zero_smul
+        rw [mul_def, finsupp.sum_mul, finsupp.sum_sum_index],
+        work_on_goal 1 { intros, rw zero_smul, },
+        work_on_goal 1 { intros, rw add_smul, },
+        refine finset.sum_congr rfl (λ a ha, _),
+        simp only,
+        rw [finsupp.mul_sum, finsupp.sum_sum_index],
+        work_on_goal 1 { intros, rw zero_smul, },
+        work_on_goal 1 { intros, rw add_smul, },
+        refine finset.sum_congr rfl (λ a' ha', _),
+        simp only,
+        rw [sum_single_index, F.map_mul, algebra.mul_smul_comm, algebra.smul_mul_assoc, smul_smul, mul_comm],
+        apply zero_smul,
       end,
     map_zero' := sum_zero_index,
-    map_add' := λ f g, by rw [sum_add_index]; intros; simp only [zero_smul, add_smul],
-    commutes' := λ r, by rw [coe_algebra_map, sum_single_index, F.map_one, algebra.smul_def,
-      mul_one]; apply zero_smul },
+    map_add' := λ f g,
+      begin
+        rw [sum_add_index],
+        { intros, rw zero_smul, },
+        { intros, rw add_smul, },
+      end,
+    commutes' := λ r,
+      begin
+        rw [coe_algebra_map, sum_single_index, F.map_one, algebra.smul_def, mul_one],
+        apply zero_smul
+      end, },
   left_inv := λ f, begin ext x, simp [sum_single_index] end,
   right_inv := λ F,
     begin
@@ -634,6 +645,8 @@ def lift [comm_semiring k] [add_monoid G] {R : Type u₃} [semiring R] [algebra 
   (multiplicative G →* R) ≃ (add_monoid_algebra k G →ₐ[k] R) :=
 { inv_fun := λ f, ((f : add_monoid_algebra k G →+* R) : add_monoid_algebra k G →* R).comp (of k G),
   to_fun := λ F, {
+    -- The proofs here are almost identical to `monoid_algebra.lift`, but use `erw` instead of `rw`
+    -- to unfold `multiplicative`
     to_fun := λ f, f.sum (λ a b, b • F a),
     map_one' := by { rw [one_def, sum_single_index, one_smul], erw [F.map_one], apply zero_smul },
     map_mul' := λ f g,


### PR DESCRIPTION
This continues from a06c87ed28989d062aa3d5324e880e62edf4a2f8, which changed add_monoid_algebra.lift but not monoid_algebra.lift.
Note only the additive proof needs `erw` (to unfold `multiplicative`).


---
<!-- put comments you want to keep out of the PR commit here -->

a06c87ed28989d062aa3d5324e880e62edf4a2f8 is #4338