### PR TITLE
[Merged by Bors] - feat(tactic/apply_fun): work on the goal as well

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -627,6 +627,9 @@ theorem ne_of_mem_of_not_mem {α β} [has_mem α β] {s : β} {a b : α}
   (h : a ∈ s) : b ∉ s → a ≠ b :=
 mt $ λ e, e ▸ h
 
+lemma ne_of_apply_ne {α β : Sort*} (f : α → β) {x y : α} {h : f x ≠ f y} : x ≠ y :=
+λ (w : x = y), h (congr_arg f w)
+
 theorem eq_equivalence : equivalence (@eq α) :=
 ⟨eq.refl, @eq.symm _, @eq.trans _⟩
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -627,7 +627,7 @@ theorem ne_of_mem_of_not_mem {α β} [has_mem α β] {s : β} {a b : α}
   (h : a ∈ s) : b ∉ s → a ≠ b :=
 mt $ λ e, e ▸ h
 
-lemma ne_of_apply_ne {α β : Sort*} (f : α → β) {x y : α} {h : f x ≠ f y} : x ≠ y :=
+lemma ne_of_apply_ne {α β : Sort*} (f : α → β) {x y : α} (h : f x ≠ f y) : x ≠ y :=
 λ (w : x = y), h (congr_arg f w)
 
 theorem eq_equivalence : equivalence (@eq α) :=

--- a/src/tactic/apply_fun.lean
+++ b/src/tactic/apply_fun.lean
@@ -76,7 +76,7 @@ do t ← target,
       n ← get_local n,
       apply n,
       clear n)
-  | _ := fail!"failed to apply {pp} to the goal"
+  | _ := fail!"failed to apply {e} to the goal"
   end
 
 namespace interactive

--- a/src/tactic/apply_fun.lean
+++ b/src/tactic/apply_fun.lean
@@ -58,9 +58,7 @@ we obtain a new goal `f a ≤ f b`.
 meta def apply_fun_to_goal (e : pexpr) (lem : option pexpr) : tactic unit :=
 do t ← target,
   match t with
-  | `(%%l ≠ %%r) := (do
-      to_expr ``(ne_of_apply_ne %%e) >>= apply,
-      skip)
+  | `(%%l ≠ %%r) := to_expr ``(ne_of_apply_ne %%e) >>= apply >> skip
   | `(¬%%l = %%r) := (do
       to_expr ``(ne_of_apply_ne %%e) >>= apply,
       skip)
@@ -76,16 +74,9 @@ do t ← target,
       swap,
       n ← get_local n,
       apply n,
-      clear n,
-      skip)
-  | `(%%l ≤ %%r) := (do
-      e' ← to_expr ``((order_iso.le_iff_le %%e).mp),
-      apply e',
-      skip)
-  | `(%%l < %%r) := (do
-      e' ← to_expr ``((order_iso.lt_iff_lt %%e).mp),
-      apply e',
-      skip)
+      clear n)
+  | `(%%l ≤ %%r) := to_expr ``((order_iso.le_iff_le %%e).mp) >>= apply >> skip
+  | `(%%l < %%r) := to_expr ``((order_iso.lt_iff_lt %%e).mp) >>= apply e' >> skip
   | _ := fail ("failed to apply " ++ to_string e ++ " to the goal")
   end
 

--- a/src/tactic/apply_fun.lean
+++ b/src/tactic/apply_fun.lean
@@ -62,6 +62,10 @@ do t ← target,
       e' ← to_expr ``(ne_of_apply_ne %%e),
       apply e',
       skip)
+  | `(¬%%l = %%r) := (do
+      e' ← to_expr ``(ne_of_apply_ne %%e),
+      apply e',
+      skip)
   | `(%%l = %%r) := (do
       to_expr ``(%%e %%l), -- build and discard an application, to fill in implicit arguments
       n ← get_unused_name `inj,

--- a/src/tactic/apply_fun.lean
+++ b/src/tactic/apply_fun.lean
@@ -130,11 +130,7 @@ end
  -/
 meta def apply_fun (q : parse texpr) (locs : parse location) (lem : parse (tk "using" *> texpr)?)
   : tactic unit :=
