### PR TITLE
[Merged by Bors] - feat(src/ring_theory/polynomial/cyclotomic): cyclotomic polynomials

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -157,7 +157,7 @@ Ring Theory:
   Polynomial rings:
     $K[X]$ is a euclidean ring when $K$ is a field: 'polynomial.euclidean_domain'
     irreducible polynomial: 'irreducible'
-    cyclotomic polynomials in $\Q[X]$: ''
+    cyclotomic polynomials in $\Q[X]$: 'ring_theory/polynomial/cyclotomic'
     Eisenstein's criterion: 'polynomial.irreducible_of_eisenstein_criterion'
     polynomial algebra in one or several indeterminates over a commutative ring: 'mv_polynomial'
     roots of a polynomial: 'polynomial.roots'

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -157,7 +157,7 @@ Ring Theory:
   Polynomial rings:
     $K[X]$ is a euclidean ring when $K$ is a field: 'polynomial.euclidean_domain'
     irreducible polynomial: 'irreducible'
-    cyclotomic polynomials in $\Q[X]$: 'ring_theory/polynomial/cyclotomic'
+    cyclotomic polynomials in $\Q[X]$: polynomial.cyclotomic'
     Eisenstein's criterion: 'polynomial.irreducible_of_eisenstein_criterion'
     polynomial algebra in one or several indeterminates over a commutative ring: 'mv_polynomial'
     roots of a polynomial: 'polynomial.roots'

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -93,7 +93,7 @@ lemma cyclotomic'.monic (n : ℕ) (R : Type*) [integral_domain R] : (cyclotomic'
 monic_prod_of_monic _ _ $ λ z hz, monic_X_sub_C _
 
 /-- `cyclotomic' n R` is different from `0`. -/
