### PR TITLE
[Merged by Bors] - feat(archive/imo): formalize IMO 1964 problem 1

### DIFF
--- a/archive/imo/imo1964_q1.lean
+++ b/archive/imo/imo1964_q1.lean
@@ -27,7 +27,7 @@ open nat.modeq
 lemma two_pow_three_mul_mod_seven (m : ℕ) : 2 ^ (3 * m) ≡ 1 [MOD 7] :=
 begin
   rw pow_mul,
-  have h : 8 ≡ 1 [MOD 7] := modeq_of_dvd (by {use -1, norm_num } ),
+  have h : 8 ≡ 1 [MOD 7] := modeq_of_dvd (by {use -1, norm_num }),
   convert modeq_pow _ h,
   simp,
 end

--- a/archive/imo/imo1964_q1.lean
+++ b/archive/imo/imo1964_q1.lean
@@ -19,7 +19,7 @@ integers which are a multiple of 3.
 -/
 
 /-!
-## intermediate lemmas
+## Intermediate lemmas
 -/
 
 open nat.modeq

--- a/archive/imo/imo1964_q1.lean
+++ b/archive/imo/imo1964_q1.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2020 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+
+import tactic
+import data.nat.modeq
+
+/-!
+# IMO 1964 Q1
+
+(a) Find all positive integers $n$ for which $2^n-1$ is divisible by $7$.
+
+(b) Prove that there is no positive integer $n$ for which $2^n+1$ is divisible by $7$.
+
+We define part (a) as a predicate, and prove that it is the set of positive
+integers which are a multiple of 3.
+-/
+
+/-!
+## intermediate lemmas
+-/
+
+open nat.modeq
+
+lemma two_pow_mul_three_mod_seven (m : ℕ) : 2 ^ (3 * m) ≡ 1 [MOD 7] :=
+begin
+  rw pow_mul,
+  have h : 8 ≡ 1 [MOD 7] := modeq_of_dvd (by {use -1, norm_num } ),
+  convert modeq_pow h,
+  simp,
+end
+
+lemma two_pow_mul_three_add_one_mod_seven (m : ℕ) : 2 ^ (3 * m + 1) ≡ 2 [MOD 7] :=
+begin
+  rw pow_add,
+  exact modeq_mul (two_pow_mul_three_mod_seven m) (show 2 ^ 1 ≡ 2 [MOD 7], by refl),
+end
+
+lemma two_pow_mul_three_add_two_mod_seven (m : ℕ) : 2 ^ (3 * m + 2) ≡ 4 [MOD 7] :=
+begin
+  rw pow_add,
+  exact modeq_mul (two_pow_mul_three_mod_seven m) (show 2 ^ 2 ≡ 4 [MOD 7], by refl),
+end
+
+/-!
+## the question
+-/
+
+def problem_predicate (n : ℕ) : Prop := 7 ∣ 2 ^ n - 1
+
+lemma aux (n : ℕ) : problem_predicate n ↔ 2 ^ n ≡ 1 [MOD 7] :=
+begin
+  rw nat.modeq.comm,
+  apply (modeq_iff_dvd' _).symm,
+  apply nat.one_le_pow'
+end
+
+theorem imo1964_q1a (n : ℕ) (hn : 0 < n) : problem_predicate n ↔ 3 ∣ n :=
+begin
+  rw aux,
+  split,
+  { intro h,
+    let t := n % 3,
+    rw [(show n = t + 3 * (n / 3), from (nat.mod_add_div n 3).symm), add_comm] at h,
+    have ht : t < 3 := nat.mod_lt _ dec_trivial,
+    interval_cases t with hr; rw hr at h,
+    { exact nat.dvd_of_mod_eq_zero hr },
+    { exfalso,
+      have nonsense := (two_pow_mul_three_add_one_mod_seven _).symm.trans h,
+      rw modeq_iff_dvd at nonsense,
+      norm_num at nonsense },
+    { exfalso,
+      have nonsense := (two_pow_mul_three_add_two_mod_seven _).symm.trans h,
+      rw modeq_iff_dvd at nonsense,
+      norm_num at nonsense } },
+  { rintro ⟨m, rfl⟩,
+    apply two_pow_mul_three_mod_seven }
+end
+
+theorem imo1964_q1b (n : ℕ) : ¬ (7 ∣ 2 ^ n + 1) :=
+begin
+  let t := n % 3,
+  rw [← modeq_zero_iff, (show n = t + 3 * (n / 3), from (nat.mod_add_div n 3).symm), add_comm],
+  have ht : t < 3 := nat.mod_lt _ dec_trivial,
+  interval_cases t with hr; rw hr,
+  { rw zero_add,
+    intro h,
+    have := h.symm.trans (modeq_add (nat.modeq.refl _) (two_pow_mul_three_mod_seven _)),
+    rw modeq_iff_dvd at this,
+    norm_num at this },
+  { rw add_comm _ (3 * _),
+    intro h,
+    have := h.symm.trans (modeq_add (nat.modeq.refl _) (two_pow_mul_three_add_one_mod_seven _)),
+    rw modeq_iff_dvd at this,
+    norm_num at this },
+  { rw add_comm _ (3 * _),
+    intro h,
+    have := h.symm.trans (modeq_add (nat.modeq.refl _) (two_pow_mul_three_add_two_mod_seven _)),
+    rw modeq_iff_dvd at this,
+    norm_num at this },
+end

--- a/archive/imo/imo1964_q1.lean
+++ b/archive/imo/imo1964_q1.lean
@@ -45,7 +45,7 @@ begin
 end
 
 /-!
-## the question
+## The question
 -/
 
 def problem_predicate (n : ℕ) : Prop := 7 ∣ 2 ^ n - 1

--- a/archive/imo/imo1964_q1.lean
+++ b/archive/imo/imo1964_q1.lean
@@ -14,7 +14,7 @@ import data.nat.modeq
 
 (b) Prove that there is no positive integer $n$ for which $2^n+1$ is divisible by $7$.
 
-We define part (a) as a predicate, and prove that it is the set of positive
+We define a predicate for the solutions in (a), and prove that it is the set of positive
 integers which are a multiple of 3.
 -/
 
@@ -24,24 +24,24 @@ integers which are a multiple of 3.
 
 open nat.modeq
 
-lemma two_pow_mul_three_mod_seven (m : ℕ) : 2 ^ (3 * m) ≡ 1 [MOD 7] :=
+lemma two_pow_three_mul_mod_seven (m : ℕ) : 2 ^ (3 * m) ≡ 1 [MOD 7] :=
 begin
   rw pow_mul,
   have h : 8 ≡ 1 [MOD 7] := modeq_of_dvd (by {use -1, norm_num } ),
-  convert modeq_pow h,
+  convert modeq_pow _ h,
   simp,
 end
 
-lemma two_pow_mul_three_add_one_mod_seven (m : ℕ) : 2 ^ (3 * m + 1) ≡ 2 [MOD 7] :=
+lemma two_pow_three_mul_add_one_mod_seven (m : ℕ) : 2 ^ (3 * m + 1) ≡ 2 [MOD 7] :=
 begin
   rw pow_add,
-  exact modeq_mul (two_pow_mul_three_mod_seven m) (show 2 ^ 1 ≡ 2 [MOD 7], by refl),
+  exact modeq_mul (two_pow_three_mul_mod_seven m) (show 2 ^ 1 ≡ 2 [MOD 7], by refl),
 end
 
-lemma two_pow_mul_three_add_two_mod_seven (m : ℕ) : 2 ^ (3 * m + 2) ≡ 4 [MOD 7] :=
+lemma two_pow_three_mul_add_two_mod_seven (m : ℕ) : 2 ^ (3 * m + 2) ≡ 4 [MOD 7] :=
 begin
   rw pow_add,
-  exact modeq_mul (two_pow_mul_three_mod_seven m) (show 2 ^ 2 ≡ 4 [MOD 7], by refl),
+  exact modeq_mul (two_pow_three_mul_mod_seven m) (show 2 ^ 2 ≡ 4 [MOD 7], by refl),
 end
 
 /-!
@@ -68,15 +68,15 @@ begin
     interval_cases t with hr; rw hr at h,
     { exact nat.dvd_of_mod_eq_zero hr },
     { exfalso,
-      have nonsense := (two_pow_mul_three_add_one_mod_seven _).symm.trans h,
+      have nonsense := (two_pow_three_mul_add_one_mod_seven _).symm.trans h,
       rw modeq_iff_dvd at nonsense,
       norm_num at nonsense },
     { exfalso,
-      have nonsense := (two_pow_mul_three_add_two_mod_seven _).symm.trans h,
+      have nonsense := (two_pow_three_mul_add_two_mod_seven _).symm.trans h,
       rw modeq_iff_dvd at nonsense,
       norm_num at nonsense } },
   { rintro ⟨m, rfl⟩,
-    apply two_pow_mul_three_mod_seven }
+    apply two_pow_three_mul_mod_seven }
 end
 
 theorem imo1964_q1b (n : ℕ) : ¬ (7 ∣ 2 ^ n + 1) :=
