### PR TITLE
[Merged by Bors] - feat(measure_theory/lp_space): Define Lp spaces

### DIFF
--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -599,6 +599,16 @@ by rw sqrt_eq_rpow; exact continuous_rpow_of_pos (λa, by norm_num) continuous_i
 
 end sqrt
 
+lemma measurable_rpow {p : ℝ} (hp0 : 0 < p) : measurable (λ a : ℝ, a ^ p) :=
+begin
+  have h : continuous (λ a : ℝ, a ^ p),
+  { change continuous (λ a : ℝ, (id a) ^ ((λ a : ℝ, p) a)),
+    refine real.continuous_rpow _ continuous_id continuous_const,
+    intro a, right,
+    exact hp0, },
+  exact continuous.measurable h,
+end
+
 end real
 
 section differentiability
@@ -945,6 +955,16 @@ begin
   { exact ((continuous_subtype_val.comp continuous_fst).prod_mk continuous_snd).continuous_at }
 end
 
+lemma measurable_rpow {p : ℝ} (hp0 : 0 < p) : measurable (λ a : nnreal, a ^ p) :=
+begin
+  have h_rw : (λ (a : nnreal), a ^ p) = (λ (a : nnreal), nnreal.of_real(↑a ^ p)),
+  { ext1 a, rw ←nnreal.coe_rpow, rw nnreal.of_real_coe, },
+  rw h_rw,
+  refine measurable.nnreal_of_real _,
+  change measurable ((λ a : ℝ, a ^ p) ∘ (λ a : nnreal, ↑a)),
+  exact measurable.comp (real.measurable_rpow hp0) (nnreal.measurable_coe),
+end
+
 end nnreal
 
 open filter
@@ -1068,7 +1088,8 @@ end
 lemma rpow_eq_top_of_nonneg (x : ennreal) {p : ℝ} (hp0 : 0 ≤ p) : x ^ p = ⊤ → x = ⊤ :=
 begin
   rw ennreal.rpow_eq_top_iff,
-  intro h, cases h,
+  intro h,
+  cases h,
   { exfalso, rw lt_iff_not_ge at h, exact h.right hp0, },
   { exact h.left, },
 end
@@ -1336,6 +1357,13 @@ begin
   { simp [H] },
   { cases x, { simp [H, ne_of_gt] },
     simp [coe_rpow_of_nonneg _ (le_of_lt H)] }
+end
+
+lemma measurable_rpow_coe {p : ℝ} (hp0 : 0 < p) :
+  measurable (λ a : nnreal, (a : ennreal) ^ p) :=
+begin
+  simp_rw ennreal.coe_rpow_of_nonneg _ (le_of_lt hp0),
+  exact measurable.ennreal_coe (nnreal.measurable_rpow hp0),
 end
 
 end ennreal

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1065,6 +1065,20 @@ begin
     { simp [coe_rpow_of_ne_zero h, h] } }
 end
 
