### PR TITLE
[Merged by Bors] - fix(group_theory/subgroup): Fix doubly-namespaced instance

### DIFF
--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1015,7 +1015,7 @@ def range (f : G →* N) : subgroup N :=
 subgroup.copy ((⊤ : subgroup G).map f) (set.range f) (by simp [set.ext_iff])
 
 @[to_additive]
-instance monoid_hom.decidable_mem_range (f : G →* N) [fintype G] [decidable_eq N] :
+instance decidable_mem_range (f : G →* N) [fintype G] [decidable_eq N] :
   decidable_pred (λ x, x ∈ f.range) :=
 λ x, fintype.decidable_exists_fintype
 


### PR DESCRIPTION
Not sure why the linter missed this.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
