### PR TITLE
[Merged by Bors] - fix(algebra/module/basic): Do not attach the `ℕ` and `ℤ` `is_scalar_tower` and `smul_comm_class` instances to a specific definition of `smul`

### DIFF
--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -298,16 +298,13 @@ begin
     rw [one_smul], }
 end
 
-local attribute [instance] nat_semimodule
-
-instance nat_is_scalar_tower [semiring S] [semimodule S M] :
+/-- Note this does not depend on the `nat_semimodule` definition above, to avoid issues when
+diamonds occur in finding `semimodule ℕ M` instances. -/
+instance nat_is_scalar_tower [semiring S] [semimodule S M] [semimodule ℕ S] [semimodule ℕ M] :
   is_scalar_tower ℕ S M :=
-{ smul_assoc := begin
-    intros n x y,
-    induction n with n ih,
-    { simp only [zero_smul] },
-    { simp only [nat.succ_eq_add_one, add_smul, one_smul, ih] }
-  end }
+{ smul_assoc := λ n x y, nat.rec_on n
+    (by simp only [zero_smul])
+    (λ n ih, by simp only [nat.succ_eq_add_one, add_smul, one_smul, ih]) }
 
 end add_comm_monoid
 
@@ -354,17 +351,12 @@ begin
   { rw [int.neg_succ_of_nat_coe, neg_smul, neg_smul, nat_smul], }
 end
 
-local attribute [instance] int_module add_comm_monoid.nat_semimodule
-
-instance int_is_scalar_tower [ring S] [module S M] :
+instance int_is_scalar_tower [ring S] [module S M] [semimodule ℤ S] [semimodule ℤ M] :
   is_scalar_tower ℤ S M :=
-{ smul_assoc := begin
-    intros n x y,
-    cases n,
-    { show (n • x) • y = n • x • y, apply smul_assoc },
-    { simp only [int.neg_succ_of_nat_eq, neg_smul],
-      convert congr_arg has_neg.neg (smul_assoc n.succ x y) },
-  end }
+{ smul_assoc := λ n x y, int.induction_on n
+    (by simp only [zero_smul])
+    (λ n ih, by simp only [one_smul, add_smul, ih])
+    (λ n ih, by simp only [one_smul, sub_smul, ih]) }
 
 end add_comm_group
 
@@ -390,24 +382,21 @@ lemma nat.smul_def {M : Type*} [add_comm_monoid M] (n : ℕ) (x : M) :
   n • x = n •ℕ x :=
 rfl
 
+end
+
 namespace nat
 
-variables [semiring R] [add_comm_monoid M] [semimodule R M]
+variables [semiring R] [add_comm_monoid M] [semimodule R M] [semimodule ℕ M]
 
 instance smul_comm_class : smul_comm_class ℕ R M :=
-{ smul_comm := λ n r m, begin
-    simp only [nat.smul_def],
-    induction n with n ih,
-    { simp },
-    { simp [succ_nsmul, ←ih, smul_add] },
-  end }
+{ smul_comm := λ n r m, nat.rec_on n
+    (by simp only [zero_smul, smul_zero])
+    (λ n ih, by simp only [succ_eq_add_one, add_smul, one_smul, ←ih, smul_add]) }
 
 -- `smul_comm_class.symm` is not registered as an instance, as it would cause a loop
 instance smul_comm_class' : smul_comm_class R ℕ M := smul_comm_class.symm _ _ _
 
 end nat
-
-end
 
 section
 local attribute [instance] add_comm_group.int_module
@@ -425,23 +414,26 @@ begin
     rw neg_smul, }
 end
 
+end
+
 lemma module.gsmul_eq_smul {M : Type*} [add_comm_group M] [module ℤ M]
   (n : ℤ) (b : M) : gsmul n b = n • b :=
 by rw [module.gsmul_eq_smul_cast ℤ, int.cast_id]
 
 namespace int
 
-variables [semiring R] [add_comm_group M] [semimodule R M]
+variables [semiring R] [add_comm_group M] [semimodule R M] [semimodule ℤ M]
 
 instance smul_comm_class : smul_comm_class ℤ R M :=
-{ smul_comm := λ z r l, by cases z; simp [←gsmul_eq_smul, ←nat.smul_def, smul_comm (_ : ℕ)] }
+{ smul_comm := λ n x y, int.induction_on n
+    (by simp only [zero_smul, smul_zero])
+    (λ n ih, by simp only [one_smul, add_smul, smul_add, ih])
+    (λ n ih, by simp only [one_smul, sub_smul, smul_sub, ih]) }
 
 -- `smul_comm_class.symm` is not registered as an instance, as it would cause a loop
 instance smul_comm_class' : smul_comm_class R ℤ M := smul_comm_class.symm _ _ _
 
 end int
-
-end
 
 namespace add_monoid_hom
 


### PR DESCRIPTION
These instances are in `Prop`, so the more the merrier.
Without this change, these instances are not available for alternative ℤ-module definitions.

An example of one of these alternate definitions is `linear_map.semimodule`, which provide a second non-defeq ℤ-module structure alongside `add_comm_group.int_module`.
With this PR, both semimodule structures are shown to satisfy `smul_comm_class` and `is_scalar_tower`; while before it, only `add_comm_group.int_module` was shown to satisfy these.

This PR makes the following work:
```lean
example {R : Type*} {M₁ M₂ M₃ : Type*}
  [comm_semiring R]
  [add_comm_monoid M₁] [semimodule R M₁]
  [add_comm_monoid M₂] [semimodule R M₂]
  [add_comm_monoid M₃] [semimodule R M₃]
(f : M₁ →ₗ[R] M₂ →ₗ[R] M₃) (x : M₁) (n : ℕ) : f (n • x) = n • f x :=
by simp
```

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.235509.20less.20painful.20semimodule.20diamonds/near/221283217)