### PR TITLE
[Merged by Bors] - feat(field_theory/minpoly): add `minpoly.nat_degree_pos`

### DIFF
--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -106,20 +106,20 @@ section ring
 variables [ring B] [algebra A B] [nontrivial B]
 variables {x : B}
 
-/-- The degree of a minimal polynomial is positive. -/
-lemma degree_pos [nontrivial A] (hx : is_integral A x) : 0 < degree (minpoly A x) :=
+/-- The degree of a minimal polynomial, as a natural number, is positive. -/
+lemma nat_degree_pos [nontrivial A] (hx : is_integral A x) : 0 < nat_degree (minpoly A x) :=
 begin
-  apply lt_of_le_of_ne,
-  { simpa only [zero_le_degree_iff] using ne_zero hx },
-  assume deg_eq_zero,
-  rw eq_comm at deg_eq_zero,
-  have ndeg_eq_zero : nat_degree (minpoly A x) = 0,
-  { simpa using congr_arg nat_degree (eq_C_of_degree_eq_zero deg_eq_zero) },
+  rw pos_iff_ne_zero,
+  intro ndeg_eq_zero,
   have eq_one : minpoly A x = 1,
-  { rw eq_C_of_degree_eq_zero deg_eq_zero, convert C_1,
+  { rw eq_C_of_nat_degree_eq_zero ndeg_eq_zero, convert C_1,
     simpa only [ndeg_eq_zero.symm] using (monic hx).leading_coeff },
   simpa only [eq_one, alg_hom.map_one, one_ne_zero] using aeval A x
 end
+
+/-- The degree of a minimal polynomial is positive. -/
+lemma degree_pos [nontrivial A] (hx : is_integral A x) : 0 < degree (minpoly A x) :=
+nat_degree_pos_iff_degree_pos.mp (nat_degree_pos hx)
 
 /-- If `B/A` is an injective ring extension, and `a` is an element of `A`,
 then the minimal polynomial of `algebra_map A B a` is `X - C a`. -/
@@ -135,8 +135,7 @@ begin
     simp only [aeval_C, aeval_X, alg_hom.map_sub, sub_self] },
   have hdeg : (minpoly A (algebra_map A B a)).degree = 1,
   { apply (degree_eq_iff_nat_degree_eq (ne_zero (@is_integral_algebra_map A B _ _ _ a))).2,
-    exact (has_le.le.antisymm hdegle (nat.succ_le_of_lt (with_bot.coe_lt_coe.1
-    (lt_of_lt_of_le (degree_pos (@is_integral_algebra_map A B _ _ _ a)) degree_le_nat_degree)))) },
+    apply le_antisymm hdegle (nat_degree_pos (@is_integral_algebra_map A B _ _ _ a)) },
   have hrw := eq_X_add_C_of_degree_eq_one hdeg,
   simp only [monic (@is_integral_algebra_map A B _ _ _ a), one_mul,
     monic.leading_coeff, ring_hom.map_one] at hrw,

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -107,7 +107,7 @@ variables [ring B] [algebra A B] [nontrivial B]
 variables {x : B}
 
 /-- The degree of a minimal polynomial, as a natural number, is positive. -/
-lemma nat_degree_pos [nontrivial A] (hx : is_integral A x) : 0 < nat_degree (minpoly A x) :=
+lemma nat_degree_pos (hx : is_integral A x) : 0 < nat_degree (minpoly A x) :=
 begin
   rw pos_iff_ne_zero,
   intro ndeg_eq_zero,
@@ -118,7 +118,7 @@ begin
 end
 
 /-- The degree of a minimal polynomial is positive. -/
-lemma degree_pos [nontrivial A] (hx : is_integral A x) : 0 < degree (minpoly A x) :=
+lemma degree_pos (hx : is_integral A x) : 0 < degree (minpoly A x) :=
 nat_degree_pos_iff_degree_pos.mp (nat_degree_pos hx)
 
 /-- If `B/A` is an injective ring extension, and `a` is an element of `A`,


### PR DESCRIPTION
I needed this lemma and noticed that `minpoly.lean` actually uses this result more than `minpoly.degree_pos` (including in the proof of `degree_pos` itself). So I took the opportunity to golf a couple of proofs.


---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
