### PR TITLE
[Merged by Bors] - feat(data/zmod/basic): add simp lemmas about coercions, tidy lemma names

### DIFF
--- a/src/combinatorics/simple_graph/degree_sum.lean
+++ b/src/combinatorics/simple_graph/degree_sum.lean
@@ -182,7 +182,7 @@ theorem even_card_odd_degree_vertices [fintype V] [decidable_rel G.adj] :
 begin
   classical,
   have h := congr_arg ((λ n, ↑n) : ℕ → zmod 2) G.sum_degrees_eq_twice_card_edges,
-  simp only [zmod.cast_self, zero_mul, nat.cast_mul] at h,
+  simp only [zmod.nat_cast_self, zero_mul, nat.cast_mul] at h,
   rw [sum_nat_cast, ←sum_filter_ne_zero] at h,
   rw @sum_congr _ (zmod 2) _ _ (λ v, (G.degree v : zmod 2)) (λ v, (1 : zmod 2)) _ rfl at h,
   { simp only [filter_congr_decidable, mul_one, nsmul_eq_mul, sum_const, ne.def] at h,

--- a/src/data/padics/ring_homs.lean
+++ b/src/data/padics/ring_homs.lean
@@ -100,7 +100,7 @@ begin
   rw ← zmod.int_coe_zmod_eq_zero_iff_dvd,
   simp only [int.cast_coe_nat, zmod.cast_mod_nat p, int.cast_mul, int.cast_sub],
   have := congr_arg (coe : ℤ → zmod p) (gcd_eq_gcd_ab r.denom p),
-  simp only [int.cast_coe_nat, add_zero, int.cast_add, zmod.cast_self, int.cast_mul, zero_mul]
+  simp only [int.cast_coe_nat, add_zero, int.cast_add, zmod.nat_cast_self, int.cast_mul, zero_mul]
     at this,
   push_cast,
   rw [mul_right_comm, mul_assoc, ←this],
@@ -267,7 +267,7 @@ begin
   dsimp [to_zmod, to_zmod_hom],
   unfreezingI { rcases (exists_eq_add_of_lt (hp_prime.pos)) with ⟨p', rfl⟩ },
   change ↑(zmod.val _) = _,
-  simp only [zmod.val_cast_nat, add_zero, add_def, cast_inj, zero_add],
+  simp only [zmod.val_nat_cast, add_zero, add_def, cast_inj, zero_add],
   apply mod_eq_of_lt,
   simpa only [zero_add] using zmod_repr_lt_p z,
 end
@@ -302,7 +302,7 @@ lemma appr_lt (x : ℤ_[p]) (n : ℕ) : x.appr n < p ^ n :=
 begin
   induction n with n ih generalizing x,
   { simp only [appr, succ_pos', pow_zero], },
-  simp only [appr, ring_hom.map_nat_cast, zmod.cast_self, ring_hom.map_pow, int.nat_abs,
+  simp only [appr, ring_hom.map_nat_cast, zmod.nat_cast_self, ring_hom.map_pow, int.nat_abs,
     ring_hom.map_mul],
   have hp : p ^ n < p ^ (n + 1),
   { apply pow_lt_pow hp_prime.one_lt (lt_add_one n) },
@@ -354,7 +354,7 @@ begin
     { rw h, apply dvd_zero },
     { push_cast, rw sub_add_eq_sub_sub,
       obtain ⟨c, hc⟩ := ih x,
-      simp only [ring_hom.map_nat_cast, zmod.cast_self, ring_hom.map_pow, ring_hom.map_mul,
+      simp only [ring_hom.map_nat_cast, zmod.nat_cast_self, ring_hom.map_pow, ring_hom.map_mul,
         zmod.nat_cast_val],
       have hc' : c ≠ 0,
       { rintro rfl, simp only [mul_zero] at hc, contradiction },

--- a/src/data/padics/ring_homs.lean
+++ b/src/data/padics/ring_homs.lean
@@ -98,7 +98,7 @@ lemma norm_sub_mod_part_aux (r : ℚ) (h : ∥(r : ℚ_[p])∥ ≤ 1) :
   ↑p ∣ r.num - r.num * r.denom.gcd_a p % p * ↑(r.denom) :=
 begin
   rw ← zmod.int_coe_zmod_eq_zero_iff_dvd,
-  simp only [int.cast_coe_nat, zmod.cast_mod_nat p, int.cast_mul, int.cast_sub],
+  simp only [int.cast_coe_nat, zmod.nat_cast_mod p, int.cast_mul, int.cast_sub],
   have := congr_arg (coe : ℤ → zmod p) (gcd_eq_gcd_ab r.denom p),
   simp only [int.cast_coe_nat, add_zero, int.cast_add, zmod.nat_cast_self, int.cast_mul, zero_mul]
     at this,

--- a/src/data/padics/ring_homs.lean
+++ b/src/data/padics/ring_homs.lean
@@ -646,7 +646,7 @@ lemma lift_spec (n : ℕ) : (to_zmod_pow n).comp (lift f_compat) = f n :=
 begin
   ext r,
   haveI : fact (0 < p ^ n) := pow_pos (nat.prime.pos ‹_›) n,
-  rw [ring_hom.comp_apply, ← zmod.cast_val (f n r), ← (to_zmod_pow n).map_nat_cast,
+  rw [ring_hom.comp_apply, ← zmod.nat_cast_zmod_val (f n r), ← (to_zmod_pow n).map_nat_cast,
       ← sub_eq_zero, ← ring_hom.map_sub, ← ring_hom.mem_ker, ker_to_zmod_pow],
   apply lift_sub_val_mem_span,
 end

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -204,8 +204,10 @@ by { cases n; refl }
 
 end
 
+/-- So-named because the coercion is `nat.cast` into `zmod`. For `nat.cast` into an arbitrary ring,
+see `zmod.nat_cast_val`. -/
 @[simp]
-lemma cast_val {n : ℕ} [fact (0 < n)] (a : zmod n) :
+lemma nat_cast_zmod_val {n : ℕ} [fact (0 < n)] (a : zmod n) :
   (a.val : zmod n) = a :=
 begin
   casesI n,
@@ -214,12 +216,14 @@ begin
     rw [val, fin.ext_iff, fin.coe_coe_eq_self] }
 end
 
-lemma nat_cast_surjective [fact (0 < n)] :
+lemma nat_cast_zmod_surjective [fact (0 < n)] :
   function.surjective (coe : ℕ → zmod n) :=
-function.right_inverse.surjective cast_val
+function.right_inverse.surjective nat_cast_zmod_val
 
+/-- So-named because the outer coercion is `int.cast` into `zmod`. For `int.cast` into an arbitrary
+ring, see `zmod.int_cast_cast`. -/
 @[simp]
-lemma int_cast_coe_zmod (a : zmod n) :
+lemma int_cast_zmod_cast (a : zmod n) :
   ((a : ℤ) : zmod n) = a :=
 begin
   cases n,
@@ -229,18 +233,19 @@ end
 
 lemma int_cast_surjective :
   function.surjective (coe : ℤ → zmod n) :=
-function.right_inverse.surjective int_cast_coe_zmod
+function.right_inverse.surjective int_cast_zmod_cast
 
 @[norm_cast]
 lemma cast_id : ∀ n (i : zmod n), ↑i = i
 | 0     i := int.cast_id i
-| (n+1) i := cast_val i
+| (n+1) i := nat_cast_zmod_val i
 
 @[simp]
 lemma cast_id' : (coe : zmod n → zmod n) = id := funext (cast_id n)
 
 variables (R) [ring R]
 
+/-- The coercions are respectively `nat.cast` and `zmod.cast`. -/
 @[simp] lemma nat_cast_comp_val [fact (0 < n)] :
   (coe : ℕ → R) ∘ (val : zmod n → ℕ) = coe :=
 begin
@@ -249,7 +254,8 @@ begin
   refl
 end
 
-@[simp] lemma int_cast_comp_coe :
+/-- The coercions are respectively `int.cast`, `zmod.cast`, and `zmod.cast`. -/
+@[simp] lemma int_cast_comp_cast :
   (coe : ℤ → R) ∘ (coe : zmod n → ℤ) = coe :=
 begin
   cases n,
@@ -263,9 +269,9 @@ variables {R}
   (i.val : R) = i :=
 congr_fun (nat_cast_comp_val R) i
 
-@[simp] lemma int_cast_coe (i : zmod n) :
+@[simp] lemma int_cast_cast (i : zmod n) :
   ((i : ℤ) : R) = i :=
-congr_fun (int_cast_comp_coe R) i
+congr_fun (int_cast_comp_cast R) i
 
 section char_dvd
 /-! If the characteristic of `R` divides `n`, then `cast` is a homomorphism. -/
@@ -497,7 +503,7 @@ begin
   { set k := n.succ,
     calc a * a⁻¹ = a * a⁻¹ + k * nat.gcd_b (val a) k : by rw [cast_self, zero_mul, add_zero]
              ... = ↑(↑a.val * nat.gcd_a (val a) k + k * nat.gcd_b (val a) k) :
-                     by { push_cast, rw cast_val, refl }
+                     by { push_cast, rw nat_cast_zmod_val, refl }
              ... = nat.gcd a.val k : (congr_arg coe (nat.gcd_eq_gcd_ab a.val k)).symm, }
 end
 
@@ -535,7 +541,7 @@ begin
   have := units.ext_iff.1 (mul_right_inv u),
   rw [units.coe_one] at this,
   rw [← eq_iff_modeq_nat, nat.cast_one, ← this], clear this,
-  rw [← cast_val ((u * u⁻¹ : units (zmod (n+1))) : zmod (n+1))],
+  rw [← nat_cast_zmod_val ((u * u⁻¹ : units (zmod (n+1))) : zmod (n+1))],
   rw [units.coe_mul, val_mul, cast_mod_nat],
 end
 
@@ -567,7 +573,7 @@ def units_equiv_coprime {n : ℕ} [fact (0 < n)] :
   units (zmod n) ≃ {x : zmod n // nat.coprime x.val n} :=
 { to_fun := λ x, ⟨x, val_coe_unit_coprime x⟩,
   inv_fun := λ x, unit_of_coprime x.1.val x.2,
-  left_inv := λ ⟨_, _, _, _⟩, units.ext (cast_val _),
+  left_inv := λ ⟨_, _, _, _⟩, units.ext (nat_cast_zmod_val _),
   right_inv := λ ⟨_, _⟩, by simp }
 
 section totient
@@ -614,10 +620,11 @@ begin
     rw [← nat.two_mul_odd_div_two hn, two_mul, ← nat.succ_add, nat.add_sub_cancel], },
   have hxn : (n : ℕ) - x.val < n,
   { rw [nat.sub_lt_iff (le_of_lt x.val_lt) (le_refl _), nat.sub_self],
-    rw ← zmod.cast_val x at hx0,
+    rw ← zmod.nat_cast_zmod_val x at hx0,
     exact nat.pos_of_ne_zero (λ h, by simpa [h] using hx0) },
   by conv {to_rhs, rw [← nat.succ_le_iff, nat.succ_eq_add_one, ← hn2', ← zero_add (- x),
-    ← zmod.cast_self, ← sub_eq_add_neg, ← zmod.cast_val x, ← nat.cast_sub (le_of_lt x.val_lt),
+    ← zmod.cast_self, ← sub_eq_add_neg, ← zmod.nat_cast_zmod_val x,
+    ← nat.cast_sub (le_of_lt x.val_lt),
     zmod.val_cast_nat, nat.mod_eq_of_lt hxn, nat.sub_le_sub_left_iff (le_of_lt x.val_lt)] }
 end
 
@@ -686,8 +693,8 @@ end
 begin
   rw val_min_abs_def_pos,
   split_ifs,
-  { rw [int.cast_coe_nat, cast_val] },
-  { rw [int.cast_sub, int.cast_coe_nat, cast_val, int.cast_coe_nat, cast_self, sub_zero], }
+  { rw [int.cast_coe_nat, nat_cast_zmod_val] },
+  { rw [int.cast_sub, int.cast_coe_nat, nat_cast_zmod_val, int.cast_coe_nat, cast_self, sub_zero] }
 end
 
 lemma nat_abs_val_min_abs_le {n : ℕ} [fact (0 < n)] (x : zmod n) : x.val_min_abs.nat_abs ≤ n / 2 :=
@@ -731,9 +738,9 @@ begin
     by { erw [sub_nonpos, int.coe_nat_le], exact le_of_lt a.val_lt, },
   rw [zmod.val_min_abs_def_pos],
   split_ifs,
-  { rw [int.nat_abs_of_nat, cast_val] },
+  { rw [int.nat_abs_of_nat, nat_cast_zmod_val] },
   { rw [← int.cast_coe_nat, int.of_nat_nat_abs_of_nonpos this, int.cast_neg, int.cast_sub],
-    rw [int.cast_coe_nat, int.cast_coe_nat, cast_self, sub_zero, cast_val], }
+    rw [int.cast_coe_nat, int.cast_coe_nat, cast_self, sub_zero, nat_cast_zmod_val], }
 end
 
 @[simp] lemma nat_abs_val_min_abs_neg {n : ℕ} (a : zmod n) :
@@ -757,7 +764,7 @@ begin
     { assume h,
       apply lt_of_le_of_ne (le_trans (nat.le_add_left _ _) h),
       contrapose! haa,
-      rw [← zmod.cast_val a, ← haa, neg_eq_iff_add_eq_zero, ← nat.cast_add],
+      rw [← zmod.nat_cast_zmod_val a, ← haa, neg_eq_iff_add_eq_zero, ← nat.cast_add],
       rw [char_p.cast_eq_zero_iff (zmod (n+1)) (n+1)],
       rw [← two_mul, ← zero_add (2 * _), ← hn0, nat.mod_add_div] },
     { rw [hn0, zero_add], exact le_of_lt } },
@@ -781,7 +788,7 @@ variables (p : ℕ) [fact p.prime]
 
 private lemma mul_inv_cancel_aux (a : zmod p) (h : a ≠ 0) : a * a⁻¹ = 1 :=
 begin
-  obtain ⟨k, rfl⟩ := nat_cast_surjective a,
+  obtain ⟨k, rfl⟩ := nat_cast_zmod_surjective a,
   apply coe_mul_inv_eq_one,
   apply nat.coprime.symm,
   rwa [nat.prime.coprime_iff_not_dvd ‹p.prime›, ← char_p.cast_eq_zero_iff (zmod p)]

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -156,7 +156,7 @@ end
 | 0     := rfl
 | (n+1) := rfl
 
-lemma val_cast_nat {n : ℕ} (a : ℕ) : (a : zmod n).val = a % n :=
+lemma val_nat_cast {n : ℕ} (a : ℕ) : (a : zmod n).val = a % n :=
 begin
   casesI n,
   { rw [nat.mod_zero, int.nat_cast_eq_coe_nat],
@@ -173,14 +173,14 @@ instance (n : ℕ) : char_p (zmod n) n :=
     { simp only [int.nat_cast_eq_coe_nat, zero_dvd_iff, int.coe_nat_eq_zero], },
     rw [fin.eq_iff_veq],
     show (k : zmod (n+1)).val = (0 : zmod (n+1)).val ↔ _,
-    rw [val_cast_nat, val_zero, nat.dvd_iff_mod_eq_zero],
+    rw [val_nat_cast, val_zero, nat.dvd_iff_mod_eq_zero],
   end }
 
-@[simp] lemma cast_self (n : ℕ) : (n : zmod n) = 0 :=
+@[simp] lemma nat_cast_self (n : ℕ) : (n : zmod n) = 0 :=
 char_p.cast_eq_zero (zmod n) n
 
-@[simp] lemma cast_self' (n : ℕ) : (n + 1 : zmod (n + 1)) = 0 :=
-by rw [← nat.cast_add_one, cast_self (n + 1)]
+@[simp] lemma nat_cast_self' (n : ℕ) : (n + 1 : zmod (n + 1)) = 0 :=
+by rw [← nat.cast_add_one, nat_cast_self (n + 1)]
 
 section universal_property
 
@@ -423,7 +423,7 @@ begin
 end
 
 @[push_cast, simp]
-lemma cast_mod_int (a : ℤ) (b : ℕ) : ((a % b : ℤ) : zmod b) = (a : zmod b) :=
+lemma int_cast_mod (a : ℤ) (b : ℕ) : ((a % b : ℤ) : zmod b) = (a : zmod b) :=
 begin
   rw zmod.int_coe_eq_int_coe_iff,
   apply int.modeq.mod_modeq,
@@ -431,7 +431,7 @@ end
 
 local attribute [semireducible] int.nonneg
 
-@[simp] lemma coe_to_nat (p : ℕ) :
+@[simp] lemma nat_cast_to_nat (p : ℕ) :
   ∀ {z : ℤ} (h : 0 ≤ z), (z.to_nat : zmod p) = z
 | (n : ℕ) h := by simp only [int.cast_coe_nat, int.to_nat_coe_nat]
 | -[1+n]  h := false.elim h
@@ -447,7 +447,7 @@ begin
 end
 
 lemma val_one_eq_one_mod (n : ℕ) : (1 : zmod n).val = 1 % n :=
-by rw [← nat.cast_one, val_cast_nat]
+by rw [← nat.cast_one, val_nat_cast]
 
 lemma val_one (n : ℕ) [fact (1 < n)] : (1 : zmod n).val = 1 :=
 by { rw val_one_eq_one_mod, exact nat.mod_eq_of_lt ‹1 < n› }
@@ -494,27 +494,27 @@ begin
              ... = a.nat_abs   : by rw [int.mul_sign, int.nat_cast_eq_coe_nat]
              ... = a.val.gcd 0 : by rw nat.gcd_zero_right; refl },
   { set k := n.succ,
-    calc a * a⁻¹ = a * a⁻¹ + k * nat.gcd_b (val a) k : by rw [cast_self, zero_mul, add_zero]
+    calc a * a⁻¹ = a * a⁻¹ + k * nat.gcd_b (val a) k : by rw [nat_cast_self, zero_mul, add_zero]
              ... = ↑(↑a.val * nat.gcd_a (val a) k + k * nat.gcd_b (val a) k) :
                      by { push_cast, rw nat_cast_zmod_val, refl }
              ... = nat.gcd a.val k : (congr_arg coe (nat.gcd_eq_gcd_ab a.val k)).symm, }
 end
 
-@[simp] lemma cast_mod_nat (n : ℕ) (a : ℕ) : ((a % n : ℕ) : zmod n) = a :=
+@[simp] lemma nat_cast_mod (n : ℕ) (a : ℕ) : ((a % n : ℕ) : zmod n) = a :=
 by conv {to_rhs, rw ← nat.mod_add_div a n}; simp
 
 lemma eq_iff_modeq_nat (n : ℕ) {a b : ℕ} : (a : zmod n) = b ↔ a ≡ b [MOD n] :=
 begin
   cases n,
   { simp only [nat.modeq, int.coe_nat_inj', nat.mod_zero, int.nat_cast_eq_coe_nat], },
-  { rw [fin.ext_iff, nat.modeq, ← val_cast_nat, ← val_cast_nat], exact iff.rfl, }
+  { rw [fin.ext_iff, nat.modeq, ← val_nat_cast, ← val_nat_cast], exact iff.rfl, }
 end
 
 lemma coe_mul_inv_eq_one {n : ℕ} (x : ℕ) (h : nat.coprime x n) :
   (x * x⁻¹ : zmod n) = 1 :=
 begin
   rw [nat.coprime, nat.gcd_comm, nat.gcd_rec] at h,
-  rw [mul_inv_eq_gcd, val_cast_nat, h, nat.cast_one],
+  rw [mul_inv_eq_gcd, val_nat_cast, h, nat.cast_one],
 end
 
 /-- `unit_of_coprime` makes an element of `units (zmod n)` given
@@ -522,7 +522,7 @@ end
 def unit_of_coprime {n : ℕ} (x : ℕ) (h : nat.coprime x n) : units (zmod n) :=
 ⟨x, x⁻¹, coe_mul_inv_eq_one x h, by rw [mul_comm, coe_mul_inv_eq_one x h]⟩
 
-@[simp] lemma cast_unit_of_coprime {n : ℕ} (x : ℕ) (h : nat.coprime x n) :
+@[simp] lemma coe_unit_of_coprime {n : ℕ} (x : ℕ) (h : nat.coprime x n) :
   (unit_of_coprime x h : zmod n) = x := rfl
 
 lemma val_coe_unit_coprime {n : ℕ} (u : units (zmod n)) :
@@ -535,7 +535,7 @@ begin
   rw [units.coe_one] at this,
   rw [← eq_iff_modeq_nat, nat.cast_one, ← this], clear this,
   rw [← nat_cast_zmod_val ((u * u⁻¹ : units (zmod (n+1))) : zmod (n+1))],
-  rw [units.coe_mul, val_mul, cast_mod_nat],
+  rw [units.coe_mul, val_mul, nat_cast_mod],
 end
 
 @[simp] lemma inv_coe_unit {n : ℕ} (u : units (zmod n)) :
@@ -587,7 +587,7 @@ begin
     { let u := unit_of_coprime b hb.2.symm,
       exact val_coe_unit_coprime u },
     { show zmod.val (b : zmod n) = b,
-      rw [val_cast_nat, nat.mod_eq_of_lt hb.1], } }
+      rw [val_nat_cast, nat.mod_eq_of_lt hb.1], } }
 end
 
 end totient
@@ -616,9 +616,9 @@ begin
     rw ← zmod.nat_cast_zmod_val x at hx0,
     exact nat.pos_of_ne_zero (λ h, by simpa [h] using hx0) },
   by conv {to_rhs, rw [← nat.succ_le_iff, nat.succ_eq_add_one, ← hn2', ← zero_add (- x),
-    ← zmod.cast_self, ← sub_eq_add_neg, ← zmod.nat_cast_zmod_val x,
+    ← zmod.nat_cast_self, ← sub_eq_add_neg, ← zmod.nat_cast_zmod_val x,
     ← nat.cast_sub (le_of_lt x.val_lt),
-    zmod.val_cast_nat, nat.mod_eq_of_lt hxn, nat.sub_le_sub_left_iff (le_of_lt x.val_lt)] }
+    zmod.val_nat_cast, nat.mod_eq_of_lt hxn, nat.sub_le_sub_left_iff (le_of_lt x.val_lt)] }
 end
 
 lemma ne_neg_self (n : ℕ) [hn : fact ((n : ℕ) % 2 = 1)] {a : zmod n} (ha : a ≠ 0) : a ≠ -a :=
