### PR TITLE
[Merged by Bors] - doc(analysis/analytic/inverse): fix mathjax output

### DIFF
--- a/src/analysis/analytic/basic.lean
+++ b/src/analysis/analytic/basic.lean
@@ -624,11 +624,11 @@ end
 If a function is analytic in a disk `D(x, R)`, then it is analytic in any disk contained in that
 one. Indeed, one can write
 $$
-f (x + y + z) = \sum_{n} p_n (y + z)^n = \sum_{n, k} \binom{n}{k} p_n y^{n-k} z^k
-= \sum_{k} \Bigl(\sum_{n} \binom{n}{k} p_n y^{n-k}\Bigr) z^k.
+f (x + y + z) = \\sum_{n} p_n (y + z)^n = \\sum_{n, k} \binom{n}{k} p_n y^{n-k} z^k
+= \\sum_{k} \Bigl(\\sum_{n} \binom{n}{k} p_n y^{n-k}\Bigr) z^k.
 $$
 The corresponding power series has thus a `k`-th coefficient equal to
-$\sum_{n} \binom{n}{k} p_n y^{n-k}$. In the general case where `pₙ` is a multilinear map, this has
+$\\sum_{n} \binom{n}{k} p_n y^{n-k}$. In the general case where `pₙ` is a multilinear map, this has
 to be interpreted suitably: instead of having a binomial coefficient, one should sum over all
 possible subsets `s` of `fin n` of cardinal `k`, and attribute `z` to the indices in `s` and
 `y` to the indices outside of `s`.

--- a/src/analysis/analytic/composition.lean
+++ b/src/analysis/analytic/composition.lean
@@ -819,7 +819,7 @@ let ⟨q, hq⟩ := hg, ⟨p, hp⟩ := hf in (hq.comp hp).analytic_at
 /-!
 ### Associativity of the composition of formal multilinear series
 
-In this paragraph, we us prove the associativity of the composition of formal power series.
+In this paragraph, we prove the associativity of the composition of formal power series.
 By definition,
 ```
 (r.comp q).comp p n v

--- a/src/analysis/analytic/inverse.lean
+++ b/src/analysis/analytic/inverse.lean
@@ -304,9 +304,9 @@ $$
 \begin{align}
 Q(z) & := \sum Q_n z^n = Q_1 z + C' \sum_{2 \leq k \leq n} \sum_{i_1 + \dotsc + i_k = n}
   (r z^{i_1} Q_{i_1}) \dotsm (r z^{i_k} Q_{i_k})
-\\ & = Q_1 z + C' \sum_{k = 2}^\infty (\sum_{i_1 \geq 1} r z^{i_1} Q_{i_1})
+\\\\ & = Q_1 z + C' \sum_{k = 2}^\infty (\sum_{i_1 \geq 1} r z^{i_1} Q_{i_1})
   \dotsm (\sum_{i_k \geq 1} r z^{i_k} Q_{i_k})
-\\ & = Q_1 z + C' \sum_{k = 2}^\infty (r Q(z))^k
+\\\\ & = Q_1 z + C' \sum_{k = 2}^\infty (r Q(z))^k
 = Q_1 z + C' (r Q(z))^2 / (1 - r Q(z)).
 \end{align}
 $$

--- a/src/analysis/analytic/inverse.lean
+++ b/src/analysis/analytic/inverse.lean
@@ -304,9 +304,9 @@ $$
 \begin{align*}
 Q(z) & := \sum Q_n z^n = Q_1 z + C' \sum_{2 \leq k \leq n} \sum_{i_1 + \dotsc + i_k = n}
   (r z^{i_1} Q_{i_1}) \dotsm (r z^{i_k} Q_{i_k})
-\\& = Q_1 z + C' \sum_{k = 2}^\infty (\sum_{i_1 \geq 1} r z^{i_1} Q_{i_1})
+\\ & = Q_1 z + C' \sum_{k = 2}^\infty (\sum_{i_1 \geq 1} r z^{i_1} Q_{i_1})
   \dotsm (\sum_{i_k \geq 1} r z^{i_k} Q_{i_k})
-\\& = Q_1 z + C' \sum_{k = 2}^\infty (r Q(z))^k
+\\ & = Q_1 z + C' \sum_{k = 2}^\infty (r Q(z))^k
 = Q_1 z + C' (r Q(z))^2 / (1 - r Q(z)).
 \end{align*}
 $$

--- a/src/analysis/analytic/inverse.lean
+++ b/src/analysis/analytic/inverse.lean
@@ -301,14 +301,14 @@ However, assuming that the inequality above were an equality, one could get a fo
 generating series of the `Qₙ`:
 
 $$
-\begin{align*}
+\begin{align}
 Q(z) & := \sum Q_n z^n = Q_1 z + C' \sum_{2 \leq k \leq n} \sum_{i_1 + \dotsc + i_k = n}
   (r z^{i_1} Q_{i_1}) \dotsm (r z^{i_k} Q_{i_k})
 \\ & = Q_1 z + C' \sum_{k = 2}^\infty (\sum_{i_1 \geq 1} r z^{i_1} Q_{i_1})
   \dotsm (\sum_{i_k \geq 1} r z^{i_k} Q_{i_k})
 \\ & = Q_1 z + C' \sum_{k = 2}^\infty (r Q(z))^k
 = Q_1 z + C' (r Q(z))^2 / (1 - r Q(z)).
-\end{align*}
+\end{align}
 $$
 
 One can solve this formula explicitly. The solution is analytic in a neighborhood of `0` in `ℂ`,


### PR DESCRIPTION
`\\` in source code is converted to `\` in the generated html file, so one should have `\\\\` to generate proper line break for mathjax.
