### PR TITLE
[Merged by Bors] - feat(measure_theory/haar_measure): Prove uniqueness

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -97,6 +97,15 @@ MRREVIEWER = {Fangmin Song},
        URL = {https://doi.org/10.1007/978-3-642-59058-0},
 }
 
+@book{halmos2013measure,
+  title     = {Measure theory},
+  author    = {Halmos, Paul R},
+  volume    = {18},
+  year      = {1950},
+  publisher = {Springer},
+  isbn      = {0-387-90088-8}
+}
+
 @article {huneke2002,
     AUTHOR = {Huneke, Craig},
      TITLE = {The Friendship Theorem},

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -1216,7 +1216,7 @@ end normed_space
 namespace measure_theory
 namespace measure
 
-variables [topological_space α]
+variables [topological_space α] {μ : measure α}
 
 /-- A measure `μ` is regular if
   - it is finite on all compact sets;
@@ -1231,16 +1231,20 @@ structure regular (μ : measure α) : Prop :=
 
 namespace regular
 
-lemma outer_regular_eq {μ : measure α} (hμ : μ.regular) {{A : set α}}
+lemma outer_regular_eq (hμ : μ.regular) {{A : set α}}
   (hA : is_measurable A) : (⨅ (U : set α) (h : is_open U) (h2 : A ⊆ U), μ U) = μ A :=
 le_antisymm (hμ.outer_regular hA) $ le_infi $ λ s, le_infi $ λ hs, le_infi $ λ h2s, μ.mono h2s
 
-lemma inner_regular_eq {μ : measure α} (hμ : μ.regular) {{U : set α}}
+lemma inner_regular_eq (hμ : μ.regular) {{U : set α}}
   (hU : is_open U) : (⨆ (K : set α) (h : is_compact K) (h2 : K ⊆ U), μ K) = μ U :=
 le_antisymm (supr_le $ λ s, supr_le $ λ hs, supr_le $ λ h2s, μ.mono h2s) (hμ.inner_regular hU)
 
+lemma exists_compact_not_null (hμ : regular μ) : (∃ K, is_compact K ∧ μ K ≠ 0) ↔ μ ≠ 0 :=
+by simp_rw [ne.def, ← measure_univ_eq_zero, ← hμ.inner_regular_eq is_open_univ,
+    ennreal.supr_eq_zero, not_forall, exists_prop, subset_univ, true_and]
+
 protected lemma map [opens_measurable_space α] [measurable_space β] [topological_space β]
-  [t2_space β] [borel_space β] {μ : measure α} (hμ : μ.regular) (f : α ≃ₜ β) :
+  [t2_space β] [borel_space β] (hμ : μ.regular) (f : α ≃ₜ β) :
   (measure.map f μ).regular :=
 begin
   have hf := f.continuous.measurable,
@@ -1262,7 +1266,7 @@ begin
     rw [map_apply hf hK.is_measurable] }
 end
 
-protected lemma smul {μ : measure α} (hμ : μ.regular) {x : ennreal} (hx : x < ⊤) :
+protected lemma smul (hμ : μ.regular) {x : ennreal} (hx : x < ⊤) :
   (x • μ).regular :=
 begin
   split,
@@ -1276,6 +1280,15 @@ begin
     simp only [supr_and'], simp only [supr_subtype'],
     rw [ennreal.mul_supr], refl' }
 end
+
+/-- A regular measure in a σ-compact space is σ-finite. -/
+protected lemma sigma_finite [opens_measurable_space α] [t2_space α] [sigma_compact_space α]
+  (hμ : regular μ) : sigma_finite μ :=
+⟨{ set := compact_covering α,
+  set_mem := λ n, (is_compact_compact_covering α n).is_measurable,
+  finite := λ n, hμ.lt_top_of_is_compact $ is_compact_compact_covering α n,
+  spanning := Union_compact_covering α }⟩
+
 
 end regular
 

--- a/src/measure_theory/content.lean
+++ b/src/measure_theory/content.lean
@@ -141,12 +141,14 @@ begin
   apply h,
 end
 
-lemma is_left_invariant_inner_content [group G] [topological_group G] {μ : compacts G → ennreal}
+@[to_additive]
+lemma is_mul_left_invariant_inner_content [group G] [topological_group G] {μ : compacts G → ennreal}
   (h : ∀ (g : G) {K : compacts G}, μ (K.map _ $ continuous_mul_left g) = μ K) (g : G)
   (U : opens G) : inner_content μ (U.comap $ continuous_mul_left g) = inner_content μ U :=
 by convert inner_content_comap (homeomorph.mul_left g) (λ K, h g) U
 
-lemma inner_content_pos [t2_space G] [group G] [topological_group G] {μ : compacts G → ennreal}
+lemma inner_content_pos_of_is_mul_left_invariant [t2_space G] [group G] [topological_group G]
+  {μ : compacts G → ennreal}
   (h1 : μ ⊥ = 0)
   (h2 : ∀ (K₁ K₂ : compacts G), μ (K₁ ⊔ K₂) ≤ μ K₁ + μ K₂)
   (h3 : ∀ (g : G) {K : compacts G}, μ (K.map _ $ continuous_mul_left g) = μ K)
@@ -162,8 +164,22 @@ begin
   refine (le_inner_content _ _ this).trans _,
   refine (rel_supr_sum (inner_content μ) (inner_content_empty h1) (≤)
     (inner_content_Sup_nat h1 h2) _ _).trans _,
-  simp only [is_left_invariant_inner_content h3, finset.sum_const, nsmul_eq_mul, le_refl]
+  simp only [is_mul_left_invariant_inner_content h3, finset.sum_const, nsmul_eq_mul, le_refl]
 end
+
+/-- To additive fails to translate -/
+lemma inner_content_pos_of_is_add_left_invariant [t2_space G] [add_group G]
+  [topological_add_group G]
+  {μ : compacts G → ennreal}
+  (h1 : μ ⊥ = 0)
+  (h2 : ∀ (K₁ K₂ : compacts G), μ (K₁ ⊔ K₂) ≤ μ K₁ + μ K₂)
+  (h3 : ∀ (g : G) {K : compacts G}, μ (K.map _ $ continuous_add_left g) = μ K)
+  (K : compacts G) (hK : 0 < μ K) (U : opens G) (hU : (U : set G).nonempty) :
+  0 < inner_content μ U :=
+@inner_content_pos_of_is_mul_left_invariant (multiplicative G) _inst_1 _inst_2 _ sorry μ h1 h2 h3
+  K hK U hU
+
+attribute [to_additive] inner_content_pos_of_is_mul_left_invariant
 
 lemma inner_content_mono' {μ : compacts G → ennreal} ⦃U V : set G⦄
   (hU : is_open U) (hV : is_open V) (h2 : U ⊆ V) :
@@ -228,7 +244,8 @@ begin
   intros s hs, convert inner_content_comap f h ⟨s, hs⟩
 end
 
