### PR TITLE
[Merged by Bors] - chore(analysis/normed_space/extend): remove unnecessary imports

### DIFF
--- a/src/analysis/normed_space/extend.lean
+++ b/src/analysis/normed_space/extend.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ruben Van de Velde
 -/
 
-import analysis.complex.basic
-import analysis.normed_space.operator_norm
 import data.complex.is_R_or_C
 
 /-!


### PR DESCRIPTION
Remove two imports.  `import analysis.complex.basic` is actually unnecessary, `import analysis.normed_space.operator_norm` is indirectly imported via `data.complex.is_R_or_C`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
