### PR TITLE
[Merged by Bors] - feat(ring_theory/polynomial/content): `gcd_monoid` instance on polynomials over gcd domain

### DIFF
--- a/src/data/polynomial/cancel_leads.lean
+++ b/src/data/polynomial/cancel_leads.lean
@@ -60,7 +60,8 @@ begin
       mul_comm _ q.leading_coeff, ← sub_eq_add_neg, ← mul_sub, sub_self, mul_zero] }
 end
 
-lemma dvd_cancel_leads_of_dvd_of_dvd [comm_ring R] {p q r : polynomial R} (pq : p ∣ q) (pr : p ∣ r) :
+lemma dvd_cancel_leads_of_dvd_of_dvd
+  [comm_ring R] {p q r : polynomial R} (pq : p ∣ q) (pr : p ∣ r) :
   p ∣ q.cancel_leads r :=
 dvd_sub (dvd.trans pr (dvd.intro_left _ rfl)) (dvd.trans pq (dvd.intro_left _ rfl))
 

--- a/src/data/polynomial/cancel_leads.lean
+++ b/src/data/polynomial/cancel_leads.lean
@@ -22,11 +22,24 @@ noncomputable theory
 
 variables {R : Type*}
 
+section comm_ring
+variables [comm_ring R] (p q : polynomial R)
+
 /-- `cancel_leads p q` is formed by multiplying `p` and `q` by monomials so that they
   have the same leading term, and then subtracting. -/
-def cancel_leads [comm_ring R] (p q : polynomial R) : polynomial R :=
-  C p.leading_coeff * X ^ (p.nat_degree - q.nat_degree) * q
-  - C q.leading_coeff * X ^ (q.nat_degree - p.nat_degree) * p
+def cancel_leads : polynomial R :=
+C p.leading_coeff * X ^ (p.nat_degree - q.nat_degree) * q -
+C q.leading_coeff * X ^ (q.nat_degree - p.nat_degree) * p
+
+variables {p q}
+
+@[simp] lemma neg_cancel_leads : - p.cancel_leads q = q.cancel_leads p := neg_sub _ _
+
+lemma dvd_cancel_leads_of_dvd_of_dvd {r : polynomial R} (pq : p ∣ q) (pr : p ∣ r) :
+  p ∣ q.cancel_leads r :=
+dvd_sub (dvd.trans pr (dvd.intro_left _ rfl)) (dvd.trans pq (dvd.intro_left _ rfl))
+
+end comm_ring
 
 lemma nat_degree_cancel_leads_lt_of_nat_degree_le_nat_degree [integral_domain R]
   {p q : polynomial R} (h : p.nat_degree ≤ q.nat_degree) (hq : 0 < q.nat_degree) :
@@ -59,10 +72,5 @@ begin
     rw [add_comm p.nat_degree, nat.sub_add_cancel h, ← leading_coeff, ← leading_coeff,
       mul_comm _ q.leading_coeff, ← sub_eq_add_neg, ← mul_sub, sub_self, mul_zero] }
 end
-
-lemma dvd_cancel_leads_of_dvd_of_dvd
-  [comm_ring R] {p q r : polynomial R} (pq : p ∣ q) (pr : p ∣ r) :
-  p ∣ q.cancel_leads r :=
-dvd_sub (dvd.trans pr (dvd.intro_left _ rfl)) (dvd.trans pq (dvd.intro_left _ rfl))
 
 end polynomial

