### PR TITLE
[Merged by Bors] - chore(.github/workflows): github action for crossing off PR dependencies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
 
 ---
-<!-- put comments you want to keep out of the PR commit here -->
+<!--
+put comments you want to keep out of the PR commit here.
+If this PR depends on other PRs, please list them below this comment,
+using the following format:
+- [ ] depends on: #abc [optional extra text]
+- [ ] depends on: #xyz [optional extra text]
+-->

--- a/.github/workflows/sync_closed_tasks.yaml
+++ b/.github/workflows/sync_closed_tasks.yaml
@@ -16,4 +16,3 @@ jobs:
     steps:
       - name: Cross off any linked issue and PR references
         uses: jonabc/sync-task-issues@v1
- 

--- a/.github/workflows/sync_closed_tasks.yaml
+++ b/.github/workflows/sync_closed_tasks.yaml
@@ -1,0 +1,18 @@
+name: Cross off linked issues
+on:
+  # the closed event type causes unchecked checkbox references to be checked / marked complete
+  # the reopened event type causes checked checkbox references to be unchecked / marked incomplete
+  issues:
+    types: [closed, reopened]
+
+  # the action works on pull request events as well
+  pull_requests:
+    types: [closed, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cross off any linked issue and PR references
+        uses: jonabc/sync-task-issues@v1
+ 

--- a/.github/workflows/sync_closed_tasks.yaml
+++ b/.github/workflows/sync_closed_tasks.yaml
@@ -6,7 +6,7 @@ on:
     types: [closed, reopened]
 
   # the action works on pull request events as well
-  pull_requests:
+  pull_request:
     types: [closed, reopened]
 
 jobs:

--- a/.github/workflows/sync_closed_tasks.yaml
+++ b/.github/workflows/sync_closed_tasks.yaml
@@ -1,4 +1,5 @@
 name: Cross off linked issues
+
 on:
   # the closed event type causes unchecked checkbox references to be checked / marked complete
   # the reopened event type causes checked checkbox references to be unchecked / marked incomplete


### PR DESCRIPTION
---
<!-- put comments you want to keep out of the PR commit here -->

The following is a suggestion of @jcommelin. From now on we should track dependent PRs in the top post of a PR as follows:
Instead of
```text
Blocked by: #1337 #4589
```
we should write
```text
- [ ] depends on: #1337
- [ ] depends on: #4589
```

Side benefit: in the PR list you see a little progress bar. See e.g. the second (as of right now) PR in this queue:
https://github.com/leanprover-community/mathlib/pulls?q=is%3Apr+is%3Aopen+label%3Aawaiting-review+author%3Ajcommelin

This PR adds [an action script](https://github.com/marketplace/actions/sync-closed-task-references) which should automatically check off these items as they are completed. 
