### PR TITLE
[Merged by Bors] - fix(ring_theory/power_series/basic): fix algebra arguments

### DIFF
--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -798,7 +798,8 @@ instance {A S} [semiring R] [semiring S] [add_comm_monoid A] [semimodule R A] [s
   is_scalar_tower R S (power_series A) :=
 pi.is_scalar_tower
 
-instance [comm_ring R]       : algebra R       (power_series R) := by apply_instance
+instance {A} [semiring A] [comm_semiring R] [algebra R A] :
+  algebra R (power_series A) := by apply_instance
 
 end
 


### PR DESCRIPTION
`power_series` is just an alias for `mv_power_series` over `unit`, yet it did not correctly inherit the algebra instance


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
