### PR TITLE
[Merged by Bors] - feat(tactic/induction): add induction'/cases'/eliminate_hyp/eliminate_expr tactics

### DIFF
--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -15,7 +15,7 @@ proofs about these definitions, those are contained in other files in `data/list
 
 namespace list
 
-open function nat
+open function nat native (rb_map mk_rb_map rb_map.of_list)
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
 
@@ -837,5 +837,75 @@ zip_right = map₂_right prod.mk
 -/
 def zip_right : list α → list β → list (option α × β) :=
 map₂_right prod.mk
+
+/--
+If all elements of `xs` are `some xᵢ`, `all_some xs` returns the `xᵢ`. Otherwise
+it returns `none`.
+
+```
+all_some [some 1, some 2] = some [1, 2]
+all_some [some 1, none  ] = none
+```
+-/
+def all_some : list (option α) → option (list α)
+| [] := some []
+| (some a :: as) := cons a <$> all_some as
+| (none :: as) := none
+
+/--
+`fill_nones xs ys` replaces the `none`s in `xs` with elements of `ys`. If there
+are not enough `ys` to replace all the `none`s, the remaining `none`s are
+dropped from `xs`.
+
+```
+fill_nones [none, some 1, none, none] [2, 3] = [2, 1, 3]
+```
+-/
+def fill_nones {α} : list (option α) → list α → list α
+| [] _ := []
+| (some a :: as) as' := a :: fill_nones as as'
+| (none :: as) [] := as.reduce_option
+| (none :: as) (a :: as') := a :: fill_nones as as'
+
+/--
+`take_list as ns` extracts successive sublists from `as`. For `ns = n₁ ... nₘ`,
+it first takes the `n₁` initial elements from `as`, then the next `n₂` ones,
+etc. It returns the sublists of `as` -- one for each `nᵢ` -- and the remaining
+elements of `as`. If `as` does not have at least as many elements as the sum of
+the `nᵢ`, the corresponding sublists will have less than `nᵢ` elements.
+
+```
+take_list ['a', 'b', 'c', 'd', 'e'] [2, 1, 1] = ([['a', 'b'], ['c'], ['d']], ['e'])
+take_list ['a', 'b'] [3, 1] = ([['a', 'b'], []], [])
+```
+-/
+def take_list {α} : list α → list ℕ → list (list α) × list α
+| xs [] := ([], xs)
+| xs (n :: ns) :=
+  let ⟨xs₁, xs₂⟩ := xs.split_at n in
+  let ⟨xss, rest⟩ := take_list xs₂ ns in
+  (xs₁ :: xss, rest)
+
+/--
+`to_rbmap as` is the map that associates each index `i` of `as` with the
+corresponding element of `as`.
+
+```
+to_rbmap ['a', 'b', 'c'] = rbmap_of [(0, 'a'), (1, 'b'), (2, 'c')]
+```
+-/
+def to_rbmap : list α → rbmap ℕ α :=
+foldl_with_index (λ i mapp a, mapp.insert i a) (mk_rbmap ℕ α)
+
+/--
+`to_rb_map as` is the map that associates each index `i` of `as` with the
+corresponding element of `as`.
+
+```
+to_rb_map ['a', 'b', 'c'] = rb_map.of_list [(0, 'a'), (1, 'b'), (2, 'c')]
+```
+-/
+meta def to_rb_map {α : Type} : list α → rb_map ℕ α :=
+foldl_with_index (λ i mapp a, mapp.insert i a) mk_rb_map
 
 end list

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -270,6 +270,16 @@ meta def get_app_fn_const_whnf (e : expr) (md := semireducible)
     "expected a constant (possibly applied to some arguments), but got:\n{e}"
   end
 
+/--
+`get_app_args_whnf e md unfold_ginductive` is like `expr.get_app_args e` but `e`
+is normalised as necessary (with transparency `md`). `unfold_ginductive`
+controls whether constructors of generalised inductive types are unfolded. The
+returned expressions are not necessarily in whnf.
+-/
+meta def get_app_args_whnf (e : expr) (md := semireducible)
+  (unfold_ginductive := tt) : tactic (list expr) :=
+prod.snd <$> get_app_fn_args_whnf e md unfold_ginductive
+
 /-- `pis loc_consts f` is used to create a pi expression whose body is `f`.
 `loc_consts` should be a list of local constants. The function will abstract these local
 constants from `f` and bind them with pi binders.

--- a/src/tactic/induction.lean
+++ b/src/tactic/induction.lean
@@ -1,0 +1,1290 @@
+/-
+Copyright (c) 2020 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jannis Limperg
+-/
+
+import tactic.dependencies
+import tactic.fresh_names
+import tactic.generalizes
+import tactic.has_variable_names
+import tactic.unify_equations
+
+/-!
+# A better tactic for induction and case analysis
+
+This module defines the tactics `tactic.interactive.induction'` and
+`tactic.interactive.cases'`, which are variations on Lean's builtin `induction`
+and `cases`. The primed variants feature various improvements over the builtin
+tactics; in particular, they generate more human-friendly names and `induction'`
+deals much better with indexed inductive types. See the tactics' documentation
+for more details. We also provide corresponding non-interactive induction
+tactics `tactic.eliminate_hyp` and `tactic.eliminate_expr`.
+
+The design and implementation of these tactics is described in a
+[draft paper](https://limperg.de/paper/cpp2021-induction/).
+-/
+
+open expr native
+open tactic.interactive (case_tag.from_tag_hyps)
+
+namespace tactic
+namespace eliminate
+
+
+/-!
+## Tracing
+
+We set up two tracing functions to be used by `eliminate_hyp` and its supporting
+tactics. Their output is enabled by setting `trace.eliminate_hyp` to `true`.
+-/
+
+
+declare_trace eliminate_hyp
+
+/--
+`trace_eliminate_hyp msg` traces `msg` if the option `trace.eliminate_hyp` is
+`true`.
+-/
+meta def trace_eliminate_hyp {α} [has_to_format α] (msg : thunk α) : tactic unit :=
+when_tracing `eliminate_hyp $ trace $ to_fmt "eliminate_hyp: " ++ to_fmt (msg ())
+
+/--
+`trace_state_eliminate_hyp msg` traces `msg` followed by the tactic state if the
+option `trace.eliminate_hyp` is `true`.
+-/
+meta def trace_state_eliminate_hyp {α} [has_to_format α] (msg : thunk α) :
+  tactic unit := do
+  state ← read,
+  trace_eliminate_hyp $ format.join
+    [to_fmt (msg ()), "\n-----\n", to_fmt state, "\n-----"]
+
+
+/-!
+## Information Gathering
+
+We define data structures for information relevant to the induction, and
+functions to collect this information for a specific goal.
+-/
+
+
+/--
+Information about a constructor argument. Contains:
+
+- `aname`: the argument's name.
+- `type` : the argument's type.
+- `dependent`: whether the argument is dependent, i.e. whether it occurs in the
+  remainder of the constructor type.
+- `index_occurrences`: the index arguments of the constructor's return type
+  in which this argument occurs. If the constructor return type is
+  `I i₀ ... iₙ` and the argument under consideration is `a`, and `a` occurs in
+  `i₁` and `i₂`, then the `index_occurrences` are `1, 2`. As an additional
+  requirement, for `iⱼ` to be considered an index occurrences,
+  the type of `iⱼ` must match that of `a` according to
+  `index_occurrence_type_match`.
+- `is_recursive`: whether this is a recursive constructor argument.
+-/
+@[derive has_reflect]
+meta structure constructor_argument_info :=
+(aname : name)
+(type : expr)
+(dependent : bool)
+(index_occurrences : list ℕ)
+(is_recursive : bool)
+
+/--
+Information about a constructor. Contains:
+
+- `cname`: the constructor's name.
+- `non_param_args`: information about the arguments of the constructor,
+  excluding the arguments induced by the parameters of the inductive type.
+- `num_non_param_args`: the length of `non_param_args`.
+- `rec_args`: the subset of `non_param_args` which are recursive constructor
+  arguments.
+- `num_rec_args`: the length of `rec_args`.
+
+For example, take the constructor
+```
+list.cons : ∀ {α} (x : α) (xs : list α), list α
+```
+`α` is a parameter of `list`, so `non_param_args` contains information about `x`
+and `xs`. `rec_args` contains information about `xs`.
+-/
+@[derive has_reflect]
+meta structure constructor_info :=
+(cname : name)
+(non_param_args : list constructor_argument_info)
+(num_non_param_args : ℕ)
+(rec_args : list constructor_argument_info)
+(num_rec_args : ℕ)
+
+/--
+When we construct the goal for the minor premise of a given constructor, this is
+the number of hypotheses we must name.
+-/
+meta def constructor_info.num_nameable_hypotheses (c : constructor_info) : ℕ :=
+c.num_non_param_args + c.num_rec_args
+
+/--
+Information about an inductive type. Contains:
+
+- `iname`: the type's name.
+- `constructors`: information about the type's constructors.
+- `num_constructors`: the length of `constructors`.
+- `type`: the type's type.
+- `num_param`: the type's number of parameters.
+- `num_indices`: the type's number of indices.
+-/
+@[derive has_reflect]
+meta structure inductive_info :=
+(iname : name)
+(constructors : list constructor_info)
+(num_constructors : ℕ)
+(type : expr)
+(num_params : ℕ)
+(num_indices : ℕ)
+
+/--
+Information about an eliminee (i.e. the hypothesis on which we are performing
+induction). Contains:
+
+- `ename`: the eliminee's name.
+- `eexpr`: the eliminee hypothesis.
+- `type`: the type of `eexpr`.
+- `args`: the eliminee's arguments. The eliminee has type `I x₀ ... xₙ`, where
+  `I` is an inductive type. `args` is the map `[0 → x₀, ..., n → xₙ]`.
+-/
+meta structure eliminee_info :=
+(ename : name)
+(eexpr : expr)
+(type : expr)
+(args : rb_map ℕ expr)
+
+/--
+`index_occurrence_type_match t s` is true iff `t` and `s` are definitionally
+equal.
+-/
+-- We could extend this check to be more permissive. E.g. if a constructor
+-- argument has type `list α` and the index has type `list β`, we may want to
+-- consider these types sufficiently similar to inherit the name. Same (but even
+-- more obvious) with `vec α n` and `vec α (n + 1)`.
+meta def index_occurrence_type_match (t s : expr) : tactic bool :=
+succeeds $ is_def_eq t s
+
+/--
+From the return type of a constructor `C` of an inductive type `I`, determine
+the index occurrences of the constructor arguments of `C`.
+
+Input:
+
+- `num_params:` the number of parameters of `I`.
+- `e`: the return type of `C`. `e` must be of the form `I x₁ ... xₙ`.
+
+Output: A map associating each local constant `c` that appears in any of the `xᵢ`
+with the set of indexes `j` such that `c` appears in `xⱼ` and `xⱼ`'s type
+matches that of `c` according to `tactic.index_occurrence_type_match`.
+-/
+meta def get_index_occurrences (num_params : ℕ) :
+  expr → tactic (rb_lmap expr ℕ) :=
+λ ret_type, do
+  ret_args ← get_app_args_whnf ret_type,
+  ret_args.mfoldl_with_index
+    (λ i occ_map ret_arg, do
+      if i < num_params
+        then pure occ_map
+        else do
+          let ret_arg_consts := ret_arg.list_local_consts',
+          ret_arg_consts.mfold occ_map $ λ c occ_map, do
+            ret_arg_type ← infer_type ret_arg,
+            eq ← index_occurrence_type_match c.local_type ret_arg_type,
+            pure $ if eq then occ_map.insert c i else occ_map)
+    mk_rb_map
+
+/--
+Returns true iff `arg_type` is the local constant named `type_name`
+(possibly applied to some arguments). If `arg_type` is the type of an argument
+of one of `type_name`'s constructors and this function returns true, then the
+constructor argument is a recursive occurrence.
+-/
+meta def is_recursive_constructor_argument (type_name : name) (arg_type : expr) :
+  bool :=
+let base := arg_type.get_app_fn in
+match base with
+| (expr.const base _) := base = type_name
+| _ := ff
+end
+
+/--
+Get information about the arguments of a constructor `C` of an inductive type
+`I`.
+
+Input:
+
+- `inductive_name`: the name of `I`.
+- `num_params`: the number of parameters of `I`.
+- `T`: the type of `C`.
+
+Output: a `constructor_argument_info` structure for each argument of `C`.
+-/
+meta def get_constructor_argument_info (inductive_name : name)
+  (num_params : ℕ) (T : expr) :
+  tactic (list constructor_argument_info) := do
+  ⟨args, ret⟩ ← open_pis_whnf_dep T,
+  index_occs ← get_index_occurrences num_params ret,
+  pure $ args.map $ λ ⟨c, dep⟩,
+    let occs := rb_set.of_list $ index_occs.find c in
+    let type := c.local_type in
+    let is_recursive := is_recursive_constructor_argument inductive_name type in
+    ⟨c.local_pp_name, type, dep, occs.to_list, is_recursive⟩
+
+/--
+Get information about a constructor `C` of an inductive type `I`.
+
+Input:
+
+- `iname`: the name of `I`.
+- `num_params`: the number of parameters of `I`.
+- `c` : the name of `C`.
+
+Output:
+
+A `constructor_info` structure for `C`.
+-/
+meta def get_constructor_info (iname : name) (num_params : ℕ) (c : name) :
+  tactic constructor_info := do
+  env ← get_env,
+  when (¬ env.is_constructor c) $ fail! "Expected {c} to be a constructor.",
+  decl ← env.get c,
+  args ← get_constructor_argument_info iname num_params decl.type,
+  let non_param_args := args.drop num_params,
+  let rec_args := non_param_args.filter $ λ ainfo, ainfo.is_recursive,
+  pure
+    { cname := decl.to_name,
+      non_param_args := non_param_args,
+      num_non_param_args := non_param_args.length,
+      rec_args := rec_args,
+      num_rec_args := rec_args.length
+    }
+
+/--
+Get information about an inductive type `I`, given `I`'s name.
+-/
+meta def get_inductive_info (I : name) : tactic inductive_info := do
+  env ← get_env,
+  when (¬ env.is_inductive I) $ fail! "Expected {I} to be an inductive type.",
+  decl ← env.get I,
+  let type := decl.type,
+  let num_params := env.inductive_num_params I,
+  let num_indices := env.inductive_num_indices I,
+  let constructor_names := env.constructors_of I,
+  constructors ← constructor_names.mmap
+    (get_constructor_info I num_params),
+  pure
+    { iname := I,
+      constructors := constructors,
+      num_constructors := constructors.length,
+      type := type,
+      num_params := num_params,
+      num_indices := num_indices }
+
+/--
+Get information about an eliminee. The eliminee must be a local hypothesis.
+-/
+meta def get_eliminee_info (eliminee : expr) : tactic eliminee_info := do
+  type ← infer_type eliminee,
+  ⟨f, args⟩ ← get_app_fn_args_whnf type,
+  pure
+    { ename := eliminee.local_pp_name,
+      eexpr := eliminee,
+      type := type,
+      args := args.to_rb_map }
+
+
+/-!
+## Constructor Argument Naming
+
+We define the algorithm for naming constructor argument (which is a remarkably
+big part of the tactic).
+-/
+
+
+/--
+Information used when naming a constructor argument.
+-/
+meta structure constructor_argument_naming_info :=
+(einfo : eliminee_info)
+(iinfo : inductive_info)
+(cinfo : constructor_info)
+(ainfo : constructor_argument_info)
+
+/--
+A constructor argument naming rule takes a `constructor_argument_naming_info`
+structure and returns a list of suitable names for the argument. If the rule is
+not applicable to the given constructor argument, the returned list is empty.
+-/
+@[reducible] meta def constructor_argument_naming_rule : Type :=
+constructor_argument_naming_info → tactic (list name)
+
+/--
+Naming rule for recursive constructor arguments.
+-/
+meta def constructor_argument_naming_rule_rec : constructor_argument_naming_rule :=
+λ i, pure $ if i.ainfo.is_recursive then [i.einfo.ename] else []
+
+/--
+Naming rule for constructor arguments associated with an index.
+-/
+meta def constructor_argument_naming_rule_index : constructor_argument_naming_rule :=
+λ i,
+let index_occs := i.ainfo.index_occurrences in
+let eliminee_args := i.einfo.args in
+let get_eliminee_arg_local_names : ℕ → option (name × name) := λ i, do {
+  arg ← eliminee_args.find i,
+  (uname, ppname, _) ← arg.match_local_const,
+  pure (uname, ppname)
+} in
+let local_index_instantiations :=
+  (index_occs.map get_eliminee_arg_local_names).all_some in
+-- Right now, this rule only triggers if the eliminee arg is exactly a local
+-- const. We could consider a more permissive rule where the eliminee arg can be
+-- an arbitrary term as long as that term *contains* only a single local const.
+pure $
+  match local_index_instantiations with
+  | none := []
+  | some [] := []
+  | some ((uname, ppname) :: is) :=
+    if is.all (λ ⟨uname', _⟩, uname' = uname)
+      then [ppname]
+      else []
+  end
+
+/--
+Naming rule for constructor arguments which are named in the constructor
+declaration.
+-/
+meta def constructor_argument_naming_rule_named : constructor_argument_naming_rule :=
+λ i,
+let arg_name := i.ainfo.aname in
+let arg_dep := i.ainfo.dependent in
+pure $
+  if ! arg_dep && arg_name.is_likely_generated_binder_name
+    then []
+    else [arg_name]
+
+/--
+Naming rule for constructor arguments whose type is associated with a list of
+typical variable names. See `tactic.typical_variable_names`.
+-/
+meta def constructor_argument_naming_rule_type : constructor_argument_naming_rule :=
+λ i, typical_variable_names i.ainfo.type <|> pure []
+
+/--
+Naming rule for constructor arguments whose type is in `Prop`.
+-/
+meta def constructor_argument_naming_rule_prop : constructor_argument_naming_rule :=
+λ i, do
+  (sort level.zero) ← infer_type i.ainfo.type | pure [],
+  pure [`h]
+
+/--
+Fallback constructor argument naming rule. This rule never fails.
+-/
+meta def constructor_argument_naming_rule_fallback : constructor_argument_naming_rule :=
+λ _, pure [`x]
+
+/--
+`apply_constructor_argument_naming_rules info rules` applies the constructor
+argument naming rules in `rules` to the constructor argument given by `info`.
+Returns the result of the first applicable rule. Fails if no rule is applicable.
+-/
+meta def apply_constructor_argument_naming_rules
+  (info : constructor_argument_naming_info)
+  (rules : list constructor_argument_naming_rule) : tactic (list name) := do
+  names ← try_core $ rules.mfirst (λ r, do
+    names ← r info,
+    match names with
+    | [] := failed
+    | _ := pure names
+    end),
+  match names with
+  | none := fail
+      "apply_constructor_argument_naming_rules: no applicable naming rule"
+  | (some names) := pure names
+  end
+
+/--
+Get possible names for a constructor argument. This tactic applies all the
+previously defined rules in order. It cannot fail and always returns a nonempty
+list.
+-/
+meta def constructor_argument_names (info : constructor_argument_naming_info) :
+  tactic (list name) :=
+apply_constructor_argument_naming_rules info
+  [ constructor_argument_naming_rule_rec
+  , constructor_argument_naming_rule_index
+  , constructor_argument_naming_rule_named
+  , constructor_argument_naming_rule_type
+  , constructor_argument_naming_rule_prop
+  , constructor_argument_naming_rule_fallback ]
+
+/--
+`intron_fresh n` introduces `n` hypotheses with names generated by
+`tactic.mk_fresh_name`.
+-/
+meta def intron_fresh (n : ℕ) : tactic (list expr) :=
+iterate_exactly n (mk_fresh_name >>= intro)
+
+/--
+Introduce the new hypotheses generated by the minor premise for a given
+constructor. The new hypotheses are given fresh (unique, non-human-friendly)
+names. They are later renamed by `constructor_renames`. We delay the generation
+of the human-friendly names because when `constructor_renames` is called, more
+names may have become unused.
+
+Input:
+
+- `generate_induction_hyps`: whether we generate induction hypotheses (i.e.
+  whether `eliminate_hyp` is in `induction` or `cases` mode).
+- `iinfo`: information about the inductive type.
+- `cinfo`: information about the constructor.
+
+Output:
+
+- For each constructor argument, the pretty name of the newly introduced
+  hypothesis corresponding to the argument and its `constructor_argument_info`.
+- For each newly introduced induction hypothesis, its pretty name and the name
+  of the recursive constructor argument from which it was derived.
+-/
+meta def constructor_intros (generate_induction_hyps : bool)
+  (cinfo : constructor_info) :
+  tactic (list (name × constructor_argument_info) × list (name × name)) := do
+  let args := cinfo.non_param_args,
+  arg_hyps ← intron_fresh cinfo.num_non_param_args,
+  let arg_hyp_names :=
+    list.map₂ (λ (h : expr) ainfo, (h.local_pp_name, ainfo)) arg_hyps args,
+  tt ← pure generate_induction_hyps | pure (arg_hyp_names, []),
+
+  let rec_args := arg_hyp_names.filter $ λ x, x.2.is_recursive,
+  ih_hyps ← intron_fresh cinfo.num_rec_args,
+  let ih_hyp_names :=
+    list.map₂
+      (λ (h : expr) (arg : name × constructor_argument_info),
+        (h.local_pp_name, arg.1))
+      ih_hyps rec_args,
+  pure (arg_hyp_names, ih_hyp_names)
+
+/--
+`ih_name arg_name` is the name `ih_<arg_name>`.
+-/
+meta def ih_name (arg_name : name) : name :=
+mk_simple_name ("ih_" ++ arg_name.to_string)
+
+private meta def get_with_name : option name → option name
+| (some `_) := none
+| (some n) := some n
+| none := none
+
+/--
+Rename the new hypotheses in the goal for a minor premise.
+
+Input:
+
+- `generate_induction_hyps`: whether we generate induction hypotheses (i.e.
+  whether `eliminate_hyp` is in `induction` or `cases` mode).
+- `einfo`: information about the eliminee.
+- `iinfo`: information about the inductive type.
+- `cinfo`: information about the constructor whose minor premise we are
+  processing.
+- `with_names`: a list of names given by the user. These are used to name
+  constructor arguments and induction hypotheses. Our own naming logic only
+  kicks in if this list does not contain enough names.
+- `args` and `ihs`: the output of `constructor_intros`.
+
+Output:
+
+- The newly introduced hypotheses corresponding to constructor arguments.
+- The newly introduced induction hypotheses.
+-/
+meta def constructor_renames (generate_induction_hyps : bool)
+  (einfo : eliminee_info) (iinfo : inductive_info) (cinfo : constructor_info)
+  (with_names : list name) (args : list (name × constructor_argument_info))
+  (ihs : list (name × name)) :
+  tactic (list expr × list expr) := do
+
+  -- Rename constructor arguments
+  let arg_pp_name_set := name_set.of_list $ args.map prod.fst,
+  let iname := iinfo.iname,
+  let ⟨args, with_names⟩ := args.zip_left' with_names,
+  arg_renames : list (name × list name) ←
+    args.mmap_filter $ λ ⟨⟨old_ppname, ainfo⟩, with_name⟩, do {
+      new ←
+        match get_with_name with_name with
+        | some with_name := pure [with_name]
+        | none := constructor_argument_names ⟨einfo, iinfo, cinfo, ainfo⟩
+        end,
+      -- Some of the arg hyps may have been cleared by earlier simplification
+      -- steps, so get_local may fail.
+      (some old) ← try_core $ get_local old_ppname | pure none,
+      pure $ some (old.local_uniq_name, new)
+    },
+  let arg_renames := rb_map.of_list arg_renames,
+  arg_hyp_map ← rename_fresh arg_renames mk_name_set,
+  let new_arg_hyps := arg_hyp_map.filter_map $ λ ⟨old, new⟩,
+    if arg_pp_name_set.contains old.local_pp_name then some new else none,
+  let arg_hyp_map : name_map expr :=
+    rb_map.of_list $ arg_hyp_map.map $ λ ⟨old, new⟩, (old.local_pp_name, new),
+
+  -- Rename induction hypotheses (if we generated them)
+  tt ← pure generate_induction_hyps | pure (new_arg_hyps, []),
+  let ih_pp_name_set := name_set.of_list $ ihs.map prod.fst,
+  let ihs := ihs.zip_left with_names,
+  ih_renames ← ihs.mmap_filter $ λ ⟨⟨ih_hyp_ppname, arg_hyp_ppname⟩, with_name⟩, do {
+    some arg_hyp ← pure $ arg_hyp_map.find arg_hyp_ppname
+      | fail! "internal error in constructor_renames",
+    let new :=
+      match get_with_name with_name with
+      | some with_name := sum.inl with_name
+      | none := sum.inr $ ih_name arg_hyp.local_pp_name
+      end,
+    (some ih_hyp) ← try_core $ get_local ih_hyp_ppname | pure none,
+    pure $ some (ih_hyp.local_uniq_name, new)
+  },
+  let ih_renames : list (name × list name) :=
+    -- Special case: When there's only one IH and it hasn't been named
+    -- explicitly in a "with" clause, we call it simply "ih" (unless that name
+    -- is already taken).
+    match ih_renames with
+    | [(h, sum.inr n)] := [(h, ["ih", n])]
+    | ns := ns.map (λ ⟨h, n⟩, (h, [n.elim id id]))
+    end,
+  ih_hyp_map ← rename_fresh (rb_map.of_list ih_renames) mk_name_set,
+  let new_ih_hyps := ih_hyp_map.filter_map $ λ ⟨old, new⟩,
+    if ih_pp_name_set.contains old.local_pp_name then some new else none,
+  pure (new_arg_hyps, new_ih_hyps)
+
+
+/-!
+## Generalisation
+
+`induction'` can generalise the goal before performing an induction, which gives
+us a more general induction hypothesis. We call this 'auto-generalisation'.
+-/
+
+
+/--
+A value of `generalization_mode` describes the behaviour of the
+auto-generalisation functionality:
+
+- `generalize_all_except hs` means that the `hs` remain fixed and all other
+  hypotheses are generalised. However, there are three exceptions:
+
+  * Hypotheses depending on any `h` in `hs` also remain fixed. If we were to
+    generalise them, we would have to generalise `h` as well.
+  * Hypotheses which do not occur in the target and which do not mention the
+    eliminee or its dependencies are never generalised. Generalising them would
+    not lead to a more general induction hypothesis.
+  * Frozen local instances and their dependencies are never generalised.
+
+- `generalize_only hs` means that only the `hs` are generalised. Exception:
+  hypotheses which depend on the eliminee are generalised even if they do not
+  appear in `hs`.
+-/
+@[derive has_reflect]
+inductive generalization_mode
+| generalize_all_except (hs : list name) : generalization_mode
+| generalize_only (hs : list name) : generalization_mode
+
+instance : inhabited generalization_mode :=
+⟨ generalization_mode.generalize_all_except []⟩
+
+namespace generalization_mode
+
+/--
+Given the eliminee and a generalization_mode, this function returns the
+unique names of the hypotheses that should be generalized. See
+`generalization_mode` for what these are.
+-/
+meta def to_generalize (eliminee : expr) : generalization_mode → tactic name_set
+| (generalize_only ns) := do
+  eliminee_rev_deps ← reverse_dependencies_of_hyps [eliminee],
+  let eliminee_rev_deps :=
+    name_set.of_list $ eliminee_rev_deps.map local_uniq_name,
+  ns ← ns.mmap (functor.map local_uniq_name ∘ get_local),
+  pure $ eliminee_rev_deps.insert_list ns
+| (generalize_all_except fixed) := do
+  fixed ← fixed.mmap get_local,
+  tgt ← target,
+  let tgt_dependencies := tgt.list_local_const_unique_names,
+  eliminee_type ← infer_type eliminee,
+  eliminee_dependencies ← dependency_name_set_of_hyp_inclusive eliminee,
+  fixed_dependencies ←
+    (eliminee :: fixed).mmap dependency_name_set_of_hyp_inclusive,
+  let fixed_dependencies := fixed_dependencies.foldl name_set.union mk_name_set,
+  ctx ← revertible_local_context,
+  to_revert ← ctx.mmap_filter $ λ h, do {
+    h_depends_on_eliminee_deps ←
+      -- TODO `hyp_depends_on_local_name_set` is somewhat expensive
+      hyp_depends_on_local_name_set h eliminee_dependencies,
+    let h_name := h.local_uniq_name,
+    let rev :=
+      ¬ fixed_dependencies.contains h_name ∧
+      (h_depends_on_eliminee_deps ∨ tgt_dependencies.contains h_name),
+    -- I think `h_depends_on_eliminee_deps` is an overapproximation. What we
+    -- actually want is any hyp that depends either on the eliminee or on one of
+    -- the eliminee's index args. (But the overapproximation seems to work okay
+    -- in practice as well.)
+    pure $ if rev then some h_name else none
+  },
+  pure $ name_set.of_list to_revert
+
+end generalization_mode
+
+/--
+Generalize hypotheses for the given eliminee and generalization mode. See
+`generalization_mode` and `to_generalize`.
+-/
+meta def generalize_hyps (eliminee : expr) (gm : generalization_mode) : tactic ℕ := do
+  to_revert ← gm.to_generalize eliminee,
+  ⟨n, _⟩ ← revert_name_set to_revert,
+  pure n
+
+
+/-!
+## Complex Index Generalisation
+
+We define how complex index arguments of the eliminee are generalised.
+-/
+
+/--
+Generalise the complex index arguments.
+
+Input:
+
+- `eliminee`: the eliminee.
+- `num_params`: the number of parameters of the inductive type.
+- `generate_induction_hyps`: whether we generate induction hypotheses (i.e.
+  whether `eliminate_hyp` is in `induction` or `cases` mode).
+
+Output:
+
+- The new eliminee. This procedure may change the eliminee's type signature, so
+  the old eliminee hypothesis is invalidated.
+- The number of index placeholder hypotheses we introduced.
+- The index placeholder hypotheses we introduced.
+- The number of hypotheses which were reverted because they contain complex
+  indices.
+-/
+meta def generalize_complex_index_args (eliminee : expr) (num_params : ℕ)
+  (generate_induction_hyps : bool) : tactic (expr × ℕ × list name × ℕ) :=
+focus1 $ do
+  eliminee_type ← infer_type eliminee,
+  (eliminee_head, eliminee_args) ← get_app_fn_args_whnf eliminee_type,
+  let ⟨eliminee_param_args, eliminee_index_args⟩ :=
+    eliminee_args.split_at num_params,
+
+  -- TODO Add equations only for complex index args (not all index args).
+  -- This shouldn't matter semantically, but we'd get simpler terms.
+
+  let js := eliminee_index_args,
+  ctx ← revertible_local_context,
+  tgt ← target,
+  eliminee_deps ← dependency_name_set_of_hyp_inclusive eliminee,
+
+  -- Revert the hypotheses which depend on the index args or the eliminee. We
+  -- exclude dependencies of the eliminee because we can't replace their index
+  -- occurrences anyway when we apply the recursor.
+  relevant_ctx ← ctx.mfilter $ λ h, do {
+    let dep_of_eliminee := eliminee_deps.contains h.local_uniq_name,
+    dep_on_eliminee ← hyp_depends_on_locals h [eliminee],
+    H ← infer_type h,
+    dep_of_index ← js.many $ λ j, kdepends_on H j,
+    -- TODO We need a variant of `kdepends_on` that takes local defs into account.
+    pure $ (dep_on_eliminee ∧ h ≠ eliminee) ∨ (dep_of_index ∧ ¬ dep_of_eliminee)
+  },
+  ⟨relevant_ctx_size, relevant_ctx⟩ ← revert_lst' relevant_ctx,
+  revert eliminee,
+
+  -- Create the local constants that will replace the index args. We have to be
+  -- careful to get the right types.
+  let go : expr → list expr → tactic (list expr) :=
+        λ j ks, do {
+          J ← infer_type j,
+          k ← mk_local' `index binder_info.default J,
+          ks ← ks.mmap $ λ k', kreplace k' j k,
+          pure $ k :: ks
+        },
+  ks ← js.mfoldr go [],
+
+  let js_ks := js.zip ks,
+
+  -- Replace the index args in the relevant context.
+  new_ctx ← relevant_ctx.mmap $ λ h, js_ks.mfoldr (λ ⟨j, k⟩ h, kreplace h j k) h,
+
+  -- Replace the index args in the eliminee
+  let new_eliminee_type := eliminee_head.mk_app (eliminee_param_args ++ ks),
+  let new_eliminee :=
+    local_const eliminee.local_uniq_name eliminee.local_pp_name
+      eliminee.binding_info new_eliminee_type,
+
+  -- Replace the index args in the target.
+  new_tgt ← js_ks.mfoldr (λ ⟨j, k⟩ tgt, kreplace tgt j k) tgt,
+  let new_tgt := new_tgt.pis (new_eliminee :: new_ctx),
+
+  -- Generate the index equations and their proofs.
+  let eq_name := if generate_induction_hyps then `induction_eq else `cases_eq,
+  let step2_input := js_ks.map $ λ ⟨j, k⟩, (eq_name, j, k),
+  eqs_and_proofs ← generalizes.step2 reducible step2_input,
+  let eqs := eqs_and_proofs.map prod.fst,
+  let eq_proofs := eqs_and_proofs.map prod.snd,
+
+  -- Assert the generalized goal and derive the current goal from it.
+  generalizes.step3 new_tgt js ks eqs eq_proofs,
+
+  -- Introduce the index variables and eliminee. The index equations
+  -- and the relevant context remain reverted.
+  let num_index_vars := js.length,
+  index_vars ← intron' num_index_vars,
+  index_equations ← intron' num_index_vars,
+  eliminee ← intro1,
+  revert_lst index_equations,
+
+  let index_vars := index_vars.map local_pp_name,
+  pure (eliminee, index_vars.length, index_vars, relevant_ctx_size)
+
+
+/-!
+## Simplification of Induction Hypotheses
+
+Auto-generalisation and complex index generalisation may produce unnecessarily
+complex induction hypotheses. We define a simplification algorithm that recovers
+understandable induction hypotheses in many practical cases.
+-/
+
+
+/--
+Process one index equation for `simplify_ih`.
+
+Input: a local constant `h : x = y` or `h : x == y`.
+
+Output: A proof of `x = y` or `x == y` and possibly a local constant of type
+`x = y` or `x == y` used in the proof. More specifically:
+
+- For `h : x = y` and `x` defeq `y`, we return the proof of `x = y` by
+  reflexivity and `none`.
+- For `h : x = y` and `x` not defeq `y`, we return `h` and `h`.
+- For `h : x == y` where `x` and `y` have defeq types:
+  - If `x` defeq `y`, we return the proof of `x == y` by reflexivity and `none`.
+  - If `x` not defeq `y`, we return `heq_of_eq h'` and a fresh local constant
+    `h' : x = y`.
+- For `h : x == y` where `x` and `y` do not have defeq types, we return
+  `h` and `h`.
+
+Checking for definitional equality of the left- and right-hand sides may assign
+metavariables.
+-/
+meta def process_index_equation : expr → tactic (expr × option expr)
+| h@(local_const _ ppname binfo
+    T@(app (app (app (const `eq [u]) type) lhs) rhs)) := do
+  rhs_eq_lhs ← succeeds $ unify lhs rhs,
+  if rhs_eq_lhs
+    then pure ((const `eq.refl [u]) type lhs, none)
+    else do
+      pure (h, some h)
+| h@(local_const uname ppname binfo
+    T@(app (app (app (app (const `heq [u]) lhs_type) lhs) rhs_type) rhs)) := do
+  lhs_type_eq_rhs_type ← succeeds $ is_def_eq lhs_type rhs_type,
+  if ¬ lhs_type_eq_rhs_type
+    then do
+      pure (h, some h)
+    else do
+      lhs_eq_rhs ← succeeds $ unify lhs rhs,
+      if lhs_eq_rhs
+        then pure ((const `heq.refl [u]) lhs_type lhs, none)
+        else do
+          c ← mk_local' ppname binfo $ (const `eq [u]) lhs_type lhs rhs,
+          let arg := (const `heq_of_eq [u]) lhs_type lhs rhs c,
+          pure (arg, some c)
+| (local_const _ _ _ T) := fail!
+  "process_index_equation: expected a homogeneous or heterogeneous equation, but got:\n{T}"
+| e := fail!
+  "process_index_equation: expected a local constant, but got:\n{e}"
+
+/--
+`assign_local_to_unassigned_mvar mv pp_name binfo`, where `mv` is a
+metavariable, acts as follows:
+
+- If `mv` is assigned, it is not changed and the tactic returns `none`.
+- If `mv` is not assigned, it is assigned a fresh local constant with
+  the type of `mv`, pretty name `pp_name` and binder info `binfo`. This local
+  constant is returned.
+-/
+meta def assign_local_to_unassigned_mvar (mv : expr) (pp_name : name)
+  (binfo : binder_info) : tactic (option expr) := do
+  ff ← is_assigned mv | pure none,
+  type ← infer_type mv,
+  c ← mk_local' pp_name binfo type,
+  unify mv c,
+  pure c
+
+/--
+Apply `assign_local_to_unassigned_mvar` to a list of metavariables. Returns the
+newly created local constants.
+-/
+meta def assign_locals_to_unassigned_mvars
+  (mvars : list (expr × name × binder_info)) : tactic (list expr) :=
+mvars.mmap_filter $ λ ⟨mv, pp_name, binfo⟩,
+  assign_local_to_unassigned_mvar mv pp_name binfo
+
+/--
+Simplify an induction hypothesis.
+
+Input: a local constant
+```
+ih : ∀ (x₁ : T₁) ... (xₙ : Tₙ) (eq₁ : y₁ = z₁) ... (eqₘ : yₘ = zₘ), P
+```
+where `n = num_generalized` and `m = num_index_vars`. The `xᵢ` are hypotheses
+that we generalised over before performing induction. The `eqᵢ` are index
+equations.
+
+Output: a new local constant
+```
+ih' : ∀ (x'₁ : T'₁) ... (x'ₖ : T'ₖ) (eq'₁ : y'₁ = z'₁) ... (eq'ₗ : y'ₗ = z'ₗ), P'
+```
+This new induction hypothesis is derived from `ih` by removing those `eqᵢ` whose
+left- and right-hand sides can be unified. This unification may also determine
+some of the `xᵢ`. The `x'ᵢ` and `eq'ᵢ` are those `xᵢ` and `eqᵢ` that were not
+removed by this process.
+
+Some of the `eqᵢ` may be heterogeneous: `eqᵢ : yᵢ == zᵢ`. In this case, we
+proceed as follows:
+
+- If `yᵢ` and `zᵢ` are defeq, then `eqᵢ` is removed.
+- If `yᵢ` and `zᵢ` are not defeq but their types are, then `eqᵢ` is replaced by
+  `eq'ᵢ : x = y`.
+- Otherwise `eqᵢ` remains unchanged.
+-/
+meta def simplify_ih (num_generalized : ℕ) (num_index_vars : ℕ) (ih : expr) :
+  tactic expr := do
+  T ← infer_type ih,
+
+  -- Replace the `xᵢ` with fresh metavariables.
+  (generalized_arg_mvars, body) ← open_n_pis_metas' T num_generalized,
+
+  -- Replace the `eqᵢ` with fresh local constants.
+  (index_eq_lcs, body) ← open_n_pis body num_index_vars,
+
+  -- Process the `eqᵢ` local constants, yielding
+  -- - `new_args`: proofs of `yᵢ = zᵢ`.
+  -- - `new_index_eq_lcs`: local constants of type `yᵢ = zᵢ` or `yᵢ == zᵢ` used
+  --   in `new_args`.
+  new_index_eq_lcs_new_args ← index_eq_lcs.mmap process_index_equation,
+  let (new_args, new_index_eq_lcs) := new_index_eq_lcs_new_args.unzip,
+  let new_index_eq_lcs := new_index_eq_lcs.reduce_option,
+
+  -- Assign fresh local constants to those `xᵢ` metavariables that were not
+  -- assigned by the previous step.
+  new_generalized_arg_lcs ←
+    assign_locals_to_unassigned_mvars generalized_arg_mvars,
+
+  -- Instantiate the metavariables assigned in the previous steps.
+  new_generalized_arg_lcs ← new_generalized_arg_lcs.mmap instantiate_mvars,
+  new_index_eq_lcs ← new_index_eq_lcs.mmap instantiate_mvars,
+
+  -- Construct a proof of the new induction hypothesis by applying `ih` to the
+  -- `xᵢ` metavariables and the `new_args`, then abstracting over the
+  -- `new_index_eq_lcs` and the `new_generalized_arg_lcs`.
+  b ← instantiate_mvars $
+    ih.mk_app (generalized_arg_mvars.map prod.fst ++ new_args),
+  new_ih ← lambdas (new_generalized_arg_lcs ++ new_index_eq_lcs) b,
+
+  -- Type-check the new induction hypothesis as a sanity check.
+  type_check new_ih <|> fail!
+    "internal error in simplify_ih: constructed term does not type check:\n{new_ih}",
+
+  -- Replace the old induction hypothesis with the new one.
+  ih' ← note ih.local_pp_name none new_ih,
+  clear ih,
+  pure ih'
+
+
+/-!
+## Temporary utilities
+
+The utility functions in this section should be removed pending certain changes
+to Lean's standard library.
+-/
+
+
+/--
+  Updates the tags of new subgoals produced by `cases` or `induction`. `in_tag`
+  is the initial tag, i.e. the tag of the goal on which `cases`/`induction` was
+  applied. `rs` should contain, for each subgoal, the constructor name
+  associated with that goal and the hypotheses that were introduced.
+-/
+-- TODO Copied from init.meta.interactive. Make that function non-private.
+meta def set_cases_tags (in_tag : tag) (rs : list (name × list expr)) : tactic unit :=
+do gs ← get_goals,
+   match gs with
+    -- if only one goal was produced, we should not make the tag longer
+   | [g] := set_tag g in_tag
+   | _   :=
+     let tgs : list (name × list expr × expr) :=
+       rs.map₂ (λ ⟨n, new_hyps⟩ g, ⟨n, new_hyps, g⟩) gs in
+     tgs.mmap' $ λ ⟨n, new_hyps, g⟩, with_enable_tags $
+        set_tag g $
+          (case_tag.from_tag_hyps (n :: in_tag) (new_hyps.map expr.local_uniq_name)).render
+   end
+
+end eliminate
+
+
+/-!
+## The Elimination Tactics
+
+Finally, we define the tactics `induction'` and `cases'` tactics as well as the
+non-interactive variant `eliminate_hyp.`
+-/
+
+
+open eliminate
+
+/--
+`eliminate_hyp generate_ihs eliminee gm with_names` performs induction or case
+analysis on the hypothesis `eliminee`. If `generate_ihs` is true, the tactic
+performs induction, otherwise case analysis.
+
+In case analysis mode, `eliminate_hyp` is very similar to `tactic.cases`. The
+only differences (assuming no bugs in `eliminate_hyp`) are that `eliminate_hyp`
+can do case analysis on a slightly larger class of hypotheses and that it
+generates more human-friendly names.
+
+In induction mode, `eliminate_hyp` is similar to `tactic.induction`, but with
+more significant differences:
+
+- If the eliminee (the hypothesis we are performing induction on) has complex
+  indices, `eliminate_hyp` 'remembers' them. A complex expression is any
+  expression that is not merely a local hypothesis. An eliminee
+  `e : I p₁ ... pₙ j₁ ... jₘ`, where `I` is an inductive type with `n`
+  parameters and `m` indices, has a complex index if any of the `jᵢ` are
+  complex. In this situation, standard `induction` effectively forgets the exact
+  values of the complex indices, which often leads to unprovable goals.
+  `eliminate_hyp` 'remembers' them by adding propositional equalities. As a
+  result, you may find equalities named `induction_eq` in your goal, and the
+  induction hypotheses may also quantify over additional equalities.
+- `eliminate_hyp` generalises induction hypotheses as much as possible by
+  default. This means that if you eliminate `n` in the goal
+  ```
+  n m : ℕ
+  ⊢ P n m
+  ```
+  the induction hypothesis is `∀ m, P n m` instead of `P n m`.
+
+  You can modify this behaviour by giving a different generalisation mode `gm`;
+  see `tactic.eliminate.generalization_mode`.
+- `eliminate_hyp` generates much more human-friendly names than `induction`. It
+  also clears more redundant hypotheses.
+- `eliminate_hyp` currently does not support custom induction principles a la
+  `induction using`.
+
+If `with_names` is nonempty, `eliminate_hyp` uses the given names for the new
+hypotheses it introduces (like `cases with` and `induction with`).
+
+To debug this tactic, use
+
+```
+set_option trace.eliminate_hyp true
+```
+-/
+meta def eliminate_hyp (generate_ihs : bool) (eliminee : expr)
+  (gm := generalization_mode.generalize_all_except [])
+  (with_names : list name := []) : tactic unit :=
+focus1 $ do
+  einfo ← get_eliminee_info eliminee,
+  let eliminee := einfo.eexpr,
+  let eliminee_type := einfo.type,
+  let eliminee_args := einfo.args.values.reverse,
+  env ← get_env,
+
+  -- Get info about the inductive type
+  iname ← get_app_fn_const_whnf eliminee_type <|> fail!
+    "The type of {eliminee} should be an inductive type, but it is\n{eliminee_type}",
+  iinfo ← get_inductive_info iname,
+
+  -- We would like to disallow mutual/nested inductive types, since these have
+  -- complicated recursors which we probably don't support. However, there seems
+  -- to be no way to find out whether an inductive type is mutual/nested.
+  -- (`environment.is_ginductive` doesn't seem to work.)
+
+  trace_state_eliminate_hyp "State before complex index generalisation:",
+
+  -- Generalise complex indices
+  (eliminee, num_index_vars, index_var_names, num_index_generalized) ←
+    generalize_complex_index_args eliminee iinfo.num_params generate_ihs,
+
+  trace_state_eliminate_hyp
+    "State after complex index generalisation and before auto-generalisation:",
+
+  -- Generalise hypotheses according to the given generalization_mode.
+  num_auto_generalized ← generalize_hyps eliminee gm,
+  let num_generalized := num_index_generalized + num_auto_generalized,
+
+  -- NOTE: The previous step may have changed the unique names of all hyps in
+  -- the context.
+
+  -- Record the current case tag and the unique names of all hypotheses in the
+  -- context.
+  in_tag ← get_main_tag,
+
+  trace_state_eliminate_hyp
+    "State after auto-generalisation and before recursor application:",
+
+  -- Apply the recursor. We first try the nondependent recursor, then the
+  -- dependent recursor (if available).
+
+  -- Construct a pexpr `@rec _ ... _ eliminee`. Why not ``(%%rec %%eliminee)?
+  -- Because for whatever reason, `false.rec_on` takes the motive not as an
+  -- implicit argument, like any other recursor, but as an explicit one.
+  -- Why not something based on `mk_app` or `mk_mapp`? Because we need the
+  -- special elaborator support for `elab_as_eliminator` definitions.
+  let rec_app : name → pexpr := λ rec_suffix,
+    (unchecked_cast expr.mk_app : pexpr → list pexpr → pexpr)
+      (pexpr.mk_explicit (const (iname ++ rec_suffix) []))
+      (list.repeat pexpr.mk_placeholder (eliminee_args.length + 1) ++
+        [to_pexpr eliminee]),
+  let rec_suffix := if generate_ihs then "rec_on" else "cases_on",
+  let drec_suffix := if generate_ihs then "drec_on" else "dcases_on",
+  interactive.apply (rec_app rec_suffix)
+    <|> interactive.apply (rec_app drec_suffix)
+    <|> fail! "Failed to apply the (dependent) recursor for {iname} on {eliminee}.",
+
+  -- Prepare the "with" names for each constructor case.
+  let with_names := prod.fst $
+    with_names.take_list
+      (iinfo.constructors.map constructor_info.num_nameable_hypotheses),
+  let constrs := iinfo.constructors.zip with_names,
+
+  -- For each case (constructor):
+  cases : list (option (name × list expr)) ←
+    focus $ constrs.map $ λ ⟨cinfo, with_names⟩, do {
+      trace_eliminate_hyp "============",
+      trace_eliminate_hyp $ format! "Case {cinfo.cname}",
+      trace_state_eliminate_hyp "Initial state:",
+
+      -- Get the eliminee's arguments. (Some of these may have changed due to
+      -- the generalising step above.)
+      eliminee_type ← infer_type eliminee,
+      eliminee_args ← get_app_args_whnf eliminee_type,
+
+      -- Clear the eliminated hypothesis (if possible)
+      try $ clear eliminee,
+
+      -- Clear the index args (unless other stuff in the goal depends on them)
+      eliminee_args.mmap' (try ∘ clear),
+
+      trace_state_eliminate_hyp
+        "State after clearing the eliminee (and its arguments) and before introductions:",
+
+      -- Introduce the constructor arguments
+      (constructor_arg_names, ih_names) ←
+        constructor_intros generate_ihs cinfo,
+
+      -- Introduce the auto-generalised hypotheses.
+      intron num_auto_generalized,
+
+      -- Introduce the index equations
+      index_equations ← intron' num_index_vars,
+      let index_equations := index_equations.map local_pp_name,
+
+      -- Introduce the hypotheses that were generalised during index
+      -- generalisation.
+      intron num_index_generalized,
+
+      trace_state_eliminate_hyp
+        "State after introductions and before simplifying index equations:",
+
+      -- Simplify the index equations. Stop after this step if the goal has been
+      -- solved by the simplification.
+      ff ← unify_equations index_equations
+        | trace_eliminate_hyp "Case solved while simplifying index equations." >>
+          pure none,
+
+      trace_state_eliminate_hyp
+        "State after simplifying index equations and before simplifying IHs:",
+
+      -- Simplify the induction hypotheses
+      -- NOTE: The previous step may have changed the unique names of the
+      -- induction hypotheses, so we have to locate them again. Their pretty
+      -- names should be unique in the context, so we can use these.
+      (ih_names.map prod.fst).mmap'
+        (get_local >=> simplify_ih num_auto_generalized num_index_vars),
+
+      trace_state_eliminate_hyp
+        "State after simplifying IHs and before clearing index variables:",
+
+      -- Try to clear the index variables. These often become unused during
+      -- the index equation simplification step.
+      index_var_names.mmap $ λ h, try (get_local h >>= clear),
+
+      trace_state_eliminate_hyp
+        "State after clearing index variables and before renaming:",
+
+      -- Rename the constructor names and IHs. We do this here (rather than
+      -- earlier, when we introduced them) because there may now be less
+      -- hypotheses in the context, and therefore more of the desired
+      -- names may be free.
+      (constructor_arg_hyps, ih_hyps) ←
+        constructor_renames generate_ihs einfo iinfo cinfo with_names
+          constructor_arg_names ih_names,
+
+      trace_state_eliminate_hyp "Final state:",
+
+      -- Return the constructor name and the renamable new hypotheses. These are
+      -- the hypotheses that can later be renamed by the `case` tactic. Note
+      -- that index variables and index equations are not renamable. This may be
+      -- counterintuitive in some cases, but it's surprisingly difficult to
+      -- catch exactly the relevant hyps here.
+      pure $ some (cinfo.cname, constructor_arg_hyps ++ ih_hyps)
+    },
+
+  set_cases_tags in_tag cases.reduce_option,
+
+  pure ()
+
+/--
+A variant of `tactic.eliminate_hyp` which performs induction or case analysis on
+an arbitrary expression. `eliminate_hyp` requires that the eliminee is a
+hypothesis. `eliminate_expr` lifts this restriction by generalising the goal
+over the eliminee before calling `eliminate_hyp`. The generalisation replaces
+the eliminee with a new hypothesis `x` everywhere in the goal. If `eq_name` is
+`some h`, an equation `h : eliminee = x` is added to remember the value of the
+eliminee.
+-/
+meta def eliminate_expr (generate_induction_hyps : bool) (eliminee : expr)
+  (eq_name : option name := none) (gm := generalization_mode.generalize_all_except [])
+  (with_names : list name := []) : tactic unit := do
+  num_reverted ← revert_reverse_dependencies_of_hyp eliminee,
+  hyp ← match eq_name with
+      | some h := do
+          x ← get_unused_name `x,
+          interactive.generalize h () (to_pexpr eliminee, x),
+          get_local x
+      | none := do
+          if eliminee.is_local_constant
+            then pure eliminee
+            else do
+              x ← get_unused_name `x,
+              generalize' eliminee x
+      end,
+  intron num_reverted,
+  eliminate_hyp generate_induction_hyps hyp gm with_names
+
+end tactic
+
+
+namespace tactic.interactive
+
+open tactic tactic.eliminate interactive interactive.types lean.parser
+
+/--
+Parse a `fixing` or `generalizing` clause for `induction'` or `cases'`.
+-/
+meta def generalisation_mode_parser : lean.parser generalization_mode :=
+  (tk "fixing" *>
+    ((tk "*" *> pure (generalization_mode.generalize_only []))
+      <|>
+      generalization_mode.generalize_all_except <$> many ident))
+  <|>
+  (tk "generalizing" *> generalization_mode.generalize_only <$> many ident)
+  <|>
+  pure (generalization_mode.generalize_all_except [])
+
+precedence `fixing`:0
+
+/--
+A variant of `tactic.interactive.induction`, with the following differences:
+
+- If the eliminee (the hypothesis we are performing induction on) has complex
+  indices, `induction'` 'remembers' them. A complex expression is any
+  expression that is not merely a local hypothesis. An eliminee
+  `e : I p₁ ... pₙ j₁ ... jₘ`, where `I` is an inductive type with `n`
+  parameters and `m` indices, has a complex index if any of the `jᵢ` are
+  complex. In this situation, standard `induction` effectively forgets the exact
+  values of the complex indices, which often leads to unprovable goals.
+  `induction'` 'remembers' them by adding propositional equalities. As a
+  result, you may find equalities named `induction_eq` in your goal, and the
+  induction hypotheses may also quantify over additional equalities.
+- `induction'` generalises induction hypotheses as much as possible by default.
+  This means that if you eliminate `n` in the goal
+  ```
+  n m : ℕ
+  ⊢ P n m
+  ```
+  the induction hypothesis is `∀ m, P n m` instead of `P n m`.
+- `induction'` generates much more human-friendly names than `induction`. It
+  also clears redundant hypotheses more aggressively.
+- `induction'` currently does not support custom induction principles a la
+  `induction using`.
+
+Like `induction`, `induction'` supports some modifiers:
+
+`induction' e with n₁ ... nₘ` uses the names `nᵢ` for the new hypotheses.
+
+`induction' e fixing h₁ ... hₙ` fixes the hypotheses `hᵢ`, so the induction
+hypothesis is not generalised over these hypotheses.
+
+`induction' e fixing *` fixes all hypotheses. This disables the generalisation
+functionality, so this mode behaves like standard `induction`.
+
+`induction' e generalizing h₁ ... hₙ` generalises only the hypotheses `hᵢ`. This
+mode behaves like `induction e generalising h₁ ... hₙ`.
+
+`induction' t`, where `t` is an arbitrary term (rather than a hypothesis),
+generalises the goal over `t`, then performs induction on the generalised goal.
+
+`induction' h : t = x` is similar, but also adds an equation `h : t = x` to
+remember the value of `t`.
+
+To debug this tactic, use
+
+```
+set_option trace.eliminate_hyp true
+```
+-/
+meta def induction' (eliminee : parse cases_arg_p)
+  (gm : parse generalisation_mode_parser)
+  (with_names : parse (optional with_ident_list)) : tactic unit := do
+  let ⟨eq_name, e⟩ := eliminee,
+  e ← to_expr e,
+  eliminate_expr tt e eq_name gm (with_names.get_or_else [])
+
+/--
+A variant of `tactic.interactive.cases`, with minor changes:
+
+- `cases'` can perform case analysis on some (rare) goals that `cases` does not
+  support.
+- `cases'` generates much more human-friendly names for the new hypotheses it
+  introduces.
+
+This tactic supports the same modifiers as `cases`, e.g.
+
+```
+cases' H : e = x with n m o
+```
+
+This is almost exactly the same as `tactic.interactive.induction'`, only that no
+induction hypotheses are generated.
+
+To debug this tactic, use
+
+```
+set_option trace.eliminate_hyp true
+```
+-/
+meta def cases' (eliminee : parse cases_arg_p)
+  (with_names : parse (optional with_ident_list)) : tactic unit := do
+  let ⟨eq_name, e⟩ := eliminee,
+  e ← to_expr e,
+  eliminate_expr ff e eq_name (generalization_mode.generalize_only [])
+    (with_names.get_or_else [])
+
+end tactic.interactive

--- a/src/tactic/induction.lean
+++ b/src/tactic/induction.lean
@@ -875,6 +875,17 @@ proceed as follows:
   `eq'ᵢ : x = y`.
 - Otherwise `eqᵢ` remains unchanged.
 -/
+/-
+TODO `simplify_ih` currently uses Lean's builtin unification procedure to
+process the index equations. This procedure has some limitations. For example,
+we would like to clear an IH that assumes `0 = 1` since this IH can never be
+applied, but Lean's unification doesn't allow us to conclude this.
+
+It would therefore be preferable to use the algorithm from
+`tactic.unify_equations` instead. There is no problem with this in principle,
+but it requires a complete refactoring of `unify_equations` so that it works
+not only on hypotheses but on arbitrary terms.
+-/
 meta def simplify_ih (num_generalized : ℕ) (num_index_vars : ℕ) (ih : expr) :
   tactic expr := do
   T ← infer_type ih,

--- a/src/tactic/induction.lean
+++ b/src/tactic/induction.lean
@@ -69,9 +69,21 @@ functions to collect this information for a specific goal.
 
 
 /--
-Information about a constructor argument. Contains:
+Information about a constructor argument. E.g. given the declaration
 
-- `aname`: the argument's name.
+```
+induction ℕ : Type
+| zero : ℕ
+| suc (n : ℕ) : ℕ
+```
+
+the `zero` constructor has no arguments and the `suc` constructor has one
+argument, `n`.
+
+We record the following information:
+
+- `aname`: the argument's name. If the argument was not explicitly named in the
+  declaration, the elaborator generates a name for it.
 - `type` : the argument's type.
 - `dependent`: whether the argument is dependent, i.e. whether it occurs in the
   remainder of the constructor type.

--- a/src/tactic/induction.lean
+++ b/src/tactic/induction.lean
@@ -700,6 +700,16 @@ Output:
 - The number of hypotheses which were reverted because they contain complex
   indices.
 -/
+/-
+TODO The following function currently replaces complex index arguments
+everywhere in the goal, not only in the major premise. Such replacements are
+sometimes necessary to make sure that the goal remains type-correct. However,
+the replacements can also have the opposite effect, yielding unprovable
+subgoals. The test suite contains one such case. There is probably a middle
+ground between 'replace everywhere' and 'replace only in the major premise', but
+I don't know what exactly this middle ground is. See also the discussion at
+https://github.com/leanprover-community/mathlib/pull/5027#discussion_r538902424
+-/
 meta def generalize_complex_index_args (major_premise : expr) (num_params : ℕ)
   (generate_induction_hyps : bool) : tactic (expr × ℕ × list name × ℕ) :=
 focus1 $ do

--- a/test/induction.lean
+++ b/test/induction.lean
@@ -1,0 +1,1338 @@
+import tactic.induction
+import tactic.linarith
+
+universes u v w
+
+inductive le : ℕ → ℕ → Type
+| zero {n} : le 0 n
+| succ {n m} : le n m → le (n + 1) (m + 1)
+
+inductive lt : ℕ → ℕ → Type
+| zero {n} : lt 0 (n + 1)
+| succ {n m} : lt n m → lt (n + 1) (m + 1)
+
+inductive Fin : ℕ → Type
+| zero {n} : Fin (n + 1)
+| succ {n} : Fin n → Fin (n + 1)
+
+inductive List (α : Sort*) : Sort*
+| nil {} : List
+| cons {} (x : α) (xs : List) : List
+
+namespace List
+
+def append {α} : List α → List α → List α
+| nil ys := ys
+| (cons x xs) ys := cons x (append xs ys)
+
+end List
+
+inductive Vec (α : Sort u) : ℕ → Sort (max 1 u)
+| nil : Vec 0
+| cons {n} : α → Vec n → Vec (n + 1)
+
+namespace Vec
+
+inductive eq {α} : ∀ n m, Vec α n → Vec α m → Prop
+| nil : eq 0 0 nil nil
+| cons {n m} {xs : Vec α n} {ys : Vec α m} {x y : α} :
+  x = y →
+  eq n m xs ys →
+  eq (n + 1) (m + 1) (cons x xs) (cons y ys)
+
+end Vec
+
+inductive Two : Type | zero | one
+
+inductive ℕ' : Type
+| intro : ℕ → ℕ'
+
+example (k) : 0 + k = k :=
+begin
+  induction' k,
+  { refl },
+  { simp }
+end
+
+example {k} (fk : Fin k) : Fin (k + 1) :=
+begin
+  induction' fk,
+  { exact Fin.zero },
+  { exact Fin.succ ih }
+end
+
+example {α} (l : List α) : l.append List.nil = l :=
+begin
+  induction' l,
+  { refl },
+  { dsimp only [List.append],
+    exact (congr_arg _ ih)
+  }
+end
+
+example {k l} (h : lt k l) : le k l :=
+begin
+  induction' h,
+  { exact le.zero },
+  { exact le.succ ih }
+end
+
+example {k l} : lt k l → le k l :=
+begin
+  induction' k; induction' l; intro hlt,
+  { cases' hlt },
+  { exact le.zero },
+  { cases' hlt },
+  { cases' hlt,
+    exact le.succ (@ih m hlt),
+  }
+end
+
+example {α n m} {xs : Vec α n} {ys : Vec α m} (h : Vec.eq n m xs ys) : n = m :=
+begin
+  induction' h,
+  case nil {
+    refl
+  },
+  case cons {
+    exact congr_arg nat.succ ih,
+  }
+end
+
+-- A simple induction with complex index arguments.
+example {k} (h : lt (k + 1) k) : false :=
+begin
+  induction' h,
+  { exact ih }
+end
+
+-- A more complex induction with complex index arguments. Note the dependencies
+-- between index arguments.
+example {α : Sort u} {x y n m} {xs : Vec α n} {ys : Vec α m}
+  : Vec.eq (n + 1) (m + 1) (Vec.cons x xs) (Vec.cons y ys)
+  → Vec.eq n m xs ys :=
+begin
+  intro h,
+  induction' h,
+  exact h_1
+end
+
+-- It also works with cases'.
+example {α : Sort u} {x y n m} {xs : Vec α n} {ys : Vec α m}
+  : Vec.eq (n + 1) (m + 1) (Vec.cons x xs) (Vec.cons y ys)
+  → Vec.eq n m xs ys :=
+begin
+  intro h,
+  cases' h,
+  exact h_1
+end
+
+-- This example requires elimination of cyclic generalised index equations.
+example (n : ℕ) (h : n = n + 3) : false :=
+begin
+  success_if_fail { cases h },
+  induction' h
+end
+
+-- It also works with cases'.
+example (n : ℕ) (h : n = n + 3) : false :=
+begin
+  success_if_fail { cases h },
+  cases' h
+end
+
+-- This example used to fail because it involves a nested inductive as a complex
+-- index.
+inductive rose₁ : Type
+| tip : rose₁
+| node : list rose₁ → rose₁
+
+example (rs) (h : rose₁.tip = rose₁.node rs) : false :=
+begin
+  cases' h
+end
+
+-- This example tests type-based naming.
+example (k : ℕ') (i : ℕ') : ℕ :=
+begin
+  induction' k,
+  induction' i,
+  exact (n + m)
+end
+
+-- For constructor arguments that are propositions, the default name is "h".
+-- For non-propositions, it is "x".
+inductive nat_or_positive
+| nat : ℕ' → nat_or_positive
+| positive (n : ℕ) : n > 0 → nat_or_positive
+
+example (n : nat_or_positive) : unit :=
+begin
+  cases' n,
+  case nat {
+    guard_hyp x : ℕ',
+    exact ()
+  },
+  case positive {
+    guard_hyp n : ℕ,
+    guard_hyp h : n > 0,
+    exact ()
+  }
+end
+
+-- By default, induction' generates the most general possible induction
+-- hypothesis.
+example {n m : ℕ} : n + m = m + n :=
+begin
+  induction' m,
+  case zero { simp },
+  case succ : k IH {
+    guard_hyp k : ℕ,
+    guard_hyp n : ℕ,
+    guard_hyp IH : ∀ {n}, n + k = k + n,
+    ac_refl
+  }
+end
+
+-- Here's an example where this is more useful.
+example {n m : ℕ} (h : n + n = m + m) : n = m :=
+begin
+  induction' n with n ih,
+  case zero {
+    cases' m,
+    { refl },
+    { cases' h }
+  },
+  case succ {
+    cases' m,
+    { cases' h },
+    { rw @ih m,
+      simp only [nat.succ_eq_add_one] at h,
+      replace h : n + n + 2 = m + m + 2 := by linarith,
+      injections
+    }
+  }
+end
+
+-- If we don't want a hypothesis to be generalised, we can say so with a
+-- "fixing" clause.
+example {n m : ℕ} : n + m = m + n :=
+begin
+  induction' m fixing n,
+  case zero { simp },
+  case succ : k IH {
+    guard_hyp k : ℕ,
+    guard_hyp n : ℕ,
+    guard_hyp IH : n + k = k + n,
+    ac_refl
+  }
+end
+
+-- We can also fix all hypotheses. This gives us the behaviour of stock
+-- `induction`. Hypotheses which depend on the eliminee (or its index arguments)
+-- still get generalised.
+example {n m k : ℕ} (h : n + m = k) : n + m = k :=
+begin
+  induction' n fixing *,
+  case zero { simp [*] },
+  case succ : n IH {
+    guard_hyp n : ℕ,
+    guard_hyp m : ℕ,
+    guard_hyp k : ℕ,
+    guard_hyp h : n.succ + m = k,
+    guard_hyp IH : n + m = k → n + m = k,
+    -- Neither m nor k were generalised.
+    exact h
+  }
+end
+
+-- We can also generalise only certain hypotheses using a `generalizing`
+-- clause. This gives us the behaviour of stock `induction ... generalizing`.
+-- Hypotheses which depend on the eliminee get generalised even if they are not
+-- mentioned in the `generalizing` clause.
+example {n m k : ℕ} (h : n + m = k) : n + m = k :=
+begin
+  induction' n generalizing k,
+  case zero { simp [*] },
+  case succ : n IH {
+    guard_hyp n : ℕ,
+    guard_hyp m : ℕ,
+    guard_hyp k : ℕ,
+    guard_hyp h : n.succ + m = k,
+    guard_hyp IH : ∀ {k}, n + m = k → n + m = k,
+    -- k was generalised, but m was not.
+    exact h
+  }
+end
+
+-- Sometimes generalising a hypothesis H does not give us a more general
+-- induction hypothesis. In such cases, induction' should not generalise H. The
+-- following example is not realistic, but situations like this can occur in
+-- practice; see accufact_1_eq_fact below.
+example (n m k : ℕ) : m + k = k + m :=
+begin
+  induction' m,
+  case zero { simp },
+  case succ {
+    guard_hyp ih : ∀ k, m + k = k + m,
+    -- k was generalised because this makes the IH more general.
+    -- n was not generalised -- if it had been, the IH would be
+    --
+    --     ∀ n k, m + k = k + m
+    --
+    -- with one useless additional argument.
+    ac_refl
+  }
+end
+
+-- This example checks that constructor arguments don't 'steal' the names of
+-- generalised hypotheses.
+example (n : list ℕ) (n : ℕ) : list ℕ :=
+begin
+  -- this performs induction on (n : ℕ)
+  induction' n,
+  { exact n },
+  { guard_hyp n : list ℕ,
+    guard_hyp n_1 : ℕ,
+    -- n is the list, which was automatically generalized and keeps its name.
+    -- n_1 is the recursive argument of `nat.succ`. It would be called `n` if
+    -- there wasn't already an `n` in the context.
+    exact (n_1 :: n)
+  }
+end
+
+-- This example tests whether `induction'` gets confused when there are
+-- additional cases around.
+example (k : ℕ) (t : Two) : 0 + k = k :=
+begin
+  cases t,
+  induction' k,
+  { refl },
+  { simp },
+  induction' k,
+  { refl },
+  { simp }
+end
+
+-- The type of the induction premise can be a complex expression so long as it
+-- normalises to an inductive (possibly applied to params/indexes).
+example (n) : 0 + n = n :=
+begin
+  let T := ℕ,
+  change T at n,
+  induction' n; simp
+end
+
+-- Fail if the type of the induction premise is not an inductive type
+example {α} (x : α) (f : α → α) : unit :=
+begin
+  success_if_fail { induction' x },
+  success_if_fail { induction' f },
+  exact ()
+end
+
+-- The following example used to trigger a bug where eliminate would generate
+-- hypotheses with duplicate names.
+structure fraction : Type :=
+(num           : ℤ)
+(denom         : ℤ)
+(denom_ne_zero : denom ≠ 0)
+
+lemma fraction.ext (a b : fraction) (hnum : fraction.num a = fraction.num b)
+    (hdenom : fraction.denom a = fraction.denom b) :
+  a = b :=
+begin
+  cases' a,
+  cases' b,
+  guard_hyp num : ℤ,
+  guard_hyp denom : ℤ,
+  guard_hyp num_1 : ℤ,
+  guard_hyp denom_1 : ℤ,
+  rw fraction.mk.inj_eq,
+  exact and.intro hnum hdenom
+end
+
+-- A "with" clause can be used to give the names of constructor arguments (as
+-- for `cases`, `induction` etc).
+example (x : ℕ × ℕ) (y : Vec ℕ 2) (z : List ℕ) : unit :=
+begin
+  cases' x with i j k l,
+  guard_hyp i : ℕ,
+  guard_hyp j : ℕ,
+  clear i j,
+
+  cases' y with i j k l,
+  -- Note that i is 'skipped' because it is used to name the (n : ℕ)
+  -- argument of `cons`, but that argument is cleared by index unification. I
+  -- find this a little strange, but `cases` also behaves like this.
+  guard_hyp j : ℕ,
+  guard_hyp k : Vec ℕ 1,
+  clear j k,
+
+  cases' z with i j k l,
+  case nil { exact () },
+  case cons {
+    guard_hyp i : ℕ,
+    guard_hyp j : List ℕ,
+    exact ()
+  }
+end
+
+-- "with" also works with induction'.
+example (x : List ℕ) : unit :=
+begin
+  induction' x with i j k l,
+  case nil { exact () },
+  case cons {
+    guard_hyp i : ℕ,
+    guard_hyp j : List ℕ,
+    guard_hyp k : unit,
+    exact ()
+  }
+end
+
+-- An underscore in a "with" clause means "use the auto-generated name for this
+-- argument".
+example (x : List ℕ) : unit :=
+begin
+  induction' x with _ j _ l,
+  case nil { exact () },
+  case cons {
+    guard_hyp x : ℕ,
+    guard_hyp j : List ℕ,
+    guard_hyp ih : unit,
+    exact ()
+  }
+end
+
+-- induction' and cases' can be used to perform induction/case analysis on
+-- arbitrary expressions (not just hypotheses). A very synthetic example:
+example {α} : α ∨ ¬ α :=
+begin
+  cases' classical.em α with a nota,
+  { exact (or.inl a) },
+  { exact (or.inr nota) }
+end
+
+-- Cases'/induction' can add an equation witnessing the case split they
+-- performed. Again, a highly synthetic example:
+example {α} (xs : list α)
+  : xs.reverse.length = 0 ∨ ∃ m, xs.reverse.length = m + 1 :=
+begin
+  cases' eq : xs.length,
+  case zero {
+    left,
+    rw list.length_reverse,
+    exact eq
+  },
+  case succ : l {
+    right,
+    rw list.length_reverse,
+    use l,
+    exact eq
+  }
+end
+
+-- Index equation simplification can deal with equations that aren't in normal
+-- form.
+example {α} (x : α) (xs) : list.take 1 (x :: xs) ≠ [] :=
+begin
+  intro contra,
+  cases' contra
+end
+
+-- Index generalisation should leave early occurrences of complex index terms
+-- alone. This means that given the eliminee `e : E (f y) y` where `y` is a
+-- complex term, index generalisation should give us
+--
+--     e : E (f y) i,
+--
+-- *not*
+--
+--     e : E (f i) i.
+--
+-- Otherwise we get problems with examples like this:
+inductive ℕ₂ : Type
+| zero
+| succ (n : ℕ₂) : ℕ₂
+
+namespace ℕ₂
+
+def plus : ℕ₂ → ℕ₂ → ℕ₂
+| zero y := y
+| (succ x) y := succ (plus x y)
+
+example (x : ℕ₂) (h : plus zero x = zero) : x = zero :=
+begin
+  cases' h,
+  guard_target zero = plus zero zero,
+  refl
+  -- If index generalisation blindly replaced all occurrences of zero, we would
+  -- get
+  --
+  --     index = zero        → plus index x = index → x = index
+  --
+  -- and after applying the recursor
+  --
+  --     plus index x = zero                        → x = plus index x
+  --
+  -- This leaves the goal provable, but very confusing.
+end
+
+end ℕ₂
+
+-- For whatever reason, the eliminator for `false` has an explicit argument
+-- where all other eliminators have an implicit one. `eliminate_hyp` has to
+-- work around this to ensure that we can eliminate a `false` hyp.
+example {α} (h : false) : α :=
+begin
+  cases' h
+end
+
+-- Index equation simplification also works with nested datatypes.
+inductive rose (α : Type) : Type
+| leaf : rose
+| node (val : α) (children : list rose) : rose
+
+namespace rose
+
+inductive nonempty {α} : rose α → Prop
+| node (v c cs) : nonempty (node v (c :: cs))
+
+lemma nonempty_node_elim {α} {v : α} {cs} (h : nonempty (node v cs)) : ¬ cs.empty :=
+begin
+  induction' h,
+  finish
+end
+
+end rose
+
+--------------------------------------------------------------------------------
+-- Jasmin's original use cases
+--------------------------------------------------------------------------------
+
+/- Head induction for transitive closure -/
+
+inductive star {α : Sort*} (r : α → α → Prop) (a : α) : α → Prop
+| refl {}    : star a
+| tail {b c} : star b → r b c → star c
+
+namespace star
+
+variables {α : Sort*} {r : α → α → Prop} {a b c d : α}
+
+lemma head (hab : r a b) (hbc : star r b c) :
+  star r a c :=
+begin
+  induction' hbc fixing hab,
+  case refl {
+    exact refl.tail hab },
+  case tail : c d hbc hcd hac {
+    exact hac.tail hcd }
+end
+
+-- In this example, induction' must apply the dependent recursor for star; the
+-- nondependent one doesn't apply.
+lemma head_induction_on {P : ∀a : α, star r a b → Prop} {a} (h : star r a b)
+  (refl : P b refl)
+  (head : ∀{a c} (h' : r a c) (h : star r c b), P c h → P a (h.head h')) :
+  P a h :=
+begin
+  induction' h,
+  case refl {
+    exact refl
+  },
+  case tail : b c hab hbc ih {
+    apply ih,
+    { exact head hbc _ refl, },
+    { intros _ _ hab _, exact head hab _}
+  }
+end
+
+end star
+
+
+/- Factorial -/
+
+def accufact : ℕ → ℕ → ℕ
+| a 0       := a
+| a (n + 1) := accufact ((n + 1) * a) n
+
+lemma accufact_1_eq_fact (n : ℕ) :
+  accufact 1 n = nat.factorial n :=
+have accufact_eq_fact_mul : ∀m a, accufact a m = nat.factorial m * a :=
+  begin
+    intros m a,
+    induction' m,
+    case zero {
+      simp [nat.factorial, accufact] },
+    case succ {
+      simp [nat.factorial, accufact, ih, nat.succ_eq_add_one],
+      cc }
+  end,
+by simp [accufact_eq_fact_mul n 1]
+
+/- Substitution -/
+
+namespace expressions
+
+inductive exp : Type
+| Var  : string → exp
+| Num  : ℤ → exp
+| Plus : exp → exp → exp
+
+export exp
+
+def subst (ρ : string → exp) : exp → exp
+| (Var y)      := ρ y
+| (Num i)      := Num i
+| (Plus e₁ e₂) := Plus (subst e₁) (subst e₂)
+
+
+lemma subst_Var (e : exp) :
+  subst (λx, Var x) e = e :=
+begin
+  induction' e,
+  case Var {
+    guard_hyp s : string,
+    rw [subst]
+  },
+  case Num {
+    guard_hyp n : ℤ,
+    rw [subst]
+  },
+  case Plus {
+    guard_hyp e : exp,
+    guard_hyp e_1 : exp,
+    guard_hyp ih_e,
+    guard_hyp ih_e_1,
+    rw [subst],
+    rw ih_e,
+    rw ih_e_1
+   }
+end
+
+end expressions
+
+
+/- Less-than -/
+
+namespace less_than
+
+inductive lt : nat → nat → Type
+| zero_succ (n : nat) : lt 0 (1 + n)
+| succ_succ {n m : nat} : lt n m → lt (1 + n) (1 + m)
+
+inductive lte : nat → nat → Type
+| zero (n : nat) : lte 0 n
+| succ {n m : nat} : lte n m → lte (1 + n) (1 + m)
+
+lemma lt_lte {n m} : lt n m → lte n m :=
+begin
+  intro lt_n_m,
+  induction' lt_n_m,
+  case zero_succ : i {
+    constructor
+  },
+  case succ_succ : i j lt_i_j ih {
+    constructor,
+    apply ih
+  }
+end
+
+end less_than
+
+/- Sortedness -/
+
+inductive sorted : list ℕ → Prop
+| nil : sorted []
+| single {x : ℕ} : sorted [x]
+| two_or_more {x y : ℕ} {zs : list ℕ} (hle : x ≤ y)
+    (hsorted : sorted (y :: zs)) :
+  sorted (x :: y :: zs)
+
+/- In this example it's important that cases' *doesn't* normalise the values of
+indexes when simplifying index equations. -/
+lemma not_sorted_17_13 :
+  ¬ sorted [17, 13] :=
+begin
+  intro h,
+  cases' h,
+  guard_hyp hle : 17 ≤ 13,
+  linarith
+end
+
+
+/- Palindromes -/
+
+namespace palindrome
+
+inductive palindrome {α : Type} : list α → Prop
+| nil : palindrome []
+| single (x : α) : palindrome [x]
+| sandwich (x : α) (xs : list α) (hpal : palindrome xs) :
+  palindrome ([x] ++ xs ++ [x])
+
+axiom reverse_append_sandwich {α : Type} (x : α) (ys : list α) :
+  list.reverse ([x] ++ ys ++ [x]) = [x] ++ list.reverse ys ++ [x]
+
+lemma rev_palindrome {α : Type} (xs : list α) (hpal : palindrome xs) :
+  palindrome (list.reverse xs) :=
+begin
+  induction' hpal,
+  case nil {
+    exact palindrome.nil
+  },
+  case single {
+    exact palindrome.single _
+  },
+  case sandwich {
+    rw reverse_append_sandwich,
+    apply palindrome.sandwich,
+    apply ih
+  }
+end
+
+end palindrome
+
+
+/- Transitive Closure -/
+
+namespace transitive_closure
+
+inductive tc {α : Type} (r : α → α → Prop) : α → α → Prop
+| base (x y : α) (hr : r x y) : tc x y
+| step (x y z : α) (hr : r x y) (ht : tc y z) : tc x z
+
+/- The transitive closure is a nice example with lots of variables to keep track
+of. We start with a lemma where the variable names do not collide with those
+appearing in the definition of the inductive predicate. -/
+
+lemma tc_pets₁ {α : Type} (r : α → α → Prop) (c : α) :
+  ∀a b, tc r a b → r b c → tc r a c :=
+begin
+  intros a b htab hrbc,
+  induction' htab fixing c,
+  case base : _ _ hrab {
+    exact tc.step _ _ _ hrab (tc.base _ _ hrbc)
+  },
+  case step : _ x _ hrax {
+    exact tc.step _ _ _ hrax (ih hrbc)
+  }
+end
+
+/- The same proof, but this time the variable names clash. Also, this time we
+let `induction'` generalize `z`. -/
+
+lemma tc_pets₂ {α : Type} (r : α → α → Prop) (z : α) :
+  ∀x y, tc r x y → r y z → tc r x z :=
+begin
+  intros x y htxy hryz,
+  induction' htxy,
+  case base : _ _ hrxy {
+    exact tc.step _ _ _ hrxy (tc.base _ _ hryz)
+  },
+  case step : _ x' y hrxx' htx'y ih {
+    exact tc.step _ _ _ hrxx' (ih _ hryz)
+  }
+end
+
+/- Another proof along the same lines. -/
+
+lemma tc_trans {α : Type} (r : α → α → Prop) (c : α) :
+  ∀a b : α, tc r a b → tc r b c → tc r a c :=
+begin
+  intros a b htab htbc,
+  induction' htab,
+  case base {
+    exact tc.step _ _ _ hr htbc
+  },
+  case step {
+    exact tc.step _ _ _ hr (ih _ htbc)
+  }
+end
+
+/- ... and with clashing variable names: -/
+
+lemma tc_trans' {α : Type} (r : α → α → Prop) {x y z} :
+  tc r x y → tc r y z → tc r x z :=
+begin
+  intros h₁ h₂,
+  induction' h₁,
+  case base {
+    exact tc.step _ _ _ hr h₂
+  },
+  case step {
+    exact tc.step _ _ _ hr (ih h₂)
+  }
+end
+
+end transitive_closure
+
+
+/- Evenness -/
+
+inductive Even : ℕ → Prop
+| zero    : Even 0
+| add_two : ∀k : ℕ, Even k → Even (k + 2)
+
+lemma not_even_2_mul_add_1 (n : ℕ) :
+  ¬ Even (2 * n + 1) :=
+begin
+  intro h,
+  induction' h,
+  -- No case tag since there's only one goal. I don't really like this, but
+  -- this is the behaviour of induction/cases.
+  {
+    apply ih (n - 1),
+    cases' n,
+    case zero {
+      linarith
+    },
+    case succ {
+      simp [nat.succ_eq_add_one] at *,
+      linarith
+    }
+  }
+end
+
+
+/- Big-Step Semantics -/
+
+namespace semantics
+
+def state :=
+string → ℕ
+
+def state.update (name : string) (val : ℕ) (s : state) : state :=
+λname', if name' = name then val else s name'
+
+notation s `{` name ` ↦ ` val `}` := state.update name val s
+
+inductive stmt : Type
+| skip   : stmt
+| assign : string → (state → ℕ) → stmt
+| seq    : stmt → stmt → stmt
+| ite    : (state → Prop) → stmt → stmt → stmt
+| while  : (state → Prop) → stmt → stmt
+
+export stmt
+
+infixr ` ;; ` : 90 := stmt.seq
+
+/- Our first version is partly uncurried, like in the Logical Verification
+course, and also like in Concrete Semantics. This makes the binary infix
+notation possible. -/
+
+inductive big_step : stmt × state → state → Prop
+| skip {s} :
+  big_step (skip, s) s
+| assign {x a s} :
+  big_step (assign x a, s) (s{x ↦ a s})
+| seq {S T s t u} (hS : big_step (S, s) t)
+    (hT : big_step (T, t) u) :
+  big_step (seq S T, s) u
+| ite_true {b : state → Prop} {S T s t} (hcond : b s)
+    (hbody : big_step (S, s) t) :
+  big_step (ite b S T, s) t
+| ite_false {b : state → Prop} {S T s t} (hcond : ¬ b s)
+    (hbody : big_step (T, s) t) :
+  big_step (ite b S T, s) t
+| while_true {b : state → Prop} {S s t u} (hcond : b s)
+    (hbody : big_step (S, s) t)
+    (hrest : big_step (while b S, t) u) :
+  big_step (while b S, s) u
+| while_false {b : state → Prop} {S s} (hcond : ¬ b s) :
+  big_step (while b S, s) s
+
+infix ` ⟹ `:110 := big_step
+
+open big_step
+
+lemma not_big_step_while_true {S s t} :
+  ¬ (while (λ_, true) S, s) ⟹ t :=
+begin
+  intro hw,
+  induction' hw,
+  case while_true {
+    exact ih_hw_1
+  },
+  case while_false {
+    exact hcond trivial
+  }
+end
+
+/- The same with a curried version of the predicate. It should make no
+difference whether a predicate is curried or uncurried. -/
+
+inductive curried_big_step : stmt → state → state → Prop
+| skip {s} :
+  curried_big_step skip s s
+| assign {x a s} :
+  curried_big_step (assign x a) s (s{x ↦ a s})
+| seq {S T s t u} (hS : curried_big_step S s t)
+    (hT : curried_big_step T t u) :
+  curried_big_step (seq S T) s u
+| ite_true {b : state → Prop} {S T s t} (hcond : b s)
+    (hbody : curried_big_step S s t) :
+  curried_big_step (ite b S T) s t
+| ite_false {b : state → Prop} {S T s t} (hcond : ¬ b s)
+    (hbody : curried_big_step T s t) :
+  curried_big_step (ite b S T) s t
+| while_true {b : state → Prop} {S s t u} (hcond : b s)
+    (hbody : curried_big_step S s t)
+    (hrest : curried_big_step (while b S) t u) :
+  curried_big_step (while b S) s u
+| while_false {b : state → Prop} {S s} (hcond : ¬ b s) :
+  curried_big_step (while b S) s s
+
+lemma not_curried_big_step_while_true {S s t} :
+  ¬ curried_big_step (while (λ_, true) S) s t :=
+begin
+  intro hw,
+  induction' hw,
+  case while_true {
+    exact ih_hw_1,
+  },
+  case while_false {
+    exact hcond trivial
+  }
+end
+
+end semantics
+
+
+/- Small-Step Semantics -/
+
+namespace semantics
+
+inductive small_step : stmt × state → stmt × state → Prop
+| assign {x a s} :
+  small_step (assign x a, s) (skip, s{x ↦ a s})
+| seq_step {S S' T s s'} (hS : small_step (S, s) (S', s')) :
+  small_step (seq S T, s) (seq S' T, s')
+| seq_skip {T s} :
+  small_step (seq skip T, s) (T, s)
+| ite_true {b : state → Prop} {S T s} (hcond : b s) :
+  small_step (ite b S T, s) (S, s)
+| ite_false {b : state → Prop} {S T s} (hcond : ¬ b s) :
+  small_step (ite b S T, s) (T, s)
+| while {b : state → Prop} {S s} :
+  small_step (while b S, s) (ite b (seq S (while b S)) skip, s)
+
+lemma small_step_if_equal_states {S T s t s' t'}
+    (hstep : small_step (S, s) (T, t)) (hs : s' = s) (ht : t' = t) :
+  small_step (S, s') (T, t') :=
+begin
+  induction' hstep,
+  { rw [hs, ht],
+    exact small_step.assign,
+  },
+  { apply small_step.seq_step,
+    exact ih hs ht,
+  },
+  { rw [hs, ht],
+    exact small_step.seq_skip,
+  },
+  { rw [hs, ht],
+    exact small_step.ite_true hcond,
+  },
+  { rw [hs, ht],
+    exact small_step.ite_false hcond,
+  },
+  { rw [hs, ht],
+    exact small_step.while,
+  }
+end
+
+infixr ` ⇒ ` := small_step
+infixr ` ⇒* ` : 100 := star small_step
+
+
+/- More lemmas about big-step and small-step semantics. These are taken from the
+Logical Verification course materials. They provide lots of good test cases for
+cases'/induction'. -/
+
+namespace star
+
+variables {α : Sort*} {r : α → α → Prop} {a b c d : α}
+
+attribute [refl] star.refl
+
+@[trans] lemma trans (hab : star r a b) (hbc : star r b c) :
+  star r a c :=
+begin
+  induction' hbc,
+  case refl {
+    assumption },
+  case tail : c d hbc hcd hac {
+    exact (star.tail (hac hab)) hcd }
+end
+
+lemma single (hab : r a b) :
+  star r a b :=
+star.refl.tail hab
+
+lemma trans_induction_on {α : Sort*} {r : α → α → Prop}
+    {p : ∀{a b : α}, star r a b → Prop} {a b : α} (h : star r a b)
+    (ih₁ : ∀a, @p a a star.refl) (ih₂ : ∀{a b} (h : r a b), p (single h))
+    (ih₃ : ∀{a b c} (h₁ : star r a b) (h₂ : star r b c), p h₁ →
+       p h₂ → p (trans h₁ h₂)) :
+  p h :=
+begin
+  induction' h,
+  case refl {
+    exact ih₁ a },
+  case tail : b c hab hbc ih {
+    exact ih₃ hab (single hbc) (ih ih₁ @ih₂ @ih₃) (ih₂ hbc) }
+end
+
+lemma lift {β : Sort*} {s : β → β → Prop} (f : α → β)
+  (h : ∀a b, r a b → s (f a) (f b)) (hab : star r a b) :
+  star s (f a) (f b) :=
+begin
+  apply trans_induction_on hab,
+  exact (λ a, star.refl),
+  exact (λ a b, star.single ∘ h _ _),
+  exact (λ a b c _ _, star.trans)
+end
+
+end star
+
+lemma big_step_deterministic {S s l r} (hl : (S, s) ⟹ l)
+    (hr : (S, s) ⟹ r) :
+  l = r :=
+begin
+  induction' hl,
+  case skip : t {
+    cases' hr,
+    refl },
+  case assign : x a s {
+    cases' hr,
+    refl },
+  case seq : S T s t l hS hT ihS ihT {
+    cases' hr with _ _ _ _ _ _ _ t' _ hS' hT',
+    cases' ihS hS',
+    cases' ihT hT',
+    refl },
+  case ite_true : b S T s t hb hS ih {
+    cases' hr,
+    { apply ih,
+      assumption },
+    { apply ih,
+      cc } },
+  case ite_false : b S T s t hb hT ih {
+    cases' hr,
+    { apply ih,
+      cc },
+    { apply ih,
+      assumption } },
+  case while_true : b S s t u hb hS hw ihS ihw {
+    cases' hr,
+    { cases' ihS hr,
+      cases' ihw hr_1,
+      refl },
+    { cc } },
+  { cases' hr,
+    { cc },
+    { refl } }
+end
+
+@[simp] lemma big_step_skip_iff {s t} :
+  (stmt.skip, s) ⟹ t ↔ t = s :=
+begin
+  apply iff.intro,
+  { intro h,
+    cases' h,
+    refl },
+  { intro h,
+    rw h,
+    exact big_step.skip }
+end
+
+@[simp] lemma big_step_assign_iff {x a s t} :
+  (stmt.assign x a, s) ⟹ t ↔ t = s{x ↦ a s} :=
+begin
+  apply iff.intro,
+  { intro h,
+    cases' h,
+    refl },
+  { intro h,
+    rw h,
+    exact big_step.assign }
+end
+
+@[simp] lemma big_step_seq_iff {S T s t} :
+  (S ;; T, s) ⟹ t ↔ (∃u, (S, s) ⟹ u ∧ (T, u) ⟹ t) :=
+begin
+  apply iff.intro,
+  { intro h,
+    cases' h,
+    apply exists.intro,
+    apply and.intro; assumption },
+  { intro h,
+    cases' h,
+    cases' h,
+    apply big_step.seq; assumption }
+end
+
+@[simp] lemma big_step_ite_iff {b S T s t} :
+  (stmt.ite b S T, s) ⟹ t ↔
+  (b s ∧ (S, s) ⟹ t) ∨ (¬ b s ∧ (T, s) ⟹ t) :=
+begin
+  apply iff.intro,
+  { intro h,
+    cases' h,
+    { apply or.intro_left,
+      cc },
+    { apply or.intro_right,
+      cc } },
+  { intro h,
+    cases' h; cases' h,
+    { apply big_step.ite_true; assumption },
+    { apply big_step.ite_false; assumption } }
+end
+
+lemma big_step_while_iff {b S s u} :
+  (stmt.while b S, s) ⟹ u ↔
+  (∃t, b s ∧ (S, s) ⟹ t ∧ (stmt.while b S, t) ⟹ u)
+  ∨ (¬ b s ∧ u = s) :=
+begin
+  apply iff.intro,
+  { intro h,
+    cases' h,
+    { apply or.intro_left,
+      apply exists.intro t,
+      cc },
+    { apply or.intro_right,
+      cc } },
+  { intro h,
+    cases' h,
+    case or.inl {
+      cases' h with t h,
+      cases' h with hb h,
+      cases' h with hS hwhile,
+      exact big_step.while_true hb hS hwhile },
+    case or.inr {
+      cases' h with hb hus,
+      rw hus,
+      exact big_step.while_false hb } }
+end
+
+lemma big_step_while_true_iff {b : state → Prop} {S s u}
+    (hcond : b s) :
+  (stmt.while b S, s) ⟹ u ↔
+  (∃t, (S, s) ⟹ t ∧ (stmt.while b S, t) ⟹ u) :=
+by rw big_step_while_iff; simp [hcond]
+
+@[simp] lemma big_step_while_false_iff {b : state → Prop}
+    {S s t} (hcond : ¬ b s) :
+  (stmt.while b S, s) ⟹ t ↔ t = s :=
+by rw big_step_while_iff; simp [hcond]
+
+
+lemma small_step_final (S s) :
+  (¬ ∃T t, (S, s) ⇒ (T, t)) ↔ S = stmt.skip :=
+begin
+  induction' S,
+  case skip {
+    simp,
+    intros T t hstep,
+    cases' hstep },
+  case assign : x a {
+    simp,
+    apply exists.intro stmt.skip,
+    apply exists.intro (s{x ↦ a s}),
+    exact small_step.assign },
+  case seq : S T ihS ihT {
+    simp,
+    cases' classical.em (S = stmt.skip),
+    case inl {
+      rw h,
+      apply exists.intro T,
+      apply exists.intro s,
+      exact small_step.seq_skip },
+    case inr {
+      simp [h, auto.not_forall_eq, auto.not_not_eq] at ihS,
+      cases' ihS s with S' hS',
+      cases' hS' with s' hs',
+      apply exists.intro (S' ;; T),
+      apply exists.intro s',
+      exact small_step.seq_step hs' } },
+  case ite : b S T ihS ihT {
+    simp,
+    cases' classical.em (b s),
+    case inl {
+      apply exists.intro S,
+      apply exists.intro s,
+      exact small_step.ite_true h },
+    case inr {
+      apply exists.intro T,
+      apply exists.intro s,
+      exact small_step.ite_false h } },
+  case while : b S ih {
+    simp,
+    apply exists.intro (stmt.ite b (S ;; stmt.while b S) stmt.skip),
+    apply exists.intro s,
+    exact small_step.while }
+end
+
+lemma small_step_deterministic {S s Ll Rr}
+    (hl : (S, s) ⇒ Ll) (hr : (S, s) ⇒ Rr) :
+  Ll = Rr :=
+begin
+  induction' hl,
+  case assign : x a s {
+    cases' hr,
+    refl },
+  case seq_step : S S₁ T s s₁ hS₁ ih {
+    cases' hr,
+    case seq_step : S S₂ _ _ s₂ hS₂ {
+      have hSs₁₂ := ih hS₂,
+      cc },
+    case seq_skip {
+      cases' hS₁ } },
+  case seq_skip : T s {
+    cases' hr,
+    { cases' hr },
+    { refl } },
+  case ite_true : b S T s hcond {
+    cases' hr,
+    case ite_true {
+      refl },
+    case ite_false {
+      cc } },
+  case ite_false : b S T s hcond {
+    cases' hr,
+    case ite_true {
+      cc },
+    case ite_false {
+      refl } },
+  case while : b S s {
+    cases' hr,
+    refl }
+end
+
+lemma small_step_skip {S s t} :
+  ¬ ((stmt.skip, s) ⇒ (S, t)) :=
+by intro h; cases' h
+
+@[simp] lemma small_step_seq_iff {S T s Ut} :
+  (S ;; T, s) ⇒ Ut ↔
+  (∃S' t, (S, s) ⇒ (S', t) ∧ Ut = (S' ;; T, t))
+  ∨ (S = stmt.skip ∧ Ut = (T, s)) :=
+begin
+  apply iff.intro,
+  { intro h,
+    cases' h,
+    { apply or.intro_left,
+      apply exists.intro S',
+      apply exists.intro s',
+      cc },
+    { apply or.intro_right,
+      cc } },
+  { intro h,
+    cases' h,
+    { cases' h,
+      cases' h,
+      cases' h,
+      rw right,
+      apply small_step.seq_step,
+      assumption },
+    { cases' h,
+      rw left,
+      rw right,
+      apply small_step.seq_skip } }
+end
+
+@[simp] lemma small_step_ite_iff {b S T s Us} :
+  (stmt.ite b S T, s) ⇒ Us ↔
+  (b s ∧ Us = (S, s)) ∨ (¬ b s ∧ Us = (T, s)) :=
+begin
+  apply iff.intro,
+  { intro h,
+    cases' h,
+    { apply or.intro_left,
+      cc },
+    { apply or.intro_right,
+      cc } },
+  { intro h,
+    cases' h,
+    { cases' h,
+      rw right,
+      apply small_step.ite_true,
+      assumption },
+    { cases' h,
+      rw right,
+      apply small_step.ite_false,
+      assumption } }
+end
+
+lemma star_small_step_seq {S T s u}
+    (h : (S, s) ⇒* (stmt.skip, u)) :
+  (S ;; T, s) ⇒* (stmt.skip ;; T, u) :=
+begin
+  apply star.lift (λSs, (prod.fst Ss ;; T, prod.snd Ss)) _ h,
+  intros Ss Ss' h,
+  cases' Ss,
+  cases' Ss',
+  apply small_step.seq_step,
+  assumption
+end
+
+lemma star_small_step_of_big_step {S s t} (h : (S, s) ⟹ t) :
+  (S, s) ⇒* (stmt.skip, t) :=
+begin
+  induction' h,
+  case skip {
+    refl },
+  case assign {
+    exact star.single small_step.assign },
+  case seq : S T s t u hS hT ihS ihT {
+    transitivity,
+    exact star_small_step_seq ihS,
+    apply star.head small_step.seq_skip ihT },
+  case ite_true : b S T s t hs hst ih {
+    exact star.head (small_step.ite_true hs) ih },
+  case ite_false : b S T s t hs hst ih {
+    exact star.head (small_step.ite_false hs) ih },
+  case while_true : b S s t u hb hS hw ihS ihw {
+    exact (star.head small_step.while
+      (star.head (small_step.ite_true hb)
+         (star.trans (star_small_step_seq ihS)
+            (star.head small_step.seq_skip ihw)))) },
+  case while_false : b S s hb {
+    exact star.tail (star.single small_step.while)
+      (small_step.ite_false hb) }
+end
+
+lemma big_step_of_small_step_of_big_step {S₀ S₁ s₀ s₁ s₂}
+  (h₁ : (S₀, s₀) ⇒ (S₁, s₁)) :
+  (S₁, s₁) ⟹ s₂ → (S₀, s₀) ⟹ s₂ :=
+begin
+  induction' h₁;
+    simp [*, big_step_while_true_iff, or_imp_distrib] {contextual := tt},
+  case seq_step {
+    intros u hS' hT,
+    apply exists.intro u,
+    exact and.intro (ih hS') hT },
+end
+
+lemma big_step_of_star_small_step {S s t} :
+  (S, s) ⇒* (stmt.skip, t) → (S, s) ⟹ t :=
+begin
+  generalize hSs : (S, s) = Ss,
+  intro h,
+  induction h
+      using star.head_induction_on
+      with _ S's' h h' ih
+      generalizing S s;
+    cases' hSs,
+  { exact big_step.skip },
+  { cases' S's' with S' s',
+    apply big_step_of_small_step_of_big_step h,
+    apply ih,
+    refl }
+end
+
+end semantics

--- a/test/induction.lean
+++ b/test/induction.lean
@@ -489,6 +489,17 @@ begin
   -- This leaves the goal provable, but very confusing.
 end
 
+-- TODO Here's a test case (due to Floris van Doorn) where index generalisation
+-- is over-eager: it replaces the complex index `zero` everywhere in the goal,
+-- which makes the goal type-incorrect. `cases` does not exhibit this problem.
+example (x : ℕ₂) (h : plus zero x = zero) :
+  (⟨x, h⟩ : ∃ x, plus zero x = zero) = ⟨zero, rfl⟩ :=
+begin
+  success_if_fail { cases' h },
+  cases h,
+  refl
+end
+
 end ℕ₂
 
 -- For whatever reason, the eliminator for `false` has an explicit argument
@@ -548,7 +559,7 @@ end
 
 -- In this example, induction' must apply the dependent recursor for star; the
 -- nondependent one doesn't apply.
-lemma head_induction_on {P : ∀a : α, star r a b → Prop} {a} (h : star r a b)
+lemma head_induction_on {b} {P : ∀a : α, star r a b → Prop} {a} (h : star r a b)
   (refl : P b refl)
   (head : ∀{a c} (h' : r a c) (h : star r c b), P c h → P a (h.head h')) :
   P a h :=

--- a/test/induction.lean
+++ b/test/induction.lean
@@ -229,8 +229,8 @@ begin
 end
 
 -- We can also fix all hypotheses. This gives us the behaviour of stock
--- `induction`. Hypotheses which depend on the eliminee (or its index arguments)
--- still get generalised.
+-- `induction`. Hypotheses which depend on the major premise (or its index
+-- arguments) still get generalised.
 example {n m k : ℕ} (h : n + m = k) : n + m = k :=
 begin
   induction' n fixing *,
@@ -248,8 +248,8 @@ end
 
 -- We can also generalise only certain hypotheses using a `generalizing`
 -- clause. This gives us the behaviour of stock `induction ... generalizing`.
--- Hypotheses which depend on the eliminee get generalised even if they are not
--- mentioned in the `generalizing` clause.
+-- Hypotheses which depend on the major premise get generalised even if they are
+-- not mentioned in the `generalizing` clause.
 example {n m k : ℕ} (h : n + m = k) : n + m = k :=
 begin
   induction' n generalizing k,
@@ -442,7 +442,7 @@ begin
 end
 
 -- Index generalisation should leave early occurrences of complex index terms
--- alone. This means that given the eliminee `e : E (f y) y` where `y` is a
+-- alone. This means that given the major premise `e : E (f y) y` where `y` is a
 -- complex term, index generalisation should give us
 --
 --     e : E (f y) i,

--- a/test/induction.lean
+++ b/test/induction.lean
@@ -3,6 +3,10 @@ import tactic.linarith
 
 universes u v w
 
+--------------------------------------------------------------------------------
+-- Setup: Some Inductive Types
+--------------------------------------------------------------------------------
+
 inductive le : ℕ → ℕ → Type
 | zero {n} : le 0 n
 | succ {n m} : le n m → le (n + 1) (m + 1)
@@ -46,6 +50,12 @@ inductive Two : Type | zero | one
 
 inductive ℕ' : Type
 | intro : ℕ → ℕ'
+
+
+--------------------------------------------------------------------------------
+-- Unit Tests
+--------------------------------------------------------------------------------
+
 
 example (k) : 0 + k = k :=
 begin
@@ -414,7 +424,7 @@ begin
   { exact (or.inr nota) }
 end
 
--- Cases'/induction' can add an equation witnessing the case split they
+-- Cases'/induction' can add an equation witnessing the case split it
 -- performed. Again, a highly synthetic example:
 example {α} (xs : list α)
   : xs.reverse.length = 0 ∨ ∃ m, xs.reverse.length = m + 1 :=
@@ -507,9 +517,14 @@ end
 
 end rose
 
+
 --------------------------------------------------------------------------------
--- Jasmin's original use cases
+-- Logical Verification Use Cases
 --------------------------------------------------------------------------------
+
+-- The following examples were graciously provided by Jasmin Blanchette. They
+-- are taken from his course 'Logical Verification'.
+
 
 /- Head induction for transitive closure -/
 
@@ -571,6 +586,7 @@ have accufact_eq_fact_mul : ∀m a, accufact a m = nat.factorial m * a :=
       cc }
   end,
 by simp [accufact_eq_fact_mul n 1]
+
 
 /- Substitution -/
 
@@ -641,6 +657,7 @@ begin
 end
 
 end less_than
+
 
 /- Sortedness -/
 


### PR DESCRIPTION
This PR adds interactive tactics `induction'` and `cases'` as well as
non-interactive variants `eliminate_hyp` and `eliminate_expr`. The tactics are
similar to standard `induction` and `cases`, but they feature several
improvements:

- `induction'` performs 'dependent induction', which means it takes the indices
  of indexed inductive types fully into account. This is convenient, for example,
  for programming language or logic formalisations, which tend to rely heavily on
  indexed types.
- `induction'` by default generalises everything that can be generalised. This
  is to support beginners, who often struggle to identify that a proof requires
  a generalised induction hypothesis. In cases where this feature hinders more
  than it helps, it can easily be turned off.
- `induction'` and `cases'` generate much more human-friendly names than their
  standard counterparts. This is, again, mostly to support beginners. Experts
  should usually supply explicit names to make proof scripts more robust.
- `cases'` works for some rare goals which `cases` does not support, but should
  otherwise be mostly a drop-in replacement (except for the generated names).

---

Sorry about the big code drop. I think I've split off everything that merits splitting off. But half the PR is test code, so you maybe don't need to look too much into that.