### PR TITLE
[Merged by Bors] - chore(logic/function/basic): Add function.update_apply

### DIFF
--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -303,6 +303,16 @@ variables {α : Sort u} {β : α → Sort v} {α' : Sort w} [decidable_eq α] [d
 def update (f : Πa, β a) (a' : α) (v : β a') (a : α) : β a :=
 if h : a = a' then eq.rec v h.symm else f a
 
+/-- On non-dependent functions, `function.update` can be expressed as an `ite` -/
+lemma function.update_apply {β : Type*} (f : α → β) (a' : α) (b : β) (a : α) :
+  function.update f a' b a = if a = a' then b else f a :=
+begin
+  dunfold function.update,
+  congr,
+  ext,
+  rw eq_rec_constant,
+end
+
 @[simp] lemma update_same (a : α) (v : β a) (f : Πa, β a) : update f a v a = v :=
 dif_pos rfl
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -309,7 +309,7 @@ lemma function.update_apply {β : Type*} (f : α → β) (a' : α) (b : β) (a :
 begin
   dunfold function.update,
   congr,
-  ext,
+  funext,
   rw eq_rec_constant,
 end
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -304,7 +304,7 @@ def update (f : Πa, β a) (a' : α) (v : β a') (a : α) : β a :=
 if h : a = a' then eq.rec v h.symm else f a
 
 /-- On non-dependent functions, `function.update` can be expressed as an `ite` -/
-lemma update_apply {β : Type*} (f : α → β) (a' : α) (b : β) (a : α) :
+lemma update_apply {β : Sort*} (f : α → β) (a' : α) (b : β) (a : α) :
   update f a' b a = if a = a' then b else f a :=
 begin
   dunfold update,

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -304,10 +304,10 @@ def update (f : Πa, β a) (a' : α) (v : β a') (a : α) : β a :=
 if h : a = a' then eq.rec v h.symm else f a
 
 /-- On non-dependent functions, `function.update` can be expressed as an `ite` -/
-lemma function.update_apply {β : Type*} (f : α → β) (a' : α) (b : β) (a : α) :
-  function.update f a' b a = if a = a' then b else f a :=
+lemma update_apply {β : Type*} (f : α → β) (a' : α) (b : β) (a : α) :
+  update f a' b a = if a = a' then b else f a :=
 begin
-  dunfold function.update,
+  dunfold update,
   congr,
   funext,
   rw eq_rec_constant,


### PR DESCRIPTION
This makes it easier to eliminate `dite`s in simple situations when only `ite` is needed.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
