### PR TITLE
[Merged by Bors] - chore(topology/path_connected): move `proj_Icc` to a separate file

### DIFF
--- a/src/data/set/intervals/proj_Icc.lean
+++ b/src/data/set/intervals/proj_Icc.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2020 Yury G. Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury G. Kudryashov, Patrick Massot
+-/
+import data.set.intervals.basic
+
+variables {α β : Type*} [linear_order α]
+
+open function
+
+namespace set
+
+/-- Projection of `α` to the closed interval `[a, b]`. -/
+def proj_Icc (a b : α) (h : a ≤ b) (x : α) : Icc a b :=
+⟨max a (min b x), le_max_left _ _, max_le h (min_le_left _ _)⟩
+
+variables {a b : α} (h : a ≤ b) {x : α}
+
+lemma proj_Icc_of_le_left (hx : x ≤ a) : proj_Icc a b h x = ⟨a, left_mem_Icc.2 h⟩ :=
+by simp [proj_Icc, hx, hx.trans h]
+
+@[simp] lemma proj_Icc_left : proj_Icc a b h a = ⟨a, left_mem_Icc.2 h⟩ :=
+proj_Icc_of_le_left h le_rfl
+
+lemma proj_Icc_of_right_le (hx : b ≤ x) : proj_Icc a b h x = ⟨b, right_mem_Icc.2 h⟩ :=
+by simp [proj_Icc, hx, h]
+
+@[simp] lemma proj_Icc_right : proj_Icc a b h b = ⟨b, right_mem_Icc.2 h⟩ :=
+proj_Icc_of_right_le h le_rfl
+
+lemma proj_Icc_of_mem (hx : x ∈ Icc a b) : proj_Icc a b h x = ⟨x, hx⟩ :=
+by simp [proj_Icc, hx.1, hx.2]
+
+@[simp] lemma proj_Icc_coe (x : Icc a b) : proj_Icc a b h x = x :=
+by { cases x, apply proj_Icc_of_mem }
+
+lemma proj_Icc_surj_on : surj_on (proj_Icc a b h) (Icc a b) univ :=
+λ x _, ⟨x, x.2, proj_Icc_coe h x⟩
+
+lemma proj_Icc_surjective : surjective (proj_Icc a b h) :=
+λ x, ⟨x, proj_Icc_coe h x⟩
+
+@[simp] lemma range_proj_Icc : range (proj_Icc a b h) = univ :=
+(proj_Icc_surjective h).range_eq
+
+lemma monotone_proj_Icc : monotone (proj_Icc a b h) :=
+λ x y hxy, max_le_max le_rfl $ min_le_min le_rfl hxy
+
+/-- Extend a function `[a, b] → β` to a map `α → β`. -/
+def Icc_extend (a b : α) (h : a ≤ b) (f : Icc a b → β) : α → β :=
+f ∘ proj_Icc a b h
+
+@[simp] lemma Icc_extend_range (f : Icc a b → β) :
+  range (Icc_extend a b h f) = range f :=
+by simp [Icc_extend, range_comp f]
+
+lemma Icc_extend_of_le_left (f : Icc a b → β) (hx : x ≤ a) :
+  Icc_extend a b h f x = f ⟨a, left_mem_Icc.2 h⟩ :=
+congr_arg f $ proj_Icc_of_le_left h hx
+
+@[simp] lemma Icc_extend_left (f : Icc a b → β) :
+  Icc_extend a b h f a = f ⟨a, left_mem_Icc.2 h⟩ :=
+Icc_extend_of_le_left h f le_rfl
+
+lemma Icc_extend_of_right_le (f : Icc a b → β) (hx : b ≤ x) :
+  Icc_extend a b h f x = f ⟨b, right_mem_Icc.2 h⟩ :=
+congr_arg f $ proj_Icc_of_right_le h hx
+
+@[simp] lemma Icc_extend_right (f : Icc a b → β) :
+  Icc_extend a b h f b = f ⟨b, right_mem_Icc.2 h⟩ :=
+Icc_extend_of_right_le h f le_rfl
+
+lemma Icc_extend_of_mem (f : Icc a b → β) (hx : x ∈ Icc a b) :
+  Icc_extend a b h f x = f ⟨x, hx⟩ :=
+congr_arg f $ proj_Icc_of_mem h hx
+
+@[simp] lemma Icc_extend_coe (f : Icc a b → β) (x : Icc a b) :
+  Icc_extend a b h f x = f x :=
+congr_arg f $ proj_Icc_coe h x
+
+lemma Icc_extend_monotone [preorder β] {f : Icc a b → β} (hf : monotone f) :
+  monotone (Icc_extend a b h f) :=
+hf.comp $ monotone_proj_Icc h
+
+end set

