### PR TITLE
[Merged by Bors] - feat(topology/algebra/ordered): prove `tendsto.Icc` for pi-types

### DIFF
--- a/src/order/filter/interval.lean
+++ b/src/order/filter/interval.lean
@@ -132,17 +132,9 @@ tendsto_Ixx_class_of_subset (λ _ _, Ioc_subset_Icc_self)
 instance tendsto_Ioo_at_bot_at_bot : tendsto_Ixx_class Ioo (at_bot : filter α) at_bot :=
 tendsto_Ixx_class_of_subset (λ _ _, Ioo_subset_Icc_self)
 
-instance tendsto_Icc_Ici_Ici {a : α} : tendsto_Ixx_class Icc (𝓟 (Ici a)) (𝓟 (Ici a)) :=
-tendsto_Ixx_class_principal.2 ord_connected_Ici
-
-instance tendsto_Icc_Iic_Iic {a : α} : tendsto_Ixx_class Icc (𝓟 (Iic a)) (𝓟 (Iic a)) :=
-tendsto_Ixx_class_principal.2 ord_connected_Iic
-
-instance tendsto_Icc_Ioi_Ioi {a : α} : tendsto_Ixx_class Icc (𝓟 (Ioi a)) (𝓟 (Ioi a)) :=
-tendsto_Ixx_class_principal.2 ord_connected_Ioi
-
-instance tendsto_Icc_Iio_Iio {a : α} : tendsto_Ixx_class Icc (𝓟 (Iio a)) (𝓟 (Iio a)) :=
-tendsto_Ixx_class_principal.2 ord_connected_Iio
+instance ord_connected.tendsto_Icc {s : set α} [ord_connected s] :
+  tendsto_Ixx_class Icc (𝓟 s) (𝓟 s) :=
+tendsto_Ixx_class_principal.2 ‹_›
 
 instance tendsto_Ico_Ici_Ici {a : α} : tendsto_Ixx_class Ico (𝓟 (Ici a)) (𝓟 (Ici a)) :=
 tendsto_Ixx_class_of_subset (λ _ _, Ico_subset_Icc_self)

--- a/src/order/filter/lift.lean
+++ b/src/order/filter/lift.lean
@@ -88,6 +88,10 @@ infi_le_infi $ assume s, infi_le_infi2 $ assume hs, ⟨hf hs, hg s⟩
 lemma lift_mono' (hg : ∀s∈f, g₁ s ≤ g₂ s) : f.lift g₁ ≤ f.lift g₂ :=
 infi_le_infi $ assume s, infi_le_infi $ assume hs, hg s hs
 
+lemma tendsto_lift {m : γ → β} {l : filter γ} :
+  tendsto m l (f.lift g) ↔ ∀ s ∈ f, tendsto m l (g s) :=
+by simp only [filter.lift, tendsto_infi]
+
 lemma map_lift_eq {m : β → γ} (hg : monotone g) : map m (f.lift g) = f.lift (map m ∘ g) :=
 have monotone (map m ∘ g),
   from map_mono.comp hg,
@@ -216,6 +220,10 @@ variables {f f₁ f₂ : filter α} {h h₁ h₂ : set α → set β}
 lemma mem_lift' {t : set α} (ht : t ∈ f) : h t ∈ (f.lift' h) :=
 le_principal_iff.mp $ show f.lift' h ≤ 𝓟 (h t),
   from infi_le_of_le t $ infi_le_of_le ht $ le_refl _
