### PR TITLE
[Merged by Bors] - fix(*): arsinh and complex.basic had module docs at the wrong position

### DIFF
--- a/src/analysis/special_functions/arsinh.lean
+++ b/src/analysis/special_functions/arsinh.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: James Arthur, Chris Hughes, Shing Tak Lam
 -/
 import analysis.special_functions.trigonometric
-noncomputable theory
 
 /-!
 # Inverse of the sinh function
@@ -23,6 +22,7 @@ inverse, arsinh.
 
 arsinh, arcsinh, argsinh, asinh, sinh injective, sinh bijective, sinh surjective
 -/
+noncomputable theory
 
 namespace real
 

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -5,13 +5,15 @@ Authors: Kevin Buzzard, Mario Carneiro
 -/
 import data.real.sqrt
 
-open_locale big_operators
-
 /-!
 # The complex numbers
 
-The complex numbers are modelled as ℝ^2 in the obvious way.
+The complex numbers are modelled as ℝ^2 in the obvious way and it is shown that they form a field
+of characteristic zero. The result that the complex numbers are algebraically closed, see
+`field_theory.algebraic_closure`.
 -/
+
+open_locale big_operators
 
 /-! ### Definition and basic arithmmetic -/
 


### PR DESCRIPTION
This is fixed and the module doc for `complex.basic` is expanded slightly.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
