### PR TITLE
[Merged by Bors] - feat(order/well_founded_set) : Define when a set is well-founded with `set.is_wf`

### DIFF
--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -4,15 +4,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Mario Carneiro
 -/
 import data.nat.basic
+import data.equiv.denumerable
 import order.rel_iso
 import logic.function.iterate
 
 namespace rel_embedding
 
-variables {α : Type*} {r : α → α → Prop}
+variables {α : Type*} {r : α → α → Prop} [is_strict_order α r]
 
 /-- If `f` is a strictly `r`-increasing sequence, then this returns `f` as an order embedding. -/
-def nat_lt [is_strict_order α r] (f : ℕ → α) (H : ∀ n:ℕ, r (f n) (f (n+1))) :
+def nat_lt (f : ℕ → α) (H : ∀ n:ℕ, r (f n) (f (n+1))) :
   ((<) : ℕ → ℕ → Prop) ↪r r :=
 of_monotone f $ λ a b h, begin
   induction b with b IH, {exact (nat.not_lt_zero _ h).elim},
@@ -21,12 +22,15 @@ of_monotone f $ λ a b h, begin
   { subst b, apply H }
 end
 
+@[simp]
+lemma nat_lt_apply {f : ℕ → α} {H : ∀ n:ℕ, r (f n) (f (n+1))} {n : ℕ} : nat_lt f H n = f n := rfl
+
 /-- If `f` is a strictly `r`-decreasing sequence, then this returns `f` as an order embedding. -/
-def nat_gt [is_strict_order α r] (f : ℕ → α) (H : ∀ n:ℕ, r (f (n+1)) (f n)) :
+def nat_gt (f : ℕ → α) (H : ∀ n:ℕ, r (f (n+1)) (f n)) :
   ((>) : ℕ → ℕ → Prop) ↪r r :=
 by haveI := is_strict_order.swap r; exact rel_embedding.swap (nat_lt f H)
 
-theorem well_founded_iff_no_descending_seq [is_strict_order α r] :
+theorem well_founded_iff_no_descending_seq :
   well_founded r ↔ ¬ nonempty (((>) : ℕ → ℕ → Prop) ↪r r) :=
 ⟨λ ⟨h⟩ ⟨⟨f, o⟩⟩,
   suffices ∀ a, acc r a → ∀ n, a ≠ f n, from this (f 0) (h _) 0 rfl,