-lemma is_left_invariant_of_content [group G] [topological_group G]
+@[to_additive]
+lemma is_mul_left_invariant_of_content [group G] [topological_group G]
   (h : ∀ (g : G) {K : compacts G}, μ (K.map _ $ continuous_mul_left g) = μ K) (g : G)
   (A : set G) : of_content μ h1 ((λ h, g * h) ⁻¹' A) = of_content μ h1 A :=
 by convert of_content_preimage h2 (homeomorph.mul_left g) (λ K, h g) A
@@ -243,11 +260,13 @@ begin
   apply inner_content_mono'
 end
 
-lemma of_content_pos_of_is_open [group G] [topological_group G]
+@[to_additive]
+lemma of_content_pos_of_is_mul_left_invariant [group G] [topological_group G]
   (h3 : ∀ (g : G) {K : compacts G}, μ (K.map _ $ continuous_mul_left g) = μ K)
   (K : compacts G) (hK : 0 < μ K) {U : set G} (h1U : is_open U) (h2U : U.nonempty) :
   0 < of_content μ h1 U :=
-by { convert inner_content_pos h1 h2 h3 K hK ⟨U, h1U⟩ h2U, exact of_content_opens h2 ⟨U, h1U⟩ }
+by { convert inner_content_pos_of_is_mul_left_invariant h1 h2 h3 K hK ⟨U, h1U⟩ h2U,
+     exact of_content_opens h2 ⟨U, h1U⟩ }
 
 end outer_measure
 end measure_theory

--- a/src/measure_theory/content.lean
+++ b/src/measure_theory/content.lean
@@ -147,6 +147,7 @@ lemma is_mul_left_invariant_inner_content [group G] [topological_group G] {μ : 
   (U : opens G) : inner_content μ (U.comap $ continuous_mul_left g) = inner_content μ U :=
 by convert inner_content_comap (homeomorph.mul_left g) (λ K, h g) U
 
+-- @[to_additive] (fails for now)
 lemma inner_content_pos_of_is_mul_left_invariant [t2_space G] [group G] [topological_group G]
   {μ : compacts G → ennreal}
   (h1 : μ ⊥ = 0)
@@ -166,20 +167,6 @@ begin
     (inner_content_Sup_nat h1 h2) _ _).trans _,
   simp only [is_mul_left_invariant_inner_content h3, finset.sum_const, nsmul_eq_mul, le_refl]
 end
-
-/-- To additive fails to translate -/
-lemma inner_content_pos_of_is_add_left_invariant [t2_space G] [add_group G]
-  [topological_add_group G]
-  {μ : compacts G → ennreal}
-  (h1 : μ ⊥ = 0)
-  (h2 : ∀ (K₁ K₂ : compacts G), μ (K₁ ⊔ K₂) ≤ μ K₁ + μ K₂)
-  (h3 : ∀ (g : G) {K : compacts G}, μ (K.map _ $ continuous_add_left g) = μ K)
-  (K : compacts G) (hK : 0 < μ K) (U : opens G) (hU : (U : set G).nonempty) :
-  0 < inner_content μ U :=
-@inner_content_pos_of_is_mul_left_invariant (multiplicative G) _inst_1 _inst_2 _ sorry μ h1 h2 h3
-  K hK U hU
-
-attribute [to_additive] inner_content_pos_of_is_mul_left_invariant
 
 lemma inner_content_mono' {μ : compacts G → ennreal} ⦃U V : set G⦄
   (hU : is_open U) (hV : is_open V) (h2 : U ⊆ V) :
@@ -260,7 +247,7 @@ begin
   apply inner_content_mono'
 end
 
-@[to_additive]
+-- @[to_additive] (fails for now)
 lemma of_content_pos_of_is_mul_left_invariant [group G] [topological_group G]
   (h3 : ∀ (g : G) {K : compacts G}, μ (K.map _ $ continuous_mul_left g) = μ K)
   (K : compacts G) (hK : 0 < μ K) {U : set G} (h1U : is_open U) (h2U : U.nonempty) :

--- a/src/measure_theory/group.lean
+++ b/src/measure_theory/group.lean
@@ -105,7 +105,7 @@ variables [measurable_space G] [group G] [topological_space G] [topological_grou
 by { refine ⟨λ h, _, measure.regular.inv⟩, rw ←μ.inv_inv, exact measure.regular.inv h }
 
 @[to_additive]
-lemma is_mul_right_invariant_inv' (h : is_mul_left_invariant μ) :
+lemma is_mul_left_invariant.inv (h : is_mul_left_invariant μ) :
   is_mul_right_invariant μ.inv :=
 begin
   intros g A hA,
@@ -118,7 +118,7 @@ begin
 end
 
 @[to_additive]
-lemma is_mul_left_invariant_inv' (h : is_mul_right_invariant μ) : is_mul_left_invariant μ.inv :=
+lemma is_mul_right_invariant.inv (h : is_mul_right_invariant μ) : is_mul_left_invariant μ.inv :=
 begin
   intros g A hA,
   rw [μ.inv_apply (measurable_mul_left g hA), μ.inv_apply hA],
@@ -131,19 +131,11 @@ end
 
 @[simp, to_additive]
 lemma is_mul_right_invariant_inv : is_mul_right_invariant μ.inv ↔ is_mul_left_invariant μ :=
-begin
-    refine ⟨λ h, _, is_mul_right_invariant_inv'⟩,
-    rw ← μ.inv_inv,
-    exact is_mul_left_invariant_inv' h
-end
+⟨λ h, by { rw ← μ.inv_inv, exact h.inv }, λ h, h.inv⟩
 
 @[simp, to_additive]
 lemma is_mul_left_invariant_inv : is_mul_left_invariant μ.inv ↔ is_mul_right_invariant μ :=
-begin
-  refine ⟨λ h, _, is_mul_left_invariant_inv'⟩,
-  rw ← μ.inv_inv,
-  exact is_mul_right_invariant_inv' h
-end
+⟨λ h, by { rw ← μ.inv_inv, exact h.inv }, λ h, h.inv⟩
 
 end inv
 

--- a/src/measure_theory/group.lean
+++ b/src/measure_theory/group.lean
@@ -3,15 +3,14 @@ Copyright (c) 2020 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
-import measure_theory.borel_space
+import measure_theory.integration
 /-!
 # Measures on Groups
 
 We develop some properties of measures on (topological) groups
 
-* We define properties on measures: left and right invariant measures
-* We define the conjugate `A ↦ μ (A⁻¹)` of a measure `μ`, and show that it is right invariant iff
-  `μ` is left invariant
+* We define properties on measures: left and right invariant measures.
+* We define the measure `A ↦ μ(A⁻¹)` and show that it is right invariant iff `μ` is left invariant.
 -/
 noncomputable theory
 
@@ -25,16 +24,26 @@ section
 
 variables [measurable_space G] [has_mul G]
 
-/-- A measure `μ` on a topological group is left invariant if
-  for all measurable sets `s` and all `g`, we have `μ (gs) = μ s`,
-  where `gs` denotes the translate of `s` by left multiplication with `g`. -/
-def is_left_invariant (μ : set G → ennreal) : Prop :=
+/-- A measure `μ` on a topological group is left invariant
+  if the measure of left translations of a set are equal to the measure of the set itself.
+  To left translate sets we use preimage under left multiplication,
+  since preimages are nicer to work with than images. -/
+@[to_additive "A measure on a topological group is left invariant
+  if the measure of left translations of a set are equal to the measure of the set itself.
+  To left translate sets we use preimage under left addition,
+  since preimages are nicer to work with than images."]
+def is_mul_left_invariant (μ : set G → ennreal) : Prop :=
 ∀ (g : G) {A : set G} (h : is_measurable A), μ ((λ h, g * h) ⁻¹' A) = μ A
 
-/-- A measure `μ` on a topological group is right invariant if
-  for all measurable sets `s` and all `g`, we have `μ (sg) = μ s`,
-  where `sg` denotes the translate of `s` by right multiplication with `g`. -/
-def is_right_invariant (μ : set G → ennreal) : Prop :=
+/-- A measure `μ` on a topological group is right invariant
+  if the measure of right translations of a set are equal to the measure of the set itself.
+  To right translate sets we use preimage under right multiplication,
+  since preimages are nicer to work with than images. -/
+@[to_additive "A measure on a topological group is right invariant
+  if the measure of right translations of a set are equal to the measure of the set itself.
+  To right translate sets we use preimage under right addition,
+  since preimages are nicer to work with than images."]
+def is_mul_right_invariant (μ : set G → ennreal) : Prop :=
 ∀ (g : G) {A : set G} (h : is_measurable A), μ ((λ h, h * g) ⁻¹' A) = μ A
 
 end
@@ -43,73 +52,182 @@ namespace measure
 
 variables [measurable_space G]
 
+@[to_additive]
 lemma map_mul_left_eq_self [topological_space G] [has_mul G] [has_continuous_mul G] [borel_space G]
-  {μ : measure G} : (∀ g, measure.map ((*) g) μ = μ) ↔ is_left_invariant μ :=
+  {μ : measure G} : (∀ g, measure.map ((*) g) μ = μ) ↔ is_mul_left_invariant μ :=
 begin
   apply forall_congr, intro g, rw [measure.ext_iff], apply forall_congr, intro A,
   apply forall_congr, intro hA, rw [map_apply (measurable_mul_left g) hA]
 end
 
+@[to_additive]
 lemma map_mul_right_eq_self [topological_space G] [has_mul G] [has_continuous_mul G] [borel_space G]
-  {μ : measure G} : (∀ g, measure.map (λ h, h * g) μ = μ) ↔ is_right_invariant μ :=
+  {μ : measure G} : (∀ g, measure.map (λ h, h * g) μ = μ) ↔ is_mul_right_invariant μ :=
 begin
   apply forall_congr, intro g, rw [measure.ext_iff], apply forall_congr, intro A,
   apply forall_congr, intro hA, rw [map_apply (measurable_mul_right g) hA]
 end
 
-/-- The conjugate of a measure on a topological group.
-  Defined to be `A ↦ μ (A⁻¹)`, where `A⁻¹` is the pointwise inverse of `A`. -/
-protected def conj [group G] (μ : measure G) : measure G :=
+/-- The measure `A ↦ μ (A⁻¹)`, where `A⁻¹` is the pointwise inverse of `A`. -/
+@[to_additive "The measure `A ↦ μ (- A)`, where `- A` is the pointwise negation of `A`."]
+protected def inv [has_inv G] (μ : measure G) : measure G :=
 measure.map inv μ
 
 variables [group G] [topological_space G] [topological_group G] [borel_space G]
 
-lemma conj_apply (μ : measure G) {s : set G} (hs : is_measurable s) :
-  μ.conj s = μ s⁻¹ :=
-by { unfold measure.conj, rw [measure.map_apply measurable_inv hs, inv_preimage] }
+@[to_additive]
+lemma inv_apply (μ : measure G) {s : set G} (hs : is_measurable s) :
+  μ.inv s = μ s⁻¹ :=
+by { unfold measure.inv, rw [measure.map_apply measurable_inv hs, inv_preimage] }
 
-@[simp] lemma conj_conj (μ : measure G) : μ.conj.conj = μ :=
+@[simp, to_additive] protected lemma inv_inv (μ : measure G) : μ.inv.inv = μ :=
 begin
-  ext1 s hs, rw [μ.conj.conj_apply hs, μ.conj_apply, set.inv_inv], exact measurable_inv hs
+  ext1 s hs, rw [μ.inv.inv_apply hs, μ.inv_apply, set.inv_inv],
+  exact measurable_inv hs
 end
 
 variables {μ : measure G}
 
-lemma regular.conj [t2_space G] (hμ : μ.regular) : μ.conj.regular :=
+@[to_additive]
+lemma regular.inv [t2_space G] (hμ : μ.regular) : μ.inv.regular :=
 hμ.map (homeomorph.inv G)
 
 end measure
 
-section conj
+section inv
 variables [measurable_space G] [group G] [topological_space G] [topological_group G] [borel_space G]
   {μ : measure G}
 
-@[simp] lemma regular_conj_iff [t2_space G] : μ.conj.regular ↔ μ.regular :=
-by { refine ⟨λ h, _, measure.regular.conj⟩, rw ←μ.conj_conj, exact measure.regular.conj h }
+@[simp, to_additive] lemma regular_inv_iff [t2_space G] : μ.inv.regular ↔ μ.regular :=
+by { refine ⟨λ h, _, measure.regular.inv⟩, rw ←μ.inv_inv, exact measure.regular.inv h }
 
-lemma is_right_invariant_conj' (h : is_left_invariant μ) :
-  is_right_invariant μ.conj :=
+@[to_additive]
+lemma is_mul_right_invariant_inv' (h : is_mul_left_invariant μ) :
+  is_mul_right_invariant μ.inv :=
 begin
-  intros g A hA, rw [μ.conj_apply (measurable_mul_right g hA), μ.conj_apply hA],
+  intros g A hA, rw [μ.inv_apply (measurable_mul_right g hA), μ.inv_apply hA],
   convert h g⁻¹ (measurable_inv hA) using 2,
   simp only [←preimage_comp, ← inv_preimage],
   apply preimage_congr, intro h, simp only [mul_inv_rev, comp_app, inv_inv]
 end
 
-lemma is_left_invariant_conj' (h : is_right_invariant μ) : is_left_invariant μ.conj :=
+@[to_additive]
+lemma is_mul_left_invariant_inv' (h : is_mul_right_invariant μ) : is_mul_left_invariant μ.inv :=
 begin
-  intros g A hA, rw [μ.conj_apply (measurable_mul_left g hA), μ.conj_apply hA],
+  intros g A hA, rw [μ.inv_apply (measurable_mul_left g hA), μ.inv_apply hA],
   convert h g⁻¹ (measurable_inv hA) using 2,
   simp only [←preimage_comp, ← inv_preimage],
   apply preimage_congr, intro h, simp only [mul_inv_rev, comp_app, inv_inv]
 end
 
-@[simp] lemma is_right_invariant_conj : is_right_invariant μ.conj ↔ is_left_invariant μ :=
-by { refine ⟨λ h, _, is_right_invariant_conj'⟩, rw ←μ.conj_conj, exact is_left_invariant_conj' h }
+@[simp, to_additive]
+lemma is_mul_right_invariant_inv : is_mul_right_invariant μ.inv ↔ is_mul_left_invariant μ :=
+by { refine ⟨λ h, _, is_mul_right_invariant_inv'⟩, rw ← μ.inv_inv,
+     exact is_mul_left_invariant_inv' h }
 
-@[simp] lemma is_left_invariant_conj : is_left_invariant μ.conj ↔ is_right_invariant μ :=
-by { refine ⟨λ h, _, is_left_invariant_conj'⟩, rw ←μ.conj_conj, exact is_right_invariant_conj' h }
+@[simp, to_additive]
+lemma is_mul_left_invariant_inv : is_mul_left_invariant μ.inv ↔ is_mul_right_invariant μ :=
+by { refine ⟨λ h, _, is_mul_left_invariant_inv'⟩, rw ← μ.inv_inv,
+     exact is_mul_right_invariant_inv' h }
 
-end conj
+end inv
+
+namespace measure
+
+variables [measurable_space G] [topological_space G] [borel_space G] {μ : measure G}
+
+section group
+
+variables [group G] [topological_group G]
+
+/-! Properties of regular left invariant measures -/
+
+@[to_additive]
+lemma null_of_is_mul_left_invariant_of_ne_zero (hμ : μ.regular) (h2μ : is_mul_left_invariant μ)
+  (h3μ : μ ≠ 0) {s : set G} (hs : is_open s) : μ s = 0 ↔ s = ∅ :=
+begin
+  obtain ⟨K, hK, h2K⟩ := hμ.exists_compact_not_null.mpr h3μ,
+  refine ⟨λ h, _, λ h, by simp [h]⟩,
+  by_contradiction h2s, apply h2K,
+  rw [← ne.def, ne_empty_iff_nonempty] at h2s, cases h2s with y hy,
+  obtain ⟨t, -, h1t, h2t⟩ := hK.elim_finite_subcover_image
+    (show ∀ x ∈ @univ G, is_open ((λ y, x * y) ⁻¹' s),
+      from λ x _, (continuous_mul_left x).is_open_preimage _ hs) _,
+  { rw [← nonpos_iff_eq_zero],
+    refine (measure_mono h2t).trans _,
+    refine (measure_bUnion_le h1t.countable _).trans_eq _,
+    simp_rw [h2μ _ hs.is_measurable], rw [h, tsum_zero] },
+  { intros x _, simp_rw [mem_Union, mem_preimage], use [y * x⁻¹, mem_univ _],
+    rwa [inv_mul_cancel_right] }
+end
+
+@[to_additive] lemma null_of_is_mul_left_invariant (hμ : regular μ) (h2μ : is_mul_left_invariant μ)
+  {s : set G} (hs : is_open s) : μ s = 0 ↔ s = ∅ ∨ μ = 0 :=
+begin
+  by_cases h3μ : μ = 0, { simp [h3μ] }, simp only [h3μ, or_false],
+  exact null_of_is_mul_left_invariant_of_ne_zero hμ h2μ h3μ hs,
+end
+
+@[to_additive]
+lemma measure_ne_zero_of_is_mul_left_invariant (hμ : regular μ) (h2μ : is_mul_left_invariant μ)
+  (h3μ : μ ≠ 0) {s : set G} (hs : is_open s) : μ s ≠ 0 ↔ s.nonempty :=
+by simp_rw [← ne_empty_iff_nonempty, ne.def, null_of_is_mul_left_invariant_of_ne_zero hμ h2μ h3μ hs]
+
+/-- For nonzero regular left invariant measures, the integral of a continuous nonnegative function
+  `f` is 0 iff `f` is 0. -/
+lemma lintegral_eq_zero_of_is_mul_left_invariant (hμ : regular μ)
+  (h2μ : is_mul_left_invariant μ) (h3μ : μ ≠ 0) {f : G → ennreal} (hf : continuous f) :
+  ∫⁻ x, f x ∂μ = 0 ↔ f = 0 :=
+begin
+  split, swap, { rintro rfl, simp_rw [pi.zero_apply, lintegral_zero] },
+  intro h, contrapose h,
+  simp_rw [funext_iff, not_forall, pi.zero_apply] at h, cases h with x hx,
+  obtain ⟨r, h1r, h2r⟩ : ∃ r : ennreal, 0 < r ∧ r < f x :=
+  exists_between (pos_iff_ne_zero.mpr hx),
+  have h3r := hf.is_open_preimage (Ioi r) is_open_Ioi,
+  let s := Ioi r,
+  rw [← ne.def, ← pos_iff_ne_zero],
+  have : 0 < r * μ (f ⁻¹' Ioi r),
+  { rw ennreal.mul_pos,
+    refine ⟨h1r, _⟩,
+    rw [pos_iff_ne_zero,
+      measure_ne_zero_of_is_mul_left_invariant hμ h2μ h3μ h3r],
+    exact ⟨x, h2r⟩ },
+  refine this.trans_le _,
+  rw [← set_lintegral_const, ← lintegral_indicator _ h3r.is_measurable],
+  apply lintegral_mono,
+  refine indicator_le (λ y, le_of_lt),
+end
+
+end group
+
+section add_group
+
+-- todo: move
+instance multiplicative.has_continuous_mul [has_add G] [has_continuous_add G] :
+  @has_continuous_mul (multiplicative G) _inst_2 _ :=
+{ continuous_mul := @continuous_add G _ _ _  }
+
+variables [add_group G] [topological_add_group G]
+
+instance multiplicative.topological_grop : @topological_group (multiplicative G) _inst_2 _ :=
+{ continuous_inv := @continuous_neg G _ _ _ }
+#check multiplicative.topological_grop
+
+/-- For nonzero regular left invariant measures, the integral of a continuous nonnegative function
+  `f` is 0 iff `f` is 0.
+  We manually prove this for the additive version, since the proof uses
+  multiplication that shouldn't be transformed into addition. -/
+lemma lintegral_eq_zero_of_is_add_left_invariant (hμ : regular μ)
+  (h2μ : is_add_left_invariant μ) (h3μ : μ ≠ 0) {f : G → ennreal} (hf : continuous f) :
+  ∫⁻ x, f x ∂μ = 0 ↔ f = 0 :=
+@lintegral_eq_zero_of_is_mul_left_invariant (multiplicative G) _inst_1 _inst_2 _inst_3
+  μ _ _ hμ h2μ h3μ f hf
+
+end add_group
+
+attribute [to_additive] lintegral_eq_zero_of_is_mul_left_invariant
+
+end measure
 
 end measure_theory

--- a/src/measure_theory/group.lean
+++ b/src/measure_theory/group.lean
@@ -175,6 +175,7 @@ by simp_rw [← ne_empty_iff_nonempty, ne.def, null_of_is_mul_left_invariant_of_
 
 /-- For nonzero regular left invariant measures, the integral of a continuous nonnegative function
   `f` is 0 iff `f` is 0. -/
+-- @[to_additive] (fails for now)
 lemma lintegral_eq_zero_of_is_mul_left_invariant (hμ : regular μ)
   (h2μ : is_mul_left_invariant μ) (h3μ : μ ≠ 0) {f : G → ennreal} (hf : continuous f) :
   ∫⁻ x, f x ∂μ = 0 ↔ f = 0 :=
@@ -200,33 +201,6 @@ begin
 end
 
 end group
-
-section add_group
-
--- todo: move
-instance multiplicative.has_continuous_mul [has_add G] [has_continuous_add G] :
-  @has_continuous_mul (multiplicative G) _inst_2 _ :=
-{ continuous_mul := @continuous_add G _ _ _  }
-
-variables [add_group G] [topological_add_group G]
-
-instance multiplicative.topological_grop : @topological_group (multiplicative G) _inst_2 _ :=
-{ continuous_inv := @continuous_neg G _ _ _ }
-#check multiplicative.topological_grop
-
-/-- For nonzero regular left invariant measures, the integral of a continuous nonnegative function
-  `f` is 0 iff `f` is 0.
-  We manually prove this for the additive version, since the proof uses
-  multiplication that shouldn't be transformed into addition. -/
-lemma lintegral_eq_zero_of_is_add_left_invariant (hμ : regular μ)
-  (h2μ : is_add_left_invariant μ) (h3μ : μ ≠ 0) {f : G → ennreal} (hf : continuous f) :
-  ∫⁻ x, f x ∂μ = 0 ↔ f = 0 :=
-@lintegral_eq_zero_of_is_mul_left_invariant (multiplicative G) _inst_1 _inst_2 _inst_3
-  μ _ _ hμ h2μ h3μ f hf
-
-end add_group
-
-attribute [to_additive] lintegral_eq_zero_of_is_mul_left_invariant
 
 end measure
 

--- a/src/measure_theory/group.lean
+++ b/src/measure_theory/group.lean
@@ -4,14 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import measure_theory.integration
+
 /-!
 # Measures on Groups
 
 We develop some properties of measures on (topological) groups
 
 * We define properties on measures: left and right invariant measures.
-* We define the measure `A ↦ μ(A⁻¹)` and show that it is right invariant iff `μ` is left invariant.
+* We define the measure `μ.inv : A ↦ μ(A⁻¹)` and show that it is right invariant iff
+  `μ` is left invariant.
 -/
+
 noncomputable theory
 
 open has_inv set function

--- a/src/measure_theory/haar_measure.lean
+++ b/src/measure_theory/haar_measure.lean
@@ -27,6 +27,8 @@ formally using Tychonoff's theorem.
 This function `h` forms a content, which we can extend to an outer measure `μ`
 (`haar_outer_measure`), and obtain the Haar measure from that (`haar_measure`).
 We normalize the Haar measure so that the measure of `K₀` is `1`.
+We show that for second countable spaces any left invariant Borel measure is a scalar multiple of
+the Haar measure.
 
 Note that `μ` need not coincide with `h` on compact sets, according to
 [halmos1950measure, ch. X, §53 p.233]. However, we know that `h(K)` lies between `μ(Kᵒ)` and `μ(K)`,

--- a/src/measure_theory/haar_measure.lean
+++ b/src/measure_theory/haar_measure.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import measure_theory.content
-import measure_theory.group
+import measure_theory.prod_group
+
 /-!
 # Haar measure
 
@@ -483,7 +484,7 @@ end
 
 lemma haar_outer_measure_pos_of_is_open {K₀ : positive_compacts G}
   {U : set G} (hU : is_open U) (h2U : U.nonempty) : 0 < haar_outer_measure K₀ U :=
-outer_measure.of_content_pos_of_is_open echaar_sup_le is_left_invariant_echaar
+outer_measure.of_content_pos_of_is_mul_left_invariant echaar_sup_le is_left_invariant_echaar
   ⟨K₀.1, K₀.2.1⟩ (by simp only [echaar_self, ennreal.zero_lt_one]) hU h2U
 
 lemma haar_outer_measure_self_pos {K₀ : positive_compacts G} :
@@ -540,12 +541,12 @@ lemma haar_measure_apply {K₀ : positive_compacts G} {s : set G} (hs : is_measu
 by { simp only [haar_measure, hs, ennreal.div_def, mul_comm, to_measure_apply,
       algebra.id.smul_eq_mul, pi.smul_apply, measure.coe_smul] }
 
-lemma is_left_invariant_haar_measure (K₀ : positive_compacts G) :
-  is_left_invariant (haar_measure K₀) :=
+lemma is_mul_left_invariant_haar_measure (K₀ : positive_compacts G) :
+  is_mul_left_invariant (haar_measure K₀) :=
 begin
   intros g A hA, rw [haar_measure_apply hA, haar_measure_apply (measurable_mul_left g hA)],
   congr' 1,
-  exact outer_measure.is_left_invariant_of_content echaar_sup_le is_left_invariant_echaar g A
+  exact outer_measure.is_mul_left_invariant_of_content echaar_sup_le is_left_invariant_echaar g A
 end
 
 lemma haar_measure_self [locally_compact_space G] {K₀ : positive_compacts G} :
@@ -579,6 +580,36 @@ begin
     rw [to_measure_apply _ _ K.2.is_measurable], apply echaar_le_haar_outer_measure },
   { rw ennreal.inv_lt_top, apply haar_outer_measure_self_pos }
 end
+
+instance [locally_compact_space G] [separable_space G] (K₀ : positive_compacts G) :
+  sigma_finite (haar_measure K₀) :=
+regular_haar_measure.sigma_finite
+
+section unique
+
+variables [locally_compact_space G] [second_countable_topology G] {μ : measure G} [sigma_finite μ]
+
+/-- The Haar measure is unique up to scaling. More precisely: every σ-finite left invariant measure
+  is a scalar multiple of the Haar measure. -/
+theorem haar_measure_unqiue (hμ : is_mul_left_invariant μ)
+  (K₀ : positive_compacts G) : μ = μ K₀.1 • haar_measure K₀ :=
+begin
+  ext1 s hs,
+  have :=
+  measure_mul_measure_eq hμ (is_mul_left_invariant_haar_measure K₀) regular_haar_measure K₀.2.1 hs,
+  rw [haar_measure_self, one_mul] at this,
+  rw [← this (by norm_num), smul_apply],
+end
+
+theorem regular_of_left_invariant [locally_compact_space G] (hμ : is_mul_left_invariant μ)
+  {K} (hK : is_compact K)
+  (h2K : (interior K).nonempty) (hμK : μ K < ⊤) : regular μ :=
+begin
+  rw [haar_measure_unqiue hμ ⟨K, hK, h2K⟩],
+  refine regular.smul regular_haar_measure hμK
+end
+
+end unique
 
 end measure
 end measure_theory

--- a/src/measure_theory/haar_measure.lean
+++ b/src/measure_theory/haar_measure.lean
@@ -603,8 +603,7 @@ begin
   rw [← this (by norm_num), smul_apply],
 end
 
-theorem regular_of_left_invariant [locally_compact_space G] (hμ : is_mul_left_invariant μ)
-  {K} (hK : is_compact K)
+theorem regular_of_left_invariant (hμ : is_mul_left_invariant μ) {K} (hK : is_compact K)
   (h2K : (interior K).nonempty) (hμK : μ K < ⊤) : regular μ :=
 begin
   rw [haar_measure_unqiue hμ ⟨K, hK, h2K⟩],

--- a/src/measure_theory/haar_measure.lean
+++ b/src/measure_theory/haar_measure.lean
@@ -546,7 +546,8 @@ by { simp only [haar_measure, hs, ennreal.div_def, mul_comm, to_measure_apply,
 lemma is_mul_left_invariant_haar_measure (K₀ : positive_compacts G) :
   is_mul_left_invariant (haar_measure K₀) :=
 begin
-  intros g A hA, rw [haar_measure_apply hA, haar_measure_apply (measurable_mul_left g hA)],
+  intros g A hA,
+  rw [haar_measure_apply hA, haar_measure_apply (measurable_mul_left g hA)],
   congr' 1,
   exact outer_measure.is_mul_left_invariant_of_content echaar_sup_le is_left_invariant_echaar g A
 end
@@ -593,12 +594,12 @@ variables [locally_compact_space G] [second_countable_topology G] {μ : measure 
 
 /-- The Haar measure is unique up to scaling. More precisely: every σ-finite left invariant measure
   is a scalar multiple of the Haar measure. -/
-theorem haar_measure_unqiue (hμ : is_mul_left_invariant μ)
+theorem haar_measure_unique (hμ : is_mul_left_invariant μ)
   (K₀ : positive_compacts G) : μ = μ K₀.1 • haar_measure K₀ :=
 begin
   ext1 s hs,
-  have :=
-  measure_mul_measure_eq hμ (is_mul_left_invariant_haar_measure K₀) regular_haar_measure K₀.2.1 hs,
+  have := measure_mul_measure_eq hμ (is_mul_left_invariant_haar_measure K₀)
+    regular_haar_measure K₀.2.1 hs,
   rw [haar_measure_self, one_mul] at this,
   rw [← this (by norm_num), smul_apply],
 end
@@ -606,8 +607,8 @@ end
 theorem regular_of_left_invariant (hμ : is_mul_left_invariant μ) {K} (hK : is_compact K)
   (h2K : (interior K).nonempty) (hμK : μ K < ⊤) : regular μ :=
 begin
-  rw [haar_measure_unqiue hμ ⟨K, hK, h2K⟩],
-  refine regular.smul regular_haar_measure hμK
+  rw [haar_measure_unique hμ ⟨K, hK, h2K⟩],
+  exact regular.smul regular_haar_measure hμK
 end
 
 end unique

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1820,10 +1820,10 @@ begin
   exacts [f.measurable, f.measurable_inv_fun ht]
 end
 
-lemma map_symm_map (e : α ≃ᵐ β) : map e.symm (map e μ) = μ :=
+@[simp] lemma map_symm_map (e : α ≃ᵐ β) : map e.symm (map e μ) = μ :=
 by simp [map_map e.symm.measurable e.measurable]
 
-lemma map_map_symm (e : α ≃ᵐ β) : map e (map e.symm ν) = ν :=
+@[simp] lemma map_map_symm (e : α ≃ᵐ β) : map e (map e.symm ν) = ν :=
 by simp [map_map e.measurable e.symm.measurable]
 
 lemma map_measurable_equiv_injective (e : α ≃ᵐ β) : injective (map e) :=

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -84,7 +84,7 @@ measure, almost everywhere, measure space, completion, null set, null measurable
 
 noncomputable theory
 
-open classical set filter function measurable_space
+open classical set filter (hiding map) function measurable_space
 open_locale classical topological_space big_operators filter
 
 variables {α β γ δ ι : Type*}
@@ -1797,13 +1797,15 @@ open measure_theory measure_theory.measure
 
 namespace measurable_equiv
 
-open equiv
+/-! Interactions of measurable equivalences and measures -/
+
+open equiv measure_theory.measure
 
 variables [measurable_space α] [measurable_space β] {μ : measure α} {ν : measure β}
 
 /-- If we map a measure along a measurable equivalence, we can compute the measure on all sets
   (not just the measurable ones). -/
-protected theorem map_apply (f : α ≃ᵐ β) (s : set β) : measure.map f μ s = μ (f ⁻¹' s) :=
+protected theorem map_apply (f : α ≃ᵐ β) (s : set β) : map f μ s = μ (f ⁻¹' s) :=
 begin
   refine le_antisymm _ (le_map_apply f.measurable s),
   rw [measure_eq_infi' μ],
@@ -1817,6 +1819,19 @@ begin
   { refine congr_arg μ (eq.symm _), convert preimage_id, exact funext f.left_inv },
   exacts [f.measurable, f.measurable_inv_fun ht]
 end
+
+lemma map_symm_map (e : α ≃ᵐ β) : map e.symm (map e μ) = μ :=
+by simp [map_map e.symm.measurable e.measurable]
+
+lemma map_map_symm (e : α ≃ᵐ β) : map e (map e.symm ν) = ν :=
+by simp [map_map e.measurable e.symm.measurable]
+
+lemma map_measurable_equiv_injective (e : α ≃ᵐ β) : injective (map e) :=
+by { intros μ₁ μ₂ hμ, apply_fun map e.symm at hμ, simpa [map_symm_map e] using hμ }
+
+lemma map_apply_eq_iff_map_symm_apply_eq (e : α ≃ᵐ β) : map e μ = ν ↔ map e.symm ν = μ :=
+by rw [← (map_measurable_equiv_injective e).eq_iff, map_map_symm, eq_comm]
+
 
 end measurable_equiv
 

--- a/src/measure_theory/prod_group.lean
+++ b/src/measure_theory/prod_group.lean
@@ -83,8 +83,8 @@ begin
     map_prod_inv_mul_eq_swap hν]
 end
 
-lemma measure_null_of_measure_inv_null (hμ : is_mul_left_invariant μ) {E : set G} (hE : is_measurable E)
-  (h2E : μ ((λ x, x⁻¹) ⁻¹' E) = 0) : μ E = 0 :=
+lemma measure_null_of_measure_inv_null (hμ : is_mul_left_invariant μ)
+  {E : set G} (hE : is_measurable E) (h2E : μ ((λ x, x⁻¹) ⁻¹' E) = 0) : μ E = 0 :=
 begin
   have hf : measurable (λ z : G × G, (z.2 * z.1, z.1⁻¹)) :=
   (measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv,

--- a/src/measure_theory/prod_group.lean
+++ b/src/measure_theory/prod_group.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2021 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+-/
+import measure_theory.prod
+import measure_theory.group
+
+/-!
+# The product of groups
+
+In this file we show properties about measure theory in products of topological groups
+or iterated integrals in topological groups.
+
+These lemmas show the uniqueness of left invariant measures on locally compact groups, up to
+scaling.
+-/
+
+noncomputable theory
+open topological_space set (hiding prod_eq) function
+open_locale classical
+
+namespace measure_theory
+
+open measure
+
+variables {G : Type*} [topological_space G] [measurable_space G] [second_countable_topology G]
+  [borel_space G] [group G] [topological_group G]
+variables {μ ν : measure G} [sigma_finite ν] [sigma_finite μ]
+
+/-- This condition is part of the definition of a measurable group in [Halmos, §59].
+  There, the map in this lemma is called `S`. -/
+lemma map_prod_mul_eq (hν : is_mul_left_invariant ν) :
+  map (λ z : G × G, (z.1, z.1 * z.2)) (μ.prod ν) = μ.prod ν :=
+begin
+  refine (prod_eq _).symm, intros s t hs ht,
+  simp_rw [map_apply (measurable_fst.prod_mk (measurable_fst.mul measurable_snd)) (hs.prod ht),
+    prod_apply ((measurable_fst.prod_mk (measurable_fst.mul measurable_snd)) (hs.prod ht)),
+    preimage_preimage],
+  conv_lhs { congr, skip, funext, rw [mk_preimage_prod_right_fn_eq_if ((*) x), measure_if] },
+  simp_rw [hν _ ht, lintegral_indicator _ hs, set_lintegral_const, mul_comm]
+end
+
+/-- The function we are mapping along is `SR` in [Halmos, §59],
+  where `S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
+lemma map_prod_mul_eq_swap (hμ : is_mul_left_invariant μ) :
+  map (λ z : G × G, (z.2, z.2 * z.1)) (μ.prod ν) = ν.prod μ :=
+begin
+  rw [← prod_swap],
+  simp_rw [map_map (measurable_snd.prod_mk (measurable_snd.mul measurable_fst)) measurable_swap],
+  exact map_prod_mul_eq hμ
+end
+
+/-- The function we are mapping along is `S⁻¹` in [Halmos, §59],
+  where `S` is the map in `map_prod_mul_eq`. -/
+lemma map_prod_inv_mul_eq (hν : is_mul_left_invariant ν) :
+  map (λ z : G × G, (z.1, z.1⁻¹ * z.2)) (μ.prod ν) = μ.prod ν :=
+(homeomorph.shear_mul_right G).to_measurable_equiv.map_apply_eq_iff_map_symm_apply_eq.mp $
+  map_prod_mul_eq hν
+
+/-- The function we are mapping along is `S⁻¹R` in [Halmos, §59],
+  where `S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
+lemma map_prod_inv_mul_eq_swap (hμ : is_mul_left_invariant μ) :
+  map (λ z : G × G, (z.2, z.2⁻¹ * z.1)) (μ.prod ν) = ν.prod μ :=
+begin
+  rw [← prod_swap],
+  simp_rw
+    [map_map (measurable_snd.prod_mk $ measurable_snd.inv.mul measurable_fst) measurable_swap],
+  exact map_prod_inv_mul_eq hμ
+end
+
+/-- The function we are mapping along is `S⁻¹RSR` in [Halmos, §59],
+  where `S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
+lemma map_prod_mul_inv_eq (hμ : is_mul_left_invariant μ) (hν : is_mul_left_invariant ν) :
+  map (λ z : G × G, (z.2 * z.1, z.1⁻¹)) (μ.prod ν) = μ.prod ν :=
+begin
+  let S := (homeomorph.shear_mul_right G).to_measurable_equiv,
+  suffices : map ((λ z : G × G, (z.2, z.2⁻¹ * z.1)) ∘ (λ z : G × G, (z.2, z.2 * z.1))) (μ.prod ν) =
+    μ.prod ν,
+  { convert this, ext1 ⟨x, y⟩, simp },
+  simp_rw [← map_map (measurable_snd.prod_mk (measurable_snd.inv.mul measurable_fst))
+    (measurable_snd.prod_mk (measurable_snd.mul measurable_fst)), map_prod_mul_eq_swap hμ,
+    map_prod_inv_mul_eq_swap hν]
+end
+
+lemma measure_null_of_measure_inv_null (hμ : is_mul_left_invariant μ) {E : set G} (hE : is_measurable E)
+  (h2E : μ ((λ x, x⁻¹) ⁻¹' E) = 0) : μ E = 0 :=
+begin
+  have hf : measurable (λ z : G × G, (z.2 * z.1, z.1⁻¹)) :=
+  (measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv,
+  suffices : map (λ z : G × G, (z.2 * z.1, z.1⁻¹)) (μ.prod μ) (E.prod E) = 0,
+  { simpa only [map_prod_mul_inv_eq hμ hμ, prod_prod hE hE, mul_eq_zero, or_self] using this },
+  simp_rw [map_apply hf (hE.prod hE), prod_apply_symm (hf (hE.prod hE)), preimage_preimage,
+    mk_preimage_prod],
+  convert lintegral_zero, ext1 x, refine measure_mono_null (inter_subset_right _ _) h2E
+end
+
+lemma measure_inv_null (hμ : is_mul_left_invariant μ) {E : set G} (hE : is_measurable E) :
+  μ ((λ x, x⁻¹) ⁻¹' E) = 0 ↔ μ E = 0 :=
+begin
+  refine ⟨measure_null_of_measure_inv_null hμ hE, _⟩,
+  intro h2E, apply measure_null_of_measure_inv_null hμ (measurable_inv hE), convert h2E using 2,
+  exact set.inv_inv
+end
+
+lemma measurable_measure_mul_right {E : set G} (hE : is_measurable E) :
+  measurable (λ x, μ ((λ y, y * x) ⁻¹' E)) :=
+begin
+  suffices :
+    measurable (λ y, μ ((λ x, (x, y)) ⁻¹' ((λ z : G × G, (1, z.1 * z.2)) ⁻¹' set.prod univ E))),
+  { convert this, ext1 x, congr' 1 with y : 1, simp },
+  apply measurable_measure_prod_mk_right,
+  exact measurable_const.prod_mk (measurable_fst.mul measurable_snd) (is_measurable.univ.prod hE)
+end
+
+lemma lintegral_lintegral_mul_inv (hμ : is_mul_left_invariant μ) (hν : is_mul_left_invariant ν)
+  (f : G → G → ennreal) (hf : measurable (uncurry f)) :
+  ∫⁻ x, ∫⁻ y, f (y * x) x⁻¹ ∂ν ∂μ = ∫⁻ x, ∫⁻ y, f x y ∂ν ∂μ :=
+begin
+  have h2f : measurable (uncurry $ λ x y, f (y * x) x⁻¹) :=
+  hf.comp ((measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv),
+  simp_rw [lintegral_lintegral h2f, lintegral_lintegral hf],
+  conv_rhs { rw [← map_prod_mul_inv_eq hμ hν] },
+  symmetry, exact lintegral_map hf ((measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv)
+end
+
+lemma measure_mul_right_null (hμ : is_mul_left_invariant μ) {E : set G} (hE : is_measurable E)
+  (y : G) : μ ((λ x, x * y) ⁻¹' E) = 0 ↔ μ E = 0 :=
+begin
+  rw [← measure_inv_null hμ hE, ← hμ y⁻¹ (measurable_inv hE),
+    ← measure_inv_null hμ (measurable_mul_right y hE)],
+  convert iff.rfl using 3, ext x, simp,
+end
+
+lemma measure_mul_right_ne_zero (hμ : is_mul_left_invariant μ) {E : set G} (hE : is_measurable E)
+  (h2E : μ E ≠ 0) (y : G) : μ ((λ x, x * y) ⁻¹' E) ≠ 0 :=
+(not_iff_not_of_iff (measure_mul_right_null hμ hE y)).mpr h2E
+
+/-- This is basically [Halmos, §60 Th. A].
+  There seems to be a gap in the last step of the proof in [Halmos].
+  In the last line, the equality `g(x⁻¹)ν(Ex⁻¹) = f(x)` holds if we can prove that
+  `0 < ν(Ex⁻¹) < ∞`. The first inequality follows from §59, Th. D, but I couldn't find the second
+  inequality. For this reason, we use a compact `E` instead of a measurable `E` as in [Halmos], and
+  additionally assume that `ν` is a regular measure (we only need that it is finite on compact
+  sets).
+ -/
+lemma measure_lintegral_div_measure [t2_space G] (hμ : is_mul_left_invariant μ)
+  (hν : is_mul_left_invariant ν) (h2ν : regular ν) {E : set G} (hE : is_compact E) (h2E : ν E ≠ 0)
+  (f : G → ennreal) (hf : measurable f) :
+  μ E * ∫⁻ y, f y⁻¹ / ν ((λ h, h * y⁻¹) ⁻¹' E) ∂ν = ∫⁻ x, f x ∂μ :=
+begin
+  let Em := hE.is_measurable,
+  symmetry,
+  set g := λ y, f y⁻¹ / ν ((λ h, h * y⁻¹) ⁻¹' E),
+  have hg : measurable g := (hf.comp measurable_inv).ennreal_div
+    ((measurable_measure_mul_right Em).comp measurable_inv),
+  simp_rw [← set_lintegral_one, ← lintegral_indicator _ Em,
+    ← lintegral_lintegral_mul (measurable_const.indicator Em) hg],
+  rw [← lintegral_lintegral_mul_inv hμ hν],
+  have mE : ∀ x : G, measurable (λ y, ((λ z, z * x) ⁻¹' E).indicator (λ z, (1 : ennreal)) y) :=
+  λ x, measurable_const.indicator (measurable_mul_right _ Em),
+  have : ∀ x y, E.indicator (λ (z : G), (1 : ennreal)) (y * x) =
+    ((λ z, z * x) ⁻¹' E).indicator (λ (b : G), 1) y,
+  { intros x y, symmetry, convert indicator_comp_right (λ y, y * x), ext1 z, simp },
+  have h3E : ∀ y, ν ((λ x, x * y) ⁻¹' E) ≠ ⊤ :=
+  λ y, ennreal.lt_top_iff_ne_top.mp (h2ν.lt_top_of_is_compact $
+    (homeomorph.mul_right _).compact_preimage.mpr hE),
+  simp_rw [this, lintegral_mul_const _ (mE _), lintegral_indicator _ (measurable_mul_right _ Em),
+    set_lintegral_one, g, inv_inv,
+    ennreal.mul_div_cancel' (measure_mul_right_ne_zero hν Em h2E _) (h3E _)],
+  exact ((measurable_const.indicator Em).comp measurable_fst).ennreal_mul (hg.comp measurable_snd)
+end
+
+lemma measure_mul_measure_eq [t2_space G] (hμ : is_mul_left_invariant μ)
+  (hν : is_mul_left_invariant ν) (h2ν : regular ν) {E F : set G}
+  (hE : is_compact E) (hF : is_measurable F) (h2E : ν E ≠ 0) : μ E * ν F = ν E * μ F :=
+begin
+  have h1 := measure_lintegral_div_measure hν hν h2ν hE h2E (F.indicator (λ x, 1))
+    (measurable_const.indicator hF),
+  have h2 := measure_lintegral_div_measure hμ hν h2ν hE h2E (F.indicator (λ x, 1))
+    (measurable_const.indicator hF),
+  rw [lintegral_indicator _ hF, set_lintegral_one] at h1 h2,
+  rw [← h1, mul_left_comm, h2],
+end
+
+end measure_theory

--- a/src/measure_theory/prod_group.lean
+++ b/src/measure_theory/prod_group.lean
@@ -10,7 +10,7 @@ import measure_theory.group
 # The product of groups
 
 In this file we show properties about measure theory in products of topological groups
-or iterated integrals in topological groups.
+and properties of iterated integrals in topological groups.
 
 These lemmas show the uniqueness of left invariant measures on locally compact groups, up to
 scaling. In this file we follow the proof and refer to the book *Measure Theory* by Paul Halmos.

--- a/src/measure_theory/prod_group.lean
+++ b/src/measure_theory/prod_group.lean
@@ -18,12 +18,15 @@ scaling. In this file we follow the proof and refer to the book *Measure Theory*
 The idea of the proof is to use the translation invariance of measures to prove `μ(F) = c * μ(E)`
 for two sets `E` and `F`, where `c` is a constant that does not depend on `μ`. Let `e` and `f` be
 the characteristic functions of `E` and `F`.
-By translation invariance the map `(x, y) ↦ (y * x, x⁻¹)` is measure-preserving, which means that
+Assume that `μ` and `ν` are left-invariant measures. Then the map `(x, y) ↦ (y * x, x⁻¹)`
+preserves the measure `μ.prod ν`, which means that
 ```
   ∫ x, ∫ y, h x y ∂ν ∂μ = ∫ x, ∫ y, h (y * x) x⁻¹ ∂ν ∂μ
 ```
 If we apply this to `h x y := e x * f y⁻¹ / ν ((λ h, h * y⁻¹) ⁻¹' E)`, we can rewrite the RHS to
-`μ(F)`, and the LHS to `c * μ(E)`, where `c` does not depend on `μ`.
+`μ(F)`, and the LHS to `c * μ(E)`, where `c = c(ν)` does not depend on `μ`.
+Applying this to `μ` and to `ν` gives `μ (F) / μ (E) = ν (F) / ν (E)`, which is the uniqueness up to
+scalar multiplication.
 
 The proof in [Halmos] seems to contain an omission in §60 Th. A, see
 `measure_theory.measure_lintegral_div_measure` and
@@ -153,6 +156,8 @@ lemma measure_mul_right_ne_zero (hμ : is_mul_left_invariant μ) {E : set G} (hE
 (not_iff_not_of_iff (measure_mul_right_null hμ hE y)).mpr h2E
 
 /-- A technical lemma relating two different measures. This is basically [Halmos, §60 Th. A].
+  Note that if `f` is the characteristic function of a measurable set `F` this states that
+  `μ F = c * μ E` for a constant `c` that does not depend on `μ`.
   There seems to be a gap in the last step of the proof in [Halmos].
   In the last line, the equality `g(x⁻¹)ν(Ex⁻¹) = f(x)` holds if we can prove that
   `0 < ν(Ex⁻¹) < ∞`. The first inequality follows from §59, Th. D, but I couldn't find the second

--- a/src/measure_theory/prod_group.lean
+++ b/src/measure_theory/prod_group.lean
@@ -7,7 +7,7 @@ import measure_theory.prod
 import measure_theory.group
 
 /-!
-# The product of groups
+# Measure theory in the product of groups
 
 In this file we show properties about measure theory in products of topological groups
 and properties of iterated integrals in topological groups.
@@ -139,14 +139,13 @@ lemma measure_mul_right_ne_zero (hμ : is_mul_left_invariant μ) {E : set G} (hE
   (h2E : μ E ≠ 0) (y : G) : μ ((λ x, x * y) ⁻¹' E) ≠ 0 :=
 (not_iff_not_of_iff (measure_mul_right_null hμ hE y)).mpr h2E
 
-/-- This is basically [Halmos, §60 Th. A].
+/-- A technical lemma relating two different measures. This is basically [Halmos, §60 Th. A].
   There seems to be a gap in the last step of the proof in [Halmos].
   In the last line, the equality `g(x⁻¹)ν(Ex⁻¹) = f(x)` holds if we can prove that
   `0 < ν(Ex⁻¹) < ∞`. The first inequality follows from §59, Th. D, but I couldn't find the second
   inequality. For this reason, we use a compact `E` instead of a measurable `E` as in [Halmos], and
   additionally assume that `ν` is a regular measure (we only need that it is finite on compact
-  sets).
- -/
+  sets). -/
 lemma measure_lintegral_div_measure [t2_space G] (hμ : is_mul_left_invariant μ)
   (hν : is_mul_left_invariant ν) (h2ν : regular ν) {E : set G} (hE : is_compact E) (h2E : ν E ≠ 0)
   (f : G → ennreal) (hf : measurable f) :
@@ -174,6 +173,8 @@ begin
   exact ((measurable_const.indicator Em).comp measurable_fst).ennreal_mul (hg.comp measurable_snd)
 end
 
+/-- This is roughly the uniqueness (up to a scalar) of left invariant Borel measures on a second
+  countable locally compact group. -/
 lemma measure_mul_measure_eq [t2_space G] (hμ : is_mul_left_invariant μ)
   (hν : is_mul_left_invariant ν) (h2ν : regular ν) {E F : set G}
   (hE : is_compact E) (hF : is_measurable F) (h2E : ν E ≠ 0) : μ E * ν F = ν E * μ F :=

--- a/src/measure_theory/prod_group.lean
+++ b/src/measure_theory/prod_group.lean
@@ -13,7 +13,10 @@ In this file we show properties about measure theory in products of topological 
 or iterated integrals in topological groups.
 
 These lemmas show the uniqueness of left invariant measures on locally compact groups, up to
-scaling.
+scaling. In this file we follow the proof and refer to the book *Measure Theory* by Paul Halmos.
+The proof seems to contain an omission in §60 Th. A, see
+`measure_theory.measure_lintegral_div_measure` and
+https://math.stackexchange.com/questions/3974485/does-right-translation-preserve-finiteness-for-a-left-invariant-measure
 -/
 
 noncomputable theory


### PR DESCRIPTION
Prove the uniqueness of Haar measure (up to a scalar) following  *Measure Theory* by Paul Halmos. This proof seems to contain an omission which we fix by adding an extra hypothesis to an intermediate lemma.
Add some lemmas about left invariant regular measures.
We add the file `measure_theory.prod_group` which contain various measure-theoretic properties of products of topological groups, needed for the uniqueness.
We add `@[to_additive]` to some declarations in `measure_theory`, but leave it out for many because of #4210. This causes some renamings in concepts, like `is_left_invariant` -> `is_mul_left_invariant` and `measure.conj` -> `measure.inv` (though a better naming suggestion for this one is welcome).

---

- [x] depends on: #5656
- [x] depends on: #5657 