### PR TITLE
[Merged by Bors] - feat(data/set/intervals/basic): not_mem of various intervals

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -220,6 +220,12 @@ theorem eq_of_subset_of_subset {a b : set α} : a ⊆ b → b ⊆ a → a = b :=
 
 theorem mem_of_subset_of_mem {s₁ s₂ : set α} {a : α} (h : s₁ ⊆ s₂) : a ∈ s₁ → a ∈ s₂ := @h _
 
+theorem not_mem_subset {s t : set α} (hsubset : s ⊆ t) (ht : a ∉ t) : a ∉ s :=
+begin
+  by_contra hs,
+  exact absurd (mem_of_subset_of_mem hsubset hs) ht,
+end
+
 theorem not_subset : (¬ s ⊆ t) ↔ ∃a ∈ s, a ∉ t := by simp only [subset_def, not_forall]
 
 /-! ### Definition of strict subsets `s ⊂ t` and basic properties. -/

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -220,7 +220,7 @@ theorem eq_of_subset_of_subset {a b : set α} : a ⊆ b → b ⊆ a → a = b :=
 
 theorem mem_of_subset_of_mem {s₁ s₂ : set α} {a : α} (h : s₁ ⊆ s₂) : a ∈ s₁ → a ∈ s₂ := @h _
 
-theorem not_mem_subset {s t : set α} (hsubset : s ⊆ t) (ht : a ∉ t) : a ∉ s :=
+theorem not_mem_subset (hsubset : s ⊆ t) (ht : a ∉ t) : a ∉ s :=
 begin
   by_contra hs,
   exact absurd (mem_of_subset_of_mem hsubset hs) ht,

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -220,8 +220,8 @@ theorem eq_of_subset_of_subset {a b : set α} : a ⊆ b → b ⊆ a → a = b :=
 
 theorem mem_of_subset_of_mem {s₁ s₂ : set α} {a : α} (h : s₁ ⊆ s₂) : a ∈ s₁ → a ∈ s₂ := @h _
 
-theorem not_mem_subset (hsubset : s ⊆ t) (ht : a ∉ t) : a ∉ s :=
-λ hs, ht (mem_of_subset_of_mem hsubset hs)
+theorem not_mem_subset (h : s ⊆ t) : a ∉ t → a ∉ s :=
+mt $ mem_of_subset_of_mem h
 
 theorem not_subset : (¬ s ⊆ t) ↔ ∃a ∈ s, a ∉ t := by simp only [subset_def, not_forall]
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -221,10 +221,7 @@ theorem eq_of_subset_of_subset {a b : set α} : a ⊆ b → b ⊆ a → a = b :=
 theorem mem_of_subset_of_mem {s₁ s₂ : set α} {a : α} (h : s₁ ⊆ s₂) : a ∈ s₁ → a ∈ s₂ := @h _
 
 theorem not_mem_subset (hsubset : s ⊆ t) (ht : a ∉ t) : a ∉ s :=
-begin
-  by_contra hs,
-  exact absurd (mem_of_subset_of_mem hsubset hs) ht,
-end
+λ hs, ht (mem_of_subset_of_mem hsubset hs)
 
 theorem not_subset : (¬ s ⊆ t) ↔ ∃a ∈ s, a ∉ t := by simp only [subset_def, not_forall]
 

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -506,7 +506,43 @@ variables {α : Type u} [order_bot α] {a : α}
 end order_bot
 
 section linear_order
