### PR TITLE
[Merged by Bors] - chore(logic/function/basic): remove classical decidable instance from a lemma statement

### DIFF
--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -462,7 +462,7 @@ Mostly useful when `f` is injective. -/
 def extend (f : α → β) (g : α → γ) (e' : β → γ) : β → γ :=
 λ b, if h : ∃ a, f a = b then g (classical.some h) else e' b
 
-lemma extend_def (f : α → β) (g : α → γ) (e' : β → γ) (b : β) :
+lemma extend_def (f : α → β) (g : α → γ) (e' : β → γ) (b : β) [decidable (∃ a, f a = b)]:
   extend f g e' b = if h : ∃ a, f a = b then g (classical.some h) else e' b := rfl
 
 @[simp] lemma extend_apply (hf : injective f) (g : α → γ) (e' : β → γ) (a : α) :

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -462,7 +462,7 @@ Mostly useful when `f` is injective. -/
 def extend (f : α → β) (g : α → γ) (e' : β → γ) : β → γ :=
 λ b, if h : ∃ a, f a = b then g (classical.some h) else e' b
 
-lemma extend_def (f : α → β) (g : α → γ) (e' : β → γ) (b : β) [decidable (∃ a, f a = b)]:
+lemma extend_def (f : α → β) (g : α → γ) (e' : β → γ) (b : β) [decidable (∃ a, f a = b)] :
   extend f g e' b = if h : ∃ a, f a = b then g (classical.some h) else e' b := rfl
 
 @[simp] lemma extend_apply (hf : injective f) (g : α → γ) (e' : β → γ) (a : α) :

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -463,7 +463,7 @@ def extend (f : α → β) (g : α → γ) (e' : β → γ) : β → γ :=
 λ b, if h : ∃ a, f a = b then g (classical.some h) else e' b
 
 lemma extend_def (f : α → β) (g : α → γ) (e' : β → γ) (b : β) [decidable (∃ a, f a = b)] :
-  extend f g e' b = if h : ∃ a, f a = b then g (classical.some h) else e' b := rfl
+  extend f g e' b = if h : ∃ a, f a = b then g (classical.some h) else e' b := by convert rfl
 
 @[simp] lemma extend_apply (hf : injective f) (g : α → γ) (e' : β → γ) (a : α) :
   extend f g e' (f a) = g a :=

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -463,7 +463,8 @@ def extend (f : α → β) (g : α → γ) (e' : β → γ) : β → γ :=
 λ b, if h : ∃ a, f a = b then g (classical.some h) else e' b
 
 lemma extend_def (f : α → β) (g : α → γ) (e' : β → γ) (b : β) [decidable (∃ a, f a = b)] :
-  extend f g e' b = if h : ∃ a, f a = b then g (classical.some h) else e' b := by convert rfl
+  extend f g e' b = if h : ∃ a, f a = b then g (classical.some h) else e' b :=
+by { unfold extend, congr }
 
 @[simp] lemma extend_apply (hf : injective f) (g : α → γ) (e' : β → γ) (a : α) :
   extend f g e' (f a) = g a :=


### PR DESCRIPTION
Found using #6485

This means that this lemma can be use in reverse against any `ite`, not just one that uses `classical.decidable`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
