### PR TITLE
[Merged by Bors] - feat(data/polynomial/ring_division): add multiplicity of sum of polynomials is at least minimum of multiplicities

### DIFF
--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -471,17 +471,11 @@ namespace comm_semiring
 
 variables [comm_semiring R]
 
-lemma min_pow_dvd_sum {n m : ℕ} {a b c : R} (ha : c^n ∣ a) (hb : c^m ∣ b) :
-c^(min n m) ∣ a + b :=
+lemma min_pow_dvd_sum {n m : ℕ} {a b c : R} (ha : c ^ n ∣ a) (hb : c ^ m ∣ b) : c ^ (min n m) ∣ a + b :=
 begin
-by_cases n ≤ m,
-{ simp [h],
-  replace hb := dvd.trans (pow_dvd_pow c h) hb,
-  exact dvd_add ha hb },
-{ simp [le_of_not_ge h],
-  replace ha := dvd.trans (pow_dvd_pow c (le_of_not_ge h)) ha,
-  exact dvd_add ha hb,
- },
+  replace ha := dvd.trans (pow_dvd_pow c (min_le_left n m)) ha,
+  replace hb := dvd.trans (pow_dvd_pow c (min_le_right n m)) hb,
+  exact dvd_add ha hb
 end
 
 end comm_semiring

--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -471,7 +471,7 @@ section comm_semiring
 
 variables [comm_semiring R]
 
-lemma min_pow_dvd_sum {n m : ℕ} {a b c : R} (ha : c ^ n ∣ a) (hb : c ^ m ∣ b) : c ^ (min n m) ∣ a + b :=
+lemma min_pow_dvd_add {n m : ℕ} {a b c : R} (ha : c ^ n ∣ a) (hb : c ^ m ∣ b) : c ^ (min n m) ∣ a + b :=
 begin
   replace ha := dvd.trans (pow_dvd_pow c (min_le_left n m)) ha,
   replace hb := dvd.trans (pow_dvd_pow c (min_le_right n m)) hb,

--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -467,7 +467,7 @@ end
 
 end cancel_add_monoid
 
-namespace comm_semiring
+section comm_semiring
 
 variables [comm_semiring R]
 

--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -467,6 +467,25 @@ end
 
 end cancel_add_monoid
 
+namespace comm_semiring
+
+variables [comm_semiring R]
+
+lemma min_pow_dvd_sum {n m : ℕ} {a b c : R} (ha : c^n ∣ a) (hb : c^m ∣ b) :
+c^(min n m) ∣ a + b :=
+begin
+by_cases n ≤ m,
+{ simp [h],
+  replace hb := dvd.trans (pow_dvd_pow c h) hb,
+  exact dvd_add ha hb },
+{ simp [le_of_not_ge h],
+  replace ha := dvd.trans (pow_dvd_pow c (le_of_not_ge h)) ha,
+  exact dvd_add ha hb,
+ },
+end
+
+end comm_semiring
+
 namespace canonically_ordered_semiring
 variable [canonically_ordered_comm_semiring R]
 

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -206,7 +206,7 @@ begin
              ge_iff_le, zero_le, le_add_iff_nonneg_right],
 end
 
-/-The multiplicty of p+q is at leas the minimum of the multiplicities-/
+/- The multiplicty of `p + q` is at leas the minimum of the multiplicities. -/
 lemma root_multiplicity_add {p q : polynomial R} (a : R) (hzero : p + q ≠ 0) :
   min (root_multiplicity a p) (root_multiplicity a q) ≤ root_multiplicity a (p + q) :=
 begin

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -198,7 +198,7 @@ end
 
 /-- If `(X - a) ^ n` divides a polynomial `p` then the multiplicity of `a` as root of `p` is at
 least `n`. -/
-lemma multiplicity_of_dvd {p : polynomial R} {a : R} {n : ℕ}
+lemma root_multiplicity_of_dvd {p : polynomial R} {a : R} {n : ℕ}
   (hzero : p ≠ 0) (h : (X - C a) ^ n ∣ p) : n ≤ root_multiplicity a p :=
 begin
   obtain ⟨q, hq⟩ := exists_eq_mul_right_of_dvd h,

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -185,7 +185,7 @@ begin
   exact root_multiplicity_eq_zero (mt root_X_sub_C.mp (ne.symm hxy))
 end
 
-/-- The multiplicity of `a` as root of `(X - a) ^ n` is `n`. --/
+/-- The multiplicity of `a` as root of `(X - a) ^ n` is `n`. -/
 lemma root_multiplicity_X_sub_C_pow (a : R) (n : ℕ) : root_multiplicity a ((X - C a) ^ n) = n :=
 begin
   induction n with n hn,

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -185,7 +185,7 @@ begin
   exact root_multiplicity_eq_zero (mt root_X_sub_C.mp (ne.symm hxy))
 end
 
