### PR TITLE
[Merged by Bors] - feat(tactic/has_variable_names): add tactic for type-based naming

### DIFF
--- a/src/tactic/has_variable_names.lean
+++ b/src/tactic/has_variable_names.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2020 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jannis Limperg
+-/
+
+import tactic.core
+
+/-!
+# A tactic for type-based naming of variables
+
+When we name hypotheses or variables, we often do so in a type-directed fashion:
+a hypothesis of type `ℕ` is called `n` or `m`; a hypothesis of type `list ℕ` is
+called `ns`; etc. This module provides a tactic,
+`tactic.typical_variable_names`, which looks up typical variable names for a
+given type. Typical variable names are registered by giving an instance of the
+type class `has_variable_names`.
+-/
+
+universes u v
+
+/--
+Type class for associating a type `α` with typical variable names for elements
+of `α`. See `tactic.typical_variable_names`.
+-/
+meta class has_variable_names (α : Sort u) : Type :=
+(first_name : name)
+(other_names : list name)
+
+
+namespace tactic
+
+/--
+`typical_variable_names t` obtains typical names for variables of type `t`.
+The returned list is guaranteed to be nonempty. Fails if there is no instance
+`has_typical_variable_names t`.
+
+```
+typical_variable_names `(ℕ) = [`n, `m, `o]
+```
+-/
+meta def typical_variable_names (t : expr) : tactic (list name) :=
+(do
+  first_name ← to_expr ``(has_variable_names.first_name %%t),
+  n ← eval_expr name first_name,
+  other_names ← to_expr ``(has_variable_names.other_names %%t),
+  ns ← eval_expr (list name) other_names,
+  pure $ n :: ns)
+<|> fail! "typical_variable_names: unable to get typical variable names for type {t}"
+
+end tactic
+
+
+namespace has_variable_names
+
+/--
+`@make_listlike_instance α _ β` creates an instance `has_variable_names β` from
+an instance `has_variable_names α`. If `α` has associated names `a`, `b`, ...,
+the generated instance for `β` has names `as`, `bs`, ... This can be used to
+create instances for 'containers' such as lists or sets.
+-/
+meta def make_listlike_instance (α : Sort u) [has_variable_names α]
+  {β : Sort v} : has_variable_names β :=
+⟨ (first_name α).append_suffix "s",
+  (other_names α).map $ λ n, n.append_suffix "s" ⟩
+
+/--
+`@make_inheriting_instance α _ β` creates an instance `has_variable_names β`
+from an instance `has_variable_names α`. The generated instance contains the
+same variable names as that of `α`. This can be used to create instances for
+'wrapper' types like `option` and `subtype`.
+-/
+meta def make_inheriting_instance (α : Sort u) [has_variable_names α]
+  {β : Sort v} : has_variable_names β :=
+⟨ first_name α, other_names α ⟩
+
+end has_variable_names
+
+open has_variable_names
+
+
+meta instance {n α} [has_variable_names α] : has_variable_names (d_array n (λ _, α)) :=
+make_listlike_instance α
+
+meta instance : has_variable_names bool :=
+⟨`b, []⟩
+
+meta instance : has_variable_names char :=
+⟨`c, []⟩
+
+meta instance {n} : has_variable_names (fin n):=
+⟨`n, [`m, `o]⟩
+
+meta instance : has_variable_names ℤ :=
+⟨`n, [`m, `o]⟩
+
+meta instance {α} [has_variable_names α] : has_variable_names (list α) :=
+make_listlike_instance α
+
+meta instance : has_variable_names ℕ :=
+⟨`n, [`m, `o]⟩
+
+meta instance : has_variable_names Prop :=
+⟨`P, [`Q, `R]⟩
+
+meta instance {α} [has_variable_names α] : has_variable_names (thunk α) :=
+make_inheriting_instance α
+
+meta instance {α β} : has_variable_names (prod α β) :=
+⟨`p, []⟩
+
+meta instance {α β} : has_variable_names (pprod α β) :=
+⟨`p, []⟩
+
+meta instance {α} {β : α → Type*} : has_variable_names (sigma β) :=
+⟨`p, []⟩
+
+meta instance {α} {β : α → Sort*} : has_variable_names (psigma β) :=
+⟨`p, []⟩
+
+meta instance {α} [has_variable_names α] {p : α → Prop} : has_variable_names (subtype p) :=
+make_inheriting_instance α
+
+meta instance {α} [has_variable_names α] : has_variable_names (option α) :=
+make_inheriting_instance α
+
+meta instance {α} : has_variable_names (bin_tree α) :=
+⟨`t, []⟩
+
+meta instance {α} [has_variable_names α] {lt : α → α → Prop} :
+  has_variable_names (rbtree α lt) :=
+make_listlike_instance α
+
+meta instance {α} [has_variable_names α] : has_variable_names (native.rb_set α) :=
+make_listlike_instance α
+
+meta instance {α} [has_variable_names α] : has_variable_names (set α) :=
+make_listlike_instance α
+
+meta instance : has_variable_names string :=
+⟨`s, []⟩
+
+meta instance : has_variable_names unsigned :=
+⟨`n, [`m, `o]⟩
+
+meta instance {α} {β : α → Sort*} : has_variable_names (Π a : α, β a) :=
+⟨`f, [`g, `h]⟩
+
+meta instance : has_variable_names name :=
+⟨`n, []⟩
+
+meta instance {α} : has_variable_names (tactic α) :=
+⟨`t, []⟩
+
+meta instance : has_variable_names expr :=
+⟨`e, []⟩
+
+meta instance : has_variable_names pexpr :=
+⟨`e, []⟩
+
+meta instance : has_variable_names level :=
+⟨`u, [`v, `w]⟩
+
+meta instance : has_variable_names binder_info :=
+⟨`bi, []⟩

--- a/src/tactic/has_variable_names.lean
+++ b/src/tactic/has_variable_names.lean
@@ -13,8 +13,20 @@ When we name hypotheses or variables, we often do so in a type-directed fashion:
 a hypothesis of type `ℕ` is called `n` or `m`; a hypothesis of type `list ℕ` is
 called `ns`; etc. This module provides a tactic,
 `tactic.typical_variable_names`, which looks up typical variable names for a
-given type. Typical variable names are registered by giving an instance of the
-type class `has_variable_names`.
+given type.
+
+Typical variable names are registered by giving an instance of the type class
+`has_variable_names`. This file provides `has_variable_names` instances for many
+of the core Lean types. If you want to override these, you can declare a
+high-priority instance (perhaps localised) of `has_variable_names`. E.g. to
+change the names given to natural numbers:
+
+```lean
+def foo : has_variable_names ℕ :=
+⟨[`i, `j, `k]⟩
+
+local attribute [instance, priority 1000] foo
+```
 -/
 
 universes u v
@@ -23,21 +35,9 @@ universes u v
 Type class for associating a type `α` with typical variable names for elements
 of `α`. See `tactic.typical_variable_names`.
 -/
-meta class has_variable_names (α : Sort u) : Type :=
-(first_name : name)
-(other_names : list name)
-
-
-namespace has_variable_names
-
-/--
-`names α` returns the names associated with the type `α`. The returned list is
-guaranteed to be nonempty.
--/
-meta def names {α} [has_variable_names α] : list name :=
-first_name α :: other_names α
-
-end has_variable_names
+class has_variable_names (α : Sort u) : Type :=
+(names : list name)
+(names_nonempty : 0 < names.length . tactic.exact_dec_trivial)
 
 
 namespace tactic
@@ -68,10 +68,10 @@ an instance `has_variable_names α`. If `α` has associated names `a`, `b`, ...,
 the generated instance for `β` has names `as`, `bs`, ... This can be used to
 create instances for 'containers' such as lists or sets.
 -/
-meta def make_listlike_instance (α : Sort u) [has_variable_names α]
+def make_listlike_instance (α : Sort u) [has_variable_names α]
   {β : Sort v} : has_variable_names β :=
-⟨ (first_name α).append_suffix "s",
-  (other_names α).map $ λ n, n.append_suffix "s" ⟩
+⟨ (names α).map $ λ n, n.append_suffix "s",
+  by simp [names_nonempty] ⟩
 
 /--
 `@make_inheriting_instance α _ β` creates an instance `has_variable_names β`
@@ -79,96 +79,96 @@ from an instance `has_variable_names α`. The generated instance contains the
 same variable names as that of `α`. This can be used to create instances for
 'wrapper' types like `option` and `subtype`.
 -/
-meta def make_inheriting_instance (α : Sort u) [has_variable_names α]
+def make_inheriting_instance (α : Sort u) [has_variable_names α]
   {β : Sort v} : has_variable_names β :=
-⟨ first_name α, other_names α ⟩
+⟨names α, names_nonempty⟩
 
 end has_variable_names
 
 open has_variable_names
 
 
-meta instance {n α} [has_variable_names α] : has_variable_names (d_array n (λ _, α)) :=
+instance {n α} [has_variable_names α] : has_variable_names (d_array n (λ _, α)) :=
 make_listlike_instance α
 
-meta instance : has_variable_names bool :=
-⟨`b, []⟩
+instance : has_variable_names bool :=
+⟨[`b]⟩
 
-meta instance : has_variable_names char :=
-⟨`c, []⟩
+instance : has_variable_names char :=
+⟨[`c]⟩
 
-meta instance {n} : has_variable_names (fin n):=
-⟨`n, [`m, `o]⟩
+instance {n} : has_variable_names (fin n):=
+⟨[`n, `m, `o]⟩
 
-meta instance : has_variable_names ℤ :=
-⟨`n, [`m, `o]⟩
+instance : has_variable_names ℤ :=
+⟨[`n, `m, `o]⟩
 
-meta instance {α} [has_variable_names α] : has_variable_names (list α) :=
+instance {α} [has_variable_names α] : has_variable_names (list α) :=
 make_listlike_instance α
 
-meta instance : has_variable_names ℕ :=
-⟨`n, [`m, `o]⟩
+instance : has_variable_names ℕ :=
+⟨[`n, `m, `o]⟩
 
-meta instance : has_variable_names Prop :=
-⟨`P, [`Q, `R]⟩
+instance : has_variable_names Prop :=
+⟨[`P, `Q, `R]⟩
 
-meta instance {α} [has_variable_names α] : has_variable_names (thunk α) :=
+instance {α} [has_variable_names α] : has_variable_names (thunk α) :=
 make_inheriting_instance α
 
-meta instance {α β} : has_variable_names (prod α β) :=
-⟨`p, []⟩
+instance {α β} : has_variable_names (prod α β) :=
+⟨[`p]⟩
 
-meta instance {α β} : has_variable_names (pprod α β) :=
-⟨`p, []⟩
+instance {α β} : has_variable_names (pprod α β) :=
+⟨[`p]⟩
 
-meta instance {α} {β : α → Type*} : has_variable_names (sigma β) :=
-⟨`p, []⟩
+instance {α} {β : α → Type*} : has_variable_names (sigma β) :=
+⟨[`p]⟩
 
-meta instance {α} {β : α → Sort*} : has_variable_names (psigma β) :=
-⟨`p, []⟩
+instance {α} {β : α → Sort*} : has_variable_names (psigma β) :=
+⟨[`p]⟩
 
-meta instance {α} [has_variable_names α] {p : α → Prop} : has_variable_names (subtype p) :=
+instance {α} [has_variable_names α] {p : α → Prop} : has_variable_names (subtype p) :=
 make_inheriting_instance α
 
-meta instance {α} [has_variable_names α] : has_variable_names (option α) :=
+instance {α} [has_variable_names α] : has_variable_names (option α) :=
 make_inheriting_instance α
 
-meta instance {α} : has_variable_names (bin_tree α) :=
-⟨`t, []⟩
+instance {α} : has_variable_names (bin_tree α) :=
+⟨[`t]⟩
 
-meta instance {α} [has_variable_names α] {lt : α → α → Prop} :
+instance {α} [has_variable_names α] {lt : α → α → Prop} :
   has_variable_names (rbtree α lt) :=
 make_listlike_instance α
 
 meta instance {α} [has_variable_names α] : has_variable_names (native.rb_set α) :=
 make_listlike_instance α
 
-meta instance {α} [has_variable_names α] : has_variable_names (set α) :=
+instance {α} [has_variable_names α] : has_variable_names (set α) :=
 make_listlike_instance α
 
-meta instance : has_variable_names string :=
-⟨`s, []⟩
+instance : has_variable_names string :=
+⟨[`s]⟩
 
-meta instance : has_variable_names unsigned :=
-⟨`n, [`m, `o]⟩
+instance : has_variable_names unsigned :=
+⟨[`n, `m, `o]⟩
 
-meta instance {α} {β : α → Sort*} : has_variable_names (Π a : α, β a) :=
-⟨`f, [`g, `h]⟩
+instance {α} {β : α → Sort*} : has_variable_names (Π a : α, β a) :=
+⟨[`f, `g, `h]⟩
 
-meta instance : has_variable_names name :=
-⟨`n, []⟩
+instance : has_variable_names name :=
+⟨[`n]⟩
 
 meta instance {α} : has_variable_names (tactic α) :=
-⟨`t, []⟩
+⟨[`t]⟩
 
 meta instance : has_variable_names expr :=
-⟨`e, []⟩
+⟨[`e]⟩
 
 meta instance : has_variable_names pexpr :=
-⟨`e, []⟩
+⟨[`e]⟩
 
 meta instance : has_variable_names level :=
-⟨`u, [`v, `w]⟩
+⟨[`u, `v, `w]⟩
 
-meta instance : has_variable_names binder_info :=
-⟨`bi, []⟩
+instance : has_variable_names binder_info :=
+⟨[`bi]⟩

--- a/src/tactic/has_variable_names.lean
+++ b/src/tactic/has_variable_names.lean
@@ -28,6 +28,18 @@ meta class has_variable_names (α : Sort u) : Type :=
 (other_names : list name)
 
 
+namespace has_variable_names
+
+/--
+`names α` returns the names associated with the type `α`. The returned list is
+guaranteed to be nonempty.
+-/
+meta def names {α} [has_variable_names α] : list name :=
+first_name α :: other_names α
+
+end has_variable_names
+
+
 namespace tactic
 
 /--
@@ -41,11 +53,8 @@ typical_variable_names `(ℕ) = [`n, `m, `o]
 -/
 meta def typical_variable_names (t : expr) : tactic (list name) :=
 (do
-  first_name ← to_expr ``(has_variable_names.first_name %%t),
-  n ← eval_expr name first_name,
-  other_names ← to_expr ``(has_variable_names.other_names %%t),
-  ns ← eval_expr (list name) other_names,
-  pure $ n :: ns)
+  names ← to_expr ``(has_variable_names.names %%t),
+  eval_expr (list name) names)
 <|> fail! "typical_variable_names: unable to get typical variable names for type {t}"
 
 end tactic


### PR DESCRIPTION
When we name hypotheses or variables, we often do so in a type-directed fashion:
a hypothesis of type `ℕ` is called `n` or `m`; a hypothesis of type `list ℕ` is
called `ns`; etc. This commits adds a tactic which looks up typical variable
names for a given type. Typical variable names are registered by giving an
instance of the new type class `has_variable_names`. We also give instances of
this type class for many core types.

---
I need this for the upcoming `induction'` tactic.