### PR TITLE
[Merged by Bors] - chore(data/matrix/basic): instances for unique, subsing, nontriv, coe

### DIFF
--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -82,15 +82,6 @@ instance [subsingleton α] : subsingleton (matrix m n α) := pi.subsingleton
 instance [nonempty m] [nonempty n] [nontrivial α] : nontrivial (matrix m n α) :=
 function.nontrivial
 
-/--
-A 1 × 1 `matrix` can be considered as a value of the underlying scalar.
--/
-instance [unique n] [unique m] : has_coe (matrix m n α) α := ⟨λ M, M (default _) (default _)⟩
-
-/--
-A 1 × 1 `matrix` can be considered as a value of the underlying scalar.
--/
-lemma coe_def [unique n] [unique m] (M : matrix m n α) : (M : α) = M (default _) (default _) := rfl
 
 @[simp] theorem zero_apply [has_zero α] (i j) : (0 : matrix m n α) i j = 0 := rfl
 @[simp] theorem neg_apply [has_neg α] (M : matrix m n α) (i j) : (- M) i j = - M i j := rfl

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -79,7 +79,7 @@ instance [add_group α] : add_group (matrix m n α) := pi.add_group
 instance [add_comm_group α] : add_comm_group (matrix m n α) := pi.add_comm_group
 instance [unique α] : unique (matrix m n α) := pi.unique
 instance [subsingleton α] : subsingleton (matrix m n α) := pi.subsingleton
-instance [inhabited m] [inhabited n] [nontrivial α] : nontrivial (matrix m n α) :=
+instance [nonempty m] [nonempty n] [nontrivial α] : nontrivial (matrix m n α) :=
 function.nontrivial
 
 /--

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -82,7 +82,6 @@ instance [subsingleton α] : subsingleton (matrix m n α) := pi.subsingleton
 instance [nonempty m] [nonempty n] [nontrivial α] : nontrivial (matrix m n α) :=
 function.nontrivial
 
-
 @[simp] theorem zero_apply [has_zero α] (i j) : (0 : matrix m n α) i j = 0 := rfl
 @[simp] theorem neg_apply [has_neg α] (M : matrix m n α) (i j) : (- M) i j = - M i j := rfl
 @[simp] theorem add_apply [has_add α] (M N : matrix m n α) (i j) :

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -77,6 +77,20 @@ instance [has_neg α] : has_neg (matrix m n α) := pi.has_neg
 instance [has_sub α] : has_sub (matrix m n α) := pi.has_sub
 instance [add_group α] : add_group (matrix m n α) := pi.add_group
 instance [add_comm_group α] : add_comm_group (matrix m n α) := pi.add_comm_group
+instance [unique α] : unique (matrix m n α) := pi.unique
+instance [subsingleton α] : subsingleton (matrix m n α) := pi.subsingleton
+instance [inhabited m] [inhabited n] [nontrivial α] : nontrivial (matrix m n α) :=
+function.nontrivial
+
+/--
+A 1 × 1 `matrix` can be considered as a value of the underlying scalar.
+-/
+instance [unique n] [unique m] : has_coe (matrix m n α) α := ⟨λ M, M (default _) (default _)⟩
+
+/--
+A 1 × 1 `matrix` can be considered as a value of the underlying scalar.
+-/
+lemma coe_def [unique n] [unique m] (M : matrix m n α) : (M : α) = M (default _) (default _) := rfl
 
 @[simp] theorem zero_apply [has_zero α] (i j) : (0 : matrix m n α) i j = 0 := rfl
 @[simp] theorem neg_apply [has_neg α] (M : matrix m n α) (i j) : (- M) i j = - M i j := rfl


### PR DESCRIPTION
This adds a coercion to the underlying scalar if the matrix is 1 x 1.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Should `coe_def` be simp tagged?

Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/nontrivial.20matrices