### PR TITLE
some suggestions for the prime avoidance proof

### DIFF
--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -505,7 +505,7 @@ begin
 end
 
 theorem is_prime.inf_le' {s : finset ι} {f : ι → ideal R} {P : ideal R} (hp : is_prime P)
-  (hsne: s.nonempty):
+  (hsne: s.nonempty) :
   s.inf f ≤ P ↔ ∃ i ∈ s, f i ≤ P :=
 ⟨λ h, (hp.prod_le hsne).1 $ le_trans prod_le_inf h,
   λ ⟨i, his, hip⟩, le_trans (finset.inf_le his) hip⟩

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -476,16 +476,17 @@ theorem is_prime.inf_le {I J P : ideal R} (hp : is_prime P) :
 ⟨λ h, hp.mul_le.1 $ le_trans mul_le_inf h,
 λ h, or.cases_on h (le_trans inf_le_left) (le_trans inf_le_right)⟩
 
-theorem is_prime.prod_le {s : finset ι} {f : ι → ideal R} {P : ideal R} (hp : is_prime P) (hne: s.nonempty) :
+theorem is_prime.prod_le {s : finset ι} {f : ι → ideal R} {P : ideal R}
+  (hp : is_prime P) (hne: s.nonempty) :
   s.prod f ≤ P ↔ ∃ i ∈ s, f i ≤ P :=
 suffices s.prod f ≤ P → ∃ i ∈ s, f i ≤ P,
   from ⟨this, λ ⟨i, his, hip⟩, le_trans prod_le_inf $ le_trans (finset.inf_le his) hip⟩,
 begin
   classical,
-  rcases hne.bex with ⟨b, hb⟩,
-  have : ∃ t, b ∉ t ∧ s = insert b t := ⟨s.erase b, s.not_mem_erase b, (finset.insert_erase hb).symm⟩,
-  rcases this with ⟨t, hat, rfl⟩,
-  revert hat,
+  obtain ⟨b, hb⟩ : ∃ b, b ∈ s := hne.bex,
+  obtain ⟨t, hbt, rfl⟩ : ∃ t, b ∉ t ∧ s = insert b t,
+  from ⟨s.erase b, s.not_mem_erase b, (finset.insert_erase hb).symm⟩,
+  revert hbt,
   refine t.induction_on _ _,
   { simp only [finset.not_mem_empty, insert_emptyc_eq, exists_prop, finset.prod_singleton,
       imp_self, exists_eq_left, not_false_iff, finset.mem_singleton] },
@@ -499,10 +500,7 @@ begin
   rw finset.insert.comm,
   cases h,
   { exact ⟨a, finset.mem_insert_self a _, h⟩ },
-  have : b ∉ s,
-  { contrapose! hbs,
-    exact finset.mem_insert_of_mem hbs },
-  rcases ih this h with ⟨i, hi, ih⟩,
+  obtain ⟨i, hi, ih⟩ : ∃ i ∈ insert b s, f i ≤ P := ih (mt finset.mem_insert_of_mem hbs) h,
   exact ⟨i, finset.mem_insert_of_mem hi, ih⟩
 end
 

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -527,7 +527,8 @@ suffices (I : set R) ⊆ f a ∪ f b ∪ (⋃ i ∈ (↑s : set ι), f i) → I 
       (set.subset_union_left _ _) (set.subset_union_left _ _)) $
     λ h, or.cases_on h (λ h, set.subset.trans h $ set.subset.trans
       (set.subset_union_right _ _) (set.subset_union_left _ _)) $
-    λ ⟨i, his, hi⟩, by refine (set.subset.trans hi $ set.subset.trans _ $ set.subset_union_right _ _);
+    λ ⟨i, his, hi⟩, by refine (set.subset.trans hi $ set.subset.trans _ $
+        set.subset_union_right _ _);
       exact set.subset_bUnion_of_mem (finset.mem_coe.2 his)⟩,
 begin
   generalize hn : s.card = n, intros h,
@@ -541,10 +542,9 @@ begin
   unfreezingI { rcases hn with ⟨i, t, hit, rfl, hn⟩ },
   replace hp : is_prime (f i) ∧ ∀ x ∈ t, is_prime (f x) := (t.forall_mem_insert _ _).1 hp,
   by_cases Ht : ∃ j ∈ t, f j ≤ f i,
