### PR TITLE
[Merged by Bors] - docs(undergrad.yaml): update with #5724 and #5788

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -166,7 +166,7 @@ Ring Theory:
     Newton's identities:
     polynomial derivative: 'polynomial.derivative'
     decomposition into sums of homogeneous polynomials: 'mv_polynomial.sum_homogeneous_component'
-    symmetric polynomials:
+    symmetric polynomials: 'mv_polynomial.is_symmetric'
   Field Theory:
     fields: 'field'
     characteristic of a ring: 'ring_char'
@@ -340,9 +340,9 @@ Single Variable Real Analysis:
     integral over a segment of piecewise continuous functions:
     antiderivatives:
     Riemann sums:
-    antiderivative of a continuous function: interval_integral.integral_has_strict_deriv_at_of_tendsto_ae_right
+    antiderivative of a continuous function: 'interval_integral.integral_has_strict_deriv_at_of_tendsto_ae_right'
     change of variable:
-    integration by parts:
+    integration by parts: 'interval_integral.integral_mul_deriv_eq_deriv_mul'
     improper integrals:
     absolute vs conditional convergence of improper integrals:
     comparison test for improper integrals:
@@ -512,7 +512,8 @@ Measures and integral Calculus:
     Holder's inequality: 'nnreal.lintegral_mul_le_Lp_mul_Lq'
     Fubini's theorem: 'measure_theory.integral_prod'
     change of variables for multiple integrals:
-    integration by parts:
+    change of variables to polar co-ordinates:
+    change of variables to spherical co-ordinates:
     convolution:
     regularization and approximation by convolution:
   Fourier Analysis:


### PR DESCRIPTION
Add results from a couple of recent PRs.  Also correct an apparent oversight from the translation of the file.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The second appearance of "integration by parts" in the file looked like a mistake, so I checked [the original source](https://media.devenirenseignant.gouv.fr/file/agreg_externe/59/7/p2020_agreg_ext_maths_1107597.pdf) and saw that it was supposed to be the existence of polar and spherical co-ordinates (!).
```quote
Changement de variables dans une intégrale multiple.
Cas des coordonnées polaires, cas des coordonnées sphériques.
```