### PR TITLE
[Merged by Bors] - feat(data/complex/basic): Adding `im_eq_sub_conj`

### DIFF
--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -370,8 +370,8 @@ by {rw add_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
 
 /-- A complex number `z` minus its conjuagate `conj z` is `2i` times it's imaginary part -/
 theorem im_eq_sub_conj (z : ℂ) : (z.im : ℂ) = (z - conj(z))/(2 * I) :=
-by {rw sub_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
-  rw [mul_right_comm, mul_div_cancel_left _ (mul_ne_zero two_ne_zero' I_ne_zero : 2 * I ≠ 0)]}
+by { rw sub_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
+  rw [mul_right_comm, mul_div_cancel_left _ (mul_ne_zero two_ne_zero' I_ne_zero : 2 * I ≠ 0)] }
 
 /-! ### Absolute value -/
 

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -370,8 +370,8 @@ by { rw add_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
 
 /-- A complex number `z` minus its conjugate `conj z` is `2i` times its imaginary part. -/
 theorem im_eq_sub_conj (z : ℂ) : (z.im : ℂ) = (z - conj(z))/(2 * I) :=
-by { rw sub_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
-  rw [mul_right_comm, mul_div_cancel_left _ (mul_ne_zero two_ne_zero' I_ne_zero : 2 * I ≠ 0)] }
+by simp only [sub_conj, of_real_mul, of_real_one, of_real_bit0, mul_right_comm, 
+     mul_div_cancel_left _ (mul_ne_zero two_ne_zero' I_ne_zero : 2 * I ≠ 0)]
 
 /-! ### Absolute value -/
 

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -365,8 +365,8 @@ by rwa [← of_real_nat_cast, of_real_eq_zero, nat.cast_eq_zero] at h
 
 /-- A complex number `z` plus its conjugate `conj z` is `2` times its real part. -/
 theorem re_eq_add_conj (z : ℂ) : (z.re : ℂ) = (z + conj z) / 2 :=
-by {rw add_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
-  rw [mul_div_cancel_left (z.re:ℂ) two_ne_zero']}
+by { rw add_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
+  rw [mul_div_cancel_left (z.re:ℂ) two_ne_zero'] }
 
 /-- A complex number `z` minus its conjugate `conj z` is `2i` times its imaginary part. -/
 theorem im_eq_sub_conj (z : ℂ) : (z.im : ℂ) = (z - conj(z))/(2 * I) :=

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -363,10 +363,12 @@ instance char_zero_complex : char_zero ℂ :=
 char_zero_of_inj_zero $ λ n h,
 by rwa [← of_real_nat_cast, of_real_eq_zero, nat.cast_eq_zero] at h
 
+/-- A complex number `z` plus its conjuagate `conj z` is `2` times it's real part -/
 theorem re_eq_add_conj (z : ℂ) : (z.re : ℂ) = (z + conj z) / 2 :=
 by {rw add_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
   rw [mul_div_cancel_left (z.re:ℂ) two_ne_zero']}
 
+/-- A complex number `z` minus its conjuagate `conj z` is `2i` times it's imaginary part -/
 theorem im_eq_sub_conj (z : ℂ) : (z.im : ℂ) = (z - conj(z))/(2 * I) :=
 by {rw sub_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
   rw [mul_right_comm, mul_div_cancel_left _ (mul_ne_zero two_ne_zero' I_ne_zero : 2 * I ≠ 0)]}

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -363,7 +363,7 @@ instance char_zero_complex : char_zero ℂ :=
 char_zero_of_inj_zero $ λ n h,
 by rwa [← of_real_nat_cast, of_real_eq_zero, nat.cast_eq_zero] at h
 
-/-- A complex number `z` plus its conjuagate `conj z` is `2` times it's real part -/
+/-- A complex number `z` plus its conjugate `conj z` is `2` times its real part. -/
 theorem re_eq_add_conj (z : ℂ) : (z.re : ℂ) = (z + conj z) / 2 :=
 by {rw add_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
   rw [mul_div_cancel_left (z.re:ℂ) two_ne_zero']}

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -368,7 +368,7 @@ theorem re_eq_add_conj (z : ℂ) : (z.re : ℂ) = (z + conj z) / 2 :=
 by {rw add_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
   rw [mul_div_cancel_left (z.re:ℂ) two_ne_zero']}
 
-/-- A complex number `z` minus its conjuagate `conj z` is `2i` times it's imaginary part -/
+/-- A complex number `z` minus its conjugate `conj z` is `2i` times its imaginary part. -/
 theorem im_eq_sub_conj (z : ℂ) : (z.im : ℂ) = (z - conj(z))/(2 * I) :=
 by { rw sub_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
   rw [mul_right_comm, mul_div_cancel_left _ (mul_ne_zero two_ne_zero' I_ne_zero : 2 * I ≠ 0)] }

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -365,8 +365,8 @@ by rwa [← of_real_nat_cast, of_real_eq_zero, nat.cast_eq_zero] at h
 
 /-- A complex number `z` plus its conjugate `conj z` is `2` times its real part. -/
 theorem re_eq_add_conj (z : ℂ) : (z.re : ℂ) = (z + conj z) / 2 :=
-by { rw add_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
-  rw [mul_div_cancel_left (z.re:ℂ) two_ne_zero'] }
+by simp only [add_conj, of_real_mul, of_real_one, of_real_bit0, 
+     mul_div_cancel_left (z.re:ℂ) two_ne_zero']
 
 /-- A complex number `z` minus its conjugate `conj z` is `2i` times its imaginary part. -/
 theorem im_eq_sub_conj (z : ℂ) : (z.im : ℂ) = (z - conj(z))/(2 * I) :=

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -366,6 +366,10 @@ by rwa [← of_real_nat_cast, of_real_eq_zero, nat.cast_eq_zero] at h
 theorem re_eq_add_conj (z : ℂ) : (z.re : ℂ) = (z + conj z) / 2 :=
 by rw [add_conj]; simp; rw [mul_div_cancel_left (z.re:ℂ) two_ne_zero']
 
+theorem im_eq_sub_conj (z : ℂ) : (z.im : ℂ) = (z - conj(z))/(2 * I) :=
+by rw sub_conj; simp; rw [mul_right_comm, mul_div_cancel_left _
+  (mul_ne_zero two_ne_zero' I_ne_zero : 2 * I ≠ 0)]
+
 /-! ### Absolute value -/
 
 /-- The complex absolute value function, defined as the square root of the norm squared. -/

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -364,11 +364,12 @@ char_zero_of_inj_zero $ λ n h,
 by rwa [← of_real_nat_cast, of_real_eq_zero, nat.cast_eq_zero] at h
 
 theorem re_eq_add_conj (z : ℂ) : (z.re : ℂ) = (z + conj z) / 2 :=
-by rw [add_conj]; simp; rw [mul_div_cancel_left (z.re:ℂ) two_ne_zero']
+by {rw add_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
+  rw [mul_div_cancel_left (z.re:ℂ) two_ne_zero']}
 
 theorem im_eq_sub_conj (z : ℂ) : (z.im : ℂ) = (z - conj(z))/(2 * I) :=
-by rw sub_conj; simp; rw [mul_right_comm, mul_div_cancel_left _
-  (mul_ne_zero two_ne_zero' I_ne_zero : 2 * I ≠ 0)]
+by {rw sub_conj, simp only [of_real_mul, of_real_one, of_real_bit0],
+  rw [mul_right_comm, mul_div_cancel_left _ (mul_ne_zero two_ne_zero' I_ne_zero : 2 * I ≠ 0)]}
 
 /-! ### Absolute value -/
 


### PR DESCRIPTION
Adds `im_eq_sub_conj`, which I couldn't find in the library.