### PR TITLE
[Merged by Bors] - feat(algebra/module/basic): generalize `is_scalar_tower` instances

### DIFF
--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -349,6 +349,18 @@ lemma nat.smul_def {M : Type*} [add_comm_monoid M] (n : ℕ) (x : M) :
   n • x = n •ℕ x :=
 rfl
 
+namespace nat
+
+instance [semiring R] [add_comm_monoid M] [semimodule R M] : smul_comm_class ℕ R M :=
+{ smul_comm := λ n r m, begin
+    simp only [nat.smul_def],
+    induction n with n ih,
+    { simp },
+    { simp [succ_nsmul, ←ih, smul_add] },
+  end }
+
+end nat
+
 end
 
 section
@@ -370,6 +382,13 @@ end
 lemma module.gsmul_eq_smul {M : Type*} [add_comm_group M] [module ℤ M]
   (n : ℤ) (b : M) : gsmul n b = n • b :=
 by rw [module.gsmul_eq_smul_cast ℤ, int.cast_id]
+
+namespace int
+
+instance [semiring R] [add_comm_group M] [semimodule R M] : smul_comm_class ℤ R M :=
+{ smul_comm := λ z r l, by cases z; simp [←gsmul_eq_smul, ←nat.smul_def, smul_comm] }
+
+end int
 
 end
 

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -289,7 +289,7 @@ instance nat_is_scalar_tower [semiring S] [semimodule S M] :
     induction n with n ih,
     { simp only [zero_smul] },
     { simp only [nat.succ_eq_add_one, add_smul, one_smul, ih] }
-  end}
+  end }
 
 end add_comm_monoid
 

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -280,6 +280,17 @@ def nat_semimodule : semimodule ℕ M :=
   zero_smul := zero_nsmul,
   smul_zero := nsmul_zero }
 
+local attribute [instance] nat_semimodule
+
+instance nat_is_scalar_tower [semiring S] [semimodule S M] :
+  is_scalar_tower ℕ S M :=
+{ smul_assoc := begin
+    intros n x y,
+    induction n with n ih,
+    { simp only [zero_smul] },
+    { simp only [nat.succ_eq_add_one, add_smul, one_smul, ih] }
+  end}
+
 end add_comm_monoid
 
 namespace add_comm_group
@@ -325,6 +336,18 @@ begin
   { rw [int.neg_succ_of_nat_coe, neg_smul, neg_smul, nat_smul], }
 end
 
+local attribute [instance] int_module add_comm_monoid.nat_semimodule
+
+instance int_is_scalar_tower [ring S] [module S M] :
+  is_scalar_tower ℤ S M :=
+{ smul_assoc := begin
+    intros n x y,
+    cases n,
+    { show (n • x) • y = n • x • y, apply smul_assoc },
+    { simp only [int.neg_succ_of_nat_eq, neg_smul],
+      convert congr_arg has_neg.neg (smul_assoc n.succ x y) },
+  end }
+
 end add_comm_group
 
 section
@@ -349,18 +372,6 @@ lemma nat.smul_def {M : Type*} [add_comm_monoid M] (n : ℕ) (x : M) :
   n • x = n •ℕ x :=
 rfl
 
-namespace nat
-
-instance [semiring R] [add_comm_monoid M] [semimodule R M] : smul_comm_class ℕ R M :=
-{ smul_comm := λ n r m, begin
-    simp only [nat.smul_def],
-    induction n with n ih,
-    { simp },
-    { simp [succ_nsmul, ←ih, smul_add] },
-  end }
-
-end nat
-
 end
 
 section
@@ -382,13 +393,6 @@ end
 lemma module.gsmul_eq_smul {M : Type*} [add_comm_group M] [module ℤ M]
   (n : ℤ) (b : M) : gsmul n b = n • b :=
 by rw [module.gsmul_eq_smul_cast ℤ, int.cast_id]
-
-namespace int
-
-instance [semiring R] [add_comm_group M] [semimodule R M] : smul_comm_class ℤ R M :=
-{ smul_comm := λ z r l, by cases z; simp [←gsmul_eq_smul, ←nat.smul_def, smul_comm] }
-
-end int
 
 end
 

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -114,9 +114,6 @@ def restrict_base (f : A →ₐ[S] B) : A →ₐ[R] B :=
 instance right : is_scalar_tower R S S :=
 of_algebra_map_eq $ λ x, rfl
 
-instance nat : is_scalar_tower ℕ S A :=
-of_algebra_map_eq $ λ x, ((algebra_map S A).map_nat_cast x).symm
-
 instance comap {R S A : Type*} [comm_semiring R] [comm_semiring S] [semiring A]
   [algebra R S] [algebra S A] : is_scalar_tower R S (algebra.comap R S A) :=
 of_algebra_map_eq $ λ x, rfl
@@ -191,15 +188,6 @@ instance linear_map (R : Type u) (A : Type v) (V : Type w)
 ⟨λ x y f, linear_map.ext $ λ v, algebra.smul_mul_assoc x y (f v)⟩
 
 end comm_semiring
-
-section comm_ring
-variables [comm_ring R] [comm_ring S] [comm_ring A] [algebra R S] [algebra S A] [algebra R A]
-variables [is_scalar_tower R S A]
-
-instance int : is_scalar_tower ℤ S A :=
-of_algebra_map_eq $ λ x, ((algebra_map S A).map_int_cast x).symm
-
-end comm_ring
 
 section division_ring
 variables [field R] [division_ring S] [algebra R S] [char_zero R] [char_zero S]


### PR DESCRIPTION
---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Zulip: https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/gsmul.20and.20smul.20commute/near/218117713

Needed to define the alternization of a multilinear map, which is something like `∑ (σ : equiv.perm ι), (equiv.perm.sign σ : ℤ) • m.dom_dom_congr σ v` (with #5136)
