### PR TITLE
[Merged by Bors] -  chore(data/finsupp): replace `eq_zero_of_zero_eq_one` with `finsupp.unique_of_right`

### DIFF
--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -225,6 +225,9 @@ a two-sided additive inverse. The actual definition says that `a` is equal to so
 `u : add_units M`, where `add_units M` is a bundled version of `is_add_unit`."]
 def is_unit [monoid M] (a : M) : Prop := ∃ u : units M, (u : M) = a
 
+lemma is_unit_of_subsingleton [monoid M] [subsingleton M] (a : M) : is_unit a :=
+⟨⟨a, a, subsingleton.elim _ _, subsingleton.elim _ _⟩, rfl⟩
+
 @[simp, to_additive is_add_unit_add_unit]
 lemma is_unit_unit [monoid M] (u : units M) : is_unit (u : M) := ⟨u, rfl⟩
 

--- a/src/algebra/group_with_zero.lean
+++ b/src/algebra/group_with_zero.lean
@@ -90,6 +90,10 @@ lemma right_ne_zero_of_mul : a * b ≠ 0 → b ≠ 0 := mt (mul_eq_zero_of_right
 lemma ne_zero_and_ne_zero_of_mul (h : a * b ≠ 0) : a ≠ 0 ∧ b ≠ 0 :=
 ⟨left_ne_zero_of_mul h, right_ne_zero_of_mul h⟩
 
+lemma mul_eq_zero_of_ne_zero_imp_eq_zero {a b : M₀} (h : a ≠ 0 → b = 0) :
+  a * b = 0 :=
+if ha : a = 0 then by rw [ha, zero_mul] else by rw [h ha, mul_zero]
+
 end mul_zero_class
 
 /-- Predicate typeclass for expressing that `a * b = 0` implies `a = 0` or `b = 0`
@@ -309,23 +313,21 @@ All other elements will be provably equal to it, but not necessarily definitiona
 def unique_of_zero_eq_one (h : (0 : M₀) = 1) : unique M₀ :=
 { default := 0, uniq := eq_zero_of_zero_eq_one h }
 
-/-- In a monoid with zero, if zero equals one, then all elements of that semiring are equal. -/
-theorem subsingleton_of_zero_eq_one (h : (0 : M₀) = 1) : subsingleton M₀ :=
-@unique.subsingleton _ (unique_of_zero_eq_one h)
+/-- In a monoid with zero, zero equals one if and only if all elements of that semiring are equal. -/
+theorem subsingleton_iff_zero_eq_one : (0 : M₀) = 1 ↔ subsingleton M₀ :=
+⟨λ h, @unique.subsingleton _ (unique_of_zero_eq_one h), λ h, @subsingleton.elim _ h _ _⟩
+
+alias subsingleton_iff_zero_eq_one ↔ subsingleton_of_zero_eq_one _
 
 lemma eq_of_zero_eq_one (h : (0 : M₀) = 1) (a b : M₀) : a = b :=
 @subsingleton.elim _ (subsingleton_of_zero_eq_one h) a b
 
 @[simp] theorem is_unit_zero_iff : is_unit (0 : M₀) ↔ (0:M₀) = 1 :=
 ⟨λ ⟨⟨_, a, (a0 : 0 * a = 1), _⟩, rfl⟩, by rwa zero_mul at a0,
- λ h, ⟨⟨0, 0, eq_of_zero_eq_one h _ _, eq_of_zero_eq_one h _ _⟩, rfl⟩⟩
+ λ h, @is_unit_of_subsingleton _ _ (subsingleton_of_zero_eq_one h) 0⟩
 
 @[simp] theorem not_is_unit_zero [nontrivial M₀] : ¬ is_unit (0 : M₀) :=
 mt is_unit_zero_iff.1 zero_ne_one
-
-lemma mul_eq_zero_of_ne_zero_imp_eq_zero {a b : M₀} (h : a ≠ 0 → b = 0) :
-  a * b = 0 :=
-if ha : a = 0 then by rw [ha, zero_mul] else by rw [h ha, mul_zero]
 
 variable (M₀)
 

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -209,6 +209,13 @@ theorem smul_eq_zero {R E : Type*} [division_ring R] [add_comm_group E] [module 
 
 end module
 
+/-- A semimodule over a `subsingleton` semiring is a `subsingleton`. We cannot register this
+as an instance because Lean has no way to guess `R`. -/
+theorem semimodule.subsingleton (R M : Type*) [semiring R] [subsingleton R] [add_comm_monoid M]
+  [semimodule R M] :
+  subsingleton M :=
+⟨λ x y, by rw [← one_smul R x, ← one_smul R y, subsingleton.elim (1:R) 0, zero_smul, zero_smul]⟩
+
 @[priority 910] -- see Note [lower instance priority]
 instance semiring.to_semimodule [semiring R] : semimodule R R :=
 { smul := (*),

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1563,9 +1563,9 @@ lemma mul_sum (b : γ) (s : α →₀ β) {f : α → β → γ} :
   b * (s.sum f) = s.sum (λ a c, b * (f a c)) :=
 by simp only [finsupp.sum, finset.mul_sum]
 
-protected lemma eq_zero_of_zero_eq_one
-  (zero_eq_one : (0 : β) = 1) (l : α →₀ β) : l = 0 :=
-by ext i; simp only [eq_zero_of_zero_eq_one zero_eq_one (l i), finsupp.zero_apply]
+instance unique_of_right [subsingleton β] : unique (α →₀ β) :=
+{ uniq := λ l, ext $ λ i, subsingleton.elim _ _,
+  .. finsupp.inhabited }
 
 end
 

--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -125,8 +125,8 @@ begin
   simp only [finsupp.map_domain_apply hf],
 end
 
-lemma linear_independent_of_zero_eq_one (zero_eq_one : (0 : R) = 1) : linear_independent R v :=
-linear_independent_iff.2 (λ l hl, finsupp.eq_zero_of_zero_eq_one zero_eq_one _)
+lemma linear_independent_of_subsingleton [subsingleton R] : linear_independent R v :=
+linear_independent_iff.2 (λ l hl, subsingleton.elim l 0)
 
 lemma linear_independent.unique (hv : linear_independent R v) {l₁ l₂ : ι →₀ R} :
   finsupp.total ι M R v l₁ = finsupp.total ι M R v l₂ → l₁ = l₂ :=
@@ -167,7 +167,7 @@ linear_independent_equiv' (equiv.set.image_of_inj_on _ _ hf) rfl
 theorem linear_independent.image' {ι} {s : set ι} {f : ι → M}
   (hs : linear_independent R (λ x : s, f x)) : linear_independent R (λ x : f '' s, (x : M)) :=
 or.cases_on (subsingleton_or_nontrivial R)
-  (λ hr, linear_independent_of_zero_eq_one $ by exactI subsingleton.elim _ _)
+  (λ hr, by exactI linear_independent_of_subsingleton )
   (λ hr, by exactI (linear_independent_image $ set.inj_on_iff_injective.2 hs.injective).1 hs)
 
 lemma linear_independent_span (hs : linear_independent R v) :
@@ -257,9 +257,8 @@ by rw [finsupp.total_on, linear_map.ker, linear_map.comap_cod_restrict, map_bot,
 lemma linear_independent.to_subtype_range
   (hv : linear_independent R v) : linear_independent R (λ x, x : range v → M) :=
 begin
-  by_cases zero_eq_one : (0 : R) = 1,
-  { apply linear_independent_of_zero_eq_one zero_eq_one },
-  haveI : nontrivial R := ⟨⟨0, 1, zero_eq_one⟩⟩,
+  cases subsingleton_or_nontrivial R; resetI,
+  { apply linear_independent_of_subsingleton },
   rw linear_independent_subtype,
   intros l hl₁ hl₂,
   have h_bij : bij_on v (v ⁻¹' ↑l.support) ↑l.support,
@@ -429,9 +428,7 @@ lemma linear_independent_Union_finite {η : Type*} {ιs : η → Type*}
       disjoint (span R (range (f i))) (⨆i∈t, span R (range (f i)))) :
   linear_independent R (λ ji : Σ j, ιs j, f ji.1 ji.2) :=
 begin
-  by_cases zero_eq_one : (0 : R) = 1,
-  { apply linear_independent_of_zero_eq_one zero_eq_one },
-  haveI : nontrivial R := ⟨⟨0, 1, zero_eq_one⟩⟩,
+  cases subsingleton_or_nontrivial R; resetI, { exact linear_independent_of_subsingleton },
   apply linear_independent.of_subtype_range,
   { rintros ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ hxy,
     by_cases h_cases : x₁ = y₁,
@@ -628,9 +625,7 @@ lemma linear_independent_inl_union_inr' {v : ι → M} {v' : ι' → M'}
   (hv : linear_independent R v) (hv' : linear_independent R v') :
   linear_independent R (sum.elim (inl R M M' ∘ v) (inr R M M' ∘ v')) :=
 begin
-  by_cases zero_eq_one : (0 : R) = 1,
-  { apply linear_independent_of_zero_eq_one zero_eq_one },
-  haveI : nontrivial R := ⟨⟨0, 1, zero_eq_one⟩⟩,
+  cases subsingleton_or_nontrivial R; resetI; [exact linear_independent_of_subsingleton, skip],
   have inj_v : injective v := (linear_independent.injective hv),
   have inj_v' : injective v' := (linear_independent.injective hv'),
   apply linear_independent.of_subtype_range,


### PR DESCRIPTION
Also add a lemma `semimodule.subsingleton`: if `R` is a subsingleton semiring, then any semimodule over `R` is a subsingleton.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
