### PR TITLE
[Merged by Bors] - fix(linear_algebra/quadratic_form): nondegenerate -> anisotropic

### DIFF
--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -23,7 +23,7 @@ and composition with linear maps `f`, `Q.comp f x = Q (f x)`.
 
  * `quadratic_form.associated`: associated bilinear form
  * `quadratic_form.pos_def`: positive definite quadratic forms
- * `quadratic_form.nondegenerate`: non-degenerate quadratic forms
+ * `quadratic_form.anisotropic`: anisotropic quadratic forms
  * `quadratic_form.discr`: discriminant of a quadratic form
 
 ## Main statements
@@ -389,20 +389,16 @@ quadratic_form.ext $ λ x,
 
 end associated
 
-section nondegenerate
+section anisotropic
 
-/-- A non-degenerate quadratic form is zero only on zero vectors. -/
-def nondegenerate (Q : quadratic_form R M) : Prop := ∀ x, Q x = 0 → x = 0
+/-- An anisotropic quadratic form is zero only on zero vectors. -/
+def anisotropic (Q : quadratic_form R M) : Prop := ∀ x, Q x = 0 → x = 0
 
-lemma not_nondegenerate_iff_exists (Q : quadratic_form R M) :
-  ¬nondegenerate Q ↔ ∃ x ≠ 0, Q x = 0 :=
-begin
-  unfold nondegenerate,
-  push_neg,
-  simp only [and_comm, exists_prop],
-end
+lemma not_anisotropic_iff_exists (Q : quadratic_form R M) :
+  ¬anisotropic Q ↔ ∃ x ≠ 0, Q x = 0 :=
+by simp only [anisotropic, not_forall, exists_prop, and_comm]
 
-end nondegenerate
+end anisotropic
 
 section pos_def
 


### PR DESCRIPTION
I made a mistake by merging a PR that defined `nondegenerate`
but should have used the terminology `anisotropic` instead.



---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->