### PR TITLE
[Merged by Bors] - feat({field,ring}_theory/adjoin): generalize `induction_on_adjoin`

### DIFF
--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -346,6 +346,8 @@ section induction
 
 variables {F : Type*} [field F] {E : Type*} [field E] [algebra F E]
 
+/-- An intermediate field `S` is finitely generated if there exists `t : finset E` such that
+`intermediate_field.adjoin F t = S`. -/
 def fg (S : intermediate_field F E) : Prop := ∃ (t : finset E), adjoin F ↑t = S
 
 lemma fg_adjoin_finset (t : finset E) : (adjoin F (↑t : set E)).fg :=

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -250,6 +250,12 @@ S.to_subalgebra.range_subset
 lemma field_range_le : (algebra_map K L).field_range ≤ S.to_subfield :=
 λ x hx, S.to_subalgebra.range_subset (by rwa [set.mem_range, ← ring_hom.mem_field_range])
 
+@[simp] lemma to_subalgebra_le_to_subalgebra {S S' : intermediate_field K L} :
+  S.to_subalgebra ≤ S'.to_subalgebra ↔ S ≤ S' := iff.rfl
+
+@[simp] lemma to_subalgebra_lt_to_subalgebra {S S' : intermediate_field K L} :
+  S.to_subalgebra < S'.to_subalgebra ↔ S < S' := iff.rfl
+
 variables {S}
 
 section tower

--- a/src/ring_theory/adjoin.lean
+++ b/src/ring_theory/adjoin.lean
@@ -82,6 +82,13 @@ lemma adjoin_image (f : A →ₐ[R] B) (s : set A) :
 le_antisymm (adjoin_le $ set.image_subset _ subset_adjoin) $
 subalgebra.map_le.2 $ adjoin_le $ set.image_subset_iff.1 subset_adjoin
 
+@[simp] lemma adjoin_insert_adjoin (x : A) :
+  adjoin R (insert x (adjoin R s : set A)) = adjoin R (insert x s) :=
+le_antisymm
+  (adjoin_le (set.insert_subset.mpr
+    ⟨subset_adjoin (set.mem_insert _ _), adjoin_mono (set.subset_insert _ _)⟩))
+  (algebra.adjoin_mono (set.insert_subset_insert algebra.subset_adjoin))
+
 end semiring
 
 section comm_semiring
@@ -223,6 +230,16 @@ theorem fg_def {S : subalgebra R A} : S.fg ↔ ∃ t : set A, set.finite t ∧ a
 theorem fg_bot : (⊥ : subalgebra R A).fg :=
 ⟨∅, algebra.adjoin_empty R A⟩
 
+theorem fg_of_fg_to_submodule {S : subalgebra R A} : (S : submodule R A).fg → S.fg :=
+λ ⟨t, ht⟩, ⟨t, le_antisymm
+  (algebra.adjoin_le (λ x hx, show x ∈ (S : submodule R A), from ht ▸ subset_span hx))
+  (λ x (hx : x ∈ (S : submodule R A)), span_le.mpr
+    (λ x hx, algebra.subset_adjoin hx)
+      (show x ∈ span R ↑t, by { rw ht, exact hx }))⟩
+
+theorem fg_of_noetherian [is_noetherian R A] (S : subalgebra R A) : S.fg :=
+fg_of_fg_to_submodule (is_noetherian.noetherian S)
+
 lemma fg_of_submodule_fg (h : (⊤ : submodule R A).fg) : (⊤ : subalgebra R A).fg :=
 let ⟨s, hs⟩ := h in ⟨s, to_submodule_injective $
 by { rw [algebra.coe_top, eq_top_iff, ← hs, span_le], exact algebra.subset_adjoin }⟩
@@ -242,6 +259,19 @@ by { rw [← algebra.adjoin_image, finset.coe_preimage, set.image_preimage_eq_of
 lemma fg_top (S : subalgebra R A) : (⊤ : subalgebra R S).fg ↔ S.fg :=
 ⟨λ h, by { rw [← S.range_val, ← algebra.map_top], exact fg_map _ _ h },
 λ h, fg_of_fg_map _ S.val subtype.val_injective $ by { rw [algebra.map_top, range_val], exact h }⟩
+
+lemma induction_on_adjoin [is_noetherian R A] (P : subalgebra R A → Prop)
+  (base : P ⊥) (ih : ∀ (S : subalgebra R A) (x : A), P S → P (algebra.adjoin R (insert x S)))
+  (S : subalgebra R A) : P S :=
+begin
+  classical,
+  obtain ⟨t, rfl⟩ := S.fg_of_noetherian,
+  refine finset.induction_on t _ _,
+  { simpa using base },
+  intros x t hxt h,
+  convert ih _ x h using 1,
+  rw [finset.coe_insert, algebra.adjoin_insert_adjoin]
+end
 
 end subalgebra
 

--- a/src/ring_theory/adjoin.lean
+++ b/src/ring_theory/adjoin.lean
@@ -83,7 +83,7 @@ le_antisymm (adjoin_le $ set.image_subset _ subset_adjoin) $
 subalgebra.map_le.2 $ adjoin_le $ set.image_subset_iff.1 subset_adjoin
 
 @[simp] lemma adjoin_insert_adjoin (x : A) :
-  adjoin R (insert x (adjoin R s : set A)) = adjoin R (insert x s) :=
+  adjoin R (insert x ↑(adjoin R s : submodule R A)) = adjoin R (insert x s) :=
 le_antisymm
   (adjoin_le (set.insert_subset.mpr
     ⟨subset_adjoin (set.mem_insert _ _), adjoin_mono (set.subset_insert _ _)⟩))
@@ -270,7 +270,7 @@ begin
   { simpa using base },
   intros x t hxt h,
   convert ih _ x h using 1,
-  rw [finset.coe_insert, algebra.adjoin_insert_adjoin]
+  rw [finset.coe_insert, coe_coe, algebra.adjoin_insert_adjoin]
 end
 
 end subalgebra


### PR DESCRIPTION
We can prove `induction_on_adjoin` for both `algebra.adjoin` and `intermediate_field.adjoin` in a very similar way, if we add a couple of small lemmas. The extra lemmas I introduced for `algebra.adjoin` shorten the proof of `intermediate_field.adjoin` noticeably.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
