### PR TITLE
[Merged by Bors] - feat(ring_theory/roots_of_unity): Roots of unity as union of primitive roots

### DIFF
--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -346,8 +346,7 @@ theorem dvd_one_iff (n : ℕ+) : n ∣ 1 ↔ n = 1 :=
 lemma pos_of_div_pos {n : ℕ+} {a : ℕ} (h : a ∣ n) : 0 < a :=
 begin
   apply zero_lt_iff_ne_zero.2,
-  by_contra hzero,
-  rw [not_not] at hzero,
+  intro hzero,
   rw hzero at h,
   exact pnat.ne_zero n (eq_zero_of_zero_dvd h)
 end

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -343,6 +343,15 @@ theorem dvd_antisymm {m n : ℕ+} : m ∣ n → n ∣ m → m = n :=
 theorem dvd_one_iff (n : ℕ+) : n ∣ 1 ↔ n = 1 :=
  ⟨λ h, dvd_antisymm h (one_dvd n), λ h, h.symm ▸ (dvd_refl 1)⟩
 
+lemma pos_of_div_pos {n : ℕ+} {a : ℕ} (h : a ∣ n) : 0 < a :=
+begin
+  apply zero_lt_iff_ne_zero.2,
+  by_contra hzero,
+  rw [not_not] at hzero,
+  rw hzero at h,
+  exact pnat.ne_zero n (eq_zero_of_zero_dvd h)
+end
+
 /-- The greatest common divisor (gcd) of two positive natural numbers,
   viewed as positive natural number. -/
 def gcd (n m : ℕ+) : ℕ+ :=

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -405,6 +405,14 @@ then if h : (X : polynomial R) ^ n - C a = 0
 else by rw [← with_bot.coe_le_coe, ← degree_X_pow_sub_C (nat.pos_of_ne_zero hn) a];
   exact card_roots (X_pow_sub_C_ne_zero (nat.pos_of_ne_zero hn) a)
 
+/-- The multiset `nth_roots ↑n (1 : R)` as a finset. -/
+def nth_roots_finset (n : ℕ+) (R : Type*) [integral_domain R] : finset R :=
+multiset.to_finset (nth_roots n (1 : R))
+
+@[simp] lemma mem_nth_roots_finset {n : ℕ+} {x : R} :
+  x ∈ nth_roots_finset n R ↔ x ^ (n : ℕ) = 1 :=
+by rw [nth_roots_finset, mem_to_finset, mem_nth_roots n.pos]
+
 end nth_roots
 
 lemma coeff_comp_degree_mul_degree (hqd0 : nat_degree q ≠ 0) :

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -261,8 +261,7 @@ begin
       exact nat.divisor_le hx },
     { simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff] at hx,
       exact hx } },
-  {
-    intros x hx,
+  { intros x hx,
     simp only [finset.mem_filter, finset.mem_range] at hx,
     simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff],
     exact hx.2 }

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -253,7 +253,8 @@ lemma finset_div_eq_filter (n : ℕ+) :
   finset.filter (λ (x : ℕ), x ∣ ↑n) (finset.range (n : ℕ).succ) = (n : ℕ).divisors :=
 begin
   apply finset.ext,
