### PR TITLE
[Merged by Bors] - feat(linear_algebra/finsupp): add mem_span_set

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -807,30 +807,37 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
 The implementation uses `finsupp.sum`.
 The Type `M` has an explicit universe, since otherwise it gets assigned `Type (max u_2 u_3)`.
   -/
-lemma span_as_sum {R : Type*} {M : Type u} [semiring R] [add_comm_group M] [semimodule R M]
-  {m : M} {s : set M} (hm : m ∈ submodule.span R s) :
+lemma span_as_sum {M : Type u} [add_comm_group M] [semimodule R M] {m : M} {s : set M} :
+  m ∈ submodule.span R s ↔
   ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ (c.sum (λ i, (smul_add_hom R M).flip i)) = m :=
 begin
-  classical,
-  refine span_induction hm (λ x hx, _) ⟨0, by simp⟩ _ _; clear hm m,
-  { refine ⟨finsupp.single x 1, λ y hy, _, by simp⟩,
-    rw [finset.mem_coe, finsupp.mem_support_single] at hy,
-    rwa hy.1 },
-  { rintros x y ⟨c, hc, rfl⟩ ⟨d, hd, rfl⟩,
-    refine ⟨c + d, _, by simp⟩,
-    refine set.subset.trans _ (set.union_subset hc hd),
-    rw [← finset.coe_union, finset.coe_subset],
-    convert finsupp.support_add },
-  { rintros r m ⟨c, hc, rfl⟩,
-    refine ⟨r • c, λ x hx, hc _, _⟩,
-    { rw [finset.mem_coe, finsupp.mem_support_iff] at hx ⊢,
-      rw [finsupp.coe_smul] at hx,
-      exact right_ne_zero_of_mul hx },
-    { rw finsupp.sum_smul_index' (λ (m : M), _),
-      { convert (add_monoid_hom.map_finsupp_sum (smul_add_hom R M r) _ _).symm,
-        ext m s,
-        simp [mul_smul r s m] },
-      { exact (((smul_add_hom R M).flip) m).map_zero } } }
+  refine ⟨λ hm, _, λ hx, _⟩,
+  { classical,
+    refine span_induction hm (λ x hx, _) ⟨0, by simp⟩ _ _; clear hm m,
+    { refine ⟨finsupp.single x 1, λ y hy, _, by simp⟩,
+      rw [finset.mem_coe, finsupp.mem_support_single] at hy,
+      rwa hy.1 },
+    { rintros x y ⟨c, hc, rfl⟩ ⟨d, hd, rfl⟩,
+      refine ⟨c + d, _, by simp⟩,
+      refine set.subset.trans _ (set.union_subset hc hd),
+      rw [← finset.coe_union, finset.coe_subset],
+      convert finsupp.support_add },
+    { rintros r m ⟨c, hc, rfl⟩,
+      refine ⟨r • c, λ x hx, hc _, _⟩,
+      { rw [finset.mem_coe, finsupp.mem_support_iff] at hx ⊢,
+        rw [finsupp.coe_smul] at hx,
+        exact right_ne_zero_of_mul hx },
+      { rw finsupp.sum_smul_index' (λ (m : M), _),
+        { convert (add_monoid_hom.map_finsupp_sum (smul_add_hom R M r) _ _).symm,
+          ext m s,
+          simp [mul_smul r s m] },
+        { exact (((smul_add_hom R M).flip) m).map_zero } } } },
+  { rcases hx with ⟨c, cM, rfl⟩,
+    refine sum_mem (span R s) _,
+    rintros d ds S ⟨h1, rfl⟩,
+    rintros g ⟨h1m : s ⊆ ↑h1, rfl⟩,
+    refine h1.smul_mem (c d) _,
+    exact @set.mem_of_mem_of_subset M d _ _ ((finset.mem_coe).mpr ds) (set.subset.trans cM h1m) }
 end
 
 section

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -802,11 +802,10 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
   (H2 : ∀ (a:R) x, p x → p (a • x)) : p x :=
 (@span_le _ _ _ _ _ _ ⟨p, H0, H1, H2⟩).2 Hs h
 
-/-- If `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, then we can write
-`m` as a finite `R`-linear combination of elements of `s`.
+/-- An element `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, if and only if
+`m` can be written as a finite `R`-linear combination of elements of `s`.
 The implementation uses `finsupp.sum`.
