### PR TITLE
[Merged by Bors] - feat(category/eq_to_hom): lemmas to replace rewriting in objects with eq_to_hom

### DIFF
--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -29,6 +29,9 @@ by { cases p, cases q, simp, }
 If we (perhaps unintentionally) perform equational rewriting on
 the source object of a morphism,
 we can replace the resulting `_.mpr f` term by a composition with an `eq_to_hom`.
+
+It may be advisable to introduce any necessary `eq_to_hom` morphisms manually,
+rather than relying on this lemma firing.
 -/
 @[simp]
 lemma congr_arg_mpr_hom_left {X Y Z : C} (p : X = Y) (q : Y ⟶ Z) :
@@ -39,6 +42,9 @@ by { cases p, simp, }
 If we (perhaps unintentionally) perform equational rewriting on
 the target object of a morphism,
 we can replace the resulting `_.mpr f` term by a composition with an `eq_to_hom`.
+
+It may be advisable to introduce any necessary `eq_to_hom` morphisms manually,
+rather than relying on this lemma firing.
 -/
 @[simp]
 lemma congr_arg_mpr_hom_right {X Y Z : C} (p : X ⟶ Y) (q : Z = Y) :

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -23,7 +23,27 @@ def eq_to_hom {X Y : C} (p : X = Y) : X ⟶ Y := by rw p; exact 𝟙 _
 @[simp] lemma eq_to_hom_refl (X : C) (p : X = X) : eq_to_hom p = 𝟙 X := rfl
 @[simp, reassoc] lemma eq_to_hom_trans {X Y Z : C} (p : X = Y) (q : Y = Z) :
   eq_to_hom p ≫ eq_to_hom q = eq_to_hom (p.trans q) :=
-by cases p; cases q; simp
+by { cases p, cases q, simp, }
+
+/--
+If we (perhaps unintentionally) perform equational rewriting on
+the source object of a morphism,
+we can replace the resulting `_.mpr f` term by a composition with an `eq_to_hom`.
+-/
+@[simp]
+lemma congr_arg_mpr_hom_left {X Y Z : C} (p : X = Y) (q : Y ⟶ Z) :
+  (congr_arg (λ W : C, W ⟶ Z) p).mpr q = eq_to_hom p ≫ q :=
+by { cases p, simp, }
+
+/--
+If we (perhaps unintentionally) perform equational rewriting on
+the target object of a morphism,
+we can replace the resulting `_.mpr f` term by a composition with an `eq_to_hom`.
+-/
+@[simp]
+lemma congr_arg_mpr_hom_right {X Y Z : C} (p : X ⟶ Y) (q : Z = Y) :
+  (congr_arg (λ W : C, X ⟶ W) q).mpr p = p ≫ eq_to_hom q.symm :=
+by { cases q, simp, }
 
 /--
 An equality `X = Y` gives us a morphism `X ⟶ Y`.

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -633,6 +633,26 @@ lemma eq_mp_rfl {α : Sort*} {a : α} : eq.mp (eq.refl α) a = a := rfl
 @[simp]
 lemma eq_mpr_rfl {α : Sort*} {a : α} : eq.mpr (eq.refl α) a = a := rfl
 
+@[simp] lemma congr_refl_left {α β : Sort*} (f : α → β) {a b : α} (h : a = b) :
+  congr (eq.refl f) h = congr_arg f h :=
+rfl
+
+@[simp] lemma congr_refl_right {α β : Sort*} {f g : α → β} (h : f = g) (a : α) :
+  congr h (eq.refl a) = congr_fun h a :=
+rfl
+
+@[simp] lemma congr_arg_refl {α β : Sort*} (f : α → β) (a : α) :
+  congr_arg f (eq.refl a) = eq.refl (f a) :=
+rfl
+
+@[simp] lemma congr_fun_rfl {α β : Sort*} (f : α → β) (a : α) :
+  congr_fun (eq.refl f) a = eq.refl (f a) :=
+rfl
+
+@[simp] lemma congr_fun_congr_arg {α β γ : Sort*} (f : α → β → γ) {a a' : α} (p : a = a') (b : β) :
+  congr_fun (congr_arg f p) b = congr_arg (λ a, f a b) p :=
+rfl
+
 lemma heq_of_eq_mp :
   ∀ {α β : Sort*} {a : α} {a' : β} (e : α = β) (h₂ : (eq.mp e a) = a'), a == a'
 | α ._ a a' rfl h := eq.rec_on h (heq.refl _)


### PR DESCRIPTION
This adds two lemmas which replace expressions in which we've used `eq.mpr` to rewrite the source or target of a morphism, replacing the `eq.mpr` by composition with an `eq_to_hom`.

Possibly we just shouldn't add these --- usually doing that rewriting in the first place was a bad idea, and these lemmas are only useful to salvage a bad situation.

On the other hand, perhaps the existence of these lemmas, and their doc-strings, is helpful for understanding.

On the gripping hand, sometimes I just want to be evil and rewrite in objects, and allow lemmas like this to clean up the mess afterwards.