### PR TITLE
[Merged by Bors] - chore(linear_algebra/basic): redefine `restrict`

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -127,9 +127,7 @@ ext $ assume b, rfl
 
 /-- Restrict domain and codomain of an endomorphism. -/
 def restrict (f : M →ₗ[R] M) {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) : p →ₗ[R] p :=
-{ to_fun := λ x, ⟨f x, hf x.1 x.2⟩,
-  map_add' := begin intros, apply set_coe.ext, simp end,
-  map_smul' := begin intros, apply set_coe.ext, simp end }
+(f.dom_restrict p).cod_restrict p $ submodule.forall.2 hf
 
 lemma restrict_apply
   {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) (x : p) :


### PR DESCRIPTION
Use `dom_restrict` and `cod_restrict`

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->