-The Type `M` has an explicit universe, since otherwise it gets assigned `Type (max u_2 u_3)`.
-  -/
+The Type `M` has an explicit universe, since otherwise it gets assigned `Type (max u_2 u_3)`. -/
 lemma span_as_sum {M : Type u} [add_comm_group M] [semimodule R M] {m : M} {s : set M} :
   m ∈ submodule.span R s ↔
   ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ (c.sum (λ i, (smul_add_hom R M).flip i)) = m :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -807,7 +807,7 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
 The implementation uses `finsupp.sum`.  -/
 lemma span_as_sum {R M : Type*} [semiring R] [add_comm_group M] [semimodule R M]
   {m : M} {s : set M} (hm : m ∈ submodule.span R s) :
-  ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ (c.sum (λ m, (smul_add_hom R M).flip m)) = m :=
+  ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ (c.sum (λ i, (smul_add_hom R M).flip i)) = m :=
 begin
   classical,
   refine span_induction hm (λ x hx, _) ⟨0, by simp⟩ _ _; clear hm m,

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -817,8 +817,7 @@ begin
       rw [finset.mem_coe, finsupp.mem_support_single] at hy,
       rwa hy.1 },
     { rintros x y ⟨c, hc, rfl⟩ ⟨d, hd, rfl⟩,
-      refine ⟨c + d, _, by simp⟩,
-      refine set.subset.trans _ (set.union_subset hc hd),
+      refine ⟨c + d, trans _ (set.union_subset hc hd), by simp⟩,
       rw [← finset.coe_union, finset.coe_subset],
       convert finsupp.support_add },
     { rintros r m ⟨c, hc, rfl⟩,
@@ -830,13 +829,12 @@ begin
         { convert (add_monoid_hom.map_finsupp_sum (smul_add_hom R M r) _ _).symm,
           ext m s,
           simp [mul_smul r s m] },
-        { exact (((smul_add_hom R M).flip) m).map_zero } } } },
+        { exact ((smul_add_hom R M).flip m).map_zero } } } },
   { rcases hx with ⟨c, cM, rfl⟩,
     refine sum_mem (span R s) _,
-    rintros d ds S ⟨h1, rfl⟩,
-    rintros g ⟨h1m : s ⊆ ↑h1, rfl⟩,
-    refine h1.smul_mem (c d) _,
-    exact @set.mem_of_mem_of_subset M d _ _ ((finset.mem_coe).mpr ds) (set.subset.trans cM h1m) }
+    simp only [add_monoid_hom.flip_apply, smul_add_hom_apply],
+    intros d hd,
+    exact smul_mem _ _ (subset_span (cM hd)) }
 end
 
 section

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -804,8 +804,10 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
 
 /-- If `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, then we can write
 `m` as a finite `R`-linear combination of elements of `s`.
-The implementation uses `finsupp.sum`.  -/
-lemma span_as_sum {R M : Type*} [semiring R] [add_comm_group M] [semimodule R M]
+The implementation uses `finsupp.sum`.
+The Type `M` has an explicit universe, since otherwise it gets assigned `Type (max u_2 u_3)`.
+  -/
+lemma span_as_sum {R : Type*} {M : Type u} [semiring R] [add_comm_group M] [semimodule R M]
   {m : M} {s : set M} (hm : m ∈ submodule.span R s) :
   ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ (c.sum (λ i, (smul_add_hom R M).flip i)) = m :=
 begin

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -802,43 +802,6 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
   (H2 : ∀ (a:R) x, p x → p (a • x)) : p x :=
 (@span_le _ _ _ _ _ _ ⟨p, H0, H1, H2⟩).2 Hs h
 
-/-- An element `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, if and only if
-`m` can be written as a finite `R`-linear combination of elements of `s`.
-The implementation uses `finsupp.sum`.
-The Type `M` has an explicit universe, since otherwise it gets assigned `Type (max u_2 u_3)`. -/
-lemma span_as_sum {M : Type u} [add_comm_group M] [semimodule R M] {m : M} {s : set M} :
-  m ∈ submodule.span R s ↔
-  ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ (c.sum (λ i, (smul_add_hom R M).flip i)) = m :=
-begin
-  refine ⟨λ hm, _, λ hx, _⟩,
-  { classical,
-    refine span_induction hm (λ x hx, _) ⟨0, by simp⟩ _ _; clear hm m,
-    { refine ⟨finsupp.single x 1, λ y hy, _, by simp⟩,
-      rw [finset.mem_coe, finsupp.mem_support_single] at hy,
-      rwa hy.1 },
-    { rintros x y ⟨c, hc, rfl⟩ ⟨d, hd, rfl⟩,
-      refine ⟨c + d, _, by simp⟩,
-      refine set.subset.trans _ (set.union_subset hc hd),
-      rw [← finset.coe_union, finset.coe_subset],
-      convert finsupp.support_add },
-    { rintros r m ⟨c, hc, rfl⟩,
-      refine ⟨r • c, λ x hx, hc _, _⟩,
-      { rw [finset.mem_coe, finsupp.mem_support_iff] at hx ⊢,
-        rw [finsupp.coe_smul] at hx,
-        exact right_ne_zero_of_mul hx },
-      { rw finsupp.sum_smul_index' (λ (m : M), _),
-        { convert (add_monoid_hom.map_finsupp_sum (smul_add_hom R M r) _ _).symm,
-          ext m s,
-          simp [mul_smul r s m] },
-        { exact (((smul_add_hom R M).flip) m).map_zero } } } },
-  { rcases hx with ⟨c, cM, rfl⟩,
-    refine sum_mem (span R s) _,
-    rintros d ds S ⟨h1, rfl⟩,
-    rintros g ⟨h1m : s ⊆ ↑h1, rfl⟩,
-    refine h1.smul_mem (c d) _,
-    exact @set.mem_of_mem_of_subset M d _ _ ((finset.mem_coe).mpr ds) (set.subset.trans cM h1m) }
-end
-
 section
 variables (R M)
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -805,7 +805,6 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
 /-- If `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, then we can write
 `m` as a finite `R`-linear combination of elements of `s`.
 The implementation uses `finsupp.sum`.  -/
-
 lemma span_as_sum {R M : Type*} [semiring R] [add_comm_group M] [semimodule R M]
   {m : M} {s : set M} (hm : m ∈ submodule.span R s) :
   ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ (c.sum (λ m, (smul_add_hom R M).flip m)) = m :=

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -638,8 +638,7 @@ lemma mem_span_finset {s : finset M} {x : M} :
 `m` can be written as a finite `R`-linear combination of elements of `s`.
 The implementation uses `finsupp.sum`. -/
 lemma mem_span_set {m : M} {s : set M} :
-  m ∈ submodule.span R s ↔
-  ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ c.sum (λ mi r, r • mi) = m :=
+  m ∈ submodule.span R s ↔ ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ c.sum (λ mi r, r • mi) = m :=
 begin
   conv_lhs { rw ←set.image_id s },
   simp_rw ←exists_prop,

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -638,9 +638,9 @@ universe u
 
 /-- An element `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, if and only if
 `m` can be written as a finite `R`-linear combination of elements of `s`.
