### PR TITLE
[Merged by Bors] - fix(group_action/defs): make mul_action.regular an instance

### DIFF
--- a/src/algebra/group_action_hom.lean
+++ b/src/algebra/group_action_hom.lean
@@ -93,8 +93,6 @@ ext $ λ x, by rw [comp_apply, id_apply]
 @[simp] lemma comp_id (f : X →[M'] Y) : f.comp (mul_action_hom.id M') = f :=
 ext $ λ x, by rw [comp_apply, id_apply]
 
-local attribute [instance] mul_action.regular
-
 variables {G} (H)
 
 /-- The canonical map to the left cosets. -/

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -222,15 +222,10 @@ theorem semimodule.subsingleton (R M : Type*) [semiring R] [subsingleton R] [add
 
 @[priority 910] -- see Note [lower instance priority]
 instance semiring.to_semimodule [semiring R] : semimodule R R :=
-{ smul := (*),
-  smul_add := mul_add,
+{ smul_add := mul_add,
   add_smul := add_mul,
-  mul_smul := mul_assoc,
-  one_smul := one_mul,
   zero_smul := zero_mul,
   smul_zero := mul_zero }
-
-@[simp] lemma smul_eq_mul [semiring R] {a a' : R} : a • a' = a * a' := rfl
 
 /-- A ring homomorphism `f : R →+* M` defines a module structure by `r • x = f r * x`. -/
 def ring_hom.to_semimodule [semiring R] [semiring S] (f : R →+* S) : semimodule R S :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1620,7 +1620,7 @@ Scalar multiplication by a group element on finitely supported functions on a gr
 given by precomposition with the action of g⁻¹. -/
 def comap_distrib_mul_action_self :
   distrib_mul_action G (G →₀ M) :=
-@finsupp.comap_distrib_mul_action G M G _ (mul_action.regular G) _
+@finsupp.comap_distrib_mul_action G M G _ (monoid.to_mul_action G) _
 
 @[simp]
 lemma comap_smul_single (g : G) (a : α) (b : M) :

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -114,7 +114,7 @@ by split_ifs; refl
 
 end ite
 
-namespace mul_action
+section
 
 variables (α)
 
@@ -129,6 +129,9 @@ instance monoid.to_mul_action : mul_action α α :=
 instance is_scalar_tower.left : is_scalar_tower α α β :=
 ⟨λ x y z, mul_smul x y z⟩
 
+end
+
+namespace mul_action
 
 variables (α β)
 

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -121,10 +121,13 @@ variables (α)
 /-- The regular action of a monoid on itself by left multiplication.
 
 This is promoted to a semimodule by `semiring.to_semimodule`. -/
+@[priority 910] -- see Note [lower instance priority]
 instance monoid.to_mul_action : mul_action α α :=
 { smul := (*),
   one_smul := one_mul,
   mul_smul := mul_assoc }
+
+@[simp] lemma smul_eq_mul {a a' : α} : a • a' = a * a' := rfl
 
 instance is_scalar_tower.left : is_scalar_tower α α β :=
 ⟨λ x y z, mul_smul x y z⟩

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -118,20 +118,17 @@ namespace mul_action
 
 variables (α)
 
-/-- The regular action of a monoid on itself by left multiplication. -/
-def regular : mul_action α α :=
-{ smul := λ a₁ a₂, a₁ * a₂,
-  one_smul := λ a, one_mul a,
-  mul_smul := λ a₁ a₂ a₃, mul_assoc _ _ _, }
+/-- The regular action of a monoid on itself by left multiplication.
 
-section regular
-
-local attribute [instance] regular
+This is promoted to a semimodule by `semiring.to_semimodule`. -/
+instance monoid.to_mul_action : mul_action α α :=
+{ smul := (*),
+  one_smul := one_mul,
+  mul_smul := mul_assoc }
 
 instance is_scalar_tower.left : is_scalar_tower α α β :=
 ⟨λ x y z, mul_smul x y z⟩
 
-end regular
 
 variables (α β)
 


### PR DESCRIPTION
This is essentially already an instance via `semiring.to_semimodule.to_distrib_mul_action.to_mul_action`, but with an unecessary `semiring R` constraint.

I can't remember the details, but I've run into multiple instance resolution issues in the past that were resolved with `local attribute [instance] mul_action.regular`.

This also renames the instance to `monoid.to_mul_action` for consistency with `semiring.to_semimodule`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
