### PR TITLE
[Merged by Bors] - chore(logic/basic): +2 simp lemmas

### DIFF
--- a/src/data/ordmap/ordset.lean
+++ b/src/data/ordmap/ordset.lean
@@ -155,7 +155,7 @@ theorem balanced_sz.symm {l r : ℕ} : balanced_sz l r → balanced_sz r l :=
 or.imp (by rw add_comm; exact id) and.symm
 
 theorem balanced_sz_zero {l : ℕ} : balanced_sz l 0 ↔ l ≤ 1 :=
-by simp [balanced_sz]; apply or_iff_left_of_imp; rintro rfl; exact zero_le_one
+by simp [balanced_sz] { contextual := tt }
 
 theorem balanced_sz_up {l r₁ r₂ : ℕ} (h₁ : r₁ ≤ r₂)
   (h₂ : l + r₂ ≤ 1 ∨ r₂ ≤ delta * l)

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -383,6 +383,12 @@ protected theorem decidable.not_imp_not [decidable a] : (¬ a → ¬ b) ↔ (b �
 
 theorem not_imp_not : (¬ a → ¬ b) ↔ (b → a) := decidable.not_imp_not
 
+@[simp] theorem or.congr_left_iff : (a ∨ b ↔ a) ↔ (b → a) :=
+⟨λ h hb, h.1 (or.inr hb), λ h, ⟨λ h', h'.elim id h, or.inl⟩⟩
+
+@[simp] theorem or.congr_right_iff : (a ∨ b ↔ b) ↔ (a → b) :=
+by rw [or_comm, or.congr_left_iff]
+
 /-! ### Declarations about distributivity -/
 
 /-- `∧` distributes over `∨` (on the left). -/

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -383,11 +383,11 @@ protected theorem decidable.not_imp_not [decidable a] : (¬ a → ¬ b) ↔ (b �
 
 theorem not_imp_not : (¬ a → ¬ b) ↔ (b → a) := decidable.not_imp_not
 
-@[simp] theorem or.congr_left_iff : (a ∨ b ↔ a) ↔ (b → a) :=
-⟨λ h hb, h.1 (or.inr hb), λ h, ⟨λ h', h'.elim id h, or.inl⟩⟩
+@[simp] theorem or_iff_left_iff_imp : (a ∨ b ↔ a) ↔ (b → a) :=
+⟨λ h hb, h.1 (or.inr hb), or_iff_left_of_imp⟩
 
-@[simp] theorem or.congr_right_iff : (a ∨ b ↔ b) ↔ (a → b) :=
-by rw [or_comm, or.congr_left_iff]
+@[simp] theorem or_iff_right_iff_imp : (a ∨ b ↔ b) ↔ (a → b) :=
+by rw [or_comm, or_iff_left_iff_imp]
 
 /-! ### Declarations about distributivity -/
 


### PR DESCRIPTION
* simplify `a ∨ b ↔ a` to `b → a`;
* simplify `a ∨ b ↔ b` to `a → b`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
