### PR TITLE
[Merged by Bors] - feat(linear_algebra/alternating): Add alternatization of multilinear_map

### DIFF
--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -242,19 +242,19 @@ open_locale big_operators
 
 namespace multilinear_map
 
-open equiv finset
+open equiv
 
 variables [fintype ι]
 
 private lemma alternization_map_eq_zero_of_eq_aux
   (m : multilinear_map R (λ i : ι, M) L)
   (v : ι → M) (i j : ι) (i_ne_j : i ≠ j) (hv : v i = v j) :
-  ∑ (σ : equiv.perm ι), (equiv.perm.sign σ : ℤ) • m.dom_dom_congr σ v = 0 :=
+  ∑ (σ : perm ι), (σ.sign : ℤ) • m.dom_dom_congr σ v = 0 :=
 finset.sum_involution
   (λ σ _, swap i j * σ)
   (λ σ _, begin
-    convert add_right_neg (↑(equiv.perm.sign σ) • m.dom_dom_congr σ v),
-    rw [equiv.perm.sign_mul, equiv.perm.sign_swap i_ne_j, ←neg_smul,
+    convert add_right_neg (↑σ.sign • m.dom_dom_congr σ v),
+    rw [perm.sign_mul, perm.sign_swap i_ne_j, ←neg_smul,
       multilinear_map.dom_dom_congr_apply, multilinear_map.dom_dom_congr_apply],
     congr' 2,
     { simp },
@@ -268,25 +268,25 @@ finset.sum_involution
 permutations. -/
 def alternatization : multilinear_map R (λ i : ι, M) L →+ alternating_map R M L ι :=
 { to_fun := λ m,
-  { to_fun := λ v, ∑ (σ : equiv.perm ι), (equiv.perm.sign σ : ℤ) • m.dom_dom_congr σ v,
+  { to_fun := λ v, ∑ (σ : perm ι), (σ.sign : ℤ) • m.dom_dom_congr σ v,
     map_add' := λ v i a b, by simp_rw [←finset.sum_add_distrib, multilinear_map.map_add, smul_add],
     map_smul' := λ v i c a, by simp_rw [finset.smul_sum, multilinear_map.map_smul, smul_comm],
     map_eq_zero_of_eq' := λ v i j hvij hij, alternization_map_eq_zero_of_eq_aux m v i j hij hvij },
   map_add' := λ a b, begin
     ext,
     simp only [
-      sum_add_distrib, smul_add, add_apply, dom_dom_congr_apply, alternating_map.add_apply,
+      finset.sum_add_distrib, smul_add, add_apply, dom_dom_congr_apply, alternating_map.add_apply,
       alternating_map.coe_mk],
   end,
   map_zero' := begin
     ext,
     simp only [
-      dom_dom_congr_apply, alternating_map.zero_apply, sum_const_zero, smul_zero,
+      dom_dom_congr_apply, alternating_map.zero_apply, finset.sum_const_zero, smul_zero,
       alternating_map.coe_mk, zero_apply]
   end }
 
 lemma alternatization_apply (m : multilinear_map R (λ i : ι, M) L) (v : ι → M) :
-  alternatization m v = ∑ (σ : equiv.perm ι), (equiv.perm.sign σ : ℤ) • m.dom_dom_congr σ v := rfl
+  alternatization m v = ∑ (σ : perm ι), (σ.sign : ℤ) • m.dom_dom_congr σ v := rfl
 
 end multilinear_map
 

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -237,3 +237,78 @@ lemma map_congr_perm [fintype ι] (σ : equiv.perm ι) :
 by { rw [g.map_perm, smul_smul], simp }
 
 end alternating_map
+
+open_locale big_operators
+
+namespace multilinear_map
+
+open equiv finset
+
+variables [fintype ι]
+
+private lemma alternization_map_eq_zero_of_eq_aux
+  (m : multilinear_map R (λ i : ι, M) L)
+  (v : ι → M) (i j : ι) (i_ne_j : i ≠ j) (hv : v i = v j) :
+  ∑ (σ : equiv.perm ι), (equiv.perm.sign σ : ℤ) • m.dom_dom_congr σ v = 0 :=
+begin
+  have : ∀ σ, _root_.disjoint {σ} {swap i j * σ},
+  { intros σ,
+    rw [disjoint_singleton, mem_singleton],
+    exact (not_congr swap_mul_eq_iff).mpr i_ne_j },
+
+  apply finset.sum_cancels_of_partition_cancels (perm.mod_swap i j),
+  intros σ _,
+  erw [filter_or, filter_eq', filter_eq', if_pos (mem_univ σ), if_pos (mem_univ (swap i j * σ)),
+    sum_union (this σ), sum_singleton, sum_singleton],
+
+  convert add_right_neg (↑(equiv.perm.sign σ) • m.dom_dom_congr σ v),
+  rw [equiv.perm.sign_mul, equiv.perm.sign_swap i_ne_j, ←neg_smul],
+  rw multilinear_map.dom_dom_congr_apply,
+  rw multilinear_map.dom_dom_congr_apply,
+  congr' 2,
+  { simp },
+  ext, simp [apply_swap_eq_self hv],
+end
+
+/-- Produce an `alternating_map` out of a `multilinear_map`, by summing over all argument
+permutations. -/
+def alternatization : multilinear_map R (λ i : ι, M) L →+ alternating_map R M L ι :=
+{ to_fun := λ m,
+  { to_fun := λ v, ∑ (σ : equiv.perm ι), (equiv.perm.sign σ : ℤ) • m.dom_dom_congr σ v,
+    map_add' := λ v i a b, by simp_rw [←finset.sum_add_distrib, multilinear_map.map_add, smul_add],
+    map_smul' := λ v i c a, by simp_rw [finset.smul_sum, multilinear_map.map_smul, smul_comm],
+    map_eq_zero_of_eq' := λ v i j hvij hij, alternization_map_eq_zero_of_eq_aux m v i j hij hvij },
+  map_add' := λ a b, begin
+    ext,
+    simp only [
+      sum_add_distrib, smul_add, add_apply, dom_dom_congr_apply, alternating_map.add_apply,
+      alternating_map.coe_mk],
+  end,
+  map_zero' := begin
+    ext,
+    simp only [
+      dom_dom_congr_apply, alternating_map.zero_apply, sum_const_zero, smul_zero,
+      alternating_map.coe_mk, zero_apply]
+  end }
+
+lemma alternatization_apply (m : multilinear_map R (λ i : ι, M) L) (v : ι → M) :
+  alternatization m v = ∑ (σ : equiv.perm ι), (equiv.perm.sign σ : ℤ) • m.dom_dom_congr σ v := rfl
+
+end multilinear_map
+
+namespace alternating_map
+
+/-- Alternatizing a multilinear map that is already alternating results in a scale factor of `n!`,
+where `n` is the number of inputs. -/
+lemma to_multilinear_map_alternization [fintype ι] (a : alternating_map R M L ι) :
+  a.to_multilinear_map.alternatization = nat.factorial (fintype.card ι) • a :=
+begin
+  ext,
+  simp only [
+    multilinear_map.alternatization_apply, map_perm, smul_smul, ←nat.smul_def, coe_mk, smul_apply,
+    add_monoid_hom.coe_mk, finset.sum_const, coe_multilinear_map, one_smul,
+    multilinear_map.dom_dom_congr_apply, int.units_coe_mul_self, to_multilinear_map_eq_coe,
+    finset.card_univ, fintype.card_perm],
+end
+
+end alternating_map

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -250,25 +250,19 @@ private lemma alternization_map_eq_zero_of_eq_aux
   (m : multilinear_map R (λ i : ι, M) L)
   (v : ι → M) (i j : ι) (i_ne_j : i ≠ j) (hv : v i = v j) :
   ∑ (σ : equiv.perm ι), (equiv.perm.sign σ : ℤ) • m.dom_dom_congr σ v = 0 :=
-begin
-  have : ∀ σ, _root_.disjoint {σ} {swap i j * σ},
-  { intros σ,
-    rw [disjoint_singleton, mem_singleton],
-    exact (not_congr swap_mul_eq_iff).mpr i_ne_j },
-
-  apply finset.sum_cancels_of_partition_cancels (perm.mod_swap i j),
-  intros σ _,
-  erw [filter_or, filter_eq', filter_eq', if_pos (mem_univ σ), if_pos (mem_univ (swap i j * σ)),
-    sum_union (this σ), sum_singleton, sum_singleton],
-
-  convert add_right_neg (↑(equiv.perm.sign σ) • m.dom_dom_congr σ v),
-  rw [equiv.perm.sign_mul, equiv.perm.sign_swap i_ne_j, ←neg_smul],
-  rw multilinear_map.dom_dom_congr_apply,
-  rw multilinear_map.dom_dom_congr_apply,
-  congr' 2,
-  { simp },
-  ext, simp [apply_swap_eq_self hv],
-end
+finset.sum_involution
+  (λ σ _, swap i j * σ)
+  (λ σ _, begin
+    convert add_right_neg (↑(equiv.perm.sign σ) • m.dom_dom_congr σ v),
+    rw [equiv.perm.sign_mul, equiv.perm.sign_swap i_ne_j, ←neg_smul,
+      multilinear_map.dom_dom_congr_apply, multilinear_map.dom_dom_congr_apply],
+    congr' 2,
+    { simp },
+    { ext, simp [apply_swap_eq_self hv] },
+  end)
+  (λ σ _ _, (not_congr swap_mul_eq_iff).mpr i_ne_j)
+  (λ σ _, finset.mem_univ _)
+  (λ σ _, swap_mul_involutive i j σ)
 
 /-- Produce an `alternating_map` out of a `multilinear_map`, by summing over all argument
 permutations. -/
@@ -304,9 +298,8 @@ lemma to_multilinear_map_alternization [fintype ι] (a : alternating_map R M L �
   a.to_multilinear_map.alternatization = nat.factorial (fintype.card ι) • a :=
 begin
   ext,
-  simp only [
-    multilinear_map.alternatization_apply, map_perm, smul_smul, ←nat.smul_def, coe_mk, smul_apply,
-    add_monoid_hom.coe_mk, finset.sum_const, coe_multilinear_map, one_smul,
+  simp only [multilinear_map.alternatization_apply, map_perm, smul_smul, ←nat.smul_def, coe_mk,
+    smul_apply, add_monoid_hom.coe_mk, finset.sum_const, coe_multilinear_map, one_smul,
     multilinear_map.dom_dom_congr_apply, int.units_coe_mul_self, to_multilinear_map_eq_coe,
     finset.card_univ, fintype.card_perm],
 end


### PR DESCRIPTION
This adds:

* `def multilinear_map.alternatize`
* `lemma alternating_map.to_multilinear_map_alternize`

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #5180
- [x] depends on: #5201
- [x] depends on: #5135

https://en.wikipedia.org/wiki/Alternating_multilinear_map#Alternatization

~~This is rebased on `staging`, only the last commit is part of this PR.~~
