### PR TITLE
[Merged by Bors] - feat(ring_theory/integral_closure): Cleanup interface for ring_hom.is_integral

### DIFF
--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -29,8 +29,8 @@ open_locale big_operators
 open polynomial submodule
 
 section ring
-variables {R A : Type*}
-variables [comm_ring R] [ring A]
+variables {R S A : Type*}
+variables [comm_ring R] [ring A] [ring S] (f : R →+* S)
 
 /-- An element `x` of `A` is said to be integral over `R` with respect to `f`
 if it is a root of a monic polynomial `p : polynomial R` evaluated under `f` -/
@@ -58,9 +58,11 @@ def algebra.is_integral : Prop :=
 
 variables {R A}
 
+lemma ring_hom.is_integral_map {x : R} : f.is_integral_elem (f x) :=
+⟨X - C x, monic_X_sub_C _, by simp⟩
+
 theorem is_integral_algebra_map {x : R} : is_integral R (algebra_map R A x) :=
-⟨X - C x, monic_X_sub_C _,
-by simp⟩
+(algebra_map R A).is_integral_map
 
 theorem is_integral_of_noetherian (H : is_noetherian R A) (x : A) :
   is_integral R x :=
@@ -108,9 +110,9 @@ end
 end ring
 
 section
-variables {R : Type*} {A : Type*} {B : Type*}
-variables [comm_ring R] [comm_ring A] [comm_ring B]
-variables [algebra R A] [algebra R B]
+variables {R A B S : Type*}
+variables [comm_ring R] [comm_ring A] [comm_ring B] [comm_ring S]
+variables [algebra R A] [algebra R B] (f : R →+* S)
 
 theorem is_integral_alg_hom (f : A →ₐ[R] B) {x : A} (hx : is_integral R x) : is_integral R (f x) :=
 let ⟨p, hp, hpx⟩ := hx in ⟨p, hp, by rw [← aeval_def, aeval_alg_hom_apply, aeval_def, hpx, f.map_zero]⟩
@@ -232,43 +234,72 @@ begin
   exact subalgebra.smul_mem _ (algebra.subset_adjoin $ hlx1 hr) _
 end
 
+lemma ring_hom.is_integral_of_mem_closure {x y z : S}
+  (hx : f.is_integral_elem x) (hy : f.is_integral_elem y)
+  (hz : z ∈ ring.closure ({x, y} : set S)) :
+  f.is_integral_elem z :=
+begin
+  letI : algebra R S := f.to_algebra,
+  have := fg_mul _ _ (fg_adjoin_singleton_of_integral x hx) (fg_adjoin_singleton_of_integral y hy),
+  rw [← algebra.adjoin_union_coe_submodule, set.singleton_union] at this,
+  exact is_integral_of_mem_of_fg (algebra.adjoin R {x, y}) this z
+    (algebra.mem_adjoin_iff.2  $ ring.closure_mono (set.subset_union_right _ _) hz),
+end
+
 theorem is_integral_of_mem_closure {x y z : A}
   (hx : is_integral R x) (hy : is_integral R y)
   (hz : z ∈ ring.closure ({x, y} : set A)) :
   is_integral R z :=
-begin
-  have := fg_mul _ _ (fg_adjoin_singleton_of_integral x hx) (fg_adjoin_singleton_of_integral y hy),
-  rw [← algebra.adjoin_union_coe_submodule, set.singleton_union] at this,
-  exact is_integral_of_mem_of_fg (algebra.adjoin R {x, y}) this z
-    (algebra.mem_adjoin_iff.2  $ ring.closure_mono (set.subset_union_right _ _) hz)
-end
+(algebra_map R A).is_integral_of_mem_closure hx hy hz
+
+lemma ring_hom.is_integral_zero : f.is_integral_elem 0 :=
+f.map_zero ▸ f.is_integral_map
 
 theorem is_integral_zero : is_integral R (0:A) :=
