### PR TITLE
[Merged by Bors] - feat(combinatorics/simple_graph/basic): add decidable instance for adjacency of complement

### DIFF
--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -442,6 +442,9 @@ instance has_compl : has_compl (simple_graph V) :=
 @[simp]
 lemma compl_adj (G : simple_graph V) (v w : V) : Gᶜ.adj v w ↔ v ≠ w ∧ ¬G.adj v w := iff.rfl
 
+instance compl_adj_decidable (V : Type u) [decidable_eq V] (G : simple_graph V)
+[decidable_rel G.adj] : decidable_rel Gᶜ.adj := λ v w, and.decidable
+
 @[simp]
 lemma compl_compl (G : simple_graph V) : Gᶜᶜ = G :=
 begin

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -443,7 +443,7 @@ instance has_compl : has_compl (simple_graph V) :=
 lemma compl_adj (G : simple_graph V) (v w : V) : Gᶜ.adj v w ↔ v ≠ w ∧ ¬G.adj v w := iff.rfl
 
 instance compl_adj_decidable (V : Type u) [decidable_eq V] (G : simple_graph V)
-[decidable_rel G.adj] : decidable_rel Gᶜ.adj := λ v w, and.decidable
+  [decidable_rel G.adj] : decidable_rel Gᶜ.adj := λ v w, and.decidable
 
 @[simp]
 lemma compl_compl (G : simple_graph V) : Gᶜᶜ = G :=


### PR DESCRIPTION
Add instance that states that, if the adjacency relation for a simple graph is decidable, the adjacency relation for its complement is also decidable. 

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
