### PR TITLE
[Merged by Bors] - chore(topology/continuous_on): change type of `continuous_on.comp_continuous`

### DIFF
--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -578,11 +578,10 @@ lemma continuous.comp_continuous_on {g : β → γ} {f : α → β} {s : set α}
 hg.continuous_on.comp hf subset_preimage_univ
 
 lemma continuous_on.comp_continuous {g : β → γ} {f : α → β} {s : set β}
-  (hg : continuous_on g s) (hf : continuous f) (hfg : range f ⊆ s) : continuous (g ∘ f) :=
+  (hg : continuous_on g s) (hf : continuous f) (hs : ∀ x, f x ∈ s) : continuous (g ∘ f) :=
 begin
   rw continuous_iff_continuous_on_univ at *,
-  apply hg.comp hf,
-  rwa [← image_subset_iff, image_univ]
+  exact hg.comp hf (λ x _, hs x),
 end
 
 lemma continuous_within_at.preimage_mem_nhds_within {f : α → β} {x : α} {s : set α} {t : set β}

--- a/src/topology/path_connected.lean
+++ b/src/topology/path_connected.lean
@@ -209,7 +209,7 @@ lemma extend_of_one_le {X : Type*} [topological_space X] {a b : X}
 /-- The path obtained from a map defined on `ℝ` by restriction to the unit interval. -/
 def of_line {f : ℝ → X} (hf : continuous_on f I) (h₀ : f 0 = x) (h₁ : f 1 = y) : path x y :=
 { to_fun := f ∘ coe,
-  continuous' := hf.comp_continuous continuous_subtype_coe (by rw subtype.range_coe),
+  continuous' := hf.comp_continuous continuous_subtype_coe subtype.prop,
   source' := h₀,
   target' := h₁ }
 


### PR DESCRIPTION
Use `∀ x, f x ∈ s` instead of `range f ⊆ s`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
