### PR TITLE
[Merged by Bors] - chore(algebra/algebra/basic): add simp lemma about `algebra_map ℚ`

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1013,6 +1013,9 @@ namespace rat
 instance algebra_rat {α} [division_ring α] [char_zero α] : algebra ℚ α :=
 (rat.cast_hom α).to_algebra' $ λ r x, r.cast_commute x
 
+@[simp] theorem algebra_map_rat_rat : algebra_map ℚ ℚ = ring_hom.id ℚ :=
+subsingleton.elim _ _
+
 end rat
 
 namespace algebra


### PR DESCRIPTION
Since there is a subsingleton instance over ring_homs, we may as well let the simplifier replace `algebra_map` with `id`.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
