### PR TITLE
[Merged by Bors] - perf(ring_theory/{noetherian,ideal/basic}): Simplify proofs of Krull's theorem and related theorems

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1026,6 +1026,12 @@ begin
   exact ⟨y, ⟨hyd, by simpa only [span_le, singleton_subset_iff]⟩⟩,
 end
 
+instance : is_compactly_generated (submodule R M) :=
+⟨λ s, ⟨(λ x, span R {x}) '' s, ⟨λ t ht, begin
+  rcases (set.mem_image _ _ _).1 ht with ⟨x, hx, rfl⟩,
+  apply singleton_span_is_compact_element,
+end, by rw [Sup_eq_supr, supr_image, ←span_eq_supr_of_singleton_spans, span_eq]⟩⟩⟩
+
 lemma lt_add_iff_not_mem {I : submodule R M} {a : M} : I < I + (R ∙ a) ↔ a ∉ I :=
 begin
   split,

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -11,6 +11,7 @@ import algebra.group.prod
 import data.finsupp.basic
 import data.dfinsupp
 import algebra.pointwise
+import order.compactly_generated
 
 /-!
 # Linear algebra
@@ -1014,6 +1015,16 @@ le_antisymm
 
 lemma span_singleton_le_iff_mem (m : M) (p : submodule R M) : (R ∙ m) ≤ p ↔ m ∈ p :=
 by rw [span_le, singleton_subset_iff, mem_coe]
+
+lemma singleton_span_is_compact_element (x : M) :
+  complete_lattice.is_compact_element (span R {x} : submodule R M) :=
+begin
+  rw complete_lattice.is_compact_element_iff_le_of_directed_Sup_le,
+  intros d hemp hdir hsup,
+  have : x ∈ Sup d, from (le_def.mp hsup) (mem_span_singleton_self x),
+  obtain ⟨y, ⟨hyd, hxy⟩⟩ := (mem_Sup_of_directed hemp hdir).mp this,
+  exact ⟨y, ⟨hyd, by simpa only [span_le, singleton_subset_iff]⟩⟩,
+end
 
 lemma lt_add_iff_not_mem {I : submodule R M} {a : M} : I < I + (R ∙ a) ↔ a ∉ I :=
 begin

