### PR TITLE
[Merged by Bors] - feat(tactic/rcases): add `rintro (x y : t)` support

### DIFF
--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -685,11 +685,11 @@ meta def rintro_patt_parse : bool → parser (listΠ rcases_patt)
   (do tk ":", e ← texpr, pure (pats.map (λ p, rcases_patt.typed p e))) <|>
   pure pats
 
-/-- Syntax for a `rintro` pattern: `('?' (: n)?) | patt*`. -/
+/-- Syntax for a `rintro` pattern: `('?' (: n)?) | rintro_patt`. -/
 meta def rintro_parse : parser (listΠ rcases_patt ⊕ nat) :=
 with_desc "('?' (: n)?) | patt*" $
 (tk "?" >> sum.inr <$> rcases_parse_depth) <|>
-(sum.inl ∘ list.join) <$> (rintro_patt_parse tt)*
+sum.inl <$> rintro_patt_parse ff
 
 namespace interactive
 open interactive interactive.types expr

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -654,7 +654,6 @@ with_desc "('?' expr (: n)?) | ((h :)? expr (with patt)?)" $ do
     pure $ rcases_args.hint p depth
   end
 
-
 /--
 `rintro_patt_parse` is like `rcases_patt_parse`, but is used for parsing top level
 `rintro` patterns, which allow sequences like `(x y : t)` in addition to simple `rcases` patterns.

--- a/test/rcases.lean
+++ b/test/rcases.lean
@@ -44,6 +44,13 @@ begin
   { guard_hyp c : γ, trivial }
 end
 
+example : cond ff ℕ ℤ → cond tt ℤ ℕ → (ℕ ⊕ unit) → true :=
+begin
+  rintro (x y : ℤ) (z | u),
+  { guard_hyp x : ℤ, guard_hyp y : ℤ, guard_hyp z : ℕ, trivial },
+  { guard_hyp x : ℤ, guard_hyp y : ℤ, guard_hyp u : unit, trivial }
+end
+
 example (x y : ℕ) (h : x = y) : true :=
 begin
   rcases x with _|⟨⟩|z,

--- a/test/rcases.lean
+++ b/test/rcases.lean
@@ -182,3 +182,7 @@ begin
     (do lc ← tactic.local_context, guard lc.empty),
     trivial },
 end
+
+example : bool → false → true
+| ff := by rintro ⟨⟩
+| tt := by rintro ⟨⟩


### PR DESCRIPTION
As requested on Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/rintros/near/213999254