### PR TITLE
feat(order/heyting_algebra): Heyting algebras

### DIFF
--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -132,7 +132,7 @@ lemma heyting_of_boolean_aux_aux {α}
   : x ≤ z :=
   calc
     x ≤ (y ⊓ (yᶜ ⊔ z)) : le_inf h_2 h_1
-    ... ≤ (y ⊓ yᶜ) ⊔ (y ⊓ z) : inf_sup_left.le
+    ... = (y ⊓ yᶜ) ⊔ (y ⊓ z) : inf_sup_left
     ... ≤ ((y ⊓ yᶜ) ⊔ z) : sup_le_sup_left inf_le_right (y ⊓ yᶜ)
     ... = ⊥ ⊔ z : by {congr, exact inf_compl_eq_bot}
     ... = z : by {exact bot_sup_eq}

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -6,36 +6,23 @@ Authors: Johannes Hölzl
 Type class hierarchy for Boolean algebras.
 -/
 import order.bounded_lattice
+import order.heyting_algebra
 
 set_option old_structure_cmd true
 
 universes u v
 variables {α : Type u} {w x y z : α}
 
-/-- Set / lattice complement -/
-class has_compl (α : Type*) := (compl : α → α)
-
-export has_compl (compl)
-
-postfix `ᶜ`:(max+1) := compl
-
 /-- A boolean algebra is a bounded distributive lattice with a
   complementation operation `-` such that `x ⊓ - x = ⊥` and `x ⊔ - x = ⊤`.
   This is a generalization of (classical) logic of propositions, or
   the powerset lattice. -/
-class boolean_algebra α extends bounded_distrib_lattice α, has_compl α, has_sdiff α :=
-(inf_compl_le_bot : ∀x:α, x ⊓ xᶜ ≤ ⊥)
+class boolean_algebra α extends heyting_algebra α, has_sdiff α :=
 (top_le_sup_compl : ∀x:α, ⊤ ≤ x ⊔ xᶜ)
 (sdiff_eq : ∀x y:α, x \ y = x ⊓ yᶜ)
 
 section boolean_algebra
 variables [boolean_algebra α]
-
-@[simp] theorem inf_compl_eq_bot : x ⊓ xᶜ = ⊥ :=
-bot_unique $ boolean_algebra.inf_compl_le_bot x
-
-@[simp] theorem compl_inf_eq_bot : xᶜ ⊓ x = ⊥ :=
-eq.trans inf_comm inf_compl_eq_bot
 
 @[simp] theorem sup_compl_eq_top : x ⊔ xᶜ = ⊤ :=
 top_unique $ boolean_algebra.top_le_sup_compl x
@@ -54,9 +41,6 @@ theorem disjoint_compl_left : disjoint xᶜ x := disjoint_compl_right.symm
 
 theorem sdiff_eq : x \ y = x ⊓ yᶜ :=
 boolean_algebra.sdiff_eq x y
-
-theorem compl_unique (i : x ⊓ y = ⊥) (s : x ⊔ y = ⊤) : xᶜ = y :=
-(is_compl.of_eq i s).compl_eq
 
 @[simp] theorem compl_top : ⊤ᶜ = (⊥:α) :=
 is_compl_top_bot.compl_eq
@@ -110,10 +94,12 @@ instance boolean_algebra_Prop : boolean_algebra Prop :=
 { compl := not,
   sdiff := λ p q, p ∧ ¬ q,
   sdiff_eq := λ _ _, rfl,
-  inf_compl_le_bot := λ p ⟨Hp, Hpc⟩, Hpc Hp,
   top_le_sup_compl := λ p H, classical.em p,
-  .. bounded_distrib_lattice_Prop }
+  .. heyting_algebra_prop }
 
 instance pi.boolean_algebra {α : Type u} {β : Type v} [boolean_algebra β] :
   boolean_algebra (α → β) :=
