### PR TITLE
[Merged by Bors] - lint(group_theory/*): docstrings and an inhabited instance

### DIFF
--- a/src/group_theory/abelianization.lean
+++ b/src/group_theory/abelianization.lean
@@ -63,6 +63,8 @@ begin
   simp [monoid_hom.mem_ker, mul_right_comm (f p) (f q)],
 end
 
+/-- If `f : G → A` is a group homomorphism to an abelian group, then `lift f` is the unique map from
+  the abelianization of a `G` to `A` that factors through `f`. -/
 def lift : abelianization G →* A :=
 quotient_group.lift _ f (λ x h, f.mem_ker.2 $ commutator_subset_ker _ h)
 

--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -847,4 +847,3 @@ def quotient_quotient_equiv_quotient (c d : con M) (h : c ≤ d) :
   ..quotient_quotient_equiv_quotient c.to_setoid d.to_setoid h }
 
 end con
-#lint

--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -65,10 +65,10 @@ structure add_con [has_add M] extends setoid M :=
 @[to_additive add_con] structure con [has_mul M] extends setoid M :=
 (mul' : ∀ {w x y z}, r w x → r y z → r (w * y) (x * z))
 
-/-- An additive congruence relation as an equivalence relation. -/
+/-- The equivalence relation underlying an additive congruence relation. -/
 add_decl_doc add_con.to_setoid
 
-/-- A congruence relation as an equivalence relation. -/
+/-- The equivalence relation underlying a multiplicative congruence relation. -/
 add_decl_doc con.to_setoid
 
 variables {M}

--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -65,6 +65,12 @@ structure add_con [has_add M] extends setoid M :=
 @[to_additive add_con] structure con [has_mul M] extends setoid M :=
 (mul' : ∀ {w x y z}, r w x → r y z → r (w * y) (x * z))
 
+/-- An additive congruence relation as an equivalence relation. -/
+add_decl_doc add_con.to_setoid
+
+/-- A congruence relation as an equivalence relation. -/
+add_decl_doc con.to_setoid
+
 variables {M}
 
 /-- The inductively defined smallest additive congruence relation containing a given binary
@@ -841,3 +847,4 @@ def quotient_quotient_equiv_quotient (c d : con M) (h : c ≤ d) :
   ..quotient_quotient_equiv_quotient c.to_setoid d.to_setoid h }
 
 end con
+#lint

--- a/src/group_theory/presented_group.lean
+++ b/src/group_theory/presented_group.lean
@@ -58,4 +58,7 @@ theorem to_group.unique (g : presented_group rels →* β)
     (λ _, free_group.to_group.unique (g.comp (quotient_group.mk' _)) hg)
 
 end to_group
+
+instance (rels : set (free_group α)) : inhabited (presented_group rels) := ⟨1⟩
+
 end presented_group


### PR DESCRIPTION
An inhabited instance for `presented_group`
Docstrings in `group_theory/abelianization` and `group_theory/congruence`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
