### PR TITLE
[Merged by Bors] - refactor(category_theory/pairwise): change direction of morphisms in the category of pairwise intersections

### DIFF
--- a/src/category_theory/category/pairwise.lean
+++ b/src/category_theory/category/pairwise.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 
-import topology.sheaves.sheaf
 import category_theory.limits.preserves.basic
+import category_theory.limits.lattice
 
 /-!
 # The category of "pairwise intersections".
@@ -13,22 +13,19 @@ import category_theory.limits.preserves.basic
 Given `ι : Type v`, we build the diagram category `pairwise ι`
 with objects `single i` and `pair i j`, for `i j : ι`,
 whose only non-identity morphisms are
-`left : single i ⟶ pair i j` and `right : single j ⟶ pair i j`.
+`left : pair i j ⟶ single i` and `right : pair i j ⟶ single j`.
 
-We use this later in describing the sheaf condition.
+We use this later in describing (one formulation of) the sheaf condition.
 
-Given any function `U : ι → α`, where `α` is some complete lattice (e.g. `opens X`),
-we produce a functor `pairwise ι ⥤ αᵒᵖ` in the obvious way,
-and show that `supr U` provides a limit cone over this functor.
+Given any function `U : ι → α`, where `α` is some complete lattice (e.g. `(opens X)ᵒᵖ`),
+we produce a functor `pairwise ι ⥤ α` in the obvious way,
+and show that `supr U` provides a colimit cocone over this functor.
 -/
 
 noncomputable theory
 
 universes v u
 
-open topological_space
-open Top
-open opposite
 open category_theory
 open category_theory.limits
 
@@ -55,8 +52,8 @@ Morphisms in the category `pairwise ι`. The only non-identity morphisms are
 inductive hom : pairwise ι → pairwise ι → Type v
 | id_single : Π i, hom (single i) (single i)
 | id_pair : Π i j, hom (pair i j) (pair i j)
-| left : Π i j, hom (single i) (pair i j)
-| right : Π i j, hom (single j) (pair i j)
+| left : Π i j, hom (pair i j) (single i)
+| right : Π i j, hom (pair i j) (single j)
 
 open hom
 
@@ -74,8 +71,8 @@ def id : Π (o : pairwise ι), hom o o
 def comp : Π {o₁ o₂ o₃ : pairwise ι} (f : hom o₁ o₂) (g : hom o₂ o₃), hom o₁ o₃
 | _ _ _ (id_single i) g := g
 | _ _ _ (id_pair i j) g := g
-| _ _ _ (left i j) (id_pair _ _) := left i j
-| _ _ _ (right i j) (id_pair _ _) := right i j
+| _ _ _ (left i j) (id_single _) := left i j
+| _ _ _ (right i j) (id_single _) := right i j
 
 section
 local attribute [tidy] tactic.case_bash
@@ -94,25 +91,25 @@ variables [semilattice_inf α]
 
 /-- Auxilliary definition for `diagram`. -/
 @[simp]
-def diagram_obj : pairwise ι → αᵒᵖ
-| (single i) := op (U i)
-| (pair i j) := op (U i ⊓ U j)
+def diagram_obj : pairwise ι → α
+| (single i) := U i
+| (pair i j) := U i ⊓ U j
 
 /-- Auxilliary definition for `diagram`. -/
 @[simp]
 def diagram_map : Π {o₁ o₂ : pairwise ι} (f : o₁ ⟶ o₂), diagram_obj U o₁ ⟶ diagram_obj U o₂
 | _ _ (id_single i) := 𝟙 _
 | _ _ (id_pair i j) := 𝟙 _
-| _ _ (left i j) := (hom_of_le inf_le_left).op
-| _ _ (right i j) := (hom_of_le inf_le_right).op
+| _ _ (left i j) := hom_of_le inf_le_left
+| _ _ (right i j) := hom_of_le inf_le_right
 
 /--
