### PR TITLE
[Merged by Bors] - fix(scripts): fix mixing absolute and relative paths to the linter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
+
+      - name: sanity check the linter
+        run: |
+          ./scripts/lint_style_sanity_test.py
 
       - name: lint
         run: |

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -3,8 +3,6 @@
 from pathlib import Path
 import sys
 
-fns = sys.argv[1:]
-
 ERR_COP = 0 # copyright header
 ERR_IMP = 1 # import statements
 ERR_MOD = 2 # module docstring
@@ -22,22 +20,22 @@ RESERVED_NOTATION = ROOT_DIR / 'src/tactic/reserved_notation.lean'
 
 with SCRIPTS_DIR.joinpath("style-exceptions.txt").open() as f:
     for line in f:
-        fn, _, _, _, _, errno, *_ = line.split()
-        fn = ROOT_DIR / fn
+        filename, _, _, _, _, errno, *_ = line.split()
+        path = ROOT_DIR / filename
         if errno == "ERR_COP":
-            exceptions += [(ERR_COP, fn)]
+            exceptions += [(ERR_COP, path)]
         if errno == "ERR_IMP":
-            exceptions += [(ERR_IMP, fn)]
+            exceptions += [(ERR_IMP, path)]
         if errno == "ERR_MOD":
-            exceptions += [(ERR_MOD, fn)]
+            exceptions += [(ERR_MOD, path)]
         if errno == "ERR_LIN":
-            exceptions += [(ERR_LIN, fn)]
+            exceptions += [(ERR_LIN, path)]
         if errno == "ERR_SAV":
-            exceptions += [(ERR_SAV, fn)]
+            exceptions += [(ERR_SAV, path)]
         if errno == "ERR_RNT":
-            exceptions += [(ERR_RNT, fn)]
+            exceptions += [(ERR_RNT, path)]
         if errno == "ERR_OPT":
-            exceptions += [(ERR_OPT, fn)]
+            exceptions += [(ERR_OPT, path)]
 
 new_exceptions = False
 
@@ -78,43 +76,43 @@ def skip_string(enumerate_lines):
                 continue
         yield line_nr, line
 
-def small_alpha_vrachy_check(lines, fn):
+def small_alpha_vrachy_check(lines, path):
     errors = []
     for line_nr, line in skip_string(skip_comments(enumerate(lines, 1))):
         if 'ᾰ' in line:
-            errors += [(ERR_SAV, line_nr, fn)]
+            errors += [(ERR_SAV, line_nr, path)]
     return errors
 
-def reserved_notation_check(lines, fn):
-    if fn.resolve() == RESERVED_NOTATION:
+def reserved_notation_check(lines, path):
+    if path.resolve() == RESERVED_NOTATION:
         return []
     errors = []
     for line_nr, line in skip_string(skip_comments(enumerate(lines, 1))):
         if line.startswith('reserve') or line.startswith('precedence'):
-            errors += [(ERR_RNT, line_nr, fn)]
+            errors += [(ERR_RNT, line_nr, path)]
     return errors
 
-def set_option_check(lines, fn):
+def set_option_check(lines, path):
     errors = []
     for line_nr, line in skip_string(skip_comments(enumerate(lines, 1))):
         if line.startswith('set_option'):
             next_two_chars = line.split(' ')[1][:2]
             # forbidden options: pp, profiler, trace
             if next_two_chars == 'pp' or next_two_chars == 'pr' or next_two_chars == 'tr':
-                errors += [(ERR_OPT, line_nr, fn)]
+                errors += [(ERR_OPT, line_nr, path)]
     return errors
 
-def long_lines_check(lines, fn):
+def long_lines_check(lines, path):
     errors = []
     # TODO: some string literals (in e.g. tactic output messages) can be excepted from this rule
     for line_nr, line in enumerate(lines, 1):
         if "http" in line:
             continue
         if len(line) > 101:
-            errors += [(ERR_LIN, line_nr, fn)]
+            errors += [(ERR_LIN, line_nr, path)]
     return errors
 
-def import_only_check(lines, fn):
+def import_only_check(lines, path):
     import_only_file = True
     errors = []
     for line_nr, line in skip_comments(enumerate(lines, 1)):
@@ -128,10 +126,10 @@ def import_only_check(lines, fn):
             if imports[2] == "--":
                 continue
             else:
-                errors += [(ERR_IMP, line_nr, fn)]
+                errors += [(ERR_IMP, line_nr, path)]
     return (import_only_file, errors)
 
-def regular_check(lines, fn):
+def regular_check(lines, path):
     errors = []
     copy_started = False
     copy_done = False
