### PR TITLE
[Merged by Bors] - feat(topology/category/Profinite): add category of profinite top. spaces

### DIFF
--- a/src/topology/category/CompHaus.lean
+++ b/src/topology/category/CompHaus.lean
@@ -42,6 +42,10 @@ instance {X : CompHaus} : t2_space X := X.is_hausdorff
 
 instance category : category CompHaus := induced_category.category to_Top
 
+@[simp]
+lemma coe_to_Top {X : CompHaus} : (X.to_Top : Type*) = X :=
+rfl
+
 end  CompHaus
 
 /-- The fully faithful embedding of `CompHaus` in `Top`. -/

--- a/src/topology/category/CompHaus.lean
+++ b/src/topology/category/CompHaus.lean
@@ -45,13 +45,5 @@ instance category : category CompHaus := induced_category.category to_Top
 end  CompHaus
 
 /-- The fully faithful embedding of `CompHaus` in `Top`. -/
-def CompHaus_to_Top : CompHaus ⥤ Top :=
-{ obj := λ X, { α := X },
-  map := λ _ _ f, f }
-
-namespace CompHaus_to_Top
-
-instance : full CompHaus_to_Top := { preimage := λ _ _ f, f }
-instance : faithful CompHaus_to_Top := {}
-
-end CompHaus_to_Top
+@[simps {rhs_md := semireducible}, derive [full, faithful]]
+def CompHaus_to_Top : CompHaus ⥤ Top := induced_functor _

--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -55,6 +55,10 @@ instance {X : Profinite} : totally_disconnected_space X := X.is_td
 
 instance category : category Profinite := induced_category.category to_Top
 
+@[simp]
+lemma coe_to_Top {X : Profinite} : (X.to_Top : Type*) = X :=
+rfl
+
 end Profinite
 
 /-- The fully faithful embedding of `Profinite` in `Top`. -/
@@ -63,9 +67,7 @@ def Profinite_to_Top : Profinite ⥤ Top := induced_functor _
 
 /-- The fully faithful embedding of `Profinite` in `Top`. -/
 @[simps] def Profinite_to_CompHaus : Profinite ⥤ CompHaus :=
-{ obj := λ X, { to_Top := X.to_Top,
-  is_compact := X.is_compact,
-  is_hausdorff := X.is_t2 },
+{ obj := λ X, { to_Top := X.to_Top },
   map := λ _ _ f, f }
 
 instance : full Profinite_to_CompHaus := { preimage := λ _ _ f, f }

--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -8,6 +8,7 @@ import topology.category.CompHaus
 
 /-!
 # The category of Profinite Types
+
 We construct the category of profinite topological spaces,
 often called profinite sets -- perhaps they could be called
 profinite types in Lean.
@@ -16,9 +17,22 @@ The type of profinite topological spaces is called `Profinite`. It has a categor
 instance and is a fully faithful subcategory of `Top`. The fully faithful functor
 is called `Profinite_to_Top`.
 
+## Implementation notes
+
+A profinite type is defined to be a topological space which is
+compact, Hausdorff and totally disconnected.
+
 ## TODO
+
+0. Link to category of projective limits of finite discrete sets.
 1. existence of products, limits(?), finite coproducts
 2. `Profinite_to_Top` creates limits?
+3. Clausen/Scholze topology on the category `Profinite`.
+
+## Tags
+
+profinite
+
 -/
 
 open category_theory

--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2020 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+
+import topology.category.CompHaus
+
+/-!
+# The category of Profinite Types
+We construct the category of profinite topological spaces,
+often called profinite sets -- perhaps they could be called
+profinite types in Lean.
+
+The type of profinite topological spaces is called `Profinite`. It has a category
+instance and is a fully faithful subcategory of `Top`. The fully faithful functor
+is called `Profinite_to_Top`.
+
+-- TODO
+1) existence of products, limits(?), finite coproducts
+2) `Profinite_to_Top` creates limits?
+-/
+
+open category_theory
+
+/-- The type of profinite topological spaces. -/
+structure Profinite :=
+(to_Top : Top)
+[is_compact : compact_space to_Top]
+[is_t2 : t2_space to_Top]
+[is_td : totally_disconnected_space to_Top]
+
+namespace Profinite
+
+instance : inhabited Profinite := ⟨{to_Top := { α := pempty }}⟩
+
+instance : has_coe_to_sort Profinite := ⟨Type*, λ X, X.to_Top⟩
+instance {X : Profinite} : compact_space X := X.is_compact
+instance {X : Profinite} : t2_space X := X.is_t2
+instance {X : Profinite} : totally_disconnected_space X := X.is_td
+
+instance category : category Profinite := induced_category.category to_Top
+
+end Profinite
+
+/-- The fully faithful embedding of `Profinite` in `Top`. -/
+@[simps {rhs_md := semireducible}, derive [full, faithful]]
+def Profinite_to_Top : Profinite ⥤ Top := induced_functor _
+
+/-- The fully faithful embedding of `Profinite` in `Top`. -/
+@[simps] def Profinite_to_CompHaus : Profinite ⥤ CompHaus :=
+{ obj := λ X, { to_Top := X.to_Top,
+  is_compact := X.is_compact,
+  is_hausdorff := X.is_t2 },
+  map := λ _ _ f, f }
+
+instance : full Profinite_to_CompHaus := { preimage := λ _ _ f, f }
+instance : faithful Profinite_to_CompHaus := {}
+
+@[simp] lemma Profinite_to_CompHaus_to_Top :
+  Profinite_to_CompHaus ⋙ CompHaus_to_Top = Profinite_to_Top :=
+rfl

--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -42,7 +42,7 @@ structure Profinite :=
 (to_Top : Top)
 [is_compact : compact_space to_Top]
 [is_t2 : t2_space to_Top]
-[is_td : totally_disconnected_space to_Top]
+[is_totally_disconnected : totally_disconnected_space to_Top]
 
 namespace Profinite
 

--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -16,9 +16,9 @@ The type of profinite topological spaces is called `Profinite`. It has a categor
 instance and is a fully faithful subcategory of `Top`. The fully faithful functor
 is called `Profinite_to_Top`.
 
--- TODO
-1) existence of products, limits(?), finite coproducts
-2) `Profinite_to_Top` creates limits?
+## TODO
+1. existence of products, limits(?), finite coproducts
+2. `Profinite_to_Top` creates limits?
 -/
 
 open category_theory

--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -51,7 +51,7 @@ instance : inhabited Profinite := ⟨{to_Top := { α := pempty }}⟩
 instance : has_coe_to_sort Profinite := ⟨Type*, λ X, X.to_Top⟩
 instance {X : Profinite} : compact_space X := X.is_compact
 instance {X : Profinite} : t2_space X := X.is_t2
-instance {X : Profinite} : totally_disconnected_space X := X.is_td
+instance {X : Profinite} : totally_disconnected_space X := X.is_totally_disconnected
 
 instance category : category Profinite := induced_category.category to_Top
 


### PR DESCRIPTION

---

I just added the basic category for now, plus the morphisms to CompHaus and Top, and proof that they're compatible. `rfl` didn't work initially, that's why I changed the `CompHaus` file (thanks Bhavik/Kenny). There was some debate about whether it should be `simp`. 

<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
