### PR TITLE
[Merged by Bors] - lint(data/pnat): Docstrings and an unused argument in `pnat.basic`, `pnat.factors`

### DIFF
--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -222,14 +222,13 @@ theorem add_sub_of_lt {a b : ℕ+} : a < b → a + (b - a) = b :=
  λ h, eq $ by { rw [add_coe, sub_coe, if_pos h],
                 exact nat.add_sub_of_le (le_of_lt h) }
 
-/-- We define m % k and m / k in the same way as for nat
-  except that when m = n * k we take m % k = k and
-  m / k = n - 1.  This ensures that m % k is always positive
-  and m = (m % k) + k * (m / k) in all cases.  Later we
-  define a function div_exact which gives the usual m / k
-  in the case where k divides m.
+/-- We define `m % k` and `m / k` in the same way as for nat
+  except that when `m = n * k` we take `m % k = k` and
+  `m / k = n - 1`.  This ensures that `m % k` is always positive
+  and `m = (m % k) + k * (m / k)` in all cases.  Later we
+  define a function `div_exact` which gives the usual `m / k`
+  in the case where `k` divides `m`.
 -/
-
 def mod_div_aux : ℕ+ → ℕ → ℕ → ℕ+ × ℕ
 | k 0 q := ⟨k, q.pred⟩
 | k (r + 1) q := ⟨⟨r + 1, nat.succ_pos r⟩, q⟩
@@ -242,9 +241,25 @@ lemma mod_div_aux_spec : ∀ (k : ℕ+) (r q : ℕ) (h : ¬ (r = 0 ∧ q = 0)),
   rw [nat.pred_succ, nat.mul_succ, zero_add, add_comm]}
 | k (r + 1) q h := rfl
 
+/-- `mod_div m k = (m % k, m / k)`.
+  We define `m % k` and `m / k` in the same way as for nat
+  except that when `m = n * k` we take `m % k = k` and
+  `m / k = n - 1`.  This ensures that `m % k` is always positive
+  and `m = (m % k) + k * (m / k)` in all cases.  Later we
+  define a function `div_exact` which gives the usual `m / k`
+  in the case where `k` divides `m`.
+-/
 def mod_div (m k : ℕ+) : ℕ+ × ℕ := mod_div_aux k ((m : ℕ) % (k : ℕ)) ((m : ℕ) / (k : ℕ))
 
+/-- We define `m % k` in the same way as for nat
+  except that when `m = n * k` we take `m % k = k` This ensures that `m % k` is always positive.
+-/
 def mod (m k : ℕ+) : ℕ+ := (mod_div m k).1
+
+/-- We define `m / k` in the same way as for nat except that when `m = n * k` we take
+  `m / k = n - 1`. This ensures that `m = (m % k) + k * (m / k)` in all cases. Later we
+  define a function `div_exact` which gives the usual `m / k` in the case where `k` divides `m`.
+-/
 def div (m k : ℕ+) : ℕ  := (mod_div m k).2
 
 theorem mod_add_div (m k : ℕ+) : (m : ℕ) = (mod m k) + k * (div m k) :=
