### PR TITLE
feat(archive/imo): formalize IMO 1964 problem 1

### DIFF
--- a/archive/imo/imo1964_q1.lean
+++ b/archive/imo/imo1964_q1.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2020 Kenji Nakagawa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenji Nakagawa
+-/
+
+import tactic.basic
+import data.zmod.basic
+
+
+/-!
+# IMO 1959 Q1
+
+Prove that the fraction `(21n+4)/(14n+3)` is irreducible for every natural number `n`.
+
+Since Lean doesn't have a concept of "irreducible fractions" per se, we just formalize this
+as saying the numerator and denominator are relatively prime.
+-/
+
+lemma modfact1 (n : ℕ): ((2^(3+n)) : zmod 7).val = (2^n : zmod 7).val :=
+begin
+  have h2 : (2^3 : zmod 7) = 1 := by refl,
+  have h4 : (2^(3+n) : zmod 7).val = (2^3*2^n : zmod 7).val := congr_arg zmod.val (pow_add 2 3 n),
+  rwa [h2,one_mul] at h4,
+end
+
+lemma modfact2 (n : ℕ) : (2^n : zmod 7) = 2^(n : zmod 3).val :=
+begin
+  norm_cast at *,
+
+  sorry,
+
+end
+
+example (n : ℕ) : ((2^n -1) : zmod 7).val = 0 ↔ (n : zmod 3).val = 0 :=
+begin
+  split,
+  { rw modfact2,
+    have h1 := zmod.val_lt (n : zmod 3),
+    intro hn,
+    rw zmod.val_eq_zero _ at hn,
+    have h2 : (n : zmod 3).val = 0 ∨ (n : zmod 3).val = 1 ∨ (n : zmod 3).val = 2 := by omega,
+    cases h2,
+    assumption,
+    cases h2;
+    rw h2 at hn;
+    exfalso;
+    norm_num at hn,
+    contrapose! hn,
+    dec_trivial },
+  { intro hn,
+    rw [(zmod.val_eq_zero (2^n - 1)), modfact2, hn],
+    norm_num }
+end
+
+example (n : ℕ) : ¬((2^n + 1) : zmod 7).val = 0 :=
+begin
+  intro hn,
+  have h1 := zmod.val_lt (n : zmod 3),
+  have h2 : (n : zmod 3).val = 0 ∨ (n : zmod 3).val = 1 ∨ (n : zmod 3).val = 2 := by omega,
+  rw [zmod.val_eq_zero,modfact2] at hn,
+  repeat {cases h2};
+  rw h2 at hn; ring at hn; contrapose! hn; dec_trivial,
+end

--- a/archive/imo/imo1964_q1.lean
+++ b/archive/imo/imo1964_q1.lean
@@ -4,61 +4,61 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenji Nakagawa
 -/
 
-import tactic.basic
+import tactic
+import tactic.fin_cases
 import data.zmod.basic
+import field_theory.finite.basic
 
+@[simp] lemma zmod.pow_bit0 (n : ℕ) [fact (bit1 n).prime] (k : zmod (bit1 n)) (hk : k ≠ 0) :
+  k ^ (bit0 n) = 1 :=
+zmod.pow_card_sub_one_eq_one hk
+
+lemma modfact (n : ℕ) : (2^n : zmod 7) = 2 ^ (n : zmod 3).val :=
+begin
+  have h1 : ∀ (k : ℕ), k < 6 → (2^k : zmod 7) = 2 ^ (k : zmod 3).val := by dec_trivial,
+  haveI : fact (nat.prime 7) := by { delta fact, norm_num },
+  have h2 : (2 : zmod 7) ≠ 0 := dec_trivial,
+  rw ← nat.mod_add_div n 6,
+  simp only [h2, pow_add, pow_mul, bit0_zero, one_pow, add_zero, mul_one, zmod.cast_self,
+    zmod.pow_bit0, nat.cast_bit0, zero_mul, ne.def, nat.cast_add, not_false_iff, nat.cast_mul],
+  apply h1,
+  apply nat.mod_lt,
+  norm_num,
+end
 
 /-!
-# IMO 1959 Q1
+# IMO 1964 Q1
 
-Prove that the fraction `(21n+4)/(14n+3)` is irreducible for every natural number `n`.
+* (a) Find all positive integers `n` for which `2^n-1` is divisble by `7`.
+* (b) Prove that there is no positive integer `n` for which `2^n+1` is divisible by `7`.
 