-Given a function `U : ι → α` for `[semilattice_inf α]`, we obtain a functor `pairwise ι ⥤ αᵒᵖ`,
-sending `single i` to `op (U i)` and `pair i j` to `op (U i ⊓ U j)`,
+Given a function `U : ι → α` for `[semilattice_inf α]`, we obtain a functor `pairwise ι ⥤ α`,
+sending `single i` to `U i` and `pair i j` to `U i ⊓ U j`,
 and the morphisms to the obvious inequalities.
 -/
 @[simps]
-def diagram : pairwise ι ⥤ αᵒᵖ :=
+def diagram : pairwise ι ⥤ α :=
 { obj := diagram_obj U,
   map := λ X Y f, diagram_map U f, }
 
@@ -123,30 +120,30 @@ section
 -- but the appropriate structure has not been defined.
 variables [complete_lattice α]
 
-/-- Auxilliary definition for `cone`. -/
-def cone_π_app : Π (o : pairwise ι), op (supr U) ⟶ diagram_obj U o
-| (single i) := (hom_of_le (le_supr _ _)).op
-| (pair i j) := (hom_of_le inf_le_left ≫ hom_of_le (le_supr U i)).op
+/-- Auxilliary definition for `cocone`. -/
+def cocone_ι_app : Π (o : pairwise ι), diagram_obj U o ⟶ supr U
+| (single i) := hom_of_le (le_supr U i)
+| (pair i j) := hom_of_le inf_le_left ≫ hom_of_le (le_supr U i)
 
 /--
 Given a function `U : ι → α` for `[complete_lattice α]`,
-`supr U` provides a cone over `diagram U`.
+`supr U` provides a cocone over `diagram U`.
 -/
 @[simps]
-def cone : cone (diagram U) :=
-{ X := op (supr U),
-  π := { app := cone_π_app U, } }
+def cocone : cocone (diagram U) :=
+{ X := supr U,
+  ι := { app := cocone_ι_app U, } }
 
 /--
 Given a function `U : ι → α` for `[complete_lattice α]`,
-`supr U` provides a limit cone over `diagram U`.
+`infi U` provides a limit cone over `diagram U`.
 -/
