### PR TITLE
[Merged by Bors] - refactor(algebra/add_torsor): define pointwise `-ᵥ` and `+ᵥ` on sets

### DIFF
--- a/src/algebra/add_torsor.lean
+++ b/src/algebra/add_torsor.lean
@@ -6,6 +6,7 @@ Authors: Joseph Myers, Yury Kudryashov.
 import algebra.group.prod
 import algebra.group.type_tags
 import algebra.group.pi
+import algebra.pointwise
 import data.equiv.basic
 import data.set.finite
 
@@ -229,29 +230,68 @@ element. -/
 lemma eq_vadd_iff_vsub_eq (p1 : P) (g : G) (p2 : P) : p1 = g +ᵥ p2 ↔ p1 -ᵥ p2 = g :=
 ⟨λ h, h.symm ▸ vadd_vsub _ _, λ h, h ▸ (vsub_vadd _ _).symm⟩
 
-/-- The pairwise differences of a set of points. -/
-def vsub_set (s : set P) : set G := set.image2 (-ᵥ) s s
+namespace set
 
-/-- `vsub_set` of an empty set. -/
-@[simp] lemma vsub_set_empty : vsub_set (∅ : set P) = ∅ :=
-set.image2_empty_left
+instance has_vsub : has_vsub (set G) (set P) := ⟨set.image2 (-ᵥ)⟩
 
-/-- `vsub_set` of a single point. -/
-@[simp] lemma vsub_set_singleton (p : P) : vsub_set ({p} : set P) = {(0:G)} :=
-by simp [vsub_set]
+section vsub
 
-/-- `vsub_set` of a finite set is finite. -/
-lemma vsub_set_finite_of_finite {s : set P} (h : set.finite s) : set.finite (vsub_set s) :=
-h.image2 _ h
+variables (s t : set P)
 
-/-- Each pairwise difference is in the `vsub_set`. -/
-lemma vsub_mem_vsub_set {p1 p2 : P} {s : set P} (hp1 : p1 ∈ s) (hp2 : p2 ∈ s) :
-  (p1 -ᵥ p2) ∈ vsub_set s :=
-set.mem_image2_of_mem hp1 hp2
+@[simp] lemma vsub_empty : s -ᵥ ∅ = ∅ := set.image2_empty_right
 
