### PR TITLE
[Merged by Bors] - feat(measure_theory/lp_space): extend the definition of Lp seminorm to p ennreal

### DIFF
--- a/src/measure_theory/ess_sup.lean
+++ b/src/measure_theory/ess_sup.lean
@@ -105,19 +105,19 @@ lemma ae_lt_of_lt_ess_inf {f : α → β} {x : β} (hf : x < ess_inf f μ) : ∀
 
 end complete_linear_order
 
-section ennreal
+namespace ennreal
 
-lemma ennreal.ae_le_ess_sup (f : α → ennreal) : ∀ᵐ y ∂μ, f y ≤ ess_sup f μ :=
-ennreal.eventually_le_limsup f
+lemma ae_le_ess_sup (f : α → ennreal) : ∀ᵐ y ∂μ, f y ≤ ess_sup f μ :=
+eventually_le_limsup f
 
 lemma ess_sup_eq_zero_iff {f : α → ennreal} : ess_sup f μ = 0 ↔ f =ᵐ[μ] 0 :=
-ennreal.limsup_eq_zero_iff
+limsup_eq_zero_iff
 
-lemma ennreal.ess_sup_const_mul {f : α → ennreal} {a : ennreal} :
+lemma ess_sup_const_mul {f : α → ennreal} {a : ennreal} :
   ess_sup (λ (x : α), a * (f x)) μ = a * ess_sup f μ :=
-ennreal.limsup_const_mul
+limsup_const_mul
 
