### PR TITLE
[Merged by Bors] - feat(algebra/opposites): Provide semimodule instances and op_linear_equiv

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -327,12 +327,11 @@ namespace opposite
 variables {R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
 
 instance : algebra R Aᵒᵖ :=
-{ smul := λ c x, op (c • unop x),
-  to_ring_hom := (algebra_map R A).to_opposite $ λ x y, algebra.commutes _ _,
-  smul_def' := λ c x, by dsimp; simp only [op_mul, algebra.smul_def, algebra.commutes, op_unop],
-  commutes' := λ r, op_induction $ λ x, by dsimp; simp only [← op_mul, algebra.commutes] }
-
-@[simp] lemma op_smul (c : R) (a : A) : op (c • a) = c • op a := rfl
+{ to_ring_hom := (algebra_map R A).to_opposite $ λ x y, algebra.commutes _ _,
+  smul_def' := λ c x, unop_injective $
+    by { dsimp, simp only [op_mul, algebra.smul_def, algebra.commutes, op_unop] },
+  commutes' := λ r, op_induction $ λ x, by dsimp; simp only [← op_mul, algebra.commutes],
+  ..opposite.has_scalar A R }
 
 @[simp] lemma algebra_map_apply (c : R) : algebra_map R Aᵒᵖ c = op (algebra_map R A c) := rfl
 

--- a/src/algebra/category/Group/limits.lean
+++ b/src/algebra/category/Group/limits.lean
@@ -8,6 +8,7 @@ import algebra.category.Group.preadditive
 import category_theory.over
 import category_theory.limits.concrete_category
 import category_theory.limits.shapes.concrete_category
+import group_theory.subgroup
 
 /-!
 # The category of (commutative) (additive) groups has all limits

--- a/src/algebra/category/Mon/limits.lean
+++ b/src/algebra/category/Mon/limits.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import algebra.group.pi
 import algebra.category.Mon.basic
+import group_theory.submonoid
 import category_theory.limits.types
 import category_theory.limits.creates
 

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -3,9 +3,12 @@ Copyright (c) 2015 Nathaniel Thomas. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
 -/
-import group_theory.group_action
-import tactic.nth_rewrite
+import algebra.big_operators.basic
 import algebra.group.hom
+import algebra.ring.basic
+import data.rat.cast
+import group_theory.group_action.group
+import tactic.nth_rewrite
 
 /-!
 # Modules over a ring

--- a/src/algebra/module/opposites.lean
+++ b/src/algebra/module/opposites.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2020 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import algebra.module.linear_map
+import algebra.opposites
+
+/-!
+# Module operations on `Mᵒᵖ`
+
+This file contains definitions that could not be placed into `algebra.opposites` due to import
+cycles.
+-/
+
+namespace opposite
+universes u v
+
+variables (R : Type u) {M : Type v} [semiring R] [add_comm_monoid M] [semimodule R M]
+
+/-- `opposite.distrib_mul_action` extends to a `semimodule` -/
+instance : semimodule R (opposite M) :=
+{ add_smul := λ r₁ r₂ x, unop_injective $ add_smul r₁ r₂ (unop x),
+  zero_smul := λ x, unop_injective $ zero_smul _ (unop x),
+  ..opposite.distrib_mul_action M R }
+
+/-- The function `op` is a linear equivalence. -/
+def op_linear_equiv : M ≃ₗ[R] Mᵒᵖ :=
+{ map_smul' := opposite.op_smul, .. op_add_equiv }
+
+@[simp] lemma coe_op_linear_equiv :
+  (op_linear_equiv R : M → Mᵒᵖ) = op := rfl
+@[simp] lemma coe_op_linear_equiv_symm :
+  ((op_linear_equiv R).symm : Mᵒᵖ → M) = unop := rfl
+
+@[simp] lemma coe_op_linear_equiv_to_linear_map :
+  ((op_linear_equiv R).to_linear_map : M → Mᵒᵖ) = op := rfl
+@[simp] lemma coe_op_linear_equiv_symm_to_linear_map :
+  ((op_linear_equiv R).symm.to_linear_map : Mᵒᵖ → M) = unop := rfl
+
+@[simp] lemma op_linear_equiv_to_add_equiv :
+  (op_linear_equiv R : M ≃ₗ[R] Mᵒᵖ).to_add_equiv = op_add_equiv := rfl
+@[simp] lemma op_linear_equiv_symm_to_add_equiv :
+  (op_linear_equiv R : M ≃ₗ[R] Mᵒᵖ).symm.to_add_equiv = op_add_equiv.symm := rfl
+
+end opposite

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau
 -/
 import data.opposite
 import algebra.field
+import group_theory.group_action.defs
 import data.equiv.mul_add
 
 /-!
@@ -144,6 +145,20 @@ instance [field α] : field (opposite α) :=
   inv_zero := unop_injective inv_zero,
   .. opposite.comm_ring α, .. opposite.has_inv α, .. opposite.nontrivial α }
 
+instance (R : Type*) [has_scalar R α] : has_scalar R (opposite α) :=
+{ smul := λ c x, op (c • unop x) }
+
+instance (R : Type*) [monoid R] [mul_action R α] : mul_action R (opposite α) :=
+{ one_smul := λ x, unop_injective $ one_smul R (unop x),
+  mul_smul := λ r₁ r₂ x, unop_injective $ mul_smul r₁ r₂ (unop x),
+  ..opposite.has_scalar α R  }
+
+instance (R : Type*) [monoid R] [add_monoid α] [distrib_mul_action R α] :
+  distrib_mul_action R (opposite α) :=
+{ smul_add := λ r x₁ x₂, unop_injective $ smul_add r (unop x₁) (unop x₂),
+  smul_zero := λ r, unop_injective $ smul_zero r,
+  ..opposite.mul_action α R }
+
 @[simp] lemma op_zero [has_zero α] : op (0 : α) = 0 := rfl
 @[simp] lemma unop_zero [has_zero α] : unop (0 : αᵒᵖ) = 0 := rfl
 
@@ -166,6 +181,10 @@ variable {α}
 
 @[simp] lemma op_sub [add_group α] (x y : α) : op (x - y) = op x - op y := rfl
 @[simp] lemma unop_sub [add_group α] (x y : αᵒᵖ) : unop (x - y) = unop x - unop y := rfl
+
+@[simp] lemma op_smul {R : Type*} [has_scalar R α] (c : R) (a : α) : op (c • a) = c • op a := rfl
+@[simp] lemma unop_smul {R : Type*} [has_scalar R α] (c : R) (a : αᵒᵖ) :
+  unop (c • a) = c • unop a := rfl
 
 /-- The function `op` is an additive equivalence. -/
 def op_add_equiv [has_add α] : α ≃+ αᵒᵖ :=

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -5,6 +5,7 @@ Authors: Johan Commelin, Floris van Doorn
 -/
 import algebra.module.basic
 import data.set.finite
+import group_theory.submonoid.basic
 
 /-!
 # Pointwise addition, multiplication, and scalar multiplication of sets.

--- a/src/category_theory/action.lean
+++ b/src/category_theory/action.lean
@@ -5,6 +5,7 @@ Authors: David Wärn
 -/
 import category_theory.elements
 import category_theory.single_obj
+import group_theory.group_action.basic
 
 /-!
 # Actions as functors and as categories

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Scott Morrison
 import algebra.group.pi
 import algebra.big_operators.order
 import algebra.module.basic
+import group_theory.submonoid.basic
 import data.fintype.card
 import data.finset.preimage
 import data.multiset.antidiagonal

--- a/src/group_theory/monoid_localization.lean
+++ b/src/group_theory/monoid_localization.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amelia Livingston
 -/
 import group_theory.congruence
+import group_theory.submonoid
 import algebra.group.units
 import algebra.punit_instances
 


### PR DESCRIPTION
We already have a `has_scalar` definition via an `algebra` definition.

The definition used there satisfies a handful of other typeclasses too, and also allows for `op_add_equiv` to be stated more strongly as `op_linear_equiv`.

This also cuts back the imports a little on `algebra.module.basic`, which means formerly-transitive imports have to be added to downstream files.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->

- [x] depends on: #4936, which adjusts the import order to avoid loops here

This cleans up some imports, which will lead to CI failures until I track down all the missing transitive imports downstream