--- a/src/data/polynomial/cancel_leads.lean
+++ b/src/data/polynomial/cancel_leads.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2020 Aaron Anderson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Anderson
+-/
+import data.polynomial.degree.basic
+
+/-!
+# Cancel the leading terms of two polynomials
+
+## Definition
+
+* `cancel_leads p q`: the polynomial formed by multiplying `p` and `q` by monomials so that they
+  have the same leading term, and then subtracting.
+
+## Main Results
+The degree of `cancel_leads` is less than that of the larger of the two polynomials being cancelled.
+Thus it is useful for induction or minimal-degree arguments.
+-/
+namespace polynomial
+noncomputable theory
+
+variables {R : Type*}
+
+/-- `cancel_leads p q` is formed by multiplying `p` and `q` by monomials so that they
+  have the same leading term, and then subtracting. -/
+def cancel_leads [comm_ring R] (p q : polynomial R) : polynomial R :=
+  C p.leading_coeff * X ^ (p.nat_degree - q.nat_degree) * q
+  - C q.leading_coeff * X ^ (q.nat_degree - p.nat_degree) * p
+
+lemma nat_degree_cancel_leads_lt_of_nat_degree_le_nat_degree [integral_domain R]
+  {p q : polynomial R} (h : p.nat_degree ≤ q.nat_degree) (hq : 0 < q.nat_degree) :
+  (p.cancel_leads q).nat_degree < q.nat_degree :=
+begin
+  by_cases hp : p = 0,
+  { convert hq,
+    simp [hp, cancel_leads], },
+  rw [cancel_leads, sub_eq_add_neg, nat.sub_eq_zero_of_le h, pow_zero, mul_one],
+  by_cases h0 :
+      C p.leading_coeff * q + -(C q.leading_coeff * X ^ (q.nat_degree - p.nat_degree) * p) = 0,
+  { convert hq,
+    simp only [h0, nat_degree_zero], },
+  have hq0 : ¬ q = 0,
+  { contrapose! hq,
+    simp [hq] },
+  apply lt_of_le_of_ne,
+  { rw [← with_bot.coe_le_coe, ← degree_eq_nat_degree h0, ← degree_eq_nat_degree hq0],
+    apply le_trans (degree_add_le _ _),
+    rw ← leading_coeff_eq_zero at hp hq0,
+    simp only [max_le_iff, degree_C hp, degree_C hq0, le_refl q.degree, true_and, nat.cast_with_bot,
+      nsmul_one, degree_neg, degree_mul, zero_add, degree_X, degree_pow],
+    rw leading_coeff_eq_zero at hp hq0,
+    rw [degree_eq_nat_degree hp, degree_eq_nat_degree hq0, ← with_bot.coe_add, with_bot.coe_le_coe,
+      nat.sub_add_cancel h], },
+  { contrapose! h0,
+    rw [← leading_coeff_eq_zero, leading_coeff, h0, mul_assoc, mul_comm _ p,
+      ← nat.sub_add_cancel h, add_comm _ p.nat_degree],
+    simp only [coeff_mul_X_pow, coeff_neg, coeff_C_mul, nat.add_sub_cancel_left, coeff_add],
+    rw [add_comm p.nat_degree, nat.sub_add_cancel h, ← leading_coeff, ← leading_coeff,
+      mul_comm _ q.leading_coeff, ← sub_eq_add_neg, ← mul_sub, sub_self, mul_zero] }
+end
+
+lemma dvd_cancel_leads_of_dvd_of_dvd [comm_ring R] {p q r : polynomial R} (pq : p ∣ q) (pr : p ∣ r) :
+  p ∣ q.cancel_leads r :=
+dvd_sub (dvd.trans pr (dvd.intro_left _ rfl)) (dvd.trans pq (dvd.intro_left _ rfl))
+
+end polynomial

--- a/src/ring_theory/polynomial/content.lean
+++ b/src/ring_theory/polynomial/content.lean
@@ -6,6 +6,7 @@ Author: Aaron Anderson
 import data.finset.gcd
 import data.polynomial
 import data.polynomial.erase_lead
+import data.polynomial.cancel_leads
 
 /-!
 # Gauss's Lemma, and GCD structures on polynomials
@@ -195,24 +196,67 @@ begin
     apply h _ (C_content_dvd _) }
 end
 
-lemma eq_C_mul_primitive (p : polynomial R) :
-  ∃ (r : R) (q : polynomial R), p = C r * q ∧ q.is_primitive ∧ p.nat_degree = q.nat_degree :=
+section prim_part
+variable [decidable_eq R]
+
+/-- The primitive part of a polynomial `p` is the primitive polynomial gained by dividing `p` by
+  `p.content`. If `p = 0`, then `p.prim_part = 1`.  -/
+noncomputable def prim_part (p : polynomial R) : polynomial R :=
+if p = 0 then 1 else classical.some (C_content_dvd p)
+
+lemma eq_C_content_mul_prim_part (p : polynomial R) : p = C p.content * p.prim_part :=
 begin
