### PR TITLE
[Merged by Bors] - doc(tactic/slim_check): improve advice in error message

### DIFF
--- a/src/tactic/slim_check.lean
+++ b/src/tactic/slim_check.lean
@@ -200,9 +200,9 @@ meta def slim_check (cfg : slim_check_cfg := {}) : tactic unit := do
   inst ← mk_app ``testable [tgt'] >>= mk_instance <|>
     fail!"Failed to create a `testable` instance for `{tgt}`.
 What to do:
-1. make sure that the types you are using have `sampleable` instances (you can use `#sample my_type` if you are unsure);
+1. make sure that the types you are using have `slim_check.sampleable` instances (you can use `#sample my_type` if you are unsure);
 2. make sure that the relations and predicates that your proposition use are decidable;
-3. make sure that instances of `testable` exist that, when combined, apply to your decorated proposition:
+3. make sure that instances of `slim_check.testable` exist that, when combined, apply to your decorated proposition:
 ```
 {tgt'}
 ```
@@ -211,7 +211,7 @@ Use `set_option trace.class_instances true` to understand what instances are mis
 
 Try this:
 set_option trace.class_instances true
-#check (by apply_instance : testable ({tgt'}))",
+#check (by apply_instance : slim_check.testable ({tgt'}))",
   e ← mk_mapp ``testable.check [tgt, `(cfg), tgt', inst],
   when_tracing `slim_check.decoration trace!"[testable decoration]\n  {tgt'}",
   when_tracing `slim_check.instance   $ do


### PR DESCRIPTION
The error message in `slim_check` suggests to look for `testable` and it now specifies which namespace to find `testable` in.

---

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/slim_check/near/212631821)