### PR TITLE
[Merged by Bors] - chore(*): Replace integral_domain assumptions with no_zero_divisors

### DIFF
--- a/src/algebra/algebra/subalgebra.lean
+++ b/src/algebra/algebra/subalgebra.lean
@@ -266,6 +266,10 @@ lemma mem_map {S : subalgebra R A} {f : A →ₐ[R] B} {y : B} :
   y ∈ map S f ↔ ∃ x ∈ S, f x = y :=
 subsemiring.mem_map
 
+instance no_zero_divisors {R A : Type*} [comm_ring R] [semiring A] [no_zero_divisors A]
+  [algebra R A] (S : subalgebra R A) : no_zero_divisors S :=
+S.to_subsemiring.no_zero_divisors
+
 instance integral_domain {R A : Type*} [comm_ring R] [integral_domain A] [algebra R A]
   (S : subalgebra R A) : integral_domain S :=
 @subring.domain A _ S _

--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -275,7 +275,7 @@ end comm_ring
 
 end frobenius
 
-theorem frobenius_inj (α : Type u) [integral_domain α] (p : ℕ) [fact p.prime] [char_p α p] :
+theorem frobenius_inj (α : Type u) [comm_ring α] [no_zero_divisors α] (p : ℕ) [fact p.prime] [char_p α p] :
   function.injective (frobenius α p) :=
 λ x h H, by { rw ← sub_eq_zero at H ⊢, rw ← frobenius_sub at H, exact pow_eq_zero H }
 

--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -275,7 +275,8 @@ end comm_ring
 
 end frobenius
 
-theorem frobenius_inj (α : Type u) [comm_ring α] [no_zero_divisors α] (p : ℕ) [fact p.prime] [char_p α p] :
+theorem frobenius_inj (α : Type u) [comm_ring α] [no_zero_divisors α]
+  (p : ℕ) [fact p.prime] [char_p α p] :
   function.injective (frobenius α p) :=
 λ x h H, by { rw ← sub_eq_zero at H ⊢, rw ← frobenius_sub at H, exact pow_eq_zero H }
 

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -138,11 +138,13 @@ instance [ring α] : ring (opposite α) :=
 instance [comm_ring α] : comm_ring (opposite α) :=
 { .. opposite.ring α, .. opposite.comm_semigroup α }
 
-instance [integral_domain α] : integral_domain (opposite α) :=
+instance [has_zero α] [has_mul α] [no_zero_divisors α] : no_zero_divisors (opposite α) :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := λ x y (H : op (_ * _) = op (0:α)),
     or.cases_on (eq_zero_or_eq_zero_of_mul_eq_zero $ op_injective H)
