### PR TITLE
[Merged by Bors] - feat(measure_theory/borel_space): add ae_measurable versions of finset.measurable_prod and measurable.ennreal_tsum

### DIFF
--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -560,6 +560,15 @@ finset.induction_on s
   (assume i s his ih, by simpa [his] using (hf i).mul ih)
 
 @[to_additive]
+lemma finset.ae_measurable_prod {ι : Type*} [comm_monoid α] [has_continuous_mul α]
+  [second_countable_topology α] {f : ι → δ → α} {μ : measure δ} (s : finset ι)
+  (hf : ∀i, ae_measurable (f i) μ) :
+  ae_measurable (λ a, ∏ i in s, f i a) μ :=
+finset.induction_on s
+  (by simp only [finset.prod_empty, ae_measurable_const])
+  (assume i s his ih, by simpa [his] using (hf i).mul ih)
+
+@[to_additive]
 lemma measurable_inv [group α] [topological_group α] : measurable (has_inv.inv : α → α) :=
 continuous_inv.measurable
 
@@ -1200,6 +1209,12 @@ ennreal.measurable_sub.comp (hf.prod_mk hg)
 lemma measurable.ennreal_tsum {ι} [encodable ι] {f : ι → α → ℝ≥0∞} (h : ∀ i, measurable (f i)) :
   measurable (λ x, ∑' i, f i x) :=
 by { simp_rw [ennreal.tsum_eq_supr_sum], apply measurable_supr, exact λ s, s.measurable_sum h }
+
+lemma ae_measurable.ennreal_tsum {ι} [encodable ι] {f : ι → α → ℝ≥0∞} {μ : measure α}
+  (h : ∀ i, ae_measurable (f i) μ) :
+  ae_measurable (λ x, ∑' i, f i x) μ :=
+by { simp_rw [ennreal.tsum_eq_supr_sum], apply ae_measurable_supr,
+  exact λ s, finset.ae_measurable_sum s h }
 
 lemma measurable.ennreal_inv {f : α → ℝ≥0∞} (hf : measurable f) : measurable (λ a, (f a)⁻¹) :=
 ennreal.measurable_inv.comp hf

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -1685,6 +1685,13 @@ begin
   rw [lintegral_indicator _ (hf (measurable_set_singleton ∞))], simp [ennreal.top_mul, preimage, h]
 end
 
+lemma ae_lt_top' {f : α → ℝ≥0∞} (hf : ae_measurable f μ) (h2f : ∫⁻ x, f x ∂μ < ∞) :
+  ∀ᵐ x ∂μ, f x < ∞ :=
+begin
+  have h2f_meas : ∫⁻ x, hf.mk f x ∂μ < ∞, by rwa ←lintegral_congr_ae hf.ae_eq_mk,
+  exact (ae_lt_top hf.measurable_mk h2f_meas).mp (hf.ae_eq_mk.mono (λ x hx h, by rwa hx)),
+end
+
 /-- Given a measure `μ : measure α` and a function `f : α → ℝ≥0∞`, `μ.with_density f` is the
 measure such that for a measurable set `s` we have `μ.with_density f s = ∫⁻ a in s, f a ∂μ`. -/
 def measure.with_density (μ : measure α) (f : α → ℝ≥0∞) : measure α :=


### PR DESCRIPTION
Also add an ae_measurable version of `ae_lt_top`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
