### PR TITLE
[Merged by Bors] - feat(algebra/lie/basic): define ideal operations for Lie modules

### DIFF
--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -934,23 +934,26 @@ of submodules of `M`. -/
 instance : has_bracket (lie_ideal R L) (lie_submodule R L M) :=
 ⟨λ I N, lie_submodule.lie_span R L { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m }⟩
 
-lemma lie_apply :
+lemma lie_ideal_oper_eq_span :
   ⁅I, N⁆ = lie_submodule.lie_span R L { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m } := rfl
 
 lemma lie_mem_lie (x : I) (m : N) : ⁅(x : L), (m : M)⁆ ∈ ⁅I, N⁆ :=
-by { rw lie_apply, apply subset_lie_span, use [x, m], }
+by { rw lie_ideal_oper_eq_span, apply subset_lie_span, use [x, m], }
 
 lemma lie_comm : ⁅I, J⁆ = ⁅J, I⁆ :=
 begin
   suffices : ∀ (I J : lie_ideal R L), ⁅I, J⁆ ≤ ⁅J, I⁆, { exact le_antisymm (this I J) (this J I), },
   clear I J, intros I J,
-  rw [lie_apply, lie_span_le], rintros x ⟨y, z, h⟩, rw ← h,
+  rw [lie_ideal_oper_eq_span, lie_span_le], rintros x ⟨y, z, h⟩, rw ← h,
   rw [← lie_skew, ← lie_neg, ← submodule.coe_neg],
   apply lie_mem_lie,
 end
 
 lemma lie_le_right : ⁅I, N⁆ ≤ N :=
-by { rw [lie_apply, lie_span_le], rintros m ⟨x, n, hn⟩, rw ← hn, exact N.lie_mem n.property, }
+begin
+  rw [lie_ideal_oper_eq_span, lie_span_le], rintros m ⟨x, n, hn⟩, rw ← hn,
+  exact N.lie_mem n.property,
+end
 
 lemma lie_le_left : ⁅I, J⁆ ≤ I :=
 by { rw lie_comm, exact lie_le_right I J, }
@@ -968,13 +971,14 @@ by { rw eq_bot_iff, apply lie_le_right, }
 @[simp] lemma bot_lie : ⁅(⊥ : lie_ideal R L), N⁆ = ⊥ :=
 begin
   suffices : ⁅(⊥ : lie_ideal R L), N⁆ ≤ ⊥, { exact le_bot_iff.mp this, },
