### PR TITLE
[Merged by Bors] - chore(*): add more simp lemmas, refactor theorems about `fintype.sum`

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -218,15 +218,14 @@ by rw [←prod_union sdiff_disjoint, sdiff_union_of_subset h]
 @[simp, to_additive]
 lemma prod_sum_elim [decidable_eq (α ⊕ γ)]
   (s : finset α) (t : finset γ) (f : α → β) (g : γ → β) :
-  ∏ x in s.image sum.inl ∪ t.image sum.inr, sum.elim f g x = (∏ x in s, f x) * (∏ x in t, g x) :=
+  ∏ x in s.map function.embedding.inl ∪ t.map function.embedding.inr, sum.elim f g x =
+    (∏ x in s, f x) * (∏ x in t, g x) :=
 begin
-  rw [prod_union, prod_image, prod_image],
-  { simp only [sum.elim_inl, sum.elim_inr] },
-  { exact λ _ _ _ _, sum.inr.inj },
-  { exact λ _ _ _ _, sum.inl.inj },
-  { rintros i hi,
-    erw [finset.mem_inter, finset.mem_image, finset.mem_image] at hi,
-    rcases hi with ⟨⟨i, hi, rfl⟩, ⟨j, hj, H⟩⟩,
+  rw [prod_union, prod_map, prod_map],
+  { simp only [sum.elim_inl, function.embedding.inl_apply, function.embedding.inr_apply,
+      sum.elim_inr] },
+  { simp only [disjoint_left, finset.mem_map, finset.mem_map],
+    rintros _ ⟨i, hi, rfl⟩ ⟨j, hj, H⟩,
     cases H }
 end
 

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -937,7 +937,7 @@ lemma finset.center_mass_segment'
   (s : finset ι) (t : finset ι') (ws : ι → ℝ) (zs : ι → E) (wt : ι' → ℝ) (zt : ι' → E)
   (hws : ∑ i in s, ws i = 1) (hwt : ∑ i in t, wt i = 1) (a b : ℝ) (hab : a + b = 1) :
   a • s.center_mass ws zs + b • t.center_mass wt zt =
-    (s.image sum.inl ∪ t.image sum.inr).center_mass
+    (s.map function.embedding.inl ∪ t.map function.embedding.inr).center_mass
       (sum.elim (λ i, a * ws i) (λ j, b * wt j))
       (sum.elim zs zt) :=
 begin
@@ -1148,15 +1148,14 @@ begin
     rw [finset.center_mass_segment' _ _ _ _ _ _ hwx₁ hwy₁ _ _ hab],
     refine ⟨_, _, _, _, _, _, _, rfl⟩,
     { rintros i hi,
-      rw [finset.mem_union, finset.mem_image, finset.mem_image] at hi,
+      rw [finset.mem_union, finset.mem_map, finset.mem_map] at hi,
       rcases hi with ⟨j, hj, rfl⟩|⟨j, hj, rfl⟩;
         simp only [sum.elim_inl, sum.elim_inr];
         apply_rules [mul_nonneg, hwx₀, hwy₀] },
     { simp [finset.sum_sum_elim, finset.mul_sum.symm, *] },
     { intros i hi,
-      rw [finset.mem_union, finset.mem_image, finset.mem_image] at hi,
-      rcases hi with ⟨j, hj, rfl⟩|⟨j, hj, rfl⟩;
-        simp only [sum.elim_inl, sum.elim_inr]; apply_rules [hzx, hzy] } },
+      rw [finset.mem_union, finset.mem_map, finset.mem_map] at hi,
+      rcases hi with ⟨j, hj, rfl⟩|⟨j, hj, rfl⟩; apply_rules [hzx, hzy] } },
   { rintros _ ⟨ι, t, w, z, hw₀, hw₁, hz, rfl⟩,
     exact t.center_mass_mem_convex_hull hw₀ (hw₁.symm ▸ zero_lt_one) hz }
 end

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -224,6 +224,10 @@ def mk_continuous (C : ℝ) (H : ∀ m, ∥f m∥ ≤ C * ∏ i, ∥m i∥) :
   continuous_multilinear_map 𝕜 E₁ E₂ :=
 { cont := f.continuous_of_bound C H, ..f }
 