@@ -643,7 +643,7 @@ end
 | (n+1) a := by { rw fin.ext_iff, exact iff.rfl }
 
 lemma val_cast_of_lt {n : ℕ} {a : ℕ} (h : a < n) : (a : zmod n).val = a :=
-by rw [val_cast_nat, nat.mod_eq_of_lt h]
+by rw [val_nat_cast, nat.mod_eq_of_lt h]
 
 lemma neg_val' {n : ℕ} [fact (0 < n)] (a : zmod n) : (-a).val = (n - a.val) % n :=
 begin
@@ -687,7 +687,7 @@ begin
   rw val_min_abs_def_pos,
   split_ifs,
   { rw [int.cast_coe_nat, nat_cast_zmod_val] },
-  { rw [int.cast_sub, int.cast_coe_nat, nat_cast_zmod_val, int.cast_coe_nat, cast_self, sub_zero] }
+  { rw [int.cast_sub, int.cast_coe_nat, nat_cast_zmod_val, int.cast_coe_nat, nat_cast_self, sub_zero] }
 end
 
 lemma nat_abs_val_min_abs_le {n : ℕ} [fact (0 < n)] (x : zmod n) : x.val_min_abs.nat_abs ≤ n / 2 :=
@@ -724,7 +724,7 @@ begin
   { rintro rfl, rw val_min_abs_zero }
 end
 
