### PR TITLE
[Merged by Bors] - feat(group_theory/subgroup): prove relation between pointwise product of submonoids/subgroups and their join

### DIFF
--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -473,4 +473,18 @@ begin
   exact s.mul_mem ha hb
 end
 
+@[to_additive]
+lemma closure_mul_le (S T : set M) : closure (S * T) ≤ closure S ⊔ closure T :=
+Inf_le $ λ x ⟨s, t, hs, ht, hx⟩, hx ▸ (closure S ⊔ closure T).mul_mem
+    (le_def.mp le_sup_left $ subset_closure hs)
+    (le_def.mp le_sup_right $ subset_closure ht)
+
+@[to_additive]
+lemma sup_eq_closure (H K : submonoid M) : H ⊔ K = closure (H * K) :=
+le_antisymm
+  (sup_le
+    (λ h hh, subset_closure ⟨h, 1, hh, K.one_mem, mul_one h⟩)
+    (λ k hk, subset_closure ⟨1, k, H.one_mem, hk, one_mul k⟩))
+  (by conv_rhs { rw [← closure_eq H, ← closure_eq K] }; apply closure_mul_le)
+
 end submonoid

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -5,6 +5,7 @@ Authors: Kexing Ying
 -/
 import group_theory.submonoid
 import algebra.group.conj
+import algebra.pointwise
 import order.modular_lattice
 
 /-!
@@ -1375,3 +1376,101 @@ instance : is_modular_lattice (subgroup C) :=
 end⟩
 
 end subgroup
