### PR TITLE
[Merged by Bors] - feat(set_theory/cardinal, data/nat/fincard): Define `nat`- and `enat`-valued cardinalities

### DIFF
--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -182,19 +182,14 @@ finite_dimensional_iff_dim_lt_omega.2 (lt_of_le_of_lt (dim_quotient_le _) (dim_l
 be `0` if the space is infinite-dimensional. -/
 noncomputable def findim (K V : Type*) [field K]
   [add_comm_group V] [vector_space K V] : ℕ :=
-if h : dim K V < omega.{v} then classical.some (lt_omega.1 h) else 0
+(dim K V).to_nat
 
 /-- In a finite-dimensional space, its dimension (seen as a cardinal) coincides with its
 `findim`. -/
 lemma findim_eq_dim (K : Type u) (V : Type v) [field K]
   [add_comm_group V] [vector_space K V] [finite_dimensional K V] :
   (findim K V : cardinal.{v}) = dim K V :=
-begin
-  have : findim K V = classical.some (lt_omega.1 (dim_lt_omega K V)) :=
-    dif_pos (dim_lt_omega K V),
-  rw this,
-  exact (classical.some_spec (lt_omega.1 (dim_lt_omega K V))).symm
-end
+by rw [findim, cast_to_nat_of_lt_omega (dim_lt_omega K V)]
 
 lemma findim_of_infinite_dimensional {K V : Type*} [field K] [add_comm_group V] [vector_space K V]
   (h : ¬finite_dimensional K V) : findim K V = 0 :=

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -770,6 +770,8 @@ begin
   rintro ⟨f'⟩, cases embedding.trans f' equiv.ulift.to_embedding with f hf, exact ⟨f, hf⟩
 end
 
+/-- This function sends finite cardinals to the corresponding natural, and infinite cardinals
+  to 0. -/
 noncomputable def to_nat (c : cardinal) : ℕ :=
 if h : c < omega.{v} then classical.some (lt_omega.1 h) else 0
 
@@ -800,6 +802,8 @@ by rw [← to_nat_cast 0, nat.cast_zero]
 lemma one_to_nat : cardinal.to_nat 1 = 1 :=
 by rw [← to_nat_cast 1, nat.cast_one]
 
+/-- This function sends finite cardinals to the corresponding natural, and infinite cardinals
+  to `⊤`. -/
 noncomputable def to_enat : cardinal →+ enat :=
 { to_fun := λ c, if c < omega.{v} then c.to_nat else ⊤,
   map_zero' := by simp [if_pos (lt_trans zero_lt_one one_lt_omega)],

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -758,6 +758,28 @@ end
 theorem infinite_iff {α : Type u} : infinite α ↔ omega ≤ mk α :=
 by rw [←not_lt, lt_omega_iff_fintype, not_nonempty_fintype]
 
+noncomputable def to_nat (c : cardinal) : ℕ :=
+if h : c < omega.{v} then classical.some (lt_omega.1 h) else 0
+
+lemma cast_to_nat_of_lt_omega {c : cardinal} (h : c < omega) :
+  ↑c.to_nat = c :=
+by rw [to_nat, dif_pos h, ← classical.some_spec (lt_omega.1 h)]
+
+@[simp]
+lemma to_nat_cast (n : ℕ) : cardinal.to_nat n = n :=
+begin
+  rw [to_nat, dif_pos (nat_lt_omega n), ← nat_cast_inj],
+  exact (classical.some_spec (lt_omega.1 (nat_lt_omega n))).symm,
+end
+
+@[simp]
+lemma mk_to_nat_of_infinite [h : infinite α] : (mk α).to_nat = 0 :=
+dif_neg (not_lt_of_le (infinite_iff.1 h))
+
+@[simp]
+lemma mk_to_nat_eq_card [fintype α] : (mk α).to_nat = fintype.card α :=
+by simp [fintype_card]
+
 lemma countable_iff (s : set α) : countable s ↔ mk s ≤ omega :=
 begin
   rw [countable_iff_exists_injective], split,
@@ -1091,3 +1113,18 @@ end cardinal
 
 lemma equiv.cardinal_eq {α β} : α ≃ β → cardinal.mk α = cardinal.mk β :=
 cardinal.eq_congr
+
+section fincard
+open cardinal
+
+noncomputable def fincard (α : Type*) : ℕ := (mk α).to_nat
+
+@[simp]
+lemma infinite.fincard [h : infinite α] : fincard α = 0 :=
+mk_to_nat_of_infinite
+
+@[simp]
+lemma fintype.fincard_eq_card [fintype α] : fincard α = fintype.card α :=
+mk_to_nat_eq_card
+
+end fincard


### PR DESCRIPTION
Defines `cardinal.to_nat` and `cardinal.to_enat`
Uses those to define `nat.card` and `enat.card`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
