### PR TITLE
[Merged by Bors] - fix(topology/algebra/infinite_sum): fix docstring typos and add example

### DIFF
--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -38,7 +38,7 @@ variables [add_comm_monoid α] [topological_space α]
 
 The `at_top` filter on `finset β` is the limit of all finite sets towards the entire type. So we sum
 up bigger and bigger sets. This sum operation is invariant under reordering. In particular,
-the function `ℕ → ℝ` sending n to (-1)^n/(n+1) does not have a
+the function `ℕ → ℝ` sending `n` to `(-1)^n / (n+1)` does not have a
 sum for this definition, but a series which is absolutely convergent will have the correct sum.
 
 This is based on Mario Carneiro's infinite sum in Metamath.

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -36,8 +36,9 @@ variables [add_comm_monoid α] [topological_space α]
 
 /-- Infinite sum on a topological monoid
 The `at_top` filter on `finset β` is the limit of all finite sets towards the entire type. So we sum
-up bigger and bigger sets. This sum operation is still invariant under reordering, and a absolute
-sum operator.
+up bigger and bigger sets. This sum operation is still invariant under reordering, and an absolute
+sum operator. In particular, the function `ℕ → ℝ` sending n to (-1)^n/(n+1) does not have a
+sum for this definition, but a series which is absolutely convergent will have the correct sum.
 
 This is based on Mario Carneiro's infinite sum in Metamath.
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -42,7 +42,7 @@ the function `ℕ → ℝ` sending `n` to `(-1)^n / (n+1)` does not have a
 sum for this definition, but a series which is absolutely convergent will have the correct sum.
 
 This is based on Mario Carneiro's
-[infinite sum `df-sum` in Metamath](http://us.metamath.org/mpeuni/df-sum.html).
+[infinite sum `df-tsums` in Metamath](http://us.metamath.org/mpeuni/df-tsms.html).
 
 For the definition or many statements, `α` does not need to be a topological monoid. We only add
 this assumption later, for the lemmas where it is relevant.

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -35,6 +35,7 @@ section has_sum
 variables [add_comm_monoid α] [topological_space α]
 
 /-- Infinite sum on a topological monoid
+
 The `at_top` filter on `finset β` is the limit of all finite sets towards the entire type. So we sum
 up bigger and bigger sets. This sum operation is invariant under reordering. In particular,
 the function `ℕ → ℝ` sending n to (-1)^n/(n+1) does not have a

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -35,7 +35,7 @@ section has_sum
 variables [add_comm_monoid α] [topological_space α]
 
 /-- Infinite sum on a topological monoid
-The `at_top` filter on `finset α` is the limit of all finite sets towards the entire type. So we sum
+The `at_top` filter on `finset β` is the limit of all finite sets towards the entire type. So we sum
 up bigger and bigger sets. This sum operation is still invariant under reordering, and a absolute
 sum operator.
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -41,10 +41,10 @@ up bigger and bigger sets. This sum operation is invariant under reordering. In 
 the function `ℕ → ℝ` sending `n` to `(-1)^n / (n+1)` does not have a
 sum for this definition, but a series which is absolutely convergent will have the correct sum.
 
-This is based on Mario Carneiro's 
+This is based on Mario Carneiro's
 [infinite sum `df-sum` in Metamath](http://us.metamath.org/mpeuni/df-sum.html).
 
-For the definition or many statements, α does not need to be a topological monoid. We only add
+For the definition or many statements, `α` does not need to be a topological monoid. We only add
 this assumption later, for the lemmas where it is relevant.
 -/
 def has_sum (f : β → α) (a : α) : Prop := tendsto (λs:finset β, ∑ b in s, f b) at_top (𝓝 a)

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -41,7 +41,8 @@ up bigger and bigger sets. This sum operation is invariant under reordering. In 
 the function `ℕ → ℝ` sending `n` to `(-1)^n / (n+1)` does not have a
 sum for this definition, but a series which is absolutely convergent will have the correct sum.
 
-This is based on Mario Carneiro's infinite sum in Metamath.
+This is based on Mario Carneiro's 
+[infinite sum `df-sum` in Metamath](http://us.metamath.org/mpeuni/df-sum.html).
 
 For the definition or many statements, α does not need to be a topological monoid. We only add
 this assumption later, for the lemmas where it is relevant.

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -36,8 +36,8 @@ variables [add_comm_monoid α] [topological_space α]
 
 /-- Infinite sum on a topological monoid
 The `at_top` filter on `finset β` is the limit of all finite sets towards the entire type. So we sum
-up bigger and bigger sets. This sum operation is still invariant under reordering, and an absolute
-sum operator. In particular, the function `ℕ → ℝ` sending n to (-1)^n/(n+1) does not have a
+up bigger and bigger sets. This sum operation is invariant under reordering. In particular,
+the function `ℕ → ℝ` sending n to (-1)^n/(n+1) does not have a
 sum for this definition, but a series which is absolutely convergent will have the correct sum.
 
 This is based on Mario Carneiro's infinite sum in Metamath.

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -42,7 +42,7 @@ the function `ℕ → ℝ` sending `n` to `(-1)^n / (n+1)` does not have a
 sum for this definition, but a series which is absolutely convergent will have the correct sum.
 
 This is based on Mario Carneiro's
-[infinite sum `df-tsums` in Metamath](http://us.metamath.org/mpeuni/df-tsms.html).
+[infinite sum `df-tsms` in Metamath](http://us.metamath.org/mpeuni/df-tsms.html).
 
 For the definition or many statements, `α` does not need to be a topological monoid. We only add
 this assumption later, for the lemmas where it is relevant.


### PR DESCRIPTION
---

`finset alpha` should be `finset beta`, right? I also change `a absolute` to `an absolute`, and note that a series which is convergent but absolutely convergent does not have a sum.

<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
