### PR TITLE
[Merged by Bors] - chore(topology/sheaves): speed up slow proofs by tidy

### DIFF
--- a/src/topology/sheaves/sheaf_condition/pairwise_intersections.lean
+++ b/src/topology/sheaves/sheaf_condition/pairwise_intersections.lean
@@ -52,7 +52,7 @@ An alternative formulation of the sheaf condition
 `sheaf_condition_equiv_sheaf_condition_pairwise_intersections`).
 
 A presheaf is a sheaf if `F` sends the cone `(pairwise.cocone U).op` to a limit cone.
-(Recall `pairwise.cocone U`, has cone point `supr U`, mapping down to the `U i` and the `U i ⊓ U j`.)
+(Recall `pairwise.cocone U` has cone point `supr U`, mapping down to the `U i` and the `U i ⊓ U j`.)
 -/
 @[derive subsingleton, nolint has_inhabited_instance]
 def sheaf_condition_pairwise_intersections (F : presheaf C X) : Type (max u (v+1)) :=
@@ -99,21 +99,25 @@ def cone_equiv_functor_obj (F : presheaf C X)
     begin
       cases Y; cases Z; cases f,
       { ext i, dsimp,
-        simp only [limit.lift_π, category.id_comp, fan.mk_π_app, category_theory.functor.map_id, category.assoc],
+        simp only [limit.lift_π, category.id_comp, fan.mk_π_app, category_theory.functor.map_id,
+          category.assoc],
         dsimp,
         simp only [limit.lift_π, category.id_comp, fan.mk_π_app], },
       { ext ⟨i, j⟩, dsimp [sheaf_condition_equalizer_products.left_res],
-        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app, category.assoc],
+        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app,
+          category.assoc],
         have h := c.π.naturality (has_hom.hom.op (hom.left i j)),
         dsimp at h,
         simpa using h, },
       { ext ⟨i, j⟩, dsimp [sheaf_condition_equalizer_products.right_res],
-        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app, category.assoc],
+        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app,
+          category.assoc],
         have h := c.π.naturality (has_hom.hom.op (hom.right i j)),
         dsimp at h,
         simpa using h,  },
       { ext i, dsimp,
-        simp only [limit.lift_π, category.id_comp, fan.mk_π_app, category_theory.functor.map_id, category.assoc],
+        simp only [limit.lift_π, category.id_comp, fan.mk_π_app, category_theory.functor.map_id,
+          category.assoc],
         dsimp,
         simp only [limit.lift_π, category.id_comp, fan.mk_π_app], },
     end, }, }
@@ -125,10 +129,16 @@ local attribute [tidy] tactic.case_bash
 @[simps]
 def cone_equiv_functor (F : presheaf C X)
   ⦃ι : Type v⦄ (U : ι → opens ↥X) :
-  limits.cone ((diagram U).op ⋙ F) ⥤ limits.cone (sheaf_condition_equalizer_products.diagram F U) :=
+  limits.cone ((diagram U).op ⋙ F) ⥤
+    limits.cone (sheaf_condition_equalizer_products.diagram F U) :=
 { obj := λ c, cone_equiv_functor_obj F U c,
   map := λ c c' f,
-  { hom := f.hom, }, }.
+  { hom := f.hom,
+    w' := λ j, begin
+      cases j;
+      { ext, simp only [limits.fan.mk_π_app, limits.cone_morphism.w,
+        limits.limit.lift_π, category.assoc, cone_equiv_functor_obj_π_app], },
+    end }, }.
 
 end
 
@@ -187,7 +197,8 @@ def cone_equiv_inverse_obj (F : presheaf C X)
 @[simps]
 def cone_equiv_inverse (F : presheaf C X)
   ⦃ι : Type v⦄ (U : ι → opens ↥X) :