-lemma cast_nat_abs_val_min_abs {n : ℕ} [fact (0 < n)] (a : zmod n) :
+lemma nat_cast_nat_abs_val_min_abs {n : ℕ} [fact (0 < n)] (a : zmod n) :
   (a.val_min_abs.nat_abs : zmod n) = if a.val ≤ (n : ℕ) / 2 then a else -a :=
 begin
   have : (a.val : ℤ) - n ≤ 0,
@@ -733,7 +733,7 @@ begin
   split_ifs,
   { rw [int.nat_abs_of_nat, nat_cast_zmod_val] },
   { rw [← int.cast_coe_nat, int.of_nat_nat_abs_of_nonpos this, int.cast_neg, int.cast_sub],
-    rw [int.cast_coe_nat, int.cast_coe_nat, cast_self, sub_zero, nat_cast_zmod_val], }
+    rw [int.cast_coe_nat, int.cast_coe_nat, nat_cast_self, sub_zero, nat_cast_zmod_val], }
 end
 
 @[simp] lemma nat_abs_val_min_abs_neg {n : ℕ} (a : zmod n) :

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -207,8 +207,7 @@ end
 /-- So-named because the coercion is `nat.cast` into `zmod`. For `nat.cast` into an arbitrary ring,
 see `zmod.nat_cast_val`. -/
 @[simp]
