### PR TITLE
feat(ring_theory/unique_factorization_domain): a `normalization_monoid` structure for ufms

### DIFF
--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -427,7 +427,7 @@ instance : preorder (associates α) :=
 /-- `associates.mk` as a `monoid_hom`. -/
 protected def mk_monoid_hom : α →* (associates α) := ⟨associates.mk, mk_one, λ x y, mk_mul_mk⟩
 
-@[simp] lemma mk_monoid_hom_apply {a : α} : associates.mk_monoid_hom a = associates.mk a := rfl
+@[simp] lemma mk_monoid_hom_apply (a : α) : associates.mk_monoid_hom a = associates.mk a := rfl
 
 lemma mk_pow (a : α) (n : ℕ) : associates.mk (a ^ n) = (associates.mk a) ^ n :=
 by induction n; simp [*, pow_succ, associates.mk_mul_mk.symm]

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -429,6 +429,11 @@ protected def mk_monoid_hom : α →* (associates α) := ⟨associates.mk, mk_on
 
 @[simp] lemma mk_monoid_hom_apply (a : α) : associates.mk_monoid_hom a = associates.mk a := rfl
 
+lemma associated_map_mk {f : associates α →* α}
+  (hinv : function.right_inverse f associates.mk) (a : α) :
+  a ~ᵤ f (associates.mk a) :=
+associates.mk_eq_mk_iff_associated.1 (hinv (associates.mk a)).symm
+
 lemma mk_pow (a : α) (n : ℕ) : associates.mk (a ^ n) = (associates.mk a) ^ n :=
 by induction n; simp [*, pow_succ, associates.mk_mul_mk.symm]
 

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -424,6 +424,11 @@ instance : preorder (associates α) :=
 
 @[simp] lemma mk_one : associates.mk (1 : α) = 1 := rfl
 
+/-- `associates.mk` as a `monoid_hom`. -/
+protected def mk_monoid_hom : α →* (associates α) := ⟨associates.mk, mk_one, λ x y, mk_mul_mk⟩
+
+@[simp] lemma mk_monoid_hom_apply {a : α} : associates.mk_monoid_hom a = associates.mk a := rfl
+
 lemma mk_pow (a : α) (n : ℕ) : associates.mk (a ^ n) = (associates.mk a) ^ n :=
 by induction n; simp [*, pow_succ, associates.mk_mul_mk.symm]
 

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -634,7 +634,14 @@ end integral_domain
 section constructors
 noncomputable theory
 
+open associates
+
 variables [comm_cancel_monoid_with_zero α] [nontrivial α]
+
+private lemma map_mk_unit_aux [decidable_eq α] {f : associates α →* α}
+  (hinv : function.right_inverse f associates.mk) (a : α) :
+    a * ↑(classical.some (associated_map_mk hinv a)) = f (associates.mk a) :=
+classical.some_spec (associated_map_mk hinv a)
 
 /-- Define `normalization_monoid` on a structure from a `monoid_hom` inverse to `associates.mk`. -/
 def normalization_monoid_of_monoid_hom_right_inverse [decidable_eq α] (f : associates α →* α)
@@ -645,18 +652,17 @@ def normalization_monoid_of_monoid_hom_right_inverse [decidable_eq α] (f : asso
   norm_unit_zero := if_pos rfl,
   norm_unit_mul := λ a b ha hb, by {
     rw [if_neg (mul_ne_zero ha hb), if_neg ha, if_neg hb, units.ext_iff, units.coe_mul],
-    apply mul_left_cancel' (mul_ne_zero ha hb),
-    conv_rhs { rw [← mul_assoc, mul_comm, mul_assoc, mul_comm b, mul_comm, ← mul_assoc], },
-    rw [classical.some_spec (associates.mk_eq_mk_iff_associated.1 (hinv (associates.mk a)).symm),
-      classical.some_spec (associates.mk_eq_mk_iff_associated.1 (hinv (associates.mk (a * b))).symm),
-      mul_assoc,
-      classical.some_spec (associates.mk_eq_mk_iff_associated.1 (hinv (associates.mk b)).symm),
-      ← monoid_hom.map_mul, associates.mk_mul_mk] },
+    suffices : (a * b) * ↑(classical.some (associated_map_mk hinv (a * b))) =
+      (a * ↑(classical.some (associated_map_mk hinv a))) *
+      (b * ↑(classical.some (associated_map_mk hinv b))),
+    { apply mul_left_cancel' (mul_ne_zero ha hb) _,
+      simpa only [mul_assoc, mul_comm, mul_left_comm] using this },
+    rw [map_mk_unit_aux hinv a, map_mk_unit_aux hinv (a * b), map_mk_unit_aux hinv b,
+        ← monoid_hom.map_mul, associates.mk_mul_mk] },
   norm_unit_coe_units := λ u, by {
     rw [if_neg (units.ne_zero u), units.ext_iff],
     apply mul_left_cancel' (units.ne_zero u),
-    rw [units.mul_inv,
-      classical.some_spec (associates.mk_eq_mk_iff_associated.1 (hinv (associates.mk u)).symm),
+    rw [units.mul_inv, map_mk_unit_aux hinv u,
       associates.mk_eq_mk_iff_associated.2 (associated_one_iff_is_unit.2 ⟨u, rfl⟩),
       associates.mk_one, monoid_hom.map_one] } }
 

