### PR TITLE
[Merged by Bors] - feat(algebra/lie/solvable): images of solvable Lie algebras are solvable

### DIFF
--- a/src/algebra/lie/solvable.lean
+++ b/src/algebra/lie/solvable.lean
@@ -33,11 +33,11 @@ lie algebra, derived series, derived length, solvable, radical
 
 universes u v w w₁ w₂
 
-namespace lie_algebra
+variables (R : Type u) (L : Type v) (M : Type w) {L' : Type w₁}
+variables [comm_ring R] [lie_ring L] [lie_algebra R L] [lie_ring L'] [lie_algebra R L']
+variables (I J : lie_ideal R L) {f : L' →ₗ⁅R⁆ L}
 
-variables (R : Type u) (L : Type v) (M : Type w)
-variables [comm_ring R] [lie_ring L] [lie_algebra R L]
-variables (I : lie_ideal R L)
+namespace lie_algebra
 
 /-- A generalisation of the derived series of a Lie algebra, whose zeroth term is a specified ideal.
 
@@ -127,9 +127,7 @@ namespace lie_ideal
 
 open lie_algebra
 
-variables {R : Type u} {L : Type v}
-variables [comm_ring R] [lie_ring L] [lie_algebra R L]
-variables (I J : lie_ideal R L)
+variables {R L}
 
 lemma derived_series_eq_derived_series_of_ideal_comap (k : ℕ) :
   derived_series R I k = (derived_series_of_ideal R L k I).comap I.incl :=
@@ -161,8 +159,8 @@ begin
                      ... ≤ ⊥ : by { rw [hI, hJ], simp, },
 end
 
-lemma derived_series_map_le_derived_series {L' : Type w} [lie_ring L'] [lie_algebra R L']
-  {f : L' →ₗ⁅R⁆ L} (k : ℕ) : (derived_series R L' k).map f ≤ derived_series R L k :=
+lemma derived_series_map_le (k : ℕ) :
+  (derived_series R L' k).map f ≤ derived_series R L k :=
 begin
   induction k with k ih,
   { simp only [derived_series_def, derived_series_of_ideal_zero, le_top], },
@@ -170,12 +168,18 @@ begin
     exact le_trans (map_bracket_le f) (lie_submodule.mono_lie _ _ _ _ ih ih), },
 end
 
+lemma derived_series_map_eq (k : ℕ) (h : function.surjective f) :
+  (derived_series R L' k).map f = derived_series R L k :=
+begin
+  have h' : (⊤ : lie_ideal R L').map f = ⊤, { exact f.ideal_range_eq_top_of_surjective h, },
+  induction k with k ih,
+  { exact h', },
+  { simp only [derived_series_def, map_bracket_eq f h, ih, derived_series_of_ideal_succ], },
+end
+
 end lie_ideal
 
 namespace lie_algebra
-
-variables (R : Type u) (L : Type v)
-variables [comm_ring R] [lie_ring L] [lie_algebra R L]
 
 /-- A Lie algebra is solvable if its derived series reaches 0 (in a finite number of steps). -/
 class is_solvable : Prop :=
@@ -193,20 +197,46 @@ begin
   exact ⟨⟨k+l, lie_ideal.derived_series_add_eq_bot hk hl⟩⟩,
 end
 
+end lie_algebra
+
 variables {R L}
 
-lemma is_solvable_of_injective {L' : Type w} [lie_ring L'] [lie_algebra R L']
-  [h₁ : is_solvable R L] {f : L' →ₗ⁅R⁆ L} (h₂ : function.injective f) : is_solvable R L' :=
+namespace function
+
+open lie_algebra
+
+lemma injective.lie_algebra_is_solvable [h₁ : is_solvable R L] (h₂ : injective f) :
+  is_solvable R L' :=
 begin
   tactic.unfreeze_local_instances, obtain ⟨k, hk⟩ := h₁,
   use k,
   apply lie_ideal.bot_of_map_eq_bot h₂, rw [eq_bot_iff, ← hk],
-  apply lie_ideal.derived_series_map_le_derived_series,
+  apply lie_ideal.derived_series_map_le,
+end
+
+lemma surjective.lie_algebra_is_solvable [h₁ : is_solvable R L'] (h₂ : surjective f) :
+  is_solvable R L :=
+begin
+  tactic.unfreeze_local_instances, obtain ⟨k, hk⟩ := h₁,
+  use k,
+  rw [← lie_ideal.derived_series_map_eq k h₂, hk],
+  simp only [lie_hom.map_bot_iff, bot_le],
+end
+
+end function
+
+namespace lie_algebra
+
+lemma solvable_iff_equiv_solvable (e : L' ≃ₗ⁅R⁆ L) : is_solvable R L' ↔ is_solvable R L :=
+begin
+  split; introsI h,
+  { exact e.symm.injective.lie_algebra_is_solvable, },
+  { exact e.injective.lie_algebra_is_solvable, },
 end
 
 lemma le_solvable_ideal_solvable {I J : lie_ideal R L} (h₁ : I ≤ J) (h₂ : is_solvable R J) :
   is_solvable R I :=
-lie_algebra.is_solvable_of_injective (lie_ideal.hom_of_le_injective h₁)
+(lie_ideal.hom_of_le_injective h₁).lie_algebra_is_solvable
 
 variables (R L)
 

--- a/src/algebra/lie/solvable.lean
+++ b/src/algebra/lie/solvable.lean
@@ -225,6 +225,10 @@ end
 
 end function
 
+lemma lie_hom.is_solvable_range (f : L' →ₗ⁅R⁆ L) [h : lie_algebra.is_solvable R L'] :
+  lie_algebra.is_solvable R f.range :=
+f.surjective_range_restrict.lie_algebra_is_solvable
+
 namespace lie_algebra
 
 lemma solvable_iff_equiv_solvable (e : L' ≃ₗ⁅R⁆ L) : is_solvable R L' ↔ is_solvable R L :=

--- a/src/algebra/lie/subalgebra.lean
+++ b/src/algebra/lie/subalgebra.lean
@@ -148,6 +148,22 @@ linear_map.range_coe ↑f
 
 @[simp] lemma mem_range (x : L₂) : x ∈ f.range ↔ ∃ (y : L), f y = x := linear_map.mem_range
 
+lemma mem_range_self (x : L) : f x ∈ f.range := linear_map.mem_range_self f x
+
+def range_restrict : L →ₗ⁅R⁆ f.range :=
+{ map_lie' := λ x y, by { apply subtype.ext, exact f.map_lie x y, },
+  ..(f : L →ₗ[R] L₂).range_restrict, }
+
+@[simp] lemma range_restrict_apply (x : L) : f.range_restrict x = ⟨f x, f.mem_range_self x⟩ := rfl
+
+lemma surjective_range_restrict : function.surjective (f.range_restrict) :=
+begin
+  rintros ⟨y, hy⟩,
+  erw mem_range at hy, obtain ⟨x, rfl⟩ := hy,
+  use x,
+  simp only [subtype.mk_eq_mk, range_restrict_apply],
+end
+
 end lie_hom
 
 namespace lie_subalgebra

--- a/src/algebra/lie/subalgebra.lean
+++ b/src/algebra/lie/subalgebra.lean
@@ -150,6 +150,7 @@ linear_map.range_coe ↑f
 
 lemma mem_range_self (x : L) : f x ∈ f.range := linear_map.mem_range_self f x
 
+/-- We can restrict a morphism to a (surjective) map to its range. -/
 def range_restrict : L →ₗ⁅R⁆ f.range :=
 { map_lie' := λ x y, by { apply subtype.ext, exact f.map_lie x y, },
   ..(f : L →ₗ[R] L₂).range_restrict, }


### PR DESCRIPTION
Summary of changes:

New definition:
 - `lie_hom.range_restrict`

New lemmas:
 - `lie_ideal.derived_series_map_eq`
 - `function.surjective.lie_algebra_is_solvable`
 - `lie_algebra.solvable_iff_equiv_solvable`
 - `lie_hom.is_solvable_range`
 - `lie_hom.mem_range_self`
 - `lie_hom.range_restrict_apply`
 - `lie_hom.surjective_range_restrict`

Renamed lemmas:
 - `lie_algebra.is_solvable_of_injective` → `function.injective.lie_algebra_is_solvable`
 - `lie_ideal.derived_series_map_le_derived_series` → `lie_ideal.derived_series_map_le`

---
These scraps fell between the cracks of a few recent PRs.