### PR TITLE
[Merged by Bors] - fix(data/real/basic): remove `decidable_le` field in `real.conditionally_complete_linear_order`

### DIFF
--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -451,7 +451,6 @@ noncomputable instance : conditionally_complete_linear_order ℝ :=
     assume (s : set ℝ) (a : ℝ) (_ : s.nonempty) (H : ∀b∈s, a ≤ b),
     show a ≤ Inf s,
       from lb_le_Inf s ‹s.nonempty› H,
-  decidable_le := classical.dec_rel _,
  ..real.linear_order, ..real.lattice}
 
 theorem Sup_empty : Sup (∅ : set ℝ) = 0 := dif_neg $ by simp


### PR DESCRIPTION
Because of this field, `@conditionally_complete_linear_order.to_linear_order ℝ real.conditionally_complete_linear_order` and `real.linear_order` were not defeq

See : https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Different.20linear.20orders.20on.20reals/near/226257434

Co-authored by @urkud 
