### PR TITLE
[Merged by Bors] - chore(analysis/calculus/*): rename `*.of_local_homeomorph` to `local_homeomorph.*_symm`

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -1474,9 +1474,8 @@ lemma local_homeomorph.has_deriv_at_symm (f : local_homeomorph 𝕜 𝕜) {a f' 
 htff'.of_local_left_inverse (f.symm.continuous_at ha) hf' (f.eventually_right_inverse ha)
 
 theorem not_differentiable_within_at_of_local_left_inverse_has_deriv_within_at_zero
-  {f g : 𝕜 → 𝕜} {a : 𝕜} {s t : set 𝕜} (ha : a ∈ s) (hs : is_closed s)
-  (hsu : unique_diff_within_at 𝕜 s a) (hf : has_deriv_within_at f 0 t (g a))
-  (hst : maps_to g s t) (hfg : f ∘ g =ᶠ[𝓝[s] a] id) :
+  {f g : 𝕜 → 𝕜} {a : 𝕜} {s t : set 𝕜} (ha : a ∈ s) (hsu : unique_diff_within_at 𝕜 s a)
+  (hf : has_deriv_within_at f 0 t (g a)) (hst : maps_to g s t) (hfg : f ∘ g =ᶠ[𝓝[s] a] id) :
   ¬differentiable_within_at 𝕜 g s a :=
 begin
   intro hg,

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -393,6 +393,10 @@ lemma has_deriv_within_at.congr_of_eventually_eq (h : has_deriv_within_at f f' s
   (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : has_deriv_within_at f₁ f' s x :=
 has_deriv_at_filter.congr_of_eventually_eq h h₁ hx
 
+lemma has_deriv_within_at.congr_of_eventually_eq_of_mem (h : has_deriv_within_at f f' s x)
+  (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : x ∈ s) : has_deriv_within_at f₁ f' s x :=
+h.congr_of_eventually_eq h₁ (h₁.eq_of_nhds_within hx)
+
 lemma has_deriv_at.congr_of_eventually_eq (h : has_deriv_at f f' x)
   (h₁ : f₁ =ᶠ[𝓝 x] f) : has_deriv_at f₁ f' x :=
 has_deriv_at_filter.congr_of_eventually_eq h h₁ (mem_of_nhds h₁ : _)
@@ -1458,6 +1462,36 @@ theorem has_deriv_at.of_local_left_inverse {f g : 𝕜 → 𝕜} {f' a : 𝕜}
   (hfg : ∀ᶠ y in 𝓝 a, f (g y) = y) :
   has_deriv_at g f'⁻¹ a :=
 (hf.has_fderiv_at_equiv hf').of_local_left_inverse hg hfg
+
+/-- If `f` is a local homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has an
+nonzero derivative `f'` at `f.symm a`, then `f.symm` has the derivative `f'⁻¹` at `a`.
+
+This is one of the easy parts of the inverse function theorem: it assumes that we already have
+an inverse function. -/
+lemma local_homeomorph.has_deriv_at_symm (f : local_homeomorph 𝕜 𝕜) {a f' : 𝕜}
+  (ha : a ∈ f.target) (hf' : f' ≠ 0) (htff' : has_deriv_at f f' (f.symm a)) :
+  has_deriv_at f.symm f'⁻¹ a :=
+htff'.of_local_left_inverse (f.symm.continuous_at ha) hf' (f.eventually_right_inverse ha)
+
+theorem not_differentiable_within_at_of_local_left_inverse_has_deriv_within_at_zero
+  {f g : 𝕜 → 𝕜} {a : 𝕜} {s t : set 𝕜} (ha : a ∈ s) (hs : is_closed s)
+  (hsu : unique_diff_within_at 𝕜 s a) (hf : has_deriv_within_at f 0 t (g a))
+  (hst : maps_to g s t) (hfg : f ∘ g =ᶠ[𝓝[s] a] id) :
+  ¬differentiable_within_at 𝕜 g s a :=
+begin
+  intro hg,
+  have := (hf.comp a hg.has_deriv_within_at hst).congr_of_eventually_eq_of_mem hfg.symm ha,
+  simpa using hsu.eq_deriv _ this (has_deriv_within_at_id _ _)
+end
+
+theorem not_differentiable_at_of_local_left_inverse_has_deriv_at_zero
+  {f g : 𝕜 → 𝕜} {a : 𝕜} (hf : has_deriv_at f 0 (g a)) (hfg : f ∘ g =ᶠ[𝓝 a] id) :
+  ¬differentiable_at 𝕜 g a :=
+begin
+  intro hg,
+  have := (hf.comp a hg.has_deriv_at).congr_of_eventually_eq hfg.symm,
+  simpa using has_deriv_at_unique this (has_deriv_at_id a)
+end
 
 end
 

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -2387,13 +2387,23 @@ begin
     simp only [(∘), hp, hfg.self_of_nhds] }
 end
 
+/-- If `f` is a local homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has an
+invertible derivative `f'` in the sense of strict differentiability at `f.symm a`, then `f.symm` has
+the derivative `f'⁻¹` at `a`.
+
+This is one of the easy parts of the inverse function theorem: it assumes that we already have
+an inverse function. -/
+lemma local_homeomorph.has_strict_fderiv_at_symm (f : local_homeomorph E F) {f' : E ≃L[𝕜] F} {a : F}
+  (ha : a ∈ f.target) (htff' : has_strict_fderiv_at f (f' : E →L[𝕜] F) (f.symm a)) :
+  has_strict_fderiv_at f.symm (f'.symm : F →L[𝕜] E) a :=
+htff'.of_local_left_inverse (f.symm.continuous_at ha) (f.eventually_right_inverse ha)
 
 /-- If `f` is a local homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has an
 invertible derivative `f'` at `f.symm a`, then `f.symm` has the derivative `f'⁻¹` at `a`.
 
 This is one of the easy parts of the inverse function theorem: it assumes that we already have
 an inverse function. -/
-lemma has_fderiv_at.of_local_homeomorph {f : local_homeomorph E F} {f' : E ≃L[𝕜] F} {a : F}
+lemma local_homeomorph.has_fderiv_at_symm (f : local_homeomorph E F) {f' : E ≃L[𝕜] F} {a : F}
   (ha : a ∈ f.target) (htff' : has_fderiv_at f (f' : E →L[𝕜] F) (f.symm a)) :
   has_fderiv_at f.symm (f'.symm : F →L[𝕜] E) a :=
 htff'.of_local_left_inverse (f.symm.continuous_at ha) (f.eventually_right_inverse ha)

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -424,11 +424,15 @@ def local_inverse (hf : has_strict_fderiv_at f (f' : E →L[𝕜] F) a) : F → 
 
 variables {f f' a}
 
+lemma local_inverse_def (hf : has_strict_fderiv_at f (f' : E →L[𝕜] F) a) :
+  hf.local_inverse f _ _ = (hf.to_local_homeomorph f).symm :=
+rfl
+
 lemma eventually_left_inverse (hf : has_strict_fderiv_at f (f' : E →L[𝕜] F) a) :
   ∀ᶠ x in 𝓝 a, hf.local_inverse f f' a (f x) = x :=
 (hf.to_local_homeomorph f).eventually_left_inverse hf.mem_to_local_homeomorph_source
 
-lemma local_inverse_apply_image (hf : has_strict_fderiv_at f (f' : E →L[𝕜] F) a) :
+@[simp] lemma local_inverse_apply_image (hf : has_strict_fderiv_at f (f' : E →L[𝕜] F) a) :
   hf.local_inverse f f' a (f a) = a :=
 hf.eventually_left_inverse.self_of_nhds
 
@@ -454,11 +458,8 @@ eventually_eq_of_left_inv_of_right_inv hg hf.eventually_right_inverse $
 then the inverse function `hf.local_inverse f` has derivative `f'.symm` at `f a`. -/
 theorem to_local_inverse (hf : has_strict_fderiv_at f (f' : E →L[𝕜] F) a) :
   has_strict_fderiv_at (hf.local_inverse f f' a) (f'.symm : F →L[𝕜] E) (f a) :=
-begin
-  have : has_strict_fderiv_at f (f' : E →L[𝕜] F) (hf.local_inverse f f' a (f a)),
-  { rwa hf.local_inverse_apply_image },
-  exact this.of_local_left_inverse hf.local_inverse_continuous_at hf.eventually_right_inverse
-end
+(hf.to_local_homeomorph f).has_strict_fderiv_at_symm hf.image_mem_to_local_homeomorph_target $
+  by simpa [← local_inverse_def] using hf
 
 /-- If `f : E → F` has an invertible derivative `f'` at `a` in the sense of strict differentiability
 and `g (f x) = x` in a neighborhood of `a`, then `g` has derivative `f'.symm` at `f a`.
@@ -563,7 +564,8 @@ lemma to_local_inverse
   times_cont_diff_at ℝ n (hf.local_inverse hf' hn) (f a) :=
 begin
   have := hf.local_inverse_apply_image hf' hn,
-  apply times_cont_diff_at.of_local_homeomorph (image_mem_to_local_homeomorph_target hf hf' hn),
+  apply (hf.to_local_homeomorph f hf' hn).times_cont_diff_at_symm
+    (image_mem_to_local_homeomorph_target hf hf' hn),
   { convert hf' },
   { convert hf }
 end

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -2458,8 +2458,8 @@ equivalence, then `f.symm` is `n` times continuously differentiable at the point
 
 This is one of the easy parts of the inverse function theorem: it assumes that we already have
 an inverse function. -/
-theorem times_cont_diff_at.of_local_homeomorph [complete_space E] {n : with_top ℕ}
-  {f : local_homeomorph E F} {f₀' : E ≃L[𝕜] F} {a : F} (ha : a ∈ f.target)
+theorem local_homeomorph.times_cont_diff_at_symm [complete_space E] {n : with_top ℕ}
+  (f : local_homeomorph E F) {f₀' : E ≃L[𝕜] F} {a : F} (ha : a ∈ f.target)
   (hf₀' : has_fderiv_at f (f₀' : E →L[𝕜] F) (f.symm a)) (hf : times_cont_diff_at 𝕜 n f (f.symm a)) :
   times_cont_diff_at 𝕜 n f.symm a :=
 begin
@@ -2490,7 +2490,7 @@ begin
       have h_deriv : has_fderiv_at f ↑e ((f.symm) x),
       { rw he,
         exact hff' (f.symm x) hxu },
-      convert h_deriv.of_local_homeomorph hx.1,
+      convert f.has_fderiv_at_symm hx.1 h_deriv,
       simp [← he] },
     { -- Then we check that the formula, being a composition of `times_cont_diff` pieces, is
       -- itself `times_cont_diff`


### PR DESCRIPTION
Rename some lemmas, and make `(f : local_homeomorph _ _)` an explicit argument:

* `has_fderiv_at.of_local_homeomorph` → `local_homeomorph.has_fderiv_at_symm`;
* `times_cont_diff_at.of_local_homeomorph` → `local_homeomorph.times_cont_diff_at_symm`.

If we want to apply one of these lemmas to prove smoothness of, e.g., `arctan`, `log`, or `arcsin`, then the goal
has no `local_homeomorph.symm`, and we need to explicitly supply a `local_homeomorph` with an appropriate `inv_fun`.

Also add some lemmas that help to prove that the inverse function is **not** differentiable at a point.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