-  simp only [mem_divisors, mem_filter, mem_range, and_true, and_iff_right_iff_imp, ne.def, pnat.ne_zero, not_false_iff],
+  simp only [mem_divisors, mem_filter, mem_range, and_true,
+  and_iff_right_iff_imp, ne.def, pnat.ne_zero, not_false_iff],
   intros a ha,
   exact nat.lt_succ_of_le (nat.divisor_le (nat.mem_divisors.2 (and.intro ha (pnat.ne_zero n))))
 end

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -248,4 +248,23 @@ lemma prod_divisors_prime_pow {α : Type*} [comm_monoid α] {k p : ℕ} {f : ℕ
   ∏ x in (p ^ k).divisors, f x = ∏ x in range (k + 1), f (p ^ x) :=
 @sum_divisors_prime_pow (additive α) _ _ _ _ h
 
+lemma finset_div_eq_filter (n : ℕ+) : (n : ℕ).divisors = finset.filter (λ (x : ℕ), x ∣ ↑n) (finset.range (n : ℕ).succ) :=
+begin
+  rw finset.subset.antisymm_iff,
+  split,
+  { intros x hx,
+    simp only [finset.mem_filter, finset.mem_range],
+    split,
+    { apply (nat.lt_of_succ_le),
+      apply (nat.add_le_add_iff_le_right 1 x ↑n).2,
+      exact nat.divisor_le hx },
+    { simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff] at hx,
+      exact hx } },
+  {
+    intros x hx,
+    simp only [finset.mem_filter, finset.mem_range] at hx,
+    simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff],
+    exact hx.2 }
+end
+
 end nat

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -249,7 +249,7 @@ lemma prod_divisors_prime_pow {α : Type*} [comm_monoid α] {k p : ℕ} {f : ℕ
 @sum_divisors_prime_pow (additive α) _ _ _ _ h
 
 @[simp]
-lemma finset_div_eq_filter (n : ℕ+) :
+lemma filter_dvd_eq_divisors (n : ℕ+) :
   finset.filter (λ (x : ℕ), x ∣ ↑n) (finset.range (n : ℕ).succ) = (n : ℕ).divisors :=
 begin
   apply finset.ext,

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -248,7 +248,8 @@ lemma prod_divisors_prime_pow {α : Type*} [comm_monoid α] {k p : ℕ} {f : ℕ
   ∏ x in (p ^ k).divisors, f x = ∏ x in range (k + 1), f (p ^ x) :=
 @sum_divisors_prime_pow (additive α) _ _ _ _ h
 
-lemma finset_div_eq_filter (n : ℕ+) : (n : ℕ).divisors = finset.filter (λ (x : ℕ), x ∣ ↑n) (finset.range (n : ℕ).succ) :=
+lemma finset_div_eq_filter (n : ℕ+) :
+  (n : ℕ).divisors = finset.filter (λ (x : ℕ), x ∣ ↑n) (finset.range (n : ℕ).succ) :=
 begin
   rw finset.subset.antisymm_iff,
   split,

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -248,23 +248,14 @@ lemma prod_divisors_prime_pow {α : Type*} [comm_monoid α] {k p : ℕ} {f : ℕ
   ∏ x in (p ^ k).divisors, f x = ∏ x in range (k + 1), f (p ^ x) :=
 @sum_divisors_prime_pow (additive α) _ _ _ _ h
 
+@[simp]
 lemma finset_div_eq_filter (n : ℕ+) :
-  (n : ℕ).divisors = finset.filter (λ (x : ℕ), x ∣ ↑n) (finset.range (n : ℕ).succ) :=
+  finset.filter (λ (x : ℕ), x ∣ ↑n) (finset.range (n : ℕ).succ) = (n : ℕ).divisors :=
 begin
-  rw finset.subset.antisymm_iff,
-  split,
-  { intros x hx,
-    simp only [finset.mem_filter, finset.mem_range],
-    split,
-    { apply (nat.lt_of_succ_le),
-      apply (nat.add_le_add_iff_le_right 1 x ↑n).2,
-      exact nat.divisor_le hx },
-    { simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff] at hx,
-      exact hx } },
-  { intros x hx,
-    simp only [finset.mem_filter, finset.mem_range] at hx,
-    simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff],
-    exact hx.2 }
+  apply finset.ext,
+  simp only [mem_divisors, mem_filter, mem_range, and_true, and_iff_right_iff_imp, ne.def, pnat.ne_zero, not_false_iff],
+  intros a ha,
+  exact nat.lt_succ_of_le (nat.divisor_le (nat.mem_divisors.2 (and.intro ha (pnat.ne_zero n))))
 end
 
 end nat

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -254,7 +254,7 @@ lemma filter_dvd_eq_divisors (n : ℕ+) :
 begin
   apply finset.ext,
   simp only [mem_divisors, mem_filter, mem_range, and_true,
-  and_iff_right_iff_imp, ne.def, pnat.ne_zero, not_false_iff],
+    and_iff_right_iff_imp, ne.def, pnat.ne_zero, not_false_iff],
   intros a ha,
   exact nat.lt_succ_of_le (nat.divisor_le (nat.mem_divisors.2 (and.intro ha (pnat.ne_zero n))))
 end

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -560,7 +560,7 @@ begin
   exact h.card_roots_of_unity'
 end
 