--- a/src/order/atoms.lean
+++ b/src/order/atoms.lean
@@ -442,6 +442,27 @@ by rw [is_simple_lattice_iff_is_atom_top, is_simple_lattice_iff_is_atom_top,
 lemma is_simple_lattice [h : is_simple_lattice β] (f : α ≃o β) : is_simple_lattice α :=
 f.is_simple_lattice_iff.mpr h
 
+lemma is_atomic_iff : is_atomic α ↔ is_atomic β :=
+begin
+  suffices : ∀ (b : α),
+    (b = ⊥ ∨ ∃ (a : α), is_atom a ∧ a ≤ b) ↔ ((f b) = ⊥ ∨ ∃ (a : β), is_atom a ∧ a ≤ (f b)),
+  { split; rintro ⟨h⟩; refine ⟨λ b, _⟩,
+    { rw ←(@apply_symm_apply _ _ _ _ f b), exact (this $ f.symm b).mp (h $ f.symm b), },
+    { exact (this $ b).mpr (h $ f b), }, },
+  intro b, apply or_congr,
+  { split,
+    rintro ⟨rfl⟩, exact map_bot f,
+    intro h, rwa [f.apply_eq_iff_eq_symm_apply, map_bot] at h, },
+  { split,
+    exact λ ⟨a, ha⟩, ⟨f a, ⟨(f.is_atom_iff a).mpr ha.1, f.le_iff_le.mpr ha.2⟩⟩,
+    rintros ⟨b, hb⟩, refine ⟨f.symm b, ⟨(f.symm.is_atom_iff b).mpr hb.1, _⟩⟩,
+    { rw [←f.le_iff_le, f.apply_symm_apply], exact hb.2, } },
+end
+
+lemma is_coatomic_iff : is_coatomic α ↔ is_coatomic β :=
+by { rw [←is_atomic_dual_iff_is_coatomic, ←is_atomic_dual_iff_is_coatomic],
+  exact f.dual.is_atomic_iff, }
+
 end order_iso
 
 section is_modular_lattice

--- a/src/order/atoms.lean
+++ b/src/order/atoms.lean
@@ -444,19 +444,18 @@ f.is_simple_lattice_iff.mpr h
 
 lemma is_atomic_iff : is_atomic α ↔ is_atomic β :=
 begin
-  suffices : ∀ (b : α),
-    (b = ⊥ ∨ ∃ (a : α), is_atom a ∧ a ≤ b) ↔ ((f b) = ⊥ ∨ ∃ (a : β), is_atom a ∧ a ≤ (f b)),
-  { split; rintro ⟨h⟩; refine ⟨λ b, _⟩,
-    { rw ←(@apply_symm_apply _ _ _ _ f b), exact (this $ f.symm b).mp (h $ f.symm b), },
-    { exact (this $ b).mpr (h $ f b), }, },
+  suffices : (∀ b : α, b = ⊥ ∨ ∃ (a : α), is_atom a ∧ a ≤ b) ↔
+    (∀ b : β, b = ⊥ ∨ ∃ (a : β), is_atom a ∧ a ≤ b),
+  from ⟨λ ⟨p⟩, ⟨this.mp p⟩, λ ⟨p⟩, ⟨this.mpr p⟩⟩,
+  apply f.to_equiv.forall_congr,
+  simp_rw [rel_iso.coe_fn_to_equiv],
   intro b, apply or_congr,
+  { rw [f.apply_eq_iff_eq_symm_apply, map_bot], },
   { split,
-    rintro ⟨rfl⟩, exact map_bot f,
-    intro h, rwa [f.apply_eq_iff_eq_symm_apply, map_bot] at h, },
-  { split,
-    exact λ ⟨a, ha⟩, ⟨f a, ⟨(f.is_atom_iff a).mpr ha.1, f.le_iff_le.mpr ha.2⟩⟩,
-    rintros ⟨b, hb⟩, refine ⟨f.symm b, ⟨(f.symm.is_atom_iff b).mpr hb.1, _⟩⟩,
-    { rw [←f.le_iff_le, f.apply_symm_apply], exact hb.2, } },
+    { exact λ ⟨a, ha⟩, ⟨f a, ⟨(f.is_atom_iff a).mpr ha.1, f.le_iff_le.mpr ha.2⟩⟩, },
+    { rintros ⟨b, ⟨hb1, hb2⟩⟩,
+      refine ⟨f.symm b, ⟨(f.symm.is_atom_iff b).mpr hb1, _⟩⟩,
+      rwa [←f.le_iff_le, f.apply_symm_apply], }, },
 end
 
 lemma is_coatomic_iff : is_coatomic α ↔ is_coatomic β :=

--- a/src/order/compactly_generated.lean
+++ b/src/order/compactly_generated.lean
@@ -334,14 +334,6 @@ theorem Iic_coatomic_of_compact_element {k : α} (h : is_compact_element k) :
 end⟩
 
 lemma coatomic_of_top_compact (h : is_compact_element (⊤ : α)) : is_coatomic α :=
-⟨λ b, begin
-  obtain ⟨prop⟩ := Iic_coatomic_of_compact_element h,
-  by_cases hb : b = ⊤, exact or.inl hb, right,
-  obtain ⟨⟨a, _⟩, ⟨⟨ha1, ha2⟩, ha3⟩⟩ :=
-    (prop ⟨b, le_top b⟩).resolve_left (λ n, by { injection n with n, exact hb n }),
-  replace ha1 := lt_of_le_of_ne _root_.le_top ha1, rw [←subtype.coe_lt_coe] at ha1,
-  refine ⟨a, ⟨⟨ne_of_lt ha1, _⟩, ha3⟩⟩,
-  intros c hc, specialize ha2 ⟨c, le_top c⟩ hc, injection ha2,
-end⟩
+(@order_iso.Iic_top α _).is_coatomic_iff.mp (Iic_coatomic_of_compact_element h)
 
 end complete_lattice

