### PR TITLE
[Merged by Bors] - feat(ring_theory/roots_of_unity): add squarefreeness mod p of minimal polynomial

### DIFF
--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -746,7 +746,7 @@ begin
   int.cast_one, aeval_one, alg_hom.map_sub, sub_self]
 end
 
-/-- The reduction modulo `p` of the minimal polynomial of `μ` is separable. -/
+/-- The reduction modulo `p` of the minimal polynomial of a root of unity `μ` is separable. -/
 lemma separable_minimal_polynomial_mod {p : ℕ} [fact p.prime] (hdiv : ¬p ∣ n) :
   separable (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
 begin

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -763,7 +763,7 @@ end
 /-- The reduction modulo `p` of the minimal polynomial of `μ` is squarefree. -/
 lemma squarefree_minimal_polynomial_mod {p : ℕ} [hprime : fact p.prime] (hdiv : ¬ p ∣ n) :
   squarefree (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
-separable.squarefree (separable_minimal_polynomial_mod h hpos hdiv)
+(separable_minimal_polynomial_mod h hpos hdiv).squarefree
 
 end minimal_polynomial
 

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -756,8 +756,8 @@ begin
       ring_hom.map_dvd (ring_hom.of (map (int.cast_ring_hom (zmod p))))
         (minimal_polynomial_dvd_X_pow_sub_one h hpos) },
   refine separable.of_dvd (separable_X_pow_sub_C 1 _ one_ne_zero) hdvd,
-  { by_contra hzero,
-    exact hdiv ((zmod.nat_coe_zmod_eq_zero_iff_dvd n p).1 (not_not.1 hzero)) },
+  by_contra hzero,
+    exact hdiv ((zmod.nat_coe_zmod_eq_zero_iff_dvd n p).1 (not_not.1 hzero))
 end
 
 /-- The reduction modulo `p` of the minimal polynomial of `μ` is squarefree. -/

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -747,7 +747,7 @@ begin
 end
 
 /-- The reduction modulo `p` of the minimal polynomial of `μ` is separable. -/
-lemma separable_minimal_polynomial_mod {p : ℕ} [hprime : fact p.prime] (hdiv : ¬p ∣ n) :
+lemma separable_minimal_polynomial_mod {p : ℕ} [fact p.prime] (hdiv : ¬p ∣ n) :
   separable (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
 begin
   have hdvd : (map (int.cast_ring_hom (zmod p))

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -752,9 +752,9 @@ lemma separable_minimal_polynomial_mod {p : ℕ} [hprime : fact p.prime] (hdiv :
 begin
   have hdvd : (map (int.cast_ring_hom (zmod p))
     (minimal_polynomial (is_integral h hpos))) ∣ X ^ n - 1,
-  { have hmap := ring_hom.map_dvd (ring_hom.of (map (int.cast_ring_hom (zmod p))))
-    (minimal_polynomial_dvd_X_pow_sub_one h hpos),
-    simpa [map_pow, map_X, map_one, ring_hom.coe_of, map_sub] using hmap },
+  { simpa [map_pow, map_X, map_one, ring_hom.coe_of, map_sub] using
+      ring_hom.map_dvd (ring_hom.of (map (int.cast_ring_hom (zmod p))))
+        (minimal_polynomial_dvd_X_pow_sub_one h hpos) },
   refine separable.of_dvd (separable_X_pow_sub_C 1 _ one_ne_zero) hdvd,
   { by_contra hzero,
     exact hdiv ((zmod.nat_coe_zmod_eq_zero_iff_dvd n p).1 (not_not.1 hzero)) },

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -747,7 +747,7 @@ begin
 end
 
 /-- The reduction modulo `p` of the minimal polynomial of `μ` is separable. -/
-lemma minimal_polynomial_is_separable {p : ℕ} [hprime : fact p.prime] (hdiv : ¬p ∣ n) : separable
+lemma separable_minimal_polynomial_mod {p : ℕ} [hprime : fact p.prime] (hdiv : ¬p ∣ n) : separable
   (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
 begin
   have hdvd : (map (int.cast_ring_hom (zmod p)) (minimal_polynomial
@@ -761,9 +761,9 @@ begin
 end
 
 /-- The reduction modulo `p` of the minimal polynomial of `μ` is squarefree. -/
-lemma minimal_polynomial_is_squarefree {p : ℕ} [hprime : fact p.prime] (hdiv : ¬ p ∣ n) : squarefree
-  (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
-separable.squarefree (minimal_polynomial_is_separable h hpos hdiv)
+lemma squarefree_minimal_polynomial_mod {p : ℕ} [hprime : fact p.prime] (hdiv : ¬ p ∣ n) :
+  squarefree (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
+separable.squarefree (separable_minimal_polynomial_mod h hpos hdiv)
 
 end minimal_polynomial
 

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -750,8 +750,8 @@ end
 lemma separable_minimal_polynomial_mod {p : ℕ} [hprime : fact p.prime] (hdiv : ¬p ∣ n) : separable
   (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
 begin
-  have hdvd : (map (int.cast_ring_hom (zmod p)) (minimal_polynomial
-  (is_integral h hpos))) ∣ X ^ n - 1,
+  have hdvd : (map (int.cast_ring_hom (zmod p))
+    (minimal_polynomial (is_integral h hpos))) ∣ X ^ n - 1,
   { have hmap := ring_hom.map_dvd (ring_hom.of (map (int.cast_ring_hom (zmod p))))
     (minimal_polynomial_dvd_X_pow_sub_one h hpos),
     simpa [map_pow, map_X, map_one, ring_hom.coe_of, map_sub] using hmap },

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -761,7 +761,7 @@ begin
 end
 
 /-- The reduction modulo `p` of the minimal polynomial of `μ` is squarefree. -/
-lemma squarefree_minimal_polynomial_mod {p : ℕ} [hprime : fact p.prime] (hdiv : ¬ p ∣ n) :
+lemma squarefree_minimal_polynomial_mod {p : ℕ} [fact p.prime] (hdiv : ¬ p ∣ n) :
   squarefree (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
 (separable_minimal_polynomial_mod h hpos hdiv).squarefree
 

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -757,7 +757,7 @@ begin
         (minimal_polynomial_dvd_X_pow_sub_one h hpos) },
   refine separable.of_dvd (separable_X_pow_sub_C 1 _ one_ne_zero) hdvd,
   by_contra hzero,
-    exact hdiv ((zmod.nat_coe_zmod_eq_zero_iff_dvd n p).1 (not_not.1 hzero))
+  exact hdiv ((zmod.nat_coe_zmod_eq_zero_iff_dvd n p).1 (not_not.1 hzero))
 end
 
 /-- The reduction modulo `p` of the minimal polynomial of `μ` is squarefree. -/

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -746,6 +746,25 @@ begin
   int.cast_one, aeval_one, alg_hom.map_sub, sub_self]
 end
 
+/-- The reduction modulo `p` of the minimal polynomial of `μ` is separable. -/
+lemma minimal_polynomial_is_separable {p : ℕ} [hprime : fact p.prime] (hdiv : ¬p ∣ n) : separable
+  (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
+begin
+  have hdvd : (map (int.cast_ring_hom (zmod p)) (minimal_polynomial
+  (is_integral h hpos))) ∣ X ^ n - 1,
+  { have hmap := ring_hom.map_dvd (ring_hom.of (map (int.cast_ring_hom (zmod p))))
+    (minimal_polynomial_dvd_X_pow_sub_one h hpos),
+    simpa [map_pow, map_X, map_one, ring_hom.coe_of, map_sub] using hmap },
+  refine separable.of_dvd (separable_X_pow_sub_C 1 _ one_ne_zero) hdvd,
+  { by_contra hzero,
+    exact hdiv ((zmod.nat_coe_zmod_eq_zero_iff_dvd n p).1 (not_not.1 hzero)) },
+end
+
+/-- The reduction modulo `p` of the minimal polynomial of `μ` is squarefree. -/
+lemma minimal_polynomial_is_squarefree {p : ℕ} [hprime : fact p.prime] (hdiv : ¬ p ∣ n) : squarefree
+  (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
+separable.squarefree (minimal_polynomial_is_separable h hpos hdiv)
+
 end minimal_polynomial
 
 end is_primitive_root

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -736,7 +736,7 @@ end
 
 variables [char_zero K]
 
-/--The minimal polynomial of `μ` divides `X ^ n - 1`. -/
+/--The minimal polynomial of a root of unity `μ` divides `X ^ n - 1`. -/
 lemma minimal_polynomial_dvd_X_pow_sub_one :
   minimal_polynomial (is_integral h hpos) ∣ X ^ n - 1 :=
 begin

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -747,8 +747,8 @@ begin
 end
 
 /-- The reduction modulo `p` of the minimal polynomial of `μ` is separable. -/
-lemma separable_minimal_polynomial_mod {p : ℕ} [hprime : fact p.prime] (hdiv : ¬p ∣ n) : separable
-  (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
+lemma separable_minimal_polynomial_mod {p : ℕ} [hprime : fact p.prime] (hdiv : ¬p ∣ n) :
+  separable (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
 begin
   have hdvd : (map (int.cast_ring_hom (zmod p))
     (minimal_polynomial (is_integral h hpos))) ∣ X ^ n - 1,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -760,7 +760,7 @@ begin
   exact hdiv ((zmod.nat_coe_zmod_eq_zero_iff_dvd n p).1 (not_not.1 hzero))
 end
 
-/-- The reduction modulo `p` of the minimal polynomial of `μ` is squarefree. -/
+/-- The reduction modulo `p` of the minimal polynomial of a root of unity `μ` is squarefree. -/
 lemma squarefree_minimal_polynomial_mod {p : ℕ} [fact p.prime] (hdiv : ¬ p ∣ n) :
   squarefree (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
 (separable_minimal_polynomial_mod h hpos hdiv).squarefree


### PR DESCRIPTION
Two easy results about the reduction `mod p` of the minimal polynomial over `ℤ` of a primitive root of unity: it is separable and hence squarefree.