### PR TITLE
[Merged by Bors] - docs(undergrad.yaml): analysis updates

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -47,7 +47,7 @@
 15:
   title  : Fundamental Theorem of Integral Calculus
   decls  :
-    - interval_integral.measure_integral_sub_integral_sub_linear_is_o_of_tendsto_ae
+    - interval_integral.integral_has_strict_deriv_at_of_tendsto_ae_right 
     - interval_integral.integral_eq_sub_of_has_deriv_right_of_le
   author : Yury G. Kudryashov (first) and Benjamin Davidson (second)
 16:

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -340,7 +340,7 @@ Single Variable Real Analysis:
     integral over a segment of piecewise continuous functions:
     antiderivatives:
     Riemann sums:
-    antiderivative of a continuous function:
+    antiderivative of a continuous function: interval_integral.integral_has_strict_deriv_at_of_tendsto_ae_right
     change of variable:
     integration by parts:
     improper integrals:

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -414,7 +414,7 @@ Topology:
     contraction mapping theorem: 'contracting_with.exists_fixed_point'
   Normed vector spaces on $\R$ and $\C$:
     topology on a normed vector space: 'normed_space.topological_vector_space'
-    equivalent norms: 
+    equivalent norms:
     Banach open mapping theorem: 'open_mapping'
     equivalence of norms in finite dimension: 'linear_equiv.to_continuous_linear_equiv'
     norms $\lVert\cdot\rVert_p$ on $\R^n$ and $\C^n$: 'pi_Lp.normed_space'
@@ -506,10 +506,8 @@ Measures and integral Calculus:
     integrable functions: 'measure_theory.integrable'
     dominated convergence theorem: 'measure_theory.tendsto_integral_of_dominated_convergence'
     finite dimensional vector-valued integrable functions: 'measure_theory.integrable'
-    continuity of integrals with respect to parameters: 'interval_integral.continuous_on_integral_of_continuous'
-    differentiability of integrals with respect to parameters: 'interval_integral.differentiable_on_integral_of_continuous'
-    fundamental theorem of calculus, part 1: 'interval_integral.integral_has_fderiv_at_of_tendsto_ae'
-    fundamental theorem of calculus, part 2: 'interval_integral.integral_eq_sub_of_has_deriv_right_of_le'
+    continuity of integrals with respect to parameters:
+    differentiability of integrals with respect to parameters:
     $\mathrm{L}^p$ spaces where $1 ≤ p ≤ ∞$:
     Completeness of $\mathrm{L}^p$ spaces:
     Holder's inequality: 'nnreal.lintegral_mul_le_Lp_mul_Lq'

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -344,9 +344,8 @@ Single Variable Real Analysis:
     change of variable:
     integration by parts:
     improper integrals:
-    absolute convergence of improper integrals:
+    absolute vs conditional convergence of improper integrals:
     comparison test for improper integrals:
-    conditional convergence of improper integrals:
   Sequences and series of functions:
     pointwise convergence:
     uniform convergence: 'tendsto_uniformly'

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -212,8 +212,8 @@ Bilinear and Quadratic Forms Over a Vector Space:
     Gram-Schmidt orthogonalisation:
   Euclidean and Hermitian spaces:
     Euclidean vector spaces: 'inner_product_space'
-    Hermitian vector spaces:
-    dual isomorphism in the euclidean case:
+    Hermitian vector spaces: 'inner_product_space'
+    dual isomorphism in the euclidean case: 'inner_product_space.isometric.to_dual'
     orthogonal complement: 'submodule.orthogonal'
     Cauchy-Schwarz inequality: 'inner_mul_inner_self_le'
     norm: 'inner_product_space.of_core.to_has_norm'
@@ -343,10 +343,10 @@ Single Variable Real Analysis:
     antiderivative of a continuous function:
     change of variable:
     integration by parts:
-    generalized integrals:
-    absolutely convergent integrals:
-    integration of asymptotic comparison relationships:
-    semi-convergent integrals:
+    improper integrals:
+    absolute convergence of improper integrals:
+    comparison test for improper integrals:
+    conditional convergence of improper integrals:
   Sequences and series of functions:
     pointwise convergence:
     uniform convergence: 'tendsto_uniformly'
@@ -414,7 +414,7 @@ Topology:
     contraction mapping theorem: 'contracting_with.exists_fixed_point'
   Normed vector spaces on $\R$ and $\C$:
     topology on a normed vector space: 'normed_space.topological_vector_space'
-    equivalent norms:
+    equivalent norms: 'linear_equiv.to_continuous_linear_equiv_of_bounds'
     Banach open mapping theorem: 'open_mapping'
     equivalence of norms in finite dimension: 'linear_equiv.to_continuous_linear_equiv'
     norms $\lVert\cdot\rVert_p$ on $\R^n$ and $\C^n$: 'pi_Lp.normed_space'
@@ -512,7 +512,7 @@ Measures and integral Calculus:
     fundamental theorem of calculus, part 2: 'interval_integral.integral_eq_sub_of_has_deriv_right_of_le'
     $\mathrm{L}^p$ spaces where $1 ≤ p ≤ ∞$:
     Completeness of $\mathrm{L}^p$ spaces:
-    Holder's inequality:
+    Holder's inequality: 'nnreal.lintegral_mul_le_Lp_mul_Lq'
     Fubini's theorem: 'measure_theory.integral_prod'
     change of variables for multiple integrals:
     integration by parts:

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -414,7 +414,7 @@ Topology:
     contraction mapping theorem: 'contracting_with.exists_fixed_point'
   Normed vector spaces on $\R$ and $\C$:
     topology on a normed vector space: 'normed_space.topological_vector_space'
-    equivalent norms: 'linear_equiv.to_continuous_linear_equiv_of_bounds'
+    equivalent norms: 
     Banach open mapping theorem: 'open_mapping'
     equivalence of norms in finite dimension: 'linear_equiv.to_continuous_linear_equiv'
     norms $\lVert\cdot\rVert_p$ on $\R^n$ and $\C^n$: 'pi_Lp.normed_space'

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -1329,7 +1329,7 @@ theorem integral_eq_sub_of_has_deriv_at' (hcont : continuous_on f (interval a b)
 integral_eq_sub_of_has_deriv_right hcont (λ x hx, (hderiv x hx).has_deriv_within_at) hcont' hmeas'
 
 /-- Fundamental theorem of calculus-2: If `f : ℝ → E` has a derivative at `f' x` for all `x` in
-  `[a, b)` and `f'` is continuous on `[a, b]` and measurable, then `∫ y in a..b, f' y` equals
+  `[a, b]` and `f'` is continuous on `[a, b]` and measurable, then `∫ y in a..b, f' y` equals
   `f b - f a`. -/
 theorem integral_eq_sub_of_has_deriv_at (hderiv : ∀ x ∈ interval a b, has_deriv_at f (f' x) x)
   (hcont' : continuous_on f' (interval a b)) (hmeas' : ae_measurable f') :


### PR DESCRIPTION
Updates to `undergrad.yaml` (including reverting some changes from #5638, after further discussion), and fix a docstring typo in `measure_theory.interval_integral`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

@PatrickMassot can you please check (1) whether my amended translations in lines 346-349 are correct?  (2) whether `inner_product_space.isometric.to_dual` and `linear_equiv.to_continuous_linear_equiv_of_bounds` are sufficiently close to the desired results to count?  (I do think they are _morally_ the desired results.)