### PR TITLE
[Merged by Bors] - feat(tactic/simps): some improvements

### DIFF
--- a/src/algebra/category/Algebra/limits.lean
+++ b/src/algebra/category/Algebra/limits.lean
@@ -88,10 +88,10 @@ begin
   refine is_limit.of_faithful
     (forget (Algebra R)) (types.limit_cone_is_limit _)
     (λ s, { .. }) (λ s, rfl),
-  { simp only [forget_map_eq_coe, alg_hom.map_one, functor.map_cone_π], refl, },
-  { intros x y, simp only [forget_map_eq_coe, alg_hom.map_mul, functor.map_cone_π], refl, },
-  { simp only [forget_map_eq_coe, alg_hom.map_zero, functor.map_cone_π], refl, },
-  { intros x y, simp only [forget_map_eq_coe, alg_hom.map_add, functor.map_cone_π], refl, },
+  { simp only [forget_map_eq_coe, alg_hom.map_one, functor.map_cone_π_app], refl, },
+  { intros x y, simp only [forget_map_eq_coe, alg_hom.map_mul, functor.map_cone_π_app], refl, },
+  { simp only [forget_map_eq_coe, alg_hom.map_zero, functor.map_cone_π_app], refl, },
+  { intros x y, simp only [forget_map_eq_coe, alg_hom.map_add, functor.map_cone_π_app], refl, },
   { intros r, ext j, exact (s.π.app j).commutes r,  },
 end
 

