### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/{finite_dimension, inner_product}): assorted finite-dimensionality lemmas

### DIFF
--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -177,6 +177,28 @@ def linear_equiv.to_continuous_linear_equiv [finite_dimensional 𝕜 E] (e : E �
   end,
   ..e }
 
+/-- Two finite-dimensional normed spaces are linearly equivalent if they have the same (finite)
+dimension. -/
+theorem finite_dimensional.nonempty_continuous_linear_equiv_of_findim_eq
+  [finite_dimensional 𝕜 E] [finite_dimensional 𝕜 F] (cond : findim 𝕜 E = findim 𝕜 F) :
+  nonempty (E ≃L[𝕜] F) :=
+(nonempty_linear_equiv_of_findim_eq cond).map linear_equiv.to_continuous_linear_equiv
+
+/-- Two finite-dimensional normed spaces are linearly equivalent if and only if they have the same
+(finite) dimension. -/
+theorem finite_dimensional.nonempty_continuous_linear_equiv_iff_findim_eq
+  [finite_dimensional 𝕜 E] [finite_dimensional 𝕜 F] :
+   nonempty (E ≃L[𝕜] F) ↔ findim 𝕜 E = findim 𝕜 F :=
+⟨ λ ⟨h⟩, h.to_linear_equiv.findim_eq,
+  λ h, finite_dimensional.nonempty_continuous_linear_equiv_of_findim_eq h⟩
+
+/-- A continuous linear equivalence between two finite-dimensional normed spaces of the same
+(finite) dimension. -/
+def continuous_linear_equiv.of_findim_eq [finite_dimensional 𝕜 E] [finite_dimensional 𝕜 F]
+  (cond : findim 𝕜 E = findim 𝕜 F) :
+  E ≃L[𝕜] F :=
+(linear_equiv.of_findim_eq E F cond).to_continuous_linear_equiv
+
 variables {ι : Type*} [fintype ι]
 
 /-- Construct a continuous linear map given the value at a finite basis. -/

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -190,7 +190,7 @@ theorem finite_dimensional.nonempty_continuous_linear_equiv_iff_findim_eq
   [finite_dimensional 𝕜 E] [finite_dimensional 𝕜 F] :
    nonempty (E ≃L[𝕜] F) ↔ findim 𝕜 E = findim 𝕜 F :=
 ⟨ λ ⟨h⟩, h.to_linear_equiv.findim_eq,
-  λ h, finite_dimensional.nonempty_continuous_linear_equiv_of_findim_eq h⟩
+  λ h, finite_dimensional.nonempty_continuous_linear_equiv_of_findim_eq h ⟩
 
 /-- A continuous linear equivalence between two finite-dimensional normed spaces of the same
 (finite) dimension. -/

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -177,15 +177,15 @@ def linear_equiv.to_continuous_linear_equiv [finite_dimensional 𝕜 E] (e : E �
   end,
   ..e }
 
-/-- Two finite-dimensional normed spaces are linearly equivalent if they have the same (finite)
-dimension. -/
+/-- Two finite-dimensional normed spaces are continuously linearly equivalent if they have the same
+(finite) dimension. -/
 theorem finite_dimensional.nonempty_continuous_linear_equiv_of_findim_eq
   [finite_dimensional 𝕜 E] [finite_dimensional 𝕜 F] (cond : findim 𝕜 E = findim 𝕜 F) :
   nonempty (E ≃L[𝕜] F) :=
 (nonempty_linear_equiv_of_findim_eq cond).map linear_equiv.to_continuous_linear_equiv
 
-/-- Two finite-dimensional normed spaces are linearly equivalent if and only if they have the same
-(finite) dimension. -/
+/-- Two finite-dimensional normed spaces are continuously linearly equivalent if and only if they
+have the same (finite) dimension. -/
 theorem finite_dimensional.nonempty_continuous_linear_equiv_iff_findim_eq
   [finite_dimensional 𝕜 E] [finite_dimensional 𝕜 F] :
    nonempty (E ≃L[𝕜] F) ↔ findim 𝕜 E = findim 𝕜 F :=

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1851,4 +1851,38 @@ begin
   rw add_zero at hd,
   exact hd.symm
 end