-Since Lean doesn't have a concept of "irreducible fractions" per se, we just formalize this
-as saying the numerator and denominator are relatively prime.
 -/
-
-lemma modfact1 (n : ℕ): ((2^(3+n)) : zmod 7).val = (2^n : zmod 7).val :=
-begin
-  have h2 : (2^3 : zmod 7) = 1 := by refl,
-  have h4 : (2^(3+n) : zmod 7).val = (2^3*2^n : zmod 7).val := congr_arg zmod.val (pow_add 2 3 n),
-  rwa [h2,one_mul] at h4,
-end
-
-lemma modfact2 (n : ℕ) : (2^n : zmod 7) = 2^(n : zmod 3).val :=
-begin
-  norm_cast at *,
-
-  sorry,
-
-end
-
-example (n : ℕ) : ((2^n -1) : zmod 7).val = 0 ↔ (n : zmod 3).val = 0 :=
+example (n : ℕ) (gt_zero : 0 < n) : ((2^n -1) : zmod 7) = 0 ↔ (n : zmod 3) = 0 :=
 begin
   split,
-  { rw modfact2,
+  { rw modfact,
     have h1 := zmod.val_lt (n : zmod 3),
     intro hn,
-    rw zmod.val_eq_zero _ at hn,
     have h2 : (n : zmod 3).val = 0 ∨ (n : zmod 3).val = 1 ∨ (n : zmod 3).val = 2 := by omega,
     cases h2,
-    assumption,
+    exact fin.ext h2,
     cases h2;
     rw h2 at hn;
-    exfalso;
+    exfalso,
     norm_num at hn,
     contrapose! hn,
     dec_trivial },
   { intro hn,
-    rw [(zmod.val_eq_zero (2^n - 1)), modfact2, hn],
+    rw [modfact, hn],
     norm_num }
 end
 
-example (n : ℕ) : ¬((2^n + 1) : zmod 7).val = 0 :=
+example (n : ℕ) (gt_zero : 0 < n) : ¬((2^n + 1) : zmod 7) = 0 :=
 begin
   intro hn,
   have h1 := zmod.val_lt (n : zmod 3),
   have h2 : (n : zmod 3).val = 0 ∨ (n : zmod 3).val = 1 ∨ (n : zmod 3).val = 2 := by omega,
-  rw [zmod.val_eq_zero,modfact2] at hn,
+  rw [modfact] at hn,
   repeat {cases h2};
   rw h2 at hn; ring at hn; contrapose! hn; dec_trivial,
 end

--- a/archive/imo/imo1964_q1.lean
+++ b/archive/imo/imo1964_q1.lean
@@ -4,14 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenji Nakagawa
 -/
 
-import tactic
-import tactic.fin_cases
-import data.zmod.basic
 import field_theory.finite.basic
-
-@[simp] lemma zmod.pow_bit0 (n : ℕ) [fact (bit1 n).prime] (k : zmod (bit1 n)) (hk : k ≠ 0) :
-  k ^ (bit0 n) = 1 :=
-zmod.pow_card_sub_one_eq_one hk
 
 lemma modfact (n : ℕ) : (2^n : zmod 7) = 2 ^ (n : zmod 3).val :=
 begin
@@ -31,7 +24,6 @@ end
 
 * (a) Find all positive integers `n` for which `2^n-1` is divisble by `7`.
 * (b) Prove that there is no positive integer `n` for which `2^n+1` is divisible by `7`.
-
 -/
 example (n : ℕ) (gt_zero : 0 < n) : ((2^n -1) : zmod 7) = 0 ↔ (n : zmod 3) = 0 :=
 begin

--- a/archive/imo/imo1964_q1.lean
+++ b/archive/imo/imo1964_q1.lean
@@ -19,35 +19,72 @@ begin
   norm_num,
 end
 
+/- TODO(?) : Refactor to only use `%` -/
+lemma modfact' (n : ℕ) : (2^n : ℕ) % 7 = 2^(n % 3) % 7 :=
+begin
+  have h1 : ∀(k : ℕ), k < 6 → ((2^k : ℕ) % 7) = 2^(k % 3) % 7 := by dec_trivial,
+  haveI : fact (nat.prime 7) := by { delta fact, norm_num },
+  have h2 : (2 % 7) ≠ 0 := dec_trivial,
+  rw ← nat.mod_add_div n 6,
+  have : 6 * (n / 6) % 3 = 0, sorry,
+  --simp similar to above
+  sorry,
+end
+
+
 /-!
 # IMO 1964 Q1
 
-* (a) Find all positive integers `n` for which `2^n-1` is divisble by `7`.
+* (a) Find all positive integers `n` for which `2^n-1` is divisible by `7`.
 * (b) Prove that there is no positive integer `n` for which `2^n+1` is divisible by `7`.
 -/
-example (n : ℕ) (gt_zero : 0 < n) : ((2^n -1) : zmod 7) = 0 ↔ (n : zmod 3) = 0 :=
+
+lemma nonneg (n : ℕ) (gt_zero : 0 < n) : 1 ≤ (2^n : ℤ) :=
 begin
+    { induction gt_zero with k h1 h2,
+      simp only [nat.succ_pos', pow_one, nat.one_le_bit0_iff],
+      rw [pow_succ,mul_comm],
+      suffices : 1 * (1 : ℤ) ≤ 2^k * 2, rwa mul_one (1 : ℤ) at this,
+      apply int.mul_le_mul h2;
+      linarith, }
+end
+
+lemma modcoe (n : ℕ) (gt_zero : 0 < n) : (↑(2^n-1) : zmod 7) = 2^n-1 :=
+begin
+  have nonne := nonneg n gt_zero,
+  suffices : ((2^n-1) : ℕ) = 2^n-1,
+  have h1 : 1 ≤ 2^n := by linarith,
+  sorry,
+  exact ⟨_⟩,
+end
+
+
+example (n : ℕ) (gt_zero : 0 < n) : 7 ∣ 2^(n : ℕ) -1 ↔ 3 ∣ n :=
+begin
+  repeat {rw [←zmod.nat_coe_zmod_eq_zero_iff_dvd]},
   split,
-  { rw modfact,
+  { intro hn,
+    rw [(modcoe n gt_zero), modfact] at hn,
     have h1 := zmod.val_lt (n : zmod 3),
-    intro hn,
     have h2 : (n : zmod 3).val = 0 ∨ (n : zmod 3).val = 1 ∨ (n : zmod 3).val = 2 := by omega,
     cases h2,
     exact fin.ext h2,
     cases h2;
     rw h2 at hn;
-    exfalso,
+    exfalso;
     norm_num at hn,
     contrapose! hn,
-    dec_trivial },
+    dec_trivial,},
   { intro hn,
-    rw [modfact, hn],
-    norm_num }
+    rw [(modcoe n gt_zero), modfact, hn],
+    norm_num,}
 end
 
-example (n : ℕ) (gt_zero : 0 < n) : ¬((2^n + 1) : zmod 7) = 0 :=
+example (n : ℕ) (gt_zero : 0 < n) : ¬(7 ∣ (2^n + 1)) :=
 begin
   intro hn,
+  rw [←zmod.nat_coe_zmod_eq_zero_iff_dvd] at hn,
+  simp only [nat.cast_bit0, nat.cast_add, nat.cast_one, nat.cast_pow] at hn,
   have h1 := zmod.val_lt (n : zmod 3),
   have h2 : (n : zmod 3).val = 0 ∨ (n : zmod 3).val = 1 ∨ (n : zmod 3).val = 2 := by omega,
   rw [modfact] at hn,

--- a/src/field_theory/finite/basic.lean
+++ b/src/field_theory/finite/basic.lean
@@ -314,6 +314,10 @@ theorem pow_card_sub_one_eq_one {p : ℕ} [fact p.prime] {a : zmod p} (ha : a �
   a ^ (p - 1) = 1 :=
 by { have h := pow_card_sub_one_eq_one a ha, rwa zmod.card p at h }
 
+@[simp] lemma pow_bit0 (n : ℕ) [fact (bit1 n).prime] (k : zmod (bit1 n)) (hk : k ≠ 0) :
+  k ^ (bit0 n) = 1 :=
+pow_card_sub_one_eq_one hk
+
 open polynomial
 
 lemma expand_card {p : ℕ} [fact p.prime] (f : polynomial (zmod p)) :


### PR DESCRIPTION
The [problem](https://artofproblemsolving.com/wiki/index.php/1964_IMO_Problems/Problem_1) states:
(a) Find all positive n such that 2^n-1 is divisible by 7
(b) Prove that for all positive n, 2^n+1 is not divisible by 7
<!-- put comments you want to keep out of the PR commit here -->
It might be more desirable to have it be in a more literal formalization of the problem statements, however, coercions seem painful to get to zmod.
Also features a nice simp lemma, thanks to @jcommelin (as well as main fact) as discussed [here](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/easy.20zmod.20proof/near/211873184).