### PR TITLE
[Merged by Bors] - chore(category_theory/limits/binary_products): fixup binary product lemmas

### DIFF
--- a/src/category_theory/abelian/non_preadditive.lean
+++ b/src/category_theory/abelian/non_preadditive.lean
@@ -575,7 +575,7 @@ by simp
 
 /-- σ is a cokernel of Δ X. -/
 def is_colimit_σ {X : C} : is_colimit (cokernel_cofork.of_π σ diag_σ) :=
-cokernel.cokernel_iso _ σ (as_iso (r X)).symm (by simp)
+cokernel.cokernel_iso _ σ (as_iso (r X)).symm (by rw [iso.symm_hom, as_iso_inv])
 
 /-- This is the key identity satisfied by `σ`. -/
 lemma σ_comp {X Y : C} (f : X ⟶ Y) : σ ≫ f = limits.prod.map f f ≫ σ :=

--- a/src/category_theory/abelian/non_preadditive.lean
+++ b/src/category_theory/abelian/non_preadditive.lean
@@ -615,11 +615,11 @@ lemma sub_zero {X Y : C} (a : X ⟶ Y) : a - 0 = a :=
 begin
   rw sub_def,
   conv_lhs { congr, congr, rw ←category.comp_id a, skip, rw (show 0 = a ≫ (0 : Y ⟶ Y), by simp)},
-  rw [← prod.lift_comp_comp, category.assoc, lift_σ, category.comp_id]
+  rw [← prod.comp_lift, category.assoc, lift_σ, category.comp_id]
 end
 
 lemma sub_self {X Y : C} (a : X ⟶ Y) : a - a = 0 :=
-by rw [sub_def, ←category.comp_id a, ← prod.lift_comp_comp, category.assoc, diag_σ, comp_zero]
+by rw [sub_def, ←category.comp_id a, ← prod.comp_lift, category.assoc, diag_σ, comp_zero]
 
 lemma lift_sub_lift {X Y : C} (a b c d : X ⟶ Y) :
   prod.lift a b - prod.lift c d = prod.lift (a - c) (b - d) :=
@@ -686,7 +686,7 @@ lemma add_zero {X Y : C} (a : X ⟶ Y) : a + 0 = a :=
 by rw [add_def, neg_def, sub_self, sub_zero]
 
 lemma comp_sub {X Y Z : C} (f : X ⟶ Y) (g h : Y ⟶ Z) : f ≫ (g - h) = f ≫ g - f ≫ h :=
-by rw [sub_def, ←category.assoc, prod.lift_comp_comp, sub_def]
+by rw [sub_def, ←category.assoc, prod.comp_lift, sub_def]
 
 lemma sub_comp {X Y Z : C} (f g : X ⟶ Y) (h : Y ⟶ Z) : (f - g) ≫ h = f ≫ h - g ≫ h :=
 by rw [sub_def, category.assoc, σ_comp, ←category.assoc, prod.lift_map, sub_def]

--- a/src/category_theory/abelian/non_preadditive.lean
+++ b/src/category_theory/abelian/non_preadditive.lean
@@ -499,22 +499,19 @@ is_kernel.iso_kernel _ _
 end cokernel_of_kernel
 section
 
-/-- The diagonal morphism `(𝟙 A, 𝟙 A) : A → A ⨯ A`. -/
-abbreviation Δ (A : C) : A ⟶ A ⨯ A := prod.lift (𝟙 A) (𝟙 A)
-
 /-- The composite `A ⟶ A ⨯ A ⟶ cokernel (Δ A)`, where the first map is `(𝟙 A, 0)` and the second map
     is the canonical projection into the cokernel. -/
-abbreviation r (A : C) : A ⟶ cokernel (Δ A) := prod.lift (𝟙 A) 0 ≫ cokernel.π (Δ A)
+abbreviation r (A : C) : A ⟶ cokernel (diag A) := prod.lift (𝟙 A) 0 ≫ cokernel.π (diag A)
 
-instance mono_Δ {A : C} : mono (Δ A) := mono_of_mono_fac $ prod.lift_fst _ _
+instance mono_Δ {A : C} : mono (diag A) := mono_of_mono_fac $ prod.lift_fst _ _
 
 instance mono_r {A : C} : mono (r A) :=
 begin
-  let hl : is_limit (kernel_fork.of_ι (Δ A) (cokernel.condition (Δ A))),
+  let hl : is_limit (kernel_fork.of_ι (diag A) (cokernel.condition (diag A))),
   { exact mono_is_kernel_of_cokernel _ (colimit.is_colimit _) },
   apply mono_of_cancel_zero,
   intros Z x hx,
-  have hxx : (x ≫ prod.lift (𝟙 A) (0 : A ⟶ A)) ≫ cokernel.π (Δ A) = 0,
+  have hxx : (x ≫ prod.lift (𝟙 A) (0 : A ⟶ A)) ≫ cokernel.π (diag A) = 0,
   { rw [category.assoc, hx] },
   obtain ⟨y, hy⟩ := kernel_fork.is_limit.lift' hl _ hxx,
   rw kernel_fork.ι_of_ι at hy,
@@ -542,7 +539,7 @@ begin
   { exact epi_is_cokernel_of_kernel _ hp1 },
   apply epi_of_zero_cancel,
   intros Z z hz,
-  have h : prod.lift (𝟙 A) (0 : A ⟶ A) ≫ cokernel.π (Δ A) ≫ z = 0,
+  have h : prod.lift (𝟙 A) (0 : A ⟶ A) ≫ cokernel.π (diag A) ≫ z = 0,
   { rw [←category.assoc, hz] },
   obtain ⟨t, ht⟩ := cokernel_cofork.is_colimit.desc' hp2 _ h,
   rw cokernel_cofork.π_of_π at ht,
@@ -551,36 +548,33 @@ begin
     change 𝟙 A ≫ t = 0,
     rw [←limits.prod.lift_snd (𝟙 A) (𝟙 A), category.assoc, ht, ←category.assoc,
       cokernel.condition, zero_comp] },
-  apply (cancel_epi (cokernel.π (Δ A))).1,
+  apply (cancel_epi (cokernel.π (diag A))).1,
   rw [←ht, htt, comp_zero, comp_zero]
 end
 
 instance is_iso_r {A : C} : is_iso (r A) :=
 is_iso_of_mono_of_epi _
 
-/-- The composite `A ⨯ A ⟶ cokernel (Δ A) ⟶ A` given by the natural projection into the cokernel
+/-- The composite `A ⨯ A ⟶ cokernel (diag A) ⟶ A` given by the natural projection into the cokernel
     followed by the inverse of `r`. In the category of modules, using the normal kernels and
     cokernels, this map is equal to the map `(a, b) ↦ a - b`, hence the name `σ` for
     "subtraction". -/
-abbreviation σ {A : C} : A ⨯ A ⟶ A := cokernel.π (Δ A) ≫ is_iso.inv (r A)
+abbreviation σ {A : C} : A ⨯ A ⟶ A := cokernel.π (diag A) ≫ is_iso.inv (r A)
 
 end
 
-@[simp, reassoc] lemma Δ_σ {X : C} : Δ X ≫ σ = 0 :=
+@[simp, reassoc] lemma diag_σ {X : C} : diag X ≫ σ = 0 :=
 by rw [cokernel.condition_assoc, zero_comp]
 
 @[simp, reassoc] lemma lift_σ {X : C} : prod.lift (𝟙 X) 0 ≫ σ = 𝟙 X :=
 by rw [←category.assoc, is_iso.hom_inv_id]
 
-@[simp, reassoc] lemma Δ_map {X Y : C} (f : X ⟶ Y) : Δ X ≫ limits.prod.map f f = f ≫ Δ Y :=
-by ext; simp; erw category.id_comp
-
 @[reassoc] lemma lift_map {X Y : C} (f : X ⟶ Y) :
   prod.lift (𝟙 X) 0 ≫ limits.prod.map f f = f ≫ prod.lift (𝟙 Y) 0 :=
-by ext; simp; erw category.id_comp
+by simp
 
 /-- σ is a cokernel of Δ X. -/
-def is_colimit_σ {X : C} : is_colimit (cokernel_cofork.of_π σ Δ_σ) :=
+def is_colimit_σ {X : C} : is_colimit (cokernel_cofork.of_π σ diag_σ) :=
 cokernel.cokernel_iso _ σ (as_iso (r X)).symm (by simp)
 
 /-- This is the key identity satisfied by `σ`. -/
@@ -621,12 +615,11 @@ lemma sub_zero {X Y : C} (a : X ⟶ Y) : a - 0 = a :=
 begin
   rw sub_def,
   conv_lhs { congr, congr, rw ←category.comp_id a, skip, rw (show 0 = a ≫ (0 : Y ⟶ Y), by simp)},
-  rw [prod.lift_comp_comp, category.assoc, lift_σ, category.comp_id]
+  rw [← prod.lift_comp_comp, category.assoc, lift_σ, category.comp_id]
 end
 
 lemma sub_self {X Y : C} (a : X ⟶ Y) : a - a = 0 :=