--- a/src/data/set/intervals/proj_Icc.lean
+++ b/src/data/set/intervals/proj_Icc.lean
@@ -5,6 +5,19 @@ Authors: Yury G. Kudryashov, Patrick Massot
 -/
 import data.set.intervals.basic
 
+/-!
+# Projection of a line onto a closed interval
+
+Given a linearly ordered type `α`, in this file we define
+
+* `set.proj_Icc (a b : α) (h : a ≤ b)` to be the map `α → [a, b]` sending `(-∞, a]` to `a`, `[b, ∞)`
+  to `b`, and each point `x ∈ [a, b]` to itself;
+* `set.Icc_extend {a b : α} (h : a ≤ b) (f : Icc a b → β)` to be the extension of `f` to `α` defined
+  as `f ∘ proj_Icc a b h`.
+
+We also prove some trivial properties of these maps.
+-/
+
 variables {α β : Type*} [linear_order α]
 
 open function
@@ -48,39 +61,39 @@ lemma monotone_proj_Icc : monotone (proj_Icc a b h) :=
 λ x y hxy, max_le_max le_rfl $ min_le_min le_rfl hxy
 
 /-- Extend a function `[a, b] → β` to a map `α → β`. -/
-def Icc_extend (a b : α) (h : a ≤ b) (f : Icc a b → β) : α → β :=
+def Icc_extend {a b : α} (h : a ≤ b) (f : Icc a b → β) : α → β :=
 f ∘ proj_Icc a b h
 
 @[simp] lemma Icc_extend_range (f : Icc a b → β) :
-  range (Icc_extend a b h f) = range f :=
+  range (Icc_extend h f) = range f :=
 by simp [Icc_extend, range_comp f]
 
 lemma Icc_extend_of_le_left (f : Icc a b → β) (hx : x ≤ a) :
-  Icc_extend a b h f x = f ⟨a, left_mem_Icc.2 h⟩ :=
+  Icc_extend h f x = f ⟨a, left_mem_Icc.2 h⟩ :=
 congr_arg f $ proj_Icc_of_le_left h hx
 
 @[simp] lemma Icc_extend_left (f : Icc a b → β) :
-  Icc_extend a b h f a = f ⟨a, left_mem_Icc.2 h⟩ :=
+  Icc_extend h f a = f ⟨a, left_mem_Icc.2 h⟩ :=
 Icc_extend_of_le_left h f le_rfl
 
 lemma Icc_extend_of_right_le (f : Icc a b → β) (hx : b ≤ x) :
-  Icc_extend a b h f x = f ⟨b, right_mem_Icc.2 h⟩ :=
+  Icc_extend h f x = f ⟨b, right_mem_Icc.2 h⟩ :=
 congr_arg f $ proj_Icc_of_right_le h hx
 
 @[simp] lemma Icc_extend_right (f : Icc a b → β) :
-  Icc_extend a b h f b = f ⟨b, right_mem_Icc.2 h⟩ :=
+  Icc_extend h f b = f ⟨b, right_mem_Icc.2 h⟩ :=
 Icc_extend_of_right_le h f le_rfl
 
 lemma Icc_extend_of_mem (f : Icc a b → β) (hx : x ∈ Icc a b) :
-  Icc_extend a b h f x = f ⟨x, hx⟩ :=
+  Icc_extend h f x = f ⟨x, hx⟩ :=
 congr_arg f $ proj_Icc_of_mem h hx
 
 @[simp] lemma Icc_extend_coe (f : Icc a b → β) (x : Icc a b) :
