### PR TITLE
[Merged by Bors] - feat(src/order/basic): show injectivity of order conversions, and tag lemmas with ext

### DIFF
--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -59,25 +59,42 @@ variables {α : Type u} {β : Type v} {γ : Type w} {r : α → α → Prop}
 @[simp] lemma lt_self_iff_false [preorder α] (a : α) : a < a ↔ false :=
 by simp [lt_irrefl a]
 
+attribute [ext] has_le
+
+@[ext]
+lemma preorder.to_has_le_injective {α : Type*} :
+  function.injective (@preorder.to_has_le α) :=
+λ A B h, begin
+  cases A, cases B,
+  injection h with h_le,
+  have : A_lt = B_lt,
+  { funext a b,
+    dsimp [(≤)] at A_lt_iff_le_not_le B_lt_iff_le_not_le h_le,
+    simp [A_lt_iff_le_not_le, B_lt_iff_le_not_le, h_le], },
+  congr',
+end
+
+@[ext]
+lemma partial_order.to_preorder_injective {α : Type*} :
+  function.injective (@partial_order.to_preorder α) :=
+λ A B h, by { cases A, cases B, injection h, congr' }
+
+@[ext]
+lemma linear_order.to_partial_order_injective {α : Type*} :
+  function.injective (@linear_order.to_partial_order α) :=
+λ A B h, by { cases A, cases B, injection h, congr' }
+
 theorem preorder.ext {α} {A B : preorder α}
   (H : ∀ x y : α, (by haveI := A; exact x ≤ y) ↔ x ≤ y) : A = B :=
-begin
-  casesI A, casesI B, congr,
-  { funext x y, exact propext (H x y) },
-  { funext x y,
-    dsimp [(≤)] at A_lt_iff_le_not_le B_lt_iff_le_not_le H,
-    simp [A_lt_iff_le_not_le, B_lt_iff_le_not_le, H] },
-end
+by { ext x y, exact H x y }
 
 theorem partial_order.ext {α} {A B : partial_order α}
   (H : ∀ x y : α, (by haveI := A; exact x ≤ y) ↔ x ≤ y) : A = B :=
-by { haveI this := preorder.ext H,
-     casesI A, casesI B, injection this, congr' }
+by { ext x y, exact H x y }
 
 theorem linear_order.ext {α} {A B : linear_order α}
   (H : ∀ x y : α, (by haveI := A; exact x ≤ y) ↔ x ≤ y) : A = B :=
-by { haveI this := partial_order.ext H,
-     casesI A, casesI B, injection this, congr' }
+by { ext x y, exact H x y }
 
 /-- Given a relation `R` on `β` and a function `f : α → β`,
   the preimage relation on `α` is defined by `x ≤ y ↔ f x ≤ f y`.


### PR DESCRIPTION
Stating these as `function.injective` provides slightly more API, especially since before only the composition was proven as injective.

For convenience, this leaves behind `preorder.ext`, `partial_order.ext`, and `linear_order.ext`, although these are now provable with trivial applications of `ext`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
