### PR TITLE
[Merged by Bors] - feat(data/dfinsupp): Port `finsupp.lsum` and lemmas about `lift_add_hom`

### DIFF
--- a/src/algebra/direct_sum.lean
+++ b/src/algebra/direct_sum.lean
@@ -102,7 +102,7 @@ def to_add_monoid : (⨁ i, β i) →+ γ :=
 (dfinsupp.lift_add_hom φ)
 
 @[simp] lemma to_add_monoid_of (i) (x : β i) : to_add_monoid φ (of β i x) = φ i x :=
-by simp [to_add_monoid, of]
+dfinsupp.lift_add_hom_apply_single φ i x
 
 variables (ψ : (⨁ i, β i) →+ γ)
 

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -931,7 +931,7 @@ begin
 end
 
 /-- The `dfinsupp` version of `finsupp.lsum`,-/
-@[simps apply symm_apply symm_apply_apply {rhs_md := semireducible, simp_rhs := tt}]
+@[simps apply symm_apply]
 def lsum {R : Type*} [semiring R] [Π i, add_comm_monoid (β i)] [Π i, semimodule R (β i)]
   [add_comm_monoid γ] [semimodule R γ] :
     (Π i, β i →ₗ[R] γ) ≃+ ((Π₀ i, β i) →ₗ[R] γ) :=

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -831,7 +831,7 @@ begin
 end
 
 /-- The `dfinsupp` version of `finsupp.lift_add_hom`,-/