-variables {α : Type u} [linear_order α] {a a₁ a₂ b b₁ b₂ : α}
+variables {α : Type u} [linear_order α] {a a₁ a₂ b b₁ b₂ c d : α}
+
+lemma not_mem_Ici_of_lt (ha : c < a) : c ∉ Ici a :=
+by rwa [mem_Ici, not_le]
+
+lemma not_mem_Iic_of_gt (hb : b < c) : c ∉ Iic b :=
+by rwa [mem_Iic, not_le]
+
+lemma not_mem_Icc_of_lt (ha : c < a) : c ∉ Icc a b :=
+not_mem_subset Icc_subset_Ici_self (not_mem_Ici_of_lt ha)
+
+lemma not_mem_Icc_of_gt (hb : b < c) : c ∉ Icc a b :=
+not_mem_subset Icc_subset_Iic_self (not_mem_Iic_of_gt hb)
+
+lemma not_mem_Ico_of_lt (ha : c < a) : c ∉ Ico a b :=
+not_mem_subset Ico_subset_Icc_self (not_mem_Icc_of_lt ha)
+
+lemma not_mem_Ioc_of_gt (hb : b < c) : c ∉ Ioc a b :=
+not_mem_subset Ioc_subset_Icc_self (not_mem_Icc_of_gt hb)
+
+lemma not_mem_Ioi_of_le (ha : c ≤ a) : c ∉ Ioi a :=
+by rwa [mem_Ioi, not_lt]
+
+lemma not_mem_Iio_of_ge (hb : b ≤ c) : c ∉ Iio b :=
+by rwa [mem_Iio, not_lt]
+
+lemma not_mem_Ioc_of_le (ha : c ≤ a) : c ∉ Ioc a b :=
+not_mem_subset Ioc_subset_Ioi_self (not_mem_Ioi_of_le ha)
+
+lemma not_mem_Ico_of_ge (hb : b ≤ c) : c ∉ Ico a b :=
+not_mem_subset Ico_subset_Iio_self (not_mem_Iio_of_ge hb)
+
+lemma not_mem_Ioo_of_le (ha : c ≤ a) : c ∉ Ioo a b :=
+not_mem_subset Ioo_subset_Ioc_self (not_mem_Ioc_of_le ha)
+
+lemma not_mem_Ioo_of_ge (hb : b ≤ c) : c ∉ Ioo a b :=
+not_mem_subset Ioo_subset_Ico_self (not_mem_Ico_of_ge hb)
 
 @[simp] lemma compl_Iic : (Iic a)ᶜ = Ioi a := ext $ λ _, not_le
 @[simp] lemma compl_Ici : (Ici a)ᶜ = Iio a := ext $ λ _, not_le
@@ -616,7 +652,7 @@ by rw [← diff_eq_empty, Iio_diff_Iic, Ioo_eq_empty_iff]
 
 /-! #### A finite and an infinite interval -/
 
-lemma Ioo_union_Ioi' {c : α} (h₁ : c < b) :
+lemma Ioo_union_Ioi' (h₁ : c < b) :
   Ioo a b ∪ Ioi c = Ioi (min a c) :=
 begin
   ext1 x,
@@ -627,7 +663,7 @@ begin
     tauto, },
 end
 
-lemma Ioo_union_Ioi {c : α} (h : c < max a b) :
+lemma Ioo_union_Ioi (h : c < max a b) :
   Ioo a b ∪ Ioi c = Ioi (min a c) :=
 begin
   cases le_total a b with hab hab; simp [hab] at h,
@@ -648,7 +684,7 @@ lemma Ici_subset_Ico_union_Ici : Ici a ⊆ Ico a b ∪ Ici b :=
 @[simp] lemma Ico_union_Ici_eq_Ici (h : a ≤ b) : Ico a b ∪ Ici b = Ici a :=
 subset.antisymm (λ x hx, hx.elim and.left (le_trans h)) Ici_subset_Ico_union_Ici
 
-lemma Ico_union_Ici' {c : α} (h₁ : c ≤ b) :
+lemma Ico_union_Ici' (h₁ : c ≤ b) :
   Ico a b ∪ Ici c = Ici (min a c) :=
 begin
   ext1 x,
@@ -659,7 +695,7 @@ begin
     tauto, },
 end
 
-lemma Ico_union_Ici {c : α} (h : c ≤ max a b) :
+lemma Ico_union_Ici  (h : c ≤ max a b) :
   Ico a b ∪ Ici c = Ici (min a c) :=
 begin
   cases le_total a b with hab hab; simp [hab] at h,
@@ -673,7 +709,7 @@ lemma Ioi_subset_Ioc_union_Ioi : Ioi a ⊆ Ioc a b ∪ Ioi b :=
 @[simp] lemma Ioc_union_Ioi_eq_Ioi (h : a ≤ b) : Ioc a b ∪ Ioi b = Ioi a :=
 subset.antisymm (λ x hx, hx.elim and.left (lt_of_le_of_lt h)) Ioi_subset_Ioc_union_Ioi
 
-lemma Ioc_union_Ioi' {c : α} (h₁ : c ≤ b) :
+lemma Ioc_union_Ioi' (h₁ : c ≤ b) :
   Ioc a b ∪ Ioi c = Ioi (min a c) :=
 begin
   ext1 x,
