### PR TITLE
[Merged by Bors] - chore(analysis|measure_theory|topology): give tsum notation precedence 67

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -48,7 +48,7 @@ rfl
 
 end finset
 
-/-
+/--
 ## Operator precedence of `∏` and `∑`
 
 There is no established mathematical convention
@@ -68,6 +68,7 @@ In practice, this means that parentheses should be placed as follows:
 ```
 (Example taken from page 490 of Knuth's *Concrete Mathematics*.)
 -/
+library_note "operator precedence of big operators"
 
 localized "notation `∑` binders `, ` r:(scoped:67 f, finset.sum finset.univ f) := r"
   in big_operators

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -148,8 +148,8 @@ begin
   have su : summable u := summable_of_summable_norm sNu,
   let x := tsum u,
   have x_ineq : ∥x∥ ≤ (2 * C + 1) * ∥y∥ := calc
-    ∥x∥ ≤ (∑'n, ∥u n∥) : norm_tsum_le_tsum_norm sNu
-    ... ≤ (∑'n, (1/2)^n * (C * ∥y∥)) :
+    ∥x∥ ≤ ∑'n, ∥u n∥ : norm_tsum_le_tsum_norm sNu
+    ... ≤ ∑'n, (1/2)^n * (C * ∥y∥) :
       tsum_le_tsum ule sNu (summable.mul_right _ summable_geometric_two)
     ... = (∑'n, (1/2)^n) * (C * ∥y∥) : tsum_mul_right
     ... = 2 * C * ∥y∥ : by rw [tsum_geometric_two, mul_assoc]

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -1203,13 +1203,13 @@ lemma has_sum_of_subseq_of_summable {f : ι → α} (hf : summable (λa, ∥f a�
   has_sum f a :=
 tendsto_nhds_of_cauchy_seq_of_subseq (cauchy_seq_finset_of_summable_norm hf) hs ha
 
-/-- If `∑' i, ∥f i∥` is summable, then `∥(∑' i, f i)∥ ≤ (∑' i, ∥f i∥)`. Note that we do not assume
+/-- If `∑' i, ∥f i∥` is summable, then `∥∑' i, f i∥ ≤ (∑' i, ∥f i∥)`. Note that we do not assume
 that `∑' i, f i` is summable, and it might not be the case if `α` is not a complete space. -/
 lemma norm_tsum_le_tsum_norm {f : ι → α} (hf : summable (λi, ∥f i∥)) :
-  ∥(∑'i, f i)∥ ≤ (∑' i, ∥f i∥) :=
+  ∥∑'i, f i∥ ≤ ∑' i, ∥f i∥ :=
 begin
   by_cases h : summable f,
-  { have h₁ : tendsto (λs:finset ι, ∥∑ i in s, f i∥) at_top (𝓝 ∥(∑' i, f i)∥) :=
+  { have h₁ : tendsto (λs:finset ι, ∥∑ i in s, f i∥) at_top (𝓝 ∥∑' i, f i∥) :=
       (continuous_norm.tendsto _).comp h.has_sum,
     have h₂ : tendsto (λs:finset ι, ∑ i in s, ∥f i∥) at_top (𝓝 (∑' i, ∥f i∥)) :=
       hf.has_sum,
@@ -1231,10 +1231,10 @@ lemma summable_of_norm_bounded
 by { rw summable_iff_cauchy_seq_finset, exact cauchy_seq_finset_of_norm_bounded g hg h }
 
 /-- Quantitative result associated to the direct comparison test for series:  If `∑' i, g i` is
-summable, and for all `i`, `∥f i∥ ≤ g i`, then `∥(∑' i, f i)∥ ≤ (∑' i, g i)`. Note that we do not
+summable, and for all `i`, `∥f i∥ ≤ g i`, then `∥∑' i, f i∥ ≤ ∑' i, g i`. Note that we do not
 assume that `∑' i, f i` is summable, and it might not be the case if `α` is not a complete space. -/
 lemma tsum_of_norm_bounded {f : ι → α} {g : ι → ℝ} {a : ℝ} (hg : has_sum g a) (h : ∀i, ∥f i∥ ≤ g i) :
-  ∥(∑' (i:ι), f i)∥ ≤ a :=
+  ∥∑' i:ι, f i∥ ≤ a :=
 begin
   have h' : summable (λ (i : ι), ∥f i∥),
   { let f' : ι → ℝ := λ i, ∥f i∥,
@@ -1243,9 +1243,9 @@ begin
       convert h i,
       simp },
     simpa [f'] using summable_of_norm_bounded g hg.summable h'' },
-  have h1 : ∥(∑' (i:ι), f i)∥ ≤ ∑' (i:ι), ∥f i∥ := by simpa using norm_tsum_le_tsum_norm h',
+  have h1 : ∥∑' i:ι, f i∥ ≤ ∑' i:ι, ∥f i∥ := by simpa using norm_tsum_le_tsum_norm h',
   have h2 := tsum_le_tsum h h' hg.summable,
-  have h3 : a = ∑' (i:ι), g i := (has_sum.tsum_eq hg).symm,
+  have h3 : a = ∑' i:ι, g i := (has_sum.tsum_eq hg).symm,
   linarith
 end
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -847,7 +847,7 @@ protected lemma continuous_linear_equiv.summable {f : ι → M} (e : M ≃L[R] M
 ⟨λ hf, (e.has_sum.1 hf.has_sum).summable, (e : M →L[R] M₂).summable⟩
 
 lemma continuous_linear_equiv.tsum_eq_iff [t2_space M] [t2_space M₂] {f : ι → M}
-  (e : M ≃L[R] M₂) {y : M₂} : (∑' z, e (f z)) = y ↔ (∑' z, f z) = e.symm y :=
+  (e : M ≃L[R] M₂) {y : M₂} : ∑' z, e (f z) = y ↔ ∑' z, f z = e.symm y :=
 begin
   by_cases hf : summable f,
   { exact ⟨λ h, (e.has_sum.mp ((e.summable.mpr hf).has_sum_iff.mpr h)).tsum_eq,

--- a/src/analysis/normed_space/units.lean
+++ b/src/analysis/normed_space/units.lean
@@ -38,7 +38,7 @@ namespace units
 from `1` is a unit.  Here we construct its `units` structure.  -/
 def one_sub (t : R) (h : ∥t∥ < 1) : units R :=
 { val := 1 - t,
-  inv := ∑' (n : ℕ), t ^ n,
+  inv := ∑' n : ℕ, t ^ n,
   val_inv := mul_neg_geom_series t h,
   inv_val := geom_series_mul_neg t h }
 
@@ -171,7 +171,7 @@ begin
   { have : (2:ℝ)⁻¹ < 1 := by cancel_denoms,
     linarith },
   simp only [inverse_one_sub t ht', norm_one, mul_one, set.mem_set_of_eq],
-  change ∥(∑' (n : ℕ), t ^ n)∥ ≤ _,
+  change ∥∑' n : ℕ, t ^ n∥ ≤ _,
   have := normed_ring.tsum_geometric_of_norm_lt_1 t ht',
   have : (1 - ∥t∥)⁻¹ ≤ 2,
   { rw ← inv_inv' (2:ℝ),

--- a/src/analysis/p_series.lean
+++ b/src/analysis/p_series.lean
@@ -92,7 +92,7 @@ namespace ennreal
 variable {f : ℕ → ennreal}
 
 lemma le_tsum_condensed (hf : ∀ ⦃m n⦄, 0 < m → m ≤ n → f n ≤ f m) :
-  (∑' k, f k) ≤ f 0 + ∑' k : ℕ, (2 ^ k) * f (2 ^ k) :=
+  ∑' k, f k ≤ f 0 + ∑' k : ℕ, (2 ^ k) * f (2 ^ k) :=
 begin
   rw [ennreal.tsum_eq_supr_nat' (nat.tendsto_pow_at_top_at_top_of_one_lt _root_.one_lt_two)],
   refine supr_le (λ n, (finset.le_sum_condensed hf n).trans (add_le_add_left _ _)),
@@ -101,7 +101,7 @@ begin
 end
 
 lemma tsum_condensed_le (hf : ∀ ⦃m n⦄, 1 < m → m ≤ n → f n ≤ f m) :
-  (∑' k : ℕ, (2 ^ k) * f (2 ^ k)) ≤ f 1 + 2 * ∑' k, f k :=
+  ∑' k : ℕ, (2 ^ k * f (2 ^ k)) ≤ f 1 + 2 * ∑' k, f k :=
 begin
   rw [ennreal.tsum_eq_supr_nat' (tendsto_at_top_mono nat.le_succ tendsto_id), two_mul, ← two_nsmul],
   refine supr_le (λ n, le_trans _ (add_le_add_left (nsmul_le_nsmul_of_le_right

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -243,7 +243,7 @@ have (λ n, (∑ i in range n, r ^ i)) = (λ n, geom_series r n) := rfl,
 lemma summable_geometric_of_lt_1 {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) : summable (λn:ℕ, r ^ n) :=
 ⟨_, has_sum_geometric_of_lt_1 h₁ h₂⟩
 
-lemma tsum_geometric_of_lt_1 {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) : (∑'n:ℕ, r ^ n) = (1 - r)⁻¹ :=
+lemma tsum_geometric_of_lt_1 {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) : ∑'n:ℕ, r ^ n = (1 - r)⁻¹ :=
 (has_sum_geometric_of_lt_1 h₁ h₂).tsum_eq
 
 lemma has_sum_geometric_two : has_sum (λn:ℕ, ((1:ℝ)/2) ^ n) 2 :=
@@ -252,7 +252,7 @@ by convert has_sum_geometric_of_lt_1 _ _; norm_num
 lemma summable_geometric_two : summable (λn:ℕ, ((1:ℝ)/2) ^ n) :=
 ⟨_, has_sum_geometric_two⟩
 
-lemma tsum_geometric_two : (∑'n:ℕ, ((1:ℝ)/2) ^ n) = 2 :=
+lemma tsum_geometric_two : ∑'n:ℕ, ((1:ℝ)/2) ^ n = 2 :=
 has_sum_geometric_two.tsum_eq
 
 lemma sum_geometric_two_le (n : ℕ) : ∑ (i : ℕ) in range n, (1 / (2 : ℝ)) ^ i ≤ 2 :=
@@ -274,7 +274,7 @@ end
 lemma summable_geometric_two' (a : ℝ) : summable (λ n:ℕ, (a / 2) / 2 ^ n) :=
 ⟨a, has_sum_geometric_two' a⟩
 
-lemma tsum_geometric_two' (a : ℝ) : (∑' n:ℕ, (a / 2) / 2^n) = a :=
+lemma tsum_geometric_two' (a : ℝ) : ∑' n:ℕ, (a / 2) / 2^n = a :=
 (has_sum_geometric_two' a).tsum_eq
 
 lemma nnreal.has_sum_geometric {r : ℝ≥0} (hr : r < 1) :
@@ -289,12 +289,12 @@ end
 lemma nnreal.summable_geometric {r : ℝ≥0} (hr : r < 1) : summable (λn:ℕ, r ^ n) :=
 ⟨_, nnreal.has_sum_geometric hr⟩
 
-lemma tsum_geometric_nnreal {r : ℝ≥0} (hr : r < 1) : (∑'n:ℕ, r ^ n) = (1 - r)⁻¹ :=
+lemma tsum_geometric_nnreal {r : ℝ≥0} (hr : r < 1) : ∑'n:ℕ, r ^ n = (1 - r)⁻¹ :=
 (nnreal.has_sum_geometric hr).tsum_eq
 
 /-- The series `pow r` converges to `(1-r)⁻¹`. For `r < 1` the RHS is a finite number,
 and for `1 ≤ r` the RHS equals `∞`. -/
-lemma ennreal.tsum_geometric (r : ennreal) : (∑'n:ℕ, r ^ n) = (1 - r)⁻¹ :=
+lemma ennreal.tsum_geometric (r : ennreal) : ∑'n:ℕ, r ^ n = (1 - r)⁻¹ :=
 begin
   cases lt_or_le r 1 with hr hr,
   { rcases ennreal.lt_iff_exists_coe.1 hr with ⟨r, rfl, hr'⟩,
@@ -325,7 +325,7 @@ end
 lemma summable_geometric_of_norm_lt_1 (h : ∥ξ∥ < 1) : summable (λn:ℕ, ξ ^ n) :=
 ⟨_, has_sum_geometric_of_norm_lt_1 h⟩
 
-lemma tsum_geometric_of_norm_lt_1 (h : ∥ξ∥ < 1) : (∑'n:ℕ, ξ ^ n) = (1 - ξ)⁻¹ :=
+lemma tsum_geometric_of_norm_lt_1 (h : ∥ξ∥ < 1) : ∑'n:ℕ, ξ ^ n = (1 - ξ)⁻¹ :=
 (has_sum_geometric_of_norm_lt_1 h).tsum_eq
 
 lemma has_sum_geometric_of_abs_lt_1 {r : ℝ} (h : abs r < 1) : has_sum (λn:ℕ, r ^ n) (1 - r)⁻¹ :=
@@ -334,7 +334,7 @@ has_sum_geometric_of_norm_lt_1 h
 lemma summable_geometric_of_abs_lt_1 {r : ℝ} (h : abs r < 1) : summable (λn:ℕ, r ^ n) :=
 summable_geometric_of_norm_lt_1 h
 
-lemma tsum_geometric_of_abs_lt_1 {r : ℝ} (h : abs r < 1) : (∑'n:ℕ, r ^ n) = (1 - r)⁻¹ :=
+lemma tsum_geometric_of_abs_lt_1 {r : ℝ} (h : abs r < 1) : ∑'n:ℕ, r ^ n = (1 - r)⁻¹ :=
 tsum_geometric_of_norm_lt_1 h
 
 /-- A geometric series in a normed field is summable iff the norm of the common ratio is less than
@@ -554,12 +554,12 @@ end
 /-- Bound for the sum of a geometric series in a normed ring.  This formula does not assume that the
 normed ring satisfies the axiom `∥1∥ = 1`. -/
 lemma normed_ring.tsum_geometric_of_norm_lt_1
-  (x : R) (h : ∥x∥ < 1) : ∥(∑' (n:ℕ), x ^ n)∥ ≤ ∥(1:R)∥ - 1 + (1 - ∥x∥)⁻¹ :=
+  (x : R) (h : ∥x∥ < 1) : ∥∑' n:ℕ, x ^ n∥ ≤ ∥(1:R)∥ - 1 + (1 - ∥x∥)⁻¹ :=
 begin
   rw tsum_eq_zero_add (normed_ring.summable_geometric_of_norm_lt_1 x h),
   simp only [pow_zero],
   refine le_trans (norm_add_le _ _) _,
-  have : ∥(∑' (b : ℕ), (λ n, x ^ (n + 1)) b)∥ ≤ (1 - ∥x∥)⁻¹ - 1,
+  have : ∥∑' b : ℕ, (λ n, x ^ (n + 1)) b∥ ≤ (1 - ∥x∥)⁻¹ - 1,
   { refine tsum_of_norm_bounded _ (λ b, norm_pow_le' _ (nat.succ_pos b)),
     convert (has_sum_nat_add_iff' 1).mpr (has_sum_geometric_of_lt_1 (norm_nonneg x) h),
     simp },
@@ -567,7 +567,7 @@ begin
 end
 
 lemma geom_series_mul_neg (x : R) (h : ∥x∥ < 1) :
-  (∑' (i:ℕ), x ^ i) * (1 - x) = 1 :=
+  (∑' i:ℕ, x ^ i) * (1 - x) = 1 :=
 begin
   have := ((normed_ring.summable_geometric_of_norm_lt_1 x h).has_sum.mul_right (1 - x)),
   refine tendsto_nhds_unique this.tendsto_sum_nat _,
@@ -579,7 +579,7 @@ begin
 end
 
 lemma mul_neg_geom_series (x : R) (h : ∥x∥ < 1) :
-  (1 - x) * (∑' (i:ℕ), x ^ i) = 1 :=
+  (1 - x) * ∑' i:ℕ, x ^ i = 1 :=
 begin
   have := (normed_ring.summable_geometric_of_norm_lt_1 x h).has_sum.mul_left (1 - x),
   refine tendsto_nhds_unique this.tendsto_sum_nat _,
@@ -624,7 +624,7 @@ end nnreal
 namespace ennreal
 
 theorem exists_pos_sum_of_encodable {ε : ennreal} (hε : 0 < ε) (ι) [encodable ι] :
-  ∃ ε' : ι → ℝ≥0, (∀ i, 0 < ε' i) ∧ (∑' i, (ε' i : ennreal)) < ε :=
+  ∃ ε' : ι → ℝ≥0, (∀ i, 0 < ε' i) ∧ ∑' i, (ε' i : ennreal) < ε :=
 begin
   rcases exists_between hε with ⟨r, h0r, hrε⟩,
   rcases lt_iff_exists_coe.1 hrε with ⟨x, rfl, hx⟩,

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -97,7 +97,7 @@ extension of the restricted measure. -/
 structure measure (α : Type*) [measurable_space α] extends outer_measure α :=
 (m_Union ⦃f : ℕ → set α⦄ :
   (∀ i, is_measurable (f i)) → pairwise (disjoint on f) →
-  measure_of (⋃ i, f i) = (∑' i, measure_of (f i)))
+  measure_of (⋃ i, f i) = ∑' i, measure_of (f i))
 (trimmed : to_outer_measure.trim = to_outer_measure)
 
 /-- Measure projections for a measure space.
@@ -121,7 +121,7 @@ namespace measure
 def of_measurable (m : Π (s : set α), is_measurable s → ennreal)
   (m0 : m ∅ is_measurable.empty = 0)
   (mU : ∀ {{f : ℕ → set α}} (h : ∀ i, is_measurable (f i)), pairwise (disjoint on f) →
-    m (⋃ i, f i) (is_measurable.Union h) = (∑' i, m (f i) (h i))) : measure α :=
+    m (⋃ i, f i) (is_measurable.Union h) = ∑' i, m (f i) (h i)) : measure α :=
 { m_Union := λ f hf hd,
   show induced_outer_measure m _ m0 (Union f) =
       ∑' i, induced_outer_measure m _ m0 (f i), begin
@@ -139,7 +139,7 @@ def of_measurable (m : Π (s : set α), is_measurable s → ennreal)
 lemma of_measurable_apply {m : Π (s : set α), is_measurable s → ennreal}
   {m0 : m ∅ is_measurable.empty = 0}
   {mU : ∀ {{f : ℕ → set α}} (h : ∀ i, is_measurable (f i)), pairwise (disjoint on f) →
-    m (⋃ i, f i) (is_measurable.Union h) = (∑' i, m (f i) (h i))}
+    m (⋃ i, f i) (is_measurable.Union h) = ∑' i, m (f i) (h i)}
   (s : set α) (hs : is_measurable s) : of_measurable m m0 mU s = m s hs :=
 induced_outer_measure_eq m0 mU hs
 
@@ -205,7 +205,7 @@ lemma exists_is_measurable_superset_iff_measure_eq_zero :
   (∃ t, s ⊆ t ∧ is_measurable t ∧ μ t = 0) ↔ μ s = 0 :=
 ⟨λ ⟨t, hst, _, ht⟩, measure_mono_null hst ht, exists_is_measurable_superset_of_null⟩
 
-theorem measure_Union_le [encodable β] (s : β → set α) : μ (⋃ i, s i) ≤ (∑' i, μ (s i)) :=
+theorem measure_Union_le [encodable β] (s : β → set α) : μ (⋃ i, s i) ≤ ∑' i, μ (s i) :=
 μ.to_outer_measure.Union _
 
 lemma measure_bUnion_le {s : set β} (hs : countable s) (f : β → set α) :
@@ -251,7 +251,7 @@ lemma measure_union_null_iff : μ (s₁ ∪ s₂) = 0 ↔ μ s₁ = 0 ∧ μ s�
 
 lemma measure_Union [encodable β] {f : β → set α}
   (hn : pairwise (disjoint on f)) (h : ∀ i, is_measurable (f i)) :
-  μ (⋃ i, f i) = (∑' i, μ (f i)) :=
+  μ (⋃ i, f i) = ∑' i, μ (f i) :=
 begin
   rw [measure_eq_extend (is_measurable.Union h),
     extend_Union is_measurable.empty _ is_measurable.Union _ hn h],
@@ -293,7 +293,7 @@ end
 of the fibers `f ⁻¹' {y}`. -/
 lemma tsum_measure_preimage_singleton {s : set β} (hs : countable s) {f : α → β}
   (hf : ∀ y ∈ s, is_measurable (f ⁻¹' {y})) :
-  (∑' b : s, μ (f ⁻¹' {↑b})) = μ (f ⁻¹' s) :=
+  ∑' b : s, μ (f ⁻¹' {↑b}) = μ (f ⁻¹' s) :=
 by rw [← set.bUnion_preimage_singleton, measure_bUnion hs (pairwise_on_disjoint_fiber _ _) hf]
 
 /-- If `s` is a `finset`, then the measure of its preimage can be found as the sum of measures
@@ -322,7 +322,7 @@ by { rw ← measure_bUnion_finset H h, exact measure_mono (subset_univ _) }
 
 lemma tsum_measure_le_measure_univ {s : ι → set α} (hs : ∀ i, is_measurable (s i))
   (H : pairwise (disjoint on s)) :
-  (∑' i, μ (s i)) ≤ μ (univ : set α) :=
+  ∑' i, μ (s i) ≤ μ (univ : set α) :=
 begin
   rw [ennreal.tsum_eq_supr_sum],
   exact supr_le (λ s, sum_measure_le_measure_univ (λ i hi, hs i) (λ i hi j hj hij, H i j hij))
@@ -441,7 +441,7 @@ end
 /-- One direction of the Borel-Cantelli lemma: if (sᵢ) is a sequence of measurable sets such that
   ∑ μ sᵢ exists, then the limit superior of the sᵢ is a null set. -/
 lemma measure_limsup_eq_zero {s : ℕ → set α} (hs : ∀ i, is_measurable (s i))
-  (hs' : (∑' i, μ (s i)) ≠ ⊤) : μ (limsup at_top s) = 0 :=
+  (hs' : ∑' i, μ (s i) ≠ ⊤) : μ (limsup at_top s) = 0 :=
 begin
   rw limsup_eq_infi_supr_of_nat',
   -- We will show that both `μ (⨅ n, ⨆ i, s (i + n))` and `0` are the limit of `μ (⊔ i, s (i + n))`
@@ -535,7 +535,7 @@ instance : has_add (measure α) :=
 ⟨λ μ₁ μ₂, {
   to_outer_measure := μ₁.to_outer_measure + μ₂.to_outer_measure,
   m_Union := λ s hs hd,
-    show μ₁ (⋃ i, s i) + μ₂ (⋃ i, s i) = ∑' i, μ₁ (s i) + μ₂ (s i),
+    show μ₁ (⋃ i, s i) + μ₂ (⋃ i, s i) = ∑' i, (μ₁ (s i) + μ₂ (s i)),
     by rw [ennreal.tsum_add, measure_Union hd hs, measure_Union hd hs],
   trimmed := by rw [outer_measure.trim_add, μ₁.trimmed, μ₂.trimmed] }⟩
 
@@ -1324,7 +1324,7 @@ ae_eq_bot.trans restrict_eq_zero
 /-- A version of the Borel-Cantelli lemma: if sᵢ is a sequence of measurable sets such that
 ∑ μ sᵢ exists, then for almost all x, x does not belong to almost all sᵢ. -/
 lemma ae_eventually_not_mem {s : ℕ → set α} (hs : ∀ i, is_measurable (s i))
-  (hs' : (∑' i, μ (s i)) ≠ ⊤) : ∀ᵐ x ∂ μ, ∀ᶠ n in at_top, x ∉ s n :=
+  (hs' : ∑' i, μ (s i) ≠ ⊤) : ∀ᵐ x ∂ μ, ∀ᶠ n in at_top, x ∉ s n :=
 begin
   refine measure_mono_null _ (measure_limsup_eq_zero hs hs'),
   rw ←set.le_eq_subset,

--- a/src/measure_theory/probability_mass_function.lean
+++ b/src/measure_theory/probability_mass_function.lean
@@ -42,7 +42,7 @@ lemma has_sum_coe_one (p : pmf α) : has_sum p 1 := p.2
 
 lemma summable_coe (p : pmf α) : summable p := (p.has_sum_coe_one).summable
 
-@[simp] lemma tsum_coe (p : pmf α) : (∑' a, p a) = 1 := p.has_sum_coe_one.tsum_eq
+@[simp] lemma tsum_coe (p : pmf α) : ∑' a, p a = 1 := p.has_sum_coe_one.tsum_eq
 
 /-- The support of a `pmf` is the set where it is nonzero. -/
 def support (p : pmf α) : set α := {a | p.1 a ≠ 0}
@@ -77,11 +77,11 @@ def bind (p : pmf α) (f : α → pmf β) : pmf β :=
       (ennreal.coe_tsum p.summable_coe).symm]
   end⟩
 
-@[simp] lemma bind_apply (p : pmf α) (f : α → pmf β) (b : β) : p.bind f b = (∑'a, p a * f a b) :=
+@[simp] lemma bind_apply (p : pmf α) (f : α → pmf β) (b : β) : p.bind f b = ∑'a, p a * f a b :=
 rfl
 
 lemma coe_bind_apply (p : pmf α) (f : α → pmf β) (b : β) :
-  (p.bind f b : ennreal) = (∑'a, p a * f a b) :=
+  (p.bind f b : ennreal) = ∑'a, p a * f a b :=
 eq.trans (ennreal.coe_tsum $ bind.summable p f b) $ by simp
 
 @[simp] lemma pure_bind (a : α) (f : α → pmf β) : (pure a).bind f = f a :=

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -56,7 +56,7 @@ def summable (f : β → α) : Prop := ∃a, has_sum f a
 /-- `∑' i, f i` is the sum of `f` it exists, or 0 otherwise -/
 @[irreducible] def tsum {β} (f : β → α) := if h : summable f then classical.some h else 0
 
--- See the comment on precedence of big operators in `algebra/big_operators/basic.lean`.
+-- see Note [operator precedence of big operators]
 notation `∑'` binders `, ` r:(scoped:67 f, tsum f) := r
 
 variables {f g : β → α} {a b : α} {s : finset β}

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -56,7 +56,8 @@ def summable (f : β → α) : Prop := ∃a, has_sum f a
 /-- `∑' i, f i` is the sum of `f` it exists, or 0 otherwise -/
 @[irreducible] def tsum {β} (f : β → α) := if h : summable f then classical.some h else 0
 
-notation `∑'` binders `, ` r:(scoped f, tsum f) := r
+-- See the comment on precedence of big operators in `algebra/big_operators/basic.lean`.
+notation `∑'` binders `, ` r:(scoped:67 f, tsum f) := r
 
 variables {f g : β → α} {a b : α} {s : finset β}
 
@@ -71,7 +72,7 @@ by simp [has_sum, tendsto_const_nhds]
 
 lemma summable_zero : summable (λb, 0 : β → α) := has_sum_zero.summable
 
-lemma tsum_eq_zero_of_not_summable (h : ¬ summable f) : (∑'b, f b) = 0 :=
+lemma tsum_eq_zero_of_not_summable (h : ¬ summable f) : ∑'b, f b = 0 :=
 by simp [tsum, h]
 
 lemma has_sum.has_sum_of_sum_eq {g : γ → α}
@@ -289,36 +290,36 @@ section tsum
 variables [add_comm_monoid α] [topological_space α] [t2_space α]
 variables {f g : β → α} {a a₁ a₂ : α}
 
-lemma has_sum.tsum_eq (ha : has_sum f a) : (∑'b, f b) = a :=
+lemma has_sum.tsum_eq (ha : has_sum f a) : ∑'b, f b = a :=
 (summable.has_sum ⟨a, ha⟩).unique ha
 
-lemma summable.has_sum_iff (h : summable f) : has_sum f a ↔ (∑'b, f b) = a :=
+lemma summable.has_sum_iff (h : summable f) : has_sum f a ↔ ∑'b, f b = a :=
 iff.intro has_sum.tsum_eq (assume eq, eq ▸ h.has_sum)
 
-@[simp] lemma tsum_zero : (∑'b:β, 0:α) = 0 := has_sum_zero.tsum_eq
+@[simp] lemma tsum_zero : ∑'b:β, (0:α) = 0 := has_sum_zero.tsum_eq
 
 lemma tsum_eq_sum {f : β → α} {s : finset β} (hf : ∀b∉s, f b = 0)  :
-  (∑'b, f b) = ∑ b in s, f b :=
+  ∑'b, f b = ∑ b in s, f b :=
 (has_sum_sum_of_ne_finset_zero hf).tsum_eq
 
-lemma tsum_fintype [fintype β] (f : β → α) : (∑'b, f b) = ∑ b, f b :=
+lemma tsum_fintype [fintype β] (f : β → α) : ∑'b, f b = ∑ b, f b :=
 (has_sum_fintype f).tsum_eq
 
 @[simp] lemma finset.tsum_subtype (s : finset β) (f : β → α) :
-  (∑'x : {x // x ∈ s}, f x) = ∑ x in s, f x :=
+  ∑'x : {x // x ∈ s}, f x = ∑ x in s, f x :=
 (s.has_sum f).tsum_eq
 
 lemma tsum_eq_single {f : β → α} (b : β) (hf : ∀b' ≠ b, f b' = 0)  :
-  (∑'b, f b) = f b :=
+  ∑'b, f b = f b :=
 (has_sum_single b hf).tsum_eq
 
-@[simp] lemma tsum_ite_eq (b : β) (a : α) : (∑'b', if b' = b then a else 0) = a :=
+@[simp] lemma tsum_ite_eq (b : β) (a : α) : ∑'b', (if b' = b then a else 0) = a :=
 (has_sum_ite_eq b a).tsum_eq
 
 lemma equiv.tsum_eq_tsum_of_has_sum_iff_has_sum {α' : Type*} [add_comm_monoid α']
   [topological_space α'] (e : α' ≃ α) (h0 : e 0 = 0) {f : β → α} {g : γ → α'}
   (h : ∀ {a}, has_sum f (e a) ↔ has_sum g a) :
-  (∑' b, f b) = e (∑' c, g c) :=
+  ∑' b, f b = e (∑' c, g c) :=
 by_cases
   (assume : summable g, (h.mpr this.has_sum).tsum_eq)
   (assume hg : ¬ summable g,
@@ -327,10 +328,10 @@ by_cases
 
 lemma tsum_eq_tsum_of_has_sum_iff_has_sum {f : β → α} {g : γ → α}
   (h : ∀{a}, has_sum f a ↔ has_sum g a) :
-  (∑'b, f b) = (∑'c, g c) :=
+  ∑'b, f b = ∑'c, g c :=
 (equiv.refl α).tsum_eq_tsum_of_has_sum_iff_has_sum rfl @h
 
-lemma equiv.tsum_eq (j : γ ≃ β) (f : β → α) : (∑'c, f (j c)) = (∑'b, f b) :=
+lemma equiv.tsum_eq (j : γ ≃ β) (f : β → α) : ∑'c, f (j c) = ∑'b, f b :=
 tsum_eq_tsum_of_has_sum_iff_has_sum $ λ a, j.has_sum_iff
 
 lemma equiv.tsum_eq_tsum_of_support {f : β → α} {g : γ → α} (e : support f ≃ support g)
@@ -341,35 +342,35 @@ tsum_eq_tsum_of_has_sum_iff_has_sum $ λ _, e.has_sum_iff_of_support he
 lemma tsum_eq_tsum_of_ne_zero_bij {g : γ → α} (i : support g → β)
   (hi : ∀ ⦃x y⦄, i x = i y → (x : γ) = y)
   (hf : support f ⊆ set.range i) (hfg : ∀ x, f (i x) = g x) :
-  (∑' x, f x)  = ∑' y, g y :=
+  ∑' x, f x  = ∑' y, g y :=
 tsum_eq_tsum_of_has_sum_iff_has_sum $ λ _, has_sum_iff_has_sum_of_ne_zero_bij i hi hf hfg
 
 lemma tsum_subtype (s : set β) (f : β → α) :
-  (∑' x : s, f x) = ∑' x, s.indicator f x :=
+  ∑' x:s, f x = ∑' x, s.indicator f x :=
 tsum_eq_tsum_of_has_sum_iff_has_sum $ λ _, has_sum_subtype_iff_indicator
 
 section has_continuous_add
 variable [has_continuous_add α]
 
-lemma tsum_add (hf : summable f) (hg : summable g) : (∑'b, f b + g b) = (∑'b, f b) + (∑'b, g b) :=
+lemma tsum_add (hf : summable f) (hg : summable g) : ∑'b, (f b + g b) = (∑'b, f b) + (∑'b, g b) :=
 (hf.has_sum.add hg.has_sum).tsum_eq
 
 lemma tsum_sum {f : γ → β → α} {s : finset γ} (hf : ∀i∈s, summable (f i)) :
-  (∑'b, ∑ i in s, f i b) = ∑ i in s, ∑'b, f i b :=
+  ∑'b, ∑ i in s, f i b = ∑ i in s, ∑'b, f i b :=
 (has_sum_sum $ assume i hi, (hf i hi).has_sum).tsum_eq
 
 lemma tsum_sigma' [regular_space α] {γ : β → Type*} {f : (Σb:β, γ b) → α}
-  (h₁ : ∀b, summable (λc, f ⟨b, c⟩)) (h₂ : summable f) : (∑'p, f p) = (∑'b c, f ⟨b, c⟩) :=
+  (h₁ : ∀b, summable (λc, f ⟨b, c⟩)) (h₂ : summable f) : ∑'p, f p = ∑'b c, f ⟨b, c⟩ :=
 (h₂.has_sum.sigma (assume b, (h₁ b).has_sum)).tsum_eq.symm
 
 lemma tsum_prod' [regular_space α] {f : β × γ → α} (h : summable f)
   (h₁ : ∀b, summable (λc, f (b, c))) :
-  (∑'p, f p) = (∑'b c, f (b, c)) :=
+  ∑'p, f p = ∑'b c, f (b, c) :=
 (h.has_sum.prod_fiberwise (assume b, (h₁ b).has_sum)).tsum_eq.symm
 
 lemma tsum_comm' [regular_space α] {f : β → γ → α} (h : summable (function.uncurry f))
   (h₁ : ∀b, summable (f b)) (h₂ : ∀ c, summable (λ b, f b c)) :
-  (∑' c b, f b c) = (∑' b c, f b c) :=
+  ∑' c b, f b c = ∑' b c, f b c :=
 begin
   erw [← tsum_prod' h h₁, ← tsum_prod' h.prod_symm h₂, ← (equiv.prod_comm β γ).tsum_eq],
   refl,
@@ -385,7 +386,7 @@ variable [encodable γ]
 /-- You can compute a sum over an encodably type by summing over the natural numbers and
   taking a supremum. This is useful for outer measures. -/
 theorem tsum_supr_decode2 [complete_lattice β] (m : β → α) (m0 : m ⊥ = 0)
-  (s : γ → β) : (∑' i : ℕ, m (⨆ b ∈ decode2 γ i, s b)) = (∑' b : γ, m (s b)) :=
+  (s : γ → β) : ∑' i : ℕ, m (⨆ b ∈ decode2 γ i, s b) = ∑' b : γ, m (s b) :=
 begin
   have H : ∀ n, m (⨆ b ∈ decode2 γ n, s b) ≠ 0 → (decode2 γ n).is_some,
   { intros n h,
@@ -408,7 +409,7 @@ end
 
 /-- `tsum_supr_decode2` specialized to the complete lattice of sets. -/
 theorem tsum_Union_decode2 (m : set β → α) (m0 : m ∅ = 0)
-  (s : γ → set β) : (∑' i, m (⋃ b ∈ decode2 γ i, s b)) = (∑' b, m (s b)) :=
+  (s : γ → set β) : ∑' i, m (⋃ b ∈ decode2 γ i, s b) = ∑' b, m (s b) :=
 tsum_supr_decode2 m m0 s
 
 /-! Some properties about measure-like functions.
@@ -419,8 +420,8 @@ tsum_supr_decode2 m m0 s
 
 /-- If a function is countably sub-additive then it is sub-additive on encodable types -/
 theorem rel_supr_tsum [complete_lattice β] (m : β → α) (m0 : m ⊥ = 0)
-  (R : α → α → Prop) (m_supr : ∀(s : ℕ → β), R (m (⨆ i, s i)) (∑' i, m (s i)))
-  (s : γ → β) : R (m (⨆ b : γ, s b)) (∑' b : γ, m (s b)) :=
+  (R : α → α → Prop) (m_supr : ∀(s : ℕ → β), R (m (⨆ i, s i)) ∑' i, m (s i))
+  (s : γ → β) : R (m (⨆ b : γ, s b)) ∑' b : γ, m (s b) :=
 by { rw [← supr_decode2, ← tsum_supr_decode2 _ m0 s], exact m_supr _ }
 
 /-- If a function is countably sub-additive then it is sub-additive on finite sets -/
@@ -521,10 +522,10 @@ lemma set.finite.summable_compl_iff {s : set β} (hs : s.finite) :
 section tsum
 variables [t2_space α]
 
-lemma tsum_neg (hf : summable f) : (∑'b, - f b) = - (∑'b, f b) :=
+lemma tsum_neg (hf : summable f) : ∑'b, - f b = - ∑'b, f b :=
 hf.has_sum.neg.tsum_eq
 
-lemma tsum_sub (hf : summable f) (hg : summable g) : (∑'b, f b - g b) = (∑'b, f b) - (∑'b, g b) :=
+lemma tsum_sub (hf : summable f) (hg : summable g) : ∑'b, (f b - g b) = ∑'b, f b - ∑'b, g b :=
 (hf.has_sum.sub hg.has_sum).tsum_eq
 
 lemma tsum_add_tsum_compl {s : set β} (hs : summable (f ∘ coe : s → α))
@@ -564,12 +565,12 @@ lemma has_sum_nat_add_iff' {f : ℕ → α} (k : ℕ) {a : α} :
 by simp [has_sum_nat_add_iff]
 
 lemma sum_add_tsum_nat_add [t2_space α] {f : ℕ → α} (k : ℕ) (h : summable f) :
-  (∑ i in range k, f i) + (∑' i, f (i + k)) = (∑' i, f i) :=
+  (∑ i in range k, f i) + (∑' i, f (i + k)) = ∑' i, f i :=
 by simpa [add_comm] using
   ((has_sum_nat_add_iff k).1 ((summable_nat_add_iff k).2 h).has_sum).unique h.has_sum
 
 lemma tsum_eq_zero_add [t2_space α] {f : ℕ → α} (hf : summable f) :
-  (∑'b, f b) = f 0 + (∑'b, f (b + 1)) :=
+  ∑'b, f b = f 0 + ∑'b, f (b + 1) :=
 by simpa only [range_one, sum_singleton] using (sum_add_tsum_nat_add 1 hf).symm
 
 /-- For `f : ℕ → α`, then `∑' k, f (k + i)` tends to zero. This does not require a summability
@@ -611,7 +612,7 @@ lemma summable.mul_right (a) (hf : summable f) : summable (λb, f b * a) :=
 section tsum
 variables [t2_space α]
 
-lemma summable.tsum_mul_left (a) (hf : summable f) : (∑'b, a * f b) = a * (∑'b, f b) :=
+lemma summable.tsum_mul_left (a) (hf : summable f) : ∑'b, a * f b = a * ∑'b, f b :=
 (hf.has_sum.mul_left _).tsum_eq
 
 lemma summable.tsum_mul_right (a) (hf : summable f) : (∑'b, f b * a) = (∑'b, f b) * a :=
@@ -634,7 +635,7 @@ hf.map (const_smul_hom α r) (continuous_const.smul continuous_id)
 lemma summable.smul {r : R} (hf : summable f) : summable (λ z, r • f z) :=
 hf.has_sum.smul.summable
 
-lemma tsum_smul [t2_space α] {r : R} (hf : summable f) : (∑' z, r • f z) = r • (∑' z, f z) :=
+lemma tsum_smul [t2_space α] {r : R} (hf : summable f) : ∑' z, r • f z = r • ∑' z, f z :=
 hf.has_sum.smul.tsum_eq
 
 end topological_semimodule
@@ -722,7 +723,7 @@ sum_le_has_sum s hs hf.has_sum
 lemma le_tsum (hf : summable f) (b : β) (hb : ∀ b' ≠ b, 0 ≤ f b') : f b ≤ ∑' b, f b :=
 le_has_sum (summable.has_sum hf) b hb
 
-lemma tsum_le_tsum (h : ∀b, f b ≤ g b) (hf : summable f) (hg : summable g) : (∑'b, f b) ≤ (∑'b, g b) :=
+lemma tsum_le_tsum (h : ∀b, f b ≤ g b) (hf : summable f) (hg : summable g) : ∑'b, f b ≤ ∑'b, g b :=
 has_sum_le h hf.has_sum hg.has_sum
 
 lemma has_sum.nonneg (h : ∀ b, 0 ≤ g b) (ha : has_sum g a) : 0 ≤ a :=
@@ -731,14 +732,14 @@ has_sum_le h has_sum_zero ha
 lemma has_sum.nonpos (h : ∀ b, g b ≤ 0) (ha : has_sum g a) : a ≤ 0 :=
 has_sum_le h ha has_sum_zero
 
-lemma tsum_nonneg (h : ∀ b, 0 ≤ g b) : 0 ≤ (∑'b, g b) :=
+lemma tsum_nonneg (h : ∀ b, 0 ≤ g b) : 0 ≤ ∑'b, g b :=
 begin
   by_cases hg : summable g,
   { exact hg.has_sum.nonneg h },
   { simp [tsum_eq_zero_of_not_summable hg] }
 end
 
-lemma tsum_nonpos (h : ∀ b, f b ≤ 0) : (∑'b, f b) ≤ 0 :=
+lemma tsum_nonpos (h : ∀ b, f b ≤ 0) : ∑'b, f b ≤ 0 :=
 begin
   by_cases hf : summable f,
   { exact hf.has_sum.nonpos h },
@@ -766,7 +767,7 @@ begin
     exact funext h }
 end
 
-lemma tsum_eq_zero_iff (hf : summable f) : (∑' i, f i) = 0 ↔ ∀ x, f x = 0 :=
+lemma tsum_eq_zero_iff (hf : summable f) : ∑' i, f i = 0 ↔ ∀ x, f x = 0 :=
 by rw [←has_sum_zero_iff, hf.has_sum_iff]
 
 end canonically_ordered
@@ -864,15 +865,15 @@ lemma summable.prod_factor {f : β × γ → α} (h : summable f) (b : β) :
 h.comp_injective $ λ c₁ c₂ h, (prod.ext_iff.1 h).2
 
 lemma tsum_sigma [regular_space α] {γ : β → Type*} {f : (Σb:β, γ b) → α}
-  (ha : summable f) : (∑'p, f p) = (∑'b c, f ⟨b, c⟩) :=
+  (ha : summable f) : ∑'p, f p = ∑'b c, f ⟨b, c⟩ :=
 tsum_sigma' (λ b, ha.sigma_factor b) ha
 
 lemma tsum_prod [regular_space α] {f : β × γ → α} (h : summable f) :
-  (∑'p, f p) = (∑'b c, f ⟨b, c⟩) :=
+  ∑'p, f p = ∑'b c, f ⟨b, c⟩ :=
 tsum_prod' h h.prod_factor
 
 lemma tsum_comm [regular_space α] {f : β → γ → α} (h : summable (function.uncurry f)) :
-  (∑' c b, f b c) = (∑' b c, f b c) :=
+  ∑' c b, f b c = ∑' b c, f b c :=
 tsum_comm' h h.prod_factor h.prod_symm.prod_factor
 
 end uniform_group

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -452,10 +452,10 @@ have (λs:finset α, ∑ a in s, ↑(f a)) = (coe : ℝ≥0 → ennreal) ∘ (λ
   from funext $ assume s, ennreal.coe_finset_sum.symm,
 by unfold has_sum; rw [this, tendsto_coe]
 
-protected lemma tsum_coe_eq {f : α → ℝ≥0} (h : has_sum f r) : (∑'a, (f a : ennreal)) = r :=
+protected lemma tsum_coe_eq {f : α → ℝ≥0} (h : has_sum f r) : ∑'a, (f a : ennreal) = r :=
 (ennreal.has_sum_coe.2 h).tsum_eq
 
-protected lemma coe_tsum {f : α → ℝ≥0} : summable f → ↑(tsum f) = (∑'a, (f a : ennreal))
+protected lemma coe_tsum {f : α → ℝ≥0} : summable f → ↑(tsum f) = ∑'a, (f a : ennreal)
 | ⟨r, hr⟩ := by rw [hr.tsum_eq, ennreal.tsum_coe_eq hr]
 
 protected lemma has_sum : has_sum f (⨆s:finset α, ∑ a in s, f a) :=
@@ -472,7 +472,7 @@ tendsto_order.2
 @[simp] protected lemma summable : summable f := ⟨_, ennreal.has_sum⟩
 
 lemma tsum_coe_ne_top_iff_summable {f : β → ℝ≥0} :
-  (∑' b, (f b:ennreal)) ≠ ∞ ↔ summable f :=
+  ∑' b, (f b:ennreal) ≠ ∞ ↔ summable f :=
 begin
   refine ⟨λ h, _, λ h, ennreal.coe_tsum h ▸ ennreal.coe_ne_top⟩,
   lift (∑' b, (f b:ennreal)) to ℝ≥0 using h with a ha,
@@ -481,11 +481,11 @@ begin
   exact ennreal.summable.has_sum
 end
 
-protected lemma tsum_eq_supr_sum : (∑'a, f a) = (⨆s:finset α, ∑ a in s, f a) :=
+protected lemma tsum_eq_supr_sum : ∑'a, f a = (⨆s:finset α, ∑ a in s, f a) :=
 ennreal.has_sum.tsum_eq
 
 protected lemma tsum_eq_supr_sum' {ι : Type*} (s : ι → finset α) (hs : ∀ t, ∃ i, t ⊆ s i) :
-  (∑' a, f a) = ⨆ i, ∑ a in s i, f a :=
+  ∑' a, f a = ⨆ i, ∑ a in s i, f a :=
 begin
   rw [ennreal.tsum_eq_supr_sum],
   symmetry,
@@ -494,55 +494,55 @@ begin
 end
 
 protected lemma tsum_sigma {β : α → Type*} (f : Πa, β a → ennreal) :
-  (∑'p:Σa, β a, f p.1 p.2) = (∑'a b, f a b) :=
+  ∑'p:Σa, β a, f p.1 p.2 = ∑'a b, f a b :=
 tsum_sigma' (assume b, ennreal.summable) ennreal.summable
 
 protected lemma tsum_sigma' {β : α → Type*} (f : (Σ a, β a) → ennreal) :
-  (∑'p:(Σa, β a), f p) = (∑'a b, f ⟨a, b⟩) :=
+  ∑'p:(Σa, β a), f p = ∑'a b, f ⟨a, b⟩ :=
 tsum_sigma' (assume b, ennreal.summable) ennreal.summable
 
-protected lemma tsum_prod {f : α → β → ennreal} : (∑'p:α×β, f p.1 p.2) = (∑'a, ∑'b, f a b) :=
+protected lemma tsum_prod {f : α → β → ennreal} : ∑'p:α×β, f p.1 p.2 = ∑'a, ∑'b, f a b :=
 tsum_prod' ennreal.summable $ λ _, ennreal.summable
 
-protected lemma tsum_comm {f : α → β → ennreal} : (∑'a, ∑'b, f a b) = (∑'b, ∑'a, f a b) :=
+protected lemma tsum_comm {f : α → β → ennreal} : ∑'a, ∑'b, f a b = ∑'b, ∑'a, f a b :=
 tsum_comm' ennreal.summable (λ _, ennreal.summable) (λ _, ennreal.summable)
 
-protected lemma tsum_add : (∑'a, f a + g a) = (∑'a, f a) + (∑'a, g a) :=
+protected lemma tsum_add : ∑'a, (f a + g a) = (∑'a, f a) + (∑'a, g a) :=
 tsum_add ennreal.summable ennreal.summable
 
-protected lemma tsum_le_tsum (h : ∀a, f a ≤ g a) : (∑'a, f a) ≤ (∑'a, g a) :=
+protected lemma tsum_le_tsum (h : ∀a, f a ≤ g a) : ∑'a, f a ≤ ∑'a, g a :=
 tsum_le_tsum h ennreal.summable ennreal.summable
 
 protected lemma sum_le_tsum {f : α → ennreal} (s : finset α) : ∑ x in s, f x ≤ ∑' x, f x :=
 sum_le_tsum s (λ x hx, zero_le _) ennreal.summable
 
 protected lemma tsum_eq_supr_nat' {f : ℕ → ennreal} {N : ℕ → ℕ} (hN : tendsto N at_top at_top) :
-  (∑'i:ℕ, f i) = (⨆i:ℕ, ∑ a in finset.range (N i), f a) :=
+  ∑'i:ℕ, f i = (⨆i:ℕ, ∑ a in finset.range (N i), f a) :=
 ennreal.tsum_eq_supr_sum' _ $ λ t,
   let ⟨n, hn⟩    := t.exists_nat_subset_range,
       ⟨k, _, hk⟩ := exists_le_of_tendsto_at_top hN 0 n in
   ⟨k, finset.subset.trans hn (finset.range_mono hk)⟩
 
 protected lemma tsum_eq_supr_nat {f : ℕ → ennreal} :
-  (∑'i:ℕ, f i) = (⨆i:ℕ, ∑ a in finset.range i, f a) :=
+  ∑'i:ℕ, f i = (⨆i:ℕ, ∑ a in finset.range i, f a) :=
 ennreal.tsum_eq_supr_sum' _ finset.exists_nat_subset_range
 
-protected lemma le_tsum (a : α) : f a ≤ (∑'a, f a) :=
+protected lemma le_tsum (a : α) : f a ≤ ∑'a, f a :=
 le_tsum' ennreal.summable a
 
-protected lemma tsum_eq_top_of_eq_top : (∃ a, f a = ∞) → (∑' a, f a) = ∞
+protected lemma tsum_eq_top_of_eq_top : (∃ a, f a = ∞) → ∑' a, f a = ∞
 | ⟨a, ha⟩ := top_unique $ ha ▸ ennreal.le_tsum a
 
-protected lemma ne_top_of_tsum_ne_top (h : (∑' a, f a) ≠ ∞) (a : α) : f a ≠ ∞ :=
+protected lemma ne_top_of_tsum_ne_top (h : ∑' a, f a ≠ ∞) (a : α) : f a ≠ ∞ :=
 λ ha, h $ ennreal.tsum_eq_top_of_eq_top ⟨a, ha⟩
 
-protected lemma tsum_mul_left : (∑'i, a * f i) = a * (∑'i, f i) :=
+protected lemma tsum_mul_left : ∑'i, a * f i = a * ∑'i, f i :=
 if h : ∀i, f i = 0 then by simp [h] else
 let ⟨i, (hi : f i ≠ 0)⟩ := not_forall.mp h in
-have sum_ne_0 : (∑'i, f i) ≠ 0, from ne_of_gt $
+have sum_ne_0 : ∑'i, f i ≠ 0, from ne_of_gt $
   calc 0 < f i : lt_of_le_of_ne (zero_le _) hi.symm
-    ... ≤ (∑'i, f i) : ennreal.le_tsum _,
-have tendsto (λs:finset α, ∑ j in s, a * f j) at_top (𝓝 (a * (∑'i, f i))),
+    ... ≤ ∑'i, f i : ennreal.le_tsum _,
+have tendsto (λs:finset α, ∑ j in s, a * f j) at_top (𝓝 (a * ∑'i, f i)),
   by rw [← show (*) a ∘ (λs:finset α, ∑ j in s, f j) = λs, ∑ j in s, a * f j,
          from funext $ λ s, finset.mul_sum];
   exact ennreal.tendsto.const_mul ennreal.summable.has_sum (or.inl sum_ne_0),
@@ -552,7 +552,7 @@ protected lemma tsum_mul_right : (∑'i, f i * a) = (∑'i, f i) * a :=
 by simp [mul_comm, ennreal.tsum_mul_left]
 
 @[simp] lemma tsum_supr_eq {α : Type*} (a : α) {f : α → ennreal} :
-  (∑'b:α, ⨆ (h : a = b), f b) = f a :=
+  ∑'b:α, (⨆ (h : a = b), f b) = f a :=
 le_antisymm
   (by rw [ennreal.tsum_eq_supr_sum]; exact supr_le (assume s,
     calc (∑ b in s, ⨆ (h : a = b), f b) ≤ ∑ b in {a}, ⨆ (h : a = b), f b :
@@ -573,11 +573,11 @@ begin
   { exact assume s t hst, finset.sum_le_sum_of_subset (finset.range_subset.2 hst) }
 end
 
-lemma to_nnreal_apply_of_tsum_ne_top {α : Type*} {f : α → ennreal} (hf : (∑' i, f i) ≠ ∞) (x : α) :
+lemma to_nnreal_apply_of_tsum_ne_top {α : Type*} {f : α → ennreal} (hf : ∑' i, f i ≠ ∞) (x : α) :
   (((ennreal.to_nnreal ∘ f) x : ℝ≥0) : ennreal) = f x :=
 coe_to_nnreal $ ennreal.ne_top_of_tsum_ne_top hf _
 
-lemma summable_to_nnreal_of_tsum_ne_top {α : Type*} {f : α → ennreal} (hf : (∑' i, f i) ≠ ∞) :
+lemma summable_to_nnreal_of_tsum_ne_top {α : Type*} {f : α → ennreal} (hf : ∑' i, f i ≠ ∞) :
   summable (ennreal.to_nnreal ∘ f) :=
 by simpa only [←tsum_coe_ne_top_iff_summable, to_nnreal_apply_of_tsum_ne_top hf] using hf
 
@@ -585,10 +585,10 @@ protected lemma tsum_apply {ι α : Type*} {f : ι → α → ennreal} {x : α} 
   (∑' i, f i) x = ∑' i, f i x :=
 tsum_apply $ pi.summable.mpr $ λ _, ennreal.summable
 
-lemma tsum_sub {f : ℕ → ennreal} {g : ℕ → ennreal} (h₁ : (∑' i, g i) < ∞) (h₂ : g ≤ f) :
-  (∑' i, (f i - g i)) = (∑' i, f i) - (∑' i, g i) :=
+lemma tsum_sub {f : ℕ → ennreal} {g : ℕ → ennreal} (h₁ : ∑' i, g i < ∞) (h₂ : g ≤ f) :
+  ∑' i, (f i - g i) = (∑' i, f i) - (∑' i, g i) :=
 begin
-  have h₃:(∑' i, (f i - g i)) = (∑' i, (f i - g i) + (g i))-(∑' i, g i),
+  have h₃: ∑' i, (f i - g i) = ∑' i, (f i - g i + g i) - ∑' i, g i,
   { rw [ennreal.tsum_add, add_sub_self h₁]},
   have h₄:(λ i, (f i - g i) + (g i)) = f,
   { ext n, rw ennreal.sub_add_cancel_of_le (h₂ n)},
@@ -606,7 +606,7 @@ open_locale nnreal
 /-- Comparison test of convergence of `ℝ≥0`-valued series. -/
 lemma exists_le_has_sum_of_le {f g : β → ℝ≥0} {r : ℝ≥0}
   (hgf : ∀b, g b ≤ f b) (hfr : has_sum f r) : ∃p≤r, has_sum g p :=
-have (∑'b, (g b : ennreal)) ≤ r,
+have ∑'b, (g b : ennreal) ≤ r,
 begin
   refine has_sum_le (assume b, _) ennreal.summable.has_sum (ennreal.has_sum_coe.2 hfr),
   exact ennreal.coe_le_coe.2 (hgf _)
@@ -652,11 +652,11 @@ begin
 end
 
 lemma tsum_le_of_sum_range_le {f : ℕ → ℝ≥0} {c : ℝ≥0}
-  (h : ∀ n, ∑ i in finset.range n, f i ≤ c) : (∑' n, f n) ≤ c :=
+  (h : ∀ n, ∑ i in finset.range n, f i ≤ c) : ∑' n, f n ≤ c :=
 le_of_tendsto' (has_sum_iff_tendsto_nat.1 (summable_of_sum_range_le h).has_sum) h
 
 lemma tsum_comp_le_tsum_of_inj {β : Type*} {f : α → ℝ≥0} (hf : summable f)
-  {i : β → α} (hi : function.injective i) : (∑' x, f (i x)) ≤ ∑' x, f x :=
+  {i : β → α} (hi : function.injective i) : ∑' x, f (i x) ≤ ∑' x, f x :=
 tsum_le_tsum_of_inj i hi (λ c hc, zero_le _) (λ b, le_refl _) (summable_comp_injective hf hi) hf
 
 lemma summable_sigma {β : Π x : α, Type*} {f : (Σ x, β x) → ℝ≥0} :
@@ -685,10 +685,10 @@ end nnreal
 
 namespace ennreal
 
-lemma tendsto_sum_nat_add (f : ℕ → ennreal) (hf : (∑' i, f i) ≠ ∞) :
+lemma tendsto_sum_nat_add (f : ℕ → ennreal) (hf : ∑' i, f i ≠ ∞) :
   tendsto (λ i, ∑' k, f (k + i)) at_top (𝓝 0) :=
 begin
-  have : ∀ i, (∑' k, (((ennreal.to_nnreal ∘ f) (k + i) : ℝ≥0) : ennreal)) =
+  have : ∀ i, ∑' k, (((ennreal.to_nnreal ∘ f) (k + i) : ℝ≥0) : ennreal) =
     (∑' k, (ennreal.to_nnreal ∘ f) (k + i) : ℝ≥0) :=
     λ i, (ennreal.coe_tsum
       (nnreal.summable_nat_add _ (summable_to_nnreal_of_tsum_ne_top hf) _)).symm,
@@ -752,7 +752,7 @@ begin
 end
 
 lemma tsum_le_of_sum_range_le {f : ℕ → ℝ} {c : ℝ} (hf : ∀ n, 0 ≤ f n)
-  (h : ∀ n, ∑ i in finset.range n, f i ≤ c) : (∑' n, f n) ≤ c :=
+  (h : ∀ n, ∑ i in finset.range n, f i ≤ c) : ∑' n, f n ≤ c :=
 le_of_tendsto' ((has_sum_iff_tendsto_nat_of_nonneg hf _).1
   (summable_of_sum_range_le hf h).has_sum) h
 

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -82,12 +82,12 @@ end
 
 open_locale classical big_operators
 
-@[norm_cast] lemma coe_tsum {f : α → ℝ≥0} : ↑(∑'a, f a) = (∑'a, (f a : ℝ)) :=
+@[norm_cast] lemma coe_tsum {f : α → ℝ≥0} : ↑∑'a, f a = ∑'a, (f a : ℝ) :=
 if hf : summable f
 then (eq.symm $ (has_sum_coe.2 $ hf.has_sum).tsum_eq)
 else by simp [tsum, hf, mt summable_coe.1 hf]
 
-lemma tsum_mul_left (a : ℝ≥0) (f : α → ℝ≥0) : (∑' x, a * f x) = a * ∑' x, f x :=
+lemma tsum_mul_left (a : ℝ≥0) (f : α → ℝ≥0) : ∑' x, a * f x = a * ∑' x, f x :=
 nnreal.eq $ by simp only [coe_tsum, nnreal.coe_mul, tsum_mul_left]
 
 lemma tsum_mul_right (f : α → ℝ≥0) (a : ℝ≥0) : (∑' x, f x * a) = (∑' x, f x) * a :=
@@ -109,7 +109,7 @@ begin
 end
 
 lemma sum_add_tsum_nat_add {f : ℕ → ℝ≥0} (k : ℕ) (hf : summable f) :
-  (∑' i, f i) = (∑ i in range k, f i) + ∑' i, f (i + k) :=
+  ∑' i, f i = (∑ i in range k, f i) + ∑' i, f (i + k) :=
 by rw [←nnreal.coe_eq, coe_tsum, nnreal.coe_add, coe_sum, coe_tsum,
   sum_add_tsum_nat_add k (nnreal.summable_coe.2 hf)]
 


### PR DESCRIPTION
This saves us a lot of `()`
In particular, lean no longer thinks that `∑' i, f i = 37` is a tsum of propositions.



---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->