### PR TITLE
[Merged by Bors] - feat(data/zsqrtd/to_real): Add `to_real`

### DIFF
--- a/src/data/zsqrtd/basic.lean
+++ b/src/data/zsqrtd/basic.lean
@@ -595,4 +595,20 @@ begin
     exact mul_nonpos_of_nonpos_of_nonneg h.le (mul_self_nonneg _) }
 end
 
+variables {R : Type} [comm_ring R]
+
+/-- A `ring_hom` from `ℤ√d` to a ring `R`, constructed by replacing `√d` with the provided root. -/
+@[simps]
+def lift {d : ℤ} (r : R) (hr : r * r = ↑d) : ℤ√d →+* R := {
+  to_fun := λ a, a.1 + a.2*r,
+  map_zero' := by simp,
+  map_add' := λ a b, by { simp, ring, },
+  map_one' := by simp,
+  map_mul' := λ a b, by {
+    have : (↑a.re + ↑a.im * r) * (↑b.re + ↑b.im * r) =
+             ↑a.re * ↑b.re + (↑a.re * ↑b.im + ↑a.im * ↑b.re) * r
+                           + ↑a.im * ↑b.im * (r * r) := by ring,
+    simp [this, hr],
+    ring, } }
+
 end zsqrtd

--- a/src/data/zsqrtd/basic.lean
+++ b/src/data/zsqrtd/basic.lean
@@ -600,6 +600,12 @@ end
 
 variables {R : Type} [comm_ring R]
 
+@[ext] lemma hom_ext {d : ℤ} (f g : ℤ√d →+* R) (h : f sqrtd = g sqrtd) : f = g :=
+begin
+  ext ⟨x_re, x_im⟩,
+  simp [decompose, h],
+end
+
 /-- The unique `ring_hom` from `ℤ√d` to a ring `R`, constructed by replacing `√d` with the provided
 root. Conversely, this associates to every mapping `ℤ√d →+* R` a value of `√d` in `R`. -/
 @[simps]
@@ -616,7 +622,7 @@ def lift {d : ℤ} : {r : R // r * r = ↑d} ≃ (ℤ√d →+* R) :=
       ring, } },
   inv_fun := λ f, ⟨f sqrtd, by rw [←f.map_mul, dmuld, ring_hom.map_int_cast]⟩,
   left_inv := λ r, by { ext, simp },
-  right_inv := λ f, by { ext x, cases x, simp [decompose], } }
+  right_inv := λ f, by { ext, simp } }
 
 /-- `lift r` is injective if `d` is non-square, and R has characteristic zero (that is, the map from
 `ℤ` into `R` is injective). -/

--- a/src/data/zsqrtd/basic.lean
+++ b/src/data/zsqrtd/basic.lean
@@ -612,14 +612,14 @@ def lift {d : ℤ} (r : R) (hr : r * r = ↑d) : ℤ√d →+* R := {
     ring, } }
 
 /-- `lift` is injective if `d` is non-square, and the map from `ℤ` into `R` is injective. -/
-lemma lift_injective {d : ℤ} (r : R) (hr : r * r = ↑d) (h_nonsquare : ∀ n : ℤ, d ≠ n*n)
-  (h_inj : function.injective (coe : ℤ → R)) :
+lemma lift_injective [char_zero R] {d : ℤ} (r : R) (hr : r * r = ↑d) (hd : ∀ n : ℤ, d ≠ n*n) :
   function.injective (lift r hr) :=
 (lift r hr).injective_iff.mpr $ λ a ha,
 begin
+  have h_inj : function.injective (coe : ℤ → R) := int.cast_injective,
   suffices : lift r hr a.norm = 0,
   { simp only [coe_int_re, add_zero, lift_apply, coe_int_im, int.cast_zero, zero_mul] at this,
-    rwa [← int.cast_zero, h_inj.eq_iff, norm_eq_zero h_nonsquare] at this },
+    rwa [← int.cast_zero, h_inj.eq_iff, norm_eq_zero hd] at this },
   rw [norm_eq_mul_conj, ring_hom.map_mul, ha, zero_mul]
 end
 

