### PR TITLE
[Merged by Bors] - feat(data/matrix): little lemmas on `map`

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -800,6 +800,44 @@ end division_ring
 
 end alg_equiv
 
+namespace matrix
+
+/-! ### `matrix` section
+
+Specialize `matrix.one_map` and `matrix.zero_map` to `alg_hom` and `alg_equiv`.
+TODO: there should be a way to avoid restating these for each `foo_hom`.
+-/
+
+variables {R A₁ A₂ n : Type*} [fintype n]
+
+section semiring
+
+variables [comm_semiring R] [semiring A₁] [algebra R A₁] [semiring A₂] [algebra R A₂]
+
+/-- A version of `matrix.one_map` where `f` is an `alg_hom`. -/
+@[simp] lemma alg_hom_map_one [decidable_eq n]
+  (f : A₁ →ₐ[R] A₂) : (1 : matrix n n A₁).map f = 1 :=
+one_map f.map_zero f.map_one
+
+/-- A version of `matrix.one_map` where `f` is an `alg_equiv`. -/
+@[simp] lemma alg_equiv_map_one [decidable_eq n]
+  (f : A₁ ≃ₐ[R] A₂) : (1 : matrix n n A₁).map f = 1 :=
+one_map f.map_zero f.map_one
+
+/-- A version of `matrix.zero_map` where `f` is an `alg_hom`. -/
+@[simp] lemma alg_hom_map_zero [decidable_eq n]
+  (f : A₁ →ₐ[R] A₂) : (0 : matrix n n A₁).map f = 0 :=
+map_zero f.map_zero
+
+/-- A version of `matrix.zero_map` where `f` is an `alg_equiv`. -/
+@[simp] lemma alg_equiv_map_zero [decidable_eq n]
+  (f : A₁ ≃ₐ[R] A₂) : (0 : matrix n n A₁).map f = 0 :=
+map_zero f.map_zero
+
+end semiring
+
+end matrix
+
 namespace algebra
 
 variables (R : Type u) (S : Type v) (A : Type w)

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -825,12 +825,12 @@ one_map f.map_zero f.map_one
 one_map f.map_zero f.map_one
 
 /-- A version of `matrix.zero_map` where `f` is an `alg_hom`. -/
-@[simp] lemma alg_hom_map_zero [decidable_eq n]
+@[simp] lemma alg_hom_map_zero
   (f : A₁ →ₐ[R] A₂) : (0 : matrix n n A₁).map f = 0 :=
 map_zero f.map_zero
 
 /-- A version of `matrix.zero_map` where `f` is an `alg_equiv`. -/
-@[simp] lemma alg_equiv_map_zero [decidable_eq n]
+@[simp] lemma alg_equiv_map_zero
   (f : A₁ ≃ₐ[R] A₂) : (0 : matrix n n A₁).map f = 0 :=
 map_zero f.map_zero
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -350,9 +350,10 @@ theorem diagonal_mul_diagonal' [decidable_eq n] (d₁ d₂ : n → α) :
   diagonal d₁ * diagonal d₂ = diagonal (λ i, d₁ i * d₂ i) :=
 diagonal_mul_diagonal _ _
 
+@[simp]
 lemma map_mul {L : matrix m n α} {M : matrix n o α}
   {β : Type w} [semiring β] {f : α →+* β} :
-(L ⬝ M).map f = L.map f ⬝ M.map f :=
+  (L ⬝ M).map f = L.map f ⬝ M.map f :=
 by { ext, simp [mul_apply, ring_hom.map_sum], }
 
 /-- A version of `one_map` where `f` is a ring hom. -/
