### PR TITLE
[Merged by Bors] - feat(algebra/module/basic): Add symmetric smul_comm_class instances for int and nat

### DIFF
--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -385,7 +385,7 @@ instance smul_comm_class : smul_comm_class ℕ R M :=
   end }
 
 -- `smul_comm_class.symm` is not registered as an instance, as it would cause a loop
-instance smul_comm_class.symm : smul_comm_class R ℕ M := smul_comm_class.symm _ _ _
+instance smul_comm_class' : smul_comm_class R ℕ M := smul_comm_class.symm _ _ _
 
 end nat
 
@@ -419,7 +419,7 @@ instance smul_comm_class : smul_comm_class ℤ R M :=
 { smul_comm := λ z r l, by cases z; simp [←gsmul_eq_smul, ←nat.smul_def, smul_comm (_ : ℕ)] }
 
 -- `smul_comm_class.symm` is not registered as an instance, as it would cause a loop
-instance smul_comm_class.symm : smul_comm_class R ℤ M := smul_comm_class.symm _ _ _
+instance smul_comm_class' : smul_comm_class R ℤ M := smul_comm_class.symm _ _ _
 
 end int
 

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -384,6 +384,9 @@ instance smul_comm_class : smul_comm_class ℕ R M :=
     { simp [succ_nsmul, ←ih, smul_add] },
   end }
 
+-- `smul_comm_class.symm` is not registered as an instance, as it would cause a loop
+instance smul_comm_class.symm : smul_comm_class R ℕ M := smul_comm_class.symm _ _ _
+
 end nat
 
 end
@@ -413,7 +416,10 @@ namespace int
 variables [semiring R] [add_comm_group M] [semimodule R M]
 
 instance smul_comm_class : smul_comm_class ℤ R M :=
-{ smul_comm := λ z r l, by cases z; simp [←gsmul_eq_smul, ←nat.smul_def, smul_comm] }
+{ smul_comm := λ z r l, by cases z; simp [←gsmul_eq_smul, ←nat.smul_def, smul_comm (_ : ℕ)] }
+
+-- `smul_comm_class.symm` is not registered as an instance, as it would cause a loop
+instance smul_comm_class.symm : smul_comm_class R ℤ M := smul_comm_class.symm _ _ _
 
 end int
 

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -270,7 +270,8 @@ def alternatization : multilinear_map R (λ i : ι, M) L →+ alternating_map R 
 { to_fun := λ m,
   { to_fun := λ v, ∑ (σ : perm ι), (σ.sign : ℤ) • m.dom_dom_congr σ v,
     map_add' := λ v i a b, by simp_rw [←finset.sum_add_distrib, multilinear_map.map_add, smul_add],
-    map_smul' := λ v i c a, by simp_rw [finset.smul_sum, multilinear_map.map_smul, smul_comm],
+    map_smul' := λ v i c a, by simp_rw [finset.smul_sum, multilinear_map.map_smul,
+                                        smul_comm (_ : ℤ)],
     map_eq_zero_of_eq' := λ v i j hvij hij, alternization_map_eq_zero_of_eq_aux m v i j hij hvij },
   map_add' := λ a b, begin
     ext,


### PR DESCRIPTION
These can't be added globally for all types as they cause instance resolution loops, but are safe here as these definitions do not depend on an existing `smul_comm_class`.

Note that these instances already exist via `is_scalar_tower.to_smul_comm_class'` for algebras - this just makes sure the instances are still available in the presence of weaker typeclasses. There's no diamond concern here, as `smul_comm_class` is in `Prop`.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

replaces #5365
