### PR TITLE
[Merged by Bors] - feat(measure_theory/lp_space): add lemmas about the monotonicity of the Lp seminorm

### DIFF
--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -837,13 +837,8 @@ begin
     have hpp2 : p * p2 = q,
     { symmetry, rw [mul_comm, ←div_eq_iff hp0_ne], },
     have hpq2 : p * q2 = r,
-    { change p * ((q/p)/(q/p - 1)) = r,
-      have hr : r = p * q / (q - p),
-      { symmetry,
-        rw [←one_mul r, ←div_eq_iff hr0_ne, div_eq_mul_one_div, h_one_div_r],
-        have hpq0_ne : q - p ≠ 0, by simp [sub_eq_zero, (ne_of_lt hpq).symm],
-        field_simp [hp0_ne, hq0_ne, hpq0_ne], },
-      field_simp [hp0_ne, hr], },
+    { rw [← inv_inv' r, ← one_div, ← one_div, h_one_div_r],
+      field_simp [q2, real.conjugate_exponent, p2, hp0_ne, hq0_ne] },
     simp_rw [div_mul_div, mul_one, mul_comm p2, mul_comm q2, hpp2, hpq2],
   end
 end

--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -802,6 +802,53 @@ begin
   end
 end
 
+lemma lintegral_Lp_mul_le_Lq_mul_Lr {α} [measurable_space α] {p q r : ℝ} (hp1 : 1 ≤ p)
+  (hpq : p < q) (hpqr : 1/p = 1/q + 1/r) (μ : measure α) {f g : α → ennreal}
+  (hf : measurable f) (hg : measurable g) :
+  (∫⁻ a, ((f * g) a)^p ∂μ) ^ (1/p) ≤ (∫⁻ a, (f a)^q ∂μ) ^ (1/q) * (∫⁻ a, (g a)^r ∂μ) ^ (1/r) :=
+begin
+  have hp0_lt : 0 < p, from lt_of_lt_of_le zero_lt_one hp1,
+  have hp0_ne : p ≠ 0, from (ne_of_lt hp0_lt).symm,
+  have hp0 : 0 ≤ p, from le_of_lt hp0_lt,
+  have hq0_lt : 0 < q, from lt_of_le_of_lt hp0 hpq,
+  have hq0_ne : q ≠ 0, from (ne_of_lt hq0_lt).symm,
+  have h_one_div_r : 1/r = 1/p - 1/q, by simp [hpqr],
+  have hr0_ne : r ≠ 0,
+  { have hr_inv_pos : 0 < 1/r,
+    by rwa [h_one_div_r, sub_pos, one_div_lt_one_div hq0_lt hp0_lt],
+    rw [one_div, _root_.inv_pos] at hr_inv_pos,
+    exact (ne_of_lt hr_inv_pos).symm, },
+  let p2 := q/p,
+  let q2 := p2.conjugate_exponent,
+  have hp2q2 : p2.is_conjugate_exponent q2,
+  from real.is_conjugate_exponent_conjugate_exponent (by simp [lt_div_iff, hpq, hp0_lt]),
+  calc (∫⁻ (a : α), ((f * g) a) ^ p ∂μ) ^ (1 / p)
+      = (∫⁻ (a : α), (f a)^p * (g a)^p ∂μ) ^ (1 / p) :
+  by simp_rw [pi.mul_apply, ennreal.mul_rpow_of_nonneg _ _ hp0]
+  ... ≤ ((∫⁻ a, (f a)^(p * p2) ∂ μ)^(1/p2) * (∫⁻ a, (g a)^(p * q2) ∂ μ)^(1/q2)) ^ (1/p) :
+  begin
+    refine ennreal.rpow_le_rpow _ (by simp [hp0]),
+    simp_rw ennreal.rpow_mul,
+    exact ennreal.lintegral_mul_le_Lp_mul_Lq μ hp2q2 hf.ennreal_rpow_const hg.ennreal_rpow_const,
+  end
+  ... = (∫⁻ (a : α), (f a) ^ q ∂μ) ^ (1 / q) * (∫⁻ (a : α), (g a) ^ r ∂μ) ^ (1 / r) :
+  begin
+    rw [@ennreal.mul_rpow_of_nonneg _ _ (1/p) (by simp [hp0]), ←ennreal.rpow_mul,
+      ←ennreal.rpow_mul],
+    have hpp2 : p * p2 = q,
+    { symmetry, rw [mul_comm, ←div_eq_iff hp0_ne], },
+    have hpq2 : p * q2 = r,
+    { change p * ((q/p)/(q/p - 1)) = r,
+      have hr : r = p * q / (q - p),
+      { symmetry,
+        rw [←one_mul r, ←div_eq_iff hr0_ne, div_eq_mul_one_div, h_one_div_r],
+        have hpq0_ne : q - p ≠ 0, by simp [sub_eq_zero, (ne_of_lt hpq).symm],
+        field_simp [hp0_ne, hq0_ne, hpq0_ne], },
+      field_simp [hp0_ne, hr], },
+    simp_rw [div_mul_div, mul_one, mul_comm p2, mul_comm q2, hpp2, hpq2],
+  end
+end
+
 lemma lintegral_mul_rpow_le_lintegral_rpow_mul_lintegral_rpow {p q : ℝ}
   (hpq : p.is_conjugate_exponent q) {f g : α → ennreal} (hf : measurable f) (hg : measurable g)
   (hf_top : ∫⁻ a, (f a) ^ p ∂μ ≠ ⊤) :

--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -802,12 +802,11 @@ begin
   end
 end
 
-lemma lintegral_Lp_mul_le_Lq_mul_Lr {α} [measurable_space α] {p q r : ℝ} (hp1 : 1 ≤ p)
+lemma lintegral_Lp_mul_le_Lq_mul_Lr {α} [measurable_space α] {p q r : ℝ} (hp0_lt : 0 < p)
   (hpq : p < q) (hpqr : 1/p = 1/q + 1/r) (μ : measure α) {f g : α → ennreal}
   (hf : measurable f) (hg : measurable g) :
   (∫⁻ a, ((f * g) a)^p ∂μ) ^ (1/p) ≤ (∫⁻ a, (f a)^q ∂μ) ^ (1/q) * (∫⁻ a, (g a)^r ∂μ) ^ (1/r) :=
 begin
-  have hp0_lt : 0 < p, from lt_of_lt_of_le zero_lt_one hp1,
   have hp0_ne : p ≠ 0, from (ne_of_lt hp0_lt).symm,
   have hp0 : 0 ≤ p, from le_of_lt hp0_lt,
   have hq0_lt : 0 < q, from lt_of_le_of_lt hp0 hpq,

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -169,9 +169,8 @@ lemma snorm_mono {p q : ℝ} (hp1 : 1 ≤ p) (hpq : p ≤ q) (μ : measure α) [
   {f : α → E} (hf : measurable f) :
   snorm f p μ ≤ snorm f q μ :=
 begin
-  have h_le_mu : snorm f p μ ≤ snorm f q μ * (μ set.univ) ^ (1/p - 1/q),
-  from snorm_le_snorm_mul_rpow_measure_univ hp1 hpq μ hf,
-  rwa [measure_univ, ennreal.one_rpow, mul_one] at h_le_mu,
+  have h_le_μ := snorm_le_snorm_mul_rpow_measure_univ hp1 hpq μ hf,
+  rwa [measure_univ, ennreal.one_rpow, mul_one] at h_le_μ,
 end
 
 lemma mem_ℒp_of_mem_ℒp_of_le {p q : ℝ} {μ : measure α} [finite_measure μ] {f : α → E}

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -165,7 +165,7 @@ begin
   end
 end
 
-lemma snorm_le_of_exponent_le {p q : ℝ} (hp1 : 1 ≤ p) (hpq : p ≤ q) (μ : measure α)
+lemma snorm_le_snorm_of_exponent_le {p q : ℝ} (hp1 : 1 ≤ p) (hpq : p ≤ q) (μ : measure α)
   [probability_measure μ] {f : α → E} (hf : measurable f) :
   snorm f p μ ≤ snorm f q μ :=
 begin

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -149,14 +149,7 @@ begin
       ←ennreal.rpow_mul],
     have h_rw1 : 1 / p2 * (1 / p) = 1/q, by rw [div_mul_div, one_mul, mul_comm, hpp2],
     have h_rw2 : 1 / q2 * (1 / p) = 1/p - 1/q,
-    { rw [div_mul_div, one_mul, div_sub_div _ _ hp0_ne (ne_of_lt hq0_lt).symm, mul_one, one_mul,
-        div_eq_iff, mul_comm p q, mul_comm q2 p, div_eq_mul_inv, hq2,
-        mul_comm ((q - p) * (q * p)⁻¹) _, ←mul_assoc, ←mul_assoc, mul_assoc, mul_assoc],
-      nth_rewrite 1 ←mul_assoc,
-      rw [inv_mul_cancel, one_mul, mul_comm p, mul_inv_cancel],
-      { simp [hp0_ne, (ne_of_lt hq0_lt).symm], },
-      { rw [ne.def, sub_eq_zero], exact (ne_of_lt hpq).symm, },
-      { simp [hp0_ne, hp2q2.symm.ne_zero], }, },
+      by field_simp [q2, real.conjugate_exponent, p2, hp0_ne, ne_of_gt hq0_lt],
     rw [h_rw1, h_rw2],
   end
 end

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -173,7 +173,7 @@ begin
   rwa [measure_univ, ennreal.one_rpow, mul_one] at h_le_μ,
 end
 
-lemma mem_ℒp.mem_ℒp_of_le {p q : ℝ} {μ : measure α} [finite_measure μ] {f : α → E}
+lemma mem_ℒp.mem_ℒp_of_exponent_le {p q : ℝ} {μ : measure α} [finite_measure μ] {f : α → E}
   (hfq : mem_ℒp f q μ) (hp1 : 1 ≤ p) (hpq : p ≤ q) :
   mem_ℒp f p μ :=
 begin
@@ -207,7 +207,7 @@ lemma mem_ℒp.integrable (hp1 : 1 ≤ p) {f : α → E} [finite_measure μ] (hf
   integrable f μ :=
 begin
   rw ←mem_ℒp_one_iff_integrable,
-  exact hfp.mem_ℒp_of_le (le_refl 1) hp1,
+  exact hfp.mem_ℒp_of_exponent_le (le_refl 1) hp1,
 end
 
 section second_countable_topology

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -211,6 +211,7 @@ begin
   exact mem_ℒp_of_mem_ℒp_of_le hfp (le_refl 1) hp1,
 end
 
+section second_countable_topology
 variable [topological_space.second_countable_topology E]
 
 lemma mem_ℒp.add {f g : α → E} (hf : mem_ℒp f p μ) (hg : mem_ℒp g p μ) (hp1 : 1 ≤ p) :
@@ -233,6 +234,25 @@ begin
   exact ennreal.lintegral_rpow_add_lt_top_of_lintegral_rpow_lt_top hf.1.nnnorm.ennreal_coe hf.2
     hg.1.nnnorm.ennreal_coe hg.2 hp1,
 end
+
+end second_countable_topology
+
+section normed_space
+
+variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E]
+
+lemma mem_ℒp.smul (f : α → E) (c : 𝕜) (hp_pos : 0 < p) (hfp : mem_ℒp f p μ) :
+  mem_ℒp (c • f) p μ :=
+begin
+  have hp0 : 0 ≤ p, from le_of_lt hp_pos,
+  split,
+  { exact measurable.const_smul hfp.1 c, },
+  simp_rw [pi.smul_apply, nnnorm_smul, ennreal.coe_mul, ennreal.mul_rpow_of_nonneg _ _ hp0],
+  rw lintegral_const_mul _ hfp.1.nnnorm.ennreal_coe.ennreal_rpow_const,
+  exact ennreal.mul_lt_top (ennreal.rpow_lt_top_of_nonneg hp0 ennreal.coe_ne_top) hfp.2,
+end
+
+end normed_space
 
 end borel_space
 

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -173,7 +173,7 @@ begin
   rwa [measure_univ, ennreal.one_rpow, mul_one] at h_le_μ,
 end
 
-lemma mem_ℒp_of_mem_ℒp_of_le {p q : ℝ} {μ : measure α} [finite_measure μ] {f : α → E}
+lemma mem_ℒp.mem_ℒp_of_le {p q : ℝ} {μ : measure α} [finite_measure μ] {f : α → E}
   (hfq : mem_ℒp f q μ) (hp1 : 1 ≤ p) (hpq : p ≤ q) :
   mem_ℒp f p μ :=
 begin
@@ -207,7 +207,7 @@ lemma mem_ℒp.integrable (hp1 : 1 ≤ p) {f : α → E} [finite_measure μ] (hf
   integrable f μ :=
 begin
   rw ←mem_ℒp_one_iff_integrable,
-  exact mem_ℒp_of_mem_ℒp_of_le hfp (le_refl 1) hp1,
+  exact hfp.mem_ℒp_of_le (le_refl 1) hp1,
 end
 
 section second_countable_topology

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -126,8 +126,6 @@ begin
   let q2 := p2.conjugate_exponent,
   have hp2q2 : p2.is_conjugate_exponent q2,
   from real.is_conjugate_exponent_conjugate_exponent (by simp [lt_div_iff, hpq, hp0_lt]),
-  have hq2 : q2 = q * (q - p)⁻¹,
-    by field_simp [q2, real.conjugate_exponent, p2, ne_of_gt (sub_pos.mpr hpq), hp0_ne],
   calc (∫⁻ (a : α), ↑((f_nnreal * g_nnreal) a) ∂μ) ^ (1 / p)
     ≤ ((∫⁻ a, (f_nnreal a)^p2 ∂ μ)^(1/p2)*(∫⁻ a, (g_nnreal a)^q2 ∂ μ)^(1/q2)) ^ (1/p) :
   begin

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -204,7 +204,7 @@ begin
   end
 end
 
-lemma integrable_of_mem_ℒp (hp1 : 1 ≤ p) {f : α → E} [finite_measure μ] (hfp : mem_ℒp f p μ) :
+lemma mem_ℒp.integrable (hp1 : 1 ≤ p) {f : α → E} [finite_measure μ] (hfp : mem_ℒp f p μ) :
   integrable f μ :=
 begin
   rw ←mem_ℒp_one_iff_integrable,

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -213,7 +213,7 @@ section normed_space
 
 variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E]
 
-lemma mem_ℒp.smul {f : α → E} (hfp : mem_ℒp f p μ) (c : 𝕜) (hp0 : 0 ≤ p) :
+lemma mem_ℒp.const_smul {f : α → E} (hfp : mem_ℒp f p μ) (c : 𝕜) (hp0 : 0 ≤ p) :
   mem_ℒp (c • f) p μ :=
 begin
   split,

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -127,11 +127,7 @@ begin
   have hp2q2 : p2.is_conjugate_exponent q2,
   from real.is_conjugate_exponent_conjugate_exponent (by simp [lt_div_iff, hpq, hp0_lt]),
   have hq2 : q2 = q * (q - p)⁻¹,
-  { change (q/p)/(q/p - 1) = q * (q - p)⁻¹,
-    rw [←div_self hp0_ne, ←sub_div, div_eq_mul_one_div, one_div_div, div_eq_mul_inv, div_eq_mul_inv,
-      mul_assoc],
-    nth_rewrite 1 ←mul_assoc,
-    rw [inv_mul_cancel hp0_ne, one_mul], },
+    by field_simp [q2, real.conjugate_exponent, p2, ne_of_gt (sub_pos.mpr hpq), hp0_ne],
   calc (∫⁻ (a : α), ↑((f_nnreal * g_nnreal) a) ∂μ) ^ (1 / p)
     ≤ ((∫⁻ a, (f_nnreal a)^p2 ∂ μ)^(1/p2)*(∫⁻ a, (g_nnreal a)^q2 ∂ μ)^(1/q2)) ^ (1/p) :
   begin

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -165,8 +165,8 @@ begin
   end
 end
 
-lemma snorm_mono {p q : ℝ} (hp1 : 1 ≤ p) (hpq : p ≤ q) (μ : measure α) [probability_measure μ]
-  {f : α → E} (hf : measurable f) :
+lemma snorm_le_of_exponent_le {p q : ℝ} (hp1 : 1 ≤ p) (hpq : p ≤ q) (μ : measure α)
+  [probability_measure μ] {f : α → E} (hf : measurable f) :
   snorm f p μ ≤ snorm f q μ :=
 begin
   have h_le_μ := snorm_le_snorm_mul_rpow_measure_univ hp1 hpq μ hf,

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -240,7 +240,7 @@ section normed_space
 
 variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E]
 
