### PR TITLE
[Merged by Bors] - feat(simps): improve error messages

### DIFF
--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -14,7 +14,7 @@ reducing a definition when projections are applied to it.
 
 There are three attributes being defined here
 * `@[simps]` is the attribute for objects of a structure or instances of a class. It will
-  automatically generate simplication lemmas for each projection of the object/instance that
+  automatically generate simplification lemmas for each projection of the object/instance that
   contains data. See the doc strings for `simps_attr` and `simps_cfg` for more details and
   configuration options.
 * `@[_simps_str]` is automatically added to structures that have been used in `@[simps]` at least
@@ -237,7 +237,7 @@ meta def simps_get_projection_exprs (e : environment) (tgt : expr)
     projections are applied in a lemma. When this is `ff` (default) all projection names will be
     appended to the definition name to form the lemma name, and when this is `tt`, only the
     last projection name will be appended.
-  * if `simp_rhs` is `tt` then the right-hand-side of the generated lemmas will be put simp-normal
+  * if `simp_rhs` is `tt` then the right-hand-side of the generated lemmas will be put in simp-normal
     form.
   * `type_md` specifies how aggressively definitions are unfolded in the type of expressions
     for the purposes of finding out whether the type is a function type.

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -18,7 +18,7 @@ There are three attributes being defined here
   contains data. See the doc strings for `simps_attr` and `simps_cfg` for more details and
   configuration options.
 * `@[_simps_str]` is automatically added to structures that have been used in `@[simps]` at least
-  once. They contain the data of the projections used for this structure by all following
+  once. This attribute contains the data of the projections used for this structure by all following
   invocations of `@[simps]`.
 * `@[notation_class]` should be added to all classes that define notation, like `has_mul` and
   `has_zero`. This specifies that the projections that `@[simps]` used are the projections from

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -1,5 +1,6 @@
 import tactic.simps
 
+universe variables v u w
 -- set_option trace.simps.verbose true
 -- set_option trace.app_builder true
 
@@ -233,14 +234,16 @@ run_cmd do
   guard $ 12 = e.fold 0 -- there are no other lemmas generated
     (λ d n, n + if d.to_name.components.init.ilast = `specify then 1 else 0),
   success_if_fail_with_msg (simps_tac `specify.specify1 {} ["fst_fst"])
