### PR TITLE
refactor(linear_algebra/matrix): generalize `is_basis.to_matrix` to other index types

### DIFF
--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -265,7 +265,7 @@ end to_matrix
 
 section is_basis_to_matrix
 
-variables {ι ι' : Type*} [fintype ι] [decidable_eq ι] [fintype ι'] [decidable_eq ι']
+variables {ι ι' : Type*} [fintype ι] [fintype ι']
 variables {R M : Type*} [comm_ring R] [add_comm_group M] [module R M]
 
 open function matrix
@@ -282,18 +282,18 @@ namespace is_basis
 lemma to_matrix_apply : he.to_matrix v i j = he.equiv_fun (v j) i :=
 rfl
 
-lemma to_matrix_eq_to_matrix_constr (v : ι → M) :
+lemma to_matrix_eq_to_matrix_constr [decidable_eq ι] (v : ι → M) :
   he.to_matrix v = linear_map.to_matrix he he (he.constr v) :=
 by { ext, simp [is_basis.to_matrix_apply, linear_map.to_matrix_apply] }
 
-@[simp] lemma to_matrix_self : he.to_matrix e = 1 :=
+@[simp] lemma to_matrix_self [decidable_eq ι] : he.to_matrix e = 1 :=
 begin
   rw is_basis.to_matrix,
   ext i j,
   simp [is_basis.equiv_fun, matrix.one_apply, finsupp.single, eq_comm]
 end
 
-lemma to_matrix_update (x : M) :
+lemma to_matrix_update [decidable_eq ι'] (x : M) :
   he.to_matrix (function.update v j x) = matrix.update_column (he.to_matrix v) j (he.repr x) :=
 begin
   ext i' k,
@@ -743,9 +743,9 @@ theorem trace_aux_eq (R : Type u) [comm_ring R] {M : Type v} [add_comm_group M] 
   {κ : Type*} [decidable_eq κ] [fintype κ] {c : κ → M} (hc : is_basis R c) :
   trace_aux R hb = trace_aux R hc :=
 calc  trace_aux R hb
-    = trace_aux R hb.range : by { rw trace_aux_range R hb }
+    = trace_aux R hb.range : by rw trace_aux_range R hb
 ... = trace_aux R hc.range : trace_aux_eq' _ _ _
-... = trace_aux R hc : by { rw trace_aux_range R hc }
+... = trace_aux R hc : by rw trace_aux_range R hc
 
 /-- Trace of an endomorphism independent of basis. -/
 def trace (R : Type u) [comm_ring R] (M : Type v) [add_comm_group M] [module R M] :


### PR DESCRIPTION
`is_basis.to_matrix` was defined only for families of vectors that have the same index type as the basis, resulting in square matrices. With some small tweaks to the definition, it's also possible to support rectangular matrices.

This is especially helpful if you have two bases with different index sets, and you want to apply a basis change.

Adding explicit `decidable_eq` parameters was required in some lemmas even though `open_locale classical` was active. The right hand side of the equalities contained `classical.decidable_eq`, which needed extra `congr`s to unify with the actual `decidable_eq` that was available.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
