### PR TITLE
[Merged by Bors] - feat(archive/imo): IMO 2020 Q2

### DIFF
--- a/archive/imo/imo2020_q2.lean
+++ b/archive/imo/imo2020_q2.lean
@@ -25,25 +25,22 @@ theorem imo2020_q2 (a b c d : ℝ) (hd0 : 0 < d) (hdc : d ≤ c) (hcb : c ≤ b)
   (h1 : a + b + c + d = 1) :
   (a + 2 * b + 3 * c + 4 * d) * a ^ a * b ^ b * c ^ c * d ^ d < 1 :=
 begin
-  have hc0 : 0 < c := hd0.trans_le hdc,
-  have hb0 : 0 < b := hc0.trans_le hcb,
-  have ha0 : 0 < a := hb0.trans_le hba,
-  have hp : a ^ a * b ^ b * c ^ c * d ^ d ≤ a * a + b * b + c * c + d * d :=
-    geom_mean_le_arith_mean4_weighted ha0.le hb0.le hc0.le hd0.le ha0.le hb0.le hc0.le hd0.le h1,
-  calc (a + 2 * b + 3 * c + 4 * d) * a ^ a * b ^ b * c ^ c * d ^ d
-    = (a + 2 * b + 3 * c + 4 * d) * (a ^ a * b ^ b * c ^ c * d ^ d) : by ac_refl
-    ... ≤ (a + 2 * b + 3 * c + 4 * d) * (a * a + b * b + c * c + d * d) :
-      mul_le_mul_of_nonneg_left hp (by linarith)
-    ... = (a + 2 * b + 3 * c + 4 * d) * (a * a) + (a + 2 * b + 3 * c + 4 * d) * (b * b) +
-          (a + 2 * b + 3 * c + 4 * d) * (c * c) + (a + 2 * b + 3 * c + 4 * d) * (d * d) :
-      by simp only [mul_add]
-    ... ≤ (a + 3 * b + 3 * c + 3 * d) * (a * a) + (3 * a + b + 3 * c + 3 * d) * (b * b) +
-          (3 * a + 3 * b + c + 3 * d) * (c * c) + (3 * a + 3 * b + 3 * c + d) * (d * d) :
-      by apply_rules [add_le_add]; refine mul_le_mul_of_nonneg_right _ (mul_self_nonneg _); linarith
-    ... < (a + 3 * b + 3 * c + 3 * d) * (a * a) + (3 * a + b + 3 * c + 3 * d) * (b * b) +
-          (3 * a + 3 * b + c + 3 * d) * (c * c) + (3 * a + 3 * b + 3 * c + d) * (d * d) +
-          (6 * a * b * c + 6 * a * b * d + 6 * a * c * d + 6 * b * c * d) :
-      lt_add_of_pos_right _ (by apply_rules [add_pos, mul_pos, zero_lt_one])
-    ... = (a + b + c + d) ^ 3 : by ring
-    ... = 1 : by simp [h1]
+  have hp : a ^ a * b ^ b * c ^ c * d ^ d ≤ a * a + b * b + c * c + d * d,
+  by refine geom_mean_le_arith_mean4_weighted _ _ _ _ _ _ _ _ h1; linarith,
+  calc  (a + 2 * b + 3 * c + 4 * d) * a ^ a * b ^ b * c ^ c * d ^ d
+      = (a + 2 * b + 3 * c + 4 * d) * (a ^ a * b ^ b * c ^ c * d ^ d) : by ac_refl
+  ... ≤ (a + 2 * b + 3 * c + 4 * d) * (a * a + b * b + c * c + d * d) :
+    mul_le_mul_of_nonneg_left hp (by linarith)
+  ... = (a + 2 * b + 3 * c + 4 * d) * (a * a) + (a + 2 * b + 3 * c + 4 * d) * (b * b) +
+        (a + 2 * b + 3 * c + 4 * d) * (c * c) + (a + 2 * b + 3 * c + 4 * d) * (d * d) :
+    by simp only [mul_add]
+  ... ≤ (a + 3 * b + 3 * c + 3 * d) * (a * a) + (3 * a + b + 3 * c + 3 * d) * (b * b) +
+        (3 * a + 3 * b + c + 3 * d) * (c * c) + (3 * a + 3 * b + 3 * c + d) * (d * d) :
+    by apply_rules [add_le_add]; refine mul_le_mul_of_nonneg_right _ (mul_self_nonneg _); linarith
+  ... < (a + 3 * b + 3 * c + 3 * d) * (a * a) + (3 * a + b + 3 * c + 3 * d) * (b * b) +
+        (3 * a + 3 * b + c + 3 * d) * (c * c) + (3 * a + 3 * b + 3 * c + d) * (d * d) +
+        (6 * a * b * c + 6 * a * b * d + 6 * a * c * d + 6 * b * c * d) :
+    lt_add_of_pos_right _ (by apply_rules [add_pos, mul_pos, zero_lt_one]; linarith)
+  ... = (a + b + c + d) ^ 3 : by ring
+  ... = 1 : by simp [h1]
 end