-lemma nat_cast_zmod_val {n : ℕ} [fact (0 < n)] (a : zmod n) :
-  (a.val : zmod n) = a :=
+lemma nat_cast_zmod_val {n : ℕ} [fact (0 < n)] (a : zmod n) : (a.val : zmod n) = a :=
 begin
   casesI n,
   { exfalso, exact nat.not_lt_zero 0 ‹0 < 0› },
@@ -216,23 +215,20 @@ begin
     rw [val, fin.ext_iff, fin.coe_coe_eq_self] }
 end
 
-lemma nat_cast_zmod_surjective [fact (0 < n)] :
-  function.surjective (coe : ℕ → zmod n) :=
+lemma nat_cast_zmod_surjective [fact (0 < n)] : function.surjective (coe : ℕ → zmod n) :=
 function.right_inverse.surjective nat_cast_zmod_val
 
 /-- So-named because the outer coercion is `int.cast` into `zmod`. For `int.cast` into an arbitrary
 ring, see `zmod.int_cast_cast`. -/
 @[simp]
-lemma int_cast_zmod_cast (a : zmod n) :
-  ((a : ℤ) : zmod n) = a :=
+lemma int_cast_zmod_cast (a : zmod n) : ((a : ℤ) : zmod n) = a :=
 begin
   cases n,
   { rw [int.cast_id a, int.cast_id a], },
   { rw [coe_coe, int.nat_cast_eq_coe_nat, int.cast_coe_nat, fin.coe_coe_eq_self] }
 end
 
