### PR TITLE
[Merged by Bors] - feat(ring_theory/jacobson): Generalize proofs about Jacobson rings and polynomials

### DIFF
--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -147,6 +147,13 @@ lemma C_injective (σ : Type*) (R : Type*) [comm_semiring R] :
   function.injective (C : R → mv_polynomial σ R) :=
 finsupp.single_injective _
 
+lemma C_surjective {R : Type*} [comm_ring R] :
+  function.surjective (mv_polynomial.C : R → mv_polynomial (fin 0) R) :=
+begin
+  refine λ p, ⟨p.to_fun 0, finsupp.ext (λ a, _)⟩,
+  simpa [(finsupp.ext fin_zero_elim : a = 0), C, monomial],
+end
+
 @[simp] lemma C_inj {σ : Type*} (R : Type*) [comm_semiring R] (r s : R) :
   (C r : mv_polynomial σ R) = C s ↔ r = s :=
 (C_injective σ R).eq_iff

--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -147,12 +147,16 @@ lemma C_injective (σ : Type*) (R : Type*) [comm_semiring R] :
   function.injective (C : R → mv_polynomial σ R) :=
 finsupp.single_injective _
 
-lemma C_surjective {R : Type*} [comm_ring R] :
-  function.surjective (mv_polynomial.C : R → mv_polynomial (fin 0) R) :=
+lemma C_surjective {R : Type*} [comm_semiring R] (σ : Type*) (hσ : ¬ nonempty σ) :
+  function.surjective (C : R → mv_polynomial σ R) :=
 begin
   refine λ p, ⟨p.to_fun 0, finsupp.ext (λ a, _)⟩,
-  simpa [(finsupp.ext fin_zero_elim : a = 0), C, monomial],
+  simpa [(finsupp.ext (λ x, absurd (nonempty.intro x) hσ) : a = 0), C, monomial],
 end
+
+lemma C_surjective_fin_0 {R : Type*} [comm_ring R] :
+  function.surjective (mv_polynomial.C : R → mv_polynomial (fin 0) R) :=
+C_surjective (fin 0) (λ h, let ⟨n⟩ := h in fin_zero_elim n)
 
 @[simp] lemma C_inj {σ : Type*} (R : Type*) [comm_semiring R] (r s : R) :
   (C r : mv_polynomial σ R) = C s ↔ r = s :=

--- a/src/data/mv_polynomial/equiv.lean
+++ b/src/data/mv_polynomial/equiv.lean
@@ -262,6 +262,18 @@ end
     (λ i : fin (n+1), fin.cases polynomial.X (λ k, polynomial.C (X k)) i) p :=
 by { rw ← fin_succ_equiv_eq, refl }
 
