### PR TITLE
[Merged by Bors] - feat(linear_algebra/{clifford,exterior,tensor,free}_algebra): provide canonical images from larger algebras into smaller ones

### DIFF
--- a/src/linear_algebra/clifford_algebra.lean
+++ b/src/linear_algebra/clifford_algebra.lean
@@ -170,7 +170,7 @@ namespace tensor_algebra
 
 variables {Q}
 
-/- The canonical image of the `tensor_algebra` in the `clifford_algebra`, which maps
+/-- The canonical image of the `tensor_algebra` in the `clifford_algebra`, which maps
 `tensor_algebra.ι R x` to `clifford_algebra.ι Q x`. -/
 def to_clifford : tensor_algebra R M →ₐ[R] clifford_algebra Q :=
 tensor_algebra.lift R (clifford_algebra.ι Q)

--- a/src/linear_algebra/clifford_algebra.lean
+++ b/src/linear_algebra/clifford_algebra.lean
@@ -165,3 +165,17 @@ alg_equiv.of_alg_hom
   (by { ext, simp, })
 
 end clifford_algebra
+
+namespace tensor_algebra
+
+variables {Q}
+
+/- The canonical image of the `tensor_algebra` in the `clifford_algebra`, which maps
+`tensor_algebra.ι R x` to `clifford_algebra.ι Q x`. -/
+def to_clifford : tensor_algebra R M →ₐ[R] clifford_algebra Q :=
+tensor_algebra.lift R (clifford_algebra.ι Q)
+
+@[simp] lemma to_clifford_ι (m : M) : (tensor_algebra.ι R m).to_clifford = clifford_algebra.ι Q m :=
+by simp [to_clifford]
+
+end tensor_algebra

--- a/src/linear_algebra/exterior_algebra.lean
+++ b/src/linear_algebra/exterior_algebra.lean
@@ -226,3 +226,17 @@ lemma ι_multi_apply {n : ℕ} (v : fin n → M) :
   ι_multi R n v = (list.of_fn $ λ i, ι R (v i)).prod := rfl
 
 end exterior_algebra
+
+namespace tensor_algebra
+
+variables {R M}
+
+/- The canonical image of the `tensor_algebra` in the `exterior_algebra`, which maps
+`tensor_algebra.ι R x` to `exterior_algebra.ι R x`. -/
+def to_exterior : tensor_algebra R M →ₐ[R] exterior_algebra R M :=
+tensor_algebra.lift R (exterior_algebra.ι R)
+
+@[simp] lemma to_exterior_ι (m : M) : (tensor_algebra.ι R m).to_exterior = exterior_algebra.ι R m :=
+by simp [to_exterior]
+
+end tensor_algebra

--- a/src/linear_algebra/exterior_algebra.lean
+++ b/src/linear_algebra/exterior_algebra.lean
@@ -231,7 +231,7 @@ namespace tensor_algebra
 
 variables {R M}
 
-/- The canonical image of the `tensor_algebra` in the `exterior_algebra`, which maps
+/-- The canonical image of the `tensor_algebra` in the `exterior_algebra`, which maps
 `tensor_algebra.ι R x` to `exterior_algebra.ι R x`. -/
 def to_exterior : tensor_algebra R M →ₐ[R] exterior_algebra R M :=
 tensor_algebra.lift R (exterior_algebra.ι R)

--- a/src/linear_algebra/tensor_algebra.lean
+++ b/src/linear_algebra/tensor_algebra.lean
@@ -137,7 +137,7 @@ namespace free_algebra
 
 variables {R M}
 
-/- The canonical image of the `free_algebra` in the `tensor_algebra`, which maps
+/-- The canonical image of the `free_algebra` in the `tensor_algebra`, which maps
 `free_algebra.ι R x` to `tensor_algebra.ι R x`. -/
 def to_tensor : free_algebra R M →ₐ[R] tensor_algebra R M :=
 free_algebra.lift R (tensor_algebra.ι R)

--- a/src/linear_algebra/tensor_algebra.lean
+++ b/src/linear_algebra/tensor_algebra.lean
@@ -132,3 +132,17 @@ lemma ι_injective : function.injective (ι R : M → tensor_algebra R M) :=
   triv_sq_zero_ext.inr_injective $ hfxx.symm.trans ((f.congr_arg hxy).trans hfyy)
 
 end tensor_algebra
+
+namespace free_algebra
+
+variables {R M}
+
+/- The canonical image of the `free_algebra` in the `tensor_algebra`, which maps
+`free_algebra.ι R x` to `tensor_algebra.ι R x`. -/
+def to_tensor : free_algebra R M →ₐ[R] tensor_algebra R M :=
+free_algebra.lift R (tensor_algebra.ι R)
+
+@[simp] lemma to_tensor_ι (m : M) : (free_algebra.ι R m).to_tensor = tensor_algebra.ι R m :=
+by simp [to_tensor]
+
+end free_algebra


### PR DESCRIPTION
This adds:

* `free_algebra.to_tensor`
* `tensor_algebra.to_exterior`
* `tensor_algebra.to_clifford`

Providing the injection in the other direction is more challenging, so is left as future work.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
