### PR TITLE
[Merged by Bors] - feat(algebra/category/Mon/adjunctions): adjoin_unit adjunction from Semigroup

### DIFF
--- a/src/algebra/category/Mon/adjunctions.lean
+++ b/src/algebra/category/Mon/adjunctions.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2021 Julian Kuelshammer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julian Kuelshammer
+-/
+import algebra.category.Mon.basic
+import algebra.category.Semigroup.basic
+import algebra.group.with_one
+
+/-!
+# Adjunctions regarding the category of (commutative) monoids
+
+-/
+
+universe u
+
+open category_theory
+
+/-- The functor of adjoining a neutral element `one` to a semigroup.
+ -/
+@[simps]
+def adjoin_one : Semigroup.{u} ⥤ Mon.{u} :=
+{ obj := λ S, Mon.of (with_one S),
+  map := λ X Y, with_one.map,
+  map_id' := λ X, with_one.map_id,
+  map_comp' := λ X Y Z, with_one.map_comp }
+
+@[to_additive has_forget_to_AddSemigroup]
+instance has_forget_to_Semigroup : has_forget₂ Mon Semigroup :=
+{ forget₂ :=
+  { obj := λ M, Semigroup.of M,
+    map := λ M N, monoid_hom.to_mul_hom },
+}
+
+/-- The adjoin_one-forgetful adjunction from `Semigroup` to `Mon`.-/
+def adjoin_one_adj : adjoin_one ⊣ forget₂ Mon.{u} Semigroup.{u} :=
+adjunction.mk_of_hom_equiv
+{ hom_equiv := λ S M, with_one.lift.symm,
+  hom_equiv_naturality_left_symm' := begin intros, ext1, simp, sorry end }

--- a/src/algebra/category/Mon/adjunctions.lean
+++ b/src/algebra/category/Mon/adjunctions.lean
@@ -10,6 +10,8 @@ import algebra.group.with_one
 /-!
 # Adjunctions regarding the category of (commutative) monoids
 
+This file proves the adjunction between adjoining a unit to a semigroup and the forgetful functor
+from monoids to semigroups.
 -/
 
 universe u
@@ -18,7 +20,7 @@ open category_theory
 
 /-- The functor of adjoining a neutral element `one` to a semigroup.
  -/
-@[simps]
+@[to_additive, simps]
 def adjoin_one : Semigroup.{u} ⥤ Mon.{u} :=
 { obj := λ S, Mon.of (with_one S),
   map := λ X Y, with_one.map,
@@ -33,7 +35,18 @@ instance has_forget_to_Semigroup : has_forget₂ Mon Semigroup :=
 }
 
 /-- The adjoin_one-forgetful adjunction from `Semigroup` to `Mon`.-/
+@[to_additive]
 def adjoin_one_adj : adjoin_one ⊣ forget₂ Mon.{u} Semigroup.{u} :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ S M, with_one.lift.symm,
-  hom_equiv_naturality_left_symm' := begin intros, ext1, simp, sorry end }
+  hom_equiv_naturality_left_symm' :=
+  begin
+    intros S T M f g,
+    ext1,
+    simp only [equiv.symm_symm, adjoin_one_map, coe_comp],
+    simp_rw with_one.map,
+    apply with_one.cases_on x,
+    { refl },
+    { simp }
+  end
+}

--- a/src/algebra/category/Mon/adjunctions.lean
+++ b/src/algebra/category/Mon/adjunctions.lean
@@ -8,10 +8,15 @@ import algebra.category.Semigroup.basic
 import algebra.group.with_one
 
 /-!
-# Adjunctions regarding the category of (commutative) monoids
+# Adjunctions regarding the category of monoids
 
 This file proves the adjunction between adjoining a unit to a semigroup and the forgetful functor
 from monoids to semigroups.
+
+## TODO
+
+* free-forgetful adjunction for monoids
+* adjunctions related to commutative monoids
 -/
 
 universe u
@@ -20,7 +25,7 @@ open category_theory
 
 /-- The functor of adjoining a neutral element `one` to a semigroup.
  -/
-@[to_additive, simps]
+@[to_additive "The functor of adjoining a neutral element `zero` to a semigroup", simps]
 def adjoin_one : Semigroup.{u} ⥤ Mon.{u} :=
 { obj := λ S, Mon.of (with_one S),
   map := λ X Y, with_one.map,
@@ -35,14 +40,14 @@ instance has_forget_to_Semigroup : has_forget₂ Mon Semigroup :=
 }
 
 /-- The adjoin_one-forgetful adjunction from `Semigroup` to `Mon`.-/
-@[to_additive]
+@[to_additive "The adjoin_one-forgetful adjunction from `AddSemigroup` to `AddMon`"]
 def adjoin_one_adj : adjoin_one ⊣ forget₂ Mon.{u} Semigroup.{u} :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ S M, with_one.lift.symm,
   hom_equiv_naturality_left_symm' :=
   begin
     intros S T M f g,
-    ext1,
+    ext,
     simp only [equiv.symm_symm, adjoin_one_map, coe_comp],
     simp_rw with_one.map,
     apply with_one.cases_on x,

--- a/src/algebra/category/Semigroup/basic.lean
+++ b/src/algebra/category/Semigroup/basic.lean
@@ -20,7 +20,6 @@ along with the relevant forgetful functors between them.
 ## TODO
 
 * Limits in these categories
-* adjoining a unit adjunction to Mon
 * free/forgetful adjunctions
 -/
 

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -6,7 +6,7 @@ Authors: Mario Carneiro, Johan Commelin
 import algebra.ring.basic
 import data.equiv.basic
 
-universes u v
+universes u v w
 variable {α : Type u}
 
 /-- Add an extra element `1` to a type -/
@@ -127,6 +127,15 @@ variables {β : Type v} [semigroup α] [semigroup β]
   from `with_zero α` to `with_zero β`"]
 def map (f : mul_hom α β) : with_one α →* with_one β :=
 lift (coe_mul_hom.comp f)
+
+@[simp, to_additive]
+lemma map_id : map (mul_hom.id α) = monoid_hom.id (with_one α) :=
+by { ext, cases x; refl }
+
+@[simp, to_additive]
+lemma map_comp {γ : Type w} [semigroup γ] (f : mul_hom α β) (g : mul_hom β γ) :
+map (g.comp f) = (map g).comp (map f) :=
+by { ext, cases x; refl }
 
 end map
 

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -81,7 +81,7 @@ instance [comm_semigroup α] : comm_monoid (with_one α) :=
   ..with_one.monoid }
 
 /-- `coe` as a bundled morphism -/
-@[simps apply, to_additive "`coe` as a bundled morphism"]
+@[to_additive "`coe` as a bundled morphism", simps apply]
 def coe_mul_hom [has_mul α] : mul_hom α (with_one α) :=
 { to_fun := coe, map_mul' := λ x y, rfl }
 

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -6,6 +6,18 @@ Authors: Mario Carneiro, Johan Commelin
 import algebra.ring.basic
 import data.equiv.basic
 
+/-!
+# Adjoining a zero/one to semigroups and related algebraic structures
+
+This file contains different results about adjoining an element to an algebraic structure which then
+behaves like a zero or a one. An example is adjoining a one to a semigroup to obtain a monoid. That
+this provides an example of an adjunction is proved in `algebra.category.Mon.adjunctions`.
+
+Another result says that adjoining to a group an element `zero` gives a `group_with_zero`. For more
+information about these structures (which are not that standard in informal mathematics, see
+`algebra.group_with_zero.basic`)
+-/
+
 universes u v w
 variable {α : Type u}
 


### PR DESCRIPTION
This PR provides the adjoin_unit-forgetful adjunction between `Semigroup` and `Mon` and additionally the second to last module doc in algebra, namely `algebra.group.with_one`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
