### PR TITLE
[Merged by Bors] - feat(field_theory/separable): is_separable_of_alg_hom_is_separable

### DIFF
--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -573,7 +573,7 @@ begin
   exact hs,
 end
 
-lemma is_separable_of_alg_hom_is_separable {E' : Type*} [field E'] [algebra F E']
+lemma is_separable.of_alg_hom {E' : Type*} [field E'] [algebra F E']
   (f : E →ₐ[F] E') (h : is_separable F E') : is_separable F E :=
 begin
   letI : algebra E E' := ring_hom.to_algebra f.to_ring_hom,

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -573,4 +573,12 @@ begin
   exact hs,
 end
 
+lemma is_separable_of_alg_hom_is_separable {E' : Type*} [field E'] [algebra F E']
+  (f : E →ₐ[F] E') (h : is_separable F E') : is_separable F E :=
+begin
+  letI : algebra E E' := ring_hom.to_algebra f.to_ring_hom,
+  haveI : is_scalar_tower F E E' := is_scalar_tower.of_algebra_map_eq (λ x, (f.commutes x).symm),
+  exact is_separable_tower_bot_of_is_separable E h,
+end
+
 end is_separable_tower


### PR DESCRIPTION
Proves that is_separable pulls back along an alg_hom

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
