### PR TITLE
[Merged by Bors] - refactor(real): protect real.pi

### DIFF
--- a/src/analysis/complex/roots_of_unity.lean
+++ b/src/analysis/complex/roots_of_unity.lean
@@ -25,10 +25,10 @@ are exactly the complex numbers `e ^ (2 * real.pi * complex.I * (i / n))` for `i
 namespace complex
 
 open polynomial real
-open_locale nat
+open_locale nat real
 
 lemma is_primitive_root_exp_of_coprime (i n : ℕ) (h0 : n ≠ 0) (hi : i.coprime n) :
-  is_primitive_root (exp (2 * pi * I * (i / n))) n :=
+  is_primitive_root (exp (2 * π * I * (i / n))) n :=
 begin
   rw is_primitive_root.iff_def,
   simp only [← exp_nat_mul, exp_eq_one_iff],
@@ -45,12 +45,12 @@ begin
     exact hi.symm.dvd_of_dvd_mul_left this }
 end
 
-lemma is_primitive_root_exp (n : ℕ) (h0 : n ≠ 0) : is_primitive_root (exp (2 * pi * I / n)) n :=
+lemma is_primitive_root_exp (n : ℕ) (h0 : n ≠ 0) : is_primitive_root (exp (2 * π * I / n)) n :=
 by simpa only [nat.cast_one, one_div]
   using is_primitive_root_exp_of_coprime 1 n h0 n.coprime_one_left
 
 lemma is_primitive_root_iff (ζ : ℂ) (n : ℕ) (hn : n ≠ 0) :
-  is_primitive_root ζ n ↔ (∃ (i < (n : ℕ)) (hi : i.coprime n), exp (2 * pi * I * (i / n)) = ζ) :=
+  is_primitive_root ζ n ↔ (∃ (i < (n : ℕ)) (hi : i.coprime n), exp (2 * π * I * (i / n)) = ζ) :=
 begin
   have hn0 : (n : ℂ) ≠ 0 := by exact_mod_cast hn,
   split, swap,
@@ -67,13 +67,13 @@ end
 /-- The complex `n`-th roots of unity are exactly the
 complex numbers of the form `e ^ (2 * real.pi * complex.I * (i / n))` for some `i < n`. -/
 lemma mem_roots_of_unity (n : ℕ+) (x : units ℂ) :
-  x ∈ roots_of_unity n ℂ ↔ (∃ i < (n : ℕ), exp (2 * pi * I * (i / n)) = x) :=
+  x ∈ roots_of_unity n ℂ ↔ (∃ i < (n : ℕ), exp (2 * π * I * (i / n)) = x) :=
 begin
   rw [mem_roots_of_unity, units.ext_iff, units.coe_pow, units.coe_one],
   have hn0 : (n : ℂ) ≠ 0 := by exact_mod_cast (n.ne_zero),
   split,
   { intro h,
-    obtain ⟨i, hi, H⟩ : ∃ i < (n : ℕ), exp (2 * pi * I / n) ^ i = x,
+    obtain ⟨i, hi, H⟩ : ∃ i < (n : ℕ), exp (2 * π * I / n) ^ i = x,
     { simpa only using (is_primitive_root_exp n n.ne_zero).eq_pow_of_pow_eq_one h n.pos },
     refine ⟨i, hi, _⟩,
     rw [← H, ← exp_nat_mul],

--- a/src/analysis/special_functions/trigonometric.lean
+++ b/src/analysis/special_functions/trigonometric.lean
@@ -884,20 +884,20 @@ intermediate_value_Icc' (by norm_num) continuous_on_cos
 
 /-- The number π = 3.14159265... Defined here using choice as twice a zero of cos in [1,2], from
 which one can derive all its properties. For explicit bounds on π, see `data.real.pi`. -/
-noncomputable def pi : ℝ := 2 * classical.some exists_cos_eq_zero
+protected noncomputable def pi : ℝ := 2 * classical.some exists_cos_eq_zero
 
 localized "notation `π` := real.pi" in real
 
 @[simp] lemma cos_pi_div_two : cos (π / 2) = 0 :=
-by rw [pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
+by rw [real.pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
   exact (classical.some_spec exists_cos_eq_zero).2
 
 lemma one_le_pi_div_two : (1 : ℝ) ≤ π / 2 :=
-by rw [pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
+by rw [real.pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
   exact (classical.some_spec exists_cos_eq_zero).1.1
 
 lemma pi_div_two_le_two : π / 2 ≤ 2 :=
-by rw [pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
+by rw [real.pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
   exact (classical.some_spec exists_cos_eq_zero).1.2
 
 lemma two_le_pi : (2 : ℝ) ≤ π :=
@@ -1251,7 +1251,7 @@ lemma sqrt_two_add_series_monotone_left {x y : ℝ} (h : x ≤ y) :
     exact sqrt_le_sqrt (add_le_add_left (sqrt_two_add_series_monotone_left _) _)
   end
 
-@[simp] lemma cos_pi_over_two_pow : ∀(n : ℕ), cos (pi / 2 ^ (n+1)) = sqrt_two_add_series 0 n / 2
+@[simp] lemma cos_pi_over_two_pow : ∀(n : ℕ), cos (π / 2 ^ (n+1)) = sqrt_two_add_series 0 n / 2
 | 0     := by simp
 | (n+1) :=
   begin
@@ -1266,24 +1266,24 @@ lemma sqrt_two_add_series_monotone_left {x y : ℝ} (h : x ≤ y) :
     apply le_of_lt, apply cos_pos_of_mem_Ioo ⟨_, _⟩,
     { transitivity (0 : ℝ), rw neg_lt_zero, apply pi_div_two_pos,
       apply div_pos pi_pos, apply pow_pos, norm_num },
-    apply div_lt_div' (le_refl pi) _ pi_pos _,
+    apply div_lt_div' (le_refl π) _ pi_pos _,
     refine lt_of_le_of_lt (le_of_eq (pow_one _).symm) _,
     apply pow_lt_pow, norm_num, apply nat.succ_lt_succ, apply nat.succ_pos, all_goals {norm_num}
   end
 
 lemma sin_square_pi_over_two_pow (n : ℕ) :
-  sin (pi / 2 ^ (n+1)) ^ 2 = 1 - (sqrt_two_add_series 0 n / 2) ^ 2 :=
+  sin (π / 2 ^ (n+1)) ^ 2 = 1 - (sqrt_two_add_series 0 n / 2) ^ 2 :=
 by rw [sin_square, cos_pi_over_two_pow]
 
 lemma sin_square_pi_over_two_pow_succ (n : ℕ) :
-  sin (pi / 2 ^ (n+2)) ^ 2 = 1 / 2 - sqrt_two_add_series 0 n / 4 :=
+  sin (π / 2 ^ (n+2)) ^ 2 = 1 / 2 - sqrt_two_add_series 0 n / 4 :=
 begin
   rw [sin_square_pi_over_two_pow, sqrt_two_add_series, div_pow, sqr_sqrt, add_div, ←sub_sub],
   congr, norm_num, norm_num, apply add_nonneg, norm_num, apply sqrt_two_add_series_zero_nonneg,
 end
 
 @[simp] lemma sin_pi_over_two_pow_succ (n : ℕ) :
-  sin (pi / 2 ^ (n+2)) = sqrt (2 - sqrt_two_add_series 0 n) / 2 :=
+  sin (π / 2 ^ (n+2)) = sqrt (2 - sqrt_two_add_series 0 n) / 2 :=
 begin
   symmetry, rw [div_eq_iff_mul_eq], symmetry,
   rw [sqrt_eq_iff_sqr_eq, mul_pow, sin_square_pi_over_two_pow_succ, sub_mul],
@@ -1297,29 +1297,29 @@ begin
   apply pow_pos, all_goals {norm_num}
 end
 
-@[simp] lemma cos_pi_div_four : cos (pi / 4) = sqrt 2 / 2 :=
-by { transitivity cos (pi / 2 ^ 2), congr, norm_num, simp }
+@[simp] lemma cos_pi_div_four : cos (π / 4) = sqrt 2 / 2 :=
+by { transitivity cos (π / 2 ^ 2), congr, norm_num, simp }
 
-@[simp] lemma sin_pi_div_four : sin (pi / 4) = sqrt 2 / 2 :=
-by { transitivity sin (pi / 2 ^ 2), congr, norm_num, simp }
+@[simp] lemma sin_pi_div_four : sin (π / 4) = sqrt 2 / 2 :=
+by { transitivity sin (π / 2 ^ 2), congr, norm_num, simp }
 
-@[simp] lemma cos_pi_div_eight : cos (pi / 8) = sqrt (2 + sqrt 2) / 2 :=
-by { transitivity cos (pi / 2 ^ 3), congr, norm_num, simp }
+@[simp] lemma cos_pi_div_eight : cos (π / 8) = sqrt (2 + sqrt 2) / 2 :=
+by { transitivity cos (π / 2 ^ 3), congr, norm_num, simp }
 
-@[simp] lemma sin_pi_div_eight : sin (pi / 8) = sqrt (2 - sqrt 2) / 2 :=
-by { transitivity sin (pi / 2 ^ 3), congr, norm_num, simp }
+@[simp] lemma sin_pi_div_eight : sin (π / 8) = sqrt (2 - sqrt 2) / 2 :=
+by { transitivity sin (π / 2 ^ 3), congr, norm_num, simp }
 
-@[simp] lemma cos_pi_div_sixteen : cos (pi / 16) = sqrt (2 + sqrt (2 + sqrt 2)) / 2 :=
-by { transitivity cos (pi / 2 ^ 4), congr, norm_num, simp }
+@[simp] lemma cos_pi_div_sixteen : cos (π / 16) = sqrt (2 + sqrt (2 + sqrt 2)) / 2 :=
+by { transitivity cos (π / 2 ^ 4), congr, norm_num, simp }
 
-@[simp] lemma sin_pi_div_sixteen : sin (pi / 16) = sqrt (2 - sqrt (2 + sqrt 2)) / 2 :=
-by { transitivity sin (pi / 2 ^ 4), congr, norm_num, simp }
+@[simp] lemma sin_pi_div_sixteen : sin (π / 16) = sqrt (2 - sqrt (2 + sqrt 2)) / 2 :=
+by { transitivity sin (π / 2 ^ 4), congr, norm_num, simp }
 
-@[simp] lemma cos_pi_div_thirty_two : cos (pi / 32) = sqrt (2 + sqrt (2 + sqrt (2 + sqrt 2))) / 2 :=
-by { transitivity cos (pi / 2 ^ 5), congr, norm_num, simp }
+@[simp] lemma cos_pi_div_thirty_two : cos (π / 32) = sqrt (2 + sqrt (2 + sqrt (2 + sqrt 2))) / 2 :=
+by { transitivity cos (π / 2 ^ 5), congr, norm_num, simp }
 
-@[simp] lemma sin_pi_div_thirty_two : sin (pi / 32) = sqrt (2 - sqrt (2 + sqrt (2 + sqrt 2))) / 2 :=
-by { transitivity sin (pi / 2 ^ 5), congr, norm_num, simp }
+@[simp] lemma sin_pi_div_thirty_two : sin (π / 32) = sqrt (2 - sqrt (2 + sqrt (2 + sqrt 2))) / 2 :=
+by { transitivity sin (π / 2 ^ 5), congr, norm_num, simp }
 
 -- This section is also a convenient location for other explicit values of `sin` and `cos`.
 

--- a/src/data/real/pi.lean
+++ b/src/data/real/pi.lean
@@ -8,16 +8,17 @@ import analysis.special_functions.pow
 # Pi
 
 This file contains lemmas which establish bounds on or approximations of `real.pi`. Notably, these
-include `pi_gt_sqrt_two_add_series` and `pi_lt_sqrt_two_add_series`, which bound `pi` using series;
+include `pi_gt_sqrt_two_add_series` and `pi_lt_sqrt_two_add_series`, which bound `π` using series;
 numerical bounds on `pi` such as `pi_gt_314`and `pi_lt_315` (more precise versions are given, too);
-and `tendsto_sum_pi_div_four`, Leibniz's series for `pi`.
+and `tendsto_sum_pi_div_four`, Leibniz's series for `π`.
 -/
 
+open_locale real
 namespace real
 
-lemma pi_gt_sqrt_two_add_series (n : ℕ) : 2 ^ (n+1) * sqrt (2 - sqrt_two_add_series 0 n) < pi :=
+lemma pi_gt_sqrt_two_add_series (n : ℕ) : 2 ^ (n+1) * sqrt (2 - sqrt_two_add_series 0 n) < π :=
 begin
-  have : sqrt (2 - sqrt_two_add_series 0 n) / 2 * 2 ^ (n+2) < pi,
+  have : sqrt (2 - sqrt_two_add_series 0 n) / 2 * 2 ^ (n+2) < π,
   { rw [← lt_div_iff, ←sin_pi_over_two_pow_succ], apply sin_lt, apply div_pos pi_pos,
     all_goals { apply pow_pos, norm_num } },
   apply lt_of_le_of_lt (le_of_eq _) this,
@@ -25,9 +26,9 @@ begin
 end
 
 lemma pi_lt_sqrt_two_add_series (n : ℕ) :
-  pi < 2 ^ (n+1) * sqrt (2 - sqrt_two_add_series 0 n) + 1 / 4 ^ n :=
+  π < 2 ^ (n+1) * sqrt (2 - sqrt_two_add_series 0 n) + 1 / 4 ^ n :=
 begin
-  have : pi < (sqrt (2 - sqrt_two_add_series 0 n) / 2 + 1 / (2 ^ n) ^ 3 / 4) * 2 ^ (n+2),
+  have : π < (sqrt (2 - sqrt_two_add_series 0 n) / 2 + 1 / (2 ^ n) ^ 3 / 4) * 2 ^ (n+2),
   { rw [← div_lt_iff, ← sin_pi_over_two_pow_succ],
     refine lt_of_lt_of_le (lt_add_of_sub_right_lt (sin_gt_sub_cube _ _)) _,
     { apply div_pos pi_pos, apply pow_pos, norm_num },
@@ -55,10 +56,10 @@ begin
 end
 
 /-- From an upper bound on `sqrt_two_add_series 0 n = 2 cos (pi / 2 ^ (n+1))` of the form
-`sqrt_two_add_series 0 n ≤ 2 - (a / 2 ^ (n + 1)) ^ 2)`, one can deduce the lower bound `a < pi`
+`sqrt_two_add_series 0 n ≤ 2 - (a / 2 ^ (n + 1)) ^ 2)`, one can deduce the lower bound `a < π`
 thanks to basic trigonometric inequalities as expressed in `pi_gt_sqrt_two_add_series`. -/
 theorem pi_lower_bound_start (n : ℕ) {a}
-  (h : sqrt_two_add_series ((0:ℕ) / (1:ℕ)) n ≤ 2 - (a / 2 ^ (n + 1)) ^ 2) : a < pi :=
+  (h : sqrt_two_add_series ((0:ℕ) / (1:ℕ)) n ≤ 2 - (a / 2 ^ (n + 1)) ^ 2) : a < π :=
 begin
   refine lt_of_le_of_lt _ (pi_gt_sqrt_two_add_series n), rw [mul_comm],
   refine (div_le_iff (pow_pos (by norm_num) _ : (0 : ℝ) < _)).mp (le_sqrt_of_sqr_le _),
@@ -77,7 +78,7 @@ begin
   exact_mod_cast h
 end
 
-/-- Create a proof of `a < pi` for a fixed rational number `a`, given a witness, which is a
+/-- Create a proof of `a < π` for a fixed rational number `a`, given a witness, which is a
 sequence of rational numbers `sqrt 2 < r 1 < r 2 < ... < r n < 2` satisfying the property that
 `sqrt (2 + r i) ≤ r(i+1)`, where `r 0 = 0` and `sqrt (2 - r n) ≥ a/2^(n+1)`. -/
 meta def pi_lower_bound (l : list ℚ) : tactic unit :=
@@ -90,12 +91,12 @@ do let n := l.length,
   `[simp only [sqrt_two_add_series, nat.cast_bit0, nat.cast_bit1, nat.cast_one, nat.cast_zero]],
   `[norm_num1]
 
-/-- From a lower bound on `sqrt_two_add_series 0 n = 2 cos (pi / 2 ^ (n+1))` of the form
+/-- From a lower bound on `sqrt_two_add_series 0 n = 2 cos (π / 2 ^ (n+1))` of the form
 `2 - ((a - 1 / 4 ^ n) / 2 ^ (n + 1)) ^ 2 ≤ sqrt_two_add_series 0 n`, one can deduce the upper bound
 `pi < a` thanks to basic trigonometric formulas as expressed in `pi_lt_sqrt_two_add_series`. -/
 theorem pi_upper_bound_start (n : ℕ) {a}
   (h : 2 - ((a - 1 / 4 ^ n) / 2 ^ (n + 1)) ^ 2 ≤ sqrt_two_add_series ((0:ℕ) / (1:ℕ)) n)
-  (h₂ : 1 / 4 ^ n ≤ a) : pi < a :=
+  (h₂ : 1 / 4 ^ n ≤ a) : π < a :=
 begin
   refine lt_of_lt_of_le (pi_lt_sqrt_two_add_series n) _,
   rw [← le_sub_iff_add_le, ← le_div_iff', sqrt_le_left, sub_le],
@@ -116,7 +117,7 @@ begin
   exact_mod_cast h
 end
 
-/-- Create a proof of `pi < a` for a fixed rational number `a`, given a witness, which is a
+/-- Create a proof of `π < a` for a fixed rational number `a`, given a witness, which is a
 sequence of rational numbers `sqrt 2 < r 1 < r 2 < ... < r n < 2` satisfying the property that
 `sqrt (2 + r i) ≥ r(i+1)`, where `r 0 = 0` and `sqrt (2 - r n) ≥ (a - 1/4^n) / 2^(n+1)`. -/
 meta def pi_upper_bound (l : list ℚ) : tactic unit :=
@@ -129,24 +130,24 @@ do let n := l.length,
   `[simp only [sqrt_two_add_series, nat.cast_bit0, nat.cast_bit1, nat.cast_one, nat.cast_zero]],
   `[norm_num]
 
-lemma pi_gt_three : 3 < pi := by pi_lower_bound [23/16]
+lemma pi_gt_three : 3 < π := by pi_lower_bound [23/16]
 
-lemma pi_gt_314 : 3.14 < pi := by pi_lower_bound [99/70, 874/473, 1940/989, 1447/727]
+lemma pi_gt_314 : 3.14 < π := by pi_lower_bound [99/70, 874/473, 1940/989, 1447/727]
 
-lemma pi_lt_315 : pi < 3.15 := by pi_upper_bound [140/99, 279/151, 51/26, 412/207]
+lemma pi_lt_315 : π < 3.15 := by pi_upper_bound [140/99, 279/151, 51/26, 412/207]
 
-lemma pi_gt_31415 : 3.1415 < pi := by pi_lower_bound [
+lemma pi_gt_31415 : 3.1415 < π := by pi_lower_bound [
   11482/8119, 5401/2923, 2348/1197, 11367/5711, 25705/12868, 23235/11621]
 
-lemma pi_lt_31416 : pi < 3.1416 := by pi_upper_bound [
+lemma pi_lt_31416 : π < 3.1416 := by pi_upper_bound [
   4756/3363, 101211/54775, 505534/257719, 83289/41846,
   411278/205887, 438142/219137, 451504/225769, 265603/132804, 849938/424971]
 
-lemma pi_gt_3141592 : 3.141592 < pi := by pi_lower_bound [
+lemma pi_gt_3141592 : 3.141592 < π := by pi_lower_bound [
   11482/8119, 7792/4217, 54055/27557, 949247/476920, 3310126/1657059,
   2635492/1318143, 1580265/790192, 1221775/610899, 3612247/1806132, 849943/424972]
 
-lemma pi_lt_3141593 : pi < 3.141593 := by pi_upper_bound [
+lemma pi_lt_3141593 : π < 3.141593 := by pi_upper_bound [
   27720/19601, 56935/30813, 49359/25163, 258754/130003, 113599/56868, 1101994/551163,
   8671537/4336095, 3877807/1938940, 52483813/26242030, 56946167/28473117, 23798415/11899211]
 
@@ -154,7 +155,7 @@ lemma pi_lt_3141593 : pi < 3.141593 := by pi_upper_bound [
 /-! ### Leibniz's Series for Pi -/
 
 open filter set
-open_locale real classical big_operators topological_space
+open_locale classical big_operators topological_space
 local notation `|`x`|` := abs x
 
 /-- This theorem establishes Leibniz's series for `π`: The alternating sum of the reciprocals of the

--- a/src/data/real/pi.lean
+++ b/src/data/real/pi.lean
@@ -9,7 +9,7 @@ import analysis.special_functions.pow
 
 This file contains lemmas which establish bounds on or approximations of `real.pi`. Notably, these
 include `pi_gt_sqrt_two_add_series` and `pi_lt_sqrt_two_add_series`, which bound `π` using series;
-numerical bounds on `pi` such as `pi_gt_314`and `pi_lt_315` (more precise versions are given, too);
+numerical bounds on `π` such as `pi_gt_314`and `pi_lt_315` (more precise versions are given, too);
 and `tendsto_sum_pi_div_four`, Leibniz's series for `π`.
 -/
 
@@ -55,7 +55,7 @@ begin
   apply pow_ne_zero, norm_num, norm_num
 end
 
-/-- From an upper bound on `sqrt_two_add_series 0 n = 2 cos (pi / 2 ^ (n+1))` of the form
+/-- From an upper bound on `sqrt_two_add_series 0 n = 2 cos (π / 2 ^ (n+1))` of the form
 `sqrt_two_add_series 0 n ≤ 2 - (a / 2 ^ (n + 1)) ^ 2)`, one can deduce the lower bound `a < π`
 thanks to basic trigonometric inequalities as expressed in `pi_gt_sqrt_two_add_series`. -/
 theorem pi_lower_bound_start (n : ℕ) {a}
@@ -93,7 +93,7 @@ do let n := l.length,
 
 /-- From a lower bound on `sqrt_two_add_series 0 n = 2 cos (π / 2 ^ (n+1))` of the form
 `2 - ((a - 1 / 4 ^ n) / 2 ^ (n + 1)) ^ 2 ≤ sqrt_two_add_series 0 n`, one can deduce the upper bound
-`pi < a` thanks to basic trigonometric formulas as expressed in `pi_lt_sqrt_two_add_series`. -/
+`π < a` thanks to basic trigonometric formulas as expressed in `pi_lt_sqrt_two_add_series`. -/
 theorem pi_upper_bound_start (n : ℕ) {a}
   (h : 2 - ((a - 1 / 4 ^ n) / 2 ^ (n + 1)) ^ 2 ≤ sqrt_two_add_series ((0:ℕ) / (1:ℕ)) n)
   (h₂ : 1 / 4 ^ n ≤ a) : π < a :=


### PR DESCRIPTION
Currently, `real.pi` is not protected. This can conflict with `set.pi`. Since it is most often used as `π` through the `real` locale, let's protect it.