### PR TITLE
[Merged by Bors] - refactor(analysis/calculus/deriv): simpler proof of `differentiable_at.div_const`

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -1413,7 +1413,7 @@ by simp [div_eq_inv_mul, differentiable_within_at.const_mul, hc]
 
 @[simp] lemma differentiable_at.div_const (hc : differentiable_at 𝕜 c x) {d : 𝕜} :
   differentiable_at 𝕜 (λ x, c x / d) x :=
-by simp [div_eq_inv_mul, hc]
+(hc.has_deriv_at.mul_const d⁻¹).differentiable_at
 
 lemma differentiable_on.div_const (hc : differentiable_on 𝕜 c s) {d : 𝕜} :
   differentiable_on 𝕜 (λx, c x / d) s :=


### PR DESCRIPTION
Co-authors: `lean-gptf`, Yuhuai Wu
