### PR TITLE
[Merged by Bors] - ci(*): run style lint in parallel job, fix update-copy-mod-doc-exceptions.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,19 @@ on:
       - 'lean-3.*'
 
 jobs:
+  style_lint:
+    name: Check for copyright header, module doc and long lines
+    runs-on: ubuntu-latest
+    steps:
+      - name: install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: lint
+        run: |
+          ./scripts/lint-copy-mod-doc.sh
+
   build:
     name: Build mathlib
     runs-on: ubuntu-latest
@@ -144,7 +157,3 @@ jobs:
           python scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
           bash scripts/mk_all.sh
           lean --run scripts/yaml_check.lean
-
-      - name: check for copyright headers and module docstrings
-        run: |
-          ./scripts/lint-copy-mod-doc.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
     name: Check for copyright header, module doc and long lines
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
       - name: install Python
         uses: actions/setup-python@v1
         with:

--- a/scripts/copy-mod-doc-exceptions.txt
+++ b/scripts/copy-mod-doc-exceptions.txt
@@ -83,8 +83,8 @@ src/algebra/category/Group/limits.lean : line 82 : ERR_LIN : Line has more than 
 src/algebra/category/Group/limits.lean : line 90 : ERR_LIN : Line has more than 100 characters
 src/algebra/category/Group/zero.lean : line 12 : ERR_LIN : Line has more than 100 characters
 src/algebra/category/Module/basic.lean : line 106 : ERR_LIN : Line has more than 100 characters
-src/algebra/category/Module/basic.lean : line 129 : ERR_LIN : Line has more than 100 characters
 src/algebra/category/Module/basic.lean : line 12 : ERR_MOD : Module docstring missing, or too late
+src/algebra/category/Module/basic.lean : line 129 : ERR_LIN : Line has more than 100 characters
 src/algebra/category/Module/basic.lean : line 131 : ERR_LIN : Line has more than 100 characters
 src/algebra/category/Module/basic.lean : line 58 : ERR_LIN : Line has more than 100 characters
 src/algebra/category/Module/basic.lean : line 96 : ERR_LIN : Line has more than 100 characters
@@ -162,29 +162,20 @@ src/algebra/gcd_monoid.lean : line 99 : ERR_LIN : Line has more than 100 charact
 src/algebra/geom_sum.lean : line 13 : ERR_MOD : Module docstring missing, or too late
 src/algebra/geom_sum.lean : line 182 : ERR_LIN : Line has more than 100 characters
 src/algebra/geom_sum.lean : line 34 : ERR_LIN : Line has more than 100 characters
-src/algebra/group_action_hom.lean : line 276 : ERR_LIN : Line has more than 100 characters
-src/algebra/group_action_hom.lean : line 287 : ERR_LIN : Line has more than 100 characters
 src/algebra/group/basic.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 src/algebra/group/defs.lean : line 288 : ERR_LIN : Line has more than 100 characters
+src/algebra/group/prod.lean : line 237 : ERR_LIN : Line has more than 100 characters
+src/algebra/group/prod.lean : line 238 : ERR_LIN : Line has more than 100 characters
+src/algebra/group/with_one.lean : line 8 : ERR_MOD : Module docstring missing, or too late
+src/algebra/group_action_hom.lean : line 276 : ERR_LIN : Line has more than 100 characters
+src/algebra/group_action_hom.lean : line 287 : ERR_LIN : Line has more than 100 characters
 src/algebra/group_power/basic.lean : line 396 : ERR_LIN : Line has more than 100 characters
 src/algebra/group_power/basic.lean : line 474 : ERR_LIN : Line has more than 100 characters
 src/algebra/group_power/lemmas.lean : line 437 : ERR_LIN : Line has more than 100 characters
-src/algebra/group/prod.lean : line 237 : ERR_LIN : Line has more than 100 characters
-src/algebra/group/prod.lean : line 238 : ERR_LIN : Line has more than 100 characters
 src/algebra/group_ring_action.lean : line 223 : ERR_LIN : Line has more than 100 characters
 src/algebra/group_ring_action.lean : line 224 : ERR_LIN : Line has more than 100 characters
-src/algebra/group/with_one.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 src/algebra/group_with_zero.lean : line 291 : ERR_LIN : Line has more than 100 characters
 src/algebra/group_with_zero_power.lean : line 148 : ERR_LIN : Line has more than 100 characters
-src/algebraic_geometry/locally_ringed_space.lean : line 18 : ERR_LIN : Line has more than 100 characters
-src/algebraic_geometry/locally_ringed_space.lean : line 65 : ERR_LIN : Line has more than 100 characters
-src/algebraic_geometry/presheafed_space/has_colimits.lean : line 206 : ERR_LIN : Line has more than 100 characters
-src/algebraic_geometry/presheafed_space/has_colimits.lean : line 239 : ERR_LIN : Line has more than 100 characters
-src/algebraic_geometry/Scheme.lean : line 29 : ERR_LIN : Line has more than 100 characters
-src/algebraic_geometry/sheafed_space.lean : line 50 : ERR_LIN : Line has more than 100 characters
-src/algebraic_geometry/sheafed_space.lean : line 82 : ERR_LIN : Line has more than 100 characters
-src/algebraic_geometry/stalks.lean : line 47 : ERR_LIN : Line has more than 100 characters
-src/algebraic_geometry/stalks.lean : line 48 : ERR_LIN : Line has more than 100 characters
 src/algebra/invertible.lean : line 204 : ERR_LIN : Line has more than 100 characters
 src/algebra/invertible.lean : line 212 : ERR_LIN : Line has more than 100 characters
 src/algebra/invertible.lean : line 221 : ERR_LIN : Line has more than 100 characters
@@ -222,6 +213,7 @@ src/algebra/monoid_algebra.lean : line 355 : ERR_LIN : Line has more than 100 ch
 src/algebra/monoid_algebra.lean : line 373 : ERR_LIN : Line has more than 100 characters
 src/algebra/monoid_algebra.lean : line 639 : ERR_LIN : Line has more than 100 characters
 src/algebra/monoid_algebra.lean : line 645 : ERR_LIN : Line has more than 100 characters
+src/algebra/order_functions.lean : line 138 : ERR_LIN : Line has more than 100 characters
 src/algebra/ordered_group.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/algebra/ordered_group.lean : line 1210 : ERR_LIN : Line has more than 100 characters
 src/algebra/ordered_group.lean : line 1212 : ERR_LIN : Line has more than 100 characters
@@ -230,9 +222,8 @@ src/algebra/ordered_group.lean : line 614 : ERR_LIN : Line has more than 100 cha
 src/algebra/ordered_ring.lean : line 1039 : ERR_LIN : Line has more than 100 characters
 src/algebra/ordered_ring.lean : line 677 : ERR_LIN : Line has more than 100 characters
 src/algebra/ordered_ring.lean : line 681 : ERR_LIN : Line has more than 100 characters
