### PR TITLE
[Merged by Bors] - feat(ring_theory/hahn_series): algebra structure, equivalences with power series

### DIFF
--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -44,6 +44,17 @@ lemma C_eq_algebra_map {R : Type*} [comm_ring R] (r : R) :
   C r = algebra_map R (polynomial R) r :=
 rfl
 
+instance [nontrivial A] : nontrivial (subalgebra R (polynomial A)) :=
+⟨⟨⊥, ⊤, begin
+  rw [ne.def, subalgebra.ext_iff, not_forall],
+  refine ⟨X, _⟩,
+  simp only [algebra.mem_bot, not_exists, set.mem_range, iff_true, algebra.mem_top,
+    algebra_map_apply, not_forall],
+  intro x,
+  rw [ext_iff, not_forall],
+  refine ⟨1, _⟩,
+  simp [coeff_C],
+end⟩⟩
 
 @[simp]
 lemma alg_hom_eval₂_algebra_map

--- a/src/order/well_founded_set.lean
+++ b/src/order/well_founded_set.lean
@@ -66,6 +66,9 @@ variables [has_lt α]
 /-- `s.is_wf` indicates that `<` is well-founded when restricted to `s`. -/
 def is_wf (s : set α) : Prop := well_founded_on s (<)
 
+lemma is_wf_univ_iff : is_wf (univ : set α) ↔ well_founded ((<) : α → α → Prop) :=
+by simp [is_wf, well_founded_on_iff]
+
 variables {s t : set α}
 
 theorem is_wf.mono (h : is_wf t) (st : s ⊆ t) : is_wf s :=
@@ -453,3 +456,7 @@ theorem is_wf_support_mul_antidiagonal :
 (hs.mul ht).mono support_mul_antidiagonal_subset_mul
 
 end finset
+
+lemma well_founded.is_wf [has_lt α] (h : well_founded ((<) : α → α → Prop)) (s : set α) :
+  s.is_wf :=
+(set.is_wf_univ_iff.2 h).mono (set.subset_univ s)

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -163,29 +163,23 @@ instance : distrib_mul_action R (hahn_series Γ V) :=
   smul_add := λ _ _ _, by { ext, simp [smul_add] },
   mul_smul := λ _ _ _, by { ext, simp [mul_smul] } }
 
+variables {S : Type*} [monoid S] [distrib_mul_action S V]
+
+instance [has_scalar R S] [is_scalar_tower R S V] :
+  is_scalar_tower R S (hahn_series Γ V) :=
+⟨λ r s a, by { ext, simp }⟩
+
+instance [smul_comm_class R S V] :
+  smul_comm_class R S (hahn_series Γ V) :=
+⟨λ r s a, by { ext, simp [smul_comm] }⟩
+
 end distrib_mul_action
 
-section scalar
-
-variables [linear_order Γ] [semiring R] {V : Type*} [add_comm_monoid V] [semimodule R V]
-
-instance :
+instance [linear_order Γ] [semiring R] {V : Type*} [add_comm_monoid V] [semimodule R V] :
   semimodule R (hahn_series Γ V) :=
 { zero_smul := λ _, by { ext, simp },
   add_smul := λ _ _ _, by { ext, simp [add_smul] },
   .. hahn_series.distrib_mul_action }
-
-variables {S : Type*} [semiring S] [semimodule S V]
-
-instance [semimodule R S] [is_scalar_tower R S V] :
-  is_scalar_tower R S (hahn_series Γ V) :=
-⟨λ r s a, by { ext, simp }⟩
-
-instance [semimodule R V] [smul_comm_class R S V] :
-  smul_comm_class R S (hahn_series Γ V) :=
-⟨λ r s a, by { ext, simp [smul_comm] }⟩
-
-end scalar
 
 section multiplication
 

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -505,6 +505,19 @@ theorem C_eq_algebra_map : C = (algebra_map R (hahn_series Γ R)) := rfl
 theorem algebra_map_apply {r : R} :
   algebra_map R (hahn_series Γ A) r = C (algebra_map R A r) := rfl
 
+instance [nontrivial Γ] [nontrivial R] : nontrivial (subalgebra R (hahn_series Γ R)) :=
+⟨⟨⊥, ⊤, begin
+  rw [ne.def, subalgebra.ext_iff, not_forall],
+  obtain ⟨a, ha⟩ := exists_ne (0 : Γ),
+  refine ⟨single a 1, _⟩,
+  simp only [algebra.mem_bot, not_exists, set.mem_range, iff_true, algebra.mem_top],
+  intros x,
+  rw [ext_iff, function.funext_iff, not_forall],
+  refine ⟨a, _⟩,
+  rw [single_coeff_same, algebra_map_apply, C_apply, single_coeff_of_ne ha],
+  exact zero_ne_one
+end⟩⟩
+
 end algebra
 
 end multiplication

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -6,6 +6,7 @@ Authors: Aaron Anderson
 import order.well_founded_set
 import algebra.big_operators
 import algebra.module.pi
