### PR TITLE
[Merged by Bors] - chore(field_theory|ring_theory|linear_algebra): rename minimal_polynomial to minpoly

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -153,7 +153,7 @@ Linear algebra:
     determinant: 'matrix.det'
     invertibility: 'matrix.nonsing_inv'
   Endomorphism polynomials:
-    minimal polynomial: 'minimal_polynomial'
+    minimal polynomial: 'minpoly'
     characteristic polynomial: 'char_poly'
     Cayley-Hamilton theorem: 'aeval_self_char_poly'
   Structure theory of endomorphisms:

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -52,7 +52,7 @@ Linear algebra:
     row-reduced matrices: ''
   Endomorphism polynomials:
     annihilating polynomials: ''
-    minimal polynomial: 'minimal_polynomial'
+    minimal polynomial: 'minpoly'
     characteristic polynomial: 'char_poly'
     Cayley-Hamilton theorem: 'aeval_self_char_poly'
   Structure theory of endomorphisms:

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -731,9 +731,6 @@ src/field_theory/fixed.lean : line 27 : ERR_LIN : Line has more than 100 charact
 src/field_theory/fixed.lean : line 77 : ERR_LIN : Line has more than 100 characters
 src/field_theory/intermediate_field.lean : line 150 : ERR_LIN : Line has more than 100 characters
 src/field_theory/intermediate_field.lean : line 155 : ERR_LIN : Line has more than 100 characters
-src/field_theory/minpoly.lean : line 102 : ERR_LIN : Line has more than 100 characters
-src/field_theory/minpoly.lean : line 250 : ERR_LIN : Line has more than 100 characters
-src/field_theory/minpoly.lean : line 319 : ERR_LIN : Line has more than 100 characters
 src/field_theory/mv_polynomial.lean : line 14 : ERR_MOD : Module docstring missing, or too late
 src/field_theory/primitive_element.lean : line 29 : ERR_LIN : Line has more than 100 characters
 src/field_theory/splitting_field.lean : line 16 : ERR_MOD : Module docstring missing, or too late

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -731,9 +731,9 @@ src/field_theory/fixed.lean : line 27 : ERR_LIN : Line has more than 100 charact
 src/field_theory/fixed.lean : line 77 : ERR_LIN : Line has more than 100 characters
 src/field_theory/intermediate_field.lean : line 150 : ERR_LIN : Line has more than 100 characters
 src/field_theory/intermediate_field.lean : line 155 : ERR_LIN : Line has more than 100 characters
-src/field_theory/minimal_polynomial.lean : line 102 : ERR_LIN : Line has more than 100 characters
-src/field_theory/minimal_polynomial.lean : line 250 : ERR_LIN : Line has more than 100 characters
-src/field_theory/minimal_polynomial.lean : line 319 : ERR_LIN : Line has more than 100 characters
+src/field_theory/minpoly.lean : line 102 : ERR_LIN : Line has more than 100 characters
+src/field_theory/minpoly.lean : line 250 : ERR_LIN : Line has more than 100 characters
+src/field_theory/minpoly.lean : line 319 : ERR_LIN : Line has more than 100 characters
 src/field_theory/mv_polynomial.lean : line 14 : ERR_MOD : Module docstring missing, or too late
 src/field_theory/primitive_element.lean : line 29 : ERR_LIN : Line has more than 100 characters
 src/field_theory/splitting_field.lean : line 16 : ERR_MOD : Module docstring missing, or too late

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -300,8 +300,8 @@ begin
   by_cases x = 0,
   { rw [h, inv_zero], exact subalgebra.zero_mem (algebra.adjoin F {α}) },
 
