### PR TITLE
[Merged by Bors] - chore(data/equiv/perm): Move around lemmas about perm and swap

### DIFF
--- a/src/category_theory/graded_object.lean
+++ b/src/category_theory/graded_object.lean
@@ -6,6 +6,7 @@ Authors: Scott Morrison
 import category_theory.shift
 import category_theory.concrete_category
 import category_theory.pi.basic
+import algebra.group.basic
 
 /-!
 # The category of graded objects

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -14,7 +14,7 @@ In this file we define two types:
   not equality!) to express that various `Type`s or `Sort`s are equivalent.
 
 * `equiv.perm α`: the group of permutations `α ≃ α`. More lemmas about `equiv.perm` can be found in
-  `data/equiv/perm`.
+  `group_theory/perm`.
 
 Then we define
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
 import data.set.function
-import algebra.group.basic
 
 /-!
 # Equivalence between types
@@ -14,7 +13,8 @@ In this file we define two types:
 * `equiv α β` a.k.a. `α ≃ β`: a bijective map `α → β` bundled with its inverse map; we use this (and
   not equality!) to express that various `Type`s or `Sort`s are equivalent.
 
-* `equiv.perm α`: the group of permutations `α ≃ α`.
+* `equiv.perm α`: the group of permutations `α ≃ α`. More lemmas about `equiv.perm` can be found in
+  `data/equiv/perm`.
 
 Then we define
 
@@ -47,9 +47,6 @@ Then we define
 
   More definitions of this kind can be found in other files. E.g., `data/equiv/transfer_instance`
   does it for many algebraic type classes like `group`, `module`, etc.
-
-* group structure on `equiv.perm α`. More lemmas about `equiv.perm` can be found in
-  `data/equiv/perm`.
 
 ## Tags
 
@@ -254,42 +251,6 @@ by { rw [← set.image_comp], simp }
 protected lemma image_compl {α β} (f : equiv α β) (s : set α) :
   f '' sᶜ = (f '' s)ᶜ :=
 set.image_compl_eq f.bijective
-
-/-!
-### The group of permutations (self-equivalences) of a type `α`
--/
-
-namespace perm
-
-instance perm_group {α : Type u} : group (perm α) :=
-begin
-  refine { mul := λ f g, equiv.trans g f, one := equiv.refl α, inv:= equiv.symm, ..};
-  intros; apply equiv.ext; try { apply trans_apply },
-  apply symm_apply_apply
-end
-
-theorem mul_apply {α : Type u} (f g : perm α) (x) : (f * g) x = f (g x) :=
-equiv.trans_apply _ _ _
-
-theorem one_apply {α : Type u} (x) : (1 : perm α) x = x := rfl
-
-@[simp] lemma inv_apply_self {α : Type u} (f : perm α) (x) :
-  f⁻¹ (f x) = x := equiv.symm_apply_apply _ _
-
-@[simp] lemma apply_inv_self {α : Type u} (f : perm α) (x) :
-  f (f⁻¹ x) = x := equiv.apply_symm_apply _ _
-
-lemma one_def {α : Type u} : (1 : perm α) = equiv.refl α := rfl
-
-lemma mul_def {α : Type u} (f g : perm α) : f * g = g.trans f := rfl
-
-lemma inv_def {α : Type u} (f : perm α) : f⁻¹ = f.symm := rfl
-
-@[simp] lemma coe_mul {α : Type u} (f g : perm α) : ⇑(f * g) = f ∘ g := rfl
-
-@[simp] lemma coe_one {α : Type u} : ⇑(1 : perm α) = id := rfl
-
-end perm
 
 /-- If `α` is an empty type, then it is equivalent to the `empty` type. -/
 def equiv_empty (h : α → false) : α ≃ empty :=
