### PR TITLE
[Merged by Bors] - chore(algebra/*): add a few `prod.*` instances

### DIFF
--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -93,6 +93,20 @@ instance [comm_semigroup G] [comm_semigroup H] : comm_semigroup (G × H) :=
   .. prod.semigroup }
 
 @[to_additive]
+instance [left_cancel_semigroup G] [left_cancel_semigroup H] :
+  left_cancel_semigroup (G × H) :=
+{ mul_left_cancel := λ a b c h, prod.ext (mul_left_cancel (prod.ext_iff.1 h).1)
+    (mul_left_cancel (prod.ext_iff.1 h).2),
+  .. prod.semigroup }
+
+@[to_additive]
+instance [right_cancel_semigroup G] [right_cancel_semigroup H] :
+  right_cancel_semigroup (G × H) :=
+{ mul_right_cancel := λ a b c h, prod.ext (mul_right_cancel (prod.ext_iff.1 h).1)
+    (mul_right_cancel (prod.ext_iff.1 h).2),
+  .. prod.semigroup }
+
+@[to_additive]
 instance [comm_monoid M] [comm_monoid N] : comm_monoid (M × N) :=
 { .. prod.comm_semigroup, .. prod.monoid }
 

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -5,6 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import algebra.group.with_one
 import algebra.group.type_tags
+import algebra.group.prod
 import algebra.order_functions
 import order.bounded_lattice
 
@@ -1887,6 +1888,25 @@ instance [decidable_linear_ordered_cancel_add_comm_monoid α] :
   .. order_dual.ordered_cancel_add_comm_monoid }
 
 end order_dual
+
+namespace prod
+
+variables {M N G H : Type*}
+
+@[to_additive]
+instance [ordered_cancel_comm_monoid M] [ordered_cancel_comm_monoid N] :
+  ordered_cancel_comm_monoid (M × N) :=
+{ mul_le_mul_left := λ a b h c, ⟨mul_le_mul_left' h.1 _, mul_le_mul_left' h.2 _⟩,
+  le_of_mul_le_mul_left := λ a b c h, ⟨le_of_mul_le_mul_left' h.1, le_of_mul_le_mul_left' h.2⟩,
+ .. prod.comm_monoid, .. prod.left_cancel_semigroup, .. prod.right_cancel_semigroup,
+ .. prod.partial_order M N }
+
+@[to_additive]
+instance [ordered_comm_group M] [ordered_comm_group N] :
+  ordered_comm_group (M × N) :=
+{ .. prod.comm_group, .. prod.partial_order M N, .. prod.ordered_cancel_comm_monoid }
+
+end prod
 
 section type_tags
 


### PR DESCRIPTION
* `prod.left_cancel_semigroup`;
* `prod_right_cancel_semigroup`;
* `prod.ordered_cancel_comm_monoid`;
* `ordered_comm_group`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->