### PR TITLE
[Merged by Bors] - feat(order/liminf_limsup): liminf_nat_add and liminf_le_of_frequently_le'

### DIFF
--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import order.bounds
-import tactic.nth_rewrite
 
 /-!
 # Theory of complete lattices

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import order.bounds
+import tactic.nth_rewrite
 
 /-!
 # Theory of complete lattices
@@ -912,6 +913,19 @@ end
 
 lemma infi_ge_eq_infi_nat_add {u : ℕ → α} (n : ℕ) : (⨅ i ≥ n, u i) = ⨅ i, u (i + n) :=
 @supr_ge_eq_supr_nat_add (order_dual α) _ _ _
+
+lemma monotone.supr_nat_add {f : ℕ → α} (hf : monotone f) (k : ℕ) :
+  (⨆ n, f n) = (⨆ n, f (n + k)) :=
+le_antisymm (supr_le_supr (λ i, hf (nat.le_add_right i k)))
+    (supr_le (λ i, (le_refl _).trans (le_supr _ (i + k))))
+
+lemma supr_infi_ge_nat_add (f : ℕ → α) (k : ℕ) :
+  (⨆ n, ⨅ i ≥ n, f i) = ⨆ n, ⨅ i ≥ n, f (i + k) :=
+begin
+  rw monotone.supr_nat_add _ k,
+  { simp_rw [infi_ge_eq_infi_nat_add, ←nat.add_assoc], },
+  { exact λ n m hnm, le_infi (λ i, (infi_le _ i).trans (le_infi (λ h, infi_le _ (hnm.trans h)))), },
+end
 
 end
 

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import order.bounds
+import tactic.nth_rewrite
 
 /-!
 # Theory of complete lattices
@@ -914,16 +915,17 @@ lemma infi_ge_eq_infi_nat_add {u : ℕ → α} (n : ℕ) : (⨅ i ≥ n, u i) = 
 @supr_ge_eq_supr_nat_add (order_dual α) _ _ _
 
 lemma monotone.supr_nat_add {f : ℕ → α} (hf : monotone f) (k : ℕ) :
-  (⨆ n, f n) = (⨆ n, f (n + k)) :=
-le_antisymm (supr_le_supr (λ i, hf (nat.le_add_right i k)))
-    (supr_le (λ i, (le_refl _).trans (le_supr _ (i + k))))
+  (⨆ n, f (n + k)) = ⨆ n, f n :=
+le_antisymm (supr_le (λ i, (le_refl _).trans (le_supr _ (i + k))))
+    (supr_le_supr (λ i, hf (nat.le_add_right i k)))
 
-lemma supr_infi_ge_nat_add (f : ℕ → α) (k : ℕ) :
-  (⨆ n, ⨅ i ≥ n, f i) = ⨆ n, ⨅ i ≥ n, f (i + k) :=
+@[simp] lemma supr_infi_ge_nat_add (f : ℕ → α) (k : ℕ) :
+  (⨆ n, ⨅ i ≥ n, f (i + k)) = ⨆ n, ⨅ i ≥ n, f i :=
 begin
-  rw monotone.supr_nat_add _ k,
+  have hf : monotone (λ n, ⨅ i ≥ n, f i),
+    from λ n m hnm, le_infi (λ i, (infi_le _ i).trans (le_infi (λ h, infi_le _ (hnm.trans h)))),
+  rw ←monotone.supr_nat_add hf k,
   { simp_rw [infi_ge_eq_infi_nat_add, ←nat.add_assoc], },
-  { exact λ n m hnm, le_infi (λ i, (infi_le _ i).trans (le_infi (λ h, infi_le _ (hnm.trans h)))), },
 end
 
 end

--- a/src/order/liminf_limsup.lean
+++ b/src/order/liminf_limsup.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2018 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sébastien Gouëzel, Johannes Hölzl
+Authors: Sébastien Gouëzel, Johannes Hölzl, Rémy Degenne
 -/
 import order.filter.partial
 import order.filter.at_top_bot
@@ -364,6 +364,32 @@ lemma liminf_eq_supr_infi_of_nat' {u : ℕ → α} : liminf at_top u = ⨆ n : �
 theorem has_basis.liminf_eq_supr_infi {p : ι → Prop} {s : ι → set β} {f : filter β} {u : β → α}
   (h : f.has_basis p s) : f.liminf u = ⨆ i (hi : p i), ⨅ a ∈ s i, u a :=
 @has_basis.limsup_eq_infi_supr (order_dual α) _ _ _ _ _ _ _ h
