### PR TITLE
[Merged by Bors] - doc(topology/subset_properties): minor change to docstring of `is_compact`

### DIFF
--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -52,7 +52,7 @@ variables {α : Type u} {β : Type v} [topological_space α] {s t : set α}
 section compact
 
 /-- A set `s` is compact if for every filter `f` that contains `s`,
-    every set of `f` also meets every neighborhood of some `a ∈ s`. -/
+    there exists `a ∈ s` such that every set of `f` meets every neighborhood of `a`. -/
 def is_compact (s : set α) := ∀ ⦃f⦄ [ne_bot f], f ≤ 𝓟 s → ∃a∈s, cluster_pt a f
 
 /-- The complement to a compact set belongs to a filter `f` if it belongs to each filter

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -51,7 +51,7 @@ variables {α : Type u} {β : Type v} [topological_space α] {s t : set α}
 /- compact sets -/
 section compact
 
-/-- A set `s` is compact if for every filter `f` that contains `s`,
+/-- A set `s` is compact if for every nontrivial filter `f` that contains `s`,
     there exists `a ∈ s` such that every set of `f` meets every neighborhood of `a`. -/
 def is_compact (s : set α) := ∀ ⦃f⦄ [ne_bot f], f ≤ 𝓟 s → ∃a∈s, cluster_pt a f
 


### PR DESCRIPTION
I'm learning (for the first time) about how to do topology with filters, and this docstring confused me for a second. If there are linguistic reasons for leaving it as it is then fair enough, but it wasn't clear to me on first reading that `a` was independent of the set in the filter.

---
<!--
put comments you want to keep out of the PR commit here.
If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
