### PR TITLE
[Merged by Bors] - refactor(ring_theory/polynomial/symmetric): simplify proof

### DIFF
--- a/src/ring_theory/polynomial/symmetric.lean
+++ b/src/ring_theory/polynomial/symmetric.lean
@@ -90,7 +90,7 @@ lemma neg (hφ : is_symmetric φ) : is_symmetric (-φ) :=
 λ e, by rw [alg_hom.map_neg, hφ]
 
 lemma sub (hφ : is_symmetric φ) (hψ : is_symmetric ψ) : is_symmetric (φ - ψ) :=
-λ e, by rw [alg_hom.map_sub, hφ, hψ]
+by rw sub_eq_add_neg; exact hφ.add hψ.neg
 
 end comm_ring
 

--- a/src/ring_theory/polynomial/symmetric.lean
+++ b/src/ring_theory/polynomial/symmetric.lean
@@ -90,7 +90,7 @@ lemma neg (hφ : is_symmetric φ) : is_symmetric (-φ) :=
 λ e, by rw [alg_hom.map_neg, hφ]
 
 lemma sub (hφ : is_symmetric φ) (hψ : is_symmetric ψ) : is_symmetric (φ - ψ) :=
-by rw sub_eq_add_neg; exact hφ.add hψ.neg
+by { rw sub_eq_add_neg, exact hφ.add hψ.neg }
 
 end comm_ring
 


### PR DESCRIPTION
... of `mv_polynomial.is_symmetric.sub`

2X smaller proof term

Co-authors: `lean-gptf`, Stanislas Polu

This was found by `formal-lean-wm-to-tt-m1-m2-v4-c4` when we evaluated it on theorems added to `mathlib` after we last extracted training data.
