### PR TITLE
[Merged by Bors] - fix(doc/references.bib): fix syntax

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -315,9 +315,9 @@ journal = {The American Mathematical Monthly},
 volume = 110,
 number = 7,
 publisher = {Taylor & Francis, Ltd. on behalf of the Mathematical Association of America},
-pages = 633-635,
-url = https://www.jstor.org/stable/3647749,
-doi = 10.2307/3647749
+pages = {633-635},
+url = {https://www.jstor.org/stable/3647749},
+doi = {10.2307/3647749}
 }
 
 @book{aluffi2016,


### PR DESCRIPTION

---
Noticed this when testing something for https://github.com/leanprover-community/doc-gen/issues/61.

Maybe we need a `.bib` checking step?