### PR TITLE
[Merged by Bors] - feat(algebra/direct_sum): Fix two todos about generalizing over unique types

### DIFF
--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -308,6 +308,9 @@ by simp only [single_apply, dif_pos rfl]
 lemma single_eq_of_ne {i i' b} (h : i ≠ i') : (single i b : Π₀ i, β i) i' = 0 :=
 by simp only [single_apply, dif_neg h]
 
+lemma single_injective {i} : function.injective (single i : β i → Π₀ i, β i) :=
+λ x y H, congr_fun (mk_injective _ H) ⟨i, by simp⟩
+
 /-- Redefine `f i` to be `0`. -/
 def erase (i : ι) (f : Π₀ i, β i) : Π₀ i, β i :=
 quotient.lift_on f (λ x, ⟦(⟨λ j, if j = i then 0 else x.1 j, x.2,

--- a/src/linear_algebra/direct_sum_module.lean
+++ b/src/linear_algebra/direct_sum_module.lean
@@ -75,7 +75,8 @@ def to_module : (⨁ i, M i) →ₗ[R] N :=
       by rw [← of_smul, to_group_of, to_group_of, linear_map.to_add_monoid_hom_coe,
         linear_map.map_smul])
     (λ x y ihx ihy,
-      by rw [smul_add, add_monoid_hom.map_add, ihx, ihy, add_monoid_hom.map_add, smul_add]) }
+      by rw [smul_add, add_monoid_hom.map_add, ihx, ihy, add_monoid_hom.map_add, smul_add]),
+  ..(to_group (λ i, (φ i).to_add_monoid_hom))}
 
 variables {ι N φ}
 
@@ -103,16 +104,16 @@ into a larger subset of the direct summands, as a linear map.
 -/
 def lset_to_set (S T : set ι) (H : S ⊆ T) :
   (⨁ (i : S), M i) →ₗ (⨁ (i : T), M i) :=
-to_module R _ _ $ λ i, lof R T (M ∘ @subtype.val _ T) ⟨i.1, H i.2⟩
+to_module R _ _ $ λ i, lof R T (λ (i : subtype T), M i) ⟨i, H i.prop⟩
 
 omit dec_ι
 
-/-- The natural linear equivalence between `⨁ _ : punit, M` and `M`. -/
+/-- The natural linear equivalence between `⨁ _ : ι, M` and `M` when `unique ι`. -/
 -- TODO: generalize this to arbitrary index type `ι` with `unique ι`
-protected def lid (M : Type v) [add_comm_group M] [semimodule R M] :
-  (⨁ (_ : punit), M) ≃ₗ M :=
-{ .. direct_sum.id M,
-  .. to_module R punit M (λ i, linear_map.id) }
+protected def lid (M : Type v) (ι : Type* := punit) [add_comm_group M] [semimodule R M] [unique ι] :
+  (⨁ (_ : ι), M) ≃ₗ M :=
+{ .. direct_sum.id M ι,
+  .. to_module R ι M (λ i, linear_map.id) }
 
 variables (ι M)
 /-- The projection map onto one component, as a linear map. -/


### PR DESCRIPTION
Also promotes `id` to a `≃+`, and prefers coercion over direct use of `subtype.val`.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
