### PR TITLE
[Merged by Bors] - feat(algebra/squarefree): a squarefree element of a UFM divides a power iff it divides

### DIFF
--- a/src/algebra/squarefree.lean
+++ b/src/algebra/squarefree.lean
@@ -115,6 +115,19 @@ begin
     assumption_mod_cast }
 end
 
+lemma dvd_pow_iff_dvd_of_squarefree {x y : R} {n : ℕ} (hsq : squarefree x) (h0 : n ≠ 0) :
+  x ∣ y ^ n ↔ x ∣ y :=
+begin
+  by_cases hx : x = 0,
+  { simp [hx, pow_eq_zero_iff (nat.pos_of_ne_zero h0)] },
+  by_cases hy : y = 0,
+  { simp [hy, zero_pow (nat.pos_of_ne_zero h0)] },
+  refine ⟨λ h, _, λ h, dvd_pow h h0⟩,
+  rw [dvd_iff_factors_le_factors hx (pow_ne_zero n hy), factors_pow,
+    ((squarefree_iff_nodup_factors hx).1 hsq).le_nsmul_iff_le h0] at h,
+  rwa dvd_iff_factors_le_factors hx hy,
+end
+
 end unique_factorization_monoid
 
 namespace nat

--- a/src/algebra/squarefree.lean
+++ b/src/algebra/squarefree.lean
@@ -86,9 +86,9 @@ end multiplicity
 
 namespace unique_factorization_monoid
 variables [comm_cancel_monoid_with_zero R] [nontrivial R] [unique_factorization_monoid R]
-variables [normalization_monoid R] [decidable_eq R]
+variables [normalization_monoid R]
 
-lemma squarefree_iff_nodup_factors {x : R} (x0 : x ≠ 0) :
+lemma squarefree_iff_nodup_factors [decidable_eq R] {x : R} (x0 : x ≠ 0) :
   squarefree x ↔ multiset.nodup (factors x) :=
 begin
   have drel : decidable_rel (has_dvd.dvd : R → R → Prop),
@@ -118,6 +118,7 @@ end
 lemma dvd_pow_iff_dvd_of_squarefree {x y : R} {n : ℕ} (hsq : squarefree x) (h0 : n ≠ 0) :
   x ∣ y ^ n ↔ x ∣ y :=
 begin
+  classical,
   by_cases hx : x = 0,
   { simp [hx, pow_eq_zero_iff (nat.pos_of_ne_zero h0)] },
   by_cases hy : y = 0,

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -848,8 +848,8 @@ quotient.induction_on s $ λ l,
 lemma dvd_prod [comm_monoid α] {a : α} {s : multiset α} : a ∈ s → a ∣ s.prod :=
 quotient.induction_on s (λ l a h, by simpa using list.dvd_prod h) a
 
-lemma prod_dvd_prod {α : Type*} [comm_monoid α] {x y : multiset α} (h : x ≤ y) :
-  x.prod ∣ y.prod :=
+lemma prod_dvd_prod [comm_monoid α] {s t : multiset α} (h : s ≤ t) :
+  s.prod ∣ t.prod :=
 begin
   rcases multiset.le_iff_exists_add.1 h with ⟨z, rfl⟩,
   simp,

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -1712,16 +1712,6 @@ iff_not_comm.1 $ count_pos.symm.trans pos_iff_ne_zero
 theorem count_ne_zero {a : α} {s : multiset α} : count a s ≠ 0 ↔ a ∈ s :=
 by simp [ne.def, count_eq_zero]
 
-@[simp]
-lemma mem_nsmul {a : α} {s : multiset α} {n : ℕ} (h0 : n ≠ 0) :
-  a ∈ n •ℕ s ↔ a ∈ s :=
-begin
-  cases n,
-  { exfalso, apply h0 rfl },
-  rw [← not_iff_not, ← count_eq_zero, ← count_eq_zero],
-  simp [h0],
-end
-
 @[simp] theorem count_repeat_self (a : α) (n : ℕ) : count a (repeat a n) = n :=
 by simp [repeat]
 
@@ -1812,6 +1802,17 @@ instance : semilattice_sup_bot (multiset α) :=
   bot_le := zero_le,
   ..multiset.lattice }
 
+end
+
+@[simp]
+lemma mem_nsmul {a : α} {s : multiset α} {n : ℕ} (h0 : n ≠ 0) :
+  a ∈ n •ℕ s ↔ a ∈ s :=
+begin
+  classical,
+  cases n,
+  { exfalso, apply h0 rfl },
+  rw [← not_iff_not, ← count_eq_zero, ← count_eq_zero],
+  simp [h0],
 end
 
 /- relator -/

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -848,7 +848,7 @@ quotient.induction_on s $ λ l,
 lemma dvd_prod [comm_monoid α] {a : α} {s : multiset α} : a ∈ s → a ∣ s.prod :=
 quotient.induction_on s (λ l a h, by simpa using list.dvd_prod h) a
 
-lemma multiset.prod_dvd_prod {α : Type*} [comm_monoid α] {x y : multiset α} (h : x ≤ y) :
+lemma prod_dvd_prod {α : Type*} [comm_monoid α] {x y : multiset α} (h : x ≤ y) :
   x.prod ∣ y.prod :=
 begin
   rcases multiset.le_iff_exists_add.1 h with ⟨z, rfl⟩,

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -848,6 +848,13 @@ quotient.induction_on s $ λ l,
 lemma dvd_prod [comm_monoid α] {a : α} {s : multiset α} : a ∈ s → a ∣ s.prod :=
 quotient.induction_on s (λ l a h, by simpa using list.dvd_prod h) a
 
