### PR TITLE
[Merged by Bors] - feat(algebra,linear_algebra): `{smul,lmul,lsmul}_injective`

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1185,6 +1185,16 @@ namespace algebra
 
 variables {R A : Type*} [comm_semiring R] [ring A] [algebra R A]
 
+lemma lmul_left_injective [no_zero_divisors A] {x : A} (hx : x ≠ 0) :
+  function.injective (lmul_left R x) :=
+by { letI : domain A := { exists_pair_ne := ⟨x, 0, hx⟩, ..‹ring A›, ..‹no_zero_divisors A› },
+     exact mul_right_injective' hx }
+
+lemma lmul_right_injective [no_zero_divisors A] {x : A} (hx : x ≠ 0) :
+  function.injective (lmul_right R x) :=
+by { letI : domain A := { exists_pair_ne := ⟨x, 0, hx⟩, ..‹ring A›, ..‹no_zero_divisors A› },
+     exact mul_left_injective' hx }
+
 lemma lmul_injective [no_zero_divisors A] {x : A} (hx : x ≠ 0) :
   function.injective (lmul R A x) :=
 by { letI : domain A := { exists_pair_ne := ⟨x, 0, hx⟩, ..‹ring A›, ..‹no_zero_divisors A› },

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1186,7 +1186,7 @@ namespace algebra
 variables {R A : Type*} [comm_semiring R] [domain A] [algebra R A]
 
 lemma lmul_injective {x : A} (hx : x ≠ 0) : function.injective (lmul R A x) :=
-mul_left_injective' hx
+mul_right_injective' hx
 
 end algebra
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1179,6 +1179,20 @@ instance linear_map.semimodule' (R : Type u) [comm_semiring R]
 
 end algebra
 
+section domain
+
+namespace algebra
+
+variables {R A : Type*} [comm_semiring R] [domain A] [algebra R A]
+
+lemma lmul_injective {x : A} (hx : x ≠ 0) : function.injective (lmul R A x) :=
+(lmul R A x).to_add_monoid_hom.injective_iff.mpr
+  (λ y h, (eq_zero_or_eq_zero_of_mul_eq_zero h).resolve_left hx)
+
+end algebra
+
+end domain
+
 section nat
 
 variables (R : Type*) [semiring R]

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1186,8 +1186,7 @@ namespace algebra
 variables {R A : Type*} [comm_semiring R] [domain A] [algebra R A]
 
 lemma lmul_injective {x : A} (hx : x ≠ 0) : function.injective (lmul R A x) :=
-(lmul R A x).to_add_monoid_hom.injective_iff.mpr
-  (λ y h, (eq_zero_or_eq_zero_of_mul_eq_zero h).resolve_left hx)
+mul_left_injective' hx
 
 end algebra
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1179,18 +1179,20 @@ instance linear_map.semimodule' (R : Type u) [comm_semiring R]
 
 end algebra
 
-section domain
+section ring
 
 namespace algebra
 
-variables {R A : Type*} [comm_semiring R] [domain A] [algebra R A]
+variables {R A : Type*} [comm_semiring R] [ring A] [algebra R A]
 
-lemma lmul_injective {x : A} (hx : x ≠ 0) : function.injective (lmul R A x) :=
-mul_right_injective' hx
+lemma lmul_injective [no_zero_divisors A] {x : A} (hx : x ≠ 0) :
+  function.injective (lmul R A x) :=
+by { letI : domain A := { exists_pair_ne := ⟨x, 0, hx⟩, ..‹ring A›, ..‹no_zero_divisors A› },
+     exact mul_right_injective' hx }
 
 end algebra
 
-end domain
+end ring
 
 section nat
 

--- a/src/algebra/algebra/tower.lean
+++ b/src/algebra/algebra/tower.lean
@@ -275,3 +275,18 @@ le_antisymm (span_le.2 $ λ x hx, let ⟨p, q, hps, hqt, hpqx⟩ := set.mem_smul
 end submodule
 
 end semiring
+
+section ring
+
+namespace algebra
+
+variables [comm_semiring R] [ring A]  [algebra R A]
+variables [add_comm_group M] [module A M] [semimodule R M] [is_scalar_tower R A M]
+
+lemma lsmul_injective [no_zero_smul_divisors A M] {x : A} (hx : x ≠ 0) :
+  function.injective (lsmul R M x) :=
+smul_injective hx
+
+end algebra
+
+end ring

--- a/src/algebra/algebra/tower.lean
+++ b/src/algebra/algebra/tower.lean
@@ -280,7 +280,7 @@ section ring
 
 namespace algebra
 
-variables [comm_semiring R] [ring A]  [algebra R A]
+variables [comm_semiring R] [ring A] [algebra R A]
 variables [add_comm_group M] [module A M] [semimodule R M] [is_scalar_tower R A M]
 
 lemma lsmul_injective [no_zero_smul_divisors A M] {x : A} (hx : x ≠ 0) :

--- a/src/algebra/group_with_zero/defs.lean
+++ b/src/algebra/group_with_zero/defs.lean
@@ -74,6 +74,12 @@ cancel_monoid_with_zero.mul_left_cancel_of_ne_zero ha h
 lemma mul_right_cancel' (hb : b ≠ 0) (h : a * b = c * b) : a = c :=
 cancel_monoid_with_zero.mul_right_cancel_of_ne_zero hb h
 
+lemma mul_left_injective' (ha : a ≠ 0) : function.injective (λ b, a * b) :=
+λ b c, mul_left_cancel' ha
+
+lemma mul_right_injective' (hb : b ≠ 0) : function.injective (λ a, a * b) :=
+λ a c, mul_right_cancel' hb
+
 end cancel_monoid_with_zero
 
 /-- A type `M` is a commutative “monoid with zero” if it is a commutative monoid with zero

--- a/src/algebra/group_with_zero/defs.lean
+++ b/src/algebra/group_with_zero/defs.lean
@@ -74,10 +74,10 @@ cancel_monoid_with_zero.mul_left_cancel_of_ne_zero ha h
 lemma mul_right_cancel' (hb : b ≠ 0) (h : a * b = c * b) : a = c :=
 cancel_monoid_with_zero.mul_right_cancel_of_ne_zero hb h
 
-lemma mul_left_injective' (ha : a ≠ 0) : function.injective (λ b, a * b) :=
+lemma mul_right_injective' (ha : a ≠ 0) : function.injective (λ b, a * b) :=
 λ b c, mul_left_cancel' ha
 
-lemma mul_right_injective' (hb : b ≠ 0) : function.injective (λ a, a * b) :=
+lemma mul_left_injective' (hb : b ≠ 0) : function.injective (λ a, a * b) :=
 λ a c, mul_right_cancel' hb
 
 end cancel_monoid_with_zero

--- a/src/algebra/group_with_zero/defs.lean
+++ b/src/algebra/group_with_zero/defs.lean
@@ -74,10 +74,10 @@ cancel_monoid_with_zero.mul_left_cancel_of_ne_zero ha h
 lemma mul_right_cancel' (hb : b ≠ 0) (h : a * b = c * b) : a = c :=
 cancel_monoid_with_zero.mul_right_cancel_of_ne_zero hb h
 
-lemma mul_right_injective' (ha : a ≠ 0) : function.injective (λ b, a * b) :=
+lemma mul_right_injective' (ha : a ≠ 0) : function.injective ((*) a) :=
 λ b c, mul_left_cancel' ha
 
-lemma mul_left_injective' (hb : b ≠ 0) : function.injective ((*) a) :=
+lemma mul_left_injective' (hb : b ≠ 0) : function.injective (λ a, a * b) :=
 λ a c, mul_right_cancel' hb
 
 end cancel_monoid_with_zero

--- a/src/algebra/group_with_zero/defs.lean
+++ b/src/algebra/group_with_zero/defs.lean
@@ -77,7 +77,7 @@ cancel_monoid_with_zero.mul_right_cancel_of_ne_zero hb h
 lemma mul_right_injective' (ha : a ≠ 0) : function.injective (λ b, a * b) :=
 λ b c, mul_left_cancel' ha
 
-lemma mul_left_injective' (hb : b ≠ 0) : function.injective (λ a, a * b) :=
+lemma mul_left_injective' (hb : b ≠ 0) : function.injective ((*) a) :=
 λ a c, mul_right_cancel' hb
 
 end cancel_monoid_with_zero

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -509,6 +509,12 @@ section module
 
 variables [ring R] [add_comm_group M] [module R M]
 
+lemma smul_injective [no_zero_smul_divisors R M] {c : R} (hc : c ≠ 0) :
+  function.injective (λ (x : M), c • x) :=
+λ x y h, sub_eq_zero.mp ((smul_eq_zero.mp
+  (calc c • (x - y) = c • x - c • y : smul_sub c x y
+                ... = 0 : sub_eq_zero.mpr h)).resolve_left hc)
+
 section nat
 
 variables (R) [no_zero_smul_divisors R M] [char_zero R]

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -505,9 +505,9 @@ end nat
 
 end semimodule
 
-section module
+section add_comm_group -- `R` can still be a semiring here
 
-variables [ring R] [add_comm_group M] [module R M]
+variables [semiring R] [add_comm_group M] [semimodule R M]
 
 lemma smul_injective [no_zero_smul_divisors R M] {c : R} (hc : c ≠ 0) :
   function.injective (λ (x : M), c • x) :=
@@ -531,7 +531,15 @@ begin
   abel
 end
 
-variables {R}
+end nat
+
+end add_comm_group
+
+section module
+
+section nat
+
+variables {R} [ring R] [add_comm_group M] [module R M] [no_zero_smul_divisors R M] [char_zero R]
 
 lemma ne_neg_of_ne_zero [no_zero_divisors R] {v : R} (hv : v ≠ 0) : v ≠ -v :=
 λ h, have semimodule ℕ R := add_comm_monoid.nat_semimodule, by exactI hv (eq_zero_of_eq_neg R h)

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -190,6 +190,16 @@ variables {R M}
 
 end comm_semiring
 
+section comm_ring
+
+variables {R M : Type*} [comm_ring R] [add_comm_group M] [module R M]
+
+lemma lsmul_injective [no_zero_smul_divisors R M] {x : R} (hx : x ≠ 0) :
+  function.injective (lsmul R M x) :=
+smul_injective hx
+
+end comm_ring
+
 end linear_map
 
 section semiring


### PR DESCRIPTION
This PR proves a few injectivity results for (scalar) multiplication in the setting of modules and algebras over a ring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
