### PR TITLE
[Merged by Bors] - chore(data/equiv/mul_add): Split out the group structure on automorphisms

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau, Yury Kudryashov
 -/
 import tactic.nth_rewrite
 import data.matrix.basic
+import data.equiv.ring_aut
 import linear_algebra.tensor_product
 import ring_theory.subring
 import deprecated.subring

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -6,14 +6,12 @@ Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 import algebra.group.hom
 import algebra.group.type_tags
 import algebra.group.units_hom
-import group_theory.perm.basic
 
 /-!
 # Multiplicative and additive equivs
 
 In this file we define two extensions of `equiv` called `add_equiv` and `mul_equiv`, which are
-datatypes representing isomorphisms of `add_monoid`s/`add_group`s and `monoid`s/`group`s. We also
-introduce the corresponding groups of automorphisms `add_aut` and `mul_aut`.
+datatypes representing isomorphisms of `add_monoid`s/`add_group`s and `monoid`s/`group`s.
 
 ## Notations
 
@@ -25,13 +23,9 @@ notation when treating the isomorphisms as maps.
 The fields for `mul_equiv`, `add_equiv` now avoid the unbundled `is_mul_hom` and `is_add_hom`, as
 these are deprecated.
 
-Definition of multiplication in the groups of automorphisms agrees with function composition,
-multiplication in `equiv.perm`, and multiplication in `category_theory.End`, not with
-`category_theory.comp`.
-
 ## Tags
 
-equiv, mul_equiv, add_equiv, mul_aut, add_aut
+equiv, mul_equiv, add_equiv
 -/
 
 variables {A : Type*} {B : Type*} {M : Type*} {N : Type*} {P : Type*} {G : Type*} {H : Type*}
@@ -266,106 +260,6 @@ lemma add_equiv.map_sub [add_group A] [add_group B] (h : A ≃+ B) (x y : A) :
 h.to_add_monoid_hom.map_sub x y
 
 instance add_equiv.inhabited {M : Type*} [has_add M] : inhabited (M ≃+ M) := ⟨add_equiv.refl M⟩
