### PR TITLE
[Merged by Bors] - feat(group_theory/order_of_element): add is_cyclic_of_prime_card

### DIFF
--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -303,9 +303,11 @@ lemma is_cyclic_of_order_of_eq_card [group α] [decidable_eq α] [fintype α]
   (set.subset_univ _)
   (by {rw [fintype.card_congr (equiv.set.univ α), ← hx, order_eq_card_gpowers], refl})⟩⟩
 
-lemma is_cyclic_of_prime_card [group α] [fintype α] (p : ℕ) (hp : nat.prime p) (h : fintype.card α = p) : is_cyclic α :=
+lemma is_cyclic_of_prime_card [group α] [fintype α] {p : ℕ} [hp : fact p.prime]
+  (h : fintype.card α = p) : is_cyclic α :=
 ⟨begin
-  obtain ⟨g, hg⟩ : ∃ g : α, g ≠ 1 := fintype.exists_ne_of_one_lt_card (by { rw h, exact nat.prime.one_lt hp }) 1,
+  obtain ⟨g, hg⟩ : ∃ g : α, g ≠ 1,
+  from fintype.exists_ne_of_one_lt_card (by { rw h, exact nat.prime.one_lt hp }) 1,
   have : fintype.card (subgroup.gpowers g) ∣ p,
   { rw ←h,
     apply card_subgroup_dvd_card },

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -303,6 +303,29 @@ lemma is_cyclic_of_order_of_eq_card [group α] [decidable_eq α] [fintype α]
   (set.subset_univ _)
   (by {rw [fintype.card_congr (equiv.set.univ α), ← hx, order_eq_card_gpowers], refl})⟩⟩
 
+lemma is_cyclic_of_prime_card [group α] [fintype α] (p : ℕ) (hp : nat.prime p) (h : fintype.card α = p) : is_cyclic α :=
+⟨begin
+  obtain ⟨g, hg⟩ : ∃ g : α, g ≠ 1 := fintype.exists_ne_of_one_lt_card (by { rw h, exact nat.prime.one_lt hp }) 1,
+  use g,
+  intro x,
+  have : fintype.card (subgroup.gpowers g) ∣ p,
+  { rw ←h,
+    apply card_subgroup_dvd_card },
+  rw nat.dvd_prime hp at this,
+  cases this,
+  { rw fintype.card_eq_one_iff at this,
+    cases this with t ht,
+    suffices : g = 1,
+    { contradiction },
+    have hgt := ht ⟨g, by { change g ∈ subgroup.gpowers g, exact subgroup.mem_gpowers g}⟩,
+    rw [←ht 1] at hgt,
+    change (⟨_, _⟩ : subgroup.gpowers g) = ⟨_, _⟩ at hgt,
+    simpa using hgt },
+  { rw [←h] at this,
+    rw subgroup.eq_top_of_card_eq _ _ this,
+    exact subgroup.mem_top _ }
+end⟩
+
 lemma order_of_eq_card_of_forall_mem_gpowers [group α] [decidable_eq α] [fintype α]
   {g : α} (hx : ∀ x, x ∈ gpowers g) : order_of g = fintype.card α :=
 by {rw [← fintype.card_congr (equiv.set.univ α), order_eq_card_gpowers],

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -315,7 +315,7 @@ lemma is_cyclic_of_prime_card [group α] [fintype α] (p : ℕ) (hp : nat.prime 
     cases this with t ht,
     suffices : g = 1,
     { contradiction },
-    have hgt := ht ⟨g, by { change g ∈ subgroup.gpowers g, exact subgroup.mem_gpowers g}⟩,
+    have hgt := ht ⟨g, by { change g ∈ subgroup.gpowers g, exact subgroup.mem_gpowers g }⟩,
     rw [←ht 1] at hgt,
     change (⟨_, _⟩ : subgroup.gpowers g) = ⟨_, _⟩ at hgt,
     simpa using hgt },

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -306,8 +306,6 @@ lemma is_cyclic_of_order_of_eq_card [group α] [decidable_eq α] [fintype α]
 lemma is_cyclic_of_prime_card [group α] [fintype α] (p : ℕ) (hp : nat.prime p) (h : fintype.card α = p) : is_cyclic α :=
 ⟨begin
   obtain ⟨g, hg⟩ : ∃ g : α, g ≠ 1 := fintype.exists_ne_of_one_lt_card (by { rw h, exact nat.prime.one_lt hp }) 1,
-  use g,
-  intro x,
   have : fintype.card (subgroup.gpowers g) ∣ p,
   { rw ←h,
     apply card_subgroup_dvd_card },
@@ -321,8 +319,10 @@ lemma is_cyclic_of_prime_card [group α] [fintype α] (p : ℕ) (hp : nat.prime 
     rw [←ht 1] at hgt,
     change (⟨_, _⟩ : subgroup.gpowers g) = ⟨_, _⟩ at hgt,
     simpa using hgt },
-  { rw [←h] at this,
-    rw subgroup.eq_top_of_card_eq _ _ this,
+  { use g,
+    intro x,
+    rw [←h] at this,
+    rw subgroup.eq_top_of_card_eq _ this,
     exact subgroup.mem_top _ }
 end⟩
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -350,7 +350,7 @@ begin
     exact ⟨h x, by { rintros rfl, exact H.one_mem }⟩ },
 end
 
-@[to_additive] lemma subgroup.eq_top_of_card_eq [fintype G] (h : fintype.card H = fintype.card G) : H = ⊤ :=
+@[to_additive] lemma eq_top_of_card_eq [fintype G] (h : fintype.card H = fintype.card G) : H = ⊤ :=
 begin
   change fintype.card H.carrier = _ at h,
   cases H with S hS1 hS2 hS3,

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -350,6 +350,19 @@ begin
     exact ⟨h x, by { rintros rfl, exact H.one_mem }⟩ },
 end
 
+@[to_additive] lemma subgroup.eq_top_of_card_eq [fintype G] (h : fintype.card H = fintype.card G) : H = ⊤ :=
+begin
+  change fintype.card H.carrier = _ at h,
+  cases H with S hS1 hS2 hS3,
+  have : S = set.univ,
+  { suffices : S.to_finset = finset.univ,
+    { rwa [←set.to_finset_univ, set.to_finset_inj] at this, },
+    apply finset.eq_univ_of_card,
+    rwa set.to_finset_card },
+  change (⟨_, _, _, _⟩ : subgroup G) = ⟨_, _, _, _⟩,
+  congr',
+end
+
 @[to_additive] lemma nontrivial_iff_exists_ne_one (H : subgroup G) : nontrivial H ↔ ∃ x ∈ H, x ≠ (1:G) :=
 begin
   split,


### PR DESCRIPTION
Add `is_cyclic_of_prime_card`, which says if a group has prime order, then it is cyclic. I also added `eq_top_of_card_eq` which says a subgroup is `top` when it has the same size as the group, not sure where that should be in the file.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
