### PR TITLE
[Merged by Bors] - chore(data/complex/is_R_or_C): Remove two unnecessary axioms

### DIFF
--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1102,14 +1102,12 @@ def inner_product_space.is_R_or_C_to_real : inner_product_space ℝ E :=
 { norm_sq_eq_inner := norm_sq_eq_inner,
   conj_sym := λ x y, inner_re_symm,
   nonneg_im := λ x, rfl,
-  add_left := λ x y z, by { change re ⟪x + y, z⟫ = re ⟪x, z⟫ + re ⟪y, z⟫, simp [inner_add_left] },
-  smul_left :=
-  begin
-    intros x y r,
+  add_left := λ x y z, by {
+    change re ⟪x + y, z⟫ = re ⟪x, z⟫ + re ⟪y, z⟫,
+    simp [inner_add_left] },
+  smul_left := λ x y r, by {
     change re ⟪(algebra_map ℝ 𝕜 r) • x, y⟫ = r * re ⟪x, y⟫,
-    have : algebra_map ℝ 𝕜 r = r • (1 : 𝕜) := by simp [algebra_map, algebra.smul_def'],
-    simp [this, inner_smul_left, smul_coe_mul_ax],
-  end,
+    simp [inner_smul_left] },
   ..has_inner.is_R_or_C_to_real 𝕜,
   ..normed_space.restrict_scalars ℝ 𝕜 E }
 

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -58,7 +58,7 @@ local notation `𝓚` := @is_R_or_C.of_real K _
 local postfix `†`:100 := @is_R_or_C.conj K _
 
 lemma of_real_alg (x : ℝ) : 𝓚 x = x • (1 : K) :=
-mul_one (𝓚 x) ▸ (algebra.smul_def x (1 : K)).symm
+algebra.algebra_map_eq_smul_one x
 
 @[simp] lemma re_add_im (z : K) : 𝓚 (re z) + 𝓚 (im z) * I = z := is_R_or_C.re_add_im_ax z
 @[simp] lemma of_real_re : ∀ r : ℝ, re (𝓚 r) = r := is_R_or_C.of_real_re_ax
@@ -80,19 +80,17 @@ by { simp_rw ext_iff, cc }
 
 @[simp] lemma zero_re : re (𝓚 0) = (0 : ℝ) := by simp only [of_real_re]
 @[simp] lemma zero_im : im (𝓚 0) = 0 := by rw [of_real_im]
-lemma of_real_zero : 𝓚 0 = 0 := by rw [of_real_alg, zero_smul]
+lemma of_real_zero : 𝓚 0 = 0 := (algebra_map ℝ K).map_zero
 
-@[simp] lemma zero_re' : re (0 : K) = (0 : ℝ) :=
-by simp only [add_monoid_hom.map_zero]
+@[simp] lemma zero_re' : re (0 : K) = (0 : ℝ) := re.map_zero
 
 
-@[simp] lemma of_real_one : 𝓚 1 = 1 := by rw [of_real_alg, one_smul]
+@[simp] lemma of_real_one : 𝓚 1 = 1 := (algebra_map ℝ K).map_one
 @[simp] lemma one_re : re (1 : K) = 1 := by rw [←of_real_one, of_real_re]
 @[simp] lemma one_im : im (1 : K) = 0 := by rw [←of_real_one, of_real_im]
 
 @[simp] theorem of_real_inj {z w : ℝ} : 𝓚 z = 𝓚 w ↔ z = w :=
-{ mp := λ h, by { convert congr_arg re h; simp only [of_real_re] },
-  mpr := λ h, by rw h }
+(algebra_map ℝ K).injective.eq_iff
 
 
 @[simp] lemma bit0_re (z : K) : re (bit0 z) = bit0 (re z) := by simp [bit0]
@@ -103,16 +101,16 @@ by simp only [bit1, add_monoid_hom.map_add, bit0_re, add_right_inj, one_re]
 by simp only [bit1, add_right_eq_self, add_monoid_hom.map_add, bit0_im, one_im]
 
 @[simp] theorem of_real_eq_zero {z : ℝ} : 𝓚 z = 0 ↔ z = 0 :=
-by rw [←of_real_zero]; exact of_real_inj
+(algebra_map ℝ K).map_eq_zero
 
 @[simp] lemma of_real_add ⦃r s : ℝ⦄ : 𝓚 (r + s) = 𝓚 r + 𝓚 s :=
-by apply (@is_R_or_C.ext_iff K _ (𝓚 (r + s)) (𝓚 r + 𝓚 s)).mpr; simp
+(algebra_map ℝ K).map_add r s
 
 @[simp] lemma of_real_bit0 (r : ℝ) : 𝓚 (bit0 r : ℝ) = bit0 (𝓚 r) :=
-ext_iff.2 $ by simp [bit0]
+(algebra_map ℝ K).map_bit0 r
 
 @[simp] lemma of_real_bit1 (r : ℝ) : 𝓚 (bit1 r : ℝ) = bit1 (𝓚 r) :=
-ext_iff.2 $ by simp [bit1]
+(algebra_map ℝ K).map_bit1 r
 
 /- Note: This can be proven by `norm_num` once K is proven to be of characteristic zero below. -/
 lemma two_ne_zero : (2 : K) ≠ 0 :=
@@ -270,10 +268,7 @@ by simp [inv_def, norm_sq_eq_def, norm_sq, division_def]
 by simp [inv_def, norm_sq_eq_def, norm_sq, division_def]
 
 @[simp] lemma of_real_inv (r : ℝ) : 𝓚 (r⁻¹) = (𝓚 r)⁻¹ :=
-begin
-  rw ext_iff, by_cases r = 0, { simp [h] },
-  { simp; field_simp [h, norm_sq] },
-end
+(algebra_map ℝ K).map_inv r
 
 protected lemma inv_zero : (0⁻¹ : K) = 0 :=
 by rw [← of_real_zero, ← of_real_inv, inv_zero]

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -20,6 +20,9 @@ complex case. One would produce the definitions and proof for an arbitrary field
 typeclass, which basically amounts to doing the complex case, and the two cases then fall out
 immediately from the two instances of the class.
 -/
+section
+
+local notation `𝓚` := algebra_map ℝ _
 
 /--
 This typeclass captures properties shared by ℝ and ℂ, with an API that closely matches that of ℂ.
@@ -29,13 +32,11 @@ class is_R_or_C (K : Type*) extends nondiscrete_normed_field K, normed_algebra �
 (im : K →+ ℝ)
 (conj : K →+* K)
 (I : K)                 -- Meant to be set to 0 for K=ℝ
-(of_real : ℝ → K)      -- Meant to be id for K=ℝ and the coercion from ℝ for K=ℂ
 (I_re_ax : re I = 0)
 (I_mul_I_ax : I = 0 ∨ I * I = -1)
-(re_add_im_ax : ∀ (z : K), of_real (re z) + of_real (im z) * I = z)
-(smul_coe_mul_ax : ∀ (z : K) (r : ℝ), r • z = of_real r * z)
-(of_real_re_ax : ∀ r : ℝ, re (of_real r) = r)
-(of_real_im_ax : ∀ r : ℝ, im (of_real r) = 0)
+(re_add_im_ax : ∀ (z : K), 𝓚 (re z) + 𝓚 (im z) * I = z)
+(of_real_re_ax : ∀ r : ℝ, re (𝓚 r) = r)
+(of_real_im_ax : ∀ r : ℝ, im (𝓚 r) = 0)
 (mul_re_ax : ∀ z w : K, re (z * w) = re z * re w - im z * im w)
 (mul_im_ax : ∀ z w : K, im (z * w) = re z * im w + im z * re w)
 (conj_re_ax : ∀ z : K, re (conj z) = re z)
@@ -43,17 +44,21 @@ class is_R_or_C (K : Type*) extends nondiscrete_normed_field K, normed_algebra �
 (conj_I_ax : conj I = -I)
 (norm_sq_eq_def_ax : ∀ (z : K), ∥z∥^2 = (re z) * (re z) + (im z) * (im z))
 (mul_im_I_ax : ∀ (z : K), (im z) * im I = im z)
-(inv_def_ax : ∀ (z : K), z⁻¹ = conj z * of_real ((∥z∥^2)⁻¹))
+(inv_def_ax : ∀ (z : K), z⁻¹ = conj z * 𝓚 ((∥z∥^2)⁻¹))
 (div_I_ax : ∀ (z : K), z / I = -(z * I))
 
-namespace is_R_or_C
+end
 
+namespace is_R_or_C
 variables {K : Type*} [is_R_or_C K]
+
+noncomputable abbreviation of_real (r : ℝ) := algebra_map ℝ K r
+
 local notation `𝓚` := @is_R_or_C.of_real K _
 local postfix `†`:100 := @is_R_or_C.conj K _
 
-lemma of_real_alg : ∀ x : ℝ, 𝓚 x = x • (1 : K) :=
-λ x, by rw [←mul_one (𝓚 x), smul_coe_mul_ax]
+lemma of_real_alg (x : ℝ) : 𝓚 x = x • (1 : K) :=
+mul_one (𝓚 x) ▸ (algebra.smul_def x (1 : K)).symm
 
 @[simp] lemma re_add_im (z : K) : 𝓚 (re z) + 𝓚 (im z) * I = z := is_R_or_C.re_add_im_ax z
 @[simp] lemma of_real_re : ∀ r : ℝ, re (𝓚 r) = r := is_R_or_C.of_real_re_ax
@@ -127,9 +132,9 @@ lemma smul_im (r : ℝ) (z : K) : im ((𝓚 r) * z) = r * (im z) :=
 by simp only [add_zero, of_real_im, zero_mul, of_real_re, mul_im]
 
 lemma smul_re' : ∀ (r : ℝ) (z : K), re (r • z) = r * (re z) :=
-λ r z, by { rw [smul_coe_mul_ax], apply smul_re }
+λ r z, by { rw algebra.smul_def, apply smul_re }
 lemma smul_im' : ∀ (r : ℝ) (z : K), im (r • z) = r * (im z) :=
-λ r z, by { rw [smul_coe_mul_ax], apply smul_im }
+λ r z, by { rw algebra.smul_def, apply smul_im }
 
 /-! ### The imaginary unit, `I` -/
 
@@ -198,7 +203,7 @@ lemma norm_sq_eq_def {z : K} : ∥z∥^2 = (re z) * (re z) + (im z) * (im z) := 
 lemma norm_sq_eq_def' (z : K) : norm_sq z = ∥z∥^2 := by rw [norm_sq_eq_def, norm_sq]
 
 @[simp] lemma norm_sq_of_real (r : ℝ) : ∥𝓚 r∥^2 = r * r :=
-by simp [norm_sq_eq_def]
+by simp [norm_sq_eq_def, -norm_algebra_map_eq]
 
 @[simp] lemma norm_sq_zero : norm_sq (0 : K) = 0 := by simp [norm_sq, pow_two]
 @[simp] lemma norm_sq_one : norm_sq (1 : K) = 1 := by simp [norm_sq]
@@ -237,11 +242,10 @@ theorem add_conj (z : K) : z + conj z = 𝓚 (2 * re z) :=
 by simp [ext_iff, two_mul]
 
 /-- The pseudo-coercion `of_real` as a `ring_hom`. -/
-def of_real_hom : ℝ →+* K := ⟨of_real, of_real_one, of_real_mul, of_real_zero, of_real_add⟩
+noncomputable def of_real_hom : ℝ →+* K := algebra_map ℝ K
 
-@[simp] lemma of_real_sub (r s : ℝ) : 𝓚 (r - s : ℝ) = 𝓚 r - 𝓚 s := ext_iff.2 $ by simp
-@[simp] lemma of_real_pow (r : ℝ) (n : ℕ) : 𝓚 (r ^ n : ℝ) = (𝓚 r) ^ n :=
-by induction n; simp [*, of_real_mul, pow_succ]
+@[simp] lemma of_real_sub (r s : ℝ) : 𝓚 (r - s : ℝ) = 𝓚 r - 𝓚 s := of_real_hom.map_sub r s
+@[simp] lemma of_real_pow (r : ℝ) (n : ℕ) : 𝓚 (r ^ n : ℝ) = (𝓚 r) ^ n := of_real_hom.map_pow r n
 
 theorem sub_conj (z : K) : z - conj z = 𝓚 (2 * im z) * I :=
 by simp [ext_iff, two_mul, sub_eq_add_neg, add_mul, mul_im_I_ax]
@@ -535,12 +539,10 @@ noncomputable instance real.is_R_or_C : is_R_or_C ℝ :=
   im := 0,
   conj := ring_hom.id ℝ,
   I := 0,
-  of_real := id,
   I_re_ax := by simp only [add_monoid_hom.map_zero],
   I_mul_I_ax := or.intro_left _ rfl,
   re_add_im_ax := λ z, by unfold_coes; simp [add_zero, id.def, mul_zero],
-  smul_coe_mul_ax := λ z r, by simp only [algebra.id.smul_eq_mul, id.def],
-  of_real_re_ax := λ r, by simp only [id.def, add_monoid_hom.id_apply],
+  of_real_re_ax := λ r, by simp only [add_monoid_hom.id_apply, algebra.id.map_eq_self],
   of_real_im_ax := λ r, by simp only [add_monoid_hom.zero_apply],
   mul_re_ax := λ z w, by simp only [sub_zero, mul_zero, add_monoid_hom.zero_apply, add_monoid_hom.id_apply],
   mul_im_ax := λ z w, by simp only [add_zero, zero_mul, mul_zero, add_monoid_hom.zero_apply],
@@ -570,13 +572,14 @@ noncomputable instance complex.is_R_or_C : is_R_or_C ℂ :=
   im := ⟨complex.im, complex.zero_im, complex.add_im⟩,
   conj := complex.conj,
   I := complex.I,
-  of_real := coe,
   I_re_ax := by simp only [add_monoid_hom.coe_mk, complex.I_re],
   I_mul_I_ax := by simp only [complex.I_mul_I, eq_self_iff_true, or_true],
-  re_add_im_ax := by simp only [forall_const, add_monoid_hom.coe_mk, complex.re_add_im, eq_self_iff_true],
-  smul_coe_mul_ax := λ z r, rfl,
-  of_real_re_ax := λ r, by simp only [add_monoid_hom.coe_mk, complex.of_real_re],
-  of_real_im_ax := λ r, by simp only [add_monoid_hom.coe_mk, complex.of_real_im],
+  re_add_im_ax := λ z, by simp only [add_monoid_hom.coe_mk, complex.re_add_im,
+                                     complex.coe_algebra_map, complex.of_real_eq_coe],
+  of_real_re_ax := λ r, by simp only [add_monoid_hom.coe_mk, complex.of_real_re,
+                                      complex.coe_algebra_map, complex.of_real_eq_coe],
+  of_real_im_ax := λ r, by simp only [add_monoid_hom.coe_mk, complex.of_real_im,
+                                      complex.coe_algebra_map, complex.of_real_eq_coe],
   mul_re_ax := λ z w, by simp only [complex.mul_re, add_monoid_hom.coe_mk],
   mul_im_ax := λ z w, by simp only [add_monoid_hom.coe_mk, complex.mul_im],
   conj_re_ax := λ z, by simp only [ring_hom.coe_mk, add_monoid_hom.coe_mk, complex.conj_re],
@@ -584,7 +587,10 @@ noncomputable instance complex.is_R_or_C : is_R_or_C ℂ :=
   conj_I_ax := by simp only [complex.conj_I, ring_hom.coe_mk],
   norm_sq_eq_def_ax := λ z, by simp only [←complex.norm_sq_eq_abs, ←complex.norm_sq, add_monoid_hom.coe_mk, complex.norm_eq_abs],
   mul_im_I_ax := λ z, by simp only [mul_one, add_monoid_hom.coe_mk, complex.I_im],
-  inv_def_ax := λ z, by convert complex.inv_def z; exact (complex.norm_sq_eq_abs z).symm,
+  inv_def_ax := λ z, by {
+    simp only [complex.inv_def, complex.norm_sq_eq_abs, complex.coe_algebra_map,
+               complex.of_real_eq_coe, complex.norm_eq_abs],
+  },
   div_I_ax := complex.div_I }
 
 end instances

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -52,6 +52,7 @@ end
 namespace is_R_or_C
 variables {K : Type*} [is_R_or_C K]
 