--- a/archive/imo/imo2020_q2.lean
+++ b/archive/imo/imo2020_q2.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Joseph Myers.
+Author: Joseph Myers, Yury Kudryashov.
 -/
 
 import analysis.mean_inequalities
@@ -19,43 +19,31 @@ terms.  The version here using factors such as `a+3b+3c+3d` is from
 the official solutions.
 -/
 
-theorem imo2020_q2 : ∀ (a b c d : ℝ), 0 < d → d ≤ c → c ≤ b → b ≤ a → a + b + c + d = 1 →
+open real
+
+theorem imo2020_q2 (a b c d : ℝ) (hd0 : 0 < d) (hdc : d ≤ c) (hcb : c ≤ b) (hba : b ≤ a)
+  (h1 : a + b + c + d = 1) :
   (a + 2 * b + 3 * c + 4 * d) * a ^ a * b ^ b * c ^ c * d ^ d < 1 :=
 begin
-  intros a b c d hd0 hcd hbc hab habcd,
-  have hc0 : 0 < c, by linarith,
-  have hb0 : 0 < b, by linarith,
-  have ha0 : 0 < a, by linarith,
-  have hd0' := le_of_lt hd0,
-  have hc0' := le_of_lt hc0,
-  have hb0' := le_of_lt hb0,
-  have ha0' := le_of_lt ha0,
+  have hc0 : 0 < c := hd0.trans_le hdc,
+  have hb0 : 0 < b := hc0.trans_le hcb,
+  have ha0 : 0 < a := hb0.trans_le hba,
   have hp : a ^ a * b ^ b * c ^ c * d ^ d ≤ a * a + b * b + c * c + d * d :=
-    real.geom_mean_le_arith_mean4_weighted ha0' hb0' hc0' hd0' ha0' hb0' hc0' hd0' habcd,
-  have h6abc : 0 < 6 * a * b * c := mul_pos (mul_pos (mul_pos (by norm_num) ha0) hb0) hc0,
-  have h6abd : 0 < 6 * a * b * d := mul_pos (mul_pos (mul_pos (by norm_num) ha0) hb0) hd0,
-  have h6acd : 0 < 6 * a * c * d := mul_pos (mul_pos (mul_pos (by norm_num) ha0) hc0) hd0,
-  have h6bcd : 0 < 6 * b * c * d := mul_pos (mul_pos (mul_pos (by norm_num) hb0) hc0) hd0,
-  have h6 : 0 < 6 * a * b * c + 6 * a * b * d + 6 * a * c * d + 6 * b * c * d :=
-    add_pos (add_pos (add_pos h6abc h6abd) h6acd) h6bcd,
+    geom_mean_le_arith_mean4_weighted ha0.le hb0.le hc0.le hd0.le ha0.le hb0.le hc0.le hd0.le h1,
   calc (a + 2 * b + 3 * c + 4 * d) * a ^ a * b ^ b * c ^ c * d ^ d
-    = (a + 2 * b + 3 * c + 4 * d) * (a ^ a * b ^ b * c ^ c * d ^ d) : by ring
+    = (a + 2 * b + 3 * c + 4 * d) * (a ^ a * b ^ b * c ^ c * d ^ d) : by ac_refl
     ... ≤ (a + 2 * b + 3 * c + 4 * d) * (a * a + b * b + c * c + d * d) :
       mul_le_mul_of_nonneg_left hp (by linarith)
     ... = (a + 2 * b + 3 * c + 4 * d) * (a * a) + (a + 2 * b + 3 * c + 4 * d) * (b * b) +