--- a/src/order/compactly_generated.lean
+++ b/src/order/compactly_generated.lean
@@ -333,4 +333,15 @@ theorem Iic_coatomic_of_compact_element {k : α} (h : is_compact_element k) :
       set.mem_empty_eq, forall_const, forall_prop_of_false, not_false_iff]⟩, },
 end⟩
 
+lemma coatomic_of_top_compact (h : is_compact_element (⊤ : α)) : is_coatomic α :=
+⟨λ b, begin
+  obtain ⟨prop⟩ := Iic_coatomic_of_compact_element h,
+  by_cases hb : b = ⊤, exact or.inl hb, right,
+  obtain ⟨⟨a, _⟩, ⟨⟨ha1, ha2⟩, ha3⟩⟩ :=
+    (prop ⟨b, le_top b⟩).resolve_left (λ n, by { injection n with n, exact hb n }),
+  replace ha1 := lt_of_le_of_ne _root_.le_top ha1, rw [←subtype.coe_lt_coe] at ha1,
+  refine ⟨a, ⟨⟨ne_of_lt ha1, _⟩, ha3⟩⟩,
+  intros c hc, specialize ha2 ⟨c, le_top c⟩ hc, injection ha2,
+end⟩
+
 end complete_lattice

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -520,6 +520,9 @@ e.to_equiv.apply_symm_apply x
 @[simp] lemma symm_apply_apply (e : α ≃o β) (x : α) : e.symm (e x) = x :=
 e.to_equiv.symm_apply_apply x
 
+lemma apply_eq_iff_eq_symm_apply (e : α ≃o β) (x : α) (y : β) : e x = y ↔ x = e.symm y :=
+e.to_equiv.apply_eq_iff_eq_symm_apply
+
 theorem symm_apply_eq (e : α ≃o β) {x : α} {y : β} : e.symm y = x ↔ y = e x :=
 e.to_equiv.symm_apply_eq
 
@@ -690,5 +693,13 @@ lemma order_iso.map_sup [semilattice_sup α] [semilattice_sup β]
   (f : α ≃o β) (x y : α) :
   f (x ⊔ y) = f x ⊔ f y :=
 f.dual.map_inf x y
+
+lemma order_iso.Iic_top [order_top α] : set.Iic (⊤ : α) ≃o α :=
+{ map_rel_iff' := λ x y, by refl,
+  .. (@equiv.subtype_univ_equiv α (set.Iic (⊤ : α)) (λ x, le_top)), }
+
+lemma order_iso.Ici_bot [order_bot α] : set.Ici (⊥ : α) ≃o α :=
+{ map_rel_iff' := λ x y, by refl,
+  .. (@equiv.subtype_univ_equiv α (set.Ici (⊥ : α)) (λ x, bot_le)) }
 
 end lattice_isos

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -694,12 +694,12 @@ lemma order_iso.map_sup [semilattice_sup α] [semilattice_sup β]
   f (x ⊔ y) = f x ⊔ f y :=
 f.dual.map_inf x y
 
-/-- Order isomorphism between Iic (⊤ : α) and α when α has a top element -/
+/-- Order isomorphism between `Iic (⊤ : α)` and `α` when `α` has a top element -/
 def order_iso.Iic_top [order_top α] : set.Iic (⊤ : α) ≃o α :=
 { map_rel_iff' := λ x y, by refl,
   .. (@equiv.subtype_univ_equiv α (set.Iic (⊤ : α)) (λ x, le_top)), }
 