-      (λ hy, or.inr $ unop_injective $ hy) (λ hx, or.inl $ unop_injective $ hx),
-  .. opposite.comm_ring α, .. opposite.nontrivial α }
+      (λ hy, or.inr $ unop_injective $ hy) (λ hx, or.inl $ unop_injective $ hx), }
+
+instance [integral_domain α] : integral_domain (opposite α) :=
+{ .. opposite.no_zero_divisors α, .. opposite.comm_ring α, .. opposite.nontrivial α }
 
 instance [field α] : field (opposite α) :=
 { mul_inv_cancel := λ x hx, unop_injective $ inv_mul_cancel $ λ hx', hx $ unop_injective hx',

--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -126,13 +126,14 @@ end
 
 end comm_ring
 
-section integral_domain
-variables [integral_domain R] (f : ι → polynomial R)
+section no_zero_divisors
+variables [comm_ring R] [no_zero_divisors R] (f : ι → polynomial R)
 
-lemma nat_degree_prod (h : ∀ i ∈ s, f i ≠ 0) :
+lemma nat_degree_prod [nontrivial R] (h : ∀ i ∈ s, f i ≠ 0) :
   (∏ i in s, f i).nat_degree = ∑ i in s, (f i).nat_degree :=
 begin
-  apply nat_degree_prod', rw prod_ne_zero_iff,
+  apply nat_degree_prod',
+  rw prod_ne_zero_iff,
   intros x hx, simp [h x hx],
 end
 
@@ -140,5 +141,5 @@ lemma leading_coeff_prod :
   (∏ i in s, f i).leading_coeff = ∏ i in s, (f i).leading_coeff :=
 by { rw ← leading_coeff_hom_apply, apply monoid_hom.map_prod }
 
-end integral_domain
+end no_zero_divisors
 end polynomial

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -822,7 +822,8 @@ lemma sum_map_mul_right [semiring β] {b : β} {s : multiset α} {f : α → β}
   sum (s.map (λa, f a * b)) = sum (s.map f) * b :=
 multiset.induction_on s (by simp) (assume a s ih, by simp [ih, add_mul])
 
-theorem prod_ne_zero {R : Type*} [integral_domain R] {m : multiset R} :
+theorem prod_ne_zero {R : Type*} [comm_semiring R] [no_zero_divisors R] [nontrivial R]
+  {m : multiset R} :
   (∀ x ∈ m, (x : _) ≠ 0) → m.prod ≠ 0 :=
 multiset.induction_on m (λ _, one_ne_zero) $ λ hd tl ih H,
   by { rw forall_mem_cons at H, rw prod_cons, exact mul_ne_zero H.1 (ih H.2) }

--- a/src/data/polynomial/cancel_leads.lean
+++ b/src/data/polynomial/cancel_leads.lean
@@ -41,7 +41,7 @@ dvd_sub (dvd.trans pr (dvd.intro_left _ rfl)) (dvd.trans pq (dvd.intro_left _ rf
 
 end comm_ring
 
-lemma nat_degree_cancel_leads_lt_of_nat_degree_le_nat_degree [integral_domain R]
+lemma nat_degree_cancel_leads_lt_of_nat_degree_le_nat_degree [comm_ring R] [no_zero_divisors R]
   {p q : polynomial R} (h : p.nat_degree ≤ q.nat_degree) (hq : 0 < q.nat_degree) :
   (p.cancel_leads q).nat_degree < q.nat_degree :=
 begin

--- a/src/data/polynomial/cancel_leads.lean
+++ b/src/data/polynomial/cancel_leads.lean
@@ -41,7 +41,7 @@ dvd_sub (dvd.trans pr (dvd.intro_left _ rfl)) (dvd.trans pq (dvd.intro_left _ rf
 
 end comm_ring
 
-lemma nat_degree_cancel_leads_lt_of_nat_degree_le_nat_degree [comm_ring R] [no_zero_divisors R]
+lemma nat_degree_cancel_leads_lt_of_nat_degree_le_nat_degree [integral_domain R]
   {p q : polynomial R} (h : p.nat_degree ≤ q.nat_degree) (hq : 0 < q.nat_degree) :
   (p.cancel_leads q).nat_degree < q.nat_degree :=
 begin

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -834,8 +834,8 @@ by { apply nat_degree_eq_of_degree_eq_some, simp [degree_X_pow_sub_C hn], }
 
 end nonzero_ring
 
-section integral_domain
-variables [integral_domain R] {p q : polynomial R}
+section no_zero_divisors
+variables [comm_semiring R] [no_zero_divisors R] {p q : polynomial R}
 
 @[simp] lemma degree_mul : degree (p * q) = degree p + degree q :=
 if hp0 : p = 0 then by simp only [hp0, degree_zero, zero_mul, with_bot.bot_add]
@@ -843,7 +843,7 @@ else if hq0 : q = 0 then  by simp only [hq0, degree_zero, mul_zero, with_bot.add
 else degree_mul' $ mul_ne_zero (mt leading_coeff_eq_zero.1 hp0)
     (mt leading_coeff_eq_zero.1 hq0)
 
-@[simp] lemma degree_pow (p : polynomial R) (n : ℕ) :
+@[simp] lemma degree_pow [nontrivial R] (p : polynomial R) (n : ℕ) :
   degree (p ^ n) = n •ℕ (degree p) :=
 by induction n; [simp only [pow_zero, degree_one, zero_nsmul],
 simp only [*, pow_succ, succ_nsmul, degree_mul]]
@@ -859,7 +859,7 @@ begin
       exact mul_ne_zero (mt leading_coeff_eq_zero.1 hp) (mt leading_coeff_eq_zero.1 hq) } }
 end
 
-@[simp] lemma leading_coeff_X_add_C (a b : R) (ha : a ≠ 0):
+@[simp] lemma leading_coeff_X_add_C [nontrivial R] (a b : R) (ha : a ≠ 0):
   leading_coeff (C a * X + C b) = a :=
 begin
   rw [add_comm, leading_coeff_add_of_degree_lt],
@@ -867,7 +867,7 @@ begin
   { simpa [degree_C ha] using lt_of_le_of_lt degree_C_le (with_bot.coe_lt_coe.2 zero_lt_one)}
 end
 
-/-- `polynomial.leading_coeff` bundled as a `monoid_hom` when `R` is an `integral_domain`, and thus
+/-- `polynomial.leading_coeff` bundled as a `monoid_hom` when `R` has `no_zero_divisors`, and thus
   `leading_coeff` is multiplicative -/
 def leading_coeff_hom : polynomial R →* R :=
 { to_fun := leading_coeff,
@@ -881,6 +881,6 @@ def leading_coeff_hom : polynomial R →* R :=
   leading_coeff (p ^ n) = leading_coeff p ^ n :=
 leading_coeff_hom.map_pow p n
 
-end integral_domain
+end no_zero_divisors
 
 end polynomial

--- a/src/data/quaternion.lean
+++ b/src/data/quaternion.lean
@@ -239,7 +239,8 @@ lemma eq_re_iff_mem_range_coe {a : ℍ[R, c₁, c₂]} :
 ⟨λ h, ⟨a.re, h.symm⟩, λ ⟨x, h⟩, eq_re_of_eq_coe h.symm⟩
 
 @[simp]
-lemma conj_fixed {R : Type*} [integral_domain R] [char_zero R] {c₁ c₂ : R} {a : ℍ[R, c₁, c₂]} :
+lemma conj_fixed {R : Type*} [comm_ring R] [no_zero_divisors R] [char_zero R]
+  {c₁ c₂ : R} {a : ℍ[R, c₁, c₂]} :
   conj a = a ↔ a = a.re :=
 by simp [ext_iff, neg_eq_iff_add_eq_zero, add_self_eq_zero]
 
@@ -430,7 +431,7 @@ quaternion_algebra.eq_re_of_eq_coe h
 lemma eq_re_iff_mem_range_coe {a : ℍ[R]} : a = a.re ↔ a ∈ set.range (coe : R → ℍ[R]) :=
 quaternion_algebra.eq_re_iff_mem_range_coe
 
-@[simp] lemma conj_fixed {R : Type*} [integral_domain R] [char_zero R] {a : ℍ[R]} :
+@[simp] lemma conj_fixed {R : Type*} [comm_ring R] [no_zero_divisors R] [char_zero R] {a : ℍ[R]} :
   conj a = a ↔ a = a.re :=
 quaternion_algebra.conj_fixed
 

--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -631,7 +631,8 @@ end
 
 /-- Dedekind's linear independence of characters -/
 -- See, for example, Keith Conrad's note <https://kconrad.math.uconn.edu/blurbs/galoistheory/linearchar.pdf>
-theorem linear_independent_monoid_hom (G : Type*) [monoid G] (L : Type*) [integral_domain L] :
+theorem linear_independent_monoid_hom (G : Type*) [monoid G] (L : Type*) [comm_ring L]
+  [no_zero_divisors L] :
   @linear_independent _ L (G → L) (λ f, f : (G →* L) → (G → L)) _ _ _ :=
 by letI := classical.dec_eq (G →* L);
    letI : mul_action L L := distrib_mul_action.to_mul_action;

--- a/src/ring_theory/prime.lean
+++ b/src/ring_theory/prime.lean
@@ -10,7 +10,7 @@ import algebra.big_operators.basic
 This file contains lemmas about prime elements of commutative rings.
 -/
 
-variables {R : Type*} [integral_domain R]
+variables {R : Type*} [comm_cancel_monoid_with_zero R]
 open finset
 
 open_locale big_operators

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -374,16 +374,15 @@ def subset_comm_ring (S : subring cR) : comm_ring S :=
 
 /-- A subring of a non-trivial ring is non-trivial. -/
 instance {D : Type*} [ring D] [nontrivial D] (S : subring D) : nontrivial S :=
-{ exists_pair_ne := ⟨0, 1, mt subtype.ext_iff_val.1 zero_ne_one⟩, }
+S.to_subsemiring.nontrivial
 
 /-- A subring of an ring with no zero divisors has no zero divisors. -/
 instance {D : Type*} [ring D] [no_zero_divisors D] (S : subring D) : no_zero_divisors S :=
-{ eq_zero_or_eq_zero_of_mul_eq_zero := λ ⟨x, hx⟩ ⟨y, hy⟩,
-    by { simp only [subtype.ext_iff_val, subtype.coe_mk], exact eq_zero_or_eq_zero_of_mul_eq_zero },}
+S.to_subsemiring.no_zero_divisors
 
 /-- A subring of an integral domain is an integral domain. -/
 instance subring.domain {D : Type*} [integral_domain D] (S : subring D) : integral_domain S :=
-{ .. S.non_trivial, .. S.no_zero_divisors, .. S.subset_comm_ring, }
+{ .. S.nontrivial, .. S.no_zero_divisors, .. S.subset_comm_ring }
 
 /-! # bot -/
 

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -376,7 +376,7 @@ def subset_comm_ring (S : subring cR) : comm_ring S :=
 instance {D : Type*} [ring D] [nontrivial D] (S : subring D) : nontrivial S :=
 S.to_subsemiring.nontrivial
 
-/-- A subring of an ring with no zero divisors has no zero divisors. -/
+/-- A subring of a ring with no zero divisors has no zero divisors. -/
 instance {D : Type*} [ring D] [no_zero_divisors D] (S : subring D) : no_zero_divisors S :=
 S.to_subsemiring.no_zero_divisors
 

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -372,12 +372,18 @@ variables {cR : Type u} [comm_ring cR]
 def subset_comm_ring (S : subring cR) : comm_ring S :=
 {mul_comm := λ _ _, subtype.eq $ mul_comm _ _, ..subring.to_ring S}
 
+/-- A subring of a non-trivial ring is non-trivial. -/
+instance {D : Type*} [ring D] [nontrivial D] (S : subring D) : nontrivial S :=
+{ exists_pair_ne := ⟨0, 1, mt subtype.ext_iff_val.1 zero_ne_one⟩, }
+
+/-- A subring of an ring with no zero divisors has no zero divisors. -/
+instance {D : Type*} [ring D] [no_zero_divisors D] (S : subring D) : no_zero_divisors S :=
+{ eq_zero_or_eq_zero_of_mul_eq_zero := λ ⟨x, hx⟩ ⟨y, hy⟩,
+    by { simp only [subtype.ext_iff_val, subtype.coe_mk], exact eq_zero_or_eq_zero_of_mul_eq_zero },}
+
 /-- A subring of an integral domain is an integral domain. -/
 instance subring.domain {D : Type*} [integral_domain D] (S : subring D) : integral_domain S :=
-{ exists_pair_ne := ⟨0, 1, mt subtype.ext_iff_val.1 zero_ne_one⟩,
-  eq_zero_or_eq_zero_of_mul_eq_zero := λ ⟨x, hx⟩ ⟨y, hy⟩,
-    by { simp only [subtype.ext_iff_val, subtype.coe_mk], exact eq_zero_or_eq_zero_of_mul_eq_zero },
-  .. S.subset_comm_ring, }
+{ .. S.non_trivial, .. S.no_zero_divisors, .. S.subset_comm_ring, }
 
 /-! # bot -/
 

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -160,7 +160,12 @@ instance to_semiring : semiring s :=
   .. s.to_submonoid.to_monoid, .. s.to_add_submonoid.to_add_comm_monoid }
 
 instance nontrivial [nontrivial R] : nontrivial s :=
-@nontrivial_of_ne s 0 1 (λ H, zero_ne_one (congr_arg subtype.val H : _))
+nontrivial_of_ne 0 1 $ λ H, zero_ne_one (congr_arg subtype.val H)
+
+instance no_zero_divisors [no_zero_divisors R] : no_zero_divisors s :=
+{ eq_zero_or_eq_zero_of_mul_eq_zero := λ x y h,
+  or.cases_on (eq_zero_or_eq_zero_of_mul_eq_zero $ subtype.ext_iff.mp h)
+    (λ h, or.inl $ subtype.eq h) (λ h, or.inr $ subtype.eq h) }
 
 @[simp, norm_cast] lemma coe_mul (x y : s) : (↑(x * y) : R) = ↑x * ↑y := rfl
 @[simp, norm_cast] lemma coe_one : ((1 : s) : R) = 1 := rfl


### PR DESCRIPTION
This removes unnecessary `nontrivial` assumptions, and reduces some `comm_ring` requirements to `comm_semiring`.

This also adds some missing `nontrivial` and `no_zero_divisors` instances.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
