### PR TITLE
[Merged by Bors] - feat(ring_theory/power_basis): `equiv`s between algebras with the same power basis

### DIFF
--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -15,6 +15,7 @@ We promote `eval₂` to an algebra hom in `aeval`.
 
 noncomputable theory
 open finset
+open_locale big_operators
 
 namespace polynomial
 universes u v w z
@@ -206,6 +207,14 @@ end
 lemma dvd_term_of_is_root_of_dvd_terms {r p : S} {f : polynomial S} (i : ℕ)
   (hr : f.is_root r) (h : ∀ (j ≠ i), p ∣ f.coeff j * r ^ j) : p ∣ f.coeff i * r ^ i :=
 dvd_term_of_dvd_eval_of_dvd_terms i (eq.symm hr ▸ dvd_zero p) h
+
+lemma aeval_eq_sum_range [algebra R S] {p : polynomial R} (x : S) :
+  aeval x p = ∑ i in finset.range (p.nat_degree + 1), p.coeff i • x ^ i :=
+by { simp_rw algebra.smul_def, exact eval₂_eq_sum_range (algebra_map R S) x }
+
+lemma aeval_eq_sum_range' [algebra R S] {p : polynomial R} {n : ℕ} (hn : p.nat_degree < n) (x : S) :
+  aeval x p = ∑ i in finset.range n, p.coeff i • x ^ i :=
+by { simp_rw algebra.smul_def, exact eval₂_eq_sum_range' (algebra_map R S) hn x }
 
 end aeval
 

--- a/src/data/polynomial/degree/basic.lean
+++ b/src/data/polynomial/degree/basic.lean
@@ -772,28 +772,13 @@ lemma nat_degree_X_sub_C_le {r : R} : (X - C r).nat_degree ≤ 1 :=
 nat_degree_le_iff_degree_le.2 $ le_trans (degree_sub_le _ _) $ max_le degree_X_le $
 le_trans degree_C_le $ with_bot.coe_le_coe.2 zero_le_one
 
-lemma degree_sum_le_max {ι : Type*} {s : finset ι} (p : ι → polynomial R) :
-  degree (s.sum p) ≤ s.fold (⊔) ⊥ (λ i, degree (p i)) :=
-begin
-  classical,
-  refine s.induction_on _ _,
-  { simp },
-  intros a s ha ih,
-  calc  ((insert a s).sum p).degree
-      = (p a + s.sum p).degree : by rw finset.sum_insert ha
-  ... ≤ max (p a).degree (s.sum p).degree : degree_add_le _ _
-  ... ≤ max (p a).degree (s.fold (⊔) ⊥ (λ i, degree (p i))) : max_le_max (refl _) ih
-  ... = (insert a s).fold (⊔) ⊥ (λ i, degree (p i)) :
-    by rw [finset.fold_insert ha, with_bot.sup_eq_max]
-end
-
 lemma degree_sum_fin_lt {n : ℕ} (f : fin n → R) :
   degree (∑ i : fin n, C (f i) * X ^ (i : ℕ)) < n :=
 begin
   haveI : is_commutative (with_bot ℕ) max := ⟨max_comm⟩,
   haveI : is_associative (with_bot ℕ) max := ⟨max_assoc⟩,
   calc  (∑ i, C (f i) * X ^ (i : ℕ)).degree
-      ≤ finset.univ.fold (⊔) ⊥ (λ i, (C (f i) * X ^ (i : ℕ)).degree) : degree_sum_le_max _
+      ≤ finset.univ.fold (⊔) ⊥ (λ i, (C (f i) * X ^ (i : ℕ)).degree) : degree_sum_le _ _
   ... = finset.univ.fold max ⊥ (λ i, (C (f i) * X ^ (i : ℕ)).degree) :
     (@finset.fold_hom _ _ _ (⊔) _ _ _ ⊥ finset.univ _ _ _ id (with_bot.sup_eq_max)).symm
   ... < n : (finset.fold_max_lt (n : with_bot ℕ)).mpr ⟨with_bot.bot_lt_some _, _⟩,

--- a/src/data/polynomial/degree/basic.lean
+++ b/src/data/polynomial/degree/basic.lean
@@ -770,6 +770,40 @@ lemma nat_degree_X_sub_C_le {r : R} : (X - C r).nat_degree ≤ 1 :=
 nat_degree_le_iff_degree_le.2 $ le_trans (degree_sub_le _ _) $ max_le degree_X_le $
 le_trans degree_C_le $ with_bot.coe_le_coe.2 zero_le_one
 
+lemma degree_sum_le_max {ι : Type*} {s : finset ι} (p : ι → polynomial R) :
+  degree (s.sum p) ≤ s.fold (⊔) ⊥ (λ i, degree (p i)) :=
+begin
+  classical,
+  refine s.induction_on _ _,
+  { simp },
+  intros a s ha ih,
+  calc  ((insert a s).sum p).degree
+      = (p a + s.sum p).degree : by rw finset.sum_insert ha
+  ... ≤ max (p a).degree (s.sum p).degree : degree_add_le _ _
+  ... ≤ max (p a).degree (s.fold (⊔) ⊥ (λ i, degree (p i))) : max_le_max (refl _) ih
+  ... = (insert a s).fold (⊔) ⊥ (λ i, degree (p i)) :
+    by rw [finset.fold_insert ha, with_bot.sup_eq_max]
+end
+
+lemma degree_sum_fin_lt {n : ℕ} (f : fin n → R) :
+  degree (∑ i : fin n, C (f i) * X ^ (i : ℕ)) < n :=
+begin
+  haveI : is_commutative (with_bot ℕ) max := ⟨max_comm⟩,
+  haveI : is_associative (with_bot ℕ) max := ⟨max_assoc⟩,
+  calc  (∑ i, C (f i) * X ^ (i : ℕ)).degree
+      ≤ finset.univ.fold (⊔) ⊥ (λ i, (C (f i) * X ^ (i : ℕ)).degree) : degree_sum_le_max _
+  ... = finset.univ.fold max ⊥ (λ i, (C (f i) * X ^ (i : ℕ)).degree) :
+    (@finset.fold_hom _ _ _ (⊔) _ _ _ ⊥ finset.univ _ _ _ id (with_bot.sup_eq_max)).symm
+  ... < n : (finset.fold_max_lt (n : with_bot ℕ)).mpr ⟨with_bot.bot_lt_some _, _⟩,
+
+  rintros ⟨i, hi⟩ -,
+  calc (C (f ⟨i, hi⟩) * X ^ i).degree
+      ≤ (C _).degree + (X ^ i).degree : degree_mul_le _ _
+  ... ≤ 0 + i : add_le_add degree_C_le (degree_X_pow_le i)
+  ... = i : zero_add _
+  ... < n : with_bot.some_lt_some.mpr hi,
+end
+
 end ring
 
 section nonzero_ring

--- a/src/data/polynomial/div.lean
+++ b/src/data/polynomial/div.lean
@@ -538,6 +538,11 @@ lemma dvd_iff_is_root : (X - C a) ∣ p ↔ is_root p a :=
 lemma mod_by_monic_X (p : polynomial R) : p %ₘ X = C (p.eval 0) :=
 by rw [← mod_by_monic_X_sub_C_eq_C_eval, C_0, sub_zero]
 
+lemma eval₂_mod_by_monic_eq_self_of_root [comm_ring S] {f : R →+* S}
+  {p q : polynomial R} (hq : q.monic) {x : S} (hx : q.eval₂ f x = 0) :
+  (p %ₘ q).eval₂ f x = p.eval₂ f x :=
+by rw [mod_by_monic_eq_sub_mul_div p hq, eval₂_sub, eval₂_mul, hx, zero_mul, sub_zero]
+
 section multiplicity
 /-- An algorithm for deciding polynomial divisibility.
 The algorithm is "compute `p %ₘ q` and compare to `0`". `

--- a/src/data/polynomial/div.lean
+++ b/src/data/polynomial/div.lean
@@ -100,7 +100,7 @@ calc (div_X p).degree < (div_X p * X + C (p.coeff 0)).degree :
               (by rw [zero_le_degree_iff, ne.def, div_X_eq_zero_iff];
                 exact λ h0, h (h0.symm ▸ degree_C_le))
               (le_refl _),
-    by rw [add_comm, degree_add_eq_of_degree_lt this];
+    by rw [degree_add_eq_left_of_degree_lt this];
       exact degree_lt_degree_mul_X hXp0
 ... = p.degree : by rw div_X_mul_X_add
 
@@ -364,7 +364,7 @@ have hmod : degree (p %ₘ q) < degree (q * (p /ₘ q)) :=
       degree_eq_nat_degree hdiv0, ← with_bot.coe_add, with_bot.coe_le_coe];
     exact nat.le_add_right _ _,
 calc degree q + degree (p /ₘ q) = degree (q * (p /ₘ q)) : eq.symm (degree_mul' hlc)
-... = degree (p %ₘ q + q * (p /ₘ q)) : (degree_add_eq_of_degree_lt hmod).symm
+... = degree (p %ₘ q + q * (p /ₘ q)) : (degree_add_eq_right_of_degree_lt hmod).symm
 ... = _ : congr_arg _ (mod_by_monic_add_div _ hq)
 
 lemma degree_div_by_monic_le (p q : polynomial R) : degree (p /ₘ q) ≤ degree p :=

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -188,6 +188,14 @@ lemma eval₂_eq_sum_range :
   p.eval₂ f x = ∑ i in finset.range (p.nat_degree + 1), f (p.coeff i) * x^i :=
 trans (congr_arg _ p.as_sum_range) (trans (eval₂_finset_sum f _ _ x) (congr_arg _ (by simp)))
 
+lemma eval₂_eq_sum_range' (f : R →+* S) {p : polynomial R} {n : ℕ} (hn : p.nat_degree < n) (x : S) :
+  eval₂ f x p = ∑ i in finset.range n, f (p.coeff i) * x ^ i :=
+begin
+  rw [eval₂_eq_sum, p.sum_over_range' _ _ hn],
+  intro i,
+  rw [f.map_zero, zero_mul]
+end
+
 end eval₂
 
 section eval

--- a/src/data/polynomial/field_division.lean
+++ b/src/data/polynomial/field_division.lean
@@ -175,8 +175,8 @@ lemma degree_add_div (hq0 : q ≠ 0) (hpq : degree q ≤ degree p) :
 have degree (p % q) < degree (q * (p / q)) :=
   calc degree (p % q) < degree q : euclidean_domain.mod_lt _ hq0
   ... ≤ _ : degree_le_mul_left _ (mt (div_eq_zero_iff hq0).1 (not_lt_of_ge hpq)),
-by conv {to_rhs, rw [← euclidean_domain.div_add_mod p q, add_comm,
-    degree_add_eq_of_degree_lt this, degree_mul]}
+by conv_rhs { rw [← euclidean_domain.div_add_mod p q,
+    degree_add_eq_left_of_degree_lt this, degree_mul] }
 
 lemma degree_div_le (p q : polynomial R) : degree (p / q) ≤ degree p :=
 if hq : q = 0 then by simp [hq]

--- a/src/data/polynomial/lifts.lean
+++ b/src/data/polynomial/lifts.lean
@@ -177,7 +177,7 @@ begin
   rw [←hdeg, erase_lead] at deg_erase,
   replace deg_erase := lt_of_le_of_lt degree_le_nat_degree (with_bot.coe_lt_coe.2 deg_erase),
   rw [← deg_lead, ← herase.2] at deg_erase,
-  rw [degree_add_eq_of_degree_lt deg_erase, deg_lead, degree_eq_nat_degree pzero]
+  rw [degree_add_eq_right_of_degree_lt deg_erase, deg_lead, degree_eq_nat_degree pzero]
 end
 
 end lift_deg
@@ -213,7 +213,7 @@ begin
   { simp only [hq, map_add, map_pow, map_X],
     nth_rewrite 3 [← erase_lead_add_C_mul_X_pow p],
     rw [erase_lead, monic.leading_coeff hmonic, C_1, one_mul] },
-  { rw [degree_add_eq_of_degree_lt deg_er, @degree_X_pow R _ Rtrivial p.nat_degree,
+  { rw [degree_add_eq_right_of_degree_lt deg_er, @degree_X_pow R _ Rtrivial p.nat_degree,
     degree_eq_nat_degree (monic.ne_zero hmonic)] },
   { rw [monic.def, leading_coeff_add_of_degree_lt deg_er],
     exact monic_pow monic_X p.nat_degree }

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -92,6 +92,14 @@ lemma monic_pow (hp : monic p) : ∀ (n : ℕ), monic (p ^ n)
 | 0     := monic_one
 | (n+1) := monic_mul hp (monic_pow n)
 
+lemma monic_add_of_left {p q : polynomial R} (hp : monic p) (hpq : degree q < degree p) :
+  monic (p + q) :=
+by rwa [monic, add_comm, leading_coeff_add_of_degree_lt hpq]
+
+lemma monic_add_of_right {p q : polynomial R} (hq : monic q) (hpq : degree p < degree q) :
+  monic (p + q) :=
+by rwa [monic, leading_coeff_add_of_degree_lt hpq]
+
 end semiring
 
 section comm_semiring

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -40,6 +40,11 @@ lemma degree_pos_of_aeval_root [algebra R S] {p : polynomial R} (hp : p ≠ 0)
   0 < p.degree :=
 nat_degree_pos_iff_degree_pos.mp (nat_degree_pos_of_aeval_root hp hz inj)
 
+lemma aeval_mod_by_monic_eq_self_of_root [algebra R S]
+  {p q : polynomial R} (hq : q.monic) {x : S} (hx : aeval x q = 0) :
+  aeval x (p %ₘ q) = aeval x p :=
+eval₂_mod_by_monic_eq_self_of_root hq hx
+
 end comm_ring
 
 section integral_domain

--- a/src/field_theory/minimal_polynomial.lean
+++ b/src/field_theory/minimal_polynomial.lean
@@ -59,6 +59,10 @@ lemma min {p : polynomial α} (pmonic : p.monic) (hp : polynomial.aeval x p = 0)
   degree (minimal_polynomial hx) ≤ degree p :=
 le_of_not_lt $ well_founded.not_lt_min degree_lt_wf _ hx ⟨pmonic, hp⟩
 
+/-- A minimal polynomial is nonzero. -/
+lemma ne_zero [nontrivial α] : (minimal_polynomial hx) ≠ 0 :=
+ne_zero_of_monic (monic hx)
+
 end ring
 
 section field
@@ -67,10 +71,6 @@ variables [field α]
 section ring
 variables [ring β] [algebra α β]
 variables {x : β} (hx : is_integral α x)
-
-/--A minimal polynomial is nonzero.-/
-lemma ne_zero : (minimal_polynomial hx) ≠ 0 :=
-ne_zero_of_monic (monic hx)
 
 /--If an element x is a root of a nonzero polynomial p,
 then the degree of p is at least the degree of the minimal polynomial of x.-/

--- a/src/linear_algebra/char_poly/coeff.lean
+++ b/src/linear_algebra/char_poly/coeff.lean
@@ -92,7 +92,7 @@ begin
   { rw degree_eq_iff_nat_degree_eq_of_pos, swap, apply nat.pos_of_ne_zero h,
     rw nat_degree_prod', simp_rw nat_degree_X_sub_C, unfold fintype.card, simp,
     simp_rw (monic_X_sub_C _).leading_coeff, simp, },
-  rw degree_add_eq_of_degree_lt, exact h1, rw h1,
+  rw degree_add_eq_right_of_degree_lt, exact h1, rw h1,
   apply lt_trans (char_poly_sub_diagonal_degree_lt M), rw with_bot.coe_lt_coe,
   rw ← nat.pred_eq_sub_one, apply nat.pred_lt, apply h,
 end

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -25,6 +25,12 @@ element to a ring/field.
 * `findim (hf : f ≠ 0) : finite_dimensional.findim K (adjoin_root f) = f.nat_degree`,
   the dimension of `adjoin_root f` equals the degree of `f`
 
+* `power_basis.lift (pb : power_basis R S)`: if `y : S'` satisfies the same
+  equations as `pb.gen`, this is the map `S →ₐ[R] S'` sending `pb.gen` to `y`
+
+* `power_basis.equiv`: if two power bases satisfy the same equations, they are
+  equivalent as algebras
+
 ## Implementation notes
 
 Throughout this file, `R`, `S`, ... are `comm_ring`s, `A`, `B`, ... are
@@ -110,6 +116,217 @@ begin
       exact lt_of_le_of_ne (nat.zero_le d) hd.symm <|> exact with_bot.bot_lt_some d },
     simpa only [degree_eq_nat_degree hf, with_bot.coe_lt_coe] using h },
 end
