### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal/operations): add quotient_equiv

### DIFF
--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1318,12 +1318,12 @@ ring_hom.ext (λ x, by simp only [function.comp_app, ring_hom.coe_comp, ideal.qu
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f (map f.symm) = I`. -/
 lemma map_of_equiv (I : ideal R) (f : R ≃+* S) : (I.map f.to_ring_hom).map f.symm.to_ring_hom = I :=
-by simp [map_map, map_id]
+by simp [map_map]
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `comap f.symm (comap f) = I`. -/
 lemma comap_of_equiv (I : ideal R) (f : R ≃+* S) :
   (I.comap f.symm.to_ring_hom).comap f.to_ring_hom = I :=
-by simp [comap_comap, comap_id]
+by simp [comap_comap]
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f I = comap f.symm I`. -/
 lemma map_comap_of_equiv (I : ideal R) (f : R ≃+* S) : I.map (f : R →+* S) = I.comap f.symm :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1317,27 +1317,18 @@ lemma quotient_map_comp_mk {J : ideal R} {I : ideal S} {f : R →+* S} (H : J �
 ring_hom.ext (λ x, by simp only [function.comp_app, ring_hom.coe_comp, ideal.quotient_map_mk])
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f (map f.symm) = I`. -/
-lemma map_of_equiv (I : ideal R) (f : R ≃+* S) : (I.map (f : R →+* S)).map ↑f.symm = I :=
-begin
-  have h : (f.symm : S →+* R).comp (f : R →+* S) = ring_hom.id _,
-  { ext r, simp },
-  rw [map_map, h, map_id]
-end
+lemma map_of_equiv (I : ideal R) (f : R ≃+* S) : (I.map f.to_ring_hom).map f.symm.to_ring_hom = I :=
+by simp [map_map, map_id]
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `comap f.symm (comap f) = I`. -/
-lemma comap_of_equiv (I : ideal R) (f : R ≃+* S) : (I.comap (f.symm : S →+* R)).comap ↑f = I :=
-begin
-  have h : (f.symm : S →+* R).comp (f : R →+* S) = ring_hom.id _,
-  { ext r, simp },
-  rw [comap_comap, h, comap_id]
-end
+lemma comap_of_equiv (I : ideal R) (f : R ≃+* S) :
+  (I.comap f.symm.to_ring_hom).comap f.to_ring_hom = I :=
+by simp [comap_comap, comap_id]
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f I = comap f.symm I`. -/
 lemma map_comap_of_equiv (I : ideal R) (f : R ≃+* S) : I.map (f : R →+* S) = I.comap f.symm :=
-begin
-  refine le_antisymm (le_comap_of_map_le (le_of_eq (map_of_equiv I f))) _,
-  exact le_map_of_comap_le_of_surjective _ f.surjective (comap_of_equiv I f).le
-end
+le_antisymm (le_comap_of_map_le (le_of_eq (map_of_equiv I f)))
+  (le_map_of_comap_le_of_surjective _ f.surjective (comap_of_equiv I f).le)
 
 /-- The ring equiv `R/I ≃+* S/J` induced by a ring equiv `f : R ≃+** S`,  where `J = f(I)`. -/
 @[simps]

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1317,13 +1317,13 @@ lemma quotient_map_comp_mk {J : ideal R} {I : ideal S} {f : R →+* S} (H : J �
 ring_hom.ext (λ x, by simp only [function.comp_app, ring_hom.coe_comp, ideal.quotient_map_mk])
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f (map f.symm) = I`. -/
-lemma map_of_equiv (I : ideal R) (f : R ≃+* S) : (I.map f.to_ring_hom).map f.symm.to_ring_hom = I :=
-by simp [map_map]
+lemma map_of_equiv (I : ideal R) (f : R ≃+* S) : (I.map (f : R →+* S)).map (f.symm : S →+* R) = I :=
+by { rw [← ring_equiv.to_ring_hom_eq_coe, ← ring_equiv.to_ring_hom_eq_coe], simp [map_map] }
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `comap f.symm (comap f) = I`. -/
 lemma comap_of_equiv (I : ideal R) (f : R ≃+* S) :
-  (I.comap f.symm.to_ring_hom).comap f.to_ring_hom = I :=
-by simp [comap_comap]
+  (I.comap (f.symm : S →+* R)).comap (f : R →+* S) = I :=
+by { rw [← ring_equiv.to_ring_hom_eq_coe, ← ring_equiv.to_ring_hom_eq_coe], simp [comap_comap] }
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f I = comap f.symm I`. -/
 lemma map_comap_of_equiv (I : ideal R) (f : R ≃+* S) : I.map (f : R →+* S) = I.comap f.symm :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1394,7 +1394,8 @@ alg_hom.ext (λ x, by simp only [quotient_map_mkₐ, quotient.mkₐ_eq_mk, alg_h
 
 /-- The algebra equiv `A/I ≃ₐ[R] S/J` induced by an algebra equiv `f : A ≃ₐ[R] S`,
 where`J = f(I)`. -/
-def quotient_equiv_alg (I : ideal A) (f : A ≃ₐ[R] S) : I.quotient ≃ₐ[R] (map (f : A →+* S) I).quotient :=
+def quotient_equiv_alg (I : ideal A) (f : A ≃ₐ[R] S) : I.quotient ≃ₐ[R]
+  (map (f : A →+* S) I).quotient :=
 { commutes' := λ r,
   begin
     have h : (algebra_map R I.quotient) r = (quotient.mk I) (algebra_map R A r) := rfl,

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1336,7 +1336,7 @@ end
 lemma map_comap_of_equiv (I : ideal R) (f : R ≃+* S) : I.map (f : R →+* S) = I.comap f.symm :=
 begin
   refine le_antisymm (le_comap_of_map_le (le_of_eq (map_of_equiv I f))) _,
-  exact le_map_of_comap_le_of_surjective _ (ring_equiv.surjective f) (le_of_eq (comap_of_equiv I f))
+  exact le_map_of_comap_le_of_surjective _ f.surjective (comap_of_equiv I f).le
 end
 
 /-- The ring equiv `R/I ≃+* S/J` induced by a ring equiv `f : R ≃+** S`,  where `J = f(I)`. -/

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1327,7 +1327,7 @@ by simp [← ring_equiv.to_ring_hom_eq_coe, comap_comap]
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f I = comap f.symm I`. -/
 lemma map_comap_of_equiv (I : ideal R) (f : R ≃+* S) : I.map (f : R →+* S) = I.comap f.symm :=
-le_antisymm (le_comap_of_map_le (le_of_eq (map_of_equiv I f)))
+le_antisymm (le_comap_of_map_le (map_of_equiv I f).le)
   (le_map_of_comap_le_of_surjective _ f.surjective (comap_of_equiv I f).le)
 
 /-- The ring equiv `R/I ≃+* S/J` induced by a ring equiv `f : R ≃+** S`,  where `J = f(I)`. -/

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1318,7 +1318,7 @@ ring_hom.ext (λ x, by simp only [function.comp_app, ring_hom.coe_comp, ideal.qu
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f (map f.symm) = I`. -/
 lemma map_of_equiv (I : ideal R) (f : R ≃+* S) : (I.map (f : R →+* S)).map (f.symm : S →+* R) = I :=
-by { rw [← ring_equiv.to_ring_hom_eq_coe, ← ring_equiv.to_ring_hom_eq_coe], simp [map_map] }
+by simp [← ring_equiv.to_ring_hom_eq_coe, map_map]
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `comap f.symm (comap f) = I`. -/
 lemma comap_of_equiv (I : ideal R) (f : R ≃+* S) :

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1323,7 +1323,7 @@ by { rw [← ring_equiv.to_ring_hom_eq_coe, ← ring_equiv.to_ring_hom_eq_coe], 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `comap f.symm (comap f) = I`. -/
 lemma comap_of_equiv (I : ideal R) (f : R ≃+* S) :
   (I.comap (f.symm : S →+* R)).comap (f : R →+* S) = I :=
-by { rw [← ring_equiv.to_ring_hom_eq_coe, ← ring_equiv.to_ring_hom_eq_coe], simp [comap_comap] }
+by simp [← ring_equiv.to_ring_hom_eq_coe, comap_comap]
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f I = comap f.symm I`. -/
 lemma map_comap_of_equiv (I : ideal R) (f : R ≃+* S) : I.map (f : R →+* S) = I.comap f.symm :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1308,42 +1308,6 @@ def quotient_map {I : ideal R} (J : ideal S) (f : R →+* S) (hIJ : I ≤ J.coma
   by simpa [function.comp_app, ring_hom.coe_comp, quotient.eq_zero_iff_mem] using hIJ ha))
 
 @[simp]
-lemma quotient_map.apply {I : ideal R} (J : ideal S) (f : R →+* S) (hIJ : I ≤ J.comap f) (r : R) :
-  quotient_map J f hIJ (quotient.mk I r) = quotient.mk J (f r) := rfl
-
-/-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f (map f.symm) = I` -/
-lemma map_of_equiv (I : ideal R) (f : R ≃+* S) : (I.map (f : R →+* S)).map ↑f.symm = I :=
-begin
-  have h : (f.symm : S →+* R).comp (f : R →+* S) = ring_hom.id _,
-  { ext r, simp },
-  rw [map_map, h, map_id]
-end
-
-/-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `comap f.symm (comap f) = I` -/
-lemma comap_of_equiv (I : ideal R) (f : R ≃+* S) : (I.comap (f.symm : S →+* R)).comap ↑f = I :=
-begin
-  have h : (f.symm : S →+* R).comp (f : R →+* S) = ring_hom.id _,
-  { ext r, simp },
-  rw [comap_comap, h, comap_id]
-end
-
-/-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f I = comap f.symm I` -/
-lemma map_comap_of_equiv (I : ideal R) (f : R ≃+* S) : I.map (f : R →+* S) = I.comap f.symm :=
-begin
-  refine le_antisymm (le_comap_of_map_le (le_of_eq (map_of_equiv I f))) _,
-  exact le_map_of_comap_le_of_surjective _ (ring_equiv.surjective f) (le_of_eq (comap_of_equiv I f))
-end
-
-/-- The ring equiv `R/I ≃+* S/J` induced by a ring equiv `f : R ≃+** S` with `J = f(I)` -/
-@[simps]
-def quotient_equiv {I : ideal R} (f : R ≃+* S) :
-  I.quotient ≃+* (map ↑f I).quotient :=
-{ inv_fun := quotient_map I ↑f.symm (le_of_eq (map_comap_of_equiv I f)),
-  left_inv := by {rintro ⟨r⟩, simp},
-  right_inv := by {rintro ⟨s⟩, simp},
-  ..quotient_map (map ↑f I) ↑f (@le_comap_map _ S _ _ _ _) }
-
-@[simp]
 lemma quotient_map_mk {J : ideal R} {I : ideal S} {f : R →+* S} {H : J ≤ I.comap f}
   {x : R} : quotient_map I f H (quotient.mk J x) = quotient.mk I (f x) :=
 quotient.lift_mk J _ _
@@ -1352,7 +1316,39 @@ lemma quotient_map_comp_mk {J : ideal R} {I : ideal S} {f : R →+* S} (H : J �
   (quotient_map I f H).comp (quotient.mk J) = (quotient.mk I).comp f :=
 ring_hom.ext (λ x, by simp only [function.comp_app, ring_hom.coe_comp, ideal.quotient_map_mk])
 
-/-- `H` and `h` are kept as separate hypothesis since H is used in constructing the quotient map -/
+/-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f (map f.symm) = I`. -/
+lemma map_of_equiv (I : ideal R) (f : R ≃+* S) : (I.map (f : R →+* S)).map ↑f.symm = I :=
+begin
+  have h : (f.symm : S →+* R).comp (f : R →+* S) = ring_hom.id _,
+  { ext r, simp },
+  rw [map_map, h, map_id]
+end
+
+/-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `comap f.symm (comap f) = I`. -/
+lemma comap_of_equiv (I : ideal R) (f : R ≃+* S) : (I.comap (f.symm : S →+* R)).comap ↑f = I :=
+begin
+  have h : (f.symm : S →+* R).comp (f : R →+* S) = ring_hom.id _,
+  { ext r, simp },
+  rw [comap_comap, h, comap_id]
+end
+
+/-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f I = comap f.symm I`. -/
+lemma map_comap_of_equiv (I : ideal R) (f : R ≃+* S) : I.map (f : R →+* S) = I.comap f.symm :=
+begin
+  refine le_antisymm (le_comap_of_map_le (le_of_eq (map_of_equiv I f))) _,
+  exact le_map_of_comap_le_of_surjective _ (ring_equiv.surjective f) (le_of_eq (comap_of_equiv I f))
+end
+
+/-- The ring equiv `R/I ≃+* S/J` induced by a ring equiv `f : R ≃+** S`,  where `J = f(I)`. -/
+@[simps]
+def quotient_equiv (I : ideal R) (f : R ≃+* S) :
+  I.quotient ≃+* (map ↑f I).quotient :=
+{ inv_fun := quotient_map I ↑f.symm (le_of_eq (map_comap_of_equiv I f)),
+  left_inv := by {rintro ⟨r⟩, simp},
+  right_inv := by {rintro ⟨s⟩, simp},
+  ..quotient_map (map ↑f I) ↑f (@le_comap_map _ S _ _ _ _) }
+
+/-- `H` and `h` are kept as separate hypothesis since H is used in constructing the quotient map. -/
 lemma quotient_map_injective' {J : ideal R} {I : ideal S} {f : R →+* S} {H : J ≤ I.comap f}
   (h : I.comap f ≤ J) : function.injective (quotient_map I f H) :=
 begin
@@ -1386,6 +1382,34 @@ begin
 end
 
 variables {I : ideal R} {J: ideal S} [algebra R S]
+
+/-- The algebra hom `A/I →+* S/J` induced by an algebra hom `f : A →ₐ[R] S` with `I ≤ f⁻¹(J)`. -/
+def quotient_mapₐ {I : ideal A} (J : ideal S) (f : A →ₐ[R] S) (hIJ : I ≤ J.comap f) :
+  I.quotient →ₐ[R] J.quotient :=
+{ commutes' := λ r,
+  begin
+    have h : (algebra_map R I.quotient) r = (quotient.mk I) (algebra_map R A r) := rfl,
+    simpa [h]
+  end
+  ..quotient_map J ↑f hIJ }
+
+@[simp]
+lemma quotient_map_mkₐ {I : ideal A} (J : ideal S) (f : A →ₐ[R] S) (H : I ≤ J.comap f)
+  {x : A} : quotient_mapₐ J f H (quotient.mk I x) = quotient.mkₐ R J (f x) := rfl
+
+lemma quotient_map_comp_mkₐ {I : ideal A} (J : ideal S) (f : A →ₐ[R] S) (H : I ≤ J.comap f) :
+  (quotient_mapₐ J f H).comp (quotient.mkₐ R I) = (quotient.mkₐ R J).comp f :=
+alg_hom.ext (λ x, by simp only [quotient_map_mkₐ, quotient.mkₐ_eq_mk, alg_hom.comp_apply])
+
+/-- The algebra equiv `A/I ≃ₐ[R] S/J` induced by an algebra equiv `f : A ≃ₐ[R] S`,
+where`J = f(I)`. -/
+def quotient_equiv_alg (I : ideal A) (f : A ≃ₐ[R] S) : I.quotient ≃ₐ[R] (map (f : A →+* S) I).quotient :=
+{ commutes' := λ r,
+  begin
+    have h : (algebra_map R I.quotient) r = (quotient.mk I) (algebra_map R A r) := rfl,
+    simpa [h]
+  end,
+  ..quotient_equiv I (f : A ≃+* S) }
 
 @[priority 100]
 instance quotient_algebra : algebra (J.comap (algebra_map R S)).quotient J.quotient :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1332,12 +1332,12 @@ le_antisymm (le_comap_of_map_le (le_of_eq (map_of_equiv I f)))
 
 /-- The ring equiv `R/I ≃+* S/J` induced by a ring equiv `f : R ≃+** S`,  where `J = f(I)`. -/
 @[simps]
-def quotient_equiv (I : ideal R) (f : R ≃+* S) :
-  I.quotient ≃+* (map ↑f I).quotient :=
-{ inv_fun := quotient_map I ↑f.symm (le_of_eq (map_comap_of_equiv I f)),
-  left_inv := by {rintro ⟨r⟩, simp},
-  right_inv := by {rintro ⟨s⟩, simp},
-  ..quotient_map (map ↑f I) ↑f (@le_comap_map _ S _ _ _ _) }
+def quotient_equiv (I : ideal R) (J : ideal S) (f : R ≃+* S) (hIJ : J = I.map (f : R →+* S)) :
+  I.quotient ≃+* J.quotient :=
+{ inv_fun := quotient_map I ↑f.symm (by {rw hIJ, exact le_of_eq (map_comap_of_equiv I f)}),
+  left_inv := by {rintro ⟨r⟩, simp },
+  right_inv := by {rintro ⟨s⟩, simp },
+  ..quotient_map J ↑f (by {rw hIJ, exact @le_comap_map _ S _ _ _ _}) }
 
 /-- `H` and `h` are kept as separate hypothesis since H is used in constructing the quotient map. -/
 lemma quotient_map_injective' {J : ideal R} {I : ideal S} {f : R →+* S} {H : J ≤ I.comap f}
@@ -1394,14 +1394,14 @@ alg_hom.ext (λ x, by simp only [quotient_map_mkₐ, quotient.mkₐ_eq_mk, alg_h
 
 /-- The algebra equiv `A/I ≃ₐ[R] S/J` induced by an algebra equiv `f : A ≃ₐ[R] S`,
 where`J = f(I)`. -/
-def quotient_equiv_alg (I : ideal A) (f : A ≃ₐ[R] S) : I.quotient ≃ₐ[R]
-  (map (f : A →+* S) I).quotient :=
+def quotient_equiv_alg (I : ideal A) (J : ideal S) (f : A ≃ₐ[R] S) (hIJ : J = I.map (f : A →+* S)) :
+  I.quotient ≃ₐ[R] J.quotient :=
 { commutes' := λ r,
   begin
     have h : (algebra_map R I.quotient) r = (quotient.mk I) (algebra_map R A r) := rfl,
     simpa [h]
   end,
-  ..quotient_equiv I (f : A ≃+* S) }
+  ..quotient_equiv I J (f : A ≃+* S) hIJ }
 
 @[priority 100]
 instance quotient_algebra : algebra (J.comap (algebra_map R S)).quotient J.quotient :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1317,10 +1317,12 @@ lemma quotient_map_comp_mk {J : ideal R} {I : ideal S} {f : R →+* S} (H : J �
 ring_hom.ext (λ x, by simp only [function.comp_app, ring_hom.coe_comp, ideal.quotient_map_mk])
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `map f (map f.symm) = I`. -/
+@[simp]
 lemma map_of_equiv (I : ideal R) (f : R ≃+* S) : (I.map (f : R →+* S)).map (f.symm : S →+* R) = I :=
 by simp [← ring_equiv.to_ring_hom_eq_coe, map_map]
 
 /-- If `f : R ≃+* S` is a ring isomorphism and `I : ideal R`, then `comap f.symm (comap f) = I`. -/
+@[simp]
 lemma comap_of_equiv (I : ideal R) (f : R ≃+* S) :
   (I.comap (f.symm : S →+* R)).comap (f : R →+* S) = I :=
 by simp [← ring_equiv.to_ring_hom_eq_coe, comap_comap]


### PR DESCRIPTION
The ring equiv `R/I ≃+* S/J` induced by a ring equiv `f : R ≃+* S`,  where `J = f(I)`, and similarly for algebras.