### PR TITLE
fix(data/list/defs): remove chunking hack

### DIFF
--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -925,7 +925,7 @@ meta def to_chunks {α} (n : ℕ) : list α → list (list α)
 /--
 Asynchronous version of `list.map`.
 -/
-meta def map_async_chunked {α β} (f : α → β) (xs : list α) (chunk_size := 1024) : list β :=
-((xs.to_chunks chunk_size).map (λ xs, task.delay (λ _, list.map f xs))).bind task.get
+meta def map_async {α β} (f : α → β) (xs : list α) : list β :=
+(xs.map (λ x, task.delay (λ _, f x))).map task.get
 
 end list

--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -84,7 +84,7 @@ checks.mmap $ λ ⟨linter_name, linter⟩, do
   let test_decls := if linter.auto_decls then all_decls else non_auto_decls,
   test_decls ← test_decls.mfilter (λ decl, should_be_linted linter_name decl.to_name),
   s ← read,
-  let results := test_decls.map_async_chunked $ λ decl, prod.mk decl.to_name $
+  let results := test_decls.map_async $ λ decl, prod.mk decl.to_name $
       match linter.test decl s with
       | result.success w _ := w
       | result.exception msg _ _ :=


### PR DESCRIPTION
Before Lean 3.27, it was impossible to spawn more than a few thousand tasks via `task.delay`, because storing the log messages was quadratic in the number of tasks.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
