### PR TITLE
[Merged by Bors] - feat(order/filter/ultrafilter): Restriction of ultrafilters along large embeddings

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1682,7 +1682,7 @@ begin
   { exact λ h, ⟨default ι, h.symm⟩ }
 end
 
-lemma range_inter_compl_image_comlp_eq_image {f : α → β} (H : injective f) (s : set α) :
+lemma range_inter_compl_image_compl_eq_image {f : α → β} (H : injective f) (s : set α) :
   range f ∩ (f '' sᶜ)ᶜ = f '' s :=
 begin
   ext x,

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1682,6 +1682,22 @@ begin
   { exact λ h, ⟨default ι, h.symm⟩ }
 end
 
+@[simp] lemma range_inter_compl_image_comlp_eq_image {f : α → β} (H : injective f) (s : set α) :
+  range f ∩ (f '' sᶜ)ᶜ = f '' s :=
+begin
+  ext x,
+  split,
+  { rintros ⟨⟨x, rfl⟩, h⟩,
+    refine ⟨x, _, rfl⟩,
+    by_contra c,
+    exact h ⟨x, c, rfl⟩ },
+  { rintro ⟨x, hx, rfl⟩,
+    refine ⟨⟨x, rfl⟩, _⟩,
+    rintro ⟨y, hy, h⟩,
+    rw H h at *,
+    contradiction },
+end
+
 end range
 
 /-- The set `s` is pairwise `r` if `r x y` for all *distinct* `x y ∈ s`. -/

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1683,9 +1683,9 @@ begin
 end
 
 lemma range_inter_compl_image_compl_eq_image {f : α → β} (H : injective f) (s : set α) :
-  range f ∩ (f '' sᶜ)ᶜ = f '' s := ext $ λ x, iff.intro
-  (λ ⟨⟨y, h1⟩, h2⟩, ⟨y, by_contra $ λ h, h2 ⟨y, h, h1⟩, h1⟩)
-  (λ ⟨y, h1, h2⟩, ⟨⟨y, h2⟩, λ ⟨z, c1, c2⟩, c1 $ (H $ eq.trans h2 c2.symm).subst h1 ⟩)
+  range f ∩ (f '' sᶜ)ᶜ = f '' s :=
+ext $ λ x, iff.intro (λ ⟨⟨y, h1⟩, h2⟩, ⟨y, by_contra $ λ h, h2 ⟨y, h, h1⟩, h1⟩)
+  (λ ⟨y, h1, h2⟩, ⟨⟨y, h2⟩, λ ⟨z, c1, c2⟩, c1 $ (H $ eq.trans h2 c2.symm).subst h1⟩)
 
 end range
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1682,7 +1682,7 @@ begin
   { exact λ h, ⟨default ι, h.symm⟩ }
 end
 
-@[simp] lemma range_inter_compl_image_comlp_eq_image {f : α → β} (H : injective f) (s : set α) :
+lemma range_inter_compl_image_comlp_eq_image {f : α → β} (H : injective f) (s : set α) :
   range f ∩ (f '' sᶜ)ᶜ = f '' s :=
 begin
   ext x,

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1683,20 +1683,9 @@ begin
 end
 
 lemma range_inter_compl_image_compl_eq_image {f : α → β} (H : injective f) (s : set α) :
-  range f ∩ (f '' sᶜ)ᶜ = f '' s :=
-begin
-  ext x,
-  split,
-  { rintros ⟨⟨x, rfl⟩, h⟩,
-    refine ⟨x, _, rfl⟩,
-    by_contra c,
-    exact h ⟨x, c, rfl⟩ },
-  { rintro ⟨x, hx, rfl⟩,
-    refine ⟨⟨x, rfl⟩, _⟩,
-    rintro ⟨y, hy, h⟩,
-    rw H h at *,
-    contradiction },
-end
+  range f ∩ (f '' sᶜ)ᶜ = f '' s := ext $ λ x, iff.intro
+  (λ ⟨⟨y, h1⟩, h2⟩, ⟨y, by_contra $ λ h, h2 ⟨y, h, h1⟩, h1⟩)
+  (λ ⟨y, h1, h2⟩, ⟨⟨y, h2⟩, λ ⟨z, c1, c2⟩, c1 $ (H $ eq.trans h2 c2.symm).subst h1 ⟩)
 
 end range
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1682,10 +1682,14 @@ begin
   { exact λ h, ⟨default ι, h.symm⟩ }
 end
 
