### PR TITLE
[Merged by Bors] - fix(haar_measure): minor changes

### DIFF
--- a/src/measure_theory/content.lean
+++ b/src/measure_theory/content.lean
@@ -182,6 +182,10 @@ lemma of_content_opens (U : opens G) : of_content μ h1 U = inner_content μ U :
 induced_outer_measure_eq' (λ _, is_open_Union) (inner_content_Union_nat h1 h2)
   inner_content_mono U.2
 
+lemma of_content_le (h : ∀ (K₁ K₂ : compacts G), K₁.1 ⊆ K₂.1 → μ K₁ ≤ μ K₂)
+  (U : opens G) (K : compacts G) (hUK : (U : set G) ⊆ K.1) : of_content μ h1 U ≤ μ K :=
+(of_content_opens h2 U).le.trans $ inner_content_le h U K hUK
+
 lemma le_of_content_compacts (K : compacts G) : μ K ≤ of_content μ h1 K.1 :=
 begin
   rw [of_content, induced_outer_measure_eq_infi],

--- a/src/measure_theory/haar_measure.lean
+++ b/src/measure_theory/haar_measure.lean
@@ -27,6 +27,10 @@ This function `h` forms a content, which we can extend to an outer measure
 (`haar_outer_measure`), and obtain the Haar measure from that (`haar_measure`).
 We normalize the Haar measure so that the measure of `K₀` is `1`.
 
+Note that `haar_outer_measure` need not coincide with `chaar` on compact sets, according to
+[halmos1950measure, ch. X, §53 p.233]. However, we know that `chaar K` lies between
+`haar_outer_measure (interior K)` and `haar_outer_measure K`.
+
 ## Main Declarations
 
 * `haar_measure`: the Haar measure on a locally compact Hausdorff group. This is a left invariant
@@ -437,7 +441,7 @@ lemma haar_outer_measure_eq_infi (K₀ : positive_compacts G) (A : set G) :
 outer_measure.of_content_eq_infi echaar_sup_le A
 
 lemma chaar_le_haar_outer_measure {K₀ : positive_compacts G} (K : compacts G) :
-   (show ℝ≥0, from ⟨chaar K₀ K, chaar_nonneg K₀ K⟩ : ennreal) ≤ haar_outer_measure K₀ K.1 :=
+   echaar K₀ K ≤ haar_outer_measure K₀ K.1 :=
 outer_measure.le_of_content_compacts echaar_sup_le K
 
 lemma haar_outer_measure_of_is_open {K₀ : positive_compacts G} (U : set G) (hU : is_open U) :

--- a/src/measure_theory/haar_measure.lean
+++ b/src/measure_theory/haar_measure.lean
@@ -18,12 +18,12 @@ https://en.wikipedia.org/wiki/Haar_measure#A_construction_using_compact_subsets.
 
 We construct the Haar measure first on compact sets. For this we define `(K : U)` as the (smallest)
 number of left-translates of `U` are needed to cover `K` (`index` in the formalization).
-Then we define the Haar measure on compact sets as `lim_U (K : U) / (K₀ : U)`,
-where `U` ranges over open neighborhoods of `1`, and `K₀` is a fixed compact set with nonempty
-interior. This is `chaar` in the formalization, and we prove that the limit exists by Tychonoff's
-theorem.
+Then we define a function `h` on compact sets as `lim_U (K : U) / (K₀ : U)`,
+where `U` becomes a smaller and smaller open neighborhood of `1`, and `K₀` is a fixed compact set
+with nonempty interior. This function is `chaar` in the formalization, and we define the limit
+formally using Tychonoff's theorem.
 
-The Haar measure on compact sets forms a content, which we can extend to an outer measure
+This function `h` forms a content, which we can extend to an outer measure
 (`haar_outer_measure`), and obtain the Haar measure from that (`haar_measure`).
 We normalize the Haar measure so that the measure of `K₀` is `1`.
 


### PR DESCRIPTION
There were some mistakes in the doc, which made it sound like `chaar` and `haar_outer_measure` coincide on compact sets, which is not generally true. 
Also cleanup various proofs.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
