### PR TITLE
[Merged by Bors] - feat(ring_theory/unique_factorization_domain): connecting `multiplicity` to `unique_factorization_domain.factors`

### DIFF
--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -251,8 +251,7 @@ lemma associated_pow_pow [comm_monoid α] {a b : α} {n : ℕ} (h : a ~ᵤ b) :
   a ^ n ~ᵤ b ^ n :=
 begin
   induction n with n ih, { simp [h] },
-  rw [pow_succ, pow_succ],
-  apply associated_mul_mul h ih,
+  convert associated_mul_mul h ih,
 end
 
 lemma dvd_of_associated [monoid α] {a b : α} : a ~ᵤ b → a ∣ b := λ ⟨u, hu⟩, ⟨u, hu.symm⟩

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -247,6 +247,14 @@ lemma associated_mul_mul [comm_monoid α] {a₁ a₂ b₁ b₂ : α} :
   a₁ ~ᵤ b₁ → a₂ ~ᵤ b₂ → (a₁ * a₂) ~ᵤ (b₁ * b₂)
 | ⟨c₁, h₁⟩ ⟨c₂, h₂⟩ := ⟨c₁ * c₂, by simp [h₁.symm, h₂.symm, mul_assoc, mul_comm, mul_left_comm]⟩
 
+lemma associated_pow_pow [comm_monoid α] {a b : α} {n : ℕ} (h : a ~ᵤ b) :
+  a ^ n ~ᵤ b ^ n :=
+begin
+  induction n with n ih, { simp [h] },
+  rw [pow_succ, pow_succ],
+  apply associated_mul_mul h ih,
+end
+
 lemma dvd_of_associated [monoid α] {a b : α} : a ~ᵤ b → a ∣ b := λ ⟨u, hu⟩, ⟨u, hu.symm⟩
 
 lemma dvd_dvd_of_associated [monoid α] {a b : α} (h : a ~ᵤ b) : a ∣ b ∧ b ∣ a :=

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -571,6 +571,44 @@ lemma exists_reduced_factors' (a b : R) (hb : b ≠ 0) :
 let ⟨b', a', c', no_factor, hb, ha⟩ := exists_reduced_factors b hb a
 in ⟨a', b', c', λ _ hpb hpa, no_factor hpa hpb, ha, hb⟩
 
+section multiplicity
+variables [nontrivial R] [normalization_monoid R] [decidable_eq R]
+variables [decidable_rel (has_dvd.dvd : R → R → Prop)]
+open multiplicity multiset
+
+lemma le_multiplicity_iff_repeat_le_factors {a b : R} {n : ℕ} (ha : irreducible a) (hb : b ≠ 0) :
+  ↑n ≤ multiplicity a b ↔ repeat (normalize a) n ≤ factors b :=
+begin
+  rw ← pow_dvd_iff_le_multiplicity,
+  revert b,
+  induction n with n ih, { simp },
+  intros b hb,
+  split,
+  { rintro ⟨c, rfl⟩,
+    rw [ne.def, pow_succ, mul_assoc, mul_eq_zero, decidable.not_or_iff_and_not] at hb,
+    rw [pow_succ, mul_assoc, factors_mul hb.1 hb.2, repeat_succ, factors_irreducible ha,
+      cons_add, cons_le_cons_iff, zero_add, ← ih hb.2],
+    apply dvd.intro _ rfl },
+  { rw [multiset.le_iff_exists_add],
+    rintro ⟨u, hu⟩,
+    rw [← dvd_iff_dvd_of_rel_right (factors_prod hb), hu, prod_add, prod_repeat],
+    apply dvd.trans (dvd_of_associated (associated_pow_pow _)) (dvd.intro u.prod rfl),
+    apply associated_normalize }
+end
+
+lemma multiplicity_eq_count_factors {a b : R} (ha : irreducible a) (hb : b ≠ 0) :
+  multiplicity a b = (factors b).count (normalize a) :=
+begin
+  apply le_antisymm,
+  { apply enat.le_of_lt_add_one,
+    rw [← enat.coe_one, ← enat.coe_add, lt_iff_not_ge, ge_iff_le,
+      le_multiplicity_iff_repeat_le_factors ha hb, ← le_count_iff_repeat_le],
+    simp },
+  rw [le_multiplicity_iff_repeat_le_factors ha hb, ← le_count_iff_repeat_le],
+end
+
+end multiplicity
+
 end unique_factorization_monoid
 
 


### PR DESCRIPTION
Connects multiplicity of an irreducible to the multiset of irreducible factors

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