+/-- Shorthand for `algebra_map ℝ K` -/
 noncomputable abbreviation of_real (r : ℝ) := algebra_map ℝ K r
 
 local notation `𝓚` := @is_R_or_C.of_real K _
@@ -200,8 +201,8 @@ def norm_sq (z : K) : ℝ := re z * re z + im z * im z
 lemma norm_sq_eq_def {z : K} : ∥z∥^2 = (re z) * (re z) + (im z) * (im z) := norm_sq_eq_def_ax z
 lemma norm_sq_eq_def' (z : K) : norm_sq z = ∥z∥^2 := by rw [norm_sq_eq_def, norm_sq]
 
-@[simp] lemma norm_sq_of_real (r : ℝ) : ∥𝓚 r∥^2 = r * r :=
-by simp [norm_sq_eq_def, -norm_algebra_map_eq]
+lemma norm_sq_of_real (r : ℝ) : ∥𝓚 r∥^2 = r * r :=
+by simp [pow_two, real.norm_eq_abs, abs_mul_abs_self]
 
 @[simp] lemma norm_sq_zero : norm_sq (0 : K) = 0 := by simp [norm_sq, pow_two]
 @[simp] lemma norm_sq_one : norm_sq (1 : K) = 1 := by simp [norm_sq]

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -292,7 +292,7 @@ begin
   { simp [h, of_real_zero] },
   { change r ≠ 0 at h,
     rw [div_eq_mul_inv, ←of_real_inv, div_eq_mul_inv],
-    simp [norm_sq, norm_sq_of_real, div_mul_eq_div_mul_one_div, div_self h] }
+    simp [norm_sq, div_mul_eq_div_mul_one_div, div_self h] }
 end
 
 @[simp] lemma of_real_fpow (r : ℝ) (n : ℤ) : 𝓚 (r ^ n) = (𝓚 r) ^ n :=
@@ -386,7 +386,7 @@ local notation `abs'` := _root_.abs
 local notation `absK` := @abs K _
 
 @[simp] lemma abs_of_real (r : ℝ) : absK (𝓚 r) = abs' r :=
-by simp [abs, norm_sq, norm_sq_of_real, real.sqrt_mul_self_eq_abs]
+by simp [abs, norm_sq, real.sqrt_mul_self_eq_abs]
 
 lemma norm_eq_abs (z : K) : ∥z∥ = absK z := by simp [abs, norm_sq_eq_def']
 


### PR DESCRIPTION
`of_real` and `smul_coe_mul_ax` are already implied by the algebra structure.

The addition of `noncomputable` does not matter here, as both instances of `is_R_or_C` are marked non-computable anyway.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

A brief skim of #3934 suggests that the redundancy of these was not noticed.