+
+section subgroup_monoid
+
+namespace subgroup
+
+/-- Two subgroups `H` and `K` can be multiplied to form another one. The result
+is the smallest subgroup that contains `{ h * k | h ∈ H, k ∈ K }`. -/
+instance subgroup_mul : has_mul (subgroup G) := ⟨λ H K, closure (H * K)⟩
+
+section inequalities
+
+variables {H K L : subgroup G}
+
+lemma subset_set_mul_left : (H : set G) ⊆ ↑H * ↑K :=
+λ x hx, ⟨x, 1, mem_coe.mpr hx, mem_coe.mpr K.one_mem, mul_one x⟩
+
+lemma le_mul_left : H ≤ H * K :=
+λ x hx, subset_closure $ subset_set_mul_left hx
+
+lemma subset_set_mul_right : (K : set G) ⊆ ↑H * ↑K :=
+λ x hx, ⟨1, x, mem_coe.mpr H.one_mem, mem_coe.mpr hx, one_mul x⟩
+
+lemma le_mul_right : K ≤ H * K :=
+λ x hx, subset_closure $ subset_set_mul_right hx
+
+lemma mul_le : H ≤ L → K ≤ L → H * K ≤ L :=
+λ hH hK, Inf_le $ λ x ⟨h, k, hh, hk, hx⟩, hx ▸ L.mul_mem (hH hh) (hK hk)
+
+end inequalities
+
+protected def mul_normal_aux (H N : subgroup G) [hN : N.normal] : subgroup G :=
+{ carrier := (H : set G) * N,
+  one_mem' := ⟨1, 1, H.one_mem, N.one_mem, by rw mul_one⟩,
+  mul_mem' := λ a b ⟨h, n, hh, hn, ha⟩ ⟨h', n', hh', hn', hb⟩,
+    ⟨h * h', h'⁻¹ * n * h' * n',
+    H.mul_mem hh hh', N.mul_mem (by simpa using hN.conj_mem _ hn h'⁻¹) hn',
+    by simp [← ha, ← hb, mul_assoc]⟩,
+  inv_mem' := λ x ⟨h, n, hh, hn, hx⟩,
+    ⟨h⁻¹, h * n⁻¹ * h⁻¹, H.inv_mem hh, hN.conj_mem _ (N.inv_mem hn) h,
+    by rw [mul_assoc h, inv_mul_cancel_left, ← hx, mul_inv_rev]⟩ }
+
+/-- The carrier of `H * N` is just `↑H * ↑N` when `N` is normal. -/
+lemma mul_normal (H N : subgroup G) [N.normal] : (↑(H * N) : set G) = H * N :=
+set.ext $ λ x,
+  ⟨λ hx, suffices h : H * N ≤ subgroup.mul_normal_aux H N, from h (mem_coe.mp hx),
+    Inf_le (λ y hy, hy),
+  λ hx, subset_closure hx⟩
+
+protected def normal_mul_aux (N H : subgroup G) [hN : N.normal] : subgroup G :=
+{ carrier := (N : set G) * H,
+  one_mem' := ⟨1, 1, N.one_mem, H.one_mem, by rw mul_one⟩,
+  mul_mem' := λ a b ⟨n, h, hn, hh, ha⟩ ⟨n', h', hn', hh', hb⟩,
+    ⟨n * (h * n' * h⁻¹), h * h',
+    N.mul_mem hn (hN.conj_mem _ hn' _), H.mul_mem hh hh',
+    by simp [← ha, ← hb, mul_assoc]⟩,
+  inv_mem' := λ x ⟨n, h, hn, hh, hx⟩,
+    ⟨h⁻¹ * n⁻¹ * h, h⁻¹,
+    by simpa using hN.conj_mem _ (N.inv_mem hn) h⁻¹, H.inv_mem hh,
+    by rw [mul_inv_cancel_right, ← mul_inv_rev, hx]⟩ }
+
+/-- The carrier of `N * H` is just `↑N * ↑H` when `N` is normal. -/
+lemma normal_mul (N H : subgroup G) [N.normal] : (↑(N * H) : set G) = N * H :=
+set.ext $ λ x,
+  ⟨λ hx, suffices h : N * H ≤ subgroup.normal_mul_aux N H, from h (mem_coe.mp hx),
+    Inf_le (λ y hy, hy),
+  λ hx, subset_closure hx⟩
+
+lemma mul_mul (H K L : subgroup G) : H * K * L = closure (H * K * L) :=
+le_antisymm
+  (le_Inf $ λ A hA, mul_le
+    (Inf_le $ λ hk hhk, hA $ ⟨hk, 1, hhk, L.one_mem, mul_one hk⟩)
+    (λ l hl, hA $ ⟨1, l, ⟨1, 1, H.one_mem, K.one_mem, mul_one 1⟩, hl, one_mul l⟩))
+  (Inf_le $ set.subset.trans (set.mul_subset_mul subset_closure $ set.subset.refl _) subset_closure)
+
+protected lemma mul_assoc (H K L : subgroup G) : H * K * L = H * (K * L) :=
+suffices h : H * (K * L) = closure (H * (K * L)), by rw [mul_mul, h, mul_assoc],
+le_antisymm
+  (le_Inf $ λ A hA, mul_le
+    (λ h hh, hA $ ⟨h, 1, hh, ⟨1, 1, K.one_mem, L.one_mem, mul_one 1⟩, mul_one h⟩)
+    (Inf_le $ λ kl hkl, hA $ ⟨1, kl, H.one_mem, hkl, one_mul kl⟩))
+  (Inf_le $ set.subset.trans (set.mul_subset_mul (set.subset.refl _) subset_closure) subset_closure)
+
+
+/-- Subgroups form a monoid under multiplication. -/
+instance : monoid (subgroup G) :=
+{ mul := (*),
+  mul_assoc := subgroup.mul_assoc,
+  one := ⊥ ,
+  one_mul := λ H, ext' $ eq.trans (normal_mul _ _) $ set.ext $ λ x,
+    ⟨λ ⟨a, b, ha, hb, hx⟩, by simpa [← hx, mem_bot.mp ha],
+    λ hx, ⟨1, x, mem_coe.mpr $ one_mem ⊥, hx, one_mul x⟩⟩,
+  mul_one := λ H, ext' $ eq.trans (mul_normal _ _) $ set.ext $ λ x,
+    ⟨λ ⟨a, b, ha, hb, hx⟩, by simpa [← hx, mem_bot.mp hb],
+    λ hx, ⟨x, 1, hx, mem_coe.mpr $ one_mem ⊥, mul_one x⟩⟩ }
+
+end subgroup
+
+end subgroup_monoid

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1382,17 +1382,21 @@ section pointwise
 namespace subgroup
 
 @[to_additive]
+lemma closure_mul_le (S T : set G) : closure (S * T) ≤ closure S ⊔ closure T :=
+Inf_le $ λ x ⟨s, t, hs, ht, hx⟩, hx ▸ (closure S ⊔ closure T).mul_mem
+    (le_def.mp le_sup_left $ subset_closure hs)
+    (le_def.mp le_sup_right $ subset_closure ht)
+
+@[to_additive]
 lemma sup_eq_closure (H K : subgroup G) : H ⊔ K = closure (H * K) :=
 le_antisymm
   (sup_le
     (λ h hh, subset_closure ⟨h, 1, hh, K.one_mem, mul_one h⟩)
     (λ k hk, subset_closure ⟨1, k, H.one_mem, hk, one_mul k⟩))
-  (Inf_le $ λ x ⟨h, k, hh, hk, hx⟩, hx ▸ (H ⊔ K).mul_mem
-    (le_def.mp le_sup_left hh)
-    (le_def.mp le_sup_right hk))
+  (by conv_rhs { rw [← closure_eq H, ← closure_eq K] }; apply closure_mul_le)
 
 @[to_additive]
-protected def mul_normal_aux (H N : subgroup G) [hN : N.normal] : subgroup G :=
+private def mul_normal_aux (H N : subgroup G) [hN : N.normal] : subgroup G :=
 { carrier := (H : set G) * N,
   one_mem' := ⟨1, 1, H.one_mem, N.one_mem, by rw mul_one⟩,
   mul_mem' := λ a b ⟨h, n, hh, hn, ha⟩ ⟨h', n', hh', hn', hb⟩,
@@ -1408,12 +1412,12 @@ protected def mul_normal_aux (H N : subgroup G) [hN : N.normal] : subgroup G :=
 when `N` is normal."]
 lemma mul_normal (H N : subgroup G) [N.normal] : (↑(H ⊔ N) : set G) = H * N :=
 set.subset.antisymm
-  (show H ⊔ N ≤ subgroup.mul_normal_aux H N,
+  (show H ⊔ N ≤ mul_normal_aux H N,
     by { rw sup_eq_closure, apply Inf_le _, dsimp, refl })
   ((sup_eq_closure H N).symm ▸ subset_closure)
 
 @[to_additive]
-protected def normal_mul_aux (N H : subgroup G) [hN : N.normal] : subgroup G :=
+private def normal_mul_aux (N H : subgroup G) [hN : N.normal] : subgroup G :=
 { carrier := (N : set G) * H,
   one_mem' := ⟨1, 1, N.one_mem, H.one_mem, by rw mul_one⟩,
   mul_mem' := λ a b ⟨n, h, hn, hh, ha⟩ ⟨n', h', hn', hh', hb⟩,
@@ -1430,7 +1434,7 @@ protected def normal_mul_aux (N H : subgroup G) [hN : N.normal] : subgroup G :=
 when `N` is normal."]
 lemma normal_mul (N H : subgroup G) [N.normal] : (↑(N ⊔ H) : set G) = N * H :=
 set.subset.antisymm
-  (show N ⊔ H ≤ subgroup.normal_mul_aux N H,
+  (show N ⊔ H ≤ normal_mul_aux N H,
     by { rw sup_eq_closure, apply Inf_le _, dsimp, refl })
   ((sup_eq_closure N H).symm ▸ subset_closure)
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1381,6 +1381,7 @@ section pointwise
 
 namespace subgroup
 
+@[to_additive]
 lemma sup_eq_closure (H K : subgroup G) : H ⊔ K = closure (H * K) :=
 le_antisymm
   (sup_le
@@ -1390,7 +1391,8 @@ le_antisymm
     (le_def.mp le_sup_left hh)
     (le_def.mp le_sup_right hk))
 
-protected def sup_normal_aux (H N : subgroup G) [hN : N.normal] : subgroup G :=
+@[to_additive]
+protected def mul_normal_aux (H N : subgroup G) [hN : N.normal] : subgroup G :=
 { carrier := (H : set G) * N,
   one_mem' := ⟨1, 1, H.one_mem, N.one_mem, by rw mul_one⟩,
   mul_mem' := λ a b ⟨h, n, hh, hn, ha⟩ ⟨h', n', hh', hn', hb⟩,
@@ -1402,12 +1404,15 @@ protected def sup_normal_aux (H N : subgroup G) [hN : N.normal] : subgroup G :=
     by rw [mul_assoc h, inv_mul_cancel_left, ← hx, mul_inv_rev]⟩ }
 
 /-- The carrier of `H ⊔ N` is just `↑H * ↑N` (pointwise set product) when `N` is normal. -/
+@[to_additive "The carrier of `H ⊔ N` is just `↑H + ↑N` (pointwise set addition)
+when `N` is normal."]
 lemma mul_normal (H N : subgroup G) [N.normal] : (↑(H ⊔ N) : set G) = H * N :=
 set.subset.antisymm
-  (show H ⊔ N ≤ subgroup.sup_normal_aux H N,
+  (show H ⊔ N ≤ subgroup.mul_normal_aux H N,
     by { rw sup_eq_closure, apply Inf_le _, dsimp, refl })
   ((sup_eq_closure H N).symm ▸ subset_closure)
 
+@[to_additive]
 protected def normal_mul_aux (N H : subgroup G) [hN : N.normal] : subgroup G :=
 { carrier := (N : set G) * H,
   one_mem' := ⟨1, 1, N.one_mem, H.one_mem, by rw mul_one⟩,
@@ -1421,6 +1426,8 @@ protected def normal_mul_aux (N H : subgroup G) [hN : N.normal] : subgroup G :=
     by rw [mul_inv_cancel_right, ← mul_inv_rev, hx]⟩ }
 
 /-- The carrier of `N ⊔ H` is just `↑N * ↑H` (pointwise set product) when `N` is normal. -/
+@[to_additive "The carrier of `N ⊔ H` is just `↑N + ↑H` (pointwise set addition)
+when `N` is normal."]
 lemma normal_mul (N H : subgroup G) [N.normal] : (↑(N ⊔ H) : set G) = N * H :=
 set.subset.antisymm
   (show N ⊔ H ≤ subgroup.normal_mul_aux N H,

--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl, Kenny Lau, Johan Commelin, Mario Carneiro, Kevin Buzza
 Amelia Livingston, Yury Kudryashov
 -/
 import data.set.lattice
-import algebra.pointwise
 
 /-!
 # Submonoids: definition and `complete_lattice` structure
@@ -429,25 +428,3 @@ add_decl_doc add_monoid_hom.of_mdense
 attribute [norm_cast] coe_of_mdense add_monoid_hom.coe_of_mdense
 
 end monoid_hom
-
-section pointwise
-
-namespace submonoid
-
-@[to_additive]
-lemma closure_mul_le (S T : set M) : closure (S * T) ≤ closure S ⊔ closure T :=
-Inf_le $ λ x ⟨s, t, hs, ht, hx⟩, hx ▸ (closure S ⊔ closure T).mul_mem
-    (le_def.mp le_sup_left $ subset_closure hs)
-    (le_def.mp le_sup_right $ subset_closure ht)
-
-@[to_additive]
-lemma sup_eq_closure (H K : submonoid M) : H ⊔ K = closure (H * K) :=
-le_antisymm
-  (sup_le
-    (λ h hh, subset_closure ⟨h, 1, hh, K.one_mem, mul_one h⟩)
-    (λ k hk, subset_closure ⟨1, k, H.one_mem, hk, one_mul k⟩))
-  (by conv_rhs { rw [← closure_eq H, ← closure_eq K] }; apply closure_mul_le)
-
-end submonoid
-
-end pointwise

--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Kenny Lau, Johan Commelin, Mario Carneiro, Kevin Buzza
 Amelia Livingston, Yury Kudryashov
 -/
 import data.set.lattice
+import algebra.pointwise
 
 /-!
 # Submonoids: definition and `complete_lattice` structure
@@ -428,3 +429,25 @@ add_decl_doc add_monoid_hom.of_mdense
 attribute [norm_cast] coe_of_mdense add_monoid_hom.coe_of_mdense
 
 end monoid_hom
+
+section pointwise
+
+namespace submonoid
+
+@[to_additive]
+lemma closure_mul_le (S T : set M) : closure (S * T) ≤ closure S ⊔ closure T :=
+Inf_le $ λ x ⟨s, t, hs, ht, hx⟩, hx ▸ (closure S ⊔ closure T).mul_mem
+    (le_def.mp le_sup_left $ subset_closure hs)
+    (le_def.mp le_sup_right $ subset_closure ht)
+
+@[to_additive]
+lemma sup_eq_closure (H K : submonoid M) : H ⊔ K = closure (H * K) :=
+le_antisymm
+  (sup_le
+    (λ h hh, subset_closure ⟨h, 1, hh, K.one_mem, mul_one h⟩)
+    (λ k hk, subset_closure ⟨1, k, H.one_mem, hk, one_mul k⟩))
+  (by conv_rhs { rw [← closure_eq H, ← closure_eq K] }; apply closure_mul_le)
+
+end submonoid
+
+end pointwise


### PR DESCRIPTION
If `H` and `K` are subgroups/submonoids then `H ⊔ K = closure (H * K)`, where `H * K` is the pointwise set product. When `H` or `K` is a normal subgroup, it is proved that `(↑(H ⊔ K) : set G) = H * K`.

<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
