### PR TITLE
[Merged by Bors] - refactor(data/{finset,multiset}): move inductions proofs on sum/prod from finset to multiset, add more induction lemmas

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -672,15 +672,9 @@ the property is multiplicative and holds on factors.
 @[to_additive "To prove a property of a sum, it suffices to prove that
 the property is additive and holds on summands."]
 lemma prod_induction {M : Type*} [comm_monoid M] (f : α → M) (p : M → Prop)
-(p_mul : ∀ a b, p a → p b → p (a * b)) (p_one : p 1) (p_s : ∀ x ∈ s, p $ f x) :
-p $ ∏ x in s, f x :=
-begin
-  refine multiset.prod_induction _ _ p_mul p_one _,
-  intros y hy,
-  obtain ⟨x, hxs, hxy⟩ := multiset.mem_map.mp hy,
-  rw ← hxy,
-  exact p_s x hxs,
-end
+  (p_mul : ∀ a b, p a → p b → p (a * b)) (p_one : p 1) (p_s : ∀ x ∈ s, p $ f x) :
+  p $ ∏ x in s, f x :=
+multiset.prod_induction _ _ p_mul p_one (multiset.forall_mem_map_iff.mpr p_s)
 
 /--
 To prove a property of a product, it suffices to prove that
@@ -691,14 +685,8 @@ the property is additive and holds on summands."]
 lemma prod_induction_nonempty {M : Type*} [comm_monoid M] (f : α → M) (p : M → Prop)
   (p_mul : ∀ a b, p a → p b → p (a * b)) (hs_nonempty : s.nonempty) (p_s : ∀ x ∈ s, p $ f x) :
   p $ ∏ x in s, f x :=
-begin
-  refine multiset.prod_induction_nonempty p p_mul _ _,
-  { simp [nonempty_iff_ne_empty.mp hs_nonempty], },
-  intros y hy,
-  obtain ⟨x, hxs, hxy⟩ := multiset.mem_map.mp hy,
-  rw ← hxy,
-  exact p_s x hxs,
-end
+multiset.prod_induction_nonempty p p_mul (by simp [nonempty_iff_ne_empty.mp hs_nonempty])
+  (multiset.forall_mem_map_iff.mpr p_s)
 
 /--
 For any product along `{0, ..., n-1}` of a commutative-monoid-valued function, we can verify that

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -675,11 +675,11 @@ lemma prod_induction {M : Type*} [comm_monoid M] (f : α → M) (p : M → Prop)
 (p_mul : ∀ a b, p a → p b → p (a * b)) (p_one : p 1) (p_s : ∀ x ∈ s, p $ f x) :
 p $ ∏ x in s, f x :=
 begin
-  classical,
-  induction s using finset.induction with x hx s hs, simpa,
-  rw finset.prod_insert, swap, assumption,
-  apply p_mul, apply p_s, simp,
-  apply hs, intros a ha, apply p_s, simp [ha],
+  refine multiset.prod_induction _ _ p_mul p_one _,
+  intros y hy,
+  obtain ⟨x, hxs, hxy⟩ := multiset.mem_map.mp hy,
+  rw ← hxy,
+  exact p_s x hxs,
 end
 
 /--
@@ -689,20 +689,15 @@ the property is multiplicative and holds on factors.
 @[to_additive "To prove a property of a sum, it suffices to prove that
 the property is additive and holds on summands."]
 lemma prod_induction_nonempty {M : Type*} [comm_monoid M] (f : α → M) (p : M → Prop)
-(p_mul : ∀ a b, p a → p b → p (a * b)) (hs_nonempty : s.nonempty) (p_s : ∀ x ∈ s, p $ f x) :
-p $ ∏ x in s, f x :=
+  (p_mul : ∀ a b, p a → p b → p (a * b)) (hs_nonempty : s.nonempty) (p_s : ∀ x ∈ s, p $ f x) :
+  p $ ∏ x in s, f x :=
 begin
-  haveI : decidable_eq α := classical.dec_eq α,
-  revert s,
-  refine finset.induction _ _,
-  { exact λ h, absurd h set.empty_not_nonempty, },
-  intros a s ha h h_nonempty hpsa,
-  by_cases hs_empty : s = ∅,
-  { simp [hs_empty, hpsa a _], },
-  { rw finset.prod_insert ha,
-    rw [← ne.def, ← nonempty_iff_ne_empty] at hs_empty,
-    exact p_mul _ _ (hpsa a (finset.mem_insert_self a s))
-      (h hs_empty (λ x hx, hpsa x (finset.mem_insert_of_mem hx))), },
+  refine multiset.prod_induction_nonempty p p_mul _ _,
+  { simp [nonempty_iff_ne_empty.mp hs_nonempty], },
+  intros y hy,
+  obtain ⟨x, hxs, hxy⟩ := multiset.mem_map.mp hy,
+  rw ← hxy,
+  exact p_s x hxs,
 end
 
 /--

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -683,6 +683,29 @@ begin
 end
 
 /--
+To prove a property of a product, it suffices to prove that
+the property is multiplicative and holds on factors.
+-/
+@[to_additive "To prove a property of a sum, it suffices to prove that
+the property is additive and holds on summands."]
+lemma prod_induction_nonempty {M : Type*} [comm_monoid M] (f : α → M) (p : M → Prop)
+(p_mul : ∀ a b, p a → p b → p (a * b)) (hs_nonempty : s.nonempty) (p_s : ∀ x ∈ s, p $ f x) :
+p $ ∏ x in s, f x :=
+begin
+  haveI : decidable_eq α := classical.dec_eq α,
+  revert s,
+  refine finset.induction _ _,
+  { exact λ h, absurd h set.empty_not_nonempty, },
+  intros a s ha h h_nonempty hpsa,
+  by_cases hs_empty : s = ∅,
+  { simp [hs_empty, hpsa a _], },
+  { rw finset.prod_insert ha,
+    rw [← ne.def, ← nonempty_iff_ne_empty] at hs_empty,
+    exact p_mul _ _ (hpsa a (finset.mem_insert_self a s))
+      (h hs_empty (λ x hx, hpsa x (finset.mem_insert_of_mem hx))), },
+end
+
+/--
 For any product along `{0, ..., n-1}` of a commutative-monoid-valued function, we can verify that
 it's equal to a different function just by checking ratios of adjacent terms.
 This is a multiplicative discrete analogue of the fundamental theorem of calculus. -/

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -31,7 +31,7 @@ lemma le_prod_nonempty_of_submultiplicative_on_pred [comm_monoid α] [ordered_co
 begin
   refine le_trans (multiset.le_prod_nonempty_of_submultiplicative_on_pred f p h_mul hp_mul _ _ _) _,
   { simp [nonempty_iff_ne_empty.mp hs_nonempty], },
-  { exact (multiset.forall_mem_map_iff).mpr hs, },
+  { exact multiset.forall_mem_map_iff.mpr hs, },
   rw multiset.map_map,
   refl,
 end

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -49,14 +49,12 @@ le_prod_nonempty_of_submultiplicative_on_pred f (λ i, true) (by simp [h_mul]) (
 @[to_additive le_sum_of_subadditive_on_pred]
 lemma le_prod_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
   (f : α → β) (h_one : f 1 = 1) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
-  (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : γ → α) {s : finset γ}
-  (hs : ∀ x, x ∈ s → p (g x)) :
+  (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : γ → α) {s : finset γ} (hs : ∀ x, x ∈ s → p (g x)) :
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 begin
   by_cases hs_nonempty : s.nonempty,
   { exact le_prod_nonempty_of_submultiplicative_on_pred f p h_mul hp_mul g s hs_nonempty hs, },
-  { rw not_nonempty_iff_eq_empty at hs_nonempty,
-    simp [hs_nonempty, h_one], },
+  { simp [not_nonempty_iff_eq_empty.mp hs_nonempty, h_one], },
 end
 
 @[to_additive le_sum_of_subadditive]
@@ -65,7 +63,7 @@ lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 begin
   refine le_trans (multiset.le_prod_of_submultiplicative f h_one h_mul _) _,
-  rw [multiset.map_map],
+  rw multiset.map_map,
   refl,
 end
 

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -31,10 +31,7 @@ lemma le_prod_nonempty_of_submultiplicative_on_pred [comm_monoid α] [ordered_co
 begin
   refine le_trans (multiset.le_prod_nonempty_of_submultiplicative_on_pred f p h_mul hp_mul _ _ _) _,
   { simp [nonempty_iff_ne_empty.mp hs_nonempty], },
-  { intros y hy,
-    obtain ⟨x, hxs, hxy⟩ := multiset.mem_map.mp hy,
-    rw ← hxy,
-    exact hs x hxs, },
+  { exact (multiset.forall_mem_map_iff).mpr hs, },
   rw multiset.map_map,
   refl,
 end
@@ -48,7 +45,7 @@ le_prod_nonempty_of_submultiplicative_on_pred f (λ i, true) (by simp [h_mul]) (
 
 @[to_additive le_sum_of_subadditive_on_pred]
 lemma le_prod_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_one : f 1 = 1) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
+  (f : α → β) (p : α → Prop) (h_one : f 1 = 1) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
   (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : γ → α) {s : finset γ} (hs : ∀ x, x ∈ s → p (g x)) :
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 begin

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -69,13 +69,19 @@ end
 lemma le_prod_of_submultiplicative' [comm_monoid α] [ordered_comm_monoid β]
   (f : α → β) (h_one : f 1 ≤ 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
-le_prod_of_submultiplicative_on_pred f h_one (λ i, true) (by simp [h_mul]) (by simp) g (by simp)
+begin
+  refine le_trans (multiset.le_prod_of_submultiplicative' f h_one h_mul _) _,
+  rw [multiset.map_map],
+  refl,
+end
 
 @[to_additive le_sum_of_subadditive]
 lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
   (f : α → β) (h_one : f 1 = 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 le_prod_of_submultiplicative' f (le_of_eq h_one) h_mul s g
+
+#print axioms le_prod_of_submultiplicative
 
 lemma abs_sum_le_sum_abs [linear_ordered_field α] {f : β → α} {s : finset β} :
   abs (∑ x in s, f x) ≤ ∑ x in s, abs (f x) :=

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -22,56 +22,66 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 namespace finset
 variables {s s₁ s₂ : finset α} {a : α} {f g : α → β}
 
-@[to_additive le_sum_of_subadditive]
-lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_zero : f 1 = 1) (h_add : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
+@[to_additive le_sum_of_subadditive_on_pred]
+lemma le_prod_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
+  (f : α → β) (h_one : f 1 ≤ 1) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
+  (hp_mul : ∀ x y, p x → p y → p (x * y)) (hp_one : p 1) (g : γ → α) {s : finset γ}
+  (hs : ∀ x, x ∈ s → p (g x)) :
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 begin
-  refine le_trans (multiset.le_prod_of_submultiplicative f h_zero h_add _) _,
-  rw [multiset.map_map],
-  refl
-end
-
-lemma le_sum_of_subadditive_on_pred [add_comm_monoid α] [ordered_add_comm_monoid β]
-  (f : α → β) (h_zero : f 0 = 0) (p : α → Prop) (h_add : ∀ x y, p x → p y → f (x + y) ≤ f x + f y)
-  (hp_add : ∀ x y, p x → p y → p (x + y)) (hp_zero : p 0) (g : γ → α) :
-  ∀ (s : finset γ) (hs : ∀ x, x ∈ s → p (g x)), f (∑ x in s, g x) ≤ ∑ x in s, f (g x) :=
-begin
+  revert s,
   haveI : decidable_eq γ := classical.dec_eq γ,
-  refine finset.induction (by simp [h_zero]) _,
+  refine finset.induction (by simp [h_one]) _,
   intros a s ha hs hsa,
-  rw finset.sum_insert ha,
+  simp_rw finset.prod_insert ha,
   have hsa_restrict : (∀ x, x ∈ s → p (g x)), from λ x hx, hsa x (finset.mem_insert_of_mem hx),
-  have hp_sup : p ∑ x in s, g x, from finset.sum_induction g p hp_add hp_zero hsa_restrict,
+  have hp_sup : p ∏ x in s, g x, from finset.prod_induction g p hp_mul hp_one hsa_restrict,
   have hp_ga : p (g a), from hsa a (finset.mem_insert_self a s),
-  refine le_trans (h_add (g a) _ hp_ga hp_sup) _,
-  rw finset.sum_insert ha,
-  exact add_le_add_left (hs hsa_restrict) _,
+  exact le_trans (h_mul (g a) _ hp_ga hp_sup) (mul_le_mul_left' (hs hsa_restrict) _),
 end
 
-lemma le_sum_nonempty_of_subadditive_on_pred [add_comm_monoid α] [ordered_add_comm_monoid β]
-  (f : α → β) (p : α → Prop) (h_add : ∀ x y, p x → p y → f (x + y) ≤ f x + f y)
-  (hp_add : ∀ x y, p x → p y → p (x + y)) (g : γ → α) :
+@[to_additive le_sum_of_subadditive']
+lemma le_prod_of_submultiplicative' [comm_monoid α] [ordered_comm_monoid β]
+  (f : α → β) (h_one : f 1 ≤ 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
+  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
+le_prod_of_submultiplicative_on_pred f h_one (λ i, true) (by simp [h_mul]) (by simp) dec_trivial g
+  (by simp)
+
+@[to_additive le_sum_of_subadditive]
+lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
+  (f : α → β) (h_one : f 1 = 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
+  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
+le_prod_of_submultiplicative' f (le_of_eq h_one) h_mul s g
+
+@[to_additive le_sum_nonempty_of_subadditive_on_pred]
+lemma le_prod_nonempty_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
+  (f : α → β) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
+  (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : γ → α) :
   ∀ (s : finset γ) (hs_nonempty : s.nonempty) (hs : ∀ x, x ∈ s → p (g x)),
-    f (∑ x in s, g x) ≤ ∑ x in s, f (g x) :=
+    f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 begin
   haveI : decidable_eq γ := classical.dec_eq γ,
   refine finset.induction _ _,
   { exact λ h, absurd h set.empty_not_nonempty, },
   rintros a s ha hs hsa_nonempty hsa_prop,
-  rw finset.sum_insert ha,
+  simp_rw finset.prod_insert ha,
   by_cases hs_empty : s = ∅,
-  { simp only [hs_empty, insert_emptyc_eq, add_zero, finset.sum_empty, forall_eq,
-      finset.mem_singleton, finset.sum_singleton], },
+  { simp only [hs_empty, insert_emptyc_eq, mul_one, finset.prod_empty, forall_eq,
+      finset.mem_singleton, finset.prod_singleton], },
   rw [← ne.def, ← nonempty_iff_ne_empty] at hs_empty,
   have hsa_restrict : (∀ x, x ∈ s → p (g x)), from λ x hx, hsa_prop x (finset.mem_insert_of_mem hx),
-  have hp_sup : p ∑ x in s, g x,
-    from finset.sum_induction_nonempty g p hp_add hs_empty hsa_restrict,
+  have hp_sup : p ∏ x in s, g x,
+    from finset.prod_induction_nonempty g p hp_mul hs_empty hsa_restrict,
   have hp_ga : p (g a), from hsa_prop a (finset.mem_insert_self a s),
-  refine le_trans (h_add (g a) _ hp_ga hp_sup) _,
-  rw finset.sum_insert ha,
-  exact add_le_add_left (hs hs_empty hsa_restrict) _,
+  exact le_trans (h_mul (g a) _ hp_ga hp_sup) (mul_le_mul_left' (hs hs_empty hsa_restrict) _),
 end
+
+@[to_additive le_sum_nonempty_of_subadditive]
+lemma le_prod_nonempty_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
+  (f : α → β) (h_mul : ∀x y, f (x * y) ≤ f x * f y) {s : finset γ} (hs : s.nonempty) (g : γ → α) :
+  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
+le_prod_nonempty_of_submultiplicative_on_pred f (λ i, true) (by simp [h_mul]) (by simp) g s hs
+  (by simp)
 
 lemma abs_sum_le_sum_abs [linear_ordered_field α] {f : β → α} {s : finset β} :
   abs (∑ x in s, f x) ≤ ∑ x in s, abs (f x) :=

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -25,24 +25,18 @@ variables {s s₁ s₂ : finset α} {a : α} {f g : α → β}
 @[to_additive le_sum_nonempty_of_subadditive_on_pred]
 lemma le_prod_nonempty_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
   (f : α → β) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
-  (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : γ → α) :
-  ∀ (s : finset γ) (hs_nonempty : s.nonempty) (hs : ∀ x, x ∈ s → p (g x)),
-    f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
+  (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : γ → α) (s : finset γ) (hs_nonempty : s.nonempty)
+  (hs : ∀ x, x ∈ s → p (g x)) :
+  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 begin
-  haveI : decidable_eq γ := classical.dec_eq γ,
-  refine finset.induction _ _,
-  { exact λ h, absurd h set.empty_not_nonempty, },
-  rintros a s ha hs hsa_nonempty hsa_prop,
-  simp_rw finset.prod_insert ha,
-  by_cases hs_empty : s = ∅,
-  { simp only [hs_empty, insert_emptyc_eq, mul_one, finset.prod_empty, forall_eq,
-      finset.mem_singleton, finset.prod_singleton], },
-  rw [← ne.def, ← nonempty_iff_ne_empty] at hs_empty,
-  have hsa_restrict : (∀ x, x ∈ s → p (g x)), from λ x hx, hsa_prop x (finset.mem_insert_of_mem hx),
-  have hp_sup : p ∏ x in s, g x,
-    from finset.prod_induction_nonempty g p hp_mul hs_empty hsa_restrict,
-  have hp_ga : p (g a), from hsa_prop a (finset.mem_insert_self a s),
-  exact le_trans (h_mul (g a) _ hp_ga hp_sup) (mul_le_mul_left' (hs hs_empty hsa_restrict) _),
+  refine le_trans (multiset.le_prod_nonempty_of_submultiplicative_on_pred f p h_mul hp_mul _ _ _) _,
+  { simp [nonempty_iff_ne_empty.mp hs_nonempty], },
+  { intros y hy,
+    obtain ⟨x, hxs, hxy⟩ := multiset.mem_map.mp hy,
+    rw ← hxy,
+    exact hs x hxs, },
+  rw multiset.map_map,
+  refl,
 end
 
 @[to_additive le_sum_nonempty_of_subadditive]

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -38,7 +38,7 @@ end
 
 @[to_additive le_sum_nonempty_of_subadditive]
 lemma le_prod_nonempty_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_mul : ∀x y, f (x * y) ≤ f x * f y) {s : finset γ} (hs : s.nonempty) (g : γ → α) :
+  (f : α → β) (h_mul : ∀ x y, f (x * y) ≤ f x * f y) {s : finset γ} (hs : s.nonempty) (g : γ → α) :
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 le_prod_nonempty_of_submultiplicative_on_pred f (λ i, true) (by simp [h_mul]) (by simp) g s hs
   (by simp)
@@ -56,7 +56,7 @@ end
 
 @[to_additive le_sum_of_subadditive]
 lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_one : f 1 = 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
+  (f : α → β) (h_one : f 1 = 1) (h_mul : ∀ x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 begin
   refine le_trans (multiset.le_prod_of_submultiplicative f h_one h_mul _) _,

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -48,7 +48,7 @@ le_prod_nonempty_of_submultiplicative_on_pred f (λ i, true) (by simp [h_mul]) (
 
 @[to_additive le_sum_of_subadditive_on_pred]
 lemma le_prod_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_one : f 1 ≤ 1) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
+  (f : α → β) (h_one : f 1 = 1) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
   (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : γ → α) {s : finset γ}
   (hs : ∀ x, x ∈ s → p (g x)) :
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
@@ -59,21 +59,15 @@ begin
     simp [hs_nonempty, h_one], },
 end
 
-@[to_additive le_sum_of_subadditive']
-lemma le_prod_of_submultiplicative' [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_one : f 1 ≤ 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
-  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
-begin
-  refine le_trans (multiset.le_prod_of_submultiplicative' f h_one h_mul _) _,
-  rw [multiset.map_map],
-  refl,
-end
-
 @[to_additive le_sum_of_subadditive]
 lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
   (f : α → β) (h_one : f 1 = 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
-le_prod_of_submultiplicative' f (le_of_eq h_one) h_mul s g
+begin
+  refine le_trans (multiset.le_prod_of_submultiplicative f h_one h_mul _) _,
+  rw [multiset.map_map],
+  refl,
+end
 
 lemma abs_sum_le_sum_abs [linear_ordered_field α] {f : β → α} {s : finset β} :
   abs (∑ x in s, f x) ≤ ∑ x in s, abs (f x) :=

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -22,37 +22,6 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 namespace finset
 variables {s s₁ s₂ : finset α} {a : α} {f g : α → β}
 
-@[to_additive le_sum_of_subadditive_on_pred]
-lemma le_prod_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_one : f 1 ≤ 1) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
-  (hp_mul : ∀ x y, p x → p y → p (x * y)) (hp_one : p 1) (g : γ → α) {s : finset γ}
-  (hs : ∀ x, x ∈ s → p (g x)) :
-  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
-begin
-  revert s,
-  haveI : decidable_eq γ := classical.dec_eq γ,
-  refine finset.induction (by simp [h_one]) _,
-  intros a s ha hs hsa,
-  simp_rw finset.prod_insert ha,
-  have hsa_restrict : (∀ x, x ∈ s → p (g x)), from λ x hx, hsa x (finset.mem_insert_of_mem hx),
-  have hp_sup : p ∏ x in s, g x, from finset.prod_induction g p hp_mul hp_one hsa_restrict,
-  have hp_ga : p (g a), from hsa a (finset.mem_insert_self a s),
-  exact le_trans (h_mul (g a) _ hp_ga hp_sup) (mul_le_mul_left' (hs hsa_restrict) _),
-end
-
-@[to_additive le_sum_of_subadditive']
-lemma le_prod_of_submultiplicative' [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_one : f 1 ≤ 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
-  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
-le_prod_of_submultiplicative_on_pred f h_one (λ i, true) (by simp [h_mul]) (by simp) dec_trivial g
-  (by simp)
-
-@[to_additive le_sum_of_subadditive]
-lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_one : f 1 = 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
-  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
-le_prod_of_submultiplicative' f (le_of_eq h_one) h_mul s g
-
 @[to_additive le_sum_nonempty_of_subadditive_on_pred]
 lemma le_prod_nonempty_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
   (f : α → β) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
@@ -82,6 +51,31 @@ lemma le_prod_nonempty_of_submultiplicative [comm_monoid α] [ordered_comm_monoi
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 le_prod_nonempty_of_submultiplicative_on_pred f (λ i, true) (by simp [h_mul]) (by simp) g s hs
   (by simp)
+
+@[to_additive le_sum_of_subadditive_on_pred]
+lemma le_prod_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
+  (f : α → β) (h_one : f 1 ≤ 1) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
+  (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : γ → α) {s : finset γ}
+  (hs : ∀ x, x ∈ s → p (g x)) :
+  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
+begin
+  by_cases hs_nonempty : s.nonempty,
+  { exact le_prod_nonempty_of_submultiplicative_on_pred f p h_mul hp_mul g s hs_nonempty hs, },
+  { rw not_nonempty_iff_eq_empty at hs_nonempty,
+    simp [hs_nonempty, h_one], },
+end
+
+@[to_additive le_sum_of_subadditive']
+lemma le_prod_of_submultiplicative' [comm_monoid α] [ordered_comm_monoid β]
+  (f : α → β) (h_one : f 1 ≤ 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
+  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
+le_prod_of_submultiplicative_on_pred f h_one (λ i, true) (by simp [h_mul]) (by simp) g (by simp)
+
+@[to_additive le_sum_of_subadditive]
+lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
+  (f : α → β) (h_one : f 1 = 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
+  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
+le_prod_of_submultiplicative' f (le_of_eq h_one) h_mul s g
 
 lemma abs_sum_le_sum_abs [linear_ordered_field α] {f : β → α} {s : finset β} :
   abs (∑ x in s, f x) ≤ ∑ x in s, abs (f x) :=

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -75,8 +75,6 @@ lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
   f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 le_prod_of_submultiplicative' f (le_of_eq h_one) h_mul s g
 
-#print axioms le_prod_of_submultiplicative
-
 lemma abs_sum_le_sum_abs [linear_ordered_field α] {f : β → α} {s : finset β} :
   abs (∑ x in s, f x) ≤ ∑ x in s, abs (f x) :=
 le_sum_of_subadditive _ abs_zero abs_add s f

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -31,10 +31,11 @@ begin
   refl
 end
 
-lemma prop_sum_of_additive {α γ} [add_comm_monoid α] [decidable_eq γ]
+lemma prop_sum_of_additive {α γ} [add_comm_monoid α]
   (p : α → Prop) (hp_add : ∀ x y, p x → p y → p (x + y)) (hp_zero : p 0) (g : γ → α) :
   ∀ (s : finset γ) (hs : ∀ x, x ∈ s → p (g x)), p (∑ x in s, g x) :=
 begin
+  haveI : decidable_eq γ := classical.dec_eq γ,
   refine finset.induction (by simp [hp_zero]) _,
   intros a s ha h hpsa,
   rw finset.sum_insert ha,
@@ -42,10 +43,11 @@ begin
     (h (λ x hx, hpsa x (finset.mem_insert_of_mem hx))),
 end
 
-lemma prop_sum_nonempty_of_additive {α γ} [add_comm_monoid α] [decidable_eq γ]
+lemma prop_sum_nonempty_of_additive {α γ} [add_comm_monoid α]
   (p : α → Prop) (hp_add : ∀ x y, p x → p y → p (x + y)) (g : γ → α) :
   ∀ (s : finset γ) (hs_nonempty : s ≠ ∅) (hs : ∀ x, x ∈ s → p (g x)), p (∑ x in s, g x) :=
 begin
+  haveI : decidable_eq γ := classical.dec_eq γ,
   refine finset.induction _ _,
   { exact λ h, absurd rfl h, },
   intros a s ha h h_nonempty hpsa,
@@ -57,11 +59,11 @@ begin
 end
 
 lemma le_sum_of_subadditive_on_prop {α β γ} [add_comm_monoid α] [ordered_add_comm_monoid β]
-  [decidable_eq γ] (f : α → β) (h_zero : f 0 = 0) (p : α → Prop)
-  (h_add : ∀ x y, p x → p y → f (x + y) ≤ f x + f y)
+  (f : α → β) (h_zero : f 0 = 0) (p : α → Prop) (h_add : ∀ x y, p x → p y → f (x + y) ≤ f x + f y)
   (hp_add : ∀ x y, p x → p y → p (x + y)) (hp_zero : p 0) (g : γ → α) :
   ∀ (s : finset γ) (hs : ∀ x, x ∈ s → p (g x)), f (∑ x in s, g x) ≤ ∑ x in s, f (g x) :=
 begin
+  haveI : decidable_eq γ := classical.dec_eq γ,
   refine finset.induction (by simp [h_zero]) _,
   intros a s ha hs hsa,
   rw finset.sum_insert ha,
@@ -76,11 +78,12 @@ begin
 end
 
 lemma le_sum_nonempty_of_subadditive_on_prop {α β γ} [add_comm_monoid α] [ordered_add_comm_monoid β]
-  [decidable_eq γ] (f : α → β) (p : α → Prop) (h_add : ∀ x y, p x → p y → f (x + y) ≤ f x + f y)
+  (f : α → β) (p : α → Prop) (h_add : ∀ x y, p x → p y → f (x + y) ≤ f x + f y)
   (hp_add : ∀ x y, p x → p y → p (x + y)) (g : γ → α) :
   ∀ (s : finset γ) (hs_nonempty : s ≠ ∅) (hs : ∀ x, x ∈ s → p (g x)),
     f (∑ x in s, g x) ≤ ∑ x in s, f (g x) :=
 begin
+  haveI : decidable_eq γ := classical.dec_eq γ,
   refine finset.induction _ _,
   { exact λ h, absurd rfl h, },
   rintros a s ha hs hsa_nonempty hsa_prop,

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -22,43 +22,17 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 namespace finset
 variables {s s₁ s₂ : finset α} {a : α} {f g : α → β}
 
-lemma le_sum_of_subadditive [add_comm_monoid α] [ordered_add_comm_monoid β]
-  (f : α → β) (h_zero : f 0 = 0) (h_add : ∀x y, f (x + y) ≤ f x + f y) (s : finset γ) (g : γ → α) :
-  f (∑ x in s, g x) ≤ ∑ x in s, f (g x) :=
+@[to_additive le_sum_of_subadditive]
+lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
+  (f : α → β) (h_zero : f 1 = 1) (h_add : ∀x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
+  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
 begin
-  refine le_trans (multiset.le_sum_of_subadditive f h_zero h_add _) _,
+  refine le_trans (multiset.le_prod_of_submultiplicative f h_zero h_add _) _,
   rw [multiset.map_map],
   refl
 end
 
-lemma prop_sum_of_additive {α γ} [add_comm_monoid α]
-  (p : α → Prop) (hp_add : ∀ x y, p x → p y → p (x + y)) (hp_zero : p 0) (g : γ → α) :
-  ∀ (s : finset γ) (hs : ∀ x, x ∈ s → p (g x)), p (∑ x in s, g x) :=
-begin
-  haveI : decidable_eq γ := classical.dec_eq γ,
-  refine finset.induction (by simp [hp_zero]) _,
-  intros a s ha h hpsa,
-  rw finset.sum_insert ha,
-  exact hp_add _ _ (hpsa a (finset.mem_insert_self a s))
-    (h (λ x hx, hpsa x (finset.mem_insert_of_mem hx))),
-end
-
-lemma prop_sum_nonempty_of_additive {α γ} [add_comm_monoid α]
-  (p : α → Prop) (hp_add : ∀ x y, p x → p y → p (x + y)) (g : γ → α) :
-  ∀ (s : finset γ) (hs_nonempty : s ≠ ∅) (hs : ∀ x, x ∈ s → p (g x)), p (∑ x in s, g x) :=
-begin
-  haveI : decidable_eq γ := classical.dec_eq γ,
-  refine finset.induction _ _,
-  { exact λ h, absurd rfl h, },
-  intros a s ha h h_nonempty hpsa,
-  by_cases hs_empty : s = ∅,
-  { simp [hs_empty, hpsa a _], },
-  { rw finset.sum_insert ha,
-    exact hp_add _ _ (hpsa a (finset.mem_insert_self a s))
-      (h hs_empty (λ x hx, hpsa x (finset.mem_insert_of_mem hx))), },
-end
-
-lemma le_sum_of_subadditive_on_prop {α β γ} [add_comm_monoid α] [ordered_add_comm_monoid β]
+lemma le_sum_of_subadditive_on_pred [add_comm_monoid α] [ordered_add_comm_monoid β]
   (f : α → β) (h_zero : f 0 = 0) (p : α → Prop) (h_add : ∀ x y, p x → p y → f (x + y) ≤ f x + f y)
   (hp_add : ∀ x y, p x → p y → p (x + y)) (hp_zero : p 0) (g : γ → α) :
   ∀ (s : finset γ) (hs : ∀ x, x ∈ s → p (g x)), f (∑ x in s, g x) ≤ ∑ x in s, f (g x) :=
@@ -67,34 +41,32 @@ begin
   refine finset.induction (by simp [h_zero]) _,
   intros a s ha hs hsa,
   rw finset.sum_insert ha,
-  have hsa_restrict : (∀ (x : γ), x ∈ s → p (g x)),
-    from λ x hx, hsa x (finset.mem_insert_of_mem hx),
-  have hp_sup : p ∑ (x : γ) in s, g x,
-    from finset.prop_sum_of_additive p hp_add hp_zero g s hsa_restrict,
+  have hsa_restrict : (∀ x, x ∈ s → p (g x)), from λ x hx, hsa x (finset.mem_insert_of_mem hx),
+  have hp_sup : p ∑ x in s, g x, from finset.sum_induction g p hp_add hp_zero hsa_restrict,
   have hp_ga : p (g a), from hsa a (finset.mem_insert_self a s),
   refine le_trans (h_add (g a) _ hp_ga hp_sup) _,
   rw finset.sum_insert ha,
   exact add_le_add_left (hs hsa_restrict) _,
 end
 
-lemma le_sum_nonempty_of_subadditive_on_prop {α β γ} [add_comm_monoid α] [ordered_add_comm_monoid β]
+lemma le_sum_nonempty_of_subadditive_on_pred [add_comm_monoid α] [ordered_add_comm_monoid β]
   (f : α → β) (p : α → Prop) (h_add : ∀ x y, p x → p y → f (x + y) ≤ f x + f y)
   (hp_add : ∀ x y, p x → p y → p (x + y)) (g : γ → α) :
-  ∀ (s : finset γ) (hs_nonempty : s ≠ ∅) (hs : ∀ x, x ∈ s → p (g x)),
+  ∀ (s : finset γ) (hs_nonempty : s.nonempty) (hs : ∀ x, x ∈ s → p (g x)),
     f (∑ x in s, g x) ≤ ∑ x in s, f (g x) :=
 begin
   haveI : decidable_eq γ := classical.dec_eq γ,
   refine finset.induction _ _,
-  { exact λ h, absurd rfl h, },
+  { exact λ h, absurd h set.empty_not_nonempty, },
   rintros a s ha hs hsa_nonempty hsa_prop,
   rw finset.sum_insert ha,
   by_cases hs_empty : s = ∅,
   { simp only [hs_empty, insert_emptyc_eq, add_zero, finset.sum_empty, forall_eq,
       finset.mem_singleton, finset.sum_singleton], },
-  have hsa_restrict : (∀ (x : γ), x ∈ s → p (g x)),
-    from λ x hx, hsa_prop x (finset.mem_insert_of_mem hx),
-  have hp_sup : p ∑ (x : γ) in s, g x,
-    from finset.prop_sum_nonempty_of_additive p hp_add g s hs_empty hsa_restrict,
+  rw [← ne.def, ← nonempty_iff_ne_empty] at hs_empty,
+  have hsa_restrict : (∀ x, x ∈ s → p (g x)), from λ x hx, hsa_prop x (finset.mem_insert_of_mem hx),
+  have hp_sup : p ∑ x in s, g x,
+    from finset.sum_induction_nonempty g p hp_add hs_empty hsa_restrict,
   have hp_ga : p (g a), from hsa_prop a (finset.mem_insert_self a s),
   refine le_trans (h_add (g a) _ hp_ga hp_sup) _,
   rw finset.sum_insert ha,

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -933,10 +933,11 @@ end
 @[to_additive le_sum_nonempty_of_subadditive_on_pred]
 lemma le_prod_nonempty_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
   (f : α → β) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
-  (hp_mul : ∀ x y, p x → p y → p (x * y)) :
-  ∀ (s : multiset α) (hs_nonempty : s ≠ ∅) (hs : ∀ x, x ∈ s → p x),
-    f s.prod ≤ (s.map f).prod :=
+  (hp_mul : ∀ x y, p x → p y → p (x * y)) (s : multiset α) (hs_nonempty : s ≠ ∅)
+  (hs : ∀ x, x ∈ s → p x) :
+  f s.prod ≤ (s.map f).prod :=
 begin
+  revert s,
   refine multiset.induction _ _,
   { intro h,
     exfalso,

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -754,7 +754,7 @@ theorem foldl_swap (f : β → α → β) (H : right_commutative f) (b : β) (s 
 
 lemma foldr_induction' (f : α → β → β) (H : left_commutative f) (x : β) (q : α → Prop)
   (p : β → Prop) (s : multiset α) (hpqf : ∀ a b, q a → p b → p (f a b)) (px : p x)
-  (q_s : ∀ y ∈ s, q y) :
+  (q_s : ∀ a ∈ s, q a) :
   p (foldr f H x s) :=
 begin
   revert s,
@@ -766,13 +766,13 @@ begin
 end
 
 lemma foldr_induction (f : α → α → α) (H : left_commutative f) (x : α) (p : α → Prop)
-  (s : multiset α) (p_f : ∀ a b, p a → p b → p (f a b)) (px : p x) (p_s : ∀ y ∈ s, p y) :
+  (s : multiset α) (p_f : ∀ a b, p a → p b → p (f a b)) (px : p x) (p_s : ∀ a ∈ s, p a) :
   p (foldr f H x s) :=
 foldr_induction' f H x p p s p_f px p_s
 
 lemma foldl_induction' (f : β → α → β) (H : right_commutative f) (x : β) (q : α → Prop)
   (p : β → Prop) (s : multiset α) (hpqf : ∀ a b, q a → p b → p (f b a)) (px : p x)
-  (q_s : ∀ y ∈ s, q y) :
+  (q_s : ∀ a ∈ s, q a) :
   p (foldl f H x s) :=
 begin
   rw foldl_swap,
@@ -780,7 +780,7 @@ begin
 end
 
 lemma foldl_induction (f : α → α → α) (H : right_commutative f) (x : α) (p : α → Prop)
-  (s : multiset α) (p_f : ∀ a b, p a → p b → p (f b a)) (px : p x) (p_s : ∀ y ∈ s, p y) :
+  (s : multiset α) (p_f : ∀ a b, p a → p b → p (f b a)) (px : p x) (p_s : ∀ a ∈ s, p a) :
   p (foldl f H x s) :=
 foldl_induction' f H x p p s p_f px p_s
 
@@ -932,7 +932,7 @@ quotient.induction_on m $ λ l, by simpa using list.sum_eq_zero_iff l
 
 @[to_additive]
 lemma prod_induction {M : Type*} [comm_monoid M] (p : M → Prop) (s : multiset M)
-  (p_mul : ∀ a b, p a → p b → p (a * b)) (p_one : p 1) (p_s : ∀ x ∈ s, p x) :
+  (p_mul : ∀ a b, p a → p b → p (a * b)) (p_one : p 1) (p_s : ∀ a ∈ s, p a) :
   p s.prod :=
 begin
   rw prod_eq_foldr,
@@ -942,8 +942,8 @@ end
 @[to_additive le_sum_of_subadditive_on_pred]
 lemma le_prod_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
   (f : α → β) (p : α → Prop) (h_one : f 1 = 1) (hp_one : p 1)
-  (h_mul : ∀x y, p x → p y → f (x * y) ≤ f x * f y)
-  (hp_mul : ∀ x y, p x → p y → p (x * y)) (s : multiset α) (hps : ∀ x, x ∈ s → p x) :
+  (h_mul : ∀ a b, p a → p b → f (a * b) ≤ f a * f b)
+  (hp_mul : ∀ a b, p a → p b → p (a * b)) (s : multiset α) (hps : ∀ a, a ∈ s → p a) :
   f s.prod ≤ (s.map f).prod :=
 begin
   revert s,
@@ -958,7 +958,7 @@ end
 
 @[to_additive le_sum_of_subadditive]
 lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_one : f 1 = 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : multiset α) :
+  (f : α → β) (h_one : f 1 = 1) (h_mul : ∀ a b, f (a * b) ≤ f a * f b) (s : multiset α) :
   f s.prod ≤ (s.map f).prod :=
 le_prod_of_submultiplicative_on_pred f (λ i, true) h_one trivial (λ x y _ _ , h_mul x y) (by simp)
   s (by simp)
@@ -966,7 +966,7 @@ le_prod_of_submultiplicative_on_pred f (λ i, true) h_one trivial (λ x y _ _ , 
 @[to_additive]
 lemma prod_induction_nonempty {M : Type*} [comm_monoid M] (p : M → Prop)
   (p_mul : ∀ a b, p a → p b → p (a * b)) {s : multiset M} (hs_nonempty : s ≠ ∅)
-  (p_s : ∀ x ∈ s, p x) :
+  (p_s : ∀ a ∈ s, p a) :
   p s.prod :=
 begin
   revert s,
@@ -984,9 +984,9 @@ end
 
 @[to_additive le_sum_nonempty_of_subadditive_on_pred]
 lemma le_prod_nonempty_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
-  (hp_mul : ∀ x y, p x → p y → p (x * y)) (s : multiset α) (hs_nonempty : s ≠ ∅)
-  (hs : ∀ x, x ∈ s → p x) :
+  (f : α → β) (p : α → Prop) (h_mul : ∀ a b, p a → p b → f (a * b) ≤ f a * f b)
+  (hp_mul : ∀ a b, p a → p b → p (a * b)) (s : multiset α) (hs_nonempty : s ≠ ∅)
+  (hs : ∀ a, a ∈ s → p a) :
   f s.prod ≤ (s.map f).prod :=
 begin
   revert s,
@@ -1007,7 +1007,7 @@ end
 
 @[to_additive le_sum_nonempty_of_subadditive]
 lemma le_prod_nonempty_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_mul : ∀ x y, f (x * y) ≤ f x * f y) (s : multiset α) (hs_nonempty : s ≠ ∅) :
+  (f : α → β) (h_mul : ∀ a b, f (a * b) ≤ f a * f b) (s : multiset α) (hs_nonempty : s ≠ ∅) :
   f s.prod ≤ (s.map f).prod :=
 le_prod_nonempty_of_submultiplicative_on_pred f (λ i, true) (by simp [h_mul]) (by simp) s
   hs_nonempty (by simp)

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -953,19 +953,13 @@ begin
   exact (h_mul a _ hp_a hp_sup).trans (mul_le_mul_left' (hs hs_empty hsa_restrict) _),
 end
 
-@[to_additive le_sum_of_subadditive']
-lemma le_prod_of_submultiplicative' [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_one : f 1 ≤ 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : multiset α) :
-  f s.prod ≤ (s.map f).prod :=
-multiset.induction_on s h_one $
-  assume a s ih, by rw [prod_cons, map_cons, prod_cons];
-    from le_trans (h_mul a s.prod) (mul_le_mul_left' ih _)
-
 @[to_additive le_sum_of_subadditive]
 lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
   (f : α → β) (h_one : f 1 = 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : multiset α) :
   f s.prod ≤ (s.map f).prod :=
-le_prod_of_submultiplicative' f (le_of_eq h_one) h_mul s
+multiset.induction_on s (le_of_eq h_one) $
+  assume a s ih, by rw [prod_cons, map_cons, prod_cons];
+    from le_trans (h_mul a s.prod) (mul_le_mul_left' ih _)
 
 lemma abs_sum_le_sum_abs [linear_ordered_field α] {s : multiset α} :
   abs s.sum ≤ (s.map abs).sum :=

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -898,12 +898,13 @@ lemma sum_eq_zero_iff [canonically_ordered_add_monoid α] {m : multiset α} :
   m.sum = 0 ↔ ∀ x ∈ m, x = (0 : α) :=
 quotient.induction_on m $ λ l, by simpa using list.sum_eq_zero_iff l
 
-lemma le_sum_of_subadditive [add_comm_monoid α] [ordered_add_comm_monoid β]
-  (f : α → β) (h_zero : f 0 = 0) (h_add : ∀x y, f (x + y) ≤ f x + f y) (s : multiset α) :
-  f s.sum ≤ (s.map f).sum :=
+@[to_additive le_sum_of_subadditive]
+lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
+  (f : α → β) (h_zero : f 1 = 1) (h_mul : ∀x y, f (x * y) ≤ f x * f y) (s : multiset α) :
+  f s.prod ≤ (s.map f).prod :=
 multiset.induction_on s (le_of_eq h_zero) $
-  assume a s ih, by rw [sum_cons, map_cons, sum_cons];
-    from le_trans (h_add a s.sum) (add_le_add_left ih _)
+  assume a s ih, by rw [prod_cons, map_cons, prod_cons];
+    from le_trans (h_mul a s.prod) (mul_le_mul_left' ih _)
 
 lemma abs_sum_le_sum_abs [linear_ordered_field α] {s : multiset α} :
   abs s.sum ≤ (s.map abs).sum :=

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -557,7 +557,7 @@ lemma finset.measurable_prod {ι : Type*} [comm_monoid α] [has_continuous_mul �
   measurable (λ a, ∏ i in s, f i a) :=
 begin
   simp_rw ← finset.prod_apply,
-  exact finset.prod_induction f measurable (λ f g , λ hf' hg', measurable.mul' hf' hg')
+  exact finset.prod_induction f measurable (λ f g hf' hg', measurable.mul' hf' hg')
     (@measurable_one α δ _ _ _) (λ i _, hf i),
 end
 
@@ -569,7 +569,7 @@ lemma finset.ae_measurable_prod {ι : Type*} [comm_monoid α] [has_continuous_mu
 begin
   simp_rw ← finset.prod_apply,
   exact finset.prod_induction f (λ f, ae_measurable f μ)
-    (λ f g , λ hf' hg', ae_measurable.mul hf' hg') (@measurable_one α δ _ _ _).ae_measurable
+    (λ f g hf' hg', ae_measurable.mul hf' hg') (@measurable_one α δ _ _ _).ae_measurable
     (λ i _, hf i),
 end
 

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -556,10 +556,9 @@ lemma finset.measurable_prod {ι : Type*} [comm_monoid α] [has_continuous_mul �
   [second_countable_topology α] {f : ι → δ → α} (s : finset ι) (hf : ∀i, measurable (f i)) :
   measurable (λ a, ∏ i in s, f i a) :=
 begin
-  convert @finset.prod_induction ι s (δ → α) _ f measurable
-    (λ f g , λ hf' hg', measurable.mul' hf' hg') (@measurable_one α δ _ _ _) (λ i _, hf i),
-  ext1 x,
-  rw finset.prod_apply,
+  simp_rw ← finset.prod_apply,
+  exact finset.prod_induction f measurable (λ f g , λ hf' hg', measurable.mul' hf' hg')
+    (@measurable_one α δ _ _ _) (λ i _, hf i),
 end
 
 @[to_additive]
@@ -568,11 +567,10 @@ lemma finset.ae_measurable_prod {ι : Type*} [comm_monoid α] [has_continuous_mu
   (hf : ∀i, ae_measurable (f i) μ) :
   ae_measurable (λ a, ∏ i in s, f i a) μ :=
 begin
-  convert @finset.prod_induction ι s (δ → α) _ f (λ f, ae_measurable f μ)
+  simp_rw ← finset.prod_apply,
+  exact finset.prod_induction f (λ f, ae_measurable f μ)
     (λ f g , λ hf' hg', ae_measurable.mul hf' hg') (@measurable_one α δ _ _ _).ae_measurable
     (λ i _, hf i),
-  ext1 x,
-  rw finset.prod_apply,
 end
 
 @[to_additive]

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -555,18 +555,25 @@ by simpa only [sub_eq_add_neg] using hf.add_const (-c)
 lemma finset.measurable_prod {ι : Type*} [comm_monoid α] [has_continuous_mul α]
   [second_countable_topology α] {f : ι → δ → α} (s : finset ι) (hf : ∀i, measurable (f i)) :
   measurable (λ a, ∏ i in s, f i a) :=
-finset.induction_on s
-  (by simp only [finset.prod_empty, measurable_const])
-  (assume i s his ih, by simpa [his] using (hf i).mul ih)
+begin
+  convert @finset.prod_induction ι s (δ → α) _ f measurable
+    (λ f g , λ hf' hg', measurable.mul' hf' hg') (@measurable_one α δ _ _ _) (λ i _, hf i),
+  ext1 x,
+  rw finset.prod_apply,
+end
 
 @[to_additive]
 lemma finset.ae_measurable_prod {ι : Type*} [comm_monoid α] [has_continuous_mul α]
   [second_countable_topology α] {f : ι → δ → α} {μ : measure δ} (s : finset ι)
   (hf : ∀i, ae_measurable (f i) μ) :
   ae_measurable (λ a, ∏ i in s, f i a) μ :=
-finset.induction_on s
-  (by simp only [finset.prod_empty, ae_measurable_const])
-  (assume i s his ih, by simpa [his] using (hf i).mul ih)
+begin
+  convert @finset.prod_induction ι s (δ → α) _ f (λ f, ae_measurable f μ)
+    (λ f g , λ hf' hg', ae_measurable.mul hf' hg') (@measurable_one α δ _ _ _).ae_measurable
+    (λ i _, hf i),
+  ext1 x,
+  rw finset.prod_apply,
+end
 
 @[to_additive]
 lemma measurable_inv [group α] [topological_group α] : measurable (has_inv.inv : α → α) :=

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -592,14 +592,14 @@ lemma snorm'_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s 
   (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hq1 : 1 ≤ q) :
   snorm' (∑ i in s, f i) q μ ≤ ∑ i in s, snorm' (f i) q μ :=
 @finset.le_sum_of_subadditive_on_pred (α → E) ℝ≥0∞ ι _ _ (λ f, snorm' f q μ)
-  (snorm'_zero (zero_lt_one.trans_le hq1)) (λ f, ae_measurable f μ)
+  (λ f, ae_measurable f μ) (snorm'_zero (zero_lt_one.trans_le hq1))
   (λ f g hf hg, snorm'_add_le hf hg hq1) (λ x y, ae_measurable.add) _ _ hfs
 
 lemma snorm_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s : finset ι}
   (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hp1 : 1 ≤ p) :
   snorm (∑ i in s, f i) p μ ≤ ∑ i in s, snorm (f i) p μ :=
 @finset.le_sum_of_subadditive_on_pred (α → E) ℝ≥0∞ ι _ _ (λ f, snorm f p μ)
-  snorm_zero (λ f, ae_measurable f μ) (λ f g hf hg, snorm_add_le hf hg hp1)
+  (λ f, ae_measurable f μ) snorm_zero (λ f g hf hg, snorm_add_le hf hg hp1)
   (λ x y, ae_measurable.add) _ _ hfs
 
 lemma snorm_add_lt_top_of_one_le {f g : α → E} (hf : mem_ℒp f p μ) (hg : mem_ℒp g p μ)

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -598,9 +598,9 @@ finset.le_sum_of_subadditive_on_pred (λ (f : α → E), snorm' f q μ)
 lemma snorm_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s : finset ι}
   (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hp1 : 1 ≤ p) :
   snorm (∑ i in s, f i) p μ ≤ ∑ i in s, snorm (f i) p μ :=
-@finset.le_sum_of_subadditive_on_pred (α → E) ℝ≥0∞ ι _ _ (λ f, snorm f p μ)
+finset.le_sum_of_subadditive_on_pred (λ (f : α → E), snorm f p μ)
   (λ f, ae_measurable f μ) snorm_zero (λ f g hf hg, snorm_add_le hf hg hp1)
-  (λ x y, ae_measurable.add) _ _ hfs
+  (λ x y, ae_measurable.add) _ hfs
 
 lemma snorm_add_lt_top_of_one_le {f g : α → E} (hf : mem_ℒp f p μ) (hg : mem_ℒp g p μ)
   (hq1 : 1 ≤ p) : snorm (f + g) p μ < ∞ :=

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -591,9 +591,9 @@ end
 lemma snorm'_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s : finset ι}
   (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hq1 : 1 ≤ q) :
   snorm' (∑ i in s, f i) q μ ≤ ∑ i in s, snorm' (f i) q μ :=
-@finset.le_sum_of_subadditive_on_pred (α → E) ℝ≥0∞ ι _ _ (λ f, snorm' f q μ)
+finset.le_sum_of_subadditive_on_pred (λ (f : α → E), snorm' f q μ)
   (λ f, ae_measurable f μ) (snorm'_zero (zero_lt_one.trans_le hq1))
-  (λ f g hf hg, snorm'_add_le hf hg hq1) (λ x y, ae_measurable.add) _ _ hfs
+  (λ f g hf hg, snorm'_add_le hf hg hq1) (λ x y, ae_measurable.add) _ hfs
 
 lemma snorm_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s : finset ι}
   (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hp1 : 1 ≤ p) :

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -593,15 +593,14 @@ lemma snorm'_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s 
   snorm' (∑ i in s, f i) q μ ≤ ∑ i in s, snorm' (f i) q μ :=
 @finset.le_sum_of_subadditive_on_pred (α → E) ℝ≥0∞ ι _ _ (λ f, snorm' f q μ)
   (snorm'_zero (zero_lt_one.trans_le hq1)) (λ f, ae_measurable f μ)
-  (λ f g hf hg, snorm'_add_le hf hg hq1) (λ x y, ae_measurable.add)
-  (@measurable_zero E α _ _ _).ae_measurable _ _ hfs
+  (λ f g hf hg, snorm'_add_le hf hg hq1) (λ x y, ae_measurable.add) _ _ hfs
 
 lemma snorm_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s : finset ι}
   (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hp1 : 1 ≤ p) :
   snorm (∑ i in s, f i) p μ ≤ ∑ i in s, snorm (f i) p μ :=
 @finset.le_sum_of_subadditive_on_pred (α → E) ℝ≥0∞ ι _ _ (λ f, snorm f p μ)
   snorm_zero (λ f, ae_measurable f μ) (λ f g hf hg, snorm_add_le hf hg hp1)
-  (λ x y, ae_measurable.add) (@measurable_zero E α _ _ _).ae_measurable _ _ hfs
+  (λ x y, ae_measurable.add) _ _ hfs
 
 lemma snorm_add_lt_top_of_one_le {f g : α → E} (hf : mem_ℒp f p μ) (hg : mem_ℒp g p μ)
   (hq1 : 1 ≤ p) : snorm (f + g) p μ < ∞ :=

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -589,7 +589,7 @@ begin
 end
 
 lemma snorm'_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s : finset ι}
-  [decidable_eq ι] (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hq1 : 1 ≤ q) :
+  (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hq1 : 1 ≤ q) :
   snorm' (∑ i in s, f i) q μ ≤ ∑ i in s, snorm' (f i) q μ :=
 begin
   refine @finset.le_sum_of_subadditive_on_prop (α → E) ℝ≥0∞ ι _ _ _ (λ f, snorm' f q μ)
@@ -599,7 +599,7 @@ begin
 end
 
 lemma snorm_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s : finset ι}
-  [decidable_eq ι] (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hp1 : 1 ≤ p) :
+  (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hp1 : 1 ≤ p) :
   snorm (∑ i in s, f i) p μ ≤ ∑ i in s, snorm (f i) p μ :=
 begin
   refine @finset.le_sum_of_subadditive_on_prop (α → E) ℝ≥0∞ ι _ _ _ (λ f, snorm f p μ)

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -591,22 +591,17 @@ end
 lemma snorm'_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s : finset ι}
   (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hq1 : 1 ≤ q) :
   snorm' (∑ i in s, f i) q μ ≤ ∑ i in s, snorm' (f i) q μ :=
-begin
-  refine @finset.le_sum_of_subadditive_on_prop (α → E) ℝ≥0∞ ι _ _ (λ f, snorm' f q μ)
-    (snorm'_zero (zero_lt_one.trans_le hq1)) (λ f, ae_measurable f μ) _
-    (λ x y, ae_measurable.add) (@measurable_zero E α _ _ _).ae_measurable _ _ hfs,
-  exact λ f g hf hg, snorm'_add_le hf hg hq1,
-end
+@finset.le_sum_of_subadditive_on_pred (α → E) ℝ≥0∞ ι _ _ (λ f, snorm' f q μ)
+  (snorm'_zero (zero_lt_one.trans_le hq1)) (λ f, ae_measurable f μ)
+  (λ f g hf hg, snorm'_add_le hf hg hq1) (λ x y, ae_measurable.add)
+  (@measurable_zero E α _ _ _).ae_measurable _ _ hfs
 
 lemma snorm_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s : finset ι}
   (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hp1 : 1 ≤ p) :
   snorm (∑ i in s, f i) p μ ≤ ∑ i in s, snorm (f i) p μ :=
-begin
-  refine @finset.le_sum_of_subadditive_on_prop (α → E) ℝ≥0∞ ι _ _ (λ f, snorm f p μ)
-    snorm_zero (λ f, ae_measurable f μ) _
-    (λ x y, ae_measurable.add) (@measurable_zero E α _ _ _).ae_measurable _ _ hfs,
-  exact λ f g hf hg, snorm_add_le hf hg hp1,
-end
+@finset.le_sum_of_subadditive_on_pred (α → E) ℝ≥0∞ ι _ _ (λ f, snorm f p μ)
+  snorm_zero (λ f, ae_measurable f μ) (λ f g hf hg, snorm_add_le hf hg hp1)
+  (λ x y, ae_measurable.add) (@measurable_zero E α _ _ _).ae_measurable _ _ hfs
 
 lemma snorm_add_lt_top_of_one_le {f g : α → E} (hf : mem_ℒp f p μ) (hg : mem_ℒp g p μ)
   (hq1 : 1 ≤ p) : snorm (f + g) p μ < ∞ :=

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -592,7 +592,7 @@ lemma snorm'_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s 
   (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hq1 : 1 ≤ q) :
   snorm' (∑ i in s, f i) q μ ≤ ∑ i in s, snorm' (f i) q μ :=
 begin
-  refine @finset.le_sum_of_subadditive_on_prop (α → E) ℝ≥0∞ ι _ _ _ (λ f, snorm' f q μ)
+  refine @finset.le_sum_of_subadditive_on_prop (α → E) ℝ≥0∞ ι _ _ (λ f, snorm' f q μ)
     (snorm'_zero (zero_lt_one.trans_le hq1)) (λ f, ae_measurable f μ) _
     (λ x y, ae_measurable.add) (@measurable_zero E α _ _ _).ae_measurable _ _ hfs,
   exact λ f g hf hg, snorm'_add_le hf hg hq1,
@@ -602,7 +602,7 @@ lemma snorm_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s :
   (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hp1 : 1 ≤ p) :
   snorm (∑ i in s, f i) p μ ≤ ∑ i in s, snorm (f i) p μ :=
 begin
-  refine @finset.le_sum_of_subadditive_on_prop (α → E) ℝ≥0∞ ι _ _ _ (λ f, snorm f p μ)
+  refine @finset.le_sum_of_subadditive_on_prop (α → E) ℝ≥0∞ ι _ _ (λ f, snorm f p μ)
     snorm_zero (λ f, ae_measurable f μ) _
     (λ x y, ae_measurable.add) (@measurable_zero E α _ _ _).ae_measurable _ _ hfs,
   exact λ f g hf hg, snorm_add_le hf hg hp1,

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -65,7 +65,7 @@ function coercion from the coercion to almost everywhere defined functions.
 
 noncomputable theory
 open topological_space measure_theory
-open_locale nnreal ennreal
+open_locale nnreal ennreal big_operators
 
 lemma fact_one_le_one_ennreal : fact ((1 : ℝ≥0∞) ≤ 1) := le_refl _
 
@@ -586,6 +586,26 @@ begin
   by rwa [← ennreal.one_to_real, ennreal.to_real_le_to_real ennreal.one_ne_top hp_top],
   repeat { rw snorm_eq_snorm' hp0 hp_top, },
   exact snorm'_add_le hf hg hp1_real,
+end
+
+lemma snorm'_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s : finset ι}
+  [decidable_eq ι] (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hq1 : 1 ≤ q) :
+  snorm' (∑ i in s, f i) q μ ≤ ∑ i in s, snorm' (f i) q μ :=
+begin
+  refine @finset.le_sum_of_subadditive_on_prop (α → E) ℝ≥0∞ ι _ _ _ (λ f, snorm' f q μ)
+    (snorm'_zero (zero_lt_one.trans_le hq1)) (λ f, ae_measurable f μ) _
+    (λ x y, ae_measurable.add) (@measurable_zero E α _ _ _).ae_measurable _ _ hfs,
+  exact λ f g hf hg, snorm'_add_le hf hg hq1,
+end
+
+lemma snorm_sum_le [second_countable_topology E] {ι} {f : ι → α → E} {s : finset ι}
+  [decidable_eq ι] (hfs : ∀ i, i ∈ s → ae_measurable (f i) μ) (hp1 : 1 ≤ p) :
+  snorm (∑ i in s, f i) p μ ≤ ∑ i in s, snorm (f i) p μ :=
+begin
+  refine @finset.le_sum_of_subadditive_on_prop (α → E) ℝ≥0∞ ι _ _ _ (λ f, snorm f p μ)
+    snorm_zero (λ f, ae_measurable f μ) _
+    (λ x y, ae_measurable.add) (@measurable_zero E α _ _ _).ae_measurable _ _ hfs,
+  exact λ f g hf hg, snorm_add_le hf hg hp1,
 end
 
 lemma snorm_add_lt_top_of_one_le {f g : α → E} (hf : mem_ℒp f p μ) (hg : mem_ℒp g p μ)


### PR DESCRIPTION
The starting point is `finset.le_sum_of_subadditive`, which is extended in several ways:
* It is written in multiplicative form, and a `[to_additive]` attribute generates the additive version,
* It is proven for multiset, which is then used for the proof of the finset case.
* For multiset, some lemmas are written for foldr/foldl (and prod is a foldr).
* Versions of these lemmas specialized to nonempty sets are provided. These don't need the initial hypothesis `f 1 = 1`/`f 0 = 0`.
* The new `..._on_pred` lemmas like `finset.le_sum_of_subadditive_on_pred` apply to functions that are only sub-additive for arguments that verify some property. I included an application of this with `snorm_sum_le`, which uses that the Lp seminorm is subadditive on a.e.-measurable functions. Those `on_pred` lemmas could be avoided by constructing the submonoid given by the predicate, then using the standard subadditive result, but I find convenient to be able to use them directly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

A note on axioms: for multisets, `le_prod_of_submultiplicative` does not require choice, but `le_prod_nonempty_of_submultiplicative` does. I think that it is due to the `by_cases hs_empty : s = ∅`. I don't know anything about decidability so I might be completely wrong, but it feels like that `hs_empty` should be decidable.
On finsets, everything uses choice (due to the definition of finset, I suppose).

My starting point for this PR is that I wanted `snorm'_sum_le`... and the scope of the changes grew a bit :) 