### PR TITLE
[Merged by Bors] - feat(data/pnat/basic): add induction principle

### DIFF
--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -239,6 +239,27 @@ begin
   exact hi b hk
 end
 
+/-- An induction principle for `pnat`: it takes values in `Sort*`, so it applies also to Types,
+not only to `Prop`. -/
+-- Proof by Mario Carnerio
+-- https://tinyurl.com/4m9r5yf8
+@[elab_as_eliminator]
+def pnat.rec_on (n : pnat) {p : pnat → Sort*} (p1 : p 1) (hp : ∀ n, p n → p (n + 1)) : p n :=
+begin
+  rcases n with ⟨n, h⟩,
+  induction n with n IH,
+  { exact absurd h dec_trivial },
+  { cases n with n,
+    { exact p1 },
+    { exact hp _ (IH n.succ_pos) } }
+end
+
+theorem pnat.rec_on_one (n : pnat) {p} (p1 hp) : @pnat.rec_on 1 p p1 hp = p1 := rfl
+
+theorem pnat.rec_on_succ (n : pnat) {p : pnat → Sort*} (p1 hp) :
+  @pnat.rec_on (n + 1) p p1 hp = hp n (@pnat.rec_on n p p1 hp) :=
+by { cases n with n h, cases n; [exact absurd h dec_trivial, refl] }
+
 /-- We define `m % k` and `m / k` in the same way as for `ℕ`
   except that when `m = n * k` we take `m % k = k` and
   `m / k = n - 1`.  This ensures that `m % k` is always positive

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -252,7 +252,7 @@ begin
     { exact hp _ (IH n.succ_pos) } }
 end
 
-@[simp] theorem rec_on_one (n : pnat) {p} (p1 hp) : @pnat.rec_on 1 p p1 hp = p1 := rfl
+@[simp] theorem rec_on_one {p} (p1 hp) : @pnat.rec_on 1 p p1 hp = p1 := rfl
 
 @[simp] theorem rec_on_succ (n : pnat) {p : pnat → Sort*} (p1 hp) :
   @pnat.rec_on (n + 1) p p1 hp = hp n (@pnat.rec_on n p p1 hp) :=

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -241,8 +241,6 @@ end
 
 /-- An induction principle for `pnat`: it takes values in `Sort*`, so it applies also to Types,
 not only to `Prop`. -/
--- Proof by Mario Carnerio
--- https://tinyurl.com/4m9r5yf8
 @[elab_as_eliminator]
 def pnat.rec_on (n : pnat) {p : pnat → Sort*} (p1 : p 1) (hp : ∀ n, p n → p (n + 1)) : p n :=
 begin
@@ -254,9 +252,9 @@ begin
     { exact hp _ (IH n.succ_pos) } }
 end
 
-theorem pnat.rec_on_one (n : pnat) {p} (p1 hp) : @pnat.rec_on 1 p p1 hp = p1 := rfl
+@[simp] theorem pnat.rec_on_one (n : pnat) {p} (p1 hp) : @pnat.rec_on 1 p p1 hp = p1 := rfl
 
-theorem pnat.rec_on_succ (n : pnat) {p : pnat → Sort*} (p1 hp) :
+@[simp] theorem pnat.rec_on_succ (n : pnat) {p : pnat → Sort*} (p1 hp) :
   @pnat.rec_on (n + 1) p p1 hp = hp n (@pnat.rec_on n p p1 hp) :=
 by { cases n with n h, cases n; [exact absurd h dec_trivial, refl] }
 

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -242,7 +242,7 @@ end
 /-- An induction principle for `pnat`: it takes values in `Sort*`, so it applies also to Types,
 not only to `Prop`. -/
 @[elab_as_eliminator]
-def pnat.rec_on (n : pnat) {p : pnat → Sort*} (p1 : p 1) (hp : ∀ n, p n → p (n + 1)) : p n :=
+def rec_on (n : pnat) {p : pnat → Sort*} (p1 : p 1) (hp : ∀ n, p n → p (n + 1)) : p n :=
 begin
   rcases n with ⟨n, h⟩,
   induction n with n IH,
@@ -252,9 +252,9 @@ begin
     { exact hp _ (IH n.succ_pos) } }
 end
 
-@[simp] theorem pnat.rec_on_one (n : pnat) {p} (p1 hp) : @pnat.rec_on 1 p p1 hp = p1 := rfl
+@[simp] theorem rec_on_one (n : pnat) {p} (p1 hp) : @pnat.rec_on 1 p p1 hp = p1 := rfl
 
-@[simp] theorem pnat.rec_on_succ (n : pnat) {p : pnat → Sort*} (p1 hp) :
+@[simp] theorem rec_on_succ (n : pnat) {p : pnat → Sort*} (p1 hp) :
   @pnat.rec_on (n + 1) p p1 hp = hp n (@pnat.rec_on n p p1 hp) :=
 by { cases n with n h, cases n; [exact absurd h dec_trivial, refl] }
 


### PR DESCRIPTION
An induction principle for `pnat`.  The proof is by Mario Carneiro.  If there are mistakes, I introduced them!

Zulip discussion:
https://leanprover.zulipchat.com/#narrow/stream/267928-condensed-mathematics/topic/torsion.20free/near/227748865


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
