### PR TITLE
[Merged by Bors] - feat(data/set/basic): add `set.set_ite`

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1012,7 +1012,7 @@ ext $ λ s, subset_empty_iff
 
 /-! ### If-then-else  for sets -/
 
-/-- `ite` for sets: `set_ite t s s' ∩ t = s ∩ t`, `set_ite t s s' ∩ tᶜ = s' ∩ tᶜ`.
+/-- `ite` for sets: `set.ite t s s' ∩ t = s ∩ t`, `set.ite t s s' ∩ tᶜ = s' ∩ tᶜ`.
 Defined as `s ∩ t ∪ s' \ t`. -/
 protected def ite (t s s' : set α) : set α := s ∩ t ∪ s' \ t
 
@@ -1020,7 +1020,7 @@ protected def ite (t s s' : set α) : set α := s ∩ t ∪ s' \ t
 by rw [set.ite, union_inter_distrib_right, diff_inter_self, inter_assoc, inter_self, union_empty]
 
 @[simp] lemma ite_compl (t s s' : set α) : tᶜ.ite s s' = t.ite s' s :=
-by rw [set.ite, set_ite, diff_compl, union_comm, diff_eq]
+by rw [set.ite, set.ite, diff_compl, union_comm, diff_eq]
 
 @[simp] lemma ite_inter_compl_self (t s s' : set α) : t.ite s s' ∩ tᶜ = s' ∩ tᶜ :=
 by rw [← ite_compl, ite_inter_self]

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -890,6 +890,8 @@ theorem diff_eq_empty {s t : set α} : s \ t = ∅ ↔ s ⊆ t :=
 @[simp] theorem diff_empty {s : set α} : s \ ∅ = s :=
 ext $ assume x, ⟨assume ⟨hx, _⟩, hx, assume h, ⟨h, not_false⟩⟩
 
+@[simp] lemma diff_univ (s : set α) : s \ univ = ∅ := diff_eq_empty.2 (subset_univ s)
+
 theorem diff_diff {u : set α} : s \ t \ u = s \ (t ∪ u) :=
 ext $ by simp [not_or_distrib, and.comm, and.left_comm]
 
@@ -1007,6 +1009,50 @@ theorem monotone_powerset : monotone (powerset : set α → set (set α)) :=
 
 @[simp] theorem powerset_empty : 𝒫 (∅ : set α) = {∅} :=
 ext $ λ s, subset_empty_iff
+
+/-! ### If-then-else  for sets -/
+
+/-- `ite` for sets: `set_ite t s s' ∩ t = s ∩ t`, `set_ite t s s' ∩ tᶜ = s' ∩ tᶜ`.
+Defined as `s ∩ t ∪ s' \ t`. -/
+def set_ite (t s s' : set α) : set α := s ∩ t ∪ s' \ t
+
+@[simp] lemma set_ite_inter_self (t s s' : set α) : set_ite t s s' ∩ t = s ∩ t :=
+by rw [set_ite, union_inter_distrib_right, diff_inter_self, inter_assoc, inter_self, union_empty]
+
+@[simp] lemma set_ite_compl (t s s' : set α) : set_ite tᶜ s s' = set_ite t s' s :=
+by rw [set_ite, set_ite, diff_compl, union_comm, diff_eq]
+
+@[simp] lemma set_ite_inter_compl_self (t s s' : set α) : set_ite t s s' ∩ tᶜ = s' ∩ tᶜ :=
+by rw [← set_ite_compl, set_ite_inter_self]
+
+@[simp] lemma set_ite_diff_self (t s s' : set α) : set_ite t s s' \ t = s' \ t :=
+set_ite_inter_compl_self t s s'
+
+@[simp] lemma set_ite_same (t s : set α) : set_ite t s s = s := inter_union_diff _ _
+
+@[simp] lemma set_ite_empty (s s' : set α) : set_ite ∅ s s' = s' :=
+by simp [set_ite]
+
+@[simp] lemma set_ite_univ (s s' : set α) : set_ite univ s s' = s :=
+by simp [set_ite]
+
+lemma set_ite_mono (t : set α) {s₁ s₁' s₂ s₂' : set α} (h : s₁ ⊆ s₂) (h' : s₁' ⊆ s₂') :
+  set_ite t s₁ s₁' ⊆ set_ite t s₂ s₂' :=
+union_subset_union (inter_subset_inter_left _ h) (inter_subset_inter_left _ h')
+
+lemma set_ite_subset_union (t s s' : set α) : set_ite t s s' ⊆ s ∪ s' :=
+union_subset_union (inter_subset_left _ _) (diff_subset _ _)
+
+lemma inter_subset_set_ite (t s s' : set α) : s ∩ s' ⊆ set_ite t s s' :=
+set_ite_same t (s ∩ s') ▸ set_ite_mono _ (inter_subset_left _ _) (inter_subset_right _ _)
+
+lemma set_ite_inter_inter (t s₁ s₂ s₁' s₂' : set α) :
+  set_ite t (s₁ ∩ s₂) (s₁' ∩ s₂') = set_ite t s₁ s₁' ∩ set_ite t s₂ s₂' :=
+by { ext x, finish [set_ite, iff_def] }
+
+lemma set_ite_inter (t s₁ s₂ s : set α) :
+  set_ite t (s₁ ∩ s) (s₂ ∩ s) = set_ite t s₁ s₂ ∩ s :=
+by rw [set_ite_inter_inter, set_ite_same]
 
 /-! ### Inverse image -/
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1014,45 +1014,45 @@ ext $ λ s, subset_empty_iff
 
 /-- `ite` for sets: `set_ite t s s' ∩ t = s ∩ t`, `set_ite t s s' ∩ tᶜ = s' ∩ tᶜ`.
 Defined as `s ∩ t ∪ s' \ t`. -/
-def set_ite (t s s' : set α) : set α := s ∩ t ∪ s' \ t
+protected def ite (t s s' : set α) : set α := s ∩ t ∪ s' \ t
 
-@[simp] lemma set_ite_inter_self (t s s' : set α) : set_ite t s s' ∩ t = s ∩ t :=
-by rw [set_ite, union_inter_distrib_right, diff_inter_self, inter_assoc, inter_self, union_empty]
+@[simp] lemma ite_inter_self (t s s' : set α) : t.ite s s' ∩ t = s ∩ t :=
+by rw [set.ite, union_inter_distrib_right, diff_inter_self, inter_assoc, inter_self, union_empty]
 
-@[simp] lemma set_ite_compl (t s s' : set α) : set_ite tᶜ s s' = set_ite t s' s :=
-by rw [set_ite, set_ite, diff_compl, union_comm, diff_eq]
+@[simp] lemma ite_compl (t s s' : set α) : tᶜ.ite s s' = t.ite s' s :=
+by rw [set.ite, set_ite, diff_compl, union_comm, diff_eq]
 
-@[simp] lemma set_ite_inter_compl_self (t s s' : set α) : set_ite t s s' ∩ tᶜ = s' ∩ tᶜ :=
-by rw [← set_ite_compl, set_ite_inter_self]
+@[simp] lemma ite_inter_compl_self (t s s' : set α) : t.ite s s' ∩ tᶜ = s' ∩ tᶜ :=
+by rw [← ite_compl, ite_inter_self]
 
-@[simp] lemma set_ite_diff_self (t s s' : set α) : set_ite t s s' \ t = s' \ t :=
-set_ite_inter_compl_self t s s'
+@[simp] lemma ite_diff_self (t s s' : set α) : t.ite s s' \ t = s' \ t :=
+ite_inter_compl_self t s s'
 
-@[simp] lemma set_ite_same (t s : set α) : set_ite t s s = s := inter_union_diff _ _
+@[simp] lemma ite_same (t s : set α) : t.ite s s = s := inter_union_diff _ _
 
-@[simp] lemma set_ite_empty (s s' : set α) : set_ite ∅ s s' = s' :=
-by simp [set_ite]
+@[simp] lemma ite_empty (s s' : set α) : set.ite ∅ s s' = s' :=
+by simp [set.ite]
 
-@[simp] lemma set_ite_univ (s s' : set α) : set_ite univ s s' = s :=
-by simp [set_ite]
+@[simp] lemma ite_univ (s s' : set α) : set.ite univ s s' = s :=
+by simp [set.ite]
 
-lemma set_ite_mono (t : set α) {s₁ s₁' s₂ s₂' : set α} (h : s₁ ⊆ s₂) (h' : s₁' ⊆ s₂') :
-  set_ite t s₁ s₁' ⊆ set_ite t s₂ s₂' :=
+lemma ite_mono (t : set α) {s₁ s₁' s₂ s₂' : set α} (h : s₁ ⊆ s₂) (h' : s₁' ⊆ s₂') :
+  t.ite s₁ s₁' ⊆ t.ite s₂ s₂' :=
 union_subset_union (inter_subset_inter_left _ h) (inter_subset_inter_left _ h')
 
-lemma set_ite_subset_union (t s s' : set α) : set_ite t s s' ⊆ s ∪ s' :=
+lemma ite_subset_union (t s s' : set α) : t.ite s s' ⊆ s ∪ s' :=
 union_subset_union (inter_subset_left _ _) (diff_subset _ _)
 
-lemma inter_subset_set_ite (t s s' : set α) : s ∩ s' ⊆ set_ite t s s' :=
-set_ite_same t (s ∩ s') ▸ set_ite_mono _ (inter_subset_left _ _) (inter_subset_right _ _)
+lemma inter_subset_ite (t s s' : set α) : s ∩ s' ⊆ t.ite s s' :=
+ite_same t (s ∩ s') ▸ ite_mono _ (inter_subset_left _ _) (inter_subset_right _ _)
 
-lemma set_ite_inter_inter (t s₁ s₂ s₁' s₂' : set α) :
-  set_ite t (s₁ ∩ s₂) (s₁' ∩ s₂') = set_ite t s₁ s₁' ∩ set_ite t s₂ s₂' :=
-by { ext x, finish [set_ite, iff_def] }
+lemma ite_inter_inter (t s₁ s₂ s₁' s₂' : set α) :
+  t.ite (s₁ ∩ s₂) (s₁' ∩ s₂') = t.ite s₁ s₁' ∩ t.ite s₂ s₂' :=
+by { ext x, finish [set.ite, iff_def] }
 
-lemma set_ite_inter (t s₁ s₂ s : set α) :
-  set_ite t (s₁ ∩ s) (s₂ ∩ s) = set_ite t s₁ s₂ ∩ s :=
-by rw [set_ite_inter_inter, set_ite_same]
+lemma ite_inter (t s₁ s₂ s : set α) :
+  t.ite (s₁ ∩ s) (s₂ ∩ s) = t.ite s₁ s₂ ∩ s :=
+by rw [ite_inter_inter, ite_same]
 
 /-! ### Inverse image -/
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1010,7 +1010,7 @@ theorem monotone_powerset : monotone (powerset : set α → set (set α)) :=
 @[simp] theorem powerset_empty : 𝒫 (∅ : set α) = {∅} :=
 ext $ λ s, subset_empty_iff
 
-/-! ### If-then-else  for sets -/
+/-! ### If-then-else for sets -/
 
 /-- `ite` for sets: `set.ite t s s' ∩ t = s ∩ t`, `set.ite t s s' ∩ tᶜ = s' ∩ tᶜ`.
 Defined as `s ∩ t ∪ s' \ t`. -/

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -818,20 +818,20 @@ lemma continuous.piecewise {s : set α} {f g : α → β} [∀ a, decidable (a �
   continuous (piecewise s f g) :=
 hf.if hs hg
 
-lemma is_open_inter_union_inter_compl' {s s' t : set α}
+lemma is_open.set_ite' {s s' t : set α}
   (hs : is_open s) (hs' : is_open s') (ht : ∀ x ∈ frontier t, x ∈ s ↔ x ∈ s') :
-  is_open (s ∩ t ∪ s' ∩ tᶜ) :=
+  is_open (set_ite t s s') :=
 begin
   classical,
-  simp only [is_open_iff_continuous_mem] at *,
+  simp only [is_open_iff_continuous_mem, set_ite] at *,
   convert continuous_piecewise (λ x hx, propext (ht x hx)) hs.continuous_on hs'.continuous_on,
   ext x, by_cases hx : x ∈ t; simp [hx]
 end
 
-lemma is_open_inter_union_inter_compl {s s' t : set α} (hs : is_open s) (hs' : is_open s')
+lemma is_open.set_ite {s s' t : set α} (hs : is_open s) (hs' : is_open s')
   (ht : s ∩ frontier t = s' ∩ frontier t) :
-  is_open (s ∩ t ∪ s' ∩ tᶜ) :=
-is_open_inter_union_inter_compl' hs hs' $ λ x hx, by simpa [hx] using ext_iff.1 ht x
+  is_open (set_ite t s s') :=
+hs.set_ite' hs' $ λ x hx, by simpa [hx] using ext_iff.1 ht x
 
 lemma continuous_on_fst {s : set (α × β)} : continuous_on prod.fst s :=
 continuous_fst.continuous_on

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -818,20 +818,20 @@ lemma continuous.piecewise {s : set α} {f g : α → β} [∀ a, decidable (a �
   continuous (piecewise s f g) :=
 hf.if hs hg
 
-lemma is_open.set_ite' {s s' t : set α}
+lemma is_open.ite' {s s' t : set α}
   (hs : is_open s) (hs' : is_open s') (ht : ∀ x ∈ frontier t, x ∈ s ↔ x ∈ s') :
-  is_open (set_ite t s s') :=
+  is_open (t.ite s s') :=
 begin
   classical,
-  simp only [is_open_iff_continuous_mem, set_ite] at *,
+  simp only [is_open_iff_continuous_mem, set.ite] at *,
   convert continuous_piecewise (λ x hx, propext (ht x hx)) hs.continuous_on hs'.continuous_on,
   ext x, by_cases hx : x ∈ t; simp [hx]
 end
 
-lemma is_open.set_ite {s s' t : set α} (hs : is_open s) (hs' : is_open s')
+lemma is_open.ite {s s' t : set α} (hs : is_open s) (hs' : is_open s')
   (ht : s ∩ frontier t = s' ∩ frontier t) :
-  is_open (set_ite t s s') :=
-hs.set_ite' hs' $ λ x hx, by simpa [hx] using ext_iff.1 ht x
+  is_open (t.ite s s') :=
+hs.ite' hs' $ λ x hx, by simpa [hx] using ext_iff.1 ht x
 
 lemma continuous_on_fst {s : set (α × β)} : continuous_on prod.fst s :=
 continuous_fst.continuous_on


### PR DESCRIPTION
I'm going to use it as `source` and `target` in
`local_equiv.piecewise` and `local_homeomorph.piecewise`. There are
many non-defeq ways to define this set and I think that it's better to
have a name than to ensure that we always use the same formula.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
