### PR TITLE
[Merged by Bors] - chore(algebra/group/basic): remove three redundant lemmas

### DIFF
--- a/src/algebra/char_zero.lean
+++ b/src/algebra/char_zero.lean
@@ -44,7 +44,7 @@ theorem char_zero_of_inj_zero {R : Type*} [add_left_cancel_monoid R] [has_one R]
    assume h,
    wlog hle : m ≤ n,
    rcases nat.le.dest hle with ⟨k, rfl⟩,
-   rw [nat.cast_add, eq_comm, add_eq_left_iff] at h,
+   rw [nat.cast_add, eq_comm, add_left_eq_self] at h,
    rw [H k h, add_zero]
  end⟩
 

--- a/src/algebra/char_zero.lean
+++ b/src/algebra/char_zero.lean
@@ -44,7 +44,7 @@ theorem char_zero_of_inj_zero {R : Type*} [add_left_cancel_monoid R] [has_one R]
    assume h,
    wlog hle : m ≤ n,
    rcases nat.le.dest hle with ⟨k, rfl⟩,
-   rw [nat.cast_add, eq_comm, add_left_eq_self] at h,
+   rw [nat.cast_add, eq_comm, add_right_eq_self] at h,
    rw [H k h, add_zero]
  end⟩
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -118,11 +118,11 @@ section left_cancel_monoid
 
 variables {M : Type u} [left_cancel_monoid M] {a b : M}
 
-@[simp, to_additive] lemma mul_eq_left_iff : a * b = a ↔ b = 1 :=
+@[simp, to_additive] lemma mul_left_eq_self : a * b = a ↔ b = 1 :=
 ⟨λ h, @mul_left_cancel _ _ a b 1 (by simp [h]), λ h, by simp [h]⟩
 
-@[simp, to_additive] lemma left_eq_mul_iff : a = a * b ↔ b = 1 :=
-eq_comm.trans mul_eq_left_iff
+@[simp, to_additive] lemma self_eq_mul_left : a = a * b ↔ b = 1 :=
+eq_comm.trans mul_left_eq_self
 
 end left_cancel_monoid
 
@@ -130,11 +130,11 @@ section right_cancel_monoid
 
 variables {M : Type u} [right_cancel_monoid M] {a b : M}
 
-@[simp, to_additive] lemma mul_eq_right_iff : a * b = b ↔ a = 1 :=
+@[simp, to_additive] lemma mul_right_eq_self : a * b = b ↔ a = 1 :=
 ⟨λ h, @mul_right_cancel _ _ a b 1 (by simp [h]), λ h, by simp [h]⟩
 
-@[simp, to_additive] lemma right_eq_mul_iff : b = a * b ↔ a = 1 :=
-eq_comm.trans mul_eq_right_iff
+@[simp, to_additive] lemma self_eq_mul_right : b = a * b ↔ a = 1 :=
+eq_comm.trans mul_right_eq_self
 
 end right_cancel_monoid
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -3,8 +3,17 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Simon Hudon, Mario Carneiro
 -/
+
 import algebra.group.defs
 import logic.function.basic
+
+/-!
+# Basic lemmas about semigroups, monoids, and groups
+
+This file lists various basic lemmas about semigroups, monoids, and groups. Most proofs are
+one-liners from the corresponding axioms. For the definitions of semigroups, monoids and groups, see
+`algebra/group/defs.lean`.
+-/
 
 universe u
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -110,8 +110,7 @@ section left_cancel_monoid
 variables {M : Type u} [left_cancel_monoid M] {a b : M}
 
 @[simp, to_additive] lemma mul_eq_left_iff : a * b = a ↔ b = 1 :=
-calc a * b = a ↔ a * b = a * 1 : by rw mul_one
-           ... ↔ b = 1         : mul_left_cancel_iff
+⟨λ h, @mul_left_cancel _ _ a b 1 (by simp [h]), λ h, by simp [h]⟩
 
 @[simp, to_additive] lemma left_eq_mul_iff : a = a * b ↔ b = 1 :=
 eq_comm.trans mul_eq_left_iff
@@ -123,8 +122,7 @@ section right_cancel_monoid
 variables {M : Type u} [right_cancel_monoid M] {a b : M}
 
 @[simp, to_additive] lemma mul_eq_right_iff : a * b = b ↔ a = 1 :=
