### PR TITLE
[Merged by Bors] - refactor(data/set/intervals/basic): simpler proof of `Iio_union_Ioo'`

### DIFF
--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -801,11 +801,12 @@ subset.antisymm (λ x hx, hx.elim (λ hx, lt_of_le_of_lt hx h) and.right) Iio_su
 lemma Iio_union_Ioo' {c d : α} (h₁ : c < b) :
   Iio b ∪ Ioo c d = Iio (max b d) :=
 begin
-  ext x, cases lt_or_le x b with hba hba,
+  ext x,
+  cases lt_or_le x b with hba hba,
   { simp [hba, h₁] },
   { simp only [mem_Iio, mem_union_eq, mem_Ioo, lt_max_iff],
-    apply or_congr, refl, split, exact and.right,
-    exact λ h₂, ⟨lt_of_lt_of_le h₁ hba, h₂⟩}
+    refine or_congr iff.rfl ⟨and.right, _⟩,
+    exact λ h₂, ⟨h₁.trans_le hba, h₂⟩ },
 end
 
 lemma Iio_union_Ioo {c d : α} (h : min c d < b) :

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -801,12 +801,11 @@ subset.antisymm (λ x hx, hx.elim (λ hx, lt_of_le_of_lt hx h) and.right) Iio_su
 lemma Iio_union_Ioo' {c d : α} (h₁ : c < b) :
   Iio b ∪ Ioo c d = Iio (max b d) :=
 begin
-  ext1 x,
-  simp_rw [mem_union, mem_Iio, mem_Ioo, lt_max_iff],
-  by_cases hc : c < x,
-  { tauto, },
-  { have hxb : x < b, from lt_of_le_of_lt (le_of_not_gt hc) h₁,
-    tauto, },
+  ext x, cases lt_or_le x b with hba hba,
+  { simp [hba, h₁] },
+  { simp only [mem_Iio, mem_union_eq, mem_Ioo, lt_max_iff],
+    apply or_congr, refl, split, exact and.right,
+    exact λ h₂, ⟨lt_of_lt_of_le h₁ hba, h₂⟩}
 end
 
 lemma Iio_union_Ioo {c d : α} (h : min c d < b) :


### PR DESCRIPTION
proof term 2577 -> 1587 chars

elaboration time 130ms -> 75ms

Co-authors: `lean-gptf`, Stanislas Polu

This was found by `formal-lean-wm-to-tt-m1-m2-v4-c4` when we evaluated it on theorems added to `mathlib` after we last extracted training data.
