### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/add_torsor): continuity of `vadd`/`vsub`

### DIFF
--- a/src/algebra/add_torsor.lean
+++ b/src/algebra/add_torsor.lean
@@ -230,6 +230,10 @@ element. -/
 lemma eq_vadd_iff_vsub_eq (p1 : P) (g : G) (p2 : P) : p1 = g +ᵥ p2 ↔ p1 -ᵥ p2 = g :=
 ⟨λ h, h.symm ▸ vadd_vsub _ _, λ h, h ▸ (vsub_vadd _ _).symm⟩
 
+lemma vadd_eq_vadd_iff_neg_add_eq_vsub {v₁ v₂ : G} {p₁ p₂ : P} :
+  v₁ +ᵥ p₁ = v₂ +ᵥ p₂ ↔ - v₁ + v₂ = p₁ -ᵥ p₂ :=
+by rw [eq_vadd_iff_vsub_eq, vadd_vsub_assoc, ← add_right_inj (-v₁), neg_add_cancel_left, eq_comm]
+
 namespace set
 
 instance has_vsub : has_vsub (set G) (set P) := ⟨set.image2 (-ᵥ)⟩
@@ -335,9 +339,11 @@ section comm
 
 variables {G : Type*} {P : Type*} [add_comm_group G] [add_torsor G P]
 
+include G
+
 /-- Cancellation subtracting the results of two subtractions. -/
 @[simp] lemma vsub_sub_vsub_cancel_left (p1 p2 p3 : P) :
-  (p3 -ᵥ p2 : G) - (p3 -ᵥ p1) = (p1 -ᵥ p2) :=
+  (p3 -ᵥ p2) - (p3 -ᵥ p1) = (p1 -ᵥ p2) :=
 by rw [sub_eq_add_neg, neg_vsub_eq_vsub_rev, add_comm, vsub_add_vsub_cancel]
 
 @[simp] lemma vadd_vsub_vadd_cancel_left (v : G) (p1 p2 : P) :
@@ -349,6 +355,14 @@ begin
   rw [←@vsub_eq_zero_iff_eq G, vadd_vsub_assoc, vsub_vadd_eq_vsub_sub],
   simp
 end
+
+lemma vadd_eq_vadd_iff_sub_eq_vsub {v₁ v₂ : G} {p₁ p₂ : P} :
+  v₁ +ᵥ p₁ = v₂ +ᵥ p₂ ↔ v₂ - v₁ = p₁ -ᵥ p₂ :=
+by rw [vadd_eq_vadd_iff_neg_add_eq_vsub, neg_add_eq_sub]
+
+lemma vsub_sub_vsub_comm (p₁ p₂ p₃ p₄ : P) :
+  (p₁ -ᵥ p₂) - (p₃ -ᵥ p₄) = (p₁ -ᵥ p₃) - (p₂ -ᵥ p₄) :=
+by rw [← vsub_vadd_eq_vsub_sub, vsub_vadd_comm, vsub_vadd_eq_vsub_sub]
 
 end comm
 

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -1,12 +1,10 @@
 /-
 Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Joseph Myers.
+Authors: Joseph Myers, Yury Kudryashov.
 -/
 import algebra.add_torsor
 import topology.metric_space.isometry
-
-noncomputable theory
 
 /-!
 # Torsors of additive normed group actions.
@@ -17,7 +15,9 @@ spaces.
 
 -/
 
-universes u v
+noncomputable theory
+open_locale nnreal topological_space
+open filter
 
 /-- A `normed_add_torsor V P` is a torsor of an additive normed group
 action by a `normed_group V` on points `P`. We bundle the metric space
@@ -25,13 +25,17 @@ structure and require the distance to be the same as results from the
 norm (which in fact implies the distance yields a metric space, but
 bundling just the distance and using an instance for the metric space
 results in type class problems). -/