+lemma multiset.prod_dvd_prod {α : Type*} [comm_monoid α] {x y : multiset α} (h : x ≤ y) :
+  x.prod ∣ y.prod :=
+begin
+  rcases multiset.le_iff_exists_add.1 h with ⟨z, rfl⟩,
+  simp,
+end
+
 theorem prod_eq_zero_iff [comm_cancel_monoid_with_zero α] [nontrivial α]
   {s : multiset α} :
   s.prod = 0 ↔ (0 : α) ∈ s :=
@@ -1704,6 +1711,16 @@ iff_not_comm.1 $ count_pos.symm.trans pos_iff_ne_zero
 
 theorem count_ne_zero {a : α} {s : multiset α} : count a s ≠ 0 ↔ a ∈ s :=
 by simp [ne.def, count_eq_zero]
+
+@[simp]
+lemma mem_nsmul {a : α} {s : multiset α} {n : ℕ} (h0 : n ≠ 0) :
+  a ∈ n •ℕ s ↔ a ∈ s :=
+begin
+  cases n,
+  { exfalso, apply h0 rfl },
+  rw [← not_iff_not, ← count_eq_zero, ← count_eq_zero],
+  simp [h0],
+end
 
 @[simp] theorem count_repeat_self (a : α) (n : ℕ) : count a (repeat a n) = n :=
 by simp [repeat]

--- a/src/data/multiset/erase_dup.lean
+++ b/src/data/multiset/erase_dup.lean
@@ -75,4 +75,24 @@ by simp [nodup_ext]
 theorem erase_dup_map_erase_dup_eq [decidable_eq β] (f : α → β) (s : multiset α) :
   erase_dup (map f (erase_dup s)) = erase_dup (map f s) := by simp [erase_dup_ext]
 
+@[simp]
+lemma erase_dup_nsmul {s : multiset α} {n : ℕ} (h0 : n ≠ 0) :
+  (n •ℕ s).erase_dup = s.erase_dup :=
+begin
+  ext a,
+  by_cases h : a ∈ s;
+  simp [h,h0]
+end
+
+lemma nodup.le_erase_dup_iff_le {s t : multiset α} (hno : s.nodup) :
+  s ≤ t.erase_dup ↔ s ≤ t :=
+by simp [le_erase_dup, hno]
+
+lemma nodup.le_nsmul_iff_le {s t : multiset α} {n : ℕ} (h : s.nodup) (hn : n ≠ 0) :
+  s ≤ n •ℕ t ↔ s ≤ t :=
+begin
+  rw [← h.le_erase_dup_iff_le, iff.comm, ← h.le_erase_dup_iff_le],
+  simp [hn]
+end
+
 end multiset

--- a/src/data/multiset/erase_dup.lean
+++ b/src/data/multiset/erase_dup.lean
@@ -88,11 +88,13 @@ lemma nodup.le_erase_dup_iff_le {s t : multiset α} (hno : s.nodup) :
   s ≤ t.erase_dup ↔ s ≤ t :=
 by simp [le_erase_dup, hno]
 
-lemma nodup.le_nsmul_iff_le {s t : multiset α} {n : ℕ} (h : s.nodup) (hn : n ≠ 0) :
+end multiset
+
+lemma multiset.nodup.le_nsmul_iff_le {α : Type*} {s t : multiset α}
+  {n : ℕ} (h : s.nodup) (hn : n ≠ 0) :
   s ≤ n •ℕ t ↔ s ≤ t :=
 begin
+  classical,
   rw [← h.le_erase_dup_iff_le, iff.comm, ← h.le_erase_dup_iff_le],
   simp [hn]
 end
-
-end multiset

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -426,6 +426,8 @@ have multiset.rel associated (p ::ₘ factors b) (factors a),
           (associated.symm (factors_prod hb0))),
 multiset.exists_mem_of_rel_of_mem this (by simp)
 
+@[simp] lemma factors_zero : factors (0 : α) = 0 := dif_pos rfl
+
 @[simp] lemma factors_one : factors (1 : α) = 0 :=
 begin
   rw ← multiset.rel_zero_right,
@@ -457,6 +459,26 @@ begin
   { rw multiset.prod_add,
     exact associated.trans (associated_mul_mul (factors_prod hx) (factors_prod hy))
       (factors_prod (mul_ne_zero hx hy)).symm, }
+end
+
+@[simp] lemma factors_pow {x : α} (n : ℕ) :
+  factors (x ^ n) = n •ℕ factors x :=
+begin
+  induction n with n ih,
+  { simp },
+  by_cases h0 : x = 0,
+  { simp [h0, zero_pow n.succ_pos, smul_zero] },
+  rw [pow_succ, succ_nsmul, factors_mul h0 (pow_ne_zero _ h0), ih],
+end
+
+lemma dvd_iff_factors_le_factors {x y : α} (hx : x ≠ 0) (hy : y ≠ 0) :
+  x ∣ y ↔ factors x ≤ factors y :=
+begin
+  split,
+  { rintro ⟨c, rfl⟩,
+    simp [hx, right_ne_zero_of_mul hy] },
+  { rw [← dvd_iff_dvd_of_rel_left (factors_prod hx), ← dvd_iff_dvd_of_rel_right (factors_prod hy)],
+    apply multiset.prod_dvd_prod }
 end
 
 end unique_factorization_monoid


### PR DESCRIPTION
Proves that if `x, y` are elements of a UFM such that `squarefree x`, then `x | y ^ n` iff `x | y`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
