### PR TITLE
[Merged by Bors] - chore(data/sym2): golf decidability proofs

### DIFF
--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -174,13 +174,7 @@ begin
 end
 
 instance mem.decidable [decidable_eq α] (x : α) (z : sym2 α) : decidable (x ∈ z) :=
-begin
-  refine quotient.rec_on_subsingleton z (λ w, _),
-  cases w with y₁ y₂,
-  by_cases h₁ : x = y₁, subst x, exact is_true (mk_has_mem _ _),
-  by_cases h₂ : x = y₂, subst x, exact is_true (mk_has_mem_right _ _),
-  apply is_false, intro h, rw mem_iff at h, cases h, exact h₁ h, exact h₂ h,
-end
+quotient.rec_on_subsingleton z (λ ⟨y₁, y₂⟩, decidable_of_iff' _ mem_iff)
 
 end membership
 
@@ -230,11 +224,11 @@ Symmetric relations define a set on `sym2 α` by taking all those pairs
 of elements that are related.
 -/
 def from_rel (sym : symmetric r) : set (sym2 α) :=
-{z | quotient.rec_on z (λ z, r z.1 z.2) (by { rintros _ _ ⟨_,_⟩, tidy })}
+quotient.lift (uncurry r) (by { rintros _ _ ⟨_, _⟩, tidy })
 
 @[simp]
 lemma from_rel_proj_prop {sym : symmetric r} {z : α × α} :
-  ⟦z⟧ ∈ from_rel sym ↔ r z.1 z.2 := by tidy
+  ⟦z⟧ ∈ from_rel sym ↔ r z.1 z.2 := iff.rfl
 
 @[simp]
 lemma from_rel_prop {sym : symmetric r} {a b : α} :
@@ -250,15 +244,9 @@ lemma mem_from_rel_irrefl_other_ne {sym : symmetric r} (irrefl : irreflexive r)
   {a : α} {z : sym2 α} (hz : z ∈ from_rel sym) (h : a ∈ z) : h.other ≠ a :=
 mem_other_ne (from_rel_irreflexive.mp irrefl hz) h
 
-instance from_rel.decidable_as_set (sym : symmetric r) [h : decidable_rel r] :
-  decidable_pred (λ x, x ∈ sym2.from_rel sym) :=
-λ (x : sym2 α), quotient.rec_on x
-  (λ x', by { simp_rw from_rel_proj_prop, apply_instance })
-  (by tidy)
-
 instance from_rel.decidable_pred (sym : symmetric r) [h : decidable_rel r] :
   decidable_pred (sym2.from_rel sym) :=
-by { change decidable_pred (λ x, x ∈ sym2.from_rel sym), apply_instance }
+λ z, quotient.rec_on_subsingleton z (λ x, h _ _)
 
 end relations
 


### PR DESCRIPTION
This golfs the decidable instances, and removes a redundant one (`from_rel.decidable_as_set` is automatically inferred from `from_rel.decidable_pred`)