-lemma mem_ℒp.smul (f : α → E) (c : 𝕜) (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) :
+lemma mem_ℒp.smul {f : α → E} (hfp : mem_ℒp f p μ) (c : 𝕜) (hp0 : 0 ≤ p) :
   mem_ℒp (c • f) p μ :=
 begin
   split,

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -127,15 +127,7 @@ begin
       ≤ (∫⁻ (a : α), ↑(nnnorm (f a)) ^ q ∂μ) ^ (1/q) * (∫⁻ (a : α), (g a) ^ r ∂μ) ^ (1/r) :
     ennreal.lintegral_Lp_mul_le_Lq_mul_Lr hp1 hpq hpqr μ hf.nnnorm.ennreal_coe measurable_const
   ... = (∫⁻ (a : α), ↑(nnnorm (f a)) ^ q ∂μ) ^ (1/q) * μ set.univ ^ (1/p - 1/q) :
-  begin
-    have hg_integral : (∫⁻ (a : α), g a ^ r ∂μ) = μ set.univ,
-    { change (∫⁻ (a : α), 1 ^ r ∂μ) = μ set.univ,
-      simp_rw ennreal.one_rpow,
-      rw [lintegral_const, one_mul], },
-    rw hg_integral,
-    congr,
-    simp [hpqr],
-  end
+    by simp [hpqr],
 end
 
 lemma snorm_le_snorm_of_exponent_le {p q : ℝ} (hp1 : 1 ≤ p) (hpq : p ≤ q) (μ : measure α)

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -110,45 +110,31 @@ lemma snorm_le_snorm_mul_rpow_measure_univ {p q : ℝ} (hp1 : 1 ≤ p) (hpq : p 
 begin
   have hq1 : 1 ≤ q, from le_trans hp1 hpq,
   by_cases hpq_eq : p = q,
-  { rw [hpq_eq, sub_self, ennreal.rpow_zero, mul_one], exact le_refl _, },
+  { rw [hpq_eq, sub_self, ennreal.rpow_zero, mul_one],
+    exact le_refl _, },
   have hpq : p < q, from lt_of_le_of_ne hpq hpq_eq,
-  have hp0_lt : 0 < p, from lt_of_lt_of_le zero_lt_one hp1,
-  have hp0_ne : p ≠ 0, from (ne_of_lt hp0_lt).symm,
-  have hp0 : 0 ≤ p, from le_trans zero_le_one hp1,
-  have hq0_lt : 0 < q, from lt_of_lt_of_le zero_lt_one hq1,
-  let f_nnreal := λ a, (nnnorm(f a)) ^ p,
-  let g_nnreal := λ a:α, (1:nnreal),
-  have h_rw : ∫⁻ a, f_nnreal a ∂ μ = ∫⁻ a, ((f_nnreal * g_nnreal) a) ∂ μ,
+  let g := λ a : α, (1 : ennreal),
+  have h_rw : ∫⁻ a, ↑(nnnorm (f a))^p ∂ μ = ∫⁻ a, (nnnorm (f a) * (g a))^p ∂ μ,
   from lintegral_congr (λ a, by simp),
   repeat {rw snorm},
-  simp_rw [ennreal.coe_rpow_of_nonneg _ hp0, h_rw],
-  let p2 := q/p,
-  let q2 := p2.conjugate_exponent,
-  have hp2q2 : p2.is_conjugate_exponent q2,
-  from real.is_conjugate_exponent_conjugate_exponent (by simp [lt_div_iff, hpq, hp0_lt]),
-  calc (∫⁻ (a : α), ↑((f_nnreal * g_nnreal) a) ∂μ) ^ (1 / p)
-    ≤ ((∫⁻ a, (f_nnreal a)^p2 ∂ μ)^(1/p2)*(∫⁻ a, (g_nnreal a)^q2 ∂ μ)^(1/q2)) ^ (1/p) :
+  rw h_rw,
+  let r := p * q / (q - p),
+  have hpqr : 1/p = 1/q + 1/r,
+  { field_simp [(ne_of_lt (lt_of_lt_of_le zero_lt_one hp1)).symm,
+      (ne_of_lt (lt_of_lt_of_le zero_lt_one hq1)).symm],
+    ring, },
+  calc (∫⁻ (a : α), (↑(nnnorm (f a)) * g a) ^ p ∂μ) ^ (1/p)
+      ≤ (∫⁻ (a : α), ↑(nnnorm (f a)) ^ q ∂μ) ^ (1/q) * (∫⁻ (a : α), (g a) ^ r ∂μ) ^ (1/r) :
+    ennreal.lintegral_Lp_mul_le_Lq_mul_Lr hp1 hpq hpqr μ hf.nnnorm.ennreal_coe measurable_const
+  ... = (∫⁻ (a : α), ↑(nnnorm (f a)) ^ q ∂μ) ^ (1/q) * μ set.univ ^ (1/p - 1/q) :
   begin
-    refine ennreal.rpow_le_rpow _ (by simp [hp0]),
-    exact nnreal.lintegral_mul_le_Lp_mul_Lq hp2q2 hf.nnnorm.nnreal_rpow_const measurable_const,
-  end
-    ... = (∫⁻ (a : α), ↑(nnnorm (f a)) ^ q ∂μ) ^ (1 / q) * μ set.univ ^ (1 / p - 1 / q) :
-  begin
-    have hpp2 : p * p2 = q,
-    { symmetry, rw [mul_comm, ←div_eq_iff hp0_ne], },
-    have h_int_g : ∫⁻ (a : α), ↑(g_nnreal a) ^ q2 ∂μ = μ set.univ, by simp,
-    have h_int_f : ∫⁻ (a : α), ↑(f_nnreal a) ^ p2 ∂μ = ∫⁻ (a : α), ↑(nnnorm(f a)) ^ q ∂μ,
-    { refine lintegral_congr (λ a, _),
-      simp_rw [ennreal.coe_rpow_of_nonneg _ hp2q2.nonneg, ←nnreal.rpow_mul,
-        ennreal.coe_rpow_of_nonneg _ (le_of_lt hq0_lt)],
-      congr,
-      exact hpp2, },
-    rw [h_int_g, h_int_f, @ennreal.mul_rpow_of_nonneg _ _ (1/p) (by simp [hp0]), ←ennreal.rpow_mul,
-      ←ennreal.rpow_mul],
-    have h_rw1 : 1 / p2 * (1 / p) = 1/q, by rw [div_mul_div, one_mul, mul_comm, hpp2],
-    have h_rw2 : 1 / q2 * (1 / p) = 1/p - 1/q,
-      by field_simp [q2, real.conjugate_exponent, p2, hp0_ne, ne_of_gt hq0_lt],
-    rw [h_rw1, h_rw2],
+    have hg_integral : (∫⁻ (a : α), g a ^ r ∂μ) = μ set.univ,
+    { change (∫⁻ (a : α), 1 ^ r ∂μ) = μ set.univ,
+      simp_rw ennreal.one_rpow,
+      rw [lintegral_const, one_mul], },
+    rw hg_integral,
+    congr,
+    simp [hpqr],
   end
 end
 

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -215,6 +215,17 @@ begin
   exact ennreal.mul_lt_top (ennreal.rpow_lt_top_of_nonneg hp0 ennreal.coe_ne_top) hfp.2,
 end
 
+lemma snorm_smul_le_mul_snorm [measurable_space 𝕜] [opens_measurable_space 𝕜] {q r : ℝ}
+  {f : α → E} (hfp : mem_ℒp f p μ) {φ : α → 𝕜} (hφ : measurable φ)
+  (hp1 : 1 ≤ p) (hpq : p < q) (hpqr : 1/p = 1/q + 1/r) :
+  snorm (φ • f) p μ ≤ snorm φ q μ * snorm f r μ :=
+begin
+  rw snorm,
+  simp_rw [pi.smul_apply', nnnorm_smul, ennreal.coe_mul],
+  exact ennreal.lintegral_Lp_mul_le_Lq_mul_Lr hp1 hpq hpqr μ hφ.nnnorm.ennreal_coe
+    hfp.1.nnnorm.ennreal_coe,
+end
+
 end normed_space
 
 end borel_space

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -240,10 +240,9 @@ section normed_space
 
 variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E]
 
-lemma mem_ℒp.smul (f : α → E) (c : 𝕜) (hp_pos : 0 < p) (hfp : mem_ℒp f p μ) :
+lemma mem_ℒp.smul (f : α → E) (c : 𝕜) (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) :
   mem_ℒp (c • f) p μ :=
 begin
-  have hp0 : 0 ≤ p, from le_of_lt hp_pos,
   split,
   { exact measurable.const_smul hfp.1 c, },
   simp_rw [pi.smul_apply, nnnorm_smul, ennreal.coe_mul, ennreal.mul_rpow_of_nonneg _ _ hp0],

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -216,14 +216,14 @@ begin
 end
 
 lemma snorm_smul_le_mul_snorm [measurable_space 𝕜] [opens_measurable_space 𝕜] {q r : ℝ}
-  {f : α → E} (hfp : mem_ℒp f p μ) {φ : α → 𝕜} (hφ : measurable φ)
+  {f : α → E} (hf : measurable f) {φ : α → 𝕜} (hφ : measurable φ)
   (hp1 : 1 ≤ p) (hpq : p < q) (hpqr : 1/p = 1/q + 1/r) :
   snorm (φ • f) p μ ≤ snorm φ q μ * snorm f r μ :=
 begin
   rw snorm,
   simp_rw [pi.smul_apply', nnnorm_smul, ennreal.coe_mul],
   exact ennreal.lintegral_Lp_mul_le_Lq_mul_Lr hp1 hpq hpqr μ hφ.nnnorm.ennreal_coe
-    hfp.1.nnnorm.ennreal_coe,
+    hf.nnnorm.ennreal_coe,
 end
 
 end normed_space

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -104,11 +104,11 @@ variable [borel_space E]
 lemma mem_ℒp.neg {f : α → E} (hf : mem_ℒp f p μ) : mem_ℒp (-f) p μ :=
 ⟨measurable.neg hf.1, by simp [hf.right]⟩
 
-lemma snorm_le_snorm_mul_rpow_measure_univ {p q : ℝ} (hp1 : 1 ≤ p) (hpq : p ≤ q) (μ : measure α)
+lemma snorm_le_snorm_mul_rpow_measure_univ {p q : ℝ} (hp0_lt : 0 < p) (hpq : p ≤ q) (μ : measure α)
   {f : α → E} (hf : measurable f) :
   snorm f p μ ≤ snorm f q μ * (μ set.univ) ^ (1/p - 1/q) :=
 begin
-  have hq1 : 1 ≤ q, from le_trans hp1 hpq,
+  have hq0_lt : 0 < q, from lt_of_lt_of_le hp0_lt hpq,
   by_cases hpq_eq : p = q,
   { rw [hpq_eq, sub_self, ennreal.rpow_zero, mul_one],
     exact le_refl _, },
@@ -120,33 +120,32 @@ begin
   rw h_rw,
   let r := p * q / (q - p),
   have hpqr : 1/p = 1/q + 1/r,
-  { field_simp [(ne_of_lt (lt_of_lt_of_le zero_lt_one hp1)).symm,
-      (ne_of_lt (lt_of_lt_of_le zero_lt_one hq1)).symm],
+  { field_simp [(ne_of_lt hp0_lt).symm,
+      (ne_of_lt hq0_lt).symm],
     ring, },
   calc (∫⁻ (a : α), (↑(nnnorm (f a)) * g a) ^ p ∂μ) ^ (1/p)
       ≤ (∫⁻ (a : α), ↑(nnnorm (f a)) ^ q ∂μ) ^ (1/q) * (∫⁻ (a : α), (g a) ^ r ∂μ) ^ (1/r) :
-    ennreal.lintegral_Lp_mul_le_Lq_mul_Lr hp1 hpq hpqr μ hf.nnnorm.ennreal_coe measurable_const
+    ennreal.lintegral_Lp_mul_le_Lq_mul_Lr hp0_lt hpq hpqr μ hf.nnnorm.ennreal_coe measurable_const
   ... = (∫⁻ (a : α), ↑(nnnorm (f a)) ^ q ∂μ) ^ (1/q) * μ set.univ ^ (1/p - 1/q) :
     by simp [hpqr],
 end
 
-lemma snorm_le_snorm_of_exponent_le {p q : ℝ} (hp1 : 1 ≤ p) (hpq : p ≤ q) (μ : measure α)
+lemma snorm_le_snorm_of_exponent_le {p q : ℝ} (hp0_lt : 0 < p) (hpq : p ≤ q) (μ : measure α)
   [probability_measure μ] {f : α → E} (hf : measurable f) :
   snorm f p μ ≤ snorm f q μ :=
 begin
-  have h_le_μ := snorm_le_snorm_mul_rpow_measure_univ hp1 hpq μ hf,
+  have h_le_μ := snorm_le_snorm_mul_rpow_measure_univ hp0_lt hpq μ hf,
   rwa [measure_univ, ennreal.one_rpow, mul_one] at h_le_μ,
 end
 
 lemma mem_ℒp.mem_ℒp_of_exponent_le {p q : ℝ} {μ : measure α} [finite_measure μ] {f : α → E}
-  (hfq : mem_ℒp f q μ) (hp1 : 1 ≤ p) (hpq : p ≤ q) :
+  (hfq : mem_ℒp f q μ) (hp_pos : 0 < p) (hpq : p ≤ q) :
   mem_ℒp f p μ :=
 begin
   cases hfq with hfq_m hfq_lt_top,
   split,
   { exact hfq_m, },
-  have hp_pos : 0 < p, from lt_of_lt_of_le zero_lt_one hp1,
-  have hq_pos : 0 < q, from lt_of_lt_of_le zero_lt_one (le_trans hp1 hpq),
+  have hq_pos : 0 < q, from lt_of_lt_of_le  hp_pos hpq,
   suffices h_snorm : snorm f p μ < ⊤,
   { have h_top_eq : (⊤ : ennreal) = ⊤ ^ (1/p), by simp [hp_pos],
     rw [snorm, h_top_eq] at h_snorm,
@@ -156,7 +155,7 @@ begin
     simpa [(ne_of_lt hp_pos).symm] using h_snorm_pow, },
   calc snorm f p μ
       ≤ snorm f q μ * (μ set.univ) ^ (1/p - 1/q) :
-    snorm_le_snorm_mul_rpow_measure_univ hp1 hpq μ hfq_m
+    snorm_le_snorm_mul_rpow_measure_univ hp_pos hpq μ hfq_m
   ... < ⊤ :
   begin
     rw ennreal.mul_lt_top_iff,
@@ -172,7 +171,7 @@ lemma mem_ℒp.integrable (hp1 : 1 ≤ p) {f : α → E} [finite_measure μ] (hf
   integrable f μ :=
 begin
   rw ←mem_ℒp_one_iff_integrable,
-  exact hfp.mem_ℒp_of_exponent_le (le_refl 1) hp1,
+  exact hfp.mem_ℒp_of_exponent_le zero_lt_one hp1,
 end
 
 section second_countable_topology
@@ -217,12 +216,12 @@ end
 
 lemma snorm_smul_le_mul_snorm [measurable_space 𝕜] [opens_measurable_space 𝕜] {q r : ℝ}
   {f : α → E} (hf : measurable f) {φ : α → 𝕜} (hφ : measurable φ)
-  (hp1 : 1 ≤ p) (hpq : p < q) (hpqr : 1/p = 1/q + 1/r) :
+  (hp0_lt : 0 < p) (hpq : p < q) (hpqr : 1/p = 1/q + 1/r) :
   snorm (φ • f) p μ ≤ snorm φ q μ * snorm f r μ :=
 begin
   rw snorm,
   simp_rw [pi.smul_apply', nnnorm_smul, ennreal.coe_mul],
-  exact ennreal.lintegral_Lp_mul_le_Lq_mul_Lr hp1 hpq hpqr μ hφ.nnnorm.ennreal_coe
+  exact ennreal.lintegral_Lp_mul_le_Lq_mul_Lr hp0_lt hpq hpqr μ hφ.nnnorm.ennreal_coe
     hf.nnnorm.ennreal_coe,
 end
 


### PR DESCRIPTION
Also add a lemma mem_Lp.const_smul for a normed space.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
I tried to use simp or ring for all the simple but tedious computations of snorm_le_snorm_mul_rpow_measure_univ, but in the end I had to do them by hand. Is there a tactic I am missing that could help?