### PR TITLE
[Merged by Bors] - refactor(data/string/basic): simplify proof of `to_list_nonempty`

### DIFF
--- a/src/data/string/basic.lean
+++ b/src/data/string/basic.lean
@@ -67,13 +67,9 @@ by { cases s, refl }
 
 @[simp] lemma to_list_singleton (c : char) : (string.singleton c).to_list = [c] := rfl
 
-lemma to_list_nonempty {s : string} (h : s ≠ string.empty) :
-  s.to_list = s.head :: (s.popn 1).to_list :=
-begin
-  induction s, cases s,
-  { exact absurd rfl h },
-  { exact rfl }
-end
+lemma to_list_nonempty : ∀ {s : string}, s ≠ string.empty →
+  s.to_list = s.head :: (s.popn 1).to_list
+| ⟨s⟩ h := by cases s; [cases h rfl, refl]
 
 @[simp] lemma head_empty : "".head = default _ := rfl
 

--- a/src/data/string/basic.lean
+++ b/src/data/string/basic.lean
@@ -70,10 +70,9 @@ by { cases s, refl }
 lemma to_list_nonempty {s : string} (h : s ≠ string.empty) :
   s.to_list = s.head :: (s.popn 1).to_list :=
 begin
-  rcases s with ⟨_ | ⟨hd, tl⟩⟩,
-  { simpa only using h },
-  { simp [to_list, popn, iterator.nextn, mk_iterator, head, iterator.next,
-          iterator.next_to_string, iterator.curr] }
+  induction s, cases s,
+  { exact absurd rfl h },
+  { exact rfl }
 end
 
 @[simp] lemma head_empty : "".head = default _ := rfl


### PR DESCRIPTION
Co-authors: `lean-gptf`, Stanislas Polu

This was found by `formal-lean-wm-to-tt-m1-m2-v4-c4` when we evaluated it on theorems added to `mathlib` after we last extracted training data.