### PR TITLE
[Merged by Bors] - feat(topology/separation, topology/metric_space/basic): add lemmas on discrete subsets of a topological space

### DIFF
--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -675,7 +675,7 @@ by simp [is_open_iff, subset_singleton_iff, mem_ball]
 /-- Given a point `x` in a discrete subset `s` of a metric space, there is an open ball
 centered at `x` and intersecting `s` only at `x`. -/
 lemma ball_of_mem_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
-∃ ε > 0, ∀ y ∈ metric.ball x ε, y ≠ x → y ∉ s :=
+  ∃ ε > 0, ∀ y ∈ metric.ball x ε, y ≠ x → y ∉ s :=
 begin
   rcases disjoint_nhds_within_of_mem_discrete hx with ⟨U, U_in, hU⟩,
   rcases metric.nhds_within_basis_ball.mem_iff.mp U_in with ⟨ε, ε_pos, hε⟩,
@@ -686,7 +686,7 @@ end
 /-- Given a point `x` in a discrete subset `s` of a metric space, there is a closed ball
 of positive radius centered at `x` and intersecting `s` only at `x`. -/
 lemma closed_ball_of_mem_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
-∃ ε > 0, ∀ y ∈ metric.closed_ball x ε, y ≠ x → y ∉ s :=
+  ∃ ε > 0, ∀ y ∈ metric.closed_ball x ε, y ≠ x → y ∉ s :=
 begin
   obtain ⟨ε, e0, F⟩ := ball_of_mem_discrete hx,
   refine ⟨ε / 2, half_pos e0, λ y (yb : dist y x ≤ ε / 2), _⟩,

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -674,24 +674,31 @@ by simp [is_open_iff, subset_singleton_iff, mem_ball]
 
 /-- Given a point `x` in a discrete subset `s` of a metric space, there is an open ball
 centered at `x` and intersecting `s` only at `x`. -/
-lemma ball_of_mem_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
-  ∃ ε > 0, ∀ y ∈ metric.ball x ε, y ≠ x → y ∉ s :=
+lemma exists_ball_inter_eq_singleton_of_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
+∃ ε > 0, metric.ball x ε ∩ s = {x} :=
 begin
   rcases disjoint_nhds_within_of_mem_discrete hx with ⟨U, U_in, hU⟩,
-  rcases metric.nhds_within_basis_ball.mem_iff.mp U_in with ⟨ε, ε_pos, hε⟩,
-  refine ⟨ε, ε_pos, λ y hyB hxy hyt, _⟩,
-  exact eq_empty_iff_forall_not_mem.mp (disjoint_iff_inter_eq_empty.mp hU) y ⟨hε ⟨hyB, hxy⟩, hyt⟩,
+  rcases metric.nhds_within_basis_ball.mem_iff.mp U_in with ⟨ε, ε0, hε⟩,
+  refine ⟨ε, ε0, subset.antisymm (λ z hz, _) ((singleton_subset_iff).mpr (⟨mem_ball_self ε0, hx⟩))⟩,
+  by_cases zx : z = x,
+  { exact zx },
+  { refine (disjoint_left.mp hU (mem_of_mem_of_subset (mem_inter hz.1 (mem_compl zx)) hε) _).elim,
+    exact mem_of_mem_of_subset hz (inter_subset_right _ _) }
 end
 
 /-- Given a point `x` in a discrete subset `s` of a metric space, there is a closed ball
 of positive radius centered at `x` and intersecting `s` only at `x`. -/
-lemma closed_ball_of_mem_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
-  ∃ ε > 0, ∀ y ∈ metric.closed_ball x ε, y ≠ x → y ∉ s :=
+lemma exists_closed_ball_inter_eq_singleton_of_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
+  ∃ ε > 0, metric.closed_ball x ε ∩ s = {x} :=
 begin
