### PR TITLE
[Merged by Bors] - feat(field_theory/galois): Is_galois iff is_galois bot

### DIFF
--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -92,6 +92,17 @@ noncomputable def bot_equiv : (⊥ : intermediate_field F E) ≃ₐ[F] F :=
   bot_equiv (algebra_map F (⊥ : intermediate_field F E) x) = x :=
 alg_equiv.commutes bot_equiv x
 
+noncomputable instance algebra_over_bot : algebra (⊥ : intermediate_field F E) F :=
+  ring_hom.to_algebra intermediate_field.bot_equiv.to_alg_hom.to_ring_hom
+
+instance is_scalar_tower_over_bot : is_scalar_tower (⊥ : intermediate_field F E) F E :=
+is_scalar_tower.of_algebra_map_eq begin intro x,
+  let ϕ := algebra.of_id F (⊥ : subalgebra F E),
+  let ψ := alg_equiv.of_bijective ϕ ((algebra.bot_equiv F E).symm.bijective),
+  change (↑x : E) = ↑(ψ (ψ.symm ⟨x, _⟩)),
+  rw alg_equiv.apply_symm_apply ψ ⟨x, _⟩,
+  refl end
+
 /-- The top intermediate_field is isomorphic to the field. -/
 noncomputable def top_equiv : (⊤ : intermediate_field F E) ≃ₐ[F] E :=
 (subalgebra.equiv_of_eq top_to_subalgebra).trans algebra.top_equiv

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -96,12 +96,15 @@ noncomputable instance algebra_over_bot : algebra (⊥ : intermediate_field F E)
   ring_hom.to_algebra intermediate_field.bot_equiv.to_alg_hom.to_ring_hom
 
 instance is_scalar_tower_over_bot : is_scalar_tower (⊥ : intermediate_field F E) F E :=
-is_scalar_tower.of_algebra_map_eq begin intro x,
+is_scalar_tower.of_algebra_map_eq
+begin
+  intro x,
   let ϕ := algebra.of_id F (⊥ : subalgebra F E),
   let ψ := alg_equiv.of_bijective ϕ ((algebra.bot_equiv F E).symm.bijective),
   change (↑x : E) = ↑(ψ (ψ.symm ⟨x, _⟩)),
   rw alg_equiv.apply_symm_apply ψ ⟨x, _⟩,
