### PR TITLE
[Merged by Bors] - feat(data/polynomial/basic): monomial_left_inj

### DIFF
--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -158,6 +158,10 @@ begin
   rw [← pow_one X, support_X_pow H 1],
 end
 
+lemma monomial_left_inj {R : Type*} [semiring R] {a : R} (ha : a ≠ 0) {i j : ℕ} :
+  (monomial i a) = (monomial j a) ↔ i = j :=
+finsupp.single_left_inj ha
+
 end semiring
 
 section comm_semiring


### PR DESCRIPTION
A version of `finsupp.single_left_inj` for monomials, so that it works with `rw.`

(this PR is part of the irreducibility saga)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
