### PR TITLE
[Merged by Bors] - feat(group_theory): add definition of solvable group

### DIFF
--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Oliver Nash. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
+import data.bracket
 import algebra.algebra.basic
 import linear_algebra.bilinear_form
 import linear_algebra.matrix
@@ -43,17 +44,6 @@ lie bracket, ring commutator, jacobi identity, lie ring, lie algebra
 -/
 
 universes u v w w₁ w₂
-
-/-- The has_bracket class has two intended uses:
-
-  1. for the product `⁅x, y⁆` of two elements `x`, `y` in a Lie algebra
-     (analogous to `has_mul` in the associative setting),
-
-  2. for the action `⁅x, m⁆` of an element `x` of a Lie algebra on an element `m` in one of its
-     modules (analogous to `has_scalar` in the associative setting). -/
-class has_bracket (L : Type v) (M : Type w) := (bracket : L → M → M)
-
-notation `⁅`x`,` y`⁆` := has_bracket.bracket x y
 
 /-- A Lie ring is an additive group with compatible product, known as the bracket, satisfying the
 Jacobi identity. The bracket is not associative unless it is identically zero. -/

--- a/src/data/bracket.lean
+++ b/src/data/bracket.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2021 Patrick Lutz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Lutz and Oliver Nash.
+-/
+
+/-!
+# Bracket Notation
+
+This file provides notation which can be used for the Lie bracket, for the commutator of two
+subgroups, and for other similar operations.
+
+## Main Definitions
+
+* `has_bracket L M` for a binary operation that takes something in `L` and something in `M` and
+produces something in `M`. Defining an instance of this structure gives access to the notation `⁅ ⁆`
+
+## Notation
+
+We introduce the notation `⁅x, y⁆` for the `bracket` of any `has_bracket` structure. Note that
+these are the Unicode "square with quill" brackets rather than the usual square brackets.
+-/
+
+/-- The has_bracket class has three intended uses:
+
+  1. for certain binary operations on structures, like the product `⁅x, y⁆` of two elements
+    `x`, `y` in a Lie algebra or the commutator of two elements `x` and `y` in a group.
+
+  2. for certain actions of one structure on another, like the action `⁅x, m⁆` of an element `x`
+    of a Lie algebra on an element `m` in one of its modules (analogous to `has_scalar` in the
+    associative setting).
+
+  3. for binary operations on substructures, like the commutator `⁅H, K⁆` of two subgroups `H` and
+     `K` of a group. -/
+class has_bracket (L M : Type*) := (bracket : L → M → M)
+
+notation `⁅`x`,` y`⁆` := has_bracket.bracket x y

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -94,11 +94,8 @@ begin
   convert mul_mem H₁ hp (h.conj_mem p⁻¹ (inv_mem H₁ hp) q),
 end
 
-@[simp] lemma general_commutator_bot_eq_bot (H : subgroup G) : general_commutator H ⊥ = ⊥ :=
-begin
-  rw eq_bot_iff,
-  exact general_commutator_le_right H ⊥,
-end
+@[simp] lemma general_commutator_bot (H : subgroup G) : general_commutator H ⊥ = ⊥ :=
+by { rw eq_bot_iff, exact general_commutator_le_right H ⊥ }
 
 @[simp] lemma bot_general_commutator_eq_bot (H : subgroup G) : general_commutator ⊥ H = ⊥ :=
 begin

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -131,9 +131,8 @@ lemma derived_series_normal (n : ℕ) : (derived_series G n).normal :=
 begin
   induction n with n ih,
   { exact subgroup.top_normal, },
-  { haveI : (derived_series G n).normal := ih,
-    rw derived_series_succ,
-    exact general_commutator_normal (derived_series G n) (derived_series G n), }
+  { rw derived_series_succ,
+    exactI general_commutator_normal (derived_series G n) (derived_series G n), }
 end
 
 lemma commutator_eq_general_commutator_top_top :
@@ -167,6 +166,7 @@ variables (G)
 class is_solvable : Prop :=
 (solvable : ∃ n : ℕ, derived_series G n = ⊥)
 
+@[priority 100]
 instance is_solvable_of_comm {G : Type*} [comm_group G] : is_solvable G :=
 begin
   use 1,

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -10,7 +10,7 @@ import group_theory.abelianization
 # Solvable Groups
 
 In this file we introduce the notion of a solvable group. We define a solvable group as one whose
-nth commutator is `1` for some `n`. This requires defining the commutator of two subgroups and
+derived series is eventually trivial. This requires defining the commutator of two subgroups and
 the derived series of a group.
 
 ## Main definitions

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -91,8 +91,7 @@ end
 lemma commutator_eq_general_commutator_top_top :
   commutator G = general_commutator (⊤ : subgroup G) (⊤ : subgroup G) :=
 begin
