### PR TITLE
[Merged by Bors] - fix(tactic/interactive): issue where long term tooltips break layout

### DIFF
--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -254,8 +254,8 @@ meta def implicit_arg_list (tooltip : tc subexpr empty) (e : expr) : tactic $ ht
   fn ← (mk tooltip) $ expr.get_app_fn e,
   args ← list.mmap (mk tooltip) $ expr.get_app_args e,
   pure $ h "div" [style [("display", "flex"), ("flexWrap", "wrap"), ("alignItems", "baseline")]]
-    ( (h "span" [className "bg-blue br3 ma1 ph2 pl3 white"] [fn]) ::
-      list.map (λ a, h "span" [className "bg-gray br3 ma1 ph2 pl3 white"] [a]) args
+    ( (h "span" [className "bg-blue br3 ma1 ph2 white"] [fn]) ::
+      list.map (λ a, h "span" [className "bg-gray br3 ma1 ph2 white"] [a]) args
     )
 
 /--
@@ -267,7 +267,12 @@ tc.stateless (λ ⟨e,ea⟩, do
     y_comp ← mk type_tooltip y,
     implicit_args ← implicit_arg_list type_tooltip e,
     pure [
-        h "div" [style [("minWidth", "8rem")]] [
+        h "div" [style [
+            ("minWidth", "8rem"),
+            -- [note]: textIndent is inherited, and we might
+            -- be in an expression here where textIndent is set
+            ("textIndent", "0")]
+          ] [
           h "div" [cn "pl1"] [y_comp],
           h "hr" [] [],
           implicit_args

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -253,9 +253,9 @@ $ tc.mk_simple
 meta def implicit_arg_list (tooltip : tc subexpr empty) (e : expr) : tactic $ html empty := do
   fn ← (mk tooltip) $ expr.get_app_fn e,
   args ← list.mmap (mk tooltip) $ expr.get_app_args e,
-  pure $ h "div" []
-    ( (h "span" [className "bg-blue br3 ma1 ph2 white"] [fn]) ::
-      list.map (λ a, h "span" [className "bg-gray br3 ma1 ph2 white"] [a]) args
+  pure $ h "div" [style [("display", "flex"), ("flexWrap", "wrap"), ("alignItems", "baseline")]]
+    ( (h "span" [className "bg-blue br3 ma1 ph2 pl3 white"] [fn]) ::
+      list.map (λ a, h "span" [className "bg-gray br3 ma1 ph2 pl3 white"] [a]) args
     )
 
 /--


### PR DESCRIPTION
For issue description see https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/widget.20v.20long.20term.20names

Basically the problem is that if the little 'argument pills' in the tooltip are too long, then there is a fight between the expression linebreaking algorithm and the pill linebreaking algorithm and something gets messed up.

A first attempt to fix this is to use flexbox for laying out the pills.
Still some issues with expressions linebreaking weirdly to sort out before this should be pulled.
Need to find a mwe that I can put in a file without a huge dependency tree.