-calc a * b = b ↔ a * b = 1 * b : by rw one_mul
-           ... ↔ a = 1         : mul_right_cancel_iff
+⟨λ h, @mul_right_cancel _ _ a b 1 (by simp [h]), λ h, by simp [h]⟩
 
 @[simp, to_additive] lemma right_eq_mul_iff : b = a * b ↔ a = 1 :=
 eq_comm.trans mul_eq_right_iff
@@ -238,10 +236,6 @@ by rw [h, mul_inv_cancel_left]
 lemma mul_eq_of_eq_mul_inv (h : a = c * b⁻¹) : a * b = c :=
 by simp [h]
 
-@[to_additive]
-theorem mul_self_iff_eq_one : a * a = a ↔ a = 1 :=
-by have := @mul_right_inj _ _ a a 1; rwa mul_one at this
-
 @[simp, to_additive]
 theorem inv_eq_one : a⁻¹ = 1 ↔ a = 1 :=
 by rw [← @inv_inj _ _ a 1, one_inv]
@@ -301,14 +295,6 @@ by rw [mul_eq_one_iff_eq_inv, inv_inv]
 @[to_additive]
 theorem inv_mul_eq_one : a⁻¹ * b = 1 ↔ a = b :=
 by rw [mul_eq_one_iff_eq_inv, inv_inj]
-
-@[simp, to_additive]
-lemma mul_left_eq_self : a * b = b ↔ a = 1 :=
-⟨λ h, @mul_right_cancel _ _ a b 1 (by simp [h]), λ h, by simp [h]⟩
-
-@[simp, to_additive]
-lemma mul_right_eq_self : a * b = a ↔ b = 1 :=
-⟨λ h, @mul_left_cancel _ _ a b 1 (by simp [h]), λ h, by simp [h]⟩
 
 @[to_additive]
 lemma div_left_injective : function.injective (λ a, a / b) :=

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -118,12 +118,12 @@ section left_cancel_monoid
 
 variables {M : Type u} [left_cancel_monoid M] {a b : M}
 
-@[simp, to_additive] lemma mul_left_eq_self : a * b = a ↔ b = 1 :=
+@[simp, to_additive] lemma mul_right_eq_self : a * b = a ↔ b = 1 :=
 calc a * b = a ↔ a * b = a * 1 : by rw mul_one
            ... ↔ b = 1         : mul_left_cancel_iff
 
-@[simp, to_additive] lemma self_eq_mul_left : a = a * b ↔ b = 1 :=
-eq_comm.trans mul_left_eq_self
+@[simp, to_additive] lemma self_eq_mul_right : a = a * b ↔ b = 1 :=
+eq_comm.trans mul_right_eq_self
 
 end left_cancel_monoid
 
@@ -131,12 +131,12 @@ section right_cancel_monoid
 
 variables {M : Type u} [right_cancel_monoid M] {a b : M}
 
-@[simp, to_additive] lemma mul_right_eq_self : a * b = b ↔ a = 1 :=
+@[simp, to_additive] lemma mul_left_eq_self : a * b = b ↔ a = 1 :=
 calc a * b = b ↔ a * b = 1 * b : by rw one_mul
            ... ↔ a = 1         : mul_right_cancel_iff
 
-@[simp, to_additive] lemma self_eq_mul_right : b = a * b ↔ a = 1 :=
-eq_comm.trans mul_right_eq_self
+@[simp, to_additive] lemma self_eq_mul_left : b = a * b ↔ a = 1 :=
+eq_comm.trans mul_left_eq_self
 
 end right_cancel_monoid
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -119,7 +119,8 @@ section left_cancel_monoid
 variables {M : Type u} [left_cancel_monoid M] {a b : M}
 
 @[simp, to_additive] lemma mul_left_eq_self : a * b = a ↔ b = 1 :=
-⟨λ h, @mul_left_cancel _ _ a b 1 (by simp [h]), λ h, by simp [h]⟩
+calc a * b = a ↔ a * b = a * 1 : by rw mul_one
+           ... ↔ b = 1         : mul_left_cancel_iff
 
 @[simp, to_additive] lemma self_eq_mul_left : a = a * b ↔ b = 1 :=
 eq_comm.trans mul_left_eq_self
@@ -131,7 +132,8 @@ section right_cancel_monoid
 variables {M : Type u} [right_cancel_monoid M] {a b : M}
 
 @[simp, to_additive] lemma mul_right_eq_self : a * b = b ↔ a = 1 :=