-/-The multiplicity of a as root of (X - a)^n is n-/
+/- The multiplicity of `a` as root of `(X - a) ^ n` is `n`. -/
 lemma root_multiplicity_X_sub_C_pow (a : R) (n : ℕ) : root_multiplicity a ((X - C a) ^ n) = n :=
 begin
   induction n with n hn,

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -211,7 +211,7 @@ end
 lemma root_multiplicity_add {p q : polynomial R} (a : R) (hzero : p + q ≠ 0) :
   min (root_multiplicity a p) (root_multiplicity a q) ≤ root_multiplicity a (p + q) :=
 begin
-  refine multiplicity_of_dvd hzero _,
+  refine root_multiplicity_of_dvd hzero _,
   have hdivp : (X - C a) ^ root_multiplicity a p ∣ p := pow_root_multiplicity_dvd p a,
   have hdivq : (X - C a) ^ root_multiplicity a q ∣ q := pow_root_multiplicity_dvd q a,
   exact min_pow_dvd_add hdivp hdivq

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -185,7 +185,7 @@ begin
   exact root_multiplicity_eq_zero (mt root_X_sub_C.mp (ne.symm hxy))
 end
 
-/- The multiplicity of `a` as root of `(X - a) ^ n` is `n`. -/
+/-- The multiplicity of `a` as root of `(X - a) ^ n` is `n`. --/
 lemma root_multiplicity_X_sub_C_pow (a : R) (n : ℕ) : root_multiplicity a ((X - C a) ^ n) = n :=
 begin
   induction n with n hn,
@@ -196,7 +196,7 @@ begin
   simp only [root_multiplicity_mul hzero, root_multiplicity_X_sub_C_self, hn, nat.one_add]
 end
 
-/- If `(X - a) ^ n` divides a polynomial `p` then the multipicity of `a` as root of `p` is at least `n`. -/
+/-- If `(X - a) ^ n` divides a polynomial `p` then the multipicity of `a` as root of `p` is at least `n`. --/
 lemma multiplicity_of_dvd {p : polynomial R} {a : R} {n : ℕ}
   (hzero : p ≠ 0) (h : (X - C a) ^ n ∣ p) : n ≤ root_multiplicity a p :=
 begin
@@ -206,7 +206,7 @@ begin
              ge_iff_le, zero_le, le_add_iff_nonneg_right],
 end
 
-/- The multiplicty of `p + q` is at leas the minimum of the multiplicities. -/
+/-- The multiplicty of `p + q` is at leas the minimum of the multiplicities. --/
 lemma root_multiplicity_add {p q : polynomial R} (a : R) (hzero : p + q ≠ 0) :
   min (root_multiplicity a p) (root_multiplicity a q) ≤ root_multiplicity a (p + q) :=
 begin

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -204,7 +204,7 @@ begin
   obtain ⟨q, hq⟩ := exists_eq_mul_right_of_dvd h,
   rw hq at hzero,
   simp only [hq, root_multiplicity_mul hzero, root_multiplicity_X_sub_C_pow,
-             ge_iff_le, zero_le, le_add_iff_nonneg_right],
+             ge_iff_le, _root_.zero_le, le_add_iff_nonneg_right],
 end
 
 /-- The multiplicity of `p + q` is at least the minimum of the multiplicities. -/

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -185,6 +185,37 @@ begin
   exact root_multiplicity_eq_zero (mt root_X_sub_C.mp (ne.symm hxy))
 end
 
