### PR TITLE
feat(ring_theory/laurent_series): introduce ring of Laurent series

### DIFF
--- a/src/ring_theory/laurent_series.lean
+++ b/src/ring_theory/laurent_series.lean
@@ -63,50 +63,50 @@ We then build some glue to treat formal power series as if they are indexed by `
 Occasionally this leads to proofs that are uglier than expected.
 -/
 
-namespace maxumal
+-- namespace maxumal
 
-def maxumal := ℕ
+-- def maxumal := ℕ
 
-def equiv_to_nat : maxumal ≃ nat := equiv.refl _
+-- def equiv_to_nat : maxumal ≃ nat := equiv.refl _
 
-notation `𝕄` := maxumal
-notation `℘` := equiv_to_nat.to_fun
-notation `℘⁻¹` := equiv_to_nat.symm
-notation `𝟘` := ℘⁻¹ 0
+-- notation `𝕄` := maxumal
+-- notation `℘` := equiv_to_nat.to_fun
+-- notation `℘⁻¹` := equiv_to_nat.symm
+-- notation `𝟘` := ℘⁻¹ 0
 
-instance : inhabited 𝕄 := ⟨𝟘⟩
-instance : has_zero 𝕄 := ⟨𝟘⟩
-instance : nontrivial 𝕄 := ⟨⟨𝟘, ℘⁻¹ 1, nat.zero_ne_one⟩⟩
+-- instance : inhabited 𝕄 := ⟨𝟘⟩
+-- instance : has_zero 𝕄 := ⟨𝟘⟩
+-- instance : nontrivial 𝕄 := ⟨⟨𝟘, ℘⁻¹ 1, nat.zero_ne_one⟩⟩
 
-lemma nat.max_zero : ∀ {m : ℕ}, max m 0 = m :=
-begin
-  intro a,
-  rw [max_comm a 0, nat.zero_max],
-end
+-- lemma nat.max_zero : ∀ {m : ℕ}, max m 0 = m :=
+-- begin
+--   intro a,
+--   rw [max_comm a 0, nat.zero_max],
+-- end
 
-instance : add_comm_monoid 𝕄 :=
-{ add := begin change ℕ → ℕ → ℕ, use max, end,
-  add_assoc := by convert max_assoc,
-  zero := 𝟘,
-  zero_add := λ _, nat.zero_max,
-  add_zero := λ _, nat.max_zero,
-  add_comm := max_comm, }
+-- instance : add_comm_monoid 𝕄 :=
+-- { add := begin change ℕ → ℕ → ℕ, use max, end,
+--   add_assoc := by convert max_assoc,
+--   zero := 𝟘,
+--   zero_add := λ _, nat.zero_max,
+--   add_zero := λ _, nat.max_zero,
+--   add_comm := max_comm, }
 
-def sub_left_maxumal : 𝕄 × 𝕄 → 𝕄
-| (𝕜₁, 𝕜₂) := ℘⁻¹ (℘ (𝕜₁ + 𝕜₂) - ℘ 𝕜₁)
-notation `μ` := sub_left_maxumal
+-- def sub_left_maxumal : 𝕄 × 𝕄 → 𝕄
+-- | (𝕜₁, 𝕜₂) := ℘⁻¹ (℘ (𝕜₁ + 𝕜₂) - ℘ 𝕜₁)
+-- notation `μ` := sub_left_maxumal
 
-@[simp] lemma zero_sub_left : ∀ (𝕜 : 𝕄), μ (𝟘, 𝕜) = 𝕜 := sorry
-@[simp] lemma sub_left_zero : ∀ (𝕜 : 𝕄 ), μ (𝕜, 𝟘) = 𝟘 := sorry
+-- @[simp] lemma zero_sub_left : ∀ (𝕜 : 𝕄), μ (𝟘, 𝕜) = 𝕜 := sorry
+-- @[simp] lemma sub_left_zero : ∀ (𝕜 : 𝕄 ), μ (𝕜, 𝟘) = 𝟘 := sorry
 
-#eval ℘ ((℘⁻¹ 8) + (℘⁻¹ 5))
-#eval μ (℘⁻¹ 8, ℘⁻¹ 5)
-#eval μ (℘⁻¹ 5, ℘⁻¹ 8)
--- #eval equiv_to_nat.to_fun ((equiv_to_nat.inv_fun 5) + (equiv_to_nat.inv_fun 8))
--- #eval equiv_to_nat.to_fun ((equiv_to_nat.inv_fun 3) + (equiv_to_nat.inv_fun 5))
--- #eval equiv_to_nat.to_fun ((equiv_to_nat.inv_fun 2) + (equiv_to_nat.inv_fun 0))
+-- #eval ℘ ((℘⁻¹ 8) + (℘⁻¹ 5))
+-- #eval μ (℘⁻¹ 8, ℘⁻¹ 5)
+-- #eval μ (℘⁻¹ 5, ℘⁻¹ 8)
+-- -- #eval equiv_to_nat.to_fun ((equiv_to_nat.inv_fun 5) + (equiv_to_nat.inv_fun 8))
+-- -- #eval equiv_to_nat.to_fun ((equiv_to_nat.inv_fun 3) + (equiv_to_nat.inv_fun 5))
+-- -- #eval equiv_to_nat.to_fun ((equiv_to_nat.inv_fun 2) + (equiv_to_nat.inv_fun 0))
 
-end maxumal
+-- end maxumal
 noncomputable theory
 open_locale classical big_operators
 
@@ -144,15 +144,19 @@ def shift_fun {R : Type*} [has_zero R]: ℕ → (ℕ → R) → (ℕ → R)
 | (k) := λ f, λ n, if (n : ℤ) < k then (0 : R) else f (n - k)
 
 @[simp] lemma shift_fun_by_zero [has_zero R] (f : ℕ → R) : shift_fun 0 f = f := rfl
-@[simp] lemma shift_neg [has_neg R] [has_zero R] (f : ℕ → R) (k : ℕ) :
-  shift_fun k (-f) = - (shift_fun k f) := sorry
-@[simp] lemma shift_fun_eq_iff [has_zero R] (f₁ f₂ : ℕ → R) (k : ℕ) :
-shift_fun k f₁ = shift_fun k f₂ ↔ f₁ = f₂ :=
-begin
-sorry,
-end
 
-example (x y z : ℤ) : x - (y + z) = x - y - z := sub_add_eq_sub_sub x y z
+-- @[simp] lemma shift_fun_eq_iff [has_zero R] (f₁ f₂ : ℕ → R) (k : ℕ) :
+-- shift_fun k f₁ = shift_fun k f₂ ↔ f₁ = f₂ :=
+-- begin
+--   split,
+--   { intro h,
+--     funext,
+--     apply congr_fun h x,
+
+--   },
+--   {sorry,},
+--   -- ext,
+-- end
 
 @[simp] lemma shift_fun_assoc [has_zero R] (f : ℕ → R) (k₁ k₂ : ℕ):
   shift_fun k₁ (shift_fun k₂ f) = shift_fun (k₁ + k₂) f :=
@@ -208,6 +212,19 @@ begin
       tauto,
       rw if_neg h,
       tauto,
+end
+
+@[simp] lemma shift_neg [ring R] (f : ℕ → R) (k : ℕ) :
+  shift_fun k (-f) = - (shift_fun k f) :=
+begin
+  ext,
+  rw pi.neg_apply,
+  dsimp [shift_fun],
+  by_cases h : (x : ℤ) < ↑k,
+  { repeat {rw if_pos h},
+    exact neg_zero.symm },
+  { repeat {rw if_neg h},
+    rw pi.neg_apply },
 end
 
 @[simp] lemma shift_fun_add (k : ℕ) (f₁ f₂ : ℕ → R) : shift_fun k (f₁ + f₂) =
@@ -282,33 +299,37 @@ instance : add_comm_monoid (punctured_power_series R) :=
 @[simp] lemma add_fst {F₁ F₂ : punctured_power_series R} :
  (F₁ + F₂).fst = F₁.fst + F₂.fst :=
 begin
-  sorry,
+  rcases F₁ with ⟨k₁, _⟩,
+  rcases F₂ with ⟨k₂, _⟩,
+  apply rfl,
 end
 
 @[simp] lemma add_snd {F₁ F₂ : punctured_power_series R} :
  (F₁ + F₂).snd = shift_fun F₂.fst F₁.snd + shift_fun F₁.fst F₂.snd :=
 begin
-  sorry,
+  rcases F₁ with ⟨_, f₁⟩,
+  rcases F₂ with ⟨_, f₂⟩,
+  apply rfl,
 end
 
-#print punctured_power_series.add
-def a : ℕ → ℤ := λ n, 4*n+3
-def b : ℕ → ℤ := λ n, 1-2*n
--- def 𝕜₁ : 𝕄 := ℘⁻¹ 1
--- def 𝕜₂ : 𝕄 := ℘⁻¹ 3
+-- #print punctured_power_series.add
+-- def a : ℕ → ℤ := λ n, 4*n+3
+-- def b : ℕ → ℤ := λ n, 1-2*n
+-- -- def 𝕜₁ : 𝕄 := ℘⁻¹ 1
+-- -- def 𝕜₂ : 𝕄 := ℘⁻¹ 3
 
-def F₁ : punctured_power_series ℤ := (1, a)
-def F₂ : punctured_power_series ℤ := (3, b)
-#eval a 5
-#eval (F₁ + F₂).snd 9
+-- def F₁ : punctured_power_series ℤ := (1, a)
+-- def F₂ : punctured_power_series ℤ := (3, b)
+-- #eval a 5
+-- #eval (F₁ + F₂).snd 9
 /-The right answers are
 0 → 0, 1 → 1, 2 → -1, 3 → 0, 4 → 2, 5 → 4, 6 → 6, 7 → 8, 8 → 10, 9 → 12
 
 def F₃ := (𝟘, b) --check!
 --/
 
-def eqv_punctured_old (F₁ F₂ : punctured_power_series R) : Prop :=
-∃ ℓ₁₂ ℓ₂₁ : 𝕄, F₁ + (ℓ₁₂, 0) = F₂ + (ℓ₂₁, 0)
+-- def eqv_punctured_old (F₁ F₂ : punctured_power_series R) : Prop :=
+-- ∃ ℓ₁₂ ℓ₂₁ : 𝕄, F₁ + (ℓ₁₂, 0) = F₂ + (ℓ₂₁, 0)
 
 def eqv_punctured (F₁ F₂ : punctured_power_series R) : Prop :=
 ∃ ℓ₁₂ ℓ₂₁ : ℕ, F₁ + (ℓ₁₂, 0) = F₂ + (ℓ₂₁, 0)
@@ -390,6 +411,7 @@ instance : has_coe (punctured_power_series R) (laurent_series R) :=
 
 variables {S : Type*} [comm_ring S]
 
+
 noncomputable theory
 open classical
 -- open_locale classical
@@ -406,7 +428,7 @@ open classical
 --   simp only [pi.add_apply] at *,
 --   apply add_comm,
 -- end
-#check (eqv_punctured.add_con S).mk'
+-- #check (eqv_punctured.add_con S).mk'
 
 def lift_neg : (punctured_power_series S) → (laurent_series S) :=
   λ ⟨k, f⟩, (eqv_punctured.add_con S).mk' ⟨k, -f⟩
@@ -416,40 +438,12 @@ lemma cong_neg : ∀ (F₁ F₂ : punctured_power_series S),  eqv_punctured F₁
 begin
   rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩ ⟨ℓ₁₂, ℓ₂₁, h⟩,
   dsimp [lift_neg],
-  -- rw eqv_punctured at h,
-  -- rcases h with ⟨ℓ₁₂, ℓ₂₁, h⟩,
   rw ext_punctured_power_series at h,
-  -- have hμ : μ (k₁, ℓ₁₂) = μ (k₂, ℓ₂₁),
-  -- rw cst_shift_fun at h,
-  -- rw μ,
-  -- sorry,
-  -- replace h : k₁ + ℓ₁₂ = k₂ + ℓ₂₁ ∧ ((k₁, f₁) + (ℓ₁₂, 0)).snd =
-  --   ((k₂, f₂) + (ℓ₂₁, 0)).snd,
-  -- split,
-  -- exact h.1,
-  -- let k := h.2,
-  -- exact h.2,
-  -- sorry,
   replace h : eqv_punctured (k₁, -f₁) (k₂, -f₂),
   { use [ℓ₁₂, ℓ₂₁],
     ext,
     exact h.1,
-    -- replace h : ((k₁, f₁) + (ℓ₁₂, 0)).snd = ((k₂, f₂) + (ℓ₂₁, 0)).snd := and.elim_right h,
-    show (shift_fun ℓ₁₂ (- f₁) + shift_fun k₁ 0) x =
-    (shift_fun ℓ₂₁ (-f₂) + shift_fun k₂ 0) x,
-    simp only [*, add_zero, pi.neg_apply, shift_fun_of_zero, neg_inj,
-      shift_neg] at *,
-    repeat {rw pi.add_apply},
-    simp [pi.zero_apply, add_zero, *] at *,
-    have this : ((k₁, f₁) + (ℓ₁₂, 0)).snd = ((k₂, f₂) + (ℓ₂₁, 0)).snd,
-    apply and.right h,
-    have that : shift_fun ℓ₁₂ f₁ = shift_fun ℓ₂₁ f₂,
-    -- dsimp [punctured_power_series.add],
-    sorry,
-    sorry,
-    sorry,
-    -- apply congr_fun that x,
-    },
+    simp * at * },
   apply (add_con.eq (eqv_punctured.add_con S)).mpr h,
 end
 
@@ -459,30 +453,34 @@ def lift_sub : (punctured_power_series S) → (punctured_power_series S) → (la
 lemma cong_sub : ∀ (F₁ F₂ G₁ G₂: punctured_power_series S),  eqv_punctured F₁ G₁ →
   eqv_punctured.add_con S F₂ G₂ → lift_sub F₁ F₂ = lift_sub G₁ G₂ :=
 begin
-  rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩ ⟨m₁, g₁⟩ ⟨m₂, g₂⟩ ⟨μ₁₂, μ₂₁, h₁⟩ ⟨θ₁₂, θ₂₁, h₂⟩,
+  rintros ⟨k₁, f₁⟩ ⟨m₁, g₁⟩ ⟨k₂, f₂⟩ ⟨m₂, g₂⟩ ⟨μ₁₂, μ₂₁, h₁⟩ ⟨θ₁₂, θ₂₁, h₂⟩,
   dsimp [lift_sub],
   rw ext_punctured_power_series at h₁,
   rw ext_punctured_power_series at h₂,
-  have h : eqv_punctured (k₁ + k₂, f₁ - f₂) (m₁ + m₂, g₁ - g₂),
+  have h : eqv_punctured (k₁ + m₁, f₁ - g₁) (k₂ + m₂, f₂ - g₂),
   { rw eqv_punctured,
     use [μ₁₂ + θ₁₂, μ₂₁ + θ₂₁],
     ext,
-    have this₁ : ((k₁, f₁) + (μ₁₂, 0)).fst = ((m₁, g₁) + (μ₂₁, 0)).fst,
-    exact h₁.1,
-    repeat {rw prod.fst_add at this₁},
-    -- rw prod.fst_add at this₁,
-    -- rw prod.fst_add (k₁, f₁) (μ₁₂, 0) at this₁,
-    have this₂ : ((k₂, f₂) + (θ₁₂, 0)).fst = ((m₂, g₂) + (θ₂₁, 0)).fst,
-    exact h₂.1,
-    repeat {rw prod.fst_add at this₂},
-    -- apply prod.fst_add,
-    -- show (k₁ + k₂, f₁ - f₂).fst + (μ₁₂ + θ₁₂).fst =
-    --   (m₁ + m₂, g₁ - g₂).fst + (μ₂₁ + θ₂₁, 0).fst,
-    -- rw prod.fst_add,
-    rw prod.fst_add ((k₁ + k₂, f₁ - f₂) : ℕ × (ℕ → S)) (μ₁₂ + θ₁₂, 0),
-  }
+    { simp only [*, add_zero, add_snd, shift_fun_of_zero, add_fst] at *,
+      sorry },
+    { simp only [*, add_zero, add_snd, shift_fun_of_zero, add_fst,
+      pi.add_apply] at *,
+      have h₁' : shift_fun μ₁₂ f₁ = shift_fun μ₂₁ g₁, sorry,
+      have h₂' : shift_fun θ₁₂ f₂ = shift_fun θ₂₁ g₂, sorry,
+      rw nat.add_comm,
+      rw ← shift_fun_assoc,
+      rw sub_eq_add_neg,
+      rw shift_fun_add,
+      rw h₁',
+      rw nat.add_comm,
+      rw ← shift_fun_assoc,
+      rw sub_eq_add_neg,
+      -- rw shift_fun_add μ₂₁ g₁ (-g₂),
+      rw ← h₁',
+      sorry,
+  }},
   -- have
-  sorry,
+  -- sorry,
   -- rw lift_sub,
   apply (add_con.eq (eqv_punctured.add_con S)).mpr h,
 end

--- a/src/ring_theory/laurent_series.lean
+++ b/src/ring_theory/laurent_series.lean
@@ -577,11 +577,28 @@ instance : comm_ring (laurent_series S) :=
   mul := λ F₁ F₂, add_con.lift_on₂ F₁ F₂ lift_mul cong_mul,
   mul_assoc := λ F₁ F₂ F₃, quotient.induction_on₃' F₁ F₂ F₃
               $ λ _ _ _, congr_arg coe $ lift_mul_assoc _ _ _,
-  one := sorry,
-  one_mul := sorry,
+  one := (eqv_punctured.add_con S).mk' (0, λ n, if n = 0 then 1 else 0),
+  one_mul := begin
+              intro G,
+              apply quotient.induction_on' G,
+              rintro ⟨k, f⟩,
+              apply congr_arg quotient.mk',
+              ext,
+              apply nat.zero_add,
+              dsimp [punctured_power_series.mul],
+              induction x with n hn,
+              { rw [finset.nat.antidiagonal_zero, finset.sum_singleton,
+                  if_pos],
+                apply one_mul,
+                apply rfl },
+              { rw multiset.nat.antidiagonal_succ,
+              sorry,
+
+              },
+            end,
   mul_one := sorry,
-  left_distrib := sorry,
-  right_distrib := sorry,
+  left_distrib := begin sorry, end,
+  right_distrib := begin sorry, end,
   mul_comm := sorry }
 
 

--- a/src/ring_theory/laurent_series.lean
+++ b/src/ring_theory/laurent_series.lean
@@ -298,6 +298,22 @@ noncomputable theory
 open classical
 -- open_locale classical
 
+def lift_neg : (punctured_power_series S) → (laurent_series S) :=
+  λ ⟨𝕜, f⟩, (eqv_punctured.add_con S).mk' ⟨𝕜, -f⟩
+lemma cong_neg : ∀ (F₁ F₂ : punctured_power_series S),  eqv_punctured F₁ F₂ →
+  lift_neg F₁ = lift_neg F₂ :=
+begin
+  rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂, f₂⟩ h,
+  dsimp [lift_neg, h],
+  rw eqv_punctured at h,
+  sorry,
+end
+
+def lift_sub : (punctured_power_series S) → (punctured_power_series S) → (laurent_series S) :=
+  λ ⟨𝕜₁, f₁⟩, λ ⟨𝕜₂, f₂⟩, (eqv_punctured.add_con S).mk' ⟨μ (𝕜₁, 𝕜₂), f₁-f₂⟩
+lemma cong_sub : ∀ (F₁ F₂ G₁ G₂: punctured_power_series S),  eqv_punctured F₁ G₁ →
+  eqv_punctured.add_con S F₂ G₂ → lift_sub F₁ F₂ = lift_sub G₁ G₂ := sorry
+
 instance : comm_ring (laurent_series S) :=
 { add := λ F₁ F₂, F₁ + F₂,
   add_assoc := sorry,
@@ -309,35 +325,42 @@ instance : comm_ring (laurent_series S) :=
   --   obtain ⟨f⟩ : ∃ f : (punctured_power_series S),
   --     (eqv_punctured.add_con S).mk' f = F,
   -- end,
-  neg := begin
-                -- refine quot.lift_on _ _ _,
-                -- use (punctured_power_series S),
-                -- -- rintros F₁ F₂,
-                -- rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂,f₂⟩,
-                -- use eqv_punctured ⟨𝕜₁, f₁⟩ ⟨𝕜₂,f₂⟩,
-                -- --  (λ (𝕜, f), (𝕜, -f))⟩,
-                -- -- begin
+  neg := λ F, add_con.lift_on F lift_neg cong_neg,
 
-                  intro G,
-                have hG : ∃ f : (punctured_power_series S),
-                    (eqv_punctured.add_con S).mk' f = G,
-                apply add_con.mk'_surjective,
-                rcases some hG with ⟨𝕜, g⟩,
-                use (eqv_punctured.add_con S).mk' ⟨𝕜, -g⟩,
-                end,
-  sub := begin
-                  intros F₁ F₂,
-                  have hF₁ : ∃ f₁ : (punctured_power_series S),
-                    (eqv_punctured.add_con S).mk' f₁ = F₁,
-                  apply add_con.mk'_surjective,
-                  have hF₂ : ∃ f₂ : (punctured_power_series S),
-                    (eqv_punctured.add_con S).mk' f₂ = F₂,
-                  apply add_con.mk'_surjective,
-                  rcases some hF₁ with ⟨𝕜₁, f₁⟩,
-                  rcases some hF₂ with ⟨𝕜₂, f₂⟩,
-                  use (eqv_punctured.add_con S).mk' (μ (𝕜₁, 𝕜₂), f₁-f₂),
-                end,
-  sub_eq_add_neg :=
+  -- begin
+  --   let φ : (punctured_power_series S) → (punctured_power_series S) :=
+  -- λ ⟨𝕜, f⟩, ⟨𝕜, -f⟩,
+  --   use (add_con.lift_on (laurent_series S) φ),
+  -- end,
+  --               -- refine quot.lift_on _ _ _,
+  --               -- use (punctured_power_series S),
+  --               -- -- rintros F₁ F₂,
+  --               -- rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂,f₂⟩,
+  --               -- use eqv_punctured ⟨𝕜₁, f₁⟩ ⟨𝕜₂,f₂⟩,
+  --               -- --  (λ (𝕜, f), (𝕜, -f))⟩,
+  --               -- -- begin
+
+  --               --   intro G,
+  --               -- have hG : ∃ f : (punctured_power_series S),
+  --               --     (eqv_punctured.add_con S).mk' f = G,
+  --               -- apply add_con.mk'_surjective,
+  --               -- rcases some hG with ⟨𝕜, g⟩,
+  --               -- use (eqv_punctured.add_con S).mk' ⟨𝕜, -g⟩,
+  --               -- end,
+  sub :=  λ F₁ F₂, add_con.lift_on₂ F₁ F₂ lift_sub cong_sub,
+  -- begin
+  --           intros F₁ F₂,
+  --                 have hF₁ : ∃ f₁ : (punctured_power_series S),
+  --                   (eqv_punctured.add_con S).mk' f₁ = F₁,
+  --                 apply add_con.mk'_surjective,
+  --                 have hF₂ : ∃ f₂ : (punctured_power_series S),
+  --                   (eqv_punctured.add_con S).mk' f₂ = F₂,
+  --                 apply add_con.mk'_surjective,
+  --                 rcases some hF₁ with ⟨𝕜₁, f₁⟩,
+  --                 rcases some hF₂ with ⟨𝕜₂, f₂⟩,
+  --                 use (eqv_punctured.add_con S).mk' (μ (𝕜₁, 𝕜₂), f₁-f₂),
+  --               end,
+  sub_eq_add_neg := --by simp,
                 begin intros F₁ F₂,
                 rcases F₁,
                 rcases F₂,
@@ -348,16 +371,16 @@ instance : comm_ring (laurent_series S) :=
                 sorry,
                 sorry,
                 end,
-  add_left_neg := _,
-  add_comm := _,
-  mul := _,
-  mul_assoc := _,
-  one := _,
-  one_mul := _,
-  mul_one := _,
-  left_distrib := _,
-  right_distrib := _,
-  mul_comm := _ }
+  add_left_neg := sorry,
+  add_comm := sorry,
+  mul := sorry,
+  mul_assoc := sorry,
+  one := sorry,
+  one_mul := sorry,
+  mul_one := sorry,
+  left_distrib := sorry,
+  right_distrib := sorry,
+  mul_comm := sorry }
 
 -- end add_comm_monoid
 end punctured_power_series--SEE PAG 166 tpil

--- a/src/ring_theory/laurent_series.lean
+++ b/src/ring_theory/laurent_series.lean
@@ -127,7 +127,7 @@ instance [nontrivial R]      : nontrivial      (punctured_power_series R) := non
 def shift_fun {R : Type*} [has_zero R]: 𝕄 → (ℕ → R) → (ℕ → R)
 | (k) := λ f, λ n, if n < (℘ k) then (0 : R) else f (n - ℘ k)
 
-lemma shift_fun_by_zero [has_zero R] (f : ℕ → R) : shift_fun 𝟘 f = f := rfl
+@[simp] lemma shift_fun_by_zero [has_zero R] (f : ℕ → R) : shift_fun 𝟘 f = f := rfl
 
 -- section add_comm_monoid
 
@@ -136,7 +136,7 @@ variable [add_comm_monoid R]
 
 -- lemma cst_shift_fun' (𝕜 : 𝕄) : shift_fun 𝕜 (function.const : ℕ → R) = (0 : ℕ → R) := sorry,
 
-lemma cst_shift_fun (𝕜 : 𝕄) : shift_fun 𝕜 (0 : ℕ → R) = (0 : ℕ → R) :=
+@[simp] lemma cst_shift_fun (𝕜 : 𝕄) : shift_fun 𝕜 (0 : ℕ → R) = (0 : ℕ → R) :=
 begin
       -- funext,
       -- dsimp [shift_fun],
@@ -151,7 +151,7 @@ begin
 
 end
 
-protected def add : (punctured_power_series R) → (punctured_power_series R) → (punctured_power_series R) :=
+def add : (punctured_power_series R) → (punctured_power_series R) → (punctured_power_series R) :=
 begin
   rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂, f₂⟩,
   exact ⟨𝕜₁ + 𝕜₂, shift_fun (μ (𝕜₁, 𝕜₂)) f₁ + shift_fun (μ (𝕜₂, 𝕜₁)) f₂⟩,
@@ -221,6 +221,7 @@ instance : add_comm_monoid (punctured_power_series R) :=
   add_zero := punctured_power_series.add_zero,
   add_comm := punctured_power_series.add_comm }
 
+#print punctured_power_series.add
 -- def a : ℕ → ℤ := λ n, 4*n+3
 -- def b : ℕ → ℤ := λ n, 1-2*n
 -- def 𝕜₁ : 𝕄 := ℘⁻¹ 1
@@ -235,11 +236,6 @@ instance : add_comm_monoid (punctured_power_series R) :=
 
 def F₃ := (𝟘, b) --check!
 --/
-
--- variables {S : Type*} [comm_ring R]
-
---def eqv_punctured_shift {R : Type*} [add_comm_monoid R] (F₁ F₂ : punctured_power_series R) : Prop :=
--- (F₂.snd = (shift_fun ℘⁻¹ (℘ (F₂.fst) - ℘ (F₁.fst))) F₁.snd)) ∨ (F₁.snd = (shift_fun (F₁.fst - F₂.fst) F₂.snd))
 
 def eqv_punctured (F₁ F₂ : punctured_power_series R) : Prop :=
 ∃ ℓ₁₂ ℓ₂₁ : 𝕄, F₁ + (ℓ₁₂, 0) = F₂ + (ℓ₂₁, 0)
@@ -269,34 +265,25 @@ instance : add_comm_monoid (laurent_series R) := (eqv_punctured.add_con R).add_c
 instance : has_coe (punctured_power_series R) (laurent_series R) :=
 ⟨@quotient.mk _ (eqv_punctured.add_con R).to_setoid⟩
 
-
-
--- def a : ℕ → ℤ := λ n, 4*n+3
--- def b : ℕ → ℤ := λ n, 1-2*n
--- def 𝕜₁ : 𝕄 := ℘⁻¹ 1
--- def 𝕜₂ : 𝕄 := ℘⁻¹ 3
-
---setoid.mk (@eqv_punctured R _) (eqv_punctured.is_equivalence)
-
--- instance laurent_series.setoid (R : Type*) [add_comm_monoid R] : setoid (punctured_power_series R) :=
--- setoid.mk (@eqv_punctured R _) (eqv_punctured.is_equivalence)
-
--- definition laurent_series (R : Type*) [add_comm_monoid R] : Type* :=
--- quotient (laurent_series.setoid R)
-
--- instance : add_comm_monoid (laurent_series R) :=
--- { add := punctured_power_series.add,
---   add_assoc := _,
---   zero := _,
---   zero_add := _,
---   add_zero := _,
---   add_comm := _ }
-
 variables {S : Type*} [comm_ring S]
 
 noncomputable theory
 open classical
 -- open_locale classical
+
+
+-- lemma add_comm : ∀ (F G: punctured_power_series R), punctured_power_series.add F G =
+--   punctured_power_series.add G F :=
+-- begin
+--   rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂, f₂⟩,
+--   ext,
+--   apply max_comm,
+--   show (shift_fun (μ (𝕜₁, 𝕜₂)) f₁ + shift_fun (μ (𝕜₂, 𝕜₁)) f₂) x =
+--     (shift_fun (μ (𝕜₂, 𝕜₁)) f₂ + shift_fun (μ (𝕜₁, 𝕜₂)) f₁) x,
+--   simp only [pi.add_apply] at *,
+--   apply add_comm,
+-- end
+#check (eqv_punctured.add_con S).mk'
 
 def lift_neg : (punctured_power_series S) → (laurent_series S) :=
   λ ⟨𝕜, f⟩, (eqv_punctured.add_con S).mk' ⟨𝕜, -f⟩
@@ -304,9 +291,18 @@ lemma cong_neg : ∀ (F₁ F₂ : punctured_power_series S),  eqv_punctured F₁
   lift_neg F₁ = lift_neg F₂ :=
 begin
   rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂, f₂⟩ h,
-  dsimp [lift_neg, h],
+  dsimp [lift_neg],
   rw eqv_punctured at h,
-  sorry,
+  rcases h with ⟨ℓ₁₂, ℓ₂₁, h⟩,
+  replace h : 𝕜₁ + ℓ₁₂ = 𝕜₂ + ℓ₂₁ ∧ shift_fun (μ (𝕜₁, ℓ₁₂)) (-f₁) = shift_fun (μ (𝕜₂, ℓ₂₁)) (-f₂),
+  split, sorry, sorry,
+  replace h : eqv_punctured (𝕜₁, -f₁) (𝕜₂, -f₂),
+  { use [ℓ₁₂, ℓ₂₁],
+    ext, exact h.1,
+    show (shift_fun (μ (𝕜₁, ℓ₁₂)) (- f₁) + shift_fun (μ (ℓ₁₂, 𝕜₁)) 0) x =
+    (shift_fun (μ (𝕜₂, ℓ₂₁)) (-f₂) + shift_fun (μ (ℓ₂₁, 𝕜₂)) 0) x,
+    simp only [*, cst_shift_fun]},
+  apply (add_con.eq (eqv_punctured.add_con S)).mpr h,
 end
 
 def lift_sub : (punctured_power_series S) → (punctured_power_series S) → (laurent_series S) :=

--- a/src/ring_theory/laurent_series.lean
+++ b/src/ring_theory/laurent_series.lean
@@ -124,6 +124,22 @@ instance [inhabited R]       : inhabited       (punctured_power_series R) := ⟨
 instance [has_zero R]        : has_zero        (punctured_power_series R) := ⟨(𝟘, 0)⟩
 instance [nontrivial R]      : nontrivial      (punctured_power_series R) := nontrivial_prod_left
 
+@[simp] lemma ext_punctured_power_series (F₁ F₂ : punctured_power_series R) :
+  F₁ = F₂ ↔ F₁.1 = F₂.1 ∧ F₁.2 = F₂.2 :=
+begin
+  split,
+    {intro h,
+    split,
+    apply_fun prod.fst at h,
+    assumption,
+    apply_fun prod.snd at h,
+    assumption },
+  { intro h,
+    ext,
+    exact h.1,
+    simp only * at * },
+end
+
 def shift_fun {R : Type*} [has_zero R]: 𝕄 → (ℕ → R) → (ℕ → R)
 | (k) := λ f, λ n, if n < (℘ k) then (0 : R) else f (n - ℘ k)
 
@@ -295,7 +311,10 @@ begin
   rw eqv_punctured at h,
   rcases h with ⟨ℓ₁₂, ℓ₂₁, h⟩,
   replace h : 𝕜₁ + ℓ₁₂ = 𝕜₂ + ℓ₂₁ ∧ shift_fun (μ (𝕜₁, ℓ₁₂)) (-f₁) = shift_fun (μ (𝕜₂, ℓ₂₁)) (-f₂),
-  split, sorry, sorry,
+  split,
+  rw ext_punctured_power_series at h,
+  exact h.1,
+  sorry,
   replace h : eqv_punctured (𝕜₁, -f₁) (𝕜₂, -f₂),
   { use [ℓ₁₂, ℓ₂₁],
     ext, exact h.1,

--- a/src/ring_theory/laurent_series.lean
+++ b/src/ring_theory/laurent_series.lean
@@ -214,7 +214,7 @@ begin
       tauto,
 end
 
-@[simp] lemma shift_neg [ring R] (f : ℕ → R) (k : ℕ) :
+@[simp] lemma shift_fun_neg [ring R] (f : ℕ → R) (k : ℕ) :
   shift_fun k (-f) = - (shift_fun k f) :=
 begin
   ext,
@@ -312,25 +312,6 @@ begin
   apply rfl,
 end
 
--- #print punctured_power_series.add
--- def a : ℕ → ℤ := λ n, 4*n+3
--- def b : ℕ → ℤ := λ n, 1-2*n
--- -- def 𝕜₁ : 𝕄 := ℘⁻¹ 1
--- -- def 𝕜₂ : 𝕄 := ℘⁻¹ 3
-
--- def F₁ : punctured_power_series ℤ := (1, a)
--- def F₂ : punctured_power_series ℤ := (3, b)
--- #eval a 5
--- #eval (F₁ + F₂).snd 9
-/-The right answers are
-0 → 0, 1 → 1, 2 → -1, 3 → 0, 4 → 2, 5 → 4, 6 → 6, 7 → 8, 8 → 10, 9 → 12
-
-def F₃ := (𝟘, b) --check!
---/
-
--- def eqv_punctured_old (F₁ F₂ : punctured_power_series R) : Prop :=
--- ∃ ℓ₁₂ ℓ₂₁ : 𝕄, F₁ + (ℓ₁₂, 0) = F₂ + (ℓ₂₁, 0)
-
 def eqv_punctured (F₁ F₂ : punctured_power_series R) : Prop :=
 ∃ ℓ₁₂ ℓ₂₁ : ℕ, F₁ + (ℓ₁₂, 0) = F₂ + (ℓ₂₁, 0)
 
@@ -414,21 +395,6 @@ variables {S : Type*} [comm_ring S]
 
 noncomputable theory
 open classical
--- open_locale classical
-
-
--- lemma add_comm : ∀ (F G: punctured_power_series R), punctured_power_series.add F G =
---   punctured_power_series.add G F :=
--- begin
---   rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂, f₂⟩,
---   ext,
---   apply max_comm,
---   show (shift_fun (μ (𝕜₁, 𝕜₂)) f₁ + shift_fun (μ (𝕜₂, 𝕜₁)) f₂) x =
---     (shift_fun (μ (𝕜₂, 𝕜₁)) f₂ + shift_fun (μ (𝕜₁, 𝕜₂)) f₁) x,
---   simp only [pi.add_apply] at *,
---   apply add_comm,
--- end
--- #check (eqv_punctured.add_con S).mk'
 
 def lift_neg : (punctured_power_series S) → (laurent_series S) :=
   λ ⟨k, f⟩, (eqv_punctured.add_con S).mk' ⟨k, -f⟩
@@ -447,105 +413,170 @@ begin
   apply (add_con.eq (eqv_punctured.add_con S)).mpr h,
 end
 
-def lift_sub : (punctured_power_series S) → (punctured_power_series S) → (laurent_series S) :=
-  λ ⟨k₁, f₁⟩ ⟨k₂, f₂⟩, (eqv_punctured.add_con S).mk' ⟨k₁ + k₂, f₁ - f₂⟩
+lemma neg_add_cong_zero (k : ℕ) (f: ℕ → S) : eqv_punctured ((k, -f) + (k, f)) 0 :=
+begin
+  use [0, k + k],
+  simp * at *,
+end
 
-lemma cong_sub : ∀ (F₁ F₂ G₁ G₂: punctured_power_series S),  eqv_punctured F₁ G₁ →
+
+def lift_sub : (punctured_power_series S) → (punctured_power_series S) → (laurent_series S) :=
+  λ ⟨k₁, f₁⟩ ⟨k₂, f₂⟩, (eqv_punctured.add_con S).mk' ⟨k₁ + k₂, shift_fun k₂ f₁ - shift_fun k₁ f₂⟩
+
+lemma cong_sub {S : Type*} [comm_ring S] : ∀ (F₁ F₂ G₁ G₂: punctured_power_series S), eqv_punctured.add_con S F₁ G₁ →
   eqv_punctured.add_con S F₂ G₂ → lift_sub F₁ F₂ = lift_sub G₁ G₂ :=
 begin
-  rintros ⟨k₁, f₁⟩ ⟨m₁, g₁⟩ ⟨k₂, f₂⟩ ⟨m₂, g₂⟩ ⟨μ₁₂, μ₂₁, h₁⟩ ⟨θ₁₂, θ₂₁, h₂⟩,
+  rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩ ⟨m₁, g₁⟩  ⟨m₂, g₂⟩ ⟨ℓ₁₂, ℓ₂₁, hf⟩ ⟨μ₁₂, μ₂₁, hg⟩,
   dsimp [lift_sub],
-  rw ext_punctured_power_series at h₁,
-  rw ext_punctured_power_series at h₂,
-  have h : eqv_punctured (k₁ + m₁, f₁ - g₁) (k₂ + m₂, f₂ - g₂),
+  rw ext_punctured_power_series at hf,
+  rw ext_punctured_power_series at hg,
+  have h : eqv_punctured (k₁ + k₂, shift_fun k₂ f₁ - shift_fun k₁ f₂)
+    (m₁ + m₂, shift_fun m₂ g₁ - shift_fun m₁ g₂),
   { rw eqv_punctured,
-    use [μ₁₂ + θ₁₂, μ₂₁ + θ₂₁],
+    use [ℓ₁₂ + μ₁₂, ℓ₂₁ + μ₂₁],
     ext,
     { simp only [*, add_zero, add_snd, shift_fun_of_zero, add_fst] at *,
-      sorry },
-    { simp only [*, add_zero, add_snd, shift_fun_of_zero, add_fst,
-      pi.add_apply] at *,
-      have h₁' : shift_fun μ₁₂ f₁ = shift_fun μ₂₁ g₁, sorry,
-      have h₂' : shift_fun θ₁₂ f₂ = shift_fun θ₂₁ g₂, sorry,
-      rw nat.add_comm,
-      rw ← shift_fun_assoc,
-      rw sub_eq_add_neg,
-      rw shift_fun_add,
-      rw h₁',
-      rw nat.add_comm,
-      rw ← shift_fun_assoc,
-      rw sub_eq_add_neg,
-      -- rw shift_fun_add μ₂₁ g₁ (-g₂),
-      rw ← h₁',
-      sorry,
-  }},
-  -- have
-  -- sorry,
-  -- rw lift_sub,
+      rw [← nat.add_left_comm, nat.add_assoc k₁ k₂ μ₁₂, hg.left,
+        nat.add_assoc m₁, nat.add_comm m₂ (ℓ₂₁ + μ₂₁), nat.add_assoc ℓ₂₁,
+        ← nat.add_assoc m₁, ← hf.left],
+      ring },
+    { simp only [*, sub_eq_add_neg, add_zero, add_snd, pi.add_apply,
+        pi.neg_apply, shift_fun_assoc, shift_fun_of_zero, shift_fun_add,
+        add_fst, shift_fun_neg, add_monoid.add_zero] at *,
+      rw nat.add_assoc,
+      rw nat.add_comm ℓ₁₂,
+      rw ← shift_fun_assoc f₁ (μ₁₂ + k₂) ℓ₁₂,
+      rw hf.right,
+      rw nat.add_assoc _ μ₁₂ k₁,
+      rw nat.add_comm μ₁₂ k₁,
+      rw ← nat.add_assoc _ k₁ μ₁₂,
+      rw ← shift_fun_assoc f₂ (ℓ₁₂ + k₁) μ₁₂,
+      rw [hg.right],
+      simp only [shift_fun_assoc],
+      have hf₁ : μ₁₂ + k₂ + ℓ₂₁ = ℓ₂₁ + μ₂₁ + m₂,
+      { rw [nat.add_comm μ₁₂ k₂, hg.left],
+        ring },
+      have hg₁ : ℓ₁₂ + k₁ + μ₂₁ = ℓ₂₁ + μ₂₁ + m₁,
+      { rw [nat.add_comm ℓ₁₂ k₁, hf.left],
+        ring },
+      rwa [hf₁, hg₁] }},
   apply (add_con.eq (eqv_punctured.add_con S)).mpr h,
 end
 
+def punctured_power_series.mul : (punctured_power_series S) → (punctured_power_series S) → (punctured_power_series S) :=
+λ ⟨k₁, f₁⟩ ⟨k₂, f₂⟩, ⟨k₁ + k₂, λ n, ∑ p in (finset.nat.antidiagonal n), f₁ p.2 * f₂ p.1⟩
+
+def lift_mul : (punctured_power_series S) → (punctured_power_series S) → (laurent_series S) :=
+  λ F₁ F₂, (eqv_punctured.add_con S).mk' (punctured_power_series.mul F₁ F₂)
+
+
+lemma lift_mul_assoc : ∀ (F₁ F₂ F₃ : punctured_power_series S), punctured_power_series.mul
+    (punctured_power_series.mul F₁ F₂ ) F₃ = punctured_power_series.mul F₁ (punctured_power_series.mul F₂ F₃) :=
+begin
+  intros,
+  sorry,
+end
+
+lemma cong_mul {S : Type*} [comm_ring S] : ∀ (F₁ F₂ G₁ G₂: punctured_power_series S), eqv_punctured.add_con S F₁ G₁ →
+  eqv_punctured.add_con S F₂ G₂ → lift_mul F₁ F₂ = lift_mul G₁ G₂ :=
+begin
+  rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩ ⟨m₁, g₁⟩  ⟨m₂, g₂⟩ ⟨ℓ₁₂, ℓ₂₁, hf⟩ ⟨μ₁₂, μ₂₁, hg⟩,
+  dsimp [lift_mul],
+  rw ext_punctured_power_series at hf,
+  rw ext_punctured_power_series at hg,
+  sorry,
+  -- have h : eqv_punctured (k₁ + k₂, shift_fun k₂ f₁ - shift_fun k₁ f₂)
+  --   (m₁ + m₂, shift_fun m₂ g₁ - shift_fun m₁ g₂),
+  -- { rw eqv_punctured,
+  --   use [ℓ₁₂ + μ₁₂, ℓ₂₁ + μ₂₁],
+  --   ext,
+  --   { simp only [*, add_zero, add_snd, shift_fun_of_zero, add_fst] at *,
+  --     rw [← nat.add_left_comm, nat.add_assoc k₁ k₂ μ₁₂, hg.left,
+  --       nat.add_assoc m₁, nat.add_comm m₂ (ℓ₂₁ + μ₂₁), nat.add_assoc ℓ₂₁,
+  --       ← nat.add_assoc m₁, ← hf.left],
+  --     ring },
+  --   { simp only [*, sub_eq_add_neg, add_zero, add_snd, pi.add_apply,
+  --       pi.neg_apply, shift_fun_assoc, shift_fun_of_zero, shift_fun_add,
+  --       add_fst, shift_fun_neg, add_monoid.add_zero] at *,
+  --     rw nat.add_assoc,
+  --     rw nat.add_comm ℓ₁₂,
+  --     rw ← shift_fun_assoc f₁ (μ₁₂ + k₂) ℓ₁₂,
+  --     rw hf.right,
+  --     rw nat.add_assoc _ μ₁₂ k₁,
+  --     rw nat.add_comm μ₁₂ k₁,
+  --     rw ← nat.add_assoc _ k₁ μ₁₂,
+  --     rw ← shift_fun_assoc f₂ (ℓ₁₂ + k₁) μ₁₂,
+  --     rw [hg.right],
+  --     simp only [shift_fun_assoc],
+  --     have hf₁ : μ₁₂ + k₂ + ℓ₂₁ = ℓ₂₁ + μ₂₁ + m₂,
+  --     { rw [nat.add_comm μ₁₂ k₂, hg.left],
+  --       ring },
+  --     have hg₁ : ℓ₁₂ + k₁ + μ₂₁ = ℓ₂₁ + μ₂₁ + m₁,
+  --     { rw [nat.add_comm ℓ₁₂ k₁, hf.left],
+  --       ring },
+  --     rwa [hf₁, hg₁] }},
+  -- apply (add_con.eq (eqv_punctured.add_con S)).mpr h,
+end
+
+-- -- #print punctured_power_series.add
+-- def a : ℕ → ℤ := λ n, if n < 5 then 4*n+3 else 0
+-- def b : ℕ → ℤ := λ n, if n < 7 then 1-2*n else 0
+-- -- -- def 𝕜₁ : 𝕄 := ℘⁻¹ 1
+-- -- -- def 𝕜₂ : 𝕄 := ℘⁻¹ 3
+
+-- def F₁ : punctured_power_series ℤ := (1, a)
+-- def F₂ : punctured_power_series ℤ := (3, b)
+-- -- #eval a 5
+-- #eval F₁.snd 2
+-- #eval F₂.snd 9
+-- #eval (F₁ + F₂).snd 7
+-- #eval (lift_mul F₁ F₂).snd 10
+/-The right answers for F₁ + F₂ are
+0 → 0, 1 → 1, 2 → -1, 3 → 0, 4 → 2, 5 → 4, 6 → 6, 7 → 8, 8 → 10, 9 → 12
+
+def F₃ := (𝟘, b) --check!
+--/
+
+-- def eqv_punctured_old (F₁ F₂ : punctured_power_series R) : Prop :=
+-- ∃ ℓ₁₂ ℓ₂₁ : 𝕄, F₁ + (ℓ₁₂, 0) = F₂ + (ℓ₂₁, 0)
+
+
 instance : comm_ring (laurent_series S) :=
 { add := λ F₁ F₂, F₁ + F₂,
-  add_assoc := sorry,
+  add_assoc :=  λ F₁ F₂ F₃, quotient.induction_on₃' F₁ F₂ F₃
+                $ λ _ _ _, congr_arg coe $ add_assoc _ _ _,
   zero := (eqv_punctured.add_con S).mk' 0,
   zero_add := λ _, by simp,
   add_zero := λ _, by simp,
-  -- begin
-  --   rintros F,
-  --   obtain ⟨f⟩ : ∃ f : (punctured_power_series S),
-  --     (eqv_punctured.add_con S).mk' f = F,
-  -- end,
   neg := λ F, add_con.lift_on F lift_neg cong_neg,
-
-  -- begin
-  --   let φ : (punctured_power_series S) → (punctured_power_series S) :=
-  -- λ ⟨𝕜, f⟩, ⟨𝕜, -f⟩,
-  --   use (add_con.lift_on (laurent_series S) φ),
-  -- end,
-  --               -- refine quot.lift_on _ _ _,
-  --               -- use (punctured_power_series S),
-  --               -- -- rintros F₁ F₂,
-  --               -- rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂,f₂⟩,
-  --               -- use eqv_punctured ⟨𝕜₁, f₁⟩ ⟨𝕜₂,f₂⟩,
-  --               -- --  (λ (𝕜, f), (𝕜, -f))⟩,
-  --               -- -- begin
-
-  --               --   intro G,
-  --               -- have hG : ∃ f : (punctured_power_series S),
-  --               --     (eqv_punctured.add_con S).mk' f = G,
-  --               -- apply add_con.mk'_surjective,
-  --               -- rcases some hG with ⟨𝕜, g⟩,
-  --               -- use (eqv_punctured.add_con S).mk' ⟨𝕜, -g⟩,
-  --               -- end,
   sub :=  λ F₁ F₂, add_con.lift_on₂ F₁ F₂ lift_sub cong_sub,
-  -- begin
-  --           intros F₁ F₂,
-  --                 have hF₁ : ∃ f₁ : (punctured_power_series S),
-  --                   (eqv_punctured.add_con S).mk' f₁ = F₁,
-  --                 apply add_con.mk'_surjective,
-  --                 have hF₂ : ∃ f₂ : (punctured_power_series S),
-  --                   (eqv_punctured.add_con S).mk' f₂ = F₂,
-  --                 apply add_con.mk'_surjective,
-  --                 rcases some hF₁ with ⟨𝕜₁, f₁⟩,
-  --                 rcases some hF₂ with ⟨𝕜₂, f₂⟩,
-  --                 use (eqv_punctured.add_con S).mk' (μ (𝕜₁, 𝕜₂), f₁-f₂),
-  --               end,
-  sub_eq_add_neg := --by simp,
-                begin intros F₁ F₂,
-                rcases F₁,
-                rcases F₂,
-                rcases F₁ with ⟨𝕜₁, f₁⟩,
-                rcases F₂ with ⟨𝕜₂, f₂⟩,
-                suffices this : f₁ - f₂ = f₁ + -f₂,
-                simp * at *,
-                sorry,
-                sorry,
-                end,
-  add_left_neg := sorry,
-  add_comm := sorry,
-  mul := sorry,
-  mul_assoc := sorry,
+  sub_eq_add_neg := begin
+                      intros G₁ G₂,
+                      apply quotient.induction_on₂' G₁ G₂,
+                      rintros ⟨k₁, f₁⟩  ⟨k₂, f₂⟩,
+                      apply congr_arg quotient.mk',
+                      ext,
+                      apply rfl,
+                      simp only [add_snd, pi.add_apply, pi.neg_apply,
+                        pi.sub_apply, shift_fun_neg],
+                      ring,
+                    end,
+  add_left_neg := begin
+                intro G,
+                apply quotient.induction_on' G,
+                rintro ⟨k, f⟩,
+                apply (add_con.eq (eqv_punctured.add_con S)).mpr (neg_add_cong_zero k f),
+                  end,
+  add_comm := begin
+                intros G₁ G₂,
+                apply quotient.induction_on₂' G₁ G₂,
+                rintros F₁ F₂,
+                apply congr_arg quotient.mk',
+                exact add_comm F₁ F₂,
+              end,
+  mul := λ F₁ F₂, add_con.lift_on₂ F₁ F₂ lift_mul cong_mul,
+  mul_assoc := λ F₁ F₂ F₃, quotient.induction_on₃' F₁ F₂ F₃
+              $ λ _ _ _, congr_arg coe $ lift_mul_assoc _ _ _,
   one := sorry,
   one_mul := sorry,
   mul_one := sorry,
@@ -553,7 +584,7 @@ instance : comm_ring (laurent_series S) :=
   right_distrib := sorry,
   mul_comm := sorry }
 
--- end add_comm_monoid
+
 end punctured_power_series--SEE PAG 166 tpil
 
 

--- a/src/ring_theory/laurent_series.lean
+++ b/src/ring_theory/laurent_series.lean
@@ -193,8 +193,6 @@ def shift_fun {R : Type*} [has_zero R]: ℕ → (ℕ → R) → (ℕ → R)
           rw [int.coe_nat_lt, not_lt] at hx₁, --uguale a riga 173
           exact hx₁} },--uguale a riga 174
 end
--- @[simp] lemma eq_shift_fun [has_neg R] [has_zero R] (𝕜₁ 𝕜₂ : 𝕄) (f₁ f₂ : ℕ → R) :
---   𝕜₁ = 𝕜₂ → shift_fun 𝕜₁ f₁ = shift_fun 𝕜₂ f₂ ↔ f₁ = f₂ := sorry
 
 
 
@@ -379,7 +377,19 @@ begin
     ring },
 end
 
+/-- The `n`th coefficient of a punctured power series.-/
+def punctured_power_series.coeff (n : ℤ) : (punctured_power_series R) → R :=
+ λ ⟨k, f⟩, if n < - k then 0 else f (int.nat_abs (n + k))
+
+end punctured_power_series
+
+namespace laurent_series
+open punctured_power_series
+
 def laurent_series (R : Type*) [add_comm_monoid R]:= (eqv_punctured.add_con R).quotient
+
+variables {R : Type*} [add_comm_monoid R]
+
 instance inhabited : inhabited (laurent_series R) :=
   begin
     use (eqv_punctured.add_con R).mk' 0,
@@ -390,17 +400,17 @@ instance : add_comm_monoid (laurent_series R) := (eqv_punctured.add_con R).add_c
 instance : has_coe (punctured_power_series R) (laurent_series R) :=
 ⟨@quotient.mk _ (eqv_punctured.add_con R).to_setoid⟩
 
-variables {S : Type*} [comm_ring S]
 
+variables {S : Type*} [comm_ring S]
 
 noncomputable theory
 open classical
 
-def lift_neg : (punctured_power_series S) → (laurent_series S) :=
-  λ ⟨k, f⟩, (eqv_punctured.add_con S).mk' ⟨k, -f⟩
+def lift_neg : (punctured_power_series.punctured_power_series S) → (laurent_series S) :=
+  λ ⟨k, f⟩, (punctured_power_series.eqv_punctured.add_con S).mk' ⟨k, -f⟩
 
-lemma cong_neg : ∀ (F₁ F₂ : punctured_power_series S),  eqv_punctured F₁ F₂ →
-  lift_neg F₁ = lift_neg F₂ :=
+lemma cong_neg : ∀ (F₁ F₂ : punctured_power_series.punctured_power_series S),
+  punctured_power_series.eqv_punctured F₁ F₂ → lift_neg F₁ = lift_neg F₂ :=
 begin
   rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩ ⟨ℓ₁₂, ℓ₂₁, h⟩,
   dsimp [lift_neg],
@@ -435,12 +445,12 @@ begin
   { rw eqv_punctured,
     use [ℓ₁₂ + μ₁₂, ℓ₂₁ + μ₂₁],
     ext,
-    { simp only [*, add_zero, add_snd, shift_fun_of_zero, add_fst] at *,
+    { simp only [*, punctured_power_series.add_zero, add_snd, shift_fun_of_zero, add_fst] at *,
       rw [← nat.add_left_comm, nat.add_assoc k₁ k₂ μ₁₂, hg.left,
         nat.add_assoc m₁, nat.add_comm m₂ (ℓ₂₁ + μ₂₁), nat.add_assoc ℓ₂₁,
         ← nat.add_assoc m₁, ← hf.left],
       ring },
-    { simp only [*, sub_eq_add_neg, add_zero, add_snd, pi.add_apply,
+    { simp only [*, sub_eq_add_neg, punctured_power_series.add_zero, add_snd, pi.add_apply,
         pi.neg_apply, shift_fun_assoc, shift_fun_of_zero, shift_fun_add,
         add_fst, shift_fun_neg, add_monoid.add_zero] at *,
       rw nat.add_assoc,
@@ -470,7 +480,7 @@ def lift_mul : (punctured_power_series S) → (punctured_power_series S) → (la
   λ F₁ F₂, (eqv_punctured.add_con S).mk' (punctured_power_series.mul F₁ F₂)
 
 
-lemma lift_mul_assoc : ∀ (F₁ F₂ F₃ : punctured_power_series S), punctured_power_series.mul
+lemma lift_mul_assoc : ∀ (F₁ F₂ F₃ : punctured_power_series.punctured_power_series S), punctured_power_series.mul
     (punctured_power_series.mul F₁ F₂ ) F₃ = punctured_power_series.mul F₁ (punctured_power_series.mul F₂ F₃) :=
 begin
   intros,
@@ -478,7 +488,7 @@ begin
 end
 
 lemma cong_mul {S : Type*} [comm_ring S] : ∀ (F₁ F₂ G₁ G₂: punctured_power_series S), eqv_punctured.add_con S F₁ G₁ →
-  eqv_punctured.add_con S F₂ G₂ → lift_mul F₁ F₂ = lift_mul G₁ G₂ :=
+  punctured_power_series.eqv_punctured.add_con S F₂ G₂ → lift_mul F₁ F₂ = lift_mul G₁ G₂ :=
 begin
   rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩ ⟨m₁, g₁⟩  ⟨m₂, g₂⟩ ⟨ℓ₁₂, ℓ₂₁, hf⟩ ⟨μ₁₂, μ₂₁, hg⟩,
   dsimp [lift_mul],
@@ -518,34 +528,11 @@ begin
   -- apply (add_con.eq (eqv_punctured.add_con S)).mpr h,
 end
 
--- -- #print punctured_power_series.add
--- def a : ℕ → ℤ := λ n, if n < 5 then 4*n+3 else 0
--- def b : ℕ → ℤ := λ n, if n < 7 then 1-2*n else 0
--- -- -- def 𝕜₁ : 𝕄 := ℘⁻¹ 1
--- -- -- def 𝕜₂ : 𝕄 := ℘⁻¹ 3
-
--- def F₁ : punctured_power_series ℤ := (1, a)
--- def F₂ : punctured_power_series ℤ := (3, b)
--- -- #eval a 5
--- #eval F₁.snd 2
--- #eval F₂.snd 9
--- #eval (F₁ + F₂).snd 7
--- #eval (lift_mul F₁ F₂).snd 10
-/-The right answers for F₁ + F₂ are
-0 → 0, 1 → 1, 2 → -1, 3 → 0, 4 → 2, 5 → 4, 6 → 6, 7 → 8, 8 → 10, 9 → 12
-
-def F₃ := (𝟘, b) --check!
---/
-
--- def eqv_punctured_old (F₁ F₂ : punctured_power_series R) : Prop :=
--- ∃ ℓ₁₂ ℓ₂₁ : 𝕄, F₁ + (ℓ₁₂, 0) = F₂ + (ℓ₂₁, 0)
-
-
 instance : comm_ring (laurent_series S) :=
 { add := λ F₁ F₂, F₁ + F₂,
   add_assoc :=  λ F₁ F₂ F₃, quotient.induction_on₃' F₁ F₂ F₃
-                $ λ _ _ _, congr_arg coe $ add_assoc _ _ _,
-  zero := (eqv_punctured.add_con S).mk' 0,
+                $ λ _ _ _, congr_arg coe $ punctured_power_series.add_assoc _ _ _,
+  zero := (punctured_power_series.eqv_punctured.add_con S).mk' 0,
   zero_add := λ _, by simp,
   add_zero := λ _, by simp,
   neg := λ F, add_con.lift_on F lift_neg cong_neg,
@@ -572,7 +559,7 @@ instance : comm_ring (laurent_series S) :=
                 apply quotient.induction_on₂' G₁ G₂,
                 rintros F₁ F₂,
                 apply congr_arg quotient.mk',
-                exact add_comm F₁ F₂,
+                exact punctured_power_series.add_comm F₁ F₂,
               end,
   mul := λ F₁ F₂, add_con.lift_on₂ F₁ F₂ lift_mul cong_mul,
   mul_assoc := λ F₁ F₂ F₃, quotient.induction_on₃' F₁ F₂ F₃
@@ -591,38 +578,56 @@ instance : comm_ring (laurent_series S) :=
                   if_pos],
                 apply one_mul,
                 apply rfl },
-              { rw multiset.nat.antidiagonal_succ,
-              sorry,
-
-              },
+              { rw finset.nat.antidiagonal_succ,
+                sorry },
             end,
   mul_one := sorry,
   left_distrib := begin sorry, end,
   right_distrib := begin sorry, end,
   mul_comm := sorry }
 
+/-- The `n`th coefficient of a laurent power series.-/
+lemma cong_coeff (n : ℤ) (F₁ F₂ : punctured_power_series S) :
+  eqv_punctured.add_con S F₁ F₂ → punctured_power_series.coeff n F₁ = punctured_power_series.coeff n F₂ :=
+begin
+  sorry,
+end
 
-end punctured_power_series--SEE PAG 166 tpil
+
+def coeff (n : ℤ) : (laurent_series S) → S :=
+begin
+  let coeff : (laurent_series S) → S := λ F, add_con.lift_on F (punctured_power_series.coeff n) (cong_coeff n),
+  use coeff,
+end
+
+
+-- -- #print punctured_power_series.add
+def a : ℕ → ℤ := λ n, if n < 5 then 4*n+3 else 0
+def b : ℕ → ℤ := λ n, if n < 7 then 1-2*n else 0
+-- -- -- def 𝕜₁ : 𝕄 := ℘⁻¹ 1
+-- -- -- def 𝕜₂ : 𝕄 := ℘⁻¹ 3
+
+-- def F₁ : punctured_power_series ℤ := (1, a)
+-- def F₂ : punctured_power_series ℤ := (3, b)
+-- def G₁ : laurent_series ℤ := F₁
+-- def F₃ : punctured_power_series ℤ := F₁ + (7, 0)
+-- def G₃ : laurent_series ℤ := F₃
+-- #eval F₁.2 2
+-- #eval punctured_power_series.coeff (-1) F₁
+-- #eval punctured_power_series.coeff (1) F₃
+-- #eval coeff 4 G₃
+-- -- #eval a 5
+-- #eval F₁.snd 2
+-- #eval F₂.snd 9
+-- #eval (F₁ + F₂).snd 7
+-- #eval (lift_mul F₁ F₂).snd 10
+/-The right answers for F₁ + F₂ are
+0 → 0, 1 → 1, 2 → -1, 3 → 0, 4 → 2, 5 → 4, 6 → 6, 7 → 8, 8 → 10, 9 → 12
+
+def F₃ := (𝟘, b) --check!
+--/
 
 
 
--- instance [add_group R]       : add_group       (punctured_power_series R) := pi.add_group
--- instance [add_comm_group R]  : add_comm_group  (punctured_power_series R) := pi.add_comm_group
 
-
--- instance {A} [semiring R] [add_comm_monoid A] [semimodule R A] :
---   semimodule R (punctured_power_series R) := pi.semimodule _ _ _
-
--- example  {A} [semiring R] [add_comm_monoid A] [semimodule R A] :
---   semimodule R (ℕ → A) :=
---   begin
---     refine pi.semimodule ℕ (λ (_ : ℕ), A) R
---   end
-
--- example  {A} [semiring R] [add_comm_monoid A] [semimodule R A] :
---   semimodule R (ℕ × A) :=
--- begin
-
--- end
-
--- end punctured_power_series
+end laurent_series

--- a/src/ring_theory/laurent_series.lean
+++ b/src/ring_theory/laurent_series.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2021 Filippo A. E. Nuccio. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import data.mv_polynomial
+import linear_algebra.std_basis
+import ring_theory.ideal.operations
+import ring_theory.multiplicity
+import ring_theory.algebra_tower
+import tactic.linarith
+
+/-!
+# Formal power series
+
+This file defines (multivariate) formal power series
+and develops the basic properties of these objects.
+
+A formal power series is to a polynomial like an infinite sum is to a finite sum.
+
+We provide the natural inclusion from polynomials to formal power series.
+
+## Generalities
+
+The file starts with setting up the (semi)ring structure on multivariate power series.
+
+`trunc n φ` truncates a formal power series to the polynomial
+that has the same coefficients as `φ`, for all `m ≤ n`, and `0` otherwise.
+
+If the constant coefficient of a formal power series is invertible,
+then this formal power series is invertible.
+
+Formal power series over a local ring form a local ring.
+
+## Formal power series in one variable
+
+We prove that if the ring of coefficients is an integral domain,
+then formal power series in one variable form an integral domain.
+
+The `order` of a formal power series `φ` is the multiplicity of the variable `X` in `φ`.
+
+If the coefficients form an integral domain, then `order` is a valuation
+(`order_mul`, `le_order_add`).
+
+## Implementation notes
+
+In this file we define multivariate formal power series with
+variables indexed by `σ` and coefficients in `R` as
+`mv_power_series σ R := (σ →₀ ℕ) → R`.
+Unfortunately there is not yet enough API to show that they are the completion
+of the ring of multivariate polynomials. However, we provide most of the infrastructure
+that is needed to do this. Once I-adic completion (topological or algebraic) is available
+it should not be hard to fill in the details.
+
+Formal power series in one variable are defined as
+`power_series R := mv_power_series unit R`.
+
+This allows us to port a lot of proofs and properties
+from the multivariate case to the single variable case.
+However, it means that formal power series are indexed by `unit →₀ ℕ`,
+which is of course canonically isomorphic to `ℕ`.
+We then build some glue to treat formal power series as if they are indexed by `ℕ`.
+Occasionally this leads to proofs that are uglier than expected.
+-/
+
+noncomputable theory
+open_locale classical big_operators
+
+/-- Multivariate formal power series, where `σ` is the index set of the variables
+and `R` is the coefficient ring.-/
+-- def mv_power_series (σ : Type*) (R : Type*) := (σ →₀ ℕ) → R
+def punctured_power_series (R : Type*) := ℕ × (ℕ → R)
+
+def old_shift_fun {R : Type*} : ℕ → (ℕ → R) → (ℕ → R)
+-- | 0 := λ x, x
+| (n) := λ f, function.comp f (nat.add n)
+
+def preshift : ℕ → ℕ → ℕ
+| 0 := λ x, x
+| k := λ x, if x < k then 0 else x-k
+
+lemma preshift_by_zero : preshift 0 = (λ x, x) := rfl
+
+def shift_fun {R : Type*} : ℕ → (ℕ → R) → (ℕ → R)
+| (n) := λ f, function.comp f (preshift n)
+
+lemma shift_fun_by_zero {R : Type*} (f : ℕ → R) : shift_fun 0 f = f :=
+begin
+  rw shift_fun,
+  funext,
+  simp only [nat.add_def, function.comp_app, preshift_by_zero],
+end
+
+namespace punctured_power_series
+-- open finsupp
+variables {R : Type*}
+
+instance [inhabited R]       : inhabited       (punctured_power_series R) := ⟨(default _, (λ _, default _))⟩
+instance [has_zero R]        : has_zero        (punctured_power_series R) := ⟨(0, 0)⟩
+instance [nontrivial R]      : nontrivial      (punctured_power_series R) := nontrivial_prod_left
+
+section monoid
+
+variable [add_monoid R]
+
+lemma zero_shift_fun (k : ℕ) : shift_fun k (0 : ℕ → R) = 0 := rfl
+
+protected def add : (punctured_power_series R) → (punctured_power_series R) → (punctured_power_series R) :=
+begin
+  rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩,
+  exact ⟨max k₁ k₂, (shift_fun ((max k₁ k₂) - k₁ ) f₁) + (shift_fun ((max k₁ k₂) - k₂ ) f₂)⟩,
+end
+
+lemma add_assoc (F₁ F₂ F₃ : punctured_power_series R) : punctured_power_series.add (punctured_power_series.add  F₁ F₂) F₃ =
+ punctured_power_series.add F₁ (punctured_power_series.add F₂ F₃) :=
+begin sorry,
+                -- rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩ ⟨k₃, f₃⟩,
+                -- ext,
+                -- apply max_assoc,
+-- suffices primo : (((k₁, f₁) + (k₂, f₂)) + (k₃, f₃)).2 x = ((k₁, f₁) + ((k₂, f₂) + (k₃, f₃))).2 x,
+-- exact primo,
+-- suffices this : (shift_fun ((max (max k₁ k₂) k₃) - max k₁ k₂) (((k₁,f₁) + (k₂, f₂)).snd)
+--     + shift_fun ((max (max k₁ k₂) k₃) - k₃) f₃) x = (shift_fun ((max k₁ (max k₂ k₃)) - k₁) f₁ + shift_fun ((max k₁ (max k₂ k₃)) - max k₂ k₃)
+--     (((k₂,f₂) + (k₃, f₃)).snd)) x,
+--                 exact this,
+end
+
+lemma zero_add : ∀ (F: punctured_power_series R), punctured_power_series.add 0 F = F :=
+begin
+  rintro ⟨k, f⟩,
+  ext,
+  apply nat.zero_max,
+  suffices this : (shift_fun ((max 0 k) - 0) 0 + shift_fun ((max 0 k) - k) f) x = f x,
+  exact this,
+  rw [nat.zero_max, nat.sub_zero, nat.sub_self, shift_fun_by_zero, zero_shift_fun, zero_add],
+end
+
+lemma add_zero : ∀ (F: punctured_power_series R), punctured_power_series.add F 0 = F :=
+begin
+  rintro ⟨k, f⟩,
+  ext,
+  convert nat.zero_max,
+  apply max_comm k 0,
+  suffices this : (shift_fun ((max k 0) - k) f + shift_fun ((max k 0) - 0) 0) x = f x,
+  exact this,
+  simp only [max_comm k 0, nat.zero_max, shift_fun_by_zero, zero_shift_fun, add_zero, nat.sub_self],
+end
+
+instance [add_monoid R]      : add_monoid      (punctured_power_series R) :=
+{ add := punctured_power_series.add,
+  add_assoc := punctured_power_series.add_assoc,
+  zero := (0, 0),
+  zero_add := punctured_power_series.zero_add,
+  add_zero := punctured_power_series.add_zero}
+
+lemma add_comm : ∀ (F G: punctured_power_series R), punctured_power_series.add F G = punctured_power_series.add G F := sorry
+
+instance [add_comm_monoid R] : add_comm_monoid (punctured_power_series R) :=
+{ add := punctured_power_series.add,
+  add_assoc := punctured_power_series.add_assoc,
+  zero := (0, 0),
+  zero_add := punctured_power_series.zero_add,
+  add_zero := punctured_power_series.add_zero,
+  add_comm := punctured_power_series.add_comm }
+
+variables F₁ F₂ : punctured_power_series R
+
+
+def eqv_punctured_shift {R : Type*} [semiring R] (F₁ F₂ : punctured_power_series R) : Prop :=
+(F₂.snd = (shift_fun (F₂.fst - F₁.fst) F₁.snd)) ∨ (F₁.snd = (shift_fun (F₁.fst - F₂.fst) F₂.snd))
+
+lemma eqv_punctured_shift_rfl {R : Type*} [semiring R] (F : punctured_power_series R) :
+  eqv_punctured_shift F F :=
+sorry
+
+lemma eqv_punctured_shift_symm {R : Type*} [semiring R] (F₁ F₂ : punctured_power_series R) :
+  eqv_punctured_shift F₁ F₂ →  eqv_punctured_shift F₂ F₁:=
+sorry
+
+lemma eqv_punctured_shift_trans {R : Type*} [semiring R] (F₁ F₂ F₃: punctured_power_series R) :
+  eqv_punctured_shift F₁ F₂ →  eqv_punctured_shift F₂ F₃ → eqv_punctured_shift F₁ F₃ :=
+begin sorry,
+end
+
+
+-- theorem is_equivalence_shift {R : Type*} [semiring R] equivalence (@eqv_punctured_shift :=
+-- begin
+-- end SEE PAG 166 tpil
+
+
+
+-- instance [add_group R]       : add_group       (punctured_power_series R) := pi.add_group
+-- instance [add_comm_group R]  : add_comm_group  (punctured_power_series R) := pi.add_comm_group
+
+
+-- instance {A} [semiring R] [add_comm_monoid A] [semimodule R A] :
+--   semimodule R (punctured_power_series R) := pi.semimodule _ _ _
+
+-- example  {A} [semiring R] [add_comm_monoid A] [semimodule R A] :
+--   semimodule R (ℕ → A) :=
+--   begin
+--     refine pi.semimodule ℕ (λ (_ : ℕ), A) R
+--   end
+
+-- example  {A} [semiring R] [add_comm_monoid A] [semimodule R A] :
+--   semimodule R (ℕ × A) :=
+-- begin
+
+-- end
+
+end monoid
+end punctured_power_series

--- a/src/ring_theory/laurent_series.lean
+++ b/src/ring_theory/laurent_series.lean
@@ -144,8 +144,12 @@ def shift_fun {R : Type*} [has_zero R]: 𝕄 → (ℕ → R) → (ℕ → R)
 | (k) := λ f, λ n, if n < (℘ k) then (0 : R) else f (n - ℘ k)
 
 @[simp] lemma shift_fun_by_zero [has_zero R] (f : ℕ → R) : shift_fun 𝟘 f = f := rfl
+@[simp] lemma shift_neg [has_neg R] [has_zero R] (f : ℕ → R) (𝕜 : 𝕄) :
+  shift_fun 𝕜 (-f) = - (shift_fun 𝕜 f) := sorry
+-- @[simp] lemma eq_shift_fun [has_neg R] [has_zero R] (𝕜₁ 𝕜₂ : 𝕄) (f₁ f₂ : ℕ → R) :
+--   𝕜₁ = 𝕜₂ → shift_fun 𝕜₁ f₁ = shift_fun 𝕜₂ f₂ ↔ f₁ = f₂ := sorry
 
--- section add_comm_monoid
+
 
 /-We only consider the case where R is a commutative additive monoid, for simplicity-/
 variable [add_comm_monoid R]
@@ -310,17 +314,25 @@ begin
   dsimp [lift_neg],
   rw eqv_punctured at h,
   rcases h with ⟨ℓ₁₂, ℓ₂₁, h⟩,
-  replace h : 𝕜₁ + ℓ₁₂ = 𝕜₂ + ℓ₂₁ ∧ shift_fun (μ (𝕜₁, ℓ₁₂)) (-f₁) = shift_fun (μ (𝕜₂, ℓ₂₁)) (-f₂),
-  split,
   rw ext_punctured_power_series at h,
+  have hμ : μ (𝕜₁, ℓ₁₂) = μ (𝕜₂, ℓ₂₁),
+  -- rw cst_shift_fun at h,
+  -- rw μ,
+  sorry,
+  replace h : 𝕜₁ + ℓ₁₂ = 𝕜₂ + ℓ₂₁ ∧ ((𝕜₁, f₁) + (ℓ₁₂, 0)).snd = ((𝕜₂, f₂) + (ℓ₂₁, 0)).snd,
+  split,
   exact h.1,
+  let k := h.2,
+  exact k,
   sorry,
   replace h : eqv_punctured (𝕜₁, -f₁) (𝕜₂, -f₂),
   { use [ℓ₁₂, ℓ₂₁],
-    ext, exact h.1,
+    ext,
+    exact h.1,
     show (shift_fun (μ (𝕜₁, ℓ₁₂)) (- f₁) + shift_fun (μ (ℓ₁₂, 𝕜₁)) 0) x =
     (shift_fun (μ (𝕜₂, ℓ₂₁)) (-f₂) + shift_fun (μ (ℓ₂₁, 𝕜₂)) 0) x,
-    simp only [*, cst_shift_fun]},
+    simp [*, prod.mk_add_mk, add_zero, pi.neg_apply, cst_shift_fun, eq_self_iff_true,
+      neg_inj, shift_neg] at *, },
   apply (add_con.eq (eqv_punctured.add_con S)).mpr h,
 end
 

--- a/src/ring_theory/laurent_series_old.lean
+++ b/src/ring_theory/laurent_series_old.lean
@@ -115,16 +115,16 @@ namespace punctured_power_series
 /-- Multivariate formal power series, where `σ` is the index set of the variables
 and `R` is the coefficient ring.-/
 -- def mv_power_series (σ : Type*) (R : Type*) := (σ →₀ ℕ) →
-def punctured_power_series (R : Type*) := ℕ × (ℕ → R)
+def punctured_power_series (R : Type*) := 𝕄 × (ℕ → R)
 
 -- open finsupp
 variables {R : Type*}
 
 instance [inhabited R]       : inhabited       (punctured_power_series R) := ⟨(default _, (λ _, default _))⟩
-instance [has_zero R]        : has_zero        (punctured_power_series R) := ⟨(0, 0)⟩
+instance [has_zero R]        : has_zero        (punctured_power_series R) := ⟨(𝟘, 0)⟩
 instance [nontrivial R]      : nontrivial      (punctured_power_series R) := nontrivial_prod_left
 
-@[ext, simp] lemma ext_punctured_power_series (F₁ F₂ : punctured_power_series R) :
+@[simp] lemma ext_punctured_power_series (F₁ F₂ : punctured_power_series R) :
   F₁ = F₂ ↔ F₁.1 = F₂.1 ∧ F₁.2 = F₂.2 :=
 begin
   split,
@@ -140,55 +140,12 @@ begin
     simp only * at * },
 end
 
-def shift_fun {R : Type*} [has_zero R]: ℕ → (ℕ → R) → (ℕ → R)
-| (k) := λ f, λ n, if (n : ℤ) < k then (0 : R) else f (n - k)
+def shift_fun {R : Type*} [has_zero R]: 𝕄 → (ℕ → R) → (ℕ → R)
+| (k) := λ f, λ n, if n < (℘ k) then (0 : R) else f (n - ℘ k)
 
-@[simp] lemma shift_fun_by_zero [has_zero R] (f : ℕ → R) : shift_fun 0 f = f := rfl
-@[simp] lemma shift_neg [has_neg R] [has_zero R] (f : ℕ → R) (k : ℕ) :
-  shift_fun k (-f) = - (shift_fun k f) := sorry
-@[simp] lemma shift_fun_eq_iff [has_zero R] (f₁ f₂ : ℕ → R) (k : ℕ) :
-shift_fun k f₁ = shift_fun k f₂ ↔ f₁ = f₂ :=
-begin
-sorry,
-end
-
-example (x y z : ℤ) : x - (y + z) = x - y - z := sub_add_eq_sub_sub x y z
-
-@[simp] lemma shift_fun_assoc [has_zero R] (f : ℕ → R) (k₁ k₂ : ℕ):
-  shift_fun k₁ (shift_fun k₂ f) = shift_fun (k₁ + k₂) f :=
-  begin
-    ext,
-    dsimp [shift_fun],
-    show ite (↑x < ↑k₁) 0 (ite (↑(x - k₁) < ↑k₂) 0 (f (x - k₁ - k₂))) =
-      ite (↑x < ↑k₁ + ↑k₂) 0 (f (x - (k₁ + k₂))),
-    by_cases hx₁ : ↑x < ↑k₁,
-    { have this : (x : ℤ) < ↑k₁ + ↑k₂,
-      apply lt_add_of_lt_of_nonneg hx₁ (int.coe_nat_nonneg k₂),
-      rw [if_pos hx₁, if_pos this], },
-    {by_cases hx₂ : (x : ℤ) < k₂,
-      { have hx₁₂ : ↑x < ↑k₁ + ↑k₂,
-        apply lt_add_of_nonneg_of_lt (int.of_nat_nonneg k₁) hx₂,
-        have hx₁₂' : (x - k₁ : ℤ) < ↑k₂,
-        apply int.sub_left_lt_of_lt_add hx₁₂,
-        rw [if_neg hx₁, if_pos hx₁₂, int.coe_nat_sub, if_pos hx₁₂'],
-        rw [int.coe_nat_lt, not_lt] at hx₁,
-        exact hx₁ },
-      { by_cases hx₁₂ : (x : ℤ) < k₁ + k₂,
-        { have hx₁₂' : (x - k₁ : ℤ) < ↑k₂,
-          apply int.sub_left_lt_of_lt_add hx₁₂,--uguale a riga 171
-          rw [if_neg hx₁, if_pos hx₁₂, int.coe_nat_sub, if_pos hx₁₂'],
-          rw [int.coe_nat_lt, not_lt] at hx₁, --uguale a riga 173
-          exact hx₁ },--uguale a riga 174
-          have hx₁₂' : ¬ (x - k₁ : ℤ) < ↑k₂,
-          simp only [not_lt, int.coe_nat_lt] at *,
-          rw [← int.coe_nat_add, int.coe_nat_le, add_comm, nat.add_le_to_le_sub] at hx₁₂,
-          rw [← int.coe_nat_sub, int.coe_nat_le],
-          exact hx₁₂,
-          repeat {exact hx₁},
-          rw [if_neg hx₁, if_neg hx₁₂, int.coe_nat_sub, if_neg hx₁₂', nat.sub_sub],
-          rw [int.coe_nat_lt, not_lt] at hx₁, --uguale a riga 173
-          exact hx₁} },--uguale a riga 174
-end
+@[simp] lemma shift_fun_by_zero [has_zero R] (f : ℕ → R) : shift_fun 𝟘 f = f := rfl
+@[simp] lemma shift_neg [has_neg R] [has_zero R] (f : ℕ → R) (𝕜 : 𝕄) :
+  shift_fun 𝕜 (-f) = - (shift_fun 𝕜 f) := sorry
 -- @[simp] lemma eq_shift_fun [has_neg R] [has_zero R] (𝕜₁ 𝕜₂ : 𝕄) (f₁ f₂ : ℕ → R) :
 --   𝕜₁ = 𝕜₂ → shift_fun 𝕜₁ f₁ = shift_fun 𝕜₂ f₂ ↔ f₁ = f₂ := sorry
 
@@ -199,76 +156,81 @@ variable [add_comm_monoid R]
 
 -- lemma cst_shift_fun' (𝕜 : 𝕄) : shift_fun 𝕜 (function.const : ℕ → R) = (0 : ℕ → R) := sorry,
 
-@[simp] lemma shift_fun_of_zero (k : ℕ) : shift_fun k (0 : ℕ → R) = (0 : ℕ → R) :=
+@[simp] lemma cst_shift_fun (𝕜 : 𝕄) : shift_fun 𝕜 (0 : ℕ → R) = (0 : ℕ → R) :=
 begin
-      funext,
-      dsimp [shift_fun],
-      by_cases h: (n : ℤ) < k,
-      rw if_pos h,
-      tauto,
-      rw if_neg h,
-      tauto,
-end
+      -- funext,
+      -- dsimp [shift_fun],
+      sorry,
+      -- apply if_congr,
+      -- split,
+      -- -- apply dif_eq_if,
+      -- apply dif_neg,
+      -- simp * at *,
+      -- rw function.const_apply _ 0 n,
+      -- apply rfl,
 
-@[simp] lemma shift_fun_add (k : ℕ) (f₁ f₂ : ℕ → R) : shift_fun k (f₁ + f₂) =
-  shift_fun k f₁ + shift_fun k f₂ :=
-begin
-  funext,
-  rw pi.add_apply,
-  dsimp [shift_fun],
-  by_cases h: (n : ℤ) < k,
-  { repeat {rw if_pos h},
-    ring },
-  { repeat {rw if_neg h},
-    rw pi.add_apply },
 end
 
 def add : (punctured_power_series R) → (punctured_power_series R) → (punctured_power_series R) :=
 begin
-  rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩,
-  exact ⟨k₁ + k₂, shift_fun k₂ f₁ + shift_fun k₁ f₂⟩,
+  rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂, f₂⟩,
+  exact ⟨𝕜₁ + 𝕜₂, shift_fun (μ (𝕜₁, 𝕜₂)) f₁ + shift_fun (μ (𝕜₂, 𝕜₁)) f₂⟩,
 end
 
 lemma add_assoc : ∀ (F₁ F₂ F₃ : punctured_power_series R), punctured_power_series.add (punctured_power_series.add  F₁ F₂) F₃ =
  punctured_power_series.add F₁ (punctured_power_series.add F₂ F₃) :=
-begin
-  rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩ ⟨k₃, f₃⟩,
+begin -- sorry,
+  rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂, f₂⟩ ⟨𝕜₃, f₃⟩,
   ext,
-  apply nat.add_assoc,
+  apply max_assoc,
   dsimp [punctured_power_series.add],
-  show (shift_fun k₃ (shift_fun k₂ f₁ + shift_fun k₁ f₂) + shift_fun (k₁ + k₂) f₃) x
-    = (shift_fun (k₂ + k₃) f₁ + shift_fun k₁ (shift_fun k₃ f₂ + shift_fun k₂ f₃)) x,
-  simp only [pi.add_apply, shift_fun_assoc, shift_fun_add] at *,
-  rw [← add_assoc, add_comm k₃ k₂, add_comm k₃ k₁],
+  show (shift_fun (μ (𝕜₁ + 𝕜₂, 𝕜₃)) (shift_fun (μ (𝕜₁, 𝕜₂)) f₁ + shift_fun (μ (𝕜₂, 𝕜₁)) f₂) +
+       shift_fun (μ (𝕜₃, 𝕜₁ + 𝕜₂)) f₃) x = (shift_fun (μ (𝕜₁, 𝕜₂ + 𝕜₃)) f₁ +
+        shift_fun (μ (𝕜₂ + 𝕜₃, 𝕜₁)) (shift_fun (μ (𝕜₂, 𝕜₃)) f₂ + shift_fun (μ (𝕜₃, 𝕜₂)) f₃)) x,
+  simp only [pi.add_apply] at *,
+  sorry,
+  -- apply add_assoc,
+  --     x,
+  -- show (shift_fun μ (μ (𝕜₁, 𝕜₂), 𝕜₃) (punctured_power_series.add  F₁ F₂).snd + shift_fun μ (𝕜₃, μ (𝕜₁, 𝕜₂)) f₃).snd x =
+  --   (shift_fun μ (𝕜₁, μ (𝕜₂, 𝕜₃)) f₁ + shift_fun μ (μ (𝕜₂, 𝕜₃), 𝕜₁) (punctured_power_series.add F₂ F₃).snd).snd x,
+-- suffices primo : (((k₁, f₁) + (k₂, f₂)) + (k₃, f₃)).2 x = ((k₁, f₁) + ((k₂, f₂) + (k₃, f₃))).2 x,
+-- exact primo,
+-- suffices this : (shift_fun ((max (max k₁ k₂) k₃) - max k₁ k₂) (((k₁,f₁) + (k₂, f₂)).snd)
+--     + shift_fun ((max (max k₁ k₂) k₃) - k₃) f₃) x = (shift_fun ((max k₁ (max k₂ k₃)) - k₁) f₁ + shift_fun ((max k₁ (max k₂ k₃)) - max k₂ k₃)
+--     (((k₂,f₂) + (k₃, f₃)).snd)) x,
+--                 exact this,
 end
 
 lemma zero_add : ∀ (F: punctured_power_series R), punctured_power_series.add 0 F = F :=
 begin
-  rintro ⟨k, f⟩,
+  rintro ⟨𝕜, f⟩,
   ext,
-  apply nat.zero_add,
-  show (shift_fun k 0 + shift_fun 0 f) x = f x,
-  simp only [shift_fun_of_zero, zero_add, shift_fun_by_zero],
+  apply nat.zero_max,
+  show (shift_fun (μ (𝟘, 𝕜)) 0 + shift_fun (μ (𝕜, 𝟘)) f) x = f x,
+  rw [maxumal.zero_sub_left, maxumal.sub_left_zero, pi.add_apply, shift_fun_by_zero,
+    cst_shift_fun, pi.zero_apply, zero_add],
 end
 
 lemma add_zero : ∀ (F: punctured_power_series R), punctured_power_series.add F 0 = F :=
 begin
-  rintro ⟨k, f⟩,
+  rintro ⟨𝕜, f⟩,
   ext,
-  apply nat.add_zero,
-  show (shift_fun 0 f + shift_fun k 0) x = f x,
-  simp only [shift_fun_of_zero, add_zero, shift_fun_by_zero],
+  apply maxumal.nat.max_zero,
+  show (shift_fun (μ (𝕜, 𝟘)) f + shift_fun (μ (𝟘, 𝕜)) 0) x = f x,
+  rw [maxumal.zero_sub_left, maxumal.sub_left_zero, pi.add_apply, shift_fun_by_zero,
+    cst_shift_fun, pi.zero_apply, add_zero],
 end
 
 lemma add_comm : ∀ (F G: punctured_power_series R), punctured_power_series.add F G =
   punctured_power_series.add G F :=
 begin
-  rintro ⟨k₁, f₁⟩ ⟨k₂, f₂⟩,
+  rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂, f₂⟩,
   ext,
-  apply nat.add_comm,
-  show (shift_fun k₂ f₁ + shift_fun k₁ f₂) x =
-    (shift_fun k₁ f₂ + shift_fun k₂ f₁) x,
-  simp only [pi.add_apply, add_comm],
+  apply max_comm,
+  show (shift_fun (μ (𝕜₁, 𝕜₂)) f₁ + shift_fun (μ (𝕜₂, 𝕜₁)) f₂) x =
+    (shift_fun (μ (𝕜₂, 𝕜₁)) f₂ + shift_fun (μ (𝕜₁, 𝕜₂)) f₁) x,
+  simp only [pi.add_apply] at *,
+  apply add_comm,
 end
 
 instance : add_comm_monoid (punctured_power_series R) :=
@@ -279,74 +241,28 @@ instance : add_comm_monoid (punctured_power_series R) :=
   add_zero := punctured_power_series.add_zero,
   add_comm := punctured_power_series.add_comm }
 
-@[simp] lemma add_fst {F₁ F₂ : punctured_power_series R} :
- (F₁ + F₂).fst = F₁.fst + F₂.fst :=
-begin
-  sorry,
-end
-
-@[simp] lemma add_snd {F₁ F₂ : punctured_power_series R} :
- (F₁ + F₂).snd = shift_fun F₂.fst F₁.snd + shift_fun F₁.fst F₂.snd :=
-begin
-  sorry,
-end
-
 #print punctured_power_series.add
-def a : ℕ → ℤ := λ n, 4*n+3
-def b : ℕ → ℤ := λ n, 1-2*n
+-- def a : ℕ → ℤ := λ n, 4*n+3
+-- def b : ℕ → ℤ := λ n, 1-2*n
 -- def 𝕜₁ : 𝕄 := ℘⁻¹ 1
 -- def 𝕜₂ : 𝕄 := ℘⁻¹ 3
 
-def F₁ : punctured_power_series ℤ := (1, a)
-def F₂ : punctured_power_series ℤ := (3, b)
-#eval a 5
-#eval (F₁ + F₂).snd 9
+-- def F₁ : punctured_power_series ℤ := (𝕜₁, a)
+-- def F₂ : punctured_power_series ℤ := (𝕜₂, b)
+
+-- #eval (F₁ + F₂).snd 8
 /-The right answers are
-0 → 0, 1 → 1, 2 → -1, 3 → 0, 4 → 2, 5 → 4, 6 → 6, 7 → 8, 8 → 10, 9 → 12
+0 → 1, 1 → -1, 2 → 0, 3 → 2, 4 → 4, 5 → 6, 6 → 8, 7 → 10, 8 → 12
 
 def F₃ := (𝟘, b) --check!
 --/
 
-def eqv_punctured_old (F₁ F₂ : punctured_power_series R) : Prop :=
+def eqv_punctured (F₁ F₂ : punctured_power_series R) : Prop :=
 ∃ ℓ₁₂ ℓ₂₁ : 𝕄, F₁ + (ℓ₁₂, 0) = F₂ + (ℓ₂₁, 0)
 
-def eqv_punctured (F₁ F₂ : punctured_power_series R) : Prop :=
-∃ ℓ₁₂ ℓ₂₁ : ℕ, F₁ + (ℓ₁₂, 0) = F₂ + (ℓ₂₁, 0)
-
-lemma eqv_punctured_rfl: reflexive (@eqv_punctured R _) :=
-begin
-  intros F,
-  use [0, 0],
-end
-
-lemma eqv_punctured_symm : symmetric (@eqv_punctured R _) :=
-begin
-  rintros F₁ F₂ ⟨ℓ₁₂, ℓ₂₁, h⟩,
-  use [ℓ₂₁, ℓ₁₂],
-  exact h.symm,
-end
-
-lemma eqv_punctured_trans : transitive (@eqv_punctured R _) :=
-begin
-  rintros F₁ F₂ F₃ ⟨ℓ₁₂, ℓ₂₁, h₁₂⟩ ⟨ℓ₂₃, ℓ₃₂, h₂₃⟩,
-  use [ℓ₁₂ + ℓ₂₃, ℓ₂₁ + ℓ₃₂],
-  simp only [*, add_zero, add_snd, ext_punctured_power_series,
-   shift_fun_of_zero, add_fst] at *,
-  split,
-  { rw [← nat.add_assoc, h₁₂.1, nat.add_assoc, nat.add_comm ℓ₂₁ ℓ₂₃,
-    ← nat.add_assoc, h₂₃.1],
-    ring },
-  { ring,
-    replace h₁₂ : shift_fun ℓ₁₂ F₁.snd = shift_fun ℓ₂₁ F₂.snd,
-    { convert h₁₂.right; ring },
-    replace h₂₃ : shift_fun ℓ₂₃ F₂.snd = shift_fun ℓ₃₂ F₃.snd,
-    { convert h₂₃.right; ring },
-    repeat {rw ← shift_fun_assoc},
-    rw [← h₂₃, shift_fun_assoc F₂.snd ℓ₂₁ ℓ₂₃, nat.add_comm ℓ₂₁ ℓ₂₃,
-      ← shift_fun_assoc F₂.snd ℓ₂₃ ℓ₂₁, ← h₁₂],
-    repeat {rw shift_fun_assoc},
-    rw nat.add_comm ℓ₁₂ ℓ₂₃ },
-end
+lemma eqv_punctured_rfl: reflexive (@eqv_punctured R _) := sorry
+lemma eqv_punctured_symm : symmetric (@eqv_punctured R _) := sorry
+lemma eqv_punctured_trans : transitive (@eqv_punctured R _) := sorry
 
 theorem eqv_punctured.is_equivalence :  equivalence (@eqv_punctured R _) :=
  ⟨eqv_punctured_rfl, eqv_punctured_symm, eqv_punctured_trans⟩
@@ -355,30 +271,11 @@ def eqv_punctured.add_con (R : Type*) [add_comm_monoid R] : add_con (punctured_p
 begin
   use @eqv_punctured R _,
   exact eqv_punctured.is_equivalence,
-  rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩ ⟨k₃, f₃⟩ ⟨k₄, f₄⟩ ⟨ℓ₁₂, ℓ₂₁, h₁₂⟩ ⟨ℓ₃₄, ℓ₄₃, h₃₄⟩,
-  rw eqv_punctured,
-  use [ℓ₁₂ + ℓ₃₄, ℓ₂₁ + ℓ₄₃],
-  simp only [*, add_zero, add_snd, ext_punctured_power_series,
-    shift_fun_assoc, shift_fun_of_zero, shift_fun_add, add_fst] at *,
-  split,
-  { rwa [nat.add_assoc, nat.add_comm ℓ₁₂ ℓ₃₄, ← nat.add_assoc k₃ ℓ₃₄ ℓ₁₂, h₃₄.1,
-      nat.add_comm, nat.add_assoc, ← nat.add_comm k₁ ℓ₁₂, h₁₂.left],
-    ring, },
-  { have h₁₂': shift_fun ℓ₁₂ f₁ = shift_fun ℓ₂₁ f₂,
-    { convert h₁₂.right; ring },
-    have h₃₄': shift_fun ℓ₃₄ f₃ = shift_fun ℓ₄₃ f₄,
-    { convert h₃₄.right; ring },
-    ring,
-    repeat {rw nat.add_assoc},
-    rw [nat.add_comm, ← shift_fun_assoc, h₁₂', nat.add_comm ℓ₃₄ k₁,
-     ← nat.add_assoc ℓ₁₂ k₁ ℓ₃₄, ← shift_fun_assoc f₃, h₃₄'],
-    repeat {rw shift_fun_assoc},
-    rw [nat.add_comm ℓ₄₃ k₄, ← h₃₄.left, nat.add_comm ℓ₁₂ k₁, h₁₂.left],
-    ring },
+  sorry,
 end
 
 def laurent_series (R : Type*) [add_comm_monoid R]:= (eqv_punctured.add_con R).quotient
-instance inhabited : inhabited (laurent_series R) :=
+instance inhabited : inhabited (laurent_series R) :=-- ⟨((eqv_punctured.add_con R).mk' 0)⟩
   begin
     use (eqv_punctured.add_con R).mk' 0,
   end
@@ -409,83 +306,40 @@ open classical
 #check (eqv_punctured.add_con S).mk'
 
 def lift_neg : (punctured_power_series S) → (laurent_series S) :=
-  λ ⟨k, f⟩, (eqv_punctured.add_con S).mk' ⟨k, -f⟩
-
+  λ ⟨𝕜, f⟩, (eqv_punctured.add_con S).mk' ⟨𝕜, -f⟩
 lemma cong_neg : ∀ (F₁ F₂ : punctured_power_series S),  eqv_punctured F₁ F₂ →
   lift_neg F₁ = lift_neg F₂ :=
 begin
-  rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩ ⟨ℓ₁₂, ℓ₂₁, h⟩,
+  rintros ⟨𝕜₁, f₁⟩ ⟨𝕜₂, f₂⟩ h,
   dsimp [lift_neg],
-  -- rw eqv_punctured at h,
-  -- rcases h with ⟨ℓ₁₂, ℓ₂₁, h⟩,
+  rw eqv_punctured at h,
+  rcases h with ⟨ℓ₁₂, ℓ₂₁, h⟩,
   rw ext_punctured_power_series at h,
-  -- have hμ : μ (k₁, ℓ₁₂) = μ (k₂, ℓ₂₁),
+  have hμ : μ (𝕜₁, ℓ₁₂) = μ (𝕜₂, ℓ₂₁),
   -- rw cst_shift_fun at h,
   -- rw μ,
-  -- sorry,
-  -- replace h : k₁ + ℓ₁₂ = k₂ + ℓ₂₁ ∧ ((k₁, f₁) + (ℓ₁₂, 0)).snd =
-  --   ((k₂, f₂) + (ℓ₂₁, 0)).snd,
-  -- split,
-  -- exact h.1,
-  -- let k := h.2,
-  -- exact h.2,
-  -- sorry,
-  replace h : eqv_punctured (k₁, -f₁) (k₂, -f₂),
+  sorry,
+  replace h : 𝕜₁ + ℓ₁₂ = 𝕜₂ + ℓ₂₁ ∧ ((𝕜₁, f₁) + (ℓ₁₂, 0)).snd = ((𝕜₂, f₂) + (ℓ₂₁, 0)).snd,
+  split,
+  exact h.1,
+  let k := h.2,
+  exact k,
+  sorry,
+  replace h : eqv_punctured (𝕜₁, -f₁) (𝕜₂, -f₂),
   { use [ℓ₁₂, ℓ₂₁],
     ext,
     exact h.1,
-    -- replace h : ((k₁, f₁) + (ℓ₁₂, 0)).snd = ((k₂, f₂) + (ℓ₂₁, 0)).snd := and.elim_right h,
-    show (shift_fun ℓ₁₂ (- f₁) + shift_fun k₁ 0) x =
-    (shift_fun ℓ₂₁ (-f₂) + shift_fun k₂ 0) x,
-    simp only [*, add_zero, pi.neg_apply, shift_fun_of_zero, neg_inj,
-      shift_neg] at *,
-    repeat {rw pi.add_apply},
-    simp [pi.zero_apply, add_zero, *] at *,
-    have this : ((k₁, f₁) + (ℓ₁₂, 0)).snd = ((k₂, f₂) + (ℓ₂₁, 0)).snd,
-    apply and.right h,
-    have that : shift_fun ℓ₁₂ f₁ = shift_fun ℓ₂₁ f₂,
-    -- dsimp [punctured_power_series.add],
-    sorry,
-    sorry,
-    sorry,
-    -- apply congr_fun that x,
-    },
+    show (shift_fun (μ (𝕜₁, ℓ₁₂)) (- f₁) + shift_fun (μ (ℓ₁₂, 𝕜₁)) 0) x =
+    (shift_fun (μ (𝕜₂, ℓ₂₁)) (-f₂) + shift_fun (μ (ℓ₂₁, 𝕜₂)) 0) x,
+    simp [*, prod.mk_add_mk, add_zero, pi.neg_apply, cst_shift_fun, eq_self_iff_true,
+      neg_inj, shift_neg] at *, },
   apply (add_con.eq (eqv_punctured.add_con S)).mpr h,
 end
 
 def lift_sub : (punctured_power_series S) → (punctured_power_series S) → (laurent_series S) :=
-  λ ⟨k₁, f₁⟩ ⟨k₂, f₂⟩, (eqv_punctured.add_con S).mk' ⟨k₁ + k₂, f₁ - f₂⟩
-
+  λ ⟨𝕜₁, f₁⟩, λ ⟨𝕜₂, f₂⟩, (eqv_punctured.add_con S).mk' ⟨μ (𝕜₁, 𝕜₂), f₁-f₂⟩
 lemma cong_sub : ∀ (F₁ F₂ G₁ G₂: punctured_power_series S),  eqv_punctured F₁ G₁ →
-  eqv_punctured.add_con S F₂ G₂ → lift_sub F₁ F₂ = lift_sub G₁ G₂ :=
-begin
-  rintros ⟨k₁, f₁⟩ ⟨k₂, f₂⟩ ⟨m₁, g₁⟩ ⟨m₂, g₂⟩ ⟨μ₁₂, μ₂₁, h₁⟩ ⟨θ₁₂, θ₂₁, h₂⟩,
-  dsimp [lift_sub],
-  rw ext_punctured_power_series at h₁,
-  rw ext_punctured_power_series at h₂,
-  have h : eqv_punctured (k₁ + k₂, f₁ - f₂) (m₁ + m₂, g₁ - g₂),
-  { rw eqv_punctured,
-    use [μ₁₂ + θ₁₂, μ₂₁ + θ₂₁],
-    ext,
-    have this₁ : ((k₁, f₁) + (μ₁₂, 0)).fst = ((m₁, g₁) + (μ₂₁, 0)).fst,
-    exact h₁.1,
-    repeat {rw prod.fst_add at this₁},
-    -- rw prod.fst_add at this₁,
-    -- rw prod.fst_add (k₁, f₁) (μ₁₂, 0) at this₁,
-    have this₂ : ((k₂, f₂) + (θ₁₂, 0)).fst = ((m₂, g₂) + (θ₂₁, 0)).fst,
-    exact h₂.1,
-    repeat {rw prod.fst_add at this₂},
-    -- apply prod.fst_add,
-    -- show (k₁ + k₂, f₁ - f₂).fst + (μ₁₂ + θ₁₂).fst =
-    --   (m₁ + m₂, g₁ - g₂).fst + (μ₂₁ + θ₂₁, 0).fst,
-    -- rw prod.fst_add,
-    rw prod.fst_add ((k₁ + k₂, f₁ - f₂) : ℕ × (ℕ → S)) (μ₁₂ + θ₁₂, 0),
-  }
-  -- have
-  sorry,
-  -- rw lift_sub,
-  apply (add_con.eq (eqv_punctured.add_con S)).mpr h,
-end
+  eqv_punctured.add_con S F₂ G₂ → lift_sub F₁ F₂ = lift_sub G₁ G₂ := sorry
 
 instance : comm_ring (laurent_series S) :=
 { add := λ F₁ F₂, F₁ + F₂,


### PR DESCRIPTION
Defines Laurent series
Provides basic algebraic structure on Laurent series, up to `comm_ring`, with still some `sorry`'s left.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
