### PR TITLE
[Merged by Bors] - feat(data/nat/modeq): add missing lemmas for int and nat regarding dvd

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -384,12 +384,8 @@ begin
   cases H with k hk,
   rw hk,
   change c ≠ 0 at h1,
-  rw mul_comm c k,
-  rw int.add_mul_div_right _ _ h1,
-  rw ←zero_add (k * c),
-  rw int.add_mul_div_right _ _ h1,
-  rw int.zero_div,
-  rw zero_add
+  rw [mul_comm c k, int.add_mul_div_right _ _ h1, ←zero_add (k * c), int.add_mul_div_right _ _ h1,
+      int.zero_div, zero_add]
 end
 
 protected theorem add_mul_div_left (a : ℤ) {b : ℤ} (c : ℤ) (H : b ≠ 0) :

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -379,14 +379,14 @@ end
 protected theorem add_div_of_dvd_right (a b c : ℤ) (H : c ∣ b) :
   (a + b) / c = a / c + b / c :=
 begin
-  by_cases h1 : c=0,
+  by_cases h1 : c = 0,
   {simp [h1],},
   cases H with k hk,
   rw hk,
-  change c≠0 at h1,
+  change c ≠ 0 at h1,
   rw mul_comm c k,
   rw int.add_mul_div_right _ _ h1,
-  rw <-zero_add (k*c),
+  rw <-zero_add (k * c),
   rw int.add_mul_div_right _ _ h1,
   rw int.zero_div,
   rw zero_add

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -380,7 +380,7 @@ protected theorem add_div_of_dvd_right (a b c : ℤ) (H : c ∣ b) :
   (a + b) / c = a / c + b / c :=
 begin
   by_cases h1 : c = 0,
-  {simp [h1],},
+  { simp [h1] },
   cases H with k hk,
   rw hk,
   change c ≠ 0 at h1,

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -392,7 +392,7 @@ protected theorem add_mul_div_left (a : ℤ) {b : ℤ} (c : ℤ) (H : b ≠ 0) :
     (a + b * c) / b = a / b + c :=
 by rw [mul_comm, int.add_mul_div_right _ _ H]
 
-protected theorem add_div_of_dvd_left (a b c : ℤ) (H : c ∣ a) :
+protected theorem add_div_of_dvd_left {a b c : ℤ} (H : c ∣ a) :
   (a + b) / c = a / c + b / c :=
 begin
   rw [add_comm, int.add_div_of_dvd_right _ _ _ H, add_comm]

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -394,9 +394,7 @@ by rw [mul_comm, int.add_mul_div_right _ _ H]
 
 protected theorem add_div_of_dvd_left {a b c : ℤ} (H : c ∣ a) :
   (a + b) / c = a / c + b / c :=
-begin
-  rw [add_comm, int.add_div_of_dvd_right H, add_comm]
-end
+by rw [add_comm, int.add_div_of_dvd_right H, add_comm]
 
 @[simp] protected theorem mul_div_cancel (a : ℤ) {b : ℤ} (H : b ≠ 0) : a * b / b = a :=
 by have := int.add_mul_div_right 0 a H;

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -376,6 +376,22 @@ match lt_trichotomy c 0 with
 | or.inr (or.inr hgt) := this hgt
 end
 
+protected theorem add_mul_div_right' (a b c : ℤ) (H : c ∣ b) :
+  (a + b) / c = a / c + b / c :=
+begin
+by_cases h1 : c=0,
+{simp [h1],},
+cases H with k hk,
+rw hk,
+change c≠0 at h1,
+rw mul_comm c k,
+rw int.add_mul_div_right _ _ h1,
+rw <-zero_add (k*c),
+rw int.add_mul_div_right _ _ h1,
+rw int.zero_div,
+rw zero_add
+end
+
 protected theorem add_mul_div_left (a : ℤ) {b : ℤ} (c : ℤ) (H : b ≠ 0) :
     (a + b * c) / b = a / b + c :=
 by rw [mul_comm, int.add_mul_div_right _ _ H]
@@ -719,18 +735,6 @@ int.div_eq_of_eq_mul_right H1 (by rw [mul_comm, H2])
 theorem neg_div_of_dvd : ∀ {a b : ℤ} (H : b ∣ a), -a / b = -(a / b)
 | ._ b ⟨c, rfl⟩ := if bz : b = 0 then by simp [bz] else
   by rw [neg_mul_eq_mul_neg, int.mul_div_cancel_left _ bz, int.mul_div_cancel_left _ bz]
