### PR TITLE
[Merged by Bors] - chore(data/list/range): Add range_zero and rename range_concat to range_succ

### DIFF
--- a/src/computability/partrec.lean
+++ b/src/computability/partrec.lean
@@ -601,7 +601,7 @@ option_some_iff.1 $
     (to₂ $ list_concat.comp (snd.comp fst) snd))).of_eq $
 λ a, begin
   simp, induction a.2 with n IH, {refl},
-  simp [IH, H, list.range_concat]
+  simp [IH, H, list.range_succ]
 end
 
 theorem list_of_fn : ∀ {n} {f : fin n → α → σ},

--- a/src/computability/primrec.lean
+++ b/src/computability/primrec.lean
@@ -963,7 +963,7 @@ theorem list_map
 theorem list_range : primrec list.range :=
 (nat_elim' primrec.id (const [])
   ((list_concat.comp snd fst).comp snd).to₂).of_eq $
-λ n, by simp; induction n; simp [*, list.range_concat]; refl
+λ n, by simp; induction n; simp [*, list.range_succ]; refl
 
 theorem list_join : primrec (@list.join α) :=
 (list_foldr primrec.id (const []) $ to₂ $
@@ -1003,7 +1003,7 @@ primrec₂.option_some_iff.1 $
     (to₂ $ list_concat.comp (snd.comp fst) snd))).of_eq $
 λ a n, begin
   simp, induction n with n IH, {refl},
-  simp [IH, H, list.range_concat]
+  simp [IH, H, list.range_succ]
 end
 
 end primrec

--- a/src/data/list/range.lean
+++ b/src/data/list/range.lean
@@ -130,8 +130,10 @@ by simp only [succ_pos', lt_add_iff_pos_right, mem_range]
 theorem nth_range {m n : ℕ} (h : m < n) : nth (range n) m = some m :=
 by simp only [range_eq_range', nth_range' _ h, zero_add]
 
-theorem range_concat (n : ℕ) : range (succ n) = range n ++ [n] :=
+theorem range_succ (n : ℕ) : range (succ n) = range n ++ [n] :=
 by simp only [range_eq_range', range'_concat, zero_add]
+
+@[simp] lemma range_zero : range 0 = [] := rfl
 
 theorem iota_eq_reverse_range' : ∀ n : ℕ, iota n = reverse (range' 1 n)
 | 0     := rfl
@@ -180,7 +182,7 @@ by rw [← length_eq_zero, length_fin_range]
 @[to_additive]
 theorem prod_range_succ {α : Type u} [monoid α] (f : ℕ → α) (n : ℕ) :
   ((range n.succ).map f).prod = ((range n).map f).prod * f n :=
-by rw [range_concat, map_append, map_singleton,
+by rw [range_succ, map_append, map_singleton,
   prod_append, prod_cons, prod_nil, mul_one]
 
 /-- A variant of `prod_range_succ` which pulls off the first

--- a/src/data/multiset/range.lean
+++ b/src/data/multiset/range.lean
@@ -19,7 +19,7 @@ def range (n : ℕ) : multiset ℕ := range n
 @[simp] theorem range_zero : range 0 = 0 := rfl
 
 @[simp] theorem range_succ (n : ℕ) : range (succ n) = n ::ₘ range n :=
-by rw [range, range_concat, ← coe_add, add_comm]; refl
+by rw [range, range_succ, ← coe_add, add_comm]; refl
 
 @[simp] theorem card_range (n : ℕ) : card (range n) = n := length_range _
 


### PR DESCRIPTION
The name `range_concat` was derived from `range'_concat`, where there are multiple possible expansions for `range' s n.succ`.
For `range` there is only one choice, and naming the lemma after the result rather than the statement makes it harder to find.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