-The implementation uses `finsupp.sum`.
-The Type `M` has an explicit universe, since otherwise it gets assigned `Type (max u_2 u_3)`. -/
-lemma mem_span_set {M : Type u} [add_comm_group M] [semimodule R M] {m : M} {s : set M} :
+The implementation uses `finsupp.sum`. -/
+-- The Type `M` has an explicit universe, since otherwise it gets assigned `Type (max u_2 u_3)`.
+lemma mem_span_set {m : M} {s : set M} :
   m ∈ submodule.span R s ↔
   ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ (c.sum (λ i, (smul_add_hom R M).flip i)) = m :=
 begin

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -644,8 +644,8 @@ lemma mem_span_set {m : M} {s : set M} :
   m ∈ submodule.span R s ↔
   ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ (c.sum (λ i, (smul_add_hom R M).flip i)) = m :=
 begin
-  convert finsupp.mem_span_iff_total R,
-  exact (set.image_id s).symm,
-  ext,
-  split; exact λ ⟨hsub, hsum⟩, ⟨hsub, hsum⟩,
+  convert @finsupp.mem_span_iff_total _ M R _ _ _ id s m,
+  { exact (set.image_id s).symm },
+  { ext,
+    split; exact λ ⟨hsub, hsum⟩, ⟨hsub, hsum⟩ }
 end

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -642,7 +642,7 @@ The implementation uses `finsupp.sum`. -/
 -- The Type `M` has an explicit universe, since otherwise it gets assigned `Type (max u_2 u_3)`.
 lemma mem_span_set {m : M} {s : set M} :
   m ∈ submodule.span R s ↔
