### PR TITLE
[Merged by Bors] - feat(topology/algebra/group_with_zero): introduce `has_continuous_inv'`

### DIFF
--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -651,9 +651,9 @@ nnreal.eq $ by simp
 @[simp] lemma norm_fpow : ∀ (a : α) (n : ℤ), ∥a^n∥ = ∥a∥^n :=
 (norm_hom : α →* ℝ).map_fpow norm_zero
 
-lemma tendsto_inv {r : α} (r0 : r ≠ 0) : tendsto (λq, q⁻¹) (𝓝 r) (𝓝 r⁻¹) :=
+instance : has_continuous_inv' α :=
 begin
-  refine (nhds_basis_closed_ball.tendsto_iff nhds_basis_closed_ball).2 (λε εpos, _),
+  refine ⟨λ r r0, (nhds_basis_closed_ball.tendsto_iff nhds_basis_closed_ball).2 (λε εpos, _)⟩,
   let δ := min (ε/2 * ∥r∥^2) (∥r∥/2),
   have norm_r_pos : 0 < ∥r∥ := norm_pos_iff.mpr r0,
   have A : 0 < ε / 2 * ∥r∥ ^ 2 := mul_pos (half_pos εpos) (pow_pos norm_r_pos 2),
@@ -687,13 +687,6 @@ begin
   end
   ... = ε * (∥r∥ * ∥r∥⁻¹)^2 : by { generalize : ∥r∥⁻¹ = u, ring }
   ... = ε : by { rw [mul_inv_cancel (ne.symm (ne_of_lt norm_r_pos))], simp }
-end
-
-lemma continuous_on_inv : continuous_on (λ(x:α), x⁻¹) {x | x ≠ 0} :=
-begin
-  assume x hx,
-  apply continuous_at.continuous_within_at,
-  exact (tendsto_inv hx)
 end
 
 end normed_field
@@ -749,65 +742,6 @@ instance : normed_field ℝ :=
 
 instance : nondiscrete_normed_field ℝ :=
 { non_trivial := ⟨2, by { unfold norm, rw abs_of_nonneg; norm_num }⟩ }
