### PR TITLE
[Merged by Bors] - feat(measure_theory/borel_space): continuity set of a function is measurable

### DIFF
--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -5,6 +5,8 @@ Authors: Johannes Hölzl, Yury Kudryashov
 -/
 import measure_theory.measure_space
 import analysis.normed_space.finite_dimension
+import topology.G_delta
+
 /-!
 # Borel (measurable) space
 
@@ -172,6 +174,16 @@ lemma is_open.is_measurable (h : is_open s) : is_measurable s :=
 opens_measurable_space.borel_le _ $ generate_measurable.basic _ h
 
 lemma is_measurable_interior : is_measurable (interior s) := is_open_interior.is_measurable
+
+lemma is_Gδ.is_measurable (h : is_Gδ s) : is_measurable s :=
+begin
+  rcases h with ⟨S, hSo, hSc, rfl⟩,
+  exact is_measurable.sInter hSc (λ t ht, (hSo t ht).is_measurable)
+end
+
+lemma is_measurable_set_of_continuous_at {β} [emetric_space β] (f : α → β) :
+  is_measurable {x | continuous_at f x} :=
+(is_Gδ_set_of_continuous_at f).is_measurable
 
 lemma is_closed.is_measurable (h : is_closed s) : is_measurable s :=
 h.is_measurable.of_compl

--- a/src/topology/G_delta.lean
+++ b/src/topology/G_delta.lean
@@ -23,7 +23,8 @@ In this file we define `Gδ` sets and prove their basic properties.
 
 ## Main results
 
-We prove that finite or countable intersections of Gδ sets is a Gδ set. We also prove that the continuity set of a function from a topological space to an (e)metric space is a Gδ set.
+We prove that finite or countable intersections of Gδ sets is a Gδ set. We also prove that the
+continuity set of a function from a topological space to an (e)metric space is a Gδ set.
 
 ## Tags
 
@@ -72,8 +73,8 @@ end
 lemma is_Gδ_Inter [encodable ι]  {s : ι → set α} (hs : ∀ i, is_Gδ (s i)) : is_Gδ (⋂ i, s i) :=
 is_Gδ_sInter (forall_range_iff.2 hs) $ countable_range s
 
-lemma is_Gδ_bInter {s : set ι} (hs : countable s) {t : Π i ∈ s, set α} (ht : ∀ i ∈ s, is_Gδ (t i ‹_›)) :
-  is_Gδ (⋂ i ∈ s, t i ‹_›) :=
+lemma is_Gδ_bInter {s : set ι} (hs : countable s) {t : Π i ∈ s, set α}
+  (ht : ∀ i ∈ s, is_Gδ (t i ‹_›)) : is_Gδ (⋂ i ∈ s, t i ‹_›) :=
 begin
   rw [bInter_eq_Inter],
   haveI := hs.to_encodable,

--- a/src/topology/G_delta.lean
+++ b/src/topology/G_delta.lean
@@ -110,7 +110,7 @@ lemma is_Gδ_set_of_continuous_at_of_countably_generated_uniformity
 begin
   rcases hU.exists_antimono_subbasis uniformity_has_basis_open_symmetric with ⟨U, hUo, hU⟩,
   simp only [uniform.continuous_at_iff_prod, nhds_prod_eq],
