### PR TITLE
[Merged by Bors] - fix(scripts): make lint-style.* work on macos and windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,27 @@ on:
       - 'lean-3.*'
 
 jobs:
+  lint_self_test:
+    name: Ensure the linter works
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version:
+          - name: 3.8
+          - name: 3.9
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version.name }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version.name }}
+
+      - name: sanity check the linter
+        run: |
+          ./scripts/lint_style_sanity_test.py
+
   style_lint:
     name: Lint style
     runs-on: ubuntu-latest
@@ -22,10 +43,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-
-      - name: sanity check the linter
-        run: |
-          ./scripts/lint_style_sanity_test.py
 
       - name: lint
         run: |

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -46,7 +46,7 @@ ROOT_DIR = SCRIPTS_DIR.parent
 RESERVED_NOTATION = ROOT_DIR / 'src/tactic/reserved_notation.lean'
 
 
-with SCRIPTS_DIR.joinpath("style-exceptions.txt").open() as f:
+with SCRIPTS_DIR.joinpath("style-exceptions.txt").open(encoding="utf-8") as f:
     for line in f:
         filename, _, _, _, _, errno, *_ = line.split()
         path = ROOT_DIR / filename
@@ -227,7 +227,7 @@ def format_errors(errors):
             output_message(path, line_nr, "ERR_OPT", "Forbidden set_option command")
 
 def lint(path):
-    with path.open() as f:
+    with path.open(encoding="utf-8") as f:
         lines = f.readlines()
         errs = long_lines_check(lines, path)
         format_errors(errs)

--- a/scripts/lint-style.sh
+++ b/scripts/lint-style.sh
@@ -41,7 +41,7 @@ find src archive -name '*.lean' | xargs ./scripts/lint-style.py
 
 # 2.1 Check for executable bit on Lean files
 
-executable_files="$(find . -name '*.lean' -type f -executable)"
+executable_files="$(find . -name '*.lean' -type f \( -perm -u=x -o -perm -g=x -o -perm -o=x \))"
 
 if [[ -n "$executable_files" ]]
 then

--- a/scripts/lint_style_sanity_test.py
+++ b/scripts/lint_style_sanity_test.py
@@ -130,7 +130,7 @@ class TestLinterIntegration(unittest.TestCase):
         self.assertNotIn(str(ROOT_DIR), current_contents)
         self.addCleanup(exceptions.write_text, current_contents)
 
-        result = subprocess.run(
+        subprocess.run(
             ["./scripts/update-style-exceptions.sh"],
             check=True,
             capture_output=True,
@@ -140,6 +140,17 @@ class TestLinterIntegration(unittest.TestCase):
             str(ROOT_DIR),
             SCRIPTS_DIR.joinpath("style-exceptions.txt").read_text(),
         )
+
+    def test_running_the_shell_script_does_not_error(self):
+        """
+        Normally, users will run scripts/lint-style.sh, which will run the
+        linter on all files within mathlib.
+
+        Running it exits with successful return code.
+        """
+
+        subprocess.run(["./scripts/lint-style.sh"], check=True, cwd=ROOT_DIR)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/lint_style_sanity_test.py
+++ b/scripts/lint_style_sanity_test.py
@@ -147,10 +147,21 @@ class TestLinterIntegration(unittest.TestCase):
         linter on all files within mathlib.
 
         Running it exits with successful return code.
+
+        This test will not run if there are current style warnings.
         """
+
+        src = list(ROOT_DIR.glob("src/**/*.lean"))
+        archive = list(ROOT_DIR.glob("archive/**/*.lean"))
+        if subprocess.run(
+            ["./scripts/lint-style.py"] + src + archive,
+            stdout=subprocess.DEVNULL,
+            cwd=ROOT_DIR,
+        ).returncode:
+            self.skipTest("Skipping... there are unfixed style warnings.")
 
         subprocess.run(["./scripts/lint-style.sh"], check=True, cwd=ROOT_DIR)
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Make lint-style.sh use a POSIX-portable way of checking for executable bits, and make it always open files as UTF-8.

Also makes CI run the sanity checks across all 3 OSes to ensure this stays working.