-src/algebra/ordered_ring.lean : line 812 : ERR_LIN : Line has more than 100 characters
 src/algebra/ordered_ring.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-src/algebra/order_functions.lean : line 138 : ERR_LIN : Line has more than 100 characters
+src/algebra/ordered_ring.lean : line 812 : ERR_LIN : Line has more than 100 characters
 src/algebra/polynomial/big_operators.lean : line 51 : ERR_LIN : Line has more than 100 characters
 src/algebra/polynomial/big_operators.lean : line 52 : ERR_LIN : Line has more than 100 characters
 src/algebra/polynomial/big_operators.lean : line 62 : ERR_LIN : Line has more than 100 characters
@@ -245,6 +236,15 @@ src/algebra/quandle.lean : line 66 : ERR_LIN : Line has more than 100 characters
 src/algebra/ring/pi.lean : line 70 : ERR_LIN : Line has more than 100 characters
 src/algebra/ring_quot.lean : line 269 : ERR_LIN : Line has more than 100 characters
 src/algebra/ring_quot.lean : line 46 : ERR_LIN : Line has more than 100 characters
+src/algebraic_geometry/Scheme.lean : line 29 : ERR_LIN : Line has more than 100 characters
+src/algebraic_geometry/locally_ringed_space.lean : line 18 : ERR_LIN : Line has more than 100 characters
+src/algebraic_geometry/locally_ringed_space.lean : line 65 : ERR_LIN : Line has more than 100 characters
+src/algebraic_geometry/presheafed_space/has_colimits.lean : line 206 : ERR_LIN : Line has more than 100 characters
+src/algebraic_geometry/presheafed_space/has_colimits.lean : line 239 : ERR_LIN : Line has more than 100 characters
+src/algebraic_geometry/sheafed_space.lean : line 50 : ERR_LIN : Line has more than 100 characters
+src/algebraic_geometry/sheafed_space.lean : line 82 : ERR_LIN : Line has more than 100 characters
+src/algebraic_geometry/stalks.lean : line 47 : ERR_LIN : Line has more than 100 characters
+src/algebraic_geometry/stalks.lean : line 48 : ERR_LIN : Line has more than 100 characters
 src/analysis/analytic/basic.lean : line 206 : ERR_LIN : Line has more than 100 characters
 src/analysis/analytic/basic.lean : line 349 : ERR_LIN : Line has more than 100 characters
 src/analysis/analytic/basic.lean : line 575 : ERR_LIN : Line has more than 100 characters
@@ -441,24 +441,25 @@ src/category_theory/epi_mono.lean : line 14 : ERR_MOD : Module docstring missing
 src/category_theory/eq_to_hom.lean : line 47 : ERR_LIN : Line has more than 100 characters
 src/category_theory/eq_to_hom.lean : line 50 : ERR_LIN : Line has more than 100 characters
 src/category_theory/eq_to_hom.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-src/category_theory/equivalence.lean : line 10 : ERR_MOD : Module docstring missing, or too late
-src/category_theory/equivalence.lean : line 12 : ERR_LIN : Line has more than 100 characters
-src/category_theory/equivalence.lean : line 177 : ERR_LIN : Line has more than 100 characters
-src/category_theory/equivalence.lean : line 182 : ERR_LIN : Line has more than 100 characters
-src/category_theory/equivalence.lean : line 213 : ERR_LIN : Line has more than 100 characters
-src/category_theory/equivalence.lean : line 451 : ERR_LIN : Line has more than 100 characters
-src/category_theory/equivalence.lean : line 474 : ERR_LIN : Line has more than 100 characters
-src/category_theory/equivalence.lean : line 481 : ERR_LIN : Line has more than 100 characters
+src/category_theory/equivalence.lean : line 240 : ERR_LIN : Line has more than 100 characters
+src/category_theory/equivalence.lean : line 245 : ERR_LIN : Line has more than 100 characters
+src/category_theory/equivalence.lean : line 249 : ERR_LIN : Line has more than 100 characters
+src/category_theory/equivalence.lean : line 261 : ERR_LIN : Line has more than 100 characters
+src/category_theory/equivalence.lean : line 278 : ERR_LIN : Line has more than 100 characters
+src/category_theory/equivalence.lean : line 533 : ERR_LIN : Line has more than 100 characters
+src/category_theory/equivalence.lean : line 556 : ERR_LIN : Line has more than 100 characters
+src/category_theory/equivalence.lean : line 56 : ERR_LIN : Line has more than 100 characters
+src/category_theory/equivalence.lean : line 563 : ERR_LIN : Line has more than 100 characters
 src/category_theory/filtered.lean : line 182 : ERR_LIN : Line has more than 100 characters
 src/category_theory/full_subcategory.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 src/category_theory/fully_faithful.lean : line 9 : ERR_LIN : Line has more than 100 characters
 src/category_theory/fully_faithful.lean : line 9 : ERR_MOD : Module docstring missing, or too late
+src/category_theory/functor.lean : line 17 : ERR_MOD : Module docstring missing, or too late
+src/category_theory/functor.lean : line 19 : ERR_LIN : Line has more than 100 characters
 src/category_theory/functor_category.lean : line 10 : ERR_LIN : Line has more than 100 characters
 src/category_theory/functor_category.lean : line 75 : ERR_LIN : Line has more than 100 characters
 src/category_theory/functor_category.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 src/category_theory/functorial.lean : line 14 : ERR_LIN : Line has more than 100 characters
-src/category_theory/functor.lean : line 17 : ERR_MOD : Module docstring missing, or too late
-src/category_theory/functor.lean : line 19 : ERR_LIN : Line has more than 100 characters
 src/category_theory/graded_object.lean : line 47 : ERR_LIN : Line has more than 100 characters
 src/category_theory/graded_object.lean : line 70 : ERR_LIN : Line has more than 100 characters
 src/category_theory/graded_object.lean : line 95 : ERR_LIN : Line has more than 100 characters
@@ -636,21 +637,21 @@ src/category_theory/monad/limits.lean : line 186 : ERR_LIN : Line has more than 
 src/category_theory/monad/limits.lean : line 213 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monad/limits.lean : line 225 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monad/limits.lean : line 9 : ERR_MOD : Module docstring missing, or too late
+src/category_theory/monoidal/CommMon_.lean : line 139 : ERR_LIN : Line has more than 100 characters
+src/category_theory/monoidal/Mon_.lean : line 55 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/braided.lean : line 217 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/category.lean : line 136 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/category.lean : line 151 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/category.lean : line 166 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/category.lean : line 207 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/category.lean : line 211 : ERR_LIN : Line has more than 100 characters
-src/category_theory/monoidal/CommMon_.lean : line 139 : ERR_LIN : Line has more than 100 characters
-src/category_theory/monoidal/functorial.lean : line 111 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/functor.lean : line 215 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/functor.lean : line 54 : ERR_LIN : Line has more than 100 characters
+src/category_theory/monoidal/functorial.lean : line 111 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/internal/functor_category.lean : line 101 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/internal/functor_category.lean : line 177 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/internal/functor_category.lean : line 181 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/internal/functor_category.lean : line 97 : ERR_LIN : Line has more than 100 characters
-src/category_theory/monoidal/Mon_.lean : line 55 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/natural_transformation.lean : line 117 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/natural_transformation.lean : line 140 : ERR_LIN : Line has more than 100 characters
 src/category_theory/monoidal/natural_transformation.lean : line 142 : ERR_LIN : Line has more than 100 characters
