### PR TITLE
[Merged by Bors] - feat(data/polynomial/erase_lead): add lemma erase_lead_card_support_eq

### DIFF
--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -102,7 +102,7 @@ lemma erase_lead_card_support {R : Type*} [semiring R] {c : ℕ} {f : polynomial
 begin
   by_cases f0 : f = 0,
   { rw [f0, support_zero, card_empty] at fc,
-    exact false.rec _ (nat.succ_ne_zero c fc.symm) },
+    exact (c.succ_ne_zero fc.symm).elim },
   { rw [erase_lead_support, card_erase_of_mem (nat_degree_mem_support_of_nonzero f0), fc],
     exact nat.pred_succ c },
 end

--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -96,8 +96,7 @@ begin
   exact card_lt_card (erase_ssubset $ nat_degree_mem_support_of_nonzero h)
 end
 
-lemma erase_lead_card_support {R : Type*} [semiring R] {c : ℕ} {f : polynomial R}
-  (fc : f.support.card = c) :
+lemma erase_lead_card_support {c : ℕ} (fc : f.support.card = c) :
   f.erase_lead.support.card = c - 1 :=
 begin
   by_cases f0 : f = 0,
@@ -105,6 +104,10 @@ begin
   { rw [erase_lead_support, card_erase_of_mem (nat_degree_mem_support_of_nonzero f0), fc],
     exact c.pred_eq_sub_one },
 end
+
+lemma erase_lead_card_support' {c : ℕ} (fc : f.support.card = c + 1) :
+  f.erase_lead.support.card = c :=
+erase_lead_card_support fc
 
 @[simp] lemma erase_lead_monomial (i : ℕ) (r : R) :
   erase_lead (monomial i r) = 0 :=

--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -97,17 +97,6 @@ begin
 end
 
 lemma erase_lead_card_support {R : Type*} [semiring R] {c : ℕ} {f : polynomial R}
-  (fc : f.support.card = c + 1) :
-  f.erase_lead.support.card = c :=
-begin
-  by_cases f0 : f = 0,
-  { rw [f0, support_zero, card_empty] at fc,
-    exact false.rec _ (nat.succ_ne_zero c fc.symm) },
-  { rw [erase_lead_support, card_erase_of_mem (nat_degree_mem_support_of_nonzero f0), fc],
-    exact nat.pred_succ c },
-end
-
-lemma erase_lead_card_support' {R : Type*} [semiring R] {c : ℕ} {f : polynomial R}
   (fc : f.support.card = c) :
   f.erase_lead.support.card = c - 1 :=
 begin

--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -114,7 +114,7 @@ begin
   by_cases f0 : f = 0,
   { rw [← fc, f0, erase_lead_zero, support_zero, card_empty] },
   { rw [erase_lead_support, card_erase_of_mem (nat_degree_mem_support_of_nonzero f0), fc],
-    exact nat.pred_eq_sub_one c },
+    exact c.pred_eq_sub_one },
 end
 
 @[simp] lemma erase_lead_monomial (i : ℕ) (r : R) :

--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -104,7 +104,7 @@ begin
   { rw [f0, support_zero, card_empty] at fc,
     exact (c.succ_ne_zero fc.symm).elim },
   { rw [erase_lead_support, card_erase_of_mem (nat_degree_mem_support_of_nonzero f0), fc],
-    exact nat.pred_succ c },
+    exact c.pred_succ },
 end
 
 lemma erase_lead_card_support' {R : Type*} [semiring R] {c : ℕ} {f : polynomial R}

--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -97,16 +97,24 @@ begin
 end
 
 lemma erase_lead_card_support {R : Type*} [semiring R] {c : ℕ} {f : polynomial R}
-  (f0 : f.support.card = c + 1) :
+  (fc : f.support.card = c + 1) :
   f.erase_lead.support.card = c :=
 begin
-  rw [erase_lead_support, card_erase_of_mem],
-  { exact nat.pred_eq_of_eq_succ f0 },
-  { rw nat_degree_eq_support_max',
-    refine f.support.max'_mem (nonempty_support_iff.mpr _),
-    rintro rfl,
-    rw [support_zero, card_empty] at f0,
-    exact (not_le.mpr c.succ_pos) f0.ge }
+  by_cases f0 : f = 0,
+  { rw [f0, support_zero, card_empty] at fc,
+    exact false.rec _ (nat.succ_ne_zero c fc.symm) },
+  { rw [erase_lead_support, card_erase_of_mem (nat_degree_mem_support_of_nonzero f0), fc],
+    exact nat.pred_succ c },
+end
+
+lemma erase_lead_card_support' {R : Type*} [semiring R] {c : ℕ} {f : polynomial R}
+  (fc : f.support.card = c) :
+  f.erase_lead.support.card = c - 1 :=
+begin
+  by_cases f0 : f = 0,
+  { rw [← fc, f0, erase_lead_zero, support_zero, card_empty] },
+  { rw [erase_lead_support, card_erase_of_mem (nat_degree_mem_support_of_nonzero f0), fc],
+    exact nat.pred_eq_sub_one c },
 end
 
 @[simp] lemma erase_lead_monomial (i : ℕ) (r : R) :

--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -96,6 +96,19 @@ begin
   exact card_lt_card (erase_ssubset $ nat_degree_mem_support_of_nonzero h)
 end
 
+lemma erase_lead_card_support_eq {R : Type*} [semiring R] {c : ℕ} {f : polynomial R}
+  (f0 : f.support.card = c.succ) :
+  f.erase_lead.support.card = c :=
+begin
+  rw [erase_lead_support, card_erase_of_mem],
+  { exact nat.pred_eq_of_eq_succ f0 },
+  { rw nat_degree_eq_support_max',
+    refine f.support.max'_mem (nonempty_support_iff.mpr _),
+    { rintro rfl,
+      rw [support_zero, card_empty] at f0,
+      exact (not_le.mpr (nat.succ_pos c)) (eq.ge f0) } }
+end
+
 @[simp] lemma erase_lead_monomial (i : ℕ) (r : R) :
   erase_lead (monomial i r) = 0 :=
 begin

--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -104,9 +104,9 @@ begin
   { exact nat.pred_eq_of_eq_succ f0 },
   { rw nat_degree_eq_support_max',
     refine f.support.max'_mem (nonempty_support_iff.mpr _),
-    { rintro rfl,
-      rw [support_zero, card_empty] at f0,
-      exact (not_le.mpr (nat.succ_pos c)) (eq.ge f0) } }
+    rintro rfl,
+    rw [support_zero, card_empty] at f0,
+    exact (not_le.mpr c.succ_pos) f0.ge }
 end
 
 @[simp] lemma erase_lead_monomial (i : ℕ) (r : R) :

--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -96,8 +96,8 @@ begin
   exact card_lt_card (erase_ssubset $ nat_degree_mem_support_of_nonzero h)
 end
 
-lemma erase_lead_card_support_eq {R : Type*} [semiring R] {c : ℕ} {f : polynomial R}
-  (f0 : f.support.card = c.succ) :
+lemma erase_lead_card_support {R : Type*} [semiring R] {c : ℕ} {f : polynomial R}
+  (f0 : f.support.card = c + 1) :
   f.erase_lead.support.card = c :=
 begin
   rw [erase_lead_support, card_erase_of_mem],


### PR DESCRIPTION
One further lemma to increase the API of `erase_lead`.  I use it to simplify the proof of the Liouville PR.  In particular, it is used in a step of the proof that you can "clear denominators" when evaluating a polynomial with integer coefficients at a rational number.