-  rw commutator,
-  rw general_commutator_def',
+  rw [commutator, general_commutator_def'],
   apply le_antisymm; apply normal_closure_mono,
   { exact λ x ⟨p, q, h⟩, ⟨p, mem_top p, q, mem_top q, h⟩, },
   { exact λ x ⟨p, _, q, _, h⟩, ⟨p, q, h⟩, }

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -59,7 +59,7 @@ end
 
 lemma general_commutator_eq_normal_closure_self (H₁ H₂ : subgroup G) [H₁.normal]
   [H₂.normal] : general_commutator H₁ H₂ = normal_closure (general_commutator H₁ H₂) :=
-eq.symm normal_closure_eq_self_of_normal
+eq.symm normal_closure_eq_self
 
 lemma general_commutator_def' (H₁ H₂ : subgroup G) [H₁.normal] [H₂.normal] :
   general_commutator H₁ H₂ = normal_closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x} :=
@@ -129,25 +129,25 @@ begin
     exactI general_commutator_normal (derived_series G n) (derived_series G n), }
 end
 
-lemma general_commutator_eq_commutator :
+@[simp] lemma general_commutator_eq_commutator :
   general_commutator (⊤ : subgroup G) (⊤ : subgroup G) = commutator G :=
 begin
   rw [commutator, general_commutator_def'],
   apply le_antisymm; apply normal_closure_mono,
-  { exact λ x ⟨p, q, h⟩, ⟨p, mem_top p, q, mem_top q, h⟩, },
-  { exact λ x ⟨p, _, q, _, h⟩, ⟨p, q, h⟩, }
+  { exact λ x ⟨p, _, q, _, h⟩, ⟨p, q, h⟩, },
+  { exact λ x ⟨p, q, h⟩, ⟨p, mem_top p, q, mem_top q, h⟩, }
 end
 
 lemma commutator_def' : commutator G = subgroup.closure {x : G | ∃ p q, p * q * p⁻¹ * q⁻¹ = x} :=
 begin
-  rw [commutator_eq_general_commutator_top_top, general_commutator],
+  rw [← general_commutator_eq_commutator, general_commutator],
   apply le_antisymm; apply closure_mono,
   { exact λ x ⟨p, _, q, _, h⟩, ⟨p, q, h⟩ },
   { exact λ x ⟨p, q, h⟩, ⟨p, mem_top p, q, mem_top q, h⟩ }
 end
 
 @[simp] lemma derived_series_one : derived_series G 1 = commutator G :=
-eq.symm $ commutator_eq_general_commutator_top_top G
+general_commutator_eq_commutator G
 
 end derived_series
 

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -28,7 +28,7 @@ variables {G : Type*} [group G]
 section general_commutator
 
 /-- The commutator of two subgroups `H₁` and `H₂`. -/
-def general_commutator (H₁ : subgroup G) (H₂ : subgroup G) : subgroup G :=
+def general_commutator (H₁ H₂ : subgroup G) : subgroup G :=
 subgroup.closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x}
 
 instance general_commutator_normal (H₁ : subgroup G) (H₂ : subgroup G) [h₁ : H₁.normal]

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -116,7 +116,7 @@ variables (G)
 
 /-- A group `G` is solvable if its derived series is eventually trivial. We use this definition
   because it's the most convenient one to work with. -/
-def is_solvable : Prop := ∃ n : ℕ, derived_series G n = (⊥ : subgroup G)
+def is_solvable : Prop := ∃ n : ℕ, derived_series G n = ⊥
 
 lemma is_solvable_of_comm {G : Type*} [comm_group G] : is_solvable G :=
 begin

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -40,7 +40,7 @@ instance general_commutator_normal (H₁ H₂ : subgroup G) [h₁ : H₁.normal]
 begin
   let base : set G := {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x},
   suffices h_base : base = group.conjugates_of_set base,
-  { dsimp only [general_commutator, ←base],
+  { dsimp only [general_commutator_def, ←base],
     rw h_base,
     exact subgroup.normal_closure_normal },
   apply set.subset.antisymm group.subset_conjugates_of_set,

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -58,13 +58,9 @@ begin
   exact ⟨p, h₁ hp, q, h₂ hq, rfl⟩,
 end
 
-lemma general_commutator_eq_normal_closure_self (H₁ H₂ : subgroup G) [H₁.normal]
-  [H₂.normal] : ⁅H₁, H₂⁆ = normal_closure (↑⁅H₁, H₂⁆ : set G) :=
-eq.symm normal_closure_eq_self
-
 lemma general_commutator_def' (H₁ H₂ : subgroup G) [H₁.normal] [H₂.normal] :
   ⁅H₁, H₂⁆ = normal_closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x} :=
