### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/trigonometric): add mistakenly omitted lemma

### DIFF
--- a/src/analysis/special_functions/trigonometric.lean
+++ b/src/analysis/special_functions/trigonometric.lean
@@ -2801,7 +2801,7 @@ lemma arcsin_eq_arctan {x : ℝ} (h : x ∈ Ioo (-(1:ℝ)) 1) :
   arcsin x = arctan (x / sqrt (1 - x ^ 2)) :=
 begin
   rw [arctan_eq_arcsin, div_pow, sqr_sqrt, one_add_div, div_div_eq_div_mul,
-      ← sqrt_mul, mul_div_cancel', sub_add_cancel, sqrt_one, div_one],
+      ← sqrt_mul, mul_div_cancel', sub_add_cancel, sqrt_one, div_one];
   nlinarith [h.1, h.2],
 end
 

--- a/src/analysis/special_functions/trigonometric.lean
+++ b/src/analysis/special_functions/trigonometric.lean
@@ -2797,6 +2797,11 @@ lemma neg_pi_div_two_lt_arctan (x : ℝ) : -(π / 2) < arctan x :=
 lemma arctan_eq_arcsin (x : ℝ) : arctan x = arcsin (x / sqrt (1 + x ^ 2)) :=
 eq.symm $ arcsin_eq_of_sin_eq (sin_arctan x) (mem_Icc_of_Ioo $ arctan_mem_Ioo x)
 
+lemma arcsin_eq_arctan {x : ℝ} (h : x ∈ Ioo (-(1:ℝ)) 1) : arcsin x = arctan (x / sqrt (1 - x^2)) :=
+by rw [arctan_eq_arcsin, div_pow, sqr_sqrt, one_add_div, div_div_eq_div_mul,
+      ← sqrt_mul, mul_div_cancel', sub_add_cancel, sqrt_one, div_one];
+    nlinarith [h.1, h.2]
+
 @[simp] lemma arctan_zero : arctan 0 = 0 :=
 by simp [arctan_eq_arcsin]
 

--- a/src/analysis/special_functions/trigonometric.lean
+++ b/src/analysis/special_functions/trigonometric.lean
@@ -2797,10 +2797,13 @@ lemma neg_pi_div_two_lt_arctan (x : ℝ) : -(π / 2) < arctan x :=
 lemma arctan_eq_arcsin (x : ℝ) : arctan x = arcsin (x / sqrt (1 + x ^ 2)) :=
 eq.symm $ arcsin_eq_of_sin_eq (sin_arctan x) (mem_Icc_of_Ioo $ arctan_mem_Ioo x)
 
-lemma arcsin_eq_arctan {x : ℝ} (h : x ∈ Ioo (-(1:ℝ)) 1) : arcsin x = arctan (x / sqrt (1 - x^2)) :=
-by rw [arctan_eq_arcsin, div_pow, sqr_sqrt, one_add_div, div_div_eq_div_mul,
-      ← sqrt_mul, mul_div_cancel', sub_add_cancel, sqrt_one, div_one];
-    nlinarith [h.1, h.2]
+lemma arcsin_eq_arctan {x : ℝ} (h : x ∈ Ioo (-(1:ℝ)) 1) :
+  arcsin x = arctan (x / sqrt (1 - x ^ 2)) :=
+begin
+  rw [arctan_eq_arcsin, div_pow, sqr_sqrt, one_add_div, div_div_eq_div_mul,
+      ← sqrt_mul, mul_div_cancel', sub_add_cancel, sqrt_one, div_one],
+  nlinarith [h.1, h.2],
+end
 
 @[simp] lemma arctan_zero : arctan 0 = 0 :=
 by simp [arctan_eq_arcsin]


### PR DESCRIPTION

---
I thought I added this lemma in #5404. I've only now realized that I accidentally deleted it in a commit shortly before that PR merged.

I've labelled this as "easy" since it met approval in the aforementioned PR.
