### PR TITLE
[Merged by Bors] - feat(category_theory/abelian/additive_functor): Adds definition of additive functors

### DIFF
--- a/src/category_theory/abelian/additive_functor.lean
+++ b/src/category_theory/abelian/additive_functor.lean
@@ -36,7 +36,7 @@ namespace category_theory
 /-- A functor `F` is additive provided `F.map` is an additive homomorphism. -/
 class functor.additive {C D : Type*} [category C] [category D]
   [preadditive C] [preadditive D] (F : C ⥤ D) : Prop :=
-(exists_hom' : ∀ (X Y : C), ∃ f : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y),
+(exists_hom [] : ∀ (X Y : C), ∃ f : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y),
   ∀ g : X ⟶ Y, F.map g = f g)
 
 section preadditive
@@ -44,9 +44,6 @@ variables {C D : Type*} [category C] [category D] [preadditive C]
   [preadditive D] (F : C ⥤ D) [functor.additive F]
 
 namespace functor.additive
-
-lemma exists_hom (X Y : C) : ∃ f : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y),
-  ∀ g : X ⟶ Y, F.map g = f g := functor.additive.exists_hom' _ _
 
 /--
 Construct an additive instance for `G` from proofs that `G.map` sends `0` to `0`

--- a/src/category_theory/abelian/additive_functor.lean
+++ b/src/category_theory/abelian/additive_functor.lean
@@ -54,9 +54,7 @@ def map_add_hom {X Y : C} : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y) :=
   map_zero' := additive.map_zero,
   map_add' := λ _ _, additive.map_add }
 
-lemma map_add_hom_spec {X Y : C} {f : X ⟶ Y} : F.map_add_hom f = F.map f := rfl
-
-lemma map_add_hom_spec' {X Y : C} : ⇑(F.map_add_hom : (X ⟶ Y) →+ _) = @map C _ D _ F X Y := rfl
+lemma coe_map_add_hom {X Y : C} : ⇑(F.map_add_hom : (X ⟶ Y) →+ _) = @map C _ D _ F X Y := rfl
 
 @[simp]
 lemma additive.map_neg {X Y : C} {f : X ⟶ Y} : F.map (-f) = - F.map f :=

--- a/src/category_theory/abelian/additive_functor.lean
+++ b/src/category_theory/abelian/additive_functor.lean
@@ -1,8 +1,38 @@
+/-
+Copyright (c) 2021 Adam Topaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Topaz
+-/
 import category_theory.preadditive
 import category_theory.abelian.basic
 
+/-!
+# Additive Functors
+
+A functor between two preadditive categories is called *additive*
+provided that the induced map on hom types is a morphism of abelian
+groups.
+
+# Implementation details
+
+`functor.additive` is a `Prop`-valued class, defined by saying that
+for every two objects `X` and `Y`, there exists a morphism of additive
+groups `f : (X ⟶ Y) → (F.obj X ⟶ F.obj Y)` whose underlying function
+agrees with `F.map`.
+
+To construct an instance of `functor.additive G` from proofs that
+`G.map` sends `0` to `0` and is compatible with addition of morphisms,
+use `functor.additive.of_is_hom`.
+
+# Projects:
+
+- Prove that an additive functor preserves finite biproducts
+- Prove that a functor is additive it it preserves finite biproducts
+-/
+
 namespace category_theory
 
+/-- A functor `F` is additive provided `F.map` is an additive homomorphism. -/
 class functor.additive {C D : Type*} [category C] [category D]
   [preadditive C] [preadditive D] (F : C ⥤ D) : Prop :=
 (exists_hom' : ∀ (X Y : C), ∃ f : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y),
@@ -17,7 +47,11 @@ namespace functor.additive
 lemma exists_hom (X Y : C) : ∃ f : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y),
   ∀ g : X ⟶ Y, F.map g = f g := functor.additive.exists_hom' _ _
 
