### PR TITLE
[Merged by Bors] - feat(data/set/finite): add to_finset lemma

### DIFF
--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -577,6 +577,10 @@ lemma to_finset_inter {α : Type*} [fintype α] (s t : set α) :
   (s ∩ t).to_finset = s.to_finset ∩ t.to_finset :=
 by ext; simp
 
+lemma to_finset_union {α : Type*} [fintype α] (s t : set α) :
+  (s ∪ t).to_finset = s.to_finset ∪ t.to_finset :=
+by ext; simp
+
 end
 
 section


### PR DESCRIPTION
Add lemma stating that taking to_finset of the union of two sets is the same as taking the union of to_finset of the sets. 

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
