### PR TITLE
[Merged by Bors] - chore(*/multilinear): generalize `comp_linear_map` to a family of linear maps

### DIFF
--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -1687,8 +1687,12 @@ series in `g ⁻¹' s`, whose `k`-th term is given by `p k (g v₁, ..., g vₖ)
 lemma has_ftaylor_series_up_to_on.comp_continuous_linear_map {n : with_top ℕ}
   (hf : has_ftaylor_series_up_to_on n f p s) (g : G →L[𝕜] E) :
   has_ftaylor_series_up_to_on n (f ∘ g)
-    (λ x k, (p (g x) k).comp_continuous_linear_map 𝕜 E g) (g ⁻¹' s) :=
+    (λ x k, (p (g x) k).comp_continuous_linear_map (λ _, g)) (g ⁻¹' s) :=
 begin
+  let A : Π m : ℕ, (E [×m]→L[𝕜] F) → (G [×m]→L[𝕜] F) :=
+    λ m h, h.comp_continuous_linear_map (λ _, g),
+  have hA : ∀ m, is_bounded_linear_map 𝕜 (A m) :=
+    λ m, is_bounded_linear_map_continuous_multilinear_map_comp_linear g,
   split,
   { assume x hx,
     simp only [(hf.zero_eq (g x) hx).symm, function.comp_app],
@@ -1696,19 +1700,13 @@ begin
     rw continuous_linear_map.map_zero,
     refl },
   { assume m hm x hx,
-    let A : (E [×m]→L[𝕜] F) → (G [×m]→L[𝕜] F) := λ h, h.comp_continuous_linear_map 𝕜 E g,
-    have hA : is_bounded_linear_map 𝕜 A :=
-      is_bounded_linear_map_continuous_multilinear_map_comp_linear g,
-    convert (hA.has_fderiv_at).comp_has_fderiv_within_at x
+    convert ((hA m).has_fderiv_at).comp_has_fderiv_within_at x
       ((hf.fderiv_within m hm (g x) hx).comp x (g.has_fderiv_within_at) (subset.refl _)),
     ext y v,
     change p (g x) (nat.succ m) (g ∘ (cons y v)) = p (g x) m.succ (cons (g y) (g ∘ v)),
     rw comp_cons },
   { assume m hm,
-    let A : (E [×m]→L[𝕜] F) → (G [×m]→L[𝕜] F) := λ h, h.comp_continuous_linear_map 𝕜 E g,
-    have hA : is_bounded_linear_map 𝕜 A :=
-      is_bounded_linear_map_continuous_multilinear_map_comp_linear g,
-    exact hA.continuous.comp_continuous_on
+    exact (hA m).continuous.comp_continuous_on
       ((hf.cont m hm).comp g.continuous.continuous_on (subset.refl _)) }
 end
 

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -182,7 +182,7 @@ lemma is_bounded_linear_map_prod_multilinear
 continuous multilinear map `f (g m₁, ..., g mₙ)` is a bounded linear operation. -/
 lemma is_bounded_linear_map_continuous_multilinear_map_comp_linear (g : G →L[𝕜] E) :
   is_bounded_linear_map 𝕜 (λ f : continuous_multilinear_map 𝕜 (λ (i : ι), E) F,
-    f.comp_continuous_linear_map 𝕜 E  g) :=
+    f.comp_continuous_linear_map (λ _, g)) :=
 begin
   refine is_linear_map.with_bound ⟨λ f₁ f₂, by { ext m, refl }, λ c f, by { ext m, refl }⟩
     (∥g∥ ^ (fintype.card ι)) (λ f, _),

--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -184,18 +184,34 @@ lemma snoc_smul (f : multilinear_map R M M₂)
   f (snoc m (c • x)) = c • f (snoc m x) :=
 by rw [← update_snoc_last x m (c • x), f.map_smul, update_snoc_last]
 
-/- If `R` and `M₂` are implicit in the next definition, Lean is never able to infer them, even
-given `g` and `f`. Therefore, we make them explicit. -/
-variables (R M₂)
+section
 
-/-- If `g` is multilinear and `f` is linear, then `g (f m₁, ..., f mₙ)` is again a multilinear
-function, that we call `g.comp_linear_map f`. -/
-def comp_linear_map (g : multilinear_map R (λ (i : ι), M₂) M₃) (f : M' →ₗ[R] M₂) :
-  multilinear_map R (λ (i : ι), M') M₃ :=
-{ to_fun    := λ m, g (f ∘ m),
-  map_add'  := λ m i x y, by simp [comp_update],
-  map_smul' := λ m i c x, by simp [comp_update] }
-variables {R M₂}
+variables {M₁' : ι → Type*} [Π i, add_comm_monoid (M₁' i)] [Π i, semimodule R (M₁' i)]
+
+/-- Compose a multilinear map with a collection of linear maps: apply `f i` to `m i` before feeding
+the resulting vector to `g`. -/
+def comp_linear_map (g : multilinear_map R M₁' M₂) (f : Π i, M₁ i →ₗ[R] M₁' i) :
+  multilinear_map R M₁ M₂ :=
+{ to_fun := λ m, g $ λ i, f i (m i),
+  map_add' := λ m i x y,
+    begin
+      have : ∀ j z, f j (update m i z j) = update (λ k, f k (m k)) i (f i z) j :=
+        λ j z, function.apply_update (λ k, f k) _ _ _ _,
+      simp [this]
+    end,
+  map_smul' := λ m i c x,
+    begin
+      have : ∀ j z, f j (update m i z j) = update (λ k, f k (m k)) i (f i z) j :=
+        λ j z, function.apply_update (λ k, f k) _ _ _ _,
+      simp [this]
+    end }
+
+@[simp] lemma comp_linear_map_apply (g : multilinear_map R M₁' M₂) (f : Π i, M₁ i →ₗ[R] M₁' i)
+  (m : Π i, M₁ i) :
+  g.comp_linear_map f m = g (λ i, f i (m i)) :=
+rfl
+
+end
 
 /-- If one adds to a vector `m'` another vector `m`, but only for coordinates in a finset `t`, then
 the image under a multilinear map `f` is the sum of `f (s.piecewise m m')` along all subsets `s` of

