### PR TITLE
[Merged by Bors] - chore(algebra/algebra/basic): show that the ℚ-algebra structure is unique

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1016,6 +1016,10 @@ instance algebra_rat {α} [division_ring α] [char_zero α] : algebra ℚ α :=
 @[simp] theorem algebra_map_rat_rat : algebra_map ℚ ℚ = ring_hom.id ℚ :=
 subsingleton.elim _ _
 
+instance algebra_rat_subsingleton {α} [division_ring α] [char_zero α] :
+  subsingleton (algebra ℚ α) :=
+⟨λ x y, algebra.algebra_ext x y $ ring_hom.congr_fun $ subsingleton.elim _ _⟩
+
 end rat
 
 namespace algebra

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1016,7 +1016,7 @@ instance algebra_rat {α} [division_ring α] [char_zero α] : algebra ℚ α :=
 @[simp] theorem algebra_map_rat_rat : algebra_map ℚ ℚ = ring_hom.id ℚ :=
 subsingleton.elim _ _
 
-instance algebra_rat_subsingleton {α} [division_ring α] [char_zero α] :
+instance algebra_rat_subsingleton {α} [semiring α] :
   subsingleton (algebra ℚ α) :=
 ⟨λ x y, algebra.algebra_ext x y $ ring_hom.congr_fun $ subsingleton.elim _ _⟩
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1016,7 +1016,8 @@ instance algebra_rat {α} [division_ring α] [char_zero α] : algebra ℚ α :=
 @[simp] theorem algebra_map_rat_rat : algebra_map ℚ ℚ = ring_hom.id ℚ :=
 subsingleton.elim _ _
 
-instance algebra_rat_subsingleton {α} [semiring α] :
+-- TODO[gh-6025]: make this an instance once safe to do so
+lemma algebra_rat_subsingleton {α} [semiring α] :
   subsingleton (algebra ℚ α) :=
 ⟨λ x y, algebra.algebra_ext x y $ ring_hom.congr_fun $ subsingleton.elim _ _⟩
 


### PR DESCRIPTION
Note that we already have similar lemmas showing that ℕ and ℤ modules are unique.

The name is based on `rat.algebra_rat`, which provides a canonical instance.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
