### PR TITLE
[Merged by Bors] - feat(data/nat/sqrt): add simple inequality lemmas and "no middle square"

### DIFF
--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -197,8 +197,8 @@ lt_succ_iff.mpr (sqrt_le _)
 theorem succ_le_succ_sqrt (n : ℕ) : n + 1 ≤ (sqrt n + 1) * (sqrt n + 1) :=
 le_of_pred_lt (lt_succ_sqrt _)
 
-/-- There are no perfect squares strictly between n² and (m+1)² -/
-theorem no_middle_square {n m : ℕ} (hl : m * m < n) (hr : n < (m + 1) * (m + 1)):
+/-- There are no perfect squares strictly between m² and (m+1)² -/
+theorem not_exists_sq {n m : ℕ} (hl : m * m < n) (hr : n < (m + 1) * (m + 1)) :
   ¬ ∃ t, t * t = n :=
 begin
   rintro ⟨t, rfl⟩,

--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -197,14 +197,14 @@ lt_succ_iff.mpr (sqrt_le _)
 theorem succ_le_succ_sqrt (n : ℕ) : n + 1 ≤ (sqrt n + 1) * (sqrt n + 1) :=
 le_of_pred_lt (lt_succ_sqrt _)
 
-/-- There are no perfect squares strictly between a² and (a+1)² -/
-theorem no_middle_square {n a : ℕ} (hl : a * a < n) (hr : n < (a + 1) * (a + 1)):
-    ¬ ∃ t, t * t = n :=
+/-- There are no perfect squares strictly between n² and (m+1)² -/
+theorem no_middle_square {n m : ℕ} (hl : m * m < n) (hr : n < (m + 1) * (m + 1)):
+  ¬ ∃ t, t * t = n :=
 begin
-    rintro ⟨t, rfl⟩,
-    have h1 : a < t, from nat.mul_self_lt_mul_self_iff.mpr hl,
-    have h2 : t < a + 1, from nat.mul_self_lt_mul_self_iff.mpr hr,
-    exact (not_lt_of_ge $ le_of_lt_succ h2) h1
+  rintro ⟨t, rfl⟩,
+  have h1 : m < t, from nat.mul_self_lt_mul_self_iff.mpr hl,
+  have h2 : t < m + 1, from nat.mul_self_lt_mul_self_iff.mpr hr,
+  exact (not_lt_of_ge $ le_of_lt_succ h2) h1
 end
 
 end nat

--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -191,7 +191,7 @@ theorem exists_mul_self (x : ℕ) :
   (∃ n, n * n = x) ↔ sqrt x * sqrt x = x :=
 ⟨λ ⟨n, hn⟩, by rw [← hn, sqrt_eq], λ h, ⟨sqrt x, h⟩⟩
 
-theorem sqrt_lt_succ (n : ℕ) : sqrt n * sqrt n < n + 1 :=
+theorem sqrt_mul_sqrt_lt_succ (n : ℕ) : sqrt n * sqrt n < n + 1 :=
 lt_succ_iff.mpr (sqrt_le _)
 
 theorem succ_le_succ_sqrt (n : ℕ) : n + 1 ≤ (sqrt n + 1) * (sqrt n + 1) :=

--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -191,4 +191,20 @@ theorem exists_mul_self (x : ℕ) :
   (∃ n, n * n = x) ↔ sqrt x * sqrt x = x :=
 ⟨λ ⟨n, hn⟩, by rw [← hn, sqrt_eq], λ h, ⟨sqrt x, h⟩⟩
 
+theorem sqrt_lt_succ (n : ℕ) : sqrt n * sqrt n < n + 1 :=
+lt_succ_iff.mpr (sqrt_le _)
+
+theorem succ_le_succ_sqrt (n : ℕ) : n + 1 ≤ (sqrt n + 1) * (sqrt n + 1) :=
+le_of_pred_lt (lt_succ_sqrt _)
+
+/-- There are no perfect squares strictly between a² and (a+1)² -/
+theorem no_middle_square {n a : ℕ} (hl : a * a < n) (hr : n < (a + 1) * (a + 1)):
+    ¬ ∃ t, t * t = n :=
+begin
+    rintro ⟨t, rfl⟩,
+    have h1 : a < t, from nat.mul_self_lt_mul_self_iff.mpr hl,
+    have h2 : t < a + 1, from nat.mul_self_lt_mul_self_iff.mpr hr,
+    exact (not_lt_of_ge $ le_of_lt_succ h2) h1
+end
+
 end nat


### PR DESCRIPTION
The first two theorems are useful when one needs the biggest perfect square strictly less than a number, whereas `no_middle_square` can be used to easily prove that a given number is not a square.

---

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Simple.20nat.2Esqrt.20lemmas)