-lemma int_cast_surjective :
-  function.surjective (coe : ℤ → zmod n) :=
+lemma int_cast_surjective : function.surjective (coe : ℤ → zmod n) :=
 function.right_inverse.surjective int_cast_zmod_cast
 
 @[norm_cast]
@@ -255,8 +251,7 @@ begin
 end
 
 /-- The coercions are respectively `int.cast`, `zmod.cast`, and `zmod.cast`. -/
-@[simp] lemma int_cast_comp_cast :
-  (coe : ℤ → R) ∘ (coe : zmod n → ℤ) = coe :=
+@[simp] lemma int_cast_comp_cast : (coe : ℤ → R) ∘ (coe : zmod n → ℤ) = coe :=
 begin
   cases n,
   { exact congr_arg ((∘) int.cast) zmod.cast_id', },
@@ -265,12 +260,10 @@ end
 
 variables {R}
 
-@[simp] lemma nat_cast_val [fact (0 < n)] (i : zmod n) :
-  (i.val : R) = i :=
+@[simp] lemma nat_cast_val [fact (0 < n)] (i : zmod n) : (i.val : R) = i :=
 congr_fun (nat_cast_comp_val R) i
 
-@[simp] lemma int_cast_cast (i : zmod n) :
-  ((i : ℤ) : R) = i :=
+@[simp] lemma int_cast_cast (i : zmod n) : ((i : ℤ) : R) = i :=
 congr_fun (int_cast_comp_cast R) i
 
 section char_dvd

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -814,13 +814,13 @@ instance subsingleton_ring_hom [semiring R] : subsingleton ((zmod n) →+* R) :=
 instance subsingleton_ring_equiv [semiring R] : subsingleton (zmod n ≃+* R) :=
 ⟨λ f g, by { rw ring_equiv.coe_ring_hom_inj_iff, apply ring_hom.ext_zmod _ _ }⟩
 
-@[simp] lemma ring_hom_map_coe [ring R] (f : R →+* (zmod n)) (k : zmod n) :
+@[simp] lemma ring_hom_map_cast [ring R] (f : R →+* (zmod n)) (k : zmod n) :
   f k = k :=
 by { cases n; simp }
 
 lemma ring_hom_surjective [ring R] (f : R →+* (zmod n)) :
   function.surjective f :=
-function.right_inverse.surjective (ring_hom_map_coe f)
+function.right_inverse.surjective (ring_hom_map_cast f)
 
 lemma ring_hom_eq_of_ker_eq [comm_ring R] (f g : R →+* (zmod n))
   (h : f.ker = g.ker) : f = g :=

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -206,7 +206,6 @@ end
 
 /-- So-named because the coercion is `nat.cast` into `zmod`. For `nat.cast` into an arbitrary ring,
 see `zmod.nat_cast_val`. -/
-@[simp]
 lemma nat_cast_zmod_val {n : ℕ} [fact (0 < n)] (a : zmod n) : (a.val : zmod n) = a :=
 begin
   casesI n,
@@ -220,7 +219,6 @@ function.right_inverse.surjective nat_cast_zmod_val
 
 /-- So-named because the outer coercion is `int.cast` into `zmod`. For `int.cast` into an arbitrary
 ring, see `zmod.int_cast_cast`. -/
-@[simp]
 lemma int_cast_zmod_cast (a : zmod n) : ((a : ℤ) : zmod n) = a :=
 begin
   cases n,

--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -268,7 +268,7 @@ lemma prime_of_nat_prime_of_mod_four_eq_three (p : ℕ) [hp : fact p.prime] (hp3
   prime (p : ℤ[i]) :=
 irreducible_iff_prime.1 $ classical.by_contradiction $ λ hpi,
   let ⟨a, b, hab⟩ := sum_two_squares_of_nat_prime_of_not_irreducible p hpi in
-have ∀ a b : zmod 4, a^2 + b^2 ≠ p, by erw [← zmod.cast_mod_nat 4 p, hp3]; exact dec_trivial,
+have ∀ a b : zmod 4, a^2 + b^2 ≠ p, by erw [← zmod.nat_cast_mod 4 p, hp3]; exact dec_trivial,
 this a b (hab ▸ by simp)
 
 /-- A prime natural number is prime in `ℤ[i]` if and only if it is `3` mod `4` -/

--- a/src/data/zsqrtd/gaussian_int.lean
+++ b/src/data/zsqrtd/gaussian_int.lean
@@ -215,7 +215,7 @@ hp.eq_two_or_odd.elim
       by rw hp41; exact dec_trivial in
     begin
       obtain ⟨k, k_lt_p, rfl⟩ : ∃ (k' : ℕ) (h : k' < p), (k' : zmod p) = k,
-      { refine ⟨k.val, k.val_lt, zmod.cast_val k⟩ },
+      { refine ⟨k.val, k.val_lt, zmod.nat_cast_zmod_val k⟩ },
       have hpk : p ∣ k ^ 2 + 1,
         by rw [← char_p.cast_eq_zero_iff (zmod p) p]; simp *,
       have hkmul : (k ^ 2 + 1 : ℤ[i]) = ⟨k, 1⟩ * ⟨k, -1⟩ :=

--- a/src/field_theory/finite/basic.lean
+++ b/src/field_theory/finite/basic.lean
@@ -288,7 +288,7 @@ begin
   have := zmod.pow_totient x',
   apply_fun (coe : units (zmod (n+1)) → zmod (n+1)) at this,
   simpa only [-zmod.pow_totient, nat.succ_eq_add_one, nat.cast_pow, units.coe_one,
-    nat.cast_one, cast_unit_of_coprime, units.coe_pow],
+    nat.cast_one, coe_unit_of_coprime, units.coe_pow],
 end
 
 open finite_field

--- a/src/group_theory/dihedral.lean
+++ b/src/group_theory/dihedral.lean
@@ -171,7 +171,7 @@ If `0 < n`, then `i : zmod n` has order `n / gcd n i`
 -/
 lemma order_of_r [fact (0 < n)] (i : zmod n) : order_of (r i) = n / nat.gcd n i.val :=
 begin
-  conv_lhs { rw ←zmod.cast_val i },
+  conv_lhs { rw ←zmod.nat_cast_zmod_val i },
   rw [←r_one_pow, order_of_pow, order_of_r_one]
 end
 

--- a/src/group_theory/dihedral.lean
+++ b/src/group_theory/dihedral.lean
@@ -161,7 +161,7 @@ begin
     { exact pow_order_of_eq_one _ },
     rw r_one_pow at h1,
     injection h1 with h2,
-    rw [←zmod.val_eq_zero, zmod.val_cast_nat, nat.mod_eq_of_lt h] at h2,
+    rw [←zmod.val_eq_zero, zmod.val_nat_cast, nat.mod_eq_of_lt h] at h2,
     exact absurd h2.symm (ne_of_lt (order_of_pos _)) },
   { exact h }
 end

--- a/src/group_theory/dihedral.lean
+++ b/src/group_theory/dihedral.lean
@@ -135,7 +135,7 @@ begin
   { rw pow_zero },
   { rw [r_one_pow, one_def],
     congr' 1,
-    exact zmod.cast_self _, }
+    exact zmod.nat_cast_self _, }
 end
 
 @[simp] lemma sr_mul_self (i : zmod n) : sr i * sr i = 1 := by rw [sr_mul_sr, sub_self, one_def]

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -163,7 +163,7 @@ have hx : x ≠ list.repeat (1 : G) p, from λ h, by simpa [h, vector.repeat] us
 have ∃ a, x = list.repeat a x.length := by exactI rotate_eq_self_iff_eq_repeat.1 (λ n,
   have list.rotate x (n : zmod p).val = x :=
     subtype.mk.inj (subtype.mk.inj (hx₃ (n : zmod p))),
-  by rwa [zmod.val_cast_nat, ← hx₁, rotate_mod] at this),
+  by rwa [zmod.val_nat_cast, ← hx₁, rotate_mod] at this),
 let ⟨a, ha⟩ := this in
 ⟨a, have hx1 : x.prod = 1 := hx₂,
   have ha1: a ≠ 1, from λ h, hx (ha.symm ▸ h ▸ hx₁ ▸ rfl),

