### PR TITLE
feat(tactic/converter): Add an exact tactic, to allow dropping back into tactic mode

### DIFF
--- a/src/tactic/converter/interactive.lean
+++ b/src/tactic/converter/interactive.lean
@@ -112,6 +112,19 @@ We use this tactic for writing tests.
 meta def guard_target (p : parse texpr) : conv unit :=
 do `(%%t = _) ← target, tactic.interactive.guard_expr_eq t p
 
+/--
+When using `rw` in `conv` mode on conditional equality lemmas, sometimes `⊢` goals can be
+introduced which are impossible to close with `conv` tactics. Note that goals like `⊢ a = 0` will
+be displayed by conv mode as `| a`, making the problem difficult to diagnose at times.
+
+The `exact` conv tactic allows these to be closed, and is sufficient to allow re-entering tactic
+mode with `exact by { ... }`.
+
+Discussion of how to fix `rw` in the longer term can be found in
+https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Closing.20.60.E2.8A.A2.60.20goals.20in.20.60conv.60.20mode/near/212181256
+-/
+meta def exact := tactic.interactive.exact
+
 end interactive
 end conv
 


### PR DESCRIPTION
---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Closing.20.60.E2.8A.A2.60.20goals.20in.20.60conv.60.20mode/near/212181256

I no longer have any PRs which depend on this.

This would be a stop-gap until https://github.com/leanprover-community/lean/pull/475 is resolved.
