### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal/operations): generalize quotient of algebras

### DIFF
--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -7,6 +7,7 @@ import data.nat.choose.sum
 import data.equiv.ring
 import algebra.algebra.operations
 import ring_theory.ideal.basic
+import algebra.algebra.tower
 /-!
 # More operations on modules and ideals
 -/
@@ -1149,6 +1150,16 @@ instance {I : ideal A} : algebra R (ideal.quotient I) :=
 `A`, where `A` is an `R`-algebra. -/
 def quotient.mkₐ (I : ideal A) : A →ₐ[R] I.quotient :=
 ⟨λ a, submodule.quotient.mk a, rfl, λ _ _, rfl, rfl, λ _ _, rfl, λ _, rfl⟩
+
+lemma quotient.alg_map (I : ideal A) : algebra_map R I.quotient =
+  (algebra_map A I.quotient).comp (algebra_map R A) :=
+begin
+  repeat {rw [ring_hom.algebra_map_to_algebra]},
+  rw [ring_hom.comp_id]
+end
+
+instance {I : ideal A} : is_scalar_tower R A (ideal.quotient I) :=
+is_scalar_tower.of_algebra_map_eq' (quotient.alg_map R I)
 
 lemma quotient.mkₐ_to_ring_hom (I : ideal A) :
   (quotient.mkₐ R I).to_ring_hom = ideal.quotient.mk I := rfl

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1151,8 +1151,8 @@ instance {I : ideal A} : algebra R (ideal.quotient I) :=
 def quotient.mkₐ (I : ideal A) : A →ₐ[R] I.quotient :=
 ⟨λ a, submodule.quotient.mk a, rfl, λ _ _, rfl, rfl, λ _ _, rfl, λ _, rfl⟩
 
-lemma quotient.alg_map (I : ideal A) : algebra_map R I.quotient =
-  (algebra_map A I.quotient).comp (algebra_map R A) :=
+lemma quotient.alg_map (I : ideal A) :
+  algebra_map R I.quotient = (algebra_map A I.quotient).comp (algebra_map R A) :=
 by simp only [ring_hom.algebra_map_to_algebra, ring_hom.comp_id]
 
 instance {I : ideal A} : is_scalar_tower R A (ideal.quotient I) :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1151,12 +1151,12 @@ instance {I : ideal A} : algebra R (ideal.quotient I) :=
 def quotient.mkₐ (I : ideal A) : A →ₐ[R] I.quotient :=
 ⟨λ a, submodule.quotient.mk a, rfl, λ _ _, rfl, rfl, λ _ _, rfl, λ _, rfl⟩
 
-lemma quotient.alg_map (I : ideal A) :
+lemma quotient.alg_map_eq (I : ideal A) :
   algebra_map R I.quotient = (algebra_map A I.quotient).comp (algebra_map R A) :=
 by simp only [ring_hom.algebra_map_to_algebra, ring_hom.comp_id]
 
 instance {I : ideal A} : is_scalar_tower R A (ideal.quotient I) :=
-is_scalar_tower.of_algebra_map_eq' (quotient.alg_map R I)
+is_scalar_tower.of_algebra_map_eq' (quotient.alg_map_eq R I)
 
 lemma quotient.mkₐ_to_ring_hom (I : ideal A) :
   (quotient.mkₐ R I).to_ring_hom = ideal.quotient.mk I := rfl

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1153,10 +1153,7 @@ def quotient.mkₐ (I : ideal A) : A →ₐ[R] I.quotient :=
 
 lemma quotient.alg_map (I : ideal A) : algebra_map R I.quotient =
   (algebra_map A I.quotient).comp (algebra_map R A) :=
-begin
-  repeat {rw [ring_hom.algebra_map_to_algebra]},
-  rw [ring_hom.comp_id]
-end
+by simp only [ring_hom.algebra_map_to_algebra, ring_hom.comp_id]
 
 instance {I : ideal A} : is_scalar_tower R A (ideal.quotient I) :=
 is_scalar_tower.of_algebra_map_eq' (quotient.alg_map R I)

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1139,28 +1139,33 @@ end
 
 section quotient_algebra
 
-/-- The `R`-algebra structure on `R/I` -/
-instance {I : ideal R} : algebra R (ideal.quotient I) := (ideal.quotient.mk I).to_algebra
+variables (R) {A : Type*} [comm_ring A] [algebra R A]
 
-/-- The canonical morphism `R →ₐ[R] I.quotient`, for `I` an ideal of `R`, as morphism of
-`R`-algebras. -/
-def quotient.mkₐ (I : ideal R) : R →ₐ[R] I.quotient :=
+/-- The `R`-algebra structure on `A/I` for an `R`-algebra `A` -/
+instance {I : ideal A} : algebra R (ideal.quotient I) :=
+(ring_hom.comp (ideal.quotient.mk I) (algebra_map R A)).to_algebra
+
+/-- The canonical morphism `A →ₐ[R] I.quotient` as morphism of `R`-algebras, for `I` an ideal of
+`A`, where `A` is an `R`-algebra. -/
+def quotient.mkₐ (I : ideal A) : A →ₐ[R] I.quotient :=
 ⟨λ a, submodule.quotient.mk a, rfl, λ _ _, rfl, rfl, λ _ _, rfl, λ _, rfl⟩
 
-lemma quotient.mkₐ_to_ring_hom (I : ideal R) :
-  (quotient.mkₐ I).to_ring_hom = ideal.quotient.mk I := rfl
+lemma quotient.mkₐ_to_ring_hom (I : ideal A) :
+  (quotient.mkₐ R I).to_ring_hom = ideal.quotient.mk I := rfl
 
-@[simp] lemma quotient.mkₐ_eq_mk (I : ideal R) :
-  ⇑(quotient.mkₐ I) = ideal.quotient.mk I := rfl
+@[simp] lemma quotient.mkₐ_eq_mk (I : ideal A) :
+  ⇑(quotient.mkₐ R I) = ideal.quotient.mk I := rfl
 
-/-- The canonical morphism `R →ₐ[R] I.quotient` is surjective. -/
-lemma quotient.mkₐ_surjective (I : ideal R) : function.surjective (quotient.mkₐ I) :=
+/-- The canonical morphism `A →ₐ[R] I.quotient` is surjective. -/
+lemma quotient.mkₐ_surjective (I : ideal A) : function.surjective (quotient.mkₐ R I) :=
 surjective_quot_mk _
 
-/-- The kernel of `R →ₐ[R] I.quotient` is `I`. -/
+/-- The kernel of `A →ₐ[R] I.quotient` is `I`. -/
 @[simp]
-lemma quotient.mkₐ_ker (I : ideal R) : (quotient.mkₐ I).to_ring_hom.ker = I :=
+lemma quotient.mkₐ_ker (I : ideal A) : (quotient.mkₐ R I).to_ring_hom.ker = I :=
 ideal.mk_ker
+
+variable {R}
 
 /-- The ring hom `R/J →+* S/I` induced by a ring hom `f : R →+* S` with `J ≤ f⁻¹(I)` -/
 def quotient_map {I : ideal R} (J : ideal S) (f : R →+* S) (hIJ : I ≤ J.comap f) :


### PR DESCRIPTION
I generalize #5703 (that was merged earlier today... sorry for that, I should have thought more carefully about it) to be able to work with `S/I` as an `R`-algebra, where `S` is an `R`-algebra.  (In #5703 only `R/I` was considered.) The proofs are the same.
