### PR TITLE
[Merged by Bors] - feat(algebra/category/Algebra/basic): Add free/forget adjunction.

### DIFF
--- a/src/algebra/category/Algebra/basic.lean
+++ b/src/algebra/category/Algebra/basic.lean
@@ -80,6 +80,7 @@ def free : Type* ⥤ Algebra R :=
   map := λ S T f, free_algebra.lift _ $ (free_algebra.ι _) ∘ f }
 
 /-- The free/forget ajunction for `R`-algebras. -/
+@[simps]
 def adj : free R ⊣ forget (Algebra R) :=
 { hom_equiv := λ X A,
   { to_fun := λ f, f ∘ (free_algebra.ι _),

--- a/src/algebra/category/Algebra/basic.lean
+++ b/src/algebra/category/Algebra/basic.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import algebra.algebra.basic
 import algebra.algebra.subalgebra
+import algebra.free_algebra
 import algebra.category.CommRing.basic
 import algebra.category.Module.basic
 
@@ -68,6 +69,25 @@ variables {R} {M N U : Module.{v} R}
 
 @[simp] lemma coe_comp (f : M ⟶ N) (g : N ⟶ U) :
   ((f ≫ g) : M → U) = g ∘ f := rfl
+
+variables (R)
+@[simps]
+def free : Type* ⥤ Algebra R :=
+{ obj := λ S,
+  { carrier := free_algebra R S,
+    is_ring := algebra.semiring_to_ring R },
+  map := λ S T f, free_algebra.lift _ $ (free_algebra.ι _) ∘ f }
+
+def adj : free R ⊣ forget (Algebra R) :=
+{ hom_equiv := λ X A,
+  { to_fun := λ f, f ∘ (free_algebra.ι _),
+    inv_fun := λ f, free_algebra.lift _ f,
+    left_inv := by tidy,
+    right_inv := by tidy },
+  unit := { app := λ S, free_algebra.ι _ },
+  counit :=
+  { app := λ S, free_algebra.lift _ $ id,
+    naturality' := by {intros, ext, simp} } } -- tidy times out :(
 
 end Algebra
 

--- a/src/algebra/category/Algebra/basic.lean
+++ b/src/algebra/category/Algebra/basic.lean
@@ -71,6 +71,7 @@ variables {R} {M N U : Module.{v} R}
   ((f ≫ g) : M → U) = g ∘ f := rfl
 
 variables (R)
+/-- The "free algebra" functor, sending a type `S` to the free algebra on `S`. -/
 @[simps]
 def free : Type* ⥤ Algebra R :=
 { obj := λ S,
@@ -78,6 +79,7 @@ def free : Type* ⥤ Algebra R :=
     is_ring := algebra.semiring_to_ring R },
   map := λ S T f, free_algebra.lift _ $ (free_algebra.ι _) ∘ f }
 
+/-- The free/forget ajunction for `R`-algebras. -/
 def adj : free R ⊣ forget (Algebra R) :=
 { hom_equiv := λ X A,
   { to_fun := λ f, f ∘ (free_algebra.ι _),


### PR DESCRIPTION
This PR adds the usual free/forget adjunction for the category of `R`-algebras.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