-          (a + 2 * b + 3 * c + 4 * d) * (c * c) + (a + 2 * b + 3 * c + 4 * d) * (d * d) : by ring
+          (a + 2 * b + 3 * c + 4 * d) * (c * c) + (a + 2 * b + 3 * c + 4 * d) * (d * d) :
+      by simp only [mul_add]
     ... ≤ (a + 3 * b + 3 * c + 3 * d) * (a * a) + (3 * a + b + 3 * c + 3 * d) * (b * b) +
           (3 * a + 3 * b + c + 3 * d) * (c * c) + (3 * a + 3 * b + 3 * c + d) * (d * d) :
-      add_le_add (add_le_add (add_le_add (mul_le_mul_of_nonneg_right (by linarith)
-                                                                     (mul_self_nonneg _))
-                                         (mul_le_mul_of_nonneg_right (by linarith)
-                                                                     (mul_self_nonneg _)))
-                             (mul_le_mul_of_nonneg_right (by linarith) (mul_self_nonneg _)))
-                 (mul_le_mul_of_nonneg_right (by linarith) (mul_self_nonneg _))
+      by apply_rules [add_le_add]; refine mul_le_mul_of_nonneg_right _ (mul_self_nonneg _); linarith
     ... < (a + 3 * b + 3 * c + 3 * d) * (a * a) + (3 * a + b + 3 * c + 3 * d) * (b * b) +
           (3 * a + 3 * b + c + 3 * d) * (c * c) + (3 * a + 3 * b + 3 * c + d) * (d * d) +
           (6 * a * b * c + 6 * a * b * d + 6 * a * c * d + 6 * b * c * d) :
-      lt_add_of_pos_right _ h6
+      lt_add_of_pos_right _ (by apply_rules [add_pos, mul_pos, zero_lt_one])
     ... = (a + b + c + d) ^ 3 : by ring
-    ... = 1 : by simp [habcd]
+    ... = 1 : by simp [h1]
 end

