### PR TITLE
[Merged by Bors] - feat(category_theory/limits/preserves): transfer preserving limits through nat iso

### DIFF
--- a/src/category_theory/limits/shapes/constructions/preserve_binary_products.lean
+++ b/src/category_theory/limits/shapes/constructions/preserve_binary_products.lean
@@ -61,7 +61,7 @@ instance preserves_binary_prods_of_prod_comparison_iso [∀ A B, is_iso (prod_co
 { preserves_limit := λ K,
   begin
     haveI := preserves_binary_prod_of_prod_comparison_iso F (K.obj walking_pair.left) (K.obj walking_pair.right),
-    apply preserves_limit_of_iso F (diagram_iso_pair K).symm,
+    apply preserves_limit_of_iso_diagram F (diagram_iso_pair K).symm,
   end }
 
 variables [preserves_limits_of_shape (discrete walking_pair) F]


### PR DESCRIPTION
- Move two defs higher in the file
- Shorten some proofs using newer lemmas
- Show that we can transfer preservation of limits through natural isomorphism in the functor.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
