### PR TITLE
[Merged by Bors] - feat(analysis/calculus/inverse): a function with onto strict derivative is locally onto

### DIFF
--- a/src/analysis/calculus/implicit.lean
+++ b/src/analysis/calculus/implicit.lean
@@ -306,11 +306,6 @@ begin
   exact congr_arg prod.snd (hf.implicit_to_local_homeomorph_of_complemented_self hf' hker).symm
 end
 
-lemma map_nhds_eq_of_complemented
-  (hf : has_strict_fderiv_at f f' a) (hf' : f'.range = ⊤) (hker : f'.ker.closed_complemented) :
-  map f (𝓝 a) = 𝓝 (f a) :=
-(implicit_function_data_of_complemented f f' hf hf' hker).map_nhds_eq
-
 lemma to_implicit_function_of_complemented (hf : has_strict_fderiv_at f f' a)
   (hf' : f'.range = ⊤) (hker : f'.ker.closed_complemented) :
   has_strict_fderiv_at (hf.implicit_function_of_complemented f f' hf' hker (f a))
@@ -414,11 +409,6 @@ lemma eq_implicit_function (hf : has_strict_fderiv_at f f' a) (hf' : f'.range = 
   ∀ᶠ x in 𝓝 a, hf.implicit_function f f' hf' (f x)
     (hf.implicit_to_local_homeomorph f f' hf' x).snd = x :=
 by apply eq_implicit_function_of_complemented
-
-lemma map_nhds_eq (hf : has_strict_fderiv_at f f' a) (hf' : f'.range = ⊤) :
-  map f (𝓝 a) = 𝓝 (f a) :=
-by haveI := finite_dimensional.complete 𝕜 F; exact
-hf.map_nhds_eq_of_complemented hf' f'.ker_closed_complemented_of_finite_dimensional_range
 
 lemma to_implicit_function (hf : has_strict_fderiv_at f f' a) (hf' : f'.range = ⊤) :
   has_strict_fderiv_at (hf.implicit_function f f' hf' (f a))

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -160,13 +160,13 @@ by Banach's open mapping theorem. -/
 
 include cs
 
-variables {s : set E} {c : ℝ≥0} {f' : E →L[𝕜] F} (f'symm : f'.nonlinear_right_inverse)
+variables {s : set E} {c : ℝ≥0} {f' : E →L[𝕜] F}
 
 /-- If a function is linearly approximated by a continuous linear map with a (possibly nonlinear)
 right inverse, then it is locally onto: a ball of an explicit radius is included in the image
 of the map. -/
 theorem surj_on_closed_ball_of_nonlinear_right_inverse
-  (hf : approximates_linear_on f f' s c)
+  (hf : approximates_linear_on f f' s c)  (f'symm : f'.nonlinear_right_inverse)
   {ε : ℝ} {b : E} (ε0 : 0 ≤ ε) (hε : closed_ball b ε ⊆ s) :
   surj_on f (closed_ball b ε) (closed_ball (f b) (((f'symm.nnnorm : ℝ)⁻¹ - c) * ε)) :=
 begin
@@ -298,7 +298,7 @@ begin
   exact tendsto_nhds_unique T1 T2,
 end
 
-lemma open_image (hf : approximates_linear_on f f' s c)
+lemma open_image (hf : approximates_linear_on f f' s c)  (f'symm : f'.nonlinear_right_inverse)
   (hs : is_open s) (hc : subsingleton F ∨ c < f'symm.nnnorm⁻¹) : is_open (f '' s) :=
 begin
   cases hc with hE hc,
@@ -313,8 +313,8 @@ begin
     hε (subset.refl _)
 end
 
-lemma image_mem_nhds (hf : approximates_linear_on f f' s c) (x : E)
-  (hs : s ∈ 𝓝 x) (hc : subsingleton F ∨ c < f'symm.nnnorm⁻¹) :
+lemma image_mem_nhds (hf : approximates_linear_on f f' s c) (f'symm : f'.nonlinear_right_inverse)
+  {x : E} (hs : s ∈ 𝓝 x) (hc : subsingleton F ∨ c < f'symm.nnnorm⁻¹) :
   f '' s ∈ 𝓝 (f x) :=
 begin
   obtain ⟨t, hts, ht, xt⟩ : ∃ t ⊆ s, is_open t ∧ x ∈ t := mem_nhds_sets_iff.1 hs,
@@ -322,13 +322,13 @@ begin
   exact mem_sets_of_superset this (image_subset _ hts),
 end
 
-lemma map_nhds_eq (hf : approximates_linear_on f f' s c) (x : E)
-  (hs : s ∈ 𝓝 x) (hc : subsingleton F ∨ c < f'symm.nnnorm⁻¹) :
+lemma map_nhds_eq (hf : approximates_linear_on f f' s c) (f'symm : f'.nonlinear_right_inverse)
+  {x : E} (hs : s ∈ 𝓝 x) (hc : subsingleton F ∨ c < f'symm.nnnorm⁻¹) :
   map f (𝓝 x) = 𝓝 (f x) :=
 begin
   refine le_antisymm ((hf.continuous_on x (mem_of_nhds hs)).continuous_at hs) (le_map (λ t ht, _)),
   have : f '' (s ∩ t) ∈ 𝓝 (f x) := (hf.mono_set (inter_subset_left s t)).image_mem_nhds
-    f'symm x (inter_mem_sets hs ht) hc,
+    f'symm (inter_mem_sets hs ht) hc,
   exact mem_sets_of_superset this (image_subset _ (inter_subset_right _ _)),
 end
 
@@ -458,7 +458,7 @@ begin
   have cpos : 0 < c, by simp [hc, nnreal.half_pos, nnreal.inv_pos, f'symm_pos],
   obtain ⟨s, s_nhds, hs⟩ : ∃ s ∈ 𝓝 a, approximates_linear_on f f' s c :=
     hf.approximates_deriv_on_nhds (or.inr cpos),
-  apply hs.map_nhds_eq f'symm _ s_nhds (or.inr (nnreal.half_lt_self _)),
+  apply hs.map_nhds_eq f'symm s_nhds (or.inr (nnreal.half_lt_self _)),
   simp [ne_of_gt f'symm_pos],
 end
 

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Heather Macbeth.
 -/
 import analysis.calculus.times_cont_diff
+import analysis.normed_space.banach
 import topology.local_homeomorph
 import topology.metric_space.contracting
 
@@ -65,18 +66,23 @@ variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
 variables {F : Type*} [normed_group F] [normed_space 𝕜 F]
 variables {G : Type*} [normed_group G] [normed_space 𝕜 G]
 variables {G' : Type*} [normed_group G'] [normed_space 𝕜 G']
+variables {ε : ℝ}
+
 
 open asymptotics filter metric set
 open continuous_linear_map (id)
 
+
 /-!
-### Non-linear maps approximating close to affine maps
+### Non-linear maps close to affine maps
 
 In this section we study a map `f` such that `∥f x - f y - f' (x - y)∥ ≤ c * ∥x - y∥` on an open set
-`s`, where `f' : E ≃L[𝕜] F` is a continuous linear equivalence and `c < ∥f'⁻¹∥`. Maps of this type
+`s`, where `f' : E →L[𝕜] F` is a continuous linear map and `c` is suitably small. Maps of this type
 behave like `f a + f' (x - a)` near each `a ∈ s`.
 
-If `E` is a complete space, we prove that the image `f '' s` is open, and `f` is a homeomorphism
+When `f'` is onto, we show that `f` is locally onto.
+
+When `f'` is a continuous linear equiv, we show that `f` is a homeomorphism
 between `s` and `f '' s`. More precisely, we define `approximates_linear_on.to_local_homeomorph` to
 be a `local_homeomorph` with `to_fun = f`, `source = s`, and `target = f '' s`.
 
@@ -145,6 +151,170 @@ continuous_on_iff_continuous_restrict.2 hf.continuous
 
 end
 
+section locally_onto
+/-!
+We prove that a function which is linearly approximated by a continuous linear map with a nonlinear
+right inverse is locally onto. This will apply to the case where the approximating map is a linear
+equivalence, for the local inverse theorem, but also whenever the approximating map is onto,
+by Banach's open mapping theorem. -/
+
+include cs
+
+variables {s : set E} {c : ℝ≥0} {f' : E →L[𝕜] F} (f'symm : f'.nonlinear_right_inverse)
+
+/-- If a function is linearly approximated by a continuous linear map with a (possibly nonlinear)
+right inverse, then it is locally onto: a ball of an explicit radius is included in the image
+of the map. -/
+theorem surj_on_closed_ball_of_nonlinear_right_inverse
+  (hf : approximates_linear_on f f' s c)
+  {ε : ℝ} {b : E} (ε0 : 0 ≤ ε) (hε : closed_ball b ε ⊆ s) :
+  surj_on f (closed_ball b ε) (closed_ball (f b) (((f'symm.nnnorm : ℝ)⁻¹ - c) * ε)) :=
+begin
+  assume y hy,
+  cases le_or_lt (f'symm.nnnorm : ℝ) ⁻¹ c with hc hc,
+  { refine ⟨b, by simp [ε0], _⟩,
+    have : dist y (f b) ≤ 0 :=
+      (mem_closed_ball.1 hy).trans (mul_nonpos_of_nonpos_of_nonneg (by linarith) ε0),
+    simp only [dist_le_zero] at this,
+    rw this },
+  have If' : (0 : ℝ) < f'symm.nnnorm,
+    by { rw [← inv_pos], exact (nnreal.coe_nonneg _).trans_lt hc },
+  have Icf' : (c : ℝ) * f'symm.nnnorm < 1, by rwa [inv_eq_one_div, lt_div_iff If'] at hc,
+  have Jf' : (f'symm.nnnorm : ℝ) ≠ 0 := ne_of_gt If',
+  have Jcf' : (1 : ℝ) - c * f'symm.nnnorm ≠ 0, by { apply ne_of_gt, linarith },
+  /- We have to show that `y` can be written as `f x` for some `x ∈ closed_ball b ε`.
+  The idea of the proof is to apply the Banach contraction principle to the map
+  `g : x ↦ x + f'symm (y - f x)`, as a fixed point of this map satisfies `f x = y`.
+  When `f'symm` is a genuine linear inverse, `g` is a contracting map. In our case, since `f'symm`
+  is nonlinear, this map is not contracting (it is not even continuous), but still the proof of
+  the contraction theorem holds: `uₙ = gⁿ b` is a Cauchy sequence, converging exponentially fast
+  to the desired point `x`. Instead of appealing to general results, we check this by hand.
+
+  The main point is that `f (u n)` becomes exponentially close to `y`, and therefore
+  `dist (u (n+1)) (u n)` becomes exponentally small, making it possible to get an inductive
+  bound on `dist (u n) b`, from which one checks that `u n` stays in the ball on which one has a
+  control. Therefore, the bound can be checked at the next step, and so on inductively.
+  -/
+  set g := λ x, x + f'symm (y - f x) with hg,
+  set u := λ (n : ℕ), g ^[n] b with hu,
+  have usucc : ∀ n, u (n + 1) = g (u n), by simp [hu, ← iterate_succ_apply' g _ b],
+  -- First bound: if `f z` is close to `y`, then `g z` is close to `z` (i.e., almost a fixed point).
+  have A : ∀ z, dist (g z) z ≤ f'symm.nnnorm * dist (f z) y,
+  { assume z,
+    rw [dist_eq_norm, hg, add_sub_cancel', dist_eq_norm'],
+    exact f'symm.bound _ },
+  -- Second bound: if `z` and `g z` are in the set with good control, then `f (g z)` becomes closer
+  -- to `y` than `f z` was (this uses the linear approximation property, and is the reason for the
+  -- choice of the formula for `g`).
+  have B : ∀ z ∈ closed_ball b ε, g z ∈ closed_ball b ε →
+    dist (f (g z)) y ≤ c * f'symm.nnnorm * dist (f z) y,
+  { assume z hz hgz,
+    set v := f'symm (y - f z) with hv,
+    calc dist (f (g z)) y = ∥f (z + v) - y∥ : by rw [dist_eq_norm]
+    ... = ∥f (z + v) - f  z - f' v + f' v - (y - f z)∥ : by { congr' 1, abel }
+    ... = ∥f (z + v) - f z - f' ((z + v) - z)∥ :
+      by simp only [continuous_linear_map.nonlinear_right_inverse.right_inv,
+                    add_sub_cancel', sub_add_cancel]
+    ... ≤ c * ∥(z + v) - z∥ : hf _ (hε hgz) _ (hε hz)
+    ... ≤ c * (f'symm.nnnorm * dist (f z) y) : begin
+      apply mul_le_mul_of_nonneg_left _ (nnreal.coe_nonneg c),
+      simpa [hv, dist_eq_norm'] using f'symm.bound (y - f z),
+    end
+    ... = c * f'symm.nnnorm * dist (f z) y : by ring },
+  -- Third bound: a complicated bound on `dist w b` (that will show up in the induction) is enough
+  -- to check that `w` is in the ball on which one has controls. Will be used to check that `u n`
+  -- belongs to this ball for all `n`.
+  have C : ∀ (n : ℕ) (w : E),
+    dist w b ≤ f'symm.nnnorm * (1 - (c * f'symm.nnnorm)^n) / (1 - c * f'symm.nnnorm) * dist (f b) y
+    → w ∈ closed_ball b ε,
+  { assume n w hw,
+    apply hw.trans,
+    rw [div_mul_eq_mul_div, div_le_iff], swap, { linarith },
+    calc (f'symm.nnnorm : ℝ) * (1 - (c * f'symm.nnnorm) ^ n) * dist (f b) y
+      = f'symm.nnnorm * dist (f b) y * (1 - (c * f'symm.nnnorm) ^ n) : by ring
+      ... ≤ f'symm.nnnorm * dist (f b) y * 1 :
+      begin
+        apply mul_le_mul_of_nonneg_left _ (mul_nonneg (nnreal.coe_nonneg _) dist_nonneg),
+        rw [sub_le_self_iff],
+        exact pow_nonneg (mul_nonneg (nnreal.coe_nonneg _) (nnreal.coe_nonneg _)) _,
+      end
+    ... ≤ f'symm.nnnorm * (((f'symm.nnnorm : ℝ)⁻¹ - c) * ε) :
+      by { rw [mul_one],
+           exact mul_le_mul_of_nonneg_left (mem_closed_ball'.1 hy) (nnreal.coe_nonneg _) }
+    ... = ε * (1 - c * f'symm.nnnorm) : by { field_simp, ring } },
+  /- Main inductive control: `f (u n)` becomes exponentially close to `y`, and therefore
+  `dist (u (n+1)) (u n)` becomes exponentally small, making it possible to get an inductive
+  bound on `dist (u n) b`, from which one checks that `u n` remains in the ball on which we
+  have estimates. -/
+  have D : ∀ (n : ℕ), dist (f (u n)) y ≤ (c * f'symm.nnnorm)^n * dist (f b) y
+    ∧ dist (u n) b ≤ f'symm.nnnorm * (1 - (c * f'symm.nnnorm)^n) / (1 - c * f'symm.nnnorm)
+      * dist (f b) y,
+  { assume n,
+    induction n with n IH, { simp [hu, le_refl] },
+    rw usucc,
+    have Ign : dist (g (u n)) b ≤
+      f'symm.nnnorm * (1 - (c * f'symm.nnnorm)^n.succ) / (1 - c * f'symm.nnnorm) * dist (f b) y :=
+    calc
+      dist (g (u n)) b ≤ dist (g (u n)) (u n) + dist (u n) b : dist_triangle _ _ _
+      ... ≤ f'symm.nnnorm * dist (f (u n)) y + dist (u n) b : add_le_add (A _) (le_refl _)
+      ... ≤ f'symm.nnnorm * ((c * f'symm.nnnorm)^n * dist (f b) y) +
+        f'symm.nnnorm * (1 - (c * f'symm.nnnorm)^n) / (1 - c * f'symm.nnnorm) * dist (f b) y :
+          add_le_add (mul_le_mul_of_nonneg_left IH.1 (nnreal.coe_nonneg _)) IH.2
+      ... = f'symm.nnnorm * (1 - (c * f'symm.nnnorm)^n.succ) / (1 - c * f'symm.nnnorm)
+        * dist (f b) y : by { field_simp [Jcf'], ring_exp },
+    refine ⟨_, Ign⟩,
+    calc dist (f (g (u n))) y ≤ c * f'symm.nnnorm * dist (f (u n)) y :
+      B _ (C n _ IH.2) (C n.succ _ Ign)
+    ... ≤ (c * f'symm.nnnorm) * ((c * f'symm.nnnorm)^n * dist (f b) y) :
+      mul_le_mul_of_nonneg_left IH.1 (mul_nonneg (nnreal.coe_nonneg _) (nnreal.coe_nonneg _))
+    ... = (c * f'symm.nnnorm) ^ n.succ * dist (f b) y : by ring_exp },
+  -- Deduce from the inductive bound that `uₙ` is a Cauchy sequence, therefore converging.
+  have : cauchy_seq u,
+  { have : ∀ (n : ℕ), dist (u n) (u (n+1)) ≤ f'symm.nnnorm * dist (f b) y * (c * f'symm.nnnorm)^n,
+    { assume n,
+      calc dist (u n) (u (n+1)) = dist (g (u n)) (u n) :  by rw [usucc, dist_comm]
+      ... ≤ f'symm.nnnorm * dist (f (u n)) y : A _
+      ... ≤ f'symm.nnnorm * ((c * f'symm.nnnorm)^n * dist (f b) y) :
+        mul_le_mul_of_nonneg_left (D n).1 (nnreal.coe_nonneg _)
+      ... = f'symm.nnnorm * dist (f b) y * (c * f'symm.nnnorm)^n : by ring },
+    exact cauchy_seq_of_le_geometric _ _ Icf' this },
+  obtain ⟨x, hx⟩ : ∃ x, tendsto u at_top (𝓝 x) := cauchy_seq_tendsto_of_complete this,
+  -- As all the `uₙ` belong to the ball `closed_ball b ε`, so does their limit `x`.
+  have xmem : x ∈ closed_ball b ε :=
+    is_closed_ball.mem_of_tendsto hx (eventually_of_forall (λ n, C n _ (D n).2)),
+  refine ⟨x, xmem, _⟩,
+  -- It remains to check that `f x = y`. This follows from continuity of `f` on `closed_ball b ε`
+  -- and from the fact that `f uₙ` is converging to `y` by construction.
+  have hx' : tendsto u at_top (𝓝[closed_ball b ε] x),
+  { simp only [nhds_within, tendsto_inf, hx, true_and, ge_iff_le, tendsto_principal],
+    exact eventually_of_forall (λ n, C n _ (D n).2) },
+  have T1 : tendsto (λ n, f (u n)) at_top (𝓝 (f x)) :=
+    (hf.continuous_on.mono hε x xmem).tendsto.comp hx',
+  have T2 : tendsto (λ n, f (u n)) at_top (𝓝 y),
+  { rw tendsto_iff_dist_tendsto_zero,
+    refine squeeze_zero (λ n, dist_nonneg) (λ n, (D n).1) _,
+    simpa using (tendsto_pow_at_top_nhds_0_of_lt_1
+      (mul_nonneg (nnreal.coe_nonneg _) (nnreal.coe_nonneg _)) Icf').mul tendsto_const_nhds },
+  exact tendsto_nhds_unique T1 T2,
+end
+
+lemma open_image_of_nonlinear_right_inverse (hf : approximates_linear_on f f' s c)
+  (hs : is_open s) (hc : subsingleton F ∨ c < f'symm.nnnorm⁻¹) : is_open (f '' s) :=
+begin
+  cases hc with hE hc,
+  { resetI,
+    apply is_open_discrete },
+  change is_open (f '' s),
+  simp only [is_open_iff_mem_nhds, nhds_basis_closed_ball.mem_iff, ball_image_iff] at hs ⊢,
+  intros x hx,
+  rcases hs x hx with ⟨ε, ε0, hε⟩,
+  refine ⟨(f'symm.nnnorm⁻¹ - c) * ε, mul_pos (sub_pos.2 hc) ε0, _⟩,
+  exact (hf.surj_on_closed_ball_of_nonlinear_right_inverse f'symm (le_of_lt ε0) hε).mono
+    hε (subset.refl _)
+end
+
+end locally_onto
+
 /-!
 From now on we assume that `f` approximates an invertible continuous linear map `f : E ≃L[𝕜] F`.
 
@@ -194,115 +364,9 @@ begin
   exact (λ x hx, (hf.to_local_equiv hc).map_target hx)
 end
 
-/-!
-Now we prove that `f '' s` is an open set. This follows from the fact that the restriction of `f`
-on `s` is an open map. More precisely, we show that the image of a closed ball $$\bar B(a, ε) ⊆ s$$
-under `f` includes the closed ball $$\bar B\left(f(a), \frac{ε}{∥{f'}⁻¹∥⁻¹-c}\right)$$.
-
-In order to do this, we introduce an auxiliary map $$g_y(x) = x + {f'}⁻¹ (y - f x)$$. Provided that
-$$∥y - f a∥ ≤ \frac{ε}{∥{f'}⁻¹∥⁻¹-c}$$, we prove that $$g_y$$ contracts in $$\bar B(a, ε)$$ and `f`
-sends the fixed point of $$g_y$$ to `y`.
--/
-
-section
-
-variables (f f')
-
-/-- Iterations of this map converge to `f⁻¹ y`. The formula is very similar to the one
-used in Newton's method, but we use the same `f'.symm` for all `y` instead of evaluating
-the derivative at each point along the orbit. -/
-def inverse_approx_map (y : F) (x : E) : E := x + f'.symm (y - f x)
-
-end
-
-section inverse_approx_map
-
-variables (y : F) {x x' : E} {ε : ℝ}
-
-local notation `g` := inverse_approx_map f f' y
-
-lemma inverse_approx_map_sub (x x' : E) : g x - g x' = (x - x') - f'.symm (f x - f x') :=
-by { simp only [inverse_approx_map, f'.symm.map_sub], abel }
-
-lemma inverse_approx_map_dist_self (x : E) :
-  dist (g x) x = dist (f'.symm $ f x) (f'.symm y) :=
-by simp only [inverse_approx_map, dist_eq_norm, f'.symm.map_sub, add_sub_cancel', norm_sub_rev]
-
-lemma inverse_approx_map_dist_self_le (x : E) :
-  dist (g x) x ≤ N * dist (f x) y :=
-by { rw inverse_approx_map_dist_self, exact f'.symm.lipschitz.dist_le_mul (f x) y }
-
-lemma inverse_approx_map_fixed_iff {x : E} :
-  g x = x ↔ f x = y :=
-by rw [← dist_eq_zero, inverse_approx_map_dist_self, dist_eq_zero, f'.symm.injective.eq_iff]
-
-lemma inverse_approx_map_contracts_on (hf : approximates_linear_on f (f' : E →L[𝕜] F) s c)
-  {x x'} (hx : x ∈ s) (hx' : x' ∈ s) :
-  dist (g x) (g x') ≤ N * c * dist x x' :=
-begin
-  rw [dist_eq_norm, dist_eq_norm, inverse_approx_map_sub, norm_sub_rev],
-  suffices : ∥f'.symm (f x - f x' - f' (x - x'))∥ ≤ N * (c * ∥x - x'∥),
-    by simpa only [f'.symm.map_sub, f'.symm_apply_apply, mul_assoc] using this,
-  exact (f'.symm : F →L[𝕜] E).le_op_norm_of_le (hf x hx x' hx')
-end
-
-variable {y}
-
-lemma inverse_approx_map_maps_to (hf : approximates_linear_on f (f' : E →L[𝕜] F) s c)
-  (hc : subsingleton E ∨ c < N⁻¹) {b : E} (hb : b ∈ s) (hε : closed_ball b ε ⊆ s)
-  (hy : y ∈ closed_ball (f b) ((N⁻¹ - c) * ε)) :
-  maps_to g (closed_ball b ε) (closed_ball b ε) :=
-begin
-  cases hc with hE hc,
-  { exactI λ x hx, subsingleton.elim x (g x) ▸ hx },
-  assume x hx,
-  simp only [mem_closed_ball] at hx hy ⊢,
-  rw [dist_comm] at hy,
-  calc dist (inverse_approx_map f f' y x) b ≤
-    dist (inverse_approx_map f f' y x) (inverse_approx_map f f' y b) +
-      dist (inverse_approx_map f f' y b) b : dist_triangle _ _ _
-  ... ≤ N * c * dist x b + N * dist (f b) y :
-    add_le_add (hf.inverse_approx_map_contracts_on y (hε hx) hb)
-      (inverse_approx_map_dist_self_le _ _)
-  ... ≤ N * c * ε + N * ((N⁻¹ - c) * ε) :
-    add_le_add (mul_le_mul_of_nonneg_left hx (mul_nonneg (nnreal.coe_nonneg _) c.coe_nonneg))
-      (mul_le_mul_of_nonneg_left hy (nnreal.coe_nonneg _))
-  ... = N * (c + (N⁻¹ - c)) * ε : by simp only [mul_add, add_mul, mul_assoc]
-  ... = ε : by { rw [add_sub_cancel'_right, mul_inv_cancel, one_mul],
-    exact ne_of_gt (inv_pos.1 $ lt_of_le_of_lt c.coe_nonneg hc) }
-end
-
-end inverse_approx_map
-
 include cs
 
-variable {ε : ℝ}
-
-theorem surj_on_closed_ball (hf : approximates_linear_on f (f' : E →L[𝕜] F) s c)
-  (hc : subsingleton E ∨ c < N⁻¹) {b : E} (ε0 : 0 ≤ ε) (hε : closed_ball b ε ⊆ s) :
-  surj_on f (closed_ball b ε) (closed_ball (f b) ((N⁻¹ - c) * ε)) :=
-begin
-  cases hc with hE hc,
-  { resetI,
-    haveI hF : subsingleton F := f'.symm.to_linear_equiv.to_equiv.subsingleton,
-    intros y hy,
-    exact ⟨b, mem_closed_ball_self ε0, subsingleton.elim _ _⟩ },
-  intros y hy,
-  have : contracting_with (N * c) ((hf.inverse_approx_map_maps_to (or.inr hc)
-    (hε $ mem_closed_ball_self ε0) hε hy).restrict _ _ _),
-  { split,
-    { rwa [mul_comm, ← nnreal.lt_inv_iff_mul_lt],
-      exact ne_of_gt (inv_pos.1 $ lt_of_le_of_lt c.coe_nonneg hc) },
-    { exact lipschitz_with.of_dist_le_mul (λ x x', hf.inverse_approx_map_contracts_on
-        y (hε x.mem) (hε x'.mem)) } },
-  refine ⟨this.efixed_point' _ _ _ b (mem_closed_ball_self ε0) (edist_lt_top _ _), _, _⟩,
-  { exact is_closed_ball.is_complete },
-  { apply contracting_with.efixed_point_mem' },
-  { exact (inverse_approx_map_fixed_iff y).1 (this.efixed_point_is_fixed_pt' _ _ _ _) }
-end
-
 section
-
 variables (f s)
 
 /-- Given a function `f` that approximates a linear equivalence on an open set `s`,
@@ -311,19 +375,8 @@ def to_local_homeomorph (hf : approximates_linear_on f (f' : E →L[𝕜] F) s c
   (hc : subsingleton E ∨ c < N⁻¹) (hs : is_open s) : local_homeomorph E F :=
 { to_local_equiv := hf.to_local_equiv hc,
   open_source := hs,
-  open_target :=
-    begin
-      cases hc with hE hc,
-      { resetI,
-        haveI hF : subsingleton F := f'.to_linear_equiv.to_equiv.symm.subsingleton,
-        apply is_open_discrete },
-      change is_open (f '' s),
-      simp only [is_open_iff_mem_nhds, nhds_basis_closed_ball.mem_iff, ball_image_iff] at hs ⊢,
-      intros x hx,
-      rcases hs x hx with ⟨ε, ε0, hε⟩,
-      refine ⟨(N⁻¹ - c) * ε, mul_pos (sub_pos.2 hc) ε0, _⟩,
-      exact (hf.surj_on_closed_ball (or.inr hc) (le_of_lt ε0) hε).mono hε (subset.refl _)
-    end,
+  open_target := hf.open_image_of_nonlinear_right_inverse f'.to_nonlinear_right_inverse hs
+    (by rwa f'.to_linear_equiv.to_equiv.subsingleton_iff at hc),
   continuous_to_fun := hf.continuous_on,
   continuous_inv_fun := hf.inverse_continuous_on hc }
 
@@ -344,7 +397,8 @@ end
 lemma closed_ball_subset_target (hf : approximates_linear_on f (f' : E →L[𝕜] F) s c)
   (hc : subsingleton E ∨ c < N⁻¹) (hs : is_open s) {b : E} (ε0 : 0 ≤ ε) (hε : closed_ball b ε ⊆ s) :
   closed_ball (f b) ((N⁻¹ - c) * ε) ⊆ (hf.to_local_homeomorph f s hc hs).target :=
-(hf.surj_on_closed_ball hc ε0 hε).mono hε (subset.refl _)
+(hf.surj_on_closed_ball_of_nonlinear_right_inverse f'.to_nonlinear_right_inverse
+  ε0 hε).mono hε (subset.refl _)
 
 end approximates_linear_on
 
@@ -592,3 +646,5 @@ begin
 end
 
 end times_cont_diff_at
+
+#lint

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -301,10 +301,7 @@ end
 lemma open_image (hf : approximates_linear_on f f' s c)  (f'symm : f'.nonlinear_right_inverse)
   (hs : is_open s) (hc : subsingleton F ∨ c < f'symm.nnnorm⁻¹) : is_open (f '' s) :=
 begin
-  cases hc with hE hc,
-  { resetI,
-    apply is_open_discrete },
-  change is_open (f '' s),
+  cases hc with hE hc, { resetI, apply is_open_discrete },
   simp only [is_open_iff_mem_nhds, nhds_basis_closed_ball.mem_iff, ball_image_iff] at hs ⊢,
   intros x hx,
   rcases hs x hx with ⟨ε, ε0, hε⟩,

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yury Kudryashov, Heather Macbeth.
+Authors: Yury Kudryashov, Heather Macbeth, Sébastien Gouëzel
 -/
 import analysis.calculus.times_cont_diff
 import analysis.normed_space.banach

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -7,7 +7,6 @@ import analysis.calculus.times_cont_diff
 import analysis.normed_space.banach
 import topology.local_homeomorph
 import topology.metric_space.contracting
-import analysis.normed_space.finite_dimension
 
 /-!
 # Inverse function theorem

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -7,6 +7,7 @@ import analysis.calculus.times_cont_diff
 import analysis.normed_space.banach
 import topology.local_homeomorph
 import topology.metric_space.contracting
+import analysis.normed_space.finite_dimension
 
 /-!
 # Inverse function theorem

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -244,18 +244,25 @@ end
 
 namespace continuous_linear_map
 
-/-- A surjective continuous linear map admits a (possibly nonlinear) controlled right inverse.
-In general, it is not possible to ensure that such a right inverse is linear. -/
-@[irreducible] noncomputable def nonlinear_right_inverse_of_surjective
-  (f : E →L[𝕜] F) (hsurj : f.range = ⊤) : nonlinear_right_inverse f :=
+lemma exists_nonlinear_right_inverse_of_surjective (f : E →L[𝕜] F) (hsurj : f.range = ⊤) :
+  ∃ (fsymm : nonlinear_right_inverse f), 0 < fsymm.nnnorm :=
 begin
   choose C hC fsymm h using exists_preimage_norm_le _ (linear_map.range_eq_top.mp hsurj),
-  exact
-  { to_fun := fsymm,
-    nnnorm := ⟨C, hC.lt.le⟩,
-    bound' := λ y, (h y).2,
-    right_inv' := λ y, (h y).1 }
+  use { to_fun := fsymm,
+        nnnorm := ⟨C, hC.lt.le⟩,
+        bound' := λ y, (h y).2,
+        right_inv' := λ y, (h y).1 },
+  exact hC
 end
+
+/-- A surjective continuous linear map admits a (possibly nonlinear) controlled right inverse.
+In general, it is not possible to ensure that such a right inverse is linear. -/
+noncomputable def nonlinear_right_inverse_of_surjective (f : E →L[𝕜] F) (hsurj : f.range = ⊤) :
+  nonlinear_right_inverse f := classical.some (exists_nonlinear_right_inverse_of_surjective f hsurj)
+
+lemma nonlinear_right_inverse_of_surjective_nnnorm_pos (f : E →L[𝕜] F) (hsurj : f.range = ⊤) :
+  0 < (nonlinear_right_inverse_of_surjective f hsurj).nnnorm :=
+classical.some_spec (exists_nonlinear_right_inverse_of_surjective f hsurj)
 
 end continuous_linear_map
 

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -257,12 +257,16 @@ end
 
 /-- A surjective continuous linear map admits a (possibly nonlinear) controlled right inverse.
 In general, it is not possible to ensure that such a right inverse is linear. -/
-noncomputable def nonlinear_right_inverse_of_surjective (f : E →L[𝕜] F) (hsurj : f.range = ⊤) :
-  nonlinear_right_inverse f := classical.some (exists_nonlinear_right_inverse_of_surjective f hsurj)
+@[irreducible] noncomputable def nonlinear_right_inverse_of_surjective
+  (f : E →L[𝕜] F) (hsurj : f.range = ⊤) : nonlinear_right_inverse f :=
+classical.some (exists_nonlinear_right_inverse_of_surjective f hsurj)
 
 lemma nonlinear_right_inverse_of_surjective_nnnorm_pos (f : E →L[𝕜] F) (hsurj : f.range = ⊤) :
   0 < (nonlinear_right_inverse_of_surjective f hsurj).nnnorm :=
-classical.some_spec (exists_nonlinear_right_inverse_of_surjective f hsurj)
+begin
+  rw nonlinear_right_inverse_of_surjective,
+  exact classical.some_spec (exists_nonlinear_right_inverse_of_surjective f hsurj)
+end
 
 end continuous_linear_map
 

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -255,8 +255,10 @@ begin
   exact hC
 end
 
-/-- A surjective continuous linear map admits a (possibly nonlinear) controlled right inverse.
-In general, it is not possible to ensure that such a right inverse is linear. -/
+/-- A surjective continuous linear map between Banach spaces admits a (possibly nonlinear)
+controlled right inverse. In general, it is not possible to ensure that such a right inverse
+is linear (take for instance the map from `E` to `E/F` where `F` is a closed subspace of `E`
+without a closed complement. Then it doesn't have a continuous linear right inverse.) -/
 @[irreducible] noncomputable def nonlinear_right_inverse_of_surjective
   (f : E →L[𝕜] F) (hsurj : f.range = ⊤) : nonlinear_right_inverse f :=
 classical.some (exists_nonlinear_right_inverse_of_surjective f hsurj)

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -14,7 +14,7 @@ bounded linear map between Banach spaces has a bounded inverse.
 -/
 
 open function metric set filter finset
-open_locale classical topological_space big_operators
+open_locale classical topological_space big_operators nnreal
 
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {E : Type*} [normed_group E] [normed_space 𝕜 E]
@@ -22,6 +22,44 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 (f : E →L[𝕜] F)
 include 𝕜
 
+namespace continuous_linear_map
+
+/-- A (possibly nonlinear) right inverse to a continuous linear map, which doesn't have to be
+linear itself but which satisfies a bound `∥inverse x∥ ≤ C * ∥x∥`. A surjective continuous linear
+map doesn't always have a continuous linear right inverse, but it always has a nonlinear inverse
+in this sense, by Banach's open mapping theorem. -/
+structure nonlinear_right_inverse :=
+(to_fun : F → E)
+(nnnorm : ℝ≥0)
+(bound' : ∀ y, ∥to_fun y∥ ≤ nnnorm * ∥y∥)
+(right_inv' : ∀ y, f (to_fun y) = y)
+
+instance : has_coe_to_fun (nonlinear_right_inverse f) := ⟨_, λ fsymm, fsymm.to_fun⟩
+
+@[simp] lemma nonlinear_right_inverse.right_inv {f : E →L[𝕜] F} (fsymm : nonlinear_right_inverse f)
+  (y : F) : f (fsymm y) = y :=
+fsymm.right_inv' y
+
+lemma nonlinear_right_inverse.bound {f : E →L[𝕜] F} (fsymm : nonlinear_right_inverse f) (y : F) :
+  ∥fsymm y∥ ≤ fsymm.nnnorm * ∥y∥ :=
+fsymm.bound' y
+
+end continuous_linear_map
+
+/-- Given a continuous linear equivalence, the inverse is in particular an instance of
+`nonlinear_right_inverse` (which turns out to be linear). -/
+noncomputable def continuous_linear_equiv.to_nonlinear_right_inverse (f : E ≃L[𝕜] F) :
+  continuous_linear_map.nonlinear_right_inverse (f : E →L[𝕜] F) :=
+{ to_fun := f.inv_fun,
+  nnnorm := nnnorm (f.symm : F →L[𝕜] E),
+  bound' := λ y, continuous_linear_map.le_op_norm (f.symm : F →L[𝕜] E) _,
+  right_inv' := f.apply_symm_apply }
+
+noncomputable instance (f : E ≃L[𝕜] F) :
+  inhabited (continuous_linear_map.nonlinear_right_inverse (f : E →L[𝕜] F)) :=
+⟨f.to_nonlinear_right_inverse⟩
+
+/-! ### Proof of the Banach open mapping theorem -/
 
 variable [complete_space F]
 
@@ -201,6 +239,25 @@ begin
     ... = ε : mul_div_cancel' _ (ne_of_gt Cpos),
   exact set.mem_image_of_mem _ (hε this)
 end
+
+/-! ### Applications of the Banach open mapping theorem -/
+
+namespace continuous_linear_map
+
+/-- A surjective continuous linear map admits a (possibly nonlinear) controlled right inverse.
+In general, it is not possible to ensure that such a right inverse is linear. -/
+@[irreducible] noncomputable def nonlinear_right_inverse_of_surjective
+  (f : E →L[𝕜] F) (hsurj : f.range = ⊤) : nonlinear_right_inverse f :=
+begin
+  choose C hC fsymm h using exists_preimage_norm_le _ (linear_map.range_eq_top.mp hsurj),
+  exact
+  { to_fun := fsymm,
+    nnnorm := ⟨C, hC.lt.le⟩,
+    bound' := λ y, (h y).2,
+    right_inv' := λ y, (h y).1 }
+end
+
+end continuous_linear_map
 
 namespace linear_equiv
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -158,6 +158,9 @@ e.injective.subsingleton
 protected theorem subsingleton.symm (e : α ≃ β) [subsingleton α] : subsingleton β :=
 e.symm.injective.subsingleton
 
+lemma subsingleton_iff (e : α ≃ β) : subsingleton α ↔ subsingleton β :=
+⟨λ h, by exactI e.symm.subsingleton, λ h, by exactI e.subsingleton⟩
+
 instance equiv_subsingleton_cod [subsingleton β] :
   subsingleton (α ≃ β) :=
 ⟨λ f g, equiv.ext $ λ x, subsingleton.elim _ _⟩


### PR DESCRIPTION
Removes a useless assumption in `map_nhds_eq_of_complemented` (no need to have a completemented subspace).

The proof of the local inverse theorem breaks into two parts, local injectivity and local surjectivity. We refactor the local surjectivity part, assuming in the proof only that the derivative is onto. The result is stronger, but the proof is less streamlined since there is no contracting map any more: we give a naive proof from first principles instead of reducing to the fixed point theorem for contracting maps.