### PR TITLE
[Merged by Bors] - chore(linear_algebra/linear_independent): relax requirements to semiring and division_ring

### DIFF
--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -81,10 +81,12 @@ universe u
 variables {ι : Type*} {ι' : Type*} {R : Type*} {K : Type*}
 variables {M : Type*} {M' M'' : Type*} {V : Type u} {V' : Type*}
 
-section module
+
+section semimodule
+
 variables {v : ι → M}
-variables [ring R] [add_comm_group M] [add_comm_group M'] [add_comm_group M'']
-variables [module R M] [module R M'] [module R M'']
+variables [semiring R] [add_comm_monoid M] [add_comm_monoid M'] [add_comm_monoid M'']
+variables [semimodule R M] [semimodule R M'] [semimodule R M'']
 variables {a b : R} {x y : M}
 
 variables (R) (v)
@@ -96,12 +98,6 @@ variables {R} {v}
 theorem linear_independent_iff : linear_independent R v ↔
   ∀l, finsupp.total ι M R v l = 0 → l = 0 :=
 by simp [linear_independent, linear_map.ker_eq_bot']
-
-theorem linear_independent_iff_injective_total : linear_independent R v ↔
-  function.injective (finsupp.total ι M R v) :=
-linear_independent_iff.trans (finsupp.total ι M R v).to_add_monoid_hom.injective_iff.symm
-
-alias linear_independent_iff_injective_total ↔ linear_independent.injective_total _
 
 theorem linear_independent_iff' : linear_independent R v ↔
   ∀ s : finset ι, ∀ g : ι → R, ∑ i in s, g i • v i = 0 → ∀ i ∈ s, g i = 0 :=
@@ -216,20 +212,6 @@ protected lemma linear_map.linear_independent_iff (f : M →ₗ[R] M') (hf_inj :
 lemma linear_independent_of_subsingleton [subsingleton R] : linear_independent R v :=
 linear_independent_iff.2 (λ l hl, subsingleton.elim _ _)
 
-lemma linear_independent.injective [nontrivial R] (hv : linear_independent R v) :
-  injective v :=
-begin
-  intros i j hij,
-  let l : ι →₀ R := finsupp.single i (1 : R) - finsupp.single j 1,
-  have h_total : finsupp.total ι M R v l = 0,
-  { simp_rw [linear_map.map_sub, finsupp.total_apply],
-    simp [hij] },
-  have h_single_eq : finsupp.single i (1 : R) = finsupp.single j 1,
-  { rw linear_independent_iff at hv,
-    simp [eq_add_of_sub_eq' (hv l h_total)] },
-  simpa [finsupp.single_eq_single_iff] using h_single_eq
-end
-
 theorem linear_independent_equiv (e : ι ≃ ι') {f : ι' → M} :
   linear_independent R (f ∘ e) ↔ linear_independent R f :=
 ⟨λ h, function.comp.right_id f ▸ e.self_comp_symm ▸ h.comp _ e.symm.injective,
@@ -245,26 +227,9 @@ iff.symm $ linear_independent_equiv' (equiv.set.range f hf) rfl
 
 alias linear_independent_subtype_range ↔ linear_independent.of_subtype_range _
 
-theorem linear_independent.to_subtype_range {ι} {f : ι → M} (hf : linear_independent R f) :
-  linear_independent R (coe : range f → M) :=
-begin
-  nontriviality R,
-  exact (linear_independent_subtype_range hf.injective).2 hf
-end
-
-theorem linear_independent.to_subtype_range' {ι} {f : ι → M} (hf : linear_independent R f)
-  {t} (ht : range f = t) :
-  linear_independent R (coe : t → M) :=
-ht ▸ hf.to_subtype_range
-
 theorem linear_independent_image {ι} {s : set ι} {f : ι → M} (hf : set.inj_on f s) :
   linear_independent R (λ x : s, f x) ↔ linear_independent R (λ x : f '' s, (x : M)) :=
 linear_independent_equiv' (equiv.set.image_of_inj_on _ _ hf) rfl
-
-theorem linear_independent.image {ι} {s : set ι} {f : ι → M}
-  (hs : linear_independent R (λ x : s, f x)) : linear_independent R (λ x : f '' s, (x : M)) :=
-(linear_independent_equiv' (equiv.set.of_eq $ by rw [range_comp, subtype.range_coe]) rfl).1
-  hs.to_subtype_range
 
 lemma linear_independent_span (hs : linear_independent R v) :
   @linear_independent ι R (span R (range v))
@@ -330,6 +295,93 @@ begin
  exact (disjoint.mono_left (finsupp.supported_mono h))
 end
 
+lemma linear_independent_of_finite (s : set M)
+  (H : ∀ t ⊆ s, finite t → linear_independent R (λ x, x : t → M)) :
+  linear_independent R (λ x, x : s → M) :=
+linear_independent_subtype.2 $
+  λ l hl, linear_independent_subtype.1 (H _ hl (finset.finite_to_set _)) l (subset.refl _)
+
+lemma linear_independent_Union_of_directed {η : Type*}
+  {s : η → set M} (hs : directed (⊆) s)
+  (h : ∀ i, linear_independent R (λ x, x : s i → M)) :
+  linear_independent R (λ x, x : (⋃ i, s i) → M) :=
+begin
+  by_cases hη : nonempty η,
+  { resetI,
+    refine linear_independent_of_finite (⋃ i, s i) (λ t ht ft, _),
+    rcases finite_subset_Union ft ht with ⟨I, fi, hI⟩,
+    rcases hs.finset_le fi.to_finset with ⟨i, hi⟩,
+    exact (h i).mono (subset.trans hI $ bUnion_subset $
+      λ j hj, hi j (finite.mem_to_finset.2 hj)) },
+  { refine (linear_independent_empty _ _).mono _,
+    rintro _ ⟨_, ⟨i, _⟩, _⟩, exact hη ⟨i⟩ }
+end
+
+lemma linear_independent_sUnion_of_directed {s : set (set M)}
+  (hs : directed_on (⊆) s)
+  (h : ∀ a ∈ s, linear_independent R (λ x, x : (a : set M) → M)) :
+  linear_independent R (λ x, x : (⋃₀ s) → M) :=
+by rw sUnion_eq_Union; exact
+linear_independent_Union_of_directed hs.directed_coe (by simpa using h)
+
+lemma linear_independent_bUnion_of_directed {η} {s : set η} {t : η → set M}
+  (hs : directed_on (t ⁻¹'o (⊆)) s) (h : ∀a∈s, linear_independent R (λ x, x : t a → M)) :
+  linear_independent R (λ x, x : (⋃a∈s, t a) → M) :=
+by rw bUnion_eq_Union; exact
+linear_independent_Union_of_directed (directed_comp.2 $ hs.directed_coe) (by simpa using h)
+
+end subtype
+
+end semimodule
+
+/-! ### Properties which require `ring R` -/
+
+section module
+variables {v : ι → M}
+variables [ring R] [add_comm_group M] [add_comm_group M'] [add_comm_group M'']
+variables [module R M] [module R M'] [module R M'']
+variables {a b : R} {x y : M}
+
+theorem linear_independent_iff_injective_total : linear_independent R v ↔
+  function.injective (finsupp.total ι M R v) :=
+linear_independent_iff.trans (finsupp.total ι M R v).to_add_monoid_hom.injective_iff.symm
+
+alias linear_independent_iff_injective_total ↔ linear_independent.injective_total _
+
+lemma linear_independent.injective [nontrivial R] (hv : linear_independent R v) :
+  injective v :=
+begin
+  intros i j hij,
+  let l : ι →₀ R := finsupp.single i (1 : R) - finsupp.single j 1,
+  have h_total : finsupp.total ι M R v l = 0,
+  { simp_rw [linear_map.map_sub, finsupp.total_apply],
+    simp [hij] },
+  have h_single_eq : finsupp.single i (1 : R) = finsupp.single j 1,
+  { rw linear_independent_iff at hv,
+    simp [eq_add_of_sub_eq' (hv l h_total)] },
+  simpa [finsupp.single_eq_single_iff] using h_single_eq
+end
+
+theorem linear_independent.to_subtype_range {ι} {f : ι → M} (hf : linear_independent R f) :
+  linear_independent R (coe : range f → M) :=
+begin
+  nontriviality R,
+  exact (linear_independent_subtype_range hf.injective).2 hf
+end
+
+theorem linear_independent.to_subtype_range' {ι} {f : ι → M} (hf : linear_independent R f)
+  {t} (ht : range f = t) :
+  linear_independent R (coe : t → M) :=
+ht ▸ hf.to_subtype_range
+
+theorem linear_independent.image {ι} {s : set ι} {f : ι → M}
+  (hs : linear_independent R (λ x : s, f x)) : linear_independent R (λ x : f '' s, (x : M)) :=
+(linear_independent_equiv' (equiv.set.of_eq $ by rw [range_comp, subtype.range_coe]) rfl).1
+  hs.to_subtype_range
+
+section subtype
+/-! The following lemmas use the subtype defined by a set in `M` as the index set `ι`. -/
+
 lemma linear_independent.disjoint_span_image (hv : linear_independent R v) {s t : set ι}
   (hs : disjoint s t) :
   disjoint (submodule.span R $ v '' s) (submodule.span R $ v '' t) :=
@@ -379,41 +431,6 @@ lemma linear_independent.union {s t : set M}
   (hst : disjoint (span R s) (span R t)) :
   linear_independent R (λ x, x : (s ∪ t) → M) :=
 (hs.sum_type ht $ by simpa).to_subtype_range' $ by simp
-
-lemma linear_independent_of_finite (s : set M)
-  (H : ∀ t ⊆ s, finite t → linear_independent R (λ x, x : t → M)) :
-  linear_independent R (λ x, x : s → M) :=
-linear_independent_subtype.2 $
-  λ l hl, linear_independent_subtype.1 (H _ hl (finset.finite_to_set _)) l (subset.refl _)
-
-lemma linear_independent_Union_of_directed {η : Type*}
-  {s : η → set M} (hs : directed (⊆) s)
-  (h : ∀ i, linear_independent R (λ x, x : s i → M)) :
-  linear_independent R (λ x, x : (⋃ i, s i) → M) :=
-begin
-  by_cases hη : nonempty η,
-  { resetI,
-    refine linear_independent_of_finite (⋃ i, s i) (λ t ht ft, _),
-    rcases finite_subset_Union ft ht with ⟨I, fi, hI⟩,
-    rcases hs.finset_le fi.to_finset with ⟨i, hi⟩,
-    exact (h i).mono (subset.trans hI $ bUnion_subset $
-      λ j hj, hi j (finite.mem_to_finset.2 hj)) },
-  { refine (linear_independent_empty _ _).mono _,
-    rintro _ ⟨_, ⟨i, _⟩, _⟩, exact hη ⟨i⟩ }
-end
-
-lemma linear_independent_sUnion_of_directed {s : set (set M)}
-  (hs : directed_on (⊆) s)
-  (h : ∀ a ∈ s, linear_independent R (λ x, x : (a : set M) → M)) :
-  linear_independent R (λ x, x : (⋃₀ s) → M) :=
-by rw sUnion_eq_Union; exact
-linear_independent_Union_of_directed hs.directed_coe (by simpa using h)
-
-lemma linear_independent_bUnion_of_directed {η} {s : set η} {t : η → set M}
-  (hs : directed_on (t ⁻¹'o (⊆)) s) (h : ∀a∈s, linear_independent R (λ x, x : t a → M)) :
-  linear_independent R (λ x, x : (⋃a∈s, t a) → M) :=
-by rw bUnion_eq_Union; exact
-linear_independent_Union_of_directed (directed_comp.2 $ hs.directed_coe) (by simpa using h)
 
 lemma linear_independent_Union_finite_subtype {ι : Type*} {f : ι → set M}
   (hl : ∀i, linear_independent R (λ x, x : f i → M))
@@ -715,12 +732,17 @@ lemma span_le_span_iff [nontrivial R] {s t u: set M}
 
 end module
 
+/-!
+### Properties which require `division_ring K`
+
+These can be considered generalizations of properties of of linear independence in `vector_space`s
+-/
+
 section vector_space
 
-variables [field K] [add_comm_group V] [add_comm_group V'] [vector_space K V] [vector_space K V']
+variables [division_ring K] [add_comm_group V] [add_comm_group V']
+variables [semimodule K V] [semimodule K V']
 variables {v : ι → V} {s t : set V} {x y z : V}
-
-include K
 
 open submodule
 

--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -735,7 +735,7 @@ end module
 /-!
 ### Properties which require `division_ring K`
 
-These can be considered generalizations of properties of of linear independence in `vector_space`s
+These can be considered generalizations of properties of linear independence in `vector_space`s.
 -/
 
 section vector_space


### PR DESCRIPTION
No lemma names or proofs were changed, this just reordered some lemmas so that they could be put into sections with weaker requirements.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
