### PR TITLE
[Merged by Bors] - feat(topology/category/Top): nonempty inverse limit of compact Hausdorff spaces

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -671,3 +671,19 @@ MRREVIEWER = {N. Sankaran},
       title = {Lattice Concepts of Module Theory},
       doi = {10.1007/978-94-015-9588-9}
 }
+
+@Article{Stone1979,
+  author     = {Stone, A. H.},
+  journal    = {General Topology Appl.},
+  title      = {Inverse limits of compact spaces},
+  year       = {1979},
+  issn       = {0016-660X},
+  number     = {2},
+  pages      = {203--211},
+  volume     = {10},
+  doi        = {10.1016/0016-660x(79)90008-4},
+  fjournal   = {General Topology and its Applications},
+  mrclass    = {54B25},
+  mrnumber   = {527845},
+  mrreviewer = {J. Segal}
+}

--- a/src/category_theory/category/default.lean
+++ b/src/category_theory/category/default.lean
@@ -250,10 +250,20 @@ Express an inequality as a morphism in the corresponding preorder category.
 -/
 def hom_of_le {U V : α} (h : U ≤ V) : U ⟶ V := ulift.up (plift.up h)
 
+@[simp] lemma hom_of_le_refl {U : α} : hom_of_le (le_refl U) = 𝟙 U := rfl
+@[simp] lemma hom_of_le_comp {U V W : α} (h : U ≤ V) (k : V ≤ W) :
+  hom_of_le h ≫ hom_of_le k = hom_of_le (h.trans k) := rfl
+
 /--
 Extract the underlying inequality from a morphism in a preorder category.
 -/
 lemma le_of_hom {U V : α} (h : U ⟶ V) : U ≤ V := h.down.down
+
+@[simp] lemma le_of_hom_hom_of_le {a b : α} (h : a ≤ b) :
+  le_of_hom (hom_of_le h) = h := rfl
+@[simp] lemma hom_of_le_le_of_hom {a b : α} (h : a ⟶ b) :
+  hom_of_le (le_of_hom h) = h :=
+by { cases h, cases h, refl, }
 
 end category_theory
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -446,6 +446,9 @@ theorem iff_false_left (ha : ¬a) : (a ↔ b) ↔ ¬b :=
 theorem iff_false_right (ha : ¬a) : (b ↔ a) ↔ ¬b :=
 iff.comm.trans (iff_false_left ha)
 
+@[simp]
+lemma iff_mpr_iff_true_intro {P : Prop} (h : P) : iff.mpr (iff_true_intro h) true.intro = h := rfl
+
 -- See Note [decidable namespace]
 protected theorem decidable.not_or_of_imp [decidable a] (h : a → b) : ¬ a ∨ b :=
 if ha : a then or.inr (h ha) else or.inl ha

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -112,7 +112,9 @@ section topological_konig
 
 A topological version of Kőnig's lemma is that the inverse limit of nonempty compact Hausdorff
 spaces is nonempty.  (Note: this can be generalized further to inverse limits of nonempty compact
-T0 spaces, where all the maps are closed maps; see A.H. Stone, "Inverse limits of compact spaces").
+T0 spaces, where all the maps are closed maps; see [Stone1979] --- however there is an erratum
+for Theorem 4 that the element in the inverse limit can have cofinally many components that are
+not closed points.)
 -/
 
 variables {J : Type u} [directed_order J]

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -135,10 +135,8 @@ begin
     else
       classical.arbitrary _,
   intros j' fle,
-  simp only [le_of_hom fle.unop, dif_pos],
-  erw category_theory.functor.map_id,
-  rw (by dec_trivial : fle = (hom_of_le (le_of_hom fle.unop)).op),
-  refl,
+  simp only [dif_pos (le_of_hom fle.unop)],
+  dsimp, simp,
 end
 
 lemma partial_sections.directed : directed (⊇) (partial_sections F) :=

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -130,7 +130,7 @@ def partial_sections (j : Jᵒᵖ) : set (Π j, F.obj j) :=
 lemma partial_sections.nonempty [Π (j : Jᵒᵖ), nonempty (F.obj j)] (j : Jᵒᵖ) :
   (partial_sections F j).nonempty :=
 begin