-    "Invalid simp-lemma specify.specify1_fst_fst. Projection fst doesn't exist, because target is not a structure.",
+    "Invalid simp-lemma specify.specify1_fst_fst.
+Projection fst doesn't exist, because target is not a structure.",
   success_if_fail_with_msg (simps_tac `specify.specify1 {} ["foo_fst"])
     "Invalid simp-lemma specify.specify1_foo_fst. Projection foo doesn't exist.",
   success_if_fail_with_msg (simps_tac `specify.specify1 {} ["snd_bar"])
     "Invalid simp-lemma specify.specify1_snd_bar. Projection bar doesn't exist.",
   success_if_fail_with_msg (simps_tac `specify.specify5 {} ["snd_snd"])
-    "Invalid simp-lemma specify.specify5_snd_snd. The given definition is not a constructor application:
-prod.map (λ (x : ℕ), x) (λ (y : ℕ), y) (2, 3)
+    "Invalid simp-lemma specify.specify5_snd_snd.
+The given definition is not a constructor application:
+  prod.map (λ (x : ℕ), x) (λ (y : ℕ), y) (2, 3)
 Possible solution: add option {rhs_md := semireducible}."
 
 
@@ -308,7 +311,6 @@ run_cmd do
   e.get `pprod_equiv_prod_inv_fun_snd
 
 /- Tests with universe levels -/
-universe variables v u
 class has_hom (obj : Type u) : Type (max u (v+1)) :=
 (hom : obj → obj → Type v)
 
@@ -478,23 +480,30 @@ def equiv.simps.inv_fun (e : α ≃ β) : β → α := e.symm
 @[simps {simp_rhs := tt}] protected def equiv.trans (e₁ : α ≃ β) (e₂ : β ≃ γ) : α ≃ γ :=
 ⟨e₂ ∘ e₁, e₁.symm ∘ e₂.symm⟩
 
+example (e₁ : α ≃ β) (e₂ : β ≃ γ) (x : γ) : (e₁.trans e₂).symm x = e₁.symm (e₂.symm x) :=
+by simp only [equiv.trans_inv_fun]
+
 end manual_coercion
 
-namespace failty_manual_coercion
-variables {α β γ : Sort*}
+namespace faulty_manual_coercion
 
 structure equiv (α : Sort*) (β : Sort*) :=
 (to_fun    : α → β)
 (inv_fun   : β → α)
 
-local infix ` ≃ `:25 := failty_manual_coercion.equiv
+local infix ` ≃ `:25 := faulty_manual_coercion.equiv
+
+variables {α β γ : Sort*}
 
 /-- See Note [custom simps projection] -/
 noncomputable def equiv.simps.inv_fun (e : α ≃ β) : β → α := classical.choice ⟨e.inv_fun⟩
 
-run_cmd do e ← get_env, success_if_fail (simps_get_raw_projections e `faulty_manual_coercion.equiv)
+run_cmd do e ← get_env, success_if_fail_with_msg (simps_get_raw_projections e `faulty_manual_coercion.equiv)
+"Invalid custom projection:
+  λ {α : Sort u_1} {β : Sort u_2} (e : α ≃ β), classical.choice _
+Expression is not definitionally equal to equiv.inv_fun."
 
-end failty_manual_coercion
+end faulty_manual_coercion
 
 namespace manual_initialize
 /- defining a manual coercion. -/
@@ -523,6 +532,58 @@ run_cmd has_attribute `_simps_str `manual_initialize.equiv
 ⟨e₂ ∘ e₁, e₁.symm ∘ e₂.symm⟩
 
 end manual_initialize
+
+namespace faulty_universes
+
+variables {α β γ : Sort*}
+
+structure equiv (α : Sort u) (β : Sort v) :=
+(to_fun    : α → β)
+(inv_fun   : β → α)
+
+local infix ` ≃ `:25 := faulty_universes.equiv
+
+instance : has_coe_to_fun $ α ≃ β := ⟨_, equiv.to_fun⟩
+
+def equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.inv_fun, e.to_fun⟩
+
+/-- See Note [custom simps projection] -/
+-- test: intentionally using different unvierse levels for equiv.symm than for equiv
+def equiv.simps.inv_fun {α : Type u} {β : Type v} (e : α ≃ β) : β → α := e.symm
+
+run_cmd do e ← get_env,
+  success_if_fail_with_msg (simps_get_raw_projections e `faulty_universes.equiv)
+"Invalid custom projection:
+  λ {α : Type u} {β : Type v} (e : α ≃ β), ⇑(e.symm)
+Expression has different type than equiv.inv_fun. Given type:
+  Π {α : Type u} {β : Type v} (e : α ≃ β), has_coe_to_fun.F e.symm
+Expected type:
+  Π {α : Sort u} {β : Sort v}, α ≃ β → β → α"
+
+end faulty_universes
+
+namespace manual_universes
+
+variables {α β γ : Sort*}
+
+structure equiv (α : Sort u) (β : Sort v) :=
+(to_fun    : α → β)
+(inv_fun   : β → α)
+
+local infix ` ≃ `:25 := manual_universes.equiv
+
+instance : has_coe_to_fun $ α ≃ β := ⟨_, equiv.to_fun⟩
+
+def equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.inv_fun, e.to_fun⟩
+
+/-- See Note [custom simps projection] -/
+-- test: intentionally using different unvierse levels for equiv.symm than for equiv
+def equiv.simps.inv_fun {α : Sort w} {β : Sort u} (e : α ≃ β) : β → α := e.symm
+
+-- check whether we can generate custom projections even if the universe names don't match
+initialize_simps_projections equiv
+
+end manual_universes
 
 -- test transparency setting
 structure set_plus (α : Type) :=
@@ -590,6 +651,7 @@ begin
 end
 
 end nested_non_fully_applied
+
 
 /- fail if you add an attribute with a parameter. -/
 run_cmd success_if_fail $ simps_tac `foo.rfl { attrs := [`higher_order] }

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -548,7 +548,8 @@ instance : has_coe_to_fun $ α ≃ β := ⟨_, equiv.to_fun⟩
 def equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.inv_fun, e.to_fun⟩
 
 /-- See Note [custom simps projection] -/
--- test: intentionally using different unvierse levels for equiv.symm than for equiv
+-- test: intentionally using different names for the universe variables for equiv.symm than for
+-- equiv
 def equiv.simps.inv_fun {α : Type u} {β : Type v} (e : α ≃ β) : β → α := e.symm
 
 run_cmd do e ← get_env,


### PR DESCRIPTION
If a custom projection has a different type than the expected projection, then it will show a more specific error message.
Also reflow most long lines
Also add some tests

---

Not sure what to do with strings of `>100` characters without newline in it. 
@eric-wieser