### PR TITLE
[Merged by Bors] - doc(data/num/basic): added doc-strings to most defs

### DIFF
--- a/src/data/num/basic.lean
+++ b/src/data/num/basic.lean
@@ -275,21 +275,21 @@ namespace num
   | a b := by dsimp [(≤)]; apply_instance
 
   /--
-  Converting a `num` to a `znum`.
+  Converts a `num` to a `znum`.
   -/
   def to_znum : num → znum
   | 0       := 0
   | (pos a) := znum.pos a
 
   /--
-  Converting `x : num` to `-x : znum`.
+  Converts `x : num` to `-x : znum`.
   -/
   def to_znum_neg : num → znum
   | 0       := 0
   | (pos a) := znum.neg a
 
   /--
-  Converting a `nat` to a `num`.
+  Converts a `nat` to a `num`.
   -/
   def of_nat' : ℕ → num :=
   nat.binary_rec 0 (λ b n, cond b num.bit1 num.bit0)
@@ -358,7 +358,7 @@ namespace znum
   | (neg n) := neg (pos_num.bit1 n)
 
   /--
-  Converting an `int` to a `znum`.
+  Converts an `int` to a `znum`.
   -/
   def of_int' : ℤ → znum
   | (n : ℕ) := num.to_znum (num.of_nat' n)
@@ -370,7 +370,7 @@ namespace pos_num
   open znum
 
   /--
-  Subtraction of two `pos_num`s producing a `znum`.
+  Subtraction of two `pos_num`s, producing a `znum`.
   -/
   def sub' : pos_num → pos_num → znum
   | a        1        := (pred' a).to_znum
@@ -381,7 +381,7 @@ namespace pos_num
   | (bit1 a) (bit1 b) := (sub' a b).bit0
 
   /--
-  Converting `znum` to `option pos_num`, where it is `some` if the `znum` was positive and `none`
+  Converts `znum` to `option pos_num`, where it is `some` if the `znum` was positive and `none`
   otherwise.
   -/
   def of_znum' : znum → option pos_num
@@ -389,7 +389,7 @@ namespace pos_num
   | _            := none
 
   /--
-  Converting a `znum` to a `pos_num`, mapping all out of range values to `1`.
+  Converts a `znum` to a `pos_num`, mapping all out of range values to `1`.
   -/
   def of_znum : znum → pos_num
   | (znum.pos p) := p
@@ -423,7 +423,7 @@ namespace num
   | (pos p) := p.pred'
 
   /--
-  Dividing a `num` by `2`
+  Divides a `num` by `2`
   -/
   def div2 : num → num
   | 0 := 0
@@ -432,7 +432,7 @@ namespace num
   | (pos (pos_num.bit1 p)) := pos p
 
   /--
-  Converting a `znum` to an `option num`, where `of_znum' p = none` if `p < 0`.
+  Converts a `znum` to an `option num`, where `of_znum' p = none` if `p < 0`.
   -/
   def of_znum' : znum → option num
   | 0            := some 0
@@ -440,14 +440,14 @@ namespace num
   | (znum.neg p) := none
 
   /--
-  Converting a `znum` to an `option num`, where `of_znum p = 0` if `p < 0`.
+  Converts a `znum` to an `option num`, where `of_znum p = 0` if `p < 0`.
   -/
   def of_znum : znum → num
   | (znum.pos p) := pos p
   | _            := 0
 
   /--
-  Subtraction of two `num`s, producting a `znum`.
+  Subtraction of two `num`s, producing a `znum`.
   -/
   def sub' : num → num → znum
   | 0       0       := 0

--- a/src/data/num/basic.lean
+++ b/src/data/num/basic.lean
@@ -381,7 +381,7 @@ namespace pos_num
   | (bit1 a) (bit1 b) := (sub' a b).bit0
 
   /--
-  Converts `znum` to `option pos_num`, where it is `some` if the `znum` was positive and `none`
+  Converts a `znum` to `option pos_num`, where it is `some` if the `znum` was positive and `none`
   otherwise.
   -/
   def of_znum' : znum → option pos_num

--- a/src/data/num/basic.lean
+++ b/src/data/num/basic.lean
@@ -163,7 +163,7 @@ section
   variables {α : Type*} [has_zero α] [has_one α] [has_add α]
 
   /--
-  Casting a `pos_num` into any type which has `0`, `1` and `+`.
+  `cast_pos_num` casts a `pos_num` into any type which has `0`, `1` and `+`.
   -/
   def cast_pos_num : pos_num → α
   | 1                := 1
@@ -171,7 +171,7 @@ section
   | (pos_num.bit1 a) := bit1 (cast_pos_num a)
 
   /--
-  Casting a `pos_num` into any type which has `0`, `1` and `+`.
+  `cast_num` casts a `num` into any type which has `0`, `1` and `+`.
   -/
   def cast_num : num → α
   | 0           := 0
@@ -654,7 +654,7 @@ section
   variables {α : Type*} [has_zero α] [has_one α] [has_add α] [has_neg α]
 
   /--
-  Casting `znum` into any type which has `0`, `1`, `+` and `neg`
+  `cast_znum` casts a `znum` into any type which has `0`, `1`, `+` and `neg`
   -/
   def cast_znum : znum → α
   | 0            := 0

--- a/src/data/num/basic.lean
+++ b/src/data/num/basic.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
+-/
 
-Binary representation of integers using inductive types.
+/-!
+# Binary representation of integers using inductive types.
 
 Note: Unlike in Coq, where this representation is preferred because of
 the reliance on kernel reduction, in Lean this representation is discouraged
@@ -48,17 +50,29 @@ instance : inhabited znum := ⟨0⟩
 
 namespace pos_num
 
+  /--
+  Appending a bit to a `pos_num`, where `bit tt x = x1` and `bit ff x = x0`.
+  -/
   def bit (b : bool) : pos_num → pos_num := cond b bit1 bit0
 
+  /--
+  The successor of a `pos_num`.
+  -/
   def succ : pos_num → pos_num
   | 1        := bit0 one
   | (bit1 n) := bit0 (succ n)
   | (bit0 n) := bit1 n
 
+  /--
+  Returns a boolean for whether the `pos_num` is `one`.
+  -/
   def is_one : pos_num → bool
   | 1 := tt
   | _ := ff
 
+  /--
+  Addition of two `pos_num`s.
+  -/
   protected def add : pos_num → pos_num → pos_num
   | 1        b        := succ b
   | a        1        := succ a
@@ -69,24 +83,39 @@ namespace pos_num
 
   instance : has_add pos_num := ⟨pos_num.add⟩
 
+  /--
+  The predecessor of a `pos_num` as a `num`.
+  -/
   def pred' : pos_num → num
   | 1        := 0
   | (bit0 n) := num.pos (num.cases_on (pred' n) 1 bit1)
   | (bit1 n) := num.pos (bit0 n)
 
+  /--
+  The predecessor of a `pos_num` as a `pos_num`. This means that `pred 1 = 1`.
+  -/
   def pred (a : pos_num) : pos_num :=
   num.cases_on (pred' a) 1 id
 
+  /--
+  The number of bits of a `pos_num`, as a `pos_num`.
+  -/
   def size : pos_num → pos_num
   | 1        := 1
   | (bit0 n) := succ (size n)
   | (bit1 n) := succ (size n)
 
+  /--
+  The number of bits of a `pos_num`, as a `nat`.
+  -/
   def nat_size : pos_num → nat
   | 1        := 1
   | (bit0 n) := nat.succ (nat_size n)
   | (bit1 n) := nat.succ (nat_size n)
 
+  /--
+  Multiplication of two `pos_num`s.
+  -/
   protected def mul (a : pos_num) : pos_num → pos_num
   | 1        := a
   | (bit0 b) := bit0 (mul b)
@@ -94,13 +123,22 @@ namespace pos_num
 
   instance : has_mul pos_num := ⟨pos_num.mul⟩
 
+  /--
+  `of_nat_succ n` is the `pos_num` corresponding to `n + 1`.
+  -/
   def of_nat_succ : ℕ → pos_num
   | 0            := 1
   | (nat.succ n) := succ (of_nat_succ n)
 
+  /--
+  `of_nat n` is the `pos_num` corresponding to `n`, except for `of_nat 0 = 1`.
+  -/
   def of_nat (n : ℕ) : pos_num := of_nat_succ (nat.pred n)
 
   open ordering
+  /--
+  Ordering of `pos_num`s.
+  -/
   def cmp : pos_num → pos_num → ordering
   | 1        1        := eq
   | _        1        := gt
@@ -124,11 +162,17 @@ end pos_num
 section
   variables {α : Type*} [has_zero α] [has_one α] [has_add α]
 
+  /--
+  Casting a `pos_num` into any type which has `0`, `1` and `+`.
+  -/
   def cast_pos_num : pos_num → α
   | 1                := 1
   | (pos_num.bit0 a) := bit0 (cast_pos_num a)
   | (pos_num.bit1 a) := bit1 (cast_pos_num a)
 
+  /--
+  Casting a `pos_num` into any type which has `0`, `1` and `+`.
+  -/
   def cast_num : num → α
   | 0           := 0
   | (num.pos p) := cast_pos_num p
@@ -146,12 +190,21 @@ end
 namespace num
   open pos_num
 
+  /--
+  The successor of a `num` as a `pos_num`.
+  -/
   def succ' : num → pos_num
   | 0       := 1
   | (pos p) := succ p
 
+  /--
+  The successor of a `num` as a `num`.
+  -/
   def succ (n : num) : num := pos (succ' n)
 
+  /--
+  Addition of two `num`s.
+  -/
   protected def add : num → num → num
   | 0       a       := a
   | b       0       := b
@@ -159,24 +212,42 @@ namespace num
 
   instance : has_add num := ⟨num.add⟩
 
+  /--
+  Appending a `0` to a `num`.
+  -/
   protected def bit0 : num → num
   | 0       := 0
   | (pos n) := pos (pos_num.bit0 n)
 
+  /--
+  Appending a `1` to a `num`.
+  -/
   protected def bit1 : num → num
   | 0       := 1
   | (pos n) := pos (pos_num.bit1 n)
 
+  /--
+  Appending a bit to a `num`, where `bit tt x = x1` and `bit ff x = x0`.
+  -/
   def bit (b : bool) : num → num := cond b num.bit1 num.bit0
 
+  /--
+  The number of bits required to represent a `num`, as a `num`. `size 0` is defined to be `0`.
+  -/
   def size : num → num
   | 0       := 0
   | (pos n) := pos (pos_num.size n)
 
+  /--
+  The number of bits required to represent a `num`, as a `nat`. `size 0` is defined to be `0`.
+  -/
   def nat_size : num → nat
   | 0       := 0
   | (pos n) := pos_num.nat_size n
 
+  /--
+  Multiplication of two `num`s.
+  -/
   protected def mul : num → num → num
   | 0       _       := 0
   | _       0       := 0
@@ -185,6 +256,9 @@ namespace num
   instance : has_mul num := ⟨num.mul⟩
 
   open ordering
+  /--
+  Ordering of `num`s.
+  -/
   def cmp : num → num → ordering
   | 0       0       := eq
   | _       0       := gt
@@ -200,14 +274,23 @@ namespace num
   instance decidable_le : @decidable_rel num (≤)
   | a b := by dsimp [(≤)]; apply_instance
 
+  /--
+  Converting a `num` to a `znum`.
+  -/
   def to_znum : num → znum
   | 0       := 0
   | (pos a) := znum.pos a
 
+  /--
+  Converting `x : num` to `-x : znum`.
+  -/
   def to_znum_neg : num → znum
   | 0       := 0
   | (pos a) := znum.neg a
 
+  /--
+  Converting a `nat` to a `num`.
+  -/
   def of_nat' : ℕ → num :=
   nat.binary_rec 0 (λ b n, cond b num.bit1 num.bit0)
 
@@ -216,6 +299,9 @@ end num
 namespace znum
   open pos_num
 
+  /--
+  The negation of a `znum`.
+  -/
   def zneg : znum → znum
   | 0       := 0
   | (pos a) := neg a
@@ -223,36 +309,57 @@ namespace znum
 
   instance : has_neg znum := ⟨zneg⟩
 
+  /--
+  The absolute value of a `znum` as a `num`.
+  -/
   def abs : znum → num
   | 0       := 0
   | (pos a) := num.pos a
   | (neg a) := num.pos a
 
+  /--
+  The successor of a `znum`.
+  -/
   def succ : znum → znum
   | 0       := 1
   | (pos a) := pos (pos_num.succ a)
   | (neg a) := (pos_num.pred' a).to_znum_neg
 
+  /--
+  The predecessor of a `znum`.
+  -/
   def pred : znum → znum
   | 0       := neg 1
   | (pos a) := (pos_num.pred' a).to_znum
   | (neg a) := neg (pos_num.succ a)
 
+  /--
+  Appending a `0` to a `znum`.
+  -/
   protected def bit0 : znum → znum
   | 0       := 0
   | (pos n) := pos (pos_num.bit0 n)
   | (neg n) := neg (pos_num.bit0 n)
 
+  /--
+  Appending a `1` to a `znum`, mapping `x` to `2 * x + 1`.
+  -/
   protected def bit1 : znum → znum
   | 0       := 1
   | (pos n) := pos (pos_num.bit1 n)
   | (neg n) := neg (num.cases_on (pred' n) 1 pos_num.bit1)
 
+  /--
+  Appending a `1` to a `znum`, mapping `x` to `2 * x - 1`.
+  -/
   protected def bitm1 : znum → znum
   | 0       := neg 1
   | (pos n) := pos (num.cases_on (pred' n) 1 pos_num.bit1)
   | (neg n) := neg (pos_num.bit1 n)
 
+  /--
+  Converting an `int` to a `znum`.
+  -/
   def of_int' : ℤ → znum
   | (n : ℕ) := num.to_znum (num.of_nat' n)
   | -[1+ n] := num.to_znum_neg (num.of_nat' (n+1))
@@ -262,6 +369,9 @@ end znum
 namespace pos_num
   open znum
 
+  /--
+  Subtraction of two `pos_num`s producing a `znum`.
+  -/
   def sub' : pos_num → pos_num → znum
   | a        1        := (pred' a).to_znum
   | 1        b        := (pred' b).to_znum_neg
@@ -270,14 +380,24 @@ namespace pos_num
   | (bit1 a) (bit0 b) := (sub' a b).bit1
   | (bit1 a) (bit1 b) := (sub' a b).bit0
 
+  /--
+  Converting `znum` to `option pos_num`, where it is `some` if the `znum` was positive and `none`
+  otherwise.
+  -/
   def of_znum' : znum → option pos_num
   | (znum.pos p) := some p
   | _            := none
 
+  /--
+  Converting a `znum` to a `pos_num`, mapping all out of range values to `1`.
+  -/
   def of_znum : znum → pos_num
   | (znum.pos p) := p
   | _            := 1
 
+  /--
+  Subtraction of `pos_num`s, where if `a < b`, then `a - b = 1`.
+  -/
   protected def sub (a b : pos_num) : pos_num :=
   match sub' a b with
   | (znum.pos p) := p
@@ -288,38 +408,62 @@ namespace pos_num
 end pos_num
 
 namespace num
+  /--
+  The predecessor of a `num` as an `option num`, where `ppred 0 = none`
+  -/
   def ppred : num → option num
   | 0       := none
   | (pos p) := some p.pred'
 
+  /--
+  The predecessor of a `num` as a `num`, where `pred 0 = 0`.
+  -/
   def pred : num → num
   | 0       := 0
   | (pos p) := p.pred'
 
+  /--
+  Dividing a `num` by `2`
+  -/
   def div2 : num → num
   | 0 := 0
   | 1 := 0
   | (pos (pos_num.bit0 p)) := pos p
   | (pos (pos_num.bit1 p)) := pos p
 
+  /--
+  Converting a `znum` to an `option num`, where `of_znum' p = none` if `p < 0`.
+  -/
   def of_znum' : znum → option num
   | 0            := some 0
   | (znum.pos p) := some (pos p)
   | (znum.neg p) := none
 
+  /--
+  Converting a `znum` to an `option num`, where `of_znum p = 0` if `p < 0`.
+  -/
   def of_znum : znum → num
   | (znum.pos p) := pos p
   | _            := 0
 
+  /--
+  Subtraction of two `num`s, producting a `znum`.
+  -/
   def sub' : num → num → znum
   | 0       0       := 0
   | (pos a) 0       := znum.pos a
   | 0       (pos b) := znum.neg b
   | (pos a) (pos b) := a.sub' b
 
+  /--
+  Subtraction of two `num`s, producing an `option num`.
+  -/
   def psub (a b : num) : option num :=
   of_znum' (sub' a b)
 
+  /--
+  Subtraction of two `num`s, where if `a < b`, `a - b = 0`.
+  -/
   protected def sub (a b : num) : num :=
   of_znum (sub' a b)
 
@@ -329,6 +473,9 @@ end num
 namespace znum
   open pos_num
 
+  /--
+  Addition of `znum`s.
+  -/
   protected def add : znum → znum → znum
   | 0       a       := a
   | b       0       := b
@@ -339,6 +486,9 @@ namespace znum
 
   instance : has_add znum := ⟨znum.add⟩
 
+  /--
+  Multiplication of `znum`s.
+  -/
   protected def mul : znum → znum → znum
   | 0       a       := 0
   | b       0       := 0
@@ -350,6 +500,9 @@ namespace znum
   instance : has_mul znum := ⟨znum.mul⟩
 
   open ordering
+  /--
+  Ordering on `znum`s.
+  -/
   def cmp : znum → znum → ordering
   | 0       0       := eq
   | (pos a) (pos b) := pos_num.cmp a b
@@ -378,6 +531,9 @@ namespace pos_num
   | none    := (num.bit0 q, r)
   end
 
+  /--
+  `divmod x y = (y / x, y % x)`.
+  -/
   def divmod (d : pos_num) : pos_num → num × num
   | (bit0 n) := let (q, r₁) := divmod n in
     divmod_aux d q (num.bit0 r₁)
@@ -385,8 +541,14 @@ namespace pos_num
     divmod_aux d q (num.bit1 r₁)
   | 1        := divmod_aux d 0 1
 
+  /--
+  Division of `pos_num`,
+  -/
   def div' (n d : pos_num) : num := (divmod d n).1
 
+  /--
+  Modulus of `pos_num`s.
+  -/
   def mod' (n d : pos_num) : num := (divmod d n).2
 
   def sqrt_aux1 (b : pos_num) (r n : num) : num × num :=
@@ -422,12 +584,17 @@ end
 end pos_num
 
 namespace num
-
+  /--
+  Division of `num`s, where `x / 0 = 0`.
+  -/
   def div : num → num → num
   | 0       _       := 0
   | _       0       := 0
   | (pos n) (pos d) := pos_num.div' n d
 
+  /--
+  Modulus of `num`s.
+  -/
   def mod : num → num → num
   | 0       _       := 0
   | n       0       := n
@@ -441,6 +608,9 @@ namespace num
   | (nat.succ n) 0 b := b
   | (nat.succ n) a b := gcd_aux n (b % a) a
 
+  /--
+  Greatest Common Divisor (GCD) of two `num`s.
+  -/
   def gcd (a b : num) : num :=
   if a ≤ b then
     gcd_aux (a.nat_size + b.nat_size) a b
@@ -451,6 +621,9 @@ end num
 
 namespace znum
 
+  /--
+  Division of `znum`, where `x / 0 = 0`.
+  -/
   def div : znum → znum → znum
   | 0       _       := 0
   | _       0       := 0
@@ -459,6 +632,9 @@ namespace znum
   | (neg n) (pos d) := neg (pos_num.pred' n / num.pos d).succ'
   | (neg n) (neg d) := pos (pos_num.pred' n / num.pos d).succ'
 
+  /--
+  Modulus of `znum`s.
+  -/
   def mod : znum → znum → znum
   | 0       d := 0
   | (pos n) d := num.to_znum (num.pos n % d.abs)
@@ -467,6 +643,9 @@ namespace znum
   instance : has_div znum := ⟨znum.div⟩
   instance : has_mod znum := ⟨znum.mod⟩
 
+  /--
+  Greatest Common Divisor (GCD) of two `znum`s.
+  -/
   def gcd (a b : znum) : num := a.abs.gcd b.abs
 
 end znum
@@ -474,6 +653,9 @@ end znum
 section
   variables {α : Type*} [has_zero α] [has_one α] [has_add α] [has_neg α]
 
+  /--
+  Casting `znum` into any type which has `0`, `1`, `+` and `neg`
+  -/
   def cast_znum : znum → α
   | 0            := 0
   | (znum.pos p) := p

--- a/src/data/num/basic.lean
+++ b/src/data/num/basic.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura, Mario Carneiro
 -/
 
 /-!
-# Binary representation of integers using inductive types.
+# Binary representation of integers using inductive types
 
 Note: Unlike in Coq, where this representation is preferred because of
 the reliance on kernel reduction, in Lean this representation is discouraged

--- a/src/data/num/basic.lean
+++ b/src/data/num/basic.lean
@@ -51,7 +51,7 @@ instance : inhabited znum := ⟨0⟩
 namespace pos_num
 
   /--
-  Appending a bit to a `pos_num`, where `bit tt x = x1` and `bit ff x = x0`.
+  `bit b n` appends the bit `b` to the end of `n`, where `bit tt x = x1` and `bit ff x = x0`.
   -/
   def bit (b : bool) : pos_num → pos_num := cond b bit1 bit0
 
@@ -213,21 +213,21 @@ namespace num
   instance : has_add num := ⟨num.add⟩
 
   /--
-  Appending a `0` to a `num`.
+  `bit0 n` appends a `0` to the end of `n`, where `bit0 n = n0`.
   -/
   protected def bit0 : num → num
   | 0       := 0
   | (pos n) := pos (pos_num.bit0 n)
 
   /--
-  Appending a `1` to a `num`.
+  `bit1 n` appends a `1` to the end of `n`, where `bit1 n = n1`.
   -/
   protected def bit1 : num → num
   | 0       := 1
   | (pos n) := pos (pos_num.bit1 n)
 
   /--
-  Appending a bit to a `num`, where `bit tt x = x1` and `bit ff x = x0`.
+  `bit b n` appends the bit `b` to the end of `n`, where `bit tt x = x1` and `bit ff x = x0`.
   -/
   def bit (b : bool) : num → num := cond b num.bit1 num.bit0
 
@@ -334,7 +334,7 @@ namespace znum
   | (neg a) := neg (pos_num.succ a)
 
   /--
-  Appending a `0` to a `znum`.
+  `bit0 n` appends a `0` to the end of `n`, where `bit0 n = n0`.
   -/
   protected def bit0 : znum → znum
   | 0       := 0
@@ -342,7 +342,7 @@ namespace znum
   | (neg n) := neg (pos_num.bit0 n)
 
   /--
-  Appending a `1` to a `znum`, mapping `x` to `2 * x + 1`.
+  `bit1 x` appends a `1` to the end of `x`, mapping `x` to `2 * x + 1`.
   -/
   protected def bit1 : znum → znum
   | 0       := 1
@@ -350,7 +350,7 @@ namespace znum
   | (neg n) := neg (num.cases_on (pred' n) 1 pos_num.bit1)
 
   /--
-  Appending a `1` to a `znum`, mapping `x` to `2 * x - 1`.
+  `bitm1 x` appends a `1` to the end of `x`, mapping `x` to `2 * x - 1`.
   -/
   protected def bitm1 : znum → znum
   | 0       := neg 1


### PR DESCRIPTION
---

I'm not sure what to write for some of the `_aux` definitions to be honest, so I left them as is. Hence there's still some `nolint`s left in this file.
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
