### PR TITLE
[Merged by Bors] - chore(algebra/module/linear_map): add linear_map.to_distrib_mul_action_hom

### DIFF
--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -72,6 +72,10 @@ variables [semiring R] [add_comm_monoid M] [add_comm_monoid M₂] [add_comm_mono
 section
 variables [semimodule R M] [semimodule R M₂]
 
+/-- The `distrib_mul_action_hom` underlying a `linear_map`. -/
+def to_distrib_mul_action_hom (f : M →ₗ[R] M₂) : distrib_mul_action_hom R M M₂ :=
+{ map_zero' := zero_smul R (0 : M) ▸ zero_smul R (f.to_fun 0) ▸ f.map_smul' 0 0, ..f }
+
 instance : has_coe_to_fun (M →ₗ[R] M₂) := ⟨_, to_fun⟩
 
 initialize_simps_projections linear_map (to_fun → apply)
@@ -127,7 +131,7 @@ variables (f g)
 @[simp] lemma map_smul (c : R) (x : M) : f (c • x) = c • f x := f.map_smul' c x
 
 @[simp] lemma map_zero : f 0 = 0 :=
-by rw [← zero_smul R, map_smul f 0 0, zero_smul]
+f.to_distrib_mul_action_hom.map_zero
 
 variables (M M₂)
 /--


### PR DESCRIPTION
My aim in adding this is primarily to give the reader a hint that `distrib_mul_action_hom` exists.

The only difference between the two is that `linear_map` can infer `map_zero'` from its typeclass arguments.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Some zulip threads:

* https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Missing.20coercions/near/205742050
* https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Notation.20for.20.60affine_map.60/near/213727120