### PR TITLE
[Merged by Bors] - refactor(data/{,mv_}polynomial): support function

### DIFF
--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -116,17 +116,13 @@ add_monoid_algebra.algebra
 end instances
 
 variables [comm_semiring R] [comm_semiring S₁] {p q : mv_polynomial σ R}
-/-- The coercion turning an `mv_polynomial` into the function which reports the coefficient
-of a given monomial. -/
-def coeff_coe_to_fun : has_coe_to_fun (mv_polynomial σ R) :=
-finsupp.has_coe_to_fun
-
-local attribute [instance] coeff_coe_to_fun
 
 /-- `monomial s a` is the monomial with coefficient `a` and exponents given by `s`  -/
 def monomial (s : σ →₀ ℕ) (a : R) : mv_polynomial σ R := single s a
 
 lemma single_eq_monomial (s : σ →₀ ℕ) (a : R) : single s a = monomial s a := rfl
+
+lemma mul_def : (p * q) = p.sum (λ m a, q.sum $ λ n b, monomial (m + n) (a * b)) := rfl
 
 /-- `C a` is the constant polynomial with value `a` -/
 def C : R →+* mv_polynomial σ R :=
@@ -143,12 +139,14 @@ variables {R σ}
 /-- `X n` is the degree `1` monomial $X_n$. -/
 def X (n : σ) : mv_polynomial σ R := monomial (single n 1) 1
 
-@[simp] lemma C_0 : C 0 = (0 : mv_polynomial σ R) := by simp [C, monomial]; refl
+lemma C_apply : (C a : mv_polynomial σ R) = monomial 0 a := rfl
+
+@[simp] lemma C_0 : C 0 = (0 : mv_polynomial σ R) := by simp [C_apply, monomial]
 
 @[simp] lemma C_1 : C 1 = (1 : mv_polynomial σ R) := rfl
 
 lemma C_mul_monomial : C a * monomial s a' = monomial s (a * a') :=
