### PR TITLE
[Merged by Bors] - feat(ring_theory/simple_module): introduce `is_semisimple_module`

### DIFF
--- a/src/order/compactly_generated.lean
+++ b/src/order/compactly_generated.lean
@@ -419,12 +419,13 @@ instance is_atomistic_of_is_complemented [is_complemented α] : is_atomistic α 
 end, λ _, and.left⟩⟩
 
 /-- See Theorem 6.6, Călugăreanu -/
-theorem is_complemented_of_is_atomistic [is_atomistic α] : is_complemented α :=
+theorem is_complemented_of_Sup_atoms_eq_top (h : Sup {a : α | is_atom a} = ⊤) : is_complemented α :=
 ⟨λ b, begin
-  rcases zorn.zorn_subset
-    {s : set α | complete_lattice.independent s ∧ b ⊓ Sup s = ⊥ ∧ ∀ a ∈ s, is_atom a} _ with
-      ⟨s, ⟨s_ind, b_inf_Sup_s, s_atoms⟩, s_max⟩,
-  { refine ⟨Sup s, le_of_eq b_inf_Sup_s, le_iff_atom_le_imp.2 (λ a ha _, _)⟩,
+  obtain ⟨s, ⟨s_ind, b_inf_Sup_s, s_atoms⟩, s_max⟩ := zorn.zorn_subset
+    {s : set α | complete_lattice.independent s ∧ b ⊓ Sup s = ⊥ ∧ ∀ a ∈ s, is_atom a} _,
+  { refine ⟨Sup s, le_of_eq b_inf_Sup_s, _⟩,
+    rw [← h, Sup_le_iff],
+    intros a ha,
     rw ← inf_eq_left,
     refine (eq_bot_or_eq_of_le_atom ha inf_le_left).resolve_left (λ con, ha.1 _),
     rw [eq_bot_iff, ← con],
@@ -468,6 +469,10 @@ theorem is_complemented_of_is_atomistic [is_atomistic α] : is_complemented α :
     { rcases set.mem_sUnion.1 ha with ⟨s, sc, as⟩,
       exact (hc1 sc).2.2 a as } }
 end⟩
+
+/-- See Theorem 6.6, Călugăreanu -/
+theorem is_complemented_of_is_atomistic [is_atomistic α] : is_complemented α :=
+is_complemented_of_Sup_atoms_eq_top Sup_atoms_eq_top
 
 theorem is_complemented_iff_is_atomistic : is_complemented α ↔ is_atomistic α :=
 begin

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -709,4 +709,32 @@ def order_iso.Ici_bot [order_bot α] : set.Ici (⊥ : α) ≃o α :=
 { map_rel_iff' := λ x y, by refl,
   .. (@equiv.subtype_univ_equiv α (set.Ici (⊥ : α)) (λ x, bot_le)) }
 
+section bounded_lattice
+
+variables [bounded_lattice α]  [bounded_lattice β] (f : α ≃o β)
+
+lemma order_iso.is_compl {x y : α} (h : is_compl x y) : is_compl (f x) (f y) :=
+⟨by { rw [← f.map_bot, ← f.map_inf, f.map_rel_iff], exact h.1 },
+  by { rw [← f.map_top, ← f.map_sup, f.map_rel_iff], exact h.2 }⟩
+
+theorem order_iso.is_compl_iff {x y : α} :
+  is_compl x y ↔ is_compl (f x) (f y) :=
+⟨f.is_compl, λ h, begin
+  rw [← f.symm_apply_apply x, ← f.symm_apply_apply y],
+  exact f.symm.is_compl h,
+end⟩
+
+lemma order_iso.is_complemented [bounded_lattice α] [bounded_lattice β] (f : α ≃o β)
+  [is_complemented α] : is_complemented β :=
+⟨λ x, begin
+  obtain ⟨y, hy⟩ := exists_is_compl (f.symm x),
+  rw ← f.symm_apply_apply y at hy,
+  refine ⟨f y, f.symm.is_compl_iff.2 hy⟩,
+end⟩
+
+theorem order_iso.is_complemented_iff [bounded_lattice α] [bounded_lattice β] (f : α ≃o β) :
+  is_complemented α ↔ is_complemented β :=
+⟨by { introI, exact f.is_complemented }, by { introI, exact f.symm.is_complemented }⟩
+
+end bounded_lattice
 end lattice_isos

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -712,6 +712,7 @@ def order_iso.Ici_bot [order_bot α] : set.Ici (⊥ : α) ≃o α :=
 section bounded_lattice
 
 variables [bounded_lattice α]  [bounded_lattice β] (f : α ≃o β)
+include f
 
 lemma order_iso.is_compl {x y : α} (h : is_compl x y) : is_compl (f x) (f y) :=
 ⟨by { rw [← f.map_bot, ← f.map_inf, f.map_rel_iff], exact h.1 },
@@ -724,7 +725,7 @@ theorem order_iso.is_compl_iff {x y : α} :
   exact f.symm.is_compl h,
 end⟩
 
-lemma order_iso.is_complemented [bounded_lattice α] [bounded_lattice β] (f : α ≃o β)
+lemma order_iso.is_complemented
   [is_complemented α] : is_complemented β :=
 ⟨λ x, begin
   obtain ⟨y, hy⟩ := exists_is_compl (f.symm x),
@@ -732,7 +733,7 @@ lemma order_iso.is_complemented [bounded_lattice α] [bounded_lattice β] (f : �
   refine ⟨f y, f.symm.is_compl_iff.2 hy⟩,
 end⟩
 
-theorem order_iso.is_complemented_iff [bounded_lattice α] [bounded_lattice β] (f : α ≃o β) :
+theorem order_iso.is_complemented_iff :
   is_complemented α ↔ is_complemented β :=
 ⟨by { introI, exact f.is_complemented }, by { introI, exact f.symm.is_complemented }⟩
 

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -7,6 +7,7 @@ import algebra.monoid_algebra
 import algebra.invertible
 import algebra.char_p.basic
 import linear_algebra.basis
+import ring_theory.simple_module
 
 /-!
 # Maschke's theorem
@@ -175,4 +176,9 @@ theorem is_complemented (not_dvd : ¬(ring_char k ∣ fintype.card G)) :
   is_complemented (submodule (monoid_algebra k G) V) := ⟨exists_is_compl not_dvd⟩
 
 end submodule
+
+theorem is_semisimple_module (not_dvd : ¬(ring_char k ∣ fintype.card G)) :
+  is_semisimple_module (monoid_algebra k G) V :=
+submodule.is_complemented not_dvd
+
 end monoid_algebra

--- a/src/ring_theory/simple_module.lean
+++ b/src/ring_theory/simple_module.lean
@@ -27,7 +27,7 @@ import order.atoms
 
 -/
 
-variables (R : Type*) [comm_ring R] (M : Type*) [add_comm_group M] [module R M]
+variables (R : Type*) [ring R] (M : Type*) [add_comm_group M] [module R M]
 
 /-- A module is simple when it has only two submodules, `⊥` and `⊤`. -/
 abbreviation is_simple_module := (is_simple_lattice (submodule R M))
@@ -82,8 +82,7 @@ end
 instance is_semisimple_submodule {m : submodule R M} : is_semisimple_module R m :=
 begin
   have f : submodule R m ≃o set.Iic m := submodule.map_subtype.rel_iso m,
-  apply f.is_complemented_iff.2,
-  apply is_modular_lattice.is_complemented_Iic,
+  exact f.is_complemented_iff.2 is_modular_lattice.is_complemented_Iic,
 end
 
 end is_semisimple_module

--- a/src/ring_theory/simple_module.lean
+++ b/src/ring_theory/simple_module.lean
@@ -13,6 +13,8 @@ import order.atoms
 ## Main Definitions
   * `is_simple_module` indicates that a module has no proper submodules
   (the only submodules are `⊥` and `⊤`).
+  * `is_semisimple_module` indicates that every submodule has a complement, or equivalently,
+    the module is a direct sum of simple modules.
   * A `division_ring` structure on the endomorphism ring of a simple module.
 
 ## Main Results
@@ -20,7 +22,7 @@ import order.atoms
   is either bijective or 0, leading to a `division_ring` structure on the endomorphism ring.
 
 ## TODO
-  * Semisimple modules, Artin-Wedderburn Theory
+  * Artin-Wedderburn Theory
   * Unify with the work on Schur's Lemma in a category theory context
 
 -/
@@ -29,6 +31,10 @@ variables (R : Type*) [comm_ring R] (M : Type*) [add_comm_group M] [module R M]
 
 /-- A module is simple when it has only two submodules, `⊥` and `⊤`. -/
 abbreviation is_simple_module := (is_simple_lattice (submodule R M))
+
+/-- A module is semisimple when every submodule has a complement, or equivalently, the module
+  is a direct sum of simple modules. -/
+abbreviation is_semisimple_module := (is_complemented (submodule R M))
 
 -- Making this an instance causes the linter to complain of "dangerous instances"
 theorem is_simple_module.nontrivial [is_simple_module R M] : nontrivial M :=
@@ -39,7 +45,52 @@ theorem is_simple_module.nontrivial [is_simple_module R M] : nontrivial M :=
   simp [submodule.mem_bot,submodule.mem_top, h x],
 end⟩⟩
 
-variables {R} {M}  {N : Type*} [add_comm_group N] [module R N]
+variables {R} {M} {m : submodule R M} {N : Type*} [add_comm_group N] [module R N]
+
+theorem is_simple_module_iff_is_atom :
+  is_simple_module R m ↔ is_atom m :=
+begin
+  rw ← set.is_simple_lattice_Iic_iff_is_atom,
+  apply order_iso.is_simple_lattice_iff,
+  exact submodule.map_subtype.rel_iso m,
+end
+
+namespace is_simple_module
+
+variable [hm : is_simple_module R m]
+
+@[simp]
+lemma is_atom : is_atom m := is_simple_module_iff_is_atom.1 hm
+
+end is_simple_module
+
+theorem is_semisimple_of_Sup_simples_eq_top
+  (h : Sup {m : submodule R M | is_simple_module R m} = ⊤) :
+  is_semisimple_module R M :=
+is_complemented_of_Sup_atoms_eq_top (by simp_rw [← h, is_simple_module_iff_is_atom])
+
+namespace is_semisimple_module
+
+variable [is_semisimple_module R M]
+
+theorem Sup_simples_eq_top : Sup {m : submodule R M | is_simple_module R m} = ⊤ :=
+begin
+  simp_rw is_simple_module_iff_is_atom,
+  exact Sup_atoms_eq_top,
+end
+
+instance is_semisimple_submodule {m : submodule R M} : is_semisimple_module R m :=
+begin
+  have f : submodule R m ≃o set.Iic m := submodule.map_subtype.rel_iso m,
+  apply f.is_complemented_iff.2,
+  apply is_modular_lattice.is_complemented_Iic,
+end
+
+end is_semisimple_module
+
+theorem is_semisimple_iff_top_eq_Sup_simples :
+  Sup {m : submodule R M | is_simple_module R m} = ⊤ ↔ is_semisimple_module R M :=
+⟨is_semisimple_of_Sup_simples_eq_top, by { introI, exact is_semisimple_module.Sup_simples_eq_top }⟩
 
 namespace linear_map
 


### PR DESCRIPTION
Defines `is_semisimple_module` to mean that the lattice of submodules is complemented
Shows that this is equivalent to the module being the `Sup` of its simple submodules

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
