### PR TITLE
[Merged by Bors] - refactor(computability/partrec): simpler proof of `subtype_mk`

### DIFF
--- a/src/computability/partrec.lean
+++ b/src/computability/partrec.lean
@@ -573,7 +573,7 @@ theorem option_get_or_else {f : α → option β} {g : α → β}
 theorem subtype_mk {f : α → β} {p : β → Prop} [decidable_pred p] {h : ∀ a, p (f a)}
     (hp : primrec_pred p) (hf : computable f) :
   @computable _ _ _ (primcodable.subtype hp) (λ a, (⟨f a, h a⟩ : subtype p)) :=
-nat.partrec.of_eq hf $ λ n, by cases decode α n; simp [subtype.encode_eq]
+hf
 
 theorem sum_cases
   {f : α → β ⊕ γ} {g : α → β → σ} {h : α → γ → σ}


### PR DESCRIPTION
Co-authors: `lean-gptf`, Stanislas Polu

This was found by `formal-lean-wm-to-tt-m1-m2-v4-c4` when we evaluated it on theorems added to `mathlib` after we last extracted training data.