### PR TITLE
[Merged by Bors] - chore(algebra/module/pi): add missing smul_comm_class instances

### DIFF
--- a/src/algebra/module/pi.lean
+++ b/src/algebra/module/pi.lean
@@ -48,6 +48,21 @@ instance is_scalar_tower'' {g : I → Type*} {h : I → Type*}
   [Π i, is_scalar_tower (f i) (g i) (h i)] : is_scalar_tower (Π i, f i) (Π i, g i) (Π i, h i) :=
 ⟨λ x y z, funext $ λ i, smul_assoc (x i) (y i) (z i)⟩
 
+instance smul_comm_class {α β : Type*}
+  [Π i, has_scalar α $ f i] [Π i, has_scalar β $ f i] [∀ i, smul_comm_class α β (f i)] :
+  smul_comm_class α β (Π i : I, f i) :=
+⟨λ x y z, funext $ λ i, smul_comm x y (z i)⟩
+
+instance smul_comm_class' {g : I → Type*} {α : Type*}
+  [Π i, has_scalar α $ g i] [Π i, has_scalar (f i) (g i)] [∀ i, smul_comm_class α (f i) (g i)] :
+  smul_comm_class α (Π i : I, f i) (Π i : I, g i) :=
+⟨λ x y z, funext $ λ i, smul_comm x (y i) (z i)⟩
+
+instance smul_comm_class'' {g : I → Type*} {h : I → Type*}
+  [Π i, has_scalar (g i) (h i)] [Π i, has_scalar (f i) (h i)]
+  [∀ i, smul_comm_class (f i) (g i) (h i)] : smul_comm_class (Π i, f i) (Π i, g i) (Π i, h i) :=
+⟨λ x y z, funext $ λ i, smul_comm (x i) (y i) (z i)⟩
+
 instance mul_action (α) {m : monoid α} [Π i, mul_action α $ f i] :
   @mul_action α (Π i : I, f i) m :=
 { smul := (•),


### PR DESCRIPTION
There are three families of these for consistency with how we have three families of `is_scalar_tower` instances.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
