### PR TITLE
[Merged by Bors] - fix (topology/algebra/basic): fix universe issue with of_nhds_one

### DIFF
--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -270,7 +270,7 @@ begin
 end
 
 @[to_additive]
-lemma topological_group.of_nhds_one {G : Type*} [group G] [topological_space G]
+lemma topological_group.of_nhds_one {G : Type u} [group G] [topological_space G]
   (hmul : tendsto (uncurry ((*) : G → G → G)) ((𝓝 1) ×ᶠ 𝓝 1) (𝓝 1))
   (hinv : tendsto (λ x : G, x⁻¹) (𝓝 1) (𝓝 1))
   (hleft : ∀ x₀ : G, 𝓝 x₀ = map (λ x, x₀*x) (𝓝 1))


### PR DESCRIPTION
Everything had type max{u v} before.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Right now on master we have this:
```
import topology.algebra.group

set_option pp.universes true
/-
topological_group.of_nhds_one.{u_1 u_2} :
  ∀ {G : Type (max u_1 u_2)} [_inst_5 : group.{(max u_1 u_2)} G] [_inst_6 : topological_space.{(max u_1 u_2)} G],
    filter.tendsto.{(max u_1 u_2) (max u_1 u_2)}
      (function.uncurry.{(max u_1 u_2) (max u_1 u_2) (max u_1 u_2)} has_mul.mul.{(max u_1 u_2)})
      ((nhds.{(max u_1 u_2)} 1).prod (nhds.{(max u_1 u_2)} 1))
      (nhds.{(max u_1 u_2)} 1) →
    filter.tendsto.{(max u_1 u_2) (max u_1 u_2)} (λ (x : G), x⁻¹) (nhds.{(max u_1 u_2)} 1)
      (nhds.{(max u_1 u_2)} 1) →
    (∀ (x₀ : G),
       nhds.{(max u_1 u_2)} x₀ =
         filter.map.{(max u_1 u_2) (max u_1 u_2)} (λ (x : G), x₀ * x) (nhds.{(max u_1 u_2)} 1)) →
    (∀ (x₀ : G),
       filter.tendsto.{(max u_1 u_2) (max u_1 u_2)} (λ (x : G), x₀ * x * x₀⁻¹) (nhds.{(max u_1 u_2)} 1)
         (nhds.{(max u_1 u_2)} 1)) →
    topological_group.{(max u_1 u_2)} G
All Messages (1)

-/
```

These caused a rewrite to fail! This fix to `topology.algebra.group` fixes the universe problem and enables the rewrite to work. Is this related to this discussion? https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/universe.20issue.20with.20.60Type*.60/near/228074514

