### PR TITLE
[Merged by Bors] - refactor(topology/local_homeomorph): simplify `prod_trans`

### DIFF
--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -541,7 +541,7 @@ by ext x; simp [prod_coe_symm]
   (e' : local_homeomorph δ η) (f' : local_homeomorph η ε) :
   (e.prod e').trans (f.prod f') = (e.trans f).prod (e'.trans f') :=
 local_homeomorph.eq_of_local_equiv_eq $
-  by simp only [trans_to_local_equiv, local_equiv.prod_trans, prod_to_local_equiv]
+  by dsimp only [trans_to_local_equiv, prod_to_local_equiv]; apply local_equiv.prod_trans
 
 end prod
 

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -540,7 +540,8 @@ by ext x; simp [prod_coe_symm]
   (e : local_homeomorph α β) (f : local_homeomorph β γ)
   (e' : local_homeomorph δ η) (f' : local_homeomorph η ε) :
   (e.prod e').trans (f.prod f') = (e.trans f).prod (e'.trans f') :=
-by ext x; simp [ext_iff]; tauto
+local_homeomorph.eq_of_local_equiv_eq $
+  by simp only [trans_to_local_equiv, local_equiv.prod_trans, prod_to_local_equiv]
 
 end prod
 


### PR DESCRIPTION
10X faster elaboration

(pretty-printed) proof term length 14637 -> 2046

Co-authors: `lean-gptf`, Stanislas Polu


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