--- a/archive/imo/imo2020_q2.lean
+++ b/archive/imo/imo2020_q2.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2020 Joseph Myers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Joseph Myers.
+-/
+
+import analysis.mean_inequalities
+
+/-!
+# IMO 2020 Q2
+
+The real numbers `a`, `b`, `c`, `d` are such that `a ≥ b ≥ c ≥ d > 0` and `a + b + c + d = 1`.
+Prove that `(a + 2b + 3c + 4d) a^a b^b c^c d^d < 1`.
+
+A solution is to eliminate the powers using weighted AM-GM and replace
+`1` by `(a+b+c+d)^3`, leaving a homogeneous inequality that can be
+proved in many ways by expanding, rearranging and comparing individual
+terms.  The version here using factors such as `a+3b+3c+3d` is from
+the official solutions.
+-/
+
+theorem imo2020_q2 : ∀ (a b c d : ℝ), 0 < d → d ≤ c → c ≤ b → b ≤ a → a + b + c + d = 1 →
+  (a + 2 * b + 3 * c + 4 * d) * a ^ a * b ^ b * c ^ c * d ^ d < 1 :=
+begin
+  intros a b c d hd0 hcd hbc hab habcd,
+  have hc0 : 0 < c, by linarith,
+  have hb0 : 0 < b, by linarith,
+  have ha0 : 0 < a, by linarith,
+  have hd0' := le_of_lt hd0,
+  have hc0' := le_of_lt hc0,
+  have hb0' := le_of_lt hb0,
+  have ha0' := le_of_lt ha0,
+  have hp : a ^ a * b ^ b * c ^ c * d ^ d ≤ a * a + b * b + c * c + d * d :=
+    real.geom_mean_le_arith_mean4_weighted ha0' hb0' hc0' hd0' ha0' hb0' hc0' hd0' habcd,
+  have h6abc : 0 < 6 * a * b * c := mul_pos (mul_pos (mul_pos (by norm_num) ha0) hb0) hc0,
+  have h6abd : 0 < 6 * a * b * d := mul_pos (mul_pos (mul_pos (by norm_num) ha0) hb0) hd0,
+  have h6acd : 0 < 6 * a * c * d := mul_pos (mul_pos (mul_pos (by norm_num) ha0) hc0) hd0,
+  have h6bcd : 0 < 6 * b * c * d := mul_pos (mul_pos (mul_pos (by norm_num) hb0) hc0) hd0,
+  have h6 : 0 < 6 * a * b * c + 6 * a * b * d + 6 * a * c * d + 6 * b * c * d :=
+    add_pos (add_pos (add_pos h6abc h6abd) h6acd) h6bcd,
+  calc (a + 2 * b + 3 * c + 4 * d) * a ^ a * b ^ b * c ^ c * d ^ d
+    = (a + 2 * b + 3 * c + 4 * d) * (a ^ a * b ^ b * c ^ c * d ^ d) : by ring
+    ... ≤ (a + 2 * b + 3 * c + 4 * d) * (a * a + b * b + c * c + d * d) :
+      mul_le_mul_of_nonneg_left hp (by linarith)
+    ... = (a + 2 * b + 3 * c + 4 * d) * (a * a) + (a + 2 * b + 3 * c + 4 * d) * (b * b) +
+          (a + 2 * b + 3 * c + 4 * d) * (c * c) + (a + 2 * b + 3 * c + 4 * d) * (d * d) : by ring
+    ... ≤ (a + 3 * b + 3 * c + 3 * d) * (a * a) + (3 * a + b + 3 * c + 3 * d) * (b * b) +
+          (3 * a + 3 * b + c + 3 * d) * (c * c) + (3 * a + 3 * b + 3 * c + d) * (d * d) :
+      add_le_add (add_le_add (add_le_add (mul_le_mul_of_nonneg_right (by linarith)
+                                                                     (mul_self_nonneg _))
+                                         (mul_le_mul_of_nonneg_right (by linarith)
+                                                                     (mul_self_nonneg _)))
+                             (mul_le_mul_of_nonneg_right (by linarith) (mul_self_nonneg _)))
+                 (mul_le_mul_of_nonneg_right (by linarith) (mul_self_nonneg _))
+    ... < (a + 3 * b + 3 * c + 3 * d) * (a * a) + (3 * a + b + 3 * c + 3 * d) * (b * b) +
+          (3 * a + 3 * b + c + 3 * d) * (c * c) + (3 * a + 3 * b + 3 * c + d) * (d * d) +
+          (6 * a * b * c + 6 * a * b * d + 6 * a * c * d + 6 * b * c * d) :
+      lt_add_of_pos_right _ h6
+    ... = (a + b + c + d) ^ 3 : by ring
+    ... = 1 : by simp [habcd]
+end

--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -32,7 +32,8 @@ a version for real-valued non-negative functions is in the `real` namespace, and
 
 - `geom_mean_le_arith_mean_weighted` : weighted version for functions on `finset`s;
 - `geom_mean_le_arith_mean2_weighted` : weighted version for two numbers;
-- `geom_mean_le_arith_mean3_weighted` : weighted version for three numbers.
+- `geom_mean_le_arith_mean3_weighted` : weighted version for three numbers;
+- `geom_mean_le_arith_mean4_weighted` : weighted version for four numbers.
 
 ### Generalized mean inequality
 
@@ -199,6 +200,15 @@ using geom_mean_le_arith_mean_weighted (univ : finset (fin 3))
   (fin.cons w₁ $ fin.cons w₂ $ fin.cons w₃ fin_zero_elim)
   (fin.cons p₁ $ fin.cons p₂ $ fin.cons p₃ fin_zero_elim)
 
