### PR TITLE
[Merged by Bors] - feat(archive/100-theorems-list/70_perfect_numbers): Perfect Number Theorem, Direction 2

### DIFF
--- a/archive/100-theorems-list/70_perfect_numbers.lean
+++ b/archive/100-theorems-list/70_perfect_numbers.lean
@@ -7,12 +7,12 @@ Author: Aaron Anderson.
 import number_theory.arithmetic_function
 import number_theory.lucas_lehmer
 import algebra.geom_sum
+import ring_theory.multiplicity
 
 /-!
 # Perfect Numbers
 
-This file proves (currently one direction of)
-  Theorem 70 from the [100 Theorems List](https://www.cs.ru.nl/~freek/100/).
+This file proves Theorem 70 from the [100 Theorems List](https://www.cs.ru.nl/~freek/100/).
 
 The theorem characterizes even perfect numbers.
 
@@ -60,5 +60,69 @@ end
 theorem even_two_pow_mul_mersenne_of_prime (k : ℕ) (pr : (mersenne (k + 1)).prime) :
   even ((2 ^ k) * mersenne (k + 1)) :=
 by simp [ne_zero_of_prime_mersenne k pr] with parity_simps
+
+lemma eq_pow_two_mul_odd {n : ℕ} (hpos : 0 < n) :
+  ∃ (k m : ℕ), n = 2 ^ k * m ∧ ¬ even m :=
+begin
+  have h := (multiplicity.finite_nat_iff.2 ⟨nat.prime_two.ne_one, hpos⟩),
+  cases multiplicity.pow_multiplicity_dvd h with m hm,
+  use [(multiplicity 2 n).get h, m],
+  refine ⟨hm, _⟩,
+  rw even_iff_two_dvd,
+  have hg := multiplicity.is_greatest' h (nat.lt_succ_self _),
+  contrapose! hg,
+  rcases hg with ⟨k, rfl⟩,
+  apply dvd.intro k,
+  rw [pow_succ', mul_assoc, ← hm],
+end
+
+/-- Euler's theorem that even perfect numbers can be factored as a
+  power of two times a Mersenne prime. -/
+theorem eq_two_pow_mul_prime_mersenne_of_even_perfect {n : ℕ} (ev : even n) (perf : perfect n) :
+  ∃ (k : ℕ), prime (mersenne (k + 1)) ∧ n = 2 ^ k * mersenne (k + 1) :=
+begin
+  have hpos := perf.2,
+  rcases eq_pow_two_mul_odd hpos with ⟨k, m, rfl, hm⟩,
+  use k,
+  rw [perfect_iff_sum_divisors_eq_two_mul hpos, ← sigma_one_apply,
+    is_multiplicative_sigma.map_mul_of_coprime (nat.prime_two.coprime_pow_of_not_dvd hm).symm,
+    sigma_two_pow_eq_mersenne_succ, ← mul_assoc, ← pow_succ] at perf,
+  rcases nat.coprime.dvd_of_dvd_mul_left
+    (nat.prime_two.coprime_pow_of_not_dvd (odd_mersenne_succ _)) (dvd.intro _ perf) with ⟨j, rfl⟩,
+  rw [← mul_assoc, mul_comm _ (mersenne _), mul_assoc] at perf,
+  have h := mul_left_cancel' (ne_of_gt (mersenne_pos (nat.succ_pos _))) perf,
+  rw [sigma_one_apply, sum_divisors_eq_sum_proper_divisors_add_self, ← succ_mersenne, add_mul,
+    one_mul, add_comm] at h,
+  have hj := add_left_cancel h,
+  cases sum_proper_divisors_dvd (by { rw hj, apply dvd.intro_left (mersenne (k + 1)) rfl }),
+  { have j1 : j = 1 := eq.trans hj.symm h_1,
+    rw [j1, mul_one, sum_proper_divisors_eq_one_iff_prime] at h_1,
+    simp [h_1, j1] },
+  { have jcon := eq.trans hj.symm h_1,
+    rw [← one_mul j, ← mul_assoc, mul_one] at jcon,
+    have jcon2 := mul_right_cancel' _ jcon,
+    { exfalso,
+      cases k,
+      { apply hm,
+        rw [← jcon2, pow_zero, one_mul, one_mul] at ev,
+        rw [← jcon2, one_mul],
+        exact ev },
+      apply ne_of_lt _ jcon2,
+      rw [mersenne, ← nat.pred_eq_sub_one, lt_pred_iff, ← pow_one (nat.succ 1)],
+      apply pow_lt_pow (nat.lt_succ_self 1) (nat.succ_lt_succ (nat.succ_pos k)) },
+    contrapose! hm,
+    simp [hm] }
+end
+
+/-- The Euclid-Euler theorem characterizing even perfect numbers -/
+theorem even_perfect_iff {n : ℕ} :
+  (even n ∧ perfect n) ↔ ∃ (k : ℕ), prime (mersenne (k + 1)) ∧ n = 2 ^ k * mersenne (k + 1) :=
+begin
+  split,
+  { rintro ⟨ev, perf⟩,
+    exact eq_two_pow_mul_prime_mersenne_of_even_perfect ev perf },
+  { rintro ⟨k, pr, rfl⟩,
+    exact ⟨even_two_pow_mul_mersenne_of_prime k pr, perfect_two_pow_mul_mersenne_of_prime k pr⟩ }
+end
 
 end nat

--- a/archive/100-theorems-list/70_perfect_numbers.lean
+++ b/archive/100-theorems-list/70_perfect_numbers.lean
@@ -115,7 +115,7 @@ begin
 end
 
 /-- The Euclid-Euler theorem characterizing even perfect numbers -/
-theorem even_perfect_iff {n : ℕ} :
+theorem even_and_perfect_iff {n : ℕ} :
   (even n ∧ perfect n) ↔ ∃ (k : ℕ), prime (mersenne (k + 1)) ∧ n = 2 ^ k * mersenne (k + 1) :=
 begin
   split,

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -224,6 +224,8 @@
   author : mathlib
 70:
   title  : The Perfect Number Theorem
+  decl   : even_and_perfect_iff
+  author : Aaron Anderson
 71:
   title  : Order of a Subgroup
   decl   : card_subgroup_dvd_card

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -224,7 +224,7 @@
   author : mathlib
 70:
   title  : The Perfect Number Theorem
-  decl   : even_and_perfect_iff
+  decl   : nat.even_and_perfect_iff
   author : Aaron Anderson
 71:
   title  : Order of a Subgroup

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -224,7 +224,8 @@
   author : mathlib
 70:
   title  : The Perfect Number Theorem
-  decl   : nat.even_and_perfect_iff
+  links  :
+    mathlib archive : https://github.com/leanprover-community/mathlib/blob/master/archive/100-theorems-list/70_perfect_numbers.lean
   author : Aaron Anderson
 71:
   title  : Order of a Subgroup

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -193,6 +193,27 @@ begin
     simp [hx, h'x] }
 end
 
+lemma sum_eq_sum_iff_of_subset_of_pos (hsub : s₁ ⊆ s₂) (hpos: ∀ x ∈ s₂, 0 < f x) :
+  ∑ x in s₁, f x = ∑ x in s₂, f x ↔ s₁ = s₂ :=
+begin
+  classical,
+  split,
+  { rw [← sum_sdiff hsub],
+    intros h,
+    apply subset.antisymm hsub,
+    rw [← sdiff_eq_empty_iff_subset],
+    contrapose h,
+    rw [← ne.def, ← nonempty_iff_ne_empty] at h,
+    apply ne_of_lt,
+    rw [← zero_add (∑ x in s₁, f x), ← add_assoc, add_zero],
+    apply add_lt_add_right,
+    have hlt := sum_lt_sum_of_nonempty h (λ x hx, hpos x ((sdiff_subset _ _) hx)),
+    simp only [sum_const_zero] at hlt,
+    apply hlt },
+  { rintro rfl,
+    refl }
+end
+
 end ordered_cancel_comm_monoid
 
 section decidable_linear_ordered_cancel_comm_monoid

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -193,27 +193,6 @@ begin
     simp [hx, h'x] }
 end
 
-lemma sum_eq_sum_iff_of_subset_of_pos (hsub : s₁ ⊆ s₂) (hpos: ∀ x ∈ s₂, 0 < f x) :
-  ∑ x in s₁, f x = ∑ x in s₂, f x ↔ s₁ = s₂ :=
-begin
-  classical,
-  split,
-  { rw [← sum_sdiff hsub],
-    intros h,
-    apply subset.antisymm hsub,
-    rw [← sdiff_eq_empty_iff_subset],
-    contrapose h,
-    rw [← ne.def, ← nonempty_iff_ne_empty] at h,
-    apply ne_of_lt,
-    rw [← zero_add (∑ x in s₁, f x), ← add_assoc, add_zero],
-    apply add_lt_add_right,
-    have hlt := sum_lt_sum_of_nonempty h (λ x hx, hpos x ((sdiff_subset _ _) hx)),
-    simp only [sum_const_zero] at hlt,
-    apply hlt },
-  { rintro rfl,
-    refl }
-end
-
 end ordered_cancel_comm_monoid
 
 section decidable_linear_ordered_cancel_comm_monoid


### PR DESCRIPTION
Adds a few extra lemmas about `divisors`, `proper_divisors` and sums of proper divisors
Proves Euler's direction of the Perfect Number theorem, finishing Freek 70

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
