### PR TITLE
[Merged by Bors] - feat(ring_theory/algebra_tower): alg_hom_equiv_sigma

### DIFF
--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -465,7 +465,7 @@ variables {A} {B} {C D : Type*} [comm_semiring A] [comm_semiring B] [comm_semiri
 [comm_semiring D] [algebra A B] [algebra B C] [algebra A C] [algebra A D] [is_scalar_tower A B C]
 
 /-- Restrict the domain of an alg_hom -/
-def alg_hom_restrict (f : C →ₐ[A] D) : B →ₐ[A] D := f.comp (is_scalar_tower.to_alg_hom A B C)
+def alg_hom.restrict (f : C →ₐ[A] D) : B →ₐ[A] D := f.comp (is_scalar_tower.to_alg_hom A B C)
 
 /-- Extend the scalars of an alg_hom -/
 def alg_hom_extend_base (f : C →ₐ[A] D) :

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -461,42 +461,26 @@ end artin_tate
 
 section alg_hom_tower
 
-variables {A} {C D : Type*} [comm_semiring A]  [comm_semiring C] [comm_semiring D]
+variables {A} {C D : Type*} [comm_semiring A] [comm_semiring C] [comm_semiring D]
   [algebra A C] [algebra A D]
 
 variables (f : C →ₐ[A] D) (B) [comm_semiring B] [algebra A B] [algebra B C] [is_scalar_tower A B C]
 
 /-- Restrict the domain of an alg_hom -/
-def alg_hom.restrict : B →ₐ[A] D := f.comp (is_scalar_tower.to_alg_hom A B C)
+def alg_hom.restrict_domain : B →ₐ[A] D := f.comp (is_scalar_tower.to_alg_hom A B C)
 
 /-- Extend the scalars of an alg_hom -/
-def alg_hom.extend_base : @alg_hom B C D _ _ _ _ (f.restrict B).to_ring_hom.to_algebra :=
+def alg_hom.extend_scalars : @alg_hom B C D _ _ _ _ (f.restrict_domain B).to_ring_hom.to_algebra :=
 { commutes' := λ _, rfl .. f }
 
 variables {B}
 
-/-- Combine two alg_hom's that are in a tower -/
-def alg_hom_compose (f : B →ₐ[A] D) (g : @alg_hom B C D _ _ _ _ f.to_ring_hom.to_algebra) :
-  C →ₐ[A] D :=
-{ to_fun := g,
-  map_one' := by simp only [alg_hom.map_one],
-  map_zero' := by simp only [alg_hom.map_zero],
-  map_mul' := by simp only [forall_const, eq_self_iff_true, alg_hom.map_mul],
-  map_add' := by simp only [alg_hom.map_add, forall_const, eq_self_iff_true],
-  commutes' :=
-  begin
-    intros r,
-    have key := @alg_hom.commutes' B C D _ _ _ _ f.to_ring_hom.to_algebra g (algebra_map A B r),
-    rw ← is_scalar_tower.algebra_map_apply at key,
-    rw ← is_scalar_tower.algebra_map_apply at key,
-    exact key,
-  end }
-
 /-- alg_hom's from the top of a tower are equivalent to a pair of alg_homs -/
 def alg_hom_equiv_sigma :
   (C →ₐ[A] D) ≃ Σ (f : B →ₐ[A] D), @alg_hom B C D _ _ _ _ f.to_ring_hom.to_algebra :=
-{ to_fun := λ f, ⟨f.restrict B, f.extend_base B⟩,
-  inv_fun := λ fg, alg_hom_compose fg.1 fg.2,
+{ to_fun := λ f, ⟨f.restrict_domain B, f.extend_scalars B⟩,
+  inv_fun := λ fg, @is_scalar_tower.restrict_base A _ _ _ _ _ _ _ _ _ fg.1.to_ring_hom.to_algebra
+    _ _ _ _ fg.2, /- Is there a nice way to provide the algebra instance without the `@`? -/
   left_inv := λ f, by {dsimp only, ext, refl},
   right_inv :=
   begin

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -464,12 +464,15 @@ section alg_hom_tower
 variables {A} {B} {C D : Type*} [comm_semiring A] [comm_semiring B] [comm_semiring C]
 [comm_semiring D] [algebra A B] [algebra B C] [algebra A C] [algebra A D] [is_scalar_tower A B C]
 
+/-- Restrict the domain of an alg_hom -/
 def alg_hom_restrict (f : C →ₐ[A] D) : B →ₐ[A] D := f.comp (is_scalar_tower.to_alg_hom A B C)
 
+/-- Extend the scalars of an alg_hom -/
 def alg_hom_extend_base (f : C →ₐ[A] D) :
   @alg_hom B C D _ _ _ _ (ring_hom.to_algebra ((alg_hom_restrict f).to_ring_hom)) :=
 { commutes' := λ _, rfl .. f }
 
+/-- Combine two alg_hom's that are in a tower -/
 def alg_hom_compose (f : B →ₐ[A] D) (g : @alg_hom B C D _ _ _ _ (ring_hom.to_algebra f)) :
   C →ₐ[A] D :=
 { to_fun := g,
@@ -486,6 +489,7 @@ def alg_hom_compose (f : B →ₐ[A] D) (g : @alg_hom B C D _ _ _ _ (ring_hom.to
     exact key,
   end }
 
+/-- alg_hom's from the top of a tower are equivalent to a pair of alg_homs -/
 def alg_hom_equiv_sigma :
   (C →ₐ[A] D) ≃ Σ (f : B →ₐ[A] D), @alg_hom B C D _ _ _ _ (ring_hom.to_algebra f) :=
 { to_fun := λ f, ⟨alg_hom_restrict f, alg_hom_extend_base f⟩,

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -476,7 +476,7 @@ def alg_hom.extend_base : @alg_hom B C D _ _ _ _ (f.restrict B).to_ring_hom.to_a
 variables {B}
 
 /-- Combine two alg_hom's that are in a tower -/
-def alg_hom_compose (f : B →ₐ[A] D) (g : @alg_hom B C D _ _ _ _ (ring_hom.to_algebra f)) :
+def alg_hom_compose (f : B →ₐ[A] D) (g : @alg_hom B C D _ _ _ _ f.to_ring_hom.to_algebra) :
   C →ₐ[A] D :=
 { to_fun := g,
   map_one' := by simp only [alg_hom.map_one],
@@ -486,7 +486,7 @@ def alg_hom_compose (f : B →ₐ[A] D) (g : @alg_hom B C D _ _ _ _ (ring_hom.to
   commutes' :=
   begin
     intros r,
-    have key := @alg_hom.commutes' B C D _ _ _ _ (ring_hom.to_algebra f) g (algebra_map A B r),
+    have key := @alg_hom.commutes' B C D _ _ _ _ f.to_ring_hom.to_algebra g (algebra_map A B r),
     rw ← is_scalar_tower.algebra_map_apply at key,
     rw ← is_scalar_tower.algebra_map_apply at key,
     exact key,
@@ -494,7 +494,7 @@ def alg_hom_compose (f : B →ₐ[A] D) (g : @alg_hom B C D _ _ _ _ (ring_hom.to
 
 /-- alg_hom's from the top of a tower are equivalent to a pair of alg_homs -/
 def alg_hom_equiv_sigma :
-  (C →ₐ[A] D) ≃ Σ (f : B →ₐ[A] D), @alg_hom B C D _ _ _ _ (ring_hom.to_algebra f) :=
+  (C →ₐ[A] D) ≃ Σ (f : B →ₐ[A] D), @alg_hom B C D _ _ _ _ f.to_ring_hom.to_algebra :=
 { to_fun := λ f, ⟨f.restrict B, f.extend_base B⟩,
   inv_fun := λ fg, alg_hom_compose fg.1 fg.2,
   left_inv := λ f, by {dsimp only, ext, refl},

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -466,7 +466,7 @@ variables {A} {C D : Type*} [comm_semiring A] [comm_semiring C] [comm_semiring D
 
 variables (f : C →ₐ[A] D) (B) [comm_semiring B] [algebra A B] [algebra B C] [is_scalar_tower A B C]
 
-/-- Restrict the domain of an alg_hom -/
+/-- Restrict the domain of an `alg_hom`. -/
 def alg_hom.restrict_domain : B →ₐ[A] D := f.comp (is_scalar_tower.to_alg_hom A B C)
 
 /-- Extend the scalars of an alg_hom -/

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -486,7 +486,7 @@ def alg_hom_compose (f : B →ₐ[A] D) (g : @alg_hom B C D _ _ _ _ (ring_hom.to
     exact key,
   end }
 
-def alg_hom_equiv_sigma_subalgebra :
+def alg_hom_equiv_sigma :
   (C →ₐ[A] D) ≃ Σ (f : B →ₐ[A] D), @alg_hom B C D _ _ _ _ (ring_hom.to_algebra f) :=
 { to_fun := λ f, ⟨alg_hom_restrict f, alg_hom_extend_base f⟩,
   inv_fun := λ fg, alg_hom_compose fg.1 fg.2,

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -479,8 +479,7 @@ variables {B}
 def alg_hom_equiv_sigma :
   (C →ₐ[A] D) ≃ Σ (f : B →ₐ[A] D), @alg_hom B C D _ _ _ _ f.to_ring_hom.to_algebra :=
 { to_fun := λ f, ⟨f.restrict_domain B, f.extend_scalars B⟩,
-  inv_fun := λ fg, @is_scalar_tower.restrict_base A _ _ _ _ _ _ _ _ _ fg.1.to_ring_hom.to_algebra
-    _ _ _ _ fg.2, /- Is there a nice way to provide the algebra instance without the `@`? -/
+  inv_fun := λ f, by letI := f.1.to_ring_hom.to_algebra; exact is_scalar_tower.restrict_base A f.2,
   left_inv := λ f, by { dsimp only, ext, refl },
   right_inv :=
   begin

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -458,3 +458,45 @@ by exactI fg_of_injective (is_scalar_tower.to_alg_hom B₀ B C).to_linear_map
   (linear_map.ker_eq_bot.2 hBCi)
 
 end artin_tate
+
+section alg_hom_tower
+
+variables {A} {B} {C D : Type*} [comm_semiring A] [comm_semiring B] [comm_semiring C]
+[comm_semiring D] [algebra A B] [algebra B C] [algebra A C] [algebra A D] [is_scalar_tower A B C]
+
+def alg_hom_restrict (f : C →ₐ[A] D) : B →ₐ[A] D := f.comp (is_scalar_tower.to_alg_hom A B C)
+
+def alg_hom_extend_base (f : C →ₐ[A] D) :
+  @alg_hom B C D _ _ _ _ (ring_hom.to_algebra ((alg_hom_restrict f).to_ring_hom)) :=
+{ commutes' := λ _, rfl .. f }
+
+def alg_hom_compose (f : B →ₐ[A] D) (g : @alg_hom B C D _ _ _ _ (ring_hom.to_algebra f)) :
+  C →ₐ[A] D :=
+{ to_fun := g,
+  map_one' := by simp only [alg_hom.map_one],
+  map_zero' := by simp only [alg_hom.map_zero],
+  map_mul' := by simp only [forall_const, eq_self_iff_true, alg_hom.map_mul],
+  map_add' := by simp only [alg_hom.map_add, forall_const, eq_self_iff_true],
+  commutes' :=
+  begin
+    intros r,
+    have key := @alg_hom.commutes' B C D _ _ _ _ (ring_hom.to_algebra f) g (algebra_map A B r),
+    rw ← is_scalar_tower.algebra_map_apply at key,
+    rw ← is_scalar_tower.algebra_map_apply at key,
+    exact key,
+  end }
+
+def alg_hom_equiv_sigma_subalgebra :
+  (C →ₐ[A] D) ≃ Σ (f : B →ₐ[A] D), @alg_hom B C D _ _ _ _ (ring_hom.to_algebra f) :=
+{ to_fun := λ f, ⟨alg_hom_restrict f, alg_hom_extend_base f⟩,
+  inv_fun := λ fg, alg_hom_compose fg.1 fg.2,
+  left_inv := λ f, by {dsimp only, ext, refl},
+  right_inv :=
+  begin
+    rintros ⟨⟨f, _, _, _, _, _⟩, g, _, _, _, _, hg⟩,
+    have : f = λ x, g (algebra_map B C x) := by { ext, exact (hg x).symm },
+    subst this,
+    refl,
+  end }
+
+end alg_hom_tower

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -481,7 +481,7 @@ def alg_hom_equiv_sigma :
 { to_fun := λ f, ⟨f.restrict_domain B, f.extend_scalars B⟩,
   inv_fun := λ fg, @is_scalar_tower.restrict_base A _ _ _ _ _ _ _ _ _ fg.1.to_ring_hom.to_algebra
     _ _ _ _ fg.2, /- Is there a nice way to provide the algebra instance without the `@`? -/
-  left_inv := λ f, by {dsimp only, ext, refl},
+  left_inv := λ f, by { dsimp only, ext, refl },
   right_inv :=
   begin
     rintros ⟨⟨f, _, _, _, _, _⟩, g, _, _, _, _, hg⟩,

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -475,7 +475,7 @@ def alg_hom.extend_scalars : @alg_hom B C D _ _ _ _ (f.restrict_domain B).to_rin
 
 variables {B}
 
-/-- alg_hom's from the top of a tower are equivalent to a pair of alg_homs -/
+/-- `alg_hom`s from the top of a tower are equivalent to a pair of `alg_hom`s. -/
 def alg_hom_equiv_sigma :
   (C →ₐ[A] D) ≃ Σ (f : B →ₐ[A] D), @alg_hom B C D _ _ _ _ f.to_ring_hom.to_algebra :=
 { to_fun := λ f, ⟨f.restrict_domain B, f.extend_scalars B⟩,

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -461,16 +461,19 @@ end artin_tate
 
 section alg_hom_tower
 
-variables {A} {B} {C D : Type*} [comm_semiring A] [comm_semiring B] [comm_semiring C]
-[comm_semiring D] [algebra A B] [algebra B C] [algebra A C] [algebra A D] [is_scalar_tower A B C]
+variables {A} {C D : Type*} [comm_semiring A]  [comm_semiring C] [comm_semiring D]
+  [algebra A C] [algebra A D]
+
+variables (f : C →ₐ[A] D) (B) [comm_semiring B] [algebra A B] [algebra B C] [is_scalar_tower A B C]
 
 /-- Restrict the domain of an alg_hom -/
-def alg_hom.restrict (f : C →ₐ[A] D) : B →ₐ[A] D := f.comp (is_scalar_tower.to_alg_hom A B C)
+def alg_hom.restrict : B →ₐ[A] D := f.comp (is_scalar_tower.to_alg_hom A B C)
 
 /-- Extend the scalars of an alg_hom -/
-def alg_hom_extend_base (f : C →ₐ[A] D) :
-  @alg_hom B C D _ _ _ _ (alg_hom_restrict f).to_ring_hom.to_algebra :=
+def alg_hom.extend_base : @alg_hom B C D _ _ _ _ (f.restrict B).to_ring_hom.to_algebra :=
 { commutes' := λ _, rfl .. f }
+
+variables {B}
 
 /-- Combine two alg_hom's that are in a tower -/
 def alg_hom_compose (f : B →ₐ[A] D) (g : @alg_hom B C D _ _ _ _ (ring_hom.to_algebra f)) :
@@ -492,7 +495,7 @@ def alg_hom_compose (f : B →ₐ[A] D) (g : @alg_hom B C D _ _ _ _ (ring_hom.to
 /-- alg_hom's from the top of a tower are equivalent to a pair of alg_homs -/
 def alg_hom_equiv_sigma :
   (C →ₐ[A] D) ≃ Σ (f : B →ₐ[A] D), @alg_hom B C D _ _ _ _ (ring_hom.to_algebra f) :=
-{ to_fun := λ f, ⟨alg_hom_restrict f, alg_hom_extend_base f⟩,
+{ to_fun := λ f, ⟨f.restrict B, f.extend_base B⟩,
   inv_fun := λ fg, alg_hom_compose fg.1 fg.2,
   left_inv := λ f, by {dsimp only, ext, refl},
   right_inv :=

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -469,7 +469,7 @@ def alg_hom_restrict (f : C →ₐ[A] D) : B →ₐ[A] D := f.comp (is_scalar_to
 
 /-- Extend the scalars of an alg_hom -/
 def alg_hom_extend_base (f : C →ₐ[A] D) :
-  @alg_hom B C D _ _ _ _ (ring_hom.to_algebra ((alg_hom_restrict f).to_ring_hom)) :=
+  @alg_hom B C D _ _ _ _ (alg_hom_restrict f).to_ring_hom.to_algebra :=
 { commutes' := λ _, rfl .. f }
 
 /-- Combine two alg_hom's that are in a tower -/

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -479,7 +479,8 @@ variables {B}
 def alg_hom_equiv_sigma :
   (C →ₐ[A] D) ≃ Σ (f : B →ₐ[A] D), @alg_hom B C D _ _ _ _ f.to_ring_hom.to_algebra :=
 { to_fun := λ f, ⟨f.restrict_domain B, f.extend_scalars B⟩,
-  inv_fun := λ f, by letI := f.1.to_ring_hom.to_algebra; exact is_scalar_tower.restrict_base A f.2,
+  inv_fun := λ fg, @is_scalar_tower.restrict_base A _ _ _ _ _ _ _ _ _
+    fg.1.to_ring_hom.to_algebra _ _ _ _ fg.2,
   left_inv := λ f, by { dsimp only, ext, refl },
   right_inv :=
   begin

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -469,7 +469,7 @@ variables (f : C →ₐ[A] D) (B) [comm_semiring B] [algebra A B] [algebra B C] 
 /-- Restrict the domain of an `alg_hom`. -/
 def alg_hom.restrict_domain : B →ₐ[A] D := f.comp (is_scalar_tower.to_alg_hom A B C)
 
-/-- Extend the scalars of an alg_hom -/
+/-- Extend the scalars of an `alg_hom`. -/
 def alg_hom.extend_scalars : @alg_hom B C D _ _ _ _ (f.restrict_domain B).to_ring_hom.to_algebra :=
 { commutes' := λ _, rfl .. f }
 


### PR DESCRIPTION
Proves that algebra homomorphisms from the top of an is_scalar_tower are the same as a pair of algebra homomorphisms.

This is useful for counting algebra homomorphisms.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