-by rw [general_commutator_eq_normal_closure_self, general_commutator,
+by rw [← normal_closure_eq_self ⁅H₁, H₂⁆, general_commutator_def,
   normal_closure_closure_eq_normal_closure]
 
 lemma general_commutator_le (H₁ H₂ : subgroup G) (K : subgroup G) :

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -97,10 +97,8 @@ end
 lemma general_commutator_le_left (H₁ H₂ : subgroup G) [h : normal H₁] :
   ⁅H₁, H₂⁆ ≤ H₁ :=
 begin
-  rw general_commutator_le,
-  intros p hp q hq,
-  rw (show p * q * p⁻¹ * q⁻¹ = p * (q * p⁻¹ * q⁻¹), by group),
-  convert mul_mem H₁ hp (h.conj_mem p⁻¹ (inv_mem H₁ hp) q),
+  rw general_commutator_comm,
+  exact general_commutator_le_right H₂ H₁,
 end
 
 @[simp] lemma general_commutator_bot (H : subgroup G) : ⁅H, ⊥⁆ = (⊥ : subgroup G) :=

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -71,8 +71,9 @@ variables (G)
 
 /-- The derived series of the group `G`, obtained by starting from the subgroup `⊤` and repeatedly
   taking the commutator of the previous subgroup with itself for `n` times. -/
-def derived_series (n : ℕ) : subgroup G :=
-nat.rec_on n (⊤ : subgroup G) (λ _ H, general_commutator H H)
+def derived_series : Π n : ℕ, subgroup G
+| 0       := ⊤
+| (n + 1) := general_commutator (derived_series n) (derived_series n)
 
 @[simp] lemma derived_series_zero : derived_series G 0 = ⊤ := rfl
 

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -100,8 +100,7 @@ end
 
 lemma commutator_def' : commutator G = subgroup.closure {x : G | ∃ p q, p * q * p⁻¹ * q⁻¹ = x} :=
 begin
-  rw commutator_eq_general_commutator_top_top,
-  rw general_commutator,
+  rw [commutator_eq_general_commutator_top_top, general_commutator],
   apply le_antisymm; apply closure_mono,
   { exact λ x ⟨p, _, q, _, h⟩, ⟨p, q, h⟩ },
   { exact λ x ⟨p, q, h⟩, ⟨p, mem_top p, q, mem_top q, h⟩ }

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -74,6 +74,18 @@ begin
     exact h p hp q hq, }
 end
 
+lemma general_commutator_comm' (H₁ H₂ : subgroup G) : ⁅H₁, H₂⁆ ≤ ⁅H₂, H₁⁆ :=
+begin
+  rw general_commutator_le,
+  intros p hp q hq,
+  have h : (p * q * p⁻¹ * q⁻¹)⁻¹ ∈ ⁅H₂, H₁⁆ := subset_closure ⟨q, hq, p, hp, by group⟩,
+  convert inv_mem ⁅H₂, H₁⁆ h,
+  group,
+end
+
+lemma general_commutator_comm (H₁ H₂ : subgroup G) : ⁅H₁, H₂⁆ = ⁅H₂, H₁⁆ :=
+le_antisymm (general_commutator_comm' _ _) (general_commutator_comm' _ _)
+
 lemma general_commutator_le_right (H₁ H₂ : subgroup G) [h : normal H₂] :
   ⁅H₁, H₂⁆ ≤ H₂ :=
 begin

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2020 Jordan Brown, Thomas Browning and Patrick Lutz. All rights reserved.
+Copyright (c) 2021 Jordan Brown, Thomas Browning and Patrick Lutz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jordan Brown, Thomas Browning and Patrick Lutz
 -/

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -54,7 +54,7 @@ begin
   exact ⟨p, h₁ hp, q, h₂ hq, rfl⟩,
 end
 
