### PR TITLE
[Merged by Bors] - feat(group_theory/solvable): Commutative groups are solvable

### DIFF
--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -227,6 +227,15 @@ begin
   ... = ⊥ : rfl,
 end
 
+lemma is_solvable_of_comm' {G : Type*} [hG : group G]
+  (h : ∀ a b : G, a * b = b * a) : is_solvable G :=
+begin
+  letI hG' : comm_group G := { mul_comm := h .. hG },
+  tactic.unfreeze_local_instances,
+  cases hG,
+  exact is_solvable_of_comm,
+end
+
 lemma is_solvable_of_top_eq_bot (h : (⊤ : subgroup G) = ⊥) : is_solvable G :=
 ⟨⟨0, h⟩⟩
 

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -219,7 +219,7 @@ lemma is_solvable_def : is_solvable G ↔ ∃ n : ℕ, derived_series G n = ⊥ 
 ⟨λ h, h.solvable, λ h, ⟨h⟩⟩
 
 @[priority 100]
-instance is_solvable_of_comm {G : Type*} [comm_group G] : is_solvable G :=
+instance comm_group.is_solvable {G : Type*} [comm_group G] : is_solvable G :=
 begin
   use 1,
   rw [eq_bot_iff, derived_series_one],
@@ -227,13 +227,13 @@ begin
   ... = ⊥ : rfl,
 end
 
-lemma is_solvable_of_comm' {G : Type*} [hG : group G]
+lemma is_solvable_of_comm {G : Type*} [hG : group G]
   (h : ∀ a b : G, a * b = b * a) : is_solvable G :=
 begin
   letI hG' : comm_group G := { mul_comm := h .. hG },
   tactic.unfreeze_local_instances,
   cases hG,
-  exact is_solvable_of_comm,
+  exact comm_group.is_solvable,
 end
 
 lemma is_solvable_of_top_eq_bot (h : (⊤ : subgroup G) = ⊥) : is_solvable G :=


### PR DESCRIPTION
In practice, `is_solvable_of_comm` is hard to use, since you often aren't working with a `comm_group`. Instead, it is much nicer to be able to write:
`apply is_solvable_of_comm'`
`intros g h`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
