### PR TITLE
[Merged by Bors] - fix(tactic/default): make field_simp work with import tactic

### DIFF
--- a/src/tactic/default.lean
+++ b/src/tactic/default.lean
@@ -35,3 +35,4 @@ import tactic.cancel_denoms
 import tactic.zify
 import tactic.transport
 import tactic.unfold_cases
+import tactic.field_simp


### PR DESCRIPTION
---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

For some reason, `field_simp` is not available after using `import tactic`; this should fix that.