-
-/-- The group of multiplicative automorphisms. -/
-@[to_additive "The group of additive automorphisms."]
-def mul_aut (M : Type*) [has_mul M] := M ≃* M
-
-attribute [reducible] mul_aut add_aut
-
-namespace mul_aut
-
-variables (M) [has_mul M]
-
-/--
-The group operation on multiplicative automorphisms is defined by
-`λ g h, mul_equiv.trans h g`.
-This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
--/
-instance : group (mul_aut M) :=
-by refine_struct
-{ mul := λ g h, mul_equiv.trans h g,
-  one := mul_equiv.refl M,
-  inv := mul_equiv.symm };
-intros; ext; try { refl }; apply equiv.left_inv
-
-instance : inhabited (mul_aut M) := ⟨1⟩
-
-@[simp] lemma coe_mul (e₁ e₂ : mul_aut M) : ⇑(e₁ * e₂) = e₁ ∘ e₂ := rfl
-@[simp] lemma coe_one : ⇑(1 : mul_aut M) = id := rfl
-
-lemma mul_def (e₁ e₂ : mul_aut M) : e₁ * e₂ = e₂.trans e₁ := rfl
-lemma one_def : (1 : mul_aut M) = mul_equiv.refl _ := rfl
-lemma inv_def (e₁ : mul_aut M) : e₁⁻¹ = e₁.symm := rfl
-@[simp] lemma mul_apply (e₁ e₂ : mul_aut M) (m : M) : (e₁ * e₂) m = e₁ (e₂ m) := rfl
-@[simp] lemma one_apply (m : M) : (1 : mul_aut M) m = m := rfl
-
-@[simp] lemma apply_inv_self (e : mul_aut M) (m : M) : e (e⁻¹ m) = m :=
-mul_equiv.apply_symm_apply _ _
-
-@[simp] lemma inv_apply_self (e : mul_aut M) (m : M) : e⁻¹ (e m) = m :=
-mul_equiv.apply_symm_apply _ _
-
-/-- Monoid hom from the group of multiplicative automorphisms to the group of permutations. -/
-def to_perm : mul_aut M →* equiv.perm M :=
-by refine_struct { to_fun := mul_equiv.to_equiv }; intros; refl
-
-/-- group conjugation as a group homomorphism into the automorphism group.
-  `conj g h = g * h * g⁻¹` -/
-def conj [group G] : G →* mul_aut G :=
-{ to_fun := λ g,
-  { to_fun := λ h, g * h * g⁻¹,
-    inv_fun := λ h, g⁻¹ * h * g,
-    left_inv := λ _, by simp [mul_assoc],
-    right_inv := λ _, by simp [mul_assoc],
-    map_mul' := by simp [mul_assoc] },
-  map_mul' := λ _ _, by ext; simp [mul_assoc],
-  map_one' := by ext; simp [mul_assoc] }
-
-@[simp] lemma conj_apply [group G] (g h : G) : conj g h = g * h * g⁻¹ := rfl
-@[simp] lemma conj_symm_apply [group G] (g h : G) : (conj g).symm h = g⁻¹ * h * g := rfl
-@[simp] lemma conj_inv_apply {G : Type*} [group G] (g h : G) : (conj g)⁻¹ h = g⁻¹ * h * g := rfl
-
-end mul_aut
-
-namespace add_aut
-
-variables (A) [has_add A]
-
-/--
-The group operation on additive automorphisms is defined by
-`λ g h, mul_equiv.trans h g`.
-This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
--/
-instance group : group (add_aut A) :=
-by refine_struct
-{ mul := λ g h, add_equiv.trans h g,
-  one := add_equiv.refl A,
-  inv := add_equiv.symm };
-intros; ext; try { refl }; apply equiv.left_inv
-
-instance : inhabited (add_aut A) := ⟨1⟩
-
-@[simp] lemma coe_mul (e₁ e₂ : add_aut A) : ⇑(e₁ * e₂) = e₁ ∘ e₂ := rfl
-@[simp] lemma coe_one : ⇑(1 : add_aut A) = id := rfl
-
-lemma mul_def (e₁ e₂ : add_aut A) : e₁ * e₂ = e₂.trans e₁ := rfl
-lemma one_def : (1 : add_aut A) = add_equiv.refl _ := rfl
-lemma inv_def (e₁ : add_aut A) : e₁⁻¹ = e₁.symm := rfl
-@[simp] lemma mul_apply (e₁ e₂ : add_aut A) (a : A) : (e₁ * e₂) a = e₁ (e₂ a) := rfl
-@[simp] lemma one_apply (a : A) : (1 : add_aut A) a = a := rfl
-
-@[simp] lemma apply_inv_self (e : add_aut A) (a : A) : e⁻¹ (e a) = a :=
-add_equiv.apply_symm_apply _ _
-
-@[simp] lemma inv_apply_self (e : add_aut A) (a : A) : e (e⁻¹ a) = a :=
-add_equiv.apply_symm_apply _ _
-
-/-- Monoid hom from the group of multiplicative automorphisms to the group of permutations. -/
-def to_perm : add_aut A →* equiv.perm A :=
-by refine_struct { to_fun := add_equiv.to_equiv }; intros; refl
-
-end add_aut
 
 /-- A group is isomorphic to its group of units. -/
 @[to_additive to_add_units "An additive group is isomorphic to its group of additive units"]

--- a/src/data/equiv/mul_add_aut.lean
+++ b/src/data/equiv/mul_add_aut.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
+-/
+import data.equiv.mul_add
+import group_theory.perm.basic
+
+/-!
+# Group structure of multiplicative and additive equiv automorphisms
+
+This file introduces the groups of automorphisms `add_aut` and `mul_aut` corresponding to
+`add_equiv` and `mul_equiv`.
+
+## Implementation notes
+
+Definition of multiplication in the groups of automorphisms agrees with function composition,
+multiplication in `equiv.perm`, and multiplication in `category_theory.End`, not with
+`category_theory.comp`.
+
+This file is kept separate from `data/equiv/mul_add` so that `group_theory.perm` is free to use
+equivalences (and other files that use them) before the group structure is defined.
+
+## Tags
+
+mul_aut, add_aut
+-/
+variables {A : Type*} {M : Type*} {G : Type*}
+
+/-- The group of multiplicative automorphisms. -/
+@[to_additive "The group of additive automorphisms."]
+def mul_aut (M : Type*) [has_mul M] := M ≃* M
+
+attribute [reducible] mul_aut add_aut
+
+namespace mul_aut
+
+variables (M) [has_mul M]
+
+/--
+The group operation on multiplicative automorphisms is defined by
+`λ g h, mul_equiv.trans h g`.
+This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
+-/
+instance : group (mul_aut M) :=
+by refine_struct
+{ mul := λ g h, mul_equiv.trans h g,
+  one := mul_equiv.refl M,
+  inv := mul_equiv.symm };
+intros; ext; try { refl }; apply equiv.left_inv
+
+instance : inhabited (mul_aut M) := ⟨1⟩
+
+@[simp] lemma coe_mul (e₁ e₂ : mul_aut M) : ⇑(e₁ * e₂) = e₁ ∘ e₂ := rfl
+@[simp] lemma coe_one : ⇑(1 : mul_aut M) = id := rfl
+
+lemma mul_def (e₁ e₂ : mul_aut M) : e₁ * e₂ = e₂.trans e₁ := rfl
+lemma one_def : (1 : mul_aut M) = mul_equiv.refl _ := rfl
+lemma inv_def (e₁ : mul_aut M) : e₁⁻¹ = e₁.symm := rfl
+@[simp] lemma mul_apply (e₁ e₂ : mul_aut M) (m : M) : (e₁ * e₂) m = e₁ (e₂ m) := rfl
+@[simp] lemma one_apply (m : M) : (1 : mul_aut M) m = m := rfl
+
+@[simp] lemma apply_inv_self (e : mul_aut M) (m : M) : e (e⁻¹ m) = m :=
+mul_equiv.apply_symm_apply _ _
+
+@[simp] lemma inv_apply_self (e : mul_aut M) (m : M) : e⁻¹ (e m) = m :=
+mul_equiv.apply_symm_apply _ _
+
+/-- Monoid hom from the group of multiplicative automorphisms to the group of permutations. -/
+def to_perm : mul_aut M →* equiv.perm M :=
+by refine_struct { to_fun := mul_equiv.to_equiv }; intros; refl
+
+/-- group conjugation as a group homomorphism into the automorphism group.
+  `conj g h = g * h * g⁻¹` -/
+def conj [group G] : G →* mul_aut G :=
+{ to_fun := λ g,
+  { to_fun := λ h, g * h * g⁻¹,
+    inv_fun := λ h, g⁻¹ * h * g,
+    left_inv := λ _, by simp [mul_assoc],
+    right_inv := λ _, by simp [mul_assoc],
+    map_mul' := by simp [mul_assoc] },
+  map_mul' := λ _ _, by ext; simp [mul_assoc],
+  map_one' := by ext; simp [mul_assoc] }
+
+@[simp] lemma conj_apply [group G] (g h : G) : conj g h = g * h * g⁻¹ := rfl
+@[simp] lemma conj_symm_apply [group G] (g h : G) : (conj g).symm h = g⁻¹ * h * g := rfl
+@[simp] lemma conj_inv_apply {G : Type*} [group G] (g h : G) : (conj g)⁻¹ h = g⁻¹ * h * g := rfl
+
+end mul_aut
+
+namespace add_aut
+
+variables (A) [has_add A]
+
+/--
+The group operation on additive automorphisms is defined by
+`λ g h, mul_equiv.trans h g`.
+This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
+-/
+instance group : group (add_aut A) :=
+by refine_struct
+{ mul := λ g h, add_equiv.trans h g,
+  one := add_equiv.refl A,
+  inv := add_equiv.symm };
+intros; ext; try { refl }; apply equiv.left_inv
+
+instance : inhabited (add_aut A) := ⟨1⟩
+
+@[simp] lemma coe_mul (e₁ e₂ : add_aut A) : ⇑(e₁ * e₂) = e₁ ∘ e₂ := rfl
+@[simp] lemma coe_one : ⇑(1 : add_aut A) = id := rfl
+
+lemma mul_def (e₁ e₂ : add_aut A) : e₁ * e₂ = e₂.trans e₁ := rfl
+lemma one_def : (1 : add_aut A) = add_equiv.refl _ := rfl
+lemma inv_def (e₁ : add_aut A) : e₁⁻¹ = e₁.symm := rfl
+@[simp] lemma mul_apply (e₁ e₂ : add_aut A) (a : A) : (e₁ * e₂) a = e₁ (e₂ a) := rfl
+@[simp] lemma one_apply (a : A) : (1 : add_aut A) a = a := rfl
+
+@[simp] lemma apply_inv_self (e : add_aut A) (a : A) : e⁻¹ (e a) = a :=
+add_equiv.apply_symm_apply _ _
+
+@[simp] lemma inv_apply_self (e : add_aut A) (a : A) : e (e⁻¹ a) = a :=
+add_equiv.apply_symm_apply _ _
+
+/-- Monoid hom from the group of multiplicative automorphisms to the group of permutations. -/
+def to_perm : add_aut A →* equiv.perm A :=
+by refine_struct { to_fun := add_equiv.to_equiv }; intros; refl
+
+end add_aut

--- a/src/data/equiv/mul_add_aut.lean
+++ b/src/data/equiv/mul_add_aut.lean
@@ -7,15 +7,15 @@ import data.equiv.mul_add
 import group_theory.perm.basic
 
 /-!
-# Group structure of multiplicative and additive equiv automorphisms
+# Multiplicative and additive group automorphisms
 
-This file introduces the groups of automorphisms `add_aut` and `mul_aut` corresponding to
-`add_equiv` and `mul_equiv`.
+This file defines the automorphism group structure on `add_aut R := add_equiv R R` and
+`mul_aut R := mul_equiv R R`.
 
 ## Implementation notes
 
-Definition of multiplication in the groups of automorphisms agrees with function composition,
-multiplication in `equiv.perm`, and multiplication in `category_theory.End`, not with
+The definition of multiplication in the automorphism groups agrees with function composition,
+multiplication in `equiv.perm`, and multiplication in `category_theory.End`, but not with
 `category_theory.comp`.
 
 This file is kept separate from `data/equiv/mul_add` so that `group_theory.perm` is free to use
@@ -94,7 +94,7 @@ variables (A) [has_add A]
 
 /--
 The group operation on additive automorphisms is defined by
-`λ g h, mul_equiv.trans h g`.
+`λ g h, add_equiv.trans h g`.
 This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
 -/
 instance group : group (add_aut A) :=

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -297,41 +297,6 @@ protected def integral_domain {A : Type*} (B : Type*) [ring A] [integral_domain 
 
 end ring_equiv
 
-/-- The group of ring automorphisms. -/
-@[reducible] def ring_aut (R : Type*) [has_mul R] [has_add R] := ring_equiv R R
-
-namespace ring_aut
-
-variables (R) [has_mul R] [has_add R]
-
-/--
-The group operation on automorphisms of a ring is defined by
-λ g h, ring_equiv.trans h g.
-This means that multiplication agrees with composition, (g*h)(x) = g (h x) .
--/
-instance : group (ring_aut R) :=
-by refine_struct
-{ mul := λ g h, ring_equiv.trans h g,
-  one := ring_equiv.refl R,
-  inv := ring_equiv.symm };
-intros; ext; try { refl }; apply equiv.left_inv
-
-instance : inhabited (ring_aut R) := ⟨1⟩
-
-/-- Monoid homomorphism from ring automorphisms to additive automorphisms. -/
-def to_add_aut : ring_aut R →* add_aut R :=
-by refine_struct { to_fun := ring_equiv.to_add_equiv }; intros; refl
-
-/-- Monoid homomorphism from ring automorphisms to multiplicative automorphisms. -/
-def to_mul_aut : ring_aut R →* mul_aut R :=
-by refine_struct { to_fun := ring_equiv.to_mul_equiv }; intros; refl
-
-/-- Monoid homomorphism from ring automorphisms to permutations. -/
-def to_perm : ring_aut R →* equiv.perm R :=
-by refine_struct { to_fun := ring_equiv.to_equiv }; intros; refl
-
-end ring_aut
-
 namespace equiv
 
 variables (K : Type*) [division_ring K]

--- a/src/data/equiv/ring_aut.lean
+++ b/src/data/equiv/ring_aut.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
+-/
+import data.equiv.ring
+import data.equiv.mul_add_aut
+
+/-!
+# Group structure of ring equiv automorphisms
+
+This file introduces the groups of automorphism `ring_aut`  corresponding to `ring_equiv`.
+
+## Implementation notes
+
+Definition of multiplication in the groups of automorphisms agrees with function composition,
+multiplication in `equiv.perm`, and multiplication in `category_theory.End`, not with
+`category_theory.comp`.
+
+This file is kept separate from `data/equiv/ring` so that `group_theory.perm` is free to use
+equivalences (and other files that use them) before the group structure is defined.
+
+## Tags
+
+ring_aut
+-/
+
+namespace ring_aut
+
+/-- The group of ring automorphisms. -/
+@[reducible] def ring_aut (R : Type*) [has_mul R] [has_add R] := ring_equiv R R
+
+variables (R : Type*) [has_mul R] [has_add R]
+
+/--
+The group operation on automorphisms of a ring is defined by
+λ g h, ring_equiv.trans h g.
+This means that multiplication agrees with composition, (g*h)(x) = g (h x) .
+-/
+instance : group (ring_aut R) :=
+by refine_struct
+{ mul := λ g h, ring_equiv.trans h g,
+  one := ring_equiv.refl R,
+  inv := ring_equiv.symm };
+intros; ext; try { refl }; apply equiv.left_inv
+
+instance : inhabited (ring_aut R) := ⟨1⟩
+
+/-- Monoid homomorphism from ring automorphisms to additive automorphisms. -/
+def to_add_aut : ring_aut R →* add_aut R :=
+by refine_struct { to_fun := ring_equiv.to_add_equiv }; intros; refl
+
+/-- Monoid homomorphism from ring automorphisms to multiplicative automorphisms. -/
+def to_mul_aut : ring_aut R →* mul_aut R :=
+by refine_struct { to_fun := ring_equiv.to_mul_equiv }; intros; refl
+
+/-- Monoid homomorphism from ring automorphisms to permutations. -/
+def to_perm : ring_aut R →* equiv.perm R :=
+by refine_struct { to_fun := ring_equiv.to_equiv }; intros; refl
+
+end ring_aut

--- a/src/data/equiv/ring_aut.lean
+++ b/src/data/equiv/ring_aut.lean
@@ -7,14 +7,14 @@ import data.equiv.ring
 import data.equiv.mul_add_aut
 
 /-!
-# Group structure of ring equiv automorphisms
+# Ring automorphisms
 
-This file introduces the groups of automorphism `ring_aut`  corresponding to `ring_equiv`.
+This file defines the automorphism group structure on `ring_aut R := ring_equiv R R`.
 
 ## Implementation notes
 
-Definition of multiplication in the groups of automorphisms agrees with function composition,
-multiplication in `equiv.perm`, and multiplication in `category_theory.End`, not with
+The definition of multiplication in the automorphism group agrees with function composition,
+multiplication in `equiv.perm`, and multiplication in `category_theory.End`, but not with
 `category_theory.comp`.
 
 This file is kept separate from `data/equiv/ring` so that `group_theory.perm` is free to use
@@ -25,17 +25,16 @@ equivalences (and other files that use them) before the group structure is defin
 ring_aut
 -/
 
-namespace ring_aut
-
 /-- The group of ring automorphisms. -/
 @[reducible] def ring_aut (R : Type*) [has_mul R] [has_add R] := ring_equiv R R
 
+namespace ring_aut
 variables (R : Type*) [has_mul R] [has_add R]
 
 /--
 The group operation on automorphisms of a ring is defined by
-λ g h, ring_equiv.trans h g.
-This means that multiplication agrees with composition, (g*h)(x) = g (h x) .
+`λ g h, ring_equiv.trans h g`.
+This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
 -/
 instance : group (ring_aut R) :=
 by refine_struct

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -11,6 +11,7 @@ import data.finset.lattice
 import data.finset.pi
 import data.array.lemmas
 import order.well_founded
+import group_theory.perm.basic
 
 open_locale nat
 

--- a/src/group_theory/group_action/group.lean
+++ b/src/group_theory/group_action/group.lean
@@ -7,6 +7,7 @@ import group_theory.group_action.defs
 import algebra.group.units
 import algebra.group_with_zero
 import data.equiv.mul_add
+import group_theory.perm.basic
 
 /-!
 # Group actions applied to various types of group

--- a/src/group_theory/semidirect_product.lean
+++ b/src/group_theory/semidirect_product.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import data.equiv.mul_add
+import data.equiv.mul_add_aut
 import logic.function.basic
 import group_theory.subgroup
 


### PR DESCRIPTION
This prevents `group_theory.perm.basic` being imported into lots of files that don't care about permutations.

The argument here is that `add_aut` is to `add_equiv` as `perm` is to `equiv`: `perm` gets its group structure in a separate file to where `equiv` is defined, so `add_aut`, `mul_aut`, and `ring_aut` should too.

This adds back imports of `group_theory.perm.basic` to downstream files that inherited them through `data.equiv.mul_add`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The motivation is similar to #5280