### PR TITLE
[Merged by Bors] - feat(linear_algebra/basic): add missing lemma finsupp.sum_smul_index_linear_map'

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1750,6 +1750,13 @@ lemma sum_smul_index' [semiring R] [add_comm_monoid M] [semimodule R M] [add_com
   (b • g).sum h = g.sum (λi c, h i (b • c)) :=
 finsupp.sum_map_range_index h0
 
+/-- A version of `finsupp.sum_smul_index'` for bundled additive maps. -/
+lemma sum_smul_index_add_monoid_hom
+  [semiring R] [add_comm_monoid M] [add_comm_monoid N] [semimodule R M]
+  {g : α →₀ M} {b : R} {h : α → M →+ N} :
+  (b • g).sum (λ a, h a) = g.sum (λ i c, h i (b • c)) :=
+sum_map_range_index (λ i, (h i).map_zero)
+
 instance [semiring R] [add_comm_monoid M] [semimodule R M] {ι : Type*}
   [no_zero_smul_divisors R M] : no_zero_smul_divisors R (ι →₀ M) :=
 ⟨λ c f h, or_iff_not_imp_left.mpr (λ hc, finsupp.ext

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -73,6 +73,19 @@ lemma smul_sum {α : Type u} {β : Type v} {R : Type w} {M : Type y}
   c • (v.sum h) = v.sum (λa b, c • h a b) :=
 finset.smul_sum
 
+@[simp]
+lemma smul_sum' {α : Type u} {R : Type v} {M : Type w} {M₂ : Type x}
+  [semiring R] [add_comm_monoid M] [semimodule R M] [add_comm_monoid M₂] [semimodule R M₂]
+  {v : α →₀ M} {c : R} {h : α → M →ₗ[R] M₂} :
+  (c • v).sum (λ a, h a) = c • (v.sum (λ a, h a)) :=
+begin
+  apply finsupp.induction v,
+  { simp only [finsupp.sum_zero_index, smul_zero], },
+  { intros a m v ha hm ih,
+    simp only [sum_add_index, ih, smul_add, linear_map.map_zero, implies_true_iff, eq_self_iff_true,
+      smul_single, forall_3_true_iff, sum_single_index, linear_map.map_smul, linear_map.map_add], },
+end
+
 end finsupp
 
 section

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -79,11 +79,9 @@ lemma smul_sum' {α : Type u} {R : Type v} {M : Type w} {M₂ : Type x}
   {v : α →₀ M} {c : R} {h : α → M →ₗ[R] M₂} :
   (c • v).sum (λ a, h a) = c • (v.sum (λ a, h a)) :=
 begin
-  apply finsupp.induction v,
-  { simp only [finsupp.sum_zero_index, smul_zero], },
-  { intros a m v ha hm ih,
-    simp only [sum_add_index, ih, smul_add, linear_map.map_zero, implies_true_iff, eq_self_iff_true,
-      smul_single, forall_3_true_iff, sum_single_index, linear_map.map_smul, linear_map.map_add], },
+  rw [finsupp.sum_smul_index', finsupp.smul_sum],
+  { simp only [linear_map.map_smul], },
+  { intro i, exact (h i).map_zero },
 end
 
 end finsupp

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -74,7 +74,7 @@ lemma smul_sum {α : Type u} {β : Type v} {R : Type w} {M : Type y}
 finset.smul_sum
 
 @[simp]
-lemma smul_sum' {α : Type u} {R : Type v} {M : Type w} {M₂ : Type x}
+lemma sum_smul_index_linear_map' {α : Type u} {R : Type v} {M : Type w} {M₂ : Type x}
   [semiring R] [add_comm_monoid M] [semimodule R M] [add_comm_monoid M₂] [semimodule R M₂]
   {v : α →₀ M} {c : R} {h : α → M →ₗ[R] M₂} :
   (c • v).sum (λ a, h a) = c • (v.sum (λ a, h a)) :=


### PR DESCRIPTION
See also [this Zulip conversation](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Sum.20is.20linear/near/229021943). cc @eric-wieser 

Co-authored-by: Adam Topaz <github@adamtopaz.com>
Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
Note that the similar-looking (but different!) lemma `smul_sum` is directly above (on line 70). I fully admit that `smul_sum'` is not a great name. I couldn't think of anything I liked better but suggestions are welcome.
