### PR TITLE
[Merged by Bors] - feat(group_theory/subgroup): Add decidable_mem_range

### DIFF
--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1014,6 +1014,11 @@ open subgroup
 def range (f : G →* N) : subgroup N :=
 subgroup.copy ((⊤ : subgroup G).map f) (set.range f) (by simp [set.ext_iff])
 
+@[to_additive]
+instance monoid_hom.decidable_mem_range (f : G →* N) [fintype G] [decidable_eq N] :
+  decidable_pred (λ x, x ∈ f.range) :=
+λ x, fintype.decidable_exists_fintype
+
 @[simp, to_additive] lemma coe_range (f : G →* N) :
   (f.range : set N) = set.range f := rfl
 


### PR DESCRIPTION
This means that `fintype (quotient_group.quotient f.range)` can be found by type-class resolution.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Note that to actually be useful for quotients this also needs #5368, but it is fine for them to be merged in either order.
