### PR TITLE
[Merged by Bors] - feat(algebra/category/Semigroup/basic): categories of magmas and semigroups

### DIFF
--- a/src/algebra/category/Mon/basic.lean
+++ b/src/algebra/category/Mon/basic.lean
@@ -118,32 +118,24 @@ section
 variables [monoid X] [monoid Y]
 
 /-- Build an isomorphism in the category `Mon` from a `mul_equiv` between `monoid`s. -/
-@[to_additive add_equiv.to_AddMon_iso "Build an isomorphism in the category `AddMon` from
+@[simps, to_additive add_equiv.to_AddMon_iso "Build an isomorphism in the category `AddMon` from
 an `add_equiv` between `add_monoid`s."]
 def mul_equiv.to_Mon_iso (e : X ≃* Y) : Mon.of X ≅ Mon.of Y :=
 { hom := e.to_monoid_hom,
   inv := e.symm.to_monoid_hom }
 
-@[simp, to_additive add_equiv.to_AddMon_iso_hom]
-lemma mul_equiv.to_Mon_iso_hom {e : X ≃* Y} : e.to_Mon_iso.hom = e.to_monoid_hom := rfl
-@[simp, to_additive add_equiv.to_AddMon_iso_inv]
-lemma mul_equiv.to_Mon_iso_inv {e : X ≃* Y} : e.to_Mon_iso.inv = e.symm.to_monoid_hom := rfl
 end
 
 section
 variables [comm_monoid X] [comm_monoid Y]
 
 /-- Build an isomorphism in the category `CommMon` from a `mul_equiv` between `comm_monoid`s. -/
-@[to_additive add_equiv.to_AddCommMon_iso "Build an isomorphism in the category `AddCommMon` from
+@[simps, to_additive add_equiv.to_AddCommMon_iso "Build an isomorphism in the category `AddCommMon` from
 an `add_equiv` between `add_comm_monoid`s."]
 def mul_equiv.to_CommMon_iso (e : X ≃* Y) : CommMon.of X ≅ CommMon.of Y :=
 { hom := e.to_monoid_hom,
   inv := e.symm.to_monoid_hom }
 
-@[simp, to_additive add_equiv.to_AddCommMon_iso_hom]
-lemma mul_equiv.to_CommMon_iso_hom {e : X ≃* Y} : e.to_CommMon_iso.hom = e.to_monoid_hom := rfl
-@[simp, to_additive add_equiv.to_AddCommMon_iso_inv]
-lemma mul_equiv.to_CommMon_iso_inv {e : X ≃* Y} : e.to_CommMon_iso.inv = e.symm.to_monoid_hom := rfl
 end
 
 namespace category_theory.iso

--- a/src/algebra/category/Mon/basic.lean
+++ b/src/algebra/category/Mon/basic.lean
@@ -130,8 +130,8 @@ section
 variables [comm_monoid X] [comm_monoid Y]
 
 /-- Build an isomorphism in the category `CommMon` from a `mul_equiv` between `comm_monoid`s. -/
-@[simps, to_additive add_equiv.to_AddCommMon_iso "Build an isomorphism in the category `AddCommMon` from
-an `add_equiv` between `add_comm_monoid`s."]
+@[simps, to_additive add_equiv.to_AddCommMon_iso "Build an isomorphism in the category `AddCommMon`
+from an `add_equiv` between `add_comm_monoid`s."]
 def mul_equiv.to_CommMon_iso (e : X ≃* Y) : CommMon.of X ≅ CommMon.of Y :=
 { hom := e.to_monoid_hom,
   inv := e.symm.to_monoid_hom }

--- a/src/algebra/category/Semigroup/basic.lean
+++ b/src/algebra/category/Semigroup/basic.lean
@@ -128,8 +128,6 @@ def mul_equiv.to_Magma_iso (e : X ≃* Y) : Magma.of X ≅ Magma.of Y :=
 { hom := e.to_mul_hom,
   inv := e.symm.to_mul_hom }
 
-variables [has_add X] [has_add Y]
-
 @[simp, to_additive add_equiv.to_AddMagma_iso_hom]
 lemma mul_equiv.to_Magma_iso_hom {e : X ≃* Y} : e.to_Magma_iso.hom = e.to_mul_hom := rfl
 @[simp, to_additive add_equiv.to_AddMagma_iso_inv]

--- a/src/algebra/category/Semigroup/basic.lean
+++ b/src/algebra/category/Semigroup/basic.lean
@@ -5,7 +5,7 @@ Authors: Julian Kuelshammer (heavily based on `Mon.basic` by Scott Morrison)
 -/
 import category_theory.concrete_category.bundled_hom
 import category_theory.concrete_category.reflects_isomorphisms
-import algebra.punit_instances
+import algebra.pempty_instances
 
 /-!
 # Category instances for has_mul, has_add, semigroup and add_semigroup
@@ -51,7 +51,7 @@ def of (M : Type u) [has_mul M] : Magma := bundled.of M
 add_decl_doc AddMagma.of
 
 @[to_additive]
-instance : inhabited Magma := ⟨Magma.of empty⟩
+instance : inhabited Magma := ⟨Magma.of pempty⟩
 
 @[to_additive]
 instance (M : Magma) : has_mul M := M.str

--- a/src/algebra/category/Semigroup/basic.lean
+++ b/src/algebra/category/Semigroup/basic.lean
@@ -117,33 +117,23 @@ section
 variables [has_mul X] [has_mul Y]
 
 /-- Build an isomorphism in the category `Magma` from a `mul_equiv` between `has_mul`s. -/
-@[to_additive add_equiv.to_AddMagma_iso "Build an isomorphism in the category `AddMagma` from
+@[simps, to_additive add_equiv.to_AddMagma_iso "Build an isomorphism in the category `AddMagma` from
 an `add_equiv` between `has_add`s."]
 def mul_equiv.to_Magma_iso (e : X ≃* Y) : Magma.of X ≅ Magma.of Y :=
 { hom := e.to_mul_hom,
   inv := e.symm.to_mul_hom }
 
-@[simp, to_additive add_equiv.to_AddMagma_iso_hom]
-lemma mul_equiv.to_Magma_iso_hom {e : X ≃* Y} : e.to_Magma_iso.hom = e.to_mul_hom := rfl
-@[simp, to_additive add_equiv.to_AddMagma_iso_inv]
-lemma mul_equiv.to_Magma_iso_inv {e : X ≃* Y} : e.to_Magma_iso.inv = e.symm.to_mul_hom := rfl
 end
 
 section
 variables [semigroup X] [semigroup Y]
 
 /-- Build an isomorphism in the category `Semigroup` from a `mul_equiv` between `semigroup`s. -/
-@[to_additive add_equiv.to_AddSemigroup_iso "Build an isomorphism in the category `AddSemigroup`
+@[simps, to_additive add_equiv.to_AddSemigroup_iso "Build an isomorphism in the category `AddSemigroup`
 from an `add_equiv` between `add_semigroup`s."]
 def mul_equiv.to_Semigroup_iso (e : X ≃* Y) : Semigroup.of X ≅ Semigroup.of Y :=
 { hom := e.to_mul_hom,
   inv := e.symm.to_mul_hom }
-
-@[simp, to_additive add_equiv.to_AddSemigroup_iso_hom]
-lemma mul_equiv.to_Semigroup_iso_hom {e : X ≃* Y} : e.to_Semigroup_iso.hom = e.to_mul_hom := rfl
-@[simp, to_additive add_equiv.to_AddSemigroup_iso_inv]
-lemma mul_equiv.to_Semigroup_iso_inv {e : X ≃* Y} : e.to_Semigroup_iso.inv = e.symm.to_mul_hom :=
-rfl
 
 end
 

--- a/src/algebra/category/Semigroup/basic.lean
+++ b/src/algebra/category/Semigroup/basic.lean
@@ -51,11 +51,6 @@ def of (M : Type u) [has_mul M] : Magma := bundled.of M
 add_decl_doc AddMagma.of
 
 @[to_additive]
-instance : semigroup empty :=
-{ mul := λ x y, by cases x,
-  mul_assoc := λ x y z, by cases x }
-
-@[to_additive]
 instance : inhabited Magma := ⟨Magma.of empty⟩
 
 @[to_additive]

--- a/src/algebra/category/Semigroup/basic.lean
+++ b/src/algebra/category/Semigroup/basic.lean
@@ -82,7 +82,7 @@ def of (M : Type u) [semigroup M] : Semigroup := bundled.of M
 add_decl_doc AddSemigroup.of
 
 @[to_additive]
-instance : inhabited Semigroup := ⟨Semigroup.of empty⟩
+instance : inhabited Semigroup := ⟨Semigroup.of pempty⟩
 
 @[to_additive]
 instance (M : Semigroup) : semigroup M := M.str

--- a/src/algebra/category/Semigroup/basic.lean
+++ b/src/algebra/category/Semigroup/basic.lean
@@ -129,8 +129,8 @@ section
 variables [semigroup X] [semigroup Y]
 
 /-- Build an isomorphism in the category `Semigroup` from a `mul_equiv` between `semigroup`s. -/
-@[simps, to_additive add_equiv.to_AddSemigroup_iso "Build an isomorphism in the category `AddSemigroup`
-from an `add_equiv` between `add_semigroup`s."]
+@[simps, to_additive add_equiv.to_AddSemigroup_iso "Build an isomorphism in the category
+`AddSemigroup` from an `add_equiv` between `add_semigroup`s."]
 def mul_equiv.to_Semigroup_iso (e : X ≃* Y) : Semigroup.of X ≅ Semigroup.of Y :=
 { hom := e.to_mul_hom,
   inv := e.symm.to_mul_hom }

--- a/src/algebra/category/Semigroup/basic.lean
+++ b/src/algebra/category/Semigroup/basic.lean
@@ -94,23 +94,6 @@ instance has_forget_to_Magma : has_forget₂ Semigroup Magma := bundled_hom.forg
 
 end Semigroup
 
--- We verify that the coercions of morphisms to functions work correctly:
-example {R S : Magma}     (f : R ⟶ S) : (R : Type) → (S : Type) := f
-example {R S : Semigroup} (f : R ⟶ S) : (R : Type) → (S : Type) := f
-
--- We verify that when constructing a morphism in `Semigroup`,
--- when we construct the `to_fun` field, the types are presented as `↥R`,
--- rather than `R.α` or (as we used to have) `↥(bundled.map semigroup.to_has_mul R)`.
-example (R : Semigroup.{u}) : R ⟶ R :=
-{ to_fun := λ X,
-  begin
-    match_target (R : Type u),
-    exact X
-  end ,
-  map_mul' := λ x y,
-  rfl, }
-
-
 variables {X Y : Type u}
 
 section

--- a/src/algebra/category/Semigroup/basic.lean
+++ b/src/algebra/category/Semigroup/basic.lean
@@ -32,7 +32,7 @@ open category_theory
 @[to_additive AddMagma]
 def Magma : Type (u+1) := bundled has_mul
 
-/-- The category of additive magmas and magma morphisms. -/
+/-- The category of additive magmas and additive magma morphisms. -/
 add_decl_doc AddMagma
 
 namespace Magma

--- a/src/algebra/category/Semigroup/basic.lean
+++ b/src/algebra/category/Semigroup/basic.lean
@@ -1,0 +1,224 @@
+/-
+Copyright (c) 2021 Julian Kuelshammer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julian Kuelshammer (heavily based on `Mon.basic` by Scott Morrison)
+-/
+import category_theory.concrete_category.bundled_hom
+import category_theory.concrete_category.reflects_isomorphisms
+import algebra.punit_instances
+
+/-!
+# Category instances for has_mul, has_add, semigroup and add_semigroup
+
+We introduce the bundled categories:
+* `Magma`
+* `AddMagma`
+* `Semigroup`
+* `AddSemigroup`
+along with the relevant forgetful functors between them.
+
+## TODO
+
+* Limits in these categories
+* adjoining a unit adjunction to Mon
+* free/forgetful adjunctions
+-/
+
+universes u v
+
+open category_theory
+
+/-- The category of magmas and magma morphisms. -/
+@[to_additive AddMagma]
+def Magma : Type (u+1) := bundled has_mul
+
+/-- The category of additive magmas and magma morphisms. -/
+add_decl_doc AddMagma
+
+namespace Magma
+
+@[to_additive]
+instance bundled_hom : bundled_hom @mul_hom :=
+⟨@mul_hom.to_fun, @mul_hom.id, @mul_hom.comp, @mul_hom.coe_inj⟩
+
+attribute [derive [has_coe_to_sort, large_category, concrete_category]] Magma AddMagma
+
+/-- Construct a bundled `Magma` from the underlying type and typeclass. -/
+@[to_additive]
+def of (M : Type u) [has_mul M] : Magma := bundled.of M
+
+/-- Construct a bundled `Magma` from the underlying type and typeclass. -/
+add_decl_doc AddMagma.of
+
+@[to_additive]
+instance : semigroup empty :=
+{ mul := λ x y, by cases x,
+  mul_assoc := λ x y z, by cases x }
+
+@[to_additive]
+instance : inhabited Magma := ⟨Magma.of empty⟩
+
+@[to_additive]
+instance (M : Magma) : has_mul M := M.str
+
+@[simp, to_additive] lemma coe_of (R : Type u) [has_mul R] : (Magma.of R : Type u) = R := rfl
+
+end Magma
+
+/-- The category of semigroups and semigroup morphisms. -/
+@[to_additive AddSemigroup]
+def Semigroup : Type (u+1) := bundled semigroup
+
+/-- The category of additive semigroups and semigroup morphisms. -/
+add_decl_doc AddSemigroup
+
+namespace Semigroup
+
+@[to_additive]
+instance : bundled_hom.parent_projection semigroup.to_has_mul := ⟨⟩
+
+attribute [derive [has_coe_to_sort, large_category, concrete_category]] Semigroup AddSemigroup
+
+/-- Construct a bundled `Semigroup` from the underlying type and typeclass. -/
+@[to_additive]
+def of (M : Type u) [semigroup M] : Semigroup := bundled.of M
+
+/-- Construct a bundled `AddSemigroup` from the underlying type and typeclass. -/
+add_decl_doc AddSemigroup.of
+
+@[to_additive]
+instance : inhabited Semigroup := ⟨Semigroup.of empty⟩
+
+@[to_additive]
+instance (M : Semigroup) : semigroup M := M.str
+
+@[simp, to_additive] lemma coe_of (R : Type u) [semigroup R] : (Semigroup.of R : Type u) = R := rfl
+
+@[to_additive has_forget_to_AddMagma]
+instance has_forget_to_Magma : has_forget₂ Semigroup Magma := bundled_hom.forget₂ _ _
+
+end Semigroup
+
+-- We verify that the coercions of morphisms to functions work correctly:
+example {R S : Magma}     (f : R ⟶ S) : (R : Type) → (S : Type) := f
+example {R S : Semigroup} (f : R ⟶ S) : (R : Type) → (S : Type) := f
+
+-- We verify that when constructing a morphism in `Semigroup`,
+-- when we construct the `to_fun` field, the types are presented as `↥R`,
+-- rather than `R.α` or (as we used to have) `↥(bundled.map semigroup.to_has_mul R)`.
+example (R : Semigroup.{u}) : R ⟶ R :=
+{ to_fun := λ X,
+  begin
+    match_target (R : Type u),
+    exact X
+  end ,
+  map_mul' := λ x y,
+  rfl, }
+
+
+variables {X Y : Type u}
+
+section
+variables [has_mul X] [has_mul Y]
+
+/-- Build an isomorphism in the category `Magma` from a `mul_equiv` between `has_mul`s. -/
+@[to_additive add_equiv.to_AddMagma_iso "Build an isomorphism in the category `AddMagma` from
+an `add_equiv` between `has_add`s."]
+def mul_equiv.to_Magma_iso (e : X ≃* Y) : Magma.of X ≅ Magma.of Y :=
+{ hom := e.to_mul_hom,
+  inv := e.symm.to_mul_hom }
+
+variables [has_add X] [has_add Y]
+
+@[simp, to_additive add_equiv.to_AddMagma_iso_hom]
+lemma mul_equiv.to_Magma_iso_hom {e : X ≃* Y} : e.to_Magma_iso.hom = e.to_mul_hom := rfl
+@[simp, to_additive add_equiv.to_AddMagma_iso_inv]
+lemma mul_equiv.to_Magma_iso_inv {e : X ≃* Y} : e.to_Magma_iso.inv = e.symm.to_mul_hom := rfl
+end
+
+section
+variables [semigroup X] [semigroup Y]
+
+/-- Build an isomorphism in the category `Semigroup` from a `mul_equiv` between `semigroup`s. -/
+@[to_additive add_equiv.to_AddSemigroup_iso "Build an isomorphism in the category `AddSemigroup`
+from an `add_equiv` between `add_semigroup`s."]
+def mul_equiv.to_Semigroup_iso (e : X ≃* Y) : Semigroup.of X ≅ Semigroup.of Y :=
+{ hom := e.to_mul_hom,
+  inv := e.symm.to_mul_hom }
+
+@[simp, to_additive add_equiv.to_AddSemigroup_iso_hom]
+lemma mul_equiv.to_Semigroup_iso_hom {e : X ≃* Y} : e.to_Semigroup_iso.hom = e.to_mul_hom := rfl
+@[simp, to_additive add_equiv.to_AddSemigroup_iso_inv]
+lemma mul_equiv.to_Semigroup_iso_inv {e : X ≃* Y} : e.to_Semigroup_iso.inv = e.symm.to_mul_hom :=
+rfl
+
+end
+
+namespace category_theory.iso
+
+/-- Build a `mul_equiv` from an isomorphism in the category `Magma`. -/
+@[to_additive AddMagma_iso_to_add_equiv "Build an `add_equiv` from an isomorphism in the category
+`AddMagma`."]
+def Magma_iso_to_mul_equiv {X Y : Magma} (i : X ≅ Y) : X ≃* Y :=
+{ to_fun := i.hom,
+  inv_fun := i.inv,
+  left_inv := begin rw function.left_inverse, simp end,
+  right_inv := begin rw function.right_inverse, rw function.left_inverse, simp end,
+  map_mul' := by simp }
+
+/-- Build a `mul_equiv` from an isomorphism in the category `Semigroup`. -/
+@[to_additive "Build an `add_equiv` from an isomorphism in the category
+`AddSemigroup`."]
+def Semigroup_iso_to_mul_equiv {X Y : Semigroup} (i : X ≅ Y) : X ≃* Y :=
+{ to_fun := i.hom,
+  inv_fun := i.inv,
+  left_inv := begin rw function.left_inverse, simp end,
+  right_inv := begin rw function.right_inverse, rw function.left_inverse, simp end,
+  map_mul' := by simp }
+
+end category_theory.iso
+
+/-- multiplicative equivalences between `has_mul`s are the same as (isomorphic to) isomorphisms
+in `Magma` -/
+@[to_additive add_equiv_iso_AddMagma_iso "additive equivalences between `has_add`s are the same
+as (isomorphic to) isomorphisms in `AddMagma`"]
+def mul_equiv_iso_Magma_iso {X Y : Type u} [has_mul X] [has_mul Y] :
+  (X ≃* Y) ≅ (Magma.of X ≅ Magma.of Y) :=
+{ hom := λ e, e.to_Magma_iso,
+  inv := λ i, i.Magma_iso_to_mul_equiv }
+
+/-- multiplicative equivalences between `semigroup`s are the same as (isomorphic to) isomorphisms
+in `Semigroup` -/
+@[to_additive add_equiv_iso_AddSemigroup_iso "additive equivalences between `add_semigroup`s are
+the same as (isomorphic to) isomorphisms in `AddSemigroup`"]
+def mul_equiv_iso_Semigroup_iso {X Y : Type u} [semigroup X] [semigroup Y] :
+  (X ≃* Y) ≅ (Semigroup.of X ≅ Semigroup.of Y) :=
+{ hom := λ e, e.to_Semigroup_iso,
+  inv := λ i, i.Semigroup_iso_to_mul_equiv }
+
+@[to_additive]
+instance Magma.forget_reflects_isos : reflects_isomorphisms (forget Magma.{u}) :=
+{ reflects := λ X Y f _,
+  begin
+    resetI,
+    let i := as_iso ((forget Magma).map f),
+    let e : X ≃* Y := { ..f, ..i.to_equiv },
+    exact { ..e.to_Magma_iso },
+  end }
+
+@[to_additive]
+instance Semigroup.forget_reflects_isos : reflects_isomorphisms (forget Semigroup.{u}) :=
+{ reflects := λ X Y f _,
+  begin
+    resetI,
+    let i := as_iso ((forget Semigroup).map f),
+    let e : X ≃* Y := { ..f, ..i.to_equiv },
+    exact { ..e.to_Semigroup_iso },
+  end }
+
+/-!
+Once we've shown that the forgetful functors to type reflect isomorphisms,
+we automatically obtain that the `forget₂` functors between our concrete categories
+reflect isomorphisms.
+-/
+example : reflects_isomorphisms (forget₂ Semigroup Magma) := by apply_instance

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -39,6 +39,11 @@ end associative
 section semigroup
 variables {α : Type*}
 
+@[to_additive]
+instance : semigroup empty :=
+{ mul := λ x y, by cases x,
+  mul_assoc := λ x y z, by cases x }
+
 /--
 Composing two multiplications on the left by `y` then `x`
 is equal to a multiplication on the left by `x * y`.

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -39,11 +39,6 @@ end associative
 section semigroup
 variables {α : Type*}
 
-@[to_additive]
-instance : semigroup empty :=
-{ mul := λ x y, by cases x,
-  mul_assoc := λ x y z, by cases x }
-
 /--
 Composing two multiplications on the left by `y` then `x`
 is equal to a multiplication on the left by `x * y`.

--- a/src/algebra/pempty_instances.lean
+++ b/src/algebra/pempty_instances.lean
@@ -16,6 +16,6 @@ that it is a semigroup.
 universes u
 
 @[to_additive]
-instance : semigroup (pempty) :=
+instance semigroup_pempty : semigroup pempty.{u+1} :=
 { mul := λ x y, by cases x,
   mul_assoc := λ x y z, by cases x }

--- a/src/algebra/pempty_instances.lean
+++ b/src/algebra/pempty_instances.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2021 Julian Kuelshammer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julian Kuelshammer
+-/
+
+import algebra.module.basic
+
+/-!
+# Instances on pempty
+
+This file collects facts about algebraic structures on the (universe-polymorphic) empty type, e.g.
+that it is a semigroup.
+-/
+
+universes u
+
+@[to_additive]
+instance : semigroup (pempty) :=
+{ mul := λ x y, by cases x,
+  mul_assoc := λ x y z, by cases x }

--- a/src/algebra/pempty_instances.lean
+++ b/src/algebra/pempty_instances.lean
@@ -16,6 +16,6 @@ that it is a semigroup.
 universes u
 
 @[to_additive]
-instance : semigroup (pempty.{u}) :=
+instance : semigroup (pempty) :=
 { mul := λ x y, by cases x,
   mul_assoc := λ x y z, by cases x }

--- a/src/algebra/pempty_instances.lean
+++ b/src/algebra/pempty_instances.lean
@@ -16,6 +16,6 @@ that it is a semigroup.
 universes u
 
 @[to_additive]
-instance : semigroup (pempty) :=
+instance : semigroup (pempty.{u}) :=
 { mul := λ x y, by cases x,
   mul_assoc := λ x y z, by cases x }


### PR DESCRIPTION
This PR introduces the category of magmas and the category of semigroups, together with their additive versions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
