### PR TITLE
[Merged by Bors] - feat(category_theory/triangulated/basic): add definitions of additive category and triangle

### DIFF
--- a/src/category_theory/additive/basic.lean
+++ b/src/category_theory/additive/basic.lean
@@ -3,11 +3,7 @@ Copyright (c) 2021 Luke Kershaw. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Luke Kershaw
 -/
--- import category_theory.limits.constructions.pullbacks
 import category_theory.limits.shapes.biproducts
--- import category_theory.limits.shapes.images
--- import category_theory.abelian.non_preadditive
--- import category_theory.shift
 
 /-!
 # Additive Categories

--- a/src/category_theory/additive/basic.lean
+++ b/src/category_theory/additive/basic.lean
@@ -3,11 +3,11 @@ Copyright (c) 2021 Luke Kershaw. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Luke Kershaw
 -/
-import category_theory.limits.constructions.pullbacks
+-- import category_theory.limits.constructions.pullbacks
 import category_theory.limits.shapes.biproducts
-import category_theory.limits.shapes.images
-import category_theory.abelian.non_preadditive
-import category_theory.shift
+-- import category_theory.limits.shapes.images
+-- import category_theory.abelian.non_preadditive
+-- import category_theory.shift
 
 /-!
 # Additive Categories

--- a/src/category_theory/additive/basic.lean
+++ b/src/category_theory/additive/basic.lean
@@ -26,8 +26,8 @@ universes v v₀ v₁ v₂ u u₀ u₁ u₂
 
 namespace category_theory
 
-variables {C : Type u} [category C]
-variables (C)
+variables (C : Type u) [category C]
+
 
 /--
 A preadditive category `C` is called additive if it has all finite biproducts.

--- a/src/category_theory/additive/basic.lean
+++ b/src/category_theory/additive/basic.lean
@@ -36,4 +36,3 @@ See https://stacks.math.columbia.edu/tag/0104.
 class additive_category extends preadditive C, has_finite_biproducts C
 
 end category_theory
-#lint

--- a/src/category_theory/additive/basic.lean
+++ b/src/category_theory/additive/basic.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2021 Luke Kershaw. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Luke Kershaw
+-/
+import category_theory.limits.constructions.pullbacks
+import category_theory.limits.shapes.biproducts
+import category_theory.limits.shapes.images
+import category_theory.abelian.non_preadditive
+import category_theory.shift
+
+/-!
+# Additive Categories
+
+This file contains the definition of additive categories.
+
+-/
+
+noncomputable theory
+
+open category_theory
+open category_theory.preadditive
+open category_theory.limits
+
+universes v v₀ v₁ v₂ u u₀ u₁ u₂
+
+namespace category_theory
+
+variables {C : Type u} [category C]
+variables (C)
+
+/--
+A preadditive category `C` is called additive if it has all finite biproducts.
+See https://stacks.math.columbia.edu/tag/0104.
+-/
+class additive_category extends preadditive C, has_finite_biproducts C
+
+end category_theory
+#lint

--- a/src/category_theory/additive/basic.lean
+++ b/src/category_theory/additive/basic.lean
@@ -10,6 +10,9 @@ import category_theory.limits.shapes.biproducts
 
 This file contains the definition of additive categories.
 
+TODO: show that finite biproducts implies enriched over commutative monoids and what is missing
+additionally to have additivity is that identities have additive inverses,
+see https://ncatlab.org/nlab/show/biproduct#BiproductsImplyEnrichment
 -/
 
 noncomputable theory

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -96,7 +96,7 @@ def triangle_morphism_id (T : triangle C) : triangle_morphism T T :=
 
 instance (T: triangle C): inhabited (triangle_morphism T T) := ⟨ triangle_morphism_id T ⟩
 
-variables {T₁ T₂ T₃ : triangle C}
+variables {T₁ T₂ T₃ T₄: triangle C}
 /--
 Composition of triangle morphisms gives a triangle morphism.
 -/
