### PR TITLE
[Merged by Bors] - chore(algebra/direct_limit): Use bundled morphisms

### DIFF
--- a/src/algebra/direct_limit.lean
+++ b/src/algebra/direct_limit.lean
@@ -348,7 +348,7 @@ section
 open_locale classical
 open polynomial
 
-variables (f' : Π i j, i ≤ j → G i →+* G j)
+variables {f' : Π i j, i ≤ j → G i →+* G j}
 
 theorem polynomial.exists_of [nonempty ι] (q : polynomial (direct_limit G (λ i j h, f' i j h))) :
   ∃ i p, polynomial.map (of G (λ i j h, f' i j h) i) p = q :=

--- a/src/algebra/direct_limit.lean
+++ b/src/algebra/direct_limit.lean
@@ -201,47 +201,41 @@ variables [Π i, add_comm_group (G i)]
 include dec_ι
 
 /-- The direct limit of a directed system is the abelian groups glued together along the maps. -/
-def direct_limit (f : Π i j, i ≤ j → G i → G j) [Π i j hij, is_add_group_hom (f i j hij)] : Type* :=
+def direct_limit (f : Π i j, i ≤ j → G i →+ G j) : Type* :=
 @module.direct_limit ℤ _ ι _ _ G _ _
-  (λ i j hij, (add_monoid_hom.of $ f i j hij).to_int_linear_map)
+  (λ i j hij, (f i j hij).to_int_linear_map)
 
 namespace direct_limit
 
-variables (f : Π i j, i ≤ j → G i → G j)
-variables [Π i j hij, is_add_group_hom (f i j hij)]
+variables (f : Π i j, i ≤ j → G i →+ G j)
 
 omit dec_ι
 
-protected lemma directed_system [directed_system G f] :
-  module.directed_system G (λ i j hij, (add_monoid_hom.of $ f i j hij).to_int_linear_map) :=
-⟨directed_system.map_self f, directed_system.map_map f⟩
+protected lemma directed_system [directed_system G (λ i j h, f i j h)] :
+  module.directed_system G (λ i j hij, (f i j hij).to_int_linear_map) :=
+⟨directed_system.map_self (λ i j h, f i j h), directed_system.map_map (λ i j h, f i j h)⟩
 
 include dec_ι
 
 local attribute [instance] direct_limit.directed_system
 
 instance : add_comm_group (direct_limit G f) :=
-module.direct_limit.add_comm_group G (λ i j hij, (add_monoid_hom.of $f i j hij).to_int_linear_map)
+module.direct_limit.add_comm_group G (λ i j hij, (f i j hij).to_int_linear_map)
 
 instance : inhabited (direct_limit G f) := ⟨0⟩
 
 /-- The canonical map from a component to the direct limit. -/
-def of (i) : G i → direct_limit G f :=
-module.direct_limit.of ℤ ι G (λ i j hij, (add_monoid_hom.of $ f i j hij).to_int_linear_map) i
+def of (i) : G i →ₗ[ℤ] direct_limit G f :=
+module.direct_limit.of ℤ ι G (λ i j hij, (f i j hij).to_int_linear_map) i
 variables {G f}
-
-instance of.is_add_group_hom (i) : is_add_group_hom (of G f i) :=
-linear_map.is_add_group_hom _
 
 @[simp] lemma of_f {i j} (hij) (x) : of G f j (f i j hij x) = of G f i x :=
 module.direct_limit.of_f
 
-@[simp] lemma of_zero (i) : of G f i 0 = 0 := is_add_group_hom.map_zero _
-@[simp] lemma of_add (i x y) : of G f i (x + y) = of G f i x + of G f i y :=
-is_add_hom.map_add _ _ _
-@[simp] lemma of_neg (i x) : of G f i (-x) = -of G f i x := is_add_group_hom.map_neg _ _
-@[simp] lemma of_sub (i x y) : of G f i (x - y) = of G f i x - of G f i y :=
-is_add_group_hom.map_sub _ _ _
+@[simp] lemma of_zero (i) : of G f i 0 = 0 := linear_map.map_zero _
+@[simp] lemma of_add (i x y) : of G f i (x + y) = of G f i x + of G f i y := linear_map.map_add _ _ _
+@[simp] lemma of_neg (i x) : of G f i (-x) = -of G f i x := linear_map.map_neg _ _
+@[simp] lemma of_sub (i x y) : of G f i (x - y) = of G f i x - of G f i y := linear_map.map_sub _ _ _
 
 @[elab_as_eliminator]
 protected theorem induction_on [nonempty ι] {C : direct_limit G f → Prop} (z : direct_limit G f)
@@ -250,39 +244,36 @@ module.direct_limit.induction_on z ih
 
 /-- A component that corresponds to zero in the direct limit is already zero in some
 bigger module in the directed system. -/
-theorem of.zero_exact [directed_system G f] (i x) (h : of G f i x = 0) : ∃ j hij, f i j hij x = 0 :=
+theorem of.zero_exact [directed_system G (λ i j h, f i j h)] (i x) (h : of G f i x = 0) : ∃ j hij, f i j hij x = 0 :=
 module.direct_limit.of.zero_exact h
 
 variables (P : Type u₁) [add_comm_group P]
-variables (g : Π i, G i → P) [Π i, is_add_group_hom (g i)]
+variables (g : Π i, G i →+ P)
 variables (Hg : ∀ i j hij x, g j (f i j hij x) = g i x)
 
 variables (G f)
 /-- The universal property of the direct limit: maps from the components to another abelian group
 that respect the directed system structure (i.e. make some diagram commute) give rise
 to a unique map out of the direct limit. -/
-def lift : direct_limit G f → P :=
-module.direct_limit.lift ℤ ι G (λ i j hij, (add_monoid_hom.of $ f i j hij).to_int_linear_map)
-  (λ i, (add_monoid_hom.of $ g i).to_int_linear_map) Hg
+def lift : direct_limit G f →ₗ[ℤ] P :=
+module.direct_limit.lift ℤ ι G (λ i j hij, (f i j hij).to_int_linear_map)
+  (λ i, (g i).to_int_linear_map) Hg
 variables {G f}
-
-instance lift.is_add_group_hom : is_add_group_hom (lift G f P g Hg) :=
-linear_map.is_add_group_hom _
 
 @[simp] lemma lift_of (i x) : lift G f P g Hg (of G f i x) = g i x :=
 module.direct_limit.lift_of _ _ _
 
-@[simp] lemma lift_zero : lift G f P g Hg 0 = 0 := is_add_group_hom.map_zero _
+@[simp] lemma lift_zero : lift G f P g Hg 0 = 0 := linear_map.map_zero _
 @[simp] lemma lift_add (x y) : lift G f P g Hg (x + y) = lift G f P g Hg x + lift G f P g Hg y :=
-is_add_hom.map_add _ _ _
-@[simp] lemma lift_neg (x) : lift G f P g Hg (-x) = -lift G f P g Hg x := is_add_group_hom.map_neg _ _
+linear_map.map_add _ _ _
+@[simp] lemma lift_neg (x) : lift G f P g Hg (-x) = -lift G f P g Hg x := linear_map.map_neg _ _
 @[simp] lemma lift_sub (x y) : lift G f P g Hg (x - y) = lift G f P g Hg x - lift G f P g Hg y :=
-is_add_group_hom.map_sub _ _ _
+linear_map.map_sub _ _ _
 
-lemma lift_unique [nonempty ι] (F : direct_limit G f → P) [is_add_group_hom F] (x) :
-  F x = @lift _ _ _ G _ f _ P _ (λ i x, F $ of G f i x) (λ i, is_add_group_hom.comp _ _)
-    (λ i j hij x, by dsimp; rw of_f) x :=
-direct_limit.induction_on x $ λ i x, by rw lift_of
+lemma lift_unique [nonempty ι] (F : direct_limit G f →+ P) (x) :
+  F x = lift G f P (λ i, F.comp (of G f i).to_add_monoid_hom)
+    (λ i j hij x, by simp) x :=
+direct_limit.induction_on x $ λ i x, by simp
 
 end direct_limit
 
@@ -292,13 +283,16 @@ end add_comm_group
 namespace ring
 
 variables [Π i, comm_ring (G i)]
+
+section
 variables (f : Π i j, i ≤ j → G i → G j)
 
 open free_comm_ring
 
 /-- The direct limit of a directed system is the rings glued together along the maps. -/
 def direct_limit : Type (max v w) :=
-(ideal.span { a | (∃ i j H x, of (⟨j, f i j H x⟩ : Σ i, G i) - of ⟨i, x⟩ = a) ∨
+(ideal.span { a |
+  (∃ i j H x, of (⟨j, f i j H x⟩ : Σ i, G i) - of ⟨i, x⟩ = a) ∨
   (∃ i, of (⟨i, 1⟩ : Σ i, G i) - 1 = a) ∨
   (∃ i x y, of (⟨i, x + y⟩ : Σ i, G i) - (of ⟨i, x⟩ + of ⟨i, y⟩) = a) ∨
   (∃ i x y, of (⟨i, x * y⟩ : Σ i, G i) - (of ⟨i, x⟩ * of ⟨i, y⟩) = a) }).quotient
@@ -314,27 +308,26 @@ comm_ring.to_ring _
 instance : inhabited (direct_limit G f) := ⟨0⟩
 
 /-- The canonical map from a component to the direct limit. -/
-def of (i) (x : G i) : direct_limit G f :=
-ideal.quotient.mk _ (of (⟨i, x⟩ : Σ i, G i))
+def of (i) : G i →+* direct_limit G f :=
+ring_hom.mk'
+{ to_fun := λ x, ideal.quotient.mk _ (of (⟨i, x⟩ : Σ i, G i)),
+  map_one' := ideal.quotient.eq.2 $ subset_span $ or.inr $ or.inl ⟨i, rfl⟩,
+  map_mul' := λ x y, ideal.quotient.eq.2 $ subset_span $ or.inr $ or.inr $ or.inr ⟨i, x, y, rfl⟩, }
+(λ x y, ideal.quotient.eq.2 $ subset_span $ or.inr $ or.inr $ or.inl ⟨i, x, y, rfl⟩)
 
 variables {G f}
-
-instance of.is_ring_hom (i) : is_ring_hom (of G f i) :=
-{ map_one := ideal.quotient.eq.2 $ subset_span $ or.inr $ or.inl ⟨i, rfl⟩,
-  map_mul := λ x y, ideal.quotient.eq.2 $ subset_span $ or.inr $ or.inr $ or.inr ⟨i, x, y, rfl⟩,
-  map_add := λ x y, ideal.quotient.eq.2 $ subset_span $ or.inr $ or.inr $ or.inl ⟨i, x, y, rfl⟩ }
 
 @[simp] lemma of_f {i j} (hij) (x) : of G f j (f i j hij x) = of G f i x :=
 ideal.quotient.eq.2 $ subset_span $ or.inl ⟨i, j, hij, x, rfl⟩
 
-@[simp] lemma of_zero (i) : of G f i 0 = 0 := is_ring_hom.map_zero _
-@[simp] lemma of_one (i) : of G f i 1 = 1 := is_ring_hom.map_one _
-@[simp] lemma of_add (i x y) : of G f i (x + y) = of G f i x + of G f i y := is_ring_hom.map_add _
-@[simp] lemma of_neg (i x) : of G f i (-x) = -of G f i x := is_ring_hom.map_neg _
-@[simp] lemma of_sub (i x y) : of G f i (x - y) = of G f i x - of G f i y := is_ring_hom.map_sub _
-@[simp] lemma of_mul (i x y) : of G f i (x * y) = of G f i x * of G f i y := is_ring_hom.map_mul _
+@[simp] lemma of_zero (i) : of G f i 0 = 0 := ring_hom.map_zero _
+@[simp] lemma of_one (i) : of G f i 1 = 1 := ring_hom.map_one _
+@[simp] lemma of_add (i x y) : of G f i (x + y) = of G f i x + of G f i y := ring_hom.map_add _ _ _
+@[simp] lemma of_neg (i x) : of G f i (-x) = -of G f i x := ring_hom.map_neg _ _
+@[simp] lemma of_sub (i x y) : of G f i (x - y) = of G f i x - of G f i y := ring_hom.map_sub _ _ _
+@[simp] lemma of_mul (i x y) : of G f i (x * y) = of G f i x * of G f i y := ring_hom.map_mul _ _ _
 @[simp] lemma of_pow (i x) (n : ℕ) : of G f i (x ^ n) = of G f i x ^ n :=
-is_monoid_hom.map_pow _ _ _
+ring_hom.map_pow _ _ _
 
 /-- Every element of the direct limit corresponds to some element in
 some component of the directed system. -/
@@ -350,22 +343,23 @@ quotient.induction_on' z $ λ x, free_abelian_group.induction_on x
   (λ p q ⟨i, x, ihx⟩ ⟨j, y, ihy⟩, let ⟨k, hik, hjk⟩ := directed_order.directed i j in
     ⟨k, f i k hik x + f j k hjk y, by rw [of_add, of_f, of_f, ihx, ihy]; refl⟩)
 
+
 section
 open_locale classical
 open polynomial
 
-variables [Π i j hij, is_ring_hom (f i j hij)]
+variables (f' : Π i j, i ≤ j → G i →+* G j)
 
-theorem polynomial.exists_of [nonempty ι] (q : polynomial (direct_limit G f)) :
-  ∃ i p, polynomial.map (ring_hom.of $ of G f i) p = q :=
+theorem polynomial.exists_of [nonempty ι] (q : polynomial (direct_limit G (λ i j h, f' i j h))) :
+  ∃ i p, polynomial.map (of G (λ i j h, f' i j h) i) p = q :=
 polynomial.induction_on q
-  (λ z, let ⟨i, x, h⟩ := exists_of z in ⟨i, C x, by rw [map_C, ring_hom.coe_of, h]⟩)
+  (λ z, let ⟨i, x, h⟩ := exists_of z in ⟨i, C x, by rw [map_C, h]⟩)
   (λ q₁ q₂ ⟨i₁, p₁, ih₁⟩ ⟨i₂, p₂, ih₂⟩, let ⟨i, h1, h2⟩ := directed_order.directed i₁ i₂ in
-    ⟨i, p₁.map (ring_hom.of $ f i₁ i h1) + p₂.map (ring_hom.of $ f i₂ i h2),
+    ⟨i, p₁.map (f' i₁ i h1) + p₂.map (f' i₂ i h2),
      by { rw [polynomial.map_add, map_map, map_map, ← ih₁, ← ih₂],
-      congr' 2; ext x; simp_rw [ring_hom.comp_apply, ring_hom.coe_of, of_f] }⟩)
+      congr' 2; ext x; simp_rw [ring_hom.comp_apply, of_f] }⟩)
   (λ n z ih, let ⟨i, x, h⟩ := exists_of z in ⟨i, C x * X ^ (n + 1),
-    by rw [polynomial.map_mul, map_C, ring_hom.coe_of, h, polynomial.map_pow, map_X]⟩)
+    by rw [polynomial.map_mul, map_C, h, polynomial.map_pow, map_X]⟩)
 
 end
 
@@ -376,57 +370,62 @@ let ⟨i, x, hx⟩ := exists_of z in hx ▸ ih i x
 section of_zero_exact
 open_locale classical
 
-variables [Π i j hij, is_ring_hom (f i j hij)]
-variables [directed_system G f]
+variables (f' : Π i j, i ≤ j → G i →+* G j)
+variables [directed_system G (λ i j h, f' i j h)]
 variables (G f)
 
 lemma of.zero_exact_aux2 {x : free_comm_ring Σ i, G i} {s t} (hxs : is_supported x s) {j k}
   (hj : ∀ z : Σ i, G i, z ∈ s → z.1 ≤ j) (hk : ∀ z : Σ i, G i, z ∈ t → z.1 ≤ k)
   (hjk : j ≤ k) (hst : s ⊆ t) :
-  f j k hjk (lift (λ ix : s, f ix.1.1 j (hj ix ix.2) ix.1.2) (restriction s x)) =
-  lift (λ ix : t, f ix.1.1 k (hk ix ix.2) ix.1.2) (restriction t x) :=
+  f' j k hjk (lift (λ ix : s, f' ix.1.1 j (hj ix ix.2) ix.1.2) (restriction s x)) =
+  lift (λ ix : t, f' ix.1.1 k (hk ix ix.2) ix.1.2) (restriction t x) :=
 begin
   refine ring.in_closure.rec_on hxs _ _ _ _,
-  { rw [(restriction _).map_one, (free_comm_ring.lift _).map_one, is_ring_hom.map_one (f j k hjk),
+  { rw [(restriction _).map_one, (free_comm_ring.lift _).map_one, (f' j k hjk).map_one,
         (restriction _).map_one, (free_comm_ring.lift _).map_one] },
   { rw [(restriction _).map_neg, (restriction _).map_one,
         (free_comm_ring.lift _).map_neg, (free_comm_ring.lift _).map_one,
-        is_ring_hom.map_neg (f j k hjk), is_ring_hom.map_one (f j k hjk),
+        (f' j k hjk).map_neg, (f' j k hjk).map_one,
         (restriction _).map_neg, (restriction _).map_one,
         (free_comm_ring.lift _).map_neg, (free_comm_ring.lift _).map_one] },
   { rintros _ ⟨p, hps, rfl⟩ n ih,
     rw [(restriction _).map_mul, (free_comm_ring.lift _).map_mul,
-        is_ring_hom.map_mul (f j k hjk), ih,
+        (f' j k hjk).map_mul, ih,
         (restriction _).map_mul, (free_comm_ring.lift _).map_mul,
         restriction_of, dif_pos hps, lift_of, restriction_of, dif_pos (hst hps), lift_of],
-    dsimp only, rw directed_system.map_map f, refl },
+    dsimp only,
+    have := directed_system.map_map (λ i j h, f' i j h),
+    dsimp only at this,
+    rw this, refl },
   { rintros x y ihx ihy,
     rw [(restriction _).map_add, (free_comm_ring.lift _).map_add,
-        is_ring_hom.map_add (f j k hjk), ihx, ihy,
+        (f' j k hjk).map_add, ihx, ihy,
         (restriction _).map_add, (free_comm_ring.lift _).map_add] }
 end
-variables {G f}
+variables {G f f'}
 
 lemma of.zero_exact_aux [nonempty ι] {x : free_comm_ring Σ i, G i}
-  (H : ideal.quotient.mk _ x = (0 : direct_limit G f)) :
+  (H : ideal.quotient.mk _ x = (0 : direct_limit G (λ i j h, f' i j h))) :
   ∃ j s, ∃ H : (∀ k : Σ i, G i, k ∈ s → k.1 ≤ j), is_supported x s ∧
-    lift (λ ix : s, f ix.1.1 j (H ix ix.2) ix.1.2) (restriction s x) = (0 : G j) :=
+    lift (λ ix : s, f' ix.1.1 j (H ix ix.2) ix.1.2) (restriction s x) = (0 : G j) :=
 begin
   refine span_induction (ideal.quotient.eq_zero_iff_mem.1 H) _ _ _ _,
   { rintros x (⟨i, j, hij, x, rfl⟩ | ⟨i, rfl⟩ | ⟨i, x, y, rfl⟩ | ⟨i, x, y, rfl⟩),
-    { refine ⟨j, {⟨i, x⟩, ⟨j, f i j hij x⟩}, _,
+    { refine ⟨j, {⟨i, x⟩, ⟨j, f' i j hij x⟩}, _,
         is_supported_sub (is_supported_of.2 $ or.inr rfl) (is_supported_of.2 $ or.inl rfl), _⟩,
       { rintros k (rfl | ⟨rfl | _⟩), exact hij, refl },
       { rw [(restriction _).map_sub, (free_comm_ring.lift _).map_sub,
             restriction_of, dif_pos, restriction_of, dif_pos, lift_of, lift_of],
-        dsimp only, rw directed_system.map_map f, exact sub_self _,
+        dsimp only,
+        have := directed_system.map_map (λ i j h, f' i j h),
+        dsimp only at this,
+        rw this, exact sub_self _,
         exacts [or.inr rfl, or.inl rfl] } },
     { refine ⟨i, {⟨i, 1⟩}, _, is_supported_sub (is_supported_of.2 rfl) is_supported_one, _⟩,
       { rintros k (rfl|h), refl },
       { rw [(restriction _).map_sub, (free_comm_ring.lift _).map_sub, restriction_of, dif_pos,
           (restriction _).map_one, lift_of, (free_comm_ring.lift _).map_one],
-        dsimp only, rw [is_ring_hom.map_one (f i i _), sub_self],
-        { apply_assumption },
+        dsimp only, rw [(f' i i _).map_one, sub_self],
         { exact set.mem_singleton _ } } },
     { refine ⟨i, {⟨i, x+y⟩, ⟨i, x⟩, ⟨i, y⟩}, _,
         is_supported_sub (is_supported_of.2 $ or.inl rfl)
@@ -438,8 +437,8 @@ begin
             dif_pos, dif_pos, dif_pos,
             (free_comm_ring.lift _).map_sub, (free_comm_ring.lift _).map_add,
             lift_of, lift_of, lift_of],
-        dsimp only, rw is_ring_hom.map_add (f i i _), exact sub_self _,
-        exacts [or.inl rfl, by apply_instance, or.inr (or.inr rfl), or.inr (or.inl rfl)] } },
+        dsimp only, rw (f' i i _).map_add, exact sub_self _,
+        exacts [or.inl rfl, or.inr (or.inr rfl), or.inr (or.inl rfl)] } },
     { refine ⟨i, {⟨i, x*y⟩, ⟨i, x⟩, ⟨i, y⟩}, _,
         is_supported_sub (is_supported_of.2 $ or.inl rfl)
           (is_supported_mul (is_supported_of.2 $ or.inr $ or.inl rfl)
@@ -450,8 +449,8 @@ begin
             dif_pos, dif_pos, dif_pos,
             (free_comm_ring.lift _).map_sub, (free_comm_ring.lift _).map_mul,
             lift_of, lift_of, lift_of],
-        dsimp only, rw is_ring_hom.map_mul (f i i _),
-        exacts [sub_self _, or.inl rfl, by apply_instance, or.inr (or.inr rfl),
+        dsimp only, rw (f' i i _).map_mul,
+        exacts [sub_self _, or.inl rfl, or.inr (or.inr rfl),
           or.inr (or.inl rfl)] } } },
   { refine nonempty.elim (by apply_instance) (assume ind : ι, _),
     refine ⟨ind, ∅, λ _, false.elim, is_supported_zero, _⟩,
@@ -463,9 +462,9 @@ begin
     refine ⟨k, s ∪ t, this, is_supported_add (is_supported_upwards hxs $ set.subset_union_left s t)
       (is_supported_upwards hyt $ set.subset_union_right s t), _⟩,
     { rw [(restriction _).map_add, (free_comm_ring.lift _).map_add,
-        ← of.zero_exact_aux2 G f hxs hi this hik (set.subset_union_left s t),
-        ← of.zero_exact_aux2 G f hyt hj this hjk (set.subset_union_right s t),
-        ihs, is_ring_hom.map_zero (f i k hik), iht, is_ring_hom.map_zero (f j k hjk), zero_add] } },
+        ← of.zero_exact_aux2 G f' hxs hi this hik (set.subset_union_left s t),
+        ← of.zero_exact_aux2 G f' hyt hj this hjk (set.subset_union_right s t),
+        ihs, (f' i k hik).map_zero, iht, (f' j k hjk).map_zero, zero_add] } },
   { rintros x y ⟨j, t, hj, hyt, iht⟩, rw smul_eq_mul,
     rcases exists_finset_support x with ⟨s, hxs⟩,
     rcases (s.image sigma.fst).exists_le with ⟨i, hi⟩,
@@ -477,34 +476,36 @@ begin
       (is_supported_upwards hxs $ set.subset_union_left ↑s t)
       (is_supported_upwards hyt $ set.subset_union_right ↑s t), _⟩,
     rw [(restriction _).map_mul, (free_comm_ring.lift _).map_mul,
-        ← of.zero_exact_aux2 G f hyt hj this hjk (set.subset_union_right ↑s t),
-        iht, is_ring_hom.map_zero (f j k hjk), mul_zero] }
+        ← of.zero_exact_aux2 G f' hyt hj this hjk (set.subset_union_right ↑s t),
+        iht, (f' j k hjk).map_zero, mul_zero] }
 end
 
 /-- A component that corresponds to zero in the direct limit is already zero in some
 bigger module in the directed system. -/
-lemma of.zero_exact {i x} (hix : of G f i x = 0) : ∃ j, ∃ hij : i ≤ j, f i j hij x = 0 :=
+lemma of.zero_exact {i x} (hix : of G (λ i j h, f' i j h) i x = 0) : ∃ j, ∃ hij : i ≤ j, f' i j hij x = 0 :=
 by haveI : nonempty ι := ⟨i⟩; exact
 let ⟨j, s, H, hxs, hx⟩ := of.zero_exact_aux hix in
 have hixs : (⟨i, x⟩ : Σ i, G i) ∈ s, from is_supported_of.1 hxs,
 ⟨j, H ⟨i, x⟩ hixs, by rw [restriction_of, dif_pos hixs, lift_of] at hx; exact hx⟩
 end of_zero_exact
 
+variables (f' : Π i j, i ≤ j → G i →+* G j)
+
 /-- If the maps in the directed system are injective, then the canonical maps
 from the components to the direct limits are injective. -/
-theorem of_injective [Π i j hij, is_ring_hom (f i j hij)] [directed_system G f]
-  (hf : ∀ i j hij, function.injective (f i j hij)) (i) :
-  function.injective (of G f i) :=
+theorem of_injective [directed_system G (λ i j h, f' i j h)]
+  (hf : ∀ i j hij, function.injective (f' i j hij)) (i) :
+  function.injective (of G (λ i j h, f' i j h) i) :=
 begin
-  suffices : ∀ x, of G f i x = 0 → x = 0,
+  suffices : ∀ x, of G (λ i j h, f' i j h) i x = 0 → x = 0,
   { intros x y hxy, rw ← sub_eq_zero_iff_eq, apply this,
-    rw [is_ring_hom.map_sub (of G f i), hxy, sub_self] },
+    rw [(of G _ i).map_sub, hxy, sub_self] },
   intros x hx, rcases of.zero_exact hx with ⟨j, hij, hfx⟩,
-  apply hf i j hij, rw [hfx, is_ring_hom.map_zero (f i j hij)]
+  apply hf i j hij, rw [hfx, (f' i j hij).map_zero]
 end
 
 variables (P : Type u₁) [comm_ring P]
-variables (g : Π i, G i → P) [Π i, is_ring_hom (g i)]
+variables (g : Π i, G i →+* P)
 variables (Hg : ∀ i j hij x, g j (f i j hij x) = g i x)
 include Hg
 
@@ -517,7 +518,7 @@ to a unique map out of the direct limit.
 
 We don't use this function as the canonical form because Lean 3 fails to automatically coerce
 it to a function; use `lift` instead. -/
-def lift_hom : direct_limit G f →+* P :=
+def lift : direct_limit G f →+* P :=
 ideal.quotient.lift _ (free_comm_ring.lift $ λ x, g x.1 x.2) begin
   suffices : ideal.span _ ≤
     ideal.comap (free_comm_ring.lift (λ (x : Σ (i : ι), G i), g (x.fst) (x.snd))) ⊥,
@@ -526,39 +527,33 @@ ideal.quotient.lift _ (free_comm_ring.lift $ λ x, g x.1 x.2) begin
   rw [mem_coe, ideal.mem_comap, mem_bot],
   rcases hx with ⟨i, j, hij, x, rfl⟩ | ⟨i, rfl⟩ | ⟨i, x, y, rfl⟩ | ⟨i, x, y, rfl⟩;
   simp only [ring_hom.map_sub, lift_of, Hg, ring_hom.map_one, ring_hom.map_add, ring_hom.map_mul,
-      is_ring_hom.map_one (g i), is_ring_hom.map_add (g i), is_ring_hom.map_mul (g i), sub_self]
+      (g i).map_one, (g i).map_add, (g i).map_mul, sub_self]
 end
-
-/-- The universal property of the direct limit: maps from the components to another ring
-that respect the directed system structure (i.e. make some diagram commute) give rise
-to a unique map out of the direct limit. -/
-def lift : direct_limit G f → P := lift_hom G f P g Hg
-
-instance lift_is_ring_hom : is_ring_hom (lift G f P g Hg) := (lift_hom G f P g Hg).is_ring_hom
 
 variables {G f}
 omit Hg
 
 @[simp] lemma lift_of (i x) : lift G f P g Hg (of G f i x) = g i x := free_comm_ring.lift_of _ _
-@[simp] lemma lift_zero : lift G f P g Hg 0 = 0 := (lift_hom G f P g Hg).map_zero
-@[simp] lemma lift_one : lift G f P g Hg 1 = 1 := (lift_hom G f P g Hg).map_one
+@[simp] lemma lift_zero : lift G f P g Hg 0 = 0 := (lift G f P g Hg).map_zero
+@[simp] lemma lift_one : lift G f P g Hg 1 = 1 := (lift G f P g Hg).map_one
 @[simp] lemma lift_add (x y) : lift G f P g Hg (x + y) = lift G f P g Hg x + lift G f P g Hg y :=
-(lift_hom G f P g Hg).map_add x y
+(lift G f P g Hg).map_add x y
 @[simp] lemma lift_neg (x) : lift G f P g Hg (-x) = -lift G f P g Hg x :=
-(lift_hom G f P g Hg).map_neg x
+(lift G f P g Hg).map_neg x
 @[simp] lemma lift_sub (x y) : lift G f P g Hg (x - y) = lift G f P g Hg x - lift G f P g Hg y :=
-(lift_hom G f P g Hg).map_sub x y
+(lift G f P g Hg).map_sub x y
 @[simp] lemma lift_mul (x y) : lift G f P g Hg (x * y) = lift G f P g Hg x * lift G f P g Hg y :=
-(lift_hom G f P g Hg).map_mul x y
+(lift G f P g Hg).map_mul x y
 @[simp] lemma lift_pow (x) (n : ℕ) : lift G f P g Hg (x ^ n) = lift G f P g Hg x ^ n :=
-(lift_hom G f P g Hg).map_pow x n
+(lift G f P g Hg).map_pow x n
 
-local attribute [instance, priority 100] is_ring_hom.comp
-theorem lift_unique [nonempty ι] (F : direct_limit G f → P) [is_ring_hom F] (x) :
-  F x = lift G f P (λ i x, F $ of G f i x) (λ i j hij x, by rw [of_f]) x :=
-direct_limit.induction_on x $ λ i x, by rw lift_of
+theorem lift_unique [nonempty ι] (F : direct_limit G f →+* P) (x) :
+  F x = lift G f P (λ i, F.comp $ of G f i) (λ i j hij x, by simp) x :=
+direct_limit.induction_on x $ λ i x, by simp
 
 end direct_limit
+
+end
 
 end ring
 
@@ -567,16 +562,17 @@ namespace field
 
 variables [nonempty ι] [Π i, field (G i)]
 variables (f : Π i j, i ≤ j → G i → G j)
+variables (f' : Π i j, i ≤ j → G i →+* G j)
 
 namespace direct_limit
 
-instance nontrivial [Π i j hij, is_ring_hom (f i j hij)] [directed_system G f] :
-  nontrivial (ring.direct_limit G f) :=
+instance nontrivial [directed_system G (λ i j h, f' i j h)] :
+  nontrivial (ring.direct_limit G (λ i j h, f' i j h)) :=
 ⟨⟨0, 1, nonempty.elim (by apply_instance) $ assume i : ι, begin
-  change (0 : ring.direct_limit G f) ≠ 1,
+  change (0 : ring.direct_limit G (λ i j h, f' i j h)) ≠ 1,
   rw ← ring.direct_limit.of_one,
   intros H, rcases ring.direct_limit.of.zero_exact H.symm with ⟨j, hij, hf⟩,
-  rw is_ring_hom.map_one (f i j hij) at hf,
+  rw (f' i j hij).map_one at hf,
   exact one_ne_zero hf
 end ⟩⟩
 
@@ -600,13 +596,13 @@ protected theorem inv_mul_cancel {p : ring.direct_limit G f} (hp : p ≠ 0) : in
 by rw [_root_.mul_comm, direct_limit.mul_inv_cancel G f hp]
 
 /-- Noncomputable field structure on the direct limit of fields. -/
-protected noncomputable def field [Π i j hij, is_ring_hom (f i j hij)] [directed_system G f] :
-  field (ring.direct_limit G f) :=
-{ inv := inv G f,
-  mul_inv_cancel := λ p, direct_limit.mul_inv_cancel G f,
+protected noncomputable def field [directed_system G (λ i j h, f' i j h)] :
+  field (ring.direct_limit G (λ i j h, f' i j h)) :=
+{ inv := inv G (λ i j h, f' i j h),
+  mul_inv_cancel := λ p, direct_limit.mul_inv_cancel G (λ i j h, f' i j h),
   inv_zero := dif_pos rfl,
-  .. ring.direct_limit.comm_ring G f,
-  .. direct_limit.nontrivial G f }
+  .. ring.direct_limit.comm_ring G (λ i j h, f' i j h),
+  .. direct_limit.nontrivial G (λ i j h, f' i j h) }
 
 end
 

--- a/src/algebra/direct_limit.lean
+++ b/src/algebra/direct_limit.lean
@@ -232,11 +232,6 @@ variables {G f}
 @[simp] lemma of_f {i j} (hij) (x) : of G f j (f i j hij x) = of G f i x :=
 module.direct_limit.of_f
 
-@[simp] lemma of_zero (i) : of G f i 0 = 0 := linear_map.map_zero _
-@[simp] lemma of_add (i x y) : of G f i (x + y) = of G f i x + of G f i y := linear_map.map_add _ _ _
-@[simp] lemma of_neg (i x) : of G f i (-x) = -of G f i x := linear_map.map_neg _ _
-@[simp] lemma of_sub (i x y) : of G f i (x - y) = of G f i x - of G f i y := linear_map.map_sub _ _ _
-
 @[elab_as_eliminator]
 protected theorem induction_on [nonempty ι] {C : direct_limit G f → Prop} (z : direct_limit G f)
   (ih : ∀ i x, C (of G f i x)) : C z :=
@@ -262,13 +257,6 @@ variables {G f}
 
 @[simp] lemma lift_of (i x) : lift G f P g Hg (of G f i x) = g i x :=
 module.direct_limit.lift_of _ _ _
-
-@[simp] lemma lift_zero : lift G f P g Hg 0 = 0 := linear_map.map_zero _
-@[simp] lemma lift_add (x y) : lift G f P g Hg (x + y) = lift G f P g Hg x + lift G f P g Hg y :=
-linear_map.map_add _ _ _
-@[simp] lemma lift_neg (x) : lift G f P g Hg (-x) = -lift G f P g Hg x := linear_map.map_neg _ _
-@[simp] lemma lift_sub (x y) : lift G f P g Hg (x - y) = lift G f P g Hg x - lift G f P g Hg y :=
-linear_map.map_sub _ _ _
 
 lemma lift_unique [nonempty ι] (F : direct_limit G f →+ P) (x) :
   F x = lift G f P (λ i, F.comp (of G f i).to_add_monoid_hom)
@@ -320,28 +308,19 @@ variables {G f}
 @[simp] lemma of_f {i j} (hij) (x) : of G f j (f i j hij x) = of G f i x :=
 ideal.quotient.eq.2 $ subset_span $ or.inl ⟨i, j, hij, x, rfl⟩
 
-@[simp] lemma of_zero (i) : of G f i 0 = 0 := ring_hom.map_zero _
-@[simp] lemma of_one (i) : of G f i 1 = 1 := ring_hom.map_one _
-@[simp] lemma of_add (i x y) : of G f i (x + y) = of G f i x + of G f i y := ring_hom.map_add _ _ _
-@[simp] lemma of_neg (i x) : of G f i (-x) = -of G f i x := ring_hom.map_neg _ _
-@[simp] lemma of_sub (i x y) : of G f i (x - y) = of G f i x - of G f i y := ring_hom.map_sub _ _ _
-@[simp] lemma of_mul (i x y) : of G f i (x * y) = of G f i x * of G f i y := ring_hom.map_mul _ _ _
-@[simp] lemma of_pow (i x) (n : ℕ) : of G f i (x ^ n) = of G f i x ^ n :=
-ring_hom.map_pow _ _ _
-
 /-- Every element of the direct limit corresponds to some element in
 some component of the directed system. -/
 theorem exists_of [nonempty ι] (z : direct_limit G f) : ∃ i x, of G f i x = z :=
 nonempty.elim (by apply_instance) $ assume ind : ι,
 quotient.induction_on' z $ λ x, free_abelian_group.induction_on x
-  ⟨ind, 0, of_zero ind⟩
+  ⟨ind, 0, (of _ _ ind).map_zero⟩
   (λ s, multiset.induction_on s
-    ⟨ind, 1, of_one ind⟩
+    ⟨ind, 1, (of _ _ ind).map_one⟩
     (λ a s ih, let ⟨i, x⟩ := a, ⟨j, y, hs⟩ := ih, ⟨k, hik, hjk⟩ := directed_order.directed i j in
-      ⟨k, f i k hik x * f j k hjk y, by rw [of_mul, of_f, of_f, hs]; refl⟩))
-  (λ s ⟨i, x, ih⟩, ⟨i, -x, by rw [of_neg, ih]; refl⟩)
+      ⟨k, f i k hik x * f j k hjk y, by rw [(of _ _ _).map_mul, of_f, of_f, hs]; refl⟩))
+  (λ s ⟨i, x, ih⟩, ⟨i, -x, by rw [(of _ _ _).map_neg, ih]; refl⟩)
   (λ p q ⟨i, x, ihx⟩ ⟨j, y, ihy⟩, let ⟨k, hik, hjk⟩ := directed_order.directed i j in
-    ⟨k, f i k hik x + f j k hjk y, by rw [of_add, of_f, of_f, ihx, ihy]; refl⟩)
+    ⟨k, f i k hik x + f j k hjk y, by rw [(of _ _ _).map_add, of_f, of_f, ihx, ihy]; refl⟩)
 
 
 section
@@ -515,9 +494,7 @@ variables (G f)
 /-- The universal property of the direct limit: maps from the components to another ring
 that respect the directed system structure (i.e. make some diagram commute) give rise
 to a unique map out of the direct limit.
-
-We don't use this function as the canonical form because Lean 3 fails to automatically coerce
-it to a function; use `lift` instead. -/
+-/
 def lift : direct_limit G f →+* P :=
 ideal.quotient.lift _ (free_comm_ring.lift $ λ x, g x.1 x.2) begin
   suffices : ideal.span _ ≤
@@ -534,18 +511,6 @@ variables {G f}
 omit Hg
 
 @[simp] lemma lift_of (i x) : lift G f P g Hg (of G f i x) = g i x := free_comm_ring.lift_of _ _
-@[simp] lemma lift_zero : lift G f P g Hg 0 = 0 := (lift G f P g Hg).map_zero
-@[simp] lemma lift_one : lift G f P g Hg 1 = 1 := (lift G f P g Hg).map_one
-@[simp] lemma lift_add (x y) : lift G f P g Hg (x + y) = lift G f P g Hg x + lift G f P g Hg y :=
-(lift G f P g Hg).map_add x y
-@[simp] lemma lift_neg (x) : lift G f P g Hg (-x) = -lift G f P g Hg x :=
-(lift G f P g Hg).map_neg x
-@[simp] lemma lift_sub (x y) : lift G f P g Hg (x - y) = lift G f P g Hg x - lift G f P g Hg y :=
-(lift G f P g Hg).map_sub x y
-@[simp] lemma lift_mul (x y) : lift G f P g Hg (x * y) = lift G f P g Hg x * lift G f P g Hg y :=
-(lift G f P g Hg).map_mul x y
-@[simp] lemma lift_pow (x) (n : ℕ) : lift G f P g Hg (x ^ n) = lift G f P g Hg x ^ n :=
-(lift G f P g Hg).map_pow x n
 
 theorem lift_unique [nonempty ι] (F : direct_limit G f →+* P) (x) :
   F x = lift G f P (λ i, F.comp $ of G f i) (λ i j hij x, by simp) x :=
@@ -570,7 +535,7 @@ instance nontrivial [directed_system G (λ i j h, f' i j h)] :
   nontrivial (ring.direct_limit G (λ i j h, f' i j h)) :=
 ⟨⟨0, 1, nonempty.elim (by apply_instance) $ assume i : ι, begin
   change (0 : ring.direct_limit G (λ i j h, f' i j h)) ≠ 1,
-  rw ← ring.direct_limit.of_one,
+  rw ← (ring.direct_limit.of _ _ _).map_one,
   intros H, rcases ring.direct_limit.of.zero_exact H.symm with ⟨j, hij, hf⟩,
   rw (f' i j hij).map_one at hf,
   exact one_ne_zero hf
@@ -578,9 +543,9 @@ end ⟩⟩
 
 theorem exists_inv {p : ring.direct_limit G f} : p ≠ 0 → ∃ y, p * y = 1 :=
 ring.direct_limit.induction_on p $ λ i x H,
-⟨ring.direct_limit.of G f i (x⁻¹), by erw [← ring.direct_limit.of_mul,
-    mul_inv_cancel (assume h : x = 0, H $ by rw [h, ring.direct_limit.of_zero]),
-    ring.direct_limit.of_one]⟩
+⟨ring.direct_limit.of G f i (x⁻¹), by erw [← (ring.direct_limit.of _ _ _).map_mul,
+    mul_inv_cancel (assume h : x = 0, H $ by rw [h, (ring.direct_limit.of _ _ _).map_zero]),
+    (ring.direct_limit.of _ _ _).map_one]⟩
 
 section
 open_locale classical


### PR DESCRIPTION
This introduced some ugliness in the form of `(λ i j h, f i j h)`, which is a little unfortunate


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
