### PR TITLE
[Merged by Bors] - refactor(algebra/lie/basic): rm extraneous rewrite hypothesis

### DIFF
--- a/src/algebra/lie/basic.lean
+++ b/src/algebra/lie/basic.lean
@@ -1040,7 +1040,7 @@ lemma subset_lie_span : s ⊆ lie_span R L s :=
 by { intros m hm, erw mem_lie_span, intros N hN, exact hN hm, }
 
 lemma submodule_span_le_lie_span : submodule.span R s ≤ lie_span R L s :=
-by { rw [submodule.span_le, coe_to_submodule], apply subset_lie_span, }
+by { rw submodule.span_le, apply subset_lie_span, }
 
 lemma lie_span_le {N} : lie_span R L s ≤ N ↔ s ⊆ N :=
 begin


### PR DESCRIPTION
Co-authors: `lean-gptf`, Stanislas Polu

This was found by `formal-lean-wm-to-tt-m1-m2-v4-c4` when we evaluated it on theorems added to `mathlib` after we last extracted training data.