@@ -740,8 +741,8 @@ src/control/monad/cont.lean : line 107 : ERR_LIN : Line has more than 100 charac
 src/control/monad/cont.lean : line 12 : ERR_MOD : Module docstring missing, or too late
 src/control/monad/cont.lean : line 80 : ERR_LIN : Line has more than 100 characters
 src/control/monad/writer.lean : line 102 : ERR_LIN : Line has more than 100 characters
-src/control/monad/writer.lean : line 110 : ERR_LIN : Line has more than 100 characters
 src/control/monad/writer.lean : line 11 : ERR_MOD : Module docstring missing, or too late
+src/control/monad/writer.lean : line 110 : ERR_LIN : Line has more than 100 characters
 src/control/monad/writer.lean : line 120 : ERR_LIN : Line has more than 100 characters
 src/control/monad/writer.lean : line 129 : ERR_LIN : Line has more than 100 characters
 src/control/monad/writer.lean : line 144 : ERR_LIN : Line has more than 100 characters
@@ -768,8 +769,8 @@ src/data/analysis/filter.lean : line 158 : ERR_LIN : Line has more than 100 char
 src/data/analysis/filter.lean : line 163 : ERR_LIN : Line has more than 100 characters
 src/data/analysis/filter.lean : line 196 : ERR_LIN : Line has more than 100 characters
 src/data/analysis/filter.lean : line 222 : ERR_LIN : Line has more than 100 characters
-src/data/analysis/filter.lean : line 90 : ERR_LIN : Line has more than 100 characters
 src/data/analysis/filter.lean : line 9 : ERR_MOD : Module docstring missing, or too late
+src/data/analysis/filter.lean : line 90 : ERR_LIN : Line has more than 100 characters
 src/data/analysis/topology.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/data/array/lemmas.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 src/data/bitvec/basic.lean : line 11 : ERR_MOD : Module docstring missing, or too late
@@ -815,10 +816,10 @@ src/data/equiv/mul_add.lean : line 482 : ERR_LIN : Line has more than 100 charac
 src/data/equiv/mul_add.lean : line 495 : ERR_LIN : Line has more than 100 characters
 src/data/equiv/nat.lean : line 12 : ERR_MOD : Module docstring missing, or too late
 src/data/erased.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-src/data/fin2.lean : line 7 : ERR_MOD : Module docstring missing, or too late
 src/data/fin.lean : line 286 : ERR_LIN : Line has more than 100 characters
 src/data/fin.lean : line 374 : ERR_LIN : Line has more than 100 characters
 src/data/fin.lean : line 505 : ERR_LIN : Line has more than 100 characters
+src/data/fin2.lean : line 7 : ERR_MOD : Module docstring missing, or too late
 src/data/finset/gcd.lean : line 133 : ERR_LIN : Line has more than 100 characters
 src/data/finsupp/basic.lean : line 1312 : ERR_LIN : Line has more than 100 characters
 src/data/finsupp/basic.lean : line 430 : ERR_LIN : Line has more than 100 characters
@@ -880,13 +881,13 @@ src/data/list/sigma.lean : line 559 : ERR_LIN : Line has more than 100 character
 src/data/list/sort.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 src/data/list/tfae.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 src/data/list/zip.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-src/data/matrix/basic.lean : line 317 : ERR_LIN : Line has more than 100 characters
-src/data/matrix/basic.lean : line 320 : ERR_LIN : Line has more than 100 characters
-src/data/matrix/basic.lean : line 415 : ERR_LIN : Line has more than 100 characters
-src/data/matrix/basic.lean : line 69 : ERR_LIN : Line has more than 100 characters
-src/data/matrix/basic.lean : line 744 : ERR_LIN : Line has more than 100 characters
-src/data/matrix/basic.lean : line 746 : ERR_LIN : Line has more than 100 characters
-src/data/matrix/basic.lean : line 799 : ERR_LIN : Line has more than 100 characters
+src/data/matrix/basic.lean : line 324 : ERR_LIN : Line has more than 100 characters
+src/data/matrix/basic.lean : line 327 : ERR_LIN : Line has more than 100 characters
+src/data/matrix/basic.lean : line 422 : ERR_LIN : Line has more than 100 characters
+src/data/matrix/basic.lean : line 74 : ERR_LIN : Line has more than 100 characters
+src/data/matrix/basic.lean : line 770 : ERR_LIN : Line has more than 100 characters
+src/data/matrix/basic.lean : line 772 : ERR_LIN : Line has more than 100 characters
+src/data/matrix/basic.lean : line 825 : ERR_LIN : Line has more than 100 characters
 src/data/matrix/notation.lean : line 252 : ERR_LIN : Line has more than 100 characters
 src/data/matrix/pequiv.lean : line 138 : ERR_LIN : Line has more than 100 characters
 src/data/matrix/pequiv.lean : line 144 : ERR_LIN : Line has more than 100 characters
@@ -936,9 +937,9 @@ src/data/mv_polynomial/monad.lean : line 262 : ERR_LIN : Line has more than 100 
 src/data/mv_polynomial/monad.lean : line 274 : ERR_LIN : Line has more than 100 characters
 src/data/mv_polynomial/monad.lean : line 66 : ERR_LIN : Line has more than 100 characters
 src/data/mv_polynomial/variables.lean : line 182 : ERR_LIN : Line has more than 100 characters
+src/data/mv_polynomial/variables.lean : line 24 : ERR_LIN : Line has more than 100 characters
 src/data/mv_polynomial/variables.lean : line 245 : ERR_LIN : Line has more than 100 characters
 src/data/mv_polynomial/variables.lean : line 247 : ERR_LIN : Line has more than 100 characters
-src/data/mv_polynomial/variables.lean : line 24 : ERR_LIN : Line has more than 100 characters
 src/data/mv_polynomial/variables.lean : line 28 : ERR_LIN : Line has more than 100 characters
 src/data/mv_polynomial/variables.lean : line 31 : ERR_LIN : Line has more than 100 characters
 src/data/mv_polynomial/variables.lean : line 34 : ERR_LIN : Line has more than 100 characters
@@ -1009,6 +1010,7 @@ src/data/padics/padic_numbers.lean : line 686 : ERR_LIN : Line has more than 100
 src/data/padics/padic_numbers.lean : line 866 : ERR_LIN : Line has more than 100 characters
 src/data/padics/ring_homs.lean : line 640 : ERR_LIN : Line has more than 100 characters
 src/data/pequiv.lean : line 8 : ERR_MOD : Module docstring missing, or too late
