### PR TITLE
[Merged by Bors] - fix(lint/type_classes): fix instance_priority bug

### DIFF
--- a/src/tactic/lint/type_classes.lean
+++ b/src/tactic/lint/type_classes.lean
@@ -45,7 +45,9 @@ private meta def instance_priority (d : declaration) : tactic (option string) :=
   (is_persistent, prio) ← has_attribute `instance nm,
   /- return `none` if `d` is has low priority -/
   if prio < 1000 then return none else do
-  let (fn, args) := d.type.pi_codomain.get_app_fn_args,
+  (_, tp) ← open_pis d.type,
+  tp ← whnf tp transparency.none,
+  let (fn, args) := tp.get_app_fn_args,
   cls ← get_decl fn.const_name,
   let (pi_args, _) := cls.type.pi_binders,
   guard (args.length = pi_args.length),
@@ -55,7 +57,7 @@ private meta def instance_priority (d : declaration) : tactic (option string) :=
   let relevant_args := (args.zip pi_args).filter_map $ λ⟨e, ⟨_, info, tp⟩⟩,
     if info = binder_info.inst_implicit ∨ tp.get_app_fn.is_constant_of `out_param
     then none else some e,
-  let always_applies := relevant_args.all expr.is_var ∧ relevant_args.nodup,
+  let always_applies := relevant_args.all expr.is_local_constant ∧ relevant_args.nodup,
   if always_applies then return $ some "set priority below 1000" else return none
 
 /--

--- a/test/lint.lean
+++ b/test/lint.lean
@@ -104,6 +104,12 @@ run_cmd do
   guard $ "maximum class-instance resolution depth has been reached".is_prefix_of s
 end
 
+instance beta_redex_test {α} [monoid α] : (λ (X : Type), has_mul X) α := ⟨(*)⟩
+run_cmd do
+  d ← get_decl `beta_redex_test,
+  x ← linter.instance_priority.test d,
+  guard $ x = some "set priority below 1000"
+
 /- test of `apply_to_fresh_variables` -/
 run_cmd do
   e ← mk_const `id,


### PR DESCRIPTION
The linter now doesn't fail if the type is a beta redex

---

Fixes error in #6278