-  obtain ⟨ε, e0, F⟩ := ball_of_mem_discrete hx,
-  refine ⟨ε / 2, half_pos e0, λ y (yb : dist y x ≤ ε / 2), _⟩,
-  apply F,
-  exact lt_of_le_of_lt yb (half_lt_self e0)
+  obtain ⟨ε, e0, F⟩ := exists_ball_inter_eq_singleton_of_discrete hx,
+  refine ⟨ε / 2, half_pos e0, subset.antisymm _ (λ f hf, _)⟩,
+  { rw ← F,
+    refine subset_inter _ (inter_subset_right _ _),
+    rintros f ⟨hf : dist _ _ ≤ _, -⟩,
+    exact lt_of_le_of_lt hf (half_lt_self e0) },
+  { cases hf,
+    exact ⟨mem_closed_ball_self (le_of_lt (half_pos e0)), hx⟩ }
 end
 
 end metric

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -675,7 +675,7 @@ by simp [is_open_iff, subset_singleton_iff, mem_ball]
 /-- Given a point `x` in a discrete subset `s` of a metric space, there is an open ball
 centered at `x` and intersecting `s` only at `x`. -/
 lemma exists_ball_inter_eq_singleton_of_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
-∃ ε > 0, metric.ball x ε ∩ s = {x} :=
+  ∃ ε > 0, metric.ball x ε ∩ s = {x} :=
 begin
   rcases disjoint_nhds_within_of_mem_discrete hx with ⟨U, U_in, hU⟩,
   rcases metric.nhds_within_basis_ball.mem_iff.mp U_in with ⟨ε, ε0, hε⟩,

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -683,13 +683,16 @@ begin
   exact eq_empty_iff_forall_not_mem.mp (disjoint_iff_inter_eq_empty.mp hU) y ⟨hε ⟨hyB, hxy⟩, hyt⟩,
 end
 
-/-- Given a point `x` in a discrete subset `s` of a metric space, there is a radius `ε` such that
-`x` is the only point of `s` with distance smaller than `ε` from `x`.
-This formulation is defeq to `metric.ball_of_mem_discrete`.
- -/
-lemma dist_lt_of_mem_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
-∃ ε > 0, ∀ y, dist y x < ε → y ≠ x → y ∉ s :=
-ball_of_mem_discrete hx
+/-- Given a point `x` in a discrete subset `s` of a metric space, there is a closed ball
+of positive radius centered at `x` and intersecting `s` only at `x`. -/
+lemma metric.closed_ball_of_mem_discrete {x : α} (hx : x ∈ s) :
+∃ ε > 0, ∀ y ∈ metric.closed_ball x ε, y ≠ x → y ∉ s :=
+begin
+  obtain ⟨ε, e0, F⟩ := metric.ball_of_mem_discrete hx,
+  refine ⟨ε / 2, half_pos e0, λ y (yb : dist y x ≤ ε / 2), _⟩,
+  apply F,
+  exact lt_of_le_of_lt yb (half_lt_self e0)
+end
 
 end metric
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -672,6 +672,25 @@ lemma is_open_singleton_iff {X : Type*} [metric_space X] {x : X} :
   is_open ({x} : set X) ↔ ∃ ε > 0, ∀ y, dist y x < ε → y = x :=
 by simp [is_open_iff, subset_singleton_iff, mem_ball]
 
+/-- Given a point `x` in a discrete subset `s` of a metric space, there is an open ball
+centered at `x` and intersecting `s` only at `x`. -/
+lemma ball_of_mem_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
+∃ ε > 0, ∀ y ∈ metric.ball x ε, y ≠ x → y ∉ s :=
+begin
+  rcases disjoint_nhds_within_of_mem_discrete hx with ⟨U, U_in, hU⟩,
+  rcases metric.nhds_within_basis_ball.mem_iff.mp U_in with ⟨ε, ε_pos, hε⟩,
+  refine ⟨ε, ε_pos, λ y hyB hxy hyt, _⟩,
+  exact eq_empty_iff_forall_not_mem.mp (disjoint_iff_inter_eq_empty.mp hU) y ⟨hε ⟨hyB, hxy⟩, hyt⟩,
+end
+
+/-- Given a point `x` in a discrete subset `s` of a metric space, there is a radius `ε` such that
+`x` is the only point of `s` with distance smaller than `ε` from `x`.
+This formulation is defeq to `metric.ball_of_mem_discrete`.
+ -/
+lemma dist_lt_of_mem_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
+∃ ε > 0, ∀ y, dist y x < ε → y ≠ x → y ∉ s :=
+ball_of_mem_discrete hx
+
 end metric
 
 open metric

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -685,10 +685,10 @@ end
 
 /-- Given a point `x` in a discrete subset `s` of a metric space, there is a closed ball
 of positive radius centered at `x` and intersecting `s` only at `x`. -/