-  Icc_extend a b h f x = f x :=
+  Icc_extend h f x = f x :=
 congr_arg f $ proj_Icc_coe h x
 
 lemma Icc_extend_monotone [preorder β] {f : Icc a b → β} (hf : monotone f) :
-  monotone (Icc_extend a b h f) :=
+  monotone (Icc_extend h f) :=
 hf.comp $ monotone_proj_Icc h
 
 end set

--- a/src/topology/algebra/ordered/proj_Icc.lean
+++ b/src/topology/algebra/ordered/proj_Icc.lean
@@ -6,6 +6,13 @@ Authors: Yury Kudryashov, Patrick Massot
 import topology.algebra.ordered
 import data.set.intervals.proj_Icc
 
+/-!
+# Projection onto a closed interval
+
+In this file we prove that the projection `set.proj_Icc f a b h` is a quotient map, and use it
+to show that `Icc_extend h f` is continuous if and only if `f` is continuous.
+-/
+
 variables {α β : Type*} [topological_space α] [linear_order α] [order_topology α]
   [topological_space β] {a b : α} {h : a ≤ b}
 
@@ -21,10 +28,10 @@ quotient_map_iff.2 ⟨proj_Icc_surjective h, λ s,
    λ hs, ⟨_, hs, by { ext, simp }⟩⟩⟩
 
 @[simp] lemma continuous_Icc_extend_iff {f : Icc a b → β} :
-  continuous (Icc_extend a b h f) ↔ continuous f :=
+  continuous (Icc_extend h f) ↔ continuous f :=
 quotient_map_proj_Icc.continuous_iff.symm
 
 @[continuity]
 lemma continuous.Icc_extend {f : Icc a b → β} (hf : continuous f) :
-  continuous (Icc_extend a b h f) :=
+  continuous (Icc_extend h f) :=
 hf.comp continuous_proj_Icc

--- a/src/topology/algebra/proj_Icc.lean
+++ b/src/topology/algebra/proj_Icc.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2020 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov, Patrick Massot
+-/
+import topology.algebra.ordered
+import data.set.intervals.proj_Icc
+
+variables {α β : Type*} [topological_space α] [linear_order α] [order_topology α]
+  [topological_space β] {a b : α} {h : a ≤ b}
+
+open set
+
+@[continuity]
+lemma continuous_proj_Icc : continuous (proj_Icc a b h) :=
+continuous_subtype_mk _ $ continuous_const.max $ continuous_const.min continuous_id
+
+lemma quotient_map_proj_Icc : quotient_map (proj_Icc a b h) :=
+quotient_map_iff.2 ⟨proj_Icc_surjective h, λ s,
+  ⟨λ hs, hs.preimage continuous_proj_Icc,
+   λ hs, ⟨_, hs, by { ext, simp }⟩⟩⟩
+
+@[simp] lemma continuous_Icc_extend_iff {f : Icc a b → β} :
+  continuous (Icc_extend a b h f) ↔ continuous f :=
+quotient_map_proj_Icc.continuous_iff.symm
+
+@[continuity]
+lemma continuous.Icc_extend {f : Icc a b → β} (hf : continuous f) :
+  continuous (Icc_extend a b h f) :=
+hf.comp continuous_proj_Icc

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -101,6 +101,10 @@ topological_space.is_open_sUnion t s h
 
 end
 
