### PR TITLE
[Merged by Bors] - feat(algebra/*): Noncomputable `group` structures from `is_unit`

### DIFF
--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -262,13 +262,13 @@ section noncomputable_defs
 variables {R : Type*} [nontrivial R]
 
 /-- Constructs a `division_ring` structure on a `ring` consisting only of units and 0. -/
-noncomputable def division_ring_of_is_unit_or_eq_zero [ring R]
+noncomputable def division_ring_of_is_unit_or_eq_zero [hR : ring R]
   (h : ∀ (a : R), is_unit a ∨ a = 0) : division_ring R :=
-{ .. (group_with_zero_of_is_unit_or_eq_zero h), .. (infer_instance : ring R) }
+{ .. (group_with_zero_of_is_unit_or_eq_zero h), .. hR }
 
 /-- Constructs a `field` structure on a `comm_ring` consisting only of units and 0. -/
-noncomputable def field_of_is_unit_or_eq_zero [comm_ring R]
+noncomputable def field_of_is_unit_or_eq_zero [hR : comm_ring R]
   (h : ∀ (a : R), is_unit a ∨ a = 0) : field R :=
-{ .. (group_with_zero_of_is_unit_or_eq_zero h), .. (infer_instance : comm_ring R) }
+{ .. (group_with_zero_of_is_unit_or_eq_zero h), .. hR }
 
 end noncomputable_defs

--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -256,3 +256,19 @@ protected lemma injective : function.injective f := f.injective_iff.2 $ λ x, f.
 end
 
 end ring_hom
+
+section noncomputable_defs
+
+variables {R : Type*} [nontrivial R]
+
+/-- Constructs a `division_ring` structure on a `ring` consisting only of units and 0. -/
+noncomputable def division_ring_of_is_unit_or_eq_zero [ring R]
+  (h : ∀ (a : R), is_unit a ∨ a = 0) : division_ring R :=
+{ .. (group_with_zero_of_is_unit_or_eq_zero h), .. (infer_instance : ring R) }
+
+/-- Constructs a `field` structure on a `comm_ring` consisting only of units and 0. -/
+noncomputable def field_of_is_unit_or_eq_zero [comm_ring R]
+  (h : ∀ (a : R), is_unit a ∨ a = 0) : field R :=
+{ .. (group_with_zero_of_is_unit_or_eq_zero h), .. (infer_instance : comm_ring R) }
+
+end noncomputable_defs

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -294,20 +294,20 @@ section noncomputable_defs
 variables {M : Type*}
 
 /-- Constructs a `group` structure on a `monoid` consisting only of units. -/
-noncomputable def group_of_is_unit [monoid M] (h : ∀ (a : M), is_unit a) : group M :=
+noncomputable def group_of_is_unit [hM : monoid M] (h : ∀ (a : M), is_unit a) : group M :=
 { inv := λ a, ↑((h a).unit)⁻¹,
   mul_left_inv := λ a, by {
     change ↑((h a).unit)⁻¹ * a = 1,
     rw [units.inv_mul_eq_iff_eq_mul, (h a).unit_spec, mul_one] },
-.. (infer_instance : monoid M)}
+.. hM }
 
 /-- Constructs a `comm_group` structure on a `comm_monoid` consisting only of units. -/
-noncomputable def comm_group_of_is_unit [comm_monoid M] (h : ∀ (a : M), is_unit a) :
+noncomputable def comm_group_of_is_unit [hM : comm_monoid M] (h : ∀ (a : M), is_unit a) :
   comm_group M :=
 { inv := λ a, ↑((h a).unit)⁻¹,
   mul_left_inv := λ a, by {
     change ↑((h a).unit)⁻¹ * a = 1,
     rw [units.inv_mul_eq_iff_eq_mul, (h a).unit_spec, mul_one] },
-.. (infer_instance : comm_monoid M)}
+.. hM }
 
 end noncomputable_defs

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -288,3 +288,26 @@ lemma is_unit.unit_spec [monoid M] {a : M} (h : is_unit a) : ↑h.unit = a :=
 classical.some_spec h
 
 end is_unit
+
+section noncomputable_defs
+
+variables {M : Type*}
+
+/-- Constructs a `group` structure on a `monoid` consisting only of units. -/
+noncomputable def group_of_is_unit [monoid M] (h : ∀ (a : M), is_unit a) : group M :=
+{ inv := λ a, ↑((h a).unit)⁻¹,
+  mul_left_inv := λ a, by {
+    change ↑((h a).unit)⁻¹ * a = 1,
+    rw [units.inv_mul_eq_iff_eq_mul, (h a).unit_spec, mul_one] },
+.. (infer_instance : monoid M)}
+
+/-- Constructs a `comm_group` structure on a `comm_monoid` consisting only of units. -/
+noncomputable def comm_group_of_is_unit [comm_monoid M] (h : ∀ (a : M), is_unit a) :
+  comm_group M :=
+{ inv := λ a, ↑((h a).unit)⁻¹,
+  mul_left_inv := λ a, by {
+    change ↑((h a).unit)⁻¹ * a = 1,
+    rw [units.inv_mul_eq_iff_eq_mul, (h a).unit_spec, mul_one] },
+.. (infer_instance : comm_monoid M)}
+
+end noncomputable_defs

--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -918,7 +918,7 @@ variables {M : Type*} [nontrivial M]
 
 /-- Constructs a `group_with_zero` structure on a `monoid_with_zero`
   consisting only of units and 0. -/
-noncomputable def group_with_zero_of_is_unit_or_eq_zero [monoid_with_zero M]
+noncomputable def group_with_zero_of_is_unit_or_eq_zero [hM : monoid_with_zero M]
   (h : ∀ (a : M), is_unit a ∨ a = 0) : group_with_zero M :=
 { inv := λ a, if h0 : a = 0 then 0 else ↑((h a).resolve_right h0).unit⁻¹,
   inv_zero := dif_pos rfl,
@@ -926,12 +926,12 @@ noncomputable def group_with_zero_of_is_unit_or_eq_zero [monoid_with_zero M]
     change a * (if h0 : a = 0 then 0 else ↑((h a).resolve_right h0).unit⁻¹) = 1,
     rw [dif_neg h0, units.mul_inv_eq_iff_eq_mul, one_mul, is_unit.unit_spec] },
   exists_pair_ne := nontrivial.exists_pair_ne,
-.. (infer_instance : monoid_with_zero M) }
+.. hM }
 
 /-- Constructs a `comm_group_with_zero` structure on a `comm_monoid_with_zero`
   consisting only of units and 0. -/
-noncomputable def comm_group_with_zero_of_is_unit_or_eq_zero [comm_monoid_with_zero M]
+noncomputable def comm_group_with_zero_of_is_unit_or_eq_zero [hM : comm_monoid_with_zero M]
   (h : ∀ (a : M), is_unit a ∨ a = 0) : comm_group_with_zero M :=
-{ .. (group_with_zero_of_is_unit_or_eq_zero h), .. (infer_instance : comm_monoid_with_zero M) }
+{ .. (group_with_zero_of_is_unit_or_eq_zero h), .. hM }
 
 end noncomputable_defs

--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -911,3 +911,27 @@ end monoid_with_zero_hom
 @[simp] lemma monoid_hom.map_units_inv {M G₀ : Type*} [monoid M] [group_with_zero G₀]
   (f : M →* G₀) (u : units M) : f ↑u⁻¹ = (f u)⁻¹ :=
 by rw [← units.coe_map, ← units.coe_map, ← units.coe_inv', monoid_hom.map_inv]
+
+section noncomputable_defs
+
+variables {M : Type*} [nontrivial M]
+
+/-- Constructs a `group_with_zero` structure on a `monoid_with_zero`
+  consisting only of units and 0. -/
+noncomputable def group_with_zero_of_is_unit_or_eq_zero [monoid_with_zero M]
+  (h : ∀ (a : M), is_unit a ∨ a = 0) : group_with_zero M :=
+{ inv := λ a, if h0 : a = 0 then 0 else ↑((h a).resolve_right h0).unit⁻¹,
+  inv_zero := dif_pos rfl,
+  mul_inv_cancel := λ a h0, by {
+    change a * (if h0 : a = 0 then 0 else ↑((h a).resolve_right h0).unit⁻¹) = 1,
+    rw [dif_neg h0, units.mul_inv_eq_iff_eq_mul, one_mul, is_unit.unit_spec] },
+  exists_pair_ne := nontrivial.exists_pair_ne,
+.. (infer_instance : monoid_with_zero M) }
+
+/-- Constructs a `comm_group_with_zero` structure on a `comm_monoid_with_zero`
+  consisting only of units and 0. -/
+noncomputable def comm_group_with_zero_of_is_unit_or_eq_zero [comm_monoid_with_zero M]
+  (h : ∀ (a : M), is_unit a ∨ a = 0) : comm_group_with_zero M :=
+{ .. (group_with_zero_of_is_unit_or_eq_zero h), .. (infer_instance : comm_monoid_with_zero M) }
+
+end noncomputable_defs


### PR DESCRIPTION
Noncomputably defines the following group structures given that all (nonzero) elements are units:
- `monoid` -> `group`
- `comm_monoid` -> `comm_group`
- `monoid_with_zero` -> `comm_group_with_zero`
- `comm_monoid_with_zero` -> `comm_group_with_zero`
- `ring` -> `division_ring`
- `comm_ring` -> `field`

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