-def of_is_hom (G : C ⥤ D)
+/--
+Construct an additive instance for `G` from proofs that `G.map` sends `0` to `0`
+and is compatible with addition of morphisms.
+-/
+lemma of_is_hom (G : C ⥤ D)
   (map_zero : ∀ X Y : C, G.map (0 : X ⟶ Y) = 0)
   (map_add : ∀ (X Y : C) (f g : X ⟶ Y), G.map (f + g) = G.map f + G.map g) :
   functor.additive G := functor.additive.mk $ λ X Y,
@@ -27,6 +61,7 @@ end functor.additive
 
 namespace functor
 
+/-- `F.add_map` is an additive homomorphism whose underlying function is `F.map`. -/
 @[simps]
 def add_map {X Y : C} : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y) :=
 { to_fun := λ f, F.map f,
@@ -58,8 +93,5 @@ F.add_map.map_sub _ _
 
 end functor
 end preadditive
-
---PROJECT: Prove that an additive functor preserves finite biproducts
---PROJECT: Prove that a functor is additive it it preserves finite biproducts
 
 end category_theory

--- a/src/category_theory/abelian/additive_functor.lean
+++ b/src/category_theory/abelian/additive_functor.lean
@@ -1,0 +1,65 @@
+import category_theory.preadditive
+import category_theory.abelian.basic
+
+namespace category_theory
+
+class functor.additive {C D : Type*} [category C] [category D]
+  [preadditive C] [preadditive D] (F : C ⥤ D) : Prop :=
+(exists_hom' : ∀ (X Y : C), ∃ f : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y),
+  ∀ g : X ⟶ Y, F.map g = f g)
+
+section preadditive
+variables {C D : Type*} [category C] [category D] [preadditive C]
+  [preadditive D] (F : C ⥤ D) [functor.additive F]
+
+namespace functor.additive
+
+lemma exists_hom (X Y : C) : ∃ f : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y),
+  ∀ g : X ⟶ Y, F.map g = f g := functor.additive.exists_hom' _ _
+
+def of_is_hom (G : C ⥤ D)
+  (map_zero : ∀ X Y : C, G.map (0 : X ⟶ Y) = 0)
+  (map_add : ∀ (X Y : C) (f g : X ⟶ Y), G.map (f + g) = G.map f + G.map g) :
+  functor.additive G := functor.additive.mk $ λ X Y,
+⟨⟨λ f, G.map f, map_zero _ _, map_add _ _⟩, λ g, rfl⟩
+
+end functor.additive
+
+namespace functor
+
+@[simps]
+def add_map {X Y : C} : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y) :=
+{ to_fun := λ f, F.map f,
+  map_zero' := begin
+    rcases functor.additive.exists_hom F X Y with ⟨f, hf⟩,
+    simp [hf],
+  end,
+  map_add' := begin
+    rcases functor.additive.exists_hom F X Y with ⟨f, hf⟩,
+    simp [hf],
+  end }
+
+lemma add_map_spec {X Y : C} {f : X ⟶ Y} : F.add_map f = F.map f := rfl
+
+@[simp]
+lemma map_zero {X Y : C} : F.map (0 : X ⟶ Y) = 0 := F.add_map.map_zero
+
+@[simp]
+lemma map_add {X Y : C} {f g : X ⟶ Y} : F.map (f + g) = F.map f + F.map g :=
+F.add_map.map_add _ _
+
+@[simp]
+lemma map_neg {X Y : C} {f : X ⟶ Y} : F.map (-f) = - F.map f :=
+F.add_map.map_neg _
+
+@[simp]
+lemma map_sub {X Y : C} {f g : X ⟶ Y} : F.map (f - g) = F.map f - F.map g :=
+F.add_map.map_sub _ _
+
+end functor
+end preadditive
+
+--PROJECT: Prove that an additive functor preserves finite biproducts
+--PROJECT: Prove that a functor is additive it it preserves finite biproducts
+
+end category_theory

--- a/src/category_theory/abelian/additive_functor.lean
+++ b/src/category_theory/abelian/additive_functor.lean
@@ -49,22 +49,22 @@ namespace functor
 
 /-- `F.add_map` is an additive homomorphism whose underlying function is `F.map`. -/
 @[simps]
