### PR TITLE
[Merged by Bors] - chore(measure_theory/set_integral): use weaker assumptions here and there

### DIFF
--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -1009,8 +1009,7 @@ In this subsection we restate results from the previous subsection in terms of `
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f x` has finite
 limits `ca` and `cb` almost surely as `x` tends to `a` and `b`, respectively, then
 `(u, v) ↦ ∫ x in u..v, f x` has derivative `(u, v) ↦ v • cb - u • ca` at `(a, b)`. -/
-lemma integral_has_fderiv_at_of_tendsto_ae
-  (hf : interval_integrable f volume a b)
+lemma integral_has_fderiv_at_of_tendsto_ae (hf : interval_integrable f volume a b)
   (hmeas_a : measurable_at_filter f (𝓝 a)) (hmeas_b : measurable_at_filter f (𝓝 b))
   (ha : tendsto f (𝓝 a ⊓ volume.ae) (𝓝 ca)) (hb : tendsto f (𝓝 b ⊓ volume.ae) (𝓝 cb)) :
   has_fderiv_at (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x)
@@ -1020,8 +1019,7 @@ lemma integral_has_fderiv_at_of_tendsto_ae
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f` is continuous
 at `a` and `b`, then `(u, v) ↦ ∫ x in u..v, f x` has derivative `(u, v) ↦ v • cb - u • ca`
 at `(a, b)`. -/
-lemma integral_has_fderiv_at
-  (hf : interval_integrable f volume a b)
+lemma integral_has_fderiv_at (hf : interval_integrable f volume a b)
   (hmeas_a : measurable_at_filter f (𝓝 a)) (hmeas_b : measurable_at_filter f (𝓝 b))
   (ha : continuous_at f a) (hb : continuous_at f b) :
   has_fderiv_at (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x)
@@ -1031,8 +1029,7 @@ lemma integral_has_fderiv_at
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f x` has finite
 limits `ca` and `cb` almost surely as `x` tends to `a` and `b`, respectively, then `fderiv`
 derivative of `(u, v) ↦ ∫ x in u..v, f x` at `(a, b)` equals `(u, v) ↦ v • cb - u • ca`. -/
-lemma fderiv_integral_of_tendsto_ae
-  (hf : interval_integrable f volume a b) (hmeas_a : measurable_at_filter f (𝓝 a))
+lemma fderiv_integral_of_tendsto_ae (hf : interval_integrable f volume a b)
   (hmeas_a : measurable_at_filter f (𝓝 a)) (hmeas_b : measurable_at_filter f (𝓝 b))
   (ha : tendsto f (𝓝 a ⊓ volume.ae) (𝓝 ca)) (hb : tendsto f (𝓝 b ⊓ volume.ae) (𝓝 cb)) :
   fderiv ℝ (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x) (a, b) =
@@ -1042,8 +1039,7 @@ lemma fderiv_integral_of_tendsto_ae
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f` is continuous
 at `a` and `b`, then `fderiv` derivative of `(u, v) ↦ ∫ x in u..v, f x` at `(a, b)` equals `(u, v) ↦
 v • cb - u • ca`. -/
-lemma fderiv_integral
-  (hf : interval_integrable f volume a b)
+lemma fderiv_integral (hf : interval_integrable f volume a b)
   (hmeas_a : measurable_at_filter f (𝓝 a)) (hmeas_b : measurable_at_filter f (𝓝 b))
   (ha : continuous_at f a) (hb : continuous_at f b) :
   fderiv ℝ (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x) (a, b) =

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -232,7 +232,7 @@ Typeclass instances allow Lean to find `l'` based on `l` but not vice versa, so
 `apply tendsto.eventually_interval_integrable_ae` will generate goals `filter α` and
 `tendsto_Ixx_class Ioc ?m_1 l'`. -/
 lemma filter.tendsto.eventually_interval_integrable_ae {f : α → E} {μ : measure α}