-  refl end
+  refl
+end
 
 /-- The top intermediate_field is isomorphic to the field. -/
 noncomputable def top_equiv : (⊤ : intermediate_field F E) ≃ₐ[F] E :=

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -129,10 +129,9 @@ instance is_galois.tower_top_intermediate_field (K : intermediate_field F E) [h 
 lemma is_galois_iff_is_galois_bot : is_galois (⊥ : intermediate_field F E) E ↔ is_galois F E :=
 begin
   split,
-  { intro h,
-    exactI is_galois.tower_top_of_is_galois (⊥ : intermediate_field F E) F E },
-  { intro h,
-    exactI is_galois.tower_top_intermediate_field ⊥ },
+  { introI h,
+    exact is_galois.tower_top_of_is_galois (⊥ : intermediate_field F E) F E },
+  { introI h, apply_instance },
 end
 
 /- More to be added later: Galois is preserved by alg_equiv, is_galois_iff_galois_top -/

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -112,13 +112,46 @@ end is_galois
 
 end
 
+section is_galois_tower
+
+variables {F E : Type*} (K : Type*) [field F] [field K] [field E] [algebra F K] [algebra F E]
+  [algebra K E] [is_scalar_tower F K E]
+
+instance is_galois.tower_top_of_is_galois (h : is_galois F E) : is_galois K E :=
+⟨is_separable_tower_top_of_is_separable K h.1, normal.tower_top_of_normal F K E h.2⟩
+
+instance is_galois.tower_top_intermediate_field (K : intermediate_field F E) [h : is_galois F E] :
+  is_galois K E :=
+⟨is_separable_tower_top_of_is_separable K h.1, normal.tower_top_of_normal F K E h.2⟩
+
+lemma is_galois_iff_is_galois_bot : is_galois (⊥ : intermediate_field F E) E ↔ is_galois F E :=
+begin
+  split,
+  { intro h,
+    letI : algebra (⊥ : intermediate_field F E) F :=
+      ring_hom.to_algebra intermediate_field.bot_equiv.to_alg_hom.to_ring_hom,
+    haveI key : is_scalar_tower (⊥ : intermediate_field F E) F E :=
+      is_scalar_tower.of_algebra_map_eq begin
+        intro x,
+        let ϕ := algebra.of_id F (⊥ : subalgebra F E),
+        let ψ := alg_equiv.of_bijective ϕ ((algebra.bot_equiv F E).symm.bijective),
+        change (↑x : E) = ↑(ψ (ψ.symm ⟨x, _⟩)),
+        rw alg_equiv.apply_symm_apply ψ ⟨x, _⟩,
+        refl
+      end,
+    exact is_galois.tower_top_of_is_galois F h },
+  { intro h,
+    exactI is_galois.tower_top_intermediate_field ⊥ },
+end
+
+/- More to be added later: Galois is preserved by alg_equiv, is_galois_iff_galois_top -/
+
+end is_galois_tower
+
 section galois_correspondence
 
 variables {F : Type*} [field F] {E : Type*} [field E] [algebra F E]
 variables (H : subgroup (E ≃ₐ[F] E)) (K : intermediate_field F E)
-
-instance is_galois.tower_top [h : is_galois F E] : is_galois K E :=
-⟨is_separable_tower_top_of_is_separable K h.1, normal.tower_top_of_normal F K E h.2⟩
 
 namespace intermediate_field
 

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -120,6 +120,7 @@ variables {F E : Type*} (K : Type*) [field F] [field K] [field E] [algebra F K] 
 lemma is_galois.tower_top_of_is_galois (h : is_galois F E) : is_galois K E :=
 ⟨is_separable_tower_top_of_is_separable K h.1, normal.tower_top_of_normal F K E h.2⟩
 
+@[priority 100] -- see Note [lower instance priority]
 instance is_galois.tower_top_intermediate_field (K : intermediate_field F E) [h : is_galois F E] :
   is_galois K E :=
 ⟨is_separable_tower_top_of_is_separable K h.1, normal.tower_top_of_normal F K E h.2⟩

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -114,8 +114,8 @@ end
 
 section is_galois_tower
 
-variables (F K E : Type*) [field F] [field K] [field E] [algebra F K] [algebra F E]
-  [algebra K E] [is_scalar_tower F K E]
+variables (F K E : Type*) [field F] [field K] [field E]
+variables [algebra F K] [algebra F E] [algebra K E] [is_scalar_tower F K E]
 
 lemma is_galois.tower_top_of_is_galois [h : is_galois F E] : is_galois K E :=
 ⟨is_separable_tower_top_of_is_separable K h.1, normal.tower_top_of_normal F K E h.2⟩

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -114,16 +114,17 @@ end
 
 section is_galois_tower
 
-variables {F E : Type*} (K : Type*) [field F] [field K] [field E] [algebra F K] [algebra F E]
+variables (F K E : Type*) [field F] [field K] [field E] [algebra F K] [algebra F E]
   [algebra K E] [is_scalar_tower F K E]
 
 lemma is_galois.tower_top_of_is_galois [h : is_galois F E] : is_galois K E :=
 ⟨is_separable_tower_top_of_is_separable K h.1, normal.tower_top_of_normal F K E h.2⟩
 
+variables {F E}
+
 @[priority 100] -- see Note [lower instance priority]
 instance is_galois.tower_top_intermediate_field (K : intermediate_field F E) [h : is_galois F E] :
-  is_galois K E :=
-⟨is_separable_tower_top_of_is_separable K h.1, normal.tower_top_of_normal F K E h.2⟩
+  is_galois K E := is_galois.tower_top_of_is_galois F K E
 
 lemma is_galois_iff_is_galois_bot : is_galois (⊥ : intermediate_field F E) E ↔ is_galois F E :=
 begin
@@ -140,7 +141,7 @@ begin
         rw alg_equiv.apply_symm_apply ψ ⟨x, _⟩,
         refl
       end,
-    exact @is_galois.tower_top_of_is_galois _ _ _ _ _ _ _ _ _ key _ },
+    exact is_galois.tower_top_of_is_galois (⊥ : intermediate_field F E) F E },
   { intro h,
     exactI is_galois.tower_top_intermediate_field ⊥ },
 end

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -117,7 +117,7 @@ section is_galois_tower
 variables {F E : Type*} (K : Type*) [field F] [field K] [field E] [algebra F K] [algebra F E]
   [algebra K E] [is_scalar_tower F K E]
 
