### PR TITLE
[Merged by Bors] - feat(algebra/gcd_monoid): noncomputably defines `gcd_monoid` structures from partial information

### DIFF
--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -19,6 +19,8 @@ This file defines extra structures on `comm_cancel_monoid_with_zero`s, including
 
 * `normalization_monoid`
 * `gcd_monoid`
+* `gcd_monoid_of_exists_gcd`
+* `gcd_monoid_of_exists_lcm`
 
 ## Implementation Notes
 
@@ -29,6 +31,18 @@ definition as currently implemented does casework on `0`.
 * `gcd_monoid` extends `normalization_monoid`, so the `gcd` and `lcm` are always normalized.
 This makes `gcd`s of polynomials easier to work with, but excludes Euclidean domains, and monoids
 without zero.
+
+* `gcd_monoid_of_gcd` noncomputably constructs a `gcd_monoid` structure just from the `gcd`
+  and its properties.
+
+* `gcd_monoid_of_exists_gcd` noncomputably constructs a `gcd_monoid` structure just from a proof
+  that any two elements have a (not necessarily normalized) `gcd`.
+
+* `gcd_monoid_of_lcm` noncomputably constructs a `gcd_monoid` structure just from the `lcm`
+  and its properties.
+
+* `gcd_monoid_of_exists_lcm` noncomputably constructs a `gcd_monoid` structure just from a proof
+  that any two elements have a (not necessarily normalized) `lcm`.
 
 ## TODO
 
@@ -600,3 +614,149 @@ lemma gcd_eq_of_dvd_sub_left {a b c : α} (h : a ∣ b - c) : gcd b a = gcd c a 
 by rw [gcd_comm _ a, gcd_comm _ a, gcd_eq_of_dvd_sub_right h]
 
 end integral_domain
