### PR TITLE
[Merged by Bors] - chore(deprecated/group): Do not import `deprecated` from `equiv/mul_add`

### DIFF
--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -3,9 +3,10 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 -/
-import data.equiv.basic
-import deprecated.group
 import algebra.group.hom
+import algebra.group.type_tags
+import algebra.group.units_hom
+import data.equiv.basic
 
 /-!
 # Multiplicative and additive equivs
@@ -73,10 +74,6 @@ lemma to_equiv_apply {f : M ≃* N} {m : M} : f.to_equiv m = f m := rfl
 /-- A multiplicative isomorphism preserves multiplication (canonical form). -/
 @[simp, to_additive]
 lemma map_mul (f : M ≃* N) : ∀ x y, f (x * y) = f x * f y := f.map_mul'
-
-/-- A multiplicative isomorphism preserves multiplication (deprecated). -/
-@[to_additive]
-instance (h : M ≃* N) : is_mul_hom h := ⟨h.map_mul⟩
 
 /-- Makes a multiplicative isomorphism from a bijection which preserves multiplication. -/
 @[to_additive "Makes an additive isomorphism from a bijection which preserves addition."]
@@ -209,18 +206,6 @@ rfl
 @[simp, to_additive]
 lemma map_inv [group G] [group H] (h : G ≃* H) (x : G) : h x⁻¹ = (h x)⁻¹ :=
 h.to_monoid_hom.map_inv x
-
-/-- A multiplicative bijection between two monoids is a monoid hom
-  (deprecated -- use to_monoid_hom). -/
-@[to_additive]
-instance is_monoid_hom {M N} [monoid M] [monoid N] (h : M ≃* N) : is_monoid_hom h :=
-⟨h.map_one⟩
-
-/-- A multiplicative bijection between two groups is a group hom
-  (deprecated -- use to_monoid_hom). -/
-@[to_additive]
-instance is_group_hom {G H} [group G] [group H] (h : G ≃* H) :
-  is_group_hom h := { map_mul := h.map_mul }
 
 /-- Two multiplicative isomorphisms agree if they are defined by the
     same underlying function. -/

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -6,6 +6,7 @@ Author: Yury Kudryashov
 import algebra.group.type_tags
 import algebra.group.units_hom
 import algebra.ring.basic
+import data.equiv.mul_add
 
 /-!
 # Unbundled monoid and group homomorphisms (deprecated)
@@ -16,7 +17,7 @@ because Lean 3 often fails to coerce a bundled homomorphism to a function.
 
 ## main definitions
 
-monoid_hom, is_monoid_hom (deprecated), is_group_hom (deprecated)
+is_monoid_hom (deprecated), is_group_hom (deprecated)
 
 ## implementation notes
 
@@ -124,6 +125,22 @@ instance (f : M →* N) : is_monoid_hom (f : M → N) :=
 
 end monoid_hom
 
+namespace mul_equiv
+
+variables {M : Type*} {N : Type*} [monoid M] [monoid N]
+
+/-- A multiplicative isomorphism preserves multiplication (deprecated). -/
+@[to_additive]
+instance (h : M ≃* N) : is_mul_hom h := ⟨h.map_mul⟩
+
+/-- A multiplicative bijection between two monoids is a monoid hom
+  (deprecated -- use to_monoid_hom). -/
+@[to_additive]
+instance {M N} [monoid M] [monoid N] (h : M ≃* N) : is_monoid_hom h :=
+⟨h.map_one⟩
+
+end mul_equiv
+
 namespace is_monoid_hom
 variables [monoid α] [monoid β] (f : α → β) [is_monoid_hom f]
 
@@ -180,6 +197,10 @@ class is_group_hom [group α] [group β] (f : α → β) extends is_mul_hom f : 
 instance monoid_hom.is_group_hom {G H : Type*} {_ : group G} {_ : group H} (f : G →* H) :
   is_group_hom (f : G → H) :=
 { map_mul := f.map_mul }
+
+@[to_additive]
+instance mul_equiv.is_group_hom {G H : Type*} {_ : group G} {_ : group H} (h : G ≃* H) :
+  is_group_hom h := { map_mul := h.map_mul }
 
 /-- Construct `is_group_hom` from its only hypothesis. The default constructor tries to get
 `is_mul_hom` from class instances, and this makes some proofs fail. -/


### PR DESCRIPTION
This swaps the direction of the import, which makes the deprecated instances for `mul_equiv` be in the same place as the instances for `monoid_hom`.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
