### PR TITLE
[Merged by Bors] - refactor(geometry/manifold): drop some unused arguments

### DIFF
--- a/src/geometry/manifold/algebra/lie_group.lean
+++ b/src/geometry/manifold/algebra/lie_group.lean
@@ -22,11 +22,9 @@ groups here are not necessarily finite dimensional.
 * `lie_add_group I G` : a Lie additive group where `G` is a manifold on the model with corners `I`.
 * `lie_group I G`     : a Lie multiplicative group where `G` is a manifold on the model with
                         corners `I`.
-* `lie_add_group_morphism I I' G G'`  : morphism of addittive Lie groups
-* `lie_group_morphism I I' G G'`      : morphism of Lie groups
+* `normed_space_lie_group` : a normed vector space over a nondiscrete normed field is a Lie group
 
 ## Implementation notes
-A priori, a Lie group here is a manifold with corners.
 
 The definition of Lie group cannot require `I : model_with_corners 𝕜 E E` with the same space as the
 model space and as the model vector space, as one might hope, beause in the product situation,

--- a/src/geometry/manifold/algebra/lie_group.lean
+++ b/src/geometry/manifold/algebra/lie_group.lean
@@ -130,7 +130,7 @@ section normed_space_lie_group
 
 /-! ### Normed spaces are Lie groups -/
 
