### PR TITLE
[Merged by Bors] - feat(data/equiv/fin): fin_add_flip and fin_rotate

### DIFF
--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -53,7 +53,7 @@ rfl
   (fin_congr h k : ℕ) = k :=
 by { cases k, refl, }
 
-@[simp] lemma fin_congr_symm_apply_coe {n m : ℕ} (h : n = m) (k : fin m) :
+lemma fin_congr_symm_apply_coe {n m : ℕ} (h : n = m) (k : fin m) :
   ((fin_congr h).symm k : ℕ) = k :=
 by { cases k, refl, }
 

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -38,17 +38,25 @@ def fin_two_equiv : fin 2 ≃ bool :=
   assume b, match b with tt := rfl | ff := rfl end⟩
 
 /-- The 'identity' equivalence between `fin n` and `fin m` when `n = m`. -/
-@[simps]
+
 def fin_congr {n m : ℕ} (h : n = m) : fin n ≃ fin m :=
 ⟨λ k, ⟨k.1, by { subst h, exact k.2 }⟩, λ k, ⟨k.1, by { subst h, exact k.2}⟩, by tidy, by tidy⟩
 
-@[simp] lemma fin_congr_apply {n m : ℕ} (h : n = m) (k : fin n) :
-  fin_congr h k = ⟨k.1, by { subst h, exact k.2 }⟩ :=
+@[simp] lemma fin_congr_apply_mk {n m : ℕ} (h : n = m) (k : ℕ) (w : k < n) :
+  fin_congr h ⟨k, w⟩ = ⟨k, by { subst h, exact w }⟩ :=
 rfl
 
-@[simp] lemma fin_congr_symm_apply {n m : ℕ} (h : n = m) (k : fin m) :
-  (fin_congr h).symm k = ⟨k.1, by { subst h, exact k.2 }⟩ :=
+@[simp] lemma fin_congr_symm_apply_mk {n m : ℕ} (h : n = m) (k : ℕ) (w : k < m) :
+  (fin_congr h).symm ⟨k, w⟩ = ⟨k, by { subst h, exact w }⟩ :=
 rfl
+
+@[simp] lemma fin_congr_apply_coe {n m : ℕ} (h : n = m) (k : fin n) :
+  (fin_congr h k : ℕ) = k :=
+by { cases k, refl, }
+
+@[simp] lemma fin_congr_symm_apply_coe {n m : ℕ} (h : n = m) (k : fin m) :
+  ((fin_congr h).symm k : ℕ) = k :=
+by { cases k, refl, }
 
 /-- An equivalence that removes `i` and maps it to `none`.
 This is a version of `fin.pred_above` that produces `option (fin n)` instead of

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -171,7 +171,7 @@ def sum_fin_sum_equiv : fin m ⊕ fin n ≃ fin (m + n) :=
 
 /-- The equivalence between `fin (m + n)` and `fin (n + m)` which rotates by `n`. -/
 def fin_add_flip : fin (m + n) ≃ fin (n + m) :=
-  (sum_fin_sum_equiv.symm.trans (equiv.sum_comm _ _)).trans sum_fin_sum_equiv
+(sum_fin_sum_equiv.symm.trans (equiv.sum_comm _ _)).trans sum_fin_sum_equiv
 
 @[simp] lemma fin_add_flip_apply_left {k : ℕ} (h : k < m) :
   fin_add_flip (⟨k, nat.lt_add_right k m n h⟩ : fin (m + n)) = ⟨n + k, add_lt_add_left h n⟩ :=

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -45,8 +45,8 @@ equiv.subtype_equiv_right (λ x, by subst h)
   fin_congr h ⟨k, w⟩ = ⟨k, by { subst h, exact w }⟩ :=
 rfl
 
-@[simp] lemma fin_congr_symm_apply_mk {n m : ℕ} (h : n = m) (k : ℕ) (w : k < m) :
-  (fin_congr h).symm ⟨k, w⟩ = ⟨k, by { subst h, exact w }⟩ :=
+@[simp] lemma fin_congr_symm {n m : ℕ} (h : n = m) :
+  (fin_congr h).symm = fin_congr h.symm :=
 rfl
 
 @[simp] lemma fin_congr_apply_coe {n m : ℕ} (h : n = m) (k : fin n) :

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -38,9 +38,8 @@ def fin_two_equiv : fin 2 ≃ bool :=
   assume b, match b with tt := rfl | ff := rfl end⟩
 
 /-- The 'identity' equivalence between `fin n` and `fin m` when `n = m`. -/
-
 def fin_congr {n m : ℕ} (h : n = m) : fin n ≃ fin m :=
-⟨λ k, ⟨k.1, by { subst h, exact k.2 }⟩, λ k, ⟨k.1, by { subst h, exact k.2}⟩, by tidy, by tidy⟩
+equiv.subtype_equiv_right (λ x, by subst h)
 
 @[simp] lemma fin_congr_apply_mk {n m : ℕ} (h : n = m) (k : ℕ) (w : k < n) :
   fin_congr h ⟨k, w⟩ = ⟨k, by { subst h, exact w }⟩ :=

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -37,6 +37,19 @@ def fin_two_equiv : fin 2 ≃ bool :=
   end,
   assume b, match b with tt := rfl | ff := rfl end⟩
 