@@ -109,5 +109,33 @@ triangle_morphism T₁ T₃ :=
   comm2 := by rw [f.comm2_assoc, g.comm2, assoc],
   comm3 := by rw [functor.map_comp, f.comm3_assoc, g.comm3, assoc], }
 
+namespace triangle_morphism
 
+@[simp]
+lemma id_comp (f: triangle_morphism T₁ T₂) : (triangle_morphism_id T₁).comp f = f :=
+begin
+  unfold comp,
+  unfold triangle_morphism_id,
+  cases f,
+  simp only [eq_self_iff_true, id_comp, and_self],
+end
+
+@[simp]
+lemma comp_id (f: triangle_morphism T₁ T₂) : f.comp (triangle_morphism_id T₂) = f :=
+begin
+  unfold comp,
+  unfold triangle_morphism_id,
+  cases f,
+  simp only [eq_self_iff_true, and_self, comp_id],
+end
+
+@[simp]
+lemma comp_assoc (f: triangle_morphism T₁ T₂) (g: triangle_morphism T₂ T₃)
+(h: triangle_morphism T₃ T₄): (f.comp g).comp h = f.comp (g.comp h) :=
+begin
+  unfold comp,
+  simp only [eq_self_iff_true, assoc, and_self],
+end
+
+end triangle_morphism
 end category_theory.triangulated

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -92,14 +92,15 @@ variable {T₃ : triangle C}
 /--
 Composition of triangle morphisms gives a triangle morphism.
 -/
-def triangle_morphism.comp (f : triangle_morphism T₁ T₂) (g : triangle_morphism T₂ T₃) : triangle_morphism T₁ T₃ :=
+def triangle_morphism.comp (f : triangle_morphism T₁ T₂) (g : triangle_morphism T₂ T₃) :
+triangle_morphism T₁ T₃ :=
 { trimor1 := f.trimor1 ≫ g.trimor1,
   trimor2 := f.trimor2 ≫ g.trimor2,
   trimor3 := f.trimor3 ≫ g.trimor3,
   comm1 := by rw [← category.assoc, f.comm1, category.assoc, g.comm1, category.assoc],
   comm2 := by rw [← category.assoc, f.comm2, category.assoc, g.comm2, category.assoc],
-  comm3 := by rw [functor.map_comp, ← category.assoc, f.comm3, category.assoc, g.comm3, category.assoc], }
+  comm3 := by rw [functor.map_comp, ← category.assoc, f.comm3, category.assoc,
+  g.comm3, category.assoc], }
 
 
 end category_theory.triangulated
-#lint

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -129,7 +129,7 @@ end
 
 @[simp]
 lemma comp_assoc (f: triangle_morphism T₁ T₂) (g: triangle_morphism T₂ T₃)
-(h: triangle_morphism T₃ T₄): (f.comp g).comp h = f.comp (g.comp h) :=
+  (h: triangle_morphism T₃ T₄) : (f.comp g).comp h = f.comp (g.comp h) :=
 begin
   unfold comp,
   simp only [eq_self_iff_true, assoc, and_self],

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -15,6 +15,7 @@ import category_theory.shift
 
 This file contains the definition of triangulated categories.
 
+TODO: generalise this to n-angulated categories as in https://arxiv.org/abs/1006.4592
 -/
 
 noncomputable theory
@@ -26,6 +27,7 @@ open category_theory.limits
 universes v v₀ v₁ v₂ u u₀ u₁ u₂
 
 namespace category_theory.triangulated
+open category_theory.category
 
 /--
 We work in an additive category C equipped with an additive shift.
@@ -47,7 +49,8 @@ structure triangle :=
 (mor3 : obj3 ⟶ obj1⟦1⟧)
 
 local attribute [instance] has_zero_object.has_zero
