### PR TITLE
[Merged by Bors] - refactor(group_theory/free_*): remove API duplicated by lift, promote lift functions to equivs

### DIFF
--- a/src/algebra/category/Group/adjunctions.lean
+++ b/src/algebra/category/Group/adjunctions.lean
@@ -61,7 +61,7 @@ The free-forgetful adjunction for abelian groups.
 -/
 def adj : free ⊣ forget AddCommGroup.{u} :=
 adjunction.mk_of_hom_equiv
-{ hom_equiv := λ X G, free_abelian_group.hom_equiv X G,
+{ hom_equiv := λ X G, free_abelian_group.lift.symm,
   hom_equiv_naturality_left_symm' :=
   by { intros, ext, refl} }
 
@@ -90,7 +90,7 @@ def free : Type u ⥤ Group :=
 -/
 def adj : free ⊣ forget Group.{u} :=
 adjunction.mk_of_hom_equiv
-{ hom_equiv := λ X G, (free_group.lift X G).symm,
+{ hom_equiv := λ X G, free_group.lift.symm,
   hom_equiv_naturality_left_symm' := λ X Y G f g, begin ext1, refl end  }
 
 end Group

--- a/src/algebra/category/Group/adjunctions.lean
+++ b/src/algebra/category/Group/adjunctions.lean
@@ -110,7 +110,7 @@ def abelianize : Group.{u} ⥤ CommGroup.{u} :=
 /-- The abelianization-forgetful adjuction from `Group` to `CommGroup`.-/
 def abelianize_adj : abelianize ⊣ forget₂ CommGroup.{u} Group.{u} :=
 adjunction.mk_of_hom_equiv
-{ hom_equiv := λ G A, abelianization.hom_equiv,
+{ hom_equiv := λ G A, abelianization.lift.symm,
   hom_equiv_naturality_left_symm' := λ G H A f g, by { ext1, refl } }
 
 end abelianization

--- a/src/algebra/free_monoid.lean
+++ b/src/algebra/free_monoid.lean
@@ -52,6 +52,7 @@ def of (x : α) : free_monoid α := [x]
 @[to_additive]
 lemma of_def (x : α) : of x = [x] := rfl
 
+@[to_additive]
 lemma of_injective : function.injective (@of α) :=
 λ a b, list.head_eq_of_cons_eq
 
@@ -98,9 +99,11 @@ congr_fun (lift_comp_of f) x
 lemma lift_restrict (f : free_monoid α →* M) : lift (f ∘ of) = f :=
 lift.apply_symm_apply f
 
+@[to_additive]
 lemma comp_lift (g : M →* N) (f : α → M) : g.comp (lift f) = lift (g ∘ f) :=
 by { ext, simp }
 
+@[to_additive]
 lemma hom_map_lift (g : M →* N) (f : α → M) (x : free_monoid α) : g (lift f x) = lift (g ∘ f) x :=
 monoid_hom.ext_iff.1 (comp_lift g f) x
 

--- a/src/group_theory/abelianization.lean
+++ b/src/group_theory/abelianization.lean
@@ -75,8 +75,11 @@ end
 
 /-- If `f : G → A` is a group homomorphism to an abelian group, then `lift f` is the unique map from
   the abelianization of a `G` to `A` that factors through `f`. -/
-def lift : abelianization G →* A :=
-quotient_group.lift _ f (λ x h, f.mem_ker.2 $ commutator_subset_ker _ h)
+def lift : (G →* A) ≃ (abelianization G →* A) :=
+{ to_fun := λ f, quotient_group.lift _ f (λ x h, f.mem_ker.2 $ commutator_subset_ker _ h),
+  inv_fun := λ F, F.comp of,
+  left_inv := λ f, monoid_hom.ext $ λ x, rfl,
+  right_inv := λ F, monoid_hom.ext $ λ x, quotient_group.induction_on x $ λ z, rfl }
 
 @[simp] lemma lift.of (x : G) : lift f (of x) = f x :=
 rfl
@@ -105,22 +108,5 @@ begin
   rw h,
   refl,
 end
-
-section lift
-
-variables {B : Type v} [comm_group B]
-
-/-- The bijection underlying the abelianization-forgetful adjuction from groups to abelian groups.
--/
-@[simps]
-def hom_equiv : (abelianization G →* B) ≃ (G →* B) :=
-{ to_fun := λ f, { to_fun := f.1 ∘ abelianization.of ,
-  map_one' := by simp,
-  map_mul' := by simp } ,
-  inv_fun := λ g, abelianization.lift g,
-  left_inv := by { intro x, ext, simp },
-  right_inv := by { intro x, ext, simp } }
-
-end lift
 
 end abelianization

--- a/src/group_theory/abelianization.lean
+++ b/src/group_theory/abelianization.lean
@@ -100,13 +100,6 @@ variables {A : Type v} [monoid A]
 @[ext]
 theorem hom_ext (φ ψ : abelianization G →* A)
   (h : φ.comp of = ψ.comp of) : φ = ψ :=
-begin
-  ext x,
-  apply quotient_group.induction_on x,
-  intro z,
-  show φ.comp of z = _,
-  rw h,
-  refl,
-end
+monoid_hom.ext $ λ x, quotient_group.induction_on x $ monoid_hom.congr_fun h
 
 end abelianization

--- a/src/group_theory/free_abelian_group.lean
+++ b/src/group_theory/free_abelian_group.lean
@@ -32,10 +32,8 @@ Here we use the following variables: `(α β : Type*) (A : Type*) [add_comm_grou
 group it is `α →₀ ℤ`, the functions from `α` to `ℤ` such that all but finitely
 many elements get mapped to zero, however this is not how it is implemented.
 
-* `lift (f : α → A) : free_abelian_group α →+ A` : the group homomorphism induced
-by the map `f`.
-
-* `hom_equiv : (free_abelian_group α →+ A) ≃ (α → A)` : the bijection witnessing adjointness.
+* `lift : (α → A) ≃ free_abelian_group α →+ A` : the group homomorphism induced
+  by the map `α → A`; the bijection witnessing adjointness.
 
 * `map (f : α → β) : free_abelian_group α →+ free_abelian_group β` : functoriality
     of `free_abelian_group`

--- a/src/group_theory/free_abelian_group.lean
+++ b/src/group_theory/free_abelian_group.lean
@@ -32,8 +32,8 @@ Here we use the following variables: `(α β : Type*) (A : Type*) [add_comm_grou
 group it is `α →₀ ℤ`, the functions from `α` to `ℤ` such that all but finitely
 many elements get mapped to zero, however this is not how it is implemented.
 
-* `lift : (α → A) ≃ free_abelian_group α →+ A` : the group homomorphism induced
-  by the map `α → A`; the bijection witnessing adjointness.
+* `lift f : free_abelian_group α →+ A` : the group homomorphism induced
+  by the map `f : α → A`.
 
 * `map (f : α → β) : free_abelian_group α →+ free_abelian_group β` : functoriality
     of `free_abelian_group`

--- a/src/group_theory/free_abelian_group.lean
+++ b/src/group_theory/free_abelian_group.lean
@@ -106,19 +106,14 @@ end
 protected theorem unique (g : free_abelian_group α →+ β)
   (hg : ∀ x, g (of x) = f x) {x} :
   g x = lift f x :=
-@abelianization.lift.unique (free_group α) _ (multiplicative β) _
-  (@free_group.lift _ (multiplicative β) _ f) g.to_multiplicative
-  (λ x, @free_group.lift.unique α (multiplicative β) _ _
-    ((add_monoid_hom.to_multiplicative' g).comp abelianization.of)
-    hg x) _
+add_monoid_hom.congr_fun ((lift.symm_apply_eq).mp (funext hg : g ∘ of = f)) _
 
 /-- See note [partially-applied ext lemmas]. -/
 @[ext]
 protected theorem ext (g h : free_abelian_group α →+ β)
   (H : ∀ x, g (of x) = h (of x)) :
   g = h :=
-add_monoid_hom.ext $ λ x, (lift.unique (g ∘ of) g (λ _, rfl)).trans $
-eq.symm $ lift.unique _ _ $ λ x, eq.symm $ H x
+lift.symm.injective $ funext H
 
 lemma map_hom {α β γ} [add_comm_group β] [add_comm_group γ]
   (a : free_abelian_group α) (f : α → β) (g : β →+ γ) :

--- a/src/group_theory/free_abelian_group.lean
+++ b/src/group_theory/free_abelian_group.lean
@@ -93,7 +93,7 @@ abelianization.of $ free_group.of x
 /-- The map `free_abelian_group α →+ A` induced by a map of types `α → A`. -/
 def lift {β : Type v} [add_comm_group β] : (α → β) ≃ (free_abelian_group α →+ β) :=
 (@free_group.lift _ (multiplicative β) _).trans $
-  (@abelianization.hom_equiv _ _ (multiplicative β) _).symm.trans monoid_hom.to_additive
+  (@abelianization.lift _ _ (multiplicative β) _).trans monoid_hom.to_additive
 
 namespace lift
 variables {β : Type v} [add_comm_group β] (f : α → β)

--- a/src/group_theory/free_abelian_group.lean
+++ b/src/group_theory/free_abelian_group.lean
@@ -91,9 +91,9 @@ def of (x : α) : free_abelian_group α :=
 abelianization.of $ free_group.of x
 
 /-- The map `free_abelian_group α →+ A` induced by a map of types `α → A`. -/
-def lift {β : Type v} [add_comm_group β] (f : α → β) : free_abelian_group α →+ β :=
-(@abelianization.lift _ _ (multiplicative β) _
-  (monoid_hom.of (@free_group.to_group _ (multiplicative β) _ f))).to_additive
+def lift {β : Type v} [add_comm_group β] : (α → β) ≃ (free_abelian_group α →+ β) :=
+(@free_group.lift _ (multiplicative β) _).trans $
+  (@abelianization.hom_equiv _ _ (multiplicative β) _).symm.trans monoid_hom.to_additive
 
 namespace lift
 variables {β : Type v} [add_comm_group β] (f : α → β)
@@ -102,15 +102,15 @@ open free_abelian_group
 @[simp] protected lemma of (x : α) : lift f (of x) = f x :=
 begin
   convert @abelianization.lift.of (free_group α) _ (multiplicative β) _ _ _,
-  convert free_group.to_group.of.symm
+  convert free_group.lift.of.symm
 end
 
 protected theorem unique (g : free_abelian_group α →+ β)
   (hg : ∀ x, g (of x) = f x) {x} :
   g x = lift f x :=
 @abelianization.lift.unique (free_group α) _ (multiplicative β) _
-  (@free_group.to_group _ (multiplicative β) _ f) g.to_multiplicative
-  (λ x, @free_group.to_group.unique α (multiplicative β) _ _
+  (@free_group.lift _ (multiplicative β) _ f) g.to_multiplicative
+  (λ x, @free_group.lift.unique α (multiplicative β) _ _
     ((add_monoid_hom.to_multiplicative' g).comp abelianization.of)
     hg x) _
 
@@ -141,28 +141,11 @@ open_locale classical
 
 lemma of_injective : function.injective (of : α → free_abelian_group α) :=
 λ x y hoxy, classical.by_contradiction $ assume hxy : x ≠ y,
-  let f : free_abelian_group α →+ ℤ := lift (λ z, if x = z then 1 else 0) in
+  let f : free_abelian_group α →+ ℤ := lift (λ z, if x = z then (1 : ℤ) else 0) in
   have hfx1 : f (of x) = 1, from (lift.of _ _).trans $ if_pos rfl,
   have hfy1 : f (of y) = 1, from hoxy ▸ hfx1,
   have hfy0 : f (of y) = 0, from (lift.of _ _).trans $ if_neg hxy,
   one_ne_zero $ hfy1.symm.trans hfy0
-
-end
-
-section
-variables (X : Type*) (G : Type*) [add_comm_group G]
-
-/-- The bijection underlying the free-forgetful adjunction for abelian groups.-/
-def hom_equiv : (free_abelian_group X →+ G) ≃ (X → G) :=
-{ to_fun := λ f, f.1 ∘ of,
-  inv_fun := λ f, lift f,
-  left_inv := λ f, begin ext, simp end,
-  right_inv := λ f, funext $ λ x, lift.of f x }
-
-@[simp]
-lemma hom_equiv_apply (f) (x) : ((hom_equiv X G) f) x = f (of x) := rfl
-@[simp]
-lemma hom_equiv_symm_apply (f) (x) : ((hom_equiv X G).symm f) x = (lift f) x := rfl
 
 end
 

--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -19,7 +19,7 @@ functor from groups to types, see `algebra/category/Group/adjunctions`.
   modulo the relation `a * x * x⁻¹ * b = a * b`.
 * `mk`: the canonical quotient map `list (α × bool) → free_group α`.
 * `of`: the canoical injection `α → free_group α`.
-* `to_group f`: the canonical group homomorphism `free_group α →* G` given a group `G` and a
+* `lift f`: the canonical group homomorphism `free_group α →* G` given a group `G` and a
   function `f : α → G`.
 
 ## Main statements
@@ -394,50 +394,51 @@ theorem of_injective : function.injective (@of α) :=
 λ _ _ H, let ⟨L₁, hx, hy⟩ := red.exact.1 H in
   by simp [red.singleton_iff] at hx hy; cc
 
-section to_group
+section lift
 
 variables {β : Type v} [group β] (f : α → β) {x y : free_group α}
 
 /-- Given `f : α → β` with `β` a group, the canonical map `list (α × bool) → β` -/
-def to_group.aux : list (α × bool) → β :=
+def lift.aux : list (α × bool) → β :=
 λ L, list.prod $ L.map $ λ x, cond x.2 (f x.1) (f x.1)⁻¹
 
-theorem red.step.to_group {f : α → β} (H : red.step L₁ L₂) :
-  to_group.aux f L₁ = to_group.aux f L₂ :=
-by cases H with _ _ _ b; cases b; simp [to_group.aux]
+theorem red.step.lift {f : α → β} (H : red.step L₁ L₂) :
+  lift.aux f L₁ = lift.aux f L₂ :=
+by cases H with _ _ _ b; cases b; simp [lift.aux]
 
-/-- If `β` is a group, then any function from `α` to `β`
-extends uniquely to a group homomorphism from
-the free group over `α` to `β`. Note that this is the bare function; the
-group homomorphism is `to_group`. -/
-def to_group.to_fun : free_group α → β :=
-quot.lift (to_group.aux f) $ λ L₁ L₂ H, red.step.to_group H
 
 /-- If `β` is a group, then any function from `α` to `β`
 extends uniquely to a group homomorphism from
 the free group over `α` to `β` -/
-def to_group : free_group α →* β :=
-monoid_hom.mk' (to_group.to_fun f) $ begin
-  rintros ⟨L₁⟩ ⟨L₂⟩; simp [to_group.to_fun, to_group.aux],
-end
-
+def lift : (α → β) ≃ (free_group α →* β) :=
+{ to_fun := λ f,
+    monoid_hom.mk' (quot.lift (lift.aux f) $ λ L₁ L₂, red.step.lift) $ begin
+      rintros ⟨L₁⟩ ⟨L₂⟩, simp [lift.aux],
+    end,
+  inv_fun := λ g, g ∘ of,
+  left_inv := λ f, one_mul _,
+  right_inv := λ g, monoid_hom.ext $ begin
+    rintros ⟨L⟩,
+    apply list.rec_on L,
+    { exact g.map_one.symm, },
+    { rintros ⟨x, _ | _⟩ t (ih : _ = g (mk t)),
+      { show _ = g ((of x)⁻¹ * mk t),
+        simpa [lift.aux] using ih },
+      { show _ = g (of x * mk t),
+        simpa [lift.aux] using ih }, },
+  end }
 variable {f}
 
-@[simp] lemma to_group.mk : to_group f (mk L) =
+@[simp] lemma lift.mk : lift f (mk L) =
   list.prod (L.map $ λ x, cond x.2 (f x.1) (f x.1)⁻¹) :=
 rfl
 
-@[simp] lemma to_group.of {x} : to_group f (of x) = f x :=
+@[simp] lemma lift.of {x} : lift f (of x) = f x :=
 one_mul _
 
-theorem to_group.unique (g : free_group α →* β)
-  (hg : ∀ x, g (of x) = f x) : ∀{x}, g x = to_group f x :=
-by rintros ⟨L⟩; exact list.rec_on L (is_group_hom.map_one g)
-(λ ⟨x, b⟩ t (ih : g (mk t) = _), bool.rec_on b
-  (show g ((of x)⁻¹ * mk t) = to_group f (mk ((x, ff) :: t)),
-     by simp [g.map_mul, g.map_inv, hg, ih, to_group.to_fun, to_group.aux])
-  (show g (of x * mk t) = to_group f (mk ((x, tt) :: t)),
-     by simp [g.map_mul, g.map_inv, hg, ih, to_group.to_fun, to_group.aux]))
+theorem lift.unique (g : free_group α →* β)
+  (hg : ∀ x, g (of x) = f x) : ∀{x}, g x = lift f x :=
+monoid_hom.congr_fun $ (lift.symm_apply_eq).mp (funext hg : g ∘ of = f)
 
 /-- Two homomorphisms out of a free group are equal if they are equal on generators.
 
@@ -445,17 +446,13 @@ See note [partially-applied ext lemmas]. -/
 @[ext]
 lemma ext_hom {G : Type*} [group G] (f g : free_group α →* G) (h : ∀ a, f (of a) = g (of a)) :
   f = g :=
-begin
-  ext x,
-  rw [to_group.unique f (λ x, rfl), to_group.unique g (λ x, rfl)],
-  simp only [h]
-end
+lift.symm.injective $ funext h
 
-theorem to_group.of_eq (x : free_group α) : to_group of x = x :=
-eq.symm $ to_group.unique (monoid_hom.id _) (λ x, rfl)
+theorem lift.of_eq (x : free_group α) : lift of x = x :=
+monoid_hom.congr_fun (lift.apply_symm_apply (monoid_hom.id _)) x
 
-theorem to_group.range_subset {s : subgroup β} (H : set.range f ⊆ s) :
-  set.range (to_group f) ⊆ s :=
+theorem lift.range_subset {s : subgroup β} (H : set.range f ⊆ s) :
+  set.range (lift f) ⊆ s :=
 by rintros _ ⟨⟨L⟩, rfl⟩; exact list.rec_on L s.one_mem
 (λ ⟨x, b⟩ tl ih, bool.rec_on b
     (by simp at ih ⊢; from s.mul_mem
@@ -468,31 +465,19 @@ begin
   simp only [h, subgroup.closure_le],
 end
 
-theorem to_group.range_eq_closure :
-  set.range (to_group f) = subgroup.closure (set.range f) :=
+theorem lift.range_eq_closure :
+  set.range (lift f) = subgroup.closure (set.range f) :=
 set.subset.antisymm
-  (to_group.range_subset subgroup.subset_closure)
+  (lift.range_subset subgroup.subset_closure)
   begin
-    suffices : (subgroup.closure (set.range f)) ≤ monoid_hom.range (to_group f),
+    suffices : (subgroup.closure (set.range f)) ≤ monoid_hom.range (lift f),
       simpa,
     rw subgroup.closure_le,
     rintros y ⟨x, hx⟩,
     exact ⟨of x, by simpa⟩
   end
 
-end to_group
-
-section
-variables (X : Type*) (G : Type*) [group G]
-
-/-- The bijection underlying the free-forgetful adjunction for groups. -/
-@[simps]
-def lift : (X → G) ≃ (free_group X →* G)  :=
-{ to_fun := λ g, to_group g,
-  inv_fun := λ f, f.1 ∘ of,
-  left_inv := by { intros x, ext1, simp },
-  right_inv := by { intros x, ext1, simp }  }
-end
+end lift
 
 section map
 
@@ -553,7 +538,7 @@ def free_group_congr {α β} (e : α ≃ β) : free_group α ≃ free_group β :
  λ x, by simp [function.comp, map.comp],
  λ x, by simp [function.comp, map.comp]⟩
 
-theorem map_eq_to_group : map f x = to_group (of ∘ f) x :=
+theorem map_eq_lift : map f x = lift (of ∘ f) x :=
 eq.symm $ map.unique _ $ λ x, by simp
 
 end map
@@ -566,7 +551,7 @@ variables [group α] (x y : free_group α)
 extends uniquely to a homomorphism from the
 free group over `α` to `α`. This is the multiplicative
 version of `sum`. -/
-def prod : free_group α →* α := to_group id
+def prod : free_group α →* α := lift id
 
 variables {x y}
 
@@ -575,19 +560,19 @@ variables {x y}
 rfl
 
 @[simp] lemma prod.of {x : α} : prod (of x) = x :=
-to_group.of
+lift.of
 
 lemma prod.unique (g : free_group α →* α)
   (hg : ∀ x, g (of x) = x) {x} :
   g x = prod x :=
-to_group.unique g hg
+lift.unique g hg
 
 end prod
 
-theorem to_group_eq_prod_map {β : Type v} [group β] {f : α → β} {x} :
-  to_group f x = prod (map f x) :=
+theorem lift_eq_prod_map {β : Type v} [group β] {f : α → β} {x} :
+  lift f x = prod (map f x) :=
 begin
-  rw ←to_group.unique (prod.comp (map f)),
+  rw ←lift.unique (prod.comp (map f)),
   { refl },
   { simp }
 end
@@ -658,7 +643,7 @@ variables {β : Type u}
 instance : monad free_group.{u} :=
 { pure := λ α, of,
   map := λ α β f, (map f),
-  bind := λ α β x f, to_group f x }
+  bind := λ α β x f, lift f x }
 
 @[elab_as_eliminator]
 protected theorem induction_on
@@ -684,17 +669,17 @@ map.of
 (map f).map_inv x
 
 @[simp] lemma pure_bind (f : α → free_group β) (x) : pure x >>= f = f x :=
-to_group.of
+lift.of
 
 @[simp] lemma one_bind (f : α → free_group β) : 1 >>= f = 1 :=
-(to_group f).map_one
+(lift f).map_one
 
 @[simp] lemma mul_bind (f : α → free_group β) (x y : free_group α) :
   x * y >>= f = (x >>= f) * (y >>= f) :=
-(to_group f).map_mul _ _
+(lift f).map_mul _ _
 
 @[simp] lemma inv_bind (f : α → free_group β) (x : free_group α) : x⁻¹ >>= f = (x >>= f)⁻¹ :=
-(to_group f).map_inv _
+(lift f).map_inv _
 
 instance : is_lawful_monad free_group.{u} :=
 { id_map := λ α x, free_group.induction_on x (map_one id) (λ x, map_pure id x)

--- a/src/group_theory/presented_group.lean
+++ b/src/group_theory/presented_group.lean
@@ -35,7 +35,7 @@ presented_group rels to β
 
 variables {β : Type} [group β] {f : α → β} {rels : set (free_group α)}
 
-local notation `F` := free_group.to_group f
+local notation `F` := free_group.lift f
 
 variable (h : ∀ r ∈ rels, F r = 1)
 
@@ -48,14 +48,14 @@ lemma to_group_eq_one_of_mem_closure : ∀ x ∈ subgroup.normal_closure rels, F
 /-- The extension of a map f : α → β that satisfies the given relations to a group homomorphism
 from presented_group rels → β. -/
 def to_group : presented_group rels →* β :=
-quotient_group.lift (subgroup.normal_closure rels) (monoid_hom.of F) (to_group_eq_one_of_mem_closure h)
+quotient_group.lift (subgroup.normal_closure rels) F (to_group_eq_one_of_mem_closure h)
 
-@[simp] lemma to_group.of {x : α} : to_group h (of x) = f x := free_group.to_group.of
+@[simp] lemma to_group.of {x : α} : to_group h (of x) = f x := free_group.lift.of
 
 theorem to_group.unique (g : presented_group rels →* β)
   (hg : ∀ x : α, g (of x) = f x) : ∀ {x}, g x = to_group h x :=
 λ x, quotient_group.induction_on x
-    (λ _, free_group.to_group.unique (g.comp (quotient_group.mk' _)) hg)
+    (λ _, free_group.lift.unique (g.comp (quotient_group.mk' _)) hg)
 
 end to_group
 

--- a/src/ring_theory/free_comm_ring.lean
+++ b/src/ring_theory/free_comm_ring.lean
@@ -55,15 +55,11 @@ universes u v
 variables (α : Type u)
 
 /-- `free_comm_ring α` is the free commutative ring on the type `α`. -/
+@[derive [comm_ring, inhabited]]
 def free_comm_ring (α : Type u) : Type u :=
 free_abelian_group $ multiplicative $ multiset α
 
 namespace free_comm_ring
-
-/-- The structure of a commutative ring on `free_comm_ring α`. -/
-instance : comm_ring (free_comm_ring α) := free_abelian_group.comm_ring _
-
-instance : inhabited (free_comm_ring α) := ⟨0⟩
 
 variables {α}
 
@@ -282,8 +278,8 @@ lemma coe_eq :
   (coe : free_ring α → free_comm_ring α) =
   @functor.map free_abelian_group _ _ _ (λ (l : list α), (l : multiset α)) :=
 funext $ λ x, free_abelian_group.lift.unique _ _ $ λ L,
-by { simp_rw [free_abelian_group.lift.of, (∘)], exact list.rec_on L rfl
-(λ hd tl ih, by { rw [list.map_cons, list.prod_cons, ih], refl }) }
+by { simp_rw [free_abelian_group.lift.of, (∘)], exact free_monoid.rec_on L rfl
+(λ hd tl ih, by { rw [(free_monoid.lift _).map_mul, free_monoid.lift_eval_of, ih], refl }) }
 
 -- FIXME This was in `deprecated.ring`, but only used here.
 -- It would be good to inline it into the next construction.

--- a/src/ring_theory/free_ring.lean
+++ b/src/ring_theory/free_ring.lean
@@ -30,18 +30,13 @@ free ring
 universes u v
 
 /-- The free ring over a type `α`. -/
+@[derive [ring, inhabited]]
 def free_ring (α : Type u) : Type u :=
 free_abelian_group $ free_monoid α
 
 namespace free_ring
 
-variables (α : Type u)
-
-instance : ring (free_ring α) := free_abelian_group.ring _
-
-instance : inhabited (free_ring α) := ⟨0⟩
-
-variables {α}
+variables {α : Type u}
 
 /-- The canonical map from α to `free_ring α`. -/
 def of (x : α) : free_ring α :=
@@ -78,7 +73,7 @@ def lift : free_ring α →+* R :=
       simp only [free_abelian_group.lift.of, add_monoid_hom.to_fun_eq_coe],
       refine free_abelian_group.induction_on x (zero_mul _).symm _ _ _,
       { intros L1, iterate 3 { rw free_abelian_group.lift.of },
-        show list.prod (list.map f (_ ++ _)) = _, rw [list.map_append, list.prod_append] },
+        rw (free_monoid.lift _).map_mul },
       { intros L1 ih,
         iterate 3 { rw (free_abelian_group.lift _).map_neg },
         rw [ih, neg_mul_eq_neg_mul] },
@@ -93,7 +88,7 @@ def lift : free_ring α →+* R :=
       simp only [add_monoid_hom.to_fun_eq_coe] at ih1 ih2 ⊢,
       rw [mul_add, add_monoid_hom.map_add, add_monoid_hom.map_add, mul_add, ih1, ih2] },
   end,
-  .. free_abelian_group.lift $ λ L, (list.map f L).prod }
+  .. free_abelian_group.lift $ free_monoid.lift f }
 
 @[simp] lemma lift_of (x : α) : lift f (of x) = f x :=
 (free_abelian_group.lift.of _ _).trans $ one_mul _


### PR DESCRIPTION
This removes:

* `free_group.to_group.to_fun` and `free_group.to_group`, as these are both subsumed by the stronger `lift`.
* `abelianization.hom_equiv` as this is now `abelianization.lift.symm`
* `free_abelian_group.hom_equiv` as this is now `free_abelian_group.lift.symm`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
