### PR TITLE
[Merged by Bors] - feat(algebra/free_algebra): Add a ring instance

### DIFF
--- a/src/algebra/free_algebra.lean
+++ b/src/algebra/free_algebra.lean
@@ -173,6 +173,8 @@ instance : algebra R (free_algebra R X) :=
   commutes' := λ _, by { rintros ⟨⟩, exact quot.sound rel.central_scalar },
   smul_def' := λ _ _, rfl }
 
+instance {S : Type*} [comm_ring S] : ring (free_algebra S X) := algebra.semiring_to_ring S
+
 variables {X}
 
 /--

--- a/src/linear_algebra/tensor_algebra.lean
+++ b/src/linear_algebra/tensor_algebra.lean
@@ -60,6 +60,9 @@ def tensor_algebra := ring_quot (tensor_algebra.rel R M)
 
 namespace tensor_algebra
 
+instance {S : Type*} [comm_ring S] [semimodule S M] : ring (tensor_algebra S M) :=
+ring_quot.ring _
+
 variables {M}
 /--
 The canonical linear map `M →ₗ[R] tensor_algebra R M`.


### PR DESCRIPTION
This also adds a ring instance to `tensor_algebra`.

The approach here does not work for `exterior_algebra` and `clifford_algebra`, and produces weird errors.
Those will be easier to investigate when their foundations are in mathlib.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is an alternative to #4289 that appears to pass CI.
