### PR TITLE
[Merged by Bors] - fix(algebra/ordered_group): use `add_neg` in autogenerated lemma name

### DIFF
--- a/src/algebra/linear_ordered_comm_group_with_zero.lean
+++ b/src/algebra/linear_ordered_comm_group_with_zero.lean
@@ -133,7 +133,7 @@ lemma div_le_div' (a b c d : α) (hb : b ≠ 0) (hd : d ≠ 0) :
 begin
   by_cases ha : a = 0, { simp [ha] },
   by_cases hc : c = 0, { simp [inv_ne_zero hb, hc, hd], },
-  exact (div_le_div_iff' (units.mk0 a ha) (units.mk0 b hb) (units.mk0 c hc) (units.mk0 d hd)),
+  exact @div_le_div_iff' _ _ (units.mk0 a ha) (units.mk0 b hb) (units.mk0 c hc) (units.mk0 d hd)
 end
 
 lemma ne_zero_of_lt (h : b < a) : a ≠ 0 :=

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -1208,8 +1208,8 @@ by rwa inv_mul_cancel_left at this
 lemma inv_mul_lt_iff_lt_mul_right : c⁻¹ * a < b ↔ a < b * c :=
 by rw [inv_mul_lt_iff_lt_mul, mul_comm]
 
-@[to_additive sub_le_sub_iff]
-lemma div_le_div_iff' (a b c d : α) : a * b⁻¹ ≤ c * d⁻¹ ↔ a * d ≤ c * b :=
+@[to_additive add_neg_le_add_neg_iff]
+lemma div_le_div_iff' : a * b⁻¹ ≤ c * d⁻¹ ↔ a * d ≤ c * b :=
 begin
   split ; intro h,
   have := mul_le_mul_right' (mul_le_mul_right' h b) d,
@@ -1438,6 +1438,8 @@ calc
   a - b = a + -b : rfl
     ... < a + 0  : add_lt_add_left (neg_neg_of_pos h) _
     ... = a      : by rw add_zero
+
+lemma sub_le_sub_iff : a - b ≤ c - d ↔ a + d ≤ c + b := add_neg_le_add_neg_iff
 
 @[simp]
 lemma sub_le_sub_iff_left (a : α) {b c : α} : a - b ≤ a - c ↔ c ≤ b :=


### PR DESCRIPTION
Explicitly add `sub_le_sub_iff` with `a - b`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->