### PR TITLE
[Merged by Bors] - feat(category_theory/adjunction): general adjoint functor theorem

### DIFF
--- a/src/category_theory/adjunction/adjoint_functor_theorems.lean
+++ b/src/category_theory/adjunction/adjoint_functor_theorems.lean
@@ -49,12 +49,6 @@ def solution_set_condition {D : Type u} [category.{v} D] (G : D ⥤ C) : Prop :=
 
 variables {D : Type u} [category.{v} D]
 
--- TODO: move this section somewhere.
--- TODO: consider showing the converse
--- TODO: dualise
--- This section proves that if each comma category (A ↓ G) has an initial object then `G` has a
--- left adjoint
-
 section gaft
 
 variables (G : D ⥤ C) [has_limits D]

--- a/src/category_theory/adjunction/adjoint_functor_theorems.lean
+++ b/src/category_theory/adjunction/adjoint_functor_theorems.lean
@@ -51,14 +51,25 @@ variables {D : Type u} [category.{v} D]
 
 section gaft
 
-variables (G : D ⥤ C) [has_limits D]
+variables (G : D ⥤ C)
+
+/-- If `G : D ⥤ C` is a right adjoint it satisfies the solution set condition.  -/
+lemma solution_set_condition_of_is_right_adjoint [is_right_adjoint G] :
+  solution_set_condition G :=
+begin
+  intros A,
+  refine ⟨punit, λ _, (left_adjoint G).obj A, λ _, (adjunction.of_right_adjoint G).unit.app A, _⟩,
+  intros B h,
+  refine ⟨punit.star, ((adjunction.of_right_adjoint G).hom_equiv _ _).symm h, _⟩,
+  rw [←adjunction.hom_equiv_unit, equiv.apply_symm_apply],
+end
 
 /--
 The general adjoint functor theorem says that if `G : D ⥤ C` preserves limits and `D` has them,
 then `G` is a right adjoint.
 -/
 noncomputable def is_right_adjoint_of_preserves_limits_of_solution_set_condition
-  [preserves_limits G] (hG : solution_set_condition G) :
+  [has_limits D] [preserves_limits G] (hG : solution_set_condition G) :
   is_right_adjoint G :=
 begin
   apply is_right_adjoint_of_structured_arrow_initials _,
@@ -74,16 +85,7 @@ begin
   apply has_initial_of_weakly_initial_and_has_wide_equalizers hT,
 end
 
-/-- If `G : D ⥤ C` is a right adjoint it satisfies the solution set condition.  -/
-lemma solution_set_condition_of_is_right_adjoint [is_right_adjoint G] :
-  solution_set_condition G :=
-begin
-  intros A,
-  refine ⟨punit, λ _, (left_adjoint G).obj A, λ _, (adjunction.of_right_adjoint G).unit.app A, _⟩,
-  intros B h,
-  refine ⟨punit.star, ((adjunction.of_right_adjoint G).hom_equiv _ _).symm h, _⟩,
-  rw [←adjunction.hom_equiv_unit, equiv.apply_symm_apply],
-end
+
 
 end gaft
 

--- a/src/category_theory/adjunction/adjoint_functor_theorems.lean
+++ b/src/category_theory/adjunction/adjoint_functor_theorems.lean
@@ -67,7 +67,7 @@ noncomputable def is_right_adjoint_of_preserves_limits_of_solution_set_condition
   [preserves_limits G] (hG : solution_set_condition G) :
   is_right_adjoint G :=
 begin
-  apply is_right_adjoint_of_initials _,
+  apply is_right_adjoint_of_structured_arrow_initials _,
   intro A,
   specialize hG A,
   choose ι B f g using hG,

--- a/src/category_theory/adjunction/adjoint_functor_theorems.lean
+++ b/src/category_theory/adjunction/adjoint_functor_theorems.lean
@@ -16,14 +16,15 @@ import category_theory.punit
 
 This file proves the (general) adjoint functor theorem, in the form:
 * If `G : D ⥤ C` preserves limits and `D` has limits, and satisfies the solution set condition,
-  then it has a left adjoint.
+  then it has a left adjoint: `is_right_adjoint_of_preserves_limits_of_solution_set_condition`.
 
 We show that the converse holds, i.e. that if `G` has a left adjoint then it satisfies the solution
-set condition (`category_theory/adjunction/limits` already shows it preserves limits).
+set condition, see `solution_set_condition_of_is_right_adjoint`
+(the file `category_theory/adjunction/limits` already shows it preserves limits).
 
-We define the *solution set condition* for the functor `G : D ⥤ C` to mean, for every object `A : C`,
-there is a set-indexed family ${f_i : A ⟶ G (B_i)}$ such that any morphism `A ⟶ G X` factors
-through one of the `f_i`.
+We define the *solution set condition* for the functor `G : D ⥤ C` to mean, for every object
+`A : C`, there is a set-indexed family ${f_i : A ⟶ G (B_i)}$ such that any morphism `A ⟶ G X`
+factors through one of the `f_i`.
 
 -/
 universes v u
@@ -65,7 +66,7 @@ begin
 end
 
 /--
-The general adjoint functor theorem says that if `G : D ⥤ C` preserves limits and `D` has them, 
+The general adjoint functor theorem says that if `G : D ⥤ C` preserves limits and `D` has them,
 if `G` satisfies the solution set condition then `G` is a right adjoint.
 -/
 noncomputable def is_right_adjoint_of_preserves_limits_of_solution_set_condition

--- a/src/category_theory/adjunction/adjoint_functor_theorems.lean
+++ b/src/category_theory/adjunction/adjoint_functor_theorems.lean
@@ -21,7 +21,7 @@ This file proves the (general) adjoint functor theorem, in the form:
 We show that the converse holds, i.e. that if `G` has a left adjoint then it satisfies the solution
 set condition (`category_theory/adjunction/limits` already shows it preserves limits).
 
-We define the solution set condition for the functor `G : D ⥤ C` to mean, for every object `A : C`,
+We define the *solution set condition* for the functor `G : D ⥤ C` to mean, for every object `A : C`,
 there is a set-indexed family ${f_i : A ⟶ G (B_i)}$ such that any morphism `A ⟶ G X` factors
 through one of the `f_i`.
 
@@ -49,7 +49,7 @@ def solution_set_condition {D : Type u} [category.{v} D] (G : D ⥤ C) : Prop :=
 
 variables {D : Type u} [category.{v} D]
 
-section gaft
+section general_adjoint_functor_theorem
 
 variables (G : D ⥤ C)
 
@@ -85,8 +85,6 @@ begin
   apply has_initial_of_weakly_initial_and_has_wide_equalizers hT,
 end
 
-
-
-end gaft
+end general_adjoint_functor_theorem
 
 end category_theory

--- a/src/category_theory/adjunction/adjoint_functor_theorems.lean
+++ b/src/category_theory/adjunction/adjoint_functor_theorems.lean
@@ -44,7 +44,7 @@ universe of morphisms of the category: this is the "smallness" condition which a
 adjoint functor theorem to go through.
 -/
 def solution_set_condition {D : Type u} [category.{v} D] (G : D ⥤ C) : Prop :=
-  ∀ (A : C), ∃ (ι : Type v) (B : ι → D) (f : Π (i : ι), A ⟶ G.obj (B i)),
+∀ (A : C), ∃ (ι : Type v) (B : ι → D) (f : Π (i : ι), A ⟶ G.obj (B i)),
   ∀ X (h : A ⟶ G.obj X), ∃ (i : ι) (g : B i ⟶ X), f i ≫ G.map g = h
 
 variables {D : Type u} [category.{v} D]
@@ -65,8 +65,8 @@ begin
 end
 
 /--
-The general adjoint functor theorem says that if `G : D ⥤ C` preserves limits and `D` has them,
-then `G` is a right adjoint.
+The general adjoint functor theorem says that if `G : D ⥤ C` preserves limits and `D` has them, 
+if `G` satisfies the solution set condition then `G` is a right adjoint.
 -/
 noncomputable def is_right_adjoint_of_preserves_limits_of_solution_set_condition
   [has_limits D] [preserves_limits G] (hG : solution_set_condition G) :

