### PR TITLE
feat(tactic/chain_trans): prove inequalities by transitivity on multiple assumptions

### DIFF
--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -661,7 +661,8 @@ def mmap_filter {m : Type u → Type v} [monad m] {α β} (f : α → m (option 
 
 /-- Filters and maps elements of a list `alternative` operations to accept or
 reject elements of the list -/
-def mmap_filter' {m} [applicative m] [alternative m] {α β} (f : α → m β) : list.{u} α → m (list.{v} β)
+def mmap_filter' {m : Type u → Type v} [applicative m] [alternative m]
+  {α β} (f : α → m β) : list.{w} α → m (list.{u} β)
 | [] := pure []
 | (x :: xs) :=
   ((::) <$> f x <|> pure id) <*> mmap_filter' xs

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -653,11 +653,18 @@ def choose (hp : ∃ a, a ∈ l ∧ p a) : α := choose_x p l hp
 end choose
 
 /-- Filters and maps elements of a list -/
-def mmap_filter {m : Type → Type v} [monad m] {α β} (f : α → m (option β)) :
+def mmap_filter {m : Type u → Type v} [monad m] {α β} (f : α → m (option β)) :
   list α → m (list β)
 | []       := return []
 | (h :: t) := do b ← f h, t' ← t.mmap_filter, return $
   match b with none := t' | (some x) := x::t' end
+
+/-- Filters and maps elements of a list `alternative` operations to accept or
+reject elements of the list -/
+def mmap_filter' {m} [applicative m] [alternative m] {α β} (f : α → m β) : list.{u} α → m (list.{v} β)
+| [] := pure []
+| (x :: xs) :=
+  ((::) <$> f x <|> pure id) <*> mmap_filter' xs
 
 /--
 `mmap_upper_triangle f l` calls `f` on all elements in the upper triangular part of `l × l`.

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -428,6 +428,18 @@ meta def match_macro {elab} : expr elab →
 | (macro df args) := some (df, args)
 | _ := none
 
+/-- Match a `≤` or `≥` expression. -/
+meta def match_le : expr → option (expr × expr)
+| `(%%x ≤ %%y) := pure (x, y)
+| `(%%x ≥ %%y) := pure (y, x)
+| _ := none
+
+/-- Match a `<` or `>` expression. -/
+meta def match_lt : expr → option (expr × expr)
+| `(%%x < %%y) := pure (x, y)
+| `(%%x > %%y) := pure (y, x)
+| _ := none
+
 /-- Tests whether an expression is a meta-variable. -/
 meta def is_mvar : expr → bool
 | (mvar _ _ _) := tt

--- a/src/meta/rb_map.lean
+++ b/src/meta/rb_map.lean
@@ -155,6 +155,10 @@ protected meta def of_list {key : Type} {data : Type} [has_lt key]
 protected meta def values {key data} (m : rb_lmap key data) : list data :=
 m.fold [] (λ _, (++))
 
+meta instance rb_lmap.has_to_format {α β} [has_to_tactic_format α] [has_to_tactic_format β] :
+  has_to_tactic_format (native.rb_lmap α β) :=
+by delta native.rb_lmap id_rhs; apply_instance
+
 end rb_lmap
 end native
 

--- a/src/tactic/chain_trans.lean
+++ b/src/tactic/chain_trans.lean
@@ -63,8 +63,10 @@ instance : decidable_linear_order edge :=
   le_refl := by { intro x, cases x; constructor },
   le_antisymm := by { introv h₀ h₁, cases h₀; cases h₁; refl },
   le_trans := by { introv h₀ h₁, cases h₀, { constructor }, cases h₁, constructor },
-  le_total := by { intros x y, cases x; cases y; { left; constructor } <|> { right; constructor } },
-  decidable_le := by { intros x y, cases x; cases y; { left; intro h; cases h; done } <|> { right; constructor } }
+  le_total :=
+  by { intros x y, cases x; cases y; { left; constructor } <|> { right; constructor } },
+  decidable_le :=
+  by { intros x y, cases x; cases y; { left; intro h; cases h; done } <|> { right; constructor } }
  }
 
 meta instance edge.has_to_format : has_to_format edge :=
@@ -143,7 +145,8 @@ ls ← local_context >>= list.mmap_filter'
 let m := list.foldl  (λ (m : graph) (e : _ × _ × _ × _),
   let ⟨pr,e,x,y⟩ := e in
   m.insert x (pr,e,y)) (native.rb_lmap.mk expr (expr × edge × expr)) ls.join,
-pr ← dfs_trans m x y goal <|> fail!"no appropriate chain of inequalities can be found between `{x}` and `{y}`",
+pr ← dfs_trans m x y goal <|>
+  fail!"no appropriate chain of inequalities can be found between `{x}` and `{y}`",
 tactic.apply pr <|>
   mk_app ``le_of_lt [pr] >>= tactic.apply,
 skip

--- a/src/tactic/chain_trans.lean
+++ b/src/tactic/chain_trans.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2020 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+-/
+import meta.rb_map
+import meta.expr
+import tactic.core
+/-!
+# `chain_trans` tactic
+
+This file defines the `chain_trans` tactic which prove goals of the
+shape `x ≤ y` or `x < y` by finding assumptions of the shape `x ≤ z`,
+`x < z` or `x = z` and combining them using transitivity. In order
+to prove `x < y`, at least one of the assumptions must be
+a strict ordering. Whatever is found, `x ≤ y` can be proved.
+
+```lean
+variables {w x y z : ℕ}
+example (h₀ : w ≤ x) (h₁ : x = y) (h₂ : y < z) : w < z :=
+begin
+  chain_trans,
+end
+```
+
+## Implementation
+
+`chain_trans` builds a graph where vertices are expressions of type
+`α`, with a preorder on `α`, and edges are assumptions stating an
+order between its source and its target. It then uses depth first
+search to find a path through that graph between two vertices.
+the edges along that path can then be combined through transitivity
+to prove an order between the two vertices.
+-/
+
+universes u v
+
+namespace tactic
+
+open expr
+
+namespace chain_trans
+
+/-- A label for the edges of a graph of assumptions to
+specify whether the assumption is a strict ordering
+(i.e. `<`) or non-strict ordering (i.e. `≤`). -/
+@[derive inhabited]
+inductive edge
+| lt | le
+
+instance : has_to_string edge :=
+⟨ λ e, match e with
+      | edge.lt := "lt"
+      | edge.le := "le"
+      end ⟩
+
+meta instance edge.has_to_format : has_to_format edge :=
+⟨ λ e, to_fmt $ to_string e ⟩
+
+open native
+
+/-- A graph, represented as adjacency lists, where edges are
+expressions of type `α` and where an edge between `u` and `v` contains
+a proof that `u ≤ v` or `u < v`. -/
+meta def graph := native.rb_lmap expr (expr × edge × expr)
+
+meta instance graph.has_to_format : has_to_tactic_format graph :=
+by delta graph; apply_instance
+
+private meta def dfs_trans' (g : graph) (r : ref expr_set) (v : expr) : expr → list (edge × expr) → tactic expr
+| x hs := do
+  vs ← read_ref r,
+  if vs.contains x then failed
+  else if v = x then do
+    (h :: hs) ← pure hs | mk_mapp ``le_refl [none, none, x],
+    prod.snd <$> hs.mfoldl (λ ⟨e',h'⟩ ⟨e, h⟩,
+              match e, e' with
+              | edge.lt, edge.lt := prod.mk edge.lt <$> mk_app ``lt_trans [h, h']
+              | edge.lt, edge.le := prod.mk edge.lt <$> mk_app ``lt_of_lt_of_le [h, h']
+              | edge.le, edge.lt := prod.mk edge.lt <$> mk_app ``lt_of_le_of_lt [h, h']
+              | edge.le, edge.le := prod.mk edge.le <$> mk_app ``le_trans [h, h']
+              end) h
+  else do
+    write_ref r $ vs.insert x,
+    (g.find x).mfirst $ λ ⟨h',e',y⟩, dfs_trans' y ((e', h') :: hs)
+
+/--
+Depth first search in a graph of ordered relation. Finds a proof
+of `v ≤ v'` or `v < v'`, whichever is strongest and true.
+-/
+meta def dfs_trans (g : graph) (v v' : expr) : tactic expr :=
+using_new_ref mk_expr_set $ λ r, dfs_trans' g r v' v []
+
+end chain_trans
+
+namespace interactive
+open chain_trans
+
+/--
+Prove a goal of the shape `x ≤ y` or `x < y` by finding assumptions of
+the shape `x ≤ z`, `x < z` or `x = z` and combining them using
+transitivity.
+
+```lean
+variables {w x y z : ℕ}
+example (h₀ : w ≤ x) (h₁ : x = y) (h₂ : y < z) : w < z :=
+begin
+  chain_trans,
+end
+```
+-/
+meta def chain_trans : tactic unit := do
+tgt ← target,
+(x, y) ← match_le tgt <|> match_lt tgt,
+α ← infer_type x,
+ls ← local_context >>= list.mmap_filter'
+  (λ h, do t ← infer_type h,
+           do { (e, x, y) ← prod.mk edge.le <$> match_le t <|>
+                    prod.mk edge.lt <$> match_lt t,
+                infer_type x >>= is_def_eq α,
+                pure [(h, e, x, y)] } <|>
+           do { (x, y) ← match_eq t,
+                infer_type x >>= is_def_eq α,
+                h₀ ← mk_eq_symm h >>= mk_app ``le_of_eq ∘ list.ret,
+                h₁ ← mk_app ``le_of_eq [h],
+                pure [(h₀, edge.le, y, x), (h₁, edge.le, x, y)] }),
+let m := list.foldl  (λ (m : graph) (e : _ × _ × _ × _),
+  let ⟨pr,e,x,y⟩ := e in
+  m.insert x (pr,e,y)) (native.rb_lmap.mk expr (expr × edge × expr)) ls.join,
+pr ← dfs_trans m x y <|> fail!"no chain of inequalities can be found between `{x}` and `{y}`",
+tactic.apply pr <|>
+  mk_app ``le_of_lt [pr] >>= tactic.apply <|>
+  fail!"`{tgt}` cannot be proved from `{infer_type pr}`",
+skip
+
+end interactive
+
+end tactic

--- a/src/tactic/chain_trans.lean
+++ b/src/tactic/chain_trans.lean
@@ -67,7 +67,8 @@ meta def graph := native.rb_lmap expr (expr × edge × expr)
 meta instance graph.has_to_format : has_to_tactic_format graph :=
 by delta graph; apply_instance
 
-private meta def dfs_trans' (g : graph) (r : ref expr_set) (v : expr) : expr → list (edge × expr) → tactic expr
+private meta def dfs_trans' (g : graph) (r : ref expr_set) (v : expr) :
+  expr → list (edge × expr) → tactic expr
 | x hs := do
   vs ← read_ref r,
   if vs.contains x then failed

--- a/src/tactic/chain_trans.lean
+++ b/src/tactic/chain_trans.lean
@@ -159,6 +159,12 @@ tactic.apply pr <|>
   fail!"`{tgt}` cannot be proved from `{infer_type pr}`",
 skip
 
+add_tactic_doc
+{ name := "chain_trans",
+  category := doc_category.tactic,
+  decl_names := [`tactic.interactive.chain_trans],
+  tags := ["finishing", "lemma application"] }
+
 end interactive
 
 end tactic

--- a/src/tactic/chain_trans.lean
+++ b/src/tactic/chain_trans.lean
@@ -44,7 +44,7 @@ namespace chain_trans
 /-- A label for the edges of a graph of assumptions to
 specify whether the assumption is a strict ordering
 (i.e. `<`) or non-strict ordering (i.e. `≤`). -/
-@[derive inhabited]
+@[derive [inhabited, decidable_eq]]
 inductive edge
 | lt | le
 
@@ -53,24 +53,6 @@ instance : has_to_string edge :=
       | edge.lt := "lt"
       | edge.le := "le"
       end ⟩
-
-/--
-
--/
-inductive edge.less_than_or_equal : edge → edge → Prop
-| bot {x} :  edge.less_than_or_equal edge.lt x
-| top {x} :  edge.less_than_or_equal x edge.le
-
-instance : decidable_linear_order edge :=
-{ le := edge.less_than_or_equal,
-  le_refl := by { intro x, cases x; constructor },
-  le_antisymm := by { introv h₀ h₁, cases h₀; cases h₁; refl },
-  le_trans := by { introv h₀ h₁, cases h₀, { constructor }, cases h₁, constructor },
-  le_total :=
-  by { intros x y, cases x; cases y; { left; constructor } <|> { right; constructor } },
-  decidable_le :=
-  by { intros x y, cases x; cases y; { left; intro h; cases h; done } <|> { right; constructor } }
- }
 
 meta instance edge.has_to_format : has_to_format edge :=
 ⟨ λ e, to_fmt $ to_string e ⟩

--- a/test/chain_trans.lean
+++ b/test/chain_trans.lean
@@ -47,3 +47,11 @@ example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : y = id z) (h₃ : x
 begin
   chain_trans,
 end
+
+variables {α : Type} [preorder α]
+
+/-- long chain of inequalities with a mix of `≤`, `<` and `=` -/
+example {x y z w u v : α} (h₀ : x ≤ y) (h₁ : y < z) (h : y < u) (h₂ : z < w) (h₃ : w = u) (h₄ : u < v) : x ≤ u :=
+begin
+  chain_trans,
+end

--- a/test/chain_trans.lean
+++ b/test/chain_trans.lean
@@ -1,0 +1,33 @@
+
+import tactic.chain_trans
+import tactic.interactive
+
+example {x y z w u v : ℕ} {a b : ℤ} (h₀ : x ≤ y) (h₁ : y < z) (h : y < u) (h₂ : z < w) (h₃ : w = u) (h₄ : u < v) : x ≤ u :=
+begin
+  chain_trans,
+end
+
+example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : x = y) (h₂ : y < z) : true :=
+begin
+  have : w < w,
+  { success_if_fail_with_msg
+    { chain_trans }
+    "`w < w` cannot be proved from `w ≤ w`",
+    admit },
+  triv
+end
+
+example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : x = y) (h₂ : y < z) : true :=
+begin
+  have : x < w,
+  { success_if_fail_with_msg
+    { chain_trans }
+    "no chain of inequalities can be found between `x` and `w`",
+    admit },
+  triv
+end
+
+example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : x = y) (h₂ : y < z) : w < z :=
+begin
+  chain_trans,
+end

--- a/test/chain_trans.lean
+++ b/test/chain_trans.lean
@@ -2,21 +2,24 @@
 import tactic.chain_trans
 import tactic.interactive
 
+/-- long chain of inequalities with a mix of `≤`, `<` and `=` -/
 example {x y z w u v : ℕ} {a b : ℤ} (h₀ : x ≤ y) (h₁ : y < z) (h : y < u) (h₂ : z < w) (h₃ : w = u) (h₄ : u < v) : x ≤ u :=
 begin
   chain_trans,
 end
 
+/-- error message when `≤` can be proved but not `<` -/
 example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : x = y) (h₂ : y < z) : true :=
 begin
   have : w < w,
   { success_if_fail_with_msg
     { chain_trans }
-    "no appropriate chain of inequalities can be found between `w` and `w`",
+    "`w < w` cannot be proved from `w ≤ w`",
     admit },
   triv
 end
 
+/-- error message when no proof is found -/
 example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : x = y) (h₂ : y < z) : true :=
 begin
   have : x < w,
@@ -27,12 +30,20 @@ begin
   triv
 end
 
+/-- simple example -/
 example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : x = y) (h₂ : y < z) : w < z :=
 begin
   chain_trans,
 end
 
+/-- there exists a proof of `w ≤ z` and one of `w < z`. `chain_trans` should prefer `w < z` -/
 example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : y = z) (h₃ : x ≤ y) (h₂ : x < y) (h₃ : x ≤ y) : w < z :=
+begin
+  chain_trans,
+end
+
+/-- normalize vertices using `whnf` to recognize definitionally equal terms -/
+example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : y = id z) (h₃ : x ≤ y) (h₂ : id x < y) (h₃ : x ≤ y) : w < z :=
 begin
   chain_trans,
 end

--- a/test/chain_trans.lean
+++ b/test/chain_trans.lean
@@ -12,7 +12,7 @@ begin
   have : w < w,
   { success_if_fail_with_msg
     { chain_trans }
-    "`w < w` cannot be proved from `w ≤ w`",
+    "no appropriate chain of inequalities can be found between `w` and `w`",
     admit },
   triv
 end
@@ -22,12 +22,17 @@ begin
   have : x < w,
   { success_if_fail_with_msg
     { chain_trans }
-    "no chain of inequalities can be found between `x` and `w`",
+    "no appropriate chain of inequalities can be found between `x` and `w`",
     admit },
   triv
 end
 
 example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : x = y) (h₂ : y < z) : w < z :=
+begin
+  chain_trans,
+end
+
+example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : x = y) (h₃ : y ≤ z) (h₂ : y < z) (h₃ : y ≤ z) : w < z :=
 begin
   chain_trans,
 end

--- a/test/chain_trans.lean
+++ b/test/chain_trans.lean
@@ -32,7 +32,7 @@ begin
   chain_trans,
 end
 
-example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : x = y) (h₃ : y ≤ z) (h₂ : y < z) (h₃ : y ≤ z) : w < z :=
+example {w x y z : ℕ} {a b : ℤ} (h₀ : w ≤ x) (h₁ : y = z) (h₃ : x ≤ y) (h₂ : x < y) (h₃ : x ≤ y) : w < z :=
 begin
   chain_trans,
 end


### PR DESCRIPTION
This new tactic proves a goal of the shape `x ≤ y` or `x < y` by finding assumptions of
the shape `x ≤ z`, `x < z` or `x = z` and combining them using
transitivity.

```lean
variables {w x y z : ℕ}
example (h₀ : w ≤ x) (h₁ : x = y) (h₂ : y < z) : w < z :=
begin
  chain_trans,
end
```

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
