### PR TITLE
[Merged by Bors] - feat(category_theory/is_filtered): is_filtered_of_equiv

### DIFF
--- a/src/category_theory/filtered.lean
+++ b/src/category_theory/filtered.lean
@@ -244,12 +244,12 @@ lemma is_filtered_of_equiv (h : C ≌ D)
   cocone_objs :=
   λ X Y, let ⟨Z,f,g,_⟩ :=
   is_filtered_or_empty.cocone_objs (h.inverse.obj X) (h.inverse.obj Y) in
-  ⟨h.functor.obj Z,(h.counit_inv.app X) ≫ (h.functor.map f),(h.counit_inv.app Y)
-  ≫ (h.functor.map g),trivial⟩,
+  ⟨h.functor.obj Z, h.counit_inv.app X ≫ h.functor.map f, h.counit_inv.app Y ≫ h.functor.map g, ⟨⟩⟩,
   cocone_maps := λ X Y f g,
   let ⟨Z,z,zz⟩ :=
   is_filtered_or_empty.cocone_maps (h.inverse.map f) (h.inverse.map g) in
-  ⟨h.functor.obj Z,(h.counit_inv.app Y) ≫ (h.functor.map z),sorry⟩,
+  ⟨h.functor.obj Z, h.counit_inv.app Y ≫ h.functor.map z,
+    by { erw [h.counit_inv.naturality_assoc, functor.comp_map, ← h.functor.map_comp, zz], simp } ⟩,
   nonempty := nonempty.map h.functor.obj hC.nonempty
 }
 

--- a/src/category_theory/filtered.lean
+++ b/src/category_theory/filtered.lean
@@ -237,7 +237,9 @@ noncomputable def cocone (F : J ⥤ C) : cocone F :=
 
 variables {D : Type u₁} [category.{v₁} D]
 
-/-- If `C` is filtered, and we have a right adjoint functor `C ⥤ D`, then `D` is filtered. -/
+/--
+If `C` is filtered, and we have a functor `R : C ⥤ D` with a left adjoint, then `D` is filtered.
+-/
 lemma of_right_adjoint {L : D ⥤ C} {R : C ⥤ D} (h : L ⊣ R) : is_filtered D :=
 { cocone_objs := λ X Y,
     ⟨_, h.hom_equiv _ _ (left_to_max _ _), h.hom_equiv _ _ (right_to_max _ _), ⟨⟩⟩,
@@ -245,6 +247,10 @@ lemma of_right_adjoint {L : D ⥤ C} {R : C ⥤ D} (h : L ⊣ R) : is_filtered D
     ⟨_, h.hom_equiv _ _ (coeq_hom _ _),
      by rw [← h.hom_equiv_naturality_left, ← h.hom_equiv_naturality_left, coeq_condition]⟩,
   nonempty := is_filtered.nonempty.map R.obj }
+
+/-- If `C` is filtered, and we have a right adjoint functor `R : C ⥤ D`, then `D` is filtered. -/
+lemma of_is_right_adjoint (R : C ⥤ D) [is_right_adjoint R] : is_filtered D :=
+of_right_adjoint (adjunction.of_right_adjoint R)
 
 /-- Being filtered is preserved by equivalence of categories. -/
 lemma of_equivalence (h : C ≌ D) : is_filtered D :=

--- a/src/category_theory/filtered.lean
+++ b/src/category_theory/filtered.lean
@@ -40,7 +40,7 @@ of finsets of morphisms.
 * Forgetful functors for algebraic categories typically preserve filtered colimits.
 -/
 
-universes v u -- declare the `v`'s first; see `category_theory.category` for an explanation
+universes v v₁ u u₁-- declare the `v`'s first; see `category_theory.category` for an explanation
 
 namespace category_theory
 
