### PR TITLE
[Merged by Bors] - chore(data/multiset/basic): make `card` a bundled `add_monoid_hom`

### DIFF
--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -47,7 +47,7 @@ quot.lift_on s sizeof $ λ l₁ l₂, perm.sizeof_eq_sizeof
 
 instance has_sizeof [has_sizeof α] : has_sizeof (multiset α) := ⟨multiset.sizeof⟩
 
-/- empty multiset -/
+/-! ### Empty multiset -/
 
 /-- `0 : multiset α` is the empty set -/
 protected def zero : multiset α := @nil α
@@ -62,7 +62,7 @@ instance : inhabited (multiset α)  := ⟨0⟩
 theorem coe_eq_zero (l : list α) : (l : multiset α) = 0 ↔ l = [] :=
 iff.trans coe_eq_coe perm_nil
 
-/- cons -/
+/- ### `multiset.cons` -/
 
 /-- `cons a s` is the multiset which contains `s` plus one more
   instance of `a`. -/
@@ -215,7 +215,7 @@ end
 
 end mem
 
-/- subset -/
+/- ### `multiset.subset` -/
 section subset
 
 /-- `s ⊆ t` is the lift of the list subset relation. It means that any
@@ -268,7 +268,7 @@ by rw [←multiset.mem_coe, multiset.coe_to_list]
 
 end to_list
 
-/- multiset order -/
+/- ### Partial order on `multiset`s -/
 
 /-- `s ≤ t` means that `s` is a sublist of `t` (up to permutation).
   Equivalently, `s ≤ t` means that `count a s ≤ count a t` for all `a`. -/
@@ -330,16 +330,95 @@ begin
     ((sublist_or_mem_of_sublist s).resolve_right m₁).subperm)
 end
 
-/- cardinality -/
+/-! ### Additive monoid -/
+
+/-- The sum of two multisets is the lift of the list append operation.
+  This adds the multiplicities of each element,
+  i.e. `count a (s + t) = count a s + count a t`. -/
+protected def add (s₁ s₂ : multiset α) : multiset α :=
+quotient.lift_on₂ s₁ s₂ (λ l₁ l₂, ((l₁ ++ l₂ : list α) : multiset α)) $
+  λ v₁ v₂ w₁ w₂ p₁ p₂, quot.sound $ p₁.append p₂
+
+instance : has_add (multiset α) := ⟨multiset.add⟩
+
+@[simp] theorem coe_add (s t : list α) : (s + t : multiset α) = (s ++ t : list α) := rfl
+
+protected theorem add_comm (s t : multiset α) : s + t = t + s :=
+quotient.induction_on₂ s t $ λ l₁ l₂, quot.sound perm_append_comm
+
+protected theorem zero_add (s : multiset α) : 0 + s = s :=
+quot.induction_on s $ λ l, rfl
+
+theorem singleton_add (a : α) (s : multiset α) : ↑[a] + s = a ::ₘ s := rfl
+
+protected theorem add_le_add_left (s) {t u : multiset α} : s + t ≤ s + u ↔ t ≤ u :=
+quotient.induction_on₃ s t u $ λ l₁ l₂ l₃, subperm_append_left _
+
+protected theorem add_left_cancel (s) {t u : multiset α} (h : s + t = s + u) : t = u :=
+le_antisymm ((multiset.add_le_add_left _).1 (le_of_eq h))
+  ((multiset.add_le_add_left _).1 (le_of_eq h.symm))
+
+instance : ordered_cancel_add_comm_monoid (multiset α) :=
+{ zero                  := 0,
+  add                   := (+),
+  add_comm              := multiset.add_comm,
+  add_assoc             := λ s₁ s₂ s₃, quotient.induction_on₃ s₁ s₂ s₃ $ λ l₁ l₂ l₃,
+    congr_arg coe $ append_assoc l₁ l₂ l₃,
+  zero_add              := multiset.zero_add,
+  add_zero              := λ s, by rw [multiset.add_comm, multiset.zero_add],
+  add_left_cancel       := multiset.add_left_cancel,
+  add_right_cancel      := λ s₁ s₂ s₃ h, multiset.add_left_cancel s₂ $
+    by simpa [multiset.add_comm] using h,
+  add_le_add_left       := λ s₁ s₂ h s₃, (multiset.add_le_add_left _).2 h,
+  le_of_add_le_add_left := λ s₁ s₂ s₃, (multiset.add_le_add_left _).1,
+  ..@multiset.partial_order α }
+
+
+theorem le_add_right (s t : multiset α) : s ≤ s + t :=
+by simpa using add_le_add_left (zero_le t) s
+
+theorem le_add_left (s t : multiset α) : s ≤ t + s :=
+by simpa using add_le_add_right (zero_le t) s
+theorem le_iff_exists_add {s t : multiset α} : s ≤ t ↔ ∃ u, t = s + u :=
+⟨λ h, le_induction_on h $ λ l₁ l₂ s,
+  let ⟨l, p⟩ := s.exists_perm_append in ⟨l, quot.sound p⟩,
+ λ ⟨u, e⟩, e.symm ▸ le_add_right _ _⟩
+
+instance : canonically_ordered_add_monoid (multiset α) :=
+{ lt_of_add_lt_add_left := @lt_of_add_lt_add_left _ _,
+  le_iff_exists_add     := @le_iff_exists_add _,
+  bot                   := 0,
+  bot_le                := multiset.zero_le,
+  ..multiset.ordered_cancel_add_comm_monoid }
+
+@[simp] theorem cons_add (a : α) (s t : multiset α) : a ::ₘ s + t = a ::ₘ (s + t) :=
+by rw [← singleton_add, ← singleton_add, add_assoc]
+
+@[simp] theorem add_cons (a : α) (s t : multiset α) : s + a ::ₘ t = a ::ₘ (s + t) :=
+by rw [add_comm, cons_add, add_comm]
+
+@[simp] theorem mem_add {a : α} {s t : multiset α} : a ∈ s + t ↔ a ∈ s ∨ a ∈ t :=
+quotient.induction_on₂ s t $ λ l₁ l₂, mem_append
+
+/-! ### Cardinality -/
 
 /-- The cardinality of a multiset is the sum of the multiplicities
   of all its elements, or simply the length of the underlying list. -/
