### PR TITLE
[Merged by Bors] - feat(data/complex/is_R_or_C): register some instances

### DIFF
--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -98,10 +98,8 @@ class inner_product_space (𝕜 : Type*) (E : Type*) [is_R_or_C 𝕜]
 (add_left  : ∀ x y z, inner (x + y) z = inner x z + inner y z)
 (smul_left : ∀ x y r, inner (r • x) y = (conj r) * inner x y)
 
-/- This instance generates the type-class problem `inner_product_space ?m E` when looking for
-   `normed_group E`. However, since `?m` can only ever be `ℝ` or `ℂ`, this should not cause
-   problems. -/
 attribute [nolint dangerous_instance] inner_product_space.to_normed_group
+-- note [is_R_or_C instance]
 
 /-!
 ### Constructing a normed space structure from an inner product

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -607,9 +607,8 @@ variables {K : Type*} [is_R_or_C K]
 open_locale classical
 open is_R_or_C
 
-/-- An `is_R_or_C` field is finite-dimensional over `ℝ`, since it is spanned by `{1, I}`. Not
-made an instance because of `recursive instance` issues. -/
-lemma is_R_or_C_to_real : finite_dimensional ℝ K :=
+/-- An `is_R_or_C` field is finite-dimensional over `ℝ`, since it is spanned by `{1, I}`. -/
+@[nolint dangerous_instance] instance is_R_or_C_to_real : finite_dimensional ℝ K :=
 finite_dimensional.iff_fg.mpr ⟨{1, I},
   begin
     rw eq_top_iff,
@@ -623,11 +622,10 @@ finite_dimensional.iff_fg.mpr ⟨{1, I},
 
 /-- Over an `is_R_or_C` field, we can register the properness of finite-dimensional normed spaces as
 an instance. -/
-@[priority 900] instance proper_is_R_or_C
+@[priority 900, nolint dangerous_instance] instance proper_is_R_or_C
   {E : Type*} [normed_group E] [normed_space K E] [finite_dimensional K E] :
   proper_space E :=
 begin
