### PR TITLE
[Merged by Bors] - feat(algebra/ordered_ring): proof that `a + b ≤ a * b`

### DIFF
--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -351,6 +351,9 @@ begin
     exact add_le_mul₂ b2 hab.le }
 end
 
+lemma add_le_mul' (a2 : 2 ≤ a) (b2 : 2 ≤ b) : a + b ≤ b * a :=
+(le_of_eq (add_comm _ _)).trans (add_le_mul b2 a2)
+
 section
 variables [nontrivial α]
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -344,11 +344,8 @@ calc a + b ≤ a + a : add_le_add_left ba a
        ... ≤ a * b : (mul_le_mul_left this).mpr b2
 
 lemma add_le_mul (a2 : 2 ≤ a) (b2 : 2 ≤ b) : a + b ≤ a * b :=
-begin
-  by_cases hab : a ≤ b,
-  { exact add_le_mul_of_left_le_right a2 hab },
-  { exact add_le_mul_of_right_le_left b2 (le_of_not_le hab) }
-end
+if hab : a ≤ b then add_le_mul_of_left_le_right a2 hab
+               else add_le_mul_of_right_le_left b2 (le_of_not_le hab)
 
 section
 variables [nontrivial α]

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -325,6 +325,32 @@ by { convert mul_lt_mul_left h, simp }
 @[simp] lemma zero_lt_mul_right (h : 0 < c) : 0 < b * c ↔ 0 < b :=
 by { convert mul_lt_mul_right h, simp }
 
+lemma add_le_mul₁ (a2 : 2 ≤ a) (ab : a ≤ b) : a + b ≤ a * b :=
+have 0 < b, from
+calc 0 < 2 : zero_lt_two
+   ... ≤ a : a2
+   ... ≤ b : ab,
+calc a + b ≤ b + b : add_le_add_right ab b
+       ... = 2 * b : (two_mul b).symm
+       ... ≤ a * b : (mul_le_mul_right this).mpr a2
+
+lemma add_le_mul₂ (b2 : 2 ≤ b) (ba : b ≤ a) : a + b ≤ a * b :=
+have 0 < a, from
+calc 0 < 2 : zero_lt_two
+   ... ≤ b : b2
+   ... ≤ a : ba,
+calc a + b ≤ a + a : add_le_add_left ba a
+       ... = a * 2 : (mul_two a).symm
+       ... ≤ a * b : (mul_le_mul_left this).mpr b2
+
+lemma add_le_mul (a2 : 2 ≤ a) (b2 : 2 ≤ b) : a + b ≤ a * b :=
+begin
+  by_cases hab : a ≤ b,
+  { exact add_le_mul₁ a2 hab },
+  { push_neg at hab,
+    exact add_le_mul₂ b2 hab.le }
+end
+
 section
 variables [nontrivial α]
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -325,7 +325,7 @@ by { convert mul_lt_mul_left h, simp }
 @[simp] lemma zero_lt_mul_right (h : 0 < c) : 0 < b * c ↔ 0 < b :=
 by { convert mul_lt_mul_right h, simp }
 
-lemma add_le_mul₁ (a2 : 2 ≤ a) (ab : a ≤ b) : a + b ≤ a * b :=
+lemma add_le_mul_of_left_le_right (a2 : 2 ≤ a) (ab : a ≤ b) : a + b ≤ a * b :=
 have 0 < b, from
 calc 0 < 2 : zero_lt_two
    ... ≤ a : a2
@@ -334,7 +334,7 @@ calc a + b ≤ b + b : add_le_add_right ab b
        ... = 2 * b : (two_mul b).symm
        ... ≤ a * b : (mul_le_mul_right this).mpr a2
 
-lemma add_le_mul₂ (b2 : 2 ≤ b) (ba : b ≤ a) : a + b ≤ a * b :=
+lemma add_le_mul_of_right_le_left (b2 : 2 ≤ b) (ba : b ≤ a) : a + b ≤ a * b :=
 have 0 < a, from
 calc 0 < 2 : zero_lt_two
    ... ≤ b : b2
@@ -346,9 +346,8 @@ calc a + b ≤ a + a : add_le_add_left ba a
 lemma add_le_mul (a2 : 2 ≤ a) (b2 : 2 ≤ b) : a + b ≤ a * b :=
 begin
   by_cases hab : a ≤ b,
-  { exact add_le_mul₁ a2 hab },
-  { push_neg at hab,
-    exact add_le_mul₂ b2 hab.le }
+  { exact add_le_mul_of_left_le_right a2 hab },
+  { exact add_le_mul_of_right_le_left b2 (le_of_not_le hab) }
 end
 
 section


### PR DESCRIPTION
This is Johan's proof of the fact above.  If you are curious about the assumptions, there is an extensive discussion on

https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/canonically_ordered.20pathology

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
