### PR TITLE
[Merged by Bors] - chore(algebra/algebra/basic): fix definition of `ring_hom.to_algebra`

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -60,12 +60,17 @@ def ring_hom.to_algebra' {R S} [comm_semiring R] [semiring S] (i : R →+* S)
 { smul := λ c x, i c * x,
   commutes' := h,
   smul_def' := λ c x, rfl,
-  .. i}
+  to_ring_hom := i}
 
 /-- Creating an algebra from a morphism to a commutative semiring. -/
 def ring_hom.to_algebra {R S} [comm_semiring R] [comm_semiring S] (i : R →+* S) :
   algebra R S :=
 i.to_algebra' $ λ _, mul_comm _
+
+@[simp] lemma ring_hom.algebra_map_to_algebra {R S} [comm_semiring R] [comm_semiring S]
+  (i : R →+* S) :
+  @algebra_map R S _ _ i.to_algebra = i :=
+rfl
 
 namespace algebra
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -67,7 +67,7 @@ def ring_hom.to_algebra {R S} [comm_semiring R] [comm_semiring S] (i : R →+* S
   algebra R S :=
 i.to_algebra' $ λ _, mul_comm _
 
-@[simp] lemma ring_hom.algebra_map_to_algebra {R S} [comm_semiring R] [comm_semiring S]
+lemma ring_hom.algebra_map_to_algebra {R S} [comm_semiring R] [comm_semiring S]
   (i : R →+* S) :
   @algebra_map R S _ _ i.to_algebra = i :=
 rfl


### PR DESCRIPTION
The new definition uses `to_ring_hom := i` instead of `.. i` to get
defeq `algebra_map R S = i`, and adds it as a lemma.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->