+import ring_theory.power_series.basic
 
 /-!
 # Hahn Series
@@ -391,5 +392,32 @@ noncomputable instance [comm_ring R] : comm_ring (hahn_series Γ R) :=
   .. hahn_series.ring }
 
 end multiplication
+
+
+section power_series
+variables [comm_semiring R]
+
+noncomputable def to_power_series : (hahn_series ℕ R) ≃+* power_series R :=
+{ to_fun := λ f, power_series.mk f.coeff,
+  inv_fun := λ f, ⟨λ n, power_series.coeff R n f, nat.lt_wf.is_wf _⟩,
+  left_inv := λ f, by { ext, simp },
+  right_inv := λ f, by { ext, simp },
+  map_add' := λ f g, by { ext, simp },
+  map_mul' := λ f g, begin
+    ext n,
+    simp only [power_series.coeff_mul, power_series.coeff_mk, mul_coeff, is_wf_support],
+    classical,
+    refine finset.sum_filter_ne_zero.symm.trans
+      ((finset.sum_congr _ (λ _ _, rfl)).trans finset.sum_filter_ne_zero),
+    ext m,
+    simp only [finset.nat.mem_antidiagonal, and.congr_left_iff, finset.mem_add_antidiagonal, ne.def,
+      and_iff_left_iff_imp, finset.mem_filter, mem_support],
+    intros h1 h2,
+    contrapose h1,
+    rw ← decidable.or_iff_not_and_not at h1,
+    cases h1; simp [h1]
+  end }
+
+end power_series
 
 end hahn_series

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -189,11 +189,23 @@ instance [smul_comm_class R S V] :
 
 end distrib_mul_action
 
-instance [linear_order Γ] [semiring R] {V : Type*} [add_comm_monoid V] [semimodule R V] :
-  semimodule R (hahn_series Γ V) :=
+section semimodule
+variables [linear_order Γ] [semiring R] {V : Type*} [add_comm_monoid V] [semimodule R V]
+
+instance : semimodule R (hahn_series Γ V) :=
 { zero_smul := λ _, by { ext, simp },
   add_smul := λ _ _ _, by { ext, simp [add_smul] },
   .. hahn_series.distrib_mul_action }
+
+/-- `single` as a linear map -/
+def single.linear_map (a : Γ) : R →ₗ[R] (hahn_series Γ R) :=
+{ map_smul' := λ r s, by { ext b, by_cases h : b = a; simp [h] },
+  ..single.add_monoid_hom a }
+
+@[simp]
+lemma single.linear_map_apply {a : Γ} {r : R} : single.linear_map a r = single a r := rfl
+
+end semimodule
 
 section multiplication
 

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -19,7 +19,7 @@ import ring_theory.power_series.basic
 
 ## TODO
   * Given `[linear_ordered_add_comm_group Γ]` and `[field R]`, define `field (hahn_series Γ R)`.
-  * Build an API for the constant map `C` and the variable `X`
+  * Build an API for the variable `X`
   * Define Laurent series
 
 -/
@@ -165,11 +165,27 @@ instance : distrib_mul_action R (hahn_series Γ V) :=
 
 end distrib_mul_action
 
-instance [linear_order Γ] {V : Type*} [semiring R] [add_comm_monoid V] [semimodule R V] :
+section scalar
+
+variables [linear_order Γ] [semiring R] {V : Type*} [add_comm_monoid V] [semimodule R V]
+
+instance :
   semimodule R (hahn_series Γ V) :=
 { zero_smul := λ _, by { ext, simp },
   add_smul := λ _ _ _, by { ext, simp [add_smul] },
   .. hahn_series.distrib_mul_action }
+
+variables {S : Type*} [semiring S] [semimodule S V]
+
+instance [semimodule R S] [is_scalar_tower R S V] :
+  is_scalar_tower R S (hahn_series Γ V) :=
+⟨λ r s a, by { ext, simp }⟩
+
+instance [semimodule R V] [smul_comm_class R S V] :
+  smul_comm_class R S (hahn_series Γ V) :=
+⟨λ r s a, by { ext, simp [smul_comm] }⟩
+
+end scalar
 
 section multiplication
 
@@ -455,7 +471,7 @@ single_zero_mul_eq_smul
 end semiring
 
 section algebra
