### PR TITLE
[Merged by Bors] - docs(references.bib): adds Samuel's Théorie Algébrique des Nombres

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -487,3 +487,13 @@ howpublished = {\url{https://leanprover.github.io/theorem_proving_in_lean/}},
   year={1992},
   publisher={Springer Science \& Business Media}
 }
+
+@book {samuel1967,
+    AUTHOR = {Samuel, Pierre},
+     TITLE = {Th\'{e}orie alg\'{e}brique des nombres},
+ PUBLISHER = {Hermann, Paris},
+      YEAR = {1967},
+     PAGES = {130},
+   MRCLASS = {10.65 (12.00)},
+  MRNUMBER = {0215808},
+}


### PR DESCRIPTION
Added Samuel's Théorie Algébrique des Nombres


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