@@ -87,17 +87,17 @@ begin
   interval_cases t with hr; rw hr,
   { rw zero_add,
     intro h,
-    have := h.symm.trans (modeq_add (nat.modeq.refl _) (two_pow_mul_three_mod_seven _)),
+    have := h.symm.trans (modeq_add (nat.modeq.refl _) (two_pow_three_mul_mod_seven _)),
     rw modeq_iff_dvd at this,
     norm_num at this },
   { rw add_comm _ (3 * _),
     intro h,
-    have := h.symm.trans (modeq_add (nat.modeq.refl _) (two_pow_mul_three_add_one_mod_seven _)),
+    have := h.symm.trans (modeq_add (nat.modeq.refl _) (two_pow_three_mul_add_one_mod_seven _)),
     rw modeq_iff_dvd at this,
     norm_num at this },
   { rw add_comm _ (3 * _),
     intro h,
-    have := h.symm.trans (modeq_add (nat.modeq.refl _) (two_pow_mul_three_add_two_mod_seven _)),
+    have := h.symm.trans (modeq_add (nat.modeq.refl _) (two_pow_three_mul_add_two_mod_seven _)),
     rw modeq_iff_dvd at this,
     norm_num at this },
 end

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -39,6 +39,8 @@ variables {n m a b c d : ℕ}
 
 @[trans] protected theorem trans : a ≡ b [MOD n] → b ≡ c [MOD n] → a ≡ c [MOD n] := eq.trans
 