-lemma general_commutator_eq_normal_closure_self (H₁ : subgroup G) (H₂ : subgroup G) [H₁.normal]
+lemma general_commutator_eq_normal_closure_self (H₁ H₂ : subgroup G) [H₁.normal]
   [H₂.normal] : general_commutator H₁ H₂ = normal_closure (general_commutator H₁ H₂) :=
 eq.symm normal_closure_eq_self_of_normal
 

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2020 Jordan Brown, Thomas Browning and Patrick Lutz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jordan Brown, Thomas Browning and Patrick Lutz
+-/
+
+import group_theory.abelianization
+
+/-!
+# Solvable Groups
+
+In this file we introduce the notion of a solvable group. We define a solvable group as one whose
+nth commutator is `1` for some `n`. This requires defining the commutator of two subgroups and
+the nth commutator of a group.
+
+## Main definitions
+
+* `general_commutator H₁ H₂` : the commutator of the subgroups `H₁` and `H₂`
+* `nth_commutator G n` : the `n`th commutator of `G`, defined by iterating `general_commutator`
+  starting with the top subgroup
+* `is_solvable G` : the group `G` is solvable
+-/
+
+open subgroup
+
+variables {G : Type*} [group G]
+
+section general_commutator
+
+/-- The commutator of two subgroups `H₁` and `H₂`. -/
+def general_commutator (H₁ : subgroup G) (H₂ : subgroup G) : subgroup G :=
+subgroup.closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x}
+
+instance general_commutator_normal (H₁ : subgroup G) (H₂ : subgroup G) [h₁ : H₁.normal]
+  [h₂ : H₂.normal] : normal (general_commutator H₁ H₂) :=
+begin
+  let base : set G := {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x},
+  suffices h_base : base = group.conjugates_of_set base,
+  { dsimp only [general_commutator, ←base],
+    rw h_base,
+    exact subgroup.normal_closure_normal },
+  apply set.subset.antisymm group.subset_conjugates_of_set,
+  intros a h,
+  rw group.mem_conjugates_of_set_iff at h,
+  rcases h with ⟨b, ⟨c, hc, e, he, rfl⟩, d, rfl⟩,
+  exact ⟨d * c * d⁻¹, h₁.conj_mem c hc d, d * e * d⁻¹, h₂.conj_mem e he d, by group⟩,
+end
+
+lemma general_commutator_mono {H₁ H₂ K₁ K₂ : subgroup G} (h₁ : H₁ ≤ K₁) (h₂ : H₂ ≤ K₂) :
+  general_commutator H₁ H₂ ≤ general_commutator K₁ K₂ :=
+begin
+  apply closure_mono,
+  rintros x ⟨p, hp, q, hq, rfl⟩,
+  exact ⟨p, h₁ hp, q, h₂ hq, rfl⟩,
+end
+
+lemma general_commutator_eq_normal_closure_self (H₁ : subgroup G) (H₂ : subgroup G) [H₁.normal]
+  [H₂.normal] : general_commutator H₁ H₂ = normal_closure (general_commutator H₁ H₂) :=
+eq.symm normal_closure_eq_self_of_normal
+
+lemma general_commutator_def' (H₁ H₂ : subgroup G) [H₁.normal] [H₂.normal] :
+  general_commutator H₁ H₂ = normal_closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x} :=
+by rw [general_commutator_eq_normal_closure_self, general_commutator,
+  normal_closure_closure_eq_normal_closure]
+
+end general_commutator
+
+section nth_commutator
+
+variables (G)
+
+/-- The nth commutator of the group `G`, obtained by starting from the subgroup `⊤` and repeatedly
+  taking the commutator of the previous subgroup with itself for `n` times. -/
+def nth_commutator (n : ℕ) : subgroup G :=
+nat.rec_on n (⊤ : subgroup G) (λ _ H, general_commutator H H)
+
+@[simp] lemma nth_commutator_zero : nth_commutator G 0 = ⊤ := rfl
+
+@[simp] lemma nth_commutator_succ (n : ℕ) :
+  nth_commutator G (n + 1) = general_commutator (nth_commutator G n) (nth_commutator G n) := rfl
+
+lemma nth_commutator_normal (n : ℕ) : (nth_commutator G n).normal :=
+begin
+  induction n with n ih,
+  { exact subgroup.top_normal, },
+  { haveI : (nth_commutator G n).normal := ih,
+    rw nth_commutator_succ,
+    exact general_commutator_normal (nth_commutator G n) (nth_commutator G n), }
+end
+
+lemma commutator_eq_general_commutator_top_top :
+  commutator G = general_commutator (⊤ : subgroup G) (⊤ : subgroup G) :=
+begin
+  rw commutator,
+  rw general_commutator_def',
+  apply le_antisymm; apply normal_closure_mono,
+  { exact λ x ⟨p, q, h⟩, ⟨p, mem_top p, q, mem_top q, h⟩, },
+  { exact λ x ⟨p, _, q, _, h⟩, ⟨p, q, h⟩, }
+end
+
+lemma commutator_def' : commutator G = subgroup.closure {x : G | ∃ p q, p * q * p⁻¹ * q⁻¹ = x} :=
+begin
+  rw commutator_eq_general_commutator_top_top,
+  rw general_commutator,
+  apply le_antisymm; apply closure_mono,
+  { exact λ x ⟨p, _, q, _, h⟩, ⟨p, q, h⟩ },
+  { exact λ x ⟨p, q, h⟩, ⟨p, mem_top p, q, mem_top q, h⟩ }
+end
+
+@[simp] lemma nth_commutator_one : nth_commutator G 1 = commutator G :=
+eq.symm $ commutator_eq_general_commutator_top_top G
+
+end nth_commutator
+
+section solvable
+
+variables (G)
+
+/-- A group `G` is solvable if for some `n`, its nth commutator is trivial. We use this definition
+  because it's the most convenient one to work with. -/
+def is_solvable : Prop := ∃ n : ℕ, nth_commutator G n = (⊥ : subgroup G)
+
+lemma is_solvable_of_comm {G : Type*} [comm_group G] : is_solvable G :=
+begin
+  use 1,
+  rw [eq_bot_iff, nth_commutator_one],
+  calc commutator G ≤ (monoid_hom.id G).ker : abelianization.commutator_subset_ker (monoid_hom.id G)
+  ... = ⊥ : rfl,
+end
+
+end solvable

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -5,6 +5,7 @@ Authors: Jordan Brown, Thomas Browning and Patrick Lutz
 -/
 
 import group_theory.abelianization
