### PR TITLE
[Merged by Bors] - chore(group_theory/coset): Make `quotient_group.mk` an abbreviation

### DIFF
--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -193,7 +193,7 @@ quotient.fintype (left_rel s)
 
 /-- The canonical map from a group `α` to the quotient `α/s`. -/
 @[to_additive "The canonical map from an `add_group` `α` to the quotient `α/s`."]
-def mk (a : α) : quotient s :=
+abbreviation mk (a : α) : quotient s :=
 quotient.mk' a
 
 @[elab_as_eliminator, to_additive]


### PR DESCRIPTION
This allows simp lemmas about `quotient.mk'` to apply here, which currently do not apply.

The definition doesn't seem interesting enough to be semireducible.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
