### PR TITLE
refactor(data/ordmap/ordset): simplify proof of `dual_node'`

### DIFF
--- a/src/data/ordmap/ordset.lean
+++ b/src/data/ordmap/ordset.lean
@@ -241,7 +241,7 @@ node' l x r
 
 theorem dual_node' (l : ordnode α) (x : α) (r : ordnode α) :
   dual (node' l x r) = node' (dual r) x (dual l) :=
-  by { rw dual, congr' 2, rw [add_comm, size_dual, size_dual] }
+by { rw dual, congr' 2, rw [add_comm, size_dual, size_dual] }
 
 theorem dual_node3_l (l : ordnode α) (x : α) (m : ordnode α) (y : α) (r : ordnode α) :
   dual (node3_l l x m y r) = node3_r (dual r) y (dual m) x (dual l) :=

--- a/src/data/ordmap/ordset.lean
+++ b/src/data/ordmap/ordset.lean
@@ -241,7 +241,7 @@ node' l x r
 
 theorem dual_node' (l : ordnode α) (x : α) (r : ordnode α) :
   dual (node' l x r) = node' (dual r) x (dual l) :=
-by { unfold dual, congr' 1, simp [add_comm, add_left_comm] }
+  by { rw dual, congr' 2, rw [add_comm, size_dual, size_dual] }
 
 theorem dual_node3_l (l : ordnode α) (x : α) (m : ordnode α) (y : α) (r : ordnode α) :
   dual (node3_l l x m y r) = node3_r (dual r) y (dual m) x (dual l) :=

--- a/src/data/ordmap/ordset.lean
+++ b/src/data/ordmap/ordset.lean
@@ -241,7 +241,7 @@ node' l x r
 
 theorem dual_node' (l : ordnode α) (x : α) (r : ordnode α) :
   dual (node' l x r) = node' (dual r) x (dual l) :=
-  by { unfold dual, congr' 1, simp [add_comm, add_left_comm] }
+by { unfold dual, congr' 1, simp [add_comm, add_left_comm] }
 
 theorem dual_node3_l (l : ordnode α) (x : α) (m : ordnode α) (y : α) (r : ordnode α) :
   dual (node3_l l x m y r) = node3_r (dual r) y (dual m) x (dual l) :=

--- a/src/data/ordmap/ordset.lean
+++ b/src/data/ordmap/ordset.lean
@@ -240,7 +240,8 @@ if size l > delta * size r then rotate_r l x r else
 node' l x r
 
 theorem dual_node' (l : ordnode α) (x : α) (r : ordnode α) :
-  dual (node' l x r) = node' (dual r) x (dual l) := by simp [node', add_comm]
+  dual (node' l x r) = node' (dual r) x (dual l) :=
+  by { unfold dual, congr' 1, simp [add_comm, add_left_comm] }
 
 theorem dual_node3_l (l : ordnode α) (x : α) (m : ordnode α) (y : α) (r : ordnode α) :
   dual (node3_l l x m y r) = node3_r (dual r) y (dual m) x (dual l) :=


### PR DESCRIPTION
2X smaller proof term

Co-authors: `lean-gptf`, Stanislas Polu

This was found by `formal-lean-wm-to-tt-m1-m2-v4-c4` when we evaluated it on theorems added to `mathlib` after we last extracted training data.