-/--The cardinality of the multiset `nth_roots ↑n (1 : R)` is `n`
+/-- The cardinality of the multiset `nth_roots ↑n (1 : R)` is `n`
 if there is a primitive root of unity in `R`. -/
 lemma card_nth_roots {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) : (nth_roots ↑n (1 : R)).card = n :=
 begin

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -577,7 +577,7 @@ end
 
 /--The multiset `nth_roots ↑n (1 : R)` has no repeated elements
 if there is a primitive root of unity in `R`. -/
-lemma nroots_nodup {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) : (nth_roots ↑n (1 : R)).nodup :=
+lemma nth_roots_nodup {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) : (nth_roots ↑n (1 : R)).nodup :=
 begin
   apply (@multiset.erase_dup_eq_self R _ _).1,
   rw eq_iff_le_not_lt,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -661,7 +661,7 @@ begin
     exact (mul_dvd_mul_iff_left hzeroa).1 hdiv }
 end
 
-/-`nth_roots n` as a finset is equal to the union of `primitive_roots i R` for `i ∣ n`
+/-- `nth_roots n` as a `finset` is equal to the union of `primitive_roots i R` for `i ∣ n`
 if there is a primitive root of unity in `R`. -/
 lemma nth_roots_one_eq_bind_primitive_roots {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) :
   nth_roots_finset n R = finset.bind (nat.divisors ↑n) (λ (i : ℕ), (primitive_roots i R)) :=

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -596,6 +596,10 @@ begin
   }
 end
 
+/--The multiset `nth_roots ↑n (1 : R)` as a finset. -/
+def nth_roots_finset {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) : finset R :=
+  ⟨nth_roots n (1 : R) , nth_roots_nodup h⟩
+
 open_locale nat
 
 /-- If an integral domain has a primitive `k`-th root of unity, then it has `φ k` of them. -/
@@ -662,6 +666,7 @@ lemma nth_roots_one_eq_bind_primitive_roots {ζ : R} {n : ℕ+} (h : is_primitiv
   (⟨nth_roots n (1 : R) , nth_roots_nodup h⟩ : finset R) =
   finset.bind (nat.divisors ↑n) (λ (i : ℕ), (primitive_roots i R)) :=
 begin
+  rw nth_roots_finset,
   symmetry,
   apply finset.eq_of_subset_of_card_le,
   { intros x hx,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -656,7 +656,7 @@ begin
     exact (mul_dvd_mul_iff_left hzeroa).1 hdiv }
 end
 
-/-`nth_roots n` as a finset is equal to the uniun of `primitive_roots i R` for `i ∣ n`
+/-`nth_roots n` as a finset is equal to the union of `primitive_roots i R` for `i ∣ n`
 if there is a primitive root of unity in `R`. -/
 lemma root_of_unity_eq_uniun_prim {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) :
   (⟨nth_roots n (1 : R) , nroots_nodup h⟩ : finset R) =

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -691,7 +691,7 @@ begin
     {
       rw ← @finset.sum_congr _ _ (finset.filter (λ (x : ℕ), x ∣ n)
         (finset.range (n : ℕ).succ)) (nat.divisors ↑n)
-        (λ i, nat.totient i) (λ i, (primitive_roots i R).card) _ (nat.finset_div_eq_filter n) _,
+        (λ i, nat.totient i) (λ i, (primitive_roots i R).card) _ (nat.filter_dvd_eq_divisors n) _,
       { symmetry; exact nat.sum_totient n },
       { intros x hx,
         simp only [finset.mem_filter, finset.mem_range],

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -638,10 +638,11 @@ begin
   exact h hkl
 end
 
-/-If in `R` there is a `n`-th primitive root of unity and `b` divides `n`,
-then there is in `R` a `b`-th primitive root of unity. -/
-lemma prim_of_pow_prim {ζ : R} {n : ℕ} {a b : ℕ} (hn: 0 < n) (h : is_primitive_root ζ n) (hprod : n = a * b)
-  : is_primitive_root (ζ ^ a) b :=
+/-- If there is a `n`-th primitive root of unity in `R` and `b` divides `n`,
+then there is a `b`-th primitive root of unity in `R`. -/
+lemma prim_of_pow_prim {ζ : R} {n : ℕ} {a b : ℕ} 
+  (hn: 0 < n) (h : is_primitive_root ζ n) (hprod : n = a * b) :
+  is_primitive_root (ζ ^ a) b :=
 begin
   apply (iff_def (ζ ^ a) b).2,
   split,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -592,8 +592,7 @@ begin
       intro x,
       simp only [multiset.mem_erase_dup, finset.mem_mk] },
     rw [hrw, ← fintype.card_congr (roots_of_unity_equiv_nth_roots R n), card_roots_of_unity h] at ha,
-    exact nat.lt_asymm ha ha
-  }
+    exact nat.lt_asymm ha ha }
 end
 
 /-- The multiset `nth_roots ↑n (1 : R)` as a finset. -/

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -619,7 +619,7 @@ begin
 end
 
 /-The sets `primitive_roots k R` are pairwise disjoint. -/
