### PR TITLE
[Merged by Bors] - feat(analysis/calculus): generalize `has_strict_fderiv_at.map_nhds_eq`

### DIFF
--- a/src/analysis/calculus/implicit.lean
+++ b/src/analysis/calculus/implicit.lean
@@ -165,6 +165,10 @@ lemma implicit_function_apply_image :
   ∀ᶠ x in 𝓝 φ.pt, φ.implicit_function (φ.left_fun x) (φ.right_fun x) = x :=
 φ.has_strict_fderiv_at.eventually_left_inverse
 
+lemma map_nhds_eq : map φ.left_fun (𝓝 φ.pt) = 𝓝 (φ.left_fun φ.pt) :=
+show map (prod.fst ∘ φ.prod_fun) (𝓝 φ.pt) = 𝓝 (φ.prod_fun φ.pt).1,
+by rw [← map_map, φ.has_strict_fderiv_at.map_nhds_eq_of_equiv, map_fst_nhds]
+
 lemma implicit_function_has_strict_fderiv_at
   (g'inv : G →L[𝕜] E) (hg'inv : φ.right_deriv.comp g'inv = continuous_linear_map.id 𝕜 G)
   (hg'invf : φ.left_deriv.comp g'inv = 0) :
@@ -293,6 +297,20 @@ lemma eq_implicit_function_of_complemented (hf : has_strict_fderiv_at f f' a)
     (hf.implicit_to_local_homeomorph_of_complemented f f' hf' hker x).snd = x :=
 (implicit_function_data_of_complemented f f' hf hf' hker).implicit_function_apply_image
 
+@[simp] lemma implicit_function_of_complemented_apply_image (hf : has_strict_fderiv_at f f' a)
+  (hf' : f'.range = ⊤) (hker : f'.ker.closed_complemented) :
+  hf.implicit_function_of_complemented f f' hf' hker (f a) 0 = a :=
+begin
+  convert (hf.implicit_to_local_homeomorph_of_complemented f f' hf' hker).left_inv
+    (hf.mem_implicit_to_local_homeomorph_of_complemented_source hf' hker),
+  exact congr_arg prod.snd (hf.implicit_to_local_homeomorph_of_complemented_self hf' hker).symm
+end
+
+lemma map_nhds_eq_of_complemented
+  (hf : has_strict_fderiv_at f f' a) (hf' : f'.range = ⊤) (hker : f'.ker.closed_complemented) :
+  map f (𝓝 a) = 𝓝 (f a) :=
+(implicit_function_data_of_complemented f f' hf hf' hker).map_nhds_eq
+
 lemma to_implicit_function_of_complemented (hf : has_strict_fderiv_at f f' a)
   (hf' : f'.range = ⊤) (hker : f'.ker.closed_complemented) :
   has_strict_fderiv_at (hf.implicit_function_of_complemented f f' hf' hker (f a))
@@ -367,10 +385,28 @@ lemma mem_implicit_to_local_homeomorph_target (hf : has_strict_fderiv_at f f' a)
   (f a, (0 : f'.ker)) ∈ (hf.implicit_to_local_homeomorph f f' hf').target :=
 by apply mem_implicit_to_local_homeomorph_of_complemented_target
 
+lemma tendsto_implicit_function (hf : has_strict_fderiv_at f f' a)
+  (hf' : f'.range = ⊤) {α : Type*} {l : filter α} {g₁ : α → F} {g₂ : α → f'.ker}
+  (h₁ : tendsto g₁ l (𝓝 $ f a)) (h₂ : tendsto g₂ l (𝓝 0)) :
+  tendsto (λ t, hf.implicit_function f f' hf' (g₁ t) (g₂ t)) l (𝓝 a) :=
+begin
+  refine ((hf.implicit_to_local_homeomorph f f' hf').tendsto_symm
+    (hf.mem_implicit_to_local_homeomorph_source hf')).comp _,
+  rw [implicit_to_local_homeomorph_self],
+  exact h₁.prod_mk_nhds h₂
+end
+
+alias tendsto_implicit_function ← filter.tendsto.implicit_function
+
 /-- `implicit_function` sends `(z, y)` to a point in `f ⁻¹' z`. -/
 lemma map_implicit_function_eq (hf : has_strict_fderiv_at f f' a) (hf' : f'.range = ⊤) :
   ∀ᶠ (p : F × f'.ker) in 𝓝 (f a, 0), f (hf.implicit_function f f' hf' p.1 p.2) = p.1 :=
 by apply map_implicit_function_of_complemented_eq
+
+@[simp] lemma implicit_function_apply_image (hf : has_strict_fderiv_at f f' a)
+  (hf' : f'.range = ⊤) :
+  hf.implicit_function f f' hf' (f a) 0 = a :=
+by apply implicit_function_of_complemented_apply_image
 
 /-- Any point in some neighborhood of `a` can be represented as `implicit_function`
 of some point. -/
@@ -378,6 +414,11 @@ lemma eq_implicit_function (hf : has_strict_fderiv_at f f' a) (hf' : f'.range = 
   ∀ᶠ x in 𝓝 a, hf.implicit_function f f' hf' (f x)
     (hf.implicit_to_local_homeomorph f f' hf' x).snd = x :=
 by apply eq_implicit_function_of_complemented
+
+lemma map_nhds_eq (hf : has_strict_fderiv_at f f' a) (hf' : f'.range = ⊤) :
+  map f (𝓝 a) = 𝓝 (f a) :=
+by haveI := finite_dimensional.complete 𝕜 F; exact
+hf.map_nhds_eq_of_complemented hf' f'.ker_closed_complemented_of_finite_dimensional_range
 
 lemma to_implicit_function (hf : has_strict_fderiv_at f f' a) (hf' : f'.range = ⊤) :
   has_strict_fderiv_at (hf.implicit_function f f' hf' (f a))

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -415,7 +415,8 @@ lemma image_mem_to_local_homeomorph_target (hf : has_strict_fderiv_at f (f' : E 
   f a ∈ (hf.to_local_homeomorph f).target :=
 (hf.to_local_homeomorph f).map_source hf.mem_to_local_homeomorph_source
 
-lemma map_nhds_eq (hf : has_strict_fderiv_at f (f' : E →L[𝕜] F) a) : map f (𝓝 a) = 𝓝 (f a) :=
+lemma map_nhds_eq_of_equiv (hf : has_strict_fderiv_at f (f' : E →L[𝕜] F) a) :
+  map f (𝓝 a) = 𝓝 (f a) :=
 (hf.to_local_homeomorph f).map_nhds_eq hf.mem_to_local_homeomorph_source
 
 variables (f f' a)
@@ -477,10 +478,10 @@ hf.to_local_inverse.congr_of_eventually_eq $ (hf.local_inverse_unique hg).mono $
 end has_strict_fderiv_at
 
 /-- If a function has an invertible strict derivative at all points, then it is an open map. -/
-lemma open_map_of_strict_fderiv [complete_space E] {f : E → F} {f' : E → E ≃L[𝕜] F}
+lemma open_map_of_strict_fderiv_equiv [complete_space E] {f : E → F} {f' : E → E ≃L[𝕜] F}
   (hf : ∀ x, has_strict_fderiv_at f (f' x : E →L[𝕜] F) x) :
   is_open_map f :=
-is_open_map_iff_nhds_le.2 $ λ x, (hf x).map_nhds_eq.ge
+is_open_map_iff_nhds_le.2 $ λ x, (hf x).map_nhds_eq_of_equiv.ge
 
 /-!
 ### Inverse function theorem, 1D case
@@ -506,7 +507,7 @@ variables (f f' a)
 variables {f f' a}
 
 lemma map_nhds_eq : map f (𝓝 a) = 𝓝 (f a) :=
-(hf.has_strict_fderiv_at_equiv hf').map_nhds_eq
+(hf.has_strict_fderiv_at_equiv hf').map_nhds_eq_of_equiv
 
 theorem to_local_inverse : has_strict_deriv_at (hf.local_inverse f f' a hf') f'⁻¹ (f a) :=
 (hf.has_strict_fderiv_at_equiv hf').to_local_inverse


### PR DESCRIPTION
Generalize `has_strict_fderiv_at.map_nhds_eq` to a function that satisfies assumptions of the implicit function theorem.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
