### PR TITLE
[Merged by Bors] - feat(algebra/lie/basic): define derived length and semisimple Lie algebras

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -59,6 +59,18 @@ MRREVIEWER = {Fangmin Song},
   MRNUMBER = {1728312},
 }
 
+@book {seligman1967,
+    AUTHOR = {Seligman, G. B.},
+     TITLE = {Modular {L}ie algebras},
+    SERIES = {Ergebnisse der Mathematik und ihrer Grenzgebiete, Band 40},
+ PUBLISHER = {Springer-Verlag New York, Inc., New York},
+      YEAR = {1967},
+     PAGES = {ix+165},
+   MRCLASS = {17.30 (22.00)},
+  MRNUMBER = {0245627},
+MRREVIEWER = {R. E. Block},
+}
+
 @book {conway2001,
     AUTHOR = {Conway, J. H.},
      TITLE = {On numbers and games},

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -285,6 +285,12 @@ def trans (e₁ : L₁ ≃ₗ⁅R⁆ L₂) (e₂ : L₂ ≃ₗ⁅R⁆ L₃) : L�
 @[simp] lemma symm_trans_apply (e₁ : L₁ ≃ₗ⁅R⁆ L₂) (e₂ : L₂ ≃ₗ⁅R⁆ L₃) (x : L₃) :
   (e₁.trans e₂).symm x = e₁.symm (e₂.symm x) := rfl
 
+lemma bijective (e : L₁ ≃ₗ⁅R⁆ L₂) : function.bijective e := e.to_linear_equiv.bijective
+
+lemma injective (e : L₁ ≃ₗ⁅R⁆ L₂) : function.injective e := e.to_linear_equiv.injective
+
+lemma surjective (e : L₁ ≃ₗ⁅R⁆ L₂) : function.surjective e := e.to_linear_equiv.surjective
+
 end equiv
 
 end lie_algebra
@@ -474,6 +480,33 @@ lie_module.is_trivial.trivial x m
 abbreviation is_lie_abelian (L : Type v) [has_bracket L L] [has_zero L] : Prop :=
 lie_module.is_trivial L L
 
+lemma lie_abelian_of_injection {R : Type u} {L₁ : Type v} {L₂ : Type w}
+  [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_algebra R L₁] [lie_algebra R L₂]
+  {f : L₁ →ₗ⁅R⁆ L₂} (h₁ : function.injective f) (h₂ : is_lie_abelian L₂) :
+  is_lie_abelian L₁ :=
+{ trivial := λ x y,
+    by { apply h₁, rw [lie_algebra.map_lie, trivial_lie_zero, lie_algebra.map_zero], } }
+
+lemma lie_abelian_of_surjection {R : Type u} {L₁ : Type v} {L₂ : Type w}
+  [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_algebra R L₁] [lie_algebra R L₂]
+  {f : L₁ →ₗ⁅R⁆ L₂} (h₁ : function.surjective f) (h₂ : is_lie_abelian L₁) :
+  is_lie_abelian L₂ :=
+{ trivial := λ x y,
+    begin
+      obtain ⟨u, hu⟩ := h₁ x, rw ← hu,
+      obtain ⟨v, hv⟩ := h₁ y, rw ← hv,
+      rw [← lie_algebra.map_lie, trivial_lie_zero, lie_algebra.map_zero],
+    end }
+
+lemma lie_abelian_iff_equiv_lie_abelian {R : Type u} {L₁ : Type v} {L₂ : Type w}
+  [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_algebra R L₁] [lie_algebra R L₂]
+  (e : L₁ ≃ₗ⁅R⁆ L₂) : is_lie_abelian L₁ ↔ is_lie_abelian L₂ :=
+begin
+  split; intros h,
+  { exact lie_abelian_of_injection e.symm.injective h, },
+  { exact @lie_abelian_of_injection R L₁ L₂ _ _ _ _ _ e e.injective h, },
+end
+
 lemma commutative_ring_iff_abelian_lie_ring : is_commutative A (*) ↔ is_lie_abelian A :=
 begin
   have h₁ : is_commutative A (*) ↔ ∀ (a b : A), a * b = b * a := ⟨λ h, h.1, λ h, ⟨h⟩⟩,
@@ -593,11 +626,15 @@ lemma lie_mem {x y : L} (hx : x ∈ L') (hy : y ∈ L') : (⁅x, y⁆ : L) ∈ L
 
 @[simp, norm_cast] lemma coe_bracket (x y : L') : (↑⁅x, y⁆ : L) = ⁅(↑x : L), ↑y⁆ := rfl
 
+lemma ext_iff (x y : L') : x = y ↔ (x : L) = y := subtype.ext_iff
+
+lemma coe_zero_iff_zero (x : L') : (x : L) = 0 ↔ x = 0 := (ext_iff L' x 0).symm
+
 @[ext] lemma ext (L₁' L₂' : lie_subalgebra R L) (h : ∀ x, x ∈ L₁' ↔ x ∈ L₂') :
   L₁' = L₂' :=
 by { cases L₁', cases L₂', simp only [], ext x, exact h x, }
 
-lemma ext_iff (L₁' L₂' : lie_subalgebra R L) : L₁' = L₂' ↔ ∀ x, x ∈ L₁' ↔ x ∈ L₂' :=
+lemma ext_iff' (L₁' L₂' : lie_subalgebra R L) : L₁' = L₂' ↔ ∀ x, x ∈ L₁' ↔ x ∈ L₂' :=
 ⟨λ h x, by rw h, ext L₁' L₂'⟩
 
 @[simp] lemma mk_coe (S : set L) (h₁ h₂ h₃ h₄) :
@@ -1140,6 +1177,17 @@ begin
   rintros m ⟨x, n, h⟩, rw trivial_lie_zero at h, simp [← h],
 end
 
+open lie_subalgebra
+
+lemma lie_abelian_iff_lie_self_eq_bot : is_lie_abelian I ↔ ⁅I, I⁆ = ⊥ :=
+begin
+  simp only [_root_.eq_bot_iff, lie_ideal_oper_eq_span, lie_span_le, bot_coe,
+    set.subset_singleton_iff, set.mem_set_of_eq, exists_imp_distrib],
+  split; intros h,
+  { intros z x y hz, rw [← hz, ← coe_bracket, coe_zero_iff_zero], apply h.trivial, },
+  { exact ⟨λ x y, by { rw ← coe_zero_iff_zero, apply h _ x y, refl, }⟩, },
+end
+
 end lie_ideal_operations
 
 /-- The quotient of a Lie module by a Lie submodule. It is a Lie module. -/
@@ -1319,6 +1367,17 @@ begin
   exact h₁ k l I J,
 end
 
+lemma derived_series_of_bot_eq_bot (k : ℕ) : derived_series_of_ideal R L k ⊥ = ⊥ :=
+by { rw eq_bot_iff, exact derived_series_of_ideal_le_self ⊥ k, }
+
+lemma abelian_iff_derived_one_eq_bot : is_lie_abelian I ↔ derived_series_of_ideal R L 1 I = ⊥ :=
+by rw [derived_series_of_ideal_succ, derived_series_of_ideal_zero,
+  lie_submodule.lie_abelian_iff_lie_self_eq_bot]
+
+lemma abelian_iff_derived_succ_eq_bot (I : lie_ideal R L) (k : ℕ) :
+  is_lie_abelian (derived_series_of_ideal R L k I) ↔ derived_series_of_ideal R L (k + 1) I = ⊥ :=
+by rw [add_comm, derived_series_of_ideal_add I 1 k, abelian_iff_derived_one_eq_bot]
+
 end lie_algebra
 
 namespace lie_module
@@ -1332,7 +1391,7 @@ def lower_central_series (k : ℕ) : lie_submodule R L M := (λ I, ⁅(⊤ : lie
   lower_central_series R L M (k + 1) = ⁅(⊤ : lie_ideal R L), lower_central_series R L M k⁆ :=
 function.iterate_succ_apply' (λ I, ⁅(⊤ : lie_ideal R L), I⁆) k ⊤
 
-lemma trivial_iff_derived_eq_bot : is_trivial L M ↔ lower_central_series R L M 1 = ⊥ :=
+lemma trivial_iff_lower_central_eq_bot : is_trivial L M ↔ lower_central_series R L M 1 = ⊥ :=
 begin
   split; intros h,
   { erw [eq_bot_iff, lie_submodule.lie_span_le], rintros m ⟨x, n, hn⟩, rw [← hn, h.trivial], simp,},
@@ -1523,11 +1582,39 @@ begin
     { intros hx, use 0, simp [hx], }, },
 end
 
+lemma ker_eq_bot : f.ker = ⊥ ↔ function.injective f :=
+by rw [← lie_submodule.coe_to_submodule_eq_iff, ker_coe_submodule, lie_submodule.bot_coe_submodule,
+  linear_map.ker_eq_bot, lie_algebra.coe_to_linear_map]
+
 end lie_algebra.morphism
 
 namespace lie_ideal
 
 variables {f : L →ₗ⁅R⁆ L'} {I : lie_ideal R L} {J : lie_ideal R L'}
+
+lemma bot_of_map_eq_bot {I : lie_ideal R L} (h₁ : function.injective f) (h₂ : I.map f = ⊥) :
+  I = ⊥ :=
+begin
+  rw ← f.ker_eq_bot at h₁, change comap f ⊥ = ⊥ at h₁,
+  rw [eq_bot_iff, map_le_iff_le_comap, h₁] at h₂,
+  rw eq_bot_iff, exact h₂,
+end
+
+/-- Given two nested Lie ideals `I₁ ⊆ I₂`, the inclusion `I₁ ↪ I₂'` is a morphism of Lie algebras.-/
+def hom_of_le {I₁ I₂ : lie_ideal R L} (h : I₁ ≤ I₂) : I₁ →ₗ⁅R⁆ I₂ :=
+{ map_lie := λ x y, rfl,
+  ..submodule.of_le h, }
+
+@[simp] lemma coe_hom_of_le {I₁ I₂ : lie_ideal R L} (h : I₁ ≤ I₂) (x : I₁) :
+  (hom_of_le h x : L) = x := rfl
+
+lemma hom_of_le_apply {I₁ I₂ : lie_ideal R L} (h : I₁ ≤ I₂) (x : I₁) :
+  hom_of_le h x = ⟨x.1, h x.2⟩ := rfl
+
+lemma hom_of_le_injective {I₁ I₂ : lie_ideal R L} (h : I₁ ≤ I₂) :
+  function.injective (hom_of_le h) :=
+λ x y, by simp only [hom_of_le_apply, imp_self, subtype.mk_eq_mk, submodule.coe_eq_coe,
+  subtype.val_eq_coe]
 
 lemma map_sup_ker_eq_map : lie_ideal.map f (I ⊔ f.ker) = lie_ideal.map f I :=
 begin
@@ -1682,6 +1769,15 @@ begin
                      ... ≤ ⊥ : by { rw [hI, hJ], simp, },
 end
 
+lemma derived_series_map_le_derived_series {L' : Type w} [lie_ring L'] [lie_algebra R L']
+  {f : L' →ₗ⁅R⁆ L} (k : ℕ) : (derived_series R L' k).map f ≤ derived_series R L k :=
+begin
+  induction k with k ih,
+  { simp only [derived_series_def, derived_series_of_ideal_zero, le_top], },
+  { simp only [derived_series_def, derived_series_of_ideal_succ] at ih ⊢,
+    exact le_trans (map_bracket_le f) (lie_submodule.mono_lie _ _ _ _ ih ih), },
+end
+
 end lie_ideal
 
 end lie_submodule_map_and_comap
@@ -1710,6 +1806,19 @@ end lie_module
 
 namespace lie_algebra
 
+variables {R L}
+
+/-- The natural equivalence between the 'top' Lie submodule and the enclosing Lie algebra. -/
+def top_equiv_self : (⊤ : lie_ideal R L) ≃ₗ⁅R⁆ L :=
+{ inv_fun   := λ x, ⟨x, set.mem_univ x⟩,
+  left_inv  := λ x, by { ext, refl, },
+  right_inv := λ x, rfl,
+  ..(⊤ : lie_ideal R L).incl, }
+
+@[simp] lemma top_equiv_self_apply (x : (⊤ : lie_ideal R L)) : top_equiv_self x = x := rfl
+
+variables (R L)
+
 /-- A Lie algebra is simple if it is irreducible as a Lie module over itself via the adjoint
 action, and it is non-Abelian. -/
 class is_simple extends lie_module.is_irreducible R L L : Prop :=
@@ -1730,6 +1839,119 @@ begin
   exact ⟨⟨k+l, lie_ideal.derived_series_add_eq_bot hk hl⟩⟩,
 end
 
+variables {R L}
+
+lemma is_solvable_of_injective {L' : Type w} [lie_ring L'] [lie_algebra R L']
+  [h₁ : is_solvable R L] {f : L' →ₗ⁅R⁆ L} (h₂ : function.injective f) : is_solvable R L' :=
+begin
+  tactic.unfreeze_local_instances, obtain ⟨k, hk⟩ := h₁,
+  use k,
+  apply lie_ideal.bot_of_map_eq_bot h₂, rw [eq_bot_iff, ← hk],
+  apply lie_ideal.derived_series_map_le_derived_series,
+end
+
+lemma le_solvable_ideal_solvable {I J : lie_ideal R L} (h₁ : I ≤ J) (h₂ : is_solvable R J) :
+  is_solvable R I :=
+lie_algebra.is_solvable_of_injective (lie_ideal.hom_of_le_injective h₁)
+
+variables (R L)
+
+/-- Given a solvable Lie ideal `I` with derived series `I = D₀ ≥ D₁ ≥ ⋯ ≥ Dₖ = ⊥`, this is the
+`k` (the number of inclusions).
+
+For a non-solvable ideal, the value is 0. -/
+noncomputable def derived_length_of_ideal (I : lie_ideal R L) : ℕ :=
+Inf {k | derived_series_of_ideal R L k I = ⊥}
+
+/-- The derived length of a Lie algebra is the derived length of its 'top' Lie ideal.
+
+See also `derived_length_eq_derived_length_of_ideal`. -/
+noncomputable abbreviation derived_length : ℕ := derived_length_of_ideal R L ⊤
+
+lemma derived_series_of_derived_length_succ (I : lie_ideal R L) (k : ℕ) :
+  derived_length_of_ideal R L I = k + 1 ↔
+  is_lie_abelian (derived_series_of_ideal R L k I) ∧ derived_series_of_ideal R L k I ≠ ⊥ :=
+begin
+  rw abelian_iff_derived_succ_eq_bot,
+  let s := {k | derived_series_of_ideal R L k I = ⊥}, change Inf s = k + 1 ↔ k + 1 ∈ s ∧ k ∉ s,
+  have hs : ∀ (k₁ k₂ : ℕ), k₁ ≤ k₂ → k₁ ∈ s → k₂ ∈ s,
+  { intros k₁ k₂ h₁₂ h₁,
+    suffices : derived_series_of_ideal R L k₂ I ≤ ⊥, { exact eq_bot_iff.mpr this, },
+    change derived_series_of_ideal R L k₁ I = ⊥ at h₁, rw ← h₁,
+    exact derived_series_of_ideal_antimono I h₁₂, },
+  exact nat.Inf_interval_above_eq_succ_iff hs k,
+end
+
+lemma derived_length_zero (I : lie_ideal R L) [hI : is_solvable R I] :
+  derived_length_of_ideal R L I = 0 ↔ I = ⊥ :=
+begin
+  let s := {k | derived_series_of_ideal R L k I = ⊥}, change Inf s = 0 ↔ _,
+  have hne : s ≠ ∅,
+  { rw set.ne_empty_iff_nonempty,
+    tactic.unfreeze_local_instances, obtain ⟨k, hk⟩ := hI, use k,
+    rw [derived_series_def, lie_ideal.derived_series_eq_bot_iff] at hk, exact hk, },
+  simp [hne],
+end
+
+lemma derived_length_eq_derived_length_of_ideal (I : lie_ideal R L) :
+  derived_length R I = derived_length_of_ideal R L I :=
+begin
+  let s₁ := {k | derived_series R I k = ⊥},
+  let s₂ := {k | derived_series_of_ideal R L k I = ⊥},
+  change Inf s₁ = Inf s₂,
+  congr, ext k, exact I.derived_series_eq_bot_iff k,
+end
+
+lemma is_lie_abelian_bot : is_lie_abelian (⊥ : lie_ideal R L) :=
+⟨begin
+  rintros ⟨x, hx⟩ ⟨y, hy⟩,
+  suffices : ⁅x, y⁆ = 0, { ext, simp [this], },
+  change x ∈ (⊥ : lie_ideal R L) at hx, rw lie_submodule.mem_bot at hx, rw [hx, zero_lie],
+end⟩
+
+variables {R L}
+
+/-- Given a solvable Lie ideal `I` with derived series `I = D₀ ≥ D₁ ≥ ⋯ ≥ Dₖ = ⊥`, this is the
+`k-1`th term in the solvable series (and is therefore an Abelian ideal contained in `I`).
+
+For a non-solvable ideal, this is the zero ideal, `⊥`. -/
+noncomputable def derived_abelian_of_ideal (I : lie_ideal R L) : lie_ideal R L :=
+match derived_length_of_ideal R L I with
+| 0     := ⊥
+| k + 1 := derived_series_of_ideal R L k I
+end
+
+lemma abelian_derived_abelian_of_ideal (I : lie_ideal R L) :
+  is_lie_abelian (derived_abelian_of_ideal I) :=
+begin
+  dunfold derived_abelian_of_ideal,
+  cases h : derived_length_of_ideal R L I with k,
+  { exact is_lie_abelian_bot R L, },
+  { rw derived_series_of_derived_length_succ at h, exact h.1, },
+end
+
+lemma abelian_of_solvable_ideal_eq_bot_iff (I : lie_ideal R L) [h : is_solvable R I] :
+  derived_abelian_of_ideal I = ⊥ ↔ I = ⊥ :=
+begin
+  dunfold derived_abelian_of_ideal,
+  cases h : derived_length_of_ideal R L I with k,
+  { rw derived_length_zero at h, rw h, refl, },
+  { obtain ⟨h₁, h₂⟩ := (derived_series_of_derived_length_succ R L I k).mp h,
+    have h₃ : I ≠ ⊥, { intros contra, apply h₂, rw contra, apply derived_series_of_bot_eq_bot, },
+    change derived_series_of_ideal R L k I = ⊥ ↔ I = ⊥,
+    split; contradiction, },
+end
+
+variables (R L)
+
+lemma of_abelian_is_solvable [is_lie_abelian L] : is_solvable R L :=
+begin
+  use 1,
+  rw [← abelian_iff_derived_one_eq_bot, lie_abelian_iff_equiv_lie_abelian top_equiv_self],
+  apply_instance,
+end
+
+
 /-- The (solvable) radical of Lie algebra is the `Sup` of all solvable ideals. -/
 def radical := Sup { I : lie_ideal R L | is_solvable R I }
 
@@ -1741,6 +1963,46 @@ begin
   refine hwf { I : lie_ideal R L | is_solvable R I } _ _,
   { use ⊥, exact lie_algebra.is_solvable_bot R L, },
   { intros I J hI hJ, apply lie_algebra.is_solvable_add R L; [exact hI, exact hJ], },
+end
+
+/-- The `→` direction of this lemma is actually true without the `is_noetherian` assumption. -/
+lemma lie_ideal.solvable_iff_le_radical [is_noetherian R L] (I : lie_ideal R L) :
+  is_solvable R I ↔ I ≤ radical R L :=
+begin
+  split; intros h,
+  { exact le_Sup h, },
+  { apply le_solvable_ideal_solvable h, apply_instance, },
+end
+
+/-- Link to https://mathoverflow.net/questions/149391/on-radicals-of-a-lie-algebra#comment383669_149391
+in PR. -/
+class is_semisimple : Prop :=
+(semisimple : radical R L = ⊥)
+
+lemma is_semisimple_iff_no_solvable_ideals :
+  is_semisimple R L ↔ ∀ (I : lie_ideal R L), is_solvable R I → I = ⊥ :=
+⟨λ h, Sup_eq_bot.mp h.semisimple, λ h, ⟨Sup_eq_bot.mpr h⟩⟩
+
+lemma is_semisimple_iff_no_abelian_ideals :
+  is_semisimple R L ↔ ∀ (I : lie_ideal R L), is_lie_abelian I → I = ⊥ :=
+begin
+  rw is_semisimple_iff_no_solvable_ideals,
+  split; intros h₁ I h₂,
+  { haveI : is_lie_abelian I := h₂, apply h₁, exact of_abelian_is_solvable R I, },
+  { haveI : is_solvable R I := h₂, rw ← abelian_of_solvable_ideal_eq_bot_iff, apply h₁,
+    exact abelian_derived_abelian_of_ideal I, },
+end
+
+/-- A simple Lie algebra is semisimple. -/
+@[priority 100]
+instance is_semisimple_of_is_simple [h : is_simple R L] : is_semisimple R L :=
+begin
+  rw is_semisimple_iff_no_abelian_ideals,
+  intros I hI,
+  tactic.unfreeze_local_instances, obtain ⟨⟨h₁⟩, h₂⟩ := h,
+  by_contradiction contra,
+  rw [h₁ I contra, lie_abelian_iff_equiv_lie_abelian top_equiv_self] at hI,
+  exact h₂ hI,
 end
 
 @[priority 100]

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -285,11 +285,14 @@ def trans (e₁ : L₁ ≃ₗ⁅R⁆ L₂) (e₂ : L₂ ≃ₗ⁅R⁆ L₃) : L�
 @[simp] lemma symm_trans_apply (e₁ : L₁ ≃ₗ⁅R⁆ L₂) (e₂ : L₂ ≃ₗ⁅R⁆ L₃) (x : L₃) :
   (e₁.trans e₂).symm x = e₁.symm (e₂.symm x) := rfl
 
-lemma bijective (e : L₁ ≃ₗ⁅R⁆ L₂) : function.bijective e := e.to_linear_equiv.bijective
+lemma bijective (e : L₁ ≃ₗ⁅R⁆ L₂) : function.bijective ((e : L₁ →ₗ⁅R⁆ L₂) : L₁ → L₂) :=
+e.to_linear_equiv.bijective
 
-lemma injective (e : L₁ ≃ₗ⁅R⁆ L₂) : function.injective e := e.to_linear_equiv.injective
+lemma injective (e : L₁ ≃ₗ⁅R⁆ L₂) : function.injective ((e : L₁ →ₗ⁅R⁆ L₂) : L₁ → L₂) :=
+e.to_linear_equiv.injective
 
-lemma surjective (e : L₁ ≃ₗ⁅R⁆ L₂) : function.surjective e := e.to_linear_equiv.surjective
+lemma surjective (e : L₁ ≃ₗ⁅R⁆ L₂) : function.surjective ((e : L₁ →ₗ⁅R⁆ L₂) : L₁ → L₂) :=
+e.to_linear_equiv.surjective
 
 end equiv
 
@@ -504,7 +507,7 @@ lemma lie_abelian_iff_equiv_lie_abelian {R : Type u} {L₁ : Type v} {L₂ : Typ
 begin
   split; intros h,
   { exact e.symm.injective.is_lie_abelian h, },
-  { exact @function.injective.is_lie_abelian R L₁ L₂ _ _ _ _ _ e e.injective h, },
+  { exact e.injective.is_lie_abelian h, },
 end
 
 lemma commutative_ring_iff_abelian_lie_ring : is_commutative A (*) ↔ is_lie_abelian A :=

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -504,11 +504,7 @@ lemma function.surjective.is_lie_abelian {R : Type u} {L₁ : Type v} {L₂ : Ty
 lemma lie_abelian_iff_equiv_lie_abelian {R : Type u} {L₁ : Type v} {L₂ : Type w}
   [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_algebra R L₁] [lie_algebra R L₂]
   (e : L₁ ≃ₗ⁅R⁆ L₂) : is_lie_abelian L₁ ↔ is_lie_abelian L₂ :=
-begin
-  split; intros h,
-  { exact e.symm.injective.is_lie_abelian h, },
-  { exact e.injective.is_lie_abelian h, },
-end
+⟨e.symm.injective.is_lie_abelian, e.injective.is_lie_abelian⟩
 
 lemma commutative_ring_iff_abelian_lie_ring : is_commutative A (*) ↔ is_lie_abelian A :=
 begin

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -480,14 +480,14 @@ lie_module.is_trivial.trivial x m
 abbreviation is_lie_abelian (L : Type v) [has_bracket L L] [has_zero L] : Prop :=
 lie_module.is_trivial L L
 
-lemma lie_abelian_of_injection {R : Type u} {L₁ : Type v} {L₂ : Type w}
+lemma function.injective.is_lie_abelian {R : Type u} {L₁ : Type v} {L₂ : Type w}
   [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_algebra R L₁] [lie_algebra R L₂]
   {f : L₁ →ₗ⁅R⁆ L₂} (h₁ : function.injective f) (h₂ : is_lie_abelian L₂) :
   is_lie_abelian L₁ :=
 { trivial := λ x y,
     by { apply h₁, rw [lie_algebra.map_lie, trivial_lie_zero, lie_algebra.map_zero], } }
 
-lemma lie_abelian_of_surjection {R : Type u} {L₁ : Type v} {L₂ : Type w}
+lemma function.surjective.is_lie_abelian {R : Type u} {L₁ : Type v} {L₂ : Type w}
   [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_algebra R L₁] [lie_algebra R L₂]
   {f : L₁ →ₗ⁅R⁆ L₂} (h₁ : function.surjective f) (h₂ : is_lie_abelian L₁) :
   is_lie_abelian L₂ :=
@@ -503,8 +503,8 @@ lemma lie_abelian_iff_equiv_lie_abelian {R : Type u} {L₁ : Type v} {L₂ : Typ
   (e : L₁ ≃ₗ⁅R⁆ L₂) : is_lie_abelian L₁ ↔ is_lie_abelian L₂ :=
 begin
   split; intros h,
-  { exact lie_abelian_of_injection e.symm.injective h, },
-  { exact @lie_abelian_of_injection R L₁ L₂ _ _ _ _ _ e e.injective h, },
+  { exact e.symm.injective.is_lie_abelian h, },
+  { exact @function.injective.is_lie_abelian R L₁ L₂ _ _ _ _ _ e e.injective h, },
 end
 
 lemma commutative_ring_iff_abelian_lie_ring : is_commutative A (*) ↔ is_lie_abelian A :=

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -38,7 +38,7 @@ Lie algebras are defined as modules with a compatible Lie ring structure and thu
 are partially unbundled.
 
 ## References
-* [N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 1--3*][bourbaki1975]
+* [N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 1--3*](bourbaki1975)
 
 ## Tags
 
@@ -1604,7 +1604,7 @@ begin
   rw eq_bot_iff, exact h₂,
 end
 
-/-- Given two nested Lie ideals `I₁ ⊆ I₂`, the inclusion `I₁ ↪ I₂'` is a morphism of Lie algebras.-/
+/-- Given two nested Lie ideals `I₁ ⊆ I₂`, the inclusion `I₁ ↪ I₂` is a morphism of Lie algebras.-/
 def hom_of_le {I₁ I₂ : lie_ideal R L} (h : I₁ ≤ I₂) : I₁ →ₗ⁅R⁆ I₂ :=
 { map_lie := λ x y, rfl,
   ..submodule.of_le h, }
@@ -1978,7 +1978,13 @@ begin
   { apply le_solvable_ideal_solvable h, apply_instance, },
 end
 
-/-- A semisimple Lie algebra is one with trivial radical. -/
+/-- A semisimple Lie algebra is one with trivial radical.
+
+Note that the label 'semisimple' is apparently not universally agreed
+[upon](https://mathoverflow.net/questions/149391/on-radicals-of-a-lie-algebra#comment383669_149391)
+for general coefficients. We are following [Seligman, page 15](seligman1967) and using the label
+for the weakest of the various properties which are all equivalent over a field of characteristic
+zero. -/
 class is_semisimple : Prop :=
 (semisimple : radical R L = ⊥)
 

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -1883,7 +1883,7 @@ begin
     suffices : derived_series_of_ideal R L k₂ I ≤ ⊥, { exact eq_bot_iff.mpr this, },
     change derived_series_of_ideal R L k₁ I = ⊥ at h₁, rw ← h₁,
     exact derived_series_of_ideal_antimono I h₁₂, },
-  exact nat.Inf_interval_above_eq_succ_iff hs k,
+  exact nat.Inf_upward_closed_eq_succ_iff hs k,
 end
 
 lemma derived_length_zero (I : lie_ideal R L) [hI : is_solvable R I] :

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -1016,6 +1016,10 @@ def hom_of_le : N →ₗ⁅R,L⁆ N' :=
 
 lemma hom_of_le_apply (m : N) : hom_of_le h m = ⟨m.1, h m.2⟩ := rfl
 
+lemma hom_of_le_injective : function.injective (hom_of_le h) :=
+λ x y, by simp only [hom_of_le_apply, imp_self, subtype.mk_eq_mk, submodule.coe_eq_coe,
+  subtype.val_eq_coe]
+
 end inclusion_maps
 
 section lie_span
@@ -1857,7 +1861,7 @@ lie_algebra.is_solvable_of_injective (lie_ideal.hom_of_le_injective h₁)
 variables (R L)
 
 /-- Given a solvable Lie ideal `I` with derived series `I = D₀ ≥ D₁ ≥ ⋯ ≥ Dₖ = ⊥`, this is the
-`k` (the number of inclusions).
+natural number `k` (the number of inclusions).
 
 For a non-solvable ideal, the value is 0. -/
 noncomputable def derived_length_of_ideal (I : lie_ideal R L) : ℕ :=
@@ -1912,7 +1916,7 @@ end⟩
 variables {R L}
 
 /-- Given a solvable Lie ideal `I` with derived series `I = D₀ ≥ D₁ ≥ ⋯ ≥ Dₖ = ⊥`, this is the
-`k-1`th term in the solvable series (and is therefore an Abelian ideal contained in `I`).
+`k-1`th term in the derived series (and is therefore an Abelian ideal contained in `I`).
 
 For a non-solvable ideal, this is the zero ideal, `⊥`. -/
 noncomputable def derived_abelian_of_ideal (I : lie_ideal R L) : lie_ideal R L :=
@@ -1974,8 +1978,7 @@ begin
   { apply le_solvable_ideal_solvable h, apply_instance, },
 end
 
-/-- Link to https://mathoverflow.net/questions/149391/on-radicals-of-a-lie-algebra#comment383669_149391
-in PR. -/
+/-- A semisimple Lie algebra is one with trivial radical. -/
 class is_semisimple : Prop :=
 (semisimple : radical R L = ⊥)
 

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -497,7 +497,7 @@ lemma eq_Ici_of_nonempty_of_upward_closed {s : set ℕ} (hs : s.nonempty)
   (hs' : ∀ (k₁ k₂ : ℕ), k₁ ≤ k₂ → k₁ ∈ s → k₂ ∈ s) : s = Ici (Inf s) :=
 ext (λ n, ⟨λ H, nat.Inf_le H, λ H, hs' (Inf s) n H (Inf_mem hs)⟩)
 
-lemma Inf_interval_above_eq_succ_iff {s : set ℕ}
+lemma Inf_upward_closed_eq_succ_iff {s : set ℕ}
   (hs : ∀ (k₁ k₂ : ℕ), k₁ ≤ k₂ → k₁ ∈ s → k₂ ∈ s) (k : ℕ) :
   Inf s = k + 1 ↔ k + 1 ∈ s ∧ k ∉ s :=
 begin

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -483,6 +483,29 @@ end
 protected lemma Inf_le {s : set ℕ} {m : ℕ} (hm : m ∈ s) : Inf s ≤ m :=
 by { rw [nat.Inf_def ⟨m, hm⟩], exact nat.find_min' ⟨m, hm⟩ hm }
 
+lemma nonempty_of_pos_Inf {s : set ℕ} (h : 0 < Inf s) : s.nonempty :=
+begin
+  by_contradiction contra, rw set.not_nonempty_iff_eq_empty at contra,
+  have h' : Inf s ≠ 0, { exact ne_of_gt h, }, apply h',
+  rw nat.Inf_eq_zero, right, assumption,
+end
+
+lemma Inf_interval_above_eq_succ_iff {s : set ℕ}
+  (hs : ∀ (k₁ k₂ : ℕ), k₁ ≤ k₂ → k₁ ∈ s → k₂ ∈ s) (k : ℕ) :
+  Inf s = k + 1 ↔ k + 1 ∈ s ∧ k ∉ s :=
+begin
+  split,
+  { intros h, rw ← h,
+    have hne : s.nonempty, { apply nonempty_of_pos_Inf, rw h, exact nat.succ_pos', },
+    have hlt : k < Inf s, { rw [h, lt_add_iff_pos_right], exact nat.one_pos, },
+    exact ⟨nat.Inf_mem hne, nat.not_mem_of_lt_Inf hlt⟩, },
+  { rintros ⟨h₁, h₂⟩,
+    refine le_antisymm (nat.Inf_le h₁) _,
+    by_contradiction h, rw [not_le, nat.lt_succ_iff] at h,
+    have hne : s.nonempty, { exact ⟨k+1, h₁⟩, },
+    apply h₂, exact hs (Inf s) k h (nat.Inf_mem hne), },
+end
+
 /-- This instance is necessary, otherwise the lattice operations would be derived via
 conditionally_complete_linear_order_bot and marked as noncomputable. -/
 instance : lattice ℕ := lattice_of_linear_order

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -490,20 +490,24 @@ begin
   rw nat.Inf_eq_zero, right, assumption,
 end
 
+lemma nonempty_of_Inf_eq_succ {s : set ℕ} {k : ℕ} (h : Inf s = k + 1) : s.nonempty :=
+nonempty_of_pos_Inf (h.symm ▸ (succ_pos k) : Inf s > 0)
+
+lemma eq_Ici_of_nonempty_of_upward_closed {s : set ℕ} (hs : s.nonempty)
+  (hs' : ∀ (k₁ k₂ : ℕ), k₁ ≤ k₂ → k₁ ∈ s → k₂ ∈ s) : s = Ici (Inf s) :=
+ext (λ n, ⟨λ H, nat.Inf_le H, λ H, hs' (Inf s) n H (Inf_mem hs)⟩)
+
 lemma Inf_interval_above_eq_succ_iff {s : set ℕ}
   (hs : ∀ (k₁ k₂ : ℕ), k₁ ≤ k₂ → k₁ ∈ s → k₂ ∈ s) (k : ℕ) :
   Inf s = k + 1 ↔ k + 1 ∈ s ∧ k ∉ s :=
 begin
   split,
-  { intros h, rw ← h,
-    have hne : s.nonempty, { apply nonempty_of_pos_Inf, rw h, exact nat.succ_pos', },
-    have hlt : k < Inf s, { rw [h, lt_add_iff_pos_right], exact nat.one_pos, },
-    exact ⟨nat.Inf_mem hne, nat.not_mem_of_lt_Inf hlt⟩, },
-  { rintros ⟨h₁, h₂⟩,
-    refine le_antisymm (nat.Inf_le h₁) _,
-    by_contradiction h, rw [not_le, nat.lt_succ_iff] at h,
-    have hne : s.nonempty, { exact ⟨k+1, h₁⟩, },
-    apply h₂, exact hs (Inf s) k h (nat.Inf_mem hne), },
+  { intro H,
+    rw [eq_Ici_of_nonempty_of_upward_closed (nonempty_of_Inf_eq_succ H) hs, H, mem_Ici, mem_Ici],
+    exact ⟨le_refl _, k.not_succ_le_self⟩, },
+  { rintro ⟨H, H'⟩,
+    rw [Inf_def (⟨_, H⟩ : s.nonempty), find_eq_iff],
+    exact ⟨H, λ n hnk hns, H' $ hs n k (lt_succ_iff.mp hnk) hns⟩, },
 end
 
 /-- This instance is necessary, otherwise the lattice operations would be derived via


### PR DESCRIPTION
We also provide proofs of some basic characterisations

---

If this is merged then I would like to follow up with a (much smaller) PR doing something similar for reductive Lie algebras and then finally refactor along the lines outlined [here](https://github.com/leanprover-community/mathlib/pull/5794#discussion_r560050825).