-lemma prim_roots_disjoint {k l : ℕ} (hk : 0 < k) (hl : 0 < l) (h : k ≠ l) :
+lemma primitive_roots_disjoint {k l : ℕ} (hk : 0 < k) (hl : 0 < l) (h : k ≠ l) :
   disjoint (primitive_roots k R) (primitive_roots l R) :=
 begin
   intros z hz,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -597,8 +597,8 @@ begin
 end
 
 /--The multiset `nth_roots ↑n (1 : R)` as a finset. -/
-def nth_roots_finset {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) : finset R :=
-  ⟨nth_roots n (1 : R) , nth_roots_nodup h⟩
+def nth_roots_finset (n : ℕ+) (R : Type*) [integral_domain R] : finset R :=
+  multiset.to_finset (nth_roots n (1 : R))
 
 open_locale nat
 
@@ -663,9 +663,9 @@ end
 /-`nth_roots n` as a finset is equal to the union of `primitive_roots i R` for `i ∣ n`
 if there is a primitive root of unity in `R`. -/
 lemma nth_roots_one_eq_bind_primitive_roots {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) :
-  nth_roots_finset h = finset.bind (nat.divisors ↑n) (λ (i : ℕ), (primitive_roots i R)) :=
+  nth_roots_finset n R = finset.bind (nat.divisors ↑n) (λ (i : ℕ), (primitive_roots i R)) :=
 begin
-  rw nth_roots_finset,
+  rw [nth_roots_finset, ← multiset.to_finset_eq (nth_roots_nodup h)],
   symmetry,
   apply finset.eq_of_subset_of_card_le,
   { intros x hx,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -622,7 +622,7 @@ begin
     exact ⟨i, ⟨hin, hi.symm⟩, H⟩ }
 end
 
-/-The sets `primitive_roots k R` are pairwise disjoint. -/
+/-- The sets `primitive_roots k R` are pairwise disjoint. -/
 lemma disjoint {k l : ℕ} (hk : 0 < k) (hl : 0 < l) (h : k ≠ l) :
   disjoint (primitive_roots k R) (primitive_roots l R) :=
 begin

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -623,7 +623,7 @@ begin
 end
 
 /-The sets `primitive_roots k R` are pairwise disjoint. -/
-lemma primitive_roots_disjoint {k l : ℕ} (hk : 0 < k) (hl : 0 < l) (h : k ≠ l) :
+lemma disjoint {k l : ℕ} (hk : 0 < k) (hl : 0 < l) (h : k ≠ l) :
   disjoint (primitive_roots k R) (primitive_roots l R) :=
 begin
   intros z hz,
@@ -701,7 +701,7 @@ begin
     },
     { intros i hi j hj hdiff,
       simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff] at hi hj,
-      exact primitive_roots_disjoint (pnat.pos_of_div_pos hi) (pnat.pos_of_div_pos hj) hdiff } }
+      exact disjoint (pnat.pos_of_div_pos hi) (pnat.pos_of_div_pos hj) hdiff } }
 end
 
 end integral_domain

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -636,13 +636,13 @@ end
 
 /-If in `R` there is a `n`-th primitive root of unity and `b` divides `n`,
 then there is in `R` a `b`-th primitive root of unity. -/
