### PR TITLE
[Merged by Bors] - feat(algebra/ring): add mk_mul_self_of_two_ne_zero

### DIFF
--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -860,7 +860,7 @@ lemma units.inv_eq_self_iff (u : units α) : u⁻¹ = u ↔ u = 1 ∨ u = -1 :=
 by { rw inv_eq_iff_mul_eq_one, simp only [units.ext_iff], push_cast, exact mul_self_eq_one_iff }
 
 /--
-Makes a ring homomorphism from a additive group homomorphism from a commutative ring to an integral
+Makes a ring homomorphism from an additive group homomorphism from a commutative ring to an integral
 domain that commutes with self multiplication, assumes that two is nonzero and one is sent to one.
 -/
 def add_monoid_hom.mk_ring_hom_of_mul_self_of_two_ne_zero [comm_ring β] (f : β →+ α)

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -881,8 +881,13 @@ def add_monoid_hom.mk_ring_hom_of_mul_self_of_two_ne_zero [comm_ring β] (f : β
 
 @[simp]
 lemma add_monoid_hom.coe_fn_mk_ring_hom_of_mul_self_of_two_ne_zero [comm_ring β] (f : β →+ α)
-  (h : ∀ x, f (x * x) = f x * f x) (h_two : (2 : α) ≠ 0) (h_one : f 1 = 1) :
+  (h h_two h_one) :
   (f.mk_ring_hom_of_mul_self_of_two_ne_zero h h_two h_one : β → α) = f := rfl
+
+@[simp]
+lemma add_monoid_hom.coe_add_monoid_hom_mk_ring_hom_of_mul_self_of_two_ne_zero [comm_ring β]
+  (f : β →+ α) (h h_two h_one) :
+  (f.mk_ring_hom_of_mul_self_of_two_ne_zero h h_two h_one : β →+ α) = f := rfl
 
 end integral_domain
 

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -887,7 +887,7 @@ lemma add_monoid_hom.coe_fn_mk_ring_hom_of_mul_self_of_two_ne_zero [comm_ring β
 @[simp]
 lemma add_monoid_hom.coe_add_monoid_hom_mk_ring_hom_of_mul_self_of_two_ne_zero [comm_ring β]
   (f : β →+ α) (h h_two h_one) :
-  (f.mk_ring_hom_of_mul_self_of_two_ne_zero h h_two h_one : β →+ α) = f := rfl
+  (f.mk_ring_hom_of_mul_self_of_two_ne_zero h h_two h_one : β →+ α) = f := by {ext, simp}
 
 end integral_domain
 

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -859,6 +859,31 @@ by rw [← mul_self_eq_mul_self_iff, one_mul]
 lemma units.inv_eq_self_iff (u : units α) : u⁻¹ = u ↔ u = 1 ∨ u = -1 :=
 by { rw inv_eq_iff_mul_eq_one, simp only [units.ext_iff], push_cast, exact mul_self_eq_one_iff }
 
+/--
+Makes a ring homomorphism from a additive group homomorphism from a commutative ring to an integral
+domain that commutes with self multiplication, assumes that two is nonzero and one is sent to one.
+-/
+def ring_hom.mk_mul_self_of_two_ne_zero [comm_ring β] (f : β →+ α) (h : ∀ x, f (x * x) = f x * f x)
+  (h2 : (2 : α) ≠ 0) (h_one : f 1 = 1) : β →+* α :=
+{ map_one' := h_one,
+  map_mul' := begin
+    intros x y,
+    have hxy := h (x + y),
+    rw [mul_add, add_mul, add_mul, f.map_add, f.map_add, f.map_add, f.map_add, h x, h y, add_mul,
+      mul_add, mul_add, ← sub_eq_zero_iff_eq, add_comm, ← sub_sub, ← sub_sub, ← sub_sub,
+      mul_comm y x, mul_comm (f y) (f x)] at hxy,
+    simp only [add_assoc, add_sub_assoc, add_sub_cancel'_right] at hxy,
+    rw [sub_sub, ← two_mul, ← add_sub_assoc, ← two_mul, ← mul_sub, mul_eq_zero, sub_eq_zero_iff_eq,
+      or_iff_not_imp_left] at hxy,
+    exact hxy h2,
+  end,
+  ..f }
+
+@[simp]
+lemma ring_hom.coe_fn_mk_mul_self_of_two_ne_zero [comm_ring β] (f : β →+ α)
+  (h : ∀ x, f (x * x) = f x * f x) (h2 : (2 : α) ≠ 0) (h_one : f 1 = 1) :
+  (ring_hom.mk_mul_self_of_two_ne_zero f h h2 h_one : β → α) = f := rfl
+
 end integral_domain
 
 namespace ring

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -863,8 +863,8 @@ by { rw inv_eq_iff_mul_eq_one, simp only [units.ext_iff], push_cast, exact mul_s
 Makes a ring homomorphism from a additive group homomorphism from a commutative ring to an integral
 domain that commutes with self multiplication, assumes that two is nonzero and one is sent to one.
 -/
-def ring_hom.mk_mul_self_of_two_ne_zero [comm_ring β] (f : β →+ α) (h : ∀ x, f (x * x) = f x * f x)
-  (h2 : (2 : α) ≠ 0) (h_one : f 1 = 1) : β →+* α :=
+def add_monoid_hom.mk_ring_hom_of_mul_self_of_two_ne_zero [comm_ring β] (f : β →+ α)
+  (h : ∀ x, f (x * x) = f x * f x) (h_two : (2 : α) ≠ 0) (h_one : f 1 = 1) : β →+* α :=
 { map_one' := h_one,
   map_mul' := begin
     intros x y,
@@ -875,14 +875,14 @@ def ring_hom.mk_mul_self_of_two_ne_zero [comm_ring β] (f : β →+ α) (h : ∀
     simp only [add_assoc, add_sub_assoc, add_sub_cancel'_right] at hxy,
     rw [sub_sub, ← two_mul, ← add_sub_assoc, ← two_mul, ← mul_sub, mul_eq_zero, sub_eq_zero_iff_eq,
       or_iff_not_imp_left] at hxy,
-    exact hxy h2,
+    exact hxy h_two,
   end,
   ..f }
 
 @[simp]
-lemma ring_hom.coe_fn_mk_mul_self_of_two_ne_zero [comm_ring β] (f : β →+ α)
-  (h : ∀ x, f (x * x) = f x * f x) (h2 : (2 : α) ≠ 0) (h_one : f 1 = 1) :
-  (ring_hom.mk_mul_self_of_two_ne_zero f h h2 h_one : β → α) = f := rfl
+lemma add_monoid_hom.coe_fn_mk_ring_hom_of_mul_self_of_two_ne_zero [comm_ring β] (f : β →+ α)
+  (h : ∀ x, f (x * x) = f x * f x) (h_two : (2 : α) ≠ 0) (h_one : f 1 = 1) :
+  (f.mk_ring_hom_of_mul_self_of_two_ne_zero h h_two h_one : β → α) = f := rfl
 
 end integral_domain
 


### PR DESCRIPTION
Which allows us to make a ring homomorphism from an additive hom which maps squares to squares assuming a couple of  things, this is especially useful in ordered fields where it allows us to think only of positive elements.

---

This is a dependency of #3292 
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
