### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal/operations): add algebra structure on quotient

### DIFF
--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1144,23 +1144,23 @@ instance {I : ideal R} : algebra R (ideal.quotient I) := (ideal.quotient.mk I).t
 
 /-- The canonical morphism `R →ₐ[R] I.quotient`, for `I` an ideal of `R`, as morphism of
 `R`-algebras. -/
-def quotient.mk.alg (I : ideal R) : R →ₐ[R] I.quotient :=
+def quotient.mkₐ (I : ideal R) : R →ₐ[R] I.quotient :=
 ⟨λ a, submodule.quotient.mk a, rfl, λ _ _, rfl, rfl, λ _ _, rfl, λ _, rfl⟩
 
-lemma quotient.mk.alg_to_ring_hom (I : ideal R) :
-  (quotient.mk.alg I).to_ring_hom = ideal.quotient.mk I := rfl
+lemma quotient.mkₐ_to_ring_hom (I : ideal R) :
+  (quotient.mkₐ I).to_ring_hom = ideal.quotient.mk I := rfl
 
-@[simp] lemma quotient.mk.alg_eq_mk (I : ideal R) :
-  ⇑(quotient.mk.alg I) = ideal.quotient.mk I := rfl
+@[simp] lemma quotient.mkₐ_eq_mk (I : ideal R) :
+  ⇑(quotient.mkₐ I) = ideal.quotient.mk I := rfl
 
 /-- The canonical morphism `R →ₐ[R] I.quotient` is surjective. -/
-lemma quotient.mk.alg_surjective (I : ideal R) : function.surjective (quotient.mk.alg I) :=
-λ y, quotient.induction_on' y (λ x, exists.intro x rfl)
+lemma quotient.mkₐ_surjective (I : ideal R) : function.surjective (quotient.mkₐ I) :=
+surjective_quot_mk _
 
 /-- The kernel of `R →ₐ[R] I.quotient` is `I`. -/
 @[simp]
-lemma quotient.mk.alg_ker (I : ideal R) : (quotient.mk.alg I).to_ring_hom.ker = I :=
-ideal.mk_ker I
+lemma quotient.mkₐ_ker (I : ideal R) : (quotient.mkₐ I).to_ring_hom.ker = I :=
+by rw [quotient.mkₐ_to_ring_hom _, ideal.mk_ker]
 
 /-- The ring hom `R/J →+* S/I` induced by a ring hom `f : R →+* S` with `J ≤ f⁻¹(I)` -/
 def quotient_map {I : ideal R} (J : ideal S) (f : R →+* S) (hIJ : I ≤ J.comap f) :

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1139,6 +1139,26 @@ end
 
 section quotient_algebra
 
+/-- The `R`-algebra structure on `R/I` -/
+instance {I : ideal R} : algebra R (ideal.quotient I) := ring_hom.to_algebra (ideal.quotient.mk I)
+
+/-- The canonical morphism `R →ₐ[R] I.quotient`, for `I` an ideal of `R`, as morphism of
+`R`-algebras. -/
+def quotient.mk.alg (I : ideal R) : R →ₐ[R] I.quotient :=
+⟨λ a, submodule.quotient.mk a, rfl, λ _ _, rfl, rfl, λ _ _, rfl, λ _, rfl⟩
+
+lemma quotient.mk.alg_to_ring_hom (I : ideal R) :
+  (quotient.mk.alg I).to_ring_hom = ideal.quotient.mk I := rfl
+
+/-- The canonical morphism `R →ₐ[R] I.quotient` is surjective. -/
+lemma quotient.mk.alg_surjective (I : ideal R) : function.surjective (quotient.mk.alg I) :=
+λ y, quotient.induction_on' y (λ x, exists.intro x rfl)
+
+/-- The kernel of `R →ₐ[R] I.quotient` is `I`. -/
+@[simp]
+lemma quotient.mk.alg_ker (I : ideal R) : (quotient.mk.alg I).to_ring_hom.ker = I :=
+by rw [quotient.mk.alg_to_ring_hom _, ideal.mk_ker]
+
 /-- The ring hom `R/J →+* S/I` induced by a ring hom `f : R →+* S` with `J ≤ f⁻¹(I)` -/
 def quotient_map {I : ideal R} (J : ideal S) (f : R →+* S) (hIJ : I ≤ J.comap f) :
   I.quotient →+* J.quotient :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1140,7 +1140,7 @@ end
 section quotient_algebra
 
 /-- The `R`-algebra structure on `R/I` -/
