### PR TITLE
feat(nat/digits): Natural basis representation using list sum and map

### DIFF
--- a/src/data/list/indexes.lean
+++ b/src/data/list/indexes.lean
@@ -6,6 +6,7 @@ Authors: Jannis Limperg
 
 import data.list.basic
 import data.list.defs
+import data.list.zip
 import logic.basic
 
 universes u v
@@ -16,6 +17,27 @@ namespace list
 
 variables {α : Type u} {β : Type v}
 
+section map_with_index
+
+lemma map_with_index_core_eq (l : list α) (f : ℕ → α → β) (n : ℕ) :
+  l.map_with_index_core f n = l.map_with_index (λ i a, f (i + n) a) :=
+begin
+  induction l with hd tl hl generalizing f n,
+  { simp [list.map_with_index, list.map_with_index_core] },
+  { rw [list.map_with_index],
+    simp [list.map_with_index_core, hl, add_left_comm, add_assoc, add_comm] }
+end
+
+lemma map_with_index_eq_enum_map_uncurry (l : list α) (f : ℕ → α → β) :
+  l.map_with_index f = l.enum.map (function.uncurry f) :=
+begin
+  induction l with hd tl hl generalizing f,
+  { simp [list.map_with_index, list.map_with_index_core, list.enum_eq_zip_range] },
+  { rw [list.map_with_index, list.map_with_index_core, list.map_with_index_core_eq, hl],
+    simp [list.enum_eq_zip_range, list.range_succ_eq_map, list.zip_with_map_left] }
+end
+
+end map_with_index
 
 section foldr_with_index
 

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -87,6 +87,28 @@ theorem zip_map_right (f : β → γ) (l₁ : list α) (l₂ : list β) :
    zip l₁ (l₂.map f) = (zip l₁ l₂).map (prod.map id f) :=
 by rw [← zip_map, map_id]
 
+lemma list.zip_with_map_left
+  (f : α → β → γ) (g : δ → α) (l : list δ) (l' : list β) :
+  list.zip_with f (l.map g) l' = list.zip_with (f ∘ g) l l' :=
+begin
+  induction l with hd tl hl generalizing l',
+  { simp },
+  { cases l' with hd' tl',
+    { simp },
+    { simp [hl] } }
+end
+
+lemma list.zip_with_map_right
+  (f : α → β → γ) (l : list α) (g : δ → β) (l' : list δ) :
+  list.zip_with f l (l'.map g) = list.zip_with (λ x, f x ∘ g) l l' :=
+begin
+  induction l with hd tl hl generalizing l',
+  { simp },
+  { cases l' with hd' tl',
+    { simp },
+    { simp [hl] } }
+end
+
 theorem zip_map' (f : α → β) (g : α → γ) : ∀ (l : list α),
    zip (l.map f) (l.map g) = l.map (λ a, (f a, g a))
 | []     := rfl
@@ -240,6 +262,17 @@ begin
         right,
         use [init_tl, tail],
         simp * at *, }, }, },
+end
+
+@[simp] lemma list.map_uncurry_zip_eq_zip_with
+  (f : α → β → γ) (l : list α) (l' : list β) :
+  list.map (function.uncurry f) (l.zip l') = list.zip_with f l l' :=
+begin
+  induction l with hd tl hl generalizing l',
+  { simp },
+  { cases l' with hd' tl',
+    { simp },
+    { simp [hl] } }
 end
 
 end list

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -275,4 +275,14 @@ begin
     { simp [hl] } }
 end
 
+@[simp] lemma list.sum_zip_with_distrib_left (f : α → β → ℕ) (n : ℕ) (l : list α) (l' : list β) :
+  (list.zip_with (λ x y, n * f x y) l l').sum = n * (l.zip_with f l').sum :=
+begin
+  induction l with hd tl hl generalizing f n l',
+  { simp },
+  { cases l' with hd' tl',
+    { simp, },
+    { simp [hl, mul_add] } }
+end
+
 end list

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Shing Tak Lam, Mario Carneiro
 -/
 import data.int.modeq
+import list.indexes
 import tactic.interval_cases
 import tactic.linarith
 
@@ -146,6 +147,30 @@ begin
   induction L with d L ih,
   { refl, },
   { dsimp [of_digits], rw ih, },
+end
+
+-- should I bury it in the main proof with a `have` ?
+lemma of_digits_eq_sum_map_with_index_aux (b : ℕ) (l : list ℕ) :
+  (list.zip_with ((λ (i a : ℕ), a * b ^ i) ∘ nat.succ) (list.range l.length) l).sum =
+  b * (list.zip_with (λ i a, a * b ^ i) (list.range l.length) l).sum :=
+begin
+  suffices : list.zip_with (((λ (i a : ℕ), a * b ^ i) ∘ nat.succ)) (list.range l.length) l =
+      list.zip_with (λ i a, b * (a * b ^ i)) (list.range l.length) l,
+    { simp [this] },
+  congr,
+  ext,
+  simp [pow_succ],
+  ring
+end
+
+lemma of_digits_eq_sum_map_with_index (b: ℕ) (L: list ℕ):
+  of_digits b L = list.sum (L.map_with_index (λ i a, a * b ^ i)) :=
+begin
+  rw [list.map_with_index_eq_enum_map_uncurry, list.enum_eq_zip_range,
+    list.map_uncurry_zip_eq_zip_with, nat.of_digits_eq_foldr b],
+  induction L with hd tl hl,
+    { simp },
+    { simp [list.range_succ_eq_map, list.zip_with_map_left, of_digits_eq_sum_map_with_index_aux, hl] }
 end
 
 @[simp] lemma of_digits_singleton {b n : ℕ} : of_digits b [n] = n := by simp [of_digits]


### PR DESCRIPTION
---

- [ ] depends on: #5963 [list lemmas]

I wonder if we should offer a direct lemma which provides `n` as an expression of a list sum and map?

(same things as #5963 applies)