-by pi_instance
+  begin
+    pi_instance,
+    apply pi.heyting_algebra.imp_adjoint,
+  end

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -1,7 +1,8 @@
 /-
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Copyright (c) 2020 Chris Upshaw. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl
+Authors: Johannes Hölzl, Chris Upshaw
 
 Type class hierarchy for Boolean algebras.
 -/

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -17,9 +17,31 @@ variables {α : Type u} {w x y z : α}
   complementation operation `-` such that `x ⊓ - x = ⊥` and `x ⊔ - x = ⊤`.
   This is a generalization of (classical) logic of propositions, or
   the powerset lattice. -/
+
 class boolean_algebra α extends heyting_algebra α, has_sdiff α :=
 (top_le_sup_compl : ∀x:α, ⊤ ≤ x ⊔ xᶜ)
 (sdiff_eq : ∀x y:α, x \ y = x ⊓ yᶜ)
+
+
+
+instance boolean_from_compl (α : Type*) [inst_bdl : bounded_distrib_lattice α] [inst_c : has_compl α] [inst_s : has_sdiff α]
+  (sdiff_eq' : ∀x y:α, x \ y = x ⊓ yᶜ) (top_le_sup_compl' : ∀x:α, ⊤ ≤ x ⊔ xᶜ) :
+  boolean_algebra α :=
+  {
+    imp := λ x y, xᶜ ⊔ y,
+    imp_adjoint :=
+      begin
+        intros,
+        have h : ∀ x y, x ⇨ y = xᶜ ⊔ y := λ x y, begin unfold imp, end,
+        rw h,
+      end,
+    compl_eq := λ x, sup_bot_eq.symm,
+    top_le_sup_compl := top_le_sup_compl',
+    sdiff_eq := sdiff_eq',
+    .. inst_bdl,
+    .. inst_c,
+    .. inst_s
+  }
 
 section boolean_algebra
 variables [boolean_algebra α]

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -1,8 +1,7 @@
 /-
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
-Copyright (c) 2020 Chris Upshaw. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Chris Upshaw
+Authors: Johannes Hölzl
 
 Type class hierarchy for Boolean algebras.
 -/