-⟨λ h, @mul_right_cancel _ _ a b 1 (by simp [h]), λ h, by simp [h]⟩
+calc a * b = b ↔ a * b = 1 * b : by rw one_mul
+           ... ↔ a = 1         : mul_right_cancel_iff
 
 @[simp, to_additive] lemma self_eq_mul_right : b = a * b ↔ a = 1 :=
 eq_comm.trans mul_right_eq_self

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -724,7 +724,7 @@ include mM
 def mk' (f : M → G) (map_mul : ∀ a b : M, f (a * b) = f a * f b) : M →* G :=
 { to_fun := f,
   map_mul' := map_mul,
-  map_one' := mul_eq_right_iff.1 $ by rw [←map_mul, mul_one] }
+  map_one' := mul_right_eq_self.1 $ by rw [←map_mul, mul_one] }
 
 @[simp, to_additive]
 lemma coe_mk' {f : M → G} (map_mul : ∀ a b : M, f (a * b) = f a * f b) :

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -724,8 +724,7 @@ include mM
 def mk' (f : M → G) (map_mul : ∀ a b : M, f (a * b) = f a * f b) : M →* G :=
 { to_fun := f,
   map_mul' := map_mul,
-  map_one' := mul_self_iff_eq_one.1 $ by rw [←map_mul, mul_one] }
-
+  map_one' := mul_eq_right_iff.1 $ by rw [←map_mul, mul_one] }
 
 @[simp, to_additive]
 lemma coe_mk' {f : M → G} (map_mul : ∀ a b : M, f (a * b) = f a * f b) :

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -724,7 +724,7 @@ include mM
 def mk' (f : M → G) (map_mul : ∀ a b : M, f (a * b) = f a * f b) : M →* G :=
 { to_fun := f,
   map_mul' := map_mul,
-  map_one' := mul_right_eq_self.1 $ by rw [←map_mul, mul_one] }
+  map_one' := mul_left_eq_self.1 $ by rw [←map_mul, mul_one] }
 
 @[simp, to_additive]
 lemma coe_mk' {f : M → G} (map_mul : ∀ a b : M, f (a * b) = f a * f b) :

--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -61,7 +61,7 @@ begin
   use k,
   { simpa only [xor, h, true_and, eq_self_iff_true, not_true, or_false, and_false]
       using (succ_ne_self (2*k)).symm },
-  { simp only [xor, h, add_left_eq_self, false_or, eq_self_iff_true, not_true, not_false_iff,
+  { simp only [xor, h, add_right_eq_self, false_or, eq_self_iff_true, not_true, not_false_iff,
                one_ne_zero, and_self] },
 end
 

--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -61,7 +61,7 @@ begin
   use k,
   { simpa only [xor, h, true_and, eq_self_iff_true, not_true, or_false, and_false]
       using (succ_ne_self (2*k)).symm },
-  { simp only [xor, h, add_right_eq_self, false_or, eq_self_iff_true, not_true, not_false_iff,
+  { simp only [xor, h, add_left_eq_self, false_or, eq_self_iff_true, not_true, not_false_iff,
                one_ne_zero, and_self] },
 end
 

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -55,7 +55,7 @@ begin
   use k,
   { simpa only [xor, h, true_and, eq_self_iff_true, not_true, or_false, and_false]
       using (succ_ne_self (2*k)).symm },
-  { simp only [xor, h, add_left_eq_self, false_or, eq_self_iff_true, not_true, not_false_iff,
+  { simp only [xor, h, add_right_eq_self, false_or, eq_self_iff_true, not_true, not_false_iff,
               one_ne_zero, and_self] },
 end
 

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -55,7 +55,7 @@ begin
   use k,
   { simpa only [xor, h, true_and, eq_self_iff_true, not_true, or_false, and_false]
       using (succ_ne_self (2*k)).symm },
-  { simp only [xor, h, add_eq_left_iff, false_or, eq_self_iff_true, not_true, not_false_iff,
+  { simp only [xor, h, add_left_eq_self, false_or, eq_self_iff_true, not_true, not_false_iff,
               one_ne_zero, and_self] },
 end
 

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -155,7 +155,7 @@ end is_monoid_hom
 @[to_additive]
 theorem is_monoid_hom.of_mul [monoid α] [group β] (f : α → β) [is_mul_hom f] :
   is_monoid_hom f :=
-{ map_one := mul_eq_left_iff.1 $ by rw [← is_mul_hom.map_mul f, one_mul] }
+{ map_one := mul_left_eq_self.1 $ by rw [← is_mul_hom.map_mul f, one_mul] }
 
 namespace is_monoid_hom
 variables [monoid α] [monoid β] (f : α → β) [is_monoid_hom f]

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -155,7 +155,7 @@ end is_monoid_hom
 @[to_additive]
 theorem is_monoid_hom.of_mul [monoid α] [group β] (f : α → β) [is_mul_hom f] :
   is_monoid_hom f :=
-{ map_one := mul_left_eq_self.1 $ by rw [← is_mul_hom.map_mul f, one_mul] }
+{ map_one := mul_right_eq_self.1 $ by rw [← is_mul_hom.map_mul f, one_mul] }
 
 namespace is_monoid_hom
 variables [monoid α] [monoid β] (f : α → β) [is_monoid_hom f]

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -155,7 +155,7 @@ end is_monoid_hom
 @[to_additive]
 theorem is_monoid_hom.of_mul [monoid α] [group β] (f : α → β) [is_mul_hom f] :
   is_monoid_hom f :=
-{ map_one := mul_self_iff_eq_one.1 $ by rw [← is_mul_hom.map_mul f, one_mul] }
+{ map_one := mul_eq_left_iff.1 $ by rw [← is_mul_hom.map_mul f, one_mul] }
 
 namespace is_monoid_hom
 variables [monoid α] [monoid β] (f : α → β) [is_monoid_hom f]
@@ -290,7 +290,7 @@ end
 end ring_hom
 
 /-- Inversion is a group homomorphism if the group is commutative. -/
-@[instance, to_additive neg.is_add_group_hom 
+@[instance, to_additive neg.is_add_group_hom
 "Negation is an `add_group` homomorphism if the `add_group` is commutative."]
 lemma inv.is_group_hom [comm_group α] : is_group_hom (has_inv.inv : α → α) :=
 { map_mul := mul_inv }

--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -71,7 +71,7 @@ coe_injective $ funext H
 @[simp] lemma map_one_eq_zero : D 1 = 0 :=
 begin
   have h : D 1 = D (1 * 1) := by rw mul_one,
-  rwa [leibniz D 1 1, one_smul, left_eq_add_iff] at h,
+  rwa [leibniz D 1 1, one_smul, self_eq_add_right] at h
 end
 
 @[simp] lemma map_algebra_map : D (algebra_map R A r) = 0 :=

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -252,9 +252,8 @@ instance is_Z_bilin.comp_swap : is_Z_bilin (f ∘ prod.swap) :=
 lemma is_Z_bilin.zero_left : ∀ b, f (0, b) = 0 :=
 begin
   intro b,
-  apply add_self_iff_eq_zero.1,
-  rw ←is_Z_bilin.add_left f,
-  simp
+  apply add_left_eq_self.1,
+  rw [ ←is_Z_bilin.add_left f, zero_add]
 end
 
 lemma is_Z_bilin.zero_right : ∀ a, f (a, 0) = 0 :=

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -252,7 +252,7 @@ instance is_Z_bilin.comp_swap : is_Z_bilin (f ∘ prod.swap) :=
 lemma is_Z_bilin.zero_left : ∀ b, f (0, b) = 0 :=
 begin
   intro b,
-  apply add_left_eq_self.1,
+  apply add_right_eq_self.1,
   rw [ ←is_Z_bilin.add_left f, zero_add]
 end
 


### PR DESCRIPTION
The following lemmas are changed in this PR (long list because of the additive versions:
* `mul_eq_left_iff` for `left_cancel_monoid` is renamed to `mul_right_eq_self` which previously was stated for `group`
* `add_eq_left_iff` the additive version is automatically renamed to `add_right_eq_self`
* `mul_eq_right_iff` for `right_cancel_monoid` is renamed to `mul_left_eq_self` which previously was stated for `group`
* `add_eq_right_iff` the additive version is automatically renamed to `add_left_eq_self`
* `left_eq_mul_iff` is renamed to `self_eq_mul_right` to fit the convention above
* `left_eq_add_iff` is renamed to `self_eq_add_right` to fit the convention above
* `right_eq_mul_iff` is renamed to `self_eq_mul_left` to fit the convention above
* `right_eq_add_iff` is renamed to `self_eq_add_left` to fit the convention above
* the duplicate `mul_left_eq_self` and `add_left_eq_self` for groups are removed
* the duplicate `mul_right_eq_self` and `add_right_eq_self` for groups are removed
* `mul_self_iff_eq_one` and `add_self_iff_eq_zero` deal only with the special case `a=b` of the other lemmas. It is therefore removed and the few instances in the library are replaced by one of the above. 

While I was at it, I provided a module doc for this file. 

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
