### PR TITLE
[Merged by Bors] - feat(measure_theory/interval_integral): add simp attribute to `integral_const`

### DIFF
--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -357,7 +357,7 @@ lemma integral_const' (c : E) :
   ∫ x in a..b, c ∂μ = ((μ $ Ioc a b).to_real - (μ $ Ioc b a).to_real) • c :=
 by simp only [interval_integral, set_integral_const, sub_smul]
 
-lemma integral_const {a b : ℝ} (c : E) : (∫ (x : ℝ) in a..b, c) = (b - a) • c :=
+@[simp] lemma integral_const {a b : ℝ} (c : E) : ∫ x in a..b, c = (b - a) • c :=
 by simp only [integral_const', real.volume_Ioc, ennreal.to_real_of_real', ← neg_sub b,
   max_zero_sub_eq_self]
 


### PR DESCRIPTION
By adding a `simp` attribute to `interval_integral.integral_const`, the likes of the following become possible:
```
import measure_theory.interval_integral

example : ∫ x:ℝ in 5..19, (12:ℝ) = 168 := by norm_num
```
