### PR TITLE
[Merged by Bors] - hack(manifold): disable subsingleton instances to speed up simp

### DIFF
--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -120,6 +120,12 @@ the arrow. -/
 localized "infixr  ` ≫ₕ `:100 := local_homeomorph.trans" in manifold
 localized "infixr  ` ≫ `:100 := local_equiv.trans" in manifold
 
+/- `simp` looks for subsingleton instances at every call. This turns out to be very
+inefficient, especially in `simp`-heavy parts of the library such as the manifold code.
+Disable two such instances to speed up things.
+NB: this is just a hack. TODO: fix `simp` properly. -/
+localized "attribute [-instance] unique.subsingleton pi.subsingleton" in manifold
+
 open set local_homeomorph
 
 /-! ### Structure groupoids-/

--- a/src/geometry/manifold/times_cont_mdiff_map.lean
+++ b/src/geometry/manifold/times_cont_mdiff_map.lean
@@ -85,8 +85,6 @@ def const (y : M') : C^n⟮I, M; I', M'⟯ := ⟨λ x, y, times_cont_mdiff_const
 
 end times_cont_mdiff_map
 
-open_locale manifold
-
 instance continuous_linear_map.has_coe_to_times_cont_mdiff_map :
   has_coe (E →L[𝕜] E') C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, E'), E'⟯ :=
 ⟨λ f, ⟨f.to_fun, f.times_cont_mdiff⟩⟩


### PR DESCRIPTION
Simp takes an enormous amount of time in manifold code looking for subsingleton instances (and in fact probably in the whole library, but manifolds are particularly simp-heavy). We disable two such instances in the `manifold` locale, to get serious speedups (for instance, `times_cont_mdiff_on.times_cont_mdiff_on_tangent_map_within` goes down from 27s to 10s on my computer).

This is *not* a proper fix. But it already makes a serious difference in this part of the library..

Zulip discussion at https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.235672.20breaks.20timeout/near/223001979