--- a/src/data/zsqrtd/basic.lean
+++ b/src/data/zsqrtd/basic.lean
@@ -613,18 +613,14 @@ def lift {d : ℤ} (r : R) (hr : r * r = ↑d) : ℤ√d →+* R := {
 
 /-- `lift` is injective if `d` is non-square, and the map from `ℤ` into `R` is injective. -/
 lemma lift_injective {d : ℤ} (r : R) (hr : r * r = ↑d) (h_nonsquare : ∀ n : ℤ, d ≠ n*n)
-  (h_inj : function.injective $ int.cast_ring_hom R):
+  (h_inj : function.injective (coe : ℤ → R)) :
   function.injective (lift r hr) :=
-(lift r hr).injective_iff.mpr $ λ a ha, (norm_eq_zero h_nonsquare a).mp begin
-  have coe_zero : ∀ x : ℤ, (x : R) = 0 ↔ x = 0 := λ x, ⟨
-    (int.cast_ring_hom R).injective_iff.mp h_inj x,
-    λ h, by { rw h, exact (int.cast_ring_hom R).map_zero }⟩,
-  replace ha := congr_arg (λ x, x * lift r hr a.conj) ha,
-  have : lift r hr (a.norm : ℤ√d) = 0,
-  { simpa only [zero_mul, ←ring_hom.map_mul, ←norm_eq_mul_conj] using ha },
-  have : (a.norm : ℤ√d) = 0,
-  { simpa [coe_zero] using this },
-  exact_mod_cast this,
+(lift r hr).injective_iff.mpr $ λ a ha,
+begin
+  suffices : lift r hr a.norm = 0,
+  { simp only [coe_int_re, add_zero, lift_apply, coe_int_im, int.cast_zero, zero_mul] at this,
+    rwa [← int.cast_zero, h_inj.eq_iff, norm_eq_zero h_nonsquare] at this },
+  rw [norm_eq_mul_conj, ring_hom.map_mul, ha, zero_mul]
 end
 
 end zsqrtd

--- a/src/data/zsqrtd/basic.lean
+++ b/src/data/zsqrtd/basic.lean
@@ -610,9 +610,8 @@ def lift {d : ℤ} : {r : R // r * r = ↑d} ≃ (ℤ√d →+* R) :=
     map_add' := λ a b, by { simp, ring, },
     map_one' := by simp,
     map_mul' := λ a b, by {
-      have : (↑a.re + ↑a.im * r : R) * (↑b.re + ↑b.im * r) =
-              ↑a.re * ↑b.re + (↑a.re * ↑b.im + ↑a.im * ↑b.re) * r
-                            + ↑a.im * ↑b.im * (r * r) := by ring,
+      have : (a.re + a.im * r : R) * (b.re + b.im * r) =
+              a.re * b.re + (a.re * b.im + a.im * b.re) * r + a.im * b.im * (r * r) := by ring,
       simp [this, r.prop],
       ring, } },
   inv_fun := λ f, ⟨f sqrtd, by rw [←f.map_mul, dmuld, ring_hom.map_int_cast]⟩,

--- a/src/data/zsqrtd/basic.lean
+++ b/src/data/zsqrtd/basic.lean
@@ -5,7 +5,6 @@ Authors: Mario Carneiro
 -/
 import algebra.associated
 import tactic.ring
-import data.real.sqrt
 
 /-- The ring of integers adjoined with a square root of `d`.
   These have the form `a + b √d` where `a b : ℤ`. The components
@@ -594,31 +593,6 @@ begin
     apply _root_.le_antisymm _ (mul_self_nonneg _),
     rw [ha, mul_assoc],
     exact mul_nonpos_of_nonpos_of_nonneg h.le (mul_self_nonneg _) }
