### PR TITLE
[Merged by Bors] - chore(data/finsupp,data/dfinsupp,algebra/big_operators): add missing lemmas about sums of bundled functions

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -133,6 +133,16 @@ lemma ring_hom.map_sum [semiring β] [semiring γ]
   g (∑ x in s, f x) = ∑ x in s, g (f x) :=
 g.to_add_monoid_hom.map_sum f s
 
+@[to_additive]
+lemma monoid_hom.coe_prod [monoid β] [comm_monoid γ] (f : α → β →* γ) (s : finset α) :
+  ⇑(∏ x in s, f x) = ∏ x in s, f x :=
+(monoid_hom.coe_fn β γ).map_prod _ _
+
+@[simp, to_additive]
+lemma monoid_hom.finset_prod_apply [monoid β] [comm_monoid γ] (f : α → β →* γ) (s : finset α)
+  (b : β) : (∏ x in s, f x) b = ∏ x in s, f x b :=
+(monoid_hom.eval b).map_prod _ _
+
 namespace finset
 variables {s s₁ s₂ : finset α} {a : α} {f g : α → β}
 

--- a/src/algebra/big_operators/pi.lean
+++ b/src/algebra/big_operators/pi.lean
@@ -40,12 +40,6 @@ lemma fintype.prod_apply {α : Type*} {β : α → Type*} {γ : Type*} [fintype 
   [∀a, comm_monoid (β a)] (a : α) (g : γ → Πa, β a) : (∏ c, g c) a = ∏ c, g c a :=
 finset.prod_apply a finset.univ g
 
-@[simp, to_additive]
-lemma monoid_hom.finset_prod_apply {ι M N : Type*} [monoid M] [comm_monoid N] (f : ι → M →* N)
-  (s : finset ι) (a : M) :
-  (∏ i in s, f i) a = ∏ i in s, f i a :=
-(monoid_hom.eval a).map_prod _ _
-
 @[to_additive prod_mk_sum]
 lemma prod_mk_prod {α β γ : Type*} [comm_monoid α] [comm_monoid β] (s : finset γ)
   (f : γ → α) (g : γ → β) : (∏ x in s, f x, ∏ x in s, g x) = ∏ x in s, (f x, g x) :=

--- a/src/algebra/group/pi.lean
+++ b/src/algebra/group/pi.lean
@@ -103,6 +103,17 @@ def monoid_hom.apply (i : I) : (Π i, f i) →* f i :=
 lemma monoid_hom.apply_apply (i : I) (g : Π i, f i) :
   (monoid_hom.apply f i) g = g i := rfl
 
+/-- Coercion of a `monoid_hom` into a function is itself a `monoid_hom`.
+
+See also `monoid_hom.eval`. -/
+@[simps, to_additive "Coercion of an `add_monoid_hom` into a function is itself a `add_monoid_hom`.
+
+See also `add_monoid_hom.eval`. "]
+def monoid_hom.coe_fn (α β : Type*) [monoid α] [comm_monoid β] : (α →* β) →* (α → β) :=
+{ to_fun := λ g, g,
+  map_one' := rfl,
+  map_mul' := λ x y, rfl, }
+
 end monoid_hom
 
 section add_monoid_single

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -965,20 +965,17 @@ namespace monoid_hom
 variables {R S : Type*} [comm_monoid R] [comm_monoid S]
 variables [Π i, add_comm_monoid (β i)] [Π i (x : β i), decidable (x ≠ 0)]
 
-@[to_additive]
+@[simp, to_additive]
 lemma map_dfinsupp_prod (h : R →* S) (f : Π₀ i, β i) (g : Π i, β i → R) :
-  h (f.prod g) = f.prod (λ a b, h (g a b)) :=
-h.map_prod _ _
-
-@[to_additive]
-lemma dfinsupp_prod_apply (f : Π₀ i, β i) (g : Π i, β i → R →* S) (r : R) :
-  (f.prod g) r = f.prod (λ a b, (g a b) r) :=
-finset_prod_apply _ _ _
+  h (f.prod g) = f.prod (λ a b, h (g a b)) := h.map_prod _ _
 
 @[to_additive]
 lemma coe_dfinsupp_prod
-  (f : Π₀ i, β i) (g : Π i, β i → R →* S) : ⇑(f.prod g) = f.prod (λ a b, (g a b)) :=
-coe_prod _ _
+  (f : Π₀ i, β i) (g : Π i, β i → R →* S) : ⇑(f.prod g) = f.prod (λ a b, (g a b)) := coe_prod _ _
+
+@[simp, to_additive]
+lemma dfinsupp_prod_apply (f : Π₀ i, β i) (g : Π i, β i → R →* S) (r : R) :
+  (f.prod g) r = f.prod (λ a b, (g a b) r) := finset_prod_apply _ _ _
 
 end monoid_hom
 

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -3,10 +3,10 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau
 -/
-import algebra.module.linear_map
 import algebra.module.pi
 import algebra.big_operators.basic
 import data.set.finite
+import group_theory.submonoid.basic
 
 /-!
 # Dependent functions with finite support
@@ -955,3 +955,31 @@ subtype_domain_sum
 end prod_and_sum
 
 end dfinsupp
+
+/-! ### Product and sum lemmas for bundled morphisms -/
+section
+
+variables [decidable_eq ι]
+
+namespace monoid_hom
+variables {R S : Type*} [comm_monoid R] [comm_monoid S]
+variables [Π i, add_comm_monoid (β i)] [Π i (x : β i), decidable (x ≠ 0)]
+
+@[to_additive]
+lemma map_dfinsupp_prod (h : R →* S) (f : Π₀ i, β i) (g : Π i, β i → R) :
+  h (f.prod g) = f.prod (λ a b, h (g a b)) :=
+h.map_prod _ _
+
+@[to_additive]
+lemma dfinsupp_prod_apply (f : Π₀ i, β i) (g : Π i, β i → R →* S) (r : R) :
+  (f.prod g) r = f.prod (λ a b, (g a b) r) :=
+finset_prod_apply _ _ _
+
+@[to_additive]
+lemma coe_dfinsupp_prod
+  (f : Π₀ i, β i) (g : Π i, β i → R →* S) : ⇑(f.prod g) = f.prod (λ a b, (g a b)) :=
+coe_prod _ _
+
+end monoid_hom
+
+end

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -970,8 +970,8 @@ lemma map_dfinsupp_prod (h : R →* S) (f : Π₀ i, β i) (g : Π i, β i → R
   h (f.prod g) = f.prod (λ a b, h (g a b)) := h.map_prod _ _
 
 @[to_additive]
-lemma coe_dfinsupp_prod
-  (f : Π₀ i, β i) (g : Π i, β i → R →* S) : ⇑(f.prod g) = f.prod (λ a b, (g a b)) := coe_prod _ _
+lemma coe_dfinsupp_prod (f : Π₀ i, β i) (g : Π i, β i → R →* S) :
+  ⇑(f.prod g) = f.prod (λ a b, (g a b)) := coe_prod _ _
 
 @[simp, to_additive]
 lemma dfinsupp_prod_apply (f : Π₀ i, β i) (g : Π i, β i → R →* S) (r : R) :

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -792,7 +792,7 @@ h.map_prod _ _
 
 @[to_additive]
 lemma monoid_hom.coe_finsupp_prod [has_zero β] [monoid N] [comm_monoid P]
-  (f : α →₀ β) (g : α → β → N →* P) (x : N) :
+  (f : α →₀ β) (g : α → β → N →* P) :
   ⇑(f.prod g) = f.prod (λ i fi, g i fi) :=
 monoid_hom.coe_prod _ _
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -790,6 +790,18 @@ lemma ring_hom.map_finsupp_prod [has_zero M] [comm_semiring R] [comm_semiring S]
   (h : R →+* S) (f : α →₀ M) (g : α → M → R) : h (f.prod g) = f.prod (λ a b, h (g a b)) :=
 h.map_prod _ _
 
+@[to_additive]
+lemma monoid_hom.coe_finsupp_prod [has_zero β] [monoid N] [comm_monoid P]
+  (f : α →₀ β) (g : α → β → N →* P) (x : N) :
+  ⇑(f.prod g) = f.prod (λ i fi, g i fi) :=
+monoid_hom.coe_prod _ _
+
+@[simp, to_additive]
+lemma monoid_hom.finsupp_prod_apply [has_zero β] [monoid N] [comm_monoid P]
+  (f : α →₀ β) (g : α → β → N →* P) (x : N) :
+  f.prod g x = f.prod (λ i fi, g i fi x) :=
+monoid_hom.finset_prod_apply _ _ _
+
 namespace finsupp
 
 section nat_sub

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1241,36 +1241,33 @@ lemma ext_on_range {v : ι → M} {f g : M →ₗ[R] M₂} (hv : span R (set.ran
   (h : ∀i, f (v i) = g (v i)) : f = g :=
 ext_on hv (set.forall_range_iff.2 h)
 
-@[simp] lemma map_finsupp_sum {γ} [has_zero γ]
-  (f : M →ₗ[R] M₂) {t : ι →₀ γ} {g : ι → γ → M} :
+section finsupp
+variables {γ : Type*} [has_zero γ]
+
+@[simp] lemma map_finsupp_sum (f : M →ₗ[R] M₂) {t : ι →₀ γ} {g : ι → γ → M} :
   f (t.sum g) = t.sum (λ i d, f (g i d)) := f.map_sum
 
-lemma coe_finsupp_sum {γ} [has_zero γ]
-  (t : ι →₀ γ) (g : ι → γ → M →ₗ[R] M₂) (b : M) :
-  ⇑(t.sum g) = t.sum (λ i d, g i d) :=
-coe_fn_sum _ _
+lemma coe_finsupp_sum (t : ι →₀ γ) (g : ι → γ → M →ₗ[R] M₂) :
+  ⇑(t.sum g) = t.sum (λ i d, g i d) := coe_fn_sum _ _
 
-@[simp] lemma finsupp_sum_apply {γ} [has_zero γ]
-  (t : ι →₀ γ) (g : ι → γ → M →ₗ[R] M₂) (b : M) :
-  (t.sum g) b = t.sum (λ i d, g i d b) :=
-sum_apply _ _ _
+@[simp] lemma finsupp_sum_apply (t : ι →₀ γ) (g : ι → γ → M →ₗ[R] M₂) (b : M) :
+  (t.sum g) b = t.sum (λ i d, g i d b) := sum_apply _ _ _
 
-@[simp] lemma map_dfinsupp_sum
-  {γ : ι → Type*} [decidable_eq ι] [Π i, has_zero (γ i)] [Π i (x : γ i), decidable (x ≠ 0)]
-  (f : M →ₗ[R] M₂) {t : Π₀ i, γ i} {g : Π i, γ i → M} :
+end finsupp
+
+section dfinsupp
+variables {γ : ι → Type*} [decidable_eq ι] [Π i, has_zero (γ i)] [Π i (x : γ i), decidable (x ≠ 0)]
+
+@[simp] lemma map_dfinsupp_sum (f : M →ₗ[R] M₂) {t : Π₀ i, γ i} {g : Π i, γ i → M} :
   f (t.sum g) = t.sum (λ i d, f (g i d)) := f.map_sum
 
-lemma coe_dfinsupp_sum
-  {γ : ι → Type*} [decidable_eq ι] [Π i, has_zero (γ i)] [Π i (x : γ i), decidable (x ≠ 0)]
-  (t : Π₀ i, γ i) (g : Π i, γ i → M →ₗ[R] M₂) (b : M) :
-  ⇑(t.sum g) = t.sum (λ i d, g i d) :=
-coe_fn_sum _ _
+lemma coe_dfinsupp_sum (t : Π₀ i, γ i) (g : Π i, γ i → M →ₗ[R] M₂) :
+  ⇑(t.sum g) = t.sum (λ i d, g i d) := coe_fn_sum _ _
 
-@[simp] lemma dfinsupp_sum_apply
-  {γ : ι → Type*} [decidable_eq ι] [Π i, has_zero (γ i)] [Π i (x : γ i), decidable (x ≠ 0)]
-  (t : Π₀ i, γ i) (g : Π i, γ i → M →ₗ[R] M₂) (b : M) :
-  (t.sum g) b = t.sum (λ i d, g i d b) :=
-sum_apply _ _ _
+@[simp] lemma dfinsupp_sum_apply (t : Π₀ i, γ i) (g : Π i, γ i → M →ₗ[R] M₂) (b : M) :
+  (t.sum g) b = t.sum (λ i d, g i d b) := sum_apply _ _ _
+
+end dfinsupp
 
 theorem map_cod_restrict (p : submodule R M) (f : M₂ →ₗ[R] M) (h p') :
   submodule.map (cod_restrict p f h) p' = comap p.subtype (p'.map f) :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -9,6 +9,7 @@ import algebra.module.prod
 import algebra.module.submodule
 import algebra.group.prod
 import data.finsupp.basic
+import data.dfinsupp
 import algebra.pointwise
 
 /-!
@@ -1240,9 +1241,36 @@ lemma ext_on_range {v : ι → M} {f g : M →ₗ[R] M₂} (hv : span R (set.ran
   (h : ∀i, f (v i) = g (v i)) : f = g :=
 ext_on hv (set.forall_range_iff.2 h)
 
-@[simp] lemma finsupp_sum {γ} [has_zero γ]
+@[simp] lemma map_finsupp_sum {γ} [has_zero γ]
   (f : M →ₗ[R] M₂) {t : ι →₀ γ} {g : ι → γ → M} :
-  f (t.sum g) = t.sum (λi d, f (g i d)) := f.map_sum
+  f (t.sum g) = t.sum (λ i d, f (g i d)) := f.map_sum
+
+lemma coe_finsupp_sum {γ} [has_zero γ]
+  (t : ι →₀ γ) (g : ι → γ → M →ₗ[R] M₂) (b : M) :
+  ⇑(t.sum g) = t.sum (λ i d, g i d) :=
+coe_fn_sum _ _
+
+@[simp] lemma finsupp_sum_apply {γ} [has_zero γ]
+  (t : ι →₀ γ) (g : ι → γ → M →ₗ[R] M₂) (b : M) :
+  (t.sum g) b = t.sum (λ i d, g i d b) :=
+sum_apply _ _ _
+
+@[simp] lemma map_dfinsupp_sum
+  {γ : ι → Type*} [decidable_eq ι] [Π i, has_zero (γ i)] [Π i (x : γ i), decidable (x ≠ 0)]
+  (f : M →ₗ[R] M₂) {t : Π₀ i, γ i} {g : Π i, γ i → M} :
+  f (t.sum g) = t.sum (λ i d, f (g i d)) := f.map_sum
+
+lemma coe_dfinsupp_sum
+  {γ : ι → Type*} [decidable_eq ι] [Π i, has_zero (γ i)] [Π i (x : γ i), decidable (x ≠ 0)]
+  (t : Π₀ i, γ i) (g : Π i, γ i → M →ₗ[R] M₂) (b : M) :
+  ⇑(t.sum g) = t.sum (λ i d, g i d) :=
+coe_fn_sum _ _
+
+@[simp] lemma dfinsupp_sum_apply
+  {γ : ι → Type*} [decidable_eq ι] [Π i, has_zero (γ i)] [Π i (x : γ i), decidable (x ≠ 0)]
+  (t : Π₀ i, γ i) (g : Π i, γ i → M →ₗ[R] M₂) (b : M) :
+  (t.sum g) b = t.sum (λ i d, g i d b) :=
+sum_apply _ _ _
 
 theorem map_cod_restrict (p : submodule R M) (f : M₂ →ₗ[R] M) (h p') :
   submodule.map (cod_restrict p f h) p' = comap p.subtype (p'.map f) :=


### PR DESCRIPTION
This adds missing lemmas about how `{finset,finsupp,dfinsupp}.{prod,sum}` acts on {coercion,application,evaluation} of `{add_monoid_hom,monoid_hom,linear_map}`. Specifically, it:

* adds the lemmas:
  * `monoid_hom.coe_prod`
  * `monoid_hom.map_dfinsupp_prod`
  * `monoid_hom.dfinsupp_prod_apply`
  * `monoid_hom.finsupp_prod_apply`
  * `monoid_hom.coe_dfinsupp_prod`
  * `monoid_hom.coe_finsupp_prod`
  * that are the additive versions of the above for `add_monoid_hom`.
  * `linear_map.map_dfinsupp_sum`
  * `linear_map.dfinsupp_sum_apply`
  * `linear_map.finsupp_sum_apply`
  * `linear_map.coe_dfinsupp_sum`
  * `linear_map.coe_finsupp_sum`
* Renames `linear_map.finsupp_sum` to `linear_map.map_finsupp_sum` for consistency with `linear_map.map_sum`.
* Adds a new `monoid_hom.coe_fn` definition

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
#5851 was split out from an earlier version of this PR, but this PR no longer depends on it.

This follows up from #4585