-(algebra_map R A).map_zero ▸ is_integral_algebra_map
+(algebra_map R A).is_integral_zero
+
+lemma ring_hom.is_integral_one : f.is_integral_elem 1 :=
+f.map_one ▸ f.is_integral_map
 
 theorem is_integral_one : is_integral R (1:A) :=
-(algebra_map R A).map_one ▸ is_integral_algebra_map
+(algebra_map R A).is_integral_one
+
+lemma ring_hom.is_integral_add {x y : S}
+  (hx : f.is_integral_elem x) (hy : f.is_integral_elem y) :
+  f.is_integral_elem (x + y) :=
+f.is_integral_of_mem_closure hx hy (is_add_submonoid.add_mem
+  (ring.subset_closure (or.inl rfl)) (ring.subset_closure (or.inr rfl)))
 
 theorem is_integral_add {x y : A}
   (hx : is_integral R x) (hy : is_integral R y) :
   is_integral R (x + y) :=
-is_integral_of_mem_closure hx hy (is_add_submonoid.add_mem
-  (ring.subset_closure (or.inl rfl)) (ring.subset_closure (or.inr rfl)))
+(algebra_map R A).is_integral_add hx hy
+
+lemma ring_hom.is_integral_neg {x : S}
+  (hx : f.is_integral_elem x) : f.is_integral_elem (-x) :=
+f.is_integral_of_mem_closure hx hx (is_add_subgroup.neg_mem
+  (ring.subset_closure (or.inl rfl)))
 
 theorem is_integral_neg {x : A}
   (hx : is_integral R x) : is_integral R (-x) :=
-is_integral_of_mem_closure hx hx (is_add_subgroup.neg_mem
-  (ring.subset_closure (or.inl rfl)))
+(algebra_map R A).is_integral_neg hx
+
+lemma ring_hom.is_integral_sub {x y : S}
+  (hx : f.is_integral_elem x) (hy : f.is_integral_elem y) : f.is_integral_elem (x - y) :=
+f.is_integral_add hx (f.is_integral_neg hy)
 
 theorem is_integral_sub {x y : A}
   (hx : is_integral R x) (hy : is_integral R y) : is_integral R (x - y) :=
-is_integral_add hx (is_integral_neg hy)
+(algebra_map R A).is_integral_sub hx hy
+
+lemma ring_hom.is_integral_mul {x y : S}
+  (hx : f.is_integral_elem x) (hy : f.is_integral_elem y) : f.is_integral_elem (x * y) :=
+f.is_integral_of_mem_closure hx hy (is_submonoid.mul_mem
+  (ring.subset_closure (or.inl rfl)) (ring.subset_closure (or.inr rfl)))
 
 theorem is_integral_mul {x y : A}
-  (hx : is_integral R x) (hy : is_integral R y) :
-  is_integral R (x * y) :=
-is_integral_of_mem_closure hx hy (is_submonoid.mul_mem
-  (ring.subset_closure (or.inl rfl)) (ring.subset_closure (or.inr rfl)))
+  (hx : is_integral R x) (hy : is_integral R y) : is_integral R (x * y) :=
+(algebra_map R A).is_integral_mul hx hy
 
 variables (R A)
 
@@ -306,18 +337,18 @@ lemma integral_closure.is_integral (x : integral_closure R A) : is_integral R x 
 let ⟨p, hpm, hpx⟩ := x.2 in ⟨p, hpm, subtype.eq $
 by rwa [← aeval_def, subtype.val_eq_coe, ← subalgebra.val_apply, aeval_alg_hom_apply] at hpx⟩
 
-theorem is_integral_of_is_integral_mul_unit {x y : A} {r : R} (hr : algebra_map R A r * y = 1)
-  (hx : is_integral R (x * y)) : is_integral R x :=
+lemma ring_hom.is_integral_of_is_integral_mul_unit (x y : S) (r : R) (hr : f r * y = 1)
+  (hx : f.is_integral_elem (x * y)) : f.is_integral_elem x :=
 begin
   obtain ⟨p, ⟨p_monic, hp⟩⟩ := hx,
   refine ⟨scale_roots p r, ⟨(monic_scale_roots_iff r).2 p_monic, _⟩⟩,
