### PR TITLE
[Merged by Bors] - feat(topology/category): compact hausdorff spaces are reflective in Top

### DIFF
--- a/src/topology/category/CompHaus.lean
+++ b/src/topology/category/CompHaus.lean
@@ -85,7 +85,10 @@ noncomputable def stone_cech_equivalence (X : Top) (Y : CompHaus) :
   end }
 
 noncomputable def Top_to_CompHaus : Top ⥤ CompHaus :=
-adjunction.left_adjoint_of_equiv stone_cech_equivalence (by tidy)
+adjunction.left_adjoint_of_equiv stone_cech_equivalence (λ _ _ _ _ _, rfl)
+
+lemma Top_to_CompHaus_obj (X : Top) : ↥(Top_to_CompHaus.obj X) = stone_cech X :=
+rfl
 
 noncomputable instance : reflective CompHaus_to_Top :=
 { to_is_right_adjoint := ⟨Top_to_CompHaus, adjunction.adjunction_of_equiv_left _ _⟩ }

--- a/src/topology/category/CompHaus.lean
+++ b/src/topology/category/CompHaus.lean
@@ -54,12 +54,20 @@ end CompHaus
 @[simps {rhs_md := semireducible}, derive [full, faithful]]
 def CompHaus_to_Top : CompHaus ⥤ Top := induced_functor _
 
+/--
+(Implementation) The object part of the compactification functor from topological spaces to
+compact Hausdorff spaces.
+-/
 @[simps]
 def StoneCech_obj (X : Top) : CompHaus :=
 { to_Top := { α := stone_cech X },
   is_compact := stone_cech.compact_space,
   is_hausdorff := @stone_cech.t2_space X _ }
 
+/--
+(Implementation) The bijection of homsets to establish the reflective adjunction of compact
+Hausdorff spaces in topological spaces.
+-/
 noncomputable def stone_cech_equivalence (X : Top) (Y : CompHaus) :
   (StoneCech_obj X ⟶ Y) ≃ (X ⟶ CompHaus_to_Top.obj Y) :=
 { to_fun := λ f,
@@ -84,11 +92,18 @@ noncomputable def stone_cech_equivalence (X : Top) (Y : CompHaus) :
     exact congr_fun (stone_cech_extend_extends hf) x,
   end }
 
+/--
+The Stone-Cech compactification functor from topological spaces to compact Hausdorff spaces,
+left adjoint to the inclusion functor.
+-/
 noncomputable def Top_to_CompHaus : Top ⥤ CompHaus :=
 adjunction.left_adjoint_of_equiv stone_cech_equivalence (λ _ _ _ _ _, rfl)
 
 lemma Top_to_CompHaus_obj (X : Top) : ↥(Top_to_CompHaus.obj X) = stone_cech X :=
 rfl
 
+/--
+The category of compact Hausdorff spaces is reflective in the category of topological spaces.
+-/
 noncomputable instance : reflective CompHaus_to_Top :=
 { to_is_right_adjoint := ⟨Top_to_CompHaus, adjunction.adjunction_of_equiv_left _ _⟩ }

--- a/src/topology/category/CompHaus.lean
+++ b/src/topology/category/CompHaus.lean
@@ -56,52 +56,32 @@ def CompHaus_to_Top : CompHaus ⥤ Top := induced_functor _
 
 @[simps]
 def StoneCech_obj (X : Top) : CompHaus :=