+
+/-- Given a finite-dimensional subspace `K₂`, and a subspace `K₁`
+containined in it, the dimensions of `K₁` and the intersection of its
+orthogonal subspace with `K₂` add to that of `K₂`. -/
+lemma submodule.findim_add_inf_findim_orthogonal' {K₁ K₂ : submodule 𝕜 E}
+  [finite_dimensional 𝕜 K₂] (h : K₁ ≤ K₂) {n : ℕ} (h_dim : findim 𝕜 K₁ + n = findim 𝕜 K₂) :
+  findim 𝕜 (K₁ᗮ ⊓ K₂ : submodule 𝕜 E) = n :=
+begin
+  refine (add_right_inj (findim 𝕜 ↥K₁)).mp _,
+  simp [submodule.findim_add_inf_findim_orthogonal h, h_dim]
+end
+
+/-- Given a finite-dimensional space `E` and subspace `K`, the dimensions of `K` and `Kᗮ` add to
+that of `E`. -/
+lemma submodule.findim_add_findim_orthogonal [finite_dimensional 𝕜 E] {K : submodule 𝕜 E} :
+  findim 𝕜 K + findim 𝕜 Kᗮ = findim 𝕜 E :=
+begin
+  have : findim 𝕜 E = findim 𝕜 (⊤ : submodule 𝕜 E) := findim_top.symm,
+  have : Kᗮ = Kᗮ ⊓ ⊤ := inf_top_eq.symm,
+  convert submodule.findim_add_inf_findim_orthogonal (le_top : K ≤ ⊤)
+end
+
+/-- Given a finite-dimensional space `E` and subspace `K`, the dimensions of `K` and `Kᗮ` add to
+that of `E`. -/
+lemma submodule.findim_add_findim_orthogonal' [finite_dimensional 𝕜 E] {K : submodule 𝕜 E} {n : ℕ}
+  (h_dim : findim 𝕜 K + n = findim 𝕜 E) :
+  findim 𝕜 Kᗮ = n :=
+begin
+  have : findim 𝕜 E = findim 𝕜 (⊤ : submodule 𝕜 E) := findim_top.symm,
+  rw this at h_dim,
+  have : Kᗮ = Kᗮ ⊓ ⊤ := inf_top_eq.symm,
+  convert submodule.findim_add_inf_findim_orthogonal' (le_top : K ≤ ⊤) h_dim
+end
+
 end orthogonal

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1865,9 +1865,9 @@ that of `E`. -/
 lemma submodule.findim_add_findim_orthogonal [finite_dimensional 𝕜 E] {K : submodule 𝕜 E} :
   findim 𝕜 K + findim 𝕜 Kᗮ = findim 𝕜 E :=
 begin
-  have : findim 𝕜 E = findim 𝕜 (⊤ : submodule 𝕜 E) := findim_top.symm,
-  have : Kᗮ = Kᗮ ⊓ ⊤ := inf_top_eq.symm,
-  convert submodule.findim_add_inf_findim_orthogonal (le_top : K ≤ ⊤)
+  convert submodule.findim_add_inf_findim_orthogonal (le_top : K ≤ ⊤) using 1,
+  { rw inf_top_eq },
+  { simp }
 end
 
 /-- Given a finite-dimensional space `E` and subspace `K`, the dimensions of `K` and `Kᗮ` add to

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1858,10 +1858,7 @@ orthogonal subspace with `K₂` add to that of `K₂`. -/
 lemma submodule.findim_add_inf_findim_orthogonal' {K₁ K₂ : submodule 𝕜 E}
   [finite_dimensional 𝕜 K₂] (h : K₁ ≤ K₂) {n : ℕ} (h_dim : findim 𝕜 K₁ + n = findim 𝕜 K₂) :
   findim 𝕜 (K₁ᗮ ⊓ K₂ : submodule 𝕜 E) = n :=
-begin
-  refine (add_right_inj (findim 𝕜 ↥K₁)).mp _,
-  simp [submodule.findim_add_inf_findim_orthogonal h, h_dim]
-end
+by { rw ← add_right_inj (findim 𝕜 K₁), simp [submodule.findim_add_inf_findim_orthogonal h, h_dim] }
 
 /-- Given a finite-dimensional space `E` and subspace `K`, the dimensions of `K` and `Kᗮ` add to
 that of `E`. -/
@@ -1878,11 +1875,6 @@ that of `E`. -/
 lemma submodule.findim_add_findim_orthogonal' [finite_dimensional 𝕜 E] {K : submodule 𝕜 E} {n : ℕ}
   (h_dim : findim 𝕜 K + n = findim 𝕜 E) :
   findim 𝕜 Kᗮ = n :=
-begin
-  have : findim 𝕜 E = findim 𝕜 (⊤ : submodule 𝕜 E) := findim_top.symm,
-  rw this at h_dim,
-  have : Kᗮ = Kᗮ ⊓ ⊤ := inf_top_eq.symm,
-  convert submodule.findim_add_inf_findim_orthogonal' (le_top : K ≤ ⊤) h_dim
-end
+by { rw ← add_right_inj (findim 𝕜 K), simp [submodule.findim_add_findim_orthogonal, h_dim] }
 
 end orthogonal


### PR DESCRIPTION
Two groups of lemmas about finite-dimensional normed spaces:
- normed spaces of the same finite dimension are continuously linearly equivalent (this is a continuation of #5559)
- variations on the existing lemma `submodule.findim_add_inf_findim_orthogonal`, that the dimensions of a subspace and its orthogonal complement sum to the dimension of the full space.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
