### PR TITLE
[Merged by Bors] - chore(category_theory/limits/binary_products): weaken assumptions

### DIFF
--- a/src/category_theory/limits/shapes/constructions/preserve_binary_products.lean
+++ b/src/category_theory/limits/shapes/constructions/preserve_binary_products.lean
@@ -23,23 +23,24 @@ universes v u₁ u₂ u₃ -- declare the `v`'s first; see `category_theory.cate
 variables {C : Type u₁} [category.{v} C]
 variables {D : Type u₂} [category.{v} D]
 
-variables [has_binary_products D] (F : C ⥤ D)
+variables (F : C ⥤ D)
 
 /-- (Implementation). Construct a cone for `pair A B ⋙ F` which we will show is limiting. -/
 @[simps]
-def alternative_cone (A B : C) : cone (pair A B ⋙ F) :=
+def alternative_cone (A B : C) [has_limit (pair (F.obj A) (F.obj B))] : cone (pair A B ⋙ F) :=
 { X := F.obj A ⨯ F.obj B,
   π := discrete.nat_trans (λ j, walking_pair.cases_on j limits.prod.fst limits.prod.snd)}
 
 /-- (Implementation). Show that we have a limit for the shape `pair A B ⋙ F`. -/
-def alternative_cone_is_limit (A B : C) : is_limit (alternative_cone F A B) :=
+def alternative_cone_is_limit (A B : C) [has_limit (pair (F.obj A) (F.obj B))] :
+  is_limit (alternative_cone F A B) :=
 { lift := λ s, prod.lift (s.π.app walking_pair.left) (s.π.app walking_pair.right),
   fac' := λ s j, walking_pair.cases_on j (prod.lift_fst _ _) (prod.lift_snd _ _),
   uniq' := λ s m w, prod.hom_ext
     (by { rw prod.lift_fst, apply w walking_pair.left })
     (by { rw prod.lift_snd, apply w walking_pair.right }) }
 
-variable [has_binary_products C]
+variables [has_binary_products C] [has_binary_products D]
 
 /-- If `prod_comparison F A B` is an iso, then `F` preserves the limit `A ⨯ B`. -/
 def preserves_binary_prod_of_prod_comparison_iso (A B : C) [is_iso (prod_comparison F A B)] :


### PR DESCRIPTION
weakens the assumptions on which limits need to exist for these constructions

not much of a change but the assumptions I used were too strong so just a small fix