### PR TITLE
[Merged by Bors] - feat(data/nat/cast): add nat.bin_cast for faster casting

### DIFF
--- a/src/data/nat/cast.lean
+++ b/src/data/nat/cast.lean
@@ -79,13 +79,10 @@ begin
   apply binary_rec _ _ n,
   { rw [binary_rec_zero, cast_zero] },
   { intros b k h,
-    rw binary_rec_eq,
-    { cases b,
-      { rw [cond, h, bit, cond, bit0, cast_add] },
-      { rw [cond, h, bit, cond, bit1, bit0, cast_add, cast_add, cast_one] } },
-    { rw [cond, zero_add] } }
+    rw [binary_rec_eq, h],
+    { cases b; simp [bit, bit0, bit1] },
+    { simp } },
 end
-
 
 /-- `coe : ℕ → α` as an `add_monoid_hom`. -/
 def cast_add_monoid_hom (α : Type*) [add_monoid α] [has_one α] : ℕ →+ α :=

--- a/src/data/nat/cast.lean
+++ b/src/data/nat/cast.lean
@@ -19,6 +19,10 @@ protected def cast : ℕ → α
 | 0     := 0
 | (n+1) := cast n + 1
 
+/-- Computationally friendlier cast than `nat.cast`, using binary representation. -/
+protected def bin_cast (n : ℕ) : α :=
+@nat.binary_rec (λ _, α) 0 (λ odd k a, cond odd (a + a + 1) (a + a)) n
+
 /--
 Coercions such as `nat.cast_coe` that go from a concrete structure such as
 `ℕ` to an arbitrary ring `α` should be set up as follows:
@@ -59,6 +63,7 @@ theorem cast_succ (n : ℕ) : ((succ n : ℕ) : α) = n + 1 := rfl
 @[simp, norm_cast] theorem cast_ite (P : Prop) [decidable P] (m n : ℕ) :
   (((ite P m n) : ℕ) : α) = ite P (m : α) (n : α) :=
 by { split_ifs; refl, }
+
 end
 
 @[simp, norm_cast] theorem cast_one [add_monoid α] [has_one α] : ((1 : ℕ) : α) = 1 := zero_add _
@@ -66,6 +71,21 @@ end
 @[simp, norm_cast] theorem cast_add [add_monoid α] [has_one α] (m) : ∀ n, ((m + n : ℕ) : α) = m + n
 | 0     := (add_zero _).symm
 | (n+1) := show ((m + n : ℕ) : α) + 1 = m + (n + 1), by rw [cast_add n, add_assoc]
+
+@[simp] lemma bin_cast_eq [add_monoid α] [has_one α] (n : ℕ) :
+  (nat.bin_cast n : α) = ((n : ℕ) : α) :=
+begin
+  rw nat.bin_cast,
+  apply binary_rec _ _ n,
+  { rw [binary_rec_zero, cast_zero] },
+  { intros b k h,
+    rw binary_rec_eq,
+    { cases b,
+      { rw [cond, h, bit, cond, bit0, cast_add] },
+      { rw [cond, h, bit, cond, bit1, bit0, cast_add, cast_add, cast_one] } },
+    { rw [cond, zero_add] } }
+end
+
 
 /-- `coe : ℕ → α` as an `add_monoid_hom`. -/
 def cast_add_monoid_hom (α : Type*) [add_monoid α] [has_one α] : ℕ →+ α :=


### PR DESCRIPTION
[As suggested](https://github.com/leanprover-community/mathlib/pull/5462#discussion_r553226279) by @gebner.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

What are the types we have that are `has_zero`, `has_one`, and `has_add` but not `add_monoid`? Because under those, the `bin_cast_eq` lemma will not fire. Currently, I think `fin n` is such a type.