### PR TITLE
[Merged by Bors] - feat(data/equiv, algebra/*): Add simps projections to many equivs and homs

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -364,8 +364,6 @@ run_cmd tactic.add_doc_string `alg_hom.to_ring_hom "Reinterpret an `alg_hom` as 
 infixr ` →ₐ `:25 := alg_hom _
 notation A ` →ₐ[`:25 R `] ` B := alg_hom R A B
 
-initialize_simps_projections alg_hom (to_fun → apply)
-
 namespace alg_hom
 
 variables {R : Type u} {A : Type v} {B : Type w} {C : Type u₁} {D : Type v₁}
@@ -376,6 +374,8 @@ variables [comm_semiring R] [semiring A] [semiring B] [semiring C] [semiring D]
 variables [algebra R A] [algebra R B] [algebra R C] [algebra R D]
 
 instance : has_coe_to_fun (A →ₐ[R] B) := ⟨_, λ f, f.to_fun⟩
+
+initialize_simps_projections alg_hom (to_fun → apply)
 
 instance coe_ring_hom : has_coe (A →ₐ[R] B) (A →+* B) := ⟨alg_hom.to_ring_hom⟩
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -364,6 +364,8 @@ run_cmd tactic.add_doc_string `alg_hom.to_ring_hom "Reinterpret an `alg_hom` as 
 infixr ` →ₐ `:25 := alg_hom _
 notation A ` →ₐ[`:25 R `] ` B := alg_hom R A B
 
+initialize_simps_projections alg_hom (to_fun → apply)
+
 namespace alg_hom
 
 variables {R : Type u} {A : Type v} {B : Type w} {C : Type u₁} {D : Type v₁}
@@ -673,6 +675,12 @@ def symm (e : A₁ ≃ₐ[R] A₂) : A₂ ≃ₐ[R] A₁ :=
 { commutes' := λ r, by { rw ←e.to_ring_equiv.symm_apply_apply (algebra_map R A₁ r), congr,
                          change _ = e _, rw e.commutes, },
   ..e.to_ring_equiv.symm, }
+
+/-- See Note [custom simps projection] -/
+@[to_additive]
+def simps.inv_fun (e : A₁ ≃ₐ[R] A₂) : A₂ → A₁ := e.symm
+
+initialize_simps_projections alg_equiv (to_fun → apply, inv_fun → symm_apply)
 
 @[simp] lemma inv_fun_apply {e : A₁ ≃ₐ[R] A₂} {a : A₂} : e.inv_fun a = e.symm a := rfl
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -677,7 +677,6 @@ def symm (e : A₁ ≃ₐ[R] A₂) : A₂ ≃ₐ[R] A₁ :=
   ..e.to_ring_equiv.symm, }
 
 /-- See Note [custom simps projection] -/
-@[to_additive]
 def simps.inv_fun (e : A₁ ≃ₐ[R] A₂) : A₂ → A₁ := e.symm
 
 initialize_simps_projections alg_equiv (to_fun → apply, inv_fun → symm_apply)

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -68,10 +68,6 @@ structure add_monoid_hom (M : Type*) (N : Type*) [add_monoid M] [add_monoid N]
 attribute [nolint doc_blame] add_monoid_hom.to_add_hom
 attribute [nolint doc_blame] add_monoid_hom.to_zero_hom
 
-initialize_simps_projections zero_hom (to_fun → apply)
-initialize_simps_projections add_hom (to_fun → apply)
-initialize_simps_projections add_monoid_hom (to_fun → apply)
-
 infixr ` →+ `:25 := add_monoid_hom
 
 /-- Homomorphism that preserves one -/
@@ -93,10 +89,6 @@ structure monoid_hom (M : Type*) (N : Type*) [monoid M] [monoid N] extends one_h
 attribute [nolint doc_blame] monoid_hom.to_mul_hom
 attribute [nolint doc_blame] monoid_hom.to_one_hom
 
-initialize_simps_projections one_hom (to_fun → apply)
-initialize_simps_projections mul_hom (to_fun → apply)
-initialize_simps_projections monoid_hom (to_fun → apply)
-
 infixr ` →* `:25 := monoid_hom
 
 -- completely uninteresting lemmas about coercion to function, that all homs need
@@ -111,6 +103,15 @@ instance {mM : has_mul M} {mN : has_mul N} : has_coe_to_fun (mul_hom M N) :=
 @[to_additive]
 instance {mM : monoid M} {mN : monoid N} : has_coe_to_fun (M →* N) :=
 ⟨_, monoid_hom.to_fun⟩
+
+-- these must come after the coe_to_fun definitions
+initialize_simps_projections zero_hom (to_fun → apply)
+initialize_simps_projections add_hom (to_fun → apply)
+initialize_simps_projections add_monoid_hom (to_fun → apply)
+
+initialize_simps_projections one_hom (to_fun → apply)
+initialize_simps_projections mul_hom (to_fun → apply)
+initialize_simps_projections monoid_hom (to_fun → apply)
 
 @[simp, to_additive]
 lemma one_hom.to_fun_eq_coe [has_one M] [has_one N] (f : one_hom M N) : f.to_fun = f := rfl

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -68,6 +68,10 @@ structure add_monoid_hom (M : Type*) (N : Type*) [add_monoid M] [add_monoid N]
 attribute [nolint doc_blame] add_monoid_hom.to_add_hom
 attribute [nolint doc_blame] add_monoid_hom.to_zero_hom
 
+initialize_simps_projections zero_hom (to_fun → apply)
+initialize_simps_projections add_hom (to_fun → apply)
+initialize_simps_projections add_monoid_hom (to_fun → apply)
+
 infixr ` →+ `:25 := add_monoid_hom
 
 /-- Homomorphism that preserves one -/
@@ -88,6 +92,10 @@ structure monoid_hom (M : Type*) (N : Type*) [monoid M] [monoid N] extends one_h
 
 attribute [nolint doc_blame] monoid_hom.to_mul_hom
 attribute [nolint doc_blame] monoid_hom.to_one_hom
+
+initialize_simps_projections one_hom (to_fun → apply)
+initialize_simps_projections mul_hom (to_fun → apply)
+initialize_simps_projections monoid_hom (to_fun → apply)
 
 infixr ` →* `:25 := monoid_hom
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -353,7 +353,7 @@ def symm : M₂ ≃ₗ[R] M :=
   .. e.to_equiv.symm }
 
 /-- See Note [custom simps projection] -/
-def simps.inv_fun (e : M ≃ₗ[R] M₂) : M₂ → M := e.symm
+def simps.inv_fun [semimodule R M] [semimodule R M₂] (e : M ≃ₗ[R] M₂) : M₂ → M := e.symm
 
 initialize_simps_projections linear_equiv (to_fun → apply, inv_fun → symm_apply)
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -71,6 +71,8 @@ variables [semimodule R M] [semimodule R M₂]
 
 instance : has_coe_to_fun (M →ₗ[R] M₂) := ⟨_, to_fun⟩
 
+initialize_simps_projections linear_map (to_fun → apply)
+
 @[simp] lemma coe_mk (f : M → M₂) (h₁ h₂) :
   ((linear_map.mk f h₁ h₂ : M →ₗ[R] M₂) : M → M₂) = f := rfl
 
@@ -349,6 +351,12 @@ end
 def symm : M₂ ≃ₗ[R] M :=
 { .. e.to_linear_map.inverse e.inv_fun e.left_inv e.right_inv,
   .. e.to_equiv.symm }
+
+/-- See Note [custom simps projection] -/
+@[to_additive]
+def simps.inv_fun (e : M ≃ₗ[R] M₂) : M₂ → M := e.symm
+
+initialize_simps_projections linear_equiv (to_fun → apply, inv_fun → symm_apply)
 
 @[simp] lemma inv_fun_apply {m : M₂} : e.inv_fun m = e.symm m := rfl
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -353,7 +353,6 @@ def symm : M₂ ≃ₗ[R] M :=
   .. e.to_equiv.symm }
 
 /-- See Note [custom simps projection] -/
-@[to_additive]
 def simps.inv_fun (e : M ≃ₗ[R] M₂) : M₂ → M := e.symm
 
 initialize_simps_projections linear_equiv (to_fun → apply, inv_fun → symm_apply)

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -219,6 +219,8 @@ add_decl_doc ring_hom.to_monoid_hom
 The `simp`-normal form is `(f : R →+ S)`. -/
 add_decl_doc ring_hom.to_add_monoid_hom
 
+initialize_simps_projections ring_hom (to_fun → apply)
+
 namespace ring_hom
 
 section coe

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -219,8 +219,6 @@ add_decl_doc ring_hom.to_monoid_hom
 The `simp`-normal form is `(f : R →+ S)`. -/
 add_decl_doc ring_hom.to_add_monoid_hom
 
-initialize_simps_projections ring_hom (to_fun → apply)
-
 namespace ring_hom
 
 section coe
@@ -230,6 +228,8 @@ variables {rα : semiring α} {rβ : semiring β}
 include rα rβ
 
 instance : has_coe_to_fun (α →+* β) := ⟨_, ring_hom.to_fun⟩
+
+initialize_simps_projections ring_hom (to_fun → apply)
 
 @[simp] lemma to_fun_eq_coe (f : α →+* β) : f.to_fun = f := rfl
 

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -110,6 +110,13 @@ def symm (h : M ≃* N) : N ≃* M :=
     end,
   .. h.to_equiv.symm}
 
+/-- See Note [custom simps projection] -/
+@[to_additive]
+def simps.inv_fun (e : M ≃* N) : N → M := e.symm
+
+initialize_simps_projections add_equiv (to_fun → apply, inv_fun → symm_apply)
+initialize_simps_projections mul_equiv (to_fun → apply, inv_fun → symm_apply)
+
 @[simp, to_additive]
 theorem to_equiv_symm (f : M ≃* N) : f.symm.to_equiv = f.to_equiv.symm := rfl
 

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -111,7 +111,7 @@ def symm (h : M ≃* N) : N ≃* M :=
   .. h.to_equiv.symm}
 
 /-- See Note [custom simps projection] -/
-@[to_additive]
+@[to_additive simps.inv_fun]
 def simps.inv_fun (e : M ≃* N) : N → M := e.symm
 
 initialize_simps_projections add_equiv (to_fun → apply, inv_fun → symm_apply)

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -111,7 +111,7 @@ def symm (h : M ≃* N) : N ≃* M :=
   .. h.to_equiv.symm}
 
 /-- See Note [custom simps projection] -/
-@[to_additive simps.inv_fun]
+@[to_additive add_equiv.simps.inv_fun "See Note [custom simps projection]"]
 def simps.inv_fun (e : M ≃* N) : N → M := e.symm
 
 initialize_simps_projections add_equiv (to_fun → apply, inv_fun → symm_apply)

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -101,6 +101,12 @@ variables {R}
 @[symm] protected def symm (e : R ≃+* S) : S ≃+* R :=
 { .. e.to_mul_equiv.symm, .. e.to_add_equiv.symm }
 
+/-- See Note [custom simps projection] -/
+@[to_additive]
+def simps.inv_fun (e : R ≃+* S) : S → R := e.symm
+
+initialize_simps_projections ring_equiv (to_fun → apply, inv_fun → symm_apply)
+
 /-- Transitivity of `ring_equiv`. -/
 @[trans] protected def trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') : R ≃+* S' :=
 { .. (e₁.to_mul_equiv.trans e₂.to_mul_equiv), .. (e₁.to_add_equiv.trans e₂.to_add_equiv) }

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -102,7 +102,6 @@ variables {R}
 { .. e.to_mul_equiv.symm, .. e.to_add_equiv.symm }
 
 /-- See Note [custom simps projection] -/
-@[to_additive]
 def simps.inv_fun (e : R ≃+* S) : S → R := e.symm
 
 initialize_simps_projections ring_equiv (to_fun → apply, inv_fun → symm_apply)


### PR DESCRIPTION
This doesn't actually change any existing lemmas to use these projections.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This follows on from #4663 and #4652