### PR TITLE
[Merged by Bors] - feat(*): make `int.le` irreducible

### DIFF
--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -81,9 +81,12 @@ lemma one_lt_pow {K} [linear_ordered_semiring K] {p : K} (hp : 1 < p) : ∀ {n :
     { apply le_of_lt (lt_trans zero_lt_one hp) }
   end
 
+section
+local attribute [semireducible] int.lt
 lemma one_lt_fpow {K}  [discrete_linear_ordered_field K] {p : K} (hp : 1 < p) :
   ∀ z : ℤ, 0 < z → 1 < p ^ z
 | (int.of_nat n) h := one_lt_pow hp (nat.succ_le_of_lt (int.lt_of_coe_nat_lt_coe_nat h))
+end
 
 section ordered
 variables  {K : Type*} [discrete_linear_ordered_field K]

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -466,7 +466,7 @@ instance : normalization_monoid ℤ :=
   end,
   norm_unit_coe_units := assume u, (units_eq_one_or u).elim
     (assume eq, eq.symm ▸ if_pos zero_le_one)
-    (assume eq, eq.symm ▸ if_neg (not_le_of_gt $ show (-1:ℤ) < 0, by simp [@neg_lt ℤ _ 1 0])), }
+    (assume eq, eq.symm ▸ if_neg (not_le_of_gt $ show (-1:ℤ) < 0, by dec_trivial)), }
 
 lemma normalize_of_nonneg {z : ℤ} (h : 0 ≤ z) : normalize z = z :=
 show z * ↑(ite _ _ _) = z, by rw [if_pos h, units.coe_one, mul_one]

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1203,3 +1203,5 @@ let ⟨lb, Plb, al⟩ := exists_least_of_bdd Hbdd' Hinh' in
 end classical
 
 end int
+
+attribute [irreducible] int.lt

--- a/src/data/int/range.lean
+++ b/src/data/int/range.lean
@@ -32,6 +32,8 @@ instance decidable_le_le (P : int → Prop) [decidable_pred P] (m n : ℤ) :
   decidable (∀ r, m ≤ r → r ≤ n → P r) :=
 decidable_of_iff (∀ r ∈ range m (n+1), P r) $ by simp only [mem_range_iff, and_imp, lt_add_one_iff]
 
+local attribute [semireducible] int.lt
+
 instance decidable_lt_lt (P : int → Prop) [decidable_pred P] (m n : ℤ) :
   decidable (∀ r, m < r → r < n → P r) :=
 int.decidable_le_lt P _ _

--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -178,7 +178,7 @@ lemma norm_le_norm_mul_left (x : ℤ[i]) {y : ℤ[i]} (hy : y ≠ 0) :
   (norm x).nat_abs ≤ (norm (x * y)).nat_abs :=
 by rw [norm_mul, int.nat_abs_mul];
   exact le_mul_of_one_le_right (nat.zero_le _)
-    (int.coe_nat_le.1 (by rw [coe_nat_abs_norm]; exact norm_pos.2 hy))
+    (int.coe_nat_le.1 (by rw [coe_nat_abs_norm]; exact int.add_one_le_of_lt (norm_pos.2 hy)))
 
 instance : nontrivial ℤ[i] :=
 ⟨⟨0, 1, dec_trivial⟩⟩

--- a/src/number_theory/pythagorean_triples.lean
+++ b/src/number_theory/pythagorean_triples.lean
@@ -189,7 +189,7 @@ end
 
 lemma ne_zero_of_coprime (hc : int.gcd x y = 1) : z ≠ 0 :=
 begin
-  suffices : 0 < z * z, { rintro rfl, simpa only [] },
+  suffices : 0 < z * z, { rintro rfl, norm_num at this },
   rw [← h.eq, ← pow_two, ← pow_two],
   have hc' : int.gcd x y ≠ 0, { rw hc, exact one_ne_zero },
   cases int.ne_zero_of_gcd hc' with hxz hyz,

--- a/src/tactic/linarith/preprocessing.lean
+++ b/src/tactic/linarith/preprocessing.lean
@@ -98,10 +98,10 @@ and similarly if `pf` proves a negated weak inequality.
 meta def mk_non_strict_int_pf_of_strict_int_pf (pf : expr) : tactic expr :=
 do tp ← infer_type pf,
 match tp with
-| `(%%a < %%b) := to_expr ``(id_rhs (%%a + 1 ≤ %%b) %%pf)
-| `(%%a > %%b) := to_expr ``(id_rhs (%%b + 1 ≤ %%a) %%pf)
-| `(¬ %%a ≤ %%b) := to_expr ``(id_rhs (%%b + 1 ≤ %%a) %%pf)
-| `(¬ %%a ≥ %%b) := to_expr ``(id_rhs (%%a + 1 ≤ %%b) %%pf)
+| `(%%a < %%b) := to_expr ``(int.add_one_le_iff.mpr %%pf)
+| `(%%a > %%b) := to_expr ``(int.add_one_le_iff.mpr %%pf)
+| `(¬ %%a ≤ %%b) := to_expr ``(int.add_one_le_iff.mpr (le_of_not_gt %%pf))
+| `(¬ %%a ≥ %%b) := to_expr ``(int.add_one_le_iff.mpr (le_of_not_gt %%pf))
 | _ := fail "mk_non_strict_int_pf_of_strict_int_pf failed: proof is not an inequality"
 end
 

--- a/src/tactic/omega/eq_elim.lean
+++ b/src/tactic/omega/eq_elim.lean
@@ -20,6 +20,7 @@ if (2 * (i % j)) < j
 then i % j
 else (i % j) - j
 
+local attribute [semireducible] int.lt
 lemma symmod_add_one_self {i : int} :
   0 < i → symmod i (i+1) = -1 :=
 begin


### PR DESCRIPTION
There's very rarely a reason to unfold `int.le` and it can create trouble: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/deep.20recursion.20was.20detected.20at.20'replace'

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
