### PR TITLE
[Merged by Bors] - fix(topology/topological_fiber_bundle): fix definition, review

### DIFF
--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -105,81 +105,113 @@ Fiber bundle, topological bundle, vector bundle, local trivialization, structure
 
 variables {ι : Type*} {B : Type*} {F : Type*}
 
-open topological_space set
+open topological_space filter set
 open_locale topological_space
 
 section topological_fiber_bundle
 
-variables {Z : Type*} [topological_space B] [topological_space Z]
-  [topological_space F] (proj : Z → B)
-
-variable (F)
+variables (F) {Z : Type*} [topological_space B] [topological_space Z]
+  [topological_space F] {proj : Z → B}
 
 /--
 A structure extending local homeomorphisms, defining a local trivialization of a projection
 `proj : Z → B` with fiber `F`, as a local homeomorphism between `Z` and `B × F` defined between two
 sets of the form `proj ⁻¹' base_set` and `base_set × F`, acting trivially on the first coordinate.
 -/
-structure bundle_trivialization extends local_homeomorph Z (B × F) :=
+structure bundle_trivialization (proj : Z → B) extends local_homeomorph Z (B × F) :=
 (base_set      : set B)
 (open_base_set : is_open base_set)
 (source_eq     : source = proj ⁻¹' base_set)
 (target_eq     : target = set.prod base_set univ)
-(proj_to_fun   : ∀ p ∈ source, (to_fun p).1 = proj p)
+(proj_to_fun   : ∀ p ∈ source, (to_local_homeomorph p).1 = proj p)
 
 instance : has_coe_to_fun (bundle_trivialization F proj) := ⟨_, λ e, e.to_fun⟩
 
-@[simp, mfld_simps] lemma bundle_trivialization.coe_coe (e : bundle_trivialization F proj) (x : Z) :
-  e.to_local_homeomorph x = e x := rfl
+variable {F}
 
-@[simp, mfld_simps] lemma bundle_trivialization.coe_mk (e : local_homeomorph Z (B × F)) (i j k l m) (x : Z) :
+@[simp, mfld_simps] lemma bundle_trivialization.coe_coe (e : bundle_trivialization F proj) :
+  ⇑e.to_local_homeomorph = e := rfl
+
+@[simp, mfld_simps] lemma bundle_trivialization.coe_mk
+  (e : local_homeomorph Z (B × F)) (i j k l m) (x : Z) :
   (bundle_trivialization.mk e i j k l m : bundle_trivialization F proj) x = e x := rfl
+
+variable (F)
 
 /-- A topological fiber bundle with fiber F over a base B is a space projecting on B for which the
 fibers are all homeomorphic to F, such that the local situation around each point is a direct
 product. -/
-def is_topological_fiber_bundle : Prop :=
-∀ x : Z, ∃e : bundle_trivialization F proj, x ∈ e.source
+def is_topological_fiber_bundle (proj : Z → B) : Prop :=
+∀ x : B, ∃e : bundle_trivialization F proj, x ∈ e.base_set
 
-variables {F} {proj}
+def is_trivial_topological_fiber_bundle (proj : Z → B) : Prop :=
+∃ e : Z ≃ₜ (B × F), ∀ x, (e x).1 = proj x
+
+variables {F}
+
+lemma bundle_trivialization.mem_source (e : bundle_trivialization F proj)
+  {x : Z} : x ∈ e.source ↔ proj x ∈ e.base_set :=
+by rw [e.source_eq, mem_preimage]
+
+lemma bundle_trivialization.mem_target (e : bundle_trivialization F proj)
+  {x : B × F} : x ∈ e.target ↔ x.1 ∈ e.base_set :=
+by rw [e.target_eq, prod_univ, mem_preimage]
 
 @[simp, mfld_simps] lemma bundle_trivialization.coe_fst (e : bundle_trivialization F proj) {x : Z}
   (ex : x ∈ e.source) : (e x).1 = proj x :=
 e.proj_to_fun x ex
 
+lemma bundle_trivialization.coe_fst' (e : bundle_trivialization F proj) {x : Z}
+  (ex : proj x ∈ e.base_set) : (e x).1 = proj x :=
+e.coe_fst (e.mem_source.2 ex)
+
+lemma bundle_trivialization.proj_symm_apply (e : bundle_trivialization F proj) {x : B × F}
+  (hx : x ∈ e.target) : proj (e.to_local_homeomorph.symm x) = x.1 :=
+begin
+  have := (e.coe_fst (e.to_local_homeomorph.map_target hx)).symm,
+  rwa [← e.coe_coe, e.to_local_homeomorph.right_inv hx] at this
+end
+
+lemma bundle_trivialization.proj_symm_apply' (e : bundle_trivialization F proj) {b : B} {x : F}
+  (hx : b ∈ e.base_set) : proj (e.to_local_homeomorph.symm (b, x)) = b :=
+e.proj_symm_apply (e.mem_target.2 hx)
+
+lemma bundle_trivialization.apply_symm_apply (e : bundle_trivialization F proj)
+  {x : B × F} (hx : x ∈ e.target) : e (e.to_local_homeomorph.symm x) = x :=
+e.to_local_homeomorph.right_inv hx
+
+lemma bundle_trivialization.apply_symm_apply' (e : bundle_trivialization F proj)
+  {b : B} {x : F} (hx : b ∈ e.base_set) : e (e.to_local_homeomorph.symm (b, x)) = (b, x) :=
+e.apply_symm_apply (e.mem_target.2 hx)
+
+@[simp, mfld_simps] lemma bundle_trivialization.symm_apply_mk_proj
+  (e : bundle_trivialization F proj) {x : Z} (ex : x ∈ e.source) :
+  e.to_local_homeomorph.symm (proj x, (e x).2) = x :=
+by rw [← e.coe_fst ex, prod.mk.eta, ← e.coe_coe, e.to_local_homeomorph.left_inv ex]
+
+lemma bundle_trivialization.coe_fst_eventually_eq_proj (e : bundle_trivialization F proj)
+  {x : Z} (ex : x ∈ e.source) : prod.fst ∘ e =ᶠ[𝓝 x] proj  :=
+mem_nhds_sets_iff.2 ⟨e.source, λ y hy, e.coe_fst hy, e.open_source, ex⟩
+
+lemma bundle_trivialization.coe_fst_eventually_eq_proj' (e : bundle_trivialization F proj)
+  {x : Z} (ex : proj x ∈ e.base_set) : prod.fst ∘ e =ᶠ[𝓝 x] proj  :=
+e.coe_fst_eventually_eq_proj (e.mem_source.2 ex)
+
+lemma is_trivial_topological_fiber_bundle.is_topological_fiber_bundle
+  (h : is_trivial_topological_fiber_bundle F proj) :
+  is_topological_fiber_bundle F proj :=
+let ⟨e, he⟩ := h in λ x,
+⟨⟨e.to_local_homeomorph, univ, is_open_univ, rfl, univ_prod_univ.symm, λ x _, he x⟩, mem_univ x⟩
+
+lemma bundle_trivialization.map_proj_nhds (e : bundle_trivialization F proj) {x : Z}
+  (ex : x ∈ e.source) : map proj (𝓝 x) = 𝓝 (proj x) :=
+by rw [← e.coe_fst ex, ← map_congr (e.coe_fst_eventually_eq_proj ex), ← map_map, ← e.coe_coe,
+  e.to_local_homeomorph.map_nhds_eq ex, map_fst_nhds]
+
 /-- In the domain of a bundle trivialization, the projection is continuous-/
 lemma bundle_trivialization.continuous_at_proj (e : bundle_trivialization F proj) {x : Z}
   (ex : x ∈ e.source) : continuous_at proj x :=
-begin
-  assume s hs,
-  obtain ⟨t, st, t_open, xt⟩ : ∃ t ⊆ s, is_open t ∧ proj x ∈ t,
-    from mem_nhds_sets_iff.1 hs,
-  rw e.source_eq at ex,
-  let u := e.base_set ∩ t,
-  have u_open : is_open u := is_open_inter e.open_base_set t_open,
-  have xu : proj x ∈ u := ⟨ex, xt⟩,
-  /- Take a small enough open neighborhood u of `proj x`, contained in a trivialization domain o.
-    One should show that its preimage is open. -/
-  suffices : is_open (proj ⁻¹' u),
-  { have : proj ⁻¹' u ∈ 𝓝 x := mem_nhds_sets this xu,
-    apply filter.mem_sets_of_superset this,
-    exact preimage_mono (subset.trans (inter_subset_right _ _) st) },
-  -- to do this, rewrite `proj ⁻¹' u` in terms of the trivialization, and use its continuity.
-  have : proj ⁻¹' u = e ⁻¹' (set.prod u univ) ∩ e.source,
-  { ext p,
-    split,
-    { assume h,
-      have : p ∈ e.source,
-      { rw e.source_eq,
-        have : u ⊆ e.base_set := inter_subset_left _ _,
-        exact preimage_mono this h },
-      simp [this, h.1, h.2], },
-    { rintros ⟨h, h_source⟩,
-      simpa [h_source] using h } },
-  rw [this, inter_comm],
-  exact continuous_on.preimage_open_of_open e.continuous_to_fun e.open_source
-    (u_open.prod is_open_univ)
-end
+(e.map_proj_nhds ex).le
 
 /-- The projection from a topological fiber bundle to its base is continuous. -/
 lemma is_topological_fiber_bundle.continuous_proj (h : is_topological_fiber_bundle F proj) :
@@ -187,53 +219,118 @@ lemma is_topological_fiber_bundle.continuous_proj (h : is_topological_fiber_bund
 begin
   rw continuous_iff_continuous_at,
   assume x,
-  rcases h x with ⟨e, ex⟩,
-  exact e.continuous_at_proj ex
+  rcases h (proj x) with ⟨e, ex⟩,
+  apply e.continuous_at_proj,
+  rwa e.source_eq
 end
 
 /-- The projection from a topological fiber bundle to its base is an open map. -/
 lemma is_topological_fiber_bundle.is_open_map_proj (h : is_topological_fiber_bundle F proj) :
   is_open_map proj :=
 begin
-  assume s hs,
-  rw is_open_iff_forall_mem_open,
-  assume x xs,
-  obtain ⟨y, ys, yx⟩ : ∃ y, y ∈ s ∧ proj y = x, from (mem_image _ _ _).1 xs,
-  obtain ⟨e, he⟩ : ∃ (e : bundle_trivialization F proj), y ∈ e.source, from h y,
-  refine ⟨proj '' (s ∩ e.source), image_subset _ (inter_subset_left _ _), _, ⟨y, ⟨ys, he⟩, yx⟩⟩,
-  have : ∀z ∈ s ∩ e.source, prod.fst (e z) = proj z := λz hz, e.proj_to_fun z hz.2,
-  rw [← image_congr this, image_comp],
-  have : is_open (e '' (s ∩ e.source)) :=
-    e.to_local_homeomorph.image_open_of_open (is_open_inter hs e.to_local_homeomorph.open_source)
-    (inter_subset_right _ _),
-  exact is_open_map_fst _ this
+  refine is_open_map_iff_nhds_le.2 (λ x, _),
+  rcases h (proj x) with ⟨e, ex⟩,
+  refine (e.map_proj_nhds _).ge,
+  rwa e.source_eq
 end
+
+/-- The first projection in a product is a trivial topological fiber bundle. -/
+lemma is_trivial_topological_fiber_bundle_fst :
+  is_trivial_topological_fiber_bundle F (prod.fst : B × F → B) :=
+⟨homeomorph.refl _, λ x, rfl⟩
 
 /-- The first projection in a product is a topological fiber bundle. -/
 lemma is_topological_fiber_bundle_fst : is_topological_fiber_bundle F (prod.fst : B × F → B) :=
-begin
-  let F : bundle_trivialization F (prod.fst : B × F → B) :=
-  { base_set      := univ,
-    open_base_set := is_open_univ,
-    source_eq     := rfl,
-    target_eq     := by simp,
-    proj_to_fun   := by simp,
-     ..local_homeomorph.refl _ },
-  exact λx, ⟨F, by simp⟩
-end
+is_trivial_topological_fiber_bundle_fst.is_topological_fiber_bundle
+
+/-- The second projection in a product is a trivial topological fiber bundle. -/
+lemma is_trivial_topological_fiber_bundle_snd :
+  is_trivial_topological_fiber_bundle F (prod.snd : F × B → B) :=
+⟨homeomorph.prod_comm _ _, λ x, rfl⟩
 
 /-- The second projection in a product is a topological fiber bundle. -/
 lemma is_topological_fiber_bundle_snd : is_topological_fiber_bundle F (prod.snd : F × B → B) :=
-begin
-  let F : bundle_trivialization F (prod.snd : F × B → B) :=
-  { base_set      := univ,
-    open_base_set := is_open_univ,
-    source_eq     := rfl,
-    target_eq     := by simp,
-    proj_to_fun   := λp, by { simp, refl },
-     ..(homeomorph.prod_comm F B).to_local_homeomorph },
-  exact λx, ⟨F, by simp⟩
-end
+is_trivial_topological_fiber_bundle_snd.is_topological_fiber_bundle
+
+/-- Composition of a `bundle_trivialization` and a `homeomorph`. -/
+def bundle_trivialization.comp_homeomorph {Z' : Type*} [topological_space Z']
+  (e : bundle_trivialization F proj) (h : Z' ≃ₜ Z) :
+  bundle_trivialization F (proj ∘ h) :=
+{ to_local_homeomorph := h.to_local_homeomorph.trans e.to_local_homeomorph,
+  base_set := e.base_set,
+  open_base_set := e.open_base_set,
+  source_eq := by simp [e.source_eq, preimage_preimage],
+  target_eq := by simp [e.target_eq],
+  proj_to_fun := λ p hp,
+    have hp : h p ∈ e.source, by simpa using hp,
+    by simp [hp] }
+
+lemma is_topological_fiber_bundle.comp_homeomorph {Z' : Type*} [topological_space Z']
+  (e : is_topological_fiber_bundle F proj) (h : Z' ≃ₜ Z) :
+  is_topological_fiber_bundle F (proj ∘ h) :=
+λ x, let ⟨e, he⟩ := e x in
+⟨e.comp_homeomorph h, by simpa [bundle_trivialization.comp_homeomorph] using he⟩
+
+section induced
+
+open_locale classical
+
+variables {B' : Type*} [topological_space B']
+
+/-- Fiven a bundle trivialization of `proj : Z → B` and a continuous map `f : B' → B`,
+construct a bundle trivialization of `φ : {p : B' × Z | f p.1 = proj p.2} → B'`
+given by `φ x = (x : B' × Z).1`. -/
+noncomputable def bundle_trivialization.induced
+  (e : bundle_trivialization F proj) (f : B' → B) (hf : continuous f)
+  (b' : B') (hb' : f b' ∈ e.base_set) :
+  bundle_trivialization F (λ x : {p : B' × Z | f p.1 = proj p.2}, (x : B' × Z).1) :=
+{ to_fun := λ p, ((p : B' × Z).1, (e (p : B' × Z).2).2),
+  inv_fun := λ p, if h : f p.1 ∈ e.base_set
+    then ⟨⟨p.1, e.to_local_homeomorph.symm (f p.1, p.2)⟩, by simp [e.proj_symm_apply' h]⟩
+    else ⟨⟨b', e.to_local_homeomorph.symm (f b', p.2)⟩, by simp [e.proj_symm_apply' hb']⟩,
+  source := {p | f (p : B' × Z).1 ∈ e.base_set},
+  target := {p | f p.1 ∈ e.base_set},
+  map_source' := λ p hp, hp,
+  map_target' := λ p (hp : f p.1 ∈ e.base_set), by simp [hp],
+  left_inv' :=
+    begin
+      rintro ⟨⟨b, x⟩, hbx⟩ hb,
+      dsimp at *,
+      have hx : x ∈ e.source, from e.mem_source.2 (hbx ▸ hb),
+      ext; simp *
+    end,
+  right_inv' := λ p (hp : f p.1 ∈ e.base_set), by simp [*, e.apply_symm_apply'],
+  open_source := e.open_base_set.preimage (hf.comp $ continuous_fst.comp continuous_subtype_coe),
+  open_target := e.open_base_set.preimage (hf.comp continuous_fst),
+  continuous_to_fun := ((continuous_fst.comp continuous_subtype_coe).continuous_on).prod $
+    continuous_snd.comp_continuous_on $ e.continuous_to_fun.comp
+      (continuous_snd.comp continuous_subtype_coe).continuous_on $
+      by { rintro ⟨⟨b, x⟩, (hbx : f b = proj x)⟩ (hb : f b ∈ e.base_set),
+           rw hbx at hb,
+           exact e.mem_source.2 hb },
+  continuous_inv_fun :=
+    begin
+      rw [embedding_subtype_coe.continuous_on_iff],
+      suffices : continuous_on (λ p : B' × F, (p.1, e.to_local_homeomorph.symm (f p.1, p.2)))
+        {p : B' × F | f p.1 ∈ e.base_set},
+      { refine this.congr (λ p (hp : f p.1 ∈ e.base_set), _),
+        simp [hp] },
+      { refine continuous_on_fst.prod (e.to_local_homeomorph.symm.continuous_on.comp _ _),
+        { exact ((hf.comp continuous_fst).prod_mk continuous_snd).continuous_on },
+        { exact λ p hp, e.mem_target.2 hp } }
+    end,
+  base_set := f ⁻¹' e.base_set,
+  source_eq := rfl,
+  target_eq := by { ext, simp },
+  open_base_set := e.open_base_set.preimage hf,
+  proj_to_fun := λ _ _, rfl }
+
+lemma is_topological_fiber_bundle.induced (h : is_topological_fiber_bundle F proj)
+  {f : B' → B} (hf : continuous f) :
+  is_topological_fiber_bundle F (λ x : {p : B' × Z | f p.1 = proj p.2}, (x : B' × Z).1) :=
+λ x, let ⟨e, he⟩ := h (f x) in ⟨e.induced f hf x he, he⟩
+
+end induced
 
 end topological_fiber_bundle
 
@@ -332,7 +429,7 @@ chart with index `index_at x`, the trivialization in the fiber above x is by def
 coordinate change from i to `index_at x`, so it depends on `x`.
 The local trivialization will ultimately be a local homeomorphism. For now, we only introduce the
 local equiv version, denoted with a prime. In further developments, avoid this auxiliary version,
-and use Z.local_triv instead.
+and use `Z.local_triv` instead.
 -/
 def local_triv' (i : ι) : local_equiv Z.total_space (B × F) :=
 { source      := Z.proj ⁻¹' (Z.base_set i),
@@ -361,7 +458,7 @@ def local_triv' (i : ι) : local_equiv Z.total_space (B × F) :=
 
 @[simp, mfld_simps] lemma mem_local_triv'_source (i : ι) (p : Z.total_space) :
   p ∈ (Z.local_triv' i).source ↔ p.1 ∈ Z.base_set i :=
-by refl
+iff.rfl
 
 @[simp, mfld_simps] lemma mem_local_triv'_target (i : ι) (p : B × F) :
   p ∈ (Z.local_triv' i).target ↔ p.1 ∈ Z.base_set i :=
@@ -434,18 +531,18 @@ def local_triv (i : ι) : local_homeomorph Z.total_space (B × F) :=
     dsimp [local_equiv.trans_source],
     rw [← preimage_comp, inter_assoc]
   end,
-  ..Z.local_triv' i }
+  to_local_equiv := Z.local_triv' i }
 
 /- We will now state again the basic properties of the local trivializations, but without primes,
 i.e., for the local homeomorphism instead of the local equiv. -/
 
 @[simp, mfld_simps] lemma mem_local_triv_source (i : ι) (p : Z.total_space) :
   p ∈ (Z.local_triv i).source ↔ p.1 ∈ Z.base_set i :=
-by refl
+iff.rfl
 
 @[simp, mfld_simps] lemma mem_local_triv_target (i : ι) (p : B × F) :
   p ∈ (Z.local_triv i).target ↔ p.1 ∈ Z.base_set i :=
-by { erw [mem_prod], simp }
+iff.rfl
 
 @[simp, mfld_simps] lemma local_triv_apply (i : ι) (p : Z.total_space) :
   (Z.local_triv i) p = ⟨p.1, Z.coord_change (Z.index_at p.1) i p.1 p.2⟩ := rfl

--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -563,11 +563,11 @@ def local_triv_ext (i : ι) : bundle_trivialization F Z.proj :=
   source_eq     := rfl,
   target_eq     := rfl,
   proj_to_fun   := λp hp, by simp,
-  ..Z.local_triv i }
+  to_local_homeomorph := Z.local_triv i }
 
 /-- A topological fiber bundle constructed from core is indeed a topological fiber bundle. -/
-theorem is_topological_fiber_bundle : is_topological_fiber_bundle F Z.proj :=
-λx, ⟨Z.local_triv_ext (Z.index_at (Z.proj x)), by simp [local_triv_ext]⟩
+protected theorem is_topological_fiber_bundle : is_topological_fiber_bundle F Z.proj :=
+λx, ⟨Z.local_triv_ext (Z.index_at x), Z.mem_base_set_at x⟩
 
 /-- The projection on the base of a topological bundle created from core is continuous -/
 lemma continuous_proj : continuous Z.proj :=

--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -22,10 +22,40 @@ fiber bundle and projection.
 
 ## Main definitions
 
+### Basic definitions
+
 * `bundle_trivialization F p` : structure extending local homeomorphisms, defining a local
                   trivialization of a topological space `Z` with projection `p` and fiber `F`.
+
 * `is_topological_fiber_bundle F p` : Prop saying that the map `p` between topological spaces is a
                   fiber bundle with fiber `F`.
+
+* `is_trivial_topological_fiber_bundle F p` : Prop saying that the map `p : Z → B` between
+  topological spaces is a trivial topological fiber bundle, i.e., there exists a homeomorphism
+  `h : Z ≃ₜ B × F` such that `proj x = (h x).1`.
+
+### Operations on bundles
+
+We provide the following operations on `bundle_trivialization`s.
+
+* `bundle_trivialization.comap`: given a local trivialization `e` of a fiber bundle `p : Z → B`, a
+  continuous map `f : B' → B` and a point `b' : B'` such that `f b' ∈ e.base_set`,
+  `e.comap f hf b' hb'` is a trivialization of the pullback bundle. The pullback bundle
+  (a.k.a., the induced bundle) has total space `{(x, y) : B' × Z | f x = p y}`, and is given by
+  `λ ⟨(x, y), h⟩, x`.
+
+* `is_topological_fiber_bundle.comap`: if `p : Z → B` is a topological fiber bundle, then its
+  pullback along a continuous map `f : B' → B` is a topological fiber bundle as well.
+
+* `bundle_trivialization.comp_homeomorph`: given a local trivialization `e` of a fiber bundle
+  `p : Z → B` and a homeomorphism `h : Z' ≃ₜ Z`, returns a local trivialization of the fiber bundle
+  `p ∘ h`.
+
+* `is_topological_fiber_bundle.comp_homeomorph`: if `p : Z → B` is a topological fiber bundle
+  and `h : Z' ≃ₜ Z` is a homeomorphism, then `p ∘ h : Z' → B` is a topological fiber bundle with
+  the same fiber.
+
+### Construction of a bundle from trivializations
 
 * `topological_fiber_bundle_core ι B F` : structure registering how changes of coordinates act
   on the fiber `F` above open subsets of `B`, where local trivializations are indexed by `ι`.
@@ -283,7 +313,7 @@ variables {B' : Type*} [topological_space B']
 /-- Given a bundle trivialization of `proj : Z → B` and a continuous map `f : B' → B`,
 construct a bundle trivialization of `φ : {p : B' × Z | f p.1 = proj p.2} → B'`
 given by `φ x = (x : B' × Z).1`. -/
-noncomputable def bundle_trivialization.induced
+noncomputable def bundle_trivialization.comap
   (e : bundle_trivialization F proj) (f : B' → B) (hf : continuous f)
   (b' : B') (hb' : f b' ∈ e.base_set) :
   bundle_trivialization F (λ x : {p : B' × Z | f p.1 = proj p.2}, (x : B' × Z).1) :=
@@ -328,10 +358,13 @@ noncomputable def bundle_trivialization.induced
   open_base_set := e.open_base_set.preimage hf,
   proj_to_fun := λ _ _, rfl }
 
-lemma is_topological_fiber_bundle.induced (h : is_topological_fiber_bundle F proj)
+/-- If `proj : Z → B` is a topological fiber bundle with fiber `F` and `f : B' → B` is a continuous
+map, then the pullback bundle (a.k.a. induced bundle) is the topological bundle with the total space
+`{(x, y) : B' × Z | f x = proj y}` given by `λ ⟨(x, y), h⟩, x`. -/
+lemma is_topological_fiber_bundle.comap (h : is_topological_fiber_bundle F proj)
   {f : B' → B} (hf : continuous f) :
   is_topological_fiber_bundle F (λ x : {p : B' × Z | f p.1 = proj p.2}, (x : B' × Z).1) :=
-λ x, let ⟨e, he⟩ := h (f x) in ⟨e.induced f hf x he, he⟩
+λ x, let ⟨e, he⟩ := h (f x) in ⟨e.comap f hf x he, he⟩
 
 end induced
 

--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -138,12 +138,15 @@ variable {F}
 
 variable (F)
 
-/-- A topological fiber bundle with fiber F over a base B is a space projecting on B for which the
-fibers are all homeomorphic to F, such that the local situation around each point is a direct
-product. -/
+/-- A topological fiber bundle with fiber `F` over a base `B` is a space projecting on `B`
+for which the fibers are all homeomorphic to `F`, such that the local situation around each point
+is a direct product. -/
 def is_topological_fiber_bundle (proj : Z → B) : Prop :=
 ∀ x : B, ∃e : bundle_trivialization F proj, x ∈ e.base_set
 
+/-- A trivial topological fiber bundle with fiber `F` over a base `B` is a space `Z`
+projecting on `B` for which there exists a homeomorphism to `B × F` that sends `proj`
+to `prod.fst`. -/
 def is_trivial_topological_fiber_bundle (proj : Z → B) : Prop :=
 ∃ e : Z ≃ₜ (B × F), ∀ x, (e x).1 = proj x
 

--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -542,7 +542,7 @@ iff.rfl
 
 @[simp, mfld_simps] lemma mem_local_triv_target (i : ι) (p : B × F) :
   p ∈ (Z.local_triv i).target ↔ p.1 ∈ Z.base_set i :=
-iff.rfl
+by { erw [mem_prod], simp }
 
 @[simp, mfld_simps] lemma local_triv_apply (i : ι) (p : Z.total_space) :
   (Z.local_triv i) p = ⟨p.1, Z.coord_change (Z.index_at p.1) i p.1 p.2⟩ := rfl

--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -280,7 +280,7 @@ open_locale classical
 
 variables {B' : Type*} [topological_space B']
 
-/-- Fiven a bundle trivialization of `proj : Z → B` and a continuous map `f : B' → B`,
+/-- Given a bundle trivialization of `proj : Z → B` and a continuous map `f : B' → B`,
 construct a bundle trivialization of `φ : {p : B' × Z | f p.1 = proj p.2} → B'`
 given by `φ x = (x : B' × Z).1`. -/
 noncomputable def bundle_trivialization.induced


### PR DESCRIPTION
* fix definition of `is_topological_fiber_bundle`;
* add `is_trivial_topological_fiber_bundle`;
* more lemmas, golf here and there;
* define induced fiber bundle.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
has a merge conflict with #6180 (on the queue)