+@[simp] lemma coe_mk_continuous (C : ℝ) (H : ∀ m, ∥f m∥ ≤ C * ∏ i, ∥m i∥) :
+  ⇑(f.mk_continuous C H) = f :=
+rfl
+
 /-- Given a multilinear map in `n` variables, if one restricts it to `k` variables putting `z` on
 the other coordinates, then the resulting restricted function satisfies an inequality
 `∥f.restr v∥ ≤ C * ∥z∥^(n-k) * Π ∥v i∥` if the original function satisfies `∥f v∥ ≤ C * Π ∥v i∥`. -/

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -1948,7 +1948,7 @@ namespace function
 lemma update_comp_equiv {α β α' : Sort*} [decidable_eq α'] [decidable_eq α] (f : α → β) (g : α' ≃ α)
   (a : α) (v : β) :
   update f a v ∘ g = update (f ∘ g) (g.symm a) v :=
-by rw [←update_comp _ g.injective, g.apply_symm_apply]
+by rw [← update_comp_eq_of_injective _ g.injective, g.apply_symm_apply]
 
 lemma update_apply_equiv_apply {α β α' : Sort*} [decidable_eq α'] [decidable_eq α]
   (f : α → β) (g : α' ≃ α) (a : α) (v : β) (a' : α') :

--- a/src/data/finset/sort.lean
+++ b/src/data/finset/sort.lean
@@ -128,6 +128,10 @@ lemma order_emb_of_fin_apply (s : finset α) {k : ℕ} (h : s.card = k) (i : fin
   s.order_emb_of_fin h i = (s.sort (≤)).nth_le i (by { rw [length_sort, h], exact i.2 }) :=
 rfl
 
+@[simp] lemma order_emb_of_fin_mem (s : finset α) {k : ℕ} (h : s.card = k) (i : fin k) :
+  s.order_emb_of_fin h i ∈ s :=
+(s.order_iso_of_fin h i).2
+
 @[simp] lemma range_order_emb_of_fin (s : finset α) {k : ℕ} (h : s.card = k) :
   set.range (s.order_emb_of_fin h) = s :=
 by simp [order_emb_of_fin, set.range_comp coe (s.order_iso_of_fin h)]

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -475,6 +475,13 @@ fintype.of_equiv _ equiv.ulift.symm
   fintype.card (ulift α) = fintype.card α :=
 fintype.of_equiv_card _
 
+lemma univ_sum_type {α β : Type*} [fintype α] [fintype β] [fintype (α ⊕ β)] [decidable_eq (α ⊕ β)] :
+  (univ : finset (α ⊕ β)) = map function.embedding.inl univ ∪ map function.embedding.inr univ :=
+begin
+  rw [eq_comm, eq_univ_iff_forall], simp only [mem_union, mem_map, exists_prop, mem_univ, true_and],
+  rintro (x|y), exacts [or.inl ⟨x, rfl⟩, or.inr ⟨y, rfl⟩]
+end
+
 instance (α : Type u) (β : Type v) [fintype α] [fintype β] : fintype (α ⊕ β) :=
 @fintype.of_equiv _ _ (@sigma.fintype _
     (λ b, cond b (ulift α) (ulift.{(max u v) v} β)) _

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -318,19 +318,14 @@ open finset
 variables {α₁ : Type*} {α₂ : Type*} {M : Type*} [fintype α₁] [fintype α₂] [comm_monoid M]
 
 @[to_additive]
+lemma fintype.prod_sum_elim (f : α₁ → M) (g : α₂ → M) :
+  (∏ x, sum.elim f g x) = (∏ a₁, f a₁) * (∏ a₂, g a₂) :=
+by { classical, rw [univ_sum_type, prod_sum_elim] }
+
+@[to_additive]
 lemma fintype.prod_sum_type (f : α₁ ⊕ α₂ → M) :
   (∏ x, f x) = (∏ a₁, f (sum.inl a₁)) * (∏ a₂, f (sum.inr a₂)) :=
-begin
-  classical,
-  let s : finset (α₁ ⊕ α₂) := univ.image sum.inr,
-  rw [← prod_sdiff (subset_univ s),
-      ← @prod_image (α₁ ⊕ α₂) _ _ _ _ _ _ sum.inl,
-      ← @prod_image (α₁ ⊕ α₂) _ _ _ _ _ _ sum.inr],
-  { congr, rw finset.ext_iff, rintro (a|a);
-    { simp only [mem_image, exists_eq, mem_sdiff, mem_univ, exists_false,
-        exists_prop_of_true, not_false_iff, and_self, not_true, and_false], } },
-  all_goals { intros, solve_by_elim [sum.inl.inj, sum.inr.inj], }
-end
+by simp only [← fintype.prod_sum_elim, sum.elim_comp_inl_inr]
 
 end
 

--- a/src/data/set/function.lean
+++ b/src/data/set/function.lean
@@ -752,37 +752,12 @@ end semiconj
 lemma update_comp_eq_of_not_mem_range' {α β : Sort*} {γ : β → Sort*} [decidable_eq β]
   (g : Π b, γ b) {f : α → β} {i : β} (a : γ i) (h : i ∉ set.range f) :
   (λ j, (function.update g i a) (f j)) = (λ j, g (f j)) :=
-begin
-  ext p,
-  have : f p ≠ i,
-  { by_contradiction H,
-    push_neg at H,
-    rw ← H at h,
-    exact h (set.mem_range_self _) },
-  simp [this],
-end
+update_comp_eq_of_forall_ne' _ _ $ λ x hx, h ⟨x, hx⟩
 
 /-- Non-dependent version of `function.update_comp_eq_of_not_mem_range'` -/
 lemma update_comp_eq_of_not_mem_range {α β γ : Sort*} [decidable_eq β]
   (g : β → γ) {f : α → β} {i : β} (a : γ) (h : i ∉ set.range f) :
   (function.update g i a) ∘ f = g ∘ f :=
 update_comp_eq_of_not_mem_range' g a h
-
-lemma update_comp_eq_of_injective' {α β : Sort*} {γ : β → Sort*} [decidable_eq α] [decidable_eq β]
-  (g : Π b, γ b) {f : α → β} (hf : function.injective f) (i : α) (a : γ (f i)) :
-  (λ j, function.update g (f i) a (f j)) = function.update (λ i, g (f i)) i a :=
-begin
-  ext j,
-  by_cases h : j = i,
-  { rw h, simp },
-  { have : f j ≠ f i := hf.ne h,
-    simp [h, this] }
-end
-
-/-- Non-dependent version of `function.update_comp_eq_of_injective'` -/
-lemma update_comp_eq_of_injective {α β γ : Sort*} [decidable_eq α] [decidable_eq β]
-  (g : β → γ) {f : α → β} (hf : function.injective f) (i : α) (a : γ) :
-  (function.update g (f i) a) ∘ f = function.update (g ∘ f) i a :=
-update_comp_eq_of_injective' g hf i a
 
 end function

--- a/src/data/sum.lean
+++ b/src/data/sum.lean
@@ -134,22 +134,22 @@ update_comp_eq_of_injective _ injective_inl _ _
   update f (inl i) x (inl j) = update (f ∘ inl) i x j :=
 by rw ← update_inl_comp_inl
 
-@[simp] lemma update_inl_comp_inr {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
+@[simp] lemma update_inl_comp_inr {α β γ} [decidable_eq (α ⊕ β)]
   {f : α ⊕ β → γ} {i : α} {x : γ} :
   update f (inl i) x ∘ inr = f ∘ inr :=
 update_comp_eq_of_forall_ne _ _ $ λ _, inr_ne_inl
 
-@[simp] lemma update_inl_apply_inr {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
+@[simp] lemma update_inl_apply_inr {α β γ} [decidable_eq (α ⊕ β)]
   {f : α ⊕ β → γ} {i : α} {j : β} {x : γ} :
   update f (inl i) x (inr j) = f (inr j) :=
 function.update_noteq inr_ne_inl _ _
 
-@[simp] lemma update_inr_comp_inl {α β γ} [decidable_eq β] [decidable_eq (α ⊕ β)]
+@[simp] lemma update_inr_comp_inl {α β γ} [decidable_eq (α ⊕ β)]
   {f : α ⊕ β → γ} {i : β} {x : γ} :
   update f (inr i) x ∘ inl = f ∘ inl :=
 update_comp_eq_of_forall_ne _ _ $ λ _, inl_ne_inr
 
-@[simp] lemma update_inr_apply_inl {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
+@[simp] lemma update_inr_apply_inl {α β γ} [decidable_eq (α ⊕ β)]
   {f : α ⊕ β → γ} {i : α} {j : β} {x : γ} :
   update f (inr j) x (inl i) = f (inl i) :=
 function.update_noteq inl_ne_inr _ _

--- a/src/data/sum.lean
+++ b/src/data/sum.lean
@@ -112,7 +112,7 @@ funext $ λ x, sum.cases_on x (λ _, rfl) (λ _, rfl)
   sum.elim (f ∘ inl) (f ∘ inr) = f :=
 funext $ λ x, sum.cases_on x (λ _, rfl) (λ _, rfl)
 
-open function (update update_eq_iff)
+open function (update update_eq_iff update_comp_eq_of_injective update_comp_eq_of_forall_ne)
 
 @[simp] lemma update_elim_inl {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
   {f : α → γ} {g : β → γ} {i : α} {x : γ} :
@@ -127,22 +127,22 @@ update_eq_iff.2 ⟨by simp, by simp { contextual := tt }⟩
 @[simp] lemma update_inl_comp_inl {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
   {f : α ⊕ β → γ} {i : α} {x : γ} :
   update f (inl i) x ∘ inl = update (f ∘ inl) i x :=
-by conv { congr, rw [← elim_comp_inl_inr f, update_elim_inl, elim_comp_inl] }
+update_comp_eq_of_injective _ injective_inl _ _
 
 @[simp] lemma update_inl_comp_inr {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
   {f : α ⊕ β → γ} {i : α} {x : γ} :
   update f (inl i) x ∘ inr = f ∘ inr :=
-by conv { congr, rw [← elim_comp_inl_inr f, update_elim_inl, elim_comp_inr] }
+update_comp_eq_of_forall_ne _ _ $ λ _, inr_ne_inl
 
 @[simp] lemma update_inr_comp_inl {α β γ} [decidable_eq β] [decidable_eq (α ⊕ β)]
   {f : α ⊕ β → γ} {i : β} {x : γ} :
   update f (inr i) x ∘ inl = f ∘ inl :=
-by conv { congr, rw [← elim_comp_inl_inr f, update_elim_inr, elim_comp_inl] }
+update_comp_eq_of_forall_ne _ _ $ λ _, inl_ne_inr
 
 @[simp] lemma update_inr_comp_inr {α β γ} [decidable_eq β] [decidable_eq (α ⊕ β)]
   {f : α ⊕ β → γ} {i : β} {x : γ} :
   update f (inr i) x ∘ inr = update (f ∘ inr) i x :=
-by conv { congr, rw [← elim_comp_inl_inr f, update_elim_inr, elim_comp_inr] }
+update_comp_eq_of_injective _ injective_inr _ _
 
 section
   variables (ra : α → α → Prop) (rb : β → β → Prop)

--- a/src/data/sum.lean
+++ b/src/data/sum.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Yury G. Kudryashov
 -/
+import logic.function.basic
 
 /-!
 # More theorems about the sum type
@@ -95,10 +96,10 @@ protected def elim {α β γ : Sort*} (f : α → γ) (g : β → γ) : α ⊕ �
 
 @[simp] lemma elim_comp_inl {α β γ : Sort*} (f : α → γ) (g : β → γ) :
   sum.elim f g ∘ inl = f := rfl
-  
+
 @[simp] lemma elim_comp_inr {α β γ : Sort*} (f : α → γ) (g : β → γ) :
   sum.elim f g ∘ inr = g := rfl
-  
+
 @[simp] lemma elim_inl_inr {α β : Sort*} :
   @sum.elim α β _ inl inr = id :=
 funext $ λ x, sum.cases_on x (λ _, rfl) (λ _, rfl)
@@ -111,12 +112,37 @@ funext $ λ x, sum.cases_on x (λ _, rfl) (λ _, rfl)
   sum.elim (f ∘ inl) (f ∘ inr) = f :=
 funext $ λ x, sum.cases_on x (λ _, rfl) (λ _, rfl)
 
-lemma elim_injective {α β γ : Sort*} {f : α → γ} {g : β → γ}
-  (hf : function.injective f) (hg : function.injective g)
- (hfg : ∀ a b, f a ≠ g b) : function.injective (sum.elim f g) :=
-λ x y, sum.rec_on x
-  (sum.rec_on y (λ x y hxy, by rw hf hxy) (λ x y hxy, false.elim $ hfg _ _ hxy))
-  (sum.rec_on y (λ x y hxy, false.elim $ hfg x y hxy.symm) (λ x y hxy, by rw hg hxy))
+open function (update update_eq_iff)
+
+@[simp] lemma update_elim_inl {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
+  {f : α → γ} {g : β → γ} {i : α} {x : γ} :
+  update (sum.elim f g) (inl i) x = sum.elim (update f i x) g :=
+update_eq_iff.2 ⟨by simp, by simp { contextual := tt }⟩
+
+@[simp] lemma update_elim_inr {α β γ} [decidable_eq β] [decidable_eq (α ⊕ β)]
+  {f : α → γ} {g : β → γ} {i : β} {x : γ} :
+  update (sum.elim f g) (inr i) x = sum.elim f (update g i x) :=
+update_eq_iff.2 ⟨by simp, by simp { contextual := tt }⟩
+
+@[simp] lemma update_inl_comp_inl {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
+  {f : α ⊕ β → γ} {i : α} {x : γ} :
+  update f (inl i) x ∘ inl = update (f ∘ inl) i x :=
+by conv { congr, rw [← elim_comp_inl_inr f, update_elim_inl, elim_comp_inl] }
+
+@[simp] lemma update_inl_comp_inr {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
+  {f : α ⊕ β → γ} {i : α} {x : γ} :
+  update f (inl i) x ∘ inr = f ∘ inr :=
+by conv { congr, rw [← elim_comp_inl_inr f, update_elim_inl, elim_comp_inr] }
+
+@[simp] lemma update_inr_comp_inl {α β γ} [decidable_eq β] [decidable_eq (α ⊕ β)]
+  {f : α ⊕ β → γ} {i : β} {x : γ} :
+  update f (inr i) x ∘ inl = f ∘ inl :=
+by conv { congr, rw [← elim_comp_inl_inr f, update_elim_inr, elim_comp_inl] }
+
+@[simp] lemma update_inr_comp_inr {α β γ} [decidable_eq β] [decidable_eq (α ⊕ β)]
+  {f : α ⊕ β → γ} {i : β} {x : γ} :
+  update f (inr i) x ∘ inr = update (f ∘ inr) i x :=
+by conv { congr, rw [← elim_comp_inl_inr f, update_elim_inr, elim_comp_inr] }
 
 section
   variables (ra : α → α → Prop) (rb : β → β → Prop)
@@ -186,6 +212,14 @@ end sum
 namespace function
 
 open sum
+
+lemma injective.sum_elim {γ} {f : α → γ} {g : β → γ}
+  (hf : injective f) (hg : injective g) (hfg : ∀ a b, f a ≠ g b) :
+  injective (sum.elim f g)
+| (inl x) (inl y) h := congr_arg inl $ hf h
+| (inl x) (inr y) h := (hfg x y h).elim
+| (inr x) (inl y) h := (hfg y x h.symm).elim
+| (inr x) (inr y) h := congr_arg inr $ hg h
 
 lemma injective.sum_map {f : α → β} {g : α' → β'} (hf : injective f) (hg : injective g) :
   injective (sum.map f g)

--- a/src/data/sum.lean
+++ b/src/data/sum.lean
@@ -129,20 +129,40 @@ update_eq_iff.2 ⟨by simp, by simp { contextual := tt }⟩
   update f (inl i) x ∘ inl = update (f ∘ inl) i x :=
 update_comp_eq_of_injective _ injective_inl _ _
 
+@[simp] lemma update_inl_apply_inl {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
+  {f : α ⊕ β → γ} {i j : α} {x : γ} :
+  update f (inl i) x (inl j) = update (f ∘ inl) i x j :=
+by rw ← update_inl_comp_inl
+
 @[simp] lemma update_inl_comp_inr {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
   {f : α ⊕ β → γ} {i : α} {x : γ} :
   update f (inl i) x ∘ inr = f ∘ inr :=
 update_comp_eq_of_forall_ne _ _ $ λ _, inr_ne_inl
+
+@[simp] lemma update_inl_apply_inr {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
+  {f : α ⊕ β → γ} {i : α} {j : β} {x : γ} :
+  update f (inl i) x (inr j) = f (inr j) :=
+function.update_noteq inr_ne_inl _ _
 
 @[simp] lemma update_inr_comp_inl {α β γ} [decidable_eq β] [decidable_eq (α ⊕ β)]
   {f : α ⊕ β → γ} {i : β} {x : γ} :
   update f (inr i) x ∘ inl = f ∘ inl :=
 update_comp_eq_of_forall_ne _ _ $ λ _, inl_ne_inr
 
+@[simp] lemma update_inr_apply_inl {α β γ} [decidable_eq α] [decidable_eq (α ⊕ β)]
+  {f : α ⊕ β → γ} {i : α} {j : β} {x : γ} :
+  update f (inr j) x (inl i) = f (inl i) :=
+function.update_noteq inl_ne_inr _ _
+
 @[simp] lemma update_inr_comp_inr {α β γ} [decidable_eq β] [decidable_eq (α ⊕ β)]
   {f : α ⊕ β → γ} {i : β} {x : γ} :
   update f (inr i) x ∘ inr = update (f ∘ inr) i x :=
 update_comp_eq_of_injective _ injective_inr _ _
+
+@[simp] lemma update_inr_apply_inr {α β γ} [decidable_eq β] [decidable_eq (α ⊕ β)]
+  {f : α ⊕ β → γ} {i j : β} {x : γ} :
+  update f (inr i) x (inr j) = update (f ∘ inr) i x j :=
+by rw ← update_inr_comp_inr
 
 section
   variables (ra : α → α → Prop) (rb : β → β → Prop)

--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -621,33 +621,9 @@ https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X
 def dom_coprod
   (a : multilinear_map R (λ _ : ι₁, N) N₁) (b : multilinear_map R (λ _ : ι₂, N) N₂) :
   multilinear_map R (λ _ : ι₁ ⊕ ι₂, N) (N₁ ⊗[R] N₂) :=
-have inl_disjoint : ∀ {α β : Type*} (a : α),
-  (sum.inl a : α ⊕ β) ∉ set.range (@sum.inr α β) := by simp,
-have inr_disjoint : ∀ {α β : Type*} (b : β),
-  (sum.inr b : α ⊕ β) ∉ set.range (@sum.inl α β) := by simp,
 { to_fun := λ v, a (λ i, v (sum.inl i)) ⊗ₜ b (λ i, v (sum.inr i)),
-  map_add' := λ v i p q, begin
-    cases i,
-    { iterate 3 {
-        rw [function.update_comp_eq_of_injective' _ sum.injective_inl,
-            function.update_comp_eq_of_not_mem_range' _ _ (inl_disjoint i)],},
-      rw [a.map_add, tensor_product.add_tmul], },
-    { iterate 3 {
-        rw [function.update_comp_eq_of_injective' _ sum.injective_inr,
-            function.update_comp_eq_of_not_mem_range' _ _ (inr_disjoint i)],},
-      rw [b.map_add, tensor_product.tmul_add], }
-  end,
-  map_smul' := λ v i c p, begin
-    cases i,
-    { iterate 2 {
-        rw [function.update_comp_eq_of_injective' _ sum.injective_inl,
-            function.update_comp_eq_of_not_mem_range' _ _ (inl_disjoint i)],},
-      rw [a.map_smul, tensor_product.smul_tmul'], },
-    { iterate 2 {
-        rw [function.update_comp_eq_of_injective' _ sum.injective_inr,
-            function.update_comp_eq_of_not_mem_range' _ _ (inr_disjoint i)]},
-      rw [b.map_smul, tensor_product.tmul_smul], },
-  end }
+  map_add' := λ v i p q, by cases i; simp [tensor_product.add_tmul, tensor_product.tmul_add],
+  map_smul' := λ v i c p, by cases i; simp [tensor_product.smul_tmul', tensor_product.tmul_smul] }
 
 /-- A more bundled version of `multilinear_map.dom_coprod` that maps
 `((ι₁ → N) → N₁) ⊗ ((ι₂ → N) → N₂)` to `(ι₁ ⊕ ι₂ → N) → N₁ ⊗ N₂`. -/
@@ -862,9 +838,7 @@ def linear_map.uncurry_left
 { to_fun := λm, f (m 0) (tail m),
   map_add' := λm i x y, begin
     by_cases h : i = 0,
-    { revert x y,
-      rw h,
-      assume x y,
+    { subst i,
       rw [update_same, update_same, update_same, f.map_add, add_apply,
           tail_update_zero, tail_update_zero, tail_update_zero] },
     { rw [update_noteq (ne.symm h), update_noteq (ne.symm h), update_noteq (ne.symm h)],
@@ -875,9 +849,7 @@ def linear_map.uncurry_left
   end,
   map_smul' := λm i c x, begin
     by_cases h : i = 0,
-    { revert x,
-      rw h,
-      assume x,
+    { subst i,
       rw [update_same, update_same, tail_update_zero, tail_update_zero,
           ← smul_apply, f.map_smul] },
     { rw [update_noteq (ne.symm h), update_noteq (ne.symm h)],

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -153,11 +153,11 @@ def sum_map {α β γ δ : Type*} (e₁ : α ↪ β) (e₂ : γ ↪ δ) : α ⊕
 rfl
 
 /-- The embedding of `α` into the sum `α ⊕ β`. -/
-def inl {α β : Type*} : α ↪ α ⊕ β :=
+@[simps] def inl {α β : Type*} : α ↪ α ⊕ β :=
 ⟨sum.inl, λ a b, sum.inl.inj⟩
 
 /-- The embedding of `β` into the sum `α ⊕ β`. -/
-def inr {α β : Type*} : β ↪ α ⊕ β :=
+@[simps] def inr {α β : Type*} : β ↪ α ⊕ β :=
 ⟨sum.inr, λ a b, sum.inr.inj⟩
 
 end sum

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -347,7 +347,7 @@ lemma update_comp_eq_of_forall_ne' {α'} (g : Π a, β a) {f : α' → α} {i : 
   (λ j, (update g i a) (f j)) = (λ j, g (f j)) :=
 funext $ λ x, update_noteq (h _) _ _
 
-/-- Non-dependent version of `function.update_comp_eq_of_not_mem_range'` -/
+/-- Non-dependent version of `function.update_comp_eq_of_forall_ne'` -/
 lemma update_comp_eq_of_forall_ne {α β : Sort*} (g : α' → β) {f : α → α'} {i : α'} (a : β)
   (h : ∀ x, f x ≠ i) :
   (update g i a) ∘ f = g ∘ f :=

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -342,9 +342,27 @@ funext_iff.trans $ forall_update_iff _ (λ x y, g x = y)
 @[simp] lemma update_eq_self (a : α) (f : Πa, β a) : update f a (f a) = f :=
 update_eq_iff.2 ⟨rfl, λ _ _, rfl⟩
 
-lemma update_comp {β : Sort v} (f : α → β) {g : α' → α} (hg : injective g) (a : α') (v : β) :
-  (update f (g a) v) ∘ g = update (f ∘ g) a v :=
-eq_update_iff.2 ⟨update_same _ _ _, λ x hx, update_noteq (hg.ne hx) _ _⟩
+lemma update_comp_eq_of_forall_ne' {α'} (g : Π a, β a) {f : α' → α} {i : α} (a : β i)
+  (h : ∀ x, f x ≠ i) :
+  (λ j, (update g i a) (f j)) = (λ j, g (f j)) :=
+funext $ λ x, update_noteq (h _) _ _
+
+/-- Non-dependent version of `function.update_comp_eq_of_not_mem_range'` -/
+lemma update_comp_eq_of_forall_ne {α β : Sort*} (g : α' → β) {f : α → α'} {i : α'} (a : β)
+  (h : ∀ x, f x ≠ i) :
+  (update g i a) ∘ f = g ∘ f :=
+update_comp_eq_of_forall_ne' g a h
+
+lemma update_comp_eq_of_injective' (g : Π a, β a) {f : α' → α} (hf : function.injective f)
+  (i : α') (a : β (f i)) :
+  (λ j, update g (f i) a (f j)) = update (λ i, g (f i)) i a :=
+eq_update_iff.2 ⟨update_same _ _ _, λ j hj, update_noteq (hf.ne hj) _ _⟩
+
+/-- Non-dependent version of `function.update_comp_eq_of_injective'` -/
+lemma update_comp_eq_of_injective {β : Sort*} (g : α' → β) {f : α → α'}
+  (hf : function.injective f) (i : α) (a : β) :
+  (function.update g (f i) a) ∘ f = function.update (g ∘ f) i a :=
+update_comp_eq_of_injective' g hf i a
 
 lemma apply_update {ι : Sort*} [decidable_eq ι] {α β : ι → Sort*}
   (f : Π i, α i → β i) (g : Π i, α i) (i : ι) (v : α i) (j : ι) :

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -528,6 +528,8 @@ e.to_equiv.symm_apply_eq
 lemma symm_injective : injective (symm : (α ≃o β) → (β ≃o α)) :=
 λ e e' h, by rw [← e.symm_symm, h, e'.symm_symm]
 
+@[simp] lemma to_equiv_symm (e : α ≃o β) : e.to_equiv.symm = e.symm.to_equiv := rfl
+
 /-- Composition of two order isomorphisms is an order isomorphism. -/
 @[trans] def trans (e : α ≃o β) (e' : β ≃o γ) : α ≃o γ := e.trans e'
 

--- a/src/topology/algebra/multilinear.lean
+++ b/src/topology/algebra/multilinear.lean
@@ -107,6 +107,10 @@ instance : has_add (continuous_multilinear_map R M₁ M₂) :=
 
 @[simp] lemma add_apply (m : Πi, M₁ i) : (f + f') m = f m + f' m := rfl
 
+@[simp] lemma to_multilinear_map_add (f g : continuous_multilinear_map R M₁ M₂) :
+  (f + g).to_multilinear_map = f.to_multilinear_map + g.to_multilinear_map :=
+rfl
+
 instance add_comm_monoid : add_comm_monoid (continuous_multilinear_map R M₁ M₂) :=
 by refine {zero := 0, add := (+), ..}; intros; ext; simp [add_comm, add_left_comm]
 
@@ -277,6 +281,10 @@ instance : has_scalar R' (continuous_multilinear_map A M₁ M₂) :=
 @[simp] lemma smul_apply (f : continuous_multilinear_map A M₁ M₂) (c : R') (m : Πi, M₁ i) :
   (c • f) m = c • f m := rfl
 
+@[simp] lemma to_multilinear_map_smul (c : R') (f : continuous_multilinear_map A M₁ M₂) :
+  (c • f).to_multilinear_map = c • f.to_multilinear_map :=
+rfl
+
 instance {R''} [comm_semiring R''] [has_scalar R' R''] [algebra R'' A]
   [semimodule R'' M₂] [is_scalar_tower R'' A M₂] [is_scalar_tower R' R'' M₂]
   [topological_space R''] [topological_semimodule R'' M₂]:
@@ -298,7 +306,7 @@ instance : semimodule R' (continuous_multilinear_map A M₁ M₂) :=
 
 /-- Linear map version of the map `to_multilinear_map` associating to a continuous multilinear map
 the corresponding multilinear map. -/
-def to_multilinear_map_linear :
+@[simps] def to_multilinear_map_linear :
   (continuous_multilinear_map A M₁ M₂) →ₗ[R'] (multilinear_map A M₁ M₂) :=
 { to_fun    := λ f, f.to_multilinear_map,
   map_add'  := λ f g, rfl,


### PR DESCRIPTION
* `finset.prod_sum_elim`, `finset.sum_sum_elim`: use `finset.map`
  instead of `finset.image`;
* add `multilinear_map.coe_mk_continuous`,
  `finset.order_emb_of_fin_mem`, `fintype.univ_sum_type`,
  `fintype.prod_sum_elim`, `sum.update_elim_inl`,
  `sum.update_elim_inr`, `sum.update_inl_comp_inl`,
  `sum.update_inl_comp_inr`, `sum.update_inr_comp_inl`,
  `sum.update_inr_comp_inr` and `apply` versions of `sum.*_comp_*` lemmas,
* move some lemmas about `function.update` from `data.set.function` to `logic.function.basic`;
* rename `sum.elim_injective` to `function.injective.sum_elim`
* `simps` lemmas for `function.embedding.inl` and
  `function.embedding.inr`;
* for `e : α ≃o β`, simplify `e.to_equiv.symm` to `e.symm_to_equiv`;
* add `continuous_multilinear_map.to_multilinear_map_add`,
  `continuous_multilinear_map.to_multilinear_map_smul`, and `simps`
  for `continuous_multilinear_map.to_multilinear_map_linear`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->