-def card (s : multiset α) : ℕ :=
-quot.lift_on s length $ λ l₁ l₂, perm.length_eq
+def card : multiset α →+ ℕ :=
+{ to_fun := λ s, quot.lift_on s length $ λ l₁ l₂, perm.length_eq,
+  map_zero' := rfl,
+  map_add' := λ s t, quotient.induction_on₂ s t length_append }
 
 @[simp] theorem coe_card (l : list α) : card (l : multiset α) = length l := rfl
 
 @[simp] theorem card_zero : @card α 0 = 0 := rfl
+
+theorem card_add (s t : multiset α) : card (s + t) = card s + card t :=
+card.map_add s t
+
+lemma card_smul (s : multiset α) (n : ℕ) :
+  (n •ℕ s).card = n * s.card :=
+by rw [card.map_nsmul s n, nat.nsmul_eq_mul]
 
 @[simp] theorem card_cons (a : α) (s : multiset α) : card (a ::ₘ s) = card s + 1 :=
 quot.induction_on s $ λ l, rfl
@@ -387,7 +466,7 @@ multiset.strong_induction_on s $ assume s,
 multiset.induction_on s (λ _, h₀) $ λ a s _ ih, h₁ _ _ $
 λ t h, ih _ $ lt_of_le_of_lt h $ lt_cons_self _ _
 
-/- singleton -/
+/- ### Singleton -/
 instance : has_singleton α (multiset α) := ⟨λ a, a ::ₘ 0⟩
 
 instance : is_lawful_singleton α (multiset α) := ⟨λ a, rfl⟩
@@ -412,84 +491,7 @@ theorem card_eq_one {s : multiset α} : card s = 1 ↔ ∃ a, s = a ::ₘ 0 :=
   (list.length_eq_one.1 h).imp $ λ a, congr_arg coe,
  λ ⟨a, e⟩, e.symm ▸ rfl⟩
 
-/- add -/
-
-/-- The sum of two multisets is the lift of the list append operation.
-  This adds the multiplicities of each element,
-  i.e. `count a (s + t) = count a s + count a t`. -/
-protected def add (s₁ s₂ : multiset α) : multiset α :=
-quotient.lift_on₂ s₁ s₂ (λ l₁ l₂, ((l₁ ++ l₂ : list α) : multiset α)) $
-  λ v₁ v₂ w₁ w₂ p₁ p₂, quot.sound $ p₁.append p₂
-
-instance : has_add (multiset α) := ⟨multiset.add⟩
-
-@[simp] theorem coe_add (s t : list α) : (s + t : multiset α) = (s ++ t : list α) := rfl
-
-protected theorem add_comm (s t : multiset α) : s + t = t + s :=
-quotient.induction_on₂ s t $ λ l₁ l₂, quot.sound perm_append_comm
-
-protected theorem zero_add (s : multiset α) : 0 + s = s :=
-quot.induction_on s $ λ l, rfl
-
-theorem singleton_add (a : α) (s : multiset α) : ↑[a] + s = a ::ₘ s := rfl
-
-protected theorem add_le_add_left (s) {t u : multiset α} : s + t ≤ s + u ↔ t ≤ u :=
-quotient.induction_on₃ s t u $ λ l₁ l₂ l₃, subperm_append_left _
-
-protected theorem add_left_cancel (s) {t u : multiset α} (h : s + t = s + u) : t = u :=
-le_antisymm ((multiset.add_le_add_left _).1 (le_of_eq h))
-  ((multiset.add_le_add_left _).1 (le_of_eq h.symm))
-
-instance : ordered_cancel_add_comm_monoid (multiset α) :=
-{ zero                  := 0,
-  add                   := (+),
-  add_comm              := multiset.add_comm,
-  add_assoc             := λ s₁ s₂ s₃, quotient.induction_on₃ s₁ s₂ s₃ $ λ l₁ l₂ l₃,
-    congr_arg coe $ append_assoc l₁ l₂ l₃,
-  zero_add              := multiset.zero_add,
-  add_zero              := λ s, by rw [multiset.add_comm, multiset.zero_add],
-  add_left_cancel       := multiset.add_left_cancel,
-  add_right_cancel      := λ s₁ s₂ s₃ h, multiset.add_left_cancel s₂ $
-    by simpa [multiset.add_comm] using h,
-  add_le_add_left       := λ s₁ s₂ h s₃, (multiset.add_le_add_left _).2 h,
-  le_of_add_le_add_left := λ s₁ s₂ s₃, (multiset.add_le_add_left _).1,
-  ..@multiset.partial_order α }
-
-@[simp] theorem cons_add (a : α) (s t : multiset α) : a ::ₘ s + t = a ::ₘ (s + t) :=
-by rw [← singleton_add, ← singleton_add, add_assoc]
-
-@[simp] theorem add_cons (a : α) (s t : multiset α) : s + a ::ₘ t = a ::ₘ (s + t) :=
-by rw [add_comm, cons_add, add_comm]
-
-theorem le_add_right (s t : multiset α) : s ≤ s + t :=
-by simpa using add_le_add_left (zero_le t) s
-
-theorem le_add_left (s t : multiset α) : s ≤ t + s :=
-by simpa using add_le_add_right (zero_le t) s
-
-@[simp] theorem card_add (s t : multiset α) : card (s + t) = card s + card t :=
-quotient.induction_on₂ s t length_append
-
-lemma card_smul (s : multiset α) (n : ℕ) :
-  (n •ℕ s).card = n * s.card :=
-by induction n; simp [succ_nsmul, *, nat.succ_mul]; cc
-
-@[simp] theorem mem_add {a : α} {s t : multiset α} : a ∈ s + t ↔ a ∈ s ∨ a ∈ t :=
-quotient.induction_on₂ s t $ λ l₁ l₂, mem_append
-
-theorem le_iff_exists_add {s t : multiset α} : s ≤ t ↔ ∃ u, t = s + u :=
-⟨λ h, le_induction_on h $ λ l₁ l₂ s,
-  let ⟨l, p⟩ := s.exists_perm_append in ⟨l, quot.sound p⟩,
-λ⟨u, e⟩, e.symm ▸ le_add_right s u⟩
-
-instance : canonically_ordered_add_monoid (multiset α) :=
-{ lt_of_add_lt_add_left := @lt_of_add_lt_add_left _ _,
-  le_iff_exists_add     := @le_iff_exists_add _,
-  bot                   := 0,
-  bot_le                := multiset.zero_le,
-  ..multiset.ordered_cancel_add_comm_monoid }
-
-/- repeat -/
+/- ### `multiset.repeat` -/
 
 /-- `repeat a n` is the multiset containing only `a` with multiplicity `n`. -/
 def repeat (a : α) (n : ℕ) : multiset α := repeat a n
@@ -520,7 +522,7 @@ theorem repeat_subset_singleton : ∀ (a : α) n, repeat a n ⊆ a ::ₘ 0 := re
 theorem repeat_le_coe {a : α} {n} {l : list α} : repeat a n ≤ l ↔ list.repeat a n <+ l :=
 ⟨λ ⟨l', p, s⟩, (perm_repeat.1 p) ▸ s, sublist.subperm⟩
 
-/- erase -/
+/- ### Erasing one copy of an element -/
 section erase
 variables [decidable_eq α] {s t : multiset α} {a b : α}
 
@@ -612,7 +614,7 @@ end erase
 @[simp] theorem coe_reverse (l : list α) : (reverse l : multiset α) = l :=
 quot.sound $ reverse_perm _
 
-/- map -/
+/- ### `multiset.map` -/
 
 /-- `map f s` is the lift of the list `map` operation. The multiplicity
   of `b` in `map f s` is the number of `a ∈ s` (counting multiplicity)
@@ -690,7 +692,7 @@ le_induction_on h $ λ l₁ l₂ h, (h.map f).subperm
 @[simp] theorem map_subset_map {f : α → β} {s t : multiset α} (H : s ⊆ t) : map f s ⊆ map f t :=
 λ b m, let ⟨a, h, e⟩ := mem_map.1 m in mem_map.2 ⟨a, H h, e⟩
 
-/- fold -/
+/- ### `multiset.fold` -/
 
 /-- `foldl f H b s` is the lift of the list operation `foldl f b l`,
   which folds `f` over the multiset. It is well defined when `f` is right-commutative,
@@ -932,7 +934,7 @@ multiset.induction_on S (by simp) $
 @[simp] theorem card_join (S) : card (@join α S) = sum (map card S) :=
 multiset.induction_on S (by simp) (by simp)
 
-/- bind -/
+/- ### `multiset.bind` -/
 
 /-- `bind s f` is the monad bind operation, defined as `join (map f s)`.
   It is the union of `f a` as `a` ranges over `s`. -/
@@ -1001,7 +1003,7 @@ lemma prod_bind [comm_monoid β] (s : multiset α) (t : α → multiset β) :
   prod (bind s t) = prod (s.map $ λa, prod (t a)) :=
 multiset.induction_on s (by simp) (assume a s ih, by simp [ih, cons_bind])
 
-/- product -/
+/- ### Product of two `multiset`s -/
 
 /-- The multiplicity of `(a, b)` in `product s t` is
   the product of the multiplicity of `a` in `s` and `b` in `t`. -/
@@ -1035,7 +1037,7 @@ multiset.induction_on s (λ t u, rfl) $ λ a s IH t u,
 @[simp] theorem card_product (s : multiset α) (t : multiset β) : card (product s t) = card s * card t :=
 by simp [product, repeat, (∘), mul_comm]
 
-/- sigma -/
+/- ### Sigma multiset -/
 section
 variable {σ : α → Type*}
 
@@ -1076,7 +1078,7 @@ by simp [multiset.sigma, (∘)]
 
 end
 
-/- map for partial functions -/
+/- ### Map for partial functions -/
 
 /-- Lift of the list `pmap` operation. Map a partial function `f` over a multiset
   `s` whose elements are all in the domain of `f`. -/
@@ -1182,7 +1184,7 @@ decidable_of_decidable_of_iff
 
 end decidable_pi_exists
 
-/- subtraction -/
+/- ### Subtraction -/
 section
 variables [decidable_eq α] {s t u : multiset α} {a b : α}
 
@@ -1259,7 +1261,7 @@ sub_le_iff_le_add.2 (le_add_right _ _)
 @[simp] theorem card_sub {s t : multiset α} (h : t ≤ s) : card (s - t) = card s - card t :=
 (nat.sub_eq_of_eq_add $ by rw [add_comm, ← card_add, sub_add_cancel h]).symm
 
-/- union -/
+/- ### Union -/
 
 /-- `s ∪ t` is the lattice join operation with respect to the
   multiset `≤`. The multiplicity of `a` in `s ∪ t` is the maximum
@@ -1291,7 +1293,7 @@ by rw ← eq_union_left h₂; exact union_le_union_right h₁ t
 quotient.induction_on₂ s t $ λ l₁ l₂,
 congr_arg coe (by rw [list.map_append f, list.map_diff finj])
 
-/- inter -/
+/- ### Intersection -/
 
 /-- `s ∩ t` is the lattice meet operation with respect to the
   multiset `≤`. The multiplicity of `a` in `s ∩ t` is the minimum
@@ -1429,8 +1431,7 @@ by rw [sub_add_inter s t, sub_add_cancel (inter_le_left _ _)]
 
 end
 
-
-/- filter -/
+/- ### `multiset.filter` -/
 section
 variables (p : α → Prop) [decidable_pred p]
 
@@ -1539,7 +1540,7 @@ theorem filter_add_not (s : multiset α) :
   filter p s + filter (λ a, ¬ p a) s = s :=
 by rw [filter_add_filter, filter_eq_self.2, filter_eq_nil.2]; simp [decidable.em]
 
-/- filter_map -/
+/- ### Simultaneously filter and map elements of a multiset -/
 
 /-- `filter_map f s` is a combination filter/map operation on `s`.
   The function `f : α → option β` is applied to each element of `s`;
@@ -1658,7 +1659,7 @@ countp_pos.2 ⟨_, h, pa⟩
 
 end
 
-/- count -/
+/- ### Multiplicity of an element -/
 
 section
 variable [decidable_eq α]
@@ -1706,7 +1707,7 @@ by simp [count, countp_pos]
 theorem count_eq_zero_of_not_mem {a : α} {s : multiset α} (h : a ∉ s) : count a s = 0 :=
 by_contradiction $ λ h', h $ count_pos.1 (nat.pos_of_ne_zero h')
 
