### PR TITLE
[Merged by Bors] - feat(category_theory/limits/types): explicit description of equalizers in Type

### DIFF
--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -159,10 +159,9 @@ begin
 end
 
 /-- The converse of `type_equalizer_of_unique`. -/
-lemma unique_of_type_equalizer (t : is_limit (fork.of_ι _ w)) :
-  (∀ (y : Y), g y = h y → ∃! (x : X), f x = y) :=
+lemma unique_of_type_equalizer (t : is_limit (fork.of_ι _ w)) (y : Y) (hy : g y = h y) :
+  ∃! (x : X), f x = y :=
 begin
-  intros y hy,
   let y' : punit ⟶ Y := λ _, y,
   have hy' : y' ≫ g = y' ≫ h := funext (λ _, hy),
   refine ⟨(fork.is_limit.lift' t _ hy').1 ⟨⟩, congr_fun (fork.is_limit.lift' t y' _).2 ⟨⟩, _⟩,


### PR DESCRIPTION
Cf https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/concrete.20limits.20in.20Type.

Adds equivalent conditions for a fork in Type to be a equalizer, and a proof that the subtype is an equalizer.

(cc: @adamtopaz @kbuzzard)

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
