### PR TITLE
[Merged by Bors] - chore(algebra/category/Module/monoidal): Speed up the elaboration

### DIFF
--- a/src/algebra/category/Module/monoidal.lean
+++ b/src/algebra/category/Module/monoidal.lean
@@ -51,24 +51,58 @@ by tidy
 def associator (M N K : Module R) : tensor_obj (tensor_obj M N) K ≅ tensor_obj M (tensor_obj N K) :=
 linear_equiv.to_Module_iso (tensor_product.assoc R M N K)
 
-lemma associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃ : Module R}
-  (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃) :
-    tensor_hom (tensor_hom f₁ f₂) f₃ ≫ (associator Y₁ Y₂ Y₃).hom =
-    (associator X₁ X₂ X₃).hom ≫ tensor_hom f₁ (tensor_hom f₂ f₃) :=
+section
+
+/-! The `associator_naturality` and `pentagon` lemmas below are very slow to elaborate.
+
+We give them some help by expressing the lemmas first non-categorically, then using
+`convert _aux using 1` to have the elaborator work as little as possible. -/
+
+open tensor_product (assoc map)
+
+private lemma associator_naturality_aux
+  {X₁ X₂ X₃ : Type*}
+  [add_comm_monoid X₁] [add_comm_monoid X₂] [add_comm_monoid X₃]
+  [semimodule R X₁] [semimodule R X₂] [semimodule R X₃]
+  {Y₁ Y₂ Y₃ : Type*}
+  [add_comm_monoid Y₁] [add_comm_monoid Y₂] [add_comm_monoid Y₃]
+  [semimodule R Y₁] [semimodule R Y₂] [semimodule R Y₃]
+  (f₁ : X₁ →ₗ[R] Y₁) (f₂ : X₂ →ₗ[R] Y₂) (f₃ : X₃ →ₗ[R] Y₃) :
+  linear_map.comp ↑(assoc R Y₁ Y₂ Y₃) (map (map f₁ f₂) f₃) =
+    (map f₁ (map f₂ f₃)).comp ↑(assoc R X₁ X₂ X₃) :=
 begin
   apply tensor_product.ext_threefold,
   intros x y z,
   refl
 end
 
-lemma pentagon (W X Y Z : Module R) :
-  tensor_hom (associator W X Y).hom (𝟙 Z) ≫ (associator W (tensor_obj X Y) Z).hom ≫ tensor_hom (𝟙 W) (associator X Y Z).hom =
-    (associator (tensor_obj W X) Y Z).hom ≫ (associator W X (tensor_obj Y Z)).hom :=
+variables (R)
+
+private lemma pentagon_aux
+  (W X Y Z : Type*)
+  [add_comm_monoid W] [add_comm_monoid X] [add_comm_monoid Y] [add_comm_monoid Z]
+  [semimodule R W] [semimodule R X] [semimodule R Y] [semimodule R Z] :
+  ((map (1 : W →ₗ[R] W) (assoc R X Y Z).to_linear_map).comp (assoc R W (X ⊗[R] Y) Z).to_linear_map)
+    .comp (map ↑(assoc R W X Y) (1 : Z →ₗ[R] Z)) =
+  (assoc R W X (Y ⊗[R] Z)).to_linear_map.comp (assoc R (W ⊗[R] X) Y Z).to_linear_map :=
 begin
   apply tensor_product.ext_fourfold,
   intros w x y z,
   refl
 end
+
+end
+
+lemma associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃ : Module R}
+  (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃) :
+    tensor_hom (tensor_hom f₁ f₂) f₃ ≫ (associator Y₁ Y₂ Y₃).hom =
+    (associator X₁ X₂ X₃).hom ≫ tensor_hom f₁ (tensor_hom f₂ f₃) :=
+by convert associator_naturality_aux f₁ f₂ f₃ using 1
+
+lemma pentagon (W X Y Z : Module R) :
+  tensor_hom (associator W X Y).hom (𝟙 Z) ≫ (associator W (tensor_obj X Y) Z).hom ≫ tensor_hom (𝟙 W) (associator X Y Z).hom =
+    (associator (tensor_obj W X) Y Z).hom ≫ (associator W X (tensor_obj Y Z)).hom :=
+by convert pentagon_aux R W X Y Z using 1
 
 /-- (implementation) the left unitor for R-modules -/
 def left_unitor (M : Module.{u} R) : Module.of R (R ⊗[R] M) ≅ M :=
@@ -105,7 +139,7 @@ begin
   change R at y,
   dsimp [tensor_hom, associator],
   erw [tensor_product.lid_tmul, tensor_product.rid_tmul],
-  apply (tensor_product.smul_tmul _ _ _).symm
+  exact (tensor_product.smul_tmul _ _ _).symm
 end
 
 end monoidal_category


### PR DESCRIPTION
This takes the elaboration time from ~5s to ~2.5s for associator_naturality, from ~90s to 5s for pentagon, and from ~14s to ~8s for `triangle`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
