### PR TITLE
[Merged by Bors] - feat(list/{zip,indexes}): Add `zip_with` and `map_with_index` lemmas

### DIFF
--- a/src/data/list/indexes.lean
+++ b/src/data/list/indexes.lean
@@ -7,6 +7,7 @@ Authors: Jannis Limperg
 import data.list.basic
 import data.list.defs
 import data.list.zip
+import data.list.range
 import logic.basic
 
 universes u v

--- a/src/data/list/indexes.lean
+++ b/src/data/list/indexes.lean
@@ -24,19 +24,19 @@ lemma map_with_index_core_eq (l : list α) (f : ℕ → α → β) (n : ℕ) :
   l.map_with_index_core f n = l.map_with_index (λ i a, f (i + n) a) :=
 begin
   induction l with hd tl hl generalizing f n,
-  { simp [list.map_with_index, list.map_with_index_core] },
-  { rw [list.map_with_index],
-    simp [list.map_with_index_core, hl, add_left_comm, add_assoc, add_comm] }
+  { simp [map_with_index, map_with_index_core] },
+  { rw [map_with_index],
+    simp [map_with_index_core, hl, add_left_comm, add_assoc, add_comm] }
 end
 
 lemma map_with_index_eq_enum_map (l : list α) (f : ℕ → α → β) :
   l.map_with_index f = l.enum.map (function.uncurry f) :=
 begin
   induction l with hd tl hl generalizing f,
-  { simp [list.map_with_index, list.map_with_index_core, list.enum_eq_zip_range] },
-  { rw [list.map_with_index, list.map_with_index_core, list.map_with_index_core_eq, hl],
-    simp [list.enum_eq_zip_range, list.range_succ_eq_map, list.zip_with_map_left,
-    list.map_uncurry_zip_eq_zip_with] }
+  { simp [map_with_index, map_with_index_core, list.enum_eq_zip_range] },
+  { rw [map_with_index, map_with_index_core, map_with_index_core_eq, hl],
+    simp [enum_eq_zip_range, range_succ_eq_map, zip_with_map_left,
+    map_uncurry_zip_eq_zip_with] }
 end
 
 end map_with_index

--- a/src/data/list/indexes.lean
+++ b/src/data/list/indexes.lean
@@ -6,6 +6,7 @@ Authors: Jannis Limperg
 
 import data.list.basic
 import data.list.defs
+import data.list.zip
 import logic.basic
 
 universes u v
@@ -16,6 +17,27 @@ namespace list
 
 variables {α : Type u} {β : Type v}
 
+section map_with_index
+
+lemma map_with_index_core_eq (l : list α) (f : ℕ → α → β) (n : ℕ) :
+  l.map_with_index_core f n = l.map_with_index (λ i a, f (i + n) a) :=
+begin
+  induction l with hd tl hl generalizing f n,
+  { simp [list.map_with_index, list.map_with_index_core] },
+  { rw [list.map_with_index],
+    simp [list.map_with_index_core, hl, add_left_comm, add_assoc, add_comm] }
+end
+
+lemma map_with_index_eq_enum_map_uncurry (l : list α) (f : ℕ → α → β) :
+  l.map_with_index f = l.enum.map (function.uncurry f) :=
+begin
+  induction l with hd tl hl generalizing f,
+  { simp [list.map_with_index, list.map_with_index_core, list.enum_eq_zip_range] },
+  { rw [list.map_with_index, list.map_with_index_core, list.map_with_index_core_eq, hl],
+    simp [list.enum_eq_zip_range, list.range_succ_eq_map, list.zip_with_map_left] }
+end
+
+end map_with_index
 
 section foldr_with_index
 

--- a/src/data/list/indexes.lean
+++ b/src/data/list/indexes.lean
@@ -29,7 +29,7 @@ begin
     simp [list.map_with_index_core, hl, add_left_comm, add_assoc, add_comm] }
 end
 
-lemma map_with_index_eq_enum_map_uncurry (l : list α) (f : ℕ → α → β) :
+lemma map_with_index_eq_enum_map (l : list α) (f : ℕ → α → β) :
   l.map_with_index f = l.enum.map (function.uncurry f) :=
 begin
   induction l with hd tl hl generalizing f,