+import data.bracket
 
 /-!
 # Solvable Groups
@@ -28,14 +29,14 @@ variables {G : Type*} [group G]
 section general_commutator
 
 /-- The commutator of two subgroups `H₁` and `H₂`. -/
-def general_commutator (H₁ H₂ : subgroup G) : subgroup G :=
-closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x}
+instance general_commutator : has_bracket (subgroup G) (subgroup G) :=
+⟨λ H₁ H₂, closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x}⟩
 
 lemma general_commutator_def (H₁ H₂ : subgroup G) :
-  general_commutator H₁ H₂ = closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x} := rfl
+  ⁅H₁, H₂⁆ = closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x} := rfl
 
 instance general_commutator_normal (H₁ H₂ : subgroup G) [h₁ : H₁.normal]
-  [h₂ : H₂.normal] : normal (general_commutator H₁ H₂) :=
+  [h₂ : H₂.normal] : normal ⁅H₁, H₂⁆ :=
 begin
   let base : set G := {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x},
   suffices h_base : base = group.conjugates_of_set base,
@@ -50,7 +51,7 @@ begin
 end
 
 lemma general_commutator_mono {H₁ H₂ K₁ K₂ : subgroup G} (h₁ : H₁ ≤ K₁) (h₂ : H₂ ≤ K₂) :
-  general_commutator H₁ H₂ ≤ general_commutator K₁ K₂ :=
+  ⁅H₁, H₂⁆ ≤ ⁅K₁, K₂⁆ :=
 begin
   apply closure_mono,
   rintros x ⟨p, hp, q, hq, rfl⟩,
@@ -58,16 +59,16 @@ begin
 end
 
 lemma general_commutator_eq_normal_closure_self (H₁ H₂ : subgroup G) [H₁.normal]
-  [H₂.normal] : general_commutator H₁ H₂ = normal_closure (general_commutator H₁ H₂) :=
+  [H₂.normal] : ⁅H₁, H₂⁆ = normal_closure (↑⁅H₁, H₂⁆ : set G) :=
 eq.symm normal_closure_eq_self
 
 lemma general_commutator_def' (H₁ H₂ : subgroup G) [H₁.normal] [H₂.normal] :
-  general_commutator H₁ H₂ = normal_closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x} :=
+  ⁅H₁, H₂⁆ = normal_closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x} :=
 by rw [general_commutator_eq_normal_closure_self, general_commutator,
   normal_closure_closure_eq_normal_closure]
 
 lemma general_commutator_le (H₁ H₂ : subgroup G) (K : subgroup G) :
-  general_commutator H₁ H₂ ≤ K ↔ ∀ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ ∈ K :=
+  ⁅H₁, H₂⁆ ≤ K ↔ ∀ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ ∈ K :=
 begin
   rw [general_commutator, closure_le],
   split,
@@ -78,7 +79,7 @@ begin
 end
 
 lemma general_commutator_le_right (H₁ H₂ : subgroup G) [h : normal H₂] :
-  general_commutator H₁ H₂ ≤ H₂ :=
+  ⁅H₁, H₂⁆ ≤ H₂ :=
 begin
   rw general_commutator_le,
   intros p hp q hq,
@@ -86,7 +87,7 @@ begin
 end
 
 lemma general_commutator_le_left (H₁ H₂ : subgroup G) [h : normal H₁] :
-  general_commutator H₁ H₂ ≤ H₁ :=
+  ⁅H₁, H₂⁆ ≤ H₁ :=
 begin
   rw general_commutator_le,
   intros p hp q hq,
@@ -94,14 +95,14 @@ begin
   convert mul_mem H₁ hp (h.conj_mem p⁻¹ (inv_mem H₁ hp) q),
 end
 
-@[simp] lemma general_commutator_bot (H : subgroup G) : general_commutator H ⊥ = ⊥ :=
+@[simp] lemma general_commutator_bot (H : subgroup G) : ⁅H, ⊥⁆ = (⊥ : subgroup G) :=
 by { rw eq_bot_iff, exact general_commutator_le_right H ⊥ }
 
-@[simp] lemma bot_general_commutator (H : subgroup G) : general_commutator ⊥ H = ⊥ :=
+@[simp] lemma bot_general_commutator (H : subgroup G) : ⁅(⊥ : subgroup G), H⁆ = (⊥ : subgroup G) :=
 by { rw eq_bot_iff, exact general_commutator_le_left ⊥ H }
 
 lemma general_commutator_le_inf (H₁ H₂ : subgroup G) [normal H₁] [normal H₂] :
