### PR TITLE
[Merged by Bors] - refactor(data/real/golden_ratio): simpler proof of `gold_pos`

### DIFF
--- a/src/data/real/golden_ratio.lean
+++ b/src/data/real/golden_ratio.lean
@@ -76,10 +76,7 @@ begin
 end
 
 lemma gold_pos : 0 < φ :=
-begin
-  rw golden_ratio,
-  linarith [real.sqrt_nonneg 5]
-end
+mul_pos (by apply add_pos; norm_num) $ inv_pos.2 zero_lt_two
 
 lemma gold_ne_zero : φ ≠ 0 := ne_of_gt gold_pos
 


### PR DESCRIPTION
13X smaller (pretty-printed) proof term

Co-authors: `lean-gptf`, Stanislas Polu


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