-
-lemma add_div_of_dvd {a b c : ℤ} :
-  c ∣ a → c ∣ b → (a + b) / c = a / c + b / c :=
-begin
-  intros h1 h2,
-  by_cases h3 : c = 0,
-  { rw [h3, zero_dvd_iff] at *,
-    rw [h1, h2, h3], refl },
-  { apply mul_right_cancel' h3,
-    rw add_mul, repeat {rw [int.div_mul_cancel]};
-    try {apply dvd_add}; assumption }
-end
 
 theorem div_sign : ∀ a b, a / sign b = a * sign b
 | a (n+1:ℕ) := by unfold sign; simp

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -738,14 +738,6 @@ theorem neg_div_of_dvd : ∀ {a b : ℤ} (H : b ∣ a), -a / b = -(a / b)
 | ._ b ⟨c, rfl⟩ := if bz : b = 0 then by simp [bz] else
   by rw [neg_mul_eq_mul_neg, int.mul_div_cancel_left _ bz, int.mul_div_cancel_left _ bz]
 
--- TODO : Remove this in favour of only add_div_of_dvd_right.
-lemma add_div_of_dvd {a b c : ℤ} :
-  c ∣ a → c ∣ b → (a + b) / c = a / c + b / c :=
-begin
-  intros h1 h2,
-  exact int.add_div_of_dvd_right a b c h2
-end
-
 theorem div_sign : ∀ a b, a / sign b = a * sign b
 | a (n+1:ℕ) := by unfold sign; simp
 | a 0       := by simp [sign]

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -376,6 +376,10 @@ match lt_trichotomy c 0 with
 | or.inr (or.inr hgt) := this hgt
 end
 
+protected theorem add_mul_div_left (a : ℤ) {b : ℤ} (c : ℤ) (H : b ≠ 0) :
+    (a + b * c) / b = a / b + c :=
+by rw [mul_comm, int.add_mul_div_right _ _ H]
+
 protected theorem add_div_of_dvd_right {a b c : ℤ} (H : c ∣ b) :
   (a + b) / c = a / c + b / c :=
 begin
@@ -387,10 +391,6 @@ begin
   rw [mul_comm c k, int.add_mul_div_right _ _ h1, ←zero_add (k * c), int.add_mul_div_right _ _ h1,
       int.zero_div, zero_add]
 end
-
-protected theorem add_mul_div_left (a : ℤ) {b : ℤ} (c : ℤ) (H : b ≠ 0) :
-    (a + b * c) / b = a / b + c :=
-by rw [mul_comm, int.add_mul_div_right _ _ H]
 
 protected theorem add_div_of_dvd_left {a b c : ℤ} (H : c ∣ a) :
   (a + b) / c = a / c + b / c :=

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -376,7 +376,7 @@ match lt_trichotomy c 0 with
 | or.inr (or.inr hgt) := this hgt
 end
 
-protected theorem add_div_of_dvd_right (a b c : ℤ) (H : c ∣ b) :
+protected theorem add_div_of_dvd_right {a b c : ℤ} (H : c ∣ b) :
   (a + b) / c = a / c + b / c :=
 begin
   by_cases h1 : c = 0,

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -376,7 +376,7 @@ match lt_trichotomy c 0 with
 | or.inr (or.inr hgt) := this hgt
 end
 
-protected theorem add_mul_div_right' (a b c : ℤ) (H : c ∣ b) :
+protected theorem add_div_of_dvd_right (a b c : ℤ) (H : c ∣ b) :
   (a + b) / c = a / c + b / c :=
 begin
 by_cases h1 : c=0,
@@ -735,6 +735,14 @@ int.div_eq_of_eq_mul_right H1 (by rw [mul_comm, H2])
 theorem neg_div_of_dvd : ∀ {a b : ℤ} (H : b ∣ a), -a / b = -(a / b)
 | ._ b ⟨c, rfl⟩ := if bz : b = 0 then by simp [bz] else
   by rw [neg_mul_eq_mul_neg, int.mul_div_cancel_left _ bz, int.mul_div_cancel_left _ bz]
