### PR TITLE
[Merged by Bors] - chore(data/list/sort): docs, add a few lemmas

### DIFF
--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -159,7 +159,7 @@ theorem sorted.ordered_insert (a : α) : ∀ l, sorted r l → sorted r (ordered
   by_cases h' : a ≼ b,
   { simpa [ordered_insert, h', h] using λ b' bm, trans h' (rel_of_sorted_cons h _ bm) },
   { suffices : ∀ (b' : α), b' ∈ ordered_insert r a l → r b b',
-    { simpa [ordered_insert, h', sorted_ordered_insert l (sorted_of_sorted_cons h)] },
+    { simpa [ordered_insert, h', (sorted_of_sorted_cons h).ordered_insert l] },
     intros b' bm,
     cases (show b' = a ∨ b' ∈ l, by simpa using
       (perm_ordered_insert _ _ _).subset bm) with be bm,
@@ -170,7 +170,7 @@ end
 /-- The list `list.insertion_sort r l` is `list.sorted` with respect to `r`. -/
 theorem sorted_insertion_sort : ∀ l, sorted r (insertion_sort r l)
 | []       := sorted_nil
-| (a :: l) := sorted_ordered_insert r a _ (sorted_insertion_sort l)
+| (a :: l) := (sorted_insertion_sort l).ordered_insert r a _
 
 end total_and_transitive
 end correctness
@@ -294,7 +294,7 @@ theorem sorted.merge : ∀ {l l' : list α}, sorted r l → sorted r l' → sort
 | (a :: l) (b :: l') h₁ h₂ := begin
   by_cases a ≼ b,
   { suffices : ∀ (b' : α) (_ : b' ∈ merge r l (b :: l')), r a b',
-    { simpa [merge, h, sorted_merge (sorted_of_sorted_cons h₁) h₂] },
+    { simpa [merge, h, (sorted_of_sorted_cons h₁).merge h₂] },
     intros b' bm,
     rcases (show b' = b ∨ b' ∈ l ∨ b' ∈ l', by simpa [or.left_comm] using
       (perm_merge _ _ _).subset bm) with be | bl | bl',
@@ -302,7 +302,7 @@ theorem sorted.merge : ∀ {l l' : list α}, sorted r l → sorted r l' → sort
     { exact rel_of_sorted_cons h₁ _ bl },
     { exact trans h (rel_of_sorted_cons h₂ _ bl') } },
   { suffices : ∀ (b' : α) (_ : b' ∈ merge r (a :: l) l'), r b b',
-    { simpa [merge, h, sorted_merge h₁ (sorted_of_sorted_cons h₂)] },
+    { simpa [merge, h, h₁.merge (sorted_of_sorted_cons h₂)] },
     intros b' bm,
     have ba : b ≼ a := (total_of r _ _).resolve_left h,
     rcases (show b' = a ∨ b' ∈ l ∨ b' ∈ l', by simpa using
@@ -319,7 +319,7 @@ theorem sorted_merge_sort : ∀ l : list α, sorted r (merge_sort r l)
   cases e : split (a::b::l) with l₁ l₂,
   cases length_split_lt e with h₁ h₂,
   rw [merge_sort_cons_cons r e],
-  exact sorted_merge r (sorted_merge_sort l₁) (sorted_merge_sort l₂)
+  exact r.merge (sorted_merge_sort l₁) (sorted_merge_sort l₂)
 end
 using_well_founded {
   rel_tac := λ_ _, `[exact ⟨_, inv_image.wf length nat.lt_wf⟩],

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -7,10 +7,10 @@ import data.list.perm
 import data.list.chain
 
 /-!
-# Sort algorithms on lists
+# Sorting algorithms on lists
 
 In this file we define `list.sorted r l` to be an alias for `pairwise r l`. This alias is preferred
-in the case that `r` is a `<` or `≤`-like relation. Then we define two sort algorithms:
+in the case that `r` is a `<` or `≤`-like relation. Then we define two sorting algorithms:
 `list.insertion_sort` and `list.merge_sort`, and prove their correctness.
 -/
 
@@ -153,7 +153,7 @@ lemma sorted.insertion_sort_eq : ∀ {l : list α} (h : sorted r l), insertion_s
 section total_and_transitive
 variables [is_total α r] [is_trans α r]
 
-theorem sorted_ordered_insert (a : α) : ∀ l, sorted r l → sorted r (ordered_insert r a l)
+theorem sorted.ordered_insert (a : α) : ∀ l, sorted r l → sorted r (ordered_insert r a l)
 | []       h := sorted_singleton a
 | (b :: l) h := begin
   by_cases h' : a ≼ b,
@@ -287,7 +287,7 @@ using_well_founded {
 section total_and_transitive
 variables [is_total α r] [is_trans α r]
 
-theorem sorted_merge : ∀ {l l' : list α}, sorted r l → sorted r l' → sorted r (merge r l l')
+theorem sorted.merge : ∀ {l l' : list α}, sorted r l → sorted r l' → sorted r (merge r l l')
 | []       []        h₁ h₂ := sorted_nil
 | []       (b :: l') h₁ h₂ := by simpa [merge] using h₂
 | (a :: l) []        h₁ h₂ := by simpa [merge] using h₁

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -139,6 +139,8 @@ theorem perm_insertion_sort : ∀ l : list α, insertion_sort r l ~ l
 | (b :: l) := by simpa [insertion_sort] using
   (perm_ordered_insert _ _ _).trans ((perm_insertion_sort l).cons b)
 
+variable {r}
+
 /-- If `l` is already `list.sorted` with respect to `r`, then `insertion_sort` does not change
 it. -/
 lemma sorted.insertion_sort_eq : ∀ {l : list α} (h : sorted r l), insertion_sort r l = l
@@ -167,10 +169,12 @@ theorem sorted.ordered_insert (a : α) : ∀ l, sorted r l → sorted r (ordered
     { exact rel_of_sorted_cons h _ bm } }
 end
 
+variable (r)
+
 /-- The list `list.insertion_sort r l` is `list.sorted` with respect to `r`. -/
 theorem sorted_insertion_sort : ∀ l, sorted r (insertion_sort r l)
 | []       := sorted_nil
-| (a :: l) := (sorted_insertion_sort l).ordered_insert r a _
+| (a :: l) := (sorted_insertion_sort l).ordered_insert a _
 
 end total_and_transitive
 end correctness
@@ -285,7 +289,7 @@ using_well_founded {
 (perm_merge_sort r _).length_eq
 
 section total_and_transitive
-variables [is_total α r] [is_trans α r]
+variables {r} [is_total α r] [is_trans α r]
 
 theorem sorted.merge : ∀ {l l' : list α}, sorted r l → sorted r l' → sorted r (merge r l l')
 | []       []        h₁ h₂ := sorted_nil
@@ -312,6 +316,8 @@ theorem sorted.merge : ∀ {l l' : list α}, sorted r l → sorted r l' → sort
     { exact rel_of_sorted_cons h₂ _ bl' } }
 end
 
+variable (r)
+
 theorem sorted_merge_sort : ∀ l : list α, sorted r (merge_sort r l)
 | []        := sorted_nil
 | [a]       := sorted_singleton _
@@ -319,7 +325,7 @@ theorem sorted_merge_sort : ∀ l : list α, sorted r (merge_sort r l)
   cases e : split (a::b::l) with l₁ l₂,
   cases length_split_lt e with h₁ h₂,
   rw [merge_sort_cons_cons r e],
-  exact r.merge (sorted_merge_sort l₁) (sorted_merge_sort l₂)
+  exact (sorted_merge_sort l₁).merge (sorted_merge_sort l₂)
 end
 using_well_founded {
   rel_tac := λ_ _, `[exact ⟨_, inv_image.wf length nat.lt_wf⟩],

--- a/src/data/multiset/sort.lean
+++ b/src/data/multiset/sort.lean
@@ -23,7 +23,7 @@ variables (r : α → α → Prop) [decidable_rel r]
   (Uses merge sort algorithm.) -/
 def sort (s : multiset α) : list α :=
 quot.lift_on s (merge_sort r) $ λ a b h,
-eq_of_sorted_of_perm
+eq_of_perm_of_sorted
   ((perm_merge_sort _ _).trans $ h.trans (perm_merge_sort _ _).symm)
   (sorted_merge_sort r _)
   (sorted_merge_sort r _)


### PR DESCRIPTION
 * Add a module docstring and section headers.

* Rename `list.eq_of_sorted_of_perm` to `list.eq_of_perm_of_sorted`;
  the new name reflects the order of arguments.

* Add a few lemmas.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
