### PR TITLE
[Merged by Bors] - chore(group_theory/coset): rename lemmas to follow naming conventions

### DIFF
--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -130,17 +130,17 @@ lemma right_coset_mem_right_coset {a : α} (ha : a ∈ s) : (s : set α) *r a = 
 set.ext $ assume b, by simp [mem_right_coset_iff, mul_mem_cancel_right s (s.inv_mem ha)]
 
 @[to_additive normal_of_eq_add_cosets]
-theorem normal_of_eq_cosets (N : s.normal) (g : α) : g *l s = s *r g :=
+theorem eq_cosets_of_normal (N : s.normal) (g : α) : g *l s = s *r g :=
 set.ext $ assume a, by simp [mem_left_coset_iff, mem_right_coset_iff]; rw [N.mem_comm_iff]
 
 @[to_additive eq_add_cosets_of_normal]
-theorem eq_cosets_of_normal (h : ∀ g : α, g *l s = s *r g) : s.normal :=
+theorem normal_of_eq_cosets (h : ∀ g : α, g *l s = s *r g) : s.normal :=
 ⟨assume a ha g, show g * a * g⁻¹ ∈ (s : set α),
   by rw [← mem_right_coset_iff, ← h]; exact mem_left_coset g ha⟩
 
 @[to_additive normal_iff_eq_add_cosets]
 theorem normal_iff_eq_cosets : s.normal ↔ ∀ g : α, g *l s = s *r g :=
-⟨@normal_of_eq_cosets _ _ s, eq_cosets_of_normal s⟩
+⟨@eq_cosets_of_normal _ _ s, normal_of_eq_cosets s⟩
 
 end coset_subgroup
 

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -129,11 +129,11 @@ set.ext $ by simp [mem_left_coset_iff, mul_mem_cancel_left s (s.inv_mem ha)]
 lemma right_coset_mem_right_coset {a : α} (ha : a ∈ s) : (s : set α) *r a = s :=
 set.ext $ assume b, by simp [mem_right_coset_iff, mul_mem_cancel_right s (s.inv_mem ha)]
 
-@[to_additive normal_of_eq_add_cosets]
+@[to_additive eq_add_cosets_of_normal]
 theorem eq_cosets_of_normal (N : s.normal) (g : α) : g *l s = s *r g :=
 set.ext $ assume a, by simp [mem_left_coset_iff, mem_right_coset_iff]; rw [N.mem_comm_iff]
 
-@[to_additive eq_add_cosets_of_normal]
+@[to_additive normal_of_eq_add_cosets]
 theorem normal_of_eq_cosets (h : ∀ g : α, g *l s = s *r g) : s.normal :=
 ⟨assume a ha g, show g * a * g⁻¹ ∈ (s : set α),
   by rw [← mem_right_coset_iff, ← h]; exact mem_left_coset g ha⟩


### PR DESCRIPTION
Rename `normal_of_eq_cosets` and `eq_cosets_of_normal` to follow naming conventions. Conclusion should be stated before the `of`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
