### PR TITLE
[Merged by Bors] - feat(algebra/*): Add of_injective lemmas

### DIFF
--- a/src/algebra/free_monoid.lean
+++ b/src/algebra/free_monoid.lean
@@ -51,6 +51,9 @@ def of (x : α) : free_monoid α := [x]
 @[to_additive]
 lemma of_def (x : α) : of x = [x] := rfl
 
+lemma of_injective : function.injective (@of α) :=
+λ a b, list.head_eq_of_cons_eq
+
 /-- Recursor for `free_monoid` using `1` and `of x * xs` instead of `[]` and `x :: xs`. -/
 @[to_additive "Recursor for `free_add_monoid` using `0` and `of x + xs` instead of `[]` and `x :: xs`."]
 def rec_on {C : free_monoid α → Sort*} (xs : free_monoid α) (h0 : C 1)

--- a/src/algebra/monoid_algebra.lean
+++ b/src/algebra/monoid_algebra.lean
@@ -262,6 +262,9 @@ end
 
 @[simp] lemma of_apply (a : G) : of k G a = single a 1 := rfl
 
+lemma of_injective [nontrivial k] : function.injective (of k G) :=
+λ a b h, by simpa using (single_eq_single_iff _ _ _ _).mp h
+
 lemma mul_single_apply_aux (f : monoid_algebra k G) {r : k}
   {x y z : G} (H : ∀ a, a * x = z ↔ a = y) :
   (f * single x r) z = f y * r :=

--- a/src/algebra/monoid_algebra.lean
+++ b/src/algebra/monoid_algebra.lean
@@ -734,6 +734,9 @@ end
 
 @[simp] lemma of_apply (a : multiplicative G) : of k G a = single a.to_add 1 := rfl
 
+lemma of_injective [nontrivial k] : function.injective (of k G) :=
+λ a b h, by simpa using (single_eq_single_iff _ _ _ _).mp h
+
 lemma mul_single_apply_aux (f : add_monoid_algebra k G) (r : k)
   (x y z : G) (H : ∀ a, a + x = z ↔ a = y) :
   (f * single x r) z = f y * r :=

--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -361,7 +361,7 @@ calc (mk L₁ = mk L₂) ↔ eqv_gen red.step L₁ L₂ : iff.intro (quot.exact 
   ... ↔ join red L₁ L₂ : eqv_gen_step_iff_join_red
 
 /-- The canonical injection from the type to the free group is an injection. -/
-theorem of_injective {x y : α} : function.injective (@of α) :=
+theorem of_injective : function.injective (@of α) :=
 λ _ _ H, let ⟨L₁, hx, hy⟩ := red.exact.1 H in
   by simp [red.singleton_iff] at hx hy; cc
 

--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -361,9 +361,9 @@ calc (mk L₁ = mk L₂) ↔ eqv_gen red.step L₁ L₂ : iff.intro (quot.exact 
   ... ↔ join red L₁ L₂ : eqv_gen_step_iff_join_red
 
 /-- The canonical injection from the type to the free group is an injection. -/
-theorem of.inj {x y : α} (H : of x = of y) : x = y :=
-let ⟨L₁, hx, hy⟩ := red.exact.1 H in
-by simp [red.singleton_iff] at hx hy; cc
+theorem of_injective {x y : α} : function.injective (@of α) :=
+λ _ _ H, let ⟨L₁, hx, hy⟩ := red.exact.1 H in
+  by simp [red.singleton_iff] at hx hy; cc
 
 section to_group
 


### PR DESCRIPTION
This adds `free_monoid.of_injective`, `monoid_algebra.of_injective`, `add_monoid_algebra.of_injective`, and renames and restates `free_group.of.inj` to match these lemmas.

`function.injective (free_abelian_group.of)` is probably also true, but I wasn't able to prove it.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