+src/data/pfun.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 src/data/pfunctor/multivariate/M.lean : line 43 : ERR_LIN : Line has more than 100 characters
 src/data/pfunctor/multivariate/W.lean : line 27 : ERR_LIN : Line has more than 100 characters
 src/data/pfunctor/multivariate/W.lean : line 41 : ERR_LIN : Line has more than 100 characters
@@ -1016,7 +1018,6 @@ src/data/pfunctor/univariate/M.lean : line 167 : ERR_LIN : Line has more than 10
 src/data/pfunctor/univariate/M.lean : line 373 : ERR_LIN : Line has more than 100 characters
 src/data/pfunctor/univariate/M.lean : line 454 : ERR_LIN : Line has more than 100 characters
 src/data/pfunctor/univariate/M.lean : line 58 : ERR_LIN : Line has more than 100 characters
-src/data/pfun.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 src/data/pnat/basic.lean : line 509 : ERR_LIN : Line has more than 100 characters
 src/data/pnat/basic.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 src/data/pnat/factors.lean : line 11 : ERR_MOD : Module docstring missing, or too late
@@ -1050,17 +1051,15 @@ src/data/polynomial/derivative.lean : line 172 : ERR_LIN : Line has more than 10
 src/data/polynomial/derivative.lean : line 173 : ERR_LIN : Line has more than 100 characters
 src/data/polynomial/derivative.lean : line 215 : ERR_LIN : Line has more than 100 characters
 src/data/polynomial/derivative.lean : line 39 : ERR_LIN : Line has more than 100 characters
-src/data/polynomial/field_division.lean : line 0 : ERR_COP : Malformed or missing copyright header
-src/data/polynomial/integral_normalization.lean : line 0 : ERR_COP : Malformed or missing copyright header
-src/data/polynomial/integral_normalization.lean : line 57 : ERR_LIN : Line has more than 100 characters
+src/data/polynomial/integral_normalization.lean : line 56 : ERR_LIN : Line has more than 100 characters
 src/data/polynomial/iterated_deriv.lean : line 111 : ERR_LIN : Line has more than 100 characters
 src/data/polynomial/iterated_deriv.lean : line 196 : ERR_LIN : Line has more than 100 characters
 src/data/polynomial/iterated_deriv.lean : line 45 : ERR_LIN : Line has more than 100 characters
 src/data/polynomial/ring_division.lean : line 84 : ERR_LIN : Line has more than 100 characters
 src/data/qpf/multivariate/basic.lean : line 159 : ERR_LIN : Line has more than 100 characters
 src/data/qpf/multivariate/basic.lean : line 252 : ERR_LIN : Line has more than 100 characters
-src/data/qpf/multivariate/basic.lean : line 74 : ERR_LIN : Line has more than 100 characters
 src/data/qpf/multivariate/basic.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/data/qpf/multivariate/basic.lean : line 74 : ERR_LIN : Line has more than 100 characters
 src/data/qpf/multivariate/constructions/cofix.lean : line 142 : ERR_LIN : Line has more than 100 characters
 src/data/qpf/multivariate/constructions/cofix.lean : line 299 : ERR_LIN : Line has more than 100 characters
 src/data/qpf/multivariate/constructions/cofix.lean : line 305 : ERR_LIN : Line has more than 100 characters
@@ -1101,8 +1100,6 @@ src/data/set/finite.lean : line 210 : ERR_LIN : Line has more than 100 character
 src/data/set/finite.lean : line 216 : ERR_LIN : Line has more than 100 characters
 src/data/set/finite.lean : line 293 : ERR_LIN : Line has more than 100 characters
 src/data/set/finite.lean : line 416 : ERR_LIN : Line has more than 100 characters
-src/data/set/function.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/data/set/function.lean : line 1 : ERR_MOD : Module docstring missing, or too late
 src/data/set/function.lean : line 367 : ERR_LIN : Line has more than 100 characters
 src/data/set/lattice.lean : line 13 : ERR_MOD : Module docstring missing, or too late
 src/data/set/lattice.lean : line 435 : ERR_LIN : Line has more than 100 characters
@@ -1115,9 +1112,9 @@ src/data/string/basic.lean : line 52 : ERR_LIN : Line has more than 100 characte
 src/data/string/defs.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 src/data/subtype.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 src/data/sum.lean : line 129 : ERR_LIN : Line has more than 100 characters
+src/data/sym.lean : line 135 : ERR_LIN : Line has more than 100 characters
 src/data/sym2.lean : line 173 : ERR_LIN : Line has more than 100 characters
 src/data/sym2.lean : line 9 : ERR_MOD : Module docstring missing, or too late
-src/data/sym.lean : line 135 : ERR_LIN : Line has more than 100 characters
 src/data/typevec.lean : line 248 : ERR_LIN : Line has more than 100 characters
 src/data/typevec.lean : line 261 : ERR_LIN : Line has more than 100 characters
 src/data/typevec.lean : line 290 : ERR_LIN : Line has more than 100 characters
@@ -1193,8 +1190,8 @@ src/geometry/euclidean/circumcenter.lean : line 842 : ERR_LIN : Line has more th
 src/geometry/euclidean/circumcenter.lean : line 846 : ERR_LIN : Line has more than 100 characters
 src/geometry/euclidean/monge_point.lean : line 255 : ERR_LIN : Line has more than 100 characters
 src/geometry/euclidean/monge_point.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-src/geometry/euclidean/triangle.lean : line 99 : ERR_LIN : Line has more than 100 characters
 src/geometry/euclidean/triangle.lean : line 9 : ERR_MOD : Module docstring missing, or too late
+src/geometry/euclidean/triangle.lean : line 99 : ERR_LIN : Line has more than 100 characters
 src/geometry/manifold/algebra/monoid.lean : line 107 : ERR_LIN : Line has more than 100 characters
 src/geometry/manifold/algebra/monoid.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 src/geometry/manifold/algebra/structures.lean : line 7 : ERR_MOD : Module docstring missing, or too late
@@ -1269,8 +1266,8 @@ src/group_theory/free_abelian_group.lean : line 230 : ERR_LIN : Line has more th
 src/group_theory/free_abelian_group.lean : line 34 : ERR_LIN : Line has more than 100 characters
 src/group_theory/free_group.lean : line 129 : ERR_LIN : Line has more than 100 characters
 src/group_theory/free_group.lean : line 176 : ERR_LIN : Line has more than 100 characters
-src/group_theory/free_group.lean : line 180 : ERR_LIN : Line has more than 100 characters
 src/group_theory/free_group.lean : line 18 : ERR_MOD : Module docstring missing, or too late
+src/group_theory/free_group.lean : line 180 : ERR_LIN : Line has more than 100 characters
 src/group_theory/free_group.lean : line 672 : ERR_LIN : Line has more than 100 characters
 src/group_theory/free_group.lean : line 737 : ERR_LIN : Line has more than 100 characters
 src/group_theory/group_action.lean : line 359 : ERR_LIN : Line has more than 100 characters
