### PR TITLE
[Merged by Bors] - feat(algebra/lie/basic): define the center of a Lie algebra and prove some related results

### DIFF
--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -555,7 +555,7 @@ variables [comm_ring R] [lie_ring L] [lie_algebra R L] [add_comm_group M] [modul
 variables [lie_ring_module L M] [lie_module R L M]
 
 /-- A Lie module yields a Lie algebra morphism into the linear endomorphisms of the module. -/
-@[simps] def lie_module.to_endo_morphism : L →ₗ⁅R⁆ module.End R M :=
+@[simps] def lie_module.to_endomorphism : L →ₗ⁅R⁆ module.End R M :=
 { to_fun    := λ x,
   { to_fun    := λ m, ⁅x, m⁆,
     map_add'  := lie_add x,
@@ -565,7 +565,7 @@ variables [lie_ring_module L M] [lie_module R L M]
   map_lie   := λ x y, by { ext m, apply lie_lie, }, }
 
 /-- The adjoint action of a Lie algebra on itself. -/
-def lie_algebra.ad : L →ₗ⁅R⁆ module.End R L := lie_module.to_endo_morphism R L L
+def lie_algebra.ad : L →ₗ⁅R⁆ module.End R L := lie_module.to_endomorphism R L L
 
 @[simp] lemma lie_algebra.ad_apply (x y : L) : lie_algebra.ad R L x y = ⁅x, y⁆ := rfl
 
@@ -1214,7 +1214,7 @@ lemma is_quotient_mk (m : M) :
 /-- Given a Lie module `M` over a Lie algebra `L`, together with a Lie submodule `N ⊆ M`, there
 is a natural linear map from `L` to the endomorphisms of `M` leaving `N` invariant. -/
 def lie_submodule_invariant : L →ₗ[R] submodule.compatible_maps N.to_submodule N.to_submodule :=
-  linear_map.cod_restrict _ (lie_module.to_endo_morphism R L M) N.lie_mem
+  linear_map.cod_restrict _ (lie_module.to_endomorphism R L M) N.lie_mem
 
 variables (N)
 
@@ -1808,13 +1808,13 @@ instance trivial_is_nilpotent [is_trivial L M] : is_nilpotent R L M :=
 ⟨by { use 1, change ⁅⊤, ⊤⁆ = ⊥, simp, }⟩
 
 /-- The kernel of the action of a Lie algebra `L` on a Lie module `M` as a Lie ideal in `L`. -/
-protected def ker : lie_ideal R L := (to_endo_morphism R L M).ker
+protected def ker : lie_ideal R L := (to_endomorphism R L M).ker
 
 @[simp] protected lemma mem_ker (x : L) : x ∈ lie_module.ker R L M ↔ ∀ (m : M), ⁅x, m⁆ = 0 :=
 begin
   dunfold lie_module.ker,
   simp only [lie_algebra.morphism.mem_ker, linear_map.ext_iff, linear_map.zero_apply,
-    to_endo_morphism_apply_apply],
+    to_endomorphism_apply_apply],
 end
 
 /-- The largest submodule of a Lie module `M` on which the Lie algebra `L` acts trivially. -/

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -157,6 +157,8 @@ instance : has_coe (L₁ →ₗ⁅R⁆ L₂) (L₁ →ₗ[R] L₂) := ⟨morphis
 /-- see Note [function coercion] -/
 instance : has_coe_to_fun (L₁ →ₗ⁅R⁆ L₂) := ⟨_, morphism.to_fun⟩
 
+initialize_simps_projections lie_algebra.morphism (to_fun → apply)
+
 @[simp] lemma coe_mk (f : L₁ → L₂) (h₁ h₂ h₃) :
   ((⟨f, h₁, h₂, h₃⟩ : L₁ →ₗ⁅R⁆ L₂) : L₁ → L₂) = f := rfl
 
@@ -987,15 +989,12 @@ by { rw [← mem_coe_submodule, sup_coe_to_submodule, submodule.mem_sup], exact 
 lemma eq_bot_iff : N = ⊥ ↔ ∀ (m : M), m ∈ N → m = 0 :=
 by { rw eq_bot_iff, exact iff.rfl, }
 
-lemma of_bot_eq_bot (N : lie_submodule R L ↥(⊥ : lie_submodule R L M)) : N = ⊥ :=
+lemma subsingleton_of_bot : subsingleton (lie_submodule R L ↥(⊥ : lie_submodule R L M)) :=
 begin
+  apply subsingleton_of_bot_eq_top,
   ext ⟨x, hx⟩, change x ∈ ⊥ at hx, rw submodule.mem_bot at hx, subst hx,
-  rw [mem_bot, submodule.mk_eq_zero, eq_self_iff_true, iff_true],
-  exact N.zero_mem,
+  simp only [true_iff, eq_self_iff_true, submodule.mk_eq_zero, lie_submodule.mem_bot],
 end
-
-lemma unique_of_bot (N N' : lie_submodule R L ↥(⊥ : lie_submodule R L M)) : N = N' :=
-by rw [N.of_bot_eq_bot, N'.of_bot_eq_bot]
 
 section inclusion_maps
 
@@ -1516,21 +1515,18 @@ begin
   { rw [lie_submodule.le_def, ← h], exact lie_submodule.subset_lie_span, },
 end
 
-/-- Note that this is not a special case of `lie_submodule.of_bot_eq_bot`. Indeed, given
+/-- Note that this is not a special case of `lie_submodule.subsingleton_of_bot`. Indeed, given
 `I : lie_ideal R L`, in general the two lattices `lie_ideal R I` and `lie_submodule R L I` are
 different (though the latter does naturally inject into the former).
 
 In other words, in general, ideals of `I`, regarded as a Lie algebra in its own right, are not the
 same as ideals of `L` contained in `I`. -/
-lemma of_bot_eq_bot (I : lie_ideal R ↥(⊥ : lie_ideal R L)) : I = ⊥ :=
+lemma subsingleton_of_bot : subsingleton (lie_ideal R ↥(⊥ : lie_ideal R L)) :=
 begin
+  apply subsingleton_of_bot_eq_top,
   ext ⟨x, hx⟩, change x ∈ ⊥ at hx, rw submodule.mem_bot at hx, subst hx,
-  rw [lie_submodule.mem_bot, submodule.mk_eq_zero, eq_self_iff_true, iff_true],
-  exact I.zero_mem,
+  simp only [true_iff, eq_self_iff_true, submodule.mk_eq_zero, lie_submodule.mem_bot],
 end
-
-lemma unique_of_bot (I J : lie_submodule R L ↥(⊥ : lie_submodule R L M)) : I = J :=
-by rw [I.of_bot_eq_bot, J.of_bot_eq_bot]
 
 end lie_ideal
 
@@ -1816,7 +1812,7 @@ protected def ker : lie_ideal R L := (to_endo_morphism R L M).ker
 begin
   dunfold lie_module.ker,
   simp only [lie_algebra.morphism.mem_ker, linear_map.ext_iff, linear_map.zero_apply,
-    to_endo_morphism_to_fun_apply],
+    to_endo_morphism_apply_apply],
 end
 
 /-- The largest submodule of a Lie module `M` on which the Lie algebra `L` acts trivially. -/
@@ -1901,7 +1897,8 @@ class is_simple extends lie_module.is_irreducible R L L : Prop :=
 class is_solvable : Prop :=
 (solvable : ∃ k, derived_series R L k = ⊥)
 
-instance is_solvable_bot : is_solvable R ↥(⊥ : lie_ideal R L) := ⟨⟨0, lie_ideal.of_bot_eq_bot ⊤⟩⟩
+instance is_solvable_bot : is_solvable R ↥(⊥ : lie_ideal R L) :=
+⟨⟨0, @subsingleton.elim _ lie_ideal.subsingleton_of_bot _ ⊥⟩⟩
 
 instance is_solvable_add {I J : lie_ideal R L} [hI : is_solvable R I] [hJ : is_solvable R J] :
   is_solvable R ↥(I + J) :=
@@ -2089,9 +2086,12 @@ begin
   exact h₂ hI,
 end
 
-lemma semisimple_lie_abelian_trivial [is_semisimple R L] [h : is_lie_abelian L] :
-  (⊤ : lie_ideal R L) = ⊥ :=
-by { rw [is_lie_abelian_iff_center_eq_top R L, center_eq_bot_of_semisimple] at h, exact h.symm, }
+lemma subsingleton_of_semisimple_lie_abelian [is_semisimple R L] [h : is_lie_abelian L] :
+  subsingleton (lie_ideal R L) :=
+begin
+  apply subsingleton_of_bot_eq_top,
+  rwa [is_lie_abelian_iff_center_eq_top R L, center_eq_bot_of_semisimple] at h,
+end
 
 @[priority 100]
 instance is_solvable_of_is_nilpotent [hL : lie_module.is_nilpotent R L L] : is_solvable R L :=

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -553,7 +553,7 @@ variables [comm_ring R] [lie_ring L] [lie_algebra R L] [add_comm_group M] [modul
 variables [lie_ring_module L M] [lie_module R L M]
 
 /-- A Lie module yields a Lie algebra morphism into the linear endomorphisms of the module. -/
-def lie_module.to_endo_morphism : L →ₗ⁅R⁆ module.End R M :=
+@[simps] def lie_module.to_endo_morphism : L →ₗ⁅R⁆ module.End R M :=
 { to_fun    := λ x,
   { to_fun    := λ m, ⁅x, m⁆,
     map_add'  := lie_add x,
@@ -561,9 +561,6 @@ def lie_module.to_endo_morphism : L →ₗ⁅R⁆ module.End R M :=
   map_add'  := λ x y, by { ext m, apply add_lie, },
   map_smul' := λ t x, by { ext m, apply smul_lie, },
   map_lie   := λ x y, by { ext m, apply lie_lie, }, }
-
-@[simp] lemma lie_module.to_endo_morphism_apply (x : L) (m : M) :
-  lie_module.to_endo_morphism R L M x m = ⁅x, m⁆ := rfl
 
 /-- The adjoint action of a Lie algebra on itself. -/
 def lie_algebra.ad : L →ₗ⁅R⁆ module.End R L := lie_module.to_endo_morphism R L L
@@ -1818,7 +1815,7 @@ protected def ker : lie_ideal R L := (to_endo_morphism R L M).ker
 @[simp] protected lemma mem_ker (x : L) : x ∈ lie_module.ker R L M ↔ ∀ (m : M), ⁅x, m⁆ = 0 :=
 begin
   dunfold lie_module.ker,
-  simp only [lie_algebra.morphism.mem_ker, linear_map.eq_zero_iff, to_endo_morphism_apply],
+  simp only [lie_algebra.morphism.mem_ker, linear_map.eq_zero_iff, to_endo_morphism_to_fun_apply],
 end
 
 /-- The largest submodule of a Lie module `M` on which the Lie algebra `L` acts trivially. -/

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -2087,6 +2087,7 @@ begin
   exact h₂ hI,
 end
 
+-- TODO[gh-6025]: make this an instance once safe to do so
 lemma subsingleton_of_semisimple_lie_abelian [is_semisimple R L] [h : is_lie_abelian L] :
   subsingleton (lie_ideal R L) :=
 begin

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -1522,6 +1522,7 @@ different (though the latter does naturally inject into the former).
 
 In other words, in general, ideals of `I`, regarded as a Lie algebra in its own right, are not the
 same as ideals of `L` contained in `I`. -/
+-- TODO[gh-6025]: make this an instance once safe to do so
 lemma subsingleton_of_bot : subsingleton (lie_ideal R ↥(⊥ : lie_ideal R L)) :=
 begin
   apply subsingleton_of_bot_eq_top,

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -1815,7 +1815,8 @@ protected def ker : lie_ideal R L := (to_endo_morphism R L M).ker
 @[simp] protected lemma mem_ker (x : L) : x ∈ lie_module.ker R L M ↔ ∀ (m : M), ⁅x, m⁆ = 0 :=
 begin
   dunfold lie_module.ker,
-  simp only [lie_algebra.morphism.mem_ker, linear_map.eq_zero_iff, to_endo_morphism_to_fun_apply],
+  simp only [lie_algebra.morphism.mem_ker, linear_map.ext_iff, linear_map.zero_apply,
+    to_endo_morphism_to_fun_apply],
 end
 
 /-- The largest submodule of a Lie module `M` on which the Lie algebra `L` acts trivially. -/

--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -989,6 +989,7 @@ by { rw [← mem_coe_submodule, sup_coe_to_submodule, submodule.mem_sup], exact 
 lemma eq_bot_iff : N = ⊥ ↔ ∀ (m : M), m ∈ N → m = 0 :=
 by { rw eq_bot_iff, exact iff.rfl, }
 
+-- TODO[gh-6025]: make this an instance once safe to do so
 lemma subsingleton_of_bot : subsingleton (lie_submodule R L ↥(⊥ : lie_submodule R L M)) :=
 begin
   apply subsingleton_of_bot_eq_top,

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -161,6 +161,13 @@ instance unique_of_left [subsingleton M] : unique (M →ₗ[R] M₂) :=
 instance unique_of_right [subsingleton M₂] : unique (M →ₗ[R] M₂) :=
 coe_injective.unique
 
+lemma eq_zero_iff (f : M →ₗ[R] M₂) : f = 0 ↔ ∀ m, f m = 0 :=
+begin
+  split,
+  { intros h x, rw h, refl, },
+  { intros h, ext, apply h, },
+end
+
 /-- The sum of two linear maps is linear. -/
 instance : has_add (M →ₗ[R] M₂) :=
 ⟨λ f g, ⟨λ b, f b + g b, by simp [add_comm, add_left_comm], by simp [smul_add]⟩⟩

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -161,13 +161,6 @@ instance unique_of_left [subsingleton M] : unique (M →ₗ[R] M₂) :=
 instance unique_of_right [subsingleton M₂] : unique (M →ₗ[R] M₂) :=
 coe_injective.unique
 
-lemma eq_zero_iff (f : M →ₗ[R] M₂) : f = 0 ↔ ∀ m, f m = 0 :=
-begin
-  split,
-  { intros h x, rw h, refl, },
-  { intros h, ext, apply h, },
-end
-
 /-- The sum of two linear maps is linear. -/
 instance : has_add (M →ₗ[R] M₂) :=
 ⟨λ f g, ⟨λ b, f b + g b, by simp [add_comm, add_left_comm], by simp [smul_add]⟩⟩


### PR DESCRIPTION
---
I had originally intended to include the definition of reductive Lie algebras. Ultimately I decided against this because I learned that:

- There is absolutely no agreement on [what the label "reductive" should mean](https://mathoverflow.net/questions/284713/is-there-a-reasonable-way-to-define-reductive-lie-algebra-in-prime-characteris) outside of fields of characteristic 0.
- The various conditions that are equivalent for a field of char 0 are not equivalent in general.
- It would require a moderate amount of work to establish equivalence of the conditions when sufficient assumptions on the coefficients are provided. (Even basic facts like the fact that radical is a characteristic ideal need some work.)

So I think this is a reasonable stopping point before I attempt [the refactor I mentioned](https://github.com/leanprover-community/mathlib/pull/5794#discussion_r560050825).