### PR TITLE
[Merged by Bors] - refactor(category_theory/abelian): golf `mono_of_kernel_ι_eq_zero`

### DIFF
--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -161,11 +161,7 @@ lemma mono_of_zero_kernel (R : C)
 non_preadditive_abelian.mono_of_zero_kernel _ _ l
 
 lemma mono_of_kernel_ι_eq_zero (h : kernel.ι f = 0) : mono f :=
-begin
-  apply mono_of_zero_kernel _ (kernel f),
-  simp_rw ←h,
-  exact is_limit.of_iso_limit (limit.is_limit (parallel_pair f 0)) (iso_of_ι _)
-end
+mono_of_kernel_zero h
 
 lemma epi_of_zero_cokernel (R : C)
   (l : is_colimit (cokernel_cofork.of_π (0 : Q ⟶ R) (show f ≫ 0 = 0, by simp))) : epi f :=


### PR DESCRIPTION
Co-authors: `lean-gptf`, Stanislas Polu


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