@@ -139,79 +137,79 @@ def regular_check(lines, fn):
     copy_lines = ""
     for line_nr, line in enumerate(lines, 1):
         if not copy_started and line == "\n":
-            errors += [(ERR_COP, copy_start_line_nr, fn)]
+            errors += [(ERR_COP, copy_start_line_nr, path)]
             continue
         if not copy_started and line == "/-\n":
             copy_started = True
             copy_start_line_nr = line_nr
             continue
         if not copy_started:
-            errors += [(ERR_COP, line_nr, fn)]
+            errors += [(ERR_COP, line_nr, path)]
         if copy_started and not copy_done:
             copy_lines += line
             if line == "-/\n":
                 if ((not "Copyright" in copy_lines) or
                     (not "Apache" in copy_lines) or
                     (not "Author" in copy_lines)):
-                    errors += [(ERR_COP, copy_start_line_nr, fn)]
+                    errors += [(ERR_COP, copy_start_line_nr, path)]
                 copy_done = True
             continue
         if copy_done and line == "\n":
             continue
         words = line.split()
         if words[0] != "import" and words[0] != "/-!":
-            errors += [(ERR_MOD, line_nr, fn)]
+            errors += [(ERR_MOD, line_nr, path)]
             break
         if words[0] == "/-!":
             break
         # final case: words[0] == "import"
         if len(words) > 2:
             if words[2] != "--":
-                errors += [(ERR_IMP, line_nr, fn)]
+                errors += [(ERR_IMP, line_nr, path)]
     return errors
 
 def format_errors(errors):
     global new_exceptions
-    for (errno, line_nr, fn) in errors:
-        if (errno, fn.resolve()) in exceptions:
+    for (errno, line_nr, path) in errors:
+        if (errno, path.resolve()) in exceptions:
             continue
         new_exceptions = True
         # filename first, then line so that we can call "sort" on the output
         if errno == ERR_COP:
-            print("{} : line {} : ERR_COP : Malformed or missing copyright header".format(fn, line_nr))
+            print("{} : line {} : ERR_COP : Malformed or missing copyright header".format(path, line_nr))
         if errno == ERR_IMP:
-            print("{} : line {} : ERR_IMP : More than one file imported per line".format(fn, line_nr))
+            print("{} : line {} : ERR_IMP : More than one file imported per line".format(path, line_nr))
         if errno == ERR_MOD:
-            print("{} : line {} : ERR_MOD : Module docstring missing, or too late".format(fn, line_nr))
+            print("{} : line {} : ERR_MOD : Module docstring missing, or too late".format(path, line_nr))
         if errno == ERR_LIN:
-            print("{} : line {} : ERR_LIN : Line has more than 100 characters".format(fn, line_nr))
+            print("{} : line {} : ERR_LIN : Line has more than 100 characters".format(path, line_nr))
         if errno == ERR_SAV:
-            print("{} : line {} : ERR_SAV : File contains the character ᾰ".format(fn, line_nr))
+            print("{} : line {} : ERR_SAV : File contains the character ᾰ".format(path, line_nr))
         if errno == ERR_RNT:
-            print("{} : line {} : ERR_RNT : Reserved notation outside tactic.reserved_notation".format(fn, line_nr))
+            print("{} : line {} : ERR_RNT : Reserved notation outside tactic.reserved_notation".format(path, line_nr))
         if errno == ERR_OPT:
-            print("{} : line {} : ERR_OPT : Forbidden set_option command".format(fn, line_nr))
+            print("{} : line {} : ERR_OPT : Forbidden set_option command".format(path, line_nr))
 
-def lint(fn):
-    with fn.open() as f:
+def lint(path):
+    with path.open() as f:
         lines = f.readlines()
-        errs = long_lines_check(lines, fn)
+        errs = long_lines_check(lines, path)
         format_errors(errs)
-        (b, errs) = import_only_check(lines, fn)
+        (b, errs) = import_only_check(lines, path)
         if b:
             format_errors(errs)
             return
-        errs = regular_check(lines, fn)
+        errs = regular_check(lines, path)
         format_errors(errs)
-        errs = small_alpha_vrachy_check(lines, fn)
+        errs = small_alpha_vrachy_check(lines, path)
         format_errors(errs)
-        errs = reserved_notation_check(lines, fn)
+        errs = reserved_notation_check(lines, path)
         format_errors(errs)
-        errs = set_option_check(lines, fn)
+        errs = set_option_check(lines, path)
         format_errors(errs)
 
