### PR TITLE
doc(docs/100): link to actual triangle inequality

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -312,7 +312,7 @@
   title  : Stirling’s Formula
 91:
   title  : The Triangle Inequality
-  decl   : inner_product_space.to_normed_group
+  decl   : norm_add_le
   author : Zhouhang Zhou
 92:
   title  : Pick’s Theorem


### PR DESCRIPTION
`inner_product_space.to_normed_group` is not rendered on the website (because it is not a declaration).  Even if it did, it doesn't scream triangle inequality to me.  Instead link to `norm_add_le`, which looks more like a triangle inequality.  (The other provers use similar theorems for number 91.)

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
