### PR TITLE
[Merged by Bors] - feat(algebra/group_power/basic): add abs_add_eq_add_abs_iff

### DIFF
--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -478,6 +478,58 @@ begin
   apply nsmul_nonneg H
 end
 
+lemma abs_nsmul {α : Type*} [linear_ordered_add_comm_group α] (n : ℕ) (a : α) :
+  abs (n •ℕ a) = n •ℕ abs a :=
+begin
+  cases le_total a 0 with hneg hpos,
+  { have h : 0 ≤ n •ℕ (-a) := nsmul_nonneg (neg_nonneg.mpr hneg) n,
+    rw [abs_of_nonpos hneg, ← abs_neg, ← neg_nsmul, abs_of_nonneg h] },
+  { have h : 0 ≤ n •ℕ a := nsmul_nonneg hpos n,
+    rw [abs_of_nonneg hpos, abs_of_nonneg h] }
+end
+
+lemma abs_add_eq_add_abs_iff {α : Type*} [linear_ordered_add_comm_group α]  (a b : α) :
+  abs (a + b) = abs a + abs b ↔ (0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0) :=
+begin
+  rcases lt_trichotomy a b with hlt | heq | hgt,
+  swap,
+  { rw [heq, and_self, ← two_nsmul b, ← two_nsmul (abs b), abs_nsmul],
+  simp only [true_iff, eq_self_iff_true, and_self, le_total 0 b] },
+  repeat { split },
+  { intro h,
+    rcases ⟨le_total 0 a, le_total 0 b⟩ with ⟨pa|na, pb|nb⟩,
+    { exact or.inl ⟨pa, pb⟩ },
+    { exfalso,
+      exact not_lt.2 nb (lt_of_le_of_lt pa hlt) },
+    { rw [abs_of_nonneg pb, abs_of_nonpos na] at h,
+      cases le_total (a + b) 0 with sumn sump,
+      { rw [abs_of_nonpos sumn, neg_add, add_right_inj (-a)] at h,
+        exact or.inr ⟨na, le_of_eq (eq_zero_of_neg_eq h)⟩ },
+      { rw [abs_of_nonneg sump, add_left_inj b] at h,
+        exact or.inl ⟨le_of_eq (eq_zero_of_neg_eq h.symm).symm, pb⟩ } },
+    { exact or.inr ⟨na, nb⟩ } },
+  { intro h,
+    cases h with p n,
+    { rw [abs_of_nonneg p.1, abs_of_nonneg p.2, abs_of_nonneg (add_nonneg p.1 p.2)] },
+    { rw [abs_of_nonpos n.1, abs_of_nonpos n.2, abs_of_nonpos (add_nonpos n.1 n.2), neg_add] } },
+  { intro h,
+    rcases ⟨le_total 0 a, le_total 0 b⟩ with ⟨pa|na, pb|nb⟩,
+    { exact or.inl ⟨pa, pb⟩ },
+    { rw [abs_of_nonneg pa, abs_of_nonpos nb] at h,
+      cases le_total (a + b) 0 with sumn sump,
+      { rw [abs_of_nonpos sumn, neg_add, add_left_inj (-b)] at h,
+        exact or.inr ⟨le_of_eq (eq_zero_of_neg_eq h), nb⟩ },
+      { rw [abs_of_nonneg sump, add_right_inj a] at h,
+        exact or.inl ⟨pa, le_of_eq (eq_zero_of_neg_eq h.symm).symm⟩ } },
+    { exfalso,
+      exact not_lt.2 na (lt_of_le_of_lt pb hgt) },
+    { exact or.inr ⟨na, nb⟩ } },
+  { intro h,
+    cases h with pp nn,
+    { rw [abs_of_nonneg pp.1, abs_of_nonneg pp.2, abs_of_nonneg (add_nonneg pp.1 pp.2)] },
+    { rw [abs_of_nonpos nn.1, abs_of_nonpos nn.2, abs_of_nonpos (add_nonpos nn.1 nn.2), neg_add] } }
+end
+
 end add_group
 
 section cancel_add_monoid

--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -478,58 +478,6 @@ begin
   apply nsmul_nonneg H
 end
 