@@ -1288,11 +1285,11 @@ src/group_theory/perm/cycles.lean : line 138 : ERR_LIN : Line has more than 100 
 src/group_theory/perm/cycles.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 src/group_theory/perm/sign.lean : line 105 : ERR_LIN : Line has more than 100 characters
 src/group_theory/perm/sign.lean : line 108 : ERR_LIN : Line has more than 100 characters
-src/group_theory/perm/sign.lean : line 111 : ERR_LIN : Line has more than 100 characters
 src/group_theory/perm/sign.lean : line 11 : ERR_MOD : Module docstring missing, or too late
+src/group_theory/perm/sign.lean : line 111 : ERR_LIN : Line has more than 100 characters
 src/group_theory/perm/sign.lean : line 141 : ERR_LIN : Line has more than 100 characters
-src/group_theory/perm/sign.lean : line 259 : ERR_LIN : Line has more than 100 characters
 src/group_theory/perm/sign.lean : line 25 : ERR_LIN : Line has more than 100 characters
+src/group_theory/perm/sign.lean : line 259 : ERR_LIN : Line has more than 100 characters
 src/group_theory/perm/sign.lean : line 284 : ERR_LIN : Line has more than 100 characters
 src/group_theory/perm/sign.lean : line 466 : ERR_LIN : Line has more than 100 characters
 src/group_theory/perm/sign.lean : line 607 : ERR_LIN : Line has more than 100 characters
@@ -1407,8 +1404,7 @@ src/measure_theory/bochner_integration.lean : line 718 : ERR_LIN : Line has more
 src/measure_theory/bochner_integration.lean : line 720 : ERR_LIN : Line has more than 100 characters
 src/measure_theory/bochner_integration.lean : line 90 : ERR_LIN : Line has more than 100 characters
 src/measure_theory/bochner_integration.lean : line 97 : ERR_LIN : Line has more than 100 characters
-src/measure_theory/category/Meas.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/measure_theory/category/Meas.lean : line 1 : ERR_MOD : Module docstring missing, or too late
+src/measure_theory/category/Meas.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/measure_theory/content.lean : line 162 : ERR_LIN : Line has more than 100 characters
 src/measure_theory/content.lean : line 98 : ERR_LIN : Line has more than 100 characters
 src/measure_theory/decomposition.lean : line 14 : ERR_MOD : Module docstring missing, or too late
@@ -1454,8 +1450,8 @@ src/meta/rb_map.lean : line 14 : ERR_LIN : Line has more than 100 characters
 src/number_theory/basic.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/number_theory/dioph.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/number_theory/lucas_lehmer.lean : line 394 : ERR_LIN : Line has more than 100 characters
-src/number_theory/pell.lean : line 106 : ERR_LIN : Line has more than 100 characters
 src/number_theory/pell.lean : line 10 : ERR_MOD : Module docstring missing, or too late
+src/number_theory/pell.lean : line 106 : ERR_LIN : Line has more than 100 characters
 src/number_theory/pell.lean : line 138 : ERR_LIN : Line has more than 100 characters
 src/number_theory/pell.lean : line 139 : ERR_LIN : Line has more than 100 characters
 src/number_theory/pell.lean : line 141 : ERR_LIN : Line has more than 100 characters
@@ -1649,6 +1645,8 @@ src/ring_theory/integral_domain.lean : line 121 : ERR_LIN : Line has more than 1
 src/ring_theory/integral_domain.lean : line 126 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/integral_domain.lean : line 141 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/integral_domain.lean : line 154 : ERR_LIN : Line has more than 100 characters
+src/ring_theory/jacobson.lean : line 221 : ERR_LIN : Line has more than 100 characters
+src/ring_theory/jacobson.lean : line 85 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/jacobson_ideal.lean : line 147 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/jacobson_ideal.lean : line 237 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/jacobson_ideal.lean : line 249 : ERR_LIN : Line has more than 100 characters
@@ -1656,8 +1654,6 @@ src/ring_theory/jacobson_ideal.lean : line 253 : ERR_LIN : Line has more than 10
 src/ring_theory/jacobson_ideal.lean : line 66 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/jacobson_ideal.lean : line 86 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/jacobson_ideal.lean : line 96 : ERR_LIN : Line has more than 100 characters
-src/ring_theory/jacobson.lean : line 221 : ERR_LIN : Line has more than 100 characters
-src/ring_theory/jacobson.lean : line 85 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/localization.lean : line 1141 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/localization.lean : line 1303 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/localization.lean : line 864 : ERR_LIN : Line has more than 100 characters
@@ -1705,11 +1701,14 @@ src/ring_theory/unique_factorization_domain.lean : line 343 : ERR_LIN : Line has
 src/ring_theory/unique_factorization_domain.lean : line 385 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/unique_factorization_domain.lean : line 45 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/unique_factorization_domain.lean : line 629 : ERR_LIN : Line has more than 100 characters
-src/ring_theory/witt_vector/structure_polynomial.lean : line 112 : ERR_LIN : Line has more than 100 characters
+src/ring_theory/witt_vector/structure_polynomial.lean : line 116 : ERR_LIN : Line has more than 100 characters
+src/ring_theory/witt_vector/structure_polynomial.lean : line 165 : ERR_LIN : Line has more than 100 characters
+src/ring_theory/witt_vector/structure_polynomial.lean : line 172 : ERR_LIN : Line has more than 100 characters
+src/ring_theory/witt_vector/structure_polynomial.lean : line 206 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/witt_vector/structure_polynomial.lean : line 53 : ERR_LIN : Line has more than 100 characters
-src/ring_theory/witt_vector/structure_polynomial.lean : line 91 : ERR_LIN : Line has more than 100 characters
-src/ring_theory/witt_vector/witt_polynomial.lean : line 137 : ERR_LIN : Line has more than 100 characters
+src/ring_theory/witt_vector/structure_polynomial.lean : line 95 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/witt_vector/witt_polynomial.lean : line 13 : ERR_MOD : Module docstring missing, or too late
+src/ring_theory/witt_vector/witt_polynomial.lean : line 137 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/witt_vector/witt_polynomial.lean : line 232 : ERR_LIN : Line has more than 100 characters
 src/ring_theory/witt_vector/witt_polynomial.lean : line 283 : ERR_LIN : Line has more than 100 characters
 src/set_theory/cardinal.lean : line 1027 : ERR_LIN : Line has more than 100 characters
@@ -1726,9 +1725,9 @@ src/set_theory/game/nim.lean : line 86 : ERR_LIN : Line has more than 100 charac
 src/set_theory/game/nim.lean : line 91 : ERR_LIN : Line has more than 100 characters
 src/set_theory/game/nim.lean : line 94 : ERR_LIN : Line has more than 100 characters
 src/set_theory/lists.lean : line 13 : ERR_MOD : Module docstring missing, or too late
+src/set_theory/ordinal.lean : line 1131 : ERR_LIN : Line has more than 100 characters
 src/set_theory/ordinal_arithmetic.lean : line 1271 : ERR_LIN : Line has more than 100 characters
 src/set_theory/ordinal_arithmetic.lean : line 1578 : ERR_LIN : Line has more than 100 characters
