### PR TITLE
[Merged by Bors] - feat(data/polynomial/denoms_clearable): add lemma about clearing denominators in evaluating a polynomial

### DIFF
--- a/src/data/polynomial/denoms_clearable.lean
+++ b/src/data/polynomial/denoms_clearable.lean
@@ -70,3 +70,27 @@ theorem denoms_clearable_nat_degree
 denoms_clearable_of_nat_degree_le f.nat_degree a bu f le_rfl
 
 end denoms_clearable
+
+open ring_hom
+
+/--  Evaluating a polynomial with integer coefficients at a rational number and clearing
+denominators, yields a number greater than or equal to one.  The target can be any
+`linear_ordered_field K`.
+The assumption on `K` could be weakened to `linear_ordered_comm_ring` assuming that the
+image of the denominator is invertible in `K`. -/
+lemma one_le_pow_mul_abs_eval_div {K : Type*} [linear_ordered_field K] {f : polynomial ℤ}
+  {a b : ℤ} (b0 : (0 : K) < b) (fab : eval ((a : K) / b) (f.map (algebra_map ℤ K)) ≠ 0) :
+  (1 : K) ≤ b ^ f.nat_degree * abs (eval ((a : K) / b) (f.map (algebra_map ℤ K))) :=
+begin
+  obtain ⟨ev, bi, bu, hF⟩ := @denoms_clearable_nat_degree _ _ _ _ b _ (algebra_map ℤ K)
+    f a (by { rw [eq_int_cast, one_div_mul_cancel], exact (b0.ne.symm) }),
+  obtain Fa := congr_arg abs hF,
+  rw [eq_one_div_of_mul_eq_one_left bu, eq_int_cast, eq_int_cast, abs_mul,
+    (abs_of_pos (pow_pos b0 _)), one_div, eq_int_cast] at Fa,
+  rw [div_eq_mul_inv, ← Fa, ← int.cast_abs, ← int.cast_one, int.cast_le],
+  refine int.le_of_lt_add_one ((lt_add_iff_pos_left 1).mpr (abs_pos.mpr (λ F0, fab _))),
+  rw [eq_one_div_of_mul_eq_one_left bu, F0, one_div, eq_int_cast, int.cast_zero, zero_eq_mul] at hF,
+  cases hF with hF hF,
+  { exact (not_le.mpr b0 (pow_eq_zero hF).le).elim },
+  { exact hF }
+end

--- a/src/data/polynomial/denoms_clearable.lean
+++ b/src/data/polynomial/denoms_clearable.lean
@@ -79,18 +79,18 @@ denominators, yields a number greater than or equal to one.  The target can be a
 The assumption on `K` could be weakened to `linear_ordered_comm_ring` assuming that the
 image of the denominator is invertible in `K`. -/
 lemma one_le_pow_mul_abs_eval_div {K : Type*} [linear_ordered_field K] {f : polynomial ℤ}
-  {a b : ℤ} (b0 : (0 : K) < b) (fab : eval ((a : K) / b) (f.map (algebra_map ℤ K)) ≠ 0) :
+  {a b : ℤ} (b0 : 0 < b) (fab : eval ((a : K) / b) (f.map (algebra_map ℤ K)) ≠ 0) :
   (1 : K) ≤ b ^ f.nat_degree * abs (eval ((a : K) / b) (f.map (algebra_map ℤ K))) :=
 begin
   obtain ⟨ev, bi, bu, hF⟩ := @denoms_clearable_nat_degree _ _ _ _ b _ (algebra_map ℤ K)
-    f a (by { rw [eq_int_cast, one_div_mul_cancel], exact (b0.ne.symm) }),
+    f a (by { rw [eq_int_cast, one_div_mul_cancel], rw [int.cast_ne_zero], exact (b0.ne.symm) }),
   obtain Fa := congr_arg abs hF,
-  rw [eq_one_div_of_mul_eq_one_left bu, eq_int_cast, eq_int_cast, abs_mul,
-    (abs_of_pos (pow_pos b0 _)), one_div, eq_int_cast] at Fa,
+  rw [eq_one_div_of_mul_eq_one_left bu, eq_int_cast, eq_int_cast, abs_mul] at Fa,
+  rw [abs_of_pos (pow_pos (int.cast_pos.mpr b0) _ : 0 < (b : K) ^ _), one_div, eq_int_cast] at Fa,
   rw [div_eq_mul_inv, ← Fa, ← int.cast_abs, ← int.cast_one, int.cast_le],
   refine int.le_of_lt_add_one ((lt_add_iff_pos_left 1).mpr (abs_pos.mpr (λ F0, fab _))),
   rw [eq_one_div_of_mul_eq_one_left bu, F0, one_div, eq_int_cast, int.cast_zero, zero_eq_mul] at hF,
   cases hF with hF hF,
-  { exact (not_le.mpr b0 (pow_eq_zero hF).le).elim },
+  { exact (not_le.mpr b0 (le_of_eq (int.cast_eq_zero.mp (pow_eq_zero hF)))).elim },
   { exact hF }
 end


### PR DESCRIPTION
Evaluating a polynomial with integer coefficients at a rational number and clearing denominators, yields a number greater than or equal to one.  The target can be any `linear_ordered_field K`.

The assumption on `K` could be weakened to `linear_ordered_comm_ring` assuming that the
image of the denominator is invertible in `K`.

Reference: Liouville PR #4301.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