+
+lemma dim_ne_zero [nontrivial S] (pb : power_basis R S) : pb.dim ≠ 0 :=
+λ h, one_ne_zero $
+show (1 : S) = 0,
+by { rw [← pb.is_basis.total_repr 1, finsupp.total_apply, finsupp.sum_fintype],
+     { refine finset.sum_eq_zero (λ x hx, _),
+       cases x with x x_lt,
+       rw h at x_lt,
+       cases x_lt },
+     { simp } }
+
+lemma exists_eq_aeval [nontrivial S] (pb : power_basis R S) (y : S) :
+  ∃ f : polynomial R, f.nat_degree < pb.dim ∧ y = aeval pb.gen f :=
+(mem_span_pow pb.dim_ne_zero).mp (pb.is_basis.mem_span y)
+
+section minpoly
+
+open_locale big_operators
+
+variable [algebra A S]
+
+/-- `pb.minpoly_gen` is a minimal polynomial for `pb.gen`.
+
+If `A` is not a field, it might not necessarily be *the* minimal polynomial,
+however `nat_degree_minimal_polynomial` shows its degree is indeed minimal.
+-/
+noncomputable def minpoly_gen (pb : power_basis A S) : polynomial A :=
+X ^ pb.dim -
+  ∑ (i : fin pb.dim), C (pb.is_basis.repr (pb.gen ^ pb.dim) i) * X ^ (i : ℕ)
+
+@[simp]
+lemma nat_degree_minpoly_gen (pb : power_basis A S) :
+  nat_degree (minpoly_gen pb) = pb.dim :=
+begin
+  rw [minpoly_gen, sub_eq_add_neg],
+  apply nat_degree_eq_of_degree_eq_some,
+  -- TODO: find a good lemma to encapsulate the next three lines
+  rw [add_comm, ← @degree_X_pow A _ _ pb.dim],
+  apply degree_add_eq_of_degree_lt,
+  rw [degree_neg, @degree_X_pow A _ _ pb.dim],
+  exact degree_sum_fin_lt _
+end
+
+lemma minpoly_gen_monic (pb : power_basis A S) : monic (minpoly_gen pb) :=
+begin
+  apply monic_add_of_left (monic_pow (monic_X) _),
+  rw [degree_neg, degree_X_pow],
+  exact degree_sum_fin_lt _
+end
+
+@[simp]
+lemma aeval_minpoly_gen (pb : power_basis A S) : aeval pb.gen (minpoly_gen pb) = 0 :=
+begin
+  simp_rw [minpoly_gen, alg_hom.map_sub, alg_hom.map_sum, alg_hom.map_mul, alg_hom.map_pow,
+           aeval_C, ← algebra.smul_def, aeval_X],
+  refine sub_eq_zero.mpr ((pb.is_basis.total_repr (pb.gen ^ pb.dim)).symm.trans _),
+  rw [finsupp.total_apply, finsupp.sum_fintype],
+  intro i, rw zero_smul
+end
+
+lemma is_integral_gen (pb : power_basis A S) : is_integral A pb.gen :=
+⟨minpoly_gen pb, minpoly_gen_monic pb, aeval_minpoly_gen pb⟩
+
+lemma dim_le_nat_degree_of_root (h : power_basis A S) {p : polynomial A}
+  (ne_zero : p ≠ 0) (root : aeval h.gen p = 0) :
+  h.dim ≤ p.nat_degree :=
+begin
+  refine le_of_not_lt (λ hlt, ne_zero _),
+  let p_coeff : fin (h.dim) → A := λ i, p.coeff i,
+  suffices : ∀ i, p_coeff i = 0,
+  { ext i,
+    by_cases hi : i < h.dim,
+    { exact this ⟨i, hi⟩ },
+    exact coeff_eq_zero_of_nat_degree_lt (lt_of_lt_of_le hlt (le_of_not_gt hi)) },
+  intro i,
+  refine linear_independent_iff'.mp h.is_basis.1 finset.univ _ _ i (finset.mem_univ _),
+  rw aeval_eq_sum_range' hlt at root,
+  rw finset.sum_fin_eq_sum_range,
+  convert root,
+  ext i,
+  split_ifs with hi,
+  { refl },
+  { rw [coeff_eq_zero_of_nat_degree_lt (lt_of_lt_of_le hlt (le_of_not_gt hi)),
+        zero_smul] }
+end
+
+@[simp]
+lemma nat_degree_minimal_polynomial (pb : power_basis A S) :
+  (minimal_polynomial pb.is_integral_gen).nat_degree = pb.dim :=
+begin
+  refine le_antisymm _
+    (dim_le_nat_degree_of_root pb (minimal_polynomial.ne_zero _) (minimal_polynomial.aeval _)),
+  rw ← nat_degree_minpoly_gen,
+  apply nat_degree_le_of_degree_le,
+  rw ← degree_eq_nat_degree (minpoly_gen_monic pb).ne_zero,
+  exact minimal_polynomial.min _ (minpoly_gen_monic pb) (aeval_minpoly_gen pb)
+end
+
+end minpoly
+
+section equiv
+
+variables [algebra A S] {S' : Type*} [comm_ring S'] [algebra A S']
+
+lemma nat_degree_lt_nat_degree {p q : polynomial R} (hp : p ≠ 0) (hpq : p.degree < q.degree) :
+  p.nat_degree < q.nat_degree :=
+begin
+  by_cases hq : q = 0, { rw [hq, degree_zero] at hpq, have := not_lt_bot hpq, contradiction },
+  rwa [degree_eq_nat_degree hp, degree_eq_nat_degree hq, with_bot.coe_lt_coe] at hpq
+end
+
+lemma constr_pow_aeval (pb : power_basis A S) {y : S'}
+  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) (f : polynomial A) :
+  pb.is_basis.constr (λ i, y ^ (i : ℕ)) (aeval pb.gen f) = aeval y f :=
+begin
+  rw [← aeval_mod_by_monic_eq_self_of_root
+          (minimal_polynomial.monic pb.is_integral_gen)
+          (minimal_polynomial.aeval _),
+      ← @aeval_mod_by_monic_eq_self_of_root _ _ _ _ _ f _
+          (minimal_polynomial.monic pb.is_integral_gen) y hy],
+  by_cases hf : f %ₘ minimal_polynomial (pb.is_integral_gen) = 0,
+  { simp only [hf, alg_hom.map_zero, linear_map.map_zero] },
+  have : (f %ₘ minimal_polynomial _).nat_degree < pb.dim,
+  { rw ← pb.nat_degree_minimal_polynomial,
+    apply nat_degree_lt_nat_degree hf,
+    exact degree_mod_by_monic_lt _ (minimal_polynomial.monic _) (minimal_polynomial.ne_zero _) },
+  rw [aeval_eq_sum_range' this, aeval_eq_sum_range' this, linear_map.map_sum],
+  refine finset.sum_congr rfl (λ i (hi : i ∈ finset.range pb.dim), _),
+  rw finset.mem_range at hi,
+  rw linear_map.map_smul,
+  congr,
+  exact @constr_basis _ _ _ _ _ _ _ _ _ _ _ (⟨i, hi⟩ : fin pb.dim) pb.is_basis,
+end
+
+lemma constr_pow_gen (pb : power_basis A S) {y : S'}
+  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) :
+  pb.is_basis.constr (λ i, y ^ (i : ℕ)) pb.gen = y :=
+by { convert pb.constr_pow_aeval hy X; rw aeval_X }
+
+lemma constr_pow_algebra_map (pb : power_basis A S) {y : S'}
+  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) (x : A) :
+  pb.is_basis.constr (λ i, y ^ (i : ℕ)) (algebra_map A S x) = algebra_map A S' x :=
+by { convert pb.constr_pow_aeval hy (C x); rw aeval_C }
+
+lemma constr_pow_mul [nontrivial S] (pb : power_basis A S) {y : S'}
+  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) (x x' : S) :
+  pb.is_basis.constr (λ i, y ^ (i : ℕ)) (x * x') =
+    pb.is_basis.constr (λ i, y ^ (i : ℕ)) x * pb.is_basis.constr (λ i, y ^ (i : ℕ)) x' :=
+begin
+  obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x,
+  obtain ⟨g, hg, rfl⟩ := pb.exists_eq_aeval x',
+  simp only [← aeval_mul, pb.constr_pow_aeval hy]
+end
+
+/-- `pb.lift y hy` is the algebra map sending `pb.gen` to `y`,
+where `hy` states the higher powers of `y` are the same as the higher powers of `pb.gen`. -/
+noncomputable def lift [nontrivial S] (pb : power_basis A S) (y : S')
+  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) :
+  S →ₐ[A] S' :=
+{ map_one' := by { convert pb.constr_pow_algebra_map hy 1 using 2; rw ring_hom.map_one },
+  map_zero' := by { convert pb.constr_pow_algebra_map hy 0 using 2; rw ring_hom.map_zero },
+  map_mul' := pb.constr_pow_mul hy,
+  commutes' := pb.constr_pow_algebra_map hy,
+  .. pb.is_basis.constr (λ i, y ^ (i : ℕ)) }
+
+@[simp] lemma lift_gen [nontrivial S] (pb : power_basis A S) (y : S')
+  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) :
+  pb.lift y hy pb.gen = y :=
+pb.constr_pow_gen hy
+
+@[simp] lemma lift_aeval [nontrivial S] (pb : power_basis A S) (y : S')
+  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) (f : polynomial A) :
+  pb.lift y hy (aeval pb.gen f) = aeval y f :=
+pb.constr_pow_aeval hy f
+
+/-- `pb.equiv pb' h` is an equivalence of algebras with the same power basis. -/
+noncomputable def equiv [nontrivial S] [nontrivial S'] [algebra A S']
+  (pb : power_basis A S) (pb' : power_basis A S')
+  (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen) :
+  S ≃ₐ[A] S' :=
+alg_equiv.of_alg_hom
+  (pb.lift pb'.gen (h.symm ▸ minimal_polynomial.aeval pb'.is_integral_gen))
+  (pb'.lift pb.gen (h ▸ minimal_polynomial.aeval pb.is_integral_gen))
+  (by { ext x, obtain ⟨f, hf, rfl⟩ := pb'.exists_eq_aeval x, simp })
+  (by { ext x, obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x, simp })
+
+@[simp]
+lemma equiv_aeval [nontrivial S] [nontrivial S'] [algebra A S']
+  (pb : power_basis A S) (pb' : power_basis A S')
+  (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen)
+  (f : polynomial A) :
+  pb.equiv pb' h (aeval pb.gen f) = aeval pb'.gen f :=
+pb.lift_aeval _ (h.symm ▸ minimal_polynomial.aeval _) _
+
+@[simp]
+lemma equiv_gen [nontrivial S] [nontrivial S'] [algebra A S']
+  (pb : power_basis A S) (pb' : power_basis A S')
+  (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen) :
+  pb.equiv pb' h pb.gen = pb'.gen :=
+pb.lift_gen _ (h.symm ▸ minimal_polynomial.aeval _)
+
+local attribute [irreducible] power_basis.lift
+
+@[simp]
+lemma equiv_symm [nontrivial S] [nontrivial S'] [algebra A S']
+  (pb : power_basis A S) (pb' : power_basis A S')
+  (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen) :
+  (pb.equiv pb' h).symm = pb'.equiv pb h.symm :=
+rfl
+
+end equiv
 
 end power_basis
 
@@ -292,15 +509,6 @@ noncomputable def power_basis (hf : f ≠ 0) :
   dim := f.nat_degree,
   is_basis := power_basis_is_basis hf }
 
-lemma finite_dimensional (hf : f ≠ 0) : finite_dimensional K (adjoin_root f) :=
-finite_dimensional.of_fintype_basis (power_basis hf).is_basis
-
-lemma findim (hf : f ≠ 0) : finite_dimensional.findim K (adjoin_root f) = f.nat_degree :=
-begin
-  rw [finite_dimensional.findim_eq_card_basis (power_basis hf).is_basis, fintype.card_fin],
-  refl,
-end
-
 end adjoin_root
 
 namespace intermediate_field
@@ -330,6 +538,9 @@ noncomputable def adjoin.power_basis {x : L} (hx : is_integral K x) :
   dim := (minimal_polynomial hx).nat_degree,
   is_basis := power_basis_is_basis hx }
 
+@[simp] lemma adjoin.power_basis.gen_eq {x : L} (hx : is_integral K x) :
+  (adjoin.power_basis hx).gen = adjoin_simple.gen K x := rfl
+
 lemma adjoin.finite_dimensional {x : L} (hx : is_integral K x) : finite_dimensional K K⟮x⟯ :=
 power_basis.finite_dimensional (adjoin.power_basis hx)
 
@@ -341,3 +552,36 @@ begin
 end
 
 end intermediate_field
+
+namespace power_basis
+
+open intermediate_field
+
+/-- `pb.equiv_adjoin_simple` is the equivalence between `K⟮pb.gen⟯` and `L` itself. -/
+noncomputable def equiv_adjoin_simple (pb : power_basis K L) :
+  K⟮pb.gen⟯ ≃ₐ[K] L :=
+(adjoin.power_basis pb.is_integral_gen).equiv pb
+  (minimal_polynomial.eq_of_algebra_map_eq (algebra_map K⟮pb.gen⟯ L).injective _ _
+    (by rw [adjoin.power_basis.gen_eq, adjoin_simple.algebra_map_gen]))
+
+@[simp]
+lemma equiv_adjoin_simple_aeval (pb : power_basis K L) (f : polynomial K) :
+  pb.equiv_adjoin_simple (aeval (adjoin_simple.gen K pb.gen) f) = aeval pb.gen f :=
+equiv_aeval _ pb _ f
+
+@[simp]
+lemma equiv_adjoin_simple_gen (pb : power_basis K L) :
+  pb.equiv_adjoin_simple (adjoin_simple.gen K pb.gen) = pb.gen :=
+equiv_gen _ pb _
+
+@[simp]
+lemma equiv_adjoin_simple_symm_aeval (pb : power_basis K L) (f : polynomial K) :
+  pb.equiv_adjoin_simple.symm (aeval pb.gen f) = aeval (adjoin_simple.gen K pb.gen) f :=
+by rw [equiv_adjoin_simple, equiv_symm, equiv_aeval, adjoin.power_basis.gen_eq]
+
+@[simp]
+lemma equiv_adjoin_simple_symm_gen (pb : power_basis K L) :
+  pb.equiv_adjoin_simple.symm pb.gen = (adjoin_simple.gen K pb.gen) :=
+by rw [equiv_adjoin_simple, equiv_symm, equiv_gen, adjoin.power_basis.gen_eq]
+
+end power_basis

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -289,7 +289,7 @@ pb.constr_pow_gen hy
 pb.constr_pow_aeval hy f
 
 /-- `pb.equiv pb' h` is an equivalence of algebras with the same power basis. -/
-noncomputable def equiv [nontrivial S] [nontrivial S'] [algebra A S']
+noncomputable def equiv [nontrivial S] [nontrivial S']
   (pb : power_basis A S) (pb' : power_basis A S')
   (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen) :
   S ≃ₐ[A] S' :=
@@ -300,7 +300,7 @@ alg_equiv.of_alg_hom
   (by { ext x, obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x, simp })
 
 @[simp]
-lemma equiv_aeval [nontrivial S] [nontrivial S'] [algebra A S']
+lemma equiv_aeval [nontrivial S] [nontrivial S']
   (pb : power_basis A S) (pb' : power_basis A S')
   (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen)
   (f : polynomial A) :
@@ -308,7 +308,7 @@ lemma equiv_aeval [nontrivial S] [nontrivial S'] [algebra A S']
 pb.lift_aeval _ (h.symm ▸ minimal_polynomial.aeval _) _
 
 @[simp]
-lemma equiv_gen [nontrivial S] [nontrivial S'] [algebra A S']
+lemma equiv_gen [nontrivial S] [nontrivial S']
   (pb : power_basis A S) (pb' : power_basis A S')
   (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen) :
   pb.equiv pb' h pb.gen = pb'.gen :=
@@ -317,7 +317,7 @@ pb.lift_gen _ (h.symm ▸ minimal_polynomial.aeval _)
 local attribute [irreducible] power_basis.lift
 
 @[simp]
-lemma equiv_symm [nontrivial S] [nontrivial S'] [algebra A S']
+lemma equiv_symm [nontrivial S] [nontrivial S']
   (pb : power_basis A S) (pb' : power_basis A S')
   (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen) :
   (pb.equiv pb' h).symm = pb'.equiv pb h.symm :=

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -150,13 +150,10 @@ X ^ pb.dim -
 lemma nat_degree_minpoly_gen (pb : power_basis A S) :
   nat_degree (minpoly_gen pb) = pb.dim :=
 begin
-  rw [minpoly_gen, sub_eq_add_neg],
+  unfold minpoly_gen,
   apply nat_degree_eq_of_degree_eq_some,
-  -- TODO: find a good lemma to encapsulate the next three lines
-  rw [add_comm, ← @degree_X_pow A _ _ pb.dim],
-  apply degree_add_eq_of_degree_lt,
-  rw [degree_neg, @degree_X_pow A _ _ pb.dim],
-  exact degree_sum_fin_lt _
+  rw degree_sub_eq_left_of_degree_lt; rw degree_X_pow,
+  apply degree_sum_fin_lt
 end
 
 lemma minpoly_gen_monic (pb : power_basis A S) : monic (minpoly_gen pb) :=


### PR DESCRIPTION
`power_basis.lift` and `power_basis.equiv` use the power basis structure to define `alg_hom`s and `alg_equiv`s.
    
The main application in this PR is `power_basis.equiv_adjoin_simple`, which states that adjoining an element of a power basis of `L : K` gives `L` itself.

---
This PR includes some additions to `data/polynomial` and one renaming/addition that touches quite a few files (in commit 5d1b078). Either of these could be split off to new PRs if that makes reviewing easier.