### PR TITLE
[Merged by Bors] - chore(tactic/interactive): propagate tags in `substs`

### DIFF
--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -36,7 +36,7 @@ do max ← i_to_expr_strict max >>= tactic.eval_expr nat,
 
 /-- Multiple `subst`. `substs x y z` is the same as `subst x, subst y, subst z`. -/
 meta def substs (l : parse ident*) : tactic unit :=
-l.mmap' (λ h, get_local h >>= tactic.subst) >> try (tactic.reflexivity reducible)
+propagate_tags $ l.mmap' (λ h, get_local h >>= tactic.subst) >> try (tactic.reflexivity reducible)
 
 add_tactic_doc
 { name       := "substs",


### PR DESCRIPTION
Before this change, the `case left` tactic here did not work:
```lean
example {α : Type*} (a b c : α) (h : a = b) : (a = b ∨ a = c) ∧ true :=
begin
  with_cases {apply and.intro},
  substs' h,
  case left : { exact or.inl rfl },
  case right : { trivial }
end
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