-@[simps]
+@[simps apply symm_apply]
 def lift_add_hom [Π i, add_monoid (β i)] [add_comm_monoid γ] :
   (Π i, β i →+ γ) ≃+ ((Π₀ i, β i) →+ γ) :=
 { to_fun := sum_add_hom,
@@ -844,22 +844,11 @@ lemma sum_sub_index [Π i, add_comm_group (β i)] [Π i (x : β i), decidable (x
   [add_comm_group γ] {f g : Π₀ i, β i}
   {h : Π i, β i → γ} (h_sub : ∀i b₁ b₂, h i (b₁ - b₂) = h i b₁ - h i b₂) :
   (f - g).sum h = f.sum h - g.sum h :=
-have h_zero : ∀i, h i 0 = 0,
-  from assume i,
-  have h i (0 - 0) = h i 0 - h i 0, from h_sub i 0 0,
-  by simpa using this,
-have h_neg : ∀i b, h i (- b) = - h i b,
-  from assume i b,
-  have h i (0 - b) = h i 0 - h i b, from h_sub i 0 b,
-  by simpa [h_zero] using this,
-have h_add : ∀i b₁ b₂, h i (b₁ + b₂) = h i b₁ + h i b₂,
-  from assume i b₁ b₂,
-  have h i (b₁ - (- b₂)) = h i b₁ - h i (- b₂), from h_sub i b₁ (-b₂),
-  by simpa [h_neg, sub_eq_add_neg] using this,
-by simp [sub_eq_add_neg];
-simp [@sum_add_index ι β _ γ _ _ _ f (-g) h h_zero h_add];
-simp [@sum_neg_index ι β _ γ _ _ _ g h h_zero, h_neg];
-simp [@sum_neg ι β _ γ _ _ _ g h]
+begin
+  have := (lift_add_hom (λ a, add_monoid_hom.of_map_sub (h a) (h_sub a))).map_sub f g,
+  rw [lift_add_hom_apply, sum_add_hom_apply, sum_add_hom_apply, sum_add_hom_apply] at this,
+  exact this,
+end
 
 @[to_additive]
 lemma prod_finset_sum_index {γ : Type w} {α : Type x}

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -832,6 +832,11 @@ def sum_add_hom [Π i, add_monoid (β i)] [add_comm_monoid γ] (φ : Π i, β i 
 (add_zero _).trans $ congr_arg (φ i) $ show (if H : i ∈ ({i} : finset _) then x else 0) = x,
 from dif_pos $ finset.mem_singleton_self i
 
+@[simp] lemma sum_add_hom_comp_single [Π i, add_comm_monoid (β i)] [add_comm_monoid γ]
+  (f : Π i, β i →+ γ) (i : ι) :
+  (sum_add_hom f).comp (single_add_hom β i) = f i :=
+add_monoid_hom.ext $ λ x, sum_add_hom_single f i x
+
 /-- While we didn't need decidable instances to define it, we do to reduce it to a sum -/
 lemma sum_add_hom_apply [Π i, add_monoid (β i)] [Π i (x : β i), decidable (x ≠ 0)]
   [add_comm_monoid γ] (φ : Π i, β i →+ γ) (f : Π₀ i, β i) :
@@ -848,7 +853,7 @@ begin
 end
 
 /-- The `dfinsupp` version of `finsupp.lift_add_hom`,-/
-@[simps apply symm_apply symm_apply_apply {rhs_md := semireducible, simp_rhs := tt}]
+@[simps apply symm_apply]
 def lift_add_hom [Π i, add_monoid (β i)] [add_comm_monoid γ] :
   (Π i, β i →+ γ) ≃+ ((Π₀ i, β i) →+ γ) :=
 { to_fun := sum_add_hom,
@@ -869,10 +874,10 @@ lemma lift_add_hom_apply_single [Π i, add_comm_monoid (β i)] [add_comm_monoid 
 by simp
 
 /-- The `dfinsupp` version of `finsupp.lift_add_hom_comp_single`,-/
-@[simp] lemma lift_add_hom_comp_single [Π i, add_comm_monoid (β i)] [add_comm_monoid γ]
+lemma lift_add_hom_comp_single [Π i, add_comm_monoid (β i)] [add_comm_monoid γ]
   (f : Π i, β i →+ γ) (i : ι) :
   (lift_add_hom f).comp (single_add_hom β i) = f i :=
-add_monoid_hom.ext $ λ x, lift_add_hom_apply_single f i x
+by simp
 
 /-- The `dfinsupp` version of `finsupp.comp_lift_add_hom`,-/
 lemma comp_lift_add_hom {δ : Type*} [Π i, add_comm_monoid (β i)] [add_comm_monoid γ]

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -831,7 +831,7 @@ begin
 end
 
 /-- The `dfinsupp` version of `finsupp.lift_add_hom`,-/
-@[simps apply symm_apply]
+@[simps apply symm_apply symm_apply_apply {rhs_md := semireducible, simp_rhs := tt}]
 def lift_add_hom [Π i, add_monoid (β i)] [add_comm_monoid γ] :
   (Π i, β i →+ γ) ≃+ ((Π₀ i, β i) →+ γ) :=
 { to_fun := sum_add_hom,
@@ -839,6 +839,31 @@ def lift_add_hom [Π i, add_monoid (β i)] [add_comm_monoid γ] :
   left_inv := λ x, by { ext, simp },
   right_inv := λ ψ, by { ext, simp },
   map_add' := λ F G, by { ext, simp } }
+
+/-- The `dfinsupp` version of `finsupp.lift_add_hom_single_add_hom`,-/
+@[simp] lemma lift_add_hom_single_add_hom [Π i, add_comm_monoid (β i)] :
+  lift_add_hom (single_add_hom β) = add_monoid_hom.id (Π₀ i, β i) :=
+lift_add_hom.to_equiv.apply_eq_iff_eq_symm_apply.2 rfl
+
+/-- The `dfinsupp` version of `finsupp.lift_add_hom_apply_single`,-/
+lemma lift_add_hom_apply_single [Π i, add_comm_monoid (β i)] [add_comm_monoid γ]
+  (f : Π i, β i →+ γ) (i : ι) (x : β i) :
+  lift_add_hom f (single i x) = f i x :=
+by simp
+
+/-- The `dfinsupp` version of `finsupp.lift_add_hom_comp_single`,-/
+@[simp] lemma lift_add_hom_comp_single [Π i, add_comm_monoid (β i)] [add_comm_monoid γ]
+  (f : Π i, β i →+ γ) (i : ι) :
+  (lift_add_hom f).comp (single_add_hom β i) = f i :=
+add_monoid_hom.ext $ λ x, lift_add_hom_apply_single f i x
+
+/-- The `dfinsupp` version of `finsupp.comp_lift_add_hom`,-/
+lemma comp_lift_add_hom {δ : Type*} [Π i, add_comm_monoid (β i)] [add_comm_monoid γ]
+  [add_comm_monoid δ]
+  (g : γ →+ δ) (f : Π i, β i →+ γ) :
+  g.comp (lift_add_hom f) = lift_add_hom (λ a, g.comp (f a)) :=
+lift_add_hom.symm_apply_eq.1 $ funext $ λ a,
+  by rw [lift_add_hom_symm_apply, add_monoid_hom.comp_assoc, lift_add_hom_comp_single]
 
 lemma sum_sub_index [Π i, add_comm_group (β i)] [Π i (x : β i), decidable (x ≠ 0)]
   [add_comm_group γ] {f g : Π₀ i, β i}

--- a/src/linear_algebra/direct_sum_module.lean
+++ b/src/linear_algebra/direct_sum_module.lean
@@ -74,16 +74,7 @@ variables (φ : Π i, M i →ₗ[R] N)
 variables (R ι N φ)
 /-- The linear map constructed using the universal property of the coproduct. -/
 def to_module : (⨁ i, M i) →ₗ[R] N :=
-{ to_fun := to_add_monoid (λ i, (φ i).to_add_monoid_hom),
-  map_add' := (to_add_monoid (λ i, (φ i).to_add_monoid_hom)).map_add,
-  map_smul' := λ c x, direct_sum.induction_on x
-    (by rw [smul_zero, add_monoid_hom.map_zero, smul_zero])
-    (λ i x,
-      by rw [← of_smul, to_add_monoid_of, to_add_monoid_of, linear_map.to_add_monoid_hom_coe,
-        linear_map.map_smul])
-    (λ x y ihx ihy,
-      by rw [smul_add, add_monoid_hom.map_add, ihx, ihy, add_monoid_hom.map_add, smul_add]),
-  ..(to_add_monoid (λ i, (φ i).to_add_monoid_hom))}
+dfinsupp.lsum φ
 
 variables {ι N φ}
 

--- a/src/linear_algebra/direct_sum_module.lean
+++ b/src/linear_algebra/direct_sum_module.lean
@@ -94,7 +94,7 @@ variables {ψ} {ψ' : (⨁ i, M i) →ₗ[R] N}
 
 theorem to_module.ext (H : ∀ i, ψ.comp (lof R ι M i) = ψ'.comp (lof R ι M i)) (f : ⨁ i, M i) :
   ψ f = ψ' f :=
-by rw [to_module.unique R ψ, to_module.unique R ψ', funext H]
+by rw dfinsupp.lhom_ext' R H
 
 /--
 The inclusion of a subset of the direct summands


### PR DESCRIPTION
This then removes the proofs of any `direct_sum` lemmas which become equivalent to the `lift_add_hom` lemmas

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
