### PR TITLE
[Merged by Bors] - feat(algebra/group/defs, data/nat/basic): some `ne` lemmas

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -269,7 +269,7 @@ eq_comm.trans $ eq_inv_iff_eq_inv.trans eq_comm
 
 @[to_additive]
 theorem mul_eq_one_iff_eq_inv : a * b = 1 ↔ a = b⁻¹ :=
-by simpa [mul_left_inv, -mul_left_inj] using @mul_left_inj _ _ b a (b⁻¹)
+⟨eq_inv_of_mul_eq_one, λ h, by rw [h, mul_left_inv]⟩
 
 @[to_additive]
 theorem mul_eq_one_iff_inv_eq : a * b = 1 ↔ a⁻¹ = b :=

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -139,7 +139,7 @@ theorem mul_right_injective (a : G) : function.injective ((*) a) :=
 theorem mul_right_inj (a : G) {b c : G} : a * b = a * c ↔ b = c :=
 (mul_right_injective a).eq_iff
 
-@[simp, to_additive]
+@[to_additive]
 theorem mul_ne_mul_right (a : G) {b c : G} : a * b ≠ a * c ↔ b ≠ c :=
 (mul_right_injective a).ne_iff
 
@@ -176,7 +176,7 @@ theorem mul_left_injective (a : G) : function.injective (λ x, x * a) :=
 theorem mul_left_inj (a : G) {b c : G} : b * a = c * a ↔ b = c :=
 (mul_left_injective a).eq_iff
 
-@[simp, to_additive]
+@[to_additive]
 theorem mul_ne_mul_left (a : G) {b c : G} : b * a ≠ c * a ↔ b ≠ c :=
 (mul_left_injective a).ne_iff
 

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -136,11 +136,11 @@ theorem mul_right_injective (a : G) : function.injective ((*) a) :=
 λ b c, mul_left_cancel
 
 @[simp, to_additive]
-theorem mul_right_inj (a : G) : a * b = a * c ↔ b = c :=
+theorem mul_right_inj (a : G) {b c : G} : a * b = a * c ↔ b = c :=
 (mul_right_injective a).eq_iff
 
 @[simp, to_additive]
-theorem mul_ne_mul_right (a : G) : a * b ≠ a * c ↔ b ≠ c :=
+theorem mul_ne_mul_right (a : G) {b c : G} : a * b ≠ a * c ↔ b ≠ c :=
 (mul_right_injective a).ne_iff
 
 end left_cancel_semigroup
@@ -173,11 +173,11 @@ theorem mul_left_injective (a : G) : function.injective (λ x, x * a) :=
 λ b c, mul_right_cancel
 
 @[simp, to_additive]
-theorem mul_left_inj (a : G) : b * a = c * a ↔ b = c :=
+theorem mul_left_inj (a : G) {b c : G} : b * a = c * a ↔ b = c :=
 (mul_left_injective a).eq_iff
 
 @[simp, to_additive]
-theorem mul_ne_mul_left (a : G) : b * a ≠ c * a ↔ b ≠ c :=
+theorem mul_ne_mul_left (a : G) {b c : G} : b * a ≠ c * a ↔ b ≠ c :=
 (mul_left_injective a).ne_iff
 
 end right_cancel_semigroup

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -136,8 +136,12 @@ theorem mul_right_injective (a : G) : function.injective ((*) a) :=
 λ b c, mul_left_cancel
 
 @[simp, to_additive]
-theorem mul_right_inj (a : G) {b c : G} : a * b = a * c ↔ b = c :=
+theorem mul_right_inj (a : G) : a * b = a * c ↔ b = c :=
 (mul_right_injective a).eq_iff
+
+@[simp, to_additive]
+theorem mul_ne_mul_right (a : G) : a * b ≠ a * c ↔ b ≠ c :=
+(mul_right_injective a).ne_iff
 
 end left_cancel_semigroup
 
@@ -169,8 +173,12 @@ theorem mul_left_injective (a : G) : function.injective (λ x, x * a) :=
 λ b c, mul_right_cancel
 
 @[simp, to_additive]
-theorem mul_left_inj (a : G) {b c : G} : b * a = c * a ↔ b = c :=
+theorem mul_left_inj (a : G) : b * a = c * a ↔ b = c :=
 (mul_left_injective a).eq_iff
+
+@[simp, to_additive]
+theorem mul_ne_mul_left (a : G) : b * a ≠ c * a ↔ b ≠ c :=
+(mul_left_injective a).ne_iff
 
 end right_cancel_semigroup
 

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -239,11 +239,10 @@ theorem succ_injective : function.injective nat.succ := λ x y, succ.inj
 lemma succ_ne_succ {n m : ℕ} : succ n ≠ succ m ↔ n ≠ m :=
 succ_injective.ne_iff
 
