### PR TITLE
[Merged by Bors] - chore(algebra/group/basic): Mark inv_involutive simp

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -95,7 +95,7 @@ theorem left_inverse_inv (G) [group G] :
   function.left_inverse (λ a : G, a⁻¹) (λ a, a⁻¹) :=
 inv_inv
 
-@[simps, to_additive]
+@[simp, to_additive]
 lemma inv_involutive : function.involutive (has_inv.inv : G → G) := inv_inv
 
 @[to_additive]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -95,7 +95,7 @@ theorem left_inverse_inv (G) [group G] :
   function.left_inverse (λ a : G, a⁻¹) (λ a, a⁻¹) :=
 inv_inv
 
-@[to_additive]
+@[simps, to_additive]
 lemma inv_involutive : function.involutive (has_inv.inv : G → G) := inv_inv
 
 @[to_additive]


### PR DESCRIPTION
This means expressions like `has_inv.inv ∘ has_inv.inv` can be simplified

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

~~I might need to remove `@[simp]` from `inv_inv` to make this pass the linter.~~