### PR TITLE
[Merged by Bors] - feat(topology/algebra/infinite_sum): add lemmas about continuous linear maps

### DIFF
--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -829,6 +829,21 @@ protected lemma continuous_linear_equiv.summable {f : ι → M} (e : M ≃L[R] M
   summable (λ b:ι, e (f b)) ↔ summable f :=
 ⟨λ hf, (e.has_sum.1 hf.has_sum).summable, (e : M →L[R] M₂).summable⟩
 
+lemma continuous_linear_equiv.tsum_eq_iff [t2_space M] [t2_space M₂] {f : ι → M}
+  (e : M ≃L[R] M₂) {y : M₂} : (∑' z, e (f z)) = y ↔ (∑' z, f z) = e.symm y :=
+begin
+  by_cases hf : summable f,
+  { exact ⟨λ h, (e.has_sum.mp ((e.summable.mpr hf).has_sum_iff.mpr h)).tsum_eq,
+      λ h, (e.has_sum.mpr (hf.has_sum_iff.mpr h)).tsum_eq⟩ },
+  { have hf' : ¬summable (λ z, e (f z)) := λ h, hf (e.summable.mp h),
+    rw [tsum_eq_zero_of_not_summable hf, tsum_eq_zero_of_not_summable hf'],
+    exact ⟨by { rintro rfl, simp }, λ H, by simpa using (congr_arg (λ z, e z) H)⟩ }
+end
+
+protected lemma continuous_linear_equiv.map_tsum [t2_space M] [t2_space M₂] {f : ι → M}
+  (e : M ≃L[R] M₂) : e (∑' z, f z) = ∑' z, e (f z) :=
+by { refine symm (e.tsum_eq_iff.mpr _), rw e.symm_apply_apply _ }
+
 end has_sum
 
 namespace continuous_linear_equiv

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -815,6 +815,10 @@ protected lemma continuous_linear_map.summable {f : ι → M} (φ : M →L[R] M�
 
 alias continuous_linear_map.summable ← summable.mapL
 
+protected lemma continuous_linear_map.map_tsum [t2_space M₂] {f : ι → M}
+  (φ : M →L[R] M₂) (hf : summable f) : φ (∑' z, f z) = ∑' z, φ (f z) :=
+(hf.has_sum.mapL φ).tsum_eq.symm
+
 /-- Applying a continuous linear map commutes with taking an (infinite) sum. -/
 protected lemma continuous_linear_equiv.has_sum {f : ι → M} (e : M ≃L[R] M₂) {y : M₂} :
   has_sum (λ (b:ι), e (f b)) y ↔ has_sum f (e.symm y) :=

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -615,6 +615,21 @@ has_sum.map hf ⟨λ y, r • y, smul_zero _, smul_add _⟩ (continuous.smul con
 lemma summable.smul {r : R} (hf : summable f) : summable (λ z, r • f z) :=
 (hf.has_sum.smul).summable
 
+lemma tsum_smul [t2_space α] {r : R} (hf : summable f) : (∑' z, r • f z) = r • (∑' z, f z) :=
+hf.has_sum.smul.tsum_eq
+
+variables [topological_space γ] [add_comm_monoid γ] [semimodule R γ]
+
+lemma has_sum.map_linear {a : α} (hf : has_sum f a) (g : α →L[R] γ) : has_sum (g ∘ f) (g a) :=
+has_sum.map hf g.to_linear_map.to_add_monoid_hom g.continuous
+
+lemma summable.map_linear (hf : summable f) (g : α →L[R] γ) : summable (g ∘ f) :=
+(hf.has_sum.map_linear g).summable
+
+lemma continuous_linear_map.map_tsum [t2_space γ] (g : α →L[R] γ) (hf : summable f) :
+  g (∑' z, f z) = ∑' z, g (f z) :=
+(hf.has_sum.map_linear g).tsum_eq.symm
+
 end topological_semimodule
 
 section division_ring

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 import algebra.big_operators.intervals
 import topology.instances.real
+import topology.algebra.module
 import data.indicator_function
 import data.equiv.encodable.lattice
 import order.filter.at_top_bot
@@ -600,6 +601,21 @@ lemma tsum_mul_right (a) (hf : summable f) : (∑'b, f b * a) = (∑'b, f b) * a
 end tsum
 
 end topological_semiring
+
+section topological_semimodule
+variables {R : Type*}
+[semiring R] [topological_space R]
+[topological_space α] [add_comm_monoid α]
+[semimodule R α] [topological_semimodule R α]
+{f : β → α}
+
+lemma has_sum.smul {a : α} {r : R} (hf : has_sum f a) : has_sum (λ z, r • f z) (r • a) :=
+has_sum.map hf ⟨λ y, r • y, smul_zero _, smul_add _⟩ (continuous.smul continuous_const continuous_id)
+
+lemma summable.smul {r : R} (hf : summable f) : summable (λ z, r • f z) :=
+(hf.has_sum.smul).summable
+
+end topological_semimodule
 
 section division_ring
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -610,7 +610,7 @@ variables {R : Type*}
 {f : β → α}
 
 lemma has_sum.smul {a : α} {r : R} (hf : has_sum f a) : has_sum (λ z, r • f z) (r • a) :=
-has_sum.map hf ⟨λ y, r • y, smul_zero _, smul_add _⟩ (continuous.smul continuous_const continuous_id)
+has_sum.map hf (const_smul_hom r) (continuous_const.smul continuous_id)
 
 lemma summable.smul {r : R} (hf : summable f) : summable (λ z, r • f z) :=
 (hf.has_sum.smul).summable

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -618,7 +618,15 @@ lemma summable.smul {r : R} (hf : summable f) : summable (λ z, r • f z) :=
 lemma tsum_smul [t2_space α] {r : R} (hf : summable f) : (∑' z, r • f z) = r • (∑' z, f z) :=
 hf.has_sum.smul.tsum_eq
 
-variables [topological_space γ] [add_comm_monoid γ] [semimodule R γ]
+end topological_semimodule
+
+section continuous_linear_map
+variables {R : Type*}
+[semiring R]
+[topological_space α] [add_comm_monoid α]
+[semimodule R α]
+[topological_space γ] [add_comm_monoid γ] [semimodule R γ]
+{f : β → α}
 
 lemma has_sum.map_linear {a : α} (hf : has_sum f a) (g : α →L[R] γ) : has_sum (g ∘ f) (g a) :=
 has_sum.map hf g.to_linear_map.to_add_monoid_hom g.continuous
@@ -630,7 +638,7 @@ lemma continuous_linear_map.map_tsum [t2_space γ] (g : α →L[R] γ) (hf : sum
   g (∑' z, f z) = ∑' z, g (f z) :=
 (hf.has_sum.map_linear g).tsum_eq.symm
 
-end topological_semimodule
+end continuous_linear_map
 
 section division_ring
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -613,7 +613,7 @@ lemma has_sum.smul {a : α} {r : R} (hf : has_sum f a) : has_sum (λ z, r • f 
 has_sum.map hf (const_smul_hom α r) (continuous_const.smul continuous_id)
 
 lemma summable.smul {r : R} (hf : summable f) : summable (λ z, r • f z) :=
-(hf.has_sum.smul).summable
+hf.has_sum.smul.summable
 
 lemma tsum_smul [t2_space α] {r : R} (hf : summable f) : (∑' z, r • f z) = r • (∑' z, f z) :=
 hf.has_sum.smul.tsum_eq

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -610,7 +610,7 @@ variables {R : Type*}
 {f : β → α}
 
 lemma has_sum.smul {a : α} {r : R} (hf : has_sum f a) : has_sum (λ z, r • f z) (r • a) :=
-has_sum.map hf (const_smul_hom r) (continuous_const.smul continuous_id)
+has_sum.map hf (const_smul_hom α r) (continuous_const.smul continuous_id)
 
 lemma summable.smul {r : R} (hf : summable f) : summable (λ z, r • f z) :=
 (hf.has_sum.smul).summable

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -620,26 +620,6 @@ hf.has_sum.smul.tsum_eq
 
 end topological_semimodule
 
-section continuous_linear_map
-variables {R : Type*}
-[semiring R]
-[topological_space α] [add_comm_monoid α]
-[semimodule R α]
-[topological_space γ] [add_comm_monoid γ] [semimodule R γ]
-{f : β → α}
-
-lemma has_sum.map_linear {a : α} (hf : has_sum f a) (g : α →L[R] γ) : has_sum (g ∘ f) (g a) :=
-has_sum.map hf g.to_linear_map.to_add_monoid_hom g.continuous
-
-lemma summable.map_linear (hf : summable f) (g : α →L[R] γ) : summable (g ∘ f) :=
-(hf.has_sum.map_linear g).summable
-
-lemma continuous_linear_map.map_tsum [t2_space γ] (g : α →L[R] γ) (hf : summable f) :
-  g (∑' z, f z) = ∑' z, g (f z) :=
-(hf.has_sum.map_linear g).tsum_eq.symm
-
-end continuous_linear_map
-
 section division_ring
 
 variables [division_ring α] [topological_space α] [topological_semiring α]

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -610,7 +610,7 @@ variables {R : Type*}
 {f : β → α}
 
 lemma has_sum.smul {a : α} {r : R} (hf : has_sum f a) : has_sum (λ z, r • f z) (r • a) :=
-has_sum.map hf (const_smul_hom α r) (continuous_const.smul continuous_id)
+hf.map (const_smul_hom α r) (continuous_const.smul continuous_id)
 
 lemma summable.smul {r : R} (hf : summable f) : summable (λ z, r • f z) :=
 hf.has_sum.smul.summable


### PR DESCRIPTION
---
This PR adds lemmas about infinite sums in topological semimodules, namely that we can take `smul`s and continuous linear maps outside of infinite sums.
