### PR TITLE
[Merged by Bors] - ci(.github/workflows/build.yml): do not install azcopy, change upload logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           python-version: 3.8
 
       - name: try to find olean cache
-        run: ./scripts/fetch_olean_cache.sh
+        run: ./scripts/fetch_olean_cache.shfail
 
       - name: leanpkg build
         id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,46 +69,23 @@ jobs:
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
           echo "short_lean_version=$(~/.elan/bin/lean --run scripts/lean_version.lean)" >> $GITHUB_ENV
 
-      - name: get azcopy version
-        id: azcopy_version
-        run: echo "::set-output name=ver::$(curl -s -D- https://aka.ms/downloadazcopy-v10-linux | grep ^Location | cut -d" " -f2)"
-
-      - name: cache azcopy
-        uses: actions/cache@v2.1.4
-        id: cache_azcopy
-        with:
-          # A list of files, directories, and wildcard patterns to cache and restore
-          path: |
-            /usr/local/bin/azcopy
-          # An explicit key for restoring and saving the cache
-          key: ${{ steps.azcopy_version.outputs.ver }}
-
-      - name: install azcopy
-        if: steps.cache_azcopy.outputs.cache-hit != 'true'
-        run: |
-          cd /usr/local/bin
-          wget -q https://aka.ms/downloadazcopy-v10-linux -O - | sudo tar zxf - --strip-components 1 --wildcards '*/azcopy'
-          sudo chmod 755 /usr/local/bin/azcopy
-
       - name: install Python
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
 
       - name: try to find olean cache
-        id: find_olean_cache
-        run: |
-          ./scripts/fetch_olean_cache.sh
-          echo "::set-output name=success::true"
+        run: ./scripts/fetch_olean_cache.sh
 
       - name: leanpkg build
         id: build
         run: |
           leanpkg configure
+          echo "::set-output name=started::true"
           lean --json -T100000 --make src | python scripts/detect_errors.py
 
       - name: push release to azure
-        if: always() && github.repository == 'leanprover-community/mathlib' && steps.find_olean_cache.outputs.success == 'true'
+        if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'
         run: |
           archive_name="$(git rev-parse HEAD).tar.gz"
           find src/ -name "*.olean" -o -name ".noisy_files" | tar czf "$archive_name" -T -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           python-version: 3.8
 
       - name: try to find olean cache
-        run: ./scripts/fetch_olean_cache.shfail
+        run: ./scripts/fetch_olean_cache.sh
 
       - name: leanpkg build
         id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
           azcopy copy "$archive_name" "${{ secrets.AZURE_SAS_TOKEN }}" --block-size-mb 99 --overwrite false
 
       - name: setup precompiled zip file
+        if: always() && steps.build.outputs.started == 'true'
         id: setup_precompiled
         run: |
           touch workspace.tar
@@ -102,6 +103,7 @@ jobs:
           git_hash="$(git log -1 --pretty=format:%h)"
           echo "::set-output name=artifact_name::precompiled-mathlib-$short_lean_version-$git_hash"
       - name: upload precompiled mathlib zip file
+        if: always() && steps.build.outputs.started == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.setup_precompiled.outputs.artifact_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,22 @@ jobs:
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
           echo "short_lean_version=$(~/.elan/bin/lean --run scripts/lean_version.lean)" >> $GITHUB_ENV
 
+      - name: get azcopy version
+        id: azcopy_version
+        run: echo "::set-output name=ver::$(curl -s -D- https://aka.ms/downloadazcopy-v10-linux | grep ^Location | cut -d" " -f2)"
+
+      - name: cache azcopy
+        uses: actions/cache@v2.1.4
+        id: cache_azcopy
+        with:
+          # A list of files, directories, and wildcard patterns to cache and restore
+          path: |
+            /usr/local/bin/azcopy
+          # An explicit key for restoring and saving the cache
+          key: ${{ steps.azcopy_version.outputs.ver }}
+
       - name: install azcopy
+        if: steps.cache_azcopy.outputs.cache-hit != 'true'
         run: |
           cd /usr/local/bin
           wget -q https://aka.ms/downloadazcopy-v10-linux -O - | sudo tar zxf - --strip-components 1 --wildcards '*/azcopy'
@@ -81,7 +96,10 @@ jobs:
           python-version: 3.8
 
       - name: try to find olean cache
-        run: ./scripts/fetch_olean_cache.sh
+        id: find_olean_cache
+        run: |
+          ./scripts/fetch_olean_cache.sh
+          echo "::set-output name=success::true"
 
       - name: leanpkg build
         id: build
@@ -90,7 +108,7 @@ jobs:
           lean --json -T100000 --make src | python scripts/detect_errors.py
 
       - name: push release to azure
-        if: always() && github.repository == 'leanprover-community/mathlib'
+        if: always() && github.repository == 'leanprover-community/mathlib' && steps.find_olean_cache.outputs.success == 'true'
         run: |
           archive_name="$(git rev-parse HEAD).tar.gz"
           find src/ -name "*.olean" -o -name ".noisy_files" | tar czf "$archive_name" -T -

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -19,9 +19,8 @@ Classical versions are in the namespace "classical".
 In the presence of automation, this whole file may be unnecessary. On the other hand,
 maybe it is useful for writing automation.
 -/
-f
 
-local attribute [instance, priority 10] classical.prop_decidable
+local attribute [instance, priority 10] classical.prop_decfidable
 
 section miscellany
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -19,6 +19,7 @@ Classical versions are in the namespace "classical".
 In the presence of automation, this whole file may be unnecessary. On the other hand,
 maybe it is useful for writing automation.
 -/
+f
 
 local attribute [instance, priority 10] classical.prop_decidable
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -20,7 +20,7 @@ In the presence of automation, this whole file may be unnecessary. On the other 
 maybe it is useful for writing automation.
 -/
 
-local attribute [instance, priority 10] classical.prop_decfidable
+local attribute [instance, priority 10] classical.prop_decidable
 
 section miscellany
 


### PR DESCRIPTION
The "install azcopy" step has been [failing](https://github.com/leanprover-community/mathlib/runs/2070026978) from time to time, probably due to failed downloads. As it turns out, the GitHub-hosted actions runner [comes with it installed](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#tools), so I've removed that step entirely.

I also made two other changes:

- The "push release to azure" step now only runs if the build actually started. The idea is that if the build never even starts due to e.g. `elan` temporarily failing to install, then we should be able to restart the build on GitHub and get `.olean`s for that commit without having to push another dummy commit. Currently we can't do this because we push an empty archive to Azure no matter what.

- We now upload artifacts if the build fails. This gives us an alternative way to get `.olean`s in case something goes wrong with Azure, and might make working with forks of mathlib slightly easier.

---

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/install.20azcopy.20step.20failing).

In some of the commits, I break various steps and check that the Azure release goes through or doesn't in various ways:

In https://github.com/leanprover-community/mathlib/commit/db4b8043799a1eb9b614596ad957bd85c9fc9fa2, I break a step that occurs before the build begins, so the push to Azure is skipped.

In https://github.com/leanprover-community/mathlib/commit/ea926aca892543d10b92567f127fa4dcbf5a2cae, I break the mathlib build itself by adding junk to a `.lean` file, and the push to Azure still occurs.