### PR TITLE
[Merged by Bors] - chore({ring,group}_theory/free_*): Add of_injective

### DIFF
--- a/src/algebra/free_algebra.lean
+++ b/src/algebra/free_algebra.lean
@@ -318,6 +318,20 @@ end
 instance [nontrivial R] : nontrivial (free_algebra R X) :=
 equiv_monoid_algebra_free_monoid.to_equiv.nontrivial
 
+section
+open_locale classical
+
+-- this proof is copied from the approach in `free_abelian_group.of_injective`
+lemma ι_injective [nontrivial R] : function.injective (ι R : X → free_algebra R X) :=
+λ x y hoxy, classical.by_contradiction $ assume hxy : x ≠ y,
+  let f : free_algebra R X →ₐ[R] R := lift R (λ z, if x = z then (1 : R) else 0) in
+  have hfx1 : f (ι R x) = 1, from (lift_ι_apply _ _).trans $ if_pos rfl,
+  have hfy1 : f (ι R y) = 1, from hoxy ▸ hfx1,
+  have hfy0 : f (ι R y) = 0, from (lift_ι_apply _ _).trans $ if_neg hxy,
+  one_ne_zero $ hfy1.symm.trans hfy0
+
+end
+
 end free_algebra
 
 -- There is something weird in the above namespace that breaks the typeclass resolution of `has_coe_to_sort` below.

--- a/src/group_theory/free_abelian_group.lean
+++ b/src/group_theory/free_abelian_group.lean
@@ -33,19 +33,6 @@ abelianization.of $ free_group.of x
 def lift {β : Type v} [add_comm_group β] (f : α → β) : free_abelian_group α →+ β :=
 (@abelianization.lift _ _ (multiplicative β) _ (monoid_hom.of (@free_group.to_group _ (multiplicative β) _ f))).to_additive
 
-section
-open_locale classical
-
-lemma of_injective : function.injective (of : α → free_abelian_group α) :=
-λ x y hoxy, classical.by_contradiction $ assume hxy : x ≠ y,
-  let f : free_abelian_group α →+ ℤ := lift (λ z, if x = z then 1 else 0) in
-  have hfx1 : f (of x) = 1, from (lift.of _ _).trans $ if_pos rfl,
-  have hfy1 : f (of y) = 1, from hoxy ▸ hfx1,
-  have hfy0 : f (of y) = 0, from (lift.of _ _).trans $ if_neg hxy,
-  one_ne_zero $ hfy1.symm.trans hfy0
-
-end
-
 namespace lift
 variables {β : Type v} [add_comm_group β] (f : α → β)
 open free_abelian_group
@@ -98,6 +85,19 @@ begin
 end
 
 end lift
+
+section
+open_locale classical
+
+lemma of_injective : function.injective (of : α → free_abelian_group α) :=
+λ x y hoxy, classical.by_contradiction $ assume hxy : x ≠ y,
+  let f : free_abelian_group α →+ ℤ := lift (λ z, if x = z then 1 else 0) in
+  have hfx1 : f (of x) = 1, from (lift.of _ _).trans $ if_pos rfl,
+  have hfy1 : f (of y) = 1, from hoxy ▸ hfx1,
+  have hfy0 : f (of y) = 0, from (lift.of _ _).trans $ if_neg hxy,
+  one_ne_zero $ hfy1.symm.trans hfy0
+
+end
 
 section
 variables (X : Type*) (G : Type*) [add_comm_group G]

--- a/src/group_theory/free_abelian_group.lean
+++ b/src/group_theory/free_abelian_group.lean
@@ -33,6 +33,19 @@ abelianization.of $ free_group.of x
 def lift {β : Type v} [add_comm_group β] (f : α → β) : free_abelian_group α →+ β :=
 (@abelianization.lift _ _ (multiplicative β) _ (monoid_hom.of (@free_group.to_group _ (multiplicative β) _ f))).to_additive
 
+section
+open_locale classical
+
+lemma of_injective : function.injective (of : α → free_abelian_group α) :=
+λ x y hoxy, classical.by_contradiction $ assume hxy : x ≠ y,
+  let f : free_abelian_group α →+ ℤ := lift (λ z, if x = z then 1 else 0) in
+  have hfx1 : f (of x) = 1, from (lift.of _ _).trans $ if_pos rfl,
+  have hfy1 : f (of y) = 1, from hoxy ▸ hfx1,
+  have hfy0 : f (of y) = 0, from (lift.of _ _).trans $ if_neg hxy,
+  one_ne_zero $ hfy1.symm.trans hfy0
+
+end
+
 namespace lift
 variables {β : Type v} [add_comm_group β] (f : α → β)
 open free_abelian_group

--- a/src/ring_theory/free_comm_ring.lean
+++ b/src/ring_theory/free_comm_ring.lean
@@ -71,6 +71,10 @@ variables {α}
 def of (x : α) : free_comm_ring α :=
 free_abelian_group.of ([x] : multiset α)
 
+lemma of_injective : function.injective (of : α → free_comm_ring α) :=
+free_abelian_group.of_injective.comp (λ x y,
+  (multiset.coe_eq_coe.trans list.singleton_perm_singleton).mp)
+
 @[elab_as_eliminator] protected lemma induction_on
   {C : free_comm_ring α → Prop} (z : free_comm_ring α)
   (hn1 : C (-1)) (hb : ∀ b, C (of b))

--- a/src/ring_theory/free_ring.lean
+++ b/src/ring_theory/free_ring.lean
@@ -47,6 +47,9 @@ variables {α}
 def of (x : α) : free_ring α :=
 free_abelian_group.of [x]
 
+lemma of_injective (α : Type u) : function.injective (of : α → free_ring α) :=
+free_abelian_group.of_injective.comp free_monoid.of_injective
+
 @[elab_as_eliminator] protected lemma induction_on
   {C : free_ring α → Prop} (z : free_ring α)
   (hn1 : C (-1)) (hb : ∀ b, C (of b))

--- a/src/ring_theory/free_ring.lean
+++ b/src/ring_theory/free_ring.lean
@@ -47,7 +47,7 @@ variables {α}
 def of (x : α) : free_ring α :=
 free_abelian_group.of [x]
 
-lemma of_injective (α : Type u) : function.injective (of : α → free_ring α) :=
+lemma of_injective : function.injective (of : α → free_ring α) :=
 free_abelian_group.of_injective.comp free_monoid.of_injective
 
 @[elab_as_eliminator] protected lemma induction_on


### PR DESCRIPTION
This adds:

* `free_abelian_group.of_injective`
* `free_ring.of_injective`
* `free_comm_ring.of_injective`
* `free_algebra.of_injective`

following up from dcbec39a5bf9af5c6e065eea185f8776ac537d3b

Co-authored-by: Kenny Lau <kc_kennylau@yahoo.com.hk>

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The one from #5034 that I couldn't get