### PR TITLE
[Merged by Bors] - refactor(data/polynomial/eval): change eval_smul lemmas to use * instead of 2nd smul

### DIFF
--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -81,11 +81,12 @@ by rw [bit0, eval₂_add, bit0]
 by rw [bit1, eval₂_add, eval₂_bit0, eval₂_one, bit1]
 
 @[simp] lemma eval₂_smul (g : R →+* S) (p : polynomial R) (x : S) {s : R} :
-  eval₂ g x (s • p) = g s • eval₂ g x p :=
+  eval₂ g x (s • p) = g s * eval₂ g x p :=
 begin
   simp only [eval₂, sum_smul_index, forall_const, zero_mul, g.map_zero, g.map_mul, mul_assoc],
+  rw [←finsupp.mul_sum],
   -- Why doesn't `rw [←finsupp.mul_sum]` work?
-  convert (@finsupp.mul_sum _ _ _ _ _ (g s) p (λ i a, (g a * x ^ i))).symm,
+  -- convert (@finsupp.mul_sum _ _ _ _ _ (g s) p (λ i a, (g a * x ^ i))).symm,
 end
 
 @[simp] lemma eval₂_C_X : eval₂ C X p = p :=
@@ -239,7 +240,7 @@ eval₂_monomial _ _
 @[simp] lemma eval_bit1 : (bit1 p).eval x = bit1 (p.eval x) := eval₂_bit1 _ _
 
 @[simp] lemma eval_smul (p : polynomial R) (x : R) {s : R} :
-  (s • p).eval x = s • p.eval x :=
+  (s • p).eval x = s * p.eval x :=
 eval₂_smul (ring_hom.id _) _ _
 
 lemma eval_sum (p : polynomial R) (f : ℕ → R → polynomial R) (x : R) :

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -85,8 +85,6 @@ by rw [bit1, eval₂_add, eval₂_bit0, eval₂_one, bit1]
 begin
   simp only [eval₂, sum_smul_index, forall_const, zero_mul, g.map_zero, g.map_mul, mul_assoc],
   rw [←finsupp.mul_sum],
-  -- Why doesn't `rw [←finsupp.mul_sum]` work?
-  -- convert (@finsupp.mul_sum _ _ _ _ _ (g s) p (λ i a, (g a * x ^ i))).symm,
 end
 
 @[simp] lemma eval₂_C_X : eval₂ C X p = p :=

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1090,7 +1090,7 @@ variables {R' : Type*} [comm_ring R']
 lemma integer_normalization_eval₂_eq_zero (g : f.codomain →+* R') (p : polynomial f.codomain)
   {x : R'} (hx : eval₂ g x p = 0) : eval₂ (g.comp f.to_map) x (f.integer_normalization p) = 0 :=
 let ⟨b, hb⟩ := integer_normalization_map_to_map p in
-trans (eval₂_map f.to_map g x).symm (by rw [hb, eval₂_smul, hx, smul_zero])
+trans (eval₂_map f.to_map g x).symm (by rw [hb, eval₂_smul, hx, mul_zero])
 
 lemma integer_normalization_aeval_eq_zero [algebra R R'] [algebra f.codomain R']
   [is_scalar_tower R f.codomain R'] (p : polynomial f.codomain)


### PR DESCRIPTION

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.235991.20polynomial.2Eeval2_smul)