### PR TITLE
[Merged by Bors] - chore(algebra/group_power): add `(a+b)^2=a^2+2ab+b^2`

### DIFF
--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -494,9 +494,9 @@ end
 
 end cancel_add_monoid
 
-section comm_semiring
+section semiring
 
-variables [comm_semiring R]
+variables [semiring R]
 
 lemma min_pow_dvd_add {n m : ℕ} {a b c : R} (ha : c ^ n ∣ a) (hb : c ^ m ∣ b) :
   c ^ (min n m) ∣ a + b :=
@@ -505,6 +505,15 @@ begin
   replace hb := dvd.trans (pow_dvd_pow c (min_le_right n m)) hb,
   exact dvd_add ha hb
 end
+
+end semiring
+
+section comm_semiring
+
+variables [comm_semiring R]
+
+lemma add_pow_two (a b : R) : (a + b) ^ 2 = a ^ 2 + 2 * a * b + b ^ 2 :=
+by simp only [pow_two, add_mul_self_eq]
 
 end comm_semiring
 

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -174,6 +174,9 @@ lemma even_iff_two_dvd {a : α} : even a ↔ 2 ∣ a := iff.rfl
 /-- An element `a` of a semiring is odd if there exists `k` such `a = 2*k + 1`. -/
 def odd (a : α) : Prop := ∃ k, a = 2*k + 1
 
+theorem dvd_add {a b c : α} (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
+dvd.elim h₁ (λ d hd, dvd.elim h₂ (λ e he, dvd.intro (d + e) (by simp [left_distrib, hd, he])))
+
 end semiring
 
 namespace add_monoid_hom
@@ -437,11 +440,7 @@ protected def function.surjective.comm_semiring [has_zero γ] [has_one γ] [has_
 { .. hf.semiring f zero one add mul, .. hf.comm_semigroup f mul }
 
 lemma add_mul_self_eq (a b : α) : (a + b) * (a + b) = a*a + 2*a*b + b*b :=
-calc (a + b)*(a + b) = a*a + (1+1)*a*b + b*b : by simp [add_mul, mul_add, mul_comm, add_assoc]
-              ...     = a*a + 2*a*b + b*b    : by rw one_add_one_eq_two
-
-theorem dvd_add (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
-dvd.elim h₁ (λ d hd, dvd.elim h₂ (λ e he, dvd.intro (d + e) (by simp [left_distrib, hd, he])))
+by simp only [two_mul, add_mul, mul_add, add_assoc, mul_comm b]
 
 @[simp] theorem two_dvd_bit0 : 2 ∣ bit0 a := ⟨a, bit0_eq_two_mul _⟩
 


### PR DESCRIPTION
Also generalize 2 lemmas from `comm_semiring` to `semiring`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->