### PR TITLE
[Merged by Bors] - chore(topology/instances/ennreal): remove summability assumption in tendsto_sum_nat_add

### DIFF
--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -546,7 +546,6 @@ If `s` is a finset of `α`, we show that the summability of `f` in the whole spa
 formula `(∑ i in range k, f i) + (∑' i, f (i + k)) = (∑' i, f i)`, in `sum_add_tsum_nat_add`.
 -/
 section subtype
-variables {s : finset β}
 
 lemma has_sum_nat_add_iff {f : ℕ → α} (k : ℕ) {a : α} :
   has_sum (λ n, f (n + k)) a ↔ has_sum f (a + ∑ i in range k, f i) :=
@@ -572,6 +571,22 @@ by simpa [add_comm] using
 lemma tsum_eq_zero_add [t2_space α] {f : ℕ → α} (hf : summable f) :
   (∑'b, f b) = f 0 + (∑'b, f (b + 1)) :=
 by simpa only [range_one, sum_singleton] using (sum_add_tsum_nat_add 1 hf).symm
+
+/-- For `f : ℕ → α`, then `∑' k, f (k + i)` tends to zero. -/
+lemma tendsto_sum_nat_add [t2_space α] (f : ℕ → α) : tendsto (λ i, ∑' k, f (k + i)) at_top (𝓝 0) :=
+begin
+  by_cases hf : summable f,
+  { have h₀ : (λ i, (∑' i, f i) - ∑ j in range i, f j) = λ i, ∑' (k : ℕ), f (k + i),
+    { ext1 i,
+      rw [sub_eq_iff_eq_add, add_comm, sum_add_tsum_nat_add i hf] },
+    have h₁ : tendsto (λ i : ℕ, ∑' i, f i) at_top (𝓝 (∑' i, f i)) := tendsto_const_nhds,
+    simpa only [h₀, sub_self] using tendsto.sub h₁ hf.has_sum.tendsto_sum_nat },
+  { convert tendsto_const_nhds,
+    ext1 i,
+    rw ← summable_nat_add_iff i at hf,
+    { exact tsum_eq_zero_of_not_summable hf },
+    { apply_instance } }
+end
 
 end subtype
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -572,7 +572,8 @@ lemma tsum_eq_zero_add [t2_space α] {f : ℕ → α} (hf : summable f) :
   (∑'b, f b) = f 0 + (∑'b, f (b + 1)) :=
 by simpa only [range_one, sum_singleton] using (sum_add_tsum_nat_add 1 hf).symm
 
-/-- For `f : ℕ → α`, then `∑' k, f (k + i)` tends to zero. -/
+/-- For `f : ℕ → α`, then `∑' k, f (k + i)` tends to zero. This does not require a summability
+assumption on `f`, as otherwise all sums are zero. -/
 lemma tendsto_sum_nat_add [t2_space α] (f : ℕ → α) : tendsto (λ i, ∑' k, f (k + i)) at_top (𝓝 0) :=
 begin
   by_cases hf : summable f,

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -646,16 +646,12 @@ tsum_le_tsum_of_inj i hi (λ c hc, zero_le _) (λ b, le_refl _) (summable_comp_i
 
 open finset
 
-/-- If `f : ℕ → ℝ≥0` and `∑' f` exists, then `∑' k, f (k + i)` tends to zero. -/
-lemma tendsto_sum_nat_add (f : ℕ → ℝ≥0) (hf : summable f) :
-  tendsto (λ i, ∑' k, f (k + i)) at_top (𝓝 0) :=
+/-- For `f : ℕ → ℝ≥0`, then `∑' k, f (k + i)` tends to zero. -/
+lemma tendsto_sum_nat_add (f : ℕ → ℝ≥0) : tendsto (λ i, ∑' k, f (k + i)) at_top (𝓝 0) :=
 begin
-  have h₀ : (λ i, (∑' i, f i) - ∑ j in range i, f j) = λ i, ∑' (k : ℕ), f (k + i),
-  { ext1 i,
-    rw [sub_eq_iff_eq_add, sum_add_tsum_nat_add i hf, add_comm],
-    exact sum_le_tsum _ (λ _ _, zero_le _) hf },
-  have h₁ : tendsto (λ i : ℕ, ∑' i, f i) at_top (𝓝 (∑' i, f i)) := tendsto_const_nhds,
-  simpa only [h₀, sub_self] using tendsto.sub h₁ hf.has_sum.tendsto_sum_nat
+  rw ← tendsto_coe,
+  convert tendsto_sum_nat_add (λ i, (f i : ℝ)),
+  norm_cast,
 end
 
 end nnreal
@@ -671,7 +667,7 @@ begin
       (nnreal.summable_nat_add _ (summable_to_nnreal_of_tsum_ne_top hf) _)).symm,
   simp only [λ x, (to_nnreal_apply_of_tsum_ne_top hf x).symm, ←ennreal.coe_zero,
     this, ennreal.tendsto_coe] { single_pass := tt },
-  exact nnreal.tendsto_sum_nat_add _ (summable_to_nnreal_of_tsum_ne_top hf)
+  exact nnreal.tendsto_sum_nat_add _
 end
 
 end ennreal

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -646,7 +646,8 @@ tsum_le_tsum_of_inj i hi (λ c hc, zero_le _) (λ b, le_refl _) (summable_comp_i
 
 open finset
 
-/-- For `f : ℕ → ℝ≥0`, then `∑' k, f (k + i)` tends to zero. -/
+/-- For `f : ℕ → ℝ≥0`, then `∑' k, f (k + i)` tends to zero. This does not require a summability
+assumption on `f`, as otherwise all sums are zero. -/
 lemma tendsto_sum_nat_add (f : ℕ → ℝ≥0) : tendsto (λ i, ∑' k, f (k + i)) at_top (𝓝 0) :=
 begin
   rw ← tendsto_coe,

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -96,6 +96,12 @@ show summable ((coe ∘ f) ∘ i), from (nnreal.summable_coe.2 hf).comp_injectiv
 lemma summable_nat_add (f : ℕ → ℝ≥0) (hf : summable f) (k : ℕ) : summable (λ i, f (i + k)) :=
 summable_comp_injective hf $ add_left_injective k
 
+lemma summable_nat_add_iff {f : ℕ → ℝ≥0} (k : ℕ) : summable (λ i, f (i + k)) ↔ summable f :=
+begin
+  rw [← summable_coe, ← summable_coe],
+  exact @summable_nat_add_iff ℝ _ _ _ (λ i, (f i : ℝ)) k,
+end
+
 lemma sum_add_tsum_nat_add {f : ℕ → ℝ≥0} (k : ℕ) (hf : summable f) :
   (∑' i, f i) = (∑ i in range k, f i) + ∑' i, f (i + k) :=
 by rw [←nnreal.coe_eq, coe_tsum, nnreal.coe_add, coe_sum, coe_tsum,


### PR DESCRIPTION
We have currently
```lean
lemma tendsto_sum_nat_add (f : ℕ → ℝ≥0) (hf : summable f) : tendsto (λ i, ∑' k, f (k + i)) at_top (𝓝 0)
```
However, the summability assumption is not necessary as otherwise all sums are zero, and the statement still holds. The PR removes the assumption.