@@ -684,7 +720,7 @@ begin
     tauto, },
 end
 
-lemma Ioc_union_Ioi {c : α} (h : c ≤ max a b) :
+lemma Ioc_union_Ioi (h : c ≤ max a b) :
   Ioc a b ∪ Ioi c = Ioi (min a c) :=
 begin
   cases le_total a b with hab hab; simp [hab] at h,
@@ -710,7 +746,7 @@ subset.trans Ici_subset_Ico_union_Ici (union_subset_union_left _ Ico_subset_Icc_
 @[simp] lemma Icc_union_Ici_eq_Ici (h : a ≤ b) : Icc a b ∪ Ici b = Ici a :=
 subset.antisymm (λ x hx, hx.elim and.left (le_trans h)) Ici_subset_Icc_union_Ici
 
-lemma Icc_union_Ici' {c : α} (h₁ : c ≤ b) :
+lemma Icc_union_Ici' (h₁ : c ≤ b) :
   Icc a b ∪ Ici c = Ici (min a c) :=
 begin
   ext1 x,
@@ -721,7 +757,7 @@ begin
     tauto, },
 end
 
-lemma Icc_union_Ici {c : α} (h : c ≤ max a b) :
+lemma Icc_union_Ici (h : c ≤ max a b) :
   Icc a b ∪ Ici c = Ici (min a c) :=
 begin
   cases le_or_lt a b with hab hab; simp [hab] at h,
@@ -747,7 +783,7 @@ lemma Iio_subset_Iio_union_Ico : Iio b ⊆ Iio a ∪ Ico a b :=
 @[simp] lemma Iio_union_Ico_eq_Iio (h : a ≤ b) : Iio a ∪ Ico a b = Iio b :=
 subset.antisymm (λ x hx, hx.elim (λ hx, lt_of_lt_of_le hx h) and.right) Iio_subset_Iio_union_Ico
 
-lemma Iio_union_Ico' {c d : α} (h₁ : c ≤ b) :
+lemma Iio_union_Ico' (h₁ : c ≤ b) :
   Iio b ∪ Ico c d = Iio (max b d) :=
 begin
   ext1 x,
@@ -758,7 +794,7 @@ begin
     tauto, },
 end
 
-lemma Iio_union_Ico {c d : α} (h : min c d ≤ b) :
+lemma Iio_union_Ico (h : min c d ≤ b) :
   Iio b ∪ Ico c d = Iio (max b d) :=
 begin
   cases le_total c d with hcd hcd; simp [hcd] at h,
@@ -772,7 +808,7 @@ lemma Iic_subset_Iic_union_Ioc : Iic b ⊆ Iic a ∪ Ioc a b :=
 @[simp] lemma Iic_union_Ioc_eq_Iic (h : a ≤ b) : Iic a ∪ Ioc a b = Iic b :=
 subset.antisymm (λ x hx, hx.elim (λ hx, le_trans hx h) and.right) Iic_subset_Iic_union_Ioc
 
-lemma Iic_union_Ioc' {c d : α} (h₁ : c < b) :
+lemma Iic_union_Ioc' (h₁ : c < b) :
   Iic b ∪ Ioc c d = Iic (max b d) :=
 begin
   ext1 x,
@@ -783,7 +819,7 @@ begin
     tauto, },
 end
 
-lemma Iic_union_Ioc {c d : α} (h : min c d < b) :
+lemma Iic_union_Ioc (h : min c d < b) :
   Iic b ∪ Ioc c d = Iic (max b d) :=
 begin
   cases le_total c d with hcd hcd; simp [hcd] at h,
@@ -798,7 +834,7 @@ lemma Iio_subset_Iic_union_Ioo : Iio b ⊆ Iic a ∪ Ioo a b :=
 @[simp] lemma Iic_union_Ioo_eq_Iio (h : a < b) : Iic a ∪ Ioo a b = Iio b :=
 subset.antisymm (λ x hx, hx.elim (λ hx, lt_of_le_of_lt hx h) and.right) Iio_subset_Iic_union_Ioo
 
-lemma Iio_union_Ioo' {c d : α} (h₁ : c < b) :
+lemma Iio_union_Ioo' (h₁ : c < b) :
   Iio b ∪ Ioo c d = Iio (max b d) :=
 begin
   ext x,
@@ -809,7 +845,7 @@ begin
     exact λ h₂, ⟨h₁.trans_le hba, h₂⟩ },
 end
 