--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -604,13 +604,6 @@ instance normalization_monoid_of_unique_units : normalization_monoid α :=
 
 @[simp] lemma normalize_eq (x : α) : normalize x = x := mul_one x
 
-@[simp] lemma associated_iff_eq (x y : α) : associated x y ↔ x = y :=
-begin
-  refine ⟨_, λ h, h ▸ associated.refl x⟩,
-  rintro ⟨u, rfl⟩,
-  simp [units_eq_one u],
-end
-
 end unique_unit
 
 section integral_domain
@@ -643,6 +636,7 @@ noncomputable theory
 
 variables [comm_cancel_monoid_with_zero α] [nontrivial α]
 
+/-- Define `normalization_monoid` on a structure from a `monoid_hom` inverse to `associates.mk`. -/
 def normalization_monoid_of_monoid_hom_right_inverse [decidable_eq α] (f : associates α →* α)
   (hinv : function.right_inverse f associates.mk) :
   normalization_monoid α :=

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -162,12 +162,6 @@ associates.irreducible_iff_prime_iff.1 (λ _, irreducible_iff_prime)
 section
 open_locale classical
 
-/-- A principal ideal domain has unique factorization -/
-@[priority 100] -- see Note [lower instance priority]
-instance to_unique_factorization_monoid : unique_factorization_monoid R :=
-{ irreducible_iff_prime := λ _, principal_ideal_ring.irreducible_iff_prime
-  .. (is_noetherian_ring.wf_dvd_monoid : wf_dvd_monoid R) }
-
 /-- `factors a` is a multiset of irreducible elements whose product is `a`, up to units -/
 noncomputable def factors (a : R) : multiset R :=
 if h : a = 0 then ∅ else classical.some (wf_dvd_monoid.exists_factors a h)
@@ -199,6 +193,12 @@ lemma ring_hom_mem_submonoid_of_factors_subset_of_units_subset {R S : Type*}
   (h : ∀ b ∈ factors a, f b ∈ s) (hf: ∀ c : units R, f c ∈ s) :
   f a ∈ s :=
 mem_submonoid_of_factors_subset_of_units_subset (s.comap f.to_monoid_hom) ha h hf
+
+/-- A principal ideal domain has unique factorization -/
+@[priority 100] -- see Note [lower instance priority]
+instance to_unique_factorization_monoid : unique_factorization_monoid R :=
+{ irreducible_iff_prime := λ _, principal_ideal_ring.irreducible_iff_prime
+  .. (is_noetherian_ring.wf_dvd_monoid : wf_dvd_monoid R) }
 
 end
 

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -162,6 +162,12 @@ associates.irreducible_iff_prime_iff.1 (λ _, irreducible_iff_prime)
 section
 open_locale classical
 
+/-- A principal ideal domain has unique factorization -/
+@[priority 100] -- see Note [lower instance priority]
+instance to_unique_factorization_monoid : unique_factorization_monoid R :=
+{ irreducible_iff_prime := λ _, principal_ideal_ring.irreducible_iff_prime
+  .. (is_noetherian_ring.wf_dvd_monoid : wf_dvd_monoid R) }
+
 /-- `factors a` is a multiset of irreducible elements whose product is `a`, up to units -/
 noncomputable def factors (a : R) : multiset R :=
 if h : a = 0 then ∅ else classical.some (wf_dvd_monoid.exists_factors a h)
