### PR TITLE
[Merged by Bors] - feat(analysis/analytic/basic): `f (x + y) - p.partial_sum n y = O(∥y∥ⁿ)`

### DIFF
--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -203,8 +203,11 @@ lemma lt_div_iff_of_neg' (hc : c < 0) : a < b / c ↔ b < c * a :=
 by rw [mul_comm, lt_div_iff_of_neg hc]
 
 /-- One direction of `div_le_iff` where `b` is allowed to be `0` (but `c` must be nonnegative) -/
-lemma div_le_iff_of_nonneg_of_le (hb : 0 ≤ b) (hc : 0 ≤ c) (h : a ≤ c * b) : a / b ≤ c :=
+lemma div_le_of_nonneg_of_le_mul (hb : 0 ≤ b) (hc : 0 ≤ c) (h : a ≤ c * b) : a / b ≤ c :=
 by { rcases eq_or_lt_of_le hb with rfl|hb', simp [hc], rwa [div_le_iff hb'] }
+
+lemma div_le_one_of_le (h : a ≤ b) (hb : 0 ≤ b) : a / b ≤ 1 :=
+div_le_of_nonneg_of_le_mul hb zero_le_one $ by rwa one_mul
 
 /-!
 ### Bi-implications of inequalities using inversions

--- a/src/analysis/analytic/basic.lean
+++ b/src/analysis/analytic/basic.lean
@@ -321,7 +321,7 @@ lemma has_fpower_series_on_ball.uniform_geometric_approx' {r' : ℝ≥0}
   ∃ (a ∈ Ioo (0 : ℝ) 1) (C > 0), (∀ y ∈ metric.ball (0 : E) r', ∀ n,
     ∥f (x + y) - p.partial_sum n y∥ ≤ C * (a * (∥y∥ / r')) ^ n) :=
 begin
-  obtain ⟨a, ha : a ∈ Ioo (0 : ℝ) 1, C : ℝ, hC : 0 < C, hp⟩ :=
+  obtain ⟨a, ha, C, hC, hp⟩ : ∃ (a ∈ Ioo (0 : ℝ) 1) (C > 0), ∀ n, ∥p n∥ * r' ^n ≤ C * a^n :=
     p.norm_mul_pow_le_mul_pow_of_lt_radius (h.trans_le hf.r_le),
   refine ⟨a, ha, C / (1 - a), div_pos hC (sub_pos.2 ha.2), λ y hy n, _⟩,
   have yr' : ∥y∥ < r', by { rw ball_0_eq at hy, exact hy },
@@ -334,7 +334,7 @@ begin
     from mul_le_of_le_one_right ha.1.le (div_le_one_of_le yr'.le r'.coe_nonneg),
   suffices : ∥p.partial_sum n y - f (x + y)∥ ≤ C * (a * (∥y∥ / r')) ^ n / (1 - a * (∥y∥ / r')),
   { refine this.trans _,
-    apply_rules [div_le_div_of_le_left, sub_pos.2, div_nonneg, mul_nonneg, pow_nonneg, hC.le,
+    apply_rules [div_le_div_of_le_left, sub_pos.2, div_nonneg, mul_nonneg, pow_nonneg, hC.lt.le,
       ha.1.le, norm_nonneg, nnreal.coe_nonneg, ha.2, (sub_le_sub_iff_left _).2] },
   apply norm_sub_le_of_geometric_bound_of_has_sum (ya.trans_lt ha.2) _ (hf.has_sum this),
   assume n,
@@ -353,10 +353,12 @@ lemma has_fpower_series_on_ball.uniform_geometric_approx {r' : ℝ≥0}
   ∃ (a ∈ Ioo (0 : ℝ) 1) (C > 0), (∀ y ∈ metric.ball (0 : E) r', ∀ n,
     ∥f (x + y) - p.partial_sum n y∥ ≤ C * a ^ n) :=
 begin
-  obtain ⟨a, ha, C, hC : 0 < C, hp⟩ := hf.uniform_geometric_approx' h,
+  obtain ⟨a, ha, C, hC, hp⟩ : ∃ (a ∈ Ioo (0 : ℝ) 1) (C > 0),
+    (∀ y ∈ metric.ball (0 : E) r', ∀ n, ∥f (x + y) - p.partial_sum n y∥ ≤ C * (a * (∥y∥ / r')) ^ n),
+    from hf.uniform_geometric_approx' h,
   refine ⟨a, ha, C, hC, λ y hy n, (hp y hy n).trans _⟩,
   have yr' : ∥y∥ < r', by rwa ball_0_eq at hy,
-  refine mul_le_mul_of_nonneg_left (pow_le_pow_of_le_left _ _ _) hC.le,
+  refine mul_le_mul_of_nonneg_left (pow_le_pow_of_le_left _ _ _) hC.lt.le,
   exacts [mul_nonneg ha.1.le (div_nonneg (norm_nonneg y) r'.coe_nonneg),
     mul_le_of_le_one_right ha.1.le (div_le_one_of_le yr'.le r'.coe_nonneg)]
 end
@@ -367,7 +369,9 @@ lemma has_fpower_series_at.is_O_sub_partial_sum_pow (hf : has_fpower_series_at f
 begin
   rcases hf with ⟨r, hf⟩,
   rcases ennreal.lt_iff_exists_nnreal_btwn.1 hf.r_pos with ⟨r', r'0, h⟩,
-  obtain ⟨a, ha, C, hC : 0 < C, hp⟩ := hf.uniform_geometric_approx' h,
+  obtain ⟨a, ha, C, hC, hp⟩ : ∃ (a ∈ Ioo (0 : ℝ) 1) (C > 0),
+    (∀ y ∈ metric.ball (0 : E) r', ∀ n, ∥f (x + y) - p.partial_sum n y∥ ≤ C * (a * (∥y∥ / r')) ^ n),
+    from hf.uniform_geometric_approx' h,
   refine is_O_iff.2 ⟨C * (a / r') ^ n, _⟩,
   replace r'0 : 0 < (r' : ℝ), by exact_mod_cast r'0,
   filter_upwards [metric.ball_mem_nhds (0 : E) r'0], intros y hy,
@@ -382,7 +386,9 @@ lemma has_fpower_series_on_ball.tendsto_uniformly_on {r' : ℝ≥0}
   tendsto_uniformly_on (λ n y, p.partial_sum n y)
     (λ y, f (x + y)) at_top (metric.ball (0 : E) r') :=
 begin
-  rcases hf.uniform_geometric_approx h with ⟨a, ha, C, hC, hp⟩,
+  obtain ⟨a, ha, C, hC, hp⟩ : ∃ (a ∈ Ioo (0 : ℝ) 1) (C > 0),
+    (∀ y ∈ metric.ball (0 : E) r', ∀ n, ∥f (x + y) - p.partial_sum n y∥ ≤ C * a ^ n),
+    from hf.uniform_geometric_approx h,
   refine metric.tendsto_uniformly_on_iff.2 (λ ε εpos, _),
   have L : tendsto (λ n, (C : ℝ) * a^n) at_top (𝓝 ((C : ℝ) * 0)) :=
     tendsto_const_nhds.mul (tendsto_pow_at_top_nhds_0_of_lt_1 ha.1.le ha.2),

--- a/src/analysis/analytic/basic.lean
+++ b/src/analysis/analytic/basic.lean
@@ -312,28 +312,66 @@ lemma has_fpower_series_at.coeff_zero (hf : has_fpower_series_at f pf x) (v : fi
 let ⟨rf, hrf⟩ := hf in hrf.coeff_zero v
 
 /-- If a function admits a power series expansion, then it is exponentially close to the partial
-sums of this power series on strict subdisks of the disk of convergence. -/
-lemma has_fpower_series_on_ball.uniform_geometric_approx {r' : ℝ≥0}
+sums of this power series on strict subdisks of the disk of convergence.
+
+This version provides an upper estimate that decreases both in `∥y∥` and `n`. See also
+`has_fpower_series_on_ball.uniform_geometric_approx` for a weaker version. -/
+lemma has_fpower_series_on_ball.uniform_geometric_approx' {r' : ℝ≥0}
   (hf : has_fpower_series_on_ball f p x r) (h : (r' : ennreal) < r) :
   ∃ (a ∈ Ioo (0 : ℝ) 1) (C > 0), (∀ y ∈ metric.ball (0 : E) r', ∀ n,
-  ∥f (x + y) - p.partial_sum n y∥ ≤ C * a ^ n) :=
+    ∥f (x + y) - p.partial_sum n y∥ ≤ C * (a * (∥y∥ / r')) ^ n) :=
 begin
-  obtain ⟨a, ha, C, hC, hp⟩ : ∃ (a ∈ Ioo (0 : ℝ) 1) (C > 0), ∀ n, ∥p n∥ * r' ^n ≤ C * a^n :=
+  obtain ⟨a, ha : a ∈ Ioo (0 : ℝ) 1, C : ℝ, hC : 0 < C, hp⟩ :=
     p.norm_mul_pow_le_mul_pow_of_lt_radius (h.trans_le hf.r_le),
   refine ⟨a, ha, C / (1 - a), div_pos hC (sub_pos.2 ha.2), λ y hy n, _⟩,
   have yr' : ∥y∥ < r', by { rw ball_0_eq at hy, exact hy },
+  have hr'0 : 0 < (r' : ℝ), from (norm_nonneg _).trans_lt yr',
   have : y ∈ emetric.ball (0 : E) r,
   { refine mem_emetric_ball_0_iff.2 (lt_trans _ h),
     exact_mod_cast yr' },
   rw [norm_sub_rev, ← mul_div_right_comm],
-  apply norm_sub_le_of_geometric_bound_of_has_sum ha.2 _ (hf.has_sum this),
+  have ya : a * (∥y∥ / ↑r') ≤ a,
+    from mul_le_of_le_one_right ha.1.le (div_le_one_of_le yr'.le r'.coe_nonneg),
+  suffices : ∥p.partial_sum n y - f (x + y)∥ ≤ C * (a * (∥y∥ / r')) ^ n / (1 - a * (∥y∥ / r')),
+  { refine this.trans _,
+    apply_rules [div_le_div_of_le_left, sub_pos.2, div_nonneg, mul_nonneg, pow_nonneg, hC.le,
+      ha.1.le, norm_nonneg, nnreal.coe_nonneg, ha.2, (sub_le_sub_iff_left _).2] },
+  apply norm_sub_le_of_geometric_bound_of_has_sum (ya.trans_lt ha.2) _ (hf.has_sum this),
   assume n,
   calc ∥(p n) (λ (i : fin n), y)∥ ≤ ∥p n∥ * (∏ i : fin n, ∥y∥) :
       continuous_multilinear_map.le_op_norm _ _
-    ... = ∥p n∥ * ∥y∥ ^ n : by simp
-    ... ≤ ∥p n∥ * r' ^ n :
-      mul_le_mul_of_nonneg_left (pow_le_pow_of_le_left (norm_nonneg _) yr'.le _) (norm_nonneg _)
-    ... ≤ C * a ^ n : hp n
+    ... = (∥p n∥ * r' ^ n) * (∥y∥ / r') ^ n : by field_simp [hr'0.ne', mul_right_comm]
+    ... ≤ (C * a ^ n) * (∥y∥ / r') ^ n :
+      mul_le_mul_of_nonneg_right (hp n) (pow_nonneg (div_nonneg (norm_nonneg _) r'.coe_nonneg) _)
+    ... ≤ C * (a * (∥y∥ / r')) ^ n : by rw [mul_pow, mul_assoc]
+end
+
+/-- If a function admits a power series expansion, then it is exponentially close to the partial
+sums of this power series on strict subdisks of the disk of convergence. -/
+lemma has_fpower_series_on_ball.uniform_geometric_approx {r' : ℝ≥0}
+  (hf : has_fpower_series_on_ball f p x r) (h : (r' : ennreal) < r) :
+  ∃ (a ∈ Ioo (0 : ℝ) 1) (C > 0), (∀ y ∈ metric.ball (0 : E) r', ∀ n,
+    ∥f (x + y) - p.partial_sum n y∥ ≤ C * a ^ n) :=
+begin
+  obtain ⟨a, ha, C, hC : 0 < C, hp⟩ := hf.uniform_geometric_approx' h,
+  refine ⟨a, ha, C, hC, λ y hy n, (hp y hy n).trans _⟩,
+  have yr' : ∥y∥ < r', by rwa ball_0_eq at hy,
+  refine mul_le_mul_of_nonneg_left (pow_le_pow_of_le_left _ _ _) hC.le,
+  exacts [mul_nonneg ha.1.le (div_nonneg (norm_nonneg y) r'.coe_nonneg),
+    mul_le_of_le_one_right ha.1.le (div_le_one_of_le yr'.le r'.coe_nonneg)]
+end
+
+/-- Taylor formula for an analytic function, `is_O` version. -/
+lemma has_fpower_series_at.is_O_sub_partial_sum_pow (hf : has_fpower_series_at f p x) (n : ℕ) :
+  is_O (λ y : E, f (x + y) - p.partial_sum n y) (λ y, ∥y∥ ^ n) (𝓝 0) :=
+begin
+  rcases hf with ⟨r, hf⟩,
+  rcases ennreal.lt_iff_exists_nnreal_btwn.1 hf.r_pos with ⟨r', r'0, h⟩,
+  obtain ⟨a, ha, C, hC : 0 < C, hp⟩ := hf.uniform_geometric_approx' h,
+  refine is_O_iff.2 ⟨C * (a / r') ^ n, _⟩,
+  replace r'0 : 0 < (r' : ℝ), by exact_mod_cast r'0,
+  filter_upwards [metric.ball_mem_nhds (0 : E) r'0], intros y hy,
+  simpa [mul_pow, mul_div_assoc, mul_assoc, div_mul_eq_mul_div] using hp y hy n
 end
 
 /-- If a function admits a power series expansion at `x`, then it is the uniform limit of the

--- a/src/analysis/asymptotics.lean
+++ b/src/analysis/asymptotics.lean
@@ -251,6 +251,18 @@ theorem is_o.comp_tendsto (hfg : is_o f g l) {k : β → α} {l' : filter β} (h
   is_o (f ∘ k) (g ∘ k) l' :=
 λ c cpos, (hfg cpos).comp_tendsto hk
 
+@[simp] theorem is_O_with_map {k : β → α} {l : filter β} :
+  is_O_with c f g (map k l) ↔ is_O_with c (f ∘ k) (g ∘ k) l :=
+mem_map
+
+@[simp] theorem is_O_map {k : β → α} {l : filter β} :
+  is_O f g (map k l) ↔ is_O (f ∘ k) (g ∘ k) l :=
+by simp only [is_O, is_O_with_map]
+
+@[simp] theorem is_o_map {k : β → α} {l : filter β} :
+  is_o f g (map k l) ↔ is_o (f ∘ k) (g ∘ k) l :=
+by simp only [is_o, is_O_with_map]
+
 theorem is_O_with.mono (h : is_O_with c f g l') (hl : l ≤ l') : is_O_with c f g l :=
 hl h
 
@@ -1129,7 +1141,7 @@ begin
   { intro h,
     use (λ x, u x / v x),
     refine ⟨eventually.mono h (λ y hy, _), h.eventually_mul_div_cancel.symm⟩,
-    simpa using div_le_iff_of_nonneg_of_le (norm_nonneg _) hc hy },
+    simpa using div_le_of_nonneg_of_le_mul (norm_nonneg _) hc hy },
   { rintros ⟨φ, hφ, h⟩,
     exact is_O_with_of_eq_mul φ hφ h }
 end
@@ -1180,9 +1192,17 @@ begin
   exact (zero_pow (nat.sub_pos_of_lt h)).symm
 end
 
+theorem is_o_norm_pow_norm_pow {m n : ℕ} (h : m < n) :
+  is_o (λ(x : E'), ∥x∥^n) (λx, ∥x∥^m) (𝓝 (0 : E')) :=
+(is_o_pow_pow h).comp_tendsto tendsto_norm_zero
+
 theorem is_o_pow_id {n : ℕ} (h : 1 < n) :
   is_o (λ(x : 𝕜), x^n) (λx, x) (𝓝 0) :=
 by { convert is_o_pow_pow h, simp only [pow_one] }
+
+theorem is_o_norm_pow_id {n : ℕ} (h : 1 < n) :
+  is_o (λ(x : E'), ∥x∥^n) (λx, x) (𝓝 0) :=
+by simpa only [pow_one, is_o_norm_right] using is_o_norm_pow_norm_pow h
 
 theorem is_O_with.right_le_sub_of_lt_1 {f₁ f₂ : α → E'} (h : is_O_with c f₁ f₂ l) (hc : c < 1) :
   is_O_with (1 / (1 - c)) f₂ (λx, f₂ x - f₁ x) l :=

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -285,19 +285,8 @@ has_fderiv_at_filter_iff_tendsto
 theorem has_fderiv_at_iff_is_o_nhds_zero : has_fderiv_at f f' x ↔
   is_o (λh, f (x + h) - f x - f' h) (λh, h) (𝓝 0) :=
 begin
-  split,
-  { assume H,
-    have : tendsto (λ (z : E), z + x) (𝓝 0) (𝓝 (0 + x)),
-      from tendsto_id.add tendsto_const_nhds,
-    rw [zero_add] at this,
-    refine (H.comp_tendsto this).congr _ _;
-      intro z; simp only [function.comp, add_sub_cancel', add_comm z] },
-  { assume H,
-    have : tendsto (λ (z : E), z - x) (𝓝 x) (𝓝 (x - x)),
-      from tendsto_id.sub tendsto_const_nhds,
-    rw [sub_self] at this,
-    refine (H.comp_tendsto this).congr _ _;
-      intro z; simp only [function.comp, add_sub_cancel'_right] }
+  rw [has_fderiv_at, has_fderiv_at_filter, ← map_add_left_nhds_zero x, is_o_map],
+  simp [(∘)]
 end
 
 /-- Converse to the mean value inequality: if `f` is differentiable at `x₀` and `C`-lipschitz
@@ -305,28 +294,14 @@ on a neighborhood of `x₀` then it its derivative at `x₀` has norm bounded by
 lemma has_fderiv_at.le_of_lip {f : E → F} {f' : E →L[𝕜] F} {x₀ : E} (hf : has_fderiv_at f f' x₀)
   {s : set E} (hs : s ∈ 𝓝 x₀) {C : ℝ≥0} (hlip : lipschitz_on_with C f s) : ∥f'∥ ≤ C :=
 begin
-  replace hf : ∀ ε > 0, ∃ δ > 0, ∀ x',
-    ∥x' - x₀∥ < δ → ∥x' - x₀∥⁻¹ * ∥f x' - f x₀ - f' (x' - x₀)∥ < ε,
-    by simpa [has_fderiv_at_iff_tendsto, normed_group.tendsto_nhds_nhds] using hf,
-  obtain ⟨ε, ε_pos, hε⟩ : ∃ ε > 0, ball x₀ ε ⊆ s := mem_nhds_iff.mp hs,
-  apply real.le_of_forall_epsilon_le,
-  intros η η_pos,
-  rcases hf η η_pos with ⟨δ, δ_pos, h⟩, clear hf,
-  apply op_norm_le_of_ball (lt_min ε_pos δ_pos) (by linarith [C.coe_nonneg]: (0 : ℝ) ≤ C + η),
-  intros u u_in,
-  let x := x₀ + u,
-  rw show u = x - x₀, by rw [add_sub_cancel'],
-  have xε : x ∈ ball x₀ ε,
-    by simpa [dist_eq_norm] using ball_subset_ball (min_le_left ε δ) u_in,
-  have xδ : ∥x - x₀∥ < δ,
-    by simpa [dist_eq_norm] using ball_subset_ball (min_le_right ε δ) u_in,
-  replace h : ∥f x - f x₀ - f' (x - x₀)∥ ≤ η*∥x - x₀∥,
-  { by_cases H : x - x₀ = 0,
-    { simp [eq_of_sub_eq_zero H] },
-    { exact (inv_mul_le_iff' $ norm_pos_iff.mpr H).mp (le_of_lt $ h x xδ) } },
-  have := hlip.norm_sub_le (hε xε) (hε $ mem_ball_self ε_pos),
-  calc ∥f' (x - x₀)∥ ≤ ∥f x - f x₀∥ + ∥f x - f x₀ - f' (x - x₀)∥ : norm_le_insert _ _
-  ... ≤ (C + η) * ∥x - x₀∥ : by linarith,
+  refine real.le_of_forall_epsilon_le (λ ε ε0, op_norm_le_of_nhds_zero _ _),
+  exact add_nonneg C.coe_nonneg ε0.le,
+  have hs' := hs, rw [← map_add_left_nhds_zero x₀, mem_map] at hs',
+  filter_upwards [is_o_iff.1 (has_fderiv_at_iff_is_o_nhds_zero.1 hf) ε0, hs'], intros y hy hys,
+  have := hlip.norm_sub_le hys (mem_of_nhds hs), rw add_sub_cancel' at this,
+  calc ∥f' y∥ ≤ ∥f (x₀ + y) - f x₀∥ + ∥f (x₀ + y) - f x₀ - f' y∥ : norm_le_insert _ _
+          ... ≤ C * ∥y∥ + ε * ∥y∥                                : add_le_add this hy
+          ... = (C + ε) * ∥y∥                                    : (add_mul _ _ _).symm
 end
 
 theorem has_fderiv_at_filter.mono (h : has_fderiv_at_filter f f' x L₂) (hst : L₁ ≤ L₂) :

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -15,7 +15,7 @@ its basic properties. In particular, show that this space is itself a normed spa
 -/
 
 noncomputable theory
-open_locale classical nnreal
+open_locale classical nnreal topological_space
 
 
 variables {𝕜 : Type*} {E : Type*} {F : Type*} {G : Type*}
@@ -288,7 +288,7 @@ lipschitz_with.of_dist_le_mul $ λ x y,
   by { rw [dist_eq_norm, dist_eq_norm, ←map_sub], apply le_op_norm }
 
 lemma ratio_le_op_norm : ∥f x∥ / ∥x∥ ≤ ∥f∥ :=
-div_le_iff_of_nonneg_of_le (norm_nonneg _) f.op_norm_nonneg (le_op_norm _ _)
+div_le_of_nonneg_of_le_mul (norm_nonneg _) f.op_norm_nonneg (le_op_norm _ _)
 
 /-- The image of the unit ball under a continuous linear map is bounded. -/
 lemma unit_le_op_norm : ∥x∥ ≤ 1 → ∥f x∥ ≤ ∥f∥ :=
@@ -315,6 +315,10 @@ begin
   refine op_norm_le_of_shell ε_pos hC hc (λ x _ hx, hf x _),
   rwa ball_0_eq
 end
+
+lemma op_norm_le_of_nhds_zero {f : E →L[𝕜] F} {C : ℝ} (hC : 0 ≤ C)
+  (hf : ∀ᶠ x in 𝓝 (0 : E), ∥f x∥ ≤ C * ∥x∥) : ∥f∥ ≤ C :=
+let ⟨ε, ε0, hε⟩ := metric.eventually_nhds_iff_ball.1 hf in op_norm_le_of_ball ε0 hC hε
 
 lemma op_norm_le_of_shell' {f : E →L[𝕜] F} {ε C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C)
   {c : 𝕜} (hc : ∥c∥ < 1) (hf : ∀ x, ε * ∥c∥ ≤ ∥x∥ → ∥x∥ < ε → ∥f x∥ ≤ C * ∥x∥) :

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -54,6 +54,12 @@ protected def homeomorph.mul_left (a : G) : G ≃ₜ G :=
   continuous_inv_fun := continuous_const.mul continuous_id,
   .. equiv.mul_left a }
 
+@[simp, to_additive]
+lemma homeomorph.coe_mul_left (a : G) : ⇑(homeomorph.mul_left a) = (*) a := rfl
+
+@[to_additive]
+lemma homeomorph.mul_left_symm (a : G) : (homeomorph.mul_left a).symm = homeomorph.mul_left a⁻¹ :=
+by { ext, refl }
 
 @[to_additive]
 lemma is_open_map_mul_left (a : G) : is_open_map (λ x, a * x) :=
@@ -211,6 +217,11 @@ by simpa only [div_eq_mul_inv, nhds_prod_eq, mem_prod_self_iff, prod_subset_iff,
 @[to_additive]
 lemma nhds_translation_mul_inv (x : G) : comap (λ y : G, y * x⁻¹) (𝓝 1) = 𝓝 x :=
 ((homeomorph.mul_right x⁻¹).comap_nhds_eq 1).trans $ show 𝓝 (1 * x⁻¹⁻¹) = 𝓝 x, by simp
+
+@[simp, to_additive] lemma map_mul_left_nhds (x y : G) : map ((*) x) (𝓝 y) = 𝓝 (x * y) :=
+(homeomorph.mul_left x).map_nhds_eq y
+
+@[to_additive] lemma map_mul_left_nhds_one (x : G) : map ((*) x) (𝓝 1) = 𝓝 x := by simp
 
 @[to_additive]
 lemma topological_group.ext {G : Type*} [group G] {t t' : topological_space G}

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -30,6 +30,12 @@ rfl
 
 lemma coe_eq_to_equiv (h : α ≃ₜ β) (a : α) : h a = h.to_equiv a := rfl
 
+lemma to_equiv_injective : function.injective (to_equiv : α ≃ₜ β → α ≃ β)
+| ⟨e, h₁, h₂⟩ ⟨e', h₁', h₂'⟩ rfl := rfl
+
+@[ext] lemma ext {h h' : α ≃ₜ β} (H : ∀ x, h x = h' x) : h = h' :=
+to_equiv_injective $ equiv.ext H
+
 /-- Identity map as a homeomorphism. -/
 protected def refl (α : Type*) [topological_space α] : α ≃ₜ α :=
 { continuous_to_fun := continuous_id, continuous_inv_fun := continuous_id, .. equiv.refl α }


### PR DESCRIPTION
### Lemmas about analytic functions

* add `has_fpower_series_on_ball.uniform_geometric_approx'`, a more
  precise version of `has_fpower_series_on_ball.uniform_geometric_approx`;
* add `has_fpower_series_at.is_O_sub_partial_sum_pow`, a version of
  the Taylor formula for an analytic function;

### Lemmas about `homeomorph` and topological groups

* add `simp` lemmas `homeomorph.coe_mul_left` and
  `homeomorph.mul_left_symm`;
* add `map_mul_left_nhds` and `map_mul_left_nhds_one`;
* add `homeomorph.to_equiv_injective` and `homeomorph.ext`;

### Lemmas about `is_O`/`is_o`

* add `simp` lemmas `asymptotics.is_O_with_map`,
  `asymptotics.is_O_map`, and `asymptotics.is_o_map`;
* add `asymptotics.is_o_norm_pow_norm_pow` and
  `asymptotics.is_o_norm_pow_id`;

### Misc changes

* rename `div_le_iff_of_nonneg_of_le` to `div_le_of_nonneg_of_le_mul`;
* add `continuous_linear_map.op_norm_le_of_nhds_zero`;
* golf some proofs.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

`has_fpower_series_at.is_O_sub_partial_sum_pow` immediately implies
that an analytic function is differentiable but I want to wait till I
have a `has_strict_fderiv_at` version.