### PR TITLE
[Merged by Bors] - refactor(geometry/euclidean): shorten proof

### DIFF
--- a/src/geometry/euclidean/basic.lean
+++ b/src/geometry/euclidean/basic.lean
@@ -805,7 +805,7 @@ rfl
 lemma eq_reflection_of_eq_subspace {s s' : affine_subspace ℝ P} [nonempty s]
   [nonempty s'] [complete_space s.direction] [complete_space s'.direction] (h : s = s') (p : P) :
   (reflection s p : P) = (reflection s' p : P) :=
-by simp [reflection_apply, eq_orthogonal_projection_of_eq_subspace h]
+by { tactic.unfreeze_local_instances, subst h }
 
 /-- Reflection is its own inverse. -/
 @[simp] lemma reflection_symm (s : affine_subspace ℝ P) [nonempty s] [complete_space s.direction] :

--- a/src/geometry/euclidean/basic.lean
+++ b/src/geometry/euclidean/basic.lean
@@ -805,7 +805,7 @@ rfl
 lemma eq_reflection_of_eq_subspace {s s' : affine_subspace ℝ P} [nonempty s]
   [nonempty s'] [complete_space s.direction] [complete_space s'.direction] (h : s = s') (p : P) :
   (reflection s p : P) = (reflection s' p : P) :=
-by { tactic.unfreeze_local_instances, subst h }
+by unfreezingI { subst h }
 
 /-- Reflection is its own inverse. -/
 @[simp] lemma reflection_symm (s : affine_subspace ℝ P) [nonempty s] [complete_space s.direction] :


### PR DESCRIPTION
... of `eq_reflection_of_eq_subspace`

Co-authors: `lean-gptf`, Stanislas Polu

This was found by `formal-lean-wm-to-tt-m1-m2-v4-c4` when we evaluated it on theorems added to `mathlib` after we last extracted training data.