-  convert scale_roots_aeval_eq_zero hp,
+  convert scale_roots_eval₂_eq_zero f hp,
   rw [mul_comm x y, ← mul_assoc, hr, one_mul],
 end
 
-theorem is_integral_of_is_integral_mul_unit' {R S : Type*} [comm_ring R] [comm_ring S] {f : R →+* S}
-  (x y : S) (r : R) (hr : f r * y = 1) (hx : f.is_integral_elem (x * y)) : f.is_integral_elem x :=
-@is_integral_of_is_integral_mul_unit R S _ _ f.to_algebra x y r hr hx
+theorem is_integral_of_is_integral_mul_unit {x y : A} {r : R} (hr : algebra_map R A r * y = 1)
+  (hx : is_integral R (x * y)) : is_integral R x :=
+(algebra_map R A).is_integral_of_is_integral_mul_unit x y r hr hx
 
 /-- Generalization of `is_integral_of_mem_closure` bootstrapped up from that lemma -/
 lemma is_integral_of_mem_closure' (G : set A) (hG : ∀ x ∈ G, is_integral R x) :
@@ -333,9 +364,9 @@ end
 
 section algebra
 open algebra
-variables {R : Type*} {A : Type*} {B : Type*}
-variables [comm_ring R] [comm_ring A] [comm_ring B]
-variables [algebra A B] [algebra R B]
+variables {R A B S T : Type*}
+variables [comm_ring R] [comm_ring A] [comm_ring B] [comm_ring S] [comm_ring T]
+variables [algebra A B] [algebra R B] (f : R →+* S) (g : S →+* T)
 
 lemma is_integral_trans_aux (x : B) {p : polynomial A} (pmonic : monic p) (hp : aeval x p = 0) :
   is_integral (adjoin R (↑(p.map $ algebra_map A B).frange : set B)) x :=
@@ -383,18 +414,17 @@ then all elements of B are integral over R.-/
 lemma algebra.is_integral_trans (hA : is_integral R A) (hB : is_integral A B) : is_integral R B :=
 λ x, is_integral_trans hA x (hB x)
 