-theorem count_eq_zero {a : α} {s : multiset α} : count a s = 0 ↔ a ∉ s :=
+@[simp] theorem count_eq_zero {a : α} {s : multiset α} : count a s = 0 ↔ a ∉ s :=
 iff_not_comm.1 $ count_pos.symm.trans pos_iff_ne_zero
 
 theorem count_ne_zero {a : α} {s : multiset α} : count a s ≠ 0 ↔ a ∈ s :=
@@ -1815,7 +1816,7 @@ begin
   simp [h0],
 end
 
-/- relator -/
+/- ### Lift a relation to `multiset`s -/
 
 section rel
 
@@ -1985,7 +1986,7 @@ match s, exists_multiset_eq_map_quot_mk s with _, ⟨t, rfl⟩ := assume h, h _ 
 
 end quot
 
-/- disjoint -/
+/- ### Disjoint multisets -/
 
 /-- `disjoint s t` means that `s` and `t` have no elements in common. -/
 def disjoint (s t : multiset α) : Prop := ∀ ⦃a⦄, a ∈ s → a ∈ t → false
@@ -2078,8 +2079,8 @@ namespace multiset
 section choose
 variables (p : α → Prop) [decidable_pred p] (l : multiset α)
 
-/-- Given a proof `hp` that there exists a unique `a ∈ l` such that `p a`, `choose p l hp` returns
-that `a`. -/
+/-- Given a proof `hp` that there exists a unique `a ∈ l` such that `p a`, `choose_x p l hp` returns
+that `a` together with proofs of `a ∈ l` and `p a`. -/
 def choose_x : Π hp : (∃! a, a ∈ l ∧ p a), { a // a ∈ l ∧ p a } :=
 quotient.rec_on l (λ l' ex_unique, list.choose_x p l' (exists_of_exists_unique ex_unique)) begin
   intros,
@@ -2093,6 +2094,8 @@ quotient.rec_on l (λ l' ex_unique, list.choose_x p l' (exists_of_exists_unique 
     ...    = y : (z_unique y py).symm }
 end
 
+/-- Given a proof `hp` that there exists a unique `a ∈ l` such that `p a`, `choose p l hp` returns
+that `a`. -/
 def choose (hp : ∃! a, a ∈ l ∧ p a) : α := choose_x p l hp
 
 lemma choose_spec (hp : ∃! a, a ∈ l ∧ p a) : choose p l hp ∈ l ∧ p (choose p l hp) :=

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -62,7 +62,7 @@ instance : inhabited (multiset α)  := ⟨0⟩
 theorem coe_eq_zero (l : list α) : (l : multiset α) = 0 ↔ l = [] :=
 iff.trans coe_eq_coe perm_nil
 
-/- ### `multiset.cons` -/
+/-! ### `multiset.cons` -/
 
 /-- `cons a s` is the multiset which contains `s` plus one more
   instance of `a`. -/
@@ -215,7 +215,7 @@ end
 
 end mem
 
-/- ### `multiset.subset` -/
+/-! ### `multiset.subset` -/
 section subset
 
 /-- `s ⊆ t` is the lift of the list subset relation. It means that any
@@ -268,7 +268,7 @@ by rw [←multiset.mem_coe, multiset.coe_to_list]
 
 end to_list
 
-/- ### Partial order on `multiset`s -/
+/-! ### Partial order on `multiset`s -/
 
 /-- `s ≤ t` means that `s` is a sublist of `t` (up to permutation).
   Equivalently, `s ≤ t` means that `count a s ≤ count a t` for all `a`. -/
@@ -373,7 +373,6 @@ instance : ordered_cancel_add_comm_monoid (multiset α) :=
   le_of_add_le_add_left := λ s₁ s₂ s₃, (multiset.add_le_add_left _).1,
   ..@multiset.partial_order α }
 
-
 theorem le_add_right (s t : multiset α) : s ≤ s + t :=
 by simpa using add_le_add_left (zero_le t) s
 
@@ -466,7 +465,7 @@ multiset.strong_induction_on s $ assume s,
 multiset.induction_on s (λ _, h₀) $ λ a s _ ih, h₁ _ _ $
 λ t h, ih _ $ lt_of_le_of_lt h $ lt_cons_self _ _
 
-/- ### Singleton -/
+/-! ### Singleton -/
 instance : has_singleton α (multiset α) := ⟨λ a, a ::ₘ 0⟩
 
 instance : is_lawful_singleton α (multiset α) := ⟨λ a, rfl⟩
@@ -491,7 +490,7 @@ theorem card_eq_one {s : multiset α} : card s = 1 ↔ ∃ a, s = a ::ₘ 0 :=
   (list.length_eq_one.1 h).imp $ λ a, congr_arg coe,
  λ ⟨a, e⟩, e.symm ▸ rfl⟩
 
-/- ### `multiset.repeat` -/
+/-! ### `multiset.repeat` -/
 
 /-- `repeat a n` is the multiset containing only `a` with multiplicity `n`. -/
 def repeat (a : α) (n : ℕ) : multiset α := repeat a n
@@ -522,7 +521,7 @@ theorem repeat_subset_singleton : ∀ (a : α) n, repeat a n ⊆ a ::ₘ 0 := re
 theorem repeat_le_coe {a : α} {n} {l : list α} : repeat a n ≤ l ↔ list.repeat a n <+ l :=
 ⟨λ ⟨l', p, s⟩, (perm_repeat.1 p) ▸ s, sublist.subperm⟩
 
-/- ### Erasing one copy of an element -/
+/-! ### Erasing one copy of an element -/
 section erase
 variables [decidable_eq α] {s t : multiset α} {a b : α}
 
@@ -614,7 +613,7 @@ end erase
 @[simp] theorem coe_reverse (l : list α) : (reverse l : multiset α) = l :=
 quot.sound $ reverse_perm _
 
-/- ### `multiset.map` -/
+/-! ### `multiset.map` -/
 
 /-- `map f s` is the lift of the list `map` operation. The multiplicity
   of `b` in `map f s` is the number of `a ∈ s` (counting multiplicity)
@@ -692,7 +691,7 @@ le_induction_on h $ λ l₁ l₂ h, (h.map f).subperm
 @[simp] theorem map_subset_map {f : α → β} {s t : multiset α} (H : s ⊆ t) : map f s ⊆ map f t :=
 λ b m, let ⟨a, h, e⟩ := mem_map.1 m in mem_map.2 ⟨a, H h, e⟩
 
-/- ### `multiset.fold` -/
+/-! ### `multiset.fold` -/
 
 /-- `foldl f H b s` is the lift of the list operation `foldl f b l`,
   which folds `f` over the multiset. It is well defined when `f` is right-commutative,
@@ -934,7 +933,7 @@ multiset.induction_on S (by simp) $
 @[simp] theorem card_join (S) : card (@join α S) = sum (map card S) :=
 multiset.induction_on S (by simp) (by simp)
 
-/- ### `multiset.bind` -/
+/-! ### `multiset.bind` -/
 
 /-- `bind s f` is the monad bind operation, defined as `join (map f s)`.
   It is the union of `f a` as `a` ranges over `s`. -/
@@ -1003,7 +1002,7 @@ lemma prod_bind [comm_monoid β] (s : multiset α) (t : α → multiset β) :
   prod (bind s t) = prod (s.map $ λa, prod (t a)) :=
 multiset.induction_on s (by simp) (assume a s ih, by simp [ih, cons_bind])
 
-/- ### Product of two `multiset`s -/
+/-! ### Product of two `multiset`s -/
 
 /-- The multiplicity of `(a, b)` in `product s t` is
   the product of the multiplicity of `a` in `s` and `b` in `t`. -/
@@ -1037,7 +1036,7 @@ multiset.induction_on s (λ t u, rfl) $ λ a s IH t u,
 @[simp] theorem card_product (s : multiset α) (t : multiset β) : card (product s t) = card s * card t :=
 by simp [product, repeat, (∘), mul_comm]
 
-/- ### Sigma multiset -/
+/-! ### Sigma multiset -/
 section
 variable {σ : α → Type*}
 
@@ -1078,7 +1077,7 @@ by simp [multiset.sigma, (∘)]
 
 end
 
-/- ### Map for partial functions -/
+/-! ### Map for partial functions -/
 
 /-- Lift of the list `pmap` operation. Map a partial function `f` over a multiset
   `s` whose elements are all in the domain of `f`. -/
@@ -1184,7 +1183,7 @@ decidable_of_decidable_of_iff
 
 end decidable_pi_exists
 
-/- ### Subtraction -/
+/-! ### Subtraction -/
 section
 variables [decidable_eq α] {s t u : multiset α} {a b : α}
 
@@ -1261,7 +1260,7 @@ sub_le_iff_le_add.2 (le_add_right _ _)
 @[simp] theorem card_sub {s t : multiset α} (h : t ≤ s) : card (s - t) = card s - card t :=
 (nat.sub_eq_of_eq_add $ by rw [add_comm, ← card_add, sub_add_cancel h]).symm
 
-/- ### Union -/
+/-! ### Union -/
 
 /-- `s ∪ t` is the lattice join operation with respect to the
   multiset `≤`. The multiplicity of `a` in `s ∪ t` is the maximum
@@ -1293,7 +1292,7 @@ by rw ← eq_union_left h₂; exact union_le_union_right h₁ t
 quotient.induction_on₂ s t $ λ l₁ l₂,
 congr_arg coe (by rw [list.map_append f, list.map_diff finj])
 
-/- ### Intersection -/
+/-! ### Intersection -/
 
 /-- `s ∩ t` is the lattice meet operation with respect to the
   multiset `≤`. The multiplicity of `a` in `s ∩ t` is the minimum
@@ -1431,7 +1430,7 @@ by rw [sub_add_inter s t, sub_add_cancel (inter_le_left _ _)]
 
 end
 
-/- ### `multiset.filter` -/
+/-! ### `multiset.filter` -/
 section
 variables (p : α → Prop) [decidable_pred p]
 
@@ -1540,7 +1539,7 @@ theorem filter_add_not (s : multiset α) :
   filter p s + filter (λ a, ¬ p a) s = s :=
 by rw [filter_add_filter, filter_eq_self.2, filter_eq_nil.2]; simp [decidable.em]
 
-/- ### Simultaneously filter and map elements of a multiset -/
+/-! ### Simultaneously filter and map elements of a multiset -/
 
 /-- `filter_map f s` is a combination filter/map operation on `s`.
   The function `f : α → option β` is applied to each element of `s`;
@@ -1659,7 +1658,7 @@ countp_pos.2 ⟨_, h, pa⟩
 
 end
 
-/- ### Multiplicity of an element -/
+/-! ### Multiplicity of an element -/
 
 section
 variable [decidable_eq α]
@@ -1816,7 +1815,7 @@ begin
   simp [h0],
 end
 
-/- ### Lift a relation to `multiset`s -/
+/-! ### Lift a relation to `multiset`s -/
 
 section rel
 
@@ -1986,7 +1985,7 @@ match s, exists_multiset_eq_map_quot_mk s with _, ⟨t, rfl⟩ := assume h, h _ 
 
 end quot
 
-/- ### Disjoint multisets -/
+/-! ### Disjoint multisets -/
 
 /-- `disjoint s t` means that `s` and `t` have no elements in common. -/
 def disjoint (s t : multiset α) : Prop := ∀ ⦃a⦄, a ∈ s → a ∈ t → false


### PR DESCRIPTION
Other changes:

* use `/-! ###` in section headers;
* move `add_monoid` section above `card`;
* fix docstrings of `multiset.choose_x` and `multiset.choose`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
