### PR TITLE
[Merged by Bors] - feat(category_theory/limits/preserves): instances for composition preserving limits

### DIFF
--- a/src/category_theory/limits/preserves/basic.lean
+++ b/src/category_theory/limits/preserves/basic.lean
@@ -120,9 +120,27 @@ instance comp_preserves_limit [preserves_limit K F] [preserves_limit (K ⋙ F) G
   preserves_limit K (F ⋙ G) :=
 ⟨λ c h, preserves_limit.preserves (preserves_limit.preserves h)⟩
 
+instance comp_preserves_limits_of_shape
+  [preserves_limits_of_shape J F] [preserves_limits_of_shape J G] :
+  preserves_limits_of_shape J (F ⋙ G) :=
+{ preserves_limit := λ K, infer_instance }
+
+instance comp_preserves_limits [preserves_limits F] [preserves_limits G] :
+  preserves_limits (F ⋙ G) :=
+{ preserves_limits_of_shape := λ J 𝒥₁, infer_instance }
+
 instance comp_preserves_colimit [preserves_colimit K F] [preserves_colimit (K ⋙ F) G] :
   preserves_colimit K (F ⋙ G) :=
 ⟨λ c h, preserves_colimit.preserves (preserves_colimit.preserves h)⟩
+
+instance comp_preserves_colimits_of_shape
+  [preserves_colimits_of_shape J F] [preserves_colimits_of_shape J G] :
+  preserves_colimits_of_shape J (F ⋙ G) :=
+{ preserves_colimit := λ K, infer_instance }
+
+instance comp_preserves_colimits [preserves_colimits F] [preserves_colimits G] :
+  preserves_colimits (F ⋙ G) :=
+{ preserves_colimits_of_shape := λ J 𝒥₁, infer_instance }
 
 end
 
@@ -295,9 +313,27 @@ instance comp_reflects_limit [reflects_limit K F] [reflects_limit (K ⋙ F) G] :
   reflects_limit K (F ⋙ G) :=
 ⟨λ c h, reflects_limit.reflects (reflects_limit.reflects h)⟩
 
+instance comp_reflects_limits_of_shape
+  [reflects_limits_of_shape J F] [reflects_limits_of_shape J G] :
+  reflects_limits_of_shape J (F ⋙ G) :=
+{ reflects_limit := λ K, infer_instance }
+
+instance comp_reflects_limits [reflects_limits F] [reflects_limits G] :
+  reflects_limits (F ⋙ G) :=
+{ reflects_limits_of_shape := λ J 𝒥₁, infer_instance }
+
 instance comp_reflects_colimit [reflects_colimit K F] [reflects_colimit (K ⋙ F) G] :
   reflects_colimit K (F ⋙ G) :=
 ⟨λ c h, reflects_colimit.reflects (reflects_colimit.reflects h)⟩
+
+instance comp_reflects_colimits_of_shape
+  [reflects_colimits_of_shape J F] [reflects_colimits_of_shape J G] :
+  reflects_colimits_of_shape J (F ⋙ G) :=
+{ reflects_colimit := λ K, infer_instance }
+
+instance comp_reflects_colimits [reflects_colimits F] [reflects_colimits G] :
+  reflects_colimits (F ⋙ G) :=
+{ reflects_colimits_of_shape := λ J 𝒥₁, infer_instance }
 
 /-- If `F ⋙ G` preserves limits for `K`, and `G` reflects limits for `K ⋙ F`,
 then `F` preserves limits for `K`. -/


### PR DESCRIPTION
A couple of quick instances. I'm pretty sure these instances don't cause clashes since they're for subsingleton classes, and they shouldn't cause loops since they're just other versions of instances already there.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
