### PR TITLE
[Merged by Bors] - feat(data/set/lattice): add lemmas set.Union_subtype and set.Union_of_singleton_coe

### DIFF
--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -358,6 +358,10 @@ theorem bUnion_union (s t : set α) (u : α → set β) :
   (⋃ x ∈ s ∪ t, u x) = (⋃ x ∈ s, u x) ∪ (⋃ x ∈ t, u x) :=
 supr_union
 
+@[simp] lemma set.bUnion_of_singleton_of_coe (s : set α) :
+  (⋃ (i : s), {i} : set α) = s :=
+ext $ by simp
+
 -- TODO(Jeremy): once again, simp doesn't do it alone.
 
 @[simp] theorem bUnion_insert (a : α) (s : set α) (t : α → set β) :

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -358,7 +358,7 @@ theorem bUnion_union (s t : set α) (u : α → set β) :
   (⋃ x ∈ s ∪ t, u x) = (⋃ x ∈ s, u x) ∪ (⋃ x ∈ t, u x) :=
 supr_union
 
-lemma Union_subtype {α β : Type*} (s : set α) (f : α → set β) :
+@[simp] lemma Union_subtype {α β : Type*} (s : set α) (f : α → set β) :
   (⋃ (i : s), f i) = ⋃ (i ∈ s), f i :=
 (set.bUnion_eq_Union s $ λ x _, f x).symm
 

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -358,10 +358,6 @@ theorem bUnion_union (s t : set α) (u : α → set β) :
   (⋃ x ∈ s ∪ t, u x) = (⋃ x ∈ s, u x) ∪ (⋃ x ∈ t, u x) :=
 supr_union
 
-@[simp] lemma bUnion_of_singleton_of_coe (s : set α) :
-  (⋃ (i : s), {i} : set α) = s :=
-ext $ by simp
-
 lemma Union_subtype {α β : Type*} (s : set α) (f : α → set β) :
   (⋃ (i : s), f i) = ⋃ (i ∈ s), f i :=
 (set.bUnion_eq_Union s $ λ x _, f x).symm
@@ -544,6 +540,10 @@ lemma Union_subset_Union_const {ι₂ : Sort x} {s : set α} (h : ι → ι₂) 
 
 @[simp] lemma Union_of_singleton (α : Type u) : (⋃(x : α), {x}) = @set.univ α :=
 ext $ λ x, ⟨λ h, ⟨⟩, λ h, ⟨{x}, ⟨⟨x, rfl⟩, mem_singleton x⟩⟩⟩
+
+@[simp] lemma Union_of_singleton_coe (s : set α) :
+  (⋃ (i : s), {i} : set α) = s :=
+ext $ by simp
 
 theorem bUnion_subset_Union (s : set α) (t : α → set β) :
   (⋃ x ∈ s, t x) ⊆ (⋃ x, t x) :=

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -362,6 +362,10 @@ supr_union
   (⋃ (i : s), {i} : set α) = s :=
 ext $ by simp
 
+lemma set.Union_subtype {α β : Type*} (s : set α) (f : α → set β) :
+  (⋃ (i : s), f i) = ⋃ (i ∈ s), f i :=
+(set.bUnion_eq_Union s $ λ x _, f x).symm
+
 -- TODO(Jeremy): once again, simp doesn't do it alone.
 
 @[simp] theorem bUnion_insert (a : α) (s : set α) (t : α → set β) :

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -362,7 +362,7 @@ supr_union
   (⋃ (i : s), {i} : set α) = s :=
 ext $ by simp
 
-lemma set.Union_subtype {α β : Type*} (s : set α) (f : α → set β) :
+lemma Union_subtype {α β : Type*} (s : set α) (f : α → set β) :
   (⋃ (i : s), f i) = ⋃ (i ∈ s), f i :=
 (set.bUnion_eq_Union s $ λ x _, f x).symm
 

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -358,7 +358,7 @@ theorem bUnion_union (s t : set α) (u : α → set β) :
   (⋃ x ∈ s ∪ t, u x) = (⋃ x ∈ s, u x) ∪ (⋃ x ∈ t, u x) :=
 supr_union
 
-@[simp] lemma set.bUnion_of_singleton_of_coe (s : set α) :
+@[simp] lemma bUnion_of_singleton_of_coe (s : set α) :
   (⋃ (i : s), {i} : set α) = s :=
 ext $ by simp
 


### PR DESCRIPTION
Add one simp lemma, following a suggestion on the Zulip chat:

https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/image_bUnion

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