-/-- Order isomorphism between Ici (⊥ : α) and α when α has a bottom element -/
+/-- Order isomorphism between `Ici (⊥ : α)` and `α` when `α` has a bottom element -/
 def order_iso.Ici_bot [order_bot α] : set.Ici (⊥ : α) ≃o α :=
 { map_rel_iff' := λ x y, by refl,
   .. (@equiv.subtype_univ_equiv α (set.Ici (⊥ : α)) (λ x, bot_le)) }

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -694,11 +694,11 @@ lemma order_iso.map_sup [semilattice_sup α] [semilattice_sup β]
   f (x ⊔ y) = f x ⊔ f y :=
 f.dual.map_inf x y
 
-lemma order_iso.Iic_top [order_top α] : set.Iic (⊤ : α) ≃o α :=
+def order_iso.Iic_top [order_top α] : set.Iic (⊤ : α) ≃o α :=
 { map_rel_iff' := λ x y, by refl,
   .. (@equiv.subtype_univ_equiv α (set.Iic (⊤ : α)) (λ x, le_top)), }
 
-lemma order_iso.Ici_bot [order_bot α] : set.Ici (⊥ : α) ≃o α :=
+def order_iso.Ici_bot [order_bot α] : set.Ici (⊥ : α) ≃o α :=
 { map_rel_iff' := λ x y, by refl,
   .. (@equiv.subtype_univ_equiv α (set.Ici (⊥ : α)) (λ x, bot_le)) }
 

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -694,10 +694,12 @@ lemma order_iso.map_sup [semilattice_sup α] [semilattice_sup β]
   f (x ⊔ y) = f x ⊔ f y :=
 f.dual.map_inf x y
 
+/-- Order isomorphism between Iic (⊤ : α) and α when α has a top element -/
 def order_iso.Iic_top [order_top α] : set.Iic (⊤ : α) ≃o α :=
 { map_rel_iff' := λ x y, by refl,
   .. (@equiv.subtype_univ_equiv α (set.Iic (⊤ : α)) (λ x, le_top)), }
 
+/-- Order isomorphism between Ici (⊥ : α) and α when α has a bottom element -/
 def order_iso.Ici_bot [order_bot α] : set.Ici (⊥ : α) ≃o α :=
 { map_rel_iff' := λ x y, by refl,
   .. (@equiv.subtype_univ_equiv α (set.Ici (⊥ : α)) (λ x, bot_le)) }

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -248,10 +248,7 @@ end
     maximal ideal. -/
 theorem exists_le_maximal (I : ideal α) (hI : I ≠ ⊤) :
   ∃ M : ideal α, M.is_maximal ∧ I ≤ M :=
-begin
-  obtain ⟨a, ⟨ha1, ha2⟩⟩ := (eq_top_or_exists_le_coatom I).resolve_left hI,
-  exact ⟨a, ⟨⟨ha1⟩, ha2⟩⟩,
-end
+let ⟨m, hm⟩ := (eq_top_or_exists_le_coatom I).resolve_left hI in ⟨m, ⟨⟨hm.1⟩, hm.2⟩⟩
 
 /-- Krull's theorem: a nontrivial ring has a maximal ideal. -/
 theorem exists_maximal [nontrivial α] : ∃ M : ideal α, M.is_maximal :=

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -7,6 +7,7 @@ import algebra.associated
 import linear_algebra.basic
 import order.zorn
 import order.atoms
+import order.compactly_generated
 /-!
 
 # Ideals over a ring
@@ -237,19 +238,19 @@ end⟩
 instance is_maximal.is_prime' (I : ideal α) : ∀ [H : I.is_maximal], I.is_prime :=
 is_maximal.is_prime
 
+instance coatomic_lattice : is_coatomic (ideal α) :=
+begin
+  apply complete_lattice.coatomic_of_top_compact,
+  rw ←span_singleton_one, exact submodule.singleton_span_is_compact_element 1,
+end
+
 /-- Krull's theorem: if `I` is an ideal that is not the whole ring, then it is included in some
     maximal ideal. -/
 theorem exists_le_maximal (I : ideal α) (hI : I ≠ ⊤) :
   ∃ M : ideal α, M.is_maximal ∧ I ≤ M :=
 begin
