### PR TITLE
[Merged by Bors] - feat(algebra/char_zero): add char_zero lemma for ordered_semirings

### DIFF
--- a/src/algebra/char_zero.lean
+++ b/src/algebra/char_zero.lean
@@ -48,7 +48,7 @@ theorem char_zero_of_inj_zero {R : Type*} [add_left_cancel_monoid R] [has_one R]
    rw [H k h, add_zero]
  end⟩
 
-/-- Note this is not an instances as `char_zero` implies `nontrivial`,
+/-- Note this is not an instance as `char_zero` implies `nontrivial`,
 and this would risk forming a loop. -/
 lemma ordered_semiring.to_char_zero {R : Type*} [ordered_semiring R] [nontrivial R] :
   char_zero R :=

--- a/src/algebra/char_zero.lean
+++ b/src/algebra/char_zero.lean
@@ -48,7 +48,8 @@ theorem char_zero_of_inj_zero {R : Type*} [add_left_cancel_monoid R] [has_one R]
    rw [H k h, add_zero]
  end⟩
 
-/-- Note this is not an instances as `char_zero` implies `nontrivial`, and this would risk forming a loop. -/
+/-- Note this is not an instances as `char_zero` implies `nontrivial`,
+and this would risk forming a loop. -/
 lemma ordered_semiring.to_char_zero {R : Type*} [ordered_semiring R] [nontrivial R] :
   char_zero R :=
 ⟨nat.strict_mono_cast.injective⟩

--- a/src/algebra/char_zero.lean
+++ b/src/algebra/char_zero.lean
@@ -53,6 +53,11 @@ instance linear_ordered_semiring.to_char_zero {R : Type*}
   [linear_ordered_semiring R] : char_zero R :=
 ⟨nat.strict_mono_cast.injective⟩
 
+/-- An `ordered_semiring` has characteristic zero. -/
+lemma char_zero_ordered_semiring {R : Type*} [ordered_semiring R] [nontrivial R] :
+  char_zero R :=
+{ cast_injective := nat.strict_mono_cast.injective }
+
 namespace nat
 variables {R : Type*} [add_monoid R] [has_one R] [char_zero R]
 

--- a/src/algebra/char_zero.lean
+++ b/src/algebra/char_zero.lean
@@ -48,15 +48,15 @@ theorem char_zero_of_inj_zero {R : Type*} [add_left_cancel_monoid R] [has_one R]
    rw [H k h, add_zero]
  end⟩
 
+/-- Note this is not an instances as `char_zero` implies `nontrivial`, and this would risk forming a loop. -/
+lemma ordered_semiring.to_char_zero {R : Type*} [ordered_semiring R] [nontrivial R] :
+  char_zero R :=
+⟨nat.strict_mono_cast.injective⟩
+
 @[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_semiring.to_char_zero {R : Type*}
   [linear_ordered_semiring R] : char_zero R :=
-⟨nat.strict_mono_cast.injective⟩
-
-/-- An `ordered_semiring` has characteristic zero. -/
-lemma char_zero_ordered_semiring {R : Type*} [ordered_semiring R] [nontrivial R] :
-  char_zero R :=
-{ cast_injective := nat.strict_mono_cast.injective }
+ordered_semiring.to_char_zero
 
 namespace nat
 variables {R : Type*} [add_monoid R] [has_one R] [char_zero R]


### PR DESCRIPTION
Relevant Zulip chat:

https://leanprover.zulipchat.com/#narrow/stream/113489-new-members

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