+theorem geom_mean_le_arith_mean4_weighted (w₁ w₂ w₃ w₄ p₁ p₂ p₃ p₄ : ℝ≥0) :
+  w₁ + w₂ + w₃ + w₄ = 1 → p₁ ^ (w₁:ℝ) * p₂ ^ (w₂:ℝ) * p₃ ^ (w₃:ℝ)* p₄ ^ (w₄:ℝ) ≤
+    w₁ * p₁ + w₂ * p₂ + w₃ * p₃ + w₄ * p₄ :=
+by simpa only  [fin.prod_univ_succ, fin.sum_univ_succ, fin.prod_univ_zero, fin.sum_univ_zero,
+  fin.cons_succ, fin.cons_zero, add_zero, mul_one, ← add_assoc, mul_assoc]
+using geom_mean_le_arith_mean_weighted (univ : finset (fin 4))
+  (fin.cons w₁ $ fin.cons w₂ $ fin.cons w₃ $ fin.cons w₄ fin_zero_elim)
+  (fin.cons p₁ $ fin.cons p₂ $ fin.cons p₃ $ fin.cons p₄ fin_zero_elim)
+
 /-- Weighted generalized mean inequality, version sums over finite sets, with `ℝ≥0`-valued
 functions and natural exponent. -/
 theorem pow_arith_mean_le_arith_mean_pow (w z : ι → ℝ≥0) (hw' : ∑ i in s, w i = 1) (n : ℕ) :
@@ -231,6 +241,19 @@ theorem geom_mean_le_arith_mean2_weighted {w₁ w₂ p₁ p₂ : ℝ} (hw₁ : 0
   p₁ ^ w₁ * p₂ ^ w₂ ≤ w₁ * p₁ + w₂ * p₂ :=
 nnreal.geom_mean_le_arith_mean2_weighted ⟨w₁, hw₁⟩ ⟨w₂, hw₂⟩ ⟨p₁, hp₁⟩ ⟨p₂, hp₂⟩ $
   nnreal.coe_eq.1 $ by assumption
+
+theorem geom_mean_le_arith_mean3_weighted {w₁ w₂ w₃ p₁ p₂ p₃ : ℝ} (hw₁ : 0 ≤ w₁) (hw₂ : 0 ≤ w₂)
+  (hw₃ : 0 ≤ w₃) (hp₁ : 0 ≤ p₁) (hp₂ : 0 ≤ p₂) (hp₃ : 0 ≤ p₃) (hw : w₁ + w₂ + w₃ = 1) :
+  p₁ ^ w₁ * p₂ ^ w₂ * p₃ ^ w₃ ≤ w₁ * p₁ + w₂ * p₂ + w₃ * p₃ :=
+nnreal.geom_mean_le_arith_mean3_weighted ⟨w₁, hw₁⟩ ⟨w₂, hw₂⟩ ⟨w₃, hw₃⟩ ⟨p₁, hp₁⟩ ⟨p₂, hp₂⟩ ⟨p₃, hp₃⟩ $
+  nnreal.coe_eq.1 $ by assumption
+
+theorem geom_mean_le_arith_mean4_weighted {w₁ w₂ w₃ w₄ p₁ p₂ p₃ p₄ : ℝ} (hw₁ : 0 ≤ w₁)
+  (hw₂ : 0 ≤ w₂) (hw₃ : 0 ≤ w₃) (hw₄ : 0 ≤ w₄) (hp₁ : 0 ≤ p₁) (hp₂ : 0 ≤ p₂) (hp₃ : 0 ≤ p₃)
+  (hp₄ : 0 ≤ p₄) (hw : w₁ + w₂ + w₃ + w₄ = 1) :
+  p₁ ^ w₁ * p₂ ^ w₂ * p₃ ^ w₃ * p₄ ^ w₄ ≤ w₁ * p₁ + w₂ * p₂ + w₃ * p₃ + w₄ * p₄ :=
+nnreal.geom_mean_le_arith_mean4_weighted ⟨w₁, hw₁⟩ ⟨w₂, hw₂⟩ ⟨w₃, hw₃⟩ ⟨w₄, hw₄⟩
+  ⟨p₁, hp₁⟩ ⟨p₂, hp₂⟩ ⟨p₃, hp₃⟩ ⟨p₄, hp₄⟩ $ nnreal.coe_eq.1 $ by assumption
 
 /-- Young's inequality, a version for nonnegative real numbers. -/
 theorem young_inequality_of_nonneg {a b p q : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b)


### PR DESCRIPTION
Add a proof of IMO 2020 Q2 (directly following one of the official
solutions; there are many very similar approaches possible).

In support of this solution, add `geom_mean_le_arith_mean4_weighted`
to `analysis.mean_inequalities`, for both `real` and `nnreal`,
analogous to the versions for two and three numbers (and also add
`geom_mean_le_arith_mean3_weighted` for `real` as it was only present
for `nnreal`).


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