+
+lemma tendsto_lift' {m : γ → β} {l : filter γ} :
+  tendsto m l (f.lift' h) ↔ ∀ s ∈ f, ∀ᶠ a in l, m a ∈ h s :=
+by simp only [filter.lift', tendsto_lift, tendsto_principal]
 
 lemma has_basis.lift' {ι} {p : ι → Prop} {s} (hf : f.has_basis p s) (hh : monotone h) :
   (f.lift' h).has_basis p (h ∘ s) :=
@@ -351,6 +359,10 @@ by simpa only [infi_bool_eq]
 theorem comap_eq_lift' {f : filter β} {m : α → β} :
   comap m f = f.lift' (preimage m) :=
 filter.ext $ λ s, (mem_lift'_sets monotone_preimage).symm
+
+lemma lift'_infi_powerset [nonempty ι] {f : ι → filter α} :
+  (infi f).lift' powerset = (⨅i, (f i).lift' powerset) :=
+lift'_infi $ λ _ _, (powerset_inter _ _).symm
 
 lemma lift'_inf_powerset (f g : filter α) :
   (f ⊓ g).lift' powerset = f.lift' powerset ⊓ g.lift' powerset :=

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -645,11 +645,6 @@ tendsto_Ixx_class_of_subset (λ _ _, Ioc_subset_Icc_self)
 instance tendsto_Ioo_class_nhds (a : α) : tendsto_Ixx_class Ioo (𝓝 a) (𝓝 a) :=
 tendsto_Ixx_class_of_subset (λ _ _, Ioo_subset_Icc_self)
 
-instance tendsto_Ixx_nhds_within (a : α) {s t : set α} {Ixx}
-  [tendsto_Ixx_class Ixx (𝓝 a) (𝓝 a)] [tendsto_Ixx_class Ixx (𝓟 s) (𝓟 t)]:
-  tendsto_Ixx_class Ixx (𝓝[s] a) (𝓝[t] a) :=
-filter.tendsto_Ixx_class_inf
-
 /-- Also known as squeeze or sandwich theorem. This version assumes that inequalities hold
 eventually for the filter. -/
 lemma tendsto_of_tendsto_of_tendsto_of_le_of_le' {f g h : β → α} {b : filter β} {a : α}
@@ -685,6 +680,27 @@ from (tendsto_infi.2 $ assume l, tendsto_infi.2 $ assume hl,
   tendsto_infi.2 $ assume u, tendsto_infi.2 $ assume hu, tendsto_principal.2 $ h l u hl hu)
 
 end partial_order
+
+instance tendsto_Ixx_nhds_within {α : Type*} [preorder α] [topological_space α]
+  (a : α) {s t : set α} {Ixx}
+  [tendsto_Ixx_class Ixx (𝓝 a) (𝓝 a)] [tendsto_Ixx_class Ixx (𝓟 s) (𝓟 t)]:
+  tendsto_Ixx_class Ixx (𝓝[s] a) (𝓝[t] a) :=
+filter.tendsto_Ixx_class_inf
+
+instance tendsto_Icc_class_nhds_pi {ι : Type*} {α : ι → Type*} [nonempty ι]
+  [Π i, partial_order (α i)] [Π i, topological_space (α i)] [∀ i, order_topology (α i)]
+  (f : Π i, α i) :
+  tendsto_Ixx_class Icc (𝓝 f) (𝓝 f) :=
+begin
+  constructor,
+  conv in ((𝓝 f).lift' powerset) { rw [nhds_pi] },
+  simp only [lift'_infi_powerset, comap_lift'_eq2 monotone_powerset, tendsto_infi, tendsto_lift',
+    mem_powerset_iff, subset_def, mem_preimage],
+  intros i s hs,
+  have : tendsto (λ g : Π i, α i, g i) (𝓝 f) (𝓝 (f i)) := ((continuous_apply i).tendsto f),
+  refine (tendsto_lift'.1 ((this.comp tendsto_fst).Icc (this.comp tendsto_snd)) s hs).mono _,
+  exact λ p hp g hg, hp ⟨hg.1 _, hg.2 _⟩
+end
 
 theorem induced_order_topology' {α : Type u} {β : Type v}
   [partial_order α] [ta : topological_space β] [partial_order β] [order_topology β]


### PR DESCRIPTION
---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->