### PR TITLE
[Merged by Bors] - feat(data/list/*): add left- and right-biased versions of map₂ and zip

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4031,46 +4031,210 @@ lemma choose_property (hp : ∃ a, a ∈ l ∧ p a) : p (choose p l hp) := (choo
 
 end choose
 
-/-! ### map₂_left' and derived functions -/
+/-! ### map₂_left' -/
 
-section biased_map₂
+section map₂_left'
 
-theorem map₂_left_eq_map₂_left' (f : α → option β → γ) :
-  ∀ as bs, map₂_left f as bs = (map₂_left' f as bs).fst
+@[simp] theorem map₂_left'_nil_right (f : α → option β → γ) (as) :
+  map₂_left' f as [] = (as.map (λ a, f a none), []) :=
+by cases as; refl
+
+end map₂_left'
+
+/-! ### map₂_right' -/
+
+section map₂_right'
+
+variables (f : option α → β → γ) (a : α) (as : list α) (b : β) (bs : list β)
+
+@[simp] theorem map₂_right'_nil_right  :
+  map₂_right' f as [] = ([], as) :=
+rfl
+
+@[simp] theorem map₂_right'_nil_cons :
+  map₂_right' f [] (b :: bs) = (f none b :: bs.map (f none), []) :=
+rfl
+
+@[simp] theorem map₂_right'_cons_cons :
+  map₂_right' f (a :: as) (b :: bs) =
+    let rec := map₂_right' f as bs in
+    (f (some a) b :: rec.fst, rec.snd) :=
+rfl
+
+@[simp] theorem map₂_right'_nil_left :
+  map₂_right' f [] bs = (bs.map (f none), []) :=
+by cases bs; refl
+
+end map₂_right'
+
+/-! ### zip_left' -/
+
+section zip_left'
+
+variables (a : α) (as : list α) (b : β) (bs : list β)
+
+@[simp] theorem zip_left'_nil_left :
+  zip_left' ([] : list α) bs = ([], bs) :=
+rfl
+
+@[simp] theorem zip_left'_cons_nil :
+  zip_left' (a :: as) ([] : list β) = ((a, none) :: as.map (λ a, (a, none)), []) :=
+rfl
+
+@[simp] theorem zip_left'_cons_cons :
+  zip_left' (a :: as) (b :: bs) =
+    let rec := zip_left' as bs in
+    ((a, some b) :: rec.fst, rec.snd) :=
+rfl
+
+@[simp] theorem zip_left'_nil_right :
+  zip_left' as ([] : list β) = (as.map (λ a, (a, none)), []) :=
+by cases as; refl
+
+end zip_left'
+
+/-! ### zip_right' -/
+
+section zip_right'
+
+variables (a : α) (as : list α) (b : β) (bs : list β)
+
+@[simp] theorem zip_right'_nil_right :
+  zip_right' as ([] : list β) = ([], as) :=
+rfl
+
+@[simp] theorem zip_right'_nil_cons :
+  zip_right' ([] : list α) (b :: bs) = ((none, b) :: bs.map (λ b, (none, b)), []) :=
+rfl
+
+@[simp] theorem zip_right'_cons_cons :
+  zip_right' (a :: as) (b :: bs) =
+    let rec := zip_right' as bs in
+    ((some a, b) :: rec.fst, rec.snd) :=
+rfl
+
+@[simp] theorem zip_right'_nil_left :
+  zip_right' ([] : list α) bs = (bs.map (λ b, (none, b)), []) :=
+by cases bs; refl
+
+end zip_right'
+
+/-! ### map₂_left -/
+
+section map₂_left
+
+variables (f : α → option β → γ) (as : list α)
+
+@[simp] theorem map₂_left_nil_right :
+  map₂_left f as [] = as.map (λ a, f a none) :=
+by cases as; refl
+
+theorem map₂_left_eq_map₂_left' : ∀ as bs,
+  map₂_left f as bs = (map₂_left' f as bs).fst
 | [] bs := by simp!
-| (a :: as) [] := by { simp! only [*], cases (map₂_left' f as nil), simp!  }
-| (a :: as) (b :: bs) := by { simp! only [*], cases (map₂_left' f as bs), simp! }
+| (a :: as) [] := by simp!
+| (a :: as) (b :: bs) := by simp! [*]
 
-theorem map₂_right_eq_map₂_right' (f : option α → β → γ) (as bs) :
+theorem map₂_left_eq_map₂ : ∀ as bs,
+  length as ≤ length bs →
+  map₂_left f as bs = map₂ (λ a b, f a (some b)) as bs
+| [] [] h := by simp!
+| [] (b :: bs) h := by simp!
+| (a :: as) [] h := by { simp at h, contradiction }
+| (a :: as) (b :: bs) h := by { simp at h, simp! [*] }
+
+end map₂_left
+
+/-! ### map₂_right -/
+
+section map₂_right
+
+variables (f : option α → β → γ) (a : α) (as : list α) (b : β) (bs : list β)
+
+@[simp] theorem map₂_right_nil_right :
+  map₂_right f as [] = [] :=
+rfl
+
+@[simp] theorem map₂_right_nil_cons :
+  map₂_right f [] (b :: bs) = f none b :: bs.map (f none) :=
+rfl
+
+@[simp] theorem map₂_right_cons_cons :
+  map₂_right f (a :: as) (b :: bs) = f (some a) b :: map₂_right f as bs :=
+rfl
+
+@[simp] theorem map₂_right_nil_left :
+  map₂_right f [] bs = bs.map (f none) :=
+by cases bs; refl
+
+theorem map₂_right_eq_map₂_right' :
   map₂_right f as bs = (map₂_right' f as bs).fst :=
 by simp only [map₂_right, map₂_right', map₂_left_eq_map₂_left']
 
-theorem zip_left_eq_zip_left' (as : list α) (bs : list β) :
-  zip_left as bs = (zip_left' as bs).fst :=
-by simp only [zip_left, zip_left', map₂_left_eq_map₂_left']
-
-theorem zip_right_eq_zip_right' (as : list α) (bs : list β) :
-  zip_right as bs = (zip_right' as bs).fst :=
-by simp only [zip_right, zip_right', map₂_right_eq_map₂_right']
-
-theorem map₂_left_eq_map₂ (f : α → option β → γ) :
-  ∀ as bs,
-    length as ≤ length bs →
-    map₂_left f as bs = map₂ (λ a b, f a (some b)) as bs
-| [] [] h := by simp!
-| [] (b :: bs) h := by simp!
-| (a :: as) [] h := by { simp at h, contradiction  }
-| (a :: as) (b :: bs) h := by { simp at h, simp! [*] }
-
-theorem map₂_right_eq_map₂ (f : option α → β → γ) (as bs)
-  (h : length bs ≤ length as) :
+theorem map₂_right_eq_map₂ (h : length bs ≤ length as) :
   map₂_right f as bs = map₂ (λ a b, f (some a) b) as bs :=
 begin
-  have eq : (λ a b, flip f a (some b)) = (flip (λ a b, f (some a) b)) := rfl,
+  have : (λ a b, flip f a (some b)) = (flip (λ a b, f (some a) b)) := rfl,
   simp only [map₂_right, map₂_left_eq_map₂, map₂_flip, *]
 end
 
-end biased_map₂
+end map₂_right
+
+/-! ### zip_left -/
+
+section zip_left
+
+variables (a : α) (as : list α) (b : β) (bs : list β)
+
+@[simp] theorem zip_left_nil_left :
+  zip_left ([] : list α) bs = [] :=
+rfl
+
+@[simp] theorem zip_left_cons_nil :
+  zip_left (a :: as) ([] : list β) = (a, none) :: as.map (λ a, (a, none)) :=
+rfl
+
+@[simp] theorem zip_left_cons_cons :
+  zip_left (a :: as) (b :: bs) = (a, some b) :: zip_left as bs :=
+rfl
+
+@[simp] theorem zip_left_nil_right :
+  zip_left as ([] : list β) = as.map (λ a, (a, none)) :=
+by cases as; refl
+
+theorem zip_left_eq_zip_left' :
+  zip_left as bs = (zip_left' as bs).fst :=
+by simp only [zip_left, zip_left', map₂_left_eq_map₂_left']
+
+end zip_left
+
+/-! ### zip_right -/
+
+section zip_right
+
+variables (a : α) (as : list α) (b : β) (bs : list β)
+
+@[simp] theorem zip_right_nil_right :
+  zip_right as ([] : list β) = [] :=
+rfl
+
+@[simp] theorem zip_right_nil_cons :
+  zip_right ([] : list α) (b :: bs) = (none, b) :: bs.map (λ b, (none, b)) :=
+rfl
+
+@[simp] theorem zip_right_cons_cons :
+  zip_right (a :: as) (b :: bs) = (some a, b) :: zip_right as bs :=
+rfl
+
+@[simp] theorem zip_right_nil_left :
+  zip_right ([] : list α) bs = bs.map (λ b, (none, b)) :=
+by cases bs; refl
+
+theorem zip_right_eq_zip_right' :
+  zip_right as bs = (zip_right' as bs).fst :=
+by simp only [zip_right, zip_right', map₂_right_eq_map₂_right']
+
+end zip_right
 
 /-! ### Miscellaneous lemmas -/
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4035,6 +4035,7 @@ end choose
 
 section map₂_left'
 
+-- The equalities for the other cases have been made available by marking `map₂_left'` as `@[simp]`.
 @[simp] theorem map₂_left'_nil_right (f : α → option β → γ) (as) :
   map₂_left' f as [] = (as.map (λ a, f a none), []) :=
 by cases as; refl
@@ -4125,6 +4126,7 @@ section map₂_left
 
 variables (f : α → option β → γ) (as : list α)
 
+-- The equalities for the other cases have been made available by marking `map₂_left'` as `@[simp]`.
 @[simp] theorem map₂_left_nil_right :
   map₂_left f as [] = as.map (λ a, f a none) :=
 by cases as; refl

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4035,7 +4035,9 @@ end choose
 
 section map₂_left'
 
--- The equalities for the other cases have been made available by marking `map₂_left'` as `@[simp]`.
+-- The definitional equalities for `map₂_left'` can already be used by the
+-- simplifie because `map₂_left'` is marked `@[simp]`.
+
 @[simp] theorem map₂_left'_nil_right (f : α → option β → γ) (as) :
   map₂_left' f as [] = (as.map (λ a, f a none), []) :=
 by cases as; refl
@@ -4047,6 +4049,10 @@ end map₂_left'
 section map₂_right'
 
 variables (f : option α → β → γ) (a : α) (as : list α) (b : β) (bs : list β)
+
+@[simp] theorem map₂_right'_nil_left :
+  map₂_right' f [] bs = (bs.map (f none), []) :=
+by cases bs; refl
 
 @[simp] theorem map₂_right'_nil_right  :
   map₂_right' f as [] = ([], as) :=
@@ -4062,10 +4068,6 @@ rfl
     (f (some a) b :: rec.fst, rec.snd) :=
 rfl
 
-@[simp] theorem map₂_right'_nil_left :
-  map₂_right' f [] bs = (bs.map (f none), []) :=
-by cases bs; refl
-
 end map₂_right'
 
 /-! ### zip_left' -/
@@ -4073,6 +4075,10 @@ end map₂_right'
 section zip_left'
 
 variables (a : α) (as : list α) (b : β) (bs : list β)
+
+@[simp] theorem zip_left'_nil_right :
+  zip_left' as ([] : list β) = (as.map (λ a, (a, none)), []) :=
+by cases as; refl
 
 @[simp] theorem zip_left'_nil_left :
   zip_left' ([] : list α) bs = ([], bs) :=
@@ -4088,10 +4094,6 @@ rfl
     ((a, some b) :: rec.fst, rec.snd) :=
 rfl
 
-@[simp] theorem zip_left'_nil_right :
-  zip_left' as ([] : list β) = (as.map (λ a, (a, none)), []) :=
-by cases as; refl
-
 end zip_left'
 
 /-! ### zip_right' -/
@@ -4099,6 +4101,10 @@ end zip_left'
 section zip_right'
 
 variables (a : α) (as : list α) (b : β) (bs : list β)
+
+@[simp] theorem zip_right'_nil_left :
+  zip_right' ([] : list α) bs = (bs.map (λ b, (none, b)), []) :=
+by cases bs; refl
 
 @[simp] theorem zip_right'_nil_right :
   zip_right' as ([] : list β) = ([], as) :=
@@ -4114,10 +4120,6 @@ rfl
     ((some a, b) :: rec.fst, rec.snd) :=
 rfl
 
-@[simp] theorem zip_right'_nil_left :
-  zip_right' ([] : list α) bs = (bs.map (λ b, (none, b)), []) :=
-by cases bs; refl
-
 end zip_right'
 
 /-! ### map₂_left -/
@@ -4126,7 +4128,9 @@ section map₂_left
 
 variables (f : α → option β → γ) (as : list α)
 
--- The equalities for the other cases have been made available by marking `map₂_left'` as `@[simp]`.
+-- The definitional equalities for `map₂_left` can already be used by the
+-- simplifier because `map₂_left` is marked `@[simp]`.
+
 @[simp] theorem map₂_left_nil_right :
   map₂_left f as [] = as.map (λ a, f a none) :=
 by cases as; refl
@@ -4153,6 +4157,10 @@ section map₂_right
 
 variables (f : option α → β → γ) (a : α) (as : list α) (b : β) (bs : list β)
 
+@[simp] theorem map₂_right_nil_left :
+  map₂_right f [] bs = bs.map (f none) :=
+by cases bs; refl
+
 @[simp] theorem map₂_right_nil_right :
   map₂_right f as [] = [] :=
 rfl
@@ -4164,10 +4172,6 @@ rfl
 @[simp] theorem map₂_right_cons_cons :
   map₂_right f (a :: as) (b :: bs) = f (some a) b :: map₂_right f as bs :=
 rfl
-
-@[simp] theorem map₂_right_nil_left :
-  map₂_right f [] bs = bs.map (f none) :=
-by cases bs; refl
 
 theorem map₂_right_eq_map₂_right' :
   map₂_right f as bs = (map₂_right' f as bs).fst :=
@@ -4188,6 +4192,10 @@ section zip_left
 
 variables (a : α) (as : list α) (b : β) (bs : list β)
 
+@[simp] theorem zip_left_nil_right :
+  zip_left as ([] : list β) = as.map (λ a, (a, none)) :=
+by cases as; refl
+
 @[simp] theorem zip_left_nil_left :
   zip_left ([] : list α) bs = [] :=
 rfl
@@ -4199,10 +4207,6 @@ rfl
 @[simp] theorem zip_left_cons_cons :
   zip_left (a :: as) (b :: bs) = (a, some b) :: zip_left as bs :=
 rfl
-
-@[simp] theorem zip_left_nil_right :
-  zip_left as ([] : list β) = as.map (λ a, (a, none)) :=
-by cases as; refl
 
 theorem zip_left_eq_zip_left' :
   zip_left as bs = (zip_left' as bs).fst :=
@@ -4216,6 +4220,10 @@ section zip_right
 
 variables (a : α) (as : list α) (b : β) (bs : list β)
 
+@[simp] theorem zip_right_nil_left :
+  zip_right ([] : list α) bs = bs.map (λ b, (none, b)) :=
+by cases bs; refl
+
 @[simp] theorem zip_right_nil_right :
   zip_right as ([] : list β) = [] :=
 rfl
@@ -4227,10 +4235,6 @@ rfl
 @[simp] theorem zip_right_cons_cons :
   zip_right (a :: as) (b :: bs) = (some a, b) :: zip_right as bs :=
 rfl
-
-@[simp] theorem zip_right_nil_left :
-  zip_right ([] : list α) bs = bs.map (λ b, (none, b)) :=
-by cases bs; refl
 
 theorem zip_right_eq_zip_right' :
   zip_right as bs = (zip_right' as bs).fst :=

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -708,4 +708,140 @@ def slice {α} : ℕ → ℕ → list α → list α
 | (succ n) m [] := []
 | (succ n) m (x :: xs) := x :: slice n m xs
 
+/--
+Left-biased version of `list.map₂`. `map₂_left' f as bs` applies `f` to each
+pair of elements `aᵢ ∈ as` and `bᵢ ∈ bs`. If `bs` is shorter than `as`, `f` is
+applied to `none` for the remaining `aᵢ`. Returns the results of the `f`
+applications and the remaining `bs`.
+
+```
+map₂_left' prod.mk [1, 2] ['a'] = ([(1, some 'a'), (2, none)], [])
+
+map₂_left' prod.mk [1] ['a', 'b'] = ([(1, some 'a')], ['b'])
+```
+-/
+def map₂_left' (f : α → option β → γ) : list α → list β → (list γ × list β)
+| [] bs := ([], bs)
+| (a :: as) [] :=
+  let ⟨cs, rest⟩ := map₂_left' as [] in
+  (f a none :: cs, rest)
+| (a :: as) (b :: bs) :=
+  let ⟨cs, rest⟩ := map₂_left' as bs in
+  (f a (some b) :: cs, rest)
+
+/--
+Right-biased version of `list.map₂`. `map₂_right' f as bs` applies `f` to each
+pair of elements `aᵢ ∈ as` and `bᵢ ∈ bs`. If `as` is shorter than `bs`, `f` is
+applied to `none` for the remaining `bᵢ`. Returns the results of the `f`
+applications and the remaining `as`.
+
+```
+map₂_right' prod.mk [1] ['a', 'b'] = ([(some 1, 'a'), (none, 'b')], [])
+
+map₂_right' prod.mk [1, 2] ['a'] = ([(some 1, 'a')], [2])
+```
+-/
+def map₂_right' (f : option α → β → γ) (as : list α) (bs : list β) : (list γ × list α) :=
+map₂_left' (flip f) bs as
+
+/--
+Left-biased version of `list.zip`. `zip_left' as bs` returns the list of
+pairs `(aᵢ, bᵢ)` for `aᵢ ∈ as` and `bᵢ ∈ bs`. If `bs` is shorter than `as`, the
+remaining `aᵢ` are paired with `none`. Also returns the remaining `bs`.
+
+```
+zip_left' [1, 2] ['a'] = ([(1, some 'a'), (2, none)], [])
+
+zip_left' [1] ['a', 'b'] = ([(1, some 'a')], ['b'])
+
+zip_left' = map₂_left' prod.mk
+
+```
+-/
+def zip_left' : list α → list β → list (α × option β) × list β :=
+map₂_left' prod.mk
+
+/--
+Right-biased version of `list.zip`. `zip_right' as bs` returns the list of
+pairs `(aᵢ, bᵢ)` for `aᵢ ∈ as` and `bᵢ ∈ bs`. If `as` is shorter than `bs`, the
+remaining `bᵢ` are paired with `none`. Also returns the remaining `as`.
+
+```
+zip_right' [1] ['a', 'b'] = ([(some 1, 'a'), (none, 'b')], [])
+
+zip_right' [1, 2] ['a'] = ([(some 1, 'a')], [2])
+
+zip_right' = map₂_right' prod.mk
+```
+-/
+def zip_right' : list α → list β → list (option α × β) × list α :=
+map₂_right' prod.mk
+
+/--
+Left-biased version of `list.map₂`. `map₂_left f as bs` applies `f` to each pair
+`aᵢ ∈ as` and `bᵢ ‌∈ bs`. If `bs` is shorter than `as`, `f` is applied to `none`
+for the remaining `aᵢ`.
+
+```
+map₂_left prod.mk [1, 2] ['a'] = [(1, some 'a'), (2, none)]
+
+map₂_left prod.mk [1] ['a', 'b'] = [(1, some 'a')]
+
+map₂_left f as bs = (map₂_left' f as bs).fst
+```
+-/
+def map₂_left (f : α → option β → γ) : list α → list β → list γ
+| [] _ := []
+| (a :: as) [] := f a none :: map₂_left as []
+| (a :: as) (b :: bs) := f a (some b) :: map₂_left as bs
+
+/--
+Right-biased version of `list.map₂`. `map₂_right f as bs` applies `f` to each
+pair `aᵢ ∈ as` and `bᵢ ‌∈ bs`. If `as` is shorter than `bs`, `f` is applied to
+`none` for the remaining `bᵢ`.
+
+```
+map₂_right prod.mk [1, 2] ['a'] = [(some 1, 'a')]
+
+map₂_right prod.mk [1] ['a', 'b'] = [(some 1, 'a'), (none, 'b')]
+
+map₂_right f as bs = (map₂_right' f as bs).fst
+```
+-/
+def map₂_right (f : option α → β → γ) (as : list α) (bs : list β) :
+  list γ :=
+map₂_left (flip f) bs as
+
+/--
+Left-biased version of `list.zip`. `zip_left as bs` returns the list of pairs
+`(aᵢ, bᵢ)` for `aᵢ ∈ as` and `bᵢ ∈ bs`. If `bs` is shorter than `as`, the
+remaining `aᵢ` are paired with `none`.
+
+```
+zip_left [1, 2] ['a'] = [(1, some 'a'), (2, none)]
+
+zip_left [1] ['a', 'b'] = [(1, some 'a')]
+
+zip_left = map₂_left prod.mk
+```
+-/
+def zip_left : list α → list β → list (α × option β) :=
+map₂_left prod.mk
+
+/--
+Right-biased version of `list.zip`. `zip_right as bs` returns the list of pairs
+`(aᵢ, bᵢ)` for `aᵢ ∈ as` and `bᵢ ∈ bs`. If `as` is shorter than `bs`, the
+remaining `bᵢ` are paired with `none`.
+
+```
+zip_right [1, 2] ['a'] = [(some 1, 'a')]
+
+zip_right [1] ['a', 'b'] = [(some 1, 'a'), (none, 'b')]
+
+zip_right = map₂_right prod.mk
+```
+-/
+def zip_right : list α → list β → list (option α × β) :=
+map₂_right prod.mk
+
 end list

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -720,14 +720,13 @@ map₂_left' prod.mk [1, 2] ['a'] = ([(1, some 'a'), (2, none)], [])
 map₂_left' prod.mk [1] ['a', 'b'] = ([(1, some 'a')], ['b'])
 ```
 -/
-def map₂_left' (f : α → option β → γ) : list α → list β → (list γ × list β)
+@[simp] def map₂_left' (f : α → option β → γ) : list α → list β → (list γ × list β)
 | [] bs := ([], bs)
 | (a :: as) [] :=
-  let ⟨cs, rest⟩ := map₂_left' as [] in
-  (f a none :: cs, rest)
+  ((a :: as).map (λ a, f a none), [])
 | (a :: as) (b :: bs) :=
-  let ⟨cs, rest⟩ := map₂_left' as bs in
-  (f a (some b) :: cs, rest)
+  let rec := map₂_left' as bs in
+  (f a (some b) :: rec.fst, rec.snd)
 
 /--
 Right-biased version of `list.map₂`. `map₂_right' f as bs` applies `f` to each
@@ -790,9 +789,9 @@ map₂_left prod.mk [1] ['a', 'b'] = [(1, some 'a')]
 map₂_left f as bs = (map₂_left' f as bs).fst
 ```
 -/
-def map₂_left (f : α → option β → γ) : list α → list β → list γ
+@[simp] def map₂_left (f : α → option β → γ) : list α → list β → list γ
 | [] _ := []
-| (a :: as) [] := f a none :: map₂_left as []
+| (a :: as) [] := (a :: as).map (λ a, f a none)
 | (a :: as) (b :: bs) := f a (some b) :: map₂_left as bs
 
 /--


### PR DESCRIPTION
When given lists of different lengths, `map₂` and `zip` truncate the output to
the length of the shorter input list. This commit adds variations on `map₂` and
`zip` whose output is always as long as the left/right input.

---

The lemmas I added to characterise these functions are a bit sparse. If you want more, I'm happy to add more.