### PR TITLE
[Merged by Bors] - doc(type_classes): Explain the use of {} instance arguments

### DIFF
--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -35,11 +35,6 @@ The constructor for a `ring_hom` between semirings needs a proof of `map_zero`, 
 `map_add` as well as `map_mul`; a separate constructor `ring_hom.mk'` will construct ring homs
 between rings from monoid homs given only a proof that addition is preserved.
 
-Throughout the section on `ring_hom` implicit `{}` brackets are often used instead
-of type class `[]` brackets. This is done when the instances can be inferred because they are
-implicit arguments to the type `ring_hom`. When they can be inferred from the type it is faster
-to use this method than to use type class inference.
-
 ## Tags
 
 `ring_hom`, `semiring_hom`, `semiring`, `comm_semiring`, `ring`, `comm_ring`, `domain`,
@@ -223,6 +218,10 @@ namespace ring_hom
 
 section coe
 
+/-!
+Throughout this section, some `semiring` arguments are specified with `{}` instead of `[]`.
+See note [implicit instance arguments].
+-/
 variables {rα : semiring α} {rβ : semiring β}
 
 include rα rβ

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1599,6 +1599,11 @@ instance [semiring R] [add_comm_monoid M] [semimodule R M] : has_scalar R (α �
 
 variables (α M)
 
+/-!
+Throughout this section, some `semiring` arguments are specified with `{}` instead of `[]`.
+See note [implicit instance arguments].
+-/
+
 @[simp] lemma smul_apply' {_:semiring R} [add_comm_monoid M] [semimodule R M]
   {a : α} {b : R} {v : α →₀ M} : (b • v) a = b • (v a) :=
 rfl

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -29,11 +29,6 @@ as `map_mul`; a separate constructor `monoid_hom.mk'` will construct
 group homs (i.e. monoid homs between groups) given only a proof
 that multiplication is preserved,
 
-Throughout the `monoid_hom` section implicit `{}` brackets are often used instead of type class `[]`
-brackets.  This is done when the instances can be inferred because they are implicit arguments to
-the type `monoid_hom`.  When they can be inferred from the type it is faster to use this method than
-to use type class inference.
-
 ## Tags
 
 is_group_hom, is_monoid_hom, monoid_hom
@@ -101,6 +96,11 @@ class is_monoid_hom [monoid α] [monoid β] (f : α → β) extends is_mul_hom f
 (map_one [] : f 1 = 1)
 
 namespace monoid_hom
+
+/-!
+Throughout this section, some `monoid` arguments are specified with `{}` instead of `[]`.
+See note [implicit instance arguments].
+-/
 variables {M : Type*} {N : Type*} {P : Type*} [mM : monoid M] [mN : monoid N] {mP : monoid P}
 variables {G : Type*} {H : Type*} [group G] [comm_group H]
 

--- a/src/tactic/lint/type_classes.lean
+++ b/src/tactic/lint/type_classes.lean
@@ -58,6 +58,18 @@ private meta def instance_priority (d : declaration) : tactic (option string) :=
   if always_applies then return $ some "set priority below 1000" else return none
 
 /--
+There are places where typeclass arguments are specified with implicit `{}` brackets instead of
+the usual `[]` brackets. This is done when the instances can be inferred because they are implicit
+arguments to the type of one of the other arguments. When they can be inferred from these other
+arguments,  it is faster to use this method than to use type class inference.
+
+For example, when writing lemmas about `(f : α →+* β)`, it is faster to specify the fact that `α`
+and `β` are `semiring`s as `{rα : semiring α} {rβ : semiring β}` rather than the usual
+`[semiring α] [semiring β]`.
+-/
+library_note "implicit instance arguments"
+
+/--
 Certain instances always apply during type-class resolution. For example, the instance
 `add_comm_group.to_add_group {α} [add_comm_group α] : add_group α` applies to all type-class
 resolution problems of the form `add_group _`, and type-class inference will then do an


### PR DESCRIPTION
Closes gh-4660


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
