### PR TITLE
[Merged by Bors] - feat(data/nat/parity): even/odd.mul_even/odd

### DIFF
--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -103,8 +103,8 @@ by simp [bit1] with parity_simps
 lemma two_not_dvd_two_mul_add_one (n : ℕ) : ¬(2 ∣ 2 * n + 1) :=
 by convert not_even_bit1 n; exact two_mul n
 
-lemma two_not_dvd_two_mul_sub_one : Π {n} (w : 0 < n), ¬(2 ∣ 2 * n - 1) | (n + 1) _ :=
-two_not_dvd_two_mul_add_one n
+lemma two_not_dvd_two_mul_sub_one : Π {n} (w : 0 < n), ¬(2 ∣ 2 * n - 1)
+| (n + 1) _ := two_not_dvd_two_mul_add_one n
 
 @[parity_simps] theorem even_sub (h : n ≤ m) : even (m - n) ↔ (even m ↔ even n) :=
 begin
@@ -137,6 +137,21 @@ begin
   { exact @modeq.modeq_mul _ _ 1 _ 0 h₁ h₂ },
   exact @modeq.modeq_mul _ _ 1 _ 1 h₁ h₂
 end
+
+lemma odd_mul : odd (m * n) ↔ odd m ∧ odd n :=
+by simp [not_or_distrib] with parity_simps
+
+lemma even.mul_even (hm : even m) (hn : even n) : even (m * n) :=
+even_mul.mpr $ or.inl hm
+
+lemma even.mul_odd (hm : even m) (hn : odd n) : even (m * n) :=
+even_mul.mpr $ or.inl hm
+
+lemma odd.mul_even (hm : odd m) (hn : even n) : even (m * n) :=
+even_mul.mpr $ or.inr hn
+
+lemma odd.mul_odd (hm : odd m) (hn : odd n) : odd (m * n) :=
+odd_mul.mpr ⟨hm, hn⟩
 
 /-- If `m` and `n` are natural numbers, then the natural number `m^n` is even
 if and only if `m` is even and `n` is positive. -/

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -141,21 +141,27 @@ end
 theorem odd_mul : odd (m * n) ↔ odd m ∧ odd n :=
 by simp [not_or_distrib] with parity_simps
 
-theorem even.mul (hm : even m) (n) : even (m * n) :=
+theorem even.mul_left (hm : even m) (n) : even (m * n) :=
 even_mul.mpr $ or.inl hm
 
-theorem mul_even (m) (hn : even n) : even (m * n) :=
+theorem even.mul_right (m) (hn : even n) : even (m * n) :=
 even_mul.mpr $ or.inr hn
 
-theorem odd.mul_odd (hm : odd m) (hn : odd n) : odd (m * n) :=
+theorem odd.mul (hm : odd m) (hn : odd n) : odd (m * n) :=
 odd_mul.mpr ⟨hm, hn⟩
+
+theorem odd.of_mul_left (h : odd (m * n)) : odd m :=
+(odd_mul.mp h).1
+
+theorem odd.of_mul_right (h : odd (m * n)) : odd n :=
+(odd_mul.mp h).2
 
 /-- If `m` and `n` are natural numbers, then the natural number `m^n` is even
 if and only if `m` is even and `n` is positive. -/
 @[parity_simps] theorem even_pow : even (m^n) ↔ even m ∧ n ≠ 0 :=
 by { induction n with n ih; simp [*, pow_succ', even_mul], tauto }
 
-lemma even_div  : even (m / n) ↔ m % (2 * n) / n = 0 :=
+theorem even_div  : even (m / n) ↔ m % (2 * n) / n = 0 :=
 by rw [even_iff_two_dvd, dvd_iff_mod_eq_zero, nat.div_mod_eq_mod_mul_div, mul_comm]
 
 @[parity_simps] theorem odd_add : odd (m + n) ↔ (odd m ↔ even n) :=

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -138,19 +138,16 @@ begin
   exact @modeq.modeq_mul _ _ 1 _ 1 h₁ h₂
 end
 
-lemma odd_mul : odd (m * n) ↔ odd m ∧ odd n :=
+theorem odd_mul : odd (m * n) ↔ odd m ∧ odd n :=
 by simp [not_or_distrib] with parity_simps
 
-lemma even.mul_even (hm : even m) (hn : even n) : even (m * n) :=
+theorem even.mul (hm : even m) (n) : even (m * n) :=
 even_mul.mpr $ or.inl hm
 
-lemma even.mul_odd (hm : even m) (hn : odd n) : even (m * n) :=
-even_mul.mpr $ or.inl hm
-
-lemma odd.mul_even (hm : odd m) (hn : even n) : even (m * n) :=
+theorem mul_even (m) (hn : even n) : even (m * n) :=
 even_mul.mpr $ or.inr hn
 
-lemma odd.mul_odd (hm : odd m) (hn : odd n) : odd (m * n) :=
+theorem odd.mul_odd (hm : odd m) (hn : odd n) : odd (m * n) :=
 odd_mul.mpr ⟨hm, hn⟩
 
 /-- If `m` and `n` are natural numbers, then the natural number `m^n` is even


### PR DESCRIPTION
Lemmas pertaining to the multiplication of even and odd natural numbers.

---
I am planning a follow-up PR which will add these lemmas (along with with others that exist in `nat` but not `int`) to `data/int/parity`.
