### PR TITLE
[Merged by Bors] - feat(apply_fun): handle implicit arguments

### DIFF
--- a/src/tactic/monotonicity/lemmas.lean
+++ b/src/tactic/monotonicity/lemmas.lean
@@ -71,7 +71,7 @@ open set
 attribute [mono] inter_subset_inter union_subset_union
                  sUnion_mono bUnion_mono sInter_subset_sInter bInter_mono
                  image_subset preimage_mono prod_mono monotone_prod seq_mono
-                 image2_subset
+                 image2_subset order_embedding.monotone
 attribute [mono] upper_bounds_mono_set lower_bounds_mono_set
                  upper_bounds_mono_mem  lower_bounds_mono_mem
                  upper_bounds_mono  lower_bounds_mono

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -47,3 +47,10 @@ begin
   guard_hyp' h : f (A * B) = f 0,
   exact h,
 end
+
+-- Verify that `apply_fun` works with `fin.cast_succ`, even though it has an implicit argument.
+example (n : ℕ) (a b : fin n) (H : a ≤ b) : a.cast_succ ≤ b.cast_succ :=
+begin
+  apply_fun fin.cast_succ at H,
+  exact H,
+end


### PR DESCRIPTION
I've modified the way `apply_fun` handles inequalities, by building an intermediate expression before calling `mono` to discharge the `monotone f` subgoal. This has the effect of sometimes filling in implicit arguments successfully, so that `mono` works.

In `tests/apply_fun.lean` I've added an example showing this in action 
