### PR TITLE
[Merged by Bors] - feat(linear_algebra/{clifford,exterior,tensor}_algebra): add induction principles

### DIFF
--- a/src/algebra/free_algebra.lean
+++ b/src/algebra/free_algebra.lean
@@ -368,8 +368,6 @@ begin
   -- the arguments are enough to construct a subalgebra, and a mapping into it from X
   let s : subalgebra R (free_algebra R X) := {
     carrier := C,
-    one_mem' := h_grade0 1,
-    zero_mem' := h_grade0 0,
     mul_mem' := h_mul,
     add_mem' := h_add,
     algebra_map_mem' := h_grade0, },

--- a/src/linear_algebra/clifford_algebra.lean
+++ b/src/linear_algebra/clifford_algebra.lean
@@ -156,6 +156,37 @@ begin
   simp only [h],
 end
 
+/-- If `C` holds for the `algebra_map` of `r : R` into `clifford_algebra Q`, the `ι` of `x : M`,
+and is preserved under addition and muliplication, then it holds for all of `clifford_algebra Q`.
+-/
+-- This proof closely follows `tensor_algebra.induction`
+@[elab_as_eliminator]
+lemma induction {C : clifford_algebra Q → Prop}
+  (h_grade0 : ∀ r, C (algebra_map R (clifford_algebra Q) r))
+  (h_grade1 : ∀ x, C (ι Q x))
+  (h_mul : ∀ a b, C a → C b → C (a * b))
+  (h_add : ∀ a b, C a → C b → C (a + b))
+  (a : clifford_algebra Q) :
+  C a :=
+begin
+  -- the arguments are enough to construct a subalgebra, and a mapping into it from M
+  let s : subalgebra R (clifford_algebra Q) := {
+    carrier := C,
+    mul_mem' := h_mul,
+    add_mem' := h_add,
+    algebra_map_mem' := h_grade0, },
+  let of : { f : M →ₗ[R] s // ∀ m, f m * f m = algebra_map _ _ (Q m) } :=
+  ⟨(ι Q).cod_restrict s.to_submodule h_grade1,
+    λ m, subtype.eq $ ι_square_scalar Q m ⟩,
+  -- the mapping through the subalgebra is the identity
+  have of_id : alg_hom.id R (clifford_algebra Q) = s.val.comp (lift Q of),
+  { ext,
+    simp [of], },
+  -- finding a proof is finding an element of the subalgebra
+  convert subtype.prop (lift Q of a),
+  exact alg_hom.congr_fun of_id a,
+end
+
 /-- A Clifford algebra with a zero quadratic form is isomorphic to an `exterior_algebra` -/
 def as_exterior : clifford_algebra (0 : quadratic_form R M) ≃ₐ[R] exterior_algebra R M :=
 alg_equiv.of_alg_hom

--- a/src/linear_algebra/exterior_algebra.lean
+++ b/src/linear_algebra/exterior_algebra.lean
@@ -162,6 +162,37 @@ begin
   simp only [h],
 end
 
+/-- If `C` holds for the `algebra_map` of `r : R` into `exterior_algebra R M`, the `ι` of `x : M`,
+and is preserved under addition and muliplication, then it holds for all of `exterior_algebra R M`.
+-/
+-- This proof closely follows `tensor_algebra.induction`
+@[elab_as_eliminator]
+lemma induction {C : exterior_algebra R M → Prop}
+  (h_grade0 : ∀ r, C (algebra_map R (exterior_algebra R M) r))
+  (h_grade1 : ∀ x, C (ι R x))
+  (h_mul : ∀ a b, C a → C b → C (a * b))
+  (h_add : ∀ a b, C a → C b → C (a + b))
+  (a : exterior_algebra R M) :
+  C a :=
+begin
+  -- the arguments are enough to construct a subalgebra, and a mapping into it from M
+  let s : subalgebra R (exterior_algebra R M) := {
+    carrier := C,
+    mul_mem' := h_mul,
+    add_mem' := h_add,
+    algebra_map_mem' := h_grade0, },
+  let of : { f : M →ₗ[R] s // ∀ m, f m * f m = 0 } :=
+  ⟨(ι R).cod_restrict s.to_submodule h_grade1,
+    λ m, subtype.eq $ ι_square_zero m ⟩,
+  -- the mapping through the subalgebra is the identity
+  have of_id : alg_hom.id R (exterior_algebra R M) = s.val.comp (lift Q of),
+  { ext,
+    simp [of], },
+  -- finding a proof is finding an element of the subalgebra
+  convert subtype.prop (lift Q of a),
+  exact alg_hom.congr_fun of_id a,
+end
+
 /-- The left-inverse of `algebra_map`. -/
 def algebra_map_inv : exterior_algebra R M →ₐ[R] R :=
 exterior_algebra.lift R ⟨(0 : M →ₗ[R] R), λ m, by simp⟩

--- a/src/linear_algebra/exterior_algebra.lean
+++ b/src/linear_algebra/exterior_algebra.lean
@@ -185,7 +185,7 @@ begin
   ⟨(ι R).cod_restrict s.to_submodule h_grade1,
     λ m, subtype.eq $ ι_square_zero m ⟩,
   -- the mapping through the subalgebra is the identity
-  have of_id : alg_hom.id R (exterior_algebra R M) = s.val.comp (lift Q of),
+  have of_id : alg_hom.id R (exterior_algebra R M) = s.val.comp (lift R of),
   { ext,
     simp [of], },
   -- finding a proof is finding an element of the subalgebra

--- a/src/linear_algebra/exterior_algebra.lean
+++ b/src/linear_algebra/exterior_algebra.lean
@@ -189,7 +189,7 @@ begin
   { ext,
     simp [of], },
   -- finding a proof is finding an element of the subalgebra
-  convert subtype.prop (lift Q of a),
+  convert subtype.prop (lift R of a),
   exact alg_hom.congr_fun of_id a,
 end
 

--- a/src/linear_algebra/tensor_algebra.lean
+++ b/src/linear_algebra/tensor_algebra.lean
@@ -122,6 +122,35 @@ begin
   exact (lift R).symm.injective w,
 end
 
+/-- If `C` holds for the `algebra_map` of `r : R` into `tensor_algebra R M`, the `ι` of `x : M`,
+and is preserved under addition and muliplication, then it holds for all of `tensor_algebra R M`.
+-/
+-- This proof closely follows `free_algebra.induction`
+@[elab_as_eliminator]
+lemma induction {C : tensor_algebra R M → Prop}
+  (h_grade0 : ∀ r, C (algebra_map R (tensor_algebra R M) r))
+  (h_grade1 : ∀ x, C (ι R x))
+  (h_mul : ∀ a b, C a → C b → C (a * b))
+  (h_add : ∀ a b, C a → C b → C (a + b))
+  (a : tensor_algebra R M) :
+  C a :=
+begin
+  -- the arguments are enough to construct a subalgebra, and a mapping into it from M
+  let s : subalgebra R (tensor_algebra R M) := {
+    carrier := C,
+    mul_mem' := h_mul,
+    add_mem' := h_add,
+    algebra_map_mem' := h_grade0, },
+  let of : M →ₗ[R] s := (ι R).cod_restrict s.to_submodule h_grade1,
+  -- the mapping through the subalgebra is the identity
+  have of_id : alg_hom.id R (tensor_algebra R M) = s.val.comp (lift R of),
+  { ext,
+    simp [of], },
+  -- finding a proof is finding an element of the subalgebra
+  convert subtype.prop (lift R of a),
+  exact alg_hom.congr_fun of_id a,
+end
+
 /-- The left-inverse of `algebra_map`. -/
 def algebra_map_inv : tensor_algebra R M →ₐ[R] R :=
 lift R (0 : M →ₗ[R] R)


### PR DESCRIPTION
These are closely derived from the induction principle for the free algebra.
I can't think of a good way to deduplicate them, so for now I've added comments making it clear to the reader that the code is largely copied.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