--- a/src/category_theory/adjunction/adjoint_functor_theorems.lean
+++ b/src/category_theory/adjunction/adjoint_functor_theorems.lean
@@ -1,0 +1,305 @@
+/-
+Copyright (c) 2020 Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bhavik Mehta
+-/
+import category_theory.adjunction.basic
+import category_theory.limits.shapes.wide_equalizers
+import category_theory.limits.shapes
+import category_theory.limits.preserves.basic
+import category_theory.limits.creates
+import category_theory.punit
+
+universes v u
+
+namespace category_theory
+open limits
+
+variables {J : Type v}
+variables {C : Type u} [category.{v} C]
+
+/--
+If `C` has (small) products and a small weakly initial set of objects, then it has a weakly initial
+object.
+-/
+lemma has_weakly_initial_of_weakly_initial_set_and_has_products (C : Type u) [category.{v} C]
+  [has_products C]
+  {ι : Type v} (B : ι → C) (hB : ∀ (A : C), ∃ i, nonempty (B i ⟶ A)) :
+  ∃ (T : C), ∀ X, nonempty (T ⟶ X) :=
+⟨∏ B, λ X, ⟨pi.π _ _ ≫ (hB X).some_spec.some⟩⟩
+
+/--
+If `C` has (small) wide equalizers and a weakly initial object, then it has an initial object.
+
+The initial object is constructed as the wide equalizer of all endomorphisms on the given weakly
+initial object.
+-/
+lemma has_initial_of_weakly_initial_and_has_wide_equalizers (C : Type u) [category.{v} C]
+  [has_wide_equalizers C] (T : C) (hT : ∀ X, nonempty (T ⟶ X)) :
+  has_initial C :=
+begin
+  let endos := T ⟶ T,
+  let i := wide_equalizer.ι (id : endos → endos),
+  haveI : nonempty endos := ⟨𝟙 _⟩,
+  have : ∀ (X : C), unique (wide_equalizer (id : endos → endos) ⟶ X),
+  { intro X,
+    refine ⟨⟨i ≫ classical.choice (hT X)⟩, λ a, _⟩,
+    let E := equalizer a (i ≫ classical.choice (hT _)),
+    let e : E ⟶ wide_equalizer id := equalizer.ι _ _,
+    let h : T ⟶ E := classical.choice (hT E),
+    have : ((i ≫ h) ≫ e) ≫ i = i ≫ 𝟙 _,
+    { rw [category.assoc, category.assoc],
+      apply wide_equalizer.condition (id : endos → endos) (h ≫ e ≫ i) },
+    rw [category.comp_id, cancel_mono_id i] at this,
+    haveI : split_epi e := ⟨i ≫ h, this⟩,
+    rw ←cancel_epi e,
+    apply equalizer.condition },
+  exactI has_initial_of_unique (wide_equalizer (id : endos → endos)),
+end
+
+-- /--
+-- If `C` has (small) limits and a small weakly initial set of objects, then it has an initial object.
+-- -/
+-- lemma has_initial_of_weakly_initial_and_has_limits (C : Type u) [category.{v} C] [has_limits C]
+--   {ι : Type v} (B : ι → C) (weakly_initial : ∀ (A : C), ∃ i, nonempty (B i ⟶ A)) :
+--   has_initial C :=
+-- begin
+--   -- have fromP : Π (X : C), (∏ B ⟶ X),
+--   -- { intro X,
+--   --   exact pi.π _ (weakly_initial X).some ≫ (weakly_initial X).some_spec.some },
+--   -- let endos := ∏ B ⟶ ∏ B,
+--   -- let i := wide_equalizer.ι (id : endos → endos),
+--   -- haveI : nonempty endos := ⟨𝟙 _⟩,
+--   -- haveI : ∀ (X : C), inhabited (wide_equalizer id ⟶ X) := λ X, ⟨i ≫ fromP X⟩,
+--   -- have : ∀ (X : C), unique (wide_equalizer (id : endos → endos) ⟶ X),
+--   -- { intro X,
+--   --   refine ⟨by apply_instance, λ a, _⟩,
+--   --   let E := equalizer a (default (wide_equalizer id ⟶ X)),
+--   --   let e : E ⟶ wide_equalizer id := equalizer.ι _ _,
+--   --   let h : ∏ B ⟶ E := fromP _,
+--   --   have : ((i ≫ h) ≫ e) ≫ i = i ≫ 𝟙 _,
+--   --   { rw [category.assoc, category.assoc],
+--   --     apply wide_equalizer.condition (id : endos → endos) (h ≫ e ≫ i) },
+--   --   rw [category.comp_id, cancel_mono_id i] at this,
+--   --   haveI : split_epi e := ⟨i ≫ h, this⟩,
+--   --   rw ← cancel_epi e,
+--   --   apply equalizer.condition },
+--   -- exactI has_initial_of_unique (wide_equalizer (id : endos → endos)),
+-- end
+
+/--
+The functor `G : D ⥤ C` satisfies the *solution set condition* if for every `A : C`, there is a
+family of morphisms `{f_i : A ⟶ G (B_i) // i ∈ ι}` such that given any morphism `h : A ⟶ G X`,
+there is some `i ∈ ι` such that `h` factors through `f_i`.
+
+The key part of this definition is that the indexing set `ι` lives in `Type v`, where `v` is the
+universe of morphisms of the category: this is the "smallness" condition which allows the general
+adjoint functor theorem to go through.
+-/
+def solution_set_condition {D : Type u} [category.{v} D] (G : D ⥤ C) : Prop :=
+  ∀ (A : C), ∃ (ι : Type v) (B : ι → D) (f : Π (i : ι), A ⟶ G.obj (B i)),
+  ∀ X (h : A ⟶ G.obj X), ∃ (i : ι) (g : B i ⟶ X), f i ≫ G.map g = h
+
+variables {D : Type u} [category.{v} D]
+
+-- TODO: Move this to category_theory/comma.lean
+instance (G : D ⥤ C) (A : C) : faithful (comma.snd (functor.from_punit A) G) := {}.
+
+-- TODO: Move this to category_theory/comma.lean
+instance comma_reflects_isos (G : D ⥤ C) (A : C) :
+  reflects_isomorphisms (comma.snd (functor.from_punit A) G) :=
+{ reflects := λ X Y f i, by exactI
+  { inv :=
+    { left := eq_to_hom (subsingleton.elim _ _),
+      right := inv ((comma.snd (functor.from_punit A) G).map f),
+      w' :=
+      begin
+        dsimp,
+        simp only [id_comp, is_iso.comp_is_iso_eq],
+        rw ← f.w,
+        dsimp,
+        simp,
+      end } } }
+
+section create
+
+variables [small_category J] (G : D ⥤ C) [preserves_limits_of_shape J G]
+variables (A : C) (F : J ⥤ comma (functor.from_punit A) G)
+variables (c : cone (F ⋙ comma.snd _ G)) (t : is_limit c)
+
+def new_cone : cone ((F ⋙ comma.snd _ _) ⋙ G) :=
+{ X := A,
+  π :=
+  { app := λ j, (F.obj j).hom,
+    naturality' := λ j₁ j₂ α, (F.map α).w } }
+
+-- TODO: dualise and move to category_theory/limits/comma.lean
+def four_ten_aux : creates_limit F (comma.snd (functor.from_punit A) G) :=
+creates_limit_of_reflects_iso $ λ c t,
+{ lifted_cone :=
+  { X :=
+    { left := ⟨⟩,
+      right := c.X,
+      hom := (is_limit_of_preserves G t).lift (new_cone G A F) },
+    π :=
+    { app := λ j,
+      { left := eq_to_hom (subsingleton.elim _ _),
+        right := c.π.app j,
+        w' :=
+        begin
+          change 𝟙 A ≫ (F.obj j).hom = _,
+          rw id_comp,
+          apply ((is_limit_of_preserves G t).fac (new_cone G A F) j).symm,
+        end },
+      naturality' := λ j₁ j₂ α,
+      begin
+        ext,
+        apply c.π.naturality α,
+      end } },
+  valid_lift :=
+  begin
+    refine cones.ext (iso.refl _) _,
+    intro j,
+    dsimp,
+    simp,
+  end,
+  makes_limit :=
+  { lift := λ c',
+    { left := eq_to_hom (subsingleton.elim _ _),
+      right :=
+      begin
+        apply t.lift ⟨_, λ j, _, _⟩,
+        { apply (c'.π.app j).right },
+        { intros j₁ j₂ α,
+          rw ← c'.w α,
+          dsimp,
+          simp },
+      end,
+      w' :=
+      begin
+        dsimp,
+        rw id_comp,
+        symmetry,
+        refine (is_limit_of_preserves G t).uniq (new_cone G A F) _ _,
+        intro j,
+        dsimp [new_cone],
+        rw [assoc, ← G.map_comp],
+        simp only [is_limit.fac],
+        apply (c'.π.app j).w.symm.trans _,
+        dsimp,
+        simp,
+      end },
+    fac' := λ c' j,
+    begin
+      ext,
+      dsimp,
+      apply t.fac,
+    end,
+    uniq' := λ s m w,
+    begin
+      ext,
+      apply t.uniq ⟨_, _⟩ _ _,
+      intro j,
+      dsimp at *,
+      rw ← w j,
+      refl,
+    end } }
+
+instance : creates_limits_of_shape J (comma.snd (functor.from_punit A) G) :=
+{ creates_limit := λ F, four_ten_aux G A F }
+
+instance [has_limits_of_shape J D] : has_limits_of_shape J (comma (functor.from_punit A) G) :=
+has_limits_of_shape_of_has_limits_of_shape_creates_limits_of_shape
+  (comma.snd (functor.from_punit A) G)
+
+end create
+
+-- TODO: move this section somewhere.
+-- TODO: consider showing the converse
+-- TODO: dualise
+-- This section proves that if each comma category (A ↓ G) has an initial object then `G` has a
+-- left adjoint
+
+section initials
+noncomputable theory
+
+variables (G : D ⥤ C)
+variables [∀ A, has_initial (comma (functor.from_punit A) G)]
+
+def F : C → D := λ A, (⊥_ (comma (functor.from_punit A) G)).right
+def η (A : C) : A ⟶ G.obj (F G A) := (⊥_ (comma (functor.from_punit A) G)).hom
+
+def init_equivalence (A : C) (B : D) :
+  (F G A ⟶ B) ≃ (A ⟶ G.obj B) :=
+{ to_fun := λ g, η G A ≫ G.map g,
+  inv_fun := λ f,
+  begin
+    let B' : comma (functor.from_punit A) G := { right := B, hom := f },
+    apply comma_morphism.right (initial.to B'),
+  end,
+  left_inv := λ g,
+  begin
+    let B' : comma (functor.from_punit A) G :=
+      { left := punit.star, right := B, hom := η G A ≫ G.map g },
+    let g' : (⊥_ (comma (functor.from_punit A) G)) ⟶ B' :=
+      ⟨eq_to_hom (subsingleton.elim _ _), g, id_comp _⟩,
+    have : initial.to _ = g',
+    { apply colimit.hom_ext, rintro ⟨⟩ },
+    change comma_morphism.right (initial.to B') = _,
+    rw this,
+  end,
+  right_inv := λ f,
+  begin
+    let B' : comma (functor.from_punit A) G := { right := B, hom := f },
+    apply (comma_morphism.w (initial.to B')).symm.trans _,
+    dsimp,
+    simp,
+  end }
+
+def init_to_adj :=
+adjunction.left_adjoint_of_equiv (init_equivalence G) $
+begin
+  intros X Y Y' g h,
+  dsimp [init_equivalence],
+  simp,
+end
+
+def is_right_adjoint_of_initials : is_right_adjoint G :=
+{ left := init_to_adj G,
+  adj := adjunction.adjunction_of_equiv_left _ _ }
+end initials
+
+section gaft
+
+variables (G : D ⥤ C) [has_limits D] [preserves_limits G]
+
+/--
+The general adjoint functor theorem says that if `G : D ⥤ C` preserves limits and `D` has them,
+then `G` is a right adjoint.
+
+Strictly speaking, it also gives the converse: if `G : D ⥤ C` is a right adjoint then `G` preserves
+them and it satisfies the solution set condition; though this version is not shown here.
+-/
+noncomputable def gaft (hG : solution_set_condition G) : is_right_adjoint G :=
+begin
+  apply is_right_adjoint_of_initials _,
+  intro A,
+  specialize hG A,
+  choose ι B f g hg₁ hg₂ using hG,
+  apply gaft_aux _ _ _,
+  { refine ⟨_⟩,
+    introsI J 𝒥,
+    apply_instance },
+  { apply ι },
+  { intro i,
+    refine ⟨⟨⟩, _, f i⟩ },
+  { intro L,
+    refine ⟨g _ L.hom, ⟨_⟩⟩,
+    refine ⟨eq_to_hom (subsingleton.elim _ _), hg₁ _ _, _⟩,
+    dsimp,
+    rw [hg₂, id_comp] }
+end
+
+end gaft
+
+end category_theory

--- a/src/category_theory/adjunction/adjoint_functor_theorems.lean
+++ b/src/category_theory/adjunction/adjoint_functor_theorems.lean
@@ -1,11 +1,11 @@
 /-
-Copyright (c) 2020 Bhavik Mehta. All rights reserved.
+Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import category_theory.adjunction.basic
-import category_theory.limits.shapes.wide_equalizers
-import category_theory.limits.shapes
+import category_theory.adjunction.comma
+import category_theory.limits.constructions.weakly_initial
 import category_theory.limits.preserves.basic
 import category_theory.limits.creates
 import category_theory.limits.comma
@@ -19,7 +19,7 @@ This file proves the (general) adjoint functor theorem, in the form:
   then it has a left adjoint.
 
 We show that the converse holds, i.e. that if `G` has a left adjoint then it satisfies the solution
-set condition (`category_theroy/adjunction/limits` already shows it preserves limits).
+set condition (`category_theory/adjunction/limits` already shows it preserves limits).
 
 We define the solution set condition for the functor `G : D ⥤ C` to mean, for every object `A : C`,
 there is a set-indexed family ${f_i : A ⟶ G (B_i)}$ such that any morphism `A ⟶ G X` factors
@@ -33,45 +33,6 @@ open limits
 
 variables {J : Type v}
 variables {C : Type u} [category.{v} C]
-
-/--
-If `C` has (small) products and a small weakly initial set of objects, then it has a weakly initial
-object.
--/
-lemma has_weakly_initial_of_weakly_initial_set_and_has_products (C : Type u) [category.{v} C]
-  [has_products C]
-  {ι : Type v} (B : ι → C) (hB : ∀ (A : C), ∃ i, nonempty (B i ⟶ A)) :
-  ∃ (T : C), ∀ X, nonempty (T ⟶ X) :=
-⟨∏ B, λ X, ⟨pi.π _ _ ≫ (hB X).some_spec.some⟩⟩
-
-/--
-If `C` has (small) wide equalizers and a weakly initial object, then it has an initial object.
-
-The initial object is constructed as the wide equalizer of all endomorphisms on the given weakly
-initial object.
--/
-lemma has_initial_of_weakly_initial_and_has_wide_equalizers (C : Type u) [category.{v} C]
-  [has_wide_equalizers C] (T : C) (hT : ∀ X, nonempty (T ⟶ X)) :
-  has_initial C :=
-begin
-  let endos := T ⟶ T,
-  let i := wide_equalizer.ι (id : endos → endos),
-  haveI : nonempty endos := ⟨𝟙 _⟩,
-  have : ∀ (X : C), unique (wide_equalizer (id : endos → endos) ⟶ X),
-  { intro X,
-    refine ⟨⟨i ≫ classical.choice (hT X)⟩, λ a, _⟩,
-    let E := equalizer a (i ≫ classical.choice (hT _)),
-    let e : E ⟶ wide_equalizer id := equalizer.ι _ _,
-    let h : T ⟶ E := classical.choice (hT E),
-    have : ((i ≫ h) ≫ e) ≫ i = i ≫ 𝟙 _,
-    { rw [category.assoc, category.assoc],
-      apply wide_equalizer.condition (id : endos → endos) (h ≫ e ≫ i) },
-    rw [category.comp_id, cancel_mono_id i] at this,
-    haveI : split_epi e := ⟨i ≫ h, this⟩,
-    rw ←cancel_epi e,
-    apply equalizer.condition },
-  exactI has_initial_of_unique (wide_equalizer (id : endos → endos)),
-end
 
 /--
 The functor `G : D ⥤ C` satisfies the *solution set condition* if for every `A : C`, there is a
@@ -94,43 +55,6 @@ variables {D : Type u} [category.{v} D]
 -- This section proves that if each comma category (A ↓ G) has an initial object then `G` has a
 -- left adjoint
 
-section initials
-noncomputable theory
-
-variables (G : D ⥤ C)
-variables [∀ A, has_initial (structured_arrow A G)]
-
-def F : C → D := λ A, (⊥_ (structured_arrow A G)).right
-def η (A : C) : A ⟶ G.obj (F G A) := (⊥_ (structured_arrow A G)).hom
-
-@[simps]
-def init_equivalence (A : C) (B : D) :
-  (F G A ⟶ B) ≃ (A ⟶ G.obj B) :=
-{ to_fun := λ g, η G A ≫ G.map g,
-  inv_fun := λ f, comma_morphism.right (initial.to (structured_arrow.mk f)),
-  left_inv := λ g,
-  begin
-    let B' : structured_arrow A G := structured_arrow.mk (η G A ≫ G.map g),
-    let g' : (⊥_ (structured_arrow A G)) ⟶ B' :=
-      ⟨eq_to_hom (subsingleton.elim _ _), g, category.id_comp _⟩,
-    have : initial.to _ = g',
-    { apply colimit.hom_ext, rintro ⟨⟩ },
-    change comma_morphism.right (initial.to B') = _,
-    rw this,
-  end,
-  right_inv := λ f,
-  begin
-    let B' : structured_arrow A G := { right := B, hom := f },
-    apply (comma_morphism.w (initial.to B')).symm.trans (category.id_comp _),
-  end }
-
-def init_to_adj := adjunction.left_adjoint_of_equiv (init_equivalence G) (λ _ _, by simp)
-
-def is_right_adjoint_of_initials : is_right_adjoint G :=
-{ left := init_to_adj G,
-  adj := adjunction.adjunction_of_equiv_left _ _ }
-end initials
-
 section gaft
 
 variables (G : D ⥤ C) [has_limits D]
@@ -152,8 +76,8 @@ begin
   { intros A',
     obtain ⟨i, _, t⟩ := g _ A'.hom,
     exact ⟨i, ⟨structured_arrow.hom_mk _ t⟩⟩ },
-  obtain ⟨T, hT⟩ := has_weakly_initial_of_weakly_initial_set_and_has_products _ B' hB',
-  apply has_initial_of_weakly_initial_and_has_wide_equalizers _ _ hT,
+  obtain ⟨T, hT⟩ := has_weakly_initial_of_weakly_initial_set_and_has_products hB',
+  apply has_initial_of_weakly_initial_and_has_wide_equalizers hT,
 end
 
 /-- If `G : D ⥤ C` is a right adjoint it satisfies the solution set condition.  -/

--- a/src/category_theory/adjunction/comma.lean
+++ b/src/category_theory/adjunction/comma.lean
@@ -10,6 +10,18 @@ import category_theory.limits.creates
 import category_theory.limits.comma
 import category_theory.punit
 
+/-!
+# Properties of comma categories relating to adjunctions
+
+This file shows that for a functor `G : D ⥤ C` the data of an initial object in each
+`structured_arrow` category on `G` is equivalent to a left adjoint to `G`, as well as the dual.
+
+Specifically, `adjunction_of_structured_arrow_initials` gives the left adjoint assuming the
+appropriate initial objects exist, and `mk_initial_of_left_adjoint` constructs the initial objects
+provided a left adjoint.
+
+The duals are also shown.
+-/
 universes v u₁ u₂
 
 noncomputable theory
@@ -18,10 +30,6 @@ namespace category_theory
 open limits
 
 variables {C : Type u₁} {D : Type u₂} [category.{v} C] [category.{v} D] (G : D ⥤ C)
-
--- TODO: consider showing the converse
--- This section proves that if each comma category (A ↓ G) has an initial object then `G` has a
--- left adjoint
 
 section of_initials
 variables [∀ A, has_initial (structured_arrow A G)]
@@ -126,7 +134,7 @@ variables {F : C ⥤ D}
 
 /-- Given a left adjoint to `G`, we can construct an initial object in each structured arrow
 category on `G`. -/
-def mk_initial (h : F ⊣ G) (A : C) :
+def mk_initial_of_left_adjoint (h : F ⊣ G) (A : C) :
   is_initial (structured_arrow.mk (h.unit.app A) : structured_arrow A G) :=
 { desc := λ B, structured_arrow.hom_mk ((h.hom_equiv _ _).symm B.X.hom) (by tidy),
   uniq' := λ s m w,
@@ -139,7 +147,7 @@ def mk_initial (h : F ⊣ G) (A : C) :
 
 /-- Given a right adjoint to `F`, we can construct a terminal object in each costructured arrow
 category on `F`. -/
-def mk_terminal (h : F ⊣ G) (A : D) :
+def mk_terminal_of_right_adjoint (h : F ⊣ G) (A : D) :
   is_terminal (costructured_arrow.mk (h.counit.app A) : costructured_arrow F A) :=
 { lift := λ B, costructured_arrow.hom_mk (h.hom_equiv _ _ B.X.hom) (by tidy),
   uniq' := λ s m w,

--- a/src/category_theory/adjunction/comma.lean
+++ b/src/category_theory/adjunction/comma.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2021 Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bhavik Mehta
+-/
+import category_theory.adjunction.basic
+import category_theory.limits.constructions.weakly_initial
+import category_theory.limits.preserves.basic
+import category_theory.limits.creates
+import category_theory.limits.comma
+import category_theory.punit
+
+/-!
+# Adjoint functor theorem
+
+This file proves the (general) adjoint functor theorem, in the form:
+* If `G : D ⥤ C` preserves limits and `D` has limits, and satisfies the solution set condition,
+  then it has a left adjoint.
+
+We show that the converse holds, i.e. that if `G` has a left adjoint then it satisfies the solution
+set condition (`category_theory/adjunction/limits` already shows it preserves limits).
+
+We define the solution set condition for the functor `G : D ⥤ C` to mean, for every object `A : C`,
+there is a set-indexed family ${f_i : A ⟶ G (B_i)}$ such that any morphism `A ⟶ G X` factors
+through one of the `f_i`.
+
+-/
+universes v u₁ u₂
+
+noncomputable theory
+
+namespace category_theory
+open limits
+
+variables {C : Type u₁} {D : Type u₂} [category.{v} C] [category.{v} D] (G : D ⥤ C)
+
+-- TODO: consider showing the converse
+-- This section proves that if each comma category (A ↓ G) has an initial object then `G` has a
+-- left adjoint
+
+section of_initials
+variables [∀ A, has_initial (structured_arrow A G)]
+
+@[simps]
+def initials_equivalence (A : C) (B : D) :
+  ((⊥_ (structured_arrow A G)).right ⟶ B) ≃ (A ⟶ G.obj B) :=
+{ to_fun := λ g, (⊥_ (structured_arrow A G)).hom ≫ G.map g,
+  inv_fun := λ f, comma_morphism.right (initial.to (structured_arrow.mk f)),
+  left_inv := λ g,
+  begin
+    let B' : structured_arrow A G :=
+      structured_arrow.mk ((⊥_ (structured_arrow A G)).hom ≫ G.map g),
+    let g' : ⊥_ (structured_arrow A G) ⟶ B' := structured_arrow.hom_mk g rfl,
+    have : initial.to _ = g',
+    { apply colimit.hom_ext, rintro ⟨⟩ },
+    change comma_morphism.right (initial.to B') = _,
+    rw this,
+    refl
+  end,
+  right_inv := λ f,
+  begin
+    let B' : structured_arrow A G := { right := B, hom := f },
+    apply (comma_morphism.w (initial.to B')).symm.trans (category.id_comp _),
+  end }
+
+def left_adjoint_of_structured_arrow_initials : C ⥤ D :=
+adjunction.left_adjoint_of_equiv (initials_equivalence G) (λ _ _, by simp)
+
+def is_right_adjoint_of_structured_arrow_initials : is_right_adjoint G :=
+{ left := left_adjoint_of_structured_arrow_initials G,
+  adj := adjunction.adjunction_of_equiv_left _ _ }
+
+end of_initials
+
+section of_terminals
+variables [∀ A, has_terminal (costructured_arrow G A)]
+
+@[simps]
+def terminals_equivalence (B : D) (A : C) :
+  (G.obj B ⟶ A) ≃ (B ⟶ (⊤_ (costructured_arrow G A)).left) :=
+{ to_fun := λ g, comma_morphism.left (terminal.from (costructured_arrow.mk g)),
+  inv_fun := λ g, G.map g ≫ (⊤_ (costructured_arrow G A)).hom,
+  left_inv := by tidy,
+  right_inv := λ g,
+  begin
+    let B' : costructured_arrow G A :=
+      costructured_arrow.mk (G.map g ≫ (⊤_ (costructured_arrow G A)).hom),
+    let g' : B' ⟶ ⊤_ (costructured_arrow G A) := costructured_arrow.hom_mk g rfl,
+    have : terminal.from _ = g',
+    { apply limit.hom_ext, rintro ⟨⟩ },
+    change comma_morphism.left (terminal.from B') = _,
+    rw this,
+    refl
+  end }
+
+def right_adjoint_of_costructured_arrow_terminals : C ⥤ D :=
+adjunction.right_adjoint_of_equiv (terminals_equivalence G)
+  (λ B₁ B₂ A f g, by { rw ←equiv.eq_symm_apply, simp })
+
+def is_right_adjoint_of_costructured_arrow_terminals : is_left_adjoint G :=
+{ right := right_adjoint_of_costructured_arrow_terminals G,
+  adj := adjunction.adjunction_of_equiv_right _ _ }
+
+end of_terminals
+
+section
+variables {F : C ⥤ D}
+
+def mk_initial (h : F ⊣ G) (A : C) :
+  is_initial (structured_arrow.mk (h.unit.app A) : structured_arrow A G) :=
+{ desc := λ B, structured_arrow.hom_mk ((h.hom_equiv _ _).symm B.X.hom)
+                 (by { dsimp, rw ←h.hom_equiv_unit, simp }),
+  uniq' := λ s m w,
+  begin
+    ext,
+    dsimp,
+    rw [equiv.eq_symm_apply, adjunction.hom_equiv_unit],
+    apply structured_arrow.w m,
+  end }
+
+end
+
+end category_theory

--- a/src/category_theory/limits/constructions/weakly_initial.lean
+++ b/src/category_theory/limits/constructions/weakly_initial.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2021 Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bhavik Mehta
+-/
+import category_theory.limits.shapes.wide_equalizers
+import category_theory.limits.shapes.products
+import category_theory.limits.shapes.terminal
+
+/-!
+# Constructions related to weakly initial objects
+
+This file gives constructions related to weakly initial objects, namely:
+* If a category has small products and a small weakly initial set of objects, then it has a weakly
+  initial object.
+* If a category has wide equalizers and a weakly initial object, then it has an initial object.
+
+These are primarily useful to show the General Adjoint Functor Theorem.
+-/
+universes v u
+
+namespace category_theory
+open limits
+
+variables {C : Type u} [category.{v} C]
+
+/--
+If `C` has (small) products and a small weakly initial set of objects, then it has a weakly initial
+object.
+-/
+lemma has_weakly_initial_of_weakly_initial_set_and_has_products [has_products C]
+  {ι : Type v} {B : ι → C} (hB : ∀ (A : C), ∃ i, nonempty (B i ⟶ A)) :
+  ∃ (T : C), ∀ X, nonempty (T ⟶ X) :=
+⟨∏ B, λ X, ⟨pi.π _ _ ≫ (hB X).some_spec.some⟩⟩
+
+/--
+If `C` has (small) wide equalizers and a weakly initial object, then it has an initial object.
+
+The initial object is constructed as the wide equalizer of all endomorphisms on the given weakly
+initial object.
+-/
+lemma has_initial_of_weakly_initial_and_has_wide_equalizers [has_wide_equalizers C]
+  {T : C} (hT : ∀ X, nonempty (T ⟶ X)) :
+  has_initial C :=
+begin
+  let endos := T ⟶ T,
+  let i := wide_equalizer.ι (id : endos → endos),
+  haveI : nonempty endos := ⟨𝟙 _⟩,
+  have : ∀ (X : C), unique (wide_equalizer (id : endos → endos) ⟶ X),
+  { intro X,
+    refine ⟨⟨i ≫ classical.choice (hT X)⟩, λ a, _⟩,
+    let E := equalizer a (i ≫ classical.choice (hT _)),
+    let e : E ⟶ wide_equalizer id := equalizer.ι _ _,
+    let h : T ⟶ E := classical.choice (hT E),
+    have : ((i ≫ h) ≫ e) ≫ i = i ≫ 𝟙 _,
+    { rw [category.assoc, category.assoc],
+      apply wide_equalizer.condition (id : endos → endos) (h ≫ e ≫ i) },
+    rw [category.comp_id, cancel_mono_id i] at this,
+    haveI : split_epi e := ⟨i ≫ h, this⟩,
+    rw ←cancel_epi e,
+    apply equalizer.condition },
+  exactI has_initial_of_unique (wide_equalizer (id : endos → endos)),
+end
+
+end category_theory

--- a/src/category_theory/limits/shapes/wide_equalizers.lean
+++ b/src/category_theory/limits/shapes/wide_equalizers.lean
@@ -430,7 +430,8 @@ def trident.ext [nonempty J] {s t : trident f} (i : s.X ≅ t.X) (w : i.hom ≫ 
 Helper function for constructing morphisms between coequalizer cotridents.
 -/
 @[simps]
-def cotrident.mk_hom [nonempty J] {s t : cotrident f} (k : s.X ⟶ t.X) (w : s.π ≫ k = t.π) : s ⟶ t :=
+def cotrident.mk_hom [nonempty J] {s t : cotrident f} (k : s.X ⟶ t.X) (w : s.π ≫ k = t.π) :
+  s ⟶ t :=
 { hom := k,
   w' :=
   begin
@@ -444,7 +445,8 @@ To construct an isomorphism between cotridents,
 it suffices to give an isomorphism between the cocone points
 and check that it commutes with the `π` morphisms.
 -/
-def cotrident.ext [nonempty J] {s t : cotrident f} (i : s.X ≅ t.X) (w : s.π ≫ i.hom = t.π) : s ≅ t :=
+def cotrident.ext [nonempty J] {s t : cotrident f} (i : s.X ≅ t.X) (w : s.π ≫ i.hom = t.π) :
+  s ≅ t :=
 { hom := cotrident.mk_hom i.hom w,
   inv := cotrident.mk_hom i.inv (by rw [iso.comp_inv_eq, w]) }
 

--- a/src/category_theory/limits/shapes/wide_equalizers.lean
+++ b/src/category_theory/limits/shapes/wide_equalizers.lean
@@ -55,11 +55,19 @@ universes v u u₂
 variables {J : Type v}
 
 /-- The type of objects for the diagram indexing a wide (co)equalizer. -/
-@[derive [decidable_eq, inhabited]] inductive walking_parallel_family (J : Type v) : Type v
+inductive walking_parallel_family (J : Type v) : Type v
 | zero : walking_parallel_family
 | one : walking_parallel_family
 
 open walking_parallel_family
+
+instance : decidable_eq (walking_parallel_family J)
+| zero zero := is_true rfl
+| zero one := is_false (λ t, walking_parallel_family.no_confusion t)
+| one zero := is_false (λ t, walking_parallel_family.no_confusion t)
+| one one := is_true rfl
+
+instance : inhabited (walking_parallel_family J) := ⟨zero⟩
 
 /-- The type family of morphisms for the diagram indexing a wide (co)equalizer. -/
 @[derive decidable_eq] inductive walking_parallel_family.hom (J : Type v) :

--- a/src/category_theory/limits/shapes/wide_equalizers.lean
+++ b/src/category_theory/limits/shapes/wide_equalizers.lean
@@ -1,0 +1,650 @@
+/-
+Copyright (c) 2021 Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bhavik Mehta
+-/
+import category_theory.epi_mono
+import category_theory.limits.has_limits
+import category_theory.limits.shapes.equalizers
+
+/-!
+# Wide equalizers and wide coequalizers
+
+This file defines wide (co)equalizers as special cases of (co)limits.
+
+A wide equalizer for the family of morphisms `X ⟶ Y` indexed by `J` is the categorical
+generalization of the subobject `{a ∈ A | ∀ j₁ j₂, f(j₁, a) = f(j₂, a)}`. Note that if `J` has
+fewer than two morphisms this condition is trivial, so some lemmas and definitions assume this.
+
+## Main definitions
+
+* `walking_parallel_family` is the indexing category used for wide (co)equalizer diagrams
+* `parallel_family` is a functor from `walking_parallel_family` to our category `C`.
+* a `trident` is a cone over a parallel family.
+  * there is really only one interesting morphism in a trident: the arrow from the vertex of the
+    trident to the domain of f and g. It is called `trident.ι`.
+* a `wide_equalizer` is now just a `limit (parallel_family f)`
+
+Each of these has a dual.
+
+## Main statements
+
+* `wide_equalizer.ι_mono` states that every wide_equalizer map is a monomorphism
+* `is_iso_limit_cone_parallel_family_of_self` states that the identity on the domain of `f` is an
+  equalizer of `f` and `f`.
+
+## Implementation notes
+As with the other special shapes in the limits library, all the definitions here are given as
+`abbreviation`s of the general statements for limits, so all the `simp` lemmas and theorems about
+general limits can be used.
+
+## References
+
+* [F. Borceux, *Handbook of Categorical Algebra 1*][borceux-vol1]
+-/
+
+noncomputable theory
+
+namespace category_theory.limits
+
+open category_theory
+
+universes v u u₂
+
+variables {J : Type v}
+
+/-- The type of objects for the diagram indexing a wide (co)equalizer. -/
+@[derive [decidable_eq, inhabited]] inductive walking_parallel_family (J : Type v) : Type v
+| zero : walking_parallel_family
+| one : walking_parallel_family
+
+open walking_parallel_family
+
+/-- The type family of morphisms for the diagram indexing a wide (co)equalizer. -/
+@[derive decidable_eq] inductive walking_parallel_family.hom (J : Type v) :
+  walking_parallel_family J → walking_parallel_family J → Type v
+| id : Π X : walking_parallel_family.{v} J, walking_parallel_family.hom X X
+| line : Π (j : J), walking_parallel_family.hom zero one
+
+/-- Satisfying the inhabited linter -/
+instance (J : Type v) : inhabited (walking_parallel_family.hom J zero zero) :=
+{ default := hom.id _ }
+
+open walking_parallel_family.hom
+
+/-- Composition of morphisms in the indexing diagram for wide (co)equalizers. -/
+def walking_parallel_family.hom.comp :
+  Π (X Y Z : walking_parallel_family J)
+    (f : walking_parallel_family.hom J X Y) (g : walking_parallel_family.hom J Y Z),
+    walking_parallel_family.hom J X Z
+  | _ _ _ (id _)   h := h
+  | _ _ _ (line j) (id one) := line j.
+
+local attribute [tidy] tactic.case_bash
+
+instance walking_parallel_family.category : small_category (walking_parallel_family J) :=
+{ hom  := walking_parallel_family.hom J,
+  id   := walking_parallel_family.hom.id,
+  comp := walking_parallel_family.hom.comp }
+
+@[simp]
+lemma walking_parallel_family.hom_id (X : walking_parallel_family J) :
+  walking_parallel_family.hom.id X = 𝟙 X :=
+rfl
+
+variables {C : Type u} [category.{v} C]
+variables {X Y : C} (f : J → (X ⟶ Y))
+
+/--
+`parallel_family f` is the diagram in `C` consisting of the given family of morphisms, each with
+common domain and codomain.
+-/
+def parallel_family : walking_parallel_family J ⥤ C :=
+{ obj := λ x, walking_parallel_family.cases_on x X Y,
+  map := λ x y h, match x, y, h with
+  | _, _, (id _) := 𝟙 _
+  | _, _, (line j) := f j
+  end,
+  map_comp' :=
+  begin
+    rintro _ _ _ ⟨⟩ ⟨⟩;
+    { unfold_aux, simp; refl },
+  end }
+
+@[simp] lemma parallel_family_obj_zero : (parallel_family f).obj zero = X := rfl
+@[simp] lemma parallel_family_obj_one : (parallel_family f).obj one = Y := rfl
+
+@[simp] lemma parallel_family_map_left {j : J} : (parallel_family f).map (line j) = f j := rfl
+
+/-- Every functor indexing a wide (co)equalizer is naturally isomorphic (actually, equal) to a
+    `parallel_family` -/
+@[simps]
+def diagram_iso_parallel_family (F : walking_parallel_family J ⥤ C) :
+  F ≅ parallel_family (λ j, F.map (line j)) :=
+nat_iso.of_components (λ j, eq_to_iso $ by cases j; tidy) $ by tidy
+
+@[simps]
+def walking_parallel_family_equiv_walking_parallel_pair :
+  walking_parallel_family.{v} (ulift bool) ≌ walking_parallel_pair.{v} :=
+{ functor := parallel_family
+      (λ p, cond p.down walking_parallel_pair_hom.left walking_parallel_pair_hom.right),
+  inverse := parallel_pair (line (ulift.up tt)) (line (ulift.up ff)),
+  unit_iso :=
+  begin
+    apply nat_iso.of_components _ _,
+    { intro X,
+      apply eq_to_iso,
+      cases X;
+      refl, },
+    { tidy }
+  end,
+  counit_iso :=
+  begin
+    apply nat_iso.of_components _ _,
+    { intro X,
+      apply eq_to_iso,
+      cases X;
+      refl },
+    { tidy },
+  end }
+
+/-- A trident on `f` is just a `cone (parallel_family f)`. -/
+abbreviation trident := cone (parallel_family f)
+
+/-- A cotrident on `f` and `g` is just a `cocone (parallel_family f)`. -/
+abbreviation cotrident := cocone (parallel_family f)
+
+variables {f}
+
+/-- A trident `t` on the parallel family `f : J → (X ⟶ Y)` consists of two morphisms
+    `t.π.app zero : t.X ⟶ X` and `t.π.app one : t.X ⟶ Y`. Of these, only the first one is
+    interesting, and we give it the shorter name `trident.ι t`. -/
+abbreviation trident.ι (t : trident f) := t.π.app zero
+
+/-- A cotrident `t` on the parallel family `f : J → (X ⟶ Y)` consists of two morphisms
+    `t.ι.app zero : X ⟶ t.X` and `t.ι.app one : Y ⟶ t.X`. Of these, only the second one is
+    interesting, and we give it the shorter name `cotrident.π t`. -/
+abbreviation cotrident.π (t : cotrident f) := t.ι.app one
+
+@[simp] lemma trident.ι_eq_app_zero (t : trident f) : t.ι = t.π.app zero := rfl
+@[simp] lemma cotrident.π_eq_app_one (t : cotrident f) : t.π = t.ι.app one := rfl
+
+@[simp, reassoc] lemma trident.app_zero (s : trident f) (j : J) :
+  s.π.app zero ≫ f j = s.π.app one :=
+by rw [←s.w (line j), parallel_family_map_left]
+
+@[simp, reassoc] lemma cotrident.app_one (s : cotrident f) (j : J) :
+  f j ≫ s.ι.app one = s.ι.app zero :=
+by rw [←s.w (line j), parallel_family_map_left]
+
+/--
+A trident on `f : J → (X ⟶ Y)` is determined by the morphism `ι : P ⟶ X` satisfying
+`∀ j₁ j₂, ι ≫ f j₁ = ι ≫ f j₂`.
+-/
+@[simps]
+def trident.of_ι [nonempty J] {P : C} (ι : P ⟶ X) (w : ∀ j₁ j₂, ι ≫ f j₁ = ι ≫ f j₂) : trident f :=
+{ X := P,
+  π :=
+  { app := λ X, walking_parallel_family.cases_on X ι (ι ≫ f (classical.arbitrary J)),
+    naturality' := λ i j f,
+      begin
+        dsimp,
+        cases f with _ k,
+        { simp },
+        { simp [w (classical.arbitrary J) k] },
+      end } }
+
+/--
+A cotrident on `f : J → (X ⟶ Y)` is determined by the morphism `π : Y ⟶ P` satisfying
+`∀ j₁ j₂, f j₁ ≫ π = f j₂ ≫ π`.
+-/
+@[simps]
+def cotrident.of_π [nonempty J] {P : C} (π : Y ⟶ P) (w : ∀ j₁ j₂, f j₁ ≫ π = f j₂ ≫ π) :
+  cotrident f :=
+{ X := P,
+  ι :=
+  { app := λ X, walking_parallel_family.cases_on X (f (classical.arbitrary J) ≫ π) π,
+    naturality' := λ i j f,
+      begin
+        dsimp,
+        cases f with _ k,
+        { simp },
+        { simp [w (classical.arbitrary J) k] }
+      end } } -- See note [dsimp, simp]
+
+lemma trident.ι_of_ι [nonempty J] {P : C} (ι : P ⟶ X) (w : ∀ j₁ j₂, ι ≫ f j₁ = ι ≫ f j₂) :
+  (trident.of_ι ι w).ι = ι := rfl
+lemma cotrident.π_of_π [nonempty J] {P : C} (π : Y ⟶ P) (w : ∀ j₁ j₂, f j₁ ≫ π = f j₂ ≫ π) :
+  (cotrident.of_π π w).π = π := rfl
+
+@[reassoc]
+lemma trident.condition (j₁ j₂ : J) (t : trident f) : t.ι ≫ f j₁ = t.ι ≫ f j₂ :=
+by rw [t.app_zero, t.app_zero]
+
+@[reassoc]
+lemma cotrident.condition (j₁ j₂ : J) (t : cotrident f) : f j₁ ≫ t.π = f j₂ ≫ t.π :=
+by rw [t.app_one, t.app_one]
+
+/-- To check whether two maps are equalized by both maps of a trident, it suffices to check it for
+the first map -/
+lemma trident.equalizer_ext [nonempty J] (s : trident f) {W : C} {k l : W ⟶ s.X}
+  (h : k ≫ s.ι = l ≫ s.ι) : ∀ (j : walking_parallel_family J),
+    k ≫ s.π.app j = l ≫ s.π.app j
+| zero := h
+| one := by rw [←s.app_zero (classical.arbitrary J), reassoc_of h]
+
+/-- To check whether two maps are coequalized by both maps of a cotrident, it suffices to check it
+for the second map -/
+lemma cotrident.coequalizer_ext [nonempty J] (s : cotrident f) {W : C} {k l : s.X ⟶ W}
+  (h : s.π ≫ k = s.π ≫ l) : ∀ (j : walking_parallel_family J),
+    s.ι.app j ≫ k = s.ι.app j ≫ l
+| zero := by rw [←s.app_one (classical.arbitrary J), category.assoc, category.assoc, h]
+| one := h
+
+lemma trident.is_limit.hom_ext [nonempty J] {s : trident f} (hs : is_limit s)
+  {W : C} {k l : W ⟶ s.X} (h : k ≫ s.ι = l ≫ s.ι) :
+  k = l :=
+hs.hom_ext $ trident.equalizer_ext _ h
+
+lemma cotrident.is_colimit.hom_ext [nonempty J] {s : cotrident f} (hs : is_colimit s)
+  {W : C} {k l : s.X ⟶ W} (h : s.π ≫ k = s.π ≫ l) :
+  k = l :=
+hs.hom_ext $ cotrident.coequalizer_ext _ h
+
+/-- If `s` is a limit trident over `f`, then a morphism `k : W ⟶ X` satisfying
+    `∀ j₁ j₂, k ≫ f j₁ = k ≫ f j₂` induces a morphism `l : W ⟶ s.X` such that
+    `l ≫ trident.ι s = k`. -/
+def trident.is_limit.lift' [nonempty J] {s : trident f} (hs : is_limit s) {W : C} (k : W ⟶ X)
+  (h : ∀ j₁ j₂, k ≫ f j₁ = k ≫ f j₂) :
+  {l : W ⟶ s.X // l ≫ trident.ι s = k} :=
+⟨hs.lift $ trident.of_ι _ h, hs.fac _ _⟩
+
+/-- If `s` is a colimit cotrident over `f`, then a morphism `k : Y ⟶ W` satisfying
+    `∀ j₁ j₂, f j₁ ≫ k = f j₂ ≫ k` induces a morphism `l : s.X ⟶ W` such that
+    `cotrident.π s ≫ l = k`. -/
+def cotrident.is_colimit.desc' [nonempty J] {s : cotrident f} (hs : is_colimit s) {W : C}
+  (k : Y ⟶ W) (h : ∀ j₁ j₂, f j₁ ≫ k = f j₂ ≫ k) :
+  {l : s.X ⟶ W // cotrident.π s ≫ l = k} :=
+⟨hs.desc $ cotrident.of_π _ h, hs.fac _ _⟩
+
+/-- This is a slightly more convenient method to verify that a trident is a limit cone. It
+    only asks for a proof of facts that carry any mathematical content -/
+def trident.is_limit.mk [nonempty J] (t : trident f)
+  (lift : Π (s : trident f), s.X ⟶ t.X)
+  (fac : ∀ (s : trident f), lift s ≫ t.ι = s.ι)
+  (uniq : ∀ (s : trident f) (m : s.X ⟶ t.X)
+  (w : ∀ j : walking_parallel_family J, m ≫ t.π.app j = s.π.app j), m = lift s) :
+  is_limit t :=
+{ lift := lift,
+  fac' := λ s j, walking_parallel_family.cases_on j (fac s)
+    (by rw [←t.w (line (classical.arbitrary J)), reassoc_of fac, s.w]),
+  uniq' := uniq }
+
+/-- This is another convenient method to verify that a trident is a limit cone. It
+    only asks for a proof of facts that carry any mathematical content, and allows access to the
+    same `s` for all parts. -/
+def trident.is_limit.mk' [nonempty J] (t : trident f)
+  (create : Π (s : trident f), {l // l ≫ t.ι = s.ι ∧ ∀ {m}, m ≫ t.ι = s.ι → m = l}) :
+is_limit t :=
+trident.is_limit.mk t
+  (λ s, (create s).1)
+  (λ s, (create s).2.1)
+  (λ s m w, (create s).2.2 (w zero))
+
+/-- This is a slightly more convenient method to verify that a cotrident is a colimit cocone. It
+    only asks for a proof of facts that carry any mathematical content -/
+def cotrident.is_colimit.mk [nonempty J] (t : cotrident f)
+  (desc : Π (s : cotrident f), t.X ⟶ s.X)
+  (fac : ∀ (s : cotrident f), t.π ≫ desc s = s.π)
+  (uniq : ∀ (s : cotrident f) (m : t.X ⟶ s.X)
+  (w : ∀ j : walking_parallel_family J, t.ι.app j ≫ m = s.ι.app j), m = desc s) :
+  is_colimit t :=
+{ desc := desc,
+  fac' := λ s j, walking_parallel_family.cases_on j
+    (by rw [←t.w_assoc (line (classical.arbitrary J)), fac, s.w]) (fac s),
+  uniq' := uniq }
+
+/-- This is another convenient method to verify that a cotrident is a colimit cocone. It
+    only asks for a proof of facts that carry any mathematical content, and allows access to the
+    same `s` for all parts. -/
+def cotrident.is_colimit.mk' [nonempty J] (t : cotrident f)
+  (create : Π (s : cotrident f), {l : t.X ⟶ s.X // t.π ≫ l = s.π ∧ ∀ {m}, t.π ≫ m = s.π → m = l}) :
+  is_colimit t :=
+cotrident.is_colimit.mk t
+  (λ s, (create s).1)
+  (λ s, (create s).2.1)
+  (λ s m w, (create s).2.2 (w one))
+
+/--
+Given a limit cone for the pair `f g : X ⟶ Y`, for any `Z`, morphisms from `Z` to its point are in
+bijection with morphisms `h : Z ⟶ X` such that `h ≫ f = h ≫ g`.
+Further, this bijection is natural in `Z`: see `trident.is_limit.hom_iso_natural`.
+-/
+@[simps]
+def trident.is_limit.hom_iso [nonempty J] {t : trident f} (ht : is_limit t) (Z : C) :
+  (Z ⟶ t.X) ≃ {h : Z ⟶ X // ∀ j₁ j₂, h ≫ f j₁ = h ≫ f j₂} :=
+{ to_fun := λ k, ⟨k ≫ t.ι, by simp⟩,
+  inv_fun := λ h, (trident.is_limit.lift' ht _ h.prop).1,
+  left_inv := λ k, trident.is_limit.hom_ext ht (trident.is_limit.lift' _ _ _).prop,
+  right_inv := λ h, subtype.ext (trident.is_limit.lift' ht _ _).prop }
+
+/-- The bijection of `trident.is_limit.hom_iso` is natural in `Z`. -/
+lemma trident.is_limit.hom_iso_natural [nonempty J] {t : trident f} (ht : is_limit t)
+  {Z Z' : C} (q : Z' ⟶ Z) (k : Z ⟶ t.X) :
+  (trident.is_limit.hom_iso ht _ (q ≫ k) : Z' ⟶ X) =
+  q ≫ (trident.is_limit.hom_iso ht _ k : Z ⟶ X) :=
+category.assoc _ _ _
+
+/--
+Given a colimit cocone for the pair `f g : X ⟶ Y`, for any `Z`, morphisms from the cocone point
+to `Z` are in bijection with morphisms `h : Y ⟶ Z` such that `f ≫ h = g ≫ h`.
+Further, this bijection is natural in `Z`: see `cotrident.is_colimit.hom_iso_natural`.
+-/
+@[simps]
+def cotrident.is_colimit.hom_iso [nonempty J] {t : cotrident f} (ht : is_colimit t) (Z : C) :
+  (t.X ⟶ Z) ≃ {h : Y ⟶ Z // ∀ j₁ j₂, f j₁ ≫ h = f j₂ ≫ h} :=
+{ to_fun := λ k, ⟨t.π ≫ k, by simp⟩,
+  inv_fun := λ h, (cotrident.is_colimit.desc' ht _ h.prop).1,
+  left_inv := λ k, cotrident.is_colimit.hom_ext ht (cotrident.is_colimit.desc' _ _ _).prop,
+  right_inv := λ h, subtype.ext (cotrident.is_colimit.desc' ht _ _).prop }
+
+/-- The bijection of `cotrident.is_colimit.hom_iso` is natural in `Z`. -/
+lemma cotrident.is_colimit.hom_iso_natural [nonempty J] {t : cotrident f} {Z Z' : C}
+  (q : Z ⟶ Z') (ht : is_colimit t) (k : t.X ⟶ Z) :
+    (cotrident.is_colimit.hom_iso ht _ (k ≫ q) : Y ⟶ Z') =
+    (cotrident.is_colimit.hom_iso ht _ k : Y ⟶ Z) ≫ q :=
+(category.assoc _ _ _).symm
+
+/-- This is a helper construction that can be useful when verifying that a category has certain wide
+    equalizers. Given `F : walking_parallel_pair ⥤ C`, which is really the same as
+    `parallel_pair (F.map left) (F.map right)`, and a trident on `F.map left` and `F.map right`,
+    we get a cone on `F`.
+
+    If you're thinking about using this, have a look at `has_equalizers_of_has_limit_parallel_pair`,
+    which you may find to be an easier way of achieving your goal. -/
+def cone.of_trident
+  {F : walking_parallel_family J ⥤ C} (t : trident (λ j, F.map (line j))) : cone F :=
+{ X := t.X,
+  π :=
+  { app := λ X, t.π.app X ≫ eq_to_hom (by tidy),
+    naturality' := λ j j' g, by { cases g; { dsimp, simp } } } }
+
+/-- This is a helper construction that can be useful when verifying that a category has all
+    coequalizers. Given `F : walking_parallel_pair ⥤ C`, which is really the same as
+    `parallel_pair (F.map left) (F.map right)`, and a cotrident on `F.map left` and `F.map right`,
+    we get a cocone on `F`.
+
+    If you're thinking about using this, have a look at
+    `has_coequalizers_of_has_colimit_parallel_pair`, which you may find to be an easier way of
+    achieving your goal. -/
+def cocone.of_cotrident
+  {F : walking_parallel_family J ⥤ C} (t : cotrident (λ j, F.map (line j))) : cocone F :=
+{ X := t.X,
+  ι :=
+  { app := λ X, eq_to_hom (by tidy) ≫ t.ι.app X,
+    naturality' := λ j j' g, by { cases g; dsimp; simp [cotrident.app_one t] } } }
+
+@[simp] lemma cone.of_trident_π
+  {F : walking_parallel_family J ⥤ C} (t : trident (λ j, F.map (line j))) (j) :
+  (cone.of_trident t).π.app j = t.π.app j ≫ eq_to_hom (by tidy) := rfl
+
+@[simp] lemma cocone.of_cotrident_ι
+  {F : walking_parallel_family J ⥤ C} (t : cotrident (λ j, F.map (line j))) (j) :
+  (cocone.of_cotrident t).ι.app j = eq_to_hom (by tidy) ≫ t.ι.app j := rfl
+
+/-- Given `F : walking_parallel_pair ⥤ C`, which is really the same as
+    `parallel_pair (F.map left) (F.map right)` and a cone on `F`, we get a trident on
+    `F.map left` and `F.map right`. -/
+def trident.of_cone
+  {F : walking_parallel_family J ⥤ C} (t : cone F) : trident (λ j, F.map (line j)) :=
+{ X := t.X,
+  π := { app := λ X, t.π.app X ≫ eq_to_hom (by tidy) } }
+
+/-- Given `F : walking_parallel_pair ⥤ C`, which is really the same as
+    `parallel_pair (F.map left) (F.map right)` and a cocone on `F`, we get a cotrident on
+    `F.map left` and `F.map right`. -/
+def cotrident.of_cocone
+  {F : walking_parallel_family J ⥤ C} (t : cocone F) : cotrident (λ j, F.map (line j)) :=
+{ X := t.X,
+  ι := { app := λ X, eq_to_hom (by tidy) ≫ t.ι.app X } }
+
+@[simp] lemma trident.of_cone_π {F : walking_parallel_family J ⥤ C} (t : cone F) (j) :
+  (trident.of_cone t).π.app j = t.π.app j ≫ eq_to_hom (by tidy) := rfl
+@[simp] lemma cotrident.of_cocone_ι {F : walking_parallel_family J ⥤ C} (t : cocone F) (j) :
+  (cotrident.of_cocone t).ι.app j = eq_to_hom (by tidy) ≫ t.ι.app j := rfl
+
+/--
+Helper function for constructing morphisms between wide equalizer tridents.
+-/
+@[simps]
+def trident.mk_hom [nonempty J] {s t : trident f} (k : s.X ⟶ t.X) (w : k ≫ t.ι = s.ι) : s ⟶ t :=
+{ hom := k,
+  w' :=
+  begin
+    rintro ⟨_|_⟩,
+    { exact w },
+    { simpa using w =≫ f (classical.arbitrary J) },
+  end }
+
+/--
+To construct an isomorphism between tridents,
+it suffices to give an isomorphism between the cone points
+and check that it commutes with the `ι` morphisms.
+-/
+@[simps]
+def trident.ext [nonempty J] {s t : trident f} (i : s.X ≅ t.X) (w : i.hom ≫ t.ι = s.ι) : s ≅ t :=
+{ hom := trident.mk_hom i.hom w,
+  inv := trident.mk_hom i.inv (by rw [← w, iso.inv_hom_id_assoc]) }
+
+/--
+Helper function for constructing morphisms between coequalizer cotridents.
+-/
+@[simps]
+def cotrident.mk_hom [nonempty J] {s t : cotrident f} (k : s.X ⟶ t.X) (w : s.π ≫ k = t.π) : s ⟶ t :=
+{ hom := k,
+  w' :=
+  begin
+    rintro ⟨_|_⟩,
+    { simpa using f (classical.arbitrary J) ≫= w },
+    { exact w },
+  end }
+
+/--
+To construct an isomorphism between cotridents,
+it suffices to give an isomorphism between the cocone points
+and check that it commutes with the `π` morphisms.
+-/
+def cotrident.ext [nonempty J] {s t : cotrident f} (i : s.X ≅ t.X) (w : s.π ≫ i.hom = t.π) : s ≅ t :=
+{ hom := cotrident.mk_hom i.hom w,
+  inv := cotrident.mk_hom i.inv (by rw [iso.comp_inv_eq, w]) }
+
+variables (f)
+
+section
+/--
+`has_equalizer f g` represents a particular choice of limiting cone
+for the parallel pair of morphisms `f` and `g`.
+-/
+abbreviation has_wide_equalizer := has_limit (parallel_family f)
+
+variables [has_wide_equalizer f]
+
+/-- If a wide equalizer of `f` exists, we can access an arbitrary choice of such by
+    saying `equalizer f g`. -/
+abbreviation wide_equalizer : C := limit (parallel_family f)
+
+/-- If a wide equalizer of `f` exists, we can access the inclusion `wide_equalizer f ⟶ X` by
+    saying `wide_equalizer.ι f`. -/
+abbreviation wide_equalizer.ι : wide_equalizer f ⟶ X :=
+limit.π (parallel_family f) zero
+
+/--
+A wide equalizer cone for a parallel family `f`.
+-/
+abbreviation wide_equalizer.trident : trident f := limit.cone (parallel_family f)
+
+@[simp] lemma wide_equalizer.trident_ι :
+  (wide_equalizer.trident f).ι = wide_equalizer.ι f := rfl
+
+@[simp] lemma wide_equalizer.trident_π_app_zero :
+  (wide_equalizer.trident f).π.app zero = wide_equalizer.ι f := rfl
+
+@[reassoc] lemma wide_equalizer.condition (j₁ j₂ : J) :
+  wide_equalizer.ι f ≫ f j₁ = wide_equalizer.ι f ≫ f j₂ :=
+trident.condition j₁ j₂ $ limit.cone $ parallel_family f
+
+/-- The equalizer built from `equalizer.ι f g` is limiting. -/
+def wide_equalizer_is_wide_equalizer [nonempty J] :
+  is_limit (trident.of_ι (wide_equalizer.ι f) (wide_equalizer.condition f)) :=
+is_limit.of_iso_limit (limit.is_limit _) (trident.ext (iso.refl _) (by tidy))
+
+variables {f}
+
+/-- A morphism `k : W ⟶ X` satisfying `k ≫ f = k ≫ g` factors through the equalizer of `f` and `g`
+    via `equalizer.lift : W ⟶ equalizer f g`. -/
+abbreviation wide_equalizer.lift [nonempty J] {W : C} (k : W ⟶ X)
+  (h : ∀ j₁ j₂, k ≫ f j₁ = k ≫ f j₂) :
+  W ⟶ wide_equalizer f :=
+limit.lift (parallel_family f) (trident.of_ι k h)
+
+@[simp, reassoc]
+lemma wide_equalizer.lift_ι [nonempty J] {W : C} (k : W ⟶ X) (h : ∀ j₁ j₂, k ≫ f j₁ = k ≫ f j₂) :
+  wide_equalizer.lift k h ≫ wide_equalizer.ι f = k :=
+limit.lift_π _ _
+
+/-- A morphism `k : W ⟶ X` satisfying `k ≫ f = k ≫ g` induces a morphism `l : W ⟶ equalizer f g`
+    satisfying `l ≫ equalizer.ι f g = k`. -/
+def wide_equalizer.lift' [nonempty J] {W : C} (k : W ⟶ X) (h : ∀ j₁ j₂, k ≫ f j₁ = k ≫ f j₂) :
+  {l : W ⟶ wide_equalizer f // l ≫ wide_equalizer.ι f = k} :=
+⟨wide_equalizer.lift k h, wide_equalizer.lift_ι _ _⟩
+
+/-- Two maps into an equalizer are equal if they are are equal when composed with the equalizer
+    map. -/
+@[ext] lemma wide_equalizer.hom_ext [nonempty J] {W : C} {k l : W ⟶ wide_equalizer f}
+  (h : k ≫ wide_equalizer.ι f = l ≫ wide_equalizer.ι f) : k = l :=
+trident.is_limit.hom_ext (limit.is_limit _) h
+
+/-- An equalizer morphism is a monomorphism -/
+instance wide_equalizer.ι_mono [nonempty J] : mono (wide_equalizer.ι f) :=
+{ right_cancellation := λ Z h k w, wide_equalizer.hom_ext w }
+
+end
+
+section
+variables {f}
+/-- The equalizer morphism in any limit cone is a monomorphism. -/
+lemma mono_of_is_limit_parallel_family [nonempty J] {c : cone (parallel_family f)}
+  (i : is_limit c) :
+  mono (trident.ι c) :=
+{ right_cancellation := λ Z h k w, trident.is_limit.hom_ext i w }
+
+end
+
+section
+/--
+`has_coequalizer f g` represents a particular choice of colimiting cocone
+for the parallel pair of morphisms `f` and `g`.
+-/
+abbreviation has_wide_coequalizer := has_colimit (parallel_family f)
+
+variables [has_wide_coequalizer f]
+
+/-- If a coequalizer of `f` and `g` exists, we can access an arbitrary choice of such by
+    saying `coequalizer f g`. -/
+abbreviation wide_coequalizer : C := colimit (parallel_family f)
+
+/--  If a coequalizer of `f` and `g` exists, we can access the corresponding projection by
+    saying `coequalizer.π f g`. -/
+abbreviation wide_coequalizer.π : Y ⟶ wide_coequalizer f :=
+colimit.ι (parallel_family f) one
+
+/--
+An arbitrary choice of coequalizer cocone for a parallel pair `f` and `g`.
+-/
+abbreviation wide_coequalizer.cotrident : cotrident f := colimit.cocone (parallel_family f)
+
+@[simp] lemma wide_coequalizer.cotrident_π :
+  (wide_coequalizer.cotrident f).π = wide_coequalizer.π f := rfl
+
+@[simp] lemma wide_coequalizer.cotrident_ι_app_one :
+  (wide_coequalizer.cotrident f).ι.app one = wide_coequalizer.π f := rfl
+
+@[reassoc] lemma wide_coequalizer.condition (j₁ j₂ : J) :
+  f j₁ ≫ wide_coequalizer.π f = f j₂ ≫ wide_coequalizer.π f :=
+cotrident.condition j₁ j₂ $ colimit.cocone $ parallel_family f
+
+/-- The cotrident built from `coequalizer.π f g` is colimiting. -/
+def wide_coequalizer_is_wide_coequalizer [nonempty J] :
+  is_colimit (cotrident.of_π (wide_coequalizer.π f) (wide_coequalizer.condition f)) :=
+is_colimit.of_iso_colimit (colimit.is_colimit _) (cotrident.ext (iso.refl _) (by tidy))
+
+variables {f}
+
+/-- Any morphism `k : Y ⟶ W` satisfying `f ≫ k = g ≫ k` factors through the coequalizer of `f`
+    and `g` via `coequalizer.desc : coequalizer f g ⟶ W`. -/
+abbreviation wide_coequalizer.desc [nonempty J] {W : C} (k : Y ⟶ W)
+  (h : ∀ j₁ j₂, f j₁ ≫ k = f j₂ ≫ k) :
+  wide_coequalizer f ⟶ W :=
+colimit.desc (parallel_family f) (cotrident.of_π k h)
+
+@[simp, reassoc]
+lemma wide_coequalizer.π_desc [nonempty J] {W : C} (k : Y ⟶ W) (h : ∀ j₁ j₂, f j₁ ≫ k = f j₂ ≫ k) :
+  wide_coequalizer.π f ≫ wide_coequalizer.desc k h = k :=
+colimit.ι_desc _ _
+
+/-- Any morphism `k : Y ⟶ W` satisfying `f ≫ k = g ≫ k` induces a morphism
+    `l : coequalizer f g ⟶ W` satisfying `coequalizer.π ≫ g = l`. -/
+def wide_coequalizer.desc' [nonempty J] {W : C} (k : Y ⟶ W) (h : ∀ j₁ j₂, f j₁ ≫ k = f j₂ ≫ k) :
+  {l : wide_coequalizer f ⟶ W // wide_coequalizer.π f ≫ l = k} :=
+⟨wide_coequalizer.desc k h, wide_coequalizer.π_desc _ _⟩
+
+/-- Two maps from a wide coequalizer are equal if they are equal when composed with the wide
+    coequalizer map -/
+@[ext] lemma wide_coequalizer.hom_ext [nonempty J] {W : C} {k l : wide_coequalizer f ⟶ W}
+  (h : wide_coequalizer.π f ≫ k = wide_coequalizer.π f ≫ l) : k = l :=
+cotrident.is_colimit.hom_ext (colimit.is_colimit _) h
+
+/-- A wide coequalizer morphism is an epimorphism -/
+instance wide_coequalizer.π_epi [nonempty J] : epi (wide_coequalizer.π f) :=
+{ left_cancellation := λ Z h k w, wide_coequalizer.hom_ext w }
+
+end
+
+section
+variables {f}
+
+/-- The wide coequalizer morphism in any colimit cocone is an epimorphism. -/
+lemma epi_of_is_colimit_parallel_chunk [nonempty J] {c : cocone (parallel_family f)}
+  (i : is_colimit c) :
+  epi (c.ι.app one) :=
+{ left_cancellation := λ Z h k w, cotrident.is_colimit.hom_ext i w }
+
+end
+
+variables (C)
+
+/-- `has_wide_equalizers` represents a choice of wide equalizer for every family of morphisms -/
+abbreviation has_wide_equalizers := Π J, has_limits_of_shape (walking_parallel_family J) C
+
+/-- `has_wide_coequalizers` represents a choice of wide coequalizer for every family of morphisms -/
+abbreviation has_wide_coequalizers := Π J, has_colimits_of_shape (walking_parallel_family J) C
+
+/-- If `C` has all limits of diagrams `parallel_family f g`, then it has all equalizers -/
+lemma has_wide_equalizers_of_has_limit_parallel_family
+  [Π {J} {X Y : C} {f : J → (X ⟶ Y)}, has_limit (parallel_family f)] : has_wide_equalizers C :=
+λ J, { has_limit := λ F, has_limit_of_iso (diagram_iso_parallel_family F).symm }
+
+/-- If `C` has all colimits of diagrams `parallel_family f g`, then it has all coequalizers -/
+lemma has_wide_coequalizers_of_has_colimit_parallel_family
+  [Π {J} {X Y : C} {f : J → (X ⟶ Y)}, has_colimit (parallel_family f)] : has_wide_coequalizers C :=
+λ J, { has_colimit := λ F, has_colimit_of_iso (diagram_iso_parallel_family F) }
+
+@[priority 10]
+instance has_equalizers_of_has_wide_equalizers [has_wide_equalizers C] : has_equalizers C :=
+has_limits_of_shape_of_equivalence walking_parallel_family_equiv_walking_parallel_pair
+
+@[priority 10]
+instance has_coequalizers_of_has_wide_coequalizers [has_wide_coequalizers C] : has_coequalizers C :=
+has_colimits_of_shape_of_equivalence walking_parallel_family_equiv_walking_parallel_pair
+
+end category_theory.limits

--- a/src/category_theory/limits/shapes/wide_equalizers.lean
+++ b/src/category_theory/limits/shapes/wide_equalizers.lean
@@ -357,11 +357,11 @@ lemma cotrident.is_colimit.hom_iso_natural [nonempty J] {t : cotrident f} {Z Z' 
 (category.assoc _ _ _).symm
 
 /-- This is a helper construction that can be useful when verifying that a category has certain wide
-    equalizers. Given `F : walking_parallel_pair ⥤ C`, which is really the same as
-    `parallel_pair (F.map left) (F.map right)`, and a trident on `F.map left` and `F.map right`,
+    equalizers. Given `F : walking_parallel_family ⥤ C`, which is really the same as
+    `parallel_family (F.map left) (F.map right)`, and a trident on `F.map left` and `F.map right`,
     we get a cone on `F`.
 
-    If you're thinking about using this, have a look at `has_equalizers_of_has_limit_parallel_pair`,
+    If you're thinking about using this, have a look at `has_equalizers_of_has_limit_parallel_family`,
     which you may find to be an easier way of achieving your goal. -/
 def cone.of_trident
   {F : walking_parallel_family J ⥤ C} (t : trident (λ j, F.map (line j))) : cone F :=
@@ -371,12 +371,12 @@ def cone.of_trident
     naturality' := λ j j' g, by { cases g; { dsimp, simp } } } }
 
 /-- This is a helper construction that can be useful when verifying that a category has all
-    coequalizers. Given `F : walking_parallel_pair ⥤ C`, which is really the same as
-    `parallel_pair (F.map left) (F.map right)`, and a cotrident on `F.map left` and `F.map right`,
+    coequalizers. Given `F : walking_parallel_family ⥤ C`, which is really the same as
+    `parallel_family (F.map left) (F.map right)`, and a cotrident on `F.map left` and `F.map right`,
     we get a cocone on `F`.
 
     If you're thinking about using this, have a look at
-    `has_coequalizers_of_has_colimit_parallel_pair`, which you may find to be an easier way of
+    `has_coequalizers_of_has_colimit_parallel_family`, which you may find to be an easier way of
     achieving your goal. -/
 def cocone.of_cotrident
   {F : walking_parallel_family J ⥤ C} (t : cotrident (λ j, F.map (line j))) : cocone F :=
@@ -393,16 +393,16 @@ def cocone.of_cotrident
   {F : walking_parallel_family J ⥤ C} (t : cotrident (λ j, F.map (line j))) (j) :
   (cocone.of_cotrident t).ι.app j = eq_to_hom (by tidy) ≫ t.ι.app j := rfl
 
-/-- Given `F : walking_parallel_pair ⥤ C`, which is really the same as
-    `parallel_pair (F.map left) (F.map right)` and a cone on `F`, we get a trident on
+/-- Given `F : walking_parallel_family ⥤ C`, which is really the same as
+    `parallel_family (F.map left) (F.map right)` and a cone on `F`, we get a trident on
     `F.map left` and `F.map right`. -/
 def trident.of_cone
   {F : walking_parallel_family J ⥤ C} (t : cone F) : trident (λ j, F.map (line j)) :=
 { X := t.X,
   π := { app := λ X, t.π.app X ≫ eq_to_hom (by tidy) } }
 
-/-- Given `F : walking_parallel_pair ⥤ C`, which is really the same as
-    `parallel_pair (F.map left) (F.map right)` and a cocone on `F`, we get a cotrident on
+/-- Given `F : walking_parallel_family ⥤ C`, which is really the same as
+    `parallel_family (F.map left) (F.map right)` and a cocone on `F`, we get a cotrident on
     `F.map left` and `F.map right`. -/
 def cotrident.of_cocone
   {F : walking_parallel_family J ⥤ C} (t : cocone F) : cotrident (λ j, F.map (line j)) :=

--- a/src/category_theory/limits/shapes/wide_equalizers.lean
+++ b/src/category_theory/limits/shapes/wide_equalizers.lean
@@ -14,7 +14,8 @@ This file defines wide (co)equalizers as special cases of (co)limits.
 
 A wide equalizer for the family of morphisms `X ⟶ Y` indexed by `J` is the categorical
 generalization of the subobject `{a ∈ A | ∀ j₁ j₂, f(j₁, a) = f(j₂, a)}`. Note that if `J` has
-fewer than two morphisms this condition is trivial, so some lemmas and definitions assume this.
+fewer than two morphisms this condition is trivial, so some lemmas and definitions assume `J` is
+nonempty.
 
 ## Main definitions
 

--- a/src/category_theory/limits/shapes/wide_equalizers.lean
+++ b/src/category_theory/limits/shapes/wide_equalizers.lean
@@ -124,30 +124,16 @@ def diagram_iso_parallel_family (F : walking_parallel_family J ⥤ C) :
   F ≅ parallel_family (λ j, F.map (line j)) :=
 nat_iso.of_components (λ j, eq_to_iso $ by cases j; tidy) $ by tidy
 
+/-- `walking_parallel_pair` as a category is equivalent to a special case of
+`walking_parallel_family`.  -/
 @[simps]
 def walking_parallel_family_equiv_walking_parallel_pair :
   walking_parallel_family.{v} (ulift bool) ≌ walking_parallel_pair.{v} :=
 { functor := parallel_family
       (λ p, cond p.down walking_parallel_pair_hom.left walking_parallel_pair_hom.right),
   inverse := parallel_pair (line (ulift.up tt)) (line (ulift.up ff)),
-  unit_iso :=
-  begin
-    apply nat_iso.of_components _ _,
-    { intro X,
-      apply eq_to_iso,
-      cases X;
-      refl, },
-    { tidy }
-  end,
-  counit_iso :=
-  begin
-    apply nat_iso.of_components _ _,
-    { intro X,
-      apply eq_to_iso,
-      cases X;
-      refl },
-    { tidy },
-  end }
+  unit_iso := nat_iso.of_components (λ X, eq_to_iso (by cases X; refl)) (by tidy),
+  counit_iso := nat_iso.of_components (λ X, eq_to_iso (by cases X; refl)) (by tidy) }
 
 /-- A trident on `f` is just a `cone (parallel_family f)`. -/
 abbreviation trident := cone (parallel_family f)
@@ -183,7 +169,8 @@ A trident on `f : J → (X ⟶ Y)` is determined by the morphism `ι : P ⟶ X` 
 `∀ j₁ j₂, ι ≫ f j₁ = ι ≫ f j₂`.
 -/
 @[simps]
-def trident.of_ι [nonempty J] {P : C} (ι : P ⟶ X) (w : ∀ j₁ j₂, ι ≫ f j₁ = ι ≫ f j₂) : trident f :=
+def trident.of_ι [nonempty J] {P : C} (ι : P ⟶ X) (w : ∀ j₁ j₂, ι ≫ f j₁ = ι ≫ f j₂) :
+  trident f :=
 { X := P,
   π :=
   { app := λ X, walking_parallel_family.cases_on X ι (ι ≫ f (classical.arbitrary J)),
@@ -317,8 +304,8 @@ cotrident.is_colimit.mk t
   (λ s m w, (create s).2.2 (w one))
 
 /--
-Given a limit cone for the pair `f g : X ⟶ Y`, for any `Z`, morphisms from `Z` to its point are in
-bijection with morphisms `h : Z ⟶ X` such that `h ≫ f = h ≫ g`.
+Given a limit cone for the family `f : J → (X ⟶ Y)`, for any `Z`, morphisms from `Z` to its point
+are in bijection with morphisms `h : Z ⟶ X` such that `∀ j₁ j₂, h ≫ f j₁ = h ≫ f j₂`.
 Further, this bijection is natural in `Z`: see `trident.is_limit.hom_iso_natural`.
 -/
 @[simps]
@@ -337,9 +324,10 @@ lemma trident.is_limit.hom_iso_natural [nonempty J] {t : trident f} (ht : is_lim
 category.assoc _ _ _
 
 /--
-Given a colimit cocone for the pair `f g : X ⟶ Y`, for any `Z`, morphisms from the cocone point
-to `Z` are in bijection with morphisms `h : Y ⟶ Z` such that `f ≫ h = g ≫ h`.
-Further, this bijection is natural in `Z`: see `cotrident.is_colimit.hom_iso_natural`.
+Given a colimit cocone for the family `f : J → (X ⟶ Y)`, for any `Z`, morphisms from the cocone
+point to `Z` are in bijection with morphisms `h : Z ⟶ X` such that
+`∀ j₁ j₂, f j₁ ≫ h = f j₂ ≫ h`.  Further, this bijection is natural in `Z`: see
+`cotrident.is_colimit.hom_iso_natural`.
 -/
 @[simps]
 def cotrident.is_colimit.hom_iso [nonempty J] {t : cotrident f} (ht : is_colimit t) (Z : C) :
@@ -358,11 +346,12 @@ lemma cotrident.is_colimit.hom_iso_natural [nonempty J] {t : cotrident f} {Z Z' 
 
 /-- This is a helper construction that can be useful when verifying that a category has certain wide
     equalizers. Given `F : walking_parallel_family ⥤ C`, which is really the same as
-    `parallel_family (F.map left) (F.map right)`, and a trident on `F.map left` and `F.map right`,
-    we get a cone on `F`.
+    `parallel_family (λ j, F.map (line j))`, and a trident on `λ j, F.map (line j)`, we get a cone
+    on `F`.
 
-    If you're thinking about using this, have a look at `has_equalizers_of_has_limit_parallel_family`,
-    which you may find to be an easier way of achieving your goal. -/
+    If you're thinking about using this, have a look at
+    `has_wide_equalizers_of_has_limit_parallel_family`, which you may find to be an easier way of
+    achieving your goal. -/
 def cone.of_trident
   {F : walking_parallel_family J ⥤ C} (t : trident (λ j, F.map (line j))) : cone F :=
 { X := t.X,
@@ -372,12 +361,12 @@ def cone.of_trident
 
 /-- This is a helper construction that can be useful when verifying that a category has all
     coequalizers. Given `F : walking_parallel_family ⥤ C`, which is really the same as
-    `parallel_family (F.map left) (F.map right)`, and a cotrident on `F.map left` and `F.map right`,
-    we get a cocone on `F`.
+    `parallel_family (λ j, F.map (line j))`, and a cotrident on `λ j, F.map (line j)` we get a
+    cocone on `F`.
 
     If you're thinking about using this, have a look at
-    `has_coequalizers_of_has_colimit_parallel_family`, which you may find to be an easier way of
-    achieving your goal. -/
+    `has_wide_coequalizers_of_has_colimit_parallel_family`, which you may find to be an easier way
+    of achieving your goal. -/
 def cocone.of_cotrident
   {F : walking_parallel_family J ⥤ C} (t : cotrident (λ j, F.map (line j))) : cocone F :=
 { X := t.X,
@@ -394,8 +383,8 @@ def cocone.of_cotrident
   (cocone.of_cotrident t).ι.app j = eq_to_hom (by tidy) ≫ t.ι.app j := rfl
 
 /-- Given `F : walking_parallel_family ⥤ C`, which is really the same as
-    `parallel_family (F.map left) (F.map right)` and a cone on `F`, we get a trident on
-    `F.map left` and `F.map right`. -/
+    `parallel_family (λ j, F.map (line j))` and a cone on `F`, we get a trident on
+    `λ j, F.map (line j)`. -/
 def trident.of_cone
   {F : walking_parallel_family J ⥤ C} (t : cone F) : trident (λ j, F.map (line j)) :=
 { X := t.X,
@@ -403,7 +392,7 @@ def trident.of_cone
 
 /-- Given `F : walking_parallel_family ⥤ C`, which is really the same as
     `parallel_family (F.map left) (F.map right)` and a cocone on `F`, we get a cotrident on
-    `F.map left` and `F.map right`. -/
+    `λ j, F.map (line j)`. -/
 def cotrident.of_cocone
   {F : walking_parallel_family J ⥤ C} (t : cocone F) : cotrident (λ j, F.map (line j)) :=
 { X := t.X,
@@ -463,15 +452,15 @@ variables (f)
 
 section
 /--
-`has_equalizer f g` represents a particular choice of limiting cone
-for the parallel pair of morphisms `f` and `g`.
+`has_wide_equalizer f` represents a particular choice of limiting cone for the parallel family of
+morphisms `f`.
 -/
 abbreviation has_wide_equalizer := has_limit (parallel_family f)
 
 variables [has_wide_equalizer f]
 
 /-- If a wide equalizer of `f` exists, we can access an arbitrary choice of such by
-    saying `equalizer f g`. -/
+    saying `wide_equalizer f`. -/
 abbreviation wide_equalizer : C := limit (parallel_family f)
 
 /-- If a wide equalizer of `f` exists, we can access the inclusion `wide_equalizer f ⟶ X` by
@@ -494,15 +483,15 @@ abbreviation wide_equalizer.trident : trident f := limit.cone (parallel_family f
   wide_equalizer.ι f ≫ f j₁ = wide_equalizer.ι f ≫ f j₂ :=
 trident.condition j₁ j₂ $ limit.cone $ parallel_family f
 
-/-- The equalizer built from `equalizer.ι f g` is limiting. -/
+/-- The wide_equalizer built from `wide_equalizer.ι f` is limiting. -/
 def wide_equalizer_is_wide_equalizer [nonempty J] :
   is_limit (trident.of_ι (wide_equalizer.ι f) (wide_equalizer.condition f)) :=
 is_limit.of_iso_limit (limit.is_limit _) (trident.ext (iso.refl _) (by tidy))
 
 variables {f}
 
-/-- A morphism `k : W ⟶ X` satisfying `k ≫ f = k ≫ g` factors through the equalizer of `f` and `g`
-    via `equalizer.lift : W ⟶ equalizer f g`. -/
+/-- A morphism `k : W ⟶ X` satisfying `∀ j₁ j₂, k ≫ f j₁ = k ≫ f j₂` factors through the
+    wide equalizer of `f` via `wide_equalizer.lift : W ⟶ wide_equalizer f`. -/
 abbreviation wide_equalizer.lift [nonempty J] {W : C} (k : W ⟶ X)
   (h : ∀ j₁ j₂, k ≫ f j₁ = k ≫ f j₂) :
   W ⟶ wide_equalizer f :=
@@ -513,19 +502,19 @@ lemma wide_equalizer.lift_ι [nonempty J] {W : C} (k : W ⟶ X) (h : ∀ j₁ j�
   wide_equalizer.lift k h ≫ wide_equalizer.ι f = k :=
 limit.lift_π _ _
 
-/-- A morphism `k : W ⟶ X` satisfying `k ≫ f = k ≫ g` induces a morphism `l : W ⟶ equalizer f g`
-    satisfying `l ≫ equalizer.ι f g = k`. -/
+/-- A morphism `k : W ⟶ X` satisfying `∀ j₁ j₂, k ≫ f j₁ = k ≫ f j₂` induces a morphism
+    `l : W ⟶ wide_equalizer f` satisfying `l ≫ wide_equalizer.ι f = k`. -/
 def wide_equalizer.lift' [nonempty J] {W : C} (k : W ⟶ X) (h : ∀ j₁ j₂, k ≫ f j₁ = k ≫ f j₂) :
   {l : W ⟶ wide_equalizer f // l ≫ wide_equalizer.ι f = k} :=
 ⟨wide_equalizer.lift k h, wide_equalizer.lift_ι _ _⟩
 
-/-- Two maps into an equalizer are equal if they are are equal when composed with the equalizer
-    map. -/
+/-- Two maps into a wide equalizer are equal if they are are equal when composed with the wide
+    equalizer map. -/
 @[ext] lemma wide_equalizer.hom_ext [nonempty J] {W : C} {k l : W ⟶ wide_equalizer f}
   (h : k ≫ wide_equalizer.ι f = l ≫ wide_equalizer.ι f) : k = l :=
 trident.is_limit.hom_ext (limit.is_limit _) h
 
-/-- An equalizer morphism is a monomorphism -/
+/-- A wide equalizer morphism is a monomorphism -/
 instance wide_equalizer.ι_mono [nonempty J] : mono (wide_equalizer.ι f) :=
 { right_cancellation := λ Z h k w, wide_equalizer.hom_ext w }
 
@@ -533,7 +522,7 @@ end
 
 section
 variables {f}
-/-- The equalizer morphism in any limit cone is a monomorphism. -/
+/-- The wide equalizer morphism in any limit cone is a monomorphism. -/
 lemma mono_of_is_limit_parallel_family [nonempty J] {c : cone (parallel_family f)}
   (i : is_limit c) :
   mono (trident.ι c) :=
@@ -543,24 +532,24 @@ end
 
 section
 /--
-`has_coequalizer f g` represents a particular choice of colimiting cocone
-for the parallel pair of morphisms `f` and `g`.
+`has_wide_coequalizer f g` represents a particular choice of colimiting cocone
+for the parallel family of morphisms `f`.
 -/
 abbreviation has_wide_coequalizer := has_colimit (parallel_family f)
 
 variables [has_wide_coequalizer f]
 
-/-- If a coequalizer of `f` and `g` exists, we can access an arbitrary choice of such by
-    saying `coequalizer f g`. -/
+/-- If a wide coequalizer of `f`, we can access an arbitrary choice of such by
+    saying `wide_coequalizer f`. -/
 abbreviation wide_coequalizer : C := colimit (parallel_family f)
 
-/--  If a coequalizer of `f` and `g` exists, we can access the corresponding projection by
-    saying `coequalizer.π f g`. -/
+/--  If a wide_coequalizer of `f` exists, we can access the corresponding projection by
+    saying `wide_coequalizer.π f`. -/
 abbreviation wide_coequalizer.π : Y ⟶ wide_coequalizer f :=
 colimit.ι (parallel_family f) one
 
 /--
-An arbitrary choice of coequalizer cocone for a parallel pair `f` and `g`.
+An arbitrary choice of coequalizer cocone for a parallel family `f`.
 -/
 abbreviation wide_coequalizer.cotrident : cotrident f := colimit.cocone (parallel_family f)
 
@@ -574,15 +563,15 @@ abbreviation wide_coequalizer.cotrident : cotrident f := colimit.cocone (paralle
   f j₁ ≫ wide_coequalizer.π f = f j₂ ≫ wide_coequalizer.π f :=
 cotrident.condition j₁ j₂ $ colimit.cocone $ parallel_family f
 
-/-- The cotrident built from `coequalizer.π f g` is colimiting. -/
+/-- The cotrident built from `wide_coequalizer.π f` is colimiting. -/
 def wide_coequalizer_is_wide_coequalizer [nonempty J] :
   is_colimit (cotrident.of_π (wide_coequalizer.π f) (wide_coequalizer.condition f)) :=
 is_colimit.of_iso_colimit (colimit.is_colimit _) (cotrident.ext (iso.refl _) (by tidy))
 
 variables {f}
 
-/-- Any morphism `k : Y ⟶ W` satisfying `f ≫ k = g ≫ k` factors through the coequalizer of `f`
-    and `g` via `coequalizer.desc : coequalizer f g ⟶ W`. -/
+/-- Any morphism `k : Y ⟶ W` satisfying `∀ j₁ j₂, f j₁ ≫ k = f j₂ ≫ k` factors through the
+    wide coequalizer of `f` via `wide_coequalizer.desc : wide_coequalizer f ⟶ W`. -/
 abbreviation wide_coequalizer.desc [nonempty J] {W : C} (k : Y ⟶ W)
   (h : ∀ j₁ j₂, f j₁ ≫ k = f j₂ ≫ k) :
   wide_coequalizer f ⟶ W :=
@@ -593,8 +582,8 @@ lemma wide_coequalizer.π_desc [nonempty J] {W : C} (k : Y ⟶ W) (h : ∀ j₁ 
   wide_coequalizer.π f ≫ wide_coequalizer.desc k h = k :=
 colimit.ι_desc _ _
 
-/-- Any morphism `k : Y ⟶ W` satisfying `f ≫ k = g ≫ k` induces a morphism
-    `l : coequalizer f g ⟶ W` satisfying `coequalizer.π ≫ g = l`. -/
+/-- Any morphism `k : Y ⟶ W` satisfying `∀ j₁ j₂, f j₁ ≫ k = f j₂ ≫ k` induces a morphism
+    `l : wide_coequalizer f ⟶ W` satisfying `wide_coequalizer.π ≫ g = l`. -/
 def wide_coequalizer.desc' [nonempty J] {W : C} (k : Y ⟶ W) (h : ∀ j₁ j₂, f j₁ ≫ k = f j₂ ≫ k) :
   {l : wide_coequalizer f ⟶ W // wide_coequalizer.π f ≫ l = k} :=
 ⟨wide_coequalizer.desc k h, wide_coequalizer.π_desc _ _⟩
@@ -615,7 +604,7 @@ section
 variables {f}
 
 /-- The wide coequalizer morphism in any colimit cocone is an epimorphism. -/
-lemma epi_of_is_colimit_parallel_chunk [nonempty J] {c : cocone (parallel_family f)}
+lemma epi_of_is_colimit_parallel_family [nonempty J] {c : cocone (parallel_family f)}
   (i : is_colimit c) :
   epi (c.ι.app one) :=
 { left_cancellation := λ Z h k w, cotrident.is_colimit.hom_ext i w }
@@ -630,12 +619,12 @@ abbreviation has_wide_equalizers := Π J, has_limits_of_shape (walking_parallel_
 /-- `has_wide_coequalizers` represents a choice of wide coequalizer for every family of morphisms -/
 abbreviation has_wide_coequalizers := Π J, has_colimits_of_shape (walking_parallel_family J) C
 
-/-- If `C` has all limits of diagrams `parallel_family f g`, then it has all equalizers -/
+/-- If `C` has all limits of diagrams `parallel_family f`, then it has all wide equalizers -/
 lemma has_wide_equalizers_of_has_limit_parallel_family
   [Π {J} {X Y : C} {f : J → (X ⟶ Y)}, has_limit (parallel_family f)] : has_wide_equalizers C :=
 λ J, { has_limit := λ F, has_limit_of_iso (diagram_iso_parallel_family F).symm }
 
-/-- If `C` has all colimits of diagrams `parallel_family f g`, then it has all coequalizers -/
+/-- If `C` has all colimits of diagrams `parallel_family f`, then it has all wide coequalizers -/
 lemma has_wide_coequalizers_of_has_colimit_parallel_family
   [Π {J} {X Y : C} {f : J → (X ⟶ Y)}, has_colimit (parallel_family f)] : has_wide_coequalizers C :=
 λ J, { has_colimit := λ F, has_colimit_of_iso (diagram_iso_parallel_family F) }


### PR DESCRIPTION
A proof of the general adjoint functor theorem. This PR also adds an API for wide equalizers (essentially copied from the equalizer API), as well as results relating adjunctions to (co)structured arrow categories and weakly initial objects. I can split this into smaller PRs if necessary?

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
