### PR TITLE
[Merged by Bors] - feat(data/set/finite): complement of finite set is infinite

### DIFF
--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -240,7 +240,7 @@ lemma infinite_of_finite_compl {α : Type} [_root_.infinite α] {s : set α}
   (hs : sᶜ.finite) : s.infinite :=
 λ h, set.infinite_univ (by simpa using hs.union h)
 
-lemma infinite_compl_of_finite {α : Type} [_root_.infinite α] {s : set α}
+lemma finite.infinite_compl {α : Type} [_root_.infinite α] {s : set α}
   (hs : s.finite) : sᶜ.infinite :=
 λ h, set.infinite_univ (by simpa using hs.union h)
 

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -236,6 +236,14 @@ fintype.of_finset (s.to_finset ∪ t.to_finset) $ by simp
 theorem finite.union {s t : set α} : finite s → finite t → finite (s ∪ t)
 | ⟨hs⟩ ⟨ht⟩ := ⟨@set.fintype_union _ (classical.dec_eq α) _ _ hs ht⟩
 
+lemma infinite_of_finite_compl {α : Type} [_root_.infinite α] {s : set α}
+  (hs : sᶜ.finite) : s.infinite :=
+λ h, set.infinite_univ (by simpa using hs.union h)
+
+lemma infinite_compl_of_finite {α : Type} [_root_.infinite α] {s : set α}
+  (hs : s.finite) : sᶜ.infinite :=
+λ h, set.infinite_univ (by simpa using hs.union h)
+
 instance fintype_sep (s : set α) (p : α → Prop) [fintype s] [decidable_pred p] :
   fintype ({a ∈ s | p a} : set α) :=
 fintype.of_finset (s.to_finset.filter p) $ by simp


### PR DESCRIPTION
Add two missing lemmas. One-line proofs due to Yakov Pechersky.

---

Alternative names: `infinite_of_finite_compl` -> `infinite_of_compl_finite` and `compl_infinite_of_finite` -> `infinite_compl_of_finite`. Any comments? I went with
the "prefix notation order" as it were.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
