### PR TITLE
[Merged by Bors] - chore(order/filter/bases): golf a proof

### DIFF
--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -67,7 +67,7 @@ lemma at_bot_basis' [semilattice_inf α] (a : α) :
 
 @[instance]
 lemma at_top_ne_bot [nonempty α] [semilattice_sup α] : ne_bot (at_top : filter α) :=
-at_top_basis.forall_nonempty_iff_ne_bot.1 $ λ a _, nonempty_Ici
+at_top_basis.ne_bot_iff.2 $ λ a _, nonempty_Ici
 
 @[instance]
 lemma at_bot_ne_bot [nonempty α] [semilattice_inf α] : ne_bot (at_bot : filter α) :=


### PR DESCRIPTION
* rename `filter.has_basis.forall_nonempty_iff_ne_bot` to
  `filter.has_basis.ne_bot_iff`, swap LHS with RHS;
* add `filter.has_basis.eq_bot_iff`;
* golf the proof of `filter.has_basis.ne_bot` using `filter.has_basis.forall_iff`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
