### PR TITLE
[Merged by Bors] - feat(measure_theory): almost everywhere measurable functions

### DIFF
--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1493,4 +1493,10 @@ lemma measurable.ennreal_rpow_const {α} [measurable_space α] {f : α → ennre
   measurable (λ a : α, (f a) ^ y) :=
 hf.ennreal_rpow measurable_const
 
+lemma ae_measurable.ennreal_rpow_const {α} [measurable_space α] {f : α → ennreal}
+  {μ : measure_theory.measure α} (hf : ae_measurable f μ) {y : ℝ} :
+  ae_measurable (λ a : α, (f a) ^ y) μ :=
+⟨λ a, (hf.mk f a)^y, hf.measurable_mk.ennreal_rpow_const,
+  eventually_eq.fun_comp hf.ae_eq_mk (λ (a : ennreal), a ^ y)⟩
+
 end measurability_ennreal

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -574,20 +574,6 @@ lemma ae_measurable.sub [add_group α] [topological_add_group α] [second_counta
   (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ x, f x - g x) μ :=
 by simpa only [sub_eq_add_neg] using hf.add hg.neg
 
-lemma closed_embedding.measurable_inv_fun [n : nonempty β] {g : β → γ} (hg : closed_embedding g) :
-  measurable (function.inv_fun g) :=
-begin
-  refine measurable_of_is_closed (λ s hs, _),
-  by_cases h : classical.choice n ∈ s,
-  { rw preimage_inv_fun_of_mem hg.to_embedding.inj h,
-    apply is_measurable.union,
-    { exact ((closed_embedding.closed_iff_image_closed hg).mp hs).is_measurable },
-    { exact ((closed_embedding.closed_iff_image_closed hg).mp is_closed_univ).is_measurable.compl }
-  },
-  { rw preimage_inv_fun_of_not_mem hg.to_embedding.inj h,
-    exact ((closed_embedding.closed_iff_image_closed hg).mp hs).is_measurable }
-end
-
 lemma measurable_comp_iff_of_closed_embedding {f : δ → β} (g : β → γ) (hg : closed_embedding g) :
   measurable (g ∘ f) ↔ measurable f :=
 begin
@@ -595,20 +581,6 @@ begin
   apply measurable_of_is_closed, intros s hs,
   convert hf (hg.is_closed_map s hs).is_measurable,
   rw [@preimage_comp _ _ _ f g, preimage_image_eq _ hg.to_embedding.inj]
-end
-
-lemma ae_measurable_comp_iff_of_closed_embedding {f : δ → β} {μ : measure δ}
-  (g : β → γ) (hg : closed_embedding g) : ae_measurable (g ∘ f) μ ↔ ae_measurable f μ :=
-begin
-  by_cases h : nonempty β,
-  { resetI,
-    refine ⟨λ hf, _, λ hf, hg.continuous.measurable.comp_ae_measurable hf⟩,
-    convert hg.measurable_inv_fun.comp_ae_measurable hf,
-    ext x,
-    exact (function.left_inverse_inv_fun hg.to_embedding.inj (f x)).symm },
-  { have H : ¬ nonempty δ, by { contrapose! h, exact nonempty.map f h },
-    simp [(measurable_of_not_nonempty H (g ∘ f)).ae_measurable,
-          (measurable_of_not_nonempty H f).ae_measurable] }
 end
 
 section linear_order

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -30,12 +30,13 @@ import topology.G_delta
   is continuous, then `λ x, op (f x, g y)` is measurable;
 * `measurable.add` etc : dot notation for arithmetic operations on `measurable` predicates,
   and similarly for `dist` and `edist`;
+* `ae_measurable.add` : similar dot notation for almost everywhere measurable functions;
 * `measurable.ennreal*` : special cases for arithmetic operations on `ennreal`s.
 -/
 
 noncomputable theory
 
-open classical set filter
+open classical set filter measure_theory
 open_locale classical big_operators topological_space nnreal
 
 universes u v w x y
@@ -352,9 +353,19 @@ lemma measurable.max {f g : δ → α} (hf : measurable f) (hg : measurable g) :
   measurable (λ a, max (f a) (g a)) :=
 hf.piecewise (is_measurable_le hg hf) hg
 
+lemma ae_measurable.max {f g : δ → α} {μ : measure δ}
+  (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ a, max (f a) (g a)) μ :=
+⟨λ a, max (hf.mk f a) (hg.mk g a), hf.measurable_mk.max hg.measurable_mk,
+  eventually_eq.comp₂ hf.ae_eq_mk _ hg.ae_eq_mk⟩
+
 lemma measurable.min {f g : δ → α} (hf : measurable f) (hg : measurable g) :
   measurable (λ a, min (f a) (g a)) :=
 hf.piecewise (is_measurable_le hf hg) hg
+
+lemma ae_measurable.min {f g : δ → α} {μ : measure δ}
+  (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ a, min (f a) (g a)) μ :=
+⟨λ a, min (hf.mk f a) (hg.mk g a), hf.measurable_mk.min hg.measurable_mk,
+  eventually_eq.comp₂ hf.ae_eq_mk _ hg.ae_eq_mk⟩
 
 end linear_order
 
@@ -392,6 +403,14 @@ lemma measurable.smul [semiring α] [second_countable_topology α]
   measurable (λ c, f c • g c) :=
 continuous_smul.measurable2 hf hg
 
+lemma ae_measurable.smul [semiring α] [second_countable_topology α]
+  [add_comm_monoid γ] [second_countable_topology γ]
+  [semimodule α γ] [topological_semimodule α γ]
+  {f : δ → α} {g : δ → γ} {μ : measure δ} (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
+  ae_measurable (λ c, f c • g c) μ :=
+⟨λ a, hf.mk f a • hg.mk g a, hf.measurable_mk.smul hg.measurable_mk,
+  eventually_eq.comp₂ hf.ae_eq_mk _ hg.ae_eq_mk⟩
+
 lemma measurable.const_smul {R M : Type*} [topological_space R] [semiring R]
   [add_comm_monoid M] [semimodule R M] [topological_space M] [topological_semimodule R M]
   [measurable_space M] [borel_space M]
@@ -399,11 +418,26 @@ lemma measurable.const_smul {R M : Type*} [topological_space R] [semiring R]
   measurable (λ x, c • f x) :=
 (continuous_const.smul continuous_id).measurable.comp hf
 
+lemma ae_measurable.const_smul {R M : Type*} [topological_space R] [semiring R]
+  [add_comm_monoid M] [semimodule R M] [topological_space M] [topological_semimodule R M]
+  [measurable_space M] [borel_space M]
+  {f : δ → M} {μ : measure δ} (hf : ae_measurable f μ) (c : R) :
+  ae_measurable (λ x, c • f x) μ :=
+⟨λ a, c • hf.mk f a, hf.measurable_mk.const_smul _, eventually_eq.fun_comp hf.ae_eq_mk _⟩
+
 lemma measurable_const_smul_iff {α : Type*} [topological_space α]
   [division_ring α] [add_comm_monoid γ]
   [semimodule α γ] [topological_semimodule α γ]
   {f : δ → γ} {c : α} (hc : c ≠ 0) :
   measurable (λ x, c • f x) ↔ measurable f :=
+⟨λ h, by simpa only [smul_smul, inv_mul_cancel hc, one_smul] using h.const_smul c⁻¹,
+  λ h, h.const_smul c⟩
+
+lemma ae_measurable_const_smul_iff {α : Type*} [topological_space α]
+  [division_ring α] [add_comm_monoid γ]
+  [semimodule α γ] [topological_semimodule α γ]
+  {f : δ → γ} {μ : measure δ} {c : α} (hc : c ≠ 0) :
+  ae_measurable (λ x, c • f x) μ ↔ ae_measurable f μ :=
 ⟨λ h, by simpa only [smul_smul, inv_mul_cancel hc, one_smul] using h.const_smul c⁻¹,
   λ h, h.const_smul c⟩
 
@@ -466,6 +500,13 @@ lemma measurable.mul [has_mul α] [has_continuous_mul α] [second_countable_topo
   {f : δ → α} {g : δ → α} : measurable f → measurable g → measurable (λ a, f a * g a) :=
 (@continuous_mul α _ _ _).measurable2
 
+@[to_additive]
+lemma ae_measurable.mul [has_mul α] [has_continuous_mul α] [second_countable_topology α]
+  {f : δ → α} {g : δ → α} {μ : measure δ}
+  (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ a, f a * g a) μ :=
+⟨λ a, hf.mk f a * hg.mk g a, hf.measurable_mk.mul hg.measurable_mk,
+  eventually_eq.comp₂ hf.ae_eq_mk _ hg.ae_eq_mk⟩
+
 /-- A variant of `measurable.mul` that uses `*` on functions -/
 @[to_additive]
 lemma measurable.mul' [has_mul α] [has_continuous_mul α] [second_countable_topology α]
@@ -499,6 +540,11 @@ lemma measurable.inv [group α] [topological_group α] {f : δ → α} (hf : mea
   measurable (λ a, (f a)⁻¹) :=
 measurable_inv.comp hf
 
+@[to_additive]
+lemma ae_measurable.inv [group α] [topological_group α] {f : δ → α} {μ : measure δ}
+  (hf : ae_measurable f μ) : ae_measurable (λ a, (f a)⁻¹) μ :=
+⟨λ a, (hf.mk f a)⁻¹, hf.measurable_mk.inv, eventually_eq.fun_comp hf.ae_eq_mk _⟩
+
 lemma measurable_inv' {α : Type*} [normed_field α] [measurable_space α] [borel_space α] :
   measurable (has_inv.inv : α → α) :=
 measurable_of_continuous_on_compl_singleton 0 continuous_on_inv'
@@ -523,6 +569,25 @@ lemma measurable.sub [add_group α] [topological_add_group α] [second_countable
   measurable (λ x, f x - g x) :=
 by simpa only [sub_eq_add_neg] using hf.add hg.neg
 
+lemma ae_measurable.sub [add_group α] [topological_add_group α] [second_countable_topology α]
+  {f g : δ → α} {μ : measure δ}
+  (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ x, f x - g x) μ :=
+by simpa only [sub_eq_add_neg] using hf.add hg.neg
+
+lemma closed_embedding.measurable_inv_fun [n : nonempty β] {g : β → γ} (hg : closed_embedding g) :
+  measurable (function.inv_fun g) :=
+begin
+  refine measurable_of_is_closed (λ s hs, _),
+  by_cases h : classical.choice n ∈ s,
+  { rw preimage_inv_fun_of_mem hg.to_embedding.inj h,
+    apply is_measurable.union,
+    { exact ((closed_embedding.closed_iff_image_closed hg).mp hs).is_measurable },
+    { exact ((closed_embedding.closed_iff_image_closed hg).mp is_closed_univ).is_measurable.compl }
+  },
+  { rw preimage_inv_fun_of_not_mem hg.to_embedding.inj h,
+    exact ((closed_embedding.closed_iff_image_closed hg).mp hs).is_measurable }
+end
+
 lemma measurable_comp_iff_of_closed_embedding {f : δ → β} (g : β → γ) (hg : closed_embedding g) :
   measurable (g ∘ f) ↔ measurable f :=
 begin
@@ -530,6 +595,20 @@ begin
   apply measurable_of_is_closed, intros s hs,
   convert hf (hg.is_closed_map s hs).is_measurable,
   rw [@preimage_comp _ _ _ f g, preimage_image_eq _ hg.to_embedding.inj]
+end
+
+lemma ae_measurable_comp_iff_of_closed_embedding {f : δ → β} {μ : measure δ}
+  (g : β → γ) (hg : closed_embedding g) : ae_measurable (g ∘ f) μ ↔ ae_measurable f μ :=
+begin
+  by_cases h : nonempty β,
+  { resetI,
+    refine ⟨λ hf, _, λ hf, hg.continuous.measurable.comp_ae_measurable hf⟩,
+    convert hg.measurable_inv_fun.comp_ae_measurable hf,
+    ext x,
+    exact (function.left_inverse_inv_fun hg.to_embedding.inj (f x)).symm },
+  { have H : ¬ nonempty δ, by { contrapose! h, exact nonempty.map f h },
+    simp [(measurable_of_not_nonempty H (g ∘ f)).ae_measurable,
+          (measurable_of_not_nonempty H f).ae_measurable] }
 end
 
 section linear_order
@@ -783,6 +862,11 @@ lemma measurable.edist {f g : β → α} (hf : measurable f) (hg : measurable g)
   measurable (λ b, edist (f b) (g b)) :=
 (@continuous_edist α _).measurable2 hf hg
 
+lemma ae_measurable.edist {f g : β → α} {μ : measure β}
+  (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ a, edist (f a) (g a)) μ :=
+⟨λ a, edist (hf.mk f a) (hg.mk g a), hf.measurable_mk.edist hg.measurable_mk,
+  eventually_eq.comp₂ hf.ae_eq_mk _ hg.ae_eq_mk⟩
+
 end emetric_space
 
 namespace real
@@ -859,6 +943,10 @@ nnreal.measurable_coe.comp hf
 lemma measurable.ennreal_coe {f : α → ℝ≥0} (hf : measurable f) :
   measurable (λ x, (f x : ennreal)) :=
 ennreal.continuous_coe.measurable.comp hf
+
+lemma ae_measurable.ennreal_coe {f : α → ℝ≥0} {μ : measure α} (hf :  ae_measurable f μ) :
+  ae_measurable (λ x, (f x : ennreal)) μ :=
+ennreal.continuous_coe.measurable.comp_ae_measurable hf
 
 lemma measurable.ennreal_of_real {f : α → ℝ} (hf : measurable f) :
   measurable (λ x, ennreal.of_real (f x)) :=
@@ -940,13 +1028,17 @@ lemma measurable.to_real {f : α → ennreal} (hf : measurable f) :
   measurable (λ x, ennreal.to_real (f x)) :=
 ennreal.measurable_to_real.comp hf
 
+lemma ae_measurable.to_real {f : α → ennreal} {μ : measure α} (hf : ae_measurable f μ) :
+  ae_measurable (λ x, ennreal.to_real (f x)) μ :=
+ennreal.measurable_to_real.comp_ae_measurable hf
+
 lemma measurable.ennreal_mul {f g : α → ennreal} (hf : measurable f) (hg : measurable g) :
   measurable (λ a, f a * g a) :=
 ennreal.measurable_mul.comp (hf.prod_mk hg)
 
-lemma measurable.ennreal_add {f g : α → ennreal}
-  (hf : measurable f) (hg : measurable g) : measurable (λ a, f a + g a) :=
-hf.add hg
+lemma ae_measurable.ennreal_mul {f g : α → ennreal} {μ : measure α}
+  (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ a, f a * g a) μ:=
+ennreal.measurable_mul.comp_ae_measurable (hf.prod_mk hg)
 
 lemma measurable.ennreal_sub {f g : α → ennreal} (hf : measurable f) (hg : measurable g) :
   measurable (λ a, f a - g a) :=
@@ -967,11 +1059,19 @@ continuous_norm.measurable
 lemma measurable.norm {f : β → α} (hf : measurable f) : measurable (λ a, norm (f a)) :=
 measurable_norm.comp hf
 
+lemma ae_measurable.norm {f : β → α} {μ : measure β} (hf : ae_measurable f μ) :
+  ae_measurable (λ a, norm (f a)) μ :=
+⟨λ a, norm (hf.mk f a), hf.measurable_mk.norm, hf.ae_eq_mk.fun_comp _⟩
+
 lemma measurable_nnnorm : measurable (nnnorm : α → ℝ≥0) :=
 continuous_nnnorm.measurable
 
 lemma measurable.nnnorm {f : β → α} (hf : measurable f) : measurable (λ a, nnnorm (f a)) :=
 measurable_nnnorm.comp hf
+
+lemma ae_measurable.nnnorm {f : β → α} {μ : measure β} (hf : ae_measurable f μ) :
+  ae_measurable (λ a, nnnorm (f a)) μ :=
+⟨λ a, nnnorm (hf.mk f a), hf.measurable_mk.nnnorm, hf.ae_eq_mk.fun_comp _⟩
 
 lemma measurable_ennnorm : measurable (λ x : α, (nnnorm x : ennreal)) :=
 measurable_nnnorm.ennreal_coe
@@ -979,6 +1079,11 @@ measurable_nnnorm.ennreal_coe
 lemma measurable.ennnorm {f : β → α} (hf : measurable f) :
   measurable (λ a, (nnnorm (f a) : ennreal)) :=
 hf.nnnorm.ennreal_coe
+
+lemma ae_measurable.ennnorm {f : β → α} {μ : measure β} (hf : ae_measurable f μ) :
+  ae_measurable (λ a, (nnnorm (f a) : ennreal)) μ :=
+⟨(λ a, (nnnorm (hf.mk f a) : ennreal)), hf.measurable_mk.ennnorm,
+  hf.ae_eq_mk.fun_comp (λ a : α, (nnnorm a : ennreal))⟩
 
 end normed_group
 
@@ -1058,6 +1163,10 @@ variables {E : Type*} [normed_group E] [normed_space 𝕜 E] [measurable_space E
 lemma measurable_smul_const {f : α → 𝕜} {c : E} (hc : c ≠ 0) :
   measurable (λ x, f x • c) ↔ measurable f :=
 measurable_comp_iff_of_closed_embedding (λ y : 𝕜, y • c) (closed_embedding_smul_left hc)
+
+lemma ae_measurable_smul_const {f : α → 𝕜} {μ : measure α} {c : E} (hc : c ≠ 0) :
+  ae_measurable (λ x, f x • c) μ ↔ ae_measurable f μ :=
+ae_measurable_comp_iff_of_closed_embedding (λ y : 𝕜, y • c) (closed_embedding_smul_left hc)
 
 end normed_space
 

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -1136,10 +1136,6 @@ lemma measurable_smul_const {f : α → 𝕜} {c : E} (hc : c ≠ 0) :
   measurable (λ x, f x • c) ↔ measurable f :=
 measurable_comp_iff_of_closed_embedding (λ y : 𝕜, y • c) (closed_embedding_smul_left hc)
 
-lemma ae_measurable_smul_const {f : α → 𝕜} {μ : measure α} {c : E} (hc : c ≠ 0) :
-  ae_measurable (λ x, f x • c) μ ↔ ae_measurable f μ :=
-ae_measurable_comp_iff_of_closed_embedding (λ y : 𝕜, y • c) (closed_embedding_smul_left hc)
-
 end normed_space
 
 namespace measure_theory

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -538,6 +538,13 @@ hf.piecewise hs measurable_const
 @[to_additive]
 lemma measurable_one [has_one α] : measurable (1 : β → α) := @measurable_const _ _ _ _ 1
 
+lemma measurable_of_not_nonempty  (h : ¬ nonempty α) (f : α → β) : measurable f :=
+begin
+  assume s hs,
+  convert is_measurable.empty,
+  exact eq_empty_of_not_nonempty h _,
+end
+
 end measurable_functions
 
 section constructions

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -709,6 +709,9 @@ lemma map_map {g : β → γ} {f : α → β} (hg : measurable g) (hf : measurab
 ext $ λ s hs,
 by simp [hf, hg, hs, hg hs, hg.comp hf, ← preimage_comp]
 
+lemma map_mono {f : α → β} (hf : measurable f) (h : μ ≤ ν) : map f μ ≤ map f ν :=
+λ s hs, by simp [hf, hs, h _ (hf hs)]
+
 /-- Even if `s` is not measurable, we can bound `map f μ s` from below.
   See also `measurable_equiv.map_apply`. -/
 theorem le_map_apply {f : α → β} (hf : measurable f) (s : set β) : μ (f ⁻¹' s) ≤ map f μ s :=
@@ -1244,6 +1247,10 @@ lemma diff_ae_eq_self : (s \ t : set α) =ᵐ[μ] s ↔ μ (s ∩ t) = 0 :=
 by simp [eventually_le_antisymm_iff, ae_le_set, diff_diff_right,
   diff_diff, diff_eq_empty.2 (set.subset_union_right _ _)]
 
+lemma ae_eq_set {s t : set α} :
+  s =ᵐ[μ] t ↔ μ (s \ t) = 0 ∧ μ (t \ s) = 0 :=
+by simp [eventually_le_antisymm_iff, ae_le_set]
+
 lemma mem_ae_map_iff {f : α → β} (hf : measurable f) {s : set β} (hs : is_measurable s) :
   s ∈ (map f μ).ae ↔ (f ⁻¹' s) ∈ μ.ae :=
 by simp only [mem_ae_iff, map_apply hf hs.compl, preimage_compl]
@@ -1259,11 +1266,31 @@ begin
   congr' with x, simp [and_comm]
 end
 
+lemma ae_restrict_iff' {s : set α} {p : α → Prop} (hp : is_measurable s) :
+  (∀ᵐ x ∂(μ.restrict s), p x) ↔ ∀ᵐ x ∂μ, x ∈ s → p x :=
+begin
+  simp only [ae_iff, ← compl_set_of, restrict_apply_eq_zero' hp],
+  congr' with x, simp [and_comm]
+end
+
 lemma ae_smul_measure {p : α → Prop} (h : ∀ᵐ x ∂μ, p x) (c : ennreal) : ∀ᵐ x ∂(c • μ), p x :=
 ae_iff.2 $ by rw [smul_apply, ae_iff.1 h, mul_zero]
 
+lemma ae_smul_measure_iff {p : α → Prop} {c : ennreal} (hc : c ≠ 0) :
+  (∀ᵐ x ∂(c • μ), p x) ↔ ∀ᵐ x ∂μ, p x :=
+by simp [ae_iff, hc]
+
 lemma ae_add_measure_iff {p : α → Prop} {ν} : (∀ᵐ x ∂μ + ν, p x) ↔ (∀ᵐ x ∂μ, p x) ∧ ∀ᵐ x ∂ν, p x :=
 add_eq_zero_iff
+
+lemma ae_eq_comp {f : α → β} {g g' : β → δ} (hf : measurable f)
+  (h : g =ᵐ[measure.map f μ] g') : g ∘ f =ᵐ[μ] g' ∘ f :=
+begin
+  rcases exists_is_measurable_superset_of_measure_eq_zero h with ⟨t, ht, tmeas, tzero⟩,
+  refine le_antisymm _ bot_le,
+  calc μ {x | g (f x) ≠ g' (f x)} ≤ μ (f⁻¹' t) : measure_mono (λ x hx, ht hx)
+  ... = 0 : by rwa ← measure.map_apply hf tmeas
+end
 
 @[simp] lemma ae_restrict_eq (hs : is_measurable s) : (μ.restrict s).ae = μ.ae ⊓ 𝓟 s :=
 begin
@@ -1852,6 +1879,74 @@ begin
   exact ht.compl.diff_null hz
 end
 
+theorem is_null_measurable_iff_ae {s : set α} :
+  is_null_measurable μ s ↔ ∃ t, is_measurable t ∧ s =ᵐ[μ] t :=
+begin
+  simp only [ae_eq_set],
+  split,
+  { assume h,
+    rcases is_null_measurable_iff.1 h with ⟨t, ts, tmeas, ht⟩,
+    refine ⟨t, tmeas, ht, _⟩,
+    rw [diff_eq_empty.2 ts, measure_empty] },
+  { rintros ⟨t, tmeas, h₁, h₂⟩,
+    have : is_null_measurable μ (t ∪ (s \ t)) :=
+      is_null_measurable.union_null (tmeas.is_null_measurable _) h₁,
+    have A : is_null_measurable μ ((t ∪ (s \ t)) \ (t \ s)) :=
+      is_null_measurable.diff_null this h₂,
+    have : (t ∪ (s \ t)) \ (t \ s) = s,
+    { apply subset.antisymm,
+      { assume x hx,
+        simp only [mem_union_eq, not_and, mem_diff, not_not_mem] at hx,
+        cases hx.1, { exact hx.2 h }, { exact h.1 } },
+      { assume x hx,
+        simp [hx, classical.em (x ∈ t)] } },
+    rwa this at A }
+end
+
+theorem is_null_measurable_iff_sandwich {s : set α} :
+  is_null_measurable μ s ↔
+  ∃ (t u : set α), is_measurable t ∧ is_measurable u ∧ t ⊆ s ∧ s ⊆ u ∧ μ (u \ t) = 0 :=
+begin
+  split,
+  { assume h,
+    rcases is_null_measurable_iff.1 h with ⟨t, ts, tmeas, ht⟩,
+    rcases is_null_measurable_iff.1 h.compl with ⟨u', u's, u'meas, hu'⟩,
+    have A : s ⊆ u'ᶜ := subset_compl_comm.mp u's,
+    refine ⟨t, u'ᶜ, tmeas, u'meas.compl, ts, A, _⟩,
+    have : sᶜ \ u' = u'ᶜ \ s, by simp [compl_eq_univ_diff, diff_diff, union_comm],
+    rw this at hu',
+    apply le_antisymm _ bot_le,
+    calc μ (u'ᶜ \ t) ≤ μ ((u'ᶜ \ s) ∪ (s \ t)) :
+    begin
+      apply measure_mono,
+      assume x hx,
+      simp at hx,
+      simp [hx, or_comm, classical.em],
+    end
+    ... ≤ μ (u'ᶜ \ s) + μ (s \ t) : measure_union_le _ _
+    ... = 0 : by rw [ht, hu', zero_add] },
+  { rintros ⟨t, u, tmeas, umeas, ts, su, hμ⟩,
+    refine is_null_measurable_iff.2 ⟨t, ts, tmeas, _⟩,
+    apply le_antisymm _ bot_le,
+    calc μ (s \ t) ≤ μ (u \ t) : measure_mono (diff_subset_diff_left su)
+    ... = 0 : hμ }
+end
+
+lemma restrict_apply_of_is_null_measurable {s t : set α}
+  (ht : is_null_measurable (μ.restrict s) t) : μ.restrict s t = μ (t ∩ s) :=
+begin
+  rcases is_null_measurable_iff_sandwich.1 ht with ⟨u, v, umeas, vmeas, ut, tv, huv⟩,
+  apply le_antisymm _ (le_restrict_apply _ _),
+  calc μ.restrict s t ≤ μ.restrict s v : measure_mono tv
+  ... = μ (v ∩ s) : restrict_apply vmeas
+  ... ≤ μ ((u ∩ s) ∪ ((v \ u) ∩ s)) : measure_mono $
+    by { assume x hx, simp at hx, simp [hx, classical.em] }
+  ... ≤ μ (u ∩ s) + μ ((v \ u) ∩ s) : measure_union_le _ _
+  ... = μ (u ∩ s) + μ.restrict s (v \ u) : by rw measure.restrict_apply (vmeas.diff umeas)
+  ... = μ (u ∩ s) : by rw [huv, add_zero]
+  ... ≤ μ (t ∩ s) : measure_mono $ inter_subset_inter_left s ut
+end
+
 /-- The measurable space of all null measurable sets. -/
 def null_measurable (μ : measure α) : measurable_space α :=
 { is_measurable' := is_null_measurable μ,
@@ -1915,6 +2010,127 @@ meta def volume_tac : tactic unit := `[exact measure_theory.measure_space.volume
 end measure_space
 
 end measure_theory
+
+/-!
+# Almost everywhere measurable functions
+
+A function is almost everywhere measurable if it coincides almost everywhere with a measurable
+function. We define this property, called `ae_measurable f μ`, and discuss several of its properties
+that are analogous to properties of measurable functions.
+-/
+
+section
+open measure_theory
+
+variables [measurable_space α] [measurable_space β]
+{f g : α → β} {μ ν : measure α}
+
+/-- A function is almost everywhere measurable if it coincides almost everywhere with a measurable
+function. -/
+def ae_measurable (f : α → β) (μ : measure α . measure_theory.volume_tac) : Prop :=
+∃ g : α → β, measurable g ∧ f =ᵐ[μ] g
+
+lemma measurable.ae_measurable (h : measurable f) : ae_measurable f μ :=
+⟨f, h, ae_eq_refl f⟩
+
+namespace ae_measurable
+
+/-- Given an almost everywhere measurable function `f`, associate to it a measurable function
+that coincides with it almost everywhere. `f` is explicit in the definition to make sure that
+it shows in pretty-printing. -/
+def mk (f : α → β) (h : ae_measurable f μ) : α → β := classical.some h
+
+lemma measurable_mk (h : ae_measurable f μ) : measurable (h.mk f) :=
+(classical.some_spec h).1
+
+lemma ae_eq_mk (h : ae_measurable f μ) : f =ᵐ[μ] (h.mk f) :=
+(classical.some_spec h).2
+
+lemma congr (hf : ae_measurable f μ) (h : f =ᵐ[μ] g) : ae_measurable g μ :=
+⟨hf.mk f, hf.measurable_mk, h.symm.trans hf.ae_eq_mk⟩
+
+lemma mono_measure (h : ae_measurable f μ) (h' : ν ≤ μ) : ae_measurable f ν :=
+begin
+  exact ⟨h.mk f, h.measurable_mk, eventually.filter_mono (ae_mono h') h.ae_eq_mk⟩
+end
+
+lemma add_measure {f : α → β} (hμ : ae_measurable f μ) (hν : ae_measurable f ν) :
+  ae_measurable f (μ + ν) :=
+begin
+  let s := {x | f x ≠ hμ.mk f x},
+  have : μ s = 0 := hμ.ae_eq_mk,
+  obtain ⟨t, st, t_meas, μt⟩ : ∃ t, s ⊆ t ∧ is_measurable t ∧ μ t = 0 :=
+    exists_is_measurable_superset_of_measure_eq_zero this,
+  let g : α → β := t.piecewise (hν.mk f) (hμ.mk f),
+  refine ⟨g, measurable.piecewise t_meas hν.measurable_mk hμ.measurable_mk, _⟩,
+  change μ {x | f x ≠ g x} + ν {x | f x ≠ g x} = 0,
+  suffices : μ {x | f x ≠ g x} = 0 ∧ ν {x | f x ≠ g x} = 0, by simp [this.1, this.2],
+  have ht : {x | f x ≠ g x} ⊆ t,
+  { assume x hx,
+    by_contra h,
+    simp only [g, h, mem_set_of_eq, ne.def, not_false_iff, piecewise_eq_of_not_mem] at hx,
+    exact h (st hx) },
+  split,
+  { have : μ {x | f x ≠ g x} ≤ μ t := measure_mono ht,
+    rw μt at this,
+    exact le_antisymm this bot_le },
+  { have : {x | f x ≠ g x} ⊆ {x | f x ≠ hν.mk f x},
+    { assume x hx,
+      simpa [ht hx, g] using hx },
+    apply le_antisymm _ bot_le,
+    calc ν {x | f x ≠ g x} ≤ ν {x | f x ≠ hν.mk f x} : measure_mono this
+    ... = 0 : hν.ae_eq_mk }
+end
+
+lemma smul_measure (h : ae_measurable f μ) (c : ennreal) :
+  ae_measurable f (c • μ) :=
+⟨h.mk f, h.measurable_mk, ae_smul_measure h.ae_eq_mk c⟩
+
+lemma comp_measurable [measurable_space δ] {f : α → δ} {g : δ → β}
+  (hg : ae_measurable g (measure.map f μ)) (hf : measurable f) : ae_measurable (g ∘ f) μ :=
+⟨(hg.mk g) ∘ f, hg.measurable_mk.comp hf, ae_eq_comp hf hg.ae_eq_mk⟩
+
+lemma prod_mk {γ : Type*} [measurable_space γ] {f : α → β} {g : α → γ}
+  (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ x, (f x, g x)) μ :=
+⟨λ a, (hf.mk f a, hg.mk g a), hf.measurable_mk.prod_mk hg.measurable_mk,
+  eventually_eq.prod_mk hf.ae_eq_mk hg.ae_eq_mk⟩
+
+lemma is_null_measurable (h : ae_measurable f μ) {s : set β} (hs : is_measurable s) :
+  is_null_measurable μ (f ⁻¹' s) :=
+begin
+  apply is_null_measurable_iff_ae.2,
+  refine ⟨(h.mk f) ⁻¹' s, h.measurable_mk hs, _⟩,
+  filter_upwards [h.ae_eq_mk],
+  assume x hx,
+  change (f x ∈ s) = ((h.mk f) x ∈ s),
+  rwa hx
+end
+
+end ae_measurable
+
+lemma ae_measurable_congr (h : f =ᵐ[μ] g) :
+  ae_measurable f μ ↔ ae_measurable g μ :=
+⟨λ hf, ae_measurable.congr hf h, λ hg, ae_measurable.congr hg h.symm⟩
+
+@[simp] lemma ae_measurable_add_measure_iff :
+  ae_measurable f (μ + ν) ↔ ae_measurable f μ ∧ ae_measurable f ν :=
+⟨λ h, ⟨h.mono_measure (measure.le_add_right (le_refl _)),
+         h.mono_measure (measure.le_add_left (le_refl _))⟩,
+  λ h, h.1.add_measure h.2⟩
+
+@[simp] lemma ae_measurable_const {b : β} : ae_measurable (λ a : α, b) μ :=
+measurable_const.ae_measurable
+
+@[simp] lemma ae_measurable_smul_measure_iff {c : ennreal} (hc : c ≠ 0) :
+  ae_measurable f (c • μ) ↔ ae_measurable f μ :=
+⟨λ h, ⟨h.mk f, h.measurable_mk, (ae_smul_measure_iff hc).1 h.ae_eq_mk⟩,
+  λ h, ⟨h.mk f, h.measurable_mk, (ae_smul_measure_iff hc).2 h.ae_eq_mk⟩⟩
+
+lemma measurable.comp_ae_measurable [measurable_space δ] {f : α → δ} {g : δ → β}
+  (hg : measurable g) (hf : ae_measurable f μ) : ae_measurable (g ∘ f) μ :=
+⟨g ∘ hf.mk f, hg.comp hf.measurable_mk, eventually_eq.fun_comp hf.ae_eq_mk _⟩
+
+end
 
 namespace is_compact
 


### PR DESCRIPTION
This PR introduces a notion of almost everywhere measurable function, i.e., a function which coincides almost everywhere with a measurable function, and builds a basic API around the notion. It will then be used in #5510 to extend the Bochner integral. The main new definition in the PR is `h : ae_measurable f μ`. It comes with `h.mk f` building a measurable function that coincides almost everywhere with `f` (these assertions are respectively `h.measurable_mk` and `h.ae_eq_mk`).

---
Preliminary for #5510