### PR TITLE
[Merged by Bors] - feat(topology): closure in a `pi` space

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -109,6 +109,16 @@ instance {α : Type*} : boolean_algebra (set α) :=
 /-- Coercion from a set to the corresponding subtype. -/
 instance {α : Type*} : has_coe_to_sort (set α) := ⟨_, λ s, {x // x ∈ s}⟩
 
+instance pi_set_coe.can_lift (ι : Type u) (α : Π i : ι, Type v) [ne : Π i, nonempty (α i)]
+  (s : set ι) :
+  can_lift (Π i : s, α i) (Π i, α i) :=
+{ coe := λ f i, f i,
+  .. pi_subtype.can_lift ι α s }
+
+instance pi_set_coe.can_lift' (ι : Type u) (α : Type v) [ne : nonempty α] (s : set ι) :
+  can_lift (s → α) (ι → α) :=
+pi_set_coe.can_lift ι (λ _, α) s
+
 end set
 
 section set_coe

--- a/src/data/set/function.lean
+++ b/src/data/set/function.lean
@@ -687,6 +687,21 @@ lemma piecewise_mem_pi {δ : α → Type*} {t : set α} {t' : Π i, set (δ i)}
   s.piecewise f g ∈ pi t t' :=
 by { intros i ht, by_cases hs : i ∈ s; simp [hf i ht, hg i ht, hs] }
 
+@[simp] lemma pi_piecewise_left {ι : Type*} {α : ι → Type*} (s s' : set ι)
+  (t t' : Π i, set (α i)) [Π x, decidable (x ∈ s')] :
+  pi s (s'.piecewise t t') = pi (s ∩ s') t ∩ pi (s \ s') t' :=
+begin
+  ext x,
+  simp only [mem_pi, mem_inter_eq, ← forall_and_distrib],
+  refine forall_congr (λ i, _),
+  by_cases hi : i ∈ s'; simp *
+end
+
+lemma pi_piecewise_univ {ι : Type*} {α : ι → Type*} (s : set ι)
+  (t : Π i, set (α i)) [Π x, decidable (x ∈ s)] :
+  pi univ (s.piecewise t (λ _, univ)) = pi s t :=
+by simp
+
 end set
 
 lemma strict_mono_incr_on.inj_on [linear_order α] [preorder β] {f : α → β} {s : set α}

--- a/src/data/set/function.lean
+++ b/src/data/set/function.lean
@@ -687,7 +687,7 @@ lemma piecewise_mem_pi {δ : α → Type*} {t : set α} {t' : Π i, set (δ i)}
   s.piecewise f g ∈ pi t t' :=
 by { intros i ht, by_cases hs : i ∈ s; simp [hf i ht, hg i ht, hs] }
 
-@[simp] lemma pi_piecewise_left {ι : Type*} {α : ι → Type*} (s s' : set ι)
+@[simp] lemma pi_piecewise {ι : Type*} {α : ι → Type*} (s s' : set ι)
   (t t' : Π i, set (α i)) [Π x, decidable (x ∈ s')] :
   pi s (s'.piecewise t t') = pi (s ∩ s') t ∩ pi (s \ s') t' :=
 begin
@@ -697,7 +697,7 @@ begin
   by_cases hi : i ∈ s'; simp *
 end
 
-lemma pi_piecewise_univ {ι : Type*} {α : ι → Type*} (s : set ι)
+lemma univ_pi_piecewise {ι : Type*} {α : ι → Type*} (s : set ι)
   (t : Π i, set (α i)) [Π x, decidable (x ∈ s)] :
   pi univ (s.piecewise t (λ _, univ)) = pi s t :=
 by simp

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -457,7 +457,7 @@ lemma infi_eq_generate (s : ι → filter α) : infi s = generate (⋃ i, (s i).
 show generate _ = generate _, from congr_arg _ supr_range
 
 lemma mem_infi_iff {ι} {s : ι → filter α} {U : set α} : (U ∈ ⨅ i, s i) ↔
-  ∃ I : set ι, finite I ∧ ∃ V : {i | i ∈ I} → set α, (∀ i, V i ∈ s i) ∧ (⋂ i, V i) ⊆ U :=
+  ∃ I : set ι, finite I ∧ ∃ V : I → set α, (∀ i, V i ∈ s i) ∧ (⋂ i, V i) ⊆ U :=
 begin
   rw [infi_eq_generate, mem_generate_iff],
   split,
@@ -475,8 +475,18 @@ begin
     { rintro _ ⟨i, rfl⟩,
       rw mem_Union,
       use [i, V_in i] },
-    { haveI : fintype {i : ι | i ∈ I} := finite.fintype Ifin,
+    { haveI : fintype I := finite.fintype Ifin,
       exact finite_range _ } },
+end
+
+lemma mem_infi_iff' {ι} {s : ι → filter α} {U : set α} : (U ∈ ⨅ i, s i) ↔
+  ∃ I : set ι, finite I ∧ ∃ V : ι → set α, (∀ i ∈ I, V i ∈ s i) ∧ (⋂ i ∈ I, V i) ⊆ U :=
+begin
+  simp only [mem_infi_iff, set_coe.forall', bInter_eq_Inter],
+  refine ⟨_, λ ⟨I, If, V, hV⟩, ⟨I, If, λ i, V i, hV⟩⟩,
+  rintro ⟨I, If, V, hV⟩,
+  lift V to ι → set α using trivial,
+  exact ⟨I, If, V, hV⟩
 end
 
 @[simp] lemma le_principal_iff {s : set α} {f : filter α} : f ≤ 𝓟 s ↔ s ∈ f :=
@@ -768,9 +778,6 @@ lemma is_compl_principal (s : set α) : is_compl (𝓟 s) (𝓟 sᶜ) :=
 ⟨by simp only [inf_principal, inter_compl_self, principal_empty, le_refl],
   by simp only [sup_principal, union_compl_self, principal_univ, le_refl]⟩
 
-lemma inf_principal_eq_bot {f : filter α} {s : set α} (hs : sᶜ ∈ f) : f ⊓ 𝓟 s = ⊥ :=
-empty_in_sets_eq_bot.mp ⟨_, hs, s, mem_principal_self s, assume x ⟨h₁, h₂⟩, h₁ h₂⟩
-
 theorem mem_inf_principal {f : filter α} {s t : set α} :
   s ∈ f ⊓ 𝓟 t ↔ {x | x ∈ t → x ∈ s} ∈ f :=
 begin
@@ -779,6 +786,9 @@ begin
   rw [← disjoint, ← (is_compl_principal (t ∩ sᶜ)).le_right_iff, compl_inter, compl_compl],
   refl
 end
+
+lemma inf_principal_eq_bot {f : filter α} {s : set α} : f ⊓ 𝓟 s = ⊥ ↔ sᶜ ∈ f :=
+by { rw [← empty_in_sets_eq_bot, mem_inf_principal], refl }
 
 lemma diff_mem_inf_principal_compl {f : filter α} {s : set α} (hs : s ∈ f) (t : set α) :
   s \ t ∈ f ⊓ 𝓟 tᶜ :=
@@ -813,6 +823,13 @@ end
 @[simp] lemma infi_principal_fintype {ι : Type w} [fintype ι] (f : ι → set α) :
   (⨅i, 𝓟 (f i)) = 𝓟 (⋂i, f i) :=
 by simpa using infi_principal_finset finset.univ f
+
+lemma infi_principal_finite {ι : Type w} {s : set ι} (hs : finite s) (f : ι → set α) :
+  (⨅i∈s, 𝓟 (f i)) = 𝓟 (⋂i∈s, f i) :=
+begin
+  unfreezingI { lift s to finset ι using hs }, -- TODO: why `unfreezingI` is needed?
+  exact_mod_cast infi_principal_finset s f
+end
 
 end lattice
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -219,6 +219,9 @@ by rw [sup_assoc, sup_idem]
 lemma sup_left_comm (a b c : α) : a ⊔ (b ⊔ c) = b ⊔ (a ⊔ c) :=
 by rw [← sup_assoc, ← sup_assoc, @sup_comm α _ a]
 
+lemma sup_right_comm (a b c : α) : a ⊔ b ⊔ c = a ⊔ c ⊔ b :=
+by rw [sup_assoc, sup_assoc, @sup_comm _ _ b]
+
 lemma forall_le_or_exists_lt_sup (a : α) : (∀b, b ≤ a) ∨ (∃b, a < b) :=
 suffices (∃b, ¬b ≤ a) → (∃b, a < b),
   by rwa [or_iff_not_imp_left, not_forall],
@@ -368,6 +371,9 @@ instance inf_is_associative : is_associative α (⊓) := ⟨@inf_assoc _ _⟩
 
 lemma inf_left_comm (a b c : α) : a ⊓ (b ⊓ c) = b ⊓ (a ⊓ c) :=
 @sup_left_comm (order_dual α) _ a b c
+
+lemma inf_right_comm (a b c : α) : a ⊓ b ⊓ c = a ⊓ c ⊓ b :=
+@sup_right_comm (order_dual α) _ a b c
 
 lemma forall_le_or_exists_lt_inf (a : α) : (∀b, a ≤ b) ∨ (∃b, b < a) :=
 @forall_le_or_exists_lt_sup (order_dual α) _ a

--- a/src/tactic/lift.lean
+++ b/src/tactic/lift.lean
@@ -53,6 +53,23 @@ instance pi.can_lift (ι : Type u) (α : Π i : ι, Type v) (β : Π i : ι, Typ
   prf := λ f hf, ⟨λ i, classical.some (can_lift.prf (f i) (hf i)), funext $ λ i,
     classical.some_spec (can_lift.prf (f i) (hf i))⟩ }
 
+instance pi_subtype.can_lift (ι : Type u) (α : Π i : ι, Type v) [ne : Π i, nonempty (α i)]
+  (p : ι → Prop) :
+  can_lift (Π i : subtype p, α i) (Π i, α i) :=
+{ coe := λ f i, f i,
+  cond := λ _, true,
+  prf :=
+    begin
+      classical,
+      refine λ f _, ⟨λ i, if hi : p i then f ⟨i, hi⟩ else classical.choice (ne i), funext _⟩,
+      rintro ⟨i, hi⟩,
+      exact dif_pos hi
+    end }
+
+instance pi_subtype.can_lift' (ι : Type u) (α : Type v) [ne : nonempty α] (p : ι → Prop) :
+  can_lift (subtype p → α) (ι → α) :=
+pi_subtype.can_lift ι (λ _, α) p
+
 namespace tactic
 
 /--

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -512,8 +512,7 @@ lemma topological_group.regular_space [t1_space G] : regular_space G :=
    is_open_prod_iff.1 ((is_open_compl_iff.2 hs).preimage hf) a (1:G) (by simpa [f]) in
  begin
    use [s * t₂, ht₂.mul_left, λ x hx, ⟨x, 1, hx, one_mem_t₂, mul_one _⟩],
-   apply inf_principal_eq_bot,
-   rw mem_nhds_sets_iff,
+   rw [nhds_within, inf_principal_eq_bot, mem_nhds_sets_iff],
    refine ⟨t₁, _, ht₁, a_mem_t₁⟩,
    rintros x hx ⟨y, z, hy, hz, yz⟩,
    have : x * z⁻¹ ∈ sᶜ := (prod_subset_iff.1 t_subset) x hx z hz,

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -918,10 +918,10 @@ instance order_topology.regular_space : regular_space α :=
           | or.inl ⟨b, hb₁, hb₂⟩ := ⟨{a | a < b}, is_open_gt' _,
               assume c hcs hca, show c < b,
                 from lt_of_not_ge $ assume hbc, h ⟨lt_of_lt_of_le hb₁ hbc, le_of_lt hca⟩ hcs,
-              inf_principal_eq_bot $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_lt' _) hb₂) $
+              inf_principal_eq_bot.2 $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_lt' _) hb₂) $
                 assume x (hx : b < x), show ¬ x < b, from not_lt.2 $ le_of_lt hx⟩
           | or.inr ⟨h₁, h₂⟩ := ⟨{a' | a' < a}, is_open_gt' _, assume b hbs hba, hba,
-              inf_principal_eq_bot $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_lt' _) hl) $
+              inf_principal_eq_bot.2 $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_lt' _) hl) $
                 assume x (hx : l < x), show ¬ x < a, from not_lt.2 $ h₁ _ hx⟩
           end)
         (assume : ¬ ∃l, l < a, ⟨∅, is_open_empty, assume l _ hl, (this ⟨l, hl⟩).elim,
@@ -935,10 +935,10 @@ instance order_topology.regular_space : regular_space α :=
           | or.inl ⟨b, hb₁, hb₂⟩ := ⟨{a | b < a}, is_open_lt' _,
               assume c hcs hca, show c > b,
                 from lt_of_not_ge $ assume hbc, h ⟨le_of_lt hca, lt_of_le_of_lt hbc hb₂⟩ hcs,
-              inf_principal_eq_bot $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_gt' _) hb₁) $
+              inf_principal_eq_bot.2 $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_gt' _) hb₁) $
                 assume x (hx : b > x), show ¬ x > b, from not_lt.2 $ le_of_lt hx⟩
           | or.inr ⟨h₁, h₂⟩ := ⟨{a' | a' > a}, is_open_lt' _, assume b hbs hba, hba,
-              inf_principal_eq_bot $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_gt' _) hu) $
+              inf_principal_eq_bot.2 $ (𝓝 a).sets_of_superset (mem_nhds_sets (is_open_gt' _) hu) $
                 assume x (hx : u > x), show ¬ x > a, from not_lt.2 $ h₂ _ hx⟩
           end)
         (assume : ¬ ∃u, u > a, ⟨∅, is_open_empty, assume l _ hl, (this ⟨l, hl⟩).elim,

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -647,6 +647,11 @@ lemma is_open_set_pi [∀a, topological_space (π a)] {i : set ι} {s : Πa, set
   (hi : finite i) (hs : ∀a∈i, is_open (s a)) : is_open (pi i s) :=
 by rw [pi_def]; exact (is_open_bInter hi $ assume a ha, (hs _ ha).preimage (continuous_apply _))
 
+lemma is_closed_set_pi [∀a, topological_space (π a)] {i : set ι} {s : Πa, set (π a)}
+  (hs : ∀a∈i, is_closed (s a)) : is_closed (pi i s) :=
+by rw [pi_def];
+  exact (is_closed_Inter $ λ a, is_closed_Inter $ λ ha, (hs _ ha).preimage (continuous_apply _))
+
 lemma set_pi_mem_nhds [Π a, topological_space (π a)] {i : set ι} {s : Π a, set (π a)}
   {x : Π a, π a} (hi : finite i) (hs : ∀ a ∈ i, s a ∈ 𝓝 (x a)) :
   pi i s ∈ 𝓝 x :=

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -193,6 +193,69 @@ lemma nhds_within_prod {α : Type*} [topological_space α] {β : Type*} [topolog
   (u.prod v) ∈ 𝓝[s.prod t] (a, b) :=
 by { rw nhds_within_prod_eq, exact prod_mem_prod hu hv, }
 
+lemma nhds_within_pi_eq' {ι : Type*} {α : ι → Type*} [Π i, topological_space (α i)]
+  {I : set ι} (hI : finite I) (s : Π i, set (α i)) (x : Π i, α i) :
+  𝓝[pi I s] x = ⨅ i, comap (λ x, x i) (𝓝 (x i) ⊓ ⨅ (hi : i ∈ I), 𝓟 (s i)) :=
+by simp only [nhds_within, nhds_pi, comap_inf, comap_infi, pi_def, comap_principal,
+  ← infi_principal_finite hI, ← infi_inf_eq]
+
+lemma nhds_within_pi_eq {ι : Type*} {α : ι → Type*} [Π i, topological_space (α i)]
+  {I : set ι} (hI : finite I) (s : Π i, set (α i)) (x : Π i, α i) :
+  𝓝[pi I s] x = (⨅ i ∈ I, comap (λ x, x i) (𝓝[s i] (x i))) ⊓
+    ⨅ (i ∉ I), comap (λ x, x i) (𝓝 (x i)) :=
+begin
+  simp only [nhds_within, nhds_pi, pi_def, ← infi_principal_finite hI, comap_inf, comap_principal,
+    function.eval],
+  rw [infi_split _ (λ i, i ∈ I), inf_right_comm],
+  simp only [infi_inf_eq]
+end
+
+lemma nhds_within_pi_univ_eq {ι : Type*} {α : ι → Type*} [fintype ι] [Π i, topological_space (α i)]
+  (s : Π i, set (α i)) (x : Π i, α i) :
+  𝓝[pi univ s] x = ⨅ i, comap (λ x, x i) 𝓝[s i] (x i) :=
+by simpa [nhds_within] using nhds_within_pi_eq finite_univ s x
+
+lemma nhds_within_pi_univ_eq_bot {ι : Type*} {α : ι → Type*} [Π i, topological_space (α i)]
+  {s : Π i, set (α i)} {x : Π i, α i} :
+  𝓝[pi univ s] x = ⊥ ↔ ∃ i, 𝓝[s i] (x i) = ⊥ :=
+begin
+  classical,
+  split,
+  { haveI : Π i, inhabited (α i) := λ i, ⟨x i⟩,
+    simp only [nhds_within, nhds_pi, inf_principal_eq_bot, mem_infi_iff', mem_comap_sets],
+    rintro ⟨I, hIf, V, hV, hVs⟩, choose! t htx htV using hV,
+    contrapose! hVs,
+    change ∀ i, ∃ᶠ y in 𝓝 (x i), y ∈ s i at hVs,
+    have : ∀ i ∈ I, (s i ∩ t i).nonempty, from λ i hi, ((hVs i).and_eventually (htx i hi)).exists,
+    choose! y hys hyt,
+    choose z hzs using λ i, (hVs i).exists,
+    suffices : I.piecewise y z ∈ (⋂ i ∈ I, V i) ∩ (pi univ s),
+      from λ H, H this.1 this.2,
+    refine ⟨mem_bInter $ λ i hi, htV i hi _, λ i hi', _⟩,
+    { simp only [mem_preimage, piecewise_eq_of_mem _ _ _ hi, hyt i hi] },
+    { by_cases hi : i ∈ I; simp * } },
+  { rintro ⟨i, eq⟩,
+    rw [← @map_eq_bot_iff _ _ _ (λ x : Π i, α i, x i)],
+    refine eq_bot_mono _ eq,
+    exact ((continuous_apply i).tendsto x).inf
+      (tendsto_principal_principal.2 $ λ y hy, hy i trivial) }
+end
+
+lemma nhds_within_pi_eq_bot {ι : Type*} {α : ι → Type*} [Π i, topological_space (α i)]
+  {I : set ι} {s : Π i, set (α i)} {x : Π i, α i} :
+  𝓝[pi I s] x = ⊥ ↔ ∃ i ∈ I, 𝓝[s i] (x i) = ⊥ :=
+begin
+  classical,
+  rw [← pi_piecewise_univ I, nhds_within_pi_univ_eq_bot],
+  refine exists_congr (λ i, _),
+  by_cases hi : i ∈ I; simp [*, nhds_within_univ, nhds_ne_bot.ne]
+end
+
+lemma nhds_within_pi_ne_bot {ι : Type*} {α : ι → Type*} [Π i, topological_space (α i)]
+  {I : set ι} {s : Π i, set (α i)} {x : Π i, α i} :
+  (𝓝[pi I s] x).ne_bot ↔ ∀ i ∈ I, (𝓝[s i] (x i)).ne_bot :=
+by simp [ne_bot_iff, nhds_within_pi_eq_bot]
+
 theorem filter.tendsto.piecewise_nhds_within {f g : α → β} {t : set α} [∀ x, decidable (x ∈ t)]
   {a : α} {s : set α} {l : filter β}
   (h₀ : tendsto f (𝓝[s ∩ t] a) l) (h₁ : tendsto g (𝓝[s ∩ tᶜ] a) l) :
@@ -244,6 +307,22 @@ by simpa only [hs.closure_eq] using mem_closure_iff_nhds_within_ne_bot.2 hx
 lemma dense_range.nhds_within_ne_bot {ι : Type*} {f : ι → α} (h : dense_range f) (x : α) :
   ne_bot (𝓝[range f] x) :=
 mem_closure_iff_cluster_pt.1 (h x)
+
+lemma mem_closure_pi {ι : Type*} {α : ι → Type*} [Π i, topological_space (α i)]
+  {I : set ι} {s : Π i, set (α i)} {x : Π i, α i} :
+  x ∈ closure (pi I s) ↔ ∀ i ∈ I, x i ∈ closure (s i) :=
+by simp only [mem_closure_iff_nhds_within_ne_bot, nhds_within_pi_ne_bot]
+
+lemma closure_pi_set {ι : Type*} {α : ι → Type*} [Π i, topological_space (α i)]
+  (I : set ι) (s : Π i, set (α i)) :
+  closure (pi I s) = pi I (λ i, closure (s i)) :=
+set.ext $ λ x, mem_closure_pi
+
+lemma dense_pi {ι : Type*} {α : ι → Type*} [Π i, topological_space (α i)] {s : Π i, set (α i)}
+  (I : set ι) (hs : ∀ i ∈ I, dense (s i)) :
+  dense (pi I s) :=
+by simp only [dense_iff_closure_eq, closure_pi_set,
+  pi_congr rfl (λ i hi, (hs i hi).closure_eq), pi_univ]
 
 lemma eventually_eq_nhds_within_iff {f g : α → β} {s : set α} {a : α} :
   (f =ᶠ[𝓝[s] a] g) ↔ ∀ᶠ x in 𝓝 a, x ∈ s → f x = g x :=

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -246,7 +246,7 @@ lemma nhds_within_pi_eq_bot {ι : Type*} {α : ι → Type*} [Π i, topological_
   𝓝[pi I s] x = ⊥ ↔ ∃ i ∈ I, 𝓝[s i] (x i) = ⊥ :=
 begin
   classical,
-  rw [← pi_piecewise_univ I, nhds_within_pi_univ_eq_bot],
+  rw [← univ_pi_piecewise I, nhds_within_pi_univ_eq_bot],
   refine exists_congr (λ i, _),
   by_cases hi : i ∈ I; simp [*, nhds_within_univ, nhds_ne_bot.ne]
 end


### PR DESCRIPTION
Also add `can_lift` instances that lift `f : subtype p → β` to `f : α → β` and a version of `filter.mem_infi_iff` that uses a globally defined function.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is needed to prove that `pi` set has the `unique_diff_on` property which is required to define a manifold structure on `Π i, M i`.