### PR TITLE
feat(order/complete_well_founded, data/finset/lattice): introduce compact elements of a complete lattice and characterize compact lattices as those with all elements compact

### DIFF
--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -119,6 +119,34 @@ begin
     { rw [finset.sup_insert, id.def], exact h h_subset.1 (h₁ htne h_subset.2), }, },
 end
 
+lemma sup_le_of_le_directed {α : Type*} [complete_lattice α] (s : set α)
+  (hdir : directed_on (≤) s) (t : finset α) :
+  t.nonempty → (∀ x ∈ t, ∃ y ∈ s, x ≤ y) → ∃ x, x ∈ s ∧ t.sup id ≤ x :=
+begin
+  classical,
+  apply finset.induction_on t,
+  { simp only [forall_prop_of_false, not_nonempty_empty, not_false_iff], },
+  { intros a s has ih,
+    by_cases hs : s.nonempty,
+    { intros _ as_below,
+      have incs : ↑s ⊆ ↑(insert a s), by { rw finset.coe_subset, apply finset.subset_insert, },
+      rcases (ih hs (set.subset.trans incs as_below)) with ⟨x, ⟨hxs, hsx_sup⟩⟩,
+      rcases (as_below a (finset.mem_insert_self a s)) with ⟨y, hys, hsy⟩,
+      rcases (hdir x hxs y hys) with ⟨z, hzs, ⟨hxz, hyz⟩⟩,
+      use z,
+      simp only [id.def, _root_.sup_le_iff, sup_le_iff, sup_insert],
+      refine ⟨hzs, ⟨le_trans hsy hyz, _⟩⟩,
+      intros b hb,
+      transitivity (s.sup id),
+      { exact le_sup hb },
+      { exact le_trans hsx_sup hxz }, },
+    { rw finset.nonempty_iff_ne_empty at hs,
+      push_neg at hs,
+      simp only [hs, and_imp, insert_emptyc_eq, forall_prop_of_true, exists_prop, id.def, forall_eq, singleton_nonempty, sup_singleton,
+        exists_imp_distrib, mem_singleton],
+      exact λ x hx hax, ⟨x, ⟨hx, hax⟩⟩, }, },
+end
+
 end sup
 
 lemma sup_eq_supr [complete_lattice β] (s : finset α) (f : α → β) : s.sup f = (⨆a∈s, f a) :=

--- a/src/order/complete_well_founded.lean
+++ b/src/order/complete_well_founded.lean
@@ -49,6 +49,61 @@ same `Sup`. -/
 def is_Sup_finite_compact : Prop :=
 ∀ (s : set α), ∃ (t : finset α), ↑t ⊆ s ∧ Sup s = t.sup id
 
+/-- An element k of a complete lattice is said to be compact if any set that Sups
+above k has a finite subset that Sups above k -/
+def is_compact_element {α : Type*} [complete_lattice α] (k : α) :=
+∀ s : set α, k ≤ Sup s → ∃ t : finset α, ↑t ⊆ s ∧ k ≤ t.sup id
+
+/-- An equivalent characterization of a compact element k is that any directed
+that Sups above k must get above k at some point in the set -/
+theorem is_compact_element_iff_directed_Sup_finite (k : α) :
+  is_compact_element k ↔ ∀ s : set α, s.nonempty → directed_on (≤) s → k ≤ Sup s → ∃ x : α, x ∈ s ∧ k ≤ x :=
+begin
+  classical,
+  split,
+  { by_cases hbot : k = ⊥,
+    -- Any nonempty directed set certainly sups above ⊥
+    { rintros _ _ ⟨x, hx⟩ _ _, use x, by simp[hx, hbot], },
+    { intros hk s hne hdir hsup,
+      cases (hk s hsup) with t ht,
+      -- If t were empty, it would sup to ⊥, which is not above k ≠ ⊥.
+      have tne : t.nonempty,
+      { by_contradiction n,
+        rw [finset.nonempty_iff_ne_empty, not_not] at n,
+        simp only [n, true_and, set.empty_subset, finset.coe_empty, finset.sup_empty, le_bot_iff] at ht,
+        exact absurd ht hbot, },
+      -- certainly ↑t ⊆ s, so every element of t is below something in s, to apply finset_sup_of_directed_on
+      have t_below_s : ∀ x ∈ t, ∃ y ∈ s, x ≤ y, from λ x hxt, ⟨x, ht.left hxt, by refl⟩,
+      rcases (finset.sup_le_of_le_directed s hdir t tne t_below_s) with ⟨x, ⟨hxs, hsupx⟩⟩,
+      exact ⟨x, ⟨hxs, le_trans k (t.sup id) x ht.right hsupx⟩⟩, }, },
+  { intros hk s hsup,
+    -- Consider the set of finite joins of elements of the (plain) set s.
+    let S : set α := { x | ∃ t : finset α, ↑t ⊆ s ∧ x = t.sup id },
+    -- S is directed, nonempty, and still sups above k.
+    have dir_US : directed_on (≤) S,
+    { intros x hx y hy,
+      cases hx with c hc,
+      cases hy with d hd,
+      use x ⊔ y,
+      split,
+      { use c ∪ d,
+        split,
+        { simp only [hc.left, hd.left, set.union_subset_iff, finset.coe_union, and_self], },
+        { simp only [hc.right, hd.right, finset.sup_union], }, },
+      simp only [and_self, le_sup_left, le_sup_right], },
+    have sup_S : Sup s ≤ Sup S,
+    { apply Sup_le_Sup,
+      intros x hx, use {x}, simpa, },
+    have Sne : S.nonempty,
+    { suffices : ⊥ ∈ S, from set.nonempty_of_mem this,
+      use ∅,
+      simp only [set.empty_subset, finset.coe_empty, finset.sup_empty, eq_self_iff_true, and_self], },
+    -- Now apply the defn of compact and finish.
+    rcases (hk S Sne dir_US (le_trans k (Sup s) (Sup S) hsup sup_S)) with ⟨j, ⟨hjS, hjk⟩⟩,
+    rcases hjS with ⟨t, ⟨htS, htsup⟩⟩,
+    use t, exact ⟨htS, by rwa ←htsup⟩, },
+end
+
 lemma well_founded.is_Sup_finite_compact (h : well_founded ((>) : α → α → Prop)) :
   is_Sup_finite_compact α :=
 begin