-src/set_theory/ordinal.lean : line 1131 : ERR_LIN : Line has more than 100 characters
 src/set_theory/schroeder_bernstein.lean : line 103 : ERR_LIN : Line has more than 100 characters
 src/set_theory/schroeder_bernstein.lean : line 11 : ERR_MOD : Module docstring missing, or too late
 src/set_theory/surreal.lean : line 365 : ERR_LIN : Line has more than 100 characters
@@ -1760,16 +1759,16 @@ src/tactic/auto_cases.lean : line 8 : ERR_MOD : Module docstring missing, or too
 src/tactic/cache.lean : line 87 : ERR_LIN : Line has more than 100 characters
 src/tactic/chain.lean : line 13 : ERR_LIN : Line has more than 100 characters
 src/tactic/chain.lean : line 32 : ERR_LIN : Line has more than 100 characters
-src/tactic/chain.lean : line 87 : ERR_LIN : Line has more than 100 characters
 src/tactic/chain.lean : line 8 : ERR_MOD : Module docstring missing, or too late
+src/tactic/chain.lean : line 87 : ERR_LIN : Line has more than 100 characters
 src/tactic/converter/binders.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/tactic/converter/binders.lean : line 31 : ERR_LIN : Line has more than 100 characters
 src/tactic/converter/interactive.lean : line 11 : ERR_MOD : Module docstring missing, or too late
 src/tactic/converter/interactive.lean : line 53 : ERR_LIN : Line has more than 100 characters
 src/tactic/converter/old_conv.lean : line 272 : ERR_LIN : Line has more than 100 characters
 src/tactic/converter/old_conv.lean : line 9 : ERR_MOD : Module docstring missing, or too late
-src/tactic/core.lean : line 1729 : ERR_LIN : Line has more than 100 characters
 src/tactic/core.lean : line 17 : ERR_MOD : Module docstring missing, or too late
+src/tactic/core.lean : line 1729 : ERR_LIN : Line has more than 100 characters
 src/tactic/core.lean : line 1817 : ERR_LIN : Line has more than 100 characters
 src/tactic/core.lean : line 2012 : ERR_LIN : Line has more than 100 characters
 src/tactic/core.lean : line 2075 : ERR_LIN : Line has more than 100 characters
@@ -1790,11 +1789,6 @@ src/tactic/core.lean : line 768 : ERR_LIN : Line has more than 100 characters
 src/tactic/delta_instance.lean : line 56 : ERR_LIN : Line has more than 100 characters
 src/tactic/delta_instance.lean : line 66 : ERR_LIN : Line has more than 100 characters
 src/tactic/delta_instance.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-src/tactic/derive_fintype.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/derive_inhabited.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/doc_commands.lean : line 146 : ERR_LIN : Line has more than 100 characters
-src/tactic/doc_commands.lean : line 193 : ERR_LIN : Line has more than 100 characters
-src/tactic/doc_commands.lean : line 194 : ERR_LIN : Line has more than 100 characters
 src/tactic/elide.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 src/tactic/equiv_rw.lean : line 173 : ERR_LIN : Line has more than 100 characters
 src/tactic/equiv_rw.lean : line 222 : ERR_LIN : Line has more than 100 characters
@@ -1814,6 +1808,11 @@ src/tactic/generalizes.lean : line 118 : ERR_LIN : Line has more than 100 charac
 src/tactic/group.lean : line 36 : ERR_LIN : Line has more than 100 characters
 src/tactic/hint.lean : line 57 : ERR_LIN : Line has more than 100 characters
 src/tactic/hint.lean : line 9 : ERR_MOD : Module docstring missing, or too late
+src/tactic/interactive.lean : line 1115 : ERR_LIN : Line has more than 100 characters
+src/tactic/interactive.lean : line 378 : ERR_LIN : Line has more than 100 characters
+src/tactic/interactive.lean : line 702 : ERR_LIN : Line has more than 100 characters
+src/tactic/interactive.lean : line 8 : ERR_MOD : Module docstring missing, or too late
+src/tactic/interactive.lean : line 905 : ERR_LIN : Line has more than 100 characters
 src/tactic/interactive_expr.lean : line 153 : ERR_LIN : Line has more than 100 characters
 src/tactic/interactive_expr.lean : line 173 : ERR_LIN : Line has more than 100 characters
 src/tactic/interactive_expr.lean : line 177 : ERR_LIN : Line has more than 100 characters
@@ -1826,12 +1825,6 @@ src/tactic/interactive_expr.lean : line 408 : ERR_LIN : Line has more than 100 c
 src/tactic/interactive_expr.lean : line 434 : ERR_LIN : Line has more than 100 characters
 src/tactic/interactive_expr.lean : line 439 : ERR_LIN : Line has more than 100 characters
 src/tactic/interactive_expr.lean : line 76 : ERR_LIN : Line has more than 100 characters
-src/tactic/interactive.lean : line 0 : ERR_COP : Malformed or missing copyright header
-src/tactic/interactive.lean : line 1116 : ERR_LIN : Line has more than 100 characters
-src/tactic/interactive.lean : line 379 : ERR_LIN : Line has more than 100 characters
-src/tactic/interactive.lean : line 703 : ERR_LIN : Line has more than 100 characters
-src/tactic/interactive.lean : line 906 : ERR_LIN : Line has more than 100 characters
-src/tactic/interactive.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 src/tactic/interval_cases.lean : line 192 : ERR_LIN : Line has more than 100 characters
 src/tactic/interval_cases.lean : line 230 : ERR_LIN : Line has more than 100 characters
 src/tactic/interval_cases.lean : line 233 : ERR_LIN : Line has more than 100 characters
@@ -1951,49 +1944,29 @@ src/tactic/nth_rewrite/basic.lean : line 8 : ERR_MOD : Module docstring missing,
 src/tactic/nth_rewrite/congr.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/tactic/nth_rewrite/default.lean : line 110 : ERR_LIN : Line has more than 100 characters
 src/tactic/nth_rewrite/default.lean : line 113 : ERR_LIN : Line has more than 100 characters