@@ -452,13 +453,6 @@ def ring_hom.map_matrix [decidable_eq m] [semiring α] {β : Type w} [semiring �
   (f : α →+* β) (M : matrix m m α) : f.map_matrix M = M.map f := rfl
 
 open_locale matrix
-
-/-- Specialize `ring_hom.map_mul` to use `matrix.mul` instead of `has_mul.mul`. -/
-@[simp]
-lemma ring_hom.map_matrix.map_mul [decidable_eq m] [semiring α] {β : Type w} [semiring β]
-  (f : α →+* β) (M N : matrix m m α) :
-  f.map_matrix (M ⬝ N) = f.map_matrix M ⬝ f.map_matrix N :=
-ring_hom.map_mul _ _ _
 
 namespace matrix
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -416,8 +416,6 @@ lemma map_matrix.map_mul [decidable_eq m] [semiring α] {β : Type w} [semiring 
   f.map_matrix (M ⬝ N) = f.map_matrix M ⬝ f.map_matrix N :=
 ring_hom.map_mul _ _ _
 
-open_locale matrix
-
 namespace matrix
 
 section ring

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -353,6 +353,18 @@ lemma map_mul {L : matrix m n α} {M : matrix n o α}
 (L ⬝ M).map f = L.map f ⬝ M.map f :=
 by { ext, simp [mul_apply, ring_hom.map_sum], }
 
+/-- A version of `one_map` where `f` is a ring hom. -/
+@[simp] lemma ring_hom_map_one [decidable_eq n]
+  {β : Type w} [semiring β] (f : α →+* β) :
+  (1 : matrix n n α).map f = 1 :=
+one_map f.map_zero f.map_one
+
+/-- A version of `map_zero` where `f` is a ring hom. -/
+@[simp] lemma ring_hom_map_zero
+  {β : Type w} [semiring β] (f : α →+* β) :
+  (0 : matrix n n α).map f = 0 :=
+map_zero f.map_zero
+
 lemma is_add_monoid_hom_mul_left (M : matrix l m α) :
   is_add_monoid_hom (λ x : matrix m n α, M ⬝ x) :=
 { to_is_add_hom := ⟨matrix.mul_add _⟩, map_zero := matrix.mul_zero _ }
@@ -394,6 +406,15 @@ def ring_hom.map_matrix [decidable_eq m] [semiring α] {β : Type w} [semiring �
 
 @[simp] lemma ring_hom.map_matrix_apply [decidable_eq m] [semiring α] {β : Type w} [semiring β]
   (f : α →+* β) (M : matrix m m α) : f.map_matrix M = M.map f := rfl
+
+open_locale matrix
+
+/-- Specialize `ring_hom.map_mul` to use `matrix.mul` instead of `has_mul.mul`. -/
+@[simp]
+lemma map_matrix.map_mul [decidable_eq m] [semiring α] {β : Type w} [semiring β]
+  (f : α →+* β) (M N : matrix m m α) :
+  f.map_matrix (M ⬝ N) = f.map_matrix M ⬝ f.map_matrix N :=
+ring_hom.map_mul _ _ _
 
 open_locale matrix
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -396,6 +396,18 @@ map_zero f.map_zero
   (0 : matrix n n α).map f = 0 :=
 map_zero f.map_zero
 
+/-- A version of `map_zero` where `f` is a `linear_map`. -/
+@[simp] lemma linear_map_map_zero
+  {β : Type w} [add_comm_monoid β] [semimodule R α] [semimodule R β] (f : α →ₗ[R] β) :
+  (0 : matrix n n α).map f = 0 :=
+map_zero f.map_zero
+
+/-- A version of `map_zero` where `f` is a `linear_equiv`. -/
+@[simp] lemma linear_equiv_map_zero
+  {β : Type w} [add_comm_monoid β] [semimodule R α] [semimodule R β] (f : α ≃ₗ[R] β) :
+  (0 : matrix n n α).map f = 0 :=
+map_zero f.map_zero
+
 /-- A version of `map_zero` where `f` is a `ring_hom`. -/
 @[simp] lemma ring_hom_map_zero
   {β : Type w} [semiring β] (f : α →+* β) :
@@ -466,7 +478,7 @@ open_locale matrix
 
 /-- Specialize `ring_hom.map_mul` to use `matrix.mul` instead of `has_mul.mul`. -/
 @[simp]
-lemma map_matrix.map_mul [decidable_eq m] [semiring α] {β : Type w} [semiring β]
+lemma ring_hom.map_matrix.map_mul [decidable_eq m] [semiring α] {β : Type w} [semiring β]
   (f : α →+* β) (M N : matrix m m α) :
   f.map_matrix (M ⬝ N) = f.map_matrix M ⬝ f.map_matrix N :=
 ring_hom.map_mul _ _ _

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -355,6 +355,7 @@ lemma map_mul {L : matrix m n α} {M : matrix n o α}
   {β : Type w} [semiring β] {f : α →+* β} :
   (L ⬝ M).map f = L.map f ⬝ M.map f :=
 by { ext, simp [mul_apply, ring_hom.map_sum], }
+
 -- TODO: there should be a way to avoid restating these for each `foo_hom`. 
 /-- A version of `one_map` where `f` is a ring hom. -/
 @[simp] lemma ring_hom_map_one [decidable_eq n]

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -359,9 +359,45 @@ by { ext, simp [mul_apply, ring_hom.map_sum], }
   (1 : matrix n n α).map f = 1 :=
 one_map f.map_zero f.map_one
 
-/-- A version of `map_zero` where `f` is a ring hom. -/
+/-- A version of `map_zero` where `f` is a `zero_hom`. -/
+@[simp] lemma zero_hom_map_zero
+  {β : Type w} [has_zero β] (f : zero_hom α β) :
+  (0 : matrix n n α).map f = 0 :=
+map_zero f.map_zero
+
+/-- A version of `map_zero` where `f` is a `add_monoid_hom`. -/
+@[simp] lemma add_monoid_hom_map_zero
+  {β : Type w} [add_monoid β] (f : α →+ β) :
+  (0 : matrix n n α).map f = 0 :=
+map_zero f.map_zero
+
+/-- A version of `map_zero` where `f` is a `add_equiv`. -/
+@[simp] lemma add_equiv_map_zero
+  {β : Type w} [add_monoid β] (f : α ≃+ β) :
+  (0 : matrix n n α).map f = 0 :=
+map_zero f.map_zero
+
+/-- A version of `map_zero` where `f` is a `ring_hom`. -/
 @[simp] lemma ring_hom_map_zero
   {β : Type w} [semiring β] (f : α →+* β) :
+  (0 : matrix n n α).map f = 0 :=
+map_zero f.map_zero
+
+/-- A version of `map_zero` where `f` is a `ring_equiv`. -/
+@[simp] lemma ring_equiv_map_zero
+  {β : Type w} [semiring β] (f : α ≃+* β) :
+  (0 : matrix n n α).map f = 0 :=
+map_zero f.map_zero
+
+/-- A version of `map_zero` where `f` is a `alg_hom`. -/
+@[simp] lemma alg_hom_map_zero
+  {β : Type w} [semiring β] [semimodule R α] [semimodule R β] (f : α →ₐ[R] β) :
+  (0 : matrix n n α).map f = 0 :=
+map_zero f.map_zero
+
+/-- A version of `map_zero` where `f` is a `alg_equiv`. -/
+@[simp] lemma alg_equiv_map_zero
+  {β : Type w} [semiring β] [semimodule R α] [semimodule R β] (f : α ≃ₐ[R] β) :
   (0 : matrix n n α).map f = 0 :=
 map_zero f.map_zero
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -359,6 +359,25 @@ by { ext, simp [mul_apply, ring_hom.map_sum], }
   (1 : matrix n n α).map f = 1 :=
 one_map f.map_zero f.map_one
 
+/-- A version of `one_map` where `f` is a `ring_equiv`. -/
+@[simp] lemma ring_equiv_map_one [decidable_eq n]
+  {β : Type w} [semiring β] (f : α ≃+* β) :
+  (1 : matrix n n α).map f = 1 :=
+one_map f.map_zero f.map_one
+
+/-- A version of `one_map` where `f` is an `alg_hom`. -/
+@[simp] lemma alg_hom_map_one [decidable_eq n]
+  {β : Type w} [semiring β] [semimodule R α] [semimodule R β] (f : α →ₐ[R] β) :
+  (1 : matrix n n α).map f = 1 :=
+one_map f.map_zero f.map_one
+
+/-- A version of `one_map` where `f` is an `alg_equiv`. -/
+@[simp] lemma alg_equiv_map_one [decidable_eq n]
+  {β : Type w} [semiring β] [semimodule R α] [semimodule R β] (f : α ≃ₐ[R] β) :
+  (1 : matrix n n α).map f = 1 :=
+one_map f.map_zero f.map_one
+
+
 /-- A version of `map_zero` where `f` is a `zero_hom`. -/
 @[simp] lemma zero_hom_map_zero
   {β : Type w} [has_zero β] (f : zero_hom α β) :

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -355,7 +355,7 @@ lemma map_mul {L : matrix m n α} {M : matrix n o α}
   {β : Type w} [semiring β] {f : α →+* β} :
   (L ⬝ M).map f = L.map f ⬝ M.map f :=
 by { ext, simp [mul_apply, ring_hom.map_sum], }
-
+-- TODO: there should be a way to avoid restating these for each `foo_hom`. 
 /-- A version of `one_map` where `f` is a ring hom. -/
 @[simp] lemma ring_hom_map_one [decidable_eq n]
   {β : Type w} [semiring β] (f : α →+* β) :

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -5,7 +5,9 @@ Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin
 -/
 import algebra.big_operators.pi
 import algebra.module.pi
+import algebra.module.linear_map
 import algebra.big_operators.ring
+import data.equiv.ring
 import data.fintype.card
 
 /-!
@@ -365,19 +367,6 @@ one_map f.map_zero f.map_one
   (1 : matrix n n α).map f = 1 :=
 one_map f.map_zero f.map_one
 
-/-- A version of `one_map` where `f` is an `alg_hom`. -/
-@[simp] lemma alg_hom_map_one [decidable_eq n]
-  {β : Type w} [semiring β] [semimodule R α] [semimodule R β] (f : α →ₐ[R] β) :
-  (1 : matrix n n α).map f = 1 :=
-one_map f.map_zero f.map_one
-
-/-- A version of `one_map` where `f` is an `alg_equiv`. -/
-@[simp] lemma alg_equiv_map_one [decidable_eq n]
-  {β : Type w} [semiring β] [semimodule R α] [semimodule R β] (f : α ≃ₐ[R] β) :
-  (1 : matrix n n α).map f = 1 :=
-one_map f.map_zero f.map_one
-
-
 /-- A version of `map_zero` where `f` is a `zero_hom`. -/
 @[simp] lemma zero_hom_map_zero
   {β : Type w} [has_zero β] (f : zero_hom α β) :
@@ -397,13 +386,13 @@ map_zero f.map_zero
 map_zero f.map_zero
 
 /-- A version of `map_zero` where `f` is a `linear_map`. -/
-@[simp] lemma linear_map_map_zero
+@[simp] lemma linear_map_map_zero {R : Type*} [semiring R]
   {β : Type w} [add_comm_monoid β] [semimodule R α] [semimodule R β] (f : α →ₗ[R] β) :
   (0 : matrix n n α).map f = 0 :=
 map_zero f.map_zero
 
 /-- A version of `map_zero` where `f` is a `linear_equiv`. -/
-@[simp] lemma linear_equiv_map_zero
+@[simp] lemma linear_equiv_map_zero {R : Type*} [semiring R]
   {β : Type w} [add_comm_monoid β] [semimodule R α] [semimodule R β] (f : α ≃ₗ[R] β) :
   (0 : matrix n n α).map f = 0 :=
 map_zero f.map_zero
@@ -417,18 +406,6 @@ map_zero f.map_zero
 /-- A version of `map_zero` where `f` is a `ring_equiv`. -/
 @[simp] lemma ring_equiv_map_zero
   {β : Type w} [semiring β] (f : α ≃+* β) :
-  (0 : matrix n n α).map f = 0 :=
-map_zero f.map_zero
-
-/-- A version of `map_zero` where `f` is a `alg_hom`. -/
-@[simp] lemma alg_hom_map_zero
-  {β : Type w} [semiring β] [semimodule R α] [semimodule R β] (f : α →ₐ[R] β) :
-  (0 : matrix n n α).map f = 0 :=
-map_zero f.map_zero
-
-/-- A version of `map_zero` where `f` is a `alg_equiv`. -/
-@[simp] lemma alg_equiv_map_zero
-  {β : Type w} [semiring β] [semimodule R α] [semimodule R β] (f : α ≃ₐ[R] β) :
   (0 : matrix n n α).map f = 0 :=
 map_zero f.map_zero
 


### PR DESCRIPTION
I had a couple of expressions involving mapping matrices, that the simplifier didn't `simp` away. It turns out the missing lemmas already existed, just not with the correct form / hypotheses. So here they are.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
