### PR TITLE
[Merged by Bors] - feat(linear_algebra/alternating): Add dom_coprod

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -281,6 +281,13 @@
   bibsource     = {dblp computer science bibliography, https://dblp.org}
 }
 
+@Inproceedings{   Gallier2011Notes,
+  title         = {Notes on Differential Geometry and Lie Groups},
+  author        = {J. Gallier and J. Quaintance},
+  year          = {2011},
+  url           = {https://www.cis.upenn.edu/~cis610/diffgeom-n.pdf}
+}
+
 @Article{         ghys87:groupes,
   author        = {Étienne Ghys},
   title         = {Groupes d'homeomorphismes du cercle et cohomologie


### PR DESCRIPTION
This implements a variant of the multiplication defined in the second half of [Proposition 22.24 of "Notes on Differential Geometry and Lie Groups" (Jean Gallier)](https://www.cis.upenn.edu/~cis610/diffgeom-n.pdf):

![image](https://user-images.githubusercontent.com/425260/104042315-3dfe7380-51d2-11eb-9b3a-bbbb52d180f0.png)

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->

Before this gets merged I'll want to squash the commits to remove @zhangir-azerbayev from the history, as none of the code changed in this PR is theirs.

<details>

<summary> Resolved Dependencies </summary>

- [x] depends on: #5187
- [x] depends on: #5260
- [x] depends on: #5266
- [x] depends on: #5270
- [x] depends on: #5279
- [x] depends on: #5368
- [x] depends on: #5365
- [x] depends on: #5364
- [x] depends on: #5372
- [x] depends on: #5374
- [x] depends on: #5301
- [x] depends on: #5396
- [x] depends on: #5317
- [x] depends on: #5430
- [x] depends on: #5509

</details>

- [x] depends on: #6186