-  by_cases h0 : p = 0,
-  { use [0, 1],
-    simp [h0] },
-  rcases C_content_dvd p with ⟨q, h⟩,
-  use [p.content, q],
-  refine ⟨h, _, _⟩,
-  { have h1 := content_C_mul p.content q,
-    rw [← h, normalize_content, ← mul_one p.content, mul_assoc, one_mul] at h1,
-    apply mul_left_cancel' _ h1.symm,
-    rwa ← content_eq_zero_iff at h0 },
-  { rw [h, mul_eq_zero] at h0,
-    classical,
-    rcases (decidable.not_or_iff_and_not _ _).1 h0,
-    rw [h, nat_degree_mul left right, nat_degree_C, zero_add] }
+  by_cases h : p = 0, { simp [h] },
+  rw [prim_part, if_neg h, ← classical.some_spec (C_content_dvd p)],
 end
+
+@[simp]
+lemma prim_part_zero : prim_part (0 : polynomial R) = 1 := if_pos rfl
+
+lemma is_primitive_prim_part (p : polynomial R) : p.prim_part.is_primitive :=
+begin
+  by_cases h : p = 0, { simp [h] },
+  rw ← content_eq_zero_iff at h,
+  apply mul_left_cancel' h,
+  conv_rhs { rw [p.eq_C_content_mul_prim_part, mul_one, content_C_mul, normalize_content] }
+end
+
+lemma content_prim_part (p : polynomial R) : p.prim_part.content = 1 :=
+p.is_primitive_prim_part
+
+lemma prim_part_ne_zero (p : polynomial R) : p.prim_part ≠ 0 := p.is_primitive_prim_part.ne_zero
+
+lemma nat_degree_prim_part (p : polynomial R) : p.prim_part.nat_degree = p.nat_degree :=
+begin
+  by_cases h : C p.content = 0,
+  { rw [C_eq_zero, content_eq_zero_iff] at h, simp [h] },
+  conv_rhs { rw [p.eq_C_content_mul_prim_part,
+    nat_degree_mul h p.prim_part_ne_zero, nat_degree_C, zero_add] },
+end
+
+@[simp]
+lemma is_primitive.prim_part_eq {p : polynomial R} (hp : p.is_primitive) : p.prim_part = p :=
+by rw [← one_mul p.prim_part, ← C_1, ← hp.content_eq_one, ← p.eq_C_content_mul_prim_part]
+
+lemma is_unit_prim_part_C (r : R) : is_unit (C r).prim_part :=
+begin
+  by_cases h0 : r = 0,
+  { simp [h0] },
+  unfold is_unit,
+  refine ⟨⟨C ↑(norm_unit r)⁻¹, C ↑(norm_unit r),
+    by rw [← ring_hom.map_mul, units.inv_mul, C_1],
+    by rw [← ring_hom.map_mul, units.mul_inv, C_1]⟩, _⟩,
+  rw [← normalize_eq_zero, ← C_eq_zero] at h0,
+  apply mul_left_cancel' h0,
+  conv_rhs { rw [← content_C, ← (C r).eq_C_content_mul_prim_part], },
+  simp only [units.coe_mk, normalize_apply, ring_hom.map_mul],
+  rw [mul_assoc, ← ring_hom.map_mul, units.mul_inv, C_1, mul_one],
+end
+
+lemma prim_part_dvd (p : polynomial R) : p.prim_part ∣ p :=
+dvd.intro_left (C p.content) p.eq_C_content_mul_prim_part.symm
+
+end prim_part
 
 lemma gcd_content_eq_of_dvd_sub {a : R} {p q : polynomial R} (h : C a ∣ p - q) :
   gcd_monoid.gcd a p.content = gcd_monoid.gcd a q.content :=
@@ -242,6 +286,7 @@ end
 @[simp]
 theorem content_mul {p q : polynomial R} : (p * q).content = p.content * q.content :=
 begin
