### PR TITLE
[Merged by Bors] - feat(measure_theory/probability_mass_function): Generalize bind on pmfs to binding on the support

### DIFF
--- a/src/measure_theory/probability_mass_function.lean
+++ b/src/measure_theory/probability_mass_function.lean
@@ -56,8 +56,7 @@ def pure (a : α) : pmf α := ⟨λ a', if a' = a then 1 else 0, has_sum_ite_eq 
 
 @[simp] lemma pure_apply (a a' : α) : pure a a' = (if a' = a then 1 else 0) := rfl
 
-@[simp] lemma mem_support_pure_iff (a a' : α) :
-  a' ∈ (pure a).support ↔ a' = a :=
+lemma mem_support_pure_iff (a a' : α) : a' ∈ (pure a).support ↔ a' = a :=
 by simp
 
 instance [inhabited α] : inhabited (pmf α) := ⟨pure (default α)⟩
@@ -155,11 +154,10 @@ end⟩
   p.bind_on_support (λ a _, f a) = p.bind f :=
 begin
   ext b,
-  simp [p.bind_on_support_apply (λ a _, f a), p.bind_apply f],
+  simp only [p.bind_on_support_apply (λ a _, f a), p.bind_apply f,
+    dite_eq_ite, nnreal.coe_eq, mul_ite, mul_zero],
   refine congr_arg _ (funext (λ a, _)),
-  split_ifs,
-  { simp [h] },
-  { exact rfl },
+  split_ifs with h; simp [h],
 end
 
 lemma coe_bind_on_support_apply (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
@@ -192,7 +190,7 @@ begin
   by_cases h : (a' = a); simp [h],
 end
 
-@[simp] lemma bind_on_support_pure (p : pmf α) :
+lemma bind_on_support_pure (p : pmf α) :
   p.bind_on_support (λ a _, pure a) = p :=
 by simp only [pmf.bind_pure, pmf.bind_on_support_eq_bind]
 

--- a/src/measure_theory/probability_mass_function.lean
+++ b/src/measure_theory/probability_mass_function.lean
@@ -132,7 +132,7 @@ end
 
 /-- Generalized version of `bind` allowing `f` to only be defined on the support of `p`.
   `p.bind f` is equivalent to `p.bind_on_support (λ a _, f a)`, see `bind_on_support_eq_bind` -/
-noncomputable def bind_on_support (p : pmf α) (f : ∀ a ∈ p.support, pmf β) : pmf β :=
+def bind_on_support (p : pmf α) (f : ∀ a ∈ p.support, pmf β) : pmf β :=
 ⟨λ b, ∑' a, p a * if h : p a = 0 then 0 else f a h b,
 ennreal.has_sum_coe.1 begin
   simp only [ennreal.coe_tsum (bind_on_support.summable p f _)],

--- a/src/measure_theory/probability_mass_function.lean
+++ b/src/measure_theory/probability_mass_function.lean
@@ -121,7 +121,7 @@ begin
 end
 
 protected lemma bind_on_support.summable (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
-  summable (λ a : α, p a * dite (p a = 0) (λ _, (0 : nnreal)) (λ h, f a h b)) :=
+  summable (λ a : α, p a * if h : p a = 0 then 0 else f a h b) :=
 begin
   refine nnreal.summable_of_le (assume a, _) p.summable_coe,
   split_ifs,
@@ -133,7 +133,7 @@ end
 /-- Generalized version of `bind` allowing `f` to only be defined on the support of `p`.
   `p.bind f` is equivalent to `p.bind_on_support (λ a _, f a)`, see `bind_on_support_eq_bind` -/
 noncomputable def bind_on_support (p : pmf α) (f : ∀ a ∈ p.support, pmf β) : pmf β :=
-⟨λ b, ∑' a, p a * dite (p a = 0) (λ _, 0) (λ h, f a h b),
+⟨λ b, ∑' a, p a * if h : p a = 0 then 0 else f a h b,
 ennreal.has_sum_coe.1 begin
   simp only [ennreal.coe_tsum (bind_on_support.summable p f _)],
   rw [ennreal.summable.has_sum_iff, ennreal.tsum_comm],
@@ -147,7 +147,7 @@ ennreal.has_sum_coe.1 begin
 end⟩
 
 @[simp] lemma bind_on_support_apply (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
-  p.bind_on_support f b = ∑' a, p a * dite (p a = 0) (λ _, 0) (λ h, f a h b) := rfl
+  p.bind_on_support f b = ∑' a, p a * if h : p a = 0 then 0 else f a h b := rfl
 
 /-- `bind_on_support` reduces to `bind` if `f` doesn't depend on the additional hypothesis -/
 @[simp] lemma bind_on_support_eq_bind (p : pmf α) (f : α → pmf β) :
@@ -161,7 +161,7 @@ begin
 end
 
 lemma coe_bind_on_support_apply (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
-  (p.bind_on_support f b : ℝ≥0∞) = ∑' a, p a * dite (p a = 0) (λ _, 0) (λ h, f a h b) :=
+  (p.bind_on_support f b : ℝ≥0∞) = ∑' a, p a * if h : p a = 0 then 0 else f a h b :=
 by simp only [bind_on_support_apply, ennreal.coe_tsum (bind_on_support.summable p f b),
     dite_cast, ennreal.coe_mul, ennreal.coe_zero]
 

--- a/src/measure_theory/probability_mass_function.lean
+++ b/src/measure_theory/probability_mass_function.lean
@@ -65,16 +65,6 @@ instance [inhabited α] : inhabited (pmf α) := ⟨pure (default α)⟩
 lemma coe_le_one (p : pmf α) (a : α) : p a ≤ 1 :=
 has_sum_le (by intro b; split_ifs; simp [h]; exact le_refl _) (has_sum_ite_eq a (p a)) p.2
 
-protected lemma bind_on_support.summable (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
-  summable (λ a : α, p a * dite (p a = 0) (λ _, (0 : nnreal)) (λ h, f a h b)) :=
-begin
-  refine nnreal.summable_of_le (assume a, _) p.summable_coe,
-  split_ifs,
-  { refine (mul_zero (p a)).symm ▸ le_of_eq h.symm },
-  { suffices : p a * f a h b ≤ p a * 1, { simpa },
-    exact mul_le_mul_of_nonneg_left ((f a h).coe_le_one _) (p a).2 }
-end
-
 protected lemma bind.summable (p : pmf α) (f : α → pmf β) (b : β) :
   summable (λ a : α, p a * f a b) :=
 begin
@@ -131,6 +121,16 @@ begin
   simp [mul_assoc, mul_left_comm, mul_comm]
 end
 
+protected lemma bind_on_support.summable (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
+  summable (λ a : α, p a * dite (p a = 0) (λ _, (0 : nnreal)) (λ h, f a h b)) :=
+begin
+  refine nnreal.summable_of_le (assume a, _) p.summable_coe,
+  split_ifs,
+  { refine (mul_zero (p a)).symm ▸ le_of_eq h.symm },
+  { suffices : p a * f a h b ≤ p a * 1, { simpa },
+    exact mul_le_mul_of_nonneg_left ((f a h).coe_le_one _) (p a).2 }
+end
+
 /-- Generalized version of `bind` allowing `f` to only be defined on the support of `p`.
   `p.bind f` is equivalent to `p.bind_on_support (λ a _, f a)`, see `bind_on_support_eq_bind` -/
 noncomputable def bind_on_support (p : pmf α) (f : ∀ a ∈ p.support, pmf β) : pmf β :=
@@ -175,7 +175,7 @@ begin
   split; rintro ⟨a, ha, haf⟩; refine ⟨a, ha, ne_of_eq_of_ne _ haf⟩; simp [ha],
 end
 
-@[simp] lemma bind_on_support_eq_zero_iff (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
+lemma bind_on_support_eq_zero_iff (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
   p.bind_on_support f b = 0 ↔ ∀ a (ha : p a ≠ 0), f a ha b = 0 :=
 begin
   simp only [bind_on_support_apply, tsum_eq_zero_iff (bind_on_support.summable p f b),

--- a/src/measure_theory/probability_mass_function.lean
+++ b/src/measure_theory/probability_mass_function.lean
@@ -172,7 +172,7 @@ by simp only [bind_on_support_apply, ennreal.coe_tsum (bind_on_support.summable 
 begin
   simp only [mem_support_iff, bind_on_support_apply,
     tsum_ne_zero_iff (bind_on_support.summable p f b), mul_ne_zero_iff],
-  split; rintro ⟨a, ha, haf⟩; refine ⟨a, ha, ne_of_eq_of_ne _ haf⟩; simp [ha],
+  split; { rintro ⟨a, ha, haf⟩, refine ⟨a, ha, ne_of_eq_of_ne _ haf⟩, simp [ha], },
 end
 
 lemma bind_on_support_eq_zero_iff (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :

--- a/src/measure_theory/probability_mass_function.lean
+++ b/src/measure_theory/probability_mass_function.lean
@@ -61,6 +61,137 @@ instance [inhabited α] : inhabited (pmf α) := ⟨pure (default α)⟩
 lemma coe_le_one (p : pmf α) (a : α) : p a ≤ 1 :=
 has_sum_le (by intro b; split_ifs; simp [h]; exact le_refl _) (has_sum_ite_eq a (p a)) p.2
 
+protected lemma bind_on_support.summable (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
+  summable (λ a : α, p a * dite (p a = 0) (λ _, (0 : nnreal)) (λ h, f a h b)) :=
+begin
+  refine nnreal.summable_of_le (assume a, _) p.summable_coe,
+  split_ifs,
+  { refine (mul_zero (p a)).symm ▸ le_of_eq h.symm },
+  { suffices : p a * f a h b ≤ p a * 1, { simpa },
+    exact mul_le_mul_of_nonneg_left ((f a h).coe_le_one _) (p a).2 }
+end
+
+/-- Generalized version of `bind` allowing `f` to only be defined on the support of `p`.
+  `p.bind f` is equivalent to `p.bind_on_support (λ a _, f a)` (`bind_on_support_eq_bind`) -/
+noncomputable def bind_on_support (p : pmf α) (f : ∀ a ∈ p.support, pmf β) : pmf β :=
+⟨λ b, ∑' a, p a * dite (p a = 0) (λ _, 0) (λ h, f a h b),
+ennreal.has_sum_coe.1 begin
+  simp only [ennreal.coe_tsum (bind_on_support.summable p f _)],
+  rw [ennreal.summable.has_sum_iff, ennreal.tsum_comm],
+  simp only [ennreal.coe_mul, ennreal.coe_one, ennreal.tsum_mul_left],
+  have : ∑' (a : α), (p a : ennreal) = 1 := by simp [← ennreal.coe_tsum p.summable_coe],
+  convert this,
+  refine funext (λ a, _),
+  split_ifs with h,
+  { simp [h] },
+  { simp [← ennreal.coe_tsum (f a h).summable_coe, (f a h).tsum_coe] }
+end⟩
+
+@[simp] lemma bind_on_support_apply (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
+  p.bind_on_support f b = ∑' a, p a * dite (p a = 0) (λ _, 0) (λ h, f a h b) := rfl
+
+lemma coe_bind_on_support_apply (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
+  (p.bind_on_support f b : ℝ≥0∞) = ∑' a, p a * dite (p a = 0) (λ _, 0) (λ h, f a h b) :=
+by simp only [bind_on_support_apply, ennreal.coe_tsum (bind_on_support.summable p f b),
+    dite_cast, ennreal.coe_mul, ennreal.coe_zero]
+
+lemma mem_support_bind_on_support_iff (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
+  b ∈ (p.bind_on_support f).support ↔ ∃ a (ha : p a ≠ 0), b ∈ (f a ha).support :=
+begin
+  simp only [mem_support_iff, bind_on_support_apply,
+    tsum_ne_zero_iff (bind_on_support.summable p f b), mul_ne_zero_iff],
+  split; rintro ⟨a, ha, haf⟩; refine ⟨a, ha, ne_of_eq_of_ne _ haf⟩; simp [ha],
+end
+
+lemma bind_on_support_eq_zero_iff (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
+  p.bind_on_support f b = 0 ↔ ∀ a (ha : p a ≠ 0), f a ha b = 0 :=
+begin
+  rw [bind_on_support_apply, tsum_eq_zero_iff (bind_on_support.summable p f b)],
+  refine ⟨λ h a ha, _, _⟩,
+  {
+    specialize h a,
+    simp only at h,
+    simp only [mul_eq_zero] at h,
+
+    refine h.rec_on _ _,
+    {
+      refine λ h, absurd h ha,
+    },
+    {
+      intro h,
+      rwa dif_neg ha at h,
+    }
+  },
+  {
+    refine λ h a, _,
+    simp only,
+    split_ifs with h',
+    rw [mul_zero],
+    rw [h a h', mul_zero],
+  }
+end
+
+@[simp] lemma pure_bind_on_support (a : α) (f : ∀ (a' : α) (ha : a' ∈ (pure a).support), pmf β) :
+  (pure a).bind_on_support f = f a (by simp) :=
+begin
+  ext b,
+  simp only [nnreal.coe_eq, bind_on_support_apply, pure_apply],
+  refine trans (tsum_congr (λ a', _)) (tsum_ite_eq a _),
+  by_cases h : (a' = a); simp [h],
+end
+
+@[simp] lemma bind_on_support_pure (p : pmf α) :
+  p.bind_on_support (λ a _, pure a) = p :=
+begin
+  ext a,
+  have h : ∀ (a' : α), ite (p a' = 0) 0 (ite (a = a') (p a') 0) = ite (a = a') (p a) 0,
+  { intro a',
+    split_ifs with h1 h2 h3 h4,
+    any_goals { trivial },
+    all_goals { simp only * at * } },
+  suffices : ∑' (a_1 : α), ite (a = a_1) (p a) 0 = p a,
+  by simpa [h],
+  exact (trans (tsum_congr (λ a', by rw @eq_comm α a a')) (tsum_ite_eq a (p a))),
+end
+
+@[simp] lemma bind_on_support_bind_on_support (p : pmf α)
+  (f : ∀ a ∈ p.support, pmf β)
+  (g : ∀ (b ∈ (p.bind_on_support f).support), pmf γ) :
+  (p.bind_on_support f).bind_on_support g =
+    p.bind_on_support (λ a ha, (f a ha).bind_on_support
+      (λ b hb, g b ((p.mem_support_bind_on_support_iff f b).mpr ⟨a, ha, hb⟩))) :=
+begin
+  refine pmf.ext (λ a, _),
+  simp only [ennreal.coe_eq_coe.symm, coe_bind_on_support_apply,
+    ennreal.tsum_mul_left.symm, ennreal.tsum_mul_right.symm],
+  refine trans (ennreal.tsum_comm) (tsum_congr (λ a', _)),
+  split_ifs with h,
+  { simp only [h, ennreal.coe_zero, zero_mul, tsum_zero] },
+  { simp only [← ennreal.tsum_mul_left, ← mul_assoc],
+    refine tsum_congr (λ b, _),
+    split_ifs with h1 h2 h3 h4,
+    { simp only [mul_zero] },
+    { rw bind_on_support_eq_zero_iff at h1,
+      simp only [h1 a' h, ennreal.coe_zero, zero_mul, mul_zero] },
+    { simp only [h3, ennreal.coe_zero, mul_zero, zero_mul] },
+    { refl } }
+end
+
+lemma bind_on_support_comm (p : pmf α) (q : pmf β)
+  (f : ∀ (a ∈ p.support) (b ∈ q.support), pmf γ) :
+  p.bind_on_support (λ a ha, q.bind_on_support (f a ha)) =
+    q.bind_on_support (λ b hb, p.bind_on_support (λ a ha, f a ha b hb)) :=
+begin
+  apply pmf.ext, rintro a,
+  simp only [ennreal.coe_eq_coe.symm, coe_bind_on_support_apply,
+    ennreal.tsum_mul_left.symm, ennreal.tsum_mul_right.symm],
+  sorry,
+  -- simp only [ennreal.coe_eq_coe.symm, coe_bind_apply, ennreal.tsum_mul_left.symm,
+  --            ennreal.tsum_mul_right.symm],
+  -- rw [ennreal.tsum_comm],
+  -- simp [mul_assoc, mul_left_comm, mul_comm]
+end
+
 protected lemma bind.summable (p : pmf α) (f : α → pmf β) (b : β) :
   summable (λ a : α, p a * f a b) :=
 begin
@@ -79,6 +210,24 @@ def bind (p : pmf α) (f : α → pmf β) : pmf β :=
     simp [ennreal.tsum_mul_left, (ennreal.coe_tsum (f _).summable_coe).symm,
       (ennreal.coe_tsum p.summable_coe).symm]
   end⟩
+
+def bind' (p : pmf α) (f : α → pmf β) : pmf β :=
+p.bind_on_support (λ a _, f a)
+
+@[simp] lemma bind'_apply (p : pmf α) (f : α → pmf β) (b : β) :
+  p.bind' f b = ∑' a, p a * f a b :=
+begin
+  simp only [bind', bind_on_support_apply],
+  refine congr_arg _ (funext (λ a, _)),
+  split_ifs with h; simp [h],
+end
+
+lemma coe_bind'_apply (p : pmf α) (f : α → pmf β) (b : β) :
+  (p.bind' f b : ℝ≥0∞) = ∑' a, p a * f a b :=
+by simp [bind'_apply, ennreal.coe_tsum (bind.summable p f b)]
+
+lemma pure_bind' (a : α) (f : α → pmf β) : (pure a).bind' f = f a :=
+pure_bind_on_support a (λ a _, f a)
 
 @[simp] lemma bind_apply (p : pmf α) (f : α → pmf β) (b : β) : p.bind f b = ∑'a, p a * f a b :=
 rfl
@@ -115,6 +264,18 @@ begin
              ennreal.tsum_mul_right.symm],
   rw [ennreal.tsum_comm],
   simp [mul_assoc, mul_left_comm, mul_comm]
+end
+
+/-- `bind_on_support` reduces to `bind` if `f` doesn't depend on the additional hypothesis -/
+lemma bind_on_support_eq_bind (p : pmf α) (f : α → pmf β) :
+  p.bind_on_support (λ a _, f a) = p.bind f :=
+begin
+  ext b,
+  simp [p.bind_on_support_apply (λ a _, f a)],
+  refine congr_arg _ (funext (λ a, _)),
+  split_ifs,
+  { simp [h] },
+  { exact rfl },
 end
 
 /-- The functorial action of a function on a `pmf`. -/

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -841,7 +841,7 @@ lemma tsum_eq_zero_iff (hf : summable f) : ∑' i, f i = 0 ↔ ∀ x, f x = 0 :=
 by rw [←has_sum_zero_iff, hf.has_sum_iff]
 
 lemma tsum_ne_zero_iff (hf : summable f) : ∑' i, f i ≠ 0 ↔ ∃ x, f x ≠ 0 :=
-by rw [ne.def, ← not_iff, tsum_eq_zero_iff hf, not_iff, not_forall]
+by rw [ne.def, tsum_eq_zero_iff hf, not_forall]
 
 end canonically_ordered
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -329,11 +329,11 @@ lemma tsum_eq_single {f : β → α} (b : β) (hf : ∀b' ≠ b, f b' = 0)  :
 (has_sum_ite_eq b a).tsum_eq
 
 lemma tsum_dite_right (P : Prop) [decidable P] (x : β → ¬ P → α) :
-  ∑' (b : β), dite P (λ h, (0 : α)) (x b) = dite P (λ h, 0) (λ h, ∑' (b : β), x b h) :=
+  ∑' (b : β), (if h : P then (0 : α) else x b h) = if h : P then (0 : α) else ∑' (b : β), x b h :=
 by by_cases hP : P; simp [hP]
 
 lemma tsum_dite_left (P : Prop) [decidable P] (x : β → P → α) :
-  ∑' (b : β), dite P (x b) (λ h, 0) = dite P (λ h, ∑' (b : β), x b h) (λ h, 0) :=
+  ∑' (b : β), (if h : P then x b h else 0) = if h : P then (∑' (b : β), x b h) else 0 :=
 by by_cases hP : P; simp [hP]
 
 lemma equiv.tsum_eq_tsum_of_has_sum_iff_has_sum {α' : Type*} [add_comm_monoid α']

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -305,8 +305,8 @@ lemma tsum_eq_sum {f : β → α} {s : finset β} (hf : ∀b∉s, f b = 0)  :
   ∑' b, f b = ∑ b in s, f b :=
 (has_sum_sum_of_ne_finset_zero hf).tsum_eq
 
-lemma tsum_congr (hfg : ∀ b, f b = g b) :
-  ∑' b, f b = ∑' b, g b :=
+lemma tsum_congr {α β : Type*} [add_comm_monoid α] [topological_space α]
+  {f g : β → α} (hfg : ∀ b, f b = g b) : ∑' b, f b = ∑' b, g b :=
 congr_arg tsum (funext hfg)
 
 lemma tsum_fintype [fintype β] (f : β → α) : ∑'b, f b = ∑ b, f b :=

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -305,6 +305,10 @@ lemma tsum_eq_sum {f : β → α} {s : finset β} (hf : ∀b∉s, f b = 0)  :
   ∑' b, f b = ∑ b in s, f b :=
 (has_sum_sum_of_ne_finset_zero hf).tsum_eq
 
+lemma tsum_congr (hfg : ∀ b, f b = g b) :
+  ∑' b, f b = ∑' b, g b :=
+congr_arg tsum (funext hfg)
+
 lemma tsum_fintype [fintype β] (f : β → α) : ∑'b, f b = ∑ b, f b :=
 (has_sum_fintype f).tsum_eq
 
@@ -778,10 +782,6 @@ begin
   { simp [tsum_eq_zero_of_not_summable hf] }
 end
 
-lemma tsum_congr {f g : ℕ → ℝ} (hfg : ∀ n, f n = g n) :
-  ∑' n, f n = ∑' n, g n :=
-congr_arg tsum (funext hfg)
-
 end order_topology
 
 section ordered_topological_group
@@ -831,6 +831,9 @@ end
 
 lemma tsum_eq_zero_iff (hf : summable f) : ∑' i, f i = 0 ↔ ∀ x, f x = 0 :=
 by rw [←has_sum_zero_iff, hf.has_sum_iff]
+
+lemma tsum_ne_zero_iff (hf : summable f) : ∑' i, f i ≠ 0 ↔ ∃ x, f x ≠ 0 :=
+by rw [ne.def, ← not_iff, tsum_eq_zero_iff hf, not_iff, not_forall]
 
 end canonically_ordered
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -328,6 +328,14 @@ lemma tsum_eq_single {f : β → α} (b : β) (hf : ∀b' ≠ b, f b' = 0)  :
   ∑' b', (if b' = b then a else 0) = a :=
 (has_sum_ite_eq b a).tsum_eq
 
+lemma tsum_dite_right (P : Prop) [decidable P] (x : β → ¬ P → α) :
+  ∑' (b : β), dite P (λ h, (0 : α)) (x b) = dite P (λ h, 0) (λ h, ∑' (b : β), x b h) :=
+by by_cases hP : P; simp [hP]
+
+lemma tsum_dite_left (P : Prop) [decidable P] (x : β → P → α) :
+  ∑' (b : β), dite P (x b) (λ h, 0) = dite P (λ h, ∑' (b : β), x b h) (λ h, 0) :=
+by by_cases hP : P; simp [hP]
+
 lemma equiv.tsum_eq_tsum_of_has_sum_iff_has_sum {α' : Type*} [add_comm_monoid α']
   [topological_space α'] (e : α' ≃ α) (h0 : e 0 = 0) {f : β → α} {g : γ → α'}
   (h : ∀ {a}, has_sum f (e a) ↔ has_sum g a) :


### PR DESCRIPTION
---
I considered changing pmf.bind to just be an instance of pmf.bind_on_support, but it seemed better to just create the lemma bind_on_support_eq_bind and leave the current definition as is.
