### PR TITLE
[Merged by Bors] - feat(algebra/lie/basic): generalise the definition of `lie_algebra.derived_series`

### DIFF
--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -543,13 +543,13 @@ set_option old_structure_cmd true
 /-- A Lie subalgebra of a Lie algebra is submodule that is closed under the Lie bracket.
 This is a sufficient condition for the subset itself to form a Lie algebra. -/
 structure lie_subalgebra extends submodule R L :=
-(lie_mem : ∀ {x y}, x ∈ carrier → y ∈ carrier → ⁅x, y⁆ ∈ carrier)
+(lie_mem' : ∀ {x y}, x ∈ carrier → y ∈ carrier → ⁅x, y⁆ ∈ carrier)
 
 attribute [nolint doc_blame] lie_subalgebra.to_submodule
 
 /-- The zero algebra is a subalgebra of any Lie algebra. -/
 instance : has_zero (lie_subalgebra R L) :=
-⟨{ lie_mem := λ x y hx hy, by { rw [((submodule.mem_bot R).1 hx), zero_lie],
+⟨{ lie_mem' := λ x y hx hy, by { rw [((submodule.mem_bot R).1 hx), zero_lie],
                                 exact submodule.zero_mem (0 : submodule R L), },
    ..(0 : submodule R L) }⟩
 
@@ -562,7 +562,7 @@ instance lie_subalgebra_coe_submodule : has_coe (lie_subalgebra R L) (submodule 
 
 /-- A Lie subalgebra forms a new Lie ring. -/
 instance lie_subalgebra_lie_ring (L' : lie_subalgebra R L) : lie_ring L' :=
-{ bracket      := λ x y, ⟨⁅x.val, y.val⁆, L'.lie_mem x.property y.property⟩,
+{ bracket      := λ x y, ⟨⁅x.val, y.val⁆, L'.lie_mem' x.property y.property⟩,
   lie_add      := by { intros, apply set_coe.ext, apply lie_add, },
   add_lie      := by { intros, apply set_coe.ext, apply add_lie, },
   lie_self     := by { intros, apply set_coe.ext, apply lie_self, },
@@ -618,7 +618,7 @@ end lie_subalgebra
 /-- A subalgebra of an associative algebra is a Lie subalgebra of the associated Lie algebra. -/
 def lie_subalgebra_of_subalgebra (A : Type v) [ring A] [algebra R A]
   (A' : subalgebra R A) : lie_subalgebra R A :=
-{ lie_mem := λ x y hx hy, by {
+{ lie_mem' := λ x y hx hy, by {
     change ⁅x, y⁆ ∈ A', change x ∈ A' at hx, change y ∈ A' at hy,
     rw lie_ring.of_associative_ring_bracket,
     have hxy := A'.mul_mem hx hy,
@@ -636,7 +636,7 @@ def lie_subalgebra.incl (L' : lie_subalgebra R L) : L' →ₗ⁅R⁆ L :=
 
 /-- The range of a morphism of Lie algebras is a Lie subalgebra. -/
 def lie_algebra.morphism.range : lie_subalgebra R L₂ :=
-{ lie_mem := λ x y,
+{ lie_mem' := λ x y,
     show x ∈ f.to_linear_map.range → y ∈ f.to_linear_map.range → ⁅x, y⁆ ∈ f.to_linear_map.range,
     by { repeat { rw linear_map.mem_range }, rintros ⟨x', hx⟩ ⟨y', hy⟩, refine ⟨⁅x', y'⁆, _⟩,
          rw [←hx, ←hy], change f ⁅x', y'⁆ = ⁅f x', f y'⁆, rw lie_algebra.map_lie, },
@@ -654,11 +654,11 @@ by { rw ← lie_subalgebra.coe_to_submodule_eq, exact (L' : submodule R L).range
 /-- The image of a Lie subalgebra under a Lie algebra morphism is a Lie subalgebra of the
 codomain. -/
 def lie_subalgebra.map (L' : lie_subalgebra R L) : lie_subalgebra R L₂ :=
-{ lie_mem := λ x y hx hy, by {
+{ lie_mem' := λ x y hx hy, by {
     erw submodule.mem_map at hx, rcases hx with ⟨x', hx', hx⟩, rw ←hx,
     erw submodule.mem_map at hy, rcases hy with ⟨y', hy', hy⟩, rw ←hy,
     erw submodule.mem_map,
-    exact ⟨⁅x', y'⁆, L'.lie_mem hx' hy', lie_algebra.map_lie f x' y'⟩, },
+    exact ⟨⁅x', y'⁆, L'.lie_mem' hx' hy', lie_algebra.map_lie f x' y'⟩, },
 ..((L' : submodule R L).map (f : L →ₗ[R] L₂))}
 
 @[simp] lemma lie_subalgebra.mem_map_submodule (e : L ≃ₗ⁅R⁆ L₂) (L' : lie_subalgebra R L) (x : L₂) :
@@ -805,7 +805,7 @@ lemma lie_mem_left (I : lie_ideal R L) (x y : L) (h : x ∈ I) : ⁅x, y⁆ ∈ 
 
 /-- An ideal of a Lie algebra is a Lie subalgebra. -/
 def lie_ideal_subalgebra (I : lie_ideal R L) : lie_subalgebra R L :=
-{ lie_mem := by { intros x y hx hy, apply lie_mem_right, exact hy, },
+{ lie_mem' := by { intros x y hx hy, apply lie_mem_right, exact hy, },
   ..I.to_submodule, }
 
 instance : has_coe (lie_ideal R L) (lie_subalgebra R L) := ⟨λ I, lie_ideal_subalgebra R L I⟩

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -574,11 +574,11 @@ instance lie_subalgebra_lie_algebra (L' : lie_subalgebra R L) : lie_algebra R L'
 
 namespace lie_subalgebra
 
-variables {R L} {L' : lie_subalgebra R L}
+variables {R L} (L' : lie_subalgebra R L)
 
 @[simp] lemma zero_mem : (0 : L) ∈ L' := (L' : submodule R L).zero_mem
 
-lemma smul_mem {t : R} {x : L} (h : x ∈ L') : t • x ∈ L' := (L' : submodule R L).smul_mem t h
+lemma smul_mem (t : R) {x : L} (h : x ∈ L') : t • x ∈ L' := (L' : submodule R L).smul_mem t h
 
 lemma add_mem {x y : L} (hx : x ∈ L') (hy : y ∈ L') : (x + y : L) ∈ L' :=
 (L' : submodule R L).add_mem hx hy
@@ -660,7 +660,7 @@ def lie_subalgebra.map (L' : lie_subalgebra R L) : lie_subalgebra R L₂ :=
     erw submodule.mem_map at hx, rcases hx with ⟨x', hx', hx⟩, rw ←hx,
     erw submodule.mem_map at hy, rcases hy with ⟨y', hy', hy⟩, rw ←hy,
     erw submodule.mem_map,
-    exact ⟨⁅x', y'⁆, L'.lie_mem' hx' hy', lie_algebra.map_lie f x' y'⟩, },
+    exact ⟨⁅x', y'⁆, L'.lie_mem hx' hy', lie_algebra.map_lie f x' y'⟩, },
 ..((L' : submodule R L).map (f : L →ₗ[R] L₂))}
 
 @[simp] lemma lie_subalgebra.mem_map_submodule (e : L ≃ₗ⁅R⁆ L₂) (L' : lie_subalgebra R L) (x : L₂) :

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -583,6 +583,8 @@ lemma smul_mem {t : R} {x : L} (h : x ∈ L') : t • x ∈ L' := (L' : submodul
 lemma add_mem {x y : L} (hx : x ∈ L') (hy : y ∈ L') : (x + y : L) ∈ L' :=
 (L' : submodule R L).add_mem hx hy
 
+lemma lie_mem {x y : L} (hx : x ∈ L') (hy : y ∈ L') : (⁅x, y⁆ : L) ∈ L' := L'.lie_mem' hx hy
+
 @[simp] lemma mem_coe {x : L} : x ∈ (L' : set L) ↔ x ∈ L' := iff.rfl
 
 @[simp] lemma mem_coe' {x : L} : x ∈ (L' : submodule R L) ↔ x ∈ L' := iff.rfl

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -1250,7 +1250,7 @@ def derived_series_of_ideal : ℕ → lie_ideal R L
 /-- The derived series of Lie ideals of a Lie algebra. -/
 abbreviation derived_series : ℕ → lie_ideal R L := derived_series_of_ideal R L ⊤
 
-@[simp] lemma derived_series_def (k : ℕ) :
+lemma derived_series_def (k : ℕ) :
   derived_series R L k = derived_series_of_ideal R L ⊤ k := rfl
 
 variables {R L}
@@ -1582,7 +1582,7 @@ lemma derived_series_eq_derived_series_of_ideal_comap (k : ℕ) :
   derived_series R I k = (derived_series_of_ideal R L I k).comap I.incl :=
 begin
   induction k with k ih,
-  { simp, },
+  { simp only [derived_series_def, comap_incl_self, derived_series_of_ideal_zero], },
   { simp only [derived_series_def, derived_series_of_ideal_succ] at ⊢ ih, rw ih,
     exact comap_bracket_incl_of_le I
       (derived_series_of_ideal_le I k) (derived_series_of_ideal_le I k), },

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -574,18 +574,20 @@ instance lie_subalgebra_lie_algebra (L' : lie_subalgebra R L) : lie_algebra R L'
 
 namespace lie_subalgebra
 
-variables {R L}
+variables {R L} {L' : lie_subalgebra R L}
 
-@[simp] lemma zero_mem {L' : lie_subalgebra R L} : (0 : L) ∈ L' := (L' : submodule R L).zero_mem
+@[simp] lemma zero_mem : (0 : L) ∈ L' := (L' : submodule R L).zero_mem
 
-@[simp] lemma mem_coe {L' : lie_subalgebra R L} {x : L} :
-  x ∈ (L' : set L) ↔ x ∈ L' := iff.rfl
+lemma smul_mem {t : R} {x : L} (h : x ∈ L') : t • x ∈ L' := (L' : submodule R L).smul_mem t h
 
-@[simp] lemma mem_coe' {L' : lie_subalgebra R L} {x : L} :
-  x ∈ (L' : submodule R L) ↔ x ∈ L' := iff.rfl
+lemma add_mem {x y : L} (hx : x ∈ L') (hy : y ∈ L') : (x + y : L) ∈ L' :=
+(L' : submodule R L).add_mem hx hy
 
-@[simp, norm_cast] lemma coe_bracket (L' : lie_subalgebra R L) (x y : L') :
-  (↑⁅x, y⁆ : L) = ⁅(↑x : L), ↑y⁆ := rfl
+@[simp] lemma mem_coe {x : L} : x ∈ (L' : set L) ↔ x ∈ L' := iff.rfl
+
+@[simp] lemma mem_coe' {x : L} : x ∈ (L' : submodule R L) ↔ x ∈ L' := iff.rfl
+
+@[simp, norm_cast] lemma coe_bracket (x y : L') : (↑⁅x, y⁆ : L) = ⁅(↑x : L), ↑y⁆ := rfl
 
 @[ext] lemma ext (L₁' L₂' : lie_subalgebra R L) (h : ∀ x, x ∈ L₁' ↔ x ∈ L₂') :
   L₁' = L₂' :=

--- a/src/algebra/lie/classical.lean
+++ b/src/algebra/lie/classical.lean
@@ -81,7 +81,7 @@ namespace special_linear
 
 /-- The special linear Lie algebra: square matrices of trace zero. -/
 def sl : lie_subalgebra R (matrix n n R) :=
-{ lie_mem := λ X Y _ _, linear_map.mem_ker.2 $ matrix_trace_commutator_zero _ _ _ _,
+{ lie_mem' := λ X Y _ _, linear_map.mem_ker.2 $ matrix_trace_commutator_zero _ _ _ _,
   ..linear_map.ker (matrix.trace n R R) }
 
 lemma sl_bracket (A B : sl n R) : ⁅A, B⁆.val = A.val ⬝ B.val - B.val ⬝ A.val := rfl

--- a/src/algebra/lie/skew_adjoint.lean
+++ b/src/algebra/lie/skew_adjoint.lean
@@ -36,7 +36,7 @@ end
 /-- Given an `R`-module `M`, equipped with a bilinear form, the skew-adjoint endomorphisms form a
 Lie subalgebra of the Lie algebra of endomorphisms. -/
 def skew_adjoint_lie_subalgebra : lie_subalgebra R (module.End R M) :=
-{ lie_mem := B.is_skew_adjoint_bracket, ..B.skew_adjoint_submodule }
+{ lie_mem' := B.is_skew_adjoint_bracket, ..B.skew_adjoint_submodule }
 
 variables {N : Type w} [add_comm_group N] [module R N] (e : N ≃ₗ[R] M)
 
@@ -87,7 +87,7 @@ end
 
 /-- The Lie subalgebra of skew-adjoint square matrices corresponding to a square matrix `J`. -/
 def skew_adjoint_matrices_lie_subalgebra : lie_subalgebra R (matrix n n R) :=
-{ lie_mem := J.is_skew_adjoint_bracket, ..(skew_adjoint_matrices_submodule J) }
+{ lie_mem' := J.is_skew_adjoint_bracket, ..(skew_adjoint_matrices_submodule J) }
 
 @[simp] lemma mem_skew_adjoint_matrices_lie_subalgebra (A : matrix n n R) :
   A ∈ skew_adjoint_matrices_lie_subalgebra J ↔ A ∈ skew_adjoint_matrices_submodule J :=


### PR DESCRIPTION
This generalisation will make it easier to relate properties of the derived
series of a Lie algebra and the derived series of its ideals (regarded as Lie
algebras in their own right).

The key definition is `lie_algebra.derived_series_of_ideal` and the key result is `lie_ideal.derived_series_eq_bot_iff`.
