### PR TITLE
[Merged by Bors] - feat(data/set/finite): add lemma about to_finset of complement of set

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -319,7 +319,8 @@ lemma finset.card_compl [decidable_eq α] [fintype α] (s : finset α) :
 finset.card_univ_diff s
 
 lemma finset.compl_to_finset [decidable_eq α] [fintype α] (s : set α) :
-  sᶜ.to_finset = (s.to_finset)ᶜ:= by ext; simp only [mem_compl, set.mem_to_finset, set.mem_compl_eq]
+  sᶜ.to_finset = (s.to_finset)ᶜ :=
+by { ext, simp only [mem_compl, set.mem_to_finset, set.mem_compl_eq] }
 
 instance (n : ℕ) : fintype (fin n) :=
 ⟨finset.fin_range n, finset.mem_fin_range⟩

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -318,10 +318,6 @@ lemma finset.card_compl [decidable_eq α] [fintype α] (s : finset α) :
   sᶜ.card = fintype.card α - s.card :=
 finset.card_univ_diff s
 
-lemma finset.compl_to_finset [decidable_eq α] [fintype α] (s : set α) :
-  sᶜ.to_finset = (s.to_finset)ᶜ :=
-by { ext, simp only [mem_compl, set.mem_to_finset, set.mem_compl_eq] }
-
 instance (n : ℕ) : fintype (fin n) :=
 ⟨finset.fin_range n, finset.mem_fin_range⟩
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -318,7 +318,7 @@ lemma finset.card_compl [decidable_eq α] [fintype α] (s : finset α) :
   sᶜ.card = fintype.card α - s.card :=
 finset.card_univ_diff s
 
-lemma finset.compl_to_finset (α : Type u) [decidable_eq α] [fintype α] (s : set α) :
+lemma finset.compl_to_finset [decidable_eq α] [fintype α] (s : set α) :
   sᶜ.to_finset = (s.to_finset)ᶜ:= by ext; simp only [mem_compl, set.mem_to_finset, set.mem_compl_eq]
 
 instance (n : ℕ) : fintype (fin n) :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -318,6 +318,9 @@ lemma finset.card_compl [decidable_eq α] [fintype α] (s : finset α) :
   sᶜ.card = fintype.card α - s.card :=
 finset.card_univ_diff s
 
+lemma finset.compl_to_finset (α : Type u) [decidable_eq α] [fintype α] (s : set α) :
+  sᶜ.to_finset = (s.to_finset)ᶜ:= by ext; simp only [mem_compl, set.mem_to_finset, set.mem_compl_eq]
+
 instance (n : ℕ) : fintype (fin n) :=
 ⟨finset.fin_range n, finset.mem_fin_range⟩
 

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -573,7 +573,6 @@ section
 
 local attribute [instance, priority 1] classical.prop_decidable
 
-
 lemma to_finset_compl {α : Type*} [fintype α](s : set α) :
   sᶜ.to_finset = (s.to_finset)ᶜ := by ext; simp
 

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -574,7 +574,8 @@ section
 local attribute [instance, priority 1] classical.prop_decidable
 
 lemma to_finset_compl {α : Type*} [fintype α] (s : set α) :
-  sᶜ.to_finset = (s.to_finset)ᶜ := by ext; simp
+  sᶜ.to_finset = (s.to_finset)ᶜ :=
+by ext; simp
 
 lemma to_finset_inter {α : Type*} [fintype α] (s t : set α) :
   (s ∩ t).to_finset = s.to_finset ∩ t.to_finset :=

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -573,7 +573,7 @@ section
 
 local attribute [instance, priority 1] classical.prop_decidable
 
-lemma to_finset_compl {α : Type*} [fintype α](s : set α) :
+lemma to_finset_compl {α : Type*} [fintype α] (s : set α) :
   sᶜ.to_finset = (s.to_finset)ᶜ := by ext; simp
 
 lemma to_finset_inter {α : Type*} [fintype α] (s t : set α) :

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -574,7 +574,7 @@ section
 local attribute [instance, priority 1] classical.prop_decidable
 
 
-lemma finset.compl_to_finset {α : Type*} [fintype α](s : set α) :
+lemma to_finset_compl {α : Type*} [fintype α](s : set α) :
   sᶜ.to_finset = (s.to_finset)ᶜ := by ext; simp
 
 lemma to_finset_inter {α : Type*} [fintype α] (s t : set α) :

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -573,6 +573,10 @@ section
 
 local attribute [instance, priority 1] classical.prop_decidable
 
+
+lemma finset.compl_to_finset {α : Type*} [fintype α](s : set α) :
+  sᶜ.to_finset = (s.to_finset)ᶜ := by ext; simp
+
 lemma to_finset_inter {α : Type*} [fintype α] (s t : set α) :
   (s ∩ t).to_finset = s.to_finset ∩ t.to_finset :=
 by ext; simp


### PR DESCRIPTION
Add lemma stating that taking to_finset of the complement of a set is the same thing as taking the complement of to_finset of the set.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
