### PR TITLE
[Merged by Bors] - feat(data/list): map lemmas paralleling functor

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1395,14 +1395,14 @@ A single `list.map` of a composition of functions is equal to
 composing a `list.map` with another `list.map`, fully applied.
 This is the reverse direction of `list.map_map`.
 -/
-lemma comp_map {α β γ : Type*} (l : list α) (g : α → β) (h : β → γ)  :
+lemma comp_map (l : list α) (g : α → β) (h : β → γ)  :
   map (h ∘ g) l = map h (map g l) := (map_map _ _ _).symm
 
 /--
 Composing a `list.map` with another `list.map` is equal to
 a single `list.map` of composed functions.
 -/
-@[simp] lemma map_comp_map {α β γ : Type*} (f : α → β) (g : β → γ) :
+@[simp] lemma map_comp_map (f : α → β) (g : β → γ) :
   map g ∘ map f = map (g ∘ f) :=
 by apply funext; intro; rw comp_map
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1390,6 +1390,22 @@ begin
     cases x, simpa using hxy, simp at hxy, simp [y_ih hxy.2, h hxy.1] }
 end
 
+/--
+A single `list.map` of a composition of functions is equal to
+composing a `list.map` with another `list.map`, fully applied.
+This is the reverse direction of `list.map_map`.
+-/
+lemma comp_map {α β γ : Type*} (l : list α) (g : α → β) (h : β → γ)  :
+  map (h ∘ g) l = map h (map g l) := (map_map _ _ _).symm
+
+/--
+Composing a `list.map` with another `list.map` is equal to
+a single `list.map` of composed functions.
+-/
+@[simp] lemma map_comp_map {α β γ : Type*} (f : α → β) (g : β → γ) :
+  map g ∘ map f = map (g ∘ f) :=
+by apply funext; intro; rw comp_map
+
 theorem map_filter_eq_foldr (f : α → β) (p : α → Prop) [decidable_pred p] (as : list α) :
   map f (filter p as) = foldr (λ a bs, if p a then f a :: bs else bs) [] as :=
 by { induction as, { refl }, { simp! [*, apply_ite (map f)] } }

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1395,16 +1395,16 @@ A single `list.map` of a composition of functions is equal to
 composing a `list.map` with another `list.map`, fully applied.
 This is the reverse direction of `list.map_map`.
 -/
-lemma comp_map (l : list α) (g : α → β) (h : β → γ)  :
+lemma comp_map (h : β → γ) (g : α → β) (l : list α) :
   map (h ∘ g) l = map h (map g l) := (map_map _ _ _).symm
 
 /--
 Composing a `list.map` with another `list.map` is equal to
 a single `list.map` of composed functions.
 -/
-@[simp] lemma map_comp_map (f : α → β) (g : β → γ) :
+@[simp] lemma map_comp_map (g : β → γ) (f : α → β) :
   map g ∘ map f = map (g ∘ f) :=
-by apply funext; intro; rw comp_map
+by { ext l, rw comp_map }
 
 theorem map_filter_eq_foldr (f : α → β) (p : α → Prop) [decidable_pred p] (as : list α) :
   map f (filter p as) = foldr (λ a bs, if p a then f a :: bs else bs) [] as :=

--- a/src/data/multiset/functor.lean
+++ b/src/data/multiset/functor.lean
@@ -102,7 +102,7 @@ lemma map_traverse {G : Type* → Type*}
   traverse (functor.map h ∘ g) x :=
 quotient.induction_on x
 (by intro; simp [traverse] with functor_norm;
-    rw [comp_map,map_traverse])
+    rw [is_lawful_functor.comp_map, map_traverse])
 
 lemma traverse_map {G : Type* → Type*}
                [applicative G] [is_comm_applicative G]


### PR DESCRIPTION
Adding `comp_map` and `map_comp_map`.
Docstrings done to match docstrings for equivalent `prod.map_comp_map`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