-lemma Iio_union_Ioo {c d : α} (h : min c d < b) :
+lemma Iio_union_Ioo (h : min c d < b) :
   Iio b ∪ Ioo c d = Iio (max b d) :=
 begin
   cases le_total c d with hcd hcd; simp [hcd] at h,
@@ -824,7 +860,7 @@ subset.trans Iic_subset_Iic_union_Ioc (union_subset_union_right _ Ioc_subset_Icc
 @[simp] lemma Iic_union_Icc_eq_Iic (h : a ≤ b) : Iic a ∪ Icc a b = Iic b :=
 subset.antisymm (λ x hx, hx.elim (λ hx, le_trans hx h) and.right) Iic_subset_Iic_union_Icc
 
-lemma Iic_union_Icc' {c d : α} (h₁ : c ≤ b) :
+lemma Iic_union_Icc' (h₁ : c ≤ b) :
   Iic b ∪ Icc c d = Iic (max b d) :=
 begin
   ext1 x,
@@ -835,7 +871,7 @@ begin
     tauto, },
 end
 
-lemma Iic_union_Icc {c d : α} (h : min c d ≤ b) :
+lemma Iic_union_Icc (h : min c d ≤ b) :
   Iic b ∪ Icc c d = Iic (max b d) :=
 begin
   cases le_or_lt c d with hcd hcd; simp [hcd] at h,