--- a/src/data/list/indexes.lean
+++ b/src/data/list/indexes.lean
@@ -35,7 +35,8 @@ begin
   induction l with hd tl hl generalizing f,
   { simp [list.map_with_index, list.map_with_index_core, list.enum_eq_zip_range] },
   { rw [list.map_with_index, list.map_with_index_core, list.map_with_index_core_eq, hl],
-    simp [list.enum_eq_zip_range, list.range_succ_eq_map, list.zip_with_map_left] }
+    simp [list.enum_eq_zip_range, list.range_succ_eq_map, list.zip_with_map_left,
+    list.map_uncurry_zip_eq_zip_with] }
 end
 
 end map_with_index

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -89,8 +89,8 @@ by rw [← zip_map, map_id]
 
 @[simp] lemma zip_with_map {μ}
   (f : γ → δ → μ) (g : α → γ) (h : β → δ) (as : list α) (bs : list β) :
-  list.zip_with f (as.map g) (bs.map h) =
-  list.zip_with (λ a b, f (g a) (h b)) as bs :=
+  zip_with f (as.map g) (bs.map h) =
+  zip_with (λ a b, f (g a) (h b)) as bs :=
 begin
   induction as generalizing bs,
   { simp },

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -93,8 +93,8 @@ lemma zip_with_map {μ}
   :=
 begin
   induction as with hd tl hl generalizing bs,
