### PR TITLE
[Merged by Bors] - feat(linear_algebra/nonsingular_inverse): state Cramer's rule explicitly

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -334,6 +334,8 @@
   author : Neil Strickland
 97:
   title  : Cramer’s Rule
+  decl   : matrix.cramers_rule
+  author : Tim Baanen
 98:
   title  : Bertrand’s Postulate
 99:

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -335,7 +335,7 @@
 97:
   title  : Cramer’s Rule
   decl   : matrix.cramers_rule
-  author : Tim Baanen
+  author : Anne Baanen
 98:
   title  : Bertrand’s Postulate
 99:

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -659,6 +659,13 @@ by { ext, apply neg_dot_product }
 lemma mul_vec_neg (v : n → α) (A : matrix m n α) : mul_vec A (-v) = - mul_vec A v :=
 by { ext, apply dot_product_neg }
 
+lemma smul_mul_vec_assoc (A : matrix n n α) (b : n → α) (a : α) :
+  (a • A).mul_vec b = a • (A.mul_vec b) :=
+begin
+  ext i, change dot_product ((a • A) i) b = _,
+  simp only [mul_vec, smul_eq_mul, pi.smul_apply, smul_dot_product],
+end
+
 end ring
 
 section transpose

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -811,7 +811,7 @@ section update
 def update_row [decidable_eq n] (M : matrix n m α) (i : n) (b : m → α) : matrix n m α :=
 function.update M i b
 
-/-- Update, i.e. replace the `i`th column of matrix `A` with the values in `b`. -/
+/-- Update, i.e. replace the `j`th column of matrix `A` with the values in `b`. -/
 def update_column [decidable_eq m] (M : matrix n m α) (j : m) (b : n → α) : matrix n m α :=
 λ i, function.update (M i) j (b i)
 

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -179,8 +179,8 @@ begin
   apply h
 end
 
-lemma det_eq_zero_of_column_eq_zero {A : matrix n n R} (i : n) (h : ∀ j, A j i = 0) : det A = 0 :=
-by { rw ← det_transpose, exact det_eq_zero_of_row_eq_zero i h, }
+lemma det_eq_zero_of_column_eq_zero {A : matrix n n R} (j : n) (h : ∀ i, A i j = 0) : det A = 0 :=
+by { rw ← det_transpose, exact det_eq_zero_of_row_eq_zero j h, }
 
 /--
   `mod_swap i j` contains permutations up to swapping `i` and `j`.

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -168,7 +168,7 @@ section det_zero
 Prove that a matrix with a repeated column has determinant equal to zero.
 -/
 
-lemma det_eq_zero_of_column_eq_zero {A : matrix n n R} (i : n) (h : ∀ j, A i j = 0) : det A = 0 :=
+lemma det_eq_zero_of_row_eq_zero {A : matrix n n R} (i : n) (h : ∀ j, A i j = 0) : det A = 0 :=
 begin
   rw [←det_transpose, det],
   convert @sum_const_zero _ _ (univ : finset (perm n)) _,
@@ -178,6 +178,9 @@ begin
   rw [transpose_apply],
   apply h
 end
+
+lemma det_eq_zero_of_column_eq_zero {A : matrix n n R} (i : n) (h : ∀ j, A j i = 0) : det A = 0 :=
+by { rw ← det_transpose, exact det_eq_zero_of_row_eq_zero i h, }
 
 /--
   `mod_swap i j` contains permutations up to swapping `i` and `j`.
@@ -195,8 +198,8 @@ instance (i j : n) : decidable_rel (mod_swap i j).r := λ σ τ, or.decidable
 
 variables {M : matrix n n R} {i j : n}
 