-
-/-- If a function converges to a nonzero value, its inverse converges to the inverse of this value.
-We use the name `tendsto.inv'` as `tendsto.inv` is already used in multiplicative topological
-groups. -/
-lemma filter.tendsto.inv' [normed_field α] {l : filter β} {f : β → α} {y : α}
-  (hy : y ≠ 0) (h : tendsto f l (𝓝 y)) :
-  tendsto (λx, (f x)⁻¹) l (𝓝 y⁻¹) :=
-(normed_field.tendsto_inv hy).comp h
-
-lemma continuous_at.inv' [topological_space α] [normed_field β] {f : α → β} {x : α}
-  (hf : continuous_at f x) (hx : f x ≠ 0) :
-  continuous_at (λ x, (f x)⁻¹) x :=
-hf.inv' hx
-
-lemma continuous_within_at.inv' [topological_space α] [normed_field β] {f : α → β} {x : α}
-  {s : set α} (hf : continuous_within_at f s x) (hx : f x ≠ 0) :
-  continuous_within_at (λ x, (f x)⁻¹) s x :=
-hf.inv' hx
-
-lemma continuous.inv' [topological_space α] [normed_field β] {f : α → β} (hf : continuous f)
-  (h0 : ∀ x, f x ≠ 0) : continuous (λ x, (f x)⁻¹) :=
-continuous_iff_continuous_at.2 $ λ x, (hf.tendsto x).inv' (h0 x)
-
-lemma continuous_on.inv' [topological_space α] [normed_field β] {f : α → β} {s : set α}
-  (hf : continuous_on f s) (h0 : ∀ x ∈ s, f x ≠ 0) :
-  continuous_on (λ x, (f x)⁻¹) s :=
-λ x hx, (hf x hx).inv' (h0 x hx)
-
-lemma filter.tendsto.div_const [normed_field α] {l : filter β} {f : β → α} {x y : α}
-  (hf : tendsto f l (𝓝 x)) : tendsto (λa, f a / y) l (𝓝 (x / y)) :=
-hf.mul tendsto_const_nhds
-
-lemma filter.tendsto.div [normed_field α] {l : filter β} {f g : β → α} {x y : α}
-  (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) (hy : y ≠ 0) :
-  tendsto (λa, f a / g a) l (𝓝 (x / y)) :=
-hf.mul (hg.inv' hy)
-
-lemma continuous_within_at.div [topological_space α] [normed_field β] {f : α → β} {g : α → β}
-  {s : set α} {x : α} (hf : continuous_within_at f s x) (hg : continuous_within_at g s x)
-  (hnz : g x ≠ 0) :
-  continuous_within_at (λ x, f x / g x) s x :=
-hf.div hg hnz
-
-lemma continuous_on.div [topological_space α] [normed_field β] {f : α → β} {g : α → β}
-  {s : set α} (hf : continuous_on f s) (hg : continuous_on g s) (hnz : ∀ x ∈ s, g x ≠ 0) :
-  continuous_on (λ x, f x / g x) s :=
-λ x hx, (hf x hx).div (hg x hx) (hnz x hx)
-
-/-- Continuity at a point of the result of dividing two functions
-continuous at that point, where the denominator is nonzero. -/
-lemma continuous_at.div [topological_space α] [normed_field β] {f : α → β} {g : α → β} {x : α}
-    (hf : continuous_at f x) (hg : continuous_at g x) (hnz : g x ≠ 0) :
-  continuous_at (λ x, f x / g x) x :=
-hf.div hg hnz
-
-lemma continuous.div [topological_space α] [normed_field β] {f : α → β} {g : α → β}
-  (hf : continuous f) (hg : continuous g) (h0 : ∀ x, g x ≠ 0) :
-  continuous (λ x, f x / g x) :=
-continuous_iff_continuous_at.2 $ λ x, (hf.tendsto x).div (hg.tendsto x) (h0 x)
 
 namespace real
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -651,6 +651,7 @@ nnreal.eq $ by simp
 @[simp] lemma norm_fpow : ∀ (a : α) (n : ℤ), ∥a^n∥ = ∥a∥^n :=
 (norm_hom : α →* ℝ).map_fpow norm_zero
 
+@[priority 100]
 instance : has_continuous_inv' α :=
 begin
   refine ⟨λ r r0, (nhds_basis_closed_ball.tendsto_iff nhds_basis_closed_ball).2 (λε εpos, _)⟩,

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -651,7 +651,7 @@ nnreal.eq $ by simp
 @[simp] lemma norm_fpow : ∀ (a : α) (n : ℤ), ∥a^n∥ = ∥a∥^n :=
 (norm_hom : α →* ℝ).map_fpow norm_zero
 
-@[priority 100]
+@[priority 100] -- see Note [lower instance priority]
 instance : has_continuous_inv' α :=
 begin
   refine ⟨λ r r0, (nhds_basis_closed_ball.tendsto_iff nhds_basis_closed_ball).2 (λε εpos, _)⟩,

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -449,7 +449,7 @@ measurable_inv.comp hf
 
 lemma measurable_inv' {α : Type*} [normed_field α] [measurable_space α] [borel_space α] :
   measurable (has_inv.inv : α → α) :=
-measurable_of_continuous_on_compl_singleton 0 normed_field.continuous_on_inv
+measurable_of_continuous_on_compl_singleton 0 continuous_on_inv'
 
 lemma measurable.inv' {α : Type*} [normed_field α] [measurable_space α] [borel_space α]
   {f : δ → α} (hf : measurable f) :

--- a/src/topology/algebra/group_with_zero.lean
+++ b/src/topology/algebra/group_with_zero.lean
@@ -11,12 +11,19 @@ import algebra.group.pi
 
 In this file we define `has_continuous_inv'` to be a mixin typeclass a type with `has_inv` and
 `has_zero` (e.g., a `group_with_zero`) such that `λ x, x⁻¹` is continuous at all nonzero points. Any
-normed (semi)field has this property.
+normed (semi)field has this property. Currently the only example of `has_continuous_inv'` in
+`mathlib` which is not a normed field is the type `nnnreal` (a.k.a. `ℝ≥0`) of nonnegative real
+numbers.
 
 Then we prove lemmas about continuity of `x ↦ x⁻¹` and `f / g` providing dot-style `*.inv'` and
 `*.div` operations on `filter.tendsto`, `continuous_at`, `continuous_within_at`, `continuous_on`,
 and `continuous`. As a special case, we provide `*.div_const` operations that require only
-`group_with_zero` and `has_continuous_mul` instances. -/
+`group_with_zero` and `has_continuous_mul` instances.
+
+All lemmas about `(⁻¹)` use `inv'` in their names because lemmas without `'` are used for
+`topological_group`s. We also use `'` in the typeclass name `has_continuous_inv'` for the sake of
+consistency of notation.
+-/
 
 open_locale topological_space
 open filter

--- a/src/topology/algebra/group_with_zero.lean
+++ b/src/topology/algebra/group_with_zero.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2020 Yury G. Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Yury G. Kudryashov
+-/
+import topology.algebra.monoid
+import algebra.group.pi
+
+/-!
+# Topological group with zero
+
+In this file we define `has_continuous_inv'` to be a mixin typeclass a type with `has_inv` and
+`has_zero` (e.g., a `group_with_zero`) such that `λ x, x⁻¹` is continuous at all nonzero points. Any
+normed (semi)field has this property.
+
+Then we prove lemmas about continuity of `x ↦ x⁻¹` and `f / g` providing dot-style `*.inv'` and
+`*.div` operations on `filter.tendsto`, `continuous_at`, `continuous_within_at`, `continuous_on`,
+and `continuous`. As a special case, we provide `*.div_const` operations that require only
+`group_with_zero` and `has_continuous_mul` instances. -/
+
+open_locale topological_space
+open filter
+
+/-!
+### A group with zero with continuous multiplication
+
+If `G₀` is a group with zero with continuous `(*)`, then `(/y)` is continuous for any `y`. In this
+section we prove lemmas that immediately follow from this fact providing `*.div_const` dot-style
+operations on `filter.tendsto`, `continuous_at`, `continuous_within_at`, `continuous_on`, and
+`continuous`.
+-/
+
+variables {α G₀ : Type*}
+
+section div_const
+
+variables [group_with_zero G₀] [topological_space G₀] [has_continuous_mul G₀]
+  {f : α → G₀} {s : set α} {l : filter α}
+
+lemma filter.tendsto.div_const {x y : G₀} (hf : tendsto f l (𝓝 x)) :
+  tendsto (λa, f a / y) l (𝓝 (x / y)) :=
+hf.mul tendsto_const_nhds
+
+variables [topological_space α]
+
+lemma continuous_at.div_const (hf : continuous f) {y : G₀} : continuous (λ x, f x / y) :=
+hf.mul continuous_const
+
+lemma continuous_within_at.div_const {a} (hf : continuous_within_at f s a) {y : G₀} :
+  continuous_within_at (λ x, f x / y) s a :=
+hf.div_const
+
+lemma continuous_on.div_const (hf : continuous_on f s) {y : G₀} : continuous_on (λ x, f x / y) s :=
+hf.mul continuous_on_const
+
+lemma continuous.div_const (hf : continuous f) {y : G₀} : continuous (λ x, f x / y) :=
+hf.mul continuous_const
+
+end div_const
+
+/-- A type with `0` and `has_inv` such that `λ x, x⁻¹` is continuous at all nonzero points. Any
+normed (semi)field has this property. -/
+class has_continuous_inv' (G₀ : Type*) [has_zero G₀] [has_inv G₀] [topological_space G₀] :=
+(continuous_at_inv' : ∀ ⦃x : G₀⦄, x ≠ 0 → continuous_at has_inv.inv x)
+
+export has_continuous_inv' (continuous_at_inv')
+
+section inv'
+
+variables [has_zero G₀] [has_inv G₀] [topological_space G₀] [has_continuous_inv' G₀]
+  {l : filter α} {f : α → G₀} {s : set α} {a : α}
+
+/-!
+### Continuity of `λ x, x⁻¹` at a non-zero point
+
+We define `topological_group_with_zero` to be a `group_with_zero` such that the operation `x ↦ x⁻¹`
+is continuous at all nonzero points. In this section we prove dot-style `*.inv'` lemmas for
+`filter.tendsto`, `continuous_at`, `continuous_within_at`, `continuous_on`, and `continuous`.
+-/
+
+lemma tendsto_inv' {x : G₀}  (hx : x ≠ 0) : tendsto has_inv.inv (𝓝 x) (𝓝 x⁻¹) :=
+continuous_at_inv' hx
+
+lemma continuous_on_inv' : continuous_on (has_inv.inv : G₀ → G₀) {0}ᶜ :=
+λ x hx, (continuous_at_inv' hx).continuous_within_at
+
+/-- If a function converges to a nonzero value, its inverse converges to the inverse of this value.
+We use the name `tendsto.inv'` as `tendsto.inv` is already used in multiplicative topological
+groups. -/
+lemma filter.tendsto.inv' {a : G₀} (hf : tendsto f l (𝓝 a))
+  (ha : a ≠ 0) :
+  tendsto (λ x, (f x)⁻¹) l (𝓝 a⁻¹) :=
+(tendsto_inv' ha).comp hf
+
+variables [topological_space α]
+
+lemma continuous_within_at.inv' (hf : continuous_within_at f s a) (ha : f a ≠ 0) :
+  continuous_within_at (λ x, (f x)⁻¹) s a :=
+hf.inv' ha
+
+lemma continuous_at.inv' (hf : continuous_at f a) (ha : f a ≠ 0) :
+  continuous_at (λ x, (f x)⁻¹) a :=
+hf.inv' ha
+
+lemma continuous.inv' (hf : continuous f) (h0 : ∀ x, f x ≠ 0) : continuous (λ x, (f x)⁻¹) :=
+continuous_iff_continuous_at.2 $ λ x, (hf.tendsto x).inv' (h0 x)
+
+lemma continuous_on.inv' (hf : continuous_on f s) (h0 : ∀ x ∈ s, f x ≠ 0) :
+  continuous_on (λ x, (f x)⁻¹) s :=
+λ x hx, (hf x hx).inv' (h0 x hx)
+
+end inv'
+
+/-!
+### Continuity of division
+
+If `G₀` is a `group_with_zero` with `x ↦ x⁻¹` continuous at all nonzero points and `(*)`, then
+division `(/)` is continuous at any point where the denominator is continuous.
+-/
+
+section div
+
+variables [group_with_zero G₀] [topological_space G₀] [has_continuous_inv' G₀]
+  [has_continuous_mul G₀] {f g : α → G₀}
+
+lemma filter.tendsto.div {l : filter α} {a b : G₀} (hf : tendsto f l (𝓝 a))
+  (hg : tendsto g l (𝓝 b)) (hy : b ≠ 0) :
+  tendsto (f / g) l (𝓝 (a / b)) :=
+hf.mul (hg.inv' hy)
+
+variables [topological_space α] {s : set α} {a : α}
+
+lemma continuous_within_at.div (hf : continuous_within_at f s a) (hg : continuous_within_at g s a)
+  (h₀ : g a ≠ 0) :
+  continuous_within_at (f / g) s a :=
+hf.div hg h₀
+
+lemma continuous_on.div (hf : continuous_on f s) (hg : continuous_on g s) (h₀ : ∀ x ∈ s, g x ≠ 0) :
+  continuous_on (f / g) s :=
+λ x hx, (hf x hx).div (hg x hx) (h₀ x hx)
+
+/-- Continuity at a point of the result of dividing two functions continuous at that point, where
+the denominator is nonzero. -/
+lemma continuous_at.div (hf : continuous_at f a) (hg : continuous_at g a) (h₀ : g a ≠ 0) :
+  continuous_at (f / g) a :=
+hf.div hg h₀
+
+lemma continuous.div (hf : continuous f) (hg : continuous g) (h₀ : ∀ x, g x ≠ 0) :
+  continuous (f / g) :=
+hf.mul $ hg.inv' h₀
+
+lemma continuous_on_div : continuous_on (λ p : G₀ × G₀, p.1 / p.2) {p | p.2 ≠ 0} :=
+continuous_on_fst.div continuous_on_snd $ λ _, id
+
+end div

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -423,7 +423,7 @@ protected lemma tendsto_coe_sub : ∀{b:ennreal}, tendsto (λb:ennreal, ↑r - b
 begin
   refine (forall_ennreal.2 $ and.intro (assume a, _) _),
   { simp [@nhds_coe a, tendsto_map'_iff, (∘), tendsto_coe, coe_sub.symm],
-    exact nnreal.tendsto.sub tendsto_const_nhds tendsto_id },
+    exact tendsto_const_nhds.sub tendsto_id },
   simp,
   exact (tendsto.congr' (mem_sets_of_superset (lt_mem_nhds $ @coe_lt_top r) $
     by simp [le_of_lt] {contextual := tt})) tendsto_const_nhds

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -6,6 +6,8 @@ Authors: Johan Commelin
 Nonnegative real numbers.
 -/
 import topology.algebra.infinite_sum
+import topology.algebra.group_with_zero
+
 noncomputable theory
 open set topological_space metric
 open_locale topological_space
@@ -36,9 +38,9 @@ continuous_subtype_mk _ $ continuous_id.max continuous_const
 lemma continuous_coe : continuous (coe : ℝ≥0 → ℝ) :=
 continuous_subtype_val
 
-@[simp, norm_cast] lemma tendsto_coe {f : filter α} {m : α → ℝ≥0} :
-  ∀{x : ℝ≥0}, tendsto (λa, (m a : ℝ)) f (𝓝 (x : ℝ)) ↔ tendsto m f (𝓝 x)
-| ⟨r, hr⟩ := by rw [nhds_subtype_eq_comap, tendsto_comap_iff]; refl
+@[simp, norm_cast] lemma tendsto_coe {f : filter α} {m : α → ℝ≥0} {x : ℝ≥0} :
+  tendsto (λa, (m a : ℝ)) f (𝓝 (x : ℝ)) ↔ tendsto m f (𝓝 x) :=
+tendsto_subtype_rng.symm
 
 lemma tendsto_coe' {f : filter α} [ne_bot f] {m : α → ℝ≥0} {x : ℝ} :
   tendsto (λ a, m a : α → ℝ) f (𝓝 x) ↔ ∃ hx : 0 ≤ x, tendsto m f (𝓝 ⟨x, hx⟩) :=
@@ -65,10 +67,9 @@ instance : has_continuous_sub ℝ≥0 :=
   ((continuous_coe.comp continuous_fst).sub
    (continuous_coe.comp continuous_snd)).max continuous_const⟩
 
-lemma tendsto.sub {f : filter α} {m n : α → ℝ≥0} {r p : ℝ≥0}
-  (hm : tendsto m f (𝓝 r)) (hn : tendsto n f (𝓝 p)) :
-  tendsto (λa, m a - n a) f (𝓝 (r - p)) :=
-tendsto_of_real $ (tendsto_coe.2 hm).sub (tendsto_coe.2 hn)
+instance : has_continuous_inv' ℝ≥0 :=
+⟨λ x hx, tendsto_coe.1 $ (real.tendsto_inv $ nnreal.coe_ne_zero.2 hx).comp
+  continuous_coe.continuous_at⟩
 
 @[norm_cast] lemma has_sum_coe {f : α → ℝ≥0} {r : ℝ≥0} :
   has_sum (λa, (f a : ℝ)) (r : ℝ) ↔ has_sum f r :=


### PR DESCRIPTION
Move lemmas about continuity of division from `normed_field`, add a few new lemmas, and introduce a new typeclass. Also use it for `nnreal`s.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