+  classical,
   suffices h : ∀ (n : ℕ) (p q : polynomial R), ((p * q).degree < n) →
     (p * q).content = p.content * q.content,
   { apply h,
@@ -257,28 +302,123 @@ begin
   rw [degree_eq_nat_degree (mul_ne_zero p0 q0), with_bot.coe_lt_coe, nat.lt_succ_iff_lt_or_eq,
     ← with_bot.coe_lt_coe, ← degree_eq_nat_degree (mul_ne_zero p0 q0), nat_degree_mul p0 q0] at hpq,
   rcases hpq with hlt | heq, { apply ih _ _ hlt },
-  rcases p.eq_C_mul_primitive with ⟨cp, p1, rfl, p1_prim, p1_deg⟩,
-  rcases q.eq_C_mul_primitive with ⟨cq, q1, rfl, q1_prim, q1_deg⟩,
-  suffices h : (q1 * p1).content = 1,
-  { rw [mul_assoc, content_C_mul, content_C_mul, mul_comm p1, mul_assoc, content_C_mul,
-    content_C_mul, h, mul_one, q1_prim.content_eq_one, p1_prim.content_eq_one, mul_one, mul_one] },
-  rw [p1_deg, q1_deg, ← with_bot.coe_eq_coe, with_bot.coe_add,
-    ← degree_eq_nat_degree p1_prim.ne_zero, ← degree_eq_nat_degree q1_prim.ne_zero] at heq,
+  rw [← p.nat_degree_prim_part, ← q.nat_degree_prim_part, ← with_bot.coe_eq_coe, with_bot.coe_add,
+    ← degree_eq_nat_degree p.prim_part_ne_zero, ← degree_eq_nat_degree q.prim_part_ne_zero] at heq,
+  rw [p.eq_C_content_mul_prim_part, q.eq_C_content_mul_prim_part],
+  suffices h : (q.prim_part * p.prim_part).content = 1,
+  { rw [mul_assoc, content_C_mul, content_C_mul, mul_comm p.prim_part, mul_assoc, content_C_mul,
+    content_C_mul, h, mul_one, content_prim_part, content_prim_part, mul_one, mul_one] },
   rw [← normalize_content, normalize_eq_one, is_unit_iff_dvd_one,
       content_eq_gcd_leading_coeff_content_erase_lead, leading_coeff_mul, gcd_comm],
   apply dvd_trans (gcd_mul_dvd_mul_gcd _ _ _),
-  rw [content_mul_aux, ih, p1_prim.content_eq_one, mul_one, gcd_comm,
-      ← content_eq_gcd_leading_coeff_content_erase_lead, q1_prim.content_eq_one, one_mul,
-      mul_comm q1, content_mul_aux, ih, q1_prim.content_eq_one, mul_one, gcd_comm,
-      ← content_eq_gcd_leading_coeff_content_erase_lead, p1_prim.content_eq_one],
+  rw [content_mul_aux, ih, content_prim_part, mul_one, gcd_comm,
+      ← content_eq_gcd_leading_coeff_content_erase_lead, content_prim_part, one_mul,
+      mul_comm q.prim_part, content_mul_aux, ih, content_prim_part, mul_one, gcd_comm,
+      ← content_eq_gcd_leading_coeff_content_erase_lead, content_prim_part],
   { rw [← heq, degree_mul, with_bot.add_lt_add_iff_right],
-    { apply degree_erase_lt p1_prim.ne_zero },
+    { apply degree_erase_lt p.prim_part_ne_zero },
     { rw [bot_lt_iff_ne_bot, ne.def, degree_eq_bot],
-      apply q1_prim.ne_zero } },
+      apply q.prim_part_ne_zero } },
   { rw [mul_comm, ← heq, degree_mul, with_bot.add_lt_add_iff_left],
-    { apply degree_erase_lt q1_prim.ne_zero },
+    { apply degree_erase_lt q.prim_part_ne_zero },
     { rw [bot_lt_iff_ne_bot, ne.def, degree_eq_bot],
-      apply p1_prim.ne_zero } }
+      apply p.prim_part_ne_zero } }
+end
+
+theorem is_primitive.mul {p q : polynomial R} (hp : p.is_primitive) (hq : q.is_primitive) :
+  (p * q).is_primitive :=
+by rw [is_primitive, content_mul, hp.content_eq_one, hq.content_eq_one, mul_one]
+
+@[simp]
+theorem prim_part_mul [decidable_eq R] {p q : polynomial R} (h0 : p * q ≠ 0) :
+  (p * q).prim_part = p.prim_part * q.prim_part :=
+begin
+  rw [ne.def, ← content_eq_zero_iff, ← C_eq_zero] at h0,
+  apply mul_left_cancel' h0,
+  conv_lhs { rw [← (p * q).eq_C_content_mul_prim_part,
+    p.eq_C_content_mul_prim_part, q.eq_C_content_mul_prim_part] },
+  rw [content_mul, ring_hom.map_mul],
+  ring,
+end
+
+lemma is_primitive.dvd_prim_part_iff_dvd [decidable_eq R] {p q : polynomial R}
+  (hp : p.is_primitive) (hq : q ≠ 0) :
+  p ∣ q.prim_part ↔ p ∣ q :=
+begin
+  refine ⟨λ h, dvd.trans h (dvd.intro_left _ q.eq_C_content_mul_prim_part.symm), λ h, _⟩,
+  rcases h with ⟨r, rfl⟩,
+  apply dvd.intro _,
+  rw [prim_part_mul hq, hp.prim_part_eq],
+end
+
+theorem exists_primitive_lcm_of_is_primitive {p q : polynomial R}
+  (hp : p.is_primitive) (hq : q.is_primitive) :
+  ∃ r : polynomial R, r.is_primitive ∧ (∀ s : polynomial R, p ∣ s ∧ q ∣ s ↔ r ∣ s) :=
+begin
+  classical,
+  have h : ∃ (n : ℕ) (r : polynomial R), r.nat_degree = n ∧ r.is_primitive ∧ p ∣ r ∧ q ∣ r :=
+    ⟨(p * q).nat_degree, p * q, rfl, hp.mul hq, dvd_mul_right _ _, dvd_mul_left _ _⟩,
+  rcases nat.find_spec h with ⟨r, rdeg, rprim, pr, qr⟩,
+  refine ⟨r, rprim, λ s, ⟨_, λ rs, ⟨dvd.trans pr rs, dvd.trans qr rs⟩⟩⟩,
+  suffices hs : ∀ (n : ℕ) (s : polynomial R), s.nat_degree = n → (p ∣ s ∧ q ∣ s → r ∣ s),
+  { apply hs s.nat_degree s rfl },
+  clear s,
+  by_contra con,
+  push_neg at con,
+  rcases nat.find_spec con with ⟨s, sdeg, ⟨ps, qs⟩, rs⟩,
+  have s0 : s ≠ 0,
+  { contrapose! rs, simp [rs] },
+  have hs := nat.find_min' h ⟨_, s.nat_degree_prim_part, s.is_primitive_prim_part,
+              (hp.dvd_prim_part_iff_dvd s0).2 ps, (hq.dvd_prim_part_iff_dvd s0).2 qs⟩,
+  rw ← rdeg at hs,
+  by_cases sC : s.nat_degree ≤ 0,
+  { rw [eq_C_of_nat_degree_le_zero (le_trans hs sC), is_primitive,
+      content_C, normalize_eq_one] at rprim,
+    rw [eq_C_of_nat_degree_le_zero (le_trans hs sC), ← dvd_content_iff_C_dvd] at rs,
+    apply rs rprim.dvd },
+  have hcancel := nat_degree_cancel_leads_lt_of_nat_degree_le_nat_degree hs (lt_of_not_ge sC),
+  rw sdeg at hcancel,
+  apply nat.find_min con hcancel,
+  refine ⟨_, rfl, ⟨dvd_cancel_leads_of_dvd_of_dvd pr ps, dvd_cancel_leads_of_dvd_of_dvd qr qs⟩,
+      λ rcs, rs _⟩,
+  rw ← rprim.dvd_prim_part_iff_dvd s0,
+  rw [cancel_leads, nat.sub_eq_zero_of_le hs, pow_zero, mul_one] at rcs,
+  have h := dvd_add rcs (dvd.intro_left _ rfl),
+  have hC0 := rprim.ne_zero,
+  rw [ne.def, ← leading_coeff_eq_zero, ← C_eq_zero] at hC0,
+  rw [sub_add_cancel, ← rprim.dvd_prim_part_iff_dvd (mul_ne_zero hC0 s0)] at h,
+  rcases is_unit_prim_part_C r.leading_coeff with ⟨u, hu⟩,
+  apply dvd.trans h (dvd_of_associated (associated.symm ⟨u, _⟩)),
+  rw [prim_part_mul (mul_ne_zero hC0 s0), hu, mul_comm],
+end
+
+lemma dvd_iff_content_dvd_content_and_prim_part_dvd_prim_part
+  [decidable_eq R] {p q : polynomial R} (hq : q ≠ 0) :
+  p ∣ q ↔ p.content ∣ q.content ∧ p.prim_part ∣ q.prim_part :=
+begin
+  split; intro h,
+  { rcases h with ⟨r, rfl⟩,
+    rw [content_mul, p.is_primitive_prim_part.dvd_prim_part_iff_dvd hq],
+    exact ⟨dvd.intro _ rfl, dvd.trans p.prim_part_dvd (dvd.intro _ rfl)⟩ },
+  { rw [p.eq_C_content_mul_prim_part, q.eq_C_content_mul_prim_part],
+    exact mul_dvd_mul (ring_hom.map_dvd C h.1) h.2 }
+end
+
+noncomputable instance [decidable_eq R] : gcd_monoid (polynomial R) :=
+gcd_monoid_of_exists_lcm $ λ p q, begin
+  rcases exists_primitive_lcm_of_is_primitive p.is_primitive_prim_part q.is_primitive_prim_part
+    with ⟨r, rprim, hr⟩,
+  refine ⟨C (lcm p.content q.content) * r, λ s, _⟩,
+  by_cases hs : s = 0,
+  { simp [hs] },
+  by_cases hpq : C (lcm p.content q.content) = 0,
+  { rw [C_eq_zero, lcm_eq_zero_iff, content_eq_zero_iff, content_eq_zero_iff] at hpq,
+    rcases hpq with hpq | hpq; simp [hpq, hs] },
+  iterate 3 { rw dvd_iff_content_dvd_content_and_prim_part_dvd_prim_part hs },
+  rw [content_mul, rprim.content_eq_one, mul_one, content_C, normalize_lcm, lcm_dvd_iff,
+    prim_part_mul (mul_ne_zero hpq rprim.ne_zero), rprim.prim_part_eq,
+    is_unit.mul_left_dvd _ _ _ (is_unit_prim_part_C (lcm p.content q.content)), ← hr s.prim_part],
+  tauto,
 end
 
 end gcd_monoid

