### PR TITLE
chore(linear_algebra/linear_independent): make a binding explicit in ne_zero

### DIFF
--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -219,9 +219,7 @@ begin
   intros i j hij,
   rw affine_independent_iff_linear_independent_vsub _ _ j at ha,
   by_contra hij',
-  refine ha.ne_zero _,
-  { exact ⟨i, hij'⟩ },
-  { exact vsub_eq_zero_iff_eq.mpr hij },
+  exact ha.ne_zero ⟨i, hij'⟩ (vsub_eq_zero_iff_eq.mpr hij)
 end
 
 /-- If a family is affinely independent, so is any subfamily given by
@@ -363,7 +361,7 @@ begin
     have h0 : ∀ v : V, v ∈ sv → v ≠ 0,
     { intros v hv,
       change ((⟨v, hv⟩ : sv) : V) ≠ 0,
-      exact hsvi.ne_zero },
+      exact hsvi.ne_zero _ },
     rw linear_independent_set_iff_affine_independent_vadd_union_singleton k h0 p₁ at hsvi,
     use [{p₁} ∪ (λ v, v +ᵥ p₁) '' sv, set.empty_subset _, hsvi,
          affine_span_singleton_union_vadd_eq_top_of_span_eq_top p₁ hsvt] },
@@ -372,7 +370,7 @@ begin
     have h0 : ∀ v : V, v ∈ sv → v ≠ 0,
     { intros v hv,
       change ((⟨v, hv⟩ : sv) : V) ≠ 0,
-      exact hsvi.ne_zero },
+      exact hsvi.ne_zero _ },
     rw linear_independent_set_iff_affine_independent_vadd_union_singleton k h0 p₁ at hsvi,
     use {p₁} ∪ (λ v, v +ᵥ p₁) '' sv,
     split,

--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -153,7 +153,7 @@ begin
 end
 
 lemma linear_independent.ne_zero [nontrivial R]
-  {i : ι} (hv : linear_independent R v) : v i ≠ 0 :=
+  (i : ι) (hv : linear_independent R v) : v i ≠ 0 :=
 λ h, @zero_ne_one R _ _ $ eq.symm begin
   suffices : (finsupp.single i 1 : ι →₀ R) i = 0, {simpa},
   rw linear_independent_iff.1 hv (finsupp.single i 1),
@@ -462,7 +462,7 @@ begin
         simp only at hxy,
         rw hxy,
         exact (subset_span (mem_range_self y₂)) },
-      exact false.elim ((hindep x₁).ne_zero h0) } },
+      exact false.elim ((hindep x₁).ne_zero _ h0) } },
   rw range_sigma_eq_Union_range,
   apply linear_independent_Union_finite_subtype (λ j, (hindep j).to_subtype_range) hd,
 end


### PR DESCRIPTION
Suggested by @PatrickMassot in
https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/independent.20columns/near/220700702