### PR TITLE
[Merged by Bors] - feat(algebra/gcd_monoid, polynomial/field_division): generalizing `normalization_monoid` on polynomials

### DIFF
--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -136,6 +136,21 @@ units.mul_right_dvd
 
 end normalization_monoid
 
+namespace comm_group_with_zero
+variables [decidable_eq α] [comm_group_with_zero α]
+
+instance : normalization_monoid α :=
+{ norm_unit := λ x, if h : x = 0 then 1 else (units.mk0 x h)⁻¹,
+  norm_unit_zero := dif_pos rfl,
+  norm_unit_mul := λ x y x0 y0, units.eq_iff.1 (by simp [x0, y0, mul_inv']),
+  norm_unit_coe_units := λ u, by { rw [dif_neg (units.ne_zero _), units.mk0_coe], apply_instance } }
+
+@[simp]
+lemma coe_norm_unit {a : α} (h0 : a ≠ 0) : (↑(norm_unit a) : α) = a⁻¹ :=
+by simp [norm_unit, h0]
+
+end comm_group_with_zero
+
 namespace associates
 variables [comm_cancel_monoid_with_zero α] [nontrivial α] [normalization_monoid α]
 

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -139,6 +139,7 @@ end normalization_monoid
 namespace comm_group_with_zero
 variables [decidable_eq α] [comm_group_with_zero α]
 
+@[priority 100] -- see Note [lower instance priority]
 instance : normalization_monoid α :=
 { norm_unit := λ x, if h : x = 0 then 1 else (units.mk0 x h)⁻¹,
   norm_unit_zero := dif_pos rfl,

--- a/src/data/polynomial/field_division.lean
+++ b/src/data/polynomial/field_division.lean
@@ -307,8 +307,7 @@ end
 lemma coe_norm_unit_of_ne_zero (hp : p ≠ 0) : (norm_unit p : polynomial R) = C p.leading_coeff⁻¹ :=
 by simp [hp]
 
-@[simp]
-lemma normalize_monic (h : monic p) : normalize p = p := by simp [h.leading_coeff]
+lemma normalize_monic (h : monic p) : normalize p = p := by simp [h]
 
 theorem map_dvd_map' [field k] (f : R →+* k) {x y : polynomial R} : x.map f ∣ y.map f ↔ x ∣ y :=
 if H : x = 0 then by rw [H, map_zero, zero_dvd_iff, zero_dvd_iff, map_eq_zero]

--- a/src/data/polynomial/field_division.lean
+++ b/src/data/polynomial/field_division.lean
@@ -21,6 +21,36 @@ namespace polynomial
 universes u v w y z
 variables {R : Type u} {S : Type v} {k : Type y} {A : Type z} {a b : R} {n : ℕ}
 
+section integral_domain
+variables [integral_domain R] [normalization_monoid R]
+instance : normalization_monoid (polynomial R) :=
+{ norm_unit := λ p, ⟨C ↑(norm_unit (p.leading_coeff)), C ↑(norm_unit (p.leading_coeff))⁻¹,
+    by rw [← ring_hom.map_mul, units.mul_inv, C_1], by rw [← ring_hom.map_mul, units.inv_mul, C_1]⟩,
+  norm_unit_zero := units.ext (by simp),
+  norm_unit_mul := λ p q hp0 hq0, units.ext (begin
+      dsimp,
+      rw [ne.def, ← leading_coeff_eq_zero] at *,
+      rw [leading_coeff_mul, norm_unit_mul hp0 hq0, units.coe_mul, C_mul],
+    end),
+  norm_unit_coe_units := λ u,
+    units.ext begin
+      rw [← mul_one u⁻¹, units.coe_mul, units.eq_inv_mul_iff_mul_eq],
+      dsimp,
+      rcases polynomial.is_unit_iff.1 ⟨u, rfl⟩ with ⟨_, ⟨w, rfl⟩, h2⟩,
+      rw [← h2, leading_coeff_C, norm_unit_coe_units, ← C_mul, units.mul_inv, C_1],
+    end, }
+
+
+@[simp]
+lemma coe_norm_unit {p : polynomial R} :
+  (norm_unit p : polynomial R) = C ↑(norm_unit p.leading_coeff) :=
+by simp [norm_unit]
+
+lemma leading_coeff_normalize (p : polynomial R) :
+  leading_coeff (normalize p) = normalize (leading_coeff p) := by simp
+
+end integral_domain
+
 section field
 variables [field R] {p q : polynomial R}
 
@@ -267,44 +297,24 @@ begin
   { simp }
 end
 
-instance : normalization_monoid (polynomial R) :=
-{ norm_unit := λ p, if hp0 : p = 0 then 1
-    else ⟨C p.leading_coeff⁻¹, C p.leading_coeff,
-      by rw [← C_mul, inv_mul_cancel, C_1];
-       exact mt leading_coeff_eq_zero.1 hp0,
-      by rw [← C_mul, mul_inv_cancel, C_1];
-       exact mt leading_coeff_eq_zero.1 hp0,⟩,
-  norm_unit_zero := dif_pos rfl,
-  norm_unit_mul := λ p q hp0 hq0, begin
-      rw [dif_neg hp0, dif_neg hq0, dif_neg (mul_ne_zero hp0 hq0)],
-      apply units.ext,
-      show C (leading_coeff (p * q))⁻¹ = C (leading_coeff p)⁻¹ * C (leading_coeff q)⁻¹,
-      rw [leading_coeff_mul, mul_inv', C_mul, mul_comm]
-    end,
-  norm_unit_coe_units := λ u,
-    have hu : degree ↑u⁻¹ = 0, from degree_eq_zero_of_is_unit ⟨u⁻¹, rfl⟩,
-    begin
-      apply units.ext,
-      rw [dif_neg (units.ne_zero u)],
-      conv_rhs {rw eq_C_of_degree_eq_zero hu},
-      refine C_inj.2 _,
-      rw [← nat_degree_eq_of_degree_eq_some hu, leading_coeff,
-        coeff_inv_units],
-      simp
-    end, }
-
 lemma monic_normalize (hp0 : p ≠ 0) : monic (normalize p) :=
-show leading_coeff (p * ↑(dite _ _ _)) = 1,
-by rw dif_neg hp0; exact monic_mul_leading_coeff_inv hp0
+begin
+  rw [ne.def, ← leading_coeff_eq_zero, ← ne.def, ← is_unit_iff_ne_zero] at hp0,
+  rw [monic, leading_coeff_normalize, normalize_eq_one],
+  apply hp0,
+end
 
-lemma coe_norm_unit (hp : p ≠ 0) : (norm_unit p : polynomial R) = C p.leading_coeff⁻¹ :=
-show ↑(dite _ _ _) = C p.leading_coeff⁻¹, by rw dif_neg hp; refl
+lemma coe_norm_unit_of_ne_zero (hp : p ≠ 0) : (norm_unit p : polynomial R) = C p.leading_coeff⁻¹ :=
+by simp [hp]
+
+@[simp]
+lemma normalize_monic (h : monic p) : normalize p = p := by simp [h.leading_coeff]
 
 theorem map_dvd_map' [field k] (f : R →+* k) {x y : polynomial R} : x.map f ∣ y.map f ↔ x ∣ y :=
 if H : x = 0 then by rw [H, map_zero, zero_dvd_iff, zero_dvd_iff, map_eq_zero]
 else by rw [← normalize_dvd_iff, ← @normalize_dvd_iff (polynomial R),
     normalize_apply, normalize_apply,
-    coe_norm_unit H, coe_norm_unit (mt (map_eq_zero _).1 H),
+    coe_norm_unit_of_ne_zero H, coe_norm_unit_of_ne_zero (mt (map_eq_zero _).1 H),
     leading_coeff_map, ← f.map_inv, ← map_C, ← map_mul,
     map_dvd_map _ f.injective (monic_mul_leading_coeff_inv H)]
 

--- a/src/data/polynomial/field_division.lean
+++ b/src/data/polynomial/field_division.lean
@@ -38,8 +38,7 @@ instance : normalization_monoid (polynomial R) :=
       dsimp,
       rcases polynomial.is_unit_iff.1 ⟨u, rfl⟩ with ⟨_, ⟨w, rfl⟩, h2⟩,
       rw [← h2, leading_coeff_C, norm_unit_coe_units, ← C_mul, units.mul_inv, C_1],
-    end, }
-
+    end }
 
 @[simp]
 lemma coe_norm_unit {p : polynomial R} :

--- a/src/field_theory/algebraic_closure.lean
+++ b/src/field_theory/algebraic_closure.lean
@@ -58,7 +58,8 @@ theorem of_exists_root (H : ∀ p : polynomial k, p.monic → irreducible p → 
   is_alg_closed k :=
 ⟨λ p, or.inr $ λ q hq hqp,
  have irreducible (q * C (leading_coeff q)⁻¹),
-   by { rw ← coe_norm_unit hq.ne_zero, exact irreducible_of_associated associated_normalize hq },
+   by { rw ← coe_norm_unit_of_ne_zero hq.ne_zero,
+        exact irreducible_of_associated associated_normalize hq },
  let ⟨x, hx⟩ := H (q * C (leading_coeff q)⁻¹) (monic_mul_leading_coeff_inv hq.ne_zero) this in
  degree_mul_leading_coeff_inv q hq.ne_zero ▸ degree_eq_one_of_irreducible_of_root this hx⟩
 

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -165,7 +165,7 @@ wf_dvd_monoid.induction_on_irreducible (f.map i)
         rw [multiset.map_cons, multiset.prod_cons, leading_coeff_mul, C_mul, mul_assoc,
           mul_left_comm (C f.leading_coeff), ← hs, ← mul_assoc, mul_left_inj' hf0],
         conv_lhs {rw eq_X_add_C_of_degree_eq_one hp1},
-        simp only [mul_add, coe_norm_unit_of_ne_zero_of_ne_zero hp.ne_zero, mul_comm p, coeff_neg,
+        simp only [mul_add, coe_norm_unit_of_ne_zero hp.ne_zero, mul_comm p, coeff_neg,
           C_neg, sub_eq_add_neg, neg_neg, coeff_C_mul, (mul_assoc _ _ _).symm, C_mul.symm,
           mul_inv_cancel (show p.leading_coeff ≠ 0, from mt leading_coeff_eq_zero.1
             hp.ne_zero), one_mul],

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -165,7 +165,7 @@ wf_dvd_monoid.induction_on_irreducible (f.map i)
         rw [multiset.map_cons, multiset.prod_cons, leading_coeff_mul, C_mul, mul_assoc,
           mul_left_comm (C f.leading_coeff), ← hs, ← mul_assoc, mul_left_inj' hf0],
         conv_lhs {rw eq_X_add_C_of_degree_eq_one hp1},
-        simp only [mul_add, coe_norm_unit hp.ne_zero, mul_comm p, coeff_neg,
+        simp only [mul_add, coe_norm_unit_of_ne_zero_of_ne_zero hp.ne_zero, mul_comm p, coeff_neg,
           C_neg, sub_eq_add_neg, neg_neg, coeff_C_mul, (mul_assoc _ _ _).symm, C_mul.symm,
           mul_inv_cancel (show p.leading_coeff ≠ 0, from mt leading_coeff_eq_zero.1
             hp.ne_zero), one_mul],
@@ -369,15 +369,16 @@ begin
   have hcoeff : p.leading_coeff ≠ 0,
   { intro h, exact hzero (leading_coeff_eq_zero.1 h) },
   have sameroots : p.roots = (normalize p).roots,
-  { rw [normalize_apply, mul_comm, coe_norm_unit hzero, roots_C_mul _ (inv_ne_zero hcoeff)] },
+  { rw [normalize_apply, mul_comm, coe_norm_unit_of_ne_zero hzero,
+        roots_C_mul _ (inv_ne_zero hcoeff)] },
   have hrootsnorm : (normalize p).roots.card = (normalize p).nat_degree,
-  { rw [← sameroots, normalize_apply, mul_comm, coe_norm_unit hzero],
+  { rw [← sameroots, normalize_apply, mul_comm, coe_norm_unit_of_ne_zero hzero],
     have hCzero : C (p.leading_coeff)⁻¹ ≠ 0,
     { rw [ne.def, C_eq_zero], exact (inv_ne_zero hcoeff) },
     simp only [nat_degree_C, zero_add, nat_degree_mul hCzero hzero],
     exact hroots },
   have hprod := prod_multiset_X_sub_C_of_monic_of_roots_card_eq (monic_normalize hzero) hrootsnorm,
-  rw [← sameroots, normalize_apply, coe_norm_unit hzero] at hprod,
+  rw [← sameroots, normalize_apply, coe_norm_unit_of_ne_zero hzero] at hprod,
   calc (C p.leading_coeff) * (multiset.map (λ (a : α), X - C a) p.roots).prod
       = p * C ((p.leading_coeff)⁻¹ * p.leading_coeff) : by rw [hprod, mul_comm, mul_assoc, ← C_mul]
   ... = p * C 1 : by field_simp [hcoeff]


### PR DESCRIPTION
Defines a `normalization_monoid` instance on any `comm_group_with_zero`, including fields
Defines a `normalization_monoid` instance on `polynomial R` when `R` has a `normalization_monoid` instance

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
