### PR TITLE
[Merged by Bors] - fix(algebra/group_with_zero/power): remove duplicate lemmas

### DIFF
--- a/src/algebra/group_with_zero/power.lean
+++ b/src/algebra/group_with_zero/power.lean
@@ -29,18 +29,6 @@ begin
   { exact zero_pow' n h.ne.symm }
 end
 
-theorem pow_eq_zero' [no_zero_divisors M] {a : M} {n : ℕ} (H : a ^ n = 0) : a = 0 :=
-begin
-  induction n with n ih,
-  { rw pow_zero at H,
-    rw [← mul_one a, H, mul_zero] },
-  exact or.cases_on (mul_eq_zero.1 H) id ih
-end
-
-@[field_simps]
-theorem pow_ne_zero' [no_zero_divisors M] {a : M} (n : ℕ) (h : a ≠ 0) : a ^ n ≠ 0 :=
-mt pow_eq_zero' h
-
 end zero
 
 section group_with_zero
@@ -55,7 +43,7 @@ by induction n with n ih; [exact inv_one.symm,
 theorem pow_sub' (a : G₀) {m n : ℕ} (ha : a ≠ 0) (h : n ≤ m) : a ^ (m - n) = a ^ m * (a ^ n)⁻¹ :=
 have h1 : m - n + n = m, from nat.sub_add_cancel h,
 have h2 : a ^ (m - n) * a ^ n = a ^ m, by rw [←pow_add, h1],
-eq_div_of_mul_eq (pow_ne_zero' _ ha) h2
+eq_div_of_mul_eq (pow_ne_zero _ ha) h2
 
 theorem pow_inv_comm' (a : G₀) (m n : ℕ) : (a⁻¹) ^ m * a ^ n = a ^ n * (a⁻¹) ^ m :=
 (commute.refl a).inv_left'.pow_pow m n
@@ -197,8 +185,8 @@ by rw [mul_comm, fpow_mul]
 | -[1+k] := by rw [gpow_neg_succ_of_nat, fpow_neg_succ_of_nat, units.coe_inv', u.coe_pow]
 
 lemma fpow_ne_zero_of_ne_zero {a : G₀} (ha : a ≠ 0) : ∀ (z : ℤ), a ^ z ≠ 0
-| (of_nat n) := pow_ne_zero' _ ha
-| -[1+n]     := inv_ne_zero $ pow_ne_zero' _ ha
+| (of_nat n) := pow_ne_zero _ ha
+| -[1+n]     := inv_ne_zero $ pow_ne_zero _ ha
 
 lemma fpow_sub {a : G₀} (ha : a ≠ 0) (z1 z2 : ℤ) : a ^ (z1 - z2) = a ^ z1 / a ^ z2 :=
 by rw [sub_eq_add_neg, fpow_add ha, fpow_neg]; refl

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -1154,7 +1154,7 @@ lemma count_pow {a : associates α} (ha : a ≠ 0) {p : associates α} (hp : irr
 begin
   induction k with n h,
   { rw [pow_zero, factors_one, zero_mul, count_zero hp] },
-  { rw [pow_succ, count_mul ha (pow_ne_zero' _ ha) hp, h, nat.succ_eq_add_one], ring }
+  { rw [pow_succ, count_mul ha (pow_ne_zero _ ha) hp, h, nat.succ_eq_add_one], ring }
 end
 
 theorem dvd_count_pow {a : associates α} (ha : a ≠ 0) {p : associates α} (hp : irreducible p)


### PR DESCRIPTION
`pow_eq_zero` and `pow_eq_zero'` are syntactically equal, as are `pow_ne_zero` and `pow_ne_zero'`. 

---

I was confused about which one to use :-) Sorry if there is a sensible reason for this! Even the proofs are equal (or alpha equivalent) according to `#print`.

<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