-  general_commutator H₁ H₂ ≤ H₁ ⊓ H₂ :=
+  ⁅H₁, H₂⁆ ≤ H₁ ⊓ H₂ :=
 by simp only [general_commutator_le_left, general_commutator_le_right, le_inf_iff, and_self]
 
 end general_commutator
@@ -114,12 +115,12 @@ variables (G)
   taking the commutator of the previous subgroup with itself for `n` times. -/
 def derived_series : ℕ → subgroup G
 | 0       := ⊤
-| (n + 1) := general_commutator (derived_series n) (derived_series n)
+| (n + 1) := ⁅(derived_series n), (derived_series n)⁆
 
 @[simp] lemma derived_series_zero : derived_series G 0 = ⊤ := rfl
 
 @[simp] lemma derived_series_succ (n : ℕ) :
-  derived_series G (n + 1) = general_commutator (derived_series G n) (derived_series G n) := rfl
+  derived_series G (n + 1) = ⁅(derived_series G n), (derived_series G n)⁆ := rfl
 
 lemma derived_series_normal (n : ℕ) : (derived_series G n).normal :=
 begin
@@ -130,7 +131,7 @@ begin
 end
 
 @[simp] lemma general_commutator_eq_commutator :
-  general_commutator (⊤ : subgroup G) (⊤ : subgroup G) = commutator G :=
+  ⁅(⊤ : subgroup G), (⊤ : subgroup G)⁆ = commutator G :=
 begin
   rw [commutator, general_commutator_def'],
   apply le_antisymm; apply normal_closure_mono,

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -31,7 +31,7 @@ section general_commutator
 def general_commutator (H₁ H₂ : subgroup G) : subgroup G :=
 subgroup.closure {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x}
 
-instance general_commutator_normal (H₁ : subgroup G) (H₂ : subgroup G) [h₁ : H₁.normal]
+instance general_commutator_normal (H₁ H₂ : subgroup G) [h₁ : H₁.normal]
   [h₂ : H₂.normal] : normal (general_commutator H₁ H₂) :=
 begin
   let base : set G := {x | ∃ (p ∈ H₁) (q ∈ H₂), p * q * p⁻¹ * q⁻¹ = x},

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -97,11 +97,8 @@ end
 @[simp] lemma general_commutator_bot (H : subgroup G) : general_commutator H ⊥ = ⊥ :=
 by { rw eq_bot_iff, exact general_commutator_le_right H ⊥ }
 
-@[simp] lemma bot_general_commutator_eq_bot (H : subgroup G) : general_commutator ⊥ H = ⊥ :=
-begin
-  rw eq_bot_iff,
-  exact general_commutator_le_left ⊥ H,
-end
+@[simp] lemma bot_general_commutator (H : subgroup G) : general_commutator ⊥ H = ⊥ :=
+by { rw eq_bot_iff, exact general_commutator_le_left ⊥ H }
 
 lemma general_commutator_le_inf (H₁ H₂ : subgroup G) [normal H₁] [normal H₂] :
   general_commutator H₁ H₂ ≤ H₁ ⊓ H₂ :=

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -74,17 +74,16 @@ begin
     exact h p hp q hq, }
 end
 
-lemma general_commutator_comm' (H₁ H₂ : subgroup G) : ⁅H₁, H₂⁆ ≤ ⁅H₂, H₁⁆ :=
+lemma general_commutator_comm (H₁ H₂ : subgroup G) : ⁅H₁, H₂⁆ = ⁅H₂, H₁⁆ :=
 begin
+  suffices : ∀ H₁ H₂ : subgroup G, ⁅H₁, H₂⁆ ≤ ⁅H₂, H₁⁆, { exact le_antisymm (this _ _) (this _ _) },
+  intros H₁ H₂,
   rw general_commutator_le,
   intros p hp q hq,
   have h : (p * q * p⁻¹ * q⁻¹)⁻¹ ∈ ⁅H₂, H₁⁆ := subset_closure ⟨q, hq, p, hp, by group⟩,
   convert inv_mem ⁅H₂, H₁⁆ h,
   group,
 end
-
-lemma general_commutator_comm (H₁ H₂ : subgroup G) : ⁅H₁, H₂⁆ = ⁅H₂, H₁⁆ :=
-le_antisymm (general_commutator_comm' _ _) (general_commutator_comm' _ _)
 
 lemma general_commutator_le_right (H₁ H₂ : subgroup G) [h : normal H₂] :
   ⁅H₁, H₂⁆ ≤ H₂ :=

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -11,13 +11,13 @@ import group_theory.abelianization
 
 In this file we introduce the notion of a solvable group. We define a solvable group as one whose
 nth commutator is `1` for some `n`. This requires defining the commutator of two subgroups and
-the nth commutator of a group.
+the derived series of a group.
 
 ## Main definitions
 
 * `general_commutator H₁ H₂` : the commutator of the subgroups `H₁` and `H₂`