--- a/src/ring_theory/polynomial/content.lean
+++ b/src/ring_theory/polynomial/content.lean
@@ -395,7 +395,7 @@ begin
 end
 
 lemma dvd_iff_content_dvd_content_and_prim_part_dvd_prim_part
-  [decidable_eq R] {p q : polynomial R} (hq : q ≠ 0) :
+  {p q : polynomial R} (hq : q ≠ 0) :
   p ∣ q ↔ p.content ∣ q.content ∧ p.prim_part ∣ q.prim_part :=
 begin
   split; intro h,
@@ -406,7 +406,7 @@ begin
     exact mul_dvd_mul (ring_hom.map_dvd C h.1) h.2 }
 end
 
-instance [decidable_eq R] : gcd_monoid (polynomial R) :=
+instance : gcd_monoid (polynomial R) :=
 gcd_monoid_of_exists_lcm $ λ p q, begin
   rcases exists_primitive_lcm_of_is_primitive p.is_primitive_prim_part q.is_primitive_prim_part
     with ⟨r, rprim, hr⟩,

--- a/src/ring_theory/polynomial/content.lean
+++ b/src/ring_theory/polynomial/content.lean
@@ -196,12 +196,14 @@ begin
     apply h _ (C_content_dvd _) }
 end
 
+open_locale classical
+noncomputable theory
+
 section prim_part
