### PR TITLE
[Merged by Bors] - refactor(group_theory/perm): move perm.subtype_perm to basic

### DIFF
--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -159,6 +159,66 @@ begin
   simpa using equiv.congr_fun h ⟨a, b⟩,
 end
 
+/-- If the permutation `f` fixes the subtype `{x // p x}`, then this returns the permutation
+  on `{x // p x}` induced by `f`. -/
+def subtype_perm (f : perm α) {p : α → Prop} (h : ∀ x, p x ↔ p (f x)) : perm {x // p x} :=
+⟨λ x, ⟨f x, (h _).1 x.2⟩, λ x, ⟨f⁻¹ x, (h (f⁻¹ x)).2 $ by simpa using x.2⟩,
+  λ _, by simp only [perm.inv_apply_self, subtype.coe_eta, subtype.coe_mk],
+  λ _, by simp only [perm.apply_inv_self, subtype.coe_eta, subtype.coe_mk]⟩
+
+@[simp] lemma subtype_perm_one (p : α → Prop) (h : ∀ x, p x ↔ p ((1 : perm α) x)) :
+  @subtype_perm α 1 p h = 1 :=
+equiv.ext $ λ ⟨_, _⟩, rfl
+
+/-- The inclusion map of permutations on a subtype of `α` into permutations of `α`,
+  fixing the other points. -/
+def of_subtype {p : α → Prop} [decidable_pred p] : perm (subtype p) →* perm α :=
+{ to_fun := λ f,
+  ⟨λ x, if h : p x then f ⟨x, h⟩ else x, λ x, if h : p x then f⁻¹ ⟨x, h⟩ else x,
+  λ x, have h : ∀ h : p x, p (f ⟨x, h⟩), from λ h, (f ⟨x, h⟩).2,
+    by { simp only [], split_ifs at *;
+         simp only [perm.inv_apply_self, subtype.coe_eta, subtype.coe_mk, not_true, *] at * },
+  λ x, have h : ∀ h : p x, p (f⁻¹ ⟨x, h⟩), from λ h, (f⁻¹ ⟨x, h⟩).2,
+    by { simp only [], split_ifs at *;
+         simp only [perm.apply_inv_self, subtype.coe_eta, subtype.coe_mk, not_true, *] at * }⟩,
+  map_one' := begin ext, dsimp, split_ifs; refl, end,
+  map_mul' := λ f g, equiv.ext $ λ x, begin
+  by_cases h : p x,
+  { have h₁ : p (f (g ⟨x, h⟩)), from (f (g ⟨x, h⟩)).2,
+    have h₂ : p (g ⟨x, h⟩), from (g ⟨x, h⟩).2,
+    simp only [h, h₂, coe_fn_mk, perm.mul_apply, dif_pos, subtype.coe_eta] },
+  { simp only [h, coe_fn_mk, perm.mul_apply, dif_neg, not_false_iff] }
+end }
+
+lemma of_subtype_subtype_perm {f : perm α} {p : α → Prop} [decidable_pred p]
+  (h₁ : ∀ x, p x ↔ p (f x)) (h₂ : ∀ x, f x ≠ x → p x) :
+  of_subtype (subtype_perm f h₁) = f :=
+equiv.ext $ λ x, begin
+  rw [of_subtype, subtype_perm],
+  by_cases hx : p x,
+  { simp only [hx, coe_fn_mk, dif_pos, monoid_hom.coe_mk, subtype.coe_mk]},
+  { haveI := classical.prop_decidable,
+    simp only [hx, not_not.mp (mt (h₂ x) hx), coe_fn_mk, dif_neg, not_false_iff,
+      monoid_hom.coe_mk] }
+end
+
+lemma of_subtype_apply_of_not_mem {p : α → Prop} [decidable_pred p]
+  (f : perm (subtype p)) {x : α} (hx : ¬ p x) :
+  of_subtype f x = x :=
+dif_neg hx
+
+lemma mem_iff_of_subtype_apply_mem {p : α → Prop} [decidable_pred p]
+  (f : perm (subtype p)) (x : α) :
+  p x ↔ p ((of_subtype f : α → α) x) :=
+if h : p x then by simpa only [of_subtype, h, coe_fn_mk, dif_pos, true_iff, monoid_hom.coe_mk]
+  using (f ⟨x, h⟩).2
+else by simp [h, of_subtype_apply_of_not_mem f h]
+
+@[simp] lemma subtype_perm_of_subtype {p : α → Prop} [decidable_pred p] (f : perm (subtype p)) :
+  subtype_perm (of_subtype f) (mem_iff_of_subtype_apply_mem f) = f :=
+equiv.ext $ λ ⟨x, hx⟩, by { dsimp [subtype_perm, of_subtype],
+  simp only [show p x, from hx, dif_pos, subtype.coe_eta] }
+
 end perm
 
 section swap


### PR DESCRIPTION
Both `perm.subtype_perm` and `perm.of_subtype` can be moved up the import hierarchy out of `group_theory/perm/sign` since they do not rely on any finiteness assumption. 

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This also makes them more discoverable, for example, compared to `equiv.subtype_congr` (or `equiv.subtype_equiv` once #6004 is merged).