### PR TITLE
[Merged by Bors] - feat(*): make int.nonneg irreducible

### DIFF
--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -90,7 +90,7 @@ lemma one_lt_pow {K} [linear_ordered_semiring K] {p : K} (hp : 1 < p) : ∀ {n :
   end
 
 section
-local attribute [semireducible] int.lt
+local attribute [semireducible] int.le
 lemma one_lt_fpow {K}  [discrete_linear_ordered_field K] {p : K} (hp : 1 < p) :
   ∀ z : ℤ, 0 < z → 1 < p ^ z
 | (int.of_nat n) h := one_lt_pow hp (nat.succ_le_of_lt (int.lt_of_coe_nat_lt_coe_nat h))

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -90,7 +90,7 @@ lemma one_lt_pow {K} [linear_ordered_semiring K] {p : K} (hp : 1 < p) : ∀ {n :
   end
 
 section
-local attribute [semireducible] int.le
+local attribute [semireducible] int.nonneg
 lemma one_lt_fpow {K}  [discrete_linear_ordered_field K] {p : K} (hp : 1 < p) :
   ∀ z : ℤ, 0 < z → 1 < p ^ z
 | (int.of_nat n) h := one_lt_pow hp (nat.succ_le_of_lt (int.lt_of_coe_nat_lt_coe_nat h))

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1223,4 +1223,4 @@ end classical
 
 end int
 
-attribute [irreducible] int.lt
+attribute [irreducible] int.le

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1223,4 +1223,4 @@ end classical
 
 end int
 
-attribute [irreducible] int.le
+attribute [irreducible] int.nonneg

--- a/src/data/int/range.lean
+++ b/src/data/int/range.lean
@@ -8,6 +8,8 @@ import data.list.range
 
 namespace int
 
+local attribute [semireducible] int.le
+
 /-- List enumerating `[m, n)`. -/
 def range (m n : ℤ) : list ℤ :=
 (list.range (to_nat (n-m))).map $ λ r, m+r
@@ -31,8 +33,6 @@ decidable_of_iff (∀ r ∈ range m n, P r) $ by simp only [mem_range_iff, and_i
 instance decidable_le_le (P : int → Prop) [decidable_pred P] (m n : ℤ) :
   decidable (∀ r, m ≤ r → r ≤ n → P r) :=
 decidable_of_iff (∀ r ∈ range m (n+1), P r) $ by simp only [mem_range_iff, and_imp, lt_add_one_iff]
-
-local attribute [semireducible] int.lt
 
 instance decidable_lt_lt (P : int → Prop) [decidable_pred P] (m n : ℤ) :
   decidable (∀ r, m < r → r < n → P r) :=

--- a/src/data/int/range.lean
+++ b/src/data/int/range.lean
@@ -8,7 +8,7 @@ import data.list.range
 
 namespace int
 
-local attribute [semireducible] int.le
+local attribute [semireducible] int.nonneg
 
 /-- List enumerating `[m, n)`. -/
 def range (m n : ℤ) : list ℤ :=

--- a/src/data/int/sqrt.lean
+++ b/src/data/int/sqrt.lean
@@ -22,6 +22,6 @@ theorem exists_mul_self (x : ℤ) :
 ⟨λ ⟨n, hn⟩, by rw [← hn, sqrt_eq, ← int.coe_nat_mul, nat_abs_mul_self],
 λ h, ⟨sqrt x, h⟩⟩
 
-theorem sqrt_nonneg (n : ℤ) : 0 ≤ sqrt n := trivial
+theorem sqrt_nonneg (n : ℤ) : 0 ≤ sqrt n := coe_nat_nonneg _
 
 end int

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -96,6 +96,8 @@ by rw [modeq_iff_dvd] at *; exact dvd.trans (dvd_mul_left (n : ℤ) (m : ℤ)) h
 theorem modeq_of_modeq_mul_right (m : ℕ) : a ≡ b [MOD n * m] → a ≡ b [MOD n] :=
 mul_comm m n ▸ modeq_of_modeq_mul_left _
 
+local attribute [reducible] int.le
+
 /-- The natural number less than `n*m` congruent to `a` mod `n` and `b` mod `m` -/
 def chinese_remainder (co : coprime n m) (a b : ℕ) : {k // k ≡ a [MOD n] ∧ k ≡ b [MOD m]} :=
 ⟨let (c, d) := xgcd n m in int.to_nat ((b * c * n + a * d * m) % (n * m)), begin

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -96,7 +96,7 @@ by rw [modeq_iff_dvd] at *; exact dvd.trans (dvd_mul_left (n : ℤ) (m : ℤ)) h
 theorem modeq_of_modeq_mul_right (m : ℕ) : a ≡ b [MOD n * m] → a ≡ b [MOD n] :=
 mul_comm m n ▸ modeq_of_modeq_mul_left _
 
-local attribute [reducible] int.le
+local attribute [semireducible] int.nonneg
 
 /-- The natural number less than `n*m` congruent to `a` mod `n` and `b` mod `m` -/
 def chinese_remainder (co : coprime n m) (a b : ℕ) : {k // k ≡ a [MOD n] ∧ k ≡ b [MOD m]} :=

--- a/src/data/rat/sqrt.lean
+++ b/src/data/rat/sqrt.lean
@@ -27,6 +27,7 @@ theorem exists_mul_self (x : ℚ) : (∃ q, q * q = x) ↔ rat.sqrt x * rat.sqrt
 
 theorem sqrt_nonneg (q : ℚ) : 0 ≤ rat.sqrt q :=
 nonneg_iff_zero_le.1 $ (mk_nonneg _ $ int.coe_nat_pos.2 $
-nat.pos_of_ne_zero $ λ H, nat.pos_iff_ne_zero.1 q.pos $ nat.sqrt_eq_zero.1 H).2 trivial
+nat.pos_of_ne_zero $ λ H, nat.pos_iff_ne_zero.1 q.pos $ nat.sqrt_eq_zero.1 H).2
+$ int.coe_nat_nonneg _
 
 end rat

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -428,7 +428,7 @@ begin
   apply int.modeq.mod_modeq,
 end
 
-local attribute [reducible] int.le
+local attribute [semireducible] int.nonneg
 
 @[simp] lemma coe_to_nat (p : ℕ) :
   ∀ {z : ℤ} (h : 0 ≤ z), (z.to_nat : zmod p) = z

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -428,6 +428,8 @@ begin
   apply int.modeq.mod_modeq,
 end
 
+local attribute [reducible] int.le
+
 @[simp] lemma coe_to_nat (p : ℕ) :
   ∀ {z : ℤ} (h : 0 ≤ z), (z.to_nat : zmod p) = z
 | (n : ℕ) h := by simp only [int.cast_coe_nat, int.to_nat_coe_nat]

--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -90,7 +90,7 @@ by rw [norm, norm_sq]; simp
 @[simp] lemma nat_cast_complex_norm (x : ℤ[i]) : (x.norm : ℂ) = (x : ℂ).norm_sq :=
 by cases x; rw [norm, norm_sq]; simp
 
-lemma norm_nonneg (x : ℤ[i]) : 0 ≤ norm x := norm_nonneg trivial _
+lemma norm_nonneg (x : ℤ[i]) : 0 ≤ norm x := norm_nonneg (by norm_num) _
 
 @[simp] lemma norm_eq_zero {x : ℤ[i]} : norm x = 0 ↔ x = 0 :=
 by rw [← @int.cast_inj ℝ _ _ _]; simp

--- a/src/number_theory/lucas_lehmer.lean
+++ b/src/number_theory/lucas_lehmer.lean
@@ -93,7 +93,7 @@ end
 lemma s_mod_nonneg (p : ℕ) (w : 0 < p) (i : ℕ) : 0 ≤ s_mod p i :=
 begin
   cases i; dsimp [s_mod],
-  { trivial, },
+  { exact sup_eq_left.mp rfl },
   { apply int.mod_nonneg, exact mersenne_int_ne_zero p w },
 end
 

--- a/src/tactic/omega/eq_elim.lean
+++ b/src/tactic/omega/eq_elim.lean
@@ -25,7 +25,7 @@ if (2 * (i % j)) < j
 then i % j
 else (i % j) - j
 
-local attribute [semireducible] int.le
+local attribute [semireducible] int.nonneg
 lemma symmod_add_one_self {i : int} :
   0 < i → symmod i (i+1) = -1 :=
 begin

--- a/src/tactic/omega/eq_elim.lean
+++ b/src/tactic/omega/eq_elim.lean
@@ -25,7 +25,7 @@ if (2 * (i % j)) < j
 then i % j
 else (i % j) - j
 
-local attribute [semireducible] int.lt
+local attribute [semireducible] int.le
 lemma symmod_add_one_self {i : int} :
   0 < i → symmod i (i+1) = -1 :=
 begin

--- a/src/tactic/omega/nat/dnf.lean
+++ b/src/tactic/omega/nat/dnf.lean
@@ -132,6 +132,7 @@ begin
   constructor, apply h5.left,
   rw list.forall_mem_append,
   apply and.intro (holds_nonneg_consts _) h5.right,
+  assume x,
   apply int.coe_nat_nonneg
 end
 

--- a/test/monotonicity.lean
+++ b/test/monotonicity.lean
@@ -21,7 +21,10 @@ example
   (h : 3 ≤ (4 : ℤ))
   (h' : 5 ≤ (6 : ℤ))
 : (1 + 3 + 2) - 6 ≤ (4 + 2 + 1 : ℤ) - 5 :=
-by ac_mono
+begin
+  ac_mono,
+  mono,
+end
 
 example
   (h : 3 ≤ (4 : ℤ))

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -239,7 +239,7 @@ begin
   lift f to α → ℕ using hf,
     guard_target ((0:ℤ) ≤ 2 * (λ i : α, (f i : ℤ)) a),
     guard_hyp hf' : ∀ a, ((λ i : α, (f i:ℤ)) a) < 1,
-  trivial
+  exact int.coe_nat_nonneg _
 end
 
 instance can_lift_unit : can_lift unit unit :=


### PR DESCRIPTION
In #4474, `int.lt` was made irreducible. We make `int.nonneg` irreducible, which is stronger as `int.lt` is expressed in terms of `int.nonneg`.

---
Zulip discussion at https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/timeout.20in.20.60cases.60/near/213124028