### PR TITLE
[Merged by Bors] - fix(deprecated/group): Correct the name of `is_add_group_hom has_neg.neg`

### DIFF
--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -269,7 +269,7 @@ end
 end ring_hom
 
 /-- Inversion is a group homomorphism if the group is commutative. -/
-@[instance, to_additive]
+@[instance, to_additive "neg.is_add_group_hom"]
 lemma inv.is_group_hom [comm_group α] : is_group_hom (has_inv.inv : α → α) :=
 { map_mul := mul_inv }
 

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -269,7 +269,7 @@ end
 end ring_hom
 
 /-- Inversion is a group homomorphism if the group is commutative. -/
-@[instance, to_additive "neg.is_add_group_hom"]
+@[instance, to_additive neg.is_add_group_hom "Negation is an add_group homomorphism if the add_group is commutative."]
 lemma inv.is_group_hom [comm_group α] : is_group_hom (has_inv.inv : α → α) :=
 { map_mul := mul_inv }
 

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -269,7 +269,8 @@ end
 end ring_hom
 
 /-- Inversion is a group homomorphism if the group is commutative. -/
-@[instance, to_additive neg.is_add_group_hom "Negation is an add_group homomorphism if the add_group is commutative."]
+@[instance, to_additive neg.is_add_group_hom 
+"Negation is an `add_group` homomorphism if the `add_group` is commutative."]
 lemma inv.is_group_hom [comm_group α] : is_group_hom (has_inv.inv : α → α) :=
 { map_mul := mul_inv }
 


### PR DESCRIPTION
Rename `inv.is_add_group_hom` to `neg.is_add_group_hom`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