+lemma rpow_eq_top_of_nonneg (x : ennreal) {p : ℝ} (hp0 : 0 ≤ p) : x ^ p = ⊤ → x = ⊤ :=
+begin
+  rw ennreal.rpow_eq_top_iff,
+  intro h, cases h,
+  { exfalso, rw lt_iff_not_ge at h, exact h.right hp0, },
+  { exact h.left, },
+end
+
+lemma rpow_ne_top_of_nonneg {x : ennreal} {p : ℝ} (hp0 : 0 ≤ p) (h : x ≠ ⊤) : x ^ p ≠ ⊤ :=
+mt (ennreal.rpow_eq_top_of_nonneg x hp0) h
+
+lemma rpow_lt_top_of_nonneg {x : ennreal} {p : ℝ} (hp0 : 0 ≤ p) (h : x ≠ ⊤) : x ^ p < ⊤ :=
+ennreal.lt_top_iff_ne_top.mpr (ennreal.rpow_ne_top_of_nonneg hp0 h)
+
 lemma rpow_add {x : ennreal} (y z : ℝ) (hx : x ≠ 0) (h'x : x ≠ ⊤) : x ^ (y + z) = x ^ y * x ^ z :=
 begin
   cases x, { exact (h'x rfl).elim },

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -599,16 +599,6 @@ by rw sqrt_eq_rpow; exact continuous_rpow_of_pos (λa, by norm_num) continuous_i
 
 end sqrt
 
-lemma measurable_rpow {p : ℝ} (hp0 : 0 < p) : measurable (λ a : ℝ, a ^ p) :=
-begin
-  have h : continuous (λ a : ℝ, a ^ p),
-  { change continuous (λ a : ℝ, (id a) ^ ((λ a : ℝ, p) a)),
-    refine real.continuous_rpow _ continuous_id continuous_const,
-    intro a, right,
-    exact hp0, },
-  exact continuous.measurable h,
-end
-
 end real
 
 section differentiability
@@ -953,16 +943,6 @@ begin
     rw ← (nnreal.coe_eq_zero x) at h,
     exact h },
   { exact ((continuous_subtype_val.comp continuous_fst).prod_mk continuous_snd).continuous_at }
-end
-
-lemma measurable_rpow {p : ℝ} (hp0 : 0 < p) : measurable (λ a : nnreal, a ^ p) :=
-begin
-  have h_rw : (λ (a : nnreal), a ^ p) = (λ (a : nnreal), nnreal.of_real(↑a ^ p)),
-  { ext1 a, rw ←nnreal.coe_rpow, rw nnreal.of_real_coe, },
-  rw h_rw,
-  refine measurable.nnreal_of_real _,
-  change measurable ((λ a : ℝ, a ^ p) ∘ (λ a : nnreal, ↑a)),
-  exact measurable.comp (real.measurable_rpow hp0) (nnreal.measurable_coe),
 end
 
 end nnreal
@@ -1357,13 +1337,6 @@ begin
   { simp [H] },
   { cases x, { simp [H, ne_of_gt] },
     simp [coe_rpow_of_nonneg _ (le_of_lt H)] }
-end
-
-lemma measurable_rpow_coe {p : ℝ} (hp0 : 0 < p) :
-  measurable (λ a : nnreal, (a : ennreal) ^ p) :=
-begin
-  simp_rw ennreal.coe_rpow_of_nonneg _ (le_of_lt hp0),
-  exact measurable.ennreal_coe (nnreal.measurable_rpow hp0),
 end
 
 end ennreal

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1085,20 +1085,20 @@ begin
     { simp [coe_rpow_of_ne_zero h, h] } }
 end
 
-lemma rpow_eq_top_of_nonneg (x : ennreal) {y : ℝ} (hp0 : 0 ≤ y) : x ^ y = ⊤ → x = ⊤ :=
+lemma rpow_eq_top_of_nonneg (x : ennreal) {y : ℝ} (hy0 : 0 ≤ y) : x ^ y = ⊤ → x = ⊤ :=
 begin
   rw ennreal.rpow_eq_top_iff,
   intro h,
   cases h,
-  { exfalso, rw lt_iff_not_ge at h, exact h.right hp0, },
+  { exfalso, rw lt_iff_not_ge at h, exact h.right hy0, },
   { exact h.left, },
 end
 
-lemma rpow_ne_top_of_nonneg {x : ennreal} {y : ℝ} (hp0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y ≠ ⊤ :=
-mt (ennreal.rpow_eq_top_of_nonneg x hp0) h
+lemma rpow_ne_top_of_nonneg {x : ennreal} {y : ℝ} (hy0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y ≠ ⊤ :=
+mt (ennreal.rpow_eq_top_of_nonneg x hy0) h
 
-lemma rpow_lt_top_of_nonneg {x : ennreal} {y : ℝ} (hp0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y < ⊤ :=
-ennreal.lt_top_iff_ne_top.mpr (ennreal.rpow_ne_top_of_nonneg hp0 h)
+lemma rpow_lt_top_of_nonneg {x : ennreal} {y : ℝ} (hy0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y < ⊤ :=
+ennreal.lt_top_iff_ne_top.mpr (ennreal.rpow_ne_top_of_nonneg hy0 h)
 
 lemma rpow_add {x : ennreal} (y z : ℝ) (hx : x ≠ 0) (h'x : x ≠ ⊤) : x ^ (y + z) = x ^ y * x ^ z :=
 begin

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1085,7 +1085,7 @@ begin
     { simp [coe_rpow_of_ne_zero h, h] } }
 end
 
-lemma rpow_eq_top_of_nonneg (x : ennreal) {p : ℝ} (hp0 : 0 ≤ p) : x ^ p = ⊤ → x = ⊤ :=
+lemma rpow_eq_top_of_nonneg (x : ennreal) {y : ℝ} (hp0 : 0 ≤ y) : x ^ y = ⊤ → x = ⊤ :=
 begin
   rw ennreal.rpow_eq_top_iff,
   intro h,
@@ -1094,10 +1094,10 @@ begin
   { exact h.left, },
 end
 
-lemma rpow_ne_top_of_nonneg {x : ennreal} {p : ℝ} (hp0 : 0 ≤ p) (h : x ≠ ⊤) : x ^ p ≠ ⊤ :=
+lemma rpow_ne_top_of_nonneg {x : ennreal} {y : ℝ} (hp0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y ≠ ⊤ :=
 mt (ennreal.rpow_eq_top_of_nonneg x hp0) h
 
-lemma rpow_lt_top_of_nonneg {x : ennreal} {p : ℝ} (hp0 : 0 ≤ p) (h : x ≠ ⊤) : x ^ p < ⊤ :=
+lemma rpow_lt_top_of_nonneg {x : ennreal} {y : ℝ} (hp0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y < ⊤ :=
 ennreal.lt_top_iff_ne_top.mpr (ennreal.rpow_ne_top_of_nonneg hp0 h)
 
 lemma rpow_add {x : ennreal} (y z : ℝ) (hx : x ≠ 0) (h'x : x ≠ ⊤) : x ^ (y + z) = x ^ y * x ^ z :=

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -65,7 +65,7 @@ end
 lemma snorm_ne_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ ≠ ⊤ :=
 ne_of_lt (snorm_lt_top hp0 hfp)
 
-lemma lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top {f : α → β} (hp0_lt : 0 < p)
+lemma lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top {f : α → γ} (hp0_lt : 0 < p)
   (hfp : snorm f p μ < ⊤) :
   ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤ :=
 begin

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -43,6 +43,14 @@ measurable f ∧ ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤
 /-- seminorm on ℒp -/
 def snorm (f : α → γ) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)
 
+lemma lintegral_rpow_nnnorm_eq_rpow_snorm {f : α → γ} (hp0_lt : 0 < p) :
+  ∫⁻ a, (nnnorm (f a)) ^ p ∂μ = (snorm f p μ) ^ p :=
+begin
+  unfold snorm,
+  rw [←ennreal.rpow_mul, one_div, inv_mul_cancel, ennreal.rpow_one],
+  symmetry, exact ne_of_lt hp0_lt,
+end
+
 end ℒp_space_definition
 
 lemma mem_ℒp_one_iff_integrable : ∀ f : α → β, mem_ℒp f 1 μ ↔ integrable f μ :=
@@ -69,18 +77,8 @@ lemma lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top {f : α → γ} (hp0_lt : 0 <
   (hfp : snorm f p μ < ⊤) :
   ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤ :=
 begin
-  have h_top_eq : ⊤ ^ (1/p) = ⊤,
-  { rw ennreal.rpow_eq_top_iff, right, split,
-    refl,
-    simp only [one_div, inv_pos],
-    exact hp0_lt, },
-  rw ←h_top_eq at hfp,
-  unfold snorm at hfp,
-  have h_snorm_rpow : ((∫⁻ (a : α), ↑(nnnorm (f a)) ^ p ∂μ) ^ (1 / p))^p < (⊤ ^ (1 / p))^p,
-  { exact ennreal.rpow_lt_rpow hfp hp0_lt, },
-  rw [←ennreal.rpow_mul, ←ennreal.rpow_mul] at h_snorm_rpow,
-  simp_rw [one_div, inv_mul_cancel (ne_of_lt hp0_lt).symm, ennreal.rpow_one] at h_snorm_rpow,
-  exact h_snorm_rpow,
+  rw lintegral_rpow_nnnorm_eq_rpow_snorm hp0_lt,
+  exact ennreal.rpow_lt_top_of_nonneg (le_of_lt hp0_lt) (ne_of_lt hfp),
 end
 
 lemma mem_ℒp_of_snorm_lt_top {f : α → β} (hp0_lt : 0 < p) (hfm : measurable f)

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -52,6 +52,8 @@ begin
   simp only [ennreal.rpow_one, nnreal.coe_one],
 end
 
+section top
+
 lemma snorm_lt_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp p μ f) : snorm f p μ < ⊤ :=
 begin
   unfold snorm,
@@ -62,6 +64,38 @@ end
 
 lemma snorm_ne_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp p μ f) : snorm f p μ ≠ ⊤ :=
 ne_of_lt (snorm_lt_top hp0 hfp)
+
+lemma lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top {f : α → β} (hp0_lt : 0 < p)
+  (hfp : snorm f p μ < ⊤) :
+  ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤ :=
+begin
+  have h_top_eq : (⊤ : ennreal) = ⊤ ^ (1/p),
+  { symmetry, rw ennreal.rpow_eq_top_iff, right, split,
+    refl,
+    simp only [one_div, inv_pos], exact hp0_lt, },
+  rw h_top_eq at hfp,
+  unfold snorm at hfp,
+  have h_seminorm_rpow : ((∫⁻ (a : α), ↑(nnnorm (f a)) ^ p ∂μ) ^ (1 / p))^p < (⊤ ^ (1 / p))^p,
+  { exact ennreal.rpow_lt_rpow hfp hp0_lt, },
+  rw [←ennreal.rpow_mul, ←ennreal.rpow_mul] at h_seminorm_rpow,
+  simp_rw one_div at h_seminorm_rpow,
+  simp_rw inv_mul_cancel (ne_of_lt hp0_lt).symm at h_seminorm_rpow,
+  simp_rw ennreal.rpow_one at h_seminorm_rpow,
+  exact h_seminorm_rpow,
+end
+
+lemma mem_ℒp_of_snorm_lt_top {f : α → β} (hp0_lt : 0 < p) (hfm : measurable f)
+  (hfp : snorm f p μ < ⊤) :
+  mem_ℒp p μ f :=
+begin
+  split,
+  exact hfm,
+  exact lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top hp0_lt hfp,
+end
+
+end top
+
+section zero
 
 lemma lintegral_rpow_nnnorm_zero (hp0_lt : 0 < p) : ∫⁻ a, (nnnorm ((0 : α → γ) a))^p ∂μ = 0 :=
 begin
@@ -89,5 +123,7 @@ begin
   refl,
   rw [one_div, inv_pos], exact hp0_lt,
 end
+
+end zero
 
 end ℒp_space

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -30,7 +30,7 @@ noncomputable theory
 
 namespace ℒp_space
 
-variables {α E F: Type*} [measurable_space α] {μ : measure α}
+variables {α E F : Type*} [measurable_space α] {μ : measure α}
   [measurable_space E] [normed_group E]
   [normed_group F]
   {p : ℝ}
@@ -86,7 +86,7 @@ end top
 
 section zero
 
-lemma zero_mem_ℒp (hp0_lt : 0 < p): mem_ℒp (0 : α → E) p μ :=
+lemma zero_mem_ℒp (hp0_lt : 0 < p) : mem_ℒp (0 : α → E) p μ :=
 ⟨measurable_zero, by simp [hp0_lt]⟩
 
 @[simp] lemma snorm_zero (hp0_lt : 0 < p) : snorm (0 : α → F) p μ = 0 :=

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2020 Rémy Degenne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Rémy Degenne.
+-/
+import measure_theory.l1_space
+import analysis.special_functions.pow
+
+/-!
+# ℒp space
+
+This file describes the type of measurable functions with finite seminorm
+`(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)` for `p:ℝ` with `1 ≤ p`.
+
+## Main definitions and results
+
+* `ℒp α β hp1 μ` : the type of measurable functions `α → β` with finite p-seminorm for
+                      measure `μ`, for `hp1 : 1 ≤ p`,
+* `in_ℒp p μ f`  : the property 'f belongs to ℒp for measure μ' and real p.
+
+## Notation
+
+* `snorm' f ` : `(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : α → β`
+* `snorm f`   : `(∫⁻ a, (nnnorm (f.val a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : ℒp α β (1≤p) μ`
+
+-/
+
+open measure_theory
+
+section ℒp_space_definition
+variables {α β γ : Type*} [measurable_space α] [measurable_space β] [normed_group β]
+  [normed_group γ]
+
+/-- The property 'f belongs to ℒp for measure μ and real p' -/
+def in_ℒp (p : ℝ) (μ : measure α) (f : α → β) : Prop :=
+measurable f ∧ ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤
+
+/-- The type of measurable functions `α → β` with finite p-seminorm for measure `μ`, for `1 ≤ p` -/
+structure ℒp (α β : Type*) [measurable_space α] [measurable_space β] [normed_group β]
+  {p : ℝ} (hp1 : 1 ≤ p) (μ : measure α) :=
+(val : α → β)
+(measurable : measurable val)
+(lintegral_lt_top : ∫⁻ a, (nnnorm (val a))^p ∂μ < ⊤)
+(one_le_p : 1 ≤ p)
+
+variables {p : ℝ} {hp1 : 1 ≤ p} {μ : measure α}
+
+protected lemma ℒp.eq : ∀ {f g : ℒp α β hp1 μ}, f.val = g.val → f = g
+| ⟨x, h11, h12, h14⟩ ⟨.(x), h21, h22, h23⟩ rfl := rfl
+
+protected lemma ℒp.in_ℒp (f : ℒp α β hp1 μ) : in_ℒp p μ f.val :=
+begin
+  split,
+  exact f.measurable,
+  exact f.lintegral_lt_top,
+end
+
+/-- Build an element of ℒp from a function with the in_ℒp property -/
+def ℒp.mk_of_in_ℒp (hp1 : 1 ≤ p) {f : α → β} (h : in_ℒp p μ f) : ℒp α β hp1 μ :=
+⟨f, h.left, h.right, hp1⟩
+
+lemma ℒp.mk_of_in_ℒp_in_ℒp_eq_self (f : ℒp α β hp1 μ) : ℒp.mk_of_in_ℒp hp1 f.in_ℒp = f :=
+begin
+  refine ℒp.eq _, refl,
+end
+
+lemma is_in_ℒp_one_iff_integrable :
+  ∀ f : α → β, in_ℒp 1 μ f ↔ integrable f μ :=
+begin
+  intro f,
+  unfold integrable, unfold has_finite_integral, unfold in_ℒp,
+  simp only [ennreal.rpow_one, nnreal.coe_one],
+end
+
+lemma lintegral_rpow_nnnorm_zero (hp0_lt : 0 < p) : ∫⁻ a, (nnnorm ((0 : α → γ) a))^p ∂μ = 0 :=
+begin
+  simp_rw pi.zero_apply,
+  rw nnnorm_zero,
+  rw lintegral_const,
+  rw mul_eq_zero,
+  left,
+  exact ennreal.zero_rpow_of_pos hp0_lt,
+end
+
+lemma zero_in_ℒp (hp0_lt : 0 < p): in_ℒp p μ (0 : α → β) :=
+begin
+  split,
+  exact measurable_zero,
+  exact lt_of_le_of_lt (le_of_eq (lintegral_rpow_nnnorm_zero hp0_lt)) with_top.zero_lt_top,
+end
+
+/-- The zero function is the 0 in ℒp -/
+protected def ℒp.zero : ℒp α β hp1 μ :=
+ℒp.mk_of_in_ℒp hp1 (zero_in_ℒp (lt_of_lt_of_le zero_lt_one hp1))
+
+instance : has_zero (ℒp α β hp1 μ) := ⟨ℒp.zero⟩
+
+instance : inhabited (ℒp α β hp1 μ) := ⟨0⟩
+
+end ℒp_space_definition
+
+
+noncomputable theory
+
+namespace ℒp
+variables {α β γ: Type*} [measurable_space α] [measurable_space β] [normed_group β]
+  [normed_group γ]
+  {p : ℝ} {hp1 : 1 ≤ p} {μ : measure α}
+
+/-- seminorm on ℒp, with function and measure as arguments \ -/
+def snorm' (f : α → γ) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)
+
+/-- seminorm on ℒp -/
+def snorm (f : ℒp α β hp1 μ) : ennreal := (∫⁻ a, (nnnorm (f.val a))^(p : ℝ) ∂μ) ^ (1/p)
+
+lemma snorm_eq_snorm' (f : ℒp α β hp1 μ) : snorm f = snorm' f.val p μ := rfl
+
+lemma snorm'_lt_top {f : α → β} (hp0 : 0 ≤ p) (hfp : in_ℒp p μ f) : snorm' f p μ < ⊤ :=
+begin
+  unfold snorm',
+  refine ennreal.rpow_lt_top_of_nonneg _ (ne_of_lt hfp.right),
+  rw [one_div, inv_nonneg],
+  exact hp0,
+end
+
+lemma snorm'_ne_top {f : α → β} (hp0 : 0 ≤ p) (hfp : in_ℒp p μ f) : snorm' f p μ ≠ ⊤ :=
+ne_of_lt (snorm'_lt_top hp0 hfp)
+
+lemma snorm_lt_top {f : ℒp α β hp1 μ} : snorm f < ⊤ :=
+by {rw snorm_eq_snorm', exact snorm'_lt_top (le_trans zero_le_one f.one_le_p) f.in_ℒp, }
+
+lemma snorm_ne_top (f : ℒp α β hp1 μ) : snorm f ≠ ⊤ := ne_of_lt snorm_lt_top
+
+lemma snorm_zero : snorm (0 : ℒp α β hp1 μ) = 0 :=
+begin
+  have hp0_lt : 0 < p, from lt_of_lt_of_le zero_lt_one hp1,
+  have h : ∫⁻ a, (nnnorm ((0 : ℒp α β hp1 μ).val a))^(p : ℝ) ∂μ = 0,
+  from lintegral_rpow_nnnorm_zero hp0_lt,
+  unfold snorm,
+  rw [h, ennreal.rpow_eq_zero_iff],
+  left,
+  split,
+  refl,
+  rw [one_div, inv_pos], exact hp0_lt,
+end
+
+end ℒp

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -69,19 +69,18 @@ lemma lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top {f : α → γ} (hp0_lt : 0 <
   (hfp : snorm f p μ < ⊤) :
   ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤ :=
 begin
-  have h_top_eq : (⊤ : ennreal) = ⊤ ^ (1/p),
-  { symmetry, rw ennreal.rpow_eq_top_iff, right, split,
+  have h_top_eq : ⊤ ^ (1/p) = ⊤,
+  { rw ennreal.rpow_eq_top_iff, right, split,
     refl,
-    simp only [one_div, inv_pos], exact hp0_lt, },
-  rw h_top_eq at hfp,
+    simp only [one_div, inv_pos],
+    exact hp0_lt, },
+  rw ←h_top_eq at hfp,
   unfold snorm at hfp,
-  have h_seminorm_rpow : ((∫⁻ (a : α), ↑(nnnorm (f a)) ^ p ∂μ) ^ (1 / p))^p < (⊤ ^ (1 / p))^p,
+  have h_snorm_rpow : ((∫⁻ (a : α), ↑(nnnorm (f a)) ^ p ∂μ) ^ (1 / p))^p < (⊤ ^ (1 / p))^p,
   { exact ennreal.rpow_lt_rpow hfp hp0_lt, },
-  rw [←ennreal.rpow_mul, ←ennreal.rpow_mul] at h_seminorm_rpow,
-  simp_rw one_div at h_seminorm_rpow,
-  simp_rw inv_mul_cancel (ne_of_lt hp0_lt).symm at h_seminorm_rpow,
-  simp_rw ennreal.rpow_one at h_seminorm_rpow,
-  exact h_seminorm_rpow,
+  rw [←ennreal.rpow_mul, ←ennreal.rpow_mul] at h_snorm_rpow,
+  simp_rw [one_div, inv_mul_cancel (ne_of_lt hp0_lt).symm, ennreal.rpow_one] at h_snorm_rpow,
+  exact h_snorm_rpow,
 end
 
 lemma mem_ℒp_of_snorm_lt_top {f : α → β} (hp0_lt : 0 < p) (hfm : measurable f)

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -129,7 +129,7 @@ ne_of_lt (snorm'_lt_top hp0 hfp)
 lemma snorm_lt_top {f : ℒp α β hp1 μ} : snorm f < ⊤ :=
 by {rw snorm_eq_snorm', exact snorm'_lt_top (le_trans zero_le_one f.one_le_p) f.in_ℒp, }
 
-lemma snorm_ne_top (f : ℒp α β hp1 μ) : snorm f ≠ ⊤ := ne_of_lt snorm_lt_top
+lemma snorm_ne_top {f : ℒp α β hp1 μ} : snorm f ≠ ⊤ := ne_of_lt snorm_lt_top
 
 lemma snorm_zero : snorm (0 : ℒp α β hp1 μ) = 0 :=
 begin

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -94,7 +94,7 @@ lemma zero_mem_ℒp (hp0_lt : 0 < p): mem_ℒp (0 : α → E) p μ :=
 ⟨measurable_zero,
   lt_of_le_of_lt (le_of_eq (lintegral_rpow_nnnorm_zero hp0_lt)) with_top.zero_lt_top⟩
 
-@[simp] lemma snorm_zero (hp0_lt : 0 < p): snorm (0 : α → F) p μ = 0 :=
+@[simp] lemma snorm_zero (hp0_lt : 0 < p) : snorm (0 : α → F) p μ = 0 :=
 by simp [snorm, hp0_lt]
 
 end zero

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -14,7 +14,7 @@ This file describes properties of measurable functions with finite seminorm
 
 ## Main definitions
 
-* `mem_ℒp p μ f` : the function `f` has finite p-seminorm for measure `μ`, for `p:ℝ` such that
+* `mem_ℒp f p μ` : the function `f` has finite p-seminorm for measure `μ`, for `p:ℝ` such that
                   `hp1 : 1 ≤ p`,
 
 ## Notation
@@ -37,7 +37,7 @@ variables {α β γ: Type*} [measurable_space α] {μ : measure α}
 section ℒp_space_definition
 
 /-- The property that f belongs to ℒp for measure μ and real p -/
-def mem_ℒp (p : ℝ) (μ : measure α) (f : α → β) : Prop :=
+def mem_ℒp (f : α → β) (p : ℝ) (μ : measure α) : Prop :=
 measurable f ∧ ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤
 
 /-- seminorm on ℒp -/
@@ -45,7 +45,7 @@ def snorm (f : α → γ) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (n
 
 end ℒp_space_definition
 
-lemma mem_ℒp_one_iff_integrable : ∀ f : α → β, mem_ℒp 1 μ f ↔ integrable f μ :=
+lemma mem_ℒp_one_iff_integrable : ∀ f : α → β, mem_ℒp f 1 μ ↔ integrable f μ :=
 begin
   intro f,
   unfold integrable, unfold has_finite_integral, unfold mem_ℒp,
@@ -54,7 +54,7 @@ end
 
 section top
 
-lemma snorm_lt_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp p μ f) : snorm f p μ < ⊤ :=
+lemma snorm_lt_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ < ⊤ :=
 begin
   unfold snorm,
   refine ennreal.rpow_lt_top_of_nonneg _ (ne_of_lt hfp.right),
@@ -62,7 +62,7 @@ begin
   exact hp0,
 end
 
-lemma snorm_ne_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp p μ f) : snorm f p μ ≠ ⊤ :=
+lemma snorm_ne_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ ≠ ⊤ :=
 ne_of_lt (snorm_lt_top hp0 hfp)
 
 lemma lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top {f : α → β} (hp0_lt : 0 < p)
@@ -86,7 +86,7 @@ end
 
 lemma mem_ℒp_of_snorm_lt_top {f : α → β} (hp0_lt : 0 < p) (hfm : measurable f)
   (hfp : snorm f p μ < ⊤) :
-  mem_ℒp p μ f :=
+  mem_ℒp f p μ :=
 begin
   split,
   exact hfm,
@@ -105,7 +105,7 @@ begin
   exact ennreal.zero_rpow_of_pos hp0_lt,
 end
 
-lemma zero_mem_ℒp (hp0_lt : 0 < p): mem_ℒp p μ (0 : α → β) :=
+lemma zero_mem_ℒp (hp0_lt : 0 < p): mem_ℒp (0 : α → β) p μ :=
 begin
   split,
   exact measurable_zero,

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -87,12 +87,8 @@ end top
 
 section zero
 
-lemma lintegral_rpow_nnnorm_zero (hp0_lt : 0 < p) : ∫⁻ a, (nnnorm ((0 : α → F) a))^p ∂μ = 0 :=
-by simp [hp0_lt]
-
 lemma zero_mem_ℒp (hp0_lt : 0 < p): mem_ℒp (0 : α → E) p μ :=
-⟨measurable_zero,
-  lt_of_le_of_lt (le_of_eq (lintegral_rpow_nnnorm_zero hp0_lt)) with_top.zero_lt_top⟩
+⟨measurable_zero, by simp [hp0_lt]⟩
 
 @[simp] lemma snorm_zero (hp0_lt : 0 < p) : snorm (0 : α → F) p μ = 0 :=
 by simp [snorm, hp0_lt]

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -20,8 +20,8 @@ This file describes the type of measurable functions with finite seminorm
 
 ## Notation
 
-* `snorm' f ` : `(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : α → β`
-* `snorm f`   : `(∫⁻ a, (nnnorm (f.val a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : ℒp α β (1≤p) μ`
+* `snorm' f p μ` : `(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : α → β`
+* `snorm f`      : `(∫⁻ a, (nnnorm (f.val a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : ℒp α β (1≤p) μ`
 
 -/
 
@@ -32,7 +32,7 @@ variables {α β γ : Type*} [measurable_space α] [measurable_space β] [normed
   [normed_group γ]
 
 /-- The property 'f belongs to ℒp for measure μ and real p' -/
-def in_ℒp (p : ℝ) (μ : measure α) (f : α → β) : Prop :=
+def mem_ℒp (p : ℝ) (μ : measure α) (f : α → β) : Prop :=
 measurable f ∧ ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤
 
 /-- The type of measurable functions `α → β` with finite p-seminorm for measure `μ`, for `1 ≤ p` -/
@@ -48,7 +48,7 @@ variables {p : ℝ} {hp1 : 1 ≤ p} {μ : measure α}
 protected lemma ℒp.eq : ∀ {f g : ℒp α β hp1 μ}, f.val = g.val → f = g
 | ⟨x, h11, h12, h14⟩ ⟨.(x), h21, h22, h23⟩ rfl := rfl
 
-protected lemma ℒp.in_ℒp (f : ℒp α β hp1 μ) : in_ℒp p μ f.val :=
+protected lemma ℒp.mem_ℒp (f : ℒp α β hp1 μ) : mem_ℒp p μ f.val :=
 begin
   split,
   exact f.measurable,
@@ -56,19 +56,19 @@ begin
 end
 
 /-- Build an element of ℒp from a function with the in_ℒp property -/
-def ℒp.mk_of_in_ℒp (hp1 : 1 ≤ p) {f : α → β} (h : in_ℒp p μ f) : ℒp α β hp1 μ :=
+def ℒp.mk_of_mem_ℒp (hp1 : 1 ≤ p) {f : α → β} (h : mem_ℒp p μ f) : ℒp α β hp1 μ :=
 ⟨f, h.left, h.right, hp1⟩
 
-lemma ℒp.mk_of_in_ℒp_in_ℒp_eq_self (f : ℒp α β hp1 μ) : ℒp.mk_of_in_ℒp hp1 f.in_ℒp = f :=
+lemma ℒp.mk_of_mem_ℒp_mem_ℒp_eq_self (f : ℒp α β hp1 μ) : ℒp.mk_of_mem_ℒp hp1 f.mem_ℒp = f :=
 begin
   refine ℒp.eq _, refl,
 end
 
-lemma in_ℒp_one_iff_integrable :
-  ∀ f : α → β, in_ℒp 1 μ f ↔ integrable f μ :=
+lemma mem_ℒp_one_iff_integrable :
+  ∀ f : α → β, mem_ℒp 1 μ f ↔ integrable f μ :=
 begin
   intro f,
-  unfold integrable, unfold has_finite_integral, unfold in_ℒp,
+  unfold integrable, unfold has_finite_integral, unfold mem_ℒp,
   simp only [ennreal.rpow_one, nnreal.coe_one],
 end
 
@@ -82,7 +82,7 @@ begin
   exact ennreal.zero_rpow_of_pos hp0_lt,
 end
 
-lemma zero_in_ℒp (hp0_lt : 0 < p): in_ℒp p μ (0 : α → β) :=
+lemma zero_mem_ℒp (hp0_lt : 0 < p): mem_ℒp p μ (0 : α → β) :=
 begin
   split,
   exact measurable_zero,
@@ -91,7 +91,7 @@ end
 
 /-- The zero function is the 0 in ℒp -/
 protected def ℒp.zero : ℒp α β hp1 μ :=
-ℒp.mk_of_in_ℒp hp1 (zero_in_ℒp (lt_of_lt_of_le zero_lt_one hp1))
+ℒp.mk_of_mem_ℒp hp1 (zero_mem_ℒp (lt_of_lt_of_le zero_lt_one hp1))
 
 instance : has_zero (ℒp α β hp1 μ) := ⟨ℒp.zero⟩
 
@@ -115,7 +115,7 @@ def snorm (f : ℒp α β hp1 μ) : ennreal := (∫⁻ a, (nnnorm (f.val a))^(p 
 
 lemma snorm_eq_snorm' (f : ℒp α β hp1 μ) : snorm f = snorm' f.val p μ := rfl
 
-lemma snorm'_lt_top {f : α → β} (hp0 : 0 ≤ p) (hfp : in_ℒp p μ f) : snorm' f p μ < ⊤ :=
+lemma snorm'_lt_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp p μ f) : snorm' f p μ < ⊤ :=
 begin
   unfold snorm',
   refine ennreal.rpow_lt_top_of_nonneg _ (ne_of_lt hfp.right),
@@ -123,11 +123,11 @@ begin
   exact hp0,
 end
 
-lemma snorm'_ne_top {f : α → β} (hp0 : 0 ≤ p) (hfp : in_ℒp p μ f) : snorm' f p μ ≠ ⊤ :=
+lemma snorm'_ne_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp p μ f) : snorm' f p μ ≠ ⊤ :=
 ne_of_lt (snorm'_lt_top hp0 hfp)
 
 lemma snorm_lt_top {f : ℒp α β hp1 μ} : snorm f < ⊤ :=
-by {rw snorm_eq_snorm', exact snorm'_lt_top (le_trans zero_le_one f.one_le_p) f.in_ℒp, }
+by {rw snorm_eq_snorm', exact snorm'_lt_top (le_trans zero_le_one f.one_le_p) f.mem_ℒp, }
 
 lemma snorm_ne_top {f : ℒp α β hp1 μ} : snorm f ≠ ⊤ := ne_of_lt snorm_lt_top
 

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -48,19 +48,14 @@ def snorm (f : α → F) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (nn
 lemma lintegral_rpow_nnnorm_eq_rpow_snorm {f : α → F} (hp0_lt : 0 < p) :
   ∫⁻ a, (nnnorm (f a)) ^ p ∂μ = (snorm f p μ) ^ p :=
 begin
-  unfold snorm,
-  rw [←ennreal.rpow_mul, one_div, inv_mul_cancel, ennreal.rpow_one],
-  symmetry, exact ne_of_lt hp0_lt,
+  rw [snorm, ←ennreal.rpow_mul, one_div, inv_mul_cancel, ennreal.rpow_one],
+  exact (ne_of_lt hp0_lt).symm,
 end
 
 end ℒp_space_definition
 
-lemma mem_ℒp_one_iff_integrable : ∀ f : α → E, mem_ℒp f 1 μ ↔ integrable f μ :=
-begin
-  intro f,
-  unfold integrable, unfold has_finite_integral, unfold mem_ℒp,
-  simp only [ennreal.rpow_one, nnreal.coe_one],
-end
+lemma mem_ℒp_one_iff_integrable {f : α → E} : mem_ℒp f 1 μ ↔ integrable f μ :=
+by simp only [integrable, has_finite_integral, mem_ℒp, ennreal.rpow_one, nnreal.coe_one]
 
 section top
 
@@ -86,42 +81,21 @@ end
 lemma mem_ℒp_of_snorm_lt_top {f : α → E} (hp0_lt : 0 < p) (hfm : measurable f)
   (hfp : snorm f p μ < ⊤) :
   mem_ℒp f p μ :=
-begin
-  split,
-  exact hfm,
-  exact lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top hp0_lt hfp,
-end
+⟨hfm, lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top hp0_lt hfp⟩
 
 end top
 
 section zero
 
 lemma lintegral_rpow_nnnorm_zero (hp0_lt : 0 < p) : ∫⁻ a, (nnnorm ((0 : α → F) a))^p ∂μ = 0 :=
-begin
-  simp_rw pi.zero_apply,
-  rw [nnnorm_zero, lintegral_const, mul_eq_zero],
-  left,
-  exact ennreal.zero_rpow_of_pos hp0_lt,
-end
+by simp [hp0_lt]
 
 lemma zero_mem_ℒp (hp0_lt : 0 < p): mem_ℒp (0 : α → E) p μ :=
-begin
-  split,
-  exact measurable_zero,
-  exact lt_of_le_of_lt (le_of_eq (lintegral_rpow_nnnorm_zero hp0_lt)) with_top.zero_lt_top,
-end
+⟨measurable_zero,
+  lt_of_le_of_lt (le_of_eq (lintegral_rpow_nnnorm_zero hp0_lt)) with_top.zero_lt_top⟩
 
-lemma snorm_zero (hp0_lt : 0 < p): snorm (0 : α → F) p μ = 0 :=
-begin
-  have h : ∫⁻ a, (nnnorm ((0 : α → F) a))^(p : ℝ) ∂μ = 0,
-  from lintegral_rpow_nnnorm_zero hp0_lt,
-  unfold snorm,
-  rw [h, ennreal.rpow_eq_zero_iff],
-  left,
-  split,
-  refl,
-  rw [one_div, inv_pos], exact hp0_lt,
-end
+@[simp] lemma snorm_zero (hp0_lt : 0 < p): snorm (0 : α → F) p μ = 0 :=
+by simp [snorm, hp0_lt]
 
 end zero
 

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -9,8 +9,8 @@ import analysis.special_functions.pow
 /-!
 # ℒp space
 
-This file describes properties of measurable functions with finite seminorm
-`(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)` for `p:ℝ` with `1 ≤ p`.
+This file describes properties of measurable functions with finite seminorm `(∫ ∥f a∥^p ∂μ) ^ (1/p)`
+for `p:ℝ` with `1 ≤ p`.
 
 ## Main definitions
 
@@ -19,8 +19,8 @@ This file describes properties of measurable functions with finite seminorm
 
 ## Notation
 
-* `snorm f p μ` : `(∫⁻ a, (nnnorm (f a)) ^ p ∂μ) ^ (1/p)` for `f : α → F`, where `α` is a
-  measurable space and `F` is a normed group.
+* `snorm f p μ` : `(∫ ∥f a∥^p ∂μ) ^ (1/p)` for `f : α → F`, where `α` is a  measurable space and
+                  `F` is a normed group.
 
 -/
 
@@ -37,12 +37,12 @@ variables {α E F : Type*} [measurable_space α] {μ : measure α}
 
 section ℒp_space_definition
 
-/-- The property that `f:α→E` is measurable and `∫⁻ a, (nnnorm (f a)) ^ p ∂μ` is finite -/
+/-- The property that `f:α→E` is measurable and `∫ ∥f a∥^p ∂μ` is finite -/
 def mem_ℒp (f : α → E) (p : ℝ) (μ : measure α) : Prop :=
 measurable f ∧ ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤
 
-/-- `(∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)`, which is a seminorm on the space of measurable
-functions for which this quantity is finite -/
+/-- `(∫ ∥f a∥^p ∂μ) ^ (1/p)`, which is a seminorm on the space of measurable functions for which
+this quantity is finite -/
 def snorm (f : α → F) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)
 
 lemma lintegral_rpow_nnnorm_eq_rpow_snorm {f : α → F} (hp0_lt : 0 < p) :

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -64,7 +64,7 @@ begin
   refine ℒp.eq _, refl,
 end
 
-lemma is_in_ℒp_one_iff_integrable :
+lemma in_ℒp_one_iff_integrable :
   ∀ f : α → β, in_ℒp 1 μ f ↔ integrable f μ :=
 begin
   intro f,

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -102,7 +102,7 @@ end ℒp_space_definition
 
 noncomputable theory
 
-namespace ℒp
+namespace ℒp_space
 variables {α β γ: Type*} [measurable_space α] [measurable_space β] [normed_group β]
   [normed_group γ]
   {p : ℝ} {hp1 : 1 ≤ p} {μ : measure α}
@@ -144,4 +144,4 @@ begin
   rw [one_div, inv_pos], exact hp0_lt,
 end
 
-end ℒp
+end ℒp_space

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -9,75 +9,64 @@ import analysis.special_functions.pow
 /-!
 # ℒp space
 
-This file describes the type of measurable functions with finite seminorm
+This file describes properties of measurable functions with finite seminorm
 `(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)` for `p:ℝ` with `1 ≤ p`.
 
-## Main definitions and results
+## Main definitions
 
-* `ℒp α β hp1 μ` : the type of measurable functions `α → β` with finite p-seminorm for
-                      measure `μ`, for `hp1 : 1 ≤ p`,
-* `mem_ℒp p μ f` : the property 'f belongs to ℒp for measure μ' and real p.
+* `mem_ℒp p μ f` : the function `f` has finite p-seminorm for measure `μ`, for `p:ℝ` such that
+                  `hp1 : 1 ≤ p`,
 
 ## Notation
 
-* `snorm' f p μ` : `(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : α → β`
-* `snorm f`      : `(∫⁻ a, (nnnorm (f.val a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : ℒp α β (1≤p) μ`
+* `snorm f p μ` : `(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : α → β`
 
 -/
 
 open measure_theory
 
-section ℒp_space_definition
-variables {α β γ : Type*} [measurable_space α] [measurable_space β] [normed_group β]
-  [normed_group γ]
+noncomputable theory
 
-/-- The property 'f belongs to ℒp for measure μ and real p' -/
+namespace ℒp_space
+
+variables {α β γ: Type*} [measurable_space α] {μ : measure α}
+  [measurable_space β] [normed_group β]
+  [normed_group γ]
+  {p : ℝ}
+
+section ℒp_space_definition
+
+/-- The property that f belongs to ℒp for measure μ and real p -/
 def mem_ℒp (p : ℝ) (μ : measure α) (f : α → β) : Prop :=
 measurable f ∧ ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤
 
-/-- The type of measurable functions `α → β` with finite p-seminorm for measure `μ`, for `1 ≤ p` -/
-structure ℒp (α β : Type*) [measurable_space α] [measurable_space β] [normed_group β]
-  {p : ℝ} (hp1 : 1 ≤ p) (μ : measure α) :=
-(val : α → β)
-(measurable : measurable val)
-(lintegral_lt_top : ∫⁻ a, (nnnorm (val a))^p ∂μ < ⊤)
-(one_le_p : 1 ≤ p)
+/-- seminorm on ℒp -/
+def snorm (f : α → γ) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)
 
-variables {p : ℝ} {hp1 : 1 ≤ p} {μ : measure α}
+end ℒp_space_definition
 
-protected lemma ℒp.eq : ∀ {f g : ℒp α β hp1 μ}, f.val = g.val → f = g
-| ⟨x, h11, h12, h14⟩ ⟨.(x), h21, h22, h23⟩ rfl := rfl
-
-protected lemma ℒp.mem_ℒp (f : ℒp α β hp1 μ) : mem_ℒp p μ f.val :=
-begin
-  split,
-  exact f.measurable,
-  exact f.lintegral_lt_top,
-end
-
-/-- Build an element of ℒp from a function with the in_ℒp property -/
-def ℒp.mk_of_mem_ℒp (hp1 : 1 ≤ p) {f : α → β} (h : mem_ℒp p μ f) : ℒp α β hp1 μ :=
-⟨f, h.left, h.right, hp1⟩
-
-lemma ℒp.mk_of_mem_ℒp_mem_ℒp_eq_self (f : ℒp α β hp1 μ) : ℒp.mk_of_mem_ℒp hp1 f.mem_ℒp = f :=
-begin
-  refine ℒp.eq _, refl,
-end
-
-lemma mem_ℒp_one_iff_integrable :
-  ∀ f : α → β, mem_ℒp 1 μ f ↔ integrable f μ :=
+lemma mem_ℒp_one_iff_integrable : ∀ f : α → β, mem_ℒp 1 μ f ↔ integrable f μ :=
 begin
   intro f,
   unfold integrable, unfold has_finite_integral, unfold mem_ℒp,
   simp only [ennreal.rpow_one, nnreal.coe_one],
 end
 
+lemma snorm_lt_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp p μ f) : snorm f p μ < ⊤ :=
+begin
+  unfold snorm,
+  refine ennreal.rpow_lt_top_of_nonneg _ (ne_of_lt hfp.right),
+  rw [one_div, inv_nonneg],
+  exact hp0,
+end
+
+lemma snorm_ne_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp p μ f) : snorm f p μ ≠ ⊤ :=
+ne_of_lt (snorm_lt_top hp0 hfp)
+
 lemma lintegral_rpow_nnnorm_zero (hp0_lt : 0 < p) : ∫⁻ a, (nnnorm ((0 : α → γ) a))^p ∂μ = 0 :=
 begin
   simp_rw pi.zero_apply,
-  rw nnnorm_zero,
-  rw lintegral_const,
-  rw mul_eq_zero,
+  rw [nnnorm_zero, lintegral_const, mul_eq_zero],
   left,
   exact ennreal.zero_rpow_of_pos hp0_lt,
 end
@@ -89,52 +78,9 @@ begin
   exact lt_of_le_of_lt (le_of_eq (lintegral_rpow_nnnorm_zero hp0_lt)) with_top.zero_lt_top,
 end
 
-/-- The zero function is the 0 in ℒp -/
-protected def ℒp.zero : ℒp α β hp1 μ :=
-ℒp.mk_of_mem_ℒp hp1 (zero_mem_ℒp (lt_of_lt_of_le zero_lt_one hp1))
-
-instance : has_zero (ℒp α β hp1 μ) := ⟨ℒp.zero⟩
-
-instance : inhabited (ℒp α β hp1 μ) := ⟨0⟩
-
-end ℒp_space_definition
-
-
-noncomputable theory
-
-namespace ℒp_space
-variables {α β γ: Type*} [measurable_space α] [measurable_space β] [normed_group β]
-  [normed_group γ]
-  {p : ℝ} {hp1 : 1 ≤ p} {μ : measure α}
-
-/-- seminorm on ℒp, with function and measure as arguments \ -/
-def snorm' (f : α → γ) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)
-
-/-- seminorm on ℒp -/
-def snorm (f : ℒp α β hp1 μ) : ennreal := (∫⁻ a, (nnnorm (f.val a))^(p : ℝ) ∂μ) ^ (1/p)
-
-lemma snorm_eq_snorm' (f : ℒp α β hp1 μ) : snorm f = snorm' f.val p μ := rfl
-
-lemma snorm'_lt_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp p μ f) : snorm' f p μ < ⊤ :=
+lemma snorm_zero (hp0_lt : 0 < p): snorm (0 : α → γ) p μ = 0 :=
 begin
-  unfold snorm',
-  refine ennreal.rpow_lt_top_of_nonneg _ (ne_of_lt hfp.right),
-  rw [one_div, inv_nonneg],
-  exact hp0,
-end
-
-lemma snorm'_ne_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp p μ f) : snorm' f p μ ≠ ⊤ :=
-ne_of_lt (snorm'_lt_top hp0 hfp)
-
-lemma snorm_lt_top {f : ℒp α β hp1 μ} : snorm f < ⊤ :=
-by {rw snorm_eq_snorm', exact snorm'_lt_top (le_trans zero_le_one f.one_le_p) f.mem_ℒp, }
-
-lemma snorm_ne_top {f : ℒp α β hp1 μ} : snorm f ≠ ⊤ := ne_of_lt snorm_lt_top
-
-lemma snorm_zero : snorm (0 : ℒp α β hp1 μ) = 0 :=
-begin
-  have hp0_lt : 0 < p, from lt_of_lt_of_le zero_lt_one hp1,
-  have h : ∫⁻ a, (nnnorm ((0 : ℒp α β hp1 μ).val a))^(p : ℝ) ∂μ = 0,
+  have h : ∫⁻ a, (nnnorm ((0 : α → γ) a))^(p : ℝ) ∂μ = 0,
   from lintegral_rpow_nnnorm_zero hp0_lt,
   unfold snorm,
   rw [h, ennreal.rpow_eq_zero_iff],

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -61,7 +61,6 @@ section top
 
 lemma snorm_lt_top {f : α → E} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ < ⊤ :=
 begin
-  unfold snorm,
   refine ennreal.rpow_lt_top_of_nonneg _ (ne_of_lt hfp.right),
   rw [one_div, inv_nonneg],
   exact hp0,

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -59,15 +59,15 @@ by simp only [integrable, has_finite_integral, mem_ℒp, ennreal.rpow_one, nnrea
 
 section top
 
-lemma snorm_lt_top {f : α → E} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ < ⊤ :=
+lemma mem_ℒp.snorm_lt_top {f : α → E} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ < ⊤ :=
 begin
   refine ennreal.rpow_lt_top_of_nonneg _ (ne_of_lt hfp.right),
   rw [one_div, inv_nonneg],
   exact hp0,
 end
 
-lemma snorm_ne_top {f : α → E} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ ≠ ⊤ :=
-ne_of_lt (snorm_lt_top hp0 hfp)
+lemma mem_ℒp.snorm_ne_top {f : α → E} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ ≠ ⊤ :=
+ne_of_lt (hfp.snorm_lt_top hp0)
 
 lemma lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top {f : α → F} (hp0_lt : 0 < p)
   (hfp : snorm f p μ < ⊤) :

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -16,7 +16,7 @@ This file describes the type of measurable functions with finite seminorm
 
 * `ℒp α β hp1 μ` : the type of measurable functions `α → β` with finite p-seminorm for
                       measure `μ`, for `hp1 : 1 ≤ p`,
-* `in_ℒp p μ f`  : the property 'f belongs to ℒp for measure μ' and real p.
+* `mem_ℒp p μ f` : the property 'f belongs to ℒp for measure μ' and real p.
 
 ## Notation
 

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -19,7 +19,8 @@ This file describes properties of measurable functions with finite seminorm
 
 ## Notation
 
-* `snorm f p μ` : `(∫⁻ a, (nnnorm (f a))^(p : ℝ) ∂μ) ^ (1/p)` for `f : α → β`
+* `snorm f p μ` : `(∫⁻ a, (nnnorm (f a)) ^ p ∂μ) ^ (1/p)` for `f : α → F`, where `α` is a
+  measurable space and `F` is a normed group.
 
 -/
 
@@ -29,21 +30,22 @@ noncomputable theory
 
 namespace ℒp_space
 
-variables {α β γ: Type*} [measurable_space α] {μ : measure α}
-  [measurable_space β] [normed_group β]
-  [normed_group γ]
+variables {α E F: Type*} [measurable_space α] {μ : measure α}
+  [measurable_space E] [normed_group E]
+  [normed_group F]
   {p : ℝ}
 
 section ℒp_space_definition
 
-/-- The property that f belongs to ℒp for measure μ and real p -/
-def mem_ℒp (f : α → β) (p : ℝ) (μ : measure α) : Prop :=
+/-- The property that `f:α→E` is measurable and `∫⁻ a, (nnnorm (f a)) ^ p ∂μ` is finite -/
+def mem_ℒp (f : α → E) (p : ℝ) (μ : measure α) : Prop :=
 measurable f ∧ ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤
 
-/-- seminorm on ℒp -/
-def snorm (f : α → γ) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)
+/-- `(∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)`, which is a seminorm on the space of measurable
+functions for which this quantity is finite -/
+def snorm (f : α → F) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)
 
-lemma lintegral_rpow_nnnorm_eq_rpow_snorm {f : α → γ} (hp0_lt : 0 < p) :
+lemma lintegral_rpow_nnnorm_eq_rpow_snorm {f : α → F} (hp0_lt : 0 < p) :
   ∫⁻ a, (nnnorm (f a)) ^ p ∂μ = (snorm f p μ) ^ p :=
 begin
   unfold snorm,
@@ -53,7 +55,7 @@ end
 
 end ℒp_space_definition
 
-lemma mem_ℒp_one_iff_integrable : ∀ f : α → β, mem_ℒp f 1 μ ↔ integrable f μ :=
+lemma mem_ℒp_one_iff_integrable : ∀ f : α → E, mem_ℒp f 1 μ ↔ integrable f μ :=
 begin
   intro f,
   unfold integrable, unfold has_finite_integral, unfold mem_ℒp,
@@ -62,7 +64,7 @@ end
 
 section top
 
-lemma snorm_lt_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ < ⊤ :=
+lemma snorm_lt_top {f : α → E} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ < ⊤ :=
 begin
   unfold snorm,
   refine ennreal.rpow_lt_top_of_nonneg _ (ne_of_lt hfp.right),
@@ -70,10 +72,10 @@ begin
   exact hp0,
 end
 
-lemma snorm_ne_top {f : α → β} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ ≠ ⊤ :=
+lemma snorm_ne_top {f : α → E} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ ≠ ⊤ :=
 ne_of_lt (snorm_lt_top hp0 hfp)
 
-lemma lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top {f : α → γ} (hp0_lt : 0 < p)
+lemma lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top {f : α → F} (hp0_lt : 0 < p)
   (hfp : snorm f p μ < ⊤) :
   ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤ :=
 begin
@@ -81,7 +83,7 @@ begin
   exact ennreal.rpow_lt_top_of_nonneg (le_of_lt hp0_lt) (ne_of_lt hfp),
 end
 
-lemma mem_ℒp_of_snorm_lt_top {f : α → β} (hp0_lt : 0 < p) (hfm : measurable f)
+lemma mem_ℒp_of_snorm_lt_top {f : α → E} (hp0_lt : 0 < p) (hfm : measurable f)
   (hfp : snorm f p μ < ⊤) :
   mem_ℒp f p μ :=
 begin
@@ -94,7 +96,7 @@ end top
 
 section zero
 
-lemma lintegral_rpow_nnnorm_zero (hp0_lt : 0 < p) : ∫⁻ a, (nnnorm ((0 : α → γ) a))^p ∂μ = 0 :=
+lemma lintegral_rpow_nnnorm_zero (hp0_lt : 0 < p) : ∫⁻ a, (nnnorm ((0 : α → F) a))^p ∂μ = 0 :=
 begin
   simp_rw pi.zero_apply,
   rw [nnnorm_zero, lintegral_const, mul_eq_zero],
@@ -102,16 +104,16 @@ begin
   exact ennreal.zero_rpow_of_pos hp0_lt,
 end
 
-lemma zero_mem_ℒp (hp0_lt : 0 < p): mem_ℒp (0 : α → β) p μ :=
+lemma zero_mem_ℒp (hp0_lt : 0 < p): mem_ℒp (0 : α → E) p μ :=
 begin
   split,
   exact measurable_zero,
   exact lt_of_le_of_lt (le_of_eq (lintegral_rpow_nnnorm_zero hp0_lt)) with_top.zero_lt_top,
 end
 
-lemma snorm_zero (hp0_lt : 0 < p): snorm (0 : α → γ) p μ = 0 :=
+lemma snorm_zero (hp0_lt : 0 < p): snorm (0 : α → F) p μ = 0 :=
 begin
-  have h : ∫⁻ a, (nnnorm ((0 : α → γ) a))^(p : ℝ) ∂μ = 0,
+  have h : ∫⁻ a, (nnnorm ((0 : α → F) a))^(p : ℝ) ∂μ = 0,
   from lintegral_rpow_nnnorm_zero hp0_lt,
   unfold snorm,
   rw [h, ennreal.rpow_eq_zero_iff],


### PR DESCRIPTION
Define the space Lp of functions for which the norm raised to the power p has finite integral.
Define the seminorm on that space (without proof that it is a seminorm, for now).

Add three lemmas to analysis/special_functions/pow.lean about ennreal.rpow
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
