### PR TITLE
[Merged by Bors] - refactor(data/real/nnreal): shorter proof of `div_lt_iff`

### DIFF
--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -601,10 +601,7 @@ lemma two_inv_lt_one : (2⁻¹:ℝ≥0) < 1 :=
 by simpa using half_lt_self zero_ne_one.symm
 
 lemma div_lt_iff {a b c : ℝ≥0} (hc : c ≠ 0) : b / c < a ↔ b < a * c :=
-begin
-  rw [← nnreal.coe_lt_coe, ← nnreal.coe_lt_coe, nnreal.coe_div, nnreal.coe_mul],
-  exact div_lt_iff (pos_iff_ne_zero.mpr hc)
-end
+lt_iff_lt_of_le_iff_le $ nnreal.le_div_iff_mul_le hc
 
 lemma div_lt_one_of_lt {a b : ℝ≥0} (h : a < b) : a / b < 1 :=
 begin


### PR DESCRIPTION
Co-authors: `lean-gptf`, Stanislas Polu

