### PR TITLE
[Merged by Bors] - feat(ring_theory/power_series/basic): remove const coeff

### DIFF
--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1203,7 +1203,7 @@ mv_power_series.mul_inv_of_unit φ u $ h
 /-- Two ways of removing the constant coefficient of a power series are the same. -/
 lemma sub_const_eq_shift_mul_X (φ : power_series R) :
   φ - C R (constant_coeff R φ) = power_series.mk (λ p, coeff R (p + 1) φ) * X :=
-sub_eq_iff_eq_add.mpr  (exact eq_shift_mul_X_add_const φ)
+sub_eq_iff_eq_add.mpr (eq_shift_mul_X_add_const φ)
 
 lemma sub_const_eq_X_mul_shift (φ : power_series R) :
   φ - C R (constant_coeff R φ) = X * power_series.mk (λ p, coeff R (p + 1) φ) :=

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1192,7 +1192,7 @@ end
 lemma sub_const_eq_X_mul_shift (φ : power_series R) :
   φ - C R (constant_coeff R φ) = X * power_series.mk (λ p, coeff R (p + 1) φ) :=
 begin
- ext, cases n,
+  ext, cases n,
   { simp only [ring_hom.map_sub, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
     zero_mul, sub_self, ring_hom.map_mul] },
   simp only [coeff_succ_X_mul, coeff_mk, linear_map.map_sub],

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -991,6 +991,7 @@ begin
   simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false, add_zero],
 end
 
+/-- Split off the constant coefficient. -/
 lemma eq_X_mul_shift_add_const (φ : power_series R) :
   φ = X * mk (λ p, coeff R (p + 1) φ) + C R (constant_coeff R φ) :=
 begin

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -984,8 +984,7 @@ mv_power_series.is_unit_constant_coeff φ h
 lemma eq_shift_mul_X_add_const (φ : power_series R) :
   φ = mk (λ p, coeff R (p + 1) φ) * X + C R (constant_coeff R φ) :=
 begin
-  ext,
-  cases n,
+  ext (_ | n),
   { simp only [ring_hom.map_add, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
     zero_add, mul_zero, ring_hom.map_mul], },
   simp only [coeff_succ_mul_X, coeff_mk, linear_map.map_add],
@@ -995,8 +994,7 @@ end
 lemma eq_X_mul_shift_add_const (φ : power_series R) :
   φ = X * mk (λ p, coeff R (p + 1) φ) + C R (constant_coeff R φ) :=
 begin
-  ext,
-  cases n,
+  ext (_ | n),
   { simp only [ring_hom.map_add, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
     zero_add, zero_mul, ring_hom.map_mul], },
   simp only [coeff_succ_X_mul, coeff_mk, linear_map.map_add],
@@ -1204,17 +1202,11 @@ mv_power_series.mul_inv_of_unit φ u $ h
 /-- Two ways of removing the constant coefficient of a power series are the same. -/
 lemma sub_const_eq_shift_mul_X (φ : power_series R) :
   φ - C R (constant_coeff R φ) = power_series.mk (λ p, coeff R (p + 1) φ) * X :=
-begin
-  rw [sub_eq_iff_eq_add],
-  exact eq_shift_mul_X_add_const φ,
-end
+sub_eq_iff_eq_add.mpr  (exact eq_shift_mul_X_add_const φ)
 
 lemma sub_const_eq_X_mul_shift (φ : power_series R) :
   φ - C R (constant_coeff R φ) = X * power_series.mk (λ p, coeff R (p + 1) φ) :=
-begin
-  rw [sub_eq_iff_eq_add],
-  exact eq_X_mul_shift_add_const φ,
-end
+sub_eq_iff_eq_add.mpr (eq_X_mul_shift_add_const φ)
 
 end ring
 

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -986,9 +986,9 @@ lemma eq_shift_mul_X_add_const (φ : power_series R) :
 begin
   ext (_ | n),
   { simp only [ring_hom.map_add, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
-    zero_add, mul_zero, ring_hom.map_mul], },
-  simp only [coeff_succ_mul_X, coeff_mk, linear_map.map_add],
-  simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false, add_zero],
+      zero_add, mul_zero, ring_hom.map_mul], },
+  { simp only [coeff_succ_mul_X, coeff_mk, linear_map.map_add, coeff_C, n.succ_ne_zero, sub_zero,
+      if_false, add_zero], }
 end
 
 /-- Split off the constant coefficient. -/
@@ -997,9 +997,9 @@ lemma eq_X_mul_shift_add_const (φ : power_series R) :
 begin
   ext (_ | n),
   { simp only [ring_hom.map_add, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
-    zero_add, zero_mul, ring_hom.map_mul], },
-  simp only [coeff_succ_X_mul, coeff_mk, linear_map.map_add],
-  simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false, add_zero],
+      zero_add, zero_mul, ring_hom.map_mul], },
+  { simp only [coeff_succ_X_mul, coeff_mk, linear_map.map_add, coeff_C, n.succ_ne_zero, sub_zero,
+      if_false, add_zero], }
 end
 
 section map

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -980,6 +980,29 @@ lemma is_unit_constant_coeff (φ : power_series R) (h : is_unit φ) :
   is_unit (constant_coeff R φ) :=
 mv_power_series.is_unit_constant_coeff φ h
 