-def add_map {X Y : C} : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y) :=
+def map_add_hom {X Y : C} : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y) :=
 { to_fun := λ f, F.map f,
   map_zero' := additive.map_zero,
   map_add' := λ _ _, additive.map_add }
 
-lemma add_map_spec {X Y : C} {f : X ⟶ Y} : F.add_map f = F.map f := rfl
+lemma map_add_hom_spec {X Y : C} {f : X ⟶ Y} : F.map_add_hom f = F.map f := rfl
 
-lemma add_map_spec' {X Y : C} : ⇑(F.add_map : (X ⟶ Y) →+ _) = @map C _ D _ F X Y := rfl
+lemma map_add_hom_spec' {X Y : C} : ⇑(F.map_add_hom : (X ⟶ Y) →+ _) = @map C _ D _ F X Y := rfl
 
 @[simp]
 lemma additive.map_neg {X Y : C} {f : X ⟶ Y} : F.map (-f) = - F.map f :=
-F.add_map.map_neg _
+F.map_add_hom.map_neg _
 
 @[simp]
 lemma additive.map_sub {X Y : C} {f g : X ⟶ Y} : F.map (f - g) = F.map f - F.map g :=
-F.add_map.map_sub _ _
+F.map_add_hom.map_sub _ _
 
 end functor
 end preadditive

--- a/src/category_theory/abelian/additive_functor.lean
+++ b/src/category_theory/abelian/additive_functor.lean
@@ -91,6 +91,10 @@ F.add_map.map_neg _
 lemma map_sub {X Y : C} {f g : X ⟶ Y} : F.map (f - g) = F.map f - F.map g :=
 F.add_map.map_sub _ _
 
+-- sanity check
+example (G : C ⥤ D) [functor.additive G] {X Y : C} {f g : X ⟶ Y} :
+  G.map (f - f + 0 - g) = - G.map g := by simp
+
 end functor
 end preadditive
 

--- a/src/category_theory/abelian/additive_functor.lean
+++ b/src/category_theory/abelian/additive_functor.lean
@@ -17,13 +17,9 @@ groups.
 # Implementation details
 
 `functor.additive` is a `Prop`-valued class, defined by saying that
-for every two objects `X` and `Y`, there exists a morphism of additive
-groups `f : (X ⟶ Y) → (F.obj X ⟶ F.obj Y)` whose underlying function
-agrees with `F.map`.
-
-To construct an instance of `functor.additive G` from proofs that
-`G.map` sends `0` to `0` and is compatible with addition of morphisms,
-use `functor.additive.of_is_hom`.
+for every two objects `X` and `Y`, the map
+`F.map : (X ⟶ Y) → (F.obj X ⟶ F.obj Y)` is a morphism of abelian
+groups.
 
 # Projects (in the case of abelian categories):
 

--- a/src/category_theory/abelian/additive_functor.lean
+++ b/src/category_theory/abelian/additive_functor.lean
@@ -77,6 +77,8 @@ def add_map {X Y : C} : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y) :=
 
 lemma add_map_spec {X Y : C} {f : X ⟶ Y} : F.add_map f = F.map f := rfl
 
+lemma add_map_spec' {X Y : C} : ⇑(F.add_map : (X ⟶ Y) →+ _) = @map C _ D _ F X Y := rfl
+
 @[simp]
 lemma map_zero {X Y : C} : F.map (0 : X ⟶ Y) = 0 := F.add_map.map_zero
 

--- a/src/category_theory/abelian/additive_functor.lean
+++ b/src/category_theory/abelian/additive_functor.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
+
 import category_theory.preadditive
 import category_theory.abelian.basic
 
@@ -24,7 +25,7 @@ To construct an instance of `functor.additive G` from proofs that
 `G.map` sends `0` to `0` and is compatible with addition of morphisms,
 use `functor.additive.of_is_hom`.
 
-# Projects:
+# Projects (in the case of abelian categories):
 
 - Prove that an additive functor preserves finite biproducts
 - Prove that a functor is additive it it preserves finite biproducts

--- a/src/category_theory/abelian/additive_functor.lean
+++ b/src/category_theory/abelian/additive_functor.lean
@@ -36,26 +36,18 @@ namespace category_theory
 /-- A functor `F` is additive provided `F.map` is an additive homomorphism. -/
 class functor.additive {C D : Type*} [category C] [category D]
   [preadditive C] [preadditive D] (F : C ⥤ D) : Prop :=
