### PR TITLE
[Merged by Bors] - feat(data/finsupp): Add `map_finsupp_prod` to homs

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1662,6 +1662,32 @@ protected def dom_congr [add_comm_monoid β] (e : α₁ ≃ α₂) : (α₁ →�
   end,
   map_add' := λ a b, map_domain_add, }
 
+end finsupp
+
+@[to_additive]
+lemma mul_equiv.map_finsupp_prod {α β γ δ : Type*}
+  [has_zero β] [comm_monoid γ] [comm_monoid δ]
+  (h : γ ≃* δ) (f : α →₀ β) (g : α → β → γ) : h (f.prod g) = f.prod (λ a b, h (g a b)) :=
+h.map_prod _ _
+
+@[to_additive]
+lemma monoid_hom.map_finsupp_prod {α β γ δ : Type*}
+  [has_zero β] [comm_monoid γ] [comm_monoid δ]
+  (h : γ →* δ) (f : α →₀ β) (g : α → β → γ) : h (f.prod g) = f.prod (λ a b, h (g a b)) :=
+h.map_prod _ _
+
+lemma ring_hom.map_finsupp_sum {α β γ δ : Type*}
+  [has_zero β] [semiring γ] [semiring δ]
+  (h : γ →+* δ) (f : α →₀ β) (g : α → β → γ) : h (f.sum g) = f.sum (λ a b, h (g a b)) :=
+h.map_sum _ _
+
+lemma ring_hom.map_finsupp_prod {α β γ δ : Type*}
+  [has_zero β] [comm_semiring γ] [comm_semiring δ]
+  (h : γ →+* δ) (f : α →₀ β) (g : α → β → γ) : h (f.prod g) = f.prod (λ a b, h (g a b)) :=
+h.map_prod _ _
+
+namespace finsupp
+
 /-! ### Declarations about sigma types -/
 
 section sigma


### PR DESCRIPTION
This is a convenience alias for `map_prod`, which is awkward to use.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/finsupp.2Esum.20commutes.20with.20monoid_hom/near/213060980