-{ to_Top := Top.of (stone_cech X),
-  is_compact := @stone_cech.compact_space X _,
+{ to_Top := { α := stone_cech X },
+  is_compact := stone_cech.compact_space,
   is_hausdorff := @stone_cech.t2_space X _ }
-
-@[simps]
-def StoneCech_unit (X : Top) :
-  X ⟶ CompHaus_to_Top.obj (StoneCech_obj X) :=
-{ to_fun := stone_cech_unit,
-  continuous_to_fun := @continuous_stone_cech_unit X _ }
-
-noncomputable def StoneCech_extend {X : Top} {Y : CompHaus} (f : X ⟶ CompHaus_to_Top.obj Y) :
-  StoneCech_obj X ⟶ Y :=
-{ to_fun := stone_cech_extend f.2,
-  continuous_to_fun := continuous_stone_cech_extend f.2 }
-
-lemma helpful_thing {α : Type*} {γ : Type*} [topological_space α]
-  [topological_space γ] [t2_space γ] [compact_space γ] (f : stone_cech α → γ) (hf : continuous f)
-  (x : _) :
-  stone_cech_extend (continuous.comp hf continuous_stone_cech_unit) x = f x :=
-begin
-  suffices : stone_cech_extend (hf.comp continuous_stone_cech_unit) = f,
-  { rw this },
-  apply continuous.ext_on dense_range_stone_cech_unit (continuous_stone_cech_extend _) hf,
-  rintro _ ⟨x, rfl⟩,
-  change (stone_cech_extend _ ∘ stone_cech_unit) x = _,
-  rw stone_cech_extend_extends,
-end
 
 noncomputable def stone_cech_equivalence (X : Top) (Y : CompHaus) :
   (StoneCech_obj X ⟶ Y) ≃ (X ⟶ CompHaus_to_Top.obj Y) :=
-{ to_fun := λ f, StoneCech_unit X ≫ CompHaus_to_Top.map f,
-  inv_fun := λ f, StoneCech_extend f,
-  left_inv := λ f,
+{ to_fun := λ f,
+  { to_fun := f ∘ stone_cech_unit,
+    continuous_to_fun := f.2.comp (@continuous_stone_cech_unit X _) },
+  inv_fun := λ f,
+  { to_fun := stone_cech_extend f.2,
+    continuous_to_fun := continuous_stone_cech_extend f.2 },
+  left_inv :=
   begin
-    ext,
-    apply helpful_thing,
-    apply f.2
+    rintro ⟨f : stone_cech X ⟶ Y, hf : continuous f⟩,
+    ext (x : stone_cech X),
+    refine congr_fun _ x,
+    apply continuous.ext_on dense_range_stone_cech_unit (continuous_stone_cech_extend _) hf,
+    rintro _ ⟨y, rfl⟩,
+    apply congr_fun (stone_cech_extend_extends (hf.comp _)) y,
   end,
   right_inv :=
   begin
-    rintro ⟨f, hf⟩,
-    dsimp at hf,
+    rintro ⟨f : ↥X ⟶ Y, hf : continuous f⟩,
     ext,
-    change _ = f x,
-    conv_rhs {rw ← stone_cech_extend_extends hf},
-    refl,
+    exact congr_fun (stone_cech_extend_extends hf) x,
   end }
 
 noncomputable def Top_to_CompHaus : Top ⥤ CompHaus :=

--- a/src/topology/category/CompHaus.lean
+++ b/src/topology/category/CompHaus.lean
@@ -1,10 +1,12 @@
 /-
 Copyright (c) 2020 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Adam Topaz
+Authors: Adam Topaz, Bhavik Mehta
 -/
 
+import category_theory.adjunction.reflective
 import topology.category.Top
+import topology.stone_cech
 
 /-!
 
@@ -46,8 +48,64 @@ instance category : category CompHaus := induced_category.category to_Top
 lemma coe_to_Top {X : CompHaus} : (X.to_Top : Type*) = X :=
 rfl
 
-end  CompHaus
+end CompHaus
 
 /-- The fully faithful embedding of `CompHaus` in `Top`. -/
-@[simps, derive [full, faithful]]
+@[simps {rhs_md := semireducible}, derive [full, faithful]]
 def CompHaus_to_Top : CompHaus ⥤ Top := induced_functor _
+
+@[simps]
+def StoneCech_obj (X : Top) : CompHaus :=
+{ to_Top := Top.of (stone_cech X),
+  is_compact := @stone_cech.compact_space X _,
+  is_hausdorff := @stone_cech.t2_space X _ }
+
+@[simps]
+def StoneCech_unit (X : Top) :
+  X ⟶ CompHaus_to_Top.obj (StoneCech_obj X) :=
+{ to_fun := stone_cech_unit,
+  continuous_to_fun := @continuous_stone_cech_unit X _ }
+
+noncomputable def StoneCech_extend {X : Top} {Y : CompHaus} (f : X ⟶ CompHaus_to_Top.obj Y) :
+  StoneCech_obj X ⟶ Y :=
+{ to_fun := stone_cech_extend f.2,
+  continuous_to_fun := continuous_stone_cech_extend f.2 }
+
+lemma helpful_thing {α : Type*} {γ : Type*} [topological_space α]
+  [topological_space γ] [t2_space γ] [compact_space γ] (f : stone_cech α → γ) (hf : continuous f)
+  (x : _) :
+  stone_cech_extend (continuous.comp hf continuous_stone_cech_unit) x = f x :=
+begin
+  suffices : stone_cech_extend (hf.comp continuous_stone_cech_unit) = f,
+  { rw this },
+  apply continuous.ext_on dense_range_stone_cech_unit (continuous_stone_cech_extend _) hf,
+  rintro _ ⟨x, rfl⟩,
+  change (stone_cech_extend _ ∘ stone_cech_unit) x = _,
+  rw stone_cech_extend_extends,
+end
+
+noncomputable def stone_cech_equivalence (X : Top) (Y : CompHaus) :
+  (StoneCech_obj X ⟶ Y) ≃ (X ⟶ CompHaus_to_Top.obj Y) :=
+{ to_fun := λ f, StoneCech_unit X ≫ CompHaus_to_Top.map f,
+  inv_fun := λ f, StoneCech_extend f,
+  left_inv := λ f,
+  begin
+    ext,
+    apply helpful_thing,
+    apply f.2
+  end,
+  right_inv :=
+  begin
+    rintro ⟨f, hf⟩,
+    dsimp at hf,
+    ext,
+    change _ = f x,
+    conv_rhs {rw ← stone_cech_extend_extends hf},
+    refl,
+  end }
+
+noncomputable def Top_to_CompHaus : Top ⥤ CompHaus :=
+adjunction.left_adjoint_of_equiv stone_cech_equivalence (by tidy)
+
+noncomputable instance : reflective CompHaus_to_Top :=
+{ to_is_right_adjoint := ⟨Top_to_CompHaus, adjunction.adjunction_of_equiv_left _ _⟩ }


### PR DESCRIPTION
Show explicitly that `CompHaus_to_Top` is a reflective functor via the Stone-Cech compactification.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