+lemma topological_space_eq_iff {t t' : topological_space α} :
+  t = t' ↔ ∀ s, @is_open α t s ↔ @is_open α t' s :=
+⟨λ h s, h ▸ iff.rfl, λ h, by { ext, exact h _ }⟩
+
 lemma is_open_fold {s : set α} {t : topological_space α} : t.is_open s = @is_open α t s :=
 rfl
 

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -161,6 +161,10 @@ def quotient_map {α : Type*} {β : Type*} [tα : topological_space α] [tβ : t
   (f : α → β) : Prop :=
 function.surjective f ∧ tβ = tα.coinduced f
 
+lemma quotient_map_iff {α β : Type*} [topological_space α] [topological_space β] {f : α → β} :
+  quotient_map f ↔ function.surjective f ∧ ∀ s : set β, is_open s ↔ is_open (f ⁻¹' s) :=
+and_congr iff.rfl topological_space_eq_iff
+
 namespace quotient_map
 variables [topological_space α] [topological_space β] [topological_space γ] [topological_space δ]
 

--- a/src/topology/path_connected.lean
+++ b/src/topology/path_connected.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot
 -/
 import topology.instances.real
+import topology.algebra.proj_Icc
 
 /-!
 # Path connectedness
@@ -95,67 +96,6 @@ subtype.ext $ by simp [I_symm]
 lemma continuous_I_symm : continuous σ :=
 by continuity!
 
-/-- Projection of `ℝ` onto its unit interval. -/
-def proj_I : ℝ → I :=
-λ t, if h : t ≤ 0 then ⟨0, left_mem_Icc.mpr zero_le_one⟩ else
-     if h' : t ≤ 1 then ⟨t, ⟨le_of_lt $ not_le.mp h, h'⟩⟩ else ⟨1, right_mem_Icc.mpr zero_le_one⟩
-
-lemma proj_I_I {t : ℝ} (h : t ∈ I) : proj_I t = ⟨t, h⟩ :=
-begin
-  unfold proj_I,
-  rw mem_Icc at h,
-  split_ifs,
-  { simp [show t = 0, by linarith] },
-  { refl },
-  { exfalso, linarith }
-end
-
-lemma proj_I_zero : proj_I 0 = 0 := proj_I_I (⟨le_refl 0, zero_le_one⟩)
-
-lemma proj_I_one : proj_I 1 = 1 := proj_I_I (⟨zero_le_one, le_refl 1⟩)
-
-lemma surjective_proj_I : surjective proj_I :=
-λ ⟨t, t_in⟩, ⟨t, proj_I_I t_in⟩
-
-lemma range_proj_I : range proj_I = univ :=
-surjective_proj_I.range_eq
-
-@[continuity]
-lemma continuous_proj_I : continuous proj_I :=
-begin
-  refine continuous_induced_rng' (coe : I → ℝ) rfl _,
-  have : continuous (λ t : ℝ, if t ≤ 0 then 0 else if t ≤ 1 then t else 1),
-  { refine continuous_if _ continuous_const (continuous_if _ continuous_id continuous_const) ;
-    simp [Iic_def, zero_le_one] },
-  convert this,
-  ext,
-  dsimp [proj_I],
-  split_ifs ; refl
-end
-
-variables {β : Type*}
-
-/-- Extension of a function defined on the unit interval to `ℝ`, by precomposing with
-the projection. -/
-def I_extend {β : Type*} (f : I → β) : ℝ → β :=
-f ∘ proj_I
-
-@[continuity]
-lemma continuous.I_extend {f : I → X} (hf : continuous f) : continuous (I_extend f) :=
-hf.comp continuous_proj_I
-
-lemma I_extend_extends (f : I → β) {t : ℝ} (ht : t ∈ I) : I_extend f t = f ⟨t, ht⟩ :=
-by simp [I_extend, proj_I_I, ht]
-
-@[simp] lemma I_extend_zero (f : I → β) : I_extend f 0 = f 0 :=
-I_extend_extends _ _
-
-@[simp] lemma I_extend_one (f : I → β) : I_extend f 1 = f 1 :=
-I_extend_extends _ _
-
-@[simp] lemma I_extend_range (f : I → β) : range (I_extend f) = range f :=
-surjective_proj_I.range_comp f
-
 instance : connected_space I :=
 subtype.connected_space ⟨nonempty_Icc.mpr zero_le_one, is_preconnected_Icc⟩
 
@@ -179,6 +119,8 @@ instance : has_coe_to_fun (path x y) := ⟨_, path.to_fun⟩
 | ⟨x, h11, h12, h13⟩ ⟨.(x), h21, h22, h23⟩ rfl := rfl
 
 namespace path
+
+@[simp] lemma coe_mk (f : I → X) (h₁ h₂ h₃) : ⇑(mk f h₁ h₂ h₃ : path x y) = f := rfl
 
 variable (γ : path x y)
 
@@ -230,45 +172,36 @@ begin
 end
 
 /-- A continuous map extending a path to `ℝ`, constant before `0` and after `1`. -/
-def extend : ℝ → X := I_extend γ
+def extend : ℝ → X := Icc_extend 0 1 zero_le_one γ
 
 lemma continuous_extend : continuous γ.extend :=
-γ.continuous.I_extend
+γ.continuous.Icc_extend
 
 @[simp] lemma extend_zero : γ.extend 0 = x :=
-by simp [extend]
+(Icc_extend_left _ _).trans γ.source
 
 @[simp] lemma extend_one : γ.extend 1 = y :=
-by simp [extend]
+(Icc_extend_right _ _).trans γ.target
 
 @[simp] lemma extend_extends {X : Type*} [topological_space X] {a b : X}
   (γ : path a b) {t : ℝ} (ht : t ∈ (Icc 0 1 : set ℝ)) : γ.extend t = γ ⟨t, ht⟩ :=
-I_extend_extends γ.to_fun ht
+Icc_extend_of_mem _ γ ht
 
 @[simp] lemma extend_extends' {X : Type*} [topological_space X] {a b : X}
-  (γ : path a b) (t : (Icc 0 1 : set ℝ)) : γ.extend ↑t = γ t :=
-by { convert γ.extend_extends t.2, rw subtype.ext_iff_val }
+  (γ : path a b) (t : (Icc 0 1 : set ℝ)) : γ.extend t = γ t :=
+Icc_extend_coe _ γ t
 
 @[simp] lemma extend_range {X : Type*} [topological_space X] {a b : X}
   (γ : path a b) : range γ.extend = range γ :=
-I_extend_range γ.to_fun
+Icc_extend_range _ γ
 
-lemma extend_le_zero {X : Type*} [topological_space X] {a b : X}
+lemma extend_of_le_zero {X : Type*} [topological_space X] {a b : X}
   (γ : path a b) {t : ℝ} (ht : t ≤ 0) : γ.extend t = a :=
-begin
-  have := γ.source,
-  simpa [path.extend, I_extend, proj_I, ht]
-end
+(Icc_extend_of_le_left _ _ ht).trans γ.source
 
-lemma extend_one_le {X : Type*} [topological_space X] {a b : X}
+lemma extend_of_one_le {X : Type*} [topological_space X] {a b : X}
   (γ : path a b) {t : ℝ} (ht : 1 ≤ t) : γ.extend t = b :=
-begin
-  simp only [path.extend, I_extend, proj_I, comp_app],
-  split_ifs,
-  { exfalso, linarith },
-  { convert γ.target, linarith },
-  { exact γ.target }
-end
+(Icc_extend_of_right_le _ _ ht).trans γ.target
 
 @[simp] lemma refl_extend {X : Type*} [topological_space X] {a : X} :
   (path.refl a).extend = λ _, a := rfl
@@ -295,9 +228,8 @@ path on `[0, 1/2]` and the second one on `[1/2, 1]`. -/
     apply (continuous_if _ _ _).comp continuous_subtype_coe,
     { norm_num },
     -- TODO: the following are provable by `continuity` but it is too slow
-    { exact ((path.continuous γ).comp continuous_proj_I).comp (continuous_const.mul continuous_id')},
-    { exact ((path.continuous γ').comp continuous_proj_I).comp
-      ((continuous_const.mul continuous_id').sub continuous_const) }
+    { exact γ.continuous_extend.comp (continuous_const.mul continuous_id) },
+    { exact γ'.continuous_extend.comp ((continuous_const.mul continuous_id).sub continuous_const) }
   end,
   source' := by norm_num,
   target' := by norm_num }
@@ -392,7 +324,7 @@ h.comp (continuous_id.prod_map continuous_I_symm)
 lemma continuous_uncurry_extend_of_continuous_family {X ι : Type*} [topological_space X]
   [topological_space ι] {a b : ι → X}  (γ : Π (t : ι), path (a t) (b t)) (h : continuous ↿γ) :
   continuous ↿(λ t, (γ t).extend) :=
-h.comp (continuous_id.prod_map continuous_proj_I)
+h.comp (continuous_id.prod_map continuous_proj_Icc)
 
 lemma trans_continuous_family {X ι : Type*} [topological_space X] [topological_space ι]
   {a b c : ι → X}
@@ -430,10 +362,10 @@ def truncate {X : Type*} [topological_space X] {a b : X}
     unfold min max,
     norm_cast,
     split_ifs with h₁ h₂ h₃ h₄,
-    { simp [γ.extend_le_zero h₁] },
+    { simp [γ.extend_of_le_zero h₁] },
     { congr, linarith },
     { have h₄ : t₁ ≤ 0 := le_of_lt (by simpa using h₂),
-      simp [γ.extend_le_zero h₄, γ.extend_le_zero h₁] },
+      simp [γ.extend_of_le_zero h₄, γ.extend_of_le_zero h₁] },
     all_goals { refl }
   end,
   target' :=
@@ -441,10 +373,10 @@ def truncate {X : Type*} [topological_space X] {a b : X}
     unfold min max,
     norm_cast,
     split_ifs with h₁ h₂ h₃,
-    { simp [γ.extend_one_le h₂] },
+    { simp [γ.extend_of_one_le h₂] },
     { refl },
     { have h₄ : 1 ≤ t₀ := le_of_lt (by simpa using h₁),
-      simp [γ.extend_one_le h₄, γ.extend_one_le (h₄.trans h₃)] },
+      simp [γ.extend_of_one_le h₄, γ.extend_of_one_le (h₄.trans h₃)] },
     { refl }
   end }
 
@@ -467,7 +399,7 @@ end
   mean the uncurried function which maps `(t₀, t₁, s)` to `γ.truncate t₀ t₁ s` is continuous. -/
 lemma truncate_continuous_family {X : Type*} [topological_space X] {a b : X}
   (γ : path a b) : continuous (λ x, γ.truncate x.1 x.2.1 x.2.2 : ℝ × ℝ × I → X) :=
-(γ.continuous.comp continuous_proj_I).comp
+γ.continuous_extend.comp
   (((continuous_subtype_coe.comp (continuous_snd.comp continuous_snd)).max continuous_fst).min
     (continuous_fst.comp continuous_snd))
 /- TODO : When `continuity` gets quicker, change the proof back to :
@@ -506,10 +438,8 @@ by convert γ.truncate_self 1; exact γ.extend_one.symm
 begin
   ext x,
   rw cast_coe,
-  simp only [truncate, has_coe_to_fun.coe, coe_fn, refl, min, max, extend, I_extend, comp_app],
-  congr,
   have : ↑x ∈ (Icc 0 1 : set ℝ) := x.2,
-  simp [this.1, this.2, proj_I_I this]
+  rw [truncate, coe_mk, max_eq_left this.1, min_eq_left this.2, extend_extends']
 end
 
 end path

--- a/src/topology/path_connected.lean
+++ b/src/topology/path_connected.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot
 -/
 import topology.instances.real
-import topology.algebra.proj_Icc
+import topology.algebra.ordered.proj_Icc
 
 /-!
 # Path connectedness
@@ -172,7 +172,7 @@ begin
 end
 
 /-- A continuous map extending a path to `ℝ`, constant before `0` and after `1`. -/
-def extend : ℝ → X := Icc_extend 0 1 zero_le_one γ
+def extend : ℝ → X := Icc_extend zero_le_one γ
 
 lemma continuous_extend : continuous γ.extend :=
 γ.continuous.Icc_extend

--- a/src/topology/path_connected.lean
+++ b/src/topology/path_connected.lean
@@ -49,8 +49,8 @@ For locally path connected spaces, we have
 ## Implementation notes
 
 By default, all paths have `I` as their source and `X` as their target, but there is an
-operation `I_extend` that will extend any continuous map `γ : I → X` into a continuous map
-`I_extend γ : ℝ → X` that is constant before `0` and after `1`.
+operation `set.Icc_extend` that will extend any continuous map `γ : I → X` into a continuous map
+`Icc_extend zero_le_one γ : ℝ → X` that is constant before `0` and after `1`.
 
 This is used to define `path.extend` that turns `γ : path x y` into a continuous map
 `γ.extend : ℝ → X` whose restriction to `I` is the original `γ`, and is equal to `x`


### PR DESCRIPTION
Also use `min` and `max` in the definition to make, e.g., the proof of the continuity trivial.

---
I'm going to redefine `real.arcsin` using `Icc_extend (h : -1 ≤ 1)`.