-lemma range_inter_compl_image_compl_eq_image {f : α → β} (H : injective f) (s : set α) :
-  range f ∩ (f '' sᶜ)ᶜ = f '' s :=
-ext $ λ x, iff.intro (λ ⟨⟨y, h1⟩, h2⟩, ⟨y, by_contra $ λ h, h2 ⟨y, h, h1⟩, h1⟩)
-  (λ ⟨y, h1, h2⟩, ⟨⟨y, h2⟩, λ ⟨z, c1, c2⟩, c1 $ (H $ eq.trans h2 c2.symm).subst h1⟩)
+lemma range_diff_image_subset {f : α → β} (H : injective f) (s : set α) :
+  range f \ f '' s ⊆ f '' sᶜ :=
+λ y ⟨⟨x, h₁⟩, h₂⟩, ⟨x, λ h, h₂ ⟨x, h, h₁⟩, h₁⟩
+
+lemma range_diff_image {f : α → β} (H : injective f) (s : set α) :
+  range f \ f '' s = f '' sᶜ :=
+subset.antisymm (range_diff_image_subset H s) $ λ y ⟨x, hx, hy⟩, hy ▸
+  ⟨mem_range_self _, λ ⟨x', hx', eq⟩, hx $ H eq ▸ hx'⟩
 
 end range
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1682,13 +1682,13 @@ begin
   { exact λ h, ⟨default ι, h.symm⟩ }
 end
 
-lemma range_diff_image_subset {f : α → β} (H : injective f) (s : set α) :
+lemma range_diff_image_subset (f : α → β) (s : set α) :
   range f \ f '' s ⊆ f '' sᶜ :=
 λ y ⟨⟨x, h₁⟩, h₂⟩, ⟨x, λ h, h₂ ⟨x, h, h₁⟩, h₁⟩
 
 lemma range_diff_image {f : α → β} (H : injective f) (s : set α) :
   range f \ f '' s = f '' sᶜ :=
-subset.antisymm (range_diff_image_subset H s) $ λ y ⟨x, hx, hy⟩, hy ▸
+subset.antisymm (range_diff_image_subset f s) $ λ y ⟨x, hx, hy⟩, hy ▸
   ⟨mem_range_self _, λ ⟨x', hx', eq⟩, hx $ H eq ▸ hx'⟩
 
 end range

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1515,7 +1515,7 @@ le_antisymm
   le_comap_map
 
 lemma mem_comap_iff {f : filter β} {m : α → β} (inj : function.injective m)
-  (large : set.range m ∈ f) (S : set α) : S ∈ comap m f ↔ m '' S ∈ f :=
+  (large : set.range m ∈ f) {S : set α} : S ∈ comap m f ↔ m '' S ∈ f :=
 by rw [← image_mem_map_iff inj, map_comap large]
 
 lemma le_of_map_le_map_inj' {f g : filter α} {m : α → β} {s : set α}

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1516,8 +1516,7 @@ le_antisymm
   le_comap_map
 
 lemma mem_comap_iff {f : filter β} {m : α → β} (inj : function.injective m)
-  (large : set.range m ∈ f) (S : set α) :
-  S ∈ comap m f ↔ m '' S ∈ f :=
+  (large : set.range m ∈ f) (S : set α) : S ∈ comap m f ↔ m '' S ∈ f :=
 begin
   refine ⟨image_mem_sets large, _⟩,
   intro h,

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1515,6 +1515,24 @@ le_antisymm
     by simp only [this, subset.refl]⟩)
   le_comap_map
 
