### PR TITLE
[Merged by Bors] - chore(algebra/group_with_zero): correct instance name

### DIFF
--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -287,7 +287,7 @@ section cancel_monoid_with_zero
 variables [cancel_monoid_with_zero M₀] {a b c : M₀}
 
 @[priority 10] -- see Note [lower instance priority]
-instance comm_cancel_monoid_with_zero.no_zero_divisors : no_zero_divisors M₀ :=
+instance cancel_monoid_with_zero.to_no_zero_divisors : no_zero_divisors M₀ :=
 ⟨λ a b ab0, by { by_cases a = 0, { left, exact h }, right,
   apply cancel_monoid_with_zero.mul_left_cancel_of_ne_zero h, rw [ab0, mul_zero], }⟩
 


### PR DESCRIPTION
The argument for this definition is `cancel_monoid_with_zero`, not `comm_cancel_monoid_with_zero`.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