-src/tactic/omega/clause.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/clause.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/coeffs.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/coeffs.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/eq_elim.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/eq_elim.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/find_ees.lean : line 147 : ERR_LIN : Line has more than 100 characters
-src/tactic/omega/find_ees.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/find_ees.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/find_scalars.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/find_scalars.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/int/dnf.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/int/dnf.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/int/form.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/int/form.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/int/main.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/int/main.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/int/preterm.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/int/preterm.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/lin_comb.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/lin_comb.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/main.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/main.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/misc.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/misc.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/nat/dnf.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/nat/dnf.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/nat/dnf.lean : line 71 : ERR_LIN : Line has more than 100 characters
-src/tactic/omega/nat/form.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/nat/form.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/nat/main.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/nat/main.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/nat/main.lean : line 92 : ERR_LIN : Line has more than 100 characters
-src/tactic/omega/nat/neg_elim.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/nat/neg_elim.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/nat/preterm.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/nat/preterm.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/nat/sub_elim.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/nat/sub_elim.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/prove_unsats.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/prove_unsats.lean : line 1 : ERR_MOD : Module docstring missing, or too late
-src/tactic/omega/term.lean : line 1 : ERR_COP : Malformed or missing copyright header
-src/tactic/omega/term.lean : line 1 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/clause.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/coeffs.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/eq_elim.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/find_ees.lean : line 152 : ERR_LIN : Line has more than 100 characters
+src/tactic/omega/find_ees.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/find_scalars.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/int/dnf.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/int/form.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/int/main.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/int/preterm.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/lin_comb.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/main.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/misc.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/nat/dnf.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/nat/dnf.lean : line 76 : ERR_LIN : Line has more than 100 characters
+src/tactic/omega/nat/form.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/nat/main.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/nat/main.lean : line 97 : ERR_LIN : Line has more than 100 characters
+src/tactic/omega/nat/neg_elim.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/nat/preterm.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/nat/sub_elim.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/prove_unsats.lean : line 7 : ERR_MOD : Module docstring missing, or too late
+src/tactic/omega/term.lean : line 7 : ERR_MOD : Module docstring missing, or too late
 src/tactic/push_neg.lean : line 12 : ERR_MOD : Module docstring missing, or too late
 src/tactic/push_neg.lean : line 180 : ERR_LIN : Line has more than 100 characters
 src/tactic/push_neg.lean : line 181 : ERR_LIN : Line has more than 100 characters
@@ -2001,18 +1974,18 @@ src/tactic/push_neg.lean : line 183 : ERR_LIN : Line has more than 100 character
 src/tactic/push_neg.lean : line 184 : ERR_LIN : Line has more than 100 characters
 src/tactic/rcases.lean : line 634 : ERR_LIN : Line has more than 100 characters
 src/tactic/restate_axiom.lean : line 9 : ERR_MOD : Module docstring missing, or too late
-src/tactic/rewrite_all/basic.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 src/tactic/rewrite.lean : line 9 : ERR_MOD : Module docstring missing, or too late
-src/tactic/ring2.lean : line 482 : ERR_LIN : Line has more than 100 characters
-src/tactic/ring_exp.lean : line 1513 : ERR_LIN : Line has more than 100 characters
+src/tactic/rewrite_all/basic.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 src/tactic/ring.lean : line 513 : ERR_LIN : Line has more than 100 characters
 src/tactic/ring.lean : line 544 : ERR_LIN : Line has more than 100 characters
 src/tactic/ring.lean : line 616 : ERR_LIN : Line has more than 100 characters
+src/tactic/ring2.lean : line 482 : ERR_LIN : Line has more than 100 characters
+src/tactic/ring_exp.lean : line 1513 : ERR_LIN : Line has more than 100 characters
 src/tactic/show_term.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-src/tactic/simpa.lean : line 38 : ERR_LIN : Line has more than 100 characters
-src/tactic/simpa.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 src/tactic/simp_result.lean : line 94 : ERR_LIN : Line has more than 100 characters
 src/tactic/simp_rw.lean : line 44 : ERR_LIN : Line has more than 100 characters
+src/tactic/simpa.lean : line 38 : ERR_LIN : Line has more than 100 characters
+src/tactic/simpa.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 src/tactic/simps.lean : line 115 : ERR_LIN : Line has more than 100 characters
 src/tactic/simps.lean : line 126 : ERR_LIN : Line has more than 100 characters
 src/tactic/simps.lean : line 129 : ERR_LIN : Line has more than 100 characters
@@ -2036,8 +2009,8 @@ src/tactic/slim_check.lean : line 198 : ERR_LIN : Line has more than 100 charact
 src/tactic/slim_check.lean : line 199 : ERR_LIN : Line has more than 100 characters
 src/tactic/slim_check.lean : line 203 : ERR_LIN : Line has more than 100 characters
 src/tactic/slim_check.lean : line 205 : ERR_LIN : Line has more than 100 characters
-src/tactic/solve_by_elim.lean : line 295 : ERR_LIN : Line has more than 100 characters
 src/tactic/solve_by_elim.lean : line 29 : ERR_LIN : Line has more than 100 characters
+src/tactic/solve_by_elim.lean : line 295 : ERR_LIN : Line has more than 100 characters
 src/tactic/split_ifs.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/tactic/split_ifs.lean : line 56 : ERR_LIN : Line has more than 100 characters
 src/tactic/squeeze.lean : line 155 : ERR_LIN : Line has more than 100 characters
@@ -2071,9 +2044,9 @@ src/tactic/where.lean : line 40 : ERR_LIN : Line has more than 100 characters
 src/tactic/where.lean : line 47 : ERR_LIN : Line has more than 100 characters
 src/tactic/where.lean : line 54 : ERR_LIN : Line has more than 100 characters
 src/tactic/where.lean : line 58 : ERR_LIN : Line has more than 100 characters
+src/tactic/wlog.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/tactic/wlog.lean : line 106 : ERR_LIN : Line has more than 100 characters
 src/tactic/wlog.lean : line 108 : ERR_LIN : Line has more than 100 characters
-src/tactic/wlog.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/tactic/wlog.lean : line 192 : ERR_LIN : Line has more than 100 characters
 src/tactic/wlog.lean : line 209 : ERR_LIN : Line has more than 100 characters
 src/tactic/wlog.lean : line 229 : ERR_LIN : Line has more than 100 characters
@@ -2138,6 +2111,11 @@ src/topology/algebra/continuous_functions.lean : line 87 : ERR_LIN : Line has mo
 src/topology/algebra/floor_ring.lean : line 12 : ERR_MOD : Module docstring missing, or too late
 src/topology/algebra/floor_ring.lean : line 183 : ERR_LIN : Line has more than 100 characters
 src/topology/algebra/floor_ring.lean : line 187 : ERR_LIN : Line has more than 100 characters
+src/topology/algebra/group.lean : line 14 : ERR_MOD : Module docstring missing, or too late
+src/topology/algebra/group.lean : line 255 : ERR_LIN : Line has more than 100 characters
+src/topology/algebra/group.lean : line 262 : ERR_LIN : Line has more than 100 characters
+src/topology/algebra/group.lean : line 434 : ERR_LIN : Line has more than 100 characters
+src/topology/algebra/group.lean : line 463 : ERR_LIN : Line has more than 100 characters
 src/topology/algebra/group_completion.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/topology/algebra/group_completion.lean : line 53 : ERR_LIN : Line has more than 100 characters
 src/topology/algebra/group_completion.lean : line 55 : ERR_LIN : Line has more than 100 characters
@@ -2145,11 +2123,6 @@ src/topology/algebra/group_completion.lean : line 69 : ERR_LIN : Line has more t
 src/topology/algebra/group_completion.lean : line 75 : ERR_LIN : Line has more than 100 characters
 src/topology/algebra/group_completion.lean : line 82 : ERR_LIN : Line has more than 100 characters
 src/topology/algebra/group_completion.lean : line 84 : ERR_LIN : Line has more than 100 characters
