### PR TITLE
[Merged by Bors] - perf(tactic/lint/frontend): run linters in parallel

### DIFF
--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -908,4 +908,24 @@ to_rb_map ['a', 'b', 'c'] = rb_map.of_list [(0, 'a'), (1, 'b'), (2, 'c')]
 meta def to_rb_map {α : Type} : list α → rb_map ℕ α :=
 foldl_with_index (λ i mapp a, mapp.insert i a) mk_rb_map
 
+/--
+`xs.to_chunks n` splits the list into sublists of size at most `n`,
+such that `(xs.to_chunks n).join = xs`.
+
+TODO: make non-meta; currently doesn't terminate, e.g.
+```
+#eval [0].to_chunks 0
+```
+-/
+meta def to_chunks {α} (n : ℕ) : list α → list (list α)
+| [] := []
+| xs :=
+  xs.take n :: (xs.drop n).to_chunks
+
+/--
+Asynchronous version of `list.map`.
+-/
+meta def map_async_chunked {α β} (f : α → β) (xs : list α) (chunk_size := 1024) : list β :=
+((xs.to_chunks chunk_size).map (λ xs, task.delay (λ _, list.map f xs))).bind task.get
+
 end list

--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -71,20 +71,6 @@ meta def get_checks (slow : bool) (extra : list name) (use_only : bool) :
   list.append default <$> get_linters extra
 
 /--
-`xs.to_chunks n` splits the list into sublists of size at most `n`,
-such that `(xs.to_chunks n).join = xs`.
--/
-meta def list.to_chunks {α} (n : ℕ) : list α → list (list α)
-| [] := []
-| xs := xs.take n :: (xs.drop n).to_chunks
-
-/--
-Asynchronous version of `list.map`.
--/
-meta def list.map_async_chunked {α β} (f : α → β) (xs : list α) (chunk_size := 1024) : list β :=
-((xs.to_chunks chunk_size).map (λ xs, task.delay (λ _, list.map f xs))).bind task.get
-
-/--
 `lint_core all_decls non_auto_decls checks` applies the linters `checks` to the list of
 declarations.
 If `auto_decls` is false for a linter (default) the linter is applied to `non_auto_decls`.


### PR DESCRIPTION
With this change it takes 5 minutes instead of 33 minutes to lint mathlib (on my machine...).

https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/linting.20time

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