-  (hfm : ae_measurable f μ) {l l' : filter α}
+  {l l' : filter α}  (hfm : measurable_at_filter f l' μ)
   [tendsto_Ixx_class Ioc l l'] [is_measurably_generated l']
   (hμ : μ.finite_at_filter l') {c : E} (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c))
   {u v : β → α} {lt : filter β} (hu : tendsto u lt l) (hv : tendsto v lt l) :
@@ -250,7 +250,7 @@ Typeclass instances allow Lean to find `l'` based on `l` but not vice versa, so
 `apply tendsto.eventually_interval_integrable_ae` will generate goals `filter α` and
 `tendsto_Ixx_class Ioc ?m_1 l'`. -/
 lemma filter.tendsto.eventually_interval_integrable {f : α → E} {μ : measure α}
-  (hfm : ae_measurable f μ) {l l' : filter α}
+  {l l' : filter α} (hfm : measurable_at_filter f l' μ)
   [tendsto_Ixx_class Ioc l l'] [is_measurably_generated l']
   (hμ : μ.finite_at_filter l') {c : E} (hf : tendsto f l' (𝓝 c))
   {u v : β → α} {lt : filter β} (hu : tendsto u lt l) (hv : tendsto v lt l) :
@@ -627,13 +627,14 @@ We use integrals of constants instead of measures because this way it is easier 
 a statement that works in both cases `u ≤ v` and `v ≤ u`. -/
 lemma measure_integral_sub_linear_is_o_of_tendsto_ae'
   [is_measurably_generated l'] [tendsto_Ixx_class Ioc l l']
-  (hfm : ae_measurable f μ) (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c)) (hl : μ.finite_at_filter l')
+  (hfm : measurable_at_filter f l' μ) (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c))
+  (hl : μ.finite_at_filter l')
   (hu : tendsto u lt l) (hv : tendsto v lt l) :
   is_o (λ t, ∫ x in u t..v t, f x ∂μ - ∫ x in u t..v t, c ∂μ)
     (λ t, ∫ x in u t..v t, (1:ℝ) ∂μ) lt :=
 begin
-  have A := (hf.integral_sub_linear_is_o_ae hfm hl).comp_tendsto (hu.Ioc hv),
-  have B := (hf.integral_sub_linear_is_o_ae hfm hl).comp_tendsto (hv.Ioc hu),
+  have A := hf.integral_sub_linear_is_o_ae hfm hl (hu.Ioc hv),
+  have B := hf.integral_sub_linear_is_o_ae hfm hl (hv.Ioc hu),
   simp only [integral_const'],
   convert (A.trans_le _).sub (B.trans_le _),
   { ext t,
@@ -654,8 +655,8 @@ See also `measure_integral_sub_linear_is_o_of_tendsto_ae_of_le` for a version as
 The primed version also works, e.g., for `l = l' = at_top`. -/
 lemma measure_integral_sub_linear_is_o_of_tendsto_ae_of_le'
   [is_measurably_generated l'] [tendsto_Ixx_class Ioc l l']
-  (hfm : ae_measurable f μ) (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c)) (hl : μ.finite_at_filter l')
-  (hu : tendsto u lt l) (hv : tendsto v lt l) (huv : u ≤ᶠ[lt] v) :
+  (hfm : measurable_at_filter f l' μ) (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c))
+  (hl : μ.finite_at_filter l') (hu : tendsto u lt l) (hv : tendsto v lt l) (huv : u ≤ᶠ[lt] v) :
   is_o (λ t, ∫ x in u t..v t, f x ∂μ - (μ (Ioc (u t) (v t))).to_real • c)
     (λ t, (μ $ Ioc (u t) (v t)).to_real) lt :=
 (measure_integral_sub_linear_is_o_of_tendsto_ae' hfm hf hl hu hv).congr'
@@ -674,8 +675,8 @@ See also `measure_integral_sub_linear_is_o_of_tendsto_ae_of_ge` for a version as
 The primed version also works, e.g., for `l = l' = at_top`. -/
 lemma measure_integral_sub_linear_is_o_of_tendsto_ae_of_ge'
   [is_measurably_generated l'] [tendsto_Ixx_class Ioc l l']
-  (hfm : ae_measurable f μ) (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c)) (hl : μ.finite_at_filter l')
-  (hu : tendsto u lt l) (hv : tendsto v lt l) (huv : v ≤ᶠ[lt] u) :
+  (hfm : measurable_at_filter f l' μ) (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c))
+  (hl : μ.finite_at_filter l') (hu : tendsto u lt l) (hv : tendsto v lt l) (huv : v ≤ᶠ[lt] u) :
   is_o (λ t, ∫ x in u t..v t, f x ∂μ + (μ (Ioc (v t) (u t))).to_real • c)
     (λ t, (μ $ Ioc (v t) (u t)).to_real) lt :=
 (measure_integral_sub_linear_is_o_of_tendsto_ae_of_le' hfm hf hl hv hu huv).neg_left.congr_left $
@@ -701,7 +702,7 @@ See also `measure_integral_sub_linear_is_o_of_tendsto_ae'` for a version that al
 
 We use integrals of constants instead of measures because this way it is easier to formulate
 a statement that works in both cases `u ≤ v` and `v ≤ u`. -/
-lemma measure_integral_sub_linear_is_o_of_tendsto_ae (hfm : ae_measurable f μ)
+lemma measure_integral_sub_linear_is_o_of_tendsto_ae (hfm : measurable_at_filter f l' μ)
   (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c)) (hu : tendsto u lt l) (hv : tendsto v lt l) :
   is_o (λ t, ∫ x in u t..v t, f x ∂μ - ∫ x in u t..v t, c ∂μ)
     (λ t, ∫ x in u t..v t, (1:ℝ) ∂μ) lt :=
@@ -715,7 +716,7 @@ If `f` has a finite limit `c` at `l' ⊓ μ.ae`, then
 See also `measure_integral_sub_linear_is_o_of_tendsto_ae_of_le'` for a version that also works,
 e.g., for `l = l' = at_top`. -/
 lemma measure_integral_sub_linear_is_o_of_tendsto_ae_of_le
-  (hfm : ae_measurable f μ) (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c))
+  (hfm : measurable_at_filter f l' μ) (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c))
   (hu : tendsto u lt l) (hv : tendsto v lt l) (huv : u ≤ᶠ[lt] v) :
   is_o (λ t, ∫ x in u t..v t, f x ∂μ - (μ (Ioc (u t) (v t))).to_real • c)
     (λ t, (μ $ Ioc (u t) (v t)).to_real) lt :=
@@ -730,7 +731,7 @@ If `f` has a finite limit `c` at `l' ⊓ μ.ae`, then
 See also `measure_integral_sub_linear_is_o_of_tendsto_ae_of_ge'` for a version that also works,
 e.g., for `l = l' = at_top`. -/
 lemma measure_integral_sub_linear_is_o_of_tendsto_ae_of_ge
-  (hfm : ae_measurable f μ) (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c))
+  (hfm : measurable_at_filter f l' μ) (hf : tendsto f (l' ⊓ μ.ae) (𝓝 c))
   (hu : tendsto u lt l) (hv : tendsto v lt l) (huv : v ≤ᶠ[lt] u) :
   is_o (λ t, ∫ x in u t..v t, f x ∂μ + (μ (Ioc (v t) (u t))).to_real • c)
     (λ t, (μ $ Ioc (v t) (u t)).to_real) lt :=
@@ -757,7 +758,8 @@ Then `∫ x in va..vb, f x ∂μ - ∫ x in ua..ub, f x ∂μ =
 as `ua` and `va` tend to `la` while `ub` and `vb` tend to `lb`.
 -/
 lemma measure_integral_sub_integral_sub_linear_is_o_of_tendsto_ae
-  (hab : interval_integrable f μ a b) (hmeas : ae_measurable f μ)
+  (hab : interval_integrable f μ a b)
+  (hmeas_a : measurable_at_filter f la' μ) (hmeas_b : measurable_at_filter f lb' μ)
   (ha_lim : tendsto f (la' ⊓ μ.ae) (𝓝 ca)) (hb_lim : tendsto f (lb' ⊓ μ.ae) (𝓝 cb))
   (hua : tendsto ua lt la) (hva : tendsto va lt la)
   (hub : tendsto ub lt lb) (hvb : tendsto vb lt lb) :
@@ -766,18 +768,18 @@ lemma measure_integral_sub_integral_sub_linear_is_o_of_tendsto_ae
     (λ t, ∥∫ x in ua t..va t, (1:ℝ) ∂μ∥ + ∥∫ x in ub t..vb t, (1:ℝ) ∂μ∥) lt :=
 begin
   refine
-    ((measure_integral_sub_linear_is_o_of_tendsto_ae hmeas ha_lim hua hva).neg_left.add_add
-    (measure_integral_sub_linear_is_o_of_tendsto_ae hmeas hb_lim hub hvb)).congr'
+    ((measure_integral_sub_linear_is_o_of_tendsto_ae hmeas_a ha_lim hua hva).neg_left.add_add
+    (measure_integral_sub_linear_is_o_of_tendsto_ae hmeas_b hb_lim hub hvb)).congr'
       _ (eventually_eq.refl _ _),
   have A : ∀ᶠ t in lt, interval_integrable f μ (ua t) (va t) :=
-    ha_lim.eventually_interval_integrable_ae hmeas (FTC_filter.finite_at_inner la) hua hva,
+    ha_lim.eventually_interval_integrable_ae hmeas_a (FTC_filter.finite_at_inner la) hua hva,
   have A' : ∀ᶠ t in lt, interval_integrable f μ a (ua t) :=
-    ha_lim.eventually_interval_integrable_ae hmeas (FTC_filter.finite_at_inner la)
+    ha_lim.eventually_interval_integrable_ae hmeas_a (FTC_filter.finite_at_inner la)
       (tendsto_const_pure.mono_right FTC_filter.pure_le) hua,
   have B : ∀ᶠ t in lt, interval_integrable f μ (ub t) (vb t) :=
-    hb_lim.eventually_interval_integrable_ae hmeas (FTC_filter.finite_at_inner lb) hub hvb,
+    hb_lim.eventually_interval_integrable_ae hmeas_b (FTC_filter.finite_at_inner lb) hub hvb,
   have B' : ∀ᶠ t in lt, interval_integrable f μ b (ub t) :=
-    hb_lim.eventually_interval_integrable_ae hmeas (FTC_filter.finite_at_inner lb)
+    hb_lim.eventually_interval_integrable_ae hmeas_b (FTC_filter.finite_at_inner lb)
       (tendsto_const_pure.mono_right FTC_filter.pure_le) hub,
   filter_upwards [A, A', B, B'],
   intros t ua_va a_ua ub_vb b_ub,
@@ -796,12 +798,12 @@ Then `∫ x in a..v, f x ∂μ - ∫ x in a..u, f x ∂μ = ∫ x in u..v, c ∂
 as `u` and `v` tend to `lb`.
 -/
 lemma measure_integral_sub_integral_sub_linear_is_o_of_tendsto_ae_right
-  (hab : interval_integrable f μ a b) (hmeas : ae_measurable f μ)
+  (hab : interval_integrable f μ a b) (hmeas : measurable_at_filter f lb' μ)
   (hf : tendsto f (lb' ⊓ μ.ae) (𝓝 c)) (hu : tendsto u lt lb) (hv : tendsto v lt lb) :
   is_o (λ t, ∫ x in a..v t, f x ∂μ - ∫ x in a..u t, f x ∂μ - ∫ x in u t..v t, c ∂μ)
     (λ t, ∫ x in u t..v t, (1:ℝ) ∂μ) lt :=
 by simpa using measure_integral_sub_integral_sub_linear_is_o_of_tendsto_ae
-  hab hmeas ((tendsto_bot : tendsto _ ⊥ (𝓝 0)).mono_left inf_le_left)
+  hab measurable_at_bot hmeas ((tendsto_bot : tendsto _ ⊥ (𝓝 0)).mono_left inf_le_left)
   hf (tendsto_const_pure : tendsto _ _ (pure a)) tendsto_const_pure hu hv
 
 /-- Fundamental theorem of calculus-1, strict derivative in left endpoint for a locally finite
@@ -814,12 +816,12 @@ Then `∫ x in v..b, f x ∂μ - ∫ x in u..b, f x ∂μ = -∫ x in u..v, c �
 as `u` and `v` tend to `la`.
 -/
 lemma measure_integral_sub_integral_sub_linear_is_o_of_tendsto_ae_left
-  (hab : interval_integrable f μ a b) (hmeas : ae_measurable f μ)
+  (hab : interval_integrable f μ a b) (hmeas : measurable_at_filter f la' μ)
   (hf : tendsto f (la' ⊓ μ.ae) (𝓝 c)) (hu : tendsto u lt la) (hv : tendsto v lt la) :
   is_o (λ t, ∫ x in v t..b, f x ∂μ - ∫ x in u t..b, f x ∂μ + ∫ x in u t..v t, c ∂μ)
     (λ t, ∫ x in u t..v t, (1:ℝ) ∂μ) lt :=
 by simpa using measure_integral_sub_integral_sub_linear_is_o_of_tendsto_ae
-  hab hmeas hf ((tendsto_bot : tendsto _ ⊥ (𝓝 0)).mono_left inf_le_left)
+  hab hmeas measurable_at_bot hf ((tendsto_bot : tendsto _ ⊥ (𝓝 0)).mono_left inf_le_left)
   hu hv (tendsto_const_pure : tendsto _ _ (pure b)) tendsto_const_pure
 
 end
@@ -847,7 +849,7 @@ we have no definition of `has_strict_(f)deriv_at_filter` in the library.
 `l'`, where `(l, l')` is an `FTC_filter` pair around `a`, then
 `∫ x in u..v, f x ∂μ = (v - u) • c + o (v - u)` as both `u` and `v` tend to `l`. -/
 lemma integral_sub_linear_is_o_of_tendsto_ae [FTC_filter a l l']
-  (hfm : ae_measurable f) (hf : tendsto f (l' ⊓ volume.ae) (𝓝 c))
+  (hfm : measurable_at_filter f l') (hf : tendsto f (l' ⊓ volume.ae) (𝓝 c))
   {u v : β → ℝ} (hu : tendsto u lt l) (hv : tendsto v lt l) :
   is_o (λ t, (∫ x in u t..v t, f x) - (v t - u t) • c) (v - u) lt :=
 by simpa [integral_const] using measure_integral_sub_linear_is_o_of_tendsto_ae hfm hf hu hv
@@ -862,14 +864,16 @@ almost surely at `la'` and `lb'`, respectively, then
 This lemma could've been formulated using `has_strict_fderiv_at_filter` if we had this
 definition. -/
 lemma integral_sub_integral_sub_linear_is_o_of_tendsto_ae
-  (hab : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hab : interval_integrable f volume a b)
+  (hmeas_a : measurable_at_filter f la') (hmeas_b : measurable_at_filter f lb')
   (ha_lim : tendsto f (la' ⊓ volume.ae) (𝓝 ca)) (hb_lim : tendsto f (lb' ⊓ volume.ae) (𝓝 cb))
   (hua : tendsto ua lt la) (hva : tendsto va lt la)
   (hub : tendsto ub lt lb) (hvb : tendsto vb lt lb) :
   is_o (λ t, (∫ x in va t..vb t, f x) - (∫ x in ua t..ub t, f x) -
     ((vb t - ub t) • cb - (va t - ua t) • ca)) (λ t, ∥va t - ua t∥ + ∥vb t - ub t∥) lt :=
-by simpa [integral_const] using
-measure_integral_sub_integral_sub_linear_is_o_of_tendsto_ae hab hmeas ha_lim hb_lim hua hva hub hvb
+by simpa [integral_const]
+  using measure_integral_sub_integral_sub_linear_is_o_of_tendsto_ae hab hmeas_a hmeas_b
+    ha_lim hb_lim hua hva hub hvb
 
 /-- Fundamental theorem of calculus-1, strict differentiability at filter in both endpoints.
 If `f` is a measurable function integrable on `a..b`, `(lb, lb')` is an `FTC_filter` pair
@@ -878,7 +882,7 @@ around `b`, and `f` has a finite limit `c` almost surely at `lb'`, then
 
 This lemma could've been formulated using `has_strict_deriv_at_filter` if we had this definition. -/
 lemma integral_sub_integral_sub_linear_is_o_of_tendsto_ae_right
-  (hab : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hab : interval_integrable f volume a b) (hmeas : measurable_at_filter f lb')
   (hf : tendsto f (lb' ⊓ volume.ae) (𝓝 c)) (hu : tendsto u lt lb) (hv : tendsto v lt lb) :
   is_o (λ t, (∫ x in a..v t, f x) - (∫ x in a..u t, f x) - (v t - u t) • c) (v - u) lt :=
 by simpa only [integral_const, smul_eq_mul, mul_one] using
@@ -891,7 +895,7 @@ around `a`, and `f` has a finite limit `c` almost surely at `la'`, then
 
 This lemma could've been formulated using `has_strict_deriv_at_filter` if we had this definition. -/
 lemma integral_sub_integral_sub_linear_is_o_of_tendsto_ae_left
-  (hab : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hab : interval_integrable f volume a b) (hmeas : measurable_at_filter f la')
   (hf : tendsto f (la' ⊓ volume.ae) (𝓝 c)) (hu : tendsto u lt la) (hv : tendsto v lt la) :
   is_o (λ t, (∫ x in v t..b, f x) - (∫ x in u t..b, f x) + (v t - u t) • c) (v - u) lt :=
 by simpa only [integral_const, smul_eq_mul, mul_one] using
@@ -933,12 +937,13 @@ limits `ca` and `cb` almost surely as `x` tends to `a` and `b`, respectively, th
 `(u, v) ↦ ∫ x in u..v, f x` has derivative `(u, v) ↦ v • cb - u • ca` at `(a, b)`
 in the sense of strict differentiability. -/
 lemma integral_has_strict_fderiv_at_of_tendsto_ae
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b)
+  (hmeas_a : measurable_at_filter f (𝓝 a)) (hmeas_b : measurable_at_filter f (𝓝 b))
   (ha : tendsto f (𝓝 a ⊓ volume.ae) (𝓝 ca)) (hb : tendsto f (𝓝 b ⊓ volume.ae) (𝓝 cb)) :
   has_strict_fderiv_at (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x)
     ((snd ℝ ℝ ℝ).smul_right cb - (fst ℝ ℝ ℝ).smul_right ca) (a, b) :=
 begin
-  have := integral_sub_integral_sub_linear_is_o_of_tendsto_ae hf hmeas ha hb
+  have := integral_sub_integral_sub_linear_is_o_of_tendsto_ae hf hmeas_a hmeas_b ha hb
     ((continuous_fst.comp continuous_snd).tendsto ((a, b), (a, b)))
     ((continuous_fst.comp continuous_fst).tendsto ((a, b), (a, b)))
     ((continuous_snd.comp continuous_snd).tendsto ((a, b), (a, b)))
@@ -952,18 +957,19 @@ end
 at `a` and `b`, then `(u, v) ↦ ∫ x in u..v, f x` has derivative `(u, v) ↦ v • cb - u • ca`
 at `(a, b)` in the sense of strict differentiability. -/
 lemma integral_has_strict_fderiv_at
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b)
+  (hmeas_a : measurable_at_filter f (𝓝 a)) (hmeas_b : measurable_at_filter f (𝓝 b))
   (ha : continuous_at f a) (hb : continuous_at f b) :
   has_strict_fderiv_at (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x)
     ((snd ℝ ℝ ℝ).smul_right (f b) - (fst ℝ ℝ ℝ).smul_right (f a)) (a, b) :=
-integral_has_strict_fderiv_at_of_tendsto_ae hf hmeas
+integral_has_strict_fderiv_at_of_tendsto_ae hf hmeas_a hmeas_b
   (ha.mono_left inf_le_left) (hb.mono_left inf_le_left)
 
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f x` has a finite
 limit `c` almost surely at `b`, then `u ↦ ∫ x in a..u, f x` has derivative `c` at `b` in the sense
 of strict differentiability. -/
 lemma integral_has_strict_deriv_at_of_tendsto_ae_right
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 b))
   (hb : tendsto f (𝓝 b ⊓ volume.ae) (𝓝 c)) : has_strict_deriv_at (λ u, ∫ x in a..u, f x) c b :=
 integral_sub_integral_sub_linear_is_o_of_tendsto_ae_right hf hmeas hb continuous_at_snd
   continuous_at_fst
@@ -972,7 +978,7 @@ integral_sub_integral_sub_linear_is_o_of_tendsto_ae_right hf hmeas hb continuous
 at `b`, then `u ↦ ∫ x in a..u, f x` has derivative `f b` at `b` in the sense of strict
 differentiability. -/
 lemma integral_has_strict_deriv_at_right
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 b))
   (hb : continuous_at f b) : has_strict_deriv_at (λ u, ∫ x in a..u, f x) (f b) b :=
 integral_has_strict_deriv_at_of_tendsto_ae_right hf hmeas (hb.mono_left inf_le_left)
 
@@ -980,7 +986,7 @@ integral_has_strict_deriv_at_of_tendsto_ae_right hf hmeas (hb.mono_left inf_le_l
 limit `c` almost surely at `a`, then `u ↦ ∫ x in u..b, f x` has derivative `-c` at `a` in the sense
 of strict differentiability. -/
 lemma integral_has_strict_deriv_at_of_tendsto_ae_left
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 a))
   (ha : tendsto f (𝓝 a ⊓ volume.ae) (𝓝 c)) : has_strict_deriv_at (λ u, ∫ x in u..b, f x) (-c) a :=
 by simpa only [← integral_symm]
   using (integral_has_strict_deriv_at_of_tendsto_ae_right hf.symm hmeas ha).neg
@@ -989,7 +995,7 @@ by simpa only [← integral_symm]
 at `a`, then `u ↦ ∫ x in u..b, f x` has derivative `-f a` at `a` in the sense of strict
 differentiability. -/
 lemma integral_has_strict_deriv_at_left
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 a))
   (ha : continuous_at f a) : has_strict_deriv_at (λ u, ∫ x in u..b, f x) (-f a) a :=
 by simpa only [← integral_symm] using (integral_has_strict_deriv_at_right hf.symm hmeas ha).neg
 
@@ -1004,95 +1010,102 @@ In this subsection we restate results from the previous subsection in terms of `
 limits `ca` and `cb` almost surely as `x` tends to `a` and `b`, respectively, then
 `(u, v) ↦ ∫ x in u..v, f x` has derivative `(u, v) ↦ v • cb - u • ca` at `(a, b)`. -/
 lemma integral_has_fderiv_at_of_tendsto_ae
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b)
+  (hmeas_a : measurable_at_filter f (𝓝 a)) (hmeas_b : measurable_at_filter f (𝓝 b))
   (ha : tendsto f (𝓝 a ⊓ volume.ae) (𝓝 ca)) (hb : tendsto f (𝓝 b ⊓ volume.ae) (𝓝 cb)) :
   has_fderiv_at (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x)
     ((snd ℝ ℝ ℝ).smul_right cb - (fst ℝ ℝ ℝ).smul_right ca) (a, b) :=
-(integral_has_strict_fderiv_at_of_tendsto_ae hf hmeas ha hb).has_fderiv_at
+(integral_has_strict_fderiv_at_of_tendsto_ae hf hmeas_a hmeas_b ha hb).has_fderiv_at
 
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f` is continuous
 at `a` and `b`, then `(u, v) ↦ ∫ x in u..v, f x` has derivative `(u, v) ↦ v • cb - u • ca`
 at `(a, b)`. -/
 lemma integral_has_fderiv_at
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b)
+  (hmeas_a : measurable_at_filter f (𝓝 a)) (hmeas_b : measurable_at_filter f (𝓝 b))
   (ha : continuous_at f a) (hb : continuous_at f b) :
   has_fderiv_at (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x)
     ((snd ℝ ℝ ℝ).smul_right (f b) - (fst ℝ ℝ ℝ).smul_right (f a)) (a, b) :=
-(integral_has_strict_fderiv_at hf hmeas ha hb).has_fderiv_at
+(integral_has_strict_fderiv_at hf hmeas_a hmeas_b ha hb).has_fderiv_at
 
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f x` has finite
 limits `ca` and `cb` almost surely as `x` tends to `a` and `b`, respectively, then `fderiv`
 derivative of `(u, v) ↦ ∫ x in u..v, f x` at `(a, b)` equals `(u, v) ↦ v • cb - u • ca`. -/
 lemma fderiv_integral_of_tendsto_ae
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b) (hmeas_a : measurable_at_filter f (𝓝 a))
+  (hmeas_a : measurable_at_filter f (𝓝 a)) (hmeas_b : measurable_at_filter f (𝓝 b))
   (ha : tendsto f (𝓝 a ⊓ volume.ae) (𝓝 ca)) (hb : tendsto f (𝓝 b ⊓ volume.ae) (𝓝 cb)) :
   fderiv ℝ (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x) (a, b) =
     (snd ℝ ℝ ℝ).smul_right cb - (fst ℝ ℝ ℝ).smul_right ca :=
-(integral_has_fderiv_at_of_tendsto_ae hf hmeas ha hb).fderiv
+(integral_has_fderiv_at_of_tendsto_ae hf hmeas_a hmeas_b ha hb).fderiv
 
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f` is continuous
 at `a` and `b`, then `fderiv` derivative of `(u, v) ↦ ∫ x in u..v, f x` at `(a, b)` equals `(u, v) ↦
 v • cb - u • ca`. -/
 lemma fderiv_integral
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b)
+  (hmeas_a : measurable_at_filter f (𝓝 a)) (hmeas_b : measurable_at_filter f (𝓝 b))
   (ha : continuous_at f a) (hb : continuous_at f b) :
   fderiv ℝ (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x) (a, b) =
     (snd ℝ ℝ ℝ).smul_right (f b) - (fst ℝ ℝ ℝ).smul_right (f a) :=
-(integral_has_fderiv_at hf hmeas ha hb).fderiv
+(integral_has_fderiv_at hf hmeas_a hmeas_b ha hb).fderiv
 
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f x` has a finite
 limit `c` almost surely at `b`, then `u ↦ ∫ x in a..u, f x` has derivative `c` at `b`. -/
 lemma integral_has_deriv_at_of_tendsto_ae_right
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 b))
   (hb : tendsto f (𝓝 b ⊓ volume.ae) (𝓝 c)) : has_deriv_at (λ u, ∫ x in a..u, f x) c b :=
 (integral_has_strict_deriv_at_of_tendsto_ae_right hf hmeas hb).has_deriv_at
 
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f` is continuous
 at `b`, then `u ↦ ∫ x in a..u, f x` has derivative `f b` at `b`. -/
 lemma integral_has_deriv_at_right
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 b))
   (hb : continuous_at f b) : has_deriv_at (λ u, ∫ x in a..u, f x) (f b) b :=
 (integral_has_strict_deriv_at_right hf hmeas hb).has_deriv_at
 
 /-- Fundamental theorem of calculus: if `f : ℝ → E` is integrable on `a..b` and `f` has a finite
 limit `c` almost surely at `b`, then the derivative of `u ↦ ∫ x in a..u, f x` at `b` equals `c`. -/
 lemma deriv_integral_of_tendsto_ae_right
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 b))
   (hb : tendsto f (𝓝 b ⊓ volume.ae) (𝓝 c)) : deriv (λ u, ∫ x in a..u, f x) b = c :=
 (integral_has_deriv_at_of_tendsto_ae_right hf hmeas hb).deriv
 
 /-- Fundamental theorem of calculus: if `f : ℝ → E` is integrable on `a..b` and `f` is continuous
 at `b`, then the derivative of `u ↦ ∫ x in a..u, f x` at `b` equals `f b`. -/
 lemma deriv_integral_right
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f ) (hb : continuous_at f b) :
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 b))
+  (hb : continuous_at f b) :
   deriv (λ u, ∫ x in a..u, f x) b = f b :=
 (integral_has_deriv_at_right hf hmeas hb).deriv
 
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f x` has a finite
 limit `c` almost surely at `a`, then `u ↦ ∫ x in u..b, f x` has derivative `-c` at `a`. -/
 lemma integral_has_deriv_at_of_tendsto_ae_left
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 a))
   (ha : tendsto f (𝓝 a ⊓ volume.ae) (𝓝 c)) : has_deriv_at (λ u, ∫ x in u..b, f x) (-c) a :=
 (integral_has_strict_deriv_at_of_tendsto_ae_left hf hmeas ha).has_deriv_at
 
 /-- Fundamental theorem of calculus-1: if `f : ℝ → E` is integrable on `a..b` and `f` is continuous
 at `a`, then `u ↦ ∫ x in u..b, f x` has derivative `-f a` at `a`. -/
 lemma integral_has_deriv_at_left
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f) (ha : continuous_at f a) :
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 a))
+  (ha : continuous_at f a) :
   has_deriv_at (λ u, ∫ x in u..b, f x) (-f a) a :=
 (integral_has_strict_deriv_at_left hf hmeas ha).has_deriv_at
 
 /-- Fundamental theorem of calculus: if `f : ℝ → E` is integrable on `a..b` and `f` has a finite
 limit `c` almost surely at `a`, then the derivative of `u ↦ ∫ x in u..b, f x` at `a` equals `-c`. -/
 lemma deriv_integral_of_tendsto_ae_left
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 a))
   (hb : tendsto f (𝓝 a ⊓ volume.ae) (𝓝 c)) : deriv (λ u, ∫ x in u..b, f x) a = -c :=
 (integral_has_deriv_at_of_tendsto_ae_left hf hmeas hb).deriv
 
 /-- Fundamental theorem of calculus: if `f : ℝ → E` is integrable on `a..b` and `f` is continuous
 at `a`, then the derivative of `u ↦ ∫ x in u..b, f x` at `a` equals `-f a`. -/
 lemma deriv_integral_left
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f ) (hb : continuous_at f a) :
+  (hf : interval_integrable f volume a b) (hmeas : measurable_at_filter f (𝓝 a))
+  (hb : continuous_at f a) :
   deriv (λ u, ∫ x in u..b, f x) a = -f a :=
 (integral_has_deriv_at_left hf hmeas hb).deriv
 
@@ -1113,14 +1126,15 @@ and `cb` almost surely at the filters `la` and `lb` from the following table.
 | `univ`  | `𝓝 a`        | `univ`  | `𝓝 b`        |
 -/
 lemma integral_has_fderiv_within_at_of_tendsto_ae
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b)
   {s t : set ℝ} [FTC_filter a (𝓝[s] a) la] [FTC_filter b (𝓝[t] b) lb]
+  (hmeas_a : measurable_at_filter f la) (hmeas_b : measurable_at_filter f lb)
   (ha : tendsto f (la ⊓ volume.ae) (𝓝 ca)) (hb : tendsto f (lb ⊓ volume.ae) (𝓝 cb)) :
   has_fderiv_within_at (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x)
     ((snd ℝ ℝ ℝ).smul_right cb - (fst ℝ ℝ ℝ).smul_right ca) (s.prod t) (a, b) :=
 begin
   rw [has_fderiv_within_at, nhds_within_prod_eq],
-  have := integral_sub_integral_sub_linear_is_o_of_tendsto_ae hf hmeas ha hb
+  have := integral_sub_integral_sub_linear_is_o_of_tendsto_ae hf hmeas_a hmeas_b ha hb
     (tendsto_const_pure.mono_right FTC_filter.pure_le : tendsto _ _ (𝓝[s] a)) tendsto_fst
     (tendsto_const_pure.mono_right FTC_filter.pure_le : tendsto _ _ (𝓝[t] b)) tendsto_snd,
   refine (this.congr_left _).trans_is_O _,
@@ -1142,12 +1156,13 @@ is definitionally equal `continuous_at f _` or `continuous_within_at f _ _`.
 | `univ`  | `𝓝 a`        | `univ`  | `𝓝 b`        |
 -/
 lemma integral_has_fderiv_within_at
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b)
+  (hmeas_a : measurable_at_filter f la) (hmeas_b : measurable_at_filter f lb)
   {s t : set ℝ} [FTC_filter a (𝓝[s] a) la] [FTC_filter b (𝓝[t] b) lb]
   (ha : tendsto f la (𝓝 $ f a)) (hb : tendsto f lb (𝓝 $ f b)) :
   has_fderiv_within_at (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x)
     ((snd ℝ ℝ ℝ).smul_right (f b) - (fst ℝ ℝ ℝ).smul_right (f a)) (s.prod t) (a, b) :=
-integral_has_fderiv_within_at_of_tendsto_ae hf hmeas (ha.mono_left inf_le_left)
+integral_has_fderiv_within_at_of_tendsto_ae hf hmeas_a hmeas_b (ha.mono_left inf_le_left)
   (hb.mono_left inf_le_left)
 
 /-- An auxiliary tactic closing goals `unique_diff_within_at ℝ s a` where
@@ -1169,21 +1184,22 @@ is equal to `(u, v) ↦ u • cb - v • ca`.
 
 -/
 lemma fderiv_within_integral_of_tendsto_ae
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
+  (hf : interval_integrable f volume a b)
+  (hmeas_a : measurable_at_filter f la) (hmeas_b : measurable_at_filter f lb)
   {s t : set ℝ} [FTC_filter a (𝓝[s] a) la] [FTC_filter b (𝓝[t] b) lb]
   (ha : tendsto f (la ⊓ volume.ae) (𝓝 ca)) (hb : tendsto f (lb ⊓ volume.ae) (𝓝 cb))
   (hs : unique_diff_within_at ℝ s a . unique_diff_within_at_Ici_Iic_univ)
   (ht : unique_diff_within_at ℝ t b . unique_diff_within_at_Ici_Iic_univ) :
   fderiv_within ℝ (λ p : ℝ × ℝ, ∫ x in p.1..p.2, f x) (s.prod t) (a, b) =
     ((snd ℝ ℝ ℝ).smul_right cb - (fst ℝ ℝ ℝ).smul_right ca) :=
-(integral_has_fderiv_within_at_of_tendsto_ae hf hmeas ha hb).fderiv_within $ hs.prod ht
+(integral_has_fderiv_within_at_of_tendsto_ae hf hmeas_a hmeas_b ha hb).fderiv_within $ hs.prod ht
 
 /-- Fundamental theorem of calculus: if `f : ℝ → E` is integrable on `a..b` and `f x` has a finite
 limit `c` almost surely as `x` tends to `b` from the right or from the left,
 then `u ↦ ∫ x in a..u, f x` has right (resp., left) derivative `c` at `b`. -/
 lemma integral_has_deriv_within_at_of_tendsto_ae_right
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
-  {s t : set ℝ} [FTC_filter b (𝓝[s] b) (𝓝[t] b)] (hb : tendsto f (𝓝[t] b ⊓ volume.ae) (𝓝 c)) :
+  (hf : interval_integrable f volume a b) {s t : set ℝ} [FTC_filter b (𝓝[s] b) (𝓝[t] b)]
+  (hmeas : measurable_at_filter f (𝓝[t] b)) (hb : tendsto f (𝓝[t] b ⊓ volume.ae) (𝓝 c)) :
   has_deriv_within_at (λ u, ∫ x in a..u, f x) c s b :=
 integral_sub_integral_sub_linear_is_o_of_tendsto_ae_right hf hmeas hb
   (tendsto_const_pure.mono_right FTC_filter.pure_le) tendsto_id
@@ -1192,8 +1208,8 @@ integral_sub_integral_sub_linear_is_o_of_tendsto_ae_right hf hmeas hb
 from the left or from the right at `b`, then `u ↦ ∫ x in a..u, f x` has left (resp., right)
 derivative `f b` at `b`. -/
 lemma integral_has_deriv_within_at_right
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
-  {s t : set ℝ} [FTC_filter b (𝓝[s] b) (𝓝[t] b)] (hb : continuous_within_at f t b) :
+  (hf : interval_integrable f volume a b) {s t : set ℝ} [FTC_filter b (𝓝[s] b) (𝓝[t] b)]
+  (hmeas : measurable_at_filter f (𝓝[t] b)) (hb : continuous_within_at f t b) :
   has_deriv_within_at (λ u, ∫ x in a..u, f x) (f b) s b :=
 integral_has_deriv_within_at_of_tendsto_ae_right hf hmeas (hb.mono_left inf_le_left)
 
@@ -1201,8 +1217,8 @@ integral_has_deriv_within_at_of_tendsto_ae_right hf hmeas (hb.mono_left inf_le_l
 limit `c` almost surely as `x` tends to `b` from the right or from the left, then the right
 (resp., left) derivative of `u ↦ ∫ x in a..u, f x` at `b` equals `c`. -/
 lemma deriv_within_integral_of_tendsto_ae_right
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
-  {s t : set ℝ} [FTC_filter b (𝓝[s] b) (𝓝[t] b)] (hb : tendsto f (𝓝[t] b ⊓ volume.ae) (𝓝 c))
+  (hf : interval_integrable f volume a b) {s t : set ℝ} [FTC_filter b (𝓝[s] b) (𝓝[t] b)]
+  (hmeas: measurable_at_filter f (𝓝[t] b)) (hb : tendsto f (𝓝[t] b ⊓ volume.ae) (𝓝 c))
   (hs : unique_diff_within_at ℝ s b . unique_diff_within_at_Ici_Iic_univ) :
   deriv_within (λ u, ∫ x in a..u, f x) s b = c :=
 (integral_has_deriv_within_at_of_tendsto_ae_right hf hmeas hb).deriv_within hs
@@ -1211,8 +1227,8 @@ lemma deriv_within_integral_of_tendsto_ae_right
 on the right or on the left at `b`, then the right (resp., left) derivative of
 `u ↦ ∫ x in a..u, f x` at `b` equals `f b`. -/
 lemma deriv_within_integral_right
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
-  {s t : set ℝ} [FTC_filter b (𝓝[s] b) (𝓝[t] b)] (hb : continuous_within_at f t b)
+  (hf : interval_integrable f volume a b) {s t : set ℝ} [FTC_filter b (𝓝[s] b) (𝓝[t] b)]
+  (hmeas : measurable_at_filter f (𝓝[t] b)) (hb : continuous_within_at f t b)
   (hs : unique_diff_within_at ℝ s b . unique_diff_within_at_Ici_Iic_univ) :
   deriv_within (λ u, ∫ x in a..u, f x) s b = f b :=
 (integral_has_deriv_within_at_right hf hmeas hb).deriv_within hs
@@ -1221,8 +1237,8 @@ lemma deriv_within_integral_right
 limit `c` almost surely as `x` tends to `a` from the right or from the left,
 then `u ↦ ∫ x in u..b, f x` has right (resp., left) derivative `-c` at `a`. -/
 lemma integral_has_deriv_within_at_of_tendsto_ae_left
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
-  {s t : set ℝ} [FTC_filter a (𝓝[s] a) (𝓝[t] a)] (ha : tendsto f (𝓝[t] a ⊓ volume.ae) (𝓝 c)) :
+  (hf : interval_integrable f volume a b) {s t : set ℝ} [FTC_filter a (𝓝[s] a) (𝓝[t] a)]
+  (hmeas : measurable_at_filter f (𝓝[t] a)) (ha : tendsto f (𝓝[t] a ⊓ volume.ae) (𝓝 c)) :
   has_deriv_within_at (λ u, ∫ x in u..b, f x) (-c) s a :=
 by { simp only [integral_symm b],
   exact (integral_has_deriv_within_at_of_tendsto_ae_right hf.symm hmeas ha).neg }
@@ -1231,8 +1247,8 @@ by { simp only [integral_symm b],
 from the left or from the right at `a`, then `u ↦ ∫ x in u..b, f x` has left (resp., right)
 derivative `-f a` at `a`. -/
 lemma integral_has_deriv_within_at_left
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
-  {s t : set ℝ} [FTC_filter a (𝓝[s] a) (𝓝[t] a)] (ha : continuous_within_at f t a) :
+  (hf : interval_integrable f volume a b) {s t : set ℝ} [FTC_filter a (𝓝[s] a) (𝓝[t] a)]
+  (hmeas : measurable_at_filter f (𝓝[t] a)) (ha : continuous_within_at f t a) :
   has_deriv_within_at (λ u, ∫ x in u..b, f x) (-f a) s a :=
 integral_has_deriv_within_at_of_tendsto_ae_left hf hmeas (ha.mono_left inf_le_left)
 
@@ -1240,8 +1256,8 @@ integral_has_deriv_within_at_of_tendsto_ae_left hf hmeas (ha.mono_left inf_le_le
 limit `c` almost surely as `x` tends to `a` from the right or from the left, then the right
 (resp., left) derivative of `u ↦ ∫ x in u..b, f x` at `a` equals `-c`. -/
 lemma deriv_within_integral_of_tendsto_ae_left
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
-  {s t : set ℝ} [FTC_filter a (𝓝[s] a) (𝓝[t] a)] (ha : tendsto f (𝓝[t] a ⊓ volume.ae) (𝓝 c))
+  (hf : interval_integrable f volume a b) {s t : set ℝ} [FTC_filter a (𝓝[s] a) (𝓝[t] a)]
+  (hmeas : measurable_at_filter f (𝓝[t] a)) (ha : tendsto f (𝓝[t] a ⊓ volume.ae) (𝓝 c))
   (hs : unique_diff_within_at ℝ s a . unique_diff_within_at_Ici_Iic_univ) :
   deriv_within (λ u, ∫ x in u..b, f x) s a = -c :=
 (integral_has_deriv_within_at_of_tendsto_ae_left hf hmeas ha).deriv_within hs
@@ -1250,8 +1266,8 @@ lemma deriv_within_integral_of_tendsto_ae_left
 on the right or on the left at `a`, then the right (resp., left) derivative of
 `u ↦ ∫ x in u..b, f x` at `a` equals `-f a`. -/
 lemma deriv_within_integral_left
-  (hf : interval_integrable f volume a b) (hmeas : ae_measurable f)
-  {s t : set ℝ} [FTC_filter a (𝓝[s] a) (𝓝[t] a)] (ha : continuous_within_at f t a)
+  (hf : interval_integrable f volume a b) {s t : set ℝ} [FTC_filter a (𝓝[s] a) (𝓝[t] a)]
+  (hmeas : measurable_at_filter f (𝓝[t] a)) (ha : continuous_within_at f t a)
   (hs : unique_diff_within_at ℝ s a . unique_diff_within_at_Ici_Iic_univ) :
   deriv_within (λ u, ∫ x in u..b, f x) s a = -f a :=
 (integral_has_deriv_within_at_left hf hmeas ha).deriv_within hs
@@ -1267,8 +1283,9 @@ variables {f' : ℝ → E}
 theorem differentiable_on_integral_of_continuous {s : set ℝ}
   (hintg : ∀ x ∈ s, interval_integrable f volume a x) (hcont : continuous f) :
   differentiable_on ℝ (λ u, ∫ x in a..u, f x) s :=
-λ y hy, (integral_has_deriv_at_right (hintg y hy) hcont.measurable.ae_measurable
-          hcont.continuous_at).differentiable_at.differentiable_within_at
+λ y hy, (integral_has_deriv_at_right (hintg y hy)
+  hcont.measurable.ae_measurable.measurable_at_filter
+    hcont.continuous_at) .differentiable_at.differentiable_within_at
 
 /-- The integral of a continuous function is continuous on a real set `s`. This is true even
   without the assumption of continuity, but a proof of that fact does not yet exist in mathlib. -/
@@ -1282,14 +1299,17 @@ theorem continuous_on_integral_of_continuous {s : set ℝ}
   then `∫ y in a..b, f' y` equals `f b - f a`. -/
 theorem integral_eq_sub_of_has_deriv_right_of_le (hab : a ≤ b) (hcont : continuous_on f (Icc a b))
   (hderiv : ∀ x ∈ Ico a b, has_deriv_within_at f (f' x) (Ici x) x)
-  (hcont' : continuous_on f' (Icc a b)) (hmeas' : ae_measurable f') :
+  (hcont' : continuous_on f' (Icc a b)) :
   ∫ y in a..b, f' y = f b - f a :=
 begin
+  have hmeas' : ae_measurable f' (volume.restrict (Icc a b)),
+    from hcont'.ae_measurable is_measurable_Icc,
   refine eq_sub_of_add_eq (eq_of_has_deriv_right_eq (λ y hy, _) hderiv
     (λ y hy, _) hcont (by simp) _ (right_mem_Icc.2 hab)),
-  { refine (integral_has_deriv_within_at_right _ hmeas' _).add_const _,
+  { refine (integral_has_deriv_within_at_right _ _ _).add_const _,
     { refine (hcont'.mono _).interval_integrable,
       simp only [hy.left, Icc_subset_Icc_right hy.right.le, interval_of_le] },
+    { exact ⟨_, Icc_mem_nhds_within_Ioi hy, hmeas'⟩,  },
     { exact (hcont' _ (mem_Icc_of_Ico hy)).mono_of_mem (Icc_mem_nhds_within_Ioi hy) } },
 { -- TODO: prove that integral of any integrable function is continuous, and use here
     letI : tendsto_Ixx_class Ioc (𝓟 (Icc a b)) (𝓟 (Ioc a b)) :=
@@ -1297,9 +1317,10 @@ begin
     haveI : is_measurably_generated (𝓝[Ioc a b] y) :=
       is_measurable_Ioc.nhds_within_is_measurably_generated y,
     letI : FTC_filter y (𝓝[Icc a b] y) (𝓝[Ioc a b] y) := ⟨pure_le_nhds_within hy, inf_le_left⟩,
-    refine (integral_has_deriv_within_at_right _ hmeas' _).continuous_within_at.add
+    refine (integral_has_deriv_within_at_right _ _ _).continuous_within_at.add
       continuous_within_at_const,
     { exact (hcont'.mono $ Icc_subset_Icc_right hy.2).interval_integrable_of_Icc hy.1 },
+    { exact ⟨_, mem_sets_of_superset self_mem_nhds_within Ioc_subset_Icc_self, hmeas'⟩ },
     { exact (hcont' y hy).mono Ioc_subset_Icc_self } }
 end
 
@@ -1308,15 +1329,14 @@ end
   measurable, then `∫ y in a..b, f' y` equals `f b - f a`. -/
 theorem integral_eq_sub_of_has_deriv_right (hcont : continuous_on f (interval a b))
   (hderiv : ∀ x ∈ Ico (min a b) (max a b), has_deriv_within_at f (f' x) (Ici x) x)
-  (hcont' : continuous_on f' (interval a b)) (hmeas' : ae_measurable f') :
+  (hcont' : continuous_on f' (interval a b)) :
   ∫ y in a..b, f' y = f b - f a :=
 begin
   cases le_total a b with hab hab,
   { simp only [interval_of_le, min_eq_left, max_eq_right, hab] at hcont hcont' hderiv,
-    exact integral_eq_sub_of_has_deriv_right_of_le hab hcont hderiv hcont' hmeas' },
+    exact integral_eq_sub_of_has_deriv_right_of_le hab hcont hderiv hcont' },
   { simp only [interval_of_ge, min_eq_right, max_eq_left, hab] at hcont hcont' hderiv,
-    rw [integral_symm, integral_eq_sub_of_has_deriv_right_of_le hab hcont hderiv hcont' hmeas',
-      neg_sub] }
+    rw [integral_symm, integral_eq_sub_of_has_deriv_right_of_le hab hcont hderiv hcont', neg_sub] }
 end
 
 /-- Fundamental theorem of calculus-2: If `f : ℝ → E` is continuous on `[a, b]` and has a derivative
@@ -1324,18 +1344,18 @@ end
   `∫ y in a..b, f' y` equals `f b - f a`. -/
 theorem integral_eq_sub_of_has_deriv_at' (hcont : continuous_on f (interval a b))
   (hderiv : ∀ x ∈ Ico (min a b) (max a b), has_deriv_at f (f' x) x)
-  (hcont' : continuous_on f' (interval a b)) (hmeas' : ae_measurable f') :
+  (hcont' : continuous_on f' (interval a b)) :
   ∫ y in a..b, f' y = f b - f a :=
-integral_eq_sub_of_has_deriv_right hcont (λ x hx, (hderiv x hx).has_deriv_within_at) hcont' hmeas'
+integral_eq_sub_of_has_deriv_right hcont (λ x hx, (hderiv x hx).has_deriv_within_at) hcont'
 
 /-- Fundamental theorem of calculus-2: If `f : ℝ → E` has a derivative at `f' x` for all `x` in
   `[a, b)` and `f'` is continuous on `[a, b]` and measurable, then `∫ y in a..b, f' y` equals
   `f b - f a`. -/
 theorem integral_eq_sub_of_has_deriv_at (hderiv : ∀ x ∈ interval a b, has_deriv_at f (f' x) x)
-  (hcont' : continuous_on f' (interval a b)) (hmeas' : ae_measurable f') :
+  (hcont' : continuous_on f' (interval a b)) :
   ∫ y in a..b, f' y = f b - f a :=
 integral_eq_sub_of_has_deriv_at' (λ x hx, (hderiv x hx).continuous_at.continuous_within_at)
-  (λ x hx, hderiv _ (mem_Icc_of_Ico hx)) hcont' hmeas'
+  (λ x hx, hderiv _ (mem_Icc_of_Ico hx)) hcont'
 
 /-- Fundamental theorem of calculus-2: If `f : ℝ → E` is differentiable at every `x` in `[a, b]` and
   its derivative is continuous on `[a, b]`, then `∫ y in a..b, deriv f y` equals `f b - f a`. -/
@@ -1343,6 +1363,5 @@ theorem integral_deriv_eq_sub (hderiv : ∀ x ∈ interval a b, differentiable_a
   (hcont' : continuous_on (deriv f) (interval a b)) :
   ∫ y in a..b, deriv f y = f b - f a :=
 integral_eq_sub_of_has_deriv_at (λ x hx, (hderiv x hx).has_deriv_at) hcont'
-  (measurable_deriv f).ae_measurable
 
 end interval_integral

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -8,7 +8,7 @@ import data.set.countable
 import data.indicator_function
 import data.equiv.encodable.lattice
 import data.tprod
-import order.filter.basic
+import order.filter.lift
 
 /-!
 # Measurable spaces and measurable functions
@@ -104,7 +104,7 @@ s.compl_compl ▸ h.compl
 @[simp] lemma is_measurable.univ : is_measurable (univ : set α) :=
 by simpa using (@is_measurable.empty α _).compl
 
-lemma subsingleton.is_measurable [subsingleton α] {s : set α} : is_measurable s :=
+@[nontriviality] lemma subsingleton.is_measurable [subsingleton α] {s : set α} : is_measurable s :=
 subsingleton.set_cases is_measurable.empty is_measurable.univ s
 
 lemma is_measurable.congr {s t : set α} (hs : is_measurable s) (h : s = t) :
@@ -508,7 +508,7 @@ lemma measurable.comp {g : β → γ} {f : α → β} (hg : measurable g) (hf : 
   measurable (g ∘ f) :=
 λ t ht, hf (hg ht)
 
-lemma subsingleton.measurable [subsingleton α] {f : α → β} : measurable f :=
+@[nontriviality] lemma subsingleton.measurable [subsingleton α] {f : α → β} : measurable f :=
 λ s hs, @subsingleton.is_measurable α _ _ _
 
 lemma measurable.piecewise {s : set α} {_ : decidable_pred s} {f g : α → β}
@@ -1336,6 +1336,13 @@ lemma eventually.exists_measurable_mem {f : filter α} [is_measurably_generated 
   {p : α → Prop} (h : ∀ᶠ x in f, p x) :
   ∃ s ∈ f, is_measurable s ∧ ∀ x ∈ s, p x :=
 is_measurably_generated.exists_measurable_subset h
+
+lemma eventually.exists_measurable_mem_of_lift' {f : filter α} [is_measurably_generated f]
+  {p : set α → Prop} (h : ∀ᶠ s in f.lift' powerset, p s) :
+  ∃ s ∈ f, is_measurable s ∧ p s :=
+let ⟨s, hsf, hs⟩ := eventually_lift'_powerset.1 h,
+  ⟨t, htf, htm, hts⟩ := is_measurably_generated.exists_measurable_subset hsf
+in ⟨t, htf, htm, hs t hts⟩
 
 instance inf_is_measurably_generated (f g : filter α) [is_measurably_generated f]
   [is_measurably_generated g] :

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -789,12 +789,12 @@ lemma restrict_apply_eq_zero (ht : is_measurable t) : μ.restrict s t = 0 ↔ μ
 by rw [restrict_apply ht]
 
 lemma measure_inter_eq_zero_of_restrict (h : μ.restrict s t = 0) : μ (t ∩ s) = 0 :=
-le_zero_iff_eq.1 (h ▸ le_restrict_apply _ _)
+nonpos_iff_eq_zero.1 (h ▸ le_restrict_apply _ _)
 
 lemma restrict_apply_eq_zero' (hs : is_measurable s) : μ.restrict s t = 0 ↔ μ (t ∩ s) = 0 :=
 begin
   refine ⟨measure_inter_eq_zero_of_restrict, λ h, _⟩,
-  rcases exists_is_measurable_superset_of_measure_eq_zero h with ⟨t', htt', ht', ht'0⟩,
+  rcases exists_is_measurable_superset_of_null h with ⟨t', htt', ht', ht'0⟩,
   apply measure_mono_null ((inter_subset _ _ _).1 htt'),
   rw [restrict_apply (hs.compl.union ht'), union_inter_distrib_right, compl_inter_self,
     set.empty_union],

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -788,10 +788,13 @@ ext $ λ u hu, by simp [*, set.inter_assoc]
 lemma restrict_apply_eq_zero (ht : is_measurable t) : μ.restrict s t = 0 ↔ μ (t ∩ s) = 0 :=
 by rw [restrict_apply ht]
 
+lemma measure_inter_eq_zero_of_restrict (h : μ.restrict s t = 0) : μ (t ∩ s) = 0 :=
+le_zero_iff_eq.1 (h ▸ le_restrict_apply _ _)
+
 lemma restrict_apply_eq_zero' (hs : is_measurable s) : μ.restrict s t = 0 ↔ μ (t ∩ s) = 0 :=
 begin
-  refine ⟨λ h, nonpos_iff_eq_zero.1 (h ▸ le_restrict_apply _ _), λ h, _⟩,
-  rcases exists_is_measurable_superset_of_null h with ⟨t', htt', ht', ht'0⟩,
+  refine ⟨measure_inter_eq_zero_of_restrict, λ h, _⟩,
+  rcases exists_is_measurable_superset_of_measure_eq_zero h with ⟨t', htt', ht', ht'0⟩,
   apply measure_mono_null ((inter_subset _ _ _).1 htt'),
   rw [restrict_apply (hs.compl.union ht'), union_inter_distrib_right, compl_inter_self,
     set.empty_union],
@@ -1197,6 +1200,8 @@ compl_mem_ae_iff.symm
 @[simp] lemma ae_eq_bot : μ.ae = ⊥ ↔ μ = 0 :=
 by rw [← empty_in_sets_eq_bot, mem_ae_iff, compl_empty, measure_univ_eq_zero]
 
+@[simp] lemma ae_zero : (0 : measure α).ae = ⊥ := ae_eq_bot.2 rfl
+
 lemma ae_of_all {p : α → Prop} (μ : measure α) : (∀ a, p a) → ∀ᵐ a ∂ μ, p a :=
 eventually_of_forall
 
@@ -1266,6 +1271,13 @@ begin
   congr' with x, simp [and_comm]
 end
 
+lemma ae_imp_of_ae_restrict {s : set α} {p : α → Prop} (h : ∀ᵐ x ∂(μ.restrict s), p x) :
+  ∀ᵐ x ∂μ, x ∈ s → p x :=
+begin
+  simp only [ae_iff] at h ⊢,
+  simpa [set_of_and, inter_comm] using  measure_inter_eq_zero_of_restrict h
+end
+
 lemma ae_restrict_iff' {s : set α} {p : α → Prop} (hp : is_measurable s) :
   (∀ᵐ x ∂(μ.restrict s), p x) ↔ ∀ᵐ x ∂μ, x ∈ s → p x :=
 begin
@@ -1291,6 +1303,9 @@ begin
   calc μ {x | g (f x) ≠ g' (f x)} ≤ μ (f⁻¹' t) : measure_mono (λ x hx, ht hx)
   ... = 0 : by rwa ← measure.map_apply hf tmeas
 end
+
+lemma le_ae_restrict : μ.ae ⊓ 𝓟 s ≤ (μ.restrict s).ae :=
+λ s hs, eventually_inf_principal.2 (ae_imp_of_ae_restrict hs)
 
 @[simp] lemma ae_restrict_eq (hs : is_measurable s) : (μ.restrict s).ae = μ.ae ⊓ 𝓟 s :=
 begin
@@ -2082,6 +2097,15 @@ def ae_measurable (f : α → β) (μ : measure α . measure_theory.volume_tac) 
 lemma measurable.ae_measurable (h : measurable f) : ae_measurable f μ :=
 ⟨f, h, ae_eq_refl f⟩
 
+@[nontriviality] lemma subsingleton.ae_measurable [subsingleton α] : ae_measurable f μ :=
+subsingleton.measurable.ae_measurable
+
+@[simp] lemma ae_measurable_zero : ae_measurable f 0 :=
+begin
+  nontriviality α, inhabit α,
+  exact ⟨λ x, f (default α), measurable_const, rfl⟩
+end
+
 lemma ae_measurable_iff_measurable [μ.is_complete] :
   ae_measurable f μ ↔ measurable f :=
 begin
@@ -2109,6 +2133,18 @@ lemma congr (hf : ae_measurable f μ) (h : f =ᵐ[μ] g) : ae_measurable g μ :=
 
 lemma mono_measure (h : ae_measurable f μ) (h' : ν ≤ μ) : ae_measurable f ν :=
 ⟨h.mk f, h.measurable_mk, eventually.filter_mono (ae_mono h') h.ae_eq_mk⟩
+
+lemma mono_set {s t} (h : s ⊆ t) (ht : ae_measurable f (μ.restrict t)) :
+  ae_measurable f (μ.restrict s) :=
+ht.mono_measure (restrict_mono h le_rfl)
+
+lemma ae_mem_imp_eq_mk {s} (h : ae_measurable f (μ.restrict s)) :
+  ∀ᵐ x ∂μ, x ∈ s → f x = h.mk f x :=
+ae_imp_of_ae_restrict h.ae_eq_mk
+
+lemma ae_inf_principal_eq_mk {s} (h : ae_measurable f (μ.restrict s)) :
+  f =ᶠ[μ.ae ⊓ 𝓟 s] h.mk f :=
+le_ae_restrict h.ae_eq_mk
 
 lemma add_measure {f : α → β} (hμ : ae_measurable f μ) (hν : ae_measurable f ν) :
   ae_measurable f (μ + ν) :=

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -487,27 +487,31 @@ end measure_theory
 
 open measure_theory asymptotics metric
 
-variables [measurable_space E] [normed_group E]
+variables {ι : Type*} [measurable_space E] [normed_group E]
 
-/-- Fundamental theorem of calculus for set integrals: if `μ` is a measure that is finite
-at a filter `l` and `f` is a measurable function that has a finite limit `b` at `l ⊓ μ.ae`,
-then `∫ x in s, f x ∂μ = μ s • b + o(μ s)` as `s` tends to `l.lift' powerset`. Since `μ s` is
-an `ennreal` number, we use `(μ s).to_real` in the actual statement. -/
+/-- Fundamental theorem of calculus for set integrals: if `μ` is a measure that is finite at a
+filter `l` and `f` is a measurable function that has a finite limit `b` at `l ⊓ μ.ae`, then `∫ x in
+s i, f x ∂μ = μ (s i) • b + o(μ (s i))` at a filter `li` provided that `s i` tends to `l.lift'
+powerset` along `li`. Since `μ (s i)` is an `ennreal` number, we use `(μ (s i)).to_real` in the
+actual statement.
+
+Often there is a good formula for `(μ (s i)).to_real`, so the formalization can take an optional
+argument `m` with this formula and a proof `of `(λ i, (μ (s i)).to_real) =ᶠ[li] m`. Without these
+arguments, `m i = (μ (s i)).to_real` is used in the output. -/
 lemma filter.tendsto.integral_sub_linear_is_o_ae
   [normed_space ℝ E] [second_countable_topology E] [complete_space E] [borel_space E]
   {μ : measure α} {l : filter α} [l.is_measurably_generated]
   {f : α → E} {b : E} (h : tendsto f (l ⊓ μ.ae) (𝓝 b))
   (hfm : measurable_at_filter f l μ) (hμ : μ.finite_at_filter l)
-  {s : β → set α} {lb : filter β} (hs : tendsto s lb (l.lift' powerset))
-  (m : β → ℝ := λ t, (μ (s t)).to_real)
-  (hsμ : (λ  t, (μ (s t)).to_real) =ᶠ[lb] m . tactic.interactive.refl) :
-  is_o (λ t, ∫ x in s t, f x ∂μ - m t • b) m lb :=
+  {s : ι → set α} {li : filter ι} (hs : tendsto s li (l.lift' powerset))
+  (m : ι → ℝ := λ i, (μ (s i)).to_real)
+  (hsμ : (λ i, (μ (s i)).to_real) =ᶠ[li] m . tactic.interactive.refl) :
+  is_o (λ i, ∫ x in s i, f x ∂μ - m i • b) m li :=
 begin
   suffices : is_o (λ s, ∫ x in s, f x ∂μ - (μ s).to_real • b) (λ s, (μ s).to_real)
     (l.lift' powerset),
-    from (this.comp_tendsto hs).congr' (hsμ.mono $ λ t ht, ht ▸ rfl) hsμ,
-  simp only [is_o_iff],
-  intros ε ε₀,
+    from (this.comp_tendsto hs).congr' (hsμ.mono $ λ a ha, ha ▸ rfl) hsμ,
+  refine is_o_iff.2 (λ ε ε₀, _),
   have : ∀ᶠ s in l.lift' powerset, ∀ᶠ x in μ.ae, x ∈ s → f x ∈ closed_ball b ε :=
     eventually_lift'_powerset_eventually.2 (h.eventually $ closed_ball_mem_nhds _ ε₀),
   filter_upwards [hμ.eventually, (hμ.integrable_at_filter_of_tendsto_ae hfm h).eventually,
@@ -520,37 +524,46 @@ begin
 end
 
 /-- Fundamental theorem of calculus for set integrals, `nhds_within` version: if `μ` is a locally
-finite measure that and `f` is an almost everywhere measurable function that is continuous at a
-point `a` within a measurable set `t`, then `∫ x in s, f x ∂μ = μ s • f a + o(μ s)` as `s` tends to
-`(𝓝[t] a).lift' powerset`.  Since `μ s` is an `ennreal` number, we use `(μ s).to_real` in the actual
-statement. -/
+finite measure and `f` is an almost everywhere measurable function that is continuous at a point `a`
+within a measurable set `t`, then `∫ x in s i, f x ∂μ = μ (s i) • f a + o(μ (s i))` at a filter `li`
+provided that `s i` tends to `(𝓝[t] a).lift' powerset` along `li`.  Since `μ (s i)` is an `ennreal`
+number, we use `(μ (s i)).to_real` in the actual statement.
+
+Often there is a good formula for `(μ (s i)).to_real`, so the formalization can take an optional
+argument `m` with this formula and a proof `of `(λ i, (μ (s i)).to_real) =ᶠ[li] m`. Without these
+arguments, `m i = (μ (s i)).to_real` is used in the output. -/
 lemma continuous_within_at.integral_sub_linear_is_o_ae
   [topological_space α] [opens_measurable_space α]
   [normed_space ℝ E] [second_countable_topology E] [complete_space E] [borel_space E]
   {μ : measure α} [locally_finite_measure μ] {a : α} {t : set α}
   {f : α → E} (ha : continuous_within_at f t a) (ht : is_measurable t)
   (hfm : measurable_at_filter f (𝓝[t] a) μ)
-  {s : β → set α} {lb : filter β} (hs : tendsto s lb ((𝓝[t] a).lift' powerset))
-  (m : β → ℝ := λ t, (μ (s t)).to_real)
-  (hsμ : (λ  t, (μ (s t)).to_real) =ᶠ[lb] m . tactic.interactive.refl) :
-  is_o (λ t, ∫ x in s t, f x ∂μ - m t • f a) m lb :=
+  {s : ι → set α} {li : filter ι} (hs : tendsto s li ((𝓝[t] a).lift' powerset))
+  (m : ι → ℝ := λ i, (μ (s i)).to_real)
+  (hsμ : (λ i, (μ (s i)).to_real) =ᶠ[li] m . tactic.interactive.refl) :
+  is_o (λ i, ∫ x in s i, f x ∂μ - m i • f a) m li :=
 by haveI : (𝓝[t] a).is_measurably_generated := ht.nhds_within_is_measurably_generated _;
 exact (ha.mono_left inf_le_left).integral_sub_linear_is_o_ae
   hfm (μ.finite_at_nhds_within a t) hs m hsμ
 
 /-- Fundamental theorem of calculus for set integrals, `nhds` version: if `μ` is a locally finite
-measure that and `f` is an almost everywhere measurable function that is continuous at a point `a`,
-then `∫ x in s, f x ∂μ = μ s • f a + o(μ s)` as `s` tends to `(𝓝 a).lift' powerset`.
-Since `μ s` is an `ennreal` number, we use `(μ s).to_real` in the actual statement. -/
+measure and `f` is an almost everywhere measurable function that is continuous at a point `a`, then
+`∫ x in s i, f x ∂μ = μ (s i) • f a + o(μ (s i))` at `li` provided that `s` tends to `(𝓝 a).lift'
+powerset` along `li.  Since `μ (s i)` is an `ennreal` number, we use `(μ (s i)).to_real` in the
+actual statement.
+
+Often there is a good formula for `(μ (s i)).to_real`, so the formalization can take an optional
+argument `m` with this formula and a proof `of `(λ i, (μ (s i)).to_real) =ᶠ[li] m`. Without these
+arguments, `m i = (μ (s i)).to_real` is used in the output. -/
 lemma continuous_at.integral_sub_linear_is_o_ae
   [topological_space α] [opens_measurable_space α]
   [normed_space ℝ E] [second_countable_topology E] [complete_space E] [borel_space E]
   {μ : measure α} [locally_finite_measure μ] {a : α}
   {f : α → E} (ha : continuous_at f a) (hfm : measurable_at_filter f (𝓝 a) μ)
-  {s : β → set α} {lb : filter β} (hs : tendsto s lb ((𝓝 a).lift' powerset))
-  (m : β → ℝ := λ t, (μ (s t)).to_real)
-  (hsμ : (λ  t, (μ (s t)).to_real) =ᶠ[lb] m . tactic.interactive.refl) :
-  is_o (λ t, ∫ x in s t, f x ∂μ - m t • f a) m lb :=
+  {s : ι → set α} {li : filter ι} (hs : tendsto s li ((𝓝 a).lift' powerset))
+  (m : ι → ℝ := λ i, (μ (s i)).to_real)
+  (hsμ : (λ i, (μ (s i)).to_real) =ᶠ[li] m . tactic.interactive.refl) :
+  is_o (λ i, ∫ x in s i, f x ∂μ - m i • f a) m li :=
 (ha.mono_left inf_le_left).integral_sub_linear_is_o_ae hfm (μ.finite_at_nhds a) hs m hsμ
 
 /-- If a function is integrable at `𝓝[s] x` for each point `x` of a compact set `s`, then it is
@@ -586,19 +599,22 @@ exact (hft a ha).integrable_at_filter ⟨_, self_mem_nhds_within, hft.ae_measura
   (μ.finite_at_nhds_within _ _)
 
 /-- Fundamental theorem of calculus for set integrals, `nhds_within` version: if `μ` is a locally
-finite measure that and `f` is an almost everywhere measurable function that is continuous at a
-point `a` within a measurable set `t`, then `∫ x in s, f x ∂μ = μ s • f a + o(μ s)` as `s` tends to
-`(𝓝[t] a).lift' powerset`.  Since `μ s` is an `ennreal` number, we use `(μ s).to_real` in the actual
-statement. -/
+finite measure, `f` is continuous on a measurable set `t`, and `a ∈ t`, then `∫ x in (s i), f x ∂μ =
+μ (s i) • f a + o(μ (s i))` at `li` provided that `s i` tends to `(𝓝[t] a).lift' powerset` along
+`li`.  Since `μ (s i)` is an `ennreal` number, we use `(μ (s i)).to_real` in the actual statement.
+
+Often there is a good formula for `(μ (s i)).to_real`, so the formalization can take an optional
+argument `m` with this formula and a proof `of `(λ i, (μ (s i)).to_real) =ᶠ[li] m`. Without these
+arguments, `m i = (μ (s i)).to_real` is used in the output. -/
 lemma continuous_on.integral_sub_linear_is_o_ae
   [topological_space α] [opens_measurable_space α]
   [normed_space ℝ E] [second_countable_topology E] [complete_space E] [borel_space E]
   {μ : measure α} [locally_finite_measure μ] {a : α} {t : set α}
   {f : α → E} (hft : continuous_on f t) (ha : a ∈ t) (ht : is_measurable t)
-  {s : β → set α} {lb : filter β} (hs : tendsto s lb ((𝓝[t] a).lift' powerset))
-  (m : β → ℝ := λ t, (μ (s t)).to_real)
-  (hsμ : (λ  t, (μ (s t)).to_real) =ᶠ[lb] m . tactic.interactive.refl) :
-  is_o (λ t, ∫ x in s t, f x ∂μ - m t • f a) m lb :=
+  {s : ι → set α} {li : filter ι} (hs : tendsto s li ((𝓝[t] a).lift' powerset))
+  (m : ι → ℝ := λ i, (μ (s i)).to_real)
+  (hsμ : (λ i, (μ (s i)).to_real) =ᶠ[li] m . tactic.interactive.refl) :
+  is_o (λ i, ∫ x in s i, f x ∂μ - m i • f a) m li :=
 (hft a ha).integral_sub_linear_is_o_ae ht ⟨t, self_mem_nhds_within, hft.ae_measurable ht⟩ hs m hsμ
 
 /-- A function `f` continuous on a compact set `s` is integrable on this set with respect to any


### PR DESCRIPTION
* use `ae_measurable f (μ.restrict s)` in more lemmas;
* introduce `measurable_at_filter` and use it.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
