### PR TITLE
[Merged by Bors] - chore(*/sub*): Use the simp normal form for has_coe_to_sort

### DIFF
--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -70,11 +70,12 @@ namespace submonoid
 @[to_additive]
 instance : has_coe (submonoid M) (set M) := ⟨submonoid.carrier⟩
 
-@[to_additive]
-instance : has_coe_to_sort (submonoid M) := ⟨Type*, λ S, S.carrier⟩
 
 @[to_additive]
 instance : has_mem M (submonoid M) := ⟨λ m S, m ∈ (S:set M)⟩
+
+@[to_additive]
+instance : has_coe_to_sort (submonoid M) := ⟨Type*, λ S, {x : M // x ∈ S}⟩
 
 @[simp, to_additive]
 lemma mem_carrier {s : submonoid M} {x : M} : x ∈ s.carrier ↔ x ∈ s := iff.rfl

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1264,14 +1264,14 @@ def int.fraction_map : fraction_map ℤ ℚ :=
   map_units' :=
   begin
     rintro ⟨x, hx⟩,
-    rw [submonoid.mem_carrier, mem_non_zero_divisors_iff_ne_zero] at hx,
+    rw mem_non_zero_divisors_iff_ne_zero at hx,
     simpa only [is_unit_iff_ne_zero, int.cast_eq_zero, ne.def, subtype.coe_mk] using hx,
   end,
   surj' :=
   begin
     rintro ⟨n, d, hd, h⟩,
     refine ⟨⟨n, ⟨d, _⟩⟩, rat.mul_denom_eq_num⟩,
-    rwa [submonoid.mem_carrier, mem_non_zero_divisors_iff_ne_zero, int.coe_nat_ne_zero_iff_pos]
+    rwa [mem_non_zero_divisors_iff_ne_zero, int.coe_nat_ne_zero_iff_pos]
   end,
   eq_iff_exists' :=
   begin
@@ -1280,7 +1280,7 @@ def int.fraction_map : fraction_map ℤ ℚ :=
     refine ⟨by { rintro rfl, use 1 }, _⟩,
     rintro ⟨⟨c, hc⟩, h⟩,
     apply int.eq_of_mul_eq_mul_right _ h,
-    rwa [submonoid.mem_carrier, mem_non_zero_divisors_iff_ne_zero] at hc,
+    rwa mem_non_zero_divisors_iff_ne_zero at hc,
   end,
   ..int.cast_ring_hom ℚ }
 

--- a/src/ring_theory/polynomial/gauss_lemma.lean
+++ b/src/ring_theory/polynomial/gauss_lemma.lean
@@ -98,7 +98,7 @@ begin
   obtain ⟨⟨c, c0⟩, hc⟩ := @integer_normalization_map_to_map _ _ _ _ _ f a,
   obtain ⟨⟨d, d0⟩, hd⟩ := @integer_normalization_map_to_map _ _ _ _ _ f b,
   rw [algebra.smul_def, ← C_eq_algebra_map, subtype.coe_mk] at hc hd,
-  rw [submonoid.mem_carrier, mem_non_zero_divisors_iff_ne_zero] at c0 d0,
+  rw mem_non_zero_divisors_iff_ne_zero at c0 d0,
   have hcd0 : c * d ≠ 0 := mul_ne_zero c0 d0,
   rw [ne.def, ← C_eq_zero] at hcd0,
   have h1 : C c * C d * p = f.integer_normalization a * f.integer_normalization b,

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -88,9 +88,9 @@ def to_submonoid (s : subring R) : submonoid R :=
 
 instance : has_coe (subring R) (set R) := ⟨subring.carrier⟩
 
-instance : has_coe_to_sort (subring R) := ⟨Type*, λ S, S.carrier⟩
-
 instance : has_mem R (subring R) := ⟨λ m S, m ∈ (S:set R)⟩
+
+instance : has_coe_to_sort (subring R) := ⟨Type*, λ S, {x : R // x ∈ S}⟩
 
 /-- Construct a `subring R` from a set `s`, a submonoid `sm`, and an additive
 subgroup `sa` such that `x ∈ s ↔ x ∈ sm ↔ x ∈ sa`. -/

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -38,9 +38,9 @@ namespace subsemiring
 
 instance : has_coe (subsemiring R) (set R) := ⟨subsemiring.carrier⟩
 
-instance : has_coe_to_sort (subsemiring R) := ⟨Type*, λ S, S.carrier⟩
-
 instance : has_mem R (subsemiring R) := ⟨λ m S, m ∈ (S:set R)⟩
+
+instance : has_coe_to_sort (subsemiring R) := ⟨Type*, λ S, {x : R // x ∈ S}⟩
 
 /-- Construct a `subsemiring R` from a set `s`, a submonoid `sm`, and an additive
 submonoid `sa` such that `x ∈ s ↔ x ∈ sm ↔ x ∈ sa`. -/


### PR DESCRIPTION
This reduces the need to start proofs on subtypes by applying `mem_coe`.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
