### PR TITLE
[Merged by Bors] - refactor(measure_theory): review def&API of the `dirac` measure

### DIFF
--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -1501,10 +1501,16 @@ let g := hfm.mk f in calc
 ... = ∫ x, g (φ x) ∂μ : integral_map_of_measurable hφ hfm.measurable_mk
 ... = ∫ x, f (φ x) ∂μ : integral_congr_ae $ ae_eq_comp hφ (hfm.ae_eq_mk).symm
 
-lemma integral_dirac (f : α → E) (a : α) (hfm : measurable f) :
+lemma integral_dirac' (f : α → E) (a : α) (hfm : measurable f) :
   ∫ x, f x ∂(measure.dirac a) = f a :=
 calc ∫ x, f x ∂(measure.dirac a) = ∫ x, f a ∂(measure.dirac a) :
-  integral_congr_ae $ eventually_eq_dirac hfm
+  integral_congr_ae $ ae_eq_dirac' hfm
+... = f a : by simp [measure.dirac_apply_of_mem]
+
+lemma integral_dirac [measurable_singleton_class α] (f : α → E) (a : α) :
+  ∫ x, f x ∂(measure.dirac a) = f a :=
+calc ∫ x, f x ∂(measure.dirac a) = ∫ x, f a ∂(measure.dirac a) :
+  integral_congr_ae $ ae_eq_dirac f
 ... = f a : by simp [measure.dirac_apply_of_mem]
 
 end properties

