### PR TITLE
[Merged by Bors] - feat(data/nat/parity,data/int/parity): odd numbers

### DIFF
--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -32,6 +32,17 @@ theorem even_iff {n : int} : even n ↔ n % 2 = 0 :=
 lemma not_even_iff {n : ℤ} : ¬ even n ↔ n % 2 = 1 :=
 by rw [even_iff, mod_two_ne_zero]
 
+/-- An integer `n` is `odd` if it is not even.  The mathlib API
+for parity is developed in terms of `even`; to avoid duplication,
+results should not be stated in terms of `odd`.  The purpose of this
+definition is for code outside mathlib that wishes to have a formal
+statement that is as literal a translation as possible of the
+corresponding informal statement, where that informal statement refers
+to odd numbers. -/
+def odd (n : ℤ) : Prop := ¬ even n
+
+@[simp] lemma odd_def (n : ℤ) : odd n ↔ ¬ even n := iff.rfl
+
 @[simp] theorem two_dvd_ne_zero {n : int} : ¬ 2 ∣ n ↔ n % 2 = 1 :=
 not_even_iff
 

--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -49,6 +49,9 @@ not_even_iff
 instance : decidable_pred even :=
 λ n, decidable_of_decidable_of_iff (by apply_instance) even_iff.symm
 
+instance decidable_pred_odd : decidable_pred odd :=
+λ n, decidable_of_decidable_of_iff (by apply_instance) not_even_iff.symm
+
 @[simp] theorem even_zero : even (0 : int) := ⟨0, dec_trivial⟩
 
 @[simp] theorem not_even_one : ¬ even (1 : int) :=

--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 
-The `even` predicate on the integers.
+The `even` and `odd` predicates on the integers.
 -/
 import data.int.modeq
 import data.nat.parity

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -38,6 +38,9 @@ def odd (n : ℕ) : Prop := ¬ even n
 instance : decidable_pred even :=
 λ n, decidable_of_decidable_of_iff (by apply_instance) even_iff.symm
 
+instance decidable_pred_odd : decidable_pred odd :=
+λ n, decidable_of_decidable_of_iff (by apply_instance) not_even_iff.symm
+
 mk_simp_attribute parity_simps "Simp attribute for lemmas about `even`"
 
 @[simp] theorem even_zero : even 0 := ⟨0, dec_trivial⟩

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -24,6 +24,17 @@ theorem even_iff {n : nat} : even n ↔ n % 2 = 0 :=
 lemma not_even_iff {n : ℕ} : ¬ even n ↔ n % 2 = 1 :=
 by rw [even_iff, mod_two_ne_zero]
 
+/-- A natural number `n` is `odd` if it is not even.  The mathlib API
+for parity is developed in terms of `even`; to avoid duplication,
+results should not be stated in terms of `odd`.  The purpose of this
+definition is for code outside mathlib that wishes to have a formal
+statement that is as literal a translation as possible of the
+corresponding informal statement, where that informal statement refers
+to odd numbers. -/
+def odd (n : ℕ) : Prop := ¬ even n
+
+@[simp] lemma odd_def (n : ℕ) : odd n ↔ ¬ even n := iff.rfl
+
 instance : decidable_pred even :=
 λ n, decidable_of_decidable_of_iff (by apply_instance) even_iff.symm
 

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 
-The `even` predicate on the natural numbers.
+The `even` and `odd` predicates on the natural numbers.
 -/
 import data.nat.modeq
 


### PR DESCRIPTION
As discussed at
<https://leanprover.zulipchat.com/#narrow/stream/208328-IMO-grand-challenge/topic/formalizing.20IMO.20problems>,
define `nat.odd` and `int.odd` to allow a more literal expression
(outside of mathlib; for example, in formal olympiad problem
statements) of results whose informal statement refers to odd numbers.
These definitions are not expected to be used in mathlib beyond the
`simp` lemmas added here that translate them back to `¬ even`.  This
is similar to how `>` is defined but almost all mathlib results are
expected to use `<` instead.

It's likely that expressing olympiad problem statements literally in
Lean will end up using some other such definitions, where avoiding API
duplication means almost everything relevant in mathlib is developed
in terms of the expansion of the definition.


---
<!-- put comments you want to keep out of the PR commit here -->