-  { simp [list.map] },
-  { cases bs with hd' tl',
+  { simp },
+  { cases bs,
     { simp },
     { simp [hl] } }
 end

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -87,9 +87,9 @@ theorem zip_map_right (f : β → γ) (l₁ : list α) (l₂ : list β) :
    zip l₁ (l₂.map f) = (zip l₁ l₂).map (prod.map id f) :=
 by rw [← zip_map, map_id]
 
-lemma list.zip_with_map_left
+lemma zip_with_map_left
   (f : α → β → γ) (g : δ → α) (l : list δ) (l' : list β) :
-  list.zip_with f (l.map g) l' = list.zip_with (f ∘ g) l l' :=
+  zip_with f (l.map g) l' = zip_with (f ∘ g) l l' :=
 begin
   induction l with hd tl hl generalizing l',
   { simp },
@@ -98,9 +98,9 @@ begin
     { simp [hl] } }
 end
 
-lemma list.zip_with_map_right
+lemma zip_with_map_right
   (f : α → β → γ) (l : list α) (g : δ → β) (l' : list δ) :
-  list.zip_with f l (l'.map g) = list.zip_with (λ x, f x ∘ g) l l' :=
+  zip_with f l (l'.map g) = zip_with (λ x, f x ∘ g) l l' :=
 begin
   induction l with hd tl hl generalizing l',
   { simp },
@@ -264,9 +264,9 @@ begin
         simp * at *, }, }, },
 end
 
-@[simp] lemma list.map_uncurry_zip_eq_zip_with
+@[simp] lemma map_uncurry_zip_eq_zip_with
   (f : α → β → γ) (l : list α) (l' : list β) :
-  list.map (function.uncurry f) (l.zip l') = list.zip_with f l l' :=
+  map (function.uncurry f) (l.zip l') = zip_with f l l' :=
 begin
   induction l with hd tl hl generalizing l',
   { simp },
@@ -275,8 +275,8 @@ begin
     { simp [hl] } }
 end
 
-@[simp] lemma list.sum_zip_with_distrib_left (f : α → β → ℕ) (n : ℕ) (l : list α) (l' : list β) :
-  (list.zip_with (λ x y, n * f x y) l l').sum = n * (l.zip_with f l').sum :=
+@[simp] lemma sum_zip_with_distrib_left (f : α → β → ℕ) (n : ℕ) (l : list α) (l' : list β) :
+  (zip_with (λ x y, n * f x y) l l').sum = n * (l.zip_with f l').sum :=
 begin
   induction l with hd tl hl generalizing f n l',
   { simp },

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -87,6 +87,28 @@ theorem zip_map_right (f : β → γ) (l₁ : list α) (l₂ : list β) :
    zip l₁ (l₂.map f) = (zip l₁ l₂).map (prod.map id f) :=
 by rw [← zip_map, map_id]
 
+lemma list.zip_with_map_left
+  (f : α → β → γ) (g : δ → α) (l : list δ) (l' : list β) :
+  list.zip_with f (l.map g) l' = list.zip_with (f ∘ g) l l' :=
+begin
+  induction l with hd tl hl generalizing l',
+  { simp },
+  { cases l' with hd' tl',
+    { simp },
+    { simp [hl] } }
+end
+
+lemma list.zip_with_map_right
+  (f : α → β → γ) (l : list α) (g : δ → β) (l' : list δ) :
+  list.zip_with f l (l'.map g) = list.zip_with (λ x, f x ∘ g) l l' :=
+begin
+  induction l with hd tl hl generalizing l',
+  { simp },
+  { cases l' with hd' tl',
+    { simp },
+    { simp [hl] } }
+end
+
 theorem zip_map' (f : α → β) (g : α → γ) : ∀ (l : list α),
    zip (l.map f) (l.map g) = l.map (λ a, (f a, g a))
 | []     := rfl
@@ -240,6 +262,17 @@ begin
         right,
         use [init_tl, tail],
         simp * at *, }, }, },
+end
+
+@[simp] lemma list.map_uncurry_zip_eq_zip_with
+  (f : α → β → γ) (l : list α) (l' : list β) :
+  list.map (function.uncurry f) (l.zip l') = list.zip_with f l l' :=
+begin
+  induction l with hd tl hl generalizing l',
+  { simp },
+  { cases l' with hd' tl',
+    { simp },
+    { simp [hl] } }
 end
 
 end list

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -87,27 +87,27 @@ theorem zip_map_right (f : β → γ) (l₁ : list α) (l₂ : list β) :
    zip l₁ (l₂.map f) = (zip l₁ l₂).map (prod.map id f) :=
 by rw [← zip_map, map_id]
 
-lemma zip_with_map_left
-  (f : α → β → γ) (g : δ → α) (l : list δ) (l' : list β) :
-  zip_with f (l.map g) l' = zip_with (f ∘ g) l l' :=
+lemma zip_with_map {μ}
+  (f: γ → δ → μ) (g: α → γ) (h: β → δ) (as: list α) (bs: list β):
+  list.zip_with f (as.map g) (bs.map h) = list.zip_with (λ a b, f (g a) (h b)) as bs
+  :=
 begin
-  induction l with hd tl hl generalizing l',
-  { simp },
-  { cases l' with hd' tl',
+  induction as with hd tl hl generalizing bs,
+  { simp [list.map] },
+  { cases bs with hd' tl',
     { simp },
     { simp [hl] } }
 end
 
+lemma zip_with_map_left
+  (f : α → β → γ) (g : δ → α) (l : list δ) (l' : list β) :
+  zip_with f (l.map g) l' = zip_with (f ∘ g) l l' :=
+by { convert (zip_with_map f g id l l'), exact eq.symm (list.map_id _) }
+
 lemma zip_with_map_right
   (f : α → β → γ) (l : list α) (g : δ → β) (l' : list δ) :
   zip_with f l (l'.map g) = zip_with (λ x, f x ∘ g) l l' :=
-begin
-  induction l with hd tl hl generalizing l',
-  { simp },
-  { cases l' with hd' tl',
-    { simp },
-    { simp [hl] } }
-end
+by { convert (list.zip_with_map f id g l l'), exact eq.symm (list.map_id _) }
 
 theorem zip_map' (f : α → β) (g : α → γ) : ∀ (l : list α),
    zip (l.map f) (l.map g) = l.map (λ a, (f a, g a))
@@ -264,7 +264,7 @@ begin
         simp * at *, }, }, },
 end
 
-@[simp] lemma map_uncurry_zip_eq_zip_with
+lemma map_uncurry_zip_eq_zip_with
   (f : α → β → γ) (l : list α) (l' : list β) :
   map (function.uncurry f) (l.zip l') = zip_with f l l' :=
 begin
@@ -273,28 +273,6 @@ begin
   { cases l' with hd' tl',
     { simp },
     { simp [hl] } }
-end
-
-@[simp] lemma sum_zip_with_distrib_left [semiring γ]
-  (f : α → β → γ) (n : γ) (l : list α) (l' : list β) :
-  (zip_with (λ x y, n * f x y) l l').sum = n * (l.zip_with f l').sum :=
-begin
-  induction l with hd tl hl generalizing f n l',
-  { simp },
-  { cases l' with hd' tl',
-    { simp, },
-    { simp [hl, mul_add] } }
-end
-
-@[simp] lemma sum_zip_with_distrib_right [semiring γ]
-  (f : α → β → γ) (n : γ) (l : list α) (l' : list β) :
-  (zip_with (λ x y, f x y * n) l l').sum = (l.zip_with f l').sum * n :=
-begin
-  induction l with hd tl hl generalizing f n l',
-  { simp },
-  { cases l' with hd' tl',
-    { simp, },
-    { simp [hl, add_mul] } }
 end
 
 end list

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -275,4 +275,14 @@ begin
     { simp [hl] } }
 end
 
+@[simp] lemma list.sum_zip_with_distrib_left (f : α → β → ℕ) (n : ℕ) (l : list α) (l' : list β) :
+  (list.zip_with (λ x y, n * f x y) l l').sum = n * (l.zip_with f l').sum :=
+begin
+  induction l with hd tl hl generalizing f n l',
+  { simp },
+  { cases l' with hd' tl',
+    { simp, },
+    { simp [hl, mul_add] } }
+end
+
 end list

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -88,15 +88,13 @@ theorem zip_map_right (f : β → γ) (l₁ : list α) (l₂ : list β) :
 by rw [← zip_map, map_id]
 
 @[simp] lemma zip_with_map {μ}
-  (f: γ → δ → μ) (g: α → γ) (h: β → δ) (as: list α) (bs: list β):
-  list.zip_with f (as.map g) (bs.map h) = list.zip_with (λ a b, f (g a) (h b)) as bs
-  :=
+  (f : γ → δ → μ) (g : α → γ) (h : β → δ) (as : list α) (bs : list β) :
+  list.zip_with f (as.map g) (bs.map h) =
+  list.zip_with (λ a b, f (g a) (h b)) as bs :=
 begin
-  induction as with hd tl hl generalizing bs,
+  induction as generalizing bs,
   { simp },
-  { cases bs,
-    { simp },
-    { simp [hl] } }
+  { cases bs; simp * }
 end
 
 lemma zip_with_map_left

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -275,7 +275,7 @@ begin
     { simp [hl] } }
 end
 
-@[simp] lemma sum_zip_with_distrib_left (f : α → β → ℕ) (n : ℕ) (l : list α) (l' : list β) :
+@[simp] lemma sum_zip_with_distrib_left [semiring γ] (f : α → β → γ) (n : γ) (l : list α) (l' : list β) :
   (zip_with (λ x y, n * f x y) l l').sum = n * (l.zip_with f l').sum :=
 begin
   induction l with hd tl hl generalizing f n l',
@@ -283,6 +283,16 @@ begin
   { cases l' with hd' tl',
     { simp, },
     { simp [hl, mul_add] } }
+end
+
+@[simp] lemma sum_zip_with_distrib_right [semiring γ] (f : α → β → γ) (n : γ) (l : list α) (l' : list β) :
+  (zip_with (λ x y, f x y * n) l l').sum = (l.zip_with f l').sum * n :=
+begin
+  induction l with hd tl hl generalizing f n l',
+  { simp },
+  { cases l' with hd' tl',
+    { simp, },
+    { simp [hl, add_mul] } }
 end
 
 end list

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -87,7 +87,7 @@ theorem zip_map_right (f : β → γ) (l₁ : list α) (l₂ : list β) :
    zip l₁ (l₂.map f) = (zip l₁ l₂).map (prod.map id f) :=
 by rw [← zip_map, map_id]
 
-lemma zip_with_map {μ}
+@[simp] lemma zip_with_map {μ}
   (f: γ → δ → μ) (g: α → γ) (h: β → δ) (as: list α) (bs: list β):
   list.zip_with f (as.map g) (bs.map h) = list.zip_with (λ a b, f (g a) (h b)) as bs
   :=

--- a/src/data/list/zip.lean
+++ b/src/data/list/zip.lean
@@ -275,7 +275,8 @@ begin
     { simp [hl] } }
 end
 
-@[simp] lemma sum_zip_with_distrib_left [semiring γ] (f : α → β → γ) (n : γ) (l : list α) (l' : list β) :
+@[simp] lemma sum_zip_with_distrib_left [semiring γ]
+  (f : α → β → γ) (n : γ) (l : list α) (l' : list β) :
   (zip_with (λ x y, n * f x y) l l').sum = n * (l.zip_with f l').sum :=
 begin
   induction l with hd tl hl generalizing f n l',
@@ -285,7 +286,8 @@ begin
     { simp [hl, mul_add] } }
 end
 
-@[simp] lemma sum_zip_with_distrib_right [semiring γ] (f : α → β → γ) (n : γ) (l : list α) (l' : list β) :
+@[simp] lemma sum_zip_with_distrib_right [semiring γ]
+  (f : α → β → γ) (n : γ) (l : list α) (l' : list β) :
   (zip_with (λ x y, f x y * n) l l').sum = (l.zip_with f l').sum * n :=
 begin
   induction l with hd tl hl generalizing f n l',


### PR DESCRIPTION
All proofs are due to @pechersky.

Co-authored-by: Yakov Pechersky <ffxen158@gmail.com>

---
I separated the statement about base representation which I will add in another PR which depend on this one, namely #5975.