-/-- If a matrix has a repeated column, the determinant will be zero. -/
-theorem det_zero_of_column_eq (i_ne_j : i ≠ j) (hij : M i = M j) : M.det = 0 :=
+/-- If a matrix has a repeated row, the determinant will be zero. -/
+theorem det_zero_of_row_eq (i_ne_j : i ≠ j) (hij : M i = M j) : M.det = 0 :=
 begin
   have swap_invariant : ∀ k, M (swap i j k) = M k,
   { intros k,

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -106,7 +106,7 @@ end
   If `A ⬝ x = b` has a unique solution in `x`, `cramer` sends a square matrix `A`
   and vector `b` to the vector `x` such that `A ⬝ x = b`.
   Otherwise, the outcome of `cramer` is well-defined but not necessarily useful. -/
-def cramer {α : Type v} [comm_ring α] (A : matrix n n α) : (n → α) →ₗ[α] (n → α) :=
+def cramer (A : matrix n n α) : (n → α) →ₗ[α] (n → α) :=
 is_linear_map.mk' (cramer_map A) (cramer_is_linear A)
 
 lemma cramer_apply (i : n) : cramer A b i = (A.update_row i b).det := rfl

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -103,9 +103,9 @@ end
   `cramer A b i` is the determinant of the matrix `A` with column `i` replaced with `b`,
   and thus `cramer A b` is the vector output by Cramer's rule on `A` and `b`.
 
-  If `A ⬝ x = b` has a unique solution in `x`, `cramer` sends a square matrix `A`
-  and vector `b` to the vector `x` such that `A ⬝ x = b`.
-  Otherwise, the outcome of `cramer` is well-defined but not necessarily useful. -/
+  If `A ⬝ x = b` has a unique solution in `x`, `cramer Aᵀ` sends the vector `b` to `A.det • x`.
+  Otherwise, the outcome of `cramer` is well-defined but not necessarily useful.
+ -/
 def cramer (A : matrix n n α) : (n → α) →ₗ[α] (n → α) :=
 is_linear_map.mk' (cramer_map A) (cramer_is_linear A)
 

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -19,12 +19,12 @@ The definition of inverse used in this file is the adjugate divided by the deter
 The adjugate is calculated with Cramer's rule, which we introduce first.
 The vectors returned by Cramer's rule are given by the linear map `cramer`,
 which sends a matrix `A` and vector `b` to the vector consisting of the
-determinant of replacing the `i`th column of `A` with `b` at index `i`
-(written as `(A.update_column i b).det`).
+determinant of replacing the `i`th row of `A` with `b` at index `i`
+(written as `(A.update_row i b).det`).
 Using Cramer's rule, we can compute for each matrix `A` the matrix `adjugate A`.
 The entries of the adjugate are the determinants of each minor of `A`.
-Instead of defining a minor to be `A` with column `i` and row `j` deleted, we
-replace the `i`th column of `A` with the `j`th basis vector; this has the same
+Instead of defining a minor to be `A` with row `i` and column `j` deleted, we
+replace the `i`th row of `A` with the `j`th basis vector; this has the same
 determinant as the minor but more importantly equals Cramer's rule applied
 to `A` and the `j`th basis vector, simplifying the subsequent proofs.
 We prove the adjugate behaves like `det A • A⁻¹`. Finally, we show that dividing
@@ -57,7 +57,7 @@ section cramer
 variables (A : matrix n n α) (b : n → α)
 
 /--
-  `cramer_map A b i` is the determinant of the matrix `A` with column `i` replaced with `b`,
+  `cramer_map A b i` is the determinant of the matrix `A` with row `i` replaced with `b`,
   and thus `cramer_map A b` is the vector output by Cramer's rule on `A` and `b`.
 
   If `A ⬝ x = b` has a unique solution in `x`, `cramer_map Aᵀ` sends the vector `b` to `A.det • x`.
@@ -100,7 +100,7 @@ begin
 end
 
 /--
-  `cramer A b i` is the determinant of the matrix `A` with column `i` replaced with `b`,
+  `cramer A b i` is the determinant of the matrix `A` with row `i` replaced with `b`,
   and thus `cramer A b` is the vector output by Cramer's rule on `A` and `b`.
 
   If `A ⬝ x = b` has a unique solution in `x`, `cramer Aᵀ` sends the vector `b` to `A.det • x`.
@@ -111,7 +111,7 @@ is_linear_map.mk' (cramer_map A) (cramer_is_linear A)
 
 lemma cramer_apply (i : n) : cramer A b i = (A.update_row i b).det := rfl
 
-/-- Applying Cramer's rule to a column of the matrix gives a scaled basis vector. -/
+/-- Applying Cramer's rule to a row of the matrix gives a scaled basis vector. -/
 lemma cramer_column_self (i : n) :
 cramer A (A i) = (λ j, if i = j then A.det else 0) :=
 begin
@@ -158,7 +158,7 @@ while the `inv` section is specifically for invertible matrices.
   Typically, the cofactor matrix is defined by taking the determinant of minors,
   i.e. the matrix with a row and column removed.
   However, the proof of `mul_adjugate` becomes a lot easier if we define the
-  minor as replacing a column with a basis vector, since it allows us to use
+  minor as replacing a row with a basis vector, since it allows us to use
   facts about the `cramer` map.
 -/
 def adjugate (A : matrix n n α) : matrix n n α := λ i, cramer A (λ j, if i = j then 1 else 0)

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -60,8 +60,7 @@ variables (A : matrix n n α) (b : n → α)
   `cramer_map A b i` is the determinant of the matrix `A` with column `i` replaced with `b`,
   and thus `cramer_map A b` is the vector output by Cramer's rule on `A` and `b`.
 
-  If `A ⬝ x = b` has a unique solution in `x`, `cramer_map` sends a square matrix `A`
-  and vector `b` to the vector `x` such that `A ⬝ x = b`.
+  If `A ⬝ x = b` has a unique solution in `x`, `cramer_map Aᵀ` sends the vector `b` to `A.det • x`.
   Otherwise, the outcome of `cramer_map` is well-defined but not necessarily useful.
 -/
 def cramer_map (i : n) : α := (A.update_row i b).det
@@ -415,8 +414,11 @@ B.nonsing_inv_left_right A h
 end inv
 
 lemma cramers_rule (A : matrix n n α) (b : n → α) (h : is_unit A.det) :
-  A.mul_vec ((↑h.unit⁻¹ : α) • (cramer Aᵀ b)) = b :=
-by rw [cramer_transpose_eq_adjugate_mul_vec, ← smul_mul_vec_assoc, ← nonsing_inv_apply,
-       mul_vec_mul_vec, A.mul_nonsing_inv h, mul_vec_one]
+  cramer Aᵀ b = A.det • A⁻¹.mul_vec b :=
+begin
+  rw [cramer_transpose_eq_adjugate_mul_vec, A.nonsing_inv_apply h, ← smul_mul_vec_assoc],
+  conv_rhs { congr, congr, rw ← h.unit_spec, },
+  rw units.smul_inv_smul,
+end
 
 end matrix


### PR DESCRIPTION
Mostly so that we can add an entry to the Freek 100.


---
Note that we state this using the slightly low-level `matrix.mul_vec` instead of building on top of `matrix.to_lin'`. This is partly because the current status of the import hierarchy (`matrix.to_lin'` is defined in a file importing `nonsingular_inverse.lean`) and partly because the statement in terms of `to_lin'` turns out to need additional ascriptions which, IMHO, render the statement of `cramers_rule` even less readable to the casual reader arriving from the Freek list.

Notwithstanding the above, I am more than happy to be persuaded to do things differently!