-match locs with
-| (loc.ns [none]) := apply_fun_to_goal q lem
-| (loc.ns l) := l.mmap' $ option.mmap $ λ h, get_local h >>= apply_fun_to_hyp q lem
-| wildcard   := local_context >>= list.mmap' (apply_fun_to_hyp q lem)
-end
+locs.apply (apply_fun_to_hyp q lem) (apply_fun_to_goal q lem)
 
 add_tactic_doc
 { name       := "apply_fun",

--- a/src/tactic/apply_fun.lean
+++ b/src/tactic/apply_fun.lean
@@ -37,8 +37,7 @@ do {
           return n
         end,
        to_expr ``(%%Hmono %%hyp)
-  | _ := (do pp ← pp e,
-             fail ("failed to apply " ++ to_string pp ++ " at " ++ to_string hyp.local_pp_name))
+  | _ := fail!"failed to apply {e} at {hyp}"
   end,
   clear hyp,
   hyp ← note hyp.local_pp_name none prf,
@@ -77,7 +76,7 @@ do t ← target,
       n ← get_local n,
       apply n,
       clear n)
-  | _ := (do pp ← pp e, fail ("failed to apply " ++ to_string pp ++ " to the goal"))
+  | _ := fail!"failed to apply {pp} to the goal"
   end
 
 namespace interactive

--- a/src/tactic/apply_fun.lean
+++ b/src/tactic/apply_fun.lean
@@ -59,12 +59,10 @@ meta def apply_fun_to_goal (e : pexpr) (lem : option pexpr) : tactic unit :=
 do t ← target,
   match t with
   | `(%%l ≠ %%r) := (do
-      e' ← to_expr ``(ne_of_apply_ne %%e),
-      apply e',
+      to_expr ``(ne_of_apply_ne %%e) >>= apply,
       skip)
   | `(¬%%l = %%r) := (do
-      e' ← to_expr ``(ne_of_apply_ne %%e),
-      apply e',
+      to_expr ``(ne_of_apply_ne %%e) >>= apply,
       skip)
   | `(%%l = %%r) := (do
       to_expr ``(%%e %%l), -- build and discard an application, to fill in implicit arguments

--- a/src/tactic/apply_fun.lean
+++ b/src/tactic/apply_fun.lean
@@ -68,13 +68,12 @@ do t ← target,
       n ← get_unused_name `inj,
       to_expr ``(function.injective %%e) >>= assert n,
       -- Attempt to discharge the `injective f` goal
-      focus1 $
+      (focus1 $
       assumption <|>
         (to_expr ``(equiv.injective) >>= apply >> done) <|>
         -- We require that applying the lemma closes the goal, not just makes progress:
-        (lem.mmap (λ l, to_expr l >>= apply) >> done),
-      -- Return to the main goal, or noop if we successfully discharged the `injective f` goal:
-      swap,
+        (lem.mmap (λ l, to_expr l >>= apply) >> done))
+        <|> swap, -- return to the main goal if we couldn't discharge `injective f`.
       n ← get_local n,
       apply n,
       clear n)

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -56,7 +56,6 @@ begin
   exact H,
 end
 
-
 example (n m : ℕ) (f : ℕ → ℕ) (h : f n ≠ f m) : n ≠ m :=
 begin
   apply_fun f,

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -1,5 +1,6 @@
 import tactic.apply_fun
 import data.matrix.basic
+
 open function
 
 example (X Y Z : Type) (f : X → Y) (g : Y → Z) (H : injective $ g ∘ f) :
@@ -53,4 +54,48 @@ example (n : ℕ) (a b : fin n) (H : a ≤ b) : a.cast_succ ≤ b.cast_succ :=
 begin
   apply_fun fin.cast_succ at H,
   exact H,
+end
+
+
+example (n m : ℕ) (f : ℕ → ℕ) (h : f n ≠ f m) : n ≠ m :=
+begin
+  apply_fun f,
+  exact h,
+end
+
+example (n m : ℕ) (f : ℕ → ℕ) (w : function.injective f) (h : f n = f m) : n = m :=
+begin
+  apply_fun f,
+  assumption,
+end
+
+example (n m : ℕ) (f : ℕ → ℕ) (w : function.injective f ∧ true) (h : f n = f m) : n = m :=
+begin
+  apply_fun f using w.1,
+  assumption,
+end
+
+example (n m : ℕ) (f : ℕ → ℕ) (w : function.injective f ∧ true) (h : f n = f m) : n = m :=
+begin
+  apply_fun f,
+  assumption,
+  exact w.1,
+end
+
+example (n m : ℕ) (f : ℕ ≃ ℕ) (h : f n = f m) : n = m :=
+begin
+  apply_fun f,
+  assumption,
+end
+
+example (n m : ℕ) (f : ℕ ≃o ℕ) (h : f n ≤ f m) : n ≤ m :=
+begin
+  apply_fun f,
+  assumption,
+end
+
+example (n m : ℕ) (f : ℕ ≃o ℕ) (h : f n < f m) : n < m :=
+begin
+  apply_fun f,
+  assumption,
 end


### PR DESCRIPTION
Extend the functionality of `apply_fun`, to "apply" functions to inequalities in the goal, as well.

```
Apply a function to an equality or inequality in either a local hypothesis or the goal.

* If we have `h : a = b`, then `apply_fun f at h` will replace this with `h : f a = f b`.
* If we have `h : a ≤ b`, then `apply_fun f at h` will replace this with `h : f a ≤ f b`,
  and create a subsidiary goal `monotone f`.
  `apply_fun` will automatically attempt to discharge this subsidiary goal using `mono`,
  or an explicit solution can be provided with `apply_fun f at h using P`, where `P : monotone f`.
* If the goal is `a ≠ b`, `apply_fun f` will replace this with `f a ≠ f b`.
* If the goal is `a = b`, `apply_fun f` will replace this with `f a = f b`,
  and create a subsidiary goal `injective f`.
  `apply_fun` will automatically attempt to discharge this subsidiary goal using local hypotheses,
  or if `f` is actually an `equiv`,
  or an explicit solution can be provided with `apply_fun f using P`, where `P : injective f`.
* If the goal is `a ≤ b` (or similarly for `a < b`), and `f` is actually an `order_iso`,
  `apply_fun f` will replace the goal with `f a ≤ f b`.
  If `f` is anything else (e.g. just a function, or an `equiv`), `apply_fun` will fail.
```