-  rcases zorn.zorn_partial_order₀ { J : ideal α | J ≠ ⊤ } _ I hI with ⟨M, M0, IM, h⟩,
-  { refine ⟨M, ⟨⟨M0, λ J hJ, by_contradiction $ λ J0, _⟩⟩, IM⟩,
-    cases h J J0 (le_of_lt hJ), exact lt_irrefl _ hJ },
-  { intros S SC cC I IS,
-    refine ⟨Sup S, λ H, _, λ _, le_Sup⟩,
-    obtain ⟨J, JS, J0⟩ : ∃ J ∈ S, (1 : α) ∈ J,
-      from (submodule.mem_Sup_of_directed ⟨I, IS⟩ cC.directed_on).1 ((eq_top_iff_one _).1 H),
-    exact SC JS ((eq_top_iff_one _).2 J0) }
+  obtain ⟨a, ⟨ha1, ha2⟩⟩ := (eq_top_or_exists_le_coatom I).resolve_left hI,
+  exact ⟨a, ⟨⟨ha1⟩, ha2⟩⟩,
 end
 
 /-- Krull's theorem: a nontrivial ring has a maximal ideal. -/

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -238,10 +238,11 @@ end⟩
 instance is_maximal.is_prime' (I : ideal α) : ∀ [H : I.is_maximal], I.is_prime :=
 is_maximal.is_prime
 
-instance coatomic_lattice : is_coatomic (ideal α) :=
+instance : is_coatomic (ideal α) :=
 begin
   apply complete_lattice.coatomic_of_top_compact,
-  rw ←span_singleton_one, exact submodule.singleton_span_is_compact_element 1,
+  rw ←span_singleton_one,
+  exact submodule.singleton_span_is_compact_element 1,
 end
 
 /-- Krull's theorem: if `I` is an ideal that is not the whole ring, then it is included in some

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -228,12 +228,6 @@ begin
     exact ⟨t, ssup⟩, },
 end
 
-instance : is_compactly_generated (submodule R M) :=
-⟨λ s, ⟨(λ x, span R {x}) '' s, ⟨λ t ht, begin
-  rcases (set.mem_image _ _ _).1 ht with ⟨x, hx, rfl⟩,
-  apply singleton_span_is_compact_element,
-end, by rw [Sup_eq_supr, supr_image, ←span_eq_supr_of_singleton_spans, span_eq]⟩⟩⟩
-
 end submodule
 
 /--

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -200,7 +200,7 @@ begin
     { exact zero_smul _ }, { exact λ _ _ _, add_smul _ _ _ } }
 end
 
-/-- Finitely generated submodules are precisely compact elements in the submodule lattice -/
+/-- Finitely generated submodules are precisely compact elements in the submodule lattice. -/
 theorem fg_iff_compact (s : submodule R M) : s.fg ↔ complete_lattice.is_compact_element s :=
 begin
   classical,

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -361,53 +361,10 @@ open is_noetherian submodule function
 theorem is_noetherian_iff_well_founded
   {R M} [ring R] [add_comm_group M] [module R M] :
   is_noetherian R M ↔ well_founded ((>) : submodule R M → submodule R M → Prop) :=
