### PR TITLE
fix(group_theory/group_action/defs): Make smul_comm_class.symm an instance

### DIFF
--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -413,7 +413,7 @@ namespace int
 variables [semiring R] [add_comm_group M] [semimodule R M]
 
 instance smul_comm_class : smul_comm_class ℤ R M :=
-{ smul_comm := λ z r l, by cases z; simp [←gsmul_eq_smul, ←nat.smul_def, smul_comm] }
+{ smul_comm := λ z r l, by cases z; simp [←gsmul_eq_smul, ←nat.smul_def, smul_comm (_ : ℕ)] }
 
 end int
 

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -55,9 +55,8 @@ class smul_comm_class (M N α : Type*) [has_scalar M α] [has_scalar N α] : Pro
 
 export mul_action (mul_smul) smul_comm_class (smul_comm)
 
-/-- Commutativity of actions is a symmetric relation. This lemma can't be an instance because this
-would cause a loop in the instance search graph. -/
-lemma smul_comm_class.symm (M N α : Type*) [has_scalar M α] [has_scalar N α]
+/-- Commutativity of actions is a symmetric relation. See note [lower instance priority. -/
+@[priority 100] instance smul_comm_class.symm (M N α : Type*) [has_scalar M α] [has_scalar N α]
   [smul_comm_class M N α] : smul_comm_class N M α :=
 ⟨λ a' a b, (smul_comm a a' b).symm⟩
 

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -270,7 +270,8 @@ def alternatization : multilinear_map R (λ i : ι, M) L →+ alternating_map R 
 { to_fun := λ m,
   { to_fun := λ v, ∑ (σ : perm ι), (σ.sign : ℤ) • m.dom_dom_congr σ v,
     map_add' := λ v i a b, by simp_rw [←finset.sum_add_distrib, multilinear_map.map_add, smul_add],
-    map_smul' := λ v i c a, by simp_rw [finset.smul_sum, multilinear_map.map_smul, smul_comm],
+    map_smul' := λ v i c a, by simp_rw [finset.smul_sum, multilinear_map.map_smul,
+                                        smul_comm (_ : ℤ)],
     map_eq_zero_of_eq' := λ v i j hvij hij, alternization_map_eq_zero_of_eq_aux m v i j hij hvij },
   map_add' := λ a b, begin
     ext,


### PR DESCRIPTION
Using a low priority appears to avoid the loops.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
I guess CI will tell whether that's actually true.

This fixes the issue in [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Instance.20diamonds.20in.20.E2.84.A4-module.20structure.20of.20linear_map/near/219822867)
