### PR TITLE
[Merged by Bors] - feat(topology/instances/{nnreal,ennreal}): add tendsto_cofinite_zero_of_summable

### DIFF
--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -600,28 +600,6 @@ end
 
 end subtype
 
-lemma tendsto_zero_at_top_of_summable {α} [add_comm_group α] [topological_space α] [t2_space α]
-  [tag : topological_add_group α] {f : ℕ → α} (hf : summable f) :
-  filter.at_top.tendsto f (𝓝 0) :=
-begin
-  have f_diff_sum : f
-    = (λ n, ∑ i in finset.range (n+1), f i) - (λ n, ∑ i in finset.range n, f i),
-  from funext (λ n, by simp [finset.sum_range_succ]),
-  rw [f_diff_sum, ←sub_self (tsum f)],
-  refine filter.tendsto.sub _ _,
-  swap, { exact (summable.has_sum_iff_tendsto_nat hf).mp hf.has_sum, },
-  have h_sum_offset : (λ n, ∑ i in finset.range (n+1), f i)
-    = λ n, f 0 + (∑ i in finset.range n, f (i+1)),
-  { ext1 n, nth_rewrite 1 add_comm, exact finset.sum_range_succ' f n, },
-  have h_tsum_add_sub : tsum f = f 0 + (tsum f - f 0), by abel,
-  rw [h_sum_offset, h_tsum_add_sub],
-  refine filter.tendsto.add tendsto_const_nhds _,
-  rw ←summable.has_sum_iff_tendsto_nat,
-  { rw @has_sum_nat_add_iff _ _ _ tag _ 1,
-    simp [hf.has_sum], },
-  { rwa @summable_nat_add_iff _ _ _ tag _ 1, },
-end
-
 end topological_group
 
 section topological_semiring
@@ -963,6 +941,9 @@ begin
   refine s.eventually_cofinite_nmem.mono (λ x hx, _),
   by simpa using hs {x} (singleton_disjoint.2 hx)
 end
+
+lemma summable.tendsto_at_top_zero {f : ℕ → G} (hf : summable f) : filter.at_top.tendsto f (𝓝 0) :=
+by { rw ←nat.cofinite_eq_at_top, exact hf.tendsto_cofinite_zero }
 
 end topological_group
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -600,6 +600,28 @@ end
 
 end subtype
 
+lemma tendsto_zero_at_top_of_summable {α} [add_comm_group α] [topological_space α] [t2_space α]
+  [tag : topological_add_group α] {f : ℕ → α} (hf : summable f) :
+  filter.at_top.tendsto f (𝓝 0) :=
+begin
+  have f_diff_sum : f
+    = (λ n, ∑ i in finset.range (n+1), f i) - (λ n, ∑ i in finset.range n, f i),
+  from funext (λ n, by simp [finset.sum_range_succ]),
+  rw [f_diff_sum, ←sub_self (tsum f)],
+  refine filter.tendsto.sub _ _,
+  swap, { exact (summable.has_sum_iff_tendsto_nat hf).mp hf.has_sum, },
+  have h_sum_offset : (λ n, ∑ i in finset.range (n+1), f i)
+    = λ n, f 0 + (∑ i in finset.range n, f (i+1)),
+  { ext1 n, nth_rewrite 1 add_comm, exact finset.sum_range_succ' f n, },
+  have h_tsum_add_sub : tsum f = f 0 + (tsum f - f 0), by abel,
+  rw [h_sum_offset, h_tsum_add_sub],
+  refine filter.tendsto.add tendsto_const_nhds _,
+  rw ←summable.has_sum_iff_tendsto_nat,
+  { rw @has_sum_nat_add_iff _ _ _ tag _ 1,
+    simp [hf.has_sum], },
+  { rwa @summable_nat_add_iff _ _ _ tag _ 1, },
+end
+
 end topological_group
 
 section topological_semiring

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -942,7 +942,7 @@ begin
   by simpa using hs {x} (singleton_disjoint.2 hx)
 end
 
-lemma summable.tendsto_at_top_zero {f : ℕ → G} (hf : summable f) : filter.at_top.tendsto f (𝓝 0) :=
+lemma summable.tendsto_at_top_zero {f : ℕ → G} (hf : summable f) : tendsto f at_top (𝓝 0) :=
 by { rw ←nat.cofinite_eq_at_top, exact hf.tendsto_cofinite_zero }
 
 end topological_group

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -591,7 +591,7 @@ lemma summable_to_nnreal_of_tsum_ne_top {α : Type*} {f : α → ℝ≥0∞} (hf
   summable (ennreal.to_nnreal ∘ f) :=
 by simpa only [←tsum_coe_ne_top_iff_summable, to_nnreal_apply_of_tsum_ne_top hf] using hf
 
-lemma tendsto_cofinite_zero_of_tsum_lt_top {α} {f : α → ennreal} (hf : tsum f < ∞) :
+lemma tendsto_cofinite_zero_of_tsum_lt_top {α} {f : α → ℝ≥0∞} (hf : ∑' x, f x < ∞) :
   tendsto f cofinite (𝓝 0) :=
 begin
   have f_ne_top : ∀ n, f n ≠ ∞, from ennreal.ne_top_of_tsum_ne_top hf.ne,

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -230,7 +230,7 @@ begin
     tendsto_coe, tendsto_add]
 end
 
-protected lemma tendsto_zero_at_top [hβ : nonempty β] [semilattice_sup β] {f : β → ennreal} :
+protected lemma tendsto_at_top_zero [hβ : nonempty β] [semilattice_sup β] {f : β → ℝ≥0∞} :
   filter.at_top.tendsto f (𝓝 0) ↔ ∀ ε > 0, ∃ N, ∀ n ≥ N, f n ≤ ε :=
 begin
   rw ennreal.tendsto_at_top zero_ne_top,
@@ -601,7 +601,7 @@ begin
   exact nnreal.tendsto_cofinite_zero_of_summable (summable_to_nnreal_of_tsum_ne_top hf.ne),
 end
 
-lemma tendsto_at_top_zero_of_tsum_lt_top {f : ℕ → ennreal} (hf : tsum f < ∞) :
+lemma tendsto_at_top_zero_of_tsum_lt_top {f : ℕ → ℝ≥0∞} (hf : ∑' x, f x < ∞) :
   tendsto f at_top (𝓝 0) :=
 by { rw ←nat.cofinite_eq_at_top, exact tendsto_cofinite_zero_of_tsum_lt_top hf }
 

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -591,15 +591,19 @@ lemma summable_to_nnreal_of_tsum_ne_top {α : Type*} {f : α → ℝ≥0∞} (hf
   summable (ennreal.to_nnreal ∘ f) :=
 by simpa only [←tsum_coe_ne_top_iff_summable, to_nnreal_apply_of_tsum_ne_top hf] using hf
 
-lemma tendsto_zero_at_top_of_tsum_lt_top {f : ℕ → ennreal} (hf : tsum f < ∞) :
-  filter.at_top.tendsto f (𝓝 0) :=
+lemma tendsto_cofinite_zero_of_tsum_lt_top {α} {f : α → ennreal} (hf : tsum f < ∞) :
+  filter.cofinite.tendsto f (𝓝 0) :=
 begin
   have f_ne_top : ∀ n, f n ≠ ∞, from ennreal.ne_top_of_tsum_ne_top hf.ne,
   have h_f_coe : f = λ n, ((f n).to_nnreal : ennreal),
     from funext (λ n, (coe_to_nnreal (f_ne_top n)).symm),
   rw [h_f_coe, ←@coe_zero, tendsto_coe],
-  exact nnreal.tendsto_zero_at_top_of_summable (summable_to_nnreal_of_tsum_ne_top hf.ne),
+  exact nnreal.tendsto_cofinite_zero_of_summable (summable_to_nnreal_of_tsum_ne_top hf.ne),
 end
+
+lemma tendsto_at_top_zero_of_summable {f : ℕ → ennreal} (hf : tsum f < ∞) :
+  filter.at_top.tendsto f (𝓝 0) :=
+by { rw ←nat.cofinite_eq_at_top, exact tendsto_cofinite_zero_of_tsum_lt_top hf }
 
 protected lemma tsum_apply {ι α : Type*} {f : ι → α → ℝ≥0∞} {x : α} :
   (∑' i, f i) x = ∑' i, f i x :=

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -601,7 +601,7 @@ begin
   exact nnreal.tendsto_cofinite_zero_of_summable (summable_to_nnreal_of_tsum_ne_top hf.ne),
 end
 
-lemma tendsto_at_top_zero_of_summable {f : ℕ → ennreal} (hf : tsum f < ∞) :
+lemma tendsto_at_top_zero_of_tsum_lt_top {f : ℕ → ennreal} (hf : tsum f < ∞) :
   filter.at_top.tendsto f (𝓝 0) :=
 by { rw ←nat.cofinite_eq_at_top, exact tendsto_cofinite_zero_of_tsum_lt_top hf }
 

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -230,6 +230,14 @@ begin
     tendsto_coe, tendsto_add]
 end
 
+protected lemma tendsto_zero_at_top [hβ : nonempty β] [semilattice_sup β] {f : β → ennreal} :
+  filter.at_top.tendsto f (𝓝 0) ↔ ∀ ε > 0, ∃ N, ∀ n ≥ N, f n ≤ ε :=
+begin
+  rw ennreal.tendsto_at_top zero_ne_top,
+  { simp_rw [set.mem_Icc, zero_add, zero_sub, zero_le _, true_and], },
+  { exact hβ, },
+end
+
 protected lemma tendsto_mul (ha : a ≠ 0 ∨ b ≠ ⊤) (hb : b ≠ 0 ∨ a ≠ ⊤) :
   tendsto (λp:ℝ≥0∞×ℝ≥0∞, p.1 * p.2) (𝓝 (a, b)) (𝓝 (a * b)) :=
 have ht : ∀b:ℝ≥0∞, b ≠ 0 → tendsto (λp:ℝ≥0∞×ℝ≥0∞, p.1 * p.2) (𝓝 ((⊤:ℝ≥0∞), b)) (𝓝 ⊤),
@@ -582,6 +590,16 @@ coe_to_nnreal $ ennreal.ne_top_of_tsum_ne_top hf _
 lemma summable_to_nnreal_of_tsum_ne_top {α : Type*} {f : α → ℝ≥0∞} (hf : ∑' i, f i ≠ ∞) :
   summable (ennreal.to_nnreal ∘ f) :=
 by simpa only [←tsum_coe_ne_top_iff_summable, to_nnreal_apply_of_tsum_ne_top hf] using hf
+
+lemma tendsto_zero_at_top_of_tsum_lt_top {f : ℕ → ennreal} (hf : tsum f < ∞) :
+  filter.at_top.tendsto f (𝓝 0) :=
+begin
+  have f_ne_top : ∀ n, f n ≠ ∞, from ennreal.ne_top_of_tsum_ne_top hf.ne,
+  have h_f_coe : f = λ n, ((f n).to_nnreal : ennreal),
+    from funext (λ n, (coe_to_nnreal (f_ne_top n)).symm),
+  rw [h_f_coe, ←@coe_zero, tendsto_coe],
+  exact nnreal.tendsto_zero_at_top_of_summable (summable_to_nnreal_of_tsum_ne_top hf.ne),
+end
 
 protected lemma tsum_apply {ι α : Type*} {f : ι → α → ℝ≥0∞} {x : α} :
   (∑' i, f i) x = ∑' i, f i x :=

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -592,7 +592,7 @@ lemma summable_to_nnreal_of_tsum_ne_top {α : Type*} {f : α → ℝ≥0∞} (hf
 by simpa only [←tsum_coe_ne_top_iff_summable, to_nnreal_apply_of_tsum_ne_top hf] using hf
 
 lemma tendsto_cofinite_zero_of_tsum_lt_top {α} {f : α → ennreal} (hf : tsum f < ∞) :
-  filter.cofinite.tendsto f (𝓝 0) :=
+  tendsto f cofinite (𝓝 0) :=
 begin
   have f_ne_top : ∀ n, f n ≠ ∞, from ennreal.ne_top_of_tsum_ne_top hf.ne,
   have h_f_coe : f = λ n, ((f n).to_nnreal : ennreal),
@@ -602,7 +602,7 @@ begin
 end
 
 lemma tendsto_at_top_zero_of_tsum_lt_top {f : ℕ → ennreal} (hf : tsum f < ∞) :
-  filter.at_top.tendsto f (𝓝 0) :=
+  tendsto f at_top (𝓝 0) :=
 by { rw ←nat.cofinite_eq_at_top, exact tendsto_cofinite_zero_of_tsum_lt_top hf }
 
 protected lemma tsum_apply {ι α : Type*} {f : ι → α → ℝ≥0∞} {x : α} :

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -168,12 +168,16 @@ le_antisymm
 
 end coe
 
-lemma tendsto_zero_at_top_of_summable {f : ℕ → nnreal} (hf : summable f) :
-  filter.at_top.tendsto f (𝓝 0) :=
+lemma tendsto_cofinite_zero_of_summable {α} {f : α → nnreal} (hf : summable f) :
+  filter.cofinite.tendsto f (𝓝 0) :=
 begin
   have h_f_coe : f = λ n, nnreal.of_real (f n : ℝ), from funext (λ n, of_real_coe.symm),
   rw [h_f_coe, ←@of_real_coe 0],
-  exact tendsto_of_real (tendsto_zero_at_top_of_summable (summable_coe.mpr hf)),
+  exact tendsto_of_real ((summable_coe.mpr hf).tendsto_cofinite_zero),
 end
+
+lemma tendsto_at_top_zero_of_summable {f : ℕ → nnreal} (hf : summable f) :
+  filter.at_top.tendsto f (𝓝 0) :=
+by { rw ←nat.cofinite_eq_at_top, exact tendsto_cofinite_zero_of_summable hf }
 
 end nnreal

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -43,7 +43,7 @@ a few of which rely on the fact that subtraction is continuous.
 
 -/
 noncomputable theory
-open set topological_space metric
+open set topological_space metric filter
 open_locale topological_space
 
 namespace nnreal
@@ -169,7 +169,7 @@ le_antisymm
 end coe
 
 lemma tendsto_cofinite_zero_of_summable {α} {f : α → nnreal} (hf : summable f) :
-  filter.cofinite.tendsto f (𝓝 0) :=
+  tendsto f cofinite (𝓝 0) :=
 begin
   have h_f_coe : f = λ n, nnreal.of_real (f n : ℝ), from funext (λ n, of_real_coe.symm),
   rw [h_f_coe, ←@of_real_coe 0],
@@ -177,7 +177,7 @@ begin
 end
 
 lemma tendsto_at_top_zero_of_summable {f : ℕ → nnreal} (hf : summable f) :
-  filter.at_top.tendsto f (𝓝 0) :=
+  tendsto f at_top (𝓝 0) :=
 by { rw ←nat.cofinite_eq_at_top, exact tendsto_cofinite_zero_of_summable hf }
 
 end nnreal

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -168,7 +168,7 @@ le_antisymm
 
 end coe
 
-lemma tendsto_cofinite_zero_of_summable {α} {f : α → nnreal} (hf : summable f) :
+lemma tendsto_cofinite_zero_of_summable {α} {f : α → ℝ≥0} (hf : summable f) :
   tendsto f cofinite (𝓝 0) :=
 begin
   have h_f_coe : f = λ n, nnreal.of_real (f n : ℝ), from funext (λ n, of_real_coe.symm),
@@ -176,7 +176,7 @@ begin
   exact tendsto_of_real ((summable_coe.mpr hf).tendsto_cofinite_zero),
 end
 
-lemma tendsto_at_top_zero_of_summable {f : ℕ → nnreal} (hf : summable f) :
+lemma tendsto_at_top_zero_of_summable {f : ℕ → ℝ≥0} (hf : summable f) :
   tendsto f at_top (𝓝 0) :=
 by { rw ←nat.cofinite_eq_at_top, exact tendsto_cofinite_zero_of_summable hf }
 

--- a/src/topology/instances/nnreal.lean
+++ b/src/topology/instances/nnreal.lean
@@ -168,4 +168,12 @@ le_antisymm
 
 end coe
 
+lemma tendsto_zero_at_top_of_summable {f : ℕ → nnreal} (hf : summable f) :
+  filter.at_top.tendsto f (𝓝 0) :=
+begin
+  have h_f_coe : f = λ n, nnreal.of_real (f n : ℝ), from funext (λ n, of_real_coe.symm),
+  rw [h_f_coe, ←@of_real_coe 0],
+  exact tendsto_of_real (tendsto_zero_at_top_of_summable (summable_coe.mpr hf)),
+end
+
 end nnreal


### PR DESCRIPTION
For `f : a -> nnreal`, `summable f` implies `tendsto f cofinite (nhds 0)`.
For `f : a -> ennreal`, `tsum f < \top` implies `tendsto f cofinite (nhds 0)`.

Add versions of these lemmas with `at_top` instead of `cofinite` when `a = N`.

Also add `ennreal.tendsto_at_top_zero`, a simpler statement for a particular case of `ennreal.tendsto_at_top`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
