### PR TITLE
[Merged by Bors] - fixup(category_theory/sites): add arrow sets that aren't sieves 

### DIFF
--- a/src/category_theory/sites/grothendieck.lean
+++ b/src/category_theory/sites/grothendieck.lean
@@ -69,13 +69,12 @@ A sieve `S` on `X` is referred to as `J`-covering, (or just covering), if `S ∈
 See https://stacks.math.columbia.edu/tag/00Z4, or [nlab], or [MM92] Chapter III, Section 2,
 Definition 1.
 -/
-@[ext]
 structure grothendieck_topology :=
 (sieves : Π (X : C), set (sieve X))
 (top_mem' : ∀ X, ⊤ ∈ sieves X)
 (pullback_stable' : ∀ ⦃X Y : C⦄ ⦃S : sieve X⦄ (f : Y ⟶ X), S ∈ sieves X → S.pullback f ∈ sieves Y)
 (transitive' : ∀ ⦃X⦄ ⦃S : sieve X⦄ (hS : S ∈ sieves X) (R : sieve X),
-              (∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄, S.arrows f → R.pullback f ∈ sieves Y) → R ∈ sieves X)
+              (∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄, S f → R.pullback f ∈ sieves Y) → R ∈ sieves X)
 
 namespace grothendieck_topology
 
@@ -85,6 +84,15 @@ instance : has_coe_to_fun (grothendieck_topology C) :=
 variables {C} {X Y : C} {S R : sieve X}
 variables (J : grothendieck_topology C)
 
+/--
+An extensionality lemma in terms of the coercion to a pi-type.
+We prove this explicitly rather than deriving it so that it is in terms of the coercion rather than
+the projection `.sieves`.
+-/
+@[ext]
+lemma ext {J₁ J₂ : grothendieck_topology C} (h : (J₁ : Π (X : C), set (sieve X)) = J₂) : J₁ = J₂ :=
+by { cases J₁, cases J₂, congr, apply h }
+
 @[simp] lemma mem_sieves_iff_coe : S ∈ J.sieves X ↔ S ∈ J X := iff.rfl
 
 -- Also known as the maximality axiom.
@@ -93,7 +101,7 @@ variables (J : grothendieck_topology C)
 @[simp] lemma pullback_stable (f : Y ⟶ X) (hS : S ∈ J X) : S.pullback f ∈ J Y :=
 J.pullback_stable' f hS
 lemma transitive (hS : S ∈ J X) (R : sieve X)
-  (h : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄, S.arrows f → R.pullback f ∈ J Y) :
+  (h : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄, S f → R.pullback f ∈ J Y) :
   R ∈ J X :=
 J.transitive' hS R h
 
@@ -131,6 +139,11 @@ lemma intersection_covering_iff : R ⊓ S ∈ J X ↔ R ∈ J X ∧ S ∈ J X :=
 ⟨λ h, ⟨J.superset_covering inf_le_left h, J.superset_covering inf_le_right h⟩,
  λ t, intersection_covering _ t.1 t.2⟩
 
+lemma bind_covering {S : sieve X} {R : Π ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, S f → sieve Y} (hS : S ∈ J X)
+  (hR : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (H : S f), R H ∈ J Y) :
+sieve.bind S R ∈ J X :=
+J.transitive hS _ (λ Y f hf, superset_covering J (sieve.le_pullback_bind S R f hf) (hR hf))
+
 /--
 The sieve `S` on `X` `J`-covers an arrow `f` to `X` if `S.pullback f ∈ J Y`.
 This definition is an alternate way of presenting a Grothendieck topology.
@@ -144,7 +157,7 @@ lemma covering_iff_covers_id (S : sieve X) : S ∈ J X ↔ J.covers S (𝟙 X) :
 by simp [covers_iff]
 
 /-- The maximality axiom in 'arrow' form: Any arrow `f` in `S` is covered by `S`. -/
-lemma arrow_max (f : Y ⟶ X) (S : sieve X) (hf : S.arrows f) : J.covers S f :=
+lemma arrow_max (f : Y ⟶ X) (S : sieve X) (hf : S f) : J.covers S f :=
 begin
   rw [covers, (sieve.pullback_eq_top_iff_mem f).1 hf],
   apply J.top_mem,
@@ -163,7 +176,7 @@ The transitivity axiom in 'arrow' form: If `S` covers `f` and every arrow in `S`
 `R`, then `R` covers `f`.
 -/
 lemma arrow_trans (f : Y ⟶ X) (S R : sieve X) (h : J.covers S f) :
-  (∀ {Z : C} (g : Z ⟶ X), S.arrows g → J.covers R g) → J.covers R f :=
+  (∀ {Z : C} (g : Z ⟶ X), S g → J.covers R g) → J.covers R f :=
 begin
   intro k,
   apply J.transitive h,
@@ -217,7 +230,7 @@ instance : partial_order (grothendieck_topology C) :=
 { le := λ J₁ J₂, (J₁ : Π (X : C), set (sieve X)) ≤ (J₂ : Π (X : C), set (sieve X)),
   le_refl := λ J₁, le_refl _,
   le_trans := λ J₁ J₂ J₃ h₁₂ h₂₃, le_trans h₁₂ h₂₃,
-  le_antisymm := λ J₁ J₂ h₁₂ h₂₁, grothendieck_topology.ext _ _ (le_antisymm h₁₂ h₂₁) }
+  le_antisymm := λ J₁ J₂ h₁₂ h₂₁, grothendieck_topology.ext (le_antisymm h₁₂ h₂₁) }
 
 /-- See https://stacks.math.columbia.edu/tag/00Z7 -/
 instance : has_Inf (grothendieck_topology C) :=
@@ -284,7 +297,7 @@ instance : inhabited (grothendieck_topology C) := ⟨⊤⟩
 @[simp] lemma top_covering : S ∈ (⊤ : grothendieck_topology C) X := ⟨⟩
 
 lemma bot_covers (S : sieve X) (f : Y ⟶ X) :
-  (⊥ : grothendieck_topology C).covers S f ↔ S.arrows f :=
+  (⊥ : grothendieck_topology C).covers S f ↔ S f :=
 by rw [covers_iff, bot_covering, ← sieve.pullback_eq_top_iff_mem]
 
 @[simp] lemma top_covers (S : sieve X) (f : Y ⟶ X) : (⊤ : grothendieck_topology C).covers S f :=
@@ -296,7 +309,7 @@ The dense Grothendieck topology.
 See https://ncatlab.org/nlab/show/dense+topology, or [MM92] Chapter III, Section 2, example (e).
 -/
 def dense : grothendieck_topology C :=
-{ sieves := λ X S, ∀ {Y : C} (f : Y ⟶ X), ∃ Z (g : Z ⟶ Y), S.arrows (g ≫ f),
+{ sieves := λ X S, ∀ {Y : C} (f : Y ⟶ X), ∃ Z (g : Z ⟶ Y), S (g ≫ f),
   top_mem' := λ X Y f, ⟨Y, 𝟙 Y, ⟨⟩⟩,
   pullback_stable' :=
   begin
@@ -312,7 +325,7 @@ def dense : grothendieck_topology C :=
     exact ⟨W, (h ≫ g), by simpa using H₄⟩,
   end }
 
-lemma dense_covering : S ∈ dense X ↔ ∀ {Y} (f : Y ⟶ X), ∃ Z (g : Z ⟶ Y), S.arrows (g ≫ f) :=
+lemma dense_covering : S ∈ dense X ↔ ∀ {Y} (f : Y ⟶ X), ∃ Z (g : Z ⟶ Y), S (g ≫ f) :=
 iff.rfl
 
 /--
@@ -333,7 +346,7 @@ For the pullback stability condition, we need the right Ore condition to hold.
 See https://ncatlab.org/nlab/show/atomic+site, or [MM92] Chapter III, Section 2, example (f).
 -/
 def atomic (hro : right_ore_condition C) : grothendieck_topology C :=
-{ sieves := λ X S, ∃ Y (f : Y ⟶ X), S.arrows f,
+{ sieves := λ X S, ∃ Y (f : Y ⟶ X), S f,
   top_mem' := λ X, ⟨_, 𝟙 _, ⟨⟩⟩,
   pullback_stable' :=
   begin

--- a/src/category_theory/sites/sieves.lean
+++ b/src/category_theory/sites/sieves.lean
@@ -28,35 +28,78 @@ sieve, pullback
 universes v u
 namespace category_theory
 
+variables {C : Type u} [category.{v} C]
+variables {X Y Z : C} (f : Y ⟶ X)
+
+/-- A set of arrows all with codomain `X`. -/
+@[derive complete_lattice]
+def arrows_with_codomain (X : C) := Π ⦃Y⦄, set (Y ⟶ X)
+
+namespace arrows_with_codomain
+
+instance : inhabited (arrows_with_codomain X) := ⟨⊤⟩
+
+/--
+Given a set of arrows `S` all with codomain `X`, and a set of arrows with codomain `Y` for each
+`f : Y ⟶ X` in `S`, produce a set of arrows with codomain `X`:
+`{ g ≫ f | (f : Y ⟶ X) ∈ S, (g : Z ⟶ Y) ∈ R f }`.
+-/
+def bind (S : arrows_with_codomain X) (R : Π ⦃Y⦄ ⦃f : Y ⟶ X⦄, S f → arrows_with_codomain Y) :
+  arrows_with_codomain X :=
+λ Z h, ∃ (Y : C) (g : Z ⟶ Y) (f : Y ⟶ X) (H : S f), R H g ∧ g ≫ f = h
+
+@[simp]
+lemma bind_comp {S : arrows_with_codomain X}
+  {R : Π ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, S f → arrows_with_codomain Y} {g : Z ⟶ Y} (h₁ : S f) (h₂ : R h₁ g) :
+bind S R (g ≫ f) :=
+⟨_, _, _, h₁, h₂, rfl⟩
+
+/-- The singleton arrow set. -/
+def singleton_arrow : arrows_with_codomain X :=
+λ Z g, ∃ (H : Z = Y), eq_to_hom H ≫ f = g
+
+@[simp] lemma singleton_arrow_eq_iff_domain (f g : Y ⟶ X) : singleton_arrow f g ↔ f = g :=
+begin
+  split,
+  { rintro ⟨_, rfl⟩,
+    apply (category.id_comp _).symm },
+  { rintro rfl,
+    exact ⟨rfl, category.id_comp _⟩ },
+end
+
+lemma singleton_arrow_self : singleton_arrow f f := (singleton_arrow_eq_iff_domain _ _).2 rfl
+
+end arrows_with_codomain
+
 /--
 For an object `X` of a category `C`, a `sieve X` is a set of morphisms to `X` which is closed under
 left-composition.
 -/
 structure sieve {C : Type u} [category.{v} C] (X : C) :=
-(arrows : Π ⦃Y⦄, set (Y ⟶ X))
-(downward_closed : ∀ {Y Z f} (hf : arrows f) (g : Z ⟶ Y), arrows (g ≫ f))
-attribute [simp, priority 100] sieve.downward_closed
+(arrows : arrows_with_codomain X)
+(downward_closed' : ∀ {Y Z f} (hf : arrows f) (g : Z ⟶ Y), arrows (g ≫ f))
 
 namespace sieve
 
-variables {C : Type u} [category.{v} C]
+instance {X : C} : has_coe_to_fun (sieve X) := ⟨_, sieve.arrows⟩
 
-variables {X Y Z : C} {S R : sieve X}
+variables {S R : sieve X}
 
-/-- A sieve gives a subset of the over category of `X`. -/
-def set_over (S : sieve X) : set (over X) := λ f, S.arrows f.hom
+@[simp, priority 100] lemma downward_closed (S : sieve X) {f : Y ⟶ X} (hf : S f)
+  (g : Z ⟶ Y) : S (g ≫ f) :=
+S.downward_closed' hf g
 
 lemma arrows_ext : Π {R S : sieve X}, R.arrows = S.arrows → R = S
 | ⟨Ra, _⟩ ⟨Sa, _⟩ rfl := rfl
 
 @[ext]
 protected lemma ext {R S : sieve X}
-  (h : ∀ ⦃Y⦄ (f : Y ⟶ X), R.arrows f ↔ S.arrows f) :
+  (h : ∀ ⦃Y⦄ (f : Y ⟶ X), R f ↔ S f) :
   R = S :=
 arrows_ext $ funext $ λ x, funext $ λ f, propext $ h f
 
 protected lemma ext_iff {R S : sieve X} :
-  R = S ↔ (∀ ⦃Y⦄ (f : Y ⟶ X), R.arrows f ↔ S.arrows f) :=
+  R = S ↔ (∀ ⦃Y⦄ (f : Y ⟶ X), R f ↔ S f) :=
 ⟨λ h Y f, h ▸ iff.rfl, sieve.ext⟩
 
 open lattice
@@ -64,49 +107,48 @@ open lattice
 /-- The supremum of a collection of sieves: the union of them all. -/
 protected def Sup (𝒮 : set (sieve X)) : (sieve X) :=
 { arrows := λ Y, {f | ∃ S ∈ 𝒮, sieve.arrows S f},
-  downward_closed := λ Y Z f, by { rintro ⟨S, hS, hf⟩ g, exact ⟨S, hS, S.downward_closed hf _⟩ } }
+  downward_closed' := λ Y Z f, by { rintro ⟨S, hS, hf⟩ g, exact ⟨S, hS, S.downward_closed hf _⟩ } }
 
 /-- The infimum of a collection of sieves: the intersection of them all. -/
 protected def Inf (𝒮 : set (sieve X)) : (sieve X) :=
 { arrows := λ Y, {f | ∀ S ∈ 𝒮, sieve.arrows S f},
-  downward_closed := λ Y Z f hf g S H, S.downward_closed (hf S H) g }
+  downward_closed' := λ Y Z f hf g S H, S.downward_closed (hf S H) g }
 
 /-- The union of two sieves is a sieve. -/
 protected def union (S R : sieve X) : sieve X :=
-{ arrows := λ Y f, S.arrows f ∨ R.arrows f,
-  downward_closed := by { rintros Y Z f (h | h) g; simp [h] } }
+{ arrows := λ Y f, S f ∨ R f,
+  downward_closed' := by { rintros Y Z f (h | h) g; simp [h] } }
 
 /-- The intersection of two sieves is a sieve. -/
 protected def inter (S R : sieve X) : sieve X :=
-{ arrows := λ Y f, S.arrows f ∧ R.arrows f,
-  downward_closed := by { rintros Y Z f ⟨h₁, h₂⟩ g, simp [h₁, h₂] } }
+{ arrows := λ Y f, S f ∧ R f,
+  downward_closed' := by { rintros Y Z f ⟨h₁, h₂⟩ g, simp [h₁, h₂] } }
 
 /--
 Sieves on an object `X` form a complete lattice.
-We generate this directly rather than using the galois insertion for nicer definitional
-properties.
+We generate this directly rather than using the galois insertion for nicer definitional properties.
 -/
 instance : complete_lattice (sieve X) :=
-{ le           := λ S R, ∀ Y (f : Y ⟶ X), S.arrows f → R.arrows f,
+{ le           := λ S R, ∀ ⦃Y⦄ (f : Y ⟶ X), S f → R f,
   le_refl      := λ S f q, id,
-  le_trans     := λ S₁ S₂ S₃ S₁₂ S₂₃ Y f h, S₂₃ _ _ (S₁₂ _ _ h),
-  le_antisymm  := λ S R p q, sieve.ext (λ Y f, ⟨p _ _, q _ _⟩),
-  top          := { arrows := λ _, set.univ, downward_closed := λ Y Z f g h, ⟨⟩ },
-  bot          := { arrows := λ _, ∅, downward_closed := λ _ _ _ p _, false.elim p },
+  le_trans     := λ S₁ S₂ S₃ S₁₂ S₂₃ Y f h, S₂₃ _ (S₁₂ _ h),
+  le_antisymm  := λ S R p q, sieve.ext (λ Y f, ⟨p _, q _⟩),
+  top          := { arrows := λ _, set.univ, downward_closed' := λ Y Z f g h, ⟨⟩ },
+  bot          := { arrows := λ _, ∅, downward_closed' := λ _ _ _ p _, false.elim p },
   sup          := sieve.union,
   inf          := sieve.inter,
   Sup          := sieve.Sup,
   Inf          := sieve.Inf,
   le_Sup       := λ 𝒮 S hS Y f hf, ⟨S, hS, hf⟩,
-  Sup_le       := λ ℰ S hS Y f, by { rintro ⟨R, hR, hf⟩, apply hS R hR _ _ hf },
+  Sup_le       := λ ℰ S hS Y f, by { rintro ⟨R, hR, hf⟩, apply hS R hR _ hf },
   Inf_le       := λ _ _ hS _ _ h, h _ hS,
-  le_Inf       := λ _ _ hS _ _ hf _ hR, hS _ hR _ _ hf,
+  le_Inf       := λ _ _ hS _ _ hf _ hR, hS _ hR _ hf,
   le_sup_left  := λ _ _ _ _, or.inl,
   le_sup_right := λ _ _ _ _, or.inr,
-  sup_le       := λ _ _ _ a b _ _ hf, hf.elim (a _ _) (b _ _),
+  sup_le       := λ _ _ _ a b _ _ hf, hf.elim (a _) (b _),
   inf_le_left  := λ _ _ _ _, and.left,
   inf_le_right := λ _ _ _ _, and.right,
-  le_inf       := λ _ _ _ p q _ _ z, ⟨p _ _ z, q _ _ z⟩,
+  le_inf       := λ _ _ _ p q _ _ z, ⟨p _ z, q _ z⟩,
   le_top       := λ _ _ _ _, trivial,
   bot_le       := λ _ _ _, false.elim }
 
@@ -115,72 +157,76 @@ instance sieve_inhabited : inhabited (sieve X) := ⟨⊤⟩
 
 @[simp]
 lemma mem_Inf {Ss : set (sieve X)} {Y} (f : Y ⟶ X) :
-  (Inf Ss).arrows f ↔ ∀ S ∈ Ss, sieve.arrows S f :=
+  Inf Ss f ↔ ∀ (S : sieve X) (H : S ∈ Ss), S f :=
 iff.rfl
 
 @[simp]
 lemma mem_Sup {Ss : set (sieve X)} {Y} (f : Y ⟶ X) :
-  (Sup Ss).arrows f ↔ ∃ S ∈ Ss, sieve.arrows S f :=
+  Sup Ss f ↔ ∃ (S : sieve X) (H : S ∈ Ss), S f :=
 iff.rfl
 
 @[simp]
 lemma mem_inter {R S : sieve X} {Y} (f : Y ⟶ X) :
-  (R ⊓ S).arrows f ↔ R.arrows f ∧ S.arrows f :=
+  (R ⊓ S) f ↔ R f ∧ S f :=
 iff.rfl
 
 @[simp]
 lemma mem_union {R S : sieve X} {Y} (f : Y ⟶ X) :
-  (R ⊔ S).arrows f ↔ R.arrows f ∨ S.arrows f :=
+  (R ⊔ S) f ↔ R f ∨ S f :=
 iff.rfl
 
 @[simp]
-lemma mem_top (f : Y ⟶ X) : (⊤ : sieve X).arrows f := trivial
-
-/-- Take the downward-closure of a set of morphisms to `X`. -/
-inductive generate_sets (𝒢 : set (over X)) : Π (Y : C), set (Y ⟶ X)
-| basic : Π {Y : C} {f : Y ⟶ X}, over.mk f ∈ 𝒢 → generate_sets _ f
-| close : Π {Y Z} {f : Y ⟶ X} (g : Z ⟶ Y), generate_sets _ f → generate_sets _ (g ≫ f)
+lemma mem_top (f : Y ⟶ X) : (⊤ : sieve X) f := trivial
 
 /-- Generate the smallest sieve containing the given set of arrows. -/
-def generate (𝒢 : set (over X)) : sieve X :=
-{ arrows := generate_sets 𝒢,
-  downward_closed := λ _ _ _ h _, generate_sets.close _ h }
+def generate (R : arrows_with_codomain X) : sieve X :=
+{ arrows := λ Z f, ∃ Y (h : Z ⟶ Y) (g : Y ⟶ X), R g ∧ h ≫ g = f,
+  downward_closed' :=
+  begin
+    rintro Y Z _ ⟨W, g, f, hf, rfl⟩ h,
+    exact ⟨_, h ≫ g, _, hf, by simp⟩,
+  end }
+
+lemma mem_generate (R : arrows_with_codomain X) (f : Z ⟶ X) :
+  generate R f ↔ ∃ (Y : C) (h : Z ⟶ Y) (g : Y ⟶ X), R g ∧ h ≫ g = f :=
+iff.rfl
+
+/-- Given a collection of arrows with fixed codomain,  -/
+def bind (S : arrows_with_codomain X) (R : Π ⦃Y⦄ ⦃f : Y ⟶ X⦄, S f → sieve Y) : sieve X :=
+{ arrows := S.bind (λ Y f h, R h),
+  downward_closed' :=
+  begin
+    rintro Y Z f ⟨W, f, h, hh, hf, rfl⟩ g,
+    exact ⟨_, g ≫ f, _, hh, by simp [hf]⟩,
+  end }
 
 open order lattice
 
-lemma sets_iff_generate (S : set (over X)) (S' : sieve X) :
-  generate S ≤ S' ↔ S ≤ S'.set_over :=
-⟨λ H g hg,
+lemma sets_iff_generate (R : arrows_with_codomain X) (S : sieve X) :
+  generate R ≤ S ↔ R ≤ S :=
+⟨λ H Y g hg, H _ ⟨_, 𝟙 _, _, hg, category.id_comp _⟩,
+ λ ss Y f,
   begin
-    have : over.mk g.hom = g,
-      cases g, dsimp [over.mk],
-      congr' 1, apply subsingleton.elim,
-    rw ← this at *,
-    exact H _ _ (generate_sets.basic hg),
-  end,
-λ ss Y f hf,
-begin
-  induction hf,
-  case basic : X g hg { exact ss hg },
-  case close : Y Z f g hf₁ hf₂ { exact S'.downward_closed hf₂ _ },
-end⟩
+    rintro ⟨Z, f, g, hg, rfl⟩,
+    exact S.downward_closed (ss Z hg) f,
+  end⟩
 
 /-- Show that there is a galois insertion (generate, set_over). -/
-def gi_generate : galois_insertion (generate : set (over X) → sieve X) set_over :=
+def gi_generate : galois_insertion (generate : arrows_with_codomain X → sieve X) arrows :=
 { gc := sets_iff_generate,
   choice := λ 𝒢 _, generate 𝒢,
   choice_eq := λ _ _, rfl,
-  le_l_u := λ S Y f hf, generate_sets.basic hf }
+  le_l_u := λ S Y f hf, ⟨_, 𝟙 _, _, hf, category.id_comp _⟩ }
 
 /-- Given a morphism `h : Y ⟶ X`, send a sieve S on X to a sieve on Y
     as the inverse image of S with `_ ≫ h`.
     That is, `sieve.pullback S h := (≫ h) '⁻¹ S`. -/
 def pullback (h : Y ⟶ X) (S : sieve X) : sieve Y :=
