### PR TITLE
[Merged by Bors] - chore(algebra/monoid_algebra): Replace `algebra_map'` with `single_(zero|one)_ring_hom`

### DIFF
--- a/src/algebra/monoid_algebra.lean
+++ b/src/algebra/monoid_algebra.lean
@@ -242,20 +242,11 @@ lemma single_one_comm [comm_semiring k] [monoid G] (r : k) (f : monoid_algebra k
   single 1 r * f = f * single 1 r :=
 by { ext, rw [single_one_mul_apply, mul_single_one_apply, mul_comm] }
 
-/--
-As a preliminary to defining the `k`-algebra structure on `monoid_algebra k G`,
-we define the underlying ring homomorphism.
-
-In fact, we do this in more generality, providing the ring homomorphism
-`k →+* monoid_algebra A G` given any ring homomorphism `k →+* A`.
--/
-def algebra_map' {A : Type*} [semiring k] [semiring A] (f : k →+* A) [monoid G] :
-  k →+* monoid_algebra A G :=
-{ to_fun := λ x, single 1 (f x),
-  map_one' := by { simp, refl },
-  map_mul' := λ x y, by rw [single_mul_single, one_mul, f.map_mul],
-  map_zero' := by rw [f.map_zero, single_zero],
-  map_add' := λ x y, by rw [f.map_add, single_add], }
+/-- `finsupp.single 1` as a `ring_hom` -/
+@[simps] def single_one_ring_hom [semiring k] [monoid G] : k →+* monoid_algebra k G :=
+{ map_one' := rfl,
+  map_mul' := λ x y, by rw [single_add_hom, single_mul_single, one_mul],
+  ..finsupp.single_add_hom 1}
 
 /--
 The instance `algebra k (monoid_algebra A G)` whenever we have `algebra k A`.
@@ -264,10 +255,9 @@ In particular this provides the instance `algebra k (monoid_algebra k G)`.
 -/
 instance {A : Type*} [comm_semiring k] [semiring A] [algebra k A] [monoid G] :
   algebra k (monoid_algebra A G) :=
-{ smul_def' := λ r a, by { ext x, dsimp [algebra_map'], rw single_one_mul_apply, rw algebra.smul_def'', },
-  commutes' := λ r f, show single 1 (algebra_map k A r) * f = f * single 1 (algebra_map k A r),
-    by { ext, rw [single_one_mul_apply, mul_single_one_apply, algebra.commutes], },
-  ..algebra_map' (algebra_map k A) }
+{ smul_def' := λ r a, by { ext, simp [single_one_mul_apply, algebra.smul_def''], },
+  commutes' := λ r f, by { ext, simp [single_one_mul_apply, mul_single_one_apply, algebra.commutes], },
+  ..single_one_ring_hom.comp (algebra_map k A) }
 
 @[simp] lemma coe_algebra_map {A : Type*} [comm_semiring k] [semiring A] [algebra k A] [monoid G] :
   (algebra_map k (monoid_algebra A G) : k → monoid_algebra A G) = single 1 ∘ (algebra_map k A) :=
@@ -535,7 +525,7 @@ instance [comm_semiring k] [add_comm_monoid G] : comm_semiring (add_monoid_algeb
     simp only [add_comm]
   end,
   .. add_monoid_algebra.semiring }
- 
+
 /-! #### Derived instances -/
 section derived_instances
 
@@ -638,20 +628,11 @@ section algebra
 variables {R : Type*}
 local attribute [reducible] add_monoid_algebra
 
-/--
-As a preliminary to defining the `k`-algebra structure on `add_monoid_algebra k G`,
-we define the underlying ring homomorphism.
-
-In fact, we do this in more generality, providing the ring homomorphism
-`R →+* add_monoid_algebra k G` given any ring homomorphism `R →+* k`.
--/
-def algebra_map' [semiring R] [semiring k] (f : R →+* k) [add_monoid G] :
-  R →+* add_monoid_algebra k G :=
-{ to_fun := λ x, single 0 (f x),
-  map_one' := by { simp, refl },
-  map_mul' := λ x y, by rw [single_mul_single, zero_add, f.map_mul],
-  map_zero' := by rw [f.map_zero, single_zero],
-  map_add' := λ x y, by rw [f.map_add, single_add], }
+/-- `finsupp.single 0` as a `ring_hom` -/
+@[simps] def single_zero_ring_hom [semiring k] [add_monoid G] : k →+* add_monoid_algebra k G :=
+{ map_one' := rfl,
+  map_mul' := λ x y, by rw [single_add_hom, single_mul_single, zero_add],
+  ..finsupp.single_add_hom 0}
 
 /--
 The instance `algebra R (add_monoid_algebra k G)` whenever we have `algebra R k`.
@@ -660,10 +641,9 @@ In particular this provides the instance `algebra k (add_monoid_algebra k G)`.
 -/
 instance [comm_semiring R] [semiring k] [algebra R k] [add_monoid G] :
   algebra R (add_monoid_algebra k G) :=
-{ smul_def' := λ r a, by { ext x, dsimp [algebra_map'], rw single_zero_mul_apply, rw algebra.smul_def'', },
-  commutes' := λ r f, show single 0 (algebra_map R k r) * f = f * single 0 (algebra_map R k r),
-    by { ext, rw [single_zero_mul_apply, mul_single_zero_apply, algebra.commutes], },
-  ..algebra_map' (algebra_map R k) }
+{ smul_def' := λ r a, by { ext, simp [single_zero_mul_apply, algebra.smul_def''], },
+  commutes' := λ r f, by { ext, simp [single_zero_mul_apply, mul_single_zero_apply, algebra.commutes], },
+  ..single_zero_ring_hom.comp (algebra_map R k) }
 
 @[simp] lemma coe_algebra_map [comm_semiring R] [semiring k] [algebra R k] [add_monoid G] :
   (algebra_map R (add_monoid_algebra k G) : R → add_monoid_algebra k G) = single 0 ∘ (algebra_map R k) :=

--- a/src/algebra/monoid_algebra.lean
+++ b/src/algebra/monoid_algebra.lean
@@ -259,6 +259,12 @@ instance {A : Type*} [comm_semiring k] [semiring A] [algebra k A] [monoid G] :
   commutes' := λ r f, by { ext, simp [single_one_mul_apply, mul_single_one_apply, algebra.commutes], },
   ..single_one_ring_hom.comp (algebra_map k A) }
 
