### PR TITLE
[Merged by Bors] - feat(field_theory.minimal_polynomial): add results for GCD domains

### DIFF
--- a/src/field_theory/minimal_polynomial.lean
+++ b/src/field_theory/minimal_polynomial.lean
@@ -281,7 +281,7 @@ end
 /-- The minimal polynomial over `ℤ` is the same as the minimal polynomial over `ℚ`. -/
 --TODO use `gcd_domain_eq_field_fractions` directly when localizations are defined
 -- in terms of algebras instead of `ring_hom`s
-lemma integer_eq_rational {α : Type u} [integral_domain α] {x : α} [algebra ℚ α]
+lemma over_int_eq_over_rat {α : Type u} [integral_domain α] {x : α} [algebra ℚ α]
   (hx : is_integral ℤ x) :
   minimal_polynomial (@is_integral_of_is_scalar_tower ℤ ℚ α _ _ _ _ _ _ _ x hx) =
     map (int.cast_ring_hom ℚ) (minimal_polynomial hx) :=

--- a/src/field_theory/minimal_polynomial.lean
+++ b/src/field_theory/minimal_polynomial.lean
@@ -259,6 +259,10 @@ eq_of_monic_of_associated hp3 (monic hx) $
 mul_one (minimal_polynomial hx) ▸ hq.symm ▸ associated_mul_mul (associated.refl _) $
 associated_one_iff_is_unit.2 $ (hp1.is_unit_or_is_unit hq).resolve_left $ not_is_unit hx
 
+section gcd_domain
+
+/-- For GCD domains, the minimal polynomial over the ring is the same as the minimal polynomial
+over the fraction field. -/
 lemma gcd_domain_eq_field_fractions {α : Type u} {β : Type v} {γ : Type w} [integral_domain α]
   [gcd_monoid α] [field β] [integral_domain γ] (f : fraction_map α β) [algebra f.codomain γ]
   [algebra α γ] [is_scalar_tower α f.codomain γ] {x : γ} (hx : is_integral α x) :
@@ -273,6 +277,51 @@ begin
     exact htower.symm },
   { exact monic_map _ (monic hx) }
 end
