### PR TITLE
[Merged by Bors] - feat(algebraic_geometry/prime_spectrum): add lemma zero_locus_bUnion

### DIFF
--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -262,7 +262,7 @@ lemma zero_locus_Union {ι : Sort*} (s : ι → set R) :
 (gc_set R).l_supr
 
 lemma zero_locus_bUnion {s : set R} :
-  zero_locus ((⋃ i ∈ s, {i}) : set R) = (⋂ i ∈ s, zero_locus ({i})) :=
+  zero_locus (⋃ i ∈ s, {i} : set R) = ⋂ i ∈ s, zero_locus {i} :=
 by ext1;
   simpa only [mem_zero_locus, set.bUnion_of_singleton, set.mem_Inter, set.singleton_subset_iff]
 

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -263,7 +263,7 @@ lemma zero_locus_Union {ι : Sort*} (s : ι → set R) :
 
 lemma zero_locus_bUnion (s : set (set R)) :
   zero_locus (⋃ s' ∈ s, s' : set R) = ⋂ s' ∈ s, zero_locus s' :=
-by rw [set.bUnion_eq_Union, zero_locus_Union, set.bInter_eq_Inter]
+by simp only [zero_locus_Union]
 
 lemma vanishing_ideal_Union {ι : Sort*} (t : ι → set (prime_spectrum R)) :
   vanishing_ideal (⋃ i, t i) = (⨅ i, vanishing_ideal (t i)) :=

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -261,6 +261,11 @@ lemma zero_locus_Union {ι : Sort*} (s : ι → set R) :
   zero_locus (⋃ i, s i) = (⋂ i, zero_locus (s i)) :=
 (gc_set R).l_supr
 
+lemma zero_locus_bUnion {s : set R} :
+  zero_locus ((⋃ i ∈ s, {i}) : set R) = (⋂ i ∈ s, zero_locus ({i})) :=
+by ext1;
+  simpa only [mem_zero_locus, set.bUnion_of_singleton, set.mem_Inter, set.singleton_subset_iff]
+
 lemma vanishing_ideal_Union {ι : Sort*} (t : ι → set (prime_spectrum R)) :
   vanishing_ideal (⋃ i, t i) = (⨅ i, vanishing_ideal (t i)) :=
 (gc R).u_infi

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -261,6 +261,12 @@ lemma zero_locus_Union {ι : Sort*} (s : ι → set R) :
   zero_locus (⋃ i, s i) = (⋂ i, zero_locus (s i)) :=
 (gc_set R).l_supr
 
+/-  Eric's suggestion that I am not able to implement
+lemma zero_locus_bUnion (s : set (set R)) :
+  zero_locus (⋃ i : s, i) = ⋂ i ∈ s, zero_locus {i} :=
+(gc_set R).l_Sup
+-/
+
 lemma zero_locus_bUnion {s : set R} :
   zero_locus (⋃ i ∈ s, {i} : set R) = ⋂ i ∈ s, zero_locus {i} :=
 by ext1;

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -261,16 +261,9 @@ lemma zero_locus_Union {ι : Sort*} (s : ι → set R) :
   zero_locus (⋃ i, s i) = (⋂ i, zero_locus (s i)) :=
 (gc_set R).l_supr
 
-/-  Eric's suggestion that I am not able to implement
 lemma zero_locus_bUnion (s : set (set R)) :
-  zero_locus (⋃ i : s, i) = ⋂ i ∈ s, zero_locus {i} :=
-(gc_set R).l_Sup
--/
-
-lemma zero_locus_bUnion {s : set R} :
-  zero_locus (⋃ i ∈ s, {i} : set R) = ⋂ i ∈ s, zero_locus {i} :=
-by ext1;
-  simpa only [mem_zero_locus, set.bUnion_of_singleton, set.mem_Inter, set.singleton_subset_iff]
+  zero_locus (⋃ s' ∈ s, s' : set R) = ⋂ s' ∈ s, zero_locus s' :=
+by rw [set.bUnion_eq_Union, zero_locus_Union, set.bInter_eq_Inter]
 
 lemma vanishing_ideal_Union {ι : Sort*} (t : ι → set (prime_spectrum R)) :
   vanishing_ideal (⋃ i, t i) = (⨅ i, vanishing_ideal (t i)) :=


### PR DESCRIPTION
Add a simple extension of a lemma, to be able to work with `bUnion`, instead of only `Union`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
