### PR TITLE
[Merged by Bors] - feat(analysis/mean_inequalities): add young_inequality for nnreal and ennreal with real exponents

### DIFF
--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -292,9 +292,9 @@ theorem young_inequality (a b : ℝ≥0) {p q : ℝ≥0} (hp : 1 < p) (hpq : 1 /
   a * b ≤ a^(p:ℝ) / p + b^(q:ℝ) / q :=
 real.young_inequality_of_nonneg a.coe_nonneg b.coe_nonneg ⟨hp, nnreal.coe_eq.2 hpq⟩
 
-/-- Young's inequality, `ℝ≥0` version with real conjugate exponents.  -/
-theorem young_inequality_real (a b : ℝ≥0) {p q : ℝ} (hpq :p.is_conjugate_exponent q) :
-  a * b ≤ a^(p:ℝ) / nnreal.of_real p + b^(q:ℝ) / nnreal.of_real q :=
+/-- Young's inequality, `ℝ≥0` version with real conjugate exponents. -/
+theorem young_inequality_real (a b : ℝ≥0) {p q : ℝ} (hpq : p.is_conjugate_exponent q) :
+  a * b ≤ a ^ p / nnreal.of_real p + b ^ q / nnreal.of_real q :=
 begin
   have hp : 1 < nnreal.of_real p,
   { rw [←of_real_one, of_real_lt_of_real_iff hpq.pos], exact hpq.one_lt, },

--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -292,6 +292,20 @@ theorem young_inequality (a b : ℝ≥0) {p q : ℝ≥0} (hp : 1 < p) (hpq : 1 /
   a * b ≤ a^(p:ℝ) / p + b^(q:ℝ) / q :=
 real.young_inequality_of_nonneg a.coe_nonneg b.coe_nonneg ⟨hp, nnreal.coe_eq.2 hpq⟩
 
+/-- Young's inequality, `ℝ≥0` version with real conjugate exponents.  -/
+theorem young_inequality_real (a b : ℝ≥0) {p q : ℝ} (hpq :p.is_conjugate_exponent q) :
+  a * b ≤ a^(p:ℝ) / nnreal.of_real p + b^(q:ℝ) / nnreal.of_real q :=
+begin
+  have hp : 1 < nnreal.of_real p,
+  { rw [←of_real_one, of_real_lt_of_real_iff hpq.pos], exact hpq.one_lt, },
+  have hpq_nnreal : 1 / nnreal.of_real p + 1 / nnreal.of_real q = 1,
+  { rw [←of_real_one, ←of_real_div' hpq.nonneg, ←of_real_div' hpq.symm.nonneg,
+      ←of_real_add hpq.one_div_nonneg hpq.symm.one_div_nonneg, hpq.inv_add_inv_conj], },
+  nth_rewrite 0 ←coe_of_real p hpq.nonneg,
+  nth_rewrite 0 ←coe_of_real q hpq.symm.nonneg,
+  exact young_inequality a b hp hpq_nnreal,
+end
+
 /-- Hölder inequality: the scalar product of two functions is bounded by the product of their
 `L^p` and `L^q` norms when `p` and `q` are conjugate exponents. Version for sums over finite sets,
 with `ℝ≥0`-valued functions. -/
@@ -443,6 +457,22 @@ by convert Lp_add_le s f g hp using 2 ; [skip, congr' 1, congr' 1];
 end real
 
 namespace ennreal
+
+/- Young inequality, ennreal version with real conjugate exponents -/
+theorem young_inequality (a b : ennreal) {p q : ℝ} (hpq : p.is_conjugate_exponent q) :
+  a * b ≤ a ^ p / ennreal.of_real p + b ^ q / ennreal.of_real q :=
+begin
+  by_cases h : a = ⊤ ∨ b = ⊤,
+  { refine le_trans le_top (le_of_eq _),
+    repeat {rw ennreal.div_def},
+    cases h; rw h; simp [h, hpq.pos, hpq.symm.pos], },
+  push_neg at h, -- if a ≠ ⊤ and b ≠ ⊤, use the nnreal version: nnreal.young_inequality_real
+  rw [←coe_to_nnreal h.left, ←coe_to_nnreal h.right, ←coe_mul,
+    coe_rpow_of_nonneg _ hpq.nonneg, coe_rpow_of_nonneg _ hpq.symm.nonneg, ennreal.of_real,
+    ennreal.of_real, ←@coe_div (nnreal.of_real p) _ (by simp [hpq.pos]),
+    ←@coe_div (nnreal.of_real q) _ (by simp [hpq.symm.pos]), ←coe_add, coe_le_coe],
+  exact nnreal.young_inequality_real a.to_nnreal b.to_nnreal hpq,
+end
 
 variables (f g : ι → ennreal)  {p q : ℝ}
 

--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -296,14 +296,9 @@ real.young_inequality_of_nonneg a.coe_nonneg b.coe_nonneg ⟨hp, nnreal.coe_eq.2
 theorem young_inequality_real (a b : ℝ≥0) {p q : ℝ} (hpq : p.is_conjugate_exponent q) :
   a * b ≤ a ^ p / nnreal.of_real p + b ^ q / nnreal.of_real q :=
 begin
-  have hp : 1 < nnreal.of_real p,
-  { rw [←of_real_one, of_real_lt_of_real_iff hpq.pos], exact hpq.one_lt, },
-  have hpq_nnreal : 1 / nnreal.of_real p + 1 / nnreal.of_real q = 1,
-  { rw [←of_real_one, ←of_real_div' hpq.nonneg, ←of_real_div' hpq.symm.nonneg,
-      ←of_real_add hpq.one_div_nonneg hpq.symm.one_div_nonneg, hpq.inv_add_inv_conj], },
   nth_rewrite 0 ←coe_of_real p hpq.nonneg,
   nth_rewrite 0 ←coe_of_real q hpq.symm.nonneg,
-  exact young_inequality a b hp hpq_nnreal,
+  exact young_inequality a b hpq.one_lt_nnreal hpq.inv_add_inv_conj_nnreal,
 end
 
 /-- Hölder inequality: the scalar product of two functions is bounded by the product of their

--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -458,7 +458,7 @@ end real
 
 namespace ennreal
 
-/- Young inequality, ennreal version with real conjugate exponents -/
+/-- Young's inequality, `ennreal` version with real conjugate exponents. -/
 theorem young_inequality (a b : ennreal) {p q : ℝ} (hpq : p.is_conjugate_exponent q) :
   a * b ≤ a ^ p / ennreal.of_real p + b ^ q / ennreal.of_real q :=
 begin

--- a/src/data/real/conjugate_exponents.lean
+++ b/src/data/real/conjugate_exponents.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Yury Kudryashov
 -/
-import data.real.basic
+import data.real.nnreal
 
 /-!
 # Real conjugate exponents
@@ -80,6 +80,16 @@ by simpa only [sub_mul, sub_eq_iff_eq_add, one_mul] using h.sub_one_mul_conj
 @[symm] protected lemma symm : q.is_conjugate_exponent p :=
 { one_lt := by { rw [h.conj_eq], exact (one_lt_div h.sub_one_pos).mpr (sub_one_lt p) },
   inv_add_inv_conj := by simpa [add_comm] using h.inv_add_inv_conj }
+
+lemma one_lt_nnreal : 1 < nnreal.of_real p :=
+begin
+  rw [←nnreal.of_real_one, nnreal.of_real_lt_of_real_iff h.pos],
+  exact h.one_lt,
+end
+
+lemma inv_add_inv_conj_nnreal : 1 / nnreal.of_real p + 1 / nnreal.of_real q = 1 :=
+by rw [←nnreal.of_real_one, ←nnreal.of_real_div' h.nonneg, ←nnreal.of_real_div' h.symm.nonneg,
+  ←nnreal.of_real_add h.one_div_nonneg h.symm.one_div_nonneg, h.inv_add_inv_conj]
 
 end is_conjugate_exponent
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -658,6 +658,25 @@ by simpa using @div_eq_div_iff a b c 1 hb one_ne_zero
 @[field_simps] lemma eq_div_iff {a b c : ℝ≥0} (hb : b ≠ 0) : c = a / b ↔ c * b = a :=
 by simpa using @div_eq_div_iff c 1 a b one_ne_zero hb
 
+lemma of_real_inv {x : ℝ} :
+  nnreal.of_real x⁻¹ = (nnreal.of_real x)⁻¹ :=
+begin
+  by_cases hx : 0 ≤ x,
+  { nth_rewrite 0 ← coe_of_real x hx,
+    rw [←nnreal.coe_inv, of_real_coe], },
+  { have hx' := le_of_not_ge hx,
+    rw [of_real_eq_zero.mpr hx', inv_zero, of_real_eq_zero.mpr (inv_nonpos.mpr hx')], },
+end
+
+lemma of_real_div {x y : ℝ} (hx : 0 ≤ x) :
+  nnreal.of_real (x / y) = nnreal.of_real x / nnreal.of_real y :=
+by rw [div_def, ←of_real_inv, ←of_real_mul hx, div_eq_mul_inv]
+
+lemma of_real_div' {x y : ℝ} (hy : 0 ≤ y) :
+  nnreal.of_real (x / y) = nnreal.of_real x / nnreal.of_real y :=
+by rw [div_def, ←of_real_inv, mul_comm, ←@of_real_mul y⁻¹ _ (by simp [hy]), mul_comm,
+  div_eq_mul_inv]
+
 end inv
 
 section pow


### PR DESCRIPTION
The existing young_inequality for nnreal has nnreal exponents. This adds a version with real exponents with the is_conjugate_exponent property, and a similar version for ennreal with real exponents.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
The ennreal version will be useful for proving Hölder's inequality for the Lebesgue integral.
