### PR TITLE
[Merged by Bors] - chore(group_theory/group_action/basic): Add a simp lemma about smul on quotient groups

### DIFF
--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -146,6 +146,9 @@ instance quotient (H : subgroup α) : mul_action α (quotient H) :=
   mul_smul := λ x y a, quotient.induction_on' a (λ a, quotient_group.eq.2
     (by simp [mul_inv_rev, subgroup.one_mem, mul_assoc])) }
 
+@[simp] lemma quotient.smul_mk (H : subgroup α) (a x : α) :
+  (a • quotient_group.mk x : quotient_group.quotient H) = quotient_group.mk (a * x) := rfl
+
 instance mul_left_cosets_comp_subtype_val (H I : subgroup α) :
   mul_action I (quotient H) :=
 mul_action.comp_hom (quotient H) (subgroup.subtype I)

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -150,7 +150,7 @@ instance quotient (H : subgroup α) : mul_action α (quotient H) :=
   (a • quotient_group.mk x : quotient_group.quotient H) = quotient_group.mk (a * x) := rfl
   
 @[simp] lemma quotient.smul_coe {α : Type*} [comm_group α] (H : subgroup α) (a x : α) :
-  (a • x : quotient_group.quotient H) = a * x := rfl
+  (a • x : quotient_group.quotient H) = ↑(a * x) := rfl
 
 instance mul_left_cosets_comp_subtype_val (H I : subgroup α) :
   mul_action I (quotient H) :=

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -148,6 +148,9 @@ instance quotient (H : subgroup α) : mul_action α (quotient H) :=
 
 @[simp] lemma quotient.smul_mk (H : subgroup α) (a x : α) :
   (a • quotient_group.mk x : quotient_group.quotient H) = quotient_group.mk (a * x) := rfl
+  
+@[simp] lemma quotient.smul_coe {α : Type*} [comm_group α] (H : subgroup α) (a x : α) :
+  (a • x : quotient_group.quotient H) = a * x := rfl
 
 instance mul_left_cosets_comp_subtype_val (H I : subgroup α) :
   mul_action I (quotient H) :=


### PR DESCRIPTION
By pushing `mk` to the outside, this increases the chance they can cancel with an outer `lift`


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
