### PR TITLE
[Merged by Bors] - feat(measure_theory): Absolute continuity

### DIFF
--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -671,7 +671,7 @@ begin
   rw [‹borel_space α›.measurable_eq, borel_eq_generate_Ioi α],
   apply measurable_generate_from,
   rintro _ ⟨a, rfl⟩,
-  simp only [set.preimage, mem_Ioi, lt_is_lub_iff (hg _), exists_range_iff, set_of_exists],
+  simp_rw [set.preimage, mem_Ioi, lt_is_lub_iff (hg _), exists_range_iff, set_of_exists],
   exact is_measurable.Union (λ i, hf i (is_open_lt' _).is_measurable)
 end
 
@@ -728,7 +728,7 @@ begin
   rw [‹borel_space α›.measurable_eq, borel_eq_generate_Iio α],
   apply measurable_generate_from,
   rintro _ ⟨a, rfl⟩,
-  simp only [set.preimage, mem_Iio, is_glb_lt_iff (hg _), exists_range_iff, set_of_exists],
+  simp_rw [set.preimage, mem_Iio, is_glb_lt_iff (hg _), exists_range_iff, set_of_exists],
   exact is_measurable.Union (λ i, hf i (is_open_gt' _).is_measurable)
 end
 
@@ -1273,9 +1273,9 @@ begin
   { refine measurable_of_tendsto_nnreal' u (λ i, (hf i).inf_nndist) _ hu hs, swap,
     rw [tendsto_pi], rw [tendsto_pi] at lim, intro x,
     exact ((continuous_inf_nndist_pt s).tendsto (g x)).comp (lim x) },
-    have h4s : g ⁻¹' s = (λ x, inf_nndist (g x) s) ⁻¹' {0},
-    { ext x, simp [h1s, ← mem_iff_inf_dist_zero_of_closed h1s h2s, ← nnreal.coe_eq_zero] },
-    rw [h4s], exact this (is_measurable_singleton 0),
+  have h4s : g ⁻¹' s = (λ x, inf_nndist (g x) s) ⁻¹' {0},
+  { ext x, simp [h1s, ← mem_iff_inf_dist_zero_of_closed h1s h2s, ← nnreal.coe_eq_zero] },
+  rw [h4s], exact this (is_measurable_singleton 0),
 end
 
 /-- A sequential limit of measurable functions valued in a metric space is measurable. -/

--- a/src/measure_theory/group.lean
+++ b/src/measure_theory/group.lean
@@ -81,7 +81,7 @@ variables [group G] [topological_space G] [topological_group G] [borel_space G]
 @[to_additive]
 lemma inv_apply (μ : measure G) {s : set G} (hs : is_measurable s) :
   μ.inv s = μ s⁻¹ :=
-by { unfold measure.inv, rw [measure.map_apply measurable_inv hs, inv_preimage] }
+measure.map_apply measurable_inv hs
 
 @[simp, to_additive] protected lemma inv_inv (μ : measure G) : μ.inv.inv = μ :=
 begin

--- a/src/measure_theory/haar_measure.lean
+++ b/src/measure_theory/haar_measure.lean
@@ -285,18 +285,22 @@ begin
   have h2V₀ : (1 : G) ∈ V₀, { simp only [mem_Inter], rintro ⟨V, hV⟩ h2V, exact hV.2 },
   refine ⟨prehaar K₀.1 V₀, _⟩,
   split,
-  { apply prehaar_mem_haar_product K₀, use 1, rwa h1V₀.interior_eq  },
+  { apply prehaar_mem_haar_product K₀, use 1, rwa h1V₀.interior_eq },
   { simp only [mem_Inter], rintro ⟨V, hV⟩ h2V, apply subset_closure,
     apply mem_image_of_mem, rw [mem_set_of_eq],
     exact ⟨subset.trans (Inter_subset _ ⟨V, hV⟩) (Inter_subset _ h2V), h1V₀, h2V₀⟩ },
 end
 
 /-!
-### The Haar measure on compact sets
+### chaar
 -/
 
-/-- The Haar measure on compact sets, defined to be an arbitrary element in the intersection of
-  all the sets `cl_prehaar K₀ V` in `haar_product K₀`. -/
+/-- This is the "limit" of `prehaar K₀.1 U K` as `U` becomes a smaller and smaller open
+  neighborhood of `(1 : G)`. More precisely, it is defined to be an arbitrary element
+  in the intersection of all the sets `cl_prehaar K₀ V` in `haar_product K₀`.
+  This is roughly equal to the Haar measure on compact sets,
+  but it can differ slightly. According to [Halmos, §53, Th. C, pg 234] we have
+  `haar_measure K₀ (interior K.1) ≤ chaar K₀ K ≤ haar_measure K₀ K.1`. -/
 def chaar (K₀ : positive_compacts G) (K : compacts G) : ℝ :=
 classical.some (nonempty_Inter_cl_prehaar K₀) K
 
@@ -313,7 +317,8 @@ by { have := chaar_mem_haar_product K₀ K (mem_univ _), rw mem_Icc at this, exa
 
 lemma chaar_empty (K₀ : positive_compacts G) : chaar K₀ ⊥ = 0 :=
 begin
-  let eval : (compacts G → ℝ) → ℝ := λ f, f ⊥, have : continuous eval := continuous_apply ⊥,
+  let eval : (compacts G → ℝ) → ℝ := λ f, f ⊥,
+  have : continuous eval := continuous_apply ⊥,
   show chaar K₀ ∈ eval ⁻¹' {(0 : ℝ)},
   apply mem_of_subset_of_mem _ (chaar_mem_cl_prehaar K₀ ⟨set.univ, is_open_univ, mem_univ _⟩),
   unfold cl_prehaar, rw is_closed.closure_subset_iff,

--- a/src/measure_theory/haar_measure.lean
+++ b/src/measure_theory/haar_measure.lean
@@ -299,8 +299,10 @@ end
   neighborhood of `(1 : G)`. More precisely, it is defined to be an arbitrary element
   in the intersection of all the sets `cl_prehaar K₀ V` in `haar_product K₀`.
   This is roughly equal to the Haar measure on compact sets,
-  but it can differ slightly. According to [Halmos, §53, Th. C, pg 234] we have
-  `haar_measure K₀ (interior K.1) ≤ chaar K₀ K ≤ haar_measure K₀ K.1`. -/
+  but it can differ slightly. We do know that
+  `haar_measure K₀ (interior K.1) ≤ chaar K₀ K ≤ haar_measure K₀ K.1`.
+  These inequalities are given by `measure_theory.measure.haar_outer_measure_le_echaar` and
+  `measure_theory.measure.echaar_le_haar_outer_measure`. -/
 def chaar (K₀ : positive_compacts G) (K : compacts G) : ℝ :=
 classical.some (nonempty_Inter_cl_prehaar K₀) K
 

--- a/src/measure_theory/haar_measure.lean
+++ b/src/measure_theory/haar_measure.lean
@@ -292,7 +292,7 @@ begin
 end
 
 /-!
-### chaar
+### Lemmas about `chaar`
 -/
 
 /-- This is the "limit" of `prehaar K₀.1 U K` as `U` becomes a smaller and smaller open

--- a/src/measure_theory/haar_measure.lean
+++ b/src/measure_theory/haar_measure.lean
@@ -178,7 +178,7 @@ lemma index_union_eq (K₁ K₂ : compacts G) {V : set G} (hV : (interior V).non
 begin
   apply le_antisymm (index_union_le K₁ K₂ hV),
   rcases index_elim (K₁.2.union K₂.2) hV with ⟨s, h1s, h2s⟩, rw [← h2s],
-  have : ∀(K : set G) , K ⊆ (⋃ g ∈ s, (λ h, g * h) ⁻¹' V) →
+  have : ∀ (K : set G) , K ⊆ (⋃ g ∈ s, (λ h, g * h) ⁻¹' V) →
     index K V ≤ (s.filter (λ g, ((λ (h : G), g * h) ⁻¹' V ∩ K).nonempty)).card,
   { intros K hK, apply nat.Inf_le, refine ⟨_, _, rfl⟩, rw [mem_set_of_eq],
     intros g hg, rcases hK hg with ⟨_, ⟨g₀, rfl⟩, _, ⟨h1g₀, rfl⟩, h2g₀⟩,

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -1298,9 +1298,9 @@ by simp_rw [mul_comm, lintegral_const_mul' r f hr]
 /- A double integral of a product where each factor contains only one variable
   is a product of integrals -/
 lemma lintegral_lintegral_mul {β} [measurable_space β] {ν : measure β}
-  {f : α → ennreal} {g : β → ennreal} (hf : measurable f) (hg : measurable g) :
+  {f : α → ennreal} {g : β → ennreal} (hf : ae_measurable f μ) (hg : ae_measurable g ν) :
   ∫⁻ x, ∫⁻ y, f x * g y ∂ν ∂μ = ∫⁻ x, f x ∂μ * ∫⁻ y, g y ∂ν :=
-by simp [lintegral_const_mul _ hg, lintegral_mul_const _ hf]
+by simp [lintegral_const_mul'' _ hg, lintegral_mul_const'' _ hf]
 
 -- TODO: Need a better way of rewriting inside of a integral
 lemma lintegral_rw₁ {f f' : α → β} (h : f =ᵐ[μ] f') (g : β → ennreal) :

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -2287,11 +2287,9 @@ lemma comp_measurable [measurable_space δ] {f : α → δ} {g : δ → β}
   (hg : ae_measurable g (map f μ)) (hf : measurable f) : ae_measurable (g ∘ f) μ :=
 ⟨hg.mk g ∘ f, hg.measurable_mk.comp hf, ae_eq_comp hf hg.ae_eq_mk⟩
 
-/- a generalization of `ae_measurable.comp_measurable` when the left map is `ae_measurable` with
-  respect that a measure different from `map f μ` -/
 lemma comp_measurable' {δ} [measurable_space δ] {ν : measure δ} {f : α → δ} {g : δ → β}
   (hg : ae_measurable g ν) (hf : measurable f) (h : map f μ ≪ ν) : ae_measurable (g ∘ f) μ :=
-⟨hg.mk g ∘ f, hg.measurable_mk.comp hf, ae_eq_comp' hf hg.ae_eq_mk h⟩
+(hg.mono' h).comp_measurable hf
 
 lemma prod_mk {γ : Type*} [measurable_space γ] {f : α → β} {g : α → γ}
   (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ x, (f x, g x)) μ :=

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -526,7 +526,7 @@ measure.ext $ λ s, μ.to_outer_measure.trim_eq
 end outer_measure
 
 variables [measurable_space α] [measurable_space β] [measurable_space γ]
-variables {μ μ₁ μ₂ ν ν' ν₁ ν₂ : measure α} {s s' t : set α}
+variables {μ μ₁ μ₂ μ₃ ν ν' ν₁ ν₂ : measure α} {s s' t : set α}
 
 namespace measure
 
@@ -1199,6 +1199,34 @@ calc count s < ⊤ ↔ count s ≠ ⊤ : lt_top_iff_ne_top
              ... ↔ ¬s.infinite : not_congr count_apply_eq_top
              ... ↔ s.finite    : not_not
 
+/-! ### Absolute continuity -/
+
+/-- We say that `μ` is absolutely continuous with respect to `ν`, or that `μ` is dominated by `ν`,
+  if `ν(A) = 0` implies that `μ(A) = 0` for -/
+def absolutely_continuous (μ ν : measure α) : Prop :=
+∀ ⦃s : set α⦄, ν s = 0 → μ s = 0
+
+infix ` ≪ `:50 := absolutely_continuous
+
+lemma absolutely_continuous.mk (h : ∀ ⦃s : set α⦄, is_measurable s → ν s = 0 → μ s = 0) : μ ≪ ν :=
+begin
+  intros s hs,
+  rcases exists_is_measurable_superset_of_null hs with ⟨t, h1t, h2t, h3t⟩,
+  exact measure_mono_null h1t (h h2t h3t),
+end
+
+@[refl] lemma absolutely_continuous.refl (μ : measure α) : μ ≪ μ := λ s hs, hs
+
+lemma absolutely_continuous.rfl : μ ≪ μ := λ s hs, hs
+
+lemma absolutely_continuous_of_eq (h : μ = ν) : μ ≪ ν := by rw h
+
+alias absolutely_continuous_of_eq ← eq.absolutely_continuous
+
+@[trans] lemma absolutely_continuous.trans (h1 : μ₁ ≪ μ₂) (h2 : μ₂ ≪ μ₃) : μ₁ ≪ μ₃ :=
+λ s hs, h1 $ h2 hs
+
+
 /-! ### The almost everywhere filter -/
 
 /-- The “almost everywhere” filter of co-null sets. -/
@@ -1340,15 +1368,12 @@ lemma ae_add_measure_iff {p : α → Prop} {ν} : (∀ᵐ x ∂μ + ν, p x) ↔
 add_eq_zero_iff
 
 lemma ae_eq_comp' {ν : measure β} {f : α → β} {g g' : β → δ} (hf : measurable f)
-  (h : g =ᵐ[ν] g') (h2f : ∀ s, is_measurable s → ν s = 0 → μ (f ⁻¹' s) = 0) : g ∘ f =ᵐ[μ] g' ∘ f :=
-begin
-  rcases exists_is_measurable_superset_of_null h with ⟨t, h1t, h2t, h3t⟩,
-  exact measure_mono_null (preimage_mono h1t : _) (h2f t h2t h3t)
-end
+  (h : g =ᵐ[ν] g') (h2 : map f μ ≪ ν) : g ∘ f =ᵐ[μ] g' ∘ f :=
+preimage_null_of_map_null hf $ h2 h
 
 lemma ae_eq_comp {f : α → β} {g g' : β → δ} (hf : measurable f)
   (h : g =ᵐ[measure.map f μ] g') : g ∘ f =ᵐ[μ] g' ∘ f :=
-preimage_null_of_map_null hf h
+ae_eq_comp' hf h absolutely_continuous.rfl
 
 lemma le_ae_restrict : μ.ae ⊓ 𝓟 s ≤ (μ.restrict s).ae :=
 λ s hs, eventually_inf_principal.2 (ae_imp_of_ae_restrict hs)
@@ -2215,6 +2240,9 @@ lemma mono_set {s t} (h : s ⊆ t) (ht : ae_measurable f (μ.restrict t)) :
   ae_measurable f (μ.restrict s) :=
 ht.mono_measure (restrict_mono h le_rfl)
 
+protected lemma mono' (h : ae_measurable f μ) (h' : ν ≪ μ) : ae_measurable f ν :=
+⟨h.mk f, h.measurable_mk, h' h.ae_eq_mk⟩
+
 lemma ae_mem_imp_eq_mk {s} (h : ae_measurable f (μ.restrict s)) :
   ∀ᵐ x ∂μ, x ∈ s → f x = h.mk f x :=
 ae_imp_of_ae_restrict h.ae_eq_mk
@@ -2262,9 +2290,8 @@ lemma comp_measurable [measurable_space δ] {f : α → δ} {g : δ → β}
 /- a generalization of `ae_measurable.comp_measurable` when the left map is `ae_measurable` with
   respect that a measure different from `map f μ` -/
 lemma comp_measurable' {δ} [measurable_space δ] {ν : measure δ} {f : α → δ} {g : δ → β}
-  (hg : ae_measurable g ν) (hf : measurable f)
-  (h2f : ∀ s, is_measurable s → ν s = 0 → μ (f ⁻¹' s) = 0) : ae_measurable (g ∘ f) μ :=
-⟨hg.mk g ∘ f, hg.measurable_mk.comp hf, ae_eq_comp' hf hg.ae_eq_mk h2f⟩
+  (hg : ae_measurable g ν) (hf : measurable f) (h : map f μ ≪ ν) : ae_measurable (g ∘ f) μ :=
+⟨hg.mk g ∘ f, hg.measurable_mk.comp hf, ae_eq_comp' hf hg.ae_eq_mk h⟩
 
 lemma prod_mk {γ : Type*} [measurable_space γ] {f : α → β} {g : α → γ}
   (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ x, (f x, g x)) μ :=

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1340,8 +1340,11 @@ lemma ae_add_measure_iff {p : α → Prop} {ν} : (∀ᵐ x ∂μ + ν, p x) ↔
 add_eq_zero_iff
 
 lemma ae_eq_comp' {ν : measure β} {f : α → β} {g g' : β → δ} (hf : measurable f)
-  (h : g =ᵐ[ν] g') (h2f : ∀ s, ν s = 0 → μ (f ⁻¹' s) = 0) : g ∘ f =ᵐ[μ] g' ∘ f :=
-h2f _ h
+  (h : g =ᵐ[ν] g') (h2f : ∀ s, is_measurable s → ν s = 0 → μ (f ⁻¹' s) = 0) : g ∘ f =ᵐ[μ] g' ∘ f :=
+begin
+  rcases exists_is_measurable_superset_of_null h with ⟨t, h1t, h2t, h3t⟩,
+  exact measure_mono_null (preimage_mono h1t : _) (h2f t h2t h3t)
+end
 
 lemma ae_eq_comp {f : α → β} {g g' : β → δ} (hf : measurable f)
   (h : g =ᵐ[measure.map f μ] g') : g ∘ f =ᵐ[μ] g' ∘ f :=
@@ -2253,13 +2256,15 @@ lemma smul_measure (h : ae_measurable f μ) (c : ennreal) :
 ⟨h.mk f, h.measurable_mk, ae_smul_measure h.ae_eq_mk c⟩
 
 lemma comp_measurable [measurable_space δ] {f : α → δ} {g : δ → β}
-  (hg : ae_measurable g (measure.map f μ)) (hf : measurable f) : ae_measurable (g ∘ f) μ :=
-⟨(hg.mk g) ∘ f, hg.measurable_mk.comp hf, ae_eq_comp hf hg.ae_eq_mk⟩
+  (hg : ae_measurable g (map f μ)) (hf : measurable f) : ae_measurable (g ∘ f) μ :=
+⟨hg.mk g ∘ f, hg.measurable_mk.comp hf, ae_eq_comp hf hg.ae_eq_mk⟩
 
+/- a generalization of `ae_measurable.comp_measurable` when the left map is `ae_measurable` with
+  respect that a measure different from `map f μ` -/
 lemma comp_measurable' {δ} [measurable_space δ] {ν : measure δ} {f : α → δ} {g : δ → β}
-  (hg : ae_measurable g ν) (hf : measurable f) (h2f : ∀ s, ν s = 0 → μ (f ⁻¹' s) = 0) :
-    ae_measurable (g ∘ f) μ :=
-⟨(hg.mk g) ∘ f, hg.measurable_mk.comp hf, ae_eq_comp' hf hg.ae_eq_mk h2f⟩
+  (hg : ae_measurable g ν) (hf : measurable f)
+  (h2f : ∀ s, is_measurable s → ν s = 0 → μ (f ⁻¹' s) = 0) : ae_measurable (g ∘ f) μ :=
+⟨hg.mk g ∘ f, hg.measurable_mk.comp hf, ae_eq_comp' hf hg.ae_eq_mk h2f⟩
 
 lemma prod_mk {γ : Type*} [measurable_space γ] {f : α → β} {g : α → γ}
   (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ x, (f x, g x)) μ :=

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -202,7 +202,7 @@ lemma exists_is_measurable_superset (μ : measure α) (s : set α) :
 by simpa only [← measure_eq_trim] using μ.to_outer_measure.exists_is_measurable_superset_eq_trim s
 
 /-- A measurable set `t ⊇ s` such that `μ t = μ s`. -/
-def to_measurable (μ : measure α) (s : set α) :=
+def to_measurable (μ : measure α) (s : set α) : set α :=
 classical.some (exists_is_measurable_superset μ s)
 
 lemma subset_to_measurable (μ : measure α) (s : set α) : s ⊆ to_measurable μ s :=

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -739,6 +739,11 @@ begin
   exact map_apply hf ht
 end
 
+/-- Even if `s` is not measurable, `map f μ s = 0` implies that `μ (f ⁻¹' s) = 0`. -/
+lemma preimage_null_of_map_null {f : α → β} (hf : measurable f) {s : set β}
+  (hs : map f μ s = 0) : μ (f ⁻¹' s) = 0 :=
+nonpos_iff_eq_zero.mp $ (le_map_apply hf s).trans_eq hs
+
 /-- Pullback of a `measure`. If `f` sends each `measurable` set to a `measurable` set, then for each
 measurable set `s` we have `comap f μ s = μ (f '' s)`. -/
 def comap (f : α → β) : measure β →ₗ[ennreal] measure α :=
@@ -1334,14 +1339,13 @@ by simp [ae_iff, hc]
 lemma ae_add_measure_iff {p : α → Prop} {ν} : (∀ᵐ x ∂μ + ν, p x) ↔ (∀ᵐ x ∂μ, p x) ∧ ∀ᵐ x ∂ν, p x :=
 add_eq_zero_iff
 
+lemma ae_eq_comp' {ν : measure β} {f : α → β} {g g' : β → δ} (hf : measurable f)
+  (h : g =ᵐ[ν] g') (h2f : ∀ s, ν s = 0 → μ (f ⁻¹' s) = 0) : g ∘ f =ᵐ[μ] g' ∘ f :=
+h2f _ h
+
 lemma ae_eq_comp {f : α → β} {g g' : β → δ} (hf : measurable f)
   (h : g =ᵐ[measure.map f μ] g') : g ∘ f =ᵐ[μ] g' ∘ f :=
-begin
-  rcases exists_is_measurable_superset_of_null h with ⟨t, ht, tmeas, tzero⟩,
-  refine le_antisymm _ bot_le,
-  calc μ {x | g (f x) ≠ g' (f x)} ≤ μ (f⁻¹' t) : measure_mono (λ x hx, ht hx)
-  ... = 0 : by rwa ← measure.map_apply hf tmeas
-end
+preimage_null_of_map_null hf h
 
 lemma le_ae_restrict : μ.ae ⊓ 𝓟 s ≤ (μ.restrict s).ae :=
 λ s hs, eventually_inf_principal.2 (ae_imp_of_ae_restrict hs)
@@ -2251,6 +2255,11 @@ lemma smul_measure (h : ae_measurable f μ) (c : ennreal) :
 lemma comp_measurable [measurable_space δ] {f : α → δ} {g : δ → β}
   (hg : ae_measurable g (measure.map f μ)) (hf : measurable f) : ae_measurable (g ∘ f) μ :=
 ⟨(hg.mk g) ∘ f, hg.measurable_mk.comp hf, ae_eq_comp hf hg.ae_eq_mk⟩
+
+lemma comp_measurable' {δ} [measurable_space δ] {ν : measure δ} {f : α → δ} {g : δ → β}
+  (hg : ae_measurable g ν) (hf : measurable f) (h2f : ∀ s, ν s = 0 → μ (f ⁻¹' s) = 0) :
+    ae_measurable (g ∘ f) μ :=
+⟨(hg.mk g) ∘ f, hg.measurable_mk.comp hf, ae_eq_comp' hf hg.ae_eq_mk h2f⟩
 
 lemma prod_mk {γ : Type*} [measurable_space γ] {f : α → β} {g : α → γ}
   (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ x, (f x, g x)) μ :=

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1202,7 +1202,7 @@ calc count s < ⊤ ↔ count s ≠ ⊤ : lt_top_iff_ne_top
 /-! ### Absolute continuity -/
 
 /-- We say that `μ` is absolutely continuous with respect to `ν`, or that `μ` is dominated by `ν`,
-  if `ν(A) = 0` implies that `μ(A) = 0` for -/
+  if `ν(A) = 0` implies that `μ(A) = 0`. -/
 def absolutely_continuous (μ ν : measure α) : Prop :=
 ∀ ⦃s : set α⦄, ν s = 0 → μ s = 0
 

--- a/src/measure_theory/prod.lean
+++ b/src/measure_theory/prod.lean
@@ -257,8 +257,7 @@ begin
     (λ x, (s' n x).integral ν),
   have hf' : ∀ n, measurable (f' n),
   { intro n, refine measurable.indicator _ (is_measurable_integrable hf),
-    have : ∀ x, (s' n x).range.filter (λ x, x ≠ 0) ⊆
-      (s n).range,
+    have : ∀ x, (s' n x).range.filter (λ x, x ≠ 0) ⊆ (s n).range,
     { intros x, refine finset.subset.trans (finset.filter_subset _ _) _, intro y,
       simp_rw [simple_func.mem_range], rintro ⟨z, rfl⟩, exact ⟨(x, z), rfl⟩ },
     simp only [simple_func.integral_eq_sum_of_subset (this _)],
@@ -860,7 +859,7 @@ begin
   { intros f g hfg i_f hf, convert hf using 1,
     { exact integral_congr_ae hfg.symm },
     { refine integral_congr_ae _,
-      rw [eventually_eq] at hfg, refine (ae_ae_of_ae_prod hfg).mp _,
+      refine (ae_ae_of_ae_prod hfg).mp _,
       apply eventually_of_forall, intros x hfgx,
       exact integral_congr_ae (ae_eq_symm hfgx) } }
 end

--- a/src/measure_theory/prod.lean
+++ b/src/measure_theory/prod.lean
@@ -414,6 +414,20 @@ begin
   { simp_rw [Union_unpair_prod, hμ.spanning, hν.spanning, univ_prod_univ] }
 end
 
+lemma prod_fst_absolutely_continuous : map prod.fst (μ.prod ν) ≪ μ :=
+begin
+  refine absolutely_continuous.mk (λ s hs h2s, _),
+  simp_rw [map_apply measurable_fst hs, ← prod_univ, prod_prod hs is_measurable.univ],
+  rw [h2s, zero_mul] -- for some reason `simp_rw [h2s]` doesn't work
+end
+
+lemma prod_snd_absolutely_continuous : map prod.snd (μ.prod ν) ≪ ν :=
+begin
+  refine absolutely_continuous.mk (λ s hs h2s, _),
+  simp_rw [map_apply measurable_snd hs, ← univ_prod, prod_prod is_measurable.univ hs],
+  rw [h2s, mul_zero] -- for some reason `simp_rw [h2s]` doesn't work
+end
+
 variables [sigma_finite μ]
 
 instance prod.sigma_finite : sigma_finite (μ.prod ν) :=
@@ -531,13 +545,11 @@ by { rw ← prod_swap at hf, exact hf.comp_measurable measurable_swap }
 
 lemma ae_measurable.fst [sigma_finite ν] {f : α → γ}
   (hf : ae_measurable f μ) : ae_measurable (λ (z : α × β), f z.1) (μ.prod ν) :=
-hf.comp_measurable' measurable_fst $
-  by { intros s h1s h2s, simp_rw [← prod_univ, prod_prod h1s is_measurable.univ, h2s, zero_mul] }
+hf.comp_measurable' measurable_fst prod_fst_absolutely_continuous
 
 lemma ae_measurable.snd [sigma_finite ν] {f : β → γ}
   (hf : ae_measurable f ν) : ae_measurable (λ (z : α × β), f z.2) (μ.prod ν) :=
-hf.comp_measurable' measurable_snd $
-  by { intros s h1s h2s, simp_rw [← univ_prod, prod_prod is_measurable.univ h1s, h2s, mul_zero] }
+hf.comp_measurable' measurable_snd prod_snd_absolutely_continuous
 
 /-- The Bochner integral is a.e.-measurable.
   This shows that the integrand of (the right-hand-side of) Fubini's theorem is a.e.-measurable. -/

--- a/src/measure_theory/prod.lean
+++ b/src/measure_theory/prod.lean
@@ -529,13 +529,15 @@ lemma ae_measurable.prod_swap [sigma_finite μ] [sigma_finite ν] {f : β × α 
   (hf : ae_measurable f (ν.prod μ)) : ae_measurable (λ (z : α × β), f z.swap) (μ.prod ν) :=
 by { rw ← prod_swap at hf, exact hf.comp_measurable measurable_swap }
 
-lemma ae_measurable.fst [sigma_finite μ] [sigma_finite ν] {f : α → γ}
+lemma ae_measurable.fst [sigma_finite ν] {f : α → γ}
   (hf : ae_measurable f μ) : ae_measurable (λ (z : α × β), f z.1) (μ.prod ν) :=
-hf.comp_measurable' measurable_fst _
+hf.comp_measurable' measurable_fst $
+  by { intros s h1s h2s, simp_rw [← prod_univ, prod_prod h1s is_measurable.univ, h2s, zero_mul] }
 
-lemma ae_measurable.snd [sigma_finite μ] [sigma_finite ν] {f : β → γ}
+lemma ae_measurable.snd [sigma_finite ν] {f : β → γ}
   (hf : ae_measurable f ν) : ae_measurable (λ (z : α × β), f z.2) (μ.prod ν) :=
-hf.comp_measurable' measurable_snd _
+hf.comp_measurable' measurable_snd $
+  by { intros s h1s h2s, simp_rw [← univ_prod, prod_prod is_measurable.univ h1s, h2s, mul_zero] }
 
 /-- The Bochner integral is a.e.-measurable.
   This shows that the integrand of (the right-hand-side of) Fubini's theorem is a.e.-measurable. -/
@@ -640,8 +642,7 @@ lemma lintegral_lintegral_swap [sigma_finite μ] ⦃f : α → β → ennreal⦄
 lemma lintegral_prod_mul [sigma_finite μ] {f : α → ennreal} {g : β → ennreal}
   (hf : ae_measurable f μ) (hg : ae_measurable g ν) :
   ∫⁻ z, f z.1 * g z.2 ∂(μ.prod ν) = ∫⁻ x, f x ∂μ * ∫⁻ y, g y ∂ν :=
-by simp [lintegral_prod _ ((hf.fst).ennreal_mul hg.snd),
-  lintegral_lintegral_mul'' hf hg]
+by simp [lintegral_prod _ (hf.fst.ennreal_mul hg.snd), lintegral_lintegral_mul hf hg]
 
 /-! ### Integrability on a product -/
 section
@@ -661,7 +662,7 @@ lemma has_finite_integral_prod_iff ⦃f : α × β → E⦄ (h1f : measurable f)
   has_finite_integral f (μ.prod ν) ↔ (∀ᵐ x ∂ μ, has_finite_integral (λ y, f (x, y)) ν) ∧
     has_finite_integral (λ x, ∫ y, ∥f (x, y)∥ ∂ν) μ :=
 begin
-  simp only [has_finite_integral, lintegral_prod _ h1f.ennnorm],
+  simp only [has_finite_integral, lintegral_prod_of_measurable _ h1f.ennnorm],
   have : ∀ x, ∀ᵐ y ∂ν, 0 ≤ ∥f (x, y)∥ := λ x, eventually_of_forall (λ y, norm_nonneg _),
   simp_rw [integral_eq_lintegral_of_nonneg_ae (this _)
     (h1f.norm.comp measurable_prod_mk_left).ae_measurable,
@@ -833,7 +834,8 @@ begin
     ∫⁻ x, ∫⁻ (y : β), nnnorm (i (x, y) - g (x, y)) ∂ν ∂μ) (𝓝 g) (𝓝 0),
   have : ∀ (i : α × β →₁[μ.prod ν] E), measurable (λ z, (nnnorm (i z - g z) : ennreal)) :=
   λ i, (i.measurable.sub g.measurable).ennnorm,
-  simp_rw [← lintegral_prod _ (this _), ← l1.of_real_norm_sub_eq_lintegral, ← of_real_zero],
+  simp_rw [← lintegral_prod_of_measurable _ (this _), ← l1.of_real_norm_sub_eq_lintegral,
+    ← of_real_zero],
   refine (continuous_of_real.tendsto 0).comp _,
   rw [← tendsto_iff_norm_tendsto_zero], exact tendsto_id
 end

--- a/src/measure_theory/prod.lean
+++ b/src/measure_theory/prod.lean
@@ -651,7 +651,7 @@ lemma lintegral_lintegral_swap [sigma_finite μ] ⦃f : α → β → ennreal⦄
   ∫⁻ x, ∫⁻ y, f x y ∂ν ∂μ = ∫⁻ y, ∫⁻ x, f x y ∂μ ∂ν :=
 (lintegral_lintegral hf).trans (lintegral_prod_symm _ hf)
 
-lemma lintegral_prod_mul [sigma_finite μ] {f : α → ennreal} {g : β → ennreal}
+lemma lintegral_prod_mul {f : α → ennreal} {g : β → ennreal}
   (hf : ae_measurable f μ) (hg : ae_measurable g ν) :
   ∫⁻ z, f z.1 * g z.2 ∂(μ.prod ν) = ∫⁻ x, f x ∂μ * ∫⁻ y, g y ∂ν :=
 by simp [lintegral_prod _ (hf.fst.ennreal_mul hg.snd), lintegral_lintegral_mul hf hg]

--- a/src/measure_theory/prod_group.lean
+++ b/src/measure_theory/prod_group.lean
@@ -138,7 +138,7 @@ lemma lintegral_lintegral_mul_inv (hμ : is_mul_left_invariant μ) (hν : is_mul
 begin
   have h2f : measurable (uncurry $ λ x y, f (y * x) x⁻¹) :=
   hf.comp ((measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv),
-  simp_rw [lintegral_lintegral h2f, lintegral_lintegral hf],
+  simp_rw [lintegral_lintegral h2f.ae_measurable, lintegral_lintegral hf.ae_measurable],
   conv_rhs { rw [← map_prod_mul_inv_eq hμ hν] },
   symmetry, exact lintegral_map hf ((measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv)
 end
@@ -175,7 +175,7 @@ begin
   have hg : measurable g := (hf.comp measurable_inv).ennreal_div
     ((measurable_measure_mul_right Em).comp measurable_inv),
   rw [← set_lintegral_one, ← lintegral_indicator _ Em,
-    ← lintegral_lintegral_mul (measurable_const.indicator Em) hg,
+    ← lintegral_lintegral_mul (measurable_const.indicator Em).ae_measurable hg.ae_measurable,
     ← lintegral_lintegral_mul_inv hμ hν],
   swap, { exact ((measurable_const.indicator Em).comp measurable_fst).ennreal_mul
       (hg.comp measurable_snd) },

--- a/src/measure_theory/prod_group.lean
+++ b/src/measure_theory/prod_group.lean
@@ -133,14 +133,17 @@ begin
 end
 
 lemma lintegral_lintegral_mul_inv (hμ : is_mul_left_invariant μ) (hν : is_mul_left_invariant ν)
-  (f : G → G → ennreal) (hf : measurable (uncurry f)) :
+  (f : G → G → ennreal) (hf : ae_measurable (uncurry f) (μ.prod ν)) :
   ∫⁻ x, ∫⁻ y, f (y * x) x⁻¹ ∂ν ∂μ = ∫⁻ x, ∫⁻ y, f x y ∂ν ∂μ :=
 begin
-  have h2f : measurable (uncurry $ λ x y, f (y * x) x⁻¹) :=
-  hf.comp ((measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv),
-  simp_rw [lintegral_lintegral h2f.ae_measurable, lintegral_lintegral hf.ae_measurable],
+  have h : measurable (λ z : G × G, (z.2 * z.1, z.1⁻¹)) :=
+  (measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv,
+  have h2f : ae_measurable (uncurry $ λ x y, f (y * x) x⁻¹) (μ.prod ν),
+  { apply hf.comp_measurable' h (map_prod_mul_inv_eq hμ hν).absolutely_continuous },
+  simp_rw [lintegral_lintegral h2f, lintegral_lintegral hf],
   conv_rhs { rw [← map_prod_mul_inv_eq hμ hν] },
-  symmetry, exact lintegral_map hf ((measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv)
+  symmetry,
+  exact lintegral_map' (hf.mono' (map_prod_mul_inv_eq hμ hν).absolutely_continuous) h,
 end
 
 lemma measure_mul_right_null (hμ : is_mul_left_invariant μ) {E : set G} (hE : is_measurable E)
@@ -177,8 +180,8 @@ begin
   rw [← set_lintegral_one, ← lintegral_indicator _ Em,
     ← lintegral_lintegral_mul (measurable_const.indicator Em).ae_measurable hg.ae_measurable,
     ← lintegral_lintegral_mul_inv hμ hν],
-  swap, { exact ((measurable_const.indicator Em).comp measurable_fst).ennreal_mul
-      (hg.comp measurable_snd) },
+  swap, { exact (((measurable_const.indicator Em).comp measurable_fst).ennreal_mul
+      (hg.comp measurable_snd)).ae_measurable },
   have mE : ∀ x : G, measurable (λ y, ((λ z, z * x) ⁻¹' E).indicator (λ z, (1 : ennreal)) y) :=
   λ x, measurable_const.indicator (measurable_mul_right _ Em),
   have : ∀ x y, E.indicator (λ (z : G), (1 : ennreal)) (y * x) =

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -457,7 +457,7 @@ by simpa using compact_univ (show f ≤ 𝓟 univ, by simp)
 
 theorem compact_space_of_finite_subfamily_closed {α : Type u} [topological_space α]
   (h : Π {ι : Type u} (Z : ι → (set α)), (∀ i, is_closed (Z i)) →
-    (⋂ i, Z i) = ∅ → (∃ (t : finset ι), (⋂ i ∈ t, Z i) = ∅)) :
+    (⋂ i, Z i) = ∅ → ∃ (t : finset ι), (⋂ i ∈ t, Z i) = ∅) :
   compact_space α :=
 { compact_univ :=
   begin
@@ -583,11 +583,11 @@ instance [compact_space α] [compact_space β] : compact_space (α ⊕ β) :=
 end⟩
 
 section tychonoff
-variables {ι : Type*} {π : ι → Type*} [∀i, topological_space (π i)]
+variables {ι : Type*} {π : ι → Type*} [∀ i, topological_space (π i)]
 
 /-- Tychonoff's theorem -/
-lemma compact_pi_infinite {s : Πi:ι, set (π i)} :
-  (∀i, is_compact (s i)) → is_compact {x : Πi:ι, π i | ∀i, x i ∈ s i} :=
+lemma compact_pi_infinite {s : Π i, set (π i)} :
+  (∀ i, is_compact (s i)) → is_compact {x : Π i, π i | ∀ i, x i ∈ s i} :=
 begin
   simp only [compact_iff_ultrafilter_le_nhds, nhds_pi, exists_prop, mem_set_of_eq, le_infi_iff,
     le_principal_iff],
@@ -600,17 +600,12 @@ begin
 end
 
 /-- A version of Tychonoff's theorem that uses `set.pi`. -/
-lemma compact_univ_pi {s : Πi:ι, set (π i)} (h : ∀i, is_compact (s i)) :
+lemma compact_univ_pi {s : Π i, set (π i)} (h : ∀ i, is_compact (s i)) :
   is_compact (pi univ s) :=
 by { convert compact_pi_infinite h, simp only [pi, forall_prop_of_true, mem_univ] }
 
-instance pi.compact [∀i:ι, compact_space (π i)] : compact_space (Πi, π i) :=
-⟨begin
-  have A : is_compact {x : Πi:ι, π i | ∀i, x i ∈ (univ : set (π i))} :=
-    compact_pi_infinite (λi, compact_univ),
-  have : {x : Πi:ι, π i | ∀i, x i ∈ (univ : set (π i))} = univ := by ext; simp,
-  rwa this at A,
-end⟩
+instance pi.compact_space [∀ i, compact_space (π i)] : compact_space (Πi, π i) :=
+⟨by { rw [← pi_univ univ], exact compact_univ_pi (λ i, compact_univ) }⟩
 
 end tychonoff
 


### PR DESCRIPTION
* Define absolute continuity between measures (@mzinkevi)
* State monotonicity of `ae_measurable` w.r.t. absolute continuity
* Weaken some `measurable` assumptions in `prod.lean` to `ae_measurable`
* Some docstring fixes
* Some cleanup

---

I'm open to a different (shorter) name than `absolutely_continuous`