### PR TITLE
[Merged by Bors] - feat(topology/{subset_properties,separation}): closed subsets of compact t0 spaces contain a closed point

### DIFF
--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -59,6 +59,38 @@ end separated
 class t0_space (α : Type u) [topological_space α] : Prop :=
 (t0 : ∀ x y, x ≠ y → ∃ U:set α, is_open U ∧ (xor (x ∈ U) (y ∈ U)))
 
+theorem exists_closed_singleton_of_compact_in_closed {α : Type*} [topological_space α]
+  [t0_space α] [compact_space α] (S : set α) (hS : is_closed S) (hne : S.nonempty) :
+  ∃ (x : α), x ∈ S ∧ is_closed ({x} : set α) :=
+begin
+  obtain ⟨V, Vsub, Vne, Vcls, hV⟩ := exists_minimal_nonempty_closed_subset_of_compact S hS hne,
+  by_cases hnt : ∃ (x y : α) (hx : x ∈ V) (hy : y ∈ V), x ≠ y,
+  { exfalso,
+    obtain ⟨x, y, hx, hy, hne⟩ := hnt,
+    obtain ⟨U, hU, hsep⟩ := t0_space.t0 _ _ hne,
+    have : ∀ (z w : α) (hz : z ∈ V) (hw : w ∈ V) (hz' : z ∈ U) (hw' : ¬ w ∈ U), false,
+    { intros z w hz hw hz' hw',
+      have uvne : (V ∩ Uᶜ).nonempty,
+      { use w, simp only [hw, hw', set.mem_inter_eq, not_false_iff, and_self, set.mem_compl_eq], },
+      specialize hV (V ∩ Uᶜ) (set.inter_subset_left _ _) uvne
+        (is_closed_inter Vcls (is_closed_compl_iff.mpr hU)),
+      have : V ⊆ Uᶜ,
+      { rw ←hV, exact set.inter_subset_right _ _ },
+      exact this hz hz', },
+    cases hsep,
+    { exact this x y hx hy hsep.1 hsep.2 },
+    { exact this y x hy hx hsep.1 hsep.2 } },
+  { push_neg at hnt,
+    obtain ⟨z, hz⟩ := Vne,
+    refine ⟨z, Vsub hz, _⟩,
+    convert Vcls,
+    ext,
+    simp only [set.mem_singleton_iff, set.mem_compl_eq],
+    split,
+    { rintro rfl, exact hz, },
+    { exact λ hx, hnt x z hx hz, }, },
+end
+
 theorem exists_open_singleton_of_open_finset [t0_space α] (s : finset α) (sne : s.nonempty)
   (hso : is_open (↑s : set α)) :
   ∃ x ∈ s, is_open ({x} : set α):=

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -59,11 +59,11 @@ end separated
 class t0_space (α : Type u) [topological_space α] : Prop :=
 (t0 : ∀ x y, x ≠ y → ∃ U:set α, is_open U ∧ (xor (x ∈ U) (y ∈ U)))
 
-theorem exists_closed_singleton_of_compact_in_closed {α : Type*} [topological_space α]
-  [t0_space α] [compact_space α] (S : set α) (hS : is_closed S) (hne : S.nonempty) :
+theorem is_closed.exists_closed_singleton {α : Type*} [topological_space α]
+  [t0_space α] [compact_space α] {S : set α} (hS : is_closed S) (hne : S.nonempty) :
   ∃ (x : α), x ∈ S ∧ is_closed ({x} : set α) :=
 begin
-  obtain ⟨V, Vsub, Vne, Vcls, hV⟩ := exists_minimal_nonempty_closed_subset_of_compact S hS hne,
+  obtain ⟨V, Vsub, Vne, Vcls, hV⟩ := hS.exists_minimal_nonempty_closed_subset hne,
   by_cases hnt : ∃ (x y : α) (hx : x ∈ V) (hy : y ∈ V), x ≠ y,
   { exfalso,
     obtain ⟨x, y, hx, hy, hne⟩ := hnt,

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -658,8 +658,8 @@ begin
   exact le_nhds_Lim ⟨x,h⟩,
 end
 
-theorem exists_minimal_nonempty_closed_subset_of_compact [compact_space α]
-  (S : set α) (hS : is_closed S) (hne : S.nonempty) :
+theorem is_closed.exists_minimal_nonempty_closed_subset [compact_space α]
+  {S : set α} (hS : is_closed S) (hne : S.nonempty) :
   ∃ (V : set α),
     V ⊆ S ∧ V.nonempty ∧ is_closed V ∧
       (∀ (V' : set α), V' ⊆ V → V'.nonempty → is_closed V' → V' = V) :=

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -658,6 +658,48 @@ begin
   exact le_nhds_Lim ⟨x,h⟩,
 end
 
+theorem exists_minimal_nonempty_closed_subset_of_compact [compact_space α]
+  (S : set α) (hS : is_closed S) (hne : S.nonempty) :
+  ∃ (V : set α),
+    V ⊆ S ∧ V.nonempty ∧ is_closed V ∧
+      (∀ (V' : set α), V' ⊆ V → V'.nonempty → is_closed V' → V' = V) :=
+begin
+  let opens := {U : set α | Sᶜ ⊆ U ∧ is_open U ∧ Uᶜ.nonempty},
+  obtain ⟨U, ⟨Uc, Uo, Ucne⟩, h⟩ := zorn.zorn_subset opens (λ c hc hz, begin
+    by_cases hcne : c.nonempty,
+    { obtain ⟨U₀, hU₀⟩ := hcne,
+      haveI : nonempty {U // U ∈ c} := ⟨⟨U₀, hU₀⟩⟩,
+      obtain ⟨U₀compl, U₀opn, U₀ne⟩ := hc hU₀,
+      use ⋃₀ c,
+      refine ⟨⟨_, _, _⟩, λ U hU a ha, ⟨U, hU, ha⟩⟩,
+      { exact λ a ha, ⟨U₀, hU₀, U₀compl ha⟩ },
+      { exact is_open_sUnion (λ _ h, (hc h).2.1) },
+      { convert_to (⋂(U : {U // U ∈ c}), U.1ᶜ).nonempty,
+        { ext,
+          simp only [not_exists, exists_prop, not_and, set.mem_Inter, subtype.forall,
+            set.mem_set_of_eq, set.mem_compl_eq, subtype.val_eq_coe],
+          refl, },
+        apply is_compact.nonempty_Inter_of_directed_nonempty_compact_closed,
+        { rintros ⟨U, hU⟩ ⟨U', hU'⟩,
+          obtain ⟨V, hVc, hVU, hVU'⟩ := zorn.chain.directed_on hz U hU U' hU',
+          exact ⟨⟨V, hVc⟩, set.compl_subset_compl.mpr hVU, set.compl_subset_compl.mpr hVU'⟩, },
+        { exact λ U, (hc U.2).2.2, },
+        { exact λ U, is_closed.compact (is_closed_compl_iff.mpr (hc U.2).2.1), },
+        { exact λ U, (is_closed_compl_iff.mpr (hc U.2).2.1), } } },
+    { use Sᶜ,
+      refine ⟨⟨set.subset.refl _, is_open_compl_iff.mpr hS, _⟩, λ U Uc, (hcne ⟨U, Uc⟩).elim⟩,
+      rw compl_compl,
+      exact hne, }
+  end),
+  refine ⟨Uᶜ, set.compl_subset_comm.mp Uc, Ucne, is_closed_compl_iff.mpr Uo, _⟩,
+  intros V' V'sub V'ne V'cls,
+  have : V'ᶜ = U,
+  { refine h V'ᶜ ⟨_, is_open_compl_iff.mpr V'cls, _⟩ (set.subset_compl_comm.mp V'sub),
+    exact set.subset.trans Uc (set.subset_compl_comm.mp V'sub),
+    simp only [compl_compl, V'ne], },
+  rw [←this, compl_compl],
+end
+
 /-- A σ-compact space is a space that is the union of a countable collection of compact subspaces.
   Note that a locally compact separable T₂ space need not be σ-compact.
   The sequence can be extracted using `topological_space.compact_covering`. -/


### PR DESCRIPTION
This adds two statements.  The first is that nonempty closed subsets of a compact space have a minimal nonempty closed subset, and the second is that when the space is additionally T0 then that minimal subset is a singleton.

(This PR does not do this, but one can go on to show that there is functor from compact T0 spaces to T1 spaces by taking the set of closed points, and it preserves nonemptiness.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
