### PR TITLE
feat(algebra/continued_fractions,data/{option,seq,stream}): add coe_t lemmas

### DIFF
--- a/src/algebra/continued_fractions/basic.lean
+++ b/src/algebra/continued_fractions/basic.lean
@@ -55,7 +55,7 @@ instance [has_repr α] : has_repr (gcf.pair α) :=
 
 section coe
 /-! Interlude: define some expected coercions. -/
-/- Fix another type `β` to which we will convert to. -/
+/- Fix another type `β` which we will convert to. -/
 variables {α} {β : Type*}
 
 /-- Coerce a pair by elementwise coercion. -/
@@ -68,8 +68,9 @@ lemma coe_to_generalized_continued_fraction_pair [has_coe α β] {a b : α} :
   (↑(gcf.pair.mk a b) : gcf.pair β) = gcf.pair.mk (a : β) (b : β) :=
 rfl
 
-/-- Again, coerce a pair by elementwise coercion. This instance is needed for coercions that are not
-marked as `has_coe` but `has_coe_t` like `rat.cast_coe`. -/
+/-- Coerce a pair by elementwise coercion. This instance is needed for coercions that are not
+marked as `has_coe` but only `has_coe_t` like `rat.cast_coe`, cf.
+`has_coe_to_generalized_continued_fraction_pair`. -/
 instance has_coe_t_to_generalized_continued_fraction_pair [has_coe_t α β] :
   has_coe_t (gcf.pair α) (gcf.pair β) :=
 ⟨λ gp, ⟨(gp.a : β), (gp.b : β)⟩⟩
@@ -148,7 +149,7 @@ rfl
 
 local attribute [instance] seq.has_coe_t_to_seq
 
-/-- Again, coerce a gcf by elementwise coercion. -/
+/-- Coerce a gcf by elementwise coercion. Cf. `has_coe_to_generalized_continued_fraction`. -/
 instance has_coe_t_to_generalized_continued_fraction [has_coe_t α β] : has_coe_t (gcf α) (gcf β) :=
 ⟨λ g, ⟨(g.h : β), (g.s : seq $ gcf.pair β)⟩⟩
 

--- a/src/algebra/continued_fractions/basic.lean
+++ b/src/algebra/continued_fractions/basic.lean
@@ -55,15 +55,27 @@ instance [has_repr α] : has_repr (gcf.pair α) :=
 
 section coe
 /-! Interlude: define some expected coercions. -/
-/- Fix another type `β` and assume `α` can be converted to `β`. -/
-variables {α} {β : Type*} [has_coe α β]
+/- Fix another type `β` to which we will convert to. -/
+variables {α} {β : Type*}
 
 /-- Coerce a pair by elementwise coercion. -/
-instance has_coe_to_generalized_continued_fraction_pair : has_coe (gcf.pair α) (gcf.pair β) :=
-⟨λ ⟨a, b⟩, ⟨(a : β), (b : β)⟩⟩
+instance has_coe_to_generalized_continued_fraction_pair [has_coe α β] :
+  has_coe (gcf.pair α) (gcf.pair β) :=
+⟨λ gp, ⟨(gp.a : β), (gp.b : β)⟩⟩
 
 @[simp, norm_cast]
-lemma coe_to_generalized_continued_fraction_pair {a b : α} :
+lemma coe_to_generalized_continued_fraction_pair [has_coe α β] {a b : α} :
+  (↑(gcf.pair.mk a b) : gcf.pair β) = gcf.pair.mk (a : β) (b : β) :=
+rfl
+
+/-- Again, coerce a pair by elementwise coercion. This instance is needed for coercions that are not
+marked as `has_coe` but `has_coe_t` like `rat.cast_coe`. -/
+instance has_coe_t_to_generalized_continued_fraction_pair [has_coe_t α β] :
+  has_coe_t (gcf.pair α) (gcf.pair β) :=
+⟨λ gp, ⟨(gp.a : β), (gp.b : β)⟩⟩
+
+@[simp, norm_cast, priority 900]
+lemma coe_t_to_generalized_continued_fraction_pair [has_coe_t α β] {a b : α} :
   (↑(gcf.pair.mk a b) : gcf.pair β) = gcf.pair.mk (a : β) (b : β) :=
 rfl
 
