### PR TITLE
[Merged by Bors] - feat(data/complex/exponential): bounds on exp

### DIFF
--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1135,44 +1135,6 @@ lemma exp_approx_start (x a b : ℝ)
   abs' (exp x - a) ≤ b :=
 by simpa using h
 
-lemma exp_one_near_10 : abs' (exp 1 - 2244083/825552) ≤ 1/10^10 :=
-begin
-  apply exp_approx_start,
-  iterate 13 { refine exp_1_approx_succ_eq (by norm_num1; refl) (by norm_cast; refl) _ },
-  norm_num1,
-  refine exp_approx_end' _ (by norm_num1; refl) _ (by norm_cast; refl) (by simp) _,
-  rw [_root_.abs_one, abs_of_pos]; norm_num1,
-end
-
-lemma exp_one_near_20 : abs' (exp 1 - 363916618873/133877442384) ≤ 1/10^20 :=
-begin
-  apply exp_approx_start,
-  iterate 21 { refine exp_1_approx_succ_eq (by norm_num1; refl) (by norm_cast; refl) _ },
-  norm_num1,
-  refine exp_approx_end' _ (by norm_num1; refl) _ (by norm_cast; refl) (by simp) _,
-  rw [_root_.abs_one, abs_of_pos]; norm_num1,
-end
-
-lemma exp_one_gt_271828182 : 2.71828182 < exp 1 :=
-lt_of_lt_of_le (by norm_num) (sub_le.1 (abs_sub_le_iff.1 exp_one_near_10).2)
-
-lemma exp_one_lt_271828183 : exp 1 < 2.71828183 :=
-lt_of_le_of_lt (sub_le_iff_le_add.1 (abs_sub_le_iff.1 exp_one_near_10).1) (by norm_num)
-
-lemma exp_neg_one_gt_0367879441 : 0.367879441 < exp (-1) :=
-begin
-  rw [exp_neg, lt_inv _ (exp_pos _)],
-  refine lt_of_le_of_lt (sub_le_iff_le_add.1 (abs_sub_le_iff.1 exp_one_near_10).1) _,
-  all_goals {norm_num},
-end
-
-lemma exp_neg_one_lt_0367879442 : exp (-1) < 0.367879442 :=
-begin
-  rw [exp_neg, inv_lt (exp_pos _)],
-  refine lt_of_lt_of_le _ (sub_le.1 (abs_sub_le_iff.1 exp_one_near_10).2),
-  all_goals {norm_num},
-end
-
 lemma cos_bound {x : ℝ} (hx : abs' x ≤ 1) :
   abs' (cos x - (1 - x ^ 2 / 2)) ≤ abs' x ^ 4 * (5 / 96) :=
 calc abs' (cos x - (1 - x ^ 2 / 2)) = abs (complex.cos x - (1 - x ^ 2 / 2)) :

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1078,6 +1078,10 @@ begin
   convert exp_bound hxc hn; norm_cast
 end
 
+/-- A finite initial segment of the exponential series, followed by an arbitrary tail.
+For fixed `n` this is just a linear map wrt `r`, and each map is a simple linear function
+of the previous (see `exp_near_succ`), with `exp_near n x r ⟶ exp x` as `n ⟶ ∞`,
+for any `r`. -/
 def exp_near (n : ℕ) (x r : ℝ) : ℝ := ∑ m in range n, x ^ m / m! + x ^ n / n! * r
 
 @[simp] theorem exp_near_zero (x r) : exp_near 0 x r = r := by simp [exp_near]

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1131,7 +1131,7 @@ lemma exp_approx_start (x a b : ℝ)
   abs' (exp x - a) ≤ b :=
 by simpa using h
 
-lemma exp_one_near_10 : abs' (exp 1 - 419314/154257) ≤ 1/10^10 :=
+lemma exp_one_near_10 : abs' (exp 1 - 2244083/825552) ≤ 1/10^10 :=
 begin
   apply exp_approx_start,
   iterate 13 { refine exp_1_approx_succ_eq (by norm_num1; refl) (by norm_cast; refl) _ },
@@ -1140,13 +1140,13 @@ begin
   rw [_root_.abs_one, abs_of_pos]; norm_num1,
 end
 
-lemma exp_one_near_20 : abs' (exp 1 - 28875761731/10622799089) ≤ 1/10^20 :=
+lemma exp_one_near_20 : abs' (exp 1 - 363916618873/133877442384) ≤ 1/10^20 :=
 begin
   apply exp_approx_start,
   iterate 21 { refine exp_1_approx_succ_eq (by norm_num1; refl) (by norm_cast; refl) _ },
   norm_num1,
   refine exp_approx_end' _ (by norm_num1; refl) _ (by norm_cast; refl) (by simp) _,
-  rw [_root_.abs_one, abs_of_neg]; norm_num1,
+  rw [_root_.abs_one, abs_of_pos]; norm_num1,
 end
 
 lemma exp_one_gt_271828182 : 2.71828182 < exp 1 :=

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1071,6 +1071,33 @@ namespace real
 
 open complex finset
 
+lemma exp_bound {x : ℝ} (hx : abs' x ≤ 1) {n : ℕ} (hn : 0 < n) :
+  abs' (exp x - ∑ m in range n, x ^ m / m!) ≤ abs' x ^ n * (n.succ * (n! * n)⁻¹) :=
+begin
+  have hxc : complex.abs x ≤ 1, by exact_mod_cast hx,
+  convert exp_bound hxc hn; norm_cast
+end
+
+lemma exp_one_gt_271828182 : 2.71828182 < exp 1:=
+begin
+  have h := exp_bound (by norm_num : abs' (1 : ℝ) ≤ 1) (by norm_num : 0 < 12),
+  rw abs_le at h,
+  replace h := h.1,
+  simp only [sum_range_succ] at h,
+  norm_num at h,
+  linarith
+end
+
+lemma exp_one_lt_271828183 : exp 1 < 2.71828183 :=
+begin
+  have h := exp_bound (by norm_num : abs' (1 : ℝ) ≤ 1) (by norm_num : 0 < 12),
+  rw abs_le at h,
+  replace h := h.2,
+  simp only [sum_range_succ] at h,
+  norm_num at h,
+  linarith
+end
+
 lemma cos_bound {x : ℝ} (hx : abs' x ≤ 1) :
   abs' (cos x - (1 - x ^ 2 / 2)) ≤ abs' x ^ 4 * (5 / 96) :=
 calc abs' (cos x - (1 - x ^ 2 / 2)) = abs (complex.cos x - (1 - x ^ 2 / 2)) :
@@ -1092,8 +1119,8 @@ calc abs' (cos x - (1 - x ^ 2 / 2)) = abs (complex.cos x - (1 - x ^ 2 / 2)) :
   by simp [complex.abs_div]
 ... ≤ ((complex.abs (x * I) ^ 4 * (nat.succ 4 * (4! * (4 : ℕ))⁻¹)) / 2 +
     (complex.abs (-x * I) ^ 4 * (nat.succ 4 * (4! * (4 : ℕ))⁻¹)) / 2)  :
-  add_le_add ((div_le_div_right (by norm_num)).2 (exp_bound (by simpa) dec_trivial))
-             ((div_le_div_right (by norm_num)).2 (exp_bound (by simpa) dec_trivial))
+  add_le_add ((div_le_div_right (by norm_num)).2 (complex.exp_bound (by simpa) dec_trivial))
+             ((div_le_div_right (by norm_num)).2 (complex.exp_bound (by simpa) dec_trivial))
 ... ≤ abs' x ^ 4 * (5 / 96) : by norm_num; simp [mul_assoc, mul_comm, mul_left_comm, mul_div_assoc]
 
 lemma sin_bound {x : ℝ} (hx : abs' x ≤ 1) :
@@ -1118,8 +1145,8 @@ calc abs' (sin x - (x - x ^ 3 / 6)) = abs (complex.sin x - (x - x ^ 3 / 6)) :
   by simp [add_comm, complex.abs_div, complex.abs_mul]
 ... ≤ ((complex.abs (x * I) ^ 4 * (nat.succ 4 * (4! * (4 : ℕ))⁻¹)) / 2 +
     (complex.abs (-x * I) ^ 4 * (nat.succ 4 * (4! * (4 : ℕ))⁻¹)) / 2) :
-  add_le_add ((div_le_div_right (by norm_num)).2 (exp_bound (by simpa) dec_trivial))
-             ((div_le_div_right (by norm_num)).2 (exp_bound (by simpa) dec_trivial))
+  add_le_add ((div_le_div_right (by norm_num)).2 (complex.exp_bound (by simpa) dec_trivial))
+             ((div_le_div_right (by norm_num)).2 (complex.exp_bound (by simpa) dec_trivial))
 ... ≤ abs' x ^ 4 * (5 / 96) : by norm_num; simp [mul_assoc, mul_comm, mul_left_comm, mul_div_assoc]
 
 lemma cos_pos_of_le_one {x : ℝ} (hx : abs' x ≤ 1) : 0 < cos x :=

--- a/src/data/complex/exponential_bounds.lean
+++ b/src/data/complex/exponential_bounds.lean
@@ -5,7 +5,9 @@ Authors: Mario Carneiro, Joseph Myers
 -/
 
 import data.complex.exponential
-
+/-!
+# Bounds on specific values of the exponential
+-/
 namespace real
 
 local notation `abs'` := _root_.abs

--- a/src/data/complex/exponential_bounds.lean
+++ b/src/data/complex/exponential_bounds.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2020 Joseph Myers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Joseph Myers
+-/
+
+import data.complex.exponential
+
+namespace real
+
+local notation `abs'` := _root_.abs
+open is_absolute_value finset cau_seq complex
+
+lemma exp_one_near_10 : abs' (exp 1 - 2244083/825552) ≤ 1/10^10 :=
+begin
+  apply exp_approx_start,
+  iterate 13 { refine exp_1_approx_succ_eq (by norm_num1; refl) (by norm_cast; refl) _ },
+  norm_num1,
+  refine exp_approx_end' _ (by norm_num1; refl) _ (by norm_cast; refl) (by simp) _,
+  rw [_root_.abs_one, abs_of_pos]; norm_num1,
+end
+
+lemma exp_one_near_20 : abs' (exp 1 - 363916618873/133877442384) ≤ 1/10^20 :=
+begin
+  apply exp_approx_start,
+  iterate 21 { refine exp_1_approx_succ_eq (by norm_num1; refl) (by norm_cast; refl) _ },
+  norm_num1,
+  refine exp_approx_end' _ (by norm_num1; refl) _ (by norm_cast; refl) (by simp) _,
+  rw [_root_.abs_one, abs_of_pos]; norm_num1,
+end
+
+lemma exp_one_gt_271828182 : 2.71828182 < exp 1 :=
+lt_of_lt_of_le (by norm_num) (sub_le.1 (abs_sub_le_iff.1 exp_one_near_10).2)
+
+lemma exp_one_lt_271828183 : exp 1 < 2.71828183 :=
+lt_of_le_of_lt (sub_le_iff_le_add.1 (abs_sub_le_iff.1 exp_one_near_10).1) (by norm_num)
+
+lemma exp_neg_one_gt_0367879441 : 0.367879441 < exp (-1) :=
+begin
+  rw [exp_neg, lt_inv _ (exp_pos _)],
+  refine lt_of_le_of_lt (sub_le_iff_le_add.1 (abs_sub_le_iff.1 exp_one_near_10).1) _,
+  all_goals {norm_num},
+end
+
+lemma exp_neg_one_lt_0367879442 : exp (-1) < 0.367879442 :=
+begin
+  rw [exp_neg, inv_lt (exp_pos _)],
+  refine lt_of_lt_of_le _ (sub_le.1 (abs_sub_le_iff.1 exp_one_near_10).2),
+  all_goals {norm_num},
+end
+
+end real


### PR DESCRIPTION
Define `real.exp_bound` using `complex.exp_bound`.  Deduce numerical
bounds on `exp 1` analogous to those we have for pi.

---

This does the computation with norm_num in a very naive way.  Is it
worth doing it in a smarter way (e.g. a series of intermediate lemmas
giving successive partial sums of the series) to make the proofs
faster and so possibly allow more precise bounds to be given?

This only adds bounds with exactly 8 places after the decimal point
(the most that can be done with this naive use of norm_num without
timing out).  Should we have a series of bounds with different numbers
of decimal places, as we do for pi?

When using these bounds, it was actually `exp (-1)`, `exp (-2)` and
`exp (-3)` I wanted to bound.  Should mathlib have any bounds on `exp`
of constants other than `1`?


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
