### PR TITLE
[Merged by Bors] - refactor(analysis/calculus/inverse): inverse of C^k functions over R or C

### DIFF
--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -36,7 +36,7 @@ In the one-dimensional case we reformulate these theorems in terms of `has_stric
 We also reformulate the theorems in terms of `times_cont_diff`, to give that `C^k` (respectively,
 smooth) inputs give `C^k` (smooth) inverses.  These versions require that continuous
 differentiability implies strict differentiability; this is false over a general field, true over
-`ℝ` (the setting in which it is implemented here), and true but (TODO) not yet implemented over `ℂ`.
+`ℝ` or `ℂ` and implemented here assuming `is_R_or_C 𝕂`.
 
 Some related theorems, providing the derivative and higher regularity assuming that we already know
 the inverse function, are formulated in `fderiv.lean`, `deriv.lean`, and `times_cont_diff.lean`.
@@ -529,14 +529,15 @@ is_open_map_iff_nhds_le.2 $ λ x, ((hf x).map_nhds_eq (h0 x)).ge
 -/
 
 namespace times_cont_diff_at
-variables {E' : Type*} [normed_group E'] [normed_space ℝ E']
-variables {F' : Type*} [normed_group F'] [normed_space ℝ F']
-variables [complete_space E'] (f : E' → F') {f' : E' ≃L[ℝ] F'} {a : E'}
+variables {𝕂 : Type*} [is_R_or_C 𝕂]
+variables {E' : Type*} [normed_group E'] [normed_space 𝕂 E']
+variables {F' : Type*} [normed_group F'] [normed_space 𝕂 F']
+variables [complete_space E'] (f : E' → F') {f' : E' ≃L[𝕂] F'} {a : E'}
 
-/-- Given a `times_cont_diff` function over `ℝ` with an invertible derivative at `a`, returns a
-`local_homeomorph` with `to_fun = f` and `a ∈ source`. -/
+/-- Given a `times_cont_diff` function over `𝕂` (which is `ℝ` or `ℂ`) with an invertible
+derivative at `a`, returns a `local_homeomorph` with `to_fun = f` and `a ∈ source`. -/
 def to_local_homeomorph
-  {n : with_top ℕ} (hf : times_cont_diff_at ℝ n f a) (hf' : has_fderiv_at f (f' : E' →L[ℝ] F') a)
+  {n : with_top ℕ} (hf : times_cont_diff_at 𝕂 n f a) (hf' : has_fderiv_at f (f' : E' →L[𝕂] F') a)
   (hn : 1 ≤ n) :
   local_homeomorph E' F' :=
 (hf.has_strict_fderiv_at' hf' hn).to_local_homeomorph f
@@ -544,42 +545,43 @@ def to_local_homeomorph
 variable {f}
 
 @[simp] lemma to_local_homeomorph_coe
-  {n : with_top ℕ} (hf : times_cont_diff_at ℝ n f a) (hf' : has_fderiv_at f (f' : E' →L[ℝ] F') a)
+  {n : with_top ℕ} (hf : times_cont_diff_at 𝕂 n f a) (hf' : has_fderiv_at f (f' : E' →L[𝕂] F') a)
   (hn : 1 ≤ n) :
   (hf.to_local_homeomorph f hf' hn : E' → F') = f := rfl
 
 lemma mem_to_local_homeomorph_source
-  {n : with_top ℕ} (hf : times_cont_diff_at ℝ n f a) (hf' : has_fderiv_at f (f' : E' →L[ℝ] F') a)
+  {n : with_top ℕ} (hf : times_cont_diff_at 𝕂 n f a) (hf' : has_fderiv_at f (f' : E' →L[𝕂] F') a)
   (hn : 1 ≤ n) :
   a ∈ (hf.to_local_homeomorph f hf' hn).source :=
 (hf.has_strict_fderiv_at' hf' hn).mem_to_local_homeomorph_source
 
 lemma image_mem_to_local_homeomorph_target
-  {n : with_top ℕ} (hf : times_cont_diff_at ℝ n f a) (hf' : has_fderiv_at f (f' : E' →L[ℝ] F') a)
+  {n : with_top ℕ} (hf : times_cont_diff_at 𝕂 n f a) (hf' : has_fderiv_at f (f' : E' →L[𝕂] F') a)
   (hn : 1 ≤ n) :
   f a ∈ (hf.to_local_homeomorph f hf' hn).target :=
 (hf.has_strict_fderiv_at' hf' hn).image_mem_to_local_homeomorph_target
 
-/-- Given a `times_cont_diff` function over `ℝ` with an invertible derivative at `a`, returns a
-function that is locally inverse to `f`. -/
+/-- Given a `times_cont_diff` function over `𝕂` (which is `ℝ` or `ℂ`) with an invertible derivative
+at `a`, returns a function that is locally inverse to `f`. -/
 def local_inverse
-  {n : with_top ℕ} (hf : times_cont_diff_at ℝ n f a) (hf' : has_fderiv_at f (f' : E' →L[ℝ] F') a)
+  {n : with_top ℕ} (hf : times_cont_diff_at 𝕂 n f a) (hf' : has_fderiv_at f (f' : E' →L[𝕂] F') a)
   (hn : 1 ≤ n) :
   F' → E' :=
 (hf.has_strict_fderiv_at' hf' hn).local_inverse f f' a
 
 lemma local_inverse_apply_image
-  {n : with_top ℕ} (hf : times_cont_diff_at ℝ n f a) (hf' : has_fderiv_at f (f' : E' →L[ℝ] F') a)
+  {n : with_top ℕ} (hf : times_cont_diff_at 𝕂 n f a) (hf' : has_fderiv_at f (f' : E' →L[𝕂] F') a)
   (hn : 1 ≤ n) :
   hf.local_inverse hf' hn (f a) = a :=
 (hf.has_strict_fderiv_at' hf' hn).local_inverse_apply_image
 
-/-- Given a `times_cont_diff` function over `ℝ` with an invertible derivative at `a`, the inverse
-function (produced by `times_cont_diff.to_local_homeomorph`) is also `times_cont_diff`. -/
+/-- Given a `times_cont_diff` function over `𝕂` (which is `ℝ` or `ℂ`) with an invertible derivative
+at `a`, the inverse function (produced by `times_cont_diff.to_local_homeomorph`) is
+also `times_cont_diff`. -/
 lemma to_local_inverse
-  {n : with_top ℕ} (hf : times_cont_diff_at ℝ n f a) (hf' : has_fderiv_at f (f' : E' →L[ℝ] F') a)
+  {n : with_top ℕ} (hf : times_cont_diff_at 𝕂 n f a) (hf' : has_fderiv_at f (f' : E' →L[𝕂] F') a)
   (hn : 1 ≤ n) :
-  times_cont_diff_at ℝ n (hf.local_inverse hf' hn) (f a) :=
+  times_cont_diff_at 𝕂 n (hf.local_inverse hf' hn) (f a) :=
 begin
   have := hf.local_inverse_apply_image hf' hn,
   apply (hf.to_local_homeomorph f hf' hn).times_cont_diff_at_symm

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -5,6 +5,7 @@ Authors: Sébastien Gouëzel, Yury Kudryashov
 -/
 import analysis.calculus.local_extr
 import analysis.convex.topology
+import data.complex.is_R_or_C
 
 /-!
 # The mean value inequality and equalities
@@ -1075,11 +1076,45 @@ begin
   simp [g, hMVT'],
 end
 
-/-! ### Vector-valued functions `f : E → F`.  Strict differentiability. -/
 
-/-- Over the reals, a continuously differentiable function is strictly differentiable. -/
+section is_R_or_C
+
+/-!
+### Vector-valued functions `f : E → F`.  Strict differentiability.
+
+A `C^1` function is strictly differentiable, when the field is `ℝ` or `ℂ`. This follows from the
+mean value inequality on balls, which is a particular case of the above results after restricting
+the scalars to `ℝ`. Note that it does not make sense to talk of a convex set over `ℂ`, but balls
+make sense and are enough. Many formulations of the mean value inequality could be generalized to
+balls over `ℝ` or `ℂ`. For now, we only include the ones that we need.
+-/
+
+variables {𝕜 : Type*} [is_R_or_C 𝕜]
+{G : Type*} [normed_group G] [normed_space 𝕜 G]
+{H : Type*} [normed_group H] [normed_space 𝕜 H]
+
+/-- Variant of the mean value inequality over `ℝ` or `ℂ`, on a ball, using a bound on the difference
+between the derivative and a fixed linear map, rather than a bound on the derivative itself.
+Version with `has_fderiv_within`. -/
+theorem is_R_or_C.norm_image_sub_le_of_norm_has_fderiv_within_le'
+  {f : G → H} {C : ℝ} {x y z : G} {r : ℝ} {f' : G → (G →L[𝕜] H)} {φ : G →L[𝕜] H}
+  (hf : ∀ x ∈ ball z r, has_fderiv_within_at f (f' x) (ball z r) x)
+  (bound : ∀ x ∈ ball z r, ∥f' x - φ∥ ≤ C) (xs : x ∈ ball z r) (ys : y ∈ ball z r) :
+  ∥f y - f x - φ (y - x)∥ ≤ C * ∥y - x∥ :=
+begin
+  letI : normed_space ℝ G := restrict_scalars.normed_space ℝ 𝕜 G,
+  letI : is_scalar_tower ℝ 𝕜 G := restrict_scalars.is_scalar_tower _ _ _,
+  letI : normed_space ℝ H := restrict_scalars.normed_space ℝ 𝕜 H,
+  letI : is_scalar_tower ℝ 𝕜 H := restrict_scalars.is_scalar_tower _ _ _,
+  change ∥f y - f x - (φ.restrict_scalars ℝ) (y - x)∥ ≤ C * ∥y - x∥,
+  have : ∀ x ∈ ball z r, has_fderiv_within_at f ((f' x).restrict_scalars ℝ) (ball z r) x := hf,
+  exact convex.norm_image_sub_le_of_norm_has_fderiv_within_le' this bound (convex_ball _ _) xs ys,
+end
+
+/-- Over the reals or the complexes, a continuously differentiable function is strictly
+differentiable. -/
 lemma strict_fderiv_of_cont_diff
-  {f : E → F} {s : set E}  {x : E} {f' : E → (E →L[ℝ] F)}
+  {f : G → H} {s : set G}  {x : G} {f' : G → (G →L[𝕜] H)}
   (hf : ∀ x ∈ s, has_fderiv_within_at f (f' x) s x) (hcont : continuous_on f' s) (hs : s ∈ 𝓝 x) :
   has_strict_fderiv_at f (f' x) x :=
 begin
@@ -1096,7 +1131,6 @@ begin
   have hts : t ⊆ s := λ _ hy, hε₂ (ball_subset_ball (min_le_right ε₁ ε₂) hy),
   have Hf : ∀ y ∈ t, has_fderiv_within_at f (f' y) t y :=
     λ y yt, has_fderiv_within_at.mono (hf y (hts yt)) hts,
-  have hconv := convex_ball x (min ε₁ ε₂),
 -- simplify formulas involving the product E × E
   rintros ⟨a, b⟩ h,
   simp only [mem_set_of_eq, map_sub],
@@ -1107,5 +1141,7 @@ begin
     refine le_of_lt (hcont' x' (hts H') _),
     exact ball_subset_ball (min_le_left ε₁ ε₂) H' },
 -- apply mean value theorem
-  simpa using convex.norm_image_sub_le_of_norm_has_fderiv_within_le' Hf hf' hconv hab.2 hab.1,
+  simpa using is_R_or_C.norm_image_sub_le_of_norm_has_fderiv_within_le' Hf hf' hab.2 hab.1,
 end
+
+end is_R_or_C

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -2523,35 +2523,36 @@ end function_inverse
 
 section real
 /-!
-### Results over `ℝ`
+### Results over `ℝ` or `ℂ`
   The results in this section rely on the Mean Value Theorem, and therefore hold only over `ℝ` (and
   its extension fields such as `ℂ`).
 -/
 
 variables
-{E' : Type*} [normed_group E'] [normed_space ℝ E']
-{F' : Type*} [normed_group F'] [normed_space ℝ F']
+{𝕂 : Type*} [is_R_or_C 𝕂]
+{E' : Type*} [normed_group E'] [normed_space 𝕂 E']
+{F' : Type*} [normed_group F'] [normed_space 𝕂 F']
 
 /-- If a function has a Taylor series at order at least 1, then at points in the interior of the
     domain of definition, the term of order 1 of this series is a strict derivative of `f`. -/
 lemma has_ftaylor_series_up_to_on.has_strict_fderiv_at
-  {s : set E'} {f : E' → F'} {x : E'} {p : E' → formal_multilinear_series ℝ E' F'} {n : with_top ℕ}
+  {s : set E'} {f : E' → F'} {x : E'} {p : E' → formal_multilinear_series 𝕂 E' F'} {n : with_top ℕ}
   (hf : has_ftaylor_series_up_to_on n f p s) (hn : 1 ≤ n) (hs : s ∈ 𝓝 x) :
-  has_strict_fderiv_at f ((continuous_multilinear_curry_fin1 ℝ E' F') (p x 1)) x :=
+  has_strict_fderiv_at f ((continuous_multilinear_curry_fin1 𝕂 E' F') (p x 1)) x :=
 begin
-  let f' := λ x, (continuous_multilinear_curry_fin1 ℝ E' F') (p x 1),
+  let f' := λ x, (continuous_multilinear_curry_fin1 𝕂 E' F') (p x 1),
   have hf' : ∀ x, x ∈ s → has_fderiv_within_at f (f' x) s x :=
     λ x, has_ftaylor_series_up_to_on.has_fderiv_within_at hf hn,
   have hcont : continuous_on f' s :=
-    (continuous_multilinear_curry_fin1 ℝ E' F').continuous.comp_continuous_on (hf.cont 1 hn),
+    (continuous_multilinear_curry_fin1 𝕂 E' F').continuous.comp_continuous_on (hf.cont 1 hn),
   exact strict_fderiv_of_cont_diff hf' hcont hs,
 end
 
 /-- If a function is `C^n` with `1 ≤ n` around a point, then the derivative of `f` at this point
 is also a strict derivative. -/
 lemma times_cont_diff_at.has_strict_fderiv_at {f : E' → F'} {x : E'} {n : with_top ℕ}
-  (hf : times_cont_diff_at ℝ n f x) (hn : 1 ≤ n) :
-  has_strict_fderiv_at f (fderiv ℝ f x) x :=
+  (hf : times_cont_diff_at 𝕂 n f x) (hn : 1 ≤ n) :
+  has_strict_fderiv_at f (fderiv 𝕂 f x) x :=
 begin
   rcases hf 1 hn with ⟨u, H, p, hp⟩,
   simp only [nhds_within_univ, mem_univ, insert_eq_of_mem] at H,
@@ -2563,15 +2564,15 @@ end
 /-- If a function is `C^n` with `1 ≤ n` around a point, and its derivative at that point is given to
 us as `f'`, then `f'` is also a strict derivative. -/
 lemma times_cont_diff_at.has_strict_fderiv_at'
-  {f : E' → F'} {f' : E' →L[ℝ] F'} {x : E'}
-  {n : with_top ℕ} (hf : times_cont_diff_at ℝ n f x) (hf' : has_fderiv_at f f' x) (hn : 1 ≤ n) :
+  {f : E' → F'} {f' : E' →L[𝕂] F'} {x : E'}
+  {n : with_top ℕ} (hf : times_cont_diff_at 𝕂 n f x) (hf' : has_fderiv_at f f' x) (hn : 1 ≤ n) :
   has_strict_fderiv_at f f' x :=
 by simpa only [hf'.fderiv] using hf.has_strict_fderiv_at hn
 
 /-- If a function is `C^n` with `1 ≤ n`, then the derivative of `f` is also a strict derivative. -/
 lemma times_cont_diff.has_strict_fderiv_at
-  {f : E' → F'} {x : E'} {n : with_top ℕ} (hf : times_cont_diff ℝ n f) (hn : 1 ≤ n) :
-  has_strict_fderiv_at f (fderiv ℝ f x) x :=
+  {f : E' → F'} {x : E'} {n : with_top ℕ} (hf : times_cont_diff 𝕂 n f) (hn : 1 ≤ n) :
+  has_strict_fderiv_at f (fderiv 𝕂 f x) x :=
 hf.times_cont_diff_at.has_strict_fderiv_at hn
 
 end real

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -5,6 +5,7 @@ Authors: Sébastien Gouëzel
 -/
 import analysis.normed_space.finite_dimension
 import data.complex.module
+import data.complex.is_R_or_C
 
 /-!
 # Normed space structure on `ℂ`.
@@ -23,6 +24,8 @@ it defines functions:
 
 They are bundled versions of the real part, the imaginary part, and the embedding of `ℝ` in `ℂ`,
 as continuous `ℝ`-linear maps.
+
+We also register the fact that `ℂ` is an `is_R_or_C` field.
 -/
 noncomputable theory
 
@@ -133,4 +136,49 @@ lemma continuous_of_real : continuous (coe : ℝ → ℂ) := isometry_of_real.co
   ∥continuous_linear_map.of_real∥ = 1 :=
 linear_isometry.of_real.norm_to_continuous_linear_map
 
+noncomputable instance : is_R_or_C ℂ :=
+{ re := ⟨complex.re, complex.zero_re, complex.add_re⟩,
+  im := ⟨complex.im, complex.zero_im, complex.add_im⟩,
+  conj := complex.conj,
+  I := complex.I,
+  I_re_ax := by simp only [add_monoid_hom.coe_mk, complex.I_re],
+  I_mul_I_ax := by simp only [complex.I_mul_I, eq_self_iff_true, or_true],
+  re_add_im_ax := λ z, by simp only [add_monoid_hom.coe_mk, complex.re_add_im,
+                                     complex.coe_algebra_map, complex.of_real_eq_coe],
+  of_real_re_ax := λ r, by simp only [add_monoid_hom.coe_mk, complex.of_real_re,
+                                      complex.coe_algebra_map, complex.of_real_eq_coe],
+  of_real_im_ax := λ r, by simp only [add_monoid_hom.coe_mk, complex.of_real_im,
+                                      complex.coe_algebra_map, complex.of_real_eq_coe],
+  mul_re_ax := λ z w, by simp only [complex.mul_re, add_monoid_hom.coe_mk],
+  mul_im_ax := λ z w, by simp only [add_monoid_hom.coe_mk, complex.mul_im],
+  conj_re_ax := λ z, by simp only [ring_hom.coe_mk, add_monoid_hom.coe_mk, complex.conj_re],
+  conj_im_ax := λ z, by simp only [ring_hom.coe_mk, complex.conj_im, add_monoid_hom.coe_mk],
+  conj_I_ax := by simp only [complex.conj_I, ring_hom.coe_mk],
+  norm_sq_eq_def_ax := λ z, by simp only [←complex.norm_sq_eq_abs, ←complex.norm_sq_apply,
+    add_monoid_hom.coe_mk, complex.norm_eq_abs],
+  mul_im_I_ax := λ z, by simp only [mul_one, add_monoid_hom.coe_mk, complex.I_im],
+  inv_def_ax := λ z, by simp only [complex.inv_def, complex.norm_sq_eq_abs, complex.coe_algebra_map,
+    complex.of_real_eq_coe, complex.norm_eq_abs],
+  div_I_ax := complex.div_I }
+
 end complex
+
+namespace is_R_or_C
+
+local notation `reC` := @is_R_or_C.re ℂ _
+local notation `imC` := @is_R_or_C.im ℂ _
+local notation `conjC` := @is_R_or_C.conj ℂ _
+local notation `IC` := @is_R_or_C.I ℂ _
+local notation `absC` := @is_R_or_C.abs ℂ _
+local notation `norm_sqC` := @is_R_or_C.norm_sq ℂ _
+
+@[simp] lemma re_to_complex {x : ℂ} : reC x = x.re := rfl
+@[simp] lemma im_to_complex {x : ℂ} : imC x = x.im := rfl
+@[simp] lemma conj_to_complex {x : ℂ} : conjC x = x.conj := rfl
+@[simp] lemma I_to_complex : IC = complex.I := rfl
+@[simp] lemma norm_sq_to_complex {x : ℂ} : norm_sqC x = complex.norm_sq x :=
+by simp [is_R_or_C.norm_sq, complex.norm_sq]
+@[simp] lemma abs_to_complex {x : ℂ} : absC x = complex.abs x :=
+by simp [is_R_or_C.abs, complex.abs]
+
+end is_R_or_C

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -3,8 +3,8 @@ Copyright (c) Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import analysis.calculus.times_cont_diff
 import analysis.normed_space.finite_dimension
+import data.complex.module
 
 /-!
 # Normed space structure on `ℂ`.
@@ -23,10 +23,6 @@ it defines functions:
 
 They are bundled versions of the real part, the imaginary part, and the embedding of `ℝ` in `ℂ`,
 as continuous `ℝ`-linear maps.
-
-`has_deriv_at.real_of_complex` expresses that, if a function on `ℂ` is differentiable (over `ℂ`),
-then its restriction to `ℝ` is differentiable over `ℝ`, with derivative the real part of the
-complex derivative.
 -/
 noncomputable theory
 
@@ -138,41 +134,3 @@ lemma continuous_of_real : continuous (coe : ℝ → ℂ) := isometry_of_real.co
 linear_isometry.of_real.norm_to_continuous_linear_map
 
 end complex
-
-section real_deriv_of_complex
-/-! ### Differentiability of the restriction to `ℝ` of complex functions -/
-open complex
-variables {e : ℂ → ℂ} {e' : ℂ} {z : ℝ}
-
-/-- If a complex function is differentiable at a real point, then the induced real function is also
-differentiable at this point, with a derivative equal to the real part of the complex derivative. -/
-theorem has_deriv_at.real_of_complex (h : has_deriv_at e e' z) :
-  has_deriv_at (λx:ℝ, (e x).re) e'.re z :=
-begin
-  have A : has_fderiv_at continuous_linear_map.of_real continuous_linear_map.of_real z :=
-    continuous_linear_map.of_real.has_fderiv_at,
-  have B : has_fderiv_at e ((continuous_linear_map.smul_right 1 e' : ℂ →L[ℂ] ℂ).restrict_scalars ℝ)
-    (continuous_linear_map.of_real z) :=
-    (has_deriv_at_iff_has_fderiv_at.1 h).restrict_scalars ℝ,
-  have C : has_fderiv_at continuous_linear_map.re continuous_linear_map.re
-    (e (continuous_linear_map.of_real z)) := continuous_linear_map.re.has_fderiv_at,
-  simpa using has_fderiv_at_iff_has_deriv_at.1 (C.comp z (B.comp z A)),
-end
-
-theorem times_cont_diff_at.real_of_complex {n : with_top ℕ} (h : times_cont_diff_at ℂ n e z) :
-  times_cont_diff_at ℝ n (λ x : ℝ, (e x).re) z :=
-begin
-  have A : times_cont_diff_at ℝ n continuous_linear_map.of_real z,
-    from continuous_linear_map.of_real.times_cont_diff.times_cont_diff_at,
-  have B : times_cont_diff_at ℝ n e z := h.restrict_scalars ℝ,
-  have C : times_cont_diff_at ℝ n continuous_linear_map.re (e z),
-    from continuous_linear_map.re.times_cont_diff.times_cont_diff_at,
-  exact C.comp z (B.comp z A)
-end
-
-theorem times_cont_diff.real_of_complex {n : with_top ℕ} (h : times_cont_diff ℂ n e) :
-  times_cont_diff ℝ n (λ x : ℝ, (e x).re) :=
-times_cont_diff_iff_times_cont_diff_at.2 $ λ x,
-  h.times_cont_diff_at.real_of_complex
-
-end real_deriv_of_complex

--- a/src/analysis/complex/real_deriv.lean
+++ b/src/analysis/complex/real_deriv.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+import analysis.calculus.times_cont_diff
+import analysis.complex.basic
+
+/-! # Real differentiability of complex-differentiable functions
+
+`has_deriv_at.real_of_complex` expresses that, if a function on `ℂ` is differentiable (over `ℂ`),
+then its restriction to `ℝ` is differentiable over `ℝ`, with derivative the real part of the
+complex derivative.
+-/
+
+
+section real_deriv_of_complex
+/-! ### Differentiability of the restriction to `ℝ` of complex functions -/
+open complex
+variables {e : ℂ → ℂ} {e' : ℂ} {z : ℝ}
+
+/-- If a complex function is differentiable at a real point, then the induced real function is also
+differentiable at this point, with a derivative equal to the real part of the complex derivative. -/
+theorem has_deriv_at.real_of_complex (h : has_deriv_at e e' z) :
+  has_deriv_at (λx:ℝ, (e x).re) e'.re z :=
+begin
+  have A : has_fderiv_at continuous_linear_map.of_real continuous_linear_map.of_real z :=
+    continuous_linear_map.of_real.has_fderiv_at,
+  have B : has_fderiv_at e ((continuous_linear_map.smul_right 1 e' : ℂ →L[ℂ] ℂ).restrict_scalars ℝ)
+    (continuous_linear_map.of_real z) :=
+    (has_deriv_at_iff_has_fderiv_at.1 h).restrict_scalars ℝ,
+  have C : has_fderiv_at continuous_linear_map.re continuous_linear_map.re
+    (e (continuous_linear_map.of_real z)) := continuous_linear_map.re.has_fderiv_at,
+  simpa using has_fderiv_at_iff_has_deriv_at.1 (C.comp z (B.comp z A)),
+end
+
+theorem times_cont_diff_at.real_of_complex {n : with_top ℕ} (h : times_cont_diff_at ℂ n e z) :
+  times_cont_diff_at ℝ n (λ x : ℝ, (e x).re) z :=
+begin
+  have A : times_cont_diff_at ℝ n continuous_linear_map.of_real z,
+    from continuous_linear_map.of_real.times_cont_diff.times_cont_diff_at,
+  have B : times_cont_diff_at ℝ n e z := h.restrict_scalars ℝ,
+  have C : times_cont_diff_at ℝ n continuous_linear_map.re (e z),
+    from continuous_linear_map.re.times_cont_diff.times_cont_diff_at,
+  exact C.comp z (B.comp z A)
+end
+
+theorem times_cont_diff.real_of_complex {n : with_top ℕ} (h : times_cont_diff ℂ n e) :
+  times_cont_diff ℝ n (λ x : ℝ, (e x).re) :=
+times_cont_diff_iff_times_cont_diff_at.2 $ λ x,
+  h.times_cont_diff_at.real_of_complex
+
+end real_deriv_of_complex

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne
 -/
 import data.complex.exponential
-import analysis.complex.basic
 import analysis.calculus.mean_value
 import measure_theory.borel_space
 import analysis.complex.real_deriv

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -7,6 +7,7 @@ import data.complex.exponential
 import analysis.complex.basic
 import analysis.calculus.mean_value
 import measure_theory.borel_space
+import analysis.complex.real_deriv
 
 /-!
 # Complex and real exponential, real logarithm

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -136,7 +136,7 @@ lemma rpow_def_of_nonneg {x : ℝ} (hx : 0 ≤ x) (y : ℝ) : x ^ y =
     else exp (log x * y) :=
 by simp only [rpow_def, complex.cpow_def];
   split_ifs;
-  simp [*, (complex.of_real_log hx).symm, -complex.of_real_mul,
+  simp [*, (complex.of_real_log hx).symm, -complex.of_real_mul, -is_R_or_C.of_real_mul,
     (complex.of_real_mul _ _).symm, complex.exp_of_real_re] at *
 
 lemma rpow_def_of_pos {x : ℝ} (hx : 0 < x) (y : ℝ) : x ^ y = exp (log x * y) :=
@@ -217,7 +217,7 @@ begin
   split_ifs;
   simp [*, abs_of_nonneg (le_of_lt (real.exp_pos _)), complex.log, complex.exp_add,
     add_mul, mul_right_comm _ I, exp_mul_I, abs_cos_add_sin_mul_I,
-    (complex.of_real_mul _ _).symm, -complex.of_real_mul] at *
+    (complex.of_real_mul _ _).symm, -complex.of_real_mul, -is_R_or_C.of_real_mul] at *
 end
 
 @[simp] lemma abs_cpow_inv_nat (x : ℂ) (n : ℕ) : abs (x ^ (n⁻¹ : ℂ)) = x.abs ^ (n⁻¹ : ℝ) :=

--- a/src/analysis/special_functions/trigonometric.lean
+++ b/src/analysis/special_functions/trigonometric.lean
@@ -7,6 +7,7 @@ import analysis.special_functions.exp_log
 import data.set.intervals.infinite
 import algebra.quadratic_discriminant
 import ring_theory.polynomial.chebyshev.defs
+import analysis.calculus.times_cont_diff
 
 /-!
 # Trigonometric functions
@@ -2126,13 +2127,13 @@ have hay : abs y ≠ 0, from (mt abs_eq_zero.1 hy),
 λ h,
   have hre : abs (y / x) * x.re = y.re,
     by rw ← of_real_div at h;
-      simpa [-of_real_div] using congr_arg re h,
+      simpa [-of_real_div, -is_R_or_C.of_real_div] using congr_arg re h,
   have hre' : abs (x / y) * y.re = x.re,
     by rw [← hre, abs_div, abs_div, ← mul_assoc, div_mul_div,
       mul_comm (abs _), div_self (mul_ne_zero hay hax), one_mul],
   have him : abs (y / x) * x.im = y.im,
     by rw ← of_real_div at h;
-      simpa [-of_real_div] using congr_arg im h,
+      simpa [-of_real_div, -is_R_or_C.of_real_div] using congr_arg im h,
   have him' : abs (x / y) * y.im = x.im,
     by rw [← him, abs_div, abs_div, ← mul_assoc, div_mul_div,
       mul_comm (abs _), div_self (mul_ne_zero hay hax), one_mul],

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -3,9 +3,9 @@ Copyright (c) 2020 Frédéric Dupuis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis
 -/
-
-import analysis.normed_space.basic
-import analysis.complex.basic
+import data.real.sqrt
+import field_theory.tower
+import analysis.normed_space.finite_dimension
 
 /-!
 # `is_R_or_C`: a typeclass for ℝ or ℂ
@@ -19,6 +19,9 @@ Possible applications include defining inner products and Hilbert spaces for bot
 complex case. One would produce the definitions and proof for an arbitrary field of this
 typeclass, which basically amounts to doing the complex case, and the two cases then fall out
 immediately from the two instances of the class.
+
+The instance for `ℝ` is registered in this file.
+The instance for `ℂ` is declared in `analysis.complex.basic`.
 
 ## Implementation notes
 
@@ -675,31 +678,6 @@ noncomputable instance real.is_R_or_C : is_R_or_C ℝ :=
   inv_def_ax := λ z, by simp [pow_two, real.norm_eq_abs, abs_mul_abs_self, ← div_eq_mul_inv],
   div_I_ax := λ z, by simp only [div_zero, mul_zero, neg_zero]}
 
-noncomputable instance complex.is_R_or_C : is_R_or_C ℂ :=
-{ re := ⟨complex.re, complex.zero_re, complex.add_re⟩,
-  im := ⟨complex.im, complex.zero_im, complex.add_im⟩,
-  conj := complex.conj,
-  I := complex.I,
-  I_re_ax := by simp only [add_monoid_hom.coe_mk, complex.I_re],
-  I_mul_I_ax := by simp only [complex.I_mul_I, eq_self_iff_true, or_true],
-  re_add_im_ax := λ z, by simp only [add_monoid_hom.coe_mk, complex.re_add_im,
-                                     complex.coe_algebra_map, complex.of_real_eq_coe],
-  of_real_re_ax := λ r, by simp only [add_monoid_hom.coe_mk, complex.of_real_re,
-                                      complex.coe_algebra_map, complex.of_real_eq_coe],
-  of_real_im_ax := λ r, by simp only [add_monoid_hom.coe_mk, complex.of_real_im,
-                                      complex.coe_algebra_map, complex.of_real_eq_coe],
-  mul_re_ax := λ z w, by simp only [complex.mul_re, add_monoid_hom.coe_mk],
-  mul_im_ax := λ z w, by simp only [add_monoid_hom.coe_mk, complex.mul_im],
-  conj_re_ax := λ z, by simp only [ring_hom.coe_mk, add_monoid_hom.coe_mk, complex.conj_re],
-  conj_im_ax := λ z, by simp only [ring_hom.coe_mk, complex.conj_im, add_monoid_hom.coe_mk],
-  conj_I_ax := by simp only [complex.conj_I, ring_hom.coe_mk],
-  norm_sq_eq_def_ax := λ z, by simp only [←complex.norm_sq_eq_abs, ←complex.norm_sq_apply,
-    add_monoid_hom.coe_mk, complex.norm_eq_abs],
-  mul_im_I_ax := λ z, by simp only [mul_one, add_monoid_hom.coe_mk, complex.I_im],
-  inv_def_ax := λ z, by simp only [complex.inv_def, complex.norm_sq_eq_abs, complex.coe_algebra_map,
-    complex.of_real_eq_coe, complex.norm_eq_abs],
-  div_I_ax := complex.div_I }
-
 end instances
 
 namespace is_R_or_C
@@ -713,13 +691,6 @@ local notation `IR` := @is_R_or_C.I ℝ _
 local notation `absR` := @is_R_or_C.abs ℝ _
 local notation `norm_sqR` := @is_R_or_C.norm_sq ℝ _
 
-local notation `reC` := @is_R_or_C.re ℂ _
-local notation `imC` := @is_R_or_C.im ℂ _
-local notation `conjC` := @is_R_or_C.conj ℂ _
-local notation `IC` := @is_R_or_C.I ℂ _
-local notation `absC` := @is_R_or_C.abs ℂ _
-local notation `norm_sqC` := @is_R_or_C.norm_sq ℂ _
-
 @[simp] lemma re_to_real {x : ℝ} : reR x = x := rfl
 @[simp] lemma im_to_real {x : ℝ} : imR x = 0 := rfl
 @[simp] lemma conj_to_real {x : ℝ} : conjR x = x := rfl
@@ -729,15 +700,6 @@ local notation `norm_sqC` := @is_R_or_C.norm_sq ℂ _
 by simp [is_R_or_C.abs, abs, real.sqrt_mul_self_eq_abs]
 
 @[simp] lemma coe_real_eq_id : @coe ℝ ℝ _ = id := rfl
-
-@[simp] lemma re_to_complex {x : ℂ} : reC x = x.re := rfl
-@[simp] lemma im_to_complex {x : ℂ} : imC x = x.im := rfl
-@[simp] lemma conj_to_complex {x : ℂ} : conjC x = x.conj := rfl
-@[simp] lemma I_to_complex : IC = complex.I := rfl
-@[simp] lemma norm_sq_to_complex {x : ℂ} : norm_sqC x = complex.norm_sq x :=
-by simp [is_R_or_C.norm_sq, complex.norm_sq]
-@[simp] lemma abs_to_complex {x : ℂ} : absC x = complex.abs x :=
-by simp [is_R_or_C.abs, complex.abs]
 
 end cleanup_lemmas
 

--- a/src/geometry/euclidean/basic.lean
+++ b/src/geometry/euclidean/basic.lean
@@ -424,14 +424,14 @@ lemma eq_of_dist_eq_of_dist_eq_of_mem_of_findim_eq_two {s : affine_subspace ℝ 
   (hpc₂ : dist p c₂ = r₂) : p = p₁ ∨ p = p₂ :=
 begin
   have ho : ⟪c₂ -ᵥ c₁, p₂ -ᵥ p₁⟫ = 0 :=
-    inner_vsub_vsub_of_dist_eq_of_dist_eq (by cc) (by cc),
+    inner_vsub_vsub_of_dist_eq_of_dist_eq (hp₁c₁.trans hp₂c₁.symm) (hp₁c₂.trans hp₂c₂.symm),
   have hop : ⟪c₂ -ᵥ c₁, p -ᵥ p₁⟫ = 0 :=
-    inner_vsub_vsub_of_dist_eq_of_dist_eq (by cc) (by cc),
+    inner_vsub_vsub_of_dist_eq_of_dist_eq (hp₁c₁.trans hpc₁.symm) (hp₁c₂.trans hpc₂.symm),
   let b : fin 2 → V := ![c₂ -ᵥ c₁, p₂ -ᵥ p₁],
   have hb : linear_independent ℝ b,
   { refine linear_independent_of_ne_zero_of_inner_eq_zero _ _,
     { intro i,
-      fin_cases i; simp [b, hc.symm, hp.symm] },
+      fin_cases i; simp [b, hc.symm, hp.symm], },
     { intros i j hij,
       fin_cases i; fin_cases j; try { exact false.elim (hij rfl) },
       { exact ho },


### PR DESCRIPTION
Some results on the local inverse of smooth functions are currently formulated only for real functions, but they work as well for complex functions. We formulate them uniformly, assuming `is_R_or_C`.
