### PR TITLE
feat(meta): Assignable datatypes and expression zippers

### DIFF
--- a/src/control/alternative.lean
+++ b/src/control/alternative.lean
@@ -1,0 +1,37 @@
+import control.fold
+
+universes u v
+
+namespace alternative
+
+  section
+    variables  {T S : Type u → Type u} [applicative T] [alternative S]
+    instance : alternative (T ∘ S) :=
+    { pure    := λ α x, (pure (pure x) : T (S _)),
+      failure := λ x, (pure $ failure : T (S _)),
+      seq     := λ α β f x, show T(S β), from pure (<*>) <*> f <*> x,
+      orelse  := λ α a b, show T(S α), from pure (<|>) <*> a <*> b
+    }
+  end
+
+  variables {T : Type u → Type v} [alternative T] {α β : Type u}
+
+  def returnopt : option α → T α
+  | none := failure
+  | (some x) := pure x
+
+  def optreturn : T α → T (option α)
+  | t := (some <$> t) <|> (pure none)
+
+  def is_ok {T : Type → Type v} [alternative T] {α : Type}:  T α → T (bool)
+  | t := (t *> pure (tt)) <|> pure (ff)
+
+  def mguard {T : Type → Type v} [alternative T] [monad T]: T bool → T unit
+  | c := do b ← c, if b then pure () else failure
+
+  variables [monad T]
+
+  meta def repeat (t : T α) : T (list α) :=
+  (pure list.cons <*> t <*> (pure punit.star >>= λ _, repeat)) <|> pure []
+
+end alternative

--- a/src/control/except.lean
+++ b/src/control/except.lean
@@ -1,0 +1,14 @@
+universes u v
+
+def except.flip {ε : Type u} {α : Type v} : except ε α → except α ε
+| e := except.rec except.ok except.error e
+
+instance monad_except.of_statet {ε σ} {m : Type → Type} [monad m] [monad_except ε m] : monad_except ε (state_t σ m) :=
+{ throw := λ α e, state_t.lift $ throw e
+, catch := λ α S e, ⟨λ s, catch (state_t.run S s) (λ x, state_t.run (e x) s)⟩ -- [note] alternatively, you could propagate the state.
+}
+
+instance monad_except.alt {ε} [inhabited ε] {m : Type → Type} [monad m] [monad_except ε m] : alternative m :=
+{ failure := λ α,throw $ inhabited.default ε
+, orelse := λ α x y, monad_except.orelse x y
+}

--- a/src/data/list/zipper.lean
+++ b/src/data/list/zipper.lean
@@ -1,0 +1,184 @@
+/- © E.W.Ayers 2019 -/
+import control.traversable
+import data.list
+
+universes u v
+
+/-- A list zipper represents a list and a 'cursor' at a particular point in the list. -/
+@[derive decidable_eq]
+structure list.zipper (α : Type u) :=
+(left : list α)
+(right : list α)
+
+namespace list.zipper
+
+open list
+
+variables {α : Type u}
+
+local notation `lz` := list.zipper α
+
+instance : has_emptyc lz := ⟨⟨[],[]⟩⟩
+
+/-- Get the list at the cursor of the zipper. -/
+def cursor : lz → list α
+| ⟨l,r⟩ := r
+
+/-- Set the list at the cursor of the zipper. -/
+def set : list α → lz → lz
+| r ⟨l, _⟩ := ⟨l,r⟩
+
+/-- Map the cursor list. -/
+def map_cursor (f : list α → list α) : lz → lz
+| ⟨l, r⟩ := ⟨l, f r⟩
+
+/-- Move the cursor up one list element. -/
+def up : lz → option lz
+| ⟨h::l,r⟩ := some ⟨l,h::r⟩ | _ := none
+
+/-- Move the cursor down one list element. -/
+def down  : lz → option lz
+| ⟨l,h::r⟩ := some ⟨h::l,r⟩ | _ := none
+
+/-- Apply cons to the cursor. -/
+def cons : α → lz → lz
+|a ⟨l,r⟩ := ⟨l,a::r⟩
+
+/-- Apply cons to the cursor and go down. -/
+def cons_down : α → lz → lz
+| a ⟨l,r⟩ := ⟨a::l,r⟩
+
+/-- Get the path of the zipper. That is, a reversed list of the entries above the cursor. -/
+def path : lz → list α
+| ⟨l,_⟩ := l
+
+/-- Pop the head of the cursor. -/
+def decons : lz → option (α × lz)
+| ⟨l,a::r⟩ := some (a,⟨l,r⟩) | _ := none
+
+/-- Return the tail of the cursor. -/
+def tail : lz → option (list α)
+| ⟨_, _::t⟩ := some t | _ := none
+
+/-- Return the head of the cursor. -/
+def head : lz → option α
+| ⟨l, a::_⟩ := some a | _ := none
+
+/-- Get the length of the whole list. -/
+def length : lz → nat
+| ⟨l,r⟩ := l.length + r.length
+
+/-- Perform `up` n times. If the zipper is already at the top then return none. -/
+def n_up : nat → lz → option lz
+|0 z := z |(n+1) z := up z >>= n_up n
+
+/-- Perform `down` n times. If the zipper reaches the bottom then return none. -/
+def n_down : nat → lz → option lz
+|0 z := z |(n+1) z := down z >>= n_down n
+
+/-- If the given integer is positive then move down else move up. Returns none if it moves out of range. -/
+def move : int → lz → option lz
+|(int.of_nat n) z := n_down n z
+|(-[1+n]) z := n_up (n+1) z
+
+/-- Check if the cursor is the entire list. -/
+def is_top : lz → bool
+| ⟨[],r⟩ := tt | _ := ff
+
+/-- Check if the cursor is empty. -/
+def is_bottom : lz → bool
+| ⟨_,[]⟩ := tt | _ := ff
+
+/-- Check if the entire list is empty. -/
+def empty : lz → bool
+| ⟨[],[]⟩ := tt | _ := ff
+
+/-- Go up until you hit the top. -/
+def top : lz → lz
+| ⟨l,r⟩ := ⟨[], list.reverse_core l r⟩
+
+/-- Go down until you hit the bottom. -/
+def bottom : lz → lz
+| ⟨l,r⟩ := ⟨list.reverse_core r l, []⟩
+
+/-- How far down the list are you? -/
+def depth : lz → nat
+|⟨l,_⟩ := list.length l
+
+/-- Move the zipper to the given index. Returns none if `index > z.length`-/
+def goto  : nat → lz → option lz
+| i z := move ((i : ℤ) - (depth z : ℤ)) z
+
+/-- Convert a list to a zipper at the top of the list. -/
+def zip : list α → lz
+| l := ⟨[],l⟩
+
+/-- Convert a zipper back to a list. -/
+def unzip : lz → list α
+| ⟨l,r⟩ := list.reverse_core l r
+
+/-- Map a zipper. -/
+protected def map {α : Type u} {β : Type v} (f : α → β) : zipper α → zipper β
+| ⟨l,r⟩ := ⟨list.map f l, list.map f r⟩
+
+instance : functor zipper := { map := @zipper.map }
+
+/-- Mmap a zipper-/
+def mmap {m : Type u → Type u} [monad m] {α : Type u} {β : Type u} (f : α → m β) : list.zipper α → m (list.zipper β)
+| ⟨l,r⟩ := pure list.zipper.mk <*> list.mmap f l <*> list.mmap f r
+
+/-- Map the path with index. Index is from cursor, so the path entry closest to the cursor gets index argument of 0. -/
+def map_with_index_path (f : nat → α → α) : lz → lz
+| ⟨l,r⟩ := ⟨list.map_with_index f l, r⟩
+
+/-- `pinch i l` removes the `i`th entry of the list and returns that entry
+and a list zipper with the cursor at the point where the entry was removed. -/
+def pinch : nat → list α → option (α × lz)
+| n l := (n_down n $ zip l) >>= decons
+
+/-- Reverse of `pinch`. Cons an element at the cursor and unzip. -/
+def unpinch : α → lz → list α
+| a z := unzip $ cons a z
+
+/-- `pinch` the last element in the list. -/
+def pinch_last : list α → option (α × lz)
+| l := (up $ bottom $ zip l) >>= decons
+
+def reverse : lz → lz
+| ⟨l, r⟩ := ⟨r.reverse, l.reverse⟩
+
+def pinch_all_core : list α → list α → list (α × lz)
+| l [] := []
+| l (h :: r) := (h, ⟨l,r⟩) :: pinch_all_core (h::l) (r)
+
+/-- Return pinches for all the elements of the given list. -/
+def pinch_all : list α → list (α × lz) := pinch_all_core []
+
+instance : traversable list.zipper :=
+⟨λ t m α β f z, begin unfreezingI { exact pure list.zipper.mk <*> traverse f z.left <*> traverse f z.right} end⟩
+
+protected def repr [has_repr α] : lz → string
+| ⟨l,r⟩ := "⟨" ++ l.repr ++ ", " ++ r.repr ++ "⟩"
+
+instance [has_repr α]: has_repr lz :=
+⟨λ z, list.zipper.repr z⟩
+
+protected def to_string [has_to_string α] : lz → string
+| ⟨l,r⟩ :=
+  let lp := string.intercalate ", " $ list.map _root_.to_string $ list.reverse $ l in
+  let rp := string.intercalate ", " $ list.map _root_.to_string $ r in
+  "[" ++ lp ++ ",| " ++ rp ++ "]"
+
+instance [has_to_string α]: has_to_string lz :=
+⟨λ z, list.zipper.to_string z⟩
+
+protected meta def pp [has_to_tactic_format α] : lz → tactic format
+| ⟨l,r⟩ := do
+  lp ← list.mmap tactic.pp $ list.reverse l,
+  rp ← list.mmap tactic.pp $ r,
+  pure $ "[" ++ (format.intercalate ", " lp) ++ ",| " ++ (format.intercalate ", " rp) ++ "]"
+
+meta instance [has_to_tactic_format α]: has_to_tactic_format lz :=
+⟨λ z, list.zipper.pp z⟩
+
+end list.zipper