-  limits.cone (sheaf_condition_equalizer_products.diagram F U) ⥤ limits.cone ((diagram U).op ⋙ F) :=
+  limits.cone (sheaf_condition_equalizer_products.diagram F U) ⥤
+    limits.cone ((diagram U).op ⋙ F) :=
 { obj := λ c, cone_equiv_inverse_obj F U c,
   map := λ c c' f,
   { hom := f.hom,
@@ -210,10 +221,25 @@ def cone_equiv_unit_iso_app (F : presheaf C X) ⦃ι : Type v⦄ (U : ι → ope
     (cone_equiv_functor F U ⋙ cone_equiv_inverse F U).obj c :=
 { hom :=
   { hom := 𝟙 _,
-    w' := λ j, begin op_induction j, rcases j; tidy, end, },
+    w' := λ j, begin
+      op_induction j, rcases j;
+      { dsimp, simp only [limits.fan.mk_π_app, category.id_comp, limits.limit.lift_π], }
+    end, },
   inv :=
   { hom := 𝟙 _,
-    w' := λ j, begin op_induction j, rcases j; tidy, end }}
+    w' := λ j, begin op_induction j, rcases j;
+      { dsimp, simp only [limits.fan.mk_π_app, category.id_comp, limits.limit.lift_π], }
+    end },
+  hom_inv_id' := begin
+    ext,
+    simp only [category.comp_id, limits.cone.category_to_category_struct_comp_hom,
+      limits.cone.category_to_category_struct_id_hom],
+  end,
+  inv_hom_id' := begin
+    ext,
+    simp only [category.comp_id, limits.cone.category_to_category_struct_comp_hom,
+      limits.cone.category_to_category_struct_id_hom],
+  end, }
 
 /-- Implementation of `sheaf_condition_pairwise_intersections.cone_equiv`. -/
 @[simps]
@@ -233,17 +259,20 @@ nat_iso.of_components (λ c,
     w' :=
     begin
       rintro ⟨_|_⟩,
-      { ext, dsimp, simp, },
-      { ext ⟨i,j⟩, dsimp, simp, },
+      { ext, dsimp, simp only [category.id_comp, limits.fan.mk_π_app, limits.limit.lift_π], },
+      { ext ⟨i,j⟩, dsimp, simp only [category.id_comp, limits.fan.mk_π_app, limits.limit.lift_π], },
     end },
   inv :=
   { hom := 𝟙 _,
     w' :=
     begin
       rintro ⟨_|_⟩,
-      { ext, dsimp, simp, },
-      { ext ⟨i,j⟩, dsimp, simp, },
-    end, }}) (by tidy)
+      { ext, dsimp, simp only [category.id_comp, limits.fan.mk_π_app, limits.limit.lift_π], },
+      { ext ⟨i,j⟩, dsimp, simp only [category.id_comp, limits.fan.mk_π_app, limits.limit.lift_π], },
+    end, },
+  hom_inv_id' := by { ext, dsimp, simp only [category.comp_id], },
+  inv_hom_id' := by { ext, dsimp, simp only [category.comp_id], }, })
+(λ c d f, by { ext, dsimp, simp only [category.comp_id, category.id_comp], })
 
 /--
 Cones over `diagram U ⋙ F` are the same as a cones over the usual sheaf condition equalizer diagram.
@@ -278,7 +307,8 @@ is_limit.of_iso_limit ((is_limit.of_cone_equiv (cone_equiv F U).symm).symm P)
       rcases x with ⟨⟩,
       { dsimp, simp, refl, },
       { dsimp,
-        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app, category.assoc],
+        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app,
+          category.assoc],
         rw ←F.map_comp,
         refl, }
     end },
@@ -291,10 +321,13 @@ is_limit.of_iso_limit ((is_limit.of_cone_equiv (cone_equiv F U).symm).symm P)
       rcases x with ⟨⟩,
       { dsimp, simp, refl, },
       { dsimp,
-        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app, category.assoc],
+        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app,
+          category.assoc],
         rw ←F.map_comp,
         refl, }
-    end }, }
+    end },
+  hom_inv_id' := by { ext, dsimp, simp only [category.comp_id], },
+  inv_hom_id' := by { ext, dsimp, simp only [category.comp_id], }, }
 
 /--
 If `F.map_cone (cone U)` is a limit cone,
@@ -312,7 +345,8 @@ is_limit.of_iso_limit ((is_limit.of_cone_equiv (cone_equiv F U)).symm Q)
       rintro ⟨⟩,
       { dsimp, simp, refl, },
       { dsimp, ext ⟨i, j⟩,
-        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app, category.assoc],
+        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app,
+          category.assoc],
         rw ←F.map_comp,
         refl, }
     end },
@@ -323,10 +357,13 @@ is_limit.of_iso_limit ((is_limit.of_cone_equiv (cone_equiv F U)).symm Q)
       rintro ⟨⟩,
       { dsimp, simp, refl, },
       { dsimp, ext ⟨i, j⟩,
-        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app, category.assoc],
+        simp only [limit.lift_π, limit.lift_π_assoc, category.id_comp, fan.mk_π_app,
+          category.assoc],
         rw ←F.map_comp,
         refl, }
-    end }, }
+    end },
+  hom_inv_id' := by { ext, dsimp, simp only [category.comp_id], },
+  inv_hom_id' := by { ext, dsimp, simp only [category.comp_id], }, }
 
 
 end sheaf_condition_pairwise_intersections


### PR DESCRIPTION
No changes, just making some proofs by tidy explicit, so the file is not quite as slow as previously. Now compiles with `-T40000`.