-def cone_is_limit : is_limit (cone U) :=
-{ lift := λ s, op_hom_of_le
+def cocone_is_colimit : is_colimit (cocone U) :=
+{ desc := λ s, hom_of_le
   begin
     apply complete_lattice.Sup_le,
     rintros _ ⟨j, rfl⟩,
-    exact le_of_op_hom (s.π.app (single j))
+    exact le_of_hom (s.ι.app (single j))
   end }
 
 end

--- a/src/topology/sheaves/sheaf_condition/pairwise_intersections.lean
+++ b/src/topology/sheaves/sheaf_condition/pairwise_intersections.lean
@@ -36,6 +36,7 @@ universes v u
 
 open topological_space
 open Top
+open opposite
 open category_theory
 open category_theory.limits
 
@@ -50,12 +51,12 @@ An alternative formulation of the sheaf condition
 (which we prove equivalent to the usual one below as
 `sheaf_condition_equiv_sheaf_condition_pairwise_intersections`).
 
-A presheaf is a sheaf if `F` sends the cone `pairwise.cone U` to a limit cone.
-(Recall `pairwise.cone U`, has cone point `supr U`, mapping down to the `U i` and the `U i ⊓ U j`.)
+A presheaf is a sheaf if `F` sends the cone `(pairwise.cocone U).op` to a limit cone.
+(Recall `pairwise.cocone U`, has cone point `supr U`, mapping down to the `U i` and the `U i ⊓ U j`.)
 -/
 @[derive subsingleton, nolint has_inhabited_instance]
 def sheaf_condition_pairwise_intersections (F : presheaf C X) : Type (max u (v+1)) :=
-Π ⦃ι : Type v⦄ (U : ι → opens X), is_limit (F.map_cone (pairwise.cone U))
+Π ⦃ι : Type v⦄ (U : ι → opens X), is_limit (F.map_cone (pairwise.cocone U).op)
 
 /--
 An alternative formulation of the sheaf condition
@@ -69,7 +70,7 @@ A presheaf is a sheaf if `F` preserves the limit of `pairwise.diagram U`.
 @[derive subsingleton, nolint has_inhabited_instance]
 def sheaf_condition_preserves_limit_pairwise_intersections
   (F : presheaf C X) : Type (max u (v+1)) :=
-Π ⦃ι : Type v⦄ (U : ι → opens X), preserves_limit (pairwise.diagram U) F
+Π ⦃ι : Type v⦄ (U : ι → opens X), preserves_limit (pairwise.diagram U).op F
 
 /-!
 The remainder of this file shows that these conditions are equivalent
@@ -86,14 +87,14 @@ open sheaf_condition_equalizer_products
 /-- Implementation of `sheaf_condition_pairwise_intersections.cone_equiv`. -/
 @[simps]
 def cone_equiv_functor_obj (F : presheaf C X)
-  ⦃ι : Type v⦄ (U : ι → opens ↥X) (c : limits.cone (diagram U ⋙ F)) :
+  ⦃ι : Type v⦄ (U : ι → opens ↥X) (c : limits.cone ((diagram U).op ⋙ F)) :
   limits.cone (sheaf_condition_equalizer_products.diagram F U) :=
 { X := c.X,
   π :=
   { app := λ Z,
       walking_parallel_pair.cases_on Z
-        (pi.lift (λ (i : ι), c.π.app (single i)))
-        (pi.lift (λ (b : ι × ι), c.π.app (pair b.1 b.2))),
+        (pi.lift (λ (i : ι), c.π.app (op (single i))))
+        (pi.lift (λ (b : ι × ι), c.π.app (op (pair b.1 b.2)))),
     naturality' := λ Y Z f,
     begin
       cases Y; cases Z; cases f,
@@ -103,12 +104,12 @@ def cone_equiv_functor_obj (F : presheaf C X)
         simp only [limit.lift_π, category.id_comp, fan.mk_π_app], },
       { ext ⟨i, j⟩, dsimp [sheaf_condition_equalizer_products.left_res],
         simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app, category.assoc],
-        have h := c.π.naturality (hom.left i j),
+        have h := c.π.naturality (has_hom.hom.op (hom.left i j)),
         dsimp at h,
         simpa using h, },
       { ext ⟨i, j⟩, dsimp [sheaf_condition_equalizer_products.right_res],
         simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app, category.assoc],
-        have h := c.π.naturality (hom.right i j),
+        have h := c.π.naturality (has_hom.hom.op (hom.right i j)),
         dsimp at h,
         simpa using h,  },
       { ext i, dsimp,
@@ -124,7 +125,7 @@ local attribute [tidy] tactic.case_bash
 @[simps]
 def cone_equiv_functor (F : presheaf C X)
   ⦃ι : Type v⦄ (U : ι → opens ↥X) :
-  limits.cone (diagram U ⋙ F) ⥤ limits.cone (sheaf_condition_equalizer_products.diagram F U) :=
+  limits.cone ((diagram U).op ⋙ F) ⥤ limits.cone (sheaf_condition_equalizer_products.diagram F U) :=
 { obj := λ c, cone_equiv_functor_obj F U c,
   map := λ c c' f,
   { hom := f.hom, }, }.
@@ -135,18 +136,33 @@ end
 @[simps]
 def cone_equiv_inverse_obj (F : presheaf C X)
   ⦃ι : Type v⦄ (U : ι → opens ↥X)
-  (c : limits.cone (sheaf_condition_equalizer_products.diagram F U)) : limits.cone (diagram U ⋙ F) :=
+  (c : limits.cone (sheaf_condition_equalizer_products.diagram F U)) :
+  limits.cone ((diagram U).op ⋙ F) :=
 { X := c.X,
   π :=
   { app :=
     begin
-      rintro (⟨i⟩|⟨i,j⟩),
+      intro x,
+      op_induction x,
+      rcases x with (⟨i⟩|⟨i,j⟩),
       { exact c.π.app (walking_parallel_pair.zero) ≫ pi.π _ i, },
       { exact c.π.app (walking_parallel_pair.one) ≫ pi.π _ (i, j), }
     end,
     naturality' :=
     begin
-      rintro (⟨i⟩|⟨⟩) (⟨⟩|⟨j,j⟩) ⟨⟩,
+      -- Unfortunately `op_induction` isn't up to the task here, and we need to use `generalize`.
+      intros x y f,
+      have ex : x = op (unop x) := rfl,
+      have ey : y = op (unop y) := rfl,
+      revert ex ey,
+      generalize : unop x = x',
+      generalize : unop y = y',
+      rintro rfl rfl,
+      have ef : f = f.unop.op := rfl,
+      revert ef,
+      generalize : f.unop = f',
+      rintro rfl,
+      rcases x' with ⟨i⟩|⟨⟩; rcases y' with ⟨⟩|⟨j,j⟩; rcases f' with ⟨⟩,
       { dsimp, erw [F.map_id], simp, },
       { dsimp, simp only [category.id_comp, category.assoc],
         have h := c.π.naturality (walking_parallel_pair_hom.left),
@@ -171,36 +187,38 @@ def cone_equiv_inverse_obj (F : presheaf C X)
 @[simps]
 def cone_equiv_inverse (F : presheaf C X)
   ⦃ι : Type v⦄ (U : ι → opens ↥X) :
-  limits.cone (sheaf_condition_equalizer_products.diagram F U) ⥤ limits.cone (diagram U ⋙ F) :=
+  limits.cone (sheaf_condition_equalizer_products.diagram F U) ⥤ limits.cone ((diagram U).op ⋙ F) :=
 { obj := λ c, cone_equiv_inverse_obj F U c,
   map := λ c c' f,
   { hom := f.hom,
     w' :=
     begin
-      rintro (⟨i⟩|⟨i,j⟩),
+      intro x,
+      op_induction x,
+      rcases x with (⟨i⟩|⟨i,j⟩),
       { dsimp,
         rw [←(f.w walking_parallel_pair.zero), category.assoc], },
       { dsimp,
         rw [←(f.w walking_parallel_pair.one), category.assoc], },
     end }, }.
 
-section
-local attribute [tidy] tactic.case_bash
-
 /-- Implementation of `sheaf_condition_pairwise_intersections.cone_equiv`. -/
 @[simps]
 def cone_equiv_unit_iso_app (F : presheaf C X) ⦃ι : Type v⦄ (U : ι → opens ↥X)
-  (c : cone (diagram U ⋙ F)) :
-  (𝟭 (cone (diagram U ⋙ F))).obj c ≅
+  (c : cone ((diagram U).op ⋙ F)) :
+  (𝟭 (cone ((diagram U).op ⋙ F))).obj c ≅
     (cone_equiv_functor F U ⋙ cone_equiv_inverse F U).obj c :=
-{ hom := { hom := 𝟙 _ }, inv := { hom := 𝟙 _ }}
-
-end
+{ hom :=
+  { hom := 𝟙 _,
+    w' := λ j, begin op_induction j, rcases j; tidy, end, },
+  inv :=
+  { hom := 𝟙 _,
+    w' := λ j, begin op_induction j, rcases j; tidy, end }}
 
 /-- Implementation of `sheaf_condition_pairwise_intersections.cone_equiv`. -/
 @[simps {rhs_md := semireducible}]
 def cone_equiv_unit_iso (F : presheaf C X) ⦃ι : Type v⦄ (U : ι → opens X) :
-  𝟭 (limits.cone (diagram U ⋙ F)) ≅
+  𝟭 (limits.cone ((diagram U).op ⋙ F)) ≅
     cone_equiv_functor F U ⋙ cone_equiv_inverse F U :=
 nat_iso.of_components (cone_equiv_unit_iso_app F U) (by tidy)
 
@@ -232,7 +250,7 @@ Cones over `diagram U ⋙ F` are the same as a cones over the usual sheaf condit
 -/
 @[simps]
 def cone_equiv (F : presheaf C X) ⦃ι : Type v⦄ (U : ι → opens X) :
-  limits.cone (diagram U ⋙ F) ≌ limits.cone (sheaf_condition_equalizer_products.diagram F U) :=
+  limits.cone ((diagram U).op ⋙ F) ≌ limits.cone (sheaf_condition_equalizer_products.diagram F U) :=
 { functor := cone_equiv_functor F U,
   inverse := cone_equiv_inverse F U,
   unit_iso := cone_equiv_unit_iso F U,
@@ -249,13 +267,15 @@ then `F.map_cone (cone U)` is a limit cone.
 def is_limit_map_cone_of_is_limit_sheaf_condition_fork
   (F : presheaf C X) ⦃ι : Type v⦄ (U : ι → opens X)
   (P : is_limit (sheaf_condition_equalizer_products.fork F U)) :
-  is_limit (F.map_cone (cone U)) :=
+  is_limit (F.map_cone (cocone U).op) :=
 is_limit.of_iso_limit ((is_limit.of_cone_equiv (cone_equiv F U).symm).symm P)
 { hom :=
   { hom := 𝟙 _,
     w' :=
     begin
-      rintro ⟨⟩,
+      intro x,
+      op_induction x,
+      rcases x with ⟨⟩,
       { dsimp, simp, refl, },
       { dsimp,
         simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app, category.assoc],
@@ -266,7 +286,9 @@ is_limit.of_iso_limit ((is_limit.of_cone_equiv (cone_equiv F U).symm).symm P)
   { hom := 𝟙 _,
     w' :=
     begin
-      rintro ⟨⟩,
+      intro x,
+      op_induction x,
+      rcases x with ⟨⟩,
       { dsimp, simp, refl, },
       { dsimp,
         simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app, category.assoc],
@@ -280,7 +302,7 @@ then `sheaf_condition_equalizer_products.fork` is an equalizer.
 -/
 def is_limit_sheaf_condition_fork_of_is_limit_map_cone
   (F : presheaf C X) ⦃ι : Type v⦄ (U : ι → opens X)
-  (Q : is_limit (F.map_cone (cone U))) :
+  (Q : is_limit (F.map_cone (cocone U).op)) :
   is_limit (sheaf_condition_equalizer_products.fork F U) :=
 is_limit.of_iso_limit ((is_limit.of_cone_equiv (cone_equiv F U)).symm Q)
 { hom :=
@@ -334,7 +356,7 @@ equiv.trans
   (sheaf_condition_equiv_sheaf_condition_pairwise_intersections F)
   (equiv.Pi_congr_right (λ i, equiv.Pi_congr_right (λ U,
      equiv_of_subsingleton_of_subsingleton
-       (λ P, preserves_limit_of_preserves_limit_cone (pairwise.cone_is_limit U) P)
-       (by { introI, exact preserves_limit.preserves (pairwise.cone_is_limit U) }))))
+       (λ P, preserves_limit_of_preserves_limit_cone (pairwise.cocone_is_colimit U).op P)
+       (by { introI, exact preserves_limit.preserves (pairwise.cocone_is_colimit U).op }))))
 
 end Top.presheaf


### PR DESCRIPTION
Even though this makes some proofs slightly more awkward, this is the more natural definition.

In a subsequent PR about another equivalent sheaf condition, it also makes proofs less awkward, too!

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