-lemma cycl'_ne_zero (n : ℕ) (R : Type*) [integral_domain R] : cyclotomic' n R ≠ 0 :=
+lemma cyclotomic'_ne_zero (n : ℕ) (R : Type*) [integral_domain R] : cyclotomic' n R ≠ 0 :=
   monic.ne_zero (cyclotomic'.monic n R)
 
 /-- The natural degree of `cyclotomic' n R` is `totient n` if there is a primitive root of
@@ -115,10 +115,10 @@ end
 /-- The degree of `cyclotomic' n R` is `totient n` if there is a primitive root of unity in `R`. -/
 lemma degree_cyclotomic' {ζ : R} {n : ℕ} (h : is_primitive_root ζ n) :
   (cyclotomic' n R).degree = nat.totient n :=
-by simp only [degree_eq_nat_degree (cycl'_ne_zero n R), nat_deg_of_cyclotomic' h]
+by simp only [degree_eq_nat_degree (cyclotomic'_ne_zero n R), nat_degree_cyclotomic' h]
 
 /-- The roots of `cyclotomic' n R` are the primitive `n`-th roots of unity. -/
-lemma roots_of_cycl (n : ℕ) (R : Type*) [integral_domain R] :
+lemma roots_of_cyclotomic (n : ℕ) (R : Type*) [integral_domain R] :
   (cyclotomic' n R).roots = (primitive_roots n R).val :=
 by { rw cyclotomic', exact roots_prod_X_sub_C (primitive_roots n R) }
 
@@ -144,7 +144,7 @@ begin
 end
 
 /-- `cyclotomic' n K` splits. -/
-lemma cycl_splits (n : ℕ) : splits (ring_hom.id K) (cyclotomic' n K) :=
+lemma cyclotomic'_splits (n : ℕ) : splits (ring_hom.id K) (cyclotomic' n K) :=
 begin
   apply splits_prod (ring_hom.id K),
   intros z hz,
@@ -164,7 +164,7 @@ end
 
 /-- If there is a primitive `n`-th root of unity in `K`, then
 `X ^ n - 1 = ∏ (cyclotomic' i K)`, where `i` divides `n`. -/
-lemma X_pow_sub_one_eq_prod_cycl' {ζ : K} {n : ℕ} (hpos : 0 < n) (h : is_primitive_root ζ n) :
+lemma X_pow_sub_one_eq_prod_cyclotomic' {ζ : K} {n : ℕ} (hpos : 0 < n) (h : is_primitive_root ζ n) :
   X ^ n - 1 = ∏ i in nat.divisors n, cyclotomic' i K :=
 begin
   rw [X_pow_sub_one_eq_prod hpos h],
@@ -188,7 +188,7 @@ end
 lemma cyclotomic'_eq_X_pow_sub_one_div {ζ : K} {n : ℕ} (hpos: 0 < n) (h : is_primitive_root ζ n) :
   cyclotomic' n K = (X ^ n - 1) /ₘ (∏ i in nat.proper_divisors n, cyclotomic' i K) :=
 begin
-  rw [X_pow_sub_one_eq_prod_cycl' hpos h,
+  rw [X_pow_sub_one_eq_prod_cyclotomic' hpos h,
   nat.divisors_eq_proper_divisors_insert_self_of_pos hpos,
   finset.prod_insert nat.proper_divisors.not_self_mem],
   have prod_monic : (∏ i in nat.proper_divisors n, cyclotomic' i K).monic,
@@ -206,7 +206,7 @@ end
 
 /-- If there is a primitive `n`-th root of unity in `K`, then `cyclotomic' n K` comes from a
 polynomial with integer coefficients. -/
-lemma int_coeff_of_cycl {ζ : K} {n : ℕ} (h : is_primitive_root ζ n) :
+lemma int_coeff_of_cyclotomic {ζ : K} {n : ℕ} (h : is_primitive_root ζ n) :
   (∃ (P : polynomial ℤ), map (int.cast_ring_hom K) P = cyclotomic' n K ∧
   P.degree = (cyclotomic' n K).degree ∧ P.monic) :=
 begin
@@ -239,7 +239,7 @@ begin
   let Q₁ : polynomial ℤ := (X ^ k - 1) /ₘ B₁,
   have huniq : 0 + B * cyclotomic' k K = X ^ k - 1 ∧ (0 : polynomial K).degree < B.degree,
   { split,
-    { rw [zero_add, mul_comm, (X_pow_sub_one_eq_prod_cycl' hpos hzeta),
+    { rw [zero_add, mul_comm, (X_pow_sub_one_eq_prod_cyclotomic' hpos hzeta),
       nat.divisors_eq_proper_divisors_insert_self_of_pos hpos],
       simp only [true_and, finset.prod_insert, not_lt, nat.mem_proper_divisors, dvd_refl] },
     rw [degree_zero, bot_lt_iff_ne_bot],
@@ -257,7 +257,7 @@ then `cyclotomic n K` comes from a unique polynomial with integer coefficients. 
 lemma unique_int_coeff_of_cycl [char_zero K] {ζ : K} {n : ℕ+} (h : is_primitive_root ζ n) :
   (∃! (P : polynomial ℤ), map (int.cast_ring_hom K) P = cyclotomic' n K) :=
 begin
-  obtain ⟨P, hP⟩ := int_coeff_of_cycl h,
+  obtain ⟨P, hP⟩ := int_coeff_of_cyclotomic h,
   rw exists_unique,
   use [P, hP.1],
   intros Q hQ,
@@ -271,21 +271,17 @@ end
 
 end field
 
-end cyclotmic'
+end cyclotomic'
 
 section cyclotomic
 
 /-- The `n`-th cyclotomic polynomial with coefficients in `R`. -/
 def cyclotomic (n : ℕ) (R : Type*) [ring R] : polynomial R :=
-begin
-  by_cases hzero : n = 0,
-  exact 1,
-  exact map (int.cast_ring_hom R) (classical.some (int_coeff_of_cycl
-  (complex.is_primitive_root_exp n hzero)))
-end
+if h : n = 0 then 1 else map (int.cast_ring_hom R) (classical.some (int_coeff_of_cyclotomic
+  (complex.is_primitive_root_exp n h)))
 
 lemma int_cyclotomic_rw {n : ℕ} (h : n ≠ 0) :
-  cyclotomic n ℤ = (classical.some (int_coeff_of_cycl (complex.is_primitive_root_exp n h))) :=
+  cyclotomic n ℤ = (classical.some (int_coeff_of_cyclotomic (complex.is_primitive_root_exp n h))) :=
 begin
   simp only [cyclotomic, h, dif_neg, not_false_iff],
   ext i,
@@ -293,7 +289,7 @@ begin
 end
 
 /-- `cyclotomic n R` comes from `cyclotomic n ℤ`. -/
-lemma cycl_from_int_cycl (n : ℕ) (R : Type*) [ring R] :
+lemma cyclotomic_from_int_cyclotomic (n : ℕ) (R : Type*) [ring R] :
   cyclotomic n R = map (int.cast_ring_hom R) (cyclotomic n ℤ) :=
 begin
   by_cases hzero : n = 0,
@@ -308,7 +304,7 @@ begin
   { simp only [hzero, cyclotomic, degree_one, monic_one, cyclotomic'_zero, dif_pos,
   eq_self_iff_true, map_one, and_self] },
   rw int_cyclotomic_rw hzero,
-  exact classical.some_spec (int_coeff_of_cycl (complex.is_primitive_root_exp n hzero))
+  exact classical.some_spec (int_coeff_of_cyclotomic (complex.is_primitive_root_exp n hzero))
 end
 
 lemma int_cyclotomic_unique {n : ℕ} {P : polynomial ℤ} (h : map (int.cast_ring_hom ℂ) P =
@@ -322,10 +318,10 @@ begin
 end
 
 /-- The definition of `cyclotomic n R` commutes with any ring homomorphism. -/
-lemma cyclotomic_of_ring_hom (n : ℕ) {R S : Type*} [ring R] [ring S] (f : R →+* S) :
+lemma map_cyclotomic (n : ℕ) {R S : Type*} [ring R] [ring S] (f : R →+* S) :
   map f (cyclotomic n R) = cyclotomic n S :=
 begin
-  rw [cycl_from_int_cycl n R, cycl_from_int_cycl n S],
+  rw [cyclotomic_from_int_cyclotomic n R, cyclotomic_from_int_cyclotomic n S],
   ext i,
   simp only [coeff_map, ring_hom.eq_int_cast, ring_hom.map_int_cast]
 end
@@ -340,24 +336,24 @@ begin
   have hspec : map (int.cast_ring_hom ℂ) (X - 1) = cyclotomic' 1 ℂ,
   { simp only [cyclotomic'_one, pnat.one_coe, map_X, map_one, map_sub] },
   symmetry,
-  rw [cycl_from_int_cycl, ←(int_cyclotomic_unique hspec)],
+  rw [cyclotomic_from_int_cyclotomic, ←(int_cyclotomic_unique hspec)],
   simp only [map_X, map_one, map_sub]
 end
 
 /-- The second cyclotomic polyomial is `X + 1`. -/
-lemma cyclotomic_two (R : Type*) [ring R] : cyclotomic 2 R = X + 1 :=
+@[simp] lemma cyclotomic_two (R : Type*) [ring R] : cyclotomic 2 R = X + 1 :=
 begin
   have hspec : map (int.cast_ring_hom ℂ) (X + 1) = cyclotomic' 2 ℂ,
   { simp only [cyclotomic'_two ℂ 0 two_ne_zero.symm, map_add, map_X, map_one] },
   symmetry,
-  rw [cycl_from_int_cycl, ←(int_cyclotomic_unique hspec)],
+  rw [cyclotomic_from_int_cyclotomic, ←(int_cyclotomic_unique hspec)],
   simp only [map_add, map_X, map_one]
 end
 
 /-- `cyclotomic n` is monic. -/
 lemma cyclotomic.monic (n : ℕ) (R : Type*) [ring R] : (cyclotomic n R).monic :=
 begin
-  rw cycl_from_int_cycl,
+  rw cyclotomic_from_int_cyclotomic,
   apply monic_map,
   exact (int_cyclotomic_spec n).2.2
 end
@@ -367,31 +363,31 @@ lemma cycl_ne_zero (n : ℕ) (R : Type*) [ring R] [nontrivial R] : cyclotomic n 
 monic.ne_zero (cyclotomic.monic n R)
 
 /-- The degree of `cyclotomic n` is `totient n`. -/
-lemma deg_of_cyclotomic (n : ℕ) (R : Type*) [ring R] [nontrivial R] :
+lemma degree_cyclotomic (n : ℕ) (R : Type*) [ring R] [nontrivial R] :
   (cyclotomic n R).degree = nat.totient n :=
 begin
-  rw cycl_from_int_cycl,
+  rw cyclotomic_from_int_cyclotomic,
   rw degree_map_eq_of_leading_coeff_ne_zero (int.cast_ring_hom R) _,
   { cases n with k,
     { simp only [cyclotomic, degree_one, dif_pos, nat.totient_zero, with_top.coe_zero]},
-    rw [←deg_of_cyclotomic' (complex.is_primitive_root_exp k.succ (nat.succ_ne_zero k))],
+    rw [←degree_cyclotomic' (complex.is_primitive_root_exp k.succ (nat.succ_ne_zero k))],
     exact (int_cyclotomic_spec k.succ).2.1 },
   simp only [(int_cyclotomic_spec n).right.right, ring_hom.eq_int_cast, monic.leading_coeff,
   int.cast_one, ne.def, not_false_iff, one_ne_zero]
 end
 
 /-- The natural degree of `cyclotomic n` is `totient n`. -/
-lemma nat_deg_of_cyclotomic (n : ℕ) (R : Type*) [ring R] [nontrivial R] :
+lemma nat_degree_cyclotomic (n : ℕ) (R : Type*) [ring R] [nontrivial R] :
   (cyclotomic n R).nat_degree = nat.totient n :=
 begin
-  have hdeg := deg_of_cyclotomic n R,
+  have hdeg := degree_cyclotomic n R,
   rw degree_eq_nat_degree (cycl_ne_zero n R) at hdeg,
   norm_cast at hdeg,
   exact hdeg
 end
 
 /-- `X ^ n - 1 = ∏ (cyclotomic i)`, where `i` divides `n`. -/
-lemma X_pow_sub_one_eq_prod_cycl {n : ℕ} (hpos : 0 < n) (R : Type*) [comm_ring R] :
+lemma X_pow_sub_one_eq_prod_cyclotomic {n : ℕ} (hpos : 0 < n) (R : Type*) [comm_ring R] :
   X ^ n - 1 = ∏ i in nat.divisors n, cyclotomic i R :=
 begin
   have integer : X ^ n - 1 = ∏ i in nat.divisors n, cyclotomic i ℤ,
@@ -401,12 +397,13 @@ begin
     apply mapinj,
     rw map_prod (int.cast_ring_hom ℂ) (λ i, cyclotomic i ℤ),
     simp only [int_cyclotomic_spec, map_pow, nat.cast_id, map_X, map_one, ring_hom.coe_of, map_sub],
-    exact X_pow_sub_one_eq_prod_cycl' hpos (complex.is_primitive_root_exp n (ne_of_lt hpos).symm) },
+    exact X_pow_sub_one_eq_prod_cyclotomic' hpos
+    (complex.is_primitive_root_exp n (ne_of_lt hpos).symm) },
   have coerc : X ^ n - 1 = map (int.cast_ring_hom R) (X ^ n - 1),
   { simp only [map_pow, map_X, map_one, map_sub] },
   have h : ∀ i ∈ n.divisors, cyclotomic i R = map (int.cast_ring_hom R) (cyclotomic i ℤ),
   { intros i hi,
-    exact cycl_from_int_cycl i R },
+    exact cyclotomic_from_int_cyclotomic i R },
   rw [finset.prod_congr (refl n.divisors) h, coerc, ←map_prod (int.cast_ring_hom R)
   (λ i, cyclotomic i ℤ), integer]
 end
@@ -416,7 +413,7 @@ end
 lemma cyclotomic_eq_X_pow_sub_one_div {K : Type*} [field K] {n : ℕ} (hpos: 0 < n) :
   cyclotomic n K = (X ^ n - 1) /ₘ (∏ i in nat.proper_divisors n, cyclotomic i K) :=
 begin
-  rw [X_pow_sub_one_eq_prod_cycl hpos,
+  rw [X_pow_sub_one_eq_prod_cyclotomic hpos,
   nat.divisors_eq_proper_divisors_insert_self_of_pos hpos,
   finset.prod_insert nat.proper_divisors.not_self_mem],
   have prod_monic : (∏ i in nat.proper_divisors n, cyclotomic i K).monic,
@@ -433,7 +430,7 @@ begin
 end
 
 /-- If there is a primitive `n`-th root of unity in `K`, then `cyclotomic n K = cyclotomic' n K`. -/
-lemma cycl_eq_cycl' {K : Type*} [field K] {ζ : K} {n : ℕ} (h : is_primitive_root ζ n) :
+lemma cyclotomic_eq_cyclotomic' {K : Type*} [field K] {ζ : K} {n : ℕ} (h : is_primitive_root ζ n) :
   cyclotomic n K = cyclotomic' n K :=
 begin
   revert h ζ,

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -429,10 +429,13 @@ begin
   exact monic.ne_zero prod_monic (degree_eq_bot.1 h)
 end
 
-/-- If there is a primitive `n`-th root of unity in `K`, then `cyclotomic n K = cyclotomic' n K`. -/
-lemma cyclotomic_eq_cyclotomic' {K : Type*} [field K] {ζ : K} {n : ℕ} (h : is_primitive_root ζ n) :
-  cyclotomic n K = cyclotomic' n K :=
+/-- If there is a primitive `n`-th root of unity in `K`, then
+`cyclotomic n K = ∏ μ in primitive_roots n R, (X - C μ)`. In particular,
+`cyclotomic n K = cyclotomic' n K` -/
+lemma cyclotomic_eq_prod_X_sub_primitive_root' {K : Type*} [field K] {ζ : K} {n : ℕ} (h : is_primitive_root ζ n) :
+  cyclotomic n K = ∏ μ in primitive_roots n K, (X - C μ) :=
 begin
+  rw ←cyclotomic',
   revert h ζ,
   apply nat.strong_induction_on n,
   intros k hk z hz,

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -332,9 +332,7 @@ end
 
 /-- The zeroth cyclotomic polyomial is `1`. -/
 @[simp] lemma cyclotomic_zero (R : Type*) [ring R] : cyclotomic 0 R = 1 :=
-begin
-  simp [cyclotomic]
-end
+by simp only [cyclotomic, dif_pos]
 
 /-- The first cyclotomic polyomial is `X - 1`. -/
 @[simp] lemma cyclotomic_one (R : Type*) [ring R] : cyclotomic 1 R = X - 1 :=

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -432,7 +432,7 @@ end
 /-- If there is a primitive `n`-th root of unity in `K`, then
 `cyclotomic n K = ∏ μ in primitive_roots n R, (X - C μ)`. In particular,
 `cyclotomic n K = cyclotomic' n K` -/
-lemma cyclotomic_eq_prod_X_sub_primitive_root' {K : Type*} [field K] {ζ : K} {n : ℕ}
+lemma cyclotomic_eq_prod_X_sub_primitive_roots {K : Type*} [field K] {ζ : K} {n : ℕ}
 (h : is_primitive_root ζ n) : cyclotomic n K = ∏ μ in primitive_roots n K, (X - C μ) :=
 begin
   rw ←cyclotomic',

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -359,7 +359,7 @@ begin
 end
 
 /-- `cyclotomic n R` is different from `0`. -/
-lemma cycl_ne_zero (n : ℕ) (R : Type*) [ring R] [nontrivial R] : cyclotomic n R ≠ 0 :=
+lemma cyclotomic_ne_zero (n : ℕ) (R : Type*) [ring R] [nontrivial R] : cyclotomic n R ≠ 0 :=
 monic.ne_zero (cyclotomic.monic n R)
 
 /-- The degree of `cyclotomic n` is `totient n`. -/

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -163,15 +163,15 @@ begin
 end
 
 /-- If there is a primitive `n`-th root of unity in `K`, then
-`X ^ n - 1 = ∏ (cyclotomic' i K)`, where `i` divides `n`. -/
-lemma X_pow_sub_one_eq_prod_cyclotomic' {ζ : K} {n : ℕ} (hpos : 0 < n) (h : is_primitive_root ζ n) :
-  X ^ n - 1 = ∏ i in nat.divisors n, cyclotomic' i K :=
+`∏ i in nat.divisors n, cyclotomic' i K = X ^ n - 1`. -/
+lemma prod_cyclotomic'_eq_X_pow_sub_one {ζ : K} {n : ℕ} (hpos : 0 < n) (h : is_primitive_root ζ n) :
+  ∏ i in nat.divisors n, cyclotomic' i K = X ^ n - 1 :=
 begin
   rw [X_pow_sub_one_eq_prod hpos h],
   have rwcyc : ∀ i ∈ nat.divisors n, cyclotomic' i K = ∏ μ in primitive_roots i K, (X - C μ),
   { intros i hi,
     simp only [cyclotomic'] },
-  conv_rhs { apply_congr,
+  conv_lhs { apply_congr,
              skip,
              simp [rwcyc, H] },
   rw ← finset.prod_bind,
@@ -188,7 +188,7 @@ end
 lemma cyclotomic'_eq_X_pow_sub_one_div {ζ : K} {n : ℕ} (hpos: 0 < n) (h : is_primitive_root ζ n) :
   cyclotomic' n K = (X ^ n - 1) /ₘ (∏ i in nat.proper_divisors n, cyclotomic' i K) :=
 begin
-  rw [X_pow_sub_one_eq_prod_cyclotomic' hpos h,
+  rw [←prod_cyclotomic'_eq_X_pow_sub_one hpos h,
   nat.divisors_eq_proper_divisors_insert_self_of_pos hpos,
   finset.prod_insert nat.proper_divisors.not_self_mem],
   have prod_monic : (∏ i in nat.proper_divisors n, cyclotomic' i K).monic,
@@ -239,7 +239,7 @@ begin
   let Q₁ : polynomial ℤ := (X ^ k - 1) /ₘ B₁,
   have huniq : 0 + B * cyclotomic' k K = X ^ k - 1 ∧ (0 : polynomial K).degree < B.degree,
   { split,
-    { rw [zero_add, mul_comm, (X_pow_sub_one_eq_prod_cyclotomic' hpos hzeta),
+    { rw [zero_add, mul_comm, ←(prod_cyclotomic'_eq_X_pow_sub_one hpos hzeta),
       nat.divisors_eq_proper_divisors_insert_self_of_pos hpos],
       simp only [true_and, finset.prod_insert, not_lt, nat.mem_proper_divisors, dvd_refl] },
     rw [degree_zero, bot_lt_iff_ne_bot],
@@ -386,18 +386,18 @@ begin
   exact hdeg
 end
 
-/-- `X ^ n - 1 = ∏ (cyclotomic i)`, where `i` divides `n`. -/
-lemma X_pow_sub_one_eq_prod_cyclotomic {n : ℕ} (hpos : 0 < n) (R : Type*) [comm_ring R] :
-  X ^ n - 1 = ∏ i in nat.divisors n, cyclotomic i R :=
+/-- `∏ i in nat.divisors n, cyclotomic i R = X ^ n - 1`. -/
+lemma prod_cyclotomic_eq_X_pow_sub_one {n : ℕ} (hpos : 0 < n) (R : Type*) [comm_ring R] :
+  ∏ i in nat.divisors n, cyclotomic i R = X ^ n - 1 :=
 begin
-  have integer : X ^ n - 1 = ∏ i in nat.divisors n, cyclotomic i ℤ,
+  have integer : ∏ i in nat.divisors n, cyclotomic i ℤ = X ^ n - 1,
   { have mapinj : function.injective (map (int.cast_ring_hom ℂ)),
     { apply map_injective,
       simp only [int.cast_injective, int.coe_cast_ring_hom] },
     apply mapinj,
     rw map_prod (int.cast_ring_hom ℂ) (λ i, cyclotomic i ℤ),
     simp only [int_cyclotomic_spec, map_pow, nat.cast_id, map_X, map_one, ring_hom.coe_of, map_sub],
-    exact X_pow_sub_one_eq_prod_cyclotomic' hpos
+    exact prod_cyclotomic'_eq_X_pow_sub_one hpos
     (complex.is_primitive_root_exp n (ne_of_lt hpos).symm) },
   have coerc : X ^ n - 1 = map (int.cast_ring_hom R) (X ^ n - 1),
   { simp only [map_pow, map_X, map_one, map_sub] },
@@ -413,7 +413,7 @@ end
 lemma cyclotomic_eq_X_pow_sub_one_div {K : Type*} [field K] {n : ℕ} (hpos: 0 < n) :
   cyclotomic n K = (X ^ n - 1) /ₘ (∏ i in nat.proper_divisors n, cyclotomic i K) :=
 begin
-  rw [X_pow_sub_one_eq_prod_cyclotomic hpos,
+  rw [←prod_cyclotomic_eq_X_pow_sub_one hpos,
   nat.divisors_eq_proper_divisors_insert_self_of_pos hpos,
   finset.prod_insert nat.proper_divisors.not_self_mem],
   have prod_monic : (∏ i in nat.proper_divisors n, cyclotomic i K).monic,

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -94,7 +94,7 @@ monic_prod_of_monic _ _ $ λ z hz, monic_X_sub_C _
 
 /-- `cyclotomic' n R` is different from `0`. -/
 lemma cyclotomic'_ne_zero (n : ℕ) (R : Type*) [integral_domain R] : cyclotomic' n R ≠ 0 :=
-  monic.ne_zero (cyclotomic'.monic n R)
+(cyclotomic'.monic n R).ne_zero
 
 /-- The natural degree of `cyclotomic' n R` is `totient n` if there is a primitive root of
 unity in `R`. -/

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -318,7 +318,7 @@ begin
 end
 
 /-- The definition of `cyclotomic n R` commutes with any ring homomorphism. -/
-lemma map_cyclotomic (n : ℕ) {R S : Type*} [ring R] [ring S] (f : R →+* S) :
+@[simp] lemma map_cyclotomic (n : ℕ) {R S : Type*} [ring R] [ring S] (f : R →+* S) :
   map f (cyclotomic n R) = cyclotomic n S :=
 begin
   rw [cyclotomic_from_int_cyclotomic n R, cyclotomic_from_int_cyclotomic n S],

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -290,7 +290,7 @@ end
 
 /-- `cyclotomic n R` comes from `cyclotomic n ℤ`. -/
 lemma map_cyclotomic_int (n : ℕ) (R : Type*) [ring R] :
-  cyclotomic n R = map (int.cast_ring_hom R) (cyclotomic n ℤ) :=
+  map (int.cast_ring_hom R) (cyclotomic n ℤ) = cyclotomic n R :=
 begin
   by_cases hzero : n = 0,
   { simp only [hzero, cyclotomic, dif_pos, map_one] },
@@ -321,7 +321,7 @@ end
 @[simp] lemma map_cyclotomic (n : ℕ) {R S : Type*} [ring R] [ring S] (f : R →+* S) :
   map f (cyclotomic n R) = cyclotomic n S :=
 begin
-  rw [cyclotomic_from_int_cyclotomic n R, cyclotomic_from_int_cyclotomic n S],
+  rw [←map_cyclotomic_int n R, ←map_cyclotomic_int n S],
   ext i,
   simp only [coeff_map, ring_hom.eq_int_cast, ring_hom.map_int_cast]
 end
@@ -336,7 +336,7 @@ begin
   have hspec : map (int.cast_ring_hom ℂ) (X - 1) = cyclotomic' 1 ℂ,
   { simp only [cyclotomic'_one, pnat.one_coe, map_X, map_one, map_sub] },
   symmetry,
-  rw [cyclotomic_from_int_cyclotomic, ←(int_cyclotomic_unique hspec)],
+  rw [←map_cyclotomic_int, ←(int_cyclotomic_unique hspec)],
   simp only [map_X, map_one, map_sub]
 end
 
@@ -346,14 +346,14 @@ begin
   have hspec : map (int.cast_ring_hom ℂ) (X + 1) = cyclotomic' 2 ℂ,
   { simp only [cyclotomic'_two ℂ 0 two_ne_zero.symm, map_add, map_X, map_one] },
   symmetry,
-  rw [cyclotomic_from_int_cyclotomic, ←(int_cyclotomic_unique hspec)],
+  rw [←map_cyclotomic_int, ←(int_cyclotomic_unique hspec)],
   simp only [map_add, map_X, map_one]
 end
 
 /-- `cyclotomic n` is monic. -/
 lemma cyclotomic.monic (n : ℕ) (R : Type*) [ring R] : (cyclotomic n R).monic :=
 begin
-  rw cyclotomic_from_int_cyclotomic,
+  rw ←map_cyclotomic_int,
   apply monic_map,
   exact (int_cyclotomic_spec n).2.2
 end
@@ -366,7 +366,7 @@ monic.ne_zero (cyclotomic.monic n R)
 lemma degree_cyclotomic (n : ℕ) (R : Type*) [ring R] [nontrivial R] :
   (cyclotomic n R).degree = nat.totient n :=
 begin
-  rw cyclotomic_from_int_cyclotomic,
+  rw ←map_cyclotomic_int,
   rw degree_map_eq_of_leading_coeff_ne_zero (int.cast_ring_hom R) _,
   { cases n with k,
     { simp only [cyclotomic, degree_one, dif_pos, nat.totient_zero, with_top.coe_zero]},
@@ -403,7 +403,7 @@ begin
   { simp only [map_pow, map_X, map_one, map_sub] },
   have h : ∀ i ∈ n.divisors, cyclotomic i R = map (int.cast_ring_hom R) (cyclotomic i ℤ),
   { intros i hi,
-    exact cyclotomic_from_int_cyclotomic i R },
+    exact (map_cyclotomic_int i R).symm },
   rw [finset.prod_congr (refl n.divisors) h, coerc, ←map_prod (int.cast_ring_hom R)
   (λ i, cyclotomic i ℤ), integer]
 end

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -433,7 +433,8 @@ end
 `cyclotomic n K = ∏ μ in primitive_roots n R, (X - C μ)`. In particular,
 `cyclotomic n K = cyclotomic' n K` -/
 lemma cyclotomic_eq_prod_X_sub_primitive_roots {K : Type*} [field K] {ζ : K} {n : ℕ}
-(h : is_primitive_root ζ n) : cyclotomic n K = ∏ μ in primitive_roots n K, (X - C μ) :=
+  (h : is_primitive_root ζ n) :
+  cyclotomic n K = ∏ μ in primitive_roots n K, (X - C μ) :=
 begin
   rw ←cyclotomic',
   revert h ζ,

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -98,7 +98,7 @@ lemma cycl'_ne_zero (n : ℕ) (R : Type*) [integral_domain R] : cyclotomic' n R 
 
 /-- The natural degree of `cyclotomic' n R` is `totient n` if there is a primitive root of
 unity in `R`. -/
-lemma nat_deg_of_cyclotomic' {ζ : R} {n : ℕ} (h : is_primitive_root ζ n) :
+lemma nat_degree_cyclotomic' {ζ : R} {n : ℕ} (h : is_primitive_root ζ n) :
   (cyclotomic' n R).nat_degree = nat.totient n :=
 begin
   cases nat.eq_zero_or_pos n with hzero hpos,

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -1,0 +1,457 @@
+/-
+Copyright (c) 2020 Riccardo Brasca. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Riccardo Brasca
+-/
+
+import field_theory.splitting_field
+import ring_theory.roots_of_unity
+import algebra.polynomial.big_operators
+import number_theory.divisors
+import data.polynomial.lifts
+import analysis.complex.roots_of_unity
+
+/-!
+# Cyclotomic polynomials.
+
+For `n : ℕ` and an integral domain `R`, we define a modified version of the `n`-th cyclotomic
+polynomial with coefficients in `R`, denoted `cyclotomic' n R`, as `∏ (X - μ)`, where `μ` varies
+over the primitive `n`th roots of unity. If there is a primitive `n`th root of unity in `R` then
+this the standard definition. We then define the standard cyclotomic polynomial `cyclotomic n R`
+with coefficients in any ring `R`.
+
+## Main definition
+
+* `cyclotomic n R` : the `n`-th cyclotomic polynomial with coefficients in `R`.
+
+## Main results
+
+* `int_coeff_of_cycl` : If there is a primitive `n`-th root of unity in `K`, then `cyclotomic' n K`
+comes from a polynomial with integer coefficients.
+* `deg_of_cyclotomic` : The degree of `cyclotomic n` is `totient n`.
+* `X_pow_sub_one_eq_prod_cycl` : `X ^ n - 1 = ∏ (cyclotomic i)`, where `i` divides `n`.
+
+## Implementation details
+
+Our definition of `cyclotomic' n R` makes sense in any integral domain `R`, but the interesting
+results hold if there is a primitive `n`th root of unity in `R`. In particular, our definition is
+not the standard one unless there is a primitive `n`th root of unity in `R`. For example,
+`cyclotomic' 3 ℤ = 1`, since there are no primitive cube roots of unity in `ℤ`. The main example is
+`R = ℂ`, we decided to work in general since the difficulties are essentially the same.
+To get the standard cyclotomic polynomials, we use `int_coeff_of_cycl`, with `R = ℂ`, to get a
+polynomial with integer coefficients and then we map it to `polynomial R`, for any ring `R`.
+
+-/
+
+open_locale classical big_operators
+noncomputable theory
+
+universe u
+
+namespace polynomial
+
+section cyclotmic'
+
+section integral_domain
+
+variables {R : Type*} [integral_domain R]
+
+/-- The modified `n`-th cyclotomic polynomial with coefficients in `R`, it is the usual cyclotomic
+polynomial if there is a primitive `n`-th root of unity in `R`. -/
+def cyclotomic' (n : ℕ) (R : Type*) [integral_domain R] : polynomial R :=
+∏ μ in primitive_roots n R, (X - C μ)
+
+/-- The zeroth modified cyclotomic polyomial is `1`. -/
+@[simp] lemma cyclotomic'_zero (R : Type*) [integral_domain R] : cyclotomic' 0 R = 1 :=
+by simp only [cyclotomic', finset.prod_empty, is_primitive_root.primitive_roots_zero]
+
+/-- The first modified cyclotomic polyomial is `X - 1`. -/
+@[simp] lemma cyclotomic'_one (R : Type*) [integral_domain R] : cyclotomic' 1 R = X - 1 :=
+begin
+  simp only [cyclotomic', finset.prod_singleton, ring_hom.map_one,
+  is_primitive_root.primitive_roots_one]
+end
+
+/-- The second modified cyclotomic polyomial is `X + 1` if the characteristic of `R` is not `2`. -/
+@[simp] lemma cyclotomic'_two (R : Type*) [integral_domain R] (p : ℕ) [char_p R p] (hp : p ≠ 2) :
+  cyclotomic' 2 R = X + 1 :=
+begin
+  rw [cyclotomic'],
+  have prim_root_two : primitive_roots 2 R = {(-1 : R)},
+  { apply finset.eq_singleton_iff_unique_mem.2,
+    split,
+    { simp only [is_primitive_root.neg_one p hp, nat.succ_pos', mem_primitive_roots] },
+    { intros x hx,
+      rw [mem_primitive_roots zero_lt_two] at hx,
+      exact is_primitive_root.eq_neg_one_of_two_right hx } },
+  simp only [prim_root_two, finset.prod_singleton, ring_hom.map_neg, ring_hom.map_one,
+  sub_neg_eq_add]
+end
+
+/-- `cyclotomic' n R` is monic. -/
+lemma cyclotomic'.monic (n : ℕ) (R : Type*) [integral_domain R] : (cyclotomic' n R).monic :=
+monic_prod_of_monic _ _ $ λ z hz, monic_X_sub_C _
+
+/-- `cyclotomic' n R` is different from `0`. -/
+lemma cycl'_ne_zero (n : ℕ) (R : Type*) [integral_domain R] : cyclotomic' n R ≠ 0 :=
+  monic.ne_zero (cyclotomic'.monic n R)
+
+/-- The natural degree of `cyclotomic' n R` is `totient n` if there is a primitive root of
+unity in `R`. -/
+lemma nat_deg_of_cyclotomic' {ζ : R} {n : ℕ} (h : is_primitive_root ζ n) :
+  (cyclotomic' n R).nat_degree = nat.totient n :=
+begin
+  cases nat.eq_zero_or_pos n with hzero hpos,
+  { simp only [hzero, cyclotomic'_zero, nat.totient_zero, nat_degree_one] },
+  rw [cyclotomic'],
+  rw nat_degree_prod (primitive_roots n R) (λ (z : R), (X - C z)),
+  simp only [is_primitive_root.card_primitive_roots h hpos, mul_one,
+  nat_degree_X_sub_C,
+  nat.cast_id, finset.sum_const, nsmul_eq_mul],
+  intros z hz,
+  exact X_sub_C_ne_zero z
+end
+
+/-- The degree of `cyclotomic' n R` is `totient n` if there is a primitive root of unity in `R`. -/
+lemma deg_of_cyclotomic' {ζ : R} {n : ℕ} (h : is_primitive_root ζ n) :
+  (cyclotomic' n R).degree = nat.totient n :=
+by simp only [degree_eq_nat_degree (cycl'_ne_zero n R), nat_deg_of_cyclotomic' h]
+
+/-- The roots of `cyclotomic' n R` are the primitive `n`-th roots of unity. -/
+lemma roots_of_cycl (n : ℕ) (R : Type*) [integral_domain R] :
+  (cyclotomic' n R).roots = (primitive_roots n R).val :=
+by { rw cyclotomic', exact roots_prod_X_sub_C (primitive_roots n R) }
+
+end integral_domain
+
+section field
+
+variables {K : Type*} [field K]
+
+/-- If there is a primitive `n`th root of unity in `K`, then `X ^ n - 1 = ∏ (X - μ)`, where `μ`
+varies over the `n`-th roots of unity. -/
+lemma X_pow_sub_one_eq_prod {ζ : K} {n : ℕ} (hpos : 0 < n) (h : is_primitive_root ζ n) :
+  X ^ n - 1 = ∏ ζ in nth_roots_finset n K, (X - C ζ) :=
+begin
+  rw [nth_roots_finset, ← multiset.to_finset_eq (is_primitive_root.nth_roots_nodup h)],
+  simp only [finset.prod_mk, ring_hom.map_one],
+  rw [nth_roots],
+  have hmonic : (X ^ n - C (1 : K)).monic := monic_X_pow_sub_C (1 : K) (ne_of_lt hpos).symm,
+  symmetry,
+  apply prod_multiset_X_sub_C_of_monic_of_roots_card_eq hmonic,
+  rw [@nat_degree_X_pow_sub_C K _ _ n hpos 1, ← nth_roots],
+  exact is_primitive_root.card_nth_roots h
+end
+
+/-- `cyclotomic' n K` splits. -/
+lemma cycl_splits (n : ℕ) : splits (ring_hom.id K) (cyclotomic' n K) :=
+begin
+  apply splits_prod (ring_hom.id K),
+  intros z hz,
+  simp only [splits_X_sub_C (ring_hom.id K)]
+end
+
+/-- If there is a primitive `n`-th root of unity in `K`, then `X ^ n - 1`splits. -/
+lemma X_pow_sub_one_splits {ζ : K} {n : ℕ} (h : is_primitive_root ζ n) :
+  splits (ring_hom.id K) (X ^ n - C (1 : K)) :=
+begin
+  by_cases hzero : n = 0,
+  { simp only [hzero, ring_hom.map_one, splits_zero, pow_zero, sub_self] },
+  apply (splits_iff_card_roots (X_pow_sub_C_ne_zero (nat.pos_of_ne_zero hzero) (1 : K))).2,
+  rw [← nth_roots, is_primitive_root.card_nth_roots h, nat_degree_X_pow_sub_C],
+  exact nat.pos_of_ne_zero hzero
+end
+
+/-- If there is a primitive `n`-th root of unity in `K`, then
+`X ^ n - 1 = ∏ (cyclotomic' i K)`, where `i` divides `n`. -/
+lemma X_pow_sub_one_eq_prod_cycl' {ζ : K} {n : ℕ} (hpos : 0 < n) (h : is_primitive_root ζ n) :
+  X ^ n - 1 = ∏ i in nat.divisors n, cyclotomic' i K :=
+begin
+  rw [X_pow_sub_one_eq_prod hpos h],
+  have rwcyc : ∀ i ∈ nat.divisors n, cyclotomic' i K = ∏ μ in primitive_roots i K, (X - C μ),
+  { intros i hi,
+    simp only [cyclotomic'] },
+  conv_rhs { apply_congr,
+             skip,
+             simp [rwcyc, H] },
+  rw ← finset.prod_bind,
+  { simp only [is_primitive_root.nth_roots_one_eq_bind_primitive_roots hpos h] },
+  intros x hx y hy hdiff,
+  simp only [nat.mem_divisors, and_true, ne.def, pnat.ne_zero, not_false_iff] at hx hy,
+  refine is_primitive_root.disjoint _ _ hdiff,
+  { exact @nat.pos_of_mem_divisors n x (nat.mem_divisors.2 hx) },
+  { exact @nat.pos_of_mem_divisors n y (nat.mem_divisors.2 hy) }
+end
+
+/-- If there is a primitive `n`-th root of unity in `K`, then
+`cyclotomic' n K = (X ^ k - 1) /ₘ (∏ i in nat.proper_divisors k, cyclotomic' i K)`. -/
+lemma cyclotomic'_eq_X_pow_sub_one_div {ζ : K} {n : ℕ} (hpos: 0 < n) (h : is_primitive_root ζ n) :
+  cyclotomic' n K = (X ^ n - 1) /ₘ (∏ i in nat.proper_divisors n, cyclotomic' i K) :=
+begin
+  rw [X_pow_sub_one_eq_prod_cycl' hpos h,
+  nat.divisors_eq_proper_divisors_insert_self_of_pos hpos,
+  finset.prod_insert nat.proper_divisors.not_self_mem],
+  have prod_monic : (∏ i in nat.proper_divisors n, cyclotomic' i K).monic,
+  { apply monic_prod_of_monic,
+    intros i hi,
+    exact cyclotomic'.monic i K },
+  rw (div_mod_by_monic_unique (cyclotomic' n K) 0 prod_monic _).1,
+  simp only [degree_zero, zero_add],
+  split,
+  { rw mul_comm },
+  rw [bot_lt_iff_ne_bot],
+  intro h,
+  exact monic.ne_zero prod_monic (degree_eq_bot.1 h)
+end
+
+/-- If there is a primitive `n`-th root of unity in `K`, then `cyclotomic' n K` comes from a
+polynomial with integer coefficients. -/
+lemma int_coeff_of_cycl {ζ : K} {n : ℕ} (h : is_primitive_root ζ n) :
+  (∃ (P : polynomial ℤ), map (int.cast_ring_hom K) P = cyclotomic' n K ∧
+  P.degree = (cyclotomic' n K).degree ∧ P.monic) :=
+begin
+  refine lifts_and_degree_eq_and_monic _ (cyclotomic'.monic n K),
+  revert h ζ,
+  apply nat.strong_induction_on n,
+  intros k hk z hzeta,
+  cases nat.eq_zero_or_pos k with hzero hpos,
+  { use 1,
+    simp only [hzero, cyclotomic'_zero, set.mem_univ, subsemiring.coe_top, eq_self_iff_true,
+    map_one, ring_hom.coe_of, and_self], },
+  by_cases hone : k = 1,
+  { use X - 1,
+    simp only [hone, cyclotomic'_one K, set.mem_univ, pnat.one_coe, subsemiring.coe_top,
+    eq_self_iff_true, map_X, map_one, ring_hom.coe_of, and_self, map_sub] },
+  let B : polynomial K := ∏ i in nat.proper_divisors k, cyclotomic' i K,
+  have Bmo : B.monic,
+  { apply monic_prod_of_monic,
+    intros i hi,
+    exact (cyclotomic'.monic i K) },
+  have Bint : B ∈ lifts (int.cast_ring_hom K),
+  { refine subsemiring.prod_mem (lifts (int.cast_ring_hom K)) _,
+    intros x hx,
+    have xsmall := (nat.mem_proper_divisors.1 hx).2,
+    obtain ⟨d, hd⟩ := (nat.mem_proper_divisors.1 hx).1,
+    rw [mul_comm] at hd,
+  exact hk x xsmall (is_primitive_root.pow hpos hzeta hd) },
+  replace Bint := lifts_and_degree_eq_and_monic Bint Bmo,
+  obtain ⟨B₁, hB₁, hB₁deg, hB₁mo⟩ := Bint,
+  let Q₁ : polynomial ℤ := (X ^ k - 1) /ₘ B₁,
+  have huniq : 0 + B * cyclotomic' k K = X ^ k - 1 ∧ (0 : polynomial K).degree < B.degree,
+  { split,
+    { rw [zero_add, mul_comm, (X_pow_sub_one_eq_prod_cycl' hpos hzeta),
+      nat.divisors_eq_proper_divisors_insert_self_of_pos hpos],
+      simp only [true_and, finset.prod_insert, not_lt, nat.mem_proper_divisors, dvd_refl] },
+    rw [degree_zero, bot_lt_iff_ne_bot],
+    intro habs,
+    exact (monic.ne_zero Bmo) (degree_eq_bot.1 habs) },
+  replace huniq := div_mod_by_monic_unique (cyclotomic' k K) (0 : polynomial K) Bmo huniq,
+  simp only [lifts, ring_hom.coe_of, ring_hom.mem_srange],
+  use Q₁,
+  rw [(map_div_by_monic (int.cast_ring_hom K) hB₁mo), hB₁, ← huniq.1],
+  simp
+end
+
+/-- If `K` is of characteristic `0` and there is a primitive `n`-th root of unity in `K`,
+then `cyclotomic n K` comes from a unique polynomial with integer coefficients. -/
+lemma unique_int_coeff_of_cycl [char_zero K] {ζ : K} {n : ℕ+} (h : is_primitive_root ζ n) :
+  (∃! (P : polynomial ℤ), map (int.cast_ring_hom K) P = cyclotomic' n K) :=
+begin
+  obtain ⟨P, hP⟩ := int_coeff_of_cycl h,
+  rw exists_unique,
+  use [P, hP.1],
+  intros Q hQ,
+  have mapinj : function.injective (map (int.cast_ring_hom K)),
+  { apply map_injective,
+    simp only [int.cast_injective, int.coe_cast_ring_hom] },
+  rw [function.injective] at mapinj,
+  apply mapinj,
+  rw [hP.1, hQ]
+end
+
+end field
+
+end cyclotmic'
+
+section cyclotomic
+
+/-- The `n`-th cyclotomic polynomial with coefficients in `R`. -/
+def cyclotomic (n : ℕ) (R : Type*) [ring R] : polynomial R :=
+begin
+  by_cases hzero : n = 0,
+  exact 1,
+  exact map (int.cast_ring_hom R) (classical.some (int_coeff_of_cycl
+  (complex.is_primitive_root_exp n hzero)))
+end
+
+lemma int_cyclotomic_rw {n : ℕ} (h : n ≠ 0) :
+  cyclotomic n ℤ = (classical.some (int_coeff_of_cycl (complex.is_primitive_root_exp n h))) :=
+begin
+  simp only [cyclotomic, h, dif_neg, not_false_iff],
+  ext i,
+  simp only [coeff_map, int.cast_id, ring_hom.eq_int_cast]
+end
+
+/-- `cyclotomic n R` comes from `cyclotomic n ℤ`. -/
+lemma cycl_from_int_cycl (n : ℕ) (R : Type*) [ring R] :
+  cyclotomic n R = map (int.cast_ring_hom R) (cyclotomic n ℤ) :=
+begin
+  by_cases hzero : n = 0,
+  { simp only [hzero, cyclotomic, dif_pos, map_one] },
+  simp only [cyclotomic, int_cyclotomic_rw, hzero, ne.def, dif_neg, not_false_iff]
+end
+
+lemma int_cyclotomic_spec (n : ℕ) : map (int.cast_ring_hom ℂ) (cyclotomic n ℤ) = cyclotomic' n ℂ ∧
+  (cyclotomic n ℤ).degree = (cyclotomic' n ℂ).degree ∧ (cyclotomic n ℤ).monic  :=
+begin
+  by_cases hzero : n = 0,
+  { simp only [hzero, cyclotomic, degree_one, monic_one, cyclotomic'_zero, dif_pos,
+  eq_self_iff_true, map_one, and_self] },
+  rw int_cyclotomic_rw hzero,
+  exact classical.some_spec (int_coeff_of_cycl (complex.is_primitive_root_exp n hzero))
+end
+
+lemma int_cyclotomic_unique {n : ℕ} {P : polynomial ℤ} (h : map (int.cast_ring_hom ℂ) P =
+  cyclotomic' n ℂ) : P = cyclotomic n ℤ :=
+begin
+  have mapinj : function.injective (map (int.cast_ring_hom ℂ)),
+  { apply map_injective,
+    simp only [int.cast_injective, int.coe_cast_ring_hom] },
+  apply mapinj,
+  rw [h, (int_cyclotomic_spec n).1]
+end
+
+/-- The definition of `cyclotomic n R` commutes with any ring homomorphism. -/
+lemma cyclotomic_of_ring_hom (n : ℕ) {R S : Type*} [ring R] [ring S] (f : R →+* S) :
+  map f (cyclotomic n R) = cyclotomic n S :=
+begin
+  rw [cycl_from_int_cycl n R, cycl_from_int_cycl n S],
+  ext i,
+  simp only [coeff_map, ring_hom.eq_int_cast, ring_hom.map_int_cast]
+end
+
+/-- The zeroth cyclotomic polyomial is `1`. -/
+@[simp] lemma cyclotomic_zero (R : Type*) [ring R] : cyclotomic 0 R = 1 :=
+begin
+  simp [cyclotomic]
+end
+
+/-- The first cyclotomic polyomial is `X - 1`. -/
+@[simp] lemma cyclotomic_one (R : Type*) [ring R] : cyclotomic 1 R = X - 1 :=
+begin
+  have hspec : map (int.cast_ring_hom ℂ) (X - 1) = cyclotomic' 1 ℂ,
+  { simp only [cyclotomic'_one, pnat.one_coe, map_X, map_one, map_sub] },
+  symmetry,
+  rw [cycl_from_int_cycl, ←(int_cyclotomic_unique hspec)],
+  simp only [map_X, map_one, map_sub]
+end
+
+/-- The second cyclotomic polyomial is `X + 1`. -/
+lemma cyclotomic_two (R : Type*) [ring R] : cyclotomic 2 R = X + 1 :=
+begin
+  have hspec : map (int.cast_ring_hom ℂ) (X + 1) = cyclotomic' 2 ℂ,
+  { simp only [cyclotomic'_two ℂ 0 two_ne_zero.symm, map_add, map_X, map_one] },
+  symmetry,
+  rw [cycl_from_int_cycl, ←(int_cyclotomic_unique hspec)],
+  simp only [map_add, map_X, map_one]
+end
+
+/-- `cyclotomic n` is monic. -/
+lemma cyclotomic.monic (n : ℕ) (R : Type*) [ring R] : (cyclotomic n R).monic :=
+begin
+  rw cycl_from_int_cycl,
+  apply monic_map,
+  exact (int_cyclotomic_spec n).2.2
+end
+
+/-- `cyclotomic n R` is different from `0`. -/
+lemma cycl_ne_zero (n : ℕ) (R : Type*) [ring R] [nontrivial R] : cyclotomic n R ≠ 0 :=
+monic.ne_zero (cyclotomic.monic n R)
+
+/-- The degree of `cyclotomic n` is `totient n`. -/
+lemma deg_of_cyclotomic (n : ℕ) (R : Type*) [ring R] [nontrivial R] :
+  (cyclotomic n R).degree = nat.totient n :=
+begin
+  rw cycl_from_int_cycl,
+  rw degree_map_eq_of_leading_coeff_ne_zero (int.cast_ring_hom R) _,
+  { cases n with k,
+    { simp only [cyclotomic, degree_one, dif_pos, nat.totient_zero, with_top.coe_zero]},
+    rw [←deg_of_cyclotomic' (complex.is_primitive_root_exp k.succ (nat.succ_ne_zero k))],
+    exact (int_cyclotomic_spec k.succ).2.1 },
+  simp only [(int_cyclotomic_spec n).right.right, ring_hom.eq_int_cast, monic.leading_coeff,
+  int.cast_one, ne.def, not_false_iff, one_ne_zero]
+end
+
+/-- The natural degree of `cyclotomic n` is `totient n`. -/
+lemma nat_deg_of_cyclotomic (n : ℕ) (R : Type*) [ring R] [nontrivial R] :
+  (cyclotomic n R).nat_degree = nat.totient n :=
+begin
+  have hdeg := deg_of_cyclotomic n R,
+  rw degree_eq_nat_degree (cycl_ne_zero n R) at hdeg,
+  norm_cast at hdeg,
+  exact hdeg
+end
+
+/-- `X ^ n - 1 = ∏ (cyclotomic i)`, where `i` divides `n`. -/
+lemma X_pow_sub_one_eq_prod_cycl {n : ℕ} (hpos : 0 < n) (R : Type*) [comm_ring R] :
+  X ^ n - 1 = ∏ i in nat.divisors n, cyclotomic i R :=
+begin
+  have integer : X ^ n - 1 = ∏ i in nat.divisors n, cyclotomic i ℤ,
+  { have mapinj : function.injective (map (int.cast_ring_hom ℂ)),
+    { apply map_injective,
+      simp only [int.cast_injective, int.coe_cast_ring_hom] },
+    apply mapinj,
+    rw map_prod (int.cast_ring_hom ℂ) (λ i, cyclotomic i ℤ),
+    simp only [int_cyclotomic_spec, map_pow, nat.cast_id, map_X, map_one, ring_hom.coe_of, map_sub],
+    exact X_pow_sub_one_eq_prod_cycl' hpos (complex.is_primitive_root_exp n (ne_of_lt hpos).symm) },
+  have coerc : X ^ n - 1 = map (int.cast_ring_hom R) (X ^ n - 1),
+  { simp only [map_pow, map_X, map_one, map_sub] },
+  have h : ∀ i ∈ n.divisors, cyclotomic i R = map (int.cast_ring_hom R) (cyclotomic i ℤ),
+  { intros i hi,
+    exact cycl_from_int_cycl i R },
+  rw [finset.prod_congr (refl n.divisors) h, coerc, ←map_prod (int.cast_ring_hom R)
+  (λ i, cyclotomic i ℤ), integer]
+end
+
+/-- We have
+`cyclotomic n K = (X ^ k - 1) /ₘ (∏ i in nat.proper_divisors k, cyclotomic i K)`. -/
+lemma cyclotomic_eq_X_pow_sub_one_div {K : Type*} [field K] {n : ℕ} (hpos: 0 < n) :
+  cyclotomic n K = (X ^ n - 1) /ₘ (∏ i in nat.proper_divisors n, cyclotomic i K) :=
+begin
+  rw [X_pow_sub_one_eq_prod_cycl hpos,
+  nat.divisors_eq_proper_divisors_insert_self_of_pos hpos,
+  finset.prod_insert nat.proper_divisors.not_self_mem],
+  have prod_monic : (∏ i in nat.proper_divisors n, cyclotomic i K).monic,
+  { apply monic_prod_of_monic,
+    intros i hi,
+    exact cyclotomic.monic i K },
+  rw (div_mod_by_monic_unique (cyclotomic n K) 0 prod_monic _).1,
+  simp only [degree_zero, zero_add],
+  split,
+  { rw mul_comm },
+  rw [bot_lt_iff_ne_bot],
+  intro h,
+  exact monic.ne_zero prod_monic (degree_eq_bot.1 h)
+end
+
+/-- If there is a primitive `n`-th root of unity in `K`, then `cyclotomic n K = cyclotomic' n K`. -/
+lemma cycl_eq_cycl' {K : Type*} [field K] {ζ : K} {n : ℕ} (h : is_primitive_root ζ n) :
+  cyclotomic n K = cyclotomic' n K :=
+begin
+  revert h ζ,
+  apply nat.strong_induction_on n,
+  intros k hk z hz,
+  cases nat.eq_zero_or_pos k with hzero hpos,
+  { simp only [hzero, cyclotomic'_zero, cyclotomic_zero] },
+  have h : ∀ i ∈ k.proper_divisors, cyclotomic i K = cyclotomic' i K,
+  { intros i hi,
+    obtain ⟨d, hd⟩ := (nat.mem_proper_divisors.1 hi).1,
+    rw mul_comm at hd,
+    exact hk i (nat.mem_proper_divisors.1 hi).2 (is_primitive_root.pow hpos hz hd) },
+  rw [cyclotomic_eq_X_pow_sub_one_div hpos, cyclotomic'_eq_X_pow_sub_one_div hpos hz,
+  finset.prod_congr (refl k.proper_divisors) h]
+end
+
+end cyclotomic
+
+end polynomial

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -289,7 +289,7 @@ begin
 end
 
 /-- `cyclotomic n R` comes from `cyclotomic n ℤ`. -/
-lemma cyclotomic_from_int_cyclotomic (n : ℕ) (R : Type*) [ring R] :
+lemma map_cyclotomic_int (n : ℕ) (R : Type*) [ring R] :
   cyclotomic n R = map (int.cast_ring_hom R) (cyclotomic n ℤ) :=
 begin
   by_cases hzero : n = 0,

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -409,18 +409,18 @@ begin
 end
 
 /-- We have
-`cyclotomic n K = (X ^ k - 1) /ₘ (∏ i in nat.proper_divisors k, cyclotomic i K)`. -/
-lemma cyclotomic_eq_X_pow_sub_one_div {K : Type*} [field K] {n : ℕ} (hpos: 0 < n) :
-  cyclotomic n K = (X ^ n - 1) /ₘ (∏ i in nat.proper_divisors n, cyclotomic i K) :=
+`cyclotomic n R = (X ^ k - 1) /ₘ (∏ i in nat.proper_divisors k, cyclotomic i K)`. -/
+lemma cyclotomic_eq_X_pow_sub_one_div {R : Type*} [comm_ring R] [nontrivial R] {n : ℕ}
+  (hpos: 0 < n) : cyclotomic n R = (X ^ n - 1) /ₘ (∏ i in nat.proper_divisors n, cyclotomic i R) :=
 begin
   rw [←prod_cyclotomic_eq_X_pow_sub_one hpos,
   nat.divisors_eq_proper_divisors_insert_self_of_pos hpos,
   finset.prod_insert nat.proper_divisors.not_self_mem],
-  have prod_monic : (∏ i in nat.proper_divisors n, cyclotomic i K).monic,
+  have prod_monic : (∏ i in nat.proper_divisors n, cyclotomic i R).monic,
   { apply monic_prod_of_monic,
     intros i hi,
-    exact cyclotomic.monic i K },
-  rw (div_mod_by_monic_unique (cyclotomic n K) 0 prod_monic _).1,
+    exact cyclotomic.monic i R },
+  rw (div_mod_by_monic_unique (cyclotomic n R) 0 prod_monic _).1,
   simp only [degree_zero, zero_add],
   split,
   { rw mul_comm },
@@ -443,8 +443,8 @@ begin
     obtain ⟨d, hd⟩ := (nat.mem_proper_divisors.1 hi).1,
     rw mul_comm at hd,
     exact hk i (nat.mem_proper_divisors.1 hi).2 (is_primitive_root.pow hpos hz hd) },
-  rw [cyclotomic_eq_X_pow_sub_one_div hpos, cyclotomic'_eq_X_pow_sub_one_div hpos hz,
-  finset.prod_congr (refl k.proper_divisors) h]
+  rw [@cyclotomic_eq_X_pow_sub_one_div _ _ (field.to_nontrivial K) _ hpos,
+  cyclotomic'_eq_X_pow_sub_one_div hpos hz, finset.prod_congr (refl k.proper_divisors) h]
 end
 
 end cyclotomic

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -50,7 +50,7 @@ universe u
 
 namespace polynomial
 
-section cyclotmic'
+section cyclotomic'
 
 section integral_domain
 

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -432,8 +432,8 @@ end
 /-- If there is a primitive `n`-th root of unity in `K`, then
 `cyclotomic n K = ∏ μ in primitive_roots n R, (X - C μ)`. In particular,
 `cyclotomic n K = cyclotomic' n K` -/
-lemma cyclotomic_eq_prod_X_sub_primitive_root' {K : Type*} [field K] {ζ : K} {n : ℕ} (h : is_primitive_root ζ n) :
-  cyclotomic n K = ∏ μ in primitive_roots n K, (X - C μ) :=
+lemma cyclotomic_eq_prod_X_sub_primitive_root' {K : Type*} [field K] {ζ : K} {n : ℕ}
+(h : is_primitive_root ζ n) : cyclotomic n K = ∏ μ in primitive_roots n K, (X - C μ) :=
 begin
   rw ←cyclotomic',
   revert h ζ,

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -113,7 +113,7 @@ begin
 end
 
 /-- The degree of `cyclotomic' n R` is `totient n` if there is a primitive root of unity in `R`. -/
-lemma deg_of_cyclotomic' {ζ : R} {n : ℕ} (h : is_primitive_root ζ n) :
+lemma degree_cyclotomic' {ζ : R} {n : ℕ} (h : is_primitive_root ζ n) :
   (cyclotomic' n R).degree = nat.totient n :=
 by simp only [degree_eq_nat_degree (cycl'_ne_zero n R), nat_deg_of_cyclotomic' h]
 

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -381,7 +381,7 @@ lemma nat_degree_cyclotomic (n : ℕ) (R : Type*) [ring R] [nontrivial R] :
   (cyclotomic n R).nat_degree = nat.totient n :=
 begin
   have hdeg := degree_cyclotomic n R,
-  rw degree_eq_nat_degree (cycl_ne_zero n R) at hdeg,
+  rw degree_eq_nat_degree (cyclotomic_ne_zero n R) at hdeg,
   norm_cast at hdeg,
   exact hdeg
 end

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -381,7 +381,7 @@ begin
     multiset.zero_subset, nth_roots_zero]
 end
 
-@[simp] lemma primitive_root_one : primitive_roots 1 R = {(1 : R)} :=
+@[simp] lemma primitive_roots_one : primitive_roots 1 R = {(1 : R)} :=
 begin
   apply finset.eq_singleton_iff_unique_mem.2,
   split,


### PR DESCRIPTION
I have added some basic results about cyclotomic polynomials. I defined them as the polynomial, with integer coefficients, that lifts the complex polynomial ∏ μ in primitive_roots n ℂ, (X - C μ). I proved that the degree of cyclotomic n is totient n and the product formula for X ^ n - 1. I plan to prove the irreducibility in the near future.

This was in [4869](https://github.com/leanprover-community/mathlib/pull/4869) before I splitted that PR. Compared to it, I added the definition of `cyclotomic n R` for any ring `R` (still using the polynomial with coefficients in `ℤ`) and some easy lemmas, especially `cyclotomic_of_ring_hom`, `cyclotomic'_eq_X_pow_sub_one_div` `cyclotomic_eq_X_pow_sub_one_div`, and `cycl_eq_cycl'`.