+lemma mem_comap_iff {f : filter β} {m : α → β} (inj : function.injective m)
+  (large : set.range m ∈ f) (S : set α) :
+  S ∈ comap m f ↔ m '' S ∈ f :=
+begin
+  refine ⟨image_mem_sets large, _⟩,
+  intro h,
+  suffices : S = m ⁻¹' (m '' S),
+  { rw this,
+    change _ ∈ map m (comap m f),
+    rw map_comap large,
+    assumption },
+  ext x,
+  refine ⟨λ h1, ⟨x, h1, rfl⟩, λ h1, _⟩,
+  rcases h1 with ⟨z,hz,h1⟩,
+  rw ← inj h1,
+  assumption,
+end
+
 lemma le_of_map_le_map_inj' {f g : filter α} {m : α → β} {s : set α}
   (hsf : s ∈ f) (hsg : s ∈ g) (hm : ∀x∈s, ∀y∈s, m x = m y → x = y)
   (h : map m f ≤ map m g) : f ≤ g :=

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1521,16 +1521,9 @@ lemma mem_comap_iff {f : filter β} {m : α → β} (inj : function.injective m)
 begin
   refine ⟨image_mem_sets large, _⟩,
   intro h,
-  suffices : S = m ⁻¹' (m '' S),
-  { rw this,
-    change _ ∈ map m (comap m f),
-    rw map_comap large,
-    assumption },
-  ext x,
-  refine ⟨λ h1, ⟨x, h1, rfl⟩, λ h1, _⟩,
-  rcases h1 with ⟨z,hz,h1⟩,
-  rw ← inj h1,
-  assumption,
+  rw ← preimage_image_eq S inj,
+  change _ ∈ map m (comap m f),
+  rwa map_comap large,
 end
 
 lemma le_of_map_le_map_inj' {f g : filter α} {m : α → β} {s : set α}

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -1254,12 +1254,15 @@ iff.rfl
 lemma image_mem_map (hs : s ∈ f) : m '' s ∈ map m f :=
 f.sets_of_superset hs $ subset_preimage_image m s
 
+lemma image_mem_map_iff (hf : function.injective m) : m '' s ∈ map m f ↔ s ∈ f :=
+⟨λ h, by rwa [← preimage_image_eq s hf], image_mem_map⟩
+
 lemma range_mem_map : range m ∈ map m f :=
 by rw ←image_univ; exact image_mem_map univ_mem_sets
 
 lemma mem_map_sets_iff : t ∈ map m f ↔ (∃s∈f, m '' s ⊆ t) :=
 iff.intro
-  (assume ht, ⟨set.preimage m t, ht, image_preimage_subset _ _⟩)
+  (assume ht, ⟨m ⁻¹' t, ht, image_preimage_subset _ _⟩)
   (assume ⟨s, hs, ht⟩, mem_sets_of_superset (image_mem_map hs) ht)
 
 @[simp] lemma map_id : filter.map id f = f :=
@@ -1506,24 +1509,14 @@ image_mem_sets (by simp [h]) W_in
 
 lemma comap_map {f : filter α} {m : α → β} (h : function.injective m) :
   comap m (map m f) = f :=
-have ∀s, preimage m (image m s) = s,
-  from assume s, preimage_image_eq s h,
 le_antisymm
-  (assume s hs, ⟨
-    image m s,
-    f.sets_of_superset hs $ by simp only [this, subset.refl],
-    by simp only [this, subset.refl]⟩)
+  (assume s hs, mem_sets_of_superset (preimage_mem_comap $ image_mem_map hs) $
+    by simp only [preimage_image_eq s h])
   le_comap_map
 
 lemma mem_comap_iff {f : filter β} {m : α → β} (inj : function.injective m)
   (large : set.range m ∈ f) (S : set α) : S ∈ comap m f ↔ m '' S ∈ f :=
-begin
-  refine ⟨image_mem_sets large, _⟩,
-  intro h,
-  rw ← preimage_image_eq S inj,
-  change _ ∈ map m (comap m f),
-  rwa map_comap large,
-end
+by rw [← image_mem_map_iff inj, map_comap large]
 
 lemma le_of_map_le_map_inj' {f g : filter α} {m : α → β} {s : set α}
   (hsf : s ∈ f) (hsg : s ∈ g) (hm : ∀x∈s, ∀y∈s, m x = m y → x = y)

--- a/src/order/filter/ultrafilter.lean
+++ b/src/order/filter/ultrafilter.lean
@@ -273,20 +273,14 @@ def ultrafilter.comap {m : α → β} (u : ultrafilter β) (inj : function.injec
     simp_rw filter.mem_comap_iff inj large,
     split,
     { intros h c,
-      have : m '' Sᶜ ⊆ (m '' S)ᶜ,
-      { rintro _ ⟨_, _, rfl⟩ ⟨z, hz, h⟩,
-        rw inj h at *,
-        contradiction },
-      replace c := u.1.sets_of_superset c this,
+      replace c := u.1.sets_of_superset c (image_compl_subset inj),
       erw ultrafilter_iff_compl_mem_iff_not_mem.mp u.2 at c,
       contradiction },
     { intros h,
-      suffices : m '' S = set.range m ∩ (m '' Sᶜ)ᶜ,
-      { rw this,
-        refine u.1.inter_sets large _,
-        erw ultrafilter_iff_compl_mem_iff_not_mem.mp u.2,
-        assumption },
-      rw set.range_inter_compl_image_comlp_eq_image inj }
+      rw ← range_inter_compl_image_compl_eq_image inj,
+      refine u.1.inter_sets large _,
+      erw ultrafilter_iff_compl_mem_iff_not_mem.mp u.2,
+      assumption },
   end }
 
 /-- The ultra-filter extending the cofinite filter. -/

