### PR TITLE
chore(group_theory/submonoid/operations): use coercion instead of .val

### DIFF
--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -309,7 +309,7 @@ end galois_insertion
 
 /-- A submonoid of a monoid inherits a multiplication. -/
 @[to_additive "An `add_submonoid` of an `add_monoid` inherits an addition."]
-instance has_mul : has_mul S := ⟨λ a b, ⟨a.1 * b.1, S.mul_mem a.2 b.2⟩⟩
+instance has_mul : has_mul S := ⟨λ a b, ⟨a * b, S.mul_mem a.2 b.2⟩⟩
 
 /-- A submonoid of a monoid inherits a 1. -/
 @[to_additive "An `add_submonoid` of an `add_monoid` inherits a zero."]


### PR DESCRIPTION
lemmas are generally phrased about coercions, so in the unlikely even this is unfolded, the former is more likely to be useful.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Split from #6509.

This seemingly harmless changes causes a timeout in `analysis/normed_space/hahn_banach.lean`.
While obviously there's minimal gain to merging this PR as is, I think there's probably something library-note worthy to be learnt about this failure.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.236509.20timeout/near/228504230)