-* `nth_commutator G n` : the `n`th commutator of `G`, defined by iterating `general_commutator`
-  starting with the top subgroup
+* `derived_series G n` : the `n`th term in the derived series of `G`, defined by iterating
+  `general_commutator` starting with the top subgroup
 * `is_solvable G` : the group `G` is solvable
 -/
 
@@ -65,27 +65,27 @@ by rw [general_commutator_eq_normal_closure_self, general_commutator,
 
 end general_commutator
 
-section nth_commutator
+section derived_series
 
 variables (G)
 
-/-- The nth commutator of the group `G`, obtained by starting from the subgroup `⊤` and repeatedly
+/-- The derived series of the group `G`, obtained by starting from the subgroup `⊤` and repeatedly
   taking the commutator of the previous subgroup with itself for `n` times. -/
-def nth_commutator (n : ℕ) : subgroup G :=
+def derived_series (n : ℕ) : subgroup G :=
 nat.rec_on n (⊤ : subgroup G) (λ _ H, general_commutator H H)
 
-@[simp] lemma nth_commutator_zero : nth_commutator G 0 = ⊤ := rfl
+@[simp] lemma derived_series_zero : derived_series G 0 = ⊤ := rfl
 
-@[simp] lemma nth_commutator_succ (n : ℕ) :
-  nth_commutator G (n + 1) = general_commutator (nth_commutator G n) (nth_commutator G n) := rfl
+@[simp] lemma derived_series_succ (n : ℕ) :
+  derived_series G (n + 1) = general_commutator (derived_series G n) (derived_series G n) := rfl
 
-lemma nth_commutator_normal (n : ℕ) : (nth_commutator G n).normal :=
+lemma derived_series_normal (n : ℕ) : (derived_series G n).normal :=
 begin
   induction n with n ih,
   { exact subgroup.top_normal, },
-  { haveI : (nth_commutator G n).normal := ih,
-    rw nth_commutator_succ,
-    exact general_commutator_normal (nth_commutator G n) (nth_commutator G n), }
+  { haveI : (derived_series G n).normal := ih,
+    rw derived_series_succ,
+    exact general_commutator_normal (derived_series G n) (derived_series G n), }
 end
 
 lemma commutator_eq_general_commutator_top_top :
@@ -105,23 +105,23 @@ begin
   { exact λ x ⟨p, q, h⟩, ⟨p, mem_top p, q, mem_top q, h⟩ }
 end
 
-@[simp] lemma nth_commutator_one : nth_commutator G 1 = commutator G :=
+@[simp] lemma derived_series_one : derived_series G 1 = commutator G :=
 eq.symm $ commutator_eq_general_commutator_top_top G
 
-end nth_commutator
+end derived_series
 
 section solvable
 
 variables (G)
 
-/-- A group `G` is solvable if for some `n`, its nth commutator is trivial. We use this definition
+/-- A group `G` is solvable if its derived series is eventually trivial. We use this definition
   because it's the most convenient one to work with. -/
-def is_solvable : Prop := ∃ n : ℕ, nth_commutator G n = (⊥ : subgroup G)
+def is_solvable : Prop := ∃ n : ℕ, derived_series G n = (⊥ : subgroup G)
 
 lemma is_solvable_of_comm {G : Type*} [comm_group G] : is_solvable G :=
 begin
   use 1,
-  rw [eq_bot_iff, nth_commutator_one],
+  rw [eq_bot_iff, derived_series_one],
   calc commutator G ≤ (monoid_hom.id G).ker : abelianization.commutator_subset_ker (monoid_hom.id G)
   ... = ⊥ : rfl,
 end

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -129,8 +129,8 @@ begin
     exactI general_commutator_normal (derived_series G n) (derived_series G n), }
 end
 