-lemma abs_nsmul {α : Type*} [linear_ordered_add_comm_group α] (n : ℕ) (a : α) :
-  abs (n •ℕ a) = n •ℕ abs a :=
-begin
-  cases le_total a 0 with hneg hpos,
-  { have h : 0 ≤ n •ℕ (-a) := nsmul_nonneg (neg_nonneg.mpr hneg) n,
-    rw [abs_of_nonpos hneg, ← abs_neg, ← neg_nsmul, abs_of_nonneg h] },
-  { have h : 0 ≤ n •ℕ a := nsmul_nonneg hpos n,
-    rw [abs_of_nonneg hpos, abs_of_nonneg h] }
-end
-
-lemma abs_add_eq_add_abs_iff {α : Type*} [linear_ordered_add_comm_group α]  (a b : α) :
-  abs (a + b) = abs a + abs b ↔ (0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0) :=
-begin
-  rcases lt_trichotomy a b with hlt | heq | hgt,
-  swap,
-  { rw [heq, and_self, ← two_nsmul b, ← two_nsmul (abs b), abs_nsmul],
-  simp only [true_iff, eq_self_iff_true, and_self, le_total 0 b] },
-  repeat { split },
-  { intro h,
-    rcases ⟨le_total 0 a, le_total 0 b⟩ with ⟨pa|na, pb|nb⟩,
-    { exact or.inl ⟨pa, pb⟩ },
-    { exfalso,
-      exact not_lt.2 nb (lt_of_le_of_lt pa hlt) },
-    { rw [abs_of_nonneg pb, abs_of_nonpos na] at h,
-      cases le_total (a + b) 0 with sumn sump,
-      { rw [abs_of_nonpos sumn, neg_add, add_right_inj (-a)] at h,
-        exact or.inr ⟨na, le_of_eq (eq_zero_of_neg_eq h)⟩ },
-      { rw [abs_of_nonneg sump, add_left_inj b] at h,
-        exact or.inl ⟨le_of_eq (eq_zero_of_neg_eq h.symm).symm, pb⟩ } },
-    { exact or.inr ⟨na, nb⟩ } },
-  { intro h,
-    cases h with p n,
-    { rw [abs_of_nonneg p.1, abs_of_nonneg p.2, abs_of_nonneg (add_nonneg p.1 p.2)] },
-    { rw [abs_of_nonpos n.1, abs_of_nonpos n.2, abs_of_nonpos (add_nonpos n.1 n.2), neg_add] } },
-  { intro h,
-    rcases ⟨le_total 0 a, le_total 0 b⟩ with ⟨pa|na, pb|nb⟩,
-    { exact or.inl ⟨pa, pb⟩ },
-    { rw [abs_of_nonneg pa, abs_of_nonpos nb] at h,
-      cases le_total (a + b) 0 with sumn sump,
-      { rw [abs_of_nonpos sumn, neg_add, add_left_inj (-b)] at h,
-        exact or.inr ⟨le_of_eq (eq_zero_of_neg_eq h), nb⟩ },
-      { rw [abs_of_nonneg sump, add_right_inj a] at h,
-        exact or.inl ⟨pa, le_of_eq (eq_zero_of_neg_eq h.symm).symm⟩ } },
-    { exfalso,
-      exact not_lt.2 na (lt_of_le_of_lt pb hgt) },
-    { exact or.inr ⟨na, nb⟩ } },
-  { intro h,
-    cases h with pp nn,
-    { rw [abs_of_nonneg pp.1, abs_of_nonneg pp.2, abs_of_nonneg (add_nonneg pp.1 pp.2)] },
-    { rw [abs_of_nonpos nn.1, abs_of_nonpos nn.2, abs_of_nonpos (add_nonpos nn.1 nn.2), neg_add] } }
-end
-
 end add_group
 
 section cancel_add_monoid

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -224,7 +224,7 @@ begin
     rwa eq_zero_of_neg_eq h.symm at F }
 end
 
-lemma abs_add_eq_add_abs_iff {α : Type*} [linear_ordered_add_comm_group α]  (a b : α) :
+lemma abs_add_eq_add_abs_iff {α : Type*} [linear_ordered_add_comm_group α] (a b : α) :
   abs (a + b) = abs a + abs b ↔ (0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0) :=
 begin
   by_cases ab : a ≤ b,

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -195,16 +195,13 @@ end
 lemma abs_gsmul {α : Type*} [linear_ordered_add_comm_group α] (n : ℤ) (a : α) :
   abs (n •ℤ a) = (abs n) •ℤ abs a :=
 begin