@@ -120,22 +132,30 @@ def terminates (g : gcf α) : Prop := g.s.terminates
 
 section coe
 /-! Interlude: define some expected coercions. -/
--- Fix another type `β` and assume `α` can be converted to `β`.
-variables {β : Type*} [has_coe α β]
+/- Fix another type `β`. -/
+variable {β : Type*}
 
-/-- Coerce a sequence by elementwise coercion. -/
-def seq.coe_to_seq : has_coe (seq α) (seq β) := ⟨seq.map (λ a, (a : β))⟩
-
-local attribute [instance] seq.coe_to_seq
+local attribute [instance] seq.has_coe_to_seq
 
 /-- Coerce a gcf by elementwise coercion. -/
-instance has_coe_to_generalized_continued_fraction : has_coe (gcf α) (gcf β) :=
-⟨λ ⟨h, s⟩, ⟨(h : β), (s : seq $ gcf.pair β)⟩⟩
+instance has_coe_to_generalized_continued_fraction [has_coe α β] : has_coe (gcf α) (gcf β) :=
+⟨λ g, ⟨(g.h : β), (g.s : seq $ gcf.pair β)⟩⟩
 
 @[simp, norm_cast]
-lemma coe_to_generalized_continued_fraction {g : gcf α} :
+lemma coe_to_generalized_continued_fraction [has_coe α β] {g : gcf α} :
   (↑(g : gcf α) : gcf β) = ⟨(g.h : β), (g.s : seq $ gcf.pair β)⟩ :=
-by { cases g, refl }
+rfl
+
+local attribute [instance] seq.has_coe_t_to_seq
+
+/-- Again, coerce a gcf by elementwise coercion. -/
+instance has_coe_t_to_generalized_continued_fraction [has_coe_t α β] : has_coe_t (gcf α) (gcf β) :=
+⟨λ g, ⟨(g.h : β), (g.s : seq $ gcf.pair β)⟩⟩
+
+@[simp, norm_cast, priority 900]
+lemma coe_t_to_generalized_continued_fraction [has_coe_t α β] {g : gcf α} :
+  (↑(g : gcf α) : gcf β) = ⟨(g.h : β), (g.s : seq $ gcf.pair β)⟩ :=
+rfl
 
 end coe
 end generalized_continued_fraction

--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -97,8 +97,9 @@ lemma coe_to_int_fract_pair [has_coe K β] {b : ℤ} {fr : K} :
   (↑(int_fract_pair.mk b fr) : int_fract_pair β) = int_fract_pair.mk b (↑fr : β) :=
 rfl
 
-/-- Again, coerce a pair by coercing the fractional component. This instance is needed for coercions
-that are not marked as `has_coe` but `has_coe_t` like `rat.cast_coe`. -/
+/-- Coerce a pair by coercing the fractional component. This instance is needed for coercions
+that are not marked as `has_coe` but `has_coe_t` like `rat.cast_coe`, cf.
+`has_coe_to_int_fract_pair`. -/
 instance has_coe_t_to_int_fract_pair [has_coe_t K β] :
   has_coe_t (int_fract_pair K) (int_fract_pair β) :=
 ⟨λ ifp, ⟨ifp.b, (ifp.fr : β)⟩⟩

--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -85,16 +85,26 @@ variable {K}
 
 section coe
 /-! Interlude: define some expected coercions. -/
-/- Fix another type `β` and assume `K` can be converted to `β`. -/
-variables {β : Type*} [has_coe K β]
+/- Fix another type `β`. -/
+variable {β : Type*}
 
 /-- Coerce a pair by coercing the fractional component. -/