@@ -232,6 +232,26 @@ An arbitrary choice of cocone over `F : J ⥤ C`, for `fin_category J` and `is_f
 -/
 noncomputable def cocone (F : J ⥤ C) : cocone F :=
 (cocone_nonempty F).some
+
+variables {D : Type u₁} [category.{v₁} D]
+
+/--
+  Being filtered is preserved by equivalence of categories.
+-/
+lemma is_filtered_of_equiv (h : C ≌ D)
+[hC : is_filtered C] : is_filtered D :=
+{
+  cocone_objs :=
+  λ X Y, let ⟨Z,f,g,_⟩ :=
+  is_filtered_or_empty.cocone_objs (h.inverse.obj X) (h.inverse.obj Y) in
+  ⟨h.functor.obj Z,(h.counit_inv.app X) ≫ (h.functor.map f),(h.counit_inv.app Y)
+  ≫ (h.functor.map g),trivial⟩,
+  cocone_maps := λ X Y f g,
+  let ⟨Z,z,zz⟩ :=
+  is_filtered_or_empty.cocone_maps (h.inverse.map f) (h.inverse.map g) in
+  ⟨h.functor.obj Z,(h.counit_inv.app Y) ≫ (h.functor.map z),sorry⟩,
+  nonempty := nonempty.map h.functor.obj hC.nonempty
+}
 
 end is_filtered
 

--- a/src/category_theory/filtered.lean
+++ b/src/category_theory/filtered.lean
@@ -5,6 +5,7 @@ Authors: Reid Barton
 -/
 import category_theory.fin_category
 import category_theory.limits.cones
+import category_theory.adjunction.basic
 import order.bounded_lattice
 
 /-!
@@ -236,20 +237,18 @@ noncomputable def cocone (F : J ⥤ C) : cocone F :=
 
 variables {D : Type u₁} [category.{v₁} D]
 
-/--
-  Being filtered is preserved by equivalence of categories.
--/
-lemma of_equiv (h : C ≌ D) : is_filtered D :=
+/-- If `C` is filtered, and we have a right adjoint functor `C ⥤ D`, then `D` is filtered. -/
+lemma of_right_adjoint {L : D ⥤ C} {R : C ⥤ D} (h : L ⊣ R) : is_filtered D :=
 { cocone_objs := λ X Y,
-    ⟨h.functor.obj (max (h.inverse.obj X) (h.inverse.obj Y)),
-     h.counit_inv.app X ≫ h.functor.map (left_to_max _ _),
-     h.counit_inv.app Y ≫ h.functor.map (right_to_max _ _),
-     ⟨⟩⟩,
+    ⟨_, h.hom_equiv _ _ (left_to_max _ _), h.hom_equiv _ _ (right_to_max _ _), ⟨⟩⟩,
   cocone_maps := λ X Y f g,
-    ⟨h.functor.obj (coeq (h.inverse.map f) (h.inverse.map g)),
-     h.counit_inv.app Y ≫ h.functor.map (coeq_hom _ _),
-     by { erw [h.counit_inv.naturality_assoc, functor.comp_map, ← h.functor.map_comp], simp } ⟩,
-  nonempty := is_filtered.nonempty.map h.functor.obj }
+    ⟨_, h.hom_equiv _ _ (coeq_hom _ _),
+     by rw [← h.hom_equiv_naturality_left, ← h.hom_equiv_naturality_left, coeq_condition]⟩,
+  nonempty := is_filtered.nonempty.map R.obj }
+
+/-- Being filtered is preserved by equivalence of categories. -/
+lemma of_equivalence (h : C ≌ D) : is_filtered D :=
+of_right_adjoint h.symm.to_adjunction
 
 end is_filtered
 

--- a/src/category_theory/filtered.lean
+++ b/src/category_theory/filtered.lean
@@ -127,6 +127,7 @@ noncomputable def coeq_hom {j j' : C} (f f' : j ⟶ j') : j' ⟶ coeq f f' :=
 `coeq_condition f f'`, for morphisms `f f' : j ⟶ j'`, is the proof that
 `f ≫ coeq_hom f f' = f' ≫ coeq_hom f f'`.
 -/
+@[simp, reassoc]
 lemma coeq_condition {j j' : C} (f f' : j ⟶ j') : f ≫ coeq_hom f f' = f' ≫ coeq_hom f f' :=
 (is_filtered_or_empty.cocone_maps f f').some_spec.some_spec
 
@@ -238,20 +239,17 @@ variables {D : Type u₁} [category.{v₁} D]
 /--
   Being filtered is preserved by equivalence of categories.
 -/
-lemma is_filtered_of_equiv (h : C ≌ D)
-[hC : is_filtered C] : is_filtered D :=
-{
-  cocone_objs :=
-  λ X Y, let ⟨Z,f,g,_⟩ :=
-  is_filtered_or_empty.cocone_objs (h.inverse.obj X) (h.inverse.obj Y) in
-  ⟨h.functor.obj Z, h.counit_inv.app X ≫ h.functor.map f, h.counit_inv.app Y ≫ h.functor.map g, ⟨⟩⟩,
+lemma of_equiv (h : C ≌ D) : is_filtered D :=
+{ cocone_objs := λ X Y,
+    ⟨h.functor.obj (max (h.inverse.obj X) (h.inverse.obj Y)),
+     h.counit_inv.app X ≫ h.functor.map (left_to_max _ _),
+     h.counit_inv.app Y ≫ h.functor.map (right_to_max _ _),
+     ⟨⟩⟩,
   cocone_maps := λ X Y f g,
-  let ⟨Z,z,zz⟩ :=
-  is_filtered_or_empty.cocone_maps (h.inverse.map f) (h.inverse.map g) in
-  ⟨h.functor.obj Z, h.counit_inv.app Y ≫ h.functor.map z,
-    by { erw [h.counit_inv.naturality_assoc, functor.comp_map, ← h.functor.map_comp, zz], simp } ⟩,
-  nonempty := nonempty.map h.functor.obj hC.nonempty
-}
+    ⟨h.functor.obj (coeq (h.inverse.map f) (h.inverse.map g)),
+     h.counit_inv.app Y ≫ h.functor.map (coeq_hom _ _),
+     by { erw [h.counit_inv.naturality_assoc, functor.comp_map, ← h.functor.map_comp], simp } ⟩,
+  nonempty := is_filtered.nonempty.map h.functor.obj }
 
 end is_filtered
 


### PR DESCRIPTION
If `C` is filtered and there is a right adjoint functor `C => D`, then `D` is filtered. Also a category equivalent to a filtered category is filtered.