### PR TITLE
[Merged by Bors] - chore(logic/basic): add `forall_apply_eq_imp_iff₂`

### DIFF
--- a/src/data/hash_map.lean
+++ b/src/data/hash_map.lean
@@ -193,9 +193,9 @@ theorem valid.as_list_nodup {n} {bkts : bucket_array α β n} {sz : nat} (v : va
   (bkts.as_list.map sigma.fst).nodup :=
 begin
   suffices : (bkts.to_list.map (list.map sigma.fst)).pairwise list.disjoint,
-  { simp [bucket_array.as_list, list.nodup_join, this],
-    change ∀ l s, array.mem s bkts → list.map sigma.fst s = l → l.nodup,
-    introv m e, subst e, cases m with i e, subst e,
+  { suffices : ∀ l, array.mem l bkts → (l.map sigma.fst).nodup,
+      by simpa [bucket_array.as_list, list.nodup_join, *],
+    rintros l ⟨i, rfl⟩,
     apply v.nodup },
   rw [← list.enum_map_snd bkts.to_list, list.pairwise_map, list.pairwise_map],
   have : (bkts.to_list.enum.map prod.fst).nodup := by simp [list.nodup_range],

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -2058,12 +2058,7 @@ by simp [disjoint, or_imp_distrib, forall_and_distrib]
 
 lemma disjoint_map_map {f : α → γ} {g : β → γ} {s : multiset α} {t : multiset β} :
   disjoint (s.map f) (t.map g) ↔ (∀a∈s, ∀b∈t, f a ≠ g b) :=
-begin
-  simp [disjoint],
-  split,
-  from assume h a ha b hb eq, h _ ha rfl _ hb eq.symm,
-  from assume h c a ha eq₁ b hb eq₂, h _ ha _ hb (eq₂.symm ▸ eq₁)
-end
+by { simp [disjoint, @eq_comm _ (f _) (g _)], refl }
 
 /-- `pairwise r m` states that there exists a list of the elements s.t. `r` holds pairwise on this list. -/
 def pairwise (r : α → α → Prop) (m : multiset α) : Prop :=

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1162,15 +1162,13 @@ iff.intro
   (assume ⟨b, hb, eq⟩, (hf eq) ▸ hb)
   (assume h, mem_image_of_mem _ h)
 
-theorem ball_image_of_ball {f : α → β} {s : set α} {p : β → Prop}
-  (h : ∀ x ∈ s, p (f x)) : ∀ y ∈ f '' s, p y :=
-by finish [mem_image_eq]
-
 theorem ball_image_iff {f : α → β} {s : set α} {p : β → Prop} :
   (∀ y ∈ f '' s, p y) ↔ (∀ x ∈ s, p (f x)) :=
-iff.intro
-  (assume h a ha, h _ $ mem_image_of_mem _ ha)
-  (assume h b ⟨a, ha, eq⟩, eq ▸ h a ha)
+by simp
+
+theorem ball_image_of_ball {f : α → β} {s : set α} {p : β → Prop}
+  (h : ∀ x ∈ s, p (f x)) : ∀ y ∈ f '' s, p y :=
+ball_image_iff.2 h
 
 theorem bex_image_iff {f : α → β} {s : set α} {p : β → Prop} :
   (∃ y ∈ f '' s, p y) ↔ (∃ x ∈ s, p (f x)) :=

--- a/src/deprecated/submonoid.lean
+++ b/src/deprecated/submonoid.lean
@@ -214,13 +214,7 @@ of the submonoid. -/
 a `finset` is an element of the `add_submonoid`."]
 lemma finset_prod_mem {M A} [comm_monoid M] (s : set M) [is_submonoid s] (f : A → M) :
   ∀(t : finset A), (∀b∈t, f b ∈ s) → ∏ b in t, f b ∈ s
-| ⟨m, hm⟩ hs :=
-  begin
-    refine multiset_prod_mem s _ _,
-    simp,
-    rintros a b hb rfl,
-    exact hs _ hb
-  end
+| ⟨m, hm⟩ hs := multiset_prod_mem s _ (by simpa)
 
 end is_submonoid
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -808,6 +808,10 @@ by simp [@eq_comm _ _ (f _)]
   (∀ b, ∀ a, b = f a → p b) ↔ (∀ a, p (f a)) :=
 by { rw forall_swap, simp }
 
+@[simp] theorem forall_apply_eq_imp_iff₂ {f : α → β} {p : α → Prop} {q : β → Prop} :
+  (∀ b, ∀ a, p a → f a = b → q b) ↔ ∀ a, p a → q (f a) :=
+⟨λ h a ha, h (f a) a ha rfl, λ h b a ha hb, hb ▸ h a ha⟩
+
 @[simp] theorem exists_eq_left' {a' : α} : (∃ a, a' = a ∧ p a) ↔ p a' :=
 by simp [@eq_comm _ a']
 

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1075,15 +1075,14 @@ begin
   { intros y hy,
     cases hf y with x hx,
     refine hx ▸ (mem_map_of_mem _),
-    rw Inf_eq_infi at ⊢ hy,
-    simp at ⊢ hy,
+    have : ∀ I ∈ A, y ∈ map f I, by simpa using hy,
+    rw [submodule.mem_Inf],
     intros J hJ,
-    cases (mem_map_iff_of_surjective f hf).1 (hy (map f J) J hJ rfl) with x' hx',
+    rcases (mem_map_iff_of_surjective f hf).1 (this J hJ) with ⟨x', hx', rfl⟩,
     have : x - x' ∈ J,
     { apply h J hJ,
-      rw [ring_hom.mem_ker, ring_hom.map_sub, hx, hx'.right, sub_self y], },
-    convert J.add_mem this hx'.left,
-    ring, }
+      rw [ring_hom.mem_ker, ring_hom.map_sub, hx, sub_self] },
+    simpa only [sub_add_cancel] using J.add_mem this hx' }
 end
 
 theorem map_is_prime_of_surjective {f : R →+* S} (hf : function.surjective f) {I : ideal R}


### PR DESCRIPTION
Other lemmas simplify `∀ y ∈ f '' s, p y` to the LHS of this lemma.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