-end
-
-/-- The image of `zsqrtd` in `ℝ`, using `real.sqrt` which takes the positive root of `d`. -/
-@[simps]
-noncomputable def to_real {d : ℤ} (h : 0 ≤ d) : ℤ√d →+* ℝ := {
-  to_fun := λ a, a.1 + a.2*real.sqrt d,
-  map_zero' := by simp,
-  map_add' := λ a b, by { simp, ring, },
-  map_one' := by simp,
-  map_mul' := λ a b, by {
-    have : (↑a.re + ↑a.im * real.sqrt d) * (↑b.re + ↑b.im * real.sqrt d) =
-             ↑a.re * ↑b.re + (↑a.re * ↑b.im + ↑a.im * ↑b.re) * real.sqrt d
-                           + ↑a.im * ↑b.im * (real.sqrt d * real.sqrt d) := by ring,
-    simp [this, real.mul_self_sqrt (int.cast_nonneg.mpr h)],
-    ring, } }
-
-lemma to_real_injective {d : ℤ} (h : 0 ≤ d) (h_nonsquare : ∀ n : ℤ, d ≠ n*n) :
-  function.injective (to_real h) :=
-(to_real h).injective_iff.mpr $ λ a ha, (norm_eq_zero h_nonsquare a).mp begin
-  replace ha := congr_arg (λ x, x * to_real h a.conj) ha,
-  have : to_real h (a.norm : ℤ√d) = 0,
-  { simpa only [zero_mul, ←ring_hom.map_mul, ←norm_eq_mul_conj] using ha },
-  have : (a.norm : ℤ√d) = 0,
-  { simpa using this },
-  exact_mod_cast this,
 end
 
 end zsqrtd

--- a/src/data/zsqrtd/basic.lean
+++ b/src/data/zsqrtd/basic.lean
@@ -611,7 +611,8 @@ def lift {d : ℤ} (r : R) (hr : r * r = ↑d) : ℤ√d →+* R := {
     simp [this, hr],
     ring, } }
 
-/-- `lift` is injective if `d` is non-square, and the map from `ℤ` into `R` is injective. -/
+/-- `lift` is injective if `d` is non-square, and R has characteristic zero (that is, the map from
+`ℤ` into `R` is injective). -/
 lemma lift_injective [char_zero R] {d : ℤ} (r : R) (hr : r * r = ↑d) (hd : ∀ n : ℤ, d ≠ n*n) :
   function.injective (lift r hr) :=
 (lift r hr).injective_iff.mpr $ λ a ha,

--- a/src/data/zsqrtd/basic.lean
+++ b/src/data/zsqrtd/basic.lean
@@ -611,4 +611,20 @@ def lift {d : ℤ} (r : R) (hr : r * r = ↑d) : ℤ√d →+* R := {
     simp [this, hr],
     ring, } }
 
+/-- `lift` is injective if `d` is non-square, and the map from `ℤ` into `R` is injective. -/
+lemma lift_injective {d : ℤ} (r : R) (hr : r * r = ↑d) (h_nonsquare : ∀ n : ℤ, d ≠ n*n)
+  (h_inj : function.injective $ int.cast_ring_hom R):
+  function.injective (lift r hr) :=
+(lift r hr).injective_iff.mpr $ λ a ha, (norm_eq_zero h_nonsquare a).mp begin
+  have coe_zero : ∀ x : ℤ, (x : R) = 0 ↔ x = 0 := λ x, ⟨
+    (int.cast_ring_hom R).injective_iff.mp h_inj x,
+    λ h, by { rw h, exact (int.cast_ring_hom R).map_zero }⟩,
+  replace ha := congr_arg (λ x, x * lift r hr a.conj) ha,
+  have : lift r hr (a.norm : ℤ√d) = 0,
+  { simpa only [zero_mul, ←ring_hom.map_mul, ←norm_eq_mul_conj] using ha },
+  have : (a.norm : ℤ√d) = 0,
+  { simpa [coe_zero] using this },
+  exact_mod_cast this,
+end
+
 end zsqrtd

--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -52,7 +52,7 @@ local attribute [-instance] complex.field -- Avoid making things noncomputable u
 
 /-- The embedding of the Gaussian integers into the complex numbers, as a ring homomorphism. -/
 def to_complex : ℤ[i] →+* ℂ :=
-zsqrtd.lift I (by simp)
+zsqrtd.lift ⟨I, by simp⟩
 end
 
 instance : has_coe (ℤ[i]) ℂ := ⟨to_complex⟩