-lemma prim_of_pow_prim {ζ : R} {n : ℕ+} {a b : ℕ} (h : is_primitive_root ζ n) (hprod : ↑n = a * b)
+lemma prim_of_pow_prim {ζ : R} {n : ℕ} {a b : ℕ} (hn: 0 < n) (h : is_primitive_root ζ n) (hprod : n = a * b)
   : is_primitive_root (ζ ^ a) b :=
 begin
   apply (iff_def (ζ ^ a) b).2,
   split,
   { calc (ζ ^ a) ^ b
-       = ζ ^ (n : ℕ) : by rw [← pow_mul', mul_comm, hprod]
+       = ζ ^ n : by rw [← pow_mul', mul_comm, hprod]
    ... = 1 : by rw ((iff_def ζ n).1 h).1 },
   { intros l hl,
     rw [← pow_mul', mul_comm] at hl,
@@ -651,8 +651,8 @@ begin
     have hzeroa : a ≠ 0,
     { by_contra hz,
       simp only [not_not] at hz,
-      simp [hz] at hprod,
-      exact hprod },
+      simp only [hz, zero_mul] at hprod,
+      exact ne.symm (ne_of_lt hn) hprod },
     exact (mul_dvd_mul_iff_left hzeroa).1 hdiv }
 end
 
@@ -693,7 +693,7 @@ begin
       simp,
       obtain ⟨d, hd⟩ := hx.2,
       rw mul_comm at hd,
-      exact card_primitive_roots (prim_of_pow_prim h hd) (pnat.pos_of_div_pos hx.2) },
+      exact card_primitive_roots (prim_of_pow_prim (pnat.pos n) h hd) (pnat.pos_of_div_pos hx.2) },
     },
     { intros i hi j hj hdiff,
       simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff] at hi hj,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -658,7 +658,7 @@ end
 
 /-`nth_roots n` as a finset is equal to the union of `primitive_roots i R` for `i ∣ n`
 if there is a primitive root of unity in `R`. -/
-lemma root_of_unity_eq_uniun_prim {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) :
+lemma root_of_unity_eq_union_prim {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) :
   (⟨nth_roots n (1 : R) , nth_roots_nodup h⟩ : finset R) =
   finset.bind (nat.divisors ↑n) (λ (i : ℕ), (primitive_roots i R)) :=
 begin

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -675,11 +675,11 @@ begin
       simp only [le_zero_iff_eq, not_lt] at h,
       simp only [h, zero_mul, pnat.ne_zero] at hd,
       exact hd },
-      calc  x ^ ↑n
-          = x ^ (a * d)  : by rw hd
-      ... = (x ^ a) ^ d  : pow_mul x a d
-      ... = 1 ^ d        : by rw ((mem_primitive_roots hazero).1 ha.2).1
-      ... = 1            : one_pow d },
+    calc  x ^ ↑n
+        = x ^ (a * d)  : by rw hd
+    ... = (x ^ a) ^ d  : pow_mul x a d
+    ... = 1 ^ d        : by rw ((mem_primitive_roots hazero).1 ha.2).1
+    ... = 1            : one_pow d },
   { simp only [card_mk],
     rw card_nth_roots h,
     apply le_of_eq,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -689,14 +689,14 @@ begin
     apply le_of_eq,
     rw finset.card_bind,
     { rw @finset.sum_congr _ _ (nat.divisors ↑n) (finset.filter (λ (x : ℕ), x ∣ n)
-    (finset.range (n : ℕ).succ))  (λ i, (primitive_roots i R).card)
-    (λ i, nat.totient i) _ (nat.finset_div_eq_filter n) _,
-    { symmetry; exact nat.sum_totient n },
-    { intros x hx,
-      simp only [finset.mem_filter, finset.mem_range] at hx,
-      simp,
-      obtain ⟨d, hd⟩ := hx.2,
-      rw mul_comm at hd,
+        (finset.range (n : ℕ).succ))  (λ i, (primitive_roots i R).card)
+        (λ i, nat.totient i) _ (nat.finset_div_eq_filter n) _,
+      { symmetry; exact nat.sum_totient n },
+      { intros x hx,
+        simp only [finset.mem_filter, finset.mem_range] at hx,
+        simp,
+        obtain ⟨d, hd⟩ := hx.2,
+        rw mul_comm at hd,
       exact card_primitive_roots (pow (pnat.pos n) h hd) (pnat.pos_of_div_pos hx.2) } },
     { intros i hi j hj hdiff,
       simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff] at hi hj,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -596,9 +596,9 @@ begin
   }
 end
 