-by simp [C, monomial, single_mul_single]
+by simp [C_apply, monomial, single_mul_single]
 
 @[simp] lemma C_add : (C (a + a') : mv_polynomial σ R) = C a + C a' := single_add
 
@@ -165,7 +163,7 @@ lemma C_surjective {R : Type*} [comm_semiring R] (σ : Type*) (hσ : ¬ nonempty
   function.surjective (C : R → mv_polynomial σ R) :=
 begin
   refine λ p, ⟨p.to_fun 0, finsupp.ext (λ a, _)⟩,
-  simpa [(finsupp.ext (λ x, absurd (nonempty.intro x) hσ) : a = 0), C, monomial],
+  simpa [(finsupp.ext (λ x, absurd (nonempty.intro x) hσ) : a = 0), C_apply, monomial],
 end
 
 lemma C_surjective_fin_0 {R : Type*} [comm_ring R] :
@@ -246,10 +244,15 @@ by rw [monomial, single_zero]; refl
   sum (monomial u r) b = b u r :=
 sum_single_index w
 
+@[simp] lemma sum_C {A : Type*} [add_comm_monoid A]
+  {b : (σ →₀ ℕ) → R → A} (w : b 0 0 = 0) :
+  sum (C a) b = b 0 a :=
+by simp [C_apply, w]
+
 lemma monomial_eq : monomial s a = C a * (s.prod $ λn e, X n ^ e : mv_polynomial σ R) :=
 begin
   apply @finsupp.induction σ ℕ _ _ s,
-  { simp only [C, prod_zero_index]; exact (mul_one _).symm },
+  { simp only [C_apply, prod_zero_index]; exact (mul_one _).symm },
   { assume n e s hns he ih,
     rw [monomial_single_add, ih, prod_add_index, prod_single_index, mul_left_comm],
     { simp only [pow_zero], },
@@ -312,15 +315,49 @@ by { ext, exact hf _ }
   f (C r) = C r :=
 f.commutes r
 
+
+section support
+
+/--
+The finite set of all `m : σ →₀ ℕ` such that `X^m` has a non-zero coefficient.
+-/
+def support (p : mv_polynomial σ R) : finset (σ →₀ ℕ) :=
+p.support
+
+lemma support_monomial : (monomial s a).support = if a = 0 then ∅ else {s} := rfl
+
+lemma support_monomial_subset : (monomial s a).support ⊆ {s} :=
+support_single_subset
+
+lemma support_add : (p + q).support ⊆ p.support ∪ q.support :=
+by convert @finsupp.support_add _ _ _ p q
+
+lemma support_X [nontrivial R] : (X n : mv_polynomial σ R).support = {single n 1} :=
+by rw [X, support_monomial, if_neg]; exact one_ne_zero
+
+end support
+
 section coeff
 
-section
--- While setting up `coeff`, we make `mv_polynomial` reducible so we can treat it as a function.
-local attribute [reducible] mv_polynomial
-
 /-- The coefficient of the monomial `m` in the multi-variable polynomial `p`. -/
-def coeff (m : σ →₀ ℕ) (p : mv_polynomial σ R) : R := p m
-end
+def coeff (m : σ →₀ ℕ) (p : mv_polynomial σ R) : R :=
+@coe_fn _ (monoid_algebra.has_coe_to_fun _ _) p m
+
+@[simp] lemma mem_support_iff {p : mv_polynomial σ R} {m : σ →₀ ℕ} :
+  m ∈ p.support ↔ p.coeff m ≠ 0 :=
+by simp [support, coeff]
+
+lemma not_mem_support_iff {p : mv_polynomial σ R} {m : σ →₀ ℕ} :
+  m ∉ p.support ↔ p.coeff m = 0 :=
+by simp
+
+lemma sum_def {A} [add_comm_monoid A] {p : mv_polynomial σ R} {b : (σ →₀ ℕ) → R → A} :
+  p.sum b = ∑ m in p.support, b m (p.coeff m) :=
+by simp [support, finsupp.sum, coeff]
+
+lemma support_mul (p q : mv_polynomial σ R) :
+  (p * q).support ⊆ p.support.bUnion (λ a, q.support.bUnion $ λ b, {a + b}) :=
+by convert add_monoid_algebra.support_mul p q; ext; convert iff.rfl
 
 @[ext] lemma ext (p q : mv_polynomial σ R) :
   (∀ m, coeff m p = coeff m q) → p = q := ext
@@ -375,18 +412,12 @@ by rw [← coeff_X_pow, pow_one]
   coeff (single i 1) (X i : mv_polynomial σ R) = 1 :=
 by rw [coeff_X', if_pos rfl]
 
-@[simp] lemma coeff_C_mul (m) (a : R) (p : mv_polynomial σ R) : coeff m (C a * p) = a * coeff m p :=
+@[simp] lemma coeff_C_mul (m) (a : R) (p : mv_polynomial σ R) :
+  coeff m (C a * p) = a * coeff m p :=
 begin
-  rw [mul_def], simp only [C, monomial], dsimp, rw [monomial],
-  rw sum_single_index,
-  { simp only [zero_add],
-    convert sum_apply,
-    simp only [single_apply, finsupp.sum],
-    rw finset.sum_eq_single m,
-    { rw if_pos rfl, refl },
-    { intros m' hm' H, apply if_neg, exact H },
-    { intros hm, rw if_pos rfl, rw not_mem_support_iff at hm, simp [hm] } },
-  simp only [zero_mul, single_zero, zero_add, sum_zero],
+  rw [mul_def, sum_C],
+  { simp [sum_def, coeff_sum] {contextual := tt} },
+  simp
 end
 
 lemma coeff_mul (p q : mv_polynomial σ R) (n : σ →₀ ℕ) :
@@ -440,19 +471,20 @@ end
 lemma coeff_mul_X' (m) (s : σ) (p : mv_polynomial σ R) :
   coeff m (p * X s) = if s ∈ m.support then coeff (m - single s 1) p else 0 :=
 begin
+  nontriviality R,
   split_ifs with h h,
   { conv_rhs {rw ← coeff_mul_X _ s},
     congr' with  t,
     by_cases hj : s = t,
     { subst t, simp only [nat_sub_apply, add_apply, single_eq_same],
-      refine (nat.sub_add_cancel $ nat.pos_of_ne_zero _).symm, rwa mem_support_iff at h },
+      refine (nat.sub_add_cancel $ nat.pos_of_ne_zero _).symm, rwa finsupp.mem_support_iff at h },
     { simp [single_eq_of_ne hj] } },
-  { delta coeff, rw ← not_mem_support_iff, intro hm, apply h,
+  { rw ← not_mem_support_iff, intro hm, apply h,
     have H := support_mul _ _ hm, simp only [finset.mem_bUnion] at H,
     rcases H with ⟨j, hj, i', hi', H⟩,
-    delta X monomial at hi', rw mem_support_single at hi', cases hi', subst i',
-    erw finset.mem_singleton at H, subst m,
-    rw [mem_support_iff, add_apply, single_apply, if_pos rfl],
+    rw [support_X, finset.mem_singleton] at hi', subst i',
+    rw finset.mem_singleton at H, subst m,
+    rw [finsupp.mem_support_iff, add_apply, single_apply, if_pos rfl],
     intro H, rw [_root_.add_eq_zero_iff] at H, exact one_ne_zero H.2 }
 end
 
@@ -483,7 +515,7 @@ begin
     simp only [coeff_C_mul, coeff_sum, coeff_monomial, finset.sum_ite_eq', c'],
     split_ifs with hi hi,
     { rw hc },
-    { rw finsupp.not_mem_support_iff at hi, rwa mul_zero } },
+    { rw not_mem_support_iff at hi, rwa mul_zero } },
 end
 
 end coeff
@@ -841,7 +873,7 @@ by { ext; simp }
 lemma support_map_subset (p : mv_polynomial σ R) : (map f p).support ⊆ p.support :=
 begin
   intro x,
-  simp only [finsupp.mem_support_iff],
+  simp only [mem_support_iff],
   contrapose!,
   change p.coeff x = 0 → (map f p).coeff x = 0,
   rw coeff_map,
@@ -856,9 +888,9 @@ begin
   apply finset.subset.antisymm,
   { exact mv_polynomial.support_map_subset _ _ },
   intros x hx,
-  rw finsupp.mem_support_iff,
+  rw mem_support_iff,
   contrapose! hx,
-  simp only [not_not, finsupp.mem_support_iff],
+  simp only [not_not, mem_support_iff],
   change (map f p).coeff x = 0 at hx,
   rw [coeff_map, ← f.map_zero] at hx,
   exact hf hx

--- a/src/data/mv_polynomial/comm_ring.lean
+++ b/src/data/mv_polynomial/comm_ring.lean
@@ -66,6 +66,9 @@ variables (σ a a')
 @[simp] lemma coeff_sub (m : σ →₀ ℕ) (p q : mv_polynomial σ R) :
   coeff m (p - q) = coeff m p - coeff m q := finsupp.sub_apply _ _ _
 
+@[simp] lemma support_neg : (- p).support = p.support :=
+finsupp.support_neg
+
 instance coeff.is_add_group_hom (m : σ →₀ ℕ) :
   is_add_group_hom (coeff m : mv_polynomial σ R → R) :=
 { map_add := coeff_add m }
@@ -75,7 +78,7 @@ variables {σ} (p)
 section degrees
 
 lemma degrees_neg (p : mv_polynomial σ R) : (- p).degrees = p.degrees :=
-by rw [degrees, finsupp.support_neg]; refl
+by rw [degrees, support_neg]; refl
 
 lemma degrees_sub (p q : mv_polynomial σ R) :
   (p - q).degrees ≤ p.degrees ⊔ q.degrees :=
@@ -142,7 +145,7 @@ section total_degree
 
 @[simp] lemma total_degree_neg (a : mv_polynomial σ R) :
   (-a).total_degree = a.total_degree :=
-by simp only [total_degree, finsupp.support_neg]
+by simp only [total_degree, support_neg]
 
 lemma total_degree_sub (a b : mv_polynomial σ R) :
   (a - b).total_degree ≤ max a.total_degree b.total_degree :=

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -221,13 +221,13 @@ lemma coeff_rename_eq_zero (f : σ → τ) (φ : mv_polynomial σ R) (d : τ →
   (h : ∀ u : σ →₀ ℕ, u.map_domain f = d → φ.coeff u = 0) :
   (rename f φ).coeff d = 0 :=
 begin
-  rw [rename_eq, coeff, ← not_mem_support_iff],
+  rw [rename_eq, ← not_mem_support_iff],
   intro H,
   replace H := map_domain_support H,
   rw [finset.mem_image] at H,
   obtain ⟨u, hu, rfl⟩ := H,
   specialize h u rfl,
-  simp [mem_support_iff, coeff] at h hu,
+  simp at h hu,
   contradiction
 end
 

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -94,7 +94,7 @@ end
 lemma degrees_monomial_eq (s : σ →₀ ℕ) (a : R) (ha : a ≠ 0) :
   degrees (monomial s a) = s.to_multiset :=
 le_antisymm (degrees_monomial s a) $ finset.le_sup $
-  by rw [monomial, finsupp.support_single_ne_zero ha, finset.mem_singleton]
+  by rw [support_monomial, if_neg ha, finset.mem_singleton]
 
 lemma degrees_C (a : R) : degrees (C a : mv_polynomial σ R) = 0 :=
 multiset.le_zero.1 $ degrees_monomial _ _
@@ -156,7 +156,7 @@ lemma degrees_pow (p : mv_polynomial σ R) :
 
 lemma mem_degrees {p : mv_polynomial σ R} {i : σ} :
   i ∈ p.degrees ↔ ∃ d, p.coeff d ≠ 0 ∧ i ∈ d.support :=
-by simp only [degrees, multiset.mem_sup, ← finsupp.mem_support_iff, coeff,
+by simp only [degrees, multiset.mem_sup, ← mem_support_iff,
     finsupp.mem_to_multiset, exists_prop]
 
 lemma le_degrees_add {p q : mv_polynomial σ R} (h : p.degrees.disjoint q.degrees) :
@@ -172,13 +172,13 @@ begin
   by_cases h0 : d = 0,
   { simp only [h0, zero_le, finsupp.zero_apply], },
   { refine @finset.le_sup _ _ _ (p + q).support _ d _,
-    rw [finsupp.mem_support_iff, ← coeff, coeff_add],
+    rw [mem_support_iff, coeff_add],
     suffices : q.coeff d = 0,
     { rwa [this, add_zero, coeff, ← finsupp.mem_support_iff], },
     rw [← finsupp.support_eq_empty, ← ne.def, ← finset.nonempty_iff_ne_empty] at h0,
     obtain ⟨j, hj⟩ := h0,
     contrapose! h,
-    rw finsupp.mem_support_iff at hd,
+    rw mem_support_iff at hd,
     refine ⟨j, _, j, _, rfl⟩,
     all_goals { rw mem_degrees, refine ⟨d, _, hj⟩, assumption } }
 end
@@ -210,7 +210,7 @@ begin
   rw [mem_degrees, multiset.mem_map],
   rintro ⟨d, hd, hi⟩,
   obtain ⟨x, rfl, hx⟩ := coeff_rename_ne_zero _ _ _ hd,
-  simp only [map_domain, mem_support_iff] at hi,
+  simp only [map_domain, finsupp.mem_support_iff] at hi,
   rw [sum_apply, finsupp.sum] at hi,
   contrapose! hi,
   rw [finset.sum_eq_zero],
@@ -247,7 +247,7 @@ by rw [X, vars_monomial (@one_ne_zero R _ _), finsupp.support_single_ne_zero (on
 
 lemma mem_vars (i : σ) :
   i ∈ p.vars ↔ ∃ (d : σ →₀ ℕ) (H : d ∈ p.support), i ∈ d.support :=
-by simp only [vars, multiset.mem_to_finset, mem_degrees, coeff, finsupp.mem_support_iff,
+by simp only [vars, multiset.mem_to_finset, mem_degrees, mem_support_iff,
   exists_prop]
 
 lemma mem_support_not_mem_vars_zero
@@ -255,7 +255,7 @@ lemma mem_support_not_mem_vars_zero
   x v = 0 :=
 begin
   rw [vars, multiset.mem_to_finset] at h,
-  rw ←not_mem_support_iff,
+  rw ← finsupp.not_mem_support_iff,
   contrapose! h,
   unfold degrees,
   rw (show f.support = insert x f.support, from eq.symm $ finset.insert_eq_of_mem H),
@@ -290,7 +290,7 @@ begin
   intro i,
   simp only [mem_vars, finset.mem_union],
   rintro ⟨d, hd, hi⟩,
-  rw [finsupp.mem_support_iff, ← coeff, coeff_mul] at hd,
+  rw [mem_support_iff, coeff_mul] at hd,
   contrapose! hd, cases hd,
   rw finset.sum_eq_zero,
   rintro ⟨d₁, d₂⟩ H,
@@ -337,11 +337,11 @@ variables {A : Type*} [integral_domain A]
 lemma vars_C_mul (a : A) (ha : a ≠ 0) (φ : mv_polynomial σ A) : (C a * φ).vars = φ.vars :=
 begin
   ext1 i,
-  simp only [mem_vars, exists_prop, finsupp.mem_support_iff],
+  simp only [mem_vars, exists_prop, mem_support_iff],
   apply exists_congr,
   intro d,
   apply and_congr _ iff.rfl,
-  rw [← coeff, ← coeff, coeff_C_mul, mul_ne_zero_iff, eq_true_intro ha, true_and],
+  rw [coeff_C_mul, mul_ne_zero_iff, eq_true_intro ha, true_and],
 end
 
 end integral_domain
@@ -457,7 +457,7 @@ total_degree_C (1 : R)
 @[simp] lemma total_degree_X {R} [comm_semiring R] [nontrivial R] (s : σ) :
   (X s : mv_polynomial σ R).total_degree = 1 :=
 begin
-  rw [total_degree, X, monomial, finsupp.support_single_ne_zero (one_ne_zero : (1 : R) ≠ 0)],
+  rw [total_degree, support_X],
   simp only [finset.sup, sum_single_index, finset.fold_singleton, sup_bot_eq],
 end
 

--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -201,7 +201,7 @@ begin
   by_cases hf : f = 0,
   { simp [hf] },
   by_cases hi : i ∈ f.support,
-  { unfold polynomial.eval polynomial.eval₂ finsupp.sum id at dvd_eval,
+  { rw [eval, eval₂, sum_def] at dvd_eval,
     rw [←finset.insert_erase hi, finset.sum_insert (finset.not_mem_erase _ _)] at dvd_eval,
     refine (dvd_add_left _).mp dvd_eval,
     apply finset.dvd_sum,

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -46,7 +46,19 @@ add_monoid_algebra.is_scalar_tower
 
 instance [subsingleton R] : unique (polynomial R) := add_monoid_algebra.unique
 
+/--
+The set of all `n` such that `X^n` has a non-zero coefficient.
+-/
+def support (p : polynomial R) : finset ℕ :=
+p.support
+
 @[simp] lemma support_zero : (0 : polynomial R).support = ∅ := rfl
+
+@[simp] lemma support_eq_empty : p.support = ∅ ↔ p = 0 :=
+by simp [support]
+
+lemma card_support_eq_zero : p.support.card = 0 ↔ p = 0 :=
+by simp
 
 /-- `monomial s a` is the monomial `a * X^s` -/
 def monomial (n : ℕ) : R →ₗ[R] polynomial R := finsupp.lsingle n
@@ -68,6 +80,9 @@ add_monoid_algebra.single_mul_single
 lemma smul_monomial {S} [semiring S] [semimodule S R] (a : S) (n : ℕ) (b : R) :
   a • monomial n b = monomial n (a • b) :=
 finsupp.smul_single _ _ _
+
+lemma support_add : (p + q).support ⊆ p.support ∪ q.support :=
+by convert @support_add _ _ _ p q
 
 /-- `X` is the polynomial variable (aka indeterminant). -/
 def X : polynomial R := monomial 1 1
@@ -192,6 +207,9 @@ lemma coeff_sub (p q : polynomial R) (n : ℕ) : coeff (p - q) n = coeff p n - c
 
 @[simp] lemma monomial_neg (n : ℕ) (a : R) : monomial n (-a) = -(monomial n a) :=
 by rw [eq_neg_iff_add_eq_zero, ←monomial_add, neg_add_self, monomial_zero_right]
+
+@[simp] lemma support_neg {p : polynomial R} : (-p).support = p.support :=
+by simp [support]
 
 end ring
 

--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -36,14 +36,18 @@ lemma coeff_add (p q : polynomial R) (n : ℕ) : coeff (p + q) n = coeff p n + c
 lemma coeff_sum [semiring S] (n : ℕ) (f : ℕ → R → polynomial S) :
   coeff (p.sum f) n = p.sum (λ a b, coeff (f a b) n) := finsupp.sum_apply
 
+lemma sum_def [add_comm_monoid S] (f : ℕ → R → S) :
+  p.sum f = ∑ n in p.support, f n (p.coeff n) :=
+rfl
+
 @[simp] lemma coeff_smul (p : polynomial R) (r : R) (n : ℕ) :
 coeff (r • p) n = r * coeff p n := finsupp.smul_apply _ _ _
 
-lemma mem_support_iff_coeff_ne_zero : n ∈ p.support ↔ p.coeff n ≠ 0 :=
-by { rw mem_support_to_fun, refl }
+@[simp] lemma mem_support_iff : n ∈ p.support ↔ p.coeff n ≠ 0 :=
+by simp [support, coeff]
 
-lemma not_mem_support_iff_coeff_zero : n ∉ p.support ↔ p.coeff n = 0 :=
-by { rw [mem_support_to_fun, not_not], refl, }
+lemma not_mem_support_iff : n ∉ p.support ↔ p.coeff n = 0 :=
+by simp
 
 variable (R)
 /-- The nth coefficient, as a linear map. -/

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -126,7 +126,7 @@ end
 
 lemma le_nat_degree_of_mem_supp (a : ℕ) :
   a ∈ p.support → a ≤ nat_degree p:=
-le_nat_degree_of_ne_zero ∘ mem_support_iff_coeff_ne_zero.mp
+le_nat_degree_of_ne_zero ∘ mem_support_iff.mp
 
 lemma supp_subset_range (h : nat_degree p < m) : p.support ⊆ finset.range m :=
 λ n hn, mem_range.2 $ (le_nat_degree_of_mem_supp _ hn).trans_lt h
@@ -315,7 +315,7 @@ end
 
 lemma le_degree_of_mem_supp (a : ℕ) :
   a ∈ p.support → ↑a ≤ degree p :=
-le_degree_of_ne_zero ∘ mem_support_iff_coeff_ne_zero.mp
+le_degree_of_ne_zero ∘ mem_support_iff.mp
 
 lemma nonempty_support_iff : p.support.nonempty ↔ p ≠ 0 :=
 by rw [ne.def, nonempty_iff_ne_empty, ne.def, ← support_eq_empty]

--- a/src/data/polynomial/degree/lemmas.lean
+++ b/src/data/polynomial/degree/lemmas.lean
@@ -145,7 +145,7 @@ lemma nat_degree_mul_C_eq_of_mul_ne_zero (h : p.leading_coeff * a ≠ 0) :
   (p * C a).nat_degree = p.nat_degree :=
 begin
   refine eq_nat_degree_of_le_mem_support (nat_degree_mul_C_le p a) _,
-  refine mem_support_iff_coeff_ne_zero.mpr _,
+  refine mem_support_iff.mpr _,
   rwa coeff_mul_C,
 end
 
@@ -158,7 +158,7 @@ lemma nat_degree_C_mul_eq_of_mul_ne_zero (h : a * p.leading_coeff ≠ 0) :
   (C a * p).nat_degree = p.nat_degree :=
 begin
   refine eq_nat_degree_of_le_mem_support (nat_degree_C_mul_le a p) _,
-  refine mem_support_iff_coeff_ne_zero.mpr _,
+  refine mem_support_iff.mpr _,
   rwa coeff_C_mul,
 end
 

--- a/src/data/polynomial/degree/trailing_degree.lean
+++ b/src/data/polynomial/degree/trailing_degree.lean
@@ -224,11 +224,11 @@ lemma trailing_coeff_nonzero_iff_nonzero : trailing_coeff p ≠ 0 ↔ p ≠ 0 :=
 not_congr trailing_coeff_eq_zero
 
 lemma nat_trailing_degree_mem_support_of_nonzero : p ≠ 0 → nat_trailing_degree p ∈ p.support :=
-(mem_support_iff_coeff_ne_zero.mpr ∘ trailing_coeff_nonzero_iff_nonzero.mpr)
+(mem_support_iff.mpr ∘ trailing_coeff_nonzero_iff_nonzero.mpr)
 
 lemma nat_trailing_degree_le_of_mem_supp (a : ℕ) :
   a ∈ p.support → nat_trailing_degree p ≤ a:=
-nat_trailing_degree_le_of_ne_zero ∘ mem_support_iff_coeff_ne_zero.mp
+nat_trailing_degree_le_of_ne_zero ∘ mem_support_iff.mp
 
 lemma nat_trailing_degree_eq_support_min' (h : p ≠ 0) :
   nat_trailing_degree p = p.support.min' (nonempty_support_iff.mpr h) :=
@@ -238,7 +238,7 @@ begin
     intros y hy,
     exact nat_trailing_degree_le_of_mem_supp y hy },
   { apply finset.min'_le,
-    exact mem_support_iff_coeff_ne_zero.mpr (trailing_coeff_nonzero_iff_nonzero.mpr h), },
+    exact mem_support_iff.mpr (trailing_coeff_nonzero_iff_nonzero.mpr h), },
 end
 
 lemma nat_trailing_degree_le_nat_degree (p : polynomial R) :
@@ -258,9 +258,9 @@ begin
   { rw [nat_trailing_degree_eq_support_min' (λ h, hp (mul_X_pow_eq_zero h)), finset.le_min'_iff],
     intros y hy,
     have key : n ≤ y,
-    { rw [mem_support_iff_coeff_ne_zero, coeff_mul_X_pow'] at hy,
+    { rw [mem_support_iff, coeff_mul_X_pow'] at hy,
       exact by_contra (λ h, hy (if_neg h)) },
-    rw [mem_support_iff_coeff_ne_zero, coeff_mul_X_pow', if_pos key] at hy,
+    rw [mem_support_iff, coeff_mul_X_pow', if_pos key] at hy,
     exact (nat.add_le_to_le_sub _ key).mpr (nat_trailing_degree_le_of_ne_zero hy) },
 end
 
@@ -284,7 +284,7 @@ section ring
 variables [ring R]
 
 @[simp] lemma trailing_degree_neg (p : polynomial R) : trailing_degree (-p) = trailing_degree p :=
-by unfold trailing_degree; rw finsupp.support_neg
+by unfold trailing_degree; rw support_neg
 
 @[simp] lemma nat_trailing_degree_neg (p : polynomial R) :
   nat_trailing_degree (-p) = nat_trailing_degree p :=

--- a/src/data/polynomial/derivative.lean
+++ b/src/data/polynomial/derivative.lean
@@ -47,7 +47,7 @@ lemma coeff_derivative (p : polynomial R) (n : ℕ) :
 begin
   rw [derivative_apply],
   simp only [coeff_X_pow, coeff_sum, coeff_C_mul],
-  rw [finsupp.sum, finset.sum_eq_single (n + 1)],
+  rw [sum_def, finset.sum_eq_single (n + 1)],
   simp only [nat.add_succ_sub_one, add_zero, mul_one, if_true, eq_self_iff_true], norm_cast,
   swap,
   { rw [if_pos (nat.add_sub_cancel _ _).symm, mul_one, nat.cast_add, nat.cast_one, mem_support_iff],
@@ -292,7 +292,7 @@ variables [integral_domain R]
 lemma mem_support_derivative [char_zero R] (p : polynomial R) (n : ℕ) :
   n ∈ (derivative p).support ↔ n + 1 ∈ p.support :=
 suffices (¬(coeff p (n + 1) = 0 ∨ ((n + 1:ℕ) : R) = 0)) ↔ coeff p (n + 1) ≠ 0,
-  by simpa only [mem_support_iff_coeff_ne_zero, coeff_derivative, ne.def, mul_eq_zero],
+  by simpa only [mem_support_iff, coeff_derivative, ne.def, mul_eq_zero],
 by { rw [nat.cast_eq_zero], simp only [nat.succ_ne_zero, or_false] }
 
 @[simp] lemma degree_derivative_eq [char_zero R] (p : polynomial R) (hp : 0 < nat_degree p) :

--- a/src/data/polynomial/div.lean
+++ b/src/data/polynomial/div.lean
@@ -27,20 +27,6 @@ variables {R : Type u} {S : Type v} {T : Type w} {A : Type z} {a b : R} {n : ℕ
 section semiring
 variables [semiring R] {p q : polynomial R}
 
-section
-/--
-The coercion turning a `polynomial` into the function which reports the coefficient of a given
-monomial `X^n`
--/
--- TODO we would like to completely remove this, but this requires fixing some proofs
-def coeff_coe_to_fun : has_coe_to_fun (polynomial R) :=
-finsupp.has_coe_to_fun
-
-local attribute [instance] coeff_coe_to_fun
-
-lemma apply_eq_coeff : p n = coeff p n := rfl
-end
-
 /-- `div_X p` return a polynomial `q` such that `q * X + C (p.coeff 0) = p`.
   It can be used in a semiring where the usual division algorithm is not possible -/
 def div_X (p : polynomial R) : polynomial R :=

--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -78,7 +78,7 @@ by rw [C_mul_X_pow_eq_monomial, self_sub_monomial_nat_degree_leading_coeff]
 
 lemma erase_lead_ne_zero (f0 : 2 ≤ f.support.card) : erase_lead f ≠ 0 :=
 begin
-  rw [ne.def, ← finsupp.card_support_eq_zero, erase_lead_support],
+  rw [ne.def, ← card_support_eq_zero, erase_lead_support],
   exact (zero_lt_one.trans_le $ (nat.sub_le_sub_right f0 1).trans
     finset.pred_card_le_card_erase).ne.symm
 end

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -304,7 +304,7 @@ end
 
 @[simp] lemma comp_C : p.comp (C a) = C (p.eval a) :=
 begin
-  dsimp [comp, eval₂, eval, finsupp.sum],
+  dsimp [comp, eval₂, eval, sum_def],
   rw [← p.support.sum_hom (@C R _)],
   apply finset.sum_congr rfl; simp
 end
@@ -393,8 +393,8 @@ nat.rec_on n rfl $ λ n ih, by rw [n.cast_succ, map_add, ih, map_one, n.cast_suc
 @[simp]
 lemma coeff_map (n : ℕ) : coeff (p.map f) n = f (coeff p n) :=
 begin
-  rw [map, eval₂, coeff_sum],
-  conv_rhs { rw [← sum_C_mul_X_eq p, coeff_sum, finsupp.sum,
+  rw [map, eval₂, coeff_sum, sum_def],
+  conv_rhs { rw [← sum_C_mul_X_eq p, coeff_sum, sum_def,
     ← p.support.sum_hom f], },
   refine finset.sum_congr rfl (λ x hx, _),
   simp [function.comp, coeff_C_mul_X, f.map_mul],

--- a/src/data/polynomial/integral_normalization.lean
+++ b/src/data/polynomial/integral_normalization.lean
@@ -63,7 +63,7 @@ lemma monic_integral_normalization {f : polynomial R} (hf : f ≠ 0) :
 begin
   apply monic_of_degree_le f.nat_degree,
   { refine finset.sup_le (λ i h, _),
-    rw [integral_normalization, mem_support_iff, on_finset_apply] at h,
+    rw [integral_normalization, mem_support_iff, coeff, on_finset_apply] at h,
     split_ifs at h with hi,
     { exact le_trans (le_of_eq hi.symm) degree_le_nat_degree },
     { erw [with_bot.some_le_some],
@@ -81,7 +81,7 @@ variables [integral_domain R]
   (integral_normalization f).support = f.support :=
 begin
   ext i,
-  simp only [integral_normalization, on_finset_apply, mem_support_iff],
+  simp only [integral_normalization, coeff, on_finset_apply, mem_support_iff],
   split_ifs with hi,
   { simp only [ne.def, not_false_iff, true_iff, one_ne_zero, hi],
     exact coeff_ne_zero_of_eq_degree hi },
@@ -101,7 +101,7 @@ lemma integral_normalization_eval₂_eq_zero {p : polynomial R} (hp : p ≠ 0) (
 calc eval₂ f (z * f p.leading_coeff) (integral_normalization p)
     = p.support.attach.sum
         (λ i, f (coeff (integral_normalization p) i.1 * p.leading_coeff ^ i.1) * z ^ i.1) :
-      by { rw [eval₂, finsupp.sum, support_integral_normalization hp],
+      by { rw [eval₂, sum_def, support_integral_normalization hp],
            simp only [mul_comm z, mul_pow, mul_assoc, ring_hom.map_pow, ring_hom.map_mul],
            exact finset.sum_attach.symm }
 ... = p.support.attach.sum

--- a/src/data/polynomial/reverse.lean
+++ b/src/data/polynomial/reverse.lean
@@ -87,7 +87,7 @@ lemma reflect_support (N : ℕ) (f : polynomial R) :
   (reflect N f).support = image (rev_at N) f.support :=
 begin
   ext1,
-  rw [reflect, mem_image, support_emb_domain, mem_map],
+  rw [reflect, mem_image, support, support, support_emb_domain, mem_map],
 end
 
 @[simp] lemma coeff_reflect (N : ℕ) (f : polynomial R) (i : ℕ) :
@@ -100,14 +100,7 @@ calc finsupp.emb_domain (rev_at N) f i
 
 @[simp] lemma reflect_eq_zero_iff {N : ℕ} {f : polynomial R} :
   reflect N (f : polynomial R) = 0 ↔ f = 0 :=
-begin
-  split,
-  { intros a,
-    injection a with f0 f1,
-    rwa [map_eq_empty, support_eq_empty] at f0, },
-  { rintro rfl,
-    refl, },
-end
+by simp [reflect]
 
 @[simp] lemma reflect_add (f g : polynomial R) (N : ℕ) :
   reflect N (f + g) = reflect N f + reflect N g :=
@@ -124,7 +117,7 @@ begin
   rw [reflect_C_mul, coeff_C_mul, coeff_C_mul, coeff_X_pow, coeff_reflect],
   split_ifs with h j,
   { rw [h, rev_at_invol, coeff_X_pow_self], },
-  { rw [not_mem_support_iff_coeff_zero.mp],
+  { rw [not_mem_support_iff.mp],
     intro a,
     rw [← one_mul (X ^ n), ← C_1] at a,
     apply h,

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -298,7 +298,7 @@ include hp
 noncomputable def contract (f : polynomial F) : polynomial F :=
 ⟨f.support.preimage (*p) $ λ _ _ _ _, (nat.mul_left_inj hp.pos).1,
 λ n, f.coeff (n * p),
-λ n, by { rw [finset.mem_preimage, finsupp.mem_support_iff], refl }⟩
+λ n, by rw [finset.mem_preimage, mem_support_iff]⟩
 
 theorem coeff_contract (f : polynomial F) (n : ℕ) : (contract p f).coeff n = f.coeff (n * p) := rfl
 

--- a/src/linear_algebra/char_poly/coeff.lean
+++ b/src/linear_algebra/char_poly/coeff.lean
@@ -138,7 +138,7 @@ begin
     have h : ∀ x : ℕ, (λ (e : ℕ) (a : R), r ^ e * a) x 0 = 0 := by simp,
     symmetry, rw ← finsupp.sum_map_range_index h, swap, refl,
     refine congr (congr rfl _) (by {ext, rw mul_comm}), ext, rw finsupp.map_range_apply,
-    simp [apply_eq_coeff], }
+    simpa [coeff] using (mat_poly_equiv_coeff_apply M a i j).symm }
 end
 
 lemma eval_det (M : matrix n n (polynomial R)) (r : R) :

--- a/src/ring_theory/mv_polynomial/basic.lean
+++ b/src/ring_theory/mv_polynomial/basic.lean
@@ -62,7 +62,7 @@ begin
   -- It's not great that we need to use an `erw` here,
   -- but hopefully it will become smoother when we move entirely away from `is_semiring_hom`.
   erw [finsupp.map_range_finset_sum (f : R →+ S)],
-  rw [← p.support.sum_hom (map f)],
+  rw [← (finsupp.support p).sum_hom (map f)],
   { refine finset.sum_congr rfl (assume n _, _),
     rw [finsupp.map_range_single, ← monomial, ← monomial, map_monomial], refl, },
   apply_instance

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -76,7 +76,7 @@ end
 theorem mem_degree_lt {n : ℕ} {f : polynomial R} :
   f ∈ degree_lt R n ↔ degree f < n :=
 by { simp_rw [degree_lt, submodule.mem_infi, linear_map.mem_ker, degree,
-    finset.sup_lt_iff (with_bot.bot_lt_coe n), finsupp.mem_support_iff, with_bot.some_eq_coe,
+    finset.sup_lt_iff (with_bot.bot_lt_coe n), mem_support_iff, with_bot.some_eq_coe,
     with_bot.coe_lt_coe, lt_iff_not_ge', ne, not_imp_not], refl }
 
 @[mono] theorem degree_lt_mono {m n : ℕ} (H : m ≤ n) :

--- a/src/ring_theory/polynomial/content.lean
+++ b/src/ring_theory/polynomial/content.lean
@@ -40,7 +40,7 @@ lemma content_dvd_coeff {p : polynomial R} (n : ℕ) : p.content ∣ p.coeff n :
 begin
   by_cases h : n ∈ p.support,
   { apply finset.gcd_dvd h },
-  rw [mem_support_iff_coeff_ne_zero, not_not] at h,
+  rw [mem_support_iff, not_not] at h,
   rw h,
   apply dvd_zero,
 end
@@ -67,7 +67,7 @@ begin
   have h : (X * p).support = p.support.map ⟨nat.succ, nat.succ_injective⟩,
   { ext a,
     simp only [exists_prop, finset.mem_map, function.embedding.coe_fn_mk, ne.def,
-      mem_support_iff_coeff_ne_zero],
+      mem_support_iff],
     cases a,
     { simp [coeff_X_mul_zero, nat.succ_ne_zero] },
     rw [mul_comm, coeff_mul_X],
@@ -100,7 +100,7 @@ lemma content_C_mul (r : R) (p : polynomial R) : (C r * p).content = normalize r
 begin
   by_cases h0 : r = 0, { simp [h0] },
   rw content, rw content, rw ← finset.gcd_mul_left,
-  refine congr (congr rfl _) _; ext; simp [h0, mem_support_iff_coeff_ne_zero]
+  refine congr (congr rfl _) _; ext; simp [h0, mem_support_iff]
 end
 
 @[simp] lemma content_monomial {r : R} {k : ℕ} : content (monomial k r) = normalize r :=
@@ -113,7 +113,7 @@ begin
   { ext n,
     by_cases h0 : n ∈ p.support,
     { rw [h n h0, coeff_zero], },
-    { rw mem_support_iff_coeff_ne_zero at h0,
+    { rw mem_support_iff at h0,
       push_neg at h0,
       simp [h0] } },
   { intros x h0,
@@ -132,7 +132,7 @@ begin
     apply content_dvd_coeff _ },
   { apply finset.gcd_mono,
     intro i,
-    simp only [nat.lt_succ_iff, mem_support_iff_coeff_ne_zero, ne.def, finset.mem_range],
+    simp only [nat.lt_succ_iff, mem_support_iff, ne.def, finset.mem_range],
     contrapose!,
     intro h1,
     apply coeff_eq_zero_of_nat_degree_lt (lt_of_lt_of_le h h1), }
@@ -147,7 +147,7 @@ lemma content_eq_gcd_leading_coeff_content_erase_lead (p : polynomial R) :
 begin
   by_cases h : p = 0,
   { simp [h] },
-  rw [← leading_coeff_eq_zero, leading_coeff, ← ne.def, ← mem_support_iff_coeff_ne_zero] at h,
+  rw [← leading_coeff_eq_zero, leading_coeff, ← ne.def, ← mem_support_iff] at h,
   rw [content, ← finset.insert_erase h, finset.gcd_insert, leading_coeff, content,
     erase_lead_support],
   refine congr rfl (finset.gcd_congr rfl (λ i hi, _)),

--- a/src/ring_theory/polynomial/homogeneous.lean
+++ b/src/ring_theory/polynomial/homogeneous.lean
@@ -164,7 +164,7 @@ begin
   apply le_antisymm,
   { apply finset.sup_le,
     intros d hd,
-    rw finsupp.mem_support_iff at hd,
+    rw mem_support_iff at hd,
     rw [finsupp.sum, hφ hd], },
   { obtain ⟨d, hd⟩ : ∃ d, coeff d φ ≠ 0 := exists_coeff_ne_zero h,
     simp only [← hφ hd, finsupp.sum],

--- a/src/ring_theory/polynomial/scale_roots.lean
+++ b/src/ring_theory/polynomial/scale_roots.lean
@@ -25,7 +25,7 @@ open finsupp polynomial
 noncomputable def scale_roots (p : polynomial R) (s : R) : polynomial R :=
 on_finset p.support
   (λ i, coeff p i * s ^ (p.nat_degree - i))
-  (λ i h, mem_support_iff.mpr (left_ne_zero_of_mul h))
+  (λ i h, polynomial.mem_support_iff.mpr (left_ne_zero_of_mul h))
 
 @[simp] lemma coeff_scale_roots (p : polynomial R) (s : R) (i : ℕ) :
   (scale_roots p s).coeff i = coeff p i * s ^ (p.nat_degree - i) :=
@@ -50,18 +50,14 @@ end
 
 lemma support_scale_roots_le (p : polynomial R) (s : R) :
   (scale_roots p s).support ≤ p.support :=
-begin
-  intros i,
-  simp only [mem_support_iff, scale_roots, on_finset_apply],
-  exact left_ne_zero_of_mul
-end
+by { intro, simpa using left_ne_zero_of_mul }
 
 lemma support_scale_roots_eq (p : polynomial R) {s : R} (hs : s ∈ non_zero_divisors R) :
   (scale_roots p s).support = p.support :=
 le_antisymm (support_scale_roots_le p s)
   begin
     intro i,
-    simp only [mem_support_iff, scale_roots, on_finset_apply],
+    simp only [coeff_scale_roots, polynomial.mem_support_iff],
     intros p_ne_zero ps_zero,
     have := ((non_zero_divisors R).pow_mem hs (p.nat_degree - i)) _ ps_zero,
     contradiction
@@ -105,7 +101,7 @@ calc eval₂ f (f s * r) (scale_roots p s) =
 ... = p.support.sum (λ (i : ℕ), f s ^ p.nat_degree * (f (p.coeff i) * r ^ i)) :
   finset.sum_congr rfl
   (λ i hi, by { rw [mul_assoc, mul_left_comm, nat.sub_add_cancel],
-                exact le_nat_degree_of_ne_zero (mem_support_iff.mp hi) })
+                exact le_nat_degree_of_ne_zero (polynomial.mem_support_iff.mp hi) })
 ... = f s ^ p.nat_degree * p.support.sum (λ (i : ℕ), (f (p.coeff i) * r ^ i)) : finset.mul_sum.symm
 ... = f s ^ p.nat_degree * eval₂ f r p : by { rw [eval₂_eq_sum], refl }
 ... = 0 : by rw [hr, _root_.mul_zero]


### PR DESCRIPTION
With polynomials, we try to avoid the function coercion in favor of the `coeff` functions.  However the coercion easily leaks through the abstraction because of the `finsupp.mem_support_iff` lemma.

This PR adds the `polynomial.support` and `mv_polynomial.support` functions.  This allows us to define the `polynomial.mem_support_iff` and `mv_polynomial.mem_support_iff` lemmas that are stated in terms of `coeff`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