+/-The multiplicity of a as root of (X - a)^n is n-/
+lemma root_multiplicity_X_sub_C_pow (a : R) (n : ℕ) : root_multiplicity a ((X - C a) ^ n) = n :=
+begin
+  induction n with n hn,
+  { refine root_multiplicity_eq_zero _,
+    simp only [eval_one, is_root.def, not_false_iff, one_ne_zero, pow_zero] },
+  have hzero :=  (ne_zero_of_monic (monic_pow (monic_X_sub_C a) n.succ)),
+  rw pow_succ (X - C a) n at hzero ⊢,
+  simp only [root_multiplicity_mul hzero, root_multiplicity_X_sub_C_self, hn, nat.one_add]
+end
+
+/-If (X - a)^n divides a polynomial p then the multipicity of a as root of p is at least n-/
+lemma multiplicity_of_dvd {p : polynomial R} {a : R} {n : ℕ}
+  (hzero : p ≠ 0) (h : (X - C a) ^ n ∣ p) : n ≤ root_multiplicity a p :=
+begin
+  obtain ⟨q, hq⟩ := exists_eq_mul_right_of_dvd h,
+  rw hq at hzero,
+  simp only [hq, root_multiplicity_mul hzero, root_multiplicity_X_sub_C_pow,
+             ge_iff_le, zero_le, le_add_iff_nonneg_right],
+end
+
+/-The multiplicty of p+q is at leas the minimum of the multiplicities-/
+lemma root_multiplicity_add {p q : polynomial R} (a : R) (hzero : p + q ≠ 0) :
+  min (root_multiplicity a p) (root_multiplicity a q) ≤ root_multiplicity a (p + q) :=
+begin
+  refine multiplicity_of_dvd hzero _,
+  have hdivp : (X - C a) ^ root_multiplicity a p ∣ p := pow_root_multiplicity_dvd p a,
+  have hdivq : (X - C a) ^ root_multiplicity a q ∣ q := pow_root_multiplicity_dvd q a,
+  exact min_pow_dvd_sum hdivp hdivq
+end
+
 lemma exists_multiset_roots : ∀ {p : polynomial R} (hp : p ≠ 0),
   ∃ s : multiset R, (s.card : with_bot ℕ) ≤ degree p ∧ ∀ a, s.count a = root_multiplicity a p
 | p := λ hp, by haveI := classical.prop_decidable (∃ x, is_root p x); exact

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -196,7 +196,7 @@ begin
   simp only [root_multiplicity_mul hzero, root_multiplicity_X_sub_C_self, hn, nat.one_add]
 end
 
-/-If (X - a)^n divides a polynomial p then the multipicity of a as root of p is at least n-/
+/- If `(X - a) ^ n` divides a polynomial `p` then the multipicity of `a` as root of `p` is at least `n`. -/
 lemma multiplicity_of_dvd {p : polynomial R} {a : R} {n : ℕ}
   (hzero : p ≠ 0) (h : (X - C a) ^ n ∣ p) : n ≤ root_multiplicity a p :=
 begin

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -214,7 +214,7 @@ begin
   refine multiplicity_of_dvd hzero _,
   have hdivp : (X - C a) ^ root_multiplicity a p ∣ p := pow_root_multiplicity_dvd p a,
   have hdivq : (X - C a) ^ root_multiplicity a q ∣ q := pow_root_multiplicity_dvd q a,
-  exact min_pow_dvd_sum hdivp hdivq
+  exact comm_semiring.min_pow_dvd_sum hdivp hdivq
 end
 
 lemma exists_multiset_roots : ∀ {p : polynomial R} (hp : p ≠ 0),

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -214,7 +214,7 @@ begin
   refine multiplicity_of_dvd hzero _,
   have hdivp : (X - C a) ^ root_multiplicity a p ∣ p := pow_root_multiplicity_dvd p a,
   have hdivq : (X - C a) ^ root_multiplicity a q ∣ q := pow_root_multiplicity_dvd q a,
-  exact comm_semiring.min_pow_dvd_sum hdivp hdivq
+  exact min_pow_dvd_add hdivp hdivq
 end
 
 lemma exists_multiset_roots : ∀ {p : polynomial R} (hp : p ≠ 0),

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -207,7 +207,7 @@ begin
              ge_iff_le, zero_le, le_add_iff_nonneg_right],
 end
 
-/-- The multiplicty of `p + q` is at leas the minimum of the multiplicities. --/
+/-- The multiplicity of `p + q` is at least the minimum of the multiplicities. -/
 lemma root_multiplicity_add {p q : polynomial R} (a : R) (hzero : p + q ≠ 0) :
   min (root_multiplicity a p) (root_multiplicity a q) ≤ root_multiplicity a (p + q) :=
 begin

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -196,7 +196,8 @@ begin
   simp only [root_multiplicity_mul hzero, root_multiplicity_X_sub_C_self, hn, nat.one_add]
 end
 
-/-- If `(X - a) ^ n` divides a polynomial `p` then the multipicity of `a` as root of `p` is at least `n`. --/
+/-- If `(X - a) ^ n` divides a polynomial `p` then the multiplicity of `a` as root of `p` is at
+least `n`. -/
 lemma multiplicity_of_dvd {p : polynomial R} {a : R} {n : ℕ}
   (hzero : p ≠ 0) (h : (X - C a) ^ n ∣ p) : n ≤ root_multiplicity a p :=
 begin


### PR DESCRIPTION
I've added the lemma `root_multiplicity_add` inside `data/polynomial/ring_division` that says that the multiplicity of a root in a sum of two polynomials is at least the minimum of the multiplicities.