-instance has_coe_to_int_fract_pair : has_coe (int_fract_pair K) (int_fract_pair β) :=
-⟨λ ⟨b, fr⟩, ⟨b, (fr : β)⟩⟩
-
+instance has_coe_to_int_fract_pair [has_coe K β] : has_coe (int_fract_pair K) (int_fract_pair β) :=
+⟨λ ifp, ⟨ifp.b, (ifp.fr : β)⟩⟩
 
 @[simp, norm_cast]
-lemma coe_to_int_fract_pair {b : ℤ} {fr : K} :
+lemma coe_to_int_fract_pair [has_coe K β] {b : ℤ} {fr : K} :
+  (↑(int_fract_pair.mk b fr) : int_fract_pair β) = int_fract_pair.mk b (↑fr : β) :=
+rfl
+
+/-- Again, coerce a pair by coercing the fractional component. This instance is needed for coercions
+that are not marked as `has_coe` but `has_coe_t` like `rat.cast_coe`. -/
+instance has_coe_t_to_int_fract_pair [has_coe_t K β] :
+  has_coe_t (int_fract_pair K) (int_fract_pair β) :=
+⟨λ ifp, ⟨ifp.b, (ifp.fr : β)⟩⟩
+
+@[simp, norm_cast, priority 900]
+lemma coe_t_to_int_fract_pair [has_coe_t K β] {b : ℤ} {fr : K} :
   (↑(int_fract_pair.mk b fr) : int_fract_pair β) = int_fract_pair.mk b (↑fr : β) :=
 rfl
 
@@ -162,7 +172,7 @@ added in a future commit).
 
 The continued fraction representation of `v` is given by `[⌊v⌋; b₀, b₁, b₂,...]`, where
 `[b₀; b₁, b₂,...]` recursively is the continued fraction representation of `1 / (v − ⌊v⌋)`. This
-process stops when the fractional part `v- ⌊v⌋` hits 0 at some step.
+process stops when the fractional part `v - ⌊v⌋` hits 0 at some step.
 
 The implementation uses `int_fract_pair.stream` to obtain the partial denominators of the continued
 fraction. Refer to said function for more details about the computation process.

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -221,4 +221,25 @@ def cases_on' : option α → β → (α → β) → β
   cases_on' o (f none) (f ∘ coe) = f o :=
 by cases o; refl
 
+section coe_t
+
+/-- Coerce an option by coercing its stored value. -/
+def has_coe_t_to_option [has_coe_t α β] : has_coe_t (option α) (option β) :=
+⟨option.map (λ a, (↑a : β))⟩
+
+local attribute [instance] has_coe_t_to_option
+
+@[simp, norm_cast]
+lemma coe_t_to_some [has_coe_t α β] {a : α} : (↑(some a) : option β) = some (↑a : β) := rfl
+
+@[simp, norm_cast]
+lemma coe_t_to_none [has_coe_t α β] : (↑(none : option α) : option β) = (none : option β) := rfl
+
+@[simp, norm_cast]
+lemma coe_t_eq_none_iff_eq_none [has_coe_t α β] {o : option α} :
+  (↑o : option β) = (none : option β) ↔ (o = (none : option α)) :=
+by { split, { intro h, cases o; finish }, { intro h, simp [h] } }
+
+end coe_t
+
 end option

--- a/src/data/seq/seq.lean
+++ b/src/data/seq/seq.lean
@@ -684,7 +684,7 @@ section coe
 /-- Coerce a sequence by elementwise coercion. -/
 def has_coe_to_seq [has_coe α β] : has_coe (seq α) (seq β) := ⟨seq.map (λ a, (a : β))⟩
 
-/-- Coerce a seq by elementwise coercion. -/
+/-- Coerce a sequence by elementwise coercion. -/
 def has_coe_t_to_seq [has_coe_t α β] : has_coe_t (seq α) (seq β) :=
 ⟨seq.map (λ a, (↑a : β))⟩
 

--- a/src/data/seq/seq.lean
+++ b/src/data/seq/seq.lean
@@ -679,6 +679,26 @@ end
 theorem mem_append_left {s₁ s₂ : seq α} {a : α} (h : a ∈ s₁) : a ∈ append s₁ s₂ :=
 by apply mem_rec_on h; intros; simp [*]
 