+/-- Split off the constant coefficient. -/
+lemma eq_shift_mul_X_add_const (φ : power_series R) :
+  φ = mk (λ p, coeff R (p + 1) φ) * X + C R (constant_coeff R φ) :=
+begin
+  ext,
+  cases n,
+  { simp only [ring_hom.map_add, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
+    zero_add, mul_zero, ring_hom.map_mul], },
+  simp only [coeff_succ_mul_X, coeff_mk, linear_map.map_add],
+  simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false, add_zero],
+end
+
+lemma eq_X_mul_shift_add_const (φ : power_series R) :
+  φ = X * mk (λ p, coeff R (p + 1) φ) + C R (constant_coeff R φ) :=
+begin
+  ext,
+  cases n,
+  { simp only [ring_hom.map_add, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
+    zero_add, zero_mul, ring_hom.map_mul], },
+  simp only [coeff_succ_X_mul, coeff_mk, linear_map.map_add],
+  simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false, add_zero],
+end
+
 section map
 variables {S : Type*} {T : Type*} [semiring S] [semiring T]
 variables (f : R →+* S) (g : S →+* T)
@@ -1182,21 +1205,15 @@ mv_power_series.mul_inv_of_unit φ u $ h
 lemma sub_const_eq_shift_mul_X (φ : power_series R) :
   φ - C R (constant_coeff R φ) = power_series.mk (λ p, coeff R (p + 1) φ) * X :=
 begin
-  ext, cases n,
-  { simp only [ring_hom.map_sub, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
-    mul_zero, sub_self, ring_hom.map_mul] },
-  simp only [coeff_succ_mul_X, coeff_mk, linear_map.map_sub],
-  simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false],
+  rw [sub_eq_iff_eq_add],
+  exact eq_shift_mul_X_add_const φ,
 end
 
 lemma sub_const_eq_X_mul_shift (φ : power_series R) :
   φ - C R (constant_coeff R φ) = X * power_series.mk (λ p, coeff R (p + 1) φ) :=
 begin
-  ext, cases n,
-  { simp only [ring_hom.map_sub, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
-    zero_mul, sub_self, ring_hom.map_mul] },
-  simp only [coeff_succ_X_mul, coeff_mk, linear_map.map_sub],
-  simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false],
+  rw [sub_eq_iff_eq_add],
+  exact eq_X_mul_shift_add_const φ,
 end
 
 end ring

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1190,7 +1190,7 @@ begin
 end
 
 lemma sub_const_eq_X_mul_shift (φ : power_series R) :
-  (φ - C R (constant_coeff R φ)) = X * power_series.mk (λ p, coeff R (p + 1) φ) :=
+  φ - C R (constant_coeff R φ) = X * power_series.mk (λ p, coeff R (p + 1) φ) :=
 begin
  ext, cases n,
   { simp only [ring_hom.map_sub, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1207,7 +1207,7 @@ begin
   simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false],
 end
 
-lemma minus_const_eq_x_mul_shift (φ: power_series A) :
+lemma sub_const_eq_x_mul_shift (φ : power_series A) :
   (φ - C A (constant_coeff A φ)) = X * power_series.mk (λ p, coeff A p.succ φ) :=
 begin
   simp only [mul_comm,  minus_const_eq_shift_mul_x],

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1196,6 +1196,23 @@ rescale (-1 : A)
 @[simp] lemma eval_neg_hom_X : eval_neg_hom (X : power_series A) = -X :=
 rescale_neg_one_X
 
+/-- Two ways of truncating a power series are the same. -/
+lemma minus_const_eq_shift_mul_x (φ: power_series A) :
+  (φ - C A (constant_coeff A φ)) = power_series.mk (λ p, coeff A p.succ φ) * X:=
+begin
+  ext, cases n,
+  { simp only [ring_hom.map_sub, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
+    mul_zero, sub_self, ring_hom.map_mul] },
+  simp only [coeff_succ_mul_X, coeff_mk, linear_map.map_sub],
+  simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false],
+end
+
+lemma minus_const_eq_x_mul_shift (φ: power_series A) :
+  (φ - C A (constant_coeff A φ)) = X * power_series.mk (λ p, coeff A p.succ φ) :=
+begin
+  simp only [mul_comm,  minus_const_eq_shift_mul_x],
+end
+
 end comm_ring
 
 section integral_domain

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1197,8 +1197,8 @@ rescale (-1 : A)
 rescale_neg_one_X
 
 /-- Two ways of truncating a power series are the same. -/
