### PR TITLE
[Merged by Bors] - refactor(category_theory/adjunction/mates): faster proof

### DIFF
--- a/src/category_theory/adjunction/mates.lean
+++ b/src/category_theory/adjunction/mates.lean
@@ -113,7 +113,7 @@ def transfer_nat_trans : (G ⋙ L₂ ⟶ L₁ ⋙ H) ≃ (R₁ ⋙ G ⟶ H ⋙ R
 lemma transfer_nat_trans_counit (f : G ⋙ L₂ ⟶ L₁ ⋙ H) (Y : D) :
   L₂.map ((transfer_nat_trans adj₁ adj₂ f).app _) ≫ adj₂.counit.app _ =
     f.app _ ≫ H.map (adj₁.counit.app Y) :=
-by simp [transfer_nat_trans]
+by { erw functor.map_comp, simp }
 
 lemma unit_transfer_nat_trans (f : G ⋙ L₂ ⟶ L₁ ⋙ H) (X : C) :
   G.map (adj₁.unit.app X) ≫ (transfer_nat_trans adj₁ adj₂ f).app _ =


### PR DESCRIPTION
Co-authors: `lean-gptf`, Stanislas Polu

elaboration 750ms -> 350ms

5X smaller proof term

This was found by `formal-lean-wm-to-tt-m1-m2-v4-c4` when we evaluated it on theorems added to `mathlib` after we last extracted training data.