-lemma commutator_eq_general_commutator_top_top :
-  commutator G = general_commutator (⊤ : subgroup G) (⊤ : subgroup G) :=
+lemma general_commutator_eq_commutator :
+  general_commutator (⊤ : subgroup G) (⊤ : subgroup G) = commutator G :=
 begin
   rw [commutator, general_commutator_def'],
   apply le_antisymm; apply normal_closure_mono,

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -71,7 +71,7 @@ variables (G)
 
 /-- The derived series of the group `G`, obtained by starting from the subgroup `⊤` and repeatedly
   taking the commutator of the previous subgroup with itself for `n` times. -/
-def derived_series : Π n : ℕ, subgroup G
+def derived_series : ℕ → subgroup G
 | 0       := ⊤
 | (n + 1) := general_commutator (derived_series n) (derived_series n)
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -973,11 +973,11 @@ le_antisymm
   (infi_le_of_le (normal_closure s) (infi_le_of_le (by apply_instance)
     (infi_le_of_le subset_normal_closure (le_refl _))))
 
-@[simp] theorem normal_closure_eq_self {H : subgroup G} [H.normal] : normal_closure ↑H = H :=
+@[simp] theorem normal_closure_eq_self (H : subgroup G) [H.normal] : normal_closure ↑H = H :=
 le_antisymm (normal_closure_le_normal rfl.subset) (le_normal_closure)
 
 @[simp] theorem normal_closure_idempotent : normal_closure ↑(normal_closure s) = normal_closure s :=
-normal_closure_eq_self
+normal_closure_eq_self _
 
 theorem closure_le_normal_closure {s : set G} : closure s ≤ normal_closure s :=
 by simp only [subset_normal_closure, closure_le]

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -973,7 +973,7 @@ le_antisymm
   (infi_le_of_le (normal_closure s) (infi_le_of_le (by apply_instance)
     (infi_le_of_le subset_normal_closure (le_refl _))))
 
-theorem normal_closure_eq_self_of_normal {H : subgroup G} [H.normal] : normal_closure ↑H = H :=
+@[simp] theorem normal_closure_eq_self {H : subgroup G} [H.normal] : normal_closure ↑H = H :=
 le_antisymm (normal_closure_le_normal rfl.subset) (le_normal_closure)
 
 @[simp] theorem normal_closure_idempotent : normal_closure ↑(normal_closure s) = normal_closure s :=

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -982,7 +982,7 @@ normal_closure_eq_self_of_normal
 theorem closure_le_normal_closure {s : set G} : closure s ≤ normal_closure s :=
 by simp only [subset_normal_closure, closure_le]
 
-theorem normal_closure_closure_eq_normal_closure {s : set G} :
+@[simp] theorem normal_closure_closure_eq_normal_closure {s : set G} :
   normal_closure ↑(closure s) = normal_closure s :=
 le_antisymm (normal_closure_le_normal closure_le_normal_closure)
   (normal_closure_mono subset_closure)

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -932,6 +932,9 @@ subset_closure
 theorem subset_normal_closure : s ⊆ normal_closure s :=
 set.subset.trans subset_conjugates_of_set conjugates_of_set_subset_normal_closure
 
+theorem le_normal_closure {H : subgroup G} : H ≤ normal_closure ↑H :=
+λ _ h, subset_normal_closure h
+
 /-- The normal closure of `s` is a normal subgroup. -/
 instance normal_closure_normal : (normal_closure s).normal :=
 ⟨λ n h g,
@@ -969,6 +972,20 @@ le_antisymm
   (le_infi (λ N, le_infi (λ hN, by exactI le_infi (normal_closure_le_normal))))
   (infi_le_of_le (normal_closure s) (infi_le_of_le (by apply_instance)
     (infi_le_of_le subset_normal_closure (le_refl _))))
+
+theorem normal_closure_eq_self_of_normal {H : subgroup G} [H.normal] : normal_closure ↑H = H :=
+le_antisymm (normal_closure_le_normal rfl.subset) (le_normal_closure)
+
+theorem normal_closure_idempotent : normal_closure ↑(normal_closure s) = normal_closure s :=
+normal_closure_eq_self_of_normal
+
+theorem closure_le_normal_closure {s : set G} : closure s ≤ normal_closure s :=
+by simp only [subset_normal_closure, closure_le]
+
+theorem normal_closure_closure_eq_normal_closure {s : set G} :
+  normal_closure ↑(closure s) = normal_closure s :=
+le_antisymm (normal_closure_le_normal closure_le_normal_closure)
+  (normal_closure_mono subset_closure)
 
 end subgroup
 namespace add_subgroup

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -976,7 +976,7 @@ le_antisymm
 theorem normal_closure_eq_self_of_normal {H : subgroup G} [H.normal] : normal_closure ↑H = H :=
 le_antisymm (normal_closure_le_normal rfl.subset) (le_normal_closure)
 
-theorem normal_closure_idempotent : normal_closure ↑(normal_closure s) = normal_closure s :=
+@[simp] theorem normal_closure_idempotent : normal_closure ↑(normal_closure s) = normal_closure s :=
 normal_closure_eq_self_of_normal
 
 theorem closure_le_normal_closure {s : set G} : closure s ≤ normal_closure s :=

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -977,7 +977,7 @@ le_antisymm
 le_antisymm (normal_closure_le_normal rfl.subset) (le_normal_closure)
 
 @[simp] theorem normal_closure_idempotent : normal_closure ↑(normal_closure s) = normal_closure s :=
-normal_closure_eq_self_of_normal
+normal_closure_eq_self
 
 theorem closure_le_normal_closure {s : set G} : closure s ≤ normal_closure s :=
 by simp only [subset_normal_closure, closure_le]


### PR DESCRIPTION
Defines solvable groups using the definition that a group is solvable if its nth commutator is eventually trivial. Defines the nth commutator of a group and provides some lemmas for working with it. More facts about solvable groups will come in future PRs.

---

