### PR TITLE
[Merged by Bors] - chore(topology/order): drop an unneeded argument

### DIFF
--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -570,7 +570,7 @@ continuous_iff_is_closed.mpr $
 
 lemma closure_subtype {x : {a // p a}} {s : set {a // p a}}:
   x ∈ closure s ↔ (x : α) ∈ closure ((coe : _ → α) '' s) :=
-closure_induced $ assume x y, subtype.eq
+closure_induced
 
 end subtype
 

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -96,6 +96,10 @@ by simp [continuous_iff_continuous_at, continuous_at, inducing.tendsto_nhds_iff 
 
 lemma inducing.continuous {f : α → β} (hf : inducing f) : continuous f :=
 hf.continuous_iff.mp continuous_id
+
+lemma inducing.closure_eq_preimage_closure_image {f : α → β} (hf : inducing f) (s : set α) :
+  closure s = f ⁻¹' closure (f '' s) :=
+by { ext x, rw [set.mem_preimage, ← closure_induced, hf.induced] }
 end inducing
 section embedding
 
@@ -150,7 +154,7 @@ inducing.continuous hf.1
 
 lemma embedding.closure_eq_preimage_closure_image {e : α → β} (he : embedding e) (s : set α) :
   closure s = e ⁻¹' closure (e '' s) :=
-by { ext x, rw [set.mem_preimage, ← closure_induced he.inj, he.induced] }
+he.1.closure_eq_preimage_closure_image s
 
 end embedding
 

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -606,25 +606,9 @@ lemma map_nhds_induced_eq {a : α} (h : range f ∈ 𝓝 (f a)) :
   map f (@nhds α (induced f t) a) = 𝓝 (f a) :=
 by rw [nhds_induced, filter.map_comap h]
 
-lemma closure_induced [t : topological_space β] {f : α → β} {a : α} {s : set α}
-  (hf : ∀x y, f x = f y → x = y) :
+lemma closure_induced [t : topological_space β] {f : α → β} {a : α} {s : set α} :
   a ∈ @closure α (topological_space.induced f t) s ↔ f a ∈ closure (f '' s) :=
-have comap f (𝓝 (f a) ⊓ 𝓟 (f '' s)) ≠ ⊥ ↔ 𝓝 (f a) ⊓ 𝓟 (f '' s) ≠ ⊥,
-  from ⟨assume h₁ h₂, h₁ $ h₂.symm ▸ comap_bot,
-    assume h,
-    ne_bot.ne $ forall_sets_nonempty_iff_ne_bot.mp $
-      assume s₁ ⟨s₂, hs₂, (hs : f ⁻¹' s₂ ⊆ s₁)⟩,
-      have f '' s ∈ 𝓝 (f a) ⊓ 𝓟 (f '' s),
-        from mem_inf_sets_of_right $ by simp [subset.refl],
-      have s₂ ∩ f '' s ∈ 𝓝 (f a) ⊓ 𝓟 (f '' s),
-        from inter_mem_sets hs₂ this,
-      let ⟨b, hb₁, ⟨a, ha, ha₂⟩⟩ := (ne_bot.mk h).nonempty_of_mem this in
-      ⟨_, hs $ by rwa [←ha₂] at hb₁⟩⟩,
-calc a ∈ @closure α (topological_space.induced f t) s
-      ↔ (@nhds α (topological_space.induced f t) a) ⊓ 𝓟 s ≠ ⊥ : by rw [mem_closure_iff_nhds_ne_bot]
-  ... ↔ comap f (𝓝 (f a)) ⊓ 𝓟 (f ⁻¹' (f '' s)) ≠ ⊥ : by rw [nhds_induced, preimage_image_eq _ hf]
-  ... ↔ comap f (𝓝 (f a) ⊓ 𝓟 (f '' s)) ≠ ⊥ : by rw [comap_inf, ←comap_principal]
-  ... ↔ _ : by simpa only [mem_closure_iff_nhds_ne_bot]
+by simp only [mem_closure_iff_frequently, nhds_induced, frequently_comap, mem_image, and_comm]
 
 end induced
 

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -360,7 +360,6 @@ begin
           nhds_induced, ← de.to_dense_inducing.nhds_eq_comap,
           ← mem_closure_iff_nhds_ne_bot, hs.closure_eq],
       exact assume hxs, ⟨⟨x, hp x hxs⟩, rfl⟩,
-      exact de.inj
     end⟩
 end
 


### PR DESCRIPTION
`closure_induced` doesn't need `f` to be injective.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