-@[simp]
-lemma succ_succ_ne_one (n : ℕ) : n.succ.succ ≠ 1 :=
+@[simp] lemma succ_succ_ne_one (n : ℕ) : n.succ.succ ≠ 1 :=
 succ_ne_succ.mpr n.succ_ne_zero
 
-lemma one_lt_succ_succ (n : ℕ) : 1 < n.succ.succ :=
+@[simp] lemma one_lt_succ_succ (n : ℕ) : 1 < n.succ.succ :=
 succ_lt_succ $ succ_pos n
 
 theorem succ_le_succ_iff {m n : ℕ} : succ m ≤ succ n ↔ m ≤ n :=

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -625,7 +625,7 @@ lemma mul_left_injective {a : ℕ} (ha : 0 < a) : function.injective (λ x, x * 
 lemma mul_right_injective {a : ℕ} (ha : 0 < a) : function.injective (λ x, a * x) :=
 λ _ _, eq_of_mul_eq_mul_left ha
 
-theorem mul_ne_mul_left {a b c : ℕ} (ha : 0 < a) : b * a ≠ c * a ↔ b ≠ c :=
+lemma mul_ne_mul_left {a b c : ℕ} (ha : 0 < a) : b * a ≠ c * a ↔ b ≠ c :=
 (mul_left_injective ha).ne_iff
 
 lemma mul_ne_mul_right {a b c : ℕ} (ha : 0 < a) : a * b ≠ a * c ↔ b ≠ c :=

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -231,10 +231,22 @@ theorem one_add (n : ℕ) : 1 + n = succ n := by simp [add_comm]
 
 @[simp] lemma succ_pos' {n : ℕ} : 0 < succ n := succ_pos n
 
+@[simp] lemma succ_ne_zero' {n : ℕ} : succ n ≠ 0 := succ_ne_zero n
+
 theorem succ_inj' {n m : ℕ} : succ n = succ m ↔ n = m :=
 ⟨succ.inj, congr_arg _⟩
 
 theorem succ_injective : function.injective nat.succ := λ x y, succ.inj
+
+lemma succ_ne_succ {n m : ℕ} : succ n ≠ succ m ↔ n ≠ m :=
+succ_injective.ne_iff
+
+@[simp]
+lemma succ_succ_ne_one (n : ℕ) : n.succ.succ ≠ 1 :=
+succ_ne_succ.mpr n.succ_ne_zero
+
+lemma one_lt_succ_succ (n : ℕ) : 1 < n.succ.succ :=
+succ_lt_succ $ succ_pos n
 
 theorem succ_le_succ_iff {m n : ℕ} : succ m ≤ succ n ↔ m ≤ n :=
 ⟨le_of_succ_le_succ, succ_le_succ⟩
@@ -615,6 +627,12 @@ lemma mul_left_injective {a : ℕ} (ha : 0 < a) : function.injective (λ x, x * 
 
 lemma mul_right_injective {a : ℕ} (ha : 0 < a) : function.injective (λ x, a * x) :=
 λ _ _, eq_of_mul_eq_mul_left ha
+
+theorem mul_ne_mul_left {a b c : ℕ} (ha : 0 < a) : b * a ≠ c * a ↔ b ≠ c :=
+(mul_left_injective ha).ne_iff
+
+lemma mul_ne_mul_right {a b c : ℕ} (ha : 0 < a) : a * b ≠ a * c ↔ b ≠ c :=
+(mul_right_injective ha).ne_iff
 
 lemma mul_right_eq_self_iff {a b : ℕ} (ha : 0 < a) : a * b = a ↔ b = 1 :=
 suffices a * b = a * 1 ↔ b = 1, by rwa mul_one at this,

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -231,8 +231,6 @@ theorem one_add (n : ℕ) : 1 + n = succ n := by simp [add_comm]
 
 @[simp] lemma succ_pos' {n : ℕ} : 0 < succ n := succ_pos n
 
-@[simp] lemma succ_ne_zero' {n : ℕ} : succ n ≠ 0 := succ_ne_zero n
-
 theorem succ_inj' {n m : ℕ} : succ n = succ m ↔ n = m :=
 ⟨succ.inj, congr_arg _⟩
 


### PR DESCRIPTION
`≠` versions of `mul_left_inj`, `mul_right_inj`, and `succ_inj`, as well as the lemma `succ_succ_ne_one`.

---
See [this](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/succ_succ_ne_one/near/228925322) conversation on Zulip, where the following two points are discussed:
- The usefulness of these lemmas
- Whether or not one can/should label `≠` lemmas with `simp`
