### PR TITLE
[Merged by Bors] - refactor(analysis/calculus/specific_functions): add params to `smooth_bump_function`

### DIFF
--- a/src/analysis/calculus/specific_functions.lean
+++ b/src/analysis/calculus/specific_functions.lean
@@ -242,7 +242,7 @@ end smooth_transition
 
 variables {E : Type*}
 
-/-- Let `x` be apoint of a real inenr product space; let `0 < r < R` be real numbers.
+/-- Let `x` be a point of a real inner product space; let `0 < r < R` be real numbers.
 Then `smooth_bump_function x r R` is a function `E → ℝ` with the following properties:
 
 - `smooth_bump_function x r R` is infinitely smooth on `E`;

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -971,6 +971,9 @@ def to_homeomorph (e : M ≃L[R] M₂) : M ≃ₜ M₂ := { to_equiv := e.to_lin
 lemma image_closure (e : M ≃L[R] M₂) (s : set M) : e '' closure s = closure (e '' s) :=
 e.to_homeomorph.image_closure s
 
+lemma map_nhds_eq (e : M ≃L[R] M₂) (x : M) : map e (𝓝 x) = 𝓝 (e x) :=
+e.to_homeomorph.map_nhds_eq x
+
 -- Make some straightforward lemmas available to `simp`.
 @[simp] lemma map_zero (e : M ≃L[R] M₂) : e (0 : M) = 0 := (e : M →L[R] M₂).map_zero
 @[simp] lemma map_add (e : M ≃L[R] M₂) (x y : M) : e (x + y) = e x + e y :=
@@ -1038,6 +1041,9 @@ by { ext, refl }
 
 @[simp] lemma symm_to_homeomorph (e : M ≃L[R] M₂) : e.to_homeomorph.symm = e.symm.to_homeomorph :=
 rfl
+
+lemma symm_map_nhds_eq (e : M ≃L[R] M₂) (x : M) : map e.symm (𝓝 (e x)) = 𝓝 x :=
+e.to_homeomorph.symm_map_nhds_eq x
 
 /-- The composition of two continuous linear equivalences as a continuous linear equivalence. -/
 @[trans] protected def trans (e₁ : M ≃L[R] M₂) (e₂ : M₂ ≃L[R] M₃) : M ≃L[R] M₃ :=

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -162,6 +162,9 @@ closed_embedding_of_embedding_closed h.embedding h.is_closed_map
 @[simp] lemma map_nhds_eq (h : α ≃ₜ β) (x : α) : map h (𝓝 x) = 𝓝 (h x) :=
 h.embedding.map_nhds_of_mem _ (by simp)
 
+lemma symm_map_nhds_eq (h : α ≃ₜ β) (x : α) : map h.symm (𝓝 (h x)) = 𝓝 x :=
+by rw [h.symm.map_nhds_eq, h.symm_apply_apply]
+
 lemma nhds_eq_comap (h : α ≃ₜ β) (x : α) : 𝓝 x = comap h (𝓝 (h x)) :=
 h.embedding.to_inducing.nhds_eq_comap x
 

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -704,9 +704,8 @@ locally_compact_space_of_has_basis this $ λ x s ⟨⟨_, h₁⟩, _, h₂⟩, h
 lemma exists_compact_subset [locally_compact_space α] {x : α} {U : set α}
   (hU : is_open U) (hx : x ∈ U) : ∃ (K : set α), is_compact K ∧ x ∈ interior K ∧ K ⊆ U :=
 begin
-  rcases locally_compact_space.local_compact_nhds x U _ with ⟨K, h1K, h2K, h3K⟩,
-  { refine ⟨K, h3K, _, h2K⟩, rwa [ mem_interior_iff_mem_nhds] },
-  rwa [← mem_interior_iff_mem_nhds, hU.interior_eq]
+  rcases locally_compact_space.local_compact_nhds x U (mem_nhds_sets hU hx) with ⟨K, h1K, h2K, h3K⟩,
+  exact ⟨K, h3K, mem_interior_iff_mem_nhds.2 h1K, h2K⟩,
 end
 
 /-- In a locally compact space every point has a compact neighborhood. -/


### PR DESCRIPTION
In the construction of a partition of unity we need a smooth bump
function that vanishes outside of `ball x R` and equals one on
`closed_ball x r` with arbitrary `0 < r < R`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