-instance [has_zero_object C]: inhabited (triangle C) := ⟨{ obj1 := 0,
+instance [has_zero_object C]: inhabited (triangle C) :=
+⟨{ obj1 := 0,
   obj2 := 0,
   obj3 := 0,
   mor1 := 0,
@@ -76,8 +79,11 @@ structure triangle_morphism (T₁ : triangle C) (T₂ : triangle C):=
 (trimor2 : T₁.obj2 ⟶ T₂.obj2)
 (trimor3 : T₁.obj3 ⟶ T₂.obj3)
 (comm1: T₁.mor1 ≫ trimor2 = trimor1 ≫ T₂.mor1)
-(comm2: T₁.mor2 ≫ trimor3 = trimor2 ≫  T₂.mor2)
+(comm2: T₁.mor2 ≫ trimor3 = trimor2 ≫ T₂.mor2)
 (comm3: T₁.mor3 ≫ trimor1⟦1⟧' = trimor3 ≫ T₂.mor3)
+attribute [reassoc] triangle_morphism.comm1
+attribute [reassoc] triangle_morphism.comm2
+attribute [reassoc] triangle_morphism.comm3
 
 /--
 The identity triangle morphism.
@@ -86,8 +92,8 @@ def triangle_morphism_id (T : triangle C) : triangle_morphism T T :=
 { trimor1 := 𝟙 T.obj1,
   trimor2 := 𝟙 T.obj2,
   trimor3 := 𝟙 T.obj3,
-  comm1 := by rw [category.id_comp, category.comp_id],
-  comm2 := by rw [category.id_comp, category.comp_id],
+  comm1 := by rw [id_comp, comp_id],
+  comm2 := by rw [id_comp, comp_id],
   comm3 := by { dsimp, simp } }
 
 instance (T: triangle C): inhabited (triangle_morphism T T) := ⟨ triangle_morphism_id T ⟩
@@ -103,10 +109,9 @@ triangle_morphism T₁ T₃ :=
 { trimor1 := f.trimor1 ≫ g.trimor1,
   trimor2 := f.trimor2 ≫ g.trimor2,
   trimor3 := f.trimor3 ≫ g.trimor3,
-  comm1 := by rw [← category.assoc, f.comm1, category.assoc, g.comm1, category.assoc],
-  comm2 := by rw [← category.assoc, f.comm2, category.assoc, g.comm2, category.assoc],
-  comm3 := by rw [functor.map_comp, ← category.assoc, f.comm3, category.assoc,
-  g.comm3, category.assoc], }
+  comm1 := by rw [f.comm1_assoc, g.comm1, assoc],
+  comm2 := by rw [f.comm2_assoc, g.comm2, assoc],
+  comm3 := by rw [functor.map_comp, f.comm3_assoc, g.comm3, assoc], }
 
 
 end category_theory.triangulated

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -49,13 +49,13 @@ structure triangle :=
 (mor3 : obj3 ⟶ obj1⟦1⟧)
 
 local attribute [instance] has_zero_object.has_zero
-instance [has_zero_object C]: inhabited (triangle C) :=
+instance [has_zero_object C] : inhabited (triangle C) :=
 ⟨{ obj1 := 0,
   obj2 := 0,
   obj3 := 0,
   mor1 := 0,
   mor2 := 0,
-  mor3 := 0 } ⟩
+  mor3 := 0 }⟩
 
 variable {C}
 
@@ -81,9 +81,7 @@ structure triangle_morphism (T₁ : triangle C) (T₂ : triangle C):=
 (comm1: T₁.mor1 ≫ trimor2 = trimor1 ≫ T₂.mor1)
 (comm2: T₁.mor2 ≫ trimor3 = trimor2 ≫ T₂.mor2)
 (comm3: T₁.mor3 ≫ trimor1⟦1⟧' = trimor3 ≫ T₂.mor3)
-attribute [reassoc] triangle_morphism.comm1
-attribute [reassoc] triangle_morphism.comm2
-attribute [reassoc] triangle_morphism.comm3
+attribute [reassoc] triangle_morphism.comm1 triangle_morphism.comm2 triangle_morphism.comm3
 
 /--
 The identity triangle morphism.
@@ -98,9 +96,7 @@ def triangle_morphism_id (T : triangle C) : triangle_morphism T T :=
 
 instance (T: triangle C): inhabited (triangle_morphism T T) := ⟨ triangle_morphism_id T ⟩
 
-variable {T₁ : triangle C}
-variable {T₂ : triangle C}
-variable {T₃ : triangle C}
+variables {T₁ T₂ T₃ : triangle C}
 /--
 Composition of triangle morphisms gives a triangle morphism.
 -/

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -30,8 +30,7 @@ namespace category_theory.triangulated
 /--
 We work in an additive category C equipped with an additive shift.
 -/
-variables {C : Type u} [category.{v} C] [has_shift C] [additive_category C]
-variables (C)
+variables (C : Type u) [category.{v} C] [has_shift C] [additive_category C]
 
 
 /--
@@ -39,7 +38,6 @@ A triangle in C is a sextuple (X,Y,Z,f,g,h) where X,Y,Z are objects of C,
 and f: X → Y, g: Y → Z, h: Z → ΣX are morphisms in C.
 See https://stacks.math.columbia.edu/tag/0144.
 -/
-@[nolint has_inhabited_instance]
 structure triangle :=
 (obj1 : C)
 (obj2 : C)
@@ -47,6 +45,14 @@ structure triangle :=
 (mor1 : obj1 ⟶ obj2)
 (mor2 : obj2 ⟶ obj3)
 (mor3 : obj3 ⟶ obj1⟦1⟧)
+
+local attribute [instance] has_zero_object.has_zero
+instance [has_zero_object C]: inhabited (triangle C) := ⟨{ obj1 := 0,
+  obj2 := 0,
+  obj3 := 0,
+  mor1 := 0,
+  mor2 := 0,
+  mor3 := 0 } ⟩
 
 variable {C}
 
@@ -65,7 +71,6 @@ In other words, we have a commutative diagram:
 
 See https://stacks.math.columbia.edu/tag/0144.
 -/
-@[nolint has_inhabited_instance]
 structure triangle_morphism (T₁ : triangle C) (T₂ : triangle C):=
 (trimor1 : T₁.obj1 ⟶ T₂.obj1)
 (trimor2 : T₁.obj2 ⟶ T₂.obj2)
@@ -85,6 +90,7 @@ def triangle_morphism_id (T : triangle C) : triangle_morphism T T :=
   comm2 := by rw [category.id_comp, category.comp_id],
   comm3 := by { dsimp, simp } }
 
+instance (T: triangle C): inhabited (triangle_morphism T T) := ⟨ triangle_morphism_id T ⟩
 
 variable {T₁ : triangle C}
 variable {T₂ : triangle C}

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2021 Luke Kershaw. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Luke Kershaw
+-/
+import category_theory.limits.constructions.pullbacks
+import category_theory.limits.shapes.biproducts
+import category_theory.limits.shapes.images
+import category_theory.abelian.non_preadditive
+import category_theory.additive.basic
+import category_theory.shift
+
+/-!
+# Triangulated Categories
+
+This file contains the definition of triangulated categories.
+
+-/
+
+noncomputable theory
+
+open category_theory
+open category_theory.preadditive
+open category_theory.limits
+
+universes v v₀ v₁ v₂ u u₀ u₁ u₂
+
+namespace category_theory.triangulated
+
+/--
+We work in an additive category C equipped with an additive shift.
+-/
+variables {C : Type u} [category.{v} C] [has_shift C] [additive_category C]
+variables (C)
+
+
+/--
+A triangle in C is a sextuple (X,Y,Z,f,g,h) where X,Y,Z are objects of C,
+and f: X → Y, g: Y → Z, h: Z → ΣX are morphisms in C.
+See https://stacks.math.columbia.edu/tag/0144.
+-/
+@[nolint has_inhabited_instance]
+structure triangle :=
+(obj1 : C)
+(obj2 : C)
+(obj3 : C)
+(mor1 : obj1 ⟶ obj2)
+(mor2 : obj2 ⟶ obj3)
+(mor3 : obj3 ⟶ obj1⟦1⟧)
+
+variable {C}
+
+/--
+A morphism of triangles (X,Y,Z,f,g,h)→(X',Y',Z',f',g',h') in C is a triple of morphisms
+a: X → X', b: Y → Y', c: Z → Z' such that b ≫ f = f' ≫ a, c ≫ g = g' ≫ b,
+and Σa ≫ h = h' ≫ c.
+In other words, we have a commutative diagram:
+     f      g      h
+  X  --> Y  --> Z  --> ΣX
+  |      |      |       |
+  |a     |b     |c      |Σa
+  V      V      V       V
+  X' --> Y' --> Z' --> ΣX'
+     f'     g'     h'
+
+See https://stacks.math.columbia.edu/tag/0144.
+-/
+@[nolint has_inhabited_instance]
+structure triangle_morphism (T₁ : triangle C) (T₂ : triangle C):=
+(trimor1 : T₁.obj1 ⟶ T₂.obj1)
+(trimor2 : T₁.obj2 ⟶ T₂.obj2)
+(trimor3 : T₁.obj3 ⟶ T₂.obj3)
+(comm1: T₁.mor1 ≫ trimor2 = trimor1 ≫ T₂.mor1)
+(comm2: T₁.mor2 ≫ trimor3 = trimor2 ≫  T₂.mor2)
+(comm3: T₁.mor3 ≫ trimor1⟦1⟧' = trimor3 ≫ T₂.mor3)
+
+/--
+The identity triangle morphism.
+-/
+def triangle_morphism_id (T : triangle C) : triangle_morphism T T :=
+{ trimor1 := 𝟙 T.obj1,
+  trimor2 := 𝟙 T.obj2,
+  trimor3 := 𝟙 T.obj3,
+  comm1 := by rw [category.id_comp, category.comp_id],
+  comm2 := by rw [category.id_comp, category.comp_id],
+  comm3 := by { dsimp, simp } }
+
+
+variable {T₁ : triangle C}
+variable {T₂ : triangle C}
+variable {T₃ : triangle C}
+/--
+Composition of triangle morphisms gives a triangle morphism.
+-/
+def triangle_morphism.comp (f : triangle_morphism T₁ T₂) (g : triangle_morphism T₂ T₃) : triangle_morphism T₁ T₃ :=
+{ trimor1 := f.trimor1 ≫ g.trimor1,
+  trimor2 := f.trimor2 ≫ g.trimor2,
+  trimor3 := f.trimor3 ≫ g.trimor3,
+  comm1 := by rw [← category.assoc, f.comm1, category.assoc, g.comm1, category.assoc],
+  comm2 := by rw [← category.assoc, f.comm2, category.assoc, g.comm2, category.assoc],
+  comm3 := by rw [functor.map_comp, ← category.assoc, f.comm3, category.assoc, g.comm3, category.assoc], }
+
+
+end category_theory.triangulated
+#lint

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -3,12 +3,9 @@ Copyright (c) 2021 Luke Kershaw. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Luke Kershaw
 -/
-import category_theory.limits.constructions.pullbacks
-import category_theory.limits.shapes.biproducts
-import category_theory.limits.shapes.images
-import category_theory.abelian.non_preadditive
 import category_theory.additive.basic
 import category_theory.shift
+import category_theory.abelian.additive_functor
 
 /-!
 # Triangulated Categories
@@ -33,6 +30,7 @@ open category_theory.category
 We work in an additive category C equipped with an additive shift.
 -/
 variables (C : Type u) [category.{v} C] [has_shift C] [additive_category C]
+[functor.additive (shift C).functor]
 
 
 /--


### PR DESCRIPTION
This PR adds the definition of an additive category and the definition of a triangle in an additive category with an additive shift.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