-⟨λ h, begin
-  refine rel_embedding.well_founded_iff_no_descending_seq.2 _,
-  rintro ⟨⟨N, hN⟩⟩,
-  let Q := ⨆ n, N n,
-  resetI,
-  rcases submodule.fg_def.1 (noetherian Q) with ⟨t, h₁, h₂⟩,
-  have hN' : ∀ {a b}, a ≤ b → N a ≤ N b :=
-    λ a b, (strict_mono.le_iff_le (λ _ _, hN.2)).2,
-  have : t ⊆ ⋃ i, (N i : set M),
-  { rw [← submodule.coe_supr_of_directed N _],
-    { show t ⊆ Q, rw ← h₂,
-      apply submodule.subset_span },
-    { exact λ i j, ⟨max i j,
-        hN' (le_max_left _ _),
-        hN' (le_max_right _ _)⟩ } },
-  simp [subset_def] at this,
-  choose f hf using show ∀ x : t, ∃ (i : ℕ), x.1 ∈ N i, { simpa },
-  cases h₁ with h₁,
-  let A := finset.sup (@finset.univ t h₁) f,
-  have : Q ≤ N A,
-  { rw ← h₂, apply submodule.span_le.2,
-    exact λ x h, hN' (finset.le_sup (@finset.mem_univ t h₁ _))
-      (hf ⟨x, h⟩) },
-  exact not_le_of_lt (hN.2 (nat.lt_succ_self A))
-    (le_trans (le_supr _ _) this)
-  end,
-  begin
-    assume h, split, assume N,
-    suffices : ∀ P ≤ N, ∃ s, finite s ∧ P ⊔ submodule.span R s = N,
-    { rcases this ⊥ bot_le with ⟨s, hs, e⟩,
-      exact submodule.fg_def.2 ⟨s, hs, by simpa using e⟩ },
-    refine λ P, h.induction P _, intros P IH PN,
-    letI := classical.dec,
-    by_cases h : ∀ x, x ∈ N → x ∈ P,
-    { cases le_antisymm PN h, exact ⟨∅, by simp⟩ },
-    { simp [not_forall] at h,
-      rcases h with ⟨x, h, h₂⟩,
-      have : ¬P ⊔ submodule.span R {x} ≤ P,
-      { intro hn, apply h₂,
-        have := le_trans le_sup_right hn,
-        exact submodule.span_le.1 this (mem_singleton x) },
-      rcases IH (P ⊔ submodule.span R {x})
-        ⟨@le_sup_left _ _ P _, this⟩
-        (sup_le PN (submodule.span_le.2 (by simpa))) with ⟨s, hs, hs₂⟩,
-      refine ⟨insert x s, hs.insert x, _⟩,
-      rw [← hs₂, sup_assoc, ← submodule.span_union], simp }
-  end⟩
+begin
+  rw (complete_lattice.well_founded_characterisations $ submodule R M).out 0 3,
+  exact ⟨λ ⟨h⟩, λ k, (fg_iff_compact k).mp (h k), λ h, ⟨λ k, (fg_iff_compact k).mpr (h k)⟩⟩,
+end
 
 lemma well_founded_submodule_gt (R M) [ring R] [add_comm_group M] [module R M] :
   ∀ [is_noetherian R M], well_founded ((>) : submodule R M → submodule R M → Prop) :=

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -200,16 +200,6 @@ begin
     { exact zero_smul _ }, { exact λ _ _ _, add_smul _ _ _ } }
 end
 
-lemma singleton_span_is_compact_element (x : M) :
-  complete_lattice.is_compact_element (span R {x} : submodule R M) :=
-begin
-  rw complete_lattice.is_compact_element_iff_le_of_directed_Sup_le,
-  intros d hemp hdir hsup,
-  have : x ∈ Sup d, from (le_def.mp hsup) (mem_span_singleton_self x),
-  obtain ⟨y, ⟨hyd, hxy⟩⟩ := (mem_Sup_of_directed hemp hdir).mp this,
-  exact ⟨y, ⟨hyd, by simpa only [span_le, singleton_subset_iff]⟩⟩,
-end
-
 /-- Finitely generated submodules are precisely compact elements in the submodule lattice -/
 theorem fg_iff_compact (s : submodule R M) : s.fg ↔ complete_lattice.is_compact_element s :=
 begin


### PR DESCRIPTION
Move `submodule.singleton_span_is_compact_element` and `submodule.is_compactly_generated` to more appropriate locations. Add trivial order isomorphisms and order-iso lemmas. Show that `is_atomic` and `is_coatomic` are respected by order isomorphisms. Greatly simplify `is_noetherian_iff_well_founded`. Provide an `is_coatomic` instance on the ideal lattice of a ring and simplify `ideal.exists_le_maximal`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
