### PR TITLE
[Merged by Bors] - feat(data/nat/basic): add injectivity and divisibility lemmas

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -334,12 +334,6 @@ begin
   exact add_lt_add_of_lt_of_le hab (nat.succ_le_iff.2 hcd)
 end
 
-lemma add_left_injective (a : ℕ) : function.injective (λ x, x + a) :=
-λ _ _, add_right_cancel
-
-lemma add_right_injective (a : ℕ) : function.injective (λ x, a + x) :=
-λ _ _, add_left_cancel
-
 /-! ### `pred` -/
 
 @[simp]

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -334,6 +334,12 @@ begin
   exact add_lt_add_of_lt_of_le hab (nat.succ_le_iff.2 hcd)
 end
 
+lemma add_left_injective (a : ℕ) : function.injective (λ x, x + a) :=
+λ _ _, add_right_cancel
+
+lemma add_right_injective (a : ℕ) : function.injective (λ x, a + x) :=
+λ _ _, add_left_cancel
+
 /-! ### `pred` -/
 
 @[simp]
@@ -585,6 +591,12 @@ protected theorem mul_left_inj {a b c : ℕ} (ha : 0 < a) : b * a = c * a ↔ b 
 
 protected theorem mul_right_inj {a b c : ℕ} (ha : 0 < a) : a * b = a * c ↔ b = c :=
 ⟨nat.eq_of_mul_eq_mul_left ha, λ e, e ▸ rfl⟩
+
+lemma mul_left_injective {a : ℕ} (ha : 0 < a) : function.injective (λ x, x * a) :=
+λ _ _, eq_of_mul_eq_mul_right ha
+
+lemma mul_right_injective {a : ℕ} (ha : 0 < a) : function.injective (λ x, a * x) :=
+λ _ _, eq_of_mul_eq_mul_left ha
 
 lemma mul_right_eq_self_iff {a b : ℕ} (ha : 0 < a) : a * b = a ↔ b = 1 :=
 suffices a * b = a * 1 ↔ b = 1, by rwa mul_one at this,
@@ -881,6 +893,14 @@ nat.dvd_add_right (dvd_refl m)
 @[simp] protected lemma dvd_add_self_right {m n : ℕ} :
   m ∣ n + m ↔ m ∣ n :=
 nat.dvd_add_left (dvd_refl m)
+
+lemma not_dvd_of_pos_of_lt {a b : ℕ} (h1 : 0 < b) (h2 : b < a) : ¬ a ∣ b :=
+begin
+  rintros ⟨c, rfl⟩,
+  rcases eq_zero_or_pos c with (rfl | hc),
+  { exact lt_irrefl 0 h1 },
+  { exact not_lt.2 (le_mul_of_pos_right hc) h2 },
+end
 
 protected theorem mul_dvd_mul_iff_left {a b c : ℕ} (ha : 0 < a) : a * b ∣ a * c ↔ b ∣ c :=
 exists_congr $ λ d, by rw [mul_assoc, nat.mul_right_inj ha]


### PR DESCRIPTION
Multiplication by a non-zero natural is injective. Also a simple criterion for non-divisibility which I couldn't find (0<b<a implies a doesn't divide b). 

---

These are some lemmas I needed in #4956, a PR which is currently on hold because Anne is in the middle of a refactor of some finset stuff and I'd like to add more lemmas there without making their life harder. In the mean time I thought there would be no harm in PR'ing some of the uncontroversial easy stuff (and editing data.nat.basic is a pain).


<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