-variables [comm_ring R] {A : Type*} [semiring A] [algebra R A]
+variables [comm_semiring R] {A : Type*} [semiring A] [algebra R A]
 
 instance : algebra R (hahn_series Γ A) :=
 { to_ring_hom := C.comp (algebra_map R A),
@@ -464,10 +480,10 @@ instance : algebra R (hahn_series Γ A) :=
     ring_hom.to_fun_eq_coe, C_apply, function.comp_app, algebra_map_smul, mul_single_zero_coeff],
     rw [← algebra.commutes, algebra.smul_def], }, }
 
-theorem C_eq_algebra_map {r : R} : C r = (algebra_map R (hahn_series Γ R)) r := rfl
+theorem C_eq_algebra_map : C = (algebra_map R (hahn_series Γ R)) := rfl
 
 theorem algebra_map_apply {r : R} :
-  algebra_map R (hahn_series Γ R) r = C r := rfl
+  algebra_map R (hahn_series Γ A) r = C (algebra_map R A r) := rfl
 
 end algebra
 
@@ -510,30 +526,31 @@ rfl
 
 end semiring
 
-section comm_ring
-variables [comm_ring R]
+section algebra
+variables (R) [comm_semiring R] {A : Type*} [semiring A] [algebra R A]
 
-/-- The `R`-algebra `hahn_series ℕ R` is isomorphic to `power_series R`. -/
-def to_power_series_alg : (hahn_series ℕ R) ≃ₐ[R] power_series R :=
+/-- The `R`-algebra `hahn_series ℕ A` is isomorphic to `power_series A`. -/
+def to_power_series_alg : (hahn_series ℕ A) ≃ₐ[R] power_series A :=
 { commutes' := λ r, begin
     ext n,
-    simp only [algebra_map_apply, ring_equiv.to_fun_eq_coe, C_apply, coeff_to_power_series],
+    simp only [algebra_map_apply, power_series.algebra_map_apply, ring_equiv.to_fun_eq_coe, C_apply,
+      coeff_to_power_series],
     cases n,
     { simp only [power_series.coeff_zero_eq_constant_coeff, single_coeff_same],
       refl },
     { simp only [n.succ_ne_zero, ne.def, not_false_iff, single_coeff_of_ne],
-      exact ((power_series.coeff_C n.succ _).trans (if_neg n.succ_ne_zero)).symm }
-end,
+      rw [power_series.coeff_C, if_neg n.succ_ne_zero] }
+  end,
   .. to_power_series }
 
 @[simp]
-lemma to_power_series_alg_apply {f : hahn_series ℕ R} :
-  f.to_power_series_alg = f.to_power_series := rfl
+lemma to_power_series_alg_apply {f : hahn_series ℕ A} :
+  hahn_series.to_power_series_alg R f = f.to_power_series := rfl
 
 @[simp]
-lemma to_power_series_alg_symm_apply {f : power_series R} :
-  hahn_series.to_power_series_alg.symm f = hahn_series.to_power_series.symm f := rfl
+lemma to_power_series_alg_symm_apply {f : power_series A} :
+  (hahn_series.to_power_series_alg R).symm f = hahn_series.to_power_series.symm f := rfl
 
-end comm_ring
+end algebra
 
 end hahn_series

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -322,7 +322,6 @@ lemma mul_single_zero_coeff [semiring R] {r : R} {x : hahn_series Γ R} {a : Γ}
   (x * (single 0 r)).coeff a = x.coeff a * r  :=
 by rw [← add_zero a, mul_single_coeff_add, add_zero]
 
-@[simp]
 lemma single_zero_mul_coeff [semiring R] {r : R} {x : hahn_series Γ R} {a : Γ} :
   ((single 0 r) * x).coeff a = r * x.coeff a :=
 by rw [← add_zero a, single_mul_coeff_add, add_zero]
@@ -330,7 +329,7 @@ by rw [← add_zero a, single_mul_coeff_add, add_zero]
 @[simp]
 lemma single_zero_mul_eq_smul [semiring R] {r : R} {x : hahn_series Γ R} :
   (single 0 r) * x = r • x :=
-by { ext, simp }
+by { ext, exact single_zero_mul_coeff }
 
 theorem support_mul_subset_add_support [semiring R] {x y : hahn_series Γ R} :
   support (x * y) ⊆ support x + support y :=
@@ -419,7 +418,7 @@ section semiring
 variables [semiring R]
 
 @[simp]
-lemma single_mul_single [semiring R] {a b : Γ} {r s : R} :
+lemma single_mul_single {a b : Γ} {r s : R} :
   single a r * single b s = single (a + b) (r * s) :=
 begin
   ext x,
@@ -450,7 +449,6 @@ lemma C_zero : C (0 : R) = (0 : hahn_series Γ R) := C.map_zero
 @[simp]
 lemma C_one : C (1 : R) = (1 : hahn_series Γ R) := C.map_one
 
