### PR TITLE
fix(linear_algebra/quadratic_form): fix a universe issue

### DIFF
--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -53,9 +53,9 @@ confusion between `*` from `ring` and `*` from `comm_ring`.
 quadratic form, homogeneous polynomial, quadratic polynomial
 -/
 
-universes u v w
+universes u u₁ v w
 variables {R : Type u} {M : Type v} [add_comm_group M] [ring R]
-variables {R₁ : Type u} [comm_ring R₁]
+variables {R₁ : Type u₁} [comm_ring R₁]
 
 namespace quadratic_form
 /-- Up to a factor 2, `Q.polar` is the associated bilinear form for a quadratic form `Q`.d

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -53,7 +53,7 @@ confusion between `*` from `ring` and `*` from `comm_ring`.
 quadratic form, homogeneous polynomial, quadratic polynomial
 -/
 
-universes u u₁ v w
+universes u u₁ u₂ v w
 variables {R : Type u} {M : Type v} [add_comm_group M] [ring R]
 variables {R₁ : Type u₁} [comm_ring R₁]
 
@@ -242,7 +242,7 @@ by simp [sub_eq_add_neg]
 by simp [sub_eq_add_neg]
 
 section has_scalar
-variables {R₂ : Type u} [comm_semiring R₂]
+variables {R₂ : Type u₂} [comm_semiring R₂]
 
 /-- `quadratic_form R M` inherits the scalar action from any algebra over `R`.
 


### PR DESCRIPTION
Without this, the `quadratic_form.semimodule` instance isn't found when `R` and `R₁` are in different universes (as they are in almost all universe-polymorphic lemmas)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
