### PR TITLE
chore(data/subtype): add heq_of_coe_eq ext lemma

### DIFF
--- a/src/data/subtype.lean
+++ b/src/data/subtype.lean
@@ -47,6 +47,11 @@ lemma heq_iff_coe_eq (h : ∀ x, p x ↔ q x) {a1 : {x // p x}} {a2 : {x // q x}
   a1 == a2 ↔ (a1 : α) = (a2 : α) :=
 eq.rec (λ a2', heq_iff_eq.trans ext_iff) (funext $ λ x, propext (h x)) a2
 
+@[ext]
+lemma heq_of_coe_eq (h : ∀ x, p x ↔ q x) {a1 : {x // p x}} {a2 : {x // q x}} :
+  (a1 : α) = (a2 : α) → a1 == a2 :=
+(heq_iff_coe_eq h).mpr
+
 lemma ext_val {a1 a2 : {x // p x}} : a1.1 = a2.1 → a1 = a2 :=
 subtype.ext
 


### PR DESCRIPTION
This means that `ext` breaks equality of sigma types into the following goals:
```lean
example {ι : Sort*} {α : Type*} {p : ι → α → Prop} {a b : Σ i, subtype (p i)} : a = b :=
begin
  ext,
  sorry, -- a.fst = b.fst
  sorry, -- p a.fst x ↔ p b.fst x
  sorry, -- ↑(a.snd) = ↑(b.snd)
end
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This overlaps with #6257, although we probably want both lemmas.