-@[simp]
 lemma C_mul_eq_smul {r : R} {x : hahn_series Γ R} : C r * x = r • x :=
 single_zero_mul_eq_smul
 

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -505,6 +505,9 @@ theorem C_eq_algebra_map : C = (algebra_map R (hahn_series Γ R)) := rfl
 theorem algebra_map_apply {r : R} :
   algebra_map R (hahn_series Γ A) r = C (algebra_map R A r) := rfl
 
+lemma subalgebra : nontrivial (subalgebra R (hahn_series Γ R)) := sorry
+
+
 end algebra
 
 end multiplication

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -505,9 +505,6 @@ theorem C_eq_algebra_map : C = (algebra_map R (hahn_series Γ R)) := rfl
 theorem algebra_map_apply {r : R} :
   algebra_map R (hahn_series Γ A) r = C (algebra_map R A r) := rfl
 
-lemma subalgebra : nontrivial (subalgebra R (hahn_series Γ R)) := sorry
-
-
 end algebra
 
 end multiplication

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -448,7 +448,7 @@ instance : algebra R (mv_power_series σ A) :=
   to_ring_hom := (mv_power_series.map σ (algebra_map R A)).comp (C σ R),
   .. mv_power_series.semimodule }
 
-theorem C_eq_algebra_map {r : R} : C σ R r = (algebra_map R (mv_power_series σ R)) r := rfl
+theorem C_eq_algebra_map : C σ R = (algebra_map R (mv_power_series σ R)) := rfl
 
 theorem algebra_map_apply {r : R} :
   algebra_map R (mv_power_series σ A) r = C σ A (algebra_map R A r) :=

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -457,6 +457,18 @@ begin
   simp,
 end
 
+instance [nonempty σ] [nontrivial R] : nontrivial (subalgebra R (mv_power_series σ R)) :=
+⟨⟨⊥, ⊤, begin
+  rw [ne.def, subalgebra.ext_iff, not_forall],
+  inhabit σ,
+  refine ⟨X (default σ), _⟩,
+  simp only [algebra.mem_bot, not_exists, set.mem_range, iff_true, algebra.mem_top],
+  intros x,
+  rw [ext_iff, not_forall],
+  refine ⟨finsupp.single (default σ) 1, _⟩,
+  simp [algebra_map_apply, coeff_C],
+end⟩⟩
+
 end algebra
 
 section trunc
@@ -1342,6 +1354,9 @@ theorem C_eq_algebra_map {r : R} : C R r = (algebra_map R (power_series R)) r :=
 theorem algebra_map_apply {r : R} :
   algebra_map R (power_series A) r = C A (algebra_map R A r) :=
 mv_power_series.algebra_map_apply
+
+instance [nontrivial R] : nontrivial (subalgebra R (power_series R)) :=
+mv_power_series.subalgebra.nontrivial
 
 end algebra
 

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -439,11 +439,25 @@ map_monomial _ _ _
 
 end map
 
-instance {A} [comm_semiring R] [semiring A] [algebra R A] : algebra R (mv_power_series σ A) :=
+section algebra
+variables {A : Type*} [comm_semiring R] [semiring A] [algebra R A]
+
+instance : algebra R (mv_power_series σ A) :=
 { commutes' := λ a φ, by { ext n, simp [algebra.commutes] },
   smul_def' := λ a σ, by { ext n, simp [(coeff A n).map_smul_of_tower a, algebra.smul_def] },
   to_ring_hom := (mv_power_series.map σ (algebra_map R A)).comp (C σ R),
   .. mv_power_series.semimodule }
+
+theorem C_eq_algebra_map {r : R} : C σ R r = (algebra_map R (mv_power_series σ R)) r := rfl
+
+theorem algebra_map_apply {r : R} :
+  algebra_map R (mv_power_series σ A) r = C σ A (algebra_map R A r) :=
+begin
+  change (mv_power_series.map σ (algebra_map R A)).comp (C σ R) r = _,
+  simp,
+end
+
+end algebra
 
 section trunc
 variables [comm_semiring R] (n : σ →₀ ℕ)
@@ -1319,6 +1333,17 @@ instance : local_ring (power_series R) :=
 mv_power_series.local_ring
 
 end local_ring
+
+section algebra
+variables {A : Type*} [comm_semiring R] [semiring A] [algebra R A]
+
+theorem C_eq_algebra_map {r : R} : C R r = (algebra_map R (power_series R)) r := rfl
+
+theorem algebra_map_apply {r : R} :
+  algebra_map R (power_series A) r = C A (algebra_map R A r) :=
+mv_power_series.algebra_map_apply
+
+end algebra
 
 section field
 variables {k : Type*} [field k]


### PR DESCRIPTION
Places an `algebra` structure on `hahn_series`
Defines a `ring_equiv` and when relevant an `alg_equiv` between `hahn_series nat R` and `power_series R`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