-variable [decidable_eq R]
 
 /-- The primitive part of a polynomial `p` is the primitive polynomial gained by dividing `p` by
   `p.content`. If `p = 0`, then `p.prim_part = 1`.  -/
-noncomputable def prim_part (p : polynomial R) : polynomial R :=
+def prim_part (p : polynomial R) : polynomial R :=
 if p = 0 then 1 else classical.some (C_content_dvd p)
 
 lemma eq_C_content_mul_prim_part (p : polynomial R) : p = C p.content * p.prim_part :=
@@ -330,7 +332,7 @@ theorem is_primitive.mul {p q : polynomial R} (hp : p.is_primitive) (hq : q.is_p
 by rw [is_primitive, content_mul, hp.content_eq_one, hq.content_eq_one, mul_one]
 
 @[simp]
-theorem prim_part_mul [decidable_eq R] {p q : polynomial R} (h0 : p * q ≠ 0) :
+theorem prim_part_mul {p q : polynomial R} (h0 : p * q ≠ 0) :
   (p * q).prim_part = p.prim_part * q.prim_part :=
 begin
   rw [ne.def, ← content_eq_zero_iff, ← C_eq_zero] at h0,
@@ -341,7 +343,7 @@ begin
   ring,
 end
 
-lemma is_primitive.dvd_prim_part_iff_dvd [decidable_eq R] {p q : polynomial R}
+lemma is_primitive.dvd_prim_part_iff_dvd {p q : polynomial R}
   (hp : p.is_primitive) (hq : q ≠ 0) :
   p ∣ q.prim_part ↔ p ∣ q :=
 begin
@@ -404,7 +406,7 @@ begin
     exact mul_dvd_mul (ring_hom.map_dvd C h.1) h.2 }
 end
 
