### PR TITLE
[Merged by Bors] - feat(linear_algebra/{bilinear,quadratic}_form): inherit scalar actions from algebras

### DIFF
--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -146,27 +146,28 @@ instance : inhabited (bilin_form R M) := ⟨0⟩
 
 section
 
-instance {R : Type*} [comm_semiring R] [semimodule R M] : semimodule R (bilin_form R M) :=
+instance {R A : Type*} [comm_semiring R] [semiring A] [algebra R A] [semimodule A M] :
+  semimodule R (bilin_form A M) :=
 { smul := λ c B,
-  { bilin := λ x y, c * B x y,
+  { bilin := λ x y, c • B x y,
     bilin_add_left := λ x y z,
-      by { unfold coe_fn has_coe_to_fun.coe bilin, rw [bilin_add_left, left_distrib] },
+      by { unfold coe_fn has_coe_to_fun.coe bilin, rw [bilin_add_left, smul_add] },
     bilin_smul_left := λ a x y, by { unfold coe_fn has_coe_to_fun.coe bilin,
-      rw [bilin_smul_left, ←mul_assoc, mul_comm c, mul_assoc] },
+      rw [bilin_smul_left, ←algebra.mul_smul_comm] },
     bilin_add_right := λ x y z, by { unfold coe_fn has_coe_to_fun.coe bilin,
-      rw [bilin_add_right, left_distrib] },
+      rw [bilin_add_right, smul_add] },
     bilin_smul_right := λ a x y, by { unfold coe_fn has_coe_to_fun.coe bilin,
-      rw [bilin_smul_right, ←mul_assoc, mul_comm c, mul_assoc] } },
-  smul_add := λ c B D, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw left_distrib },
-  add_smul := λ c B D, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw right_distrib },
-  mul_smul := λ a c D, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw mul_assoc },
-  one_smul := λ B, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw one_mul },
-  zero_smul := λ B, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw zero_mul },
-  smul_zero := λ B, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw mul_zero } }
+      rw [bilin_smul_right, ←algebra.mul_smul_comm] } },
+  smul_add := λ c B D, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw smul_add },
+  add_smul := λ c B D, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw add_smul },
+  mul_smul := λ a c D, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw ←smul_assoc, refl },
+  one_smul := λ B, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw one_smul },
+  zero_smul := λ B, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw zero_smul },
+  smul_zero := λ B, by { ext, unfold coe_fn has_coe_to_fun.coe bilin, rw smul_zero } }
 
 @[simp]
-lemma smul_apply {R : Type*} [comm_semiring R] [semimodule R M]
-  (B : bilin_form R M) (a : R) (x y : M) :
+lemma smul_apply {R A : Type*} [comm_semiring R] [semiring A] [algebra R A] [semimodule A M]
+  (B : bilin_form A M) (a : R) (x y : M) :
   (a • B) x y = a • (B x y) :=
 rfl
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -146,6 +146,9 @@ instance : inhabited (bilin_form R M) := ⟨0⟩
 
 section
 
