### PR TITLE
[Merged by Bors] - fix(algebra/big_operators/basic): add docstrings for `sum_bij` and `sum_bij'`

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -523,7 +523,12 @@ apply_ite (λ s, ∏ x in s, f x) _ _ _
   The difference with `prod_bij'` is that the bijection is specified as a surjective injection,
   rather than by an inverse function.
 -/
-@[to_additive]
+@[to_additive "
+  Reorder a sum.
+
+  The difference with `sum_bij'` is that the bijection is specified as a surjective injection,
+  rather than by an inverse function.
+"]
 lemma prod_bij {s : finset α} {t : finset γ} {f : α → β} {g : γ → β}
   (i : Πa∈s, γ) (hi : ∀a ha, i a ha ∈ t) (h : ∀a ha, f a = g (i a ha))
   (i_inj : ∀a₁ a₂ ha₁ ha₂, i a₁ ha₁ = i a₂ ha₂ → a₁ = a₂) (i_surj : ∀b∈t, ∃a ha, b = i a ha) :
@@ -537,7 +542,12 @@ congr_arg multiset.prod
   The difference with `prod_bij` is that the bijection is specified with an inverse, rather than
   as a surjective injection.
 -/
-@[to_additive]
+@[to_additive "
+  Reorder a sum.
+
+  The difference with `sum_bij` is that the bijection is specified with an inverse, rather than
+  as a surjective injection.
+"]
 lemma prod_bij' {s : finset α} {t : finset γ} {f : α → β} {g : γ → β}
   (i : Πa∈s, γ) (hi : ∀a ha, i a ha ∈ t) (h : ∀a ha, f a = g (i a ha))
   (j : Πa∈t, α) (hj : ∀a ha, j a ha ∈ s) (left_inv : ∀ a ha, j (i a ha) (hi a ha) = a)


### PR DESCRIPTION
They don't seem to be there.

---

Was `to_additive` supposed to do this? If not, should it be something we lint for? (multiplicative docstring and no corresponding additive one). `sum_bij` is hard enough for a beginner, even with a docstring! Or am I just having a local docstring fail?

<!--
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
