### PR TITLE
[Merged by Bors] - doc(ring_theory/witt_vector/witt_polynomial): move module docstring up

### DIFF
--- a/src/ring_theory/witt_vector/witt_polynomial.lean
+++ b/src/ring_theory/witt_vector/witt_polynomial.lean
@@ -10,17 +10,6 @@ import data.mv_polynomial.comm_ring
 import data.mv_polynomial.expand
 import data.zmod.basic
 
-open mv_polynomial
-open finset (hiding map)
-open finsupp (single)
-
-open_locale big_operators
-
-local attribute [-simp] coe_eval₂_hom
-
-variables (p : ℕ)
-variables (R : Type*) [comm_ring R]
-
 /-!
 # Witt polynomials
 
@@ -60,6 +49,17 @@ In this file we use the following notation
 * `W n` (and `W_ R n` when the ring needs to be explicit) denotes the `n`th Witt polynomial
 
 -/
+
+open mv_polynomial
+open finset (hiding map)
+open finsupp (single)
+
+open_locale big_operators
+
+local attribute [-simp] coe_eval₂_hom
+
+variables (p : ℕ)
+variables (R : Type*) [comm_ring R]
 
 /-- `witt_polynomial p R n` is the `n`-th Witt polynomial
 with respect to a prime `p` with coefficients in a commutative ring `R`.


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->