+/-- `quadratic_form A M` inherits the scalar action from any algebra over `A`.
+
+When `A` is commutative, this provides an `A`-action via `algebra.id`. -/
 instance {R A : Type*} [comm_semiring R] [semiring A] [algebra R A] [semimodule A M] :
   semimodule R (bilin_form A M) :=
 { smul := λ c B,

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -54,7 +54,6 @@ quadratic form, homogeneous polynomial, quadratic polynomial
 universes u v w
 variables {R : Type u} {M : Type v} [add_comm_group M] [ring R]
 variables {R₁ : Type u} [comm_ring R₁]
-variables {R₂ : Type u} [comm_semiring R₂]
 
 namespace quadratic_form
 /-- Up to a factor 2, `Q.polar` is the associated bilinear form for a quadratic form `Q`.d
@@ -240,6 +239,12 @@ by simp [sub_eq_add_neg]
 @[simp] lemma sub_apply (Q Q' : quadratic_form R M) (x : M) : (Q - Q') x = Q x - Q' x :=
 by simp [sub_eq_add_neg]
 
+section has_scalar
+variables {R₂ : Type u} [comm_semiring R₂]
+
+/-- `quadratic_form R M` inherits the scalar action from any algebra over `R`.
+
+When `R` is commutative, this provides an `R`-action via `algebra.id`. -/
 instance [algebra R₂ R] : has_scalar R₂ (quadratic_form R M) :=
 ⟨ λ a Q,
   { to_fun := a • Q,
@@ -276,6 +281,8 @@ instance [algebra R₂ R] : semimodule R₂ (quadratic_form R M) :=
   smul_zero := λ a, by { ext, simp only [zero_apply, smul_apply, smul_zero] },
   zero_smul := λ Q, by { ext, simp only [zero_apply, smul_apply, zero_smul] },
   add_smul := λ a b Q, by { ext, simp only [add_apply, smul_apply, add_smul] } }
+
+end has_scalar
 
 section comp
 

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -54,6 +54,7 @@ quadratic form, homogeneous polynomial, quadratic polynomial
 universes u v w
 variables {R : Type u} {M : Type v} [add_comm_group M] [ring R]
 variables {R₁ : Type u} [comm_ring R₁]
+variables {R₂ : Type u} [comm_semiring R₂]
 
 namespace quadratic_form
 /-- Up to a factor 2, `Q.polar` is the associated bilinear form for a quadratic form `Q`.d
@@ -239,28 +240,42 @@ by simp [sub_eq_add_neg]
 @[simp] lemma sub_apply (Q Q' : quadratic_form R M) (x : M) : (Q - Q') x = Q x - Q' x :=
 by simp [sub_eq_add_neg]
 
-instance : has_scalar R₁ (quadratic_form R₁ M) :=
+instance [algebra R₂ R] : has_scalar R₂ (quadratic_form R M) :=
 ⟨ λ a Q,
   { to_fun := a • Q,
-    to_fun_smul := λ b x, by simp only [pi.smul_apply, map_smul, smul_eq_mul, mul_left_comm],
-    polar_add_left' := λ x x' y, by simp only [polar_smul, polar_add_left, mul_add],
-    polar_smul_left' := λ b x y,
-      by simp only [polar_smul, polar_smul_left, smul_eq_mul, mul_left_comm],
-    polar_add_right' := λ x y y', by simp only [polar_smul, polar_add_right, mul_add],
-    polar_smul_right' := λ b x y,
-      by simp only [polar_smul, polar_smul_right, smul_eq_mul, mul_left_comm] } ⟩
+    to_fun_smul := λ b x, by rw [pi.smul_apply, map_smul, pi.smul_apply, algebra.mul_smul_comm],
+    polar_add_left' := λ x x' y, begin
+      rw [← one_smul R ⇑Q, ←smul_assoc],
+      simp only [polar_smul, polar_add_left, mul_add],
+    end,
+    polar_smul_left' := λ b x y, begin
+      rw [← one_smul R ⇑Q, ←smul_assoc],
+      simp only [polar_smul, polar_smul_left, smul_eq_mul, algebra.smul_def, ←mul_assoc, mul_one,
+        one_mul, algebra.commutes],
+    end,
+    polar_add_right' := λ x y y', begin
+      rw [← one_smul R ⇑Q, ←smul_assoc],
+      simp only [polar_smul, polar_add_right, mul_add],
+    end,
+    polar_smul_right' := λ b x y, begin
+      rw [← one_smul R ⇑Q, ←smul_assoc],
+      simp only [polar_smul, polar_smul_right, smul_eq_mul, algebra.smul_def, ←mul_assoc, mul_one,
+        one_mul, algebra.commutes],
+    end } ⟩
 
-@[simp] lemma coe_fn_smul (a : R₁) (Q : quadratic_form R₁ M) : ⇑(a • Q) = a • Q := rfl
+@[simp] lemma coe_fn_smul [algebra R₂ R] (a : R₂) (Q : quadratic_form R M) : ⇑(a • Q) = a • Q := rfl
 
-@[simp] lemma smul_apply (a : R₁) (Q : quadratic_form R₁ M) (x : M) : (a • Q) x = a * Q x := rfl
+@[simp] lemma smul_apply [algebra R₂ R] (a : R₂) (Q : quadratic_form R M) (x : M) :
+  (a • Q) x = a • Q x := rfl
 
-instance : module R₁ (quadratic_form R₁ M) :=
-{ mul_smul := λ a b Q, ext (λ x, by simp only [smul_apply, mul_left_comm, mul_assoc]),
+instance [algebra R₂ R] : semimodule R₂ (quadratic_form R M) :=
+{ mul_smul := λ a b Q, ext (λ x, by
+    simp only [smul_apply, mul_left_comm, ←smul_eq_mul, smul_assoc]),
   one_smul := λ Q, ext (λ x, by simp),
-  smul_add := λ a Q Q', by { ext, simp only [add_apply, smul_apply, mul_add] },
-  smul_zero := λ a, by { ext, simp only [zero_apply, smul_apply, mul_zero] },
-  zero_smul := λ Q, by { ext, simp only [zero_apply, smul_apply, zero_mul] },
-  add_smul := λ a b Q, by { ext, simp only [add_apply, smul_apply, add_mul] } }
+  smul_add := λ a Q Q', by { ext, simp only [add_apply, smul_apply, smul_add] },
+  smul_zero := λ a, by { ext, simp only [zero_apply, smul_apply, smul_zero] },
+  zero_smul := λ Q, by { ext, simp only [zero_apply, smul_apply, zero_smul] },
+  add_smul := λ a b Q, by { ext, simp only [add_apply, smul_apply, add_smul] } }
 
 section comp
 


### PR DESCRIPTION
For example, this means a quadratic form over the quaternions inherits an `ℝ` action.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