+lemma fin_succ_equiv_comp_C_eq_C {R : Type u} [comm_semiring R] (n : ℕ) :
+  ((mv_polynomial.fin_succ_equiv R n).symm.to_ring_hom).comp
+    ((polynomial.C).comp (mv_polynomial.C))
+    = (mv_polynomial.C : R →+* mv_polynomial (fin n.succ) R) :=
+begin
+  refine ring_hom.ext (λ x, _),
+  rw ring_hom.comp_apply,
+  refine (mv_polynomial.fin_succ_equiv R n).injective
+    (trans ((mv_polynomial.fin_succ_equiv R n).apply_symm_apply _) _),
+  simp only [mv_polynomial.fin_succ_equiv_apply, mv_polynomial.eval₂_hom_C],
+end
+
 end
 
 end equiv

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -419,6 +419,13 @@ def lift (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0
 @[simp] lemma lift_mk (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0) :
   lift S f H (mk S a) = f a := rfl
 
+@[simp] lemma lift_comp_mk (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0) :
+  (lift S f H).comp (mk S) = f := ring_hom.ext (λ _, rfl)
+
+lemma lift_surjective (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0)
+  (hf : function.surjective f) : function.surjective (lift S f H) :=
+λ x, let ⟨y, hy⟩ := hf x in ⟨(quotient.mk S) y, by simpa⟩
+
 end quotient
 
 section lattice

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -79,6 +79,12 @@ theorem eq_top_iff_one : I = ⊤ ↔ (1:α) ∈ I :=
 theorem ne_top_iff_one : I ≠ ⊤ ↔ (1:α) ∉ I :=
 not_congr I.eq_top_iff_one
 
+lemma exists_mem_ne_zero_of_ne_bot (hI : I ≠ ⊥) : ∃ p ∈ I, p ≠ (0 : α) :=
+begin
+  contrapose! hI,
+  exact eq_bot_iff.2 (λ x hx, (hI x hx).symm ▸ (ideal.zero_mem ⊥)),
+end
+
 @[simp]
 theorem unit_mul_mem_iff_mem {x y : α} (hy : is_unit y) : y * x ∈ I ↔ x ∈ I :=
 begin

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -79,11 +79,15 @@ theorem eq_top_iff_one : I = ⊤ ↔ (1:α) ∈ I :=
 theorem ne_top_iff_one : I ≠ ⊤ ↔ (1:α) ∉ I :=
 not_congr I.eq_top_iff_one
 
-lemma exists_mem_ne_zero_of_ne_bot (hI : I ≠ ⊥) : ∃ p ∈ I, p ≠ (0 : α) :=
+lemma exists_mem_ne_zero_iff_ne_bot : (∃ p ∈ I, p ≠ (0 : α)) ↔ I ≠ ⊥ :=
 begin
-  contrapose! hI,
-  exact eq_bot_iff.2 (λ x hx, (hI x hx).symm ▸ (ideal.zero_mem ⊥)),
+  refine ⟨λ h, let ⟨p, hp, hp0⟩ := h in λ h, absurd (h ▸ hp : p ∈ (⊥ : ideal α)) hp0,  λ h, _⟩,
+  contrapose! h,
+  exact eq_bot_iff.2 (λ x hx, (h x hx).symm ▸ (ideal.zero_mem ⊥)),
 end
+
+lemma exists_mem_ne_zero_of_ne_bot (hI : I ≠ ⊥) : ∃ p ∈ I, p ≠ (0 : α) :=
+(exists_mem_ne_zero_iff_ne_bot I).mpr hI
 
 @[simp]
 theorem unit_mul_mem_iff_mem {x y : α} (hy : is_unit y) : y * x ∈ I ↔ x ∈ I :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1149,15 +1149,20 @@ lemma quotient_map_comp_mk {J : ideal R} {I : ideal S} {f : R →+* S} {H : J �
   (quotient_map I f H).comp (quotient.mk J) = (quotient.mk I).comp f :=
 ring_hom.ext (λ x, by simp only [function.comp_app, ring_hom.coe_comp, ideal.quotient_map_mk])
 
-/-- If we take `J = I.comap f` then `quotient_map` is injective. -/
+/-- `H` and `h` are kept as seperate hypothesis since H is used in constructing the quotient map -/
+lemma quotient_map_injective' {J : ideal R} {I : ideal S} {f : R →+* S} {H : J ≤ I.comap f}
+  (h : I.comap f ≤ J) : function.injective (quotient_map I f H) :=
+begin
+  refine (quotient_map I f H).injective_iff.2 (λ a ha, _),
+  obtain ⟨r, rfl⟩ := quotient.mk_surjective a,
+  rw [quotient_map_mk, quotient.eq_zero_iff_mem] at ha,
+  exact (quotient.eq_zero_iff_mem).mpr (h ha),
+end
+
+/-- If we take `J = I.comap f` then `quotient_map` is injective automatically. -/
 lemma quotient_map_injective {I : ideal S} {f : R →+* S} :
   function.injective (quotient_map I f le_rfl) :=
-begin
-  refine (quotient_map I f le_rfl).injective_iff.2 (λ a ha, _),
-  obtain ⟨r, rfl⟩ := quotient.mk_surjective a,
-  rw quotient_map_mk at ha,
-  rwa quotient.eq_zero_iff_mem at ha ⊢
-end
+quotient_map_injective' le_rfl
 
 lemma quotient_map_surjective {J : ideal R} {I : ideal S} {f : R →+* S} {H : J ≤ I.comap f}
   (hf : function.surjective f) : function.surjective (quotient_map I f H) :=

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -532,25 +532,6 @@ begin
   rwa [← comap_comap, ← ring_hom.ker_eq_comap_bot, mk_ker] at this,
 end
 
-lemma mv_poly_step {R : Type*} [comm_semiring R] (n : ℕ) :
-  ((mv_polynomial.fin_succ_equiv R n).symm.to_ring_hom).comp
-    ((polynomial.C).comp (mv_polynomial.C))
-    = (mv_polynomial.C : R →+* mv_polynomial (fin n.succ) R) :=
-begin
-  refine ring_hom.ext (λ x, _),
-  rw ring_hom.comp_apply,
-  refine (mv_polynomial.fin_succ_equiv R n).injective
-    (trans ((mv_polynomial.fin_succ_equiv R n).apply_symm_apply _) _),
-  simp only [mv_polynomial.fin_succ_equiv_apply, mv_polynomial.eval₂_hom_C],
-end
-
-lemma C_surj {R : Type*} [comm_ring R] :
-  function.surjective (mv_polynomial.C : R → mv_polynomial (fin 0) R) :=
-begin
-  refine λ p, ⟨p.to_fun 0, mv_polynomial.ext _ _ (λ a, _)⟩,
-  simpa [(finsupp.ext fin_zero_elim : a = 0), if_true, eq_self_iff_true, mv_polynomial.coeff_C],
-end
-
 lemma lemmaB'_bootstrap {R : Type*} [integral_domain R] [is_jacobson R]
   {n : ℕ} (P : ideal (mv_polynomial (fin n) R)) [hP : P.is_maximal] :
   ((quotient.mk P).comp mv_polynomial.C : R →+* P.quotient).is_integral :=
@@ -559,15 +540,16 @@ begin
   { have := (mv_polynomial.ring_equiv_of_equiv R
       (equiv.equiv_pempty $ fin.elim0)).trans (mv_polynomial.pempty_ring_equiv R),
     refine ring_hom.is_integral_of_surjective _ (function.surjective.comp quotient.mk_surjective _),
-    refine C_surj },
+    refine mv_polynomial.C_surjective },
   { let ϕ1 : R →+* mv_polynomial (fin n) R := mv_polynomial.C,
     let ϕ2 : (mv_polynomial (fin n) R) →+* polynomial (mv_polynomial (fin n) R) := polynomial.C,
     let ϕ3 := (mv_polynomial.fin_succ_equiv R n).symm.to_ring_hom,
     let ϕ : R →+* (mv_polynomial (fin (n+1)) R) := ϕ3.comp (ϕ2.comp ϕ1),
     have hϕ : ϕ = mv_polynomial.C := begin
-      -- Can't use `mv_poly_step n` directly because of a diamond problem
+      -- Can't use `fin_succ_equiv_comp_C_eq_C n` directly because of a typeclass inference problem
       refine ring_hom.ext (λ x, _),
-      simpa using congr_arg (λ (f : R →+* mv_polynomial (fin n.succ) R), f x) (mv_poly_step n),
+      simpa using congr_arg (λ (f : R →+* mv_polynomial (fin n.succ) R), f x)
+        (mv_polynomial.fin_succ_equiv_comp_C_eq_C n),
     end,
     rw ← hϕ,
 

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -532,7 +532,7 @@ begin
   rwa [← comap_comap, ← ring_hom.ker_eq_comap_bot, mk_ker] at this,
 end
 
-lemma lemmaB'_bootstrap {R : Type*} [integral_domain R] [is_jacobson R]
+lemma lemmaB'_bootstrap {R : Type u} [integral_domain R] [is_jacobson R]
   {n : ℕ} (P : ideal (mv_polynomial (fin n) R)) [hP : P.is_maximal] :
   ((quotient.mk P).comp mv_polynomial.C : R →+* P.quotient).is_integral :=
 begin
@@ -545,13 +545,6 @@ begin
     let ϕ2 : (mv_polynomial (fin n) R) →+* polynomial (mv_polynomial (fin n) R) := polynomial.C,
     let ϕ3 := (mv_polynomial.fin_succ_equiv R n).symm.to_ring_hom,
     let ϕ : R →+* (mv_polynomial (fin (n+1)) R) := ϕ3.comp (ϕ2.comp ϕ1),
-    have hϕ : ϕ = mv_polynomial.C := begin
-      -- Can't use `fin_succ_equiv_comp_C_eq_C n` directly because of a typeclass inference problem
-      refine ring_hom.ext (λ x, _),
-      simpa using congr_arg (λ (f : R →+* mv_polynomial (fin n.succ) R), f x)
-        (mv_polynomial.fin_succ_equiv_comp_C_eq_C n),
-    end,
-    rw ← hϕ,
 
     let P3 : ideal (polynomial (mv_polynomial (fin n) R)) := P.comap ϕ3,
     let P2 : ideal (mv_polynomial (fin n) R) := P3.comap ϕ2,
@@ -579,7 +572,7 @@ begin
     by rw [ring_hom.comp_assoc, ring_hom.comp_assoc, quotient_map_comp_mk, ← ring_hom.comp_assoc ϕ1,
       quotient_map_comp_mk, ← ring_hom.comp_assoc, ← ring_hom.comp_assoc, ← ring_hom.comp_assoc,
       ← ring_hom.comp_assoc, quotient_map_comp_mk],
-    rw this,
+    rw [← mv_polynomial.fin_succ_equiv_comp_C_eq_C n, this],
     refine ring_hom.is_integral_trans (quotient.mk P1) φ _ hφ,
     exact (quotient.mk P1).is_integral_of_surjective (quotient.mk_surjective) }
 end

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -420,7 +420,6 @@ begin
   haveI hp'_prime : P'.is_prime := comap_is_prime C P,
   obtain ⟨pX, hpX, hp0⟩ := P.exists_mem_ne_zero_of_ne_bot
     (ne_of_lt (bot_lt_of_maximal P polynomial_not_is_field)).symm,
-
   have hp0 : (pX.map (quotient.mk P')).leading_coeff ≠ 0 :=
     λ hp0', hp0 $ map_injective (quotient.mk P') ((quotient.mk P').injective_iff.2
       (λ x hx, by rwa [quotient.eq_zero_iff_mem, (by rwa eq_bot_iff : P' = ⊥)] at hx))
@@ -439,9 +438,6 @@ begin
   have hM : (0 : P'.quotient) ∉ M := λ hM, hp0 (let ⟨n, hn⟩ := hM in pow_eq_zero hn),
   have hM' : (0 : P.quotient) ∉ M' := λ hM', hM (let ⟨z, hz⟩ := hM' in (hφ (trans hz.2 φ.map_zero.symm)) ▸ hz.1),
   have hφ'_int : φ'.is_integral := is_integral_localization_map_polynomial_quotient P pX hpX ϕ ϕ',
-
-  rw ← is_integral_quotient_map_iff,
-
   haveI : P'.is_maximal := begin
     letI : integral_domain (localization M') :=
       localization_map.integral_domain_localization (le_non_zero_divisors_of_domain hM'),
@@ -458,11 +454,11 @@ begin
     refine map.is_maximal ϕ'.to_map (localization_map_bijective_of_field hM' _ ϕ') hP,
     rwa [← quotient.maximal_ideal_iff_is_field_quotient, ← bot_quotient_is_maximal_iff],
   end,
-
   have hϕ : ϕ.to_map.is_integral,
   { refine ϕ.to_map.is_integral_of_surjective (localization_map_bijective_of_field hM _ ϕ).2,
     by rwa ← quotient.maximal_ideal_iff_is_field_quotient },
 
+  rw ← is_integral_quotient_map_iff,
   have : (φ'.comp ϕ.to_map).is_integral := ring_hom.is_integral_trans ϕ.to_map φ' hϕ hφ'_int,
   rw hcomm at this,
   refine φ.is_integral_tower_bot_of_is_integral ϕ'.to_map _ this,
@@ -542,7 +538,7 @@ begin
   unfreezingI {induction n with n IH},
   { have := (ring_equiv_of_equiv R (equiv.equiv_pempty $ fin.elim0)).trans (pempty_ring_equiv R),
     refine ring_hom.is_integral_of_surjective _ (function.surjective.comp quotient.mk_surjective _),
-    exact C_surjective },
+    exact C_surjective_fin_0 },
   { let ϕ1 : R →+* mv_polynomial (fin n) R := mv_polynomial.C,
     let ϕ2 : (mv_polynomial (fin n) R) →+* polynomial (mv_polynomial (fin n) R) := polynomial.C,
     let ϕ3 := (fin_succ_equiv R n).symm.to_ring_hom,

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -262,6 +262,54 @@ end localization
 section polynomial
 open polynomial
 
+/-- If `I` is an ideal of `polynomial R` and `pX ∈ I` is a non-constant polynomial,
+  then the map `R →+* R[x]/I` descends to an integral map when localizing at `pX.leading_coeff`.
+  In particular `X` is integral because it satisfies `pX`, and constants are trivially integral,
+  so integrality of the entire extension follows by closure under addition and multiplication -/
+lemma is_integral_localization_map_polynomial_quotient {R : Type*} [integral_domain R]
+  {Rₘ Sₘ : Type*} [comm_ring Rₘ] [comm_ring Sₘ]
+  (P : ideal (polynomial R)) [P.is_prime] (pX : polynomial R) (hpX : pX ∈ P)
+  (ϕ : localization_map (submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff) Rₘ)
+  (ϕ' : localization_map ((submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff).map
+    (quotient_map P C le_rfl) : submonoid P.quotient) Sₘ) :
+  (ϕ.map ((submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff).mem_map_of_mem
+      (quotient_map P C le_rfl : (P.comap C : ideal R).quotient →* P.quotient)) ϕ').is_integral :=
+begin
+  let P' : ideal R := P.comap C,
+  let M : submonoid P'.quotient := submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff,
+  let φ : P'.quotient →+* P.quotient := quotient_map P C le_rfl,
+  let φ' := (ϕ.map (M.mem_map_of_mem (φ : P'.quotient →* P.quotient)) ϕ'),
+  have hφ' : φ.comp (quotient.mk P') = (quotient.mk P).comp C := rfl,
+  intro p,
+  obtain ⟨⟨p', ⟨q, hq⟩⟩, hp⟩ := ϕ'.surj p,
+  suffices : φ'.is_integral_elem (ϕ'.to_map p'),
+  { obtain ⟨q', hq', rfl⟩ := hq,
+    obtain ⟨q'', hq''⟩ := is_unit_iff_exists_inv'.1 (ϕ.map_units ⟨q', hq'⟩),
+    refine φ'.is_integral_of_is_integral_mul_unit p (ϕ'.to_map (φ q')) q'' _ (hp.symm ▸ this),
+    convert trans (trans (φ'.map_mul _ _).symm (congr_arg φ' hq'')) φ'.map_one using 2,
+    rw [← φ'.comp_apply, localization_map.map_comp, ϕ'.to_map.comp_apply, subtype.coe_mk] },
+  refine is_integral_of_mem_closure''
+    ((ϕ'.to_map.comp (quotient.mk P)) '' (insert X {p | p.degree ≤ 0})) _ _ _,
+  { rintros x ⟨p, hp, rfl⟩,
+    refine hp.rec_on (λ hy, _) (λ hy, _),
+    { refine hy.symm ▸ (φ.is_integral_elem_localization_at_leading_coeff ((quotient.mk P) X)
+        (pX.map (quotient.mk P')) _ M ⟨1, pow_one _⟩ _ _),
+      rwa [eval₂_map, hφ', ← hom_eval₂, quotient.eq_zero_iff_mem, eval₂_C_X] },
+    { rw [set.mem_set_of_eq, degree_le_zero_iff] at hy,
+      refine hy.symm ▸ ⟨X - C (ϕ.to_map ((quotient.mk P') (p.coeff 0))), monic_X_sub_C _, _⟩,
+      simp only [eval₂_sub, eval₂_C, eval₂_X],
+      rw [sub_eq_zero_iff_eq, ← φ'.comp_apply, localization_map.map_comp, ring_hom.comp_apply],
+      refl } },
+  { obtain ⟨p, rfl⟩ := quotient.mk_surjective p',
+    refine polynomial.induction_on p
+      (λ r, subring.subset_closure $ set.mem_image_of_mem _ (or.inr degree_C_le))
+      (λ _ _ h1 h2, _) (λ n _ hr, _),
+    { convert subring.add_mem _ h1 h2,
+      rw [ring_hom.map_add, ring_hom.map_add] },
+    { rw [pow_succ X n, mul_comm X, ← mul_assoc, ring_hom.map_mul, ϕ'.to_map.map_mul],
+      exact subring.mul_mem _ hr (subring.subset_closure (set.mem_image_of_mem _ (or.inl rfl))) } },
+end
+
 /-- If `f : R → S` descends to an integral map in the localization at `x`,
   and `R` is a jacobson ring, then the intersection of all maximal ideals in `S` is trivial -/
 lemma jacobson_bot_of_integral_localization {R S : Type*} [integral_domain R] [integral_domain S]
@@ -306,6 +354,13 @@ begin
       (ring_hom.is_integral_quotient_of_is_integral _ hφ'))),
 end
 
+lemma exists_non_zero_mem_of_ne_bot {R : Type*} [comm_ring R] (I : ideal R) (hI : I ≠ ⊥) :
+  ∃ p ∈ I, p ≠ (0 : R) :=
+begin
+  contrapose! hI,
+  exact eq_bot_iff.2 (λ x hx, (hI x hx).symm ▸ (ideal.zero_mem ⊥)),
+end
+
 /-- Used to bootstrap the proof of `is_jacobson_polynomial_iff_is_jacobson`.
   That theorem is more general and should be used instead of this one -/
 private lemma is_jacobson_polynomial_of_domain (R : Type*) [integral_domain R] [hR : is_jacobson R]
@@ -318,49 +373,16 @@ begin
     have hP'_inj : function.injective (quotient.mk P') := (quotient.mk P').injective_iff.2
       (λ x hx, by rwa [quotient.eq_zero_iff_mem, (by rwa eq_bot_iff : P' = ⊥)] at hx),
     haveI : P'.is_prime := comap_is_prime C P,
-    have : ∃ (p : polynomial R) (hp : p ∈ P), p ≠ 0,
-    { contrapose! hP,
-      exact eq_bot_iff.2 (λ x hx, (hP x hx).symm ▸ (ideal.zero_mem ⊥)) },
-    obtain ⟨pX, hpX, hp0⟩ := this,
-    have hp0 : (pX.map (quotient.mk P')) ≠ 0 :=
-      λ hp0', hp0 $ map_injective (quotient.mk P') hP'_inj (by simpa using hp0'),
+    obtain ⟨pX, hpX, hp0⟩ := exists_non_zero_mem_of_ne_bot P hP,
+    have hp0 : (pX.map (quotient.mk P')).leading_coeff ≠ 0 :=
+    λ hp0', hp0 $ map_injective (quotient.mk P') ((quotient.mk P').injective_iff.2
+      (λ x hx, by rwa [quotient.eq_zero_iff_mem, (by rwa eq_bot_iff : P' = ⊥)] at hx))
+      (by simpa using hp0'),
     let φ : P'.quotient →+* P.quotient := quotient_map P C le_rfl,
-    have hφ' : φ.comp (quotient.mk P') = (quotient.mk P).comp C := rfl,
-    have hφ : function.injective φ := quotient_map_injective,
     let M : submonoid P'.quotient := submonoid.powers (pX.map (quotient.mk P')).leading_coeff,
-    let ϕ : localization_map M (localization M) := localization.of M,
-    let ϕ' : localization_map (M.map ↑φ) (localization (M.map ↑φ)) := localization.of (M.map ↑φ),
-    let φ' : (localization M) →+* (localization (M.map ↑φ)) :=
-      (ϕ.map (M.mem_map_of_mem (φ : P'.quotient →* P.quotient)) ϕ'),
-    refine jacobson_bot_of_integral_localization φ hφ (pX.map (quotient.mk P')).leading_coeff
-       (λ hx, hp0 (leading_coeff_eq_zero.1 hx)) ϕ ϕ' (λ p, _),
-    obtain ⟨⟨p', ⟨q, hq⟩⟩, hp⟩ := ϕ'.surj p,
-    suffices : φ'.is_integral_elem (ϕ'.to_map p'),
-    { obtain ⟨q', hq', rfl⟩ := hq,
-      obtain ⟨q'', hq''⟩ := is_unit_iff_exists_inv'.1 (ϕ.map_units ⟨q', hq'⟩),
-      refine φ'.is_integral_of_is_integral_mul_unit p (ϕ'.to_map (φ q')) q'' _ (hp.symm ▸ this),
-      convert trans (trans (φ'.map_mul _ _).symm (congr_arg φ' hq'')) φ'.map_one using 2,
-      rw [← φ'.comp_apply, localization_map.map_comp, ϕ'.to_map.comp_apply, subtype.coe_mk] },
-    refine is_integral_of_mem_closure''
-      ((ϕ'.to_map.comp (quotient.mk P)) '' (insert X {p | p.degree ≤ 0})) _ _ _,
-    { rintros x ⟨p, hp, rfl⟩,
-      refine hp.rec_on (λ hy, _) (λ hy, _),
-      { refine hy.symm ▸ (φ.is_integral_elem_localization_at_leading_coeff ((quotient.mk P) X)
-          (pX.map (quotient.mk P')) _ M ⟨1, pow_one _⟩ _ _),
-        rwa [eval₂_map, hφ', ← hom_eval₂, quotient.eq_zero_iff_mem, eval₂_C_X] },
-      { rw [set.mem_set_of_eq, degree_le_zero_iff] at hy,
-        refine hy.symm ▸ ⟨X - C (ϕ.to_map ((quotient.mk P') (p.coeff 0))), monic_X_sub_C _, _⟩,
-        simp only [eval₂_sub, eval₂_C, eval₂_X],
-        rw [sub_eq_zero_iff_eq, ← φ'.comp_apply, localization_map.map_comp, ring_hom.comp_apply],
-        refl } },
-    { obtain ⟨p, rfl⟩ := quotient.mk_surjective p',
-      refine polynomial.induction_on p
-        (λ r, subring.subset_closure $ set.mem_image_of_mem _ (or.inr degree_C_le))
-        (λ _ _ h1 h2, _) (λ n _ hr, _),
-      { convert subring.add_mem _ h1 h2,
-        rw [ring_hom.map_add, ring_hom.map_add] },
-      { rw [pow_succ X n, mul_comm X, ← mul_assoc, ring_hom.map_mul, ϕ'.to_map.map_mul],
-        exact subring.mul_mem _ hr (subring.subset_closure (set.mem_image_of_mem _ (or.inl rfl))) } } }
+    refine jacobson_bot_of_integral_localization φ quotient_map_injective
+      (pX.map (quotient.mk P')).leading_coeff hp0 (localization.of M) (localization.of (M.map ↑φ))
+      (is_integral_localization_map_polynomial_quotient P pX hpX _ _) },
 end
 
 theorem is_jacobson_polynomial_iff_is_jacobson {R : Type*} [comm_ring R] : is_jacobson (polynomial R) ↔ is_jacobson R :=
@@ -389,7 +411,7 @@ begin
       refine le_antisymm (le_trans (le_sup_left_of_le le_rfl)
         (le_trans (le_of_eq this) (sup_le le_rfl hi'))) le_jacobson,
       all_goals {exact polynomial.map_surjective i hi} },
-    refine is_jacobson_polynomial_of_domain R' I' (eq_zero_of_polynomial_mem_map_range I hi') },
+    refine is_jacobson_polynomial_of_domain R' I' (eq_zero_of_polynomial_mem_map_range I) },
 end
 
 instance [is_jacobson R] : is_jacobson (polynomial R) :=
@@ -412,6 +434,205 @@ begin
   obtain ⟨e⟩ := fintype.equiv_fin ι,
   rw is_jacobson_iso (mv_polynomial.ring_equiv_of_equiv R e),
   exact is_jacobson_mv_polynomial_fin _
+end
+
+/-- If `R` is a jacobson field, and `P` is a maximal ideal of `polynomial R`,
+  then `R → (polynomial R)/P` is an integral map. -/
+lemma lemmaB_field {R : Type*} [integral_domain R] [is_jacobson R]
+  (P : ideal (polynomial R)) [hP : P.is_maximal] (hP' : ∀ (x : R), C x ∈ P → x = 0)
+  :
+  ((quotient.mk P).comp C : R →+* P.quotient).is_integral :=
+begin
+  let P' : ideal R := P.comap C,
+  haveI hp'_prime : P'.is_prime := comap_is_prime C P,
+  obtain ⟨pX, hpX, hp0⟩ :=
+    exists_non_zero_mem_of_ne_bot P (ne_of_lt (bot_lt_of_maximal P polynomial_not_is_field)).symm,
+
+  have hp0 : (pX.map (quotient.mk P')).leading_coeff ≠ 0 :=
+    λ hp0', hp0 $ map_injective (quotient.mk P') ((quotient.mk P').injective_iff.2
+      (λ x hx, by rwa [quotient.eq_zero_iff_mem, (by rwa eq_bot_iff : P' = ⊥)] at hx))
+      (by simpa using hp0'),
+
+  let φ : P'.quotient →+* P.quotient := quotient_map P C le_rfl,
+  let M : submonoid P'.quotient := submonoid.powers (pX.map (quotient.mk P')).leading_coeff,
+  let M' : submonoid P.quotient := M.map φ,
+  let ϕ : localization_map M (localization M) := localization.of M,
+  let ϕ' : localization_map (M.map ↑φ) (localization (M.map ↑φ)) := localization.of (M.map ↑φ),
+  let φ' : (localization M) →+* (localization (M.map ↑φ)) :=
+    (ϕ.map (M.mem_map_of_mem (φ : P'.quotient →* P.quotient)) ϕ'),
+
+  have hcomm: φ'.comp ϕ.to_map = ϕ'.to_map.comp φ := ϕ.map_comp _,
+  have hφ : function.injective φ := quotient_map_injective,
+  have hφ' : φ.comp (quotient.mk P') = (quotient.mk P).comp C := rfl,
+  have hM : (0 : P'.quotient) ∉ M := λ hM, hp0 (let ⟨n, hn⟩ := hM in pow_eq_zero hn),
+  have hM' : (0 : P.quotient) ∉ M' := λ hM', hM (let ⟨z, hz⟩ := hM' in (hφ (trans hz.2 φ.map_zero.symm)) ▸ hz.1),
+  have hφ'_int : φ'.is_integral := is_integral_localization_map_polynomial_quotient P pX hpX ϕ ϕ',
+
+  rw ← is_integral_quotient_map_iff,
+
+  haveI : P'.is_maximal := begin
+    letI : integral_domain (localization M') :=
+      localization_map.integral_domain_localization (le_non_zero_divisors_of_domain hM'),
+    rw ← bot_quotient_is_maximal_iff at hP ⊢,
+    suffices : (⊥ : ideal (localization M)).is_maximal,
+    { rw ← ϕ.comap_map_of_is_prime_disjoint ⊥ bot_prime (λ x hx, hM (hx.2 ▸ hx.1)),
+      refine ((is_maximal_iff_is_maximal_disjoint ϕ _).mp _).1,
+      rwa map_bot },
+    suffices : (⊥ : ideal (localization M')).is_maximal,
+    { rw le_antisymm bot_le (comap_bot_le_of_injective φ' (map_injective_of_injective φ hφ M ϕ ϕ'
+        (le_non_zero_divisors_of_domain hM'))),
+      refine is_maximal_comap_of_is_integral_of_is_maximal' φ' hφ'_int ⊥ this },
+    have : (⊥ : ideal (localization M')) = map ϕ'.to_map ⊥ := map_bot.symm,
+    rw this,
+    refine map.is_maximal ϕ'.to_map (localization_map_bijective_of_field hM' _ ϕ') hP,
+    rwa [← quotient.maximal_ideal_iff_is_field_quotient, ← bot_quotient_is_maximal_iff],
+  end,
+
+  have hϕ : ϕ.to_map.is_integral,
+  { refine ϕ.to_map.is_integral_of_surjective (localization_map_bijective_of_field hM _ ϕ).2,
+    by rwa ← quotient.maximal_ideal_iff_is_field_quotient },
+
+  have : (φ'.comp ϕ.to_map).is_integral := ring_hom.is_integral_trans ϕ.to_map φ' hϕ hφ'_int,
+  rw hcomm at this,
+  refine φ.is_integral_tower_bot_of_is_integral ϕ'.to_map _ this,
+  refine ϕ'.injective (le_non_zero_divisors_of_domain hM'),
+end
+
+lemma lemmaB {R : Type*} [integral_domain R] [is_jacobson R]
+  (I : ideal (polynomial R)) [hI : I.is_maximal] :
+  ((quotient.mk I).comp C : R →+* I.quotient).is_integral :=
+begin
+  let I' : ideal R := I.comap C,
+  haveI : I'.is_prime := comap_is_prime C I,
+  let R' := I'.quotient,
+
+  let i : R →+* R' := quotient.mk I',
+  let f : polynomial R →+* polynomial R' := polynomial.map_ring_hom (quotient.mk I'),
+  have hf : function.surjective f := map_surjective i quotient.mk_surjective,
+  let J : ideal (polynomial R') := I.map f,
+
+  have hIJ : I = J.comap f := begin
+    rw comap_map_of_surjective f hf,
+    refine le_antisymm (le_sup_left_of_le le_rfl) (sup_le le_rfl _),
+
+    intros p hp,
+    refine polynomial_mem_ideal_of_coeff_mem_ideal I p (λ n, _),
+    show p.coeff n ∈ I',
+    rw ← quotient.eq_zero_iff_mem,
+    rw mem_comap at hp,
+    rw ideal.mem_bot at hp,
+    rw polynomial.ext_iff at hp,
+    simpa using hp n,
+  end,
+
+  haveI : J.is_maximal := begin
+    cases map_eq_top_or_is_maximal_of_surjective f hf hI,
+    {
+      have : J = ⊤ := h,
+      have : I = comap f ⊤ := this ▸ hIJ,
+      rw comap_top at this,
+      refine absurd this hI.1,
+    },
+    {
+      exact h,
+    }
+  end,
+
+  let i' : I.quotient →+* J.quotient := quotient_map J f le_comap_map,
+  let ϕ : R →+* I.quotient := (quotient.mk I).comp C,
+  let ϕ' : R' →+* J.quotient := (quotient.mk J).comp C,
+
+  show ϕ.is_integral,
+
+  refine ring_hom.is_integral_tower_bot_of_is_integral ϕ i' begin
+    refine i'.injective_iff.2 (λ a ha, _),
+    obtain ⟨r, rfl⟩ := quotient.mk_surjective a,
+    rw quotient_map_mk at ha,
+    rw quotient.eq_zero_iff_mem at ha,
+
+    rw quotient.eq_zero_iff_mem,
+    rwa hIJ,
+
+  end _,
+
+  have : i'.comp ϕ = ϕ'.comp i := begin
+
+  end,
+  rw this,
+
+  refine ring_hom.is_integral_trans i ϕ' (i.is_integral_of_surjective quotient.mk_surjective) _,
+  refine lemmaB_field J _,
+
+  intros x hx,
+  obtain ⟨z, rfl⟩ := quotient.mk_surjective x,
+  rw quotient.eq_zero_iff_mem,
+  rw mem_comap,
+  rw hIJ,
+  rw mem_comap,
+  rw coe_map_ring_hom,
+  rwa map_C (quotient.mk I'),
+end
+
+
+lemma pullbackMaximalB {R : Type*} [integral_domain R] [is_jacobson R]
+  (P : ideal (polynomial R)) [hP : P.is_maximal] :
+  (P.comap (C : R →+* polynomial R)).is_maximal :=
+begin
+  have := is_maximal_comap_of_is_integral_of_is_maximal' _ (lemmaB P) ⊥ (by rwa bot_quotient_is_maximal_iff),
+  rwa [← comap_comap, ← ring_hom.ker_eq_comap_bot, mk_ker] at this,
+end
+
+lemma C_surj {R : Type*} [comm_ring R] :
+  function.surjective (mv_polynomial.C : R → mv_polynomial (fin 0) R) :=
+begin
+  refine λ p, ⟨p.to_fun 0, mv_polynomial.ext _ _ (λ a, _)⟩,
+  simpa [(finsupp.ext fin_zero_elim : a = 0), if_true, eq_self_iff_true, mv_polynomial.coeff_C],
+end
+
+lemma lemmaB'_bootstrap {R : Type*} [integral_domain R] [is_jacobson R]
+  {n : ℕ} (P : ideal (mv_polynomial (fin n) R)) [hP : P.is_maximal] :
+  ((quotient.mk P).comp mv_polynomial.C : R →+* P.quotient).is_integral :=
+begin
+  unfreezingI {induction n with n IH},
+  { have := (mv_polynomial.ring_equiv_of_equiv R
+      (equiv.equiv_pempty $ fin.elim0)).trans (mv_polynomial.pempty_ring_equiv R),
+    refine ring_hom.is_integral_of_surjective _ (function.surjective.comp quotient.mk_surjective _),
+    refine C_surj },
+  { let ϕ1 : R →+* mv_polynomial (fin n) R := mv_polynomial.C,
+    let ϕ2 : (mv_polynomial (fin n) R) →+* polynomial (mv_polynomial (fin n) R) := polynomial.C,
+    let ϕ3 := (mv_polynomial.fin_succ_equiv R n).symm.to_ring_hom,
+    let ϕ : R →+* (mv_polynomial (fin (n+1)) R) := mv_polynomial.C,
+    let P3 : ideal (polynomial (mv_polynomial (fin n) R)) := P.comap ϕ3,
+    haveI : P3.is_maximal := comap_is_maximal_of_surjective ϕ3 (mv_polynomial.fin_succ_equiv R n).symm.surjective,
+    let P2 : ideal (mv_polynomial (fin n) R) := P3.comap ϕ2,
+    haveI : P2.is_maximal := pullbackMaximalB P3,
+    let P1 : ideal R := P2.comap ϕ1,
+    let φ3 : P3.quotient →+* P.quotient := quotient_map P ϕ3 le_rfl,
+    have hφ3 : φ3.is_integral := begin
+      refine φ3.is_integral_of_surjective _,
+      refine quotient_map_surjective _,
+      exact (mv_polynomial.fin_succ_equiv R n).symm.surjective,
+    end,
+    let φ2 : P2.quotient →+* P3.quotient := quotient_map P3 ϕ2 le_rfl,
+    have hφ2 : φ2.is_integral := begin
+      rw is_integral_quotient_map_iff,
+      refine lemmaB P3,
+    end,
+    let φ1 : P1.quotient →+* P2.quotient := quotient_map P2 ϕ1 le_rfl,
+    have hφ1 : φ1.is_integral := begin
+      rw is_integral_quotient_map_iff,
+      refine IH P2,
+    end,
+    let φ : P1.quotient →+* P.quotient := φ3.comp (φ2.comp φ1),
+    have hφ : φ.is_integral := begin
+      refine ring_hom.is_integral_trans (φ2.comp φ1) φ3 (ring_hom.is_integral_trans φ1 φ2 hφ1 hφ2) hφ3,
+    end,
+    have : (quotient.mk P).comp ϕ = φ.comp (quotient.mk P1) := begin
+      sorry,
+    end,
+    rw this,
+    refine ring_hom.is_integral_trans (quotient.mk P1) φ _ hφ,
+    exact (quotient.mk P1).is_integral_of_surjective (quotient.mk_surjective) }
 end
 
 end polynomial

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -262,7 +262,7 @@ end localization
 namespace polynomial
 open polynomial
 
-/-- If `I` is an ideal of `polynomial R` and `pX ∈ I` is a non-constant polynomial,
+/-- If `I` is a prime ideal of `polynomial R` and `pX ∈ I` is a non-constant polynomial,
   then the map `R →+* R[x]/I` descends to an integral map when localizing at `pX.leading_coeff`.
   In particular `X` is integral because it satisfies `pX`, and constants are trivially integral,
   so integrality of the entire extension follows by closure under addition and multiplication -/

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -499,6 +499,18 @@ begin
   rwa [quotient.eq_zero_iff_mem, mem_comap, hIJ, mem_comap, coe_map_ring_hom, map_C],
 end
 
+lemma comp_C_integral_of_surjective_of_jacobson {R : Type*} [integral_domain R] [is_jacobson R]
+  {S : Type*} [field S] (f : (polynomial R) →+* S) (hf : function.surjective f) :
+  (f.comp C).is_integral :=
+begin
+  haveI : (f.ker).is_maximal := @comap_is_maximal_of_surjective _ _ _ _ f ⊥ hf bot_is_maximal,
+  let g : f.ker.quotient →+* S := ideal.quotient.lift f.ker f (λ _ h, h),
+  have hfg : (g.comp (quotient.mk f.ker)) = f := quotient.lift_comp_mk f.ker f _,
+  rw [← hfg, ring_hom.comp_assoc],
+  refine ring_hom.is_integral_trans _ g (quotient_mk_comp_C_is_integral_of_jacobson f.ker)
+    (g.is_integral_of_surjective (quotient.lift_surjective f.ker f _ hf)),
+end
+
 lemma is_maximal_comap_C_of_is_jacobson {R : Type*} [integral_domain R] [is_jacobson R]
   (P : ideal (polynomial R)) [hP : P.is_maximal] : (P.comap (C : R →+* polynomial R)).is_maximal :=
 begin
@@ -573,6 +585,18 @@ begin
     rw [← fin_succ_equiv_comp_C_eq_C n, this],
     refine ring_hom.is_integral_trans (quotient.mk P1) φ _ hφ,
     exact (quotient.mk P1).is_integral_of_surjective (quotient.mk_surjective) }
+end
+
+lemma comp_C_integral_of_surjective_of_jacobson {R : Type*} [integral_domain R] [is_jacobson R]
+  {S : Type*} [field S] {n : ℕ} (f : (mv_polynomial (fin n) R) →+* S) (hf : function.surjective f) :
+  (f.comp C).is_integral :=
+begin
+  haveI : (f.ker).is_maximal := @comap_is_maximal_of_surjective _ _ _ _ f ⊥ hf bot_is_maximal,
+  let g : f.ker.quotient →+* S := ideal.quotient.lift f.ker f (λ _ h, h),
+  have hfg : (g.comp (quotient.mk f.ker)) = f := quotient.lift_comp_mk f.ker f _,
+  rw [← hfg, ring_hom.comp_assoc],
+  refine ring_hom.is_integral_trans _ g (quotient_mk_comp_C_is_integral_of_jacobson f.ker)
+    (g.is_integral_of_surjective (quotient.lift_surjective f.ker f _ hf)),
 end
 
 end mv_polynomial

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -532,6 +532,45 @@ begin
   rwa [← comap_comap, ← ring_hom.ker_eq_comap_bot, mk_ker] at this,
 end
 
+example {R : Type*} [hR : comm_ring R] (n : ℕ) : R :=
+begin
+  -- haveI : comm_semiring R := comm_ring.to_comm_semiring,
+
+  -- let sr1 : semiring (mv_polynomial (fin n) R) := comm_semiring.to_semiring,
+  -- let sr2 : semiring (mv_polynomial (fin n) R) := ring.to_semiring,
+
+  have a : mv_polynomial (option (fin n)) R ≃+* polynomial (mv_polynomial (fin n) R),
+  {
+    have := mv_polynomial.option_equiv_left R (fin n),
+    sorry,
+    -- exact this,
+  },
+
+  exact 0,
+end
+
+lemma mv_poly_step {R : Type*} [comm_semiring R] (n : ℕ) :
+  ((mv_polynomial.fin_succ_equiv R n).symm.to_ring_hom).comp
+    ((polynomial.C).comp (mv_polynomial.C))
+    = (mv_polynomial.C : R →+* mv_polynomial (fin n.succ) R) :=
+begin
+  refine ring_hom.ext (λ x, _),
+  rw ring_hom.comp_apply,
+  refine (mv_polynomial.fin_succ_equiv R n).injective
+    (trans ((mv_polynomial.fin_succ_equiv R n).apply_symm_apply _) _),
+  simp only [mv_polynomial.fin_succ_equiv_apply, mv_polynomial.eval₂_hom_C],
+end
+
+lemma mv_poly_step' {R : Type*} [comm_semiring R] (n : ℕ) :
+  ((mv_polynomial.fin_succ_equiv R n).symm.to_ring_hom).comp
+    ((polynomial.C).comp (mv_polynomial.C))
+    = (mv_polynomial.C : R →+* mv_polynomial (fin n.succ) R) :=
+mv_poly_step n
+
+-- lemma mv_poly_step {R S T U : Type*} [comm_ring R] [comm_ring S] [comm_ring T] [comm_ring U]
+--   (f : R →+* S) (g : S →+* T) (h : T →+* U) (I : ideal U) :
+--   (quotient.mk I).comp (h.comp (g.comp f)) =
+
 lemma C_surj {R : Type*} [comm_ring R] :
   function.surjective (mv_polynomial.C : R → mv_polynomial (fin 0) R) :=
 begin
@@ -548,31 +587,46 @@ begin
       (equiv.equiv_pempty $ fin.elim0)).trans (mv_polynomial.pempty_ring_equiv R),
     refine ring_hom.is_integral_of_surjective _ (function.surjective.comp quotient.mk_surjective _),
     refine C_surj },
-  { let ϕ1 : R →+* mv_polynomial (fin n) R := mv_polynomial.C,
+  { --haveI : comm_semiring R := comm_ring.to_comm_semiring,
+    let ϕ1 : R →+* mv_polynomial (fin n) R := mv_polynomial.C,
     let ϕ2 : (mv_polynomial (fin n) R) →+* polynomial (mv_polynomial (fin n) R) := polynomial.C,
     let ϕ3 := (mv_polynomial.fin_succ_equiv R n).symm.to_ring_hom,
-    let ϕ : R →+* (mv_polynomial (fin (n+1)) R) := mv_polynomial.C,
+    let ϕ : R →+* (mv_polynomial (fin (n+1)) R) := ϕ3.comp (ϕ2.comp ϕ1),
+    have hϕ : ϕ = mv_polynomial.C := begin
+      refine ring_hom.ext (λ x, _),
+      have := congr_arg (λ (f : R →+* mv_polynomial (fin n.succ) R), f x) (mv_poly_step n),
+      simp at this,
+      exact this,
+
+    end, --@mv_poly_step R comm_ring.to_comm_semiring n,
+    rw ← hϕ,
+
     let P3 : ideal (polynomial (mv_polynomial (fin n) R)) := P.comap ϕ3,
     haveI : P3.is_maximal := comap_is_maximal_of_surjective ϕ3 (mv_polynomial.fin_succ_equiv R n).symm.surjective,
     let P2 : ideal (mv_polynomial (fin n) R) := P3.comap ϕ2,
     haveI : P2.is_maximal := is_maximal_comap_C_of_is_jacobson P3,
     let P1 : ideal R := P2.comap ϕ1,
+
     let φ3 : P3.quotient →+* P.quotient := quotient_map P ϕ3 le_rfl,
     have hφ3 : φ3.is_integral := φ3.is_integral_of_surjective
       (quotient_map_surjective ((mv_polynomial.fin_succ_equiv R n).symm.surjective)),
+
     let φ2 : P2.quotient →+* P3.quotient := quotient_map P3 ϕ2 le_rfl,
     have hφ2 : φ2.is_integral := begin
       rw is_integral_quotient_map_iff,
       refine quotient_mk_comp_C_is_integral_of_jacobson P3,
     end,
+
     let φ1 : P1.quotient →+* P2.quotient := quotient_map P2 ϕ1 le_rfl,
     have hφ1 : φ1.is_integral := begin
       rw is_integral_quotient_map_iff,
       refine IH P2,
     end,
+
     let φ : P1.quotient →+* P.quotient := φ3.comp (φ2.comp φ1),
     have hφ : φ.is_integral := ring_hom.is_integral_trans (φ2.comp φ1) φ3
       (ring_hom.is_integral_trans φ1 φ2 hφ1 hφ2) hφ3,
+
     have : (quotient.mk P).comp ϕ = φ.comp (quotient.mk P1) := begin
       sorry,
     end,

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -312,12 +312,18 @@ def polynomial_quotient_equiv_quotient_polynomial (I : ideal R) :
   This theorem shows `I'` will not contain any non-zero constant polynomials
   -/
 lemma eq_zero_of_polynomial_mem_map_range (I : ideal (polynomial R))
-  (hi' : (polynomial.map_ring_hom ((quotient.mk I).comp C).range_restrict).ker ≤ I)
   (x : ((quotient.mk I).comp C).range)
   (hx : C x ∈ (I.map (polynomial.map_ring_hom ((quotient.mk I).comp C).range_restrict))) :
   x = 0 :=
 begin
   let i := ((quotient.mk I).comp C).range_restrict,
+  have hi' : (polynomial.map_ring_hom i).ker ≤ I,
+  { refine λ f hf, polynomial_mem_ideal_of_coeff_mem_ideal I f (λ n, _),
+    rw [mem_comap, ← quotient.eq_zero_iff_mem, ← ring_hom.comp_apply],
+    rw [ring_hom.mem_ker, coe_map_ring_hom] at hf,
+    replace hf := congr_arg (λ (f : polynomial _), f.coeff n) hf,
+    simp only [coeff_map, coeff_zero] at hf,
+    rwa [subtype.ext_iff, ring_hom.coe_range_restrict] at hf },
   obtain ⟨x, hx'⟩ := x,
   obtain ⟨y, rfl⟩ := (ring_hom.mem_range).1 hx',
   refine subtype.eq _,


### PR DESCRIPTION
These changes are meant to make deriving the classical nullstellensatz from the generalized version about Jacobson rings much easier and much more direct.

`is_integral_localization_map_polynomial_quotient` already exists in the proof of a previous theorem, and this just pulls it out into an independent lemma.

`polynomial.quotient_mk_comp_C_is_integral_of_jacobson` and `mv_polynomial.quotient_mk_comp_C_is_integral_of_jacobson` are the two main new statements, most of the rest of the changes are just generalizations and reorganizations of the existing theorems.

---
