### PR TITLE
[Merged by Bors] - doc(topology/category/*): 5 module docs

### DIFF
--- a/src/topology/category/Top/adjunctions.lean
+++ b/src/topology/category/Top/adjunctions.lean
@@ -10,7 +10,7 @@ import category_theory.adjunction.basic
 # Adjunctions regarding the category of topological spaces
 
 This file shows that the forgetful functor from topological spaces to types has a left and right
-adjoint, given by `discrete`, resp. `trivial`, the functors which equip a type with the discrete,
+adjoint, given by `Top.discrete`, resp. `Top.trivial`, the functors which equip a type with the discrete,
 resp. trivial, topology.
 -/
 

--- a/src/topology/category/Top/adjunctions.lean
+++ b/src/topology/category/Top/adjunctions.lean
@@ -10,8 +10,8 @@ import category_theory.adjunction.basic
 # Adjunctions regarding the category of topological spaces
 
 This file shows that the forgetful functor from topological spaces to types has a left and right
-adjoint, given by `Top.discrete`, resp. `Top.trivial`, the functors which equip a type with the discrete,
-resp. trivial, topology.
+adjoint, given by `Top.discrete`, resp. `Top.trivial`, the functors which equip a type with the
+discrete, resp. trivial, topology.
 -/
 
 universe u

--- a/src/topology/category/Top/adjunctions.lean
+++ b/src/topology/category/Top/adjunctions.lean
@@ -6,6 +6,14 @@ Authors: Patrick Massot, Mario Carneiro
 import topology.category.Top.basic
 import category_theory.adjunction.basic
 
+/-!
+# Adjunctions regarding the category of topological spaces
+
+This file shows that the forgetful functor from topological spaces to types has a left and right
+adjoint, given by `discrete`, resp. `trivial`, the functors which equip a type with the discrete,
+resp. trivial, topology.
+-/
+
 universe u
 
 open category_theory

--- a/src/topology/category/Top/basic.lean
+++ b/src/topology/category/Top/basic.lean
@@ -7,6 +7,15 @@ import category_theory.concrete_category.unbundled_hom
 import topology.continuous_map
 import topology.opens
 
+/-!
+# Category instance for topological spaces
+
+We introduce the bundled category `Top` of topological spaces together with the functors `discrete`
+and `trivial` from the category of types to `Top` which equip a type with the corresponding
+discrete, resp. trivial, topology. For a proof that these functors are left, resp. right adjoint
+to the forgetful functor, see `topology.category.Top.adjunctions`.
+-/
+
 open category_theory
 open topological_space
 

--- a/src/topology/category/Top/epi_mono.lean
+++ b/src/topology/category/Top/epi_mono.lean
@@ -6,6 +6,14 @@ Authors: Reid Barton
 import topology.category.Top.adjunctions
 import category_theory.epi_mono
 
+/-!
+# Epi- and monomorphisms in `Top`
+
+This file shows that a continuous function is an epimorphism in the category of topological spaces
+if and only if it is surjective, and that a continuous function is a monomorphism in the category of
+topological spaces if and only if it is injective.
+-/
+
 universe u
 
 open category_theory

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -10,7 +10,7 @@ import category_theory.limits.preserves.basic
 /-!
 # The category of topological spaces has all limits and colimits
 
-Further, these limits and colimits  are preserved by the forgetful functor --- that is, the
+Further, these limits and colimits are preserved by the forgetful functor --- that is, the
 underlying types are just the limits in the category of types.
 -/
 

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -7,6 +7,13 @@ import topology.category.Top.basic
 import category_theory.limits.types
 import category_theory.limits.preserves.basic
 
+/-!
+# The category of topological spaces has all limits and colimits
+
+Further, these limits and colimits  are preserved by the forgetful functor --- that is, the
+underlying types are just the limits in the category of types.
+-/
+
 open topological_space
 open category_theory
 open category_theory.limits
@@ -27,10 +34,13 @@ Generally you should just use `limit.cone F`, unless you need the actual definit
 (which is in terms of `types.limit_cone`).
 -/
 def limit_cone (F : J ⥤ Top.{u}) : cone F :=
-{ X := ⟨(types.limit_cone (F ⋙ forget)).X, ⨅j, (F.obj j).str.induced ((types.limit_cone (F ⋙ forget)).π.app j)⟩,
+{ X := ⟨(types.limit_cone (F ⋙ forget)).X, ⨅j,
+        (F.obj j).str.induced ((types.limit_cone (F ⋙ forget)).π.app j)⟩,
   π :=
-  { app := λ j, ⟨(types.limit_cone (F ⋙ forget)).π.app j, continuous_iff_le_induced.mpr (infi_le _ _)⟩,
-    naturality' := λ j j' f, continuous_map.coe_inj ((types.limit_cone (F ⋙ forget)).π.naturality f) } }
+  { app := λ j, ⟨(types.limit_cone (F ⋙ forget)).π.app j,
+                 continuous_iff_le_induced.mpr (infi_le _ _)⟩,
+    naturality' := λ j j' f,
+                   continuous_map.coe_inj ((types.limit_cone (F ⋙ forget)).π.naturality f) } }
 
 /--
 The chosen cone `Top.limit_cone F` for a functor `F : J ⥤ Top` is a limit cone.
@@ -40,7 +50,8 @@ Generally you should just use `limit.is_limit F`, unless you need the actual def
 def limit_cone_is_limit (F : J ⥤ Top.{u}) : is_limit (limit_cone F) :=
 by { refine is_limit.of_faithful forget (types.limit_cone_is_limit _) (λ s, ⟨_, _⟩) (λ s, rfl),
      exact continuous_iff_coinduced_le.mpr (le_infi $ λ j,
-       coinduced_le_iff_le_induced.mp $ (continuous_iff_coinduced_le.mp (s.π.app j).continuous : _) ) }
+       coinduced_le_iff_le_induced.mp $ (continuous_iff_coinduced_le.mp (s.π.app j).continuous :
+         _) ) }
 
 instance Top_has_limits : has_limits.{u} Top.{u} :=
 { has_limits_of_shape := λ J 𝒥, by exactI
@@ -58,10 +69,13 @@ Generally you should just use `colimit.coone F`, unless you need the actual defi
 (which is in terms of `types.colimit_cocone`).
 -/
 def colimit_cocone (F : J ⥤ Top.{u}) : cocone F :=
-{ X := ⟨(types.colimit_cocone (F ⋙ forget)).X, ⨆ j, (F.obj j).str.coinduced ((types.colimit_cocone (F ⋙ forget)).ι.app j)⟩,
+{ X := ⟨(types.colimit_cocone (F ⋙ forget)).X, ⨆ j,
+        (F.obj j).str.coinduced ((types.colimit_cocone (F ⋙ forget)).ι.app j)⟩,
   ι :=
-  { app := λ j, ⟨(types.colimit_cocone (F ⋙ forget)).ι.app j, continuous_iff_coinduced_le.mpr (le_supr _ j)⟩,
-    naturality' := λ j j' f, continuous_map.coe_inj ((types.colimit_cocone (F ⋙ forget)).ι.naturality f) } }
+  { app := λ j, ⟨(types.colimit_cocone (F ⋙ forget)).ι.app j,
+                 continuous_iff_coinduced_le.mpr (le_supr _ j)⟩,
+    naturality' := λ j j' f,
+                   continuous_map.coe_inj ((types.colimit_cocone (F ⋙ forget)).ι.naturality f) } }
 
 /--
 The chosen cocone `Top.colimit_cocone F` for a functor `F : J ⥤ Top` is a colimit cocone.
@@ -69,13 +83,16 @@ Generally you should just use `colimit.is_colimit F`, unless you need the actual
 (which is in terms of `types.colimit_cocone_is_colimit`).
 -/
 def colimit_cocone_is_colimit (F : J ⥤ Top.{u}) : is_colimit (colimit_cocone F) :=
-by { refine is_colimit.of_faithful forget (types.colimit_cocone_is_colimit _) (λ s, ⟨_, _⟩) (λ s, rfl),
+by { refine is_colimit.of_faithful forget (types.colimit_cocone_is_colimit _) (λ s, ⟨_, _⟩)
+       (λ s, rfl),
      exact continuous_iff_le_induced.mpr (supr_le $ λ j,
-       coinduced_le_iff_le_induced.mp $ (continuous_iff_coinduced_le.mp (s.ι.app j).continuous : _) ) }
+       coinduced_le_iff_le_induced.mp $ (continuous_iff_coinduced_le.mp (s.ι.app j).continuous :
+         _) ) }
 
 instance Top_has_colimits : has_colimits.{u} Top.{u} :=
 { has_colimits_of_shape := λ J 𝒥, by exactI
-  { has_colimit := λ F, has_colimit.mk { cocone := colimit_cocone F, is_colimit := colimit_cocone_is_colimit F } } }
+  { has_colimit := λ F, has_colimit.mk { cocone := colimit_cocone F, is_colimit :=
+    colimit_cocone_is_colimit F } } }
 
 instance forget_preserves_colimits : preserves_colimits (forget : Top.{u} ⥤ Type u) :=
 { preserves_colimits_of_shape := λ J 𝒥,

--- a/src/topology/category/Top/open_nhds.lean
+++ b/src/topology/category/Top/open_nhds.lean
@@ -42,7 +42,8 @@ instance (x : X) : order_top (open_nhds x) :=
   le_top := λ U, @le_top _ _ U.1.1,
   ..open_nhds.partial_order x }
 
-instance open_nhds_category (x : X) : category.{u} (open_nhds x) := by {unfold open_nhds, apply_instance}
+instance open_nhds_category (x : X) : category.{u} (open_nhds x) :=
+by {unfold open_nhds, apply_instance}
 
 instance opens_nhds_hom_has_coe_to_fun {x : X} {U V : open_nhds x} : has_coe_to_fun (U ⟶ V) :=
 { F := λ f, U.1 → V.1,

--- a/src/topology/category/TopCommRing.lean
+++ b/src/topology/category/TopCommRing.lean
@@ -8,7 +8,7 @@ import topology.category.Top.basic
 import topology.algebra.ring
 
 /-!
-# Category instance for topological commutative rings
+# Category of topological commutative rings
 
 We introduce the category `TopCommRing` of topological commutative rings together with the relevant
 forgetful functors to topological spaces and commutative rings.

--- a/src/topology/category/TopCommRing.lean
+++ b/src/topology/category/TopCommRing.lean
@@ -7,6 +7,13 @@ import algebra.category.CommRing.basic
 import topology.category.Top.basic
 import topology.algebra.ring
 
+/-!
+# Category instance for topological commutative rings
+
+We introduce the category `TopCommRing` of topological commutative rings together with the relevant
+forgetful functors to topological spaces and commutative rings.
+-/
+
 universes u
 
 open category_theory

--- a/src/topology/category/UniformSpace.lean
+++ b/src/topology/category/UniformSpace.lean
@@ -55,7 +55,8 @@ lemma hom_ext {X Y : UniformSpace} {f g : X ⟶ Y} : (f : X → Y) = g → f = g
 instance has_forget_to_Top : has_forget₂ UniformSpace.{u} Top.{u} :=
 { forget₂ :=
   { obj := λ X, Top.of X,
-    map := λ X Y f, { to_fun := f, continuous_to_fun := uniform_continuous.continuous f.property }, }, }
+    map := λ X Y f, { to_fun := f,
+                      continuous_to_fun := uniform_continuous.continuous f.property }, }, }
 
 end UniformSpace
 
@@ -83,7 +84,8 @@ instance separated_space (X : CpltSepUniformSpace) : separated_space ((to_Unifor
 CpltSepUniformSpace.is_separated X
 
 /-- Construct a bundled `UniformSpace` from the underlying type and the appropriate typeclasses. -/
-def of (X : Type u) [uniform_space X] [complete_space X] [separated_space X] : CpltSepUniformSpace := ⟨X⟩
+def of (X : Type u) [uniform_space X] [complete_space X] [separated_space X] :
+CpltSepUniformSpace := ⟨X⟩
 
 @[simp] lemma coe_of (X : Type u) [uniform_space X] [complete_space X] [separated_space X] :
   (of X : Type u) = X := rfl


### PR DESCRIPTION
This PR provides module docs to `Top.basic`, `Top.limits`, `Top.adjuntions`, `Top.epi_mono` , `TopCommRing`.

Furthermore, a few lines are split to please the line length linter.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