+
+/-- The minimal polynomial over `ℤ` is the same as the minimal polynomial over `ℚ`. -/
+--TODO use `gcd_domain_eq_field_fractions` directly
+lemma integer_eq_rational {α : Type u} [integral_domain α] {x : α} [algebra ℚ α]
+  (hx : is_integral ℤ x) :
+  minimal_polynomial (@is_integral_of_is_scalar_tower ℤ ℚ α _ _ _ _ _ _ _ x hx) =
+  map (int.cast_ring_hom ℚ) (minimal_polynomial hx) :=
+begin
+  refine (unique' (@is_integral_of_is_scalar_tower ℤ ℚ α _ _ _ _ _ _ _ x hx) _ _ _).symm,
+  { exact (is_primitive.int.irreducible_iff_irreducible_map_cast
+  (polynomial.monic.is_primitive (monic hx))).1 (irreducible hx) },
+  { have htower := is_scalar_tower.aeval_apply ℤ ℚ α x (minimal_polynomial hx),
+    simp only [localization_map.algebra_map_eq, aeval] at htower,
+    exact htower.symm },
+  { exact monic_map _ (monic hx) }
+end
+
+/-- For GCD domains, the minimal polynomial divides any primitive polynomial that has the integral
+element as root. -/
+lemma gcd_domain_dvd {α : Type u} {β : Type v} {γ : Type w} [integral_domain α] [gcd_monoid α]
+  [field β] [integral_domain γ] (f : fraction_map α β) [algebra f.codomain γ] [algebra α γ]
+  [is_scalar_tower α f.codomain γ] {x : γ} (hx : is_integral α x) {P : polynomial α}
+  (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) : minimal_polynomial hx ∣ P :=
+begin
+  apply (is_primitive.dvd_iff_fraction_map_dvd_fraction_map f
+    (monic.is_primitive (monic hx)) hprim ).2,
+  rw [← gcd_domain_eq_field_fractions f hx],
+  refine dvd (is_integral_of_is_scalar_tower x hx) _,
+  rwa [← localization_map.algebra_map_eq, ← is_scalar_tower.aeval_apply]
+end
+
+/-- The minimal polynomial over `ℤ` divides any primitive polynomial that has the integral element
+as root. -/
+--TODO use `gcd_domain_dvd` directly
+lemma integer_dvd {α : Type u} [integral_domain α] [algebra ℚ α] {x : α} (hx : is_integral ℤ x)
+  {P : polynomial ℤ} (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) : minimal_polynomial hx ∣ P :=
+begin
+  apply (is_primitive.int.dvd_iff_map_cast_dvd_map_cast _ _
+    (monic.is_primitive (monic hx)) hprim ).2,
+  rw [← integer_eq_rational hx],
+  refine dvd (is_integral_of_is_scalar_tower x hx) _,
+  rwa [(int.cast_ring_hom ℚ).ext_int (algebra_map ℤ ℚ), ← is_scalar_tower.aeval_apply]
+end
+
+end gcd_domain
 
 variable (β)
 /--If L/K is a field extension, and x is an element of L in the image of K,

--- a/src/field_theory/minimal_polynomial.lean
+++ b/src/field_theory/minimal_polynomial.lean
@@ -283,7 +283,7 @@ end
 lemma integer_eq_rational {α : Type u} [integral_domain α] {x : α} [algebra ℚ α]
   (hx : is_integral ℤ x) :
   minimal_polynomial (@is_integral_of_is_scalar_tower ℤ ℚ α _ _ _ _ _ _ _ x hx) =
-  map (int.cast_ring_hom ℚ) (minimal_polynomial hx) :=
+    map (int.cast_ring_hom ℚ) (minimal_polynomial hx) :=
 begin
   refine (unique' (@is_integral_of_is_scalar_tower ℤ ℚ α _ _ _ _ _ _ _ x hx) _ _ _).symm,
   { exact (is_primitive.int.irreducible_iff_irreducible_map_cast

--- a/src/field_theory/minimal_polynomial.lean
+++ b/src/field_theory/minimal_polynomial.lean
@@ -279,7 +279,8 @@ begin
 end
 
 /-- The minimal polynomial over `ℤ` is the same as the minimal polynomial over `ℚ`. -/
---TODO use `gcd_domain_eq_field_fractions` directly
+--TODO use `gcd_domain_eq_field_fractions` directly when localizations are defined
+-- in terms of algebras instead of `ring_hom`s
 lemma integer_eq_rational {α : Type u} [integral_domain α] {x : α} [algebra ℚ α]
   (hx : is_integral ℤ x) :
   minimal_polynomial (@is_integral_of_is_scalar_tower ℤ ℚ α _ _ _ _ _ _ _ x hx) =

--- a/src/field_theory/minimal_polynomial.lean
+++ b/src/field_theory/minimal_polynomial.lean
@@ -297,10 +297,12 @@ end
 
 /-- For GCD domains, the minimal polynomial divides any primitive polynomial that has the integral
 element as root. -/
-lemma gcd_domain_dvd {α : Type u} {β : Type v} {γ : Type w} [integral_domain α] [gcd_monoid α]
-  [field β] [integral_domain γ] (f : fraction_map α β) [algebra f.codomain γ] [algebra α γ]
-  [is_scalar_tower α f.codomain γ] {x : γ} (hx : is_integral α x) {P : polynomial α}
-  (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) : minimal_polynomial hx ∣ P :=
+lemma gcd_domain_dvd {α : Type u} {β : Type v} {γ : Type w}
+  [integral_domain α] [gcd_monoid α] [field β] [integral_domain γ]
+  (f : fraction_map α β) [algebra f.codomain γ] [algebra α γ] [is_scalar_tower α f.codomain γ]
+  {x : γ} (hx : is_integral α x)
+  {P : polynomial α} (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) :
+  minimal_polynomial hx ∣ P :=
 begin
   apply (is_primitive.dvd_iff_fraction_map_dvd_fraction_map f
     (monic.is_primitive (monic hx)) hprim ).2,

--- a/src/field_theory/minimal_polynomial.lean
+++ b/src/field_theory/minimal_polynomial.lean
@@ -320,7 +320,7 @@ lemma integer_dvd {α : Type u} [integral_domain α] [algebra ℚ α] {x : α} (
 begin
   apply (is_primitive.int.dvd_iff_map_cast_dvd_map_cast _ _
     (monic.is_primitive (monic hx)) hprim ).2,
-  rw [← integer_eq_rational hx],
+  rw [← over_int_eq_over_rat hx],
   refine dvd (is_integral_of_is_scalar_tower x hx) _,
   rwa [(int.cast_ring_hom ℚ).ext_int (algebra_map ℤ ℚ), ← is_scalar_tower.aeval_apply]
 end

--- a/src/field_theory/minimal_polynomial.lean
+++ b/src/field_theory/minimal_polynomial.lean
@@ -313,7 +313,8 @@ end
 
 /-- The minimal polynomial over `ℤ` divides any primitive polynomial that has the integral element
 as root. -/
---TODO use `gcd_domain_dvd` directly
+-- TODO use `gcd_domain_dvd` directly when localizations are defined in terms of algebras
+-- instead of `ring_hom`s
 lemma integer_dvd {α : Type u} [integral_domain α] [algebra ℚ α] {x : α} (hx : is_integral ℤ x)
   {P : polynomial ℤ} (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) : minimal_polynomial hx ∣ P :=
 begin


### PR DESCRIPTION
I have added `gcd_domain_dvd`: for GCD domains, the minimal polynomial divides any primitive polynomial that has the integral
element as root.

For `gcd_domain_eq_field_fractions` and `gcd_domain_dvd` I have also added explicit versions for `ℤ`. Unfortunately, it seems impossible (to me at least) to apply the general lemmas and I had to redo the proofs, see [Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Minimal.20polynomial.20over.20.E2.84.9A.20vs.20over.20.E2.84.A4) for more details. (The basic reason seems to be that it's hard to convince lean that `is_scalar_tower ℤ ℚ α` holds using the localization map).