-class normed_add_torsor (V : out_param $ Type u) (P : Type v)
+class normed_add_torsor (V : out_param $ Type*) (P : Type*)
   [out_param $ normed_group V] [metric_space P]
   extends add_torsor V P :=
 (dist_eq_norm' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
 
-variables (V : Type u) {P : Type v} [normed_group V] [metric_space P] [normed_add_torsor V P]
+variables {α V P : Type*} [normed_group V] [metric_space P] [normed_add_torsor V P]
 include V
+
+section
+
+variable (V)
 
 /-- The distance equals the norm of subtracting two points. In this
 lemma, it is necessary to have `V` as an explicit argument; otherwise
@@ -40,7 +44,12 @@ lemma dist_eq_norm_vsub (x y : P) :
   dist x y = ∥(x -ᵥ y)∥ :=
 normed_add_torsor.dist_eq_norm' x y
 
-variable {V}
+/-- A `normed_group` is a `normed_add_torsor` over itself. -/
+@[priority 100]
+instance normed_group.normed_add_torsor : normed_add_torsor V V :=
+{ dist_eq_norm' := dist_eq_norm }
+
+end
 
 @[simp] lemma dist_vadd_cancel_left (v : V) (x y : P) :
   dist (v +ᵥ x) (v +ᵥ y) = dist x y :=
@@ -50,17 +59,44 @@ by rw [dist_eq_norm_vsub V, dist_eq_norm_vsub V, vadd_vsub_vadd_cancel_left]
   dist (v₁ +ᵥ x) (v₂ +ᵥ x) = dist v₁ v₂ :=
 by rw [dist_eq_norm_vsub V, dist_eq_norm, vadd_vsub_vadd_cancel_right]
 
-/-- A `normed_group` is a `normed_add_torsor` over itself. -/
-@[nolint instance_priority] -- false positive
-instance normed_group.normed_add_torsor (V : Type u) [normed_group V] :
-  normed_add_torsor V V :=
-{ dist_eq_norm' := dist_eq_norm }
+@[simp] lemma dist_vsub_cancel_left (x y z : P) : dist (x -ᵥ y) (x -ᵥ z) = dist y z :=
+by rw [dist_eq_norm, vsub_sub_vsub_cancel_left, dist_comm, dist_eq_norm_vsub V]
+
+@[simp] lemma dist_vsub_cancel_right (x y z : P) : dist (x -ᵥ z) (y -ᵥ z) = dist x y :=
+by rw [dist_eq_norm, vsub_sub_vsub_cancel_right, dist_eq_norm_vsub V]
+
+lemma dist_vadd_vadd_le (v v' : V) (p p' : P) :
+  dist (v +ᵥ p) (v' +ᵥ p') ≤ dist v v' + dist p p' :=
+by simpa using dist_triangle (v +ᵥ p) (v' +ᵥ p) (v' +ᵥ p')
+
+lemma dist_vsub_vsub_le (p₁ p₂ p₃ p₄ : P) :
+  dist (p₁ -ᵥ p₂) (p₃ -ᵥ p₄) ≤ dist p₁ p₃ + dist p₂ p₄ :=
+by { rw [dist_eq_norm, vsub_sub_vsub_comm, dist_eq_norm_vsub V, dist_eq_norm_vsub V],
+ exact norm_sub_le _ _ }
+
+lemma nndist_vadd_vadd_le (v v' : V) (p p' : P) :
+  nndist (v +ᵥ p) (v' +ᵥ p') ≤ nndist v v' + nndist p p' :=
+by simp only [← nnreal.coe_le_coe, nnreal.coe_add, ← dist_nndist, dist_vadd_vadd_le]
+
+lemma nndist_vsub_vsub_le (p₁ p₂ p₃ p₄ : P) :
+  nndist (p₁ -ᵥ p₂) (p₃ -ᵥ p₄) ≤ nndist p₁ p₃ + nndist p₂ p₄ :=
+by simp only [← nnreal.coe_le_coe, nnreal.coe_add, ← dist_nndist, dist_vsub_vsub_le]
+
+lemma edist_vadd_vadd_le (v v' : V) (p p' : P) :
+  edist (v +ᵥ p) (v' +ᵥ p') ≤ edist v v' + edist p p' :=
+by { simp only [edist_nndist], apply_mod_cast nndist_vadd_vadd_le }
+
+lemma edist_vsub_vsub_le (p₁ p₂ p₃ p₄ : P) :
+  edist (p₁ -ᵥ p₂) (p₃ -ᵥ p₄) ≤ edist p₁ p₃ + edist p₂ p₄ :=
+by { simp only [edist_nndist], apply_mod_cast nndist_vsub_vsub_le }
+
+omit V
 
 /-- The distance defines a metric space structure on the torsor. This
 is not an instance because it depends on `V` to define a `metric_space
 P`. -/
-def metric_space_of_normed_group_of_add_torsor (V : Type u) (P : Type v) [normed_group V]
-    [add_torsor V P] : metric_space P :=
+def metric_space_of_normed_group_of_add_torsor (V P : Type*) [normed_group V] [add_torsor V P] :
+  metric_space P :=
 { dist := λ x y, ∥(x -ᵥ y : V)∥,
   dist_self := λ x, by simp,
   eq_of_dist_eq_zero := λ x y h, by simpa using h,
@@ -71,6 +107,8 @@ def metric_space_of_normed_group_of_add_torsor (V : Type u) (P : Type v) [normed
     rw ←vsub_add_vsub_cancel,
     apply norm_add_le
   end }
+
+include V
 
 namespace isometric
 
@@ -98,6 +136,83 @@ variable (V)
 isometric.to_equiv_inj $ equiv.const_vadd_zero V P
 
 end isometric
+
+lemma lipschitz_with.vadd [emetric_space α] {f : α → V} {g : α → P} {Kf Kg : ℝ≥0}
+  (hf : lipschitz_with Kf f) (hg : lipschitz_with Kg g) :
+  lipschitz_with (Kf + Kg) (f +ᵥ g) :=
+λ x y,
+calc edist (f x +ᵥ g x) (f y +ᵥ g y) ≤ edist (f x) (f y) + edist (g x) (g y) :
+  edist_vadd_vadd_le _ _ _ _
+... ≤ Kf * edist x y + Kg * edist x y :
+  add_le_add (hf x y) (hg x y)
+... = (Kf + Kg) * edist x y :
+  (add_mul _ _ _).symm
+
+lemma lipschitz_with.vsub [emetric_space α] {f g : α → P} {Kf Kg : ℝ≥0}
+  (hf : lipschitz_with Kf f) (hg : lipschitz_with Kg g) :
+  lipschitz_with (Kf + Kg) (f -ᵥ g) :=
+λ x y,
+calc edist (f x -ᵥ g x) (f y -ᵥ g y) ≤ edist (f x) (f y) + edist (g x) (g y) :
+  edist_vsub_vsub_le _ _ _ _
+... ≤ Kf * edist x y + Kg * edist x y :
+  add_le_add (hf x y) (hg x y)
+... = (Kf + Kg) * edist x y :
+  (add_mul _ _ _).symm
+
+lemma uniform_continuous_vadd : uniform_continuous (λ x : V × P, x.1 +ᵥ x.2) :=
+(lipschitz_with.prod_fst.vadd lipschitz_with.prod_snd).uniform_continuous
+
+lemma uniform_continuous_vsub : uniform_continuous (λ x : P × P, x.1 -ᵥ x.2) :=
+(lipschitz_with.prod_fst.vsub lipschitz_with.prod_snd).uniform_continuous
+
+lemma continuous_vadd : continuous (λ x : V × P, x.1 +ᵥ x.2) :=
+uniform_continuous_vadd.continuous
+
+lemma continuous_vsub : continuous (λ x : P × P, x.1 -ᵥ x.2) :=
+uniform_continuous_vsub.continuous
+
+lemma filter.tendsto.vadd {l : filter α} {f : α → V} {g : α → P} {v : V} {p : P}
+  (hf : tendsto f l (𝓝 v)) (hg : tendsto g l (𝓝 p)) :
+  tendsto (f +ᵥ g) l (𝓝 (v +ᵥ p)) :=
+(continuous_vadd.tendsto (v, p)).comp (hf.prod_mk_nhds hg)
+
+lemma filter.tendsto.vsub {l : filter α} {f g : α → P} {x y : P}
+  (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
+  tendsto (f -ᵥ g) l (𝓝 (x -ᵥ y)) :=
+(continuous_vsub.tendsto (x, y)).comp (hf.prod_mk_nhds hg)
+
+section
+
+variables [topological_space α]
+
+lemma continuous.vadd {f : α → V} {g : α → P} (hf : continuous f) (hg : continuous g) :
+  continuous (f +ᵥ g) :=
+continuous_vadd.comp (hf.prod_mk hg)
+
+lemma continuous.vsub {f g : α → P} (hf : continuous f) (hg : continuous g) :
+  continuous (f -ᵥ g) :=
+continuous_vsub.comp (hf.prod_mk hg)
+
+lemma continuous_at.vadd {f : α → V} {g : α → P} {x : α} (hf : continuous_at f x)
+  (hg : continuous_at g x) :
+  continuous_at (f +ᵥ g) x :=
+hf.vadd hg
+
+lemma continuous_at.vsub {f g : α → P}  {x : α} (hf : continuous_at f x) (hg : continuous_at g x) :
+  continuous_at (f -ᵥ g) x :=
+hf.vsub hg
+
+lemma continuous_within_at.vadd {f : α → V} {g : α → P} {x : α} {s : set α}
+  (hf : continuous_within_at f s x) (hg : continuous_within_at g s x) :
+  continuous_within_at (f +ᵥ g) s x :=
+hf.vadd hg
+
+lemma continuous_within_at.vsub {f g : α → P} {x : α} {s : set α}
+  (hf : continuous_within_at f s x) (hg : continuous_within_at g s x) :
+  continuous_within_at (f -ᵥ g) s x :=
+hf.vsub hg
+
+end
 
 variables {V' : Type*} {P' : Type*} [normed_group V'] [metric_space P'] [normed_add_torsor V' P']
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -438,15 +438,7 @@ end
 continuous. -/
 @[priority 100] -- see Note [lower instance priority]
 instance normed_uniform_group : uniform_add_group α :=
-begin
-  refine ⟨metric.uniform_continuous_iff.2 $ assume ε hε, ⟨ε / 2, half_pos hε, assume a b h, _⟩⟩,
-  rw [prod.dist_eq, max_lt_iff, dist_eq_norm, dist_eq_norm] at h,
-  calc dist (a.1 - a.2) (b.1 - b.2) = ∥(a.1 - b.1) - (a.2 - b.2)∥ :
-      by simp [dist_eq_norm, sub_eq_add_neg]; abel
-    ... ≤ ∥a.1 - b.1∥ + ∥a.2 - b.2∥ : norm_sub_le _ _
-    ... < ε / 2 + ε / 2 : add_lt_add h.1 h.2
-    ... = ε : add_halves _
-end
+⟨(lipschitz_with.prod_fst.sub lipschitz_with.prod_snd).uniform_continuous⟩
 
 @[priority 100] -- see Note [lower instance priority]
 instance normed_top_monoid : has_continuous_add α := by apply_instance -- short-circuit type class inference


### PR DESCRIPTION
Prove that `vadd`/`vsub` are Lipschitz continuous, hence uniform
continuous and continuous.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->