+
+-- TODO : Remove this in favour of only add_div_of_dvd_right.
+lemma add_div_of_dvd {a b c : ℤ} :
+  c ∣ a → c ∣ b → (a + b) / c = a / c + b / c :=
+begin
+  intros h1 h2,
+  exact int.add_div_of_dvd_right a b c h2
+end
 
 theorem div_sign : ∀ a b, a / sign b = a * sign b
 | a (n+1:ℕ) := by unfold sign; simp

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -392,6 +392,12 @@ protected theorem add_mul_div_left (a : ℤ) {b : ℤ} (c : ℤ) (H : b ≠ 0) :
     (a + b * c) / b = a / b + c :=
 by rw [mul_comm, int.add_mul_div_right _ _ H]
 
+protected theorem add_div_of_dvd_left (a b c : ℤ) (H : c ∣ a) :
+  (a + b) / c = a / c + b / c :=
+begin
+  rw [add_comm, int.add_div_of_dvd_right _ _ _ H, add_comm]
+end
+
 @[simp] protected theorem mul_div_cancel (a : ℤ) {b : ℤ} (H : b ≠ 0) : a * b / b = a :=
 by have := int.add_mul_div_right 0 a H;
    rwa [zero_add, int.zero_div, zero_add] at this

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -379,17 +379,17 @@ end
 protected theorem add_div_of_dvd_right (a b c : ℤ) (H : c ∣ b) :
   (a + b) / c = a / c + b / c :=
 begin
-by_cases h1 : c=0,
-{simp [h1],},
-cases H with k hk,
-rw hk,
-change c≠0 at h1,
-rw mul_comm c k,
-rw int.add_mul_div_right _ _ h1,
-rw <-zero_add (k*c),
-rw int.add_mul_div_right _ _ h1,
-rw int.zero_div,
-rw zero_add
+  by_cases h1 : c=0,
+  {simp [h1],},
+  cases H with k hk,
+  rw hk,
+  change c≠0 at h1,
+  rw mul_comm c k,
+  rw int.add_mul_div_right _ _ h1,
+  rw <-zero_add (k*c),
+  rw int.add_mul_div_right _ _ h1,
+  rw int.zero_div,
+  rw zero_add
 end
 
 protected theorem add_mul_div_left (a : ℤ) {b : ℤ} (c : ℤ) (H : b ≠ 0) :

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -395,7 +395,7 @@ by rw [mul_comm, int.add_mul_div_right _ _ H]
 protected theorem add_div_of_dvd_left {a b c : ℤ} (H : c ∣ a) :
   (a + b) / c = a / c + b / c :=
 begin
-  rw [add_comm, int.add_div_of_dvd_right _ _ _ H, add_comm]
+  rw [add_comm, int.add_div_of_dvd_right H, add_comm]
 end
 
 @[simp] protected theorem mul_div_cancel (a : ℤ) {b : ℤ} (H : b ≠ 0) : a * b / b = a :=

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -386,7 +386,7 @@ begin
   change c ≠ 0 at h1,
   rw mul_comm c k,
   rw int.add_mul_div_right _ _ h1,
-  rw <-zero_add (k * c),
+  rw ←zero_add (k * c),
   rw int.add_mul_div_right _ _ h1,
   rw int.zero_div,
   rw zero_add

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -209,8 +209,8 @@ lemma add_div_eq_of_add_mod_lt {a b c : ℕ} (hc : a % c + b % c < c) :
 if hc0 : c = 0 then by simp [hc0]
 else by rw [add_div (nat.pos_of_ne_zero hc0), if_neg (not_le_of_lt hc), add_zero]
 
-lemma add_div_eq_of_dvd {a b c : ℕ} (hca : c ∣ a) :
-  (a + b)/c = a/c + b/c :=
+protected lemma add_div_of_dvd_right {a b c : ℕ} (hca : c ∣ a) :
+  (a + b) / c = a / c + b / c :=
 if h : c = 0 then by simp [h] else add_div_eq_of_add_mod_lt begin
   rw [nat.mod_eq_zero_of_dvd hca, zero_add],
   exact nat.mod_lt _ (pos_iff_ne_zero.mpr h),

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -209,6 +209,13 @@ lemma add_div_eq_of_add_mod_lt {a b c : ℕ} (hc : a % c + b % c < c) :
 if hc0 : c = 0 then by simp [hc0]
 else by rw [add_div (nat.pos_of_ne_zero hc0), if_neg (not_le_of_lt hc), add_zero]
 
