### PR TITLE
[Merged by Bors] - chore(data/sum): Add trivial simp lemmas

### DIFF
--- a/src/data/sum.lean
+++ b/src/data/sum.lean
@@ -93,6 +93,16 @@ protected def elim {α β γ : Sort*} (f : α → γ) (g : β → γ) : α ⊕ �
 @[simp] lemma elim_inr {α β γ : Sort*} (f : α → γ) (g : β → γ) (x : β) :
   sum.elim f g (inr x) = g x := rfl
 
+@[simp] lemma elim_comp_inl {α β γ : Sort*} (f : α → γ) (g : β → γ) :
+  sum.elim f g ∘ inl = f := rfl
+  
+@[simp] lemma elim_comp_inr {α β γ : Sort*} (f : α → γ) (g : β → γ) :
+  sum.elim f g ∘ inr = g := rfl
+  
+@[simp] lemma elim_comp_inl_inr {α β γ : Sort*} (f : α ⊕ β → γ) :
+  sum.elim (f ∘ inl) (f ∘ inr) = f :=
+funext $ λ x, sum.cases_on x (λ _, rfl) (λ _, rfl)
+
 lemma elim_injective {α β γ : Sort*} {f : α → γ} {g : β → γ}
   (hf : function.injective f) (hg : function.injective g)
  (hfg : ∀ a b, f a ≠ g b) : function.injective (sum.elim f g) :=

--- a/src/data/sum.lean
+++ b/src/data/sum.lean
@@ -99,6 +99,14 @@ protected def elim {α β γ : Sort*} (f : α → γ) (g : β → γ) : α ⊕ �
 @[simp] lemma elim_comp_inr {α β γ : Sort*} (f : α → γ) (g : β → γ) :
   sum.elim f g ∘ inr = g := rfl
   
+@[simp] lemma elim_inl_inr {α β : Sort*} :
+  @sum.elim α β _ inl inr = id :=
+funext $ λ x, sum.cases_on x (λ _, rfl) (λ _, rfl)
+
+lemma comp_elim {α β γ δ : Sort*} (f : γ → δ) (g : α → γ) (h : β → γ):
+  f ∘ sum.elim g h = sum.elim (f ∘ g) (f ∘ h) :=
+funext $ λ x, sum.cases_on x (λ _, rfl) (λ _, rfl)
+
 @[simp] lemma elim_comp_inl_inr {α β γ : Sort*} (f : α ⊕ β → γ) :
   sum.elim (f ∘ inl) (f ∘ inr) = f :=
 funext $ λ x, sum.cases_on x (λ _, rfl) (λ _, rfl)


### PR DESCRIPTION
---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Discussed here: https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/sum.2Eelim.20%28f.20.E2.88.98.20sum.2Einl%29.20%28f.20.E2.88.98.20sum.2Einr%29.20.3D.20f/near/217891929

@rwbarton points out that `sum.elim_comp_inl_inr` is shorter as `ext (_|_); refl`, but that's hard to use as a subexpression.
