### PR TITLE
[Merged by Bors] - feat(data/polynomial): simp lemmas about polynomial derivatives

### DIFF
--- a/src/data/polynomial/derivative.lean
+++ b/src/data/polynomial/derivative.lean
@@ -64,6 +64,10 @@ lemma derivative_monomial (a : R) (n : ℕ) : derivative (monomial n a) = monomi
 lemma derivative_C_mul_X_pow (a : R) (n : ℕ) : derivative (C a * X ^ n) = C (a * n) * X^(n - 1) :=
 by rw [C_mul_X_pow_eq_monomial, C_mul_X_pow_eq_monomial, derivative_monomial]
 
+@[simp] lemma derivative_X_pow (n : ℕ) :
+  derivative (X ^ n : polynomial R) = (n : polynomial R) * X ^ (n - 1) :=
+by convert derivative_C_mul_X_pow (1 : R) n; simp
+
 @[simp] lemma derivative_C {a : R} : derivative (C a) = 0 :=
 by simp [derivative_apply]
 
@@ -72,6 +76,12 @@ by simp [derivative_apply]
 
 @[simp] lemma derivative_one : derivative (1 : polynomial R) = 0 :=
 derivative_C
+
+@[simp] lemma derivative_bit0 {a : polynomial R} : derivative (bit0 a) = bit0 (derivative a) :=
+by simp [bit0]
+
+@[simp] lemma derivative_bit1 {a : polynomial R} : derivative (bit1 a) = bit0 (derivative a) :=
+by simp [bit1]
 
 @[simp] lemma derivative_add {f g : polynomial R} :
   derivative (f + g) = derivative f + derivative g :=

--- a/test/differentiable.lean
+++ b/test/differentiable.lean
@@ -62,3 +62,24 @@ example : differentiable ℂ (λ x, (sin x) / (exp x)) :=
 by simp [exp_ne_zero]
 
 end complex
+
+namespace polynomial
+
+variables {R : Type*} [comm_semiring R]
+
+example : (2 : polynomial R).derivative = 0 :=
+by conv_lhs { simp }
+
+example : (3 + X : polynomial R).derivative = 1 :=
+by conv_lhs { simp }
+
+example : (2 * X ^ 2 : polynomial R).derivative = 4 * X :=
+by conv_lhs { simp, ring, }
+
+example : (X ^ 2 : polynomial R).derivative = 2 * X :=
+by conv_lhs { simp }
+
+example : ((C 2 * X ^ 3).derivative : polynomial R) = 6 * X ^ 2 :=
+by conv_lhs { simp, ring, }
+
+end polynomial


### PR DESCRIPTION
Add simp lemmas derivative_bit0 derivative_bit1 and derivative_X_pow

---

with this PR the following all simp nicely
```
import data.polynomial.derivative

variables {R : Type*} [comm_semiring R] ( n :ℕ)
namespace polynomial


#simp (2 : polynomial ℚ).derivative
#simp (3 + X : polynomial ℚ).derivative
#simp (2 *X^2 : polynomial ℚ).derivative
#simp (X^2 : polynomial ℚ).derivative
#simp (n •ℕ X : polynomial ℚ)
#simp ((C (1) * X^3).derivative : polynomial R)
end polynomial

```
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
