### PR TITLE
[Merged by Bors] - chore(category_theory/sites/sheaf): rename sheaf to sheaf_of_types

### DIFF
--- a/src/category_theory/sites/canonical.lean
+++ b/src/category_theory/sites/canonical.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 
-import category_theory.sites.sheaf
+import category_theory.sites.sheaf_of_types
 
 
 /-!

--- a/src/category_theory/sites/sheaf_of_types.lean
+++ b/src/category_theory/sites/sheaf_of_types.lean
@@ -9,9 +9,10 @@ import category_theory.limits.shapes.types
 import category_theory.full_subcategory
 
 /-!
-# Sheaves on a Grothendieck topology
+# Sheaves of types on a Grothendieck topology
 
-Defines the notion of a sheaf on a Grothendieck topology, as well as a range of equivalent
+Defines the notion of a sheaf of types (usually called a sheaf of sets by mathematicians)
+on a category equipped with a Grothendieck topology, as well as a range of equivalent
 conditions useful in different situations.
 
 First define what it means for a presheaf `P : Cᵒᵖ ⥤ Type v` to be a sheaf *for* a particular
@@ -885,10 +886,10 @@ variables (J : grothendieck_topology C)
 
 /-- The category of sheaves on a grothendieck topology. -/
 @[derive category]
-def Sheaf (J : grothendieck_topology C) : Type (max u (v+1)) :=
+def SheafOfTypes (J : grothendieck_topology C) : Type (max u (v+1)) :=
 {P : Cᵒᵖ ⥤ Type v // presieve.is_sheaf J P}
 
-instance : inhabited (Sheaf (⊥ : grothendieck_topology C)) :=
+instance : inhabited (SheafOfTypes (⊥ : grothendieck_topology C)) :=
 ⟨⟨(functor.const _).obj punit,
   λ X S hS,
   begin
@@ -899,7 +900,7 @@ instance : inhabited (Sheaf (⊥ : grothendieck_topology C)) :=
 
 /-- The inclusion functor from sheaves to presheaves. -/
 @[simps {rhs_md := semireducible}, derive [full, faithful]]
-def Sheaf_to_presheaf : Sheaf J ⥤ (Cᵒᵖ ⥤ Type v) :=
+def SheafOfTypes_to_presheaf : SheafOfTypes J ⥤ (Cᵒᵖ ⥤ Type v) :=
 full_subcategory_inclusion (presieve.is_sheaf J)
 
 end category_theory

--- a/src/category_theory/sites/types.lean
+++ b/src/category_theory/sites/types.lean
@@ -55,7 +55,7 @@ theorem is_sheaf_yoneda' {α : Type u} : is_sheaf types_grothendieck_topology (y
 λ f hf, funext $ λ y, by convert congr_fun (hf _ (hs y)) punit.star⟩
 
 /-- The yoneda functor that sends a type to a sheaf over the category of types -/
-@[simps] def yoneda' : Type u ⥤ Sheaf types_grothendieck_topology :=
+@[simps] def yoneda' : Type u ⥤ SheafOfTypes types_grothendieck_topology :=
 { obj := λ α, ⟨yoneda.obj α, is_sheaf_yoneda'⟩,
   map := λ α β f, yoneda.map f }
 
@@ -113,14 +113,14 @@ funext $ λ s, funext $ λ x, eval_map S (unop α) (unop β) f.unop _ _
 
 /-- Given a sheaf `S`, construct an isomorphism `S ≅ [-, S(*)]`. -/
 @[simps] noncomputable def equiv_yoneda'
-  (S : Sheaf types_grothendieck_topology) :
+  (S : SheafOfTypes types_grothendieck_topology) :
   S ≅ yoneda'.obj (S.1.obj (op punit)) :=
 { hom := (equiv_yoneda S.1 S.2).hom,
   inv := (equiv_yoneda S.1 S.2).inv,
   hom_inv_id' := (equiv_yoneda S.1 S.2).hom_inv_id,
   inv_hom_id' := (equiv_yoneda S.1 S.2).inv_hom_id }
 
-lemma eval_app (S₁ S₂ : Sheaf.{u} types_grothendieck_topology)
+lemma eval_app (S₁ S₂ : SheafOfTypes.{u} types_grothendieck_topology)
   (f : S₁ ⟶ S₂) (α : Type u) (s : S₁.1.obj (op α)) (x : α) :
   eval S₂.1 α (f.app (op α) s) x = f.app (op punit) (eval S₁.1 α s x) :=
 (congr_fun (f.2 (↾λ _ : punit, x).op) s).symm
@@ -128,7 +128,7 @@ lemma eval_app (S₁ S₂ : Sheaf.{u} types_grothendieck_topology)
 /-- `yoneda'` induces an equivalence of category between `Type u` and
 `Sheaf types_grothendieck_topology`. -/
 @[simps {rhs_md := semireducible}] noncomputable def type_equiv :
-  Type u ≌ Sheaf types_grothendieck_topology :=
+  Type u ≌ SheafOfTypes types_grothendieck_topology :=
 equivalence.mk
   yoneda'
   (induced_functor _ ⋙ (evaluation _ _).obj (op punit))

--- a/src/category_theory/sites/types.lean
+++ b/src/category_theory/sites/types.lean
@@ -5,7 +5,7 @@ Authors: Kenny Lau
 -/
 
 import category_theory.sites.canonical
-import category_theory.sites.sheaf
+import category_theory.sites.sheaf_of_types
 
 /-!
 # Grothendieck Topology and Sheaves on the Category of Types


### PR DESCRIPTION
I wanted to add sheaves with values in general categories, so I moved sheaf.lean to sheaf_of_types.lean and then added a new file sheaf.lean. Github then produced an incomprehensible diff file because sheaf.lean had completely changed. Hence I propose first moving `sheaf.lean` to `sheaf_of_types.lean` and then adding a new `sheaf.lean` later. As well as moving the file, I also slightly change it.

---

<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