-instance {I : ideal R} : algebra R (ideal.quotient I) := ring_hom.to_algebra (ideal.quotient.mk I)
+instance {I : ideal R} : algebra R (ideal.quotient I) := (ideal.quotient.mk I).to_algebra
 
 /-- The canonical morphism `R →ₐ[R] I.quotient`, for `I` an ideal of `R`, as morphism of
 `R`-algebras. -/

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1150,6 +1150,9 @@ def quotient.mk.alg (I : ideal R) : R →ₐ[R] I.quotient :=
 lemma quotient.mk.alg_to_ring_hom (I : ideal R) :
   (quotient.mk.alg I).to_ring_hom = ideal.quotient.mk I := rfl
 
+lemma quotient.mk.alg_eq_mk (I : ideal R) :
+  ⇑(quotient.mk.alg I) = ideal.quotient.mk I := rfl
+
 /-- The canonical morphism `R →ₐ[R] I.quotient` is surjective. -/
 lemma quotient.mk.alg_surjective (I : ideal R) : function.surjective (quotient.mk.alg I) :=
 λ y, quotient.induction_on' y (λ x, exists.intro x rfl)

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1150,7 +1150,7 @@ def quotient.mk.alg (I : ideal R) : R →ₐ[R] I.quotient :=
 lemma quotient.mk.alg_to_ring_hom (I : ideal R) :
   (quotient.mk.alg I).to_ring_hom = ideal.quotient.mk I := rfl
 
-lemma quotient.mk.alg_eq_mk (I : ideal R) :
+@[simp] lemma quotient.mk.alg_eq_mk (I : ideal R) :
   ⇑(quotient.mk.alg I) = ideal.quotient.mk I := rfl
 
 /-- The canonical morphism `R →ₐ[R] I.quotient` is surjective. -/

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1160,7 +1160,7 @@ surjective_quot_mk _
 /-- The kernel of `R →ₐ[R] I.quotient` is `I`. -/
 @[simp]
 lemma quotient.mkₐ_ker (I : ideal R) : (quotient.mkₐ I).to_ring_hom.ker = I :=
-by rw [quotient.mkₐ_to_ring_hom _, ideal.mk_ker]
+ideal.mk_ker
 
 /-- The ring hom `R/J →+* S/I` induced by a ring hom `f : R →+* S` with `J ≤ f⁻¹(I)` -/
 def quotient_map {I : ideal R} (J : ideal S) (f : R →+* S) (hIJ : I ≤ J.comap f) :

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1160,7 +1160,7 @@ lemma quotient.mk.alg_surjective (I : ideal R) : function.surjective (quotient.m
 /-- The kernel of `R →ₐ[R] I.quotient` is `I`. -/
 @[simp]
 lemma quotient.mk.alg_ker (I : ideal R) : (quotient.mk.alg I).to_ring_hom.ker = I :=
-by rw [quotient.mk.alg_to_ring_hom _, ideal.mk_ker]
+ideal.mk_ker I
 
 /-- The ring hom `R/J →+* S/I` induced by a ring hom `f : R →+* S` with `J ≤ f⁻¹(I)` -/
 def quotient_map {I : ideal R} (J : ideal S) (f : R →+* S) (hIJ : I ≤ J.comap f) :


### PR DESCRIPTION
I added very basic stuff about `R/I` as an `R`-algebra that are missing in mathlib.