-  let ϕ := alg_equiv.adjoin_singleton_equiv_adjoin_root_minimal_polynomial F α hα,
-  haveI := minimal_polynomial.irreducible hα,
+  let ϕ := alg_equiv.adjoin_singleton_equiv_adjoin_root_minpoly F α hα,
+  haveI := minpoly.irreducible hα,
   suffices : ϕ ⟨x, hx⟩ * (ϕ ⟨x, hx⟩)⁻¹ = 1,
   { convert subtype.mem (ϕ.symm (ϕ ⟨x, hx⟩)⁻¹),
     refine (eq_inv_of_mul_right_eq_one _).symm,
@@ -409,56 +409,56 @@ section adjoin_integral_element
 variables (F : Type*) [field F] {E : Type*} [field E] [algebra F E] {α : E}
 variables {K : Type*} [field K] [algebra F K]
 
-lemma aeval_gen_minimal_polynomial (h : is_integral F α) :
-  polynomial.aeval (adjoin_simple.gen F α) (minimal_polynomial h)  = 0 :=
+lemma aeval_gen_minpoly (h : is_integral F α) :
+  polynomial.aeval (adjoin_simple.gen F α) (minpoly h)  = 0 :=
 begin
   ext,
-  convert minimal_polynomial.aeval h,
+  convert minpoly.aeval h,
   conv in (polynomial.aeval α) { rw [← adjoin_simple.algebra_map_gen F α] },
   exact is_scalar_tower.algebra_map_aeval F F⟮α⟯ E _ _
 end
 
 /-- algebra isomorphism between `adjoin_root` and `F⟮α⟯` -/
 noncomputable def adjoin_root_equiv_adjoin (h : is_integral F α) :
-  adjoin_root (minimal_polynomial h) ≃ₐ[F] F⟮α⟯ :=
+  adjoin_root (minpoly h) ≃ₐ[F] F⟮α⟯ :=
 alg_equiv.of_bijective (alg_hom.mk (adjoin_root.lift (algebra_map F F⟮α⟯)
-  (adjoin_simple.gen F α) (aeval_gen_minimal_polynomial F h)) (ring_hom.map_one _)
+  (adjoin_simple.gen F α) (aeval_gen_minpoly F h)) (ring_hom.map_one _)
   (λ x y, ring_hom.map_mul _ x y) (ring_hom.map_zero _) (λ x y, ring_hom.map_add _ x y)
   (by { exact λ _, adjoin_root.lift_of })) (begin
-    set f := adjoin_root.lift _ _ (aeval_gen_minimal_polynomial F h),
-    haveI := minimal_polynomial.irreducible h,
+    set f := adjoin_root.lift _ _ (aeval_gen_minpoly F h),
+    haveI := minpoly.irreducible h,
     split,
     { exact ring_hom.injective f },
     { suffices : F⟮α⟯.to_subfield ≤ ring_hom.field_range ((F⟮α⟯.to_subfield.subtype).comp f),
       { exact λ x, Exists.cases_on (this (subtype.mem x)) (λ y hy, ⟨y, subtype.ext hy.2⟩) },
       exact subfield.closure_le.mpr (set.union_subset (λ x hx, Exists.cases_on hx (λ y hy, ⟨y,
         ⟨subfield.mem_top y, by { rw [ring_hom.comp_apply, adjoin_root.lift_of], exact hy }⟩⟩))
-        (set.singleton_subset_iff.mpr ⟨adjoin_root.root (minimal_polynomial h),
-        ⟨subfield.mem_top (adjoin_root.root (minimal_polynomial h)),
+        (set.singleton_subset_iff.mpr ⟨adjoin_root.root (minpoly h),
+        ⟨subfield.mem_top (adjoin_root.root (minpoly h)),
         by { rw [ring_hom.comp_apply, adjoin_root.lift_root], refl }⟩⟩)) } end)
 
 lemma adjoin_root_equiv_adjoin_apply_root (h : is_integral F α) :
-  adjoin_root_equiv_adjoin F h (adjoin_root.root (minimal_polynomial h)) =
+  adjoin_root_equiv_adjoin F h (adjoin_root.root (minpoly h)) =
     adjoin_simple.gen F α :=
 begin
   refine adjoin_root.lift_root,
-  { exact minimal_polynomial h },
-  { exact aeval_gen_minimal_polynomial F h }
+  { exact minpoly h },
+  { exact aeval_gen_minpoly F h }
 end
 
 /-- Algebra homomorphism `F⟮α⟯ →ₐ[F] K` are in bijection with the set of roots
-of `minimal_polynomial α` in `K`. -/
+of `minpoly α` in `K`. -/
 noncomputable def alg_hom_adjoin_integral_equiv (h : is_integral F α) :
-  (F⟮α⟯ →ₐ[F] K) ≃ {x // x ∈ ((minimal_polynomial h).map (algebra_map F K)).roots} :=
+  (F⟮α⟯ →ₐ[F] K) ≃ {x // x ∈ ((minpoly h).map (algebra_map F K)).roots} :=
 let ϕ := adjoin_root_equiv_adjoin F h,
-  swap1 : (F⟮α⟯ →ₐ[F] K) ≃ (adjoin_root (minimal_polynomial h) →ₐ[F] K) :=
+  swap1 : (F⟮α⟯ →ₐ[F] K) ≃ (adjoin_root (minpoly h) →ₐ[F] K) :=
   { to_fun := λ f, f.comp ϕ.to_alg_hom,
     inv_fun := λ f, f.comp ϕ.symm.to_alg_hom,
     left_inv := λ _, by { ext, simp only [alg_equiv.coe_alg_hom,
       alg_equiv.to_alg_hom_eq_coe, alg_hom.comp_apply, alg_equiv.apply_symm_apply]},
     right_inv := λ _, by { ext, simp only [alg_equiv.symm_apply_apply,
       alg_equiv.coe_alg_hom, alg_equiv.to_alg_hom_eq_coe, alg_hom.comp_apply] } },
-  swap2 := adjoin_root.equiv F K (minimal_polynomial h) (minimal_polynomial.ne_zero h) in
+  swap2 := adjoin_root.equiv F K (minpoly h) (minpoly.ne_zero h) in
 swap1.trans swap2
 
 /-- Fintype of algebra homomorphism `F⟮α⟯ →ₐ[F] K` -/
@@ -466,12 +466,12 @@ noncomputable def fintype_of_alg_hom_adjoin_integral (h : is_integral F α) :
   fintype (F⟮α⟯ →ₐ[F] K) :=
 fintype.of_equiv _ (alg_hom_adjoin_integral_equiv F h).symm
 
-lemma card_alg_hom_adjoin_integral (h : is_integral F α) (h_sep : (minimal_polynomial h).separable)
-  (h_splits : (minimal_polynomial h).splits (algebra_map F K)) :
+lemma card_alg_hom_adjoin_integral (h : is_integral F α) (h_sep : (minpoly h).separable)
+  (h_splits : (minpoly h).splits (algebra_map F K)) :
   @fintype.card (F⟮α⟯ →ₐ[F] K) (fintype_of_alg_hom_adjoin_integral F h) =
-    (minimal_polynomial h).nat_degree :=
+    (minpoly h).nat_degree :=
 begin
-  let s := ((minimal_polynomial h).map (algebra_map F K)).roots.to_finset,
+  let s := ((minpoly h).map (algebra_map F K)).roots.to_finset,
   have H := λ x, multiset.mem_to_finset,
   rw [fintype.card_congr (alg_hom_adjoin_integral_equiv F h), fintype.card_of_subtype s H,
       polynomial.nat_degree_eq_card_roots h_splits, multiset.to_finset_card_of_nodup],

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -539,7 +539,7 @@ section alg_hom_mk_adjoin_splits
 variables {F E K : Type*} [field F] [field E] [field K] [algebra F E] [algebra F K] {S : finset E}
 
 lemma alg_hom_mk_adjoin_splits
-  (hK : ∀ x ∈ S, ∃ H : is_integral F (x : E), (minimal_polynomial H).splits (algebra_map F K)) :
+  (hK : ∀ x ∈ S, ∃ H : is_integral F (x : E), (minpoly H).splits (algebra_map F K)) :
   nonempty ((adjoin F (S : set E)) →ₐ[F] K) :=
 begin
   let P : intermediate_field F E → Prop := λ L, nonempty (L →ₐ[F] K),
@@ -550,22 +550,22 @@ begin
     cases hK x hx with H hH,
     have H' : is_integral L x := is_integral_of_is_scalar_tower x H,
     letI : algebra L K := f.to_ring_hom.to_algebra,
-    have key : (minimal_polynomial H').splits (algebra_map L K),
-    { refine splits_of_splits_of_dvd _ (map_ne_zero (minimal_polynomial.ne_zero H)) _
-        (minimal_polynomial.dvd_map_of_is_scalar_tower L H),
+    have key : (minpoly H').splits (algebra_map L K),
+    { refine splits_of_splits_of_dvd _ (map_ne_zero (minpoly.ne_zero H)) _
+        (minpoly.dvd_map_of_is_scalar_tower L H),
       rwa [splits_map_iff, ←is_scalar_tower.algebra_map_eq F L K] },
     apply nonempty.intro,
     apply alg_hom_equiv_sigma.inv_fun,
     use f,
     apply (alg_hom_adjoin_integral_equiv L H').inv_fun,
-    use root_of_splits (algebra_map L K) key (ne_of_gt (minimal_polynomial.degree_pos H')),
-    simp_rw [mem_roots (map_ne_zero (minimal_polynomial.ne_zero H')), is_root, ←eval₂_eq_eval_map],
-    exact map_root_of_splits (algebra_map L K) key (ne_of_gt (minimal_polynomial.degree_pos H')),
+    use root_of_splits (algebra_map L K) key (ne_of_gt (minpoly.degree_pos H')),
+    simp_rw [mem_roots (map_ne_zero (minpoly.ne_zero H')), is_root, ←eval₂_eq_eval_map],
+    exact map_root_of_splits (algebra_map L K) key (ne_of_gt (minpoly.degree_pos H')),
     exact is_scalar_tower.of_algebra_map_eq (λ x, rfl) },
 end
 
 lemma alg_hom_mk_adjoin_splits' (hS : adjoin F (S : set E) = ⊤)
-  (hK : ∀ x ∈ S, ∃ H : is_integral F (x : E), (minimal_polynomial H).splits (algebra_map F K)) :
+  (hK : ∀ x ∈ S, ∃ H : is_integral F (x : E), (minpoly H).splits (algebra_map F K)) :
   nonempty (E →ₐ[F] K) :=
 begin
   cases alg_hom_mk_adjoin_splits hK with ϕ,

--- a/src/field_theory/algebraic_closure.lean
+++ b/src/field_theory/algebraic_closure.lean
@@ -71,14 +71,14 @@ lemma algebra_map_surjective_of_is_integral {k K : Type*} [field k] [domain K]
   [hk : is_alg_closed k] [algebra k K] (hf : algebra.is_integral k K) :
   function.surjective (algebra_map k K) :=
 begin
-  refine λ x, ⟨-((minimal_polynomial (hf x)).coeff 0), _⟩,
-  have hq : (minimal_polynomial (hf x)).leading_coeff = 1 := minimal_polynomial.monic (hf x),
-  have h : (minimal_polynomial (hf x)).degree = 1 := degree_eq_one_of_irreducible k
-    (minimal_polynomial.ne_zero (hf x)) (minimal_polynomial.irreducible (hf x)),
-  have : (aeval x (minimal_polynomial (hf x))) = 0 := minimal_polynomial.aeval (hf x),
+  refine λ x, ⟨-((minpoly (hf x)).coeff 0), _⟩,
+  have hq : (minpoly (hf x)).leading_coeff = 1 := minpoly.monic (hf x),
+  have h : (minpoly (hf x)).degree = 1 := degree_eq_one_of_irreducible k
+    (minpoly.ne_zero (hf x)) (minpoly.irreducible (hf x)),
+  have : (aeval x (minpoly (hf x))) = 0 := minpoly.aeval (hf x),
   rw [eq_X_add_C_of_degree_eq_one h, hq, C_1, one_mul,
     aeval_add, aeval_X, aeval_C, add_eq_zero_iff_eq_neg] at this,
-  exact (ring_hom.map_neg (algebra_map k K) ((minimal_polynomial (hf x)).coeff 0)).symm ▸ this.symm,
+  exact (ring_hom.map_neg (algebra_map k K) ((minpoly (hf x)).coeff 0)).symm ▸ this.symm,
 end
 
 lemma algebra_map_surjective_of_is_algebraic {k K : Type*} [field k] [domain K]

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -176,20 +176,20 @@ end minpoly
 theorem is_integral : is_integral (fixed_points G F) x :=
 ⟨minpoly G F x, minpoly.monic G F x, minpoly.eval₂ G F x⟩
 
-theorem minpoly.minpoly :
+theorem minpoly_eq_minpoly :
   minpoly G F x = _root_.minpoly (is_integral G F x) :=
 minpoly.unique' _ (minpoly.irreducible G F x)
   (minpoly.eval₂ G F x) (minpoly.monic G F x)
 
 instance normal : normal (fixed_points G F) F :=
 λ x, ⟨is_integral G F x, (polynomial.splits_id_iff_splits _).1 $
-by { rw [← minpoly.minpoly, minpoly,
+by { rw [← minpoly_eq_minpoly, minpoly,
     coe_algebra_map, polynomial.map_to_subring, prod_X_sub_smul],
   exact polynomial.splits_prod _ (λ _ _, polynomial.splits_X_sub_C _) }⟩
 
 instance separable : is_separable (fixed_points G F) F :=
 λ x, ⟨is_integral G F x,
-by { rw [← minpoly.minpoly,
+by { rw [← minpoly_eq_minpoly,
         ← polynomial.separable_map (is_subring.subtype (fixed_points G F)),
         minpoly, polynomial.map_to_subring],
   exact polynomial.separable_prod_X_sub_C_iff.2 (injective_of_quotient_stabilizer G x) }⟩

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -176,20 +176,20 @@ end minpoly
 theorem is_integral : is_integral (fixed_points G F) x :=
 ⟨minpoly G F x, minpoly.monic G F x, minpoly.eval₂ G F x⟩
 
-theorem minpoly.minimal_polynomial :
-  minpoly G F x = minimal_polynomial (is_integral G F x) :=
-minimal_polynomial.unique' _ (minpoly.irreducible G F x)
+theorem minpoly.minpoly :
+  minpoly G F x = _root_.minpoly (is_integral G F x) :=
+minpoly.unique' _ (minpoly.irreducible G F x)
   (minpoly.eval₂ G F x) (minpoly.monic G F x)
 
 instance normal : normal (fixed_points G F) F :=
 λ x, ⟨is_integral G F x, (polynomial.splits_id_iff_splits _).1 $
-by { rw [← minpoly.minimal_polynomial, minpoly,
+by { rw [← minpoly.minpoly, minpoly,
     coe_algebra_map, polynomial.map_to_subring, prod_X_sub_smul],
   exact polynomial.splits_prod _ (λ _ _, polynomial.splits_X_sub_C _) }⟩
 
 instance separable : is_separable (fixed_points G F) F :=
 λ x, ⟨is_integral G F x,
-by { rw [← minpoly.minimal_polynomial,
+by { rw [← minpoly.minpoly,
         ← polynomial.separable_map (is_subring.subtype (fixed_points G F)),
         minpoly, polynomial.map_to_subring],
   exact polynomial.separable_prod_X_sub_C_iff.2 (injective_of_quotient_stabilizer G x) }⟩

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -62,11 +62,11 @@ lemma integral (h : is_galois F E) (x : E) : is_integral F x :=
 Exists.cases_on (h.1 x) (λ H _, H)
 
 lemma separable (h : is_galois F E) (x : E) :
-  (minimal_polynomial (integral h x)).separable :=
+  (minpoly (integral h x)).separable :=
 Exists.cases_on (h.1 x) (λ _ H, H)
 
 lemma normal (h : is_galois F E) (x : E) :
-  (minimal_polynomial (integral h x)).splits (algebra_map F E) :=
+  (minpoly (integral h x)).splits (algebra_map F E) :=
 Exists.cases_on (h.2 x) (λ _ H, H)
 
 variables (F) (E)
@@ -77,8 +77,8 @@ instance of_fixed_field (G : Type*) [group G] [fintype G] [mul_semiring_action G
 
 lemma intermediate_field.adjoin_simple.card_aut_eq_findim
   [finite_dimensional F E] {α : E} (hα : is_integral F α)
-  (h_sep : (minimal_polynomial hα).separable)
-  (h_splits : (minimal_polynomial hα).splits (algebra_map F F⟮α⟯)) :
+  (h_sep : (minpoly hα).separable)
+  (h_splits : (minpoly hα).splits (algebra_map F F⟮α⟯)) :
   fintype.card (F⟮α⟯ ≃ₐ[F] F⟮α⟯) = findim F F⟮α⟯ :=
 begin
   letI : fintype (F⟮α⟯ →ₐ[F] F⟮α⟯) := intermediate_field.fintype_of_alg_hom_adjoin_integral F hα,
@@ -100,9 +100,9 @@ begin
     map_add' := λ _ _, rfl,
     commutes' := λ _, rfl },
   have H : is_integral F α := h.integral α,
-  have h_sep : (minimal_polynomial H).separable := h.separable α,
-  have h_splits : (minimal_polynomial H).splits (algebra_map F E) := h.normal α,
-  replace h_splits : polynomial.splits (algebra_map F F⟮α⟯) (minimal_polynomial H),
+  have h_sep : (minpoly H).separable := h.separable α,
+  have h_splits : (minpoly H).splits (algebra_map F E) := h.normal α,
+  replace h_splits : polynomial.splits (algebra_map F F⟮α⟯) (minpoly H),
   { convert polynomial.splits_comp_of_splits
     (algebra_map F E) iso.symm.to_alg_hom.to_ring_hom h_splits },
   rw ← linear_equiv.findim_eq iso.to_linear_equiv,
@@ -301,17 +301,17 @@ lemma is_separable_splitting_field [finite_dimensional F E] [h : is_galois F E] 
 begin
   cases field.exists_primitive_element h.1 with α h1,
   have h2 : is_integral F α := h.integral α,
-  have h3 : (minimal_polynomial h2).separable := h.separable α,
-  have h4 : (minimal_polynomial h2).splits (algebra_map F E) := h.normal α,
-  use [minimal_polynomial h2, h3, h4],
+  have h3 : (minpoly h2).separable := h.separable α,
+  have h4 : (minpoly h2).splits (algebra_map F E) := h.normal α,
+  use [minpoly h2, h3, h4],
   rw [eq_top_iff, ←intermediate_field.top_to_subalgebra, ←h1],
   rw intermediate_field.adjoin_simple_to_subalgebra_of_integral F α h2,
   apply algebra.adjoin_mono,
   rw [set.singleton_subset_iff, finset.mem_coe, multiset.mem_to_finset, polynomial.mem_roots],
   { dsimp only [polynomial.is_root],
     rw [polynomial.eval_map, ←polynomial.aeval_def],
-    exact minimal_polynomial.aeval h2 },
-  { exact polynomial.map_ne_zero (minimal_polynomial.ne_zero h2) }
+    exact minpoly.aeval h2 },
+  { exact polynomial.map_ne_zero (minpoly.ne_zero h2) }
 end
 
 lemma of_fixed_field_eq_bot [finite_dimensional F E]
@@ -342,8 +342,8 @@ lemma of_separable_splitting_field_aux [hFE : finite_dimensional F E]
 begin
   have h : is_integral K x := is_integral_of_is_scalar_tower x (is_integral_of_noetherian hFE x),
   have h1 : p ≠ 0 := λ hp, by rwa [hp, polynomial.map_zero, polynomial.roots_zero] at hx,
-  have h2 : (minimal_polynomial h) ∣ p.map (algebra_map F K),
-  { apply minimal_polynomial.dvd,
+  have h2 : (minpoly h) ∣ p.map (algebra_map F K),
+  { apply minpoly.dvd,
     rw [polynomial.aeval_def, polynomial.eval₂_map, ←polynomial.eval_map],
     exact (polynomial.mem_roots (polynomial.map_ne_zero h1)).mp hx },
   let key_equiv : ((↑K⟮x⟯ : intermediate_field F E) →ₐ[F] E) ≃ Σ (f : K →ₐ[F] E),
@@ -382,7 +382,7 @@ begin
   apply intermediate_field.induction_on_adjoin_finset s P,
   { have key := intermediate_field.card_alg_hom_adjoin_integral F
       (show is_integral F (0 : E), by exact is_integral_zero),
-    rw [minimal_polynomial.zero, polynomial.nat_degree_X] at key,
+    rw [minpoly.zero, polynomial.nat_degree_X] at key,
     specialize key polynomial.separable_X (polynomial.splits_X (algebra_map F E)),
     rw [←@subalgebra.findim_bot F E _ _ _, ←intermediate_field.bot_to_subalgebra] at key,
     refine eq.trans _ key,

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -31,44 +31,44 @@ variables [comm_ring α] [ring β] [algebra α β]
 
 /-- Let `B` be an `A`-algebra, and `x` an element of `B` that is integral over `A`
 so we have some term `hx : is_integral A x`.
-The minimal polynomial `minimal_polynomial hx` of `x` is a monic polynomial of smallest degree
+The minimal polynomial `minpoly hx` of `x` is a monic polynomial of smallest degree
 that has `x` as its root.
 For instance, if `V` is a `K`-vector space for some field `K`, and `f : V →ₗ[K] V` then
-the minimal polynomial of `f` is `minimal_polynomial f.is_integral`. -/
-noncomputable def minimal_polynomial {x : β} (hx : is_integral α x) : polynomial α :=
+the minimal polynomial of `f` is `minpoly f.is_integral`. -/
+noncomputable def minpoly {x : β} (hx : is_integral α x) : polynomial α :=
 well_founded.min degree_lt_wf _ hx
 
 end min_poly_def
 
-namespace minimal_polynomial
+namespace minpoly
 
 section ring
 variables [comm_ring α] [ring β] [algebra α β]
 variables {x : β} (hx : is_integral α x)
 
 /--A minimal polynomial is monic.-/
-lemma monic : monic (minimal_polynomial hx) :=
+lemma monic : monic (minpoly hx) :=
 (well_founded.min_mem degree_lt_wf _ hx).1
 
 /--An element is a root of its minimal polynomial.-/
-@[simp] lemma aeval : aeval x (minimal_polynomial hx) = 0 :=
+@[simp] lemma aeval : aeval x (minpoly hx) = 0 :=
 (well_founded.min_mem degree_lt_wf _ hx).2
 
 /--The defining property of the minimal polynomial of an element x:
 it is the monic polynomial with smallest degree that has x as its root.-/
 lemma min {p : polynomial α} (pmonic : p.monic) (hp : polynomial.aeval x p = 0) :
-  degree (minimal_polynomial hx) ≤ degree p :=
+  degree (minpoly hx) ≤ degree p :=
 le_of_not_lt $ well_founded.not_lt_min degree_lt_wf _ hx ⟨pmonic, hp⟩
 
 /-- A minimal polynomial is nonzero. -/
-lemma ne_zero [nontrivial α] : (minimal_polynomial hx) ≠ 0 :=
+lemma ne_zero [nontrivial α] : (minpoly hx) ≠ 0 :=
 ne_zero_of_monic (monic hx)
 
 /-- If an element `x` is a root of a nonzero monic polynomial `p`,
 then the degree of `p` is at least the degree of the minimal polynomial of `x`. -/
 lemma degree_le_of_monic
   {p : polynomial α} (hmonic : p.monic) (hp : polynomial.aeval x p = 0) :
-  degree (minimal_polynomial hx) ≤ degree p :=
+  degree (minpoly hx) ≤ degree p :=
 min _ hmonic (by simp [hp])
 
 end ring
@@ -83,15 +83,15 @@ variables [ring β] [algebra α β] [nontrivial β]
 variables {x : β} (hx : is_integral α x)
 
 /--The degree of a minimal polynomial is positive. -/
-lemma degree_pos [nontrivial α] : 0 < degree (minimal_polynomial hx) :=
+lemma degree_pos [nontrivial α] : 0 < degree (minpoly hx) :=
 begin
   apply lt_of_le_of_ne,
   { simpa only [zero_le_degree_iff] using ne_zero hx },
   assume deg_eq_zero,
   rw eq_comm at deg_eq_zero,
-  have ndeg_eq_zero : nat_degree (minimal_polynomial hx) = 0,
+  have ndeg_eq_zero : nat_degree (minpoly hx) = 0,
   { simpa using congr_arg nat_degree (eq_C_of_degree_eq_zero deg_eq_zero) },
-  have eq_one : minimal_polynomial hx = 1,
+  have eq_one : minpoly hx = 1,
   { rw eq_C_of_degree_eq_zero deg_eq_zero, convert C_1,
     simpa only [ndeg_eq_zero.symm] using (monic hx).leading_coeff },
   simpa only [eq_one, alg_hom.map_one, one_ne_zero] using aeval hx
@@ -100,22 +100,22 @@ end
 /-- If `L/K` is a ring extension, and `x` is an element of `L` in the image of `K`,
 then the minimal polynomial of `x` is `X - C x`. -/
 lemma eq_X_sub_C_of_algebra_map_inj [nontrivial α] (a : α) (hf : function.injective (algebra_map α β)) :
-  minimal_polynomial (@is_integral_algebra_map α β _ _ _ a) = X - C a :=
+  minpoly (@is_integral_algebra_map α β _ _ _ a) = X - C a :=
 begin
-  have hdegle : (minimal_polynomial (@is_integral_algebra_map α β _ _ _ a)).nat_degree ≤ 1,
+  have hdegle : (minpoly (@is_integral_algebra_map α β _ _ _ a)).nat_degree ≤ 1,
   { apply with_bot.coe_le_coe.1,
     rw [←degree_eq_nat_degree (ne_zero (@is_integral_algebra_map α β _ _ _ a)),
       with_top.coe_one, ←degree_X_sub_C a],
     refine degree_le_of_monic (@is_integral_algebra_map α β _ _ _ a) (monic_X_sub_C a) _,
     simp only [aeval_C, aeval_X, alg_hom.map_sub, sub_self] },
-  have hdeg : (minimal_polynomial (@is_integral_algebra_map α β _ _ _ a)).degree = 1,
+  have hdeg : (minpoly (@is_integral_algebra_map α β _ _ _ a)).degree = 1,
   { apply (degree_eq_iff_nat_degree_eq (ne_zero (@is_integral_algebra_map α β _ _ _ a))).2,
     exact (has_le.le.antisymm hdegle (nat.succ_le_of_lt (with_bot.coe_lt_coe.1
     (lt_of_lt_of_le (degree_pos (@is_integral_algebra_map α β _ _ _ a)) degree_le_nat_degree)))) },
   have hrw := eq_X_add_C_of_degree_eq_one hdeg,
   simp only [monic (@is_integral_algebra_map α β _ _ _ a), one_mul,
     monic.leading_coeff, ring_hom.map_one] at hrw,
-  have h0 : (minimal_polynomial (@is_integral_algebra_map α β _ _ _ a)).coeff 0 = -a,
+  have h0 : (minpoly (@is_integral_algebra_map α β _ _ _ a)).coeff 0 = -a,
   { have hroot := aeval (@is_integral_algebra_map α β _ _ _ a),
     rw [hrw, add_comm] at hroot,
     simp only [aeval_C, aeval_X, aeval_add] at hroot,
@@ -127,7 +127,7 @@ begin
 end
 
 /-- A minimal polynomial is not a unit. -/
-lemma not_is_unit : ¬ is_unit (minimal_polynomial hx) :=
+lemma not_is_unit : ¬ is_unit (minpoly hx) :=
 assume H, (ne_of_lt (degree_pos hx)).symm $ degree_eq_zero_of_is_unit H
 
 end ring
@@ -138,12 +138,12 @@ variables [domain β] [algebra α β]
 variables {x : β} (hx : is_integral α x)
 
 /-- If `a` strictly divides the minimal polynomial of `x`, then `x` cannot be a root for `a`. -/
-lemma aeval_ne_zero_of_dvd_not_unit_minimal_polynomial {a : polynomial α}
-  (hamonic : a.monic) (hdvd : dvd_not_unit a (minimal_polynomial hx)) :
+lemma aeval_ne_zero_of_dvd_not_unit_minpoly {a : polynomial α}
+  (hamonic : a.monic) (hdvd : dvd_not_unit a (minpoly hx)) :
   polynomial.aeval x a ≠ 0 :=
 begin
   intro ha,
-  refine not_lt_of_ge (minimal_polynomial.min hx hamonic ha) _,
+  refine not_lt_of_ge (minpoly.min hx hamonic ha) _,
   obtain ⟨hzeroa, b, hb_nunit, prod⟩ := hdvd,
   have hbmonic : b.monic,
   { rw monic.def,
@@ -163,9 +163,9 @@ begin
 end
 
 /--A minimal polynomial is irreducible.-/
-lemma irreducible : irreducible (minimal_polynomial hx) :=
+lemma irreducible : irreducible (minpoly hx) :=
 begin
-  cases irreducible_or_factor (minimal_polynomial hx) (not_is_unit hx) with hirr hred,
+  cases irreducible_or_factor (minpoly hx) (not_is_unit hx) with hirr hred,
   { exact hirr },
   exfalso,
   obtain ⟨a, b, ha_nunit, hb_nunit, hab_eq⟩ := hred,
@@ -178,19 +178,19 @@ begin
   have hbmonic : (b * C a.leading_coeff).monic,
   { rw [monic.def, mul_comm],
     simp only [coeff_prod, leading_coeff_mul, leading_coeff_C] },
-  have prod : minimal_polynomial hx = (a * C b.leading_coeff) * (b * C a.leading_coeff),
+  have prod : minpoly hx = (a * C b.leading_coeff) * (b * C a.leading_coeff),
   { symmetry,
     calc a * C b.leading_coeff * (b * C a.leading_coeff)
         = a * b * (C a.leading_coeff * C b.leading_coeff) : by ring
     ... = a * b * (C (a.leading_coeff * b.leading_coeff)) : by simp only [ring_hom.map_mul]
     ... = a * b : by rw [coeff_prod, C_1, mul_one]
-    ... = minimal_polynomial hx : hab_eq },
+    ... = minpoly hx : hab_eq },
   have hzero := aeval hx,
   rw [prod, aeval_mul, mul_eq_zero] at hzero,
   cases hzero,
-  { refine aeval_ne_zero_of_dvd_not_unit_minimal_polynomial hx hamonic _ hzero,
+  { refine aeval_ne_zero_of_dvd_not_unit_minpoly hx hamonic _ hzero,
     exact ⟨hamonic.ne_zero, _, mt is_unit_of_mul_is_unit_left hb_nunit, prod⟩ },
-  { refine aeval_ne_zero_of_dvd_not_unit_minimal_polynomial hx hbmonic _ hzero,
+  { refine aeval_ne_zero_of_dvd_not_unit_minpoly hx hbmonic _ hzero,
     rw mul_comm at prod,
     exact ⟨hbmonic.ne_zero, _, mt is_unit_of_mul_is_unit_left ha_nunit, prod⟩ },
 end
@@ -210,8 +210,8 @@ variables {x : β} (hx : is_integral α x)
 then the degree of p is at least the degree of the minimal polynomial of x.-/
 lemma degree_le_of_ne_zero
   {p : polynomial α} (pnz : p ≠ 0) (hp : polynomial.aeval x p = 0) :
-  degree (minimal_polynomial hx) ≤ degree p :=
-calc degree (minimal_polynomial hx) ≤ degree (p * C (leading_coeff p)⁻¹) :
+  degree (minpoly hx) ≤ degree p :=
+calc degree (minpoly hx) ≤ degree (p * C (leading_coeff p)⁻¹) :
     min _ (monic_mul_leading_coeff_inv pnz) (by simp [hp])
   ... = degree p : degree_mul_leading_coeff_inv p pnz
 
@@ -220,7 +220,7 @@ if there is another monic polynomial of minimal degree that has x as a root,
 then this polynomial is equal to the minimal polynomial of x.-/
 lemma unique {p : polynomial α} (pmonic : p.monic) (hp : polynomial.aeval x p = 0)
   (pmin : ∀ q : polynomial α, q.monic → polynomial.aeval x q = 0 → degree p ≤ degree q) :
-  p = minimal_polynomial hx :=
+  p = minpoly hx :=
 begin
   symmetry, apply eq_of_sub_eq_zero,
   by_contra hnz,
@@ -229,12 +229,12 @@ begin
   apply degree_sub_lt _ (ne_zero hx),
   { rw [(monic hx).leading_coeff, pmonic.leading_coeff] },
   { exact le_antisymm (min hx pmonic hp)
-      (pmin (minimal_polynomial hx) (monic hx) (aeval hx)) },
+      (pmin (minpoly hx) (monic hx) (aeval hx)) },
 end
 
 /--If an element x is a root of a polynomial p, then the minimal polynomial of x divides p.-/
 lemma dvd {p : polynomial α} (hp : polynomial.aeval x p = 0) :
-  minimal_polynomial hx ∣ p :=
+  minpoly hx ∣ p :=
 begin
   rw ← dvd_iff_mod_by_monic_eq_zero (monic hx),
   by_contra hnz,
@@ -247,16 +247,16 @@ end
 
 lemma dvd_map_of_is_scalar_tower {α γ : Type*} (β : Type*) [comm_ring α] [field β] [comm_ring γ]
   [algebra α β] [algebra α γ] [algebra β γ] [is_scalar_tower α β γ] {x : γ} (hx : is_integral α x) :
-  minimal_polynomial (is_integral_of_is_scalar_tower x hx) ∣ (minimal_polynomial hx).map (algebra_map α β) :=
-by { apply minimal_polynomial.dvd, rw [← is_scalar_tower.aeval_apply, minimal_polynomial.aeval] }
+  minpoly (is_integral_of_is_scalar_tower x hx) ∣ (minpoly hx).map (algebra_map α β) :=
+by { apply minpoly.dvd, rw [← is_scalar_tower.aeval_apply, minpoly.aeval] }
 
 variables [nontrivial β]
 
 theorem unique' {p : polynomial α} (hp1 : _root_.irreducible p) (hp2 : polynomial.aeval x p = 0)
-  (hp3 : p.monic) : p = minimal_polynomial hx :=
+  (hp3 : p.monic) : p = minpoly hx :=
 let ⟨q, hq⟩ := dvd hx hp2 in
 eq_of_monic_of_associated hp3 (monic hx) $
-mul_one (minimal_polynomial hx) ▸ hq.symm ▸ associated_mul_mul (associated.refl _) $
+mul_one (minpoly hx) ▸ hq.symm ▸ associated_mul_mul (associated.refl _) $
 associated_one_iff_is_unit.2 $ (hp1.is_unit_or_is_unit hq).resolve_left $ not_is_unit hx
 
 section gcd_domain
@@ -266,13 +266,13 @@ over the fraction field. -/
 lemma gcd_domain_eq_field_fractions {α : Type u} {β : Type v} {γ : Type w} [integral_domain α]
   [gcd_monoid α] [field β] [integral_domain γ] (f : fraction_map α β) [algebra f.codomain γ]
   [algebra α γ] [is_scalar_tower α f.codomain γ] {x : γ} (hx : is_integral α x) :
-  minimal_polynomial (@is_integral_of_is_scalar_tower α f.codomain γ _ _ _ _ _ _ _ x hx) =
-    ((minimal_polynomial hx).map (localization_map.to_ring_hom f)) :=
+  minpoly (@is_integral_of_is_scalar_tower α f.codomain γ _ _ _ _ _ _ _ x hx) =
+    ((minpoly hx).map (localization_map.to_ring_hom f)) :=
 begin
   refine (unique' (@is_integral_of_is_scalar_tower α f.codomain γ _ _ _ _ _ _ _ x hx) _ _ _).symm,
   { exact (polynomial.is_primitive.irreducible_iff_irreducible_map_fraction_map f
   (polynomial.monic.is_primitive (monic hx))).1 (irreducible hx) },
-  { have htower := is_scalar_tower.aeval_apply α f.codomain γ x (minimal_polynomial hx),
+  { have htower := is_scalar_tower.aeval_apply α f.codomain γ x (minpoly hx),
     simp only [localization_map.algebra_map_eq, aeval] at htower,
     exact htower.symm },
   { exact monic_map _ (monic hx) }
@@ -283,13 +283,13 @@ end
 -- in terms of algebras instead of `ring_hom`s
 lemma over_int_eq_over_rat {α : Type u} [integral_domain α] {x : α} [algebra ℚ α]
   (hx : is_integral ℤ x) :
-  minimal_polynomial (@is_integral_of_is_scalar_tower ℤ ℚ α _ _ _ _ _ _ _ x hx) =
-    map (int.cast_ring_hom ℚ) (minimal_polynomial hx) :=
+  minpoly (@is_integral_of_is_scalar_tower ℤ ℚ α _ _ _ _ _ _ _ x hx) =
+    map (int.cast_ring_hom ℚ) (minpoly hx) :=
 begin
   refine (unique' (@is_integral_of_is_scalar_tower ℤ ℚ α _ _ _ _ _ _ _ x hx) _ _ _).symm,
   { exact (is_primitive.int.irreducible_iff_irreducible_map_cast
   (polynomial.monic.is_primitive (monic hx))).1 (irreducible hx) },
-  { have htower := is_scalar_tower.aeval_apply ℤ ℚ α x (minimal_polynomial hx),
+  { have htower := is_scalar_tower.aeval_apply ℤ ℚ α x (minpoly hx),
     simp only [localization_map.algebra_map_eq, aeval] at htower,
     exact htower.symm },
   { exact monic_map _ (monic hx) }
@@ -302,7 +302,7 @@ lemma gcd_domain_dvd {α : Type u} {β : Type v} {γ : Type w}
   (f : fraction_map α β) [algebra f.codomain γ] [algebra α γ] [is_scalar_tower α f.codomain γ]
   {x : γ} (hx : is_integral α x)
   {P : polynomial α} (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) :
-  minimal_polynomial hx ∣ P :=
+  minpoly hx ∣ P :=
 begin
   apply (is_primitive.dvd_iff_fraction_map_dvd_fraction_map f
     (monic.is_primitive (monic hx)) hprim ).2,
@@ -316,7 +316,7 @@ as root. -/
 -- TODO use `gcd_domain_dvd` directly when localizations are defined in terms of algebras
 -- instead of `ring_hom`s
 lemma integer_dvd {α : Type u} [integral_domain α] [algebra ℚ α] {x : α} (hx : is_integral ℤ x)
-  {P : polynomial ℤ} (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) : minimal_polynomial hx ∣ P :=
+  {P : polynomial ℤ} (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) : minpoly hx ∣ P :=
 begin
   apply (is_primitive.int.dvd_iff_map_cast_dvd_map_cast _ _
     (monic.is_primitive (monic hx)) hprim ).2,
@@ -331,7 +331,7 @@ variable (β)
 /--If L/K is a field extension, and x is an element of L in the image of K,
 then the minimal polynomial of x is X - C x.-/
 lemma eq_X_sub_C (a : α) :
-  minimal_polynomial (@is_integral_algebra_map α β _ _ _ a) =
+  minpoly (@is_integral_algebra_map α β _ _ _ a) =
   X - C a :=
 eq.symm $ unique' (@is_integral_algebra_map α β _ _ _ a) (irreducible_X_sub_C a)
   (by rw [alg_hom.map_sub, aeval_X, aeval_C, sub_self]) (monic_X_sub_C a)
@@ -339,13 +339,13 @@ variable {β}
 
 /--The minimal polynomial of 0 is X.-/
 @[simp] lemma zero {h₀ : is_integral α (0:β)} :
-  minimal_polynomial h₀ = X :=
+  minpoly h₀ = X :=
 by simpa only [add_zero, C_0, sub_eq_add_neg, neg_zero, ring_hom.map_zero]
   using eq_X_sub_C β (0:α)
 
 /--The minimal polynomial of 1 is X - 1.-/
 @[simp] lemma one {h₁ : is_integral α (1:β)} :
-  minimal_polynomial h₁ = X - 1 :=
+  minpoly h₁ = X - 1 :=
 by simpa only [ring_hom.map_one, C_1, sub_eq_add_neg]
   using eq_X_sub_C β (1:α)
 
@@ -356,7 +356,7 @@ variables [domain β] [algebra α β]
 variables {x : β} (hx : is_integral α x)
 
 /--A minimal polynomial is prime.-/
-lemma prime : prime (minimal_polynomial hx) :=
+lemma prime : prime (minpoly hx) :=
 begin
   refine ⟨ne_zero hx, not_is_unit hx, _⟩,
   rintros p q ⟨d, h⟩,
@@ -368,8 +368,8 @@ end
 /--If L/K is a field extension and an element y of K is a root of the minimal polynomial
 of an element x ∈ L, then y maps to x under the field embedding.-/
 lemma root {x : β} (hx : is_integral α x) {y : α}
-  (h : is_root (minimal_polynomial hx) y) : algebra_map α β y = x :=
-have key : minimal_polynomial hx = X - C y :=
+  (h : is_root (minpoly hx) y) : algebra_map α β y = x :=
+have key : minpoly hx = X - C y :=
 eq_of_monic_of_associated (monic hx) (monic_X_sub_C y) (associated_of_dvd_dvd
   (dvd_symm_of_irreducible (irreducible_X_sub_C y) (irreducible hx) (dvd_iff_is_root.2 h))
   (dvd_iff_is_root.2 h)),
@@ -377,7 +377,7 @@ by { have := aeval hx, rwa [key, alg_hom.map_sub, aeval_X, aeval_C, sub_eq_zero,
 
 /--The constant coefficient of the minimal polynomial of x is 0
 if and only if x = 0.-/
-@[simp] lemma coeff_zero_eq_zero : coeff (minimal_polynomial hx) 0 = 0 ↔ x = 0 :=
+@[simp] lemma coeff_zero_eq_zero : coeff (minpoly hx) 0 = 0 ↔ x = 0 :=
 begin
   split,
   { intro h,
@@ -388,11 +388,11 @@ begin
 end
 
 /--The minimal polynomial of a nonzero element has nonzero constant coefficient.-/
-lemma coeff_zero_ne_zero (h : x ≠ 0) : coeff (minimal_polynomial hx) 0 ≠ 0 :=
+lemma coeff_zero_ne_zero (h : x ≠ 0) : coeff (minpoly hx) 0 ≠ 0 :=
 by { contrapose! h, simpa using h }
 
 end domain
 
 end field
 
-end minimal_polynomial
+end minpoly

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -99,7 +99,8 @@ end
 
 /-- If `L/K` is a ring extension, and `x` is an element of `L` in the image of `K`,
 then the minimal polynomial of `x` is `X - C x`. -/
-lemma eq_X_sub_C_of_algebra_map_inj [nontrivial α] (a : α) (hf : function.injective (algebra_map α β)) :
+lemma eq_X_sub_C_of_algebra_map_inj [nontrivial α] (a : α)
+  (hf : function.injective (algebra_map α β)) :
   minpoly (@is_integral_algebra_map α β _ _ _ a) = X - C a :=
 begin
   have hdegle : (minpoly (@is_integral_algebra_map α β _ _ _ a)).nat_degree ≤ 1,
@@ -316,7 +317,8 @@ as root. -/
 -- TODO use `gcd_domain_dvd` directly when localizations are defined in terms of algebras
 -- instead of `ring_hom`s
 lemma integer_dvd {α : Type u} [integral_domain α] [algebra ℚ α] {x : α} (hx : is_integral ℤ x)
-  {P : polynomial ℤ} (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) : minpoly hx ∣ P :=
+  {P : polynomial ℤ} (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) :
+  minpoly hx ∣ P :=
 begin
   apply (is_primitive.int.dvd_iff_map_cast_dvd_map_cast _ _
     (monic.is_primitive (monic hx)) hprim ).2,

--- a/src/field_theory/normal.lean
+++ b/src/field_theory/normal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 
-import field_theory.minimal_polynomial
+import field_theory.minpoly
 import field_theory.splitting_field
 import linear_algebra.finite_dimensional
 
@@ -30,30 +30,30 @@ variables (F : Type u) (K : Type v) [field F] [field K] [algebra F K]
 /-- Typeclass for normal field extension: `K` is a normal extension of `F` iff the minimal
 polynomial of every element `x` in `K` splits in `K`, i.e. every conjugate of `x` is in `K`. -/
 @[class] def normal : Prop :=
-∀ x : K, ∃ H : is_integral F x, splits (algebra_map F K) (minimal_polynomial H)
+∀ x : K, ∃ H : is_integral F x, splits (algebra_map F K) (minpoly H)
 
 instance normal_self : normal F F :=
-λ x, ⟨is_integral_algebra_map, by { rw minimal_polynomial.eq_X_sub_C, exact splits_X_sub_C _ }⟩
+λ x, ⟨is_integral_algebra_map, by { rw minpoly.eq_X_sub_C, exact splits_X_sub_C _ }⟩
 
 theorem normal.is_integral [h : normal F K] (x : K) : is_integral F x := (h x).fst
 
 theorem normal.splits [h : normal F K] (x : K) :
-  splits (algebra_map F K) (minimal_polynomial $ normal.is_integral F K x) := (h x).snd
+  splits (algebra_map F K) (minpoly $ normal.is_integral F K x) := (h x).snd
 
 theorem normal.exists_is_splitting_field [normal F K] [finite_dimensional F K] :
   ∃ p : polynomial F, is_splitting_field F K p :=
 begin
   obtain ⟨s, hs⟩ := finite_dimensional.exists_is_basis_finset F K,
-  refine ⟨s.prod $ λ x, minimal_polynomial $ normal.is_integral F K x,
+  refine ⟨s.prod $ λ x, minpoly $ normal.is_integral F K x,
     splits_prod _ $ λ x hx, normal.splits F K x,
     subalgebra.to_submodule_injective _⟩,
   rw [algebra.coe_top, eq_top_iff, ← hs.2, submodule.span_le, set.range_subset_iff],
   refine λ x, algebra.subset_adjoin (multiset.mem_to_finset.mpr $
     (mem_roots $ mt (map_eq_zero $ algebra_map F K).1 $
     finset.prod_ne_zero_iff.2 $ λ x hx, _).2 _),
-  { exact minimal_polynomial.ne_zero _ },
+  { exact minpoly.ne_zero _ },
   rw [is_root.def, eval_map, ← aeval_def, alg_hom.map_prod],
-  exact finset.prod_eq_zero x.2 (minimal_polynomial.aeval _)
+  exact finset.prod_eq_zero x.2 (minpoly.aeval _)
 end
 
 section normal_tower
@@ -66,9 +66,9 @@ begin
   cases h x with hx hhx,
   rw is_scalar_tower.algebra_map_eq F K E at hhx,
   exact ⟨is_integral_of_is_scalar_tower x hx, polynomial.splits_of_splits_of_dvd (algebra_map K E)
-    (polynomial.map_ne_zero (minimal_polynomial.ne_zero hx))
+    (polynomial.map_ne_zero (minpoly.ne_zero hx))
     ((polynomial.splits_map_iff (algebra_map F K) (algebra_map K E)).mpr hhx)
-    (minimal_polynomial.dvd_map_of_is_scalar_tower K hx)⟩,
+    (minpoly.dvd_map_of_is_scalar_tower K hx)⟩,
 end
 
 variables {F} {E} {E' : Type*} [field E'] [algebra F E']
@@ -80,13 +80,13 @@ begin
   have H := is_integral_alg_hom f.to_alg_hom hx,
   rw [alg_equiv.to_alg_hom_eq_coe, alg_equiv.coe_alg_hom, alg_equiv.apply_symm_apply] at H,
   use H,
-  apply polynomial.splits_of_splits_of_dvd (algebra_map F E') (minimal_polynomial.ne_zero hx),
+  apply polynomial.splits_of_splits_of_dvd (algebra_map F E') (minpoly.ne_zero hx),
   { rw ← alg_hom.comp_algebra_map f.to_alg_hom,
     exact polynomial.splits_comp_of_splits (algebra_map F E) f.to_alg_hom.to_ring_hom hhx },
-  { apply minimal_polynomial.dvd H,
+  { apply minpoly.dvd H,
     rw ← add_equiv.map_eq_zero_iff f.symm.to_add_equiv,
     exact eq.trans (polynomial.aeval_alg_hom_apply f.symm.to_alg_hom x
-      (minimal_polynomial hx)).symm (minimal_polynomial.aeval hx) },
+      (minpoly hx)).symm (minpoly.aeval hx) },
 end
 
 lemma alg_equiv.transfer_normal (f : E ≃ₐ[F] E') : normal F E ↔ normal F E' :=

--- a/src/field_theory/primitive_element.lean
+++ b/src/field_theory/primitive_element.lean
@@ -95,8 +95,8 @@ lemma primitive_element_inf_aux (F_sep : is_separable F E) :
 begin
   obtain ⟨hα, hf⟩ := F_sep α,
   obtain ⟨hβ, hg⟩ := F_sep β,
-  let f := minimal_polynomial hα,
-  let g := minimal_polynomial hβ,
+  let f := minpoly hα,
+  let g := minpoly hβ,
   let ιFE := algebra_map F E,
   let ιEE' := algebra_map E (splitting_field (g.map ιFE)),
   obtain ⟨c, hc⟩ := primitive_element_inf_aux_exists_c (ιEE'.comp ιFE) (ιEE' α) (ιEE' β) f g,
@@ -118,7 +118,7 @@ begin
   let p := euclidean_domain.gcd ((f.map (algebra_map F F⟮γ⟯)).comp
     (C (adjoin_simple.gen F γ) - (C ↑c * X))) (g.map (algebra_map F F⟮γ⟯)),
   let h := euclidean_domain.gcd ((f.map ιFE).comp (C γ - (C (ιFE c) * X))) (g.map ιFE),
-  have map_g_ne_zero : g.map ιFE ≠ 0 := map_ne_zero (minimal_polynomial.ne_zero hβ),
+  have map_g_ne_zero : g.map ιFE ≠ 0 := map_ne_zero (minpoly.ne_zero hβ),
   have h_ne_zero : h ≠ 0 :=  mt euclidean_domain.gcd_eq_zero_iff.mp
     (not_and.mpr (λ _, map_g_ne_zero)),
   suffices p_linear : p.map (algebra_map F⟮γ⟯ E) = (C h.leading_coeff) * (X - C β),
@@ -131,8 +131,8 @@ begin
   have h_root : h.eval β = 0,
   { apply eval_gcd_eq_zero,
     { rw [eval_comp, eval_sub, eval_mul, eval_C, eval_C, eval_X, eval_map, ←aeval_def,
-          ←algebra.smul_def, add_sub_cancel, minimal_polynomial.aeval] },
-    { rw [eval_map, ←aeval_def, minimal_polynomial.aeval] } },
+          ←algebra.smul_def, add_sub_cancel, minpoly.aeval] },
+    { rw [eval_map, ←aeval_def, minpoly.aeval] } },
   have h_splits : splits ιEE' h := splits_of_splits_gcd_right ιEE' map_g_ne_zero
     (splitting_field.splits _),
   have h_roots : ∀ x ∈ (h.map ιEE').roots, x = ιEE' β,
@@ -141,10 +141,10 @@ begin
     specialize hc ((ιEE' γ) - (ιEE' (ιFE c)) * x) (begin
       have f_root := root_left_of_root_gcd hx,
       rw [eval₂_comp, eval₂_sub, eval₂_mul,eval₂_C, eval₂_C, eval₂_X, eval₂_map] at f_root,
-      exact (mem_roots_map (minimal_polynomial.ne_zero hα)).mpr f_root,
+      exact (mem_roots_map (minpoly.ne_zero hα)).mpr f_root,
     end),
     specialize hc x (begin
-      rw [mem_roots_map (minimal_polynomial.ne_zero hβ), ←eval₂_map],
+      rw [mem_roots_map (minpoly.ne_zero hβ), ←eval₂_map],
       exact root_right_of_root_gcd hx,
     end),
     by_contradiction a,

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -5,7 +5,7 @@ Authors: Kenny Lau.
 -/
 
 import algebra.polynomial.big_operators
-import field_theory.minimal_polynomial
+import field_theory.minpoly
 import field_theory.splitting_field
 import field_theory.tower
 import algebra.squarefree
@@ -549,10 +549,10 @@ end
 /-- Typeclass for separable field extension: `K` is a separable field extension of `F` iff
 the minimal polynomial of every `x : K` is separable. -/
 @[class] def is_separable (F K : Sort*) [field F] [field K] [algebra F K] : Prop :=
-∀ x : K, ∃ H : is_integral F x, (minimal_polynomial H).separable
+∀ x : K, ∃ H : is_integral F x, (minpoly H).separable
 
 instance is_separable_self (F : Type*) [field F] : is_separable F F :=
-λ x, ⟨is_integral_algebra_map, by { rw minimal_polynomial.eq_X_sub_C, exact separable_X_sub_C }⟩
+λ x, ⟨is_integral_algebra_map, by { rw minpoly.eq_X_sub_C, exact separable_X_sub_C }⟩
 
 section is_separable_tower
 variables {F E : Type*} (K : Type*) [field F] [field K] [field E] [algebra F K] [algebra F E]
@@ -560,16 +560,16 @@ variables {F E : Type*} (K : Type*) [field F] [field K] [field E] [algebra F K] 
 
 lemma is_separable_tower_top_of_is_separable (h : is_separable F E) : is_separable K E :=
 λ x, Exists.cases_on (h x) (λ hx hs, ⟨is_integral_of_is_scalar_tower x hx,
-  hs.map.of_dvd (minimal_polynomial.dvd_map_of_is_scalar_tower K hx)⟩)
+  hs.map.of_dvd (minpoly.dvd_map_of_is_scalar_tower K hx)⟩)
 
 lemma is_separable_tower_bot_of_is_separable (h : is_separable F E) : is_separable F K :=
 begin
   intro x,
   obtain ⟨hx, hs⟩ := h (algebra_map K E x),
   have hx' : is_integral F x := is_integral_tower_bot_of_is_integral_field hx,
-  obtain ⟨q, hq⟩ := minimal_polynomial.dvd hx'
+  obtain ⟨q, hq⟩ := minpoly.dvd hx'
     (is_scalar_tower.aeval_eq_zero_of_aeval_algebra_map_eq_zero_field
-      (minimal_polynomial.aeval hx)),
+      (minpoly.aeval hx)),
   use hx',
   apply polynomial.separable.of_mul_left,
   rw ← hq,

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -9,7 +9,7 @@ import ring_theory.adjoin_root
 import ring_theory.algebra_tower
 import ring_theory.algebraic
 import ring_theory.polynomial
-import field_theory.minimal_polynomial
+import field_theory.minpoly
 import linear_algebra.finite_dimensional
 import tactic.field_simp
 
@@ -408,30 +408,30 @@ section embeddings
 variables (F : Type*) [field F]
 
 /-- If `p` is the minimal polynomial of `a` over `F` then `F[a] ≃ₐ[F] F[x]/(p)` -/
-def alg_equiv.adjoin_singleton_equiv_adjoin_root_minimal_polynomial
+def alg_equiv.adjoin_singleton_equiv_adjoin_root_minpoly
   {R : Type*} [comm_ring R] [algebra F R] (x : R) (hx : is_integral F x) :
-  algebra.adjoin F ({x} : set R) ≃ₐ[F] adjoin_root (minimal_polynomial hx) :=
+  algebra.adjoin F ({x} : set R) ≃ₐ[F] adjoin_root (minpoly hx) :=
 alg_equiv.symm $ alg_equiv.of_bijective
   (alg_hom.cod_restrict
-    (adjoin_root.lift_hom _ x $ minimal_polynomial.aeval hx) _
+    (adjoin_root.lift_hom _ x $ minpoly.aeval hx) _
     (λ p, adjoin_root.induction_on _ p $ λ p,
       (algebra.adjoin_singleton_eq_range F x).symm ▸ (polynomial.aeval _).mem_range.mpr ⟨p, rfl⟩))
   ⟨(alg_hom.injective_cod_restrict _ _ _).2 $ (alg_hom.injective_iff _).2 $ λ p,
     adjoin_root.induction_on _ p $ λ p hp, ideal.quotient.eq_zero_iff_mem.2 $
-    ideal.mem_span_singleton.2 $ minimal_polynomial.dvd hx hp,
+    ideal.mem_span_singleton.2 $ minpoly.dvd hx hp,
   λ y, let ⟨p, _, hp⟩ := (subalgebra.ext_iff.1 (algebra.adjoin_singleton_eq_range F x) y).1 y.2 in
   ⟨adjoin_root.mk _ p, subtype.eq hp⟩⟩
 
 open finset
 
 -- Speed up the following proof.
-local attribute [irreducible] minimal_polynomial
+local attribute [irreducible] minpoly
 -- TODO: Why is this so slow?
 /-- If `K` and `L` are field extensions of `F` and we have `s : finset K` such that
 the minimal polynomial of each `x ∈ s` splits in `L` then `algebra.adjoin F s` embeds in `L`. -/
 theorem lift_of_splits {F K L : Type*} [field F] [field K] [field L]
   [algebra F K] [algebra F L] (s : finset K) :
-  (∀ x ∈ s, ∃ H : is_integral F x, polynomial.splits (algebra_map F L) (minimal_polynomial H)) →
+  (∀ x ∈ s, ∃ H : is_integral F x, polynomial.splits (algebra_map F L) (minpoly H)) →
   nonempty (algebra.adjoin F (↑s : set K) →ₐ[F] L) :=
 begin
   refine finset.induction_on s (λ H, _) (λ a s has ih H, _),
@@ -444,18 +444,18 @@ begin
     (submodule.fg_iff_finite_dimensional _).1 (fg_adjoin_of_finite (set.finite_mem_finset s) H3),
   letI := field_of_finite_dimensional F (algebra.adjoin F (↑s : set K)),
   have H5 : is_integral (algebra.adjoin F (↑s : set K)) a := is_integral_of_is_scalar_tower a H1,
-  have H6 : (minimal_polynomial H5).splits (algebra_map (algebra.adjoin F (↑s : set K)) L),
+  have H6 : (minpoly H5).splits (algebra_map (algebra.adjoin F (↑s : set K)) L),
   { refine polynomial.splits_of_splits_of_dvd _
-      (polynomial.map_ne_zero $ minimal_polynomial.ne_zero H1 :
+      (polynomial.map_ne_zero $ minpoly.ne_zero H1 :
         polynomial.map (algebra_map _ _) _ ≠ 0)
       ((polynomial.splits_map_iff _ _).2 _)
-      (minimal_polynomial.dvd _ _),
+      (minpoly.dvd _ _),
     { rw ← is_scalar_tower.algebra_map_eq, exact H2 },
-    { rw [← is_scalar_tower.aeval_apply, minimal_polynomial.aeval H1] } },
+    { rw [← is_scalar_tower.aeval_apply, minpoly.aeval H1] } },
   obtain ⟨y, hy⟩ := polynomial.exists_root_of_splits _ H6
-  (ne_of_lt (minimal_polynomial.degree_pos H5)).symm,
-  exact ⟨subalgebra.of_under _ _ $ (adjoin_root.lift_hom (minimal_polynomial H5) y hy).comp $
-    alg_equiv.adjoin_singleton_equiv_adjoin_root_minimal_polynomial _ _ H5⟩
+  (ne_of_lt (minpoly.degree_pos H5)).symm,
+  exact ⟨subalgebra.of_under _ _ $ (adjoin_root.lift_hom (minpoly H5) y hy).comp $
+    alg_equiv.adjoin_singleton_equiv_adjoin_root_minpoly _ _ H5⟩
 end
 
 end embeddings
@@ -703,7 +703,7 @@ alg_hom.comp (by { rw ← adjoin_roots β f, exact classical.choice (lift_of_spl
     have aeval y f = 0, from (eval₂_eq_eval_map _).trans $
       (mem_roots $ by exact map_ne_zero hf0).1 (multiset.mem_to_finset.mp hy),
     ⟨(is_algebraic_iff_is_integral _).1 ⟨f, hf0, this⟩,
-      splits_of_splits_of_dvd _ hf0 hf $ minimal_polynomial.dvd _ this⟩) })
+      splits_of_splits_of_dvd _ hf0 hf $ minpoly.dvd _ this⟩) })
   algebra.to_top
 
 theorem finite_dimensional (f : polynomial α) [is_splitting_field α β f] : finite_dimensional α β :=

--- a/src/linear_algebra/char_poly/coeff.lean
+++ b/src/linear_algebra/char_poly/coeff.lean
@@ -201,7 +201,7 @@ namespace matrix
 theorem is_integral : is_integral R M := ⟨char_poly M, ⟨char_poly_monic M, aeval_self_char_poly M⟩⟩
 
 theorem min_poly_dvd_char_poly {K : Type*} [field K] (M : matrix n n K) :
-  (minimal_polynomial M.is_integral) ∣ char_poly M :=
-minimal_polynomial.dvd M.is_integral (aeval_self_char_poly M)
+  (minpoly M.is_integral) ∣ char_poly M :=
+minpoly.dvd M.is_integral (aeval_self_char_poly M)
 
 end matrix

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -110,7 +110,7 @@ begin
     simp [algebra_map_End_apply, mem_eigenspace_iff.1 h.2, smul_smul, mul_comm] }
 end
 
-section minimal_polynomial
+section minpoly
 
 variables [finite_dimensional K V] (f : End K V)
 
@@ -120,14 +120,14 @@ is_integral_of_noetherian (by apply_instance) f
 variables {f} {μ : K}
 
 theorem is_root_of_has_eigenvalue (h : f.has_eigenvalue μ) :
-  (minimal_polynomial f.is_integral).is_root μ :=
+  (minpoly f.is_integral).is_root μ :=
 begin
   rcases (submodule.ne_bot_iff _).1 h with ⟨w, ⟨H, ne0⟩⟩,
   refine or.resolve_right (smul_eq_zero.1 _) ne0,
-  simp [← aeval_apply_of_has_eigenvector ⟨ne0, H⟩, minimal_polynomial.aeval f.is_integral],
+  simp [← aeval_apply_of_has_eigenvector ⟨ne0, H⟩, minpoly.aeval f.is_integral],
 end
 
-theorem has_eigenvalue_of_is_root (h : (minimal_polynomial f.is_integral).is_root μ) :
+theorem has_eigenvalue_of_is_root (h : (minpoly f.is_integral).is_root μ) :
   f.has_eigenvalue μ :=
 begin
   cases dvd_iff_is_root.2 h with p hp,
@@ -136,22 +136,22 @@ begin
   cases (linear_map.is_unit_iff _).2 con with u hu,
   have p_ne_0 : p ≠ 0,
   { intro con,
-    apply minimal_polynomial.ne_zero f.is_integral,
+    apply minpoly.ne_zero f.is_integral,
     rw [hp, con, mul_zero] },
-  have h_deg := minimal_polynomial.degree_le_of_ne_zero f.is_integral p_ne_0 _,
+  have h_deg := minpoly.degree_le_of_ne_zero f.is_integral p_ne_0 _,
   { rw [hp, degree_mul, degree_X_sub_C, polynomial.degree_eq_nat_degree p_ne_0] at h_deg,
     norm_cast at h_deg,
     linarith, },
-  { have h_aeval := minimal_polynomial.aeval f.is_integral,
+  { have h_aeval := minpoly.aeval f.is_integral,
     revert h_aeval,
     simp [hp, ← hu] },
 end
 
 theorem has_eigenvalue_iff_is_root :
-  f.has_eigenvalue μ ↔ (minimal_polynomial f.is_integral).is_root μ :=
+  f.has_eigenvalue μ ↔ (minpoly f.is_integral).is_root μ :=
 ⟨is_root_of_has_eigenvalue, has_eigenvalue_of_is_root⟩
 
-end minimal_polynomial
+end minpoly
 
 /-- Every linear operator on a vector space over an algebraically closed field has
     an eigenvalue. (Lemma 5.21 of [axler2015]) -/

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -45,7 +45,7 @@ not the standard one unless there is a primitive `n`th root of unity in `R`. For
 To get the standard cyclotomic polynomials, we use `int_coeff_of_cycl`, with `R = ℂ`, to get a
 polynomial with integer coefficients and then we map it to `polynomial R`, for any ring `R`.
 To prove `cyclotomic.irreducible`, the irreducibility of `cyclotomic n ℤ`, we show in
-`minimal_polynomial_primitive_root_eq_cyclotomic` that `cyclotomic n ℤ` is the minimal polynomial of
+`minpoly_primitive_root_eq_cyclotomic` that `cyclotomic n ℤ` is the minimal polynomial of
 any `n`-th primitive root of unity `μ : K`, where `K` is a field of characteristic `0`.
 -/
 
@@ -665,30 +665,30 @@ section minimial_polynomial
 open is_primitive_root polynomial complex
 
 /-- The minimal polynomial of a primitive `n`-th root of unity `μ` divides `cyclotomic n ℤ`. -/
-lemma minimal_polynomial_primitive_root_dvd_cyclotomic {n : ℕ} {K : Type*} [field K] {μ : K}
+lemma minpoly_primitive_root_dvd_cyclotomic {n : ℕ} {K : Type*} [field K] {μ : K}
   (h : is_primitive_root μ n) (hpos : 0 < n) [char_zero K] :
-  minimal_polynomial (is_integral h hpos) ∣ cyclotomic n ℤ :=
+  minpoly (is_integral h hpos) ∣ cyclotomic n ℤ :=
 begin
-  apply minimal_polynomial.integer_dvd (is_integral h hpos) (cyclotomic.monic n ℤ).is_primitive,
+  apply minpoly.integer_dvd (is_integral h hpos) (cyclotomic.monic n ℤ).is_primitive,
   simpa [aeval_def, eval₂_eq_eval_map, is_root.def] using is_root_cyclotomic hpos h
 end
 
 /-- `cyclotomic n ℤ` is the minimal polynomial of a primitive `n`-th root of unity `μ`. -/
-lemma minimal_polynomial_primitive_root_eq_cyclotomic {n : ℕ} {K : Type*} [field K] {μ : K}
+lemma minpoly_primitive_root_eq_cyclotomic {n : ℕ} {K : Type*} [field K] {μ : K}
   (h : is_primitive_root μ n) (hpos : 0 < n) [char_zero K] :
-  cyclotomic n ℤ = minimal_polynomial (is_integral h hpos) :=
+  cyclotomic n ℤ = minpoly (is_integral h hpos) :=
 begin
-  refine eq_of_monic_of_dvd_of_nat_degree_le (minimal_polynomial.monic (is_integral h hpos))
-    (cyclotomic.monic n ℤ) (minimal_polynomial_primitive_root_dvd_cyclotomic h hpos) _,
-  simpa [nat_degree_cyclotomic n ℤ] using totient_le_degree_minimal_polynomial h hpos
+  refine eq_of_monic_of_dvd_of_nat_degree_le (minpoly.monic (is_integral h hpos))
+    (cyclotomic.monic n ℤ) (minpoly_primitive_root_dvd_cyclotomic h hpos) _,
+  simpa [nat_degree_cyclotomic n ℤ] using totient_le_degree_minpoly h hpos
 end
 
 /-- `cyclotomic n ℤ` is irreducible. -/
 lemma cyclotomic.irreducible {n : ℕ} (hpos : 0 < n) : irreducible (cyclotomic n ℤ) :=
 begin
   have h0 := (ne_of_lt hpos).symm,
-  rw [minimal_polynomial_primitive_root_eq_cyclotomic (is_primitive_root_exp n h0) hpos],
-  exact minimal_polynomial.irreducible (is_integral (is_primitive_root_exp n h0) hpos)
+  rw [minpoly_primitive_root_eq_cyclotomic (is_primitive_root_exp n h0) hpos],
+  exact minpoly.irreducible (is_integral (is_primitive_root_exp n h0) hpos)
 end
 
 end minimial_polynomial

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import field_theory.adjoin
-import field_theory.minimal_polynomial
+import field_theory.minpoly
 import ring_theory.adjoin
 import ring_theory.adjoin_root
 import ring_theory.algebraic
@@ -140,7 +140,7 @@ variable [algebra A S]
 /-- `pb.minpoly_gen` is a minimal polynomial for `pb.gen`.
 
 If `A` is not a field, it might not necessarily be *the* minimal polynomial,
-however `nat_degree_minimal_polynomial` shows its degree is indeed minimal.
+however `nat_degree_minpoly` shows its degree is indeed minimal.
 -/
 noncomputable def minpoly_gen (pb : power_basis A S) : polynomial A :=
 X ^ pb.dim -
@@ -200,15 +200,15 @@ begin
 end
 
 @[simp]
-lemma nat_degree_minimal_polynomial (pb : power_basis A S) :
-  (minimal_polynomial pb.is_integral_gen).nat_degree = pb.dim :=
+lemma nat_degree_minpoly (pb : power_basis A S) :
+  (minpoly pb.is_integral_gen).nat_degree = pb.dim :=
 begin
   refine le_antisymm _
-    (dim_le_nat_degree_of_root pb (minimal_polynomial.ne_zero _) (minimal_polynomial.aeval _)),
+    (dim_le_nat_degree_of_root pb (minpoly.ne_zero _) (minpoly.aeval _)),
   rw ← nat_degree_minpoly_gen,
   apply nat_degree_le_of_degree_le,
   rw ← degree_eq_nat_degree (minpoly_gen_monic pb).ne_zero,
-  exact minimal_polynomial.min _ (minpoly_gen_monic pb) (aeval_minpoly_gen pb)
+  exact minpoly.min _ (minpoly_gen_monic pb) (aeval_minpoly_gen pb)
 end
 
 end minpoly
@@ -225,20 +225,20 @@ begin
 end
 
 lemma constr_pow_aeval (pb : power_basis A S) {y : S'}
-  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) (f : polynomial A) :
+  (hy : aeval y (minpoly pb.is_integral_gen) = 0) (f : polynomial A) :
   pb.is_basis.constr (λ i, y ^ (i : ℕ)) (aeval pb.gen f) = aeval y f :=
 begin
   rw [← aeval_mod_by_monic_eq_self_of_root
-          (minimal_polynomial.monic pb.is_integral_gen)
-          (minimal_polynomial.aeval _),
+          (minpoly.monic pb.is_integral_gen)
+          (minpoly.aeval _),
       ← @aeval_mod_by_monic_eq_self_of_root _ _ _ _ _ f _
-          (minimal_polynomial.monic pb.is_integral_gen) y hy],
-  by_cases hf : f %ₘ minimal_polynomial (pb.is_integral_gen) = 0,
+          (minpoly.monic pb.is_integral_gen) y hy],
+  by_cases hf : f %ₘ minpoly (pb.is_integral_gen) = 0,
   { simp only [hf, alg_hom.map_zero, linear_map.map_zero] },
-  have : (f %ₘ minimal_polynomial _).nat_degree < pb.dim,
-  { rw ← pb.nat_degree_minimal_polynomial,
+  have : (f %ₘ minpoly _).nat_degree < pb.dim,
+  { rw ← pb.nat_degree_minpoly,
     apply nat_degree_lt_nat_degree hf,
-    exact degree_mod_by_monic_lt _ (minimal_polynomial.monic _) (minimal_polynomial.ne_zero _) },
+    exact degree_mod_by_monic_lt _ (minpoly.monic _) (minpoly.ne_zero _) },
   rw [aeval_eq_sum_range' this, aeval_eq_sum_range' this, linear_map.map_sum],
   refine finset.sum_congr rfl (λ i (hi : i ∈ finset.range pb.dim), _),
   rw finset.mem_range at hi,
@@ -248,17 +248,17 @@ begin
 end
 
 lemma constr_pow_gen (pb : power_basis A S) {y : S'}
-  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) :
+  (hy : aeval y (minpoly pb.is_integral_gen) = 0) :
   pb.is_basis.constr (λ i, y ^ (i : ℕ)) pb.gen = y :=
 by { convert pb.constr_pow_aeval hy X; rw aeval_X }
 
 lemma constr_pow_algebra_map (pb : power_basis A S) {y : S'}
-  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) (x : A) :
+  (hy : aeval y (minpoly pb.is_integral_gen) = 0) (x : A) :
   pb.is_basis.constr (λ i, y ^ (i : ℕ)) (algebra_map A S x) = algebra_map A S' x :=
 by { convert pb.constr_pow_aeval hy (C x); rw aeval_C }
 
 lemma constr_pow_mul [nontrivial S] (pb : power_basis A S) {y : S'}
-  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) (x x' : S) :
+  (hy : aeval y (minpoly pb.is_integral_gen) = 0) (x x' : S) :
   pb.is_basis.constr (λ i, y ^ (i : ℕ)) (x * x') =
     pb.is_basis.constr (λ i, y ^ (i : ℕ)) x * pb.is_basis.constr (λ i, y ^ (i : ℕ)) x' :=
 begin
@@ -270,7 +270,7 @@ end
 /-- `pb.lift y hy` is the algebra map sending `pb.gen` to `y`,
 where `hy` states the higher powers of `y` are the same as the higher powers of `pb.gen`. -/
 noncomputable def lift [nontrivial S] (pb : power_basis A S) (y : S')
-  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) :
+  (hy : aeval y (minpoly pb.is_integral_gen) = 0) :
   S →ₐ[A] S' :=
 { map_one' := by { convert pb.constr_pow_algebra_map hy 1 using 2; rw ring_hom.map_one },
   map_zero' := by { convert pb.constr_pow_algebra_map hy 0 using 2; rw ring_hom.map_zero },
@@ -279,47 +279,47 @@ noncomputable def lift [nontrivial S] (pb : power_basis A S) (y : S')
   .. pb.is_basis.constr (λ i, y ^ (i : ℕ)) }
 
 @[simp] lemma lift_gen [nontrivial S] (pb : power_basis A S) (y : S')
-  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) :
+  (hy : aeval y (minpoly pb.is_integral_gen) = 0) :
   pb.lift y hy pb.gen = y :=
 pb.constr_pow_gen hy
 
 @[simp] lemma lift_aeval [nontrivial S] (pb : power_basis A S) (y : S')
-  (hy : aeval y (minimal_polynomial pb.is_integral_gen) = 0) (f : polynomial A) :
+  (hy : aeval y (minpoly pb.is_integral_gen) = 0) (f : polynomial A) :
   pb.lift y hy (aeval pb.gen f) = aeval y f :=
 pb.constr_pow_aeval hy f
 
 /-- `pb.equiv pb' h` is an equivalence of algebras with the same power basis. -/
 noncomputable def equiv [nontrivial S] [nontrivial S']
   (pb : power_basis A S) (pb' : power_basis A S')
-  (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen) :
+  (h : minpoly pb.is_integral_gen = minpoly pb'.is_integral_gen) :
   S ≃ₐ[A] S' :=
 alg_equiv.of_alg_hom
-  (pb.lift pb'.gen (h.symm ▸ minimal_polynomial.aeval pb'.is_integral_gen))
-  (pb'.lift pb.gen (h ▸ minimal_polynomial.aeval pb.is_integral_gen))
+  (pb.lift pb'.gen (h.symm ▸ minpoly.aeval pb'.is_integral_gen))
+  (pb'.lift pb.gen (h ▸ minpoly.aeval pb.is_integral_gen))
   (by { ext x, obtain ⟨f, hf, rfl⟩ := pb'.exists_eq_aeval x, simp })
   (by { ext x, obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x, simp })
 
 @[simp]
 lemma equiv_aeval [nontrivial S] [nontrivial S']
   (pb : power_basis A S) (pb' : power_basis A S')
-  (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen)
+  (h : minpoly pb.is_integral_gen = minpoly pb'.is_integral_gen)
   (f : polynomial A) :
   pb.equiv pb' h (aeval pb.gen f) = aeval pb'.gen f :=
-pb.lift_aeval _ (h.symm ▸ minimal_polynomial.aeval _) _
+pb.lift_aeval _ (h.symm ▸ minpoly.aeval _) _
 
 @[simp]
 lemma equiv_gen [nontrivial S] [nontrivial S']
   (pb : power_basis A S) (pb' : power_basis A S')
-  (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen) :
+  (h : minpoly pb.is_integral_gen = minpoly pb'.is_integral_gen) :
   pb.equiv pb' h pb.gen = pb'.gen :=
-pb.lift_gen _ (h.symm ▸ minimal_polynomial.aeval _)
+pb.lift_gen _ (h.symm ▸ minpoly.aeval _)
 
 local attribute [irreducible] power_basis.lift
 
 @[simp]
 lemma equiv_symm [nontrivial S] [nontrivial S']
   (pb : power_basis A S) (pb' : power_basis A S')
-  (h : minimal_polynomial pb.is_integral_gen = minimal_polynomial pb'.is_integral_gen) :
+  (h : minpoly pb.is_integral_gen = minpoly pb'.is_integral_gen) :
   (pb.equiv pb' h).symm = pb'.equiv pb h.symm :=
 rfl
 
@@ -340,13 +340,13 @@ end
 We take `h : y = algebra_map L T x` as an argument because `rw h` typically fails
 since `is_integral R y` depends on y.
 -/
-lemma minimal_polynomial.eq_of_algebra_map_eq [algebra K S] [algebra K T]
+lemma minpoly.eq_of_algebra_map_eq [algebra K S] [algebra K T]
   [is_scalar_tower K S T] (hST : function.injective (algebra_map S T))
   {x : S} {y : T} (hx : is_integral K x) (hy : is_integral K y)
-  (h : y = algebra_map S T x) : minimal_polynomial hx = minimal_polynomial hy :=
-minimal_polynomial.unique hy (minimal_polynomial.monic hx)
-  (by rw [h, ← is_scalar_tower.algebra_map_aeval, minimal_polynomial.aeval hx, ring_hom.map_zero])
-  (λ q q_monic root_q, minimal_polynomial.min _ q_monic
+  (h : y = algebra_map S T x) : minpoly hx = minpoly hy :=
+minpoly.unique hy (minpoly.monic hx)
+  (by rw [h, ← is_scalar_tower.algebra_map_aeval, minpoly.aeval hx, ring_hom.map_zero])
+  (λ q q_monic root_q, minpoly.min _ q_monic
     (is_scalar_tower.aeval_eq_zero_of_aeval_algebra_map_eq_zero K S T hST
       (h ▸ root_q : aeval (algebra_map S T x) q = 0)))
 
@@ -356,21 +356,21 @@ open power_basis
 
 lemma mem_span_power_basis [nontrivial R] {x y : S} (hx : _root_.is_integral R x)
   (hy : ∃ f : polynomial R, y = aeval x f) :
-  y ∈ submodule.span R (set.range (λ (i : fin (minimal_polynomial hx).nat_degree),
+  y ∈ submodule.span R (set.range (λ (i : fin (minpoly hx).nat_degree),
     x ^ (i : ℕ))) :=
 begin
   obtain ⟨f, rfl⟩ := hy,
   rw mem_span_pow',
-  have := minimal_polynomial.monic hx,
-  refine ⟨f.mod_by_monic (minimal_polynomial hx),
+  have := minpoly.monic hx,
+  refine ⟨f.mod_by_monic (minpoly hx),
     lt_of_lt_of_le (degree_mod_by_monic_lt _ this (ne_zero_of_monic this)) degree_le_nat_degree,
     _⟩,
   conv_lhs { rw ← mod_by_monic_add_div f this },
-  simp only [add_zero, zero_mul, minimal_polynomial.aeval, aeval_add, alg_hom.map_mul]
+  simp only [add_zero, zero_mul, minpoly.aeval, aeval_add, alg_hom.map_mul]
 end
 
 lemma linear_independent_power_basis [algebra K S] {x : S} (hx : _root_.is_integral K x) :
-  linear_independent K (λ (i : fin (minimal_polynomial hx).nat_degree), x ^ (i : ℕ)) :=
+  linear_independent K (λ (i : fin (minpoly hx).nat_degree), x ^ (i : ℕ)) :=
 begin
   rw linear_independent_iff,
   intros p hp,
@@ -402,8 +402,8 @@ begin
   { ext i, rw [← f_def, this, coeff_zero, finsupp.zero_apply] },
   contrapose hp with hf,
   intro h,
-  have : (minimal_polynomial hx).degree ≤ f.degree,
-  { apply minimal_polynomial.degree_le_of_ne_zero hx hf,
+  have : (minpoly hx).degree ≤ f.degree,
+  { apply minpoly.degree_le_of_ne_zero hx hf,
     convert h,
     rw [finsupp.total_apply, aeval_def, eval₂_eq_sum, finsupp.sum_sum_index],
     { apply finset.sum_congr rfl,
@@ -412,9 +412,9 @@ begin
         finsupp.sum_single_index] },
     { intro, simp only [ring_hom.map_zero, zero_mul] },
     { intros, simp only [ring_hom.map_add, add_mul] } },
-  have : ¬ (minimal_polynomial hx).degree ≤ f.degree,
+  have : ¬ (minpoly hx).degree ≤ f.degree,
   { apply not_le_of_lt,
-    rw [degree_eq_nat_degree (minimal_polynomial.ne_zero hx), degree_lt_iff_coeff_zero],
+    rw [degree_eq_nat_degree (minpoly.ne_zero hx), degree_lt_iff_coeff_zero],
     intros i hi,
     rw [f_def' i, dif_neg],
     exact not_lt_of_ge hi },
@@ -422,7 +422,7 @@ begin
 end
 
 lemma power_basis_is_basis [algebra K S] {x : S} (hx : _root_.is_integral K x) :
-  is_basis K (λ (i : fin (minimal_polynomial hx).nat_degree),
+  is_basis K (λ (i : fin (minpoly hx).nat_degree),
     (⟨x, subset_adjoin (set.mem_singleton x)⟩ ^ (i : ℕ) : adjoin K ({x} : set S))) :=
 begin
   have hST : function.injective (algebra_map (adjoin K ({x} : set S)) S) := subtype.coe_injective,
@@ -431,7 +431,7 @@ begin
   { apply (is_integral_algebra_map_iff hST).mp,
     convert hx,
     apply_instance },
-  have minpoly_eq := minimal_polynomial.eq_of_algebra_map_eq hST hx' hx,
+  have minpoly_eq := minpoly.eq_of_algebra_map_eq hST hx' hx,
   refine ⟨_, _root_.eq_top_iff.mpr _⟩,
   { have := linear_independent_power_basis hx',
     rwa minpoly_eq at this,
@@ -453,7 +453,7 @@ where `d` is the degree of the minimal polynomial of `x`. -/
 noncomputable def adjoin.power_basis [algebra K S] {x : S} (hx : _root_.is_integral K x) :
   power_basis K (adjoin K ({x} : set S)) :=
 { gen := ⟨x, subset_adjoin (set.mem_singleton x)⟩,
-  dim := (minimal_polynomial hx).nat_degree,
+  dim := (minpoly hx).nat_degree,
   is_basis := power_basis_is_basis hx }
 
 end algebra
@@ -472,8 +472,8 @@ begin
   have aeval_f' : aeval (root f) f' = 0,
   { rw [f'_def, alg_hom.map_mul, aeval_eq, mk_self, zero_mul] },
   have hx : is_integral K (root f) := ⟨f', f'_monic, aeval_f'⟩,
-  have minpoly_eq : f' = minimal_polynomial hx,
-  { apply minimal_polynomial.unique hx f'_monic aeval_f',
+  have minpoly_eq : f' = minpoly hx,
+  { apply minpoly.unique hx f'_monic aeval_f',
     intros q q_monic q_aeval,
     have commutes : (lift (algebra_map K (adjoin_root f)) (root f) q_aeval).comp (mk q) = mk f,
     { ext,
@@ -511,17 +511,17 @@ end adjoin_root
 namespace intermediate_field
 
 lemma power_basis_is_basis {x : L} (hx : is_integral K x) :
-  is_basis K (λ (i : fin (minimal_polynomial hx).nat_degree), (adjoin_simple.gen K x ^ (i : ℕ))) :=
+  is_basis K (λ (i : fin (minpoly hx).nat_degree), (adjoin_simple.gen K x ^ (i : ℕ))) :=
 begin
   let ϕ := (adjoin_root_equiv_adjoin K hx).to_linear_equiv,
-  have key : ϕ (adjoin_root.root (minimal_polynomial hx)) = adjoin_simple.gen K x,
+  have key : ϕ (adjoin_root.root (minpoly hx)) = adjoin_simple.gen K x,
   { exact intermediate_field.adjoin_root_equiv_adjoin_apply_root K hx },
-  suffices : ϕ ∘ (λ (i : fin (minimal_polynomial hx).nat_degree),
-    adjoin_root.root (minimal_polynomial hx) ^ (i.val)) =
-      (λ (i : fin (minimal_polynomial hx).nat_degree),
+  suffices : ϕ ∘ (λ (i : fin (minpoly hx).nat_degree),
+    adjoin_root.root (minpoly hx) ^ (i.val)) =
+      (λ (i : fin (minpoly hx).nat_degree),
         (adjoin_simple.gen K x) ^ ↑i),
   { rw ← this, exact linear_equiv.is_basis
-    (adjoin_root.power_basis_is_basis (minimal_polynomial.ne_zero hx)) ϕ },
+    (adjoin_root.power_basis_is_basis (minpoly.ne_zero hx)) ϕ },
   ext y,
   rw [function.comp_app, fin.val_eq_coe, alg_equiv.to_linear_equiv_apply, alg_equiv.map_pow],
   rw intermediate_field.adjoin_root_equiv_adjoin_apply_root K hx,
@@ -532,7 +532,7 @@ where `d` is the degree of the minimal polynomial of `x`. -/
 noncomputable def adjoin.power_basis {x : L} (hx : is_integral K x) :
   power_basis K K⟮x⟯ :=
 { gen := adjoin_simple.gen K x,
-  dim := (minimal_polynomial hx).nat_degree,
+  dim := (minpoly hx).nat_degree,
   is_basis := power_basis_is_basis hx }
 
 @[simp] lemma adjoin.power_basis.gen_eq {x : L} (hx : is_integral K x) :
@@ -542,7 +542,7 @@ lemma adjoin.finite_dimensional {x : L} (hx : is_integral K x) : finite_dimensio
 power_basis.finite_dimensional (adjoin.power_basis hx)
 
 lemma adjoin.findim {x : L} (hx : is_integral K x) :
-  finite_dimensional.findim K K⟮x⟯ = (minimal_polynomial hx).nat_degree :=
+  finite_dimensional.findim K K⟮x⟯ = (minpoly hx).nat_degree :=
 begin
   rw power_basis.findim (adjoin.power_basis hx),
   refl,
@@ -558,7 +558,7 @@ open intermediate_field
 noncomputable def equiv_adjoin_simple (pb : power_basis K L) :
   K⟮pb.gen⟯ ≃ₐ[K] L :=
 (adjoin.power_basis pb.is_integral_gen).equiv pb
-  (minimal_polynomial.eq_of_algebra_map_eq (algebra_map K⟮pb.gen⟯ L).injective _ _
+  (minpoly.eq_of_algebra_map_eq (algebra_map K⟮pb.gen⟯ L).injective _ _
     (by rw [adjoin.power_basis.gen_eq, adjoin_simple.algebra_map_gen]))
 
 @[simp]

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -721,9 +721,9 @@ lemma nth_roots_one_eq_bind_primitive_roots {ζ : R} {n : ℕ} (hpos : 0 < n)
 
 end integral_domain
 
-section minimal_polynomial
+section minpoly
 
-open minimal_polynomial
+open minpoly
 
 variables {n : ℕ} {K : Type*} [field K] {μ : K} (h : is_primitive_root μ n) (hpos : 0 < n)
 
@@ -742,8 +742,8 @@ end
 variables [char_zero K]
 
 /--The minimal polynomial of a root of unity `μ` divides `X ^ n - 1`. -/
-lemma minimal_polynomial_dvd_X_pow_sub_one :
-  minimal_polynomial (is_integral h hpos) ∣ X ^ n - 1 :=
+lemma minpoly_dvd_X_pow_sub_one :
+  minpoly (is_integral h hpos) ∣ X ^ n - 1 :=
 begin
   apply integer_dvd (is_integral h hpos) (polynomial.monic.is_primitive
   (monic_X_pow_sub_C 1 (ne_of_lt hpos).symm)),
@@ -752,79 +752,79 @@ begin
 end
 
 /-- The reduction modulo `p` of the minimal polynomial of a root of unity `μ` is separable. -/
-lemma separable_minimal_polynomial_mod {p : ℕ} [fact p.prime] (hdiv : ¬p ∣ n) :
-  separable (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
+lemma separable_minpoly_mod {p : ℕ} [fact p.prime] (hdiv : ¬p ∣ n) :
+  separable (map (int.cast_ring_hom (zmod p)) (minpoly (is_integral h hpos))) :=
 begin
   have hdvd : (map (int.cast_ring_hom (zmod p))
-    (minimal_polynomial (is_integral h hpos))) ∣ X ^ n - 1,
+    (minpoly (is_integral h hpos))) ∣ X ^ n - 1,
   { simpa [map_pow, map_X, map_one, ring_hom.coe_of, map_sub] using
       ring_hom.map_dvd (ring_hom.of (map (int.cast_ring_hom (zmod p))))
-        (minimal_polynomial_dvd_X_pow_sub_one h hpos) },
+        (minpoly_dvd_X_pow_sub_one h hpos) },
   refine separable.of_dvd (separable_X_pow_sub_C 1 _ one_ne_zero) hdvd,
   by_contra hzero,
   exact hdiv ((zmod.nat_coe_zmod_eq_zero_iff_dvd n p).1 (not_not.1 hzero))
 end
 
 /-- The reduction modulo `p` of the minimal polynomial of a root of unity `μ` is squarefree. -/
-lemma squarefree_minimal_polynomial_mod {p : ℕ} [fact p.prime] (hdiv : ¬ p ∣ n) :
-  squarefree (map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos))) :=
-(separable_minimal_polynomial_mod h hpos hdiv).squarefree
+lemma squarefree_minpoly_mod {p : ℕ} [fact p.prime] (hdiv : ¬ p ∣ n) :
+  squarefree (map (int.cast_ring_hom (zmod p)) (minpoly (is_integral h hpos))) :=
+(separable_minpoly_mod h hpos hdiv).squarefree
 
 /- Let `P` be the minimal polynomial of a root of unity `μ` and `Q` be the minimal polynomial of
 `μ ^ p`, where `p` is a prime that does not divide `n`. Then `P` divides `expand ℤ p Q`. -/
-lemma minimal_polynomial_dvd_expand {p : ℕ} (hprime : nat.prime p) (hdiv : ¬ p ∣ n) :
-  minimal_polynomial (is_integral h hpos) ∣
-  expand ℤ p (minimal_polynomial (is_integral (pow_of_prime h hprime hdiv) hpos)) :=
+lemma minpoly_dvd_expand {p : ℕ} (hprime : nat.prime p) (hdiv : ¬ p ∣ n) :
+  minpoly (is_integral h hpos) ∣
+  expand ℤ p (minpoly (is_integral (pow_of_prime h hprime hdiv) hpos)) :=
 begin
-  apply minimal_polynomial.integer_dvd,
+  apply minpoly.integer_dvd,
   { apply monic.is_primitive,
     rw [polynomial.monic, leading_coeff, nat_degree_expand, mul_comm, coeff_expand_mul'
         (nat.prime.pos hprime), ← leading_coeff, ← polynomial.monic],
-    exact minimal_polynomial.monic (is_integral (pow_of_prime h hprime hdiv) hpos) },
+    exact minpoly.monic (is_integral (pow_of_prime h hprime hdiv) hpos) },
   { rw [aeval_def, coe_expand, ← comp, eval₂_eq_eval_map, map_comp, map_pow, map_X, eval_comp,
       eval_pow, eval_X, ← eval₂_eq_eval_map, ← aeval_def],
-    exact minimal_polynomial.aeval (is_integral (pow_of_prime h hprime hdiv) hpos) }
+    exact minpoly.aeval (is_integral (pow_of_prime h hprime hdiv) hpos) }
 end
 
 /- Let `P` be the minimal polynomial of a root of unity `μ` and `Q` be the minimal polynomial of
 `μ ^ p`, where `p` is a prime that does not divide `n`. Then `P` divides `Q ^ p` modulo `p`. -/
-lemma minimal_polynomial_dvd_pow_mod {p : ℕ} [hprime : fact p.prime] (hdiv : ¬ p ∣ n) :
-  map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos)) ∣
-  map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral
+lemma minpoly_dvd_pow_mod {p : ℕ} [hprime : fact p.prime] (hdiv : ¬ p ∣ n) :
+  map (int.cast_ring_hom (zmod p)) (minpoly (is_integral h hpos)) ∣
+  map (int.cast_ring_hom (zmod p)) (minpoly (is_integral
     (pow_of_prime h hprime hdiv) hpos)) ^ p :=
 begin
-  set Q := minimal_polynomial (is_integral (pow_of_prime h hprime hdiv) hpos),
+  set Q := minpoly (is_integral (pow_of_prime h hprime hdiv) hpos),
   have hfrob : map (int.cast_ring_hom (zmod p)) Q ^ p =
     map (int.cast_ring_hom (zmod p)) (expand ℤ p Q),
   by rw [← zmod.expand_card, map_expand (nat.prime.pos hprime)],
   rw [hfrob],
   apply ring_hom.map_dvd (ring_hom.of (map (int.cast_ring_hom (zmod p)))),
-  exact minimal_polynomial_dvd_expand h hpos hprime hdiv
+  exact minpoly_dvd_expand h hpos hprime hdiv
 end
 
 /- Let `P` be the minimal polynomial of a root of unity `μ` and `Q` be the minimal polynomial of
 `μ ^ p`, where `p` is a prime that does not divide `n`. Then `P` divides `Q` modulo `p`. -/
-lemma minimal_polynomial_dvd_mod_p {p : ℕ} [hprime : fact p.prime] (hdiv : ¬ p ∣ n) :
-  map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral h hpos)) ∣
-  map (int.cast_ring_hom (zmod p)) (minimal_polynomial (is_integral
+lemma minpoly_dvd_mod_p {p : ℕ} [hprime : fact p.prime] (hdiv : ¬ p ∣ n) :
+  map (int.cast_ring_hom (zmod p)) (minpoly (is_integral h hpos)) ∣
+  map (int.cast_ring_hom (zmod p)) (minpoly (is_integral
     (pow_of_prime h hprime hdiv) hpos)) :=
-(unique_factorization_monoid.dvd_pow_iff_dvd_of_squarefree (squarefree_minimal_polynomial_mod h
-  hpos hdiv) (nat.prime.ne_zero hprime)).1 (minimal_polynomial_dvd_pow_mod h hpos hdiv)
+(unique_factorization_monoid.dvd_pow_iff_dvd_of_squarefree (squarefree_minpoly_mod h
+  hpos hdiv) (nat.prime.ne_zero hprime)).1 (minpoly_dvd_pow_mod h hpos hdiv)
 
 /-- If `p` is a prime that does not divide `n`,
 then the minimal polynomials of a primitive `n`-th root of unity `μ`
 and of `μ ^ p` are the same. -/
-lemma minimal_polynomial_eq_pow {p : ℕ} [hprime : fact p.prime] (hdiv : ¬ p ∣ n) :
-  minimal_polynomial (is_integral h hpos) =
-  minimal_polynomial (is_integral (pow_of_prime h hprime hdiv) hpos) :=
+lemma minpoly_eq_pow {p : ℕ} [hprime : fact p.prime] (hdiv : ¬ p ∣ n) :
+  minpoly (is_integral h hpos) =
+  minpoly (is_integral (pow_of_prime h hprime hdiv) hpos) :=
 begin
   by_contra hdiff,
-  set P := minimal_polynomial (is_integral h hpos),
-  set Q := minimal_polynomial (is_integral (pow_of_prime h hprime hdiv) hpos),
-  have Pmonic : P.monic := minimal_polynomial.monic _,
-  have Qmonic : Q.monic := minimal_polynomial.monic _,
-  have Pirr : irreducible P := minimal_polynomial.irreducible _,
-  have Qirr : irreducible Q := minimal_polynomial.irreducible _,
+  set P := minpoly (is_integral h hpos),
+  set Q := minpoly (is_integral (pow_of_prime h hprime hdiv) hpos),
+  have Pmonic : P.monic := minpoly.monic _,
+  have Qmonic : Q.monic := minpoly.monic _,
+  have Pirr : irreducible P := minpoly.irreducible _,
+  have Qirr : irreducible Q := minpoly.irreducible _,
   have PQprim : is_primitive (P * Q) := Pmonic.is_primitive.mul Qmonic.is_primitive,
   have prod : P * Q ∣ X ^ n - 1,
   { apply (is_primitive.int.dvd_iff_map_cast_dvd_map_cast (P * Q) (X ^ n - 1) PQprim
@@ -838,12 +838,12 @@ begin
       refine hdiff (eq_of_monic_of_associated Pmonic Qmonic _),
       exact associated_of_dvd_dvd hdiv (dvd_symm_of_irreducible Pirr Qirr hdiv) },
     { apply (map_dvd_map (int.cast_ring_hom ℚ) int.cast_injective Pmonic).2,
-      exact minimal_polynomial_dvd_X_pow_sub_one h hpos },
+      exact minpoly_dvd_X_pow_sub_one h hpos },
     { apply (map_dvd_map (int.cast_ring_hom ℚ) int.cast_injective Qmonic).2,
-      exact minimal_polynomial_dvd_X_pow_sub_one (pow_of_prime h hprime hdiv) hpos } },
+      exact minpoly_dvd_X_pow_sub_one (pow_of_prime h hprime hdiv) hpos } },
   replace prod := ring_hom.map_dvd (ring_hom.of (map (int.cast_ring_hom (zmod p)))) prod,
   rw [ring_hom.coe_of, map_mul, map_sub, map_one, map_pow, map_X] at prod,
-  obtain ⟨R, hR⟩ := minimal_polynomial_dvd_mod_p h hpos hdiv,
+  obtain ⟨R, hR⟩ := minpoly_dvd_mod_p h hpos hdiv,
   rw [hR, ← mul_assoc, ← map_mul, ← pow_two, map_pow] at prod,
   have habs : map (int.cast_ring_hom (zmod p)) P ^ 2 ∣ map (int.cast_ring_hom (zmod p)) P ^ 2 * R,
   { use R },
@@ -858,7 +858,7 @@ begin
   { exact not_lt_of_le hle habs },
   { replace hunit := degree_eq_zero_of_is_unit hunit,
     rw degree_map_eq_of_leading_coeff_ne_zero _ _ at hunit,
-    { exact (ne_of_lt (minimal_polynomial.degree_pos (is_integral h hpos))).symm hunit },
+    { exact (ne_of_lt (minpoly.degree_pos (is_integral h hpos))).symm hunit },
     simp only [Pmonic, ring_hom.eq_int_cast, monic.leading_coeff, int.cast_one, ne.def,
       not_false_iff, one_ne_zero] }
 end
@@ -866,8 +866,8 @@ end
 /-- If `m : ℕ` is coprime with `n`,
 then the minimal polynomials of a primitive `n`-th root of unity `μ`
 and of `μ ^ m` are the same. -/
-lemma minimal_polynomial_eq_pow_coprime {m : ℕ} (hcop : nat.coprime m n) :
-  minimal_polynomial (is_integral h hpos) = minimal_polynomial
+lemma minpoly_eq_pow_coprime {m : ℕ} (hcop : nat.coprime m n) :
+  minpoly (is_integral h hpos) = minpoly
   (is_integral (h.pow_of_coprime m hcop) hpos) :=
 begin
   revert n hcop,
@@ -883,7 +883,7 @@ begin
     replace hprime := nat.prime_iff_prime.2 hprime,
     have hdiv := (nat.prime.coprime_iff_not_dvd hprime).1 (nat.coprime.coprime_mul_right hcop),
     letI : fact p.prime := hprime,
-    rw [minimal_polynomial_eq_pow
+    rw [minpoly_eq_pow
       (h.pow_of_coprime a (nat.coprime.coprime_mul_left hcop)) hpos hdiv],
     congr' 1,
     ring_exp }
@@ -892,36 +892,36 @@ end
 /-- If `m : ℕ` is coprime with `n`,
 then the minimal polynomial of a primitive `n`-th root of unity `μ`
 has `μ ^ m` as root. -/
-lemma pow_is_root_minimal_polynomial {m : ℕ} (hcop : nat.coprime m n) :
-  is_root (map (int.cast_ring_hom K) (minimal_polynomial (is_integral h hpos))) (μ ^ m) :=
-by simpa [minimal_polynomial_eq_pow_coprime h hpos hcop, eval_map, aeval_def (μ ^ m) _]
-  using minimal_polynomial.aeval (is_integral (h.pow_of_coprime m hcop) hpos)
+lemma pow_is_root_minpoly {m : ℕ} (hcop : nat.coprime m n) :
+  is_root (map (int.cast_ring_hom K) (minpoly (is_integral h hpos))) (μ ^ m) :=
+by simpa [minpoly_eq_pow_coprime h hpos hcop, eval_map, aeval_def (μ ^ m) _]
+  using minpoly.aeval (is_integral (h.pow_of_coprime m hcop) hpos)
 
 /-- `primitive_roots n K` is a subset of the roots of the minimal polynomial of a primitive
 `n`-th root of unity `μ`. -/
-lemma is_roots_of_minimal_polynomial : primitive_roots n K ⊆ (map (int.cast_ring_hom K)
-  (minimal_polynomial (is_integral h hpos))).roots.to_finset :=
+lemma is_roots_of_minpoly : primitive_roots n K ⊆ (map (int.cast_ring_hom K)
+  (minpoly (is_integral h hpos))).roots.to_finset :=
 begin
   intros x hx,
   obtain ⟨m, hle, hcop, rfl⟩ := (is_primitive_root_iff h hpos).1 ((mem_primitive_roots hpos).1 hx),
   simpa [multiset.mem_to_finset,
-    mem_roots (map_monic_ne_zero $ minimal_polynomial.monic $ is_integral h hpos)]
-    using pow_is_root_minimal_polynomial h hpos hcop
+    mem_roots (map_monic_ne_zero $ minpoly.monic $ is_integral h hpos)]
+    using pow_is_root_minpoly h hpos hcop
 end
 
 /-- The degree of the minimal polynomial of `μ` is at least `totient n`. -/
-lemma totient_le_degree_minimal_polynomial : nat.totient n ≤ (minimal_polynomial
+lemma totient_le_degree_minpoly : nat.totient n ≤ (minpoly
   (is_integral h hpos)).nat_degree :=
-let P : polynomial ℤ := minimal_polynomial (is_integral h hpos),-- minimal polynomial of `μ`
+let P : polynomial ℤ := minpoly (is_integral h hpos),-- minimal polynomial of `μ`
     P_K : polynomial K := map (int.cast_ring_hom K) P -- minimal polynomial of `μ` sent to `K[X]`
 in calc
 n.totient = (primitive_roots n K).card : (h.card_primitive_roots hpos).symm
-... ≤ P_K.roots.to_finset.card : finset.card_le_of_subset (is_roots_of_minimal_polynomial h hpos)
+... ≤ P_K.roots.to_finset.card : finset.card_le_of_subset (is_roots_of_minpoly h hpos)
 ... ≤ P_K.roots.card : multiset.to_finset_card_le _
 ... ≤ P_K.nat_degree : (card_roots' $ map_monic_ne_zero
-        (minimal_polynomial.monic $ is_integral h hpos))
+        (minpoly.monic $ is_integral h hpos))
 ... ≤ P.nat_degree : nat_degree_map_le _
 
-end minimal_polynomial
+end minpoly
 
 end is_primitive_root


### PR DESCRIPTION
This PR renames:

* `minimal_polynomial` -> `minpoly`
* a similar substitution throughout the library for all names containing the substring `minimal_polynomial`
* `fixed_points.minpoly.minimal_polynomial` -> `fixed_points.minpoly_eq_minpoly`

This PR moves a file:

  src/field_theory/minimal_polynomial.lean -> src/field_theory/minpoly.lean



---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->