-/--The multiset `nth_roots ↑n (1 : R)` as a finset. -/
+/-- The multiset `nth_roots ↑n (1 : R)` as a finset. -/
 def nth_roots_finset (n : ℕ+) (R : Type*) [integral_domain R] : finset R :=
-  multiset.to_finset (nth_roots n (1 : R))
+multiset.to_finset (nth_roots n (1 : R))
 
 open_locale nat
 

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -575,7 +575,7 @@ begin
     exact hcard }
 end
 
-/--The multiset `nth_roots ↑n (1 : R)` has no repeated elements
+/-- The multiset `nth_roots ↑n (1 : R)` has no repeated elements
 if there is a primitive root of unity in `R`. -/
 lemma nth_roots_nodup {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) : (nth_roots ↑n (1 : R)).nodup :=
 begin

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -637,7 +637,7 @@ end
 /-- If there is a `n`-th primitive root of unity in `R` and `b` divides `n`,
 then there is a `b`-th primitive root of unity in `R`. -/
 lemma pow {ζ : R} {n : ℕ} {a b : ℕ}
-  (hn: 0 < n) (h : is_primitive_root ζ n) (hprod : n = a * b) :
+  (hn : 0 < n) (h : is_primitive_root ζ n) (hprod : n = a * b) :
   is_primitive_root (ζ ^ a) b :=
 begin
   subst n,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -697,8 +697,7 @@ begin
       simp,
       obtain ⟨d, hd⟩ := hx.2,
       rw mul_comm at hd,
-      exact card_primitive_roots (pow (pnat.pos n) h hd) (pnat.pos_of_div_pos hx.2) },
-    },
+      exact card_primitive_roots (pow (pnat.pos n) h hd) (pnat.pos_of_div_pos hx.2) } },
     { intros i hi j hj hdiff,
       simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff] at hi hj,
       exact disjoint (pnat.pos_of_div_pos hi) (pnat.pos_of_div_pos hj) hdiff } }

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -663,8 +663,7 @@ end
 /-`nth_roots n` as a finset is equal to the union of `primitive_roots i R` for `i ∣ n`
 if there is a primitive root of unity in `R`. -/
 lemma nth_roots_one_eq_bind_primitive_roots {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) :
-  (⟨nth_roots n (1 : R) , nth_roots_nodup h⟩ : finset R) =
-  finset.bind (nat.divisors ↑n) (λ (i : ℕ), (primitive_roots i R)) :=
+  nth_roots_finset h = finset.bind (nat.divisors ↑n) (λ (i : ℕ), (primitive_roots i R)) :=
 begin
   rw nth_roots_finset,
   symmetry,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -658,7 +658,7 @@ end
 
 /-`nth_roots n` as a finset is equal to the union of `primitive_roots i R` for `i ∣ n`
 if there is a primitive root of unity in `R`. -/
-lemma root_of_unity_eq_union_prim {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) :
+lemma nth_roots_one_eq_bind_primitive_roots {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) :
   (⟨nth_roots n (1 : R) , nth_roots_nodup h⟩ : finset R) =
   finset.bind (nat.divisors ↑n) (λ (i : ℕ), (primitive_roots i R)) :=
 begin

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -688,8 +688,7 @@ begin
     rw card_nth_roots h,
     apply le_of_eq,
     rw finset.card_bind,
