### PR TITLE
[Merged by Bors] - feat(data/nat): Slightly strengthen nat.coprime_of_dvd/nat.coprime_of_dvd'

### DIFF
--- a/archive/imo/imo1959_q1.lean
+++ b/archive/imo/imo1959_q1.lean
@@ -24,4 +24,4 @@ have h5 : 3 * (14 * n + 3) = 2 * (21 * n + 4) + 1, by ring,
 (nat.dvd_add_right h3).mp (h5 ▸ h4)
 
 theorem imo1959_q1 : ∀ n : ℕ, coprime (21 * n + 4) (14 * n + 3) :=
-assume n, coprime_of_dvd' (calculation n)
+assume n, coprime_of_dvd' $ λ k hp h1 h2, calculation n k h1 h2

--- a/src/data/nat/gcd.lean
+++ b/src/data/nat/gcd.lean
@@ -189,15 +189,8 @@ theorem coprime.gcd_eq_one {m n : ℕ} : coprime m n → gcd m n = 1 := id
 
 theorem coprime.symm {m n : ℕ} : coprime n m → coprime m n := (gcd_comm m n).trans
 
-theorem coprime_of_dvd {m n : ℕ} (H : ∀ k, 1 < k → k ∣ m → ¬ k ∣ n) : coprime m n :=
-or.elim (eq_zero_or_pos (gcd m n))
-  (λg0, by rw [eq_zero_of_gcd_eq_zero_left g0, eq_zero_of_gcd_eq_zero_right g0] at H; exact false.elim
-    (H 2 dec_trivial (dvd_zero _) (dvd_zero _)))
-  (λ(g1 : 1 ≤ _), eq.symm $ (lt_or_eq_of_le g1).resolve_left $ λg2,
-    H _ g2 (gcd_dvd_left _ _) (gcd_dvd_right _ _))
-
-theorem coprime_of_dvd' {m n : ℕ} (H : ∀ k, k ∣ m → k ∣ n → k ∣ 1) : coprime m n :=
-coprime_of_dvd $ λk kl km kn, not_le_of_gt kl $ le_of_dvd zero_lt_one (H k km kn)
+-- see coprime_of_dvd / coprime_of_dvd' in prime.lean
+-- TODO: should this be mentioned in a doc comment?
 
 theorem coprime.dvd_of_dvd_mul_right {m n k : ℕ} (H1 : coprime k n) (H2 : k ∣ m * n) : k ∣ m :=
 let t := dvd_gcd (dvd_mul_left k m) H2 in

--- a/src/data/nat/gcd.lean
+++ b/src/data/nat/gcd.lean
@@ -181,16 +181,17 @@ dvd_antisymm
     (dvd.trans (dvd_lcm_left m n) (dvd_lcm_left (lcm m n) k))
     (lcm_dvd (dvd.trans (dvd_lcm_right m n) (dvd_lcm_left (lcm m n) k)) (dvd_lcm_right (lcm m n) k)))
 
-/-! ### `coprime` -/
+/-!
+### `coprime`
+
+See also `nat.coprime_of_dvd` and `nat.coprime_of_dvd'` to prove `nat.coprime m n`.
+-/
 
 instance (m n : ℕ) : decidable (coprime m n) := by unfold coprime; apply_instance
 
 theorem coprime.gcd_eq_one {m n : ℕ} : coprime m n → gcd m n = 1 := id
 
 theorem coprime.symm {m n : ℕ} : coprime n m → coprime m n := (gcd_comm m n).trans
-
--- see coprime_of_dvd / coprime_of_dvd' in prime.lean
--- TODO: should this be mentioned in a doc comment?
 
 theorem coprime.dvd_of_dvd_mul_right {m n k : ℕ} (H1 : coprime k n) (H2 : k ∣ m * n) : k ∣ m :=
 let t := dvd_gcd (dvd_mul_left k m) H2 in

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -131,7 +131,7 @@ lemma modeq_and_modeq_iff_modeq_mul {a b m n : ℕ} (hmn : coprime m n) :
 λ h, ⟨nat.modeq.modeq_of_modeq_mul_right _ h, nat.modeq.modeq_of_modeq_mul_left _ h⟩⟩
 
 lemma coprime_of_mul_modeq_one (b : ℕ) {a n : ℕ} (h : a * b ≡ 1 [MOD n]) : coprime a n :=