-{ arrows := λ Y sl, S.arrows (sl ≫ h),
-  downward_closed := λ Z W f g h, by simp [g] }
+{ arrows := λ Y sl, S (sl ≫ h),
+  downward_closed' := λ Z W f g h, by simp [g] }
 
 @[simp] lemma mem_pullback (h : Y ⟶ X) {f : Z ⟶ Y} :
-  (S.pullback h).arrows f ↔ S.arrows (f ≫ h) := iff.rfl
+  (S.pullback h) f ↔ S (f ≫ h) := iff.rfl
 
 @[simp]
 lemma pullback_id : S.pullback (𝟙 _) = S :=
@@ -200,27 +246,27 @@ lemma pullback_inter {f : Y ⟶ X} (S R : sieve X) :
 by simp [sieve.ext_iff]
 
 /-- If the identity arrow is in a sieve, the sieve is maximal. -/
-lemma id_mem_iff_eq_top : S.arrows (𝟙 X) ↔ S = ⊤ :=
+lemma id_mem_iff_eq_top : S (𝟙 X) ↔ S = ⊤ :=
 ⟨λ h, top_unique $ λ Y f _, by simpa using downward_closed _ h f,
  λ h, h.symm ▸ trivial⟩
 
-lemma pullback_eq_top_iff_mem (f : Y ⟶ X) : S.arrows f ↔ S.pullback f = ⊤ :=
+lemma pullback_eq_top_iff_mem (f : Y ⟶ X) : S f ↔ S.pullback f = ⊤ :=
 by rw [← id_mem_iff_eq_top, mem_pullback, category.id_comp]
 
-lemma pullback_eq_top_of_mem (S : sieve X) {f : Y ⟶ X} : S.arrows f → S.pullback f = ⊤ :=
+lemma pullback_eq_top_of_mem (S : sieve X) {f : Y ⟶ X} : S f → S.pullback f = ⊤ :=
 (pullback_eq_top_iff_mem f).1
 
 /--
-Push a sieve `R` on `Y` forward along an arrow `f : Y ⟶ X`: `gf : Z ⟶ X`
-is in the sieve if `gf` factors through some `g : Z ⟶ Y` which is in `R`.
+Push a sieve `R` on `Y` forward along an arrow `f : Y ⟶ X`: `gf : Z ⟶ X` is in the sieve if `gf`
+factors through some `g : Z ⟶ Y` which is in `R`.
 -/
 def pushforward (f : Y ⟶ X) (R : sieve Y) : sieve X :=
-{ arrows := λ Z gf, ∃ g, g ≫ f = gf ∧ R.arrows g,
-  downward_closed := λ Z₁ Z₂ g ⟨j, k, z⟩ h, ⟨h ≫ j, by simp [k], by simp [z]⟩ }
+{ arrows := λ Z gf, ∃ g, g ≫ f = gf ∧ R g,
+  downward_closed' := λ Z₁ Z₂ g ⟨j, k, z⟩ h, ⟨h ≫ j, by simp [k], by simp [z]⟩ }
 
 @[simp]
-lemma mem_pushforward_of_comp {R : sieve Y} {Z : C} {g : Z ⟶ Y} (hg : R.arrows g) (f : Y ⟶ X) :
-  (R.pushforward f).arrows (g ≫ f) :=
+lemma mem_pushforward_of_comp {R : sieve Y} {Z : C} {g : Z ⟶ Y} (hg : R g) (f : Y ⟶ X) :
+  R.pushforward f (g ≫ f) :=
 ⟨g, rfl, hg⟩
 
 lemma pushforward_comp {f : Y ⟶ X} {g : Z ⟶ Y} (R : sieve Z) :
@@ -229,7 +275,7 @@ sieve.ext (λ W h, ⟨λ ⟨f₁, hq, hf₁⟩, ⟨f₁ ≫ g, by simpa, f₁, r
                    λ ⟨y, hy, z, hR, hz⟩, ⟨z, by rwa reassoc_of hR, hz⟩⟩)
 
 lemma galois_connection (f : Y ⟶ X) : galois_connection (sieve.pushforward f) (sieve.pullback f) :=
-λ S R, ⟨λ hR Z g hg, hR _ _ ⟨g, rfl, hg⟩, λ hS Z g ⟨h, hg, hh⟩, hg ▸ hS Z h hh⟩
+λ S R, ⟨λ hR Z g hg, hR _ ⟨g, rfl, hg⟩, λ hS Z g ⟨h, hg, hh⟩, hg ▸ hS h hh⟩
 
 lemma pullback_monotone (f : Y ⟶ X) : monotone (sieve.pullback f) :=
 (galois_connection f).monotone_u
@@ -248,6 +294,22 @@ lemma pullback_pushforward_le (f : Y ⟶ X) (R : sieve X) :
 lemma pushforward_union {f : Y ⟶ X} (S R : sieve Y) :
   (S ⊔ R).pushforward f = S.pushforward f ⊔ R.pushforward f :=
 (galois_connection f).l_sup
+
+lemma pushforward_le_bind_of_mem (S : arrows_with_codomain X)
+  (R : Π ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, S f → sieve Y) (f : Y ⟶ X) (h : S f) :
+  (R h).pushforward f ≤ bind S R :=
+begin
+  rintro Z _ ⟨g, rfl, hg⟩,
+  exact ⟨_, g, f, h, hg, rfl⟩,
+end
+
+lemma le_pullback_bind (S : arrows_with_codomain X) (R : Π ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, S f → sieve Y)
+  (f : Y ⟶ X) (h : S f) :
+  R h ≤ (bind S R).pullback f :=
+begin
+  rw ← galois_connection f,
+  apply pushforward_le_bind_of_mem,
+end
 
 /-- If `f` is a monomorphism, the pushforward-pullback adjunction on sieves is coreflective. -/
 def galois_coinsertion_of_mono (f : Y ⟶ X) [mono f] :
@@ -280,7 +342,7 @@ presheaves.
 -/
 @[simps]
 def nat_trans_of_le {S T : sieve X} (h : S ≤ T) : S.functor ⟶ T.functor :=
-{ app := λ Y f, ⟨f.1, h _ _ f.2⟩ }.
+{ app := λ Y f, ⟨f.1, h _ f.2⟩ }.
 
 /-- The natural inclusion from the functor induced by a sieve to the yoneda embedding. -/
 @[simps]


### PR DESCRIPTION
Broken off from #4648.

- I realised that by creating a type `arrows_with_codomain` I can avoid using `set (over X)` entirely (the bit I was missing was that `derive complete_lattice` works on the new type even though it wasn't inferred on the pi-type), so I changed sieves to use that instead. 
- I added constructors for special arrow sets. The definitions of `singleton_arrow` and `pullback_arrows` look a bit dubious because of the equality and `eq_to_hom` stuff; I don't love that either so if there's a suggestion on how to achieve the same things (in particular stating (1) and (3) from: https://stacks.math.columbia.edu/tag/00VH, as well as a complete lattice structure) I'd be happy to consider.
- I added a coercion so we can write `S f` instead of `S.arrows f` for sieves.