-    {
-      rw ← @finset.sum_congr _ _ (finset.filter (λ (x : ℕ), x ∣ n)
+    { rw ← @finset.sum_congr _ _ (finset.filter (λ (x : ℕ), x ∣ n)
         (finset.range (n : ℕ).succ)) (nat.divisors ↑n)
         (λ i, nat.totient i) (λ i, (primitive_roots i R).card) _ (nat.filter_dvd_eq_divisors n) _,
       { symmetry; exact nat.sum_totient n },

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -646,8 +646,8 @@ begin
   apply (iff_def (ζ ^ a) b).2,
   split,
   { calc (ζ ^ a) ^ b
-       = ζ ^ n : by rw [← pow_mul', mul_comm, hprod]
-   ... = 1 : by rw ((iff_def ζ n).1 h).1 },
+        = ζ ^ n : by rw [← pow_mul', mul_comm, hprod]
+    ... = 1 : by rw ((iff_def ζ n).1 h).1 },
   { intros l hl,
     rw [← pow_mul', mul_comm] at hl,
     have hdiv := ((iff_def ζ n).1 h).2 (a * l) hl,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -598,11 +598,6 @@ begin
     exact nat.lt_asymm ha ha }
 end
 
--- TODO: move this to just after the definition of `nth_roots`
-/-- The multiset `nth_roots ↑n (1 : R)` as a finset. -/
-def nth_roots_finset (n : ℕ+) (R : Type*) [integral_domain R] : finset R :=
-multiset.to_finset (nth_roots n (1 : R))
-
 @[simp] lemma card_nth_roots_finset {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) :
   (nth_roots_finset n R).card = n :=
 by rw [nth_roots_finset, ← multiset.to_finset_eq (nth_roots_nodup h), card_mk, h.card_nth_roots]

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -694,7 +694,6 @@ begin
       { symmetry; exact nat.sum_totient n },
       { intros x hx,
         simp only [finset.mem_filter, finset.mem_range] at hx,
-        simp,
         obtain ⟨d, hd⟩ := hx.2,
         rw mul_comm at hd,
       exact card_primitive_roots (pow (pnat.pos n) h hd) (pnat.pos_of_div_pos hx.2) } },

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -562,7 +562,7 @@ end
 
 /--The cardinality of the multiset `nth_roots ↑n (1 : R)` is `n`
 if there is a primitive root of unity in `R`. -/
-lemma card_nthroots {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) : (nth_roots ↑n (1 : R)).card = n :=
+lemma card_nth_roots {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) : (nth_roots ↑n (1 : R)).card = n :=
 begin
   rw eq_iff_le_not_lt,
   split,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -569,7 +569,7 @@ begin
   { exact card_nth_roots n 1 },
   { rw [not_lt],
     have hcard : fintype.card {x // x ∈ nth_roots n (1 : R)}
-    ≤ (nth_roots n (1 : R)).attach.card := multiset.card_le_of_le (multiset.erase_dup_le _),
+      ≤ (nth_roots n (1 : R)).attach.card := multiset.card_le_of_le (multiset.erase_dup_le _),
     rw multiset.card_attach at hcard,
     rw [← fintype.card_congr (roots_of_unity_equiv_nth_roots R n), card_roots_of_unity h] at hcard,
     exact hcard }

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -640,7 +640,7 @@ end
 
 /-- If there is a `n`-th primitive root of unity in `R` and `b` divides `n`,
 then there is a `b`-th primitive root of unity in `R`. -/
-lemma prim_of_pow_prim {ζ : R} {n : ℕ} {a b : ℕ} 
+lemma pow {ζ : R} {n : ℕ} {a b : ℕ} 
   (hn: 0 < n) (h : is_primitive_root ζ n) (hprod : n = a * b) :
   is_primitive_root (ζ ^ a) b :=
 begin
@@ -698,7 +698,7 @@ begin
       simp,
       obtain ⟨d, hd⟩ := hx.2,
       rw mul_comm at hd,
-      exact card_primitive_roots (prim_of_pow_prim (pnat.pos n) h hd) (pnat.pos_of_div_pos hx.2) },
+      exact card_primitive_roots (pow (pnat.pos n) h hd) (pnat.pos_of_div_pos hx.2) },
     },
     { intros i hi j hj hdiff,
       simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff] at hi hj,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -585,7 +585,7 @@ begin
   { exact multiset.erase_dup_le (nth_roots ↑n (1 : R)) },
   { by_contra ha,
     replace ha := multiset.card_lt_of_lt ha,
-    rw card_nthroots h at ha,
+    rw card_nth_roots h at ha,
     have hrw : (nth_roots ↑n (1 : R)).erase_dup.card = fintype.card {x // x ∈ (nth_roots ↑n (1 : R))},
     { set fs := (⟨(nth_roots ↑n (1 : R)).erase_dup, multiset.nodup_erase_dup _⟩ : finset R),
       rw [← finset.card_mk, ← fintype.card_of_subtype fs _],
@@ -659,7 +659,7 @@ end
 /-`nth_roots n` as a finset is equal to the union of `primitive_roots i R` for `i ∣ n`
 if there is a primitive root of unity in `R`. -/
 lemma root_of_unity_eq_uniun_prim {ζ : R} {n : ℕ+} (h : is_primitive_root ζ n) :
-  (⟨nth_roots n (1 : R) , nroots_nodup h⟩ : finset R) =
+  (⟨nth_roots n (1 : R) , nth_roots_nodup h⟩ : finset R) =
   finset.bind (nat.divisors ↑n) (λ (i : ℕ), (primitive_roots i R)) :=
 begin
   symmetry,
@@ -681,7 +681,7 @@ begin
       ... = 1 ^ d        : by rw ((mem_primitive_roots hazero).1 ha.2).1
       ... = 1            : one_pow d },
   { simp only [card_mk],
-    rw card_nthroots h,
+    rw card_nth_roots h,
     apply le_of_eq,
     rw finset.card_bind,
     { rw @finset.sum_congr _ _ (nat.divisors ↑n) (finset.filter (λ (x : ℕ), x ∣ n)
@@ -697,7 +697,7 @@ begin
     },
     { intros i hi j hj hdiff,
       simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff] at hi hj,
-      exact prim_roots_disjoint (pnat.pos_of_div_pos hi) (pnat.pos_of_div_pos hj) hdiff } }
+      exact primitive_roots_disjoint (pnat.pos_of_div_pos hi) (pnat.pos_of_div_pos hj) hdiff } }
 end
 
 end integral_domain

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -639,7 +639,7 @@ end
 
 /-- If there is a `n`-th primitive root of unity in `R` and `b` divides `n`,
 then there is a `b`-th primitive root of unity in `R`. -/
-lemma pow {ζ : R} {n : ℕ} {a b : ℕ} 
+lemma pow {ζ : R} {n : ℕ} {a b : ℕ}
   (hn: 0 < n) (h : is_primitive_root ζ n) (hprod : n = a * b) :
   is_primitive_root (ζ ^ a) b :=
 begin
@@ -688,15 +688,16 @@ begin
     rw card_nth_roots h,
     apply le_of_eq,
     rw finset.card_bind,
-    { rw @finset.sum_congr _ _ (nat.divisors ↑n) (finset.filter (λ (x : ℕ), x ∣ n)
-        (finset.range (n : ℕ).succ))  (λ i, (primitive_roots i R).card)
-        (λ i, nat.totient i) _ (nat.finset_div_eq_filter n) _,
+    {
+      rw ← @finset.sum_congr _ _ (finset.filter (λ (x : ℕ), x ∣ n)
+        (finset.range (n : ℕ).succ)) (nat.divisors ↑n)
+        (λ i, nat.totient i) (λ i, (primitive_roots i R).card) _ (nat.finset_div_eq_filter n) _,
       { symmetry; exact nat.sum_totient n },
       { intros x hx,
-        simp only [finset.mem_filter, finset.mem_range] at hx,
-        obtain ⟨d, hd⟩ := hx.2,
+        simp only [finset.mem_filter, finset.mem_range],
+        obtain ⟨d, hd⟩ := (nat.mem_divisors.1 hx).1,
         rw mul_comm at hd,
-      exact card_primitive_roots (pow (pnat.pos n) h hd) (pnat.pos_of_div_pos hx.2) } },
+      rw ← card_primitive_roots (pow (pnat.pos n) h hd) (pnat.pos_of_div_pos (nat.mem_divisors.1 hx).1) } },
     { intros i hi j hj hdiff,
       simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff] at hi hj,
       exact disjoint (pnat.pos_of_div_pos hi) (pnat.pos_of_div_pos hj) hdiff } }


### PR DESCRIPTION
I have added some lemmas about roots of unity, especially `root_of_unity_eq_uniun_prim` that says that, if there is a primitive `n`-th root of unity in `R`, then the set of `n`-th roots of unity is equal to the union of `primitive_roots i R` for `i | n`.

I will use this lemma in to develop the theory of cyclotomic polynomials.

---

All comments are welcome!