### PR TITLE
[Merged by Bors] - chore(group_theory/coset): right_coset additions and module doc

### DIFF
--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -13,21 +13,18 @@ This file develops the basic theory of left and right cosets.
 
 ## Main definitions
 
-* `left_coset a s`: the left coset `a * s` corresponding to an element `a : α` and a subset `s ⊆ α`.
-* `right_coset s a`: the right coset `s * a` corresponding to an element `a : α` and a subset
-  `s ⊆ α`.
+* `left_coset a s`: the left coset `a * s` for an element `a : α` and a subset `s ⊆ α`.
+* `right_coset s a`: the right coset `s * a` for an element `a : α` and a subset `s ⊆ α`.
 * `quotient s`: the quotient type corresponding to the left cosets with respect to a subgroup `s`.
 * `mk`: the canonical map from `α` to `α/s` for a subgroup `s` of `α`.
 * `left_coset_equiv_subgroup`: the natural bijection between a left coset and the subgroup.
 
 ## Notation
 
-* `a *l s`: for a `has_mul α` , i.e. a magma, `a : α` and `s ⊆ α`, the left coset `a * s`.
-* `a +l s`: for a `has_add α`, i.e. an additively written magma, `a : α` and `s ⊆ α` the left coset
-  `a + s`.
-* `s *r a`: for a `has_mul α`, i.e. a magma, `a : α` and `s ⊆ α`, the right coset `s * a`.
-* `s +r a`: for a `has_add α`, i.e. an additively written magma, `a : α` and `s ⊆ α` the right coset
-  `s + a`.
+* `a *l s`: for `left_coset a s`.
+* `a +l s`: for `left_add_coset a s`.
+* `s *r a`: for `right_coset s a`.
+* `s +r a`: for `right_add_coset s a`.
 
 ## TODO
 

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -67,15 +67,15 @@ lemma mem_right_coset {s : set α} {x : α} (a : α) (hxS : x ∈ s) : x * a ∈
 mem_image_of_mem (λ b : α, b * a) hxS
 
 /-- Equality of two left cosets `a * s` and `b * s`. -/
-@[to_additive left_add_coset_equiv "Equality of two left cosets `a + s` and `b + s`."]
-def left_coset_equiv (s : set α) (a b : α) := a *l s = b *l s
+@[to_additive left_add_coset_equivalence "Equality of two left cosets `a + s` and `b + s`."]
+def left_coset_equivalence (s : set α) (a b : α) := a *l s = b *l s
 
-@[to_additive left_add_coset_equiv_rel]
-lemma left_coset_equiv_rel (s : set α) : equivalence (left_coset_equiv s) :=
-mk_equivalence (left_coset_equiv s) (λ a, rfl) (λ a b, eq.symm) (λ a b c, eq.trans)
+@[to_additive left_add_coset_equivalence_rel]
+lemma left_coset_equivalence_rel (s : set α) : equivalence (left_coset_equivalence s) :=
+mk_equivalence (left_coset_equivalence s) (λ a, rfl) (λ a b, eq.symm) (λ a b c, eq.trans)
 
 /-- Equality of two right cosets `s * a` and `s * b`. -/
-@[to_additive right_add_coset_equiv "Equality of two right cosets `s + a` and `s + b`."]
+@[to_additive right_add_coset_equivalence "Equality of two right cosets `s + a` and `s + b`."]
 def right_coset_equivalence (s : set α) (a b : α) := s *r a = s *r b
 
 @[to_additive right_add_coset_equivalence_rel]
@@ -195,11 +195,11 @@ def left_rel [group α] (s : subgroup α) : setoid α :=
 ⟨λ x y, x⁻¹ * y ∈ s,
   assume x, by simp [s.one_mem],
   assume x y hxy,
-  have (x⁻¹ * y)⁻¹ ∈ s, from s.inv_mem hxy,
-  by simpa using this,
+    have (x⁻¹ * y)⁻¹ ∈ s, from s.inv_mem hxy,
+    by simpa using this,
   assume x y z hxy hyz,
