### PR TITLE
[Merged by Bors] - feat(group_theory/subgroup) top is a normal subgroup

### DIFF
--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -747,6 +747,9 @@ end normal
 @[priority 100, to_additive]
 instance bot_normal : normal (⊥ : subgroup G) := ⟨by simp⟩
 
+@[priority 100, to_additive]
+instance top_normal : normal (⊤ : subgroup G) := ⟨by simp⟩
+
 variable (G)
 /-- The center of a group `G` is the set of elements that commute with everything in `G` -/
 @[to_additive "The center of a group `G` is the set of elements that commute with everything in `G`"]

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -748,7 +748,7 @@ end normal
 instance bot_normal : normal (⊥ : subgroup G) := ⟨by simp⟩
 
 @[priority 100, to_additive]
-instance top_normal : normal (⊤ : subgroup G) := ⟨by simp⟩
+instance top_normal : normal (⊤ : subgroup G) := ⟨λ _ _, mem_top⟩
 
 variable (G)
 /-- The center of a group `G` is the set of elements that commute with everything in `G` -/


### PR DESCRIPTION
---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/normal.20subgroups/near/216410660)