### PR TITLE
[Merged by Bors] - doc(algebraic_geometry/structure_sheaf): fix latex

### DIFF
--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -89,12 +89,12 @@ consisting of those functions which can locally be expressed as a ratio of
 
 Quoting Hartshorne:
 
-For an open set $$U ⊆ Spec A$$, we define $$𝒪(U)$$ to be the set of functions
-$$s : U → ⨆_{𝔭 ∈ U} A_𝔭$$, such that $s(𝔭) ∈ A_𝔭$$ for each $$𝔭$$,
-and such that $$s$$ is locally a quotient of elements of $$A$$:
-to be precise, we require that for each $$𝔭 ∈ U$$, there is a neighborhood $$V$$ of $$𝔭$$,
-contained in $$U$$, and elements $$a, f ∈ A$$, such that for each $$𝔮 ∈ V, f ∉ 𝔮$$,
-and $$s(𝔮) = a/f$$ in $$A_𝔮$$.
+For an open set $U ⊆ Spec A$, we define $𝒪(U)$ to be the set of functions
+$s : U → ⨆_{𝔭 ∈ U} A_𝔭$, such that $s(𝔭) ∈ A_𝔭$ for each $𝔭$,
+and such that $s$ is locally a quotient of elements of $A$:
+to be precise, we require that for each $𝔭 ∈ U$, there is a neighborhood $V$ of $𝔭$,
+contained in $U$, and elements $a, f ∈ A$, such that for each $𝔮 ∈ V, f ∉ 𝔮$,
+and $s(𝔮) = a/f$ in $A_𝔮$.
 
 Now Hartshorne had the disadvantage of not knowing about dependent functions,
 so we replace his circumlocution about functions into a disjoint union with


### PR DESCRIPTION
This is broken regardless of the markdown processor: <https://leanprover-community.github.io/mathlib_docs/algebraic_geometry/structure_sheaf.html#algebraic_geometry.structure_sheaf.is_locally_fraction>



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