--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -52,10 +52,7 @@ local attribute [-instance] complex.field -- Avoid making things noncomputable u
 
 /-- The embedding of the Gaussian integers into the complex numbers, as a ring homomorphism. -/
 def to_complex : ℤ[i] →+* ℂ :=
-begin
-  refine_struct { to_fun := λ x : ℤ[i], (x.re + x.im * I : ℂ), .. };
-  intros; apply complex.ext; dsimp; norm_cast; simp; abel
-end
+zsqrtd.lift I (by simp)
 end
 
 instance : has_coe (ℤ[i]) ℂ := ⟨to_complex⟩

--- a/src/data/zsqrtd/to_real.lean
+++ b/src/data/zsqrtd/to_real.lean
@@ -20,10 +20,10 @@ namespace zsqrtd
 If the negative root is desired, use `to_real h a.conj`. -/
 @[simps]
 noncomputable def to_real {d : ℤ} (h : 0 ≤ d) : ℤ√d →+* ℝ :=
-lift (real.sqrt d) (real.mul_self_sqrt (int.cast_nonneg.mpr h))
+lift ⟨real.sqrt d, real.mul_self_sqrt (int.cast_nonneg.mpr h)⟩
 
 lemma to_real_injective {d : ℤ} (h0d : 0 ≤ d) (hd : ∀ n : ℤ, d ≠ n*n) :
   function.injective (to_real h0d) :=
-lift_injective _ _ hd
+lift_injective _ hd
 
 end zsqrtd

--- a/src/data/zsqrtd/to_real.lean
+++ b/src/data/zsqrtd/to_real.lean
@@ -22,8 +22,8 @@ If the negative root is desired, use `to_real h a.conj`. -/
 noncomputable def to_real {d : ℤ} (h : 0 ≤ d) : ℤ√d →+* ℝ :=
 lift (real.sqrt d) (real.mul_self_sqrt (int.cast_nonneg.mpr h))
 
-lemma to_real_injective {d : ℤ} (h : 0 ≤ d) (h_nonsquare : ∀ n : ℤ, d ≠ n*n) :
-  function.injective (to_real h) :=
-lift_injective _ _ h_nonsquare int.cast_injective
+lemma to_real_injective {d : ℤ} (h0d : 0 ≤ d) (hd : ∀ n : ℤ, d ≠ n*n) :
+  function.injective (to_real h0d) :=
+lift_injective _ _ hd
 
 end zsqrtd

--- a/src/data/zsqrtd/to_real.lean
+++ b/src/data/zsqrtd/to_real.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro
+Authors: Eric Wieser
 -/
 import data.real.sqrt
 import data.zsqrtd.basic

--- a/src/data/zsqrtd/to_real.lean
+++ b/src/data/zsqrtd/to_real.lean
@@ -24,13 +24,6 @@ lift (real.sqrt d) (real.mul_self_sqrt (int.cast_nonneg.mpr h))
 
 lemma to_real_injective {d : ℤ} (h : 0 ≤ d) (h_nonsquare : ∀ n : ℤ, d ≠ n*n) :
   function.injective (to_real h) :=
-(to_real h).injective_iff.mpr $ λ a ha, (norm_eq_zero h_nonsquare a).mp begin
-  replace ha := congr_arg (λ x, x * to_real h a.conj) ha,
-  have : to_real h (a.norm : ℤ√d) = 0,
-  { simpa only [zero_mul, ←ring_hom.map_mul, ←norm_eq_mul_conj] using ha },
-  have : (a.norm : ℤ√d) = 0,
-  { simpa using this },
-  exact_mod_cast this,
-end
+lift_injective _ _ h_nonsquare ((ring_hom.injective_iff _).mpr $ λ a, by simp)
 
 end zsqrtd

