### PR TITLE
[Merged by Bors] - chore(topology/algebra/ordered): use dot notation, golf some proofs

### DIFF
--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -285,6 +285,15 @@ lemma is_greatest.union [linear_order γ] {a b : γ} {s t : set γ}
 ⟨by cases (le_total a b) with h h; simp [h, ha.1, hb.1],
   (ha.is_lub.union hb.is_lub).1⟩
 
+lemma is_lub.inter_Ici_of_mem [linear_order γ] {s : set γ} {a b : γ} (ha : is_lub s a)
+  (hb : b ∈ s) : is_lub (s ∩ Ici b) a :=
+⟨λ x hx, ha.1 hx.1, λ c hc, have hbc : b ≤ c, from hc ⟨hb, le_rfl⟩,
+  ha.2 $ λ x hx, (le_total x b).elim (λ hxb, hxb.trans hbc) $ λ hbx, hc ⟨hx, hbx⟩⟩
+
+lemma is_glb.inter_Iic_of_mem [linear_order γ] {s : set γ} {a b : γ} (ha : is_glb s a)
+  (hb : b ∈ s) : is_glb (s ∩ Iic b) a :=
+@is_lub.inter_Ici_of_mem (order_dual γ) _ _ _ _ ha hb
+
 /-!
 ### Specific sets
 

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -975,6 +975,10 @@ lemma frequently.mp {p q : α → Prop} {f : filter α} (h : ∃ᶠ x in f, p x)
   ∃ᶠ x in f, q x :=
 mt (λ hq, hq.mp $ hpq.mono $ λ x, mt) h
 
+lemma frequently.filter_mono {p : α → Prop} {f g : filter α} (h : ∃ᶠ x in f, p x) (hle : f ≤ g) :
+  ∃ᶠ x in g, p x :=
+mt (λ h', h'.filter_mono hle) h
+
 lemma frequently.mono {p q : α → Prop} {f : filter α} (h : ∃ᶠ x in f, p x)
   (hpq : ∀ x, p x → q x) :
   ∃ᶠ x in f, q x :=

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -310,6 +310,10 @@ closure_minimal (subset.trans h subset_closure) is_closed_closure
 lemma monotone_closure (α : Type*) [topological_space α] : monotone (@closure α _) :=
 λ _ _, closure_mono
 
+lemma diff_subset_closure_iff {s t : set α} :
+  s \ t ⊆ closure t ↔ s ⊆ closure t :=
+by rw [diff_subset_iff, union_eq_self_of_subset_left subset_closure]
+
 lemma closure_inter_subset_inter_closure (s t : set α) :
   closure (s ∩ t) ⊆ closure s ∩ closure t :=
 (monotone_closure α).map_inf_le s t

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -354,7 +354,7 @@ lemma bsupr_add {ι} {s : set ι} (hs : s.nonempty) {f : ι → ℝ≥0∞} :
 begin
   simp only [← Sup_image], symmetry,
   rw [image_comp (+ a)],
-  refine is_lub.Sup_eq (is_lub_of_is_lub_of_tendsto _ (is_lub_Sup _) (hs.image _) _),
+  refine is_lub.Sup_eq ((is_lub_Sup $ f '' s).is_lub_of_tendsto _ (hs.image _) _),
   exacts [λ x _ y _ hxy, add_le_add hxy le_rfl,
     tendsto.add (tendsto_id' inf_le_left) tendsto_const_nhds]
 end
@@ -415,9 +415,8 @@ begin
     have s₁ : Sup s ≠ 0 :=
       pos_iff_ne_zero.1 (lt_of_lt_of_le (pos_iff_ne_zero.2 hx0) (le_Sup hx)),
     have : Sup ((λb, a * b) '' s) = a * Sup s :=
-      is_lub.Sup_eq (is_lub_of_is_lub_of_tendsto
+      is_lub.Sup_eq ((is_lub_Sup s).is_lub_of_tendsto
         (assume x _ y _ h, canonically_ordered_semiring.mul_le_mul (le_refl _) h)
-        (is_lub_Sup _)
         ⟨x, hx⟩
         (ennreal.tendsto.const_mul (tendsto_id' inf_le_left) (or.inl s₁))),
     rw [this.symm, Sup_image] }
@@ -439,16 +438,14 @@ begin
     by simp [le_of_lt] {contextual := tt})) tendsto_const_nhds
 end
 
-lemma sub_supr {ι : Sort*} [hι : nonempty ι] {b : ι → ℝ≥0∞} (hr : a < ⊤) :
+lemma sub_supr {ι : Sort*} [nonempty ι] {b : ι → ℝ≥0∞} (hr : a < ⊤) :
   a - (⨆i, b i) = (⨅i, a - b i) :=
-let ⟨i⟩ := hι in
 let ⟨r, eq, _⟩ := lt_iff_exists_coe.mp hr in
 have Inf ((λb, ↑r - b) '' range b) = ↑r - (⨆i, b i),
-  from is_glb.Inf_eq $ is_glb_of_is_lub_of_tendsto
+  from is_glb.Inf_eq $ is_lub_supr.is_glb_of_tendsto
     (assume x _ y _, sub_le_sub (le_refl _))
-    is_lub_supr
-    ⟨_, i, rfl⟩
-    (tendsto.comp ennreal.tendsto_coe_sub (tendsto_id' inf_le_left)),
+    (range_nonempty _)
+    (ennreal.tendsto_coe_sub.comp (tendsto_id' inf_le_left)),
 by rw [eq, ←this]; simp [Inf_image, infi_range, -mem_range]; exact le_refl _
 
 lemma supr_eq_zero {ι : Sort*} {f : ι → ℝ≥0∞} : (⨆ i, f i) = 0 ↔ ∀ i, f i = 0 :=


### PR DESCRIPTION
Use more precise typeclass arguments here and there, golf some proofs, use dot notation.

### Renamed lemmas

* `is_lub_of_is_lub_of_tendsto` → `is_lub.is_lub_of_tendsto`;
* `is_glb_of_is_glb_of_tendsto` → `is_glb.is_glb_of_tendsto`;
* `is_glb_of_is_lub_of_tendsto` → `is_lub.is_glb_of_tendsto`;
* `is_lub_of_is_glb_of_tendsto` → `is_glb.is_lub_of_tendsto`;
* `mem_closure_of_is_lub` → `is_lub.mem_closure`;
* `mem_of_is_lub_of_is_closed` → `is_lub.mem_of_is_closed`, `is_closed.is_lub_mem`;
* `mem_closure_of_is_glb` → `is_glb.mem_closure`;
* `mem_of_is_glb_of_is_closed` → `is_glb.mem_of_is_closed`, `is_closed.is_glb_mem`;

### New lemmas

* `is_lub.inter_Ici_of_mem`
* `is_glb.inter_Iic_of_mem`
* `frequently.filter_mono`
* `is_lub.frequently_mem`
* `is_lub.frequently_nhds_mem`
* `is_glb.frequently_mem`
* `is_glb.frequently_nhds_mem`
* `is_lub.mem_upper_bounds_of_tendsto`
* `is_glb.mem_lower_bounds_of_tendsto`
* `is_lub.mem_lower_bounds_of_tendsto`
* `is_glb.mem_upper_bounds_of_tendsto`
* `diff_subset_closure_iff`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->