-noncomputable instance [decidable_eq R] : gcd_monoid (polynomial R) :=
+instance [decidable_eq R] : gcd_monoid (polynomial R) :=
 gcd_monoid_of_exists_lcm $ λ p q, begin
   rcases exists_primitive_lcm_of_is_primitive p.is_primitive_prim_part q.is_primitive_prim_part
     with ⟨r, rprim, hr⟩,

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -7,7 +7,6 @@ Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson
 import algebra.gcd_monoid
 import ring_theory.integral_domain
 import ring_theory.noetherian
-import ring_theory.polynomial.content
 
 /--
 

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -1128,12 +1128,3 @@ noncomputable def unique_factorization_monoid.to_gcd_monoid
   .. ‹normalization_monoid α› }
 
 end
-
-instance polynomial.unique_factorization_monoid
-  [integral_domain α] [normalization_monoid α] [unique_factorization_monoid α]  :
-  unique_factorization_monoid (polynomial α) :=
-begin
-  classical,
-  haveI := unique_factorization_monoid.to_gcd_monoid α,
-  exact ufm_of_gcd_of_wf_dvd_monoid,
-end

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -7,6 +7,7 @@ Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson
 import algebra.gcd_monoid
 import ring_theory.integral_domain
 import ring_theory.noetherian
+import ring_theory.polynomial.content
 
 /--
 
@@ -1126,4 +1127,13 @@ noncomputable def unique_factorization_monoid.to_gcd_monoid
   normalize_gcd := assume a b, by convert normalize_out _,
   .. ‹normalization_monoid α› }
 
+end
+
+instance polynomial.unique_factorization_monoid
+  [integral_domain α] [normalization_monoid α] [unique_factorization_monoid α]  :
+  unique_factorization_monoid (polynomial α) :=
+begin
+  classical,
+  haveI := unique_factorization_monoid.to_gcd_monoid α,
+  exact ufm_of_gcd_of_wf_dvd_monoid,
 end


### PR DESCRIPTION
Refactors `ring_theory/polynomial/content` a bit to introduce `prim_part`
Provides a `gcd_monoid` instance on polynomials over a gcd domain

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
