### PR TITLE
[Merged by Bors] - fix(*): remove some simp lemmas

### DIFF
--- a/src/data/bool.lean
+++ b/src/data/bool.lean
@@ -22,15 +22,15 @@ prefix `!`:90 := bnot
 
 namespace bool
 
-@[simp] theorem coe_sort_tt : coe_sort.{1 1} tt = true := eq_true_intro rfl
+theorem coe_sort_tt : coe_sort.{1 1} tt = true := coe_sort_tt
 
-@[simp] theorem coe_sort_ff : coe_sort.{1 1} ff = false := eq_false_intro ff_ne_tt
+theorem coe_sort_ff : coe_sort.{1 1} ff = false := coe_sort_ff
 
-@[simp] theorem to_bool_true {h} : @to_bool true h = tt :=
-show _ = to_bool true, by congr
+theorem to_bool_true {h} : @to_bool true h = tt :=
+to_bool_true_eq_tt h
 
-@[simp] theorem to_bool_false {h} : @to_bool false h = ff :=
-show _ = to_bool false, by congr
+theorem to_bool_false {h} : @to_bool false h = ff :=
+to_bool_false_eq_ff h
 
 @[simp] theorem to_bool_coe (b:bool) {h} : @to_bool b h = b :=
 (show _ = to_bool b, by congr).trans (by cases b; refl)

--- a/src/data/bool.lean
+++ b/src/data/bool.lean
@@ -22,13 +22,17 @@ prefix `!`:90 := bnot
 
 namespace bool
 
+-- TODO: duplicate of a lemma in core
 theorem coe_sort_tt : coe_sort.{1 1} tt = true := coe_sort_tt
 
+-- TODO: duplicate of a lemma in core
 theorem coe_sort_ff : coe_sort.{1 1} ff = false := coe_sort_ff
 
+-- TODO: duplicate of a lemma in core
 theorem to_bool_true {h} : @to_bool true h = tt :=
 to_bool_true_eq_tt h
 
+-- TODO: duplicate of a lemma in core
 theorem to_bool_false {h} : @to_bool false h = ff :=
 to_bool_false_eq_ff h
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -508,7 +508,7 @@ function.left_inverse.injective (length_repeat a)
 @[simp] theorem bind_eq_bind {α β} (f : α → list β) (l : list α) :
   l >>= f = l.bind f := rfl
 
-@[simp] theorem bind_append (f : α → list β) (l₁ l₂ : list α) :
+theorem bind_append (f : α → list β) (l₁ l₂ : list α) :
   (l₁ ++ l₂).bind f = l₁.bind f ++ l₂.bind f :=
 append_bind _ _ _
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -508,6 +508,7 @@ function.left_inverse.injective (length_repeat a)
 @[simp] theorem bind_eq_bind {α β} (f : α → list β) (l : list α) :
   l >>= f = l.bind f := rfl
 
+-- TODO: duplicate of a lemma in core
 theorem bind_append (f : α → list β) (l₁ l₂ : list α) :
   (l₁ ++ l₂).bind f = l₁.bind f ++ l₂.bind f :=
 append_bind _ _ _

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -784,6 +784,7 @@ by simp [decidable.not_not]
 
 @[simp] theorem not_exists_not : (¬ ∃ x, ¬ p x) ↔ ∀ x, p x := decidable.not_exists_not
 
+-- TODO: duplicate of a lemma in core
 theorem forall_true_iff : (α → true) ↔ true :=
 implies_true_iff α
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -784,8 +784,8 @@ by simp [decidable.not_not]
 
 @[simp] theorem not_exists_not : (¬ ∃ x, ¬ p x) ↔ ∀ x, p x := decidable.not_exists_not
 
-@[simp] theorem forall_true_iff : (α → true) ↔ true :=
-iff_true_intro (λ _, trivial)
+theorem forall_true_iff : (α → true) ↔ true :=
+implies_true_iff α
 
 -- Unfortunately this causes simp to loop sometimes, so we
 -- add the 2 and 3 cases as simp lemmas instead


### PR DESCRIPTION
All of these simp lemmas are also declared in core. 
Maybe one of the copies can be removed in a future PR, but this PR is just to remove the duplicate simp attributes.

This is part of fixing linting problems in core, done in leanprover-community/lean#545. 
Most of the duplicate simp lemmas are fixed in `core`, but I prefer to remove the simp attribute here in mathlib if the simp lemmas were already used in core.