--- a/src/order/filter/ultrafilter.lean
+++ b/src/order/filter/ultrafilter.lean
@@ -266,22 +266,9 @@ The pullback of an ultrafilter along an injection whose image is large
 with respect to the given ultrafilter. -/
 def ultrafilter.comap {m : α → β} (u : ultrafilter β) (inj : function.injective m)
   (large : set.range m ∈ u.1) : ultrafilter α :=
-{ val := filter.comap m u.1,
-  property := begin
-    rw ultrafilter_iff_compl_mem_iff_not_mem',
-    intros S,
-    simp_rw filter.mem_comap_iff inj large,
-    split,
-    { intros h c,
-      replace c := u.1.sets_of_superset c (image_compl_subset inj),
-      erw ultrafilter_iff_compl_mem_iff_not_mem.mp u.2 at c,
-      contradiction },
-    { intros h,
-      rw ← range_inter_compl_image_compl_eq_image inj,
-      refine u.1.inter_sets large _,
-      erw ultrafilter_iff_compl_mem_iff_not_mem.mp u.2,
-      assumption },
-  end }
+⟨comap m u.1, u.2.1.comap_of_range_mem large, λ g hg hgu s hs,
+  (mem_comap_iff inj large).2 $ u.2.2 (g.map m) (hg.map m) (map_le_iff_le_comap.2 hgu)
+    (image_mem_map hs)⟩
 
 /-- The ultra-filter extending the cofinite filter. -/
 noncomputable def hyperfilter : filter α := ultrafilter_of cofinite

--- a/src/order/filter/ultrafilter.lean
+++ b/src/order/filter/ultrafilter.lean
@@ -286,7 +286,7 @@ def ultrafilter.comap {m : α → β} (u : ultrafilter β) (inj : function.injec
         refine u.1.inter_sets large _,
         erw ultrafilter_iff_compl_mem_iff_not_mem.mp u.2,
         assumption },
-      simp, }
+      rw range_inter_compl_image_comlp_eq_image inj }
   end }
 
 /-- The ultra-filter extending the cofinite filter. -/

--- a/src/order/filter/ultrafilter.lean
+++ b/src/order/filter/ultrafilter.lean
@@ -261,40 +261,32 @@ instance ultrafilter.inhabited [inhabited α] : inhabited (ultrafilter α) := �
 
 instance {F : ultrafilter α} : ne_bot F.1 := F.2.1
 
