### PR TITLE
[Merged by Bors] - feat(order/conditionally_complete_lattice): nested intervals lemma

### DIFF
--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -334,8 +334,29 @@ by rw [infi, range_const, cInf_singleton]
 @[simp] theorem csupr_const [hι : nonempty ι] {a : α} : (⨆ b:ι, a) = a :=
 by rw [supr, range_const, cSup_singleton]
 
+lemma csupr_mem_Inter_Icc [nonempty β] [semilattice_sup β] {f g : β → α} (hf : monotone f)
+  (hg : ∀ ⦃m n⦄, m ≤ n → g n ≤ g m) (h : ∀ n, f n ≤ g n) :
+  (⨆ n, f n) ∈ ⋂ n, Icc (f n) (g n) :=
+begin
+  inhabit β,
+  refine mem_Inter.2 (λ n, ⟨le_csupr ⟨g $ default β, forall_range_iff.2 $ λ m, _⟩ _,
+    csupr_le $ λ m, _⟩); exact forall_le_of_monotone_of_mono_decr hf hg h _ _
+end
+
 end conditionally_complete_lattice
 
+instance pi.conditionally_complete_lattice {ι : Type*} {α : Π i : ι, Type*}
+  [Π i, conditionally_complete_lattice (α i)] :
+  conditionally_complete_lattice (Π i, α i) :=
+{ le_cSup := λ s f ⟨g, hg⟩ hf i, le_cSup ⟨g i, set.forall_range_iff.2 $ λ ⟨f', hf'⟩, hg hf' i⟩
+    ⟨⟨f, hf⟩, rfl⟩,
+  cSup_le := λ s f hs hf i, cSup_le (by haveI := hs.to_subtype; apply range_nonempty) $
+    λ b ⟨⟨g, hg⟩, hb⟩, hb ▸ hf hg i,
+  cInf_le := λ s f ⟨g, hg⟩ hf i, cInf_le ⟨g i, set.forall_range_iff.2 $ λ ⟨f', hf'⟩, hg hf' i⟩
+    ⟨⟨f, hf⟩, rfl⟩,
+  le_cInf := λ s f hs hf i, le_cInf (by haveI := hs.to_subtype; apply range_nonempty) $
+    λ b ⟨⟨g, hg⟩, hb⟩, hb ▸ hf hg i,
+  .. pi.lattice, .. pi.has_Sup, .. pi.has_Inf }
 
 section conditionally_complete_linear_order
 variables [conditionally_complete_linear_order α] {s t : set α} {a b : α}

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -334,14 +334,33 @@ by rw [infi, range_const, cInf_singleton]
 @[simp] theorem csupr_const [hι : nonempty ι] {a : α} : (⨆ b:ι, a) = a :=
 by rw [supr, range_const, cSup_singleton]
 
-lemma csupr_mem_Inter_Icc [nonempty β] [semilattice_sup β] {f g : β → α} (hf : monotone f)
-  (hg : ∀ ⦃m n⦄, m ≤ n → g n ≤ g m) (h : ∀ n, f n ≤ g n) :
+/-- Nested intervals lemma: if `f` is a monotonically increasing sequence, `g` is a monotonically
+decreasing sequence, and `f n ≤ g n` for all `n`, then `⨆ n, f n` belongs to all the intervals
+`[f n, g n]`. -/
+lemma csupr_mem_Inter_Icc_of_mono_incr_of_mono_decr [nonempty β] [semilattice_sup β]
+  {f g : β → α} (hf : monotone f) (hg : ∀ ⦃m n⦄, m ≤ n → g n ≤ g m) (h : ∀ n, f n ≤ g n) :
   (⨆ n, f n) ∈ ⋂ n, Icc (f n) (g n) :=
 begin
   inhabit β,
   refine mem_Inter.2 (λ n, ⟨le_csupr ⟨g $ default β, forall_range_iff.2 $ λ m, _⟩ _,
     csupr_le $ λ m, _⟩); exact forall_le_of_monotone_of_mono_decr hf hg h _ _
 end
