### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/pow): prove measurability of rpow for ennreal

### DIFF
--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1128,17 +1128,8 @@ begin
   { exact coe_rpow_of_ne_zero hx _ }
 end
 
-lemma coe_rpow_def {p : nnreal × ℝ} :
-  (p.1 : ennreal) ^ p.2 = ite (p.1=0 ∧ p.2<0) ⊤ ↑(p.1 ^ p.2) :=
-begin
-  split_ifs,
-  { rw [h.left, ennreal.coe_zero, ennreal.zero_rpow_of_neg h.right], },
-  rw auto.not_and_eq at h,
-  cases h,
-    { rw coe_rpow_of_ne_zero h, },
-    { push_neg at h,
-      rw coe_rpow_of_nonneg _ h, },
-end
+lemma coe_rpow_def (x : ℝ≥0) (y : ℝ) :
+  (x : ennreal) ^ y = if x = 0 ∧ y < 0 then ⊤ else (x ^ y : ℝ≥0) := rfl
 
 @[simp] lemma rpow_one (x : ennreal) : x ^ (1 : ℝ) = x :=
 by cases x; dsimp only [(^), rpow]; simp [zero_lt_one, not_lt_of_le zero_le_one]

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1442,13 +1442,11 @@ section measurability_ennreal
 lemma ennreal.measurable_rpow : measurable (λ p : ennreal × ℝ, p.1 ^ p.2) :=
 begin
   refine ennreal.measurable_of_measurable_nnreal_prod _ _,
-  { change measurable (λ (p : ℝ≥0 × ℝ), ↑(p.fst) ^  p.snd),
-    simp_rw ennreal.coe_rpow_def,
+  { simp_rw ennreal.coe_rpow_def,
     refine measurable.ite _ measurable_const nnreal.measurable_rpow.ennreal_coe,
     exact is_measurable.inter (measurable_fst (is_measurable_singleton 0))
       (measurable_snd is_measurable_Iio), },
-  { change measurable (λ (x : ℝ), (⊤ : ennreal) ^ x),
-    simp_rw ennreal.top_rpow_def,
+  { simp_rw ennreal.top_rpow_def,
     refine measurable.ite is_measurable_Ioi measurable_const _,
     exact measurable.ite (is_measurable_singleton 0) measurable_const measurable_const, },
 end

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1481,8 +1481,7 @@ begin
     ite (0 < a.val.val.snd) 0 (ite (a.val.val.snd = 0) 1 ⊤)),
     { ext1 a,
       have h0 : a.val.val.fst = (0 : ennreal), from a.prop,
-      rw h0,
-      rw ennreal.zero_rpow_def, },
+      rw [h0, ennreal.zero_rpow_def], },
     rw h_eq,
     have hm : measurable (prod.snd
         ∘ (λ (a : {b : {p : ennreal × ℝ | p.fst ≠ ⊤} | b.val.fst = 0}), a.val.val)),

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1,7 +1,8 @@
 /-
 Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne, Sébastien Gouëzel
+Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne, Sébastien Gouëzel,
+  Rémy Degenne
 -/
 import analysis.special_functions.trigonometric
 import analysis.calculus.extend_deriv

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1459,8 +1459,7 @@ begin
         have h_zero : a.val.fst = 0, from a.prop,
         rw [h_zero, ennreal.coe_zero, ennreal.zero_rpow_def], },
       rw h_eq,
-      change measurable ((λ x : ℝ,
-        ite (0 < x) 0 (ite (x = 0) (1:ennreal) ⊤))
+      change measurable ((λ x : ℝ, ite (0 < x) 0 (ite (x = 0) (1:ennreal) ⊤))
         ∘ (λ a : nnreal × ℝ, a.snd)
         ∘ (λ a : {p : ℝ≥0 × ℝ | p.fst = 0}, a.val)),
       refine measurable.comp (measurable.ite is_measurable_Ioi measurable_const _) _,

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -495,6 +495,15 @@ begin
   exact (hs.inter $ hf ht).union (hs.compl.inter $ hg ht)
 end
 
+/-- this is slightly different from `measurable.piecewise`. It can be used to show
+`measurable (ite (x=0) 0 1)` by
+`exact measurable.ite (is_measurable_singleton 0) measurable_const measurable_const`,
+but replacing `measurable.ite` by `measurable.piecewise` in that example proof does not work. -/
+lemma measurable.ite {p : α → Prop} {_ : decidable_pred p} {f g : α → β}
+  (hp : is_measurable {a : α | p a}) (hf : measurable f) (hg : measurable g) :
+  measurable (λ x, ite (p x) (f x) (g x)) :=
+measurable.piecewise hp hf hg
+
 @[simp] lemma measurable_const {a : α} : measurable (λ b : β, a) :=
 assume s hs, is_measurable.const (a ∈ s)
 


### PR DESCRIPTION
Prove measurability of rpow for an ennreal argument.
Also shorten the proof in the real case.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
