### PR TITLE
[Merged by Bors] - feat(data/polynomial/coeff): Alternate form of coeff_mul_X_pow

### DIFF
--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -105,6 +105,18 @@ begin
   { exact λ h1, (h1 (nat.mem_antidiagonal.2 rfl)).elim }
 end
 
+lemma coeff_mul_X_pow' (p : polynomial R) (n d : ℕ) :
+  (p * X ^ n).coeff d = ite (n ≤ d) (p.coeff (d - n)) 0 :=
+begin
+  by_cases h : n ≤ d,
+  { rw [if_pos h, ←@nat.sub_add_cancel d n h, coeff_mul_X_pow, nat.add_sub_cancel] },
+  { rw [if_neg h, coeff_mul],
+    refine finset.sum_eq_zero (λ x hx, _),
+    rw [coeff_X_pow, if_neg, mul_zero],
+    exact ne_of_lt (lt_of_le_of_lt (nat.le_of_add_le_right
+      (le_of_eq (finset.nat.mem_antidiagonal.mp hx))) (not_le.mp h)) },
+end
+
 @[simp] theorem coeff_mul_X (p : polynomial R) (n : ℕ) :
   coeff (p * X) (n + 1) = coeff p n :=
 by simpa only [pow_one] using coeff_mul_X_pow p 1 n

--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -108,10 +108,9 @@ end
 lemma coeff_mul_X_pow' (p : polynomial R) (n d : ℕ) :
   (p * X ^ n).coeff d = ite (n ≤ d) (p.coeff (d - n)) 0 :=
 begin
-  by_cases h : n ≤ d,
-  { rw [if_pos h, ←@nat.sub_add_cancel d n h, coeff_mul_X_pow, nat.add_sub_cancel] },
-  { rw [if_neg h, coeff_mul],
-    refine finset.sum_eq_zero (λ x hx, _),
+  split_ifs,
+  { rw [←@nat.sub_add_cancel d n h, coeff_mul_X_pow, nat.add_sub_cancel] },
+  { refine (coeff_mul _ _ _).trans (finset.sum_eq_zero (λ x hx, _)),
     rw [coeff_X_pow, if_neg, mul_zero],
     exact ne_of_lt (lt_of_le_of_lt (nat.le_of_add_le_right
       (le_of_eq (finset.nat.mem_antidiagonal.mp hx))) (not_le.mp h)) },


### PR DESCRIPTION
An `ite`-version of `coeff_mul_X_pow` that sometimes works better with `rw`.

(this PR is part of the irreducibility saga)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
