### PR TITLE
[Merged by Bors] - fix(tactic/push_neg): fully simplify expressions not named `h`

### DIFF
--- a/src/tactic/push_neg.lean
+++ b/src/tactic/push_neg.lean
@@ -142,13 +142,16 @@ at every assumption and the goal using `push_neg at *` or at selected assumption
 using say `push_neg at h h' ⊢` as usual.
 -/
 meta def tactic.interactive.push_neg : parse location → tactic unit
-| (loc.ns loc_l) := loc_l.mmap'
-                      (λ l, match l with
-                            | some h := do push_neg_at_hyp h,
-                                            try `[simp only [push_neg.not_eq] at h { eta := ff }]
-                            | none   := do push_neg_at_goal,
-                                            try `[simp only [push_neg.not_eq] { eta := ff }]
-                            end)
+| (loc.ns loc_l) :=
+  loc_l.mmap'
+    (λ l, match l with
+          | some h := do push_neg_at_hyp h,
+                          try $ interactive.simp_core { eta := ff } failed tt
+                                 [simp_arg_type.expr ``(push_neg.not_eq)] []
+                                 (interactive.loc.ns [some h])
+          | none   := do push_neg_at_goal,
+                          try `[simp only [push_neg.not_eq] { eta := ff }]
+          end)
 | loc.wildcard := do
     push_neg_at_goal,
     local_context >>= mmap' (λ h, push_neg_at_hyp (local_pp_name h)) ,

--- a/test/push_neg.lean
+++ b/test/push_neg.lean
@@ -77,3 +77,16 @@ begin
     "contrapose only applies to nondependent arrows between props",
   intro, refl
 end
+
+open tactic
+example (X : Type) (f : X → ℕ) (h : ¬∀ x, f x = 0) (hf : false) : false :=
+begin
+  have h1 := h,
+  -- h h1: ¬∀ (x : X), f x = 0
+  push_neg at h,
+  push_neg at h1,
+  (do ht ← get_local `h >>= infer_type,
+      h1t ← get_local `h1 >>= infer_type,
+      guard (ht = h1t) ),
+  exact hf
+end


### PR DESCRIPTION
A final pass of `push_neg` is intended to turn `¬ a = b` into `a ≠ b`.
Unfortunately, when you use `push_neg at ...`, this is applied to the hypothesis literally named `h`.


[Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60push_neg.60.20behaviour.20depends.20on.20variable.20name)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