+protected theorem comm : a ≡ b [MOD n] ↔ b ≡ a [MOD n] := ⟨nat.modeq.symm, nat.modeq.symm⟩
+
 theorem modeq_zero_iff : a ≡ 0 [MOD n] ↔ n ∣ a :=
 by rw [modeq, zero_mod, dvd_iff_mod_eq_zero]
 
@@ -72,6 +74,13 @@ by rw [mul_comm a, mul_comm b]; exact modeq_mul_left c h
 
 theorem modeq_mul (h₁ : a ≡ b [MOD n]) (h₂ : c ≡ d [MOD n]) : a * c ≡ b * d [MOD n] :=
 (modeq_mul_left _ h₂).trans (modeq_mul_right _ h₁)
+
+theorem modeq_pow {m : ℕ} (h : a ≡ b [MOD n]) : a ^ m ≡ b ^ m [MOD n] :=
+begin
+  induction m with d hd, refl,
+  rw [pow_succ, pow_succ],
+  exact modeq_mul h hd,
+end
 
 theorem modeq_add (h₁ : a ≡ b [MOD n]) (h₂ : c ≡ d [MOD n]) : a + c ≡ b + d [MOD n] :=
 modeq_of_dvd begin

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -75,7 +75,7 @@ by rw [mul_comm a, mul_comm b]; exact modeq_mul_left c h
 theorem modeq_mul (h₁ : a ≡ b [MOD n]) (h₂ : c ≡ d [MOD n]) : a * c ≡ b * d [MOD n] :=
 (modeq_mul_left _ h₂).trans (modeq_mul_right _ h₁)
 
-theorem modeq_pow {m : ℕ} (h : a ≡ b [MOD n]) : a ^ m ≡ b ^ m [MOD n] :=
+theorem modeq_pow (m : ℕ) (h : a ≡ b [MOD n]) : a ^ m ≡ b ^ m [MOD n] :=
 begin
   induction m with d hd, refl,
   rw [pow_succ, pow_succ],

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -77,7 +77,7 @@ theorem modeq_mul (h₁ : a ≡ b [MOD n]) (h₂ : c ≡ d [MOD n]) : a * c ≡ 
 
 theorem modeq_pow (m : ℕ) (h : a ≡ b [MOD n]) : a ^ m ≡ b ^ m [MOD n] :=
 begin
-  induction m with d hd, refl,
+  induction m with d hd, {refl},
   rw [pow_succ, pow_succ],
   exact modeq_mul h hd,
 end


### PR DESCRIPTION
This is an alternative approach to #4369, where progress seems to have stalled. I avoid integers completely by working with `nat.modeq`, and deal with the cases of n mod 3 by simply breaking into three cases.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