+lemma add_div_eq_of_dvd {a b c : ℕ} (hca : c ∣ a) :
+  (a + b)/c = a/c + b/c :=
+if h : c = 0 then by simp [h] else add_div_eq_of_add_mod_lt begin
+  rw [nat.mod_eq_zero_of_dvd hca, zero_add],
+  exact nat.mod_lt _ (pos_iff_ne_zero.mpr h),
+end
+
 lemma add_div_eq_of_le_mod_add_mod {a b c : ℕ} (hc : c ≤ a % c + b % c) (hc0 : 0 < c) :
   (a + b) / c = a / c + b / c + 1 :=
 by rw [add_div hc0, if_pos hc]

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -218,9 +218,7 @@ end
 
 protected lemma add_div_of_dvd_left {a b c : ℕ} (hca : c ∣ b) :
   (a + b) / c = a / c + b / c :=
-begin
-  rwa [add_comm, nat.add_div_of_dvd_right, add_comm]
-end
+by rwa [add_comm, nat.add_div_of_dvd_right, add_comm]
 
 lemma add_div_eq_of_le_mod_add_mod {a b c : ℕ} (hc : c ≤ a % c + b % c) (hc0 : 0 < c) :
   (a + b) / c = a / c + b / c + 1 :=

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -216,6 +216,12 @@ if h : c = 0 then by simp [h] else add_div_eq_of_add_mod_lt begin
   exact nat.mod_lt _ (pos_iff_ne_zero.mpr h),
 end
 
+protected lemma add_div_of_dvd_left {a b c : ℕ} (hca : c ∣ b) :
+  (a + b) / c = a / c + b / c :=
+begin
+  rwa [add_comm, nat.add_div_of_dvd_right, add_comm]
+end
+
 lemma add_div_eq_of_le_mod_add_mod {a b c : ℕ} (hc : c ≤ a % c + b % c) (hc0 : 0 < c) :
   (a + b) / c = a / c + b / c + 1 :=
 by rw [add_div hc0, if_pos hc]

--- a/src/tactic/omega/coeffs.lean
+++ b/src/tactic/omega/coeffs.lean
@@ -290,7 +290,7 @@ lemma dvd_val {as : list int} {i : int} :
 | (m+1) :=
   begin
     unfold val_between,
-    rw [@val_between_map_div m, int.add_div_of_dvd (dvd_val_between h1)],
+    rw [@val_between_map_div m, int.add_div_of_dvd_right],
     apply fun_mono_2 rfl,
     { apply calc get (l + m) (list.map (λ (x : ℤ), x / i) as) * v (l + m)
           = ((get (l + m) as) / i) * v (l + m) :

--- a/src/tactic/omega/term.lean
+++ b/src/tactic/omega/term.lean
@@ -74,7 +74,7 @@ lemma val_div {v : nat → int} {i b : int} {as : list int} :
   i ∣ b → (∀ x ∈ as, i ∣ x) → (div i (b,as)).val v = (val v (b,as)) / i :=
 begin
   intros h1 h2, simp only [val, div, list.map],
-  rw [int.add_div_of_dvd_left _ _ _ h1],
+  rw [int.add_div_of_dvd_left h1],
   apply fun_mono_2 rfl,
   rw ← coeffs.val_map_div h2
 end

--- a/src/tactic/omega/term.lean
+++ b/src/tactic/omega/term.lean
@@ -74,7 +74,7 @@ lemma val_div {v : nat → int} {i b : int} {as : list int} :
   i ∣ b → (∀ x ∈ as, i ∣ x) → (div i (b,as)).val v = (val v (b,as)) / i :=
 begin
   intros h1 h2, simp only [val, div, list.map],
-  rw [int.add_div_of_dvd h1 (coeffs.dvd_val h2)],
+  rw [int.add_div_of_dvd_left _ _ _ h1],
   apply fun_mono_2 rfl,
   rw ← coeffs.val_map_div h2
 end


### PR DESCRIPTION
Adding lemmas `(a+b)/c=a/c+b/c` if `c` divides `a` for `a b c : nat` and `a b c : int` after discussion on Zulip https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/nat_add_div

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