-  haveI := classical.dec_pred (λ (j' : Jᵒᵖ), j'.unop ≤ j.unop),
+  classical,
   use λ (j' : Jᵒᵖ),
     if h : j'.unop ≤ j.unop then
       F.map (hom_of_le h).op (classical.arbitrary (F.obj j))

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -17,6 +17,7 @@ underlying types are just the limits in the category of types.
 open topological_space
 open category_theory
 open category_theory.limits
+open opposite
 
 universe u
 
@@ -99,5 +100,98 @@ instance forget_preserves_colimits : preserves_colimits (forget : Top.{u} ⥤ Ty
   { preserves_colimit := λ F,
     by exactI preserves_colimit_of_preserves_colimit_cocone
       (colimit_cocone_is_colimit F) (types.colimit_cocone_is_colimit (F ⋙ forget)) } }
+
+end Top
+
+namespace Top
+
+section topological_konig
+
+/-!
+## Topological Kőnig's lemma
+
+A topological version of Kőnig's lemma is that the inverse limit of nonempty compact Hausdorff
+spaces is nonempty.  (Note: this can be generalized further to inverse limits of nonempty compact
+T0 spaces, where all the maps are closed maps; see A.H. Stone, "Inverse limits of compact spaces").
+-/
+
+variables {J : Type u} [directed_order J]
+variables (F : Jᵒᵖ ⥤ Top.{u})
+
+/--
+The partial sections of an inverse system of topological spaces from an index `j` are sections
+when restricted to all objects less than or equal to `j`.
+-/
+def partial_sections (j : Jᵒᵖ) : set (Π j, F.obj j) :=
+{ u | ∀ {j'} (f : j ⟶ j'), F.map f (u j) = u j'}
+
+lemma partial_sections.nonempty [Π (j : Jᵒᵖ), nonempty (F.obj j)] (j : Jᵒᵖ) :
+  (partial_sections F j).nonempty :=
+begin
+  haveI := classical.dec_pred (λ (j' : Jᵒᵖ), j'.unop ≤ j.unop),
+  use λ (j' : Jᵒᵖ),
+    if h : j'.unop ≤ j.unop then
+      F.map (hom_of_le h).op (classical.arbitrary (F.obj j))
+    else
+      classical.arbitrary _,
+  intros j' fle,
+  simp only [le_of_hom fle.unop, dif_pos],
+  erw category_theory.functor.map_id,
+  rw (by dec_trivial : fle = (hom_of_le (le_of_hom fle.unop)).op),
+  refl,
+end
+
+lemma partial_sections.directed : directed (⊇) (partial_sections F) :=
+begin
+  intros j j',
+  obtain ⟨j'', hj''⟩ := directed_order.directed j.unop j'.unop,
+  use op j'',
+  split,
+  { intros u hu j''' f''',
+    rw [←hu ((hom_of_le hj''.1).op ≫ f'''), ←hu],
+    simp only [Top.comp_app, functor.map_comp] },
+  { intros u hu j''' f''',
+    rw [←hu ((hom_of_le hj''.2).op ≫ f'''), ←hu],
+    simp only [Top.comp_app, functor.map_comp] },
+end
+
+lemma partial_sections.closed [Π (j : Jᵒᵖ), t2_space (F.obj j)] (j : Jᵒᵖ) :
+  is_closed (partial_sections F j) :=
+begin
+  have hps : partial_sections F j =
+    ⋂ (f : Σ j', j ⟶ j'), {u : Π (j : Jᵒᵖ), F.obj j | F.map f.2 (u j) = u f.1},
+  { ext u,
+    simp only [set.mem_Inter, sigma.forall, set.mem_set_of_eq],
+    exact ⟨λ hu j' f, hu f, λ hu j' f, hu j' f⟩ },
+  rw hps,
+  apply is_closed_Inter,
+  rintros ⟨j', f⟩,
+  let proj : Π (j' : Jᵒᵖ), C((Π (j : Jᵒᵖ), F.obj j), F.obj j') :=
+    λ j', ⟨λ u, u j', continuous_apply j'⟩,
+  exact is_closed_eq
+    (((F.map f).continuous.comp (proj j).continuous).comp continuous_id)
+    ((proj j').continuous.comp continuous_id),
+end
+
+lemma nonempty_limit_cone_of_compact_t2_inverse_system
+  [Π (j : Jᵒᵖ), nonempty (F.obj j)]
+  [Π (j : Jᵒᵖ), compact_space (F.obj j)]
+  [Π (j : Jᵒᵖ), t2_space (F.obj j)] :
+  nonempty (Top.limit_cone F).X :=
+begin
+  by_cases h : nonempty Jᵒᵖ,
+  { haveI := h,
+    obtain ⟨u, hu⟩ := is_compact.nonempty_Inter_of_directed_nonempty_compact_closed
+      (partial_sections F) (partial_sections.directed F) (partial_sections.nonempty F)
+      (λ j, is_closed.compact (partial_sections.closed F j)) (partial_sections.closed F),
+    use u,
+    intros j j' f,
+    specialize hu (partial_sections F j),
+    simp only [forall_prop_of_true, set.mem_range_self] at hu,
+    exact hu f, },
+  { exact ⟨⟨λ j, (h ⟨j⟩).elim, λ j, (h ⟨j⟩).elim⟩⟩, },
+end
+
+end topological_konig
 
 end Top


### PR DESCRIPTION
The limit of an inverse system of nonempty compact Hausdorff spaces is nonempty, and this can be seen as a generalization of Kőnig's lemma.  A future PR will address the weaker generalization that the limit of an inverse system of nonempty finite types is nonempty.

This result could be generalized more, to the inverse limit of nonempty compact T0 spaces where all the maps are closed, but I think it involves an essentially different method.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
