### PR TITLE
[Merged by Bors] - doc(group_theory/*): module docs for `quotient_group` and `presented_group`

### DIFF
--- a/src/group_theory/presented_group.lean
+++ b/src/group_theory/presented_group.lean
@@ -14,11 +14,11 @@ given by generators `x : α` and relations `r ∈ rels`.
 
 ## Main definitions
 
-* `presented group rels`: the quotient group of the free group on a type `α` by a subset `rels` of
+* `presented_group rels`: the quotient group of the free group on a type `α` by a subset `rels` of
   relations of the free group on `α`.
 * `of`: The canonical map from `α` to a presented group with generators `α`.
-* `to_group f`: the canonical group homomorphsim `presented_group rels → G`, given a function
-`f : α → G` from a type `α` to a group `G` which satisfies the relations `rels`.
+* `to_group f`: the canonical group homomorphism `presented_group rels → G`, given a function
+  `f : α → G` from a type `α` to a group `G` which satisfies the relations `rels`.
 
 ## Tags
 

--- a/src/group_theory/presented_group.lean
+++ b/src/group_theory/presented_group.lean
@@ -2,16 +2,33 @@
 Copyright (c) 2019 Michael Howes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Howes
-
-Defining a group given by generators and relations
 -/
 import group_theory.free_group
 import group_theory.quotient_group
 
+/-!
+# Defining a group given by generators and relations
+
+Given a subset `rels` of relations of the free group on a type `α`, this file constructs the group
+given by generators `x : α` and relations `r ∈ rels`.
+
+## Main definitions
+
+* `presented group rels`: the quotient group of the free group on a type `α` by a subset `rels` of
+  relations of the free group on `α`.
+* `of`: The canonical map from `α` to a presented group with generators `α`.
+* `to_group f`: the canonical group homomorphsim `presented_group rels → G`, given a function
+`f : α → G` from a type `α` to a group `G` which satisfies the relations `rels`.
+
+## Tags
+
+generators, relations, group presentations
+-/
+
 variables {α : Type}
 
-/-- Given a set of relations, rels, over a type α, presented_group constructs the group with
-generators α and relations rels as a quotient of free_group α.-/
+/-- Given a set of relations, rels, over a type `α`, presented_group constructs the group with
+generators `x : α` and relations `rels` as a quotient of free_group `α`.-/
 def presented_group (rels : set (free_group α)) : Type :=
 quotient_group.quotient $ subgroup.normal_closure rels
 
@@ -20,20 +37,20 @@ namespace presented_group
 instance (rels : set (free_group α)) : group (presented_group (rels)) :=
 quotient_group.quotient.group _
 
-/-- `of x` is the canonical map from α to a presented group with generators α. The term x is
-mapped to the equivalence class of the image of x in free_group α. -/
+/-- `of` is the canonical map from `α` to a presented group with generators `x : α`. The term `x` is
+mapped to the equivalence class of the image of `x` in `free_group α`. -/
 def of {rels : set (free_group α)} (x : α) : presented_group rels :=
 quotient_group.mk (free_group.of x)
 
 section to_group
 
 /-
-Presented groups satisfy a universal property. If β is a group and f : α → β is a map such that the
-images of f satisfy all the given relations, then f extends uniquely to a group homomorphism from
-presented_group rels to β
+Presented groups satisfy a universal property. If `G` is a group and `f : α → G` is a map such that
+the images of `f` satisfy all the given relations, then `f` extends uniquely to a group homomorphism
+from `presented_group rels` to `G`.
 -/
 
-variables {β : Type} [group β] {f : α → β} {rels : set (free_group α)}
+variables {G : Type} [group G] {f : α → G} {rels : set (free_group α)}
 
 local notation `F` := free_group.lift f
 
@@ -45,14 +62,14 @@ subgroup.normal_closure_le_normal (λ x w, (monoid_hom.mem_ker _).2 (h x w))
 lemma to_group_eq_one_of_mem_closure : ∀ x ∈ subgroup.normal_closure rels, F x = 1 :=
 λ x w, (monoid_hom.mem_ker _).1 $ closure_rels_subset_ker h w
 
-/-- The extension of a map f : α → β that satisfies the given relations to a group homomorphism
-from presented_group rels → β. -/
-def to_group : presented_group rels →* β :=
+/-- The extension of a map `f : α → G` that satisfies the given relations to a group homomorphism
+from `presented_group rels → G`. -/
+def to_group : presented_group rels →* G :=
 quotient_group.lift (subgroup.normal_closure rels) F (to_group_eq_one_of_mem_closure h)
 
 @[simp] lemma to_group.of {x : α} : to_group h (of x) = f x := free_group.lift.of
 
-theorem to_group.unique (g : presented_group rels →* β)
+theorem to_group.unique (g : presented_group rels →* G)
   (hg : ∀ x : α, g (of x) = f x) : ∀ {x}, g x = to_group h x :=
 λ x, quotient_group.induction_on x
     (λ _, free_group.lift.unique (g.comp (quotient_group.mk' _)) hg)

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -7,6 +7,37 @@ This file is to a certain extent based on `quotient_module.lean` by Johannes Hö
 -/
 import group_theory.coset
 
+/-!
+# Quotients of groups by normal subgroups
+
+This files develops the basic theory of quotients of groups by normal subgroups. In particular it
+proves Noether's first and second isomorphism theorems.
+
+## Main definitions
+
+* `mk'`: the canonical group homomorphism `G →* G/N` given a normal subgroup `N` of `G`.
+* `lift φ`: the group homomorphism `G/N →* H` given a group homomorphism `φ : G →* H` such that
+  `N ⊆ ker φ`.
+* `map f`: the group homomorphism `G/N →* H/M` given a group homomorphism `f : G →* H` such that
+  `N ⊆ f⁻¹(M)`.
+
+## Main statements
+
+* `quotient_ker_equiv_range`: Noether's first isomorphism theorem, an explicit isomorphism
+  `G/ker φ → range φ` for every group homomorphism `φ : G →* H`.
+* `quotient_inf_equiv_prod_normal_quotient`: Noether's second isomorphism theorem, an explicit
+  isomorphism between `H/(H ∩ N)` and `(HN)/N` given a subgroup `H` and a normal subgroup `N` of a
+  group `G`.
+
+## Tags
+
+isomorphism theorems, quotient groups
+
+## TODO
+
+Noether's third isomorphism theorem
+-/
+
 universes u v
 
 namespace quotient_group
@@ -205,7 +236,7 @@ def equiv_quotient_of_eq {M N : subgroup G} [M.normal] [N.normal] (h : M = N) :
   right_inv := λ x, x.induction_on' $ by { intro, refl },
   map_mul' := λ x y, by rw map_mul }
 
-  section snd_isomorphism_thm
+section snd_isomorphism_thm
 
 open subgroup
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
