### PR TITLE
[Merged by Bors] - feat(algebra/polynomial/big_operators): add degree_prod lemma

### DIFF
--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -150,9 +150,11 @@ the sum of the degrees, where the degree of the zero polynomial is ⊥.
 lemma degree_prod [nontrivial R] : (∏ i in s, f i).degree = ∑ i in s, (f i).degree :=
 begin
   classical,
-  induction s using finset.induction with a s ha hs, { simp },
-  rw [prod_insert ha, sum_insert ha],
-  rw polynomial.degree_mul, rw hs,
+  induction s using finset.induction with a s ha hs,
+  { simp },
+  { rw [prod_insert ha, sum_insert ha],
+    rw degree_mul,
+    rw hs },
 end
 
 /--

--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -155,4 +155,21 @@ lemma leading_coeff_prod :
 by { rw ← leading_coeff_hom_apply, apply monoid_hom.map_prod }
 
 end no_zero_divisors
+
+section nontrivial_no_zero_divisors
+variables [comm_semiring R] [nontrivial R] [no_zero_divisors R] (f : ι → polynomial R)
+
+/--
+The degree of a product of polynomials is equal to
+the sum of the degrees, where the degree of the zero polynomial is ⊥.
+-/
+lemma degree_prod : (∏ i in s, f i).degree = ∑ i in s, (f i).degree :=
+begin
+  classical,
+  induction s using finset.induction with a s ha hs, { simp },
+  rw [prod_insert ha, sum_insert ha],
+  rw polynomial.degree_mul, rw hs,
+end
+
+end nontrivial_no_zero_divisors
 end polynomial

--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -144,6 +144,18 @@ begin
 end
 
 /--
+The degree of a product of polynomials is equal to
+the sum of the degrees, where the degree of the zero polynomial is ⊥.
+-/
+lemma degree_prod [nontrivial R] : (∏ i in s, f i).degree = ∑ i in s, (f i).degree :=
+begin
+  classical,
+  induction s using finset.induction with a s ha hs, { simp },
+  rw [prod_insert ha, sum_insert ha],
+  rw polynomial.degree_mul, rw hs,
+end
+
+/--
 The leading coefficient of a product of polynomials is equal to
 the product of the leading coefficients.
 
@@ -155,21 +167,4 @@ lemma leading_coeff_prod :
 by { rw ← leading_coeff_hom_apply, apply monoid_hom.map_prod }
 
 end no_zero_divisors
-
-section nontrivial_no_zero_divisors
-variables [comm_semiring R] [nontrivial R] [no_zero_divisors R] (f : ι → polynomial R)
-
-/--
-The degree of a product of polynomials is equal to
-the sum of the degrees, where the degree of the zero polynomial is ⊥.
--/
-lemma degree_prod : (∏ i in s, f i).degree = ∑ i in s, (f i).degree :=
-begin
-  classical,
-  induction s using finset.induction with a s ha hs, { simp },
-  rw [prod_insert ha, sum_insert ha],
-  rw polynomial.degree_mul, rw hs,
-end
-
-end nontrivial_no_zero_divisors
 end polynomial

--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -152,9 +152,7 @@ begin
   classical,
   induction s using finset.induction with a s ha hs,
   { simp },
-  { rw [prod_insert ha, sum_insert ha],
-    rw degree_mul,
-    rw hs },
+  { rw [prod_insert ha, sum_insert ha, degree_mul, hs] },
 end
 
 /--


### PR DESCRIPTION
This PR adds a degree_prod lemma next to the nat_degree_prod lemma. This version of the lemma works for the interpretation of 'degree' which says the degree of the zero polynomial is \bot

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Trying again, because I screwed it up the first time

