### PR TITLE
[Merged by Bors] - chore(algebra/ring): delete a duplicate instance

### DIFF
--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -419,10 +419,6 @@ instance comm_semiring.to_comm_monoid_with_zero [comm_semiring α] : comm_monoid
 section comm_semiring
 variables [comm_semiring α] [comm_semiring β] {a b c : α}
 
-@[priority 100] -- see Note [lower instance priority]
-instance comm_semiring.comm_monoid_with_zero : comm_monoid_with_zero α :=
-{ .. (‹_› : comm_semiring α) }
-
 /-- Pullback a `semiring` instance along an injective function. -/
 protected def function.injective.comm_semiring [has_zero γ] [has_one γ] [has_add γ] [has_mul γ]
   (f : γ → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)


### PR DESCRIPTION
In #3303 and #3296 which were merged 1 day apart two versions of the instance comm_monoid_with_zero from a comm_semiring were added 5 lines apart in the file, delete one.


---

We have comm_semiring.to_comm_monoid_with_zero and comm_semiring.comm_monoid_with_zero now
 I figure we should delete one, but I have no idea which of the two names and definitions people prefer?