@@ -88,12 +143,36 @@ begin
   { rintros x y ⟨m, hm⟩ ⟨n, hn⟩, use m ⊔ n, rw [← hm, ← hn], apply a.to_rel_hom.map_sup, },
 end
 
+lemma all_elements_compact.is_Sup_finite_compact (h : ∀ k : α, is_compact_element k) :
+  is_Sup_finite_compact α :=
+begin
+  intro s,
+  rcases (h (Sup s) s (by refl)) with ⟨t, ⟨hts, htsup⟩⟩,
+  have : Sup s = t.sup id,
+  { suffices : t.sup id ≤ Sup s, by { apply le_antisymm; assumption },
+    simp only [id.def, finset.sup_le_iff],
+    intros x hx,
+    apply le_Sup, exact hts hx, },
+  use [t, hts], assumption,
+end
+
+lemma is_Sup_finite_compact.all_elements_compact (h : is_Sup_finite_compact α) :
+  ∀ k : α, is_compact_element k :=
+begin
+  intros k s hs,
+  rcases (h s) with ⟨t, ⟨hts, htsup⟩⟩,
+  use [t, hts],
+  rwa ←htsup,
+end
+
 lemma well_founded_characterisations :
-  tfae [well_founded ((>) : α → α → Prop), is_Sup_finite_compact α, is_sup_closed_compact α] :=
+  tfae [well_founded ((>) : α → α → Prop), is_Sup_finite_compact α, is_sup_closed_compact α, ∀ k : α, is_compact_element k] :=
 begin
   tfae_have : 1 → 2, by { exact well_founded.is_Sup_finite_compact α, },
   tfae_have : 2 → 3, by { exact is_Sup_finite_compact.is_sup_closed_compact α, },
   tfae_have : 3 → 1, by { exact is_sup_closed_compact.well_founded α, },
+  tfae_have : 2 → 4, by { exact is_Sup_finite_compact.all_elements_compact α },
+  tfae_have : 4 → 2, by { exact all_elements_compact.is_Sup_finite_compact α },
   tfae_finish,
 end
 
@@ -109,9 +188,14 @@ lemma is_sup_closed_compact_iff_well_founded :
   is_sup_closed_compact α ↔ well_founded ((>) : α → α → Prop) :=
 (well_founded_characterisations α).out 2 0
 
+lemma is_Sup_finite_compact_iff_all_elements_compact :
+  is_Sup_finite_compact α ↔ ∀ k : α, is_compact_element k :=
+(well_founded_characterisations α).out 1 3
+
 alias well_founded_iff_is_Sup_finite_compact ↔ _ is_Sup_finite_compact.well_founded
 alias is_Sup_finite_compact_iff_is_sup_closed_compact ↔
       _ is_sup_closed_compact.is_Sup_finite_compact
 alias is_sup_closed_compact_iff_well_founded ↔ _ well_founded.is_sup_closed_compact
+alias is_Sup_finite_compact_iff_all_elements_compact ↔ _ all_elements_compact.is_Sup_finite_compact
 
 end complete_lattice


### PR DESCRIPTION
Provide a definition of compact elements. Prove the equivalence of two characterizations of compact elements. Add "all elements are compact" to the equivalent characterizations of compact lattices. Introduce an auxiliary lemma about finite sups and directed sets.

<!--
A reference for the two equivalent definitions of compact element can be found [here](https://ncatlab.org/nlab/show/compact+element+in+a+lattice)
-->
