### PR TITLE
[Merged by Bors] - chore(*): update to Lean 3.21.0c

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mathlib"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.20.0"
+lean_version = "leanprover-community/lean:3.21.0"
 path = "src"
 
 [dependencies]

--- a/src/computability/halting.lean
+++ b/src/computability/halting.lean
@@ -233,7 +233,7 @@ inductive partrec' : ∀ {n}, (vector ℕ n →. ℕ) → Prop
   partrec' f → (∀ i, partrec' (g i)) →
   partrec' (λ v, m_of_fn (λ i, g i v) >>= f)
 | rfind {n} {f : vector ℕ (n+1) → ℕ} : @partrec' (n+1) f →
-  partrec' (λ v, rfind (λ n, some (f (vector.cons n v) = 0)))
+  partrec' (λ v, rfind (λ n, some (f (n ::ᵥ v) = 0)))
 
 end nat
 
@@ -268,7 +268,7 @@ theorem tail {n f} (hf : @partrec' n f) : @partrec' n.succ (λ v, f v.tail) :=
 
 protected theorem bind {n f g}
   (hf : @partrec' n f) (hg : @partrec' (n+1) g) :
-  @partrec' n (λ v, (f v).bind (λ a, g (vector.cons a v))) :=
+  @partrec' n (λ v, (f v).bind (λ a, g (a ::ᵥ v))) :=
 (@comp n (n+1) g
   (λ i, fin.cases f (λ i v, some (v.nth i)) i) hg
   (λ i, begin
@@ -279,7 +279,7 @@ protected theorem bind {n f g}
 
 protected theorem map {n f} {g : vector ℕ (n+1) → ℕ}
   (hf : @partrec' n f) (hg : @partrec' (n+1) g) :
-  @partrec' n (λ v, (f v).map (λ a, g (vector.cons a v))) :=
+  @partrec' n (λ v, (f v).map (λ a, g (a ::ᵥ v))) :=
 by simp [(roption.bind_some_eq_map _ _).symm];
    exact hf.bind hg
 
@@ -295,7 +295,7 @@ protected theorem nil {n} : @vec n 0 (λ _, nil) := λ i, i.elim0
 
 protected theorem cons {n m} {f : vector ℕ n → ℕ} {g}
   (hf : @partrec' n f) (hg : @vec n m g) :
-  vec (λ v, vector.cons (f v) (g v)) :=
+  vec (λ v, f v ::ᵥ g v) :=
 λ i, fin.cases (by simp *) (λ i, by simp [hg i]) i
 
 theorem idv {n} : @vec n n id := vec.prim nat.primrec'.idv
@@ -311,7 +311,7 @@ by simpa using hf.comp' (partrec'.cons hg partrec'.nil)
 
 theorem rfind_opt {n} {f : vector ℕ (n+1) → ℕ}
   (hf : @partrec' (n+1) f) :
-  @partrec' n (λ v, nat.rfind_opt (λ a, of_nat (option ℕ) (f (vector.cons a v)))) :=
+  @partrec' n (λ v, nat.rfind_opt (λ a, of_nat (option ℕ) (f (a ::ᵥ v)))) :=
 ((rfind $ (of_prim (primrec.nat_sub.comp (primrec.const 1) primrec.vector_head))
    .comp₁ (λ n, roption.some (1 - n)) hf)
    .bind ((prim nat.primrec'.pred).comp₁ nat.pred hf)).of_eq $
@@ -320,10 +320,10 @@ theorem rfind_opt {n} {f : vector ℕ (n+1) → ℕ}
   refine exists_congr (λ a,
     (and_congr (iff_of_eq _) iff.rfl).trans (and_congr_right (λ h, _))),
   { congr; funext n,
-    simp, cases f (vector.cons n v); simp [nat.succ_ne_zero]; refl },
+    simp, cases f (n ::ᵥ v); simp [nat.succ_ne_zero]; refl },
   { have := nat.rfind_spec h,
     simp at this,
-    cases f (vector.cons a v) with c, {cases this},
+    cases f (a ::ᵥ v) with c, {cases this},
     rw [← option.some_inj, eq_comm], refl }
 end
 

--- a/src/computability/halting.lean
+++ b/src/computability/halting.lean
@@ -233,7 +233,7 @@ inductive partrec' : ∀ {n}, (vector ℕ n →. ℕ) → Prop
   partrec' f → (∀ i, partrec' (g i)) →
   partrec' (λ v, m_of_fn (λ i, g i v) >>= f)
 | rfind {n} {f : vector ℕ (n+1) → ℕ} : @partrec' (n+1) f →
-  partrec' (λ v, rfind (λ n, some (f (n :: v) = 0)))
+  partrec' (λ v, rfind (λ n, some (f (vector.cons n v) = 0)))
 
 end nat
 
@@ -268,7 +268,7 @@ theorem tail {n f} (hf : @partrec' n f) : @partrec' n.succ (λ v, f v.tail) :=
 
 protected theorem bind {n f g}
   (hf : @partrec' n f) (hg : @partrec' (n+1) g) :
-  @partrec' n (λ v, (f v).bind (λ a, g (a :: v))) :=
+  @partrec' n (λ v, (f v).bind (λ a, g (vector.cons a v))) :=
 (@comp n (n+1) g
   (λ i, fin.cases f (λ i v, some (v.nth i)) i) hg
   (λ i, begin
@@ -279,7 +279,7 @@ protected theorem bind {n f g}
 
 protected theorem map {n f} {g : vector ℕ (n+1) → ℕ}
   (hf : @partrec' n f) (hg : @partrec' (n+1) g) :
-  @partrec' n (λ v, (f v).map (λ a, g (a :: v))) :=
+  @partrec' n (λ v, (f v).map (λ a, g (vector.cons a v))) :=
 by simp [(roption.bind_some_eq_map _ _).symm];
    exact hf.bind hg
 
@@ -295,7 +295,7 @@ protected theorem nil {n} : @vec n 0 (λ _, nil) := λ i, i.elim0
 
 protected theorem cons {n m} {f : vector ℕ n → ℕ} {g}
   (hf : @partrec' n f) (hg : @vec n m g) :
-  vec (λ v, f v :: g v) :=
+  vec (λ v, vector.cons (f v) (g v)) :=
 λ i, fin.cases (by simp *) (λ i, by simp [hg i]) i
 
 theorem idv {n} : @vec n n id := vec.prim nat.primrec'.idv
@@ -311,7 +311,7 @@ by simpa using hf.comp' (partrec'.cons hg partrec'.nil)
 
 theorem rfind_opt {n} {f : vector ℕ (n+1) → ℕ}
   (hf : @partrec' (n+1) f) :
-  @partrec' n (λ v, nat.rfind_opt (λ a, of_nat (option ℕ) (f (a :: v)))) :=
+  @partrec' n (λ v, nat.rfind_opt (λ a, of_nat (option ℕ) (f (vector.cons a v)))) :=
 ((rfind $ (of_prim (primrec.nat_sub.comp (primrec.const 1) primrec.vector_head))
    .comp₁ (λ n, roption.some (1 - n)) hf)
    .bind ((prim nat.primrec'.pred).comp₁ nat.pred hf)).of_eq $
@@ -320,10 +320,10 @@ theorem rfind_opt {n} {f : vector ℕ (n+1) → ℕ}
   refine exists_congr (λ a,
     (and_congr (iff_of_eq _) iff.rfl).trans (and_congr_right (λ h, _))),
   { congr; funext n,
-    simp, cases f (n :: v); simp [nat.succ_ne_zero]; refl },
+    simp, cases f (vector.cons n v); simp [nat.succ_ne_zero]; refl },
   { have := nat.rfind_spec h,
     simp at this,
-    cases f (a :: v) with c, {cases this},
+    cases f (vector.cons a v) with c, {cases this},
     rw [← option.some_inj, eq_comm], refl }
 end
 

--- a/src/computability/primrec.lean
+++ b/src/computability/primrec.lean
@@ -1188,7 +1188,7 @@ inductive primrec' : ∀ {n}, (vector ℕ n → ℕ) → Prop
   primrec' (λ a, f (of_fn (λ i, g i a)))
 | prec {n f g} : @primrec' n f → @primrec' (n+2) g →
   primrec' (λ v : vector ℕ (n+1),
-    v.head.elim (f v.tail) (λ y IH, g (vector.cons y (vector.cons IH  v.tail))))
+    v.head.elim (f v.tail) (λ y IH, g (y ::ᵥ IH ::ᵥ v.tail)))
 
 end nat
 
@@ -1234,7 +1234,7 @@ protected theorem nil {n} : @vec n 0 (λ _, nil) := λ i, i.elim0
 
 protected theorem cons {n m f g}
   (hf : @primrec' n f) (hg : @vec n m g) :
-  vec (λ v, (vector.cons (f v) (g v))) :=
+  vec (λ v, (f v ::ᵥ g v)) :=
 λ i, fin.cases (by simp *) (λ i, by simp [hg i]) i
 
 theorem idv {n} : @vec n n id := nth
@@ -1257,7 +1257,7 @@ by simpa using hf.comp' (hg.cons $ hh.cons primrec'.nil)
 theorem prec' {n f g h}
   (hf : @primrec' n f) (hg : @primrec' n g) (hh : @primrec' (n+2) h) :
   @primrec' n (λ v, (f v).elim (g v)
-    (λ (y IH : ℕ), h (vector.cons y (vector.cons IH v)))) :=
+    (λ (y IH : ℕ), h (y ::ᵥ IH ::ᵥ v))) :=
 by simpa using comp' (prec hg hh) (hf.cons idv)
 
 theorem pred : @primrec' 1 (λ v, v.head.pred) :=

--- a/src/computability/primrec.lean
+++ b/src/computability/primrec.lean
@@ -1188,7 +1188,7 @@ inductive primrec' : ∀ {n}, (vector ℕ n → ℕ) → Prop
   primrec' (λ a, f (of_fn (λ i, g i a)))
 | prec {n f g} : @primrec' n f → @primrec' (n+2) g →
   primrec' (λ v : vector ℕ (n+1),
-    v.head.elim (f v.tail) (λ y IH, g (y :: IH :: v.tail)))
+    v.head.elim (f v.tail) (λ y IH, g (vector.cons y (vector.cons IH  v.tail))))
 
 end nat
 
@@ -1234,7 +1234,7 @@ protected theorem nil {n} : @vec n 0 (λ _, nil) := λ i, i.elim0
 
 protected theorem cons {n m f g}
   (hf : @primrec' n f) (hg : @vec n m g) :
-  vec (λ v, f v :: g v) :=
+  vec (λ v, (vector.cons (f v) (g v))) :=
 λ i, fin.cases (by simp *) (λ i, by simp [hg i]) i
 
 theorem idv {n} : @vec n n id := nth
@@ -1257,7 +1257,7 @@ by simpa using hf.comp' (hg.cons $ hh.cons primrec'.nil)
 theorem prec' {n f g h}
   (hf : @primrec' n f) (hg : @primrec' n g) (hh : @primrec' (n+2) h) :
   @primrec' n (λ v, (f v).elim (g v)
-    (λ (y IH : ℕ), h (y :: IH :: v))) :=
+    (λ (y IH : ℕ), h (vector.cons y (vector.cons IH v)))) :=
 by simpa using comp' (prec hg hh) (hf.cons idv)
 
 theorem pred : @primrec' 1 (λ v, v.head.pred) :=

--- a/src/computability/tm_to_partrec.lean
+++ b/src/computability/tm_to_partrec.lean
@@ -215,7 +215,7 @@ begin
     obtain ⟨cf, hf⟩ := IHf, obtain ⟨cg, hg⟩ := IHg,
     simp only [roption.map_eq_map, roption.map_some, pfun.coe_val] at hf hg,
     refine ⟨prec cf cg, λ v, _⟩, rw ← v.cons_head_tail,
-    specialize hf v.tail, replace hg := λ a b, hg (vector.cons a (vector.cons b v.tail)),
+    specialize hf v.tail, replace hg := λ a b, hg (a ::ᵥ b ::ᵥ v.tail),
     simp only [vector.cons_val, vector.tail_val] at hf hg,
     simp only [roption.map_eq_map, roption.map_some, vector.cons_val,
       vector.cons_tail, vector.cons_head, pfun.coe_val, vector.tail_val],
@@ -224,8 +224,7 @@ begin
       ← bind_pure_comp_eq_map, show ∀ x, pure x = [x], from λ _, rfl, -subtype.val_eq_coe],
     suffices : ∀ a b, a + b = n →
       (n.succ :: 0 :: g
-        (vector.cons n $ vector.cons
-          (nat.elim (f v.tail) (λ y IH, g (vector.cons y $ vector.cons IH v.tail)) n) v.tail)
+        (n ::ᵥ (nat.elim (f v.tail) (λ y IH, g (y ::ᵥ IH ::ᵥ v.tail)) n) ::ᵥ v.tail)
         :: v.val.tail : list ℕ) ∈
       pfun.fix (λ v : list ℕ, do
         x ← cg.eval (v.head :: v.tail.tail),
@@ -233,7 +232,7 @@ begin
           then sum.inl (v.head.succ :: v.tail.head.pred :: x.head :: v.tail.tail.tail : list ℕ)
           else sum.inr (v.head.succ :: v.tail.head.pred :: x.head :: v.tail.tail.tail))
         (a :: b :: nat.elim (f v.tail)
-          (λ y IH, g (vector.cons y $ vector.cons IH v.tail)) a :: v.val.tail),
+          (λ y IH, g (y ::ᵥ IH ::ᵥ v.tail)) a :: v.val.tail),
     { rw (_ : pfun.fix _ _ = pure _), swap, exact roption.eq_some_iff.2 (this 0 n (zero_add n)),
       simp only [list.head, pure_bind, list.tail_cons] },
     intros a b e, induction b with b IH generalizing a e,
@@ -245,7 +244,7 @@ begin
   case comp : m n f g hf hg IHf IHg { exact exists_code.comp IHf IHg },
   case rfind : n f hf IHf {
     obtain ⟨cf, hf⟩ := IHf, refine ⟨rfind cf, λ v, _⟩,
-    replace hf := λ a, hf (vector.cons a v),
+    replace hf := λ a, hf (a ::ᵥ v),
     simp only [roption.map_eq_map, roption.map_some, vector.cons_val, pfun.coe_val,
       show ∀ x, pure x = [x], from λ _, rfl] at hf ⊢,
     refine roption.ext (λ x, _),
@@ -259,8 +258,8 @@ begin
       suffices : ∀ (v₁ : list ℕ), v' ∈ pfun.fix
         (λ v, (cf.eval v).bind $ λ y, roption.some $ if y.head = 0 then
           sum.inl (v.head.succ :: v.tail) else sum.inr (v.head.succ :: v.tail)) v₁ →
-        ∀ n, v₁ = n :: v.val → (∀ m < n, ¬f (vector.cons m v) = 0) →
-        (∃ (a : ℕ), (f (vector.cons a v) = 0 ∧ ∀ {m : ℕ}, m < a → ¬f (vector.cons m v) = 0) ∧
+        ∀ n, v₁ = n :: v.val → (∀ m < n, ¬f (m ::ᵥ v) = 0) →
+        (∃ (a : ℕ), (f (a ::ᵥ v) = 0 ∧ ∀ {m : ℕ}, m < a → ¬f (m ::ᵥ v) = 0) ∧
           [a] = [v'.head.pred]),
       { exact this _ h1 0 rfl (by rintro _ ⟨⟩) },
       clear h1, intros v₀ h1,

--- a/src/computability/tm_to_partrec.lean
+++ b/src/computability/tm_to_partrec.lean
@@ -215,7 +215,7 @@ begin
     obtain ⟨cf, hf⟩ := IHf, obtain ⟨cg, hg⟩ := IHg,
     simp only [roption.map_eq_map, roption.map_some, pfun.coe_val] at hf hg,
     refine ⟨prec cf cg, λ v, _⟩, rw ← v.cons_head_tail,
-    specialize hf v.tail, replace hg := λ a b, hg (a :: b :: v.tail),
+    specialize hf v.tail, replace hg := λ a b, hg (vector.cons a (vector.cons b v.tail)),
     simp only [vector.cons_val, vector.tail_val] at hf hg,
     simp only [roption.map_eq_map, roption.map_some, vector.cons_val,
       vector.cons_tail, vector.cons_head, pfun.coe_val, vector.tail_val],
@@ -223,14 +223,17 @@ begin
     induction v.head with n IH; simp [prec, hf, bind_assoc, ← roption.map_eq_map,
       ← bind_pure_comp_eq_map, show ∀ x, pure x = [x], from λ _, rfl, -subtype.val_eq_coe],
     suffices : ∀ a b, a + b = n →
-      (n.succ :: 0 :: g (n :: nat.elim (f v.tail) (λ y IH, g (y::IH::v.tail)) n :: v.tail)
-         :: v.val.tail : list ℕ) ∈
+      (n.succ :: 0 :: g
+        (vector.cons n $ vector.cons
+          (nat.elim (f v.tail) (λ y IH, g (vector.cons y $ vector.cons IH v.tail)) n) v.tail)
+        :: v.val.tail : list ℕ) ∈
       pfun.fix (λ v : list ℕ, do
         x ← cg.eval (v.head :: v.tail.tail),
         pure $ if v.tail.head = 0
           then sum.inl (v.head.succ :: v.tail.head.pred :: x.head :: v.tail.tail.tail : list ℕ)
           else sum.inr (v.head.succ :: v.tail.head.pred :: x.head :: v.tail.tail.tail))
-        (a :: b :: nat.elim (f v.tail) (λ y IH, g (y::IH::v.tail)) a :: v.val.tail),
+        (a :: b :: nat.elim (f v.tail)
+          (λ y IH, g (vector.cons y $ vector.cons IH v.tail)) a :: v.val.tail),
     { rw (_ : pfun.fix _ _ = pure _), swap, exact roption.eq_some_iff.2 (this 0 n (zero_add n)),
       simp only [list.head, pure_bind, list.tail_cons] },
     intros a b e, induction b with b IH generalizing a e,
@@ -242,7 +245,7 @@ begin
   case comp : m n f g hf hg IHf IHg { exact exists_code.comp IHf IHg },
   case rfind : n f hf IHf {
     obtain ⟨cf, hf⟩ := IHf, refine ⟨rfind cf, λ v, _⟩,
-    replace hf := λ a, hf (a :: v),
+    replace hf := λ a, hf (vector.cons a v),
     simp only [roption.map_eq_map, roption.map_some, vector.cons_val, pfun.coe_val,
       show ∀ x, pure x = [x], from λ _, rfl] at hf ⊢,
     refine roption.ext (λ x, _),
@@ -256,8 +259,9 @@ begin
       suffices : ∀ (v₁ : list ℕ), v' ∈ pfun.fix
         (λ v, (cf.eval v).bind $ λ y, roption.some $ if y.head = 0 then
           sum.inl (v.head.succ :: v.tail) else sum.inr (v.head.succ :: v.tail)) v₁ →
-        ∀ n, v₁ = n :: v.val → (∀ m < n, ¬f (m :: v) = 0) →
-        (∃ (a : ℕ), (f (a :: v) = 0 ∧ ∀ {m : ℕ}, m < a → ¬f (m :: v) = 0) ∧ [a] = [v'.head.pred]),
+        ∀ n, v₁ = n :: v.val → (∀ m < n, ¬f (vector.cons m v) = 0) →
+        (∃ (a : ℕ), (f (vector.cons a v) = 0 ∧ ∀ {m : ℕ}, m < a → ¬f (vector.cons m v) = 0) ∧
+          [a] = [v'.head.pred]),
       { exact this _ h1 0 rfl (by rintro _ ⟨⟩) },
       clear h1, intros v₀ h1,
       refine pfun.fix_induction h1 (λ v₁ h2 IH, _), clear h1,

--- a/src/computability/turing_machine.lean
+++ b/src/computability/turing_machine.lean
@@ -1395,8 +1395,8 @@ local notation `cfg'` := cfg bool Λ' σ
 def read_aux : ∀ n, (vector bool n → stmt') → stmt'
 | 0     f := f vector.nil
 | (i+1) f := stmt.branch (λ a s, a)
-    (stmt.move dir.right $ read_aux i (λ v, f (vector.cons tt v)))
-    (stmt.move dir.right $ read_aux i (λ v, f (vector.cons ff v)))
+    (stmt.move dir.right $ read_aux i (λ v, f (tt ::ᵥ v)))
+    (stmt.move dir.right $ read_aux i (λ v, f (ff ::ᵥ v)))
 
 parameters {n : ℕ} (enc : Γ → vector bool n) (dec : vector bool n → Γ)
 
@@ -1568,7 +1568,7 @@ begin
   clear f L a R, intros, subst i,
   induction l₂ with a l₂ IH generalizing l₁, {refl},
   transitivity step_aux
-    (read_aux l₂.length (λ v, f (vector.cons a v))) v
+    (read_aux l₂.length (λ v, f (a ::ᵥ v))) v
     (tape.mk' ((L'.append l₁).cons a) (R'.append l₂)),
   { dsimp [read_aux, step_aux], simp, cases a; refl },
   rw [← list_blank.append, IH], refl

--- a/src/computability/turing_machine.lean
+++ b/src/computability/turing_machine.lean
@@ -1395,8 +1395,8 @@ local notation `cfg'` := cfg bool Λ' σ
 def read_aux : ∀ n, (vector bool n → stmt') → stmt'
 | 0     f := f vector.nil
 | (i+1) f := stmt.branch (λ a s, a)
-    (stmt.move dir.right $ read_aux i (λ v, f (tt :: v)))
-    (stmt.move dir.right $ read_aux i (λ v, f (ff :: v)))
+    (stmt.move dir.right $ read_aux i (λ v, f (vector.cons tt v)))
+    (stmt.move dir.right $ read_aux i (λ v, f (vector.cons ff v)))
 
 parameters {n : ℕ} (enc : Γ → vector bool n) (dec : vector bool n → Γ)
 
@@ -1568,7 +1568,7 @@ begin
   clear f L a R, intros, subst i,
   induction l₂ with a l₂ IH generalizing l₁, {refl},
   transitivity step_aux
-    (read_aux l₂.length (λ v, f (a :: v))) v
+    (read_aux l₂.length (λ v, f (vector.cons a v))) v
     (tape.mk' ((L'.append l₁).cons a) (R'.append l₂)),
   { dsimp [read_aux, step_aux], simp, cases a; refl },
   rw [← list_blank.append, IH], refl

--- a/src/data/bitvec/core.lean
+++ b/src/data/bitvec/core.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joe Hendrix, Sebastian Ullrich
 -/
 
-import data.vector
+import data.vector2
 import data.nat.basic
 
 /-!
@@ -22,7 +22,6 @@ namespace bitvec
 open nat
 open vector
 
-local infix `::` := vector.cons
 local infix `++ₜ`:65 := vector.append
 
 /-- Create a zero bitvector -/
@@ -31,7 +30,7 @@ local infix `++ₜ`:65 := vector.append
 /-- Create a bitvector of length `n` whose `n-1`st entry is 1 and other entries are 0. -/
 @[reducible] protected def one : Π (n : ℕ), bitvec n
 | 0        := nil
-| (succ n) := repeat ff n ++ₜ tt::nil
+| (succ n) := repeat ff n ++ₜ tt::ᵥnil
 
 /-- Create a bitvector from another with a provably equal length. -/
 protected def cong {a b : ℕ} (h : a = b) : bitvec a → bitvec b
@@ -72,7 +71,7 @@ fill_shr x i ff
 /-- signed shift right -/
 def sshr : Π {m : ℕ}, bitvec m → ℕ → bitvec m
 | 0        _ _ := nil
-| (succ m) x i := head x :: fill_shr (tail x) i (head x)
+| (succ m) x i := head x ::ᵥ fill_shr (tail x) i (head x)
 
 end shift
 
@@ -110,7 +109,7 @@ prod.snd (map_accumr f x ff)
 def adc (x y : bitvec n) (c : bool) : bitvec (n+1) :=
 let f := λ x y c, (bitvec.carry x y c, bitvec.xor3 x y c) in
 let ⟨c, z⟩ := vector.map_accumr₂ f x y c in
-c :: z
+c ::ᵥ z
 
 /-- The sum of two bitvectors -/
 protected def add (x y : bitvec n) : bitvec n := tail (adc x y ff)
@@ -183,12 +182,12 @@ variable {α : Type}
 /-- Create a bitvector from a `nat` -/
 protected def of_nat : Π (n : ℕ), nat → bitvec n
 | 0        x := nil
-| (succ n) x := of_nat n (x / 2) ++ₜ to_bool (x % 2 = 1) :: nil
+| (succ n) x := of_nat n (x / 2) ++ₜ to_bool (x % 2 = 1) ::ᵥ nil
 
 /-- Create a bitvector in the two's complement representation from an `int` -/
 protected def of_int : Π (n : ℕ), int → bitvec (succ n)
-| n (int.of_nat m)          := ff :: bitvec.of_nat n m
-| n (int.neg_succ_of_nat m) := tt :: not (bitvec.of_nat n m)
+| n (int.of_nat m)          := ff ::ᵥ bitvec.of_nat n m
+| n (int.neg_succ_of_nat m) := tt ::ᵥ not (bitvec.of_nat n m)
 
 /-- `add_lsb r b` is `r + r + 1` if `b` is `tt` and `r + r` otherwise. -/
 def add_lsb (r : ℕ) (b : bool) := r + r + cond b 1 0
@@ -209,7 +208,7 @@ local attribute [simp] nat.zero_add nat.add_zero nat.one_mul nat.mul_one nat.zer
 -- mul_left_comm
 
 theorem to_nat_append {m : ℕ} (xs : bitvec m) (b : bool) :
-bitvec.to_nat (xs ++ₜ b::nil) = bitvec.to_nat xs * 2 + bitvec.to_nat (b::nil) :=
+bitvec.to_nat (xs ++ₜ b::ᵥnil) = bitvec.to_nat xs * 2 + bitvec.to_nat (b::ᵥnil) :=
 begin
   cases xs with xs P,
   simp [bits_to_nat_to_list], clear P,
@@ -223,7 +222,7 @@ begin
 end
 
 theorem bits_to_nat_to_bool (n : ℕ)
-: bitvec.to_nat (to_bool (n % 2 = 1) :: nil) = n % 2 :=
+: bitvec.to_nat (to_bool (n % 2 = 1) ::ᵥ nil) = n % 2 :=
 begin
   simp [bits_to_nat_to_list],
   unfold bits_to_nat add_lsb list.foldl cond,
@@ -231,7 +230,7 @@ begin
 end
 
 theorem of_nat_succ {k n : ℕ}
-:  bitvec.of_nat (succ k) n = bitvec.of_nat k (n / 2) ++ₜ to_bool (n % 2 = 1) :: nil :=
+:  bitvec.of_nat (succ k) n = bitvec.of_nat k (n / 2) ++ₜ to_bool (n % 2 = 1) ::ᵥ nil :=
 rfl
 
 theorem to_nat_of_nat {k n : ℕ}

--- a/src/data/bitvec/core.lean
+++ b/src/data/bitvec/core.lean
@@ -22,6 +22,7 @@ namespace bitvec
 open nat
 open vector
 
+local infix `::` := vector.cons
 local infix `++ₜ`:65 := vector.append
 
 /-- Create a zero bitvector -/

--- a/src/data/num/bitwise.lean
+++ b/src/data/num/bitwise.lean
@@ -2,11 +2,19 @@
 Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Mario Carneiro
-
-Bitwise operations using binary representation of integers.
 -/
 import data.num.basic
 import data.bitvec.core
+
+/-!
+# Bitwise operations using binary representation of integers
+
+## Definitions
+
+* bitwise operations for `pos_num` and `num`,
+* `snum`, a type that represents integers as a bit string with a sign bit at the end,
+* arithmetic operations for `snum`.
+-/
 
 namespace pos_num
 
@@ -146,8 +154,10 @@ instance : has_one snum := ⟨snum.nz 1⟩
 instance : inhabited nzsnum := ⟨1⟩
 instance : inhabited snum := ⟨0⟩
 
-/- The snum representation uses a bit string, essentially a list of 0 (ff) and 1 (tt) bits,
-   and the negation of the MSB is sign-extended to all higher bits. -/
+/-!
+The `snum` representation uses a bit string, essentially a list of 0 (`ff`) and 1 (`tt`) bits,
+and the negation of the MSB is sign-extended to all higher bits.
+-/
 namespace nzsnum
   notation a :: b := bit a b
 
@@ -242,7 +252,7 @@ namespace snum
 
   instance : has_neg snum := ⟨snum.neg⟩
 
-  -- First bit is 0 or 1 (tt), second bit is 0 or -1 (tt)
+  -- First bit is 0 or 1 (`tt`), second bit is 0 or -1 (`tt`)
   def czadd : bool → bool → snum → snum
   | ff ff p := p
   | ff tt p := pred p
@@ -255,8 +265,7 @@ namespace snum
 
 def bits : snum → Π n, vector bool n
 | p 0     := vector.nil
-| p (n+1) := head p :: bits (tail p) n
-
+| p (n+1) := vector.cons (head p) (bits (tail p) n)
 
 def cadd : snum → snum → bool → snum :=
 rec' (λ a p c, czadd c a p) $ λa p IH,

--- a/src/data/num/bitwise.lean
+++ b/src/data/num/bitwise.lean
@@ -265,7 +265,7 @@ namespace snum
 
 def bits : snum → Π n, vector bool n
 | p 0     := vector.nil
-| p (n+1) := vector.cons (head p) (bits (tail p) n)
+| p (n+1) := head p ::ᵥ bits (tail p) n
 
 def cadd : snum → snum → bool → snum :=
 rec' (λ a p c, czadd c a p) $ λa p IH,

--- a/src/data/sym.lean
+++ b/src/data/sym.lean
@@ -103,7 +103,7 @@ mem_cons.2 (or.inr h)
 @[simp] lemma mem_cons_self (a : α) (s : sym α n) : a ∈ a :: s :=
 mem_cons.2 (or.inl rfl)
 
-lemma cons_of_coe_eq (a : α) (v : vector α n) : a :: (↑v : sym α n) = ↑(a :: v) :=
+lemma cons_of_coe_eq (a : α) (v : vector α n) : a :: (↑v : sym α n) = ↑(vector.cons a v) :=
 by { unfold_coes, delta of_vector, delta cons, delta vector.cons, tidy }
 
 lemma sound {a b : vector α n} (h : a.val ~ b.val) : (↑a : sym α n) = ↑b :=

--- a/src/data/sym.lean
+++ b/src/data/sym.lean
@@ -5,7 +5,7 @@ Author: Kyle Miller.
 -/
 
 import data.multiset.basic
-import data.vector
+import data.vector2
 import tactic.tidy
 
 /-!
@@ -103,7 +103,7 @@ mem_cons.2 (or.inr h)
 @[simp] lemma mem_cons_self (a : α) (s : sym α n) : a ∈ a :: s :=
 mem_cons.2 (or.inl rfl)
 
-lemma cons_of_coe_eq (a : α) (v : vector α n) : a :: (↑v : sym α n) = ↑(vector.cons a v) :=
+lemma cons_of_coe_eq (a : α) (v : vector α n) : a :: (↑v : sym α n) = ↑(a ::ᵥ v) :=
 by { unfold_coes, delta of_vector, delta cons, delta vector.cons, tidy }
 
 lemma sound {a b : vector α n} (h : a.val ~ b.val) : (↑a : sym α n) = ↑b :=

--- a/src/data/vector2.lean
+++ b/src/data/vector2.lean
@@ -16,6 +16,8 @@ variables {n : ℕ}
 namespace vector
 variables {α : Type*}
 
+infixr `::ᵥ`:67  := vector.cons
+
 attribute [simp] head_cons tail_cons
 
 instance [inhabited α] : inhabited (vector α n) :=

--- a/src/data/vector2.lean
+++ b/src/data/vector2.lean
@@ -263,7 +263,7 @@ variables {α β γ : Type u}
 
 @[simp] protected lemma traverse_def
   (f : α → F β) (x : α) : ∀ (xs : vector α n),
-  (cons x xs).traverse f = cons <$> f x <*> xs.traverse f :=
+  (x ::ᵥ xs).traverse f = cons <$> f x <*> xs.traverse f :=
 by rintro ⟨xs, rfl⟩; refl
 
 protected lemma id_traverse : ∀ (x : vector α n), x.traverse id.mk = x :=

--- a/src/data/vector2.lean
+++ b/src/data/vector2.lean
@@ -2,14 +2,14 @@
 Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
-
-Additional theorems about the `vector` type.
 -/
 import data.vector
 import data.list.nodup
 import data.list.of_fn
 import control.applicative
-
+/-!
+# Additional theorems about the `vector` type
+-/
 universes u
 variables {n : ℕ}
 
@@ -24,13 +24,13 @@ instance [inhabited α] : inhabited (vector α n) :=
 theorem to_list_injective : function.injective (@to_list α n) :=
 subtype.val_injective
 
-@[simp] theorem cons_val (a : α) : ∀ (v : vector α n), (a :: v).val = a :: v.val
+@[simp] theorem cons_val (a : α) : ∀ (v : vector α n), (cons a v).val = a :: v.val
 | ⟨_, _⟩ := rfl
 
-@[simp] theorem cons_head (a : α) : ∀ (v : vector α n), (a :: v).head = a
+@[simp] theorem cons_head (a : α) : ∀ (v : vector α n), (cons a v).head = a
 | ⟨_, _⟩ := rfl
 
-@[simp] theorem cons_tail (a : α) : ∀ (v : vector α n), (a :: v).tail = v
+@[simp] theorem cons_tail (a : α) : ∀ (v : vector α n), (cons a v).tail = v
 | ⟨_, _⟩ := rfl
 
 @[simp] theorem to_list_of_fn : ∀ {n} (f : fin n → α), to_list (of_fn f) = list.of_fn f
@@ -110,16 +110,16 @@ def reverse (v : vector α n) : vector α n :=
 by rw [← nth_zero, nth_of_fn]
 
 @[simp] theorem nth_cons_zero
-  (a : α) (v : vector α n) : nth (a :: v) 0 = a :=
+  (a : α) (v : vector α n) : nth (cons a v) 0 = a :=
 by simp [nth_zero]
 
 @[simp] theorem nth_cons_succ
-  (a : α) (v : vector α n) (i : fin n) : nth (a :: v) i.succ = nth v i :=
+  (a : α) (v : vector α n) (i : fin n) : nth (cons a v) i.succ = nth v i :=
 by rw [← nth_tail, tail_cons]
 
 def m_of_fn {m} [monad m] {α : Type u} : ∀ {n}, (fin n → m α) → m (vector α n)
 | 0     f := pure nil
-| (n+1) f := do a ← f 0, v ← m_of_fn (λi, f i.succ), pure (a :: v)
+| (n+1) f := do a ← f 0, v ← m_of_fn (λi, f i.succ), pure (cons a v)
 
 theorem m_of_fn_pure {m} [monad m] [is_lawful_monad m] {α} :
   ∀ {n} (f : fin n → α), @m_of_fn m _ _ _ (λ i, pure (f i)) = pure (of_fn f)
@@ -129,14 +129,14 @@ theorem m_of_fn_pure {m} [monad m] [is_lawful_monad m] {α} :
 def mmap {m} [monad m] {α} {β : Type u} (f : α → m β) :
   ∀ {n}, vector α n → m (vector β n)
 | _ ⟨[], rfl⟩   := pure nil
-| _ ⟨a::l, rfl⟩ := do h' ← f a, t' ← mmap ⟨l, rfl⟩, pure (h' :: t')
+| _ ⟨a::l, rfl⟩ := do h' ← f a, t' ← mmap ⟨l, rfl⟩, pure (cons h' t')
 
 @[simp] theorem mmap_nil {m} [monad m] {α β} (f : α → m β) :
   mmap f nil = pure nil := rfl
 
 @[simp] theorem mmap_cons {m} [monad m] {α β} (f : α → m β) (a) :
-  ∀ {n} (v : vector α n), mmap f (a::v) =
-  do h' ← f a, t' ← mmap f v, pure (h' :: t')
+  ∀ {n} (v : vector α n), mmap f (cons a v) =
+  do h' ← f a, t' ← mmap f v, pure (cons h' t')
 | _ ⟨l, rfl⟩ := rfl
 
 @[ext] theorem ext : ∀ {v w : vector α n}
@@ -261,7 +261,7 @@ variables {α β γ : Type u}
 
 @[simp] protected lemma traverse_def
   (f : α → F β) (x : α) : ∀ (xs : vector α n),
-  (x :: xs).traverse f = cons <$> f x <*> xs.traverse f :=
+  (cons x xs).traverse f = cons <$> f x <*> xs.traverse f :=
 by rintro ⟨xs, rfl⟩; refl
 
 protected lemma id_traverse : ∀ (x : vector α n), x.traverse id.mk = x :=

--- a/src/data/vector2.lean
+++ b/src/data/vector2.lean
@@ -9,6 +9,8 @@ import data.list.of_fn
 import control.applicative
 /-!
 # Additional theorems about the `vector` type
+
+This file introduces the infix notation `::ᵥ` for `vector.cons`.
 -/
 universes u
 variables {n : ℕ}

--- a/src/data/vector2.lean
+++ b/src/data/vector2.lean
@@ -26,13 +26,13 @@ instance [inhabited α] : inhabited (vector α n) :=
 theorem to_list_injective : function.injective (@to_list α n) :=
 subtype.val_injective
 
-@[simp] theorem cons_val (a : α) : ∀ (v : vector α n), (cons a v).val = a :: v.val
+@[simp] theorem cons_val (a : α) : ∀ (v : vector α n), (a ::ᵥ v).val = a :: v.val
 | ⟨_, _⟩ := rfl
 
-@[simp] theorem cons_head (a : α) : ∀ (v : vector α n), (cons a v).head = a
+@[simp] theorem cons_head (a : α) : ∀ (v : vector α n), (a ::ᵥ v).head = a
 | ⟨_, _⟩ := rfl
 
-@[simp] theorem cons_tail (a : α) : ∀ (v : vector α n), (cons a v).tail = v
+@[simp] theorem cons_tail (a : α) : ∀ (v : vector α n), (a ::ᵥ v).tail = v
 | ⟨_, _⟩ := rfl
 
 @[simp] theorem to_list_of_fn : ∀ {n} (f : fin n → α), to_list (of_fn f) = list.of_fn f
@@ -112,16 +112,16 @@ def reverse (v : vector α n) : vector α n :=
 by rw [← nth_zero, nth_of_fn]
 
 @[simp] theorem nth_cons_zero
-  (a : α) (v : vector α n) : nth (cons a v) 0 = a :=
+  (a : α) (v : vector α n) : nth (a ::ᵥ v) 0 = a :=
 by simp [nth_zero]
 
 @[simp] theorem nth_cons_succ
-  (a : α) (v : vector α n) (i : fin n) : nth (cons a v) i.succ = nth v i :=
+  (a : α) (v : vector α n) (i : fin n) : nth (a ::ᵥ v) i.succ = nth v i :=
 by rw [← nth_tail, tail_cons]
 
 def m_of_fn {m} [monad m] {α : Type u} : ∀ {n}, (fin n → m α) → m (vector α n)
 | 0     f := pure nil
-| (n+1) f := do a ← f 0, v ← m_of_fn (λi, f i.succ), pure (cons a v)
+| (n+1) f := do a ← f 0, v ← m_of_fn (λi, f i.succ), pure (a ::ᵥ v)
 
 theorem m_of_fn_pure {m} [monad m] [is_lawful_monad m] {α} :
   ∀ {n} (f : fin n → α), @m_of_fn m _ _ _ (λ i, pure (f i)) = pure (of_fn f)
@@ -131,14 +131,14 @@ theorem m_of_fn_pure {m} [monad m] [is_lawful_monad m] {α} :
 def mmap {m} [monad m] {α} {β : Type u} (f : α → m β) :
   ∀ {n}, vector α n → m (vector β n)
 | _ ⟨[], rfl⟩   := pure nil
-| _ ⟨a::l, rfl⟩ := do h' ← f a, t' ← mmap ⟨l, rfl⟩, pure (cons h' t')
+| _ ⟨a::l, rfl⟩ := do h' ← f a, t' ← mmap ⟨l, rfl⟩, pure (h' ::ᵥ t')
 
 @[simp] theorem mmap_nil {m} [monad m] {α β} (f : α → m β) :
   mmap f nil = pure nil := rfl
 
 @[simp] theorem mmap_cons {m} [monad m] {α β} (f : α → m β) (a) :
-  ∀ {n} (v : vector α n), mmap f (cons a v) =
-  do h' ← f a, t' ← mmap f v, pure (cons h' t')
+  ∀ {n} (v : vector α n), mmap f (a ::ᵥ v) =
+  do h' ← f a, t' ← mmap f v, pure (h' ::ᵥ t')
 | _ ⟨l, rfl⟩ := rfl
 
 @[ext] theorem ext : ∀ {v w : vector α n}

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -78,7 +78,7 @@ namespace sylow
 /-- Given a vector `v` of length `n`, make a vector of length `n+1` whose product is `1`,
 by consing the the inverse of the product of `v`. -/
 def mk_vector_prod_eq_one (n : ℕ) (v : vector G n) : vector G (n+1) :=
-vector.cons v.to_list.prod⁻¹ v
+v.to_list.prod⁻¹ ::ᵥ v
 
 lemma mk_vector_prod_eq_one_injective (n : ℕ) : injective (@mk_vector_prod_eq_one G _ n) :=
 λ ⟨v, _⟩ ⟨w, _⟩ h, subtype.eq (show v = w, by injection h with h; injection h)

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -34,7 +34,8 @@ begin
 end
 
 lemma card_modeq_card_fixed_points [fintype α] [fintype G] [fintype (fixed_points G α)]
-  (p : ℕ) {n : ℕ} [hp : fact p.prime] (h : card G = p ^ n) : card α ≡ card (fixed_points G α) [MOD p] :=
+  (p : ℕ) {n : ℕ} [hp : fact p.prime] (h : card G = p ^ n) :
+  card α ≡ card (fixed_points G α) [MOD p] :=
 calc card α = card (Σ y : quotient (orbit_rel G α), {x // quotient.mk' x = y}) :
   card_congr (sigma_preimage_equiv (@quotient.mk' _ (orbit_rel G α))).symm
 ... = ∑ a : quotient (orbit_rel G α), card {x // quotient.mk' x = a} : card_sigma _
@@ -77,7 +78,7 @@ namespace sylow
 /-- Given a vector `v` of length `n`, make a vector of length `n+1` whose product is `1`,
 by consing the the inverse of the product of `v`. -/
 def mk_vector_prod_eq_one (n : ℕ) (v : vector G n) : vector G (n+1) :=
-v.to_list.prod⁻¹ :: v
+vector.cons v.to_list.prod⁻¹ v
 
 lemma mk_vector_prod_eq_one_injective (n : ℕ) : injective (@mk_vector_prod_eq_one G _ n) :=
 λ ⟨v, _⟩ ⟨w, _⟩ h, subtype.eq (show v = w, by injection h with h; injection h)
@@ -172,8 +173,9 @@ let ⟨a, ha⟩ := this in
 
 open subgroup submonoid is_group_hom mul_action
 
-lemma mem_fixed_points_mul_left_cosets_iff_mem_normalizer {H : subgroup G} [fintype ((H : set G) : Type u)]
-  {x : G} : (x : quotient H) ∈ fixed_points H (quotient H) ↔ x ∈ normalizer H :=
+lemma mem_fixed_points_mul_left_cosets_iff_mem_normalizer {H : subgroup G}
+  [fintype ((H : set G) : Type u)] {x : G} :
+  (x : quotient H) ∈ fixed_points H (quotient H) ↔ x ∈ normalizer H :=
 ⟨λ hx, have ha : ∀ {y : quotient H}, y ∈ orbit H (x : quotient H) → y = x,
   from λ _, ((mem_fixed_points' _).1 hx _),
   (inv_mem_iff _).1 (@mem_normalizer_fintype _ _ _ _inst_2 _ (λ n (hn : n ∈ H),
@@ -192,7 +194,8 @@ def fixed_points_mul_left_cosets_equiv_quotient (H : subgroup G) [fintype (H : s
   fixed_points H (quotient H) ≃
   quotient (subgroup.comap ((normalizer H).subtype : normalizer H →* G) H) :=
 @subtype_quotient_equiv_quotient_subtype G (normalizer H : set G) (id _) (id _) (fixed_points _ _)
-  (λ a, (@mem_fixed_points_mul_left_cosets_iff_mem_normalizer _ _ _ _inst_2 _).symm) (by intros; refl)
+  (λ a, (@mem_fixed_points_mul_left_cosets_iff_mem_normalizer _ _ _ _inst_2 _).symm)
+  (by intros; refl)
 
 lemma exists_subgroup_card_pow_prime [fintype G] (p : ℕ) : ∀ {n : ℕ} [hp : fact p.prime]
   (hdvd : p ^ n ∣ card G), ∃ H : subgroup G, fintype.card H = p ^ n
@@ -224,17 +227,16 @@ have hequiv : H ≃ (subgroup.comap ((normalizer H).subtype : normalizer H →* 
 -- begin proof of ∃ H : subgroup G, fintype.card H = p ^ n
 ⟨subgroup.map ((normalizer H).subtype) (subgroup.comap (quotient_group.mk' _) (gpowers x)),
 begin
-  show card ↥(map H.normalizer.subtype (comap (mk' (comap H.normalizer.subtype H)) (subgroup.gpowers x))) =
-    p ^ (n + 1),
+  show card ↥(map H.normalizer.subtype
+    (comap (mk' (comap H.normalizer.subtype H)) (subgroup.gpowers x))) = p ^ (n + 1),
   suffices : card ↥(subtype.val '' ((subgroup.comap (mk' (comap H.normalizer.subtype H))
     (gpowers x)) : set (↥(H.normalizer)))) = p^(n+1),
   { convert this },
   rw [set.card_image_of_injective
-       (subgroup.comap (quotient_group.mk' _) (gpowers x) : set (H.normalizer)) subtype.val_injective,
+       (subgroup.comap (mk' _) (gpowers x) : set (H.normalizer)) subtype.val_injective,
       pow_succ', ← hH2, fintype.card_congr hequiv, ← hx, order_eq_card_gpowers,
       ← fintype.card_prod],
   exact @fintype.card_congr _ _ (id _) (id _) (preimage_mk_equiv_subgroup_times_set _ _)
-end
-⟩
+end⟩
 
 end sylow

--- a/src/number_theory/sum_four_squares.lean
+++ b/src/number_theory/sum_four_squares.lean
@@ -80,8 +80,10 @@ private lemma sum_four_squares_of_two_mul_sum_four_squares {m a b c d : ℤ}
 have ∀ f : fin 4 → zmod 2, (f 0)^2 + (f 1)^2 + (f 2)^2 + (f 3)^2 = 0 →
     ∃ i : (fin 4), (f i)^2 + f (swap i 0 1)^2 = 0 ∧ f (swap i 0 2)^2 + f (swap i 0 3)^2 = 0,
   from dec_trivial,
-let f : fin 4 → ℤ := vector.nth (a::b::c::d::vector.nil) in
-let ⟨i, hσ⟩ := this (coe ∘ f) (by rw [← @zero_mul (zmod 2) _ m, ← show ((2 : ℤ) : zmod 2) = 0, from rfl,
+let f : fin 4 → ℤ :=
+  vector.nth (vector.cons a $ vector.cons b $ vector.cons c $ vector.cons d vector.nil) in
+let ⟨i, hσ⟩ := this (coe ∘ f) (by rw [← @zero_mul (zmod 2) _ m,
+  ← show ((2 : ℤ) : zmod 2) = 0, from rfl,
   ← int.cast_mul, ← h]; simp only [int.cast_add, int.cast_pow]; refl) in
 let σ := swap i 0 in
 have h01 : 2 ∣ f (σ 0) ^ 2 + f (σ 1) ^ 2,
@@ -156,7 +158,8 @@ m.mod_two_eq_zero_or_one.elim
         have hwxyz0 : (w.nat_abs^2 + x.nat_abs^2 + y.nat_abs^2 + z.nat_abs^2 : ℕ) = 0,
           by { rw [← int.coe_nat_eq_zero, ← hnat_abs], rwa [hn0, mul_zero] at hn },
         have habcd0 : (m : ℤ) ∣ a ∧ (m : ℤ) ∣ b ∧ (m : ℤ) ∣ c ∧ (m : ℤ) ∣ d,
-          by simpa [@add_eq_zero_iff_eq_zero_of_nonneg ℤ _ _ _ (pow_two_nonneg _) (pow_two_nonneg _),
+          by simpa [@add_eq_zero_iff_eq_zero_of_nonneg ℤ _ _ _ (pow_two_nonneg _)
+              (pow_two_nonneg _),
             pow_two, w, x, y, z, (char_p.int_cast_eq_zero_iff _ m _), and.assoc] using hwxyz0,
         let ⟨ma, hma⟩ := habcd0.1,     ⟨mb, hmb⟩ := habcd0.2.1,
             ⟨mc, hmc⟩ := habcd0.2.2.1, ⟨md, hmd⟩ := habcd0.2.2.2 in

--- a/src/number_theory/sum_four_squares.lean
+++ b/src/number_theory/sum_four_squares.lean
@@ -81,7 +81,7 @@ have ∀ f : fin 4 → zmod 2, (f 0)^2 + (f 1)^2 + (f 2)^2 + (f 3)^2 = 0 →
     ∃ i : (fin 4), (f i)^2 + f (swap i 0 1)^2 = 0 ∧ f (swap i 0 2)^2 + f (swap i 0 3)^2 = 0,
   from dec_trivial,
 let f : fin 4 → ℤ :=
-  vector.nth (vector.cons a $ vector.cons b $ vector.cons c $ vector.cons d vector.nil) in
+  vector.nth (a ::ᵥ b ::ᵥ c ::ᵥ d ::ᵥ vector.nil) in
 let ⟨i, hσ⟩ := this (coe ∘ f) (by rw [← @zero_mul (zmod 2) _ m,
   ← show ((2 : ℤ) : zmod 2) = 0, from rfl,
   ← int.cast_mul, ← h]; simp only [int.cast_add, int.cast_pow]; refl) in

--- a/src/topology/list.lean
+++ b/src/topology/list.lean
@@ -169,7 +169,7 @@ instance (n : ℕ) : topological_space (vector α n) :=
 by unfold vector; apply_instance
 
 lemma tendsto_cons {n : ℕ} {a : α} {l : vector α n}:
-  tendsto (λp:α×vector α n, vector.cons p.1 p.2) (𝓝 a ×ᶠ 𝓝 l) (𝓝 (vector.cons a l)) :=
+  tendsto (λp:α×vector α n, p.1 ::ᵥ p.2) (𝓝 a ×ᶠ 𝓝 l) (𝓝 (a ::ᵥ l)) :=
 by { simp [tendsto_subtype_rng, ←subtype.val_eq_coe, cons_val],
   exact tendsto_fst.cons (tendsto.comp continuous_at_subtype_coe tendsto_snd) }
 

--- a/src/topology/list.lean
+++ b/src/topology/list.lean
@@ -2,12 +2,13 @@
 Copyright (c) 2019 Reid Barton. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
-
-Topology on lists and vectors.
 -/
 import topology.constructions
 import topology.algebra.group
+/-!
+# Topology on lists and vectors
 
+-/
 open topological_space set filter
 open_locale topological_space filter
 
@@ -29,7 +30,8 @@ begin
     rcases (mem_traverse_sets_iff _ _).1 hs with ⟨u, hu, hus⟩, clear as hs,
     have : ∃v:list (set α), l.forall₂ (λa s, is_open s ∧ a ∈ s) v ∧ sequence v ⊆ s,
     { induction hu generalizing s,
-      case list.forall₂.nil : hs this { existsi [], simpa only [list.forall₂_nil_left_iff, exists_eq_left] },
+      case list.forall₂.nil : hs this
+        { existsi [], simpa only [list.forall₂_nil_left_iff, exists_eq_left] },
       case list.forall₂.cons : a s as ss ht h ih t hts {
         rcases mem_nhds_sets_iff.1 ht with ⟨u, hut, hu⟩,
         rcases ih (subset.refl _) with ⟨v, hv, hvss⟩,
@@ -167,7 +169,7 @@ instance (n : ℕ) : topological_space (vector α n) :=
 by unfold vector; apply_instance
 
 lemma tendsto_cons {n : ℕ} {a : α} {l : vector α n}:
-  tendsto (λp:α×vector α n, vector.cons p.1 p.2) (𝓝 a ×ᶠ 𝓝 l) (𝓝 (a :: l)) :=
+  tendsto (λp:α×vector α n, vector.cons p.1 p.2) (𝓝 a ×ᶠ 𝓝 l) (𝓝 (vector.cons a l)) :=
 by { simp [tendsto_subtype_rng, ←subtype.val_eq_coe, cons_val],
   exact tendsto_fst.cons (tendsto.comp continuous_at_subtype_coe tendsto_snd) }
 


### PR DESCRIPTION
The only real change is the removal of notation for `vector.cons`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