+
+lemma liminf_nat_add (f : ℕ → α) (k : ℕ) :
+  at_top.liminf f = at_top.liminf (λ i, f (i + k)) :=
+by { simp_rw liminf_eq_supr_infi_of_nat, exact supr_infi_ge_nat_add f k }
+
+lemma limsup_nat_add (f : ℕ → α) (k : ℕ) :
+  at_top.limsup f = at_top.limsup (λ i, f (i + k)) :=
+@liminf_nat_add (order_dual α) _ f k
+
+lemma liminf_le_of_frequently_le' {α β} [complete_lattice β]
+  {f : filter α} {u : α → β} {x : β} (h : ∃ᶠ a in f, u a ≤ x) :
+  f.liminf u ≤ x :=
+begin
+  rw liminf_eq,
+  refine Sup_le (λ b hb, _),
+  have hbx : ∃ᶠ a in f, b ≤ x,
+  { revert h,
+    rw [←not_imp_not, not_frequently, not_frequently],
+    exact λ h, hb.mp (h.mono (λ a hbx hba hax, hbx (hba.trans hax))), },
+  exact hbx.exists.some_spec,
+end
+
+lemma le_limsup_of_frequently_le' {α β} [complete_lattice β]
+  {f : filter α} {u : α → β} {x : β} (h : ∃ᶠ a in f, x ≤ u a) :
+  x ≤ f.limsup u :=
+@liminf_le_of_frequently_le' _ (order_dual β) _ _ _ _ h
 
 end complete_lattice
 

--- a/src/order/liminf_limsup.lean
+++ b/src/order/liminf_limsup.lean
@@ -365,10 +365,12 @@ theorem has_basis.liminf_eq_supr_infi {p : ι → Prop} {s : ι → set β} {f :
   (h : f.has_basis p s) : f.liminf u = ⨆ i (hi : p i), ⨅ a ∈ s i, u a :=
 @has_basis.limsup_eq_infi_supr (order_dual α) _ _ _ _ _ _ _ h
 
-lemma liminf_nat_add (f : ℕ → α) (k : ℕ) : at_top.liminf f = at_top.liminf (λ i, f (i + k)) :=
+@[simp] lemma liminf_nat_add (f : ℕ → α) (k : ℕ) :
+  at_top.liminf (λ i, f (i + k)) = at_top.liminf f :=
 by { simp_rw liminf_eq_supr_infi_of_nat, exact supr_infi_ge_nat_add f k }
 
-lemma limsup_nat_add (f : ℕ → α) (k : ℕ) : at_top.limsup f = at_top.limsup (λ i, f (i + k)) :=
+@[simp] lemma limsup_nat_add (f : ℕ → α) (k : ℕ) :
+  at_top.limsup (λ i, f (i + k)) = at_top.limsup f :=
 @liminf_nat_add (order_dual α) _ f k
 
 lemma liminf_le_of_frequently_le' {α β} [complete_lattice β]

--- a/src/order/liminf_limsup.lean
+++ b/src/order/liminf_limsup.lean
@@ -365,12 +365,10 @@ theorem has_basis.liminf_eq_supr_infi {p : ι → Prop} {s : ι → set β} {f :
   (h : f.has_basis p s) : f.liminf u = ⨆ i (hi : p i), ⨅ a ∈ s i, u a :=
 @has_basis.limsup_eq_infi_supr (order_dual α) _ _ _ _ _ _ _ h
 
-lemma liminf_nat_add (f : ℕ → α) (k : ℕ) :
-  at_top.liminf f = at_top.liminf (λ i, f (i + k)) :=
+lemma liminf_nat_add (f : ℕ → α) (k : ℕ) : at_top.liminf f = at_top.liminf (λ i, f (i + k)) :=
 by { simp_rw liminf_eq_supr_infi_of_nat, exact supr_infi_ge_nat_add f k }
 
-lemma limsup_nat_add (f : ℕ → α) (k : ℕ) :
-  at_top.limsup f = at_top.limsup (λ i, f (i + k)) :=
+lemma limsup_nat_add (f : ℕ → α) (k : ℕ) : at_top.limsup f = at_top.limsup (λ i, f (i + k)) :=
 @liminf_nat_add (order_dual α) _ f k
 
 lemma liminf_le_of_frequently_le' {α β} [complete_lattice β]


### PR DESCRIPTION
Add `liminf_nat_add (f : ℕ → α) (k : ℕ) : at_top.liminf f = at_top.liminf (λ i, f (i + k))`. Same for `limsup`.

Add `liminf_le_of_frequently_le'`, variant of `liminf_le_of_frequently_le` in which the lattice is complete but there is no linear order. Same for `limsup`.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
