### PR TITLE
[Merged by Bors] - chore(*): fix authorship for split files

### DIFF
--- a/src/data/finset/order.lean
+++ b/src/data/finset/order.lean
@@ -1,10 +1,14 @@
 /-
-Copyright (c) 2020 Scott Morrison. All rights reserved.
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott Morrison
+Authors: Mario Carneiro, Kenny Lau
 -/
 
 import data.finset.basic
+
+/-!
+# Finsets of ordered types
+-/
 
 universes u v w
 variables {α : Type u}

--- a/src/data/setoid/partition.lean
+++ b/src/data/setoid/partition.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2020 Yury G. Kudryashov. All rights reserved.
+Copyright (c) 2019 Amelia Livingston. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yury G. Kudryashov
+Authors: Amelia Livingston, Bryan Gin-ge Chen
 -/
 
 import data.setoid.basic

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -1,7 +1,8 @@
 /-
-Copyright (c) 2020 Yury G. Kudryashov. All rights reserved.
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yury G. Kudryashov
+Authors: Johannes Hölzl, Kenny Lau, Johan Commelin, Mario Carneiro, Kevin Buzzard,
+Amelia Livingston, Yury Kudryashov
 -/
 
 import group_theory.submonoid.basic


### PR DESCRIPTION
A few files with missing copyright headers in #4477 came from splitting up older files, so the attribution was incorrect:
- `data/setoid/partition.lean` was split from `data/setoid.lean` in #2853.
- `data/finset/order.lean` was split from `algebra/big_operators.lean` in #3495.
- `group_theory/submonoid/operations.lean` was split from `group_theory/submonoid.lean` in  #3058.