@@ -311,10 +326,11 @@ end
 lemma le_of_dvd {m n : ℕ+} : m ∣ n → m ≤ n :=
 by { rw dvd_iff', intro h, rw ← h, apply (mod_le n m).left }
 
-def div_exact {m k : ℕ+} (h : k ∣ m) : ℕ+ :=
+/-- If `h : k | m`, then `k * (div_exact m k) = m`. Note that this is not equal to `m / k`. -/
+def div_exact (m k : ℕ+) : ℕ+ :=
  ⟨(div m k).succ, nat.succ_pos _⟩
 
-theorem mul_div_exact {m k : ℕ+} (h : k ∣ m) : k * (div_exact h) = m :=
+theorem mul_div_exact {m k : ℕ+} (h : k ∣ m) : k * (div_exact m k) = m :=
 begin
  apply eq, rw [mul_coe],
  change (k : ℕ) * (div m k).succ = m,
@@ -327,9 +343,11 @@ theorem dvd_antisymm {m n : ℕ+} : m ∣ n → n ∣ m → m = n :=
 theorem dvd_one_iff (n : ℕ+) : n ∣ 1 ↔ n = 1 :=
  ⟨λ h, dvd_antisymm h (one_dvd n), λ h, h.symm ▸ (dvd_refl 1)⟩
 
+/-- If `(n m : ℕ+)`, then `nat.gcd n m` is also positive. -/
 def gcd (n m : ℕ+) : ℕ+ :=
  ⟨nat.gcd (n : ℕ) (m : ℕ), nat.gcd_pos_of_pos_left (m : ℕ) n.pos⟩
 
+/-- If `(n m : ℕ+)`, then `nat.lcm n m` is also positive. -/
 def lcm (n m : ℕ+) : ℕ+ :=
  ⟨nat.lcm (n : ℕ) (m : ℕ),
   by { let h := mul_pos n.pos m.pos,
@@ -367,6 +385,7 @@ end
 section prime
 /-! ### Prime numbers -/
 
+/-- Defined using `nat.prime`. -/
 def prime (p : ℕ+) : Prop := (p : ℕ).prime
 
 lemma prime.one_lt {p : ℕ+} : p.prime → 1 < p := nat.prime.one_lt

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -222,7 +222,7 @@ theorem add_sub_of_lt {a b : ℕ+} : a < b → a + (b - a) = b :=
  λ h, eq $ by { rw [add_coe, sub_coe, if_pos h],
                 exact nat.add_sub_of_le (le_of_lt h) }
 
-/-- We define `m % k` and `m / k` in the same way as for nat
+/-- We define `m % k` and `m / k` in the same way as for `ℕ`
   except that when `m = n * k` we take `m % k = k` and
   `m / k = n - 1`.  This ensures that `m % k` is always positive
   and `m = (m % k) + k * (m / k)` in all cases.  Later we
@@ -242,7 +242,7 @@ lemma mod_div_aux_spec : ∀ (k : ℕ+) (r q : ℕ) (h : ¬ (r = 0 ∧ q = 0)),
 | k (r + 1) q h := rfl
 
 /-- `mod_div m k = (m % k, m / k)`.
-  We define `m % k` and `m / k` in the same way as for nat
+  We define `m % k` and `m / k` in the same way as for `ℕ`
   except that when `m = n * k` we take `m % k = k` and
   `m / k = n - 1`.  This ensures that `m % k` is always positive
   and `m = (m % k) + k * (m / k)` in all cases.  Later we
@@ -251,12 +251,12 @@ lemma mod_div_aux_spec : ∀ (k : ℕ+) (r q : ℕ) (h : ¬ (r = 0 ∧ q = 0)),
 -/
 def mod_div (m k : ℕ+) : ℕ+ × ℕ := mod_div_aux k ((m : ℕ) % (k : ℕ)) ((m : ℕ) / (k : ℕ))
 
-/-- We define `m % k` in the same way as for nat
+/-- We define `m % k` in the same way as for `ℕ`
   except that when `m = n * k` we take `m % k = k` This ensures that `m % k` is always positive.
 -/
 def mod (m k : ℕ+) : ℕ+ := (mod_div m k).1
 
-/-- We define `m / k` in the same way as for nat except that when `m = n * k` we take
+/-- We define `m / k` in the same way as for `ℕ` except that when `m = n * k` we take
   `m / k = n - 1`. This ensures that `m = (m % k) + k * (m / k)` in all cases. Later we
   define a function `div_exact` which gives the usual `m / k` in the case where `k` divides `m`.
 -/
@@ -385,7 +385,7 @@ end
 section prime
 /-! ### Prime numbers -/
 
-/-- Defined using `nat.prime`. -/
+/-- Primality predicate for `ℕ+`, defined in terms of `nat.prime`. -/
 def prime (p : ℕ+) : Prop := (p : ℕ).prime
 
 lemma prime.one_lt {p : ℕ+} : p.prime → 1 < p := nat.prime.one_lt

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -343,11 +343,13 @@ theorem dvd_antisymm {m n : ℕ+} : m ∣ n → n ∣ m → m = n :=
 theorem dvd_one_iff (n : ℕ+) : n ∣ 1 ↔ n = 1 :=
  ⟨λ h, dvd_antisymm h (one_dvd n), λ h, h.symm ▸ (dvd_refl 1)⟩
 
-/-- If `(n m : ℕ+)`, then `nat.gcd n m` is also positive. -/
+/-- The greatest common divisor (gcd) of two positive natural numbers,
+  viewed as positive natural number. -/
 def gcd (n m : ℕ+) : ℕ+ :=
  ⟨nat.gcd (n : ℕ) (m : ℕ), nat.gcd_pos_of_pos_left (m : ℕ) n.pos⟩
 
-/-- If `(n m : ℕ+)`, then `nat.lcm n m` is also positive. -/
+/-- The least common multiple (lcm) of two positive natural numbers,
+  viewed as positive natural number. -/
 def lcm (n m : ℕ+) : ℕ+ :=
  ⟨nat.lcm (n : ℕ) (m : ℕ),
   by { let h := mul_pos n.pos m.pos,

--- a/src/data/pnat/factors.lean
+++ b/src/data/pnat/factors.lean
@@ -70,6 +70,7 @@ theorem coe_nat_prime (v : prime_multiset)
 by { rcases multiset.mem_map.mp h with ⟨⟨p', hp'⟩, ⟨h_mem, h_eq⟩⟩,
      exact h_eq ▸ hp' }
 
+/-- Converts a `prime_multiset` to a `multiset ℕ+`. -/
 def to_pnat_multiset : prime_multiset → multiset ℕ+ :=
 λ v, v.map (λ p, (p : ℕ+))
 
@@ -97,6 +98,7 @@ theorem coe_pnat_nat (v : prime_multiset) :
 by { change (v.map (coe : nat.primes → ℕ+)).map subtype.val = v.map subtype.val,
      rw [multiset.map_map], congr }
 
+/-- The product of a `prime_multiset`, as a `ℕ+`. -/
 def prod (v : prime_multiset) : ℕ+ := (v : multiset pnat).prod
 
 theorem coe_prod (v : prime_multiset) : (v.prod : ℕ) = (v : multiset ℕ).prod :=
@@ -112,6 +114,7 @@ theorem prod_of_prime (p : nat.primes) : (of_prime p).prod = (p : ℕ+) :=
 by { change multiset.prod ((p : ℕ+) :: 0) = (p : ℕ+),
      rw [multiset.prod_cons, multiset.prod_zero, mul_one] }
 
+/-- If a `multiset ℕ` consists only of primes, it can be recast as a `prime_multiset`. -/
 def of_nat_multiset
   (v : multiset ℕ) (h : ∀ (p : ℕ), p ∈ v → p.prime) : prime_multiset :=
 @multiset.pmap ℕ nat.primes nat.prime (λ p hp, ⟨p, hp⟩) v h
@@ -130,6 +133,7 @@ theorem prod_of_nat_multiset (v : multiset ℕ) (h) :
   ((of_nat_multiset v h).prod : ℕ) = (v.prod : ℕ) :=
 by rw[coe_prod, to_of_nat_multiset]
 
+/-- If a `multiset ℕ+` consists only of primes, it can be recast as a `prime_multiset`. -/
 def of_pnat_multiset
   (v : multiset ℕ+) (h : ∀ (p : ℕ+), p ∈ v → p.prime) : prime_multiset :=
 @multiset.pmap ℕ+ nat.primes pnat.prime (λ p hp, ⟨(p : ℕ), hp⟩) v h
@@ -157,6 +161,8 @@ theorem prod_of_nat_list (l : list ℕ) (h) : ((of_nat_list l h).prod : ℕ) = l
 by { have := prod_of_nat_multiset (l : multiset ℕ) h,
      rw [multiset.coe_prod] at this, exact this }
 
+/-- If a `list ℕ+` consists only of primes, it can be recast as a `prime_multiset` with
+  the coercion from lists to multisets. -/
 def of_pnat_list (l : list ℕ+) (h : ∀ (p : ℕ+), p ∈ l → p.prime) : prime_multiset :=
 of_pnat_multiset (l : multiset ℕ+) h
 


### PR DESCRIPTION
Adds docstrings
Changes `div_exact` from having one unused input of type `k | m` to `div_exact m k`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
