### PR TITLE
[Merged by Bors] - feat(linear_algebra/multilinear_map): Add `range` and `map`

### DIFF
--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -1064,8 +1064,7 @@ def map [nonempty ι] (f : multilinear_map R M₁ M₂) (p : Π i, submodule R (
     refine ⟨update x i (c • x i), λ j, if hij : j = i then _ else _, _⟩,
     { rw [hij, update_same], exact (p i).smul_mem _ (hx i) },
     { rw [update_noteq hij], exact hx j },
-    { rw [f.map_smul, update_eq_self] },
-  } }
+    { rw [f.map_smul, update_eq_self] } } }
 
 /-- The map is always nonempty. This lemma is needed to apply `sub_mul_action.zero_mem`. -/
 lemma map_nonempty [nonempty ι] (f : multilinear_map R M₁ M₂) (p : Π i, submodule R (M₁ i)) :

--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -1042,3 +1042,40 @@ def multilinear_curry_right_equiv :
   right_inv := multilinear_map.uncurry_curry_right }
 
 end currying
+
+section submodule
+
+variables {R M M₂}
+[ring R] [∀i, add_comm_monoid (M₁ i)] [add_comm_monoid M'] [add_comm_monoid M₂]
+[∀i, semimodule R (M₁ i)] [semimodule R M'] [semimodule R M₂]
+
+namespace multilinear_map
+
+/-- The pushforward of an indexed collection of submodule `p i ⊆ M₁ i` by `f : M₁ → M₂`.#exit
+
+Note that this is not a submodule - it is not closed under multiplication. -/
+def map [nonempty ι] (f : multilinear_map R M₁ M₂) (p : Π i, submodule R (M₁ i)) :
+  sub_mul_action R M₂ :=
+{ carrier   := f '' { v | ∀ i, v i ∈ p i},
+  smul_mem' := by {
+    rintro c _ ⟨x, hx, rfl⟩,
+    tactic.unfreeze_local_instances,
+    obtain ⟨i⟩ := ‹nonempty ι›,
+    refine ⟨update x i (c • x i), λ j, if hij : j = i then _ else _, _⟩,
+    { rw [hij, update_same], exact (p i).smul_mem _ (hx i) },
+    { rw [update_noteq hij], exact hx j },
+    { rw [f.map_smul, update_eq_self] },
+  } }
+
+/-- The map is always nonempty. This lemma is needed to apply `sub_mul_action.zero_mem`. -/
+lemma map_nonempty [nonempty ι] (f : multilinear_map R M₁ M₂) (p : Π i, submodule R (M₁ i)) :
+  (map f p : set M₂).nonempty :=
+⟨f 0, 0, λ i, (p i).zero_mem, rfl⟩
+
+/-- The range of a multilinear map, closed under scalar multiplication. -/
+def range [nonempty ι] (f : multilinear_map R M₁ M₂) : sub_mul_action R M₂ :=
+f.map (λ i, ⊤)
+
+end multilinear_map
+
+end submodule

--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -1057,11 +1057,8 @@ Note that this is not a submodule - it is not closed under addition. -/
 def map [nonempty ι] (f : multilinear_map R M₁ M₂) (p : Π i, submodule R (M₁ i)) :
   sub_mul_action R M₂ :=
 { carrier   := f '' { v | ∀ i, v i ∈ p i},
-  smul_mem' := by {
-    rintro c _ ⟨x, hx, rfl⟩,
-    tactic.unfreeze_local_instances,
-    obtain ⟨i⟩ := ‹nonempty ι›,
-    refine ⟨update x i (c • x i), λ j, if hij : j = i then _ else _, _⟩,
+  smul_mem' := λ c _ ⟨x, hx, hf⟩, let ⟨i⟩ := ‹nonempty ι› in by {
+    refine ⟨update x i (c • x i), λ j, if hij : j = i then _ else _, hf ▸ _⟩,
     { rw [hij, update_same], exact (p i).smul_mem _ (hx i) },
     { rw [update_noteq hij], exact hx j },
     { rw [f.map_smul, update_eq_self] } } }

--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -1051,9 +1051,9 @@ variables {R M M₂}
 
 namespace multilinear_map
 
-/-- The pushforward of an indexed collection of submodule `p i ⊆ M₁ i` by `f : M₁ → M₂`.#exit
+/-- The pushforward of an indexed collection of submodule `p i ⊆ M₁ i` by `f : M₁ → M₂`.
 
-Note that this is not a submodule - it is not closed under multiplication. -/
+Note that this is not a submodule - it is not closed under addition. -/
 def map [nonempty ι] (f : multilinear_map R M₁ M₂) (p : Π i, submodule R (M₁ i)) :
   sub_mul_action R M₂ :=
 { carrier   := f '' { v | ∀ i, v i ∈ p i},


### PR DESCRIPTION
Note that unlike `linear_map`, `range` cannot return a submodule, only a `sub_mul_action`.
We also can't guarantee closure under `smul` unless the map has at least one argument, as there is nothing requiring the multilinear map of no arguments to be zero.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I don't have a strong feeling about whether this API makes sense or not yet.