### PR TITLE
[Merged by Bors] - feat(topology/category): constructor for compact hausdorff spaces

### DIFF
--- a/src/topology/category/CompHaus.lean
+++ b/src/topology/category/CompHaus.lean
@@ -48,6 +48,18 @@ instance category : category CompHaus := induced_category.category to_Top
 lemma coe_to_Top {X : CompHaus} : (X.to_Top : Type*) = X :=
 rfl
 
+variables (X : Type*) [topological_space X] [compact_space X] [t2_space X]
+
+/-- A constructor for objects of the category `CompHaus`,
+taking a type, and bundling the compact Hausdorff topology
+found by typeclass inference. -/
+def of : CompHaus :=
+{ to_Top := Top.of X,
+  is_compact := ‹_›,
+  is_hausdorff := ‹_› }
+
+@[simp] lemma coe_of : (CompHaus.of X : Type _) = X := rfl
+
 end CompHaus
 
 /-- The fully faithful embedding of `CompHaus` in `Top`. -/
@@ -59,10 +71,7 @@ def CompHaus_to_Top : CompHaus ⥤ Top := induced_functor _
 compact Hausdorff spaces.
 -/
 @[simps]
-def StoneCech_obj (X : Top) : CompHaus :=
-{ to_Top := { α := stone_cech X },
-  is_compact := stone_cech.compact_space,
-  is_hausdorff := @stone_cech.t2_space X _ }
+def StoneCech_obj (X : Top) : CompHaus := CompHaus.of (stone_cech X)
 
 /--
 (Implementation) The bijection of homsets to establish the reflective adjunction of compact


### PR DESCRIPTION
`CompHaus.of` constructor. From the lean-liquid project.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
