### PR TITLE
chore(linear_algebra/basic): Rename `linear_map.applyₗ` to match `monoid_hom.eval`

### DIFF
--- a/src/analysis/calculus/fderiv_measurable.lean
+++ b/src/analysis/calculus/fderiv_measurable.lean
@@ -84,7 +84,7 @@ instance : borel_space (E →L[𝕜] F) := ⟨rfl⟩
 
 lemma measurable_apply [measurable_space F] [borel_space F] (x : E) :
   measurable (λ f : E →L[𝕜] F, f x) :=
-(apply 𝕜 F x).continuous.measurable
+(eval 𝕜 F x).continuous.measurable
 
 lemma measurable_apply' [measurable_space E] [opens_measurable_space E]
   [measurable_space F] [borel_space F] :

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -686,25 +686,22 @@ continuous_linear_map.homothety_norm _ c.norm_smul_right_apply
 
 variables (𝕜 F)
 
-/-- The linear map obtained by applying a continuous linear map at a given vector. -/
-def evalₗ (v : E) : (E →L[𝕜] F) →ₗ[𝕜] F :=
-{ to_fun := λ f, f v,
-  map_add' := λ f g, f.add_apply g v,
-  map_smul' := λ x f, f.smul_apply x v }
-
-lemma continuous_evalₗ (v : E) : continuous (continuous_linear_map.eval 𝕜 F v) :=
-begin
-  apply (continuous_linear_map.eval 𝕜 F v).continuous_of_bound,
-  intro f,
-  rw mul_comm,
-  exact f.le_op_norm v,
-end
-
 /-- The continuous linear map obtained by applying a continuous linear map at a given vector.
 
 This is the continuous version of `linear_map.eval`. -/
-def eval (v : E) : (E →L[𝕜] F) →L[𝕜] F :=
-⟨continuous_linear_map.eval 𝕜 F v, continuous_linear_map.continuous_eval _ _ _⟩
+def eval : E →ₗ[𝕜] (E →L[𝕜] F) →L[𝕜] F :=
+{ to_fun := λ v,
+  { to_fun := λ f, f v,
+    map_add' := λ f g, f.add_apply g v,
+    map_smul' := λ x f, f.smul_apply x v,
+    cont := begin
+      rw linear_map.to_fun_eq_coe,
+      refine linear_map.continuous_of_bound _ (∥v∥) (λ f, _),
+      rw mul_comm,
+      exact f.le_op_norm v,
+    end },
+  map_add' := λ _ _, ext $ λ f, f.map_add _ _,
+  map_smul' := λ _ _, ext $ λ f, f.map_smul _ _, }
 
 variables {𝕜 F}
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -687,26 +687,28 @@ continuous_linear_map.homothety_norm _ c.norm_smul_right_apply
 variables (𝕜 F)
 
 /-- The linear map obtained by applying a continuous linear map at a given vector. -/
-def applyₗ (v : E) : (E →L[𝕜] F) →ₗ[𝕜] F :=
+def evalₗ (v : E) : (E →L[𝕜] F) →ₗ[𝕜] F :=
 { to_fun := λ f, f v,
   map_add' := λ f g, f.add_apply g v,
   map_smul' := λ x f, f.smul_apply x v }
 
-lemma continuous_applyₗ (v : E) : continuous (continuous_linear_map.applyₗ 𝕜 F v) :=
+lemma continuous_evalₗ (v : E) : continuous (continuous_linear_map.eval 𝕜 F v) :=
 begin
-  apply (continuous_linear_map.applyₗ 𝕜 F v).continuous_of_bound,
+  apply (continuous_linear_map.eval 𝕜 F v).continuous_of_bound,
   intro f,
   rw mul_comm,
   exact f.le_op_norm v,
 end
 
-/-- The continuous linear map obtained by applying a continuous linear map at a given vector. -/
-def apply (v : E) : (E →L[𝕜] F) →L[𝕜] F :=
-⟨continuous_linear_map.applyₗ 𝕜 F v, continuous_linear_map.continuous_applyₗ _ _ _⟩
+/-- The continuous linear map obtained by applying a continuous linear map at a given vector.
+
+This is the continuous version of `linear_map.eval`. -/
+def eval (v : E) : (E →L[𝕜] F) →L[𝕜] F :=
+⟨continuous_linear_map.eval 𝕜 F v, continuous_linear_map.continuous_eval _ _ _⟩
 
 variables {𝕜 F}
 
-@[simp] lemma apply_apply (v : E) (f : E →L[𝕜] F) : apply 𝕜 F v f = f v := rfl
+@[simp] lemma eval_apply (v : E) (f : E →L[𝕜] F) : eval 𝕜 F v f = f v := rfl
 
 section multiplication_linear
 variables (𝕜) (𝕜' : Type*) [normed_ring 𝕜'] [normed_algebra 𝕜 𝕜']

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -399,8 +399,9 @@ variable (S)
 
 /-- Applying a linear map at `v : M`, seen as `S`-linear map from `M →ₗ[R] M₂` to `M₂`.
 
- See `applyₗ` for a version where `S = R` -/
-def applyₗ' (v : M) : (M →ₗ[R] M₂) →ₗ[S] M₂ :=
+ See `linear_map.eval` for a version where `S = R` -/
+@[simps]
+def eval' (v : M) : (M →ₗ[R] M₂) →ₗ[S] M₂ :=
 { to_fun := λ f, f v,
   map_add' := λ f g, f.add_apply g v,
   map_smul' := λ x f, f.smul_apply x v }
@@ -425,9 +426,13 @@ def comp_right (f : M₂ →ₗ[R] M₃) : (M →ₗ[R] M₂) →ₗ[R] (M →�
 λ _ _, linear_map.ext $ λ _, f.3 _ _⟩
 
 /-- Applying a linear map at `v : M`, seen as a linear map from `M →ₗ[R] M₂` to `M₂`.
-See also `linear_map.applyₗ'` for a version that works with two different semirings. -/
-def applyₗ (v : M) : (M →ₗ[R] M₂) →ₗ[R] M₂ :=
-applyₗ' R v
+See also `linear_map.eval'` for a version that works with two different semirings.
+
+This is the `linear_map` version of `add_monoid_hom.eval`. -/
+def eval : M →ₗ[R] (M →ₗ[R] M₂) →ₗ[R] M₂ :=
+{ to_fun := λ v, eval' R v,
+  map_add' := λ x y, linear_map.ext $ λ f, f.map_add _ _,
+  map_smul' := λ x y, linear_map.ext $ λ f, f.map_smul _ _, }
 
 end comm_semiring
 


### PR DESCRIPTION
This also:

* Renames `continuous_linear_map.apply` to `continuous_linear_map.eval`
* Shows that `linear_map.eval` and `continuous_linear_map.eval` are linear in their first arguments too, as is done in `monoid_hom.eval`
* Removes the intermediate `continuous_linear_map.applyₗ` definition which can be constructed internally to `eval`.
---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

We could rename in the other direction instead if we wanted.