### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/inner_product): orthogonal complement lemmas

### DIFF
--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1782,13 +1782,8 @@ submodule.sup_orthogonal_of_is_complete (complete_space_coe_iff_is_complete.mp �
 /-- If `K` is complete, any `v` in `E` can be expressed as a sum of elements of `K` and
 `K.orthogonal`. -/
 lemma submodule.exists_sum_mem_mem_orthogonal (K : submodule 𝕜 E) [complete_space K] (v : E) :
-  ∃ {y : K} {z : K.orthogonal}, v = y + z :=
-begin
-  have hv : v ∈ K ⊔ K.orthogonal,
-  { simp [submodule.sup_orthogonal_of_complete_space] },
-  obtain ⟨y, hy, z, hz, hyz⟩ := submodule.mem_sup.mp hv,
-  exact ⟨⟨y, hy⟩, ⟨z, hz⟩, hyz.symm⟩
-end
+  ∃ (y ∈ K) (z ∈ K.orthogonal), y + z = v :=
+by { rw [← submodule.mem_sup], simp [submodule.sup_orthogonal_of_complete_space] }
 
 /-- If `K` is complete, then the orthogonal complement of its orthogonal complement is itself. -/
 @[simp] lemma submodule.mem_orthogonal_orthogonal_iff
@@ -1796,15 +1791,12 @@ end
   v ∈ K.orthogonal.orthogonal ↔ v ∈ K :=
 begin
   split,
-  { obtain ⟨⟨y, hy⟩, ⟨z, hz⟩, hvyz⟩ := K.exists_sum_mem_mem_orthogonal v,
-    have hyz : ⟪z, y⟫ = 0,
-    { simpa [inner_eq_zero_sym] using hz y hy },
+  { obtain ⟨y, hy, z, hz, hvyz⟩ := K.exists_sum_mem_mem_orthogonal v,
     intros hv,
     have hz' : z = 0,
-    { have hyz' : ⟪z, y + z⟫ = 0,
-      { simpa [hvyz] using hv z hz },
-      simpa [inner_add_right, hyz] using hyz' },
-    simp [hvyz, hy, hz'] },
+    { have hyz : ⟪z, y⟫ = 0 := by simp [hz y hy, inner_eq_zero_sym],
+      simpa [← hvyz, inner_add_right, hyz] using hv z hz },
+    simp [← hvyz, hy, hz'] },
   { intros hv w hw,
     rw inner_eq_zero_sym,
     exact hw v hv }

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1673,7 +1673,7 @@ lemma submodule.inner_right_of_mem_orthogonal {u v : E} {K : submodule 𝕜 E} (
 (K.mem_orthogonal v).1 hv u hu
 
 /-- A vector in `K.orthogonal` is orthogonal to one in `K`. -/
-lemma submodule.inner_right_of_mem_orthogonal {u v : E} {K : submodule 𝕜 E} (hu : u ∈ K)
+lemma submodule.inner_left_of_mem_orthogonal {u v : E} {K : submodule 𝕜 E} (hu : u ∈ K)
     (hv : v ∈ K.orthogonal) : ⟪v, u⟫ = 0 :=
 by rw [inner_eq_zero_sym]; exact submodule.inner_right_of_mem_orthogonal hu hv
 
@@ -1716,8 +1716,8 @@ variables (𝕜 E)
 lemma submodule.orthogonal_gc :
   @galois_connection (submodule 𝕜 E) (order_dual $ submodule 𝕜 E) _ _
     submodule.orthogonal submodule.orthogonal :=
-λ K₁ K₂, ⟨λ h v hv u hu, submodule.inner_right_of_mem_orthogonal hv (h hu),
-          λ h v hv u hu, submodule.inner_right_of_mem_orthogonal hv (h hu)⟩
+λ K₁ K₂, ⟨λ h v hv u hu, submodule.inner_left_of_mem_orthogonal hv (h hu),
+          λ h v hv u hu, submodule.inner_left_of_mem_orthogonal hv (h hu)⟩
 
 variables {𝕜 E}
 

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1697,6 +1697,18 @@ begin
     exact hv ⟨w, hw⟩ }
 end
 
+/-- The orthogonal complement of any submodule `K` is closed. -/
+lemma submodule.is_closed_orthogonal (K : submodule 𝕜 E) : is_closed (K.orthogonal : set E) :=
+begin
+  rw orthogonal_eq_inter K,
+  convert is_closed_Inter (λ v : K, (inner_left (v:E)).is_closed_ker),
+  simp
+end
+
+/-- In a complete space, the orthogonal complement of any submodule `K` is complete. -/
+instance [complete_space E] (K : submodule 𝕜 E) : complete_space K.orthogonal :=
+K.is_closed_orthogonal.complete_space_coe
+
 variables (𝕜 E)
 
 /-- `submodule.orthogonal` gives a `galois_connection` between
@@ -1714,7 +1726,6 @@ subspaces. -/
 lemma submodule.orthogonal_le {K₁ K₂ : submodule 𝕜 E} (h : K₁ ≤ K₂) :
   K₂.orthogonal ≤ K₁.orthogonal :=
 (submodule.orthogonal_gc 𝕜 E).monotone_l h
-
 
 /-- `K` is contained in `K.orthogonal.orthogonal`. -/
 lemma submodule.le_orthogonal_orthogonal (K : submodule 𝕜 E) : K ≤ K.orthogonal.orthogonal :=
@@ -1831,19 +1842,6 @@ begin
   have : K ⊔ K.orthogonal = ⊤ := submodule.sup_orthogonal_of_is_complete hK,
   rwa [h, sup_comm, bot_sup_eq] at this,
 end
-
-/-- In a complete space, the orthogonal complement of any submodule `K` is closed. -/
-lemma submodule.is_closed_orthogonal [complete_space E] (K : submodule 𝕜 E) :
-  is_closed (K.orthogonal : set E) :=
-begin
-  rw orthogonal_eq_inter K,
-  convert is_closed_Inter (λ v : K, (inner_left (v:E)).is_closed_ker),
-  simp
-end
-
-/-- In a complete space, the orthogonal complement of any submodule `K` is complete. -/
-instance [complete_space E] (K : submodule 𝕜 E) : complete_space K.orthogonal :=
-K.is_closed_orthogonal.complete_space_coe
 
 open finite_dimensional
 

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1027,7 +1027,7 @@ by simp_rw [sum_inner, inner_sum, real_inner_smul_left, real_inner_smul_right,
 /-- The inner product with a fixed left element, as a continuous linear map.  This can be upgraded
 to a continuous map which is jointly conjugate-linear in the left argument and linear in the right
 argument, once (TODO) conjugate-linear maps have been defined. -/
-def inner_left (v : E) : E →L[𝕜] 𝕜 :=
+def inner_right (v : E) : E →L[𝕜] 𝕜 :=
 linear_map.mk_continuous
   { to_fun := λ w, ⟪v, w⟫,
     map_add' := λ x y, inner_add_right,
@@ -1035,9 +1035,9 @@ linear_map.mk_continuous
   ∥v∥
   (by simpa [is_R_or_C.norm_eq_abs] using abs_inner_le_norm v)
 
-@[simp] lemma inner_left_coe (v : E) : (inner_left v : E → 𝕜) = λ w, ⟪v, w⟫ := rfl
+@[simp] lemma inner_right_coe (v : E) : (inner_right v : E → 𝕜) = λ w, ⟪v, w⟫ := rfl
 
-@[simp] lemma inner_left_apply (v w : E) : inner_left v w = ⟪v, w⟫ := rfl
+@[simp] lemma inner_right_apply (v w : E) : inner_right v w = ⟪v, w⟫ := rfl
 
 end norm
 
@@ -1673,7 +1673,7 @@ lemma submodule.inner_right_of_mem_orthogonal {u v : E} {K : submodule 𝕜 E} (
 (K.mem_orthogonal v).1 hv u hu
 
 /-- A vector in `K.orthogonal` is orthogonal to one in `K`. -/
-lemma submodule.inner_left_of_mem_orthogonal {u v : E} {K : submodule 𝕜 E} (hu : u ∈ K)
+lemma submodule.inner_right_of_mem_orthogonal {u v : E} {K : submodule 𝕜 E} (hu : u ∈ K)
     (hv : v ∈ K.orthogonal) : ⟪v, u⟫ = 0 :=
 by rw [inner_eq_zero_sym]; exact submodule.inner_right_of_mem_orthogonal hu hv
 
@@ -1686,7 +1686,7 @@ end
 
 /-- `K.orthogonal` can be characterized as the intersection of the kernels of the operations of
 inner product with each of the elements of `K`. -/
-lemma orthogonal_eq_inter (K : submodule 𝕜 E) : K.orthogonal = ⨅ v : K, (inner_left (v:E)).ker :=
+lemma orthogonal_eq_inter (K : submodule 𝕜 E) : K.orthogonal = ⨅ v : K, (inner_right (v:E)).ker :=
 begin
   apply le_antisymm,
   { rw le_infi_iff,
@@ -1701,7 +1701,7 @@ end
 lemma submodule.is_closed_orthogonal (K : submodule 𝕜 E) : is_closed (K.orthogonal : set E) :=
 begin
   rw orthogonal_eq_inter K,
-  convert is_closed_Inter (λ v : K, (inner_left (v:E)).is_closed_ker),
+  convert is_closed_Inter (λ v : K, (inner_right (v:E)).is_closed_ker),
   simp
 end
 
@@ -1716,8 +1716,8 @@ variables (𝕜 E)
 lemma submodule.orthogonal_gc :
   @galois_connection (submodule 𝕜 E) (order_dual $ submodule 𝕜 E) _ _
     submodule.orthogonal submodule.orthogonal :=
-λ K₁ K₂, ⟨λ h v hv u hu, submodule.inner_left_of_mem_orthogonal hv (h hu),
-          λ h v hv u hu, submodule.inner_left_of_mem_orthogonal hv (h hu)⟩
+λ K₁ K₂, ⟨λ h v hv u hu, submodule.inner_right_of_mem_orthogonal hv (h hu),
+          λ h v hv u hu, submodule.inner_right_of_mem_orthogonal hv (h hu)⟩
 
 variables {𝕜 E}
 

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1782,8 +1782,12 @@ submodule.sup_orthogonal_of_is_complete (complete_space_coe_iff_is_complete.mp �
 /-- If `K` is complete, any `v` in `E` can be expressed as a sum of elements of `K` and
 `K.orthogonal`. -/
 lemma submodule.exists_sum_mem_mem_orthogonal (K : submodule 𝕜 E) [complete_space K] (v : E) :
-  ∃ (y ∈ K) (z ∈ K.orthogonal), y + z = v :=
-by { rw [← submodule.mem_sup], simp [submodule.sup_orthogonal_of_complete_space] }
+  ∃ (y ∈ K) (z ∈ K.orthogonal), v = y + z :=
+begin
+  have h_mem : v ∈ K ⊔ K.orthogonal := by simp [submodule.sup_orthogonal_of_complete_space],
+  obtain ⟨y, hy, z, hz, hyz⟩ := submodule.mem_sup.mp h_mem,
+  exact ⟨y, hy, z, hz, hyz.symm⟩
+end
 
 /-- If `K` is complete, then the orthogonal complement of its orthogonal complement is itself. -/
 @[simp] lemma submodule.orthogonal_orthogonal (K : submodule 𝕜 E) [complete_space K] :
@@ -1791,12 +1795,12 @@ by { rw [← submodule.mem_sup], simp [submodule.sup_orthogonal_of_complete_spac
 begin
   ext v,
   split,
-  { obtain ⟨y, hy, z, hz, hvyz⟩ := K.exists_sum_mem_mem_orthogonal v,
+  { obtain ⟨y, hy, z, hz, rfl⟩ := K.exists_sum_mem_mem_orthogonal v,
     intros hv,
     have hz' : z = 0,
     { have hyz : ⟪z, y⟫ = 0 := by simp [hz y hy, inner_eq_zero_sym],
-      simpa [← hvyz, inner_add_right, hyz] using hv z hz },
-    simp [← hvyz, hy, hz'] },
+      simpa [inner_add_right, hyz] using hv z hz },
+    simp [hy, hz'] },
   { intros hv w hw,
     rw inner_eq_zero_sym,
     exact hw v hv }

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1791,10 +1791,10 @@ begin
 end
 
 /-- If `K` is complete, then the orthogonal complement of its orthogonal complement is itself. -/
-@[simp] lemma submodule.mem_orthogonal_orthogonal_iff
-  (K : submodule 𝕜 E) [complete_space K] (v : E) :
-  v ∈ K.orthogonal.orthogonal ↔ v ∈ K :=
+@[simp] lemma submodule.orthogonal_orthogonal (K : submodule 𝕜 E) [complete_space K] :
+  K.orthogonal.orthogonal = K :=
 begin
+  ext v,
   split,
   { obtain ⟨⟨y, hy⟩, ⟨z, hz⟩, hvyz⟩ := K.exists_sum_mem_mem_orthogonal v,
     have hyz : ⟪z, y⟫ = 0,
@@ -1809,11 +1809,6 @@ begin
     rw inner_eq_zero_sym,
     exact hw v hv }
 end
-
-/-- If `K` is complete, then the orthogonal complement of its orthogonal complement is itself. -/
-@[simp] lemma submodule.orthogonal_orthogonal (K : submodule 𝕜 E) [complete_space K] :
-  K.orthogonal.orthogonal = K :=
-by { ext v, exact K.mem_orthogonal_orthogonal_iff v }
 
 /-- If `K` is complete, `K` and `K.orthogonal` are complements of each
 other. -/

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1685,7 +1685,7 @@ begin
 end
 
 /-- `K.orthogonal` can be characterized as the intersection of the kernels of the operations of
-inner product which each of the elements of `K`. -/
+inner product with each of the elements of `K`. -/
 lemma orthogonal_eq_inter (K : submodule 𝕜 E) : K.orthogonal = ⨅ v : K, (inner_left (v:E)).ker :=
 begin
   apply le_antisymm,


### PR DESCRIPTION
The orthogonal complement of a subspace is closed.  The orthogonal complement of the orthogonal complement of a complete subspace is itself.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
