### PR TITLE
[Merged by Bors] - fix(tactic/delta_instance): improve naming of instances with multiple arguments

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -429,7 +429,7 @@ Topology:
   Hilbert Spaces:
     Hilbert projection theorem: 'exists_norm_eq_infi_of_complete_convex'
     orthogonal projection onto closed vector subspaces: 'orthogonal_projection_fn'
-    dual space: 'normed_space.dual.inst'
+    dual space: 'normed_space.dual.normed_space'
     Riesz representation theorem: 'inner_product_space.to_dual'
     $l^2$ and $L^2$ cases:
     Hilbert (orthonormal) bases (in the separable case): 'exists_is_orthonormal_dense_span'

--- a/src/tactic/delta_instance.lean
+++ b/src/tactic/delta_instance.lean
@@ -38,6 +38,7 @@ good name. -/
 meta def delta_instance_name : pexpr → string
 | (expr.app f _) := delta_instance_name f
 | (expr.pi _ _ _ body) := delta_instance_name body
+| (expr.lam _ _ _ body) := delta_instance_name body
 | (expr.const nm _) := nm.last
 | _ := "inst"
 

--- a/src/tactic/delta_instance.lean
+++ b/src/tactic/delta_instance.lean
@@ -31,6 +31,16 @@ meta def delta_instance (ids : parse ident*) : itactic :=
 tactic.delta_instance ids
 end interactive
 
+/-- Guess a name for an instance from its expression.
+
+This is a poor-man's version of the C++ `heuristic_inst_name`, and tries much less hard to pick a
+good name. -/
+meta def delta_instance_name : pexpr → string
+| (expr.app f _) := delta_instance_name f
+| (expr.pi _ _ _ body) := delta_instance_name body
+| (expr.const nm _) := nm.last
+| _ := "inst"
+
 /--
 Tries to derive instances by unfolding the newly introduced type and applying type class resolution.
 
@@ -58,11 +68,7 @@ do new_decl ← get_decl new_decl_name,
    inst ← instantiate_mvars inst,
    inst ← replace_univ_metas_with_univ_params inst,
    tgt ← instantiate_mvars tgt,
-   nm ← get_unused_decl_name $ new_decl_name <.>
-     match cls with
-     | (expr.const nm _) := nm.last
-     | _ := "inst"
-     end,
+   nm ← get_unused_decl_name $ new_decl_name <.> (delta_instance_name cls),
    add_protected_decl $ declaration.defn nm inst.collect_univ_params tgt inst new_decl.reducibility_hints new_decl.is_trusted,
    set_basic_attribute `instance nm tt,
    return tt

--- a/test/delta_instance.lean
+++ b/test/delta_instance.lean
@@ -16,11 +16,12 @@ instance : binclass ℤ ℤ := ⟨⟩
 
 @[derive [ring, binclass ℤ]] def U := ℤ
 
+@[derive λ α, binclass α ℤ] def V := ℤ
+
 -- test instance naming
 example := U.ring
 example := U.binclass
-
-@[derive λ α, binclass α ℤ] def V := ℤ
+example := V.binclass
 
 @[derive ring] def id_ring (α) [ring α] : Type := α
 

--- a/test/delta_instance.lean
+++ b/test/delta_instance.lean
@@ -16,6 +16,10 @@ instance : binclass ℤ ℤ := ⟨⟩
 
 @[derive [ring, binclass ℤ]] def U := ℤ
 
+-- test instance naming
+example := U.ring
+example := U.binclass
+
 @[derive λ α, binclass α ℤ] def V := ℤ
 
 @[derive ring] def id_ring (α) [ring α] : Type := α


### PR DESCRIPTION
---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