+
+/-- Nested intervals lemma: if `[f n, g n]` is a monotonically decreasing sequence of nonempty
+closed intervals, then `⨆ n, f n` belongs to all the intervals `[f n, g n]`. -/
+lemma csupr_mem_Inter_Icc_of_mono_decr_Icc [nonempty β] [semilattice_sup β]
+  {f g : β → α} (h : ∀ ⦃m n⦄, m ≤ n → Icc (f n) (g n) ⊆ Icc (f m) (g m)) (h' : ∀ n, f n ≤ g n) :
+  (⨆ n, f n) ∈ ⋂ n, Icc (f n) (g n) :=
+csupr_mem_Inter_Icc_of_mono_incr_of_mono_decr (λ m n hmn, ((Icc_subset_Icc_iff (h' n)).1 (h hmn)).1)
+  (λ m n hmn, ((Icc_subset_Icc_iff (h' n)).1 (h hmn)).2) h'
+
+/-- Nested intervals lemma: if `[f n, g n]` is a monotonically decreasing sequence of nonempty
+closed intervals, then `⨆ n, f n` belongs to all the intervals `[f n, g n]`. -/
+lemma csupr_mem_Inter_Icc_of_mono_decr_Icc_nat
+  {f g : ℕ → α} (h : ∀ n, Icc (f (n + 1)) (g (n + 1)) ⊆ Icc (f n) (g n)) (h' : ∀ n, f n ≤ g n) :
+  (⨆ n, f n) ∈ ⋂ n, Icc (f n) (g n) :=
+csupr_mem_Inter_Icc_of_mono_decr_Icc
+  (@monotone_of_monotone_nat (order_dual $ set α) _ (λ n, Icc (f n) (g n)) h) h'
 
 end conditionally_complete_lattice
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -151,6 +151,13 @@ suffices (∃b, ¬b ≤ a) → (∃b, a < b),
 assume ⟨b, hb⟩,
 ⟨a ⊔ b, lt_of_le_of_ne le_sup_left $ mt left_eq_sup.1 hb⟩
 
+theorem forall_le_of_monotone_of_mono_decr {β : Type*} [preorder β]
+  {f g : α → β} (hf : monotone f) (hg : ∀ ⦃m n⦄, m ≤ n → g n ≤ g m)
+  (h : ∀ n, f n ≤ g n) (m n : α) : f m ≤ g n :=
+calc f m ≤ f (m ⊔ n) : hf le_sup_left
+     ... ≤ g (m ⊔ n) : h _
+     ... ≤ g n       : hg le_sup_right
+
 theorem semilattice_sup.ext_sup {α} {A B : semilattice_sup α}
   (H : ∀ x y : α, (by haveI := A; exact x ≤ y) ↔ x ≤ y)
   (x y : α) : (by haveI := A; exact (x ⊔ y)) = x ⊔ y :=

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -151,6 +151,8 @@ suffices (∃b, ¬b ≤ a) → (∃b, a < b),
 assume ⟨b, hb⟩,
 ⟨a ⊔ b, lt_of_le_of_ne le_sup_left $ mt left_eq_sup.1 hb⟩
 
+/-- If `f` is a monotonically increasing sequence, `g` is a monotonically decreasing
+sequence, and `f n ≤ g n` for all `n`, then for all `m`, `n` we have `f m ≤ g n`. -/
 theorem forall_le_of_monotone_of_mono_decr {β : Type*} [preorder β]
   {f g : α → β} (hf : monotone f) (hg : ∀ ⦃m n⦄, m ≤ n → g n ≤ g m)
   (h : ∀ n, f n ≤ g n) (m n : α) : f m ≤ g n :=


### PR DESCRIPTION
* Add a few versions of the nested intervals lemma.
* Add `pi`-instance for `conditionally_complete_lattice`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->