### PR TITLE
[Merged by Bors] - chore(data/equiv/basic): Add trivial simp lemma

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -273,6 +273,10 @@ equiv.trans_apply _ _ _
 
 @[simp] theorem one_apply {α : Type u} (x) : (1 : perm α) x = x := rfl
 
+@[simp] lemma comp_one (f : α → β) : f ∘ (1 : equiv.perm α) = f := rfl
+
+@[simp] lemma one_comp (f : α → β) : (1 : equiv.perm β) ∘ f = f := rfl
+
 @[simp] lemma inv_apply_self {α : Type u} (f : perm α) (x) :
   f⁻¹ (f x) = x := equiv.symm_apply_apply _ _
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -273,10 +273,6 @@ equiv.trans_apply _ _ _
 
 @[simp] theorem one_apply {α : Type u} (x) : (1 : perm α) x = x := rfl
 
-@[simp] lemma comp_one (f : α → β) : f ∘ (1 : equiv.perm α) = f := rfl
-
-@[simp] lemma one_comp (f : α → β) : (1 : equiv.perm β) ∘ f = f := rfl
-
 @[simp] lemma inv_apply_self {α : Type u} (f : perm α) (x) :
   f⁻¹ (f x) = x := equiv.symm_apply_apply _ _
 
@@ -290,6 +286,8 @@ lemma mul_def {α : Type u} (f g : perm α) : f * g = g.trans f := rfl
 lemma inv_def {α : Type u} (f : perm α) : f⁻¹ = f.symm := rfl
 
 @[simp] lemma coe_mul {α : Type u} (f g : perm α) : ⇑(f * g) = f ∘ g := rfl
+
+@[simp] lemma coe_one {α : Type u} : ⇑(1 : perm α) = id := rfl
 
 end perm
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -271,7 +271,7 @@ end
 theorem mul_apply {α : Type u} (f g : perm α) (x) : (f * g) x = f (g x) :=
 equiv.trans_apply _ _ _
 
-@[simp] theorem one_apply {α : Type u} (x) : (1 : perm α) x = x := rfl
+theorem one_apply {α : Type u} (x) : (1 : perm α) x = x := rfl
 
 @[simp] lemma inv_apply_self {α : Type u} (f : perm α) (x) :
   f⁻¹ (f x) = x := equiv.symm_apply_apply _ _


### PR DESCRIPTION
With this in place, `⇑1 ∘ f` simplifies to `⇑f`

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Forgotten in #4723