### PR TITLE
[Merged by Bors] - refactor(measure_theory/*): rename `is_(null_)?measurable` to `(null_)?measurable_set`

### DIFF
--- a/src/analysis/calculus/fderiv_measurable.lean
+++ b/src/analysis/calculus/fderiv_measurable.lean
@@ -13,7 +13,7 @@ import measure_theory.borel_space
 In this file we prove that the derivative of any function with complete codomain is a measurable
 function. Namely, we prove:
 
-* `measurable_set_set_of_differentiable_at`: the set `{x | differentiable_at 𝕜 f x}` is measurable;
+* `measurable_set_of_differentiable_at`: the set `{x | differentiable_at 𝕜 f x}` is measurable;
 * `measurable_fderiv`: the function `fderiv 𝕜 f` is measurable;
 * `measurable_fderiv_apply_const`: for a fixed vector `y`, the function `λ x, fderiv 𝕜 f x y`
   is measurable;
@@ -392,7 +392,7 @@ variables (𝕜 f)
 
 /-- The set of differentiability points of a function, with derivative in a given complete set,
 is Borel-measurable. -/
-theorem measurable_set_set_of_differentiable_at_of_is_complete
+theorem measurable_set_of_differentiable_at_of_is_complete
   {K : set (E →L[𝕜] F)} (hK : is_complete K) :
   measurable_set {x | differentiable_at 𝕜 f x ∧ fderiv 𝕜 f x ∈ K} :=
 by simp [differentiable_set_eq_D K hK, D, is_open_B.measurable_set, measurable_set.Inter_Prop,
@@ -402,11 +402,11 @@ variable [complete_space F]
 
 /-- The set of differentiability points of a function taking values in a complete space is
 Borel-measurable. -/
-theorem measurable_set_set_of_differentiable_at :
+theorem measurable_set_of_differentiable_at :
   measurable_set {x | differentiable_at 𝕜 f x} :=
 begin
   have : is_complete (univ : set (E →L[𝕜] F)) := complete_univ,
-  convert measurable_set_set_of_differentiable_at_of_is_complete 𝕜 f this,
+  convert measurable_set_of_differentiable_at_of_is_complete 𝕜 f this,
   simp
 end
 
@@ -417,8 +417,8 @@ begin
     {x | (0 : E →L[𝕜] F) ∈ s} ∩ {x | ¬differentiable_at 𝕜 f x} :=
     set.ext (λ x, mem_preimage.trans fderiv_mem_iff),
   rw this,
-  exact (measurable_set_set_of_differentiable_at_of_is_complete _ _ hs.is_complete).union
-    ((measurable_set.const _).inter (measurable_set_set_of_differentiable_at _ _).compl)
+  exact (measurable_set_of_differentiable_at_of_is_complete _ _ hs.is_complete).union
+    ((measurable_set.const _).inter (measurable_set_of_differentiable_at _ _).compl)
 end
 
 lemma measurable_fderiv_apply_const [measurable_space F] [borel_space F] (y : E) :

--- a/src/analysis/calculus/fderiv_measurable.lean
+++ b/src/analysis/calculus/fderiv_measurable.lean
@@ -13,7 +13,7 @@ import measure_theory.borel_space
 In this file we prove that the derivative of any function with complete codomain is a measurable
 function. Namely, we prove:
 
-* `is_measurable_set_of_differentiable_at`: the set `{x | differentiable_at 𝕜 f x}` is measurable;
+* `measurable_set_set_of_differentiable_at`: the set `{x | differentiable_at 𝕜 f x}` is measurable;
 * `measurable_fderiv`: the function `fderiv 𝕜 f` is measurable;
 * `measurable_fderiv_apply_const`: for a fixed vector `y`, the function `λ x, fderiv 𝕜 f x y`
   is measurable;
@@ -392,21 +392,21 @@ variables (𝕜 f)
 
 /-- The set of differentiability points of a function, with derivative in a given complete set,
 is Borel-measurable. -/
-theorem is_measurable_set_of_differentiable_at_of_is_complete
+theorem measurable_set_set_of_differentiable_at_of_is_complete
   {K : set (E →L[𝕜] F)} (hK : is_complete K) :
-  is_measurable {x | differentiable_at 𝕜 f x ∧ fderiv 𝕜 f x ∈ K} :=
-by simp [differentiable_set_eq_D K hK, D, is_open_B.is_measurable, is_measurable.Inter_Prop,
-         is_measurable.Inter, is_measurable.Union]
+  measurable_set {x | differentiable_at 𝕜 f x ∧ fderiv 𝕜 f x ∈ K} :=
+by simp [differentiable_set_eq_D K hK, D, is_open_B.measurable_set, measurable_set.Inter_Prop,
+         measurable_set.Inter, measurable_set.Union]
 
 variable [complete_space F]
 
 /-- The set of differentiability points of a function taking values in a complete space is
 Borel-measurable. -/
-theorem is_measurable_set_of_differentiable_at :
-  is_measurable {x | differentiable_at 𝕜 f x} :=
+theorem measurable_set_set_of_differentiable_at :
+  measurable_set {x | differentiable_at 𝕜 f x} :=
 begin
   have : is_complete (univ : set (E →L[𝕜] F)) := complete_univ,
-  convert is_measurable_set_of_differentiable_at_of_is_complete 𝕜 f this,
+  convert measurable_set_set_of_differentiable_at_of_is_complete 𝕜 f this,
   simp
 end
 
@@ -417,8 +417,8 @@ begin
     {x | (0 : E →L[𝕜] F) ∈ s} ∩ {x | ¬differentiable_at 𝕜 f x} :=
     set.ext (λ x, mem_preimage.trans fderiv_mem_iff),
   rw this,
-  exact (is_measurable_set_of_differentiable_at_of_is_complete _ _ hs.is_complete).union
-    ((is_measurable.const _).inter (is_measurable_set_of_differentiable_at _ _).compl)
+  exact (measurable_set_set_of_differentiable_at_of_is_complete _ _ hs.is_complete).union
+    ((measurable_set.const _).inter (measurable_set_set_of_differentiable_at _ _).compl)
 end
 
 lemma measurable_fderiv_apply_const [measurable_space F] [borel_space F] (y : E) :

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -603,8 +603,8 @@ section measurability_real
 
 lemma real.measurable_rpow : measurable (λ p : ℝ × ℝ, p.1 ^ p.2) :=
 begin
-  have h_meas : is_measurable {p : ℝ × ℝ | p.1 = 0} :=
-    (is_closed_singleton.preimage continuous_fst).is_measurable,
+  have h_meas : measurable_set {p : ℝ × ℝ | p.1 = 0} :=
+    (is_closed_singleton.preimage continuous_fst).measurable_set,
   refine measurable_of_measurable_union_cover {p : ℝ × ℝ | p.1 = 0} {p : ℝ × ℝ | p.1 ≠ 0} h_meas
     h_meas.compl _ _ _,
   { intro x, simp [em (x.fst = 0)], },
@@ -621,7 +621,7 @@ begin
     change measurable ((λ x : ℝ, ite (x = 0) (1:ℝ) (0:ℝ))
       ∘ (λ a : {p : ℝ × ℝ | p.fst = 0}, (a:ℝ×ℝ).snd)),
     refine measurable.comp _ (measurable_snd.comp measurable_subtype_coe),
-    exact measurable.ite (is_measurable_singleton 0) measurable_const measurable_const, },
+    exact measurable.ite (measurable_set_singleton 0) measurable_const measurable_const, },
   { refine continuous.measurable _,
     rw continuous_iff_continuous_at,
     intro x,
@@ -1558,11 +1558,11 @@ begin
   refine ennreal.measurable_of_measurable_nnreal_prod _ _,
   { simp_rw ennreal.coe_rpow_def,
     refine measurable.ite _ measurable_const nnreal.measurable_rpow.ennreal_coe,
-    exact is_measurable.inter (measurable_fst (is_measurable_singleton 0))
-      (measurable_snd is_measurable_Iio), },
+    exact measurable_set.inter (measurable_fst (measurable_set_singleton 0))
+      (measurable_snd measurable_set_Iio), },
   { simp_rw ennreal.top_rpow_def,
-    refine measurable.ite is_measurable_Ioi measurable_const _,
-    exact measurable.ite (is_measurable_singleton 0) measurable_const measurable_const, },
+    refine measurable.ite measurable_set_Ioi measurable_const _,
+    exact measurable.ite (measurable_set_singleton 0) measurable_const measurable_const, },
 end
 
 lemma measurable.ennreal_rpow {α} [measurable_space α] {f : α → ennreal} (hf : measurable f)

--- a/src/measure_theory/ae_measurable_sequence.lean
+++ b/src/measure_theory/ae_measurable_sequence.lean
@@ -89,15 +89,15 @@ end
 
 end mem_ae_seq_set
 
-lemma ae_seq_set_is_measurable {hf : ∀ i, ae_measurable (f i) μ} :
-  is_measurable (ae_seq_set hf p) :=
-(is_measurable_to_measurable _ _).compl
+lemma ae_seq_set_measurable_set {hf : ∀ i, ae_measurable (f i) μ} :
+  measurable_set (ae_seq_set hf p) :=
+(measurable_set_to_measurable _ _).compl
 
 lemma measurable (hf : ∀ i, ae_measurable (f i) μ) (p : α → (ι → β) → Prop)
   (i : ι) :
   measurable (ae_seq hf p i) :=
 begin
-  refine measurable.ite ae_seq_set_is_measurable (hf i).measurable_mk _,
+  refine measurable.ite ae_seq_set_measurable_set (hf i).measurable_mk _,
   by_cases hα : nonempty α,
   { exact @measurable_const _ _ _ _ (⟨f i hα.some⟩ : nonempty β).some },
   { exact measurable_of_not_nonempty hα _ }

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -235,7 +235,7 @@ begin
   refine finset.sum_image' _ (assume b hb, _),
   rcases mem_range.1 hb with ⟨a, rfl⟩,
   rw [map_preimage_singleton, ← sum_measure_preimage_singleton _
-    (λ _ _, f.is_measurable_preimage _)],
+    (λ _ _, f.measurable_set_preimage _)],
   -- Now we use `hf : integrable f μ` to show that `ennreal.to_real` is additive.
   by_cases ha : g (f a) = 0,
   { simp only [ha, smul_zero],
@@ -1509,7 +1509,7 @@ begin
     ((integrable_map_measure hfm.ae_measurable hφ).1 hfi),
   ext1 i,
   simp only [simple_func.approx_on_comp, simple_func.integral, measure.map_apply, hφ,
-    simple_func.is_measurable_preimage, ← preimage_comp, simple_func.coe_comp],
+    simple_func.measurable_set_preimage, ← preimage_comp, simple_func.coe_comp],
   refine (finset.sum_subset (simple_func.range_comp_subset_range _ hφ) (λ y _ hy, _)).symm,
   rw [simple_func.mem_range, ← set.preimage_singleton_eq_empty, simple_func.coe_comp] at hy,
   simp [hy]

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -25,7 +25,7 @@ import topology.G_delta
 
 ## Main statements
 
-* `is_open.is_measurable`, `is_closed.is_measurable`: open and closed sets are measurable;
+* `is_open.measurable_set`, `is_closed.measurable_set`: open and closed sets are measurable;
 * `continuous.measurable` : a continuous function is measurable;
 * `continuous.measurable2` : if `f : α → β` and `g : α → γ` are measurable and `op : β × γ → δ`
   is continuous, then `λ x, op (f x, g y)` is measurable;
@@ -57,9 +57,9 @@ lemma borel_eq_top_of_encodable [topological_space α] [t1_space α] [encodable 
   borel α = ⊤ :=
 begin
   refine (top_le_iff.1 $ λ s hs, bUnion_of_singleton s ▸ _),
-  apply is_measurable.bUnion s.countable_encodable,
+  apply measurable_set.bUnion s.countable_encodable,
   intros x hx,
-  apply is_measurable.of_compl,
+  apply measurable_set.of_compl,
   apply generate_measurable.basic,
   exact is_closed_singleton
 end
@@ -75,13 +75,13 @@ le_antisymm
       case generate_open.basic : u hu
       { exact generate_measurable.basic u hu },
       case generate_open.univ
-      { exact @is_measurable.univ α (generate_from s) },
+      { exact @measurable_set.univ α (generate_from s) },
       case generate_open.inter : s₁ s₂ _ _ hs₁ hs₂
-      { exact @is_measurable.inter α (generate_from s) _ _ hs₁ hs₂ },
+      { exact @measurable_set.inter α (generate_from s) _ _ hs₁ hs₂ },
       case generate_open.sUnion : f hf ih {
         rcases is_open_sUnion_countable f (by rwa hs) with ⟨v, hv, vf, vu⟩,
         rw ← vu,
-        exact @is_measurable.sUnion α (generate_from s) _ hv
+        exact @measurable_set.sUnion α (generate_from s) _ hv
           (λ x xv, ih _ (vf xv)) }
     end)
   (generate_from_le $ assume u hu, generate_measurable.basic _ $
@@ -100,7 +100,7 @@ begin
   refine le_antisymm _ (generate_from_le _),
   { rw borel_eq_generate_from_of_subbasis (@order_topology.topology_eq_generate_intervals α _ _ _),
     letI : measurable_space α := measurable_space.generate_from (range Iio),
-    have H : ∀ a : α, is_measurable (Iio a) := λ a, generate_measurable.basic _ ⟨_, rfl⟩,
+    have H : ∀ a : α, measurable_set (Iio a) := λ a, generate_measurable.basic _ ⟨_, rfl⟩,
     refine generate_from_le _, rintro _ ⟨a, rfl | rfl⟩; [skip, apply H],
     by_cases h : ∃ a', ∀ b, a < b ↔ a' ≤ b,
     { rcases h with ⟨a', ha'⟩,
@@ -119,7 +119,7 @@ begin
         exact ⟨x, λ b, ⟨λ ab, le_of_not_lt (λ h', h ⟨b, ab, h'⟩),
           lt_of_lt_of_le ax⟩⟩ },
       rw this, resetI,
-      apply is_measurable.Union,
+      apply measurable_set.Union,
       exact λ _, (H _).compl } },
   { rw forall_range_iff,
     intro a,
@@ -174,43 +174,43 @@ variables [topological_space α] [measurable_space α] [opens_measurable_space �
    [topological_space γ₂] [measurable_space γ₂] [borel_space γ₂]
    [measurable_space δ]
 
-lemma is_open.is_measurable (h : is_open s) : is_measurable s :=
+lemma is_open.measurable_set (h : is_open s) : measurable_set s :=
 opens_measurable_space.borel_le _ $ generate_measurable.basic _ h
 
-lemma is_measurable_interior : is_measurable (interior s) := is_open_interior.is_measurable
+lemma measurable_set_interior : measurable_set (interior s) := is_open_interior.measurable_set
 
-lemma is_Gδ.is_measurable (h : is_Gδ s) : is_measurable s :=
+lemma is_Gδ.measurable_set (h : is_Gδ s) : measurable_set s :=
 begin
   rcases h with ⟨S, hSo, hSc, rfl⟩,
-  exact is_measurable.sInter hSc (λ t ht, (hSo t ht).is_measurable)
+  exact measurable_set.sInter hSc (λ t ht, (hSo t ht).measurable_set)
 end
 
-lemma is_measurable_set_of_continuous_at {β} [emetric_space β] (f : α → β) :
-  is_measurable {x | continuous_at f x} :=
-(is_Gδ_set_of_continuous_at f).is_measurable
+lemma measurable_set_set_of_continuous_at {β} [emetric_space β] (f : α → β) :
+  measurable_set {x | continuous_at f x} :=
+(is_Gδ_set_of_continuous_at f).measurable_set
 
-lemma is_closed.is_measurable (h : is_closed s) : is_measurable s :=
-h.is_measurable.of_compl
+lemma is_closed.measurable_set (h : is_closed s) : measurable_set s :=
+h.measurable_set.of_compl
 
-lemma is_compact.is_measurable [t2_space α] (h : is_compact s) : is_measurable s :=
-h.is_closed.is_measurable
+lemma is_compact.measurable_set [t2_space α] (h : is_compact s) : measurable_set s :=
+h.is_closed.measurable_set
 
-lemma is_measurable_closure : is_measurable (closure s) :=
-is_closed_closure.is_measurable
+lemma measurable_set_closure : measurable_set (closure s) :=
+is_closed_closure.measurable_set
 
-lemma measurable_of_is_open {f : δ → γ} (hf : ∀ s, is_open s → is_measurable (f ⁻¹' s)) :
+lemma measurable_of_is_open {f : δ → γ} (hf : ∀ s, is_open s → measurable_set (f ⁻¹' s)) :
   measurable f :=
 by { rw [‹borel_space γ›.measurable_eq], exact measurable_generate_from hf }
 
-lemma measurable_of_is_closed {f : δ → γ} (hf : ∀ s, is_closed s → is_measurable (f ⁻¹' s)) :
+lemma measurable_of_is_closed {f : δ → γ} (hf : ∀ s, is_closed s → measurable_set (f ⁻¹' s)) :
   measurable f :=
 begin
   apply measurable_of_is_open, intros s hs,
-  rw [← is_measurable.compl_iff, ← preimage_compl], apply hf, rw [is_closed_compl_iff], exact hs
+  rw [← measurable_set.compl_iff, ← preimage_compl], apply hf, rw [is_closed_compl_iff], exact hs
 end
 
 lemma measurable_of_is_closed' {f : δ → γ}
-  (hf : ∀ s, is_closed s → s.nonempty → s ≠ univ → is_measurable (f ⁻¹' s)) : measurable f :=
+  (hf : ∀ s, is_closed s → s.nonempty → s ≠ univ → measurable_set (f ⁻¹' s)) : measurable f :=
 begin
   apply measurable_of_is_closed, intros s hs,
   cases eq_empty_or_nonempty s with h1 h1, { simp [h1] },
@@ -222,20 +222,21 @@ instance nhds_is_measurably_generated (a : α) : (𝓝 a).is_measurably_generate
 begin
   rw [nhds, infi_subtype'],
   refine @filter.infi_is_measurably_generated _ _ _ _ (λ i, _),
-  exact i.2.2.is_measurable.principal_is_measurably_generated
+  exact i.2.2.measurable_set.principal_is_measurably_generated
 end
 
 /-- If `s` is a measurable set, then `𝓝[s] a` is a measurably generated filter for
-each `a`. This cannot be an `instance` because it depends on a non-instance `hs : is_measurable s`.
+each `a`. This cannot be an `instance` because it depends on a non-instance `hs : measurable_set s`.
 -/
-lemma is_measurable.nhds_within_is_measurably_generated {s : set α} (hs : is_measurable s) (a : α) :
+lemma measurable_set.nhds_within_is_measurably_generated {s : set α} (hs : measurable_set s)
+  (a : α) :
   (𝓝[s] a).is_measurably_generated :=
 by haveI := hs.principal_is_measurably_generated; exact filter.inf_is_measurably_generated _ _
 
 @[priority 100] -- see Note [lower instance priority]
 instance opens_measurable_space.to_measurable_singleton_class [t1_space α] :
   measurable_singleton_class α :=
-⟨λ x, is_closed_singleton.is_measurable⟩
+⟨λ x, is_closed_singleton.measurable_set⟩
 
 instance pi.opens_measurable_space {ι : Type*} {π : ι → Type*} [fintype ι]
   [t' : Π i, topological_space (π i)]
@@ -251,7 +252,7 @@ begin
   rw [borel_eq_generate_from_of_subbasis this],
   apply generate_from_le,
   rintros _ ⟨s, i, hi, rfl⟩,
-  refine is_measurable.pi i.countable_to_set (λ a ha, is_open.is_measurable _),
+  refine measurable_set.pi i.countable_to_set (λ a ha, is_open.measurable_set _),
   rw [hinst],
   exact generate_open.basic _ (hi a ha)
 end
@@ -269,7 +270,7 @@ begin
   rintros _ ⟨u, hu, v, hv, rfl⟩,
   have hu : is_open u, by { rw [ha₅], exact generate_open.basic _ hu },
   have hv : is_open v, by { rw [hb₅], exact generate_open.basic _ hv },
-  exact hu.is_measurable.prod hv.is_measurable
+  exact hu.measurable_set.prod hv.measurable_set
 end
 
 section
@@ -281,25 +282,25 @@ end
 section preorder
 variables [preorder α] [order_closed_topology α] {a b : α}
 
-@[simp] lemma is_measurable_Ici : is_measurable (Ici a) := is_closed_Ici.is_measurable
-@[simp] lemma is_measurable_Iic : is_measurable (Iic a) := is_closed_Iic.is_measurable
-@[simp] lemma is_measurable_Icc : is_measurable (Icc a b) := is_closed_Icc.is_measurable
+@[simp] lemma measurable_set_Ici : measurable_set (Ici a) := is_closed_Ici.measurable_set
+@[simp] lemma measurable_set_Iic : measurable_set (Iic a) := is_closed_Iic.measurable_set
+@[simp] lemma measurable_set_Icc : measurable_set (Icc a b) := is_closed_Icc.measurable_set
 
 instance nhds_within_Ici_is_measurably_generated :
   (𝓝[Ici b] a).is_measurably_generated :=
-is_measurable_Ici.nhds_within_is_measurably_generated _
+measurable_set_Ici.nhds_within_is_measurably_generated _
 
 instance nhds_within_Iic_is_measurably_generated :
   (𝓝[Iic b] a).is_measurably_generated :=
-is_measurable_Iic.nhds_within_is_measurably_generated _
+measurable_set_Iic.nhds_within_is_measurably_generated _
 
 instance at_top_is_measurably_generated : (filter.at_top : filter α).is_measurably_generated :=
 @filter.infi_is_measurably_generated _ _ _ _ $
-  λ a, (is_measurable_Ici : is_measurable (Ici a)).principal_is_measurably_generated
+  λ a, (measurable_set_Ici : measurable_set (Ici a)).principal_is_measurably_generated
 
 instance at_bot_is_measurably_generated : (filter.at_bot : filter α).is_measurably_generated :=
 @filter.infi_is_measurably_generated _ _ _ _ $
-  λ a, (is_measurable_Iic : is_measurable (Iic a)).principal_is_measurably_generated
+  λ a, (measurable_set_Iic : measurable_set (Iic a)).principal_is_measurably_generated
 
 end preorder
 
@@ -307,44 +308,44 @@ section partial_order
 variables [partial_order α] [order_closed_topology α] [second_countable_topology α]
   {a b : α}
 
-lemma is_measurable_le' : is_measurable {p : α × α | p.1 ≤ p.2} :=
-order_closed_topology.is_closed_le'.is_measurable
+lemma measurable_set_le' : measurable_set {p : α × α | p.1 ≤ p.2} :=
+order_closed_topology.is_closed_le'.measurable_set
 
-lemma is_measurable_le {f g : δ → α} (hf : measurable f) (hg : measurable g) :
-  is_measurable {a | f a ≤ g a} :=
-hf.prod_mk hg is_measurable_le'
+lemma measurable_set_le {f g : δ → α} (hf : measurable f) (hg : measurable g) :
+  measurable_set {a | f a ≤ g a} :=
+hf.prod_mk hg measurable_set_le'
 
 end partial_order
 
 section linear_order
 variables [linear_order α] [order_closed_topology α] {a b : α}
 
-@[simp] lemma is_measurable_Iio : is_measurable (Iio a) := is_open_Iio.is_measurable
-@[simp] lemma is_measurable_Ioi : is_measurable (Ioi a) := is_open_Ioi.is_measurable
-@[simp] lemma is_measurable_Ioo : is_measurable (Ioo a b) := is_open_Ioo.is_measurable
+@[simp] lemma measurable_set_Iio : measurable_set (Iio a) := is_open_Iio.measurable_set
+@[simp] lemma measurable_set_Ioi : measurable_set (Ioi a) := is_open_Ioi.measurable_set
+@[simp] lemma measurable_set_Ioo : measurable_set (Ioo a b) := is_open_Ioo.measurable_set
 
-@[simp] lemma is_measurable_Ioc : is_measurable (Ioc a b) :=
-is_measurable_Ioi.inter is_measurable_Iic
+@[simp] lemma measurable_set_Ioc : measurable_set (Ioc a b) :=
+measurable_set_Ioi.inter measurable_set_Iic
 
-@[simp] lemma is_measurable_Ico : is_measurable (Ico a b) :=
-is_measurable_Ici.inter is_measurable_Iio
+@[simp] lemma measurable_set_Ico : measurable_set (Ico a b) :=
+measurable_set_Ici.inter measurable_set_Iio
 
 instance nhds_within_Ioi_is_measurably_generated :
   (𝓝[Ioi b] a).is_measurably_generated :=
-is_measurable_Ioi.nhds_within_is_measurably_generated _
+measurable_set_Ioi.nhds_within_is_measurably_generated _
 
 instance nhds_within_Iio_is_measurably_generated :
   (𝓝[Iio b] a).is_measurably_generated :=
-is_measurable_Iio.nhds_within_is_measurably_generated _
+measurable_set_Iio.nhds_within_is_measurably_generated _
 
 variables [second_countable_topology α]
 
-lemma is_measurable_lt' : is_measurable {p : α × α | p.1 < p.2} :=
-(is_open_lt continuous_fst continuous_snd).is_measurable
+lemma measurable_set_lt' : measurable_set {p : α × α | p.1 < p.2} :=
+(is_open_lt continuous_fst continuous_snd).measurable_set
 
-lemma is_measurable_lt {f g : δ → α} (hf : measurable f) (hg : measurable g) :
-  is_measurable {a | f a < g a} :=
-hf.prod_mk hg is_measurable_lt'
+lemma measurable_set_lt {f g : δ → α} (hf : measurable f) (hg : measurable g) :
+  measurable_set {a | f a < g a} :=
+hf.prod_mk hg measurable_set_lt'
 
 end linear_order
 
@@ -352,14 +353,14 @@ section linear_order
 
 variables [linear_order α] [order_closed_topology α]
 
-lemma is_measurable_interval {a b : α} : is_measurable (interval a b) :=
-is_measurable_Icc
+lemma measurable_set_interval {a b : α} : measurable_set (interval a b) :=
+measurable_set_Icc
 
 variables [second_countable_topology α]
 
 lemma measurable.max {f g : δ → α} (hf : measurable f) (hg : measurable g) :
   measurable (λ a, max (f a) (g a)) :=
-hf.piecewise (is_measurable_le hg hf) hg
+hf.piecewise (measurable_set_le hg hf) hg
 
 lemma ae_measurable.max {f g : δ → α} {μ : measure δ}
   (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ a, max (f a) (g a)) μ :=
@@ -368,7 +369,7 @@ lemma ae_measurable.max {f g : δ → α} {μ : measure δ}
 
 lemma measurable.min {f g : δ → α} (hf : measurable f) (hg : measurable g) :
   measurable (λ a, min (f a) (g a)) :=
-hf.piecewise (is_measurable_le hf hg) hg
+hf.piecewise (measurable_set_le hf hg) hg
 
 lemma ae_measurable.min {f g : δ → α} {μ : measure δ}
   (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ a, min (f a) (g a)) μ :=
@@ -602,10 +603,10 @@ begin
   refine measurable_of_is_closed (λ s hs, _),
   by_cases h : classical.choice n ∈ s,
   { rw preimage_inv_fun_of_mem hg.to_embedding.inj h,
-    exact (hg.closed_iff_image_closed.mp hs).is_measurable.union
-      hg.closed_range.is_measurable.compl },
+    exact (hg.closed_iff_image_closed.mp hs).measurable_set.union
+      hg.closed_range.measurable_set.compl },
   { rw preimage_inv_fun_of_not_mem hg.to_embedding.inj h,
-    exact (hg.closed_iff_image_closed.mp hs).is_measurable }
+    exact (hg.closed_iff_image_closed.mp hs).measurable_set }
 end
 
 lemma measurable_comp_iff_of_closed_embedding {f : δ → β} (g : β → γ) (hg : closed_embedding g) :
@@ -613,7 +614,7 @@ lemma measurable_comp_iff_of_closed_embedding {f : δ → β} (g : β → γ) (h
 begin
   refine ⟨λ hf, _, λ hf, hg.continuous.measurable.comp hf⟩,
   apply measurable_of_is_closed, intros s hs,
-  convert hf (hg.is_closed_map s hs).is_measurable,
+  convert hf (hg.is_closed_map s hs).measurable_set,
   rw [@preimage_comp _ _ _ f g, preimage_image_eq _ hg.to_embedding.inj]
 end
 
@@ -635,31 +636,31 @@ section linear_order
 
 variables [linear_order α] [order_topology α] [second_countable_topology α]
 
-lemma measurable_of_Iio {f : δ → α} (hf : ∀ x, is_measurable (f ⁻¹' Iio x)) : measurable f :=
+lemma measurable_of_Iio {f : δ → α} (hf : ∀ x, measurable_set (f ⁻¹' Iio x)) : measurable f :=
 begin
   convert measurable_generate_from _,
   exact borel_space.measurable_eq.trans (borel_eq_generate_Iio _),
   rintro _ ⟨x, rfl⟩, exact hf x
 end
 
-lemma measurable_of_Ioi {f : δ → α} (hf : ∀ x, is_measurable (f ⁻¹' Ioi x)) : measurable f :=
+lemma measurable_of_Ioi {f : δ → α} (hf : ∀ x, measurable_set (f ⁻¹' Ioi x)) : measurable f :=
 begin
   convert measurable_generate_from _,
   exact borel_space.measurable_eq.trans (borel_eq_generate_Ioi _),
   rintro _ ⟨x, rfl⟩, exact hf x
 end
 
-lemma measurable_of_Iic {f : δ → α} (hf : ∀ x, is_measurable (f ⁻¹' Iic x)) : measurable f :=
+lemma measurable_of_Iic {f : δ → α} (hf : ∀ x, measurable_set (f ⁻¹' Iic x)) : measurable f :=
 begin
   apply measurable_of_Ioi,
-  simp_rw [← compl_Iic, preimage_compl, is_measurable.compl_iff],
+  simp_rw [← compl_Iic, preimage_compl, measurable_set.compl_iff],
   assumption
 end
 
-lemma measurable_of_Ici {f : δ → α} (hf : ∀ x, is_measurable (f ⁻¹' Ici x)) : measurable f :=
+lemma measurable_of_Ici {f : δ → α} (hf : ∀ x, measurable_set (f ⁻¹' Ici x)) : measurable f :=
 begin
   apply measurable_of_Iio,
-  simp_rw [← compl_Ici, preimage_compl, is_measurable.compl_iff],
+  simp_rw [← compl_Ici, preimage_compl, measurable_set.compl_iff],
   assumption
 end
 
@@ -672,7 +673,7 @@ begin
   apply measurable_generate_from,
   rintro _ ⟨a, rfl⟩,
   simp_rw [set.preimage, mem_Ioi, lt_is_lub_iff (hg _), exists_range_iff, set_of_exists],
-  exact is_measurable.Union (λ i, hf i (is_open_lt' _).is_measurable)
+  exact measurable_set.Union (λ i, hf i (is_open_lt' _).measurable_set)
 end
 
 private lemma ae_measurable.is_lub_of_nonempty {ι} (hι : nonempty ι)
@@ -729,7 +730,7 @@ begin
   apply measurable_generate_from,
   rintro _ ⟨a, rfl⟩,
   simp_rw [set.preimage, mem_Iio, is_glb_lt_iff (hg _), exists_range_iff, set_of_exists],
-  exact is_measurable.Union (λ i, hf i (is_open_gt' _).is_measurable)
+  exact measurable_set.Union (λ i, hf i (is_open_gt' _).measurable_set)
 end
 
 private lemma ae_measurable.is_glb_of_nonempty {ι} (hι : nonempty ι)
@@ -890,7 +891,7 @@ begin
   { simp [h2s, measurable_const] },
   { apply measurable_of_Iic, intro y,
     simp_rw [preimage, mem_Iic, cSup_le_iff (bdd _) (h2s.image _), ball_image_iff, set_of_forall],
-    exact is_measurable.bInter hs (λ i hi, is_measurable_le (hf i) measurable_const) }
+    exact measurable_set.bInter hs (λ i hi, measurable_set_le (hf i) measurable_const) }
 end
 
 end conditionally_complete_linear_order
@@ -929,11 +930,11 @@ variables [measurable_space β] {x : α} {ε : ℝ}
 
 open metric
 
-lemma is_measurable_ball : is_measurable (metric.ball x ε) :=
-metric.is_open_ball.is_measurable
+lemma measurable_set_ball : measurable_set (metric.ball x ε) :=
+metric.is_open_ball.measurable_set
 
-lemma is_measurable_closed_ball : is_measurable (metric.closed_ball x ε) :=
-metric.is_closed_ball.is_measurable
+lemma measurable_set_closed_ball : measurable_set (metric.closed_ball x ε) :=
+metric.is_closed_ball.measurable_set
 
 lemma measurable_inf_dist {s : set α} : measurable (λ x, inf_dist x s) :=
 (continuous_inf_dist_pt s).measurable
@@ -973,8 +974,8 @@ variables [measurable_space β] {x : α} {ε : ennreal}
 
 open emetric
 
-lemma is_measurable_eball : is_measurable (emetric.ball x ε) :=
-emetric.is_open_ball.is_measurable
+lemma measurable_set_eball : measurable_set (emetric.ball x ε) :=
+emetric.is_open_ball.measurable_set
 
 lemma measurable_edist_right : measurable (edist x) :=
 (continuous_const.edist continuous_id).measurable
@@ -1044,16 +1045,16 @@ begin
     simp only [mem_Union], rintro ⟨a, b, h, H⟩,
     rw [mem_singleton_iff.1 H],
     rw (set.ext (λ x, _) : Ioo (a : ℝ) b = (⋃c>a, (Iio c)ᶜ) ∩ Iio b),
-    { have hg : ∀ q : ℚ, g.is_measurable' (Iio q) :=
+    { have hg : ∀ q : ℚ, g.measurable_set' (Iio q) :=
         λ q, generate_measurable.basic (Iio q) (by { simp, exact ⟨_, rfl⟩ }),
-      refine @is_measurable.inter _ g _ _ _ (hg _),
-      refine @is_measurable.bUnion _ _ g _ _ (countable_encodable _) (λ c h, _),
-      exact @is_measurable.compl _ _ g (hg _) },
+      refine @measurable_set.inter _ g _ _ _ (hg _),
+      refine @measurable_set.bUnion _ _ g _ _ (countable_encodable _) (λ c h, _),
+      exact @measurable_set.compl _ _ g (hg _) },
     { suffices : x < ↑b → (↑a < x ↔ ∃ (i : ℚ), a < i ∧ ↑i ≤ x), by simpa,
       refine λ _, ⟨λ h, _, λ ⟨i, hai, hix⟩, (rat.cast_lt.2 hai).trans_le hix⟩,
       rcases exists_rat_btwn h with ⟨c, ac, cx⟩,
       exact ⟨c, rat.cast_lt.1 ac, cx.le⟩ } },
-  { simp, rintro r rfl, exact is_open_Iio.is_measurable }
+  { simp, rintro r rfl, exact is_open_Iio.measurable_set }
 end
 
 end real
@@ -1140,9 +1141,9 @@ begin
   apply measurable_of_measurable_nnreal_nnreal,
   { simp only [← ennreal.coe_mul, measurable_mul.ennreal_coe] },
   { simp only [ennreal.top_mul, ennreal.coe_eq_zero],
-    exact measurable_const.piecewise (is_measurable_singleton _) measurable_const },
+    exact measurable_const.piecewise (measurable_set_singleton _) measurable_const },
   { simp only [ennreal.mul_top, ennreal.coe_eq_zero],
-    exact measurable_const.piecewise (is_measurable_singleton _) measurable_const }
+    exact measurable_const.piecewise (measurable_set_singleton _) measurable_const }
 end
 
 lemma measurable_sub : measurable (λ p : ennreal × ennreal, p.1 - p.2) :=
@@ -1275,7 +1276,7 @@ begin
     exact ((continuous_inf_nndist_pt s).tendsto (g x)).comp (lim x) },
   have h4s : g ⁻¹' s = (λ x, inf_nndist (g x) s) ⁻¹' {0},
   { ext x, simp [h1s, ← mem_iff_inf_dist_zero_of_closed h1s h2s, ← nnreal.coe_eq_zero] },
-  rw [h4s], exact this (is_measurable_singleton 0),
+  rw [h4s], exact this (measurable_set_singleton 0),
 end
 
 /-- A sequential limit of measurable functions valued in a metric space is measurable. -/
@@ -1386,7 +1387,7 @@ variables [topological_space α] {μ : measure α}
   - it is inner regular: `μ(U) = sup { μ(K) | K ⊆ U compact }` for `U` open. -/
 structure regular (μ : measure α) : Prop :=
 (lt_top_of_is_compact : ∀ {{K : set α}}, is_compact K → μ K < ⊤)
-(outer_regular : ∀ {{A : set α}}, is_measurable A →
+(outer_regular : ∀ {{A : set α}}, measurable_set A →
   (⨅ (U : set α) (h : is_open U) (h2 : A ⊆ U), μ U) ≤ μ A)
 (inner_regular : ∀ {{U : set α}}, is_open U →
   μ U ≤ ⨆ (K : set α) (h : is_compact K) (h2 : K ⊆ U), μ K)
@@ -1394,7 +1395,7 @@ structure regular (μ : measure α) : Prop :=
 namespace regular
 
 lemma outer_regular_eq (hμ : μ.regular) {{A : set α}}
-  (hA : is_measurable A) : (⨅ (U : set α) (h : is_open U) (h2 : A ⊆ U), μ U) = μ A :=
+  (hA : measurable_set A) : (⨅ (U : set α) (h : is_open U) (h2 : A ⊆ U), μ U) = μ A :=
 le_antisymm (hμ.outer_regular hA) $ le_infi $ λ s, le_infi $ λ hs, le_infi $ λ h2s, μ.mono h2s
 
 lemma inner_regular_eq (hμ : μ.regular) {{U : set α}}
@@ -1413,19 +1414,19 @@ begin
   have h2f := f.to_equiv.injective.preimage_surjective,
   have h3f := f.to_equiv.surjective,
   split,
-  { intros K hK, rw [map_apply hf hK.is_measurable],
+  { intros K hK, rw [map_apply hf hK.measurable_set],
     apply hμ.lt_top_of_is_compact, rwa f.compact_preimage },
   { intros A hA, rw [map_apply hf hA, ← hμ.outer_regular_eq (hf hA)],
     refine le_of_eq _, apply infi_congr (preimage f) h2f,
     intro U, apply infi_congr_Prop f.is_open_preimage, intro hU,
     apply infi_congr_Prop h3f.preimage_subset_preimage_iff, intro h2U,
-    rw [map_apply hf hU.is_measurable], },
+    rw [map_apply hf hU.measurable_set], },
   { intros U hU,
-    rw [map_apply hf hU.is_measurable, ← hμ.inner_regular_eq (hU.preimage f.continuous)],
+    rw [map_apply hf hU.measurable_set, ← hμ.inner_regular_eq (hU.preimage f.continuous)],
     refine ge_of_eq _, apply supr_congr (preimage f) h2f,
     intro K, apply supr_congr_Prop f.compact_preimage, intro hK,
     apply supr_congr_Prop h3f.preimage_subset_preimage_iff, intro h2U,
-    rw [map_apply hf hK.is_measurable] }
+    rw [map_apply hf hK.measurable_set] }
 end
 
 protected lemma smul (hμ : μ.regular) {x : ennreal} (hx : x < ⊤) :
@@ -1447,7 +1448,7 @@ end
 protected lemma sigma_finite [opens_measurable_space α] [t2_space α] [sigma_compact_space α]
   (hμ : regular μ) : sigma_finite μ :=
 ⟨{ set := compact_covering α,
-  set_mem := λ n, (is_compact_compact_covering α n).is_measurable,
+  set_mem := λ n, (is_compact_compact_covering α n).measurable_set,
   finite := λ n, hμ.lt_top_of_is_compact $ is_compact_compact_covering α n,
   spanning := Union_compact_covering α }⟩
 

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -185,7 +185,7 @@ begin
   exact measurable_set.sInter hSc (λ t ht, (hSo t ht).measurable_set)
 end
 
-lemma measurable_set_set_of_continuous_at {β} [emetric_space β] (f : α → β) :
+lemma measurable_set_of_continuous_at {β} [emetric_space β] (f : α → β) :
   measurable_set {x | continuous_at f x} :=
 (is_Gδ_set_of_continuous_at f).measurable_set
 

--- a/src/measure_theory/content.lean
+++ b/src/measure_theory/content.lean
@@ -238,7 +238,7 @@ lemma is_mul_left_invariant_of_content [group G] [topological_group G]
 by convert of_content_preimage h2 (homeomorph.mul_left g) (λ K, h g) A
 
 lemma of_content_caratheodory (A : set G) :
-  (of_content μ h1).caratheodory.is_measurable' A ↔ ∀ (U : opens G),
+  (of_content μ h1).caratheodory.measurable_set' A ↔ ∀ (U : opens G),
   of_content μ h1 (U ∩ A) + of_content μ h1 (U \ A) ≤ of_content μ h1 U :=
 begin
   dsimp [opens], rw subtype.forall,

--- a/src/measure_theory/decomposition.lean
+++ b/src/measure_theory/decomposition.lean
@@ -24,12 +24,12 @@ private lemma aux {m : ℕ} {γ d : ℝ} (h : γ - (1 / 2) ^ m < d) :
 by linarith
 
 lemma hahn_decomposition (hμ : μ univ < ⊤) (hν : ν univ < ⊤) :
-  ∃s, is_measurable s ∧
-    (∀t, is_measurable t → t ⊆ s → ν t ≤ μ t) ∧
-    (∀t, is_measurable t → t ⊆ sᶜ → μ t ≤ ν t) :=
+  ∃s, measurable_set s ∧
+    (∀t, measurable_set t → t ⊆ s → ν t ≤ μ t) ∧
+    (∀t, measurable_set t → t ⊆ sᶜ → μ t ≤ ν t) :=
 begin
   let d : set α → ℝ := λs, ((μ s).to_nnreal : ℝ) - (ν s).to_nnreal,
-  let c : set ℝ := d '' {s | is_measurable s },
+  let c : set ℝ := d '' {s | measurable_set s },
   let γ : ℝ := Sup c,
 
   have hμ : ∀s, μ s < ⊤ := assume s, lt_of_le_of_lt (measure_mono $ subset_univ _) hμ,
@@ -41,7 +41,7 @@ begin
 
   have d_empty : d ∅ = 0, { simp [d], rw [measure_empty, measure_empty], simp },
 
-  have d_split : ∀s t, is_measurable s → is_measurable t →
+  have d_split : ∀s t, measurable_set s → measurable_set t →
     d s = d (s \ t) + d (s ∩ t),
   { assume s t hs ht,
     simp only [d],
@@ -51,7 +51,7 @@ begin
     simp only [sub_eq_add_neg, neg_add],
     ac_refl },
 
-  have d_Union : ∀(s : ℕ → set α), (∀n, is_measurable (s n)) → monotone s →
+  have d_Union : ∀(s : ℕ → set α), (∀n, measurable_set (s n)) → monotone s →
     tendsto (λn, d (s n)) at_top (𝓝 (d (⋃n, s n))),
   { assume s hs hm,
     refine tendsto.sub _ _;
@@ -60,7 +60,7 @@ begin
     exact hμ _,
     exact hν _ },
 
-  have d_Inter : ∀(s : ℕ → set α), (∀n, is_measurable (s n)) → (∀n m, n ≤ m → s m ⊆ s n) →
+  have d_Inter : ∀(s : ℕ → set α), (∀n, measurable_set (s n)) → (∀n m, n ≤ m → s m ⊆ s n) →
     tendsto (λn, d (s n)) at_top (𝓝 (d (⋂n, s n))),
   { assume s hs hm,
     refine tendsto.sub _ _;
@@ -78,26 +78,26 @@ begin
     rw [nnreal.coe_le_coe, ← ennreal.coe_le_coe, to_nnreal_μ, to_nnreal_μ],
     exact measure_mono (subset_univ _) },
 
-  have c_nonempty : c.nonempty := nonempty.image _ ⟨_, is_measurable.empty⟩,
+  have c_nonempty : c.nonempty := nonempty.image _ ⟨_, measurable_set.empty⟩,
 
-  have d_le_γ : ∀s, is_measurable s → d s ≤ γ := assume s hs, le_cSup bdd_c ⟨s, hs, rfl⟩,
+  have d_le_γ : ∀s, measurable_set s → d s ≤ γ := assume s hs, le_cSup bdd_c ⟨s, hs, rfl⟩,
 
-  have : ∀n:ℕ, ∃s : set α, is_measurable s ∧ γ - (1/2)^n < d s,
+  have : ∀n:ℕ, ∃s : set α, measurable_set s ∧ γ - (1/2)^n < d s,
   { assume n,
     have : γ - (1/2)^n < γ := sub_lt_self γ (pow_pos (half_pos zero_lt_one) n),
     rcases exists_lt_of_lt_cSup c_nonempty this with ⟨r, ⟨s, hs, rfl⟩, hlt⟩,
     exact ⟨s, hs, hlt⟩ },
   rcases classical.axiom_of_choice this with ⟨e, he⟩,
   change ℕ → set α at e,
-  have he₁ : ∀n, is_measurable (e n) := assume n, (he n).1,
+  have he₁ : ∀n, measurable_set (e n) := assume n, (he n).1,
   have he₂ : ∀n, γ - (1/2)^n < d (e n) := assume n, (he n).2,
 
   let f : ℕ → ℕ → set α := λn m, (finset.Ico n (m + 1)).inf e,
 
-  have hf : ∀n m, is_measurable (f n m),
+  have hf : ∀n m, measurable_set (f n m),
   { assume n m,
     simp only [f, finset.inf_eq_infi],
-    exact is_measurable.bInter (countable_encodable _) (assume i _, he₁ _) },
+    exact measurable_set.bInter (countable_encodable _) (assume i _, he₁ _) },
 
   have f_subset_f : ∀{a b c d}, a ≤ b → c ≤ d → f a d ⊆ f b c,
   { assume a b c d hab hcd,
@@ -157,7 +157,7 @@ begin
           (le_of_lt $ half_pos $ zero_lt_one) (half_lt_self zero_lt_one)) },
     have hd : tendsto (λm, d (⋂n, f m n)) at_top (𝓝 (d (⋃ m, ⋂ n, f m n))),
     { refine d_Union _ _ _,
-      { assume n, exact is_measurable.Inter (assume m, hf _ _) },
+      { assume n, exact measurable_set.Inter (assume m, hf _ _) },
       { exact assume n m hnm, subset_Inter
           (assume i, subset.trans (Inter_subset (f n) i) $ f_subset_f hnm $ le_refl _) } },
     refine le_of_tendsto_of_tendsto' hγ hd (assume m, _),
@@ -170,8 +170,8 @@ begin
     refine le_trans _ (le_d_f _ _ hmn),
     exact le_add_of_le_of_nonneg (le_refl _) (pow_nonneg (le_of_lt $ half_pos $ zero_lt_one) _) },
 
-  have hs : is_measurable s :=
-    is_measurable.Union (assume n, is_measurable.Inter (assume m, hf _ _)),
+  have hs : measurable_set s :=
+    measurable_set.Union (assume n, measurable_set.Inter (assume m, hf _ _)),
   refine ⟨s, hs, _, _⟩,
   { assume t ht hts,
     have : 0 ≤ d t := ((add_le_add_iff_left γ).1 $

--- a/src/measure_theory/giry_monad.lean
+++ b/src/measure_theory/giry_monad.lean
@@ -42,19 +42,19 @@ variables [measurable_space α] [measurable_space β]
 
 /-- Measurability structure on `measure`: Measures are measurable w.r.t. all projections -/
 instance : measurable_space (measure α) :=
-⨆ (s : set α) (hs : is_measurable s), (borel ennreal).comap (λμ, μ s)
+⨆ (s : set α) (hs : measurable_set s), (borel ennreal).comap (λμ, μ s)
 
-lemma measurable_coe {s : set α} (hs : is_measurable s) : measurable (λμ : measure α, μ s) :=
+lemma measurable_coe {s : set α} (hs : measurable_set s) : measurable (λμ : measure α, μ s) :=
 measurable.of_comap_le $ le_supr_of_le s $ le_supr_of_le hs $ le_refl _
 
 lemma measurable_of_measurable_coe (f : β → measure α)
-  (h : ∀(s : set α) (hs : is_measurable s), measurable (λb, f b s)) :
+  (h : ∀(s : set α) (hs : measurable_set s), measurable (λb, f b s)) :
   measurable f :=
 measurable.of_le_map $ bsupr_le $ assume s hs, measurable_space.comap_le_iff_le_map.2 $
   by rw [measurable_space.map_comp]; exact h s hs
 
 lemma measurable_measure {μ : α → measure β} :
-  measurable μ ↔ ∀(s : set β) (hs : is_measurable s), measurable (λb, μ b s) :=
+  measurable μ ↔ ∀(s : set β) (hs : measurable_set s), measurable (λb, μ b s) :=
 ⟨λ hμ s hs, (measurable_coe hs).comp hμ, measurable_of_measurable_coe μ⟩
 
 lemma measurable_map (f : α → β) (hf : measurable f) :
@@ -78,7 +78,7 @@ begin
   simp only [lintegral_eq_supr_eapprox_lintegral, hf, simple_func.lintegral],
   refine measurable_supr (λ n, finset.measurable_sum _ (λ i, _)),
     refine measurable_const.ennreal_mul _,
-    exact measurable_coe ((simple_func.eapprox f n).is_measurable_preimage _)
+    exact measurable_coe ((simple_func.eapprox f n).measurable_set_preimage _)
 end
 
 /-- Monadic join on `measure` in the category of measurable spaces and measurable
@@ -95,7 +95,7 @@ measure.of_measurable
   end
 
 @[simp] lemma join_apply {m : measure (measure α)} :
-  ∀{s : set α}, is_measurable s → join m s = ∫⁻ μ, μ s ∂m :=
+  ∀{s : set α}, measurable_set s → join m s = ∫⁻ μ, μ s ∂m :=
 measure.of_measurable_apply
 
 lemma measurable_join : measurable (join : measure (measure α) → measure α) :=
@@ -109,7 +109,7 @@ begin
   have : ∀n x,
     join m (⇑(simple_func.eapprox (λ (a : α), f a) n) ⁻¹' {x}) =
       ∫⁻ μ, μ ((⇑(simple_func.eapprox (λ (a : α), f a) n) ⁻¹' {x})) ∂m :=
-    assume n x, join_apply (simple_func.is_measurable_preimage _ _),
+    assume n x, join_apply (simple_func.measurable_set_preimage _ _),
   simp only [simple_func.lintegral, this],
   transitivity,
   have : ∀(s : ℕ → finset ennreal) (f : ℕ → ennreal → measure α → ennreal)
@@ -136,7 +136,7 @@ begin
   refine this _ _; clear this,
   { assume n r,
     apply measurable_coe,
-    exact simple_func.is_measurable_preimage _ _ },
+    exact simple_func.measurable_set_preimage _ _ },
   { change monotone (λn μ, (simple_func.eapprox f n).lintegral μ),
     assume n m h μ,
     refine simple_func.lintegral_mono _ (le_refl _),
@@ -153,7 +153,7 @@ functions. When the function `f` is not measurable the result is not well define
 def bind (m : measure α) (f : α → measure β) : measure β := join (map f m)
 
 @[simp] lemma bind_apply {m : measure α} {f : α → measure β} {s : set β}
-  (hs : is_measurable s) (hf : measurable f) :
+  (hs : measurable_set s) (hf : measurable f) :
   bind m f s = ∫⁻ a, f a s ∂m :=
 by rw [bind, join_apply hs, lintegral_map (measurable_coe hs) hf]
 

--- a/src/measure_theory/group.lean
+++ b/src/measure_theory/group.lean
@@ -36,7 +36,7 @@ variables [measurable_space G] [has_mul G]
   To left translate sets we use preimage under left addition,
   since preimages are nicer to work with than images."]
 def is_mul_left_invariant (μ : set G → ennreal) : Prop :=
-∀ (g : G) {A : set G} (h : is_measurable A), μ ((λ h, g * h) ⁻¹' A) = μ A
+∀ (g : G) {A : set G} (h : measurable_set A), μ ((λ h, g * h) ⁻¹' A) = μ A
 
 /-- A measure `μ` on a topological group is right invariant
   if the measure of right translations of a set are equal to the measure of the set itself.
@@ -47,7 +47,7 @@ def is_mul_left_invariant (μ : set G → ennreal) : Prop :=
   To right translate sets we use preimage under right addition,
   since preimages are nicer to work with than images."]
 def is_mul_right_invariant (μ : set G → ennreal) : Prop :=
-∀ (g : G) {A : set G} (h : is_measurable A), μ ((λ h, h * g) ⁻¹' A) = μ A
+∀ (g : G) {A : set G} (h : measurable_set A), μ ((λ h, h * g) ⁻¹' A) = μ A
 
 end
 
@@ -79,7 +79,7 @@ measure.map inv μ
 variables [group G] [topological_space G] [topological_group G] [borel_space G]
 
 @[to_additive]
-lemma inv_apply (μ : measure G) {s : set G} (hs : is_measurable s) :
+lemma inv_apply (μ : measure G) {s : set G} (hs : measurable_set s) :
   μ.inv s = μ s⁻¹ :=
 measure.map_apply measurable_inv hs
 
@@ -161,7 +161,7 @@ begin
   { rw [← nonpos_iff_eq_zero],
     refine (measure_mono h2t).trans _,
     refine (measure_bUnion_le h1t.countable _).trans_eq _,
-    simp_rw [h2μ _ hs.is_measurable], rw [h, tsum_zero] },
+    simp_rw [h2μ _ hs.measurable_set], rw [h, tsum_zero] },
   { intros x _,
     simp_rw [mem_Union, mem_preimage],
     use [y * x⁻¹, mem_univ _],
@@ -204,7 +204,7 @@ begin
     rw [pos_iff_ne_zero, h2μ.measure_ne_zero_iff_nonempty hμ h3μ h3r],
     exact ⟨x, h2r⟩ },
   refine this.trans_le _,
-  rw [← set_lintegral_const, ← lintegral_indicator _ h3r.is_measurable],
+  rw [← set_lintegral_const, ← lintegral_indicator _ h3r.measurable_set],
   apply lintegral_mono,
   refine indicator_le (λ y, le_of_lt),
 end

--- a/src/measure_theory/haar_measure.lean
+++ b/src/measure_theory/haar_measure.lean
@@ -480,7 +480,7 @@ lemma haar_outer_measure_exists_compact {K₀ : positive_compacts G} {U : opens 
 outer_measure.of_content_exists_compact echaar_sup_le hU hε
 
 lemma haar_outer_measure_caratheodory {K₀ : positive_compacts G} (A : set G) :
-  (haar_outer_measure K₀).caratheodory.is_measurable' A ↔ ∀ (U : opens G),
+  (haar_outer_measure K₀).caratheodory.measurable_set' A ↔ ∀ (U : opens G),
   haar_outer_measure K₀ (U ∩ A) + haar_outer_measure K₀ (U \ A) ≤ haar_outer_measure K₀ U :=
 outer_measure.of_content_caratheodory echaar_sup_le A
 
@@ -545,7 +545,7 @@ def haar_measure (K₀ : positive_compacts G) : measure G :=
 (haar_outer_measure K₀ K₀.1)⁻¹ •
   (haar_outer_measure K₀).to_measure (haar_caratheodory_measurable K₀)
 
-lemma haar_measure_apply {K₀ : positive_compacts G} {s : set G} (hs : is_measurable s) :
+lemma haar_measure_apply {K₀ : positive_compacts G} {s : set G} (hs : measurable_set s) :
   haar_measure K₀ s = haar_outer_measure K₀ s / haar_outer_measure K₀ K₀.1 :=
 by { simp only [haar_measure, hs, div_eq_mul_inv, mul_comm, to_measure_apply,
       algebra.id.smul_eq_mul, pi.smul_apply, measure.coe_smul] }
@@ -562,7 +562,7 @@ end
 lemma haar_measure_self [locally_compact_space G] {K₀ : positive_compacts G} :
   haar_measure K₀ K₀.1 = 1 :=
 begin
-  rw [haar_measure_apply K₀.2.1.is_measurable, ennreal.div_self],
+  rw [haar_measure_apply K₀.2.1.measurable_set, ennreal.div_self],
   { rw [← pos_iff_ne_zero], exact haar_outer_measure_self_pos },
   { exact ne_of_lt (haar_outer_measure_lt_top_of_is_compact K₀.2.1) }
 end
@@ -570,7 +570,7 @@ end
 lemma haar_measure_pos_of_is_open [locally_compact_space G] {K₀ : positive_compacts G}
   {U : set G} (hU : is_open U) (h2U : U.nonempty) : 0 < haar_measure K₀ U :=
 begin
-  rw [haar_measure_apply hU.is_measurable, ennreal.div_pos_iff],
+  rw [haar_measure_apply hU.measurable_set, ennreal.div_pos_iff],
   refine ⟨_, ne_of_lt $ haar_outer_measure_lt_top_of_is_compact K₀.2.1⟩,
   rw [← pos_iff_ne_zero], apply haar_outer_measure_pos_of_is_open hU h2U
 end
@@ -579,15 +579,15 @@ lemma regular_haar_measure [locally_compact_space G] {K₀ : positive_compacts G
   (haar_measure K₀).regular :=
 begin
   apply measure.regular.smul, split,
-  { intros K hK, rw [to_measure_apply _ _ hK.is_measurable],
+  { intros K hK, rw [to_measure_apply _ _ hK.measurable_set],
     apply haar_outer_measure_lt_top_of_is_compact hK },
   { intros A hA, rw [to_measure_apply _ _ hA, haar_outer_measure_eq_infi],
     refine binfi_le_binfi _, intros U hU, refine infi_le_infi _, intro h2U,
-    rw [to_measure_apply _ _ hU.is_measurable, haar_outer_measure_of_is_open U hU], refl' },
-  { intros U hU, rw [to_measure_apply _ _ hU.is_measurable, haar_outer_measure_of_is_open U hU],
+    rw [to_measure_apply _ _ hU.measurable_set, haar_outer_measure_of_is_open U hU], refl' },
+  { intros U hU, rw [to_measure_apply _ _ hU.measurable_set, haar_outer_measure_of_is_open U hU],
     dsimp only [inner_content], refine bsupr_le (λ K hK, _),
     refine le_supr_of_le K.1 _, refine le_supr_of_le K.2 _, refine le_supr_of_le hK _,
-    rw [to_measure_apply _ _ K.2.is_measurable], apply echaar_le_haar_outer_measure },
+    rw [to_measure_apply _ _ K.2.measurable_set], apply echaar_le_haar_outer_measure },
   { rw ennreal.inv_lt_top, apply haar_outer_measure_self_pos }
 end
 

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -966,7 +966,7 @@ by { convert (monotone_lintegral μ).map_infi2_le f, ext1 a, simp only [infi_app
 lemma lintegral_mono_ae {f g : α → ennreal} (h : ∀ᵐ a ∂μ, f a ≤ g a) :
   (∫⁻ a, f a ∂μ) ≤ (∫⁻ a, g a ∂μ) :=
 begin
-  rcases exists_measurable_set_superset_of_null h with ⟨t, hts, ht, ht0⟩,
+  rcases exists_measurable_superset_of_null h with ⟨t, hts, ht, ht0⟩,
   have : ∀ᵐ x ∂μ, x ∉ t := measure_zero_iff_ae_nmem.1 ht0,
   refine (supr_le $ assume s, supr_le $ assume hfs,
     le_supr_of_le (s.restrict tᶜ) $ le_supr_of_le _ _),
@@ -1382,7 +1382,7 @@ by simp [pos_iff_ne_zero, hf, filter.eventually_eq, ae_iff, function.support]
 lemma lintegral_supr_ae {f : ℕ → α → ennreal} (hf : ∀n, measurable (f n))
   (h_mono : ∀n, ∀ᵐ a ∂μ, f n a ≤ f n.succ a) :
   (∫⁻ a, ⨆n, f n a ∂μ) = (⨆n, ∫⁻ a, f n a ∂μ) :=
-let ⟨s, hs⟩ := exists_measurable_set_superset_of_null
+let ⟨s, hs⟩ := exists_measurable_superset_of_null
                        (ae_iff.1 (ae_all_iff.2 h_mono)) in
 let g := λ n a, if a ∈ s then 0 else f n a in
 have g_eq_f : ∀ᵐ a ∂μ, ∀n, g n a = f n a,

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -46,7 +46,7 @@ if every preimage `f ⁻¹' {x}` is measurable, and the range is finite. This st
 a function with these properties. -/
 structure {u v} simple_func (α : Type u) [measurable_space α] (β : Type v) :=
 (to_fun : α → β)
-(is_measurable_fiber' : ∀ x, is_measurable (to_fun ⁻¹' {x}))
+(measurable_set_fiber' : ∀ x, measurable_set (to_fun ⁻¹' {x}))
 (finite_range' : (set.range to_fun).finite)
 
 local infixr ` →ₛ `:25 := simple_func
@@ -65,8 +65,8 @@ coe_injective $ funext H
 
 lemma finite_range (f : α →ₛ β) : (set.range f).finite := f.finite_range'
 
-lemma is_measurable_fiber (f : α →ₛ β) (x : β) : is_measurable (f ⁻¹' {x}) :=
-f.is_measurable_fiber' x
+lemma measurable_set_fiber (f : α →ₛ β) (x : β) : measurable_set (f ⁻¹' {x}) :=
+f.measurable_set_fiber' x
 
 /-- Range of a simple function `α →ₛ β` as a `finset β`. -/
 protected def range (f : α →ₛ β) : finset β := f.finite_range.to_finset
@@ -101,7 +101,7 @@ f.range.exists_le.imp $ λ C, forall_range_iff.1
 
 /-- Constant function as a `simple_func`. -/
 def const (α) {β} [measurable_space α] (b : β) : α →ₛ β :=
-⟨λ a, b, λ x, is_measurable.const _, finite_range_const⟩
+⟨λ a, b, λ x, measurable_set.const _, finite_range_const⟩
 
 instance [inhabited β] : inhabited (α →ₛ β) := ⟨const _ (default _)⟩
 
@@ -113,24 +113,24 @@ theorem const_apply (a : α) (b : β) : (const α b) a = b := rfl
   (const α b).range = {b} :=
 finset.coe_injective $ by simp
 
-lemma is_measurable_cut (r : α → β → Prop) (f : α →ₛ β)
-  (h : ∀b, is_measurable {a | r a b}) : is_measurable {a | r a (f a)} :=
+lemma measurable_set_cut (r : α → β → Prop) (f : α →ₛ β)
+  (h : ∀b, measurable_set {a | r a b}) : measurable_set {a | r a (f a)} :=
 begin
   have : {a | r a (f a)} = ⋃ b ∈ range f, {a | r a b} ∩ f ⁻¹' {b},
   { ext a,
     suffices : r a (f a) ↔ ∃ i, r a (f i) ∧ f a = f i, by simpa,
     exact ⟨λ h, ⟨a, ⟨h, rfl⟩⟩, λ ⟨a', ⟨h', e⟩⟩, e.symm ▸ h'⟩ },
   rw this,
-  exact is_measurable.bUnion f.finite_range.countable
-    (λ b _, is_measurable.inter (h b) (f.is_measurable_fiber _))
+  exact measurable_set.bUnion f.finite_range.countable
+    (λ b _, measurable_set.inter (h b) (f.measurable_set_fiber _))
 end
 
-theorem is_measurable_preimage (f : α →ₛ β) (s) : is_measurable (f ⁻¹' s) :=
-is_measurable_cut (λ _ b, b ∈ s) f (λ b, is_measurable.const (b ∈ s))
+theorem measurable_set_preimage (f : α →ₛ β) (s) : measurable_set (f ⁻¹' s) :=
+measurable_set_cut (λ _ b, b ∈ s) f (λ b, measurable_set.const (b ∈ s))
 
 /-- A simple function is measurable -/
 protected theorem measurable [measurable_space β] (f : α →ₛ β) : measurable f :=
-λ s _, is_measurable_preimage f s
+λ s _, measurable_set_preimage f s
 
 protected theorem ae_measurable [measurable_space β] {μ : measure α} (f : α →ₛ β) :
   ae_measurable f μ :=
@@ -138,46 +138,46 @@ f.measurable.ae_measurable
 
 protected lemma sum_measure_preimage_singleton (f : α →ₛ β) {μ : measure α} (s : finset β) :
   ∑ y in s, μ (f ⁻¹' {y}) = μ (f ⁻¹' ↑s) :=
-sum_measure_preimage_singleton _ (λ _ _, f.is_measurable_fiber _)
+sum_measure_preimage_singleton _ (λ _ _, f.measurable_set_fiber _)
 
 lemma sum_range_measure_preimage_singleton (f : α →ₛ β) (μ : measure α) :
   ∑ y in f.range, μ (f ⁻¹' {y}) = μ univ :=
 by rw [f.sum_measure_preimage_singleton, coe_range, preimage_range]
 
 /-- If-then-else as a `simple_func`. -/
-def piecewise (s : set α) (hs : is_measurable s) (f g : α →ₛ β) : α →ₛ β :=
+def piecewise (s : set α) (hs : measurable_set s) (f g : α →ₛ β) : α →ₛ β :=
 ⟨s.piecewise f g,
  λ x, by letI : measurable_space β := ⊤; exact
    f.measurable.piecewise hs g.measurable trivial,
  (f.finite_range.union g.finite_range).subset range_ite_subset⟩
 
-@[simp] theorem coe_piecewise {s : set α} (hs : is_measurable s) (f g : α →ₛ β) :
+@[simp] theorem coe_piecewise {s : set α} (hs : measurable_set s) (f g : α →ₛ β) :
   ⇑(piecewise s hs f g) = s.piecewise f g :=
 rfl
 
-theorem piecewise_apply {s : set α} (hs : is_measurable s) (f g : α →ₛ β) (a) :
+theorem piecewise_apply {s : set α} (hs : measurable_set s) (f g : α →ₛ β) (a) :
   piecewise s hs f g a = if a ∈ s then f a else g a :=
 rfl
 
-@[simp] lemma piecewise_compl {s : set α} (hs : is_measurable sᶜ) (f g : α →ₛ β) :
+@[simp] lemma piecewise_compl {s : set α} (hs : measurable_set sᶜ) (f g : α →ₛ β) :
   piecewise sᶜ hs f g = piecewise s hs.of_compl g f :=
 coe_injective $ by simp [hs]
 
-@[simp] lemma piecewise_univ (f g : α →ₛ β) : piecewise univ is_measurable.univ f g = f :=
+@[simp] lemma piecewise_univ (f g : α →ₛ β) : piecewise univ measurable_set.univ f g = f :=
 coe_injective $ by simp
 
-@[simp] lemma piecewise_empty (f g : α →ₛ β) : piecewise ∅ is_measurable.empty f g = g :=
+@[simp] lemma piecewise_empty (f g : α →ₛ β) : piecewise ∅ measurable_set.empty f g = g :=
 coe_injective $ by simp
 
 lemma measurable_bind [measurable_space γ] (f : α →ₛ β) (g : β → α → γ)
   (hg : ∀ b, measurable (g b)) : measurable (λ a, g (f a) a) :=
-λ s hs, f.is_measurable_cut (λ a b, g b a ∈ s) $ λ b, hg b hs
+λ s hs, f.measurable_set_cut (λ a b, g b a ∈ s) $ λ b, hg b hs
 
 /-- If `f : α →ₛ β` is a simple function and `g : β → α →ₛ γ` is a family of simple functions,
 then `f.bind g` binds the first argument of `g` to `f`. In other words, `f.bind g a = g (f a) a`. -/
 def bind (f : α →ₛ β) (g : β → α →ₛ γ) : α →ₛ γ :=
 ⟨λa, g (f a) a,
- λ c, f.is_measurable_cut (λ a b, g b a = c) $ λ b, (g b).is_measurable_preimage {c},
+ λ c, f.measurable_set_cut (λ a b, g b a = c) $ λ b, (g b).measurable_set_preimage {c},
  (f.finite_range.bUnion (λ b _, (g b).finite_range)).subset $
  by rintro _ ⟨a, rfl⟩; simp; exact ⟨a, a, rfl⟩⟩
 
@@ -213,7 +213,7 @@ map_preimage _ _ _
 def comp [measurable_space β] (f : β →ₛ γ) (g : α → β) (hgm : measurable g) : α →ₛ γ :=
 { to_fun := f ∘ g,
   finite_range' := f.finite_range.subset $ set.range_comp_subset_range _ _,
-  is_measurable_fiber' := λ z, hgm (f.is_measurable_fiber z) }
+  measurable_set_fiber' := λ z, hgm (f.measurable_set_fiber z) }
 
 @[simp] lemma coe_comp [measurable_space β] (f : β →ₛ γ) {g : α → β} (hgm : measurable g) :
   ⇑(f.comp g hgm) = f ∘ g :=
@@ -375,14 +375,14 @@ variables [has_zero β]
 /-- Restrict a simple function `f : α →ₛ β` to a set `s`. If `s` is measurable,
 then `f.restrict s a = if a ∈ s then f a else 0`, otherwise `f.restrict s = const α 0`. -/
 def restrict (f : α →ₛ β) (s : set α) : α →ₛ β :=
-if hs : is_measurable s then piecewise s hs f 0 else 0
+if hs : measurable_set s then piecewise s hs f 0 else 0
 
 theorem restrict_of_not_measurable {f : α →ₛ β} {s : set α}
-  (hs : ¬is_measurable s) :
+  (hs : ¬measurable_set s) :
   restrict f s = 0 :=
 dif_neg hs
 
-@[simp] theorem coe_restrict (f : α →ₛ β) {s : set α} (hs : is_measurable s) :
+@[simp] theorem coe_restrict (f : α →ₛ β) {s : set α} (hs : measurable_set s) :
   ⇑(restrict f s) = indicator s f :=
 by { rw [restrict, dif_pos hs], refl }
 
@@ -395,7 +395,7 @@ by simp [restrict]
 theorem map_restrict_of_zero [has_zero γ] {g : β → γ} (hg : g 0 = 0) (f : α →ₛ β) (s : set α) :
   (f.restrict s).map g = (f.map g).restrict s :=
 ext $ λ x,
-if hs : is_measurable s then by simp [hs, set.indicator_comp_of_zero hg]
+if hs : measurable_set s then by simp [hs, set.indicator_comp_of_zero hg]
 else by simp [restrict_of_not_measurable hs, hg]
 
 theorem map_coe_ennreal_restrict (f : α →ₛ ℝ≥0) (s : set α) :
@@ -406,32 +406,32 @@ theorem map_coe_nnreal_restrict (f : α →ₛ ℝ≥0) (s : set α) :
   (f.restrict s).map (coe : ℝ≥0 → ℝ) = (f.map coe).restrict s :=
 map_restrict_of_zero nnreal.coe_zero _ _
 
-theorem restrict_apply (f : α →ₛ β) {s : set α} (hs : is_measurable s) (a) :
+theorem restrict_apply (f : α →ₛ β) {s : set α} (hs : measurable_set s) (a) :
   restrict f s a = if a ∈ s then f a else 0 :=
 by simp only [hs, coe_restrict]
 
-theorem restrict_preimage (f : α →ₛ β) {s : set α} (hs : is_measurable s)
+theorem restrict_preimage (f : α →ₛ β) {s : set α} (hs : measurable_set s)
   {t : set β} (ht : (0:β) ∉ t) : restrict f s ⁻¹' t = s ∩ f ⁻¹' t :=
 by simp [hs, indicator_preimage_of_not_mem _ _ ht]
 
-theorem restrict_preimage_singleton (f : α →ₛ β) {s : set α} (hs : is_measurable s)
+theorem restrict_preimage_singleton (f : α →ₛ β) {s : set α} (hs : measurable_set s)
   {r : β} (hr : r ≠ 0) : restrict f s ⁻¹' {r} = s ∩ f ⁻¹' {r} :=
 f.restrict_preimage hs hr.symm
 
-lemma mem_restrict_range {r : β} {s : set α} {f : α →ₛ β} (hs : is_measurable s) :
+lemma mem_restrict_range {r : β} {s : set α} {f : α →ₛ β} (hs : measurable_set s) :
   r ∈ (restrict f s).range ↔ (r = 0 ∧ s ≠ univ) ∨ (r ∈ f '' s) :=
 by rw [← finset.mem_coe, coe_range, coe_restrict _ hs, mem_range_indicator]
 
 lemma mem_image_of_mem_range_restrict {r : β} {s : set α} {f : α →ₛ β}
   (hr : r ∈ (restrict f s).range) (h0 : r ≠ 0) :
   r ∈ f '' s :=
-if hs : is_measurable s then by simpa [mem_restrict_range hs, h0] using hr
+if hs : measurable_set s then by simpa [mem_restrict_range hs, h0] using hr
 else by { rw [restrict_of_not_measurable hs] at hr,
   exact (h0 $ eq_zero_of_mem_range_zero hr).elim }
 
 @[mono] lemma restrict_mono [preorder β] (s : set α) {f g : α →ₛ β} (H : f ≤ g) :
   f.restrict s ≤ g.restrict s :=
-if hs : is_measurable s then λ x, by simp only [coe_restrict _ hs, indicator_le_indicator (H x)]
+if hs : measurable_set s then λ x, by simp only [coe_restrict _ hs, indicator_le_indicator (H x)]
 else by simp only [restrict_of_not_measurable hs, le_refl]
 
 end restrict
@@ -457,7 +457,7 @@ begin
   funext k,
   rw [restrict_apply],
   refl,
-  exact (hf is_measurable_Ici)
+  exact (hf measurable_set_Ici)
 end
 
 lemma monotone_approx (i : ℕ → β) (f : α → β) : monotone (approx i f) :=
@@ -613,12 +613,12 @@ lemma lintegral_smul (f : α →ₛ ennreal) (c : ennreal) :
 lemma lintegral_sum {ι} (f : α →ₛ ennreal) (μ : ι → measure α) :
   f.lintegral (measure.sum μ) = ∑' i, f.lintegral (μ i) :=
 begin
-  simp only [lintegral, measure.sum_apply, f.is_measurable_preimage, ← finset.tsum_subtype,
+  simp only [lintegral, measure.sum_apply, f.measurable_set_preimage, ← finset.tsum_subtype,
     ← ennreal.tsum_mul_left],
   apply ennreal.tsum_comm
 end
 
-lemma restrict_lintegral (f : α →ₛ ennreal) {s : set α} (hs : is_measurable s) :
+lemma restrict_lintegral (f : α →ₛ ennreal) {s : set α} (hs : measurable_set s) :
   (restrict f s).lintegral μ = ∑ r in f.range, r * μ (f ⁻¹' {r} ∩ s) :=
 calc (restrict f s).lintegral μ = ∑ r in f.range, r * μ (restrict f s ⁻¹' {r}) :
   lintegral_eq_of_subset _ $ λ x hx, if hxs : x ∈ s
@@ -630,10 +630,10 @@ calc (restrict f s).lintegral μ = ∑ r in f.range, r * μ (restrict f s ⁻¹'
 
 lemma lintegral_restrict (f : α →ₛ ennreal) (s : set α) (μ : measure α) :
   f.lintegral (μ.restrict s) = ∑ y in f.range, y * μ (f ⁻¹' {y} ∩ s) :=
-by simp only [lintegral, measure.restrict_apply, f.is_measurable_preimage]
+by simp only [lintegral, measure.restrict_apply, f.measurable_set_preimage]
 
 lemma restrict_lintegral_eq_lintegral_restrict (f : α →ₛ ennreal) {s : set α}
-  (hs : is_measurable s) :
+  (hs : measurable_set s) :
   (restrict f s).lintegral μ = f.lintegral (μ.restrict s) :=
 by rw [f.restrict_lintegral hs, lintegral_restrict]
 
@@ -647,9 +647,9 @@ end
 
 lemma const_lintegral_restrict (c : ennreal) (s : set α) :
   (const α c).lintegral (μ.restrict s) = c * μ s :=
-by rw [const_lintegral, measure.restrict_apply is_measurable.univ, univ_inter]
+by rw [const_lintegral, measure.restrict_apply measurable_set.univ, univ_inter]
 
-lemma restrict_const_lintegral (c : ennreal) {s : set α} (hs : is_measurable s) :
+lemma restrict_const_lintegral (c : ennreal) {s : set α} (hs : measurable_set s) :
   ((const α c).restrict s).lintegral μ = c * μ s :=
 by rw [restrict_lintegral_eq_lintegral_restrict _ hs, const_lintegral_restrict]
 
@@ -673,7 +673,7 @@ calc f.lintegral μ ≤ f.lintegral μ ⊔ g.lintegral μ : le_sup_left
   ... ≤ (f ⊔ g).lintegral μ : le_sup_lintegral _ _
   ... = g.lintegral μ : by rw [sup_of_le_right hfg]
   ... ≤ g.lintegral ν : finset.sum_le_sum $ λ y hy, ennreal.mul_left_mono $
-                          hμν _ (g.is_measurable_preimage _)
+                          hμν _ (g.measurable_set_preimage _)
 
 /-- `simple_func.lintegral` depends only on the measures of `f ⁻¹' {y}`. -/
 lemma lintegral_eq_of_measure_preimage [measurable_space β] {f : α →ₛ ennreal} {g : β →ₛ ennreal}
@@ -694,10 +694,10 @@ lintegral_eq_of_measure_preimage $ λ y, measure_congr $
   eventually.set_eq $ h.mono $ λ x hx, by simp [hx]
 
 lemma lintegral_map {β} [measurable_space β] {μ' : measure β} (f : α →ₛ ennreal) (g : β →ₛ ennreal)
-  (m : α → β) (eq : ∀a:α, f a = g (m a)) (h : ∀s:set β, is_measurable s → μ' s = μ (m ⁻¹' s)) :
+  (m : α → β) (eq : ∀a:α, f a = g (m a)) (h : ∀s:set β, measurable_set s → μ' s = μ (m ⁻¹' s)) :
   f.lintegral μ = g.lintegral μ' :=
 lintegral_eq_of_measure_preimage $ λ y,
-by { simp only [preimage, eq], exact (h (g ⁻¹' {y}) (g.is_measurable_preimage _)).symm }
+by { simp only [preimage, eq], exact (h (g ⁻¹' {y}) (g.measurable_set_preimage _)).symm }
 
 end measure
 
@@ -815,7 +815,7 @@ once we need them (for example it is only necessary to consider the case where `
 of a characteristic function, and that this multiple doesn't appear in the image of `f`) -/
 @[elab_as_eliminator]
 protected lemma induction {α γ} [measurable_space α] [add_monoid γ] {P : simple_func α γ → Prop}
-  (h_ind : ∀ c {s} (hs : is_measurable s),
+  (h_ind : ∀ c {s} (hs : measurable_set s),
     P (simple_func.piecewise s hs (simple_func.const _ c) (simple_func.const _ 0)))
   (h_sum : ∀ ⦃f g : simple_func α γ⦄, set.univ ⊆ f ⁻¹' {0} ∪ g ⁻¹' {0} → P f → P g → P (f + g))
   (f : simple_func α γ) : P f :=
@@ -824,9 +824,9 @@ begin
   rw [← finset.coe_inj, finset.coe_sdiff, finset.coe_singleton, simple_func.coe_range] at h,
   revert s f h, refine finset.induction _ _,
   { intros f hf, rw [finset.coe_empty, diff_eq_empty, range_subset_singleton] at hf,
-    convert h_ind 0 is_measurable.univ, ext x, simp [hf] },
+    convert h_ind 0 measurable_set.univ, ext x, simp [hf] },
   { intros x s hxs ih f hf,
-    have mx := f.is_measurable_preimage {x},
+    have mx := f.measurable_set_preimage {x},
     let g := simple_func.piecewise (f ⁻¹' {x}) mx 0 f,
     have Pg : P g,
     { apply ih, simp only [g, simple_func.coe_piecewise, range_piecewise],
@@ -918,7 +918,7 @@ begin
     refine le_trans le_top (ge_of_eq $ (supr_eq_top _).2 $ λ b hb, _),
     obtain ⟨n, hn⟩ : ∃ n : ℕ, b < n * μ (φ ⁻¹' {⊤}), from exists_nat_mul_gt h_meas (ne_of_lt hb),
     use (const α (n : ℝ≥0)).restrict (φ ⁻¹' {⊤}),
-    simp only [lt_supr_iff, exists_prop, coe_restrict, φ.is_measurable_preimage, coe_const,
+    simp only [lt_supr_iff, exists_prop, coe_restrict, φ.measurable_set_preimage, coe_const,
       ennreal.coe_indicator, map_coe_ennreal_restrict, map_const, ennreal.coe_nat,
       restrict_const_lintegral],
     refine ⟨indicator_le (λ x hx, le_trans _ (hφ _)), hn⟩,
@@ -966,7 +966,7 @@ by { convert (monotone_lintegral μ).map_infi2_le f, ext1 a, simp only [infi_app
 lemma lintegral_mono_ae {f g : α → ennreal} (h : ∀ᵐ a ∂μ, f a ≤ g a) :
   (∫⁻ a, f a ∂μ) ≤ (∫⁻ a, g a ∂μ) :=
 begin
-  rcases exists_is_measurable_superset_of_null h with ⟨t, hts, ht, ht0⟩,
+  rcases exists_measurable_set_superset_of_null h with ⟨t, hts, ht, ht0⟩,
   have : ∀ᵐ x ∂μ, x ∉ t := measure_zero_iff_ae_nmem.1 ht0,
   refine (supr_le $ assume s, supr_le $ assume hfs,
     le_supr_of_le (s.restrict tᶜ) $ le_supr_of_le _ _),
@@ -1028,8 +1028,8 @@ begin
   { assume r i j h,
     refine inter_subset_inter (subset.refl _) _,
     assume x hx, exact le_trans hx (h_mono h x) },
-  have h_meas : ∀n, is_measurable {a : α | ⇑(map c rs) a ≤ f n a} :=
-    assume n, is_measurable_le (simple_func.measurable _) (hf n),
+  have h_meas : ∀n, measurable_set {a : α | ⇑(map c rs) a ≤ f n a} :=
+    assume n, measurable_set_le (simple_func.measurable _) (hf n),
   calc (r:ennreal) * (s.map c).lintegral μ = ∑ r in (rs.map c).range, r * μ ((rs.map c) ⁻¹' {r}) :
       by rw [← const_mul_lintegral, eq_rs, simple_func.lintegral]
     ... ≤ ∑ r in (rs.map c).range, r * μ (⋃n, (rs.map c) ⁻¹' {r} ∩ {a | r ≤ f n a}) :
@@ -1039,8 +1039,8 @@ begin
         begin
           rw [measure_Union_eq_supr _ (directed_of_sup $ mono x), ennreal.mul_supr],
           { assume i,
-            refine ((rs.map c).is_measurable_preimage _).inter _,
-            exact hf i is_measurable_Ici }
+            refine ((rs.map c).measurable_set_preimage _).inter _,
+            exact hf i measurable_set_Ici }
         end)
     ... ≤ ⨆n, ∑ r in (rs.map c).range, r * μ ((rs.map c) ⁻¹' {r} ∩ {a | r ≤ f n a}) :
       begin
@@ -1313,7 +1313,7 @@ lemma lintegral_rw₂ {f₁ f₁' : α → β} {f₂ f₂' : α → γ} (h₁ : 
   (∫⁻ a, g (f₁ a) (f₂ a) ∂μ) = (∫⁻ a, g (f₁' a) (f₂' a) ∂μ) :=
 lintegral_congr_ae $ h₁.mp $ h₂.mono $ λ _ h₂ h₁, by rw [h₁, h₂]
 
-@[simp] lemma lintegral_indicator (f : α → ennreal) {s : set α} (hs : is_measurable s) :
+@[simp] lemma lintegral_indicator (f : α → ennreal) {s : set α} (hs : measurable_set s) :
   ∫⁻ a, s.indicator f a ∂μ = ∫⁻ a in s, f a ∂μ :=
 begin
   simp only [lintegral, ← restrict_lintegral_eq_lintegral_restrict _ hs, supr_subtype'],
@@ -1332,7 +1332,7 @@ end
 lemma mul_meas_ge_le_lintegral {f : α → ennreal} (hf : measurable f) (ε : ennreal) :
   ε * μ {x | ε ≤ f x} ≤ ∫⁻ a, f a ∂μ :=
 begin
-  have : is_measurable {a : α | ε ≤ f a }, from hf is_measurable_Ici,
+  have : measurable_set {a : α | ε ≤ f a }, from hf measurable_set_Ici,
   rw [← simple_func.restrict_const_lintegral _ this, ← simple_func.lintegral_eq_lintegral],
   refine lintegral_mono (λ a, _),
   simp only [restrict_apply _ this],
@@ -1382,7 +1382,7 @@ by simp [pos_iff_ne_zero, hf, filter.eventually_eq, ae_iff, function.support]
 lemma lintegral_supr_ae {f : ℕ → α → ennreal} (hf : ∀n, measurable (f n))
   (h_mono : ∀n, ∀ᵐ a ∂μ, f n a ≤ f n.succ a) :
   (∫⁻ a, ⨆n, f n a ∂μ) = (⨆n, ∫⁻ a, f n a ∂μ) :=
-let ⟨s, hs⟩ := exists_is_measurable_superset_of_null
+let ⟨s, hs⟩ := exists_measurable_set_superset_of_null
                        (ae_iff.1 (ae_all_iff.2 h_mono)) in
 let g := λ n a, if a ∈ s then 0 else f n a in
 have g_eq_f : ∀ᵐ a ∂μ, ∀n, g n a = f n a,
@@ -1612,7 +1612,7 @@ end
 
 open measure
 
-lemma lintegral_Union [encodable β] {s : β → set α} (hm : ∀ i, is_measurable (s i))
+lemma lintegral_Union [encodable β] {s : β → set α} (hm : ∀ i, measurable_set (s i))
   (hd : pairwise (disjoint on s)) (f : α → ennreal) :
   ∫⁻ a in ⋃ i, s i, f a ∂μ = ∑' i, ∫⁻ a in s i, f a ∂μ :=
 by simp only [measure.restrict_Union hd hm, lintegral_sum_measure]
@@ -1647,7 +1647,7 @@ lemma lintegral_comp [measurable_space β] {f : β → ennreal} {g : α → β}
 (lintegral_map hf hg).symm
 
 lemma set_lintegral_map [measurable_space β] {f : β → ennreal} {g : α → β}
-  {s : set β} (hs : is_measurable s) (hf : measurable f) (hg : measurable g) :
+  {s : set β} (hs : measurable_set s) (hf : measurable f) (hg : measurable g) :
   ∫⁻ y in s, f y ∂(map g μ) = ∫⁻ x in g ⁻¹' s, f (g x) ∂μ :=
 by rw [restrict_map hg hs, lintegral_map hf hg]
 
@@ -1682,7 +1682,7 @@ begin
   have : (f ⁻¹' {⊤}).indicator ⊤ ≤ f,
   { intro x, by_cases hx : x ∈ f ⁻¹' {⊤}; [simpa [hx], simp [hx]] },
   convert lintegral_mono this,
-  rw [lintegral_indicator _ (hf (is_measurable_singleton ⊤))], simp [ennreal.top_mul, preimage, h]
+  rw [lintegral_indicator _ (hf (measurable_set_singleton ⊤))], simp [ennreal.top_mul, preimage, h]
 end
 
 /-- Given a measure `μ : measure α` and a function `f : α → ennreal`, `μ.with_density f` is the
@@ -1690,7 +1690,7 @@ measure such that for a measurable set `s` we have `μ.with_density f s = ∫⁻
 def measure.with_density (μ : measure α) (f : α → ennreal) : measure α :=
 measure.of_measurable (λs hs, ∫⁻ a in s, f a ∂μ) (by simp) (λ s hs hd, lintegral_Union hs hd _)
 
-@[simp] lemma with_density_apply (f : α → ennreal) {s : set α} (hs : is_measurable s) :
+@[simp] lemma with_density_apply (f : α → ennreal) {s : set α} (hs : measurable_set s) :
   μ.with_density f s = ∫⁻ a in s, f a ∂μ :=
 measure.of_measurable_apply s hs
 
@@ -1709,7 +1709,7 @@ a simple function with a multiple of a characteristic function and that the inte
 of their images is a subset of `{0}`. -/
 @[elab_as_eliminator]
 theorem measurable.ennreal_induction {α} [measurable_space α] {P : (α → ennreal) → Prop}
-  (h_ind : ∀ (c : ennreal) ⦃s⦄, is_measurable s → P (indicator s (λ _, c)))
+  (h_ind : ∀ (c : ennreal) ⦃s⦄, measurable_set s → P (indicator s (λ _, c)))
   (h_sum : ∀ ⦃f g : α → ennreal⦄, set.univ ⊆ f ⁻¹' {0} ∪ g ⁻¹' {0} → measurable f → measurable g →
     P f → P g → P (f + g))
   (h_supr : ∀ ⦃f : ℕ → α → ennreal⦄ (hf : ∀n, measurable (f n)) (h_mono : monotone f)

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -329,7 +329,7 @@ lemma norm_integral_le_of_norm_le_const_ae {a b C : ℝ} {f : ℝ → E}
   ∥∫ x in a..b, f x∥ ≤ C * abs (b - a) :=
 begin
   rw [norm_integral_eq_norm_integral_Ioc],
-  convert norm_set_integral_le_of_norm_le_const_ae'' _ is_measurable_Ioc h,
+  convert norm_set_integral_le_of_norm_le_const_ae'' _ measurable_set_Ioc h,
   { rw [real.volume_Ioc, max_sub_min_eq_abs, ennreal.to_real_of_real (abs_nonneg _)] },
   { simp only [real.volume_Ioc, ennreal.of_real_lt_top] },
 end
@@ -369,7 +369,7 @@ lemma integral_comp_add_right (a b c : ℝ) (f : ℝ → E) (hfm : ae_measurable
   ∫ x in a..b, f (x + c) = ∫ x in a+c..b+c, f x :=
 have A : ae_measurable f (measure.map (λ x, x + c) volume), by rwa [real.map_volume_add_right],
 calc ∫ x in a..b, f (x + c) = ∫ x in a+c..b+c, f x ∂(measure.map (λ x, x + c) volume) :
-  by simp only [interval_integral, set_integral_map is_measurable_Ioc A (measurable_add_right _),
+  by simp only [interval_integral, set_integral_map measurable_set_Ioc A (measurable_add_right _),
     preimage_add_const_Ioc, add_sub_cancel]
 ... = ∫ x in a+c..b+c, f x : by rw [real.map_volume_add_right]
 
@@ -380,7 +380,7 @@ begin
     by { rw real.map_volume_mul_right (ne_of_gt hc), exact hfm.smul_measure _ },
   conv_rhs { rw [← real.smul_map_volume_mul_right (ne_of_gt hc)] },
   rw [integral_smul_measure],
-  simp only [interval_integral, set_integral_map is_measurable_Ioc A (measurable_mul_right _),
+  simp only [interval_integral, set_integral_map measurable_set_Ioc A (measurable_mul_right _),
     hc, preimage_mul_const_Ioc, mul_div_cancel _ (ne_of_gt hc), abs_of_pos,
     ennreal.to_real_of_real (le_of_lt hc), inv_smul_smul' (ne_of_gt hc)],
 end
@@ -390,7 +390,7 @@ lemma integral_comp_neg (a b : ℝ) (f : ℝ → E) (hfm : ae_measurable f) :
 begin
   have A : ae_measurable f (measure.map (λ (x : ℝ), -x) volume), by rwa real.map_volume_neg,
   conv_rhs { rw ← real.map_volume_neg },
-  simp only [interval_integral, set_integral_map is_measurable_Ioc A measurable_neg, neg_preimage,
+  simp only [interval_integral, set_integral_map measurable_set_Ioc A measurable_neg, neg_preimage,
     preimage_neg_Ioc, neg_neg, restrict_congr_set Ico_ae_eq_Ioc]
 end
 
@@ -412,7 +412,7 @@ variables [order_closed_topology α]
 lemma integral_congr {a b : α} {f g : α → E} (h : eq_on f g (interval a b)) :
   ∫ x in a..b, f x ∂μ = ∫ x in a..b, g x ∂μ :=
 by cases le_total a b with hab hab; simpa [hab, integral_of_le, integral_of_ge]
-  using set_integral_congr is_measurable_Ioc (h.mono Ioc_subset_Icc_self)
+  using set_integral_congr measurable_set_Ioc (h.mono Ioc_subset_Icc_self)
 
 lemma integral_add_adjacent_intervals_cancel (hab : interval_integrable f μ a b)
   (hbc : interval_integrable f μ b c) :
@@ -424,7 +424,7 @@ begin
   { suffices : Ioc a b ∪ Ioc b c ∪ Ioc c a = Ioc b a ∪ Ioc c b ∪ Ioc a c, by rw this,
     rw [Ioc_union_Ioc_union_Ioc_cycle, union_right_comm, Ioc_union_Ioc_union_Ioc_cycle,
       min_left_comm, max_left_comm] },
-  all_goals { simp [*, is_measurable.union, is_measurable_Ioc, Ioc_disjoint_Ioc_same,
+  all_goals { simp [*, measurable_set.union, measurable_set_Ioc, Ioc_disjoint_Ioc_same,
     Ioc_disjoint_Ioc_same.symm, hab.1, hab.2, hbc.1, hbc.2, hac.1, hac.2] }
 end
 
@@ -462,7 +462,7 @@ begin
   wlog hab : a ≤ b using [a b] tactic.skip,
   { rw [sub_eq_iff_eq_add', integral_of_le hab, ← integral_union (Iic_disjoint_Ioc (le_refl _)),
       Iic_union_Ioc_eq_Iic hab],
-    exacts [is_measurable_Iic, is_measurable_Ioc, ha, hb.mono_set (λ _, and.right)] },
+    exacts [measurable_set_Iic, measurable_set_Ioc, ha, hb.mono_set (λ _, and.right)] },
   { intros ha hb,
     rw [integral_symm, ← this hb ha, neg_sub] }
 end
@@ -480,7 +480,7 @@ lemma integral_eq_integral_of_support_subset {f : α → E} {a b} (h : function.
   ∫ x in a..b, f x ∂μ = ∫ x, f x ∂μ :=
 begin
   cases le_total a b with hab hab,
-  { rw [integral_of_le hab, ← integral_indicator is_measurable_Ioc, indicator_eq_self.2 h];
+  { rw [integral_of_le hab, ← integral_indicator measurable_set_Ioc, indicator_eq_self.2 h];
     apply_instance },
   { rw [Ioc_eq_empty hab, subset_empty_iff, function.support_eq_empty_iff] at h,
     simp [h] }
@@ -1305,7 +1305,7 @@ theorem integral_eq_sub_of_has_deriv_right_of_le (hab : a ≤ b) (hcont : contin
   ∫ y in a..b, f' y = f b - f a :=
 begin
   have hmeas' : ae_measurable f' (volume.restrict (Icc a b)),
-    from hcont'.ae_measurable is_measurable_Icc,
+    from hcont'.ae_measurable measurable_set_Icc,
   refine eq_sub_of_add_eq (eq_of_has_deriv_right_eq (λ y hy, _) hderiv
     (λ y hy, _) hcont (by simp) _ (right_mem_Icc.2 hab)),
   { refine (integral_has_deriv_within_at_right _ _ _).add_const _,
@@ -1317,7 +1317,7 @@ begin
     letI : tendsto_Ixx_class Ioc (𝓟 (Icc a b)) (𝓟 (Ioc a b)) :=
       tendsto_Ixx_class_principal.2 (λ x hx y hy, Ioc_subset_Ioc hx.1 hy.2),
     haveI : is_measurably_generated (𝓝[Ioc a b] y) :=
-      is_measurable_Ioc.nhds_within_is_measurably_generated y,
+      measurable_set_Ioc.nhds_within_is_measurably_generated y,
     letI : FTC_filter y (𝓝[Icc a b] y) (𝓝[Ioc a b] y) := ⟨pure_le_nhds_within hy, inf_le_left⟩,
     refine (integral_has_deriv_within_at_right _ _ _).continuous_within_at.add
       continuous_within_at_const,

--- a/src/measure_theory/lebesgue_measure.lean
+++ b/src/measure_theory/lebesgue_measure.lean
@@ -397,7 +397,7 @@ Exists.snd (classical.some_spec (vitali_aux_h x h):_)
 
 def vitali : set ℝ := {x | ∃ h, x = vitali_aux x h}
 
-theorem vitali_nonmeasurable : ¬ is_null_measurable measure_space.μ vitali :=
+theorem vitali_nonmeasurable : ¬ null_measurable_set measure_space.μ vitali :=
 sorry
 
 end vitali

--- a/src/measure_theory/lebesgue_measure.lean
+++ b/src/measure_theory/lebesgue_measure.lean
@@ -172,7 +172,7 @@ by rw [← Ico_diff_left, lebesgue_outer.diff_null _ (lebesgue_outer_singleton _
 by rw [← Icc_diff_left, lebesgue_outer.diff_null _ (lebesgue_outer_singleton _), lebesgue_outer_Icc]
 
 lemma is_lebesgue_measurable_Iio {c : ℝ} :
-  lebesgue_outer.caratheodory.is_measurable' (Iio c) :=
+  lebesgue_outer.caratheodory.measurable_set' (Iio c) :=
 outer_measure.of_function_caratheodory $ λ t,
 le_infi $ λ a, le_infi $ λ b, le_infi $ λ h, begin
   refine le_trans (add_le_add
@@ -195,7 +195,8 @@ begin
   refine le_trans _ (add_le_add_left (le_of_lt hε) _),
   rw ← ennreal.tsum_add,
   choose g hg using show
-    ∀ i, ∃ s, f i ⊆ s ∧ is_measurable s ∧ lebesgue_outer s ≤ lebesgue_length (f i) + of_real (ε' i),
+    ∀ i, ∃ s, f i ⊆ s ∧ measurable_set s ∧
+      lebesgue_outer s ≤ lebesgue_length (f i) + of_real (ε' i),
   { intro i,
     have := (ennreal.lt_add_right (lt_of_le_of_lt (ennreal.le_tsum i) h)
         (ennreal.zero_lt_coe_iff.2 (ε'0 i))),
@@ -203,11 +204,11 @@ begin
     simp only [infi_lt_iff] at this,
     rcases this with ⟨a, b, h₁, h₂⟩,
     rw ← lebesgue_outer_Ico at h₂,
-    exact ⟨_, h₁, is_measurable_Ico, le_of_lt $ by simpa using h₂⟩ },
+    exact ⟨_, h₁, measurable_set_Ico, le_of_lt $ by simpa using h₂⟩ },
   simp at hg,
   apply infi_le_of_le (Union g) _,
   apply infi_le_of_le (subset.trans hf $ Union_subset_Union (λ i, (hg i).1)) _,
-  apply infi_le_of_le (is_measurable.Union (λ i, (hg i).2.1)) _,
+  apply infi_le_of_le (measurable_set.Union (λ i, (hg i).2.1)) _,
   exact le_trans (lebesgue_outer.Union _) (ennreal.tsum_le_tsum $ λ i, (hg i).2.2)
 end
 
@@ -292,7 +293,7 @@ lemma volume_Icc_pi {a b : ι → ℝ} : volume (Icc a b) = ∏ i, ennreal.of_re
 begin
   rw [← pi_univ_Icc, volume_pi_pi],
   { simp only [real.volume_Icc] },
-  { exact λ i, is_measurable_Icc }
+  { exact λ i, measurable_set_Icc }
 end
 
 @[simp] lemma volume_Icc_pi_to_real {a b : ι → ℝ} (h : a ≤ b) :
@@ -329,7 +330,7 @@ by simp only [volume_pi_Ico, ennreal.to_real_prod, ennreal.to_real_of_real (sub_
 
 lemma map_volume_add_left (a : ℝ) : measure.map ((+) a) volume = volume :=
 eq.symm $ real.measure_ext_Ioo_rat $ λ p q,
-  by simp [measure.map_apply (measurable_add_left a) is_measurable_Ioo, sub_sub_sub_cancel_right]
+  by simp [measure.map_apply (measurable_add_left a) measurable_set_Ioo, sub_sub_sub_cancel_right]
 
 lemma map_volume_add_right (a : ℝ) : measure.map (+ a) volume = volume :=
 by simpa only [add_comm] using real.map_volume_add_left a
@@ -340,11 +341,11 @@ begin
   refine (real.measure_ext_Ioo_rat $ λ p q, _).symm,
   cases lt_or_gt_of_ne h with h h,
   { simp only [real.volume_Ioo, measure.smul_apply, ← ennreal.of_real_mul (le_of_lt $ neg_pos.2 h),
-      measure.map_apply (measurable_mul_left a) is_measurable_Ioo, neg_sub_neg,
+      measure.map_apply (measurable_mul_left a) measurable_set_Ioo, neg_sub_neg,
       ← neg_mul_eq_neg_mul, preimage_const_mul_Ioo_of_neg _ _ h, abs_of_neg h, mul_sub,
       mul_div_cancel' _ (ne_of_lt h)] },
   { simp only [real.volume_Ioo, measure.smul_apply, ← ennreal.of_real_mul (le_of_lt h),
-      measure.map_apply (measurable_mul_left a) is_measurable_Ioo, preimage_const_mul_Ioo _ _ h,
+      measure.map_apply (measurable_mul_left a) measurable_set_Ioo, preimage_const_mul_Ioo _ _ h,
       abs_of_pos h, mul_sub, mul_div_cancel' _ (ne_of_gt h)] }
 end
 
@@ -364,7 +365,7 @@ by simpa only [mul_comm] using real.map_volume_mul_left h
 
 @[simp] lemma map_volume_neg : measure.map has_neg.neg (volume : measure ℝ) = volume :=
 eq.symm $ real.measure_ext_Ioo_rat $ λ p q,
-  by simp [measure.map_apply measurable_neg is_measurable_Ioo]
+  by simp [measure.map_apply measurable_neg measurable_set_Ioo]
 
 end real
 

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -76,10 +76,10 @@ variables {α β γ δ δ' : Type*} {ι : Sort*} {s t u : set α}
 
 /-- A measurable space is a space equipped with a σ-algebra. -/
 structure measurable_space (α : Type*) :=
-(is_measurable' : set α → Prop)
-(is_measurable_empty : is_measurable' ∅)
-(is_measurable_compl : ∀ s, is_measurable' s → is_measurable' sᶜ)
-(is_measurable_Union : ∀ f : ℕ → set α, (∀ i, is_measurable' (f i)) → is_measurable' (⋃ i, f i))
+(measurable_set' : set α → Prop)
+(measurable_set_empty : measurable_set' ∅)
+(measurable_set_compl : ∀ s, measurable_set' s → measurable_set' sᶜ)
+(measurable_set_Union : ∀ f : ℕ → set α, (∀ i, measurable_set' (f i)) → measurable_set' (⋃ i, f i))
 
 attribute [class] measurable_space
 
@@ -88,182 +88,186 @@ instance [h : measurable_space α] : measurable_space (order_dual α) := h
 section
 variable [measurable_space α]
 
-/-- `is_measurable s` means that `s` is measurable (in the ambient measure space on `α`) -/
-def is_measurable : set α → Prop := ‹measurable_space α›.is_measurable'
+/-- `measurable_set s` means that `s` is measurable (in the ambient measure space on `α`) -/
+def measurable_set : set α → Prop := ‹measurable_space α›.measurable_set'
 
-@[simp] lemma is_measurable.empty : is_measurable (∅ : set α) :=
-‹measurable_space α›.is_measurable_empty
+@[simp] lemma measurable_set.empty : measurable_set (∅ : set α) :=
+‹measurable_space α›.measurable_set_empty
 
-lemma is_measurable.compl : is_measurable s → is_measurable sᶜ :=
-‹measurable_space α›.is_measurable_compl s
+lemma measurable_set.compl : measurable_set s → measurable_set sᶜ :=
+‹measurable_space α›.measurable_set_compl s
 
-lemma is_measurable.of_compl (h : is_measurable sᶜ) : is_measurable s :=
+lemma measurable_set.of_compl (h : measurable_set sᶜ) : measurable_set s :=
 compl_compl s ▸ h.compl
 
-@[simp] lemma is_measurable.compl_iff : is_measurable sᶜ ↔ is_measurable s :=
-⟨is_measurable.of_compl, is_measurable.compl⟩
+@[simp] lemma measurable_set.compl_iff : measurable_set sᶜ ↔ measurable_set s :=
+⟨measurable_set.of_compl, measurable_set.compl⟩
 
-@[simp] lemma is_measurable.univ : is_measurable (univ : set α) :=
-by simpa using (@is_measurable.empty α _).compl
+@[simp] lemma measurable_set.univ : measurable_set (univ : set α) :=
+by simpa using (@measurable_set.empty α _).compl
 
-@[nontriviality] lemma subsingleton.is_measurable [subsingleton α] {s : set α} : is_measurable s :=
-subsingleton.set_cases is_measurable.empty is_measurable.univ s
+@[nontriviality] lemma subsingleton.measurable_set [subsingleton α] {s : set α} :
+  measurable_set s :=
+subsingleton.set_cases measurable_set.empty measurable_set.univ s
 
-lemma is_measurable.congr {s t : set α} (hs : is_measurable s) (h : s = t) :
-  is_measurable t :=
+lemma measurable_set.congr {s t : set α} (hs : measurable_set s) (h : s = t) :
+  measurable_set t :=
 by rwa ← h
 
-lemma is_measurable.bUnion_decode2 [encodable β] ⦃f : β → set α⦄ (h : ∀ b, is_measurable (f b))
-  (n : ℕ) : is_measurable (⋃ b ∈ decode2 β n, f b) :=
-encodable.Union_decode2_cases is_measurable.empty h
+lemma measurable_set.bUnion_decode2 [encodable β] ⦃f : β → set α⦄ (h : ∀ b, measurable_set (f b))
+  (n : ℕ) : measurable_set (⋃ b ∈ decode2 β n, f b) :=
+encodable.Union_decode2_cases measurable_set.empty h
 
-lemma is_measurable.Union [encodable β] ⦃f : β → set α⦄ (h : ∀ b, is_measurable (f b)) :
-  is_measurable (⋃ b, f b) :=
+lemma measurable_set.Union [encodable β] ⦃f : β → set α⦄ (h : ∀ b, measurable_set (f b)) :
+  measurable_set (⋃ b, f b) :=
 begin
   rw ← encodable.Union_decode2,
-  exact ‹measurable_space α›.is_measurable_Union _ (is_measurable.bUnion_decode2 h)
+  exact ‹measurable_space α›.measurable_set_Union _ (measurable_set.bUnion_decode2 h)
 end
 
-lemma is_measurable.bUnion {f : β → set α} {s : set β} (hs : countable s)
-  (h : ∀ b ∈ s, is_measurable (f b)) : is_measurable (⋃ b ∈ s, f b) :=
+lemma measurable_set.bUnion {f : β → set α} {s : set β} (hs : countable s)
+  (h : ∀ b ∈ s, measurable_set (f b)) : measurable_set (⋃ b ∈ s, f b) :=
 begin
   rw bUnion_eq_Union,
   haveI := hs.to_encodable,
-  exact is_measurable.Union (by simpa using h)
+  exact measurable_set.Union (by simpa using h)
 end
 
-lemma set.finite.is_measurable_bUnion {f : β → set α} {s : set β} (hs : finite s)
-  (h : ∀ b ∈ s, is_measurable (f b)) :
-  is_measurable (⋃ b ∈ s, f b) :=
-is_measurable.bUnion hs.countable h
+lemma set.finite.measurable_set_bUnion {f : β → set α} {s : set β} (hs : finite s)
+  (h : ∀ b ∈ s, measurable_set (f b)) :
+  measurable_set (⋃ b ∈ s, f b) :=
+measurable_set.bUnion hs.countable h
 
-lemma finset.is_measurable_bUnion {f : β → set α} (s : finset β)
-  (h : ∀ b ∈ s, is_measurable (f b)) :
-  is_measurable (⋃ b ∈ s, f b) :=
-s.finite_to_set.is_measurable_bUnion h
+lemma finset.measurable_set_bUnion {f : β → set α} (s : finset β)
+  (h : ∀ b ∈ s, measurable_set (f b)) :
+  measurable_set (⋃ b ∈ s, f b) :=
+s.finite_to_set.measurable_set_bUnion h
 
-lemma is_measurable.sUnion {s : set (set α)} (hs : countable s) (h : ∀ t ∈ s, is_measurable t) :
-  is_measurable (⋃₀ s) :=
-by { rw sUnion_eq_bUnion, exact is_measurable.bUnion hs h }
+lemma measurable_set.sUnion {s : set (set α)} (hs : countable s) (h : ∀ t ∈ s, measurable_set t) :
+  measurable_set (⋃₀ s) :=
+by { rw sUnion_eq_bUnion, exact measurable_set.bUnion hs h }
 
-lemma set.finite.is_measurable_sUnion {s : set (set α)} (hs : finite s)
-  (h : ∀ t ∈ s, is_measurable t) :
-  is_measurable (⋃₀ s) :=
-is_measurable.sUnion hs.countable h
+lemma set.finite.measurable_set_sUnion {s : set (set α)} (hs : finite s)
+  (h : ∀ t ∈ s, measurable_set t) :
+  measurable_set (⋃₀ s) :=
+measurable_set.sUnion hs.countable h
 
-lemma is_measurable.Union_Prop {p : Prop} {f : p → set α} (hf : ∀ b, is_measurable (f b)) :
-  is_measurable (⋃ b, f b) :=
-by { by_cases p; simp [h, hf, is_measurable.empty] }
+lemma measurable_set.Union_Prop {p : Prop} {f : p → set α} (hf : ∀ b, measurable_set (f b)) :
+  measurable_set (⋃ b, f b) :=
+by { by_cases p; simp [h, hf, measurable_set.empty] }
 
-lemma is_measurable.Inter [encodable β] {f : β → set α} (h : ∀ b, is_measurable (f b)) :
-  is_measurable (⋂ b, f b) :=
-is_measurable.compl_iff.1 $
-by { rw compl_Inter, exact is_measurable.Union (λ b, (h b).compl) }
+lemma measurable_set.Inter [encodable β] {f : β → set α} (h : ∀ b, measurable_set (f b)) :
+  measurable_set (⋂ b, f b) :=
+measurable_set.compl_iff.1 $
+by { rw compl_Inter, exact measurable_set.Union (λ b, (h b).compl) }
 
 section fintype
 
 local attribute [instance] fintype.encodable
 
-lemma is_measurable.Union_fintype [fintype β] {f : β → set α} (h : ∀ b, is_measurable (f b)) :
-  is_measurable (⋃ b, f b) :=
-is_measurable.Union h
+lemma measurable_set.Union_fintype [fintype β] {f : β → set α} (h : ∀ b, measurable_set (f b)) :
+  measurable_set (⋃ b, f b) :=
+measurable_set.Union h
 
-lemma is_measurable.Inter_fintype [fintype β] {f : β → set α} (h : ∀ b, is_measurable (f b)) :
-  is_measurable (⋂ b, f b) :=
-is_measurable.Inter h
+lemma measurable_set.Inter_fintype [fintype β] {f : β → set α} (h : ∀ b, measurable_set (f b)) :
+  measurable_set (⋂ b, f b) :=
+measurable_set.Inter h
 
 end fintype
 
-lemma is_measurable.bInter {f : β → set α} {s : set β} (hs : countable s)
-  (h : ∀ b ∈ s, is_measurable (f b)) : is_measurable (⋂ b ∈ s, f b) :=
-is_measurable.compl_iff.1 $
-by { rw compl_bInter, exact is_measurable.bUnion hs (λ b hb, (h b hb).compl) }
+lemma measurable_set.bInter {f : β → set α} {s : set β} (hs : countable s)
+  (h : ∀ b ∈ s, measurable_set (f b)) : measurable_set (⋂ b ∈ s, f b) :=
+measurable_set.compl_iff.1 $
+by { rw compl_bInter, exact measurable_set.bUnion hs (λ b hb, (h b hb).compl) }
 
-lemma set.finite.is_measurable_bInter {f : β → set α} {s : set β} (hs : finite s)
-  (h : ∀ b ∈ s, is_measurable (f b)) : is_measurable (⋂ b ∈ s, f b) :=
-is_measurable.bInter hs.countable h
+lemma set.finite.measurable_set_bInter {f : β → set α} {s : set β} (hs : finite s)
+  (h : ∀ b ∈ s, measurable_set (f b)) : measurable_set (⋂ b ∈ s, f b) :=
+measurable_set.bInter hs.countable h
 
-lemma finset.is_measurable_bInter {f : β → set α} (s : finset β)
-  (h : ∀ b ∈ s, is_measurable (f b)) : is_measurable (⋂ b ∈ s, f b) :=
-s.finite_to_set.is_measurable_bInter h
+lemma finset.measurable_set_bInter {f : β → set α} (s : finset β)
+  (h : ∀ b ∈ s, measurable_set (f b)) : measurable_set (⋂ b ∈ s, f b) :=
+s.finite_to_set.measurable_set_bInter h
 
-lemma is_measurable.sInter {s : set (set α)} (hs : countable s) (h : ∀ t ∈ s, is_measurable t) :
-  is_measurable (⋂₀ s) :=
-by { rw sInter_eq_bInter, exact is_measurable.bInter hs h }
+lemma measurable_set.sInter {s : set (set α)} (hs : countable s) (h : ∀ t ∈ s, measurable_set t) :
+  measurable_set (⋂₀ s) :=
+by { rw sInter_eq_bInter, exact measurable_set.bInter hs h }
 
-lemma set.finite.is_measurable_sInter {s : set (set α)} (hs : finite s)
-  (h : ∀ t ∈ s, is_measurable t) : is_measurable (⋂₀ s) :=
-is_measurable.sInter hs.countable h
+lemma set.finite.measurable_set_sInter {s : set (set α)} (hs : finite s)
+  (h : ∀ t ∈ s, measurable_set t) : measurable_set (⋂₀ s) :=
+measurable_set.sInter hs.countable h
 
-lemma is_measurable.Inter_Prop {p : Prop} {f : p → set α} (hf : ∀ b, is_measurable (f b)) :
-  is_measurable (⋂ b, f b) :=
-by { by_cases p; simp [h, hf, is_measurable.univ] }
+lemma measurable_set.Inter_Prop {p : Prop} {f : p → set α} (hf : ∀ b, measurable_set (f b)) :
+  measurable_set (⋂ b, f b) :=
+by { by_cases p; simp [h, hf, measurable_set.univ] }
 
-@[simp] lemma is_measurable.union {s₁ s₂ : set α} (h₁ : is_measurable s₁) (h₂ : is_measurable s₂) :
-  is_measurable (s₁ ∪ s₂) :=
-by { rw union_eq_Union, exact is_measurable.Union (bool.forall_bool.2 ⟨h₂, h₁⟩) }
+@[simp] lemma measurable_set.union {s₁ s₂ : set α} (h₁ : measurable_set s₁)
+  (h₂ : measurable_set s₂) :
+  measurable_set (s₁ ∪ s₂) :=
+by { rw union_eq_Union, exact measurable_set.Union (bool.forall_bool.2 ⟨h₂, h₁⟩) }
 
-@[simp] lemma is_measurable.inter {s₁ s₂ : set α} (h₁ : is_measurable s₁) (h₂ : is_measurable s₂) :
-  is_measurable (s₁ ∩ s₂) :=
+@[simp] lemma measurable_set.inter {s₁ s₂ : set α} (h₁ : measurable_set s₁)
+  (h₂ : measurable_set s₂) :
+  measurable_set (s₁ ∩ s₂) :=
 by { rw inter_eq_compl_compl_union_compl, exact (h₁.compl.union h₂.compl).compl }
 
-@[simp] lemma is_measurable.diff {s₁ s₂ : set α} (h₁ : is_measurable s₁) (h₂ : is_measurable s₂) :
-  is_measurable (s₁ \ s₂) :=
+@[simp] lemma measurable_set.diff {s₁ s₂ : set α} (h₁ : measurable_set s₁)
+  (h₂ : measurable_set s₂) :
+  measurable_set (s₁ \ s₂) :=
 h₁.inter h₂.compl
 
-@[simp] lemma is_measurable.disjointed {f : ℕ → set α} (h : ∀ i, is_measurable (f i)) (n) :
-  is_measurable (disjointed f n) :=
-disjointed_induct (h n) (assume t i ht, is_measurable.diff ht $ h _)
+@[simp] lemma measurable_set.disjointed {f : ℕ → set α} (h : ∀ i, measurable_set (f i)) (n) :
+  measurable_set (disjointed f n) :=
+disjointed_induct (h n) (assume t i ht, measurable_set.diff ht $ h _)
 
-@[simp] lemma is_measurable.const (p : Prop) : is_measurable {a : α | p} :=
-by { by_cases p; simp [h, is_measurable.empty]; apply is_measurable.univ }
+@[simp] lemma measurable_set.const (p : Prop) : measurable_set {a : α | p} :=
+by { by_cases p; simp [h, measurable_set.empty]; apply measurable_set.univ }
 
 /-- Every set has a measurable superset. Declare this as local instance as needed. -/
-lemma nonempty_measurable_superset (s : set α) : nonempty { t // s ⊆ t ∧ is_measurable t} :=
-⟨⟨univ, subset_univ s, is_measurable.univ⟩⟩
+lemma nonempty_measurable_superset (s : set α) : nonempty { t // s ⊆ t ∧ measurable_set t} :=
+⟨⟨univ, subset_univ s, measurable_set.univ⟩⟩
 
 end
 
 @[ext] lemma measurable_space.ext : ∀ {m₁ m₂ : measurable_space α},
-  (∀ s : set α, m₁.is_measurable' s ↔ m₂.is_measurable' s) → m₁ = m₂
+  (∀ s : set α, m₁.measurable_set' s ↔ m₂.measurable_set' s) → m₁ = m₂
 | ⟨s₁, _, _, _⟩ ⟨s₂, _, _, _⟩ h :=
   have s₁ = s₂, from funext $ assume x, propext $ h x,
   by subst this
 
 @[ext] lemma measurable_space.ext_iff {m₁ m₂ : measurable_space α} :
-  m₁ = m₂ ↔ (∀ s : set α, m₁.is_measurable' s ↔ m₂.is_measurable' s) :=
+  m₁ = m₂ ↔ (∀ s : set α, m₁.measurable_set' s ↔ m₂.measurable_set' s) :=
 ⟨by { unfreezingI {rintro rfl}, intro s, refl }, measurable_space.ext⟩
 
 /-- A typeclass mixin for `measurable_space`s such that each singleton is measurable. -/
 class measurable_singleton_class (α : Type*) [measurable_space α] : Prop :=
-(is_measurable_singleton : ∀ x, is_measurable ({x} : set α))
+(measurable_set_singleton : ∀ x, measurable_set ({x} : set α))
 
-export measurable_singleton_class (is_measurable_singleton)
+export measurable_singleton_class (measurable_set_singleton)
 
-attribute [simp] is_measurable_singleton
+attribute [simp] measurable_set_singleton
 
 section measurable_singleton_class
 
 variables [measurable_space α] [measurable_singleton_class α]
 
-lemma is_measurable_eq {a : α} : is_measurable {x | x = a} :=
-is_measurable_singleton a
+lemma measurable_set_eq {a : α} : measurable_set {x | x = a} :=
+measurable_set_singleton a
 
-lemma is_measurable.insert {s : set α} (hs : is_measurable s) (a : α) :
-  is_measurable (insert a s) :=
-(is_measurable_singleton a).union hs
+lemma measurable_set.insert {s : set α} (hs : measurable_set s) (a : α) :
+  measurable_set (insert a s) :=
+(measurable_set_singleton a).union hs
 
-@[simp] lemma is_measurable_insert {a : α} {s : set α} :
-  is_measurable (insert a s) ↔ is_measurable s :=
+@[simp] lemma measurable_set_insert {a : α} {s : set α} :
+  measurable_set (insert a s) ↔ measurable_set s :=
 ⟨λ h, if ha : a ∈ s then by rwa ← insert_eq_of_mem ha
-  else insert_diff_self_of_not_mem ha ▸ h.diff (is_measurable_singleton _),
+  else insert_diff_self_of_not_mem ha ▸ h.diff (measurable_set_singleton _),
   λ h, h.insert a⟩
 
-lemma set.finite.is_measurable {s : set α} (hs : finite s) : is_measurable s :=
-finite.induction_on hs is_measurable.empty $ λ a s ha hsf hsm, hsm.insert _
+lemma set.finite.measurable_set {s : set α} (hs : finite s) : measurable_set s :=
+finite.induction_on hs measurable_set.empty $ λ a s ha hsf hsm, hsm.insert _
 
-protected lemma finset.is_measurable (s : finset α) : is_measurable (↑s : set α) :=
-s.finite_to_set.is_measurable
+protected lemma finset.measurable_set (s : finset α) : measurable_set (↑s : set α) :=
+s.finite_to_set.measurable_set
 
 end measurable_singleton_class
 
@@ -272,7 +276,7 @@ namespace measurable_space
 section complete_lattice
 
 instance : partial_order (measurable_space α) :=
-{ le          := λ m₁ m₂, m₁.is_measurable' ≤ m₂.is_measurable',
+{ le          := λ m₁ m₂, m₁.measurable_set' ≤ m₂.measurable_set',
   le_refl     := assume a b, le_refl _,
   le_trans    := assume a b c, le_trans,
   le_antisymm := assume a b h₁ h₂, measurable_space.ext $ assume s, ⟨h₁ s, h₂ s⟩ }
@@ -286,51 +290,51 @@ inductive generate_measurable (s : set (set α)) : set α → Prop
 
 /-- Construct the smallest measure space containing a collection of basic sets -/
 def generate_from (s : set (set α)) : measurable_space α :=
-{ is_measurable'      := generate_measurable s,
-  is_measurable_empty := generate_measurable.empty,
-  is_measurable_compl := generate_measurable.compl,
-  is_measurable_Union := generate_measurable.union }
+{ measurable_set'      := generate_measurable s,
+  measurable_set_empty := generate_measurable.empty,
+  measurable_set_compl := generate_measurable.compl,
+  measurable_set_Union := generate_measurable.union }
 
-lemma is_measurable_generate_from {s : set (set α)} {t : set α} (ht : t ∈ s) :
-  (generate_from s).is_measurable' t :=
+lemma measurable_set_generate_from {s : set (set α)} {t : set α} (ht : t ∈ s) :
+  (generate_from s).measurable_set' t :=
 generate_measurable.basic t ht
 
 lemma generate_from_le {s : set (set α)} {m : measurable_space α}
-  (h : ∀ t ∈ s, m.is_measurable' t) : generate_from s ≤ m :=
+  (h : ∀ t ∈ s, m.measurable_set' t) : generate_from s ≤ m :=
 assume t (ht : generate_measurable s t), ht.rec_on h
-  (is_measurable_empty m)
-  (assume s _ hs, is_measurable_compl m s hs)
-  (assume f _ hf, is_measurable_Union m f hf)
+  (measurable_set_empty m)
+  (assume s _ hs, measurable_set_compl m s hs)
+  (assume f _ hf, measurable_set_Union m f hf)
 
 lemma generate_from_le_iff {s : set (set α)} (m : measurable_space α) :
-  generate_from s ≤ m ↔ s ⊆ {t | m.is_measurable' t} :=
+  generate_from s ≤ m ↔ s ⊆ {t | m.measurable_set' t} :=
 iff.intro
-  (assume h u hu, h _ $ is_measurable_generate_from hu)
+  (assume h u hu, h _ $ measurable_set_generate_from hu)
   (assume h, generate_from_le h)
 
-@[simp] lemma generate_from_is_measurable [measurable_space α] :
-  generate_from {s : set α | is_measurable s} = ‹_› :=
-le_antisymm (generate_from_le $ λ _, id) $ λ s, is_measurable_generate_from
+@[simp] lemma generate_from_measurable_set [measurable_space α] :
+  generate_from {s : set α | measurable_set s} = ‹_› :=
+le_antisymm (generate_from_le $ λ _, id) $ λ s, measurable_set_generate_from
 
 /-- If `g` is a collection of subsets of `α` such that the `σ`-algebra generated from `g` contains
 the same sets as `g`, then `g` was already a `σ`-algebra. -/
-protected def mk_of_closure (g : set (set α)) (hg : {t | (generate_from g).is_measurable' t} = g) :
+protected def mk_of_closure (g : set (set α)) (hg : {t | (generate_from g).measurable_set' t} = g) :
   measurable_space α :=
-{ is_measurable'      := λ s, s ∈ g,
-  is_measurable_empty := hg ▸ is_measurable_empty _,
-  is_measurable_compl := hg ▸ is_measurable_compl _,
-  is_measurable_Union := hg ▸ is_measurable_Union _ }
+{ measurable_set'      := λ s, s ∈ g,
+  measurable_set_empty := hg ▸ measurable_set_empty _,
+  measurable_set_compl := hg ▸ measurable_set_compl _,
+  measurable_set_Union := hg ▸ measurable_set_Union _ }
 
 lemma mk_of_closure_sets {s : set (set α)}
-  {hs : {t | (generate_from s).is_measurable' t} = s} :
+  {hs : {t | (generate_from s).measurable_set' t} = s} :
   measurable_space.mk_of_closure s hs = generate_from s :=
 measurable_space.ext $ assume t, show t ∈ s ↔ _, by { conv_lhs { rw [← hs] }, refl }
 
 /-- We get a Galois insertion between `σ`-algebras on `α` and `set (set α)` by using `generate_from`
   on one side and the collection of measurable sets on the other side. -/
-def gi_generate_from : galois_insertion (@generate_from α) (λ m, {t | @is_measurable α m t}) :=
+def gi_generate_from : galois_insertion (@generate_from α) (λ m, {t | @measurable_set α m t}) :=
 { gc        := assume s, generate_from_le_iff,
-  le_l_u    := assume m s, is_measurable_generate_from,
+  le_l_u    := assume m s, measurable_set_generate_from,
   choice    :=
     λ g hg, measurable_space.mk_of_closure g $ le_antisymm hg $ (generate_from_le_iff _).1 le_rfl,
   choice_eq := assume g hg, mk_of_closure_sets }
@@ -340,12 +344,12 @@ gi_generate_from.lift_complete_lattice
 
 instance : inhabited (measurable_space α) := ⟨⊤⟩
 
-lemma is_measurable_bot_iff {s : set α} : @is_measurable α ⊥ s ↔ (s = ∅ ∨ s = univ) :=
+lemma measurable_set_bot_iff {s : set α} : @measurable_set α ⊥ s ↔ (s = ∅ ∨ s = univ) :=
 let b : measurable_space α :=
-{ is_measurable'      := λ s, s = ∅ ∨ s = univ,
-  is_measurable_empty := or.inl rfl,
-  is_measurable_compl := by simp [or_imp_distrib] {contextual := tt},
-  is_measurable_Union := assume f hf, classical.by_cases
+{ measurable_set'      := λ s, s = ∅ ∨ s = univ,
+  measurable_set_empty := or.inl rfl,
+  measurable_set_compl := by simp [or_imp_distrib] {contextual := tt},
+  measurable_set_Union := assume f hf, classical.by_cases
     (assume h : ∃i, f i = univ,
       let ⟨i, hi⟩ := h in
       or.inr $ eq_univ_of_univ_subset $ hi ▸ le_supr f i)
@@ -353,40 +357,41 @@ let b : measurable_space α :=
       or.inl $ eq_empty_of_subset_empty $ Union_subset $ assume i,
         (hf i).elim (by simp {contextual := tt}) (assume hi, false.elim $ h ⟨i, hi⟩)) } in
 have b = ⊥, from bot_unique $ assume s hs,
-  hs.elim (λ s, s.symm ▸ @is_measurable_empty _ ⊥) (λ s, s.symm ▸ @is_measurable.univ _ ⊥),
+  hs.elim (λ s, s.symm ▸ @measurable_set_empty _ ⊥) (λ s, s.symm ▸ @measurable_set.univ _ ⊥),
 this ▸ iff.rfl
 
-@[simp] theorem is_measurable_top {s : set α} : @is_measurable _ ⊤ s := trivial
+@[simp] theorem measurable_set_top {s : set α} : @measurable_set _ ⊤ s := trivial
 
-@[simp] theorem is_measurable_inf {m₁ m₂ : measurable_space α} {s : set α} :
-  @is_measurable _ (m₁ ⊓ m₂) s ↔ @is_measurable _ m₁ s ∧ @is_measurable _ m₂ s :=
+@[simp] theorem measurable_set_inf {m₁ m₂ : measurable_space α} {s : set α} :
+  @measurable_set _ (m₁ ⊓ m₂) s ↔ @measurable_set _ m₁ s ∧ @measurable_set _ m₂ s :=
 iff.rfl
 
-@[simp] theorem is_measurable_Inf {ms : set (measurable_space α)} {s : set α} :
-  @is_measurable _ (Inf ms) s ↔ ∀ m ∈ ms, @is_measurable _ m s :=
-show s ∈ (⋂ m ∈ ms, {t | @is_measurable _ m t }) ↔ _, by simp
+@[simp] theorem measurable_set_Inf {ms : set (measurable_space α)} {s : set α} :
+  @measurable_set _ (Inf ms) s ↔ ∀ m ∈ ms, @measurable_set _ m s :=
+show s ∈ (⋂ m ∈ ms, {t | @measurable_set _ m t }) ↔ _, by simp
 
-@[simp] theorem is_measurable_infi {ι} {m : ι → measurable_space α} {s : set α} :
-  @is_measurable _ (infi m) s ↔ ∀ i, @is_measurable _ (m i) s :=
-show s ∈ (λ m, {s | @is_measurable _ m s }) (infi m) ↔ _,
+@[simp] theorem measurable_set_infi {ι} {m : ι → measurable_space α} {s : set α} :
+  @measurable_set _ (infi m) s ↔ ∀ i, @measurable_set _ (m i) s :=
+show s ∈ (λ m, {s | @measurable_set _ m s }) (infi m) ↔ _,
 by { rw (@gi_generate_from α).gc.u_infi, simp }
 
-theorem is_measurable_sup {m₁ m₂ : measurable_space α} {s : set α} :
-  @is_measurable _ (m₁ ⊔ m₂) s ↔ generate_measurable (m₁.is_measurable' ∪ m₂.is_measurable') s :=
+theorem measurable_set_sup {m₁ m₂ : measurable_space α} {s : set α} :
+  @measurable_set _ (m₁ ⊔ m₂) s ↔ generate_measurable (m₁.measurable_set' ∪ m₂.measurable_set') s :=
 iff.refl _
 
-theorem is_measurable_Sup {ms : set (measurable_space α)} {s : set α} :
-  @is_measurable _ (Sup ms) s ↔
-    generate_measurable {s : set α | ∃ m ∈ ms, @is_measurable _ m s} s :=
+theorem measurable_set_Sup {ms : set (measurable_space α)} {s : set α} :
+  @measurable_set _ (Sup ms) s ↔
+    generate_measurable {s : set α | ∃ m ∈ ms, @measurable_set _ m s} s :=
 begin
-  change @is_measurable' _ (generate_from $ ⋃ m ∈ ms, _) _ ↔ _,
+  change @measurable_set' _ (generate_from $ ⋃ m ∈ ms, _) _ ↔ _,
   simp [generate_from, ← set_of_exists]
 end
 
-theorem is_measurable_supr {ι} {m : ι → measurable_space α} {s : set α} :
-  @is_measurable _ (supr m) s ↔ generate_measurable {s : set α | ∃ i, @is_measurable _ (m i) s} s :=
+theorem measurable_set_supr {ι} {m : ι → measurable_space α} {s : set α} :
+  @measurable_set _ (supr m) s ↔
+    generate_measurable {s : set α | ∃ i, @measurable_set _ (m i) s} s :=
 begin
-  convert @is_measurable_Sup _ (range m) s,
+  convert @measurable_set_Sup _ (range m) s,
   simp,
 end
 
@@ -398,10 +403,10 @@ variables {m m₁ m₂ : measurable_space α} {m' : measurable_space β} {f : α
 /-- The forward image of a measure space under a function. `map f m` contains the sets `s : set β`
   whose preimage under `f` is measurable. -/
 protected def map (f : α → β) (m : measurable_space α) : measurable_space β :=
-{ is_measurable'      := λ s, m.is_measurable' $ f ⁻¹' s,
-  is_measurable_empty := m.is_measurable_empty,
-  is_measurable_compl := assume s hs, m.is_measurable_compl _ hs,
-  is_measurable_Union := assume f hf, by { rw [preimage_Union], exact m.is_measurable_Union _ hf }}
+{ measurable_set'      := λ s, m.measurable_set' $ f ⁻¹' s,
+  measurable_set_empty := m.measurable_set_empty,
+  measurable_set_compl := assume s hs, m.measurable_set_compl _ hs,
+  measurable_set_Union := assume f hf, by { rw preimage_Union, exact m.measurable_set_Union _ hf }}
 
 @[simp] lemma map_id : m.map id = m :=
 measurable_space.ext $ assume s, iff.rfl
@@ -412,12 +417,12 @@ measurable_space.ext $ assume s, iff.rfl
 /-- The reverse image of a measure space under a function. `comap f m` contains the sets `s : set α`
   such that `s` is the `f`-preimage of a measurable set in `β`. -/
 protected def comap (f : α → β) (m : measurable_space β) : measurable_space α :=
-{ is_measurable'      := λ s, ∃s', m.is_measurable' s' ∧ f ⁻¹' s' = s,
-  is_measurable_empty := ⟨∅, m.is_measurable_empty, rfl⟩,
-  is_measurable_compl := assume s ⟨s', h₁, h₂⟩, ⟨s'ᶜ, m.is_measurable_compl _ h₁, h₂ ▸ rfl⟩,
-  is_measurable_Union := assume s hs,
+{ measurable_set'      := λ s, ∃s', m.measurable_set' s' ∧ f ⁻¹' s' = s,
+  measurable_set_empty := ⟨∅, m.measurable_set_empty, rfl⟩,
+  measurable_set_compl := assume s ⟨s', h₁, h₂⟩, ⟨s'ᶜ, m.measurable_set_compl _ h₁, h₂ ▸ rfl⟩,
+  measurable_set_Union := assume s hs,
     let ⟨s', hs'⟩ := classical.axiom_of_choice hs in
-    ⟨⋃ i, s' i, m.is_measurable_Union _ (λ i, (hs' i).left), by simp [hs'] ⟩ }
+    ⟨⋃ i, s' i, m.measurable_set_Union _ (λ i, (hs' i).left), by simp [hs'] ⟩ }
 
 @[simp] lemma comap_id : m.comap id = m :=
 measurable_space.ext $ assume s, ⟨assume ⟨s', hs', h⟩, h ▸ hs', assume h, ⟨s, h, rfl⟩⟩
@@ -476,7 +481,7 @@ open measurable_space
 /-- A function `f` between measurable spaces is measurable if the preimage of every
   measurable set is measurable. -/
 def measurable [measurable_space α] [measurable_space β] (f : α → β) : Prop :=
-∀ ⦃t : set β⦄, is_measurable t → is_measurable (f ⁻¹' t)
+∀ ⦃t : set β⦄, measurable_set t → measurable_set (f ⁻¹' t)
 
 lemma measurable_iff_le_map {m₁ : measurable_space α} {m₂ : measurable_space β} {f : α → β} :
   measurable f ↔ m₂ ≤ m₁.map f :=
@@ -499,7 +504,7 @@ lemma measurable_from_top [measurable_space β] {f : α → β} : @measurable _ 
 λ s hs, trivial
 
 lemma measurable_generate_from [measurable_space α] {s : set (set β)} {f : α → β}
-  (h : ∀ t ∈ s, is_measurable (f ⁻¹' t)) : @measurable _ _ _ (generate_from s) f :=
+  (h : ∀ t ∈ s, measurable_set (f ⁻¹' t)) : @measurable _ _ _ (generate_from s) f :=
 measurable.of_le_map $ generate_from_le h
 
 variables [measurable_space α] [measurable_space β] [measurable_space γ]
@@ -511,10 +516,10 @@ lemma measurable.comp {g : β → γ} {f : α → β} (hg : measurable g) (hf : 
 λ t ht, hf (hg ht)
 
 @[nontriviality] lemma subsingleton.measurable [subsingleton α] {f : α → β} : measurable f :=
-λ s hs, @subsingleton.is_measurable α _ _ _
+λ s hs, @subsingleton.measurable_set α _ _ _
 
 lemma measurable.piecewise {s : set α} {_ : decidable_pred s} {f g : α → β}
-  (hs : is_measurable s) (hf : measurable f) (hg : measurable g) :
+  (hs : measurable_set s) (hf : measurable f) (hg : measurable g) :
   measurable (piecewise s f g) :=
 begin
   intros t ht,
@@ -524,18 +529,18 @@ end
 
 /-- this is slightly different from `measurable.piecewise`. It can be used to show
 `measurable (ite (x=0) 0 1)` by
-`exact measurable.ite (is_measurable_singleton 0) measurable_const measurable_const`,
+`exact measurable.ite (measurable_set_singleton 0) measurable_const measurable_const`,
 but replacing `measurable.ite` by `measurable.piecewise` in that example proof does not work. -/
 lemma measurable.ite {p : α → Prop} {_ : decidable_pred p} {f g : α → β}
-  (hp : is_measurable {a : α | p a}) (hf : measurable f) (hg : measurable g) :
+  (hp : measurable_set {a : α | p a}) (hf : measurable f) (hg : measurable g) :
   measurable (λ x, ite (p x) (f x) (g x)) :=
 measurable.piecewise hp hf hg
 
 @[simp] lemma measurable_const {a : α} : measurable (λ b : β, a) :=
-assume s hs, is_measurable.const (a ∈ s)
+assume s hs, measurable_set.const (a ∈ s)
 
 lemma measurable.indicator [has_zero β] {s : set α} {f : α → β}
-  (hf : measurable f) (hs : is_measurable s) : measurable (s.indicator f) :=
+  (hf : measurable f) (hs : measurable_set s) : measurable (s.indicator f) :=
 hf.piecewise hs measurable_const
 
 @[to_additive]
@@ -544,7 +549,7 @@ lemma measurable_one [has_one α] : measurable (1 : β → α) := @measurable_co
 lemma measurable_of_not_nonempty  (h : ¬ nonempty α) (f : α → β) : measurable f :=
 begin
   assume s hs,
-  convert is_measurable.empty,
+  convert measurable_set.empty,
   exact eq_empty_of_not_nonempty h _,
 end
 
@@ -561,16 +566,16 @@ instance : measurable_space ℕ := ⊤
 instance : measurable_space ℤ := ⊤
 instance : measurable_space ℚ := ⊤
 
-lemma measurable_to_encodable [encodable α] {f : β → α} (h : ∀ y, is_measurable (f ⁻¹' {f y})) :
+lemma measurable_to_encodable [encodable α] {f : β → α} (h : ∀ y, measurable_set (f ⁻¹' {f y})) :
   measurable f :=
 begin
   assume s hs,
   rw [← bUnion_preimage_singleton],
-  refine is_measurable.Union (λ y, is_measurable.Union_Prop $ λ hy, _),
+  refine measurable_set.Union (λ y, measurable_set.Union_Prop $ λ hy, _),
   by_cases hyf : y ∈ range f,
   { rcases hyf with ⟨y, rfl⟩,
     apply h },
-  { simp only [preimage_singleton_eq_empty.2 hyf, is_measurable.empty] }
+  { simp only [preimage_singleton_eq_empty.2 hyf, measurable_set.empty] }
 end
 
 lemma measurable_unit (f : unit → α) : measurable f :=
@@ -581,32 +586,32 @@ section nat
 lemma measurable_from_nat {f : ℕ → α} : measurable f :=
 measurable_from_top
 
-lemma measurable_to_nat {f : α → ℕ} : (∀ y, is_measurable (f ⁻¹' {f y})) → measurable f :=
+lemma measurable_to_nat {f : α → ℕ} : (∀ y, measurable_set (f ⁻¹' {f y})) → measurable f :=
 measurable_to_encodable
 
 lemma measurable_find_greatest' {p : α → ℕ → Prop}
-  {N} (hN : ∀ k ≤ N, is_measurable {x | nat.find_greatest (p x) N = k}) :
+  {N} (hN : ∀ k ≤ N, measurable_set {x | nat.find_greatest (p x) N = k}) :
   measurable (λ x, nat.find_greatest (p x) N) :=
 measurable_to_nat $ λ x, hN _ nat.find_greatest_le
 
-lemma measurable_find_greatest {p : α → ℕ → Prop} {N} (hN : ∀ k ≤ N, is_measurable {x | p x k}) :
+lemma measurable_find_greatest {p : α → ℕ → Prop} {N} (hN : ∀ k ≤ N, measurable_set {x | p x k}) :
   measurable (λ x, nat.find_greatest (p x) N) :=
 begin
   refine measurable_find_greatest' (λ k hk, _),
   simp only [nat.find_greatest_eq_iff, set_of_and, set_of_forall, ← compl_set_of],
-  repeat { apply_rules [is_measurable.inter, is_measurable.const, is_measurable.Inter,
-    is_measurable.Inter_Prop, is_measurable.compl, hN]; try { intros } }
+  repeat { apply_rules [measurable_set.inter, measurable_set.const, measurable_set.Inter,
+    measurable_set.Inter_Prop, measurable_set.compl, hN]; try { intros } }
 end
 
 lemma measurable_find {p : α → ℕ → Prop} (hp : ∀ x, ∃ N, p x N)
-  (hm : ∀ k, is_measurable {x | p x k}) :
+  (hm : ∀ k, measurable_set {x | p x k}) :
   measurable (λ x, nat.find (hp x)) :=
 begin
   refine measurable_to_nat (λ x, _),
   simp only [set.preimage, mem_singleton_iff, nat.find_eq_iff, set_of_and, set_of_forall,
     ← compl_set_of],
-  repeat { apply_rules [is_measurable.inter, hm, is_measurable.Inter, is_measurable.Inter_Prop,
-    is_measurable.compl]; try { intros } }
+  repeat { apply_rules [measurable_set.inter, hm, measurable_set.Inter, measurable_set.Inter_Prop,
+    measurable_set.compl]; try { intros } }
 end
 
 end nat
@@ -627,16 +632,16 @@ lemma measurable.subtype_mk {p : β → Prop} {f : α → β} (hf : measurable f
   measurable (λ x, (⟨f x, h x⟩ : subtype p)) :=
 λ t ⟨s, hs⟩, hs.2 ▸ by simp only [← preimage_comp, (∘), subtype.coe_mk, hf hs.1]
 
-lemma is_measurable.subtype_image {s : set α} {t : set s}
-  (hs : is_measurable s) : is_measurable t → is_measurable ((coe : s → α) '' t)
-| ⟨u, (hu : is_measurable u), (eq : coe ⁻¹' u = t)⟩ :=
+lemma measurable_set.subtype_image {s : set α} {t : set s}
+  (hs : measurable_set s) : measurable_set t → measurable_set ((coe : s → α) '' t)
+| ⟨u, (hu : measurable_set u), (eq : coe ⁻¹' u = t)⟩ :=
   begin
     rw [← eq, subtype.image_preimage_coe],
     exact hu.inter hs
   end
 
 lemma measurable_of_measurable_union_cover
-  {f : α → β} (s t : set α) (hs : is_measurable s) (ht : is_measurable t) (h : univ ⊆ s ∪ t)
+  {f : α → β} (s t : set α) (hs : measurable_set s) (ht : measurable_set t) (h : univ ⊆ s ∪ t)
   (hc : measurable (λ a : s, f a)) (hd : measurable (λ a : t, f a)) :
   measurable f :=
 begin
@@ -650,7 +655,7 @@ end
 lemma measurable_of_measurable_on_compl_singleton [measurable_singleton_class α]
   {f : α → β} (a : α) (hf : measurable (set.restrict f {x | x ≠ a})) :
   measurable f :=
-measurable_of_measurable_union_cover _ _ is_measurable_eq is_measurable_eq.compl
+measurable_of_measurable_union_cover _ _ measurable_set_eq measurable_set_eq.compl
   (λ x hx, classical.em _)
   (@subsingleton.measurable {x | x = a} _ _ _ ⟨λ x y, subtype.eq $ x.2.trans y.2.symm⟩ _) hf
 
@@ -707,30 +712,30 @@ measurable.prod measurable_snd measurable_fst
 lemma measurable_swap_iff {f : α × β → γ} : measurable (f ∘ prod.swap) ↔ measurable f :=
 ⟨λ hf, by { convert hf.comp measurable_swap, ext ⟨x, y⟩, refl }, λ hf, hf.comp measurable_swap⟩
 
-lemma is_measurable.prod {s : set α} {t : set β} (hs : is_measurable s) (ht : is_measurable t) :
-  is_measurable (s.prod t) :=
-is_measurable.inter (measurable_fst hs) (measurable_snd ht)
+lemma measurable_set.prod {s : set α} {t : set β} (hs : measurable_set s) (ht : measurable_set t) :
+  measurable_set (s.prod t) :=
+measurable_set.inter (measurable_fst hs) (measurable_snd ht)
 
-lemma is_measurable_prod_of_nonempty {s : set α} {t : set β} (h : (s.prod t).nonempty) :
-  is_measurable (s.prod t) ↔ is_measurable s ∧ is_measurable t :=
+lemma measurable_set_prod_of_nonempty {s : set α} {t : set β} (h : (s.prod t).nonempty) :
+  measurable_set (s.prod t) ↔ measurable_set s ∧ measurable_set t :=
 begin
   rcases h with ⟨⟨x, y⟩, hx, hy⟩,
   refine ⟨λ hst, _, λ h, h.1.prod h.2⟩,
-  have : is_measurable ((λ x, (x, y)) ⁻¹' s.prod t) := measurable_id.prod_mk measurable_const hst,
-  have : is_measurable (prod.mk x ⁻¹' s.prod t) := measurable_const.prod_mk measurable_id hst,
+  have : measurable_set ((λ x, (x, y)) ⁻¹' s.prod t) := measurable_id.prod_mk measurable_const hst,
+  have : measurable_set (prod.mk x ⁻¹' s.prod t) := measurable_const.prod_mk measurable_id hst,
   simp * at *
 end
 
-lemma is_measurable_prod {s : set α} {t : set β} :
-  is_measurable (s.prod t) ↔ (is_measurable s ∧ is_measurable t) ∨ s = ∅ ∨ t = ∅ :=
+lemma measurable_set_prod {s : set α} {t : set β} :
+  measurable_set (s.prod t) ↔ (measurable_set s ∧ measurable_set t) ∨ s = ∅ ∨ t = ∅ :=
 begin
   cases (s.prod t).eq_empty_or_nonempty with h h,
   { simp [h, prod_eq_empty_iff.mp h] },
-  { simp [←not_nonempty_iff_eq_empty, prod_nonempty_iff.mp h, is_measurable_prod_of_nonempty h] }
+  { simp [←not_nonempty_iff_eq_empty, prod_nonempty_iff.mp h, measurable_set_prod_of_nonempty h] }
 end
 
-lemma is_measurable_swap_iff {s : set (α × β)} :
-  is_measurable (prod.swap ⁻¹' s) ↔ is_measurable s :=
+lemma measurable_set_swap_iff {s : set (α × β)} :
+  measurable_set (prod.swap ⁻¹' s) ↔ measurable_set s :=
 ⟨λ hs, by { convert measurable_swap hs, ext ⟨x, y⟩, refl }, λ hs, measurable_swap hs⟩
 
 end prod
@@ -772,38 +777,38 @@ begin
 end
 
 /- Even though we cannot use projection notation, we still keep a dot to be consistent with similar
-  lemmas, like `is_measurable.prod`. -/
-lemma is_measurable.pi {s : set δ} {t : Π i : δ, set (π i)} (hs : countable s)
-  (ht : ∀ i ∈ s, is_measurable (t i)) :
-  is_measurable (s.pi t) :=
-by { rw [pi_def], exact is_measurable.bInter hs (λ i hi, measurable_pi_apply _ (ht i hi)) }
+  lemmas, like `measurable_set.prod`. -/
+lemma measurable_set.pi {s : set δ} {t : Π i : δ, set (π i)} (hs : countable s)
+  (ht : ∀ i ∈ s, measurable_set (t i)) :
+  measurable_set (s.pi t) :=
+by { rw [pi_def], exact measurable_set.bInter hs (λ i hi, measurable_pi_apply _ (ht i hi)) }
 
-lemma is_measurable.pi_univ [encodable δ] {t : Π i : δ, set (π i)}
-  (ht : ∀ i, is_measurable (t i)) : is_measurable (pi univ t) :=
-is_measurable.pi (countable_encodable _) (λ i _, ht i)
+lemma measurable_set.pi_univ [encodable δ] {t : Π i : δ, set (π i)}
+  (ht : ∀ i, measurable_set (t i)) : measurable_set (pi univ t) :=
+measurable_set.pi (countable_encodable _) (λ i _, ht i)
 
-lemma is_measurable_pi_of_nonempty {s : set δ} {t : Π i, set (π i)} (hs : countable s)
-  (h : (pi s t).nonempty) : is_measurable (pi s t) ↔ ∀ i ∈ s, is_measurable (t i) :=
+lemma measurable_set_pi_of_nonempty {s : set δ} {t : Π i, set (π i)} (hs : countable s)
+  (h : (pi s t).nonempty) : measurable_set (pi s t) ↔ ∀ i ∈ s, measurable_set (t i) :=
 begin
-  rcases h with ⟨f, hf⟩, refine ⟨λ hst i hi, _, is_measurable.pi hs⟩,
+  rcases h with ⟨f, hf⟩, refine ⟨λ hst i hi, _, measurable_set.pi hs⟩,
   convert measurable_update f hst, rw [update_preimage_pi hi], exact λ j hj _, hf j hj
 end
 
-lemma is_measurable_pi {s : set δ} {t : Π i, set (π i)} (hs : countable s) :
-  is_measurable (pi s t) ↔ (∀ i ∈ s, is_measurable (t i)) ∨ pi s t = ∅ :=
+lemma measurable_set_pi {s : set δ} {t : Π i, set (π i)} (hs : countable s) :
+  measurable_set (pi s t) ↔ (∀ i ∈ s, measurable_set (t i)) ∨ pi s t = ∅ :=
 begin
   cases (pi s t).eq_empty_or_nonempty with h h,
   { simp [h] },
-  { simp [is_measurable_pi_of_nonempty hs, h, ← not_nonempty_iff_eq_empty] }
+  { simp [measurable_set_pi_of_nonempty hs, h, ← not_nonempty_iff_eq_empty] }
 end
 
 section fintype
 
 local attribute [instance] fintype.encodable
 
-lemma is_measurable.pi_fintype [fintype δ] {s : set δ} {t : Π i, set (π i)}
-  (ht : ∀ i ∈ s, is_measurable (t i)) : is_measurable (pi s t) :=
-is_measurable.pi (countable_encodable _) ht
+lemma measurable_set.pi_fintype [fintype δ] {s : set δ} {t : Π i, set (π i)}
+  (ht : ∀ i ∈ s, measurable_set (t i)) : measurable_set (pi s t) :=
+measurable_set.pi (countable_encodable _) ht
 
 end fintype
 end pi
@@ -839,9 +844,9 @@ lemma measurable_tprod_elim' {l : list δ} (h : ∀ i, i ∈ l) :
   measurable (tprod.elim' h : tprod π l → Π i, π i) :=
 measurable_pi_lambda _ (λ i, measurable_tprod_elim (h i))
 
-lemma is_measurable.tprod (l : list δ) {s : ∀ i, set (π i)} (hs : ∀ i, is_measurable (s i)) :
-  is_measurable (set.tprod l s) :=
-by { induction l with i l ih, exact is_measurable.univ, exact (hs i).prod ih }
+lemma measurable_set.tprod (l : list δ) {s : ∀ i, set (π i)} (hs : ∀ i, measurable_set (s i)) :
+  measurable_set (set.tprod l s) :=
+by { induction l with i l ih, exact measurable_set.univ, exact (hs i).prod ih }
 
 end tprod
 
@@ -864,25 +869,25 @@ lemma measurable.sum_elim {f : α → γ} {g : β → γ} (hf : measurable f) (h
   measurable (sum.elim f g) :=
 measurable_sum hf hg
 
-lemma is_measurable.inl_image {s : set α} (hs : is_measurable s) :
-  is_measurable (sum.inl '' s : set (α ⊕ β)) :=
-⟨show is_measurable (sum.inl ⁻¹' _), by { rwa [preimage_image_eq], exact (λ a b, sum.inl.inj) },
+lemma measurable_set.inl_image {s : set α} (hs : measurable_set s) :
+  measurable_set (sum.inl '' s : set (α ⊕ β)) :=
+⟨show measurable_set (sum.inl ⁻¹' _), by { rwa [preimage_image_eq], exact (λ a b, sum.inl.inj) },
   have sum.inr ⁻¹' (sum.inl '' s : set (α ⊕ β)) = ∅ :=
     eq_empty_of_subset_empty $ assume x ⟨y, hy, eq⟩, by contradiction,
-  show is_measurable (sum.inr ⁻¹' _), by { rw [this], exact is_measurable.empty }⟩
+  show measurable_set (sum.inr ⁻¹' _), by { rw [this], exact measurable_set.empty }⟩
 
-lemma is_measurable_range_inl : is_measurable (range sum.inl : set (α ⊕ β)) :=
-by { rw [← image_univ], exact is_measurable.univ.inl_image }
+lemma measurable_set_range_inl : measurable_set (range sum.inl : set (α ⊕ β)) :=
+by { rw [← image_univ], exact measurable_set.univ.inl_image }
 
-lemma is_measurable_inr_image {s : set β} (hs : is_measurable s) :
-  is_measurable (sum.inr '' s : set (α ⊕ β)) :=
+lemma measurable_set_inr_image {s : set β} (hs : measurable_set s) :
+  measurable_set (sum.inr '' s : set (α ⊕ β)) :=
 ⟨ have sum.inl ⁻¹' (sum.inr '' s : set (α ⊕ β)) = ∅ :=
     eq_empty_of_subset_empty $ assume x ⟨y, hy, eq⟩, by contradiction,
-  show is_measurable (sum.inl ⁻¹' _), by { rw [this], exact is_measurable.empty },
-  show is_measurable (sum.inr ⁻¹' _), by { rwa [preimage_image_eq], exact λ a b, sum.inr.inj }⟩
+  show measurable_set (sum.inl ⁻¹' _), by { rw [this], exact measurable_set.empty },
+  show measurable_set (sum.inr ⁻¹' _), by { rwa [preimage_image_eq], exact λ a b, sum.inr.inj }⟩
 
-lemma is_measurable_range_inr : is_measurable (range sum.inr : set (α ⊕ β)) :=
-by { rw [← image_univ], exact is_measurable_inr_image is_measurable.univ }
+lemma measurable_set_range_inr : measurable_set (range sum.inr : set (α ⊕ β)) :=
+by { rw [← image_univ], exact measurable_set_inr_image measurable_set.univ }
 
 end sum
 
@@ -1015,7 +1020,7 @@ def set.singleton (a : α) : ({a} : set α) ≃ᵐ unit :=
 /-- A set is equivalent to its image under a function `f` as measurable spaces,
   if `f` is an injective measurable function that sends measurable sets to measurable sets. -/
 noncomputable def set.image (f : α → β) (s : set α) (hf : injective f)
-  (hfm : measurable f) (hfi : ∀ s, is_measurable s → is_measurable (f '' s)) : s ≃ᵐ (f '' s) :=
+  (hfm : measurable f) (hfi : ∀ s, measurable_set s → measurable_set (f '' s)) : s ≃ᵐ (f '' s) :=
 { to_equiv := equiv.set.image f s hf,
   measurable_to_fun  := (hfm.comp measurable_id.subtype_coe).subtype_mk,
   measurable_inv_fun :=
@@ -1027,7 +1032,7 @@ noncomputable def set.image (f : α → β) (s : set α) (hf : injective f)
 /-- The domain of `f` is equivalent to its range as measurable spaces,
   if `f` is an injective measurable function that sends measurable sets to measurable sets. -/
 noncomputable def set.range (f : α → β) (hf : injective f) (hfm : measurable f)
-  (hfi : ∀ s, is_measurable s → is_measurable (f '' s)) :
+  (hfi : ∀ s, measurable_set s → measurable_set (f '' s)) :
   α ≃ᵐ (range f) :=
 (measurable_equiv.set.univ _).symm.trans $
   (measurable_equiv.set.image f univ hf hfm hfi).trans $
@@ -1042,7 +1047,7 @@ def set.range_inl : (range sum.inl : set (α ⊕ β)) ≃ᵐ α :=
   inv_fun   := λ a, ⟨sum.inl a, a, rfl⟩,
   left_inv  := by { rintro ⟨ab, a, rfl⟩, refl },
   right_inv := assume a, rfl,
-  measurable_to_fun  := assume s (hs : is_measurable s),
+  measurable_to_fun  := assume s (hs : measurable_set s),
     begin
       refine ⟨_, hs.inl_image, set.ext _⟩,
       rintros ⟨ab, a, rfl⟩,
@@ -1059,9 +1064,9 @@ def set.range_inr : (range sum.inr : set (α ⊕ β)) ≃ᵐ β :=
   inv_fun   := λ b, ⟨sum.inr b, b, rfl⟩,
   left_inv  := by { rintro ⟨ab, b, rfl⟩, refl },
   right_inv := assume b, rfl,
-  measurable_to_fun  := assume s (hs : is_measurable s),
+  measurable_to_fun  := assume s (hs : measurable_set s),
     begin
-      refine ⟨_, is_measurable_inr_image hs, set.ext _⟩,
+      refine ⟨_, measurable_set_inr_image hs, set.ext _⟩,
       rintros ⟨ab, b, rfl⟩,
       simp [set.range_inr._match_1]
     end,
@@ -1076,8 +1081,8 @@ def sum_prod_distrib (α β γ) [measurable_space α] [measurable_space β] [mea
     refine measurable_of_measurable_union_cover
       ((range sum.inl).prod univ)
       ((range sum.inr).prod univ)
-      (is_measurable_range_inl.prod is_measurable.univ)
-      (is_measurable_range_inr.prod is_measurable.univ)
+      (measurable_set_range_inl.prod measurable_set.univ)
+      (measurable_set_range_inr.prod measurable_set.univ)
       (by { rintro ⟨a|b, c⟩; simp [set.prod_eq] })
       _
       _,
@@ -1136,8 +1141,8 @@ def is_pi_system {α} (C : set (set α)) : Prop :=
 
 namespace measurable_space
 
-lemma is_pi_system_is_measurable [measurable_space α] :
-  is_pi_system {s : set α | is_measurable s} :=
+lemma is_pi_system_measurable_set [measurable_space α] :
+  is_pi_system {s : set α | measurable_set s} :=
 λ s t hs ht _, hs.inter ht
 
 /-- A Dynkin system is a collection of subsets of a type `α` that contains the empty set,
@@ -1195,10 +1200,10 @@ instance : partial_order (dynkin_system α) :=
 
 /-- Every measurable space (σ-algebra) forms a Dynkin system -/
 def of_measurable_space (m : measurable_space α) : dynkin_system α :=
-{ has       := m.is_measurable',
-  has_empty := m.is_measurable_empty,
-  has_compl := m.is_measurable_compl,
-  has_Union_nat := assume f _ hf, m.is_measurable_Union f hf }
+{ has       := m.measurable_set',
+  has_empty := m.measurable_set_empty,
+  has_compl := m.measurable_set_compl,
+  has_Union_nat := assume f _ hf, m.measurable_set_Union f hf }
 
 lemma of_measurable_space_le_of_measurable_space_iff {m₁ m₂ : measurable_space α} :
   of_measurable_space m₁ ≤ of_measurable_space m₂ ↔ m₁ ≤ m₂ :=
@@ -1230,10 +1235,10 @@ instance : inhabited (dynkin_system α) := ⟨generate univ⟩
 /-- If a Dynkin system is closed under binary intersection, then it forms a `σ`-algebra. -/
 def to_measurable_space (h_inter : ∀ s₁ s₂, d.has s₁ → d.has s₂ → d.has (s₁ ∩ s₂)) :=
 { measurable_space .
-  is_measurable'      := d.has,
-  is_measurable_empty := d.has_empty,
-  is_measurable_compl := assume s h, d.has_compl h,
-  is_measurable_Union := assume f hf,
+  measurable_set'      := d.has,
+  measurable_set_empty := d.has_empty,
+  measurable_set_compl := assume s h, d.has_compl h,
+  measurable_set_Union := assume f hf,
     have ∀ n, d.has (disjointed f n),
       from assume n, disjointed_induct (hf n)
         (assume t i h, h_inter _ _ h $ d.has_compl $ hf i),
@@ -1268,8 +1273,8 @@ lemma generate_le {s : set (set α)} (h : ∀ t ∈ s, d.has t) : generate s ≤
   (assume f hd _ hf, d.has_Union hd hf)
 
 lemma generate_has_subset_generate_measurable {C : set (set α)} {s : set α}
-  (hs : (generate C).has s) : (generate_from C).is_measurable' s :=
-generate_le (of_measurable_space (generate_from C)) (λ t, is_measurable_generate_from) s hs
+  (hs : (generate C).has s) : (generate_from C).measurable_set' s :=
+generate_le (of_measurable_space (generate_from C)) (λ t, measurable_set_generate_from) s hs
 
 lemma generate_inter {s : set (set α)}
   (hs : is_pi_system s) {t₁ t₂ : set α}
@@ -1299,18 +1304,18 @@ le_antisymm
   (generate_from_le $ assume t ht, generate_has.basic t ht)
   (of_measurable_space_le_of_measurable_space_iff.mp $
     by { rw [of_measurable_space_to_measurable_space],
-    exact (generate_le _ $ assume t ht, is_measurable_generate_from ht) })
+    exact (generate_le _ $ assume t ht, measurable_set_generate_from ht) })
 
 end dynkin_system
 
 lemma induction_on_inter {C : set α → Prop} {s : set (set α)} [m : measurable_space α]
   (h_eq : m = generate_from s)
   (h_inter : is_pi_system s)
-  (h_empty : C ∅) (h_basic : ∀ t ∈ s, C t) (h_compl : ∀ t, is_measurable t → C t → C tᶜ)
+  (h_empty : C ∅) (h_basic : ∀ t ∈ s, C t) (h_compl : ∀ t, measurable_set t → C t → C tᶜ)
   (h_union : ∀ f : ℕ → set α, pairwise (disjoint on f) →
-    (∀ i, is_measurable (f i)) → (∀ i, C (f i)) → C (⋃ i, f i)) :
-  ∀ ⦃t⦄, is_measurable t → C t :=
-have eq : is_measurable = dynkin_system.generate_has s,
+    (∀ i, measurable_set (f i)) → (∀ i, C (f i)) → C (⋃ i, f i)) :
+  ∀ ⦃t⦄, measurable_set t → C t :=
+have eq : measurable_set = dynkin_system.generate_has s,
   by { rw [h_eq, dynkin_system.generate_from_eq h_inter], refl },
 assume t ht,
 have dynkin_system.generate_has s t, by rwa [eq] at ht,
@@ -1326,22 +1331,22 @@ variables [measurable_space α]
 
 /-- A filter `f` is measurably generates if each `s ∈ f` includes a measurable `t ∈ f`. -/
 class is_measurably_generated (f : filter α) : Prop :=
-(exists_measurable_subset : ∀ ⦃s⦄, s ∈ f → ∃ t ∈ f, is_measurable t ∧ t ⊆ s)
+(exists_measurable_subset : ∀ ⦃s⦄, s ∈ f → ∃ t ∈ f, measurable_set t ∧ t ⊆ s)
 
 instance is_measurably_generated_bot : is_measurably_generated (⊥ : filter α) :=
-⟨λ _ _, ⟨∅, mem_bot_sets, is_measurable.empty, empty_subset _⟩⟩
+⟨λ _ _, ⟨∅, mem_bot_sets, measurable_set.empty, empty_subset _⟩⟩
 
 instance is_measurably_generated_top : is_measurably_generated (⊤ : filter α) :=
-⟨λ s hs, ⟨univ, univ_mem_sets, is_measurable.univ, λ x _, hs x⟩⟩
+⟨λ s hs, ⟨univ, univ_mem_sets, measurable_set.univ, λ x _, hs x⟩⟩
 
 lemma eventually.exists_measurable_mem {f : filter α} [is_measurably_generated f]
   {p : α → Prop} (h : ∀ᶠ x in f, p x) :
-  ∃ s ∈ f, is_measurable s ∧ ∀ x ∈ s, p x :=
+  ∃ s ∈ f, measurable_set s ∧ ∀ x ∈ s, p x :=
 is_measurably_generated.exists_measurable_subset h
 
 lemma eventually.exists_measurable_mem_of_lift' {f : filter α} [is_measurably_generated f]
   {p : set α → Prop} (h : ∀ᶠ s in f.lift' powerset, p s) :
-  ∃ s ∈ f, is_measurable s ∧ p s :=
+  ∃ s ∈ f, measurable_set s ∧ p s :=
 let ⟨s, hsf, hs⟩ := eventually_lift'_powerset.1 h,
   ⟨t, htf, htm, hts⟩ := is_measurably_generated.exists_measurable_subset hsf
 in ⟨t, htf, htm, hs t hts⟩
@@ -1359,7 +1364,7 @@ begin
 end
 
 lemma principal_is_measurably_generated_iff {s : set α} :
-  is_measurably_generated (𝓟 s) ↔ is_measurable s :=
+  is_measurably_generated (𝓟 s) ↔ measurable_set s :=
 begin
   refine ⟨_, λ hs, ⟨λ t ht, ⟨s, mem_principal_self s, hs, ht⟩⟩⟩,
   rintros ⟨hs⟩,
@@ -1369,7 +1374,7 @@ begin
 end
 
 alias principal_is_measurably_generated_iff ↔
-  _ is_measurable.principal_is_measurably_generated
+  _ measurable_set.principal_is_measurably_generated
 
 instance infi_is_measurably_generated {f : ι → filter α} [∀ i, is_measurably_generated (f i)] :
   is_measurably_generated (⨅ i, f i) :=
@@ -1382,7 +1387,7 @@ begin
   { rw [← equiv.plift.surjective.infi_comp, mem_infi_iff],
     refine ⟨t, ht, U, hUf, subset.refl _⟩ },
   { haveI := ht.countable.to_encodable,
-    refine is_measurable.Inter (λ i, (hU i).1) },
+    refine measurable_set.Inter (λ i, (hU i).1) },
   { exact subset.trans (Inter_subset_Inter $ λ i, (hU i).2) hVs }
 end
 
@@ -1395,6 +1400,6 @@ end filter
 def is_countably_spanning (C : set (set α)) : Prop :=
 ∃ (s : ℕ → set α), (∀ n, s n ∈ C) ∧ (⋃ n, s n) = univ
 
-lemma is_countably_spanning_is_measurable [measurable_space α] :
-  is_countably_spanning {s : set α | is_measurable s} :=
-⟨λ _, univ, λ _, is_measurable.univ, Union_const _⟩
+lemma is_countably_spanning_measurable_set [measurable_space α] :
+  is_countably_spanning {s : set α | measurable_set s} :=
+⟨λ _, univ, λ _, measurable_set.univ, Union_const _⟩

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -96,7 +96,7 @@ measurable sets, with the additional assumption that the outer measure is the ca
 extension of the restricted measure. -/
 structure measure (α : Type*) [measurable_space α] extends outer_measure α :=
 (m_Union ⦃f : ℕ → set α⦄ :
-  (∀ i, is_measurable (f i)) → pairwise (disjoint on f) →
+  (∀ i, measurable_set (f i)) → pairwise (disjoint on f) →
   measure_of (⋃ i, f i) = ∑' i, measure_of (f i))
 (trimmed : to_outer_measure.trim = to_outer_measure)
 
@@ -118,10 +118,10 @@ namespace measure
 /-! ### General facts about measures -/
 
 /-- Obtain a measure by giving a countably additive function that sends `∅` to `0`. -/
-def of_measurable (m : Π (s : set α), is_measurable s → ennreal)
-  (m0 : m ∅ is_measurable.empty = 0)
-  (mU : ∀ {{f : ℕ → set α}} (h : ∀ i, is_measurable (f i)), pairwise (disjoint on f) →
-    m (⋃ i, f i) (is_measurable.Union h) = ∑' i, m (f i) (h i)) : measure α :=
+def of_measurable (m : Π (s : set α), measurable_set s → ennreal)
+  (m0 : m ∅ measurable_set.empty = 0)
+  (mU : ∀ {{f : ℕ → set α}} (h : ∀ i, measurable_set (f i)), pairwise (disjoint on f) →
+    m (⋃ i, f i) (measurable_set.Union h) = ∑' i, m (f i) (h i)) : measure α :=
 { m_Union := λ f hf hd,
   show induced_outer_measure m _ m0 (Union f) =
       ∑' i, induced_outer_measure m _ m0 (f i), begin
@@ -136,20 +136,20 @@ def of_measurable (m : Π (s : set α), is_measurable s → ennreal)
   end,
   ..induced_outer_measure m _ m0 }
 
-lemma of_measurable_apply {m : Π (s : set α), is_measurable s → ennreal}
-  {m0 : m ∅ is_measurable.empty = 0}
-  {mU : ∀ {{f : ℕ → set α}} (h : ∀ i, is_measurable (f i)), pairwise (disjoint on f) →
-    m (⋃ i, f i) (is_measurable.Union h) = ∑' i, m (f i) (h i)}
-  (s : set α) (hs : is_measurable s) : of_measurable m m0 mU s = m s hs :=
+lemma of_measurable_apply {m : Π (s : set α), measurable_set s → ennreal}
+  {m0 : m ∅ measurable_set.empty = 0}
+  {mU : ∀ {{f : ℕ → set α}} (h : ∀ i, measurable_set (f i)), pairwise (disjoint on f) →
+    m (⋃ i, f i) (measurable_set.Union h) = ∑' i, m (f i) (h i)}
+  (s : set α) (hs : measurable_set s) : of_measurable m m0 mU s = m s hs :=
 induced_outer_measure_eq m0 mU hs
 
 lemma to_outer_measure_injective : injective (to_outer_measure : measure α → outer_measure α) :=
 λ ⟨m₁, u₁, h₁⟩ ⟨m₂, u₂, h₂⟩ h, by { congr, exact h }
 
-@[ext] lemma ext (h : ∀ s, is_measurable s → μ₁ s = μ₂ s) : μ₁ = μ₂ :=
+@[ext] lemma ext (h : ∀ s, measurable_set s → μ₁ s = μ₂ s) : μ₁ = μ₂ :=
 to_outer_measure_injective $ by rw [← trimmed, outer_measure.trim_congr h, trimmed]
 
-lemma ext_iff : μ₁ = μ₂ ↔ ∀ s, is_measurable s → μ₁ s = μ₂ s :=
+lemma ext_iff : μ₁ = μ₂ ↔ ∀ s, measurable_set s → μ₁ s = μ₂ s :=
 ⟨by { rintro rfl s hs, refl }, measure.ext⟩
 
 end measure
@@ -161,26 +161,26 @@ lemma to_outer_measure_apply (s : set α) : μ.to_outer_measure s = μ s := rfl
 lemma measure_eq_trim (s : set α) : μ s = μ.to_outer_measure.trim s :=
 by rw μ.trimmed; refl
 
-lemma measure_eq_infi (s : set α) : μ s = ⨅ t (st : s ⊆ t) (ht : is_measurable t), μ t :=
+lemma measure_eq_infi (s : set α) : μ s = ⨅ t (st : s ⊆ t) (ht : measurable_set t), μ t :=
 by rw [measure_eq_trim, outer_measure.trim_eq_infi]; refl
 
 /-- A variant of `measure_eq_infi` which has a single `infi`. This is useful when applying a
   lemma next that only works for non-empty infima, in which case you can use
   `nonempty_measurable_superset`. -/
 lemma measure_eq_infi' (μ : measure α) (s : set α) :
-  μ s = ⨅ t : { t // s ⊆ t ∧ is_measurable t}, μ t :=
+  μ s = ⨅ t : { t // s ⊆ t ∧ measurable_set t}, μ t :=
 by simp_rw [infi_subtype, infi_and, subtype.coe_mk, ← measure_eq_infi]
 
 lemma measure_eq_induced_outer_measure :
-  μ s = induced_outer_measure (λ s _, μ s) is_measurable.empty μ.empty s :=
+  μ s = induced_outer_measure (λ s _, μ s) measurable_set.empty μ.empty s :=
 measure_eq_trim _
 
 lemma to_outer_measure_eq_induced_outer_measure :
-  μ.to_outer_measure = induced_outer_measure (λ s _, μ s) is_measurable.empty μ.empty :=
+  μ.to_outer_measure = induced_outer_measure (λ s _, μ s) measurable_set.empty μ.empty :=
 μ.trimmed.symm
 
-lemma measure_eq_extend (hs : is_measurable s) :
-  μ s = extend (λ t (ht : is_measurable t), μ t) s :=
+lemma measure_eq_extend (hs : measurable_set s) :
+  μ s = extend (λ t (ht : measurable_set t), μ t) s :=
 by { rw [measure_eq_induced_outer_measure, induced_outer_measure_eq_extend _ _ hs],
   exact μ.m_Union }
 
@@ -197,31 +197,31 @@ nonpos_iff_eq_zero.1 $ h₂ ▸ measure_mono h
 lemma measure_mono_top (h : s₁ ⊆ s₂) (h₁ : μ s₁ = ⊤) : μ s₂ = ⊤ :=
 top_unique $ h₁ ▸ measure_mono h
 
-lemma exists_is_measurable_superset (μ : measure α) (s : set α) :
-  ∃ t, s ⊆ t ∧ is_measurable t ∧ μ t = μ s :=
-by simpa only [← measure_eq_trim] using μ.to_outer_measure.exists_is_measurable_superset_eq_trim s
+lemma exists_measurable_set_superset (μ : measure α) (s : set α) :
+  ∃ t, s ⊆ t ∧ measurable_set t ∧ μ t = μ s :=
+by simpa only [← measure_eq_trim] using μ.to_outer_measure.exists_measurable_set_superset_eq_trim s
 
 /-- A measurable set `t ⊇ s` such that `μ t = μ s`. -/
 def to_measurable (μ : measure α) (s : set α) : set α :=
-classical.some (exists_is_measurable_superset μ s)
+classical.some (exists_measurable_set_superset μ s)
 
 lemma subset_to_measurable (μ : measure α) (s : set α) : s ⊆ to_measurable μ s :=
-(classical.some_spec (exists_is_measurable_superset μ s)).1
+(classical.some_spec (exists_measurable_set_superset μ s)).1
 
-@[simp] lemma is_measurable_to_measurable (μ : measure α) (s : set α) :
-  is_measurable (to_measurable μ s) :=
-(classical.some_spec (exists_is_measurable_superset μ s)).2.1
+@[simp] lemma measurable_set_to_measurable (μ : measure α) (s : set α) :
+  measurable_set (to_measurable μ s) :=
+(classical.some_spec (exists_measurable_set_superset μ s)).2.1
 
 @[simp] lemma measure_to_measurable (s : set α) : μ (to_measurable μ s) = μ s :=
-(classical.some_spec (exists_is_measurable_superset μ s)).2.2
+(classical.some_spec (exists_measurable_set_superset μ s)).2.2
 
-lemma exists_is_measurable_superset_of_null (h : μ s = 0) :
-  ∃ t, s ⊆ t ∧ is_measurable t ∧ μ t = 0 :=
-outer_measure.exists_is_measurable_superset_of_trim_eq_zero (by rw [← measure_eq_trim, h])
+lemma exists_measurable_set_superset_of_null (h : μ s = 0) :
+  ∃ t, s ⊆ t ∧ measurable_set t ∧ μ t = 0 :=
+outer_measure.exists_measurable_set_superset_of_trim_eq_zero (by rw [← measure_eq_trim, h])
 
-lemma exists_is_measurable_superset_iff_measure_eq_zero :
-  (∃ t, s ⊆ t ∧ is_measurable t ∧ μ t = 0) ↔ μ s = 0 :=
-⟨λ ⟨t, hst, _, ht⟩, measure_mono_null hst ht, exists_is_measurable_superset_of_null⟩
+lemma exists_measurable_set_superset_iff_measure_eq_zero :
+  (∃ t, s ⊆ t ∧ measurable_set t ∧ μ t = 0) ↔ μ s = 0 :=
+⟨λ ⟨t, hst, _, ht⟩, measure_mono_null hst ht, exists_measurable_set_superset_of_null⟩
 
 theorem measure_Union_le [encodable β] (s : β → set α) : μ (⋃ i, s i) ≤ ∑' i, μ (s i) :=
 μ.to_outer_measure.Union _
@@ -268,17 +268,17 @@ lemma measure_union_null_iff : μ (s₁ ∪ s₂) = 0 ↔ μ s₁ = 0 ∧ μ s�
   λ h, measure_union_null h.1 h.2⟩
 
 lemma measure_Union [encodable β] {f : β → set α}
-  (hn : pairwise (disjoint on f)) (h : ∀ i, is_measurable (f i)) :
+  (hn : pairwise (disjoint on f)) (h : ∀ i, measurable_set (f i)) :
   μ (⋃ i, f i) = ∑' i, μ (f i) :=
 begin
-  rw [measure_eq_extend (is_measurable.Union h),
-    extend_Union is_measurable.empty _ is_measurable.Union _ hn h],
+  rw [measure_eq_extend (measurable_set.Union h),
+    extend_Union measurable_set.empty _ measurable_set.Union _ hn h],
   { simp [measure_eq_extend, h] },
   { exact μ.empty },
   { exact μ.m_Union }
 end
 
-lemma measure_union (hd : disjoint s₁ s₂) (h₁ : is_measurable s₁) (h₂ : is_measurable s₂) :
+lemma measure_union (hd : disjoint s₁ s₂) (h₁ : measurable_set s₁) (h₂ : measurable_set s₂) :
   μ (s₁ ∪ s₂) = μ s₁ + μ s₂ :=
 begin
   rw [union_eq_Union, measure_Union, tsum_fintype, fintype.sum_bool, cond, cond],
@@ -286,7 +286,7 @@ begin
 end
 
 lemma measure_bUnion {s : set β} {f : β → set α} (hs : countable s)
-  (hd : pairwise_on s (disjoint on f)) (h : ∀ b ∈ s, is_measurable (f b)) :
+  (hd : pairwise_on s (disjoint on f)) (h : ∀ b ∈ s, measurable_set (f b)) :
   μ (⋃ b ∈ s, f b) = ∑' p : s, μ (f p) :=
 begin
   haveI := hs.to_encodable,
@@ -295,12 +295,12 @@ begin
 end
 
 lemma measure_sUnion {S : set (set α)} (hs : countable S)
-  (hd : pairwise_on S disjoint) (h : ∀ s ∈ S, is_measurable s) :
+  (hd : pairwise_on S disjoint) (h : ∀ s ∈ S, measurable_set s) :
   μ (⋃₀ S) = ∑' s : S, μ s :=
 by rw [sUnion_eq_bUnion, measure_bUnion hs hd h]
 
 lemma measure_bUnion_finset {s : finset ι} {f : ι → set α} (hd : pairwise_on ↑s (disjoint on f))
-  (hm : ∀ b ∈ s, is_measurable (f b)) :
+  (hm : ∀ b ∈ s, measurable_set (f b)) :
   μ (⋃ b ∈ s, f b) = ∑ p in s, μ (f p) :=
 begin
   rw [← finset.sum_attach, finset.attach_eq_univ, ← tsum_fintype],
@@ -310,19 +310,19 @@ end
 /-- If `s` is a countable set, then the measure of its preimage can be found as the sum of measures
 of the fibers `f ⁻¹' {y}`. -/
 lemma tsum_measure_preimage_singleton {s : set β} (hs : countable s) {f : α → β}
-  (hf : ∀ y ∈ s, is_measurable (f ⁻¹' {y})) :
+  (hf : ∀ y ∈ s, measurable_set (f ⁻¹' {y})) :
   ∑' b : s, μ (f ⁻¹' {↑b}) = μ (f ⁻¹' s) :=
 by rw [← set.bUnion_preimage_singleton, measure_bUnion hs (pairwise_on_disjoint_fiber _ _) hf]
 
 /-- If `s` is a `finset`, then the measure of its preimage can be found as the sum of measures
 of the fibers `f ⁻¹' {y}`. -/
 lemma sum_measure_preimage_singleton (s : finset β) {f : α → β}
-  (hf : ∀ y ∈ s, is_measurable (f ⁻¹' {y})) :
+  (hf : ∀ y ∈ s, measurable_set (f ⁻¹' {y})) :
   ∑ b in s, μ (f ⁻¹' {b}) = μ (f ⁻¹' ↑s) :=
 by simp only [← measure_bUnion_finset (pairwise_on_disjoint_fiber _ _) hf,
   finset.set_bUnion_preimage_singleton]
 
-lemma measure_diff (h : s₂ ⊆ s₁) (h₁ : is_measurable s₁) (h₂ : is_measurable s₂)
+lemma measure_diff (h : s₂ ⊆ s₁) (h₁ : measurable_set s₁) (h₂ : measurable_set s₂)
   (h_fin : μ s₂ < ⊤) :
   μ (s₁ \ s₂) = μ s₁ - μ s₂ :=
 begin
@@ -330,15 +330,15 @@ begin
   rw [← measure_union disjoint_diff h₂ (h₁.diff h₂), union_diff_cancel h]
 end
 
-lemma measure_compl (h₁ : is_measurable s) (h_fin : μ s < ⊤) : μ (sᶜ) = μ univ - μ s :=
-by { rw compl_eq_univ_diff, exact measure_diff (subset_univ s) is_measurable.univ h₁ h_fin }
+lemma measure_compl (h₁ : measurable_set s) (h_fin : μ s < ⊤) : μ (sᶜ) = μ univ - μ s :=
+by { rw compl_eq_univ_diff, exact measure_diff (subset_univ s) measurable_set.univ h₁ h_fin }
 
-lemma sum_measure_le_measure_univ {s : finset ι} {t : ι → set α} (h : ∀ i ∈ s, is_measurable (t i))
+lemma sum_measure_le_measure_univ {s : finset ι} {t : ι → set α} (h : ∀ i ∈ s, measurable_set (t i))
   (H : pairwise_on ↑s (disjoint on t)) :
   ∑ i in s, μ (t i) ≤ μ (univ : set α) :=
 by { rw ← measure_bUnion_finset H h, exact measure_mono (subset_univ _) }
 
-lemma tsum_measure_le_measure_univ {s : ι → set α} (hs : ∀ i, is_measurable (s i))
+lemma tsum_measure_le_measure_univ {s : ι → set α} (hs : ∀ i, measurable_set (s i))
   (H : pairwise (disjoint on s)) :
   ∑' i, μ (s i) ≤ μ (univ : set α) :=
 begin
@@ -349,7 +349,7 @@ end
 /-- Pigeonhole principle for measure spaces: if `∑' i, μ (s i) > μ univ`, then
 one of the intersections `s i ∩ s j` is not empty. -/
 lemma exists_nonempty_inter_of_measure_univ_lt_tsum_measure (μ : measure α) {s : ι → set α}
-  (hs : ∀ i, is_measurable (s i)) (H : μ (univ : set α) < ∑' i, μ (s i)) :
+  (hs : ∀ i, measurable_set (s i)) (H : μ (univ : set α) < ∑' i, μ (s i)) :
   ∃ i j (h : i ≠ j), (s i ∩ s j).nonempty :=
 begin
   contrapose! H,
@@ -360,7 +360,7 @@ end
 /-- Pigeonhole principle for measure spaces: if `s` is a `finset` and
 `∑ i in s, μ (t i) > μ univ`, then one of the intersections `t i ∩ t j` is not empty. -/
 lemma exists_nonempty_inter_of_measure_univ_lt_sum_measure (μ : measure α) {s : finset ι}
-  {t : ι → set α} (h : ∀ i ∈ s, is_measurable (t i)) (H : μ (univ : set α) < ∑ i in s, μ (t i)) :
+  {t : ι → set α} (h : ∀ i ∈ s, measurable_set (t i)) (H : μ (univ : set α) < ∑ i in s, μ (t i)) :
   ∃ (i ∈ s) (j ∈ s) (h : i ≠ j), (t i ∩ t j).nonempty :=
 begin
   contrapose! H,
@@ -370,15 +370,15 @@ end
 
 /-- Continuity from below: the measure of the union of a directed sequence of measurable sets
 is the supremum of the measures. -/
-lemma measure_Union_eq_supr [encodable ι] {s : ι → set α} (h : ∀ i, is_measurable (s i))
+lemma measure_Union_eq_supr [encodable ι] {s : ι → set α} (h : ∀ i, measurable_set (s i))
   (hd : directed (⊆) s) : μ (⋃ i, s i) = ⨆ i, μ (s i) :=
 begin
   by_cases hι : nonempty ι, swap,
   { simp only [supr_of_empty hι, Union], exact measure_empty },
   resetI,
   refine le_antisymm _ (supr_le $ λ i, measure_mono $ subset_Union _ _),
-  have : ∀ n, is_measurable (disjointed (λ n, ⋃ b ∈ encodable.decode2 ι n, s b) n) :=
-    is_measurable.disjointed (is_measurable.bUnion_decode2 h),
+  have : ∀ n, measurable_set (disjointed (λ n, ⋃ b ∈ encodable.decode2 ι n, s b) n) :=
+    measurable_set.disjointed (measurable_set.bUnion_decode2 h),
   rw [← encodable.Union_decode2, ← Union_disjointed, measure_Union disjoint_disjointed this,
     ennreal.tsum_eq_supr_nat],
   simp only [← measure_bUnion_finset (disjoint_disjointed.pairwise_on _) (λ n _, this n)],
@@ -392,7 +392,7 @@ begin
 end
 
 lemma measure_bUnion_eq_supr {s : ι → set α} {t : set ι} (ht : countable t)
-  (h : ∀ i ∈ t, is_measurable (s i)) (hd : directed_on ((⊆) on s) t) :
+  (h : ∀ i ∈ t, measurable_set (s i)) (hd : directed_on ((⊆) on s) t) :
   μ (⋃ i ∈ t, s i) = ⨆ i ∈ t, μ (s i) :=
 begin
   haveI := ht.to_encodable,
@@ -404,14 +404,14 @@ end
 /-- Continuity from above: the measure of the intersection of a decreasing sequence of measurable
 sets is the infimum of the measures. -/
 lemma measure_Inter_eq_infi [encodable ι] {s : ι → set α}
-  (h : ∀ i, is_measurable (s i)) (hd : directed (⊇) s)
+  (h : ∀ i, measurable_set (s i)) (hd : directed (⊇) s)
   (hfin : ∃ i, μ (s i) < ⊤) :
   μ (⋂ i, s i) = (⨅ i, μ (s i)) :=
 begin
   rcases hfin with ⟨k, hk⟩,
   rw [← ennreal.sub_sub_cancel (by exact hk) (infi_le _ k), ennreal.sub_infi,
     ← ennreal.sub_sub_cancel (by exact hk) (measure_mono (Inter_subset _ k)),
-    ← measure_diff (Inter_subset _ k) (h k) (is_measurable.Inter h)
+    ← measure_diff (Inter_subset _ k) (h k) (measurable_set.Inter h)
       (lt_of_le_of_lt (measure_mono (Inter_subset _ k)) hk),
     diff_Inter, measure_Union_eq_supr],
   { congr' 1,
@@ -427,19 +427,19 @@ begin
   { exact hd.mono_comp _ (λ _ _, diff_subset_diff_right) }
 end
 
-lemma measure_eq_inter_diff (hs : is_measurable s) (ht : is_measurable t) :
+lemma measure_eq_inter_diff (hs : measurable_set s) (ht : measurable_set t) :
   μ s = μ (s ∩ t) + μ (s \ t) :=
 have hd : disjoint (s ∩ t) (s \ t) := assume a ⟨⟨_, hs⟩, _, hns⟩, hns hs ,
 by rw [← measure_union hd (hs.inter ht) (hs.diff ht), inter_union_diff s t]
 
-lemma measure_union_add_inter (hs : is_measurable s) (ht : is_measurable t) :
+lemma measure_union_add_inter (hs : measurable_set s) (ht : measurable_set t) :
   μ (s ∪ t) + μ (s ∩ t) = μ s + μ t :=
 by { rw [measure_eq_inter_diff (hs.union ht) ht, set.union_inter_cancel_right,
   union_diff_right, measure_eq_inter_diff hs ht], ac_refl }
 
 /-- Continuity from below: the measure of the union of an increasing sequence of measurable sets
 is the limit of the measures. -/
-lemma tendsto_measure_Union {s : ℕ → set α} (hs : ∀ n, is_measurable (s n)) (hm : monotone s) :
+lemma tendsto_measure_Union {s : ℕ → set α} (hs : ∀ n, measurable_set (s n)) (hm : monotone s) :
   tendsto (μ ∘ s) at_top (𝓝 (μ (⋃ n, s n))) :=
 begin
   rw measure_Union_eq_supr hs (directed_of_sup hm),
@@ -449,7 +449,7 @@ end
 /-- Continuity from above: the measure of the intersection of a decreasing sequence of measurable
 sets is the limit of the measures. -/
 lemma tendsto_measure_Inter {s : ℕ → set α}
-  (hs : ∀ n, is_measurable (s n)) (hm : ∀ ⦃n m⦄, n ≤ m → s m ⊆ s n) (hf : ∃ i, μ (s i) < ⊤) :
+  (hs : ∀ n, measurable_set (s n)) (hm : ∀ ⦃n m⦄, n ≤ m → s m ⊆ s n) (hf : ∃ i, μ (s i) < ⊤) :
   tendsto (μ ∘ s) at_top (𝓝 (μ (⋂ n, s n))) :=
 begin
   rw measure_Inter_eq_infi hs (directed_of_sup hm) hf,
@@ -458,14 +458,14 @@ end
 
 /-- One direction of the Borel-Cantelli lemma: if (sᵢ) is a sequence of measurable sets such that
   ∑ μ sᵢ exists, then the limit superior of the sᵢ is a null set. -/
-lemma measure_limsup_eq_zero {s : ℕ → set α} (hs : ∀ i, is_measurable (s i))
+lemma measure_limsup_eq_zero {s : ℕ → set α} (hs : ∀ i, measurable_set (s i))
   (hs' : ∑' i, μ (s i) ≠ ⊤) : μ (limsup at_top s) = 0 :=
 begin
   rw limsup_eq_infi_supr_of_nat',
   -- We will show that both `μ (⨅ n, ⨆ i, s (i + n))` and `0` are the limit of `μ (⊔ i, s (i + n))`
   -- as `n` tends to infinity. For the former, we use continuity from above.
   refine tendsto_nhds_unique
-    (tendsto_measure_Inter (λ i, is_measurable.Union (λ b, hs (b + i))) _
+    (tendsto_measure_Inter (λ i, measurable_set.Union (λ b, hs (b + i))) _
       ⟨0, lt_of_le_of_lt (measure_Union_le s) (ennreal.lt_top_iff_ne_top.2 hs')⟩) _,
   { intros n m hnm x,
     simp only [set.mem_Union],
@@ -512,7 +512,7 @@ end
   (m.to_measure h).to_outer_measure = m.trim := rfl
 
 @[simp] lemma to_measure_apply (m : outer_measure α) (h : ms ≤ m.caratheodory)
-  {s : set α} (hs : is_measurable s) : m.to_measure h s = m s :=
+  {s : set α} (hs : measurable_set s) : m.to_measure h s = m s :=
 m.trim_eq hs
 
 lemma le_to_measure_apply (m : outer_measure α) (h : ms ≤ m.caratheodory) (s : set α) :
@@ -530,7 +530,8 @@ variables {μ μ₁ μ₂ μ₃ ν ν' ν₁ ν₂ : measure α} {s s' t : set �
 
 namespace measure
 
-protected lemma caratheodory (μ : measure α) (hs : is_measurable s) : μ (t ∩ s) + μ (t \ s) = μ t :=
+protected lemma caratheodory (μ : measure α) (hs : measurable_set s) :
+  μ (t ∩ s) + μ (t \ s) = μ t :=
 (le_to_outer_measure_caratheodory μ s hs t).symm
 
 /-! ### The `ennreal`-module of measures -/
@@ -591,13 +592,13 @@ injective.semimodule ennreal ⟨to_outer_measure, zero_to_outer_measure, add_to_
 /-! ### The complete lattice of measures -/
 
 instance : partial_order (measure α) :=
-{ le          := λ m₁ m₂, ∀ s, is_measurable s → m₁ s ≤ m₂ s,
+{ le          := λ m₁ m₂, ∀ s, measurable_set s → m₁ s ≤ m₂ s,
   le_refl     := assume m s hs, le_refl _,
   le_trans    := assume m₁ m₂ m₃ h₁ h₂ s hs, le_trans (h₁ s hs) (h₂ s hs),
   le_antisymm := assume m₁ m₂ h₁ h₂, ext $
     assume s hs, le_antisymm (h₁ s hs) (h₂ s hs) }
 
-theorem le_iff : μ₁ ≤ μ₂ ↔ ∀ s, is_measurable s → μ₁ s ≤ μ₂ s := iff.rfl
+theorem le_iff : μ₁ ≤ μ₂ ↔ ∀ s, measurable_set s → μ₁ s ≤ μ₂ s := iff.rfl
 
 theorem to_outer_measure_le : μ₁.to_outer_measure ≤ μ₂.to_outer_measure ↔ μ₁ ≤ μ₂ :=
 by rw [← μ₂.trimmed, outer_measure.le_trim_iff]; refl
@@ -605,7 +606,7 @@ by rw [← μ₂.trimmed, outer_measure.le_trim_iff]; refl
 theorem le_iff' : μ₁ ≤ μ₂ ↔ ∀ s, μ₁ s ≤ μ₂ s :=
 to_outer_measure_le.symm
 
-theorem lt_iff : μ < ν ↔ μ ≤ ν ∧ ∃ s, is_measurable s ∧ μ s < ν s :=
+theorem lt_iff : μ < ν ↔ μ ≤ ν ∧ ∃ s, measurable_set s ∧ μ s < ν s :=
 lt_iff_le_not_le.trans $ and_congr iff.rfl $ by simp only [le_iff, not_forall, not_le, exists_prop]
 
 theorem lt_iff' : μ < ν ↔ μ ≤ ν ∧ ∃ s, μ s < ν s :=
@@ -632,8 +633,8 @@ protected lemma le_add_right (h : μ ≤ ν) : μ ≤ ν + ν' :=
 section Inf
 variables {m : set (measure α)}
 
-lemma Inf_caratheodory (s : set α) (hs : is_measurable s) :
-  (Inf (to_outer_measure '' m)).caratheodory.is_measurable' s :=
+lemma Inf_caratheodory (s : set α) (hs : measurable_set s) :
+  (Inf (to_outer_measure '' m)).caratheodory.measurable_set' s :=
 begin
   rw [outer_measure.Inf_eq_bounded_by_Inf_gen],
   refine outer_measure.bounded_by_caratheodory (λ t, _),
@@ -653,7 +654,7 @@ end
 instance : has_Inf (measure α) :=
 ⟨λ m, (Inf (to_outer_measure '' m)).to_measure $ Inf_caratheodory⟩
 
-lemma Inf_apply (hs : is_measurable s) : Inf m s = Inf (to_outer_measure '' m) s :=
+lemma Inf_apply (hs : measurable_set s) : Inf m s = Inf (to_outer_measure '' m) s :=
 to_measure_apply _ _ hs
 
 private lemma measure_Inf_le (h : μ ∈ m) : Inf m ≤ μ :=
@@ -699,7 +700,7 @@ def lift_linear (f : outer_measure α →ₗ[ennreal] outer_measure β)
   map_smul' := λ c μ, ext $ λ s hs, by simp [hs] }
 
 @[simp] lemma lift_linear_apply {f : outer_measure α →ₗ[ennreal] outer_measure β} (hf)
-  {s : set β} (hs : is_measurable s) : lift_linear f hf μ s = f μ.to_outer_measure s :=
+  {s : set β} (hs : measurable_set s) : lift_linear f hf μ s = f μ.to_outer_measure s :=
 to_measure_apply _ _ hs
 
 lemma le_lift_linear_apply {f : outer_measure α →ₗ[ennreal] outer_measure β} (hf) (s : set β) :
@@ -715,7 +716,7 @@ else 0
 
 /-- We can evaluate the pushforward on measurable sets. For non-measurable sets, see
   `measure_theory.measure.le_map_apply` and `measurable_equiv.map_apply`. -/
-@[simp] theorem map_apply {f : α → β} (hf : measurable f) {s : set β} (hs : is_measurable s) :
+@[simp] theorem map_apply {f : α → β} (hf : measurable f) {s : set β} (hs : measurable_set s) :
   map f μ s = μ (f ⁻¹' s) :=
 by simp [map, dif_pos hf, hs]
 
@@ -747,7 +748,7 @@ nonpos_iff_eq_zero.mp $ (le_map_apply hf s).trans_eq hs
 /-- Pullback of a `measure`. If `f` sends each `measurable` set to a `measurable` set, then for each
 measurable set `s` we have `comap f μ s = μ (f '' s)`. -/
 def comap (f : α → β) : measure β →ₗ[ennreal] measure α :=
-if hf : injective f ∧ ∀ s, is_measurable s → is_measurable (f '' s) then
+if hf : injective f ∧ ∀ s, measurable_set s → measurable_set (f '' s) then
   lift_linear (outer_measure.comap f) $ λ μ s hs t,
   begin
     simp only [coe_to_outer_measure, outer_measure.comap_apply, ← image_inter hf.1,
@@ -758,7 +759,7 @@ if hf : injective f ∧ ∀ s, is_measurable s → is_measurable (f '' s) then
 else 0
 
 lemma comap_apply (f : α → β) (hfi : injective f)
-  (hf : ∀ s, is_measurable s → is_measurable (f '' s)) (μ : measure β) (hs : is_measurable s) :
+  (hf : ∀ s, measurable_set s → measurable_set (f '' s)) (μ : measure β) (hs : measurable_set s) :
   comap f μ s = μ (f '' s) :=
 begin
   rw [comap, dif_pos, lift_linear_apply _ hs, outer_measure.comap_apply, coe_to_outer_measure],
@@ -783,11 +784,11 @@ def restrict (μ : measure α) (s : set α) : measure α := restrictₗ s μ
   restrictₗ s μ = μ.restrict s :=
 rfl
 
-@[simp] lemma restrict_apply (ht : is_measurable t) : μ.restrict s t = μ (t ∩ s) :=
+@[simp] lemma restrict_apply (ht : measurable_set t) : μ.restrict s t = μ (t ∩ s) :=
 by simp [← restrictₗ_apply, restrictₗ, ht]
 
 lemma restrict_apply_univ (s : set α) : μ.restrict s univ = μ s :=
-by rw [restrict_apply is_measurable.univ, set.univ_inter]
+by rw [restrict_apply measurable_set.univ, set.univ_inter]
 
 lemma le_restrict_apply (s t : set α) :
   μ (t ∩ s) ≤ μ.restrict s t :=
@@ -804,20 +805,20 @@ by { rw [restrict, restrictₗ], convert le_lift_linear_apply _ t, simp }
   (c • μ).restrict s = c • μ.restrict s :=
 (restrictₗ s).map_smul c μ
 
-@[simp] lemma restrict_restrict (hs : is_measurable s) :
+@[simp] lemma restrict_restrict (hs : measurable_set s) :
   (μ.restrict t).restrict s = μ.restrict (s ∩ t) :=
 ext $ λ u hu, by simp [*, set.inter_assoc]
 
-lemma restrict_apply_eq_zero (ht : is_measurable t) : μ.restrict s t = 0 ↔ μ (t ∩ s) = 0 :=
+lemma restrict_apply_eq_zero (ht : measurable_set t) : μ.restrict s t = 0 ↔ μ (t ∩ s) = 0 :=
 by rw [restrict_apply ht]
 
 lemma measure_inter_eq_zero_of_restrict (h : μ.restrict s t = 0) : μ (t ∩ s) = 0 :=
 nonpos_iff_eq_zero.1 (h ▸ le_restrict_apply _ _)
 
-lemma restrict_apply_eq_zero' (hs : is_measurable s) : μ.restrict s t = 0 ↔ μ (t ∩ s) = 0 :=
+lemma restrict_apply_eq_zero' (hs : measurable_set s) : μ.restrict s t = 0 ↔ μ (t ∩ s) = 0 :=
 begin
   refine ⟨measure_inter_eq_zero_of_restrict, λ h, _⟩,
-  rcases exists_is_measurable_superset_of_null h with ⟨t', htt', ht', ht'0⟩,
+  rcases exists_measurable_set_superset_of_null h with ⟨t', htt', ht', ht'0⟩,
   apply measure_mono_null ((inter_subset _ _ _).1 htt'),
   rw [restrict_apply (hs.compl.union ht'), union_inter_distrib_right, compl_inter_self,
     set.empty_union],
@@ -831,19 +832,19 @@ by rw [← measure_univ_eq_zero, restrict_apply_univ]
 
 @[simp] lemma restrict_univ : μ.restrict univ = μ := ext $ λ s hs, by simp [hs]
 
-lemma restrict_union_apply (h : disjoint (t ∩ s) (t ∩ s')) (hs : is_measurable s)
-  (hs' : is_measurable s') (ht : is_measurable t) :
+lemma restrict_union_apply (h : disjoint (t ∩ s) (t ∩ s')) (hs : measurable_set s)
+  (hs' : measurable_set s') (ht : measurable_set t) :
   μ.restrict (s ∪ s') t = μ.restrict s t + μ.restrict s' t :=
 begin
   simp only [restrict_apply, ht, set.inter_union_distrib_left],
   exact measure_union h (ht.inter hs) (ht.inter hs'),
 end
 
-lemma restrict_union (h : disjoint s t) (hs : is_measurable s) (ht : is_measurable t) :
+lemma restrict_union (h : disjoint s t) (hs : measurable_set s) (ht : measurable_set t) :
   μ.restrict (s ∪ t) = μ.restrict s + μ.restrict t :=
 ext $ λ t' ht', restrict_union_apply (h.mono inf_le_right inf_le_right) hs ht ht'
 
-lemma restrict_union_add_inter (hs : is_measurable s) (ht : is_measurable t) :
+lemma restrict_union_add_inter (hs : measurable_set s) (ht : measurable_set t) :
   μ.restrict (s ∪ t) + μ.restrict (s ∩ t) = μ.restrict s + μ.restrict t :=
 begin
   ext1 u hu,
@@ -852,11 +853,11 @@ begin
   rw [set.inter_left_comm (u ∩ s), set.inter_assoc, ← set.inter_assoc u u, set.inter_self]
 end
 
-@[simp] lemma restrict_add_restrict_compl (hs : is_measurable s) :
+@[simp] lemma restrict_add_restrict_compl (hs : measurable_set s) :
   μ.restrict s + μ.restrict sᶜ = μ :=
 by rw [← restrict_union disjoint_compl_right hs hs.compl, union_compl_self, restrict_univ]
 
-@[simp] lemma restrict_compl_add_restrict (hs : is_measurable s) :
+@[simp] lemma restrict_compl_add_restrict (hs : measurable_set s) :
   μ.restrict sᶜ + μ.restrict s = μ :=
 by rw [add_comm, restrict_add_restrict_compl hs]
 
@@ -869,7 +870,7 @@ begin
 end
 
 lemma restrict_Union_apply [encodable ι] {s : ι → set α} (hd : pairwise (disjoint on s))
-  (hm : ∀ i, is_measurable (s i)) {t : set α} (ht : is_measurable t) :
+  (hm : ∀ i, measurable_set (s i)) {t : set α} (ht : measurable_set t) :
   μ.restrict (⋃ i, s i) t = ∑' i, μ.restrict (s i) t :=
 begin
   simp only [restrict_apply, ht, inter_Union],
@@ -878,7 +879,7 @@ begin
 end
 
 lemma restrict_Union_apply_eq_supr [encodable ι] {s : ι → set α}
-  (hm : ∀ i, is_measurable (s i)) (hd : directed (⊆) s) {t : set α} (ht : is_measurable t) :
+  (hm : ∀ i, measurable_set (s i)) (hd : directed (⊆) s) {t : set α} (ht : measurable_set t) :
   μ.restrict (⋃ i, s i) t = ⨆ i, μ.restrict (s i) t :=
 begin
   simp only [restrict_apply ht, inter_Union],
@@ -886,11 +887,11 @@ begin
   exacts [λ i, ht.inter (hm i), hd.mono_comp _ (λ s₁ s₂, inter_subset_inter_right _)]
 end
 
-lemma restrict_map {f : α → β} (hf : measurable f) {s : set β} (hs : is_measurable s) :
+lemma restrict_map {f : α → β} (hf : measurable f) {s : set β} (hs : measurable_set s) :
   (map f μ).restrict s = map f (μ.restrict $ f ⁻¹' s) :=
 ext $ λ t ht, by simp [*, hf ht]
 
-lemma map_comap_subtype_coe (hs : is_measurable s) :
+lemma map_comap_subtype_coe (hs : measurable_set s) :
   (map (coe : s → α)).comp (comap coe) = restrictₗ s :=
 linear_map.ext $ λ μ, ext $ λ t ht,
 by rw [restrictₗ_apply, restrict_apply ht, linear_map.comp_apply,
@@ -912,20 +913,20 @@ assume t ht,
 calc μ.restrict s t = μ (t ∩ s) : restrict_apply ht
 ... ≤ μ t : measure_mono $ inter_subset_left t s
 
-lemma restrict_congr_meas (hs : is_measurable s) :
-  μ.restrict s = ν.restrict s ↔ ∀ t ⊆ s, is_measurable t → μ t = ν t :=
+lemma restrict_congr_meas (hs : measurable_set s) :
+  μ.restrict s = ν.restrict s ↔ ∀ t ⊆ s, measurable_set t → μ t = ν t :=
 ⟨λ H t hts ht,
    by rw [← inter_eq_self_of_subset_left hts, ← restrict_apply ht, H, restrict_apply ht],
  λ H, ext $ λ t ht,
    by rw [restrict_apply ht, restrict_apply ht, H _ (inter_subset_right _ _) (ht.inter hs)]⟩
 
-lemma restrict_congr_mono (hs : s ⊆ t) (hm : is_measurable s) (h : μ.restrict t = ν.restrict t) :
+lemma restrict_congr_mono (hs : s ⊆ t) (hm : measurable_set s) (h : μ.restrict t = ν.restrict t) :
   μ.restrict s = ν.restrict s :=
 by rw [← inter_eq_self_of_subset_left hs, ← restrict_restrict hm, h, restrict_restrict hm]
 
 /-- If two measures agree on all measurable subsets of `s` and `t`, then they agree on all
 measurable subsets of `s ∪ t`. -/
-lemma restrict_union_congr (hsm : is_measurable s) (htm : is_measurable t) :
+lemma restrict_union_congr (hsm : measurable_set s) (htm : measurable_set t) :
   μ.restrict (s ∪ t) = ν.restrict (s ∪ t) ↔
     μ.restrict s = ν.restrict s ∧ μ.restrict t = ν.restrict t :=
 begin
@@ -939,24 +940,24 @@ begin
 end
 
 lemma restrict_finset_bUnion_congr {s : finset ι} {t : ι → set α}
-  (htm : ∀ i ∈ s, is_measurable (t i)) :
+  (htm : ∀ i ∈ s, measurable_set (t i)) :
   μ.restrict (⋃ i ∈ s, t i) = ν.restrict (⋃ i ∈ s, t i) ↔
     ∀ i ∈ s, μ.restrict (t i) = ν.restrict (t i) :=
 begin
   induction s using finset.induction_on with i s hi hs, { simp },
   simp only [finset.mem_insert, or_imp_distrib, forall_and_distrib, forall_eq] at htm ⊢,
   simp only [finset.set_bUnion_insert, ← hs htm.2],
-  exact restrict_union_congr htm.1 (s.is_measurable_bUnion htm.2)
+  exact restrict_union_congr htm.1 (s.measurable_set_bUnion htm.2)
 end
 
-lemma restrict_Union_congr [encodable ι] {s : ι → set α} (hm : ∀ i, is_measurable (s i)) :
+lemma restrict_Union_congr [encodable ι] {s : ι → set α} (hm : ∀ i, measurable_set (s i)) :
   μ.restrict (⋃ i, s i) = ν.restrict (⋃ i, s i) ↔
     ∀ i, μ.restrict (s i) = ν.restrict (s i) :=
 begin
   refine ⟨λ h i, restrict_congr_mono (subset_Union _ _) (hm i) h, λ h, _⟩,
   ext1 t ht,
-  have M : ∀ t : finset ι, is_measurable (⋃ i ∈ t, s i) :=
-    λ t, t.is_measurable_bUnion (λ i _, hm i),
+  have M : ∀ t : finset ι, measurable_set (⋃ i ∈ t, s i) :=
+    λ t, t.measurable_set_bUnion (λ i _, hm i),
   have D : directed (⊆) (λ t : finset ι, ⋃ i ∈ t, s i) :=
     directed_of_sup (λ t₁ t₂ ht, bUnion_subset_bUnion_left ht),
   rw [Union_eq_Union_finset],
@@ -965,7 +966,7 @@ begin
 end
 
 lemma restrict_bUnion_congr {s : set ι} {t : ι → set α} (hc : countable s)
-  (htm : ∀ i ∈ s, is_measurable (t i)) :
+  (htm : ∀ i ∈ s, measurable_set (t i)) :
   μ.restrict (⋃ i ∈ s, t i) = ν.restrict (⋃ i ∈ s, t i) ↔
     ∀ i ∈ s, μ.restrict (t i) = ν.restrict (t i) :=
 begin
@@ -974,23 +975,23 @@ begin
   exact restrict_Union_congr htm
 end
 
-lemma restrict_sUnion_congr {S : set (set α)} (hc : countable S) (hm : ∀ s ∈ S, is_measurable s) :
+lemma restrict_sUnion_congr {S : set (set α)} (hc : countable S) (hm : ∀ s ∈ S, measurable_set s) :
   μ.restrict (⋃₀ S) = ν.restrict (⋃₀ S) ↔ ∀ s ∈ S, μ.restrict s = ν.restrict s :=
 by rw [sUnion_eq_bUnion, restrict_bUnion_congr hc hm]
 
 /-- This lemma shows that `restrict` and `to_outer_measure` commute. Note that the LHS has a
 restrict on measures and the RHS has a restrict on outer measures. -/
-lemma restrict_to_outer_measure_eq_to_outer_measure_restrict (h : is_measurable s) :
+lemma restrict_to_outer_measure_eq_to_outer_measure_restrict (h : measurable_set s) :
     (μ.restrict s).to_outer_measure = outer_measure.restrict s μ.to_outer_measure :=
 by simp_rw [restrict, restrictₗ, lift_linear, linear_map.coe_mk, to_measure_to_outer_measure,
   outer_measure.restrict_trim h, μ.trimmed]
 
 /-- This lemma shows that `Inf` and `restrict` commute for measures. -/
-lemma restrict_Inf_eq_Inf_restrict {m : set (measure α)} (hm : m.nonempty) (ht : is_measurable t) :
+lemma restrict_Inf_eq_Inf_restrict {m : set (measure α)} (hm : m.nonempty) (ht : measurable_set t) :
   (Inf m).restrict t = Inf ((λ μ : measure α, μ.restrict t) '' m) :=
 begin
   ext1 s hs,
-  simp_rw [Inf_apply hs, restrict_apply hs, Inf_apply (is_measurable.inter hs ht), set.image_image,
+  simp_rw [Inf_apply hs, restrict_apply hs, Inf_apply (measurable_set.inter hs ht), set.image_image,
     restrict_to_outer_measure_eq_to_outer_measure_restrict ht, ← set.image_image _ to_outer_measure,
     ← outer_measure.restrict_Inf_eq_Inf_restrict _ (hm.image _),
     outer_measure.restrict_apply]
@@ -1001,7 +1002,7 @@ end
 /-- Two measures are equal if they have equal restrictions on a spanning collection of sets
   (formulated using `Union`). -/
 lemma ext_iff_of_Union_eq_univ [encodable ι] {s : ι → set α}
-  (hm : ∀ i, is_measurable (s i)) (hs : (⋃ i, s i) = univ) :
+  (hm : ∀ i, measurable_set (s i)) (hs : (⋃ i, s i) = univ) :
   μ = ν ↔ ∀ i, μ.restrict (s i) = ν.restrict (s i) :=
 by rw [← restrict_Union_congr hm, hs, restrict_univ, restrict_univ]
 
@@ -1010,7 +1011,7 @@ alias ext_iff_of_Union_eq_univ ↔ _ measure_theory.measure.ext_of_Union_eq_univ
 /-- Two measures are equal if they have equal restrictions on a spanning collection of sets
   (formulated using `bUnion`). -/
 lemma ext_iff_of_bUnion_eq_univ {S : set ι} {s : ι → set α} (hc : countable S)
-  (hm : ∀ i ∈ S, is_measurable (s i)) (hs : (⋃ i ∈ S, s i) = univ) :
+  (hm : ∀ i ∈ S, measurable_set (s i)) (hs : (⋃ i ∈ S, s i) = univ) :
   μ = ν ↔ ∀ i ∈ S, μ.restrict (s i) = ν.restrict (s i) :=
 by rw [← restrict_bUnion_congr hc hm, hs, restrict_univ, restrict_univ]
 
@@ -1019,7 +1020,7 @@ alias ext_iff_of_bUnion_eq_univ ↔ _ measure_theory.measure.ext_of_bUnion_eq_un
 /-- Two measures are equal if they have equal restrictions on a spanning collection of sets
   (formulated using `sUnion`). -/
 lemma ext_iff_of_sUnion_eq_univ {S : set (set α)} (hc : countable S)
-  (hm : ∀ s ∈ S, is_measurable s) (hs : (⋃₀ S) = univ) :
+  (hm : ∀ s ∈ S, measurable_set s) (hs : (⋃₀ S) = univ) :
   μ = ν ↔ ∀ s ∈ S, μ.restrict s = ν.restrict s :=
 ext_iff_of_bUnion_eq_univ hc hm $ by rwa ← sUnion_eq_bUnion
 
@@ -1028,7 +1029,7 @@ alias ext_iff_of_sUnion_eq_univ ↔ _ measure_theory.measure.ext_of_sUnion_eq_un
 lemma ext_of_generate_from_of_cover {S T : set (set α)}
   (h_gen : ‹_› = generate_from S) (hc : countable T)
   (h_inter : is_pi_system S)
-  (hm : ∀ t ∈ T, is_measurable t) (hU : ⋃₀ T = univ) (htop : ∀ t ∈ T, μ t < ⊤)
+  (hm : ∀ t ∈ T, measurable_set t) (hU : ⋃₀ T = univ) (htop : ∀ t ∈ T, μ t < ⊤)
   (ST_eq : ∀ (t ∈ T) (s ∈ S), μ (s ∩ t) = ν (s ∩ t)) (T_eq : ∀ t ∈ T, μ t = ν t) :
   μ = ν :=
 begin
@@ -1046,7 +1047,7 @@ begin
   { intros f hfd hfm h_eq,
     have : pairwise (disjoint on λ n, f n ∩ t) :=
       λ m n hmn, (hfd m n hmn).mono (inter_subset_left _ _) (inter_subset_left _ _),
-    simp only [Union_inter, measure_Union this (λ n, is_measurable.inter (hfm n) (hm t ht)), h_eq] }
+    simp only [Union_inter, measure_Union this (λ n, (hfm n).inter (hm t ht)), h_eq] }
 end
 
 /-- Two measures are equal if they are equal on the π-system generating the σ-algebra,
@@ -1086,7 +1087,7 @@ def dirac (a : α) : measure α :=
 lemma le_dirac_apply {a} : s.indicator 1 a ≤ dirac a s :=
 outer_measure.dirac_apply a s ▸ le_to_measure_apply _ _ _
 
-@[simp] lemma dirac_apply' (a : α) (hs : is_measurable s) :
+@[simp] lemma dirac_apply' (a : α) (hs : measurable_set s) :
   dirac a s = s.indicator 1 a :=
 to_measure_apply _ _ hs
 
@@ -1096,7 +1097,7 @@ begin
   have : ∀ t : set α, a ∈ t → t.indicator (1 : α → ennreal) a = 1,
     from λ t ht, indicator_of_mem ht 1,
   refine le_antisymm (this univ trivial ▸ _) (this s h ▸ le_dirac_apply),
-  rw [← dirac_apply' a is_measurable.univ],
+  rw [← dirac_apply' a measurable_set.univ],
   exact measure_mono (subset_univ s)
 end
 
@@ -1106,7 +1107,7 @@ begin
   by_cases h : a ∈ s, by rw [dirac_apply_of_mem h, indicator_of_mem h, pi.one_apply],
   rw [indicator_of_not_mem h, ← nonpos_iff_eq_zero],
   calc dirac a s ≤ dirac a {a}ᶜ : measure_mono (subset_compl_comm.1 $ singleton_subset_iff.2 h)
-             ... = 0            : by simp [dirac_apply' _ (is_measurable_singleton _).compl]
+             ... = 0            : by simp [dirac_apply' _ (measurable_set_singleton _).compl]
 end
 
 lemma map_dirac {f : α → β} (hf : measurable f) (a : α) :
@@ -1124,7 +1125,7 @@ lemma le_sum_apply (f : ι → measure α) (s : set α) :
   (∑' i, f i s) ≤ sum f s :=
 le_to_measure_apply _ _ _
 
-@[simp] lemma sum_apply (f : ι → measure α) {s : set α} (hs : is_measurable s) :
+@[simp] lemma sum_apply (f : ι → measure α) {s : set α} (hs : measurable_set s) :
   sum f s = ∑' i, f i s :=
 to_measure_apply _ _ hs
 
@@ -1132,7 +1133,7 @@ lemma le_sum (μ : ι → measure α) (i : ι) : μ i ≤ sum μ :=
 λ s hs, by simp only [sum_apply μ hs, ennreal.le_tsum i]
 
 lemma restrict_Union [encodable ι] {s : ι → set α} (hd : pairwise (disjoint on s))
-  (hm : ∀ i, is_measurable (s i)) :
+  (hm : ∀ i, measurable_set (s i)) :
   μ.restrict (⋃ i, s i) = sum (λ i, μ.restrict (s i)) :=
 ext $ λ t ht, by simp only [sum_apply _ ht, restrict_Union_apply hd hm ht]
 
@@ -1150,7 +1151,7 @@ ext $ λ s hs, by simp [hs, tsum_fintype]
 @[simp] lemma sum_cond (μ ν : measure α) : sum (λ b, cond b μ ν) = μ + ν :=
 sum_bool _
 
-@[simp] lemma restrict_sum (μ : ι → measure α) {s : set α} (hs : is_measurable s) :
+@[simp] lemma restrict_sum (μ : ι → measure α) {s : set α} (hs : measurable_set s) :
   (sum μ).restrict s = sum (λ i, (μ i).restrict s) :=
 ext $ λ t ht, by simp only [sum_apply, restrict_apply, ht, ht.inter hs]
 
@@ -1162,12 +1163,12 @@ calc (∑' i : s, 1 : ennreal) = ∑' i, indicator s 1 i : tsum_subtype s 1
 ... ≤ ∑' i, dirac i s : ennreal.tsum_le_tsum $ λ x, le_dirac_apply
 ... ≤ count s : le_sum_apply _ _
 
-lemma count_apply (hs : is_measurable s) : count s = ∑' i : s, 1 :=
+lemma count_apply (hs : measurable_set s) : count s = ∑' i : s, 1 :=
 by simp only [count, sum_apply, hs, dirac_apply', ← tsum_subtype s 1, pi.one_apply]
 
 @[simp] lemma count_apply_finset [measurable_singleton_class α] (s : finset α) :
   count (↑s : set α) = s.card :=
-calc count (↑s : set α) = ∑' i : (↑s : set α), 1 : count_apply s.is_measurable
+calc count (↑s : set α) = ∑' i : (↑s : set α), 1 : count_apply s.measurable_set
                     ... = ∑ i in s, 1 : s.tsum_subtype 1
                     ... = s.card : by simp
 
@@ -1208,10 +1209,10 @@ def absolutely_continuous (μ ν : measure α) : Prop :=
 
 infix ` ≪ `:50 := absolutely_continuous
 
-lemma absolutely_continuous.mk (h : ∀ ⦃s : set α⦄, is_measurable s → ν s = 0 → μ s = 0) : μ ≪ ν :=
+lemma absolutely_continuous.mk (h : ∀ ⦃s : set α⦄, measurable_set s → ν s = 0 → μ s = 0) : μ ≪ ν :=
 begin
   intros s hs,
-  rcases exists_is_measurable_superset_of_null hs with ⟨t, h1t, h2t, h3t⟩,
+  rcases exists_measurable_set_superset_of_null hs with ⟨t, h1t, h2t, h3t⟩,
   exact measure_mono_null h1t (h h2t h3t),
 end
 
@@ -1289,7 +1290,7 @@ instance : countable_Inter_filter μ.ae :=
 end⟩
 
 instance ae_is_measurably_generated : is_measurably_generated μ.ae :=
-⟨λ s hs, let ⟨t, hst, htm, htμ⟩ := exists_is_measurable_superset_of_null hs in
+⟨λ s hs, let ⟨t, hst, htm, htμ⟩ := exists_measurable_set_superset_of_null hs in
   ⟨tᶜ, compl_mem_ae_iff.2 htμ, htm.compl, compl_subset_comm.1 hst⟩⟩
 
 lemma ae_all_iff [encodable ι] {p : α → ι → Prop} :
@@ -1328,15 +1329,15 @@ lemma ae_eq_set {s t : set α} :
   s =ᵐ[μ] t ↔ μ (s \ t) = 0 ∧ μ (t \ s) = 0 :=
 by simp [eventually_le_antisymm_iff, ae_le_set]
 
-lemma mem_ae_map_iff {f : α → β} (hf : measurable f) {s : set β} (hs : is_measurable s) :
+lemma mem_ae_map_iff {f : α → β} (hf : measurable f) {s : set β} (hs : measurable_set s) :
   s ∈ (map f μ).ae ↔ (f ⁻¹' s) ∈ μ.ae :=
 by simp only [mem_ae_iff, map_apply hf hs.compl, preimage_compl]
 
-lemma ae_map_iff {f : α → β} (hf : measurable f) {p : β → Prop} (hp : is_measurable {x | p x}) :
+lemma ae_map_iff {f : α → β} (hf : measurable f) {p : β → Prop} (hp : measurable_set {x | p x}) :
   (∀ᵐ y ∂ (map f μ), p y) ↔ ∀ᵐ x ∂ μ, p (f x) :=
 mem_ae_map_iff hf hp
 
-lemma ae_restrict_iff {p : α → Prop} (hp : is_measurable {x | p x}) :
+lemma ae_restrict_iff {p : α → Prop} (hp : measurable_set {x | p x}) :
   (∀ᵐ x ∂(μ.restrict s), p x) ↔ ∀ᵐ x ∂μ, x ∈ s → p x :=
 begin
   simp only [ae_iff, ← compl_set_of, restrict_apply hp.compl],
@@ -1350,7 +1351,7 @@ begin
   simpa [set_of_and, inter_comm] using  measure_inter_eq_zero_of_restrict h
 end
 
-lemma ae_restrict_iff' {s : set α} {p : α → Prop} (hp : is_measurable s) :
+lemma ae_restrict_iff' {s : set α} {p : α → Prop} (hp : measurable_set s) :
   (∀ᵐ x ∂(μ.restrict s), p x) ↔ ∀ᵐ x ∂μ, x ∈ s → p x :=
 begin
   simp only [ae_iff, ← compl_set_of, restrict_apply_eq_zero' hp],
@@ -1378,7 +1379,7 @@ ae_eq_comp' hf h absolutely_continuous.rfl
 lemma le_ae_restrict : μ.ae ⊓ 𝓟 s ≤ (μ.restrict s).ae :=
 λ s hs, eventually_inf_principal.2 (ae_imp_of_ae_restrict hs)
 
-@[simp] lemma ae_restrict_eq (hs : is_measurable s) : (μ.restrict s).ae = μ.ae ⊓ 𝓟 s :=
+@[simp] lemma ae_restrict_eq (hs : measurable_set s) : (μ.restrict s).ae = μ.ae ⊓ 𝓟 s :=
 begin
   ext t,
   simp only [mem_inf_principal, mem_ae_iff, restrict_apply_eq_zero' hs, compl_set_of,
@@ -1392,13 +1393,13 @@ ae_eq_bot.trans restrict_eq_zero
 @[simp] lemma ae_restrict_ne_bot {s} : (μ.restrict s).ae.ne_bot ↔ 0 < μ s :=
 (not_congr ae_restrict_eq_bot).trans pos_iff_ne_zero.symm
 
-lemma self_mem_ae_restrict {s} (hs : is_measurable s) : s ∈ (μ.restrict s).ae :=
+lemma self_mem_ae_restrict {s} (hs : measurable_set s) : s ∈ (μ.restrict s).ae :=
 by simp only [ae_restrict_eq hs, exists_prop, mem_principal_sets, mem_inf_sets];
   exact ⟨_, univ_mem_sets, s, by rw [univ_inter, and_self]⟩
 
 /-- A version of the Borel-Cantelli lemma: if `sᵢ` is a sequence of measurable sets such that
 `∑ μ sᵢ` exists, then for almost all `x`, `x` does not belong to almost all `sᵢ`. -/
-lemma ae_eventually_not_mem {s : ℕ → set α} (hs : ∀ i, is_measurable (s i))
+lemma ae_eventually_not_mem {s : ℕ → set α} (hs : ∀ i, measurable_set (s i))
   (hs' : ∑' i, μ (s i) ≠ ⊤) : ∀ᵐ x ∂ μ, ∀ᶠ n in at_top, x ∉ s n :=
 begin
   refine measure_mono_null _ (measure_limsup_eq_zero hs hs'),
@@ -1411,10 +1412,10 @@ begin
   exact hi j hj hj'
 end
 
-lemma mem_ae_dirac_iff {a : α} (hs : is_measurable s) : s ∈ (dirac a).ae ↔ a ∈ s :=
+lemma mem_ae_dirac_iff {a : α} (hs : measurable_set s) : s ∈ (dirac a).ae ↔ a ∈ s :=
 by by_cases a ∈ s; simp [mem_ae_iff, dirac_apply', hs.compl, indicator_apply, *]
 
-lemma ae_dirac_iff {a : α} {p : α → Prop} (hp : is_measurable {x | p x}) :
+lemma ae_dirac_iff {a : α} {p : α → Prop} (hp : measurable_set {x | p x}) :
   (∀ᵐ x ∂(dirac a), p x) ↔ p a :=
 mem_ae_dirac_iff hp
 
@@ -1423,7 +1424,7 @@ by { ext s, simp [mem_ae_iff, imp_false] }
 
 lemma ae_eq_dirac' [measurable_singleton_class β] {a : α} {f : α → β} (hf : measurable f) :
   f =ᵐ[dirac a] const α (f a) :=
-(ae_dirac_iff $ show is_measurable (f ⁻¹' {f a}), from hf $ is_measurable_singleton _).2 rfl
+(ae_dirac_iff $ show measurable_set (f ⁻¹' {f a}), from hf $ measurable_set_singleton _).2 rfl
 
 lemma ae_eq_dirac [measurable_singleton_class α] {a : α} (f : α → δ) :
   f =ᵐ[dirac a] const α (f a) :=
@@ -1600,11 +1601,11 @@ open measure
 /-- A measure `μ` is called σ-finite if there is a countable collection of sets
   `{ A i | i ∈ ℕ }` such that `μ (A i) < ⊤` and `⋃ i, A i = s`. -/
 @[class] def sigma_finite (μ : measure α) : Prop :=
-nonempty (μ.finite_spanning_sets_in {s | is_measurable s})
+nonempty (μ.finite_spanning_sets_in {s | measurable_set s})
 
 /-- If `μ` is σ-finite it has finite spanning sets in the collection of all measurable sets. -/
 def measure.to_finite_spanning_sets_in (μ : measure α) [h : sigma_finite μ] :
-  μ.finite_spanning_sets_in {s | is_measurable s} :=
+  μ.finite_spanning_sets_in {s | measurable_set s} :=
 classical.choice h
 
 /-- A noncomputable way to get a monotone collection of sets that span `univ` and have finite
@@ -1617,9 +1618,9 @@ lemma monotone_spanning_sets (μ : measure α) [sigma_finite μ] :
   monotone (spanning_sets μ) :=
 monotone_accumulate
 
-lemma is_measurable_spanning_sets (μ : measure α) [sigma_finite μ] (i : ℕ) :
-  is_measurable (spanning_sets μ i) :=
-is_measurable.Union $ λ j, is_measurable.Union_Prop $
+lemma measurable_set_spanning_sets (μ : measure α) [sigma_finite μ] (i : ℕ) :
+  measurable_set (spanning_sets μ i) :=
+measurable_set.Union $ λ j, measurable_set.Union_Prop $
   λ hij, μ.to_finite_spanning_sets_in.set_mem j
 
 lemma measure_spanning_sets_lt_top (μ : measure α) [sigma_finite μ] (i : ℕ) :
@@ -1636,10 +1637,10 @@ lemma is_countably_spanning_spanning_sets (μ : measure α) [sigma_finite μ] :
 
 namespace measure
 
-lemma supr_restrict_spanning_sets [sigma_finite μ] (hs : is_measurable s) :
+lemma supr_restrict_spanning_sets [sigma_finite μ] (hs : measurable_set s) :
   (⨆ i, μ.restrict (spanning_sets μ i) s) = μ s :=
 begin
-  convert (restrict_Union_apply_eq_supr (is_measurable_spanning_sets μ) _ hs).symm,
+  convert (restrict_Union_apply_eq_supr (measurable_set_spanning_sets μ) _ hs).symm,
   { simp [Union_spanning_sets] },
   { exact directed_of_sup (monotone_spanning_sets μ) }
 end
@@ -1654,7 +1655,7 @@ protected def mono (h : μ.finite_spanning_sets_in C) (hC : C ⊆ D) : μ.finite
 
 /-- If `μ` has finite spanning sets in the collection of measurable sets `C`, then `μ` is σ-finite.
 -/
-protected lemma sigma_finite (h : μ.finite_spanning_sets_in C) (hC : ∀ s ∈ C, is_measurable s) :
+protected lemma sigma_finite (h : μ.finite_spanning_sets_in C) (hC : ∀ s ∈ C, measurable_set s) :
   sigma_finite μ :=
 ⟨h.mono hC⟩
 
@@ -1670,7 +1671,7 @@ protected lemma is_countably_spanning (h : μ.finite_spanning_sets_in C) : is_co
 end finite_spanning_sets_in
 
 lemma sigma_finite_of_not_nonempty (μ : measure α) (hα : ¬ nonempty α) : sigma_finite μ :=
-⟨⟨λ _, ∅, λ n, is_measurable.empty, λ n, by simp, by simp [eq_empty_of_not_nonempty hα univ]⟩⟩
+⟨⟨λ _, ∅, λ n, measurable_set.empty, λ n, by simp, by simp [eq_empty_of_not_nonempty hα univ]⟩⟩
 
 lemma sigma_finite_of_countable {S : set (set α)} (hc : countable S)
   (hμ : ∀ s ∈ S, μ s < ⊤)  (hU : ⋃₀ S = univ) :
@@ -1678,7 +1679,7 @@ lemma sigma_finite_of_countable {S : set (set α)} (hc : countable S)
 begin
   obtain ⟨s, hμ, hs⟩ : ∃ s : ℕ → set α, (∀ n, μ (s n) < ⊤) ∧ (⋃ n, s n) = univ,
     from (exists_seq_cover_iff_countable ⟨∅, by simp⟩).2 ⟨S, hc, hμ, hU⟩,
-  refine ⟨⟨λ n, to_measurable μ (s n), λ n, is_measurable_to_measurable _ _, by simpa, _⟩⟩,
+  refine ⟨⟨λ n, to_measurable μ (s n), λ n, measurable_set_to_measurable _ _, by simpa, _⟩⟩,
   exact eq_univ_of_subset (Union_subset_Union $ λ n, subset_to_measurable μ (s n)) hs
 end
 
@@ -1687,13 +1688,13 @@ end measure
 /-- Every finite measure is σ-finite. -/
 @[priority 100]
 instance finite_measure.to_sigma_finite (μ : measure α) [finite_measure μ] : sigma_finite μ :=
-⟨⟨λ _, univ, λ _, is_measurable.univ, λ _, measure_lt_top μ _, Union_const _⟩⟩
+⟨⟨λ _, univ, λ _, measurable_set.univ, λ _, measure_lt_top μ _, Union_const _⟩⟩
 
 instance restrict.sigma_finite (μ : measure α) [sigma_finite μ] (s : set α) :
   sigma_finite (μ.restrict s) :=
 begin
-  refine ⟨⟨spanning_sets μ, is_measurable_spanning_sets μ, λ i, _, Union_spanning_sets μ⟩⟩,
-  rw [restrict_apply (is_measurable_spanning_sets μ i)],
+  refine ⟨⟨spanning_sets μ, measurable_set_spanning_sets μ, λ i, _, Union_spanning_sets μ⟩⟩,
+  rw [restrict_apply (measurable_set_spanning_sets μ i)],
   exact (measure_mono $ inter_subset_left _ _).trans_lt (measure_spanning_sets_lt_top μ i)
 end
 
@@ -1701,8 +1702,8 @@ instance sum.sigma_finite {ι} [fintype ι] (μ : ι → measure α) [∀ i, sig
   sigma_finite (sum μ) :=
 begin
   haveI : encodable ι := (encodable.trunc_encodable_of_fintype ι).out,
-  have : ∀ n, is_measurable (⋂ (i : ι), spanning_sets (μ i) n) :=
-  λ n, is_measurable.Inter (λ i, is_measurable_spanning_sets (μ i) n),
+  have : ∀ n, measurable_set (⋂ (i : ι), spanning_sets (μ i) n) :=
+  λ n, measurable_set.Inter (λ i, measurable_set_spanning_sets (μ i) n),
   refine ⟨⟨λ n, ⋂ i, spanning_sets (μ i) n, this, λ n, _, _⟩⟩,
   { rw [sum_apply _ (this n), tsum_fintype, ennreal.sum_lt_top_iff],
     rintro i -,
@@ -1763,7 +1764,7 @@ lemma ext_on_measurable_space_of_generate_finite {α} (m₀ : measurable_space �
   {μ ν : measure α} [finite_measure μ]
   (C : set (set α)) (hμν : ∀ s ∈ C, μ s = ν s) {m : measurable_space α}
   (h : m ≤ m₀) (hA : m = measurable_space.generate_from C) (hC : is_pi_system C)
-  (h_univ : μ set.univ = ν set.univ) {s : set α} (hs : m.is_measurable' s) :
+  (h_univ : μ set.univ = ν set.univ) {s : set α} (hs : m.measurable_set' s) :
   μ s = ν s :=
 begin
   haveI : @finite_measure _ m₀ ν := begin
@@ -1773,12 +1774,12 @@ begin
   end,
   refine induction_on_inter hA hC (by simp) hμν _ _ hs,
   { intros t h1t h2t,
-    have h1t_ : @is_measurable α m₀ t, from h _ h1t,
+    have h1t_ : @measurable_set α m₀ t, from h _ h1t,
     rw [@measure_compl α m₀ μ t h1t_ (@measure_lt_top α m₀ μ _ t),
       @measure_compl α m₀ ν t h1t_ (@measure_lt_top α m₀ ν _ t), h_univ, h2t], },
   { intros f h1f h2f h3f,
-    have h2f_ : ∀ (i : ℕ), @is_measurable α m₀ (f i), from (λ i, h _ (h2f i)),
-    have h_Union : @is_measurable α m₀ (⋃ (i : ℕ), f i),from @is_measurable.Union α ℕ m₀ _ f h2f_,
+    have h2f_ : ∀ (i : ℕ), @measurable_set α m₀ (f i), from (λ i, h _ (h2f i)),
+    have h_Union : @measurable_set α m₀ (⋃ (i : ℕ), f i),from @measurable_set.Union α ℕ m₀ _ f h2f_,
     simp [measure_Union, h_Union, h1f, h3f, h2f_], },
 end
 
@@ -1867,11 +1868,11 @@ end
 
 /-- This application lemma only works in special circumstances. Given knowledge of
 when `μ ≤ ν` and `ν ≤ μ`, a more general application lemma can be written. -/
-lemma sub_apply [finite_measure ν] (h₁ : is_measurable s) (h₂ : ν ≤ μ) : (μ - ν) s = μ s - ν s :=
+lemma sub_apply [finite_measure ν] (h₁ : measurable_set s) (h₂ : ν ≤ μ) : (μ - ν) s = μ s - ν s :=
 begin
   -- We begin by defining `measure_sub`, which will be equal to `(μ - ν)`.
   let measure_sub : measure α := @measure_theory.measure.of_measurable α _
-    (λ (t : set α) (h_t_is_measurable : is_measurable t), (μ t - ν t))
+    (λ (t : set α) (h_t_measurable_set : measurable_set t), (μ t - ν t))
     begin
       simp
     end
@@ -1883,10 +1884,10 @@ begin
   -- Now, we demonstrate `μ - ν = measure_sub`, and apply it.
   begin
     have h_measure_sub_add : (ν + measure_sub = μ),
-    { ext t h_t_is_measurable,
+    { ext t h_t_measurable_set,
       simp only [pi.add_apply, coe_add],
-      rw [measure_theory.measure.of_measurable_apply _ h_t_is_measurable, add_comm,
-        ennreal.sub_add_cancel_of_le (h₂ t h_t_is_measurable)] },
+      rw [measure_theory.measure.of_measurable_apply _ h_t_measurable_set, add_comm,
+        ennreal.sub_add_cancel_of_le (h₂ t h_t_measurable_set)] },
     have h_measure_sub_eq : (μ - ν) = measure_sub,
     { rw measure_theory.measure.sub_def, apply le_antisymm,
       { apply @Inf_le (measure α) (measure.complete_lattice), simp [le_refl, add_comm,
@@ -1961,16 +1962,16 @@ section is_complete
   that a set `s` is null if `μ s = 0`. -/
 @[class] def measure_theory.measure.is_complete {_ : measurable_space α} (μ : measure α) :
   Prop :=
-∀ s, μ s = 0 → is_measurable s
+∀ s, μ s = 0 → measurable_set s
 
 variables [measurable_space α] {μ : measure α} {s t z : set α}
 
 /-- A set is null measurable if it is the union of a null set and a measurable set. -/
 def null_measurable_set (μ : measure α) (s : set α) : Prop :=
-∃ t z, s = t ∪ z ∧ is_measurable t ∧ μ z = 0
+∃ t z, s = t ∪ z ∧ measurable_set t ∧ μ z = 0
 
 theorem null_measurable_set_iff : null_measurable_set μ s ↔
-  ∃ t, t ⊆ s ∧ is_measurable t ∧ μ (s \ t) = 0 :=
+  ∃ t, t ⊆ s ∧ measurable_set t ∧ μ (s \ t) = 0 :=
 begin
   split,
   { rintro ⟨t, z, rfl, ht, hz⟩,
@@ -1987,14 +1988,14 @@ begin
   rw [union_diff_cancel st, hz] at this, simpa
 end
 
-theorem is_measurable.null_measurable_set (μ : measure α) (hs : is_measurable s) :
+theorem measurable_set.null_measurable_set (μ : measure α) (hs : measurable_set s) :
   null_measurable_set μ s :=
 ⟨s, ∅, by simp, hs, μ.empty⟩
 
 theorem null_measurable_set_of_complete (μ : measure α) [c : μ.is_complete] :
-  null_measurable_set μ s ↔ is_measurable s :=
+  null_measurable_set μ s ↔ measurable_set s :=
 ⟨by rintro ⟨t, z, rfl, ht, hz⟩; exact
-  is_measurable.union ht (c _ hz),
+  measurable_set.union ht (c _ hz),
  λ h, h.null_measurable_set _⟩
 
 theorem null_measurable_set.union_null (hs : null_measurable_set μ s) (hz : μ z = 0) :
@@ -2006,7 +2007,7 @@ begin
 end
 
 theorem null_null_measurable_set (hz : μ z = 0) : null_measurable_set μ z :=
-by simpa using (is_measurable.empty.null_measurable_set _).union_null hz
+by simpa using (measurable_set.empty.null_measurable_set _).union_null hz
 
 theorem null_measurable_set.Union_nat {s : ℕ → set α} (hs : ∀ i, null_measurable_set μ (s i)) :
   null_measurable_set μ (Union s) :=
@@ -2015,24 +2016,24 @@ begin
   simp [forall_and_distrib] at ht,
   rcases ht with ⟨st, ht, hz⟩,
   refine null_measurable_set_iff.2
-    ⟨Union t, Union_subset_Union st, is_measurable.Union ht,
+    ⟨Union t, Union_subset_Union st, measurable_set.Union ht,
       measure_mono_null _ (measure_Union_null hz)⟩,
   rw [diff_subset_iff, ← Union_union_distrib],
   exact Union_subset_Union (λ i, by rw ← diff_subset_iff)
 end
 
-theorem is_measurable.diff_null (hs : is_measurable s) (hz : μ z = 0) :
+theorem measurable_set.diff_null (hs : measurable_set s) (hz : μ z = 0) :
   null_measurable_set μ (s \ z) :=
 begin
   rw measure_eq_infi at hz,
   choose f hf using show ∀ q : {q : ℚ // q > 0}, ∃ t : set α,
-    z ⊆ t ∧ is_measurable t ∧ μ t < (nnreal.of_real q.1 : ennreal),
+    z ⊆ t ∧ measurable_set t ∧ μ t < (nnreal.of_real q.1 : ennreal),
   { rintro ⟨ε, ε0⟩,
     have : 0 < (nnreal.of_real ε : ennreal), { simpa using ε0 },
     rw ← hz at this, simpa [infi_lt_iff] },
   refine null_measurable_set_iff.2 ⟨s \ Inter f,
     diff_subset_diff_right (subset_Inter (λ i, (hf i).1)),
-    hs.diff (is_measurable.Inter (λ i, (hf i).2.1)),
+    hs.diff (measurable_set.Inter (λ i, (hf i).2.1)),
     measure_mono_null _ (nonpos_iff_eq_zero.1 $ le_of_not_lt $ λ h, _)⟩,
   { exact Inter f },
   { rw [diff_subset_iff, diff_union_self],
@@ -2059,7 +2060,7 @@ begin
 end
 
 theorem null_measurable_set_iff_ae {s : set α} :
-  null_measurable_set μ s ↔ ∃ t, is_measurable t ∧ s =ᵐ[μ] t :=
+  null_measurable_set μ s ↔ ∃ t, measurable_set t ∧ s =ᵐ[μ] t :=
 begin
   simp only [ae_eq_set],
   split,
@@ -2084,7 +2085,7 @@ end
 
 theorem null_measurable_set_iff_sandwich {s : set α} :
   null_measurable_set μ s ↔
-  ∃ (t u : set α), is_measurable t ∧ is_measurable u ∧ t ⊆ s ∧ s ⊆ u ∧ μ (u \ t) = 0 :=
+  ∃ (t u : set α), measurable_set t ∧ measurable_set u ∧ t ⊆ s ∧ s ⊆ u ∧ μ (u \ t) = 0 :=
 begin
   split,
   { assume h,
@@ -2127,14 +2128,14 @@ begin
 end
 
 /-- The measurable space of all null measurable sets. -/
-def null_measurable_fun (μ : measure α) : measurable_space α :=
-{ is_measurable' := null_measurable_set μ,
-  is_measurable_empty := is_measurable.empty.null_measurable_set _,
-  is_measurable_compl := λ s hs, hs.compl,
-  is_measurable_Union := λ f, null_measurable_set.Union_nat }
+def null_measurable (μ : measure α) : measurable_space α :=
+{ measurable_set' := null_measurable_set μ,
+  measurable_set_empty := measurable_set.empty.null_measurable_set _,
+  measurable_set_compl := λ s hs, hs.compl,
+  measurable_set_Union := λ f, null_measurable_set.Union_nat }
 
 /-- Given a measure we can complete it to a (complete) measure on all null measurable sets. -/
-def completion (μ : measure α) : @measure_theory.measure α (null_measurable_fun μ) :=
+def completion (μ : measure α) : @measure_theory.measure α (null_measurable μ) :=
 { to_outer_measure := μ.to_outer_measure,
   m_Union := λ s hs hd, show μ (Union s) = ∑' i, μ (s i), begin
     choose t ht using assume i, null_measurable_set_iff.1 (hs i),
@@ -2150,7 +2151,7 @@ def completion (μ : measure α) : @measure_theory.measure α (null_measurable_f
       exact Union_subset_Union (λ i, by rw ← diff_subset_iff) }
   end,
   trimmed := begin
-    letI := null_measurable_fun μ,
+    letI := null_measurable μ,
     refine le_antisymm (λ s, _) (outer_measure.le_trim _),
     rw outer_measure.trim_eq_infi,
     dsimp,
@@ -2172,13 +2173,13 @@ begin
   let t := {x | f x = g x},
   have ht_compl : μ tᶜ = 0, by rwa [filter.eventually_eq, ae_iff] at hfg,
   rw (set.inter_union_compl (g ⁻¹' s) t).symm,
-  refine is_measurable.union _ _,
+  refine measurable_set.union _ _,
   { have h_g_to_f : (g ⁻¹' s) ∩ t = (f ⁻¹' s) ∩ t,
     { ext,
       simp only [set.mem_inter_iff, set.mem_preimage, and.congr_left_iff, set.mem_set_of_eq],
       exact λ hx, by rw hx, },
     rw h_g_to_f,
-    exact is_measurable.inter (hf hs) (is_measurable.compl_iff.mp (hμ tᶜ ht_compl)), },
+    exact measurable_set.inter (hf hs) (measurable_set.compl_iff.mp (hμ tᶜ ht_compl)), },
   { exact hμ (g ⁻¹' s ∩ tᶜ) (measure_mono_null (set.inter_subset_right _ _) ht_compl), },
 end
 
@@ -2287,8 +2288,8 @@ lemma add_measure {f : α → β} (hμ : ae_measurable f μ) (hν : ae_measurabl
 begin
   let s := {x | f x ≠ hμ.mk f x},
   have : μ s = 0 := hμ.ae_eq_mk,
-  obtain ⟨t, st, t_meas, μt⟩ : ∃ t, s ⊆ t ∧ is_measurable t ∧ μ t = 0 :=
-    exists_is_measurable_superset_of_null this,
+  obtain ⟨t, st, t_meas, μt⟩ : ∃ t, s ⊆ t ∧ measurable_set t ∧ μ t = 0 :=
+    exists_measurable_set_superset_of_null this,
   let g : α → β := t.piecewise (hν.mk f) (hμ.mk f),
   refine ⟨g, measurable.piecewise t_meas hν.measurable_mk hμ.measurable_mk, _⟩,
   change μ {x | f x ≠ g x} + ν {x | f x ≠ g x} = 0,
@@ -2327,7 +2328,7 @@ lemma prod_mk {γ : Type*} [measurable_space γ] {f : α → β} {g : α → γ}
 ⟨λ a, (hf.mk f a, hg.mk g a), hf.measurable_mk.prod_mk hg.measurable_mk,
   eventually_eq.prod_mk hf.ae_eq_mk hg.ae_eq_mk⟩
 
-lemma null_measurable_set (h : ae_measurable f μ) {s : set β} (hs : is_measurable s) :
+lemma null_measurable_set (h : ae_measurable f μ) {s : set β} (hs : measurable_set s) :
   null_measurable_set μ (f ⁻¹' s) :=
 begin
   apply null_measurable_set_iff_ae.2,

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -62,8 +62,8 @@ To prove that two measures are equal, there are multiple options:
 * `ext`: two measures are equal if they are equal on all measurable sets.
 * `ext_of_generate_from_of_Union`: two measures are equal if they are equal on a π-system generating
   the measurable sets, if the π-system contains a spanning increasing sequence of sets where the
-  measures take finite value (in particular the measures are σ-finite). This is a special case of the
-  more general `ext_of_generate_from_of_cover`
+  measures take finite value (in particular the measures are σ-finite). This is a special case of
+  the more general `ext_of_generate_from_of_cover`
 * `ext_of_generate_finite`: two finite measures are equal if they are equal on a π-system
   generating the measurable sets. This is a special case of `ext_of_generate_from_of_Union` using
   `C ∪ {univ}`, but is easier to work with.
@@ -1889,7 +1889,8 @@ begin
         ennreal.sub_add_cancel_of_le (h₂ t h_t_is_measurable)] },
     have h_measure_sub_eq : (μ - ν) = measure_sub,
     { rw measure_theory.measure.sub_def, apply le_antisymm,
-      { apply @Inf_le (measure α) (measure.complete_lattice), simp [le_refl, add_comm, h_measure_sub_add] },
+      { apply @Inf_le (measure α) (measure.complete_lattice), simp [le_refl, add_comm,
+          h_measure_sub_add] },
       apply @le_Inf (measure α) (measure.complete_lattice),
       intros d h_d, rw [← h_measure_sub_add, mem_set_of_eq, add_comm d] at h_d,
       apply measure.le_of_add_le_add_left h_d },
@@ -1965,10 +1966,10 @@ section is_complete
 variables [measurable_space α] {μ : measure α} {s t z : set α}
 
 /-- A set is null measurable if it is the union of a null set and a measurable set. -/
-def is_null_measurable (μ : measure α) (s : set α) : Prop :=
+def null_measurable_set (μ : measure α) (s : set α) : Prop :=
 ∃ t z, s = t ∪ z ∧ is_measurable t ∧ μ z = 0
 
-theorem is_null_measurable_iff : is_null_measurable μ s ↔
+theorem null_measurable_set_iff : null_measurable_set μ s ↔
   ∃ t, t ⊆ s ∧ is_measurable t ∧ μ (s \ t) = 0 :=
 begin
   split,
@@ -1979,41 +1980,41 @@ begin
     exact ⟨t, _, (union_diff_cancel st).symm, ht, hz⟩ }
 end
 
-theorem is_null_measurable_measure_eq (st : t ⊆ s) (hz : μ (s \ t) = 0) : μ s = μ t :=
+theorem null_measurable_set_measure_eq (st : t ⊆ s) (hz : μ (s \ t) = 0) : μ s = μ t :=
 begin
   refine le_antisymm _ (measure_mono st),
   have := measure_union_le t (s \ t),
   rw [union_diff_cancel st, hz] at this, simpa
 end
 
-theorem is_measurable.is_null_measurable (μ : measure α) (hs : is_measurable s) :
-  is_null_measurable μ s :=
+theorem is_measurable.null_measurable_set (μ : measure α) (hs : is_measurable s) :
+  null_measurable_set μ s :=
 ⟨s, ∅, by simp, hs, μ.empty⟩
 
-theorem is_null_measurable_of_complete (μ : measure α) [c : μ.is_complete] :
-  is_null_measurable μ s ↔ is_measurable s :=
+theorem null_measurable_set_of_complete (μ : measure α) [c : μ.is_complete] :
+  null_measurable_set μ s ↔ is_measurable s :=
 ⟨by rintro ⟨t, z, rfl, ht, hz⟩; exact
   is_measurable.union ht (c _ hz),
- λ h, h.is_null_measurable _⟩
+ λ h, h.null_measurable_set _⟩
 
-theorem is_null_measurable.union_null (hs : is_null_measurable μ s) (hz : μ z = 0) :
-  is_null_measurable μ (s ∪ z) :=
+theorem null_measurable_set.union_null (hs : null_measurable_set μ s) (hz : μ z = 0) :
+  null_measurable_set μ (s ∪ z) :=
 begin
   rcases hs with ⟨t, z', rfl, ht, hz'⟩,
   exact ⟨t, z' ∪ z, set.union_assoc _ _ _, ht, nonpos_iff_eq_zero.1
     (le_trans (measure_union_le _ _) $ by simp [hz, hz'])⟩
 end
 
-theorem null_is_null_measurable (hz : μ z = 0) : is_null_measurable μ z :=
-by simpa using (is_measurable.empty.is_null_measurable _).union_null hz
+theorem null_null_measurable_set (hz : μ z = 0) : null_measurable_set μ z :=
+by simpa using (is_measurable.empty.null_measurable_set _).union_null hz
 
-theorem is_null_measurable.Union_nat {s : ℕ → set α} (hs : ∀ i, is_null_measurable μ (s i)) :
-  is_null_measurable μ (Union s) :=
+theorem null_measurable_set.Union_nat {s : ℕ → set α} (hs : ∀ i, null_measurable_set μ (s i)) :
+  null_measurable_set μ (Union s) :=
 begin
-  choose t ht using assume i, is_null_measurable_iff.1 (hs i),
+  choose t ht using assume i, null_measurable_set_iff.1 (hs i),
   simp [forall_and_distrib] at ht,
   rcases ht with ⟨st, ht, hz⟩,
-  refine is_null_measurable_iff.2
+  refine null_measurable_set_iff.2
     ⟨Union t, Union_subset_Union st, is_measurable.Union ht,
       measure_mono_null _ (measure_Union_null hz)⟩,
   rw [diff_subset_iff, ← Union_union_distrib],
@@ -2021,7 +2022,7 @@ begin
 end
 
 theorem is_measurable.diff_null (hs : is_measurable s) (hz : μ z = 0) :
-  is_null_measurable μ (s \ z) :=
+  null_measurable_set μ (s \ z) :=
 begin
   rw measure_eq_infi at hz,
   choose f hf using show ∀ q : {q : ℚ // q > 0}, ∃ t : set α,
@@ -2029,7 +2030,7 @@ begin
   { rintro ⟨ε, ε0⟩,
     have : 0 < (nnreal.of_real ε : ennreal), { simpa using ε0 },
     rw ← hz at this, simpa [infi_lt_iff] },
-  refine is_null_measurable_iff.2 ⟨s \ Inter f,
+  refine null_measurable_set_iff.2 ⟨s \ Inter f,
     diff_subset_diff_right (subset_Inter (λ i, (hf i).1)),
     hs.diff (is_measurable.Inter (λ i, (hf i).2.1)),
     measure_mono_null _ (nonpos_iff_eq_zero.1 $ le_of_not_lt $ λ h, _)⟩,
@@ -2042,35 +2043,35 @@ begin
   exact measure_mono (Inter_subset _ _)
 end
 
-theorem is_null_measurable.diff_null (hs : is_null_measurable μ s) (hz : μ z = 0) :
-  is_null_measurable μ (s \ z) :=
+theorem null_measurable_set.diff_null (hs : null_measurable_set μ s) (hz : μ z = 0) :
+  null_measurable_set μ (s \ z) :=
 begin
   rcases hs with ⟨t, z', rfl, ht, hz'⟩,
   rw [set.union_diff_distrib],
   exact (ht.diff_null hz).union_null (measure_mono_null (diff_subset _ _) hz')
 end
 
-theorem is_null_measurable.compl (hs : is_null_measurable μ s) : is_null_measurable μ sᶜ :=
+theorem null_measurable_set.compl (hs : null_measurable_set μ s) : null_measurable_set μ sᶜ :=
 begin
   rcases hs with ⟨t, z, rfl, ht, hz⟩,
   rw compl_union,
   exact ht.compl.diff_null hz
 end
 
-theorem is_null_measurable_iff_ae {s : set α} :
-  is_null_measurable μ s ↔ ∃ t, is_measurable t ∧ s =ᵐ[μ] t :=
+theorem null_measurable_set_iff_ae {s : set α} :
+  null_measurable_set μ s ↔ ∃ t, is_measurable t ∧ s =ᵐ[μ] t :=
 begin
   simp only [ae_eq_set],
   split,
   { assume h,
-    rcases is_null_measurable_iff.1 h with ⟨t, ts, tmeas, ht⟩,
+    rcases null_measurable_set_iff.1 h with ⟨t, ts, tmeas, ht⟩,
     refine ⟨t, tmeas, ht, _⟩,
     rw [diff_eq_empty.2 ts, measure_empty] },
   { rintros ⟨t, tmeas, h₁, h₂⟩,
-    have : is_null_measurable μ (t ∪ (s \ t)) :=
-      is_null_measurable.union_null (tmeas.is_null_measurable _) h₁,
-    have A : is_null_measurable μ ((t ∪ (s \ t)) \ (t \ s)) :=
-      is_null_measurable.diff_null this h₂,
+    have : null_measurable_set μ (t ∪ (s \ t)) :=
+      null_measurable_set.union_null (tmeas.null_measurable_set _) h₁,
+    have A : null_measurable_set μ ((t ∪ (s \ t)) \ (t \ s)) :=
+      null_measurable_set.diff_null this h₂,
     have : (t ∪ (s \ t)) \ (t \ s) = s,
     { apply subset.antisymm,
       { assume x hx,
@@ -2081,14 +2082,14 @@ begin
     rwa this at A }
 end
 
-theorem is_null_measurable_iff_sandwich {s : set α} :
-  is_null_measurable μ s ↔
+theorem null_measurable_set_iff_sandwich {s : set α} :
+  null_measurable_set μ s ↔
   ∃ (t u : set α), is_measurable t ∧ is_measurable u ∧ t ⊆ s ∧ s ⊆ u ∧ μ (u \ t) = 0 :=
 begin
   split,
   { assume h,
-    rcases is_null_measurable_iff.1 h with ⟨t, ts, tmeas, ht⟩,
-    rcases is_null_measurable_iff.1 h.compl with ⟨u', u's, u'meas, hu'⟩,
+    rcases null_measurable_set_iff.1 h with ⟨t, ts, tmeas, ht⟩,
+    rcases null_measurable_set_iff.1 h.compl with ⟨u', u's, u'meas, hu'⟩,
     have A : s ⊆ u'ᶜ := subset_compl_comm.mp u's,
     refine ⟨t, u'ᶜ, tmeas, u'meas.compl, ts, A, _⟩,
     have : sᶜ \ u' = u'ᶜ \ s, by simp [compl_eq_univ_diff, diff_diff, union_comm],
@@ -2104,16 +2105,16 @@ begin
     ... ≤ μ (u'ᶜ \ s) + μ (s \ t) : measure_union_le _ _
     ... = 0 : by rw [ht, hu', zero_add] },
   { rintros ⟨t, u, tmeas, umeas, ts, su, hμ⟩,
-    refine is_null_measurable_iff.2 ⟨t, ts, tmeas, _⟩,
+    refine null_measurable_set_iff.2 ⟨t, ts, tmeas, _⟩,
     apply le_antisymm _ bot_le,
     calc μ (s \ t) ≤ μ (u \ t) : measure_mono (diff_subset_diff_left su)
     ... = 0 : hμ }
 end
 
-lemma restrict_apply_of_is_null_measurable {s t : set α}
-  (ht : is_null_measurable (μ.restrict s) t) : μ.restrict s t = μ (t ∩ s) :=
+lemma restrict_apply_of_null_measurable_set {s t : set α}
+  (ht : null_measurable_set (μ.restrict s) t) : μ.restrict s t = μ (t ∩ s) :=
 begin
-  rcases is_null_measurable_iff_sandwich.1 ht with ⟨u, v, umeas, vmeas, ut, tv, huv⟩,
+  rcases null_measurable_set_iff_sandwich.1 ht with ⟨u, v, umeas, vmeas, ut, tv, huv⟩,
   apply le_antisymm _ (le_restrict_apply _ _),
   calc μ.restrict s t ≤ μ.restrict s v : measure_mono tv
   ... = μ (v ∩ s) : restrict_apply vmeas
@@ -2126,22 +2127,22 @@ begin
 end
 
 /-- The measurable space of all null measurable sets. -/
-def null_measurable (μ : measure α) : measurable_space α :=
-{ is_measurable' := is_null_measurable μ,
-  is_measurable_empty := is_measurable.empty.is_null_measurable _,
+def null_measurable_fun (μ : measure α) : measurable_space α :=
+{ is_measurable' := null_measurable_set μ,
+  is_measurable_empty := is_measurable.empty.null_measurable_set _,
   is_measurable_compl := λ s hs, hs.compl,
-  is_measurable_Union := λ f, is_null_measurable.Union_nat }
+  is_measurable_Union := λ f, null_measurable_set.Union_nat }
 
 /-- Given a measure we can complete it to a (complete) measure on all null measurable sets. -/
-def completion (μ : measure α) : @measure_theory.measure α (null_measurable μ) :=
+def completion (μ : measure α) : @measure_theory.measure α (null_measurable_fun μ) :=
 { to_outer_measure := μ.to_outer_measure,
   m_Union := λ s hs hd, show μ (Union s) = ∑' i, μ (s i), begin
-    choose t ht using assume i, is_null_measurable_iff.1 (hs i),
+    choose t ht using assume i, null_measurable_set_iff.1 (hs i),
     simp [forall_and_distrib] at ht, rcases ht with ⟨st, ht, hz⟩,
-    rw is_null_measurable_measure_eq (Union_subset_Union st),
+    rw null_measurable_set_measure_eq (Union_subset_Union st),
     { rw measure_Union _ ht,
       { congr, funext i,
-        exact (is_null_measurable_measure_eq (st i) (hz i)).symm },
+        exact (null_measurable_set_measure_eq (st i) (hz i)).symm },
       { rintro i j ij x ⟨h₁, h₂⟩,
         exact hd i j ij ⟨st i h₁, st j h₂⟩ } },
     { refine measure_mono_null _ (measure_Union_null hz),
@@ -2149,7 +2150,7 @@ def completion (μ : measure α) : @measure_theory.measure α (null_measurable �
       exact Union_subset_Union (λ i, by rw ← diff_subset_iff) }
   end,
   trimmed := begin
-    letI := null_measurable μ,
+    letI := null_measurable_fun μ,
     refine le_antisymm (λ s, _) (outer_measure.le_trim _),
     rw outer_measure.trim_eq_infi,
     dsimp,
@@ -2157,11 +2158,11 @@ def completion (μ : measure α) : @measure_theory.measure α (null_measurable �
     resetI,
     rw measure_eq_infi s,
     exact infi_le_infi (λ t, infi_le_infi $ λ st,
-      infi_le_infi2 $ λ ht, ⟨ht.is_null_measurable _, le_refl _⟩)
+      infi_le_infi2 $ λ ht, ⟨ht.null_measurable_set _, le_refl _⟩)
   end }
 
 instance completion.is_complete (μ : measure α) : (completion μ).is_complete :=
-λ z hz, null_is_null_measurable hz
+λ z hz, null_null_measurable_set hz
 
 lemma measurable.ae_eq {α β} [measurable_space α] [measurable_space β] {μ : measure α}
   [hμ : μ.is_complete] {f g : α → β} (hf : measurable f) (hfg : f =ᵐ[μ] g) :
@@ -2326,10 +2327,10 @@ lemma prod_mk {γ : Type*} [measurable_space γ] {f : α → β} {g : α → γ}
 ⟨λ a, (hf.mk f a, hg.mk g a), hf.measurable_mk.prod_mk hg.measurable_mk,
   eventually_eq.prod_mk hf.ae_eq_mk hg.ae_eq_mk⟩
 
-lemma is_null_measurable (h : ae_measurable f μ) {s : set β} (hs : is_measurable s) :
-  is_null_measurable μ (f ⁻¹' s) :=
+lemma null_measurable_set (h : ae_measurable f μ) {s : set β} (hs : is_measurable s) :
+  null_measurable_set μ (f ⁻¹' s) :=
 begin
-  apply is_null_measurable_iff_ae.2,
+  apply null_measurable_set_iff_ae.2,
   refine ⟨(h.mk f) ⁻¹' s, h.measurable_mk hs, _⟩,
   filter_upwards [h.ae_eq_mk],
   assume x hx,

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -197,31 +197,31 @@ nonpos_iff_eq_zero.1 $ h₂ ▸ measure_mono h
 lemma measure_mono_top (h : s₁ ⊆ s₂) (h₁ : μ s₁ = ⊤) : μ s₂ = ⊤ :=
 top_unique $ h₁ ▸ measure_mono h
 
-lemma exists_measurable_set_superset (μ : measure α) (s : set α) :
+lemma exists_measurable_superset (μ : measure α) (s : set α) :
   ∃ t, s ⊆ t ∧ measurable_set t ∧ μ t = μ s :=
-by simpa only [← measure_eq_trim] using μ.to_outer_measure.exists_measurable_set_superset_eq_trim s
+by simpa only [← measure_eq_trim] using μ.to_outer_measure.exists_measurable_superset_eq_trim s
 
 /-- A measurable set `t ⊇ s` such that `μ t = μ s`. -/
 def to_measurable (μ : measure α) (s : set α) : set α :=
-classical.some (exists_measurable_set_superset μ s)
+classical.some (exists_measurable_superset μ s)
 
 lemma subset_to_measurable (μ : measure α) (s : set α) : s ⊆ to_measurable μ s :=
-(classical.some_spec (exists_measurable_set_superset μ s)).1
+(classical.some_spec (exists_measurable_superset μ s)).1
 
 @[simp] lemma measurable_set_to_measurable (μ : measure α) (s : set α) :
   measurable_set (to_measurable μ s) :=
-(classical.some_spec (exists_measurable_set_superset μ s)).2.1
+(classical.some_spec (exists_measurable_superset μ s)).2.1
 
 @[simp] lemma measure_to_measurable (s : set α) : μ (to_measurable μ s) = μ s :=
-(classical.some_spec (exists_measurable_set_superset μ s)).2.2
+(classical.some_spec (exists_measurable_superset μ s)).2.2
 
-lemma exists_measurable_set_superset_of_null (h : μ s = 0) :
+lemma exists_measurable_superset_of_null (h : μ s = 0) :
   ∃ t, s ⊆ t ∧ measurable_set t ∧ μ t = 0 :=
-outer_measure.exists_measurable_set_superset_of_trim_eq_zero (by rw [← measure_eq_trim, h])
+outer_measure.exists_measurable_superset_of_trim_eq_zero (by rw [← measure_eq_trim, h])
 
-lemma exists_measurable_set_superset_iff_measure_eq_zero :
+lemma exists_measurable_superset_iff_measure_eq_zero :
   (∃ t, s ⊆ t ∧ measurable_set t ∧ μ t = 0) ↔ μ s = 0 :=
-⟨λ ⟨t, hst, _, ht⟩, measure_mono_null hst ht, exists_measurable_set_superset_of_null⟩
+⟨λ ⟨t, hst, _, ht⟩, measure_mono_null hst ht, exists_measurable_superset_of_null⟩
 
 theorem measure_Union_le [encodable β] (s : β → set α) : μ (⋃ i, s i) ≤ ∑' i, μ (s i) :=
 μ.to_outer_measure.Union _
@@ -818,7 +818,7 @@ nonpos_iff_eq_zero.1 (h ▸ le_restrict_apply _ _)
 lemma restrict_apply_eq_zero' (hs : measurable_set s) : μ.restrict s t = 0 ↔ μ (t ∩ s) = 0 :=
 begin
   refine ⟨measure_inter_eq_zero_of_restrict, λ h, _⟩,
-  rcases exists_measurable_set_superset_of_null h with ⟨t', htt', ht', ht'0⟩,
+  rcases exists_measurable_superset_of_null h with ⟨t', htt', ht', ht'0⟩,
   apply measure_mono_null ((inter_subset _ _ _).1 htt'),
   rw [restrict_apply (hs.compl.union ht'), union_inter_distrib_right, compl_inter_self,
     set.empty_union],
@@ -1212,7 +1212,7 @@ infix ` ≪ `:50 := absolutely_continuous
 lemma absolutely_continuous.mk (h : ∀ ⦃s : set α⦄, measurable_set s → ν s = 0 → μ s = 0) : μ ≪ ν :=
 begin
   intros s hs,
-  rcases exists_measurable_set_superset_of_null hs with ⟨t, h1t, h2t, h3t⟩,
+  rcases exists_measurable_superset_of_null hs with ⟨t, h1t, h2t, h3t⟩,
   exact measure_mono_null h1t (h h2t h3t),
 end
 
@@ -1290,7 +1290,7 @@ instance : countable_Inter_filter μ.ae :=
 end⟩
 
 instance ae_is_measurably_generated : is_measurably_generated μ.ae :=
-⟨λ s hs, let ⟨t, hst, htm, htμ⟩ := exists_measurable_set_superset_of_null hs in
+⟨λ s hs, let ⟨t, hst, htm, htμ⟩ := exists_measurable_superset_of_null hs in
   ⟨tᶜ, compl_mem_ae_iff.2 htμ, htm.compl, compl_subset_comm.1 hst⟩⟩
 
 lemma ae_all_iff [encodable ι] {p : α → ι → Prop} :
@@ -1618,7 +1618,7 @@ lemma monotone_spanning_sets (μ : measure α) [sigma_finite μ] :
   monotone (spanning_sets μ) :=
 monotone_accumulate
 
-lemma measurable_set_spanning_sets (μ : measure α) [sigma_finite μ] (i : ℕ) :
+lemma measurable_spanning_sets (μ : measure α) [sigma_finite μ] (i : ℕ) :
   measurable_set (spanning_sets μ i) :=
 measurable_set.Union $ λ j, measurable_set.Union_Prop $
   λ hij, μ.to_finite_spanning_sets_in.set_mem j
@@ -1640,7 +1640,7 @@ namespace measure
 lemma supr_restrict_spanning_sets [sigma_finite μ] (hs : measurable_set s) :
   (⨆ i, μ.restrict (spanning_sets μ i) s) = μ s :=
 begin
-  convert (restrict_Union_apply_eq_supr (measurable_set_spanning_sets μ) _ hs).symm,
+  convert (restrict_Union_apply_eq_supr (measurable_spanning_sets μ) _ hs).symm,
   { simp [Union_spanning_sets] },
   { exact directed_of_sup (monotone_spanning_sets μ) }
 end
@@ -1693,8 +1693,8 @@ instance finite_measure.to_sigma_finite (μ : measure α) [finite_measure μ] : 
 instance restrict.sigma_finite (μ : measure α) [sigma_finite μ] (s : set α) :
   sigma_finite (μ.restrict s) :=
 begin
-  refine ⟨⟨spanning_sets μ, measurable_set_spanning_sets μ, λ i, _, Union_spanning_sets μ⟩⟩,
-  rw [restrict_apply (measurable_set_spanning_sets μ i)],
+  refine ⟨⟨spanning_sets μ, measurable_spanning_sets μ, λ i, _, Union_spanning_sets μ⟩⟩,
+  rw [restrict_apply (measurable_spanning_sets μ i)],
   exact (measure_mono $ inter_subset_left _ _).trans_lt (measure_spanning_sets_lt_top μ i)
 end
 
@@ -1703,7 +1703,7 @@ instance sum.sigma_finite {ι} [fintype ι] (μ : ι → measure α) [∀ i, sig
 begin
   haveI : encodable ι := (encodable.trunc_encodable_of_fintype ι).out,
   have : ∀ n, measurable_set (⋂ (i : ι), spanning_sets (μ i) n) :=
-  λ n, measurable_set.Inter (λ i, measurable_set_spanning_sets (μ i) n),
+  λ n, measurable_set.Inter (λ i, measurable_spanning_sets (μ i) n),
   refine ⟨⟨λ n, ⋂ i, spanning_sets (μ i) n, this, λ n, _, _⟩⟩,
   { rw [sum_apply _ (this n), tsum_fintype, ennreal.sum_lt_top_iff],
     rintro i -,
@@ -2289,7 +2289,7 @@ begin
   let s := {x | f x ≠ hμ.mk f x},
   have : μ s = 0 := hμ.ae_eq_mk,
   obtain ⟨t, st, t_meas, μt⟩ : ∃ t, s ⊆ t ∧ measurable_set t ∧ μ t = 0 :=
-    exists_measurable_set_superset_of_null this,
+    exists_measurable_superset_of_null this,
   let g : α → β := t.piecewise (hν.mk f) (hμ.mk f),
   refine ⟨g, measurable.piecewise t_meas hν.measurable_mk hμ.measurable_mk, _⟩,
   change μ {x | f x ≠ g x} + ν {x | f x ≠ g x} = 0,

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -908,7 +908,7 @@ theorem trim_sum_ge {ι} (m : ι → outer_measure α) : sum (λ i, (m i).trim) 
 λ t st ht, ennreal.tsum_le_tsum (λ i,
   infi_le_of_le t $ infi_le_of_le st $ infi_le _ ht)
 
-lemma exists_measurable_set_superset_eq_trim (m : outer_measure α) (s : set α) :
+lemma exists_measurable_superset_eq_trim (m : outer_measure α) (s : set α) :
   ∃ t, s ⊆ t ∧ measurable_set t ∧ m t = m.trim s :=
 begin
   simp only [trim_eq_infi], set ms := ⨅ (t : set α) (st : s ⊆ t) (ht : measurable_set t), m t,
@@ -935,11 +935,11 @@ begin
       refine infi_le _ (measurable_set.Inter hm) } }
 end
 
-lemma exists_measurable_set_superset_of_trim_eq_zero
+lemma exists_measurable_superset_of_trim_eq_zero
   {m : outer_measure α} {s : set α} (h : m.trim s = 0) :
   ∃t, s ⊆ t ∧ measurable_set t ∧ m t = 0 :=
 begin
-  rcases exists_measurable_set_superset_eq_trim m s with ⟨t, hst, ht, hm⟩,
+  rcases exists_measurable_superset_eq_trim m s with ⟨t, hst, ht, hm⟩,
   exact ⟨t, hst, ht, h ▸ hm⟩
 end
 
@@ -951,7 +951,7 @@ begin
   haveI : nonempty {t // s ⊆ t ∧ measurable_set t} := ⟨⟨univ, subset_univ _, measurable_set.univ⟩⟩,
   refine ennreal.infi_mul_left (assume hc hs, _),
   rw ← trim_eq_infi' at hs,
-  simpa [and_assoc] using exists_measurable_set_superset_of_trim_eq_zero hs
+  simpa [and_assoc] using exists_measurable_superset_of_trim_eq_zero hs
 end
 
 /-- The trimmed property of a measure μ states that `μ.to_outer_measure.trim = μ.to_outer_measure`.

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -823,7 +823,8 @@ lemma extend_mono {s₁ s₂ : set α} (h₁ : measurable_set s₁) (hs : s₁ �
   extend m s₁ ≤ extend m s₂ :=
 begin
   refine le_infi _, intro h₂,
-  have := extend_union measurable_set.empty m0 measurable_set.Union mU disjoint_diff h₁ (h₂.diff h₁),
+  have := extend_union measurable_set.empty m0 measurable_set.Union mU disjoint_diff
+    h₁ (h₂.diff h₁),
   rw union_diff_cancel hs at this,
   rw ← extend_eq m,
   exact le_iff_exists_add.2 ⟨_, this⟩,
@@ -871,7 +872,8 @@ by { unfold trim, congr, funext s hs, exact H hs }
 theorem trim_le_trim {m₁ m₂ : outer_measure α} (H : m₁ ≤ m₂) : m₁.trim ≤ m₂.trim :=
 λ s, binfi_le_binfi $ λ f hs, ennreal.tsum_le_tsum $ λ b, infi_le_infi $ λ hf, H _
 
-theorem le_trim_iff {m₁ m₂ : outer_measure α} : m₁ ≤ m₂.trim ↔ ∀ s, measurable_set s → m₁ s ≤ m₂ s :=
+theorem le_trim_iff {m₁ m₂ : outer_measure α} :
+  m₁ ≤ m₂.trim ↔ ∀ s, measurable_set s → m₁ s ≤ m₂ s :=
 le_of_function.trans $ forall_congr $ λ s, le_infi_iff
 
 theorem trim_eq_infi (s : set α) : m.trim s = ⨅ t (st : s ⊆ t) (ht : measurable_set t), m t :=

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -500,15 +500,15 @@ protected def caratheodory : measurable_space α :=
 caratheodory_dynkin.to_measurable_space $ assume s₁ s₂, is_caratheodory_inter
 
 lemma is_caratheodory_iff {s : set α} :
-  caratheodory.is_measurable' s ↔ ∀t, m t = m (t ∩ s) + m (t \ s) :=
+  caratheodory.measurable_set' s ↔ ∀t, m t = m (t ∩ s) + m (t \ s) :=
 iff.rfl
 
 lemma is_caratheodory_iff_le {s : set α} :
-  caratheodory.is_measurable' s ↔ ∀t, m (t ∩ s) + m (t \ s) ≤ m t :=
+  caratheodory.measurable_set' s ↔ ∀t, m (t ∩ s) + m (t \ s) ≤ m t :=
 is_caratheodory_iff_le'
 
 protected lemma Union_eq_of_caratheodory {s : ℕ → set α}
-  (h : ∀i, caratheodory.is_measurable' (s i)) (hd : pairwise (disjoint on s)) :
+  (h : ∀i, caratheodory.measurable_set' (s i)) (hd : pairwise (disjoint on s)) :
   m (⋃i, s i) = ∑'i, m (s i) :=
 f_Union h hd
 
@@ -518,7 +518,7 @@ variables {α : Type*}
 
 lemma of_function_caratheodory {m : set α → ennreal} {s : set α}
   {h₀ : m ∅ = 0} (hs : ∀t, m (t ∩ s) + m (t \ s) ≤ m t) :
-  (outer_measure.of_function m h₀).caratheodory.is_measurable' s :=
+  (outer_measure.of_function m h₀).caratheodory.measurable_set' s :=
 begin
   apply (is_caratheodory_iff_le _).mpr,
   refine λ t, le_infi (λ f, le_infi $ λ hf, _),
@@ -531,7 +531,7 @@ begin
 end
 
 lemma bounded_by_caratheodory {m : set α → ennreal} {s : set α}
-  (hs : ∀t, m (t ∩ s) + m (t \ s) ≤ m t) : (bounded_by m).caratheodory.is_measurable' s :=
+  (hs : ∀t, m (t ∩ s) + m (t \ s) ≤ m t) : (bounded_by m).caratheodory.measurable_set' s :=
 begin
   apply of_function_caratheodory, intro t,
   cases t.eq_empty_or_nonempty with h h,
@@ -554,7 +554,7 @@ theorem le_add_caratheodory (m₁ m₂ : outer_measure α) :
 theorem le_sum_caratheodory {ι} (m : ι → outer_measure α) :
   (⨅ i, (m i).caratheodory) ≤ (sum m).caratheodory :=
 λ s h t, by simp [λ i,
-  measurable_space.is_measurable_infi.1 h i t, ennreal.tsum_add]
+  measurable_space.measurable_set_infi.1 h i t, ennreal.tsum_add]
 
 theorem le_smul_caratheodory (a : ennreal) (m : outer_measure α) :
   m.caratheodory ≤ (a • m).caratheodory :=
@@ -650,7 +650,7 @@ open outer_measure
   `induced_outer_measure`.
 
   Some lemmas below are proven twice, once in the general case, and one where the function `m`
-  is only defined on measurable sets (i.e. when `P = is_measurable`). In the latter cases, we can
+  is only defined on measurable sets (i.e. when `P = measurable_set`). In the latter cases, we can
   remove some hypotheses in the statement. The general version has the same name, but with a prime
   at the end. -/
 section extend
@@ -792,7 +792,7 @@ end
   of `s`.
 -/
 lemma induced_outer_measure_caratheodory (s : set α) :
-  (induced_outer_measure m P0 m0).caratheodory.is_measurable' s ↔ ∀ (t : set α), P t →
+  (induced_outer_measure m P0 m0).caratheodory.measurable_set' s ↔ ∀ (t : set α), P t →
   induced_outer_measure m P0 m0 (t ∩ s) + induced_outer_measure m P0 m0 (t \ s) ≤
     induced_outer_measure m P0 m0 t :=
 begin
@@ -808,22 +808,22 @@ end
 
 end extend_set
 
-/-! If `P` is `is_measurable` for some measurable space, then we can remove some hypotheses of the
+/-! If `P` is `measurable_set` for some measurable space, then we can remove some hypotheses of the
   above lemmas. -/
 section measurable_space
 
 variables {α : Type*} [measurable_space α]
-variables {m : Π (s : set α), is_measurable s → ennreal}
-variables (m0 : m ∅ is_measurable.empty = 0)
-variable (mU : ∀ {{f : ℕ → set α}} (hm : ∀i, is_measurable (f i)), pairwise (disjoint on f) →
-  m (⋃i, f i) (is_measurable.Union hm) = ∑'i, m (f i) (hm i))
+variables {m : Π (s : set α), measurable_set s → ennreal}
+variables (m0 : m ∅ measurable_set.empty = 0)
+variable (mU : ∀ {{f : ℕ → set α}} (hm : ∀i, measurable_set (f i)), pairwise (disjoint on f) →
+  m (⋃i, f i) (measurable_set.Union hm) = ∑'i, m (f i) (hm i))
 include m0 mU
 
-lemma extend_mono {s₁ s₂ : set α} (h₁ : is_measurable s₁) (hs : s₁ ⊆ s₂) :
+lemma extend_mono {s₁ s₂ : set α} (h₁ : measurable_set s₁) (hs : s₁ ⊆ s₂) :
   extend m s₁ ≤ extend m s₂ :=
 begin
   refine le_infi _, intro h₂,
-  have := extend_union is_measurable.empty m0 is_measurable.Union mU disjoint_diff h₁ (h₂.diff h₁),
+  have := extend_union measurable_set.empty m0 measurable_set.Union mU disjoint_diff h₁ (h₂.diff h₁),
   rw union_diff_cancel hs at this,
   rw ← extend_eq m,
   exact le_iff_exists_add.2 ⟨_, this⟩,
@@ -831,20 +831,20 @@ end
 
 lemma extend_Union_le_tsum_nat : ∀ (s : ℕ → set α), extend m (⋃i, s i) ≤ ∑'i, extend m (s i) :=
 begin
-  refine extend_Union_le_tsum_nat' is_measurable.Union _, intros f h,
+  refine extend_Union_le_tsum_nat' measurable_set.Union _, intros f h,
   simp [Union_disjointed.symm] {single_pass := tt},
-  rw [mU (is_measurable.disjointed h) disjoint_disjointed],
+  rw [mU (measurable_set.disjointed h) disjoint_disjointed],
   refine ennreal.tsum_le_tsum (λ i, _),
   rw [← extend_eq m, ← extend_eq m],
-  exact extend_mono m0 mU (is_measurable.disjointed h _) (inter_subset_left _ _)
+  exact extend_mono m0 mU (measurable_set.disjointed h _) (inter_subset_left _ _)
 end
 
-lemma induced_outer_measure_eq_extend {s : set α} (hs : is_measurable s) :
-  induced_outer_measure m is_measurable.empty m0 s = extend m s :=
+lemma induced_outer_measure_eq_extend {s : set α} (hs : measurable_set s) :
+  induced_outer_measure m measurable_set.empty m0 s = extend m s :=
 of_function_eq s (λ t, extend_mono m0 mU hs) (extend_Union_le_tsum_nat m0 mU)
 
-lemma induced_outer_measure_eq {s : set α} (hs : is_measurable s) :
-  induced_outer_measure m is_measurable.empty m0 s = m s hs :=
+lemma induced_outer_measure_eq {s : set α} (hs : measurable_set s) :
+  induced_outer_measure m measurable_set.empty m0 s = m s hs :=
 (induced_outer_measure_eq_extend m0 mU hs).trans $ extend_eq _ _
 
 end measurable_space
@@ -855,30 +855,30 @@ variables {α : Type*} [measurable_space α] (m : outer_measure α)
 /-- Given an outer measure `m` we can forget its value on non-measurable sets, and then consider
   `m.trim`, the unique maximal outer measure less than that function. -/
 def trim : outer_measure α :=
-induced_outer_measure (λ s _, m s) is_measurable.empty m.empty
+induced_outer_measure (λ s _, m s) measurable_set.empty m.empty
 
 theorem le_trim : m ≤ m.trim :=
 le_of_function.mpr $ λ s, le_infi $ λ _, le_refl _
 
-theorem trim_eq {s : set α} (hs : is_measurable s) : m.trim s = m s :=
-induced_outer_measure_eq' is_measurable.Union (λ f hf, m.Union_nat f) (λ _ _ _ _ h, m.mono h) hs
+theorem trim_eq {s : set α} (hs : measurable_set s) : m.trim s = m s :=
+induced_outer_measure_eq' measurable_set.Union (λ f hf, m.Union_nat f) (λ _ _ _ _ h, m.mono h) hs
 
 theorem trim_congr {m₁ m₂ : outer_measure α}
-  (H : ∀ {s : set α}, is_measurable s → m₁ s = m₂ s) :
+  (H : ∀ {s : set α}, measurable_set s → m₁ s = m₂ s) :
   m₁.trim = m₂.trim :=
 by { unfold trim, congr, funext s hs, exact H hs }
 
 theorem trim_le_trim {m₁ m₂ : outer_measure α} (H : m₁ ≤ m₂) : m₁.trim ≤ m₂.trim :=
 λ s, binfi_le_binfi $ λ f hs, ennreal.tsum_le_tsum $ λ b, infi_le_infi $ λ hf, H _
 
-theorem le_trim_iff {m₁ m₂ : outer_measure α} : m₁ ≤ m₂.trim ↔ ∀ s, is_measurable s → m₁ s ≤ m₂ s :=
+theorem le_trim_iff {m₁ m₂ : outer_measure α} : m₁ ≤ m₂.trim ↔ ∀ s, measurable_set s → m₁ s ≤ m₂ s :=
 le_of_function.trans $ forall_congr $ λ s, le_infi_iff
 
-theorem trim_eq_infi (s : set α) : m.trim s = ⨅ t (st : s ⊆ t) (ht : is_measurable t), m t :=
+theorem trim_eq_infi (s : set α) : m.trim s = ⨅ t (st : s ⊆ t) (ht : measurable_set t), m t :=
 by { simp only [infi_comm] {single_pass := tt}, exact induced_outer_measure_eq_infi
-    is_measurable.Union (λ f _, m.Union_nat f) (λ _ _ _ _ h, m.mono h) s }
+    measurable_set.Union (λ f _, m.Union_nat f) (λ _ _ _ _ h, m.mono h) s }
 
-theorem trim_eq_infi' (s : set α) : m.trim s = ⨅ t : {t // s ⊆ t ∧ is_measurable t}, m t :=
+theorem trim_eq_infi' (s : set α) : m.trim s = ⨅ t : {t // s ⊆ t ∧ measurable_set t}, m t :=
 by simp [infi_subtype, infi_and, trim_eq_infi]
 
 theorem trim_trim (m : outer_measure α) : m.trim.trim = m.trim :=
@@ -887,7 +887,7 @@ le_antisymm (le_trim_iff.2 $ λ s hs, by simp [trim_eq _ hs, le_refl]) (le_trim 
 @[simp] theorem trim_zero : (0 : outer_measure α).trim = 0 :=
 ext $ λ s, le_antisymm
   (le_trans ((trim 0).mono (subset_univ s)) $
-    le_of_eq $ trim_eq _ is_measurable.univ)
+    le_of_eq $ trim_eq _ measurable_set.univ)
   (zero_le _)
 
 theorem trim_add (m₁ m₂ : outer_measure α) : (m₁ + m₂).trim = m₁.trim + m₂.trim :=
@@ -906,23 +906,23 @@ theorem trim_sum_ge {ι} (m : ι → outer_measure α) : sum (λ i, (m i).trim) 
 λ t st ht, ennreal.tsum_le_tsum (λ i,
   infi_le_of_le t $ infi_le_of_le st $ infi_le _ ht)
 
-lemma exists_is_measurable_superset_eq_trim (m : outer_measure α) (s : set α) :
-  ∃ t, s ⊆ t ∧ is_measurable t ∧ m t = m.trim s :=
+lemma exists_measurable_set_superset_eq_trim (m : outer_measure α) (s : set α) :
+  ∃ t, s ⊆ t ∧ measurable_set t ∧ m t = m.trim s :=
 begin
-  simp only [trim_eq_infi], set ms := ⨅ (t : set α) (st : s ⊆ t) (ht : is_measurable t), m t,
+  simp only [trim_eq_infi], set ms := ⨅ (t : set α) (st : s ⊆ t) (ht : measurable_set t), m t,
   by_cases hs : ms = ⊤,
   { simp only [hs],
     simp only [infi_eq_top] at hs,
-    exact ⟨univ, subset_univ s, is_measurable.univ, hs _ (subset_univ s) is_measurable.univ⟩ },
-  { have : ∀ r > ms, ∃ t, s ⊆ t ∧ is_measurable t ∧ m t < r,
+    exact ⟨univ, subset_univ s, measurable_set.univ, hs _ (subset_univ s) measurable_set.univ⟩ },
+  { have : ∀ r > ms, ∃ t, s ⊆ t ∧ measurable_set t ∧ m t < r,
     { intros r hs,
       simpa [infi_lt_iff] using hs },
-    have : ∀ n : ℕ, ∃ t, s ⊆ t ∧ is_measurable t ∧ m t < ms + n⁻¹,
+    have : ∀ n : ℕ, ∃ t, s ⊆ t ∧ measurable_set t ∧ m t < ms + n⁻¹,
     { assume n,
       refine this _ (ennreal.lt_add_right (lt_top_iff_ne_top.2 hs) _),
       exact (ennreal.inv_pos.2 $ ennreal.nat_ne_top _) },
     choose t hsub hm hm',
-    refine ⟨⋂ n, t n, subset_Inter hsub, is_measurable.Inter hm, _⟩,
+    refine ⟨⋂ n, t n, subset_Inter hsub, measurable_set.Inter hm, _⟩,
     have : tendsto (λ n : ℕ, ms + n⁻¹) at_top (𝓝 (ms + 0)),
       from tendsto_const_nhds.add ennreal.tendsto_inv_nat_nhds_zero,
     rw add_zero at this,
@@ -930,14 +930,14 @@ begin
     { exact le_trans (m.mono' $ Inter_subset t n) (hm' n).le },
     { refine infi_le_of_le (⋂ n, t n) _,
       refine infi_le_of_le (subset_Inter hsub) _,
-      refine infi_le _ (is_measurable.Inter hm) } }
+      refine infi_le _ (measurable_set.Inter hm) } }
 end
 
-lemma exists_is_measurable_superset_of_trim_eq_zero
+lemma exists_measurable_set_superset_of_trim_eq_zero
   {m : outer_measure α} {s : set α} (h : m.trim s = 0) :
-  ∃t, s ⊆ t ∧ is_measurable t ∧ m t = 0 :=
+  ∃t, s ⊆ t ∧ measurable_set t ∧ m t = 0 :=
 begin
-  rcases exists_is_measurable_superset_eq_trim m s with ⟨t, hst, ht, hm⟩,
+  rcases exists_measurable_set_superset_eq_trim m s with ⟨t, hst, ht, hm⟩,
   exact ⟨t, hst, ht, h ▸ hm⟩
 end
 
@@ -946,15 +946,15 @@ theorem trim_smul (c : ennreal) (m : outer_measure α) :
 begin
   ext1 s,
   simp only [trim_eq_infi', smul_apply],
-  haveI : nonempty {t // s ⊆ t ∧ is_measurable t} := ⟨⟨univ, subset_univ _, is_measurable.univ⟩⟩,
+  haveI : nonempty {t // s ⊆ t ∧ measurable_set t} := ⟨⟨univ, subset_univ _, measurable_set.univ⟩⟩,
   refine ennreal.infi_mul_left (assume hc hs, _),
   rw ← trim_eq_infi' at hs,
-  simpa [and_assoc] using exists_is_measurable_superset_of_trim_eq_zero hs
+  simpa [and_assoc] using exists_measurable_set_superset_of_trim_eq_zero hs
 end
 
 /-- The trimmed property of a measure μ states that `μ.to_outer_measure.trim = μ.to_outer_measure`.
 This theorem shows that a restricted trimmed outer measure is a trimmed outer measure. -/
-lemma restrict_trim {μ : outer_measure α} {s : set α} (hs : is_measurable s) :
+lemma restrict_trim {μ : outer_measure α} {s : set α} (hs : measurable_set s) :
   (restrict s μ).trim = restrict s μ.trim :=
 begin
   apply measure_theory.outer_measure.ext, intro t,

--- a/src/measure_theory/pi.lean
+++ b/src/measure_theory/pi.lean
@@ -137,11 +137,11 @@ begin
 end
 
 lemma tprod_tprod (l : list δ) (μ : Π i, measure (π i)) [∀ i, sigma_finite (μ i)]
-  {s : Π i, set (π i)} (hs : ∀ i, is_measurable (s i)) :
+  {s : Π i, set (π i)} (hs : ∀ i, measurable_set (s i)) :
   measure.tprod l μ (set.tprod l s) = (l.map (λ i, (μ i) (s i))).prod :=
 begin
   induction l with i l ih, { simp },
-  simp_rw [tprod_cons, set.tprod, prod_prod (hs i) (is_measurable.tprod l hs), map_cons,
+  simp_rw [tprod_cons, set.tprod, prod_prod (hs i) (measurable_set.tprod l hs), map_cons,
     prod_cons, ih]
 end
 
@@ -167,11 +167,11 @@ def pi' : measure (Π i, α i) :=
 measure.map (tprod.elim' encodable.mem_sorted_univ) (measure.tprod (encodable.sorted_univ ι) μ)
 
 lemma pi'_pi [∀ i, sigma_finite (μ i)] {s : Π i, set (α i)}
-  (hs : ∀ i, is_measurable (s i)) : pi' μ (pi univ s) = ∏ i, μ i (s i) :=
+  (hs : ∀ i, measurable_set (s i)) : pi' μ (pi univ s) = ∏ i, μ i (s i) :=
 begin
   have hl := λ i : ι, encodable.mem_sorted_univ i,
   have hnd := @encodable.sorted_univ_nodup ι _ _,
-  rw [pi', map_apply (measurable_tprod_elim' hl) (is_measurable.pi_fintype (λ i _, hs i)),
+  rw [pi', map_apply (measurable_tprod_elim' hl) (measurable_set.pi_fintype (λ i _, hs i)),
     elim_preimage_pi hnd, tprod_tprod _ μ hs, ← list.prod_to_finset _ hnd],
   congr' with i, simp [hl]
 end
@@ -214,16 +214,16 @@ to_measure (outer_measure.pi (λ i, (μ i).to_outer_measure)) (pi_caratheodory �
 
 variables [∀ i, sigma_finite (μ i)]
 
-lemma pi_pi (s : Π i, set (α i)) (hs : ∀ i, is_measurable (s i)) :
+lemma pi_pi (s : Π i, set (α i)) (hs : ∀ i, measurable_set (s i)) :
   measure.pi μ (pi univ s) = ∏ i, μ i (s i) :=
 begin
   refine le_antisymm _ _,
-  { rw [measure.pi, to_measure_apply _ _ (is_measurable.pi_fintype (λ i _, hs i))],
+  { rw [measure.pi, to_measure_apply _ _ (measurable_set.pi_fintype (λ i _, hs i))],
     apply outer_measure.pi_pi_le },
   { haveI : encodable ι := encodable.fintype.encodable ι,
     rw [← pi'_pi μ hs],
     simp_rw [← pi'_pi μ hs, measure.pi,
-      to_measure_apply _ _ (is_measurable.pi_fintype (λ i _, hs i)), ← to_outer_measure_apply],
+      to_measure_apply _ _ (measurable_set.pi_fintype (λ i _, hs i)), ← to_outer_measure_apply],
     suffices : (pi' μ).to_outer_measure ≤ outer_measure.pi (λ i, (μ i).to_outer_measure),
     { exact this _ },
     clear hs s,
@@ -237,7 +237,7 @@ lemma pi_eval_preimage_null {i : ι} {s : set (α i)} (hs : μ i s = 0) :
   measure.pi μ (eval i ⁻¹' s) = 0 :=
 begin
   /- WLOG, `s` is measurable -/
-  rcases exists_is_measurable_superset_of_null hs with ⟨t, hst, htm, hμt⟩,
+  rcases exists_measurable_set_superset_of_null hs with ⟨t, hst, htm, hμt⟩,
   suffices : measure.pi μ (eval i ⁻¹' t) = 0,
     from measure_mono_null (preimage_mono hst) this,
   clear_dependent s,
@@ -349,7 +349,7 @@ begin
   choose s hxs ho hμ using λ i, (μ i).exists_is_open_measure_lt_top (x i),
   refine ⟨pi univ s, set_pi_mem_nhds finite_univ (λ i hi, mem_nhds_sets (ho i) (hxs i)), _⟩,
   rw [pi_pi],
-  exacts [ennreal.prod_lt_top (λ i _, hμ i), λ i, (ho i).is_measurable]
+  exacts [ennreal.prod_lt_top (λ i _, hμ i), λ i, (ho i).measurable_set]
 end
 
 end measure
@@ -362,7 +362,7 @@ lemma volume_pi [Π i, measure_space (α i)] :
 rfl
 
 lemma volume_pi_pi [Π i, measure_space (α i)] [∀ i, sigma_finite (volume : measure (α i))]
-  (s : Π i, set (α i)) (hs : ∀ i, is_measurable (s i)) :
+  (s : Π i, set (α i)) (hs : ∀ i, measurable_set (s i)) :
   volume (pi univ s) = ∏ i, volume (s i) :=
 measure.pi_pi (λ i, volume) s hs
 

--- a/src/measure_theory/pi.lean
+++ b/src/measure_theory/pi.lean
@@ -237,7 +237,7 @@ lemma pi_eval_preimage_null {i : ι} {s : set (α i)} (hs : μ i s = 0) :
   measure.pi μ (eval i ⁻¹' s) = 0 :=
 begin
   /- WLOG, `s` is measurable -/
-  rcases exists_measurable_set_superset_of_null hs with ⟨t, hst, htm, hμt⟩,
+  rcases exists_measurable_superset_of_null hs with ⟨t, hst, htm, hμt⟩,
   suffices : measure.pi μ (eval i ⁻¹' t) = 0,
     from measure_mono_null (preimage_mono hst) this,
   clear_dependent s,

--- a/src/measure_theory/prod.lean
+++ b/src/measure_theory/prod.lean
@@ -336,7 +336,7 @@ local attribute [instance] nonempty_measurable_superset
 lemma prod_prod_le (s : set α) (t : set β) : μ.prod ν (s.prod t) ≤ μ s * ν t :=
 begin
   by_cases hs0 : μ s = 0,
-  { rcases (exists_measurable_set_superset_of_null hs0) with ⟨s', hs', h2s', h3s'⟩,
+  { rcases (exists_measurable_superset_of_null hs0) with ⟨s', hs', h2s', h3s'⟩,
     convert measure_mono (prod_mono hs' (subset_univ _)),
     simp_rw [hs0, prod_prod h2s' measurable_set.univ, h3s', zero_mul] },
   by_cases hti : ν t = ⊤,
@@ -347,7 +347,7 @@ begin
   rintro ⟨s', h1s', h2s'⟩,
   rw [subtype.coe_mk],
   by_cases ht0 : ν t = 0,
-  { rcases (exists_measurable_set_superset_of_null ht0) with ⟨t', ht', h2t', h3t'⟩,
+  { rcases (exists_measurable_superset_of_null ht0) with ⟨t', ht', h2t', h3t'⟩,
     convert measure_mono (prod_mono (subset_univ _) ht'),
     simp_rw [ht0, prod_prod measurable_set.univ h2t', h3t', mul_zero] },
   by_cases hsi : μ s' = ⊤,
@@ -386,7 +386,7 @@ by simp_rw [prod_apply hs, lintegral_eq_zero_iff (measurable_measure_prod_mk_lef
 lemma measure_ae_null_of_prod_null {s : set (α × β)}
   (h : μ.prod ν s = 0) : (λ x, ν (prod.mk x ⁻¹' s)) =ᵐ[μ] 0 :=
 begin
-  obtain ⟨t, hst, mt, ht⟩ := exists_measurable_set_superset_of_null h,
+  obtain ⟨t, hst, mt, ht⟩ := exists_measurable_superset_of_null h,
   simp_rw [measure_prod_null mt] at ht,
   rw [eventually_le_antisymm_iff],
   exact ⟨eventually_le.trans_eq

--- a/src/measure_theory/prod.lean
+++ b/src/measure_theory/prod.lean
@@ -133,14 +133,14 @@ by rw [← hC, ← hD, generate_from_prod_eq h2C h2D]
 /-- The product σ-algebra is generated from boxes, i.e. `s.prod t` for sets `s : set α` and
   `t : set β`. -/
 lemma generate_from_prod :
-  generate_from (image2 set.prod { s : set α | measurable_set s } { t : set β | measurable_set t }) =
+  generate_from (image2 set.prod {s : set α | measurable_set s} {t : set β | measurable_set t}) =
   prod.measurable_space :=
 generate_from_eq_prod generate_from_measurable_set generate_from_measurable_set
   is_countably_spanning_measurable_set is_countably_spanning_measurable_set
 
 /-- Rectangles form a π-system. -/
 lemma is_pi_system_prod :
-  is_pi_system (image2 set.prod { s : set α | measurable_set s } { t : set β | measurable_set t }) :=
+  is_pi_system (image2 set.prod {s : set α | measurable_set s} {t : set β | measurable_set t}) :=
 is_pi_system_measurable_set.prod is_pi_system_measurable_set
 
 /-- If `ν` is a finite measure, and `s ⊆ α × β` is measurable, then `x ↦ ν { y | (x, y) ∈ s }` is

--- a/src/measure_theory/prod.lean
+++ b/src/measure_theory/prod.lean
@@ -109,18 +109,18 @@ begin
       apply generate_from_le; rintro _ ⟨s, hs, rfl⟩,
     { rcases hD with ⟨t, h1t, h2t⟩,
       rw [← prod_univ, ← h2t, prod_Union],
-      apply is_measurable.Union,
-      intro n, apply is_measurable_generate_from,
+      apply measurable_set.Union,
+      intro n, apply measurable_set_generate_from,
       exact ⟨s, t n, hs, h1t n, rfl⟩ },
     { rcases hC with ⟨t, h1t, h2t⟩,
       rw [← univ_prod, ← h2t, Union_prod],
-      apply is_measurable.Union,
-      rintro n, apply is_measurable_generate_from,
+      apply measurable_set.Union,
+      rintro n, apply measurable_set_generate_from,
       exact mem_image2_of_mem (h1t n) hs } },
   { apply generate_from_le, rintro _ ⟨s, t, hs, ht, rfl⟩, rw [prod_eq],
     apply (measurable_fst _).inter (measurable_snd _),
-    { exact is_measurable_generate_from hs },
-    { exact is_measurable_generate_from ht } }
+    { exact measurable_set_generate_from hs },
+    { exact measurable_set_generate_from ht } }
 end
 
 /-- If `C` and `D` generate the σ-algebras on `α` resp. `β`, then rectangles formed by `C` and `D`
@@ -133,20 +133,20 @@ by rw [← hC, ← hD, generate_from_prod_eq h2C h2D]
 /-- The product σ-algebra is generated from boxes, i.e. `s.prod t` for sets `s : set α` and
   `t : set β`. -/
 lemma generate_from_prod :
-  generate_from (image2 set.prod { s : set α | is_measurable s } { t : set β | is_measurable t }) =
+  generate_from (image2 set.prod { s : set α | measurable_set s } { t : set β | measurable_set t }) =
   prod.measurable_space :=
-generate_from_eq_prod generate_from_is_measurable generate_from_is_measurable
-  is_countably_spanning_is_measurable is_countably_spanning_is_measurable
+generate_from_eq_prod generate_from_measurable_set generate_from_measurable_set
+  is_countably_spanning_measurable_set is_countably_spanning_measurable_set
 
 /-- Rectangles form a π-system. -/
 lemma is_pi_system_prod :
-  is_pi_system (image2 set.prod { s : set α | is_measurable s } { t : set β | is_measurable t }) :=
-is_pi_system_is_measurable.prod is_pi_system_is_measurable
+  is_pi_system (image2 set.prod { s : set α | measurable_set s } { t : set β | measurable_set t }) :=
+is_pi_system_measurable_set.prod is_pi_system_measurable_set
 
 /-- If `ν` is a finite measure, and `s ⊆ α × β` is measurable, then `x ↦ ν { y | (x, y) ∈ s }` is
   a measurable function. `measurable_measure_prod_mk_left` is strictly more general. -/
 lemma measurable_measure_prod_mk_left_finite [finite_measure ν] {s : set (α × β)}
-  (hs : is_measurable s) : measurable (λ x, ν (prod.mk x ⁻¹' s)) :=
+  (hs : measurable_set s) : measurable (λ x, ν (prod.mk x ⁻¹' s)) :=
 begin
   refine induction_on_inter generate_from_prod.symm is_pi_system_prod _ _ _ _ hs,
   { simp [measurable_zero, const_def] },
@@ -165,9 +165,9 @@ end
 /-- If `ν` is a σ-finite measure, and `s ⊆ α × β` is measurable, then `x ↦ ν { y | (x, y) ∈ s }` is
   a measurable function. -/
 lemma measurable_measure_prod_mk_left [sigma_finite ν] {s : set (α × β)}
-  (hs : is_measurable s) : measurable (λ x, ν (prod.mk x ⁻¹' s)) :=
+  (hs : measurable_set s) : measurable (λ x, ν (prod.mk x ⁻¹' s)) :=
 begin
-  have : ∀ x, is_measurable (prod.mk x ⁻¹' s) := λ x, measurable_prod_mk_left hs,
+  have : ∀ x, measurable_set (prod.mk x ⁻¹' s) := λ x, measurable_prod_mk_left hs,
   simp only [← @supr_restrict_spanning_sets _ _ ν, this],
   apply measurable_supr, intro i,
   haveI : fact _ := measure_spanning_sets_lt_top ν i,
@@ -177,8 +177,8 @@ end
 /-- If `μ` is a σ-finite measure, and `s ⊆ α × β` is measurable, then `y ↦ μ { x | (x, y) ∈ s }` is
   a measurable function. -/
 lemma measurable_measure_prod_mk_right {μ : measure α} [sigma_finite μ] {s : set (α × β)}
-  (hs : is_measurable s) : measurable (λ y, μ ((λ x, (x, y)) ⁻¹' s)) :=
-measurable_measure_prod_mk_left (is_measurable_swap_iff.mpr hs)
+  (hs : measurable_set s) : measurable (λ y, μ ((λ x, (x, y)) ⁻¹' s)) :=
+measurable_measure_prod_mk_left (measurable_set_swap_iff.mpr hs)
 
 lemma measurable.map_prod_mk_left [sigma_finite ν] : measurable (λ x : α, map (prod.mk x) ν) :=
 begin
@@ -234,11 +234,11 @@ lemma measurable.lintegral_prod_left [sigma_finite μ] {f : α → β → ennrea
   (hf : measurable (uncurry f)) : measurable (λ y, ∫⁻ x, f x y ∂μ) :=
 hf.lintegral_prod_left'
 
-lemma is_measurable_integrable [sigma_finite ν] [opens_measurable_space E] ⦃f : α → β → E⦄
-  (hf : measurable (uncurry f)) : is_measurable { x | integrable (f x) ν } :=
+lemma measurable_set_integrable [sigma_finite ν] [opens_measurable_space E] ⦃f : α → β → E⦄
+  (hf : measurable (uncurry f)) : measurable_set { x | integrable (f x) ν } :=
 begin
   simp_rw [integrable, hf.of_uncurry_left.ae_measurable, true_and],
-  exact is_measurable_lt (measurable.lintegral_prod_right hf.ennnorm) measurable_const
+  exact measurable_set_lt (measurable.lintegral_prod_right hf.ennnorm) measurable_const
 end
 
 section
@@ -256,7 +256,7 @@ begin
   let f' : ℕ → α → E := λ n, {x | integrable (f x) ν}.indicator
     (λ x, (s' n x).integral ν),
   have hf' : ∀ n, measurable (f' n),
-  { intro n, refine measurable.indicator _ (is_measurable_integrable hf),
+  { intro n, refine measurable.indicator _ (measurable_set_integrable hf),
     have : ∀ x, (s' n x).range.filter (λ x, x ≠ 0) ⊆ (s n).range,
     { intros x, refine finset.subset.trans (finset.filter_subset _ _) _, intro y,
       simp_rw [simple_func.mem_range], rintro ⟨z, rfl⟩, exact ⟨(x, z), rfl⟩ },
@@ -265,7 +265,7 @@ begin
     refine (measurable.to_real _).smul measurable_const,
     simp only [simple_func.coe_comp, preimage_comp] {single_pass := tt},
     apply measurable_measure_prod_mk_left,
-    exact (s n).is_measurable_fiber x },
+    exact (s n).measurable_set_fiber x },
   have h2f' : tendsto f' at_top (𝓝 (λ (x : α), ∫ (y : β), f x y ∂ν)),
   { rw [tendsto_pi], intro x,
     by_cases hfx : integrable (f x) ν,
@@ -320,15 +320,15 @@ instance prod.measure_space {α β} [measure_space α] [measure_space β] : meas
 
 variables {μ ν} [sigma_finite ν]
 
-lemma prod_apply {s : set (α × β)} (hs : is_measurable s) :
+lemma prod_apply {s : set (α × β)} (hs : measurable_set s) :
   μ.prod ν s = ∫⁻ x, ν (prod.mk x ⁻¹' s) ∂μ :=
 by simp_rw [measure.prod, bind_apply hs measurable.map_prod_mk_left,
   map_apply measurable_prod_mk_left hs]
 
 @[simp] lemma prod_prod {s : set α} {t : set β}
-  (hs : is_measurable s) (ht : is_measurable t) : μ.prod ν (s.prod t) = μ s * ν t :=
+  (hs : measurable_set s) (ht : measurable_set t) : μ.prod ν (s.prod t) = μ s * ν t :=
 by simp_rw [prod_apply (hs.prod ht), mk_preimage_prod_right_eq_if, measure_if,
-  lintegral_indicator _ hs, lintegral_const, restrict_apply is_measurable.univ,
+  lintegral_indicator _ hs, lintegral_const, restrict_apply measurable_set.univ,
   univ_inter, mul_comm]
 
 local attribute [instance] nonempty_measurable_superset
@@ -336,9 +336,9 @@ local attribute [instance] nonempty_measurable_superset
 lemma prod_prod_le (s : set α) (t : set β) : μ.prod ν (s.prod t) ≤ μ s * ν t :=
 begin
   by_cases hs0 : μ s = 0,
-  { rcases (exists_is_measurable_superset_of_null hs0) with ⟨s', hs', h2s', h3s'⟩,
+  { rcases (exists_measurable_set_superset_of_null hs0) with ⟨s', hs', h2s', h3s'⟩,
     convert measure_mono (prod_mono hs' (subset_univ _)),
-    simp_rw [hs0, prod_prod h2s' is_measurable.univ, h3s', zero_mul] },
+    simp_rw [hs0, prod_prod h2s' measurable_set.univ, h3s', zero_mul] },
   by_cases hti : ν t = ⊤,
   { convert le_top, simp_rw [hti, ennreal.mul_top, hs0, if_false] },
   rw [measure_eq_infi' μ],
@@ -347,9 +347,9 @@ begin
   rintro ⟨s', h1s', h2s'⟩,
   rw [subtype.coe_mk],
   by_cases ht0 : ν t = 0,
-  { rcases (exists_is_measurable_superset_of_null ht0) with ⟨t', ht', h2t', h3t'⟩,
+  { rcases (exists_measurable_set_superset_of_null ht0) with ⟨t', ht', h2t', h3t'⟩,
     convert measure_mono (prod_mono (subset_univ _) ht'),
-    simp_rw [ht0, prod_prod is_measurable.univ h2t', h3t', mul_zero] },
+    simp_rw [ht0, prod_prod measurable_set.univ h2t', h3t', mul_zero] },
   by_cases hsi : μ s' = ⊤,
   { convert le_top, simp_rw [hsi, ennreal.top_mul, ht0, if_false] },
   rw [measure_eq_infi' ν],
@@ -360,12 +360,12 @@ begin
   simp [prod_prod h2s' h2t'],
 end
 
-lemma ae_measure_lt_top {s : set (α × β)} (hs : is_measurable s)
+lemma ae_measure_lt_top {s : set (α × β)} (hs : measurable_set s)
   (h2s : (μ.prod ν) s < ⊤) : ∀ᵐ x ∂μ, ν (prod.mk x ⁻¹' s) < ⊤ :=
 by { simp_rw [prod_apply hs] at h2s, refine ae_lt_top (measurable_measure_prod_mk_left hs) h2s }
 
 lemma integrable_measure_prod_mk_left {s : set (α × β)}
-  (hs : is_measurable s) (h2s : (μ.prod ν) s < ⊤) :
+  (hs : measurable_set s) (h2s : (μ.prod ν) s < ⊤) :
   integrable (λ x, (ν (prod.mk x ⁻¹' s)).to_real) μ :=
 begin
   refine ⟨(measurable_measure_prod_mk_left hs).to_real.ae_measurable, _⟩,
@@ -378,7 +378,7 @@ end
 /-- Note: the assumption `hs` cannot be dropped. For a counterexample, see
   Walter Rudin *Real and Complex Analysis*, example (c) in section 8.9. -/
 lemma measure_prod_null {s : set (α × β)}
-  (hs : is_measurable s) : μ.prod ν s = 0 ↔ (λ x, ν (prod.mk x ⁻¹' s)) =ᵐ[μ] 0 :=
+  (hs : measurable_set s) : μ.prod ν s = 0 ↔ (λ x, ν (prod.mk x ⁻¹' s)) =ᵐ[μ] 0 :=
 by simp_rw [prod_apply hs, lintegral_eq_zero_iff (measurable_measure_prod_mk_left hs)]
 
 /-- Note: the converse is not true without assuming that `s` is measurable. For a counterexample,
@@ -386,7 +386,7 @@ by simp_rw [prod_apply hs, lintegral_eq_zero_iff (measurable_measure_prod_mk_lef
 lemma measure_ae_null_of_prod_null {s : set (α × β)}
   (h : μ.prod ν s = 0) : (λ x, ν (prod.mk x ⁻¹' s)) =ᵐ[μ] 0 :=
 begin
-  obtain ⟨t, hst, mt, ht⟩ := exists_is_measurable_superset_of_null h,
+  obtain ⟨t, hst, mt, ht⟩ := exists_measurable_set_superset_of_null h,
   simp_rw [measure_prod_null mt] at ht,
   rw [eventually_le_antisymm_iff],
   exact ⟨eventually_le.trans_eq
@@ -403,7 +403,7 @@ measure_ae_null_of_prod_null h
 /-- `μ.prod ν` has finite spanning sets in rectangles of finite spanning sets. -/
 def finite_spanning_sets_in.prod {ν : measure β} {C : set (set α)} {D : set (set β)}
   (hμ : μ.finite_spanning_sets_in C) (hν : ν.finite_spanning_sets_in D)
-  (hC : ∀ s ∈ C, is_measurable s) (hD : ∀ t ∈ D, is_measurable t) :
+  (hC : ∀ s ∈ C, measurable_set s) (hD : ∀ t ∈ D, measurable_set t) :
   (μ.prod ν).finite_spanning_sets_in (image2 set.prod C D) :=
 begin
   haveI := hν.sigma_finite hD,
@@ -417,14 +417,14 @@ end
 lemma prod_fst_absolutely_continuous : map prod.fst (μ.prod ν) ≪ μ :=
 begin
   refine absolutely_continuous.mk (λ s hs h2s, _),
-  simp_rw [map_apply measurable_fst hs, ← prod_univ, prod_prod hs is_measurable.univ],
+  simp_rw [map_apply measurable_fst hs, ← prod_univ, prod_prod hs measurable_set.univ],
   rw [h2s, zero_mul] -- for some reason `simp_rw [h2s]` doesn't work
 end
 
 lemma prod_snd_absolutely_continuous : map prod.snd (μ.prod ν) ≪ ν :=
 begin
   refine absolutely_continuous.mk (λ s hs h2s, _),
-  simp_rw [map_apply measurable_snd hs, ← univ_prod, prod_prod is_measurable.univ hs],
+  simp_rw [map_apply measurable_snd hs, ← univ_prod, prod_prod measurable_set.univ hs],
   rw [h2s, mul_zero] -- for some reason `simp_rw [h2s]` doesn't work
 end
 
@@ -443,10 +443,10 @@ lemma prod_eq_generate_from {μ : measure α} {ν : measure β} {C : set (set α
   {μν : measure (α × β)}
   (h₁ : ∀ (s ∈ C) (t ∈ D), μν (set.prod s t) = μ s * ν t) : μ.prod ν = μν :=
 begin
-  have h4C : ∀ (s : set α), s ∈ C → is_measurable s,
-  { intros s hs, rw [← hC], exact is_measurable_generate_from hs },
-  have h4D : ∀ (t : set β), t ∈ D → is_measurable t,
-  { intros t ht, rw [← hD], exact is_measurable_generate_from ht },
+  have h4C : ∀ (s : set α), s ∈ C → measurable_set s,
+  { intros s hs, rw [← hC], exact measurable_set_generate_from hs },
+  have h4D : ∀ (t : set β), t ∈ D → measurable_set t,
+  { intros t ht, rw [← hD], exact measurable_set_generate_from ht },
   refine (h3C.prod h3D h4C h4D).ext
     (generate_from_eq_prod hC hD h3C.is_countably_spanning h3D.is_countably_spanning).symm
     (h2C.prod h2D) _,
@@ -456,9 +456,9 @@ end
 
 /-- Measures on a product space are equal to the product measure if they are equal on rectangles. -/
 lemma prod_eq {μν : measure (α × β)}
-  (h : ∀ s t, is_measurable s → is_measurable t → μν (s.prod t) = μ s * ν t) : μ.prod ν = μν :=
-prod_eq_generate_from generate_from_is_measurable generate_from_is_measurable
-  is_pi_system_is_measurable is_pi_system_is_measurable
+  (h : ∀ s t, measurable_set s → measurable_set t → μν (s.prod t) = μ s * ν t) : μ.prod ν = μν :=
+prod_eq_generate_from generate_from_measurable_set generate_from_measurable_set
+  is_pi_system_measurable_set is_pi_system_measurable_set
   μ.to_finite_spanning_sets_in ν.to_finite_spanning_sets_in (λ s hs t ht, h s t hs ht)
 
 lemma prod_swap : map prod.swap (μ.prod ν) = ν.prod μ :=
@@ -468,7 +468,7 @@ begin
   simp_rw [map_apply measurable_swap (hs.prod ht), preimage_swap_prod, prod_prod ht hs, mul_comm]
 end
 
-lemma prod_apply_symm {s : set (α × β)} (hs : is_measurable s) :
+lemma prod_apply_symm {s : set (α × β)} (hs : measurable_set s) :
   μ.prod ν s = ∫⁻ y, μ ((λ x, (x, y)) ⁻¹' s) ∂ν :=
 by { rw [← prod_swap, map_apply measurable_swap hs],
      simp only [prod_apply (measurable_swap hs)], refl }
@@ -476,8 +476,8 @@ by { rw [← prod_swap, map_apply measurable_swap hs],
 lemma prod_assoc_prod [sigma_finite τ] :
   map measurable_equiv.prod_assoc ((μ.prod ν).prod τ) = μ.prod (ν.prod τ) :=
 begin
-  refine (prod_eq_generate_from generate_from_is_measurable generate_from_prod
-    is_pi_system_is_measurable is_pi_system_prod μ.to_finite_spanning_sets_in
+  refine (prod_eq_generate_from generate_from_measurable_set generate_from_prod
+    is_pi_system_measurable_set is_pi_system_prod μ.to_finite_spanning_sets_in
     (ν.to_finite_spanning_sets_in.prod τ.to_finite_spanning_sets_in (λ _, id) (λ _, id)) _).symm,
   rintro s hs _ ⟨t, u, ht, hu, rfl⟩, rw [mem_set_of_eq] at hs ht hu,
   simp_rw [map_apply (measurable_equiv.measurable _) (hs.prod (ht.prod hu)), prod_prod ht hu,
@@ -487,7 +487,7 @@ end
 
 /-! ### The product of specific measures -/
 
-lemma prod_restrict {s : set α} {t : set β} (hs : is_measurable s) (ht : is_measurable t) :
+lemma prod_restrict {s : set α} {t : set β} (hs : measurable_set s) (ht : measurable_set t) :
   (μ.restrict s).prod (ν.restrict t) = (μ.prod ν).restrict (s.prod t) :=
 begin
   refine prod_eq (λ s' t' hs' ht', _),

--- a/src/measure_theory/prod_group.lean
+++ b/src/measure_theory/prod_group.lean
@@ -101,7 +101,7 @@ begin
 end
 
 lemma measure_null_of_measure_inv_null (hμ : is_mul_left_invariant μ)
-  {E : set G} (hE : is_measurable E) (h2E : μ ((λ x, x⁻¹) ⁻¹' E) = 0) : μ E = 0 :=
+  {E : set G} (hE : measurable_set E) (h2E : μ ((λ x, x⁻¹) ⁻¹' E) = 0) : μ E = 0 :=
 begin
   have hf : measurable (λ z : G × G, (z.2 * z.1, z.1⁻¹)) :=
   (measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv,
@@ -112,7 +112,7 @@ begin
   convert lintegral_zero, ext1 x, refine measure_mono_null (inter_subset_right _ _) h2E
 end
 
-lemma measure_inv_null (hμ : is_mul_left_invariant μ) {E : set G} (hE : is_measurable E) :
+lemma measure_inv_null (hμ : is_mul_left_invariant μ) {E : set G} (hE : measurable_set E) :
   μ ((λ x, x⁻¹) ⁻¹' E) = 0 ↔ μ E = 0 :=
 begin
   refine ⟨measure_null_of_measure_inv_null hμ hE, _⟩,
@@ -122,14 +122,14 @@ begin
   exact set.inv_inv
 end
 
-lemma measurable_measure_mul_right {E : set G} (hE : is_measurable E) :
+lemma measurable_measure_mul_right {E : set G} (hE : measurable_set E) :
   measurable (λ x, μ ((λ y, y * x) ⁻¹' E)) :=
 begin
   suffices :
     measurable (λ y, μ ((λ x, (x, y)) ⁻¹' ((λ z : G × G, (1, z.1 * z.2)) ⁻¹' set.prod univ E))),
   { convert this, ext1 x, congr' 1 with y : 1, simp },
   apply measurable_measure_prod_mk_right,
-  exact measurable_const.prod_mk (measurable_fst.mul measurable_snd) (is_measurable.univ.prod hE)
+  exact measurable_const.prod_mk (measurable_fst.mul measurable_snd) (measurable_set.univ.prod hE)
 end
 
 lemma lintegral_lintegral_mul_inv (hμ : is_mul_left_invariant μ) (hν : is_mul_left_invariant ν)
@@ -146,7 +146,7 @@ begin
   exact lintegral_map' (hf.mono' (map_prod_mul_inv_eq hμ hν).absolutely_continuous) h,
 end
 
-lemma measure_mul_right_null (hμ : is_mul_left_invariant μ) {E : set G} (hE : is_measurable E)
+lemma measure_mul_right_null (hμ : is_mul_left_invariant μ) {E : set G} (hE : measurable_set E)
   (y : G) : μ ((λ x, x * y) ⁻¹' E) = 0 ↔ μ E = 0 :=
 begin
   rw [← measure_inv_null hμ hE, ← hμ y⁻¹ (measurable_inv hE),
@@ -154,7 +154,7 @@ begin
   convert iff.rfl using 3, ext x, simp,
 end
 
-lemma measure_mul_right_ne_zero (hμ : is_mul_left_invariant μ) {E : set G} (hE : is_measurable E)
+lemma measure_mul_right_ne_zero (hμ : is_mul_left_invariant μ) {E : set G} (hE : measurable_set E)
   (h2E : μ E ≠ 0) (y : G) : μ ((λ x, x * y) ⁻¹' E) ≠ 0 :=
 (not_iff_not_of_iff (measure_mul_right_null hμ hE y)).mpr h2E
 
@@ -172,7 +172,7 @@ lemma measure_lintegral_div_measure [t2_space G] (hμ : is_mul_left_invariant μ
   (f : G → ennreal) (hf : measurable f) :
   μ E * ∫⁻ y, f y⁻¹ / ν ((λ h, h * y⁻¹) ⁻¹' E) ∂ν = ∫⁻ x, f x ∂μ :=
 begin
-  have Em := hE.is_measurable,
+  have Em := hE.measurable_set,
   symmetry,
   set g := λ y, f y⁻¹ / ν ((λ h, h * y⁻¹) ⁻¹' E),
   have hg : measurable g := (hf.comp measurable_inv).ennreal_div
@@ -200,7 +200,7 @@ end
   `measure_theory.measure.haar_measure_unique` -/
 lemma measure_mul_measure_eq [t2_space G] (hμ : is_mul_left_invariant μ)
   (hν : is_mul_left_invariant ν) (h2ν : regular ν) {E F : set G}
-  (hE : is_compact E) (hF : is_measurable F) (h2E : ν E ≠ 0) : μ E * ν F = ν E * μ F :=
+  (hE : is_compact E) (hF : measurable_set F) (h2E : ν E ≠ 0) : μ E * ν F = ν E * μ F :=
 begin
   have h1 := measure_lintegral_div_measure hν hν h2ν hE h2E (F.indicator (λ x, 1))
     (measurable_const.indicator hF),

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -58,13 +58,13 @@ section piecewise
 
 variables {μ : measure α} {s : set α} {f g : α → β}
 
-lemma piecewise_ae_eq_restrict (hs : is_measurable s) : piecewise s f g =ᵐ[μ.restrict s] f :=
+lemma piecewise_ae_eq_restrict (hs : measurable_set s) : piecewise s f g =ᵐ[μ.restrict s] f :=
 begin
   rw [ae_restrict_eq hs],
   exact (piecewise_eq_on s f g).eventually_eq.filter_mono inf_le_right
 end
 
-lemma piecewise_ae_eq_restrict_compl (hs : is_measurable s) :
+lemma piecewise_ae_eq_restrict_compl (hs : measurable_set s) :
   piecewise s f g =ᵐ[μ.restrict sᶜ] g :=
 begin
   rw [ae_restrict_eq hs.compl],
@@ -77,10 +77,10 @@ section indicator_function
 
 variables [has_zero β] {μ : measure α} {s : set α} {f : α → β}
 
-lemma indicator_ae_eq_restrict (hs : is_measurable s) : indicator s f =ᵐ[μ.restrict s] f :=
+lemma indicator_ae_eq_restrict (hs : measurable_set s) : indicator s f =ᵐ[μ.restrict s] f :=
 piecewise_ae_eq_restrict hs
 
-lemma indicator_ae_eq_restrict_compl (hs : is_measurable s) : indicator s f =ᵐ[μ.restrict sᶜ] 0 :=
+lemma indicator_ae_eq_restrict_compl (hs : measurable_set s) : indicator s f =ᵐ[μ.restrict sᶜ] 0 :=
 piecewise_ae_eq_restrict_compl hs
 
 end indicator_function
@@ -210,7 +210,7 @@ by { delta integrable_on, rw measure.restrict_add, exact hμ.integrable.add_meas
   h.mono_measure (measure.le_add_left (le_refl _))⟩,
   λ h, h.1.add_measure h.2⟩
 
-lemma ae_measurable_indicator_iff (hs : is_measurable s) :
+lemma ae_measurable_indicator_iff (hs : measurable_set s) :
   ae_measurable f (μ.restrict s) ↔ ae_measurable (indicator s f) μ :=
 begin
   split,
@@ -227,12 +227,12 @@ begin
     exact (h.mono_measure measure.restrict_le_self).congr (indicator_ae_eq_restrict hs) }
 end
 
-lemma integrable_indicator_iff (hs : is_measurable s) :
+lemma integrable_indicator_iff (hs : measurable_set s) :
   integrable (indicator s f) μ ↔ integrable_on f s μ :=
 by simp [integrable_on, integrable, has_finite_integral, nnnorm_indicator_eq_indicator_nnnorm,
   ennreal.coe_indicator, lintegral_indicator _ hs, ae_measurable_indicator_iff hs]
 
-lemma integrable_on.indicator (h : integrable_on f s μ) (hs : is_measurable s) :
+lemma integrable_on.indicator (h : integrable_on f s μ) (hs : measurable_set s) :
   integrable (indicator s f) μ :=
 (integrable_indicator_iff hs).2 h
 
@@ -317,8 +317,8 @@ begin
   refine ⟨λ hfg, _, λ h, h.1.add h.2⟩,
   rw [← indicator_add_eq_left h],
   conv { congr, skip, rw [← indicator_add_eq_right h] },
-  rw [integrable_indicator_iff (hf (is_measurable_singleton 0)).compl],
-  rw [integrable_indicator_iff (hg (is_measurable_singleton 0)).compl],
+  rw [integrable_indicator_iff (hf (measurable_set_singleton 0)).compl],
+  rw [integrable_indicator_iff (hg (measurable_set_singleton 0)).compl],
   exact ⟨hfg.integrable_on, hfg.integrable_on⟩
 end
 
@@ -336,7 +336,7 @@ of their images is a subset of `{0}`).
 -/
 @[elab_as_eliminator]
 lemma integrable.induction (P : (α → E) → Prop)
-  (h_ind : ∀ (c : E) ⦃s⦄, is_measurable s → μ s < ⊤ → P (s.indicator (λ _, c)))
+  (h_ind : ∀ (c : E) ⦃s⦄, measurable_set s → μ s < ⊤ → P (s.indicator (λ _, c)))
   (h_sum : ∀ ⦃f g : α → E⦄, set.univ ⊆ f ⁻¹' {0} ∪ g ⁻¹' {0} → integrable f μ → integrable g μ →
     P f → P g → P (f + g))
   (h_closed : is_closed {f : α →₁[μ] E | P f} )
@@ -348,7 +348,7 @@ begin
     { intros c s hs h, dsimp only [simple_func.coe_const, simple_func.const_zero,
         piecewise_eq_indicator, simple_func.coe_zero, simple_func.coe_piecewise] at h ⊢,
       by_cases hc : c = 0,
-      { subst hc, convert h_ind 0 is_measurable.empty (by simp) using 1, simp [const] },
+      { subst hc, convert h_ind 0 measurable_set.empty (by simp) using 1, simp [const] },
       apply h_ind c hs,
       have : (nnnorm c : ennreal) * μ s < ⊤,
       { have := @comp_indicator _ _ _ _ (λ x : E, (nnnorm x : ennreal)) (const α c) s,
@@ -370,15 +370,15 @@ end
 variables [complete_space E] [normed_space ℝ E]
 
 
-lemma set_integral_congr_ae (hs : is_measurable s) (h : ∀ᵐ x ∂μ, x ∈ s → f x = g x) :
+lemma set_integral_congr_ae (hs : measurable_set s) (h : ∀ᵐ x ∂μ, x ∈ s → f x = g x) :
   ∫ x in s, f x ∂μ = ∫ x in s, g x ∂μ :=
 integral_congr_ae ((ae_restrict_iff' hs).2 h)
 
-lemma set_integral_congr (hs : is_measurable s) (h : eq_on f g s) :
+lemma set_integral_congr (hs : measurable_set s) (h : eq_on f g s) :
   ∫ x in s, f x ∂μ = ∫ x in s, g x ∂μ :=
 set_integral_congr_ae hs $ eventually_of_forall h
 
-lemma integral_union (hst : disjoint s t) (hs : is_measurable s) (ht : is_measurable t)
+lemma integral_union (hst : disjoint s t) (hs : measurable_set s) (ht : measurable_set t)
   (hfs : integrable_on f s μ) (hft : integrable_on f t μ) :
   ∫ x in s ∪ t, f x ∂μ = ∫ x in s, f x ∂μ + ∫ x in t, f x ∂μ :=
 by simp only [integrable_on, measure.restrict_union hst hs ht, integral_add_measure hfs hft]
@@ -387,14 +387,14 @@ lemma integral_empty : ∫ x in ∅, f x ∂μ = 0 := by rw [measure.restrict_em
 
 lemma integral_univ : ∫ x in univ, f x ∂μ = ∫ x, f x ∂μ := by rw [measure.restrict_univ]
 
-lemma integral_add_compl (hs : is_measurable s) (hfi : integrable f μ) :
+lemma integral_add_compl (hs : measurable_set s) (hfi : integrable f μ) :
   ∫ x in s, f x ∂μ + ∫ x in sᶜ, f x ∂μ = ∫ x, f x ∂μ :=
 by rw [← integral_union disjoint_compl_right hs hs.compl hfi.integrable_on hfi.integrable_on,
   union_compl_self, integral_univ]
 
 /-- For a function `f` and a measurable set `s`, the integral of `indicator s f`
 over the whole space is equal to `∫ x in s, f x ∂μ` defined as `∫ x, f x ∂(μ.restrict s)`. -/
-lemma integral_indicator (hs : is_measurable s) :
+lemma integral_indicator (hs : measurable_set s) :
   ∫ x, indicator s f x ∂μ = ∫ x in s, f x ∂μ :=
 begin
   by_cases hf : ae_measurable f (μ.restrict s), swap,
@@ -416,12 +416,12 @@ lemma set_integral_const (c : E) : ∫ x in s, c ∂μ = (μ s).to_real • c :=
 by rw [integral_const, measure.restrict_apply_univ]
 
 @[simp]
-lemma integral_indicator_const (e : E) ⦃s : set α⦄ (s_meas : is_measurable s) :
+lemma integral_indicator_const (e : E) ⦃s : set α⦄ (s_meas : measurable_set s) :
   ∫ (a : α), s.indicator (λ (x : α), e) a ∂μ = (μ s).to_real • e :=
 by rw [integral_indicator s_meas, ← set_integral_const]
 
 lemma set_integral_map {β} [measurable_space β] {g : α → β} {f : β → E} {s : set β}
-  (hs : is_measurable s) (hf : ae_measurable f (measure.map g μ)) (hg : measurable g) :
+  (hs : measurable_set s) (hf : ae_measurable f (measure.map g μ)) (hg : measurable g) :
   ∫ y in s, f y ∂(measure.map g μ) = ∫ x in g ⁻¹' s, f (g x) ∂μ :=
 begin
   rw [measure.restrict_map hg hs, integral_map hg (hf.mono_measure _)],
@@ -447,13 +447,13 @@ begin
     assume a h1 h2 h3,
     rw [← h2 h3],
     exact h1 h3 },
-  have B : is_measurable {x | ∥(hfm.mk f) x∥ ≤ C} := hfm.measurable_mk.norm is_measurable_Iic,
+  have B : measurable_set {x | ∥(hfm.mk f) x∥ ≤ C} := hfm.measurable_mk.norm measurable_set_Iic,
   filter_upwards [hfm.ae_eq_mk, (ae_restrict_iff B).2 A],
   assume a h1 h2,
   rwa h1
 end
 
-lemma norm_set_integral_le_of_norm_le_const_ae'' {C : ℝ} (hs : μ s < ⊤) (hsm : is_measurable s)
+lemma norm_set_integral_le_of_norm_le_const_ae'' {C : ℝ} (hs : μ s < ⊤) (hsm : measurable_set s)
   (hC : ∀ᵐ x ∂μ, x ∈ s → ∥f x∥ ≤ C) :
   ∥∫ x in s, f x ∂μ∥ ≤ C * (μ s).to_real :=
 norm_set_integral_le_of_norm_le_const_ae hs $ by rwa [ae_restrict_eq hsm, eventually_inf_principal]
@@ -463,7 +463,7 @@ lemma norm_set_integral_le_of_norm_le_const {C : ℝ} (hs : μ s < ⊤)
   ∥∫ x in s, f x ∂μ∥ ≤ C * (μ s).to_real :=
 norm_set_integral_le_of_norm_le_const_ae' hs (eventually_of_forall hC) hfm
 
-lemma norm_set_integral_le_of_norm_le_const' {C : ℝ} (hs : μ s < ⊤) (hsm : is_measurable s)
+lemma norm_set_integral_le_of_norm_le_const' {C : ℝ} (hs : μ s < ⊤) (hsm : measurable_set s)
   (hC : ∀ x ∈ s, ∥f x∥ ≤ C) :
   ∥∫ x in s, f x ∂μ∥ ≤ C * (μ s).to_real :=
 norm_set_integral_le_of_norm_le_const_ae'' hs hsm $ eventually_of_forall hC
@@ -478,7 +478,7 @@ lemma set_integral_pos_iff_support_of_nonneg_ae {f : α → ℝ} (hf : 0 ≤ᵐ[
   0 < ∫ x in s, f x ∂μ ↔ 0 < μ (support f ∩ s) :=
 begin
   rw [integral_pos_iff_support_of_nonneg_ae hf hfi, restrict_apply_of_null_measurable_set],
-  exact hfi.ae_measurable.null_measurable_set (is_measurable_singleton 0).compl
+  exact hfi.ae_measurable.null_measurable_set (measurable_set_singleton 0).compl
 end
 
 end normed_group
@@ -536,7 +536,7 @@ lemma continuous_within_at.integral_sub_linear_is_o_ae
   [topological_space α] [opens_measurable_space α]
   [normed_space ℝ E] [second_countable_topology E] [complete_space E] [borel_space E]
   {μ : measure α} [locally_finite_measure μ] {a : α} {t : set α}
-  {f : α → E} (ha : continuous_within_at f t a) (ht : is_measurable t)
+  {f : α → E} (ha : continuous_within_at f t a) (ht : measurable_set t)
   (hfm : measurable_at_filter f (𝓝[t] a) μ)
   {s : ι → set α} {li : filter ι} (hs : tendsto s li ((𝓝[t] a).lift' powerset))
   (m : ι → ℝ := λ i, (μ (s i)).to_real)
@@ -577,7 +577,7 @@ is_compact.induction_on hs integrable_on_empty (λ s t hst ht, ht.mono_set hst)
 /-- A function which is continuous on a set `s` is almost everywhere measurable with respect to
 `μ.restrict s`. -/
 lemma continuous_on.ae_measurable [topological_space α] [opens_measurable_space α] [borel_space E]
-  {f : α → E} {s : set α} {μ : measure α} (hf : continuous_on f s) (hs : is_measurable s) :
+  {f : α → E} {s : set α} {μ : measure α} (hf : continuous_on f s) (hs : measurable_set s) :
   ae_measurable f (μ.restrict s) :=
 begin
   refine ⟨indicator s f, _, (indicator_ae_eq_restrict hs).symm⟩,
@@ -586,13 +586,13 @@ begin
   obtain ⟨u, u_open, hu⟩ : ∃ (u : set α), is_open u ∧ f ⁻¹' t ∩ s = u ∩ s :=
     _root_.continuous_on_iff'.1 hf t ht,
   rw [indicator_preimage, inter_comm, hu],
-  exact (u_open.is_measurable.inter hs).union (hs.compl.inter (measurable_const ht.is_measurable))
+  exact (u_open.measurable_set.inter hs).union (hs.compl.inter (measurable_const ht.measurable_set))
 end
 
 lemma continuous_on.integrable_at_nhds_within
   [topological_space α] [opens_measurable_space α] [borel_space E]
   {μ : measure α} [locally_finite_measure μ] {a : α} {t : set α} {f : α → E}
-  (hft : continuous_on f t) (ht : is_measurable t) (ha : a ∈ t) :
+  (hft : continuous_on f t) (ht : measurable_set t) (ha : a ∈ t) :
   integrable_at_filter f (𝓝[t] a) μ :=
 by haveI : (𝓝[t] a).is_measurably_generated := ht.nhds_within_is_measurably_generated _;
 exact (hft a ha).integrable_at_filter ⟨_, self_mem_nhds_within, hft.ae_measurable ht⟩
@@ -610,7 +610,7 @@ lemma continuous_on.integral_sub_linear_is_o_ae
   [topological_space α] [opens_measurable_space α]
   [normed_space ℝ E] [second_countable_topology E] [complete_space E] [borel_space E]
   {μ : measure α} [locally_finite_measure μ] {a : α} {t : set α}
-  {f : α → E} (hft : continuous_on f t) (ha : a ∈ t) (ht : is_measurable t)
+  {f : α → E} (hft : continuous_on f t) (ha : a ∈ t) (ht : measurable_set t)
   {s : ι → set α} {li : filter ι} (hs : tendsto s li ((𝓝[t] a).lift' powerset))
   (m : ι → ℝ := λ i, (μ (s i)).to_real)
   (hsμ : (λ i, (μ (s i)).to_real) =ᶠ[li] m . tactic.interactive.refl) :
@@ -624,7 +624,7 @@ lemma continuous_on.integrable_on_compact
   [t2_space α] {μ : measure α} [locally_finite_measure μ]
   {s : set α} (hs : is_compact s) {f : α → E} (hf : continuous_on f s) :
   integrable_on f s μ :=
-hs.integrable_on_of_nhds_within $ λ x hx, hf.integrable_at_nhds_within hs.is_measurable hx
+hs.integrable_on_of_nhds_within $ λ x hx, hf.integrable_at_nhds_within hs.measurable_set hx
 
 /-- A continuous function `f` is integrable on any compact set with respect to any locally finite
 measure. -/
@@ -643,7 +643,7 @@ lemma continuous.integrable_of_compact_closure_support
   integrable f μ :=
 begin
   rw [← indicator_eq_self.2 (@subset_closure _ _ (support f)),
-    integrable_indicator_iff is_closed_closure.is_measurable],
+    integrable_indicator_iff is_closed_closure.measurable_set],
   { exact hf.integrable_on_compact hfc },
   { apply_instance }
 end
@@ -824,7 +824,7 @@ variables [measurable_space α]
   {s t : set α} {f g : α → β} {μ : measure α}
 open set
 
-lemma integral_on_congr (hf : measurable f) (hg : measurable g) (hs : is_measurable s)
+lemma integral_on_congr (hf : measurable f) (hg : measurable g) (hs : measurable_set s)
   (h : ∀ᵐ a ∂μ, a ∈ s → f a = g a) : ∫ a in s, f a ∂μ = ∫ a in s, g a ∂μ :=
 integral_congr_ae hf hg $ _
 
@@ -861,7 +861,7 @@ lemma integral_on_union (hsm : measurable_on s f) (hsi : integrable_on s f)
   (∫ a in (s ∪ t), f a) = (∫ a in s, f a) + (∫ a in t, f a) :=
 by { rw [indicator_union_of_disjoint h, integral_add hsm hsi htm hti] }
 
-lemma integral_on_union_ae (hs : is_measurable s) (ht : is_measurable t) (hsm : measurable_on s f)
+lemma integral_on_union_ae (hs : measurable_set s) (ht : measurable_set t) (hsm : measurable_on s f)
   (hsi : integrable_on s f) (htm : measurable_on t f) (hti : integrable_on t f)
   (h : ∀ᵐ a, a ∉ s ∩ t) :
   (∫ a in (s ∪ t), f a) = (∫ a in s, f a) + (∫ a in t, f a) :=
@@ -884,7 +884,7 @@ integral_nonpos_of_nonpos_ae $ by { filter_upwards [hf] λ a h, indicator_nonpos
 lemma integral_on_nonpos {f : α → ℝ} (hf : ∀ a, a ∈ s → f a ≤ 0) : (∫ a in s, f a) ≤ 0 :=
 integral_on_nonpos_of_ae $ univ_mem_sets' hf
 
-lemma tendsto_integral_on_of_monotone {s : ℕ → set α} {f : α → β} (hsm : ∀i, is_measurable (s i))
+lemma tendsto_integral_on_of_monotone {s : ℕ → set α} {f : α → β} (hsm : ∀i, measurable_set (s i))
   (h_mono : monotone s) (hfm : measurable_on (Union s) f) (hfi : integrable_on (Union s) f) :
   tendsto (λi, ∫ a in (s i), f a) at_top (nhds (∫ a in (Union s), f a)) :=
 let bound : α → ℝ := indicator (Union s) (λa, ∥f a∥) in
@@ -900,14 +900,14 @@ begin
   { filter_upwards [] λa, le_trans (tendsto_indicator_of_monotone _ h_mono _ _) (pure_le_nhds _) }
 end
 
-lemma tendsto_integral_on_of_antimono (s : ℕ → set α) (f : α → β) (hsm : ∀i, is_measurable (s i))
+lemma tendsto_integral_on_of_antimono (s : ℕ → set α) (f : α → β) (hsm : ∀i, measurable_set (s i))
   (h_mono : ∀i j, i ≤ j → s j ⊆ s i) (hfm : measurable_on (s 0) f) (hfi : integrable_on (s 0) f) :
   tendsto (λi, ∫ a in (s i), f a) at_top (nhds (∫ a in (Inter s), f a)) :=
 let bound : α → ℝ := indicator (s 0) (λa, ∥f a∥) in
 begin
   apply tendsto_integral_of_dominated_convergence,
   { assume i, refine hfm.subset (hsm i) (h_mono _ _ (zero_le _)) },
-  { exact hfm.subset (is_measurable.Inter hsm) (Inter_subset _ _) },
+  { exact hfm.subset (measurable_set.Inter hsm) (Inter_subset _ _) },
   { show integrable_on (s 0) (λa, ∥f a∥), rwa integrable_on_norm_iff },
   { assume i, apply ae_of_all,
     assume a,
@@ -918,7 +918,7 @@ end
 
 -- TODO : prove this for an encodable type
 -- by proving an encodable version of `filter.is_countably_generated_at_top_finset_nat `
-lemma integral_on_Union (s : ℕ → set α) (f : α → β) (hm : ∀i, is_measurable (s i))
+lemma integral_on_Union (s : ℕ → set α) (f : α → β) (hm : ∀i, measurable_set (s i))
   (hd : ∀ i j, i ≠ j → s i ∩ s j = ∅) (hfm : measurable_on (Union s) f)
   (hfi : integrable_on (Union s) f) :
   (∫ a in (Union s), f a) = ∑'i, ∫ a in s i, f a :=
@@ -937,7 +937,7 @@ begin
   { exact is_countably_generated_at_top_finset_nat },
   { refine univ_mem_sets' (λ n, _),
     simp only [mem_set_of_eq],
-    refine hfm.subset (is_measurable.Union (λ i, is_measurable.Union_Prop (λh, hm _)))
+    refine hfm.subset (measurable_set.Union (λ i, measurable_set.Union_Prop (λh, hm _)))
       (bUnion_subset_Union _ _), },
   { assumption },
   { refine univ_mem_sets' (λ n, univ_mem_sets' $ _),

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -477,8 +477,8 @@ lemma set_integral_pos_iff_support_of_nonneg_ae {f : α → ℝ} (hf : 0 ≤ᵐ[
   (hfi : integrable_on f s μ) :
   0 < ∫ x in s, f x ∂μ ↔ 0 < μ (support f ∩ s) :=
 begin
-  rw [integral_pos_iff_support_of_nonneg_ae hf hfi, restrict_apply_of_is_null_measurable],
-  exact hfi.ae_measurable.is_null_measurable (is_measurable_singleton 0).compl
+  rw [integral_pos_iff_support_of_nonneg_ae hf hfi, restrict_apply_of_null_measurable_set],
+  exact hfi.ae_measurable.null_measurable_set (is_measurable_singleton 0).compl
 end
 
 end normed_group

--- a/src/measure_theory/simple_func_dense.lean
+++ b/src/measure_theory/simple_func_dense.lean
@@ -47,8 +47,8 @@ points `e 0`, ..., `e N`. If more than one point are at the same distance from `
 noncomputable def nearest_pt_ind (e : ℕ → α) : ℕ → α →ₛ ℕ
 | 0 := const α 0
 | (N + 1) := piecewise (⋂ k ≤ N, {x | edist (e (N + 1)) x < edist (e k) x})
-    (is_measurable.Inter $ λ k, is_measurable.Inter_Prop $ λ hk,
-      is_measurable_lt measurable_edist_right measurable_edist_right)
+    (measurable_set.Inter $ λ k, measurable_set.Inter_Prop $ λ hk,
+      measurable_set_lt measurable_edist_right measurable_edist_right)
     (const α $ N + 1) (nearest_pt_ind N)
 
 /-- `nearest_pt e N x` is the nearest point to `x` among the points `e 0`, ..., `e N`. If more than

--- a/src/probability_theory/independence.lean
+++ b/src/probability_theory/independence.lean
@@ -90,14 +90,14 @@ for any finite set of indices `s = {i_1, ..., i_n}`, for any sets
 `f i_1 ∈ m i_1, ..., f i_n ∈ m i_n`, then `μ (⋂ i in s, f i) = ∏ i in s, μ (f i) `. -/
 def Indep {α ι} (m : ι → measurable_space α) [measurable_space α] (μ : measure α . volume_tac) :
   Prop :=
-Indep_sets (λ x, (m x).is_measurable') μ
+Indep_sets (λ x, (m x).measurable_set') μ
 
 /-- Two measurable space structures (or σ-algebras) `m₁, m₂` are independent with respect to a
 measure `μ` (defined on a third σ-algebra) if for any sets `t₁ ∈ m₁, t₂ ∈ m₂`,
 `μ (t₁ ∩ t₂) = μ (t₁) * μ (t₂)` -/
 def indep {α} (m₁ m₂ : measurable_space α) [measurable_space α] (μ : measure α . volume_tac) :
   Prop :=
-indep_sets (m₁.is_measurable') (m₂.is_measurable') μ
+indep_sets (m₁.measurable_set') (m₂.measurable_set') μ
 
 /-- A family of sets is independent if the family of measurable space structures they generate is
 independent. For a set `s`, the generated measurable space has measurable sets `∅, s, sᶜ, univ`. -/
@@ -229,7 +229,7 @@ lemma Indep.indep {α ι} {m : ι → measurable_space α} [measurable_space α]
   (h_indep : Indep m μ) {i j : ι} (hij : i ≠ j) :
   indep (m i) (m j) μ :=
 begin
-  change indep_sets ((λ x, (m x).is_measurable') i) ((λ x, (m x).is_measurable') j) μ,
+  change indep_sets ((λ x, (m x).measurable_set') i) ((λ x, (m x).measurable_set') j) μ,
   exact Indep_sets.indep_sets h_indep hij,
 end
 
@@ -251,13 +251,13 @@ lemma Indep.Indep_sets {α ι} [measurable_space α] {μ : measure α} {m : ι �
 begin
   refine (λ S f hfs, h_indep S (λ x hxS, _)),
   simp_rw hms x,
-  exact is_measurable_generate_from (hfs x hxS),
+  exact measurable_set_generate_from (hfs x hxS),
 end
 
 lemma indep.indep_sets {α} [measurable_space α] {μ : measure α} {s1 s2 : set (set α)}
   (h_indep : indep (generate_from s1) (generate_from s2) μ) :
   indep_sets s1 s2 μ :=
-λ t1 t2 ht1 ht2, h_indep t1 t2 (is_measurable_generate_from ht1) (is_measurable_generate_from ht2)
+λ t1 t2 ht1 ht2, h_indep t1 t2 (measurable_set_generate_from ht1) (measurable_set_generate_from ht2)
 
 end from_measurable_spaces_to_sets_of_sets
 
@@ -267,7 +267,7 @@ section from_pi_systems_to_measurable_spaces
 private lemma indep_sets.indep_aux {α} {m2 : measurable_space α}
   {m : measurable_space α} {μ : measure α} [probability_measure μ] {p1 p2 : set (set α)}
   (h2 : m2 ≤ m) (hp2 : is_pi_system p2) (hpm2 : m2 = generate_from p2)
-  (hyp : indep_sets p1 p2 μ) {t1 t2 : set α} (ht1 : t1 ∈ p1) (ht2m : m2.is_measurable' t2) :
+  (hyp : indep_sets p1 p2 μ) {t1 t2 : set α} (ht1 : t1 ∈ p1) (ht2m : m2.measurable_set' t2) :
   μ (t1 ∩ t2) = μ t1 * μ t2 :=
 begin
   let μ_inter := μ.restrict t1,
@@ -277,10 +277,10 @@ begin
   haveI : finite_measure μ_inter := @restrict.finite_measure α _ t1 μ (measure_lt_top μ t1),
   rw [set.inter_comm, ←@measure.restrict_apply α _ μ t1 t2 (h2 t2 ht2m)],
   refine ext_on_measurable_space_of_generate_finite m p2 (λ t ht, _) h2 hpm2 hp2 h_univ ht2m,
-  have ht2 : m.is_measurable' t,
+  have ht2 : m.measurable_set' t,
   { refine h2 _ _,
     rw hpm2,
-    exact is_measurable_generate_from ht, },
+    exact measurable_set_generate_from ht, },
   rw [measure.restrict_apply ht2, measure.smul_apply, set.inter_comm],
   exact hyp t1 t ht1 ht,
 end
@@ -299,10 +299,10 @@ begin
   haveI : finite_measure μ_inter := @restrict.finite_measure α _ t2 μ (measure_lt_top μ t2),
   rw [mul_comm, ←@measure.restrict_apply α _ μ t2 t1 (h1 t1 ht1)],
   refine ext_on_measurable_space_of_generate_finite m p1 (λ t ht, _) h1 hpm1 hp1 h_univ ht1,
-  have ht1 : m.is_measurable' t,
+  have ht1 : m.measurable_set' t,
   { refine h1 _ _,
     rw hpm1,
-    exact is_measurable_generate_from ht, },
+    exact measurable_set_generate_from ht, },
   rw [measure.restrict_apply ht1, measure.smul_apply, mul_comm],
   exact indep_sets.indep_aux h2 hp2 hpm2 hyp ht ht2,
 end


### PR DESCRIPTION
Search & replace:
* `is_null_measurable` → `null_measurable`;
* `is_measurable` → `measurable_set'`;
* `measurable_set_set` → `measurable_set`;
* `measurable_set_spanning_sets` → `measurable_spanning_sets`;
* `measurable_set_superset` → `measurable_superset`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
