### PR TITLE
[Merged by Bors] - chore(data/fintype/basic): Remove duplicate instance

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -243,12 +243,6 @@ def of_surjective [decidable_eq β] [fintype α] (f : α → β) (H : function.s
   fintype β :=
 ⟨univ.image f, λ b, let ⟨a, e⟩ := H b in e ▸ mem_image_of_mem _ (mem_univ _)⟩
 
-instance subtype_of_fintype {α : Sort*} [fintype α] (p : α → Prop) [decidable_pred p] :
-  fintype (subtype p) :=
-{ elems := ⟨((finset.univ : finset α).filter p).1.pmap subtype.mk (by simp),
-  multiset.nodup_pmap (λ _ _ _ _, subtype.mk.inj) (multiset.nodup_filter p finset.univ.nodup)⟩,
-  complete := λ ⟨x, h⟩, by simp [h] }
-
 /-- Given an injective function to a fintype, the domain is also a
 fintype. This is noncomputable because injectivity alone cannot be
 used to construct preimages. -/


### PR DESCRIPTION
We already have `subtype.fintype`, there is no need for `fintype.subtype_of_fintype` which does the same thing


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Follow up to #5890 and #5919. Turns out the instance we wanted was there all along, and it was shadowed by a bad noncomputable one. #5919 made the non-computable one computable, but at that point the two instances are the same.

The offending instance was added in #4786