+
+section constructors
+variables [comm_cancel_monoid_with_zero α] [nontrivial α] [normalization_monoid α]
+
+/-- Define `gcd_monoid` on a structure just from the `gcd` and its properties. -/
+noncomputable def gcd_monoid_of_gcd [decidable_eq α] (gcd : α → α → α)
+  (gcd_dvd_left   : ∀a b, gcd a b ∣ a)
+  (gcd_dvd_right  : ∀a b, gcd a b ∣ b)
+  (dvd_gcd        : ∀{a b c}, a ∣ c → a ∣ b → a ∣ gcd c b)
+  (normalize_gcd  : ∀a b, normalize (gcd a b) = gcd a b) :
+  gcd_monoid α :=
+{ gcd := gcd,
+  gcd_dvd_left := gcd_dvd_left,
+  gcd_dvd_right := gcd_dvd_right,
+  dvd_gcd := λ a b c, dvd_gcd,
+  normalize_gcd := normalize_gcd,
+  lcm := λ a b, if a = 0 then 0 else classical.some (dvd_normalize_iff.2
+          (dvd.trans (gcd_dvd_left a b) (dvd.intro b rfl))),
+  gcd_mul_lcm := λ a b, by {
+    by_cases a0 : a = 0,
+    { rw [if_pos a0, mul_zero, a0, zero_mul, normalize_zero] },
+    { rw if_neg a0,
+      exact (classical.some_spec (dvd_normalize_iff.2
+                  (dvd.trans (gcd_dvd_left a b) (dvd.intro b rfl)))).symm } },
+  lcm_zero_left := λ a, if_pos rfl,
+  lcm_zero_right := λ a, by {
+    by_cases a0 : a = 0, { apply if_pos a0 },
+    rw if_neg a0,
+    rw ← normalize_eq_zero at a0,
+    have h := (classical.some_spec (dvd_normalize_iff.2
+                  (dvd.trans (gcd_dvd_left a 0) (dvd.intro 0 rfl)))).symm,
+    have gcd0 : gcd a 0 = normalize a,
+    { rw [← normalize_gcd],
+      apply normalize_eq_normalize (gcd_dvd_left _ _) (dvd_gcd (dvd_refl a) (dvd_zero a)) },
+    rw ← gcd0 at a0,
+    apply or_iff_not_imp_left.1 (mul_eq_zero.1 _) a0,
+    rw [h, mul_zero, normalize_zero] },
+  .. (infer_instance : normalization_monoid α) }
+
+/-- Define `gcd_monoid` on a structure just from the `lcm` and its properties. -/
+noncomputable def gcd_monoid_of_lcm [decidable_eq α] (lcm : α → α → α)
+  (dvd_lcm_left   : ∀a b, a ∣ lcm a b)
+  (dvd_lcm_right  : ∀a b, b ∣ lcm a b)
+  (lcm_dvd        : ∀{a b c}, c ∣ a → b ∣ a → lcm c b ∣ a)
+  (normalize_lcm  : ∀a b, normalize (lcm a b) = lcm a b) :
+  gcd_monoid α :=
+{ lcm := lcm,
+  gcd := λ a b, if a = 0 then normalize b else (if b = 0 then normalize a else
+    classical.some (dvd_normalize_iff.2 (lcm_dvd (dvd.intro b rfl) (dvd.intro_left a rfl)))),
+  gcd_mul_lcm := λ a b, by {
+    split_ifs,
+    { rw [h, zero_dvd_iff.1 (dvd_lcm_left _ _), mul_zero, zero_mul, normalize_zero] },
+    { rw [h_1, zero_dvd_iff.1 (dvd_lcm_right _ _), mul_zero, mul_zero, normalize_zero] },
+    apply eq.trans (mul_comm _ _) (classical.some_spec
+      (dvd_normalize_iff.2 (lcm_dvd (dvd.intro b rfl) (dvd.intro_left a rfl)))).symm },
+  normalize_gcd := λ a b, by {
+    split_ifs,
+    { apply normalize_idem },
+    { apply normalize_idem },
+    have hspec := (classical.some_spec
+      (dvd_normalize_iff.2 (lcm_dvd (dvd.intro b rfl) (dvd.intro_left a rfl)))).symm,
+    have h0 : lcm a b ≠ 0,
+    { intro con,
+      have h := lcm_dvd (dvd.intro b rfl) (dvd.intro_left a rfl),
+      rw [con, zero_dvd_iff, mul_eq_zero] at h,
+      cases h; tauto },
+    apply mul_left_cancel' h0,
+    rw [hspec],
+    apply eq.trans (congr (congr rfl (normalize_lcm a b).symm) rfl),
+    apply eq.trans (monoid_hom.map_mul _ _ _).symm,
+    apply eq.trans (congr rfl hspec) (normalize_idem _) },
+  lcm_zero_left := λ a, zero_dvd_iff.1 (dvd_lcm_left _ _),
+  lcm_zero_right := λ a, zero_dvd_iff.1 (dvd_lcm_right _ _),
+  gcd_dvd_left := λ a b, by {
+    split_ifs,
+    { rw h, apply dvd_zero },
+    { apply dvd_of_associated normalize_associated },
+    have h0 : lcm a b ≠ 0,
+    { intro con,
+      have h := lcm_dvd (dvd.intro b rfl) (dvd.intro_left a rfl),
+      rw [con, zero_dvd_iff, mul_eq_zero] at h,
+      cases h; tauto },
+    rw [← mul_dvd_mul_iff_left h0, (classical.some_spec (dvd_normalize_iff.2
+      (lcm_dvd (dvd.intro b rfl) (dvd.intro_left a rfl)))).symm,
+      normalize_dvd_iff, mul_comm, mul_dvd_mul_iff_right h],
+    apply dvd_lcm_right },
+  gcd_dvd_right := λ a b, by {
+    split_ifs,
+    { apply dvd_of_associated normalize_associated },
+    { rw h_1, apply dvd_zero },
+    have h0 : lcm a b ≠ 0,
+    { intro con,
+      have h := lcm_dvd (dvd.intro b rfl) (dvd.intro_left a rfl),
+      rw [con, zero_dvd_iff, mul_eq_zero] at h,
+      cases h; tauto },
+    rw [← mul_dvd_mul_iff_left h0, (classical.some_spec (dvd_normalize_iff.2
+      (lcm_dvd (dvd.intro b rfl) (dvd.intro_left a rfl)))).symm,
+      normalize_dvd_iff, mul_dvd_mul_iff_right h_1],
+    apply dvd_lcm_left },
+  dvd_gcd := λ a b c ac ab, by {
+    split_ifs,
+    { apply dvd_normalize_iff.2 ab },
+    { apply dvd_normalize_iff.2 ac },
+    have h0 : lcm c b ≠ 0,
+    { intro con,
+      have h := lcm_dvd (dvd.intro b rfl) (dvd.intro_left c rfl),
+      rw [con, zero_dvd_iff, mul_eq_zero] at h,
+      cases h; tauto },
+    rw [← mul_dvd_mul_iff_left h0, ← classical.some_spec (dvd_normalize_iff.2
+        (lcm_dvd (dvd.intro b rfl) (dvd.intro_left c rfl))), dvd_normalize_iff],
+    rcases ab with ⟨d, rfl⟩,
+    rw mul_eq_zero at h_1,
+    push_neg at h_1,
+    rw [mul_comm a, ← mul_assoc, mul_dvd_mul_iff_right h_1.1],
+    apply lcm_dvd (dvd.intro d rfl),
+    rw [mul_comm, mul_dvd_mul_iff_right h_1.2],
+    apply ac },
+  .. (infer_instance : normalization_monoid α) }
+
+/-- Define a `gcd_monoid` structure on a monoid just from the existence of a `gcd`. -/
+noncomputable def gcd_monoid_of_exists_gcd [decidable_eq α]
+  (h : ∀ a b : α, ∃ c : α, ∀ d : α, d ∣ a ∧ d ∣ b ↔ d ∣ c) :
+  gcd_monoid α :=
+gcd_monoid_of_gcd
+  (λ a b, normalize (classical.some (h a b)))
+  (λ a b, normalize_dvd_iff.2
+    (((classical.some_spec (h a b) (classical.some (h a b))).2 (dvd_refl _))).1)
+  (λ a b, normalize_dvd_iff.2
+    (((classical.some_spec (h a b) (classical.some (h a b))).2 (dvd_refl _))).2)
+  (λ a b c ac ab, dvd_normalize_iff.2 ((classical.some_spec (h c b) a).1 ⟨ac, ab⟩))
+  (λ a b, normalize_idem _)
+
+/-- Define a `gcd_monoid` structure on a monoid just from the existence of an `lcm`. -/
+noncomputable def gcd_monoid_of_exists_lcm [decidable_eq α]
+  (h : ∀ a b : α, ∃ c : α, ∀ d : α, a ∣ d ∧ b ∣ d ↔ c ∣ d) :
+  gcd_monoid α :=
+gcd_monoid_of_lcm
+  (λ a b, normalize (classical.some (h a b)))
+  (λ a b, dvd_normalize_iff.2
+    (((classical.some_spec (h a b) (classical.some (h a b))).2 (dvd_refl _))).1)
+  (λ a b, dvd_normalize_iff.2
+    (((classical.some_spec (h a b) (classical.some (h a b))).2 (dvd_refl _))).2)
+  (λ a b c ac ab, normalize_dvd_iff.2 ((classical.some_spec (h c b) a).1 ⟨ac, ab⟩))
+  (λ a b, normalize_idem _)
+
+end constructors


### PR DESCRIPTION
Adds the following 4 noncomputable functions which define `gcd_monoid` instances.
`gcd_monoid_of_gcd` takes as input a `gcd` function and a few of its properties
`gcd_monoid_of_lcm` takes as input a `lcm` function and a few of its properties
`gcd_monoid_of_exists_gcd` takes as input the prop that every two elements have a `gcd`
`gcd_monoid_of_exists_lcm` takes as input the prop that every two elements have an `lcm`

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
