### PR TITLE
[Merged by Bors] - chore(number_theory/bernoulli): refactor definition of bernoulli

### DIFF
--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -39,7 +39,7 @@ To get the "minus" convention, just use `(-1)^n * bernoulli n`.
 There is no particular reason that the `+` convention was used.
 In some sense it's like choosing whether you want to sum over `fin n`
 (so `j < n`) or sum over `j ≤ n` (or `nat.antidagonal n`). Indeed
-$$(t+1)\sum_{j<n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
+$$(t+1)\sum_{j}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
 and
 $$(t+1)\sum_{j\leq n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{+}n^{t+1-k}.$$
 

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -38,7 +38,7 @@ To get the "minus" convention, just use `(-1)^n * bernoulli n`.
 
 There is no particular reason that the `+` convention was used.
 In some sense it's like choosing whether you want to sum over `fin n`
-(so `j < n`) or sum over `j ≤ n` (or `nat.antidagonal n`). Indeed
+(so `j < n`) or sum over `j ≤ n` (or `nat.antidiagonal n`). Indeed
 $$(t+1)\sum_{j\lt n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
 and
 $$(t+1)\sum_{j\leq n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{+}n^{t+1-k}.$$

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -47,7 +47,7 @@ $$(t+1)\sum_{j\leq n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{+}n^{t+1-k}.$$
 
 The Bernoulli numbers are defined using well-founded induction, by the formula
 $$B_n=1-\sum_{k\lt n}\frac{\binom{n}{k}}{n-k+1}B_k.$$
-This formula is true for all $$n$$ and in particular it implies that $$B_0=1$$.
+This formula is true for all $n$ and in particular $B_0=1$.
 
 ## Main theorems
 
@@ -55,11 +55,13 @@ This formula is true for all $$n$$ and in particular it implies that $$B_0=1$$.
 
 ## Todo
 
-`∑ k : fin n, n.binomial k * (-1)^k * bernoulli k = if n = 1 then 1 else 0`
+* `∑ k : fin n, n.binomial k * (-1)^k * bernoulli k = if n = 1 then 1 else 0`
 
-`∑ k : fin n, k ^ t =` some explicit Bernoulli polynomial B_t evaluated at n
+* Bernoulli polynomials
 
-`∑ k : fin n.succ, n.succ.choose k bernoulli_poly k X = n.succ * X ^ n` as polynomials
+* `∑ k : fin n, k ^ t =` the Bernoulli polynomial B_t evaluated at n
+
+* `∑ k : fin n.succ, n.succ.choose k bernoulli_poly k X = n.succ * X ^ n` as polynomials
 -/
 
 open_locale big_operators

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -39,7 +39,7 @@ To get the "minus" convention, just use `(-1)^n * bernoulli n`.
 There is no particular reason that the `+` convention was used.
 In some sense it's like choosing whether you want to sum over `fin n`
 (so `j < n`) or sum over `j ≤ n` (or `nat.antidagonal n`). Indeed
-$$(t+1)\sum_{j<n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
+$$(t+1)\sum_{j\lt n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
 and
 $$(t+1)\sum_{j\leq n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{+}n^{t+1-k}.$$
 

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -59,11 +59,11 @@ Setting `n = 0` we deduce that `bernoulli 0 = 1` and one can go on from there.
 
 ## Todo
 
-`∑ (k : fin n) n.binomial k * (-1)^k * bernoulli k = if n = 1 then 1 else 0`
+`∑ k : fin n, n.binomial k * (-1)^k * bernoulli k = if n = 1 then 1 else 0`
 
-`∑ (k : fin n) k ^ t =` some explicit Bernoulli polynomial B_t evaluated at n
+`∑ k : fin n, k ^ t =` some explicit Bernoulli polynomial B_t evaluated at n
 
-`∑ (k : fin n.succ) n.succ.choose k bernoulli_poly k X = n.succ * X ^ n` as polynomials
+`∑ k : fin n.succ, n.succ.choose k bernoulli_poly k X = n.succ * X ^ n` as polynomials
 -/
 
 open_locale big_operators

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -39,7 +39,7 @@ To get the "minus" convention, just use `(-1)^n * bernoulli n`.
 There is no particular reason that the `+` convention was used.
 In some sense it's like choosing whether you want to sum over `fin n`
 (so `j < n`) or sum over `j ≤ n` (or `nat.antidagonal n`). Indeed
-$$(t+1)\sum_{j\leq n-1}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
+$$(t+1)\sum_{j<n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
 and
 $$(t+1)\sum_{j\leq n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{+}n^{t+1-k}.$$
 

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johan Commelin
+Authors: Johan Commelin, Kevin Buzzard
 -/
 import data.rat
 import data.fintype.card
@@ -9,73 +9,131 @@ import data.fintype.card
 /-!
 # Bernoulli numbers
 
-The Bernoulli numbers are a sequence of numbers that frequently show up in number theory.
+The Bernoulli numbers are a sequence of rational numbers that frequently show up in
+number theory.
 
-For example, they show up in the Taylor series of many trigonometric and hyperbolic functions,
-and also as (integral multiples of products of powers of `π` and)
-special values of the Riemann zeta function.
-(Note: these facts are not yet available in mathlib)
+## Mathematical overview
 
-In this file, we provide the definition,
-and the basic fact (`sum_bernoulli`) that
-$$ \sum_{k < n} \binom{n}{k} * B_k = n, $$
-where $B_k$ denotes the the $k$-th Bernoulli number.
+The Bernoulli numbers $(B_0, B_1, B_2, \ldots)=(1, 1/2, 1/6, 0, -1/30, \ldots)$ are
+a sequence of rational numbers. They show up in the formula for the the sum
+of the first $n$ `k`th powers, they are related to the Taylor series of
+trigonometric and hyperbolic functions such as $x/tan(x)$, and also show up in the values
+that the Riemann Zeta function takes both at both negative and positive integers.
+For example If $1 \leq n$ is even then
 
+$$\zeta(2n)=\sum_{t\geq1}t^{-2n}=(-1)^{n+1}\frac{(2\pi)^{2n}B_{2n}}{2(2n)!}.$$
+
+Note however that this result is not yet formalised in Lean.
+
+The Bernoulli numbers can be formally defined using the power series
+
+$$\sum B_n\frac{t^n}{n!}=\frac{t}{1-e^{-t}}$$
+
+although that happens to not be the definition in mathlib (this is an *implementation
+detail* though, and need not concern the mathematician).
+
+Note that $B_1=+1/2$, meaning that we are using the $B_n^+$ of
+https://en.wikipedia.org/wiki/Bernoulli_number .
+To get the "minus" convention, just use `(-1)^n * bernoulli n`.
+
+## Implementation detail
+
+```
+def bernoulli : ℕ → ℚ :=
+well_founded.fix nat.lt_wf
+  (λ n bernoulli, 1 - ∑ k : fin n, (n.choose k) * bernoulli k k.2 / (n + 1 - k))
+```
+
+The formal definition has the property that `bernoulli 0 = 1`
+
+## Main theorems
+
+`sum_bernoulli : ∑ k in finset.range n, (n.choose k : ℚ) * bernoulli k = n`
+
+## Todo
+
+∑ (k : fin n) n.binomial k * (-1)^k * bernoulli k = if n = 1 then 1 else 0
+∑ (k : fin n) k ^ t = some explicit Bernoulli polynomial B_t evaluated at n
+∑ (k : fin n.succ) n.succ.choose k bernoulli_poly k X = n.succ * X ^ n as polynomials
 -/
 
 open_locale big_operators
+
+/-!
+
+### Definitions
+
+-/
 
 /-- The Bernoulli numbers:
 the $n$-th Bernoulli number $B_n$ is defined recursively via
 $$B_n = 1 - \sum_{k < n} \binom{n}{k}\frac{B_k}{n+1-k}$$ -/
 def bernoulli : ℕ → ℚ :=
 well_founded.fix nat.lt_wf
-  (λ n bernoulli, 1 - ∑ k : fin n, (n.choose k) * bernoulli k k.2 / (n + 1 - k))
+  (λ n bernoulli, 1 - ∑ k : fin n, n.choose k / (n - k + 1) * bernoulli k k.2)
 
 lemma bernoulli_def' (n : ℕ) :
-  bernoulli n = 1 - ∑ k : fin n, (n.choose k) * (bernoulli k) / (n + 1 - k) :=
+  bernoulli n = 1 - ∑ k : fin n, (n.choose k) / (n - k + 1) * bernoulli k :=
 well_founded.fix_eq _ _ _
 
 lemma bernoulli_def (n : ℕ) :
-  bernoulli n = 1 - ∑ k in finset.range n, (n.choose k) * (bernoulli k) / (n + 1 - k) :=
+  bernoulli n = 1 - ∑ k in finset.range n, (n.choose k) / (n - k + 1) * bernoulli k :=
 by { rw [bernoulli_def', ← fin.sum_univ_eq_sum_range], refl }
 
+/-!
+
+### Examples
+
+-/
+
+section examples
+
+open finset
+
 @[simp] lemma bernoulli_zero  : bernoulli 0 = 1   := rfl
+
 @[simp] lemma bernoulli_one   : bernoulli 1 = 1/2 :=
 begin
-  rw [bernoulli_def],
-  repeat { try { rw [finset.sum_range_succ] }, try { rw [nat.choose_succ_succ] }, simp, norm_num1 }
+    rw [bernoulli_def, sum_range_one], norm_num
 end
+
 @[simp] lemma bernoulli_two   : bernoulli 2 = 1/6 :=
 begin
-  rw [bernoulli_def],
-  repeat { try { rw [finset.sum_range_succ] }, try { rw [nat.choose_succ_succ] }, simp, norm_num1 }
+  rw [bernoulli_def, sum_range_succ, sum_range_one], norm_num
 end
+
 @[simp] lemma bernoulli_three : bernoulli 3 = 0   :=
 begin
-  rw [bernoulli_def],
-  repeat { try { rw [finset.sum_range_succ] }, try { rw [nat.choose_succ_succ] }, simp, norm_num1 }
+  rw [bernoulli_def, sum_range_succ, sum_range_succ, sum_range_one], norm_num
 end
+
 @[simp] lemma bernoulli_four  : bernoulli 4 = -1/30 :=
 begin
-  rw [bernoulli_def],
-  repeat { try { rw [finset.sum_range_succ] }, try { rw [nat.choose_succ_succ] }, simp, norm_num1 }
+  rw [bernoulli_def, sum_range_succ, sum_range_succ, sum_range_succ, sum_range_one],
+  rw (show nat.choose 4 2 = 6, from dec_trivial), -- shrug
+  norm_num,
 end
+
+end examples
+
+open nat
 
 @[simp] lemma sum_bernoulli (n : ℕ) :
   ∑ k in finset.range n, (n.choose k : ℚ) * bernoulli k = n :=
 begin
-  induction n with n ih, { simp },
-  rw [finset.sum_range_succ],
-  rw [nat.choose_succ_self_right],
-  rw [bernoulli_def, mul_sub, mul_one, sub_add_eq_add_sub, sub_eq_iff_eq_add],
-  rw [add_left_cancel_iff, finset.mul_sum, finset.sum_congr rfl],
-  intros k hk, rw finset.mem_range at hk,
-  rw [mul_div_right_comm, ← mul_assoc],
-  congr' 1,
-  rw [← mul_div_assoc, eq_div_iff],
-  { rw [mul_comm ((n+1 : ℕ) : ℚ)],
-    have hk' : k ≤ n + 1, by linarith,
-    rw_mod_cast nat.choose_mul_succ_eq n k },
-  { contrapose! hk with H, rw sub_eq_zero at H, norm_cast at H, linarith }
+  cases n with n, simp,
+  rw [finset.sum_range_succ, bernoulli_def],
+  suffices : (n + 1 : ℚ) * ∑ (k : ℕ) in finset.range n, (n.choose k : ℚ) / (n - k + 1) * bernoulli k
+    = ∑ (x : ℕ) in finset.range n, (n.succ.choose x : ℚ) * bernoulli x,
+  { rw [← this, nat.choose_succ_self_right], norm_cast, ring},
+  simp_rw [finset.mul_sum, ← mul_assoc],
+  apply finset.sum_congr rfl,
+  intros k hk, replace hk := le_of_lt (finset.mem_range.1 hk),
+  rw ← cast_sub hk,
+  congr',
+  field_simp [show ((n - k : ℕ) : ℚ) + 1 ≠ 0, by {norm_cast, simp}],
+  -- down to nat
+  norm_cast,
+  rw [mul_comm, nat.sub_add_eq_add_sub hk],
+  exact nat.choose_mul_succ_eq n k,
 end

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -130,7 +130,7 @@ open nat finset
 @[simp] lemma sum_bernoulli (n : ℕ) :
   ∑ k in finset.range n, (n.choose k : ℚ) * bernoulli k = n :=
 begin
-  cases n with n, simp,
+  cases n with n, { simp },
   rw [sum_range_succ, bernoulli_def],
   suffices : (n + 1 : ℚ) * ∑ k in range n, (n.choose k : ℚ) / (n - k + 1) * bernoulli k =
     ∑ x in range n, (n.succ.choose x : ℚ) * bernoulli x,

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -59,9 +59,9 @@ Setting `n = 0` we deduce that `bernoulli 0 = 1` and one can go on from there.
 
 ## Todo
 
-∑ (k : fin n) n.binomial k * (-1)^k * bernoulli k = if n = 1 then 1 else 0
-∑ (k : fin n) k ^ t = some explicit Bernoulli polynomial B_t evaluated at n
-∑ (k : fin n.succ) n.succ.choose k bernoulli_poly k X = n.succ * X ^ n as polynomials
+`∑ (k : fin n) n.binomial k * (-1)^k * bernoulli k = if n = 1 then 1 else 0`
+`∑ (k : fin n) k ^ t =` some explicit Bernoulli polynomial B_t evaluated at n
+`∑ (k : fin n.succ) n.succ.choose k bernoulli_poly k X = n.succ * X ^ n` as polynomials
 -/
 
 open_locale big_operators

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -39,7 +39,7 @@ To get the "minus" convention, just use `(-1)^n * bernoulli n`.
 There is no particular reason that the `+` convention was used.
 In some sense it's like choosing whether you want to sum over `fin n`
 (so `j < n`) or sum over `j ≤ n` (or `nat.antidagonal n`). Indeed
-$$(t+1)\sum_{j\lt n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
+$$(t+1)\sum_{j\leq n-1}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
 and
 $$(t+1)\sum_{j\leq n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{+}n^{t+1-k}.$$
 

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -36,6 +36,13 @@ Note that $B_1=+1/2$, meaning that we are using the $B_n^+$ of
 https://en.wikipedia.org/wiki/Bernoulli_number .
 To get the "minus" convention, just use `(-1)^n * bernoulli n`.
 
+There is no particular reason that the `+` convention was used.
+In some sense it's like choosing whether you want to sum over `fin n`
+(so `j < n`) or sum over `j ≤ n` (or `nat.antidagonal n`). Indeed
+$$(t+1)\sum_{j<n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
+and
+$$(t+1)\sum_{j\leq n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{+}n^{t+1-k}.$$
+
 ## Implementation detail
 
 ```
@@ -44,7 +51,7 @@ well_founded.fix nat.lt_wf
   (λ n bernoulli, 1 - ∑ k : fin n, (n.choose k) * bernoulli k k.2 / (n + 1 - k))
 ```
 
-Setting `n = 0` we deduce that `bernoulli 1 = 0` and one can go on from there.
+Setting `n = 0` we deduce that `bernoulli 0 = 1` and one can go on from there.
 
 ## Main theorems
 

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -19,7 +19,7 @@ a sequence of rational numbers. They show up in the formula for the sums of $k$t
 powers. They are related to the Taylor series expansions of $x/\tan(x)$ and
 of $\coth(x)$, and also show up in the values that the Riemann Zeta function
 takes both at both negative and positive integers (and hence in the
-theory of modular forms). For example If $1 \leq n$ is even then
+theory of modular forms). For example, if $1 \leq n$ is even then
 
 $$\zeta(2n)=\sum_{t\geq1}t^{-2n}=(-1)^{n+1}\frac{(2\pi)^{2n}B_{2n}}{2(2n)!}.$$
 

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -15,11 +15,11 @@ number theory.
 ## Mathematical overview
 
 The Bernoulli numbers $(B_0, B_1, B_2, \ldots)=(1, 1/2, 1/6, 0, -1/30, \ldots)$ are
-a sequence of rational numbers. They show up in the formula for the the sum
-of the first $n$ `k`th powers, they are related to the Taylor series of
-trigonometric and hyperbolic functions such as $x/tan(x)$, and also show up in the values
-that the Riemann Zeta function takes both at both negative and positive integers.
-For example If $1 \leq n$ is even then
+a sequence of rational numbers. They show up in the formula for the sums of $k$th
+powers. They are related to the Taylor series expansions of $x/\tan(x)$ and
+of $\coth(x)$, and also show up in the values that the Riemann Zeta function
+takes both at both negative and positive integers (and hence in the
+theory of modular forms). For example If $1 \leq n$ is even then
 
 $$\zeta(2n)=\sum_{t\geq1}t^{-2n}=(-1)^{n+1}\frac{(2\pi)^{2n}B_{2n}}{2(2n)!}.$$
 
@@ -44,7 +44,7 @@ well_founded.fix nat.lt_wf
   (λ n bernoulli, 1 - ∑ k : fin n, (n.choose k) * bernoulli k k.2 / (n + 1 - k))
 ```
 
-The formal definition has the property that `bernoulli 0 = 1`
+Setting `n = 0` we deduce that `bernoulli 1 = 0` and one can go on from there.
 
 ## Main theorems
 

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -45,13 +45,9 @@ $$(t+1)\sum_{j\leq n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{+}n^{t+1-k}.$$
 
 ## Implementation detail
 
-```
-def bernoulli : ℕ → ℚ :=
-well_founded.fix nat.lt_wf
-  (λ n bernoulli, 1 - ∑ k : fin n, (n.choose k) * bernoulli k k.2 / (n + 1 - k))
-```
-
-Setting `n = 0` we deduce that `bernoulli 0 = 1` and one can go on from there.
+The Bernoulli numbers are defined using well-founded induction, by the formula
+$$B_n=1-\sum_{k\lt n}\frac{\binom{n}{k}}{n-k+1}B_k.$$
+This formula is true for all $$n$$ and in particular it implies that $$B_0=1$$.
 
 ## Main theorems
 

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -39,7 +39,7 @@ To get the "minus" convention, just use `(-1)^n * bernoulli n`.
 There is no particular reason that the `+` convention was used.
 In some sense it's like choosing whether you want to sum over `fin n`
 (so `j < n`) or sum over `j ≤ n` (or `nat.antidagonal n`). Indeed
-$$(t+1)\sum_{j}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
+$$(t+1)\sum_{j\lt n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{-}n^{t+1-k}$$
 and
 $$(t+1)\sum_{j\leq n}j^t=\sum_{k\leq t}\binom{t+1}{k}B_k^{+}n^{t+1-k}.$$
 

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -60,7 +60,9 @@ Setting `n = 0` we deduce that `bernoulli 0 = 1` and one can go on from there.
 ## Todo
 
 `∑ (k : fin n) n.binomial k * (-1)^k * bernoulli k = if n = 1 then 1 else 0`
+
 `∑ (k : fin n) k ^ t =` some explicit Bernoulli polynomial B_t evaluated at n
+
 `∑ (k : fin n.succ) n.succ.choose k bernoulli_poly k X = n.succ * X ^ n` as polynomials
 -/
 

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -33,7 +33,7 @@ although that happens to not be the definition in mathlib (this is an *implement
 detail* though, and need not concern the mathematician).
 
 Note that $B_1=+1/2$, meaning that we are using the $B_n^+$ of
-https://en.wikipedia.org/wiki/Bernoulli_number .
+[from Wikipedia](https://en.wikipedia.org/wiki/Bernoulli_number).
 To get the "minus" convention, just use `(-1)^n * bernoulli n`.
 
 There is no particular reason that the `+` convention was used.

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -125,24 +125,24 @@ end
 
 end examples
 
-open nat
+open nat finset
 
 @[simp] lemma sum_bernoulli (n : ℕ) :
   ∑ k in finset.range n, (n.choose k : ℚ) * bernoulli k = n :=
 begin
   cases n with n, simp,
-  rw [finset.sum_range_succ, bernoulli_def],
-  suffices : (n + 1 : ℚ) * ∑ (k : ℕ) in finset.range n, (n.choose k : ℚ) / (n - k + 1) * bernoulli k
-    = ∑ (x : ℕ) in finset.range n, (n.succ.choose x : ℚ) * bernoulli x,
-  { rw [← this, nat.choose_succ_self_right], norm_cast, ring},
-  simp_rw [finset.mul_sum, ← mul_assoc],
-  apply finset.sum_congr rfl,
-  intros k hk, replace hk := le_of_lt (finset.mem_range.1 hk),
+  rw [sum_range_succ, bernoulli_def],
+  suffices : (n + 1 : ℚ) * ∑ k in range n, (n.choose k : ℚ) / (n - k + 1) * bernoulli k =
+    ∑ x in range n, (n.succ.choose x : ℚ) * bernoulli x,
+  { rw [← this, choose_succ_self_right], norm_cast, ring},
+  simp_rw [mul_sum, ← mul_assoc],
+  apply sum_congr rfl,
+  intros k hk, replace hk := le_of_lt (mem_range.1 hk),
   rw ← cast_sub hk,
   congr',
   field_simp [show ((n - k : ℕ) : ℚ) + 1 ≠ 0, by {norm_cast, simp}],
   -- down to nat
   norm_cast,
   rw [mul_comm, nat.sub_add_eq_add_sub hk],
-  exact nat.choose_mul_succ_eq n k,
+  exact choose_mul_succ_eq n k,
 end


### PR DESCRIPTION
A minor refactor of the definition of Bernoulli number, and I expanded the docstring.

---

I want to add more theorems about Bernoulli numbers but I thought I'd start by just "fixing" the definition. There's no point having binomial * bernoulli / another natural, you often want to just pull the bernoulli out and replace it with something else, or cancel it. These things are delicate. I even considered `∑ k : fin n, ((n - k) + k).choose k / ...` for a while, which does have advantages, but decided it was small swings and roundabouts here once you've got the hang of `apply finset.sum_congr rfl`, and I figured it was probably best to stick to the way which didn't look insane.

<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