-lemma metric.closed_ball_of_mem_discrete {x : α} (hx : x ∈ s) :
+lemma metric.closed_ball_of_mem_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
 ∃ ε > 0, ∀ y ∈ metric.closed_ball x ε, y ≠ x → y ∉ s :=
 begin
-  obtain ⟨ε, e0, F⟩ := metric.ball_of_mem_discrete hx,
+  obtain ⟨ε, e0, F⟩ := ball_of_mem_discrete hx,
   refine ⟨ε / 2, half_pos e0, λ y (yb : dist y x ≤ ε / 2), _⟩,
   apply F,
   exact lt_of_le_of_lt yb (half_lt_self e0)

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -685,7 +685,7 @@ end
 
 /-- Given a point `x` in a discrete subset `s` of a metric space, there is a closed ball
 of positive radius centered at `x` and intersecting `s` only at `x`. -/
-lemma metric.closed_ball_of_mem_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
+lemma closed_ball_of_mem_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
 ∃ ε > 0, ∀ y ∈ metric.closed_ball x ε, y ≠ x → y ∉ s :=
 begin
   obtain ⟨ε, e0, F⟩ := ball_of_mem_discrete hx,

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -674,32 +674,15 @@ by simp [is_open_iff, subset_singleton_iff, mem_ball]
 
 /-- Given a point `x` in a discrete subset `s` of a metric space, there is an open ball
 centered at `x` and intersecting `s` only at `x`. -/
-lemma exists_ball_inter_eq_singleton_of_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
+lemma exists_ball_inter_eq_singleton_of_mem_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
   ∃ ε > 0, metric.ball x ε ∩ s = {x} :=
-begin
-  rcases disjoint_nhds_within_of_mem_discrete hx with ⟨U, U_in, hU⟩,
-  rcases metric.nhds_within_basis_ball.mem_iff.mp U_in with ⟨ε, ε0, hε⟩,
-  refine ⟨ε, ε0, subset.antisymm (λ z hz, _) ((singleton_subset_iff).mpr (⟨mem_ball_self ε0, hx⟩))⟩,
-  by_cases zx : z = x,
-  { exact zx },
-  { refine (disjoint_left.mp hU (mem_of_mem_of_subset (mem_inter hz.1 (mem_compl zx)) hε) _).elim,
-    exact mem_of_mem_of_subset hz (inter_subset_right _ _) }
-end
+nhds_basis_ball.exists_inter_eq_singleton_of_mem_discrete hx
 
 /-- Given a point `x` in a discrete subset `s` of a metric space, there is a closed ball
 of positive radius centered at `x` and intersecting `s` only at `x`. -/
 lemma exists_closed_ball_inter_eq_singleton_of_discrete [discrete_topology s] {x : α} (hx : x ∈ s) :
   ∃ ε > 0, metric.closed_ball x ε ∩ s = {x} :=
-begin
-  obtain ⟨ε, e0, F⟩ := exists_ball_inter_eq_singleton_of_discrete hx,
-  refine ⟨ε / 2, half_pos e0, subset.antisymm _ (λ f hf, _)⟩,
-  { rw ← F,
-    refine subset_inter _ (inter_subset_right _ _),
-    rintros f ⟨hf : dist _ _ ≤ _, -⟩,
-    exact lt_of_le_of_lt hf (half_lt_self e0) },
-  { cases hf,
-    exact ⟨mem_closed_ball_self (le_of_lt (half_pos e0)), hx⟩ }
-end
+nhds_basis_closed_ball.exists_inter_eq_singleton_of_mem_discrete hx
 
 end metric
 

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -139,17 +139,34 @@ begin
   exact is_closed_bUnion (finite.of_fintype _) (λ y _, is_closed_singleton)
 end
 
