### PR TITLE
[Merged by Bors] - doc(algebraic_geometry/is_open_comap_C): add reference to Stacks project

### DIFF
--- a/src/algebraic_geometry/is_open_comap_C.lean
+++ b/src/algebraic_geometry/is_open_comap_C.lean
@@ -7,6 +7,10 @@ import algebraic_geometry.prime_spectrum
 import ring_theory.polynomial.basic
 /-!
 The morphism `Spec R[x] --> Spec R` induced by the natural inclusion `R --> R[x]` is an open map.
+
+The main result if the part of the statement of Lemma 00FB in the Stacks Project.
+
+https://stacks.math.columbia.edu/tag/00FB
 -/
 
 open ideal polynomial prime_spectrum set
@@ -54,7 +58,9 @@ begin
     exact comap_C_mem_image_of_Df complement }
 end
 
-/--  The morphism `C⁺ : Spec R[x] → Spec R` is open. -/
+/--  The morphism `C⁺ : Spec R[x] → Spec R` is open.
+Stacks Project "Lemma 00FB", first part.
+https://stacks.math.columbia.edu/tag/00FB  -/
 theorem is_open_map_comap_C :
   is_open_map (comap (C : R →+* polynomial R)) :=
 begin

--- a/src/algebraic_geometry/is_open_comap_C.lean
+++ b/src/algebraic_geometry/is_open_comap_C.lean
@@ -8,7 +8,7 @@ import ring_theory.polynomial.basic
 /-!
 The morphism `Spec R[x] --> Spec R` induced by the natural inclusion `R --> R[x]` is an open map.
 
-The main result is the part of the statement of Lemma 00FB in the Stacks Project.
+The main result is the first part of the statement of Lemma 00FB in the Stacks Project.
 
 https://stacks.math.columbia.edu/tag/00FB
 -/

--- a/src/algebraic_geometry/is_open_comap_C.lean
+++ b/src/algebraic_geometry/is_open_comap_C.lean
@@ -8,7 +8,7 @@ import ring_theory.polynomial.basic
 /-!
 The morphism `Spec R[x] --> Spec R` induced by the natural inclusion `R --> R[x]` is an open map.
 
-The main result if the part of the statement of Lemma 00FB in the Stacks Project.
+The main result is the part of the statement of Lemma 00FB in the Stacks Project.
 
 https://stacks.math.columbia.edu/tag/00FB
 -/
@@ -60,7 +60,9 @@ end
 
 /--  The morphism `C⁺ : Spec R[x] → Spec R` is open.
 Stacks Project "Lemma 00FB", first part.
-https://stacks.math.columbia.edu/tag/00FB  -/
+
+https://stacks.math.columbia.edu/tag/00FB
+-/
 theorem is_open_map_comap_C :
   is_open_map (comap (C : R →+* polynomial R)) :=
 begin


### PR DESCRIPTION
Updated the doc-strings to reference the Stacks project.

Zulip chat:
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/stacks.20tags


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