-  ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ (c.sum (λ i, (smul_add_hom R M).flip i)) = m :=
+  ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ c.sum (λ mi r, r • mi) = m :=
 begin
   convert @finsupp.mem_span_iff_total _ M R _ _ _ id s m,
   { exact (set.image_id s).symm },

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -639,7 +639,6 @@ universe u
 /-- An element `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, if and only if
 `m` can be written as a finite `R`-linear combination of elements of `s`.
 The implementation uses `finsupp.sum`. -/
--- The Type `M` has an explicit universe, since otherwise it gets assigned `Type (max u_2 u_3)`.
 lemma mem_span_set {m : M} {s : set M} :
   m ∈ submodule.span R s ↔
   ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ c.sum (λ mi r, r • mi) = m :=

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -501,7 +501,6 @@ theorem mem_span_iff_total {s : set α} {x : M} :
   x ∈ span R (v '' s) ↔ ∃ l ∈ supported R R s, finsupp.total α M R v l = x :=
 by rw span_eq_map_total; simp
 
-
 variables (α) (M) (v)
 
 /-- `finsupp.total_on M v s` interprets `p : α →₀ R` as a linear combination of a

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -501,6 +501,7 @@ theorem mem_span_iff_total {s : set α} {x : M} :
   x ∈ span R (v '' s) ↔ ∃ l ∈ supported R R s, finsupp.total α M R v l = x :=
 by rw span_eq_map_total; simp
 
+
 variables (α) (M) (v)
 
 /-- `finsupp.total_on M v s` interprets `p : α →₀ R` as a linear combination of a
@@ -632,3 +633,19 @@ lemma mem_span_finset {s : finset M} {x : M} :
     (show x ∈ span R (id '' (↑s : set M)), by rwa set.image_id) in
   ⟨v, hvx ▸ (finsupp.total_apply_of_mem_supported _ hvs).symm⟩,
 λ ⟨f, hf⟩, hf ▸ sum_mem _ (λ i hi, smul_mem _ _ $ subset_span hi)⟩
+
+universe u
+
+/-- An element `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, if and only if
+`m` can be written as a finite `R`-linear combination of elements of `s`.
+The implementation uses `finsupp.sum`.
+The Type `M` has an explicit universe, since otherwise it gets assigned `Type (max u_2 u_3)`. -/
+lemma mem_span_set {M : Type u} [add_comm_group M] [semimodule R M] {m : M} {s : set M} :
+  m ∈ submodule.span R s ↔
+  ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ (c.sum (λ i, (smul_add_hom R M).flip i)) = m :=
+begin
+  convert finsupp.mem_span_iff_total R,
+  exact (set.image_id s).symm,
+  ext,
+  split; exact λ ⟨hsub, hsum⟩, ⟨hsub, hsum⟩,
+end

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -634,8 +634,6 @@ lemma mem_span_finset {s : finset M} {x : M} :
   ⟨v, hvx ▸ (finsupp.total_apply_of_mem_supported _ hvs).symm⟩,
 λ ⟨f, hf⟩, hf ▸ sum_mem _ (λ i hi, smul_mem _ _ $ subset_span hi)⟩
 
-universe u
-
 /-- An element `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, if and only if
 `m` can be written as a finite `R`-linear combination of elements of `s`.
 The implementation uses `finsupp.sum`. -/

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -641,8 +641,7 @@ lemma mem_span_set {m : M} {s : set M} :
   m ∈ submodule.span R s ↔
   ∃ c : M →₀ R, (c.support : set M) ⊆ s ∧ c.sum (λ mi r, r • mi) = m :=
 begin
-  convert @finsupp.mem_span_iff_total _ M R _ _ _ id s m,
-  { exact (set.image_id s).symm },
-  { ext,
-    split; exact λ ⟨hsub, hsum⟩, ⟨hsub, hsum⟩ }
+  conv_lhs { rw ←set.image_id s },
+  simp_rw ←exists_prop,
+  exact finsupp.mem_span_iff_total R,
 end


### PR DESCRIPTION
From the doc-string:

If `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, then we can write
`m` as a finite `R`-linear combination of elements of `s`.
The implementation uses `finsupp.sum`.

The initial proof was a substantial simplification of mine, due to Kevin Buzzard.  The final one is due to Eric Wieser.

Zulip discussion for the proof:
https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/submodule.2Espan.20as_sum

Zulip discussion for the universe issue:
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/universe.20issue.20with.20.60Type*.60

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