--- a/src/measure_theory/category/Meas.lean
+++ b/src/measure_theory/category/Meas.lean
@@ -83,7 +83,7 @@ nicely under the monad operations. -/
 def Integral : monad.algebra Measure :=
 { A      := Meas.of ennreal ,
   a      := ⟨λm:measure ennreal, ∫⁻ x, x ∂m, measure.measurable_lintegral measurable_id ⟩,
-  unit'  := subtype.eq $ funext $ assume r:ennreal, lintegral_dirac _ measurable_id,
+  unit'  := subtype.eq $ funext $ assume r:ennreal, lintegral_dirac' _ measurable_id,
   assoc' := subtype.eq $ funext $ assume μ : measure (measure ennreal),
     show ∫⁻ x, x ∂ μ.join = ∫⁻ x, x ∂ (measure.map (λm:measure ennreal, ∫⁻ x, x ∂m) μ),
     by rw [measure.lintegral_join, lintegral_map];

--- a/src/measure_theory/giry_monad.lean
+++ b/src/measure_theory/giry_monad.lean
@@ -68,7 +68,7 @@ lemma measurable_dirac :
   measurable (measure.dirac : α → measure α) :=
 measurable_of_measurable_coe _ $ assume s hs,
   begin
-    simp only [dirac_apply, hs],
+    simp only [dirac_apply', hs],
     exact measurable_one.indicator hs
   end
 
@@ -177,15 +177,11 @@ begin
 end
 
 lemma bind_dirac {f : α → measure β} (hf : measurable f) (a : α) : bind (dirac a) f = f a :=
-measure.ext $ assume s hs, by rw [bind_apply hs hf, lintegral_dirac a ((measurable_coe hs).comp hf)]
+measure.ext $ λ s hs, by rw [bind_apply hs hf, lintegral_dirac' a ((measurable_coe hs).comp hf)]
 
 lemma dirac_bind {m : measure α} : bind m dirac = m :=
 measure.ext $ assume s hs,
-by simp [bind_apply hs measurable_dirac, dirac_apply _ hs, lintegral_indicator 1 hs]
-
-lemma map_dirac {f : α → β} (hf : measurable f) (a : α) :
-  map f (dirac a) = dirac (f a) :=
-measure.ext $ assume s hs, by simp [hs, map_apply hf hs, hf hs, indicator_apply]
+by simp [bind_apply hs measurable_dirac, dirac_apply' _ hs, lintegral_indicator 1 hs]
 
 lemma join_eq_bind (μ : measure (measure α)) : join μ = bind μ id :=
 by rw [bind, map_id]

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -1550,9 +1550,13 @@ lemma set_lintegral_map [measurable_space β] {f : β → ennreal} {g : α → �
   ∫⁻ y in s, f y ∂(map g μ) = ∫⁻ x in g ⁻¹' s, f (g x) ∂μ :=
 by rw [restrict_map hg hs, lintegral_map hf hg]
 
-lemma lintegral_dirac (a : α) {f : α → ennreal} (hf : measurable f) :
+lemma lintegral_dirac' (a : α) {f : α → ennreal} (hf : measurable f) :
   ∫⁻ a, f a ∂(dirac a) = f a :=
-by simp [lintegral_congr_ae (eventually_eq_dirac hf)]
+by simp [lintegral_congr_ae (ae_eq_dirac' hf)]
+
+lemma lintegral_dirac [measurable_singleton_class α] (a : α) (f : α → ennreal) :
+  ∫⁻ a, f a ∂(dirac a) = f a :=
+by simp [lintegral_congr_ae (ae_eq_dirac f)]
 
 lemma ae_lt_top {f : α → ennreal} (hf : measurable f) (h2f : ∫⁻ x, f x ∂μ < ⊤) :
   ∀ᵐ x ∂μ, f x < ⊤ :=

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1078,19 +1078,21 @@ end
 def dirac (a : α) : measure α :=
 (outer_measure.dirac a).to_measure (by simp)
 
-lemma dirac_apply' (a : α) (hs : is_measurable s) :
+lemma le_dirac_apply {a} : s.indicator 1 a ≤ dirac a s :=
+outer_measure.dirac_apply a s ▸ le_to_measure_apply _ _ _
+
+@[simp] lemma dirac_apply' (a : α) (hs : is_measurable s) :
   dirac a s = s.indicator 1 a :=
-to_measure_apply _ _ hs.null_measurable
+to_measure_apply _ _ hs
 
 @[simp] lemma dirac_apply_of_mem {a : α} (h : a ∈ s) :
   dirac a s = 1 :=
 begin
-  rw [measure_eq_infi, infi_subtype', infi_subtype'],
-  convert infi_const,
-  { ext1 ⟨⟨t, hst⟩, ht⟩,
-    dsimp only [subtype.coe_mk] at *,
-    rw [dirac_apply' _ ht, indicator_of_mem (hst h), pi.one_apply] },
-  { exact ⟨⟨⟨set.univ, subset_univ _⟩, is_measurable.univ⟩⟩ }
+  have : ∀ t : set α, a ∈ t → t.indicator (1 : α → ennreal) a = 1,
+    from λ t ht, indicator_of_mem ht 1,
+  refine le_antisymm (this univ trivial ▸ _) (this s h ▸ le_dirac_apply),
+  rw [← dirac_apply' a is_measurable.univ],
+  exact measure_mono (subset_univ s)
 end
 
 @[simp] lemma dirac_apply [measurable_singleton_class α] (a : α) (s : set α) :
@@ -1102,12 +1104,20 @@ begin
              ... = 0            : by simp [dirac_apply' _ (is_measurable_singleton _).compl]
 end
 
+lemma map_dirac {f : α → β} (hf : measurable f) (a : α) :
+  map f (dirac a) = dirac (f a) :=
+ext $ assume s hs, by simp [hs, map_apply hf hs, hf hs, indicator_apply]
+
 /-- Sum of an indexed family of measures. -/
 def sum (f : ι → measure α) : measure α :=
 (outer_measure.sum (λ i, (f i).to_outer_measure)).to_measure $
 le_trans
   (by exact le_infi (λ i, le_to_outer_measure_caratheodory _))
   (outer_measure.le_sum_caratheodory _)
+
+lemma le_sum_apply (f : ι → measure α) (s : set α) :
+  (∑' i, f i s) ≤ sum f s :=
+le_to_measure_apply _ _ _
 
 @[simp] lemma sum_apply (f : ι → measure α) {s : set α} (hs : is_measurable s) :
   sum f s = ∑' i, f i s :=
@@ -1142,12 +1152,17 @@ ext $ λ t ht, by simp only [sum_apply, restrict_apply, ht, ht.inter hs]
 /-- Counting measure on any measurable space. -/
 def count : measure α := sum dirac
 
+lemma le_count_apply : (∑' i : s, 1 : ennreal) ≤ count s :=
+calc (∑' i : s, 1 : ennreal) = ∑' i, indicator s 1 i : tsum_subtype s 1
+... ≤ ∑' i, dirac i s : ennreal.tsum_le_tsum $ λ x, le_dirac_apply
+... ≤ count s : le_sum_apply _ _
+
 lemma count_apply (hs : is_measurable s) : count s = ∑' i : s, 1 :=
-by simp only [count, sum_apply, hs, dirac_apply, ← tsum_subtype s 1, pi.one_apply]
+by simp only [count, sum_apply, hs, dirac_apply', ← tsum_subtype s 1, pi.one_apply]
 
 @[simp] lemma count_apply_finset [measurable_singleton_class α] (s : finset α) :
   count (↑s : set α) = s.card :=
-calc count (↑s : set α) = ∑' i : (↑s : set α), (1 : α → ennreal) i : count_apply s.is_measurable
+calc count (↑s : set α) = ∑' i : (↑s : set α), 1 : count_apply s.is_measurable
                     ... = ∑ i in s, 1 : s.tsum_subtype 1
                     ... = s.card : by simp
 
@@ -1156,13 +1171,14 @@ lemma count_apply_finite [measurable_singleton_class α] (s : set α) (hs : fini
 by rw [← count_apply_finset, finite.coe_to_finset]
 
 /-- `count` measure evaluates to infinity at infinite sets. -/
-lemma count_apply_infinite [measurable_singleton_class α] (hs : s.infinite) : count s = ⊤ :=
+lemma count_apply_infinite (hs : s.infinite) : count s = ⊤ :=
 begin
-  by_contra H,
-  rcases ennreal.exists_nat_gt H with ⟨n, hn⟩,
+  refine top_unique (le_of_tendsto' ennreal.tendsto_nat_nhds_top $ λ n, _),
   rcases hs.exists_subset_card_eq n with ⟨t, ht, rfl⟩,
-  have := lt_of_le_of_lt (measure_mono ht) hn,
-  simpa [lt_irrefl] using this
+  calc (t.card : ennreal) = ∑ i in t, 1 : by simp
+  ... = ∑' i : (t : set α), 1 : (t.tsum_subtype 1).symm
+  ... ≤ count (t : set α) : le_count_apply
+  ... ≤ count s : measure_mono ht
 end
 
 @[simp] lemma count_apply_eq_top [measurable_singleton_class α] : count s = ⊤ ↔ s.infinite :=
@@ -1345,7 +1361,7 @@ ae_eq_bot.trans restrict_eq_zero
 (not_congr ae_restrict_eq_bot).trans pos_iff_ne_zero.symm
 
 /-- A version of the Borel-Cantelli lemma: if sᵢ is a sequence of measurable sets such that
-∑ μ sᵢ exists, then for almost all x, x does not belong to almost all sᵢ. -/
+`∑ μ sᵢ` exists, then for almost all `x`, `x` does not belong to almost all `s`ᵢ. -/
 lemma ae_eventually_not_mem {s : ℕ → set α} (hs : ∀ i, is_measurable (s i))
   (hs' : ∑' i, μ (s i) ≠ ⊤) : ∀ᵐ x ∂ μ, ∀ᶠ n in at_top, x ∉ s n :=
 begin
@@ -1359,33 +1375,23 @@ begin
   exact hi j hj hj'
 end
 
-lemma mem_dirac_ae_iff {a : α} (hs : is_measurable s) : s ∈ (dirac a).ae ↔ a ∈ s :=
-by by_cases a ∈ s; simp [mem_ae_iff, dirac_apply, hs.compl, indicator_apply, *]
+lemma mem_ae_dirac_iff {a : α} (hs : is_measurable s) : s ∈ (dirac a).ae ↔ a ∈ s :=
+by by_cases a ∈ s; simp [mem_ae_iff, dirac_apply', hs.compl, indicator_apply, *]
 
-lemma eventually_dirac {a : α} {p : α → Prop} (hp : is_measurable {x | p x}) :
+lemma ae_dirac_iff {a : α} {p : α → Prop} (hp : is_measurable {x | p x}) :
   (∀ᵐ x ∂(dirac a), p x) ↔ p a :=
-mem_dirac_ae_iff hp
+mem_ae_dirac_iff hp
 
-lemma eventually_eq_dirac [measurable_singleton_class β] {a : α} {f : α → β} (hf : measurable f) :
+@[simp] lemma ae_dirac_eq [measurable_singleton_class α] (a : α) : (dirac a).ae = pure a :=
+by { ext s, simp [mem_ae_iff, imp_false] }
+
+lemma ae_eq_dirac' [measurable_singleton_class β] {a : α} {f : α → β} (hf : measurable f) :
   f =ᵐ[dirac a] const α (f a) :=
-(eventually_dirac $ show is_measurable (f ⁻¹' {f a}), from hf $ is_measurable_singleton _).2 rfl
+(ae_dirac_iff $ show is_measurable (f ⁻¹' {f a}), from hf $ is_measurable_singleton _).2 rfl
 
-lemma dirac_ae_eq [measurable_singleton_class α] (a : α) : (dirac a).ae = pure a :=
-begin
-  ext s,
-  simp only [mem_ae_iff, mem_pure_sets],
-  by_cases ha : a ∈ s,
-  { simp only [ha, iff_true],
-    rw [← set.singleton_subset_iff, ← compl_subset_compl] at ha,
-    refine measure_mono_null ha _,
-    simp [dirac_apply a (is_measurable_singleton a).compl] },
-  { simp only [ha, iff_false, dirac_apply_of_mem (mem_compl ha)],
-    exact one_ne_zero }
-end
-
-lemma eventually_eq_dirac' [measurable_singleton_class α] {a : α} (f : α → δ) :
+lemma ae_eq_dirac [measurable_singleton_class α] {a : α} (f : α → δ) :
   f =ᵐ[dirac a] const α (f a) :=
-by { rw [dirac_ae_eq], show f a = f a, refl }
+by simp [filter.eventually_eq]
 
 /-- If `s ⊆ t` modulo a set of measure `0`, then `μ s ≤ μ t`. -/
 lemma measure_mono_ae (H : s ≤ᵐ[μ] t) : μ s ≤ μ t :=

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1079,22 +1079,27 @@ def dirac (a : α) : measure α :=
 (outer_measure.dirac a).to_measure (by simp)
 
 lemma dirac_apply' (a : α) (hs : is_measurable s) :
-  dirac a s = ⨆ h : a ∈ s, 1 :=
-to_measure_apply _ _ hs
-
-@[simp] lemma dirac_apply (a : α) (hs : is_measurable s) :
   dirac a s = s.indicator 1 a :=
-(dirac_apply' a hs).trans $ by { by_cases h : a ∈ s; simp [h] }
+to_measure_apply _ _ hs.null_measurable
 
-lemma dirac_apply_of_mem {a : α} (h : a ∈ s) :
+@[simp] lemma dirac_apply_of_mem {a : α} (h : a ∈ s) :
   dirac a s = 1 :=
 begin
   rw [measure_eq_infi, infi_subtype', infi_subtype'],
   convert infi_const,
   { ext1 ⟨⟨t, hst⟩, ht⟩,
     dsimp only [subtype.coe_mk] at *,
-    simp only [dirac_apply _ ht, indicator_of_mem (hst h), pi.one_apply] },
+    rw [dirac_apply' _ ht, indicator_of_mem (hst h), pi.one_apply] },
   { exact ⟨⟨⟨set.univ, subset_univ _⟩, is_measurable.univ⟩⟩ }
+end
+
+@[simp] lemma dirac_apply [measurable_singleton_class α] (a : α) (s : set α) :
+  dirac a s = s.indicator 1 a :=
+begin
+  by_cases h : a ∈ s, by rw [dirac_apply_of_mem h, indicator_of_mem h, pi.one_apply],
+  rw [indicator_of_not_mem h, ← nonpos_iff_eq_zero],
+  calc dirac a s ≤ dirac a {a}ᶜ : measure_mono (subset_compl_comm.1 $ singleton_subset_iff.2 h)
+             ... = 0            : by simp [dirac_apply' _ (is_measurable_singleton _).compl]
 end
 
 /-- Sum of an indexed family of measures. -/

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1360,7 +1360,7 @@ ae_eq_bot.trans restrict_eq_zero
 @[simp] lemma ae_restrict_ne_bot {s} : (μ.restrict s).ae.ne_bot ↔ 0 < μ s :=
 (not_congr ae_restrict_eq_bot).trans pos_iff_ne_zero.symm
 
-/-- A version of the Borel-Cantelli lemma: if sᵢ is a sequence of measurable sets such that
+/-- A version of the Borel-Cantelli lemma: if `sᵢ` is a sequence of measurable sets such that
 `∑ μ sᵢ` exists, then for almost all `x`, `x` does not belong to almost all `s`ᵢ. -/
 lemma ae_eventually_not_mem {s : ℕ → set α} (hs : ∀ i, is_measurable (s i))
   (hs' : ∑' i, μ (s i) ≠ ⊤) : ∀ᵐ x ∂ μ, ∀ᶠ n in at_top, x ∉ s n :=

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -562,8 +562,8 @@ theorem le_smul_caratheodory (a : ennreal) (m : outer_measure α) :
 
 @[simp] theorem dirac_caratheodory (a : α) : (dirac a).caratheodory = ⊤ :=
 top_unique $ λ s _ t, begin
-  by_cases a ∈ t; simp [h],
-  by_cases a ∈ s; simp [h]
+  by_cases ht : a ∈ t, swap, by simp [ht],
+  by_cases hs : a ∈ s; simp*
 end
 
 section Inf_gen

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -238,15 +238,18 @@ instance : is_lawful_functor outer_measure :=
 
 /-- The dirac outer measure. -/
 def dirac (a : α) : outer_measure α :=
-{ measure_of := λs, ⨆ h : a ∈ s, 1,
+{ measure_of := λs, indicator s (λ _, 1) a,
   empty := by simp,
-  mono := λ s t h, supr_le_supr2 (λ h', ⟨h h', le_refl _⟩),
-  Union_nat := λ s, supr_le $ λ h,
-    let ⟨i, h⟩ := mem_Union.1 h in
-    le_trans (by exact le_supr _ h) (ennreal.le_tsum i) }
+  mono := λ s t h, indicator_le_indicator_of_subset h (λ _, zero_le _) a,
+  Union_nat := λ s,
+    if hs : a ∈ ⋃ n, s n then let ⟨i, hi⟩ := mem_Union.1 hs in
+      calc indicator (⋃ n, s n) (λ _, (1 : ennreal)) a = 1 : indicator_of_mem hs _
+      ... = indicator (s i) (λ _, 1) a : (indicator_of_mem hi _).symm
+      ... ≤ ∑' n, indicator (s n) (λ _, 1) a : ennreal.le_tsum _
+    else by simp only [indicator_of_not_mem hs, zero_le]}
 
 @[simp] theorem dirac_apply (a : α) (s : set α) :
-  dirac a s = ⨆ h : a ∈ s, 1 := rfl
+  dirac a s = indicator s (λ _, 1) a := rfl
 
 /-- The sum of an (arbitrary) collection of outer measures. -/
 def sum {ι} (f : ι → outer_measure α) : outer_measure α :=
@@ -260,8 +263,8 @@ def sum {ι} (f : ι → outer_measure α) : outer_measure α :=
   sum f s = ∑' i, f i s := rfl
 
 theorem smul_dirac_apply (a : ennreal) (b : α) (s : set α) :
-  (a • dirac b) s = ⨆ h : b ∈ s, a :=
-by by_cases b ∈ s; simp [h]
+  (a • dirac b) s = indicator s (λ _, a) b :=
+by simp
 
 /-- Pullback of an `outer_measure`: `comap f μ s = μ (f '' s)`. -/
 def comap {β} (f : α → β) : outer_measure β →ₗ[ennreal] outer_measure α :=

--- a/src/measure_theory/prod.lean
+++ b/src/measure_theory/prod.lean
@@ -487,14 +487,14 @@ lemma prod_dirac (y : β) : μ.prod (dirac y) = map (λ x, (x, y)) μ :=
 begin
   refine prod_eq (λ s t hs ht, _),
   simp_rw [map_apply measurable_prod_mk_right (hs.prod ht), mk_preimage_prod_left_eq_if, measure_if,
-    dirac_apply _ ht, ← indicator_mul_right _ (λ x, μ s), pi.one_apply, mul_one]
+    dirac_apply' _ ht, ← indicator_mul_right _ (λ x, μ s), pi.one_apply, mul_one]
 end
 
 lemma dirac_prod (x : α) : (dirac x).prod ν = map (prod.mk x) ν :=
 begin
   refine prod_eq (λ s t hs ht, _),
   simp_rw [map_apply measurable_prod_mk_left (hs.prod ht), mk_preimage_prod_right_eq_if, measure_if,
-    dirac_apply _ hs, ← indicator_mul_left _ _ (λ x, ν t), pi.one_apply, one_mul]
+    dirac_apply' _ hs, ← indicator_mul_left _ _ (λ x, ν t), pi.one_apply, one_mul]
 end
 
 lemma dirac_prod_dirac {x : α} {y : β} : (dirac x).prod (dirac y) = dirac (x, y) :=

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -301,15 +301,19 @@ iff.intro has_sum.tsum_eq (assume eq, eq ▸ h.has_sum)
 @[simp] lemma tsum_zero : ∑'b:β, (0:α) = 0 := has_sum_zero.tsum_eq
 
 lemma tsum_eq_sum {f : β → α} {s : finset β} (hf : ∀b∉s, f b = 0)  :
-  ∑'b, f b = ∑ b in s, f b :=
+  ∑' b, f b = ∑ b in s, f b :=
 (has_sum_sum_of_ne_finset_zero hf).tsum_eq
 
 lemma tsum_fintype [fintype β] (f : β → α) : ∑'b, f b = ∑ b, f b :=
 (has_sum_fintype f).tsum_eq
 
 @[simp] lemma finset.tsum_subtype (s : finset β) (f : β → α) :
-  ∑'x : {x // x ∈ s}, f x = ∑ x in s, f x :=
+  ∑' x : {x // x ∈ s}, f x = ∑ x in s, f x :=
 (s.has_sum f).tsum_eq
+
+@[simp] lemma finset.tsum_subtype' (s : finset β) (f : β → α) :
+  ∑' x : (s : set β), f x = ∑ x in s, f x :=
+s.tsum_subtype f
 
 lemma tsum_eq_single {f : β → α} (b : β) (hf : ∀b' ≠ b, f b' = 0)  :
   ∑'b, f b = f b :=


### PR DESCRIPTION
* use `set.indicator` instead of `⨆ a ∈ s, 1` in the definition.
* rename some theorems to `thm'`, add a version assuming
  `[measurable_singleton_class α]` but not
  `is_measurable s`/`measurable f` under the old name.
* rename some lemmas from `eventually` to `ae`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I'm not sure which version should have `'` in the name: the one assuming
`[measurable_singleton_class α]` or the one assuming `is_measurable`/`measurable`?