### PR TITLE
[Merged by Bors] - feat(algebra/*_power): simplify `(-a)^(bit0 _)` and `(-a)^(bit1 _)`

### DIFF
--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -14,6 +14,14 @@ universe u
   ∀ (a : K) (n : ℤ), f (a ^ n) = f a ^ n :=
 f.to_monoid_hom.map_fpow f.map_zero
 
+@[simp] lemma neg_fpow_bit0 {K : Type*} [division_ring K] (x : K) (n : ℤ) :
+  (-x) ^ (bit0 n) = x ^ bit0 n :=
+by rw [fpow_bit0', fpow_bit0', neg_mul_neg]
+
+@[simp] lemma neg_fpow_bit1 {K : Type*} [division_ring K] (x : K) (n : ℤ) :
+  (-x) ^ (bit1 n) = - x ^ bit1 n :=
+by rw [fpow_bit1', fpow_bit1', neg_mul_neg, neg_mul_eq_mul_neg]
+
 section ordered_field_power
 open int
 

--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -201,6 +201,24 @@ by simp only [pow_succ, ihn, ← mul_assoc, (h.pow_left n).right_comm]
 theorem neg_pow [ring R] (a : R) (n : ℕ) : (- a) ^ n = (-1) ^ n * a ^ n :=
 (neg_one_mul a) ▸ (commute.neg_one_left a).mul_pow n
 
+theorem pow_bit0' (a : M) (n : ℕ) : a ^ bit0 n = (a * a) ^ n :=
+by rw [pow_bit0, (commute.refl a).mul_pow]
+
+theorem bit0_nsmul' (a : A) (n : ℕ) : bit0 n •ℕ a = n •ℕ (a + a) :=
+@pow_bit0' (multiplicative A) _ _ _
+
+theorem pow_bit1' (a : M) (n : ℕ) : a ^ bit1 n = (a * a) ^ n * a :=
+by rw [bit1, pow_succ', pow_bit0']
+
+theorem bit1_nsmul' : ∀ (a : A) (n : ℕ), bit1 n •ℕ a = n •ℕ (a + a) + a :=
+@pow_bit1' (multiplicative A) _
+
+@[simp] theorem neg_pow_bit0 [ring R] (a : R) (n : ℕ) : (- a) ^ (bit0 n) = a ^ (bit0 n) :=
+by rw [pow_bit0', neg_mul_neg, pow_bit0']
+
+@[simp] theorem neg_pow_bit1 [ring R] (a : R) (n : ℕ) : (- a) ^ (bit1 n) = - a ^ (bit1 n) :=
+by simp only [bit1, pow_succ, neg_pow_bit0, neg_mul_eq_neg_mul]
+
 end monoid
 
 /-!

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -141,7 +141,7 @@ theorem gpow_bit0 (a : G) (n : ℤ) : a ^ bit0 n = a ^ n * a ^ n := gpow_add _ _
 theorem bit0_gsmul (a : A) (n : ℤ) : bit0 n •ℤ a = n •ℤ a + n •ℤ a := gpow_add _ _ _
 
 theorem gpow_bit1 (a : G) (n : ℤ) : a ^ bit1 n = a ^ n * a ^ n * a :=
-by rw [bit1, gpow_add]; simp [gpow_bit0]
+by rw [bit1, gpow_add, gpow_bit0, gpow_one]
 
 theorem bit1_gsmul : ∀ (a : A) (n : ℤ), bit1 n •ℤ a = n •ℤ a + n •ℤ a + a :=
 @gpow_bit1 (multiplicative A) _

--- a/src/algebra/group_with_zero_power.lean
+++ b/src/algebra/group_with_zero_power.lean
@@ -124,6 +124,18 @@ begin
   { rw [fpow_sub_one ha, ← mul_assoc, ← ihn, ← fpow_sub_one ha, add_sub_assoc] }
 end
 
+lemma fpow_add' {a : G₀} {m n : ℤ} (h : a ≠ 0 ∨ m + n ≠ 0 ∨ m = 0 ∧ n = 0) :
+  a ^ (m + n) = a ^ m * a ^ n :=
+begin
+  by_cases hm : m = 0, { simp [hm] },
+  by_cases hn : n = 0, { simp [hn] },
+  by_cases ha : a = 0,
+  { subst a,
+    simp only [false_or, eq_self_iff_true, not_true, ne.def, hm, hn, false_and, or_false] at h,
+    rw [zero_fpow _ h, zero_fpow _ hm, zero_mul] },
+  { exact fpow_add ha m n }
+end
+
 theorem fpow_one_add {a : G₀} (h : a ≠ 0) (i : ℤ) : a ^ (1 + i) = a * a ^ i :=
 by rw [fpow_add h, fpow_one]
 
@@ -146,6 +158,21 @@ theorem commute.fpow_self (a : G₀) (n : ℤ) : commute (a^n) a := (commute.ref
 theorem commute.self_fpow (a : G₀) (n : ℤ) : commute a (a^n) := (commute.refl a).fpow_right n
 
 theorem commute.fpow_fpow_self (a : G₀) (m n : ℤ) : commute (a^m) (a^n) := (commute.refl a).fpow_fpow m n
+
+theorem fpow_bit0 (a : G₀) (n : ℤ) : a ^ bit0 n = a ^ n * a ^ n :=
+begin
+  apply fpow_add', right,
+  by_cases hn : n = 0,
+  { simp [hn] },
+  { simp [← two_mul, hn, two_ne_zero] }
+end
+
+theorem fpow_bit1 (a : G₀) (n : ℤ) : a ^ bit1 n = a ^ n * a ^ n * a :=
+begin
+  rw [← fpow_bit0, bit1, fpow_add', fpow_one],
+  right, left,
+  apply bit1_ne_zero
+end
 
 theorem fpow_mul (a : G₀) : ∀ m n : ℤ, a ^ (m * n) = (a ^ m) ^ n
 | (m : ℕ) (n : ℕ) := pow_mul _ _ _
@@ -179,6 +206,12 @@ lemma commute.mul_fpow {a b : G₀} (h : commute a b) :
 lemma mul_fpow {G₀ : Type*} [comm_group_with_zero G₀] (a b : G₀) (m : ℤ):
   (a * b) ^ m = (a ^ m) * (b ^ m) :=
 (commute.all a b).mul_fpow m
+
+theorem fpow_bit0' (a : G₀) (n : ℤ) : a ^ bit0 n = (a * a) ^ n :=
+(fpow_bit0 a n).trans ((commute.refl a).mul_fpow n).symm
+
+theorem fpow_bit1' (a : G₀) (n : ℤ) : a ^ bit1 n = (a * a) ^ n * a :=
+by rw [fpow_bit1, (commute.refl a).mul_fpow]
 
 lemma fpow_eq_zero {x : G₀} {n : ℤ} (h : x ^ n = 0) : x = 0 :=
 classical.by_contradiction $ λ hx, fpow_ne_zero_of_ne_zero hx n h

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -125,7 +125,6 @@ ext_iff.2 $ by simp
 @[simp] lemma re_add_im (z : ℂ) : (z.re : ℂ) + z.im * I = z :=
 ext_iff.2 $ by simp
 
-
 /-! ### Commutative ring instance and lemmas -/
 
 instance : comm_ring ℂ :=
@@ -137,6 +136,18 @@ instance re.is_add_group_hom : is_add_group_hom complex.re :=
 
 instance im.is_add_group_hom : is_add_group_hom complex.im :=
 { map_add := complex.add_im }
+
+@[simp] lemma I_pow_bit0_bit0 (n : ℕ) : I ^ (bit0 (bit0 n)) = 1 :=
+by rw [pow_bit0', I_mul_I, neg_pow_bit0, one_pow]
+
+@[simp] lemma I_pow_bit0_bit1 (n : ℕ) : I ^ (bit0 (bit1 n)) = -1 :=
+by rw [pow_bit0', I_mul_I, neg_pow_bit1, one_pow]
+
+@[simp] lemma I_pow_bit1_bit0 (n : ℕ) : I ^ (bit1 (bit0 n)) = I :=
+by rw [pow_bit1', I_mul_I, neg_pow_bit0, one_pow, one_mul]
+
+@[simp] lemma I_pow_bit1_bit1 (n : ℕ) : I ^ (bit1 (bit1 n)) = -I :=
+by rw [pow_bit1', I_mul_I, neg_pow_bit1, one_pow, neg_one_mul]
 
 /-! ### Complex conjugation -/
 
@@ -278,6 +289,18 @@ noncomputable instance : field ℂ :=
   mul_inv_cancel := @complex.mul_inv_cancel,
   inv_zero := complex.inv_zero,
   ..complex.comm_ring }
+
+@[simp] lemma I_fpow_bit0_bit0 (n : ℤ) : I ^ (bit0 (bit0 n)) = 1 :=
+by rw [fpow_bit0', I_mul_I, neg_fpow_bit0, one_fpow]
+
+@[simp] lemma I_fpow_bit0_bit1 (n : ℤ) : I ^ (bit0 (bit1 n)) = -1 :=
+by rw [fpow_bit0', I_mul_I, neg_fpow_bit1, one_fpow]
+
+@[simp] lemma I_fpow_bit1_bit0 (n : ℤ) : I ^ (bit1 (bit0 n)) = I :=
+by rw [fpow_bit1', I_mul_I, neg_fpow_bit0, one_fpow, one_mul]
+
+@[simp] lemma I_fpow_bit1_bit1 (n : ℤ) : I ^ (bit1 (bit1 n)) = -I :=
+by rw [fpow_bit1', I_mul_I, neg_fpow_bit1, one_fpow, neg_one_mul]
 
 lemma div_re (z w : ℂ) : (z / w).re = z.re * w.re / norm_sq w + z.im * w.im / norm_sq w :=
 by simp [div_eq_mul_inv, mul_assoc, sub_eq_add_neg]

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -137,17 +137,11 @@ instance re.is_add_group_hom : is_add_group_hom complex.re :=
 instance im.is_add_group_hom : is_add_group_hom complex.im :=
 { map_add := complex.add_im }
 
-@[simp] lemma I_pow_bit0_bit0 (n : ℕ) : I ^ (bit0 (bit0 n)) = 1 :=
-by rw [pow_bit0', I_mul_I, neg_pow_bit0, one_pow]
+@[simp] lemma I_pow_bit0 (n : ℕ) : I ^ (bit0 n) = (-1) ^ n :=
+by rw [pow_bit0', I_mul_I]
 
-@[simp] lemma I_pow_bit0_bit1 (n : ℕ) : I ^ (bit0 (bit1 n)) = -1 :=
-by rw [pow_bit0', I_mul_I, neg_pow_bit1, one_pow]
-
-@[simp] lemma I_pow_bit1_bit0 (n : ℕ) : I ^ (bit1 (bit0 n)) = I :=
-by rw [pow_bit1', I_mul_I, neg_pow_bit0, one_pow, one_mul]
-
-@[simp] lemma I_pow_bit1_bit1 (n : ℕ) : I ^ (bit1 (bit1 n)) = -I :=
-by rw [pow_bit1', I_mul_I, neg_pow_bit1, one_pow, neg_one_mul]
+@[simp] lemma I_pow_bit1 (n : ℕ) : I ^ (bit1 n) = (-1) ^ n * I :=
+by rw [pow_bit1', I_mul_I]
 
 /-! ### Complex conjugation -/
 
@@ -290,17 +284,11 @@ noncomputable instance : field ℂ :=
   inv_zero := complex.inv_zero,
   ..complex.comm_ring }
 
-@[simp] lemma I_fpow_bit0_bit0 (n : ℤ) : I ^ (bit0 (bit0 n)) = 1 :=
-by rw [fpow_bit0', I_mul_I, neg_fpow_bit0, one_fpow]
+@[simp] lemma I_fpow_bit0 (n : ℤ) : I ^ (bit0 n) = (-1) ^ n :=
+by rw [fpow_bit0', I_mul_I]
 
-@[simp] lemma I_fpow_bit0_bit1 (n : ℤ) : I ^ (bit0 (bit1 n)) = -1 :=
-by rw [fpow_bit0', I_mul_I, neg_fpow_bit1, one_fpow]
-
-@[simp] lemma I_fpow_bit1_bit0 (n : ℤ) : I ^ (bit1 (bit0 n)) = I :=
-by rw [fpow_bit1', I_mul_I, neg_fpow_bit0, one_fpow, one_mul]
-
-@[simp] lemma I_fpow_bit1_bit1 (n : ℤ) : I ^ (bit1 (bit1 n)) = -I :=
-by rw [fpow_bit1', I_mul_I, neg_fpow_bit1, one_fpow, neg_one_mul]
+@[simp] lemma I_fpow_bit1 (n : ℤ) : I ^ (bit1 n) = (-1) ^ n * I :=
+by rw [fpow_bit1', I_mul_I]
 
 lemma div_re (z w : ℂ) : (z / w).re = z.re * w.re / norm_sq w + z.im * w.im / norm_sq w :=
 by simp [div_eq_mul_inv, mul_assoc, sub_eq_add_neg]

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -959,7 +959,7 @@ lemma units_inv_eq_self (u : units ℤ) : u⁻¹ = u :=
 
 @[simp] lemma bodd_zero : bodd 0 = ff := rfl
 @[simp] lemma bodd_one : bodd 1 = tt := rfl
-@[simp] lemma bodd_two : bodd 2 = ff := rfl
+lemma bodd_two : bodd 2 = ff := rfl
 
 @[simp, norm_cast] lemma bodd_coe (n : ℕ) : int.bodd n = nat.bodd n := rfl
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1022,11 +1022,24 @@ by rw [bit_val, nat.bit_val]; cases b; refl
 @[simp] lemma bodd_bit (b n) : bodd (bit b n) = b :=
 by rw bit_val; simp; cases b; cases bodd n; refl
 
+@[simp] lemma bodd_bit0 (n : ℤ) : bodd (bit0 n) = ff := bodd_bit ff n
+
+@[simp] lemma bodd_bit1 (n : ℤ) : bodd (bit1 n) = tt := bodd_bit tt n
+
 @[simp] lemma div2_bit (b n) : div2 (bit b n) = n :=
 begin
   rw [bit_val, div2_val, add_comm, int.add_mul_div_left, (_ : (_/2:ℤ) = 0), zero_add],
   cases b, all_goals {exact dec_trivial}
 end
+
+lemma bit0_ne_bit1 (m n : ℤ) : bit0 m ≠ bit1 n :=
+mt (congr_arg bodd) $ by simp
+
+lemma bit1_ne_bit0 (m n : ℤ) : bit1 m ≠ bit0 n :=
+(bit0_ne_bit1 _ _).symm
+
+lemma bit1_ne_zero (m : ℤ) : bit1 m ≠ 0 :=
+by simpa only [bit0_zero] using bit1_ne_bit0 m 0
 
 @[simp] lemma test_bit_zero (b) : ∀ n, test_bit (bit b n) 0 = b
 | (n : ℕ) := by rw [bit_coe_nat]; apply nat.test_bit_zero


### PR DESCRIPTION
Works for `pow` and `fpow`. Also simplify powers of `I : ℂ`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
