### PR TITLE
[Merged by Bors] - refactor(algebra/lie/of_associative): remove `ring_commutator` namespace; use `ring` instead

### DIFF
--- a/src/algebra/lie/of_associative.lean
+++ b/src/algebra/lie/of_associative.lean
@@ -37,28 +37,28 @@ section of_associative
 
 variables {A : Type v} [ring A]
 
-namespace ring_commutator
+namespace ring
 
 /-- The bracket operation for rings is the ring commutator, which captures the extent to which a
 ring is commutative. It is identically zero exactly when the ring is commutative. -/
 @[priority 100]
 instance : has_bracket A A := ⟨λ x y, x*y - y*x⟩
 
-lemma commutator (x y : A) : ⁅x, y⁆ = x*y - y*x := rfl
+lemma has_bracket_def (x y : A) : ⁅x, y⁆ = x*y - y*x := rfl
 
-end ring_commutator
+end ring
 
 namespace lie_ring
 
 /-- An associative ring gives rise to a Lie ring by taking the bracket to be the ring commutator. -/
 @[priority 100]
 instance of_associative_ring : lie_ring A :=
-{ add_lie      := by simp only [ring_commutator.commutator, right_distrib, left_distrib,
+{ add_lie      := by simp only [ring.has_bracket_def, right_distrib, left_distrib,
     sub_eq_add_neg, add_comm, add_left_comm, forall_const, eq_self_iff_true, neg_add_rev],
-  lie_add      := by simp only [ring_commutator.commutator, right_distrib, left_distrib,
+  lie_add      := by simp only [ring.has_bracket_def, right_distrib, left_distrib,
     sub_eq_add_neg, add_comm, add_left_comm, forall_const, eq_self_iff_true, neg_add_rev],
-  lie_self     := by simp only [ring_commutator.commutator, forall_const, sub_self],
-  leibniz_lie  := λ x y z, by { repeat {rw ring_commutator.commutator}, noncomm_ring, } }
+  lie_self     := by simp only [ring.has_bracket_def, forall_const, sub_self],
+  leibniz_lie  := λ x y z, by { repeat { rw ring.has_bracket_def }, noncomm_ring, } }
 
 lemma of_associative_ring_bracket (x y : A) : ⁅x, y⁆ = x*y - y*x := rfl
 

--- a/src/algebra/lie/of_associative.lean
+++ b/src/algebra/lie/of_associative.lean
@@ -44,7 +44,7 @@ ring is commutative. It is identically zero exactly when the ring is commutative
 @[priority 100]
 instance : has_bracket A A := ⟨λ x y, x*y - y*x⟩
 
-lemma has_bracket_def (x y : A) : ⁅x, y⁆ = x*y - y*x := rfl
+lemma lie_def (x y : A) : ⁅x, y⁆ = x*y - y*x := rfl
 
 end ring
 
@@ -53,12 +53,12 @@ namespace lie_ring
 /-- An associative ring gives rise to a Lie ring by taking the bracket to be the ring commutator. -/
 @[priority 100]
 instance of_associative_ring : lie_ring A :=
-{ add_lie      := by simp only [ring.has_bracket_def, right_distrib, left_distrib,
+{ add_lie      := by simp only [ring.lie_def, right_distrib, left_distrib,
     sub_eq_add_neg, add_comm, add_left_comm, forall_const, eq_self_iff_true, neg_add_rev],
-  lie_add      := by simp only [ring.has_bracket_def, right_distrib, left_distrib,
+  lie_add      := by simp only [ring.lie_def, right_distrib, left_distrib,
     sub_eq_add_neg, add_comm, add_left_comm, forall_const, eq_self_iff_true, neg_add_rev],
-  lie_self     := by simp only [ring.has_bracket_def, forall_const, sub_self],
-  leibniz_lie  := λ x y z, by { repeat { rw ring.has_bracket_def }, noncomm_ring, } }
+  lie_self     := by simp only [ring.lie_def, forall_const, sub_self],
+  leibniz_lie  := λ x y z, by { repeat { rw ring.lie_def, }, noncomm_ring, } }
 
 lemma of_associative_ring_bracket (x y : A) : ⁅x, y⁆ = x*y - y*x := rfl
 

--- a/src/algebra/lie/semisimple.lean
+++ b/src/algebra/lie/semisimple.lean
@@ -39,6 +39,7 @@ namespace lie_algebra
 variables (R : Type u) (L : Type v)
 variables [comm_ring R] [lie_ring L] [lie_algebra R L]
 
+set_option old_structure_cmd true
 /-- A Lie algebra is simple if it is irreducible as a Lie module over itself via the adjoint
 action, and it is non-Abelian. -/
 class is_simple extends lie_module.is_irreducible R L L : Prop :=
@@ -77,7 +78,7 @@ instance is_semisimple_of_is_simple [h : is_simple R L] : is_semisimple R L :=
 begin
   rw is_semisimple_iff_no_abelian_ideals,
   intros I hI,
-  tactic.unfreeze_local_instances, obtain ⟨⟨h₁⟩, h₂⟩ := h,
+  tactic.unfreeze_local_instances, obtain ⟨h₁, h₂⟩ := h,
   by_contradiction contra,
   rw [h₁ I contra, lie_abelian_iff_equiv_lie_abelian top_equiv_self] at hI,
   exact h₂ hI,

--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -159,7 +159,7 @@ variables (D : derivation R A A) {D1 D2 : derivation R A A} (r : R) (a b : A)
 /-- The commutator of derivations is again a derivation. -/
 def commutator (D1 D2 : derivation R A A) : derivation R A A :=
 { leibniz' := λ a b, by
-  { simp only [ring.has_bracket_def, map_add, id.smul_eq_mul, linear_map.mul_app, leibniz,
+  { simp only [ring.lie_def, map_add, id.smul_eq_mul, linear_map.mul_app, leibniz,
                linear_map.to_fun_eq_coe, coe_fn_coe, linear_map.sub_apply], ring, },
   ..⁅(D1 : module.End R A), (D2 : module.End R A)⁆, }
 

--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -156,12 +156,10 @@ section lie_structures
 
 variables (D : derivation R A A) {D1 D2 : derivation R A A} (r : R) (a b : A)
 
-open ring_commutator
-
 /-- The commutator of derivations is again a derivation. -/
 def commutator (D1 D2 : derivation R A A) : derivation R A A :=
 { leibniz' := λ a b, by
-  { simp only [commutator, map_add, id.smul_eq_mul, linear_map.mul_app, leibniz,
+  { simp only [ring.has_bracket_def, map_add, id.smul_eq_mul, linear_map.mul_app, leibniz,
                linear_map.to_fun_eq_coe, coe_fn_coe, linear_map.sub_apply], ring, },
   ..⁅(D1 : module.End R A), (D2 : module.End R A)⁆, }
 


### PR DESCRIPTION
The `old_structure_cmd` change to `lie_algebra.is_simple` is unrelated and is
included here only for convenience.

`ring_commutator.commutator` -> `ring.lie_def`

---
These are the final bits of refactoring that I wanted to do for Lie theory.