--- a/src/data/zsqrtd/to_real.lean
+++ b/src/data/zsqrtd/to_real.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2021 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import data.real.sqrt
+import data.zsqrtd.basic
+
+/-!
+# Image of `zsqrtd` in `ℝ`
+
+This file defines `zsqrtd.to_real` and related lemmas.
+It is in a separate file to avoid pulling in all of `data.real` into `data.zsqrtd`.
+-/
+
+namespace zsqrtd
+
+/-- The image of `zsqrtd` in `ℝ`, using `real.sqrt` which takes the positive root of `d`.
+
+If the negative root is desired, use `to_real h a.conj`. -/
+@[simps]
+noncomputable def to_real {d : ℤ} (h : 0 ≤ d) : ℤ√d →+* ℝ := {
+  to_fun := λ a, a.1 + a.2*real.sqrt d,
+  map_zero' := by simp,
+  map_add' := λ a b, by { simp, ring, },
+  map_one' := by simp,
+  map_mul' := λ a b, by {
+    have : (↑a.re + ↑a.im * real.sqrt d) * (↑b.re + ↑b.im * real.sqrt d) =
+             ↑a.re * ↑b.re + (↑a.re * ↑b.im + ↑a.im * ↑b.re) * real.sqrt d
+                           + ↑a.im * ↑b.im * (real.sqrt d * real.sqrt d) := by ring,
+    simp [this, real.mul_self_sqrt (int.cast_nonneg.mpr h)],
+    ring, } }
+
+lemma to_real_injective {d : ℤ} (h : 0 ≤ d) (h_nonsquare : ∀ n : ℤ, d ≠ n*n) :
+  function.injective (to_real h) :=
+(to_real h).injective_iff.mpr $ λ a ha, (norm_eq_zero h_nonsquare a).mp begin
+  replace ha := congr_arg (λ x, x * to_real h a.conj) ha,
+  have : to_real h (a.norm : ℤ√d) = 0,
+  { simpa only [zero_mul, ←ring_hom.map_mul, ←norm_eq_mul_conj] using ha },
+  have : (a.norm : ℤ√d) = 0,
+  { simpa using this },
+  exact_mod_cast this,
+end
+
+end zsqrtd

--- a/src/data/zsqrtd/to_real.lean
+++ b/src/data/zsqrtd/to_real.lean
@@ -24,6 +24,6 @@ lift (real.sqrt d) (real.mul_self_sqrt (int.cast_nonneg.mpr h))
 
 lemma to_real_injective {d : ℤ} (h : 0 ≤ d) (h_nonsquare : ∀ n : ℤ, d ≠ n*n) :
   function.injective (to_real h) :=
-lift_injective _ _ h_nonsquare ((ring_hom.injective_iff _).mpr $ λ a, by simp)
+lift_injective _ _ h_nonsquare int.cast_injective
 
 end zsqrtd

--- a/src/data/zsqrtd/to_real.lean
+++ b/src/data/zsqrtd/to_real.lean
@@ -19,17 +19,8 @@ namespace zsqrtd
 
 If the negative root is desired, use `to_real h a.conj`. -/
 @[simps]
-noncomputable def to_real {d : ℤ} (h : 0 ≤ d) : ℤ√d →+* ℝ := {
-  to_fun := λ a, a.1 + a.2*real.sqrt d,
-  map_zero' := by simp,
-  map_add' := λ a b, by { simp, ring, },
-  map_one' := by simp,
-  map_mul' := λ a b, by {
-    have : (↑a.re + ↑a.im * real.sqrt d) * (↑b.re + ↑b.im * real.sqrt d) =
-             ↑a.re * ↑b.re + (↑a.re * ↑b.im + ↑a.im * ↑b.re) * real.sqrt d
-                           + ↑a.im * ↑b.im * (real.sqrt d * real.sqrt d) := by ring,
-    simp [this, real.mul_self_sqrt (int.cast_nonneg.mpr h)],
-    ring, } }
+noncomputable def to_real {d : ℤ} (h : 0 ≤ d) : ℤ√d →+* ℝ :=
+lift (real.sqrt d) (real.mul_self_sqrt (int.cast_nonneg.mpr h))
 
 lemma to_real_injective {d : ℤ} (h : 0 ≤ d) (h_nonsquare : ∀ n : ℤ, d ≠ n*n) :
   function.injective (to_real h) :=


### PR DESCRIPTION
Also adds `norm_eq_zero`, and replaces some calls to simp with direct lemma applications

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