+/--
+The pullback of an ultrafilter along an injection whose image is large
+with respect to the given ultrafilter. -/
 def ultrafilter.comap {m : α → β} (u : ultrafilter β) (inj : function.injective m)
   (large : set.range m ∈ u.1) : ultrafilter α :=
 { val := filter.comap m u.1,
   property := begin
     rw ultrafilter_iff_compl_mem_iff_not_mem',
     intros S,
+    simp_rw filter.mem_comap_iff inj large,
     split,
     { intros h c,
-      rw filter.mem_comap_iff inj large at *,
       have : m '' Sᶜ ⊆ (m '' S)ᶜ,
-      { rintro _ ⟨_,_,rfl⟩ ⟨z,hz,h⟩,
+      { rintro _ ⟨_, _, rfl⟩ ⟨z, hz, h⟩,
         rw inj h at *,
         contradiction },
       replace c := u.1.sets_of_superset c this,
       erw ultrafilter_iff_compl_mem_iff_not_mem.mp u.2 at c,
       contradiction },
     { intros h,
-      rw filter.mem_comap_iff inj large at *,
       suffices : m '' S = set.range m ∩ (m '' Sᶜ)ᶜ,
       { rw this,
         refine u.1.inter_sets large _,
         erw ultrafilter_iff_compl_mem_iff_not_mem.mp u.2,
         assumption },
-      ext x,
-      split,
-      { rintro ⟨y,hy,rfl⟩,
-        refine ⟨⟨y,rfl⟩,_⟩,
-        rintro ⟨w,hw,h⟩,
-        rw inj h at hw,
-        contradiction },
-      { rintro ⟨⟨y,hy,rfl⟩,h1⟩,
-        refine ⟨y,_,rfl⟩,
-        by_contra c,
-        exact h1 ⟨y,c,rfl⟩ } },
+      simp, }
   end }
 
 /-- The ultra-filter extending the cofinite filter. -/

--- a/src/order/filter/ultrafilter.lean
+++ b/src/order/filter/ultrafilter.lean
@@ -261,6 +261,42 @@ instance ultrafilter.inhabited [inhabited α] : inhabited (ultrafilter α) := �
 
 instance {F : ultrafilter α} : ne_bot F.1 := F.2.1
 
+def ultrafilter.comap {m : α → β} (u : ultrafilter β) (inj : function.injective m)
+  (large : set.range m ∈ u.1) : ultrafilter α :=
+{ val := filter.comap m u.1,
+  property := begin
+    rw ultrafilter_iff_compl_mem_iff_not_mem',
+    intros S,
+    split,
+    { intros h c,
+      rw filter.mem_comap_iff inj large at *,
+      have : m '' Sᶜ ⊆ (m '' S)ᶜ,
+      { rintro _ ⟨_,_,rfl⟩ ⟨z,hz,h⟩,
+        rw inj h at *,
+        contradiction },
+      replace c := u.1.sets_of_superset c this,
+      erw ultrafilter_iff_compl_mem_iff_not_mem.mp u.2 at c,
+      contradiction },
+    { intros h,
+      rw filter.mem_comap_iff inj large at *,
+      suffices : m '' S = set.range m ∩ (m '' Sᶜ)ᶜ,
+      { rw this,
+        refine u.1.inter_sets large _,
+        erw ultrafilter_iff_compl_mem_iff_not_mem.mp u.2,
+        assumption },
+      ext x,
+      split,
+      { rintro ⟨y,hy,rfl⟩,
+        refine ⟨⟨y,rfl⟩,_⟩,
+        rintro ⟨w,hw,h⟩,
+        rw inj h at hw,
+        contradiction },
+      { rintro ⟨⟨y,hy,rfl⟩,h1⟩,
+        refine ⟨y,_,rfl⟩,
+        by_contra c,
+        exact h1 ⟨y,c,rfl⟩ } },
+  end }
+
 /-- The ultra-filter extending the cofinite filter. -/
 noncomputable def hyperfilter : filter α := ultrafilter_of cofinite
 

--- a/src/order/filter/ultrafilter.lean
+++ b/src/order/filter/ultrafilter.lean
@@ -286,7 +286,7 @@ def ultrafilter.comap {m : α → β} (u : ultrafilter β) (inj : function.injec
         refine u.1.inter_sets large _,
         erw ultrafilter_iff_compl_mem_iff_not_mem.mp u.2,
         assumption },
-      rw range_inter_compl_image_comlp_eq_image inj }
+      rw set.range_inter_compl_image_comlp_eq_image inj }
   end }
 
 /-- The ultra-filter extending the cofinite filter. -/


### PR DESCRIPTION
This PR adds the fact that the `comap` of an ultrafilter along a "large" embedding (meaning the image is large w.r.t. the ultrafilter) is again an ultrafilter.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