-  rw [lie_apply, lie_span_le], rintros m ⟨⟨x, hx⟩, n, hn⟩, rw ← hn,
+  rw [lie_ideal_oper_eq_span, lie_span_le], rintros m ⟨⟨x, hx⟩, n, hn⟩, rw ← hn,
   change x ∈ (⊥ : lie_ideal R L) at hx, rw mem_bot at hx, simp [hx],
 end
 
 lemma mono_lie (h₁ : I ≤ J) (h₂ : N ≤ N') : ⁅I, N⁆ ≤ ⁅J, N'⁆ :=
 begin
-  intros m h, rw [lie_apply, mem_lie_span] at h, rw [lie_apply, mem_lie_span],
+  intros m h,
+  rw [lie_ideal_oper_eq_span, mem_lie_span] at h, rw [lie_ideal_oper_eq_span, mem_lie_span],
   intros N hN, apply h, rintros m' ⟨⟨x, hx⟩, ⟨n, hn⟩, hm⟩, rw ← hm, apply hN,
   use [⟨x, h₁ hx⟩, ⟨n, h₂ hn⟩], refl,
 end
@@ -988,7 +992,7 @@ begin
   have h : ⁅I, N⁆ ⊔ ⁅I, N'⁆ ≤ ⁅I, N ⊔ N'⁆,
   { rw sup_le_iff, split; apply mono_lie_right; [exact le_sup_left, exact le_sup_right], },
   suffices : ⁅I, N ⊔ N'⁆ ≤ ⁅I, N⁆ ⊔ ⁅I, N'⁆, { exact le_antisymm this h, }, clear h,
-  rw [lie_apply, lie_span_le], rintros m ⟨x, ⟨n, hn⟩, h⟩, erw lie_submodule.mem_sup,
+  rw [lie_ideal_oper_eq_span, lie_span_le], rintros m ⟨x, ⟨n, hn⟩, h⟩, erw lie_submodule.mem_sup,
   erw lie_submodule.mem_sup at hn, rcases hn with ⟨n₁, hn₁, n₂, hn₂, hn'⟩,
   use ⁅(x : L), (⟨n₁, hn₁⟩ : N)⁆, split, { apply lie_mem_lie, },
   use ⁅(x : L), (⟨n₂, hn₂⟩ : N')⁆, split, { apply lie_mem_lie, },
@@ -1000,7 +1004,7 @@ begin
   have h : ⁅I, N⁆ ⊔ ⁅J, N⁆ ≤ ⁅I ⊔ J, N⁆,
   { rw sup_le_iff, split; apply mono_lie_left; [exact le_sup_left, exact le_sup_right], },
   suffices : ⁅I ⊔ J, N⁆ ≤ ⁅I, N⁆ ⊔ ⁅J, N⁆, { exact le_antisymm this h, }, clear h,
-  rw [lie_apply, lie_span_le], rintros m ⟨⟨x, hx⟩, n, h⟩, erw lie_submodule.mem_sup,
+  rw [lie_ideal_oper_eq_span, lie_span_le], rintros m ⟨⟨x, hx⟩, n, h⟩, erw lie_submodule.mem_sup,
   erw lie_submodule.mem_sup at hx, rcases hx with ⟨x₁, hx₁, x₂, hx₂, hx'⟩,
   use ⁅((⟨x₁, hx₁⟩ : I) : L), (n : N)⁆, split, { apply lie_mem_lie, },
   use ⁅((⟨x₂, hx₂⟩ : J) : L), (n : N)⁆, split, { apply lie_mem_lie, },

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -718,7 +718,7 @@ instance has_mem : has_mem M (lie_submodule R L M) := ⟨λ x N, x ∈ (N : set 
 @[simp] lemma mem_carrier (N : lie_submodule R L M) {x : M} : x ∈ N.carrier ↔ x ∈ (N : set M) :=
 iff.rfl
 
-@[simp] lemma mk_coe (S : set M) (h₁ h₂ h₃ h₄) :
+@[simp] lemma coe_to_set_mk (S : set M) (h₁ h₂ h₃ h₄) :
   ((⟨S, h₁, h₂, h₃, h₄⟩ : lie_submodule R L M) : set M) = S := rfl
 
 @[simp] lemma mk_coe_submodule (p : submodule R M) (h) :

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -783,7 +783,7 @@ instance : partial_order (lie_submodule R L M) :=
 
 lemma le_def : N ≤ N' ↔ (N : set M) ⊆ N' := iff.rfl
 
-lemma le_def_submodule : N ≤ N' ↔ (N : submodule R M) ≤ N' := iff.rfl
+@[simp] lemma coe_le_coe_submodule : (N : submodule R M) ≤ N' ↔ N ≤ N' := iff.rfl
 
 instance : has_bot (lie_submodule R L M) := ⟨0⟩
 
@@ -868,7 +868,8 @@ begin
         use [⁅x, y⁆, N.lie_mem hy, ⁅x, z⁆, N'.lie_mem hz],
       end,
       ..(N : submodule R M) ⊔ (N' : submodule R M) } : lie_submodule R L M),
-  use NN, simp [le_def_submodule],
+  use NN, simp only [←coe_le_coe_submodule, mem_set_of_eq, eq_self_iff_true, and_self, le_sup_left,
+    le_sup_right, mk_coe_submodule],
 end
 
 lemma mem_sup (x : M) : x ∈ N ⊔ N' ↔ ∃ (y ∈ N) (z ∈ N'), y + z = x :=
@@ -939,10 +940,30 @@ lemma lie_apply :
 lemma lie_mem_lie (x : I) (m : N) : ⁅(x : L), (m : M)⁆ ∈ ⁅I, N⁆ :=
 by { rw lie_apply, apply subset_lie_span, use [x, m], }
 
-lemma lie_le : ⁅I, N⁆ ≤ N :=
+lemma lie_comm : ⁅I, J⁆ = ⁅J, I⁆ :=
+begin
+  suffices : ∀ (I J : lie_ideal R L), ⁅I, J⁆ ≤ ⁅J, I⁆, { exact le_antisymm (this I J) (this J I), },
+  clear I J, intros I J,
+  rw [lie_apply, lie_span_le], rintros x ⟨y, z, h⟩, rw ← h,
+  rw [← lie_skew, ← lie_neg, ← submodule.coe_neg],
+  apply lie_mem_lie,
+end
+
+lemma lie_le_right : ⁅I, N⁆ ≤ N :=
 by { rw [lie_apply, lie_span_le], rintros m ⟨x, n, hn⟩, rw ← hn, exact N.lie_mem n.property, }
 
-@[simp] lemma lie_bot : ⁅I, (⊥ : lie_submodule R L M)⁆ = ⊥ := by { rw eq_bot_iff, apply lie_le, }
+lemma lie_le_left : ⁅I, J⁆ ≤ I :=
+by { rw lie_comm, exact lie_le_right I J, }
+
+lemma lie_le_inf : ⁅I, J⁆ ≤ I ⊓ J :=
+begin
+  rw le_inf_iff, split,
+  { rw lie_comm, apply lie_le_right, },
+  { apply lie_le_right, },
+end
+
+@[simp] lemma lie_bot : ⁅I, (⊥ : lie_submodule R L M)⁆ = ⊥ :=
+by { rw eq_bot_iff, apply lie_le_right, }
 
 @[simp] lemma bot_lie : ⁅(⊥ : lie_ideal R L), N⁆ = ⊥ :=
 begin
@@ -984,22 +1005,6 @@ begin
   use ⁅((⟨x₁, hx₁⟩ : I) : L), (n : N)⁆, split, { apply lie_mem_lie, },
   use ⁅((⟨x₂, hx₂⟩ : J) : L), (n : N)⁆, split, { apply lie_mem_lie, },
   simp [← h, ← hx'],
-end
-
-lemma lie_comm : ⁅I, J⁆ = ⁅J, I⁆ :=
-begin
-  suffices : ∀ (I J : lie_ideal R L), ⁅I, J⁆ ≤ ⁅J, I⁆, { exact le_antisymm (this I J) (this J I), },
-  clear I J, intros I J,
-  rw [lie_apply, lie_span_le], rintros x ⟨y, z, h⟩, rw ← h,
-  rw [← lie_skew, ← lie_neg, ← submodule.coe_neg],
-  apply lie_mem_lie,
-end
-
-lemma lie_le_inf : ⁅I, J⁆ ≤ I ⊓ J :=
-begin
-  rw le_inf_iff, split,
-  { rw lie_comm, apply lie_le, },
-  { apply lie_le, },
 end
 
 end lie_ideal_operations

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -718,6 +718,13 @@ instance has_mem : has_mem M (lie_submodule R L M) := ⟨λ x N, x ∈ (N : set 
 @[simp] lemma mem_carrier (N : lie_submodule R L M) {x : M} : x ∈ N.carrier ↔ x ∈ (N : set M) :=
 iff.rfl
 
+@[simp] lemma mk_coe (S : set M) (h₁ h₂ h₃ h₄) :
+  ((⟨S, h₁, h₂, h₃, h₄⟩ : lie_submodule R L M) : set M) = S := rfl
+
+@[simp] lemma mk_coe_submodule (p : submodule R M) (h) :
+  (({lie_mem := h, ..p} : lie_submodule R L M) : submodule R M) = p :=
+by { cases p, refl, }
+
 @[ext] lemma ext (N N' : lie_submodule R L M) (h : ∀ m, m ∈ N ↔ m ∈ N') : N = N' :=
 by { cases N, cases N', simp only [], ext m, exact h m, }
 
@@ -761,7 +768,7 @@ namespace lie_submodule
 variables {R : Type u} {L : Type v} {M : Type w}
 variables [comm_ring R] [lie_ring L] [lie_algebra R L] [add_comm_group M] [module R M]
 variables [lie_ring_module L M] [lie_module R L M]
-variables (N : lie_submodule R L M) (I : lie_ideal R L)
+variables (N N' : lie_submodule R L M) (I J : lie_ideal R L)
 
 section lattice_structure
 
@@ -774,7 +781,9 @@ instance : partial_order (lie_submodule R L M) :=
 { le := λ N N', ∀ ⦃x⦄, x ∈ N → x ∈ N', -- Overriding `le` like this gives a better defeq.
   ..partial_order.lift (coe : lie_submodule R L M → set M) coe_injective }
 
-lemma le_def (N N' : lie_submodule R L M) : N ≤ N' ↔ (N : set M) ⊆ N' := iff.rfl
+lemma le_def : N ≤ N' ↔ (N : set M) ⊆ N' := iff.rfl
+
+lemma le_def_submodule : N ≤ N' ↔ (N : submodule R M) ≤ N' := iff.rfl
 
 instance : has_bot (lie_submodule R L M) := ⟨0⟩
 
@@ -840,7 +849,33 @@ instance : add_comm_monoid (lie_submodule R L M) :=
   add_zero  := λ _, sup_bot_eq,
   add_comm  := λ _ _, sup_comm, }
 
-@[simp] lemma add_eq_sup (N N' : lie_submodule R L M) : N + N' = N ⊔ N' := rfl
+@[simp] lemma add_eq_sup : N + N' = N ⊔ N' := rfl
+
+lemma sup_eq_sup_submodule :
+  (↑(N ⊔ N') : submodule R M) = (N : submodule R M) ⊔ (N' : submodule R M) :=
+begin
+  suffices : (↑(N ⊔ N') : submodule R M) ≤ (N : submodule R M) ⊔ (N' : submodule R M),
+  { apply le_antisymm this, apply Inf_le_Inf _,
+    simp only [and_imp, set_of_subset_set_of, mem_set_of_eq, exists_imp_distrib],
+    intros p N'' hN hN' hp, rw ← hp, split; assumption, },
+  apply Inf_le _,
+  let NN :=
+  ({ lie_mem := λ x m h,
+      begin
+        rw [submodule.mem_carrier, submodule.mem_coe, submodule.mem_sup] at h,
+        rcases h with ⟨y, hy, z, hz, hm⟩, rw ← hm,
+        rw [submodule.mem_carrier, submodule.mem_coe, lie_add, submodule.mem_sup],
+        use [⁅x, y⁆, N.lie_mem hy, ⁅x, z⁆, N'.lie_mem hz],
+      end,
+      ..(N : submodule R M) ⊔ (N' : submodule R M) } : lie_submodule R L M),
+  use NN, simp [le_def_submodule],
+end
+
+lemma mem_sup (x : M) : x ∈ N ⊔ N' ↔ ∃ (y ∈ N) (z ∈ N'), y + z = x :=
+by { erw [← submodule.mem_sup, ← sup_eq_sup_submodule], refl, }
+
+lemma eq_bot_iff : N = ⊥ ↔ ∀ (m : M), m ∈ N → m = 0 :=
+by { rw eq_bot_iff, exact iff.rfl, }
 
 section inclusion_maps
 
@@ -853,7 +888,7 @@ def incl : N →ₗ⁅R,L⁆ M :=
 
 lemma incl_eq_val : (N.incl : N → M) = subtype.val := rfl
 
-variables {N} {N' : lie_submodule R L M} (h : N ≤ N')
+variables {N N'} (h : N ≤ N')
 
 /-- Given two nested Lie submodules `N ⊆ N'`, the inclusion `N ↪ N'` is a morphism of Lie modules.-/
 def hom_of_le : N →ₗ⁅R,L⁆ N' :=
@@ -890,6 +925,84 @@ end
 end lie_span
 
 end lattice_structure
+
+section lie_ideal_operations
+
+/-- Given a Lie module `M` over a Lie algebra `L`, the set of Lie ideals of `L` acts on the set
+of submodules of `M`. -/
+instance : has_bracket (lie_ideal R L) (lie_submodule R L M) :=
+⟨λ I N, lie_submodule.lie_span R L { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m }⟩
+
+lemma lie_apply :
+  ⁅I, N⁆ = lie_submodule.lie_span R L { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m } := rfl
+
+lemma lie_mem_lie (x : I) (m : N) : ⁅(x : L), (m : M)⁆ ∈ ⁅I, N⁆ :=
+by { rw lie_apply, apply subset_lie_span, use [x, m], }
+
+lemma lie_le : ⁅I, N⁆ ≤ N :=
+by { rw [lie_apply, lie_span_le], rintros m ⟨x, n, hn⟩, rw ← hn, exact N.lie_mem n.property, }
+
+@[simp] lemma lie_bot : ⁅I, (⊥ : lie_submodule R L M)⁆ = ⊥ := by { rw eq_bot_iff, apply lie_le, }
+
+@[simp] lemma bot_lie : ⁅(⊥ : lie_ideal R L), N⁆ = ⊥ :=
+begin
+  suffices : ⁅(⊥ : lie_ideal R L), N⁆ ≤ ⊥, { exact le_bot_iff.mp this, },
+  rw [lie_apply, lie_span_le], rintros m ⟨⟨x, hx⟩, n, hn⟩, rw ← hn,
+  change x ∈ (⊥ : lie_ideal R L) at hx, rw mem_bot at hx, simp [hx],
+end
+
+lemma mono_lie (h₁ : I ≤ J) (h₂ : N ≤ N') : ⁅I, N⁆ ≤ ⁅J, N'⁆ :=
+begin
+  intros m h, rw [lie_apply, mem_lie_span] at h, rw [lie_apply, mem_lie_span],
+  intros N hN, apply h, rintros m' ⟨⟨x, hx⟩, ⟨n, hn⟩, hm⟩, rw ← hm, apply hN,
+  use [⟨x, h₁ hx⟩, ⟨n, h₂ hn⟩], refl,
+end
+
+lemma mono_lie_left (h : I ≤ J) : ⁅I, N⁆ ≤ ⁅J, N⁆ := mono_lie _ _ _ _ h (le_refl N)
+
+lemma mono_lie_right (h : N ≤ N') : ⁅I, N⁆ ≤ ⁅I, N'⁆ := mono_lie _ _ _ _ (le_refl I) h
+
+@[simp] lemma lie_sup : ⁅I, N ⊔ N'⁆ = ⁅I, N⁆ ⊔ ⁅I, N'⁆ :=
+begin
+  have h : ⁅I, N⁆ ⊔ ⁅I, N'⁆ ≤ ⁅I, N ⊔ N'⁆,
+  { rw sup_le_iff, split; apply mono_lie_right; [exact le_sup_left, exact le_sup_right], },
+  suffices : ⁅I, N ⊔ N'⁆ ≤ ⁅I, N⁆ ⊔ ⁅I, N'⁆, { exact le_antisymm this h, }, clear h,
+  rw [lie_apply, lie_span_le], rintros m ⟨x, ⟨n, hn⟩, h⟩, erw lie_submodule.mem_sup,
+  erw lie_submodule.mem_sup at hn, rcases hn with ⟨n₁, hn₁, n₂, hn₂, hn'⟩,
+  use ⁅(x : L), (⟨n₁, hn₁⟩ : N)⁆, split, { apply lie_mem_lie, },
+  use ⁅(x : L), (⟨n₂, hn₂⟩ : N')⁆, split, { apply lie_mem_lie, },
+  simp [← h, ← hn'],
+end
+
+@[simp] lemma sup_lie : ⁅I ⊔ J, N⁆ = ⁅I, N⁆ ⊔ ⁅J, N⁆ :=
+begin
+  have h : ⁅I, N⁆ ⊔ ⁅J, N⁆ ≤ ⁅I ⊔ J, N⁆,
+  { rw sup_le_iff, split; apply mono_lie_left; [exact le_sup_left, exact le_sup_right], },
+  suffices : ⁅I ⊔ J, N⁆ ≤ ⁅I, N⁆ ⊔ ⁅J, N⁆, { exact le_antisymm this h, }, clear h,
+  rw [lie_apply, lie_span_le], rintros m ⟨⟨x, hx⟩, n, h⟩, erw lie_submodule.mem_sup,
+  erw lie_submodule.mem_sup at hx, rcases hx with ⟨x₁, hx₁, x₂, hx₂, hx'⟩,
+  use ⁅((⟨x₁, hx₁⟩ : I) : L), (n : N)⁆, split, { apply lie_mem_lie, },
+  use ⁅((⟨x₂, hx₂⟩ : J) : L), (n : N)⁆, split, { apply lie_mem_lie, },
+  simp [← h, ← hx'],
+end
+
+lemma lie_comm : ⁅I, J⁆ = ⁅J, I⁆ :=
+begin
+  suffices : ∀ (I J : lie_ideal R L), ⁅I, J⁆ ≤ ⁅J, I⁆, { exact le_antisymm (this I J) (this J I), },
+  clear I J, intros I J,
+  rw [lie_apply, lie_span_le], rintros x ⟨y, z, h⟩, rw ← h,
+  rw [← lie_skew, ← lie_neg, ← submodule.coe_neg],
+  apply lie_mem_lie,
+end
+
+lemma lie_le_inf : ⁅I, J⁆ ≤ I ⊓ J :=
+begin
+  rw le_inf_iff, split,
+  { rw lie_comm, apply lie_le, },
+  { apply lie_le, },
+end
+
+end lie_ideal_operations
 
 /-- The quotient of a Lie module by a Lie submodule. It is a Lie module. -/
 abbreviation quotient := N.to_submodule.quotient
@@ -985,6 +1098,32 @@ instance lie_quotient_lie_algebra : lie_algebra R (quotient I) :=
 end quotient
 
 end lie_submodule
+
+section lie_module
+
+variables (R : Type u) (L : Type v) (M : Type w)
+variables [comm_ring R] [lie_ring L] [lie_algebra R L] [add_comm_group M] [module R M]
+variables [lie_ring_module L M] [lie_module R L M]
+
+namespace lie_module
+
+/-- The derived Lie submodule of a Lie module. -/
+def derived_lie_submodule : lie_submodule R L M := ⁅(⊤ : lie_ideal R L), ⊤⁆
+
+lemma trivial_iff_derived_eq_bot : is_trivial L M ↔ derived_lie_submodule R L M = ⊥ :=
+begin
+  split; intros h,
+  { erw [eq_bot_iff, lie_submodule.lie_span_le], rintros m ⟨x, n, hn⟩, rw [← hn, h.trivial], simp,},
+  { rw lie_submodule.eq_bot_iff at h, apply is_trivial.mk, intros x m, apply h,
+    apply lie_submodule.subset_lie_span, use [x, m], refl, },
+end
+
+end lie_module
+
+/-- The derived Lie ideal of a Lie algebra. -/
+abbreviation lie_algebra.derived_lie_ideal : lie_ideal R L := lie_module.derived_lie_submodule R L L
+
+end lie_module
 
 section lie_submodule_map_and_comap
 

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -851,7 +851,7 @@ instance : add_comm_monoid (lie_submodule R L M) :=
 
 @[simp] lemma add_eq_sup : N + N' = N ⊔ N' := rfl
 
-lemma sup_eq_sup_submodule :
+@[norm_cast] lemma coe_sup :
   (↑(N ⊔ N') : submodule R M) = (N : submodule R M) ⊔ (N' : submodule R M) :=
 begin
   suffices : (↑(N ⊔ N') : submodule R M) ≤ (N : submodule R M) ⊔ (N' : submodule R M),

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -1104,12 +1104,12 @@ variables (R : Type u) (L : Type v) (M : Type w)
 variables [comm_ring R] [lie_ring L] [lie_algebra R L] [add_comm_group M] [module R M]
 variables [lie_ring_module L M] [lie_module R L M]
 
-namespace lie_module
+section lie_module
 
 /-- The derived Lie submodule of a Lie module. -/
 def derived_lie_submodule : lie_submodule R L M := ⁅(⊤ : lie_ideal R L), ⊤⁆
 
-lemma trivial_iff_derived_eq_bot : is_trivial L M ↔ derived_lie_submodule R L M = ⊥ :=
+lemma trivial_iff_derived_eq_bot : lie_module.is_trivial L M ↔ derived_lie_submodule R L M = ⊥ :=
 begin
   split; intros h,
   { erw [eq_bot_iff, lie_submodule.lie_span_le], rintros m ⟨x, n, hn⟩, rw [← hn, h.trivial], simp,},
@@ -1120,7 +1120,7 @@ end
 end lie_module
 
 /-- The derived Lie ideal of a Lie algebra. -/
-abbreviation lie_algebra.derived_lie_ideal : lie_ideal R L := lie_module.derived_lie_submodule R L L
+abbreviation derived_lie_ideal : lie_ideal R L := derived_lie_submodule R L L
 
 end lie_module
 

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -721,7 +721,7 @@ iff.rfl
 @[simp] lemma coe_to_set_mk (S : set M) (h₁ h₂ h₃ h₄) :
   ((⟨S, h₁, h₂, h₃, h₄⟩ : lie_submodule R L M) : set M) = S := rfl
 
-@[simp] lemma mk_coe_submodule (p : submodule R M) (h) :
+@[simp] lemma coe_to_submodule_mk (p : submodule R M) (h) :
   (({lie_mem := h, ..p} : lie_submodule R L M) : submodule R M) = p :=
 by { cases p, refl, }
 

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -783,7 +783,8 @@ instance : partial_order (lie_submodule R L M) :=
 
 lemma le_def : N ≤ N' ↔ (N : set M) ⊆ N' := iff.rfl
 
-@[simp, norm_cast] lemma coe_submodule_le_coe_submodule : (N : submodule R M) ≤ N' ↔ N ≤ N' := iff.rfl
+@[simp, norm_cast] lemma coe_submodule_le_coe_submodule : (N : submodule R M) ≤ N' ↔ N ≤ N' :=
+iff.rfl
 
 instance : has_bot (lie_submodule R L M) := ⟨0⟩
 
@@ -868,12 +869,12 @@ begin
         use [⁅x, y⁆, N.lie_mem hy, ⁅x, z⁆, N'.lie_mem hz],
       end,
       ..(N : submodule R M) ⊔ (N' : submodule R M) } : lie_submodule R L M),
-  use NN, simp only [←coe_le_coe_submodule, mem_set_of_eq, eq_self_iff_true, and_self, le_sup_left,
-    le_sup_right, mk_coe_submodule],
+  use NN, simp only [← coe_submodule_le_coe_submodule, mem_set_of_eq, eq_self_iff_true, and_self,
+    le_sup_left, le_sup_right, coe_to_submodule_mk],
 end
 
 lemma mem_sup (x : M) : x ∈ N ⊔ N' ↔ ∃ (y ∈ N) (z ∈ N'), y + z = x :=
-by { erw [← submodule.mem_sup, ← sup_eq_sup_submodule], refl, }
+by { erw [← submodule.mem_sup, ← coe_sup], refl, }
 
 lemma eq_bot_iff : N = ⊥ ↔ ∀ (m : M), m ∈ N → m = 0 :=
 by { rw eq_bot_iff, exact iff.rfl, }
@@ -932,10 +933,10 @@ section lie_ideal_operations
 /-- Given a Lie module `M` over a Lie algebra `L`, the set of Lie ideals of `L` acts on the set
 of submodules of `M`. -/
 instance : has_bracket (lie_ideal R L) (lie_submodule R L M) :=
-⟨λ I N, lie_submodule.lie_span R L { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m }⟩
+⟨λ I N, lie_span R L { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m }⟩
 
 lemma lie_ideal_oper_eq_span :
-  ⁅I, N⁆ = lie_submodule.lie_span R L { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m } := rfl
+  ⁅I, N⁆ = lie_span R L { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m } := rfl
 
 lemma lie_mem_lie (x : I) (m : N) : ⁅(x : L), (m : M)⁆ ∈ ⁅I, N⁆ :=
 by { rw lie_ideal_oper_eq_span, apply subset_lie_span, use [x, m], }

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -959,11 +959,7 @@ lemma lie_le_left : ⁅I, J⁆ ≤ I :=
 by { rw lie_comm, exact lie_le_right I J, }
 
 lemma lie_le_inf : ⁅I, J⁆ ≤ I ⊓ J :=
-begin
-  rw le_inf_iff, split,
-  { rw lie_comm, apply lie_le_right, },
-  { apply lie_le_right, },
-end
+by { rw le_inf_iff, exact ⟨lie_le_left I J, lie_le_right J I⟩, }
 
 @[simp] lemma lie_bot : ⁅I, (⊥ : lie_submodule R L M)⁆ = ⊥ :=
 by { rw eq_bot_iff, apply lie_le_right, }

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -783,7 +783,7 @@ instance : partial_order (lie_submodule R L M) :=
 
 lemma le_def : N ≤ N' ↔ (N : set M) ⊆ N' := iff.rfl
 
-@[simp] lemma coe_le_coe_submodule : (N : submodule R M) ≤ N' ↔ N ≤ N' := iff.rfl
+@[simp, norm_cast] lemma coe_submodule_le_coe_submodule : (N : submodule R M) ≤ N' ↔ N ≤ N' := iff.rfl
 
 instance : has_bot (lie_submodule R L M) := ⟨0⟩
 

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -859,11 +859,10 @@ begin
   { simp only [submodule.mem_sup],
     rintro x m ⟨y, hy, z, hz, rfl⟩,
     refine ⟨⁅x, y⁆, N.lie_mem hy, ⁅x, z⁆, N'.lie_mem hz, (lie_add _ _ _).symm⟩ },
-  refine le_antisymm (Inf_le ⟨{ lie_mem := aux, ..(N ⊔ N' : submodule R M) }, _⟩) (Inf_le_Inf _),
+  refine le_antisymm (Inf_le ⟨{ lie_mem := aux, ..(N ⊔ N' : submodule R M) }, _⟩) _,
   { simp only [exists_prop, and_true, mem_set_of_eq, eq_self_iff_true, coe_to_submodule_mk,
       ← coe_submodule_le_coe_submodule, and_self, le_sup_left, le_sup_right] },
-  { simp only [and_imp, set_of_subset_set_of, mem_set_of_eq, exists_imp_distrib],
-    intros p N'' hN hN' hp, rw ← hp, split; assumption, }
+  { simp, },
 end
 
 lemma mem_sup (x : M) : x ∈ N ⊔ N' ↔ ∃ (y ∈ N) (z ∈ N'), y + z = x :=

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -855,22 +855,15 @@ instance : add_comm_monoid (lie_submodule R L M) :=
 @[norm_cast] lemma coe_sup :
   (↑(N ⊔ N') : submodule R M) = (N : submodule R M) ⊔ (N' : submodule R M) :=
 begin
-  suffices : (↑(N ⊔ N') : submodule R M) ≤ (N : submodule R M) ⊔ (N' : submodule R M),
-  { apply le_antisymm this, apply Inf_le_Inf _,
-    simp only [and_imp, set_of_subset_set_of, mem_set_of_eq, exists_imp_distrib],
-    intros p N'' hN hN' hp, rw ← hp, split; assumption, },
-  apply Inf_le _,
-  let NN :=
-  ({ lie_mem := λ x m h,
-      begin
-        rw [submodule.mem_carrier, submodule.mem_coe, submodule.mem_sup] at h,
-        rcases h with ⟨y, hy, z, hz, hm⟩, rw ← hm,
-        rw [submodule.mem_carrier, submodule.mem_coe, lie_add, submodule.mem_sup],
-        use [⁅x, y⁆, N.lie_mem hy, ⁅x, z⁆, N'.lie_mem hz],
-      end,
-      ..(N : submodule R M) ⊔ (N' : submodule R M) } : lie_submodule R L M),
-  use NN, simp only [← coe_submodule_le_coe_submodule, mem_set_of_eq, eq_self_iff_true, and_self,
-    le_sup_left, le_sup_right, coe_to_submodule_mk],
+  have aux : ∀ (x : L) m, m ∈ (N ⊔ N' : submodule R M) → ⁅x,m⁆ ∈ (N ⊔ N' : submodule R M),
+  { simp only [submodule.mem_sup],
+    rintro x m ⟨y, hy, z, hz, rfl⟩,
+    refine ⟨⁅x, y⁆, N.lie_mem hy, ⁅x, z⁆, N'.lie_mem hz, (lie_add _ _ _).symm⟩ },
+  refine le_antisymm (Inf_le ⟨{ lie_mem := aux, ..(N ⊔ N' : submodule R M) }, _⟩) (Inf_le_Inf _),
+  { simp only [exists_prop, and_true, mem_set_of_eq, eq_self_iff_true, coe_to_submodule_mk,
+      ← coe_submodule_le_coe_submodule, and_self, le_sup_left, le_sup_right] },
+  { simp only [and_imp, set_of_subset_set_of, mem_set_of_eq, exists_imp_distrib],
+    intros p N'' hN hN' hp, rw ← hp, split; assumption, }
 end
 
 lemma mem_sup (x : M) : x ∈ N ⊔ N' ↔ ∃ (y ∈ N) (z ∈ N'), y + z = x :=

--- a/src/algebra/module/submodule.lean
+++ b/src/algebra/module/submodule.lean
@@ -64,6 +64,9 @@ theorem coe_injective : injective (coe : submodule R M → set M) :=
 
 @[simp, norm_cast] theorem coe_set_eq : (p : set M) = q ↔ p = q := coe_injective.eq_iff
 
+@[simp] lemma mk_coe (S : set M) (h₁ h₂ h₃) :
+  ((⟨S, h₁, h₂, h₃⟩ : submodule R M) : set M) = S := rfl
+
 theorem ext'_iff : p = q ↔ (p : set M) = q := coe_set_eq.symm
 
 @[ext] theorem ext (h : ∀ x, x ∈ p ↔ x ∈ q) : p = q := coe_injective $ set.ext h

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -341,7 +341,7 @@ begin
     { intros _ _ _ _ _ _, exact subtype.mk.inj, },
     { intros b hbs hb,
       use b,
-      simpa only [hbs, exists_prop, dif_pos, mk_coe, and_true, if_true, finset.coe_mem,
+      simpa only [hbs, exists_prop, dif_pos, finset.mk_coe, and_true, if_true, finset.coe_mem,
         eq_self_iff_true, exists_prop_of_true, ne.def] using hb, },
     { intros a h₁, dsimp, rw [dif_pos h₁],
       intro h₂, rw [if_pos], contrapose! h₂,


### PR DESCRIPTION
---
I am hoping that if these changes are merged, I can use them for https://github.com/leanprover-community/mathlib/pull/5241
