### PR TITLE
[Merged by Bors] - refactor(data/set/finite): change type of `set.finite.dependent_image`

### DIFF
--- a/src/analysis/analytic/composition.lean
+++ b/src/analysis/analytic/composition.lean
@@ -573,7 +573,7 @@ def comp_partial_sum_target_set (m M N : ℕ) : set (Σ n, composition n) :=
 
 lemma comp_partial_sum_target_subset_image_comp_partial_sum_source
   (m M N : ℕ) (i : Σ n, composition n) (hi : i ∈ comp_partial_sum_target_set m M N) :
-  ∃ j (hj : j ∈ comp_partial_sum_source m M N), i = comp_change_of_variables m M N j hj :=
+  ∃ j (hj : j ∈ comp_partial_sum_source m M N), comp_change_of_variables m M N j hj = i :=
 begin
   rcases i with ⟨n, c⟩,
   refine ⟨⟨c.length, c.blocks_fun⟩, _, _⟩,
@@ -583,15 +583,15 @@ begin
   { dsimp [comp_change_of_variables],
     rw composition.sigma_eq_iff_blocks_eq,
     simp only [composition.blocks_fun, composition.blocks, subtype.coe_eta, nth_le_map'],
-    conv_lhs { rw ← of_fn_nth_le c.blocks } }
+    conv_rhs { rw ← of_fn_nth_le c.blocks } }
 end
 
 /-- Target set in the change of variables to compute the composition of partial sums of formal
 power series, here given a a finset.
 See also `comp_partial_sum`. -/
 def comp_partial_sum_target (m M N : ℕ) : finset (Σ n, composition n) :=
-set.finite.to_finset $ (finset.finite_to_set _).dependent_image
-  (comp_partial_sum_target_subset_image_comp_partial_sum_source m M N)
+set.finite.to_finset $ ((finset.finite_to_set _).dependent_image _).subset $
+  comp_partial_sum_target_subset_image_comp_partial_sum_source m M N
 
 @[simp] lemma mem_comp_partial_sum_target_iff {m M N : ℕ} {a : Σ n, composition n} :
   a ∈ comp_partial_sum_target m M N ↔
@@ -637,7 +637,7 @@ begin
         end
       ... = blocks_fun' i : comp_change_of_variables_blocks_fun m M N H' i },
   -- 4 - show that the map is surjective
-  { assume i hi,
+  { assume i hi, simp only [@eq_comm _ i],
     apply comp_partial_sum_target_subset_image_comp_partial_sum_source m M N i,
     simpa [comp_partial_sum_target] using hi }
 end

--- a/src/analysis/analytic/composition.lean
+++ b/src/analysis/analytic/composition.lean
@@ -573,7 +573,7 @@ def comp_partial_sum_target_set (m M N : ℕ) : set (Σ n, composition n) :=
 
 lemma comp_partial_sum_target_subset_image_comp_partial_sum_source
   (m M N : ℕ) (i : Σ n, composition n) (hi : i ∈ comp_partial_sum_target_set m M N) :
-  ∃ j (hj : j ∈ comp_partial_sum_source m M N), comp_change_of_variables m M N j hj = i :=
+  ∃ j (hj : j ∈ comp_partial_sum_source m M N), i = comp_change_of_variables m M N j hj :=
 begin
   rcases i with ⟨n, c⟩,
   refine ⟨⟨c.length, c.blocks_fun⟩, _, _⟩,
@@ -583,7 +583,7 @@ begin
   { dsimp [comp_change_of_variables],
     rw composition.sigma_eq_iff_blocks_eq,
     simp only [composition.blocks_fun, composition.blocks, subtype.coe_eta, nth_le_map'],
-    conv_rhs { rw ← of_fn_nth_le c.blocks } }
+    conv_lhs { rw ← of_fn_nth_le c.blocks } }
 end
 
 /-- Target set in the change of variables to compute the composition of partial sums of formal
@@ -637,7 +637,7 @@ begin
         end
       ... = blocks_fun' i : comp_change_of_variables_blocks_fun m M N H' i },
   -- 4 - show that the map is surjective
-  { assume i hi, simp only [@eq_comm _ i],
+  { assume i hi,
     apply comp_partial_sum_target_subset_image_comp_partial_sum_source m M N i,
     simpa [comp_partial_sum_target] using hi }
 end

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -271,16 +271,12 @@ theorem infinite_of_infinite_image (f : α → β) {s : set α} (hs : (f '' s).i
   s.infinite :=
 mt (finite.image f) hs
 
-lemma finite.dependent_image {s : set α} (hs : finite s) {F : Π i ∈ s, β} {t : set β}
-  (H : ∀ y ∈ t, ∃ x (hx : x ∈ s), y = F x hx) : set.finite t :=
+lemma finite.dependent_image {s : set α} (hs : finite s) (F : Π i ∈ s, β) :
+  finite {y : β | ∃ x (hx : x ∈ s), F x hx = y} :=
 begin
-  let G : s → β := λ x, F x.1 x.2,
-  have A : t ⊆ set.range G,
-  { assume y hy,
-    rcases H y hy with ⟨x, hx, xy⟩,
-    refine ⟨⟨x, hx⟩, xy.symm⟩ },
-  letI : fintype s := finite.fintype hs,
-  exact (finite_range G).subset A
+  letI : fintype s := hs.fintype,
+  convert finite_range (λ x : s, F x x.2),
+  simp only [set_coe.exists, subtype.coe_mk]
 end
 
 instance fintype_map {α β} [decidable_eq β] :

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -272,11 +272,11 @@ theorem infinite_of_infinite_image (f : α → β) {s : set α} (hs : (f '' s).i
 mt (finite.image f) hs
 
 lemma finite.dependent_image {s : set α} (hs : finite s) (F : Π i ∈ s, β) :
-  finite {y : β | ∃ x (hx : x ∈ s), F x hx = y} :=
+  finite {y : β | ∃ x (hx : x ∈ s), y = F x hx} :=
 begin
   letI : fintype s := hs.fintype,
   convert finite_range (λ x : s, F x x.2),
-  simp only [set_coe.exists, subtype.coe_mk]
+  simp only [set_coe.exists, subtype.coe_mk, eq_comm],
 end
 
 instance fintype_map {α β} [decidable_eq β] :


### PR DESCRIPTION
The old lemma combined a statement similar to `set.finite.image` with
`set.finite.subset`. The new statement is a direct generalization of
`set.finite.image`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
