### PR TITLE
feat(combinatorics/simple_graph/basic): add edge contraction and deletion

### DIFF
--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -489,11 +489,9 @@ def delete_edge {G : simple_graph V} {v w : V} (h : G.adj v w) : simple_graph V 
             split,
             { contrapose,
               push_neg,
-              simp only [ne.def],
               exact haw },
             { contrapose,
               push_neg,
-              simp only [ne.def],
               exact hav },
           end,
   loopless := λ a, by simp only [simple_graph.irrefl, not_false_iff, and_false]}

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -467,4 +467,37 @@ end
 
 end complement
 
+section graph_operations
+
+def two_pt_quo {β : Type*} (v w : β) := @quot β (λ i j, i = j ∨ (i = v ∧ j = w) ∨ (i = w ∧ j = v))
+
+def contract_edge {G : simple_graph V} {v w : V} (h : G.adj v w) : simple_graph (two_pt_quo v w) :=
+{ adj := λ i j, G.adj (quot.out i) (quot.out j),
+  sym := λ x y h, by exact (G.edge_symm (quot.out x) (quot.out y)).1 h,
+  loopless := λ x, by simp only [simple_graph.irrefl, not_false_iff]}
+
+def delete_edge {G : simple_graph V} {v w : V} (h : G.adj v w) : simple_graph V :=
+{ adj := λ a b, ¬((a = v ∧ b = w) ∨ (a = w ∧ b = v)) ∧ G.adj a b,
+  sym := λ a b,
+          begin
+            simp only [and_imp],
+            intros hne hadj,
+            refine ⟨_, (G.edge_symm a b).1 hadj⟩,
+            push_neg,
+            push_neg at hne,
+            cases hne with hav haw,
+            split,
+            { contrapose,
+              push_neg,
+              simp only [ne.def],
+              exact haw },
+            { contrapose,
+              push_neg,
+              simp only [ne.def],
+              exact hav },
+          end,
+  loopless := λ a, by simp only [simple_graph.irrefl, not_false_iff, and_false]}
+
+end graph_operations
+
 end simple_graph


### PR DESCRIPTION
Add the definitions of edge contraction and deletion. Adapted from [simple_graphs2](https://github.com/leanprover-community/mathlib/tree/simple_graphs2).

Coauthor: @kmill 

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
