### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/operator_norm): bundle more arguments

### DIFF
--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -1134,6 +1134,6 @@ lemma has_strict_deriv_at_of_has_deriv_at_of_continuous_at {f f' : 𝕜 → G} {
   (hder : ∀ᶠ y in 𝓝 x, has_deriv_at f (f' y) y) (hcont : continuous_at f' x) :
   has_strict_deriv_at f (f' x) x :=
 has_strict_fderiv_at_of_has_fderiv_at_of_continuous_at (hder.mono (λ y hy, hy.has_fderiv_at)) $
-  (smul_rightL 1).continuous.continuous_at.comp hcont
+  (smul_rightL 𝕜 _ _ 1).continuous.continuous_at.comp hcont
 
 end is_R_or_C

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -710,45 +710,93 @@ begin
      ... ≤ (∥c∥ * ∥x∥) * ∥f∥ :
        mul_le_mul_of_nonneg_right (le_op_norm _ _) (norm_nonneg _)
      ... = ∥c∥ * ∥f∥ * ∥x∥ : by ring },
-  { by_cases h : ∥f∥ = 0,
-    { rw h, simp [norm_nonneg] },
-    { have : 0 < ∥f∥ := lt_of_le_of_ne (norm_nonneg _) (ne.symm h),
+  { by_cases h : f = 0,
+    { simp [h] },
+    { have : 0 < ∥f∥ := norm_pos_iff.2 h,
       rw ← le_div_iff this,
       apply op_norm_le_bound _ (div_nonneg (norm_nonneg _) (norm_nonneg f)) (λx, _),
       rw [div_mul_eq_mul_div, le_div_iff this],
       calc ∥c x∥ * ∥f∥ = ∥c x • f∥ : (norm_smul _ _).symm
-      ... = ∥((smul_right c f) : E → F) x∥ : rfl
+      ... = ∥smul_right c f x∥ : rfl
       ... ≤ ∥smul_right c f∥ * ∥x∥ : le_op_norm _ _ } },
 end
 
-/-- Given `c : c : E →L[𝕜] 𝕜`, `c.smul_rightL` is the continuous linear map from `F` to `E →L[𝕜] F`
-sending `f` to `λ e, c e • f`. -/
-def smul_rightL (c : E →L[𝕜] 𝕜) : F →L[𝕜] (E →L[𝕜] F) :=
-(c.smul_rightₗ : F →ₗ[𝕜] (E →L[𝕜] F)).mk_continuous _ (λ f, le_of_eq $ c.norm_smul_right_apply f)
+variables (𝕜 E F)
+
+/-- `continuous_linear_map.smul_right` as a continuous trilinear map:
+`smul_rightL (c : E →L[𝕜] 𝕜) (f : F) (x : E) = c x • f`. -/
+def smul_rightL : (E →L[𝕜] 𝕜) →L[𝕜] F →L[𝕜] E →L[𝕜] F :=
+linear_map.mk_continuous₂
+  { to_fun := smul_rightₗ,
+    map_add' := λ c₁ c₂, by { ext x, simp [add_smul] },
+    map_smul' := λ m c, by { ext x, simp [smul_smul] } }
+  1 $ λ c x, by simp
+
+variables {𝕜 E F}
 
 @[simp] lemma norm_smul_rightL_apply (c : E →L[𝕜] 𝕜) (f : F) :
-  ∥c.smul_rightL f∥ = ∥c∥ * ∥f∥ :=
-by simp [continuous_linear_map.smul_rightL, continuous_linear_map.smul_rightₗ]
+  ∥smul_rightL 𝕜 E F c f∥ = ∥c∥ * ∥f∥ :=
+norm_smul_right_apply c f
 
 @[simp] lemma norm_smul_rightL (c : E →L[𝕜] 𝕜) [nontrivial F] :
-  ∥(c.smul_rightL : F →L[𝕜] (E →L[𝕜] F))∥ = ∥c∥ :=
+  ∥smul_rightL 𝕜 E F c∥ = ∥c∥ :=
 continuous_linear_map.homothety_norm _ c.norm_smul_right_apply
+
+/-- Flip the order of arguments of a continuous bilinear map.
+For a version bundled as `linear_isometry_equiv`, see
+`continuous_linear_map.flipL`. -/
+def flip (f : E →L[𝕜] F →L[𝕜] G) : F →L[𝕜] E →L[𝕜] G :=
+linear_map.mk_continuous₂
+  (linear_map.mk₂ 𝕜 (λ y x, f x y) (λ x y z, (f z).map_add x y) (λ c y x, (f x).map_smul c y)
+    (λ z x y, by rw [f.map_add, add_apply]) (λ c y x, by rw [map_smul, smul_apply]))
+  ∥f∥ (λ y x, (f.le_op_norm₂ x y).trans_eq $ by rw mul_right_comm)
+
+private lemma le_norm_flip (f : E →L[𝕜] F →L[𝕜] G) : ∥f∥ ≤ ∥flip f∥ :=
+f.op_norm_le_bound₂ (norm_nonneg _) $ λ x y,
+  by { rw mul_right_comm, exact (flip f).le_op_norm₂ y x }
+
+@[simp] lemma flip_flip (f : E →L[𝕜] F →L[𝕜] G) :
+  f.flip.flip = f :=
+by { ext, refl }
+
+@[simp] lemma op_norm_flip (f : E →L[𝕜] F →L[𝕜] G) :
+  ∥f.flip∥ = ∥f∥ :=
+le_antisymm (by simpa only [flip_flip] using le_norm_flip f.flip) (le_norm_flip f)
+
+@[simp] lemma flip_add (f g : E →L[𝕜] F →L[𝕜] G) :
+  (f + g).flip = f.flip + g.flip :=
+rfl
+
+@[simp] lemma flip_smul (c : 𝕜) (f : E →L[𝕜] F →L[𝕜] G) :
+  (c • f).flip = c • f.flip :=
+rfl
+
+variables (𝕜 E F G)
+
+/-- Flip the order of arguments of a continuous bilinear map.
+This is a version bundled as a `linear_isometry_equiv`.
+For an unbundled version see `continuous_linear_map.flip`. -/
+def flipₗᵢ : (E →L[𝕜] F →L[𝕜] G) ≃ₗᵢ[𝕜] (F →L[𝕜] E →L[𝕜] G) :=
+{ to_fun := flip,
+  inv_fun := flip,
+  map_add' := flip_add,
+  map_smul' := flip_smul,
+  left_inv := flip_flip,
+  right_inv := flip_flip,
+  norm_map' := op_norm_flip }
+
+variables {𝕜 E F G}
+
+@[simp] lemma flipₗᵢ_symm : (flipₗᵢ 𝕜 E F G).symm = flipₗᵢ 𝕜 F E G := rfl
+
+@[simp] lemma coe_flipₗᵢ : ⇑(flipₗᵢ 𝕜 E F G) = flip := rfl
 
 variables (𝕜 F)
 
 /-- The continuous linear map obtained by applying a continuous linear map at a given vector.
 
 This is the continuous version of `linear_map.applyₗ`. -/
-def apply : E →L[𝕜] (E →L[𝕜] F) →L[𝕜] F :=
-linear_map.mk_continuous
-{ to_fun := λ v, linear_map.mk_continuous
-    { to_fun := λ f, f v,
-      map_add' := λ f g, f.add_apply g v,
-      map_smul' := λ x f, f.smul_apply x v }
-    ∥v∥ (λ f, by simpa [mul_comm] using f.le_op_norm v),
-  map_add' := λ _ _, ext $ λ f, f.map_add _ _,
-  map_smul' := λ _ _, ext $ λ f, f.map_smul _ _, }
-1 $ λ x, op_norm_le_bound _ (by simp) (λ f, by simpa [mul_comm] using f.le_op_norm x)
+def apply : E →L[𝕜] (E →L[𝕜] F) →L[𝕜] F := flip (id 𝕜 (E →L[𝕜] F))
 
 variables {𝕜 F}
 


### PR DESCRIPTION
* bundle the first argument of `continuous_linear_map.smul_rightL`;
* add `continuous_linear_map.flip` and `continuous_linear_map.flipₗᵢ`;
* use `flip` to redefine `apply`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->