### PR TITLE
[Merged by Bors] - feat(archive/100-theorems-list/70_perfect_numbers): Direction 1 of the Perfect Number Theorem

### DIFF
--- a/archive/100-theorems-list/70_perfect_numbers.lean
+++ b/archive/100-theorems-list/70_perfect_numbers.lean
@@ -52,7 +52,9 @@ begin
     is_multiplicative_sigma.map_mul_of_coprime
         (nat.prime_two.coprime_pow_of_not_dvd (odd_mersenne_succ _)),
     sigma_two_pow_eq_mersenne_succ],
-  simp [pr, nat.prime_two]
+  { simp [pr, nat.prime_two] },
+  { apply mul_pos (pow_pos _ k) (mersenne_pos (nat.succ_pos k)),
+    norm_num }
 end
 
 lemma ne_zero_of_mersenne_of_prime (k : ℕ) (pr : (mersenne (k + 1)).prime) :

--- a/archive/100-theorems-list/70_perfect_numbers.lean
+++ b/archive/100-theorems-list/70_perfect_numbers.lean
@@ -6,6 +6,7 @@ Author: Aaron Anderson.
 
 import number_theory.arithmetic_function
 import number_theory.lucas_lehmer
+import algebra.geom_sum
 
 /-!
 # Perfect Numbers
@@ -28,33 +29,20 @@ https://en.wikipedia.org/wiki/Euclid%E2%80%93Euler_theorem
 @[simp]
 lemma succ_mersenne (k : ℕ) : mersenne k + 1 = 2 ^ k :=
 begin
-  rw [mersenne, ← nat.succ_eq_add_one, ← nat.pred_eq_sub_one, nat.succ_pred_eq_of_pos],
-  apply pow_pos,
-  dec_trivial,
+  rw [mersenne, nat.sub_add_cancel],
+  exact one_le_pow_of_one_le (by norm_num) k
 end
 
 lemma odd_mersenne_succ (k : ℕ) : ¬ 2 ∣ mersenne (k + 1) :=
-begin
-  rw [← even_iff_two_dvd, ← nat.even_succ, nat.succ_eq_add_one, succ_mersenne,
-    even_iff_two_dvd, pow_succ],
-  apply dvd.intro _ rfl,
-end
+by simp [← even_iff_two_dvd, ← nat.even_succ, nat.succ_eq_add_one] with parity_simps
 
 namespace nat
 open arithmetic_function finset
 open_locale arithmetic_function
 
 lemma sigma_two_pow_eq_mersenne_succ (k : ℕ) : σ 1 (2 ^ k) = mersenne (k + 1) :=
-begin
-  simp only [mersenne, prime_two, divisors_prime_pow, sum_map, function.embedding.coe_fn_mk,
-    pow_one, sigma_apply],
-  induction k,
-  { simp },
-  rw [pow_succ, sum_range_succ, two_mul, k_ih, nat.add_sub_assoc],
-  rw nat.succ_le_iff,
-  apply pow_pos,
-  dec_trivial,
-end
+by simpa [mersenne, prime_two, ← geom_sum_mul_add 1 (k+1)]
+
 
 /-- Euclid's theorem that Mersenne primes induce perfect numbers -/
 theorem perfect_two_pow_mul_mersenne_of_prime (k : ℕ) (pr : (mersenne (k + 1)).prime) :
@@ -67,15 +55,15 @@ begin
   simp [pr, nat.prime_two]
 end
 
+lemma ne_zero_of_mersenne_of_prime (k : ℕ) (pr : (mersenne (k + 1)).prime) :
+  k ≠ 0 :=
+begin
+  rintro rfl,
+  simpa [mersenne, not_prime_one] using pr,
+end
+
 theorem even_two_pow_mul_mersenne_of_prime (k : ℕ) (pr : (mersenne (k + 1)).prime) :
   even ((2 ^ k) * mersenne (k + 1)) :=