+section coe
+
+/-- Coerce a sequence by elementwise coercion. -/
+def has_coe_to_seq [has_coe α β] : has_coe (seq α) (seq β) := ⟨seq.map (λ a, (a : β))⟩
+
+/-- Coerce a seq by elementwise coercion. -/
+def has_coe_t_to_seq [has_coe_t α β] : has_coe_t (seq α) (seq β) :=
+⟨seq.map (λ a, (↑a : β))⟩
+
+local attribute [instance] option.has_coe_t_to_option has_coe_t_to_seq
+
+lemma coe_t_to_seq [has_coe_t α β] (s : seq α) : (↑(s : seq α) : seq β) = s.map (λ a, (↑a : β)) :=
+rfl
+
+@[simp, norm_cast]
+lemma coe_t_nth [has_coe_t α β] {s : seq α} {n : ℕ} : (↑s : seq β).nth n = ↑(s.nth n : option α) :=
+by { unfold_coes, simp [seq.map_nth] }
+
+end coe
+
 end seq
 
 namespace seq1

--- a/src/data/stream/basic.lean
+++ b/src/data/stream/basic.lean
@@ -12,23 +12,44 @@ import data.list.range
 # Additional instances and attributes for streams
 -/
 
+variable {α : Type*}
+
 attribute [ext] stream.ext
 
-instance {α} [inhabited α] : inhabited (stream α) :=
+instance [inhabited α] : inhabited (stream α) :=
 ⟨stream.const (default _)⟩
 
 namespace stream
 open nat
 
 /-- `take s n` returns a list of the `n` first elements of stream `s` -/
-def take {α} (s : stream α) (n : ℕ) : list α :=
+def take (s : stream α) (n : ℕ) : list α :=
 (list.range n).map s
 
-lemma length_take {α} (s : stream α) (n : ℕ) : (take s n).length = n :=
+lemma length_take (s : stream α) (n : ℕ) : (take s n).length = n :=
 by simp [take]
 
 /-- Use a state monad to generate a stream through corecursion -/
 def corec_state {σ α} (cmd : state σ α) (s : σ) : stream α :=
 stream.corec prod.fst (cmd.run ∘ prod.snd) (cmd.run s)
+
+section coe_t
+
+variable {β : Type*}
+
+/-- Coerce a stream by elementwise coercion. -/
+def has_coe_t_to_stream [has_coe_t α β] : has_coe_t (stream α) (stream β) :=
+⟨stream.map (λ a, (↑a : β))⟩
+
+local attribute [instance] has_coe_t_to_stream
+
+lemma coe_t_to_stream [has_coe_t α β] (s : stream α) :
+  (↑(s : stream α) : stream β) = s.map (λ a, (↑a : β)) :=
+rfl
+
+@[simp]
+lemma coe_t_nth [has_coe_t α β] {s : stream α} {n : ℕ} : (↑s : stream β) n = ↑(s n : α) := rfl
+
+end coe_t
 
 end stream


### PR DESCRIPTION
### What

Add `coe_t` lemmas and (local) `has_coe_t` instances for continued fractions and their underlying data structures option, stream, and seq.

### Why
In #4867, lemmas about the termination of rational continued fractions will be added. In those lemmas, one needs to coerce from rational continued fractions and their underlying structures to their corresponding counterpart in a more abstract field.
The coercion from rationals to such fields is marked as `coe_t` to prevent looping; see [here](https://github.com/leanprover-community/mathlib/commit/06bae3e11245a3b0147709986ae7da7e9a5e35e6#diff-9205314811ce05bdf63e1d495e7edf9c807e22b852473248b4cac37ad9a80a7fL35) for more details.
To enable coercions from the data structures containing rationals to those containing values in given abstract field, we hence add coe_t definitions for option, stream, and seq.

### How
Add coe_t definitions and some simple corresponding lemmas at the appropriate places.
Those definitions are not made global instances to avoid troubles/loops with coercions/typeclass search.
Instead, in those rare cases that users want to allow these coercions - as I will do in #4867 - a local instance should be created.