-by rw [sub_def, ←category.comp_id a, prod.lift_comp_comp, category.assoc, Δ_σ,
-  has_zero_morphisms.comp_zero]
+by rw [sub_def, ←category.comp_id a, ← prod.lift_comp_comp, category.assoc, diag_σ, comp_zero]
 
 lemma lift_sub_lift {X Y : C} (a b c d : X ⟶ Y) :
   prod.lift a b - prod.lift c d = prod.lift (a - c) (b - d) :=
@@ -639,9 +632,7 @@ end
 
 lemma sub_sub_sub {X Y : C} (a b c d : X ⟶ Y) : (a - c) - (b - d) = (a - b) - (c - d) :=
 begin
-  rw sub_def,
-  erw ←lift_sub_lift,
-  rw [sub_def, category.assoc, σ_comp, ←category.assoc, prod.lift_map, sub_def, sub_def, sub_def]
+  rw [sub_def, ←lift_sub_lift, sub_def, category.assoc, σ_comp, prod.lift_map_assoc], refl
 end
 
 lemma neg_sub {X Y : C} (a b : X ⟶ Y) : (-a) - b = (-b) - a :=
@@ -695,7 +686,7 @@ lemma add_zero {X Y : C} (a : X ⟶ Y) : a + 0 = a :=
 by rw [add_def, neg_def, sub_self, sub_zero]
 
 lemma comp_sub {X Y Z : C} (f : X ⟶ Y) (g h : Y ⟶ Z) : f ≫ (g - h) = f ≫ g - f ≫ h :=
-by rw [sub_def, ←category.assoc, ←prod.lift_comp_comp, sub_def]
+by rw [sub_def, ←category.assoc, prod.lift_comp_comp, sub_def]
 
 lemma sub_comp {X Y Z : C} (f g : X ⟶ Y) (h : Y ⟶ Z) : (f - g) ≫ h = f ≫ h - g ≫ h :=
 by rw [sub_def, category.assoc, σ_comp, ←category.assoc, prod.lift_map, sub_def]

--- a/src/category_theory/closed/cartesian.lean
+++ b/src/category_theory/closed/cartesian.lean
@@ -352,7 +352,7 @@ def cartesian_closed_of_equiv (e : C ≌ D) [h : cartesian_closed C] : cartesian
         apply prod.map_iso (iso.refl _) (e.unit_iso.app Y).symm },
       { intros Y Z g,
         dsimp [prod_comparison],
-        simp [prod.lift_comp_comp, ← e.inverse.map_comp, ← e.inverse.map_comp_assoc],
+        simp [prod.comp_lift, ← e.inverse.map_comp, ← e.inverse.map_comp_assoc],
           -- I wonder if it would be a good idea to make `map_comp` a simp lemma the other way round
         dsimp, simp -- See note [dsimp, simp]
         },

--- a/src/category_theory/closed/cartesian.lean
+++ b/src/category_theory/closed/cartesian.lean
@@ -224,13 +224,6 @@ by { rw [pre, prod_map_id_id, id_comp, ← uncurry_id_eq_ev], simp }
 
 -- There's probably a better proof of this somehow
 /-- Precomposition is contrafunctorial. -/
--- @[simp, reassoc] lemma ev_coev :
---   limits.prod.map (𝟙 A) ((coev A).app B) ≫ (ev A).app (A ⨯ B) = 𝟙 (A ⨯ B) :=
--- adjunction.left_triangle_components (exp.adjunction A)
-
--- @[simp, reassoc] lemma coev_ev : (coev A).app (A⟹B) ≫ (exp A).map ((ev A).app B) = 𝟙 (A⟹B) :=
--- adjunction.right_triangle_components (exp.adjunction A)
-
 lemma pre_map [exponentiable B] {D : C} [exponentiable D] (f : A ⟶ B) (g : B ⟶ D) :
   pre X (f ≫ g) = pre X g ≫ pre X f :=
 begin

--- a/src/category_theory/closed/cartesian.lean
+++ b/src/category_theory/closed/cartesian.lean
@@ -86,15 +86,15 @@ def exp : C ⥤ C :=
 (@closed.is_adj _ _ _ A _).right
 
 /-- The adjunction between A ⨯ - and (-)^A. -/
-def exp.adjunction : prod_functor.obj A ⊣ exp A :=
+def exp.adjunction : prod.functor.obj A ⊣ exp A :=
 closed.is_adj.adj
 
 /-- The evaluation natural transformation. -/
-def ev : exp A ⋙ prod_functor.obj A ⟶ 𝟭 C :=
+def ev : exp A ⋙ prod.functor.obj A ⟶ 𝟭 C :=
 closed.is_adj.adj.counit
 
 /-- The coevaluation natural transformation. -/
-def coev : 𝟭 C ⟶ prod_functor.obj A ⋙ exp A :=
+def coev : 𝟭 C ⟶ prod.functor.obj A ⋙ exp A :=
 closed.is_adj.adj.unit
 
 @[simp, reassoc]
@@ -183,7 +183,7 @@ lemma curry_eq (g : A ⨯ Y ⟶ X) : curry g = (coev A).app Y ≫ (exp A).map g 
 adjunction.hom_equiv_unit _
 
 lemma uncurry_id_eq_ev (A X : C) [exponentiable A] : uncurry (𝟙 (A ⟹ X)) = (ev A).app X :=
-by rw [uncurry_eq, prod_map_id_id, id_comp]
+by rw [uncurry_eq, prod.map_id_id, id_comp]
 
 lemma curry_id_eq_coev (A X : C) [exponentiable A] : curry (𝟙 _) = (coev A).app X :=
 by { rw [curry_eq, (exp A).map_id (A ⨯ _)], apply comp_id }
@@ -220,15 +220,15 @@ def pre (X : C) (f : B ⟶ A) [exponentiable B] : (A⟹X) ⟶ B⟹X :=
 curry (limits.prod.map f (𝟙 _) ≫ (ev A).app X)
 
 lemma pre_id (A X : C) [exponentiable A] : pre X (𝟙 A) = 𝟙 (A⟹X) :=
-by { rw [pre, prod_map_id_id, id_comp, ← uncurry_id_eq_ev], simp }
+by { rw [pre, prod.map_id_id, id_comp, ← uncurry_id_eq_ev], simp }
 
 -- There's probably a better proof of this somehow
 /-- Precomposition is contrafunctorial. -/
 lemma pre_map [exponentiable B] {D : C} [exponentiable D] (f : A ⟶ B) (g : B ⟶ D) :
   pre X (f ≫ g) = pre X g ≫ pre X f :=
 begin
-  rw [pre, curry_eq_iff, pre, uncurry_natural_left, pre, uncurry_curry, prod_map_swap_assoc,
-      prod_map_comp_id, assoc, ← uncurry_id_eq_ev, ← uncurry_id_eq_ev, ← uncurry_natural_left,
+  rw [pre, curry_eq_iff, pre, uncurry_natural_left, pre, uncurry_curry, prod.map_swap_assoc,
+      prod.map_comp_id, assoc, ← uncurry_id_eq_ev, ← uncurry_id_eq_ev, ← uncurry_natural_left,
       curry_natural_right, comp_id, uncurry_natural_right, uncurry_curry],
 end
 
@@ -238,7 +238,7 @@ lemma pre_post_comm [cartesian_closed C] {A B : C} {X Y : Cᵒᵖ} (f : A ⟶ B)
   pre A g.unop ≫ (exp Y.unop).map f = (exp X.unop).map f ≫ pre B g.unop :=
 begin
   rw [pre, pre, ← curry_natural_left, eq_curry_iff, uncurry_natural_right, uncurry_curry,
-      prod_map_swap_assoc, ev_naturality, assoc],
+      prod.map_swap_assoc, ev_naturality, assoc],
 end
 
 /-- The internal hom functor given by the cartesian closed structure. -/
@@ -356,15 +356,15 @@ def cartesian_closed_of_equiv (e : C ≌ D) [h : cartesian_closed C] : cartesian
           -- I wonder if it would be a good idea to make `map_comp` a simp lemma the other way round
         dsimp, simp -- See note [dsimp, simp]
         },
