### PR TITLE
[Merged by Bors] - fix(big_operators): fix imports

### DIFF
--- a/src/algebra/big_operators/default.lean
+++ b/src/algebra/big_operators/default.lean
@@ -3,4 +3,6 @@
 import algebra.big_operators.order
 import algebra.big_operators.intervals
 import algebra.big_operators.ring
+import algebra.big_operators.pi
+import algebra.big_operators.finsupp
 import algebra.big_operators.nat_antidiagonal

--- a/src/algebra/big_operators/pi.lean
+++ b/src/algebra/big_operators/pi.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
 import algebra.ring.pi
-import algebra.big_operators
+import algebra.big_operators.basic
 import data.fintype.basic
 import algebra.group.prod
 /-!

--- a/src/data/polynomial/iterated_deriv.lean
+++ b/src/data/polynomial/iterated_deriv.lean
@@ -6,6 +6,7 @@ Authors: Jujian Zhang
 
 import data.polynomial.derivative
 import logic.function.iterate
+import data.finset.intervals
 import tactic.ring
 import tactic.linarith
 

--- a/src/deprecated/submonoid.lean
+++ b/src/deprecated/submonoid.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau, Johan Commelin, Mario Carneiro, Kevin Buzzard
 -/
 import group_theory.submonoid.basic
-import algebra.big_operators
+import algebra.big_operators.basic
 
 /-!
 # Submonoids


### PR DESCRIPTION
Previously `algebra.big_operators.pi` imported `algebra.big_operators.default`. That import direction is now reversed.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
