### PR TITLE
[Merged by Bors] - chore(analysis/analytic/basic.lean): fix latex in doc

### DIFF
--- a/src/analysis/analytic/basic.lean
+++ b/src/analysis/analytic/basic.lean
@@ -461,7 +461,7 @@ If a function is analytic in a disk `D(x, R)`, then it is analytic in any disk c
 one. Indeed, one can write
 $$
 f (x + y + z) = \sum_{n} p_n (y + z)^n = \sum_{n, k} \binom{n}{k} p_n y^{n-k} z^k
-= \sum_{k} \left(\sum_{n} \binom{n}{k} p_n y^{n-k}\right) z^k.
+= \sum_{k} \Bigl(\sum_{n} \binom{n}{k} p_n y^{n-k}\Bigr) z^k.
 $$
 The corresponding power series has thus a `k`-th coefficient equal to
 $\sum_{n} \binom{n}{k} p_n y^{n-k}$. In the general case where `pₙ` is a multilinear map, this has

--- a/src/analysis/analytic/basic.lean
+++ b/src/analysis/analytic/basic.lean
@@ -460,11 +460,11 @@ end
 If a function is analytic in a disk `D(x, R)`, then it is analytic in any disk contained in that
 one. Indeed, one can write
 $$
-f (x + y + z) = \sum_{n} p_n (y + z)^n = \sum_{n, k} \choose n k p_n y^{n-k} z^k
-= \sum_{k} (\sum_{n} \choose n k p_n y^{n-k}) z^k.
+f (x + y + z) = \sum_{n} p_n (y + z)^n = \sum_{n, k} \binom{n}{k} p_n y^{n-k} z^k
+= \sum_{k} (\sum_{n} \binom{n}{k} p_n y^{n-k}) z^k.
 $$
 The corresponding power series has thus a `k`-th coefficient equal to
-`\sum_{n} \choose n k p_n y^{n-k}`. In the general case where `pₙ` is a multilinear map, this has
+$\sum_{n} \binom{n}{k} p_n y^{n-k}$. In the general case where `pₙ` is a multilinear map, this has
 to be interpreted suitably: instead of having a binomial coefficient, one should sum over all
 possible subsets `s` of `fin n` of cardinal `k`, and attribute `z` to the indices in `s` and
 `y` to the indices outside of `s`.

--- a/src/analysis/analytic/basic.lean
+++ b/src/analysis/analytic/basic.lean
@@ -461,7 +461,7 @@ If a function is analytic in a disk `D(x, R)`, then it is analytic in any disk c
 one. Indeed, one can write
 $$
 f (x + y + z) = \sum_{n} p_n (y + z)^n = \sum_{n, k} \binom{n}{k} p_n y^{n-k} z^k
-= \sum_{k} (\sum_{n} \binom{n}{k} p_n y^{n-k}) z^k.
+= \sum_{k} \left(\sum_{n} \binom{n}{k} p_n y^{n-k}\right) z^k.
 $$
 The corresponding power series has thus a `k`-th coefficient equal to
 $\sum_{n} \binom{n}{k} p_n y^{n-k}$. In the general case where `pₙ` is a multilinear map, this has


### PR DESCRIPTION
Doc in the file `analytic/basic.lean` is broken, since I used a latex command `\choose` which doesn't exist. Replace it with `\binom`.