@@ -853,8 +889,6 @@ subset.trans Iio_subset_Iic_union_Ioo (union_subset_union_right _ Ioo_subset_Ico
 subset.antisymm (λ x hx, hx.elim (λ hx, lt_of_le_of_lt hx h) and.right) Iio_subset_Iic_union_Ico
 
 /-! #### Two finite intervals, `I?o` and `Ic?` -/
-
-variables {c d : α}
 
 lemma Ioo_subset_Ioo_union_Ico : Ioo a c ⊆ Ioo a b ∪ Ico b c :=
 λ x hx, (lt_or_le x b).elim (λ hxb, or.inl ⟨hx.1, hxb⟩) (λ hxb, or.inr ⟨hxb, hx.2⟩)

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -508,41 +508,37 @@ end order_bot
 section linear_order
 variables {α : Type u} [linear_order α] {a a₁ a₂ b b₁ b₂ c d : α}
 
-lemma not_mem_Ici_of_lt (ha : c < a) : c ∉ Ici a :=
-by rwa [mem_Ici, not_le]
+lemma not_mem_Ici : c ∉ Ici a ↔ c < a := not_le
 
-lemma not_mem_Iic_of_gt (hb : b < c) : c ∉ Iic b :=
-by rwa [mem_Iic, not_le]
+lemma not_mem_Iic : c ∉ Iic b ↔ b < c := not_le
 
 lemma not_mem_Icc_of_lt (ha : c < a) : c ∉ Icc a b :=
-not_mem_subset Icc_subset_Ici_self (not_mem_Ici_of_lt ha)
+not_mem_subset Icc_subset_Ici_self $ not_mem_Ici.mpr ha
 
 lemma not_mem_Icc_of_gt (hb : b < c) : c ∉ Icc a b :=
-not_mem_subset Icc_subset_Iic_self (not_mem_Iic_of_gt hb)
+not_mem_subset Icc_subset_Iic_self $ not_mem_Iic.mpr hb
 
 lemma not_mem_Ico_of_lt (ha : c < a) : c ∉ Ico a b :=
-not_mem_subset Ico_subset_Icc_self (not_mem_Icc_of_lt ha)
+not_mem_subset Ico_subset_Ici_self $ not_mem_Ici.mpr ha
 
 lemma not_mem_Ioc_of_gt (hb : b < c) : c ∉ Ioc a b :=
-not_mem_subset Ioc_subset_Icc_self (not_mem_Icc_of_gt hb)
+not_mem_subset Ioc_subset_Iic_self $ not_mem_Iic.mpr hb
 
-lemma not_mem_Ioi_of_le (ha : c ≤ a) : c ∉ Ioi a :=
-by rwa [mem_Ioi, not_lt]
+lemma not_mem_Ioi : c ∉ Ioi a ↔ c ≤ a := not_lt
 
-lemma not_mem_Iio_of_ge (hb : b ≤ c) : c ∉ Iio b :=
-by rwa [mem_Iio, not_lt]
+lemma not_mem_Iio : c ∉ Iio b ↔ b ≤ c := not_lt
 
 lemma not_mem_Ioc_of_le (ha : c ≤ a) : c ∉ Ioc a b :=
-not_mem_subset Ioc_subset_Ioi_self (not_mem_Ioi_of_le ha)
+not_mem_subset Ioc_subset_Ioi_self $ not_mem_Ioi.mpr ha
 
 lemma not_mem_Ico_of_ge (hb : b ≤ c) : c ∉ Ico a b :=
-not_mem_subset Ico_subset_Iio_self (not_mem_Iio_of_ge hb)
+not_mem_subset Ico_subset_Iio_self $ not_mem_Iio.mpr hb
 
 lemma not_mem_Ioo_of_le (ha : c ≤ a) : c ∉ Ioo a b :=
-not_mem_subset Ioo_subset_Ioc_self (not_mem_Ioc_of_le ha)
+not_mem_subset Ioo_subset_Ioi_self $ not_mem_Ioi.mpr ha
 
 lemma not_mem_Ioo_of_ge (hb : b ≤ c) : c ∉ Ioo a b :=
-not_mem_subset Ioo_subset_Ico_self (not_mem_Ico_of_ge hb)
+not_mem_subset Ioo_subset_Iio_self $ not_mem_Iio.mpr hb
 
 @[simp] lemma compl_Iic : (Iic a)ᶜ = Ioi a := ext $ λ _, not_le
 @[simp] lemma compl_Ici : (Ici a)ᶜ = Iio a := ext $ λ _, not_le

--- a/src/data/set/intervals/unordered_interval.lean
+++ b/src/data/set/intervals/unordered_interval.lean
@@ -83,10 +83,10 @@ Icc_subset_interval ⟨ha, hb⟩
 lemma mem_interval_of_ge (hb : b ≤ x) (ha : x ≤ a) : x ∈ [a, b] :=
 Icc_subset_interval' ⟨hb, ha⟩
 
-lemma not_mem_interval_of_lt {c : α} (ha : c < a) (hb : c < b) : c ∉ [a b] :=
+lemma not_mem_interval_of_lt {c : α} (ha : c < a) (hb : c < b) : c ∉ [a, b] :=
 by simpa only [interval] using not_mem_Icc_of_lt (lt_min_iff.mpr ⟨ha, hb⟩)
 
-lemma not_mem_interval_of_gt {c : α} (ha : a < c) (hb : b < c) : c ∉ [a b] :=
+lemma not_mem_interval_of_gt {c : α} (ha : a < c) (hb : b < c) : c ∉ [a, b] :=
 by simpa only [interval] using not_mem_Icc_of_gt (max_lt_iff.mpr ⟨ha, hb⟩)
 
 lemma interval_subset_interval (h₁ : a₁ ∈ [a₂, b₂]) (h₂ : b₁ ∈ [a₂, b₂]) : [a₁, b₁] ⊆ [a₂, b₂] :=

--- a/src/data/set/intervals/unordered_interval.lean
+++ b/src/data/set/intervals/unordered_interval.lean
@@ -83,11 +83,11 @@ Icc_subset_interval ⟨ha, hb⟩
 lemma mem_interval_of_ge (hb : b ≤ x) (ha : x ≤ a) : x ∈ [a, b] :=
 Icc_subset_interval' ⟨hb, ha⟩
 
-lemma not_mem_interval_of_lt {c : α} (ha : c < a) (hb : c < b) : c ∉ [a, b] :=
-by simpa only [interval] using not_mem_Icc_of_lt (lt_min_iff.mpr ⟨ha, hb⟩)
+lemma not_mem_interval_of_lt (ha : c < a) (hb : c < b) : c ∉ interval a b :=
+not_mem_Icc_of_lt $ lt_min_iff.mpr ⟨ha, hb⟩
 
-lemma not_mem_interval_of_gt {c : α} (ha : a < c) (hb : b < c) : c ∉ [a, b] :=
-by simpa only [interval] using not_mem_Icc_of_gt (max_lt_iff.mpr ⟨ha, hb⟩)
+lemma not_mem_interval_of_gt (ha : a < c) (hb : b < c) : c ∉ interval a b :=
+not_mem_Icc_of_gt $ max_lt_iff.mpr ⟨ha, hb⟩
 
 lemma interval_subset_interval (h₁ : a₁ ∈ [a₂, b₂]) (h₂ : b₁ ∈ [a₂, b₂]) : [a₁, b₁] ⊆ [a₂, b₂] :=
 Icc_subset_Icc (le_min h₁.1 h₂.1) (max_le h₁.2 h₂.2)

--- a/src/data/set/intervals/unordered_interval.lean
+++ b/src/data/set/intervals/unordered_interval.lean
@@ -83,6 +83,12 @@ Icc_subset_interval ⟨ha, hb⟩
 lemma mem_interval_of_ge (hb : b ≤ x) (ha : x ≤ a) : x ∈ [a, b] :=
 Icc_subset_interval' ⟨hb, ha⟩
 
+lemma not_mem_interval_of_lt {c : α} (ha : c < a) (hb : c < b) : c ∉ interval a b :=
+by simpa only [interval] using not_mem_Icc_of_lt (lt_min_iff.mpr ⟨ha, hb⟩)
+
+lemma not_mem_interval_of_gt {c : α} (ha : a < c) (hb : b < c) : c ∉ interval a b :=
+by simpa only [interval] using not_mem_Icc_of_gt (max_lt_iff.mpr ⟨ha, hb⟩)
+
 lemma interval_subset_interval (h₁ : a₁ ∈ [a₂, b₂]) (h₂ : b₁ ∈ [a₂, b₂]) : [a₁, b₁] ⊆ [a₂, b₂] :=
 Icc_subset_Icc (le_min h₁.1 h₂.1) (max_le h₁.2 h₂.2)
 

--- a/src/data/set/intervals/unordered_interval.lean
+++ b/src/data/set/intervals/unordered_interval.lean
@@ -83,10 +83,10 @@ Icc_subset_interval ⟨ha, hb⟩
 lemma mem_interval_of_ge (hb : b ≤ x) (ha : x ≤ a) : x ∈ [a, b] :=
 Icc_subset_interval' ⟨hb, ha⟩
 
-lemma not_mem_interval_of_lt {c : α} (ha : c < a) (hb : c < b) : c ∉ interval a b :=
+lemma not_mem_interval_of_lt {c : α} (ha : c < a) (hb : c < b) : c ∉ [a b] :=
 by simpa only [interval] using not_mem_Icc_of_lt (lt_min_iff.mpr ⟨ha, hb⟩)
 
-lemma not_mem_interval_of_gt {c : α} (ha : a < c) (hb : b < c) : c ∉ interval a b :=
+lemma not_mem_interval_of_gt {c : α} (ha : a < c) (hb : b < c) : c ∉ [a b] :=
 by simpa only [interval] using not_mem_Icc_of_gt (max_lt_iff.mpr ⟨ha, hb⟩)
 
 lemma interval_subset_interval (h₁ : a₁ ∈ [a₂, b₂]) (h₂ : b₁ ∈ [a₂, b₂]) : [a₁, b₁] ⊆ [a₂, b₂] :=

--- a/src/data/set/intervals/unordered_interval.lean
+++ b/src/data/set/intervals/unordered_interval.lean
@@ -83,10 +83,10 @@ Icc_subset_interval ⟨ha, hb⟩
 lemma mem_interval_of_ge (hb : b ≤ x) (ha : x ≤ a) : x ∈ [a, b] :=
 Icc_subset_interval' ⟨hb, ha⟩
 
-lemma not_mem_interval_of_lt (ha : c < a) (hb : c < b) : c ∉ interval a b :=
+lemma not_mem_interval_of_lt {c : α} (ha : c < a) (hb : c < b) : c ∉ interval a b :=
 not_mem_Icc_of_lt $ lt_min_iff.mpr ⟨ha, hb⟩
 
-lemma not_mem_interval_of_gt (ha : a < c) (hb : b < c) : c ∉ interval a b :=
+lemma not_mem_interval_of_gt {c : α} (ha : a < c) (hb : b < c) : c ∉ interval a b :=
 not_mem_Icc_of_gt $ max_lt_iff.mpr ⟨ha, hb⟩
 
 lemma interval_subset_interval (h₁ : a₁ ∈ [a₂, b₂]) (h₂ : b₁ ∈ [a₂, b₂]) : [a₁, b₁] ⊆ [a₂, b₂] :=


### PR DESCRIPTION
`c` is not in a given open/closed/unordered interval if it is outside the bounds of that interval (or if it is not in a superset of that interval).
