### PR TITLE
[Merged by Bors] - feat(data/list/sort): add sorted.rel_of_mem_take_of_mem_drop

### DIFF
--- a/src/data/finset/sort.lean
+++ b/src/data/finset/sort.lean
@@ -61,7 +61,7 @@ begin
     obtain ⟨i, i_lt, hi⟩ : ∃ i (hi : i < l.length), l.nth_le i hi = s.min' H :=
       list.mem_iff_nth_le.1 this,
     rw ← hi,
-    exact (s.sort_sorted (≤)).rel_nth_le_of_le (nat.zero_le i) },
+    exact (s.sort_sorted (≤)).rel_nth_le_of_le _ _ (nat.zero_le i) },
   { have : l.nth_le 0 h ∈ s := (finset.mem_sort (≤)).1 (list.nth_le_mem l 0 h),
     exact s.min'_le _ this }
 end
@@ -87,7 +87,7 @@ begin
       list.mem_iff_nth_le.1 this,
     rw ← hi,
     have : i ≤ l.length - 1 := nat.le_pred_of_lt i_lt,
-    exact (s.sort_sorted (≤)).rel_nth_le_of_le (nat.le_pred_of_lt i_lt) },
+    exact (s.sort_sorted (≤)).rel_nth_le_of_le _ _ (nat.le_pred_of_lt i_lt) },
 end
 
 lemma sorted_last_eq_max' {s : finset α} {h : (s.sort (≤)).length - 1 < (s.sort (≤)).length} :

--- a/src/data/finset/sort.lean
+++ b/src/data/finset/sort.lean
@@ -61,7 +61,7 @@ begin
     obtain ⟨i, i_lt, hi⟩ : ∃ i (hi : i < l.length), l.nth_le i hi = s.min' H :=
       list.mem_iff_nth_le.1 this,
     rw ← hi,
-    exact list.nth_le_of_sorted_of_le (s.sort_sorted (≤)) (nat.zero_le i) },
+    exact (s.sort_sorted (≤)).rel_nth_le_of_le (nat.zero_le i) },
   { have : l.nth_le 0 h ∈ s := (finset.mem_sort (≤)).1 (list.nth_le_mem l 0 h),
     exact s.min'_le _ this }
 end
@@ -87,7 +87,7 @@ begin
       list.mem_iff_nth_le.1 this,
     rw ← hi,
     have : i ≤ l.length - 1 := nat.le_pred_of_lt i_lt,
-    exact list.nth_le_of_sorted_of_le (s.sort_sorted (≤)) (nat.le_pred_of_lt i_lt) },
+    exact (s.sort_sorted (≤)).rel_nth_le_of_le (nat.le_pred_of_lt i_lt) },
 end
 
 lemma sorted_last_eq_max' {s : finset α} {h : (s.sort (≤)).length - 1 < (s.sort (≤)).length} :

--- a/src/data/list/nodup_equiv_fin.lean
+++ b/src/data/list/nodup_equiv_fin.lean
@@ -49,11 +49,11 @@ variables [preorder α] {l : list α}
 
 lemma nth_le_mono (h : l.sorted (≤)) :
   monotone (λ i : fin l.length, l.nth_le i i.2) :=
-λ i j, h.rel_nth_le_of_le
+λ i j, h.rel_nth_le_of_le _ _
 
 lemma nth_le_strict_mono (h : l.sorted (<)) :
   strict_mono (λ i : fin l.length, l.nth_le i i.2) :=
-λ i j, h.rel_nth_le_of_lt
+λ i j, h.rel_nth_le_of_lt _ _
 
 variable [decidable_eq α]
 

--- a/src/data/list/nodup_equiv_fin.lean
+++ b/src/data/list/nodup_equiv_fin.lean
@@ -49,11 +49,11 @@ variables [preorder α] {l : list α}
 
 lemma nth_le_mono (h : l.sorted (≤)) :
   monotone (λ i : fin l.length, l.nth_le i i.2) :=
-λ i j, nth_le_of_sorted_of_le h
+λ i j, h.rel_nth_le_of_le
 
 lemma nth_le_strict_mono (h : l.sorted (<)) :
   strict_mono (λ i : fin l.length, l.nth_le i i.2) :=
-λ i j, pairwise_iff_nth_le.1 h i j j.2
+λ i j, h.rel_nth_le_of_lt
 
 variable [decidable_eq α]
 

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -86,7 +86,7 @@ lemma sorted.rel_of_mem_take_of_mem_drop {l : list α} (h : list.sorted r l)
   (k : ℕ) {x y : α} (hx : x ∈ list.take k l) (hy : y ∈ list.drop k l) :
   r x y :=
 begin
-  induction l with lh lt generalizing k,
+  induction l with lh lt l_ih generalizing k,
   { simpa using hy },
   cases k,
   { simpa using hx, },

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -82,6 +82,22 @@ begin
   { exact list.pairwise_iff_nth_le.1 h a b hb H }
 end
 
+lemma sorted.rel_of_mem_take_of_mem_drop {l : list α} (h : list.sorted r l)
+  (k : ℕ) {x y : α} (hx : x ∈ list.take k l) (hy : y ∈ list.drop k l) :
+  r x y :=
+begin
+  induction l with lh lt generalizing k,
+  { simpa using hy },
+  cases k,
+  { simpa using hx, },
+  rw [list.take, list.mem_cons_iff] at hx,
+  rw [list.drop] at hy,
+  obtain ⟨hh, ht⟩ := list.sorted_cons.mp h,
+  obtain (rfl | hx) := hx,
+  { exact hh _ (list.mem_of_mem_drop hy) },
+  { exact l_ih ht _ hx hy },
+end
+
 end sorted
 
 section sort

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -90,12 +90,9 @@ begin
   { simpa using hy },
   cases k,
   { simpa using hx, },