-  induction n,
-  { simp only [coe_nat_abs, gsmul_coe_nat, of_nat_eq_coe, abs_nsmul] },
-  have h₁ : -[1+ n] ≤ 0 := sup_eq_left.mp rfl,
-  cases le_total a 0 with hneg hpos,
-  { have h : 0 ≤ n.succ •ℕ (-a) := nsmul_nonneg (neg_nonneg.mpr hneg) n.succ,
-    rw [gsmul_neg_succ_of_nat, ← neg_nsmul, abs_of_nonneg h, abs_of_nonpos h₁, abs_of_nonpos hneg],
-    simp only [gsmul_neg_succ_of_nat, neg_gsmul, neg_neg] },
-  { have h : 0 ≤ n.succ •ℕ a := nsmul_nonneg hpos (nat.succ n),
-    rw [gsmul_neg_succ_of_nat, abs_neg, abs_of_nonneg h, abs_of_nonneg hpos, abs_of_nonpos h₁],
-    simp only [gsmul_neg_succ_of_nat, neg_gsmul, neg_neg] }
+  by_cases n0 : 0 ≤ n,
+  { lift n to ℕ using n0,
+    simp only [abs_nsmul, coe_nat_abs, gsmul_coe_nat] },
+  { lift (- n) to ℕ using int.le_of_lt (neg_pos.mpr (not_le.mp n0)) with m,
+    rw [← abs_neg (n •ℤ a), ← neg_gsmul, ← abs_neg n, ← h],
+    convert abs_nsmul m _,
+    simp only [coe_nat_abs, gsmul_coe_nat] },
 end
 
 lemma abs_add_eq_add_abs_le {α : Type*} [linear_ordered_add_comm_group α] {a b : α} (hle : a ≤ b) :

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -229,8 +229,7 @@ begin
       { rw [abs_of_nonneg sump, add_left_inj b] at h,
         exact or.inl ⟨le_of_eq (eq_zero_of_neg_eq h.symm).symm, pb⟩ } },
     { exact or.inr ⟨na, nb⟩ } },
