### PR TITLE
[Merged by Bors] - feat(linear_algebra/pi_tensor_product): tmul distributes over tprod

### DIFF
--- a/src/linear_algebra/pi_tensor_product.lean
+++ b/src/linear_algebra/pi_tensor_product.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Frédéric Dupuis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Frédéric Dupuis
+Authors: Frédéric Dupuis, Eric Wieser
 -/
 
 import group_theory.congruence
@@ -26,6 +26,8 @@ binary tensor product in `linear_algebra/tensor_product.lean`.
 * `lift φ` with `φ : multilinear_map R s E` is the corresponding linear map
   `(⨂[R] i, s i) →ₗ[R] E`. This is bundled as a linear equivalence.
 * `pi_tensor_product.reindex e` re-indexes the components of `⨂[R] i : ι, M` along `e : ι ≃ ι₂`.
+* `pi_tensor_product.mul_equiv` equivalence between a `tensor_product` of `pi_tensor_product`s and
+  a single `pi_tensor_product`.
 
 ## Notations
 

--- a/src/linear_algebra/pi_tensor_product.lean
+++ b/src/linear_algebra/pi_tensor_product.lean
@@ -482,14 +482,12 @@ For simplicity, this is defined only for homogeneously- (rather than dependently
 -/
 def tmul_equiv : (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) ≃ₗ[R] ⨂[R] i : ι ⊕ ι₂, M :=
 linear_equiv.of_linear tmul tmul_symm
-  (by {
-    ext x,
-    show tmul (tmul_symm (tprod R x)) = tprod R x,
-    simp only [tmul_symm_apply, tmul_apply, sum.elim_comp_inl_inr], })
-  (by {
-    ext x y,
-    show tmul_symm (tmul (tprod R x ⊗ₜ[R] tprod R y)) = tprod R x ⊗ₜ[R] tprod R y,
-    simp only [tmul_apply, tmul_symm_apply, sum.elim_inl, sum.elim_inr], })
+  (by { ext x,
+        show tmul (tmul_symm (tprod R x)) = tprod R x, -- Speed up the call to `simp`.
+        simp only [tmul_symm_apply, tmul_apply, sum.elim_comp_inl_inr], })
+  (by { ext x y,
+        show tmul_symm (tmul (tprod R x ⊗ₜ[R] tprod R y)) = tprod R x ⊗ₜ[R] tprod R y,
+        simp only [tmul_apply, tmul_symm_apply, sum.elim_inl, sum.elim_inr], })
 
 @[simp] lemma tmul_equiv_apply (a : ι → M) (b : ι₂ → M) :
   tmul_equiv R M ((⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i)) = ⨂ₜ[R] i, sum.elim a b i :=

--- a/src/linear_algebra/pi_tensor_product.lean
+++ b/src/linear_algebra/pi_tensor_product.lean
@@ -26,7 +26,7 @@ binary tensor product in `linear_algebra/tensor_product.lean`.
 * `lift φ` with `φ : multilinear_map R s E` is the corresponding linear map
   `(⨂[R] i, s i) →ₗ[R] E`. This is bundled as a linear equivalence.
 * `pi_tensor_product.reindex e` re-indexes the components of `⨂[R] i : ι, M` along `e : ι ≃ ι₂`.
-* `pi_tensor_product.mul_equiv` equivalence between a `tensor_product` of `pi_tensor_product`s and
+* `pi_tensor_product.tmul_equiv` equivalence between a `tensor_product` of `pi_tensor_product`s and
   a single `pi_tensor_product`.
 
 ## Notations
@@ -447,14 +447,14 @@ def pempty_equiv : ⨂[R] i : pempty, M ≃ₗ[R] R :=
 section mul
 
 /-- Collapse a `tensor_product` of `pi_tensor_product`s. -/
-def mul : (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) →ₗ[R] ⨂[R] i : ι ⊕ ι₂, M :=
+private def mul : (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) →ₗ[R] ⨂[R] i : ι ⊕ ι₂, M :=
 tensor_product.lift
   { to_fun := λ a, pi_tensor_product.lift $ pi_tensor_product.lift
       (multilinear_map.curry_sum_equiv R _ _ M _ (tprod R)) a,
     map_add' := λ a b, by simp only [linear_equiv.map_add, linear_map.map_add],
     map_smul' := λ r a, by simp only [linear_equiv.map_smul, linear_map.map_smul], }
 
-@[simp] lemma mul_tprod_tmul_tprod (a : ι → M) (b : ι₂ → M) :
+private lemma mul_tprod_tmul_tprod (a : ι → M) (b : ι₂ → M) :
   mul ((⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i)) = ⨂ₜ[R] i, sum.elim a b i :=
 begin
   erw [tensor_product.lift.tmul, pi_tensor_product.lift.tprod, pi_tensor_product.lift.tprod],
@@ -462,18 +462,18 @@ begin
 end
 
 /-- Expand `pi_tensor_product` into a `tensor_product` of two factors. -/
-def factor : ⨂[R] i : ι ⊕ ι₂, M →ₗ[R] (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) :=
+private def factor : ⨂[R] i : ι ⊕ ι₂, M →ₗ[R] (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) :=
 pi_tensor_product.lift begin
   apply multilinear_map.dom_coprod,
   exact tprod R,
   exact tprod R,
 end
 
-@[simp] lemma factor_tprod (a : ι ⊕ ι₂ → M) :
+private lemma factor_tprod (a : ι ⊕ ι₂ → M) :
   factor (⨂ₜ[R] i, a i) = (⨂ₜ[R] i, a (sum.inl i)) ⊗ₜ[R] (⨂ₜ[R] i, a (sum.inr i)) :=
 pi_tensor_product.lift.tprod _
 
-@[simp] lemma factor_comp_mul :
+private lemma factor_comp_mul :
   (factor : ⨂[R] i : ι ⊕ ι₂, M →ₗ[R] _).comp mul = linear_map.id :=
 begin
   ext,
@@ -482,11 +482,7 @@ begin
     sum.elim_inl, sum.elim_inr],
 end
 
-@[simp] lemma factor_mul (x : (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M)) :
-  factor (mul x) = x :=
-by rw [←linear_map.comp_apply, factor_comp_mul, linear_map.id_apply]
-
-@[simp] lemma mul_comp_factor :
+private lemma mul_comp_factor :
   (mul : _ →ₗ[R] ⨂[R] i : ι ⊕ ι₂, M).comp factor = linear_map.id :=
 begin
   ext,
@@ -494,22 +490,23 @@ begin
     factor_tprod, mul_tprod_tmul_tprod, sum.elim_comp_inl_inr],
 end
 
