### PR TITLE
[Merged by Bors] - feat(data/fin): trans and id lemmas for fin.cast

### DIFF
--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -357,6 +357,12 @@ def cast (eq : n = m) : fin n ≃o fin m :=
 
 @[simp] lemma coe_cast (h : n = m) (i : fin n) : (cast h i : ℕ) = i := rfl
 
+@[simp] lemma cast_trans {k : ℕ} (h : n = m) (h' : m = k) {i : fin n} :
+  cast h' (cast h i) = cast (eq.trans h h') i := rfl
+
+@[simp] lemma cast_id {h : n = n} {i : fin n} : cast h i = i :=
+by { ext, refl }
+
 /-- `cast_add m i` embeds `i : fin n` in `fin (n+m)`. -/
 def cast_add (m) : fin n ↪o fin (n + m) := cast_le $ le_add_right n m
 

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -360,7 +360,7 @@ def cast (eq : n = m) : fin n ≃o fin m :=
 @[simp] lemma cast_trans {k : ℕ} (h : n = m) (h' : m = k) {i : fin n} :
   cast h' (cast h i) = cast (eq.trans h h') i := rfl
 
-@[simp] lemma cast_id {h : n = n} {i : fin n} : cast h i = i :=
+@[simp] lemma cast_refl {i : fin n} : cast rfl i = i :=
 by { ext, refl }
 
 /-- `cast_add m i` embeds `i : fin n` in `fin (n+m)`. -/


### PR DESCRIPTION

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The recent change of `fin.cast` to be an `order_iso` has made it that one can no longer use projection notation a la `i.cast h` for `fin.cast`. Perhaps there's some way of getting that to work?