-begin
-  simp only [true_and, even_zero, not_true, ne.def, not_false_iff] with parity_simps,
-  left,
-  rintro rfl,
-  apply nat.not_prime_one,
-  revert pr,
-  simp [mersenne],
-end
+by simp [ne_zero_of_mersenne_of_prime k pr] with parity_simps
 
 end nat

--- a/archive/100-theorems-list/70_perfect_numbers.lean
+++ b/archive/100-theorems-list/70_perfect_numbers.lean
@@ -26,13 +26,6 @@ Euler proved the converse, that if `n` is even and perfect, then there exists `k
 https://en.wikipedia.org/wiki/Euclid%E2%80%93Euler_theorem
 -/
 
-@[simp]
-lemma succ_mersenne (k : ℕ) : mersenne k + 1 = 2 ^ k :=
-begin
-  rw [mersenne, nat.sub_add_cancel],
-  exact one_le_pow_of_one_le (by norm_num) k
-end
-
 lemma odd_mersenne_succ (k : ℕ) : ¬ 2 ∣ mersenne (k + 1) :=
 by simp [← even_iff_two_dvd, ← nat.even_succ, nat.succ_eq_add_one] with parity_simps
 
@@ -57,7 +50,7 @@ begin
     norm_num }
 end
 
-lemma ne_zero_of_mersenne_of_prime (k : ℕ) (pr : (mersenne (k + 1)).prime) :
+lemma ne_zero_of_prime_mersenne (k : ℕ) (pr : (mersenne (k + 1)).prime) :
   k ≠ 0 :=
 begin
   rintro rfl,
@@ -66,6 +59,6 @@ end
 
 theorem even_two_pow_mul_mersenne_of_prime (k : ℕ) (pr : (mersenne (k + 1)).prime) :
   even ((2 ^ k) * mersenne (k + 1)) :=
-by simp [ne_zero_of_mersenne_of_prime k pr] with parity_simps
+by simp [ne_zero_of_prime_mersenne k pr] with parity_simps
 
 end nat

--- a/archive/100-theorems-list/70_perfect_numbers.lean
+++ b/archive/100-theorems-list/70_perfect_numbers.lean
@@ -7,7 +7,7 @@ Author: Aaron Anderson.
 import number_theory.arithmetic_function
 import number_theory.lucas_lehmer
 
-/-
+/-!
 # Perfect Numbers
 
 This file proves (currently one direction of)

--- a/archive/100-theorems-list/70_perfect_numbers.lean
+++ b/archive/100-theorems-list/70_perfect_numbers.lean
@@ -35,12 +35,9 @@ end
 
 lemma odd_mersenne_succ (k : ℕ) : ¬ 2 ∣ mersenne (k + 1) :=
 begin
-  rw [mersenne, ← even_iff_two_dvd, nat.even_sub],
-  { simp [pow_succ, even_iff_two_dvd],
-    dec_trivial },
-  { rw nat.succ_le_iff,
-    apply pow_pos,
-    dec_trivial }
+  rw [← even_iff_two_dvd, ← nat.even_succ, nat.succ_eq_add_one, succ_mersenne,
+    even_iff_two_dvd, pow_succ],
+  apply dvd.intro _ rfl,
 end
 
 namespace nat

--- a/archive/100-theorems-list/70_perfect_numbers.lean
+++ b/archive/100-theorems-list/70_perfect_numbers.lean
@@ -67,4 +67,15 @@ begin
   simp [pr, nat.prime_two]
 end
 
+theorem even_two_pow_mul_mersenne_of_prime (k : ℕ) (pr : (mersenne (k + 1)).prime) :
+  even ((2 ^ k) * mersenne (k + 1)) :=
+begin
+  simp only [true_and, even_zero, not_true, ne.def, not_false_iff] with parity_simps,
+  left,
+  rintro rfl,
+  apply nat.not_prime_one,
+  revert pr,
+  simp [mersenne],
+end
+
 end nat

--- a/archive/100-theorems-list/70_perfect_numbers.lean
+++ b/archive/100-theorems-list/70_perfect_numbers.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2020 Aaron Anderson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Aaron Anderson.
+-/
+
+import number_theory.arithmetic_function
+import number_theory.lucas_lehmer
+
+/-
+# Perfect Numbers
+
+This file proves (currently one direction of)
+  Theorem 70 from the [100 Theorems List](https://www.cs.ru.nl/~freek/100/).
+
+The theorem characterizes even perfect numbers.
+
+Euclid proved that if `2 ^ (k + 1) - 1` is prime (these primes are known as Mersenne primes),
+  then `2 ^ k * 2 ^ (k + 1) - 1` is perfect.
+
+Euler proved the converse, that if `n` is even and perfect, then there exists `k` such that
+  `n = 2 ^ k * 2 ^ (k + 1) - 1` and `2 ^ (k + 1) - 1` is prime.
+
+## References
+https://en.wikipedia.org/wiki/Euclid%E2%80%93Euler_theorem
+-/
+
+@[simp]
+lemma succ_mersenne (k : ℕ) : mersenne k + 1 = 2 ^ k :=
+begin
+  rw [mersenne, ← nat.succ_eq_add_one, ← nat.pred_eq_sub_one, nat.succ_pred_eq_of_pos],
+  apply pow_pos,
+  dec_trivial,
+end
+
+lemma odd_mersenne_succ (k : ℕ) : ¬ 2 ∣ mersenne (k + 1) :=
+begin
+  rw [mersenne, ← even_iff_two_dvd, nat.even_sub],
+  { simp [pow_succ, even_iff_two_dvd],
+    dec_trivial },
+  { rw nat.succ_le_iff,
+    apply pow_pos,
+    dec_trivial }
+end
+
+namespace nat
+open arithmetic_function finset
+open_locale arithmetic_function
+
+lemma sigma_two_pow_eq_mersenne_succ (k : ℕ) : σ 1 (2 ^ k) = mersenne (k + 1) :=
+begin
+  simp only [mersenne, prime_two, divisors_prime_pow, sum_map, function.embedding.coe_fn_mk,
+    pow_one, sigma_apply],
+  induction k,
+  { simp },
+  rw [pow_succ, sum_range_succ, two_mul, k_ih, nat.add_sub_assoc],
+  rw nat.succ_le_iff,
+  apply pow_pos,
+  dec_trivial,
+end
+
+/-- Euclid's theorem that Mersenne primes induce perfect numbers -/
+theorem perfect_two_pow_mul_mersenne_of_prime (k : ℕ) (pr : (mersenne (k + 1)).prime) :
+  perfect ((2 ^ k) * mersenne (k + 1)) :=
+begin
+  rw [perfect_iff_sum_divisors_eq_two_mul, ← mul_assoc, ← pow_succ, ← sigma_one_apply, mul_comm,
+    is_multiplicative_sigma.map_mul_of_coprime
+        (nat.prime_two.coprime_pow_of_not_dvd (odd_mersenne_succ _)),
+    sigma_two_pow_eq_mersenne_succ],
+  simp [pr, nat.prime_two]
+end
+
+end nat

--- a/src/number_theory/arithmetic_function.lean
+++ b/src/number_theory/arithmetic_function.lean
@@ -498,6 +498,17 @@ localized "notation `σ` := sigma" in arithmetic_function
 @[simp]
 lemma sigma_apply {k n : ℕ} : σ k n = ∑ d in divisors n, d ^ k := rfl
 
+lemma sigma_one_apply {n : ℕ} : σ 1 n = ∑ d in divisors n, d := by simp
+
+@[simp]
+lemma sigma_apply_of_prime {k p : ℕ} (h : p.prime) : σ k p = p ^ k + 1 :=
+begin
+  simp only [h, divisors_prime, sigma_apply],
+  rw [sum_insert, sum_singleton, one_pow, add_comm],
+  rw mem_singleton,
+  apply h.ne_one.symm,
+end
+
 lemma zeta_mul_pow_eq_sigma {k : ℕ} : ζ * pow k = σ k :=
 begin
   ext,

--- a/src/number_theory/arithmetic_function.lean
+++ b/src/number_theory/arithmetic_function.lean
@@ -500,15 +500,6 @@ lemma sigma_apply {k n : ℕ} : σ k n = ∑ d in divisors n, d ^ k := rfl
 
 lemma sigma_one_apply {n : ℕ} : σ 1 n = ∑ d in divisors n, d := by simp
 
-@[simp]
-lemma sigma_apply_of_prime {k p : ℕ} (h : p.prime) : σ k p = p ^ k + 1 :=
-begin
-  simp only [h, divisors_prime, sigma_apply],
-  rw [sum_insert, sum_singleton, one_pow, add_comm],
-  rw mem_singleton,
-  apply h.ne_one.symm,
-end
-
 lemma zeta_mul_pow_eq_sigma {k : ℕ} : ζ * pow k = σ k :=
 begin
   ext,

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -201,12 +201,10 @@ begin
   { apply add_right_cancel h }
 end
 
-@[simp]
 lemma mem_divisors_prime_pow {p : ℕ} (pp : p.prime) (k : ℕ) {x : ℕ} :
   x ∈ divisors (p ^ k) ↔  ∃ (j : ℕ) (H : j ≤ k), x = p ^ j :=
 by rw [mem_divisors, nat.dvd_prime_pow pp, and_iff_left (ne_of_gt (pow_pos pp.pos k))]
 
-@[simp]
 lemma divisors_prime {p : ℕ} (pp : p.prime) :
   divisors p = {1 , p} :=
 begin
@@ -218,10 +216,24 @@ begin
   apply one_dvd,
 end
 
-@[simp]
 lemma divisors_prime_pow {p : ℕ} (pp : p.prime) (k : ℕ) :
   divisors (p ^ k) = (finset.range (k + 1)).map ⟨pow p, pow_right_injective pp.two_le⟩ :=
-by { ext, simp [pp, nat.lt_succ_iff, @eq_comm _ a] }
+by { ext, simp [mem_divisors_prime_pow, pp, nat.lt_succ_iff, @eq_comm _ a] }
 
+open finset
+@[simp]
+lemma sum_divisors_prime {α : Type*} [add_comm_monoid α] {p : ℕ} {f : ℕ → α} (h : p.prime) :
+  ∑ x in p.divisors, f x = f p + f 1 :=
+begin
+  simp only [h, divisors_prime],
+  rw [sum_insert, sum_singleton, add_comm],
+  rw mem_singleton,
+  apply h.ne_one.symm,
+end
+
+@[simp]
+lemma sum_divisors_prime_pow {α : Type*} [add_comm_monoid α] {k p : ℕ} {f : ℕ → α} (h : p.prime) :
+  ∑ x in (p ^ k).divisors, f x = ∑ x in range (k + 1), f (p ^ x) :=
+by simp [h, divisors_prime_pow]
 
 end nat

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -20,7 +20,7 @@ Let `n : ℕ`. All of the following definitions are in the `nat` namespace:
  * `perfect n` is true when the sum of `proper_divisors n` is `n`.
 
 ## Implementation details
- * `divisors 0` , `proper_divisors 0`, and `divisors_antidiagonal 0` are defined to be `∅`.
+ * `divisors 0`, `proper_divisors 0`, and `divisors_antidiagonal 0` are defined to be `∅`.
 
 ## Tags
 divisors, perfect numbers
@@ -202,11 +202,11 @@ begin
 end
 
 lemma mem_divisors_prime_pow {p : ℕ} (pp : p.prime) (k : ℕ) {x : ℕ} :
-  x ∈ divisors (p ^ k) ↔  ∃ (j : ℕ) (H : j ≤ k), x = p ^ j :=
+  x ∈ divisors (p ^ k) ↔ ∃ (j : ℕ) (H : j ≤ k), x = p ^ j :=
 by rw [mem_divisors, nat.dvd_prime_pow pp, and_iff_left (ne_of_gt (pow_pos pp.pos k))]
 
 lemma divisors_prime {p : ℕ} (pp : p.prime) :
-  divisors p = {1 , p} :=
+  divisors p = {1, p} :=
 begin
   ext,
   simp only [pp.ne_zero, and_true, ne.def, not_false_iff, finset.mem_insert,
@@ -221,6 +221,7 @@ lemma divisors_prime_pow {p : ℕ} (pp : p.prime) (k : ℕ) :
 by { ext, simp [mem_divisors_prime_pow, pp, nat.lt_succ_iff, @eq_comm _ a] }
 
 open finset
+
 @[simp]
 lemma sum_divisors_prime {α : Type*} [add_comm_monoid α] {p : ℕ} {f : ℕ → α} (h : p.prime) :
   ∑ x in p.divisors, f x = f p + f 1 :=

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -233,8 +233,18 @@ begin
 end
 
 @[simp]
+lemma prod_divisors_prime {α : Type*} [comm_monoid α] {p : ℕ} {f : ℕ → α} (h : p.prime) :
+  ∏ x in p.divisors, f x = f p * f 1 :=
+@sum_divisors_prime (additive α) _ _ _ h
+
+@[simp]
 lemma sum_divisors_prime_pow {α : Type*} [add_comm_monoid α] {k p : ℕ} {f : ℕ → α} (h : p.prime) :
   ∑ x in (p ^ k).divisors, f x = ∑ x in range (k + 1), f (p ^ x) :=
 by simp [h, divisors_prime_pow]
+
+@[simp]
+lemma prod_divisors_prime_pow {α : Type*} [comm_monoid α] {k p : ℕ} {f : ℕ → α} (h : p.prime) :
+  ∏ x in (p ^ k).divisors, f x = ∏ x in range (k + 1), f (p ^ x) :=
+@sum_divisors_prime_pow (additive α) _ _ _ _ h
 
 end nat

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -17,7 +17,7 @@ Let `n : ℕ`. All of the following definitions are in the `nat` namespace:
  * `divisors n` is the `finset` of natural numbers that divide `n`.
  * `proper_divisors n` is the `finset` of natural numbers that divide `n`, other than `n`.
  * `divisors_antidiagonal n` is the `finset` of pairs `(x,y)` such that `x * y = n`.
- * `perfect n` is true when the sum of `proper_divisors n` is `n`.
+ * `perfect n` is true when `n` is positive and the sum of `proper_divisors n` is `n`.
 
 ## Implementation details
  * `divisors 0`, `proper_divisors 0`, and `divisors_antidiagonal 0` are defined to be `∅`.
@@ -186,16 +186,17 @@ begin
         finset.sum_insert (proper_divisors.not_self_mem), add_comm] }
 end
 
-/-- `n : ℕ` is perfect if and only the sum of the proper divisors of `n` is `n`. -/
-def perfect (n : ℕ) : Prop := ∑ i in proper_divisors n, i = n
+/-- `n : ℕ` is perfect if and only the sum of the proper divisors of `n` is `n` and `n`
+  is positive. -/
+def perfect (n : ℕ) : Prop := (∑ i in proper_divisors n, i = n) ∧ 0 < n
 
-theorem perfect_iff_sum_proper_divisors {n : ℕ} :
-  perfect n ↔ ∑ i in proper_divisors n, i = n := iff.rfl
+theorem perfect_iff_sum_proper_divisors {n : ℕ} (h : 0 < n) :
+  perfect n ↔ ∑ i in proper_divisors n, i = n := and_iff_left h
 
-theorem perfect_iff_sum_divisors_eq_two_mul {n : ℕ} :
+theorem perfect_iff_sum_divisors_eq_two_mul {n : ℕ} (h : 0 < n) :
   perfect n ↔ ∑ i in divisors n, i = 2 * n :=
 begin
-  rw [perfect, sum_divisors_eq_sum_proper_divisors_add_self, two_mul],
+  rw [perfect_iff_sum_proper_divisors h, sum_divisors_eq_sum_proper_divisors_add_self, two_mul],
   split; intro h,
   { rw h },
   { apply add_right_cancel h }

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -20,8 +20,7 @@ Let `n : ℕ`. All of the following definitions are in the `nat` namespace:
  * `perfect n` is true when the sum of `proper_divisors n` is `n`.
 
 ## Implementation details
- * `divisors 0` is defined to be `{0}`, while
-`proper_divisors 0`, and `divisors_antidiagonal 0` are defined to be `∅`.
+ * `divisors 0` , `proper_divisors 0`, and `divisors_antidiagonal 0` are defined to be `∅`.
 
 ## Tags
 divisors, perfect numbers
@@ -34,7 +33,7 @@ open_locale big_operators
 namespace nat
 variable (n : ℕ)
 
-/-- `divisors n` is the `finset` of divisors of `n`. As a special case, `divisors 0 = {0}`. -/
+/-- `divisors n` is the `finset` of divisors of `n`. As a special case, `divisors 0 = ∅`. -/
 def divisors : finset ℕ := finset.filter (λ x : ℕ, x ∣ n) (finset.Ico 1 (n + 1))
 
 /-- `proper_divisors n` is the `finset` of divisors of `n`, other than `n`.
@@ -201,5 +200,28 @@ begin
   { rw h },
   { apply add_right_cancel h }
 end
+
+@[simp]
+lemma mem_divisors_prime_pow {p : ℕ} (pp : p.prime) (k : ℕ) {x : ℕ} :
+  x ∈ divisors (p ^ k) ↔  ∃ (j : ℕ) (H : j ≤ k), x = p ^ j :=
+by rw [mem_divisors, nat.dvd_prime_pow pp, and_iff_left (ne_of_gt (pow_pos pp.pos k))]
+
+@[simp]
+lemma divisors_prime {p : ℕ} (pp : p.prime) :
+  divisors p = {1 , p} :=
+begin
+  ext,
+  simp only [pp.ne_zero, and_true, ne.def, not_false_iff, finset.mem_insert,
+    finset.mem_singleton, mem_divisors],
+  refine ⟨pp.2 a, λ h, _⟩,
+  rcases h; subst h,
+  apply one_dvd,
+end
+
+@[simp]
+lemma divisors_prime_pow {p : ℕ} (pp : p.prime) (k : ℕ) :
+  divisors (p ^ k) = (finset.range (k + 1)).map ⟨pow p, pow_right_injective pp.two_le⟩ :=
+by { ext, simp [pp, nat.lt_succ_iff, @eq_comm _ a] }
+
 
 end nat

--- a/src/number_theory/lucas_lehmer.lean
+++ b/src/number_theory/lucas_lehmer.lean
@@ -47,6 +47,13 @@ begin
      ... ≤ 2^p - 1 : nat.pred_le_pred (nat.pow_le_pow_of_le_right (nat.succ_pos 1) h)
 end
 
+@[simp]
+lemma succ_mersenne (k : ℕ) : mersenne k + 1 = 2 ^ k :=
+begin
+  rw [mersenne, nat.sub_add_cancel],
+  exact one_le_pow_of_one_le (by norm_num) k
+end
+
 namespace lucas_lehmer
 
 open nat


### PR DESCRIPTION
Proves Euclid's half of the Euclid-Euler Theorem that if `2 ^ (k + 1) - 1` is prime, then `2 ^ k * (2 ^ (k + 1) - 1)` is an (even) perfect number.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