-lemma minus_const_eq_shift_mul_x (φ: power_series A) :
-  (φ - C A (constant_coeff A φ)) = power_series.mk (λ p, coeff A p.succ φ) * X:=
+lemma sub_const_eq_shift_mul_X (φ : power_series A) :
+  φ - C A (constant_coeff A φ) = power_series.mk (λ p, coeff A p.succ φ) * X :=
 begin
   ext, cases n,
   { simp only [ring_hom.map_sub, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1198,7 +1198,7 @@ rescale_neg_one_X
 
 /-- Two ways of removing the constant coefficient of a power series are the same. -/
 lemma sub_const_eq_shift_mul_X (φ : power_series A) :
-  φ - C A (constant_coeff A φ) = power_series.mk (λ p, coeff A p.succ φ) * X :=
+  φ - C A (constant_coeff A φ) = power_series.mk (λ p, coeff A (p + 1) φ) * X :=
 begin
   ext, cases n,
   { simp only [ring_hom.map_sub, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
@@ -1207,10 +1207,10 @@ begin
   simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false],
 end
 
-lemma sub_const_eq_x_mul_shift (φ : power_series A) :
-  (φ - C A (constant_coeff A φ)) = X * power_series.mk (λ p, coeff A p.succ φ) :=
+lemma sub_const_eq_X_mul_shift (φ : power_series A) :
+  (φ - C A (constant_coeff A φ)) = X * power_series.mk (λ p, coeff A (p + 1) φ) :=
 begin
-  simp only [mul_comm,  minus_const_eq_shift_mul_x],
+  simp only [mul_comm,  sub_const_eq_shift_mul_X],
 end
 
 end comm_ring

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1178,6 +1178,27 @@ lemma mul_inv_of_unit (φ : power_series R) (u : units R) (h : constant_coeff R 
   φ * inv_of_unit φ u = 1 :=
 mv_power_series.mul_inv_of_unit φ u $ h
 
+/-- Two ways of removing the constant coefficient of a power series are the same. -/
+lemma sub_const_eq_shift_mul_X (φ : power_series R) :
+  φ - C R (constant_coeff R φ) = power_series.mk (λ p, coeff R (p + 1) φ) * X :=
+begin
+  ext, cases n,
+  { simp only [ring_hom.map_sub, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
+    mul_zero, sub_self, ring_hom.map_mul] },
+  simp only [coeff_succ_mul_X, coeff_mk, linear_map.map_sub],
+  simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false],
+end
+
+lemma sub_const_eq_X_mul_shift (φ : power_series R) :
+  (φ - C R (constant_coeff R φ)) = X * power_series.mk (λ p, coeff R (p + 1) φ) :=
+begin
+ ext, cases n,
+  { simp only [ring_hom.map_sub, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
+    zero_mul, sub_self, ring_hom.map_mul] },
+  simp only [coeff_succ_X_mul, coeff_mk, linear_map.map_sub],
+  simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false],
+end
+
 end ring
 
 section comm_ring
@@ -1195,23 +1216,6 @@ rescale (-1 : A)
 
 @[simp] lemma eval_neg_hom_X : eval_neg_hom (X : power_series A) = -X :=
 rescale_neg_one_X
-
-/-- Two ways of removing the constant coefficient of a power series are the same. -/
-lemma sub_const_eq_shift_mul_X (φ : power_series A) :
-  φ - C A (constant_coeff A φ) = power_series.mk (λ p, coeff A (p + 1) φ) * X :=
-begin
-  ext, cases n,
-  { simp only [ring_hom.map_sub, constant_coeff_C, constant_coeff_X, coeff_zero_eq_constant_coeff,
-    mul_zero, sub_self, ring_hom.map_mul] },
-  simp only [coeff_succ_mul_X, coeff_mk, linear_map.map_sub],
-  simp only [coeff_C, n.succ_ne_zero, sub_zero, if_false],
-end
-
-lemma sub_const_eq_X_mul_shift (φ : power_series A) :
-  (φ - C A (constant_coeff A φ)) = X * power_series.mk (λ p, coeff A (p + 1) φ) :=
-begin
-  simp only [mul_comm,  sub_const_eq_shift_mul_X],
-end
 
 end comm_ring
 

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1196,7 +1196,7 @@ rescale (-1 : A)
 @[simp] lemma eval_neg_hom_X : eval_neg_hom (X : power_series A) = -X :=
 rescale_neg_one_X
 
-/-- Two ways of truncating a power series are the same. -/
+/-- Two ways of removing the constant coefficient of a power series are the same. -/
 lemma sub_const_eq_shift_mul_X (φ : power_series A) :
   φ - C A (constant_coeff A φ) = power_series.mk (λ p, coeff A p.succ φ) * X :=
 begin


### PR DESCRIPTION
This shows that we can factor out X when the constant coefficient is removed from a power series.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