--- a/src/data/list/zipper.lean
+++ b/src/data/list/zipper.lean
@@ -1,6 +1,5 @@
 /- © E.W.Ayers 2019 -/
 import control.traversable
-import data.list
 
 universes u v
 

--- a/src/data/sum.lean
+++ b/src/data/sum.lean
@@ -95,10 +95,10 @@ protected def elim {α β γ : Sort*} (f : α → γ) (g : β → γ) : α ⊕ �
 
 @[simp] lemma elim_comp_inl {α β γ : Sort*} (f : α → γ) (g : β → γ) :
   sum.elim f g ∘ inl = f := rfl
-  
+
 @[simp] lemma elim_comp_inr {α β γ : Sort*} (f : α → γ) (g : β → γ) :
   sum.elim f g ∘ inr = g := rfl
-  
+
 @[simp] lemma elim_inl_inr {α β : Sort*} :
   @sum.elim α β _ inl inr = id :=
 funext $ λ x, sum.cases_on x (λ _, rfl) (λ _, rfl)

--- a/src/meta/assignable.lean
+++ b/src/meta/assignable.lean
@@ -1,0 +1,209 @@
+import data.list.zipper meta.telescope algebra.free_monoid control.monad.writer
+
+private meta def run_inside_lambda (f : expr → expr) : telescope → expr → expr
+| [] e := f e
+| ((binder.mk n bi y) :: rest) e := expr.lambda_body $ run_inside_lambda rest $ expr.lam n bi y e
+
+/- A type α is assignable when you can run a monad over it with expressions. -/
+meta class assignable (α : Type) :=
+(mmap_children
+  {t : Type → Type}
+  [monad t]
+  (f : telescope → expr → t expr)
+  : telescope → α → t α)
+
+namespace assignable
+
+open assignable
+variables {α : Type} [assignable α]
+
+meta def get_children : α → list (telescope × expr)
+| a :=
+  let z :=
+    writer_t.run
+    $ @mmap_children α _
+        (writer (free_monoid (telescope × expr))) _
+        (λ bs e, tell [(bs, e)] *> pure e) [] a in
+  prod.snd z
+
+meta def fold_children {β} (f : β → telescope → expr → β) : β → α → β
+| b a := list.foldl (λ b p, f b (prod.fst p) (prod.snd p)) b $ get_children a
+
+meta def map_children (f : telescope → expr → expr) (a : α) : α :=
+@mmap_children α _ id _ f [] a
+
+meta def instantiate_mvars : α → tactic α :=
+mmap_children (λ bs e, tactic.instantiate_mvars e) []
+
+meta def tc.instantiate_mvars : α → tactic.unsafe.type_context α :=
+mmap_children (λ bs e, tactic.unsafe.type_context.instantiate_mvars e) []
+
+meta def lower_vars : α → nat → nat → α
+| a s d := map_children (λ bs e, expr.lower_vars e (s + bs.length) d) a
+
+meta def lift_vars : α → nat → nat → α
+| a s d := map_children (λ bs e, expr.lift_vars e (s + bs.length) d) a
+
+meta def get_free_var_range : α → nat
+| a := list.foldl max 0  $ list.map (list.length ∘ prod.fst)  $ get_children a
+
+meta def has (p : telescope × expr → Prop) [decidable_pred p] : α → bool
+| a := list.foldl bor ff $ list.map (λ q, to_bool $ p q) $ get_children a
+
+meta def has_var : α → bool :=
+has (λ p, expr.get_free_var_range p.2 > p.1.length)
+
+meta def has_var_idx : α → nat → bool
+| a n := has (λ p, expr.has_var_idx p.2 (n + p.1)) a
+
+meta def has_local : α → bool :=
+has (λ p, expr.has_local p.2)
+
+meta def has_meta_var : α → bool :=
+has (λ p, expr.has_meta_var p.2)
+
+meta def abstract_local : α → name → α
+| a n := map_children (run_inside_lambda (λ e, expr.abstract_local e n)) a
+
+meta def abstract_locals : α → list name → α
+| a n := map_children (run_inside_lambda (λ e, expr.abstract_locals e n)) a
+
+meta def abstract_mvar : α → name → α
+| a n := map_children (λ Γ x, expr.abstract_mvar Γ.length x n) a
+
+meta def instantiate_nth : nat → α → expr → α
+| n a r :=
+  if get_free_var_range a ≤ n then a else
+  map_children (λ t x,
+      let fvr := expr.get_free_var_range x in
+      if expr.get_free_var_range x ≤ t.length + n then x else
+      expr.instantiate_nth_var (t.length + n) x (expr.lift_vars r (t.length) 0)
+    ) a
+
+meta def instantiate_vars : α → list expr → α
+| a xs := map_children (λ t e, expr.instantiate_vars_core e t.length xs) a
+
+meta def instantiate_var : α → expr → α
+| a x := instantiate_vars a [x]
+
+meta def instantiate_locals (s : list (name × expr)) (e : α) : α :=
+instantiate_vars (abstract_locals e (list.reverse (list.map prod.fst s))) (list.map prod.snd s)
+
+meta def replace (a : α) (f : expr → nat → option expr) : α :=
+map_children (λ t e, expr.replace e $ λ e n, f e $ n + t.length) a
+
+notation Γ` ⍄ `f := assignable.mmap_children f Γ
+
+variables {β : Type} [assignable β]
+open tactic.unsafe
+
+/- attach the binder b to the context, perform the function, then pop and abstract the local. -/
+meta def with_local (b : binder) : (expr → α → type_context β) → (α → type_context β)
+| f a := do
+  h ← binder.push_local b,
+  b ← f h $ assignable.instantiate_var a h,
+  type_context.pop_local,
+  pure $ assignable.abstract_local b $ expr.local_uniq_name h
+
+meta def has_local_constant : expr → α → bool
+| x := has (λ p, expr.has_local_constant p.2 x)
+
+meta def has_mvar : expr → α → bool
+| x := has (λ p, expr.has_meta_var x && expr.has_mvar p.2 x)
+
+end assignable
+
+meta instance expr.assignable : assignable expr :=
+{mmap_children := λ t _ f Γ e, f Γ e }
+
+meta def assignable_of_traversable {t : Type → Type} [traversable t] {α : Type} [assignable α] : assignable (t α) :=
+⟨λ m mt f Γ ta, begin unfreezingI {refine traverse (assignable.mmap_children f Γ) ta} end⟩
+
+meta instance list.assignable {α : Type} [assignable α] : assignable (list α) :=
+{mmap_children := λ t mt f Γ l, @list.mmap t mt _ _ (@assignable.mmap_children _ _ t mt f Γ) l}
+meta instance list.zipper.assignable {α : Type} [assignable α] : assignable (list.zipper α) := assignable_of_traversable
+
+meta instance prod.assignable {α β : Type} [assignable α] [assignable β] : assignable (α × β) :=
+{mmap_children := λ t [mt:monad t] f Γ l,
+  begin unfreezingI {
+      exact pure prod.mk <*> assignable.mmap_children f Γ l.1 <*> assignable.mmap_children f Γ l.2,
+} end}
+
+meta def binder.mmap_children {t : Type → Type} [monad t] (f : telescope → expr → t expr) : telescope → binder → t binder
+| Γ ⟨n, bi, y⟩ := pure (binder.mk n bi) <*> f Γ y
+
+meta def cotelescope.mmap_children {t : Type → Type} [monad t] (f : telescope → expr → t expr) : telescope → cotelescope → t cotelescope
+| Γ [] := pure []
+| Γ (b :: tail) := do
+  b ← binder.mmap_children f Γ b,
+  pure (list.cons b) <*> cotelescope.mmap_children (b::Γ) tail
+
+meta def telescope.mmap_children  {t : Type → Type} [monad t] (f : telescope → expr → t expr) : telescope → telescope → t telescope
+| Γ bs := list.reverse <$> (cotelescope.mmap_children f Γ $ bs.reverse)
+
+meta instance binder.assignable : assignable binder := ⟨@binder.mmap_children⟩
+
+meta instance telescope.assignable : assignable (telescope) :=
+{mmap_children := @telescope.mmap_children}
+
+meta instance cotelescope.assignable : assignable (cotelescope) :=
+{mmap_children := @cotelescope.mmap_children}
+
+meta def cotelescope.to_telescope : cotelescope → telescope := list.reverse
+
+meta def telescope.to_metas : telescope → tactic (list expr)
+| c := do
+    c.mfoldr (λ ⟨n, bi, y⟩ acc, do
+      m ← tactic.mk_meta_var (expr.instantiate_vars y acc),
+      pure $ m :: acc
+    ) []
+
+meta instance telescope.pp : has_to_tactic_format telescope :=
+⟨λ x, format.join <$> list.intersperse " " <$> list.mmap tactic.pp x.reverse⟩
+
+/-- Makes an app such that `telescope.of_pis (telescope.mk_app t x) t` η-reduces to `x`  -/
+meta def telescope.mk_app : telescope → expr → expr
+| t e := expr.mk_app e $ list.reverse $ t.map_with_index (λ i _, expr.var i)
+
+meta def cotelescope.mk_locals_core : cotelescope → list expr → local_context → option (list expr × local_context)
+| [] acc lc := pure (acc, lc)
+| (⟨n,bi,y⟩ :: t) acc lc := do
+  y ← pure $ expr.instantiate_vars y acc,
+  (l, lc) ← local_context.mk_local n y bi lc,
+  cotelescope.mk_locals_core t (l::acc) lc
+
+meta def telescope.mk_locals : telescope → local_context → option (list expr × local_context)
+| t lc := cotelescope.mk_locals_core t.reverse [] lc
+
+open expr
+
+meta def expr.traverse_with_depth {m : Type → Type} [applicative m]
+(f : telescope → expr → m (expr)) :
+  telescope → expr → m (expr)
+ | Γ (var v)  := pure $ var v
+ | Γ (sort l) := pure $ sort l
+ | Γ (const n ls) := pure $ const n ls
+ | Γ (mvar n n' e) := mvar n n' <$> f Γ e
+ | Γ (local_const n n' bi e) := local_const n n' bi <$> f Γ e
+ | Γ (app e₀ e₁) := app <$> f Γ e₀ <*> f Γ e₁
+ | Γ (lam n bi e₀ e₁) := lam n bi <$> f Γ e₀ <*> f (⟨n, bi,e₀⟩::Γ) e₁
+ | Γ (pi n bi e₀ e₁) := pi n bi <$> f Γ e₀ <*> f (⟨n,bi,e₀⟩::Γ) e₁
+ | Γ (elet n e₀ e₁ e₂) := elet n <$> f Γ e₀ <*> f Γ e₁ <*> f (⟨n,binder_info.default, e₀⟩ :: Γ) e₂
+ | Γ (macro mac es) := macro mac <$> list.traverse (f Γ) es
+
+
+open tactic.unsafe
+
+namespace assignable
+
+variables {α : Type} [assignable α]
+
+meta def kabstract (e : α) (t : expr) (md := reducible) (unify := tt) : tactic α :=
+mmap_children (λ Γ c, tactic.kabstract c t md unify) [] e
+
+meta def depends_on : α → expr → bool
+| a e@(expr.mvar _ _ _) := has_mvar e a
+| a e@(expr.local_const _ _ _ _) := has_local_constant e a
+| a e := ff
+
+end assignable

--- a/src/meta/binder.lean
+++ b/src/meta/binder.lean
@@ -1,0 +1,28 @@
+/- © E.W.Ayers 2019 -/
+import meta.expr
+
+namespace binder
+
+meta def push_local : binder → tactic.unsafe.type_context expr
+| ⟨n, bi, y⟩ := tactic.unsafe.type_context.push_local n y bi
+
+meta def to_mvar : binder → tactic.unsafe.type_context expr
+| ⟨n, bi, y⟩ := tactic.unsafe.type_context.mk_mvar n y
+
+meta def of_mvar : expr → binder
+| (expr.mvar un pn y) := ⟨pn, binder_info.default, y⟩
+| _ := inhabited.default _
+
+meta def to_dummy_mvar : binder → expr
+| ⟨n, b, y⟩ := expr.mvar n n y
+
+meta def to_pi : binder → expr → expr
+| ⟨n, i, y⟩ e := expr.pi n i y e
+
+meta def to_lam : binder → expr → expr
+| ⟨n, i, y⟩ e := expr.lam n i y e
+
+meta def mk_local : binder → tactic expr
+| ⟨n, i, y⟩ := tactic.mk_local' n i y
+
+end binder

--- a/src/meta/expr_zipper.lean
+++ b/src/meta/expr_zipper.lean
@@ -1,0 +1,446 @@
+/- Author: E.W.Ayers © 2019
+-/
+import meta.assignable control.except
+
+open assignable
+
+universes u v
+
+/-!
+A zipper is a structure that lets you navigate through a recursive datastructure such as a list.
+This is a zipper for expressions, but it also does some context management for you so that your algorithms can work under binders.
+http://www.st.cs.uni-sb.de/edu/seminare/2005/advanced-fp/docs/huet-zipper.pdf
+-/
+
+namespace expr
+
+instance coord.dec_lt : decidable_rel ((<) : coord → coord → Prop) :=
+by apply_instance
+
+instance address.has_lt : has_lt address :=
+list.has_lt
+
+instance address.dec_lt : decidable_rel ((<) : address → address → Prop) :=
+list.has_decidable_lt
+
+/-- Checks whether the following the coordinate will cause the context to change. -/
+meta def coord.is_binding : coord → bool
+| coord.pi_body := tt | coord.lam_body := tt | coord.elet_body := tt
+| _ := ff
+
+/-- Returns the set of coordinates that are valid for a given expression. -/
+meta def get_coords : expr → list coord
+| (expr.app  _ _)     := [coord.app_fn, coord.app_arg]
+| (expr.pi   _ _ _ _) := [coord.pi_var_type, coord.pi_body]
+| (expr.lam  _ _ _ _) := [coord.lam_var_type, coord.lam_body]
+| (expr.elet _ _ _ _) := [coord.elet_var_type, coord.elet_assignment, coord.elet_body]
+| _ := []
+
+/-- Perform `g` on the subexpression specified by the coordinate and return the parent expression with this modified child.
+The list of binders provided to `g` has the most recently followed binder as the head,
+so `expr.var 0` corresponds to the head of the binder list. -/
+meta def expr.coord.modify {t} [alternative t] (g : telescope → expr → t expr): coord → expr → t expr
+| (coord.app_fn)          (expr.app f a)         := pure expr.app <*> g [] f <*> pure a
+| (coord.app_arg)         (expr.app f a)         := pure expr.app <*> pure f <*> g [] a
+| (coord.lam_var_type)    (expr.lam  n bi y   b) := pure (expr.lam n bi) <*> g [] y <*> pure b
+| (coord.lam_body)        (expr.lam  n bi y   b) := pure (expr.lam n bi) <*> pure y <*> g [⟨n, bi, y⟩] b
+| (coord.pi_var_type)     (expr.pi   n bi y   b) := pure (expr.pi n bi)  <*> g [] y <*> pure b
+| (coord.pi_body)         (expr.pi   n bi y   b) := pure (expr.pi n bi)  <*> pure y <*> g [⟨n, bi, y⟩] b
+| (coord.elet_var_type)   (expr.elet n    y a b) := pure (expr.elet n)   <*> g [] a <*> pure a <*> pure b
+| (coord.elet_assignment) (expr.elet n    y a b) := pure (expr.elet n)   <*> pure y <*> g [] a <*> pure b
+| (coord.elet_body)       (expr.elet n    y a b) := pure (expr.elet n)   <*> pure y <*> pure a <*> g [⟨n,binder_info.default,y⟩] b
+| _                       _                      := failure
+
+/-- Returns the subexpression, if any, at the position given by the coordinate argument. -/
+meta def expr.coord.follow : coord → expr → option expr
+| c e :=
+    let r := (@except_t.run (option expr) id expr (expr.coord.modify (λ Γ e, throw e) c e)) in
+    none <| except.to_option $ except.flip $ r
+
+meta def expr.address.follow : address → expr → option expr
+| (c :: rest) e := expr.coord.follow c e >>= expr.address.follow rest
+| [] e := pure e
+
+meta def expr.address.modify_core {t} [alternative t] (g : list binder → expr → t expr) : list binder → address → expr → t expr
+| bs []     e := g bs e
+| bs (h::t) e := expr.coord.modify (λ bs' s, expr.address.modify_core (bs' ++ bs) t s) h e
+
+meta def expr.address.modify {t} [alternative t] (g : list binder → expr → t expr) : address → expr → t expr :=
+expr.address.modify_core g []
+
+/-- expr.replace r a o will replace the subexpression of `o` at position `a` with `r`. If `a` is not a valid address it will return `none`. -/
+meta def expr.replace : expr → address → expr → option expr
+| r := expr.address.modify (λ _ _, some r)
+
+namespace zipper
+    namespace path
+        /-- An item in a zipper path. See  -/
+        @[derive decidable_eq]
+        meta inductive entry
+        |app_fn          (fn : unit) (arg : expr) : entry
+        |app_arg         (fn : expr) (arg : unit) : entry
+        |lam_var_type    (var_name : name) (bi : binder_info) (var_type : unit) (body : expr) : entry
+        |lam_body        (var_name : name) (bi : binder_info) (var_type : expr) (body : unit) : entry
+        |pi_var_type     (var_name : name) (bi : binder_info) (var_type : unit) (body : expr) : entry
+        |pi_body         (var_name : name) (bi : binder_info) (var_type : expr) (body : unit) : entry
+        |elet_var_type   (var_name : name) (type : unit) (assignment : expr)    (body : expr) : entry
+        |elet_assignment (var_name : name) (type : expr) (assignment : unit)    (body : expr) : entry
+        |elet_body       (var_name : name) (type : expr) (assignment : expr)    (body : unit) : entry
+    end path
+    /-- A path is the part of the zipper that remembers the stuff above the zipper's cursor.-/
+    @[inline] meta def path := list expr.zipper.path.entry
+
+    namespace path
+
+        open entry
+
+        meta def entry.to_coord : path.entry → coord
+        |(entry.app_fn _ _)        := coord.app_fn
+        |(entry.app_arg _ _)       := coord.app_arg
+        |(lam_var_type _ _ _ _)    := coord.lam_var_type
+        |(lam_body _ _ _ _)        := coord.lam_body
+        |(pi_var_type _ _ _ _)     := coord.pi_var_type
+        |(pi_body _ _ _ _)         := coord.pi_body
+        |(elet_var_type   _ _ _ _) := coord.elet_var_type
+        |(elet_assignment _ _ _ _) := coord.elet_assignment
+        |(elet_body       _ _ _ _) := coord.elet_body
+
+        meta def to_address : path → address :=
+        list.map entry.to_coord ∘ list.reverse
+
+        open tactic
+
+        meta def entry.to_tactic_format : path.entry → tactic format
+        |(entry.app_fn  l r)         := (pure $ λ l r, l ++ " $ " ++ r) <*> pp l <*> pp r
+        |(entry.app_arg l r)         := (pure $ λ l r, l ++ " $ " ++ r) <*> pp l <*> pp r
+        |(lam_var_type    n _ y   b) := (pure $ λ n y   b, "λ "   ++ n ++ " : " ++ y ++ ", " ++ b) <*> pp n <*> pp y <*> pp b
+        |(lam_body        n _ y   b) := (pure $ λ n y   b, "λ "   ++ n ++ " : " ++ y ++ ", " ++ b) <*> pp n <*> pp y <*> pp b
+        |(pi_var_type     n _ y   b) := (pure $ λ n y   b, "Π "   ++ n ++ " : " ++ y ++ ", " ++ b) <*> pp n <*> pp y <*> pp b
+        |(pi_body         n _ y   b) := (pure $ λ n y   b, "Π "   ++ n ++ " : " ++ y ++ ", " ++ b) <*> pp n <*> pp y <*> pp b
+        |(elet_var_type   n   y a b) := (pure $ λ n y a b, "let " ++ n ++ " : " ++ y ++ " := " ++ a ++ " in " ++ b) <*> pp n <*> pp y <*> pp a <*> pp b
+        |(elet_assignment n   y a b) := (pure $ λ n y a b, "let " ++ n ++ " : " ++ y ++ " := " ++ a ++ " in " ++ b) <*> pp n <*> pp y <*> pp a <*> pp b
+        |(elet_body       n   y a b) := (pure $ λ n y a b, "let " ++ n ++ " : " ++ y ++ " := " ++ a ++ " in " ++ b) <*> pp n <*> pp y <*> pp a <*> pp b
+
+        meta instance entry.has_to_tactic_format : has_to_tactic_format path.entry := ⟨entry.to_tactic_format⟩
+
+        meta def entry.replace (f : ℕ → expr → expr) : ℕ → path.entry → path.entry
+        |d (entry.app_fn  () r)          := (entry.app_fn  () (f d r))
+        |d (entry.app_arg l ())          := (entry.app_arg (f d l) ())
+        |d (lam_var_type    n bi ()   b)  := (lam_var_type    n bi ()  (f (d+1) b))
+        |d (lam_body        n bi y   ())  := (lam_body        n bi (f d y)   ())
+        |d (pi_var_type     n bi ()   b)  := (pi_var_type     n bi ()   (f (d+1) b))
+        |d (pi_body         n bi y   ())  := (pi_body         n bi (f d y)   ())
+        |d (elet_var_type   n    y a b)  := (elet_var_type   n    () (f d a) (f (d+1) b))
+        |d (elet_assignment n    y a b)  := (elet_assignment n    (f d y) () (f (d+1) b))
+        |d (elet_body       n    y a b)  := (elet_body       n    (f d y) (f d a) ())
+
+        meta def entry.up : expr → entry → expr
+        | x (entry.app_fn  () a)       := expr.app x a
+        | x (entry.app_arg f  ())      := expr.app f x
+        | x (lam_var_type   n bi _ b)  := expr.lam n bi x b
+        | x (lam_body       n bi y _)  := expr.lam n bi y x
+        | x (pi_var_type    n bi _ b)  := expr.pi  n bi x b
+        | x (pi_body        n bi y _)  := expr.pi  n bi y x
+        | x (elet_var_type   n _ a b)  := expr.elet n x a b
+        | x (elet_assignment n t _ b)  := expr.elet n t x b
+        | x (elet_body       n t a _)  := expr.elet n t a x
+
+        meta def up : path → expr → expr
+        | [] e := e
+        | (h::t) e := up t $ entry.up e h
+
+        meta instance : has_emptyc path := ⟨[]⟩
+
+        meta def entry.down : coord → expr → option (entry × expr)
+        |(coord.app_fn)          (expr.app f a)      := some ⟨entry.app_fn  () a       , f⟩
+        |(coord.app_arg)         (expr.app f a)      := some ⟨entry.app_arg f ()       , a⟩
+        |(coord.lam_var_type)    (expr.lam n bi y b) := some ⟨lam_var_type n bi () b   , y⟩
+        |(coord.lam_body)        (expr.lam n bi y b) := some ⟨lam_body     n bi y ()   , b⟩
+        |(coord.pi_var_type)     (expr.pi n bi y b ) := some ⟨pi_var_type  n bi () b   , y⟩
+        |(coord.pi_body)         (expr.pi n bi y b ) := some ⟨pi_body      n bi y ()   , b⟩
+        |(coord.elet_var_type)   (expr.elet n y a b) := some ⟨elet_var_type   n () a b , y⟩
+        |(coord.elet_assignment) (expr.elet n y a b) := some ⟨elet_assignment n y () b , a⟩
+        |(coord.elet_body)       (expr.elet n y a b) := some ⟨elet_body       n y a () , b⟩
+        |_ _ := none
+
+        meta def entry.as_binder : path.entry → option binder
+        |(lam_body  n bi y   b) := some $ binder.mk n bi y
+        |(pi_body   n bi y   b) := some $ binder.mk n bi y
+        |(elet_body n    y a b) := some $ binder.mk n binder_info.default y
+        |_ := none
+
+        meta def entry.binder_depth : path.entry → nat
+        | e := if option.is_some $ entry.as_binder e then 1 else 0
+
+        meta def get_context : path → telescope :=
+        list.filter_map entry.as_binder
+
+        meta def binder_depth : path → ℕ :=
+        list.sum ∘ list.map entry.binder_depth
+
+        meta def replace (f : ℕ → expr → expr) : path → path
+        | (pe::p) := entry.replace f (path.binder_depth p) pe :: replace p
+        | [] := []
+
+        meta def instantiate_vars : list expr → path → path
+        | vs p := p.replace (λ d e, expr.instantiate_vars e ((list.map expr.var $ list.range d) ++ (vs.map (λ v, expr.lift_vars v 0 d))))
+
+        meta def instantiate_nth : ℕ → expr → path → path
+        | n a p := path.replace (λ d e, expr.instantiate_nth_var (n + d) (expr.lift_vars a 0 d) e) p
+        -- /-- `as_subpath a b` finds the path `c` such that `b ++ c = a`. -/
+        -- meta def as_subpath : path → path → option path := list.as_sublist
+        meta def empty : path := []
+
+        meta instance path_eq : decidable_eq path := list.decidable_eq
+
+        meta def entry.mmap_exprs {t : Type → Type} [monad t] (f : telescope → expr → t expr) : telescope → expr → path.entry → t path.entry
+        | Γ x (entry.app_fn  () r)           := pure entry.app_fn        <*>  pure () <*> (f Γ r)
+        | Γ x (entry.app_arg l ())           := pure entry.app_arg       <*> (f Γ l)  <*> pure ()
+        | Γ x (lam_var_type    n bi ()   b)  := pure (lam_var_type n bi) <*>  pure () <*> (f (⟨n, bi, x⟩::Γ) b)
+        | Γ x (lam_body        n bi y   ())  := pure (lam_body     n bi) <*> (f Γ y)  <*>  pure ()
+        | Γ x (pi_var_type     n bi ()   b)  := pure (pi_var_type  n bi) <*>  pure () <*> (f (⟨n,bi,x⟩::Γ) b)
+        | Γ x (pi_body         n bi y   ())  := pure (pi_body      n bi) <*> (f Γ y)  <*>  pure ()
+        | Γ x (elet_var_type   n    y a b)   := pure (elet_var_type   n) <*> pure ()  <*> (f Γ a)  <*> (f (⟨n,binder_info.default,x⟩::Γ) b)
+        | Γ x (elet_assignment n    y a b)   := pure (elet_assignment n) <*> (f Γ y)  <*> pure ()  <*> (f (⟨n,binder_info.default,y⟩::Γ) b)
+        | Γ x (elet_body       n    y a b)   := pure (elet_body       n) <*> (f Γ y)  <*> (f Γ a)  <*> pure ()
+
+        meta def mmap_exprs {t : Type → Type} [m : monad t] (f : telescope → expr → t expr) : telescope → expr → path → t path
+        | Γ x [] := pure []
+        | Γ x (e :: p) := do
+          e ← (@entry.mmap_exprs t m f (get_context p ++ Γ) x e),
+          p ← mmap_exprs Γ (e.up x) p,
+          pure $ e :: p
+    end path
+end zipper
+/--
+A zipper over expressions.
+It does not replace bound variables with local constants, but instead maintains its own implicit context of the binders that it is under using its path.
+Reference: [Functional Pearl - The Zipper](https://www.st.cs.uni-saarland.de/edu/seminare/2005/advanced-fp/docs/huet-zipper.pdf)
+ -/
+@[derive decidable_eq]
+meta structure zipper :=
+(get_path : zipper.path)
+(cursor : expr)
+
+/-- Result type of calling `zipper.down`.  -/
+@[derive decidable_eq]
+meta inductive down_result
+|terminal : down_result
+|app  (left : zipper) (right : zipper) : down_result
+| lam (var_name : name) (bi : binder_info) (var_type : zipper) (body : zipper) : down_result
+|  pi (var_name : name) (bi : binder_info) (var_type : zipper) (body : zipper) : down_result
+|elet (var_name : name) (type : zipper) (assignment : zipper) (body : zipper) : down_result
+
+meta def down_result.children_with_depth : down_result → list (zipper × nat)
+|(down_result.terminal) := []
+|(down_result.app l r) := [(l,0),(r,0)]
+|(down_result.lam n bi vt b) := [(vt,0),(b,1)]
+|(down_result.pi n bi vt b) := [(vt,0),(b,1)]
+|(down_result.elet n t a b) := [(t,0),(a,0),(b,1)]
+
+meta def down_result.children : down_result → list zipper :=
+list.map prod.fst ∘ down_result.children_with_depth
+
+namespace zipper
+    open path path.entry
+    meta def mmap_children {t : Type → Type} [monad t] (f : telescope → expr → t expr) : telescope → zipper → t zipper
+    | Γ ⟨p,c⟩ := pure zipper.mk <*> path.mmap_exprs f Γ c p <*> f (get_context p ++ Γ) c
+    meta instance : assignable zipper := ⟨@mmap_children⟩
+    meta def of_path : path → expr → zipper := zipper.mk
+    /-- Move the cursor down the expression tree.-/
+    meta def down : zipper → down_result
+    |⟨p, expr.app f a⟩ :=
+        down_result.app
+            ⟨entry.app_fn  () a  :: p, f⟩
+            ⟨entry.app_arg f  () :: p, a⟩
+    |⟨p, expr.lam n bi y b⟩ :=
+        down_result.lam n bi
+            ⟨lam_var_type n bi () b  :: p, y⟩
+            ⟨lam_body     n bi y  () :: p, b⟩
+    |⟨p, expr.pi  n bi y b⟩ :=
+        down_result.pi n bi
+            ⟨pi_var_type  n bi () b  :: p, y⟩
+            ⟨pi_body      n bi y  () :: p, b⟩
+    |⟨p, expr.elet n t a b⟩ :=
+        down_result.elet n
+            ⟨elet_var_type   n () a b :: p, t⟩
+            ⟨elet_assignment n t () b :: p, a⟩
+            ⟨elet_body       n t a () :: p, b⟩
+    |⟨p,e⟩ := down_result.terminal
+
+    meta def children_with_depths : zipper → list (zipper × nat) :=
+    down_result.children_with_depth ∘ down
+
+    meta def children : zipper → list zipper :=
+    down_result.children ∘ down
+
+    meta def down_coord : coord → zipper → option zipper
+    | c ⟨p, x⟩ := path.entry.down c x >>= (λ ⟨e,x⟩, some ⟨e::p, x⟩)
+
+    /-- Pop the cursor up the expression tree. If we are already at the top, returns `none`. -/
+    meta def up : zipper → option zipper
+    |⟨[], e⟩ := none
+    |⟨e :: p, c⟩ := some $ zipper.mk p $ path.entry.up c e
+
+    meta def is_top : zipper → bool := option.is_none ∘ up
+
+    meta def top : zipper → zipper | z := option.rec_on (up z) z top
+
+    meta def down_app_fn  : zipper → option zipper := down_coord coord.app_fn
+
+    meta def down_app_arg : zipper → option zipper := down_coord coord.app_arg
+
+    /-- If the cursor is a binder, move the cursor to the binder's body. -/
+    meta def down_body : zipper → option zipper := λ z,
+        (down_coord coord.lam_body  z) <|>
+        (down_coord coord.pi_body   z) <|>
+        (down_coord coord.elet_body z)
+
+    /-- If the cursor is a binder then move the cursor on to the binder's tyoe. -/
+    meta def down_var_type : zipper → option zipper := λ z,
+        (down_coord coord.lam_var_type  z) <|>
+        (down_coord coord.pi_var_type   z) <|>
+        (down_coord coord.elet_var_type z)
+
+    /-- Move the cursor down according to the given address.
+    If the zipper has the wrong structure then return none.-/
+    meta def down_address : address → zipper → option zipper
+    |[]     z := some z
+    |(h::t) z := down_coord h z >>= down_address t
+
+    meta def unzip : zipper → expr
+    | z := option.rec_on (up z) (cursor z) (unzip)
+
+    meta def zip : expr → zipper := zipper.mk []
+
+    meta instance : has_coe expr zipper := ⟨zip⟩
+
+    meta def set_cursor : expr → zipper → zipper
+    |e ⟨p,_⟩ := ⟨p,e⟩
+
+    /-- Map the cursor. -/
+    meta def map : (expr → expr) → zipper → zipper
+    |f ⟨p,e⟩ := ⟨p,f e⟩
+
+    variables {T: Type → Type} [monad T]
+
+    /-- Monad-map the cursor. -/
+    meta def mmap : (expr → T expr) → zipper → T zipper
+    |f ⟨p,e⟩ := zipper.mk p <$> f e
+
+    meta def fold {α} (f : α → zipper → α) : α → zipper → α
+    | a z := z.children.foldl fold $ f a z
+
+    meta def mfold {α} (f : α → zipper → T α) : α → zipper → T α
+    | a z := do a ← f a z, z.children.mfoldl mfold a
+
+    meta def mfold_up {α} (f : α → zipper → T α) : α → zipper → T α
+    | a z := f a z >>= λ a, option.rec_on (up z) (pure a) (mfold_up a)
+
+    /-- Fold over each subzipper but if the monad fails then keep the α and don't recurse. -/
+    meta def altfold [alternative T] {α} (f : α → zipper → T α) : α → zipper → T α
+    | a z := (do a ← f a z, z.children.mfoldl altfold a) <|> pure a
+
+    meta def altfold_up [alternative T] {α} (f : α → zipper → T α) : α → zipper → T α
+    | a z := (f a z >>= λ a, option.rec_on (up z) (pure a) (altfold_up a)) <|> pure a
+
+    meta def pick_up [alternative T] {α} (f : zipper → T α) : zipper → T α
+    | z := f z <|> option.rec_on (up z) failure pick_up
+
+    meta def get_address : zipper → address := to_address ∘ get_path
+
+    /-- Get the context of the cursor. The first item in the list is the
+    deepest (and therefore associated with the 0th de-Bruijn variable) -/
+    meta def get_context : zipper → telescope := path.get_context ∘ get_path
+
+    /-- The number of binders above the cursor. -/
+    meta def binder_depth : zipper → ℕ := list.length ∘ get_context
+
+    /-- Replace the cursor and unzip. -/
+    meta def unzip_with : expr → zipper → expr := λ e z, unzip $ z.set_cursor e
+
+    meta def is_var : zipper → bool := expr.is_var ∘ cursor
+
+    meta def is_constant : zipper → bool := expr.is_constant ∘ cursor
+
+    /-- True when the cursor does not contain local constants. -/
+    meta def has_local : zipper → bool | z := z.cursor.has_local
+
+    /-- True when the cursor is on a local constant. -/
+    meta def is_local_constant : zipper → bool :=
+    expr.is_local_constant ∘ cursor
+
+    /-- True when the cursor is on a metavariable. -/
+    meta def is_mvar : zipper → bool
+    | z := match z.cursor with (expr.mvar _ _ _) := tt | _ := ff end
+
+    /-- True when the cursor has no further recursive arguments. -/
+    meta def is_terminal : zipper → bool :=
+    λ z, z.down = down_result.terminal
+
+    /-- True when the cursor is _in_ the arg of an app.
+    That is, the path directly above is `app_arg`. -/
+    meta def is_app_arg : zipper → bool
+    |⟨(entry.app_arg _ _)::t,_⟩ := tt |_ := ff
+
+    /-- Make fresh local_constants for each item in the
+    context and instantiate the cursor with them. -/
+    meta def instantiate_cursor : zipper → tactic (expr × list expr)
+    | z := do hs ← telescope.to_locals z.get_context, pure (instantiate_vars z.cursor hs, hs)
+
+    /-- Infer the type of the subexpression at the cursor position. -/
+    meta def infer_type : zipper → tactic expr := λ z, do
+        (c,_) ← instantiate_cursor z,
+        tactic.infer_type c
+
+    meta instance : has_to_tactic_format zipper := ⟨λ z, do
+        whole  ← tactic.pp $ z.unzip_with (expr.const `O []),
+        cursor ← tactic.pp z.cursor,
+        pure $ format.highlight cursor format.color.blue ++ " in " ++ whole⟩
+
+    meta def instantiate_mvars : zipper → tactic zipper | z := do
+        e ← tactic.instantiate_mvars (unzip z),
+        down_address (get_address z) (zip e)
+
+    meta def instantiate_vars : zipper → list expr → zipper
+    | z vs := option.rec (undefined_core "instantiate_vars unreachable") id
+              $ down_address (get_address z)
+              $ zip
+              $ expr.instantiate_vars z.unzip vs
+
+    /-- Check if the paths of the given zippers are equal.
+    That is, they are the same except for the cursor expressions. -/
+    meta def above_equal : zipper → zipper → bool
+    |⟨p₁,_⟩ ⟨p₂,_⟩ := p₁ = p₂
+
+    meta def address_below : zipper → zipper → option address
+    | z₁ z₂ := address.as_below z₁.get_address z₂.get_address
+
+    meta def path.apply : path → expr → expr | p e := zipper.unzip ⟨p,e⟩
+
+    protected meta def lt : zipper → zipper → bool
+    | z₁ z₂ := bor (z₁.get_address < z₂.get_address)
+               $ band (z₁.get_address = z₂.get_address)
+               $ z₁.unzip < z₂.unzip
+
+    meta instance : has_lt zipper :=
+    ⟨λ z₁ z₂, zipper.lt z₁ z₂⟩
+
+    meta instance : decidable_rel ((<) : zipper → zipper → Prop) := by apply_instance
+
+    /-- Find all zippers whose cursor is on the given de Bruijn variable. -/
+    meta def find_var : zipper → ℕ → list zipper
+    | z n := match z.cursor with
+      | (expr.var i) :=
+        if n + z.binder_depth = i then [z] else []
+      | c :=
+        if expr.get_free_var_range c < n + z.binder_depth then [] else
+        z.children.bind (λ z, find_var z n)
+      end
+
+    meta def to_path : address → expr → option zipper.path
+    | a e := zipper.get_path <$> zipper.down_address a (zipper.zip e)
+end zipper
+
+
+end expr

--- a/src/meta/telescope.lean
+++ b/src/meta/telescope.lean
@@ -1,0 +1,80 @@
+/- © E.W.Ayers 2019 -/
+import meta.binder
+
+/-- A list of binders where the first binder is the _innermost_ one. Note that this is a different convention to
+the list of binders created by `expr.pi_binders`. -/
+meta def telescope := list binder
+
+/-- A list of binders where the first binder is the _outermost_ one. -/
+meta def cotelescope := list binder
+
+namespace telescope
+
+meta instance : has_append telescope := list.has_append
+-- meta instance : has_to_tactic_format telescope := ⟨tactic.pp ∘ list.reverse⟩
+
+meta def to_pis : expr → telescope → expr
+| b (h :: t) := to_pis (binder.to_pi h b) t
+| b [] := b
+
+meta def to_lams : expr → telescope → expr
+| b (h :: t) := to_lams (binder.to_lam h b) t
+| b [] := b
+
+meta def binders_aux (once : expr → option (binder × expr)) : list binder → expr → (list binder × expr)
+| acc x := (acc, x) <| ((once x) >>= (λ ⟨h,b⟩, binders_aux (h::acc) b))
+
+meta def n_binders_aux (once : expr → option (binder × expr)) : nat → list binder → expr → option (list binder × expr)
+| 0 acc x := some (acc, x)
+| (n+1) acc x := ((once x) >>= (λ ⟨h,b⟩, n_binders_aux n (h::acc) b))
+
+meta def mbinders_aux {m} [monad m] [alternative m] (once : expr → m (binder × expr)) : list binder → expr → m (list binder × expr)
+| acc x := ((once x) >>= (λ ⟨h,b⟩, mbinders_aux (h::acc) b)) <|> pure (acc, x)
+
+/- Like binder.pi_binders except that the ordering of binders is reversed. -/
+meta def of_pis : expr → (telescope × expr) := binders_aux expr.pi_binder []
+
+meta def of_lams : expr → (telescope × expr) := binders_aux expr.lam_binder []
+
+meta def of_exists : expr → (telescope × expr) := binders_aux expr.exists_binder []
+
+meta def of_exists_conj : expr → tactic (telescope × expr) := mbinders_aux expr.exists_conj_binder []
+
+meta def of_n_pis : expr → nat → option (telescope × expr)
+| e n := n_binders_aux expr.pi_binder n [] e
+
+meta def of_n_lams : expr → nat → option (telescope × expr)
+| e n := n_binders_aux expr.lam_binder n [] e
+
+private meta def to_locals_folder : binder → list expr → tactic (list expr)
+| ⟨n, bi, y⟩ acc := do h ← tactic.mk_local' n bi (expr.instantiate_vars y acc), pure $ h :: acc
+
+meta def to_locals : list binder → tactic (list expr)
+| ctxt := list.mfoldr to_locals_folder [] ctxt
+
+open tactic.unsafe
+
+meta def push_type_context_core : binder → list expr → type_context (list expr)
+| ⟨n, bi, y⟩ acc := do h ← type_context.push_local n (expr.instantiate_vars y acc) bi, pure $ h :: acc
+
+meta def push_type_context : telescope → type_context (list expr)
+| Γ := list.mfoldr push_type_context_core [] Γ
+
+private meta def entry.of_local_folder : expr → (list name × telescope) → (list name × telescope)
+|  (expr.local_const u p b y) (l,c) := (l ++ [u], (binder.mk p b $ expr.abstract_locals y l) :: c )
+| _ _ := undefined_core "entry.of_local_folder"
+
+/-- Convert a list of local constants to a context. -/
+meta def of_locals : list expr → telescope
+|ls :=  prod.snd $ list.foldr entry.of_local_folder ([],[]) $ ls
+
+meta def pexpr_pis_of_ctxt : telescope → pexpr → pexpr
+|[] e := to_pexpr e
+|(⟨n,bi,y⟩ :: rest) e :=
+    pexpr_pis_of_ctxt rest $ @expr.pi ff n bi (to_pexpr y) $ e
+
+meta def to_cotelescope : telescope → cotelescope := list.reverse
+
+meta instance : has_coe telescope nat := ⟨list.length⟩
+
+end telescope


### PR DESCRIPTION
Over the last couple of years I have ended up writing a lot of code for manipulating expressions and lists. At the moment this PR is just a dump of some of the code which I think might belong in mathlib.
It's not ready to merge, but some people have expressed interest in viewing it and I figured I would paste it here in case there is some interest in merging.

The main contributions are the `assignable` typeclass and the `expr.zipper` datatype.

## assignable

```lean
/- A type α is assignable when you can run a monad over it with expressions. -/
meta class assignable (α : Type) :=
(mmap_children
  {t : Type → Type}
  [monad t]
  (f : telescope → expr → t expr)
  : telescope → α → t α)
```

Here, `telescope` is a list of uninstantiated binders where the head binder is the deepest binder dependent on all of the variables bound in the tail of the telescope.
The definition `mmap_children` should iterate over all of the expressions in `α` that would need to be operated on to ensure that the resulting `α` is 'well-formed'. An example of an assignable might be `list expr`, where `mmap_children` maps each of the items in the list and keeps the context the same. A more complex example might be `assignable telescope`, since in this case the child binders each exist in different contexts. It plays a similar role to a traversal in optics, but with the additional tracking of the context of the expression using the telescopes.

I've found this useful because you can write your own datatypes such as

```lean
structure rewrite_rule :=
(lhs : expr)
(rhs: expr)
```

and then once you show `assignable rewrite_rule`, you get a toolkit of expression manipulators for free: `instantiate_mvars : rewrite_rule → tactic rewrite_rule`, `abstract : rewrite_rule → expr → rewrite_rule` etc etc.


## expr.zipper

Zippers were introduced by Huet in http://www.st.cs.uni-sb.de/edu/seminare/2005/advanced-fp/docs/huet-zipper.pdf 
The idea is that you can navigate around a recursive datatype by keeping track of a `path` representing the data 'above you' and a `cursor` 'below you'. The paper explains it better!

Zipping on expressions is a little more interesting, because you also want to be able to track binders to zip underneath lambdas. So I built an `expr.zipper` type that makes it a little easier to work with binders.

 
