### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space/finite_dimensional): more lemmas

### DIFF
--- a/src/linear_algebra/affine_space/basic.lean
+++ b/src/linear_algebra/affine_space/basic.lean
@@ -941,6 +941,38 @@ lemma vector_span_range_eq_span_range_vsub_right (p : ι → P) (i0 : ι) :
   vector_span k (set.range p) = submodule.span k (set.range (λ (i : ι), p i -ᵥ p i0)) :=
 by rw [vector_span_eq_span_vsub_set_right k (set.mem_range_self i0), ←set.range_comp]
 
+/-- The `vector_span` of an indexed family is the span of the pairwise
+subtractions with a given point on the left, excluding the subtraction
+of that point from itself. -/
+lemma vector_span_range_eq_span_range_vsub_left_ne (p : ι → P) (i₀ : ι) :
+  vector_span k (set.range p) = submodule.span k (set.range (λ (i : {x // x ≠ i₀}), p i₀ -ᵥ p i)) :=
+begin
+  rw [←set.image_univ, vector_span_image_eq_span_vsub_set_left_ne k _ (set.mem_univ i₀)],
+  congr' with v,
+  simp only [set.mem_range, set.mem_image, set.mem_diff, set.mem_singleton_iff, subtype.exists,
+             subtype.coe_mk],
+  split,
+  { rintros ⟨x, ⟨i₁, ⟨⟨hi₁u, hi₁⟩, rfl⟩⟩, hv⟩,
+    exact ⟨i₁, hi₁, hv⟩ },
+  { exact λ ⟨i₁, hi₁, hv⟩, ⟨p i₁, ⟨i₁, ⟨set.mem_univ _, hi₁⟩, rfl⟩, hv⟩ }
+end
+
+/-- The `vector_span` of an indexed family is the span of the pairwise
+subtractions with a given point on the right, excluding the subtraction
+of that point from itself. -/
+lemma vector_span_range_eq_span_range_vsub_right_ne (p : ι → P) (i₀ : ι) :
+  vector_span k (set.range p) = submodule.span k (set.range (λ (i : {x // x ≠ i₀}), p i -ᵥ p i₀)) :=
+begin
+  rw [←set.image_univ, vector_span_image_eq_span_vsub_set_right_ne k _ (set.mem_univ i₀)],
+  congr' with v,
+  simp only [set.mem_range, set.mem_image, set.mem_diff, set.mem_singleton_iff, subtype.exists,
+             subtype.coe_mk],
+  split,
+  { rintros ⟨x, ⟨i₁, ⟨⟨hi₁u, hi₁⟩, rfl⟩⟩, hv⟩,
+    exact ⟨i₁, hi₁, hv⟩ },
+  { exact λ ⟨i₁, hi₁, hv⟩, ⟨p i₁, ⟨i₁, ⟨set.mem_univ _, hi₁⟩, rfl⟩, hv⟩ }
+end
+
 /-- The affine span of a set is nonempty if and only if that set
 is. -/
 lemma affine_span_nonempty (s : set P) :


### PR DESCRIPTION
Add more lemmas concerning dimensions of affine spans of finite
families of points.  In particular, various forms of the lemma that `n + 1`
points are affinely independent if and only if their `vector_span` has
dimension `n` (or equivalently, at least `n`).  With suitable
definitions, this is equivalent to saying that three points are
affinely independent or collinear, four are affinely independent or
coplanar, etc., thus preparing for giving a definition of `collinear`
(for any set of points in an affine space for a vector space) in terms
of dimension and proving some basic properties of it including
relating it to affine independence.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