--- a/src/algebra/category/Group/basic.lean
+++ b/src/algebra/category/Group/basic.lean
@@ -198,13 +198,13 @@ namespace category_theory.iso
 
 /-- Build a `mul_equiv` from an isomorphism in the category `Group`. -/
 @[to_additive AddGroup_iso_to_add_equiv "Build an `add_equiv` from an isomorphism in the category
-`AddGroup`.", simps {rhs_md := semireducible}]
+`AddGroup`.", simps]
 def Group_iso_to_mul_equiv {X Y : Group} (i : X ≅ Y) : X ≃* Y :=
 i.hom.to_mul_equiv i.inv i.hom_inv_id i.inv_hom_id
 
 /-- Build a `mul_equiv` from an isomorphism in the category `CommGroup`. -/
 @[to_additive AddCommGroup_iso_to_add_equiv "Build an `add_equiv` from an isomorphism
-in the category `AddCommGroup`.", simps {rhs_md := semireducible}]
+in the category `AddCommGroup`.", simps]
 def CommGroup_iso_to_mul_equiv {X Y : CommGroup} (i : X ≅ Y) : X ≃* Y :=
 i.hom.to_mul_equiv i.inv i.hom_inv_id i.inv_hom_id
 

--- a/src/algebra/category/Group/limits.lean
+++ b/src/algebra/category/Group/limits.lean
@@ -264,7 +264,7 @@ end
 The categorical kernel inclusion for `f : G ⟶ H`, as an object over `G`,
 agrees with the `subtype` map.
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def kernel_iso_ker_over {G H : AddCommGroup.{u}} (f : G ⟶ H) :
   over.mk (kernel.ι f) ≅ @over.mk _ _ G (AddCommGroup.of f.ker) (add_subgroup.subtype f.ker) :=
 over.iso_mk (kernel_iso_ker f) (by simp)

--- a/src/algebraic_geometry/presheafed_space/has_colimits.lean
+++ b/src/algebraic_geometry/presheafed_space/has_colimits.lean
@@ -252,7 +252,7 @@ def colimit_cocone_is_colimit (F : J ⥤ PresheafedSpace C) : is_colimit (colimi
     have t : m.base = colimit.desc (F ⋙ PresheafedSpace.forget C) ((PresheafedSpace.forget C).map_cocone s),
     { ext,
       dsimp,
-      simp only [colimit.ι_desc_apply, map_cocone_ι],
+      simp only [colimit.ι_desc_apply, map_cocone_ι_app],
       rw ← w j,
       simp, },
     fapply PresheafedSpace.ext, -- could `ext` please not reorder goals?

--- a/src/category_theory/Fintype.lean
+++ b/src/category_theory/Fintype.lean
@@ -40,7 +40,7 @@ instance {X : Fintype} : fintype X := X.2
 instance : category Fintype := induced_category.category bundled.α
 
 /-- The fully faithful embedding of `Fintype` into the category of types. -/
-@[derive [full, faithful], simps {rhs_md:=semireducible}]
+@[derive [full, faithful], simps]
 def incl : Fintype ⥤ Type* := induced_functor _
 
 instance : concrete_category Fintype := ⟨incl⟩

--- a/src/category_theory/adjunction/basic.lean
+++ b/src/category_theory/adjunction/basic.lean
@@ -351,7 +351,7 @@ def left_adjoint_of_equiv : C ⥤ D :=
 
 /-- Show that the functor given by `left_adjoint_of_equiv` is indeed left adjoint to `G`. Dual
 to `adjunction_of_equiv_right`. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def adjunction_of_equiv_left : left_adjoint_of_equiv e he ⊣ G :=
 mk_of_hom_equiv
 { hom_equiv := e,
@@ -390,7 +390,7 @@ def right_adjoint_of_equiv : D ⥤ C :=
 
 /-- Show that the functor given by `right_adjoint_of_equiv` is indeed right adjoint to `F`. Dual
 to `adjunction_of_equiv_left`. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def adjunction_of_equiv_right : F ⊣ right_adjoint_of_equiv e he :=
 mk_of_hom_equiv
 { hom_equiv := e,
@@ -419,7 +419,7 @@ def to_equivalence (adj : F ⊣ G) [∀ X, is_iso (adj.unit.app X)] [∀ Y, is_i
 If the unit and counit for the adjunction corresponding to a right adjoint functor are (pointwise)
 isomorphisms, then the functor is an equivalence of categories.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def is_right_adjoint_to_is_equivalence [is_right_adjoint G]
   [∀ X, is_iso ((adjunction.of_right_adjoint G).unit.app X)]
   [∀ Y, is_iso ((adjunction.of_right_adjoint G).counit.app Y)] :

--- a/src/category_theory/adjunction/lifting.lean
+++ b/src/category_theory/adjunction/lifting.lean
@@ -126,7 +126,7 @@ noncomputable def construct_left_adjoint_obj (Y : B) : A :=
 coequalizer (F'.map (U.map (adj₁.counit.app Y))) (other_map _ _ adj₁ adj₂ Y)
 
 /-- The homset equivalence which helps show that `R` is a right adjoint. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 noncomputable
 def construct_left_adjoint_equiv [∀ (X : B), regular_epi (adj₁.counit.app X)] (Y : A) (X : B) :
   (construct_left_adjoint_obj _ _ adj₁ adj₂ X ⟶ Y) ≃ (X ⟶ R.obj Y) :=

--- a/src/category_theory/adjunction/lifting.lean
+++ b/src/category_theory/adjunction/lifting.lean
@@ -126,7 +126,7 @@ noncomputable def construct_left_adjoint_obj (Y : B) : A :=
 coequalizer (F'.map (U.map (adj₁.counit.app Y))) (other_map _ _ adj₁ adj₂ Y)
 
 /-- The homset equivalence which helps show that `R` is a right adjoint. -/
-@[simps]
+@[simps {rhs_md := semireducible}]
 noncomputable
 def construct_left_adjoint_equiv [∀ (X : B), regular_epi (adj₁.counit.app X)] (Y : A) (X : B) :
   (construct_left_adjoint_obj _ _ adj₁ adj₂ X ⟶ Y) ≃ (X ⟶ R.obj Y) :=

--- a/src/category_theory/currying.lean
+++ b/src/category_theory/currying.lean
@@ -89,7 +89,7 @@ def curry : ((C × D) ⥤ E) ⥤ (C ⥤ (D ⥤ E)) :=
 /--
 The equivalence of functor categories given by currying/uncurrying.
 -/
-@[simps {rhs_md := semireducible}] -- create projection simp lemmas even though this isn't a `{ .. }`.
+@[simps] -- create projection simp lemmas even though this isn't a `{ .. }`.
 def currying : (C ⥤ (D ⥤ E)) ≌ ((C × D) ⥤ E) :=
 equivalence.mk uncurry curry
   (nat_iso.of_components (λ F, nat_iso.of_components

--- a/src/category_theory/equivalence.lean
+++ b/src/category_theory/equivalence.lean
@@ -272,7 +272,7 @@ by { dsimp [inv_fun_id_assoc], tidy }
 by { dsimp [inv_fun_id_assoc], tidy }
 
 /-- If `C` is equivalent to `D`, then `C ⥤ E` is equivalent to `D ⥤ E`. -/
-@[simps functor inverse unit_iso counit_iso {rhs_md:=semireducible}]
+@[simps functor inverse unit_iso counit_iso]
 def congr_left (e : C ≌ D) : (C ⥤ E) ≌ (D ⥤ E) :=
 equivalence.mk
   ((whiskering_left _ _ _).obj e.inverse)
@@ -281,7 +281,7 @@ equivalence.mk
   (nat_iso.of_components (λ F, e.inv_fun_id_assoc F) (by tidy))
 
 /-- If `C` is equivalent to `D`, then `E ⥤ C` is equivalent to `E ⥤ D`. -/
-@[simps functor inverse unit_iso counit_iso {rhs_md:=semireducible}]
+@[simps functor inverse unit_iso counit_iso]
 def congr_right (e : C ≌ D) : (E ⥤ C) ≌ (E ⥤ D) :=
 equivalence.mk
   ((whiskering_right _ _ _).obj e.functor)

--- a/src/category_theory/essential_image.lean
+++ b/src/category_theory/essential_image.lean
@@ -68,7 +68,7 @@ lemma obj_mem_ess_image (F : D ⥤ C) (Y : D) : F.obj Y ∈ ess_image F := ⟨Y,
 instance : category F.ess_image := category_theory.full_subcategory _
 
 /-- The essential image as a subcategory has a fully faithful inclusion into the target category. -/
-@[derive [full, faithful], simps {rhs_md := semireducible}]
+@[derive [full, faithful], simps]
 def ess_image_inclusion (F : C ⥤ D) : F.ess_image ⥤ D :=
 full_subcategory_inclusion _
 
@@ -85,7 +85,7 @@ def to_ess_image (F : C ⥤ D) : C ⥤ F.ess_image :=
 The functor `F` factorises through its essential image, where the first functor is essentially
 surjective and the second is fully faithful.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def to_ess_image_comp_essential_image_inclusion :
   F.to_ess_image ⋙ F.ess_image_inclusion ≅ F :=
 nat_iso.of_components (λ X, iso.refl _) (by tidy)

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -163,7 +163,7 @@ def equiv (F : J ⥤ C) : cocone F ≅ Σ X, F.cocones.obj X :=
 { app := λ X f, c.ι ≫ (const J).map f }
 
 /-- A map from the vertex of a cocone induces a cocone by composition. -/
-@[simps] def extend (c : cocone F) {X : C} (f : c.X ⟶ X) : cocone F :=
+@[simp] def extend (c : cocone F) {X : C} (f : c.X ⟶ X) : cocone F :=
 { X := X,
   ι := c.extensions.app X f }
 

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -20,9 +20,6 @@ open category_theory.category
 open category_theory.functor
 open opposite
 
-set_option trace.simps.verbose true
--- set_option trace.simps.debug true
-
 namespace category_theory
 
 namespace functor

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -25,12 +25,14 @@ namespace category_theory
 namespace functor
 variables {J C} (F : J ⥤ C)
 
+set_option trace.simps.verbose true
+
 /--
 `F.cones` is the functor assigning to an object `X` the type of
 natural transformations from the constant functor with value `X` to `F`.
 An object representing this functor is a limit of `F`.
 -/
-def cones : Cᵒᵖ ⥤ Type v := (const J).op ⋙ (yoneda.obj F)
+@[simps map_app {rhs_md := semireducible, type_md := tactic.transparency.all}] def cones : Cᵒᵖ ⥤ Type v := (const J).op ⋙ (yoneda.obj F)
 
 lemma cones_obj (X : Cᵒᵖ) : F.cones.obj X = ((const J).obj (unop X) ⟶ F) := rfl
 

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -167,6 +167,10 @@ def equiv (F : J ⥤ C) : cocone F ≅ Σ X, F.cocones.obj X :=
 { X := X,
   ι := c.extensions.app X f }
 
+@[simp] lemma extend_ι (c : cocone F) {X : C} (f : c.X ⟶ X) :
+  (extend c f).ι = c.extensions.app X f :=
+rfl
+
 /--
 Whisker a cocone by precomposition of a functor. See `whiskering` for a functorial
 version.

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -758,6 +758,8 @@ def cocone_left_op_of_cone (c : cone F) : cocone (F.left_op) :=
 -- set_option pp.structure_projections false
 
 /-- Change a cone on `F.left_op : Jᵒᵖ ⥤ C` to a cocone on `F : J ⥤ Cᵒᵖ`. -/
+-- When trying to generate the `ι_app` field of this definition, `@[simps]` tries to reduce the RHS
+-- using `expr.dsimp` and `expr.simp`, but for some reason the expression is not reduced enough.
 @[simps X] -- @[simps {rhs_md := semireducible, simp_rhs := tt}]
 def cocone_of_cone_left_op (c : cone F.left_op) : cocone F :=
 { X := op c.X,
@@ -788,15 +790,12 @@ def cocone_of_cone_left_op (c : cone F.left_op) : cocone F :=
   (cocone_of_cone_left_op c).ι.app j = (c.π.app (op j)).op :=
 by { dsimp [cocone_of_cone_left_op], simp }
 
-
+-- set_option trace.simps.verbose true
 /-- Change a cocone on `F : J ⥤ Cᵒᵖ` to a cone on `F.left_op : Jᵒᵖ ⥤ C`. -/
-@[simps X] def cone_left_op_of_cocone (c : cocone F) : cone (F.left_op) :=
+@[simps {rhs_md := semireducible, simp_rhs := tt}]
+def cone_left_op_of_cocone (c : cocone F) : cone (F.left_op) :=
 { X := unop c.X,
   π := nat_trans.left_op c.ι }
-
-@[simp] lemma cone_left_op_of_cocone_π_app (c : cocone F) (j) :
-  (cone_left_op_of_cocone c).π.app j = (c.ι.app (unop j)).unop :=
-by { dsimp [cone_left_op_of_cocone], simp }
 
 end
 

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -564,7 +564,7 @@ def map_cocone_inv_map_cocone {F : J ⥤ D} (H : D ⥤ C) [is_equivalence H] (c 
 (limits.cocones.functoriality_equivalence F (as_equivalence H)).unit_iso.symm.app c
 
 /-- `functoriality F _ ⋙ postcompose (whisker_left F _)` simplifies to `functoriality F _`. -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def functoriality_comp_postcompose {H H' : C ⥤ D} (α : H ≅ H') :
   cones.functoriality F H ⋙ cones.postcompose (whisker_left F α.hom) ≅ cones.functoriality F H' :=
 nat_iso.of_components (λ c, cones.ext (α.app _) (by tidy)) (by tidy)
@@ -574,7 +574,7 @@ For `F : J ⥤ C`, given a cone `c : cone F`, and a natural isomorphism `α : H 
 `H H' : C ⥤ D`, the postcomposition of the cone `H.map_cone` using the isomorphism `α` is
 isomorphic to the cone `H'.map_cone`.
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def postcompose_whisker_left_map_cone {H H' : C ⥤ D} (α : H ≅ H') (c : cone F) :
   (cones.postcompose (whisker_left F α.hom : _)).obj (H.map_cone c) ≅ H'.map_cone c :=
 (functoriality_comp_postcompose α).app c
@@ -584,7 +584,7 @@ def postcompose_whisker_left_map_cone {H H' : C ⥤ D} (α : H ≅ H') (c : cone
 natural transformation `α : F ⟶ G` and a functor `H : C ⥤ D`, we have two obvious ways of producing
 a cone over `G ⋙ H`, and they are both isomorphic.
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def map_cone_postcompose {α : F ⟶ G} {c} :
   H.map_cone ((cones.postcompose α).obj c) ≅
   (cones.postcompose (whisker_right α H : _)).obj (H.map_cone c) :=
@@ -593,14 +593,14 @@ cones.ext (iso.refl _) (by tidy)
 /--
 `map_cone` commutes with `postcompose_equivalence`
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def map_cone_postcompose_equivalence_functor {α : F ≅ G} {c} :
   H.map_cone ((cones.postcompose_equivalence α).functor.obj c) ≅
     (cones.postcompose_equivalence (iso_whisker_right α H : _)).functor.obj (H.map_cone c) :=
 cones.ext (iso.refl _) (by tidy)
 
 /-- `functoriality F _ ⋙ precompose (whisker_left F _)` simplifies to `functoriality F _`. -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def functoriality_comp_precompose {H H' : C ⥤ D} (α : H ≅ H') :
    cocones.functoriality F H ⋙ cocones.precompose (whisker_left F α.inv)
  ≅ cocones.functoriality F H' :=
@@ -611,7 +611,7 @@ For `F : J ⥤ C`, given a cocone `c : cocone F`, and a natural isomorphism `α 
 `H H' : C ⥤ D`, the precomposition of the cocone `H.map_cocone` using the isomorphism `α` is
 isomorphic to the cocone `H'.map_cocone`.
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def precompose_whisker_left_map_cocone {H H' : C ⥤ D} (α : H ≅ H') (c : cocone F) :
   (cocones.precompose (whisker_left F α.inv : _)).obj (H.map_cocone c) ≅ H'.map_cocone c :=
 (functoriality_comp_precompose α).app c
@@ -621,7 +621,7 @@ def precompose_whisker_left_map_cocone {H H' : C ⥤ D} (α : H ≅ H') (c : coc
 `c : cocone F`, a natural transformation `α : F ⟶ G` and a functor `H : C ⥤ D`, we have two obvious
 ways of producing a cocone over `G ⋙ H`, and they are both isomorphic.
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def map_cocone_precompose {α : F ⟶ G} {c} :
   H.map_cocone ((cocones.precompose α).obj c) ≅
   (cocones.precompose (whisker_right α H : _)).obj (H.map_cocone c) :=
@@ -630,7 +630,7 @@ cocones.ext (iso.refl _) (by tidy)
 /--
 `map_cocone` commutes with `precompose_equivalence`
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def map_cocone_precompose_equivalence_functor {α : F ≅ G} {c} :
   H.map_cocone ((cocones.precompose_equivalence α).functor.obj c) ≅
     (cocones.precompose_equivalence (iso_whisker_right α H : _)).functor.obj (H.map_cocone c) :=
@@ -641,7 +641,7 @@ variables {K : Type v} [small_category K]
 /--
 `map_cone` commutes with `whisker`
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def map_cone_whisker {E : K ⥤ J} {c : cone F} :
   H.map_cone (c.whisker E) ≅ (H.map_cone c).whisker E :=
 cones.ext (iso.refl _) (by tidy)
@@ -649,7 +649,7 @@ cones.ext (iso.refl _) (by tidy)
 /--
 `map_cocone` commutes with `whisker`
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def map_cocone_whisker {E : K ⥤ J} {c : cocone F} :
   H.map_cocone (c.whisker E) ≅ (H.map_cocone c).whisker E :=
 cocones.ext (iso.refl _) (by tidy)

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -20,7 +20,7 @@ open category_theory.category
 open category_theory.functor
 open opposite
 
--- set_option trace.simps.verbose true
+set_option trace.simps.verbose true
 -- set_option trace.simps.debug true
 
 namespace category_theory
@@ -33,21 +33,16 @@ variables {J C} (F : J ⥤ C)
 natural transformations from the constant functor with value `X` to `F`.
 An object representing this functor is a limit of `F`.
 -/
-@[simps map_app {rhs_md := semireducible, type_md := semireducible, simp_rhs := tt}]
+@[simps]
 def cones : Cᵒᵖ ⥤ Type v := (const J).op ⋙ (yoneda.obj F)
-
-lemma cones_obj (X : Cᵒᵖ) : F.cones.obj X = ((const J).obj (unop X) ⟶ F) := rfl
-
 
 /--
 `F.cocones` is the functor assigning to an object `X` the type of
 natural transformations from `F` to the constant functor with value `X`.
 An object corepresenting this functor is a colimit of `F`.
 -/
-@[simps map_app {rhs_md := semireducible, type_md := semireducible, simp_rhs := tt}]
+@[simps]
 def cocones : C ⥤ Type v := const J ⋙ coyoneda.obj (op F)
-
-lemma cocones_obj (X : C) : F.cocones.obj X = (F ⟶ (const J).obj X) := rfl
 
 end functor
 
@@ -280,7 +275,7 @@ def whiskering_equivalence {K : Type v} [small_category K] (e : K ≌ J) :
 The categories of cones over `F` and `G` are equivalent if `F` and `G` are naturally isomorphic
 (possibly after changing the indexing category by an equivalence).
 -/
-@[simps functor_obj {rhs_md := semireducible, simp_rhs := tt}]
+@[simps functor_obj]
 def equivalence_of_reindexing {K : Type v} [small_category K] {G : K ⥤ C}
   (e : K ≌ J) (α : e.functor ⋙ F ≅ G) : cone F ≌ cone G :=
 (whiskering_equivalence e).trans (postcompose_equivalence α)
@@ -441,7 +436,7 @@ def whiskering_equivalence {K : Type v} [small_category K] (e : K ≌ J) :
 The categories of cocones over `F` and `G` are equivalent if `F` and `G` are naturally isomorphic
 (possibly after changing the indexing category by an equivalence).
 -/
-@[simps functor_obj {rhs_md := semireducible, simp_rhs := tt}]
+@[simps functor_obj]
 def equivalence_of_reindexing {K : Type v} [small_category K] {G : K ⥤ C}
   (e : K ≌ J) (α : e.functor ⋙ F ≅ G) : cocone F ≌ cocone G :=
 (whiskering_equivalence e).trans (precompose_equivalence α.symm)
@@ -523,10 +518,10 @@ variables {F : J ⥤ C} {G : J ⥤ C} (H : C ⥤ D)
 open category_theory.limits
 
 /-- The image of a cone in C under a functor G : C ⥤ D is a cone in D. -/
-@[simps {rhs_md := semireducible, simp_rhs := tt}]
+@[simps]
 def map_cone   (c : cone F)   : cone (F ⋙ H)   := (cones.functoriality F H).obj c
 /-- The image of a cocone in C under a functor G : C ⥤ D is a cocone in D. -/
-@[simps {rhs_md := semireducible, simp_rhs := tt}]
+@[simps]
 def map_cocone (c : cocone F) : cocone (F ⋙ H) := (cocones.functoriality F H).obj c
 
 /-- Given a cone morphism `c ⟶ c'`, construct a cone morphism on the mapped cones functorially.  -/
@@ -755,46 +750,19 @@ def cocone_left_op_of_cone (c : cone F) : cocone (F.left_op) :=
 { X := unop c.X,
   ι := nat_trans.left_op c.π }
 
--- local attribute [simp] comp_id
--- set_option trace.simps.debug true
--- set_option pp.implicit true
--- set_option pp.notation false
--- set_option pp.structure_projections false
-
 /-- Change a cone on `F.left_op : Jᵒᵖ ⥤ C` to a cocone on `F : J ⥤ Cᵒᵖ`. -/
--- When trying to generate the `ι_app` field of this definition, `@[simps]` tries to reduce the RHS
--- using `expr.dsimp` and `expr.simp`, but for some reason the expression is not reduced enough.
-@[simps X] -- @[simps {rhs_md := semireducible, simp_rhs := tt}]
+/- When trying use `@[simps]` to generate the `ι_app` field of this definition, `@[simps]` tries to
+  reduce the RHS using `expr.dsimp` and `expr.simp`, but for some reason the expression is not
+  being simplified properly. -/
+@[simps X]
 def cocone_of_cone_left_op (c : cone F.left_op) : cocone F :=
 { X := op c.X,
   ι := nat_trans.remove_left_op ((const.op_obj_unop (op c.X)).hom ≫ c.π) }
-
--- lemma cocone_of_cone_left_op_ι_app' (c : cone F.left_op) (X : J) :
---   (@nat_trans.app Jᵒᵖ (@category.opposite J _inst_1) C _inst_2
---    ((@const J _inst_1 Cᵒᵖ (@category.opposite C _inst_2)).obj (@op C c.X)).left_op
---    F.left_op
---    ((@const.op_obj_unop J _inst_1 C _inst_2 (@op C c.X)).hom ≫ c.π)
---    (@op J X)).op = sorry :=
--- by { dsimp, simp, }
-
--- -- set_option pp.all true
--- lemma cocone_of_cone_left_op_ι_app'' (c : cone F.left_op) (X : J) :
---   @category_struct.comp (opposite C) (@to_category_struct (opposite C) (@category.opposite C _inst_2)) (F.obj X)
---   (@op C c.X)
---   (@op C c.X)
---   (@nat_trans.app (opposite J) (@category.opposite J _inst_1) C _inst_2
---      ((@const J _inst_1 (opposite C) (@category.opposite C _inst_2)).obj (@op C c.X)).left_op
---      F.left_op
---      c.π
---      (@op J X)).op
---   (@category_struct.id (opposite C) (@to_category_struct (opposite C) (@category.opposite C _inst_2)) (@op C c.X)) = sorry :=
--- by {  simp, }
 
 @[simp] lemma cocone_of_cone_left_op_ι_app (c : cone F.left_op) (j) :
   (cocone_of_cone_left_op c).ι.app j = (c.π.app (op j)).op :=
 by { dsimp [cocone_of_cone_left_op], simp }
 
--- set_option trace.simps.verbose true
 /-- Change a cocone on `F : J ⥤ Cᵒᵖ` to a cone on `F.left_op : Jᵒᵖ ⥤ C`. -/
 @[simps {rhs_md := semireducible, simp_rhs := tt}]
 def cone_left_op_of_cocone (c : cocone F) : cone (F.left_op) :=

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -20,36 +20,34 @@ open category_theory.category
 open category_theory.functor
 open opposite
 
+-- set_option trace.simps.verbose true
+-- set_option trace.simps.debug true
+
 namespace category_theory
 
 namespace functor
 variables {J C} (F : J ⥤ C)
-
-set_option trace.simps.verbose true
 
 /--
 `F.cones` is the functor assigning to an object `X` the type of
 natural transformations from the constant functor with value `X` to `F`.
 An object representing this functor is a limit of `F`.
 -/
-@[simps map_app {rhs_md := semireducible, type_md := tactic.transparency.all}] def cones : Cᵒᵖ ⥤ Type v := (const J).op ⋙ (yoneda.obj F)
+@[simps map_app {rhs_md := semireducible, type_md := semireducible, simp_rhs := tt}]
+def cones : Cᵒᵖ ⥤ Type v := (const J).op ⋙ (yoneda.obj F)
 
 lemma cones_obj (X : Cᵒᵖ) : F.cones.obj X = ((const J).obj (unop X) ⟶ F) := rfl
 
-@[simp] lemma cones_map_app {X₁ X₂ : Cᵒᵖ} (f : X₁ ⟶ X₂) (t : F.cones.obj X₁) (j : J) :
-  (F.cones.map f t).app j = f.unop ≫ t.app j := rfl
 
 /--
 `F.cocones` is the functor assigning to an object `X` the type of
 natural transformations from `F` to the constant functor with value `X`.
 An object corepresenting this functor is a colimit of `F`.
 -/
+@[simps map_app {rhs_md := semireducible, type_md := semireducible, simp_rhs := tt}]
 def cocones : C ⥤ Type v := const J ⋙ coyoneda.obj (op F)
 
 lemma cocones_obj (X : C) : F.cocones.obj X = (F ⟶ (const J).obj X) := rfl
-
-@[simp] lemma cocones_map_app {X₁ X₂ : C} (f : X₁ ⟶ X₂) (t : F.cocones.obj X₁) (j : J) :
-  (F.cocones.map f t).app j = t.app j ≫ f := rfl
 
 end functor
 
@@ -165,13 +163,9 @@ def equiv (F : J ⥤ C) : cocone F ≅ Σ X, F.cocones.obj X :=
 { app := λ X f, c.ι ≫ (const J).map f }
 
 /-- A map from the vertex of a cocone induces a cocone by composition. -/
-@[simp] def extend (c : cocone F) {X : C} (f : c.X ⟶ X) : cocone F :=
+@[simps] def extend (c : cocone F) {X : C} (f : c.X ⟶ X) : cocone F :=
 { X := X,
   ι := c.extensions.app X f }
-
-@[simp] lemma extend_ι  (c : cocone F) {X : C} (f : c.X ⟶ X) :
-  (extend c f).ι = c.extensions.app X f :=
-rfl
 
 /--
 Whisker a cocone by precomposition of a functor. See `whiskering` for a functorial
@@ -282,16 +276,10 @@ def whiskering_equivalence {K : Type v} [small_category K] (e : K ≌ J) :
 The categories of cones over `F` and `G` are equivalent if `F` and `G` are naturally isomorphic
 (possibly after changing the indexing category by an equivalence).
 -/
+@[simps functor_obj {rhs_md := semireducible, simp_rhs := tt}]
 def equivalence_of_reindexing {K : Type v} [small_category K] {G : K ⥤ C}
   (e : K ≌ J) (α : e.functor ⋙ F ≅ G) : cone F ≌ cone G :=
 (whiskering_equivalence e).trans (postcompose_equivalence α)
-
-@[simp]
-lemma equivalence_of_reindexing_functor_obj {K : Type v} [small_category K] {G : K ⥤ C}
-  (e : K ≌ J) (α : e.functor ⋙ F ≅ G) (c : cone F) :
-  (equivalence_of_reindexing e α).functor.obj c =
-  (postcompose α.hom).obj (cone.whisker e.functor c) :=
-rfl
 
 section
 variable (F)
@@ -449,16 +437,10 @@ def whiskering_equivalence {K : Type v} [small_category K] (e : K ≌ J) :
 The categories of cocones over `F` and `G` are equivalent if `F` and `G` are naturally isomorphic
 (possibly after changing the indexing category by an equivalence).
 -/
+@[simps functor_obj {rhs_md := semireducible, simp_rhs := tt}]
 def equivalence_of_reindexing {K : Type v} [small_category K] {G : K ⥤ C}
   (e : K ≌ J) (α : e.functor ⋙ F ≅ G) : cocone F ≌ cocone G :=
 (whiskering_equivalence e).trans (precompose_equivalence α.symm)
-
-@[simp]
-lemma equivalence_of_reindexing_functor_obj {K : Type v} [small_category K] {G : K ⥤ C}
-  (e : K ≌ J) (α : e.functor ⋙ F ≅ G) (c : cocone F) :
-  (equivalence_of_reindexing e α).functor.obj c =
-  (precompose α.inv).obj (cocone.whisker e.functor c) :=
-rfl
 
 section
 variable (F)
@@ -537,12 +519,11 @@ variables {F : J ⥤ C} {G : J ⥤ C} (H : C ⥤ D)
 open category_theory.limits
 
 /-- The image of a cone in C under a functor G : C ⥤ D is a cone in D. -/
+@[simps {rhs_md := semireducible, simp_rhs := tt}]
 def map_cone   (c : cone F)   : cone (F ⋙ H)   := (cones.functoriality F H).obj c
 /-- The image of a cocone in C under a functor G : C ⥤ D is a cocone in D. -/
+@[simps {rhs_md := semireducible, simp_rhs := tt}]
 def map_cocone (c : cocone F) : cocone (F ⋙ H) := (cocones.functoriality F H).obj c
-
-@[simp] lemma map_cone_X (c : cone F) : (H.map_cone c).X = H.obj c.X := rfl
-@[simp] lemma map_cocone_X (c : cocone F) : (H.map_cocone c).X = H.obj c.X := rfl
 
 /-- Given a cone morphism `c ⟶ c'`, construct a cone morphism on the mapped cones functorially.  -/
 def map_cone_morphism   {c c' : cone F}   (f : c ⟶ c')   :
@@ -550,11 +531,6 @@ def map_cone_morphism   {c c' : cone F}   (f : c ⟶ c')   :
 /-- Given a cocone morphism `c ⟶ c'`, construct a cocone morphism on the mapped cocones functorially.  -/
 def map_cocone_morphism {c c' : cocone F} (f : c ⟶ c') :
   H.map_cocone c ⟶ H.map_cocone c' := (cocones.functoriality F H).map f
-
-@[simp] lemma map_cone_π (c : cone F) (j : J) :
-  (map_cone H c).π.app j = H.map (c.π.app j) := rfl
-@[simp] lemma map_cocone_ι (c : cocone F) (j : J) :
-  (map_cocone H c).ι.app j = H.map (c.ι.app j) := rfl
 
 /-- If `H` is an equivalence, we invert `H.map_cone` and get a cone for `F` from a cone
 for `F ⋙ H`.-/
@@ -764,31 +740,54 @@ variables {F : J ⥤ Cᵒᵖ}
 /-- Change a cocone on `F.left_op : Jᵒᵖ ⥤ C` to a cocone on `F : J ⥤ Cᵒᵖ`. -/
 -- Here and below we only automatically generate the `@[simp]` lemma for the `X` field,
 -- as we can write a simpler `rfl` lemma for the components of the natural transformation by hand.
-@[simps X] def cone_of_cocone_left_op (c : cocone F.left_op) : cone F :=
+@[simps {rhs_md := semireducible, simp_rhs := tt}]
+def cone_of_cocone_left_op (c : cocone F.left_op) : cone F :=
 { X := op c.X,
   π := nat_trans.remove_left_op (c.ι ≫ (const.op_obj_unop (op c.X)).hom) }
 
-@[simp] lemma cone_of_cocone_left_op_π_app (c : cocone F.left_op) (j) :
-  (cone_of_cocone_left_op c).π.app j = (c.ι.app (op j)).op :=
-by { dsimp [cone_of_cocone_left_op], simp }
-
 /-- Change a cone on `F : J ⥤ Cᵒᵖ` to a cocone on `F.left_op : Jᵒᵖ ⥤ C`. -/
-@[simps X] def cocone_left_op_of_cone (c : cone F) : cocone (F.left_op) :=
+@[simps {rhs_md := semireducible, simp_rhs := tt}]
+def cocone_left_op_of_cone (c : cone F) : cocone (F.left_op) :=
 { X := unop c.X,
   ι := nat_trans.left_op c.π }
 
-@[simp] lemma cocone_left_op_of_cone_ι_app (c : cone F) (j) :
-  (cocone_left_op_of_cone c).ι.app j = (c.π.app (unop j)).unop :=
-by { dsimp [cocone_left_op_of_cone], simp }
+-- local attribute [simp] comp_id
+-- set_option trace.simps.debug true
+-- set_option pp.implicit true
+-- set_option pp.notation false
+-- set_option pp.structure_projections false
 
 /-- Change a cone on `F.left_op : Jᵒᵖ ⥤ C` to a cocone on `F : J ⥤ Cᵒᵖ`. -/
-@[simps X] def cocone_of_cone_left_op (c : cone F.left_op) : cocone F :=
+@[simps X] -- @[simps {rhs_md := semireducible, simp_rhs := tt}]
+def cocone_of_cone_left_op (c : cone F.left_op) : cocone F :=
 { X := op c.X,
   ι := nat_trans.remove_left_op ((const.op_obj_unop (op c.X)).hom ≫ c.π) }
+
+-- lemma cocone_of_cone_left_op_ι_app' (c : cone F.left_op) (X : J) :
+--   (@nat_trans.app Jᵒᵖ (@category.opposite J _inst_1) C _inst_2
+--    ((@const J _inst_1 Cᵒᵖ (@category.opposite C _inst_2)).obj (@op C c.X)).left_op
+--    F.left_op
+--    ((@const.op_obj_unop J _inst_1 C _inst_2 (@op C c.X)).hom ≫ c.π)
+--    (@op J X)).op = sorry :=
+-- by { dsimp, simp, }
+
+-- -- set_option pp.all true
+-- lemma cocone_of_cone_left_op_ι_app'' (c : cone F.left_op) (X : J) :
+--   @category_struct.comp (opposite C) (@to_category_struct (opposite C) (@category.opposite C _inst_2)) (F.obj X)
+--   (@op C c.X)
+--   (@op C c.X)
+--   (@nat_trans.app (opposite J) (@category.opposite J _inst_1) C _inst_2
+--      ((@const J _inst_1 (opposite C) (@category.opposite C _inst_2)).obj (@op C c.X)).left_op
+--      F.left_op
+--      c.π
+--      (@op J X)).op
+--   (@category_struct.id (opposite C) (@to_category_struct (opposite C) (@category.opposite C _inst_2)) (@op C c.X)) = sorry :=
+-- by {  simp, }
 
 @[simp] lemma cocone_of_cone_left_op_ι_app (c : cone F.left_op) (j) :
   (cocone_of_cone_left_op c).ι.app j = (c.π.app (op j)).op :=
 by { dsimp [cocone_of_cone_left_op], simp }
+
 
 /-- Change a cocone on `F : J ⥤ Cᵒᵖ` to a cone on `F.left_op : Jᵒᵖ ⥤ C`. -/
 @[simps X] def cone_left_op_of_cocone (c : cocone F) : cone (F.left_op) :=

--- a/src/category_theory/limits/fubini.lean
+++ b/src/category_theory/limits/fubini.lean
@@ -235,16 +235,13 @@ begin
   exact limit_uncurry_iso_limit_comp_lim ((@curry J _ K _ C _).obj G),
 end
 
-@[simp,reassoc]
+@[simp, reassoc]
 lemma limit_iso_limit_curry_comp_lim_hom_π_π {j} {k} :
   (limit_iso_limit_curry_comp_lim G).hom ≫ limit.π _ j ≫ limit.π _ k = limit.π _ (j, k) :=
-begin
-  dsimp [limit_iso_limit_curry_comp_lim, is_limit.cone_point_unique_up_to_iso,
-    is_limit.unique_up_to_iso],
-  simp, dsimp, simp, -- See note [dsimp, simp].
-end
+by simp [limit_iso_limit_curry_comp_lim, is_limit.cone_point_unique_up_to_iso,
+  is_limit.unique_up_to_iso]
 
-@[simp,reassoc]
+@[simp, reassoc]
 lemma limit_iso_limit_curry_comp_lim_inv_π {j} {k} :
   (limit_iso_limit_curry_comp_lim G).inv ≫ limit.π _ (j, k) = limit.π _ j ≫ limit.π _ k :=
 begin

--- a/src/category_theory/limits/presheaf.lean
+++ b/src/category_theory/limits/presheaf.lean
@@ -56,7 +56,7 @@ In the case where `ℰ = Cᵒᵖ ⥤ Type u` and `A = yoneda`, this functor is i
 
 Defined as in [MM92], Chapter I, Section 5, Theorem 2.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def restricted_yoneda : ℰ ⥤ (Cᵒᵖ ⥤ Type u₁) :=
 yoneda ⋙ (whiskering_left _ _ (Type u₁)).obj (functor.op A)
 

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -90,14 +90,14 @@ def map_pair : F ⟶ G := { app := λ j, walking_pair.cases_on j f g }
 @[simp] lemma map_pair_right : (map_pair f g).app right = g := rfl
 
 /-- The natural isomorphism between two functors out of the walking pair, specified by its components. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def map_pair_iso (f : F.obj left ≅ G.obj left) (g : F.obj right ≅ G.obj right) : F ≅ G :=
 nat_iso.of_components (λ j, walking_pair.cases_on j f g) (by tidy)
 
 end
 
 /-- Every functor out of the walking pair is naturally isomorphic (actually, equal) to a `pair` -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def diagram_iso_pair (F : discrete walking_pair ⥤ C) :
   F ≅ pair (F.obj walking_pair.left) (F.obj walking_pair.right) :=
 map_pair_iso (iso.refl _) (iso.refl _)

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -769,9 +769,10 @@ variables {C} [split_mono f]
 A split mono `f` equalizes `(retraction f ≫ f)` and `(𝟙 Y)`.
 Here we build the cone, and show in `split_mono_equalizes` that it is a limit cone.
 -/
-@[simps]
+@[simps {rhs_md := semireducible}]
 def cone_of_split_mono : cone (parallel_pair (𝟙 Y) (retraction f ≫ f)) :=
 fork.of_ι f (by simp)
+
 
 /--
 A split mono `f` equalizes `(retraction f ≫ f)` and `(𝟙 Y)`.
@@ -792,7 +793,7 @@ variables {C} [split_epi f]
 A split epi `f` coequalizes `(f ≫ section_ f)` and `(𝟙 X)`.
 Here we build the cocone, and show in `split_epi_coequalizes` that it is a colimit cocone.
 -/
-@[simps]
+@[simps {rhs_md := semireducible}]
 def cocone_of_split_epi : cocone (parallel_pair (𝟙 X) (f ≫ section_ f)) :=
 cofork.of_π f (by simp)
 

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -125,7 +125,7 @@ end
 
 /-- Every functor indexing a (co)equalizer is naturally isomorphic (actually, equal) to a
     `parallel_pair` -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def diagram_iso_parallel_pair (F : walking_parallel_pair ⥤ C) :
   F ≅ parallel_pair (F.map left) (F.map right) :=
 nat_iso.of_components (λ j, eq_to_iso $ by cases j; tidy) $ by tidy
@@ -769,7 +769,7 @@ variables {C} [split_mono f]
 A split mono `f` equalizes `(retraction f ≫ f)` and `(𝟙 Y)`.
 Here we build the cone, and show in `split_mono_equalizes` that it is a limit cone.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def cone_of_split_mono : cone (parallel_pair (𝟙 Y) (retraction f ≫ f)) :=
 fork.of_ι f (by simp)
 
@@ -792,7 +792,7 @@ variables {C} [split_epi f]
 A split epi `f` coequalizes `(f ≫ section_ f)` and `(𝟙 X)`.
 Here we build the cocone, and show in `split_epi_coequalizes` that it is a colimit cocone.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def cocone_of_split_epi : cocone (parallel_pair (𝟙 X) (f ≫ section_ f)) :=
 cofork.of_π f (by simp)
 

--- a/src/category_theory/limits/shapes/split_coequalizer.lean
+++ b/src/category_theory/limits/shapes/split_coequalizer.lean
@@ -87,7 +87,7 @@ section
 open limits
 
 /-- A split coequalizer clearly induces a cofork. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def is_split_coequalizer.as_cofork {Z : C} {h : Y ⟶ Z} (t : is_split_coequalizer f g h) :
   cofork f g :=
 cofork.of_π h t.condition

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -66,7 +66,7 @@ open category_theory.limits.walking_pair
 /-- The product type `X × Y` forms a cone for the binary product of `X` and `Y`. -/
 -- We manually generate the other projection lemmas since the simp-normal form for the legs is
 -- otherwise not created correctly.
-@[simps X {rhs_md := semireducible}]
+@[simps X]
 def binary_product_cone (X Y : Type u) : binary_fan X Y :=
 binary_fan.mk prod.fst prod.snd
 
@@ -95,7 +95,9 @@ def binary_product_limit_cone (X Y : Type u) : limits.limit_cone (pair X Y) :=
 ⟨_, binary_product_limit X Y⟩
 
 /-- The functor which sends `X, Y` to the product type `X × Y`. -/
-@[simps]
+-- We add the option `type_md` to tell `@[simps]` to not treat homomorphisms `X ⟶ Y` in `Type*` as
+-- a function type
+@[simps {type_md := reducible}]
 def binary_product_functor : Type u ⥤ Type u ⥤ Type u :=
 { obj := λ X,
   { obj := λ Y, X × Y,
@@ -121,7 +123,7 @@ begin
 end
 
 /-- The sum type `X ⊕ Y` forms a cocone for the binary coproduct of `X` and `Y`. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def binary_coproduct_cocone (X Y : Type u) : cocone (pair X Y) :=
 binary_cofan.mk sum.inl sum.inr
 

--- a/src/category_theory/monad/algebra.lean
+++ b/src/category_theory/monad/algebra.lean
@@ -112,7 +112,7 @@ instance [inhabited C] : inhabited (algebra T) :=
     cf Lemma 5.2.8 of [Riehl][riehl2017]. -/
 -- The other two `simps` projection lemmas can be derived from these two, so `simp_nf` complains if
 -- those are added too
-@[simps unit counit {rhs_md := semireducible}]
+@[simps unit counit]
 def adj : free T ⊣ forget T :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ X Y,
@@ -229,7 +229,7 @@ for a comonad.
 -/
 -- The other two `simps` projection lemmas can be derived from these two, so `simp_nf` complains if
 -- those are added too
-@[simps unit counit {rhs_md := semireducible}]
+@[simps unit counit]
 def adj : forget G ⊣ cofree G :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ X Y,

--- a/src/category_theory/monad/algebra.lean
+++ b/src/category_theory/monad/algebra.lean
@@ -112,7 +112,7 @@ instance [inhabited C] : inhabited (algebra T) :=
     cf Lemma 5.2.8 of [Riehl][riehl2017]. -/
 -- The other two `simps` projection lemmas can be derived from these two, so `simp_nf` complains if
 -- those are added too
-@[simps unit counit]
+@[simps unit counit {rhs_md := semireducible}]
 def adj : free T ⊣ forget T :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ X Y,

--- a/src/category_theory/monad/coequalizer.lean
+++ b/src/category_theory/monad/coequalizer.lean
@@ -34,7 +34,7 @@ Show that any algebra is a coequalizer of free algebras.
 -/
 
 /-- The top map in the coequalizer diagram we will construct. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def free_coequalizer.top_map : (monad.free T).obj (T.obj X.A) ⟶ (monad.free T).obj X.A :=
 (monad.free T).map X.a
 
@@ -70,7 +70,7 @@ end
 Construct the Beck cofork in the category of algebras. This cofork is reflexive as well as a
 coequalizer.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def beck_algebra_cofork : cofork (free_coequalizer.top_map X) (free_coequalizer.bottom_map X) :=
 cofork.of_π _ (free_coequalizer.condition X)
 
@@ -101,7 +101,7 @@ def beck_split_coequalizer : is_split_coequalizer (T.map X.a) ((μ_ T).app _) X.
 ⟨(η_ T).app _, (η_ T).app _, X.assoc.symm, X.unit, monad.left_unit _, ((η_ T).naturality _).symm⟩
 
 /-- This is the Beck cofork. It is a split coequalizer, in particular a coequalizer. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def beck_cofork : cofork (T.map X.a) ((μ_ T).app _) :=
 (beck_split_coequalizer X).as_cofork
 

--- a/src/category_theory/monad/limits.lean
+++ b/src/category_theory/monad/limits.lean
@@ -180,7 +180,7 @@ algebra T :=
   begin
     apply is_colimit.hom_ext (preserves_colimit.preserves (preserves_colimit.preserves t)),
     intro j,
-    erw [← category.assoc, nat_trans.naturality (μ_ T), ← functor.map_cocone_ι, category.assoc,
+    erw [← category.assoc, nat_trans.naturality (μ_ T), ← functor.map_cocone_ι_app, category.assoc,
          is_colimit.fac _ (new_cocone c) j],
     rw ← category.assoc,
     erw [← functor.map_comp, commuting],

--- a/src/category_theory/monad/monadicity.lean
+++ b/src/category_theory/monad/monadicity.lean
@@ -90,7 +90,7 @@ coequalizer (F .map A.a) (adj .counit.app _)
 We have a bijection of homsets which will be used to construct the left adjoint to the comparison
 functor.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def comparison_left_adjoint_hom_equiv (A : algebra (F ⋙ G)) (B : D)
   [has_coequalizer (F .map A.a) (adj .counit.app (F .obj A.A))] :
   (comparison_left_adjoint_obj A ⟶ B) ≃ (A ⟶ (comparison G).obj B) :=
@@ -132,7 +132,7 @@ end
 /--
 Provided we have the appropriate coequalizers, we have an adjunction to the comparison functor.
 -/
-@[simps counit {rhs_md := semireducible}]
+@[simps counit]
 def comparison_adjunction
   [∀ (A : algebra (F ⋙ G)), has_coequalizer (F .map A.a) (adj .counit.app (F .obj A.A))] :
   left_adjoint_comparison ⊣ comparison G :=
@@ -149,7 +149,7 @@ congr_arg (adj .hom_equiv _ _) (category.comp_id _)
 This is a cofork which is helpful for establishing monadicity: the morphism from the Beck
 coequalizer to this cofork is the unit for the adjunction on the comparison functor.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def unit_cofork (A : algebra (F ⋙ G))
   [has_coequalizer (F .map A.a) (adj .counit.app (F .obj A.A))] :
   cofork (G.map (F .map A.a)) (G.map (adj .counit.app (F .obj A.A))) :=
@@ -177,7 +177,7 @@ end
 The cofork which describes the counit of the adjunction: the morphism from the coequalizer of
 this pair to this morphism is the counit.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def counit_cofork (B : D) :
   cofork (F .map (G.map (adj .counit.app B))) (adj .counit.app (F .obj (G.obj B))) :=
 cofork.of_π (adj .counit.app B) (adj .counit_naturality _)

--- a/src/category_theory/monoidal/CommMon_.lean
+++ b/src/category_theory/monoidal/CommMon_.lean
@@ -134,7 +134,7 @@ def CommMon_to_lax_braided : CommMon_ C ⥤ lax_braided_functor (discrete punit)
     tensor' := λ _ _, f.mul_hom, }, }
 
 /-- Implementation of `CommMon_.equiv_lax_braided_functor_punit`. -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def unit_iso :
   𝟭 (lax_braided_functor (discrete punit) C) ≅ lax_braided_to_CommMon C ⋙ CommMon_to_lax_braided C :=
 nat_iso.of_components (λ F, lax_braided_functor.mk_iso
@@ -144,7 +144,7 @@ nat_iso.of_components (λ F, lax_braided_functor.mk_iso
   (by tidy)
 
 /-- Implementation of `CommMon_.equiv_lax_braided_functor_punit`. -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def counit_iso : CommMon_to_lax_braided C ⋙ lax_braided_to_CommMon C ≅ 𝟭 (CommMon_ C) :=
 nat_iso.of_components (λ F, { hom := { hom := 𝟙 _, }, inv := { hom := 𝟙 _, } })
   (by tidy)

--- a/src/category_theory/monoidal/Mon_.lean
+++ b/src/category_theory/monoidal/Mon_.lean
@@ -242,7 +242,7 @@ def Mon_to_lax_monoidal : Mon_ C ⥤ lax_monoidal_functor (discrete punit) C :=
     tensor' := λ _ _, f.mul_hom, }, }
 
 /-- Implementation of `Mon_.equiv_lax_monoidal_functor_punit`. -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def unit_iso :
   𝟭 (lax_monoidal_functor (discrete punit) C) ≅ lax_monoidal_to_Mon C ⋙ Mon_to_lax_monoidal C :=
 nat_iso.of_components (λ F,
@@ -252,7 +252,7 @@ nat_iso.of_components (λ F,
   (by tidy)
 
 /-- Implementation of `Mon_.equiv_lax_monoidal_functor_punit`. -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def counit_iso : Mon_to_lax_monoidal C ⋙ lax_monoidal_to_Mon C ≅ 𝟭 (Mon_ C) :=
 nat_iso.of_components (λ F, { hom := { hom := 𝟙 _, }, inv := { hom := 𝟙 _, } })
   (by tidy)

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -165,7 +165,7 @@ variables {U V W X Y Z : C}
 -- monoidal_category.pentagon monoidal_category.triangle
 
 -- tensor_comp_id tensor_id_comp comp_id_tensor_tensor_id
--- triangle_assoc_comp_left triangle_assoc_comp_right 
+-- triangle_assoc_comp_left triangle_assoc_comp_right
 -- triangle_assoc_comp_left_inv triangle_assoc_comp_right_inv
 -- left_unitor_tensor left_unitor_tensor_inv
 -- right_unitor_tensor right_unitor_tensor_inv
@@ -445,7 +445,7 @@ def tensor_unit_right : C ⥤ C :=
 -- as natural isomorphisms.
 
 /-- The associator as a natural isomorphism. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def associator_nat_iso :
   left_assoc_tensor C ≅ right_assoc_tensor C :=
 nat_iso.of_components
@@ -453,7 +453,7 @@ nat_iso.of_components
   (by { intros, apply monoidal_category.associator_naturality })
 
 /-- The left unitor as a natural isomorphism. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def left_unitor_nat_iso :
   tensor_unit_left C ≅ 𝟭 C :=
 nat_iso.of_components
@@ -461,7 +461,7 @@ nat_iso.of_components
   (by { intros, apply monoidal_category.left_unitor_naturality })
 
 /-- The right unitor as a natural isomorphism. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def right_unitor_nat_iso :
   tensor_unit_right C ≅ 𝟭 C :=
 nat_iso.of_components

--- a/src/category_theory/monoidal/internal/functor_category.lean
+++ b/src/category_theory/monoidal/internal/functor_category.lean
@@ -88,7 +88,7 @@ def inverse : (C ⥤ Mon_ D) ⥤ Mon_ (C ⥤ D) :=
 /--
 The unit for the equivalence `Mon_ (C ⥤ D) ≌ C ⥤ Mon_ D`.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def unit_iso : 𝟭 (Mon_ (C ⥤ D)) ≅ functor ⋙ inverse :=
 nat_iso.of_components (λ A,
   { hom :=
@@ -109,7 +109,7 @@ nat_iso.of_components (λ A,
 /--
 The counit for the equivalence `Mon_ (C ⥤ D) ≌ C ⥤ Mon_ D`.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def counit_iso : inverse ⋙ functor ≅ 𝟭 (C ⥤ Mon_ D) :=
 nat_iso.of_components (λ A,
   nat_iso.of_components (λ X,
@@ -168,7 +168,7 @@ def inverse : (C ⥤ CommMon_ D) ⥤ CommMon_ (C ⥤ D) :=
 /--
 The unit for the equivalence `CommMon_ (C ⥤ D) ≌ C ⥤ CommMon_ D`.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def unit_iso : 𝟭 (CommMon_ (C ⥤ D)) ≅ functor ⋙ inverse :=
 nat_iso.of_components (λ A,
   { hom :=
@@ -189,7 +189,7 @@ nat_iso.of_components (λ A,
 /--
 The counit for the equivalence `CommMon_ (C ⥤ D) ≌ C ⥤ CommMon_ D`.
 -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def counit_iso : inverse ⋙ functor ≅ 𝟭 (C ⥤ CommMon_ D) :=
 nat_iso.of_components (λ A,
   nat_iso.of_components (λ X,

--- a/src/category_theory/monoidal/internal/limits.lean
+++ b/src/category_theory/monoidal/internal/limits.lean
@@ -74,7 +74,7 @@ def limit_cone_is_limit (F : J ⥤ Mon_ C) : is_limit (limit_cone F) :=
   uniq' := λ s m w,
   begin
     ext,
-    dsimp, simp only [Mon_.forget_map, limit.lift_π, functor.map_cone_π],
+    dsimp, simp only [Mon_.forget_map, limit.lift_π, functor.map_cone_π_app],
     exact congr_arg Mon_.hom.hom (w j),
   end, }
 

--- a/src/category_theory/monoidal/internal/limits.lean
+++ b/src/category_theory/monoidal/internal/limits.lean
@@ -35,7 +35,7 @@ by interpreting it as a functor `Mon_ (J ⥤ C)`,
 and noting that taking limits is a lax monoidal functor,
 and hence sends monoid objects to monoid objects.
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def limit (F : J ⥤ Mon_ C) : Mon_ C :=
 lim_lax.map_Mon.obj (Mon_functor_category_equivalence.inverse.obj F)
 

--- a/src/category_theory/monoidal/transport.lean
+++ b/src/category_theory/monoidal/transport.lean
@@ -249,7 +249,7 @@ def from_transported (e : C ≌ D) : monoidal_functor (transported e) C :=
   ..lax_from_transported e, }
 
 /-- The unit isomorphism upgrades to a monoidal isomorphism. -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def transported_monoidal_unit_iso (e : C ≌ D) :
   lax_monoidal_functor.id C ≅ lax_to_transported e ⊗⋙ lax_from_transported e :=
 monoidal_nat_iso.of_components (λ X, e.unit_iso.app X) (λ X Y f, e.unit.naturality f)
@@ -263,7 +263,7 @@ monoidal_nat_iso.of_components (λ X, e.unit_iso.app X) (λ X Y f, e.unit.natura
   end)
 
 /-- The counit isomorphism upgrades to a monoidal isomorphism. -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def transported_monoidal_counit_iso (e : C ≌ D) :
   lax_from_transported e ⊗⋙ lax_to_transported e ≅ lax_monoidal_functor.id (transported e) :=
 monoidal_nat_iso.of_components (λ X, e.counit_iso.app X) (λ X Y f, e.counit.naturality f)

--- a/src/category_theory/over.lean
+++ b/src/category_theory/over.lean
@@ -85,7 +85,7 @@ def hom_mk {U V : over X} (f : U.left ⟶ V.left) (w : f ≫ V.hom = U.hom . obv
 Construct an isomorphism in the over category given isomorphisms of the objects whose forward
 direction gives a commutative triangle.
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def iso_mk {f g : over X} (hl : f.left ≅ g.left) (hw : hl.hom ≫ g.hom = f.hom . obviously) : f ≅ g :=
 comma.iso_mk hl (eq_to_iso (subsingleton.elim _ _)) (by simp [hw])
 

--- a/src/category_theory/pi/basic.lean
+++ b/src/category_theory/pi/basic.lean
@@ -87,7 +87,7 @@ def comap_comp (f : K → J) (g : J → I) : comap C g ⋙ comap (C ∘ g) f ≅
   inv := { app := λ X b, 𝟙 (X (g (f b))) } }
 
 /-- The natural isomorphism between pulling back then evaluating, and just evaluating. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def comap_eval_iso_eval (h : J → I) (j : J) : comap C h ⋙ eval (C ∘ h) j ≅ eval C (h j) :=
 nat_iso.of_components (λ f, iso.refl _) (by tidy)
 

--- a/src/category_theory/products/basic.lean
+++ b/src/category_theory/products/basic.lean
@@ -87,7 +87,7 @@ to the identity functor.
 /--
 The equivalence, given by swapping factors, between `C × D` and `D × C`.
 -/
-@[simps {rhs_md:=semireducible}]
+@[simps]
 def braiding : C × D ≌ D × C :=
 equivalence.mk (swap C D) (swap D C)
   (nat_iso.of_components (λ X, eq_to_iso (by simp)) (by tidy))

--- a/src/category_theory/sigma/basic.lean
+++ b/src/category_theory/sigma/basic.lean
@@ -185,20 +185,20 @@ rfl
 /--
 The functor `sigma.map C g` restricted to the subcategory `C j` acts as the inclusion of `g j`.
 -/
-@[simps {rhs_md := semireducible, simp_rhs := tt}]
+@[simps]
 def incl_comp_map (j : J) : incl j ⋙ map C g ≅ incl (g j) := iso.refl _
 
 variable (I)
 
 /-- The functor `sigma.map` applied to the identity function is just the identity functor. -/
-@[simps {rhs_md := semireducible, simp_rhs := tt}]
+@[simps]
 def map_id : map C (id : I → I) ≅ 𝟭 (Σ i, C i) :=
 nat_iso (λ i, nat_iso.of_components (λ X, iso.refl _) (by tidy))
 
 variables {I} {K : Type w₃}
 
 /-- The functor `sigma.map` applied to a composition is a composition of functors. -/
-@[simps {rhs_md := semireducible, simp_rhs := tt}]
+@[simps]
 def map_comp (f : K → J) (g : J → I) : map (C ∘ g) f ⋙ (map C g : _) ≅ map C (g ∘ f) :=
 desc_uniq _ _ $ λ k,
   (iso_whisker_right (incl_comp_map (C ∘ g) f k) (map C g : _) : _) ≪≫ incl_comp_map _ _ _

--- a/src/category_theory/sites/sheaf_of_types.lean
+++ b/src/category_theory/sites/sheaf_of_types.lean
@@ -899,7 +899,7 @@ instance : inhabited (SheafOfTypes (⊥ : grothendieck_topology C)) :=
   end⟩⟩
 
 /-- The inclusion functor from sheaves to presheaves. -/
-@[simps {rhs_md := semireducible}, derive [full, faithful]]
+@[simps, derive [full, faithful]]
 def SheafOfTypes_to_presheaf : SheafOfTypes J ⥤ (Cᵒᵖ ⥤ Type v) :=
 full_subcategory_inclusion (presieve.is_sheaf J)
 

--- a/src/category_theory/sites/types.lean
+++ b/src/category_theory/sites/types.lean
@@ -105,7 +105,7 @@ lemma eval_map (S : (Type u)ᵒᵖ ⥤ Type u) (α β) (f : β ⟶ α) (s x) :
 by { simp_rw [eval, ← functor_to_types.map_comp_apply, ← op_comp], refl }
 
 /-- Given a sheaf `S`, construct an isomorphism `S ≅ [-, S(*)]`. -/
-@[simps {rhs_md := semireducible}] noncomputable def equiv_yoneda (S : (Type u)ᵒᵖ ⥤ Type u)
+@[simps] noncomputable def equiv_yoneda (S : (Type u)ᵒᵖ ⥤ Type u)
   (hs : is_sheaf types_grothendieck_topology S) :
   S ≅ yoneda.obj (S.obj (op punit)) :=
 nat_iso.of_components (λ α, equiv.to_iso $ eval_equiv S hs $ unop α) $ λ α β f,
@@ -127,7 +127,7 @@ lemma eval_app (S₁ S₂ : SheafOfTypes.{u} types_grothendieck_topology)
 
 /-- `yoneda'` induces an equivalence of category between `Type u` and
 `Sheaf types_grothendieck_topology`. -/
-@[simps {rhs_md := semireducible}] noncomputable def type_equiv :
+@[simps] noncomputable def type_equiv :
   Type u ≌ SheafOfTypes types_grothendieck_topology :=
 equivalence.mk
   yoneda'

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -1454,7 +1454,7 @@ protected noncomputable def image_of_inj_on {α β} (f : α → β) (s : set α)
  λ ⟨y, h⟩, subtype.eq (classical.some_spec h).2⟩
 
 /-- If `f` is an injective function, then `s` is equivalent to `f '' s`. -/
-@[simps apply {rhs_md := semireducible}]
+@[simps apply]
 protected noncomputable def image {α β} (f : α → β) (s : set α) (H : injective f) : s ≃ (f '' s) :=
 equiv.set.image_of_inj_on f s (H.inj_on s)
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -361,7 +361,7 @@ A version of `equiv.arrow_congr` in `Type`, rather than `Sort`.
 The `equiv_rw` tactic is not able to use the default `Sort` level `equiv.arrow_congr`,
 because Lean's universe rules will not unify `?l_1` with `imax (1 ?m_1)`.
 -/
-@[congr, simps apply {rhs_md := semireducible, simp_rhs := tt}]
+@[congr, simps apply]
 def arrow_congr' {α₁ β₁ α₂ β₂ : Type*} (hα : α₁ ≃ α₂) (hβ : β₁ ≃ β₂) : (α₁ → β₁) ≃ (α₂ → β₂) :=
 equiv.arrow_congr hα hβ
 
@@ -378,7 +378,7 @@ rfl
 rfl
 
 /-- Conjugate a map `f : α → α` by an equivalence `α ≃ β`. -/
-@[simps apply {rhs_md := semireducible, simp_rhs := tt}]
+@[simps apply]
 def conj (e : α ≃ β) : (α → α) ≃ (β → β) := arrow_congr e e
 
 @[simp] lemma conj_refl : conj (equiv.refl α) = equiv.refl (α → α) := rfl
@@ -484,7 +484,7 @@ section
 ⟨λ p, p.1, λ a, (a, punit.star), λ ⟨_, punit.star⟩, rfl, λ a, rfl⟩
 
 /-- `punit` is a left identity for type product up to an equivalence. -/
-@[simps apply {rhs_md := semireducible, simp_rhs := tt}]
+@[simps apply]
 def punit_prod (α : Type*) : punit.{u+1} × α ≃ α :=
 calc punit × α ≃ α × punit : prod_comm _ _
            ... ≃ α         : prod_punit _
@@ -1070,7 +1070,7 @@ rfl
 
 /-- If two predicates `p` and `q` are pointwise equivalent, then `{x // p x}` is equivalent to
 `{x // q x}`. -/
-@[simps {rhs_md := semireducible, simp_rhs := tt}]
+@[simps]
 def subtype_congr_right {p q : α → Prop} (e : ∀x, p x ↔ q x) : {x // p x} ≃ {x // q x} :=
 subtype_congr (equiv.refl _) e
 
@@ -1091,7 +1091,7 @@ def subtype_congr_prop {α : Type*} {p q : α → Prop} (h : p = q) : subtype p 
 subtype_congr (equiv.refl α) (assume a, h ▸ iff.rfl)
 
 /-- The subtypes corresponding to equal sets are equivalent. -/
-@[simps apply {rhs_md := semireducible, simp_rhs := tt}]
+@[simps apply]
 def set_congr {α : Type*} {s t : set α} (h : s = t) : s ≃ t :=
 subtype_congr_prop h
 
@@ -1501,7 +1501,7 @@ protected def powerset {α} (S : set α) : 𝒫 S ≃ set S :=
 end set
 
 /-- If `f` is a bijective function, then its domain is equivalent to its codomain. -/
-@[simps apply {rhs_md := semireducible, simp_rhs := tt}]
+@[simps apply]
 noncomputable def of_bijective {α β} (f : α → β) (hf : bijective f) : α ≃ β :=
 (equiv.set.range f hf.1).trans $ (set_congr hf.2.range_eq).trans $ equiv.set.univ β
 
@@ -1514,7 +1514,7 @@ lemma of_bijective_apply_symm_apply {α β} (f : α → β) (hf : bijective f) (
 (of_bijective f hf).symm_apply_apply x
 
 /-- If `f` is an injective function, then its domain is equivalent to its range. -/
-@[simps apply {rhs_md := semireducible, simp_rhs := tt}]
+@[simps apply]
 noncomputable def of_injective {α β} (f : α → β) (hf : injective f) : α ≃ _root_.set.range f :=
 of_bijective (λ x, ⟨f x, set.mem_range_self x⟩)
   ⟨λ x y hxy, hf $ by injections, λ ⟨_, x, rfl⟩, ⟨x, rfl⟩⟩

--- a/src/order/omega_complete_partial_order.lean
+++ b/src/order/omega_complete_partial_order.lean
@@ -671,13 +671,13 @@ def of_mono (f : α →ₘ β) (h : ∀ c : chain α, f (ωSup c) = ωSup (c.map
   cont := h }
 
 /-- The identity as a continuous function. -/
-@[simps { rhs_md := reducible }]
+@[simps]
 def id : α →𝒄 α :=
 of_mono preorder_hom.id
   (by intro; rw [chain.map_id]; refl)
 
 /-- The composition of continuous functions. -/
-@[simps { rhs_md := reducible }]
+@[simps]
 def comp (f : β →𝒄 γ) (g : α →𝒄 β) : α →𝒄 γ :=
 of_mono (preorder_hom.comp (↑f) (↑g))
   (by intro; rw [preorder_hom.comp,← preorder_hom.comp,← chain.map_comp,← f.continuous,← g.continuous]; refl)
@@ -761,7 +761,7 @@ by rw [forall_swap,forall_forall_merge]
 
 /-- The `ωSup` operator for continuous functions, which takes the pointwise countable supremum
 of the functions in the `ω`-chain. -/
-@[simps { rhs_md := reducible }]
+@[simps]
 protected def ωSup (c : chain (α →𝒄 β)) : α →𝒄 β :=
 continuous_hom.of_mono (ωSup $ c.map to_mono)
 begin
@@ -772,7 +772,7 @@ begin
     forall_forall_merge, forall_forall_merge', function.comp_app],
 end
 
-@[simps ωSup {rhs_md := reducible}]
+@[simps ωSup]
 instance : omega_complete_partial_order (α →𝒄 β) :=
 omega_complete_partial_order.lift continuous_hom.to_mono continuous_hom.ωSup
   (λ x y h, h) (λ c, rfl)

--- a/src/order/omega_complete_partial_order.lean
+++ b/src/order/omega_complete_partial_order.lean
@@ -558,7 +558,7 @@ protected def ωSup (c : chain (α →ₘ β)) : α →ₘ β :=
 { to_fun := λ a, ωSup (c.map (monotone_apply a)),
   monotone' := λ x y h, ωSup_le_ωSup_of_le (chain.map_le_map _ $ λ a, a.monotone h) }
 
-@[simps ωSup_to_fun {rhs_md := semireducible, simp_rhs := tt}]
+@[simps ωSup_to_fun]
 instance omega_complete_partial_order : omega_complete_partial_order (α →ₘ β) :=
 omega_complete_partial_order.lift preorder_hom.to_fun_hom preorder_hom.ωSup
   (λ x y h, h) (λ c, rfl)

--- a/src/order/omega_complete_partial_order.lean
+++ b/src/order/omega_complete_partial_order.lean
@@ -96,7 +96,7 @@ def prod.snd : (α × β) →ₘ β :=
   monotone' := λ ⟨x,x'⟩ ⟨y,y'⟩ ⟨h,h'⟩, h' }
 
 /-- The `prod` constructor, as a monotone function. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def prod.zip (f : α →ₘ β) (g : α →ₘ γ) : α →ₘ (β × γ) :=
 (prod.map f g).comp prod.diag
 
@@ -144,7 +144,7 @@ instance : has_le (chain α) :=
 { le := λ x y, ∀ i, ∃ j, x i ≤ y j  }
 
 /-- `map` function for `chain` -/
-@[simps {rhs_md := semireducible}] def map : chain β :=
+@[simps] def map : chain β :=
 f.comp c
 
 variables {f}
@@ -169,7 +169,7 @@ lemma map_le_map {g : α →ₘ β} (h : f ≤ g) : c.map f ≤ c.map g :=
 λ i, by simp [mem_map_iff]; intros; existsi i; apply h
 
 /-- `chain.zip` pairs up the elements of two chains that have the same index -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def zip (c₀ : chain α) (c₁ : chain β) : chain (α × β) :=
 preorder_hom.prod.zip c₀ c₁
 
@@ -421,7 +421,7 @@ variables [omega_complete_partial_order γ]
 protected def ωSup (c : chain (α × β)) : α × β :=
 (ωSup (c.map preorder_hom.prod.fst), ωSup (c.map preorder_hom.prod.snd))
 
-@[simps ωSup_fst ωSup_snd {rhs_md := semireducible}]
+@[simps ωSup_fst ωSup_snd]
 instance : omega_complete_partial_order (α × β) :=
 { ωSup := prod.ωSup,
   ωSup_le := λ c ⟨x,x'⟩ h, ⟨ωSup_le _ _ $ λ i, (h i).1, ωSup_le _ _ $ λ i, (h i).2⟩,

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -336,7 +336,7 @@ meta def simps_get_projection_exprs (e : environment) (tgt : expr)
 meta def simps_add_projection (nm : name) (type lhs rhs : expr) (args : list expr)
   (univs : list name) (cfg : simps_cfg) : tactic unit := do
   when_tracing `simps.debug trace!
-    "[simps] > Planning to add lemma\n        > {lhs} = ({rhs} : {type})",
+    "[simps] > Planning to add the equality\n        > {lhs} = ({rhs} : {type})",
   -- simplify `rhs` if `cfg.simp_rhs` is true
   (rhs, prf) ← do { guard cfg.simp_rhs,
     rhs' ← rhs.dsimp {fail_if_unchanged := ff},

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -316,10 +316,10 @@ meta def simps_get_projection_exprs (e : environment) (tgt : expr)
     `@[simps]`, so only the "final" projection will be non-fully applied.
     However, it can be used in combination with explicit field names, to get a partially applied
     intermediate projection.
-  * The list `not_recursive` is the list of names of types for which `@[simps]` doesn't recursively
-    apply projections. For example, given an equivalence `α × β ≃ β × α` one usually wants to only
-    apply the projections for `equiv`, and not also those for `×`. This option is  only relevant if
-    no explicit projection names are given as argument to `@[simps]`.
+  * The option `not_recursive` contains the list of names of types for which `@[simps]` doesn't
+    recursively apply projections. For example, given an equivalence `α × β ≃ β × α` one usually
+    wants to only apply the projections for `equiv`, and not also those for `×`. This option is
+    only relevant if no explicit projection names are given as argument to `@[simps]`.
 -/
 @[derive [has_reflect, inhabited]] structure simps_cfg :=
 (attrs         := [`simp])
@@ -353,7 +353,7 @@ meta def simps_add_projection (nm : name) (type lhs rhs : expr) (args : list exp
   let decl_value := prf.lambdas args,
   let decl := declaration.thm decl_name univs decl_type (pure decl_value),
   when_tracing `simps.verbose trace!
-    "[simps] > adding projection {decl_name} :\n        > {decl_type}",
+    "[simps] > adding projection {decl_name}:\n        > {decl_type}",
   decorate_error ("failed to add projection lemma " ++ decl_name.to_string ++ ". Nested error:") $
     add_decl decl,
   b ← succeeds $ is_def_eq lhs rhs,

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -308,11 +308,18 @@ meta def simps_get_projection_exprs (e : environment) (tgt : expr)
   * `rhs_md` specifies how aggressively definition in the declaration are unfolded for the purposes
     of finding out whether it is a constructor.
     Default: `none`
+    Exception: `@[simps]` will automatically add the options
+    `{rhs_md := semireducible, simp_rhs := tt}` if the given definition is not a constructor with
+    the given reducibility setting for `rhs_md`.
   * If `fully_applied` is `ff` then the generated simp-lemmas will be between non-fully applied
     terms, i.e. equalities between functions. This does not restrict the recursive behavior of
     `@[simps]`, so only the "final" projection will be non-fully applied.
     However, it can be used in combination with explicit field names, to get a partially applied
     intermediate projection.
+  * The list `not_recursive` is the list of names of types for which `@[simps]` doesn't recursively
+    apply projections. For example, given an equivalence `α × β ≃ β × α` one usually wants to only
+    apply the projections for `equiv`, and not also those for `×`. This option is  only relevant if
+    no explicit projection names are given as argument to `@[simps]`.
 -/
 @[derive [has_reflect, inhabited]] structure simps_cfg :=
 (attrs         := [`simp])
@@ -321,6 +328,7 @@ meta def simps_get_projection_exprs (e : environment) (tgt : expr)
 (type_md       := transparency.instances)
 (rhs_md        := transparency.none)
 (fully_applied := tt)
+(not_recursive := [`prod, `pprod])
 
 /-- Add a lemma with `nm` stating that `lhs = rhs`. `type` is the type of both `lhs` and `rhs`,
   `args` is the list of local constants occurring, and `univs` is the list of universe variables.
@@ -328,8 +336,7 @@ meta def simps_get_projection_exprs (e : environment) (tgt : expr)
 meta def simps_add_projection (nm : name) (type lhs rhs : expr) (args : list expr)
   (univs : list name) (cfg : simps_cfg) : tactic unit := do
   when_tracing `simps.debug trace!
-    "[simps] > Planning to add\n        > {lhs}\n        > =\n        > {rhs}\n        > in type
-        > {type}",
+    "[simps] > Planning to add lemma\n        > {lhs} = ({rhs} : {type})",
   -- simplify `rhs` if `cfg.simp_rhs` is true
   (rhs, prf) ← do { guard cfg.simp_rhs,
     rhs' ← rhs.dsimp {fail_if_unchanged := ff},
@@ -351,7 +358,7 @@ meta def simps_add_projection (nm : name) (type lhs rhs : expr) (args : list exp
   let decl_value := prf.lambdas args,
   let decl := declaration.thm decl_name univs decl_type (pure decl_value),
   when_tracing `simps.verbose trace!
-    "[simps] > adding projection\n        > {decl_name} : {decl_type}",
+    "[simps] > adding projection {decl_name} :\n        > {decl_type}",
   decorate_error ("failed to add projection lemma " ++ decl_name.to_string ++ ". Nested error:") $
     add_decl decl,
   b ← succeeds $ is_def_eq lhs rhs,
@@ -381,13 +388,12 @@ meta def simps_add_projections : ∀(e : environment) (nm : name) (suffix : stri
   let new_nm := nm.append_suffix suffix,
   /- We want to generate the current projection if it is in `todo` -/
   let todo_next := todo.filter (≠ ""),
-  /- Don't recursively continue if `str` is not a structure. As a special case, also don't
-    recursively continue if the nested structure is `prod` or `pprod`, unless projections are
-    specified manually. -/
-  if e.is_structure str ∧ ¬(todo = [] ∧ str ∈ [`prod, `pprod] ∧ ¬must_be_str) then do
+  /- Don't recursively continue if `str` is not a structure or if the structure is in
+    `not_recursive`. -/
+  if e.is_structure str ∧ ¬(todo = [] ∧ str ∈ cfg.not_recursive ∧ ¬must_be_str) then do
     [intro] ← return $ e.constructors_of str | fail "unreachable code (3)",
     rhs_whnf ← whnf rhs_ap cfg.rhs_md,
-    (rhs_ap, todo_now) ← if h : ¬is_constant_of rhs_ap.get_app_fn intro ∧
+    (rhs_ap, todo_now) ← if h : ¬ is_constant_of rhs_ap.get_app_fn intro ∧
       is_constant_of rhs_whnf.get_app_fn intro then
       /- If this was a desired projection, we want to apply it before taking the whnf.
         However, if the current field is an eta-expansion (see below), we first want
@@ -438,24 +444,27 @@ Note: the projection names used by @[simps] might not correspond to the projecti
               suffix ++ "_" ++ proj.last,
             simps_add_projections e nm new_suffix new_type new_lhs new_rhs new_args univs
               ff cfg new_todo
+    -- if I'm about to run into an error, try to set the transparency for `rhs_md` higher.
+    else if cfg.rhs_md = transparency.none ∧ (must_be_str ∨ todo_next ≠ []) then do
+      when_tracing `simps.verbose trace!
+        "[simps] > The given definition is not a constructor application:
+        >   {rhs_ap}
+        > Retrying with the options {{ rhs_md := semireducible, simp_rhs := tt}.",
+      simps_add_projections e nm suffix type lhs rhs args univs must_be_str
+        { rhs_md := semireducible, simp_rhs := tt, ..cfg} todo
     else do
       when must_be_str $
-        fail!"Invalid `simps` attribute. The body is not a constructor application:
-  {rhs_ap}
-Possible solution: add option {{rhs_md := semireducible}.
-The option {{simp_rhs := tt} might also be useful to simplify the right-hand side.",
+        fail!"Invalid `simps` attribute. The body is not a constructor application:\n  {rhs_ap}",
       when (todo_next ≠ []) $
         fail!"Invalid simp-lemma {nm.append_suffix $ suffix ++ todo_next.head}.
-The given definition is not a constructor application:\n  {rhs_ap}
-Possible solution: add option {{rhs_md := semireducible}.
-The option {{simp_rhs := tt} might also be useful to simplify the right-hand side.",
+The given definition is not a constructor application:\n  {rhs_ap}",
       if cfg.fully_applied then
         simps_add_projection new_nm tgt lhs_ap rhs_ap new_args univs cfg else
         simps_add_projection new_nm type lhs rhs args univs cfg
   else do
     when must_be_str $
-      fail "Invalid `simps` attribute. Target is not a structure",
-    when (todo_next ≠ [] ∧ str ∉ [`prod, `pprod]) $
+      fail!"Invalid `simps` attribute. Target {str} is not a structure",
+    when (todo_next ≠ [] ∧ str ∉ cfg.not_recursive) $
         fail!"Invalid simp-lemma {nm.append_suffix $ suffix ++ todo_next.head}.
 Projection {(todo_next.head.split_on '_').tail.head} doesn't exist, because target is not a structure.",
     if cfg.fully_applied then

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -340,16 +340,11 @@ meta def simps_add_projection (nm : name) (type lhs rhs : expr) (args : list exp
   -- simplify `rhs` if `cfg.simp_rhs` is true
   (rhs, prf) ← do { guard cfg.simp_rhs,
     rhs' ← rhs.dsimp {fail_if_unchanged := ff},
-    -- o ← get_options,
-    -- let o' := o.set_bool `pp.implicit tt,
-    -- let o' := o'.set_bool `pp.notation ff,
-    -- set_options o',
     when_tracing `simps.debug $ when (rhs ≠ rhs') trace!
       "[simps] > `dsimp` simplified rhs to\n        > {rhs'}",
     rhsprf ← rhs'.simp {fail_if_unchanged := ff},
     when_tracing `simps.debug $ when (rhs' ≠ rhsprf.1) trace!
       "[simps] > `simp` simplified rhs to\n        > {rhsprf.1}",
-    -- set_options o,
     return rhsprf }
     <|> prod.mk rhs <$> mk_app `eq.refl [type, lhs],
   eq_ap ← mk_mapp `eq $ [type, lhs, rhs].map some,

--- a/src/topology/category/CompHaus.lean
+++ b/src/topology/category/CompHaus.lean
@@ -49,5 +49,5 @@ rfl
 end  CompHaus
 
 /-- The fully faithful embedding of `CompHaus` in `Top`. -/
-@[simps {rhs_md := semireducible}, derive [full, faithful]]
+@[simps, derive [full, faithful]]
 def CompHaus_to_Top : CompHaus ⥤ Top := induced_functor _

--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -62,7 +62,7 @@ rfl
 end Profinite
 
 /-- The fully faithful embedding of `Profinite` in `Top`. -/
-@[simps {rhs_md := semireducible}, derive [full, faithful]]
+@[simps, derive [full, faithful]]
 def Profinite_to_Top : Profinite ⥤ Top := induced_functor _
 
 /-- The fully faithful embedding of `Profinite` in `CompHaus`. -/

--- a/src/topology/sheaves/sheaf_condition/pairwise_intersections.lean
+++ b/src/topology/sheaves/sheaf_condition/pairwise_intersections.lean
@@ -216,14 +216,14 @@ def cone_equiv_unit_iso_app (F : presheaf C X) ⦃ι : Type v⦄ (U : ι → ope
     w' := λ j, begin op_induction j, rcases j; tidy, end }}
 
 /-- Implementation of `sheaf_condition_pairwise_intersections.cone_equiv`. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def cone_equiv_unit_iso (F : presheaf C X) ⦃ι : Type v⦄ (U : ι → opens X) :
   𝟭 (limits.cone ((diagram U).op ⋙ F)) ≅
     cone_equiv_functor F U ⋙ cone_equiv_inverse F U :=
 nat_iso.of_components (cone_equiv_unit_iso_app F U) (by tidy)
 
 /-- Implementation of `sheaf_condition_pairwise_intersections.cone_equiv`. -/
-@[simps {rhs_md := semireducible}]
+@[simps]
 def cone_equiv_counit_iso (F : presheaf C X) ⦃ι : Type v⦄ (U : ι → opens X) :
   cone_equiv_inverse F U ⋙ cone_equiv_functor F U ≅
     𝟭 (limits.cone (sheaf_condition_equalizer_products.diagram F U)) :=

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -2,7 +2,7 @@ import tactic.simps
 import algebra.group.to_additive
 
 universe variables v u w
-set_option trace.simps.verbose true
+-- set_option trace.simps.verbose true
 -- set_option trace.simps.debug true
 -- set_option trace.app_builder true
 

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -3,6 +3,7 @@ import algebra.group.to_additive
 
 universe variables v u w
 -- set_option trace.simps.verbose true
+-- set_option trace.simps.debug true
 -- set_option trace.app_builder true
 
 open function tactic expr

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -776,3 +776,32 @@ run_cmd do
 
 example {M N} [has_one M] [has_one N] : (1 : M × N) = ⟨1, 1⟩ := by simp
 example {M N} [has_zero M] [has_zero N] : (0 : M × N) = ⟨0, 0⟩ := by simp
+
+section
+/-! Test `dsimp, simp` with the option `simp_rhs` -/
+
+local attribute [simp] nat.add
+
+structure my_type :=
+(A : Type)
+
+@[simps {simp_rhs := tt}] def my_type_def : my_type := ⟨{ x : fin (nat.add 3 0) // 1 + 1 = 2 }⟩
+
+example (h : false) (x y : { x : fin (nat.add 3 0) // 1 + 1 = 2 }) : my_type_def.A = unit :=
+begin
+  simp only [my_type_def_A],
+  guard_target ({ x : fin 3 // true } = unit),
+  /- note: calling only one of `simp` or `dsimp` does not produce the current target,
+  as the following tests show. -/
+  success_if_fail { guard_hyp x : { x : fin 3 // true } },
+  dsimp at x,
+  success_if_fail { guard_hyp x : { x : fin 3 // true } },
+  simp at y,
+  success_if_fail { guard_hyp y : { x : fin 3 // true } },
+  simp at x, dsimp at y,
+  guard_hyp x : { x : fin 3 // true },
+  guard_hyp y : { x : fin 3 // true },
+  contradiction
+end
+
+end


### PR DESCRIPTION
* `@[simps]` would previously fail if the definition is not a constructor application (with the suggestion to add option `{rhs_md := semireducible}` and maybe `simp_rhs := tt`). Now it automatically adds `{rhs_md := semireducible, simp_rhs := tt}` whenever it reaches this situation. 
* Remove all (now) unnecessary occurrences of `{rhs_md := semireducible}` from the library. There are still a couple left where the `simp_rhs := tt` is undesirable.
* `@[simps {simp_rhs := tt}]` now also applies `dsimp, simp` to the right-hand side of the lemmas it generates.
* Add some `@[simps]` in `category_theory/limits/cones.lean`
* `@[simps]` would not recursively apply projections of `prod` or `pprod`. This is now customizable with the `not_recursive` option.
* Add an option `trace.simps.debug` with some debugging information.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