@@ -193,12 +199,6 @@ lemma ring_hom_mem_submonoid_of_factors_subset_of_units_subset {R S : Type*}
   (h : ∀ b ∈ factors a, f b ∈ s) (hf: ∀ c : units R, f c ∈ s) :
   f a ∈ s :=
 mem_submonoid_of_factors_subset_of_units_subset (s.comap f.to_monoid_hom) ha h hf
-
-/-- A principal ideal domain has unique factorization -/
-@[priority 100] -- see Note [lower instance priority]
-instance to_unique_factorization_monoid : unique_factorization_monoid R :=
-{ irreducible_iff_prime := λ _, principal_ideal_ring.irreducible_iff_prime
-  .. (is_noetherian_ring.wf_dvd_monoid : wf_dvd_monoid R) }
 
 end
 

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -1203,7 +1203,7 @@ open_locale classical
 open unique_factorization_monoid
 variables (α) [integral_domain α] [unique_factorization_monoid α]
 
-instance unique_factorization_monoid : unique_factorization_monoid α :=
+@[priority 100] instance unique_factorization_monoid : unique_factorization_monoid α :=
 begin
   haveI := arbitrary (normalization_monoid α),
   haveI := to_gcd_monoid α,

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -1196,18 +1196,3 @@ noncomputable def unique_factorization_monoid.to_gcd_monoid
   .. ‹normalization_monoid α› }
 
 end
-
-namespace polynomial
-
-open_locale classical
-open unique_factorization_monoid
-variables (α) [integral_domain α] [unique_factorization_monoid α]
-
-@[priority 100] instance unique_factorization_monoid : unique_factorization_monoid α :=
-begin
-  haveI := arbitrary (normalization_monoid α),
-  haveI := to_gcd_monoid α,
-  exact ufm_of_gcd_of_wf_dvd_monoid
-end
-
-end polynomial

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -500,7 +500,7 @@ noncomputable theory
 variables [comm_cancel_monoid_with_zero α] [nontrivial α] [unique_factorization_monoid α]
 
 /-- Noncomputably defines a `normalization_monoid` structure on a `unique_factorization_monoid`. -/