-instance is_galois.tower_top_of_is_galois (h : is_galois F E) : is_galois K E :=
+lemma is_galois.tower_top_of_is_galois (h : is_galois F E) : is_galois K E :=
 ⟨is_separable_tower_top_of_is_separable K h.1, normal.tower_top_of_normal F K E h.2⟩
 
 instance is_galois.tower_top_intermediate_field (K : intermediate_field F E) [h : is_galois F E] :

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -140,7 +140,7 @@ begin
         rw alg_equiv.apply_symm_apply ψ ⟨x, _⟩,
         refl
       end,
-    exact is_galois.tower_top_of_is_galois F h },
+    exact @is_galois.tower_top_of_is_galois _ _ _ _ _ _ _ _ _ key _ },
   { intro h,
     exactI is_galois.tower_top_intermediate_field ⊥ },
 end

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -130,18 +130,7 @@ lemma is_galois_iff_is_galois_bot : is_galois (⊥ : intermediate_field F E) E �
 begin
   split,
   { intro h,
-    letI : algebra (⊥ : intermediate_field F E) F :=
-      ring_hom.to_algebra intermediate_field.bot_equiv.to_alg_hom.to_ring_hom,
-    haveI key : is_scalar_tower (⊥ : intermediate_field F E) F E :=
-      is_scalar_tower.of_algebra_map_eq begin
-        intro x,
-        let ϕ := algebra.of_id F (⊥ : subalgebra F E),
-        let ψ := alg_equiv.of_bijective ϕ ((algebra.bot_equiv F E).symm.bijective),
-        change (↑x : E) = ↑(ψ (ψ.symm ⟨x, _⟩)),
-        rw alg_equiv.apply_symm_apply ψ ⟨x, _⟩,
-        refl
-      end,
-    exact is_galois.tower_top_of_is_galois (⊥ : intermediate_field F E) F E },
+    exactI is_galois.tower_top_of_is_galois (⊥ : intermediate_field F E) F E },
   { intro h,
     exactI is_galois.tower_top_intermediate_field ⊥ },
 end

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -117,7 +117,7 @@ section is_galois_tower
 variables {F E : Type*} (K : Type*) [field F] [field K] [field E] [algebra F K] [algebra F E]
   [algebra K E] [is_scalar_tower F K E]
 
-lemma is_galois.tower_top_of_is_galois (h : is_galois F E) : is_galois K E :=
+lemma is_galois.tower_top_of_is_galois [h : is_galois F E] : is_galois K E :=
 ⟨is_separable_tower_top_of_is_separable K h.1, normal.tower_top_of_normal F K E h.2⟩
 
 @[priority 100] -- see Note [lower instance priority]


### PR DESCRIPTION
Proves that E/F is Galois iff E/bot is Galois.

This is useful in Galois theory because it gives a new way of showing that E/F is Galois:
1) Show that bot is the fixed field of some subgroup
2) Apply `is_galois.of_fixed_field`
3) Apply `is_galois_iff_is_galois_bot`

More to be added later (once #5225 is merged): Galois is preserved by alg_equiv, is_galois_iff_galois_top

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
