### PR TITLE
[Merged by Bors] - feat(data/vector2): add lemma map_id

### DIFF
--- a/src/data/vector2.lean
+++ b/src/data/vector2.lean
@@ -105,6 +105,11 @@ begin
              and_self, singleton_tail]
 end
 
+/-- Mapping under `id` does not change a vector.-/
+@[simp] lemma map_id {n : ℕ} (v : vector α n) : vector.map id v = v :=
+  vector.eq _ _ (by simp only [list.map_id, vector.to_list_map])
+
+
 lemma mem_iff_nth {a : α} {v : vector α n} : a ∈ v.to_list ↔ ∃ i, v.nth i = a :=
 by simp only [list.mem_iff_nth_le, fin.exists_iff, vector.nth_eq_nth_le];
   exact ⟨λ ⟨i, hi, h⟩, ⟨i, by rwa to_list_length at hi, h⟩,

--- a/src/data/vector2.lean
+++ b/src/data/vector2.lean
@@ -105,10 +105,9 @@ begin
              and_self, singleton_tail]
 end
 
-/-- Mapping under `id` does not change a vector.-/
+/-- Mapping under `id` does not change a vector. -/
 @[simp] lemma map_id {n : ℕ} (v : vector α n) : vector.map id v = v :=
   vector.eq _ _ (by simp only [list.map_id, vector.to_list_map])
-
 
 lemma mem_iff_nth {a : α} {v : vector α n} : a ∈ v.to_list ↔ ∃ i, v.nth i = a :=
 by simp only [list.mem_iff_nth_le, fin.exists_iff, vector.nth_eq_nth_le];


### PR DESCRIPTION
`map_id` proves that a vector is unchanged when mapped under the `id` function. This is similar to `list.map_id`. This lemma was marked with the `simp` attribute to make it available to the simplifier.

---
I have made the changes in `data/vector2`. I don't know if this was the right choice. Perhaps it should have been in `core/data/vector`?