--- a/src/order/heyting_algebra.lean
+++ b/src/order/heyting_algebra.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2020 Chris A. Upshaw. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris A. Upshaw.
+
+Type class hierarchy for Heyting algebras.
+-/
+import
+
+import order.bounded_lattice
+
+set_option old_structure_cmd true
+
+/-- Set / lattice complement -/
+class has_compl (α : Type*) := (compl : α → α)
+
+export has_compl (compl)
+
+postfix `ᶜ`:(max+1) := compl
+
+universes u v
+variables {α : Type u} {w x y z : α}
+
+class has_internal_imp (α : Type*) :=
+  (imp : α → α → α)
+
+infixr ` ⟶ `:60 := has_internal_imp.imp
+
+/-- A heyting algebra is a bounded distributive lattice with a
+  internal implication right adjoint to the meet. Equivently it is a
+  bounded distributive lattice with a psudo-complement `ᶜ` such that
+  `x ⊓ xᶜ = ⊥`, but not nessarily `x ⊔ xᶜ = ⊤`.
+  This is a generalization of the logic of propositions, or
+  the powerset lattice.-/
+class heyting_algebra α extends bounded_distrib_lattice α, has_compl α, has_internal_imp α :=
+  (imp_adjoint : ∀ a b c : α, a ⊓ b ≤ c ↔ a ≤ b ⟶ c)
+  (compl_from_imp : ∀ a : α, aᶜ = (a ⟶ ⊥))
+
+export heyting_algebra (imp_adjoint compl_from_imp)
+
+section heyting_algebra
+variables [heyting_algebra α]
+
+@[simp] lemma imp_refl : x ⟶ x = ⊤ :=
+  begin
+    rw le_antisymm_iff,
+    split,
+      {exact le_top},
+      {
+        rw ← imp_adjoint,
+        exact inf_le_right
+      },
+  end
+
+lemma imp_mp : x ⊓ (x ⟶ y) ≤ y :=
+  begin
+    rw inf_comm,
+    rw imp_adjoint,
+    reflexivity,
+  end
+
+lemma le_imp : x ≤ (y ⟶ x) :=
+  begin
+    rw ← imp_adjoint,
+    exact inf_le_left,
+  end
+
+@[simp]
+lemma imp_mp_simp : x ⊓ (x ⟶ y) = x ⊓ y :=
+  le_antisymm (le_inf inf_le_left imp_mp) (inf_le_inf (le_refl x) le_imp)
+
+lemma imp_app : (x ⟶ y) ⊓ x ≤ y :=
+  begin
+    rw inf_comm,
+    exact imp_mp
+  end
+
+@[simp]
+lemma imp_app_simp : (x ⟶ y) ⊓ x = y ⊓ x:=
+  le_antisymm (le_inf imp_app inf_le_right) (inf_le_inf le_imp rfl.ge)
+
+@[simp]
+lemma inf_compl_eq_bot : x ⊓ xᶜ = ⊥ :=
+  begin
+    rw compl_from_imp,
+    exact imp_mp_simp.trans inf_bot_eq,
+  end
+
+@[simp] theorem compl_inf_eq_bot : xᶜ ⊓ x = ⊥ :=
+  eq.trans inf_comm inf_compl_eq_bot
+
+-- if x has a boolean complement it is unique
+theorem compl_unique (i : x ⊓ y = ⊥) (s : x ⊔ y = ⊤) : xᶜ = y :=
+  begin
+    rw compl_from_imp,
+    apply le_antisymm,
+    {
+      transitivity (⊤ ⊓ (x ⟶ ⊥)),
+      have h : (x ⟶ ⊥) = ⊤ ⊓ (x ⟶ ⊥):= top_inf_eq.symm,
+      rw ← h,
+      reflexivity,
+      rw ← s,
+      rw inf_sup_right,
+      apply sup_le,
+      transitivity ⊥,
+      apply imp_mp,
+      exact bot_le,
+      apply inf_le_left,
+    },
+
+    {
+      rw ← imp_adjoint,
+      rw inf_comm,
+      rw i,
+    }
+
+  end
+end heyting_algebra
+
+instance has_internal_imp_prop : has_internal_imp Prop := ⟨λ x y, x → y⟩
+
+lemma imp_adjoint_prop (a b c : Prop) : (a ⊓ b ≤ c) ↔ (a ≤ b ⟶ c) :=
+  begin
+    unfold has_internal_imp.imp,
+    simp,
+    split; intros iff_hyp hyp; try {intro hyp_b}; apply iff_hyp;
+      try {cases hyp}; try {split}; assumption
+  end
+
+instance heyting_algebra_prop : heyting_algebra Prop :=
+  {
+    compl := not,
+    imp_adjoint := imp_adjoint_prop,
+    compl_from_imp := λ a, rfl,
+    ..has_internal_imp_prop,
+    ..bounded_distrib_lattice_Prop
+  }
+
+instance pi.heyting_algebra {α : Type u} {β : Type v} [heyting_algebra β] :
+  heyting_algebra (α → β) :=
+  begin
+    pi_instance,
+    intros,
+    simp only [],
+    transitivity ∀ i, (a i) ⊓ (b i) ≤ c i,
+    {
+      have inf_unfolded : ∀ i : α, (a ⊓ b) i = a i ⊓ b i := λ i, begin simp end,
+      split; intros hyp i;
+        try { rw inf_unfolded i}; try {rw ← inf_unfolded i};
+        exact hyp i,
+    },
+    symmetry,
+    transitivity (∀ i : α, a i ≤ heyting_algebra.imp (b i) (c i)),
+    {
+      have h : ∀ x : α → β, a ≤ x ↔ ∀ i, a i ≤ x i,
+        {
+          unfold_projs,
+          intros, split; intros a_le_x; apply a_le_x,
+        },
+      rw h,
+    },
+    have h : ∀ p q : α → Prop, (∀ i, p i ↔ q i) → ((∀ i, p i) ↔ (∀ i, q i))
+      := λ p q hyp, begin finish end,
+    rw h, clear h,
+    intros,
+    symmetry,
+    apply heyting_algebra.imp_adjoint,
+  end

