### PR TITLE
[Merged by Bors] - refactor(data/pequiv): simpler proof of `pequiv.of_set_univ`

### DIFF
--- a/src/data/pequiv.lean
+++ b/src/data/pequiv.lean
@@ -140,7 +140,7 @@ by dsimp [of_set]; split_ifs; split; finish
 @[simp] lemma of_set_symm : (of_set s).symm = of_set s := rfl
 
 @[simp] lemma of_set_univ : of_set set.univ = pequiv.refl α :=
-by ext; dsimp [of_set]; simp [eq_comm]
+by refl
 
 @[simp] lemma of_set_eq_refl {s : set α} [decidable_pred s] :
   of_set s = pequiv.refl α ↔ s = set.univ :=

--- a/src/data/pequiv.lean
+++ b/src/data/pequiv.lean
@@ -140,7 +140,7 @@ by dsimp [of_set]; split_ifs; split; finish
 @[simp] lemma of_set_symm : (of_set s).symm = of_set s := rfl
 
 @[simp] lemma of_set_univ : of_set set.univ = pequiv.refl α :=
-by refl
+rfl
 
 @[simp] lemma of_set_eq_refl {s : set α} [decidable_pred s] :
   of_set s = pequiv.refl α ↔ s = set.univ :=

--- a/src/data/pequiv.lean
+++ b/src/data/pequiv.lean
@@ -139,8 +139,7 @@ by dsimp [of_set]; split_ifs; split; finish
 
 @[simp] lemma of_set_symm : (of_set s).symm = of_set s := rfl
 
-@[simp] lemma of_set_univ : of_set set.univ = pequiv.refl α :=
-rfl
+@[simp] lemma of_set_univ : of_set set.univ = pequiv.refl α := rfl
 
 @[simp] lemma of_set_eq_refl {s : set α} [decidable_pred s] :
   of_set s = pequiv.refl α ↔ s = set.univ :=


### PR DESCRIPTION
17X smaller proof

co-authors: `lean-gptf`, Stanislas Polu


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