-  have x⁻¹ * y * (y⁻¹ * z) ∈ s, from s.mul_mem hxy hyz,
-  by simpa [mul_assoc] using this⟩
+    have x⁻¹ * y * (y⁻¹ * z) ∈ s, from s.mul_mem hxy hyz,
+    by simpa [mul_assoc] using this⟩
 
 @[to_additive]
 instance left_rel_decidable [group α] (s : subgroup α) [d : decidable_pred (λ a, a ∈ s)] :

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -76,11 +76,11 @@ mk_equivalence (left_coset_equiv s) (λ a, rfl) (λ a b, eq.symm) (λ a b c, eq.
 
 /-- Equality of two right cosets `s * a` and `s * b`. -/
 @[to_additive right_add_coset_equiv "Equality of two right cosets `s + a` and `s + b`."]
-def right_coset_equiv (s : set α) (a b : α) := s *r a = s *r b
+def right_coset_equivalence (s : set α) (a b : α) := s *r a = s *r b
 
-@[to_additive right_add_coset_equiv_rel]
-lemma right_coset_equiv_rel (s : set α) : equivalence (right_coset_equiv s) :=
-mk_equivalence (right_coset_equiv s) (λ a, rfl) (λ a b, eq.symm) (λ a b c, eq.trans)
+@[to_additive right_add_coset_equivalence_rel]
+lemma right_coset_equivalence_rel (s : set α) : equivalence (right_coset_equivalence s) :=
+mk_equivalence (right_coset_equivalence s) (λ a, rfl) (λ a b, eq.symm) (λ a b c, eq.trans)
 
 end coset_mul
 
@@ -210,18 +210,18 @@ instance left_rel_decidable [group α] (s : subgroup α) [d : decidable_pred (λ
 def quotient [group α] (s : subgroup α) : Type* := quotient (left_rel s)
 
 /-- The equivalence relation corresponding to the partition of a group by right cosets of a
-subgroup.-/
+subgroup. -/
 @[to_additive "The equivalence relation corresponding to the partition of a group by right cosets of
 a subgroup."]
 def right_rel [group α] (s : subgroup α) : setoid α :=
 ⟨λ x y, y * x⁻¹ ∈ s,
   assume x, by simp [s.one_mem],
   assume x y hxy,
-  have (y * x⁻¹)⁻¹ ∈ s, from s.inv_mem hxy,
-  by simpa using this,
+    have (y * x⁻¹)⁻¹ ∈ s, from s.inv_mem hxy,
+    by simpa using this,
   assume x y z hxy hyz,
-  have (z * y⁻¹) * (y * x⁻¹) ∈ s, from s.mul_mem hyz hxy,
-  by simpa [mul_assoc] using this⟩
+    have (z * y⁻¹) * (y * x⁻¹) ∈ s, from s.mul_mem hyz hxy,
+    by simpa [mul_assoc] using this⟩
 
 @[to_additive]
 instance right_rel_decidable [group α] (s : subgroup α) [d : decidable_pred (λ a, a ∈ s)] :
@@ -296,15 +296,15 @@ open quotient_group
 variables [group α] {s : subgroup α}
 
 /-- The natural bijection between a left coset `g * s` and `s`. -/
-@[to_additive "The natural bijection between the cosets `g + s` and `s`"]
+@[to_additive "The natural bijection between the cosets `g + s` and `s`."]
 def left_coset_equiv_subgroup (g : α) : left_coset g s ≃ s :=
 ⟨λ x, ⟨g⁻¹ * x.1, (mem_left_coset_iff _).1 x.2⟩,
  λ x, ⟨g * x.1, x.1, x.2, rfl⟩,
  λ ⟨x, hx⟩, subtype.eq $ by simp,
  λ ⟨g, hg⟩, subtype.eq $ by simp⟩
 
-/-- The natural bijection between a right coset `s * g` and `s`.-/
-@[to_additive "The natural bijection between the cosets `s + g` and `s`"]
+/-- The natural bijection between a right coset `s * g` and `s`. -/
+@[to_additive "The natural bijection between the cosets `s + g` and `s`."]
 def right_coset_equiv_subgroup (g : α) : right_coset ↑s g ≃ s :=
 ⟨λ x, ⟨x.1 * g⁻¹, (mem_right_coset_iff _).1 x.2⟩,
  λ x, ⟨x.1 * g, x.1, x.2, rfl⟩,

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -21,8 +21,8 @@ This file develops the basic theory of left and right cosets.
   subgroup `s`, for an `add_group` this is `quotient_add_group.quotient s`.
 * `quotient_group.mk`: the canonical map from `α` to `α/s` for a subgroup `s` of `α`, for an
   `add_group` this is `quotient_add_group.mk`.
-* `subgroup.left_coset_equiv_subgroup`: the natural bijection between a left coset and the subgroup, for an
-  `add_group` this is `add_subgroup.left_coset_equiv_add_subgroup`.
+* `subgroup.left_coset_equiv_subgroup`: the natural bijection between a left coset and the subgroup,
+  for an `add_group` this is `add_subgroup.left_coset_equiv_add_subgroup`.
 
 ## Notation
 

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -15,7 +15,7 @@ This file develops the basic theory of left and right cosets.
 
 * `left_coset a s`: the left coset `a * s` for an element `a : α` and a subset `s ⊆ α`.
 * `right_coset s a`: the right coset `s * a` for an element `a : α` and a subset `s ⊆ α`.
-* `quotient s`: the quotient type corresponding to the left cosets with respect to a subgroup `s`.
+* `quotient s`: the quotient type representing the left cosets with respect to a subgroup `s`.
 * `mk`: the canonical map from `α` to `α/s` for a subgroup `s` of `α`.
 * `left_coset_equiv_subgroup`: the natural bijection between a left coset and the subgroup.
 
@@ -35,13 +35,13 @@ open set function
 
 variable {α : Type*}
 
-/-- The left coset `a*s` corresponding to an element `a : α` and a subset `s : set α` -/
-@[to_additive left_add_coset "The left coset `a+s` corresponding to an element `a : α`
+/-- The left coset `a * s` for an element `a : α` and a subset `s : set α` -/
+@[to_additive left_add_coset "The left coset `a+s` for an element `a : α`
 and a subset `s : set α`"]
 def left_coset [has_mul α] (a : α) (s : set α) : set α := (λ x, a * x) '' s
 
-/-- The right coset `s*a` corresponding to an element `a : α` and a subset `s : set α` -/
-@[to_additive right_add_coset "The right coset `s+a` corresponding to an element `a : α`
+/-- The right coset `s * a` for an element `a : α` and a subset `s : set α` -/
+@[to_additive right_add_coset "The right coset `s+a` for an element `a : α`
 and a subset `s : set α`"]
 def right_coset [has_mul α] (s : set α) (a : α) : set α := (λ x, x * a) '' s
 

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -13,11 +13,16 @@ This file develops the basic theory of left and right cosets.
 
 ## Main definitions
 
-* `left_coset a s`: the left coset `a * s` for an element `a : α` and a subset `s ⊆ α`.
-* `right_coset s a`: the right coset `s * a` for an element `a : α` and a subset `s ⊆ α`.
-* `quotient s`: the quotient type representing the left cosets with respect to a subgroup `s`.
-* `mk`: the canonical map from `α` to `α/s` for a subgroup `s` of `α`.
-* `left_coset_equiv_subgroup`: the natural bijection between a left coset and the subgroup.
+* `left_coset a s`: the left coset `a * s` for an element `a : α` and a subset `s ⊆ α`, for an
+  `add_group` this is `left_add_coset a s`.
+* `right_coset s a`: the right coset `s * a` for an element `a : α` and a subset `s ⊆ α`, for an
+  `add_group` this is `right_add_coset s a`.
+* `quotient_group.quotient s`: the quotient type representing the left cosets with respect to a
+  subgroup `s`, for an `add_group` this is `quotient_add_group.quotient s`.
+* `quotient_group.mk`: the canonical map from `α` to `α/s` for a subgroup `s` of `α`, for an
+  `add_group` this is `quotient_add_group.mk`.
+* `subgroup.left_coset_equiv_subgroup`: the natural bijection between a left coset and the subgroup, for an
+  `add_group` this is `add_subgroup.left_coset_equiv_add_subgroup`.
 
 ## Notation
 

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -291,7 +291,7 @@ open quotient_group
 variables [group α] {s : subgroup α}
 
 /-- The natural bijection between a left coset `g * s` and `s`. -/
-@[to_additive "The natural bijection between the cosets `g+s` and `s`"]
+@[to_additive "The natural bijection between the cosets `g + s` and `s`"]
 def left_coset_equiv_subgroup (g : α) : left_coset g s ≃ s :=
 ⟨λ x, ⟨g⁻¹ * x.1, (mem_left_coset_iff _).1 x.2⟩,
  λ x, ⟨g * x.1, x.1, x.2, rfl⟩,
@@ -299,6 +299,7 @@ def left_coset_equiv_subgroup (g : α) : left_coset g s ≃ s :=
  λ ⟨g, hg⟩, subtype.eq $ by simp⟩
 
 /-- The natural bijection between a right coset `s * g` and `s`.-/
+@[to_additive "The natural bijection between the cosets `s + g` and `s`"]
 def right_coset_equiv_subgroup (g : α) : right_coset ↑s g ≃ s :=
 ⟨λ x, ⟨x.1 * g⁻¹, (mem_right_coset_iff _).1 x.2⟩,
  λ x, ⟨x.1 * g, x.1, x.2, rfl⟩,


### PR DESCRIPTION
This PR dualises two results from left_coset to right_coset and adds a module doc.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