-def default_normalization_monoid : normalization_monoid α :=
+def normalization_monoid : normalization_monoid α :=
 normalization_monoid_of_monoid_hom_right_inverse {
   to_fun := λ a : associates α, if a = 0 then 0 else ((factors a).map
     (classical.some mk_surjective.has_right_inverse : associates α → α)).prod,
@@ -523,7 +523,7 @@ normalization_monoid_of_monoid_hom_right_inverse {
   apply factors_prod hx
 end
 
-instance : inhabited (normalization_monoid α) := ⟨default_normalization_monoid⟩
+instance : inhabited (normalization_monoid α) := ⟨normalization_monoid⟩
 
 end unique_factorization_monoid
 

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -500,7 +500,7 @@ noncomputable theory
 variables [comm_cancel_monoid_with_zero α] [nontrivial α] [unique_factorization_monoid α]
 
 /-- Noncomputably defines a `normalization_monoid` structure on a `unique_factorization_monoid`. -/
-def normalization_monoid : normalization_monoid α :=
+protected def normalization_monoid : normalization_monoid α :=
 normalization_monoid_of_monoid_hom_right_inverse {
   to_fun := λ a : associates α, if a = 0 then 0 else ((factors a).map
     (classical.some mk_surjective.has_right_inverse : associates α → α)).prod,
@@ -523,7 +523,7 @@ normalization_monoid_of_monoid_hom_right_inverse {
   apply factors_prod hx
 end
 
-instance : inhabited (normalization_monoid α) := ⟨normalization_monoid⟩
+instance : inhabited (normalization_monoid α) := ⟨unique_factorization_monoid.normalization_monoid⟩
 
 end unique_factorization_monoid
 

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -456,6 +456,75 @@ have multiset.rel associated (p ::ₘ factors b) (factors a),
           (associated.symm (factors_prod hb0))),
 multiset.exists_mem_of_rel_of_mem this (by simp)
 
+@[simp] lemma factors_one : factors (1 : α) = 0 :=
+begin
+  rw ← multiset.rel_zero_right,
+  apply factors_unique irreducible_of_factor,
+  { intros x hx,
+    exfalso,
+    apply multiset.not_mem_zero x hx },
+  { simp [factors_prod one_ne_zero] },
+  apply_instance
+end
+
+@[simp] lemma factors_mul {x y : α} (hx : x ≠ 0) (hy : y ≠ 0) :
+  factors (x * y) = factors x + factors y :=
+begin
+  have h : (normalize : α → α) = associates.out ∘ associates.mk,
+  { ext, rw [function.comp_apply, associates.out_mk], },
+  rw [← multiset.map_id' (factors (x * y)), ← multiset.map_id' (factors x),
+    ← multiset.map_id' (factors y), ← multiset.map_congr normalize_factor,
+    ← multiset.map_congr normalize_factor, ← multiset.map_congr normalize_factor,
+    ← multiset.map_add, h, ← multiset.map_map associates.out, eq_comm,
+    ← multiset.map_map associates.out],
+  refine congr rfl _,
+  apply multiset.map_mk_eq_map_mk_of_rel,
+  apply factors_unique,
+  { intros x hx,
+    rcases multiset.mem_add.1 hx with hx | hx;
+    exact irreducible_of_factor x hx },
+  { exact irreducible_of_factor },
+  { rw multiset.prod_add,
+    exact associated.trans (associated_mul_mul (factors_prod hx) (factors_prod hy))
+      (factors_prod (mul_ne_zero hx hy)).symm, }
+end
+
+end unique_factorization_monoid
+
+namespace unique_factorization_monoid
+
+open_locale classical
+open multiset associates
+noncomputable theory
+
+variables [comm_cancel_monoid_with_zero α] [nontrivial α] [unique_factorization_monoid α]
+
+/-- Noncomputably defines a `normalization_monoid` structure on a `unique_factorization_monoid`. -/
+def default_normalization_monoid : normalization_monoid α :=
+normalization_monoid_of_monoid_hom_right_inverse {
+  to_fun := λ a : associates α, if a = 0 then 0 else ((factors a).map
+    (classical.some mk_surjective.has_right_inverse : associates α → α)).prod,
+  map_one' := by simp,
+  map_mul' := λ x y, by {
+    by_cases hx : x = 0, { simp [hx] },
+    by_cases hy : y = 0, { simp [hy] },
+    simp [hx, hy] } } begin
+  intro x,
+  dsimp,
+  by_cases hx : x = 0, { simp [hx] },
+  have h : associates.mk_monoid_hom ∘ (classical.some mk_surjective.has_right_inverse) =
+           (id : associates α → associates α),
+  { ext x,
+    rw [function.comp_apply, mk_monoid_hom_apply,
+      classical.some_spec mk_surjective.has_right_inverse x],
+    refl },
+  rw [if_neg hx, ← mk_monoid_hom_apply, monoid_hom.map_multiset_prod, map_map, h, map_id,
+      ← associated_iff_eq],
+  apply factors_prod hx
+end
+
+instance : inhabited (normalization_monoid α) := ⟨default_normalization_monoid⟩
+
 end unique_factorization_monoid
 
 namespace unique_factorization_monoid
@@ -1109,8 +1178,8 @@ open associates unique_factorization_monoid
 /-- `to_gcd_monoid` constructs a GCD monoid out of a normalization on a
   unique factorization domain. -/
 noncomputable def unique_factorization_monoid.to_gcd_monoid
-  (α : Type*) [integral_domain α] [unique_factorization_monoid α] [normalization_monoid α]
-  [decidable_eq (associates α)] [decidable_eq α] : gcd_monoid α :=
+  (α : Type*) [comm_cancel_monoid_with_zero α] [nontrivial α] [unique_factorization_monoid α]
+  [normalization_monoid α] [decidable_eq (associates α)] [decidable_eq α] : gcd_monoid α :=
 { gcd := λa b, (associates.mk a ⊓ associates.mk b).out,
   lcm := λa b, (associates.mk a ⊔ associates.mk b).out,
   gcd_dvd_left := assume a b, (out_dvd_iff a (associates.mk a ⊓ associates.mk b)).2 $ inf_le_left,
@@ -1127,3 +1196,18 @@ noncomputable def unique_factorization_monoid.to_gcd_monoid
   .. ‹normalization_monoid α› }
 
 end
+
+namespace polynomial
+
+open_locale classical
+open unique_factorization_monoid
+variables (α) [integral_domain α] [unique_factorization_monoid α]
+
+instance unique_factorization_monoid : unique_factorization_monoid α :=
+begin
+  haveI := arbitrary (normalization_monoid α),
+  haveI := to_gcd_monoid α,
+  exact ufm_of_gcd_of_wf_dvd_monoid
+end
+
+end polynomial


### PR DESCRIPTION
Provides a default `normalization_monoid` structure on a `unique_factorization_monoid`

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
