### PR TITLE
[Merged by Bors] - lint(order/order_iso_nat): docstrings

### DIFF
--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -11,6 +11,7 @@ namespace rel_embedding
 
 variables {α : Type*} {r : α → α → Prop}
 
+/-- If `f` is a strictly `r`-increasing sequence, then this returns `f` as an order embedding. -/
 def nat_lt [is_strict_order α r] (f : ℕ → α) (H : ∀ n:ℕ, r (f n) (f (n+1))) :
   ((<) : ℕ → ℕ → Prop) ↪r r :=
 of_monotone f $ λ a b h, begin
@@ -20,6 +21,7 @@ of_monotone f $ λ a b h, begin
   { subst b, apply H }
 end
 
+/-- If `f` is a strictly `r`-decreasing sequence, then this returns `f` as an order embedding. -/
 def nat_gt [is_strict_order α r] (f : ℕ → α) (H : ∀ n:ℕ, r (f (n+1)) (f n)) :
   ((>) : ℕ → ℕ → Prop) ↪r r :=
 by haveI := is_strict_order.swap r; exact rel_embedding.swap (nat_lt f H)


### PR DESCRIPTION
Adds docstrings to `rel_embedding.nat_lt` and `rel_embedding.nat_gt`

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
