### PR TITLE
[Merged by Bors] - feat(data/real/{nnreal,ennreal}): add (e)nnreal.of_real_bit0/bit1

### DIFF
--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1385,7 +1385,7 @@ end
 @[simp] lemma to_nnreal_bit1 {x : ℝ≥0∞} (hx_top : x ≠ ∞) :
   (bit1 x).to_nnreal = bit1 (x.to_nnreal) :=
 by simp [bit1, bit1, to_nnreal_add
-    (lt_top_iff_ne_top.mpr (by rwa [ne.def, bit0_eq_top_iff])) ennreal.one_lt_top]
+  (lt_top_iff_ne_top.mpr (by rwa [ne.def, bit0_eq_top_iff])) ennreal.one_lt_top]
 
 @[simp] lemma to_real_bit0 {x : ℝ≥0∞} : (bit0 x).to_real = bit0 (x.to_real) :=
 by simp [ennreal.to_real]

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1375,6 +1375,33 @@ begin
   exact nnreal.of_real_prod_of_nonneg hf,
 end
 
+@[simp] lemma to_nnreal_bit0 {x : ℝ≥0∞} : (bit0 x).to_nnreal = bit0 (x.to_nnreal) :=
+begin
+  by_cases hx_top : x = ∞,
+  { simp [hx_top, bit0_eq_top_iff.mpr rfl], },
+  exact to_nnreal_add (lt_top_iff_ne_top.mpr hx_top) (lt_top_iff_ne_top.mpr hx_top),
+end
+
+@[simp] lemma to_nnreal_bit1 {x : ℝ≥0∞} (hx_top : x ≠ ∞) :
+  (bit1 x).to_nnreal = bit1 (x.to_nnreal) :=
+by simp [bit1, bit1, to_nnreal_add
+    (lt_top_iff_ne_top.mpr (by rwa [ne.def, bit0_eq_top_iff])) ennreal.one_lt_top]
+
+@[simp] lemma to_real_bit0 {x : ℝ≥0∞} : (bit0 x).to_real = bit0 (x.to_real) :=
+by simp [ennreal.to_real]
+
+@[simp] lemma to_real_bit1 {x : ℝ≥0∞} (hx_top : x ≠ ∞) :
+  (bit1 x).to_real = bit1 (x.to_real) :=
+by simp [ennreal.to_real, hx_top]
+
+@[simp] lemma of_real_bit0 {r : ℝ} (hr : 0 ≤ r) :
+  ennreal.of_real (bit0 r) = bit0 (ennreal.of_real r) :=
+of_real_add hr hr
+
+@[simp] lemma of_real_bit1 {r : ℝ} (hr : 0 ≤ r) :
+  ennreal.of_real (bit1 r) = bit1 (ennreal.of_real r) :=
+(of_real_add (by simp [hr]) zero_le_one).trans (by simp [nnreal.of_real_one, bit1, hr])
+
 end real
 
 section infi

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -441,6 +441,14 @@ begin
     intro rp, have : ¬(p ≤ 0) := not_le_of_lt (lt_of_le_of_lt (coe_nonneg _) rp), contradiction }
 end
 
+@[simp] lemma of_real_bit0 {r : ℝ} (hr : 0 ≤ r) :
+  nnreal.of_real (bit0 r) = bit0 (nnreal.of_real r) :=
+of_real_add hr hr
+
+@[simp] lemma of_real_bit1 {r : ℝ} (hr : 0 ≤ r) :
+  nnreal.of_real (bit1 r) = bit1 (nnreal.of_real r) :=
+(of_real_add (by simp [hr]) zero_le_one).trans (by simp [of_real_one, bit1, hr])
+
 end of_real
 
 section mul


### PR DESCRIPTION
Add bit0/bit1 lemmas for `nnreal.of_real`, `ennreal.of_real` and `ennreal.to_nnreal`.
With these additions, it is for example possible to prove `h : ennreal.of_real (2 : ℝ) = 2 := by simp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
