### PR TITLE
[Merged by Bors] - feat(algebra/big_operators/nat_antidiagonal): add prod_antidiagonal_eq_prod_range_succ

### DIFF
--- a/src/algebra/big_operators/nat_antidiagonal.lean
+++ b/src/algebra/big_operators/nat_antidiagonal.lean
@@ -58,13 +58,8 @@ prod_congr rfl $ λ p hp, by rw [nat.mem_antidiagonal.1 hp]
 lemma prod_antidiagonal_eq_prod_range_succ {M : Type*} [comm_monoid M] (f : ℕ → ℕ → M) (n : ℕ) :
   ∏ ij in finset.nat.antidiagonal n, f ij.1 ij.2 = ∏ k in range n.succ, f k (n - k) :=
 begin
-  refine finset.prod_bij' (λ (ij : ℕ × ℕ) _, ij.1) _ _
-    (λ a _, (a, n - a) : Π (a : ℕ), a ∈ finset.range n.succ → ℕ × ℕ) _ _ _,
-  { rintro ⟨i, j⟩ ha, rw mem_antidiagonal at ha, simp [mem_range_succ_iff, nat.le.intro ha] },
-  { rintro ⟨i, j⟩ ha, rw mem_antidiagonal at ha, subst ha, congr', simp },
-  { intros a ha, rw mem_range_succ_iff at ha, rw mem_antidiagonal, exact nat.add_sub_of_le ha, },
-  { rintro ⟨i, j⟩ ha, rw mem_antidiagonal at ha, subst ha, congr', simp },
-  { rintros, refl },
+  convert prod_map _ ⟨λ i, (i, n - i), λ x y h, (prod.mk.inj h).1⟩ _,
+  refl,
 end
 
 end nat

--- a/src/algebra/big_operators/nat_antidiagonal.lean
+++ b/src/algebra/big_operators/nat_antidiagonal.lean
@@ -54,5 +54,19 @@ lemma prod_antidiagonal_subst {n : ℕ} {f : ℕ × ℕ → ℕ → M} :
   ∏ p in antidiagonal n, f p n = ∏ p in antidiagonal n, f p (p.1 + p.2) :=
 prod_congr rfl $ λ p hp, by rw [nat.mem_antidiagonal.1 hp]
 
+@[to_additive]
+lemma prod_antidiagonal_eq_prod_range_succ {M : Type*} [comm_monoid M] (f : ℕ → ℕ → M) (n : ℕ) :
+  ∏ ij in finset.nat.antidiagonal n, f ij.1 ij.2 = ∏ k in range n.succ, f k (n - k) :=
+begin
+  refine finset.prod_bij' (λ (ij : ℕ × ℕ) _, ij.1) _ _
+    (λ a _, (a, n - a) : Π (a : ℕ), a ∈ finset.range n.succ → ℕ × ℕ) _ _ _,
+  { rintro ⟨i, j⟩ ha, rw mem_antidiagonal at ha, simp [mem_range_succ_iff, nat.le.intro ha] },
+  { rintro ⟨i, j⟩ ha, rw mem_antidiagonal at ha, subst ha, congr', simp },
+  { intros a ha, rw mem_range_succ_iff at ha, rw mem_antidiagonal, exact nat.add_sub_of_le ha, },
+  { rintro ⟨i, j⟩ ha, rw mem_antidiagonal at ha, subst ha, congr', simp },
+  { rintros, refl },
+end
+
 end nat
+
 end finset

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1278,6 +1278,9 @@ range_succ
 
 theorem range_mono : monotone range := λ _ _, range_subset.2
 
+lemma mem_range_succ_iff {a b : ℕ} : a ∈ finset.range b.succ ↔ a ≤ b :=
+finset.mem_range.trans nat.lt_succ_iff
+
 end range
 
 /- useful rules for calculations with quantifiers -/


### PR DESCRIPTION
Sometimes summing over nat.antidiagonal is nicer than summing over range(n+1).

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
