### PR TITLE
[Merged by Bors] - feat(data/mv_polynomial): stronger `degrees_X` for `nontrivial R`

### DIFF
--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -101,10 +101,10 @@ multiset.le_zero.1 $ degrees_monomial _ _
 lemma degrees_X (n : σ) : degrees (X n : mv_polynomial σ R) ≤ {n} :=
 le_trans (degrees_monomial _ _) $ le_of_eq $ to_multiset_single _ _
 
-lemma degrees_zero : degrees (0 : mv_polynomial σ R) = 0 :=
+@[simp] lemma degrees_zero : degrees (0 : mv_polynomial σ R) = 0 :=
 by { rw ← C_0, exact degrees_C 0 }
 
-lemma degrees_one : degrees (1 : mv_polynomial σ R) = 0 := degrees_C 1
+[simp] lemma degrees_one : degrees (1 : mv_polynomial σ R) = 0 := degrees_C 1
 
 lemma degrees_add (p q : mv_polynomial σ R) : (p + q).degrees ≤ p.degrees ⊔ q.degrees :=
 begin

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -98,13 +98,16 @@ le_antisymm (degrees_monomial s a) $ finset.le_sup $
 lemma degrees_C (a : R) : degrees (C a : mv_polynomial σ R) = 0 :=
 multiset.le_zero.1 $ degrees_monomial _ _
 
-lemma degrees_X (n : σ) : degrees (X n : mv_polynomial σ R) ≤ {n} :=
+lemma degrees_X' (n : σ) : degrees (X n : mv_polynomial σ R) ≤ {n} :=
 le_trans (degrees_monomial _ _) $ le_of_eq $ to_multiset_single _ _
+
+@[simp] lemma degrees_X [nontrivial R] (n : σ) : degrees (X n : mv_polynomial σ R) = {n} :=
+(degrees_monomial_eq _ _ one_ne_zero).trans (to_multiset_single _ _)
 
 @[simp] lemma degrees_zero : degrees (0 : mv_polynomial σ R) = 0 :=
 by { rw ← C_0, exact degrees_C 0 }
 
-[simp] lemma degrees_one : degrees (1 : mv_polynomial σ R) = 0 := degrees_C 1
+@[simp] lemma degrees_one : degrees (1 : mv_polynomial σ R) = 0 := degrees_C 1
 
 lemma degrees_add (p q : mv_polynomial σ R) : (p + q).degrees ≤ p.degrees ⊔ q.degrees :=
 begin

--- a/src/field_theory/finite/polynomial.lean
+++ b/src/field_theory/finite/polynomial.lean
@@ -90,7 +90,7 @@ begin
   refine le_trans (degrees_pow _ _) (nsmul_le_nsmul_of_le_right _ _),
   refine le_trans (degrees_sub _ _) _,
   rw [degrees_C, ← bot_eq_zero, sup_bot_eq],
-  exact degrees_X _
+  exact degrees_X' _
 end
 
 lemma indicator_mem_restrict_degree (c : σ → K) :


### PR DESCRIPTION
Also rename `degrees_X` to `degrees_X'` and mark `degrees_{zero,one}` with `simp`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
