### PR TITLE
[Merged by Bors] - refactor(order/closure): golf `closure_inter_le`

### DIFF
--- a/src/order/closure.lean
+++ b/src/order/closure.lean
@@ -86,7 +86,7 @@ le_antisymm le_top (c.le_closure _)
 
 lemma closure_inter_le {α : Type u} [semilattice_inf α] (c : closure_operator α) (x y : α) :
   c (x ⊓ y) ≤ c x ⊓ c y :=
-le_inf (c.monotone inf_le_left) (c.monotone inf_le_right)
+c.monotone.map_inf_le _ _
 
 lemma closure_union_closure_le {α : Type u} [semilattice_sup α] (c : closure_operator α) (x y : α) :
   c x ⊔ c y ≤ c (x ⊔ y) :=

--- a/src/order/closure.lean
+++ b/src/order/closure.lean
@@ -90,7 +90,7 @@ c.monotone.map_inf_le _ _
 
 lemma closure_union_closure_le {α : Type u} [semilattice_sup α] (c : closure_operator α) (x y : α) :
   c x ⊔ c y ≤ c (x ⊔ y) :=
-sup_le (c.monotone le_sup_left) (c.monotone le_sup_right)
+c.monotone.le_map_sup _ _
 
 /-- An element `x` is closed for the closure operator `c` if it is a fixed point for it. -/
 def closed : set α := λ x, c x = x


### PR DESCRIPTION
Co-authors: `lean-gptf`, Stanislas Polu

This was found by `formal-lean-wm-to-tt-m1-m2-v4-c4` when we evaluated it on theorems added to `mathlib` after we last extracted training data.