-  simp only [ (nhds_basis_opens _).prod_self.tendsto_iff hU.to_has_basis, forall_prop_of_true,
+  simp only [(nhds_basis_opens _).prod_self.tendsto_iff hU.to_has_basis, forall_prop_of_true,
     set_of_forall, id],
   refine is_Gδ_Inter (λ k, is_open.is_Gδ $ is_open_iff_mem_nhds.2 $ λ x, _),
   rintros ⟨s, ⟨hsx, hso⟩, hsU⟩,

--- a/src/topology/G_delta.lean
+++ b/src/topology/G_delta.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel, Yury Kudryashov
+-/
+import topology.metric_space.emetric_space
+
+/-!
+# `Gδ` sets
+
+In this file we define `Gδ` sets and prove their basic properties.
+
+## Main definitions
+
+* `is_Gδ`: a set `s` is a `Gδ` set if it can be represented as an intersection
+  of countably many open sets;
+
+* `residual`: the filter of residual sets. A set `s` is called *residual* if it includes a dense
+  `Gδ` set. In a Baire space (e.g., in a complete (e)metric space), residual sets form a filter.
+
+  For technical reasons, we define `residual` in any topological space but the definition agrees
+  with the description above only in Baire spaces.
+
+## Main results
+
+We prove that finite or countable intersections of Gδ sets is a Gδ set. We also prove that the continuity set of a function from a topological space to an (e)metric space is a Gδ set.
+
+## Tags
+
+Gδ set, residual set
+-/
+
+noncomputable theory
+open_locale classical topological_space filter
+
+open filter encodable set
+
+variables {α : Type*} {β : Type*} {γ : Type*} {ι : Type*}
+
+section is_Gδ
+variable [topological_space α]
+
+/-- A Gδ set is a countable intersection of open sets. -/
+def is_Gδ (s : set α) : Prop :=
+  ∃T : set (set α), (∀t ∈ T, is_open t) ∧ countable T ∧ s = (⋂₀ T)
+
+/-- An open set is a Gδ set. -/
+lemma is_open.is_Gδ {s : set α} (h : is_open s) : is_Gδ s :=
+⟨{s}, by simp [h], countable_singleton _, (set.sInter_singleton _).symm⟩
+
+lemma is_Gδ_univ : is_Gδ (univ : set α) := is_open_univ.is_Gδ
+
+lemma is_Gδ_bInter_of_open {I : set ι} (hI : countable I) {f : ι → set α}
+  (hf : ∀i ∈ I, is_open (f i)) : is_Gδ (⋂i∈I, f i) :=
+⟨f '' I, by rwa ball_image_iff, hI.image _, by rw sInter_image⟩
+
+lemma is_Gδ_Inter_of_open [encodable ι] {f : ι → set α}
+  (hf : ∀i, is_open (f i)) : is_Gδ (⋂i, f i) :=
+⟨range f, by rwa forall_range_iff, countable_range _, by rw sInter_range⟩
+
+/-- A countable intersection of Gδ sets is a Gδ set. -/
+lemma is_Gδ_sInter {S : set (set α)} (h : ∀s∈S, is_Gδ s) (hS : countable S) : is_Gδ (⋂₀ S) :=
+begin
+  choose T hT using h,
+  refine ⟨_, _, _, (sInter_bUnion (λ s hs, (hT s hs).2.2)).symm⟩,
+  { simp only [mem_Union],
+    rintros t ⟨s, hs, tTs⟩,
+    exact (hT s hs).1 t tTs },
+  { exact hS.bUnion (λs hs, (hT s hs).2.1) },
+end
+
+lemma is_Gδ_Inter [encodable ι]  {s : ι → set α} (hs : ∀ i, is_Gδ (s i)) : is_Gδ (⋂ i, s i) :=
+is_Gδ_sInter (forall_range_iff.2 hs) $ countable_range s
+
+lemma is_Gδ_bInter {s : set ι} (hs : countable s) {t : Π i ∈ s, set α} (ht : ∀ i ∈ s, is_Gδ (t i ‹_›)) :
+  is_Gδ (⋂ i ∈ s, t i ‹_›) :=
+begin
+  rw [bInter_eq_Inter],
+  haveI := hs.to_encodable,
+  exact is_Gδ_Inter (λ x, ht x x.2)
+end
+
+lemma is_Gδ.inter {s t : set α} (hs : is_Gδ s) (ht : is_Gδ t) : is_Gδ (s ∩ t) :=
+by { rw inter_eq_Inter, exact is_Gδ_Inter (bool.forall_bool.2 ⟨ht, hs⟩) }
+
+/-- The union of two Gδ sets is a Gδ set. -/
+lemma is_Gδ.union {s t : set α} (hs : is_Gδ s) (ht : is_Gδ t) : is_Gδ (s ∪ t) :=
+begin
+  rcases hs with ⟨S, Sopen, Scount, rfl⟩,
+  rcases ht with ⟨T, Topen, Tcount, rfl⟩,
+  rw [sInter_union_sInter],
+  apply is_Gδ_bInter_of_open (countable_prod Scount Tcount),
+  rintros ⟨a, b⟩ hab,
+  exact is_open_union (Sopen a hab.1) (Topen b hab.2)
+end
+
+end is_Gδ
+
+section continuous_at
+
+open topological_space
+open_locale uniformity
+
+variables [topological_space α]
+
+lemma is_Gδ_set_of_continuous_at_of_countably_generated_uniformity
+  [uniform_space β] (hU : is_countably_generated (𝓤 β)) (f : α → β) :
+  is_Gδ {x | continuous_at f x} :=
+begin
+  rcases hU.exists_antimono_subbasis uniformity_has_basis_open_symmetric with ⟨U, hUo, hU⟩,
+  simp only [uniform.continuous_at_iff_prod, nhds_prod_eq],
+  simp only [ (nhds_basis_opens _).prod_self.tendsto_iff hU.to_has_basis, forall_prop_of_true,
+    set_of_forall, id],
+  refine is_Gδ_Inter (λ k, is_open.is_Gδ $ is_open_iff_mem_nhds.2 $ λ x, _),
+  rintros ⟨s, ⟨hsx, hso⟩, hsU⟩,
+  filter_upwards [mem_nhds_sets hso hsx],
+  intros y hy,
+  exact ⟨s, ⟨hy, hso⟩, hsU⟩
+end
+
+/-- The set of points where a function is continuous is a Gδ set. -/
+lemma is_Gδ_set_of_continuous_at [emetric_space β] (f : α → β) :
+  is_Gδ {x | continuous_at f x} :=
+is_Gδ_set_of_continuous_at_of_countably_generated_uniformity
+  emetric.uniformity_has_countable_basis _
+
+end continuous_at
+
+/-- A set `s` is called *residual* if it includes a dense `Gδ` set. If `α` is a Baire space
+(e.g., a complete metric space), then residual sets form a filter, see `mem_residual`.
+
+For technical reasons we define the filter `residual` in any topological space but in a non-Baire
+space it is not useful because it may contain some non-residual sets. -/
+def residual (α : Type*) [topological_space α] : filter α :=
+⨅ t (ht : is_Gδ t) (ht' : dense t), 𝓟 t

--- a/src/topology/metric_space/baire.lean
+++ b/src/topology/metric_space/baire.lean
@@ -5,6 +5,7 @@ Authors: Sébastien Gouëzel
 -/
 import analysis.specific_limits
 import order.filter.countable_Inter
+import topology.G_delta
 
 /-!
 # Baire theorem
@@ -30,74 +31,6 @@ open_locale classical topological_space filter
 open filter encodable set
 
 variables {α : Type*} {β : Type*} {γ : Type*} {ι : Type*}
-
-section is_Gδ
-variable [topological_space α]
-
-/-- A Gδ set is a countable intersection of open sets. -/
-def is_Gδ (s : set α) : Prop :=
-  ∃T : set (set α), (∀t ∈ T, is_open t) ∧ countable T ∧ s = (⋂₀ T)
-
-/-- An open set is a Gδ set. -/
-lemma is_open.is_Gδ {s : set α} (h : is_open s) : is_Gδ s :=
-⟨{s}, by simp [h], countable_singleton _, (set.sInter_singleton _).symm⟩
-
-lemma is_Gδ_univ : is_Gδ (univ : set α) := is_open_univ.is_Gδ
-
-lemma is_Gδ_bInter_of_open {I : set ι} (hI : countable I) {f : ι → set α}
-  (hf : ∀i ∈ I, is_open (f i)) : is_Gδ (⋂i∈I, f i) :=
-⟨f '' I, by rwa ball_image_iff, hI.image _, by rw sInter_image⟩
-
-lemma is_Gδ_Inter_of_open [encodable ι] {f : ι → set α}
-  (hf : ∀i, is_open (f i)) : is_Gδ (⋂i, f i) :=
-⟨range f, by rwa forall_range_iff, countable_range _, by rw sInter_range⟩
-
-/-- A countable intersection of Gδ sets is a Gδ set. -/
-lemma is_Gδ_sInter {S : set (set α)} (h : ∀s∈S, is_Gδ s) (hS : countable S) : is_Gδ (⋂₀ S) :=
-begin
-  choose T hT using h,
-  refine ⟨_, _, _, (sInter_bUnion (λ s hs, (hT s hs).2.2)).symm⟩,
-  { simp only [mem_Union],
-    rintros t ⟨s, hs, tTs⟩,
-    exact (hT s hs).1 t tTs },
-  { exact hS.bUnion (λs hs, (hT s hs).2.1) },
-end
-
-lemma is_Gδ_Inter [encodable ι]  {s : ι → set α} (hs : ∀ i, is_Gδ (s i)) : is_Gδ (⋂ i, s i) :=
-is_Gδ_sInter (forall_range_iff.2 hs) $ countable_range s
-
-lemma is_Gδ_bInter {s : set ι} (hs : countable s) {t : Π i ∈ s, set α} (ht : ∀ i ∈ s, is_Gδ (t i ‹_›)) :
-  is_Gδ (⋂ i ∈ s, t i ‹_›) :=
-begin
-  rw [bInter_eq_Inter],
-  haveI := hs.to_encodable,
-  exact is_Gδ_Inter (λ x, ht x x.2)
-end
-
-lemma is_Gδ.inter {s t : set α} (hs : is_Gδ s) (ht : is_Gδ t) : is_Gδ (s ∩ t) :=
-by { rw inter_eq_Inter, exact is_Gδ_Inter (bool.forall_bool.2 ⟨ht, hs⟩) }
-
-/-- The union of two Gδ sets is a Gδ set. -/
-lemma is_Gδ.union {s t : set α} (hs : is_Gδ s) (ht : is_Gδ t) : is_Gδ (s ∪ t) :=
-begin
-  rcases hs with ⟨S, Sopen, Scount, rfl⟩,
-  rcases ht with ⟨T, Topen, Tcount, rfl⟩,
-  rw [sInter_union_sInter],
-  apply is_Gδ_bInter_of_open (countable_prod Scount Tcount),
-  rintros ⟨a, b⟩ hab,
-  exact is_open_union (Sopen a hab.1) (Topen b hab.2)
-end
-
-end is_Gδ
-
-/-- A set `s` is called *residual* if it includes a dense `Gδ` set. If `α` is a Baire space
-(e.g., a complete metric space), then residual sets form a filter, see `mem_residual`.
-
- For technical reasons we define the filter `residual` in any topological space
- but in a non-Baire space it is not useful because it may contain some non-residual
- sets. -/
-def residual (α : Type*) [topological_space α] : filter α :=
-⨅ t (ht : is_Gδ t) (ht' : dense t), 𝓟 t
 
 section Baire_theorem
 open emetric ennreal

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -705,10 +705,9 @@ match this with
 end
 
 /-- Entourages are neighborhoods of the diagonal. -/
-lemma nhds_le_uniformity : (⨆ x : α, 𝓝 (x, x)) ≤ 𝓤 α :=
+lemma nhds_le_uniformity (x : α) : 𝓝 (x, x) ≤ 𝓤 α :=
 begin
-  apply supr_le _,
-  intros x V V_in,
+  intros V V_in,
   rcases comp_symm_mem_uniformity_sets V_in with ⟨w, w_in, w_symm, w_sub⟩,
   have : (ball x w).prod (ball x w) ∈ 𝓝 (x, x),
   { rw nhds_prod_eq,
@@ -717,6 +716,10 @@ begin
   rintros ⟨u, v⟩ ⟨u_in, v_in⟩,
   exact w_sub (mem_comp_of_mem_ball w_symm u_in v_in)
 end
+
+/-- Entourages are neighborhoods of the diagonal. -/
+lemma supr_nhds_le_uniformity : (⨆ x : α, 𝓝 (x, x)) ≤ 𝓤 α :=
+supr_le nhds_le_uniformity
 
 /-!
 ### Closure and interior in uniform spaces
@@ -1426,6 +1429,11 @@ by rw [continuous_at, tendsto_nhds_right]
 theorem continuous_at_iff'_left [topological_space β] {f : β → α} {b : β} :
   continuous_at f b ↔ tendsto (λ x, (f x, f b)) (𝓝 b) (𝓤 α) :=
 by rw [continuous_at, tendsto_nhds_left]
+
+theorem continuous_at_iff_prod [topological_space β] {f : β → α} {b : β} :
+  continuous_at f b ↔ tendsto (λ x : β × β, (f x.1, f x.2)) (𝓝 (b, b)) (𝓤 α) :=
+⟨λ H, le_trans (H.prod_map' H) (nhds_le_uniformity _),
+  λ H, continuous_at_iff'_left.2 $ H.comp $ tendsto_id.prod_mk_nhds tendsto_const_nhds⟩
 
 theorem continuous_within_at_iff'_right [topological_space β] {f : β → α} {b : β} {s : set β} :
   continuous_within_at f s b ↔ tendsto (λ x, (f b, f x)) (𝓝[s] b) (𝓤 α) :=

--- a/src/topology/uniform_space/compact_separated.lean
+++ b/src/topology/uniform_space/compact_separated.lean
@@ -37,10 +37,11 @@ variables {α β : Type*} [uniform_space α] [uniform_space β]
 ### Uniformity on compact separated spaces
 -/
 
-
+/-- On a separated compact uniform space, the topology determines the uniform structure, entourages
+are exactly the neighborhoods of the diagonal. -/
 lemma compact_space_uniformity [compact_space α] [separated_space α] : 𝓤 α = ⨆ x : α, 𝓝 (x, x) :=
 begin
-  symmetry, refine le_antisymm nhds_le_uniformity _,
+  symmetry, refine le_antisymm supr_nhds_le_uniformity _,
   by_contra H,
   obtain ⟨V, hV, h⟩ : ∃ V : set (α × α), (∀ x : α, V ∈ 𝓝 (x, x)) ∧ ne_bot (𝓤 α ⊓ 𝓟 Vᶜ),
   { simpa [le_iff_forall_inf_principal_compl] using H },
@@ -204,7 +205,7 @@ map (prod.map f f) (𝓤 α) = map (prod.map f f) (⨆ x, 𝓝 (x, x))  : by rw 
                      ... =  ⨆ x, map (prod.map f f) (𝓝 (x, x)) : by rw map_supr
                      ... ≤ ⨆ x, 𝓝 (f x, f x)     : supr_le_supr (λ x, (h.prod_map h).continuous_at)
                      ... ≤ ⨆ y, 𝓝 (y, y)         : supr_comp_le (λ y, 𝓝 (y, y)) f
-                     ... ≤ 𝓤 β                   : nhds_le_uniformity
+                     ... ≤ 𝓤 β                   : supr_nhds_le_uniformity
 
 /-- Heine-Cantor: a continuous function on a compact separated set of a uniform space is
 uniformly continuous. -/


### PR DESCRIPTION
* Move the definition of `is_Gδ` and basic lemmas to a separate file.
* Prove that `{x | continuous_at f x}` is a Gδ set provided that the
  codomain is a uniform space with countable basis of the uniformity
  filter (e.g., an `emetric_space`). In particular, this set is
  measurable.
* Rename `nhds_le_uniformity` to `supr_nhds_le_uniformity`.
* Add new `nhds_le_uniformity` without `⨆` in the statement.
* Add `uniform.continuous_at_iff_prod`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
