### PR TITLE
[Merged by Bors] - fix(logic/nontrivial): change tactic doc entry tag to more common "type class"

### DIFF
--- a/src/logic/nontrivial.lean
+++ b/src/logic/nontrivial.lean
@@ -253,6 +253,6 @@ add_tactic_doc
 { name                     := "nontriviality",
   category                 := doc_category.tactic,
   decl_names               := [`tactic.interactive.nontriviality],
-  tags                     := ["logic", "typeclass"] }
+  tags                     := ["logic", "type class"] }
 
 end tactic.interactive


### PR DESCRIPTION

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Click "Filter by tag" in the top right of [our tactic docs](https://leanprover-community.github.io/mathlib_docs/tactics.html) and note that `nontriviality` is the only tactic with the tag `typeclass`.