-/-- A point `x` in a discrete subset `s` of a topological space admits a neighbourhood
-that only meets `s` at `x`.  -/
-lemma nhd_singleton_of_mem_discrete {s : set α} [discrete_topology s] {x : α} (hx : x ∈ s) :
-  ∃ U ∈ 𝓝 x, U ∩ s = {x} :=
+lemma singleton_mem_nhds_within_of_mem_discrete {s : set α} [discrete_topology s]
+  {x : α} (hx : x ∈ s) :
+  {x} ∈ 𝓝[s] x :=
 begin
   have : ({⟨x, hx⟩} : set s) ∈ 𝓝 (⟨x, hx⟩ : s), by simp [nhds_discrete],
-  rw [nhds_induced] at this,
-  rcases this with ⟨U, U_in, h⟩,
-  refine ⟨U, U_in, subset.antisymm _ (singleton_subset_iff.mpr ⟨mem_of_nhds U_in, hx⟩)⟩,
-  simpa only [image_singleton, subtype.image_preimage_coe] using image_subset (coe : s → α) h
+  simpa only [nhds_within_eq_map_subtype_coe hx, image_singleton]
+    using @image_mem_map _ _ _ (coe : s → α) _ this
 end
+
+lemma nhds_within_of_mem_discrete {s : set α} [discrete_topology s] {x : α} (hx : x ∈ s) :
+  𝓝[s] x = pure x :=
+le_antisymm (le_pure_iff.2 $ singleton_mem_nhds_within_of_mem_discrete hx) (pure_le_nhds_within hx)
+
+lemma filter.has_basis.exists_inter_eq_singleton_of_mem_discrete
+  {ι : Type*} {p : ι → Prop} {t : ι → set α} {s : set α} [discrete_topology s] {x : α}
+  (hb : (𝓝 x).has_basis p t) (hx : x ∈ s) :
+  ∃ i (hi : p i), t i ∩ s = {x} :=
+begin
+  rcases (nhds_within_has_basis hb s).mem_iff.1 (singleton_mem_nhds_within_of_mem_discrete hx)
+    with ⟨i, hi, hix⟩,
+  exact ⟨i, hi, subset.antisymm hix $ singleton_subset_iff.2 ⟨mem_of_nhds $ hb.mem_of_mem hi, hx⟩⟩
+end
+
+/-- A point `x` in a discrete subset `s` of a topological space admits a neighbourhood
+that only meets `s` at `x`.  -/
+lemma nhds_inter_eq_singleton_of_mem_discrete {s : set α} [discrete_topology s] {x : α} (hx : x ∈ s) :
+  ∃ U ∈ 𝓝 x, U ∩ s = {x} :=
+by simpa using (𝓝 x).basis_sets.exists_inter_eq_singleton_of_mem_discrete hx
 
 /-- For point `x` in a discrete subset `s` of a topological space, there is a set `U`
 such that
@@ -158,7 +175,7 @@ such that
 -/
 lemma disjoint_nhds_within_of_mem_discrete {s : set α} [discrete_topology s] {x : α} (hx : x ∈ s) :
   ∃ U ∈ 𝓝[{x}ᶜ] x, disjoint U s :=
