### PR TITLE
[Merged by Bors] - refactor(*): Add `_injective` alongside `_inj` lemmas

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -350,11 +350,17 @@ by simp [h.symm]
 lemma add_eq_of_eq_sub (h : a = c - b) : a + b = c :=
 by simp [h]
 
+@[simp] lemma sub_right_injective (a : G) : function.injective (λ b, a - b) :=
+(add_right_injective _).comp neg_injective
+
 @[simp] lemma sub_right_inj : a - b = a - c ↔ b = c :=
-(add_right_inj _).trans neg_inj
+(sub_right_injective _).eq_iff
+
+@[simp] lemma sub_left_injective (b : G) : function.injective (λ a, a - b) :=
+add_left_injective _
 
 @[simp] lemma sub_left_inj : b - a = c - a ↔ b = c :=
-add_left_inj _
+(sub_left_injective _).eq_iff
 
 lemma sub_add_sub_cancel (a b c : G) : (a - b) + (b - c) = a - c :=
 by rw [← add_sub_assoc, sub_add_cancel]

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -137,7 +137,7 @@ theorem mul_right_injective (a : G) : function.injective ((*) a) :=
 
 @[simp, to_additive]
 theorem mul_right_inj (a : G) {b c : G} : a * b = a * c ↔ b = c :=
-⟨mul_left_cancel, congr_arg _⟩
+(mul_right_injective a).eq_iff
 
 end left_cancel_semigroup
 
@@ -170,7 +170,7 @@ theorem mul_left_injective (a : G) : function.injective (λ x, x * a) :=
 
 @[simp, to_additive]
 theorem mul_left_inj (a : G) {b c : G} : b * a = c * a ↔ b = c :=
-⟨mul_right_cancel, congr_arg _⟩
+(mul_left_injective a).eq_iff
 
 end right_cancel_semigroup
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -46,7 +46,7 @@ assume Peq, list.no_confusion Peq (assume Pheq Pteq, Pteq)
 assume l₁ l₂, assume Pe, tail_eq_of_cons_eq Pe
 
 theorem cons_inj (a : α) {l l' : list α} : a::l = a::l' ↔ l = l' :=
-⟨λ e, cons_injective e, congr_arg _⟩
+cons_injective.eq_iff
 
 theorem exists_cons_of_ne_nil {l : list α} (h : l ≠ nil) : ∃ b L, l = b :: L :=
 by { induction l with c l',  contradiction,  use [c,l'], }
@@ -408,11 +408,17 @@ append_inj_right h rfl
 theorem append_right_cancel {s₁ s₂ t : list α} (h : s₁ ++ t = s₂ ++ t) : s₁ = s₂ :=
 append_inj_left' h rfl
 
+theorem append_right_injective (s : list α) : function.injective (λ t, s ++ t) :=
+λ t₁ t₂, append_left_cancel
+
 theorem append_right_inj {t₁ t₂ : list α} (s) : s ++ t₁ = s ++ t₂ ↔ t₁ = t₂ :=
-⟨append_left_cancel, congr_arg _⟩
+(append_right_injective s).eq_iff
+
+theorem append_left_injective (t : list α) : function.injective (λ s, s ++ t) :=
+λ s₁ s₂, append_right_cancel
 
 theorem append_left_inj {s₁ s₂ : list α} (t) : s₁ ++ t = s₂ ++ t ↔ s₁ = s₂ :=
-⟨append_right_cancel, congr_arg _⟩
+(append_left_injective t).eq_iff
 
 theorem map_eq_append_split {f : α → β} {l : list α} {s₁ s₂ : list β}
   (h : map f l = s₁ ++ s₂) : ∃ l₁ l₂, l = l₁ ++ l₂ ∧ map f l₁ = s₁ ∧ map f l₂ = s₂ :=


### PR DESCRIPTION
This adds four new `injective` lemmas:

* `list.append_right_injective`
* `list.append_left_injective`
* `sub_right_injective`
* `sub_left_injective`

It also replaces as many `*_inj` lemmas as possible with an implementation of `*_injective.eq_iff`, to make it clear that the lemmas are just aliases of each other.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