-  rw [list.take, list.mem_cons_iff] at hx,
-  rw [list.drop] at hy,
-  obtain ⟨hh, ht⟩ := list.sorted_cons.mp h,
-  obtain (rfl | hx) := hx,
-  { exact hh _ (list.mem_of_mem_drop hy) },
-  { exact l_ih ht _ hx hy },
+  rcases hx with (rfl | hx),
+  { exact rel_of_sorted_cons h _ (mem_of_mem_drop hy) },
+  { exact l_ih (sorted_of_sorted_cons h) _ hx hy },
 end
 
 end sorted

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -73,26 +73,31 @@ end
 
 @[simp] theorem sorted_singleton (a : α) : sorted r [a] := pairwise_singleton _ _
 
-lemma nth_le_of_sorted_of_le [is_refl α r] {l : list α}
+lemma sorted.rel_nth_le_of_lt {l : list α}
+  (h : l.sorted r) {a b : ℕ} {ha : a < l.length} {hb : b < l.length} (hab : a < b) :
+  r (l.nth_le a ha) (l.nth_le b hb) :=
+list.pairwise_iff_nth_le.1 h a b hb hab
+
+lemma sorted.rel_nth_le_of_le [is_refl α r] {l : list α}
   (h : l.sorted r) {a b : ℕ} {ha : a < l.length} {hb : b < l.length} (hab : a ≤ b) :
   r (l.nth_le a ha) (l.nth_le b hb) :=
 begin
   cases eq_or_lt_of_le hab with H H,
-  { induction H, exact refl _ },
-  { exact list.pairwise_iff_nth_le.1 h a b hb H }
+  { subst H, exact refl _ },
+  { exact h.rel_nth_le_of_lt H }
 end
 
 lemma sorted.rel_of_mem_take_of_mem_drop {l : list α} (h : list.sorted r l)
-  (k : ℕ) {x y : α} (hx : x ∈ list.take k l) (hy : y ∈ list.drop k l) :
+  {k : ℕ} {x y : α} (hx : x ∈ list.take k l) (hy : y ∈ list.drop k l) :
   r x y :=
 begin
-  induction l with lh lt l_ih generalizing k,
-  { simpa using hy },
-  cases k,
-  { simpa using hx, },
-  rcases hx with (rfl | hx),
-  { exact rel_of_sorted_cons h _ (mem_of_mem_drop hy) },
-  { exact l_ih (sorted_of_sorted_cons h) _ hx hy },
+  obtain ⟨iy, hiy, rfl⟩ := nth_le_of_mem hy,
+  obtain ⟨ix, hix, rfl⟩ := nth_le_of_mem hx,
+  rw [nth_le_take', nth_le_drop'],
+  apply h.rel_nth_le_of_lt,
+  apply nat.lt_add_right,
+  rw [length_take] at hix,
+  exact (lt_min_iff.mp hix).left
 end
 
 end sorted

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -74,17 +74,17 @@ end
 @[simp] theorem sorted_singleton (a : α) : sorted r [a] := pairwise_singleton _ _
 
 lemma sorted.rel_nth_le_of_lt {l : list α}
-  (h : l.sorted r) {a b : ℕ} {ha : a < l.length} {hb : b < l.length} (hab : a < b) :
+  (h : l.sorted r) {a b : ℕ} (ha : a < l.length) (hb : b < l.length) (hab : a < b) :
   r (l.nth_le a ha) (l.nth_le b hb) :=
 list.pairwise_iff_nth_le.1 h a b hb hab
 
 lemma sorted.rel_nth_le_of_le [is_refl α r] {l : list α}
-  (h : l.sorted r) {a b : ℕ} {ha : a < l.length} {hb : b < l.length} (hab : a ≤ b) :
+  (h : l.sorted r) {a b : ℕ} (ha : a < l.length) (hb : b < l.length) (hab : a ≤ b) :
   r (l.nth_le a ha) (l.nth_le b hb) :=
 begin
   cases eq_or_lt_of_le hab with H H,
   { subst H, exact refl _ },
-  { exact h.rel_nth_le_of_lt H }
+  { exact h.rel_nth_le_of_lt _ _ H }
 end
 
 lemma sorted.rel_of_mem_take_of_mem_drop {l : list α} (h : list.sorted r l)
@@ -94,10 +94,8 @@ begin
   obtain ⟨iy, hiy, rfl⟩ := nth_le_of_mem hy,
   obtain ⟨ix, hix, rfl⟩ := nth_le_of_mem hx,
   rw [nth_le_take', nth_le_drop'],
-  apply h.rel_nth_le_of_lt,
-  apply nat.lt_add_right,
-  rw [length_take] at hix,
-  exact (lt_min_iff.mp hix).left
+  rw length_take at hix,
+  exact h.rel_nth_le_of_lt _ _ (ix.lt_add_right _ _ (lt_min_iff.mp hix).left)
 end
 
 end sorted


### PR DESCRIPTION
Also renames the existing lemmas to enable dot notation

Co-authored-by: pechersky@users.noreply.github.com

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