-@[simp] lemma mul_factor (x : ⨂[R] i : ι ⊕ ι₂, M) :
+private lemma mul_factor (x : ⨂[R] i : ι ⊕ ι₂, M) :
   mul (factor x) = x :=
 by rw [←linear_map.comp_apply, mul_comp_factor, linear_map.id_apply]
 
 variables (R M)
 
-/-- `mul` and `factor` combined as an ``linear_equiv`. -/
-def mul_equiv : (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) ≃ₗ[R] ⨂[R] i : ι ⊕ ι₂, M :=
+/-- Equivalence between a `tensor_product` of `pi_tensor_product`s and a single
+`pi_tensor_product`. -/
+def tmul_equiv : (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) ≃ₗ[R] ⨂[R] i : ι ⊕ ι₂, M :=
 linear_equiv.of_linear mul factor mul_comp_factor factor_comp_mul
 
-@[simp] lemma mul_equiv_apply (a : ι → M) (b : ι₂ → M) :
-  mul_equiv R M ((⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i)) = ⨂ₜ[R] i, sum.elim a b i :=
+@[simp] lemma tmul_equiv_apply (a : ι → M) (b : ι₂ → M) :
+  tmul_equiv R M ((⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i)) = ⨂ₜ[R] i, sum.elim a b i :=
 mul_tprod_tmul_tprod a b
 
-@[simp] lemma mul_equiv_symm_apply (a : ι ⊕ ι₂ → M) :
-  (mul_equiv R M).symm (⨂ₜ[R] i, a i) = (⨂ₜ[R] i, a (sum.inl i)) ⊗ₜ[R] (⨂ₜ[R] i, a (sum.inr i)) :=
+@[simp] lemma tmul_equiv_symm_apply (a : ι ⊕ ι₂ → M) :
+  (tmul_equiv R M).symm (⨂ₜ[R] i, a i) = (⨂ₜ[R] i, a (sum.inl i)) ⊗ₜ[R] (⨂ₜ[R] i, a (sum.inr i)) :=
 factor_tprod a
 
 end mul

--- a/src/linear_algebra/pi_tensor_product.lean
+++ b/src/linear_algebra/pi_tensor_product.lean
@@ -463,11 +463,8 @@ end
 
 /-- Expand `pi_tensor_product` into a `tensor_product` of two factors. -/
 private def tmul_symm : ⨂[R] i : ι ⊕ ι₂, M →ₗ[R] (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) :=
-pi_tensor_product.lift begin
-  apply multilinear_map.dom_coprod,
-  exact tprod R,
-  exact tprod R,
-end
+-- by using tactic mode, we avoid the need for a lot of `@`s and `_`s
+pi_tensor_product.lift $ by apply multilinear_map.dom_coprod; [exact tprod R, exact tprod R]
 
 private lemma tmul_symm_apply (a : ι ⊕ ι₂ → M) :
   tmul_symm (⨂ₜ[R] i, a i) = (⨂ₜ[R] i, a (sum.inl i)) ⊗ₜ[R] (⨂ₜ[R] i, a (sum.inr i)) :=

--- a/src/linear_algebra/pi_tensor_product.lean
+++ b/src/linear_algebra/pi_tensor_product.lean
@@ -442,6 +442,59 @@ def pempty_equiv : ⨂[R] i : pempty, M ≃ₗ[R] R :=
   map_add' := linear_map.map_add _,
   map_smul' := linear_map.map_smul _, }
 
+section mul
+
+/-- Collapse a `tensor_product` of `pi_tensor_product`s -/
+def mul : (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) →ₗ[R] ⨂[R] i : ι ⊕ ι₂, M :=
+tensor_product.lift
+  { to_fun := λ a, pi_tensor_product.lift $ pi_tensor_product.lift
+      (multilinear_map.curry_sum_equiv R _ _ M _ (tprod R)) a,
+    map_add' := λ a b, by simp only [linear_equiv.map_add, linear_map.map_add],
+    map_smul' := λ r a, by simp only [linear_equiv.map_smul, linear_map.map_smul], }
+
+@[simp] lemma mul_tprod_tmul_tprod (a : ι → M) (b : ι₂ → M) :
+  mul ((⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i)) = ⨂ₜ[R] i, sum.elim a b i :=
+begin
+  erw [tensor_product.lift.tmul, pi_tensor_product.lift.tprod, pi_tensor_product.lift.tprod],
+  refl
+end
+
+/-- Expand `pi_tensor_product` into a `tensor_product` of two halves -/
+def unmul : ⨂[R] i : ι ⊕ ι₂, M →ₗ[R] (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) :=
+pi_tensor_product.lift begin
+  apply multilinear_map.dom_coprod,
+  exact tprod R,
+  exact tprod R,
+end
+
+@[simp] lemma unmul_tprod (a : ι ⊕ ι₂ → M) :
+  unmul (⨂ₜ[R] i, a i) = (⨂ₜ[R] i, a (sum.inl i)) ⊗ₜ[R] (⨂ₜ[R] i, a (sum.inr i)) :=
+pi_tensor_product.lift.tprod _
+
+/-- `mul` and `unmul` combined as an equiv. -/
+def mul_equiv : (⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) ≃ₗ[R] ⨂[R] i : ι ⊕ ι₂, M :=
+linear_equiv.of_linear mul unmul
+  begin
+    ext,
+    simp only [linear_map.comp_multilinear_map_apply, linear_map.comp_apply, linear_map.id_apply,
+      unmul_tprod, mul_tprod_tmul_tprod, sum.elim_comp_inl_inr],
+  end
+  begin
+    ext,
+    simp only [linear_map.comp_multilinear_map_apply, linear_map.comp_apply, linear_map.id_apply,
+      linear_map.compr₂_apply, tensor_product.mk_apply, unmul_tprod, mul_tprod_tmul_tprod,
+      sum.elim_inl, sum.elim_inr],
+  end
+
+lemma mul_equiv_apply (a : ι → M) (b : ι₂ → M) :
+  mul_equiv ((⨂ₜ[R] i, a i) ⊗ₜ[R] (⨂ₜ[R] i, b i)) = ⨂ₜ[R] i, sum.elim a b i :=
+mul_tprod_tmul_tprod a b
+
+lemma mul_equiv_symm_apply (a : ι ⊕ ι₂ → M) :
+  mul_equiv.symm (⨂ₜ[R] i, a i) = (⨂ₜ[R] i, a (sum.inl i)) ⊗ₜ[R] (⨂ₜ[R] i, a (sum.inr i)) :=
+unmul_tprod a
+
+end mul
 end multilinear
 
 end pi_tensor_product


### PR DESCRIPTION
This adds the equivalence `(⨂[R] i : ι, M) ⊗[R] (⨂[R] i : ι₂, M) ≃ₗ[R] ⨂[R] i : ι ⊕ ι₂, M`.
Working with dependently-typed `M` here is more trouble than it's worth, as we don't have any typeclass structures on `sum.elim M N` right now,

This is one of the pieces needed to provide a ring structure on `⨁ n, ⨂[R] i : fin n, M`, but that's left for another time.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This was the motivation behind #6105.

~~I'd appreciate some name suggestions for these definitions - `mul`, `factor`, and `mul_equiv` do not strike me as particularly good, but maybe they're ok now that I got rid of `unmul`.~~

~~For instance, `tmul_equiv` _might_ be a better name than `mul_equiv`.~~