--- a/src/number_theory/quadratic_reciprocity.lean
+++ b/src/number_theory/quadratic_reciprocity.lean
@@ -162,7 +162,7 @@ begin
       simp only [div_eq_mul_inv, hap, char_p.cast_eq_zero_iff (zmod p) p, hpe hb, not_false_iff,
         val_min_abs_eq_zero, inv_eq_zero, int.nat_abs_eq_zero, ne.def, mul_eq_zero, or_self] },
       { apply lt_succ_of_le, apply nat_abs_val_min_abs_le },
-      { rw cast_nat_abs_val_min_abs,
+      { rw nat_cast_nat_abs_val_min_abs,
         split_ifs,
         { erw [mul_div_cancel' _ hap, val_min_abs_def_pos, val_cast_of_lt (hep hb),
             if_pos (le_of_lt_succ (Ico.mem.1 hb).2), int.nat_abs_of_nat], },
@@ -188,7 +188,7 @@ calc (a ^ (p / 2) * (p / 2)! : zmod p) =
     (if (a * x : zmod p).val ≤ p / 2 then 1 else -1) *
       (a * x : zmod p).val_min_abs.nat_abs) :
   prod_congr rfl $ λ _ _, begin
-    simp only [cast_nat_abs_val_min_abs],
+    simp only [nat_cast_nat_abs_val_min_abs],
     split_ifs; simp
   end
 ... = (-1)^((Ico 1 (p / 2).succ).filter
@@ -233,7 +233,7 @@ calc ((∑ x in Ico 1 (p / 2).succ, a * x : ℕ) : zmod 2)
   by simp only [mod_add_div]
 ... = (∑ x in Ico 1 (p / 2).succ, ((a * x : ℕ) : zmod p).val : ℕ) +
     (∑ x in Ico 1 (p / 2).succ, (a * x) / p : ℕ) :
-  by simp only [val_cast_nat];
+  by simp only [val_nat_cast];
     simp [sum_add_distrib, mul_sum.symm, nat.cast_add, nat.cast_mul, sum_nat_cast, hp2]
 ... = _ : congr_arg2 (+)
   (calc ((∑ x in Ico 1 (p / 2).succ, ((a * x : ℕ) : zmod p).val : ℕ) : zmod 2)

--- a/src/number_theory/sum_four_squares.lean
+++ b/src/number_theory/sum_four_squares.lean
@@ -154,7 +154,7 @@ m.mod_two_eq_zero_or_one.elim
           ((a^2 + b^2 + c^2 + d^2 : ℤ) : zmod m),
         by simp [w, x, y, z, pow_two],
       have hwxyz0 : ((w^2 + x^2 + y^2 + z^2 : ℤ) : zmod m) = 0,
-        by rw [hwxyzabcd, habcd, int.cast_mul, cast_coe_nat, zmod.cast_self, zero_mul],
+        by rw [hwxyzabcd, habcd, int.cast_mul, cast_coe_nat, zmod.nat_cast_self, zero_mul],
       let ⟨n, hn⟩ := ((char_p.int_cast_eq_zero_iff _ m _).1 hwxyz0) in
       have hn0 : 0 < n.nat_abs, from int.nat_abs_pos_of_ne_zero (λ hn0,
         have hwxyz0 : (w.nat_abs^2 + x.nat_abs^2 + y.nat_abs^2 + z.nat_abs^2 : ℕ) = 0,

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -609,7 +609,7 @@ begin
   suffices hpow : eval (nat.cast_ring_hom (zmod p) a) (X ^ n - 1 : polynomial (zmod p)) = 0,
   { simp only [eval_X, eval_one, eval_pow, eval_sub, ring_hom.eq_nat_cast] at hpow,
     apply units.coe_eq_one.1,
-    simp only [sub_eq_zero.mp hpow, zmod.cast_unit_of_coprime, units.coe_pow] },
+    simp only [sub_eq_zero.mp hpow, zmod.coe_unit_of_coprime, units.coe_pow] },
   rw [is_root.def] at hroot,
   rw [← prod_cyclotomic_eq_X_pow_sub_one hpos (zmod p),
     nat.divisors_eq_proper_divisors_insert_self_of_pos hpos,
@@ -635,7 +635,7 @@ begin
     { exact dvd_trans hdivm (X_pow_sub_one_dvd_prod_cyclotomic (zmod p) hpos
         (order_of_root_cyclotomic_dvd hpos hroot) hdiff) },
     rw [map_sub, map_X, map_nat_cast, ← C_eq_nat_cast, dvd_iff_is_root, is_root.def, eval_sub,
-      eval_pow, eval_one, eval_X, sub_eq_zero, ← zmod.cast_unit_of_coprime a ha, ← units.coe_pow,
+      eval_pow, eval_one, eval_X, sub_eq_zero, ← zmod.coe_unit_of_coprime a ha, ← units.coe_pow,
       units.coe_eq_one],
     exact pow_order_of_eq_one (zmod.unit_of_coprime a ha) },
   have habs : (map (int.cast_ring_hom (zmod p)) (X - a)) ^ 2 ∣ X ^ n - 1,

--- a/src/ring_theory/witt_vector/frobenius.lean
+++ b/src/ring_theory/witt_vector/frobenius.lean
@@ -200,7 +200,7 @@ lemma frobenius_poly_zmod (n : ℕ) :
   mv_polynomial.map (int.cast_ring_hom (zmod p)) (frobenius_poly p n) = X n ^ p :=
 begin
   rw [frobenius_poly, ring_hom.map_add, ring_hom.map_pow, ring_hom.map_mul, map_X, map_C],
-  simp only [int.cast_coe_nat, add_zero, ring_hom.eq_int_cast, zmod.cast_self, zero_mul, C_0],
+  simp only [int.cast_coe_nat, add_zero, ring_hom.eq_int_cast, zmod.nat_cast_self, zero_mul, C_0],
 end
 
 @[simp]


### PR DESCRIPTION
Split from #5797. This takes the new proofs without introducing the objectionable names.

This also renames a bunch of lemmas from `zmod.cast_*` to `zmod.nat_cast_*` and `zmod.int_cast_*`, in order to distinguish lemmas about `zmod.cast` from lemmas about `nat.cast` and `int.cast` applied with a zmod argument.

As an example, `zmod.cast_val` has been renamed to `zmod.nat_cast_zmod_val`, as the lemma statement is defeq to `(nat.cast : ℕ → zmod n) (zmod.val x) = x`, and `zmod.nat_cast_val` is already taken by `nat.cast (zmod.val x) = (x : R)`.

The full list of renames:
* `zmod.cast_val` → `zmod.nat_cast_zmod_val`
* `zmod.cast_self` → `zmod.nat_cast_self`
* `zmod.cast_self'` → `zmod.nat_cast_self'`
* `zmod.cast_mod_nat` → `zmod.nat_cast_mod`
* `zmod.cast_mod_int` → `zmod.int_cast_mod`
* `zmod.val_cast_nat` → `zmod.val_nat_cast`
* `zmod.coe_to_nat` → `zmod.nat_cast_to_nat`
* `zmod.cast_unit_of_coprime` → `coe_unit_of_coprime`
* `zmod.cast_nat_abs_val_min_abs` → `zmod.nat_cast_nat_abs_val_min_abs`
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