-let ⟨V, h, h'⟩ := nhd_singleton_of_mem_discrete hx in ⟨{x}ᶜ ∩ V, inter_mem_nhds_within _ h,
+let ⟨V, h, h'⟩ := nhds_inter_eq_singleton_of_mem_discrete hx in ⟨{x}ᶜ ∩ V, inter_mem_nhds_within _ h,
   (disjoint_iff_inter_eq_empty.mpr (by { rw [inter_assoc, h', compl_inter_self] }))⟩
 
 /-- A T₂ space, also known as a Hausdorff space, is one in which for every

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -153,7 +153,7 @@ end
 
 /-- For point `x` in a discrete subset `s` of a topological space, there is a set `U`
 such that
-1. `U ∪ {x}` is a neighbourhood of `x`,
+1. `U` is a punctured neighborhood of `x` (ie. `U ∪ {x}` is a neighbourhood of `x`),
 2. `U` is disjoint from `s`.
 -/
 lemma disjoint_nhds_within_of_mem_discrete {s : set α} [discrete_topology s] {x : α} (hx : x ∈ s) :

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -139,6 +139,28 @@ begin
   exact is_closed_bUnion (finite.of_fintype _) (λ y _, is_closed_singleton)
 end
 
+/-- A point `x` in a discrete subset `s` of a topological space admits a neighbourhood
+that only meets `s` at `x`.  -/
+lemma nhd_singleton_of_mem_discrete {s : set α} [discrete_topology s] {x : α} (hx : x ∈ s) :
+∃ U ∈ 𝓝 x, U ∩ s = {x} :=
+begin
+  have : ({⟨x, hx⟩} : set s) ∈ 𝓝 (⟨x, hx⟩ : s), by simp [nhds_discrete],
+  rw [nhds_induced] at this,
+  rcases this with ⟨U, U_in, h⟩,
+  refine ⟨U, U_in, subset.antisymm _ (singleton_subset_iff.mpr ⟨mem_of_nhds U_in, hx⟩)⟩,
+  simpa only [image_singleton, subtype.image_preimage_coe] using image_subset (coe : s → α) h
+end
+
+/-- For point `x` in a discrete subset `s` of a topological space, there is a set `U`
+such that
+1. `U ∪ {x}` is a neighbourhood of `x`,
+2. `U` is disjoint from `s`.
+-/
+lemma disjoint_nhds_within_of_mem_discrete {s : set α} [discrete_topology s] {x : α} (hx : x ∈ s) :
+∃ U ∈ 𝓝[{x}ᶜ] x, disjoint U s :=
+let ⟨V, h, h'⟩ := nhd_singleton_of_mem_discrete hx in ⟨{x}ᶜ ∩ V, inter_mem_nhds_within _ h,
+  (disjoint_iff_inter_eq_empty.mpr (by { rw [inter_assoc, h', compl_inter_self] }))⟩
+
 /-- A T₂ space, also known as a Hausdorff space, is one in which for every
   `x ≠ y` there exists disjoint open sets around `x` and `y`. This is
   the most widely used of the separation axioms. -/

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -142,7 +142,7 @@ end
 /-- A point `x` in a discrete subset `s` of a topological space admits a neighbourhood
 that only meets `s` at `x`.  -/
 lemma nhd_singleton_of_mem_discrete {s : set α} [discrete_topology s] {x : α} (hx : x ∈ s) :
-∃ U ∈ 𝓝 x, U ∩ s = {x} :=
+  ∃ U ∈ 𝓝 x, U ∩ s = {x} :=
 begin
   have : ({⟨x, hx⟩} : set s) ∈ 𝓝 (⟨x, hx⟩ : s), by simp [nhds_discrete],
   rw [nhds_induced] at this,
@@ -157,7 +157,7 @@ such that
 2. `U` is disjoint from `s`.
 -/
 lemma disjoint_nhds_within_of_mem_discrete {s : set α} [discrete_topology s] {x : α} (hx : x ∈ s) :
-∃ U ∈ 𝓝[{x}ᶜ] x, disjoint U s :=
+  ∃ U ∈ 𝓝[{x}ᶜ] x, disjoint U s :=
 let ⟨V, h, h'⟩ := nhd_singleton_of_mem_discrete hx in ⟨{x}ᶜ ∩ V, inter_mem_nhds_within _ h,
   (disjoint_iff_inter_eq_empty.mpr (by { rw [inter_assoc, h', compl_inter_self] }))⟩
 


### PR DESCRIPTION
These lemmas form part of a simplification of the proofs of #5361.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
