### PR TITLE
refactor(analysis/*): make Type argument of continuous_linear_map.lmul_* implicit

### DIFF
--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -96,10 +96,12 @@ variables {R}
 
 variables (M N P Q)
 protected theorem mul_assoc : (M * N) * P = M * (N * P) :=
-le_antisymm (mul_le.2 $ λ mn hmn p hp, suffices M * N ≤ (M * (N * P)).comap ((algebra.lmul R A).flip p), from this hmn,
+le_antisymm (mul_le.2 $ λ mn hmn p hp,
+  suffices M * N ≤ (M * (N * P)).comap (algebra.lmul_right R p), from this hmn,
   mul_le.2 $ λ m hm n hn, show m * n * p ∈ M * (N * P), from
   (mul_assoc m n p).symm ▸ mul_mem_mul hm (mul_mem_mul hn hp))
-(mul_le.2 $ λ m hm np hnp, suffices N * P ≤ (M * N * P).comap (algebra.lmul R A m), from this hnp,
+(mul_le.2 $ λ m hm np hnp,
+  suffices N * P ≤ (M * N * P).comap (algebra.lmul_left R m), from this hnp,
   mul_le.2 $ λ n hn p hp, show m * (n * p) ∈ M * N * P, from
   mul_assoc m n p ▸ mul_mem_mul (mul_mem_mul hm hn) hp)
 
@@ -240,7 +242,7 @@ lemma smul_le_smul {s t : set_semiring A} {M N : submodule R A} (h₁ : s.down �
 mul_le_mul (span_mono h₁) h₂
 
 lemma smul_singleton (a : A) (M : submodule R A) :
-  ({a} : set A).up • M = M.map (lmul_left _ _ a) :=
+  ({a} : set A).up • M = M.map (lmul_left _ a) :=
 begin
   conv_lhs {rw ← span_eq M},
   change span _ _ * span _ _ = _,

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -2150,7 +2150,7 @@ open normed_ring continuous_linear_map ring
 /-- At an invertible element `x` of a normed algebra `R`, the Fréchet derivative of the inversion
 operation is the linear map `λ t, - x⁻¹ * t * x⁻¹`. -/
 lemma has_fderiv_at_ring_inverse (x : units R) :
-  has_fderiv_at ring.inverse (- (lmul_right 𝕜 R ↑x⁻¹).comp (lmul_left 𝕜 R ↑x⁻¹)) x :=
+  has_fderiv_at ring.inverse (- (lmul_right 𝕜 (↑x⁻¹ : R)).comp (lmul_left 𝕜 ↑x⁻¹)) x :=
 begin
   have h_is_o : is_o (λ (t : R), inverse (↑x + t) - ↑x⁻¹ + ↑x⁻¹ * t * ↑x⁻¹)
     (λ (t : R), t) (𝓝 0),
@@ -2174,7 +2174,7 @@ lemma differentiable_at_inverse (x : units R) : differentiable_at 𝕜 (@ring.in
 (has_fderiv_at_ring_inverse x).differentiable_at
 
 lemma fderiv_inverse (x : units R) :
-  fderiv 𝕜 (@ring.inverse R _) x = - (lmul_right 𝕜 R ↑x⁻¹).comp (lmul_left 𝕜 R ↑x⁻¹) :=
+  fderiv 𝕜 (@ring.inverse R _) x = - (lmul_right 𝕜 ↑x⁻¹).comp (lmul_left 𝕜 ↑x⁻¹) :=
 (has_fderiv_at_ring_inverse x).fderiv
 
 end algebra_inverse

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -2335,7 +2335,7 @@ begin
         exact (inverse_continuous_at x').continuous_within_at },
       { simp [ftaylor_series_within] } } },
   { apply times_cont_diff_at_succ_iff_has_fderiv_at.mpr,
-    refine ⟨λ (x : R), - lmul_left_right 𝕜 R (inverse x, inverse x), _, _⟩,
+    refine ⟨λ (x : R), - lmul_left_right 𝕜 (inverse x, inverse x), _, _⟩,
     { refine ⟨{y : R | is_unit y}, x.nhds, _⟩,
       intros y hy,
       cases mem_set_of_eq.mp hy with y' hy',

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -402,11 +402,11 @@ variables (𝕜)
 /-- The function `lmul_left_right : 𝕜' × 𝕜' → (𝕜' →L[𝕜] 𝕜')` is a bounded bilinear map. -/
 lemma continuous_linear_map.lmul_left_right_is_bounded_bilinear
   (𝕜' : Type*) [normed_ring 𝕜'] [normed_algebra 𝕜 𝕜'] :
-  is_bounded_bilinear_map 𝕜 (continuous_linear_map.lmul_left_right 𝕜 𝕜') :=
+  is_bounded_bilinear_map 𝕜 (@continuous_linear_map.lmul_left_right 𝕜 _ 𝕜 _ _) :=
 { add_left := λ v₁ v₂ w, by {ext t, simp [add_comm, add_mul]},
-  smul_left := λ c v w, by {ext, simp },
+  smul_left := λ c v w, by {ext, simp [mul_assoc] },
   add_right := λ v w₁ w₂, by {ext t, simp [add_comm, mul_add]},
-  smul_right := λ c v w, by {ext, simp },
+  smul_right := λ c v w, by {ext, simp [mul_assoc, mul_left_comm], },
   bound := begin
     refine ⟨1, by linarith, _⟩,
     intros v w,

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -680,7 +680,7 @@ def apply (v : E) : (E →L[𝕜] F) →L[𝕜] F :=
 variables {𝕜 F}
 
 section multiplication_linear
-variables (𝕜) (𝕜' : Type*) [normed_ring 𝕜'] [normed_algebra 𝕜 𝕜']
+variables (𝕜) {𝕜' : Type*} [normed_ring 𝕜'] [normed_algebra 𝕜 𝕜']
 
 /-- Left-multiplication in a normed algebra, considered as a continuous linear map. -/
 def lmul_left : 𝕜' → (𝕜' →L[𝕜] 𝕜') :=
@@ -695,12 +695,12 @@ def lmul_right : 𝕜' → (𝕜' →L[𝕜] 𝕜') :=
 /-- Simultaneous left- and right-multiplication in a normed algebra, considered as a continuous
 linear map. -/
 def lmul_left_right (vw : 𝕜' × 𝕜') : 𝕜' →L[𝕜] 𝕜' :=
-(lmul_right 𝕜 𝕜' vw.2).comp (lmul_left 𝕜 𝕜' vw.1)
+(lmul_right 𝕜 vw.2).comp (lmul_left 𝕜 vw.1)
 
-@[simp] lemma lmul_left_apply (x y : 𝕜') : lmul_left 𝕜 𝕜' x y = x * y := rfl
-@[simp] lemma lmul_right_apply (x y : 𝕜') : lmul_right 𝕜 𝕜' x y = y * x := rfl
+@[simp] lemma lmul_left_apply (x y : 𝕜') : lmul_left 𝕜 x y = x * y := rfl
+@[simp] lemma lmul_right_apply (x y : 𝕜') : lmul_right 𝕜 x y = y * x := rfl
 @[simp] lemma lmul_left_right_apply (vw : 𝕜' × 𝕜') (x : 𝕜') :
-  lmul_left_right 𝕜 𝕜' vw x = vw.1 * x * vw.2 := rfl
+  lmul_left_right 𝕜 vw x = vw.1 * x * vw.2 := rfl
 
 end multiplication_linear
 
@@ -903,22 +903,21 @@ continuous_linear_equiv.uniform_embedding
 namespace continuous_linear_map
 variables (𝕜) (𝕜' : Type*) [normed_ring 𝕜'] [normed_algebra 𝕜 𝕜']
 
-@[simp] lemma lmul_left_norm (v : 𝕜') : ∥lmul_left 𝕜 𝕜' v∥ = ∥v∥ :=
+@[simp] lemma lmul_left_norm (v : 𝕜') : ∥lmul_left 𝕜 v∥ = ∥v∥ :=
 begin
   refine le_antisymm _ _,
   { exact linear_map.mk_continuous_norm_le _ (norm_nonneg v) _ },
-  { simpa [@normed_algebra.norm_one 𝕜 _ 𝕜' _ _] using le_op_norm (lmul_left 𝕜 𝕜' v) (1:𝕜') }
+  { simpa [@normed_algebra.norm_one 𝕜 _ 𝕜' _ _] using le_op_norm (lmul_left 𝕜 v) (1:𝕜') }
 end
 
-@[simp] lemma lmul_right_norm (v : 𝕜') : ∥lmul_right 𝕜 𝕜' v∥ = ∥v∥ :=
+@[simp] lemma lmul_right_norm (v : 𝕜') : ∥lmul_right 𝕜 v∥ = ∥v∥ :=
 begin
   refine le_antisymm _ _,
   { exact linear_map.mk_continuous_norm_le _ (norm_nonneg v) _ },
-  { simpa [@normed_algebra.norm_one 𝕜 _ 𝕜' _ _] using le_op_norm (lmul_right 𝕜 𝕜' v) (1:𝕜') }
+  { simpa [@normed_algebra.norm_one 𝕜 _ 𝕜' _ _] using le_op_norm (lmul_right 𝕜 v) (1:𝕜') }
 end
 
-lemma lmul_left_right_norm_le (vw : 𝕜' × 𝕜') :
-  ∥lmul_left_right 𝕜 𝕜' vw∥ ≤ ∥vw.1∥ * ∥vw.2∥ :=
-by simpa [mul_comm] using op_norm_comp_le (lmul_right 𝕜 𝕜' vw.2) (lmul_left 𝕜 𝕜' vw.1)
+lemma lmul_left_right_norm_le (vw : 𝕜' × 𝕜') : ∥lmul_left_right 𝕜 vw∥ ≤ ∥vw.1∥ * ∥vw.2∥ :=
+by simpa [mul_comm] using op_norm_comp_le (lmul_right 𝕜 vw.2) (lmul_left 𝕜 vw.1)
 
 end continuous_linear_map

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -684,12 +684,12 @@ variables (𝕜) (𝕜' : Type*) [normed_ring 𝕜'] [normed_algebra 𝕜 𝕜']
 
 /-- Left-multiplication in a normed algebra, considered as a continuous linear map. -/
 def lmul_left : 𝕜' → (𝕜' →L[𝕜] 𝕜') :=
-λ x, (algebra.lmul_left 𝕜 𝕜' x).mk_continuous ∥x∥
+λ x, (algebra.lmul_left 𝕜 x).mk_continuous ∥x∥
 (λ y, by {rw algebra.lmul_left_apply, exact norm_mul_le x y})
 
 /-- Right-multiplication in a normed algebra, considered as a continuous linear map. -/
 def lmul_right : 𝕜' → (𝕜' →L[𝕜] 𝕜') :=
-λ x, (algebra.lmul_right 𝕜 𝕜' x).mk_continuous ∥x∥
+λ x, (algebra.lmul_right 𝕜 x).mk_continuous ∥x∥
 (λ y, by {rw [algebra.lmul_right_apply, mul_comm], exact norm_mul_le y x})
 
 /-- Simultaneous left- and right-multiplication in a normed algebra, considered as a continuous

--- a/src/category_theory/monoidal/internal/Module.lean
+++ b/src/category_theory/monoidal/internal/Module.lean
@@ -90,7 +90,7 @@ Converting a bundled algebra to a monoid object in `Module R`.
 def inverse_obj (A : Algebra.{u} R) : Mon_ (Module.{u} R) :=
 { X := Module.of R A,
   one := algebra.linear_map R A,
-  mul := algebra.lmul' R A,
+  mul := @algebra.lmul' R A _ _ _,
   one_mul' :=
   begin
     ext x,
@@ -112,8 +112,9 @@ def inverse_obj (A : Algebra.{u} R) : Mon_ (Module.{u} R) :=
     dsimp,
     apply tensor_product.induction_on xy,
     { simp only [linear_map.map_zero, tensor_product.zero_tmul], },
-    { intros x y, dsimp, simp [mul_assoc], },
-    { intros x y hx hy, dsimp, simp [tensor_product.add_tmul, hx, hy], },
+    { intros x y, dsimp, simp only [mul_assoc, algebra.lmul'_apply], },
+    { intros x y hx hy, dsimp,
+      simp only [tensor_product.add_tmul, hx, hy, map_add], },
   end }
 
 /--

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -386,15 +386,24 @@ def applyₗ (v : M) : (M →ₗ[R] M₂) →ₗ[R] M₂ :=
 
 end comm_semiring
 
+section semiring
+
+variables [semiring R] [add_comm_monoid M] [semimodule R M]
+
+instance endomorphism_semiring : semiring (M →ₗ[R] M) :=
+by refine {mul := (*), one := 1, ..linear_map.add_comm_monoid, ..};
+  { intros, apply linear_map.ext, simp {proj := ff} }
+
+@[simp] lemma mul_apply (f g : M →ₗ[R] M) (x : M) : (f * g) x = f (g x) := rfl
+
+end semiring
+
 section ring
 
 variables [ring R] [add_comm_group M] [semimodule R M]
 
 instance endomorphism_ring : ring (M →ₗ[R] M) :=
-by refine {mul := (*), one := 1, ..linear_map.add_comm_group, ..};
-  { intros, apply linear_map.ext, simp {proj := ff} }
-
-@[simp] lemma mul_apply (f g : M →ₗ[R] M) (x : M) : (f * g) x = f (g x) := rfl
+{ ..linear_map.endomorphism_semiring, ..linear_map.add_comm_group }
 
 end ring
 

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -808,10 +808,10 @@ section
 noncomputable def field_of_finite_dimensional (F K : Type*) [field F] [integral_domain K]
   [algebra F K] [finite_dimensional F K] : field K :=
 { inv := λ x, if H : x = 0 then 0 else classical.some $
-    (show function.surjective (algebra.lmul_left F K x), from
+    (show function.surjective (algebra.lmul_left F x), from
       linear_map.injective_iff_surjective.1 $ λ _ _, (mul_right_inj' H).1) 1,
   mul_inv_cancel := λ x hx, show x * dite _ _ _ = _, by { rw dif_neg hx,
-    exact classical.some_spec ((show function.surjective (algebra.lmul_left F K x), from
+    exact classical.some_spec ((show function.surjective (algebra.lmul_left F x), from
       linear_map.injective_iff_surjective.1 $ λ _ _, (mul_right_inj' hx).1) 1) },
   inv_zero := dif_pos rfl,
   .. ‹integral_domain K› }


### PR DESCRIPTION
Not sure if this is a good idea... but it seemed like a natural follow-up of #4724


---

- [x] depends on: #4724

<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->