-instance normed_space_lie_group {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
+instance normed_space_lie_add_group {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {E : Type*} [normed_group E] [normed_space 𝕜 E] :
   lie_add_group (model_with_corners_self 𝕜 E) E :=
 { smooth_add := smooth_iff.2 ⟨continuous_add, λ x y, times_cont_diff_add.times_cont_diff_on⟩,

--- a/src/geometry/manifold/algebra/lie_group.lean
+++ b/src/geometry/manifold/algebra/lie_group.lean
@@ -22,7 +22,8 @@ groups here are not necessarily finite dimensional.
 * `lie_add_group I G` : a Lie additive group where `G` is a manifold on the model with corners `I`.
 * `lie_group I G`     : a Lie multiplicative group where `G` is a manifold on the model with
                         corners `I`.
-* `normed_space_lie_group` : a normed vector space over a nondiscrete normed field is a Lie group
+* `normed_space_lie_add_group` : a normed vector space over a nondiscrete normed field
+                                 is an additive Lie group.
 
 ## Implementation notes
 
@@ -126,8 +127,6 @@ instance {𝕜 : Type*} [nondiscrete_normed_field 𝕜] {H : Type*} [topological
 
 end prod_lie_group
 
-section normed_space_lie_group
-
 /-! ### Normed spaces are Lie groups -/
 
 instance normed_space_lie_add_group {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
@@ -135,5 +134,3 @@ instance normed_space_lie_add_group {𝕜 : Type*} [nondiscrete_normed_field �
   lie_add_group (model_with_corners_self 𝕜 E) E :=
 { smooth_add := smooth_iff.2 ⟨continuous_add, λ x y, times_cont_diff_add.times_cont_diff_on⟩,
   smooth_neg := smooth_iff.2 ⟨continuous_neg, λ x y, times_cont_diff_neg.times_cont_diff_on⟩ }
-
-end normed_space_lie_group

--- a/src/geometry/manifold/algebra/lie_group.lean
+++ b/src/geometry/manifold/algebra/lie_group.lean
@@ -53,7 +53,7 @@ the addition and negation operations are smooth. -/
 class lie_add_group {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
   {E : Type*} [normed_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
-  (G : Type*) [add_group G] [topological_space G] [topological_add_group G] [charted_space H G]
+  (G : Type*) [add_group G] [topological_space G] [charted_space H G]
   extends has_smooth_add I G : Prop :=
 (smooth_neg : smooth I I (λ a:G, -a))
 
@@ -63,7 +63,7 @@ the multiplication and inverse operations are smooth. -/
 class lie_group {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
   {E : Type*} [normed_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
-  (G : Type*) [group G] [topological_space G] [topological_group G] [charted_space H G]
+  (G : Type*) [group G] [topological_space G] [charted_space H G]
   extends has_smooth_mul I G : Prop :=
 (smooth_inv : smooth I I (λ a:G, a⁻¹))
 
@@ -75,14 +75,13 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {H : Type*} [topological_space H]
 {E : Type*} [normed_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
 {F : Type*} [normed_group F] [normed_space 𝕜 F] {J : model_with_corners 𝕜 F F}
-{G : Type*} [topological_space G] [charted_space H G] [group G]
-[topological_group G] [lie_group I G]
+{G : Type*} [topological_space G] [charted_space H G] [group G] [lie_group I G]
 {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
-{M : Type*} [topological_space M] [charted_space H' M] [smooth_manifold_with_corners I' M]
+{M : Type*} [topological_space M] [charted_space H' M]
 {E'' : Type*} [normed_group E''] [normed_space 𝕜 E'']
 {H'' : Type*} [topological_space H''] {I'' : model_with_corners 𝕜 E'' H''}
-{M' : Type*} [topological_space M'] [charted_space H'' M'] [smooth_manifold_with_corners I'' M']
+{M' : Type*} [topological_space M'] [charted_space H'' M']
 
 localized "notation `L_add` := left_add" in lie_group
 
@@ -92,23 +91,30 @@ localized "notation `L` := left_mul" in lie_group
 
 localized "notation `R` := right_mul" in lie_group
 
-lemma smooth_pow : ∀ n : ℕ, smooth I I (λ a : G, a ^ n)
-| 0 := by { simp only [pow_zero], exact smooth_const }
-| (k+1) := show smooth I I (λ (a : G), a * a ^ k), from smooth_id.mul (smooth_pow _)
+section
+
+variable (I)
 
 @[to_additive]
 lemma smooth_inv : smooth I I (λ x : G, x⁻¹) :=
 lie_group.smooth_inv
 
 @[to_additive]
+lemma topological_group_of_lie_group : topological_group G :=
+{ continuous_inv := (smooth_inv I).continuous,
+  .. has_continuous_mul_of_smooth I }
+
+end
+
+@[to_additive]
 lemma smooth.inv {f : M → G}
   (hf : smooth I' I f) : smooth I' I (λx, (f x)⁻¹) :=
-lie_group.smooth_inv.comp hf
+(smooth_inv I).comp hf
 
 @[to_additive]
 lemma smooth_on.inv {f : M → G} {s : set M}
   (hf : smooth_on I' I f s) : smooth_on I' I (λx, (f x)⁻¹) s :=
-smooth_inv.comp_smooth_on hf
+(smooth_inv I).comp_smooth_on hf
 
 end lie_group
 
@@ -118,8 +124,7 @@ section prod_lie_group
 @[to_additive]
 instance {𝕜 : Type*} [nondiscrete_normed_field 𝕜] {H : Type*} [topological_space H]
   {E : Type*} [normed_group E] [normed_space 𝕜 E]  {I : model_with_corners 𝕜 E H}
-  {G : Type*} [topological_space G] [charted_space H G] [group G] [topological_group G]
-  [lie_group I G]
+  {G : Type*} [topological_space G] [charted_space H G] [group G] [lie_group I G]
   {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
   {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
   {G' : Type*} [topological_space G'] [charted_space H' G']
@@ -130,105 +135,6 @@ instance {𝕜 : Type*} [nondiscrete_normed_field 𝕜] {H : Type*} [topological
 
 end prod_lie_group
 
-section lie_group_morphism
-
-variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
-{E : Type*} [normed_group E] [normed_space 𝕜 E]
-{E' : Type*} [normed_group E'] [normed_space 𝕜 E']
-
-/-- Morphism of additive Lie groups. -/
-structure lie_add_group_morphism (I : model_with_corners 𝕜 E E) (I' : model_with_corners 𝕜 E' E')
-  (G : Type*) [topological_space G] [charted_space E G]
-  [add_group G] [topological_add_group G] [lie_add_group I G]
-  (G' : Type*) [topological_space G'] [charted_space E' G']
-  [add_group G'] [topological_add_group G'] [lie_add_group I' G']
-  extends smooth_add_monoid_morphism I I' G G'
-
-/-- Morphism of Lie groups. -/
-@[to_additive]
-structure lie_group_morphism (I : model_with_corners 𝕜 E E) (I' : model_with_corners 𝕜 E' E')
-  (G : Type*) [topological_space G] [charted_space E G] [group G]
-  [topological_group G] [lie_group I G]
-  (G' : Type*) [topological_space G'] [charted_space E' G']
-  [group G'] [topological_group G'] [lie_group I' G']
-  extends smooth_monoid_morphism I I' G G'
-
-variables {I : model_with_corners 𝕜 E E} {I' : model_with_corners 𝕜 E' E'}
-{G : Type*} [topological_space G] [charted_space E G]
-[group G] [topological_group G] [lie_group I G]
-{G' : Type*} [topological_space G'] [charted_space E' G']
-[group G'] [topological_group G'] [lie_group I' G']
-
-@[to_additive]
-instance : has_one (lie_group_morphism I I' G G') := ⟨{ ..(1 : smooth_monoid_morphism I I' G G') }⟩
-
-@[to_additive]
-instance : inhabited (lie_group_morphism I I' G G') := ⟨1⟩
-
-@[to_additive]
-instance : has_coe_to_fun (lie_group_morphism I I' G G') := ⟨_, λ a, a.to_fun⟩
-
-end lie_group_morphism
-
-section lie_group_core
-
-section
-set_option old_structure_cmd true
-
-/-- Sometimes one might want to define a Lie additive group `G` without having proved previously
-that `G` is a topological additive group. In such case it is possible to use `lie_add_group_core`
-that does not require such instance, and then get a Lie group by invoking `to_lie_add_group`. -/
-@[ancestor smooth_manifold_with_corner]
-structure lie_add_group_core {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
-  {E : Type*} [normed_group E]
-  [normed_space 𝕜 E] (I : model_with_corners 𝕜 E E)
-  (G : Type*) [add_group G] [topological_space G]
-  [charted_space E G] extends smooth_manifold_with_corners I G : Prop :=
-(smooth_add : smooth (I.prod I) I (λ p : G×G, p.1 + p.2))
-(smooth_neg : smooth I I (λ a:G, -a))
-
-/-- Sometimes one might want to define a Lie group `G` without having proved previously that `G` is
-a topological group. In such case it is possible to use `lie_group_core` that does not require such
-instance, and then get a Lie group by invoking `to_lie_group` defined below. -/
-@[ancestor smooth_manifold_with_corner, to_additive]
-structure lie_group_core {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
-  {E : Type*} [normed_group E]
-  [normed_space 𝕜 E] (I : model_with_corners 𝕜 E E)
-  (G : Type*) [group G] [topological_space G]
-  [charted_space E G] extends smooth_manifold_with_corners I G : Prop :=
-(smooth_mul : smooth (I.prod I) I (λ p : G×G, p.1 * p.2))
-(smooth_inv : smooth I I (λ a:G, a⁻¹))
-
--- The linter does not recognize that the followings are structure projections, disable it
-attribute [nolint def_lemma doc_blame] lie_add_group_core.to_smooth_manifold_with_corners
-  lie_group_core.to_smooth_manifold_with_corners
-
-end
-
-variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
-{E : Type*} [normed_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E E}
-{F : Type*} [normed_group F] [normed_space 𝕜 F] {J : model_with_corners 𝕜 F F}
-{G : Type*} [topological_space G] [charted_space E G] [group G]
-
-namespace lie_group_core
-
-variables (c : lie_group_core I G)
-
-@[to_additive]
-protected lemma to_topological_group : topological_group G :=
-{ continuous_mul := c.smooth_mul.continuous,
-  continuous_inv := c.smooth_inv.continuous, }
-
-@[to_additive]
-protected lemma to_lie_group : @lie_group 𝕜 _ _ _ E _ _ I G _ _ c.to_topological_group _ :=
-{ smooth_mul := c.smooth_mul,
-  smooth_inv := c.smooth_inv,
-  .. c.to_smooth_manifold_with_corners }
-
-end lie_group_core
-
-end lie_group_core
-
 section normed_space_lie_group
 
 /-! ### Normed spaces are Lie groups -/
@@ -236,22 +142,7 @@ section normed_space_lie_group
 instance normed_space_lie_group {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {E : Type*} [normed_group E] [normed_space 𝕜 E] :
   lie_add_group (model_with_corners_self 𝕜 E) E :=
-{ smooth_add :=
-  begin
-    rw smooth_iff,
-    refine ⟨continuous_add, λ x y, _⟩,
-    simp only [prod.mk.eta] with mfld_simps,
-    rw times_cont_diff_on_univ,
-    exact times_cont_diff_add,
-  end,
-  smooth_neg :=
-  begin
-    rw smooth_iff,
-    refine ⟨continuous_neg, λ x y, _⟩,
-    simp only [prod.mk.eta] with mfld_simps,
-    rw times_cont_diff_on_univ,
-    exact times_cont_diff_neg,
-  end,
-  .. model_space_smooth }
+{ smooth_add := smooth_iff.2 ⟨continuous_add, λ x y, times_cont_diff_add.times_cont_diff_on⟩,
+  smooth_neg := smooth_iff.2 ⟨continuous_neg, λ x y, times_cont_diff_neg.times_cont_diff_on⟩ }
 
 end normed_space_lie_group

--- a/src/geometry/manifold/algebra/lie_group.lean
+++ b/src/geometry/manifold/algebra/lie_group.lean
@@ -24,13 +24,6 @@ groups here are not necessarily finite dimensional.
                         corners `I`.
 * `lie_add_group_morphism I I' G G'`  : morphism of addittive Lie groups
 * `lie_group_morphism I I' G G'`      : morphism of Lie groups
-* `lie_add_group_core I G`            : allows to define a Lie additive group without first proving
-                                        it is a topological additive group.
-* `lie_group_core I G`                : allows to define a Lie group without first proving
-                                        it is a topological group.
-
-* `reals_lie_group`                   : real numbers are a Lie group
-
 
 ## Implementation notes
 A priori, a Lie group here is a manifold with corners.
@@ -128,7 +121,7 @@ instance {𝕜 : Type*} [nondiscrete_normed_field 𝕜] {H : Type*} [topological
   {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
   {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
   {G' : Type*} [topological_space G'] [charted_space H' G']
-  [group G'] [topological_group G'] [lie_group I' G'] :
+  [group G'] [lie_group I' G'] :
   lie_group (I.prod I') (G×G') :=
 { smooth_inv := smooth_fst.inv.prod_mk smooth_snd.inv,
   ..has_smooth_mul.prod _ _ _ _ }

--- a/src/geometry/manifold/algebra/lie_group.lean
+++ b/src/geometry/manifold/algebra/lie_group.lean
@@ -36,6 +36,8 @@ so the definition does not apply. Hence the definition should be more general, a
 
 noncomputable theory
 
+open_locale manifold
+
 section
 set_option old_structure_cmd true
 
@@ -131,6 +133,7 @@ end prod_lie_group
 
 instance normed_space_lie_add_group {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {E : Type*} [normed_group E] [normed_space 𝕜 E] :
-  lie_add_group (model_with_corners_self 𝕜 E) E :=
+  lie_add_group (𝓘(𝕜, E)) E :=
 { smooth_add := smooth_iff.2 ⟨continuous_add, λ x y, times_cont_diff_add.times_cont_diff_on⟩,
-  smooth_neg := smooth_iff.2 ⟨continuous_neg, λ x y, times_cont_diff_neg.times_cont_diff_on⟩ }
+  smooth_neg := smooth_iff.2 ⟨continuous_neg, λ x y, times_cont_diff_neg.times_cont_diff_on⟩,
+  .. model_space_smooth }

--- a/src/geometry/manifold/algebra/lie_group.lean
+++ b/src/geometry/manifold/algebra/lie_group.lean
@@ -44,6 +44,7 @@ set_option old_structure_cmd true
 
 /-- A Lie (additive) group is a group and a smooth manifold at the same time in which
 the addition and negation operations are smooth. -/
+-- See note [Design choices about smooth algebraic structures]
 @[ancestor has_smooth_add]
 class lie_add_group {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
@@ -54,6 +55,7 @@ class lie_add_group {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 
 /-- A Lie group is a group and a smooth manifold at the same time in which
 the multiplication and inverse operations are smooth. -/
+-- See note [Design choices about smooth algebraic structures]
 @[ancestor has_smooth_mul, to_additive]
 class lie_group {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
@@ -94,7 +96,11 @@ variable (I)
 lemma smooth_inv : smooth I I (λ x : G, x⁻¹) :=
 lie_group.smooth_inv
 
-@[to_additive]
+/-- A Lie group is a topological group. This is not an instance for technical reasons,
+see note [Design choices about smooth algebraic structures]. -/
+@[to_additive
+"An additive Lie group is an additive topological group. This is not an instance for technical
+reasons, see note [Design choices about smooth algebraic structures]."]
 lemma topological_group_of_lie_group : topological_group G :=
 { continuous_inv := (smooth_inv I).continuous,
   .. has_continuous_mul_of_smooth I }

--- a/src/geometry/manifold/algebra/lie_group.lean
+++ b/src/geometry/manifold/algebra/lie_group.lean
@@ -26,6 +26,7 @@ groups here are not necessarily finite dimensional.
                                  is an additive Lie group.
 
 ## Implementation notes
+A priori, a Lie group here is a manifold with corners.
 
 The definition of Lie group cannot require `I : model_with_corners 𝕜 E E` with the same space as the
 model space and as the model vector space, as one might hope, beause in the product situation,

--- a/src/geometry/manifold/algebra/monoid.lean
+++ b/src/geometry/manifold/algebra/monoid.lean
@@ -18,13 +18,16 @@ semigroups.
 
 section
 
+set_option old_structure_cmd true
+
 /-- Basic hypothesis to talk about a smooth (Lie) additive monoid or a smooth additive
 semigroup. A smooth additive monoid over `α`, for example, is obtained by requiring both the
 instances `add_monoid α` and `has_smooth_add α`. -/
 class has_smooth_add {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
   {E : Type*} [normed_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
-  (G : Type*) [has_add G] [topological_space G] [charted_space H G] : Prop :=
+  (G : Type*) [has_add G] [topological_space G] [charted_space H G]
+  extends smooth_manifold_with_corners I G : Prop :=
 (smooth_add : smooth (I.prod I) I (λ p : G×G, p.1 + p.2))
 
 /-- Basic hypothesis to talk about a smooth (Lie) monoid or a smooth semigroup.
@@ -34,7 +37,8 @@ and `has_smooth_mul I G`. -/
 class has_smooth_mul {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
   {E : Type*} [normed_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
-  (G : Type*) [has_mul G] [topological_space G] [charted_space H G] : Prop :=
+  (G : Type*) [has_mul G] [topological_space G] [charted_space H G]
+  extends smooth_manifold_with_corners I G : Prop :=
 (smooth_mul : smooth (I.prod I) I (λ p : G×G, p.1 * p.2))
 
 end
@@ -95,7 +99,8 @@ instance has_smooth_mul.prod {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   [has_mul G'] [has_smooth_mul I' G'] :
   has_smooth_mul (I.prod I') (G×G') :=
 { smooth_mul := ((smooth_fst.comp smooth_fst).smooth.mul (smooth_fst.comp smooth_snd)).prod_mk
-    ((smooth_snd.comp smooth_fst).smooth.mul (smooth_snd.comp smooth_snd)) }
+    ((smooth_snd.comp smooth_fst).smooth.mul (smooth_snd.comp smooth_snd)),
+  .. smooth_manifold_with_corners.prod G G' }
 
 variable (I)
 

--- a/src/geometry/manifold/algebra/monoid.lean
+++ b/src/geometry/manifold/algebra/monoid.lean
@@ -20,9 +20,30 @@ section
 
 set_option old_structure_cmd true
 
+/--
+1. All smooth algebraic structures on `G` are `Prop`-valued classes that extend
+`smooth_manifold_with_corners I G`. This way we save users from adding both
+`[smooth_manifold_with_corners I G]` and `[has_smooth_mul I G]` to the assumptions. While many API
+lemmas hold true without the `smooth_manifold_with_corners I G` assumption, we're not aware of a
+mathematically interesting monoid on a topological manifold such that (a) the space is not a
+`smooth_manifold_with_corners`; (b) the multiplication is smooth at `(a, b)` in the charts
+`ext_chart_at I a`, `ext_chart_at I b`, `ext_chart_at I (a * b)`.
+
+2. Because of `model_prod` we can't assume, e.g., that a `lie_group` is modelled on `𝓘(𝕜, E)`. So,
+we formulate the definitions and lemmas for any model.
+
+3. While smoothness of an operation implies its continuity, lemmas like
+`has_continuous_mul_of_smooth` can't be instances becausen otherwise Lean would have to search for
+`has_smooth_mul I G` with unknown `𝕜`, `E`, `H`, and
+`I : model_with_corners 𝕜 E H`. If users needs `[has_continuous_mul G]` in a proof about a smooth
+monoid, then they need to either add `[has_continuous_mul G]` as an assumption (worse) or use `letI`
+in the proof (better). -/
+library_note "Design choices about smooth algebraic structures"
+
 /-- Basic hypothesis to talk about a smooth (Lie) additive monoid or a smooth additive
 semigroup. A smooth additive monoid over `α`, for example, is obtained by requiring both the
 instances `add_monoid α` and `has_smooth_add α`. -/
+-- See note [Design choices about smooth algebraic structures]
 @[ancestor smooth_manifold_with_corners]
 class has_smooth_add {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
@@ -34,6 +55,7 @@ class has_smooth_add {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 /-- Basic hypothesis to talk about a smooth (Lie) monoid or a smooth semigroup.
 A smooth monoid over `G`, for example, is obtained by requiring both the instances `monoid G`
 and `has_smooth_mul I G`. -/
+-- See note [Design choices about smooth algebraic structures]
 @[ancestor smooth_manifold_with_corners, to_additive]
 class has_smooth_mul {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
@@ -62,7 +84,11 @@ variables (I)
 lemma smooth_mul : smooth (I.prod I) I (λ p : G×G, p.1 * p.2) :=
 has_smooth_mul.smooth_mul
 
-@[to_additive]
+/-- If the multiplication is smooth, then it is continuous. This is not an instance for technical
+reasons, see note [Design choices about smooth algebraic structures]. -/
+@[to_additive
+"If the addition is smooth, then it is continuous. This is not an instance for technical reasons,
+see note [Design choices about smooth algebraic structures]."]
 lemma has_continuous_mul_of_smooth : has_continuous_mul G :=
 ⟨(smooth_mul I).continuous⟩
 

--- a/src/geometry/manifold/algebra/monoid.lean
+++ b/src/geometry/manifold/algebra/monoid.lean
@@ -23,6 +23,7 @@ set_option old_structure_cmd true
 /-- Basic hypothesis to talk about a smooth (Lie) additive monoid or a smooth additive
 semigroup. A smooth additive monoid over `α`, for example, is obtained by requiring both the
 instances `add_monoid α` and `has_smooth_add α`. -/
+@[ancestor smooth_manifold_with_corners]
 class has_smooth_add {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
   {E : Type*} [normed_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
@@ -33,7 +34,7 @@ class has_smooth_add {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 /-- Basic hypothesis to talk about a smooth (Lie) monoid or a smooth semigroup.
 A smooth monoid over `G`, for example, is obtained by requiring both the instances `monoid G`
 and `has_smooth_mul I G`. -/
-@[to_additive]
+@[ancestor smooth_manifold_with_corners, to_additive]
 class has_smooth_mul {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
   {E : Type*} [normed_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
@@ -63,7 +64,7 @@ has_smooth_mul.smooth_mul
 
 @[to_additive]
 lemma has_continuous_mul_of_smooth : has_continuous_mul G :=
-⟨(smooth_mul I).continuous⟩ 
+⟨(smooth_mul I).continuous⟩
 
 end
 

--- a/src/geometry/manifold/algebra/monoid.lean
+++ b/src/geometry/manifold/algebra/monoid.lean
@@ -36,7 +36,7 @@ we formulate the definitions and lemmas for any model.
 `has_continuous_mul_of_smooth` can't be instances becausen otherwise Lean would have to search for
 `has_smooth_mul I G` with unknown `𝕜`, `E`, `H`, and
 `I : model_with_corners 𝕜 E H`. If users needs `[has_continuous_mul G]` in a proof about a smooth
-monoid, then they need to either add `[has_continuous_mul G]` as an assumption (worse) or use `letI`
+monoid, then they need to either add `[has_continuous_mul G]` as an assumption (worse) or use `haveI`
 in the proof (better). -/
 library_note "Design choices about smooth algebraic structures"
 

--- a/src/geometry/manifold/algebra/monoid.lean
+++ b/src/geometry/manifold/algebra/monoid.lean
@@ -6,8 +6,6 @@ Authors: Nicolò Cavalleri
 
 import geometry.manifold.times_cont_mdiff
 
-variables {α : Type*} [add_comm_group α]
-
 /-!
 # Smooth monoid
 A smooth monoid is a monoid that is also a smooth manifold, in which multiplication is a smooth map
@@ -19,28 +17,24 @@ semigroups.
 -/
 
 section
-set_option old_structure_cmd true
 
 /-- Basic hypothesis to talk about a smooth (Lie) additive monoid or a smooth additive
 semigroup. A smooth additive monoid over `α`, for example, is obtained by requiring both the
 instances `add_monoid α` and `has_smooth_add α`. -/
-@[ancestor smooth_manifold_with_corners]
 class has_smooth_add {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
   {E : Type*} [normed_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
-  (G : Type*) [has_add G] [topological_space G] [has_continuous_add G] [charted_space H G]
-  extends smooth_manifold_with_corners I G : Prop :=
+  (G : Type*) [has_add G] [topological_space G] [charted_space H G] : Prop :=
 (smooth_add : smooth (I.prod I) I (λ p : G×G, p.1 + p.2))
 
 /-- Basic hypothesis to talk about a smooth (Lie) monoid or a smooth semigroup.
 A smooth monoid over `G`, for example, is obtained by requiring both the instances `monoid G`
 and `has_smooth_mul I G`. -/
-@[ancestor smooth_manifold_with_corners, to_additive]
+@[to_additive]
 class has_smooth_mul {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {H : Type*} [topological_space H]
   {E : Type*} [normed_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
-  (G : Type*) [has_mul G] [topological_space G] [has_continuous_mul G] [charted_space H G]
-  extends smooth_manifold_with_corners I G : Prop :=
+  (G : Type*) [has_mul G] [topological_space G] [charted_space H G] : Prop :=
 (smooth_mul : smooth (I.prod I) I (λ p : G×G, p.1 * p.2))
 
 end
@@ -50,34 +44,43 @@ section has_smooth_mul
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {H : Type*} [topological_space H]
 {E : Type*} [normed_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
-{G : Type*} [has_mul G] [topological_space G] [has_continuous_mul G] [charted_space H G]
-  [has_smooth_mul I G]
+{G : Type*} [has_mul G] [topological_space G] [charted_space H G] [has_smooth_mul I G]
 {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
-{M : Type*} [topological_space M] [charted_space H' M] [smooth_manifold_with_corners I' M]
+{M : Type*} [topological_space M] [charted_space H' M]
+
+section
+
+variables (I)
 
 @[to_additive]
 lemma smooth_mul : smooth (I.prod I) I (λ p : G×G, p.1 * p.2) :=
 has_smooth_mul.smooth_mul
 
 @[to_additive]
+lemma has_continuous_mul_of_smooth : has_continuous_mul G :=
+⟨(smooth_mul I).continuous⟩ 
+
+end
+
+@[to_additive]
 lemma smooth.mul {f : M → G} {g : M → G} (hf : smooth I' I f) (hg : smooth I' I g) :
   smooth I' I (f * g) :=
-smooth_mul.comp (hf.prod_mk hg)
+(smooth_mul I).comp (hf.prod_mk hg)
 
 @[to_additive]
 lemma smooth_mul_left {a : G} : smooth I I (λ b : G, a * b) :=
-smooth_mul.comp (smooth_const.prod_mk smooth_id)
+smooth_const.mul smooth_id
 
 @[to_additive]
 lemma smooth_mul_right {a : G} : smooth I I (λ b : G, b * a) :=
-smooth_mul.comp (smooth_id.prod_mk smooth_const)
+smooth_id.mul smooth_const
 
 @[to_additive]
 lemma smooth_on.mul {f : M → G} {g : M → G} {s : set M}
   (hf : smooth_on I' I f s) (hg : smooth_on I' I g s) :
   smooth_on I' I (f * g) s :=
-(smooth_mul.comp_smooth_on (hf.prod_mk hg) : _)
+((smooth_mul I).comp_smooth_on (hf.prod_mk hg) : _)
 
 /- Instance of product -/
 @[to_additive]
@@ -85,50 +88,52 @@ instance has_smooth_mul.prod {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
   {E : Type*} [normed_group E] [normed_space 𝕜 E]
   {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
   (G : Type*) [topological_space G] [charted_space H G]
-  [has_mul G] [has_continuous_mul G] [has_smooth_mul I G]
+  [has_mul G] [has_smooth_mul I G]
   {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
   {H' : Type*} [topological_space H'] (I' : model_with_corners 𝕜 E' H')
   (G' : Type*) [topological_space G'] [charted_space H' G']
-  [has_mul G'] [has_continuous_mul G'] [has_smooth_mul I' G'] :
+  [has_mul G'] [has_smooth_mul I' G'] :
   has_smooth_mul (I.prod I') (G×G') :=
 { smooth_mul := ((smooth_fst.comp smooth_fst).smooth.mul (smooth_fst.comp smooth_snd)).prod_mk
-    ((smooth_snd.comp smooth_fst).smooth.mul (smooth_snd.comp smooth_snd)),
-  .. smooth_manifold_with_corners.prod _ _ }
+    ((smooth_snd.comp smooth_fst).smooth.mul (smooth_snd.comp smooth_snd)) }
+
+variable (I)
 
 end has_smooth_mul
 
-section smooth_monoid_morphism
+section monoid
 
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
-{E : Type*} [normed_group E] [normed_space 𝕜 E]
-{E' : Type*} [normed_group E'] [normed_space 𝕜 E']
+{H : Type*} [topological_space H]
+{E : Type*} [normed_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
+{G : Type*} [monoid G] [topological_space G] [charted_space H G] [has_smooth_mul I G]
+{H' : Type*} [topological_space H']
+{E' : Type*} [normed_group E'] [normed_space 𝕜 E'] {I' : model_with_corners 𝕜 E' H'}
+{G' : Type*} [monoid G'] [topological_space G'] [charted_space H' G'] [has_smooth_mul I' G']
+
+lemma smooth_pow : ∀ n : ℕ, smooth I I (λ a : G, a ^ n)
+| 0 := by { simp only [pow_zero], exact smooth_const }
+| (k+1) := show smooth I I (λ (a : G), a * a ^ k), from smooth_id.mul (smooth_pow _)
 
 /-- Morphism of additive smooth monoids. -/
-structure smooth_add_monoid_morphism (I : model_with_corners 𝕜 E E) (I' : model_with_corners 𝕜 E' E')
-  (G : Type*) [topological_space G] [charted_space E G]
-  [add_monoid G] [has_continuous_add G] [has_smooth_add I G]
-  (G' : Type*) [topological_space G'] [charted_space E' G']
-  [add_monoid G'] [has_continuous_add G'] [has_smooth_add I' G'] extends add_monoid_hom G G' :=
+structure smooth_add_monoid_morphism
+  (I : model_with_corners 𝕜 E H) (I' : model_with_corners 𝕜 E' H')
+  (G : Type*) [topological_space G] [charted_space H G] [add_monoid G] [has_smooth_add I G]
+  (G' : Type*) [topological_space G'] [charted_space H' G'] [add_monoid G'] [has_smooth_add I' G']
+  extends G →+ G' :=
 (smooth_to_fun : smooth I I' to_fun)
 
 /-- Morphism of smooth monoids. -/
-@[to_additive]
-structure smooth_monoid_morphism (I : model_with_corners 𝕜 E E) (I' : model_with_corners 𝕜 E' E')
-  (G : Type*) [topological_space G] [charted_space E G]
-  [monoid G] [has_continuous_mul G] [has_smooth_mul I G]
-  (G' : Type*) [topological_space G'] [charted_space E' G']
-  [monoid G'] [has_continuous_mul G'] [has_smooth_mul I' G'] extends monoid_hom G G' :=
+@[to_additive] structure smooth_monoid_morphism
+  (I : model_with_corners 𝕜 E H) (I' : model_with_corners 𝕜 E' H')
+  (G : Type*) [topological_space G] [charted_space H G] [monoid G] [has_smooth_mul I G]
+  (G' : Type*) [topological_space G'] [charted_space H' G'] [monoid G'] [has_smooth_mul I' G']
+  extends G →* G' :=
 (smooth_to_fun : smooth I I' to_fun)
-
-variables {I : model_with_corners 𝕜 E E} {I' : model_with_corners 𝕜 E' E'}
-{G : Type*} [topological_space G] [charted_space E G]
-[monoid G] [has_continuous_mul G] [has_smooth_mul I G]
-{G' : Type*} [topological_space G'] [charted_space E' G']
-[monoid G'] [has_continuous_mul G'] [has_smooth_mul I' G']
 
 @[to_additive]
 instance : has_one (smooth_monoid_morphism I I' G G') :=
-⟨{ smooth_to_fun := smooth_const, .. (1 : G →* G') }⟩
+⟨{ smooth_to_fun := smooth_const, to_monoid_hom := 1 }⟩
 
 @[to_additive]
 instance : inhabited (smooth_monoid_morphism I I' G G') := ⟨1⟩
@@ -136,52 +141,4 @@ instance : inhabited (smooth_monoid_morphism I I' G G') := ⟨1⟩
 @[to_additive]
 instance : has_coe_to_fun (smooth_monoid_morphism I I' G G') := ⟨_, λ a, a.to_fun⟩
 
-end smooth_monoid_morphism
-
-section has_smooth_mul_core
-
-/-- Sometimes one might want to define a smooth additive monoid `G` without having proved previously
-that `G` is a topological additive monoid. In such case it is possible to use `has_smooth_add_core`
-that does not require such instance, and then get a smooth additive monoid by invoking
-`to_has_smooth_add`. -/
-@[ancestor smooth_manifold_with_corners]
-structure has_smooth_add_core {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
-  {H : Type*} [topological_space H]
-  {E : Type*} [normed_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
-  (G : Type*) [has_add G] [topological_space G] [charted_space H G]
-  extends smooth_manifold_with_corners I G : Prop :=
-(smooth_add : smooth (I.prod I) I (λ p : G×G, p.1 + p.2))
-
-/-- Sometimes one might want to define a smooth monoid `G` without having proved previously that `G`
-is a topological monoid. In such case it is possible to use `has_smooth_mul_core` that does not
-require such instance, and then get a smooth monoid by invoking `to_has_smooth_mul`. -/
-@[ancestor smooth_manifold_with_corners, to_additive]
-structure has_smooth_mul_core {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
-  {H : Type*} [topological_space H]
-  {E : Type*} [normed_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
-  (G : Type*) [has_mul G] [topological_space G] [charted_space H G]
-  extends smooth_manifold_with_corners I G : Prop :=
-(smooth_mul : smooth (I.prod I) I (λ p : G×G, p.1 * p.2))
-
-variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
-{E : Type*} [normed_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E E}
-{F : Type*} [normed_group F] [normed_space 𝕜 F] {J : model_with_corners 𝕜 F F}
-{G : Type*} [topological_space G] [charted_space E G] [group G]
-
-namespace has_smooth_mul_core
-
-variables (c : has_smooth_mul_core I G)
-
-@[to_additive]
-protected lemma to_has_continuous_mul : has_continuous_mul G :=
-{ continuous_mul := c.smooth_mul.continuous, }
-
-@[to_additive]
-protected lemma to_has_smooth_mul :
-  @has_smooth_mul 𝕜 _ _ _ E _ _ I G _ _ c.to_has_continuous_mul _ :=
-{ smooth_mul := c.smooth_mul,
-  compatible := c.compatible }
-
-end has_smooth_mul_core
-
-end has_smooth_mul_core
+end monoid

--- a/src/geometry/manifold/algebra/smooth_functions.lean
+++ b/src/geometry/manifold/algebra/smooth_functions.lean
@@ -22,19 +22,18 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
 {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
-{N : Type*} [topological_space N] [charted_space H N] [smooth_manifold_with_corners I N]
+{N : Type*} [topological_space N] [charted_space H N]
 
 namespace smooth_map
 
 @[to_additive]
-instance has_mul {G : Type*} [has_mul G] [topological_space G] [has_continuous_mul G]
-  [charted_space H' G] [has_smooth_mul I' G] :
+instance has_mul {G : Type*} [has_mul G] [topological_space G] [charted_space H' G]
+  [has_smooth_mul I' G] :
   has_mul C^∞⟮I, N; I', G⟯ :=
-⟨λ f g, ⟨f * g, smooth_mul.comp (f.smooth.prod_mk g.smooth)⟩⟩
+⟨λ f g, ⟨f * g, f.smooth.mul g.smooth⟩⟩
 
 @[to_additive]
-instance has_one {G : Type*} [monoid G] [topological_space G]
-  [charted_space H' G] [smooth_manifold_with_corners I' G] :
+instance has_one {G : Type*} [monoid G] [topological_space G] [charted_space H' G] :
   has_one C^∞⟮I, N; I', G⟯ :=
 ⟨times_cont_mdiff_map.const (1 : G)⟩
 
@@ -51,14 +50,14 @@ under pointwise multiplication.
 
 @[to_additive]
 instance smooth_map_semigroup {G : Type*} [semigroup G] [topological_space G]
-  [has_continuous_mul G] [charted_space H' G] [has_smooth_mul I' G] :
+  [charted_space H' G] [has_smooth_mul I' G] :
   semigroup C^∞⟮I, N; I', G⟯ :=
 { mul_assoc := λ a b c, by ext; exact mul_assoc _ _ _,
   ..smooth_map.has_mul}
 
 @[to_additive]
 instance smooth_map_monoid {G : Type*} [monoid G] [topological_space G]
-  [has_continuous_mul G] [charted_space H' G] [has_smooth_mul I' G] :
+  [charted_space H' G] [has_smooth_mul I' G] :
   monoid C^∞⟮I, N; I', G⟯ :=
 { one_mul := λ a, by ext; exact one_mul _,
   mul_one := λ a, by ext; exact mul_one _,
@@ -67,23 +66,23 @@ instance smooth_map_monoid {G : Type*} [monoid G] [topological_space G]
 
 @[to_additive]
 instance smooth_map_comm_monoid {G : Type*} [comm_monoid G] [topological_space G]
-  [has_continuous_mul G] [charted_space H' G] [has_smooth_mul I' G] :
+  [charted_space H' G] [has_smooth_mul I' G] :
   comm_monoid C^∞⟮I, N; I', G⟯ :=
 { mul_comm := λ a b, by ext; exact mul_comm _ _,
   ..smooth_map_monoid,
   ..smooth_map.has_one }
 
 @[to_additive]
-instance smooth_map_group {G : Type*} [group G] [topological_space G] [topological_group G]
-  [charted_space H' G] [smooth_manifold_with_corners I' G] [lie_group I' G] :
+instance smooth_map_group {G : Type*} [group G] [topological_space G]
+  [charted_space H' G] [lie_group I' G] :
   group C^∞⟮I, N; I', G⟯ :=
-{ inv := λ f, ⟨λ x, (f x)⁻¹, smooth_inv.comp f.smooth⟩,
+{ inv := λ f, ⟨λ x, (f x)⁻¹, f.smooth.inv⟩,
   mul_left_inv := λ a, by ext; exact mul_left_inv _,
-  ..smooth_map_monoid }
+  .. smooth_map_monoid }
 
 @[to_additive]
 instance smooth_map_comm_group {G : Type*} [comm_group G] [topological_space G]
-  [topological_group G] [charted_space H' G] [lie_group I' G] :
+  [charted_space H' G] [lie_group I' G] :
   comm_group C^∞⟮I, N; I', G⟯ :=
 { ..smooth_map_group,
   ..smooth_map_comm_monoid }
@@ -100,7 +99,7 @@ under pointwise multiplication.
 -/
 
 instance smooth_map_semiring {R : Type*} [semiring R] [topological_space R]
-  [topological_semiring R] [charted_space H' R] [smooth_semiring I' R] :
+  [charted_space H' R] [smooth_semiring I' R] :
   semiring C^∞⟮I, N; I', R⟯ :=
 { left_distrib := λ a b c, by ext; exact left_distrib _ _ _,
   right_distrib := λ a b c, by ext; exact right_distrib _ _ _,
@@ -110,13 +109,13 @@ instance smooth_map_semiring {R : Type*} [semiring R] [topological_space R]
   ..smooth_map_monoid }
 
 instance smooth_map_ring {R : Type*} [ring R] [topological_space R]
-  [topological_ring R] [charted_space H' R] [smooth_ring I' R] :
+  [charted_space H' R] [smooth_ring I' R] :
   ring C^∞⟮I, N; I', R⟯ :=
 { ..smooth_map_semiring,
   ..smooth_map_add_comm_group, }
 
 instance smooth_map_comm_ring {R : Type*} [comm_ring R] [topological_space R]
-  [topological_ring R] [charted_space H' R] [smooth_ring I' R] :
+  [charted_space H' R] [smooth_ring I' R] :
   comm_ring C^∞⟮I, N; I', R⟯ :=
 { ..smooth_map_semiring,
   ..smooth_map_add_comm_group,

--- a/src/geometry/manifold/algebra/structures.lean
+++ b/src/geometry/manifold/algebra/structures.lean
@@ -25,16 +25,16 @@ set_option default_priority 100 -- see Note [default priority]
 
 /-- A smooth semiring is a semiring where addition and multiplication are smooth. -/
 class smooth_semiring (I : model_with_corners 𝕜 E H)
-  (R : Type*) [semiring R] [topological_space R] [topological_semiring R] [charted_space H R]
+  (R : Type*) [semiring R] [topological_space R] [charted_space H R]
   extends has_smooth_add I R, has_smooth_mul I R : Prop
 
 /-- A smooth ring is a ring where the ring operations are smooth. -/
 class smooth_ring (I : model_with_corners 𝕜 E H)
-  (R : Type*) [ring R] [topological_space R] [topological_ring R] [charted_space H R]
+  (R : Type*) [ring R] [topological_space R] [charted_space H R]
   extends lie_add_group I R, has_smooth_mul I R : Prop
 
 instance smooth_ring.to_smooth_semiring {I : model_with_corners 𝕜 E H}
-  {R : Type*} [ring R] [topological_space R] [topological_ring R]
+  {R : Type*} [ring R] [topological_space R]
   [charted_space H R] [t : smooth_ring I R] :
   smooth_semiring I R := { ..t }
 

--- a/src/geometry/manifold/algebra/structures.lean
+++ b/src/geometry/manifold/algebra/structures.lean
@@ -50,4 +50,4 @@ instance field_smooth_ring {𝕜 : Type*} [nondiscrete_normed_field 𝕜] :
     rw times_cont_diff_on_univ,
     exact times_cont_diff_mul,
   end,
-  ..normed_space_lie_group }
+  ..normed_space_lie_add_group }

--- a/src/geometry/manifold/algebra/structures.lean
+++ b/src/geometry/manifold/algebra/structures.lean
@@ -3,15 +3,14 @@ Copyright © 2020 Nicolò Cavalleri. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nicolò Cavalleri
 -/
+import geometry.manifold.algebra.lie_group
 
-/-|
+/-!
 # Smooth structures
 
 In this file we define smooth structures that build on Lie groups. We prefer using the term smooth
 instead of Lie mainly because Lie ring has currently another use in mathematics.
 -/
-
-import geometry.manifold.algebra.lie_group
 
 open_locale manifold
 
@@ -24,11 +23,13 @@ set_option old_structure_cmd true
 set_option default_priority 100 -- see Note [default priority]
 
 /-- A smooth semiring is a semiring where addition and multiplication are smooth. -/
+-- See note [Design choices about smooth algebraic structures]
 class smooth_semiring (I : model_with_corners 𝕜 E H)
   (R : Type*) [semiring R] [topological_space R] [charted_space H R]
   extends has_smooth_add I R, has_smooth_mul I R : Prop
 
 /-- A smooth ring is a ring where the ring operations are smooth. -/
+-- See note [Design choices about smooth algebraic structures]
 class smooth_ring (I : model_with_corners 𝕜 E H)
   (R : Type*) [ring R] [topological_space R] [charted_space H R]
   extends lie_add_group I R, has_smooth_mul I R : Prop
@@ -51,3 +52,20 @@ instance field_smooth_ring {𝕜 : Type*} [nondiscrete_normed_field 𝕜] :
     exact times_cont_diff_mul,
   end,
   ..normed_space_lie_add_group }
+
+variables {𝕜 R E H : Type*} [topological_space R] [topological_space H]
+  [nondiscrete_normed_field 𝕜] [normed_group E] [normed_space 𝕜 E]
+  [charted_space H R] (I : model_with_corners 𝕜 E H)
+
+/-- A smooth semiring is a topological semiring. This is not an instance for technical reasons,
+see note [Design choices about smooth algebraic structures]. -/
+lemma topological_semiring_of_smooth [semiring R] [smooth_semiring I R] :
+  topological_semiring R :=
+{ .. has_continuous_mul_of_smooth I, .. has_continuous_add_of_smooth I }
+
+/-- A smooth ring is a topological ring. This is not an instance for technical reasons,
+see note [Design choices about smooth algebraic structures]. -/
+lemma topological_ring_of_smooth [ring R] [smooth_ring I R] :
+  topological_ring R :=
+{ .. has_continuous_mul_of_smooth I, .. topological_add_group_of_lie_add_group I }
+

--- a/src/geometry/manifold/diffeomorph.lean
+++ b/src/geometry/manifold/diffeomorph.lean
@@ -44,9 +44,9 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 
 section diffeomorph
 
-variables (M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
-(M' : Type*) [topological_space M'] [charted_space H' M'] [smooth_manifold_with_corners I' M']
-(N : Type*) [topological_space N] [charted_space G N] [smooth_manifold_with_corners J N]
+variables (M : Type*) [topological_space M] [charted_space H M]
+(M' : Type*) [topological_space M'] [charted_space H' M']
+(N : Type*) [topological_space N] [charted_space G N]
 (n : with_top ℕ)
 
 /--

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -645,11 +645,11 @@ lemma ext_chart_at_open_source : is_open (ext_chart_at I x).source :=
 by { rw ext_chart_at_source, exact (chart_at H x).open_source }
 
 lemma mem_ext_chart_source : x ∈ (ext_chart_at I x).source :=
-by simp only with mfld_simps
+by simp only [ext_chart_at_source, mem_chart_source]
 
 lemma ext_chart_at_to_inv :
   (ext_chart_at I x).symm ((ext_chart_at I x) x) = x :=
-by simp only with mfld_simps
+(ext_chart_at I x).left_inv (mem_ext_chart_source I x)
 
 lemma ext_chart_at_source_mem_nhds' {x' : M} (h : x' ∈ (ext_chart_at I x).source) :
   (ext_chart_at I x).source ∈ 𝓝 x' :=
@@ -657,6 +657,14 @@ mem_nhds_sets (ext_chart_at_open_source I x) h
 
 lemma ext_chart_at_source_mem_nhds : (ext_chart_at I x).source ∈ 𝓝 x :=
 ext_chart_at_source_mem_nhds' I x (mem_ext_chart_source I x)
+
+lemma ext_chart_at_source_mem_nhds_within' {x' : M} (h : x' ∈ (ext_chart_at I x).source) :
+  (ext_chart_at I x).source ∈ 𝓝[s] x' :=
+mem_nhds_within_of_mem_nhds (ext_chart_at_source_mem_nhds' I x h)
+
+lemma ext_chart_at_source_mem_nhds_within :
+  (ext_chart_at I x).source ∈ 𝓝[s] x :=
+mem_nhds_within_of_mem_nhds (ext_chart_at_source_mem_nhds I x)
 
 lemma ext_chart_at_continuous_on :
   continuous_on (ext_chart_at I x) (ext_chart_at I x).source :=
@@ -691,32 +699,34 @@ lemma ext_chart_at_map_nhds :
   map (ext_chart_at I x) (𝓝 x) = 𝓝[range I] (ext_chart_at I x x) :=
 ext_chart_at_map_nhds' I $ mem_ext_chart_source I x
 
+lemma ext_chart_at_target_mem_nhds_within' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
+  (ext_chart_at I x).target ∈ 𝓝[range I] (ext_chart_at I x y) :=
+begin
+  rw [← local_equiv.image_source_eq_target, ← ext_chart_at_map_nhds' I hy],
+  exact image_mem_map (ext_chart_at_source_mem_nhds' _ _ hy)
+end
+
 lemma ext_chart_at_target_mem_nhds_within :
   (ext_chart_at I x).target ∈ 𝓝[range I] (ext_chart_at I x x) :=
-begin
-  rw [← local_equiv.image_source_eq_target, ← ext_chart_at_map_nhds],
-  exact image_mem_map (ext_chart_at_source_mem_nhds _ _)
-end
+ext_chart_at_target_mem_nhds_within' I x (mem_ext_chart_source I x)
 
 lemma ext_chart_at_target_subset_range : (ext_chart_at I x).target ⊆ range I :=
 by simp only with mfld_simps
 
+lemma nhds_within_ext_chart_target_eq' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
+  𝓝[(ext_chart_at I x).target] (ext_chart_at I x y) =
+  𝓝[range I] (ext_chart_at I x y) :=
+(nhds_within_mono _ (ext_chart_at_target_subset_range _ _)).antisymm $
+  nhds_within_le_of_mem (ext_chart_at_target_mem_nhds_within' _ _ hy)
+
 lemma nhds_within_ext_chart_target_eq :
   𝓝[(ext_chart_at I x).target] ((ext_chart_at I x) x) =
   𝓝[range I] ((ext_chart_at I x) x) :=
-(nhds_within_mono _ (ext_chart_at_target_subset_range _ _)).antisymm $
-  nhds_within_le_of_mem (ext_chart_at_target_mem_nhds_within _ _)
+nhds_within_ext_chart_target_eq' I x (mem_ext_chart_source I x)
 
 lemma ext_chart_continuous_at_symm'' {y : E} (h : y ∈ (ext_chart_at I x).target) :
   continuous_at (ext_chart_at I x).symm y :=
-begin
-  apply continuous_at.comp,
-  { suffices : continuous_at (chart_at H x).symm (I.symm y), by simpa only with mfld_simps,
-    refine (chart_at H x).continuous_at_symm _,
-    simp only with mfld_simps at h,
-    exact h.2 },
-  { exact I.continuous_symm.continuous_at }
-end
+continuous_at.comp ((chart_at H x).continuous_at_symm h.2) (I.continuous_symm.continuous_at)
 
 lemma ext_chart_continuous_at_symm' {x' : M} (h : x' ∈ (ext_chart_at I x).source) :
   continuous_at (ext_chart_at I x).symm (ext_chart_at I x x') :=
@@ -730,20 +740,64 @@ lemma ext_chart_continuous_on_symm :
   continuous_on (ext_chart_at I x).symm (ext_chart_at I x).target :=
 λ y hy, (ext_chart_continuous_at_symm'' _ _ hy).continuous_within_at
 
+lemma ext_chart_at_map_nhds_within_eq_image' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
+  map (ext_chart_at I x) (𝓝[s] y) =
+    𝓝[ext_chart_at I x '' ((ext_chart_at I x).source ∩ s)] (ext_chart_at I x y) :=
+by set e := ext_chart_at I x;
+calc map e (𝓝[s] y) = map e (𝓝[e.source ∩ s] y) :
+  congr_arg (map e) (nhds_within_inter_of_mem (ext_chart_at_source_mem_nhds_within' I x hy)).symm
+... = 𝓝[e '' (e.source ∩ s)] (e y) :
+  ((ext_chart_at I x).left_inv_on.mono $ inter_subset_left _ _).map_nhds_within_eq
+    ((ext_chart_at I x).left_inv hy)
+    (ext_chart_continuous_at_symm' I x hy).continuous_within_at
+    (ext_chart_at_continuous_at' I x hy).continuous_within_at
+
+lemma ext_chart_at_map_nhds_within_eq_image :
+  map (ext_chart_at I x) (𝓝[s] x) =
+    𝓝[ext_chart_at I x '' ((ext_chart_at I x).source ∩ s)] (ext_chart_at I x x) :=
+ext_chart_at_map_nhds_within_eq_image' I x (mem_ext_chart_source I x)
+
+lemma ext_chart_at_map_nhds_within' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
+  map (ext_chart_at I x) (𝓝[s] y) =
+    𝓝[(ext_chart_at I x).symm ⁻¹' s ∩ range I] (ext_chart_at I x y) :=
+by rw [ext_chart_at_map_nhds_within_eq_image' I x hy, nhds_within_inter,
+  ← nhds_within_ext_chart_target_eq' _ _ hy, ← nhds_within_inter, inter_comm,
+  (ext_chart_at I x).image_inter_source_eq', inter_comm]
+
+lemma ext_chart_at_map_nhds_within :
+  map (ext_chart_at I x) (𝓝[s] x) =
+    𝓝[(ext_chart_at I x).symm ⁻¹' s ∩ range I] (ext_chart_at I x x) :=
+ext_chart_at_map_nhds_within' I x (mem_ext_chart_source I x)
+
+lemma ext_chart_at_symm_map_nhds_within' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
+  map (ext_chart_at I x).symm
+    (𝓝[(ext_chart_at I x).symm ⁻¹' s ∩ range I] (ext_chart_at I x y)) = 𝓝[s] y :=
+begin
+  rw [← ext_chart_at_map_nhds_within' I x hy, map_map, map_congr, map_id],
+  exact (ext_chart_at I x).left_inv_on.eq_on.eventually_eq_of_mem
+    (ext_chart_at_source_mem_nhds_within' _ _ hy)
+end
+
+lemma ext_chart_at_symm_map_nhds_within_range' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
+  map (ext_chart_at I x).symm (𝓝[range I] (ext_chart_at I x y)) = 𝓝 y :=
+by rw [← nhds_within_univ, ← ext_chart_at_symm_map_nhds_within' I x hy, preimage_univ, univ_inter]
+
+lemma ext_chart_at_symm_map_nhds_within :
+  map (ext_chart_at I x).symm
+    (𝓝[(ext_chart_at I x).symm ⁻¹' s ∩ range I] (ext_chart_at I x x)) = 𝓝[s] x :=
+ext_chart_at_symm_map_nhds_within' I x (mem_ext_chart_source I x)
+
+lemma ext_chart_at_symm_map_nhds_within_range :
+  map (ext_chart_at I x).symm (𝓝[range I] (ext_chart_at I x x)) = 𝓝 x :=
+ext_chart_at_symm_map_nhds_within_range' I x (mem_ext_chart_source I x)
+
 /-- Technical lemma ensuring that the preimage under an extended chart of a neighborhood of a point
 in the source is a neighborhood of the preimage, within a set. -/
 lemma ext_chart_preimage_mem_nhds_within' {x' : M} (h : x' ∈ (ext_chart_at I x).source)
   (ht : t ∈ 𝓝[s] x') :
   (ext_chart_at I x).symm ⁻¹' t ∈
     𝓝[(ext_chart_at I x).symm ⁻¹' s ∩ range I] ((ext_chart_at I x) x') :=
-begin
-  apply (ext_chart_continuous_at_symm' I x h).continuous_within_at.tendsto_nhds_within_image,
-  rw (ext_chart_at I x).left_inv h,
-  apply nhds_within_mono _ _ ht,
-  have : (ext_chart_at I x).symm '' ((ext_chart_at I x).symm ⁻¹' s) ⊆ s :=
-    image_preimage_subset _ _,
-  exact subset.trans (image_subset _ (inter_subset_left _ _)) this
-end
+by rwa [← ext_chart_at_symm_map_nhds_within' I x h, mem_map] at ht
 
 /-- Technical lemma ensuring that the preimage under an extended chart of a neighborhood of the
 base point is a neighborhood of the preimage, within a set. -/

--- a/src/geometry/manifold/times_cont_mdiff_map.lean
+++ b/src/geometry/manifold/times_cont_mdiff_map.lean
@@ -20,12 +20,12 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {H : Type*} [topological_space H]
 {H' : Type*} [topological_space H']
 (I : model_with_corners 𝕜 E H) (I' : model_with_corners 𝕜 E' H')
-(M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
-(M' : Type*) [topological_space M'] [charted_space H' M'] [smooth_manifold_with_corners I' M']
+(M : Type*) [topological_space M] [charted_space H M]
+(M' : Type*) [topological_space M'] [charted_space H' M']
 {E'' : Type*} [normed_group E''] [normed_space 𝕜 E'']
 {H'' : Type*} [topological_space H'']
 {I'' : model_with_corners 𝕜 E'' H''}
-{M'' : Type*} [topological_space M''] [charted_space H'' M''] [smooth_manifold_with_corners I'' M'']
+{M'' : Type*} [topological_space M''] [charted_space H'' M'']
 (n : with_top ℕ)
 
 /-- Bundled `n` times continuously differentiable maps. -/


### PR DESCRIPTION
API changes:

* add lemmas about `map (ext_chart_at I x) (𝓝[s] x')`;
* prove `times_cont_mdiff_within_at.comp` directly without using other charts; the new proof does not need a `smooth_manifold_with_corners` instance;
* add aliases `times_cont_mdiff.times_cont_diff` etc;
* `times_cont_mdiff_map` no longer needs a `smooth_manifold_with_corners` instance;
* `has_smooth_mul` no longer extends `smooth_manifold_with_corners` and no longer takes `has_continuous_mul` as an argument;
* `has_smooth_mul_core` is gone in favor of `has_continuous_mul_of_smooth`;
* `smooth_monoid_morphism` now works with any model space (needed, e.g., to define `smooth_monoid_morphism.prod`);
* `lie_group_morphism` is gone: we use `M →* N` both for monoids and groups, no reason to have two structures in this case;
* `lie_group` no longer extends `smooth_manifold_with_corners` and no longer takes `topological_group` as an argument;
* `lie_group_core` is gone in favor of `topological_group_of_lie_group`;
* the `I : model_with_corners 𝕜 E H` argument of `smooth_mul` and `smooth_inv` is now explicit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->