-      { have : is_left_adjoint (e.functor ⋙ prod_functor.obj X ⋙ e.inverse) :=
+      { have : is_left_adjoint (e.functor ⋙ prod.functor.obj X ⋙ e.inverse) :=
           by exactI adjunction.left_adjoint_of_nat_iso this.symm,
-        have : is_left_adjoint (e.inverse ⋙ e.functor ⋙ prod_functor.obj X ⋙ e.inverse) :=
+        have : is_left_adjoint (e.inverse ⋙ e.functor ⋙ prod.functor.obj X ⋙ e.inverse) :=
           by exactI adjunction.left_adjoint_of_comp e.inverse _,
-        have : (e.inverse ⋙ e.functor ⋙ prod_functor.obj X ⋙ e.inverse) ⋙ e.functor ≅
-          prod_functor.obj X,
-        { apply iso_whisker_right e.counit_iso (prod_functor.obj X ⋙ e.inverse ⋙ e.functor) ≪≫ _,
-          change prod_functor.obj X ⋙ e.inverse ⋙ e.functor ≅ prod_functor.obj X,
-          apply iso_whisker_left (prod_functor.obj X) e.counit_iso, },
+        have : (e.inverse ⋙ e.functor ⋙ prod.functor.obj X ⋙ e.inverse) ⋙ e.functor ≅
+          prod.functor.obj X,
+        { apply iso_whisker_right e.counit_iso (prod.functor.obj X ⋙ e.inverse ⋙ e.functor) ≪≫ _,
+          change prod.functor.obj X ⋙ e.inverse ⋙ e.functor ≅ prod.functor.obj X,
+          apply iso_whisker_left (prod.functor.obj X) e.counit_iso, },
         resetI,
         apply adjunction.left_adjoint_of_nat_iso this },
     end } }

--- a/src/category_theory/closed/cartesian.lean
+++ b/src/category_theory/closed/cartesian.lean
@@ -205,7 +205,7 @@ yoneda.ext (⊤_ C ⟹ X) X
   (λ Y f, curry ((prod.left_unitor Y).hom ≫ f))
   (λ Z g, by rw [curry_eq_iff, iso.hom_inv_id_assoc] )
   (λ Z g, by simp)
-  (λ Z W f g, by rw [uncurry_natural_left, prod_left_unitor_inv_naturality_assoc f] )
+  (λ Z W f g, by rw [uncurry_natural_left, prod.left_unitor_inv_naturality_assoc f] )
 
 /-- The internal element which points at the given morphism. -/
 def internalize_hom (f : A ⟶ Y) : ⊤_C ⟶ (A ⟹ Y) :=
@@ -344,8 +344,8 @@ def cartesian_closed_of_equiv (e : C ≌ D) [h : cartesian_closed C] : cartesian
   { is_adj :=
     begin
       haveI q : exponentiable (e.inverse.obj X) := infer_instance,
-      have : is_left_adjoint (prod_functor.obj (e.inverse.obj X)) := q.is_adj,
-      have : e.functor ⋙ prod_functor.obj X ⋙ e.inverse ≅ prod_functor.obj (e.inverse.obj X),
+      have : is_left_adjoint (prod.functor.obj (e.inverse.obj X)) := q.is_adj,
+      have : e.functor ⋙ prod.functor.obj X ⋙ e.inverse ≅ prod.functor.obj (e.inverse.obj X),
       apply nat_iso.of_components _ _,
       intro Y,
       { apply as_iso (prod_comparison e.inverse X (e.functor.obj Y)) ≪≫ _,
@@ -385,10 +385,10 @@ lemma exp_comparison_natural_left (A A' B : C) (f : A' ⟶ A) :
   exp_comparison F A B ≫ pre (F.obj B) (F.map f) = F.map (pre B f) ≫ exp_comparison F A' B :=
 begin
   rw [exp_comparison, exp_comparison, ← curry_natural_left, eq_curry_iff, uncurry_natural_left,
-       pre, uncurry_curry, prod_map_swap_assoc, curry_eq, prod_map_id_comp, assoc, ev_naturality],
+       pre, uncurry_curry, prod.map_swap_assoc, curry_eq, prod.map_id_comp, assoc, ev_naturality],
   erw [ev_coev_assoc, ← F.map_id, ← prod_comparison_inv_natural_assoc,
        ← F.map_id, ← prod_comparison_inv_natural_assoc, ← F.map_comp, ← F.map_comp, pre, curry_eq,
-       prod_map_id_comp, assoc, (ev _).naturality, ev_coev_assoc], refl,
+       prod.map_id_comp, assoc, (ev _).naturality, ev_coev_assoc], refl,
 end
 
 /-- The exponential comparison map is natural in its right argument. -/

--- a/src/category_theory/closed/cartesian.lean
+++ b/src/category_theory/closed/cartesian.lean
@@ -103,8 +103,8 @@ lemma ev_naturality {X Y : C} (f : X ⟶ Y) :
 (ev A).naturality f
 
 @[simp, reassoc]
-def coev_naturality {X Y : C} (f : X ⟶ Y) :
-  f ≫ (coev A).app Y = (coev A).app X ≫ ((exp A).map (limits.prod.map (𝟙 A) f)) :=
+lemma coev_naturality {X Y : C} (f : X ⟶ Y) :
+  f ≫ (coev A).app Y = (coev A).app X ≫ (exp A).map (limits.prod.map (𝟙 A) f) :=
 (coev A).naturality f
 
 notation A ` ⟹ `:20 B:20 := (exp A).obj B

--- a/src/category_theory/limits/connected.lean
+++ b/src/category_theory/limits/connected.lean
@@ -69,17 +69,17 @@ namespace prod_preserves_connected_limits
 
 /-- (Impl). The obvious natural transformation from (X × K -) to K. -/
 @[simps]
-def γ₂ {K : J ⥤ C} (X : C) : K ⋙ prod_functor.obj X ⟶ K :=
+def γ₂ {K : J ⥤ C} (X : C) : K ⋙ prod.functor.obj X ⟶ K :=
 { app := λ Y, limits.prod.snd }
 
 /-- (Impl). The obvious natural transformation from (X × K -) to X -/
 @[simps]
-def γ₁ {K : J ⥤ C} (X : C) : K ⋙ prod_functor.obj X ⟶ (functor.const J).obj X :=
+def γ₁ {K : J ⥤ C} (X : C) : K ⋙ prod.functor.obj X ⟶ (functor.const J).obj X :=
 { app := λ Y, limits.prod.fst }
 
 /-- (Impl). Given a cone for (X × K -), produce a cone for K using the natural transformation `γ₂` -/
 @[simps]
-def forget_cone {X : C} {K : J ⥤ C} (s : cone (K ⋙ prod_functor.obj X)) : cone K :=
+def forget_cone {X : C} {K : J ⥤ C} (s : cone (K ⋙ prod.functor.obj X)) : cone K :=
 { X := s.X,
   π := s.π ≫ γ₂ X }
 
@@ -95,7 +95,7 @@ Note that this functor does not preserve the two most obvious disconnected limit
 -/
 noncomputable
 def prod_preserves_connected_limits [is_connected J] (X : C) :
