### PR TITLE
[Merged by Bors] - chore(data/mv_polynomial): rename `pderivative` to `pderiv`

### DIFF
--- a/src/data/mv_polynomial/pderiv.lean
+++ b/src/data/mv_polynomial/pderiv.lean
@@ -18,7 +18,7 @@ It is based purely on the polynomial exponents and coefficients.
 
 ## Main declarations
 
-* `mv_polynomial.pderivative i p` : the partial derivative of `p` with respect to `i`.
+* `mv_polynomial.pderiv i p` : the partial derivative of `p` with respect to `i`.
 
 ## Notation
 
@@ -52,45 +52,45 @@ variables {R : Type u}
 namespace mv_polynomial
 variables {σ : Type*} {a a' a₁ a₂ : R} {s : σ →₀ ℕ}
 
-section pderivative
+section pderiv
 
 variables {R} [comm_semiring R]
 
-/-- `pderivative i p` is the partial derivative of `p` with respect to `i` -/
-def pderivative (i : σ) : mv_polynomial σ R →ₗ[R] mv_polynomial σ R :=
+/-- `pderiv i p` is the partial derivative of `p` with respect to `i` -/
+def pderiv (i : σ) : mv_polynomial σ R →ₗ[R] mv_polynomial σ R :=
 { to_fun := λ p, p.sum (λ A B, monomial (A - single i 1) (B * (A i))),
   map_smul' := begin
     intros c x,
     rw [sum_smul_index', smul_sum],
-    simp_rw [monomial, smul_single, smul_eq_mul, mul_assoc],
-    intros s,
-    simp only [monomial_zero, zero_mul],
+    { simp_rw [monomial, smul_single, smul_eq_mul, mul_assoc] },
+    { intros s,
+      simp only [monomial_zero, zero_mul] }
   end,
   map_add' := λ f g, sum_add_index (by simp only [monomial_zero, forall_const, zero_mul])
     (by simp only [add_mul, forall_const, eq_self_iff_true, monomial_add]), }
 
 @[simp]
-lemma pderivative_monomial {i : σ} :
-  pderivative i (monomial s a) = monomial (s - single i 1) (a * (s i)) :=
-by simp only [pderivative, monomial_zero, sum_monomial, zero_mul, linear_map.coe_mk]
+lemma pderiv_monomial {i : σ} :
+  pderiv i (monomial s a) = monomial (s - single i 1) (a * (s i)) :=
+by simp only [pderiv, monomial_zero, sum_monomial, zero_mul, linear_map.coe_mk]
 
 @[simp]
-lemma pderivative_C {i : σ} : pderivative i (C a) = 0 :=
-suffices pderivative i (monomial 0 a) = 0, by simpa,
-by simp only [monomial_zero, pderivative_monomial, nat.cast_zero, mul_zero, zero_apply]
+lemma pderiv_C {i : σ} : pderiv i (C a) = 0 :=
+suffices pderiv i (monomial 0 a) = 0, by simpa,
+by simp only [monomial_zero, pderiv_monomial, nat.cast_zero, mul_zero, zero_apply]
 
-lemma pderivative_eq_zero_of_not_mem_vars {i : σ} {f : mv_polynomial σ R} (h : i ∉ f.vars) :
-  pderivative i f = 0 :=
+lemma pderiv_eq_zero_of_not_mem_vars {i : σ} {f : mv_polynomial σ R} (h : i ∉ f.vars) :
+  pderiv i f = 0 :=
 begin
-  change (pderivative i) f = 0,
+  change (pderiv i) f = 0,
   rw [f.as_sum, linear_map.map_sum],
   apply finset.sum_eq_zero,
   intros x H,
   simp [mem_support_not_mem_vars_zero H h],
 end
 
-lemma pderivative_monomial_single {i : σ} {n : ℕ} :
-  pderivative i (monomial (single i n) a) = monomial (single i (n-1)) (a * n) :=
+lemma pderiv_monomial_single {i : σ} {n : ℕ} :
+  pderiv i (monomial (single i n) a) = monomial (single i (n-1)) (a * n) :=
 by simp
 
 private lemma monomial_sub_single_one_add {i : σ} {s' : σ →₀ ℕ} :
@@ -103,9 +103,9 @@ private lemma monomial_add_sub_single_one {i : σ} {s' : σ →₀ ℕ} :
     monomial (s + s' - single i 1) (a * (a' * (s' i))) :=
 by by_cases h : s' i = 0; simp [h, add_sub_single_one]
 
-lemma pderivative_monomial_mul {i : σ} {s' : σ →₀ ℕ} :
-  pderivative i (monomial s a * monomial s' a') =
-    pderivative i (monomial s a) * monomial s' a' + monomial s a * pderivative i (monomial s' a') :=
+lemma pderiv_monomial_mul {i : σ} {s' : σ →₀ ℕ} :
+  pderiv i (monomial s a * monomial s' a') =
+    pderiv i (monomial s a) * monomial s' a' + monomial s a * pderiv i (monomial s' a') :=
 begin
   simp [monomial_sub_single_one_add, monomial_add_sub_single_one],
   congr,
@@ -113,12 +113,12 @@ begin
 end
 
 @[simp]
-lemma pderivative_mul {i : σ} {f g : mv_polynomial σ R} :
-  pderivative i (f * g) = pderivative i f * g + f * pderivative i g :=
+lemma pderiv_mul {i : σ} {f g : mv_polynomial σ R} :
+  pderiv i (f * g) = pderiv i f * g + f * pderiv i g :=
 begin
   apply induction_on' f,
   { apply induction_on' g,
-    { intros u r u' r', exact pderivative_monomial_mul },
+    { intros u r u' r', exact pderiv_monomial_mul },
     { intros p q hp hq u r,
       rw [mul_add, linear_map.map_add, hp, hq, mul_add, linear_map.map_add],
       ring } },
@@ -128,10 +128,10 @@ begin
 end
 
 @[simp]
-lemma pderivative_C_mul {f : mv_polynomial σ R} {i : σ} :
-  pderivative i (C a * f) = C a * pderivative i f :=
-by convert linear_map.map_smul (pderivative i) a f; rw C_mul'
+lemma pderiv_C_mul {f : mv_polynomial σ R} {i : σ} :
+  pderiv i (C a * f) = C a * pderiv i f :=
+by convert linear_map.map_smul (pderiv i) a f; rw C_mul'
 
-end pderivative
+end pderiv
 
 end mv_polynomial


### PR DESCRIPTION
This name matches `fderiv` and `deriv` we have in `analysis/`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->