-for fn in fns:
-    lint(Path(fn))
+for filename in sys.argv[1:]:
+    lint(Path(filename))
 
 # if "exceptions" is empty,
 # we're trying to generate style-exceptions.txt,

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -9,7 +9,7 @@ Sample usage:
 which will lint all of the Lean files in the specified directories.
 
 The resulting error output will contain one line for each style error
-encountered.
+encountered that isn't in the list of allowed / ignored style exceptions.
 
 Paths with no errors will not appear in the output, and the script will
 exit with successful return code if there are no errors encountered in
@@ -22,8 +22,10 @@ that contain the relative path, whilst linting absolute paths (like
 ``/root/mathlib/src/foo/bar.lean``) will produce errors with the
 absolute path.
 
-This script may also be used (with no arguments) to update the list of
-allowed / ignored style exceptions, normally found alongside this file.
+This script can also be used to regenerate the list of allowed / ignored style
+exceptions by redirecting the output to ``style-exceptions.txt``:
+
+    $ ./scripts/lint-style.py $(find src archive -name '*.lean') > scripts/style-exceptions.txt
 """
 
 from pathlib import Path

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -1,4 +1,30 @@
 #!/usr/bin/env python3
+"""
+Lint a file or files from mathlib for style.
+
+Sample usage:
+
+    $ ./scripts/lint-style.py $(find src archive -name '*.lean')
+
+which will lint all of the Lean files in the specified directories.
+
+The resulting error output will contain one line for each style error
+encountered.
+
+Paths with no errors will not appear in the output, and the script will
+exit with successful return code if there are no errors encountered in
+any provided paths.
+
+Paths emitted in the output will match the paths provided on the
+command line for any files containing errors -- in particular, linting
+a relative path (like ``src/foo/bar.lean``) will produce errors
+that contain the relative path, whilst linting absolute paths (like
+``/root/mathlib/src/foo/bar.lean``) will produce errors with the
+absolute path.
+
+This script may also be used (with no arguments) to update the list of
+allowed / ignored style exceptions, normally found alongside this file.
+"""
 
 from pathlib import Path
 import sys

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -15,13 +15,15 @@ ERR_OPT = 6 # set_option
 
 exceptions = []
 
-SCRIPTS_DIR = Path(__file__).parent
+SCRIPTS_DIR = Path(__file__).parent.resolve()
 ROOT_DIR = SCRIPTS_DIR.parent
+RESERVED_NOTATION = ROOT_DIR / 'src/tactic/reserved_notation.lean'
+
 
 with SCRIPTS_DIR.joinpath("style-exceptions.txt").open() as f:
     for line in f:
         fn, _, _, _, _, errno, *_ = line.split()
-        fn = Path(fn)
+        fn = ROOT_DIR / fn
         if errno == "ERR_COP":
             exceptions += [(ERR_COP, fn)]
         if errno == "ERR_IMP":
@@ -84,7 +86,7 @@ def small_alpha_vrachy_check(lines, fn):
     return errors
 
 def reserved_notation_check(lines, fn):
-    if fn.relative_to(ROOT_DIR) == Path('src/tactic/reserved_notation.lean'):
+    if fn.resolve() == RESERVED_NOTATION:
         return []
     errors = []
     for line_nr, line in skip_string(skip_comments(enumerate(lines, 1))):
@@ -171,7 +173,7 @@ def regular_check(lines, fn):
 def format_errors(errors):
     global new_exceptions
     for (errno, line_nr, fn) in errors:
-        if (errno, Path(fn).relative_to(ROOT_DIR)) in exceptions:
+        if (errno, fn.resolve()) in exceptions:
             continue
         new_exceptions = True
         # filename first, then line so that we can call "sort" on the output

--- a/scripts/lint_style_sanity_test.py
+++ b/scripts/lint_style_sanity_test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+import subprocess
+import unittest
+
+
+SCRIPTS_DIR = Path(__file__).parent.resolve()
+ROOT_DIR = SCRIPTS_DIR.parent
+
+
+class TestLinterIntegration(unittest.TestCase):
+    def test_path_combinations(self):
+        """
+        The linter can be run with absolute or relative paths.
+
+        This works both for the executable itself as well as any provided
+        files.
+        """
+
+        new_file = ROOT_DIR / "src/somenewfile.lean"
+        self.assertFalse(new_file.is_file())
+        new_file.write_text("example : 2 = 2\n")
+        self.addCleanup(new_file.unlink)
+
+        exceptions = SCRIPTS_DIR.joinpath("style-exceptions.txt")
+        self.assertTrue(exceptions.is_file)
+        self.addCleanup(exceptions.write_text, exceptions.read_text())
+        subprocess.run(
+            ["./scripts/update-style-exceptions.sh"],
+            check=True,
+            capture_output=True,
+            cwd=ROOT_DIR,
+        )
+
+        combinations = [
+            (
+                ("relative", "./lint-style.py"),
+                ("relative", "../src/somenewfile.lean"),
+                ("cwd", SCRIPTS_DIR),
+            ), (
+                ("relative", "./lint-style.py"),
+                ("absolute", (ROOT_DIR / "src/somenewfile.lean").resolve()),
+                ("cwd", SCRIPTS_DIR),
+            ), (
+                ("absolute", (SCRIPTS_DIR / "lint-style.py").resolve()),
+                ("relative", "../src/somenewfile.lean"),
+                ("cwd", SCRIPTS_DIR),
+            ), (
+                ("absolute", (SCRIPTS_DIR / "lint-style.py").resolve()),
+                ("absolute", (ROOT_DIR / "src/somenewfile.lean").resolve()),
+                ("cwd", SCRIPTS_DIR),
+            ), (
+                ("absolute", (SCRIPTS_DIR / "lint-style.py").resolve()),
+                ("absolute", (ROOT_DIR / "src/somenewfile.lean").resolve()),
+                ("cwd", Path.home()),
+            ),
+        ]
+
+        for (
+            (linter_kind, linter_path),
+            (file_kind, file_path),
+            (_, cwd),
+        ) in combinations:
+            with self.subTest(
+                linter_kind=linter_kind,
+                file_kind=file_kind,
+                cwd=cwd,
+            ):
+                subprocess.run([linter_path, file_path], check=True, cwd=cwd)
+
+    def test_it_fails_for_missing_copyright_headers(self):
+        """
+        Failing to include a copyright header at the top of a file warns.
+        """
+        with NamedTemporaryFile(suffix=".lean") as file:
+            file.write(b"example : 37 = 37\n")
+            file.flush()
+            result = subprocess.run(
+                [SCRIPTS_DIR / "lint-style.py", file.name],
+                capture_output=True,
+            )
+        self.assertIn(b"ERR_COP :", result.stdout)
+
+    def test_reserved_notation_is_allowed_in_reserved_notation(self):
+        """
+        reserved_notation.lean is the one file that may reserve notation.
+        """
+        result = subprocess.run(
+            [
+                SCRIPTS_DIR / "lint-style.py",
+                ROOT_DIR / "src/tactic/reserved_notation.lean",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        self.assertNotIn(b"reserved notation", result.stdout)
+        self.assertNotIn(b"reserved notation", result.stderr)
+        self.assertNotIn(b"ERR_RNT", result.stdout)
+        self.assertNotIn(b"ERR_RNT", result.stderr)
+
+    def test_reserved_notation_is_allowed_in_relative_reserved_notation(self):
+        """
+        reserved_notation.lean should allow reserving notation even when
+        checked via a relative path.
+        """
+        result = subprocess.run(
+            [
+                "./scripts/lint-style.py",
+                "src/tactic/reserved_notation.lean",
+            ],
+            capture_output=True,
+            cwd=ROOT_DIR,
+        )
+        self.assertNotIn(b"reserved notation", result.stdout)
+        self.assertNotIn(b"reserved notation", result.stderr)
+        self.assertNotIn(b"ERR_RNT", result.stdout)
+        self.assertNotIn(b"ERR_RNT", result.stderr)
+
+    def test_updating_style_exceptions_uses_relative_paths(self):
+        """
+        The scripts/update-style-exceptions.sh file updates style exceptions.
+
+        It emits relative paths when doing so, since the file will be synced
+        with other remote machines with different filesystems.
+        """
+        exceptions = SCRIPTS_DIR.joinpath("style-exceptions.txt")
+        self.assertTrue(exceptions.is_file)
+        current_contents = exceptions.read_text()
+        self.assertNotIn(str(ROOT_DIR), current_contents)
+        self.addCleanup(exceptions.write_text, current_contents)
+
+        result = subprocess.run(
+            ["./scripts/update-style-exceptions.sh"],
+            check=True,
+            capture_output=True,
+            cwd=ROOT_DIR,
+        )
+        self.assertNotIn(
+            str(ROOT_DIR),
+            SCRIPTS_DIR.joinpath("style-exceptions.txt").read_text(),
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fix providing either relative or absolute paths to the linter.

Make the linter emit outputted paths corresponding to the ones passed on the command line -- relative if relative, absolute if absolute.

Also adds a short set of tests.

Reported in: https://leanprover.zulipchat.com/#narrow/stream/208328-IMO-grand-challenge/topic/2013.20Q5 (and introduced in #5721).