-  preserves_limits_of_shape J (prod_functor.obj X) :=
+  preserves_limits_of_shape J (prod.functor.obj X) :=
 { preserves_limit := λ K,
   { preserves := λ c l,
     { lift := λ s, prod.lift (s.π.app (classical.arbitrary _) ≫ limits.prod.fst) (l.lift (forget_cone s)),

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -257,12 +257,14 @@ lemma prod.lift_snd {W X Y : C} [has_binary_product X Y] (f : W ⟶ X) (g : W �
   prod.lift f g ≫ prod.snd = g :=
 limit.lift_π _ _
 
-@[simp, reassoc]
+-- The simp linter says simp can prove the reassoc version of this lemma.
+@[reassoc, simp]
 lemma coprod.inl_desc {W X Y : C} [has_binary_coproduct X Y] (f : X ⟶ W) (g : Y ⟶ W) :
   coprod.inl ≫ coprod.desc f g = f :=
 colimit.ι_desc _ _
 
-@[simp, reassoc]
+-- The simp linter says simp can prove the reassoc version of this lemma.
+@[reassoc, simp]
 lemma coprod.inr_desc {W X Y : C} [has_binary_coproduct X Y] (f : X ⟶ W) (g : Y ⟶ W) :
   coprod.inr ≫ coprod.desc f g = g :=
 colimit.ι_desc _ _
@@ -304,23 +306,15 @@ lim_map (map_pair f g)
 
 /-- If the coproducts `W ⨿ X` and `Y ⨿ Z` exist, then every pair of morphisms `f : W ⟶ Y` and
     `g : W ⟶ Z` induces a morphism `coprod.map f g : W ⨿ X ⟶ Y ⨿ Z`. -/
-abbreviation coprod.map {W X Y Z : C} [has_binary_coproduct W X] [has_binary_coproduct Y Z]
+def coprod.map {W X Y Z : C} [has_binary_coproduct W X] [has_binary_coproduct Y Z]
   (f : W ⟶ Y) (g : X ⟶ Z) : W ⨿ X ⟶ Y ⨿ Z :=
 colim_map (map_pair f g)
 
-/-- If the coproducts `W ⨿ X` and `Y ⨿ Z` exist, then every pair of isomorphisms `f : W ≅ Y` and
-    `g : W ≅ Z` induces a isomorphism `coprod.map_iso f g : W ⨿ X ≅ Y ⨿ Z`. -/
-@[simps]
-def coprod.map_iso {W X Y Z : C} [has_binary_coproduct W X] [has_binary_coproduct Y Z]
-  (f : W ≅ Y) (g : X ≅ Z) : W ⨿ X ≅ Y ⨿ Z :=
-{ hom := coprod.map f.hom g.hom,
-  inv := coprod.map f.inv g.inv }
-
 section prod_lemmas
 
-@[simp]
+@[simp, reassoc]
 lemma prod.comp_lift {V W X Y : C} [has_binary_product X Y] (f : V ⟶ W) (g : W ⟶ X) (h : W ⟶ Y) :
-   f ≫ prod.lift g h = prod.lift (f ≫ g) (f ≫ h):=
+  f ≫ prod.lift g h = prod.lift (f ≫ g) (f ≫ h) :=
 by { ext; simp }
 
 lemma prod.comp_diag {X Y : C} [has_binary_product Y Y] (f : X ⟶ Y) :
@@ -337,11 +331,11 @@ lemma prod.map_snd {W X Y Z : C} [has_binary_product W X] [has_binary_product Y 
   (f : W ⟶ Y) (g : X ⟶ Z) : prod.map f g ≫ prod.snd = prod.snd ≫ g :=
 lim_map_π _ _
 
-@[simp] lemma prod_map_id_id (X Y : C) [has_binary_product X Y] :
+@[simp] lemma prod.map_id_id {X Y : C} [has_binary_product X Y] :
   prod.map (𝟙 X) (𝟙 Y) = 𝟙 _ :=
 by { ext; simp }
 
-@[simp] lemma prod_lift_fst_snd {X Y : C} [has_binary_product X Y] :
+@[simp] lemma prod.lift_fst_snd {X Y : C} [has_binary_product X Y] :
   prod.lift prod.fst prod.snd = 𝟙 (X ⨯ Y) :=
 by { ext; simp }
 
@@ -359,7 +353,7 @@ by { rw ← prod.lift_map, simp }
 -- `f ≫ h` and `g ≫ k` can fire (eg `id_comp`) , while `map_fst` and `map_snd` can still work just
 -- as well.
 @[simp, reassoc]
-lemma prod_map_map {A₁ A₂ A₃ B₁ B₂ B₃ : C}
+lemma prod.map_map {A₁ A₂ A₃ B₁ B₂ B₃ : C}
   [has_binary_product A₁ B₁] [has_binary_product A₂ B₂] [has_binary_product A₃ B₃]
   (f : A₁ ⟶ A₂) (g : B₁ ⟶ B₂) (h : A₂ ⟶ A₃) (k : B₂ ⟶ B₃) :
   prod.map f g ≫ prod.map h k = prod.map (f ≫ h) (g ≫ k) :=
@@ -367,16 +361,16 @@ by { ext; simp }
 
 -- TODO: is it necessary to weaken the assumption here?
 @[reassoc]
-lemma prod_map_swap {A B X Y : C} (f : A ⟶ B) (g : X ⟶ Y) [has_limits_of_shape (discrete walking_pair) C] :
+lemma prod.map_swap {A B X Y : C} (f : A ⟶ B) (g : X ⟶ Y) [has_limits_of_shape (discrete walking_pair) C] :
   prod.map (𝟙 X) f ≫ prod.map g (𝟙 B) = prod.map g (𝟙 A) ≫ prod.map (𝟙 Y) f :=
 by simp
 
-@[reassoc] lemma prod_map_comp_id {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z)
+@[reassoc] lemma prod.map_comp_id {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z)
   [has_binary_product X W] [has_binary_product Z W] [has_binary_product Y W] :
   prod.map (f ≫ g) (𝟙 W) = prod.map f (𝟙 W) ≫ prod.map g (𝟙 W) :=
 by simp
 
-@[reassoc] lemma prod_map_id_comp {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z)
+@[reassoc] lemma prod.map_id_comp {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z)
   [has_binary_product W X] [has_binary_product W Y] [has_binary_product W Z] :
   prod.map (𝟙 W) (f ≫ g) = prod.map (𝟙 W) f ≫ prod.map (𝟙 W) g :=
 by simp
@@ -412,70 +406,103 @@ end prod_lemmas
 
 section coprod_lemmas
 
-/- The redundant simp lemma linter says that simp can prove the reassoc version of this lemma. -/
-@[reassoc, simp]
-lemma coprod.desc_comp_comp {V W X Y : C} [has_binary_coproduct X Y] (f : V ⟶ W) (g : X ⟶ V)
-  (h : Y ⟶ V) : coprod.desc (g ≫ f) (h ≫ f) = coprod.desc g h ≫ f :=
-by tidy
+@[simp, reassoc]
+lemma coprod.desc_comp {V W X Y : C} [has_binary_coproduct X Y] (f : V ⟶ W) (g : X ⟶ V) (h : Y ⟶ V) :
+  coprod.desc g h ≫ f = coprod.desc (g ≫ f) (h ≫ f) :=
+by { ext; simp }
 
-variable [has_colimits_of_shape (discrete walking_pair) C]
+lemma coprod.diag_comp {X Y : C} [has_binary_coproduct X X] (f : X ⟶ Y) :
+  codiag X ≫ f = coprod.desc f f :=
+by simp
 
-@[reassoc]
-lemma coprod.inl_map {W X Y Z : C}
-  (f : W ⟶ Y) (g : X ⟶ Z) : coprod.inl ≫ coprod.map f g = f ≫ coprod.inl := by simp
+@[simp, reassoc]
+lemma coprod.inl_map {W X Y Z : C} [has_binary_coproduct W X] [has_binary_coproduct Y Z]
+  (f : W ⟶ Y) (g : X ⟶ Z) : coprod.inl ≫ coprod.map f g = f ≫ coprod.inl :=
+ι_colim_map _ _
 
-@[reassoc]
-lemma coprod.inr_map {W X Y Z : C}
-  (f : W ⟶ Y) (g : X ⟶ Z) : coprod.inr ≫ coprod.map f g = g ≫ coprod.inr := by simp
+@[simp, reassoc]
+lemma coprod.inr_map {W X Y Z : C} [has_binary_coproduct W X] [has_binary_coproduct Y Z]
+  (f : W ⟶ Y) (g : X ⟶ Z) : coprod.inr ≫ coprod.map f g = g ≫ coprod.inr :=
+ι_colim_map _ _
 
-@[simp] lemma coprod_map_id_id {X Y : C} :
+@[simp]
+lemma coprod.map_id_id {X Y : C} [has_binary_coproduct X Y] :
   coprod.map (𝟙 X) (𝟙 Y) = 𝟙 _ :=
-by tidy
+by { ext; simp }
 
-@[simp] lemma coprod_desc_inl_inr {X Y : C} :
+@[simp]
+lemma coprod.desc_inl_inr {X Y : C} [has_binary_coproduct X Y] :
   coprod.desc coprod.inl coprod.inr = 𝟙 (X ⨿ Y) :=
-by tidy
+by { ext; simp }
 
--- I don't think it's a good idea to make any of the following simp lemmas.
-@[reassoc]
-lemma coprod_map_map {A B X Y : C} (f : A ⟶ B) (g : X ⟶ Y) :
-  coprod.map (𝟙 X) f ≫ coprod.map g (𝟙 B) = coprod.map g (𝟙 A) ≫ coprod.map (𝟙 Y) f :=
-by tidy
-
-@[reassoc] lemma coprod_map_comp_id {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
-  coprod.map (f ≫ g) (𝟙 W) = coprod.map f (𝟙 W) ≫ coprod.map g (𝟙 W) :=
-by tidy
-
-@[reassoc] lemma coprod_map_id_comp {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
-  coprod.map (𝟙 W) (f ≫ g) = coprod.map (𝟙 W) f ≫ coprod.map (𝟙 W) g :=
-by tidy
-
-@[reassoc] lemma coprod.map_desc {S T U V W : C} (f : U ⟶ S) (g : W ⟶ S) (h : T ⟶ U) (k : V ⟶ W) :
+-- The simp linter says simp can prove the reassoc version of this lemma.
+@[reassoc, simp]
+lemma coprod.map_desc {S T U V W : C} [has_binary_coproduct U W] [has_binary_coproduct T V]
+  (f : U ⟶ S) (g : W ⟶ S) (h : T ⟶ U) (k : V ⟶ W) :
   coprod.map h k ≫ coprod.desc f g = coprod.desc (h ≫ f) (k ≫ g) :=
-by tidy
+by { ext; simp }
 
+@[simp]
+lemma coprod.desc_comp_inl_comp_inr {W X Y Z : C}
+  [has_binary_coproduct W Y] [has_binary_coproduct X Z]
+  (g : W ⟶ X) (g' : Y ⟶ Z) :
+  coprod.desc (g ≫ coprod.inl) (g' ≫ coprod.inr) = coprod.map g g' :=
+by { rw ← coprod.map_desc, simp }
+
+-- We take the right hand side here to be simp normal form, as this way composition lemmas for
+-- `f ≫ h` and `g ≫ k` can fire (eg `id_comp`) , while `inl_map` and `inr_map` can still work just
+-- as well.
 @[simp, reassoc]
-lemma coprod.map_codiag {X Y : C} (f : X ⟶ Y) :
+lemma coprod.map_map {A₁ A₂ A₃ B₁ B₂ B₃ : C}
+  [has_binary_coproduct A₁ B₁] [has_binary_coproduct A₂ B₂] [has_binary_coproduct A₃ B₃]
+  (f : A₁ ⟶ A₂) (g : B₁ ⟶ B₂) (h : A₂ ⟶ A₃) (k : B₂ ⟶ B₃) :
+  coprod.map f g ≫ coprod.map h k = coprod.map (f ≫ h) (g ≫ k) :=
+by { ext; simp }
+
+-- I don't think it's a good idea to make any of the following three simp lemmas.
+@[reassoc]
+lemma coprod.map_swap {A B X Y : C} (f : A ⟶ B) (g : X ⟶ Y) [has_colimits_of_shape (discrete walking_pair) C] :
+  coprod.map (𝟙 X) f ≫ coprod.map g (𝟙 B) = coprod.map g (𝟙 A) ≫ coprod.map (𝟙 Y) f :=
+by simp
+
+@[reassoc] lemma coprod.map_comp_id {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z)
+  [has_binary_coproduct Z W] [has_binary_coproduct Y W] [has_binary_coproduct X W] :
+  coprod.map (f ≫ g) (𝟙 W) = coprod.map f (𝟙 W) ≫ coprod.map g (𝟙 W) :=
+by simp
+
+@[reassoc] lemma coprod.map_id_comp {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z)
+  [has_binary_coproduct W X] [has_binary_coproduct W Y] [has_binary_coproduct W Z] :
+  coprod.map (𝟙 W) (f ≫ g) = coprod.map (𝟙 W) f ≫ coprod.map (𝟙 W) g :=
+by simp
+
+/-- If the coproducts `W ⨿ X` and `Y ⨿ Z` exist, then every pair of isomorphisms `f : W ≅ Y` and
+    `g : W ≅ Z` induces a isomorphism `coprod.map_iso f g : W ⨿ X ≅ Y ⨿ Z`. -/
+@[simps]
+def coprod.map_iso {W X Y Z : C} [has_binary_coproduct W X] [has_binary_coproduct Y Z]
+  (f : W ≅ Y) (g : X ≅ Z) : W ⨿ X ≅ Y ⨿ Z :=
+{ hom := coprod.map f.hom g.hom,
+  inv := coprod.map f.inv g.inv }
+
+-- The simp linter says simp can prove the reassoc version of this lemma.
+@[reassoc, simp]
+lemma coprod.map_codiag {X Y : C} (f : X ⟶ Y) [has_binary_coproduct X X] [has_binary_coproduct Y Y] :
   coprod.map f f ≫ codiag Y = codiag X ≫ f :=
-by ext; { simp, dsimp, simp, } -- See note [dsimp, simp]
+by simp
 
-@[simp, reassoc]
-lemma coprod.map_inl_inr_codiag {X Y : C}  :
+-- The simp linter says simp can prove the reassoc version of this lemma.
+@[reassoc, simp]
+lemma coprod.map_inl_inr_codiag {X Y : C} [has_binary_coproduct X Y] [has_binary_coproduct (X ⨿ Y) (X ⨿ Y)] :
   coprod.map coprod.inl coprod.inr ≫ codiag (X ⨿ Y) = 𝟙 (X ⨿ Y) :=
-by ext; { simp, dsimp, simp, } -- See note [dsimp, simp]
+by simp
 
-@[simp, reassoc]
-lemma coprod.map_comp_codiag {X X' Y Z : C} (f : X ⟶ Y) (f' : X' ⟶ Y) (g : Y ⟶ Z) :
-  coprod.map (f ≫ g) (f' ≫ g) ≫ codiag Z = coprod.map f f' ≫ codiag Y ≫ g :=
-by ext; { simp, dsimp, simp, } -- See note [dsimp, simp]
-
-@[simp, reassoc]
-lemma coprod.map_comp_inl_inr_codiag {X X' Y Y' : C} (g : X ⟶ Y) (g' : X' ⟶ Y') :
+-- The simp linter says simp can prove the reassoc version of this lemma.
+@[reassoc, simp]
+lemma coprod.map_comp_inl_inr_codiag [has_colimits_of_shape (discrete walking_pair) C]
+  {X X' Y Y' : C} (g : X ⟶ Y) (g' : X' ⟶ Y') :
   coprod.map (g ≫ coprod.inl) (g' ≫ coprod.inr) ≫ codiag (Y ⨿ Y') = coprod.map g g' :=
-by ext; { simp, dsimp, simp, } -- See note [dsimp, simp]
+by simp
 
 end coprod_lemmas
-
 
 variables (C)
 

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -312,7 +312,8 @@ colim_map (map_pair f g)
 
 section prod_lemmas
 
-@[simp, reassoc]
+-- Making the reassoc version of this a simp lemma seems to be more harmful than helpful.
+@[reassoc, simp]
 lemma prod.comp_lift {V W X Y : C} [has_binary_product X Y] (f : V ⟶ W) (g : W ⟶ X) (h : W ⟶ Y) :
   f ≫ prod.lift g h = prod.lift (f ≫ g) (f ≫ h) :=
 by { ext; simp }

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -536,7 +536,7 @@ variables {C} [has_binary_products C]
 -- FIXME deterministic timeout with `-T50000`
 /-- The binary product functor. -/
 @[simps]
-def prod_functor : C ⥤ C ⥤ C :=
+def prod.functor : C ⥤ C ⥤ C :=
 { obj := λ X, { obj := λ Y, X ⨯ Y, map := λ Y Z, prod.map (𝟙 X) },
   map := λ Y Z f, { app := λ T, prod.map f (𝟙 T) }}
 

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -319,11 +319,11 @@ def coprod.map_iso {W X Y Z : C} [has_binary_coproduct W X] [has_binary_coproduc
 section prod_lemmas
 
 @[simp]
-lemma prod.lift_comp_comp {V W X Y : C} [has_binary_product X Y] (f : V ⟶ W) (g : W ⟶ X) (h : W ⟶ Y) :
+lemma prod.comp_lift {V W X Y : C} [has_binary_product X Y] (f : V ⟶ W) (g : W ⟶ X) (h : W ⟶ Y) :
    f ≫ prod.lift g h = prod.lift (f ≫ g) (f ≫ h):=
-by {ext; simp}
+by { ext; simp }
 
-lemma prod.lift_self {X Y : C} [has_binary_product Y Y] (f : X ⟶ Y) :
+lemma prod.comp_diag {X Y : C} [has_binary_product Y Y] (f : X ⟶ Y) :
   f ≫ diag Y = prod.lift f f :=
 by simp
 
@@ -382,7 +382,7 @@ by simp
 by simp
 
 /-- If the products `W ⨯ X` and `Y ⨯ Z` exist, then every pair of isomorphisms `f : W ≅ Y` and
-    `g : X ≅ Z` induces a isomorphism `prod.map_iso f g : W ⨯ X ≅ Y ⨯ Z`. -/
+    `g : X ≅ Z` induces an isomorphism `prod.map_iso f g : W ⨯ X ≅ Y ⨯ Z`. -/
 @[simps]
 def prod.map_iso {W X Y Z : C} [has_binary_product W X] [has_binary_product Y Z]
   (f : W ≅ Y) (g : X ≅ Z) : W ⨯ X ≅ Y ⨯ Z :=
@@ -535,7 +535,7 @@ prod.lift (F.map prod.fst) (F.map prod.snd)
   F.map (prod.map f g) ≫ prod_comparison F A' B' = prod_comparison F A B ≫ prod.map (F.map f) (F.map g) :=
 begin
   rw [prod_comparison, prod_comparison, prod.lift_map, ← F.map_comp, ← F.map_comp,
-      prod.lift_comp_comp, ← F.map_comp, prod.map_fst, ← F.map_comp, prod.map_snd]
+      prod.comp_lift, ← F.map_comp, prod.map_fst, ← F.map_comp, prod.map_snd]
 end
 
 @[reassoc]

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -320,12 +320,12 @@ section prod_lemmas
 
 @[simp]
 lemma prod.lift_comp_comp {V W X Y : C} [has_binary_product X Y] (f : V ⟶ W) (g : W ⟶ X) (h : W ⟶ Y) :
-  prod.lift (f ≫ g) (f ≫ h) = f ≫ prod.lift g h :=
+   f ≫ prod.lift g h = prod.lift (f ≫ g) (f ≫ h):=
 by {ext; simp}
 
 lemma prod.lift_self {X Y : C} [has_binary_product Y Y] (f : X ⟶ Y) :
-  prod.lift f f = f ≫ diag Y :=
-by simpa using prod.lift_comp_comp f (𝟙 _) (𝟙 _)
+  f ≫ diag Y = prod.lift f f :=
+by simp
 
 @[simp, reassoc]
 lemma prod.map_fst {W X Y Z : C} [has_binary_product W X] [has_binary_product Y Z]
@@ -358,7 +358,7 @@ by { rw ← prod.lift_map, simp }
 -- We take the right hand side here to be simp normal form, as this way composition lemmas for
 -- `f ≫ h` and `g ≫ k` can fire (eg `id_comp`) , while `map_fst` and `map_snd` can still work just
 -- as well.
-@[simp]
+@[simp, reassoc]
 lemma prod_map_map {A₁ A₂ A₃ B₁ B₂ B₃ : C}
   [has_binary_product A₁ B₁] [has_binary_product A₂ B₂] [has_binary_product A₃ B₃]
   (f : A₁ ⟶ A₂) (g : B₁ ⟶ B₂) (h : A₂ ⟶ A₃) (k : B₂ ⟶ B₃) :
@@ -392,7 +392,7 @@ def prod.map_iso {W X Y Z : C} [has_binary_product W X] [has_binary_product Y Z]
 @[simp, reassoc]
 lemma prod.diag_map {X Y : C} (f : X ⟶ Y) [has_binary_product X X] [has_binary_product Y Y] :
   diag X ≫ prod.map f f = f ≫ diag Y :=
-by simp [prod.lift_self]
+by simp
 
 @[simp, reassoc]
 lemma prod.diag_map_fst_snd {X Y : C} [has_binary_product X Y] [has_binary_product (X ⨯ Y) (X ⨯ Y)] :
@@ -534,7 +534,7 @@ prod.lift (F.map prod.fst) (F.map prod.snd)
   F.map (prod.map f g) ≫ prod_comparison F A' B' = prod_comparison F A B ≫ prod.map (F.map f) (F.map g) :=
 begin
   rw [prod_comparison, prod_comparison, prod.lift_map, ← F.map_comp, ← F.map_comp,
-      ← prod.lift_comp_comp, ← F.map_comp, prod.map_fst, ← F.map_comp, prod.map_snd]
+      prod.lift_comp_comp, ← F.map_comp, prod.map_fst, ← F.map_comp, prod.map_snd]
 end
 
 @[reassoc]

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -411,13 +411,14 @@ instance {X : C} [has_binary_product X X] : split_mono (diag X) :=
 end prod_lemmas
 
 section coprod_lemmas
-variable [has_colimits_of_shape (discrete walking_pair) C]
 
 /- The redundant simp lemma linter says that simp can prove the reassoc version of this lemma. -/
 @[reassoc, simp]
 lemma coprod.desc_comp_comp {V W X Y : C} [has_binary_coproduct X Y] (f : V ⟶ W) (g : X ⟶ V)
   (h : Y ⟶ V) : coprod.desc (g ≫ f) (h ≫ f) = coprod.desc g h ≫ f :=
 by tidy
+
+variable [has_colimits_of_shape (discrete walking_pair) C]
 
 @[reassoc]
 lemma coprod.inl_map {W X Y Z : C}

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison, Bhavik Mehta
 -/
 import category_theory.limits.limits
 import category_theory.discrete_category
+import category_theory.epi_mono
 
 /-!
 # Binary (co)products
@@ -256,12 +257,6 @@ lemma prod.lift_snd {W X Y : C} [has_binary_product X Y] (f : W ⟶ X) (g : W �
   prod.lift f g ≫ prod.snd = g :=
 limit.lift_π _ _
 
-/- The redundant simp lemma linter says that simp can prove the reassoc version of this lemma. -/
-@[reassoc, simp]
-lemma prod.lift_comp_comp {V W X Y : C} [has_binary_product X Y] (f : V ⟶ W) (g : W ⟶ X) (h : W ⟶ Y) :
-  prod.lift (f ≫ g) (f ≫ h) = f ≫ prod.lift g h :=
-by tidy
-
 @[simp, reassoc]
 lemma coprod.inl_desc {W X Y : C} [has_binary_coproduct X Y] (f : X ⟶ W) (g : Y ⟶ W) :
   coprod.inl ≫ coprod.desc f g = f :=
@@ -271,12 +266,6 @@ colimit.ι_desc _ _
 lemma coprod.inr_desc {W X Y : C} [has_binary_coproduct X Y] (f : X ⟶ W) (g : Y ⟶ W) :
   coprod.inr ≫ coprod.desc f g = g :=
 colimit.ι_desc _ _
-
-/- The redundant simp lemma linter says that simp can prove the reassoc version of this lemma. -/
-@[reassoc, simp]
-lemma coprod.desc_comp_comp {V W X Y : C} [has_binary_coproduct X Y] (f : V ⟶ W) (g : X ⟶ V)
-  (h : Y ⟶ V) : coprod.desc (g ≫ f) (h ≫ f) = coprod.desc g h ≫ f :=
-by tidy
 
 instance prod.mono_lift_of_mono_left {W X Y : C} [has_binary_product X Y] (f : W ⟶ X) (g : W ⟶ Y)
   [mono f] : mono (prod.lift f g) :=
@@ -309,108 +298,126 @@ def coprod.desc' {W X Y : C} [has_binary_coproduct X Y] (f : X ⟶ W) (g : Y ⟶
 
 /-- If the products `W ⨯ X` and `Y ⨯ Z` exist, then every pair of morphisms `f : W ⟶ Y` and
     `g : X ⟶ Z` induces a morphism `prod.map f g : W ⨯ X ⟶ Y ⨯ Z`. -/
-abbreviation prod.map {W X Y Z : C} [has_limits_of_shape (discrete walking_pair) C]
+def prod.map {W X Y Z : C} [has_binary_product W X] [has_binary_product Y Z]
   (f : W ⟶ Y) (g : X ⟶ Z) : W ⨯ X ⟶ Y ⨯ Z :=
-lim.map (map_pair f g)
+lim_map (map_pair f g)
+
+/-- If the coproducts `W ⨿ X` and `Y ⨿ Z` exist, then every pair of morphisms `f : W ⟶ Y` and
+    `g : W ⟶ Z` induces a morphism `coprod.map f g : W ⨿ X ⟶ Y ⨿ Z`. -/
+abbreviation coprod.map {W X Y Z : C} [has_binary_coproduct W X] [has_binary_coproduct Y Z]
+  (f : W ⟶ Y) (g : X ⟶ Z) : W ⨿ X ⟶ Y ⨿ Z :=
+colim_map (map_pair f g)
+
+/-- If the coproducts `W ⨿ X` and `Y ⨿ Z` exist, then every pair of isomorphisms `f : W ≅ Y` and
+    `g : W ≅ Z` induces a isomorphism `coprod.map_iso f g : W ⨿ X ≅ Y ⨿ Z`. -/
+@[simps]
+def coprod.map_iso {W X Y Z : C} [has_binary_coproduct W X] [has_binary_coproduct Y Z]
+  (f : W ≅ Y) (g : X ≅ Z) : W ⨿ X ≅ Y ⨿ Z :=
+{ hom := coprod.map f.hom g.hom,
+  inv := coprod.map f.inv g.inv }
+
+section prod_lemmas
+
+@[simp]
+lemma prod.lift_comp_comp {V W X Y : C} [has_binary_product X Y] (f : V ⟶ W) (g : W ⟶ X) (h : W ⟶ Y) :
+  prod.lift (f ≫ g) (f ≫ h) = f ≫ prod.lift g h :=
+by {ext; simp}
+
+lemma prod.lift_self {X Y : C} [has_binary_product Y Y] (f : X ⟶ Y) :
+  prod.lift f f = f ≫ diag Y :=
+by simpa using prod.lift_comp_comp f (𝟙 _) (𝟙 _)
+
+@[simp, reassoc]
+lemma prod.map_fst {W X Y Z : C} [has_binary_product W X] [has_binary_product Y Z]
+  (f : W ⟶ Y) (g : X ⟶ Z) : prod.map f g ≫ prod.fst = prod.fst ≫ f :=
+lim_map_π _ _
+
+@[simp, reassoc]
+lemma prod.map_snd {W X Y Z : C} [has_binary_product W X] [has_binary_product Y Z]
+  (f : W ⟶ Y) (g : X ⟶ Z) : prod.map f g ≫ prod.snd = prod.snd ≫ g :=
+lim_map_π _ _
+
+@[simp] lemma prod_map_id_id (X Y : C) [has_binary_product X Y] :
+  prod.map (𝟙 X) (𝟙 Y) = 𝟙 _ :=
+by { ext; simp }
+
+@[simp] lemma prod_lift_fst_snd {X Y : C} [has_binary_product X Y] :
+  prod.lift prod.fst prod.snd = 𝟙 (X ⨯ Y) :=
+by { ext; simp }
+
+@[simp, reassoc] lemma prod.lift_map {V W X Y Z : C} [has_binary_product W X] [has_binary_product Y Z]
+  (f : V ⟶ W) (g : V ⟶ X) (h : W ⟶ Y) (k : X ⟶ Z) :
+  prod.lift f g ≫ prod.map h k = prod.lift (f ≫ h) (g ≫ k) :=
+by { ext; simp }
+
+@[simp] lemma prod.lift_fst_comp_snd_comp {W X Y Z : C} [has_binary_product W Y] [has_binary_product X Z]
+  (g : W ⟶ X) (g' : Y ⟶ Z) :
+  prod.lift (prod.fst ≫ g) (prod.snd ≫ g') = prod.map g g' :=
+by { rw ← prod.lift_map, simp }
+
+-- We take the right hand side here to be simp normal form, as this way composition lemmas for
+-- `f ≫ h` and `g ≫ k` can fire (eg `id_comp`) , while `map_fst` and `map_snd` can still work just
+-- as well.
+@[simp]
+lemma prod_map_map {A₁ A₂ A₃ B₁ B₂ B₃ : C}
+  [has_binary_product A₁ B₁] [has_binary_product A₂ B₂] [has_binary_product A₃ B₃]
+  (f : A₁ ⟶ A₂) (g : B₁ ⟶ B₂) (h : A₂ ⟶ A₃) (k : B₂ ⟶ B₃) :
+  prod.map f g ≫ prod.map h k = prod.map (f ≫ h) (g ≫ k) :=
+by { ext; simp }
+
+-- TODO: is it necessary to weaken the assumption here?
+@[reassoc]
+lemma prod_map_swap {A B X Y : C} (f : A ⟶ B) (g : X ⟶ Y) [has_limits_of_shape (discrete walking_pair) C] :
+  prod.map (𝟙 X) f ≫ prod.map g (𝟙 B) = prod.map g (𝟙 A) ≫ prod.map (𝟙 Y) f :=
+by simp
+
+@[reassoc] lemma prod_map_comp_id {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z)
+  [has_binary_product X W] [has_binary_product Z W] [has_binary_product Y W] :
+  prod.map (f ≫ g) (𝟙 W) = prod.map f (𝟙 W) ≫ prod.map g (𝟙 W) :=
+by simp
+
+@[reassoc] lemma prod_map_id_comp {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z)
+  [has_binary_product W X] [has_binary_product W Y] [has_binary_product W Z] :
+  prod.map (𝟙 W) (f ≫ g) = prod.map (𝟙 W) f ≫ prod.map (𝟙 W) g :=
+by simp
 
 /-- If the products `W ⨯ X` and `Y ⨯ Z` exist, then every pair of isomorphisms `f : W ≅ Y` and
     `g : X ≅ Z` induces a isomorphism `prod.map_iso f g : W ⨯ X ≅ Y ⨯ Z`. -/
-abbreviation prod.map_iso {W X Y Z : C} [has_limits_of_shape.{v} (discrete walking_pair) C]
+@[simps]
+def prod.map_iso {W X Y Z : C} [has_binary_product W X] [has_binary_product Y Z]
   (f : W ≅ Y) (g : X ≅ Z) : W ⨯ X ≅ Y ⨯ Z :=
-lim.map_iso (map_pair_iso f g)
-
--- Note that the next two `simp` lemmas are proved by `simp`,
--- but nevertheless are useful,
--- because they state the right hand side in terms of `prod.map`
--- rather than `lim.map`.
-@[simp] lemma prod.map_iso_hom {W X Y Z : C} [has_limits_of_shape.{v} (discrete walking_pair) C]
-  (f : W ≅ Y) (g : X ≅ Z) : (prod.map_iso f g).hom = prod.map f.hom g.hom := by simp
-
-@[simp] lemma prod.map_iso_inv {W X Y Z : C} [has_limits_of_shape.{v} (discrete walking_pair) C]
-  (f : W ≅ Y) (g : X ≅ Z) : (prod.map_iso f g).inv = prod.map f.inv g.inv := by simp
+{ hom := prod.map f.hom g.hom,
+  inv := prod.map f.inv g.inv }
 
 @[simp, reassoc]
-lemma prod.diag_map {X Y : C} [has_limits_of_shape (discrete walking_pair) C] (f : X ⟶ Y) :
+lemma prod.diag_map {X Y : C} (f : X ⟶ Y) [has_binary_product X X] [has_binary_product Y Y] :
   diag X ≫ prod.map f f = f ≫ diag Y :=
-by ext; { simp, dsimp, simp, } -- See note [dsimp, simp]
+by simp [prod.lift_self]
 
 @[simp, reassoc]
-lemma prod.diag_map_fst_snd {X Y : C} [has_limits_of_shape (discrete walking_pair) C] :
+lemma prod.diag_map_fst_snd {X Y : C} [has_binary_product X Y] [has_binary_product (X ⨯ Y) (X ⨯ Y)] :
   diag (X ⨯ Y) ≫ prod.map prod.fst prod.snd = 𝟙 (X ⨯ Y) :=
-by ext; { simp, dsimp, simp, } -- See note [dsimp, simp]
-
-@[simp, reassoc]
-lemma prod.diag_map_comp [has_limits_of_shape (discrete walking_pair) C]
-  {X Y Z Z' : C} (f : X ⟶ Y) (g : Y ⟶ Z) (g' : Y ⟶ Z') :
-  diag X ≫ prod.map (f ≫ g) (f ≫ g') = f ≫ diag Y ≫ prod.map g g' :=
-by ext; { simp, dsimp, simp, } -- See note [dsimp, simp]
+by simp
 
 @[simp, reassoc]
 lemma prod.diag_map_fst_snd_comp  [has_limits_of_shape (discrete walking_pair) C]
   {X X' Y Y' : C} (g : X ⟶ Y) (g' : X' ⟶ Y') :
   diag (X ⨯ X') ≫ prod.map (prod.fst ≫ g) (prod.snd ≫ g') = prod.map g g' :=
-by ext; { simp, dsimp, simp, } -- See note [dsimp, simp]
+by simp
 
-/-- If the coproducts `W ⨿ X` and `Y ⨿ Z` exist, then every pair of morphisms `f : W ⟶ Y` and
-    `g : W ⟶ Z` induces a morphism `coprod.map f g : W ⨿ X ⟶ Y ⨿ Z`. -/
-abbreviation coprod.map {W X Y Z : C} [has_colimits_of_shape (discrete walking_pair) C]
-  (f : W ⟶ Y) (g : X ⟶ Z) : W ⨿ X ⟶ Y ⨿ Z :=
-colim.map (map_pair f g)
-
-/-- If the coproducts `W ⨿ X` and `Y ⨿ Z` exist, then every pair of isomorphisms `f : W ≅ Y` and
-    `g : W ≅ Z` induces a isomorphism `coprod.map_iso f g : W ⨿ X ≅ Y ⨿ Z`. -/
-abbreviation coprod.map_iso {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
-  (f : W ≅ Y) (g : X ≅ Z) : W ⨿ X ≅ Y ⨿ Z :=
-colim.map_iso (map_pair_iso f g)
-
-@[simp] lemma coprod.map_iso_hom {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
-  (f : W ≅ Y) (g : X ≅ Z) : (coprod.map_iso f g).hom = coprod.map f.hom g.hom := by simp
-
-@[simp] lemma coprod.map_iso_inv {W X Y Z : C} [has_colimits_of_shape.{v} (discrete walking_pair) C]
-  (f : W ≅ Y) (g : X ≅ Z) : (coprod.map_iso f g).inv = coprod.map f.inv g.inv := by simp
-
-
-section prod_lemmas
-variable [has_limits_of_shape (discrete walking_pair) C]
-
-@[reassoc]
-lemma prod.map_fst {W X Y Z : C}
-  (f : W ⟶ Y) (g : X ⟶ Z) : prod.map f g ≫ prod.fst = prod.fst ≫ f := by simp
-
-@[reassoc]
-lemma prod.map_snd {W X Y Z : C}
-  (f : W ⟶ Y) (g : X ⟶ Z) : prod.map f g ≫ prod.snd = prod.snd ≫ g := by simp
-
-@[simp] lemma prod_map_id_id {X Y : C} :
-  prod.map (𝟙 X) (𝟙 Y) = 𝟙 _ :=
-by tidy
-
-@[simp] lemma prod_lift_fst_snd {X Y : C} :
-  prod.lift prod.fst prod.snd = 𝟙 (X ⨯ Y) :=
-by tidy
-
--- I don't think it's a good idea to make any of the following simp lemmas.
-@[reassoc]
-lemma prod_map_map {A B X Y : C} (f : A ⟶ B) (g : X ⟶ Y) :
-  prod.map (𝟙 X) f ≫ prod.map g (𝟙 B) = prod.map g (𝟙 A) ≫ prod.map (𝟙 Y) f :=
-by tidy
-
-@[reassoc] lemma prod_map_comp_id {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
-  prod.map (f ≫ g) (𝟙 W) = prod.map f (𝟙 W) ≫ prod.map g (𝟙 W) :=
-by tidy
-
-@[reassoc] lemma prod_map_id_comp {X Y Z W : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
-  prod.map (𝟙 W) (f ≫ g) = prod.map (𝟙 W) f ≫ prod.map (𝟙 W) g :=
-by tidy
-
-@[reassoc] lemma prod.lift_map (V W X Y Z : C) (f : V ⟶ W) (g : V ⟶ X) (h : W ⟶ Y) (k : X ⟶ Z) :
-  prod.lift f g ≫ prod.map h k = prod.lift (f ≫ h) (g ≫ k) :=
-by tidy
+instance {X : C} [has_binary_product X X] : split_mono (diag X) :=
+{ retraction := prod.fst }
 
 end prod_lemmas
 
 section coprod_lemmas
 variable [has_colimits_of_shape (discrete walking_pair) C]
+
+/- The redundant simp lemma linter says that simp can prove the reassoc version of this lemma. -/
+@[reassoc, simp]
+lemma coprod.desc_comp_comp {V W X Y : C} [has_binary_coproduct X Y] (f : V ⟶ W) (g : X ⟶ V)
+  (h : Y ⟶ V) : coprod.desc (g ≫ f) (h ≫ f) = coprod.desc g h ≫ f :=
+by tidy
 
 @[reassoc]
 lemma coprod.inl_map {W X Y Z : C}
@@ -510,28 +517,28 @@ end prod_functor
 section prod_comparison
 variables {C} [has_binary_products C]
 
-variables {D : Type u₂} [category.{v} D] [has_binary_products D]
-
+variables {D : Type u₂} [category.{v} D]
+variables (F : C ⥤ D) {A A' B B' : C}
+variables [has_binary_product (F.obj A) (F.obj B)] [has_binary_product (F.obj A') (F.obj B')]
 /--
 The product comparison morphism.
 
 In `category_theory/limits/preserves` we show this is always an iso iff F preserves binary products.
 -/
-def prod_comparison (F : C ⥤ D) (A B : C) : F.obj (A ⨯ B) ⟶ F.obj A ⨯ F.obj B :=
+def prod_comparison (F : C ⥤ D) (A B : C) [has_binary_product (F.obj A) (F.obj B)] :
+  F.obj (A ⨯ B) ⟶ F.obj A ⨯ F.obj B :=
 prod.lift (F.map prod.fst) (F.map prod.snd)
 
 /-- Naturality of the prod_comparison morphism in both arguments. -/
-@[reassoc] lemma prod_comparison_natural (F : C ⥤ D) {A A' B B' : C} (f : A ⟶ A') (g : B ⟶ B') :
+@[reassoc] lemma prod_comparison_natural (f : A ⟶ A') (g : B ⟶ B') :
   F.map (prod.map f g) ≫ prod_comparison F A' B' = prod_comparison F A B ≫ prod.map (F.map f) (F.map g) :=
 begin
-  rw [prod_comparison, prod_comparison, prod.lift_map],
-  apply prod.hom_ext,
-  { simp only [← F.map_comp, category.assoc, prod.lift_fst, prod.map_fst, category.comp_id] },
-  { simp only [← F.map_comp, category.assoc, prod.lift_snd, prod.map_snd, prod.lift_snd_assoc] },
+  rw [prod_comparison, prod_comparison, prod.lift_map, ← F.map_comp, ← F.map_comp,
+      ← prod.lift_comp_comp, ← F.map_comp, prod.map_fst, ← F.map_comp, prod.map_snd]
 end
 
 @[reassoc]
-lemma inv_prod_comparison_map_fst (F : C ⥤ D) (A B : C) [is_iso (prod_comparison F A B)] :
+lemma inv_prod_comparison_map_fst [is_iso (prod_comparison F A B)] :
   inv (prod_comparison F A B) ≫ F.map prod.fst = prod.fst :=
 begin
   erw (as_iso (prod_comparison F A B)).inv_comp_eq,
@@ -540,7 +547,7 @@ begin
 end
 
 @[reassoc]
-lemma inv_prod_comparison_map_snd (F : C ⥤ D) (A B : C) [is_iso (prod_comparison F A B)] :
+lemma inv_prod_comparison_map_snd [is_iso (prod_comparison F A B)] :
   inv (prod_comparison F A B) ≫ F.map prod.snd = prod.snd :=
 begin
   erw (as_iso (prod_comparison F A B)).inv_comp_eq,
@@ -550,7 +557,7 @@ end
 
 /-- If the product comparison morphism is an iso, its inverse is natural. -/
 @[reassoc]
-lemma prod_comparison_inv_natural (F : C ⥤ D) {A A' B B' : C} (f : A ⟶ A') (g : B ⟶ B')
+lemma prod_comparison_inv_natural (f : A ⟶ A') (g : B ⟶ B')
   [is_iso (prod_comparison F A B)] [is_iso (prod_comparison F A' B')] :
   inv (prod_comparison F A B) ≫ F.map (prod.map f g) = prod.map (F.map f) (F.map g) ≫ inv (prod_comparison F A' B') :=
 by { erw [(as_iso (prod_comparison F A' B')).eq_comp_inv, category.assoc,

--- a/src/category_theory/monoidal/of_has_finite_products.lean
+++ b/src/category_theory/monoidal/of_has_finite_products.lean
@@ -73,8 +73,8 @@ by simp
     (prod.snd ≫ prod.snd) }
 
 /-- The product functor can be decomposed. -/
-def prod_functor_left_comp (X Y : C) :
-  prod_functor.obj (X ⨯ Y) ≅ prod_functor.obj Y ⋙ prod_functor.obj X :=
+def prod.functor_left_comp (X Y : C) :
+  prod.functor.obj (X ⨯ Y) ≅ prod.functor.obj Y ⋙ prod.functor.obj X :=
 nat_iso.of_components (prod.associator _ _) (by tidy)
 
 @[reassoc]
@@ -89,8 +89,6 @@ lemma prod.associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃ : C} (f₁ : X�
   prod.map (prod.map f₁ f₂) f₃ ≫ (prod.associator Y₁ Y₂ Y₃).hom =
     (prod.associator X₁ X₂ X₃).hom ≫ prod.map f₁ (prod.map f₂ f₃) :=
 by tidy
-
-
 
 variables [has_terminal C]
 
@@ -107,24 +105,24 @@ variables [has_terminal C]
   inv := prod.lift (𝟙 _) (terminal.from P) }
 
 @[reassoc]
-lemma prod_left_unitor_hom_naturality (f : X ⟶ Y):
+lemma prod.left_unitor_hom_naturality (f : X ⟶ Y):
   prod.map (𝟙 _) f ≫ (prod.left_unitor Y).hom = (prod.left_unitor X).hom ≫ f :=
 prod.map_snd _ _
 
 @[reassoc]
-lemma prod_left_unitor_inv_naturality (f : X ⟶ Y):
+lemma prod.left_unitor_inv_naturality (f : X ⟶ Y):
   (prod.left_unitor X).inv ≫ prod.map (𝟙 _) f = f ≫ (prod.left_unitor Y).inv :=
-by rw [iso.inv_comp_eq, ← category.assoc, iso.eq_comp_inv, prod_left_unitor_hom_naturality]
+by rw [iso.inv_comp_eq, ← category.assoc, iso.eq_comp_inv, prod.left_unitor_hom_naturality]
 
 @[reassoc]
-lemma prod_right_unitor_hom_naturality (f : X ⟶ Y):
+lemma prod.right_unitor_hom_naturality (f : X ⟶ Y):
   prod.map f (𝟙 _) ≫ (prod.right_unitor Y).hom = (prod.right_unitor X).hom ≫ f :=
 prod.map_fst _ _
 
 @[reassoc]
 lemma prod_right_unitor_inv_naturality (f : X ⟶ Y):
   (prod.right_unitor X).inv ≫ prod.map f (𝟙 _) = f ≫ (prod.right_unitor Y).inv :=
-by rw [iso.inv_comp_eq, ← category.assoc, iso.eq_comp_inv, prod_right_unitor_hom_naturality]
+by rw [iso.inv_comp_eq, ← category.assoc, iso.eq_comp_inv, prod.right_unitor_hom_naturality]
 
 lemma prod.triangle (X Y : C) :
   (prod.associator X (⊤_ C) Y).hom ≫ prod.map (𝟙 X) ((prod.left_unitor Y).hom) =


### PR DESCRIPTION
The main changes in here are:
- `prod.map` is now a def, not an abbreviation. I think this is an important change because oftentimes `simp` will reduce it to `lim.map` and then get stuck, which is tough to debug and usually the wrong step to take. Instead, the `prod.map_fst` and `snd` lemmas are proved directly rather than with simp, and these are used to get everything else.
- I added a couple of new simp lemmas and rewrote a few others: the overall guide here is that more things can be proved by `rw` or `simp` *without using ext*. The idea of this is that when you're dealing with a chain of compositions containing product morphisms, it's much nicer to be able to rewrite (or simp) the parts you want rather than needing to do an auxiliary `have` and use `ext` in there, then rewrite using this lemma inside your big chain. In this file at least I managed to get rid of a bunch of uses of `ext` (and also convert `tidy` to `simp`) so I'm pretty sure these changes were positive.
- Moved around some definitions and lemmas. No big changes here, mostly just putting things which work similarly closer.
- Weakened typeclass assumptions: in particular for `prod_comparison`.
- Renamed some `prod_` lemmas to `prod.`, since there used to be a mix between the two; so I've made the usage consistent.

+ dual versions of all the above.