### PR TITLE
[Merged by Bors] - refactor(*): use is_scalar_tower instead of restrict_scalars

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1197,7 +1197,7 @@ corresponding to `V`, an `S`-submodule of the original `S`-module.
 def restrict_scalars (V : submodule A M) : submodule R M :=
 { carrier := V.carrier,
   zero_mem' := V.zero_mem,
-  smul_mem' := λ c m h, by { rw [algebra_compatible_smul A c m], exact V.smul_mem _ h },
+  smul_mem' := λ c m h, by { rw algebra_compatible_smul A c m, exact V.smul_mem _ h },
   add_mem' := λ x y hx hy, V.add_mem hx hy }
 
 @[simp]
@@ -1224,7 +1224,7 @@ lemma restrict_scalars_top : restrict_scalars R (⊤ : submodule A M) = ⊤ := r
 end submodule
 
 @[simp]
-lemma linear_map.restrict_scalars_ker (f : M →ₗ[A] N) :
+lemma linear_map.ker_restrict_scalars (f : M →ₗ[A] N) :
   (f.restrict_scalars R).ker = submodule.restrict_scalars R f.ker :=
 rfl
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1044,6 +1044,9 @@ variables {N : Type*} [add_comm_monoid N] [semimodule A N] [semimodule R N] [is_
 lemma algebra_compatible_smul (r : R) (m : M) : r • m = ((algebra_map R A) r) • m :=
 by rw [←(one_smul A m), ←smul_assoc, algebra.smul_def, mul_one, one_smul]
 
+@[simp] lemma algebra_map_smul (r : R) (m : M) : ((algebra_map R A) r) • m = r • m :=
+(algebra_compatible_smul A r m).symm
+
 variable {A}
 
 lemma smul_algebra_smul_comm (r : R) (a : A) (m : M) : a • r • m = r • a • m :=
@@ -1053,8 +1056,64 @@ by rw [algebra_compatible_smul A r (a • m), smul_smul, algebra.commutes, mul_s
   f (r • m) = r • f m :=
 by rw [algebra_compatible_smul A r m, linear_map.map_smul, ←algebra_compatible_smul A r (f m)]
 
-instance : has_coe (M →ₗ[A] N) (M →ₗ[R] N) :=
-⟨λ f, ⟨f.to_fun, λ x y, f.map_add' x y, λ r n, map_smul_eq_smul_map _ _ _⟩⟩
+namespace linear_map
+
+variables (R) {A M N}
+
+/-- The `R`-linear map induced by an `A`-linear map when `A` is an algebra over `R`. -/
+def restrict_scalars (f : M →ₗ[A] N) : M →ₗ[R] N :=
+{ to_fun := f,
+  map_add' := λ x y, f.map_add x y,
+  map_smul' := λ c x, map_smul_eq_smul_map _ _ _ }
+
+variables (R A M N)
+
+instance coe_is_scalar_tower : has_coe (M →ₗ[A] N) (M →ₗ[R] N) :=
+⟨restrict_scalars R⟩
+
+variables (R) {A M N}
+
+@[simp, norm_cast squash] lemma coe_restrict_scalars_eq_coe (f : M →ₗ[A] N) :
+  (f.restrict_scalars R : M → N) = f := rfl
+
+@[simp, norm_cast squash] lemma coe_coe_is_scalar_tower (f : M →ₗ[A] N) :
+  ((f : M →ₗ[R] N) : M → N) = f := rfl
+
+/-- `A`-linearly coerce a `R`-linear map from `M` to `A` to a function, given an algebra `A` over
+a commutative semiring `R` and `M` a semimodule over `R`. -/
+def lto_fun (R : Type u) (M : Type v) (A : Type w)
+  [comm_semiring R] [add_comm_monoid M] [semimodule R M] [comm_ring A] [algebra R A] :
+  (M →ₗ[R] A) →ₗ[A] (M → A) :=
+{ to_fun := linear_map.to_fun,
+  map_add' := λ f g, rfl,
+  map_smul' := λ c f, rfl }
+
+/--
+For `r : R`, and `f : M →ₗ[A] N` (where `A` is an `R`-algebra) we define
+`(r • f) m = f (r • m)`.
+-/
+instance algebra_has_scalar : has_scalar R (M →ₗ[A] N) :=
+{ smul := λ r f,
+  { to_fun := λ v, f (r • v),
+    map_add' := λ x y, by simp [smul_add],
+    map_smul' := λ s v, by simp [smul_smul, algebra.commutes, smul_algebra_smul_comm], } }
+
+/-- The `R`-module structure on `A`-linear maps, for `A` an `R`-algebra. -/
+instance algebra_module : semimodule R (M →ₗ[A] N) :=
+{ one_smul := λ f, by { ext v, simp only [(•), coe_mk, one_smul] },
+  mul_smul := λ r r' f, by { ext v, simp only [(•), mul_smul, coe_mk, map_smul_eq_smul_map] },
+  smul_zero := λ r, by { ext v, simp only [(•), coe_mk, zero_apply] },
+  smul_add := λ r f g, by { ext v, simp only [(•), coe_mk, add_apply] },
+  zero_smul := λ f, by { ext v, simp only [(•), coe_mk, zero_smul, map_zero, zero_apply] },
+  add_smul := λ r r' f, by { ext v, simp only [(•), add_smul, map_add, coe_mk, add_apply] } }
+
+variables {R A M N}
+@[simp]
+lemma algebra_module.smul_apply (c : R) (f : M →ₗ[A] N) (m : M) :
+  (c • f) m = (c • (f m) : N) :=
+by simp only [(•), coe_mk, map_smul_eq_smul_map]
+
+end linear_map
 
 end is_scalar_tower
 
@@ -1062,19 +1121,40 @@ section restrict_scalars
 /- In this section, we describe restriction of scalars: if `S` is an algebra over `R`, then
 `S`-modules are also `R`-modules. -/
 
-section semimodule
-
-variables (R : Type*) [comm_semiring R] (S : Type*) [semiring S] [algebra R S]
-variables (E : Type*) [add_comm_monoid E] [semimodule S E]
-variables {F : Type*} [add_comm_monoid F] [semimodule S F]
+section type_synonym
+variables (R A M : Type*)
 
 /--
-When `E` is a module over a ring `S`, and `S` is an algebra over `R`, then `E` inherits a
-module structure over `R`, called `module.restrict_scalars' R S E`.
-We do not register this as an instance as `S` can not be inferred.
+Warning: use this type synonym judiciously!
+The preferred way of working with an `A`-module `M` as `R`-module (where `A` is an `R`-algebra),
+is by `[module R M] [module A M] [is_scalar_tower R A M]`.
+
+When `M` is a module over a ring `A`, and `A` is an algebra over `R`, then `M` inherits a
+module structure over `R`, provided as a type synonym `module.restrict_scalars R A M := M`.
 -/
-def semimodule.restrict_scalars' : semimodule R E :=
-{ smul      := λ c x, (algebra_map R S c) • x,
+@[nolint unused_arguments]
+def restrict_scalars (R A M : Type*) : Type* := M
+
+instance [I : inhabited M] : inhabited (restrict_scalars R A M) := I
+
+instance [I : add_comm_monoid M] : add_comm_monoid (restrict_scalars R A M) := I
+
+instance [I : add_comm_group M] : add_comm_group (restrict_scalars R A M) := I
+
+instance restrict_scalars.module_orig [semiring A] [add_comm_monoid M] [I : semimodule A M] :
+  semimodule A (restrict_scalars R A M) := I
+
+variables [comm_semiring R] [semiring A] [algebra R A]
+variables [add_comm_monoid M] [semimodule A M]
+
+/--
+When `M` is a module over a ring `A`, and `A` is an algebra over `R`, then `M` inherits a
+module structure over `R`.
+
+The preferred way of setting this up is `[module R M] [module A M] [is_scalar_tower R A M]`.
+-/
+instance : semimodule R (restrict_scalars R A M) :=
+{ smul      := λ c x, (algebra_map R A c) • x,
   one_smul  := by simp,
   mul_smul  := by simp [mul_smul],
   smul_add  := by simp [smul_add],
@@ -1082,215 +1162,123 @@ def semimodule.restrict_scalars' : semimodule R E :=
   add_smul  := by simp [add_smul],
   zero_smul := by simp [zero_smul] }
 
-/--
-When `E` is a module over a ring `S`, and `S` is an algebra over `R`, then `E` inherits a
-module structure over `R`, provided as a type synonym `module.restrict_scalars R S E := E`.
+lemma restrict_scalars_smul_def (c : R) (x : restrict_scalars R A M) :
+  c • x = ((algebra_map R A c) • x : M) := rfl
 
-When the `R`-module structure on `E` is registered directly (using `module.restrict_scalars'` for
-instance, or for `S = ℂ` and `R = ℝ`), theorems on `module.restrict_scalars R S E` can be directly
-applied to `E` as these types are the same for the kernel.
--/
-@[nolint unused_arguments]
-def semimodule.restrict_scalars (R : Type*) (S : Type*) (E : Type*) : Type* := E
+instance : is_scalar_tower R A (restrict_scalars R A M) :=
+⟨λ r A M, by { rw [algebra.smul_def, mul_smul], refl }⟩
 
-instance (R : Type*) (S : Type*) (E : Type*) [I : inhabited E] :
-  inhabited (semimodule.restrict_scalars R S E) := I
+instance submodule.restricted_module (V : submodule A M) :
+  semimodule R V :=
+restrict_scalars.semimodule R A V
 
-instance (R : Type*) (S : Type*) (E : Type*) [I : add_comm_monoid E] :
-  add_comm_monoid (semimodule.restrict_scalars R S E) := I
+instance submodule.restricted_module_is_scalar_tower (V : submodule A M) :
+  is_scalar_tower R A V :=
+restrict_scalars.is_scalar_tower R A V
 
-instance semimodule.restrict_scalars.module_orig (R : Type*) (S : Type*) [semiring S]
-  (E : Type*) [add_comm_monoid E] [I : semimodule S E] :
-  semimodule S (semimodule.restrict_scalars R S E) := I
+end type_synonym
 
-instance : semimodule R (semimodule.restrict_scalars R S E) :=
-(semimodule.restrict_scalars' R S E : semimodule R E)
-
-lemma semimodule.restrict_scalars_smul_def (c : R) (x : semimodule.restrict_scalars R S E) :
-  c • x = ((algebra_map R S c) • x : E) := rfl
-
-/--
-`module.restrict_scalars R S S` is `R`-linearly equivalent to the original algebra `S`.
-
-Unfortunately these structures are not generally definitionally equal:
-the `R`-module structure on `S` is part of the data of `S`,
-while the `R`-module structure on `module.restrict_scalars R S S`
-comes from the ring homomorphism `R →+* S`, which is a separate part of the data of `S`.
-The field `algebra.smul_def'` gives the equation we need here.
--/
-def algebra.restrict_scalars_equiv :
-  (semimodule.restrict_scalars R S S) ≃ₗ[R] S :=
-{ to_fun := λ s, s,
-  inv_fun := λ s, s,
-  left_inv := λ s, rfl,
-  right_inv := λ s, rfl,
-  map_add' := λ x y, rfl,
-  map_smul' := λ c x, (algebra.smul_def' _ _).symm, }
-
-@[simp]
-lemma algebra.restrict_scalars_equiv_apply (s : S) :
-  algebra.restrict_scalars_equiv R S s = s := rfl
-@[simp]
-lemma algebra.restrict_scalars_equiv_symm_apply (s : S) :
-  (algebra.restrict_scalars_equiv R S).symm s = s := rfl
-
-variables {S E}
-
+section semimodule
 open semimodule
 
-instance : is_scalar_tower R S (restrict_scalars R S E) :=
-⟨λ r s e, by { rw [algebra.smul_def, mul_smul], refl }⟩
+variables (R A M N : Type*) [comm_semiring R] [semiring A] [algebra R A]
+variables [add_comm_monoid M] [semimodule R M] [semimodule A M] [is_scalar_tower R A M]
+variables [add_comm_monoid N] [semimodule R N] [semimodule A N] [is_scalar_tower R A N]
+
+variables {A M N}
+
+namespace submodule
 
 /--
 `V.restrict_scalars R` is the `R`-submodule of the `R`-module given by restriction of scalars,
 corresponding to `V`, an `S`-submodule of the original `S`-module.
 -/
 @[simps]
-def submodule.restrict_scalars (V : submodule S E) : submodule R (restrict_scalars R S E) :=
+def restrict_scalars (V : submodule A M) : submodule R M :=
 { carrier := V.carrier,
   zero_mem' := V.zero_mem,
-  smul_mem' := λ c e h, V.smul_mem _ h,
-  add_mem' := λ x y hx hy, V.add_mem hx hy, }
+  smul_mem' := λ c m h, by { rw [algebra_compatible_smul A c m], exact V.smul_mem _ h },
+  add_mem' := λ x y hx hy, V.add_mem hx hy }
 
 @[simp]
-lemma submodule.restrict_scalars_mem (V : submodule S E) (e : E) :
-  e ∈ V.restrict_scalars R ↔ e ∈ V :=
+lemma restrict_scalars_mem (V : submodule A M) (m : M) :
+  m ∈ V.restrict_scalars R ↔ m ∈ V :=
 iff.refl _
 
-@[simp]
-lemma submodule.restrict_scalars_bot :
-  submodule.restrict_scalars R (⊥ : submodule S E) = ⊥ :=
-rfl
+variables (R A M)
+
+lemma restrict_scalars_injective :
+  function.injective (restrict_scalars R : submodule A M → submodule R M) :=
+λ V₁ V₂ h, ext $ by convert set.ext_iff.1 (ext'_iff.1 h); refl
+
+@[simp] lemma restrict_scalars_inj {V₁ V₂ : submodule A M} :
+  restrict_scalars R V₁ = restrict_scalars R V₂ ↔ V₁ = V₂ :=
+⟨λ h, restrict_scalars_injective R _ _ h, congr_arg _⟩
 
 @[simp]
-lemma submodule.restrict_scalars_top :
-  submodule.restrict_scalars R (⊤ : submodule S E) = ⊤ :=
-rfl
-
-/-- The `R`-linear map induced by an `S`-linear map when `S` is an algebra over `R`. -/
-def linear_map.restrict_scalars (f : E →ₗ[S] F) :
-  (restrict_scalars R S E) →ₗ[R] (restrict_scalars R S F) :=
-{ to_fun := f.to_fun,
-  map_add' := λx y, f.map_add x y,
-  map_smul' := λc x, f.map_smul (algebra_map R S c) x }
-
-@[simp, norm_cast squash] lemma linear_map.coe_restrict_scalars_eq_coe (f : E →ₗ[S] F) :
-  (f.restrict_scalars R : E → F) = f := rfl
+lemma restrict_scalars_bot : restrict_scalars R (⊥ : submodule A M) = ⊥ := rfl
 
 @[simp]
-lemma restrict_scalars_ker (f : E →ₗ[S] F) :
+lemma restrict_scalars_top : restrict_scalars R (⊤ : submodule A M) = ⊤ := rfl
+
+end submodule
+
+@[simp]
+lemma linear_map.restrict_scalars_ker (f : M →ₗ[A] N) :
   (f.restrict_scalars R).ker = submodule.restrict_scalars R f.ker :=
 rfl
 
-/-- `A`-linearly coerce a `R`-linear map from `M` to `R` to a function, given an algebra `A` over
-a commutative semiring `R` and `M` a semimodule over `R`. -/
-def linear_map.lto_fun (R : Type u) (M : Type v) (A : Type w)
-  [comm_semiring R] [add_comm_monoid M] [semimodule R M] [comm_ring A] [algebra R A] :
-  (M →ₗ[R] A) →ₗ[A] (M → A) :=
-{ to_fun := linear_map.to_fun,
-  map_add' := λ f g, rfl,
-  map_smul' := λ c f, rfl }
-
 end semimodule
-
-section module
-
-instance (R : Type*) (S : Type*) (E : Type*) [I : add_comm_group E] :
-  add_comm_group (semimodule.restrict_scalars R S E) := I
-
-end module
 
 end restrict_scalars
 
+namespace linear_map
 section extend_scalars
 /-! When `V` is an `R`-module and `W` is an `S`-module, where `S` is an algebra over `R`, then
 the collection of `R`-linear maps from `V` to `W` admits an `S`-module structure, given by
-multiplication in the target -/
+multiplication in the target. -/
 
 variables (R : Type*) [comm_semiring R] (S : Type*) [semiring S] [algebra R S]
   (V : Type*) [add_comm_monoid V] [semimodule R V]
-  (W : Type*) [add_comm_monoid W] [semimodule S W]
+  (W : Type*) [add_comm_monoid W] [semimodule R W] [semimodule S W] [is_scalar_tower R S W]
 
 /-- The set of `R`-linear maps admits an `S`-action by left multiplication -/
-instance linear_map.has_scalar_extend_scalars :
-  has_scalar S (V →ₗ[R] (semimodule.restrict_scalars R S W)) :=
+instance has_scalar_extend_scalars :
+  has_scalar S (V →ₗ[R] W) :=
 { smul := λ r f,
   { to_fun := λ v, r • f v,
     map_add' := by simp [smul_add],
-    map_smul' := λ c x, by rw [linear_map.map_smul, smul_algebra_smul_comm] }}
+    map_smul' := λ c x, by rw [map_smul, smul_algebra_smul_comm] } }
 
 /-- The set of `R`-linear maps is an `S`-module-/
-instance linear_map.module_extend_scalars :
-  semimodule S (V →ₗ[R] (semimodule.restrict_scalars R S W)) :=
-{ one_smul := λ f, by { ext v, simp [(•)] },
-  mul_smul := λ r r' f, by { ext v, simp [(•), smul_smul] },
-  smul_add := λ r f g, by { ext v, simp [(•), smul_add] },
-  smul_zero := λ r, by { ext v, simp [(•)] },
-  add_smul := λ r r' f, by { ext v, simp [(•), add_smul] },
-  zero_smul := λ f, by { ext v, simp [(•)] } }
+instance module_extend_scalars :
+  semimodule S (V →ₗ[R] W) :=
+{ one_smul := λ f, by { ext v, simp only [(•), coe_mk, one_smul] },
+  mul_smul := λ r r' f, by { ext v, simp only [(•), mul_smul, coe_mk, map_smul_eq_smul_map] },
+  smul_zero := λ r, by { ext v, simp only [(•), coe_mk, zero_apply, smul_zero] },
+  smul_add := λ r f g, by { ext v, simp only [(•), coe_mk, add_apply, smul_add] },
+  zero_smul := λ f, by { ext v, simp only [(•), coe_mk, zero_smul, map_zero, zero_apply] },
+  add_smul := λ r r' f, by { ext v, simp only [(•), add_smul, map_add, coe_mk, add_apply] } }
+
+instance is_scalar_tower_extend_scalars :
+  is_scalar_tower R S (V →ₗ[R] W) :=
+{ smul_assoc := λ r s f, by simp only [(•), coe_mk, smul_assoc] }
 
 variables {R S V W}
 
+@[simp]
+lemma smul_apply' (c : R) (f : V →ₗ[R] W) (v : V) :
+  (c • f) v = (c • (f v) : W) :=
+by simp only [(•), coe_mk, map_smul_eq_smul_map]
+
 /-- When `f` is a linear map taking values in `S`, then `λb, f b • x` is a linear map. -/
-def smul_algebra_right (f : V →ₗ[R] S) (x : semimodule.restrict_scalars R S W) :
-  V →ₗ[R] (semimodule.restrict_scalars R S W) :=
+def smul_algebra_right (f : V →ₗ[R] S) (x : W) : V →ₗ[R] W :=
 { to_fun := λb, f b • x,
   map_add' := by simp [add_smul],
-  map_smul' := λ b y, by { simp [algebra.smul_def, ← smul_smul], refl } }
+  map_smul' := λ b y, by { simp [algebra.smul_def, ← smul_smul], } }
 
-@[simp] theorem smul_algebra_right_apply
-  (f : V →ₗ[R] S) (x : semimodule.restrict_scalars R S W) (c : V) :
+@[simp] theorem smul_algebra_right_apply (f : V →ₗ[R] S) (x : W) (c : V) :
   smul_algebra_right f x c = f c • x := rfl
 
 end extend_scalars
-
-/-!
-When `V` and `W` are `S`-modules, for some `R`-algebra `S`,
-the collection of `S`-linear maps from `V` to `W` forms an `R`-module.
-(But not generally an `S`-module, because `S` may be non-commutative.)
--/
-
-section module_of_linear_maps
-
-variables (R : Type*) [comm_semiring R] (S : Type*) [semiring S] [algebra R S]
-  (V : Type*) [add_comm_monoid V] [semimodule S V]
-  (W : Type*) [add_comm_monoid W] [semimodule S W]
-
-/--
-For `r : R`, and `f : V →ₗ[S] W` (where `S` is an `R`-algebra) we define
-`(r • f) v = f (r • v)`.
--/
-def linear_map_algebra_has_scalar : has_scalar R (V →ₗ[S] W) :=
-{ smul := λ r f,
-  { to_fun := λ v, f ((algebra_map R S r) • v),
-    map_add' := λ x y, by simp [smul_add],
-    map_smul' := λ s v, by simp [smul_smul, algebra.commutes], } }
-
-local attribute [instance] linear_map_algebra_has_scalar
-
-/-- The `R`-module structure on `S`-linear maps, for `S` an `R`-algebra. -/
-def linear_map_algebra_module : semimodule R (V →ₗ[S] W) :=
-{ one_smul := λ f, begin ext v, dsimp [(•)], simp, end,
-  mul_smul := λ r r' f,
-  begin
-    ext v, dsimp [(•)],
-    rw [linear_map.map_smul, linear_map.map_smul, linear_map.map_smul, ring_hom.map_mul,
-        smul_smul, algebra.commutes],
-  end,
-  smul_zero := λ r, by { ext v, dsimp [(•)], refl, },
-  smul_add := λ r f g, by { ext v, dsimp [(•)], simp [linear_map.map_add], },
-  zero_smul := λ f, by { ext v, dsimp [(•)], simp, },
-  add_smul := λ r r' f, by { ext v, dsimp [(•)], simp [add_smul], }, }
-
-local attribute [instance] linear_map_algebra_module
-
-variables {R S V W}
-@[simp]
-lemma linear_map_algebra_module.smul_apply (c : R) (f : V →ₗ[S] W) (v : V) :
-  (c • f) v = (c • (f v) : semimodule.restrict_scalars R S W) :=
-begin
-  erw [linear_map.map_smul],
-  refl,
-end
-
-end module_of_linear_maps
+end linear_map

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1050,7 +1050,8 @@ by rw [←(one_smul A m), ←smul_assoc, algebra.smul_def, mul_one, one_smul]
 variable {A}
 
 lemma smul_algebra_smul_comm (r : R) (a : A) (m : M) : a • r • m = r • a • m :=
-by rw [algebra_compatible_smul A r (a • m), smul_smul, algebra.commutes, mul_smul, ←algebra_compatible_smul]
+by rw [algebra_compatible_smul A r (a • m), smul_smul, algebra.commutes, mul_smul,
+  ←algebra_compatible_smul]
 
 @[simp] lemma map_smul_eq_smul_map (f : M →ₗ[A] N) (r : R) (m : M) :
   f (r • m) = r • f m :=
@@ -1088,6 +1089,17 @@ def lto_fun (R : Type u) (M : Type v) (A : Type w)
   map_add' := λ f g, rfl,
   map_smul' := λ c f, rfl }
 
+end linear_map
+
+end is_scalar_tower
+
+namespace linear_map
+
+variables (R : Type*) (A : Type*) (M : Type*) (N : Type*)
+variables [comm_semiring R] [semiring A] [algebra R A]
+variables [add_comm_monoid M] [semimodule A M]
+variables [add_comm_monoid N] [semimodule A N] [semimodule R N] [is_scalar_tower R A N]
+
 /--
 For `r : R`, and `f : M →ₗ[A] N` (where `A` is an `R`-algebra) we define
 `(r • f) m = f (r • m)`.
@@ -1115,18 +1127,17 @@ Check that two module structures on `M →ₗ[R] N` are defeq.
 - On the LHS we have the new instance, defined above, and we feed it `R` as algebra over itself.
 - On the RHS we have the ordinary instance for linear maps between `R`-modules.
  -/
-example : @linear_map.algebra_module R _ R _ _ M _ _ _ _ N _ _ _ _ =
-          @linear_map.semimodule R M N _ _ _ _ _ := rfl
+example [semimodule R M] :
+  @linear_map.algebra_module R R M N _ _ _ _ _ _ _ _ _ =
+  @linear_map.semimodule R M N _ _ _ _ _ := rfl
 
 variables {R A M N}
-@[simp]
+
 lemma algebra_module.smul_apply (c : R) (f : M →ₗ[A] N) (m : M) :
   (c • f) m = (c • (f m) : N) :=
 by simp only [(•), coe_mk, map_smul_eq_smul_map]
 
 end linear_map
-
-end is_scalar_tower
 
 section restrict_scalars
 /- In this section, we describe restriction of scalars: if `S` is an algebra over `R`, then

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1092,6 +1092,7 @@ def lto_fun (R : Type u) (M : Type v) (A : Type w)
 For `r : R`, and `f : M →ₗ[A] N` (where `A` is an `R`-algebra) we define
 `(r • f) m = f (r • m)`.
 -/
+@[priority 500]
 instance algebra_has_scalar : has_scalar R (M →ₗ[A] N) :=
 { smul := λ r f,
   { to_fun := λ v, r • f v,
@@ -1099,6 +1100,7 @@ instance algebra_has_scalar : has_scalar R (M →ₗ[A] N) :=
     map_smul' := λ s v, by simp [smul_smul, algebra.commutes, smul_algebra_smul_comm], } }
 
 /-- The `R`-module structure on `A`-linear maps, for `A` an `R`-algebra. -/
+@[priority 500]
 instance algebra_module : semimodule R (M →ₗ[A] N) :=
 { one_smul := λ f, by { ext v, simp only [(•), coe_mk, one_smul] },
   mul_smul := λ r r' f, by { ext v, simp only [(•), mul_smul, coe_mk, map_smul_eq_smul_map] },
@@ -1252,6 +1254,7 @@ variables (R : Type*) [comm_semiring R] (S : Type*) [semiring S] [algebra R S]
   (W : Type*) [add_comm_monoid W] [semimodule R W] [semimodule S W] [is_scalar_tower R S W]
 
 /-- The set of `R`-linear maps admits an `S`-action by left multiplication -/
+@[priority 500]
 instance has_scalar_extend_scalars :
   has_scalar S (V →ₗ[R] W) :=
 { smul := λ r f,
@@ -1260,6 +1263,7 @@ instance has_scalar_extend_scalars :
     map_smul' := λ c x, by rw [map_smul, smul_algebra_smul_comm] } }
 
 /-- The set of `R`-linear maps is an `S`-module-/
+@[priority 500]
 instance module_extend_scalars :
   semimodule S (V →ₗ[R] W) :=
 { one_smul := λ f, by { ext v, simp only [(•), coe_mk, one_smul] },

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1266,7 +1266,6 @@ instance is_scalar_tower_extend_scalars :
 
 variables {R S V W}
 
-@[simp]
 lemma smul_apply' (c : R) (f : V →ₗ[R] W) (v : V) :
   (c • f) v = (c • (f v) : W) :=
 by simp only [(•), coe_mk, map_smul_eq_smul_map]

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1094,7 +1094,7 @@ For `r : R`, and `f : M →ₗ[A] N` (where `A` is an `R`-algebra) we define
 -/
 instance algebra_has_scalar : has_scalar R (M →ₗ[A] N) :=
 { smul := λ r f,
-  { to_fun := λ v, f (r • v),
+  { to_fun := λ v, r • f v,
     map_add' := λ x y, by simp [smul_add],
     map_smul' := λ s v, by simp [smul_smul, algebra.commutes, smul_algebra_smul_comm], } }
 
@@ -1102,10 +1102,19 @@ instance algebra_has_scalar : has_scalar R (M →ₗ[A] N) :=
 instance algebra_module : semimodule R (M →ₗ[A] N) :=
 { one_smul := λ f, by { ext v, simp only [(•), coe_mk, one_smul] },
   mul_smul := λ r r' f, by { ext v, simp only [(•), mul_smul, coe_mk, map_smul_eq_smul_map] },
-  smul_zero := λ r, by { ext v, simp only [(•), coe_mk, zero_apply] },
-  smul_add := λ r f g, by { ext v, simp only [(•), coe_mk, add_apply] },
+  smul_zero := λ r, by { ext v, simp only [(•), coe_mk, zero_apply, smul_zero] },
+  smul_add := λ r f g, by { ext v, simp only [(•), coe_mk, add_apply, smul_add] },
   zero_smul := λ f, by { ext v, simp only [(•), coe_mk, zero_smul, map_zero, zero_apply] },
   add_smul := λ r r' f, by { ext v, simp only [(•), add_smul, map_add, coe_mk, add_apply] } }
+
+/-
+Check that two module structures on `M →ₗ[R] N` are defeq.
+
+- On the LHS we have the new instance, defined above, and we feed it `R` as algebra over itself.
+- On the RHS we have the ordinary instance for linear maps between `R`-modules.
+ -/
+example : @linear_map.algebra_module R _ R _ _ M _ _ _ _ N _ _ _ _ =
+          @linear_map.semimodule R M N _ _ _ _ _ := rfl
 
 variables {R A M N}
 @[simp]
@@ -1259,6 +1268,15 @@ instance module_extend_scalars :
   smul_add := λ r f g, by { ext v, simp only [(•), coe_mk, add_apply, smul_add] },
   zero_smul := λ f, by { ext v, simp only [(•), coe_mk, zero_smul, map_zero, zero_apply] },
   add_smul := λ r r' f, by { ext v, simp only [(•), add_smul, map_add, coe_mk, add_apply] } }
+
+/-
+Check that two module structures on `V →ₗ[R] W` are defeq.
+
+- On the LHS we have the new instance, defined above, and we feed it `R` as algebra over itself.
+- On the RHS we have the ordinary instance for linear maps between `R`-modules.
+ -/
+example : @linear_map.module_extend_scalars R _ R _ _ V _ _ W _ _ _ _ =
+          @linear_map.semimodule R V W _ _ _ _ _ := rfl
 
 instance is_scalar_tower_extend_scalars :
   is_scalar_tower R S (V →ₗ[R] W) :=

--- a/src/algebra/monoid_algebra.lean
+++ b/src/algebra/monoid_algebra.lean
@@ -375,32 +375,35 @@ section
 local attribute [reducible] monoid_algebra
 
 variables (k)
+-- TODO: generalise from groups `G` to monoids
 /-- When `V` is a `k[G]`-module, multiplication by a group element `g` is a `k`-linear map. -/
 def group_smul.linear_map [group G] [comm_ring k]
-  (V : Type u₃) [add_comm_group V] [module (monoid_algebra k G) V] (g : G) :
-  (semimodule.restrict_scalars k (monoid_algebra k G) V) →ₗ[k]
-  (semimodule.restrict_scalars k (monoid_algebra k G) V) :=
+  (V : Type u₃) [add_comm_group V] [module k V] [module (monoid_algebra k G) V]
+  [is_scalar_tower k (monoid_algebra k G) V] (g : G) :
+  V →ₗ[k] V :=
 { to_fun    := λ v, (single g (1 : k) • v : V),
   map_add'  := λ x y, smul_add (single g (1 : k)) x y,
-  map_smul' := λ c x,
-  by simp only [semimodule.restrict_scalars_smul_def, coe_algebra_map, ←mul_smul, single_one_comm], }.
+  map_smul' := λ c x, smul_algebra_smul_comm _ _ _ }
 
 @[simp]
 lemma group_smul.linear_map_apply [group G] [comm_ring k]
-  (V : Type u₃) [add_comm_group V] [module (monoid_algebra k G) V] (g : G) (v : V) :
+  (V : Type u₃) [add_comm_group V] [module k V] [module (monoid_algebra k G) V]
+  [is_scalar_tower k (monoid_algebra k G) V] (g : G) (v : V) :
   (group_smul.linear_map k V g) v = (single g (1 : k) • v : V) :=
 rfl
 
 section
 variables {k}
-variables [group G] [comm_ring k]
-  {V : Type u₃} {gV : add_comm_group V} {mV : module (monoid_algebra k G) V}
-  {W : Type u₃} {gW : add_comm_group W} {mW : module (monoid_algebra k G) W}
-  (f : (semimodule.restrict_scalars k (monoid_algebra k G) V) →ₗ[k]
-       (semimodule.restrict_scalars k (monoid_algebra k G) W))
+variables [group G] [comm_ring k] {V W : Type u₃}
+  [add_comm_group V] [module k V] [module (monoid_algebra k G) V]
+  [is_scalar_tower k (monoid_algebra k G) V]
+  [add_comm_group W] [module k W] [module (monoid_algebra k G) W]
+  [is_scalar_tower k (monoid_algebra k G) W]
+  (f : V →ₗ[k] W)
   (h : ∀ (g : G) (v : V), f (single g (1 : k) • v : V) = (single g (1 : k) • (f v) : W))
 include h
 
+-- TODO generalise from groups `G` to monoids??
 /-- Build a `k[G]`-linear map from a `k`-linear map and evidence that it is `G`-equivariant. -/
 def equivariant_of_linear_of_comm : V →ₗ[monoid_algebra k G] W :=
 { to_fun := f,
@@ -410,10 +413,10 @@ def equivariant_of_linear_of_comm : V →ₗ[monoid_algebra k G] W :=
   apply finsupp.induction c,
   { simp, },
   { intros g r c' nm nz w,
-    rw [add_smul, linear_map.map_add, w, add_smul, add_left_inj,
-      single_eq_algebra_map_mul_of, ←smul_smul, ←smul_smul],
-    erw [f.map_smul, h g v],
-    refl, }
+    simp only [add_smul, f.map_add, w, add_left_inj, single_eq_algebra_map_mul_of, ← smul_smul],
+    erw [algebra_map_smul (monoid_algebra k G) r, algebra_map_smul (monoid_algebra k G) r,
+      f.map_smul, h g v, of_apply],
+    all_goals { apply_instance } }
   end, }
 
 @[simp]

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -2535,7 +2535,6 @@ section smul_algebra
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 variables {𝕜' : Type*} [nondiscrete_normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
 variables {E : Type*} [normed_group E] [normed_space 𝕜 E] [normed_space 𝕜' E]
-variables [is_scalar_tower 𝕜 𝕜' E]
 variables {F : Type*} [normed_group F] [normed_space 𝕜 F] [normed_space 𝕜' F]
 variables [is_scalar_tower 𝕜 𝕜' F]
 variables {f : E → F} {f' : E →L[𝕜] F} {s : set E} {x : E}

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -2488,11 +2488,12 @@ respectively by `𝕜'` and `𝕜` where `𝕜'` is a normed algebra over `𝕜`
 -/
 
 variables (𝕜 : Type*) [nondiscrete_normed_field 𝕜]
-{𝕜' : Type*} [nondiscrete_normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
-{E : Type*} [normed_group E] [normed_space 𝕜' E]
-{F : Type*} [normed_group F] [normed_space 𝕜' F]
-{f : semimodule.restrict_scalars 𝕜 𝕜' E → semimodule.restrict_scalars 𝕜 𝕜' F}
-{f' : semimodule.restrict_scalars 𝕜 𝕜' E →L[𝕜'] semimodule.restrict_scalars 𝕜 𝕜' F} {s : set E} {x : E}
+variables {𝕜' : Type*} [nondiscrete_normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
+variables {E : Type*} [normed_group E] [normed_space 𝕜 E] [normed_space 𝕜' E]
+variables [is_scalar_tower 𝕜 𝕜' E]
+variables {F : Type*} [normed_group F] [normed_space 𝕜 F] [normed_space 𝕜' F]
+variables [is_scalar_tower 𝕜 𝕜' F]
+variables {f : E → F} {f' : E →L[𝕜'] F} {s : set E} {x : E}
 
 lemma has_strict_fderiv_at.restrict_scalars (h : has_strict_fderiv_at f f' x) :
   has_strict_fderiv_at f (f'.restrict_scalars 𝕜) x := h
@@ -2532,12 +2533,13 @@ by a normed algebra `𝕜'` over `𝕜`.
 section smul_algebra
 
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
-{𝕜' : Type*} [nondiscrete_normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
-{E : Type*} [normed_group E] [normed_space 𝕜 E]
-{F : Type*} [normed_group F] [normed_space 𝕜' F]
-{f : E → semimodule.restrict_scalars 𝕜 𝕜' F}
-{f' : E →L[𝕜] semimodule.restrict_scalars 𝕜 𝕜' F} {s : set E} {x : E}
-{c : E → 𝕜'} {c' : E →L[𝕜] 𝕜'} {L : filter E}
+variables {𝕜' : Type*} [nondiscrete_normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
+variables {E : Type*} [normed_group E] [normed_space 𝕜 E] [normed_space 𝕜' E]
+variables [is_scalar_tower 𝕜 𝕜' E]
+variables {F : Type*} [normed_group F] [normed_space 𝕜 F] [normed_space 𝕜' F]
+variables [is_scalar_tower 𝕜 𝕜' F]
+variables {f : E → F} {f' : E →L[𝕜] F} {s : set E} {x : E}
+variables {c : E → 𝕜'} {c' : E →L[𝕜] 𝕜'} {L : filter E}
 
 theorem has_strict_fderiv_at.smul_algebra (hc : has_strict_fderiv_at c c' x)
   (hf : has_strict_fderiv_at f f' x) :
@@ -2586,60 +2588,58 @@ lemma fderiv_smul_algebra (hc : differentiable_at 𝕜 c x) (hf : differentiable
 (hc.has_fderiv_at.smul_algebra hf.has_fderiv_at).fderiv
 
 theorem has_strict_fderiv_at.smul_algebra_const
-  (hc : has_strict_fderiv_at c c' x) (f : semimodule.restrict_scalars 𝕜 𝕜' F) :
+  (hc : has_strict_fderiv_at c c' x) (f : F) :
   has_strict_fderiv_at (λ y, c y • f) (c'.smul_algebra_right f) x :=
 by simpa only [smul_zero, zero_add] using hc.smul_algebra (has_strict_fderiv_at_const f x)
 
 theorem has_fderiv_within_at.smul_algebra_const
-  (hc : has_fderiv_within_at c c' s x) (f : semimodule.restrict_scalars 𝕜 𝕜' F) :
+  (hc : has_fderiv_within_at c c' s x) (f : F) :
   has_fderiv_within_at (λ y, c y • f) (c'.smul_algebra_right f) s x :=
 by simpa only [smul_zero, zero_add] using hc.smul_algebra (has_fderiv_within_at_const f x s)
 
 theorem has_fderiv_at.smul_algebra_const
-  (hc : has_fderiv_at c c' x) (f : semimodule.restrict_scalars 𝕜 𝕜' F) :
+  (hc : has_fderiv_at c c' x) (f : F) :
   has_fderiv_at (λ y, c y • f) (c'.smul_algebra_right f) x :=
 by simpa only [smul_zero, zero_add] using hc.smul_algebra (has_fderiv_at_const f x)
 
 lemma differentiable_within_at.smul_algebra_const
-  (hc : differentiable_within_at 𝕜 c s x) (f : semimodule.restrict_scalars 𝕜 𝕜' F) :
+  (hc : differentiable_within_at 𝕜 c s x) (f : F) :
   differentiable_within_at 𝕜 (λ y, c y • f) s x :=
 (hc.has_fderiv_within_at.smul_algebra_const f).differentiable_within_at
 
 lemma differentiable_at.smul_algebra_const
-  (hc : differentiable_at 𝕜 c x) (f : semimodule.restrict_scalars 𝕜 𝕜' F) :
+  (hc : differentiable_at 𝕜 c x) (f : F) :
   differentiable_at 𝕜 (λ y, c y • f) x :=
 (hc.has_fderiv_at.smul_algebra_const f).differentiable_at
 
 lemma differentiable_on.smul_algebra_const
-  (hc : differentiable_on 𝕜 c s) (f : semimodule.restrict_scalars 𝕜 𝕜' F) :
+  (hc : differentiable_on 𝕜 c s) (f : F) :
   differentiable_on 𝕜 (λ y, c y • f) s :=
 λx hx, (hc x hx).smul_algebra_const f
 
 lemma differentiable.smul_algebra_const
-  (hc : differentiable 𝕜 c) (f : semimodule.restrict_scalars 𝕜 𝕜' F) :
+  (hc : differentiable 𝕜 c) (f : F) :
   differentiable 𝕜 (λ y, c y • f) :=
 λx, (hc x).smul_algebra_const f
 
 lemma fderiv_within_smul_algebra_const (hxs : unique_diff_within_at 𝕜 s x)
-  (hc : differentiable_within_at 𝕜 c s x) (f : semimodule.restrict_scalars 𝕜 𝕜' F) :
+  (hc : differentiable_within_at 𝕜 c s x) (f : F) :
   fderiv_within 𝕜 (λ y, c y • f) s x =
     (fderiv_within 𝕜 c s x).smul_algebra_right f :=
 (hc.has_fderiv_within_at.smul_algebra_const f).fderiv_within hxs
 
 lemma fderiv_smul_algebra_const
-  (hc : differentiable_at 𝕜 c x) (f : semimodule.restrict_scalars 𝕜 𝕜' F) :
+  (hc : differentiable_at 𝕜 c x) (f : F) :
   fderiv 𝕜 (λ y, c y • f) x = (fderiv 𝕜 c x).smul_algebra_right f :=
 (hc.has_fderiv_at.smul_algebra_const f).fderiv
 
 theorem has_strict_fderiv_at.const_smul_algebra (h : has_strict_fderiv_at f f' x) (c : 𝕜') :
   has_strict_fderiv_at (λ x, c • f x) (c • f') x :=
-(c • (1 : (semimodule.restrict_scalars 𝕜 𝕜' F) →L[𝕜] ((semimodule.restrict_scalars 𝕜 𝕜' F))))
-  .has_strict_fderiv_at.comp x h
+(c • (1 : F →L[𝕜] F)).has_strict_fderiv_at.comp x h
 
 theorem has_fderiv_at_filter.const_smul_algebra (h : has_fderiv_at_filter f f' x L) (c : 𝕜') :
   has_fderiv_at_filter (λ x, c • f x) (c • f') x L :=
-(c • (1 : (semimodule.restrict_scalars 𝕜 𝕜' F) →L[𝕜] ((semimodule.restrict_scalars 𝕜 𝕜' F))))
-  .has_fderiv_at_filter.comp x h
+(c • (1 : F →L[𝕜] F)).has_fderiv_at_filter.comp x h
 
 theorem has_fderiv_within_at.const_smul_algebra (h : has_fderiv_within_at f f' s x) (c : 𝕜') :
   has_fderiv_within_at (λ x, c • f x) (c • f') s x :=

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -2534,7 +2534,7 @@ section smul_algebra
 
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 variables {𝕜' : Type*} [nondiscrete_normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
-variables {E : Type*} [normed_group E] [normed_space 𝕜 E] [normed_space 𝕜' E]
+variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
 variables {F : Type*} [normed_group F] [normed_space 𝕜 F] [normed_space 𝕜' F]
 variables [is_scalar_tower 𝕜 𝕜' F]
 variables {f : E → F} {f' : E →L[𝕜] F} {s : set E} {x : E}

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -74,7 +74,7 @@ attribute [instance, priority 900] complex.finite_dimensional.proper
 /-- A complex normed vector space is also a real normed vector space. -/
 @[priority 900]
 instance normed_space.restrict_scalars_real (E : Type*) [normed_group E] [normed_space ℂ E] :
-  normed_space ℝ E := normed_space.restrict_scalars' ℝ ℂ E
+  normed_space ℝ E := normed_space.restrict_scalars ℝ ℂ E
 
 /-- The space of continuous linear maps over `ℝ`, from a real vector space to a complex vector
 space, is a normed vector space over `ℂ`. -/

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -1127,7 +1127,10 @@ section restrict_scalars
 variables (𝕜 : Type*) (𝕜' : Type*) [normed_field 𝕜] [normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
 (E : Type*) [normed_group E] [normed_space 𝕜' E]
 
-/-- `𝕜`-normed space structure induced by a `𝕜'`-normed space structure when `𝕜'` is a
+/-- Warning: This declaration should be used judiciously.
+Please consider using `is_scalar_tower` instead.
+
+`𝕜`-normed space structure induced by a `𝕜'`-normed space structure when `𝕜'` is a
 normed algebra over `𝕜`. Not registered as an instance as `𝕜'` can not be inferred.
 
 The type synonym `semimodule.restrict_scalars 𝕜 𝕜' E` will be endowed with this instance by default.
@@ -1137,16 +1140,16 @@ def normed_space.restrict_scalars' : normed_space 𝕜 E :=
     change ∥(algebra_map 𝕜 𝕜' c) • x∥ = ∥c∥ * ∥x∥,
     simp [norm_smul]
   end,
-  ..semimodule.restrict_scalars' 𝕜 𝕜' E }
+  ..restrict_scalars.semimodule 𝕜 𝕜' E }
 
 instance {𝕜 : Type*} {𝕜' : Type*} {E : Type*} [I : normed_group E] :
-  normed_group (semimodule.restrict_scalars 𝕜 𝕜' E) := I
+  normed_group (restrict_scalars 𝕜 𝕜' E) := I
 
 instance semimodule.restrict_scalars.normed_space_orig {𝕜 : Type*} {𝕜' : Type*} {E : Type*}
   [normed_field 𝕜'] [normed_group E] [I : normed_space 𝕜' E] :
-  normed_space 𝕜' (semimodule.restrict_scalars 𝕜 𝕜' E) := I
+  normed_space 𝕜' (restrict_scalars 𝕜 𝕜' E) := I
 
-instance : normed_space 𝕜 (semimodule.restrict_scalars 𝕜 𝕜' E) :=
+instance : normed_space 𝕜 (restrict_scalars 𝕜 𝕜' E) :=
 (normed_space.restrict_scalars' 𝕜 𝕜' E : normed_space 𝕜 E)
 
 end restrict_scalars

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -1135,7 +1135,7 @@ normed algebra over `𝕜`. Not registered as an instance as `𝕜'` can not be 
 
 The type synonym `semimodule.restrict_scalars 𝕜 𝕜' E` will be endowed with this instance by default.
 -/
-def normed_space.restrict_scalars' : normed_space 𝕜 E :=
+def normed_space.restrict_scalars : normed_space 𝕜 E :=
 { norm_smul_le := λc x, le_of_eq $ begin
     change ∥(algebra_map 𝕜 𝕜' c) • x∥ = ∥c∥ * ∥x∥,
     simp [norm_smul]
@@ -1150,7 +1150,7 @@ instance semimodule.restrict_scalars.normed_space_orig {𝕜 : Type*} {𝕜' : T
   normed_space 𝕜' (restrict_scalars 𝕜 𝕜' E) := I
 
 instance : normed_space 𝕜 (restrict_scalars 𝕜 𝕜' E) :=
-(normed_space.restrict_scalars' 𝕜 𝕜' E : normed_space 𝕜 E)
+(normed_space.restrict_scalars 𝕜 𝕜' E : normed_space 𝕜 E)
 
 end restrict_scalars
 

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -280,8 +280,9 @@ lemma is_bounded_bilinear_map_smul :
   bound      := ⟨1, zero_lt_one, λx y, by simp [norm_smul]⟩ }
 
 lemma is_bounded_bilinear_map_smul_algebra {𝕜' : Type*} [normed_field 𝕜']
-  [normed_algebra 𝕜 𝕜'] {E : Type*} [normed_group E] [normed_space 𝕜' E] :
-  is_bounded_bilinear_map 𝕜 (λ (p : 𝕜' × (semimodule.restrict_scalars 𝕜 𝕜' E)), p.1 • p.2) :=
+  [normed_algebra 𝕜 𝕜'] {E : Type*} [normed_group E] [normed_space 𝕜 E] [normed_space 𝕜' E]
+  [is_scalar_tower 𝕜 𝕜' E] :
+  is_bounded_bilinear_map 𝕜 (λ (p : 𝕜' × E), p.1 • p.2) :=
 { add_left   := add_smul,
   smul_left  := λ c x y, by simp [smul_assoc],
   add_right  := smul_add,

--- a/src/analysis/normed_space/hahn_banach.lean
+++ b/src/analysis/normed_space/hahn_banach.lean
@@ -90,14 +90,17 @@ end real
 section complex
 variables {F : Type*} [normed_group F] [normed_space ℂ F]
 
+-- TODO: generalize away from `ℝ` and `ℂ`
+
 -- Inlining the following two definitions causes a type mismatch between
 -- subspace ℝ (semimodule.restrict_scalars ℝ ℂ F) and subspace ℂ F.
 /-- Restrict a `ℂ`-subspace to an `ℝ`-subspace. -/
-noncomputable def restrict_scalars (p : subspace ℂ F) : subspace ℝ F := p.restrict_scalars ℝ
+noncomputable def subspace.restrict_scalars (p : subspace ℂ F) :
+  subspace ℝ F := p.restrict_scalars ℝ
 
 private lemma apply_real (p : subspace ℂ F) (f' : p →L[ℝ] ℝ) :
-  ∃ g : F →L[ℝ] ℝ, (∀ x : restrict_scalars p, g x = f' x) ∧ ∥g∥ = ∥f'∥ :=
-  exists_extension_norm_eq (p.restrict_scalars ℝ) f'
+  ∃ g : F →L[ℝ] ℝ, (∀ x : p.restrict_scalars, g x = f' x) ∧ ∥g∥ = ∥f'∥ :=
+  exists_extension_norm_eq (submodule.restrict_scalars ℝ p) f'
 
 open complex
 

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1355,6 +1355,8 @@ theorem exists_norm_eq_infi_of_complete_subspace (K : subspace 𝕜 E)
   (h : is_complete (↑K : set E)) : ∀ u : E, ∃ v ∈ K, ∥u - v∥ = ⨅ w : (K : set E), ∥u - w∥ :=
 begin
   letI : inner_product_space ℝ E := inner_product_space.is_R_or_C_to_real 𝕜,
+  letI : module ℝ E := restrict_scalars.semimodule ℝ 𝕜 E,
+  letI : is_scalar_tower ℝ 𝕜 E := restrict_scalars.is_scalar_tower _ _ _,
   let K' : subspace ℝ E := submodule.restrict_scalars ℝ K,
   exact exists_norm_eq_infi_of_complete_convex ⟨0, K'.zero_mem⟩ h K'.convex
 end
@@ -1412,6 +1414,8 @@ theorem norm_eq_infi_iff_inner_eq_zero (K : subspace 𝕜 E) {u : E} {v : E}
   (hv : v ∈ K) : ∥u - v∥ = (⨅ w : (↑K : set E), ∥u - w∥) ↔ ∀ w ∈ K, ⟪u - v, w⟫ = 0 :=
 begin
   letI : inner_product_space ℝ E := inner_product_space.is_R_or_C_to_real 𝕜,
+  letI : module ℝ E := restrict_scalars.semimodule ℝ 𝕜 E,
+  letI : is_scalar_tower ℝ 𝕜 E := restrict_scalars.is_scalar_tower _ _ _,
   let K' : subspace ℝ E := K.restrict_scalars ℝ,
   split,
   { assume H,

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1094,8 +1094,6 @@ def has_inner.is_R_or_C_to_real : has_inner ℝ E :=
 lemma real_inner_eq_re_inner (x y : E) :
   @has_inner.inner ℝ E (has_inner.is_R_or_C_to_real 𝕜) x y = re ⟪x, y⟫ := rfl
 
--- TODO: remove the `'` on `restrict_scalars'`
-
 /-- A general inner product space structure implies a real inner product structure. This is not
 registered as an instance since it creates problems with the case `𝕜 = ℝ`, but in can be used in a
 proof to obtain a real inner product space structure from a given `𝕜`-inner product space
@@ -1113,7 +1111,7 @@ def inner_product_space.is_R_or_C_to_real : inner_product_space ℝ E :=
     simp [this, inner_smul_left, smul_coe_mul_ax],
   end,
   ..has_inner.is_R_or_C_to_real 𝕜,
-  ..normed_space.restrict_scalars' ℝ 𝕜 E }
+  ..normed_space.restrict_scalars ℝ 𝕜 E }
 
 omit 𝕜
 

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1094,6 +1094,8 @@ def has_inner.is_R_or_C_to_real : has_inner ℝ E :=
 lemma real_inner_eq_re_inner (x y : E) :
   @has_inner.inner ℝ E (has_inner.is_R_or_C_to_real 𝕜) x y = re ⟪x, y⟫ := rfl
 
+-- TODO: remove the `'` on `restrict_scalars'`
+
 /-- A general inner product space structure implies a real inner product structure. This is not
 registered as an instance since it creates problems with the case `𝕜 = ℝ`, but in can be used in a
 proof to obtain a real inner product space structure from a given `𝕜`-inner product space
@@ -1353,7 +1355,7 @@ theorem exists_norm_eq_infi_of_complete_subspace (K : subspace 𝕜 E)
   (h : is_complete (↑K : set E)) : ∀ u : E, ∃ v ∈ K, ∥u - v∥ = ⨅ w : (K : set E), ∥u - w∥ :=
 begin
   letI : inner_product_space ℝ E := inner_product_space.is_R_or_C_to_real 𝕜,
-  let K' : subspace ℝ E := K.restrict_scalars ℝ,
+  let K' : subspace ℝ E := submodule.restrict_scalars ℝ K,
   exact exists_norm_eq_infi_of_complete_convex ⟨0, K'.zero_mem⟩ h K'.convex
 end
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -708,19 +708,20 @@ section restrict_scalars
 
 variable (𝕜)
 variables {𝕜' : Type*} [normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
-{E' : Type*} [normed_group E'] [normed_space 𝕜' E']
-{F' : Type*} [normed_group F'] [normed_space 𝕜' F']
+variables {E' : Type*} [normed_group E'] [normed_space 𝕜 E'] [normed_space 𝕜' E']
+variables [is_scalar_tower 𝕜 𝕜' E']
+variables {F' : Type*} [normed_group F'] [normed_space 𝕜 F'] [normed_space 𝕜' F']
+variables [is_scalar_tower 𝕜 𝕜' F']
 
 /-- `𝕜`-linear continuous function induced by a `𝕜'`-linear continuous function when `𝕜'` is a
 normed algebra over `𝕜`. -/
 def restrict_scalars (f : E' →L[𝕜'] F') :
-  (semimodule.restrict_scalars 𝕜 𝕜' E') →L[𝕜] (semimodule.restrict_scalars 𝕜 𝕜' F') :=
+  E' →L[𝕜] F' :=
 { cont := f.cont,
   ..linear_map.restrict_scalars 𝕜 (f.to_linear_map) }
 
 @[simp, norm_cast] lemma restrict_scalars_coe_eq_coe (f : E' →L[𝕜'] F') :
-  (f.restrict_scalars 𝕜 :
-    (semimodule.restrict_scalars 𝕜 𝕜' E') →ₗ[𝕜] (semimodule.restrict_scalars 𝕜 𝕜' F')) =
+  (f.restrict_scalars 𝕜 : E' →ₗ[𝕜] F') =
   (f : E' →ₗ[𝕜'] F').restrict_scalars 𝕜 := rfl
 
 @[simp, norm_cast squash] lemma restrict_scalars_coe_eq_coe' (f : E' →L[𝕜'] F') :
@@ -731,9 +732,10 @@ end restrict_scalars
 section extend_scalars
 
 variables {𝕜' : Type*} [normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
-{F' : Type*} [normed_group F'] [normed_space 𝕜' F']
+variables {F' : Type*} [normed_group F'] [normed_space 𝕜 F'] [normed_space 𝕜' F']
+variables [is_scalar_tower 𝕜 𝕜' F']
 
-instance has_scalar_extend_scalars : has_scalar 𝕜' (E →L[𝕜] (semimodule.restrict_scalars 𝕜 𝕜' F')) :=
+instance has_scalar_extend_scalars : has_scalar 𝕜' (E →L[𝕜] F') :=
 { smul := λ c f, (c • f.to_linear_map).mk_continuous (∥c∥ * ∥f∥)
 begin
   assume x,
@@ -742,7 +744,7 @@ begin
   ... = ∥c∥ * ∥f∥ * ∥x∥ : (mul_assoc _ _ _).symm
 end }
 
-instance module_extend_scalars : module 𝕜' (E →L[𝕜] (semimodule.restrict_scalars 𝕜 𝕜' F')) :=
+instance module_extend_scalars : module 𝕜' (E →L[𝕜] F') :=
 { smul_zero := λ _, ext $ λ _, smul_zero _,
   zero_smul := λ _, ext $ λ _, zero_smul _ _,
   one_smul  := λ _, ext $ λ _, one_smul _ _,
@@ -750,19 +752,16 @@ instance module_extend_scalars : module 𝕜' (E →L[𝕜] (semimodule.restrict
   add_smul  := λ _ _ _, ext $ λ _, add_smul _ _ _,
   smul_add  := λ _ _ _, ext $ λ _, smul_add _ _ _ }
 
-instance normed_space_extend_scalars : normed_space 𝕜' (E →L[𝕜] (semimodule.restrict_scalars 𝕜 𝕜' F')) :=
+instance normed_space_extend_scalars : normed_space 𝕜' (E →L[𝕜] F') :=
 { norm_smul_le := λ c f,
     linear_map.mk_continuous_norm_le _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) _ }
 
 /-- When `f` is a continuous linear map taking values in `S`, then `λb, f b • x` is a
 continuous linear map. -/
-def smul_algebra_right (f : E →L[𝕜] 𝕜') (x : semimodule.restrict_scalars 𝕜 𝕜' F') :
-  E →L[𝕜] (semimodule.restrict_scalars 𝕜 𝕜' F') :=
-{ cont := by continuity!,
-  .. smul_algebra_right f.to_linear_map x }
+def smul_algebra_right (f : E →L[𝕜] 𝕜') (x : F') : E →L[𝕜] F' :=
+{ cont := by continuity!, .. f.to_linear_map.smul_algebra_right x }
 
-@[simp] theorem smul_algebra_right_apply
-  (f : E →L[𝕜] 𝕜') (x : semimodule.restrict_scalars 𝕜 𝕜' F') (c : E) :
+@[simp] theorem smul_algebra_right_apply (f : E →L[𝕜] 𝕜') (x : F') (c : E) :
   smul_algebra_right f x c = f c • x := rfl
 
 end extend_scalars

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -362,6 +362,8 @@ by rw [← of_real_rat_cast, of_real_im]
 
 /-! ### Characteristic zero -/
 
+-- TODO: I think this can be instance, because it is a `Prop`
+
 /--
 ℝ and ℂ are both of characteristic zero.
 
@@ -584,6 +586,26 @@ noncomputable instance complex.is_R_or_C : is_R_or_C ℂ :=
   mul_im_I_ax := λ z, by simp only [mul_one, add_monoid_hom.coe_mk, complex.I_im],
   inv_def_ax := λ z, by convert complex.inv_def z; exact (complex.norm_sq_eq_abs z).symm,
   div_I_ax := complex.div_I }
+
+section
+noncomputable theory
+
+variables (𝕜 : Type*) [is_R_or_C 𝕜]
+
+section real
+variables (M : Type*) [add_comm_monoid M] [semimodule 𝕜 M]
+
+@[priority 100]
+instance semimodule_ℝ : semimodule ℝ M :=
+restrict_scalars.semimodule ℝ 𝕜 M
+
+@[priority 100]
+instance is_scalar_tower_ℝ : is_scalar_tower ℝ 𝕜 M :=
+restrict_scalars.is_scalar_tower ℝ 𝕜 M
+
+end real
+
+end
 
 end instances
 

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -587,26 +587,6 @@ noncomputable instance complex.is_R_or_C : is_R_or_C ℂ :=
   inv_def_ax := λ z, by convert complex.inv_def z; exact (complex.norm_sq_eq_abs z).symm,
   div_I_ax := complex.div_I }
 
-section
-noncomputable theory
-
-variables (𝕜 : Type*) [is_R_or_C 𝕜]
-
-section real
-variables (M : Type*) [add_comm_monoid M] [semimodule 𝕜 M]
-
-@[priority 100]
-instance semimodule_ℝ : semimodule ℝ M :=
-restrict_scalars.semimodule ℝ 𝕜 M
-
-@[priority 100]
-instance is_scalar_tower_ℝ : is_scalar_tower ℝ 𝕜 M :=
-restrict_scalars.is_scalar_tower ℝ 𝕜 M
-
-end real
-
-end
-
 end instances
 
 namespace is_R_or_C

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -68,11 +68,11 @@ end complex
 vector space. -/
 @[priority 900]
 instance module.complex_to_real (E : Type*) [add_comm_group E] [module ℂ E] : module ℝ E :=
-semimodule.restrict_scalars' ℝ ℂ E
+restrict_scalars.semimodule ℝ ℂ E
 
 instance module.real_complex_tower (E : Type*) [add_comm_group E] [module ℂ E] :
   is_scalar_tower ℝ ℂ E :=
-semimodule.restrict_scalars.is_scalar_tower ℝ
+restrict_scalars.is_scalar_tower ℝ ℂ E
 
 instance (E : Type*) [add_comm_group E] [module ℝ E]
   (F : Type*) [add_comm_group F] [module ℂ F] : module ℂ (E →ₗ[ℝ] F) :=

--- a/src/field_theory/tower.lean
+++ b/src/field_theory/tower.lean
@@ -68,8 +68,8 @@ of_fintype_basis $ hb.smul hc
 
 lemma right [hf : finite_dimensional F A] : finite_dimensional K A :=
 let ⟨b, hb⟩ := iff_fg.1 hf in
-iff_fg.2 ⟨b, @submodule.restrict_scalars'_injective F _ _ _ _ _ _ _ _ _ _ _ $
-by { rw [submodule.restrict_scalars'_top, eq_top_iff, ← hb, submodule.span_le],
+iff_fg.2 ⟨b, submodule.restrict_scalars_injective F _ _ $
+by { rw [submodule.restrict_scalars_top, eq_top_iff, ← hb, submodule.span_le],
   exact submodule.subset_span }⟩
 
 /-- Tower law: if `A` is a `K`-algebra and `K` is a field extension of `F` then

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -39,8 +39,10 @@ section
 -- `[invertible (fintype.card G : k)]` when it is required.
 variables {k : Type u} [comm_ring k] {G : Type u} [group G]
 
-variables {V : Type u} [add_comm_group V] [module (monoid_algebra k G) V]
-variables {W : Type u} [add_comm_group W] [module (monoid_algebra k G) W]
+variables {V : Type u} [add_comm_group V] [module k V] [module (monoid_algebra k G) V]
+variables [is_scalar_tower k (monoid_algebra k G) V]
+variables {W : Type u} [add_comm_group W] [module k W] [module (monoid_algebra k G) W]
+variables [is_scalar_tower k (monoid_algebra k G) W]
 
 /-!
 We now do the key calculation in Maschke's theorem.
@@ -55,15 +57,15 @@ by the formula
 $$ \frac{1}{|G|} \sum_{g \in G} g⁻¹ • π(g • -). $$
 -/
 
-variables (π : (restrict_scalars k (monoid_algebra k G) W) →ₗ[k]
-               (restrict_scalars k (monoid_algebra k G) V))
+namespace linear_map
+
+variables (π : W →ₗ[k] V)
 include π
 
 /--
 We define the conjugate of `π` by `g`, as a `k`-linear map.
 -/
-def conjugate (g : G) :
-  (restrict_scalars k (monoid_algebra k G) W) →ₗ[k] (restrict_scalars k (monoid_algebra k G) V) :=
+def conjugate (g : G) : W →ₗ[k] V :=
 ((group_smul.linear_map k V g⁻¹).comp π).comp (group_smul.linear_map k W g)
 
 variables (i : V →ₗ[monoid_algebra k G] W) (h : ∀ v : V, π (i v) = v)
@@ -80,23 +82,21 @@ begin
 end
 end
 
-variables [fintype G]
+variables (G) [fintype G]
 
 /--
 The sum of the conjugates of `π` by each element `g : G`, as a `k`-linear map.
 
 (We postpone dividing by the size of the group as long as possible.)
 -/
-def sum_of_conjugates :
-  (restrict_scalars k (monoid_algebra k G) W) →ₗ[k] (restrict_scalars k (monoid_algebra k G) V) :=
-∑ g : G, conjugate π g
+def sum_of_conjugates : W →ₗ[k] V :=
+∑ g : G, π.conjugate g
 
 /--
 In fact, the sum over `g : G` of the conjugate of `π` by `g` is a `k[G]`-linear map.
 -/
-def sum_of_conjugates_equivariant :
-  W →ₗ[monoid_algebra k G] V :=
-monoid_algebra.equivariant_of_linear_of_comm (sum_of_conjugates π) (λ g v,
+def sum_of_conjugates_equivariant : W →ₗ[monoid_algebra k G] V :=
+monoid_algebra.equivariant_of_linear_of_comm (π.sum_of_conjugates G) (λ g v,
 begin
   dsimp [sum_of_conjugates],
   simp only [linear_map.sum_apply, finset.smul_sum],
@@ -107,58 +107,57 @@ begin
   },
   simp only [←mul_smul, single_mul_single, mul_inv_rev, mul_one, function.embedding.coe_fn_mk,
     finset.sum_map, inv_inv, inv_mul_cancel_right],
+  recover,
 end)
 
 section
 variables [inv : invertible (fintype.card G : k)]
 include inv
 
-section
-local attribute [instance] linear_map_algebra_module
 /--
 We construct our `k[G]`-linear retraction of `i` as
 $$ \frac{1}{|G|} \sum_{g \in G} g⁻¹ • π(g • -). $$
 -/
-def equivariant_projection :
-  W →ₗ[monoid_algebra k G] V :=
-⅟(fintype.card G : k) • (sum_of_conjugates_equivariant π)
-end
+def equivariant_projection : W →ₗ[monoid_algebra k G] V :=
+⅟(fintype.card G : k) • (π.sum_of_conjugates_equivariant G)
 
 include h
 
-lemma equivariant_projection_condition (v : V) : (equivariant_projection π) (i v) = v :=
+lemma equivariant_projection_condition (v : V) : (π.equivariant_projection G) (i v) = v :=
 begin
-  rw [equivariant_projection, linear_map_algebra_module.smul_apply, sum_of_conjugates_equivariant,
+  rw [equivariant_projection, linear_map.algebra_module.smul_apply, sum_of_conjugates_equivariant,
     equivariant_of_linear_of_comm_apply, sum_of_conjugates],
   rw [linear_map.sum_apply],
   simp only [conjugate_i π i h],
   rw [finset.sum_const, finset.card_univ,
     @semimodule.nsmul_eq_smul k _
-      (restrict_scalars k (monoid_algebra k G) V) _ _ (fintype.card G) v,
+      V _ _ (fintype.card G) v,
     ←mul_smul, invertible.inv_of_mul_self, one_smul],
 end
 end
+end linear_map
 end
 
 -- Now we work over a `[field k]`, and replace the assumption `[invertible (fintype.card G : k)]`
 -- with `¬(ring_char k ∣ fintype.card G)`.
 variables {k : Type u} [field k] {G : Type u} [fintype G] [group G]
-variables {V : Type u} [add_comm_group V] [module (monoid_algebra k G) V]
-variables {W : Type u} [add_comm_group W] [module (monoid_algebra k G) W]
+variables {V : Type u} [add_comm_group V] [module k V] [module (monoid_algebra k G) V]
+variables [is_scalar_tower k (monoid_algebra k G) V]
+variables {W : Type u} [add_comm_group W] [module k W] [module (monoid_algebra k G) W]
+variables [is_scalar_tower k (monoid_algebra k G) W]
 
 lemma monoid_algebra.exists_left_inverse_of_injective
-  (not_dvd : ¬(ring_char k ∣ fintype.card G))
-  (f : V →ₗ[monoid_algebra k G] W) (hf_inj : f.ker = ⊥) :
+  (not_dvd : ¬(ring_char k ∣ fintype.card G)) (f : V →ₗ[monoid_algebra k G] W) (hf : f.ker = ⊥) :
   ∃ (g : W →ₗ[monoid_algebra k G] V), g.comp f = linear_map.id :=
 begin
   let E := linear_map.exists_left_inverse_of_injective
-    (by convert f.restrict_scalars k) (by simp [hf_inj]),
+    (by convert f.restrict_scalars k) (by simp [hf]),
   fsplit,
   haveI : invertible (fintype.card G : k) :=
     invertible_of_ring_char_not_dvd not_dvd,
-  exact equivariant_projection (classical.some E),
+  exact (classical.some E).equivariant_projection G,
   { ext v,
-    apply equivariant_projection_condition,
+    apply linear_map.equivariant_projection_condition,
     intro v,
     have := classical.some_spec E,
     have := congr_arg linear_map.to_fun this,

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -150,18 +150,17 @@ lemma monoid_algebra.exists_left_inverse_of_injective
   (not_dvd : ¬(ring_char k ∣ fintype.card G)) (f : V →ₗ[monoid_algebra k G] W) (hf : f.ker = ⊥) :
   ∃ (g : W →ₗ[monoid_algebra k G] V), g.comp f = linear_map.id :=
 begin
-  let E := linear_map.exists_left_inverse_of_injective
-    (by convert f.restrict_scalars k) (by simp [hf]),
-  fsplit,
   haveI : invertible (fintype.card G : k) :=
     invertible_of_ring_char_not_dvd not_dvd,
-  exact (classical.some E).equivariant_projection G,
-  { ext v,
-    apply linear_map.equivariant_projection_condition,
-    intro v,
-    have := classical.some_spec E,
-    have := congr_arg linear_map.to_fun this,
-    exact congr_fun this v, }
+  obtain ⟨φ, hφ⟩ := (f.restrict_scalars k).exists_left_inverse_of_injective
+    (by simp only [hf, submodule.restrict_scalars_bot, linear_map.ker_restrict_scalars]),
+  refine ⟨φ.equivariant_projection G, _⟩,
+  ext v,
+  simp only [linear_map.id_coe, id.def, linear_map.comp_apply],
+  apply linear_map.equivariant_projection_condition,
+  intro v,
+  have := congr_arg linear_map.to_fun hφ,
+  exact congr_fun this v
 end
 
 lemma monoid_algebra.submodule.exists_is_compl

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -7,6 +7,7 @@ Authors: Kenny Lau
 import algebra.invertible
 import ring_theory.adjoin
 import linear_algebra.basis
+import algebra.algebra.basic
 
 /-!
 # Towers of algebras
@@ -282,32 +283,6 @@ by rw [finset.coe_union, finset.coe_image, algebra.adjoin_union, algebra.adjoin_
     algebra.map_top, is_scalar_tower.range_under_adjoin, ht, subalgebra.res_top]⟩
 end
 
-namespace submodule
-
-open is_scalar_tower
-
-variables [comm_semiring R] [semiring S] [add_comm_monoid A]
-variables [algebra R S] [semimodule S A] [semimodule R A] [is_scalar_tower R S A]
-
-variables (R) {S A}
-/-- Restricting the scalars of submodules in an algebra tower. -/
-def restrict_scalars' (U : submodule S A) : submodule R A :=
-{ smul_mem' := λ r x hx, algebra_map_smul S r x ▸ U.smul_mem _ hx, .. U }
-
-variables (R S A)
-theorem restrict_scalars'_top : restrict_scalars' R (⊤ : submodule S A) = ⊤ := rfl
-
-variables {R S A}
-theorem restrict_scalars'_injective (U₁ U₂ : submodule S A)
-  (h : restrict_scalars' R U₁ = restrict_scalars' R U₂) : U₁ = U₂ :=
-ext $ by convert set.ext_iff.1 (ext'_iff.1 h); refl
-
-theorem restrict_scalars'_inj {U₁ U₂ : submodule S A} :
-  restrict_scalars' R U₁ = restrict_scalars' R U₂ ↔ U₁ = U₂ :=
-⟨restrict_scalars'_injective U₁ U₂, congr_arg _⟩
-
-end submodule
-
 section semiring
 
 variables {R S A}
@@ -343,7 +318,7 @@ span_induction hx (λ x hx, let ⟨p, q, hp, hq, hpq⟩ := set.mem_smul.1 hx in
   (λ c x hx, smul_left_comm c k x ▸ smul_mem _ _ hx)
 
 theorem span_smul {s : set S} (hs : span R s = ⊤) (t : set A) :
-  span R (s • t) = (span S t).restrict_scalars' R :=
+  span R (s • t) = (span S t).restrict_scalars R :=
 le_antisymm (span_le.2 $ λ x hx, let ⟨p, q, hps, hqt, hpqx⟩ := set.mem_smul.1 hx in
   hpqx ▸ (span S t).smul_mem p (subset_span hqt)) $
 λ p hp, span_induction hp (λ x hx, one_smul S x ▸ smul_mem_span_smul hs (subset_span hx))
@@ -354,7 +329,6 @@ le_antisymm (span_le.2 $ λ x hx, let ⟨p, q, hps, hqt, hpqx⟩ := set.mem_smul
 end submodule
 
 end semiring
-
 
 section ring
 
@@ -384,8 +358,8 @@ end
 theorem is_basis.smul {ι : Type v₁} {b : ι → S} {ι' : Type w₁} {c : ι' → A}
   (hb : is_basis R b) (hc : is_basis S c) : is_basis R (λ p : ι × ι', b p.1 • c p.2) :=
 ⟨linear_independent_smul hb.1 hc.1,
-by rw [← set.range_smul_range, submodule.span_smul hb.2, ← submodule.restrict_scalars'_top R S A,
-    submodule.restrict_scalars'_inj, hc.2]⟩
+by rw [← set.range_smul_range, submodule.span_smul hb.2, ← submodule.restrict_scalars_top R S A,
+    submodule.restrict_scalars_inj, hc.2]⟩
 
 theorem is_basis.smul_repr
   {ι ι' : Type*} {b : ι → S} {c : ι' → A}
@@ -455,8 +429,8 @@ begin
         ⟨f (yi * yj) yk, algebra.subset_adjoin $ hsy yi yj yk hyi hyj hyk⟩
         (subset_span $ set.mem_insert_of_mem _ hyk : yk ∈ _)) } },
   refine ⟨algebra.adjoin A (↑s : set B), subalgebra.fg_adjoin_finset _, insert 1 y, _⟩,
-  refine restrict_scalars'_injective _ _ (_ : restrict_scalars' A _ = _),
-  rw [restrict_scalars'_top, eq_top_iff, ← algebra.coe_top, ← hx, algebra.adjoin_eq_span, span_le],
+  refine restrict_scalars_injective A _ _ _,
+  rw [restrict_scalars_top, eq_top_iff, ← algebra.coe_top, ← hx, algebra.adjoin_eq_span, span_le],
   refine λ r hr, monoid.in_closure.rec_on hr hxy (subset_span $ mem_insert_self _ _)
       (λ p q _ _ hp hq, hyy $ submodule.mul_mem_mul hp hq)
 end


### PR DESCRIPTION
- rename `semimodule.restrict_scalars` to `restrict_scalars`
- rename `restrict_scalars` to `subspace.restrict_scalars`
- use `is_scalar_tower` wherever possible
- add warnings to docstrings about `restrict_scalars` to encourage `is_scalar_tower` instead



---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->