--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -188,8 +188,9 @@ section
 
 variables {M₁' : ι → Type*} [Π i, add_comm_monoid (M₁' i)] [Π i, semimodule R (M₁' i)]
 
-/-- Compose a multilinear map with a collection of linear maps: apply `f i` to `m i` before feeding
-the resulting vector to `g`. -/
+/-- If `g` is a multilinear map and `f` is a collection of linear maps,
+then `g (f₁ m₁, ..., fₙ mₙ)` is again a multilinear map, that we call
+`g.comp_linear_map f`. -/
 def comp_linear_map (g : multilinear_map R M₁' M₂) (f : Π i, M₁ i →ₗ[R] M₁' i) :
   multilinear_map R M₁ M₂ :=
 { to_fun := λ m, g $ λ i, f i (m i),

--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -195,17 +195,13 @@ def comp_linear_map (g : multilinear_map R M₁' M₂) (f : Π i, M₁ i →ₗ[
   multilinear_map R M₁ M₂ :=
 { to_fun := λ m, g $ λ i, f i (m i),
   map_add' := λ m i x y,
-    begin
-      have : ∀ j z, f j (update m i z j) = update (λ k, f k (m k)) i (f i z) j :=
-        λ j z, function.apply_update (λ k, f k) _ _ _ _,
-      simp [this]
-    end,
+    have ∀ j z, f j (update m i z j) = update (λ k, f k (m k)) i (f i z) j :=
+      λ j z, function.apply_update (λ k, f k) _ _ _ _,
+    by simp [this],
   map_smul' := λ m i c x,
-    begin
-      have : ∀ j z, f j (update m i z j) = update (λ k, f k (m k)) i (f i z) j :=
-        λ j z, function.apply_update (λ k, f k) _ _ _ _,
-      simp [this]
-    end }
+    have ∀ j z, f j (update m i z j) = update (λ k, f k (m k)) i (f i z) j :=
+      λ j z, function.apply_update (λ k, f k) _ _ _ _,
+    by simp [this] }
 
 @[simp] lemma comp_linear_map_apply (g : multilinear_map R M₁' M₂) (f : Π i, M₁ i →ₗ[R] M₁' i)
   (m : Π i, M₁ i) :

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -326,14 +326,18 @@ begin
   { simp [h, hg.ne] }
 end
 
-lemma comp_update {α' : Sort*} {β : Sort*} (f : α' → β) (g : α → α') (i : α) (v : α') :
-  f ∘ (update g i v) = update (f ∘ g) i (f v) :=
+lemma apply_update {ι : Sort*} [decidable_eq ι] {α β : ι → Sort*}
+  (f : Π i, α i → β i) (g : Π i, α i) (i : ι) (v : α i) (j : ι) :
+  f j (update g i v j) = update (λ k, f k (g k)) i (f i v) j :=
 begin
-  refine funext (λj, _),
   by_cases h : j = i,
-  { rw h, simp },
+  { subst j, simp },
   { simp [h] }
 end
+
+lemma comp_update {α' : Sort*} {β : Sort*} (f : α' → β) (g : α → α') (i : α) (v : α') :
+  f ∘ (update g i v) = update (f ∘ g) i (f v) :=
+funext $ apply_update _ _ _ _
 
 theorem update_comm {α} [decidable_eq α] {β : α → Sort*}
   {a b : α} (h : a ≠ b) (v : β a) (w : β b) (f : Πa, β a) :

--- a/src/topology/algebra/multilinear.lean
+++ b/src/topology/algebra/multilinear.lean
@@ -34,10 +34,9 @@ especially when defining iterated derivatives.
 open function fin set
 open_locale big_operators
 
-universes u v w w₁ w₂ w₃ w₄
-variables {R : Type u} {ι : Type v} {n : ℕ}
-{M : fin n.succ → Type w} {M₁ : ι → Type w₁} {M₂ : Type w₂} {M₃ : Type w₃} {M₄ : Type w₄}
-[decidable_eq ι]
+universes u v w w₁ w₁' w₂ w₃ w₄
+variables {R : Type u} {ι : Type v} {n : ℕ} {M : fin n.succ → Type w} {M₁ : ι → Type w₁}
+  {M₁' : ι → Type w₁'} {M₂ : Type w₂} {M₃ : Type w₃} {M₄ : Type w₄} [decidable_eq ι]
 
 /-- Continuous multilinear maps over the ring `R`, from `Πi, M₁ i` to `M₂` where `M₁ i` and `M₂`
 are modules over `R` with a topological structure. In applications, there will be compatibility
@@ -56,12 +55,12 @@ namespace continuous_multilinear_map
 section semiring
 
 variables [semiring R]
-[∀i, add_comm_monoid (M i)] [∀i, add_comm_monoid (M₁ i)] [add_comm_monoid M₂] [add_comm_monoid M₃]
-[add_comm_monoid M₄]
-[∀i, semimodule R (M i)] [∀i, semimodule R (M₁ i)] [semimodule R M₂] [semimodule R M₃]
-[semimodule R M₄]
-[∀i, topological_space (M i)] [∀i, topological_space (M₁ i)] [topological_space M₂]
-[topological_space M₃] [topological_space M₄]
+[Πi, add_comm_monoid (M i)] [Πi, add_comm_monoid (M₁ i)] [Πi, add_comm_monoid (M₁' i)]
+[add_comm_monoid M₂] [add_comm_monoid M₃] [add_comm_monoid M₄]
+[Πi, semimodule R (M i)] [Πi, semimodule R (M₁ i)]  [Πi, semimodule R (M₁' i)] [semimodule R M₂]
+[semimodule R M₃] [semimodule R M₄]
+[Πi, topological_space (M i)] [Πi, topological_space (M₁ i)] [Πi, topological_space (M₁' i)]
+[topological_space M₂] [topological_space M₃] [topological_space M₄]
 (f f' : continuous_multilinear_map R M₁ M₂)
 
 instance : has_coe_to_fun (continuous_multilinear_map R M₁ M₂) :=
@@ -133,18 +132,19 @@ def prod (f : continuous_multilinear_map R M₁ M₂) (g : continuous_multilinea
   (f : continuous_multilinear_map R M₁ M₂) (g : continuous_multilinear_map R M₁ M₃) (m : Πi, M₁ i) :
   (f.prod g) m = (f m, g m) := rfl
 
-/- If `R` and `M₃` are implicit in the next definition, Lean is never able to infer them, even
-given `g` and `f`. Therefore, we make them explicit. -/
-variables (R M₃)
-
-/-- If `g` is continuous multilinear and `f` is continuous linear, then `g (f m₁, ..., f mₙ)` is
-again a continuous multilinear map, that we call `g.comp_continuous_linear_map f`. -/
+/-- If `g` is continuous multilinear and `f` is a collection of continuous linear maps,
+then `g (f₁ m₁, ..., fₙ mₙ)` is again a continuous multilinear map, that we call
+`g.comp_continuous_linear_map f`. -/
 def comp_continuous_linear_map
-  (g : continuous_multilinear_map R (λ (i : ι), M₃) M₄) (f : M₂ →L[R] M₃) :
-  continuous_multilinear_map R (λ (i : ι), M₂) M₄ :=
-{ cont := g.cont.comp $ continuous_pi $ λj, f.cont.comp $ continuous_apply _,
-  .. g.to_multilinear_map.comp_linear_map R M₃ f.to_linear_map }
-variables {R M₃}
+  (g : continuous_multilinear_map R M₁' M₄) (f : Π i : ι, M₁ i →L[R] M₁' i) :
+  continuous_multilinear_map R M₁ M₄ :=
+{ cont := g.cont.comp $ continuous_pi $ λj, (f j).cont.comp $ continuous_apply _,
+  .. g.to_multilinear_map.comp_linear_map (λ i, (f i).to_linear_map) }
+
+@[simp] lemma comp_continuous_linear_map_apply (g : continuous_multilinear_map R M₁' M₄)
+  (f : Π i : ι, M₁ i →L[R] M₁' i) (m : Π i, M₁ i) :
+  g.comp_continuous_linear_map f m = g (λ i, f i $ m i) :=
+rfl
 
 /-- In the specific case of continuous multilinear maps on spaces indexed by `fin (n+1)`, where one
 can build an element of `Π(i : fin (n+1)), M i` using `cons`, one can express directly the

--- a/src/topology/algebra/multilinear.lean
+++ b/src/topology/algebra/multilinear.lean
@@ -56,11 +56,11 @@ section semiring
 
 variables [semiring R]
 [Πi, add_comm_monoid (M i)] [Πi, add_comm_monoid (M₁ i)] [Πi, add_comm_monoid (M₁' i)]
-[add_comm_monoid M₂] [add_comm_monoid M₃] [add_comm_monoid M₄]
-[Πi, semimodule R (M i)] [Πi, semimodule R (M₁ i)]  [Πi, semimodule R (M₁' i)] [semimodule R M₂]
-[semimodule R M₃] [semimodule R M₄]
-[Πi, topological_space (M i)] [Πi, topological_space (M₁ i)] [Πi, topological_space (M₁' i)]
-[topological_space M₂] [topological_space M₃] [topological_space M₄]
+  [add_comm_monoid M₂] [add_comm_monoid M₃] [add_comm_monoid M₄]
+  [Π i, semimodule R (M i)] [Π i, semimodule R (M₁ i)]  [Π i, semimodule R (M₁' i)] [semimodule R M₂]
+  [semimodule R M₃] [semimodule R M₄]
+  [Π i, topological_space (M i)] [Π i, topological_space (M₁ i)] [Π i, topological_space (M₁' i)]
+  [topological_space M₂] [topological_space M₃] [topological_space M₄]
 (f f' : continuous_multilinear_map R M₁ M₂)
 
 instance : has_coe_to_fun (continuous_multilinear_map R M₁ M₂) :=


### PR DESCRIPTION
Together with #4316 this will give us multilinear maps corresponding to monomials.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