--- a/src/order/heyting_algebra.lean
+++ b/src/order/heyting_algebra.lean
@@ -21,17 +21,9 @@ complement.
 
 ## Notation
 
- - `ᶜ` : Set / lattice complement
  - ` ⇨ ` : implication as an operator internal to a lattice.
 
 -/
-
-/-- Set / lattice complement -/
-class has_compl (α : Type*) := (compl : α → α)
-
-export has_compl (compl)
-
-postfix `ᶜ`:(max+1) := compl
 
 universes u v
 variables {α : Type u} {w x y z : α}
@@ -48,11 +40,10 @@ infixr ` ⇨ `:60 := has_internal_imp.imp
   This is a generalization of the logic of propositions and of open sets of a topology, though
   heyting algebra morphisms are distinct from images of continous functions.
   -/
-class heyting_algebra α extends bounded_distrib_lattice α, has_compl α, has_internal_imp α :=
+class heyting_algebra α extends bounded_distrib_lattice α, has_internal_imp α :=
   (imp_adjoint : ∀ x y z : α, x ⊓ y ≤ z ↔ x ≤ y ⇨ z)
-  (compl_eq : ∀ x : α, xᶜ = (x ⇨ ⊥))
 
-export heyting_algebra (imp_adjoint compl_eq)
+export heyting_algebra (imp_adjoint)
 
 section heyting_algebra
 variables [heyting_algebra α]
@@ -94,43 +85,6 @@ lemma imp_app : (x ⇨ y) ⊓ x ≤ y :=
 @[simp]
 lemma imp_inf_eq_left_inf : (x ⇨ y) ⊓ x = y ⊓ x:=
   le_antisymm (le_inf imp_app inf_le_right) (inf_le_inf le_internal_imp rfl.ge)
-
-@[simp]
-lemma inf_compl_eq_bot : x ⊓ xᶜ = ⊥ :=
-  begin
-    rw compl_eq,
-    exact inf_imp_eq_inf_left.trans inf_bot_eq,
-  end
-
-@[simp] theorem compl_inf_eq_bot : xᶜ ⊓ x = ⊥ :=
-  eq.trans inf_comm inf_compl_eq_bot
-
--- if x has a boolean complement it is unique
-theorem compl_unique (i : x ⊓ y = ⊥) (s : x ⊔ y = ⊤) : xᶜ = y :=
-  begin
-    rw compl_eq,
-    apply le_antisymm,
-    {
-      transitivity (⊤ ⊓ (x ⇨ ⊥)),
-      have h : (x ⇨ ⊥) = ⊤ ⊓ (x ⇨ ⊥):= top_inf_eq.symm,
-      rw ← h,
-      reflexivity,
-      rw ← s,
-      rw inf_sup_right,
-      apply sup_le,
-      transitivity ⊥,
-      apply internal_imp_mp,
-      exact bot_le,
-      apply inf_le_left,
-    },
-
-    {
-      rw ← imp_adjoint,
-      rw inf_comm,
-      rw i,
-    }
-
-  end
 end heyting_algebra
 
 instance has_internal_imp_prop : has_internal_imp Prop := ⟨λ x y, x → y⟩
@@ -145,9 +99,7 @@ lemma imp_adjoint_prop (a b c : Prop) : (a ⊓ b ≤ c) ↔ (a ≤ b ⇨ c) :=
 
 instance heyting_algebra_prop : heyting_algebra Prop :=
   {
-    compl := not,
     imp_adjoint := imp_adjoint_prop,
-    compl_eq := λ a, rfl,
     ..has_internal_imp_prop,
     ..bounded_distrib_lattice_Prop
   }


### PR DESCRIPTION

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

So this is a minimal change approche that doesn't move the definition of "has_compl" or change how a boolean algebra is defined. But also doesn't make a proper hierarchy. This is fine for working with just boolean and heyting algebras, but I think it will kind of fall apart if we try to extend it to co/bi heyting algebras.

However implementing that full hierarchy will require changing every single instance of boolean_algebra so is a significantly larger project.

This is my first pull request to an open source project, Alternative ideas, comments, missing lemmas are all welcome!

