### PR TITLE
[Merged by Bors] - doc(*): remove `\\` hack for latex backslashes in markdown

### DIFF
--- a/src/algebra/lie/classical.lean
+++ b/src/algebra/lie/classical.lean
@@ -44,7 +44,7 @@ For the algebras of type `B` and `D`, there are two natural definitions. For exa
 the `2l × 2l` matrix:
 $$
   J = \left[\begin{array}{cc}
-              0_l & 1_l\\\\
+              0_l & 1_l\\
               1_l & 0_l
             \end{array}\right]
 $$
@@ -221,7 +221,7 @@ by erw [lie_equiv.trans_apply, lie_equiv.of_eq_apply,
 
 It looks like this as a `2l x 2l` matrix of `l x l` blocks:
 
-   [ 0 1 ]  
+   [ 0 1 ]
    [ 1 0 ]
 -/
 def JD : matrix (l ⊕ l) (l ⊕ l) R := matrix.from_blocks 0 1 1 0
@@ -235,7 +235,7 @@ diagonal matrix.
 
 It looks like this as a `2l x 2l` matrix of `l x l` blocks:
 
-   [ 1 -1 ]  
+   [ 1 -1 ]
    [ 1  1 ]
 -/
 def PD : matrix (l ⊕ l) (l ⊕ l) R := matrix.from_blocks 1 (-1) 1 1
@@ -289,14 +289,14 @@ end
 
 It looks like this as a `(2l+1) x (2l+1)` matrix of blocks:
 
-   [ 2 0 0 ]  
-   [ 0 0 1 ]  
+   [ 2 0 0 ]
+   [ 0 0 1 ]
    [ 0 1 0 ]
 
 where sizes of the blocks are:
 
-   [`1 x 1` `1 x l` `1 x l`]  
-   [`l x 1` `l x l` `l x l`]  
+   [`1 x 1` `1 x l` `1 x l`]
+   [`l x 1` `l x l` `l x l`]
    [`l x 1` `l x l` `l x l`]
 -/
 def JB := matrix.from_blocks ((2 : R) • 1 : matrix unit unit R) 0 0 (JD l R)
@@ -310,14 +310,14 @@ almost-split-signature diagonal matrix.
 
 It looks like this as a `(2l+1) x (2l+1)` matrix of blocks:
 
-   [ 1 0  0 ]  
-   [ 0 1 -1 ]  
+   [ 1 0  0 ]
+   [ 0 1 -1 ]
    [ 0 1  1 ]
 
 where sizes of the blocks are:
 
-   [`1 x 1` `1 x l` `1 x l`]  
-   [`l x 1` `l x l` `l x l`]  
+   [`1 x 1` `1 x l` `1 x l`]
+   [`l x 1` `l x l` `l x l`]
    [`l x 1` `l x l` `l x l`]
 -/
 def PB := matrix.from_blocks (1 : matrix unit unit R) 0 0 (PD l R)

--- a/src/analysis/analytic/basic.lean
+++ b/src/analysis/analytic/basic.lean
@@ -624,11 +624,11 @@ end
 If a function is analytic in a disk `D(x, R)`, then it is analytic in any disk contained in that
 one. Indeed, one can write
 $$
-f (x + y + z) = \\sum_{n} p_n (y + z)^n = \\sum_{n, k} \binom{n}{k} p_n y^{n-k} z^k
-= \\sum_{k} \Bigl(\\sum_{n} \binom{n}{k} p_n y^{n-k}\Bigr) z^k.
+f (x + y + z) = \sum_{n} p_n (y + z)^n = \sum_{n, k} \binom{n}{k} p_n y^{n-k} z^k
+= \sum_{k} \Bigl(\sum_{n} \binom{n}{k} p_n y^{n-k}\Bigr) z^k.
 $$
 The corresponding power series has thus a `k`-th coefficient equal to
-$\\sum_{n} \binom{n}{k} p_n y^{n-k}$. In the general case where `pₙ` is a multilinear map, this has
+$\sum_{n} \binom{n}{k} p_n y^{n-k}$. In the general case where `pₙ` is a multilinear map, this has
 to be interpreted suitably: instead of having a binomial coefficient, one should sum over all
 possible subsets `s` of `fin n` of cardinal `k`, and attribute `z` to the indices in `s` and
 `y` to the indices outside of `s`.

--- a/src/analysis/analytic/inverse.lean
+++ b/src/analysis/analytic/inverse.lean
@@ -304,9 +304,9 @@ $$
 \begin{align}
 Q(z) & := \sum Q_n z^n = Q_1 z + C' \sum_{2 \leq k \leq n} \sum_{i_1 + \dotsc + i_k = n}
   (r z^{i_1} Q_{i_1}) \dotsm (r z^{i_k} Q_{i_k})
-\\\\ & = Q_1 z + C' \sum_{k = 2}^\infty (\sum_{i_1 \geq 1} r z^{i_1} Q_{i_1})
+\\ & = Q_1 z + C' \sum_{k = 2}^\infty (\sum_{i_1 \geq 1} r z^{i_1} Q_{i_1})
   \dotsm (\sum_{i_k \geq 1} r z^{i_k} Q_{i_k})
-\\\\ & = Q_1 z + C' \sum_{k = 2}^\infty (r Q(z))^k
+\\ & = Q_1 z + C' \sum_{k = 2}^\infty (r Q(z))^k
 = Q_1 z + C' (r Q(z))^2 / (1 - r Q(z)).
 \end{align}
 $$

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -2130,7 +2130,7 @@ begin
 end
 
 /-- Given modules `M`, `M₂` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ M₂`, the
-set of maps $\\{f ∈ Hom(M, M₂) | f(p) ⊆ q \\}$ is a submodule of `Hom(M, M₂)`. -/
+set of maps $\{f ∈ Hom(M, M₂) | f(p) ⊆ q \}$ is a submodule of `Hom(M, M₂)`. -/
 def compatible_maps : submodule R (M →ₗ[R] M₂) :=
 { carrier   := {f | p ≤ comap f q},
   zero_mem' := by { change p ≤ comap 0 q, rw comap_zero, refine le_top, },
@@ -2139,7 +2139,7 @@ def compatible_maps : submodule R (M →ₗ[R] M₂) :=
   smul_mem' := λ c f h, le_trans h (comap_le_comap_smul q f c), }
 
 /-- Given modules `M`, `M₂` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ M₂`, the
-natural map $\\{f ∈ Hom(M, M₂) | f(p) ⊆ q \\} \to Hom(M/p, M₂/q)$ is linear. -/
+natural map $\{f ∈ Hom(M, M₂) | f(p) ⊆ q \} \to Hom(M/p, M₂/q)$ is linear. -/
 def mapq_linear : compatible_maps p q →ₗ[R] p.quotient →ₗ[R] q.quotient :=
 { to_fun    := λ f, mapq _ _ f.val f.property,
   map_add'  := λ x y, by { ext m', apply quotient.induction_on' m', intros m, refl, },


### PR DESCRIPTION
With leanprover-community/doc-gen#110, these should no longer be needed.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

See <https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/https.3A.2F.2Fleanprover-community.2Egithub.2Eio.2Fmathlib_docs.2F/near/226406175>
