### PR TITLE
feat(measure_theory/lp_space): define Lp spaces

### DIFF
--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1065,6 +1065,20 @@ begin
     { simp [coe_rpow_of_ne_zero h, h] } }
 end
 
+lemma rpow_eq_top_of_nonneg (x : ennreal) {p : ℝ} (hp0 : 0 ≤ p) : x ^ p = ⊤ → x = ⊤ :=
+begin
+  rw ennreal.rpow_eq_top_iff,
+  intro h, cases h,
+  { exfalso, rw lt_iff_not_ge at h, exact h.right hp0, },
+  { exact h.left, },
+end
+
+lemma rpow_ne_top_of_nonneg {x : ennreal} {p : ℝ} (hp0 : 0 ≤ p) (h : x ≠ ⊤) : x ^ p ≠ ⊤ :=
+mt (ennreal.rpow_eq_top_of_nonneg x hp0) h
+
+lemma rpow_lt_top_of_nonneg {x : ennreal} {p : ℝ} (hp0 : 0 ≤ p) (h : x ≠ ⊤) : x ^ p < ⊤ :=
+ennreal.lt_top_iff_ne_top.mpr (ennreal.rpow_ne_top_of_nonneg hp0 h)
+
 lemma rpow_add {x : ennreal} (y z : ℝ) (hx : x ≠ 0) (h'x : x ≠ ⊤) : x ^ (y + z) = x ^ y * x ^ z :=
 begin
   cases x, { exact (h'x rfl).elim },

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -493,6 +493,36 @@ lemma closure_induction {p : G → Prop} {x} (h : x ∈ closure k)
 
 attribute [elab_as_eliminator] subgroup.closure_induction add_subgroup.closure_induction
 
+/-- An induction principle on elements of the subtype `subgroup.closure`.
+If `p` holds for `1` and all elements of `k`, and is preserved under multiplication and inverse,
+then `p` holds for all elements `x : closure k`.
+
+The difference with `subgroup.closure_induction` is that this acts on the subtype.
+-/
+@[to_additive "An induction principle on elements of the subtype `add_subgroup.closure`.
+If `p` holds for `0` and all elements of `k`, and is preserved under addition and negation,
+then `p` holds for all elements `x : closure k`.
+
+The difference with `add_subgroup.closure_induction` is that this acts on the subtype."]
+lemma closure_induction' (k : set G) {p : closure k → Prop}
+  (Hk : ∀ x (h : x ∈ k), p ⟨x, subset_closure h⟩)
+  (H1 : p 1)
+  (Hmul : ∀ x y, p x → p y → p (x * y))
+  (Hinv : ∀ x, p x → p x⁻¹)
+  (x : closure k) :
+  p x :=
+subtype.rec_on x $ λ x hx, begin
+  refine exists.elim _ (λ (hx : x ∈ closure k) (hc : p ⟨x, hx⟩), hc),
+  exact closure_induction hx
+    (λ x hx, ⟨subset_closure hx, Hk x hx⟩)
+    ⟨one_mem _, H1⟩
+    (λ x y hx hy, exists.elim hx $ λ hx' hx, exists.elim hy $ λ hy' hy,
+      ⟨mul_mem _ hx' hy', Hmul _ _ hx hy⟩)
+    (λ x hx, exists.elim hx $ λ hx' hx, ⟨inv_mem _ hx', Hinv _ hx⟩),
+end
+
+attribute [elab_as_eliminator] subgroup.closure_induction' add_subgroup.closure_induction'
+
 variable (G)
 
 /-- `closure` forms a Galois insertion with the coercion to set. -/

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -338,6 +338,34 @@ def subtype : S →* M := ⟨coe, rfl, λ _ _, rfl⟩
 
 @[simp, to_additive] theorem coe_subtype : ⇑S.subtype = coe := rfl
 
+/-- An induction principle on elements of the type `submonoid.closure s`.
+If `p` holds for `1` and all elements of `s`, and is preserved under multiplication, then `p`
+holds for all elements of the closure of `s`.
+
+The difference with `submonoid.closure_induction` is that this acts on the subtype.
+-/
+@[to_additive "An induction principle on elements of the type `add_submonoid.closure s`.
+If `p` holds for `0` and all elements of `s`, and is preserved under addition, then `p`
+holds for all elements of the closure of `s`.
+
+The difference with `add_submonoid.closure_induction` is that this acts on the subtype."]
+lemma closure_induction' (s : set M) {p : closure s → Prop}
+  (Hs : ∀ x (h : x ∈ s), p ⟨x, subset_closure h⟩)
+  (H1 : p 1)
+  (Hmul : ∀ x y, p x → p y → p (x * y))
+  (x : closure s) :
+  p x :=
+subtype.rec_on x $ λ x hx, begin
+  refine exists.elim _ (λ (hx : x ∈ closure s) (hc : p ⟨x, hx⟩), hc),
+  exact closure_induction hx
+    (λ x hx, ⟨subset_closure hx, Hs x hx⟩)
+    ⟨one_mem _, H1⟩
+    (λ x y hx hy, exists.elim hx $ λ hx' hx, exists.elim hy $ λ hy' hy,
+      ⟨mul_mem _ hx' hy', Hmul _ _ hx hy⟩),
+end
+
+attribute [elab_as_eliminator] submonoid.closure_induction' add_submonoid.closure_induction'
+
 /-- Given `submonoid`s `s`, `t` of monoids `M`, `N` respectively, `s × t` as a submonoid
 of `M × N`. -/
 @[to_additive prod "Given `add_submonoid`s `s`, `t` of `add_monoid`s `A`, `B` respectively, `s × t`

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2020 Rémy Degenne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Rémy Degenne.
+-/
+import measure_theory.l1_space
+import analysis.special_functions.pow
+
+/-!
+# ℒp space
+
+This file describes the subtype of measurable functions with finite semi-norm
+`(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)` for `p:ℝ` with `1 ≤ p`.
+
+## Main definitions and results
+
+* `ℒp α β hp1 μ` : the type of measurable functions `α → β` with finite p-seminorm for measure `μ`,
+                    for `hp1 : 1 ≤ p`,
+* `in_ℒp hp1 μ f`: the property 'f belongs to ℒp for measure μ' and real p such that `hp1 : 1 ≤ p`.
+
+## Notation
+
+* `snorm' f ` : `(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : α → β`
+* `snorm f`   : `(∫⁻ a, (nnnorm (f.val a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : ℒp α β (1≤p) μ`
+
+-/
+
+open measure_theory
+
+section ℒp_space_definition
+variables {α β : Type*} [measurable_space α] [measurable_space β] [normed_group β]
+
+def in_ℒp {p : ℝ} (hp1 : 1 ≤ p) (μ : measure α) (f : α → β) : Prop :=
+measurable f ∧ ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤
+
+def ℒp (α β : Type*) [measurable_space α] [measurable_space β] [normed_group β]
+  {p : ℝ} (hp1 : 1 ≤ p) (μ : measure α) : Type* := {f : α → β // in_ℒp hp1 μ f}
+
+protected lemma ℒp.in_ℒp {α β : Type*} [measurable_space α] [measurable_space β] [normed_group β]
+  {p : ℝ} {hp1 : 1 ≤ p} {μ : measure α} (f : ℒp α β hp1 μ) : in_ℒp hp1 μ f.val := f.prop
+
+lemma in_ℒp_one_iff_integrable (μ : measure α) :
+  ∀ f : α → β, in_ℒp (le_refl 1) μ f ↔ integrable f μ :=
+begin
+  intro f,
+  unfold integrable, unfold has_finite_integral, unfold in_ℒp,
+  simp only [ennreal.rpow_one, nnreal.coe_one],
+end
+
+variables {p : ℝ} {hp1 : 1 ≤ p} {μ : measure α}
+
+lemma lintegral_rpow_nnnorm_zero (hp0_lt : 0 < p) :
+  ∫⁻ a, (nnnorm ((0 : α → β) a))^p ∂μ = 0 :=
+begin
+  simp_rw pi.zero_apply,
+  rw nnnorm_zero,
+  rw lintegral_const,
+  rw mul_eq_zero,
+  left,
+  exact ennreal.zero_rpow_of_pos hp0_lt,
+end
+
+lemma zero_in_ℒp : in_ℒp hp1 μ (0 : α → β) :=
+begin
+  split,
+  exact measurable_zero,
+  refine lt_of_le_of_lt _ with_top.zero_lt_top,
+  rw lintegral_rpow_nnnorm_zero (lt_of_lt_of_le zero_lt_one hp1),
+  exact le_refl 0,
+  exact _inst_2,
+end
+
+protected def ℒp.zero : ℒp α β hp1 μ := ⟨(0 : α → β), zero_in_ℒp⟩
+
+instance : has_zero (ℒp α β hp1 μ) := ⟨ℒp.zero⟩
+
+instance : inhabited (ℒp α β hp1 μ) := ⟨0⟩
+
+end ℒp_space_definition
+
+
+noncomputable theory
+
+namespace ℒp
+variables {α β : Type*} [measurable_space α] [measurable_space β] [normed_group β]
+  {p : ℝ} {hp1 : 1 ≤ p} {μ : measure α}
+
+def snorm' (hp1 : 1 ≤ p) {f : α → β} (hf : measurable f) (μ : measure α) : ennreal :=
+(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)
+
+def snorm (f : ℒp α β hp1 μ) : ennreal := (∫⁻ a, (nnnorm (f.val a))^(p : ℝ) ∂μ) ^ (1/p)
+
+lemma snorm_eq_snorm' (f : ℒp α β hp1 μ) : snorm f = snorm' hp1 f.prop.1 μ := rfl
+
+lemma snorm'_lt_top {f : α → β} (hfp : in_ℒp hp1 μ f) : snorm' hp1 hfp.left μ < ⊤ :=
+begin
+  unfold snorm',
+  refine ennreal.rpow_lt_top_of_nonneg _ (ne_of_lt hfp.right),
+  rw [one_div, inv_nonneg],
+  exact le_trans zero_le_one hp1,
+end
+
+lemma snorm'_ne_top {f : α → β} (hfp : in_ℒp hp1 μ f) : snorm' hp1 hfp.left μ ≠ ⊤ :=
+ne_of_lt (snorm'_lt_top hfp)
+
+lemma snorm_lt_top {f : ℒp α β hp1 μ} : snorm f < ⊤ :=
+by {rw snorm_eq_snorm', exact snorm'_lt_top f.in_ℒp, }
+
+lemma snorm_ne_top (f : ℒp α β hp1 μ) : snorm f ≠ ⊤ := ne_of_lt snorm_lt_top
+
+lemma snorm_zero : snorm (0 : ℒp α β hp1 μ) = 0 :=
+begin
+  have hp0_lt : 0 < p, from lt_of_lt_of_le zero_lt_one hp1,
+  have h : ∫⁻ a, (nnnorm ((0 : ℒp α β hp1 μ).val a))^(p : ℝ) ∂μ = 0,
+  from lintegral_rpow_nnnorm_zero hp0_lt,
+  unfold snorm, rw h,
+  rw ennreal.rpow_eq_zero_iff,
+  left,
+  split,
+  refl,
+  rw [one_div, inv_pos], exact hp0_lt,
+end
+
+end ℒp


### PR DESCRIPTION
Define the space Lp of functions for which the norm raised to the power p has finite integral.
Define the seminorm on that space (without proof that it is a seminorm, for now).

Add three lemmas to analysis/special_functions/pow.lean about ennreal.rpow
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
