### PR TITLE
[Merged by Bors] - feat(order/filter/ultrafilter): Add variant of `exists_ultrafilter`.

### DIFF
--- a/src/order/filter/ultrafilter.lean
+++ b/src/order/filter/ultrafilter.lean
@@ -142,25 +142,23 @@ begin
     hmin ⟨g, hg₁, le_trans hg₂ uτ.property.right⟩ hg₂⟩
 end
 
-lemma exists_ultrafilter' (S : set (set α)) (cond : ∀ T : finset (set α),
-  ↑T ⊆ S → ⋂₀ (↑T : set (set α)) ≠ ∅) : ∃ F : filter α, S ⊆ F.sets ∧ is_ultrafilter F :=
+lemma exists_ultrafilter_of_finite_inter_nonempty (S : set (set α)) (cond : ∀ T : finset (set α),
+  ↑T ⊆ S → (⋂₀ (↑T : set (set α))).nonempty) : ∃ F : filter α, S ⊆ F.sets ∧ is_ultrafilter F :=
 begin
-suffices : ∃ (F : filter α), ne_bot F ∧ S ⊆ F.sets,
-{ rcases this with ⟨F,cond,hF⟩,
-  rcases @exists_ultrafilter _ F cond with ⟨G,h1,h2⟩,
-  exact ⟨G,λ T hT, h1 (hF hT),h2⟩ },
-use filter.generate S,
-refine ⟨_,λ T hT, filter.generate_sets.basic hT⟩,
-rw ←forall_sets_nonempty_iff_ne_bot,
-intros T hT,
-rw mem_generate_iff at hT,
-rcases hT with ⟨A,h1,h2,h3⟩,
-let B := set.finite.to_finset h2,
-have : A = ↑B, by simp, rw this at *, clear this,
-specialize cond B h1,
-rw ne_empty_iff_nonempty at cond,
-rcases cond with ⟨x,hx⟩,
-exact ⟨x,h3 hx⟩,
+  suffices : ∃ (F : filter α), ne_bot F ∧ S ⊆ F.sets,
+  { rcases this with ⟨F,cond,hF⟩,
+    rcases @exists_ultrafilter _ F cond with ⟨G,h1,h2⟩,
+    exact ⟨G,λ T hT, h1 (hF hT),h2⟩ },
+  use filter.generate S,
+  refine ⟨_,λ T hT, filter.generate_sets.basic hT⟩,
+  rw ←forall_sets_nonempty_iff_ne_bot,
+  intros T hT,
+  rw mem_generate_iff at hT,
+  rcases hT with ⟨A,h1,h2,h3⟩,
+  let B := set.finite.to_finset h2,
+  have : A = ↑B, by simp, rw this at *, clear this,
+  rcases cond B h1 with ⟨x,hx⟩,
+  exact ⟨x,h3 hx⟩,
 end
 
 /-- Construct an ultrafilter extending a given filter.

--- a/src/order/filter/ultrafilter.lean
+++ b/src/order/filter/ultrafilter.lean
@@ -142,6 +142,27 @@ begin
     hmin ⟨g, hg₁, le_trans hg₂ uτ.property.right⟩ hg₂⟩
 end
 
+lemma exists_ultrafilter' (S : set (set α)) (cond : ∀ T : finset (set α),
+  ↑T ⊆ S → ⋂₀ (↑T : set (set α)) ≠ ∅) : ∃ F : filter α, S ⊆ F.sets ∧ is_ultrafilter F :=
+begin
+suffices : ∃ (F : filter α), ne_bot F ∧ S ⊆ F.sets,
+{ rcases this with ⟨F,cond,hF⟩,
+  rcases @exists_ultrafilter _ F cond with ⟨G,h1,h2⟩,
+  exact ⟨G,λ T hT, h1 (hF hT),h2⟩ },
+use filter.generate S,
+refine ⟨_,λ T hT, filter.generate_sets.basic hT⟩,
+rw ←forall_sets_nonempty_iff_ne_bot,
+intros T hT,
+rw mem_generate_iff at hT,
+rcases hT with ⟨A,h1,h2,h3⟩,
+let B := set.finite.to_finset h2,
+have : A = ↑B, by simp, rw this at *, clear this,
+specialize cond B h1,
+rw ne_empty_iff_nonempty at cond,
+rcases cond with ⟨x,hx⟩,
+exact ⟨x,h3 hx⟩,
+end
+
 /-- Construct an ultrafilter extending a given filter.
   The ultrafilter lemma is the assertion that such a filter exists;
   we use the axiom of choice to pick one. -/

--- a/src/order/filter/ultrafilter.lean
+++ b/src/order/filter/ultrafilter.lean
@@ -143,22 +143,23 @@ begin
 end
 
 lemma exists_ultrafilter_of_finite_inter_nonempty (S : set (set α)) (cond : ∀ T : finset (set α),
-  ↑T ⊆ S → (⋂₀ (↑T : set (set α))).nonempty) : ∃ F : filter α, S ⊆ F.sets ∧ is_ultrafilter F :=
+  (↑T : set (set α)) ⊆ S → (⋂₀ (↑T : set (set α))).nonempty) : 
+  ∃ F : filter α, S ⊆ F.sets ∧ is_ultrafilter F :=
 begin
-  suffices : ∃ (F : filter α), ne_bot F ∧ S ⊆ F.sets,
-  { rcases this with ⟨F,cond,hF⟩,
-    rcases @exists_ultrafilter _ F cond with ⟨G,h1,h2⟩,
-    exact ⟨G,λ T hT, h1 (hF hT),h2⟩ },
+  suffices : ∃ F : filter α, ne_bot F ∧ S ⊆ F.sets,
+  { rcases this with ⟨F, cond, hF⟩,
+    resetI,
+    obtain ⟨G : filter α, h1 : G ≤ F, h2 : is_ultrafilter G⟩ := exists_ultrafilter F,
+    exact ⟨G, λ T hT, h1 (hF hT), h2⟩ },
   use filter.generate S,
-  refine ⟨_,λ T hT, filter.generate_sets.basic hT⟩,
-  rw ←forall_sets_nonempty_iff_ne_bot,
+  refine ⟨_, λ T hT, filter.generate_sets.basic hT⟩,
+  rw ← forall_sets_nonempty_iff_ne_bot,
   intros T hT,
-  rw mem_generate_iff at hT,
-  rcases hT with ⟨A,h1,h2,h3⟩,
+  rcases (mem_generate_iff _).mp hT with ⟨A, h1, h2, h3⟩,
   let B := set.finite.to_finset h2,
-  have : A = ↑B, by simp, rw this at *, clear this,
-  rcases cond B h1 with ⟨x,hx⟩,
-  exact ⟨x,h3 hx⟩,
+  rw (show A = ↑B, by simp) at *,
+  rcases cond B h1 with ⟨x, hx⟩,
+  exact ⟨x, h3 hx⟩,
 end
 
 /-- Construct an ultrafilter extending a given filter.


### PR DESCRIPTION
The lemma `exists_ultrafilter` tells us that any proper filter can be extended to an ultrafilter (using Zorn's lemma). This PR adds a variant, called `exists_ultrafilter_of_finite_inter_nonempty` which says that any collection of sets `S` can be extended to an ultrafilter whenever it satisfies the property that the intersection of any finite subcollection `T` is nonempty.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