+/-- The 'identity' equivalence between `fin n` and `fin m` when `n = m`. -/
+@[simps]
+def fin_congr {n m : ℕ} (h : n = m) : fin n ≃ fin m :=
+⟨λ k, ⟨k.1, by { subst h, exact k.2 }⟩, λ k, ⟨k.1, by { subst h, exact k.2}⟩, by tidy, by tidy⟩
+
+@[simp] lemma fin_congr_apply {n m : ℕ} (h : n = m) (k : fin n) :
+  fin_congr h k = ⟨k.1, by { subst h, exact k.2 }⟩ :=
+rfl
+
+@[simp] lemma fin_congr_symm_apply {n m : ℕ} (h : n = m) (k : fin m) :
+  (fin_congr h).symm k = ⟨k.1, by { subst h, exact k.2 }⟩ :=
+rfl
+
 /-- An equivalence that removes `i` and maps it to `none`.
 This is a version of `fin.pred_above` that produces `option (fin n)` instead of
 mapping both `i.cast_succ` and `i.succ` to `i`. -/
@@ -148,6 +161,63 @@ def sum_fin_sum_equiv : fin m ⊕ fin n ≃ fin (m + n) :=
     { dsimp, rw [dif_pos H], simp },
     { dsimp, rw [dif_neg H], simp [fin.ext_iff, nat.add_sub_of_le (le_of_not_gt H)] }
   end }
+
+/-- The equivalence between `fin (m + n)` and `fin (n + m)` which rotates by `n`. -/
+def fin_add_flip : fin (m + n) ≃ fin (n + m) :=
+  (sum_fin_sum_equiv.symm.trans (equiv.sum_comm _ _)).trans sum_fin_sum_equiv
+
+@[simp] lemma fin_add_flip_apply_left {k : ℕ} (h : k < m) :
+  fin_add_flip (⟨k, nat.lt_add_right k m n h⟩ : fin (m + n)) = ⟨n + k, add_lt_add_left h n⟩ :=
+begin
+  dsimp [fin_add_flip, sum_fin_sum_equiv],
+  rw [dif_pos h],
+  refl,
+end
+
+@[simp] lemma fin_add_flip_apply_right {k : ℕ} (h₁ : m ≤ k) (h₂ : k < m + n) :
+  fin_add_flip (⟨k, h₂⟩ : fin (m + n)) =
+    ⟨k - m, lt_of_le_of_lt (nat.sub_le _ _) (by { convert h₂ using 1, simp [add_comm] })⟩ :=
+begin
+  dsimp [fin_add_flip, sum_fin_sum_equiv],
+  rw [dif_neg (not_lt.mpr h₁)],
+  refl,
+end
+
+/-- Rotate `fin n` one step to the right. -/
+def fin_rotate : Π n, fin n ≃ fin n
+| 0 := equiv.refl _
+| (n+1) := fin_add_flip.trans (fin_congr (add_comm _ _))
+
+@[simp] lemma fin_rotate_of_lt {k : ℕ} (h : k < n) :
+  fin_rotate (n+1) ⟨k, lt_of_lt_of_le h (nat.le_succ _)⟩ = ⟨k + 1, nat.succ_lt_succ h⟩ :=
+begin
+  dsimp [fin_rotate],
+  simp [h, add_comm],
+end
+
+@[simp] lemma fin_rotate_last' : fin_rotate (n+1) ⟨n, lt_add_one _⟩ = ⟨0, nat.zero_lt_succ _⟩ :=
+begin
+  dsimp [fin_rotate],
+  rw fin_add_flip_apply_right,
+  simp,
+end
+
+@[simp] lemma fin_rotate_last : fin_rotate (n+1) (fin.last _) = 0 :=
+fin_rotate_last'
+
+lemma fin.snoc_eq_cons_rotate {α : Type*} (v : fin n → α) (a : α) :
+  @fin.snoc _ (λ _, α) v a = (λ i, @fin.cons _ (λ _, α) a v (fin_rotate _ i)) :=
+begin
+  ext ⟨i, h⟩,
+  by_cases h' : i < n,
+  { rw [fin_rotate_of_lt h', fin.snoc, fin.cons, dif_pos h'],
+    refl, },
+  { have h'' : n = i,
+    { simp only [not_lt] at h', exact (nat.eq_of_le_of_lt_succ h' h).symm, },
+    subst h'',
+    rw [fin_rotate_last', fin.snoc, fin.cons, dif_neg (lt_irrefl _)],
+    refl, }
+end
 
 /-- Equivalence between `fin m × fin n` and `fin (m * n)` -/
 def fin_prod_fin_equiv : fin m × fin n ≃ fin (m * n) :=

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -222,6 +222,9 @@ theorem eq_of_lt_succ_of_not_lt {a b : ℕ} (h1 : a < b + 1) (h2 : ¬ a < b) : a
 have h3 : a ≤ b, from le_of_lt_succ h1,
 or.elim (eq_or_lt_of_not_lt h2) (λ h, h) (λ h, absurd h (not_lt_of_ge h3))
 
+lemma eq_of_le_of_lt_succ {n m : ℕ} (h₁ : n ≤ m) (h₂ : m < n + 1) : m = n :=
+nat.le_antisymm (le_of_succ_le_succ h₂) h₁
+
 theorem one_add (n : ℕ) : 1 + n = succ n := by simp [add_comm]
 
 @[simp] lemma succ_pos' {n : ℕ} : 0 < succ n := succ_pos n


### PR DESCRIPTION
Add
* `fin_add_flip : fin (m + n) ≃ fin (n + m)`
* `fin_rotate : Π n, fin n ≃ fin n` (acts by +1 mod n)
and simp lemmas, and shows `fin.snoc` is a rotation of `fin.cons`.
