### PR TITLE
[Merged by Bors] - chore(.gitignore): gitignore for emacs temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 all.lean
 *.depend
 /src/.noisy_files
+*~


### PR DESCRIPTION
Emacs backup files end in `~`, and you don't want them in the repo. Just makes things mildly easier for emacs users if that pattern is in the gitignore.