### PR TITLE
[Merged by Bors] - feat(linear_algebra/basic): add is_scalar_tower instance for hom type

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1385,15 +1385,3 @@ rfl
 end semimodule
 
 end restrict_scalars
-
-namespace linear_map
-
-variables (R : Type*) [comm_semiring R] (S : Type*) [semiring S] [algebra R S]
-  (V : Type*) [add_comm_monoid V] [semimodule R V]
-  (W : Type*) [add_comm_monoid W] [semimodule R W] [semimodule S W] [is_scalar_tower R S W]
-
-instance is_scalar_tower_extend_scalars :
-  is_scalar_tower R S (V →ₗ[R] W) :=
-{ smul_assoc := λ r s f, by simp only [(•), coe_mk, smul_assoc] }
-
-end linear_map

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -407,9 +407,6 @@ def dom_restrict'
 @[simp] lemma dom_restrict'_apply (f : M →ₗ[R] M₂) (p : submodule R M) (x : p) :
   dom_restrict' p f x = f x := rfl
 
-variables (S : Type*) [monoid S] [distrib_mul_action S M₂] [smul_comm_class R S M₂]
-  [mul_action S R] [is_scalar_tower S R M₂]
-
 end comm_semiring
 
 section semiring

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -400,6 +400,14 @@ def dom_restrict'
 @[simp] lemma dom_restrict'_apply (f : M →ₗ[R] M₂) (p : submodule R M) (x : p) :
   dom_restrict' p f x = f x := rfl
 
+variables (S : Type*) [monoid S] [distrib_mul_action S M₂] [smul_comm_class R S M₂]
+  [mul_action S R] [is_scalar_tower S R M₂]
+
+-- example application of this instance: if S and R are comm_semirings and R is an S-algebra
+-- then the S-actions and R-actions on Hom_R(M,M₂) coincide.
+instance : is_scalar_tower S R (M →ₗ[R] M₂) :=
+{ smul_assoc := λ _ _ _, linear_map.ext $ λ _, by simp only [linear_map.smul_apply, smul_assoc] }
+
 end comm_semiring
 
 section semiring

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -300,8 +300,8 @@ instance {T : Type*} [monoid T] [distrib_mul_action T M₂] [smul_comm_class R T
   smul_comm_class S T (M →ₗ[R] M₂) :=
 ⟨λ a b f, ext $ λ x, smul_comm _ _ _⟩
 
--- example application of this instance: if S and R are comm_semirings and R is an S-algebra
--- then the S-actions and R-actions on Hom_R(M,M₂) coincide.
+-- example application of this instance: if S -> T -> R are homomorphisms of commutative rings and
+-- M and M₂ are R-modules then the S-module and T-module structures on Hom_R(M,M₂) are compatible.
 instance {T : Type*} [monoid T] [has_scalar S T] [distrib_mul_action T M₂] [smul_comm_class R T M₂]
   [is_scalar_tower S T M₂] :
   is_scalar_tower S T (M →ₗ[R] M₂) :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -300,6 +300,13 @@ instance {T : Type*} [monoid T] [distrib_mul_action T M₂] [smul_comm_class R T
   smul_comm_class S T (M →ₗ[R] M₂) :=
 ⟨λ a b f, ext $ λ x, smul_comm _ _ _⟩
 
+-- example application of this instance: if S and R are comm_semirings and R is an S-algebra
+-- then the S-actions and R-actions on Hom_R(M,M₂) coincide.
+instance {T : Type*} [monoid T] [has_scalar S T] [distrib_mul_action T M₂] [smul_comm_class R T M₂]
+  [is_scalar_tower S T M₂] :
+  is_scalar_tower S T (M →ₗ[R] M₂) :=
+{ smul_assoc := λ _ _ _, ext $ λ _, smul_assoc _ _ _ }
+
 instance : distrib_mul_action S (M →ₗ[R] M₂) :=
 { one_smul := λ f, ext $ λ _, one_smul _ _,
   mul_smul := λ c c' f, ext $ λ _, mul_smul _ _ _,
@@ -402,11 +409,6 @@ def dom_restrict'
 
 variables (S : Type*) [monoid S] [distrib_mul_action S M₂] [smul_comm_class R S M₂]
   [mul_action S R] [is_scalar_tower S R M₂]
-
--- example application of this instance: if S and R are comm_semirings and R is an S-algebra
--- then the S-actions and R-actions on Hom_R(M,M₂) coincide.
-instance : is_scalar_tower S R (M →ₗ[R] M₂) :=
-{ smul_assoc := λ _ _ _, linear_map.ext $ λ _, by simp only [linear_map.smul_apply, smul_assoc] }
 
 end comm_semiring
 


### PR DESCRIPTION
This instance tells Lean that if R is an S-algebra with R and S both commutative semirings, then the R-action on Hom_R(M,N) is compatible with the S-action.

`linear_map.is_scalar_tower_extend_scalars` is just a special case of this new instance with the `smul_comm_class` arguments populated with `is_scalar_tower.to_smul_comm_class` and `smul_comm_class_self`, so has been removed.

---

Rather than assuming A is an R-algebra I minimised the type classes necessary to make the theorem true, so the actual instance has got a whole bunch of random typeclasses. If you only assume R is a semiring rather than a comm_semiring then you need `smul_comm_class R R M_2` which seemed a bit artificial, so I added commutativity of R.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