@@ -43,3 +47,46 @@ theorem well_founded_iff_no_descending_seq [is_strict_order α r] :
     by { rw [function.iterate_succ'], apply h }⟩⟩⟩
 
 end rel_embedding
+
+namespace nat
+
+variables (s : set ℕ) [decidable_pred s] [infinite s]
+/-- An order embedding from `ℕ` to itself with a specified range -/
+def order_embedding_of_set : ℕ ↪o ℕ :=
+(rel_embedding.order_embedding_of_lt_embedding
+  (rel_embedding.nat_lt (nat.subtype.of_nat s) (λ n, nat.subtype.lt_succ_self _))).trans
+  (order_embedding.subtype s)
+
+/-- `nat.subtype.of_nat` as an order isomorphism between `ℕ` and an infinite decidable subset. -/
+noncomputable def subtype.order_iso_of_nat  :
+  ℕ ≃o s :=
+rel_iso.of_surjective (rel_embedding.order_embedding_of_lt_embedding
+  (rel_embedding.nat_lt (nat.subtype.of_nat s) (λ n, nat.subtype.lt_succ_self _)))
+  nat.subtype.of_nat_surjective
+
+variable {s}
+
+@[simp]
+lemma order_embedding_of_set_apply {n : ℕ} : order_embedding_of_set s n = subtype.of_nat s n :=
+rfl
+
+@[simp]
+lemma subtype.order_iso_of_nat_apply {n : ℕ} :
+  subtype.order_iso_of_nat s n = subtype.of_nat s n :=
+by { simp [subtype.order_iso_of_nat] }
+
+@[simp]
+lemma order_embedding_of_set_range : set.range (nat.order_embedding_of_set s) = s :=
+begin
+  ext x,
+  rw [set.mem_range, nat.order_embedding_of_set],
+  split; intro h,
+  { rcases h with ⟨y, rfl⟩,
+    simp },
+  { refine ⟨(nat.subtype.order_iso_of_nat s).symm ⟨x, h⟩, _⟩,
+    simp only [rel_embedding.coe_trans, rel_embedding.order_embedding_of_lt_embedding_apply,
+      rel_embedding.nat_lt_apply, function.comp_app, order_embedding.coe_subtype],
+    rw [← subtype.order_iso_of_nat_apply, order_iso.apply_symm_apply, subtype.coe_mk] }
+end
+
+end nat

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -284,6 +284,11 @@ def order_embedding_of_lt_embedding [partial_order α] [partial_order β]
   α ↪o β :=
 { map_rel_iff' := by { intros, simp [le_iff_lt_or_eq,f.map_rel_iff, f.injective] }, .. f }
 
+@[simp]
+lemma order_embedding_of_lt_embedding_apply [partial_order α] [partial_order β]
+  {f : ((<) : α → α → Prop) ↪r ((<) : β → β → Prop)} {x : α} :
+  order_embedding_of_lt_embedding f x = f x := rfl
+
 end rel_embedding
 
 namespace order_embedding

--- a/src/order/well_founded_set.lean
+++ b/src/order/well_founded_set.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2021 Aaron Anderson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Anderson
+-/
+import data.set.finite
+import data.fintype.basic
+import order.well_founded
+import order.order_iso_nat
+
+/-!
+# Well-founded sets
+
+A well-founded subset of an ordered type is one on which the relation `<` is well-founded.
+
+## Main Definitions
+ * `set.well_founded_on s r` indicates that the relation `r` is
+  well-founded when restricted to the set `s`.
+ * `set.is_wf s` indicates that `<` is well-founded when restricted to `s`.notation
+
+## Main Results
+ * `set.well_founded_on_iff` relates `well_founded_on` to the well-foundedness of a relation on the
+ original type, to avoid dealing with subtypes.
+ * `set.is_wf.mono` shows that a subset of a well-founded subset is well-founded.
+ * `set.is_wf.union` shows that the union of two well-founded subsets is well-founded.
+ * `finset.is_wf` shows that all `finset`s are well-founded.
+
+-/
+
+variables {α : Type*}
+
+namespace set
+
+/-- `s.well_founded_on r` indicates that the relation `r` is well-founded when restricted to `s`. -/
+def well_founded_on (s : set α) (r : α → α → Prop) : Prop :=
+well_founded (λ (a : s) (b : s), r a b)
+
+lemma well_founded_on_iff {s : set α} {r : α → α → Prop} :
+  s.well_founded_on r ↔ well_founded (λ (a b : α), r a b ∧ a ∈ s ∧ b ∈ s) :=
+begin
+  have f : rel_embedding (λ (a : s) (b : s), r a b) (λ (a b : α), r a b ∧ a ∈ s ∧ b ∈ s) :=
+    ⟨⟨coe, subtype.coe_injective⟩, λ a b, by simp⟩,
+  refine ⟨λ h, _, f.well_founded⟩,
+  rw well_founded.well_founded_iff_has_min,
+  intros t ht,
+  by_cases hst : (s ∩ t).nonempty,
+  { rw ← subtype.preimage_coe_nonempty at hst,
+    rcases well_founded.well_founded_iff_has_min.1 h (coe ⁻¹' t) hst with ⟨⟨m, ms⟩, mt, hm⟩,
+    exact ⟨m, mt, λ x xt ⟨xm, xs, ms⟩, hm ⟨x, xs⟩ xt xm⟩ },
+  { rcases ht with ⟨m, mt⟩,
+    exact ⟨m, mt, λ x xt ⟨xm, xs, ms⟩, hst ⟨m, ⟨ms, mt⟩⟩⟩ }
+end
+
+section has_lt
+variables [has_lt α]
+
+/-- `s.is_wf` indicates that `<` is well-founded when restricted to `s`. -/
+def is_wf (s : set α) : Prop := well_founded_on s (<)
+
+variables {s t : set α}
+
+theorem is_wf.mono (h : is_wf t) (st : s ⊆ t) : is_wf s :=
+begin
+  rw [is_wf, well_founded_on_iff] at *,
+  refine subrelation.wf (λ x y xy, _) h,
+  exact ⟨xy.1, st xy.2.1, st xy.2.2⟩,
+end
+end has_lt
+
+section partial_order
+variables [partial_order α] {s t : set α} {a : α}
+
+theorem is_wf_iff_no_descending_seq :
+  is_wf s ↔ ∀ (f : (order_dual ℕ) ↪o α), ¬ (range f) ⊆ s :=
+begin
+  haveI : is_strict_order α (λ (a b : α), a < b ∧ a ∈ s ∧ b ∈ s) := {
+    to_is_irrefl := ⟨λ x con, lt_irrefl x con.1⟩,
+    to_is_trans := ⟨λ a b c ab bc, ⟨lt_trans ab.1 bc.1, ab.2.1, bc.2.2⟩⟩,
+  },
+  rw [is_wf, well_founded_on_iff, rel_embedding.well_founded_iff_no_descending_seq],
+  refine ⟨λ h f con, h begin
+    use f,
+      { exact f.injective },
+      { intros a b,
+        simp only [con (mem_range_self a), con (mem_range_self b), and_true, gt_iff_lt,
+          function.embedding.coe_fn_mk, order_embedding.lt_iff_lt],
+        refl } end, λ h con, _⟩,
+  rcases con with ⟨f, hf⟩,
+  have hfs' : ∀ n : ℕ, f n ∈ s := λ n, (hf.2 n.lt_succ_self).2.2,
+  refine h ⟨f, λ a b, _⟩ (λ n hn, _),
+  { split; intro hle,
+    { cases lt_or_eq_of_le hle with hlt heq,
+      { exact le_of_lt (hf.1 ⟨hlt, hfs' _, hfs' _⟩) },
+      { rw [f.injective heq] } },
+    { cases lt_or_eq_of_le hle with hlt heq,
+      { exact le_of_lt (hf.2 hlt).1, },
+      { rw [heq] } } },
+  { rcases set.mem_range.1 hn with ⟨m, hm⟩,
+    rw ← hm,
+    apply hfs' }
+end
+
+theorem is_wf.union (hs : is_wf s) (ht : is_wf t) : is_wf (s ∪ t) :=
+begin
+  classical,
+  rw [is_wf_iff_no_descending_seq] at *,
+  rintros f fst,
+  have h : infinite (f ⁻¹' s) ∨ infinite (f ⁻¹' t),
+  { have h : infinite (univ : set ℕ) := infinite_univ,
+    have hpre : f ⁻¹' (s ∪ t) = set.univ,
+    { rw [← image_univ, image_subset_iff, univ_subset_iff] at fst,
+      exact fst },
+    rw preimage_union at hpre,
+    rw ← hpre at h,
+    rw [infinite, infinite],
+    rw infinite at h,
+    contrapose! h,
+    exact finite.union h.1 h.2, },
+  rw [← infinite_coe_iff, ← infinite_coe_iff] at h,
+  cases h with inf inf; haveI := inf,
+  { apply hs ((nat.order_embedding_of_set (f ⁻¹' s)).dual.trans f),
+    change range (function.comp f (nat.order_embedding_of_set (f ⁻¹' s))) ⊆ s,
+    rw [range_comp, image_subset_iff],
+      simp },
+  { apply ht ((nat.order_embedding_of_set (f ⁻¹' t)).dual.trans f),
+    change range (function.comp f (nat.order_embedding_of_set (f ⁻¹' t))) ⊆ t,
+    rw [range_comp, image_subset_iff],
+      simp }
+end
+end partial_order
+
+end set
+
+@[simp]
+theorem finset.is_wf [partial_order α] {f : finset α} : set.is_wf (↑f : set α) :=
+fintype.preorder.well_founded
+
+namespace set
+variables [partial_order α] {s : set α} {a : α}
+
+@[simp]
+theorem is_wf_singleton : is_wf ({a} : set α) :=
+by simp [← finset.coe_singleton]
+
+theorem is_wf.insert (hs : is_wf s) : is_wf (insert a s) :=
+by { rw ← union_singleton, exact hs.union is_wf_singleton }
+
+end set

--- a/src/order/well_founded_set.lean
+++ b/src/order/well_founded_set.lean
@@ -138,6 +138,15 @@ fintype.preorder.well_founded
 namespace set
 variables [partial_order α] {s : set α} {a : α}
 
+theorem finite.is_wf (h : s.finite) : s.is_wf :=
+begin
+  rw ← h.coe_to_finset,
+  exact finset.is_wf,
+end
+
+@[simp]
+theorem fintype.is_wf [fintype α] : s.is_wf := (finite.of_fintype s).is_wf
+
 @[simp]
 theorem is_wf_singleton : is_wf ({a} : set α) :=
 by simp [← finset.coe_singleton]


### PR DESCRIPTION
Defines a predicate for when a set within an ordered type is well-founded (`set.is_wf`)
Proves basic lemmas about well-founded sets

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is a setup to defining Hahn Series