### PR TITLE
[Merged by Bors] - feat(linear_algebra/nonsingular_inverse): add stronger form of Cramer's rule

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -336,7 +336,7 @@
   author : Neil Strickland
 97:
   title  : Cramer’s Rule
-  decl   : matrix.cramers_rule
+  decl   : matrix.mul_vec_cramer
   author : Anne Baanen
 98:
   title  : Bertrand’s Postulate

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -405,7 +405,8 @@ B.nonsing_inv_left_right A h
 
 end inv
 
-lemma cramers_rule (A : matrix n n α) (b : n → α) (h : is_unit A.det) :
+/- One form of Cramer's rule. -/
+lemma mul_vec_cramer_of_det_is_unit (A : matrix n n α) (b : n → α) (h : is_unit A.det) :
   cramer A b = A.det • A⁻¹.mul_vec b :=
 begin
   rw [cramer_eq_adjugate_mul_vec, A.nonsing_inv_apply h, ← smul_mul_vec_assoc],
@@ -416,8 +417,8 @@ end
 /- A stronger form of Cramer's rule that allows us to solve some instances of `A ⬝ x = b` even if
 the determinant is not a unit. A sufficient (but still not necessary) condition is that `A.det`
 divides `b`. -/
-lemma cramers_rule_strong (A : matrix n n α) (b b' : n → α) (h : b = A.det • b') :
-  A.mul_vec (cramer A b') = b :=
-by rw [cramer_eq_adjugate_mul_vec, mul_vec_mul_vec, mul_adjugate, smul_mul_vec_assoc, mul_vec_one,h]
+@[simp] lemma mul_vec_cramer (A : matrix n n α) (b : n → α) :
+  A.mul_vec (cramer A b) = A.det • b :=
+by rw [cramer_eq_adjugate_mul_vec, mul_vec_mul_vec, mul_adjugate, smul_mul_vec_assoc, mul_vec_one]
 
 end matrix

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -194,7 +194,9 @@ begin
     exact h ((symm_apply_eq σ).mp h'.symm) }
 end
 
-lemma cramer_transpose_eq_adjugate_mul_vec (A : matrix n n α) (b : n → α) :
+/-- Since the map `b ↦ cramer A b` is linear in `b`, it must be multiplication by some matrix. This
+matrix is `A.adjugate`. -/
+lemma cramer_eq_adjugate_mul_vec (A : matrix n n α) (b : n → α) :
   cramer A b = A.adjugate.mul_vec b :=
 begin
   nth_rewrite 1 ← A.transpose_transpose,
@@ -406,9 +408,16 @@ end inv
 lemma cramers_rule (A : matrix n n α) (b : n → α) (h : is_unit A.det) :
   cramer A b = A.det • A⁻¹.mul_vec b :=
 begin
-  rw [cramer_transpose_eq_adjugate_mul_vec, A.nonsing_inv_apply h, ← smul_mul_vec_assoc],
+  rw [cramer_eq_adjugate_mul_vec, A.nonsing_inv_apply h, ← smul_mul_vec_assoc],
   conv_rhs { congr, congr, rw ← h.unit_spec, },
   rw units.smul_inv_smul,
 end
+
+/- A stronger form of Cramer's rule that allows us to solve some instances of `A ⬝ x = b` even if
+the determinant is not a unit. A sufficient (but still not necessary) condition is that `A.det`
+divides `b`. -/
+lemma cramers_rule_strong (A : matrix n n α) (b b' : n → α) (h : b = A.det • b') :
+  A.mul_vec (cramer A b') = b :=
+by rw [cramer_eq_adjugate_mul_vec, mul_vec_mul_vec, mul_adjugate, smul_mul_vec_assoc, mul_vec_one,h]
 
 end matrix

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -406,11 +406,11 @@ B.nonsing_inv_left_right A h
 end inv
 
 /- One form of Cramer's rule. -/
-lemma mul_vec_cramer_of_det_is_unit (A : matrix n n α) (b : n → α) (h : is_unit A.det) :
-  cramer A b = A.det • A⁻¹.mul_vec b :=
+@[simp] lemma det_smul_inv_mul_vec_eq_cramer (A : matrix n n α) (b : n → α) (h : is_unit A.det) :
+  A.det • A⁻¹.mul_vec b = cramer A b :=
 begin
   rw [cramer_eq_adjugate_mul_vec, A.nonsing_inv_apply h, ← smul_mul_vec_assoc],
-  conv_rhs { congr, congr, rw ← h.unit_spec, },
+  conv_lhs { congr, congr, rw ← h.unit_spec, },
   rw units.smul_inv_smul,
 end
 


### PR DESCRIPTION
Also renaming `cramer_transpose_eq_adjugate_mul_vec` --> `cramer_eq_adjugate_mul_vec` after the transpose was rendered redundant.

---
Unfortunately these changes only occurred to  me as I was looking over https://github.com/leanprover-community/mathlib/pull/4700 after it merged.

Arguably we should drop the `cramers_rule` and just keep `cramers_rule_strong` (which would then just be called `cramers_rule`).