-/-- `vsub_set` is contained in `vsub_set` of a larger set. -/
-lemma vsub_set_mono {s1 s2 : set P} (h : s1 ⊆ s2) : vsub_set s1 ⊆ vsub_set s2 :=
-set.image2_subset h h
+@[simp] lemma empty_vsub : ∅ -ᵥ s = ∅ := set.image2_empty_left
+
+@[simp] lemma singleton_vsub (p : P) : {p} -ᵥ s = ((-ᵥ) p) '' s :=
+image2_singleton_left
+
+@[simp] lemma vsub_singleton (p : P) : s -ᵥ {p} = (-ᵥ p) '' s :=
+image2_singleton_right
+
+@[simp] lemma singleton_vsub_self (p : P) : ({p} : set P) -ᵥ {p} = {(0:G)} :=
+by simp
+
+variables {s t}
+
+/-- `vsub` of a finite set is finite. -/
+lemma finite.vsub (hs : finite s) (ht : finite t) : finite (s -ᵥ t) :=
+hs.image2 _ ht
+
+/-- Each pairwise difference is in the `vsub` set. -/
+lemma vsub_mem_vsub {ps pt : P} (hs : ps ∈ s) (ht : pt ∈ t) :
+  (ps -ᵥ pt) ∈ s -ᵥ t :=
+mem_image2_of_mem hs ht
+
+/-- `s -ᵥ t` is monotone in both arguments. -/
+@[mono] lemma vsub_subset_vsub {s' t' : set P} (hs : s ⊆ s') (ht : t ⊆ t') :
+  s -ᵥ t ⊆ s' -ᵥ t' :=
+image2_subset hs ht
+
+lemma vsub_self_mono (h : s ⊆ t) : s -ᵥ s ⊆ t -ᵥ t := vsub_subset_vsub h h
+
+lemma vsub_subset_iff {u : set G} : s -ᵥ t ⊆ u ↔ ∀ (x ∈ s) (y ∈ t), x -ᵥ y ∈ u :=
+image2_subset_iff
+
+end vsub
+
+instance add_action : add_action (set G) (set P) :=
+{ vadd := set.image2 (+ᵥ),
+  zero_vadd' := λ s, by simp [← singleton_zero],
+  vadd_assoc' := λ s t p, by { symmetry, apply image2_assoc, intros, symmetry, apply vadd_assoc } }
+
+variables {s s' : set G} {t t' : set P}
+
+@[mono] lemma vadd_subset_vadd (hs : s ⊆ s') (ht : t ⊆ t') : s +ᵥ t ⊆ s' +ᵥ t' :=
+image2_subset hs ht
+
+@[simp] lemma vadd_singleton (s : set G) (p : P) : s +ᵥ {p} = (+ᵥ p) '' s := image2_singleton_right
+
+@[simp] lemma singleton_vadd (v : G) (s : set P) : ({v} : set G) +ᵥ s = ((+ᵥ) v) '' s :=
+image2_singleton_left
+
+lemma finite.vadd (hs : finite s) (ht : finite t) : finite (s +ᵥ t) := hs.image2 _ ht
+
+end set
 
 @[simp] lemma vadd_vsub_vadd_cancel_right (v₁ v₂ : G) (p : P) :
   (v₁ +ᵥ p) -ᵥ (v₂ +ᵥ p) = v₁ - v₂ :=

--- a/src/algebra/module/submodule.lean
+++ b/src/algebra/module/submodule.lean
@@ -110,6 +110,8 @@ instance : has_zero p := ⟨⟨0, zero_mem _⟩⟩
 instance : inhabited p := ⟨0⟩
 instance : has_scalar R p := ⟨λ c x, ⟨c • x.1, smul_mem _ c x.2⟩⟩
 
+protected lemma nonempty : (p : set M).nonempty := ⟨0, p.zero_mem⟩
+
 @[simp] lemma mk_eq_zero {x} (h : x ∈ p) : (⟨x, h⟩ : p) = 0 ↔ x = 0 := subtype.ext_iff_val
 
 variables {p}

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -126,8 +126,7 @@ lemma singleton_mul_singleton [has_mul α] : ({a} : set α) * {b} = {a * b} := i
 
 @[to_additive set.add_semigroup]
 instance [semigroup α] : semigroup (set α) :=
-{ mul_assoc :=
-    by { intros, simp only [← image2_mul, image2_image2_left, image2_image2_right, mul_assoc] },
+{ mul_assoc := λ _ _ _, image2_assoc mul_assoc,
   ..set.has_mul }
 
 @[to_additive set.add_monoid]

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1841,6 +1841,10 @@ lemma forall_prod_set {p : α × β → Prop} :
   (∀ x ∈ s.prod t, p x) ↔ ∀ (x ∈ s) (y ∈ t), p (x, y) :=
 prod_subset_iff
 
+lemma exists_prod_set {p : α × β → Prop} :
+  (∃ x ∈ s.prod t, p x) ↔ ∃ (x ∈ s) (y ∈ t), p (x, y) :=
+by simp [and_assoc]
+
 @[simp] theorem prod_empty : s.prod ∅ = (∅ : set (α × β)) :=
 by { ext, simp }
 
@@ -2200,6 +2204,14 @@ lemma mem_image2_iff (hf : injective2 f) : f a b ∈ image2 f s t ↔ a ∈ s �
 lemma image2_subset (hs : s ⊆ s') (ht : t ⊆ t') : image2 f s t ⊆ image2 f s' t' :=
 by { rintro _ ⟨a, b, ha, hb, rfl⟩, exact mem_image2_of_mem (hs ha) (ht hb) }
 
+lemma forall_image2_iff {p : γ → Prop} :
+  (∀ z ∈ image2 f s t, p z) ↔ ∀ (x ∈ s) (y ∈ t), p (f x y) :=
+⟨λ h x hx y hy, h _ ⟨x, y, hx, hy, rfl⟩, λ h z ⟨x, y, hx, hy, hz⟩, hz ▸ h x hx y hy⟩
+
+lemma image2_subset_iff {u : set γ} :
+  image2 f s t ⊆ u ↔ ∀ (x ∈ s) (y ∈ t), f x y ∈ u :=
+forall_image2_iff
+
 lemma image2_union_left : image2 f (s ∪ s') t = image2 f s t ∪ image2 f s' t :=
 begin
   ext c, split,
@@ -2226,10 +2238,10 @@ by { rintro _ ⟨a, b, ha, ⟨h1b, h2b⟩, rfl⟩, split; exact ⟨_, _, ‹_›
 @[simp] lemma image2_singleton : image2 f {a} {b} = {f a b} :=
 ext $ λ x, by simp [eq_comm]
 
-lemma image2_singleton_left : image2 f {a} t = f a '' t :=
+@[simp] lemma image2_singleton_left : image2 f {a} t = f a '' t :=
 ext $ λ x, by simp
 
-lemma image2_singleton_right : image2 f s {b} = (λ a, f a b) '' s :=
+@[simp] lemma image2_singleton_right : image2 f s {b} = (λ a, f a b) '' s :=
 ext $ λ x, by simp
 
 @[congr] lemma image2_congr (h : ∀ (a ∈ s) (b ∈ t), f a b = f' a b) :
@@ -2274,6 +2286,11 @@ begin
   { rintro ⟨a, _, ha, ⟨b, c, hb, hc, rfl⟩, rfl⟩, refine ⟨a, b, c, ha, hb, hc, rfl⟩ },
   { rintro ⟨a, b, c, ha, hb, hc, rfl⟩, refine ⟨a, _, ha, ⟨b, c, hb, hc, rfl⟩, rfl⟩ }
 end
+
+lemma image2_assoc {ε'} {f : δ → γ → ε} {g : α → β → δ} {f' : α → ε' → ε} {g' : β → γ → ε'}
+  (h_assoc : ∀ a b c, f (g a b) c = f' a (g' b c)) :
+  image2 f (image2 g s t) u = image2 f' s (image2 g' t u) :=
+by simp only [image2_image2_left, image2_image2_right, h_assoc]
 
 lemma image_image2 (f : α → β → γ) (g : γ → δ) :
   g '' image2 f s t = image2 (λ a b, g (f a b)) s t :=

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -2208,7 +2208,7 @@ lemma forall_image2_iff {p : γ → Prop} :
   (∀ z ∈ image2 f s t, p z) ↔ ∀ (x ∈ s) (y ∈ t), p (f x y) :=
 ⟨λ h x hx y hy, h _ ⟨x, y, hx, hy, rfl⟩, λ h z ⟨x, y, hx, hy, hz⟩, hz ▸ h x hx y hy⟩
 
-lemma image2_subset_iff {u : set γ} :
+@[simp] lemma image2_subset_iff {u : set γ} :
   image2 f s t ⊆ u ↔ ∀ (x ∈ s) (y ∈ t), f x y ∈ u :=
 forall_image2_iff
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -2235,14 +2235,13 @@ by { rintro _ ⟨a, b, ⟨h1a, h2a⟩, hb, rfl⟩, split; exact ⟨_, _, ‹_›
 lemma image2_inter_subset_right : image2 f s (t ∩ t') ⊆ image2 f s t ∩ image2 f s t' :=
 by { rintro _ ⟨a, b, ha, ⟨h1b, h2b⟩, rfl⟩, split; exact ⟨_, _, ‹_›, ‹_›, rfl⟩ }
 
-@[simp] lemma image2_singleton : image2 f {a} {b} = {f a b} :=
-ext $ λ x, by simp [eq_comm]
-
 @[simp] lemma image2_singleton_left : image2 f {a} t = f a '' t :=
 ext $ λ x, by simp
 
 @[simp] lemma image2_singleton_right : image2 f s {b} = (λ a, f a b) '' s :=
 ext $ λ x, by simp
+
+lemma image2_singleton : image2 f {a} {b} = {f a b} := by simp
 
 @[congr] lemma image2_congr (h : ∀ (a ∈ s) (b ∈ t), f a b = f' a b) :
   image2 f s t = image2 f' s t :=

--- a/src/geometry/euclidean/monge_point.lean
+++ b/src/geometry/euclidean/monge_point.lean
@@ -252,8 +252,9 @@ opposite edge (in 2 dimensions, this is the same as an altitude).
 This definition is only intended to be used when `i₁ ≠ i₂`. -/
 def monge_plane {n : ℕ} (s : simplex ℝ P (n + 2)) (i₁ i₂ : fin (n + 3)) :
   affine_subspace ℝ P :=
-mk' (({i₁, i₂}ᶜ : finset (fin (n + 3))).centroid ℝ s.points) (submodule.span ℝ {s.points i₁ -ᵥ s.points i₂}).orthogonal ⊓
-  affine_span ℝ (set.range s.points)
+mk' (({i₁, i₂}ᶜ : finset (fin (n + 3))).centroid ℝ s.points)
+  (submodule.span ℝ {s.points i₁ -ᵥ s.points i₂}).orthogonal ⊓
+    affine_span ℝ (set.range s.points)
 
 /-- The definition of a Monge plane. -/
 lemma monge_plane_def {n : ℕ} (s : simplex ℝ P (n + 2)) (i₁ i₂ : fin (n + 3)) :

--- a/src/linear_algebra/affine_space/basic.lean
+++ b/src/linear_algebra/affine_space/basic.lean
@@ -102,6 +102,8 @@ space, or more generally a module. We omit the arguments `(k : Type*) [ring k] [
 in the type synonym itself to simplify type class search. -/
 notation `affine_space` := add_torsor
 
+open set
+
 section
 
 variables (k : Type*) {V : Type*} {P : Type*} [ring k] [add_comm_group V] [module k V]
@@ -110,21 +112,21 @@ include V
 
 /-- The submodule spanning the differences of a (possibly empty) set
 of points. -/
-def vector_span (s : set P) : submodule k V := submodule.span k (vsub_set s)
+def vector_span (s : set P) : submodule k V := submodule.span k (s -ᵥ s)
 
 /-- The definition of `vector_span`, for rewriting. -/
-lemma vector_span_def (s : set P) : vector_span k s = submodule.span k (vsub_set s) :=
+lemma vector_span_def (s : set P) : vector_span k s = submodule.span k (s -ᵥ s) :=
 rfl
 
 /-- `vector_span` is monotone. -/
 lemma vector_span_mono {s₁ s₂ : set P} (h : s₁ ⊆ s₂) : vector_span k s₁ ≤ vector_span k s₂ :=
-submodule.span_mono (vsub_set_mono h)
+submodule.span_mono (vsub_self_mono h)
 
 variables (P)
 
 /-- The `vector_span` of the empty set is `⊥`. -/
 @[simp] lemma vector_span_empty : vector_span k (∅ : set P) = (⊥ : submodule k V) :=
-by rw [vector_span_def, vsub_set_empty, submodule.span_empty]
+by rw [vector_span_def, vsub_empty, submodule.span_empty]
 
 variables {P}
 
@@ -132,14 +134,14 @@ variables {P}
 @[simp] lemma vector_span_singleton (p : P) : vector_span k ({p} : set P) = ⊥ :=
 by simp [vector_span_def]
 
-/-- The `vsub_set` lies within the `vector_span`. -/
-lemma vsub_set_subset_vector_span (s : set P) : vsub_set s ⊆ vector_span k s :=
+/-- The `s -ᵥ s` lies within the `vector_span k s`. -/
+lemma vsub_set_subset_vector_span (s : set P) : s -ᵥ s ⊆ ↑(vector_span k s) :=
 submodule.subset_span
 
 /-- Each pairwise difference is in the `vector_span`. -/
 lemma vsub_mem_vector_span {s : set P} {p1 p2 : P} (hp1 : p1 ∈ s) (hp2 : p2 ∈ s) :
   p1 -ᵥ p2 ∈ vector_span k s :=
-vsub_set_subset_vector_span k s (vsub_mem_vsub_set hp1 hp2)
+vsub_set_subset_vector_span k s (vsub_mem_vsub hp1 hp2)
 
 /-- The points in the affine span of a (possibly empty) set of
 points. Use `affine_span` instead to get an `affine_subspace k P`. -/
@@ -252,17 +254,17 @@ in the definition of `submodule.span`) can be used in the proof of
 that proof. -/
 def direction_of_nonempty {s : affine_subspace k P} (h : (s : set P).nonempty) :
   submodule k V :=
-{ carrier := vsub_set (s : set P),
+{ carrier := (s : set P) -ᵥ s,
   zero_mem' := begin
     cases h with p hp,
-    exact (vsub_self p) ▸ vsub_mem_vsub_set hp hp
+    exact (vsub_self p) ▸ vsub_mem_vsub hp hp
   end,
   add_mem' := begin
     intros a b ha hb,
     rcases ha with ⟨p1, p2, hp1, hp2, rfl⟩,
     rcases hb with ⟨p3, p4, hp3, hp4, rfl⟩,
     rw [←vadd_vsub_assoc],
-    refine vsub_mem_vsub_set _ hp4,
+    refine vsub_mem_vsub _ hp4,
     convert s.smul_vsub_vadd_mem 1 hp1 hp2 hp3,
     rw one_smul
   end,
@@ -270,7 +272,7 @@ def direction_of_nonempty {s : affine_subspace k P} (h : (s : set P).nonempty) :
     intros c v hv,
     rcases hv with ⟨p1, p2, hp1, hp2, rfl⟩,
     rw [←vadd_vsub (c • (p1 -ᵥ p2)) p2],
-    refine vsub_mem_vsub_set _ hp2,
+    refine vsub_mem_vsub _ hp2,
     exact s.smul_vsub_vadd_mem c hp1 hp2 hp2
   end }
 
@@ -283,7 +285,7 @@ le_antisymm (vsub_set_subset_vector_span k s) (submodule.span_le.2 set.subset.rf
 /-- The set of vectors in the direction of a nonempty affine subspace
 is given by `vsub_set`. -/
 lemma coe_direction_eq_vsub_set {s : affine_subspace k P} (h : (s : set P).nonempty) :
-  (s.direction : set V) = vsub_set (s : set P) :=
+  (s.direction : set V) = (s : set P) -ᵥ s :=
 direction_of_nonempty_eq_direction h ▸ rfl
 
 /-- A vector is in the direction of a nonempty affine subspace if and
@@ -739,8 +741,8 @@ lemma direction_inf (s1 s2 : affine_subspace k P) :
 begin
   repeat { rw [direction_eq_vector_span, vector_span_def] },
   exact le_inf
-    (Inf_le_Inf (λ p hp, set.subset.trans (vsub_set_mono (set.inter_subset_left _ _)) hp))
-    (Inf_le_Inf (λ p hp, set.subset.trans (vsub_set_mono (set.inter_subset_right _ _)) hp))
+    (Inf_le_Inf (λ p hp, trans (vsub_self_mono (inter_subset_left _ _)) hp))
+    (Inf_le_Inf (λ p hp, trans (vsub_self_mono (inter_subset_right _ _)) hp))
 end
 
 /-- If two affine subspaces have a point in common, the direction of
@@ -789,8 +791,8 @@ lemma sup_direction_le (s1 s2 : affine_subspace k P) :
 begin
   repeat { rw [direction_eq_vector_span, vector_span_def] },
   exact sup_le
-    (Inf_le_Inf (λ p hp, set.subset.trans (vsub_set_mono (le_sup_left : s1 ≤ s1 ⊔ s2)) hp))
-    (Inf_le_Inf (λ p hp, set.subset.trans (vsub_set_mono (le_sup_right : s2 ≤ s1 ⊔ s2)) hp))
+    (Inf_le_Inf (λ p hp, set.subset.trans (vsub_self_mono (le_sup_left : s1 ≤ s1 ⊔ s2)) hp))
+    (Inf_le_Inf (λ p hp, set.subset.trans (vsub_self_mono (le_sup_right : s2 ≤ s1 ⊔ s2)) hp))
 end
 
 /-- The sup of the directions of two nonempty affine subspaces with
@@ -865,7 +867,7 @@ variables (k : Type*) {V : Type*} {P : Type*} [ring k] [add_comm_group V] [modul
 variables {ι : Type*}
 include V
 
-open affine_subspace
+open affine_subspace set
 
 /-- The `vector_span` is the span of the pairwise subtractions with a
 given point on the left. -/

--- a/src/linear_algebra/affine_space/basic.lean
+++ b/src/linear_algebra/affine_space/basic.lean
@@ -706,7 +706,7 @@ variables (P)
 
 /-- The direction of `⊥` is the submodule `⊥`. -/
 @[simp] lemma direction_bot : (⊥ : affine_subspace k P).direction = ⊥ :=
-by rw [direction_eq_vector_span, bot_coe, vector_span_def, vsub_set_empty, submodule.span_empty]
+by rw [direction_eq_vector_span, bot_coe, vector_span_def, vsub_empty, submodule.span_empty]
 
 variables {k V P}
 
@@ -1075,8 +1075,8 @@ begin
     rw [direction_eq_vector_span, vector_span_def],
     exact Inf_le_Inf (λ p hp, set.subset.trans
       (set.singleton_subset_iff.2
-        (vsub_mem_vsub_set (mem_span_points k p2 _ (set.mem_union_right _ hp2))
-                           (mem_span_points k p1 _ (set.mem_union_left _ hp1))))
+        (vsub_mem_vsub (mem_span_points k p2 _ (set.mem_union_right _ hp2))
+                       (mem_span_points k p1 _ (set.mem_union_left _ hp1))))
       hp) }
 end
 

--- a/src/linear_algebra/affine_space/finite_dimensional.lean
+++ b/src/linear_algebra/affine_space/finite_dimensional.lean
@@ -35,7 +35,7 @@ open affine_subspace finite_dimensional vector_space
 /-- The `vector_span` of a finite set is finite-dimensional. -/
 lemma finite_dimensional_vector_span_of_finite {s : set P} (h : set.finite s) :
   finite_dimensional k (vector_span k s) :=
-span_of_finite k $ vsub_set_finite_of_finite h
+span_of_finite k $ h.vsub h
 
 /-- The `vector_span` of a family indexed by a `fintype` is
 finite-dimensional. -/


### PR DESCRIPTION
This seems more natural than `vsub_set` to me.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
