### PR TITLE
[Merged by Bors] - refactor(algebraic_geometry/prime_spectrum): simplify `comap_id`, `comap_comp`

### DIFF
--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -353,7 +353,7 @@ funext $ λ x, ext.mpr $ by { rw [comap_as_ideal], apply ideal.ext, intros r, si
 
 @[simp] lemma comap_comp (f : R →+* S) (g : S →+* S') :
   comap (g.comp f) = comap f ∘ comap g :=
-funext $ λ x, ext.mpr $ by { simp, refl }
+funext $ λ _, subtype.ext $ ideal.ext $ λ _, iff.rfl
 
 @[simp] lemma preimage_comap_zero_locus (s : set R) :
   (comap f) ⁻¹' (zero_locus s) = zero_locus (f '' s) :=

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -349,7 +349,7 @@ variables (f : R →+* S)
 rfl
 
 @[simp] lemma comap_id : comap (ring_hom.id R) = id :=
-funext $ λ x, ext.mpr $ by { rw [comap_as_ideal], apply ideal.ext, intros r, simp }
+funext $ λ _, subtype.ext $ ideal.ext $ λ _, iff.rfl
 
 @[simp] lemma comap_comp (f : R →+* S) (g : S →+* S') :
   comap (g.comp f) = comap f ∘ comap g :=


### PR DESCRIPTION
faster proofs and smaller proof terms

Co-authors: `lean-gptf`, Yuhuai Wu