-  { intro h,
-    cases h with p n,
+  { rintro (p | n),
     { rw [abs_of_nonneg p.1, abs_of_nonneg p.2, abs_of_nonneg (add_nonneg p.1 p.2)] },
     { rw [abs_of_nonpos n.1, abs_of_nonpos n.2, abs_of_nonpos (add_nonpos n.1 n.2), neg_add] } }
 end

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -198,7 +198,7 @@ begin
   by_cases n0 : 0 ≤ n,
   { lift n to ℕ using n0,
     simp only [abs_nsmul, coe_nat_abs, gsmul_coe_nat] },
-  { lift (- n) to ℕ using int.le_of_lt (neg_pos.mpr (not_le.mp n0)) with m,
+  { lift (- n) to ℕ using int.le_of_lt (neg_pos.mpr (not_le.mp n0)) with m h,
     rw [← abs_neg (n •ℤ a), ← neg_gsmul, ← abs_neg n, ← h],
     convert abs_nsmul m _,
     simp only [coe_nat_abs, gsmul_coe_nat] },

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -208,30 +208,33 @@ begin
     simp only [gsmul_neg_succ_of_nat, neg_gsmul, neg_neg] }
 end
 
+lemma abs_add_eq_add_abs_le {α : Type*} [linear_ordered_add_comm_group α] {a b : α} (hle : a ≤ b) :
+  abs (a + b) = abs a + abs b ↔ (0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0) :=
+begin
+  by_cases a0 : 0 ≤ a; by_cases b0 : 0 ≤ b,
+  { simp [a0, b0, abs_of_nonneg, add_nonneg a0 b0] },
+  { exact (lt_irrefl (0 : α) (a0.trans_lt (hle.trans_lt (not_le.mp b0)))).elim },
+  any_goals { simp [(not_le.mp a0).le, (not_le.mp b0).le, abs_of_nonpos, add_nonpos, add_comm] },
+  obtain F := (not_le.mp a0),
+  have : (abs (a + b) = -a + b ↔ b ≤ 0) ↔ (abs (a + b) =
+    abs a + abs b ↔ 0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0),
+  { simp [a0, b0, abs_of_neg, abs_of_nonneg, F, F.le] },
+  refine this.mp ⟨λ h, _, λ h, by simp only [le_antisymm h b0, abs_of_neg F, add_zero]⟩,
+  by_cases ba : a + b ≤ 0,
+  { refine le_of_eq (eq_zero_of_neg_eq _),
+    rwa [abs_of_nonpos ba, neg_add_rev, add_comm, add_right_inj] at h },
+  { refine (lt_irrefl (0 : α) _).elim,
+    rw [abs_of_pos (not_le.mp ba), add_left_inj] at h,
+    rwa eq_zero_of_neg_eq h.symm at F }
+end
+
 lemma abs_add_eq_add_abs_iff {α : Type*} [linear_ordered_add_comm_group α]  (a b : α) :
   abs (a + b) = abs a + abs b ↔ (0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0) :=
 begin
-  wlog hle : a ≤ b using [a b, b a],
-  { exact le_total a b },
-  cases eq_or_lt_of_le hle with heq hlt,
-  { rw [heq, and_self, ← two_nsmul b, ← two_nsmul (abs b), abs_nsmul],
-  simp only [true_iff, eq_self_iff_true, and_self, le_total 0 b] },
-  split,
-  { intro h,
-    rcases ⟨le_total 0 a, le_total 0 b⟩ with ⟨pa|na, pb|nb⟩,
-    { exact or.inl ⟨pa, pb⟩ },
-    { exfalso,
-      exact not_lt.2 nb (lt_of_le_of_lt pa hlt) },
-    { rw [abs_of_nonneg pb, abs_of_nonpos na] at h,
-      cases le_total (a + b) 0 with sumn sump,
-      { rw [abs_of_nonpos sumn, neg_add, add_right_inj (-a)] at h,
-        exact or.inr ⟨na, le_of_eq (eq_zero_of_neg_eq h)⟩ },
-      { rw [abs_of_nonneg sump, add_left_inj b] at h,
-        exact or.inl ⟨le_of_eq (eq_zero_of_neg_eq h.symm).symm, pb⟩ } },
-    { exact or.inr ⟨na, nb⟩ } },
-  { rintro (p | n),
-    { rw [abs_of_nonneg p.1, abs_of_nonneg p.2, abs_of_nonneg (add_nonneg p.1 p.2)] },
-    { rw [abs_of_nonpos n.1, abs_of_nonpos n.2, abs_of_nonpos (add_nonpos n.1 n.2), neg_add] } }
+  by_cases ab : a ≤ b,
+  { exact abs_add_eq_add_abs_le ab },
+  { rw [add_comm a, add_comm (abs _), abs_add_eq_add_abs_le ((not_le.mp ab).le), and.comm,
+    @and.comm (b ≤ 0 ) _] }
 end
 
 end ordered_add_comm_group

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -10,7 +10,6 @@ import data.int.cast
 import data.equiv.basic
 import data.equiv.mul_add
 import deprecated.group
-import tactic.wlog
 
 /-!
 # Lemmas about power operations on monoids and groups

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -187,10 +187,10 @@ lemma abs_nsmul {α : Type*} [linear_ordered_add_comm_group α] (n : ℕ) (a : �
   abs (n •ℕ a) = n •ℕ abs a :=
 begin
   cases le_total a 0 with hneg hpos,
-  { have h : 0 ≤ n •ℕ (-a) := nsmul_nonneg (neg_nonneg.mpr hneg) n,
-    rw [abs_of_nonpos hneg, ← abs_neg, ← neg_nsmul, abs_of_nonneg h] },
-  { have h : 0 ≤ n •ℕ a := nsmul_nonneg hpos n,
-    rw [abs_of_nonneg hpos, abs_of_nonneg h] }
+  { rw [abs_of_nonpos hneg, ← abs_neg, ← neg_nsmul, abs_of_nonneg],
+    exact nsmul_nonneg (neg_nonneg.mpr hneg) n },
+  { rw [abs_of_nonneg hpos, abs_of_nonneg],
+    exact nsmul_nonneg hpos n }
 end
 
 lemma abs_gsmul {α : Type*} [linear_ordered_add_comm_group α] (n : ℤ) (a : α) :


### PR DESCRIPTION
I've added
```
lemma abs_add_eq_add_abs_iff {α : Type*} [linear_ordered_add_comm_group α]  (a b : α) :
  abs (a + b) = abs a + abs b ↔ (0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0)
```
from `lean-liquid`. For some reasons I am not able to use `wlog hle : a ≤ b using [a b, b a]` at the beginning of the proof, Lean says `unknown identifier 'wlog'` and if I try to import `tactic.wlog` I have tons of errors.