### PR TITLE
[Merged by Bors] - feat(category_theory/sites/sieves): change presieve operation defs

### DIFF
--- a/src/category_theory/sites/pretopology.lean
+++ b/src/category_theory/sites/pretopology.lean
@@ -49,10 +49,9 @@ category.
 This is not the same as the arrow set of `sieve.pullback`, but there is a relation between them
 in `pullback_arrows_comm`.
 -/
-def pullback_arrows {X Y : C} (f : Y ⟶ X) (S : presieve X) :
-  presieve Y :=
-λ Z g, ∃ Z' (h : Z' ⟶ X), S h ∧ ∃ (H : Z = pullback h f),
-  eq_to_hom H ≫ pullback.snd = g
+inductive pullback_arrows {X Y : C} (f : Y ⟶ X) (S : presieve X) :
+  presieve Y
+| mk (Z : C) (h : Z ⟶ X) : S h → pullback_arrows (pullback.snd : pullback h f ⟶ Y)
 
 lemma pullback_arrows_comm {X Y : C} (f : Y ⟶ X)
   (R : presieve X) :
@@ -60,24 +59,26 @@ lemma pullback_arrows_comm {X Y : C} (f : Y ⟶ X)
 begin
   ext Z g,
   split,
-  { rintro ⟨W, k, l, ⟨T, g, hg, rfl, rfl⟩, rfl⟩,
-    refine ⟨_, k ≫ pullback.fst, g, hg, _⟩,
-    rw [assoc, pullback.condition, eq_to_hom_refl, id_comp, assoc] },
-  { rintro ⟨W, k, h, hh, comm⟩,
-    exact ⟨_, pullback.lift _ _ comm, _, ⟨_, h, hh, rfl, rfl⟩, by simp⟩ },
+  { rintro ⟨_, h, k, hk, rfl⟩,
+    cases hk with W g hg,
+    change (sieve.generate R).pullback f (h ≫ pullback.snd),
+    rw [sieve.mem_pullback, assoc, ← pullback.condition, ← assoc],
+    apply sieve.downward_closed,
+    apply sieve.le_generate _ _ hg },
+  { rintro ⟨W, h, k, hk, comm⟩,
+    exact ⟨_, _, _, pullback_arrows.mk _ _ hk, pullback.lift_snd _ _ comm⟩ },
 end
 
 lemma pullback_singleton {X Y Z : C} (f : Y ⟶ X) (g : Z ⟶ X) :
- ∃ (W : C) (k : W ⟶ Y), pullback_arrows f (singleton g) = singleton k :=
+ pullback_arrows f (singleton g) = singleton (pullback.snd : pullback g f ⟶ _) :=
 begin
-  refine ⟨pullback (eq_to_hom (eq.refl _) ≫ g) f, pullback.snd, _⟩,
-  ext W k,
+  ext W h,
   split,
-  { rintro ⟨W, k, ⟨rfl, rfl⟩, rfl, rfl⟩,
-    rw [eq_to_hom_refl (pullback (eq_to_hom (eq.refl W) ≫ g) f) (eq.refl _), id_comp],
-    apply singleton_self },
-  { rintro ⟨rfl, rfl⟩,
-    exact ⟨_, _, by simp, _, rfl⟩ }
+  { rintro ⟨W, _, _, _⟩,
+    apply singleton.mk },
+  { rintro ⟨_⟩,
+    apply pullback_arrows.mk,
+    apply singleton.mk }
 end
 
 variables (C)
@@ -213,42 +214,26 @@ def trivial : pretopology C :=
   pullbacks := λ X Y f S,
   begin
     rintro ⟨Z, g, i, rfl⟩,
-    resetI,
-    refine ⟨pullback (eq_to_hom (eq.refl _) ≫ g) f, pullback.snd, _, _⟩,
-    { refine ⟨pullback.lift (f ≫ inv g) (𝟙 _) (by simp), _, _⟩,
-      { apply pullback.hom_ext,
-        { rw [assoc, pullback.lift_fst, ← pullback.condition_assoc],
-          simp },
-        { simp } },
-      { simp } },
-    clear i,
-    ext W k,
-    split,
-    { rintro ⟨W, k, ⟨rfl, rfl⟩, rfl, rfl⟩,
-      rw [eq_to_hom_refl (pullback (eq_to_hom (eq.refl W) ≫ g) f) (eq.refl _), id_comp],
-      apply singleton_self },
-    { rintro ⟨rfl, rfl⟩,
-      exact ⟨_, _, by simp, _, rfl⟩ },
+    refine ⟨pullback g f, pullback.snd, _, _⟩,
+    sorry,
+    apply pullback_singleton,
   end,
   transitive :=
   begin
     rintro X S Ti ⟨Z, g, i, rfl⟩ hS,
     rcases hS g (singleton_self g) with ⟨Y, f, i, hTi⟩,
     refine ⟨_, f ≫ g, _, _⟩,
-    { resetI,
-      apply_instance },
+    { resetI, apply_instance },
     ext W k,
     split,