-nat.coprime_of_dvd' (λ k ⟨ka, hka⟩ ⟨kb, hkb⟩, int.coe_nat_dvd.1 begin
+nat.coprime_of_dvd' (λ k kp ⟨ka, hka⟩ ⟨kb, hkb⟩, int.coe_nat_dvd.1 begin
   rw [hka, hkb, modeq_iff_dvd] at h,
   cases h with z hz,
   rw [sub_eq_iff_eq_add] at hz,

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -332,6 +332,25 @@ lemma prime.eq_two_or_odd {p : ℕ} (hp : prime p) : p = 2 ∨ p % 2 = 1 :=
   (λ h, or.inl ((hp.2 2 (dvd_of_mod_eq_zero h)).resolve_left dec_trivial).symm)
   or.inr
 
+theorem coprime_of_dvd {m n : ℕ} (H : ∀ k, prime k → k ∣ m → ¬ k ∣ n) : coprime m n :=
+begin
+  cases eq_zero_or_pos (gcd m n) with g0 g1,
+  { rw [eq_zero_of_gcd_eq_zero_left g0, eq_zero_of_gcd_eq_zero_right g0] at H,
+    exfalso,
+    exact H 2 prime_two (dvd_zero _) (dvd_zero _) },
+  apply eq.symm,
+  change 1 ≤ _ at g1,
+  apply (lt_or_eq_of_le g1).resolve_left,
+  intro g2,
+  obtain ⟨p, hp, hpdvd⟩ := exists_prime_and_dvd g2,
+  apply H p hp; apply dvd_trans hpdvd,
+  { exact gcd_dvd_left _ _ },
+  { exact gcd_dvd_right _ _ }
+end
+
+theorem coprime_of_dvd' {m n : ℕ} (H : ∀ k, prime k → k ∣ m → k ∣ n → k ∣ 1) : coprime m n :=
+coprime_of_dvd $ λk kp km kn, not_le_of_gt kp.one_lt $ le_of_dvd zero_lt_one $ H k kp km kn
+
 theorem factors_lemma {k} : (k+2) / min_fac (k+2) < k+2 :=
 div_lt_self dec_trivial (min_fac_prime dec_trivial).one_lt
 
@@ -382,7 +401,7 @@ lemma factors_add_two (n : ℕ) :
 
 theorem prime.coprime_iff_not_dvd {p n : ℕ} (pp : prime p) : coprime p n ↔ ¬ p ∣ n :=
 ⟨λ co d, pp.not_dvd_one $ co.dvd_of_dvd_mul_left (by simp [d]),
- λ nd, coprime_of_dvd $ λ m m2 mp, ((dvd_prime_two_le pp m2).1 mp).symm ▸ nd⟩
+ λ nd, coprime_of_dvd $ λ m m2 mp, ((prime_dvd_prime_iff_eq m2 pp).1 mp).symm ▸ nd⟩
 
 theorem prime.dvd_iff_not_coprime {p n : ℕ} (pp : prime p) : p ∣ n ↔ ¬ coprime p n :=
 iff_not_comm.2 pp.coprime_iff_not_dvd

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -196,7 +196,7 @@ section
   by injection (pell_zd_sub a1 h) with _ h; repeat {rw ← neg_mul_eq_mul_neg at h}; rw [add_comm, mul_comm] at h; exact h
 
   theorem xy_coprime (n) : (xn n).coprime (yn n) :=
-  nat.coprime_of_dvd' $ λk kx ky,
+  nat.coprime_of_dvd' $ λk kp kx ky,
   let p := pell_eq n in by rw ← p; exact
   nat.dvd_sub (le_of_lt $ nat.lt_of_sub_eq_succ p)
     (dvd_mul_of_dvd_right kx _) (dvd_mul_of_dvd_right ky _)


### PR DESCRIPTION
It is sufficient to consider prime factors.

The theorems now depend on nat.prime (data/nat/prime.lean), which depends on
data/nat/gcd.lean, so I moved them to prime.lean.


---
<!-- put comments you want to keep out of the PR commit here -->