-src/topology/algebra/group.lean : line 14 : ERR_MOD : Module docstring missing, or too late
-src/topology/algebra/group.lean : line 255 : ERR_LIN : Line has more than 100 characters
-src/topology/algebra/group.lean : line 262 : ERR_LIN : Line has more than 100 characters
-src/topology/algebra/group.lean : line 434 : ERR_LIN : Line has more than 100 characters
-src/topology/algebra/group.lean : line 463 : ERR_LIN : Line has more than 100 characters
 src/topology/algebra/infinite_sum.lean : line 664 : ERR_LIN : Line has more than 100 characters
 src/topology/algebra/module.lean : line 1053 : ERR_LIN : Line has more than 100 characters
 src/topology/algebra/module.lean : line 1063 : ERR_LIN : Line has more than 100 characters
@@ -2201,7 +2174,6 @@ src/topology/category/Top/adjunctions.lean : line 16 : ERR_LIN : Line has more t
 src/topology/category/Top/adjunctions.lean : line 26 : ERR_LIN : Line has more than 100 characters
 src/topology/category/Top/adjunctions.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 src/topology/category/Top/basic.lean : line 10 : ERR_MOD : Module docstring missing, or too late
-src/topology/category/TopCommRing.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/topology/category/Top/epi_mono.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 src/topology/category/Top/limits.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/topology/category/Top/limits.lean : line 30 : ERR_LIN : Line has more than 100 characters
@@ -2214,6 +2186,7 @@ src/topology/category/Top/limits.lean : line 72 : ERR_LIN : Line has more than 1
 src/topology/category/Top/limits.lean : line 78 : ERR_LIN : Line has more than 100 characters
 src/topology/category/Top/open_nhds.lean : line 45 : ERR_LIN : Line has more than 100 characters
 src/topology/category/Top/open_nhds.lean : line 9 : ERR_MOD : Module docstring missing, or too late
+src/topology/category/TopCommRing.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 src/topology/category/UniformSpace.lean : line 58 : ERR_LIN : Line has more than 100 characters
 src/topology/category/UniformSpace.lean : line 79 : ERR_LIN : Line has more than 100 characters
 src/topology/category/UniformSpace.lean : line 80 : ERR_LIN : Line has more than 100 characters
@@ -2230,8 +2203,8 @@ src/topology/dense_embedding.lean : line 96 : ERR_LIN : Line has more than 100 c
 src/topology/extend_from_subset.lean : line 41 : ERR_LIN : Line has more than 100 characters
 src/topology/homeomorph.lean : line 175 : ERR_LIN : Line has more than 100 characters
 src/topology/homeomorph.lean : line 183 : ERR_LIN : Line has more than 100 characters
-src/topology/homeomorph.lean : line 84 : ERR_LIN : Line has more than 100 characters
 src/topology/homeomorph.lean : line 8 : ERR_MOD : Module docstring missing, or too late
+src/topology/homeomorph.lean : line 84 : ERR_LIN : Line has more than 100 characters
 src/topology/instances/complex.lean : line 11 : ERR_MOD : Module docstring missing, or too late
 src/topology/instances/ennreal.lean : line 227 : ERR_LIN : Line has more than 100 characters
 src/topology/instances/ennreal.lean : line 246 : ERR_LIN : Line has more than 100 characters
@@ -2388,6 +2361,8 @@ src/topology/sheaves/presheaf.lean : line 58 : ERR_LIN : Line has more than 100 
 src/topology/sheaves/presheaf.lean : line 94 : ERR_LIN : Line has more than 100 characters
 src/topology/sheaves/presheaf.lean : line 97 : ERR_LIN : Line has more than 100 characters
 src/topology/sheaves/presheaf_of_functions.lean : line 80 : ERR_LIN : Line has more than 100 characters
+src/topology/sheaves/sheaf.lean : line 73 : ERR_LIN : Line has more than 100 characters
+src/topology/sheaves/sheaf.lean : line 75 : ERR_LIN : Line has more than 100 characters
 src/topology/sheaves/sheaf_condition/equalizer_products.lean : line 230 : ERR_LIN : Line has more than 100 characters
 src/topology/sheaves/sheaf_condition/equalizer_products.lean : line 231 : ERR_LIN : Line has more than 100 characters
 src/topology/sheaves/sheaf_condition/pairwise_intersections.lean : line 101 : ERR_LIN : Line has more than 100 characters
@@ -2399,8 +2374,6 @@ src/topology/sheaves/sheaf_condition/pairwise_intersections.lean : line 261 : ER
 src/topology/sheaves/sheaf_condition/pairwise_intersections.lean : line 272 : ERR_LIN : Line has more than 100 characters
 src/topology/sheaves/sheaf_condition/pairwise_intersections.lean : line 293 : ERR_LIN : Line has more than 100 characters
 src/topology/sheaves/sheaf_condition/pairwise_intersections.lean : line 304 : ERR_LIN : Line has more than 100 characters
-src/topology/sheaves/sheaf.lean : line 73 : ERR_LIN : Line has more than 100 characters
-src/topology/sheaves/sheaf.lean : line 75 : ERR_LIN : Line has more than 100 characters
 src/topology/sheaves/sheaf_of_functions.lean : line 168 : ERR_LIN : Line has more than 100 characters
 src/topology/sheaves/stalks.lean : line 11 : ERR_MOD : Module docstring missing, or too late
 src/topology/sheaves/stalks.lean : line 128 : ERR_LIN : Line has more than 100 characters

--- a/scripts/lint-copy-mod-doc.sh
+++ b/scripts/lint-copy-mod-doc.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# This script can be run locally from the root of mathlib using:
+# scripts/lint-copy-mod-doc.sh
+# to check whether there are any new copyright header / module doc / line length issues
+
 # This is a little wrapper around the python script
 # lint-copy-mod-doc.py
 

--- a/scripts/update-copy-mod-doc-exceptions.sh
+++ b/scripts/update-copy-mod-doc-exceptions.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-# This is a little wrapper around the python script
-# lint-copy-mod-doc.py
+# This script completely regenerates the scripts/copy-mod-doc-exceptions.txt file
+# Typically this should only be run by automation.
+# Human contributors shouldn't need to run this unless they are making changes to the linting script
 
-find src archive -name '*.lean' | xargs ./scripts/lint-copy-mod-doc.py | sort > scripts/copy-mod-doc-exceptions.txt
+# Replace the current exceptions file with an empty file
+> scripts/copy-mod-doc-exceptions.txt
+
+# use C locale so that sorting is the same on macOS and Linux
+# see https://unix.stackexchange.com/questions/362728/why-does-gnu-sort-sort-differently-on-my-osx-machine-and-linux-machine
+LC_ALL=C find src archive -name '*.lean' | xargs ./scripts/lint-copy-mod-doc.py | sort > scripts/copy-mod-doc-exceptions.txt


### PR DESCRIPTION
Followup to #4486:
- run the linter in a separate parallel job, per request
- the update-*.sh script now correctly generates a full exceptions file
- add some more comments to the shell scripts

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