-  letI : finite_dimensional ℝ K := is_R_or_C_to_real,
   letI : normed_space ℝ E := restrict_scalars.normed_space ℝ K E,
   letI : is_scalar_tower ℝ K E := restrict_scalars.is_scalar_tower _ _ _,
   letI : finite_dimensional ℝ E := finite_dimensional.trans ℝ K E,

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -616,13 +616,13 @@ finite_dimensional.iff_fg.mpr (⟨{1, I},
 
 /- Over an `is_R_or_C` field, we can register the properness of finite-dimensional normed spaces as
 an instance. -/
-instance finite_dimensional.proper_is_R_or_C {𝕜 : Type*}
-  [is_R_or_C 𝕜] {E : Type*} [normed_group E] [normed_space 𝕜 E] [finite_dimensional 𝕜 E] :
+instance finite_dimensional.proper_is_R_or_C
+  {E : Type*} [normed_group E] [normed_space K E] [finite_dimensional K E] :
   proper_space E :=
 begin
-  letI : normed_space ℝ E := restrict_scalars.normed_space ℝ 𝕜 E,
-  letI : is_scalar_tower ℝ 𝕜 E := restrict_scalars.is_scalar_tower _ _ _,
-  letI : finite_dimensional ℝ E := finite_dimensional.trans ℝ 𝕜 E,
+  letI : normed_space ℝ E := restrict_scalars.normed_space ℝ K E,
+  letI : is_scalar_tower ℝ K E := restrict_scalars.is_scalar_tower _ _ _,
+  letI : finite_dimensional ℝ E := finite_dimensional.trans ℝ K E,
   apply_instance
 end
 

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -599,9 +599,16 @@ ring_hom.map_finsupp_sum _ f g
   ((f.prod (λ a b, g a b) : ℝ) : K) = f.prod (λ a b, ((g a b) : K)) :=
 ring_hom.map_finsupp_prod _ f g
 
-open_locale classical
+end is_R_or_C
 
-instance finite_dimensional.is_R_or_C_to_real : finite_dimensional ℝ K :=
+namespace finite_dimensional
+variables {K : Type*} [is_R_or_C K]
+
+open_locale classical
+open is_R_or_C
+
+/-- An `is_R_or_C` field is finite-dimensional over `ℝ`, since it is spanned by `{1, I}`. -/
+instance is_R_or_C_to_real : finite_dimensional ℝ K :=
 finite_dimensional.iff_fg.mpr ⟨{1, I},
   begin
     rw eq_top_iff,
@@ -615,8 +622,7 @@ finite_dimensional.iff_fg.mpr ⟨{1, I},
 
 /- Over an `is_R_or_C` field, we can register the properness of finite-dimensional normed spaces as
 an instance. -/
-instance finite_dimensional.proper_is_R_or_C
-  {E : Type*} [normed_group E] [normed_space K E] [finite_dimensional K E] :
+instance proper_is_R_or_C {E : Type*} [normed_group E] [normed_space K E] [finite_dimensional K E] :
   proper_space E :=
 begin
   letI : normed_space ℝ E := restrict_scalars.normed_space ℝ K E,
@@ -625,7 +631,7 @@ begin
   apply_instance
 end
 
-end is_R_or_C
+end finite_dimensional
 
 section instances
 

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -607,6 +607,10 @@ variables {K : Type*} [is_R_or_C K]
 open_locale classical
 open is_R_or_C
 
+/-- This instance generates a type-class problem with a metavariable `?m` that should satisfy
+`is_R_or_C ?m`. Since this can only be satisfied by `ℝ` or `ℂ`, this does not cause problems. -/
+library_note "is_R_or_C instance"
+
 /-- An `is_R_or_C` field is finite-dimensional over `ℝ`, since it is spanned by `{1, I}`. -/
 @[nolint dangerous_instance] instance is_R_or_C_to_real : finite_dimensional ℝ K :=
 finite_dimensional.iff_fg.mpr ⟨{1, I},
@@ -622,7 +626,7 @@ finite_dimensional.iff_fg.mpr ⟨{1, I},
 
 /-- Over an `is_R_or_C` field, we can register the properness of finite-dimensional normed spaces as
 an instance. -/
-@[priority 900, nolint dangerous_instance] instance proper_is_R_or_C
+@[priority 900, nolint dangerous_instance] instance proper_is_R_or_C -- note [is_R_or_C instance]
   {E : Type*} [normed_group E] [normed_space K E] [finite_dimensional K E] :
   proper_space E :=
 begin

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -599,6 +599,33 @@ ring_hom.map_finsupp_sum _ f g
   ((f.prod (λ a b, g a b) : ℝ) : K) = f.prod (λ a b, ((g a b) : K)) :=
 ring_hom.map_finsupp_prod _ f g
 
+open_locale classical
+
+instance finite_dimensional.is_R_or_C_to_real : finite_dimensional ℝ K :=
+finite_dimensional.iff_fg.mpr (⟨{1, I},
+  begin
+    rw eq_top_iff,
+    intros a _,
+    rw [finset.coe_insert, finset.coe_singleton, submodule.mem_span_insert],
+    refine ⟨re a, (im a) * I, _, _⟩,
+    { rw submodule.mem_span_singleton,
+      use im a,
+      simp [algebra.smul_def, algebra_map_eq_of_real] },
+    simp [re_add_im a, algebra.smul_def, algebra_map_eq_of_real]
+  end⟩)
+
+/- Over an `is_R_or_C` field, we can register the properness of finite-dimensional normed spaces as
+an instance. -/
+instance finite_dimensional.proper_is_R_or_C {𝕜 : Type*}
+  [is_R_or_C 𝕜] {E : Type*} [normed_group E] [normed_space 𝕜 E] [finite_dimensional 𝕜 E] :
+  proper_space E :=
+begin
+  letI : normed_space ℝ E := restrict_scalars.normed_space ℝ 𝕜 E,
+  letI : is_scalar_tower ℝ 𝕜 E := restrict_scalars.is_scalar_tower _ _ _,
+  letI : finite_dimensional ℝ E := finite_dimensional.trans ℝ 𝕜 E,
+  apply_instance
+end
+
 end is_R_or_C
 
 section instances

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -607,8 +607,9 @@ variables {K : Type*} [is_R_or_C K]
 open_locale classical
 open is_R_or_C
 
-/-- An `is_R_or_C` field is finite-dimensional over `ℝ`, since it is spanned by `{1, I}`. -/
-instance is_R_or_C_to_real : finite_dimensional ℝ K :=
+/-- An `is_R_or_C` field is finite-dimensional over `ℝ`, since it is spanned by `{1, I}`. Not
+made an instance because of `recursive instance` issues. -/
+lemma is_R_or_C_to_real : finite_dimensional ℝ K :=
 finite_dimensional.iff_fg.mpr ⟨{1, I},
   begin
     rw eq_top_iff,
@@ -622,9 +623,11 @@ finite_dimensional.iff_fg.mpr ⟨{1, I},
 
 /-- Over an `is_R_or_C` field, we can register the properness of finite-dimensional normed spaces as
 an instance. -/
-instance proper_is_R_or_C {E : Type*} [normed_group E] [normed_space K E] [finite_dimensional K E] :
+@[priority 900] instance proper_is_R_or_C
+  {E : Type*} [normed_group E] [normed_space K E] [finite_dimensional K E] :
   proper_space E :=
 begin
+  letI : finite_dimensional ℝ K := is_R_or_C_to_real,
   letI : normed_space ℝ E := restrict_scalars.normed_space ℝ K E,
   letI : is_scalar_tower ℝ K E := restrict_scalars.is_scalar_tower _ _ _,
   letI : finite_dimensional ℝ E := finite_dimensional.trans ℝ K E,

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -602,17 +602,16 @@ ring_hom.map_finsupp_prod _ f g
 open_locale classical
 
 instance finite_dimensional.is_R_or_C_to_real : finite_dimensional ℝ K :=
-finite_dimensional.iff_fg.mpr (⟨{1, I},
+finite_dimensional.iff_fg.mpr ⟨{1, I},
   begin
     rw eq_top_iff,
     intros a _,
     rw [finset.coe_insert, finset.coe_singleton, submodule.mem_span_insert],
-    refine ⟨re a, (im a) * I, _, _⟩,
+    refine ⟨re a, (im a) • I, _, _⟩,
     { rw submodule.mem_span_singleton,
-      use im a,
-      simp [algebra.smul_def, algebra_map_eq_of_real] },
+      use im a },
     simp [re_add_im a, algebra.smul_def, algebra_map_eq_of_real]
-  end⟩)
+  end⟩
 
 /- Over an `is_R_or_C` field, we can register the properness of finite-dimensional normed spaces as
 an instance. -/

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -620,7 +620,7 @@ finite_dimensional.iff_fg.mpr ⟨{1, I},
     simp [re_add_im a, algebra.smul_def, algebra_map_eq_of_real]
   end⟩
 
-/- Over an `is_R_or_C` field, we can register the properness of finite-dimensional normed spaces as
+/-- Over an `is_R_or_C` field, we can register the properness of finite-dimensional normed spaces as
 an instance. -/
 instance proper_is_R_or_C {E : Type*} [normed_group E] [normed_space K E] [finite_dimensional K E] :
   proper_space E :=


### PR DESCRIPTION
Register a couple of facts which were previously known for `ℝ` and `ℂ` individually, but not for the typeclass `[is_R_or_C K]`:
- such a field `K` is finite-dimensional as a vector space over `ℝ`
- finite-dimensional normed spaces over `K` are proper.

https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Instances.20for.20is_R_or_C

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
