### PR TITLE
[Merged by Bors] - chore(algebra/monoid_algebra): provide finer-grained levels of structure for less-structured `G`.

### DIFF
--- a/src/algebra/monoid_algebra.lean
+++ b/src/algebra/monoid_algebra.lean
@@ -860,13 +860,6 @@ While we were not able to define `add_monoid_algebra k G = monoid_algebra k (mul
 to definitional inconveniences, we can still show the types are isomorphic.
 -/
 
-/-- The equivalence between `add_monoid_algebra` and `monoid_algebra` in terms of
-`multiplicative` -/
-protected def add_monoid_algebra.to_multiplicative [semiring k] [has_add G] :
-  add_monoid_algebra k G ≃+* monoid_algebra k (multiplicative G) :=
-{ map_mul' := λ x y, by convert monoid_algebra.map_domain_mul (mul_hom.id (multiplicative G)),
-  ..finsupp.dom_congr multiplicative.of_add }
-
 /-- The equivalence between `monoid_algebra` and `add_monoid_algebra` in terms of `additive` -/
 protected def monoid_algebra.to_additive [semiring k] [has_mul G] :
   monoid_algebra k G ≃+* add_monoid_algebra k (additive G) :=

--- a/src/algebra/monoid_algebra.lean
+++ b/src/algebra/monoid_algebra.lean
@@ -793,7 +793,7 @@ lemma single_mul_single [has_add G] {a₁ a₂ : G} {b₁ b₂ : k} :
 
 /-- Like `finsupp.map_domain_add`, but for the convolutive multiplication we define in this file -/
 lemma map_domain_mul {α : Type*} {β : Type*} {α₂ : Type*}
-  [semiring β] [add_monoid α] [add_monoid α₂]
+  [semiring β] [has_add α] [has_add α₂]
   {x y : add_monoid_algebra β α} (f : add_hom α α₂) :
   (map_domain f (x * y : add_monoid_algebra β α) : add_monoid_algebra β α₂) =
     (map_domain f x * map_domain f y : add_monoid_algebra β α₂) :=
@@ -864,7 +864,7 @@ to definitional inconveniences, we can still show the types are isomorphic.
 `multiplicative` -/
 protected def add_monoid_algebra.to_multiplicative [semiring k] [has_add G] :
   add_monoid_algebra k G ≃+* monoid_algebra k (multiplicative G) :=
-{ map_mul' := λ x y, by convert monoid_algebra.map_domain_mul (mul_hom.id (multiplicative G)),
+{ map_mul' := λ x y, by convert add_monoid_algebra.map_domain_mul (add_hom.id G),
   ..finsupp.dom_congr multiplicative.of_add }
 
 /-- The equivalence between `monoid_algebra` and `add_monoid_algebra` in terms of `additive` -/

--- a/src/algebra/monoid_algebra.lean
+++ b/src/algebra/monoid_algebra.lean
@@ -61,10 +61,9 @@ namespace monoid_algebra
 
 variables {k G}
 
-/-! #### Semiring structure -/
-section semiring
+section has_mul
 
-variables [semiring k] [monoid G]
+variables [semiring k] [has_mul G]
 
 /-- The product of `f g : monoid_algebra k G` is the finitely supported function
   whose value at `a` is the sum of `f x * g y` over all pairs `x, y`
@@ -75,6 +74,41 @@ instance : has_mul (monoid_algebra k G) :=
 lemma mul_def {f g : monoid_algebra k G} :
   f * g = (f.sum $ λa₁ b₁, g.sum $ λa₂ b₂, single (a₁ * a₂) (b₁ * b₂)) :=
 rfl
+
+instance : distrib (monoid_algebra k G) :=
+{ mul           := (*),
+  add           := (+),
+  left_distrib  := assume f g h, by simp only [mul_def, sum_add_index, mul_add, mul_zero,
+    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_add],
+  right_distrib := assume f g h, by simp only [mul_def, sum_add_index, add_mul, mul_zero, zero_mul,
+    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_zero,
+    sum_add],
+  .. finsupp.add_comm_monoid }
+
+instance : mul_zero_class (monoid_algebra k G) :=
+{ zero      := 0,
+  mul       := (*),
+  zero_mul  := assume f, by simp only [mul_def, sum_zero_index],
+  mul_zero  := assume f, by simp only [mul_def, sum_zero_index, sum_zero] }
+
+end has_mul
+
+section semigroup
+
+variables [semiring k] [semigroup G]
+
+instance : semigroup (monoid_algebra k G) :=
+{ mul       := (*),
+  mul_assoc := assume f g h, by simp only [mul_def, sum_sum_index, sum_zero_index, sum_add_index,
+    sum_single_index, single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff,
+    add_mul, mul_add, add_assoc, mul_assoc, zero_mul, mul_zero, sum_zero, sum_add],}
+
+end semigroup
+
+section has_one
+
+variables [semiring k] [has_one G]
+
 /-- The unit of the multiplication is `single 1 1`, i.e. the function
   that is `1` at `1` and zero elsewhere. -/
 instance : has_one (monoid_algebra k G) :=
@@ -82,6 +116,13 @@ instance : has_one (monoid_algebra k G) :=
 
 lemma one_def : (1 : monoid_algebra k G) = single 1 1 :=
 rfl
+
+end has_one
+
+/-! #### Semiring structure -/
+section semiring
+
+variables [semiring k] [monoid G]
 
 instance : semiring (monoid_algebra k G) :=
 { one       := 1,
@@ -92,16 +133,9 @@ instance : semiring (monoid_algebra k G) :=
     single_zero, sum_zero, zero_add, one_mul, sum_single],
   mul_one   := assume f, by simp only [mul_def, one_def, sum_single_index, mul_zero,
     single_zero, sum_zero, add_zero, mul_one, sum_single],
-  zero_mul  := assume f, by simp only [mul_def, sum_zero_index],
-  mul_zero  := assume f, by simp only [mul_def, sum_zero_index, sum_zero],
-  mul_assoc := assume f g h, by simp only [mul_def, sum_sum_index, sum_zero_index, sum_add_index,
-    sum_single_index, single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff,
-    add_mul, mul_add, add_assoc, mul_assoc, zero_mul, mul_zero, sum_zero, sum_add],
-  left_distrib  := assume f g h, by simp only [mul_def, sum_add_index, mul_add, mul_zero,
-    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_add],
-  right_distrib := assume f g h, by simp only [mul_def, sum_add_index, add_mul, mul_zero, zero_mul,
-    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_zero,
-    sum_add],
+  .. monoid_algebra.semigroup,
+  .. monoid_algebra.mul_zero_class,
+  .. monoid_algebra.distrib,
   .. finsupp.add_comm_monoid }
 
 variables {R : Type*} [semiring R]
@@ -574,10 +608,9 @@ namespace add_monoid_algebra
 
 variables {k G}
 
-/-! #### Semiring structure -/
-section semiring
+section has_mul
 
-variables [semiring k] [add_monoid G]
+variables [semiring k] [has_add G]
 
 /-- The product of `f g : add_monoid_algebra k G` is the finitely supported function
   whose value at `a` is the sum of `f x * g y` over all pairs `x, y`
@@ -590,6 +623,27 @@ lemma mul_def {f g : add_monoid_algebra k G} :
   f * g = (f.sum $ λa₁ b₁, g.sum $ λa₂ b₂, single (a₁ + a₂) (b₁ * b₂)) :=
 rfl
 
+instance : distrib (add_monoid_algebra k G) :=
+{ mul           := (*),
+  add           := (+),
+  left_distrib  := assume f g h, by simp only [mul_def, sum_add_index, mul_add, mul_zero,
+    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_add],
+  right_distrib := assume f g h, by simp only [mul_def, sum_add_index, add_mul, mul_zero, zero_mul,
+    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_zero,
+    sum_add], }
+
+instance : mul_zero_class (add_monoid_algebra k G) :=
+{ zero      := 0,
+  mul       := (*),
+  zero_mul  := assume f, by simp only [mul_def, sum_zero_index],
+  mul_zero  := assume f, by simp only [mul_def, sum_zero_index, sum_zero] }
+
+end has_mul
+
+section has_one
+
+variables [semiring k] [has_zero G]
+
 /-- The unit of the multiplication is `single 1 1`, i.e. the function
   that is `1` at `0` and zero elsewhere. -/
 instance : has_one (add_monoid_algebra k G) :=
@@ -597,6 +651,25 @@ instance : has_one (add_monoid_algebra k G) :=
 
 lemma one_def : (1 : add_monoid_algebra k G) = single 0 1 :=
 rfl
+
+end has_one
+
+section semigroup
+
+variables [semiring k] [add_semigroup G]
+
+instance : semigroup (add_monoid_algebra k G) :=
+{ mul       := (*),
+  mul_assoc := assume f g h, by simp only [mul_def, sum_sum_index, sum_zero_index, sum_add_index,
+    sum_single_index, single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff,
+    add_mul, mul_add, add_assoc, mul_assoc, zero_mul, mul_zero, sum_zero, sum_add] }
+
+end semigroup
+
+/-! #### Semiring structure -/
+section semiring
+
+variables [semiring k] [add_monoid G]
 
 instance : semiring (add_monoid_algebra k G) :=
 { one       := 1,
@@ -607,16 +680,9 @@ instance : semiring (add_monoid_algebra k G) :=
     single_zero, sum_zero, zero_add, one_mul, sum_single],
   mul_one   := assume f, by simp only [mul_def, one_def, sum_single_index, mul_zero,
     single_zero, sum_zero, add_zero, mul_one, sum_single],
-  zero_mul  := assume f, by simp only [mul_def, sum_zero_index],
-  mul_zero  := assume f, by simp only [mul_def, sum_zero_index, sum_zero],
-  mul_assoc := assume f g h, by simp only [mul_def, sum_sum_index, sum_zero_index, sum_add_index,
-    sum_single_index, single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff,
-    add_mul, mul_add, add_assoc, mul_assoc, zero_mul, mul_zero, sum_zero, sum_add],
-  left_distrib  := assume f g h, by simp only [mul_def, sum_add_index, mul_add, mul_zero,
-    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_add],
-  right_distrib := assume f g h, by simp only [mul_def, sum_add_index, add_mul, mul_zero, zero_mul,
-    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_zero,
-    sum_add],
+  .. add_monoid_algebra.semigroup,
+  .. add_monoid_algebra.mul_zero_class,
+  .. add_monoid_algebra.distrib,
   .. finsupp.add_comm_monoid }
 
 variables {R : Type*} [semiring R]


### PR DESCRIPTION
This provides `distrib` and `mul_zero_class` for when `G` is just `has_mul`, and `semigroup` for when `G` is just `semigroup`.

It also weakens the typeclass assumptions on some correspondings lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->