### PR TITLE
[Merged by Bors] - feat(tactic/dependencies): add tactics to compute (reverse) dependencies

### DIFF
--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -464,10 +464,18 @@ meta def to_implicit_binder : expr → expr
 | (pi n _ d b) := pi n binder_info.implicit d b
 | e  := e
 
-
 /-- Returns a list of all local constants in an expression (without duplicates). -/
 meta def list_local_consts (e : expr) : list expr :=
 e.fold [] (λ e' _ es, if e'.is_local_constant then insert e' es else es)
+
+/-- Returns the set of all local constants in an expression. -/
+meta def list_local_consts' (e : expr) : expr_set :=
+e.fold mk_expr_set (λ e' _ es, if e'.is_local_constant then es.insert e' else es)
+
+/-- Returns the unique names of all local constants in an expression. -/
+meta def list_local_const_unique_names (e : expr) : name_set :=
+e.fold mk_name_set
+  (λ e' _ es, if e'.is_local_constant then es.insert e'.local_uniq_name else es)
 
 /-- Returns a name_set of all constants in an expression. -/
 meta def list_constant (e : expr) : name_set :=
@@ -476,6 +484,10 @@ e.fold mk_name_set (λ e' _ es, if e'.is_constant then es.insert e'.const_name e
 /-- Returns a list of all meta-variables in an expression (without duplicates). -/
 meta def list_meta_vars (e : expr) : list expr :=
 e.fold [] (λ e' _ es, if e'.is_mvar then insert e' es else es)
+
+/-- Returns the set of all meta-variables in an expression. -/
+meta def list_meta_vars' (e : expr) : expr_set :=
+e.fold mk_expr_set (λ e' _ es, if e'.is_mvar then es.insert e' else es)
 
 /-- Returns a list of all universe meta-variables in an expression (without duplicates). -/
 meta def list_univ_meta_vars (e : expr) : list name :=

--- a/src/meta/rb_map.lean
+++ b/src/meta/rb_map.lean
@@ -205,6 +205,11 @@ end name_map
 
 namespace expr_set
 
+/--
+`local_set_to_name_set lcs` is the set of unique names of the local constants
+`lcs`. If any of the `lcs` are not local constants, the returned set will
+contain bogus names.
+-/
 meta def local_set_to_name_set (lcs : expr_set) : name_set :=
 lcs.fold mk_name_set $ λ h ns, ns.insert h.local_uniq_name
 

--- a/src/meta/rb_map.lean
+++ b/src/meta/rb_map.lean
@@ -200,3 +200,12 @@ meta instance {data : Type} : inhabited (name_map data) :=
 ⟨mk_name_map⟩
 
 end name_map
+
+/-! ### Declarations about `expr_set` -/
+
+namespace expr_set
+
+meta def local_set_to_name_set (lcs : expr_set) : name_set :=
+lcs.fold mk_name_set $ λ h ns, ns.insert h.local_uniq_name
+
+end expr_set

--- a/src/meta/rb_map.lean
+++ b/src/meta/rb_map.lean
@@ -190,6 +190,14 @@ s.fold t (λ a t, t.insert a)
 meta def insert_list (s : name_set) (l : list name) : name_set :=
 l.foldr (λ n s', s'.insert n) s
 
+/--
+`local_list_to_name_set lcs` is the set of unique names of the local
+constants `lcs`. If any of the `lcs` are not local constants, the returned set
+will contain bogus names.
+-/
+meta def local_list_to_name_set (lcs : list expr) : name_set :=
+lcs.foldl (λ ns h, ns.insert h.local_uniq_name) mk_name_set
+
 end name_set
 
 /-! ### Declarations about `name_map` -/

--- a/src/tactic/basic.lean
+++ b/src/tactic/basic.lean
@@ -5,6 +5,7 @@ import tactic.converter.apply_congr
 import tactic.congr
 import tactic.dec_trivial
 import tactic.delta_instance
+import tactic.dependencies
 import tactic.elide
 import tactic.explode
 import tactic.find

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -644,6 +644,24 @@ meta def clear_value (vs : list expr) : tactic unit := do
     set_goals $ g :: gs },
   ls.reverse.mmap' $ λ vs, intro_lst $ vs.map expr.local_pp_name
 
+/--
+`context_has_local_def` is true iff there is at least one local definition in
+the context.
+-/
+meta def context_has_local_def : tactic bool := do
+  ctx ← local_context,
+  ctx.many (succeeds ∘ local_def_value)
+
+/--
+`context_upto_hyp_has_local_def h` is true iff any of the hypotheses in the
+context up to and including `h` is a local definition.
+-/
+meta def context_upto_hyp_has_local_def (h : expr) : tactic bool := do
+  ff ← succeeds (local_def_value h) | pure tt,
+  ctx ← local_context,
+  let ctx := ctx.take_while (≠ h),
+  ctx.many (succeeds ∘ local_def_value)
+
 /-- A variant of `simplify_bottom_up`. Given a tactic `post` for rewriting subexpressions,
 `simp_bottom_up post e` tries to rewrite `e` starting at the leaf nodes. Returns the resulting
 expression and a proof of equality. -/

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -438,6 +438,21 @@ meta def mk_psigma : list expr → tactic expr
      pure $ r x y
 | _ := fail "mk_psigma expects a list of local constants"
 
+/--
+Update the type of a local constant or metavariable. For local constants and
+metavariables obtained via, for example, `tactic.get_local`, the type stored in
+the expression is not necessarily the same as the type returned by `infer_type`.
+This tactic, given a local constant or metavariable, updates the stored type to
+match the output of `infer_type`. If the input is not a local constant or
+metavariable, `update_type` does nothing.
+-/
+meta def update_type : expr → tactic expr
+| e@(expr.local_const ppname uname binfo _) :=
+  expr.local_const ppname uname binfo <$> infer_type e
+| e@(expr.mvar ppname uname _) :=
+  expr.mvar ppname uname <$> infer_type e
+| e := pure e
+
 /-- `elim_gen_prod n e _ ns` with `e` an expression of type `psigma _`, applies `cases` on `e` `n`
 times and uses `ns` to name the resulting variables. Returns a triple: list of new variables,
 remaining term and unused variable names.
@@ -585,22 +600,6 @@ tactic.unsafe.type_context.run $ do
   some let_val <- return ldecl.value |
     tactic.unsafe.type_context.fail format!"Variable {e} is not a local definition.",
   return let_val
-
-/-- `revert_deps e` reverts all the hypotheses that depend on one of the local
-constants `e`, including the local definitions that have `e` in their definition.
-This fixes a bug in `revert_kdeps` that does not revert local definitions for which `e` only
-appears in the definition. -/
-/- We cannot implement it as `revert e >> intro1`, because that would change the local constant in
-the context. -/
-meta def revert_deps (e : expr) : tactic ℕ := do
-  n ← revert_kdeps e,
-  l ← local_context,
-  [pos] ← return $ l.indexes_of e,
-  let l := l.drop pos.succ, -- local hypotheses after `e`
-  ls ← l.mfilter $ λ e', try_core (local_def_value e') >>= λ o, return $ o.elim ff $ λ e'',
-    e''.has_local_constant e,
-  n' ← revert_lst ls,
-  return $ n + n'
 
 /-- `is_local_def e` succeeds when `e` is a local definition (a local constant of the form
 `e : α := t`) and otherwise fails. -/

--- a/src/tactic/dependencies.lean
+++ b/src/tactic/dependencies.lean
@@ -281,8 +281,8 @@ hyp_depends_on_local_name_set_inclusive h $ local_list_to_name_set hs
 `dependency_set_of_hyp h` is the set of dependencies of the hypothesis `h`.
 
 This tactic is moderately expensive if the context up to `h` contains local
-definitions. If you need to check dependencies of multiple hypotheses, you may
-want to use `tactic.context_dependencies`.
+definitions. If you need the dependencies of multiple hypotheses, you may want
+to use `tactic.context_dependencies`.
 -/
 meta def dependency_set_of_hyp (h : expr) : tactic expr_set := do
   ctx ← local_context,
@@ -308,6 +308,35 @@ order.
 -/
 meta def dependencies_of_hyp (h : expr) : tactic (list expr) :=
 rb_set.to_list <$> dependency_set_of_hyp h
+
+/--
+`dependency_set_of_hyp_inclusive h` is the set of dependencies of the hypothesis
+`h`, plus `h` itself.
+
+This tactic is moderately expensive if the context up to `h` includes local
+definitions. If you need the dependencies of multiple hypotheses, you may want
+to use `tactic.context_dependencies`.
+-/
+meta def dependency_set_of_hyp_inclusive (h : expr) : tactic expr_set := do
+  deps ← dependency_set_of_hyp h,
+  pure $ deps.insert h
+
+/--
+`dependency_name_set_of_hyp_inclusive h` is the set of unique names of the
+dependencies of the hypothesis `h`, plus `h` itself. See
+`tactic.dependency_set_of_hyp_inclusive`.
+-/
+meta def dependency_name_set_of_hyp_inclusive (h : expr) : tactic name_set :=
+local_set_to_name_set <$> dependency_set_of_hyp_inclusive h
+
+/--
+`dependencies_of_hyp_inclusive h` is the list of dependencies of the hypothesis
+`h`, plus `h` itself. See `tactic.dependency_set_of_hyp_inclusive`. The
+dependencies are returned in no particular order.
+-/
+meta def dependencies_of_hyp_inclusive (h : expr) : tactic (list expr) :=
+rb_set.to_list <$> dependency_set_of_hyp_inclusive h
+
 
 /-! ## Reverse Dependencies -/
 
@@ -372,8 +401,8 @@ private meta def reverse_dependencies_of_hyp_name_set_inclusive_aux :
 /--
 `reverse_dependencies_of_hyp_name_set_inclusive hs` is the list of reverse
 dependencies of the hypotheses whose unique names appear in `hs`, including the
-`hs` themselves. The inclusive reverse dependencies are returned in the order
-in which they appear in the context.
+`hs` themselves. The reverse dependencies are returned in the order in which
+they appear in the context.
 -/
 meta def reverse_dependencies_of_hyp_name_set_inclusive (hs : name_set) :
   tactic (list expr) := do
@@ -393,8 +422,8 @@ reverse_dependencies_of_hyp_name_set_inclusive $ local_set_to_name_set hs
 
 /--
 `reverse_dependencies_of_hyps_inclusive hs` is the list of reverse dependencies
-of the hypotheses `hs`, including the `hs` themselves. The inclusive reverse
-dependencies are returned in the order in which they appear in the context.
+of the hypotheses `hs`, including the `hs` themselves. The reverse dependencies
+are returned in the order in which they appear in the context.
 -/
 meta def reverse_dependencies_of_hyps_inclusive (hs : list expr) :
   tactic (list expr) :=

--- a/src/tactic/dependencies.lean
+++ b/src/tactic/dependencies.lean
@@ -5,8 +5,6 @@ Authors: Jannis Limperg
 -/
 import tactic.core
 
-open native
-
 /-!
 # Tactics About Dependencies
 
@@ -55,6 +53,8 @@ module also provides tactics to find the *direct* dependencies of a hypothesis.
 These are the hypotheses that syntactically appear in the hypothesis's type (or
 value, if the hypothesis is a local definition).
 -/
+
+open native
 
 namespace tactic
 

--- a/src/tactic/dependencies.lean
+++ b/src/tactic/dependencies.lean
@@ -62,7 +62,7 @@ namespace tactic
 private meta def local_list_to_name_set (lcs : list expr) : name_set :=
 lcs.foldl (λ ns h, ns.insert h.local_uniq_name) mk_name_set
 
-/-! ## Direct Dependencies -/
+/-! ### Direct Dependencies -/
 
 /--
 `type_has_local_in_name_set h ns` returns true iff the type of `h` contains a
@@ -192,7 +192,7 @@ meta def hyp_directly_depends_on_locals (h : expr) (hs : list expr) :
 hyp_directly_depends_on_local_name_set h $ local_list_to_name_set hs
 
 
-/-! ## (Indirect) Dependencies -/
+/-! ### (Indirect) Dependencies -/
 
 /--
 `context_dependencies ctx` is a map associating each hypothesis `r ∈ ctx` with
@@ -338,7 +338,7 @@ meta def dependencies_of_hyp_inclusive (h : expr) : tactic (list expr) :=
 rb_set.to_list <$> dependency_set_of_hyp_inclusive h
 
 
-/-! ## Reverse Dependencies -/
+/-! ### Reverse Dependencies -/
 
 private meta def reverse_dependencies_of_hyp_name_set_aux (hs : name_set) :
   list expr → list expr → name_set → tactic (list expr)
@@ -429,7 +429,7 @@ meta def reverse_dependencies_of_hyps_inclusive (hs : list expr) :
   tactic (list expr) :=
 reverse_dependencies_of_hyp_name_set_inclusive $ local_list_to_name_set hs
 
-/-! ## Reverting -/
+/-! ### Reverting -/
 
 /--
 `revert_name_set hs` reverts the local constants whose unique names appear

--- a/src/tactic/dependencies.lean
+++ b/src/tactic/dependencies.lean
@@ -3,53 +3,68 @@ Copyright (c) 2020 Jannis Limperg. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
-import data.list.defs
-import meta.expr
 import tactic.core
 
-/-!
-# Tactics about dependencies
+open native
 
-An expression `e` depends on another expression `f` if `f` occurs in `e` (see
-note [dependencies of hypotheses] for details and corner cases). This module
-provides tactics for checking whether hypotheses depend on each other and for
-enumerating the dependencies and reverse dependencies of hypotheses.
+/-!
+# Tactics About Dependencies
+
+This module provides tactics to compute dependencies and reverse dependencies of
+hypotheses. An expression `e` depends on a hypothesis `h` if `e` would not be
+valid if `h` were removed from the context. For example, the expression `e = x >
+0` depends on `x`. We say that `x` is a dependency of `e` and that `e` is a
+reverse dependency of `x`.
+
+It is sometimes useful to consider *inclusive* dependency: `e` inclusively
+depends on `h` iff `e` depends on `h` or `e = h` (so inclusive dependency is the
+reflexive closure of regular dependency).
+
+Note that the standard library does not use quite the same terminology:
+
+* `kdependencies`/`kdeps` from the standard library compute reverse
+  dependencies, not dependencies.
+* `kdepends_on` and functions derived from it ignore local definitions and
+  therefore compute a weaker dependency relation (see next section).
+
+## Local Definitions
+
+Determining dependencies of hypotheses is usually straightforward: a hypothesis
+`r : R` depends on another hypothesis `d : D` if `d` occurs in `R`. The
+implementation is more involved, however, in the presence of local definitions.
+Consider this context:
+
+```lean
+n m : ℕ
+k : ℕ := m
+o : ℕ := k
+h : o > 0
+```
+
+`h` depends on `o`, `k` and `m`, but only the dependency on `o` is syntactically
+obvious. `kdepends_on` ignores this complication and claims that `h` does not
+depend on `k` or `m`. We do not follow this example but process local
+definitions properly. When determining whether `r : R` depends on `d : D`, we
+first check whether the context up to `r` contains any local definitions. If
+not, we can simply check whether `d` occurs in `R`. But if there are local
+definitions, we must compute the transitive dependencies of all hypotheses up to
+`r`.
+
+If you want to ignore local definitions while computing dependencies, this
+module also provides tactics to find the *direct* dependencies of a hypothesis.
+These are the hypotheses that syntactically appear in the hypothesis's type (or
+value, if the hypothesis is a local definition).
 -/
 
 namespace tactic
 
-/--
-Given a hypothesis (local constant) `h` and a local constant `i`, we say that
-`h` depends on `i` iff
+private meta def local_set_to_name_set (lcs : expr_set) : name_set :=
+lcs.fold mk_name_set $ λ h ns, ns.insert h.local_uniq_name
 
-- `i` appears in the type of `h` or
-- `h` is a local definition and `i` appears in its body.
+private meta def local_list_to_name_set (lcs : list expr) : name_set :=
+lcs.foldl (λ ns h, ns.insert h.local_uniq_name) mk_name_set
 
-We say that `h` inclusively depends on `i` iff `h` depends on `i` or `h = i`
-(so inclusive dependency is the reflexive closure of regular dependency).
-
-For example, consider the following context:
-
-```lean
-P : ∀ n, fin n → Prop
-n : ℕ
-m : ℕ := n
-f : fin m
-h : P m f
-```
-
-Here, `m` depends on `n`; `f` depends on `m`; `h` depends on `P`, `m` and `f`.
-Note that `f` and `h` do not depend on `n`, so the depends-on relation is not
-transitive in the presence of local definitions. `h` inclusively depends on `h`,
-`P`, `m` and `f`.
-
-We also say that `m` is a dependency of `f` and `f` a reverse dependency of `m`.
-Note that the Lean standard library sometimes uses these terms differently:
-`kdependencies`, confusingly, computes the reverse dependencies of an
-expression.
--/
-library_note "dependencies of hypotheses"
-
+/-! ## Direct Dependencies -/
 
 /--
 `type_has_local_in h ns` returns true iff the type of `h` contains a local
@@ -61,151 +76,230 @@ meta def type_has_local_in (h : expr) (ns : name_set) : tactic bool := do
 
 /--
 `local_def_value_has_local_in h ns` returns true iff `h` is a local definition
-whose body contains a local constant whose unique name appears in `ns`.
+whose value contains a local constant whose unique name appears in `ns`.
 -/
 meta def local_def_value_has_local_in (h : expr) (ns : name_set) : tactic bool := do
   (some h_val) ← try_core $ local_def_value h | pure ff,
   pure $ h_val.has_local_in ns
 
 /--
-Given a hypothesis `h`, `hyp_depends_on_locals h ns` returns true iff `h`
-depends on a local constant whose unique name appears in `ns`. See note
-[dependencies of hypotheses].
+`direct_dependency_set_of_hyp h` is the set of hypotheses that the hypothesis `h`
+directly depends on. These are the hypotheses that appear in `h`'s type or value
+(if `h` is a local definition).
 -/
-meta def hyp_depends_on_locals (h : expr) (ns : name_set) : tactic bool :=
+meta def direct_dependency_set_of_hyp (h : expr) : tactic expr_set := do
+  t ← infer_type h,
+  let deps := t.list_local_consts',
+  (some val) ← try_core $ local_def_value h | pure deps,
+  let deps := deps.union val.list_local_consts',
+  pure deps
+
+/--
+`direct_dependency_set_of_hyp_inclusive h` is the set of hypotheses that the
+hypothesis `h` directly depends on, plus `h` itself.
+-/
+meta def direct_dependency_set_of_hyp_inclusive (h : expr) : tactic expr_set := do
+  deps ← direct_dependency_set_of_hyp h,
+  pure $ deps.insert h
+
+/--
+`hyp_directly_depends_on_locals h ns` is true iff the hypothesis `h` directly
+depends on a hypothesis whose unique name appears in `ns`.
+-/
+meta def hyp_directly_depends_on_locals (h : expr) (ns : name_set) : tactic bool :=
 list.mbor
   [ type_has_local_in h ns,
     local_def_value_has_local_in h ns ]
 
+/-! ## (Indirect) Dependencies -/
+
 /--
-Given a hypothesis `h`, `hyp_depends_on_locals h ns` returns true iff `h`
-inclusively depends on a local constant whose unique name appears in `ns`.
-See note [dependencies of hypotheses].
+`context_dependencies ctx` is a map associating each hypothesis `r ∈ ctx` with
+those hypotheses `d ∈ ctx` which `r` depends on. `ctx` must be a sublist of the
+local context. In particular, the hypotheses in `ctx` must be in context order,
+so earlier hypotheses may not depend on later hypotheses.
 -/
-meta def hyp_depends_on_locals_inclusive (h : expr) (ns : name_set) : tactic bool :=
+meta def context_dependencies (ctx : list expr) : tactic (expr_map expr_set) :=
+ctx.mfoldl
+  (λ deps h, do
+    direct_deps ← direct_dependency_set_of_hyp h,
+    let trans_deps := direct_deps.fold direct_deps $ λ dep trans_deps,
+      trans_deps.union $ (deps.find dep).get_or_else mk_expr_set,
+    pure $ deps.insert h trans_deps
+    )
+  mk_expr_map
+
+/--
+`hyp_depends_on_local_name_set h ns` is true iff the hypothesis `h` depends on
+any of the hypotheses whose unique names appear in `ns`.
+
+This tactic is moderately expensive if the context up to `h` contains local
+definitions. If you need to check dependencies of multiple hypotheses, you may
+want to use `tactic.context_dependencies`.
+-/
+meta def hyp_depends_on_local_name_set (h : expr) (ns : name_set) : tactic bool := do
+  ctx ← local_context,
+  let ctx := ctx.take_while (≠ h) ++ [h],
+  ctx_has_local_def ← ctx.many (succeeds ∘ local_def_value),
+  if ¬ ctx_has_local_def
+    then hyp_directly_depends_on_locals h ns
+    else do
+      deps ← context_dependencies ctx,
+      let h_deps := local_set_to_name_set $ (deps.find h).get_or_else mk_expr_set,
+      pure $ ns.fold ff (λ dep b, b || h_deps.contains dep)
+
+/--
+`hyp_depends_on_locals h hs` is true iff the hypothesis `h` depends on any of
+the hypotheses `hs`. See `tactic.hyp_depends_on_local_name_set`.
+-/
+meta def hyp_depends_on_locals (h : expr) (hs : list expr) : tactic bool :=
+hyp_depends_on_local_name_set h $ local_list_to_name_set hs
+
+/--
+`hyp_depends_on_local_name_set_inclusive h ns` is true iff the hypothesis `h`
+inclusively depends on any of the hypotheses whose unique names appear in `ns`.
+This is the case if either `h` depends on any of the `ns` or `h` itself appears
+in `ns`.
+
+This tactic is moderately expensive if the context up to `h` contains local
+definitions. If you need to check dependencies of multiple hypotheses, you may
+want to use `tactic.context_dependencies`.
+-/
+meta def hyp_depends_on_local_name_set_inclusive (h : expr) (ns : name_set) :
+  tactic bool :=
 list.mbor
   [ pure $ ns.contains h.local_uniq_name,
-    hyp_depends_on_locals h ns ]
+    hyp_depends_on_local_name_set h ns ]
 
 /--
-Given a hypothesis `h` and local constant `i`, `hyp_depends_on_local h i`
-checks whether `h` depends on `i`. See note [dependencies of hypotheses].
+`hyp_depends_on_locals_inclusive h hs` is true iff the hypothesis `h` depends on
+any of the hypotheses `hs`. See
+`tactic.hyp_depends_on_local_name_set_inclusive`.
 -/
-meta def hyp_depends_on_local (h i : expr) : tactic bool :=
-hyp_depends_on_locals h (mk_name_set.insert i.local_uniq_name)
+meta def hyp_depends_on_locals_inclusive (h : expr) (hs : list expr) :
+  tactic bool :=
+hyp_depends_on_local_name_set_inclusive h $ local_list_to_name_set hs
 
 /--
-Given a hypothesis `h` and local constant `i`, `hyp_depends_on_local h i`
-checks whether `h` inclusively depends on `i`. See note
-[dependencies of hypotheses].
--/
-meta def hyp_depends_on_local_inclusive (h i : expr) : tactic bool :=
-hyp_depends_on_locals_inclusive h (mk_name_set.insert i.local_uniq_name)
+`dependency_set_of_hyp h` is the set of dependencies of the hypothesis `h`.
 
-/--
-Given a hypothesis `h`, `dependencies_of_hyp' h` returns the set of unique names
-of the local constants which `h` depends on. See note
-[dependencies of hypotheses].
+This tactic is moderately expensive if the context up to `h` contains local
+definitions. If you need to check dependencies of multiple hypotheses, you may
+want to use `tactic.context_dependencies`.
 -/
-meta def dependencies_of_hyp' (h : expr) : tactic name_set := do
-  t ← infer_type h,
-  let deps := t.list_local_const_unique_names,
-  (some val) ← try_core $ local_def_value h | pure deps,
-  let deps := deps.union val.list_local_const_unique_names,
-  pure deps
-
-/--
-Given a hypothesis `h`, `dependencies_of_hyp h` returns the hypotheses which `h`
-depends on. See note [dependencies of hypotheses].
--/
-meta def dependencies_of_hyp (h : expr) : tactic (list expr) := do
-  ns ← dependencies_of_hyp' h,
-  ns.to_list.mmap get_local
-
-/--
-Given a hypothesis `h`, `dependencies_of_hyp_inclusive' h` returns the set of
-unique names of the local constants which `h` inclusively depends on. See note
-[dependencies of hypotheses].
--/
-meta def dependencies_of_hyp_inclusive' (h : expr) : tactic name_set := do
-  deps ← dependencies_of_hyp' h,
-  pure $ deps.insert h.local_uniq_name
-
-/--
-Given a hypothesis `h`, `dependencies_of_hyp_inclusive' h` returns the
-hypotheses which `h` inclusively depends on. See note
-[dependencies of hypotheses].
--/
-meta def dependencies_of_hyp_inclusive (h : expr) : tactic (list expr) := do
-  ns ← dependencies_of_hyp_inclusive' h,
-  ns.to_list.mmap get_local
-
-/--
-Given a set `ns` of unique names of hypotheses,
-`reverse_dependencies_of_hyps' hs` returns those hypotheses which depend on any
-of the `hs`, excluding the `hs` themselves. See note
-[dependencies of hypotheses].
--/
-meta def reverse_dependencies_of_hyps' (hs : name_set) : tactic (list expr) := do
+meta def dependency_set_of_hyp (h : expr) : tactic expr_set := do
   ctx ← local_context,
-  ctx.mfilter $ λ h, list.mband
-    [ pure $ ¬ hs.contains h.local_uniq_name,
-      hyp_depends_on_locals h hs ]
+  let ctx := ctx.take_while (≠ h) ++ [h],
+  ctx_has_local_def ← ctx.many (succeeds ∘ local_def_value),
+  if ¬ ctx_has_local_def
+    then direct_dependency_set_of_hyp h
+    else do
+      deps ← context_dependencies ctx,
+      pure $ (deps.find h).get_or_else mk_expr_set
 
 /--
-`reverse_dependencies_of_hyps hs` returns those hypotheses which depend on any
-of the hypotheses `hs`, excluding the `hs` themselves.
+`dependencies_of_hyp h` is the list of dependencies of the hypothesis `h`. See
+`tactic.dependency_set_of_hyp`. The dependencies are returned in no particular
+order.
+-/
+meta def dependencies_of_hyp (h : expr) : tactic (list expr) :=
+rb_set.to_list <$> dependency_set_of_hyp h
+
+/-! ## Reverse Dependencies -/
+
+private meta def reverse_dependencies_of_hyp_name_set_aux (hs : name_set) :
+  list expr → list expr → name_set → tactic (list expr)
+| [] revdeps _ := pure revdeps.reverse
+| (H :: Hs) revdeps ns := do
+  let H_uname := H.local_uniq_name,
+  H_is_revdep ← list.mband
+    [ pure $ ¬ hs.contains H_uname,
+      hyp_directly_depends_on_locals H ns ],
+  if H_is_revdep
+    then
+      reverse_dependencies_of_hyp_name_set_aux Hs (H :: revdeps)
+        (ns.insert H_uname)
+    else
+      reverse_dependencies_of_hyp_name_set_aux Hs revdeps ns
+
+/--
+`reverse_dependencies_of_hyp_name_set hs` is the list of reverse dependencies of
+the hypotheses whose unique names appear in `hs`, excluding the `hs` themselves.
+The reverse dependencies are returned in the order in which they appear in the
+context.
+-/
+meta def reverse_dependencies_of_hyp_name_set (hs : name_set) :
+  tactic (list expr) := do
+  ctx ← local_context,
+  let ctx := ctx.after (λ h, hs.contains h.local_uniq_name),
+  reverse_dependencies_of_hyp_name_set_aux hs ctx [] hs
+
+/--
+`reverse_dependencies_of_hyps hs` is the list of reverse dependencies of the
+hypotheses `hs`, excluding the `hs` themselves. The reverse dependencies are
+returned in the order in which they appear in the context.
 -/
 meta def reverse_dependencies_of_hyps (hs : list expr) : tactic (list expr) :=
-reverse_dependencies_of_hyps' $
-  hs.foldl (λ ns h, ns.insert h.local_uniq_name) mk_name_set
+reverse_dependencies_of_hyp_name_set $ local_list_to_name_set hs
+
+private meta def reverse_dependencies_of_hyp_name_set_inclusive_aux :
+  list expr → list expr → name_set → tactic (list expr)
+| [] revdeps _ := pure revdeps.reverse
+| (H :: Hs) revdeps ns := do
+  let H_uname := H.local_uniq_name,
+  H_is_revdep ← list.mbor
+    [ pure $ ns.contains H.local_uniq_name,
+      hyp_directly_depends_on_locals H ns ],
+  if H_is_revdep
+    then
+      reverse_dependencies_of_hyp_name_set_inclusive_aux Hs (H :: revdeps)
+        (ns.insert H_uname)
+    else
+      reverse_dependencies_of_hyp_name_set_inclusive_aux Hs revdeps ns
 
 /--
-Given a set `ns` of unique names of hypotheses,
-`reverse_dependencies_of_hyps_inclusive' hs` returns those hypotheses which
-inclusively depend on any of the `hs`. See note [dependencies of hypotheses].
-
-This is the 'revert closure' of `hs`: to revert the `hs`, we must also revert
-their reverse dependencies.
+`reverse_dependencies_of_hyp_name_set_inclusive hs` is the list of reverse
+dependencies of the hypotheses whose unique names appear in `hs`, including the
+`hs` themselves. The inclusive reverse dependencies are returned in the order
+in which they appear in the context.
 -/
-meta def reverse_dependencies_of_hyps_inclusive' (hs : name_set) :
+meta def reverse_dependencies_of_hyp_name_set_inclusive (hs : name_set) :
   tactic (list expr) := do
   ctx ← local_context,
-  ctx.mfilter $ λ h, hyp_depends_on_locals_inclusive h hs
+  let ctx := ctx.drop_while (λ h, ¬ hs.contains h.local_uniq_name),
+  reverse_dependencies_of_hyp_name_set_inclusive_aux ctx [] hs
 
 /--
-`reverse_dependencies_of_hyps_inclusive hs` returns those hypotheses which
-inclusively depend on any of the hypotheses `hs`. See note
-[dependencies of hypotheses].
-
-This is the 'revert closure' of `hs`: to revert the `hs`, we must also revert
-their reverse dependencies.
+`reverse_dependencies_of_hyps_inclusive hs` is the list of reverse dependencies
+of the hypotheses `hs`, including the `hs` themselves. The inclusive reverse
+dependencies are returned in the order in which they appear in the context.
 -/
 meta def reverse_dependencies_of_hyps_inclusive (hs : list expr) :
-  tactic (list expr) := do
-reverse_dependencies_of_hyps_inclusive' $
-  hs.foldl (λ ns h, ns.insert h.local_uniq_name) mk_name_set
+  tactic (list expr) :=
+reverse_dependencies_of_hyp_name_set_inclusive $ local_list_to_name_set hs
+
+/-! ## Reverting -/
 
 /--
-Revert the local constants whose unique names appear in `hs`, as well as any
-hypotheses that depend on them. Returns the number of reverted hypotheses and a
-list containing these hypotheses. The returned hypotheses are arbitrarily
-ordered and are guaranteed to store the correct type (see `tactic.update_type`).
--/
-meta def revert_set (hs : name_set) : tactic (ℕ × list expr) := do
-  to_revert ← reverse_dependencies_of_hyps_inclusive' hs,
+`revert_name_set hs` reverts the local constants whose unique names appear
+in `hs` as well as any hypotheses that depend on them. Returns the number of
+reverted hypotheses and a list containing these hypotheses. The returned
+hypotheses are arbitrarily ordered and are guaranteed to store the correct type
+(see `tactic.update_type`). -/
+meta def revert_name_set (hs : name_set) : tactic (ℕ × list expr) := do
+  to_revert ← reverse_dependencies_of_hyp_name_set_inclusive hs,
   to_revert_with_types ← to_revert.mmap update_type,
   num_reverted ← revert_lst to_revert,
   pure (num_reverted, to_revert_with_types)
 
 /--
-Revert the local constants in `hs`, as well as any hypotheses that depend on
-them. Returns the number of reverted hypotheses and a list containing these
-hypotheses. The returned hypotheses are arbitrarily ordered and are guaranteed
-to store the correct type (see `tactic.update_type`).
+`revert_lst' hs` reverts the local constants in `hs, as well as any
+hypotheses that depend on them. Returns the number of reverted hypotheses and a
+list containing these hypotheses. The returned hypotheses are arbitrarily
+ordered and are guaranteed to store the correct type (see `tactic.update_type`).
 -/
 meta def revert_lst' (hs : list expr) : tactic (ℕ × list expr) :=
-revert_set $ hs.foldl (λ ns h, ns.insert h.local_uniq_name) mk_name_set
+revert_name_set $ local_list_to_name_set hs
 
 /--
 `revert_reverse_dependencies_of_hyp h` reverts all the hypotheses that depend on

--- a/src/tactic/dependencies.lean
+++ b/src/tactic/dependencies.lean
@@ -190,7 +190,7 @@ meta def hyp_directly_depends_on_locals (h : expr) (hs : list expr) :
 hyp_directly_depends_on_local_name_set h $ local_list_to_name_set hs
 
 
-/-! ### (Indirect) Dependencies -/
+/-! ### (Indirect/Transitive) Dependencies -/
 
 /--
 `context_dependencies ctx` is a map associating each hypothesis `r ∈ ctx` with

--- a/src/tactic/dependencies.lean
+++ b/src/tactic/dependencies.lean
@@ -229,14 +229,22 @@ meta def hyp_depends_on_local_name_set (h : expr) (ns : name_set) : tactic bool 
 
 /--
 `hyp_depends_on_local_set h hs` is true iff the hypothesis `h` depends on
-any of the hypotheses `hs`. See `tactic.hyp_depends_on_local_name_set`.
+any of the hypotheses `hs`.
+
+This tactic is moderately expensive if the context up to `h` contains local
+definitions. If you need to check dependencies of multiple hypotheses, you may
+want to use `tactic.context_dependencies`.
 -/
 meta def hyp_depends_on_local_set (h : expr) (hs : expr_set) : tactic bool :=
 hyp_depends_on_local_name_set h $ local_set_to_name_set hs
 
 /--
 `hyp_depends_on_locals h hs` is true iff the hypothesis `h` depends on any of
-the hypotheses `hs`. See `tactic.hyp_depends_on_local_name_set`.
+the hypotheses `hs`.
+
+This tactic is moderately expensive if the context up to `h` contains local
+definitions. If you need to check dependencies of multiple hypotheses, you may
+want to use `tactic.context_dependencies`.
 -/
 meta def hyp_depends_on_locals (h : expr) (hs : list expr) : tactic bool :=
 hyp_depends_on_local_name_set h $ local_list_to_name_set hs
@@ -259,8 +267,11 @@ list.mbor
 
 /--
 `hyp_depends_on_local_set_inclusive h hs` is true iff the hypothesis `h`
-depends on any of the hypotheses `hs`. See
-`tactic.hyp_depends_on_local_name_set_inclusive`.
+depends on any of the hypotheses `hs`.
+
+This tactic is moderately expensive if the context up to `h` contains local
+definitions. If you need to check dependencies of multiple hypotheses, you may
+want to use `tactic.context_dependencies`.
 -/
 meta def hyp_depends_on_local_set_inclusive (h : expr) (hs : expr_set) :
   tactic bool :=
@@ -268,8 +279,11 @@ hyp_depends_on_local_name_set_inclusive h $ local_set_to_name_set hs
 
 /--
 `hyp_depends_on_locals_inclusive h hs` is true iff the hypothesis `h` depends on
-any of the hypotheses `hs`. See
-`tactic.hyp_depends_on_local_name_set_inclusive`.
+any of the hypotheses `hs`.
+
+This tactic is moderately expensive if the context up to `h` contains local
+definitions. If you need to check dependencies of multiple hypotheses, you may
+want to use `tactic.context_dependencies`.
 -/
 meta def hyp_depends_on_locals_inclusive (h : expr) (hs : list expr) :
   tactic bool :=
@@ -294,15 +308,22 @@ meta def dependency_set_of_hyp (h : expr) : tactic expr_set := do
 
 /--
 `dependency_name_set_of_hyp h` is the set of unique names of the dependencies of
-the hypothesis `h`. See `tactic.dependency_set_of_hyp`.
+the hypothesis `h`.
+
+This tactic is moderately expensive if the context up to `h` contains local
+definitions. If you need the dependencies of multiple hypotheses, you may want
+to use `tactic.context_dependencies`.
 -/
 meta def dependency_name_set_of_hyp (h : expr) : tactic name_set :=
 local_set_to_name_set <$> dependency_set_of_hyp h
 
 /--
-`dependencies_of_hyp h` is the list of dependencies of the hypothesis `h`. See
-`tactic.dependency_set_of_hyp`. The dependencies are returned in no particular
-order.
+`dependencies_of_hyp h` is the list of dependencies of the hypothesis `h`.
+The dependencies are returned in no particular order.
+
+This tactic is moderately expensive if the context up to `h` contains local
+definitions. If you need the dependencies of multiple hypotheses, you may want
+to use `tactic.context_dependencies`.
 -/
 meta def dependencies_of_hyp (h : expr) : tactic (list expr) :=
 rb_set.to_list <$> dependency_set_of_hyp h
@@ -321,16 +342,22 @@ meta def dependency_set_of_hyp_inclusive (h : expr) : tactic expr_set := do
 
 /--
 `dependency_name_set_of_hyp_inclusive h` is the set of unique names of the
-dependencies of the hypothesis `h`, plus `h` itself. See
-`tactic.dependency_set_of_hyp_inclusive`.
+dependencies of the hypothesis `h`, plus `h` itself.
+
+This tactic is moderately expensive if the context up to `h` includes local
+definitions. If you need the dependencies of multiple hypotheses, you may want
+to use `tactic.context_dependencies`.
 -/
 meta def dependency_name_set_of_hyp_inclusive (h : expr) : tactic name_set :=
 local_set_to_name_set <$> dependency_set_of_hyp_inclusive h
 
 /--
 `dependencies_of_hyp_inclusive h` is the list of dependencies of the hypothesis
-`h`, plus `h` itself. See `tactic.dependency_set_of_hyp_inclusive`. The
-dependencies are returned in no particular order.
+`h`, plus `h` itself. The dependencies are returned in no particular order.
+
+This tactic is moderately expensive if the context up to `h` includes local
+definitions. If you need the dependencies of multiple hypotheses, you may want
+to use `tactic.context_dependencies`.
 -/
 meta def dependencies_of_hyp_inclusive (h : expr) : tactic (list expr) :=
 rb_set.to_list <$> dependency_set_of_hyp_inclusive h

--- a/src/tactic/dependencies.lean
+++ b/src/tactic/dependencies.lean
@@ -10,9 +10,9 @@ import tactic.core
 
 This module provides tactics to compute dependencies and reverse dependencies of
 hypotheses. An expression `e` depends on a hypothesis `h` if `e` would not be
-valid if `h` were removed from the context. For example, the expression `e = x >
-0` depends on `x`. We say that `x` is a dependency of `e` and that `e` is a
-reverse dependency of `x`.
+valid if `h` were removed from the context. For example, the expression
+`e := x > 0` depends on `x`. We say that `x` is a dependency of `e` and that `e`
+is a reverse dependency of `x`.
 
 It is sometimes useful to consider *inclusive* dependency: `e` inclusively
 depends on `h` iff `e` depends on `h` or `e = h` (so inclusive dependency is the
@@ -56,11 +56,9 @@ value, if the hypothesis is a local definition).
 
 open native
 open expr_set (local_set_to_name_set)
+open name_set (local_list_to_name_set)
 
 namespace tactic
-
-private meta def local_list_to_name_set (lcs : list expr) : name_set :=
-lcs.foldl (λ ns h, ns.insert h.local_uniq_name) mk_name_set
 
 /-! ### Direct Dependencies -/
 

--- a/src/tactic/dependencies.lean
+++ b/src/tactic/dependencies.lean
@@ -318,7 +318,7 @@ private meta def reverse_dependencies_of_hyp_name_set_aux (hs : name_set) :
   let H_uname := H.local_uniq_name,
   H_is_revdep ← list.mband
     [ pure $ ¬ hs.contains H_uname,
-      hyp_directly_depends_on_locals H ns ],
+      hyp_directly_depends_on_local_name_set H ns ],
   if H_is_revdep
     then
       reverse_dependencies_of_hyp_name_set_aux Hs (H :: revdeps)
@@ -361,7 +361,7 @@ private meta def reverse_dependencies_of_hyp_name_set_inclusive_aux :
   let H_uname := H.local_uniq_name,
   H_is_revdep ← list.mbor
     [ pure $ ns.contains H.local_uniq_name,
-      hyp_directly_depends_on_locals H ns ],
+      hyp_directly_depends_on_local_name_set H ns ],
   if H_is_revdep
     then
       reverse_dependencies_of_hyp_name_set_inclusive_aux Hs (H :: revdeps)

--- a/src/tactic/dependencies.lean
+++ b/src/tactic/dependencies.lean
@@ -1,0 +1,230 @@
+/-
+Copyright (c) 2020 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+import data.list.defs
+import meta.expr
+import tactic.core
+
+/-!
+# Tactics about dependencies
+
+An expression `e` depends on another expression `f` if `f` occurs in `e` (see
+note [dependencies of hypotheses] for details and corner cases). This module
+provides tactics for checking whether hypotheses depend on each other and for
+enumerating the dependencies and reverse dependencies of hypotheses.
+-/
+
+namespace tactic
+
+/--
+Given a hypothesis (local constant) `h` and a local constant `i`, we say that
+`h` depends on `i` iff
+
+- `i` appears in the type of `h` or
+- `h` is a local definition and `i` appears in its body.
+
+We say that `h` inclusively depends on `i` iff `h` depends on `i` or `h = i`
+(so inclusive dependency is the reflexive closure of regular dependency).
+
+For example, consider the following context:
+
+```lean
+P : ∀ n, fin n → Prop
+n : ℕ
+m : ℕ := n
+f : fin m
+h : P m f
+```
+
+Here, `m` depends on `n`; `f` depends on `m`; `h` depends on `P`, `m` and `f`.
+Note that `f` and `h` do not depend on `n`, so the depends-on relation is not
+transitive in the presence of local definitions. `h` inclusively depends on `h`,
+`P`, `m` and `f`.
+
+We also say that `m` is a dependency of `f` and `f` a reverse dependency of `m`.
+Note that the Lean standard library sometimes uses these terms differently:
+`kdependencies`, confusingly, computes the reverse dependencies of an
+expression.
+-/
+library_note "dependencies of hypotheses"
+
+
+/--
+`type_has_local_in h ns` returns true iff the type of `h` contains a local
+constant whose unique name appears in `ns`.
+-/
+meta def type_has_local_in (h : expr) (ns : name_set) : tactic bool := do
+  h_type ← infer_type h,
+  pure $ h_type.has_local_in ns
+
+/--
+`local_def_value_has_local_in h ns` returns true iff `h` is a local definition
+whose body contains a local constant whose unique name appears in `ns`.
+-/
+meta def local_def_value_has_local_in (h : expr) (ns : name_set) : tactic bool := do
+  (some h_val) ← try_core $ local_def_value h | pure ff,
+  pure $ h_val.has_local_in ns
+
+/--
+Given a hypothesis `h`, `hyp_depends_on_locals h ns` returns true iff `h`
+depends on a local constant whose unique name appears in `ns`. See note
+[dependencies of hypotheses].
+-/
+meta def hyp_depends_on_locals (h : expr) (ns : name_set) : tactic bool :=
+list.mbor
+  [ type_has_local_in h ns,
+    local_def_value_has_local_in h ns ]
+
+/--
+Given a hypothesis `h`, `hyp_depends_on_locals h ns` returns true iff `h`
+inclusively depends on a local constant whose unique name appears in `ns`.
+See note [dependencies of hypotheses].
+-/
+meta def hyp_depends_on_locals_inclusive (h : expr) (ns : name_set) : tactic bool :=
+list.mbor
+  [ pure $ ns.contains h.local_uniq_name,
+    hyp_depends_on_locals h ns ]
+
+/--
+Given a hypothesis `h` and local constant `i`, `hyp_depends_on_local h i`
+checks whether `h` depends on `i`. See note [dependencies of hypotheses].
+-/
+meta def hyp_depends_on_local (h i : expr) : tactic bool :=
+hyp_depends_on_locals h (mk_name_set.insert i.local_uniq_name)
+
+/--
+Given a hypothesis `h` and local constant `i`, `hyp_depends_on_local h i`
+checks whether `h` inclusively depends on `i`. See note
+[dependencies of hypotheses].
+-/
+meta def hyp_depends_on_local_inclusive (h i : expr) : tactic bool :=
+hyp_depends_on_locals_inclusive h (mk_name_set.insert i.local_uniq_name)
+
+/--
+Given a hypothesis `h`, `dependencies_of_hyp' h` returns the set of unique names
+of the local constants which `h` depends on. See note
+[dependencies of hypotheses].
+-/
+meta def dependencies_of_hyp' (h : expr) : tactic name_set := do
+  t ← infer_type h,
+  let deps := t.list_local_const_unique_names,
+  (some val) ← try_core $ local_def_value h | pure deps,
+  let deps := deps.union val.list_local_const_unique_names,
+  pure deps
+
+/--
+Given a hypothesis `h`, `dependencies_of_hyp h` returns the hypotheses which `h`
+depends on. See note [dependencies of hypotheses].
+-/
+meta def dependencies_of_hyp (h : expr) : tactic (list expr) := do
+  ns ← dependencies_of_hyp' h,
+  ns.to_list.mmap get_local
+
+/--
+Given a hypothesis `h`, `dependencies_of_hyp_inclusive' h` returns the set of
+unique names of the local constants which `h` inclusively depends on. See note
+[dependencies of hypotheses].
+-/
+meta def dependencies_of_hyp_inclusive' (h : expr) : tactic name_set := do
+  deps ← dependencies_of_hyp' h,
+  pure $ deps.insert h.local_uniq_name
+
+/--
+Given a hypothesis `h`, `dependencies_of_hyp_inclusive' h` returns the
+hypotheses which `h` inclusively depends on. See note
+[dependencies of hypotheses].
+-/
+meta def dependencies_of_hyp_inclusive (h : expr) : tactic (list expr) := do
+  ns ← dependencies_of_hyp_inclusive' h,
+  ns.to_list.mmap get_local
+
+/--
+Given a set `ns` of unique names of hypotheses,
+`reverse_dependencies_of_hyps' hs` returns those hypotheses which depend on any
+of the `hs`, excluding the `hs` themselves. See note
+[dependencies of hypotheses].
+-/
+meta def reverse_dependencies_of_hyps' (hs : name_set) : tactic (list expr) := do
+  ctx ← local_context,
+  ctx.mfilter $ λ h, list.mband
+    [ pure $ ¬ hs.contains h.local_uniq_name,
+      hyp_depends_on_locals h hs ]
+
+/--
+`reverse_dependencies_of_hyps hs` returns those hypotheses which depend on any
+of the hypotheses `hs`, excluding the `hs` themselves.
+-/
+meta def reverse_dependencies_of_hyps (hs : list expr) : tactic (list expr) :=
+reverse_dependencies_of_hyps' $
+  hs.foldl (λ ns h, ns.insert h.local_uniq_name) mk_name_set
+
+/--
+Given a set `ns` of unique names of hypotheses,
+`reverse_dependencies_of_hyps_inclusive' hs` returns those hypotheses which
+inclusively depend on any of the `hs`. See note [dependencies of hypotheses].
+
+This is the 'revert closure' of `hs`: to revert the `hs`, we must also revert
+their reverse dependencies.
+-/
+meta def reverse_dependencies_of_hyps_inclusive' (hs : name_set) :
+  tactic (list expr) := do
+  ctx ← local_context,
+  ctx.mfilter $ λ h, hyp_depends_on_locals_inclusive h hs
+
+/--
+`reverse_dependencies_of_hyps_inclusive hs` returns those hypotheses which
+inclusively depend on any of the hypotheses `hs`. See note
+[dependencies of hypotheses].
+
+This is the 'revert closure' of `hs`: to revert the `hs`, we must also revert
+their reverse dependencies.
+-/
+meta def reverse_dependencies_of_hyps_inclusive (hs : list expr) :
+  tactic (list expr) := do
+reverse_dependencies_of_hyps_inclusive' $
+  hs.foldl (λ ns h, ns.insert h.local_uniq_name) mk_name_set
+
+/--
+Revert the local constants whose unique names appear in `hs`, as well as any
+hypotheses that depend on them. Returns the number of reverted hypotheses and a
+list containing these hypotheses. The returned hypotheses are arbitrarily
+ordered and are guaranteed to store the correct type (see `tactic.update_type`).
+-/
+meta def revert_set (hs : name_set) : tactic (ℕ × list expr) := do
+  to_revert ← reverse_dependencies_of_hyps_inclusive' hs,
+  to_revert_with_types ← to_revert.mmap update_type,
+  num_reverted ← revert_lst to_revert,
+  pure (num_reverted, to_revert_with_types)
+
+/--
+Revert the local constants in `hs`, as well as any hypotheses that depend on
+them. Returns the number of reverted hypotheses and a list containing these
+hypotheses. The returned hypotheses are arbitrarily ordered and are guaranteed
+to store the correct type (see `tactic.update_type`).
+-/
+meta def revert_lst' (hs : list expr) : tactic (ℕ × list expr) :=
+revert_set $ hs.foldl (λ ns h, ns.insert h.local_uniq_name) mk_name_set
+
+/--
+`revert_reverse_dependencies_of_hyp h` reverts all the hypotheses that depend on
+the hypothesis `h`, including the local definitions that have `h` in their
+value. This fixes a bug in `revert_kdeps` that does not revert local definitions
+for which `h` only appears in the value. Returns the number of reverted
+hypotheses.
+-/
+meta def revert_reverse_dependencies_of_hyp (h : expr) : tactic ℕ :=
+reverse_dependencies_of_hyps [h] >>= revert_lst
+/- We cannot implement it as `revert e >> intro1` because that would change the
+local constant in the context. -/
+
+/--
+`revert_reverse_dependencies_of_hyp hs` reverts all the hypotheses that depend
+on a hypothesis in `hs`. The `hs` themselves are not reverted, unless they
+depend on each other. Returns the number of reverted hypotheses.
+-/
+meta def revert_reverse_dependencies_of_hyps (hs : list expr) : tactic ℕ :=
+reverse_dependencies_of_hyps hs >>= revert_lst
+
+end tactic

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Simon Hudon, Sebastien Gouezel, Scott Morrison
 -/
 import tactic.lint
+import tactic.dependencies
 
 open lean
 open lean.parser
@@ -1063,7 +1064,8 @@ add_tactic_doc
 /-- `revert_deps n₁ n₂ ...` reverts all the hypotheses that depend on one of `n₁, n₂, ...`
 It does not revert `n₁, n₂, ...` themselves (unless they depend on another `nᵢ`). -/
 meta def revert_deps (ns : parse ident*) : tactic unit :=
-propagate_tags $ ns.reverse.mmap' $ λ n, get_local n >>= tactic.revert_deps
+propagate_tags $
+  ns.mmap get_local >>= revert_reverse_dependencies_of_hyps >> skip
 
 add_tactic_doc
 { name       := "revert_deps",

--- a/src/tactic/wlog.lean
+++ b/src/tactic/wlog.lean
@@ -46,17 +46,6 @@ private meta def match_perms (pat : pattern) : expr → tactic (list $ list expr
     rs ← match_perms r,
     return (m.2 :: rs))
 
-private meta def update_type : expr → expr → expr
-| (local_const n pp bi d) t := local_const n pp bi t
-| e t := e
-
-private meta def intron' : ℕ → tactic (list expr)
-| 0       := return []
-| (i + 1) := do
-  n ← intro1,
-  ls ← intron' i,
-  return (n :: ls)
-
 meta def wlog (vars' : list expr) (h_cases fst_case : expr) (perms : list (list expr)) :
   tactic unit := do
   guard h_cases.is_local_constant,
@@ -73,7 +62,7 @@ meta def wlog (vars' : list expr) (h_cases fst_case : expr) (perms : list (list 
   ((), pr) ← solve_aux cases (repeat $ exact h_fst_case <|> left >> skip),
 
   t ← target,
-  fixed_vars ← vars.mmap (λv, do t ← infer_type v, return (update_type v t) ),
+  fixed_vars ← vars.mmap update_type,
   let t' := (instantiate_local h_cases.local_uniq_name pr t).pis (fixed_vars ++ [h_fst_case]),
 
   (h, [g]) ← local_proof `this t' (do

--- a/test/dependencies.lean
+++ b/test/dependencies.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2020 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import tactic.dependencies
+
+open tactic
+open native.rb_map (set_of_list)
+
+namespace native
+
+meta def rb_set.equals {α} (xs ys : rb_set α) : bool :=
+xs.fold tt (λ x b, b ∧ ys.contains x) &&
+ys.fold tt (λ y b, b ∧ xs.contains y)
+
+end native
+
+example (n m : ℕ) (f : fin n) : let k := m, o := k in o > 0 → true :=
+begin
+  intros k o h,
+  (do [n, m, f, k, o, h] ← [`n, `m, `f, `k, `o, `h].mmap get_local,
+
+      -- hyp_depends_on_locals
+      h_dep_m ← hyp_depends_on_locals h [m],
+      guard h_dep_m <|> fail "h_dep_m",
+      h_dep_n ← hyp_depends_on_locals h [n],
+      guard ¬ h_dep_n <|> fail "h_dep_n",
+      m_dep_n ← hyp_depends_on_locals m [n],
+      guard ¬ m_dep_n <|> fail "m_dep_n",
+      f_dep_n ← hyp_depends_on_locals f [n],
+      guard f_dep_n <|> fail "f_dep_n",
+      f_dep_n_m ← hyp_depends_on_locals f [n, m],
+      guard f_dep_n_m <|> fail "f_dep_n_m",
+
+      -- hyp_depends_on_locals_inclusive
+      h_idep_h ← hyp_depends_on_locals_inclusive h [h],
+      guard h_idep_h <|> fail "h_idep_h",
+      h_idep_n ← hyp_depends_on_locals_inclusive h [n],
+      guard ¬ h_idep_n <|> fail "h_idep_n",
+
+      -- dependency_set_of_hyp
+      f_dep_set ← dependency_set_of_hyp f,
+      guard (f_dep_set.equals (set_of_list [n])) <|> fail "f_dep_set",
+      h_dep_set ← dependency_set_of_hyp h,
+      guard (h_dep_set.equals (set_of_list [o, k, m])) <|> fail h_dep_set,
+      n_dep_set ← dependency_set_of_hyp n,
+      guard n_dep_set.empty <|> fail n_dep_set,
+
+      -- reverse_dependencies_of_hyps
+      n_revdep_set ← reverse_dependencies_of_hyps [n],
+      guard (n_revdep_set = [f]) <|> fail "n_revdep_set",
+      n_f_revdep_set ← reverse_dependencies_of_hyps [n, f],
+      guard (n_f_revdep_set = []) <|> fail "n_f_revdep_set",
+      m_revdep_set ← reverse_dependencies_of_hyps [m],
+      guard (m_revdep_set = [k, o, h]) <|> fail "m_revdep_set",
+      m_o_revdep_set ← reverse_dependencies_of_hyps [m, o],
+      guard (m_o_revdep_set = [k, h]) <|> fail "m_o_revdep_set",
+      f_revdep_set ← reverse_dependencies_of_hyps [f],
+      guard (f_revdep_set = []) <|> fail "f_revdep_set",
+
+      -- reverse_dependencies_of_hyp_name_set_inclusive
+      n_irevdep_set ← reverse_dependencies_of_hyps_inclusive [n],
+      guard (n_irevdep_set = [n, f]) <|> fail "n_irevdep_set",
+      n_f_irevdep_set ← reverse_dependencies_of_hyps_inclusive [n, f],
+      guard (n_f_irevdep_set = [n, f]) <|> fail "n_f_irevdep_set",
+      m_irevdep_set ← reverse_dependencies_of_hyps_inclusive [m],
+      guard (m_irevdep_set = [m, k, o, h]) <|> fail "m_irevdep_set",
+      m_o_irevdep_set ← reverse_dependencies_of_hyps_inclusive [m, o],
+      guard (m_o_irevdep_set = [m, k, o, h]) <|> fail "m_o_irevdep_set",
+      f_irevdep_set ← reverse_dependencies_of_hyps_inclusive [f],
+      guard (f_irevdep_set = [f]) <|> fail "f_irevdep_set",
+
+      -- revert_lst'
+      (n_reverted₁, reverted) ← revert_lst' [n, m],
+      guard (n_reverted₁ = 6) <|> fail "n_reverted₁",
+      guard
+        (reverted.map expr.local_uniq_name =
+        [n, m, f, k, o, h].map expr.local_uniq_name),
+      `[ guard_target ∀ (n m : ℕ) (f : fin n), let k := m, o := k in o > 0 → true ],
+
+      intros,
+      [n, m, f, k, o, h] ← [`n, `m, `f, `k, `o, `h].mmap get_local,
+
+      -- revert_reverse_dependencies_of_hyps
+      n_reverted₂ ← revert_reverse_dependencies_of_hyps [n, k],
+      guard (n_reverted₂ = 3) <|> fail "n_reverted₂",
+      `[ guard_hyp n : ℕ ],
+      `[ guard_hyp m : ℕ ],
+      `[ guard_hyp k : ℕ := m ],
+      `[ guard_target ∀ (f : fin n), let o := k in o > 0 → true ],
+
+      pure ()
+  ),
+  intros,
+  trivial
+end

--- a/test/dependencies.lean
+++ b/test/dependencies.lean
@@ -17,6 +17,8 @@ ys.fold tt (λ y b, b ∧ xs.contains y)
 
 end native
 
+open native
+
 example (n m : ℕ) (f : fin n) : let k := m, o := k in o > 0 → true :=
 begin
   intros k o h,
@@ -24,57 +26,87 @@ begin
 
       -- hyp_depends_on_locals
       h_dep_m ← hyp_depends_on_locals h [m],
-      guard h_dep_m <|> fail "h_dep_m",
+      guard h_dep_m <|> fail! "h_dep_m = {h_dep_m}",
       h_dep_n ← hyp_depends_on_locals h [n],
-      guard ¬ h_dep_n <|> fail "h_dep_n",
+      guard ¬ h_dep_n <|> fail! "h_dep_n = {h_dep_n}",
       m_dep_n ← hyp_depends_on_locals m [n],
-      guard ¬ m_dep_n <|> fail "m_dep_n",
+      guard ¬ m_dep_n <|> fail! "m_dep_n = {m_dep_n}",
       f_dep_n ← hyp_depends_on_locals f [n],
-      guard f_dep_n <|> fail "f_dep_n",
+      guard f_dep_n <|> fail! "f_dep_n = {f_dep_n}",
       f_dep_n_m ← hyp_depends_on_locals f [n, m],
-      guard f_dep_n_m <|> fail "f_dep_n_m",
+      guard f_dep_n_m <|> fail! "f_dep_n_m = {f_dep_n_m}",
+
+      -- hyps_depend_on_locals
+      dep_fk ← hyps_depend_on_locals [n, m, f, k, o, h] [f, k],
+      guard (dep_fk = [ff, ff, ff, ff, tt, tt]) <|> fail! "dep_fk = {dep_fk}",
+      dep_m ← hyps_depend_on_locals [n, m, f, k, o, h] [m],
+      guard (dep_m = [ff, ff, ff, tt, tt, tt]) <|> fail! "dep_m = {dep_m}",
 
       -- hyp_depends_on_locals_inclusive
       h_idep_h ← hyp_depends_on_locals_inclusive h [h],
-      guard h_idep_h <|> fail "h_idep_h",
+      guard h_idep_h <|> fail! "h_idep_h = {h_idep_h}",
       h_idep_n ← hyp_depends_on_locals_inclusive h [n],
-      guard ¬ h_idep_n <|> fail "h_idep_n",
+      guard ¬ h_idep_n <|> fail! "h_idep_n = {h_idep_n}",
+
+      -- hyps_depend_on_locals_inclusive
+      idep_fk ← hyps_depend_on_locals_inclusive [n, m, f, k, o, h] [f, k],
+      guard (idep_fk = [ff, ff, tt, tt, tt, tt]) <|> fail! "idep_fk = {idep_fk}",
+      idep_m ← hyps_depend_on_locals_inclusive [n, m, f, k, o, h] [m],
+      guard (idep_m = [ff, tt, ff, tt, tt, tt]) <|> fail! "idep_m = {idep_m}",
 
       -- dependency_set_of_hyp
       f_dep_set ← dependency_set_of_hyp f,
-      guard (f_dep_set.equals (set_of_list [n])) <|> fail "f_dep_set",
+      guard (f_dep_set.equals (set_of_list [n])) <|> fail! "f_dep_set = {f_dep_set}",
       h_dep_set ← dependency_set_of_hyp h,
-      guard (h_dep_set.equals (set_of_list [o, k, m])) <|> fail h_dep_set,
+      guard (h_dep_set.equals (set_of_list [o, k, m])) <|> fail! "h_dep_set = {h_dep_set}",
       n_dep_set ← dependency_set_of_hyp n,
-      guard n_dep_set.empty <|> fail n_dep_set,
+      guard n_dep_set.empty <|> fail! "n_dep_set = {n_dep_set}",
+
+      -- dependency_sets_of_hyps
+      fhn_dep_sets ← dependency_sets_of_hyps [f, h, n],
+      guard ((fhn_dep_sets.zip_with rb_set.equals ([[n], [o, k, m], []].map set_of_list)).band) <|>
+        fail! "fhn_dep_sets = {fhn_dep_sets}",
+
+      -- dependency_set_of_hyp_inclusive
+      f_idep_set ← dependency_set_of_hyp_inclusive f,
+      guard (f_idep_set.equals (set_of_list [n, f])) <|> fail! "f_idep_set = {f_idep_set}",
+      h_idep_set ← dependency_set_of_hyp_inclusive h,
+      guard (h_idep_set.equals (set_of_list [o, k, m, h])) <|> fail! "h_idep_set = {h_idep_set}",
+      n_idep_set ← dependency_set_of_hyp_inclusive n,
+      guard (n_idep_set.equals (set_of_list [n])) <|> fail! "n_idep_set = {n_idep_set}",
+
+      -- dependency_sets_of_hyps_inclusive
+      fhn_idep_sets ← dependency_sets_of_hyps_inclusive [f, h, n],
+      guard ((fhn_idep_sets.zip_with rb_set.equals ([[f, n], [h, o, k, m], [n]].map set_of_list)).band) <|>
+        fail! "fhn_idep_sets = {fhn_idep_sets}",
 
       -- reverse_dependencies_of_hyps
       n_revdep_set ← reverse_dependencies_of_hyps [n],
-      guard (n_revdep_set = [f]) <|> fail "n_revdep_set",
+      guard (n_revdep_set = [f]) <|> fail! "n_revdep_set = {n_revdep_set}",
       n_f_revdep_set ← reverse_dependencies_of_hyps [n, f],
-      guard (n_f_revdep_set = []) <|> fail "n_f_revdep_set",
+      guard (n_f_revdep_set = []) <|> fail! "n_f_revdep_set = {n_f_revdep_set}",
       m_revdep_set ← reverse_dependencies_of_hyps [m],
-      guard (m_revdep_set = [k, o, h]) <|> fail "m_revdep_set",
+      guard (m_revdep_set = [k, o, h]) <|> fail! "m_revdep_set = {m_revdep_set}",
       m_o_revdep_set ← reverse_dependencies_of_hyps [m, o],
-      guard (m_o_revdep_set = [k, h]) <|> fail "m_o_revdep_set",
+      guard (m_o_revdep_set = [k, h]) <|> fail! "m_o_revdep_set = {m_o_revdep_set}",
       f_revdep_set ← reverse_dependencies_of_hyps [f],
-      guard (f_revdep_set = []) <|> fail "f_revdep_set",
+      guard (f_revdep_set = []) <|> fail! "f_revdep_set = {f_revdep_set}",
 
-      -- reverse_dependencies_of_hyp_name_set_inclusive
+      -- reverse_dependencies_of_hyps_inclusive
       n_irevdep_set ← reverse_dependencies_of_hyps_inclusive [n],
-      guard (n_irevdep_set = [n, f]) <|> fail "n_irevdep_set",
+      guard (n_irevdep_set = [n, f]) <|> fail! "n_irevdep_set = {n_irevdep_set}",
       n_f_irevdep_set ← reverse_dependencies_of_hyps_inclusive [n, f],
-      guard (n_f_irevdep_set = [n, f]) <|> fail "n_f_irevdep_set",
+      guard (n_f_irevdep_set = [n, f]) <|> fail! "n_f_irevdep_set = {n_f_irevdep_set}",
       m_irevdep_set ← reverse_dependencies_of_hyps_inclusive [m],
-      guard (m_irevdep_set = [m, k, o, h]) <|> fail "m_irevdep_set",
+      guard (m_irevdep_set = [m, k, o, h]) <|> fail! "m_irevdep_set = {m_irevdep_set}",
       m_o_irevdep_set ← reverse_dependencies_of_hyps_inclusive [m, o],
-      guard (m_o_irevdep_set = [m, k, o, h]) <|> fail "m_o_irevdep_set",
+      guard (m_o_irevdep_set = [m, k, o, h]) <|> fail! "m_o_irevdep_set = {m_o_irevdep_set}",
       f_irevdep_set ← reverse_dependencies_of_hyps_inclusive [f],
-      guard (f_irevdep_set = [f]) <|> fail "f_irevdep_set",
+      guard (f_irevdep_set = [f]) <|> fail! "f_irevdep_set = {f_irevdep_set}",
 
       -- revert_lst'
       (n_reverted₁, reverted) ← revert_lst' [n, m],
-      guard (n_reverted₁ = 6) <|> fail "n_reverted₁",
+      guard (n_reverted₁ = 6) <|> fail! "n_reverted₁ = {n_reverted₁}",
       guard
         (reverted.map expr.local_uniq_name =
         [n, m, f, k, o, h].map expr.local_uniq_name),
@@ -85,7 +117,7 @@ begin
 
       -- revert_reverse_dependencies_of_hyps
       n_reverted₂ ← revert_reverse_dependencies_of_hyps [n, k],
-      guard (n_reverted₂ = 3) <|> fail "n_reverted₂",
+      guard (n_reverted₂ = 3) <|> fail! "n_reverted₂ = {n_reverted₂}",
       `[ guard_hyp n : ℕ ],
       `[ guard_hyp m : ℕ ],
       `[ guard_hyp k : ℕ := m ],

--- a/test/tactics.lean
+++ b/test/tactics.lean
@@ -476,7 +476,12 @@ begin
     "No such hypothesis 1 + 2." },
   revert_deps k, tactic.intron 5, guard_target unit,
   revert_after n, tactic.intron 7, guard_target unit,
-  do { e ← get_local `k, tactic.revert_deps e, l ← local_context, guard $ e ∈ l, intros },
+  do {
+    e ← get_local `k,
+    tactic.revert_reverse_dependencies_of_hyp e,
+    l ← local_context,
+    guard $ e ∈ l,
+    intros },
   exact unit.star
 end
 


### PR DESCRIPTION
These are the beginnings of an API about dependencies between expressions. For
now, we only deal with dependencies and reverse dependencies of hypotheses,
which are easy to compute.

Breaking change: `tactic.revert_deps` is renamed to
`tactic.revert_reverse_dependencies_of_hyp` for consistency. Its implementation
is completely new, but should be equivalent to the old one except for the order
in which hypotheses are reverted. (But the old implementation made no particular
guarantees about this order anyway.)
