### PR TITLE
[Merged by Bors] - refactor(measure_theory/measure_space): simplify proof

### DIFF
--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1577,10 +1577,7 @@ end
 
 lemma ite_ae_eq_of_measure_compl_zero {γ} (f : α → γ) (g : α → γ) (s : set α) (hs_zero : μ sᶜ = 0) :
   (λ x, ite (x ∈ s) (f x) (g x)) =ᵐ[μ] f :=
-begin
-  have h_ss : s ⊆ {a : α | ite (a ∈ s) (f a) (g a) = f a}, from λ x hx, by simp [hx],
-  exact measure_mono_null (set.compl_subset_compl.mpr h_ss) hs_zero,
-end
+by { filter_upwards [hs_zero], intros, split_ifs, refl }
 
 namespace measure
 


### PR DESCRIPTION
2X smaller proof term

Co-authors: `lean-gptf`, Stanislas Polu

This was found by `formal-lean-wm-to-tt-m1-m2-v4-c4` when we evaluated it on theorems added to `mathlib` after we last extracted training data.