### PR TITLE
[Merged by Bors] - feat(data/complex): norm_cast lemmas

### DIFF
--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -5,6 +5,8 @@ Authors: Kevin Buzzard, Mario Carneiro
 -/
 import data.real.basic
 
+open_locale big_operators
+
 /-!
 # The complex numbers
 
@@ -347,7 +349,7 @@ by rw [add_conj]; simp; rw [mul_div_cancel_left (z.re:ℂ) two_ne_zero']
 
 local notation `abs'` := _root_.abs
 
-@[simp] lemma abs_of_real (r : ℝ) : abs r = abs' r :=
+@[simp, norm_cast] lemma abs_of_real (r : ℝ) : abs r = abs' r :=
 by simp [abs, norm_sq_of_real, real.sqrt_mul_self_eq_abs]
 
 lemma abs_of_nonneg {r : ℝ} (h : 0 ≤ r) : abs r = r :=
@@ -523,5 +525,13 @@ lemma lim_abs (f : cau_seq ℂ abs) : lim (cau_seq_abs f) = abs (lim f) :=
 lim_eq_of_equiv_const (λ ε ε0,
 let ⟨i, hi⟩ := equiv_lim f ε ε0 in
 ⟨i, λ j hj, lt_of_le_of_lt (abs_abs_sub_le_abs_sub _ _) (hi j hj)⟩)
+
+@[simp, norm_cast] lemma of_real_prod {α : Type*} (s : finset α) (f : α → ℝ) :
+  ((∏ i in s, f i : ℝ) : ℂ) = ∏ i in s, (f i : ℂ) :=
+ring_hom.map_prod of_real _ _
+
+@[simp, norm_cast] lemma of_real_sum {α : Type*} (s : finset α) (f : α → ℝ) :
+  ((∑ i in s, f i : ℝ) : ℂ) = ∑ i in s, (f i : ℂ) :=
+ring_hom.map_sum of_real _ _
 
 end complex

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -488,7 +488,7 @@ end
 @[simp] lemma of_real_exp_of_real_re (x : ℝ) : ((exp x).re : ℂ) = exp x :=
 eq_conj_iff_re.1 $ by rw [← exp_conj, conj_of_real]
 
-@[simp] lemma of_real_exp (x : ℝ) : (real.exp x : ℂ) = exp x :=
+@[simp, norm_cast] lemma of_real_exp (x : ℝ) : (real.exp x : ℂ) = exp x :=
 of_real_exp_of_real_re _
 
 @[simp] lemma exp_of_real_im (x : ℝ) : (exp x).im = 0 :=
@@ -550,7 +550,7 @@ by rw [sinh, ← conj.map_neg, exp_conj, exp_conj, ← conj.map_sub, sinh, conj.
 @[simp] lemma of_real_sinh_of_real_re (x : ℝ) : ((sinh x).re : ℂ) = sinh x :=
 eq_conj_iff_re.1 $ by rw [← sinh_conj, conj_of_real]
 
-@[simp] lemma of_real_sinh (x : ℝ) : (real.sinh x : ℂ) = sinh x :=
+@[simp, norm_cast] lemma of_real_sinh (x : ℝ) : (real.sinh x : ℂ) = sinh x :=
 of_real_sinh_of_real_re _
 
 @[simp] lemma sinh_of_real_im (x : ℝ) : (sinh x).im = 0 :=
@@ -567,7 +567,7 @@ end
 @[simp] lemma of_real_cosh_of_real_re (x : ℝ) : ((cosh x).re : ℂ) = cosh x :=
 eq_conj_iff_re.1 $ by rw [← cosh_conj, conj_of_real]
 
-@[simp] lemma of_real_cosh (x : ℝ) : (real.cosh x : ℂ) = cosh x :=
+@[simp, norm_cast] lemma of_real_cosh (x : ℝ) : (real.cosh x : ℂ) = cosh x :=
 of_real_cosh_of_real_re _
 
 @[simp] lemma cosh_of_real_im (x : ℝ) : (cosh x).im = 0 :=
@@ -587,7 +587,7 @@ by rw [tanh, sinh_conj, cosh_conj, ← conj.map_div, tanh]
 @[simp] lemma of_real_tanh_of_real_re (x : ℝ) : ((tanh x).re : ℂ) = tanh x :=
 eq_conj_iff_re.1 $ by rw [← tanh_conj, conj_of_real]
 
-@[simp] lemma of_real_tanh (x : ℝ) : (real.tanh x : ℂ) = tanh x :=
+@[simp, norm_cast] lemma of_real_tanh (x : ℝ) : (real.tanh x : ℂ) = tanh x :=
 of_real_tanh_of_real_re _
 
 @[simp] lemma tanh_of_real_im (x : ℝ) : (tanh x).im = 0 :=
@@ -662,7 +662,7 @@ by rw [← mul_left_inj' I_ne_zero, ← sinh_mul_I,
 @[simp] lemma of_real_sin_of_real_re (x : ℝ) : ((sin x).re : ℂ) = sin x :=
 eq_conj_iff_re.1 $ by rw [← sin_conj, conj_of_real]
 
-@[simp] lemma of_real_sin (x : ℝ) : (real.sin x : ℂ) = sin x :=
+@[simp, norm_cast] lemma of_real_sin (x : ℝ) : (real.sin x : ℂ) = sin x :=
 of_real_sin_of_real_re _
 
 @[simp] lemma sin_of_real_im (x : ℝ) : (sin x).im = 0 :=
@@ -677,7 +677,7 @@ by rw [← cosh_mul_I, ← conj_neg_I, ← conj.map_mul, ← cosh_mul_I,
 @[simp] lemma of_real_cos_of_real_re (x : ℝ) : ((cos x).re : ℂ) = cos x :=
 eq_conj_iff_re.1 $ by rw [← cos_conj, conj_of_real]
 
-@[simp] lemma of_real_cos (x : ℝ) : (real.cos x : ℂ) = cos x :=
+@[simp, norm_cast] lemma of_real_cos (x : ℝ) : (real.cos x : ℂ) = cos x :=
 of_real_cos_of_real_re _
 
 @[simp] lemma cos_of_real_im (x : ℝ) : (cos x).im = 0 :=
@@ -697,7 +697,7 @@ by rw [tan, sin_conj, cos_conj, ← conj.map_div, tan]
 @[simp] lemma of_real_tan_of_real_re (x : ℝ) : ((tan x).re : ℂ) = tan x :=
 eq_conj_iff_re.1 $ by rw [← tan_conj, conj_of_real]
 
-@[simp] lemma of_real_tan (x : ℝ) : (real.tan x : ℂ) = tan x :=
+@[simp, norm_cast] lemma of_real_tan (x : ℝ) : (real.tan x : ℂ) = tan x :=
 of_real_tan_of_real_re _
 
 @[simp] lemma tan_of_real_im (x : ℝ) : (tan x).im = 0 :=


### PR DESCRIPTION
Mark various existing lemmas such as `abs_of_real` and `of_real_exp`
as `norm_cast` lemmas so that `norm_cast` and related tactics can
handle expressions involving those functions, and add lemmas
`of_real_prod` and `of_real_sum` to allow those tactics to work with
sums and products involving coercions from real to complex.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