-lemma ennreal.ess_sup_add_le (f g : α → ennreal) : ess_sup (f + g) μ ≤ ess_sup f μ + ess_sup g μ :=
-ennreal.limsup_add_le f g
+lemma ess_sup_add_le (f g : α → ennreal) : ess_sup (f + g) μ ≤ ess_sup f μ + ess_sup g μ :=
+limsup_add_le f g
 
 end ennreal

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -49,19 +49,13 @@ def snorm_inf (f : α → F) (μ : measure α) := ess_sup (λ x, (nnnorm (f x) :
 /-- `ℒp` seminorm, equal to `0` for `p=0`, to `(∫ ∥f a∥^p ∂μ) ^ (1/p)` for `0 < p < ∞` and to
 `ess_sup ∥f∥ μ` for `p = ∞`. -/
 def snorm (f : α → F) (q : ennreal) (μ : measure α) : ennreal :=
-begin
-  by_cases h0 : q = 0,
-  { exact 0, },
-  by_cases h_top : q = ⊤,
-  { exact snorm_inf f μ, },
-  exact snorm' f (ennreal.to_real q) μ,
-end
+if q = 0 then 0 else (if q = ⊤ then snorm_inf f μ else snorm' f (ennreal.to_real q) μ)
 
 lemma snorm_eq_snorm' (hq_ne_zero : q ≠ 0) (hq_ne_top : q ≠ ⊤) {f : α → F} :
   snorm f q μ = snorm' f (ennreal.to_real q) μ :=
 by simp [snorm, hq_ne_zero, hq_ne_top]
 
-lemma snorm_eq_snorm_inf {f : α → F} : snorm f ⊤ μ = snorm_inf f μ :=
+@[simp] lemma snorm_exponent_top {f : α → F} : snorm f ⊤ μ = snorm_inf f μ :=
 by simp [snorm]
 
 /-- The property that `f:α→E` is ae_measurable and `(∫ ∥f a∥^p ∂μ)^(1/p)` is finite -/
@@ -130,7 +124,7 @@ begin
   by_cases h0 : q = 0,
   { simp [h0], },
   by_cases h_top : q = ⊤,
-  { simp only [h_top, snorm_eq_snorm_inf, snorm_inf_zero], },
+  { simp only [h_top, snorm_exponent_top, snorm_inf_zero], },
   rw ←ne.def at h0,
   simp [snorm_eq_snorm' h0 h_top,
     ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩],
@@ -159,7 +153,7 @@ begin
   by_cases h0 : q = 0,
   { simp [h0], },
   by_cases h_top : q = ⊤,
-  { simp [h_top, snorm_eq_snorm_inf], },
+  { simp [h_top], },
   rw ←ne.def at h0,
   simp [snorm_eq_snorm' h0 h_top, snorm',
     ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩],
@@ -205,7 +199,7 @@ lemma snorm_const (c : F) (h0 : q ≠ 0) (hμ : μ ≠ 0) :
   snorm (λ x : α , c) q μ = (nnnorm c : ennreal) * (μ set.univ) ^ (1/(ennreal.to_real q)) :=
 begin
   by_cases h_top : q = ⊤,
-  { simp [h_top, snorm_eq_snorm_inf, snorm_inf_const c hμ], },
+  { simp [h_top, snorm_inf_const c hμ], },
   simp [snorm_eq_snorm' h0 h_top, snorm'_const,
     ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩],
 end
@@ -250,7 +244,7 @@ begin
   by_cases h0 : q = 0,
   { simp [h0], },
   by_cases h_top : q = ⊤,
-  { rw [h_top, snorm_eq_snorm_inf],
+  { rw [h_top, snorm_exponent_top],
     exact snorm_inf_congr_ae hfg, },
   repeat { rw snorm_eq_snorm' h0 h_top, },
   exact snorm'_congr_ae hfg,
@@ -319,7 +313,7 @@ lemma snorm_eq_zero_iff {f : α → E} (hf : ae_measurable f μ) (h0 : q ≠ 0) 
   snorm f q μ = 0 ↔ f =ᵐ[μ] 0 :=
 begin
   by_cases h_top : q = ⊤,
-  { rw [h_top, snorm_eq_snorm_inf, snorm_inf_eq_zero_iff], },
+  { rw [h_top, snorm_exponent_top, snorm_inf_eq_zero_iff], },
   rw snorm_eq_snorm' h0 h_top,
   exact snorm'_eq_zero_iff
     (ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩) hf,
@@ -334,7 +328,7 @@ begin
   by_cases h0 : q = 0,
   { simp [h0], },
   by_cases h_top : q = ⊤,
-  { simp [h_top, snorm_eq_snorm_inf, snorm_inf], },
+  { simp [h_top, snorm_inf], },
   simp [snorm_eq_snorm' h0 h_top],
 end
 
@@ -374,12 +368,11 @@ end
 lemma snorm'_le_snorm_inf_mul_rpow_measure_univ (hp_pos : 0 < p) {f : α → F} :
   snorm' f p μ ≤ snorm_inf f μ * (μ set.univ) ^ (1/p) :=
 begin
-  rw snorm',
   have h_le : ∫⁻ (a : α), ↑(nnnorm (f a)) ^ p ∂μ ≤ ∫⁻ (a : α), (snorm_inf f μ) ^ p ∂μ,
   { refine lintegral_mono_ae _,
     have h_nnnorm_le_snorm_inf := coe_nnnorm_ae_le_snorm_inf f μ,
     refine h_nnnorm_le_snorm_inf.mono (λ x hx, ennreal.rpow_le_rpow hx (le_of_lt hp_pos)), },
-  rw ←ennreal.rpow_one (snorm_inf f μ),
+  rw [snorm', ←ennreal.rpow_one (snorm_inf f μ)],
   nth_rewrite 1 ←mul_inv_cancel (ne_of_lt hp_pos).symm,
   rw [ennreal.rpow_mul, one_div,
     ←@ennreal.mul_rpow_of_nonneg _ _ p⁻¹ (by simp [le_of_lt hp_pos])],
@@ -415,7 +408,7 @@ begin
       exact le_refl _, },
     { have hp_pos : 0 < p.to_real,
       from ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) hp0.symm, hp_top⟩,
-      rw [snorm_eq_snorm' hp0 hp_top, hq_top, snorm_eq_snorm_inf],
+      rw [snorm_eq_snorm' hp0 hp_top, hq_top, snorm_exponent_top],
       refine le_trans (snorm'_le_snorm_inf_mul_rpow_measure_univ hp_pos) (le_of_eq _),
       simp [measure_univ], }, },
   { have hp_top : p ≠ ⊤,
@@ -437,9 +430,12 @@ begin
 end
 
 lemma snorm'_lt_top_of_snorm'_lt_top_of_exponent_le {p q : ℝ} [finite_measure μ] {f : α → E}
-  (hf : ae_measurable f μ) (hfq_lt_top : snorm' f q μ < ⊤) (hp_pos : 0 < p) (hpq : p ≤ q) :
+  (hf : ae_measurable f μ) (hfq_lt_top : snorm' f q μ < ⊤) (hp_nonneg : 0 ≤ p) (hpq : p ≤ q) :
   snorm' f p μ < ⊤ :=
 begin
+  cases le_or_lt p 0 with hp_nonpos hp_pos,
+  { rw le_antisymm hp_nonpos hp_nonneg,
+    simp, },
   have hq_pos : 0 < q, from lt_of_lt_of_le hp_pos hpq,
   calc snorm' f p μ
       ≤ snorm' f q μ * (μ set.univ) ^ (1/p - 1/q) :
@@ -470,7 +466,7 @@ begin
     from ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) hp0.symm, hp_top⟩,
   by_cases hq_top : q = ⊤,
   { rw snorm_eq_snorm' hp0 hp_top,
-    rw [hq_top, snorm_eq_snorm_inf] at hfq_lt_top,
+    rw [hq_top, snorm_exponent_top] at hfq_lt_top,
     refine lt_of_le_of_lt (snorm'_le_snorm_inf_mul_rpow_measure_univ hp_pos) _,
     refine ennreal.mul_lt_top hfq_lt_top _,
     exact ennreal.rpow_lt_top_of_nonneg (by simp [le_of_lt hp_pos]) (measure_ne_top μ set.univ), },
@@ -483,7 +479,7 @@ begin
   have hpq_real : p.to_real ≤ q.to_real, by rwa ennreal.to_real_le_to_real hp_top hq_top,
   rw snorm_eq_snorm' hp0 hp_top,
   rw snorm_eq_snorm' hq0 hq_top at hfq_lt_top,
-  exact snorm'_lt_top_of_snorm'_lt_top_of_exponent_le hfq_m hfq_lt_top hp_pos hpq_real,
+  exact snorm'_lt_top_of_snorm'_lt_top_of_exponent_le hfq_m hfq_lt_top (le_of_lt hp_pos) hpq_real,
 end
 
 lemma mem_ℒp.integrable (hq1 : 1 ≤ q) {f : α → E} [finite_measure μ] (hfq : mem_ℒp f q μ) :
@@ -518,7 +514,7 @@ begin
   by_cases hq0 : q = 0,
   { simp [hq0], },
   by_cases hq_top : q = ⊤,
-  { simp [hq_top, snorm_eq_snorm_inf, snorm_inf_add_le], },
+  { simp [hq_top, snorm_inf_add_le], },
   have hq1_real : 1 ≤ q.to_real,
   by rwa [←ennreal.one_to_real, ennreal.to_real_le_to_real ennreal.one_ne_top hq_top],
   repeat { rw snorm_eq_snorm' hq0 hq_top, },
@@ -546,10 +542,9 @@ end borel_space
 
 section normed_space
 
-variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E] [opens_measurable_space E]
-  [normed_space 𝕜 F]
+variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E] [normed_space 𝕜 F]
 
-lemma snorm'_const_smul {f : α → E} (hf : ae_measurable f μ) (c : 𝕜) (hp0_lt : 0 < p) :
+lemma snorm'_const_smul {f : α → F} (c : 𝕜) (hp0_lt : 0 < p) :
   snorm' (c • f) p μ = (nnnorm c : ennreal) * snorm' f p μ :=
 begin
   rw snorm',
@@ -562,32 +557,35 @@ begin
     congr,
     simp_rw [←ennreal.rpow_mul, one_div, mul_inv_cancel (ne_of_lt hp0_lt).symm,
       ennreal.rpow_one], },
-  rw lintegral_const_mul'' _ hf.nnnorm.ennreal_coe.ennreal_rpow_const,
+  rw lintegral_const_mul',
+  rw ennreal.coe_rpow_of_nonneg _ (le_of_lt hp0_lt),
+  exact ennreal.coe_ne_top,
 end
 
 lemma snorm_inf_const_smul {f : α → F} (c : 𝕜) :
   snorm_inf (c • f) μ = (nnnorm c : ennreal) * snorm_inf f μ :=
 by simp_rw [snorm_inf,  pi.smul_apply, nnnorm_smul, ennreal.coe_mul, ennreal.ess_sup_const_mul]
 
-lemma snorm_const_smul {f : α → E} (hf : ae_measurable f μ) (c : 𝕜) :
+lemma snorm_const_smul {f : α → F} (c : 𝕜) :
   snorm (c • f) q μ = (nnnorm c : ennreal) * snorm f q μ :=
 begin
   by_cases h0 : q = 0,
   { simp [h0], },
   by_cases h_top : q = ⊤,
-  { simp [h_top, snorm_eq_snorm_inf, snorm_inf_const_smul], },
+  { simp [h_top, snorm_inf_const_smul], },
   repeat { rw snorm_eq_snorm' h0 h_top, },
   rw ←ne.def at h0,
-  exact snorm'_const_smul hf c
+  exact snorm'_const_smul c
     (ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩),
 end
 
 lemma mem_ℒp.const_smul [borel_space E] {f : α → E} (hf : mem_ℒp f q μ) (c : 𝕜) :
   mem_ℒp (c • f) q μ :=
 ⟨ae_measurable.const_smul hf.1 c,
-  lt_of_le_of_lt (le_of_eq (snorm_const_smul hf.1 c)) (ennreal.mul_lt_top ennreal.coe_lt_top hf.2)⟩
+  lt_of_le_of_lt (le_of_eq (snorm_const_smul c)) (ennreal.mul_lt_top ennreal.coe_lt_top hf.2)⟩
 
-lemma snorm'_smul_le_mul_snorm' [measurable_space 𝕜] [opens_measurable_space 𝕜] {q r : ℝ}
+lemma snorm'_smul_le_mul_snorm' [opens_measurable_space E] [measurable_space 𝕜]
+  [opens_measurable_space 𝕜] {q r : ℝ}
   {f : α → E} (hf : ae_measurable f μ) {φ : α → 𝕜} (hφ : ae_measurable φ μ)
   (hp0_lt : 0 < p) (hpq : p < q) (hpqr : 1/p = 1/q + 1/r) :
   snorm' (φ • f) p μ ≤ snorm' φ q μ * snorm' f r μ :=

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -56,8 +56,7 @@ lemma snorm_eq_snorm' (hq_ne_zero : q ≠ 0) (hq_ne_top : q ≠ ⊤) {f : α →
   snorm f q μ = snorm' f (ennreal.to_real q) μ :=
 by simp [snorm, hq_ne_zero, hq_ne_top]
 
-@[simp] lemma snorm_exponent_top {f : α → F} : snorm f ⊤ μ = snorm_inf f μ :=
-by simp [snorm]
+@[simp] lemma snorm_exponent_top {f : α → F} : snorm f ⊤ μ = snorm_inf f μ := by simp [snorm]
 
 /-- The property that `f:α→E` is ae_measurable and `(∫ ∥f a∥^p ∂μ)^(1/p)` is finite -/
 def mem_ℒp (f : α → E) (p : ennreal) (μ : measure α) : Prop :=
@@ -132,11 +131,7 @@ begin
 end
 
 lemma zero_mem_ℒp : mem_ℒp (0 : α → E) q μ :=
-begin
-  refine ⟨measurable_zero.ae_measurable, _⟩,
-  rw snorm_zero,
-  exact ennreal.coe_lt_top,
-end
+⟨measurable_zero.ae_measurable, by { rw snorm_zero, exact ennreal.coe_lt_top, } ⟩
 
 lemma snorm'_measure_zero_of_pos {f : α → F} (hp_pos : 0 < p) : snorm' f p 0 = 0 :=
 by simp [snorm', hp_pos]
@@ -146,8 +141,7 @@ lemma snorm'_measure_zero_of_exponent_zero {f : α → F} : snorm' f 0 0 = 1 := 
 lemma snorm'_measure_zero_of_neg {f : α → F} (hp_neg : p < 0) : snorm' f p 0 = ⊤ :=
 by simp [snorm', hp_neg]
 
-@[simp] lemma snorm_inf_measure_zero {f : α → F} : snorm_inf f 0 = 0 :=
-by simp [snorm_inf]
+@[simp] lemma snorm_inf_measure_zero {f : α → F} : snorm_inf f 0 = 0 := by simp [snorm_inf]
 
 @[simp] lemma snorm_measure_zero {f : α → F} : snorm f q 0 = 0 :=
 begin
@@ -227,20 +221,17 @@ end
 
 end const
 
-lemma snorm'_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) :
-  snorm' f p μ = snorm' g p μ :=
+lemma snorm'_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) : snorm' f p μ = snorm' g p μ :=
 begin
   suffices h_no_pow : ∫⁻ a, (nnnorm (f a)) ^ p ∂μ = ∫⁻ a, (nnnorm (g a)) ^ p ∂μ,
   { simp_rw [snorm', h_no_pow], },
   exact lintegral_congr_ae (hfg.mono (λ x hx, by simp [*])),
 end
 
-lemma snorm_inf_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) :
-  snorm_inf f μ = snorm_inf g μ :=
+lemma snorm_inf_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) : snorm_inf f μ = snorm_inf g μ :=
 ess_sup_congr_ae (hfg.mono (λ x hx, by rw hx))
 
-lemma snorm_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) :
-  snorm f q μ = snorm g q μ :=
+lemma snorm_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) : snorm f q μ = snorm g q μ :=
 begin
   by_cases h0 : q = 0,
   { simp [h0], },
@@ -251,8 +242,7 @@ begin
   exact snorm'_congr_ae hfg,
 end
 
-lemma mem_ℒp.ae_eq {f g : α → E} (hfg : f =ᵐ[μ] g) (hf_Lp : mem_ℒp f q μ) :
-  mem_ℒp g q μ :=
+lemma mem_ℒp.ae_eq {f g : α → E} (hfg : f =ᵐ[μ] g) (hf_Lp : mem_ℒp f q μ) : mem_ℒp g q μ :=
 begin
   split,
   { cases hf_Lp.1 with f' hf',
@@ -391,10 +381,7 @@ end
 
 lemma snorm'_le_snorm_inf (hp_pos : 0 < p) {f : α → F} [probability_measure μ] :
   snorm' f p μ ≤ snorm_inf f μ :=
-begin
-  refine le_trans (snorm'_le_snorm_inf_mul_rpow_measure_univ hp_pos) (le_of_eq _),
-  simp [measure_univ],
-end
+le_trans (snorm'_le_snorm_inf_mul_rpow_measure_univ hp_pos) (le_of_eq (by simp [measure_univ]))
 
 lemma snorm_le_snorm_of_exponent_le {p q : ennreal} (hpq : p ≤ q) [probability_measure μ]
   {f : α → E} (hf : ae_measurable f μ) :
@@ -500,8 +487,7 @@ end
 ... ≤ snorm' f p μ + snorm' g p μ :
   ennreal.lintegral_Lp_add_le hf.nnnorm.ennreal_coe hg.nnnorm.ennreal_coe hp1
 
-lemma snorm_inf_add_le {f g : α → F} :
-  snorm_inf (f + g) μ ≤ snorm_inf f μ + snorm_inf g μ :=
+lemma snorm_inf_add_le {f g : α → F} : snorm_inf (f + g) μ ≤ snorm_inf f μ + snorm_inf g μ :=
 begin
   refine le_trans (ess_sup_mono_ae (filter.eventually_of_forall (λ x, _)))
     (ennreal.ess_sup_add_le _ _),

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -18,9 +18,9 @@ defined for `p:ennreal` as `0` if `p=0`, `(∫ ∥f a∥^p ∂μ) ^ (1/p)` for `
 
 * `snorm' f p μ` : `(∫ ∥f a∥^p ∂μ) ^ (1/p)` for `f : α → F` and `p : ℝ`, where `α` is a  measurable
   space and `F` is a normed group.
-* `snorm_inf f μ` : seminorm in `ℒ∞`, equal to the essential supremum `ess_sup ∥f∥ μ`.
+* `snorm_ess_sup f μ` : seminorm in `ℒ∞`, equal to the essential supremum `ess_sup ∥f∥ μ`.
 * `snorm f p μ` : for `p : ennreal`, seminorm in `ℒp`, equal to `0` for `p=0`, to `snorm' f p μ`
-  for `0 < p < ∞` and to `snorm_inf f μ` for `p = ∞`.
+  for `0 < p < ∞` and to `snorm_ess_sup f μ` for `p = ∞`.
 
 * `mem_ℒp f p μ` : property that the function `f` is almost everywhere measurable and has finite
   p-seminorm for measure `μ` (`snorm f p μ < ∞`)
@@ -45,18 +45,18 @@ this quantity is finite -/
 def snorm' (f : α → F) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)
 
 /-- seminorm for `ℒ∞`, equal to the essential supremum of `∥f∥`. -/
-def snorm_inf (f : α → F) (μ : measure α) := ess_sup (λ x, (nnnorm (f x) : ennreal)) μ
+def snorm_ess_sup (f : α → F) (μ : measure α) := ess_sup (λ x, (nnnorm (f x) : ennreal)) μ
 
 /-- `ℒp` seminorm, equal to `0` for `p=0`, to `(∫ ∥f a∥^p ∂μ) ^ (1/p)` for `0 < p < ∞` and to
 `ess_sup ∥f∥ μ` for `p = ∞`. -/
 def snorm (f : α → F) (q : ennreal) (μ : measure α) : ennreal :=
-if q = 0 then 0 else (if q = ⊤ then snorm_inf f μ else snorm' f (ennreal.to_real q) μ)
+if q = 0 then 0 else (if q = ⊤ then snorm_ess_sup f μ else snorm' f (ennreal.to_real q) μ)
 
 lemma snorm_eq_snorm' (hq_ne_zero : q ≠ 0) (hq_ne_top : q ≠ ⊤) {f : α → F} :
   snorm f q μ = snorm' f (ennreal.to_real q) μ :=
 by simp [snorm, hq_ne_zero, hq_ne_top]
 
-@[simp] lemma snorm_exponent_top {f : α → F} : snorm f ⊤ μ = snorm_inf f μ := by simp [snorm]
+@[simp] lemma snorm_exponent_top {f : α → F} : snorm f ⊤ μ = snorm_ess_sup f μ := by simp [snorm]
 
 /-- The property that `f:α→E` is ae_measurable and `(∫ ∥f a∥^p ∂μ)^(1/p)` is finite -/
 def mem_ℒp (f : α → E) (p : ennreal) (μ : measure α) : Prop :=
@@ -113,9 +113,9 @@ begin
   { simp [snorm', ennreal.rpow_eq_zero_iff, hμ, hp_neg], },
 end
 
-@[simp] lemma snorm_inf_zero : snorm_inf (0 : α → F) μ = 0 :=
+@[simp] lemma snorm_ess_sup_zero : snorm_ess_sup (0 : α → F) μ = 0 :=
 begin
-  simp_rw [snorm_inf, pi.zero_apply, nnnorm_zero, ennreal.coe_zero, ←ennreal.bot_eq_zero],
+  simp_rw [snorm_ess_sup, pi.zero_apply, nnnorm_zero, ennreal.coe_zero, ←ennreal.bot_eq_zero],
   exact ess_sup_const_bot,
 end
 
@@ -124,7 +124,7 @@ begin
   by_cases h0 : q = 0,
   { simp [h0], },
   by_cases h_top : q = ⊤,
-  { simp only [h_top, snorm_exponent_top, snorm_inf_zero], },
+  { simp only [h_top, snorm_exponent_top, snorm_ess_sup_zero], },
   rw ←ne.def at h0,
   simp [snorm_eq_snorm' h0 h_top,
     ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩],
@@ -141,7 +141,8 @@ lemma snorm'_measure_zero_of_exponent_zero {f : α → F} : snorm' f 0 0 = 1 := 
 lemma snorm'_measure_zero_of_neg {f : α → F} (hp_neg : p < 0) : snorm' f p 0 = ⊤ :=
 by simp [snorm', hp_neg]
 
-@[simp] lemma snorm_inf_measure_zero {f : α → F} : snorm_inf f 0 = 0 := by simp [snorm_inf]
+@[simp] lemma snorm_ess_sup_measure_zero {f : α → F} : snorm_ess_sup f 0 = 0 :=
+by simp [snorm_ess_sup]
 
 @[simp] lemma snorm_measure_zero {f : α → F} : snorm f q 0 = 0 :=
 begin
@@ -183,8 +184,9 @@ begin
     { exact or.inl ennreal.coe_ne_top, }, },
 end
 
-lemma snorm_inf_const (c : F) (hμ : μ ≠ 0) : snorm_inf (λ x : α, c) μ = (nnnorm c : ennreal) :=
-by rw [snorm_inf, ess_sup_const _ hμ]
+lemma snorm_ess_sup_const (c : F) (hμ : μ ≠ 0) :
+  snorm_ess_sup (λ x : α, c) μ = (nnnorm c : ennreal) :=
+by rw [snorm_ess_sup, ess_sup_const _ hμ]
 
 lemma snorm'_const_of_probability_measure (c : F) (hp_pos : 0 < p) [probability_measure μ] :
   snorm' (λ x : α , c) p μ = (nnnorm c : ennreal) :=
@@ -194,7 +196,7 @@ lemma snorm_const (c : F) (h0 : q ≠ 0) (hμ : μ ≠ 0) :
   snorm (λ x : α , c) q μ = (nnnorm c : ennreal) * (μ set.univ) ^ (1/(ennreal.to_real q)) :=
 begin
   by_cases h_top : q = ⊤,
-  { simp [h_top, snorm_inf_const c hμ], },
+  { simp [h_top, snorm_ess_sup_const c hμ], },
   simp [snorm_eq_snorm' h0 h_top, snorm'_const,
     ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩],
 end
@@ -228,7 +230,8 @@ begin
   exact lintegral_congr_ae (hfg.mono (λ x hx, by simp [*])),
 end
 
-lemma snorm_inf_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) : snorm_inf f μ = snorm_inf g μ :=
+lemma snorm_ess_sup_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) :
+  snorm_ess_sup f μ = snorm_ess_sup g μ :=
 ess_sup_congr_ae (hfg.mono (λ x hx, by rw hx))
 
 lemma snorm_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) : snorm f q μ = snorm g q μ :=
@@ -237,7 +240,7 @@ begin
   { simp [h0], },
   by_cases h_top : q = ⊤,
   { rw [h_top, snorm_exponent_top],
-    exact snorm_inf_congr_ae hfg, },
+    exact snorm_ess_sup_congr_ae hfg, },
   repeat { rw snorm_eq_snorm' h0 h_top, },
   exact snorm'_congr_ae hfg,
 end
@@ -287,13 +290,13 @@ lemma snorm'_eq_zero_iff (hp0_lt : 0 < p) {f : α → E} (hf : ae_measurable f �
   snorm' f p μ = 0 ↔ f =ᵐ[μ] 0 :=
 ⟨ae_eq_zero_of_snorm'_eq_zero (le_of_lt hp0_lt) hf, snorm'_eq_zero_of_ae_zero hp0_lt⟩
 
-lemma coe_nnnorm_ae_le_snorm_inf (f : α → F) (μ : measure α) :
-  ∀ᵐ x ∂μ, (nnnorm (f x) : ennreal) ≤ snorm_inf f μ :=
+lemma coe_nnnorm_ae_le_snorm_ess_sup (f : α → F) (μ : measure α) :
+  ∀ᵐ x ∂μ, (nnnorm (f x) : ennreal) ≤ snorm_ess_sup f μ :=
 ennreal.ae_le_ess_sup (λ x, (nnnorm (f x) : ennreal))
 
-lemma snorm_inf_eq_zero_iff {f : α → F} : snorm_inf f μ = 0 ↔ f =ᵐ[μ] 0 :=
+lemma snorm_ess_sup_eq_zero_iff {f : α → F} : snorm_ess_sup f μ = 0 ↔ f =ᵐ[μ] 0 :=
 begin
-  rw [snorm_inf, ennreal.ess_sup_eq_zero_iff],
+  rw [snorm_ess_sup, ennreal.ess_sup_eq_zero_iff],
   split; intro h;
     { refine h.mono (λ x hx, _),
       simp_rw pi.zero_apply at hx ⊢,
@@ -304,7 +307,7 @@ lemma snorm_eq_zero_iff {f : α → E} (hf : ae_measurable f μ) (h0 : q ≠ 0) 
   snorm f q μ = 0 ↔ f =ᵐ[μ] 0 :=
 begin
   by_cases h_top : q = ⊤,
-  { rw [h_top, snorm_exponent_top, snorm_inf_eq_zero_iff], },
+  { rw [h_top, snorm_exponent_top, snorm_ess_sup_eq_zero_iff], },
   rw snorm_eq_snorm' h0 h_top,
   exact snorm'_eq_zero_iff
     (ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩) hf,
@@ -319,7 +322,7 @@ begin
   by_cases h0 : q = 0,
   { simp [h0], },
   by_cases h_top : q = ⊤,
-  { simp [h_top, snorm_inf], },
+  { simp [h_top, snorm_ess_sup], },
   simp [snorm_eq_snorm' h0 h_top],
 end
 
@@ -356,14 +359,14 @@ begin
     by simp [hpqr],
 end
 
-lemma snorm'_le_snorm_inf_mul_rpow_measure_univ (hp_pos : 0 < p) {f : α → F} :
-  snorm' f p μ ≤ snorm_inf f μ * (μ set.univ) ^ (1/p) :=
+lemma snorm'_le_snorm_ess_sup_mul_rpow_measure_univ (hp_pos : 0 < p) {f : α → F} :
+  snorm' f p μ ≤ snorm_ess_sup f μ * (μ set.univ) ^ (1/p) :=
 begin
-  have h_le : ∫⁻ (a : α), ↑(nnnorm (f a)) ^ p ∂μ ≤ ∫⁻ (a : α), (snorm_inf f μ) ^ p ∂μ,
+  have h_le : ∫⁻ (a : α), ↑(nnnorm (f a)) ^ p ∂μ ≤ ∫⁻ (a : α), (snorm_ess_sup f μ) ^ p ∂μ,
   { refine lintegral_mono_ae _,
-    have h_nnnorm_le_snorm_inf := coe_nnnorm_ae_le_snorm_inf f μ,
-    refine h_nnnorm_le_snorm_inf.mono (λ x hx, ennreal.rpow_le_rpow hx (le_of_lt hp_pos)), },
-  rw [snorm', ←ennreal.rpow_one (snorm_inf f μ)],
+    have h_nnnorm_le_snorm_ess_sup := coe_nnnorm_ae_le_snorm_ess_sup f μ,
+    refine h_nnnorm_le_snorm_ess_sup.mono (λ x hx, ennreal.rpow_le_rpow hx (le_of_lt hp_pos)), },
+  rw [snorm', ←ennreal.rpow_one (snorm_ess_sup f μ)],
   nth_rewrite 1 ←mul_inv_cancel (ne_of_lt hp_pos).symm,
   rw [ennreal.rpow_mul, one_div,
     ←@ennreal.mul_rpow_of_nonneg _ _ p⁻¹ (by simp [le_of_lt hp_pos])],
@@ -379,9 +382,9 @@ begin
   rwa [measure_univ, ennreal.one_rpow, mul_one] at h_le_μ,
 end
 
-lemma snorm'_le_snorm_inf (hp_pos : 0 < p) {f : α → F} [probability_measure μ] :
-  snorm' f p μ ≤ snorm_inf f μ :=
-le_trans (snorm'_le_snorm_inf_mul_rpow_measure_univ hp_pos) (le_of_eq (by simp [measure_univ]))
+lemma snorm'_le_snorm_ess_sup (hp_pos : 0 < p) {f : α → F} [probability_measure μ] :
+  snorm' f p μ ≤ snorm_ess_sup f μ :=
+le_trans (snorm'_le_snorm_ess_sup_mul_rpow_measure_univ hp_pos) (le_of_eq (by simp [measure_univ]))
 
 lemma snorm_le_snorm_of_exponent_le {p q : ennreal} (hpq : p ≤ q) [probability_measure μ]
   {f : α → E} (hf : ae_measurable f μ) :
@@ -397,7 +400,7 @@ begin
     { have hp_pos : 0 < p.to_real,
       from ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) hp0.symm, hp_top⟩,
       rw [snorm_eq_snorm' hp0 hp_top, hq_top, snorm_exponent_top],
-      refine le_trans (snorm'_le_snorm_inf_mul_rpow_measure_univ hp_pos) (le_of_eq _),
+      refine le_trans (snorm'_le_snorm_ess_sup_mul_rpow_measure_univ hp_pos) (le_of_eq _),
       simp [measure_univ], }, },
   { have hp_top : p ≠ ⊤,
     { by_contra hp_eq_top,
@@ -455,7 +458,7 @@ begin
   by_cases hq_top : q = ⊤,
   { rw snorm_eq_snorm' hp0 hp_top,
     rw [hq_top, snorm_exponent_top] at hfq_lt_top,
-    refine lt_of_le_of_lt (snorm'_le_snorm_inf_mul_rpow_measure_univ hp_pos) _,
+    refine lt_of_le_of_lt (snorm'_le_snorm_ess_sup_mul_rpow_measure_univ hp_pos) _,
     refine ennreal.mul_lt_top hfq_lt_top _,
     exact ennreal.rpow_lt_top_of_nonneg (by simp [le_of_lt hp_pos]) (measure_ne_top μ set.univ), },
   have hq0 : q ≠ 0,
@@ -487,7 +490,8 @@ end
 ... ≤ snorm' f p μ + snorm' g p μ :
   ennreal.lintegral_Lp_add_le hf.nnnorm.ennreal_coe hg.nnnorm.ennreal_coe hp1
 
-lemma snorm_inf_add_le {f g : α → F} : snorm_inf (f + g) μ ≤ snorm_inf f μ + snorm_inf g μ :=
+lemma snorm_ess_sup_add_le {f g : α → F} :
+  snorm_ess_sup (f + g) μ ≤ snorm_ess_sup f μ + snorm_ess_sup g μ :=
 begin
   refine le_trans (ess_sup_mono_ae (filter.eventually_of_forall (λ x, _)))
     (ennreal.ess_sup_add_le _ _),
@@ -501,7 +505,7 @@ begin
   by_cases hq0 : q = 0,
   { simp [hq0], },
   by_cases hq_top : q = ⊤,
-  { simp [hq_top, snorm_inf_add_le], },
+  { simp [hq_top, snorm_ess_sup_add_le], },
   have hq1_real : 1 ≤ q.to_real,
   by rwa [←ennreal.one_to_real, ennreal.to_real_le_to_real ennreal.one_ne_top hq_top],
   repeat { rw snorm_eq_snorm' hq0 hq_top, },
@@ -551,9 +555,9 @@ begin
   exact ennreal.coe_ne_top,
 end
 
-lemma snorm_inf_const_smul {f : α → F} (c : 𝕜) :
-  snorm_inf (c • f) μ = (nnnorm c : ennreal) * snorm_inf f μ :=
-by simp_rw [snorm_inf,  pi.smul_apply, nnnorm_smul, ennreal.coe_mul, ennreal.ess_sup_const_mul]
+lemma snorm_ess_sup_const_smul {f : α → F} (c : 𝕜) :
+  snorm_ess_sup (c • f) μ = (nnnorm c : ennreal) * snorm_ess_sup f μ :=
+by simp_rw [snorm_ess_sup,  pi.smul_apply, nnnorm_smul, ennreal.coe_mul, ennreal.ess_sup_const_mul]
 
 lemma snorm_const_smul {f : α → F} (c : 𝕜) :
   snorm (c • f) q μ = (nnnorm c : ennreal) * snorm f q μ :=
@@ -561,7 +565,7 @@ begin
   by_cases h0 : q = 0,
   { simp [h0], },
   by_cases h_top : q = ⊤,
-  { simp [h_top, snorm_inf_const_smul], },
+  { simp [h_top, snorm_ess_sup_const_smul], },
   repeat { rw snorm_eq_snorm' h0 h_top, },
   rw ←ne.def at h0,
   exact snorm'_const_smul c

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -10,8 +10,9 @@ import analysis.mean_inequalities
 /-!
 # ℒp space
 
-This file describes properties of almost everywhere measurable functions with finite seminorm
-`(∫ ∥f a∥^p ∂μ) ^ (1/p)` for `p:ennreal`.
+This file describes properties of almost everywhere measurable functions with finite seminorm,
+defined for `p:ennreal` as `0` if `p=0`, `(∫ ∥f a∥^p ∂μ) ^ (1/p)` for `0 < p < ∞` and
+`ess_sup ∥f∥ μ` for `p=∞`.
 
 ## Main definitions
 
@@ -524,6 +525,8 @@ end
 section second_countable_topology
 variable [topological_space.second_countable_topology E]
 
+/-- TODO: prove mem_ℒp.add for all `q:ennreal`. `snorm_add_le` cannot be used for `q < 1` but the
+result still holds. -/
 lemma mem_ℒp.add {f g : α → E} (hf : mem_ℒp f q μ) (hg : mem_ℒp g q μ) (hq1 : 1 ≤ q) :
   mem_ℒp (f + g) q μ :=
 begin

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -3,24 +3,26 @@ Copyright (c) 2020 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Rémy Degenne.
 -/
+import measure_theory.ess_sup
 import measure_theory.l1_space
 import analysis.mean_inequalities
 
 /-!
 # ℒp space
 
-This file describes properties of measurable functions with finite seminorm `(∫ ∥f a∥^p ∂μ) ^ (1/p)`
-for `p:ℝ` with `1 ≤ p`.
+This file describes properties of almost everywhere measurable functions with finite seminorm
+`(∫ ∥f a∥^p ∂μ) ^ (1/p)` for `p:ennreal`.
 
 ## Main definitions
 
-* `mem_ℒp f p μ` : the function `f` has finite p-seminorm for measure `μ`, for `p:ℝ` such that
-                  `hp1 : 1 ≤ p`,
+* `snorm' f p μ` : `(∫ ∥f a∥^p ∂μ) ^ (1/p)` for `f : α → F` and `p : ℝ`, where `α` is a  measurable
+  space and `F` is a normed group.
+* `snorm_inf f μ` : seminorm in `ℒ∞`, equal to the essential supremum `ess_sup ∥f∥ μ`.
+* `snorm f p μ` : for `p : ennreal`, seminorm in `ℒp`, equal to `0` for `p=0`, to `snorm' f p μ`
+  for `0 < p < ∞` and to `snorm_inf f μ` for `p = ∞`.
 
-## Notation
-
-* `snorm f p μ` : `(∫ ∥f a∥^p ∂μ) ^ (1/p)` for `f : α → F`, where `α` is a  measurable space and
-                  `F` is a normed group.
+* `mem_ℒp f p μ` : property that the function `f` is almost everywhere measurable and has finite
+  p-seminorm for measure `μ` (`snorm f p μ < ∞`)
 
 -/
 
@@ -33,113 +35,154 @@ namespace ℒp_space
 variables {α E F : Type*} [measurable_space α] {μ : measure α}
   [measurable_space E] [normed_group E]
   [normed_group F]
-  {p : ℝ}
+  {p : ℝ} {q : ennreal}
 
 section ℒp_space_definition
 
-/-- The property that `f:α→E` is ae_measurable and `∫ ∥f a∥^p ∂μ` is finite -/
-def mem_ℒp (f : α → E) (p : ℝ) (μ : measure α) : Prop :=
-ae_measurable f μ ∧ ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤
-
 /-- `(∫ ∥f a∥^p ∂μ) ^ (1/p)`, which is a seminorm on the space of measurable functions for which
 this quantity is finite -/
-def snorm (f : α → F) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)
+def snorm' (f : α → F) (p : ℝ) (μ : measure α) : ennreal := (∫⁻ a, (nnnorm (f a))^p ∂μ) ^ (1/p)
 
-lemma lintegral_rpow_nnnorm_eq_rpow_snorm {f : α → F} (hp0_lt : 0 < p) :
-  ∫⁻ a, (nnnorm (f a)) ^ p ∂μ = (snorm f p μ) ^ p :=
+/-- seminorm for `ℒ∞`, equal to the essential supremum of `∥f∥`. -/
+def snorm_inf (f : α → F) (μ : measure α) := ess_sup (λ x, (nnnorm (f x) : ennreal)) μ
+
+/-- `ℒp` seminorm, equal to `0` for `p=0`, to `(∫ ∥f a∥^p ∂μ) ^ (1/p)` for `0 < p < ∞` and to
+`ess_sup ∥f∥ μ` for `p = ∞`. -/
+def snorm (f : α → F) (q : ennreal) (μ : measure α) : ennreal :=
 begin
-  rw [snorm, ←ennreal.rpow_mul, one_div, inv_mul_cancel, ennreal.rpow_one],
+  by_cases h0 : q = 0,
+  { exact 0, },
+  by_cases h_top : q = ⊤,
+  { exact snorm_inf f μ, },
+  exact snorm' f (ennreal.to_real q) μ,
+end
+
+lemma snorm_eq_snorm' (hq_ne_zero : q ≠ 0) (hq_ne_top : q ≠ ⊤) {f : α → F} :
+  snorm f q μ = snorm' f (ennreal.to_real q) μ :=
+by simp [snorm, hq_ne_zero, hq_ne_top]
+
+lemma snorm_eq_snorm_inf {f : α → F} : snorm f ⊤ μ = snorm_inf f μ :=
+by simp [snorm]
+
+/-- The property that `f:α→E` is ae_measurable and `(∫ ∥f a∥^p ∂μ)^(1/p)` is finite -/
+def mem_ℒp (f : α → E) (p : ennreal) (μ : measure α) : Prop :=
+ae_measurable f μ ∧ snorm f p μ < ⊤
+
+lemma lintegral_rpow_nnnorm_eq_rpow_snorm' {f : α → F} (hp0_lt : 0 < p) :
+  ∫⁻ a, (nnnorm (f a)) ^ p ∂μ = (snorm' f p μ) ^ p :=
+begin
+  rw [snorm', ←ennreal.rpow_mul, one_div, inv_mul_cancel, ennreal.rpow_one],
   exact (ne_of_lt hp0_lt).symm,
 end
 
 end ℒp_space_definition
 
 lemma mem_ℒp_one_iff_integrable {f : α → E} : mem_ℒp f 1 μ ↔ integrable f μ :=
-by simp only [integrable, has_finite_integral, mem_ℒp, ennreal.rpow_one, nnreal.coe_one]
+by simp_rw [integrable, has_finite_integral, mem_ℒp,
+    snorm_eq_snorm' one_ne_zero ennreal.one_ne_top, ennreal.one_to_real, snorm', one_div_one,
+    ennreal.rpow_one]
 
 section top
 
-lemma mem_ℒp.snorm_lt_top {f : α → E} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ < ⊤ :=
-begin
-  refine ennreal.rpow_lt_top_of_nonneg _ (ne_of_lt hfp.right),
-  rw [one_div, inv_nonneg],
-  exact hp0,
-end
+lemma mem_ℒp.snorm_lt_top {f : α → E} (hfp : mem_ℒp f q μ) : snorm f q μ < ⊤ := hfp.2
 
-lemma mem_ℒp.snorm_ne_top {f : α → E} (hp0 : 0 ≤ p) (hfp : mem_ℒp f p μ) : snorm f p μ ≠ ⊤ :=
-ne_of_lt (hfp.snorm_lt_top hp0)
+lemma mem_ℒp.snorm_ne_top {f : α → E} (hfp : mem_ℒp f q μ) : snorm f q μ ≠ ⊤ := ne_of_lt (hfp.2)
 
-lemma lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top {f : α → F} (hp0_lt : 0 < p)
-  (hfp : snorm f p μ < ⊤) :
+lemma lintegral_rpow_nnnorm_lt_top_of_snorm'_lt_top {f : α → F} (hp0_lt : 0 < p)
+  (hfp : snorm' f p μ < ⊤) :
   ∫⁻ a, (nnnorm (f a)) ^ p ∂μ < ⊤ :=
 begin
-  rw lintegral_rpow_nnnorm_eq_rpow_snorm hp0_lt,
+  rw lintegral_rpow_nnnorm_eq_rpow_snorm' hp0_lt,
   exact ennreal.rpow_lt_top_of_nonneg (le_of_lt hp0_lt) (ne_of_lt hfp),
 end
-
-lemma mem_ℒp_of_snorm_lt_top {f : α → E} (hp0_lt : 0 < p) (hfm : ae_measurable f μ)
-  (hfp : snorm f p μ < ⊤) : mem_ℒp f p μ :=
-⟨hfm, lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top hp0_lt hfp⟩
 
 end top
 
 section zero
 
-@[simp] lemma snorm_exponent_zero {f : α → F} : snorm f 0 μ = 1 :=
-by rw [snorm, div_zero, ennreal.rpow_zero]
+@[simp] lemma snorm'_exponent_zero {f : α → F} : snorm' f 0 μ = 1 :=
+by rw [snorm', div_zero, ennreal.rpow_zero]
 
-lemma zero_mem_ℒp_of_pos (hp_pos : 0 < p) : mem_ℒp (0 : α → E) p μ :=
-⟨measurable_zero.ae_measurable, by simp [hp_pos]⟩
+@[simp] lemma snorm_exponent_zero {f : α → F} : snorm f 0 μ = 0 :=
+by simp [snorm]
 
-lemma zero_mem_ℒp_of_nonneg [finite_measure μ] (hp0 : 0 ≤ p) : mem_ℒp (0 : α → E) p μ :=
-begin
-  by_cases h0 : p = 0,
-  { rw h0,
-    split,
-    { exact measurable_zero.ae_measurable, },
-    { simp [measure_lt_top μ set.univ], }, },
-  { rw ←ne.def at h0,
-    exact zero_mem_ℒp_of_pos (lt_of_le_of_ne hp0 h0.symm), },
-end
+lemma mem_ℒp_zero_iff_ae_measurable {f : α → E} : mem_ℒp f 0 μ ↔ ae_measurable f μ :=
+by simp [mem_ℒp, snorm_exponent_zero]
 
-@[simp] lemma snorm_zero (hp0_lt : 0 < p) : snorm (0 : α → F) p μ = 0 :=
-by simp [snorm, hp0_lt]
+@[simp] lemma snorm'_zero (hp0_lt : 0 < p) : snorm' (0 : α → F) p μ = 0 :=
+by simp [snorm', hp0_lt]
 
-@[simp] lemma snorm_zero' (hp0_ne : p ≠ 0) (hμ : μ ≠ 0) : snorm (0 : α → F) p μ = 0 :=
+@[simp] lemma snorm'_zero' (hp0_ne : p ≠ 0) (hμ : μ ≠ 0) : snorm' (0 : α → F) p μ = 0 :=
 begin
   cases le_or_lt 0 p with hp0 hp_neg,
-  { exact snorm_zero (lt_of_le_of_ne hp0 hp0_ne.symm), },
-  { rw [snorm, ennreal.rpow_eq_zero_iff],
-    simp [hμ, hp_neg], },
+  { exact snorm'_zero (lt_of_le_of_ne hp0 hp0_ne.symm), },
+  { simp [snorm', ennreal.rpow_eq_zero_iff, hμ, hp_neg], },
 end
 
-/-- When `μ = 0`, we have `∫ f^p ∂μ = 0`. `snorm f p μ` is then `0`, `1` or `⊤` depending on `p`. -/
-lemma snorm_measure_zero_of_pos {f : α → F} (hp_pos : 0 < p) : snorm f p 0 = 0 :=
-by simp [snorm, hp_pos]
+@[simp] lemma snorm_inf_zero : snorm_inf (0 : α → F) μ = 0 :=
+begin
+  simp_rw [snorm_inf, pi.zero_apply, nnnorm_zero, ennreal.coe_zero, ←ennreal.bot_eq_zero],
+  exact ess_sup_const_bot,
+end
 
-/-- When `μ = 0`, we have `∫ f^p ∂μ = 0`. `snorm f p μ` is then `0`, `1` or `⊤` depending on `p`. -/
-lemma snorm_measure_zero_of_exponent_zero {f : α → F} : snorm f 0 0 = 1 := by simp [snorm]
+@[simp] lemma snorm_zero : snorm (0 : α → F) q μ = 0 :=
+begin
+  by_cases h0 : q = 0,
+  { simp [h0], },
+  by_cases h_top : q = ⊤,
+  { simp only [h_top, snorm_eq_snorm_inf, snorm_inf_zero], },
+  rw ←ne.def at h0,
+  simp [snorm_eq_snorm' h0 h_top,
+    ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩],
+end
 
-/-- When `μ = 0`, we have `∫ f^p ∂μ = 0`. `snorm f p μ` is then `0`, `1` or `⊤` depending on `p`. -/
-lemma snorm_measure_zero_of_neg {f : α → F} (hp_neg : p < 0) : snorm f p 0 = ⊤ :=
-by simp [snorm, hp_neg]
+lemma zero_mem_ℒp : mem_ℒp (0 : α → E) q μ :=
+begin
+  refine ⟨measurable_zero.ae_measurable, _⟩,
+  rw snorm_zero,
+  exact ennreal.coe_lt_top,
+end
+
+lemma snorm'_measure_zero_of_pos {f : α → F} (hp_pos : 0 < p) : snorm' f p 0 = 0 :=
+by simp [snorm', hp_pos]
+
+lemma snorm'_measure_zero_of_exponent_zero {f : α → F} : snorm' f 0 0 = 1 := by simp [snorm']
+
+lemma snorm'_measure_zero_of_neg {f : α → F} (hp_neg : p < 0) : snorm' f p 0 = ⊤ :=
+by simp [snorm', hp_neg]
+
+@[simp] lemma snorm_inf_measure_zero {f : α → F} : snorm_inf f 0 = 0 :=
+by simp [snorm_inf]
+
+@[simp] lemma snorm_measure_zero {f : α → F} : snorm f q 0 = 0 :=
+begin
+  by_cases h0 : q = 0,
+  { simp [h0], },
+  by_cases h_top : q = ⊤,
+  { simp [h_top, snorm_eq_snorm_inf], },
+  rw ←ne.def at h0,
+  simp [snorm_eq_snorm' h0 h_top, snorm',
+    ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩],
+end
 
 end zero
 
-lemma snorm_const (c : F) (hp_pos : 0 < p) :
-  snorm (λ x : α , c) p μ = (nnnorm c : ennreal) * (μ set.univ) ^ (1/p) :=
+section const
+
+lemma snorm'_const (c : F) (hp_pos : 0 < p) :
+  snorm' (λ x : α , c) p μ = (nnnorm c : ennreal) * (μ set.univ) ^ (1/p) :=
 begin
-  rw [snorm, lintegral_const, @ennreal.mul_rpow_of_nonneg _ _ (1/p) (by simp [le_of_lt hp_pos])],
+  rw [snorm', lintegral_const, @ennreal.mul_rpow_of_nonneg _ _ (1/p) (by simp [le_of_lt hp_pos])],
   congr,
   rw ←ennreal.rpow_mul,
   suffices hp_cancel : p * (1/p) = 1, by rw [hp_cancel, ennreal.rpow_one],
   rw [one_div, mul_inv_cancel (ne_of_lt hp_pos).symm],
 end
 
-lemma snorm_const' [finite_measure μ] (c : F) (hc_ne_zero : c ≠ 0) (hp_ne_zero : p ≠ 0) :
-  snorm (λ x : α , c) p μ = (nnnorm c : ennreal) * (μ set.univ) ^ (1/p) :=
+lemma snorm'_const' [finite_measure μ] (c : F) (hc_ne_zero : c ≠ 0) (hp_ne_zero : p ≠ 0) :
+  snorm' (λ x : α , c) p μ = (nnnorm c : ennreal) * (μ set.univ) ^ (1/p) :=
 begin
-  rw [snorm, lintegral_const, ennreal.mul_rpow_of_ne_top _ (measure_ne_top μ set.univ)],
+  rw [snorm', lintegral_const, ennreal.mul_rpow_of_ne_top _ (measure_ne_top μ set.univ)],
   { congr,
     rw ←ennreal.rpow_mul,
     suffices hp_cancel : p * (1/p) = 1, by rw [hp_cancel, ennreal.rpow_one],
@@ -151,107 +194,159 @@ begin
     { exact or.inl ennreal.coe_ne_top, }, },
 end
 
-lemma snorm_const_of_probability_measure (c : F) (hp_pos : 0 < p) [probability_measure μ] :
-  snorm (λ x : α , c) p μ = (nnnorm c : ennreal) :=
-by simp [snorm_const c hp_pos, measure_univ]
+lemma snorm_inf_const (c : F) (hμ : μ ≠ 0) : snorm_inf (λ x : α, c) μ = (nnnorm c : ennreal) :=
+by rw [snorm_inf, ess_sup_const _ hμ]
 
-lemma mem_ℒp_const (c : E) (h : c ≠ 0 ∨ 0 ≤ p) [finite_measure μ] : mem_ℒp (λ a:α, c) p μ :=
+lemma snorm'_const_of_probability_measure (c : F) (hp_pos : 0 < p) [probability_measure μ] :
+  snorm' (λ x : α , c) p μ = (nnnorm c : ennreal) :=
+by simp [snorm'_const c hp_pos, measure_univ]
+
+lemma snorm_const (c : F) (h0 : q ≠ 0) (hμ : μ ≠ 0) :
+  snorm (λ x : α , c) q μ = (nnnorm c : ennreal) * (μ set.univ) ^ (1/(ennreal.to_real q)) :=
 begin
-  split,
-  { exact measurable_const.ae_measurable, },
-  dsimp only,
-  rw lintegral_const,
-  refine ennreal.mul_lt_top _ (measure_lt_top μ set.univ),
-  rw [lt_top_iff_ne_top, ne.def, ennreal.rpow_eq_top_iff, auto.not_or_eq, auto.not_and_eq,
-    auto.not_and_eq],
-  split,
-  { rw [ennreal.coe_eq_zero, nnnorm_eq_zero],
-    push_neg,
-    exact h, },
-  { exact or.inl ennreal.coe_ne_top, },
+  by_cases h_top : q = ⊤,
+  { simp [h_top, snorm_eq_snorm_inf, snorm_inf_const c hμ], },
+  simp [snorm_eq_snorm' h0 h_top, snorm'_const,
+    ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩],
 end
 
-lemma mem_ℒp_const_of_nonneg (c : E) (hp0 : 0 ≤ p) [finite_measure μ] : mem_ℒp (λ a:α, c) p μ :=
-mem_ℒp_const c (or.inr hp0)
+lemma snorm_const' (c : F) (h0 : q ≠ 0) (h_top: q ≠ ⊤) :
+  snorm (λ x : α , c) q μ = (nnnorm c : ennreal) * (μ set.univ) ^ (1/(ennreal.to_real q)) :=
+begin
+  simp [snorm_eq_snorm' h0 h_top, snorm'_const,
+    ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩],
+end
 
-lemma mem_ℒp_const_of_ne_zero (c : E) (hc : c ≠ 0) [finite_measure μ] : mem_ℒp (λ a:α, c) p μ :=
-mem_ℒp_const c (or.inl hc)
+lemma mem_ℒp_const (c : E) [finite_measure μ] : mem_ℒp (λ a:α, c) q μ :=
+begin
+  refine ⟨measurable_const.ae_measurable, _⟩,
+  by_cases h0 : q = 0,
+  { simp [h0], },
+  by_cases hμ : μ = 0,
+  { simp [hμ], },
+  rw snorm_const c h0 hμ,
+  refine ennreal.mul_lt_top ennreal.coe_lt_top _,
+  refine ennreal.rpow_lt_top_of_nonneg _ (measure_ne_top μ set.univ),
+  simp,
+end
 
-lemma snorm_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) :
-  snorm f p μ = snorm g p μ :=
+end const
+
+lemma snorm'_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) :
+  snorm' f p μ = snorm' g p μ :=
 begin
   suffices h_no_pow : ∫⁻ a, (nnnorm (f a)) ^ p ∂μ = ∫⁻ a, (nnnorm (g a)) ^ p ∂μ,
-  { simp_rw [snorm, h_no_pow], },
-  exact lintegral_congr_ae
-    (filter.eventually.mp hfg (filter.eventually_of_forall (λ x hx, by simp [*]))),
+  { simp_rw [snorm', h_no_pow], },
+  exact lintegral_congr_ae (hfg.mono (λ x hx, by simp [*])),
 end
 
-lemma mem_ℒp.ae_eq {f g : α → E} (hfg : f =ᵐ[μ] g) (hf_Lp : mem_ℒp f p μ) :
-  mem_ℒp g p μ :=
+lemma snorm_inf_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) :
+  snorm_inf f μ = snorm_inf g μ :=
+ess_sup_congr_ae (hfg.mono (λ x hx, by rw hx))
+
+lemma snorm_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) :
+  snorm f q μ = snorm g q μ :=
+begin
+  by_cases h0 : q = 0,
+  { simp [h0], },
+  by_cases h_top : q = ⊤,
+  { rw [h_top, snorm_eq_snorm_inf],
+    exact snorm_inf_congr_ae hfg, },
+  repeat { rw snorm_eq_snorm' h0 h_top, },
+  exact snorm'_congr_ae hfg,
+end
+
+lemma mem_ℒp.ae_eq {f g : α → E} (hfg : f =ᵐ[μ] g) (hf_Lp : mem_ℒp f q μ) :
+  mem_ℒp g q μ :=
 begin
   split,
   { cases hf_Lp.1 with f' hf',
-    use f',
-    exact ⟨hf'.1, ae_eq_trans hfg.symm hf'.2⟩, },
-  have h_eq : ∫⁻ (a : α), (nnnorm (g a)) ^ p ∂μ = ∫⁻ (a : α), (nnnorm (f a)) ^ p ∂μ,
-  from lintegral_congr_ae
-    (filter.eventually.mp hfg (filter.eventually_of_forall (λ x hx, by simp [hx]))),
-  rw h_eq,
-  exact hf_Lp.2,
+    exact ⟨f', ⟨hf'.1, ae_eq_trans hfg.symm hf'.2⟩⟩, },
+  { rw snorm_congr_ae hfg.symm,
+    exact hf_Lp.2, },
 end
 
-lemma mem_ℒp_congr_ae {f g : α → E} (hfg : f =ᵐ[μ] g) :
-  mem_ℒp f p μ ↔ mem_ℒp g p μ :=
+lemma mem_ℒp_congr_ae {f g : α → E} (hfg : f =ᵐ[μ] g) : mem_ℒp f q μ ↔ mem_ℒp g q μ :=
 ⟨λ h, h.ae_eq hfg, λ h, h.ae_eq hfg.symm⟩
 
 section opens_measurable_space
 variable [opens_measurable_space E]
 
-lemma snorm_eq_zero_of_ae_zero {f : α → F} (hp0_lt : 0 < p) (hf_zero : f =ᵐ[μ] 0) :
-  snorm f p μ = 0 :=
-by rw [snorm_congr_ae hf_zero, snorm_zero hp0_lt]
+lemma snorm'_eq_zero_of_ae_zero {f : α → F} (hp0_lt : 0 < p) (hf_zero : f =ᵐ[μ] 0) :
+  snorm' f p μ = 0 :=
+by rw [snorm'_congr_ae hf_zero, snorm'_zero hp0_lt]
 
-lemma snorm_eq_zero_of_ae_zero' (hp0_ne : p ≠ 0) (hμ : μ ≠ 0) {f : α → F} (hf_zero : f =ᵐ[μ] 0) :
-  snorm f p μ = 0 :=
-by rw [snorm_congr_ae hf_zero, snorm_zero' hp0_ne hμ]
+lemma snorm'_eq_zero_of_ae_zero' (hp0_ne : p ≠ 0) (hμ : μ ≠ 0) {f : α → F} (hf_zero : f =ᵐ[μ] 0) :
+  snorm' f p μ = 0 :=
+by rw [snorm'_congr_ae hf_zero, snorm'_zero' hp0_ne hμ]
 
-lemma ae_eq_zero_of_snorm_eq_zero {f : α → E} (hp0 : 0 ≤ p) (hf : ae_measurable f μ)
-  (h : snorm f p μ = 0) :
+lemma ae_eq_zero_of_snorm'_eq_zero {f : α → E} (hp0 : 0 ≤ p) (hf : ae_measurable f μ)
+  (h : snorm' f p μ = 0) :
   f =ᵐ[μ] 0 :=
 begin
-  rw [snorm, ennreal.rpow_eq_zero_iff] at h,
+  rw [snorm', ennreal.rpow_eq_zero_iff] at h,
   cases h,
   { rw lintegral_eq_zero_iff' hf.nnnorm.ennreal_coe.ennreal_rpow_const at h,
-    refine filter.eventually.mp h.left (filter.eventually_of_forall (λ x hx, _)),
+    refine h.left.mono (λ x hx, _),
     rw [pi.zero_apply, ennreal.rpow_eq_zero_iff] at hx,
     cases hx,
     { cases hx with hx _,
       rwa [←ennreal.coe_zero, ennreal.coe_eq_coe, nnnorm_eq_zero] at hx, },
-    { exfalso,
-      exact ennreal.coe_ne_top hx.left, }, },
+    { exact absurd hx.left ennreal.coe_ne_top, }, },
   { exfalso,
     rw [one_div, inv_lt_zero] at h,
     linarith, },
 end
 
-lemma snorm_eq_zero_iff (hp0_lt : 0 < p) {f : α → E} (hf : ae_measurable f μ) :
-  snorm f p μ = 0 ↔ f =ᵐ[μ] 0 :=
-⟨ae_eq_zero_of_snorm_eq_zero (le_of_lt hp0_lt) hf, snorm_eq_zero_of_ae_zero hp0_lt⟩
+lemma snorm'_eq_zero_iff (hp0_lt : 0 < p) {f : α → E} (hf : ae_measurable f μ) :
+  snorm' f p μ = 0 ↔ f =ᵐ[μ] 0 :=
+⟨ae_eq_zero_of_snorm'_eq_zero (le_of_lt hp0_lt) hf, snorm'_eq_zero_of_ae_zero hp0_lt⟩
+
+lemma coe_nnnorm_ae_le_snorm_inf (f : α → F) (μ : measure α) :
+  ∀ᵐ x ∂μ, (nnnorm (f x) : ennreal) ≤ snorm_inf f μ :=
+ennreal.ae_le_ess_sup (λ x, (nnnorm (f x) : ennreal))
+
+lemma snorm_inf_eq_zero_iff {f : α → F} : snorm_inf f μ = 0 ↔ f =ᵐ[μ] 0 :=
+begin
+  rw [snorm_inf, ennreal.ess_sup_eq_zero_iff],
+  split; intro h;
+    { refine h.mono (λ x hx, _),
+      simp_rw pi.zero_apply at hx ⊢,
+      simpa using hx, },
+end
+
+lemma snorm_eq_zero_iff {f : α → E} (hf : ae_measurable f μ) (h0 : q ≠ 0) :
+  snorm f q μ = 0 ↔ f =ᵐ[μ] 0 :=
+begin
+  by_cases h_top : q = ⊤,
+  { rw [h_top, snorm_eq_snorm_inf, snorm_inf_eq_zero_iff], },
+  rw snorm_eq_snorm' h0 h_top,
+  exact snorm'_eq_zero_iff
+    (ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩) hf,
+end
 
 end opens_measurable_space
 
-@[simp] lemma snorm_neg {f : α → F} : snorm (-f) p μ = snorm f p μ :=
-by simp [snorm]
+@[simp] lemma snorm'_neg {f : α → F} : snorm' (-f) p μ = snorm' f p μ := by simp [snorm']
+
+@[simp] lemma snorm_neg {f : α → F} : snorm (-f) q μ = snorm f q μ :=
+begin
+  by_cases h0 : q = 0,
+  { simp [h0], },
+  by_cases h_top : q = ⊤,
+  { simp [h_top, snorm_eq_snorm_inf, snorm_inf], },
+  simp [snorm_eq_snorm' h0 h_top],
+end
 
 section borel_space
 variable [borel_space E]
 
-lemma mem_ℒp.neg {f : α → E} (hf : mem_ℒp f p μ) : mem_ℒp (-f) p μ :=
+lemma mem_ℒp.neg {f : α → E} (hf : mem_ℒp f q μ) : mem_ℒp (-f) q μ :=
 ⟨ae_measurable.neg hf.1, by simp [hf.right]⟩
 
-lemma snorm_le_snorm_mul_rpow_measure_univ {p q : ℝ} (hp0_lt : 0 < p) (hpq : p ≤ q) (μ : measure α)
+lemma snorm'_le_snorm'_mul_rpow_measure_univ {p q : ℝ} (hp0_lt : 0 < p) (hpq : p ≤ q)
   {f : α → E} (hf : ae_measurable f μ) :
-  snorm f p μ ≤ snorm f q μ * (μ set.univ) ^ (1/p - 1/q) :=
+  snorm' f p μ ≤ snorm' f q μ * (μ set.univ) ^ (1/p - 1/q) :=
 begin
   have hq0_lt : 0 < q, from lt_of_lt_of_le hp0_lt hpq,
   by_cases hpq_eq : p = q,
@@ -261,7 +356,7 @@ begin
   let g := λ a : α, (1 : ennreal),
   have h_rw : ∫⁻ a, ↑(nnnorm (f a))^p ∂ μ = ∫⁻ a, (nnnorm (f a) * (g a))^p ∂ μ,
   from lintegral_congr (λ a, by simp),
-  repeat {rw snorm},
+  repeat {rw snorm'},
   rw h_rw,
   let r := p * q / (q - p),
   have hpqr : 1/p = 1/q + 1/r,
@@ -276,52 +371,127 @@ begin
     by simp [hpqr],
 end
 
-lemma snorm_le_snorm_of_exponent_le {p q : ℝ} (hp0_lt : 0 < p) (hpq : p ≤ q) (μ : measure α)
-  [probability_measure μ] {f : α → E} (hf : ae_measurable f μ) :
-  snorm f p μ ≤ snorm f q μ :=
+lemma snorm'_le_snorm_inf_mul_rpow_measure_univ (hp_pos : 0 < p) {f : α → F} :
+  snorm' f p μ ≤ snorm_inf f μ * (μ set.univ) ^ (1/p) :=
 begin
-  have h_le_μ := snorm_le_snorm_mul_rpow_measure_univ hp0_lt hpq μ hf,
+  rw snorm',
+  have h_le : ∫⁻ (a : α), ↑(nnnorm (f a)) ^ p ∂μ ≤ ∫⁻ (a : α), (snorm_inf f μ) ^ p ∂μ,
+  { refine lintegral_mono_ae _,
+    have h_nnnorm_le_snorm_inf := coe_nnnorm_ae_le_snorm_inf f μ,
+    refine h_nnnorm_le_snorm_inf.mono (λ x hx, ennreal.rpow_le_rpow hx (le_of_lt hp_pos)), },
+  rw ←ennreal.rpow_one (snorm_inf f μ),
+  nth_rewrite 1 ←mul_inv_cancel (ne_of_lt hp_pos).symm,
+  rw [ennreal.rpow_mul, one_div,
+    ←@ennreal.mul_rpow_of_nonneg _ _ p⁻¹ (by simp [le_of_lt hp_pos])],
+  refine ennreal.rpow_le_rpow _ (by simp [le_of_lt hp_pos]),
+  rwa lintegral_const at h_le,
+end
+
+lemma snorm'_le_snorm'_of_exponent_le {p q : ℝ} (hp0_lt : 0 < p) (hpq : p ≤ q) (μ : measure α)
+  [probability_measure μ] {f : α → E} (hf : ae_measurable f μ) :
+  snorm' f p μ ≤ snorm' f q μ :=
+begin
+  have h_le_μ := snorm'_le_snorm'_mul_rpow_measure_univ hp0_lt hpq hf,
   rwa [measure_univ, ennreal.one_rpow, mul_one] at h_le_μ,
 end
 
-lemma mem_ℒp.mem_ℒp_of_exponent_le {p q : ℝ} {μ : measure α} [finite_measure μ] {f : α → E}
-  (hfq : mem_ℒp f q μ) (hp_pos : 0 < p) (hpq : p ≤ q) :
-  mem_ℒp f p μ :=
+lemma snorm'_le_snorm_inf (hp_pos : 0 < p) {f : α → F} [probability_measure μ] :
+  snorm' f p μ ≤ snorm_inf f μ :=
 begin
-  cases hfq with hfq_m hfq_lt_top,
-  split,
-  { exact hfq_m, },
-  have hq_pos : 0 < q, from lt_of_lt_of_le  hp_pos hpq,
-  suffices h_snorm : snorm f p μ < ⊤,
-  { have h_top_eq : (⊤ : ennreal) = ⊤ ^ (1/p), by simp [hp_pos],
-    rw [snorm, h_top_eq] at h_snorm,
-    have h_snorm_pow : ((∫⁻ (a : α), ↑(nnnorm (f a)) ^ p ∂μ) ^ (1/p)) ^ p < (⊤ ^ (1/p)) ^ p,
-    from ennreal.rpow_lt_rpow h_snorm hp_pos,
-    rw [←ennreal.rpow_mul, ←ennreal.rpow_mul] at h_snorm_pow,
-    simpa [(ne_of_lt hp_pos).symm] using h_snorm_pow, },
-  calc snorm f p μ
-      ≤ snorm f q μ * (μ set.univ) ^ (1/p - 1/q) :
-    snorm_le_snorm_mul_rpow_measure_univ hp_pos hpq μ hfq_m
+  refine le_trans (snorm'_le_snorm_inf_mul_rpow_measure_univ hp_pos) (le_of_eq _),
+  simp [measure_univ],
+end
+
+lemma snorm_le_snorm_of_exponent_le {p q : ennreal} (hpq : p ≤ q) [probability_measure μ]
+  {f : α → E} (hf : ae_measurable f μ) :
+  snorm f p μ ≤ snorm f q μ :=
+begin
+  by_cases hp0 : p = 0,
+  { simp [hp0], },
+  rw ←ne.def at hp0,
+  by_cases hq_top : q = ⊤,
+  { by_cases hp_top : p = ⊤,
+    { rw [hq_top, hp_top],
+      exact le_refl _, },
+    { have hp_pos : 0 < p.to_real,
+      from ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) hp0.symm, hp_top⟩,
+      rw [snorm_eq_snorm' hp0 hp_top, hq_top, snorm_eq_snorm_inf],
+      refine le_trans (snorm'_le_snorm_inf_mul_rpow_measure_univ hp_pos) (le_of_eq _),
+      simp [measure_univ], }, },
+  { have hp_top : p ≠ ⊤,
+    { by_contra hp_eq_top,
+      push_neg at hp_eq_top,
+      refine hq_top _,
+      rwa [hp_eq_top, top_le_iff] at hpq, },
+    have hp_pos : 0 < p.to_real,
+    from ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) hp0.symm, hp_top⟩,
+    have hq0 : q ≠ 0,
+    { by_contra hq_eq_zero,
+      push_neg at hq_eq_zero,
+      have hp_eq_zero : p = 0, from le_antisymm (by rwa hq_eq_zero at hpq) (zero_le _),
+      rw [hp_eq_zero, ennreal.zero_to_real] at hp_pos,
+      exact (lt_irrefl _) hp_pos, },
+    have hpq_real : p.to_real ≤ q.to_real, by rwa ennreal.to_real_le_to_real hp_top hq_top,
+    rw [snorm_eq_snorm' hp0 hp_top, snorm_eq_snorm' hq0 hq_top],
+    exact snorm'_le_snorm'_of_exponent_le hp_pos hpq_real _ hf, },
+end
+
+lemma snorm'_lt_top_of_snorm'_lt_top_of_exponent_le {p q : ℝ} [finite_measure μ] {f : α → E}
+  (hf : ae_measurable f μ) (hfq_lt_top : snorm' f q μ < ⊤) (hp_pos : 0 < p) (hpq : p ≤ q) :
+  snorm' f p μ < ⊤ :=
+begin
+  have hq_pos : 0 < q, from lt_of_lt_of_le hp_pos hpq,
+  calc snorm' f p μ
+      ≤ snorm' f q μ * (μ set.univ) ^ (1/p - 1/q) :
+    snorm'_le_snorm'_mul_rpow_measure_univ hp_pos hpq hf
   ... < ⊤ :
   begin
     rw ennreal.mul_lt_top_iff,
-    left,
-    split,
-    { exact mem_ℒp.snorm_lt_top (le_of_lt hq_pos) ⟨hfq_m, hfq_lt_top⟩, },
-    { refine ennreal.rpow_lt_top_of_nonneg _ (measure_ne_top μ set.univ),
-      rwa [le_sub, sub_zero, one_div, one_div, inv_le_inv hq_pos hp_pos], },
+    refine or.inl ⟨hfq_lt_top, ennreal.rpow_lt_top_of_nonneg _ (measure_ne_top μ set.univ)⟩,
+    rwa [le_sub, sub_zero, one_div, one_div, inv_le_inv hq_pos hp_pos],
   end
 end
 
-lemma mem_ℒp.integrable (hp1 : 1 ≤ p) {f : α → E} [finite_measure μ] (hfp : mem_ℒp f p μ) :
-  integrable f μ :=
+lemma mem_ℒp.mem_ℒp_of_exponent_le {p q : ennreal} [finite_measure μ] {f : α → E}
+  (hfq : mem_ℒp f q μ) (hpq : p ≤ q) :
+  mem_ℒp f p μ :=
 begin
-  rw ←mem_ℒp_one_iff_integrable,
-  exact hfp.mem_ℒp_of_exponent_le zero_lt_one hp1,
+  cases hfq with hfq_m hfq_lt_top,
+  by_cases hp0 : p = 0,
+  { rwa [hp0, mem_ℒp_zero_iff_ae_measurable], },
+  rw ←ne.def at hp0,
+  refine ⟨hfq_m, _⟩,
+  by_cases hp_top : p = ⊤,
+  { have hq_top : q = ⊤,
+      by rwa [hp_top, top_le_iff] at hpq,
+    rw [hp_top],
+    rwa hq_top at hfq_lt_top, },
+  have hp_pos : 0 < p.to_real,
+    from ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) hp0.symm, hp_top⟩,
+  by_cases hq_top : q = ⊤,
+  { rw snorm_eq_snorm' hp0 hp_top,
+    rw [hq_top, snorm_eq_snorm_inf] at hfq_lt_top,
+    refine lt_of_le_of_lt (snorm'_le_snorm_inf_mul_rpow_measure_univ hp_pos) _,
+    refine ennreal.mul_lt_top hfq_lt_top _,
+    exact ennreal.rpow_lt_top_of_nonneg (by simp [le_of_lt hp_pos]) (measure_ne_top μ set.univ), },
+  have hq0 : q ≠ 0,
+  { by_contra hq_eq_zero,
+    push_neg at hq_eq_zero,
+    have hp_eq_zero : p = 0, from le_antisymm (by rwa hq_eq_zero at hpq) (zero_le _),
+    rw [hp_eq_zero, ennreal.zero_to_real] at hp_pos,
+    exact (lt_irrefl _) hp_pos, },
+  have hpq_real : p.to_real ≤ q.to_real, by rwa ennreal.to_real_le_to_real hp_top hq_top,
+  rw snorm_eq_snorm' hp0 hp_top,
+  rw snorm_eq_snorm' hq0 hq_top at hfq_lt_top,
+  exact snorm'_lt_top_of_snorm'_lt_top_of_exponent_le hfq_m hfq_lt_top hp_pos hpq_real,
 end
 
-lemma snorm_add_le {f g : α → E} (hf : ae_measurable f μ) (hg : ae_measurable g μ) (hp1 : 1 ≤ p) :
-  snorm (f + g) p μ ≤ snorm f p μ + snorm g p μ :=
+lemma mem_ℒp.integrable (hq1 : 1 ≤ q) {f : α → E} [finite_measure μ] (hfq : mem_ℒp f q μ) :
+  integrable f μ :=
+mem_ℒp_one_iff_integrable.mp (hfq.mem_ℒp_of_exponent_le hq1)
+
+lemma snorm'_add_le {f g : α → E} (hf : ae_measurable f μ) (hg : ae_measurable g μ) (hp1 : 1 ≤ p) :
+  snorm' (f + g) p μ ≤ snorm' f p μ + snorm' g p μ :=
 calc (∫⁻ a, ↑(nnnorm ((f + g) a)) ^ p ∂μ) ^ (1 / p)
     ≤ (∫⁻ a, (((λ a, (nnnorm (f a) : ennreal))
         + (λ a, (nnnorm (g a) : ennreal))) a) ^ p ∂μ) ^ (1 / p) :
@@ -330,59 +500,61 @@ begin
   refine lintegral_mono (λ a, ennreal.rpow_le_rpow _ (le_trans zero_le_one hp1)),
   simp [←ennreal.coe_add, nnnorm_add_le],
 end
-... ≤ snorm f p μ + snorm g p μ :
+... ≤ snorm' f p μ + snorm' g p μ :
   ennreal.lintegral_Lp_add_le hf.nnnorm.ennreal_coe hg.nnnorm.ennreal_coe hp1
+
+lemma snorm_inf_add_le {f g : α → F} :
+  snorm_inf (f + g) μ ≤ snorm_inf f μ + snorm_inf g μ :=
+begin
+  refine le_trans (ess_sup_mono_ae (filter.eventually_of_forall (λ x, _)))
+    (ennreal.ess_sup_add_le _ _),
+  simp_rw [pi.add_apply, ←ennreal.coe_add, ennreal.coe_le_coe],
+  exact nnnorm_add_le _ _,
+end
+
+lemma snorm_add_le {f g : α → E} (hf : ae_measurable f μ) (hg : ae_measurable g μ) (hq1 : 1 ≤ q) :
+  snorm (f + g) q μ ≤ snorm f q μ + snorm g q μ :=
+begin
+  by_cases hq0 : q = 0,
+  { simp [hq0], },
+  by_cases hq_top : q = ⊤,
+  { simp [hq_top, snorm_eq_snorm_inf, snorm_inf_add_le], },
+  have hq1_real : 1 ≤ q.to_real,
+  by rwa [←ennreal.one_to_real, ennreal.to_real_le_to_real ennreal.one_ne_top hq_top],
+  repeat { rw snorm_eq_snorm' hq0 hq_top, },
+  exact snorm'_add_le hf hg hq1_real,
+end
 
 section second_countable_topology
 variable [topological_space.second_countable_topology E]
 
-lemma mem_ℒp.add {f g : α → E} (hf : mem_ℒp f p μ) (hg : mem_ℒp g p μ) (hp1 : 1 ≤ p) :
-  mem_ℒp (f+g) p μ :=
+lemma mem_ℒp.add {f g : α → E} (hf : mem_ℒp f q μ) (hg : mem_ℒp g q μ) (hq1 : 1 ≤ q) :
+  mem_ℒp (f + g) q μ :=
 begin
-  have hp0_lt : 0 < p, from lt_of_lt_of_le zero_lt_one hp1,
-  have hp0 : 0 ≤ p, from le_of_lt hp0_lt,
-  split,
-  { exact ae_measurable.add hf.1 hg.1, },
-  simp_rw [pi.add_apply, ennreal.coe_rpow_of_nonneg _ hp0],
-  have h_nnnorm_add_le : ∫⁻ (a : α), ↑(nnnorm (f a + g a) ^ p) ∂μ
-    ≤ ∫⁻ a, ↑((nnnorm (f a) + nnnorm (g a)) ^ p) ∂μ,
-  { refine lintegral_mono_nnreal (λ a, _),
-    exact nnreal.rpow_le_rpow (nnnorm_add_le (f a) (g a)) (le_of_lt hp0_lt), },
-  refine lt_of_le_of_lt h_nnnorm_add_le _,
-  simp_rw [←ennreal.coe_rpow_of_nonneg _ hp0, ennreal.coe_add],
-  let f_nnnorm := (λ a : α, (nnnorm (f a) : ennreal)),
-  let g_nnnorm := (λ a : α, (nnnorm (g a) : ennreal)),
-  change ∫⁻ (a : α), ((f_nnnorm + g_nnnorm) a) ^ p ∂μ < ⊤,
-  exact ennreal.lintegral_rpow_add_lt_top_of_lintegral_rpow_lt_top hf.1.nnnorm.ennreal_coe hf.2
-    hg.1.nnnorm.ennreal_coe hg.2 hp1,
+  refine ⟨ae_measurable.add hf.1 hg.1, lt_of_le_of_lt (snorm_add_le hf.1 hg.1 hq1) _⟩,
+  rw ennreal.add_lt_top,
+  exact ⟨hf.2, hg.2⟩,
 end
 
-lemma mem_ℒp.sub {f g : α → E} (hf : mem_ℒp f p μ) (hg : mem_ℒp g p μ) (hp1 : 1 ≤ p) :
-  mem_ℒp (f-g) p μ :=
-by { rw sub_eq_add_neg, exact hf.add hg.neg hp1 }
+lemma mem_ℒp.sub {f g : α → E} (hf : mem_ℒp f q μ) (hg : mem_ℒp g q μ) (hq1 : 1 ≤ q) :
+  mem_ℒp (f-g) q μ :=
+by { rw sub_eq_add_neg, exact hf.add hg.neg hq1 }
 
 end second_countable_topology
 
+end borel_space
+
 section normed_space
 
-variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E]
+variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E] [opens_measurable_space E]
+  [normed_space 𝕜 F]
 
-lemma mem_ℒp.const_smul {f : α → E} (hfp : mem_ℒp f p μ) (c : 𝕜) (hp0 : 0 ≤ p) :
-  mem_ℒp (c • f) p μ :=
+lemma snorm'_const_smul {f : α → E} (hf : ae_measurable f μ) (c : 𝕜) (hp0_lt : 0 < p) :
+  snorm' (c • f) p μ = (nnnorm c : ennreal) * snorm' f p μ :=
 begin
-  split,
-  { exact ae_measurable.const_smul hfp.1 c, },
-  simp_rw [pi.smul_apply, nnnorm_smul, ennreal.coe_mul, ennreal.mul_rpow_of_nonneg _ _ hp0],
-  rw lintegral_const_mul'' _ hfp.1.nnnorm.ennreal_coe.ennreal_rpow_const,
-  exact ennreal.mul_lt_top (ennreal.rpow_lt_top_of_nonneg hp0 ennreal.coe_ne_top) hfp.2,
-end
-
-lemma snorm_const_smul {f : α → E} (hf : ae_measurable f μ) (c : 𝕜) (hp0_lt : 0 < p) :
-  snorm (c • f) p μ = (nnnorm c : ennreal) * snorm f p μ :=
-begin
-  rw snorm,
-  simp_rw [pi.smul_apply, nnnorm_smul, ennreal.coe_mul],
-  simp_rw ennreal.mul_rpow_of_nonneg _ _ (le_of_lt hp0_lt),
+  rw snorm',
+  simp_rw [pi.smul_apply, nnnorm_smul, ennreal.coe_mul,
+    ennreal.mul_rpow_of_nonneg _ _ (le_of_lt hp0_lt)],
   suffices h_integral : ∫⁻ a, ↑(nnnorm c) ^ p * ↑(nnnorm (f a)) ^ p ∂μ
     = (nnnorm c : ennreal)^p * ∫⁻ a, (nnnorm (f a)) ^ p ∂μ,
   { apply_fun (λ x, x ^ (1/p)) at h_integral,
@@ -393,19 +565,38 @@ begin
   rw lintegral_const_mul'' _ hf.nnnorm.ennreal_coe.ennreal_rpow_const,
 end
 
-lemma snorm_smul_le_mul_snorm [measurable_space 𝕜] [opens_measurable_space 𝕜] {q r : ℝ}
+lemma snorm_inf_const_smul {f : α → F} (c : 𝕜) :
+  snorm_inf (c • f) μ = (nnnorm c : ennreal) * snorm_inf f μ :=
+by simp_rw [snorm_inf,  pi.smul_apply, nnnorm_smul, ennreal.coe_mul, ennreal.ess_sup_const_mul]
+
+lemma snorm_const_smul {f : α → E} (hf : ae_measurable f μ) (c : 𝕜) :
+  snorm (c • f) q μ = (nnnorm c : ennreal) * snorm f q μ :=
+begin
+  by_cases h0 : q = 0,
+  { simp [h0], },
+  by_cases h_top : q = ⊤,
+  { simp [h_top, snorm_eq_snorm_inf, snorm_inf_const_smul], },
+  repeat { rw snorm_eq_snorm' h0 h_top, },
+  rw ←ne.def at h0,
+  exact snorm'_const_smul hf c
+    (ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) h0.symm, h_top⟩),
+end
+
+lemma mem_ℒp.const_smul [borel_space E] {f : α → E} (hf : mem_ℒp f q μ) (c : 𝕜) :
+  mem_ℒp (c • f) q μ :=
+⟨ae_measurable.const_smul hf.1 c,
+  lt_of_le_of_lt (le_of_eq (snorm_const_smul hf.1 c)) (ennreal.mul_lt_top ennreal.coe_lt_top hf.2)⟩
+
+lemma snorm'_smul_le_mul_snorm' [measurable_space 𝕜] [opens_measurable_space 𝕜] {q r : ℝ}
   {f : α → E} (hf : ae_measurable f μ) {φ : α → 𝕜} (hφ : ae_measurable φ μ)
   (hp0_lt : 0 < p) (hpq : p < q) (hpqr : 1/p = 1/q + 1/r) :
-  snorm (φ • f) p μ ≤ snorm φ q μ * snorm f r μ :=
+  snorm' (φ • f) p μ ≤ snorm' φ q μ * snorm' f r μ :=
 begin
-  rw snorm,
-  simp_rw [pi.smul_apply', nnnorm_smul, ennreal.coe_mul],
+  simp_rw [snorm', pi.smul_apply', nnnorm_smul, ennreal.coe_mul],
   exact ennreal.lintegral_Lp_mul_le_Lq_mul_Lr hp0_lt hpq hpqr μ hφ.nnnorm.ennreal_coe
     hf.nnnorm.ennreal_coe,
 end
 
 end normed_space
-
-end borel_space
 
 end ℒp_space


### PR DESCRIPTION
Rename the seminorm with real exponent to `snorm'`, introduce `snorm_ess_sup` for `L\infty`, equal to the essential supremum of the norm.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
