### PR TITLE
[Merged by Bors] - feat(order/ideal): added proper ideal typeclass and lemmas to order_top

### DIFF
--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -91,9 +91,9 @@ class proper (I : ideal P) : Prop := (nuniv : (I : set P) ≠ set.univ)
 
 lemma proper_of_nmem {I : ideal P} {p : P} (nmem : p ∉ I) : proper I :=
 ⟨λ hp, begin
-change p ∉ ↑I at nmem,
-rw hp at nmem,
-exact nmem (set.mem_univ p),
+  change p ∉ ↑I at nmem,
+  rw hp at nmem,
+  exact nmem (set.mem_univ p),
 end⟩
 
 end preorder

--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -136,7 +136,7 @@ begin
 end
 
 lemma proper_of_ntop {I : ideal P} (ntop : I ≠ ⊤) : proper I :=
-proper_of_not_mem (λ h, ntop (top_of_top_mem h))
+proper_of_not_mem (λ h, ntop (top_of_mem_top h))
 
 end order_top
 

--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -126,7 +126,7 @@ instance : order_top (ideal P) :=
 @[simp] lemma top_carrier : (⊤ : ideal P).carrier = set.univ :=
 set.univ_subset_iff.1 (λ p _, le_top)
 
-@[simp] lemma top_of_mem_top {I : ideal P} (topmem : ⊤ ∈ I) : I = ⊤ :=
+lemma top_of_mem_top {I : ideal P} (topmem : ⊤ ∈ I) : I = ⊤ :=
 begin
   ext,
   change x ∈ I.carrier ↔ x ∈ (⊤ : ideal P).carrier,

--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -136,7 +136,7 @@ begin
 end
 
 lemma proper_of_ntop {I : ideal P} (ntop : I ≠ ⊤) : proper I :=
-proper_of_nmem (λ h, ntop (top_of_top_mem h))
+proper_of_not_mem (λ h, ntop (top_of_top_mem h))
 
 end order_top
 

--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -135,7 +135,7 @@ begin
   { exact λ _, I.mem_of_le le_top topmem }
 end
 
-lemma proper_of_ntop {I : ideal P} (ntop : I ≠ ⊤) : proper I :=
+lemma proper_of_ne_top {I : ideal P} (ntop : I ≠ ⊤) : proper I :=
 proper_of_not_mem (λ h, ntop (top_of_mem_top h))
 
 end order_top

--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -85,6 +85,17 @@ instance : partial_order (ideal P) := partial_order.lift coe ext
 ⟨λ (h : ∀ {y}, y ≤ x → y ∈ I), h (le_refl x),
  λ h_mem y (h_le : y ≤ x), I.mem_of_le h_le h_mem⟩
 
+/-- A proper ideal is one that is not the whole set.
+    Note that the whole set might not be an ideal. -/
+class proper (I : ideal P) : Prop := (nuniv : (I : set P) ≠ set.univ)
+
+lemma proper_of_nmem {I : ideal P} {p : P} (nmem : p ∉ I) : proper I :=
+⟨λ hp, begin
+change p ∉ ↑I at nmem,
+rw hp at nmem,
+exact nmem (set.mem_univ p),
+end⟩
+
 end preorder
 
 section order_bot
@@ -102,11 +113,32 @@ instance : order_bot (ideal P) :=
 
 end order_bot
 
+section order_top
+
+variables [order_top P]
+
 /-- There is a top ideal when `P` has a top element. -/
-instance {P} [order_top P] : order_top (ideal P) :=
+instance : order_top (ideal P) :=
 { top := principal ⊤,
   le_top := λ I x h, le_top,
   .. ideal.partial_order }
+
+lemma top_carrier : (⊤ : ideal P).carrier = set.univ :=
+set.univ_subset_iff.1 (λ p _, le_top)
+
+lemma top_of_top_mem {I : ideal P} (topmem : ⊤ ∈ I) : I = ⊤ :=
+begin
+  ext,
+  change x ∈ I.carrier ↔ x ∈ (⊤ : ideal P).carrier,
+  split,
+  { simp [top_carrier] },
+  { exact λ _, I.mem_of_le le_top topmem }
+end
+
+lemma proper_of_ntop {I : ideal P} (ntop : I ≠ ⊤) : proper I :=
+proper_of_nmem (λ h, ntop (top_of_top_mem h))
+
+end order_top
 
 section semilattice_sup
 variables [semilattice_sup P] {x y : P} {I : ideal P}

--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -89,7 +89,7 @@ instance : partial_order (ideal P) := partial_order.lift coe ext
     Note that the whole set might not be an ideal. -/
 class proper (I : ideal P) : Prop := (nuniv : (I : set P) ≠ set.univ)
 
-lemma proper_of_nmem {I : ideal P} {p : P} (nmem : p ∉ I) : proper I :=
+lemma proper_of_not_mem {I : ideal P} {p : P} (nmem : p ∉ I) : proper I :=
 ⟨λ hp, begin
   change p ∉ ↑I at nmem,
   rw hp at nmem,

--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -123,10 +123,10 @@ instance : order_top (ideal P) :=
   le_top := λ I x h, le_top,
   .. ideal.partial_order }
 
-lemma top_carrier : (⊤ : ideal P).carrier = set.univ :=
+@[simp] lemma top_carrier : (⊤ : ideal P).carrier = set.univ :=
 set.univ_subset_iff.1 (λ p _, le_top)
 
-lemma top_of_top_mem {I : ideal P} (topmem : ⊤ ∈ I) : I = ⊤ :=
+@[simp] lemma top_of_mem_top {I : ideal P} (topmem : ⊤ ∈ I) : I = ⊤ :=
 begin
   ext,
   change x ∈ I.carrier ↔ x ∈ (⊤ : ideal P).carrier,


### PR DESCRIPTION
Defined `proper` and proved basic lemmas about proper ideals.
Also turned `order_top` into a section.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The goal is to define prime ideals, and for that we should have proper ideals (akin to `filter.ne_bot`).