-lemma ring_hom.is_integral_trans {R A B : Type*} [comm_ring R] [comm_ring A] [comm_ring B]
-  {f : R →+* A} {g : A →+* B} (hf : f.is_integral) (hg : g.is_integral) : (g.comp f).is_integral :=
-@algebra.is_integral_trans R A B _ _ _ g.to_algebra (g.comp f).to_algebra f.to_algebra
-  (@is_scalar_tower.of_algebra_map_eq R A B _ _ _ f.to_algebra g.to_algebra (g.comp f).to_algebra
+lemma ring_hom.is_integral_trans (hf : f.is_integral) (hg : g.is_integral) :
+  (g.comp f).is_integral :=
+@algebra.is_integral_trans R S T _ _ _ g.to_algebra (g.comp f).to_algebra f.to_algebra
+  (@is_scalar_tower.of_algebra_map_eq R S T _ _ _ f.to_algebra g.to_algebra (g.comp f).to_algebra
   (ring_hom.comp_apply g f)) hf hg
 
-lemma is_integral_of_surjective (h : function.surjective (algebra_map R A)) : is_integral R A :=
-λ x, (h x).rec_on (λ y hy, (hy ▸ is_integral_algebra_map : is_integral R x))
+lemma ring_hom.is_integral_of_surjective (hf : function.surjective f) : f.is_integral :=
+λ x, (hf x).rec_on (λ y hy, (hy ▸ f.is_integral_map : f.is_integral_elem x))
 
-lemma is_integral_of_surjective' {R A : Type*} [comm_ring R] [comm_ring A] {f : R →+* A}
-  (hf : function.surjective f) : f.is_integral :=
-@is_integral_of_surjective R A _ _ f.to_algebra hf
+lemma is_integral_of_surjective (h : function.surjective (algebra_map R A)) : is_integral R A :=
+(algebra_map R A).is_integral_of_surjective h
 
 /-- If `R → A → B` is an algebra tower with `A → B` injective,
 then if the entire tower is an integral extension so is `R → A` -/
@@ -409,10 +439,10 @@ begin
   exact H hp',
 end
 
-lemma is_integral_tower_bot_of_is_integral' {R A B : Type*} [comm_ring R] [comm_ring A] [comm_ring B]
-  (f : R →+* A) (g : A →+* B) (hg : function.injective g) (hfg : (g.comp f).is_integral) : f.is_integral :=
-λ x, @is_integral_tower_bot_of_is_integral R A B _ _ _ g.to_algebra (g.comp f).to_algebra f.to_algebra
-  (@is_scalar_tower.of_algebra_map_eq R A B _ _ _ f.to_algebra g.to_algebra (g.comp f).to_algebra
+lemma ring_hom.is_integral_tower_bot_of_is_integral (hg : function.injective g)
+  (hfg : (g.comp f).is_integral) : f.is_integral :=
+λ x, @is_integral_tower_bot_of_is_integral R S T _ _ _ g.to_algebra (g.comp f).to_algebra f.to_algebra
+  (@is_scalar_tower.of_algebra_map_eq R S T _ _ _ f.to_algebra g.to_algebra (g.comp f).to_algebra
   (ring_hom.comp_apply g f))  hg x (hfg (g x))
 
 lemma is_integral_tower_bot_of_is_integral_field {R A B : Type*} [comm_ring R] [field A]
@@ -430,18 +460,18 @@ begin
   exact hp',
 end
 
-lemma is_integral_quotient_of_is_integral {I : ideal A} (hRA : is_integral R A) :
-  is_integral (I.comap (algebra_map R A)).quotient I.quotient :=
+lemma ring_hom.is_integral_quotient_of_is_integral {I : ideal S} (hf : f.is_integral) :
+  (ideal.quotient_map I f le_rfl).is_integral :=
 begin
   rintros ⟨x⟩,
-  obtain ⟨p, ⟨p_monic, hpx⟩⟩ := hRA x,
+  obtain ⟨p, ⟨p_monic, hpx⟩⟩ := hf x,
   refine ⟨p.map (ideal.quotient.mk _), ⟨monic_map _ p_monic, _⟩⟩,
-  simpa only [aeval_def, hom_eval₂, eval₂_map] using congr_arg (ideal.quotient.mk I) hpx
+  simpa only [hom_eval₂, eval₂_map] using congr_arg (ideal.quotient.mk I) hpx
 end
 
-lemma is_integral_quotient_of_is_integral' {R S : Type*} [comm_ring R] [comm_ring S]
-  {f : R →+* S} {I : ideal S} (hf : f.is_integral) : (ideal.quotient_map I f le_rfl).is_integral :=
-@is_integral_quotient_of_is_integral R S _ _ f.to_algebra I hf
+lemma is_integral_quotient_of_is_integral {I : ideal A} (hRA : is_integral R A) :
+  is_integral (I.comap (algebra_map R A)).quotient I.quotient :=
+(algebra_map R A).is_integral_quotient_of_is_integral hRA
 
 /-- If the integral extension `R → S` is injective, and `S` is a field, then `R` is also a field -/
 lemma is_field_of_is_integral_of_is_field {R S : Type*} [integral_domain R] [integral_domain S]

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -302,12 +302,12 @@ begin
   rw ← bot_quotient_is_maximal_iff at this ⊢,
   refine is_maximal_of_is_integral_of_is_maximal_comap' f _ ⊥
     ((eq_bot_iff.2 (comap_bot_le_of_injective f quotient_map_injective)).symm ▸ this),
-  exact is_integral_tower_bot_of_is_integral' f g quotient_map_injective
+  exact f.is_integral_tower_bot_of_is_integral g quotient_map_injective
     ((comp_quotient_map_eq_of_comp_eq hcomm I).symm ▸
-    (ring_hom.is_integral_trans (is_integral_of_surjective'
+    (ring_hom.is_integral_trans _ _ (ring_hom.is_integral_of_surjective _
       (localization_map.surjective_quotient_map_of_maximal_of_localization
       (by rwa [comap_comap, hcomm, ← bot_quotient_is_maximal_iff])))
-      (is_integral_quotient_of_is_integral' hφ'))),
+      (ring_hom.is_integral_quotient_of_is_integral _ hφ'))),
 end
 
 /-- Used to bootstrap the proof of `is_jacobson_polynomial_iff_is_jacobson`.
@@ -342,15 +342,15 @@ begin
     suffices : φ'.is_integral_elem (ϕ'.to_map p'),
     { obtain ⟨q', hq', rfl⟩ := hq,
       obtain ⟨q'', hq''⟩ := is_unit_iff_exists_inv'.1 (ϕ.map_units ⟨q', hq'⟩),
-      refine is_integral_of_is_integral_mul_unit' p (ϕ'.to_map (φ q')) q'' _ (hp.symm ▸ this),
+      refine φ'.is_integral_of_is_integral_mul_unit p (ϕ'.to_map (φ q')) q'' _ (hp.symm ▸ this),
       convert trans (trans (φ'.map_mul _ _).symm (congr_arg φ' hq'')) φ'.map_one using 2,
       rw [← φ'.comp_apply, localization_map.map_comp, ϕ'.to_map.comp_apply, subtype.coe_mk] },
     refine is_integral_of_mem_closure''
       ((ϕ'.to_map.comp (quotient.mk P)) '' (insert X {p | p.degree ≤ 0})) _ _ _,
     { rintros x ⟨p, hp, rfl⟩,
       refine hp.rec_on (λ hy, _) (λ hy, _),
-      { refine hy.symm ▸ (is_integral_elem_localization_at_leading_coeff' ((quotient.mk P) X)
-          (pX.map (quotient.mk P')) φ _ M ⟨1, pow_one _⟩ _ _),
+      { refine hy.symm ▸ (φ.is_integral_elem_localization_at_leading_coeff ((quotient.mk P) X)
+          (pX.map (quotient.mk P')) _ M ⟨1, pow_one _⟩ _ _),
         rwa [eval₂_map, hφ', ← hom_eval₂, quotient.eq_zero_iff_mem, eval₂_C_X] },
       { rw [set.mem_set_of_eq, degree_le_zero_iff] at hy,
         refine hy.symm ▸ ⟨X - C (ϕ.to_map ((quotient.mk P') (p.coeff 0))), monic_X_sub_C _, _⟩,

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1469,33 +1469,34 @@ end
 
 open polynomial
 
-/-- Given a particular witness to an element being algebraic over an algebra `R → S`,
-We can localize to a submonoid containing the leading coefficient to make it integral.
-Explicitly, the map between the localizations will be an integral ring morphism -/
-theorem is_integral_localization_at_leading_coeff {x : S} (p : polynomial R)
-  (hp : aeval x p = 0) (hM' : p.leading_coeff ∈ M) :
-  (f.map (@algebra.mem_algebra_map_submonoid_of_mem R S _ _ _ _) g).is_integral_elem (g.to_map x) :=
+lemma ring_hom.is_integral_elem_localization_at_leading_coeff
+  {R S : Type*} [comm_ring R] [comm_ring S] (f : R →+* S)
+  (x : S) (p : polynomial R) (hf : p.eval₂ f x = 0) (M : submonoid R)
+  (hM : p.leading_coeff ∈ M) {Rₘ Sₘ : Type*} [comm_ring Rₘ] [comm_ring Sₘ]
+  (ϕ : localization_map M Rₘ) (ϕ' : localization_map (M.map ↑f : submonoid S) Sₘ) :
+  (ϕ.map (M.mem_map_of_mem (f : R →* S)) ϕ').is_integral_elem (ϕ'.to_map x) :=
 begin
   by_cases triv : (1 : Rₘ) = 0,
   { exact ⟨0, ⟨trans leading_coeff_zero triv.symm, eval₂_zero _ _⟩⟩ },
   haveI : nontrivial Rₘ := nontrivial_of_ne 1 0 triv,
   obtain ⟨b, hb⟩ := is_unit_iff_exists_inv.mp
-    (localization_map.map_units f ⟨p.leading_coeff, hM'⟩),
-  refine ⟨(p.map f.to_map) * C b, ⟨_, _⟩⟩,
+    (localization_map.map_units ϕ ⟨p.leading_coeff, hM⟩),
+  refine ⟨(p.map ϕ.to_map) * C b, ⟨_, _⟩⟩,
   { refine monic_mul_C_of_leading_coeff_mul_eq_one _,
-    rwa leading_coeff_map_of_leading_coeff_ne_zero f.to_map,
+    rwa leading_coeff_map_of_leading_coeff_ne_zero ϕ.to_map,
     refine λ hfp, zero_ne_one (trans (zero_mul b).symm (hfp ▸ hb) : (0 : Rₘ) = 1) },
   { refine eval₂_mul_eq_zero_of_left _ _ _ _,
-    erw [eval₂_map, localization_map.map_comp, ← hom_eval₂ _ (algebra_map R S) g.to_map x],
-    exact trans (congr_arg g.to_map hp) g.to_map.map_zero }
+    erw [eval₂_map, localization_map.map_comp, ← hom_eval₂ _ f ϕ'.to_map x],
+    exact trans (congr_arg ϕ'.to_map hf) ϕ'.to_map.map_zero }
 end
 
-theorem is_integral_elem_localization_at_leading_coeff' {R S : Type*} [comm_ring R] [comm_ring S]
-  (x : S) (p : polynomial R) (f : R →+* S) (hf : p.eval₂ f x = 0) (M : submonoid R)
-  (hM : p.leading_coeff ∈ M) {Rₘ Sₘ : Type*} [comm_ring Rₘ] [comm_ring Sₘ]
-  (ϕ : localization_map M Rₘ) (ϕ' : localization_map (M.map ↑f : submonoid S) Sₘ) :
-  (ϕ.map (M.mem_map_of_mem (f : R →* S)) ϕ').is_integral_elem (ϕ'.to_map x) :=
-@is_integral_localization_at_leading_coeff R _ M S _ Rₘ Sₘ _ _  f.to_algebra ϕ ϕ' x p hf hM
+/-- Given a particular witness to an element being algebraic over an algebra `R → S`,
+We can localize to a submonoid containing the leading coefficient to make it integral.
+Explicitly, the map between the localizations will be an integral ring morphism -/
+theorem is_integral_localization_at_leading_coeff {x : S} (p : polynomial R)
+  (hp : aeval x p = 0) (hM : p.leading_coeff ∈ M) :
+  (f.map (@algebra.mem_algebra_map_submonoid_of_mem R S _ _ _ _) g).is_integral_elem (g.to_map x) :=
+(algebra_map R S).is_integral_elem_localization_at_leading_coeff x p hp M hM f g
 
 /-- If `R → S` is an integral extension, `M` is a submonoid of `R`,
 `Rₘ` is the localization of `R` at `M`,


### PR DESCRIPTION
---
Follow up on suggestion from #4962 many of the basic lemmas about integral elements are proved in terms of homomorphisms and the algebra.is_ingtegral versions are derived as special cases of this.
