### PR TITLE
[Merged by Bors] - feat(ring_theory/algebraic): if `L / K` is algebraic, then the subalgebras are fields

### DIFF
--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -332,11 +332,12 @@ end intermediate_field
 
 /-- If `L/K` is algebraic, the `K`-subalgebras of `L` are all fields.  -/
 def subalgebra_equiv_intermediate_field (alg : algebra.is_algebraic K L) :
-  subalgebra K L ≃ intermediate_field K L :=
+  subalgebra K L ≃o intermediate_field K L :=
 { to_fun := λ S, S.to_intermediate_field (λ x hx, S.inv_mem_of_algebraic (alg (⟨x, hx⟩ : S))),
   inv_fun := λ S, S.to_subalgebra,
   left_inv := λ S, to_subalgebra_to_intermediate_field _ _,
-  right_inv := λ S, to_intermediate_field_to_subalgebra _ _ }
+  right_inv := λ S, to_intermediate_field_to_subalgebra _ _,
+  map_rel_iff' := λ S S', iff.rfl }
 
 @[simp] lemma mem_subalgebra_equiv_intermediate_field (alg : algebra.is_algebraic K L)
   {S : subalgebra K L} {x : L} :

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -32,12 +32,6 @@ i.e. it is a `subfield L` and a `subalgebra K L`.
 Intermediate fields are defined with a structure extending `subfield` and `subalgebra`.
 A `subalgebra` is closed under all operations except `⁻¹`,
 
-## TODO
-
- * `field.adjoin` currently returns a `subalgebra`, this should become an
-   `intermediate_field`. The lattice structure on `intermediate_field` will
-   follow from the adjunction given by `field.adjoin`.
-
 ## Tags
 intermediate field, field extension
 -/

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -6,6 +6,7 @@ Authors: Anne Baanen
 
 import field_theory.subfield
 import field_theory.tower
+import ring_theory.algebraic
 
 /-!
 # Intermediate fields
@@ -179,6 +180,17 @@ def subalgebra.to_intermediate_field (S : subalgebra K L) (inv_mem : ∀ x ∈ S
   inv_mem' := inv_mem,
   .. S }
 
+@[simp] lemma to_subalgebra_to_intermediate_field
+  (S : subalgebra K L) (inv_mem : ∀ x ∈ S, x⁻¹ ∈ S) :
+  (S.to_intermediate_field inv_mem).to_subalgebra = S :=
+by { ext, refl }
+
+@[simp] lemma to_intermediate_field_to_subalgebra
+  (S : intermediate_field K L) (inv_mem : ∀ x ∈ S.to_subalgebra, x⁻¹ ∈ S) :
+  S.to_subalgebra.to_intermediate_field inv_mem = S :=
+by { ext, refl }
+
+
 /-- Turn a subfield of `L` containing the image of `K` into an intermediate field -/
 def subfield.to_intermediate_field (S : subfield L)
   (algebra_map_mem : ∀ x, algebra_map K L x ∈ S) :
@@ -317,3 +329,21 @@ eq_of_le_of_findim_le' h_le h_findim.le
 end finite_dimensional
 
 end intermediate_field
+
+/-- If `L/K` is algebraic, the `K`-subalgebras of `L` are all fields.  -/
+def subalgebra_equiv_intermediate_field (alg : algebra.is_algebraic K L) :
+  subalgebra K L ≃ intermediate_field K L :=
+{ to_fun := λ S, S.to_intermediate_field (λ x hx, S.inv_mem_of_algebraic (alg (⟨x, hx⟩ : S))),
+  inv_fun := λ S, S.to_subalgebra,
+  left_inv := λ S, to_subalgebra_to_intermediate_field _ _,
+  right_inv := λ S, to_intermediate_field_to_subalgebra _ _ }
+
+@[simp] lemma mem_subalgebra_equiv_intermediate_field (alg : algebra.is_algebraic K L)
+  {S : subalgebra K L} {x : L} :
+  x ∈ subalgebra_equiv_intermediate_field alg S ↔ x ∈ S :=
+iff.rfl
+
+@[simp] lemma mem_subalgebra_equiv_intermediate_field_symm (alg : algebra.is_algebraic K L)
+  {S : intermediate_field K L} {x : L} :
+  x ∈ (subalgebra_equiv_intermediate_field alg).symm S ↔ x ∈ S :=
+iff.rfl

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -232,6 +232,8 @@ namespace subalgebra
 
 open is_scalar_tower
 
+section semiring
+
 variables (R) {S A} [comm_semiring R] [comm_semiring S] [semiring A]
 variables [algebra R S] [algebra S A] [algebra R A] [is_scalar_tower R S A]
 
@@ -254,6 +256,23 @@ def of_under {R A B : Type*} [comm_semiring R] [comm_semiring A] [semiring B]
   [algebra S B] [is_scalar_tower R S B] (f : U →ₐ[S] B) : S.under U →ₐ[R] B :=
 { commutes' := λ r, (f.commutes (algebra_map R S r)).trans (algebra_map_apply R S B r).symm,
   .. f }
+
+end semiring
+
+section comm_semiring
+
+variables (R) {S A} [comm_semiring R] [comm_semiring S] [comm_semiring A]
+variables [algebra R S] [algebra S A] [algebra R A] [is_scalar_tower R S A]
+
+@[simp] lemma aeval_coe {S : subalgebra R A} {x : S} {p : polynomial R} :
+  polynomial.aeval (x : A) p = polynomial.aeval x p :=
+begin
+  convert (polynomial.hom_eval₂ p (algebra_map R S) (algebra_map S A) x).symm,
+  rw [polynomial.aeval_def, is_scalar_tower.algebra_map_eq R S A],
+  refl
+end
+
+end comm_semiring
 
 end subalgebra
 

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -266,11 +266,7 @@ variables [algebra R S] [algebra S A] [algebra R A] [is_scalar_tower R S A]
 
 @[simp] lemma aeval_coe {S : subalgebra R A} {x : S} {p : polynomial R} :
   polynomial.aeval (x : A) p = polynomial.aeval x p :=
-begin
-  convert (polynomial.hom_eval₂ p (algebra_map R S) (algebra_map S A) x).symm,
-  rw [polynomial.aeval_def, is_scalar_tower.algebra_map_eq R S A],
-  refl
-end
+(algebra_map_aeval R S A x p).symm
 
 end comm_semiring
 


### PR DESCRIPTION
---

I wasn't sure where to put `subalgebra.aeval_coe`, so I decided to put it in `algebra_tower`, so it can use `is_scalar_tower.algebra_map_aeval`.

<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