@@ -854,7 +815,7 @@ variables {α₁ β₁ β₂ : Type*} [decidable_eq α₁] (a : α₁) (e : perm
 `(a, e b)` and keeping the other `(a', b)` fixed. -/
 def prod_extend_right : perm (α₁ × β₁) :=
 { to_fun := λ ab, if ab.fst = a then (a, e ab.snd) else ab,
-  inv_fun := λ ab, if ab.fst = a then (a, e⁻¹ ab.snd) else ab,
+  inv_fun := λ ab, if ab.fst = a then (a, e.symm ab.snd) else ab,
   left_inv := by { rintros ⟨k', x⟩, simp only, split_ifs with h; simp [h] },
   right_inv := by { rintros ⟨k', x⟩, simp only, split_ifs with h; simp [h] } }
 
@@ -1528,9 +1489,6 @@ lemma comp_swap_eq_update {β : Type*} (i j : α) (f : α → β) :
   f ∘ equiv.swap i j = update (update f j (f i)) i (f j) :=
 by rw [swap_eq_update, comp_update, comp_update, comp.right_id]
 
-@[simp] lemma swap_inv {α : Type*} [decidable_eq α] (x y : α) :
-  (swap x y)⁻¹ = swap x y := rfl
-
 @[simp] lemma symm_trans_swap_trans [decidable_eq β] (a b : α)
   (e : α ≃ β) : (e.symm.trans (swap a b)).trans e = swap (e a) (e b) :=
 equiv.ext (λ x, begin
@@ -1540,12 +1498,9 @@ equiv.ext (λ x, begin
   split_ifs; simp
 end)
 
-@[simp] lemma swap_mul_self {α : Type*} [decidable_eq α] (i j : α) : swap i j * swap i j = 1 :=
-equiv.swap_swap i j
-
 @[simp] lemma swap_apply_self {α : Type*} [decidable_eq α] (i j a : α) :
   swap i j (swap i j a) = a :=
-by rw [← perm.mul_apply, swap_mul_self, perm.one_apply]
+by rw [← equiv.trans_apply, equiv.swap_swap, equiv.refl_apply]
 
 /-- Augment an equivalence with a prescribed mapping `f a = b` -/
 def set_value (f : α ≃ β) (a : α) (b : β) : α ≃ β :=

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -6,8 +6,7 @@ Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 import algebra.group.hom
 import algebra.group.type_tags
 import algebra.group.units_hom
-import data.equiv.basic
-import data.equiv.perm
+import group_theory.perm.basic
 
 /-!
 # Multiplicative and additive equivs

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -7,6 +7,7 @@ import algebra.group.hom
 import algebra.group.type_tags
 import algebra.group.units_hom
 import data.equiv.basic
+import data.equiv.perm
 
 /-!
 # Multiplicative and additive equivs

--- a/src/data/equiv/perm.lean
+++ b/src/data/equiv/perm.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Mario Carneiro
+-/
+import data.equiv.basic
+import algebra.group.basic
+/-!
+# The group of permutations (self-equivalences) of a type `α`
+
+This file defines the `group` structure on `equiv.perm α`.
+
+More lemmas about permutations can be found in `group_theory/perm`.
+-/
+universes u v
+
+namespace equiv
+
+variables {α : Type u}
+
+namespace perm
+
+instance perm_group : group (perm α) :=
+begin
+  refine { mul := λ f g, equiv.trans g f, one := equiv.refl α, inv:= equiv.symm, ..};
+  intros; apply equiv.ext; try { apply trans_apply },
+  apply symm_apply_apply
+end
+
+theorem mul_apply (f g : perm α) (x) : (f * g) x = f (g x) :=
+equiv.trans_apply _ _ _
+
+theorem one_apply (x) : (1 : perm α) x = x := rfl
+
+@[simp] lemma inv_apply_self (f : perm α) (x) : f⁻¹ (f x) = x := f.symm_apply_apply x
+
+@[simp] lemma apply_inv_self (f : perm α) (x) : f (f⁻¹ x) = x := f.apply_symm_apply x
+
+lemma one_def : (1 : perm α) = equiv.refl α := rfl
+
+lemma mul_def (f g : perm α) : f * g = g.trans f := rfl
+
+lemma inv_def (f : perm α) : f⁻¹ = f.symm := rfl
+
+@[simp] lemma coe_mul (f g : perm α) : ⇑(f * g) = f ∘ g := rfl
+
+@[simp] lemma coe_one : ⇑(1 : perm α) = id := rfl
+
+lemma eq_inv_iff_eq {f : perm α} {x y : α} : x = f⁻¹ y ↔ f x = y := f.eq_symm_apply
+
+lemma inv_eq_iff_eq {f : perm α} {x y : α} : f⁻¹ x = y ↔ x = f y := f.symm_apply_eq
+
+end perm
+
+section swap
+variables [decidable_eq α]
+
+@[simp] lemma swap_inv (x y : α) : (swap x y)⁻¹ = swap x y := rfl
+
+@[simp] lemma swap_mul_self (i j : α) : swap i j * swap i j = 1 := swap_swap i j
+
+lemma swap_mul_eq_mul_swap (f : perm α) (x y : α) : swap x y * f = f * swap (f⁻¹ x) (f⁻¹ y) :=
+equiv.ext $ λ z, begin
+  simp only [perm.mul_apply, swap_apply_def],
+  split_ifs;
+  simp only [perm.apply_inv_self, *, perm.eq_inv_iff_eq, eq_self_iff_true, not_true] at *
+end
+
+lemma mul_swap_eq_swap_mul (f : perm α) (x y : α) : f * swap x y = swap (f x) (f y) * f :=
+by rw [swap_mul_eq_mul_swap, perm.inv_apply_self, perm.inv_apply_self]
+
+/-- Multiplying a permutation with `swap i j` twice gives the original permutation.
+
+  This specialization of `swap_mul_self` is useful when using cosets of permutations.
+-/
+@[simp]
+lemma swap_mul_self_mul (i j : α) (σ : perm α) : equiv.swap i j * (equiv.swap i j * σ) = σ :=
+by rw [←mul_assoc, swap_mul_self, one_mul]
+
+/-- A stronger version of `mul_right_injective` -/
+@[simp]
+lemma swap_mul_involutive (i j : α) : function.involutive ((*) (equiv.swap i j)) :=
+swap_mul_self_mul i j
+
+lemma swap_mul_eq_iff {i j : α} {σ : perm α} : swap i j * σ = σ ↔ i = j :=
+⟨(assume h, have swap_id : swap i j = 1 := mul_right_cancel (trans h (one_mul σ).symm),
+  by {rw [←swap_apply_right i j, swap_id], refl}),
+(assume h, by erw [h, swap_self, one_mul])⟩
+
+lemma swap_mul_swap_mul_swap {x y z : α} (hwz: x ≠ y) (hxz : x ≠ z) :
+  swap y z * swap x y * swap y z = swap z x :=
+equiv.ext $ λ n, by { simp only [swap_apply_def, perm.mul_apply], split_ifs; cc }
+
+end swap
+
+end equiv

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -9,8 +9,6 @@ import algebra.group.basic
 # The group of permutations (self-equivalences) of a type `α`
 
 This file defines the `group` structure on `equiv.perm α`.
-
-More lemmas about permutations can be found in `group_theory/perm`.
 -/
 universes u v
 

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -3,10 +3,22 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+import data.equiv.perm
 import data.fintype.basic
 import data.finset.sort
 import algebra.group.conj
 import algebra.big_operators.basic
+
+/-!
+# Sign of a permutation
+
+The main definition of this file is `equiv.perm.sign`, associating a `units ℤ` sign with a
+permutation.
+
+This file also contains miscellaneous lemmas about `equiv.perm` and `equiv.swap`, building on top
+of those in `data/equiv/basic` and `data/equiv/perm`.
+
+-/
 
 universes u v
 open equiv function fintype finset
@@ -44,13 +56,6 @@ def of_subtype {p : α → Prop} [decidable_pred p] : perm (subtype p) →* perm
     simp only [h, h₂, coe_fn_mk, perm.mul_apply, dif_pos, subtype.coe_eta] },
   { simp only [h, coe_fn_mk, perm.mul_apply, dif_neg, not_false_iff] }
 end }
-
-
-lemma eq_inv_iff_eq {f : perm α} {x y : α} : x = f⁻¹ y ↔ f x = y :=
-by conv {to_lhs, rw [← injective.eq_iff f.injective, apply_inv_self]}
-
-lemma inv_eq_iff_eq {f : perm α} {x y : α} : f⁻¹ x = y ↔ x = f y :=
-by rw [eq_comm, eq_inv_iff_eq, eq_comm]
 
 /-- Two permutations `f` and `g` are `disjoint` if their supports are disjoint, i.e.,
 every element is fixed either by `f`, or by `g`. -/
@@ -153,34 +158,6 @@ by simp only [support, true_and, mem_filter, mem_univ]
 /-- `f.is_swap` indicates that the permutation `f` is a transposition of two elements.  -/
 def is_swap (f : perm α) := ∃ x y, x ≠ y ∧ f = swap x y
 
-lemma swap_mul_eq_mul_swap (f : perm α) (x y : α) : swap x y * f = f * swap (f⁻¹ x) (f⁻¹ y) :=
-equiv.ext $ λ z, begin
-  simp only [perm.mul_apply, swap_apply_def],
-  split_ifs;
-  simp only [perm.apply_inv_self, *, eq_inv_iff_eq,eq_self_iff_true, not_true] at *
-end
-
-lemma mul_swap_eq_swap_mul (f : perm α) (x y : α) : f * swap x y = swap (f x) (f y) * f :=
-by rw [swap_mul_eq_mul_swap, inv_apply_self, inv_apply_self]
-
-/-- Multiplying a permutation with `swap i j` twice gives the original permutation.
-
-  This specialization of `swap_mul_self` is useful when using cosets of permutations.
--/
-@[simp]
-lemma swap_mul_self_mul (i j : α) (σ : perm α) : equiv.swap i j * (equiv.swap i j * σ) = σ :=
-by rw [←mul_assoc (swap i j) (swap i j) σ, equiv.swap_mul_self, one_mul]
-
-/-- A stronger version of `mul_right_injective` -/
-@[simp]
-lemma swap_mul_involutive (i j : α) : function.involutive ((*) (equiv.swap i j)) :=
-swap_mul_self_mul i j
-
-lemma swap_mul_eq_iff {i j : α} {σ : perm α} : swap i j * σ = σ ↔ i = j :=
-⟨(assume h, have swap_id : swap i j = 1 := mul_right_cancel (trans h (one_mul σ).symm),
-  by {rw [←swap_apply_right i j, swap_id], refl}),
-(assume h, by erw [h, swap_self, one_mul])⟩
-
 lemma is_swap_of_subtype {p : α → Prop} [decidable_pred p]
   {f : perm (subtype p)} (h : is_swap f) : is_swap (of_subtype f) :=
 let ⟨⟨x, hx⟩, ⟨y, hy⟩, hxy⟩ := h in
@@ -273,10 +250,6 @@ is preserved under composition with a non-trivial swap, then `P` holds for all p
 @[elab_as_eliminator] lemma swap_induction_on' [fintype α] {P : perm α → Prop} (f : perm α) :
   P 1 → (∀ f x y, x ≠ y → P f → P (f * swap x y)) → P f :=
 λ h1 IH, inv_inv f ▸ swap_induction_on f⁻¹ h1 (λ f, IH f⁻¹)
-
-lemma swap_mul_swap_mul_swap {x y z : α} (hwz: x ≠ y) (hxz : x ≠ z) :
-  swap y z * swap x y * swap y z = swap z x :=
-equiv.ext $ λ n, by simp only [swap_apply_def, mul_apply]; split_ifs; cc
 
 lemma is_conj_swap {w x y z : α} (hwx : w ≠ x) (hyz : y ≠ z) : is_conj (swap w x) (swap y z) :=
 have h : ∀ {y z : α}, y ≠ z → w ≠ z →

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -3,11 +3,11 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import data.equiv.perm
 import data.fintype.basic
 import data.finset.sort
 import algebra.group.conj
 import algebra.big_operators.basic
+import group_theory.perm.basic
 
 /-!
 # Sign of a permutation

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 -/
 import data.equiv.basic
 import data.sigma.basic
+import algebra.group.defs
 
 /-!
 # Injective functions
@@ -226,6 +227,9 @@ namespace set
 
 end set
 
+-- TODO: these two definitions probably belong somewhere else, so that we can remove the
+-- `algebra.group.defs` import.
+
 /--
 The embedding of a left cancellative semigroup into itself
 by left multiplication by a fixed element.
@@ -234,8 +238,7 @@ by left multiplication by a fixed element.
   "The embedding of a left cancellative additive semigroup into itself
    by left translation by a fixed element."]
 def mul_left_embedding {G : Type u} [left_cancel_semigroup G] (g : G) : G ↪ G :=
-{ to_fun := λ h, g * h,
-  inj' := λ h h', (mul_right_inj g).mp, }
+{ to_fun := λ h, g * h, inj' := mul_right_injective g }
 
 /--
 The embedding of a right cancellative semigroup into itself
@@ -245,7 +248,6 @@ by right multiplication by a fixed element.
   "The embedding of a right cancellative additive semigroup into itself
    by right translation by a fixed element."]
 def mul_right_embedding {G : Type u} [right_cancel_semigroup G] (g : G) : G ↪ G :=
-{ to_fun := λ h, h * g,
-  inj' := λ h h', (mul_left_inj g).mp, }
+{ to_fun := λ h, h * g, inj' := mul_left_injective g }
 
 attribute [simps] mul_left_embedding add_left_embedding mul_right_embedding add_right_embedding


### PR DESCRIPTION
Only a very small fraction of `data/equiv/basic` needs knowledge of groups, moving out `perm_group` lets us cut the dependency.

The new `perm_group` file is then a good place for some of the lemmas in `group_theory/perm/sign`, especially those which just restate `equiv` lemmas in terms of `*` and `⁻¹` instead of `.trans` and `.symm`.

This moves a few lemmas about swap out of the `equiv.perm` namespace and into `equiv`, since `equiv.swap` is also in that namespace.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
