### PR TITLE
[Merged by Bors] - feat(order/filter/cofinite): a growing function has a minimum

### DIFF
--- a/src/order/filter/cofinite.lean
+++ b/src/order/filter/cofinite.lean
@@ -120,4 +120,4 @@ end
 lemma filter.tendsto.exists_forall_ge {α β : Type*} [nonempty α] [linear_order β]
   {f : α → β} (hf : tendsto f cofinite at_bot) :
   ∃ a₀, ∀ a, f a ≤ f a₀ :=
-@filter.tendsto.exists_forall_le _ _ _ _ _ hf
+@filter.tendsto.exists_forall_le _ (order_dual β) _ _ _ hf

--- a/src/order/filter/cofinite.lean
+++ b/src/order/filter/cofinite.lean
@@ -98,7 +98,7 @@ begin
   inhabit α,
   by_cases not_all_top : ∃ y, ∃ x, f y < x,
   { -- take the inverse image, `small_vals`, of some bounded nonempty set; it's finite so has a min
-    haveI : inhabited β := ⟨f (default α)⟩,
+    haveI : nonempty β := ⟨f (default α)⟩,
     obtain ⟨y, x, hx⟩ := not_all_top,
     let small_vals : finset α := (filter.eventually_cofinite.mp
       ((at_top_basis.tendsto_right_iff).1 hf x trivial)).to_finset,

--- a/src/order/filter/cofinite.lean
+++ b/src/order/filter/cofinite.lean
@@ -90,3 +90,28 @@ end
 lemma nat.frequently_at_top_iff_infinite {p : ℕ → Prop} :
   (∃ᶠ n in at_top, p n) ↔ set.infinite {n | p n} :=
 by simp only [← nat.cofinite_eq_at_top, frequently_cofinite_iff_infinite]
+
+lemma filter.tendsto.exists_forall_le {α β : Type*} [nonempty α] [linear_order β] [no_top_order β]
+  {f : α → β} (hf : tendsto f cofinite at_top) :
+  ∃ a₀, ∀ a, f a₀ ≤ f a :=
+begin
+  -- take the inverse image, `small_vals`, of some bounded nonempty set; it's finite, so has a min
+  inhabit α,
+  haveI : inhabited β := ⟨f (default α)⟩,
+  let small_vals : finset α := (filter.eventually_cofinite.mp
+    ((at_top_basis_Ioi.tendsto_right_iff).1 hf (f $ default α) trivial)).to_finset,
+  have default_in : default α ∈ small_vals := by simp,
+  obtain ⟨a₀, -, others_bigger⟩ := small_vals.exists_min_image f ⟨default α, default_in⟩,
+  use a₀,
+  intros a,
+  by_cases h : a ∈ small_vals,
+  { exact others_bigger a h },
+  have inDef : f(a₀) ≤ f (default α) := others_bigger (default α) default_in,
+  refine le_trans inDef (le_of_lt _),
+  simpa using h,
+end
+
+lemma filter.tendsto.exists_forall_ge {α β : Type*} [nonempty α] [linear_order β] [no_bot_order β]
+  {f : α → β} (hf : tendsto f cofinite at_bot) :
+  ∃ a₀, ∀ a, f a ≤ f a₀ :=
+@filter.tendsto.exists_forall_le _ (order_dual β) _ _ _ _ hf


### PR DESCRIPTION
If `tendsto f cofinite at_top`, then `f` has a minimal element. 

Co-authored-by: Heather Macbeth <25316162+hrmacbeth@users.noreply.github.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