-  { rcases Ht with ⟨j, hjt, hfji⟩,
-    have : ∃ u, j ∉ u ∧ insert j u = t,
+  { obtain ⟨j, hjt, hfji⟩ : ∃ j ∈ t, f j ≤ f i := Ht,
+    obtain ⟨u, hju, rfl⟩ : ∃ u, j ∉ u ∧ insert j u = t,
     { exact ⟨t.erase j, t.not_mem_erase j, finset.insert_erase hjt⟩ },
-    rcases this with ⟨u, hju, rfl⟩,
     have hp' : ∀ k ∈ insert i u, is_prime (f k),
     { rw finset.forall_mem_insert at hp ⊢, exact ⟨hp.1, hp.2.2⟩ },
     have hiu : i ∉ u := mt finset.mem_insert_of_mem hit,

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -613,59 +613,44 @@ suffices (I : set R) ⊆ (⋃ i ∈ (↑s : set ι), f i) → ∃ i, i ∈ s ∧
     show i ∈ (↑s : set ι), from his⟩,
 assume h : (I : set R) ⊆ (⋃ i ∈ (↑s : set ι), f i),
 begin
-  classical,
+  classical, tactic.unfreeze_local_instances,
   by_cases has : a ∈ s,
-  { have : ∃ t, a ∉ t ∧ insert a t = s :=
+  { obtain ⟨t, hat, rfl⟩ : ∃ t, a ∉ t ∧ insert a t = s :=
       ⟨s.erase a, finset.not_mem_erase a s, finset.insert_erase has⟩,
-    unfreezingI { rcases this with ⟨t, hat, rfl⟩ }, by_cases hbt : b ∈ t,
-    { have : ∃ u, b ∉ u ∧ insert b u = t :=
+    by_cases hbt : b ∈ t,
+    { obtain ⟨u, hbu, rfl⟩ : ∃ u, b ∉ u ∧ insert b u = t :=
         ⟨t.erase b, finset.not_mem_erase b t, finset.insert_erase hbt⟩,
-      unfreezingI { rcases this with ⟨u, hbu, rfl⟩ },
       have hp' : ∀ i ∈ u, is_prime (f i),
-      { intros i hiu,
-        have hiabu : i ∈ insert a (insert b u) := finset.mem_insert_of_mem (finset.mem_insert_of_mem hiu),
-        have hia : i ≠ a, { unfreezingI { rintro rfl }, exact hat (finset.mem_insert_of_mem hiu) },
-        have hib : i ≠ b, { unfreezingI { rintro rfl }, exact hbu hiu },
-        exact hp i hiabu hia hib },
+      { intros i hiu, refine hp i (finset.mem_insert_of_mem (finset.mem_insert_of_mem hiu)) _ _;
+        rintro rfl; solve_by_elim only [finset.mem_insert_of_mem, *], },
       rw [finset.coe_insert, finset.coe_insert, set.bUnion_insert, set.bUnion_insert,
           ← set.union_assoc, subset_union_prime' hp', bex_def] at h,
       rwa [finset.exists_mem_insert, finset.exists_mem_insert] },
     { have hp' : ∀ j ∈ t, is_prime (f j),
-      { intros j hjt,
-        have hjat : j ∈ insert a t := finset.mem_insert_of_mem hjt,
-        have hja : j ≠ a, { unfreezingI { rintro rfl }, exact hat hjt },
-        have hjb : j ≠ b, { unfreezingI { rintro rfl }, exact hbt hjt },
-        exact hp j hjat hja hjb },
+      { intros j hj, refine hp j (finset.mem_insert_of_mem hj) _ _;
+        rintro rfl; solve_by_elim only [finset.mem_insert_of_mem, *], },
       rw [finset.coe_insert, set.bUnion_insert, ← set.union_self (f a : set R),
           subset_union_prime' hp', ← or_assoc, or_self, bex_def] at h,
       rwa finset.exists_mem_insert } },
   { by_cases hbs : b ∈ s,
-    { have : ∃ t, b ∉ t ∧ insert b t = s :=
+    { obtain ⟨t, hbt, rfl⟩ : ∃ t, b ∉ t ∧ insert b t = s :=
         ⟨s.erase b, finset.not_mem_erase b s, finset.insert_erase hbs⟩,
-      unfreezingI { rcases this with ⟨t, hbt, rfl⟩ },
       have hp' : ∀ j ∈ t, is_prime (f j),
-      { intros j hjt,
-        have hjbt : j ∈ insert b t := finset.mem_insert_of_mem hjt,
-        have hja : j ≠ a, { unfreezingI { rintro rfl }, exact has (finset.mem_insert_of_mem hjt) },
-        have hjb : j ≠ b, { unfreezingI { rintro rfl }, exact hbt hjt },
-        exact hp j hjbt hja hjb },
+      { intros j hj, refine hp j (finset.mem_insert_of_mem hj) _ _;
+        rintro rfl; solve_by_elim only [finset.mem_insert_of_mem, *], },
       rw [finset.coe_insert, set.bUnion_insert, ← set.union_self (f b : set R),
           subset_union_prime' hp', ← or_assoc, or_self, bex_def] at h,
       rwa finset.exists_mem_insert },
     cases s.eq_empty_or_nonempty with hse hsne,
-    { unfreezingI { subst hse }, rw [finset.coe_empty, set.bUnion_empty, set.subset_empty_iff] at h,
+    { subst hse, rw [finset.coe_empty, set.bUnion_empty, set.subset_empty_iff] at h,
       have : (I : set R) ≠ ∅ := set.nonempty.ne_empty (set.nonempty_of_mem I.zero_mem),
       exact absurd h this },
     { cases hsne.bex with i his,
-      have : ∃ t, i ∉ t ∧ insert i t = s :=
+      obtain ⟨t, hit, rfl⟩ : ∃ t, i ∉ t ∧ insert i t = s :=
         ⟨s.erase i, finset.not_mem_erase i s, finset.insert_erase his⟩,
-      unfreezingI { rcases this with ⟨t, hit, rfl⟩ },
       have hp' : ∀ j ∈ t, is_prime (f j),
-      { intros j hjt,
-        have hjit : j ∈ insert i t := finset.mem_insert_of_mem hjt,
-        have hja : j ≠ a, { unfreezingI { rintro rfl }, exact has (finset.mem_insert_of_mem hjt) },
-        have hjb : j ≠ b, { unfreezingI { rintro rfl }, exact hbs (finset.mem_insert_of_mem hjt) },
-        exact hp j hjit hja hjb },
+      { intros j hj, refine hp j (finset.mem_insert_of_mem hj) _ _;
+        rintro rfl; solve_by_elim only [finset.mem_insert_of_mem, *], },
       rw [finset.coe_insert, set.bUnion_insert, ← set.union_self (f i : set R),
           subset_union_prime' hp', ← or_assoc, or_self, bex_def] at h,
       rwa finset.exists_mem_insert } }

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -251,7 +251,7 @@ noncomputable def quotient_inf_ring_equiv_pi_quotient [fintype ι] (f : ι → i
 end chinese_remainder
 
 section mul_and_radical
-variables {R : Type u} [comm_ring R]
+variables {R : Type u} {ι : Type*} [comm_ring R]
 variables {I J K L: ideal R}
 
 instance : has_mul (ideal R) := ⟨(•)⟩
@@ -304,6 +304,15 @@ by { unfold span, rw [submodule.span_mul_span, set.singleton_mul_singleton],}
 
 theorem mul_le_inf : I * J ≤ I ⊓ J :=
 mul_le.2 $ λ r hri s hsj, ⟨I.mul_mem_right hri, J.mul_mem_left hsj⟩
+
+theorem prod_le_inf {s : finset ι} {f : ι → ideal R} : s.prod f ≤ s.inf f :=
+begin
+  classical, refine s.induction_on _ _,
+  { rw [finset.prod_empty, finset.inf_empty], exact le_top },
+  intros a s has ih,
+  rw [finset.prod_insert has, finset.inf_insert],
+  exact le_trans mul_le_inf (inf_le_inf (le_refl _) ih)
+end
 
 theorem mul_eq_inf_of_coprime (h : I ⊔ J = ⊤) : I * J = I ⊓ J :=
 le_antisymm mul_le_inf $ λ r ⟨hri, hrj⟩,
@@ -466,17 +475,6 @@ theorem is_prime.inf_le {I J P : ideal R} (hp : is_prime P) :
   I ⊓ J ≤ P ↔ I ≤ P ∨ J ≤ P :=
 ⟨λ h, hp.mul_le.1 $ le_trans mul_le_inf h,
 λ h, or.cases_on h (le_trans inf_le_left) (le_trans inf_le_right)⟩
-
-variables {ι : Type v}
-
-theorem prod_le_inf {s : finset ι} {f : ι → ideal R} : s.prod f ≤ s.inf f :=
-begin
-  classical, refine s.induction_on _ _,
-  { rw [finset.prod_empty, finset.inf_empty], exact le_top },
-  intros a s has ih,
-  rw [finset.prod_insert has, finset.inf_insert],
-  exact le_trans mul_le_inf (inf_le_inf (le_refl _) ih)
-end
 
 theorem is_prime.prod_le {s : finset ι} {f : ι → ideal R} {P : ideal R} (hp : is_prime P) (hne: s.nonempty) :
   s.prod f ≤ P ↔ ∃ i ∈ s, f i ≤ P :=


### PR DESCRIPTION
A couple of suggestions:

* the `obtain` tactic can be used to merge `have : foobar, rcases this` combos.
* one proof needed lots of `unfreezingI`. I permanently unfroze local instances at the start of the proof
* the main proof had 4 subproofs that were doing almost the same thing (proving that some family of ideals was a family of prime ideals):
  - I tried extracting this into a lemma, but the side conditions varied all the time (of course).
  - Nevertheless, the side conditions were "trivial to prove". So in the end, I'm using `solve_by_elim` to kill them.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
