### PR TITLE
[Merged by Bors] - feat(algebra/direct_sum): Bundle the homomorphisms

### DIFF
--- a/src/algebra/direct_sum.lean
+++ b/src/algebra/direct_sum.lean
@@ -49,43 +49,18 @@ include dec_ι
 
 /-- `mk β s x` is the element of `⨁ i, β i` that is zero outside `s`
 and has coefficient `x i` for `i` in `s`. -/
-def mk : Π s : finset ι, (Π i : (↑s : set ι), β i.1) → ⨁ i, β i :=
-dfinsupp.mk
+def mk (s : finset ι) : (Π i : (↑s : set ι), β i.1) →+ ⨁ i, β i :=
+{ to_fun := dfinsupp.mk s,
+  map_add' := λ _ _, dfinsupp.mk_add,
+  map_zero' := dfinsupp.mk_zero, }
 
 /-- `of i` is the natural inclusion map from `β i` to `⨁ i, β i`. -/
-def of : Π i : ι, β i → ⨁ i, β i :=
-dfinsupp.single
+def of (i : ι) : β i →+ ⨁ i, β i :=
+{ to_fun := dfinsupp.single i,
+  map_add' := λ _ _, dfinsupp.single_add,
+  map_zero' := dfinsupp.single_zero }
+
 variables {β}
-
-instance mk.is_add_group_hom (s : finset ι) : is_add_group_hom (mk β s) :=
-{ map_add := λ _ _, dfinsupp.mk_add }
-
-@[simp] lemma mk_zero (s : finset ι) : mk β s 0 = 0 :=
-is_add_group_hom.map_zero _
-
-@[simp] lemma mk_add (s : finset ι) (x y) : mk β s (x + y) = mk β s x + mk β s y :=
-is_add_hom.map_add _ x y
-
-@[simp] lemma mk_neg (s : finset ι) (x) : mk β s (-x) = -mk β s x :=
-is_add_group_hom.map_neg _ x
-
-@[simp] lemma mk_sub (s : finset ι) (x y) : mk β s (x - y) = mk β s x - mk β s y :=
-is_add_group_hom.map_sub _ x y
-
-instance of.is_add_group_hom (i : ι) : is_add_group_hom (of β i) :=
-{ map_add := λ _ _, dfinsupp.single_add }
-
-@[simp] lemma of_zero (i : ι) : of β i 0 = 0 :=
-is_add_group_hom.map_zero _
-
-@[simp] lemma of_add (i : ι) (x y) : of β i (x + y) = of β i x + of β i y :=
-is_add_hom.map_add _ x y
-
-@[simp] lemma of_neg (i : ι) (x) : of β i (-x) = -of β i x :=
-is_add_group_hom.map_neg _ x
-
-@[simp] lemma of_sub (i : ι) (x y) : of β i (x - y) = of β i x - of β i y :=
-is_add_group_hom.map_sub _ x y
 
 theorem mk_injective (s : finset ι) : function.injective (mk β s) :=
 dfinsupp.mk_injective s
@@ -105,96 +80,79 @@ begin
 end
 
 variables {γ : Type u₁} [add_comm_group γ]
-variables (φ : Π i, β i → γ) [Π i, is_add_group_hom (φ i)]
+variables (φ : Π i, β i →+ γ)
 
 variables (φ)
 /-- `to_group φ` is the natural homomorphism from `⨁ i, β i` to `γ`
 induced by a family `φ` of homomorphisms `β i → γ`. -/
-def to_group (f : ⨁ i, β i) : γ :=
-quotient.lift_on f (λ x, ∑ i in x.2.to_finset, φ i (x.1 i)) $ λ x y H,
-begin
-  have H1 : x.2.to_finset ∩ y.2.to_finset ⊆ x.2.to_finset, from finset.inter_subset_left _ _,
-  have H2 : x.2.to_finset ∩ y.2.to_finset ⊆ y.2.to_finset, from finset.inter_subset_right _ _,
-  refine (finset.sum_subset H1 _).symm.trans ((finset.sum_congr rfl _).trans (finset.sum_subset H2 _)),
-  { intros i H1 H2, rw finset.mem_inter at H2, rw H i,
-    simp only [multiset.mem_to_finset] at H1 H2,
-    rw [(y.3 i).resolve_left (mt (and.intro H1) H2), is_add_group_hom.map_zero (φ i)] },
-  { intros i H1, rw H i },
-  { intros i H1 H2, rw finset.mem_inter at H2, rw ← H i,
-    simp only [multiset.mem_to_finset] at H1 H2,
-    rw [(x.3 i).resolve_left (mt (λ H3, and.intro H3 H1) H2), is_add_group_hom.map_zero (φ i)] }
-end
-variables {φ}
-
-instance to_group.is_add_group_hom : is_add_group_hom (to_group φ) :=
-{ map_add := assume f g,
-begin
-  refine quotient.induction_on f (λ x, _),
-  refine quotient.induction_on g (λ y, _),
-  change ∑ i in _, _ = (∑ i in _, _) + (∑ i in _, _),
-  simp only, conv { to_lhs, congr, skip, funext, rw is_add_hom.map_add (φ i) },
-  simp only [finset.sum_add_distrib],
-  congr' 1,
-  { refine (finset.sum_subset _ _).symm,
-    { intro i, simp only [multiset.mem_to_finset, multiset.mem_add], exact or.inl },
-    { intros i H1 H2, simp only [multiset.mem_to_finset, multiset.mem_add] at H2,
-      rw [(x.3 i).resolve_left H2, is_add_group_hom.map_zero (φ i)] } },
-  { refine (finset.sum_subset _ _).symm,
-    { intro i, simp only [multiset.mem_to_finset, multiset.mem_add], exact or.inr },
-    { intros i H1 H2, simp only [multiset.mem_to_finset, multiset.mem_add] at H2,
-      rw [(y.3 i).resolve_left H2, is_add_group_hom.map_zero (φ i)] } }
-end }
-
-variables (φ)
-@[simp] lemma to_group_zero : to_group φ 0 = 0 :=
-is_add_group_hom.map_zero _
-
-@[simp] lemma to_group_add (x y) : to_group φ (x + y) = to_group φ x + to_group φ y :=
-is_add_hom.map_add _ x y
-
-@[simp] lemma to_group_neg (x) : to_group φ (-x) = -to_group φ x :=
-is_add_group_hom.map_neg _ x
-
-@[simp] lemma to_group_sub (x y) : to_group φ (x - y) = to_group φ x - to_group φ y :=
-is_add_group_hom.map_sub _ x y
+def to_group : (⨁ i, β i) →+ γ :=
+{ to_fun := (λ f,
+    quotient.lift_on f (λ x, ∑ i in x.2.to_finset, φ i (x.1 i)) $ λ x y H,
+    begin
+      have H1 : x.2.to_finset ∩ y.2.to_finset ⊆ x.2.to_finset, from finset.inter_subset_left _ _,
+      have H2 : x.2.to_finset ∩ y.2.to_finset ⊆ y.2.to_finset, from finset.inter_subset_right _ _,
+      refine (finset.sum_subset H1 _).symm.trans ((finset.sum_congr rfl _).trans (finset.sum_subset H2 _)),
+      { intros i H1 H2, rw finset.mem_inter at H2, rw H i,
+        simp only [multiset.mem_to_finset] at H1 H2,
+        rw [(y.3 i).resolve_left (mt (and.intro H1) H2), add_monoid_hom.map_zero] },
+      { intros i H1, rw H i },
+      { intros i H1 H2, rw finset.mem_inter at H2, rw ← H i,
+        simp only [multiset.mem_to_finset] at H1 H2,
+        rw [(x.3 i).resolve_left (mt (λ H3, and.intro H3 H1) H2), add_monoid_hom.map_zero] }
+    end),
+  map_add' := assume f g,
+  begin
+    refine quotient.induction_on f (λ x, _),
+    refine quotient.induction_on g (λ y, _),
+    change ∑ i in _, _ = (∑ i in _, _) + (∑ i in _, _),
+    simp only, conv { to_lhs, congr, skip, funext, rw add_monoid_hom.map_add },
+    simp only [finset.sum_add_distrib],
+    congr' 1,
+    { refine (finset.sum_subset _ _).symm,
+      { intro i, simp only [multiset.mem_to_finset, multiset.mem_add], exact or.inl },
+      { intros i H1 H2, simp only [multiset.mem_to_finset, multiset.mem_add] at H2,
+        rw [(x.3 i).resolve_left H2, add_monoid_hom.map_zero] } },
+    { refine (finset.sum_subset _ _).symm,
+      { intro i, simp only [multiset.mem_to_finset, multiset.mem_add], exact or.inr },
+      { intros i H1 H2, simp only [multiset.mem_to_finset, multiset.mem_add] at H2,
+        rw [(y.3 i).resolve_left H2, add_monoid_hom.map_zero] } }
+  end,
+  map_zero' := rfl
+}
 
 @[simp] lemma to_group_of (i) (x : β i) : to_group φ (of β i x) = φ i x :=
 (add_zero _).trans $ congr_arg (φ i) $ show (if H : i ∈ ({i} : finset _) then x else 0) = x,
 from dif_pos $ finset.mem_singleton_self i
 
-variables (ψ : (⨁ i, β i) → γ) [is_add_group_hom ψ]
+variables (ψ : (⨁ i, β i) →+ γ)
 
 theorem to_group.unique (f : ⨁ i, β i) :
-  ψ f = @to_group _ _ _ _ _ _ (λ i, ψ ∘ of β i) (λ i, is_add_group_hom.comp (of β i) ψ) f :=
-by haveI : ∀ i, is_add_group_hom (ψ ∘ of β i) := (λ _, is_add_group_hom.comp _ _); exact
+  ψ f = to_group (λ i, ψ.comp (of β i)) f :=
 direct_sum.induction_on f
-  (by rw [is_add_group_hom.map_zero ψ, is_add_group_hom.map_zero (to_group (λ i, ψ ∘ of β i))])
-  (λ i x, by rw [to_group_of])
-  (λ x y ihx ihy, by rw [is_add_hom.map_add ψ, is_add_hom.map_add (to_group (λ i, ψ ∘ of β i)), ihx, ihy])
+  (by rw [add_monoid_hom.map_zero, add_monoid_hom.map_zero])
+  (λ i x, by rw [to_group_of, add_monoid_hom.comp_apply])
+  (λ x y ihx ihy, by rw [add_monoid_hom.map_add, add_monoid_hom.map_add, ihx, ihy])
 
 variables (β)
 /-- `set_to_set β S T h` is the natural homomorphism `⨁ (i : S), β i → ⨁ (i : T), β i`,
 where `h : S ⊆ T`. -/
 -- TODO: generalize this to remove the assumption `S ⊆ T`.
 def set_to_set (S T : set ι) (H : S ⊆ T) :
-  (⨁ (i : S), β i) → (⨁ (i : T), β i) :=
+  (⨁ (i : S), β i) →+ (⨁ (i : T), β i) :=
 to_group $ λ i, of (β ∘ @subtype.val _ T) ⟨i.1, H i.2⟩
 variables {β}
-
-instance (S T : set ι) (H : S ⊆ T) : is_add_group_hom (set_to_set β S T H) :=
-to_group.is_add_group_hom
 
 omit dec_ι
 
 /-- The natural equivalence between `⨁ _ : punit, M` and `M`. -/
 -- TODO: generalize this to a sum over any type `ι` that is `unique ι`.
 protected def id (M : Type v) [add_comm_group M] : (⨁ (_ : punit), M) ≃ M :=
-{ to_fun := direct_sum.to_group (λ _, id),
+{ to_fun := direct_sum.to_group (λ _, add_monoid_hom.id M),
   inv_fun := of (λ _, M) punit.star,
   left_inv := λ x, direct_sum.induction_on x
-    (by rw [to_group_zero, of_zero])
+    (by rw [add_monoid_hom.map_zero, add_monoid_hom.map_zero])
     (λ ⟨⟩ x, by rw [to_group_of]; refl)
-    (λ x y ihx ihy, by rw [to_group_add, of_add, ihx, ihy]),
+    (λ x y ihx ihy, by rw [add_monoid_hom.map_add, add_monoid_hom.map_add, ihx, ihy]),
   right_inv := λ x, to_group_of _ _ _ }
 
 instance : has_coe_to_fun (⨁ i, β i) :=

--- a/src/linear_algebra/direct_sum/finsupp.lean
+++ b/src/linear_algebra/direct_sum/finsupp.lean
@@ -39,7 +39,7 @@ linear_equiv.of_linear
 
 @[simp] theorem finsupp_lequiv_direct_sum_single (i : ι) (m : M) :
   finsupp_lequiv_direct_sum R M ι (finsupp.single i m) = direct_sum.lof R ι _ i m :=
-finsupp.sum_single_index $ direct_sum.of_zero i
+finsupp.sum_single_index $ linear_map.map_zero _
 
 @[simp] theorem finsupp_lequiv_direct_sum_symm_lof (i : ι) (m : M) :
   (finsupp_lequiv_direct_sum R M ι).symm (direct_sum.lof R ι _ i m) = finsupp.single i m :=

--- a/src/linear_algebra/direct_sum_module.lean
+++ b/src/linear_algebra/direct_sum_module.lean
@@ -67,26 +67,29 @@ variables (φ : Π i, M i →ₗ[R] N)
 variables (ι N φ)
 /-- The linear map constructed using the universal property of the coproduct. -/
 def to_module : (⨁ i, M i) →ₗ[R] N :=
-{ to_fun := to_group (λ i, φ i),
-  map_add' := to_group_add _,
+{ to_fun := to_group (λ i, (φ i).to_add_monoid_hom),
+  map_add' := (to_group (λ i, (φ i).to_add_monoid_hom)).map_add,
   map_smul' := λ c x, direct_sum.induction_on x
-    (by rw [smul_zero, to_group_zero, smul_zero])
-    (λ i x, by rw [← of_smul, to_group_of, to_group_of, (φ i).map_smul c x])
-    (λ x y ihx ihy, by rw [smul_add, to_group_add, ihx, ihy, to_group_add, smul_add]) }
+    (by rw [smul_zero, add_monoid_hom.map_zero, smul_zero])
+    (λ i x,
+      by rw [← of_smul, to_group_of, to_group_of, linear_map.to_add_monoid_hom_coe,
+        linear_map.map_smul])
+    (λ x y ihx ihy,
+      by rw [smul_add, add_monoid_hom.map_add, ihx, ihy, add_monoid_hom.map_add, smul_add]) }
 
 variables {ι N φ}
 
 /-- The map constructed using the universal property gives back the original maps when
 restricted to each component. -/
 @[simp] lemma to_module_lof (i) (x : M i) : to_module R ι N φ (lof R ι M i x) = φ i x :=
-to_group_of (λ i, φ i) i x
+to_group_of (λ i, (φ i).to_add_monoid_hom) i x
 
 variables (ψ : (⨁ i, M i) →ₗ[R] N)
 
 /-- Every linear map from a direct sum agrees with the one obtained by applying
 the universal property to each of its components. -/
 theorem to_module.unique (f : ⨁ i, M i) : ψ f = to_module R ι N (λ i, ψ.comp $ lof R ι M i) f :=
-to_group.unique ψ f
+to_group.unique ψ.to_add_monoid_hom f
 
 variables {ψ} {ψ' : (⨁ i, M i) →ₗ[R] N}
 


### PR DESCRIPTION
---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

As suggested quite some time ago by @kckennylau

I'm not really convinced yet that bundled homs are better, but since the unbundled ones are deprecated...