### PR TITLE
[Merged by Bors] - feat(linear_algebra/quadratic_form): nondegenerate quadratic forms

### DIFF
--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -23,7 +23,7 @@ and composition with linear maps `f`, `Q.comp f x = Q (f x)`.
 
  * `quadratic_form.associated`: associated bilinear form
  * `quadratic_form.pos_def`: positive definite quadratic forms
- * `quadratic_form.non_degenerate`: non-degenerate quadratic forms
+ * `quadratic_form.nondegenerate`: non-degenerate quadratic forms
  * `quadratic_form.discr`: discriminant of a quadratic form
 
 ## Main statements

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -23,6 +23,7 @@ and composition with linear maps `f`, `Q.comp f x = Q (f x)`.
 
  * `quadratic_form.associated`: associated bilinear form
  * `quadratic_form.pos_def`: positive definite quadratic forms
+ * `quadratic_form.non_degenerate`: non-degenerate quadratic forms
  * `quadratic_form.discr`: discriminant of a quadratic form
 
 ## Main statements
@@ -387,6 +388,21 @@ quadratic_form.ext $ λ x,
   ... = Q x : by rw [← two_mul (Q x), ←mul_assoc, inv_of_mul_self, one_mul]
 
 end associated
+
+section nondegenerate
+
+/-- A non-degenerate quadratic form is zero only on zero vectors. -/
+def nondegenerate (Q : quadratic_form R M) : Prop := ∀ x, Q x = 0 → x = 0
+
+lemma not_nondegenerate_iff_exists (Q : quadratic_form R M) :
+  ¬nondegenerate Q ↔ ∃ x ≠ 0, Q x = 0 :=
+begin
+  unfold nondegenerate,
+  push_neg,
+  simp only [and_comm, exists_prop],
+end
+
+end nondegenerate
 
 section pos_def
 


### PR DESCRIPTION
No real lemmas about these, but `nondegenerate Q` is easier to read than `∀ x, Q x = 0 → x = 0`


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Defining.20degenerate.20quadratic.20forms