### PR TITLE
[Merged by Bors] - fix(group_theory): Remove a duplicate fintype instance on quotient_group.quotient

### DIFF
--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -162,18 +162,14 @@ def left_rel [group α] (s : subgroup α) : setoid α :=
   have x⁻¹ * y * (y⁻¹ * z) ∈ s, from s.mul_mem hxy hyz,
   by simpa [mul_assoc] using this⟩
 
+@[to_additive]
+instance left_rel_decidable [group α] [fintype α] (s : subgroup α)
+  [d : decidable_pred (λ a, a ∈ s)] :
+  decidable_rel (left_rel s).r := λ _ _, d _
+
 /-- `quotient s` is the quotient type representing the left cosets of `s`.
   If `s` is a normal subgroup, `quotient s` is a group -/
 def quotient [group α] (s : subgroup α) : Type* := quotient (left_rel s)
-
-section
-
-open_locale classical
-
-noncomputable instance [group α] [fintype α] (s : subgroup α) : fintype (quotient_group.quotient s) :=
-quotient.fintype _
-
-end
 
 end quotient_group
 
@@ -189,8 +185,12 @@ attribute [to_additive quotient_add_group.quotient] quotient_group.quotient
 
 namespace quotient_group
 
-
 variables [group α] {s : subgroup α}
+
+@[to_additive]
+instance fintype [group α] [fintype α] (s : subgroup α) [decidable_rel (left_rel s).r] :
+  fintype (quotient_group.quotient s) :=
+quotient.fintype (left_rel s)
 
 /-- The canonical map from a group `α` to the quotient `α/s`. -/
 @[to_additive "The canonical map from an `add_group` `α` to the quotient `α/s`."]

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -163,8 +163,7 @@ def left_rel [group α] (s : subgroup α) : setoid α :=
   by simpa [mul_assoc] using this⟩
 
 @[to_additive]
-instance left_rel_decidable [group α] [fintype α] (s : subgroup α)
-  [d : decidable_pred (λ a, a ∈ s)] :
+instance left_rel_decidable [group α] (s : subgroup α) [d : decidable_pred (λ a, a ∈ s)] :
   decidable_rel (left_rel s).r := λ _ _, d _
 
 /-- `quotient s` is the quotient type representing the left cosets of `s`.
@@ -188,7 +187,7 @@ namespace quotient_group
 variables [group α] {s : subgroup α}
 
 @[to_additive]
-instance fintype [group α] [fintype α] (s : subgroup α) [decidable_rel (left_rel s).r] :
+instance fintype [fintype α] (s : subgroup α) [decidable_rel (left_rel s).r] :
   fintype (quotient_group.quotient s) :=
 quotient.fintype (left_rel s)
 

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -60,10 +60,6 @@ fintype.card_eq_one_iff.2
 
 variables [fintype α] [dec : decidable_eq α]
 
-instance quotient_group.fintype (s : subgroup α) [d : decidable_pred (λ a, a ∈ s)] :
-  fintype (quotient s) :=
-@quotient.fintype _ _ (left_rel s) (λ _ _, d _)
-
 lemma card_eq_card_quotient_mul_card_subgroup (s : subgroup α) [fintype s]
   [decidable_pred (λ a, a ∈ s)] : fintype.card α = fintype.card (quotient s) * fintype.card s :=
 by rw ← fintype.card_prod;

--- a/src/group_theory/perm/subgroup.lean
+++ b/src/group_theory/perm/subgroup.lean
@@ -28,10 +28,9 @@ def sum_congr_subgroup (α β : Type*) : subgroup (perm (α ⊕ β)) :=
     ⟨sl₁₂ * sl₂₃, sr₁₂ * sr₂₃, h₂₃.symm ▸ h₁₂.symm ▸ sum_congr_mul sl₁₂ sr₁₂ sl₂₃ sr₂₃⟩,
   inv_mem' := λ σ₁ ⟨sl, sr, h⟩, ⟨sl⁻¹, sr⁻¹, h.symm ▸ sum_congr_inv sl sr⟩ }
 
-instance sum_congr_subgroup.left_rel_decidable {α β : Type*}
+instance sum_congr_subgroup.decidable_mem {α β : Type*}
   [decidable_eq α] [decidable_eq β] [fintype α] [fintype β] :
-  decidable_rel $ (quotient_group.left_rel (sum_congr_subgroup α β)).r :=
-λ σ₁ σ₂, fintype.decidable_exists_fintype
+  decidable_pred (λ x, x ∈ sum_congr_subgroup α β) := λ x, fintype.decidable_exists_fintype
 
 /-- The subgroup of permutations which do not exchange elements between fibers;
 those which are of the form `sigma_congr_right s`. -/
@@ -42,10 +41,10 @@ def sigma_congr_right_subgroup {α : Type*} (β : α → Type*) : subgroup (perm
     ⟨λ i, s₁₂ i * s₂₃ i, h₂₃.symm ▸ h₁₂.symm ▸ sigma_congr_right_mul s₁₂ s₂₃⟩,
   inv_mem' := λ σ₁ ⟨s, h⟩, ⟨λ i, (s i)⁻¹, h.symm ▸ sigma_congr_right_inv s⟩ }
 
-instance sigma_congr_right_subgroup.left_rel_decidable {α : Type*} {β : α → Type*}
+instance sigma_congr_right_subgroup.decidable_mem {α : Type*} {β : α → Type*}
   [decidable_eq α] [∀ a, decidable_eq (β a)] [fintype α] [∀ a, fintype (β a)] :
-  decidable_rel $ (quotient_group.left_rel (sigma_congr_right_subgroup β)).r :=
-λ σ₁ σ₂, fintype.decidable_exists_fintype
+   decidable_pred (λ x, x ∈ sigma_congr_right_subgroup β) :=
+λ x, fintype.decidable_exists_fintype
 
 end perm
 end equiv

--- a/src/group_theory/perm/subgroup.lean
+++ b/src/group_theory/perm/subgroup.lean
@@ -43,7 +43,7 @@ def sigma_congr_right_subgroup {α : Type*} (β : α → Type*) : subgroup (perm
 
 instance sigma_congr_right_subgroup.decidable_mem {α : Type*} {β : α → Type*}
   [decidable_eq α] [∀ a, decidable_eq (β a)] [fintype α] [∀ a, fintype (β a)] :
-   decidable_pred (λ x, x ∈ sigma_congr_right_subgroup β) :=
+  decidable_pred (λ x, x ∈ sigma_congr_right_subgroup β) :=
 λ x, fintype.decidable_exists_fintype
 
 end perm

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -33,9 +33,6 @@ begin
       ... = a : (subtype.mk.inj (hz₁ ⟨a, mem_orbit_self _⟩)).symm }
 end
 
--- This instance causes `exact card_quotient_dvd_card _` to timeout.
-local attribute [-instance] quotient_group.quotient.fintype
-
 lemma card_modeq_card_fixed_points [fintype α] [fintype G] [fintype (fixed_points G α)]
   (p : ℕ) {n : ℕ} [hp : fact p.prime] (h : card G = p ^ n) :
   card α ≡ card (fixed_points G α) [MOD p] :=


### PR DESCRIPTION
This noncomputable instance was annoying, and can easy be recovered by passing in a classical decidable_pred instance instead.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This instance was moved to `coset.lean` in #4939, and originated in #3520.