-(exists_hom [] : ∀ (X Y : C), ∃ f : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y),
-  ∀ g : X ⟶ Y, F.map g = f g)
+(map_zero' : Π {X Y : C}, F.map (0 : X ⟶ Y) = 0 . obviously)
+(map_add' : Π {X Y : C} {f g : X ⟶ Y}, F.map (f + g) = F.map f + F.map g . obviously)
+
+restate_axiom functor.additive.map_zero'
+restate_axiom functor.additive.map_add'
+
+attribute [simp] functor.additive.map_zero functor.additive.map_add
 
 section preadditive
+
 variables {C D : Type*} [category C] [category D] [preadditive C]
   [preadditive D] (F : C ⥤ D) [functor.additive F]
-
-namespace functor.additive
-
-/--
-Construct an additive instance for `G` from proofs that `G.map` sends `0` to `0`
-and is compatible with addition of morphisms.
--/
-lemma of_is_hom (G : C ⥤ D)
-  (map_zero : ∀ X Y : C, G.map (0 : X ⟶ Y) = 0)
-  (map_add : ∀ (X Y : C) (f g : X ⟶ Y), G.map (f + g) = G.map f + G.map g) :
-  functor.additive G := functor.additive.mk $ λ X Y,
-⟨⟨λ f, G.map f, map_zero _ _, map_add _ _⟩, λ g, rfl⟩
-
-end functor.additive
 
 namespace functor
 
@@ -63,37 +55,20 @@ namespace functor
 @[simps]
 def add_map {X Y : C} : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y) :=
 { to_fun := λ f, F.map f,
-  map_zero' := begin
-    rcases functor.additive.exists_hom F X Y with ⟨f, hf⟩,
-    simp [hf],
-  end,
-  map_add' := begin
-    rcases functor.additive.exists_hom F X Y with ⟨f, hf⟩,
-    simp [hf],
-  end }
+  map_zero' := additive.map_zero,
+  map_add' := λ _ _, additive.map_add }
 
 lemma add_map_spec {X Y : C} {f : X ⟶ Y} : F.add_map f = F.map f := rfl
 
 lemma add_map_spec' {X Y : C} : ⇑(F.add_map : (X ⟶ Y) →+ _) = @map C _ D _ F X Y := rfl
 
 @[simp]
-lemma map_zero {X Y : C} : F.map (0 : X ⟶ Y) = 0 := F.add_map.map_zero
-
-@[simp]
-lemma map_add {X Y : C} {f g : X ⟶ Y} : F.map (f + g) = F.map f + F.map g :=
-F.add_map.map_add _ _
-
-@[simp]
-lemma map_neg {X Y : C} {f : X ⟶ Y} : F.map (-f) = - F.map f :=
+lemma additive.map_neg {X Y : C} {f : X ⟶ Y} : F.map (-f) = - F.map f :=
 F.add_map.map_neg _
 
 @[simp]
-lemma map_sub {X Y : C} {f g : X ⟶ Y} : F.map (f - g) = F.map f - F.map g :=
+lemma additive.map_sub {X Y : C} {f g : X ⟶ Y} : F.map (f - g) = F.map f - F.map g :=
 F.add_map.map_sub _ _
-
--- sanity check
-example (G : C ⥤ D) [functor.additive G] {X Y : C} {f g : X ⟶ Y} :
-  G.map (f - f + 0 - g) = - G.map g := by simp
 
 end functor
 end preadditive

--- a/src/category_theory/abelian/additive_functor.lean
+++ b/src/category_theory/abelian/additive_functor.lean
@@ -28,7 +28,7 @@ use `functor.additive.of_is_hom`.
 # Projects (in the case of abelian categories):
 
 - Prove that an additive functor preserves finite biproducts
-- Prove that a functor is additive it it preserves finite biproducts
+- Prove that a functor is additive if it preserves finite biproducts
 -/
 
 namespace category_theory


### PR DESCRIPTION
This PR adds the basic definition of an additive functor.
See associated [zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Additive.20functors/near/227295322).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