-    { rintro ⟨V, h, k, ⟨rfl, rfl⟩, hh, rfl⟩,
-      simp only [id_comp, eq_to_hom_refl] at hh,
+    { rintro ⟨V, h, k, ⟨_⟩, hh, rfl⟩,
       rw hTi at hh,
-      rcases hh with ⟨rfl, rfl⟩,
-      simp only [id_comp, eq_to_hom_refl],
-      apply singleton_self (f ≫ g) },
-    { rintro ⟨rfl, rfl⟩,
-      refine ⟨_, f, g, singleton_self _, _, by simp⟩,
+      cases hh,
+      apply singleton.mk },
+    { rintro ⟨_⟩,
+      apply bind_comp,
       rw hTi,
-      apply singleton_self }
+      apply singleton.mk }
   end }
 
 instance : order_bot (pretopology C) :=

--- a/src/category_theory/sites/pretopology.lean
+++ b/src/category_theory/sites/pretopology.lean
@@ -63,8 +63,7 @@ begin
     cases hk with W g hg,
     change (sieve.generate R).pullback f (h ≫ pullback.snd),
     rw [sieve.mem_pullback, assoc, ← pullback.condition, ← assoc],
-    apply sieve.downward_closed,
-    apply sieve.le_generate _ _ hg },
+    exact sieve.downward_closed _ (sieve.le_generate R W hg) (h ≫ pullback.fst)},
   { rintro ⟨W, h, k, hk, comm⟩,
     exact ⟨_, _, _, pullback_arrows.mk _ _ hk, pullback.lift_snd _ _ comm⟩ },
 end
@@ -75,10 +74,9 @@ begin
   ext W h,
   split,
   { rintro ⟨W, _, _, _⟩,
-    apply singleton.mk },
+    exact singleton.mk },
   { rintro ⟨_⟩,
-    apply pullback_arrows.mk,
-    apply singleton.mk }
+    exact pullback_arrows.mk Z g singleton.mk }
 end
 
 variables (C)
@@ -215,8 +213,12 @@ def trivial : pretopology C :=
   begin
     rintro ⟨Z, g, i, rfl⟩,
     refine ⟨pullback g f, pullback.snd, _, _⟩,
-    sorry,
-    apply pullback_singleton,
+    { exactI { is_iso . inv := pullback.lift (f ≫ inv g) (𝟙 _) (by simp), hom_inv_id' := _ },
+      apply pullback.hom_ext,
+      { rw [assoc, pullback.lift_fst, ←pullback.condition_assoc],
+        simp },
+      { simp } },
+    { apply pullback_singleton },
   end,
   transitive :=
   begin
@@ -231,9 +233,9 @@ def trivial : pretopology C :=
       cases hh,
       apply singleton.mk },
     { rintro ⟨_⟩,
-      apply bind_comp,
+      refine bind_comp g presieve.singleton.mk _,
       rw hTi,
-      apply singleton.mk }
+      apply presieve.singleton.mk }
   end }
 
 instance : order_bot (pretopology C) :=

--- a/src/category_theory/sites/sieves.lean
+++ b/src/category_theory/sites/sieves.lean
@@ -56,19 +56,19 @@ bind S R (g ≫ f) :=
 
 /-- The singleton presieve.  -/
 -- Note we can't make this into `has_singleton` because of the out-param.
-def singleton : presieve X :=
-λ Z g, ∃ (H : Z = Y), eq_to_hom H ≫ f = g
+inductive singleton : presieve X
+| mk : singleton f
 
 @[simp] lemma singleton_eq_iff_domain (f g : Y ⟶ X) : singleton f g ↔ f = g :=
 begin
   split,
-  { rintro ⟨_, rfl⟩,
-    apply (category.id_comp _).symm },
+  { rintro ⟨a, rfl⟩,
+    refl },
   { rintro rfl,
-    exact ⟨rfl, category.id_comp _⟩ },
+    apply singleton.mk, }
 end
 
-lemma singleton_self : singleton f f := (singleton_eq_iff_domain _ _).2 rfl
+lemma singleton_self : singleton f f := singleton.mk
 
 end presieve
 

--- a/src/category_theory/sites/spaces.lean
+++ b/src/category_theory/sites/spaces.lean
@@ -64,7 +64,7 @@ def pretopology : pretopology (opens T) :=
   pullbacks := λ X Y f S hS x hx,
   begin
     rcases hS _ (le_of_hom f hx) with ⟨U, g, hg, hU⟩,
-    refine ⟨_, _, ⟨_, _, hg, rfl, rfl⟩, _⟩,
+    refine ⟨_, _, pullback_arrows.mk _ _ hg, _⟩,
     have : U ⊓ Y ≤ pullback g f,
       refine le_of_hom (pullback.lift (hom_of_le inf_le_left) (hom_of_le inf_le_right) rfl),
     apply this ⟨hU, hx⟩,


### PR DESCRIPTION
change the definitions of operations on presieves to avoid `eq_to_hom` and use inductive types instead, which makes proofs a lot nicer