+/-- `finsupp.single 1` as a `alg_hom` -/
+@[simps]
+def single_one_alg_hom {A : Type*} [comm_semiring k] [semiring A] [algebra k A] [monoid G] :
+  A →ₐ[k] monoid_algebra A G :=
+{ commutes' := λ r, by { ext, simp, refl, }, ..single_one_ring_hom}
+
 @[simp] lemma coe_algebra_map {A : Type*} [comm_semiring k] [semiring A] [algebra k A] [monoid G] :
   (algebra_map k (monoid_algebra A G) : k → monoid_algebra A G) = single 1 ∘ (algebra_map k A) :=
 rfl
@@ -644,6 +650,11 @@ instance [comm_semiring R] [semiring k] [algebra R k] [add_monoid G] :
 { smul_def' := λ r a, by { ext, simp [single_zero_mul_apply, algebra.smul_def''], },
   commutes' := λ r f, by { ext, simp [single_zero_mul_apply, mul_single_zero_apply, algebra.commutes], },
   ..single_zero_ring_hom.comp (algebra_map R k) }
+
+/-- `finsupp.single 0` as a `alg_hom` -/
+@[simps] def single_zero_alg_hom [comm_semiring R] [semiring k] [algebra R k] [add_monoid G] :
+  k →ₐ[R] add_monoid_algebra k G :=
+{ commutes' := λ r, by { ext, simp, refl, }, ..single_zero_ring_hom}
 
 @[simp] lemma coe_algebra_map [comm_semiring R] [semiring k] [algebra R k] [add_monoid G] :
   (algebra_map R (add_monoid_algebra k G) : R → add_monoid_algebra k G) = single 0 ∘ (algebra_map R k) :=

--- a/src/data/polynomial/monomial.lean
+++ b/src/data/polynomial/monomial.lean
@@ -25,7 +25,7 @@ variables [semiring R] {p q r : polynomial R}
 `C a` is the constant polynomial `a`.
 `C` is provided as a ring homomorphism.
 -/
-def C : R →+* polynomial R := add_monoid_algebra.algebra_map' (ring_hom.id R)
+def C : R →+* polynomial R := add_monoid_algebra.single_zero_ring_hom
 
 @[simp] lemma monomial_zero_left (a : R) : monomial 0 a = C a := rfl
 


### PR DESCRIPTION
`algebra_map'` is now trivially equal to `single_(zero|one)_ring_hom.comp`, so is no longer needed.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
