### PR TITLE
[Merged by Bors] - refactor(algebra/invertible): push deeper into the import graph

### DIFF
--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Jens Wagemaker
 -/
 import data.multiset.basic
 import algebra.divisibility
+import algebra.invertible
 
 /-!
 # Associated, prime, and irreducible elements.
@@ -14,6 +15,12 @@ variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 
 lemma is_unit.pow [monoid α] {a : α} (n : ℕ) : is_unit a → is_unit (a ^ n) :=
 λ ⟨u, hu⟩, ⟨u ^ n, by simp *⟩
+
+instance invertible_pow {M : Type*} [monoid M] (m : M) [invertible m] (n : ℕ) :
+  invertible (m ^ n) :=
+{ inv_of := ⅟ m ^ n,
+  inv_of_mul_self := by rw [← (commute_inv_of m).symm.mul_pow, inv_of_mul_self, one_pow],
+  mul_inv_of_self := by rw [← (commute_inv_of m).mul_pow, mul_inv_of_self, one_pow] }
 
 theorem is_unit_iff_dvd_one [comm_monoid α] {x : α} : is_unit x ↔ x ∣ 1 :=
 ⟨by rintro ⟨u, rfl⟩; exact ⟨_, u.mul_inv.symm⟩,

--- a/src/algebra/char_p/invertible.lean
+++ b/src/algebra/char_p/invertible.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2020 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Anne Baanen
+-/
+import algebra.invertible
+import algebra.field
+import algebra.char_p.basic
+
+/-!
+# Invertibility of elements given a characteristic
+
+This file  includes some instances of `invertible` for specific numbers in
+characteristic zero. Some more cases are given as a `def`, to be included only
+when needed. To construct instances for concrete numbers,
+`invertible_of_nonzero` is a useful definition.
+-/
+section ring_char
+
+/-- A natural number `t` is invertible in a field `K` if the charactistic of `K` does not divide
+`t`. -/
+def invertible_of_ring_char_not_dvd {K : Type*} [field K]
+  {t : ℕ} (not_dvd : ¬(ring_char K ∣ t)) : invertible (t : K) :=
+invertible_of_nonzero (λ h, not_dvd ((ring_char.spec K t).mp h))
+
+end ring_char
+
+section char_p
+
+/-- A natural number `t` is invertible in a field `K` of charactistic `p` if `p` does not divide
+`t`. -/
+def invertible_of_char_p_not_dvd {K : Type*} [field K] {p : ℕ} [char_p K p]
+  {t : ℕ} (not_dvd : ¬(p ∣ t)) : invertible (t : K) :=
+invertible_of_nonzero (λ h, not_dvd ((char_p.cast_eq_zero_iff K p t).mp h))
+
+instance invertible_of_pos {K : Type*} [field K] [char_zero K] (n : ℕ) [h : fact (0 < n)] :
+  invertible (n : K) :=
+invertible_of_nonzero $ by simpa [pos_iff_ne_zero] using h
+
+end char_p
+
+section division_ring
+
+variable [division_ring α]
+
+instance invertible_succ [char_zero α] (n : ℕ) : invertible (n.succ : α) :=
+invertible_of_nonzero (nat.cast_ne_zero.mpr (nat.succ_ne_zero _))
+
+/-!
+A few `invertible n` instances for small numerals `n`. Feel free to add your own
+number when you need its inverse.
+-/
+
+instance invertible_two [char_zero α] : invertible (2 : α) :=
+invertible_of_nonzero (by exact_mod_cast (dec_trivial : 2 ≠ 0))
+
+instance invertible_three [char_zero α] : invertible (3 : α) :=
+invertible_of_nonzero (by exact_mod_cast (dec_trivial : 3 ≠ 0))
+
+end division_ring

--- a/src/algebra/char_p/invertible.lean
+++ b/src/algebra/char_p/invertible.lean
@@ -10,40 +10,40 @@ import algebra.char_p.basic
 /-!
 # Invertibility of elements given a characteristic
 
-This file  includes some instances of `invertible` for specific numbers in
+This file includes some instances of `invertible` for specific numbers in
 characteristic zero. Some more cases are given as a `def`, to be included only
 when needed. To construct instances for concrete numbers,
 `invertible_of_nonzero` is a useful definition.
 -/
-section ring_char
+
+variables {K : Type*}
+
+section field
+variables [field K]
 
 /-- A natural number `t` is invertible in a field `K` if the charactistic of `K` does not divide
 `t`. -/
-def invertible_of_ring_char_not_dvd {K : Type*} [field K]
+def invertible_of_ring_char_not_dvd
   {t : ℕ} (not_dvd : ¬(ring_char K ∣ t)) : invertible (t : K) :=
 invertible_of_nonzero (λ h, not_dvd ((ring_char.spec K t).mp h))
 
-end ring_char
-
-section char_p
 
 /-- A natural number `t` is invertible in a field `K` of charactistic `p` if `p` does not divide
 `t`. -/
-def invertible_of_char_p_not_dvd {K : Type*} [field K] {p : ℕ} [char_p K p]
+def invertible_of_char_p_not_dvd {p : ℕ} [char_p K p]
   {t : ℕ} (not_dvd : ¬(p ∣ t)) : invertible (t : K) :=
 invertible_of_nonzero (λ h, not_dvd ((char_p.cast_eq_zero_iff K p t).mp h))
 
-instance invertible_of_pos {K : Type*} [field K] [char_zero K] (n : ℕ) [h : fact (0 < n)] :
+instance invertible_of_pos [char_zero K] (n : ℕ) [h : fact (0 < n)] :
   invertible (n : K) :=
 invertible_of_nonzero $ by simpa [pos_iff_ne_zero] using h
 
-end char_p
+end field
 
 section division_ring
+variables [division_ring K] [char_zero K]
 
-variable [division_ring α]
-
-instance invertible_succ [char_zero α] (n : ℕ) : invertible (n.succ : α) :=
+instance invertible_succ (n : ℕ) : invertible (n.succ : K) :=
 invertible_of_nonzero (nat.cast_ne_zero.mpr (nat.succ_ne_zero _))
 
 /-!
@@ -51,10 +51,10 @@ A few `invertible n` instances for small numerals `n`. Feel free to add your own
 number when you need its inverse.
 -/
 
-instance invertible_two [char_zero α] : invertible (2 : α) :=
+instance invertible_two : invertible (2 : K) :=
 invertible_of_nonzero (by exact_mod_cast (dec_trivial : 2 ≠ 0))
 
-instance invertible_three [char_zero α] : invertible (3 : α) :=
+instance invertible_three : invertible (3 : K) :=
 invertible_of_nonzero (by exact_mod_cast (dec_trivial : 3 ≠ 0))
 
 end division_ring

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -2,17 +2,15 @@
 Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Anne Baanen
-
-A typeclass for the two-sided multiplicative inverse.
 -/
 
-import algebra.char_zero
-import algebra.char_p.basic
+import algebra.group.units
+import algebra.ring.basic
 
 /-!
 # Invertible elements
 
-This file defines a typeclass `invertible a` for elements `a` with a
+This file defines a typeclass `invertible a` for elements `a` with a two-sided
 multiplicative inverse.
 
 The intent of the typeclass is to provide a way to write e.g. `⅟2` in a ring
@@ -20,10 +18,8 @@ like `ℤ[1/2]` where some inverses exist but there is no general `⁻¹` operat
 or to specify that a field has characteristic `≠ 2`.
 It is the `Type`-valued analogue to the `Prop`-valued `is_unit`.
 
-This file also includes some instances of `invertible` for specific numbers in
-characteristic zero. Some more cases are given as a `def`, to be included only
-when needed. To construct instances for concrete numbers,
-`invertible_of_nonzero` is a useful definition.
+For constructions of the invertible element given a characteristic, see
+`algebra/char_p/invertible` and other lemmas in that file.
 
 ## Notation
 
@@ -161,12 +157,6 @@ lemma commute_inv_of {M : Type*} [has_one M] [has_mul M] (m : M) [invertible m] 
 calc m * ⅟m = 1       : mul_inv_of_self m
         ... = ⅟ m * m : (inv_of_mul_self m).symm
 
-instance invertible_pow {M : Type*} [monoid M] (m : M) [invertible m] (n : ℕ) :
-  invertible (m ^ n) :=
-{ inv_of := ⅟ m ^ n,
-  inv_of_mul_self := by rw [← (commute_inv_of m).symm.mul_pow, inv_of_mul_self, one_pow],
-  mul_inv_of_self := by rw [← (commute_inv_of m).mul_pow, mul_inv_of_self, one_pow] }
-
 section group_with_zero
 
 variable [group_with_zero α]
@@ -220,47 +210,3 @@ def invertible.map {R : Type*} {S : Type*} [monoid R] [monoid S] (f : R →* S)
 { inv_of := f (⅟r),
   inv_of_mul_self := by rw [← f.map_mul, inv_of_mul_self, f.map_one],
   mul_inv_of_self := by rw [← f.map_mul, mul_inv_of_self, f.map_one] }
-
-section ring_char
-
-/-- A natural number `t` is invertible in a field `K` if the charactistic of `K` does not divide
-`t`. -/
-def invertible_of_ring_char_not_dvd {K : Type*} [field K]
-  {t : ℕ} (not_dvd : ¬(ring_char K ∣ t)) : invertible (t : K) :=
-invertible_of_nonzero (λ h, not_dvd ((ring_char.spec K t).mp h))
-
-end ring_char
-
-section char_p
-
-/-- A natural number `t` is invertible in a field `K` of charactistic `p` if `p` does not divide
-`t`. -/
-def invertible_of_char_p_not_dvd {K : Type*} [field K] {p : ℕ} [char_p K p]
-  {t : ℕ} (not_dvd : ¬(p ∣ t)) : invertible (t : K) :=
-invertible_of_nonzero (λ h, not_dvd ((char_p.cast_eq_zero_iff K p t).mp h))
-
-instance invertible_of_pos {K : Type*} [field K] [char_zero K] (n : ℕ) [h : fact (0 < n)] :
-  invertible (n : K) :=
-invertible_of_nonzero $ by simpa [pos_iff_ne_zero] using h
-
-end char_p
-
-section division_ring
-
-variable [division_ring α]
-
-instance invertible_succ [char_zero α] (n : ℕ) : invertible (n.succ : α) :=
-invertible_of_nonzero (nat.cast_ne_zero.mpr (nat.succ_ne_zero _))
-
-/-!
-A few `invertible n` instances for small numerals `n`. Feel free to add your own
-number when you need its inverse.
--/
-
-instance invertible_two [char_zero α] : invertible (2 : α) :=
-invertible_of_nonzero (by exact_mod_cast (dec_trivial : 2 ≠ 0))
-
-instance invertible_three [char_zero α] : invertible (3 : α) :=
-invertible_of_nonzero (by exact_mod_cast (dec_trivial : 3 ≠ 0))
-
-end division_ring

--- a/src/algebra/quadratic_discriminant.lean
+++ b/src/algebra/quadratic_discriminant.lean
@@ -3,9 +3,9 @@ Copyright (c) 2019 Zhouhang Zhou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou
 -/
-import tactic.linarith
-import order.filter.at_top_bot
 import algebra.char_p.invertible
+import order.filter.at_top_bot
+import tactic.linarith
 
 /-!
 # Quadratic discriminants and roots of a quadratic

--- a/src/algebra/quadratic_discriminant.lean
+++ b/src/algebra/quadratic_discriminant.lean
@@ -6,6 +6,7 @@ Authors: Zhouhang Zhou
 import algebra.invertible
 import tactic.linarith
 import order.filter.at_top_bot
+import algebra.char_p.invertible
 
 /-!
 # Quadratic discriminants and roots of a quadratic

--- a/src/algebra/quadratic_discriminant.lean
+++ b/src/algebra/quadratic_discriminant.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Zhouhang Zhou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou
 -/
-import algebra.invertible
 import tactic.linarith
 import order.filter.at_top_bot
 import algebra.char_p.invertible

--- a/src/linear_algebra/affine_space/midpoint.lean
+++ b/src/linear_algebra/affine_space/midpoint.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Yury Kudryashov
 -/
-import algebra.invertible
+import algebra.char_p.invertible
 import linear_algebra.affine_space.affine_equiv
 
 /-!

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Scott Morrison
 -/
 import algebra.monoid_algebra
-import algebra.invertible
 import algebra.char_p.basic
+import algebra.char_p.invertible
 import linear_algebra.basis
 import ring_theory.simple_module
 

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Scott Morrison
 -/
 import algebra.monoid_algebra
-import algebra.char_p.basic
 import algebra.char_p.invertible
 import linear_algebra.basis
 import ring_theory.simple_module

--- a/src/ring_theory/polynomial/dickson.lean
+++ b/src/ring_theory/polynomial/dickson.lean
@@ -7,7 +7,7 @@ Authors: Julian Kuelshammer
 import ring_theory.polynomial.chebyshev
 import ring_theory.localization
 import data.zmod.basic
-import algebra.invertible
+import algebra.char_p.invertible
 
 
 /-!

--- a/src/ring_theory/witt_vector/witt_polynomial.lean
+++ b/src/ring_theory/witt_vector/witt_polynomial.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Robert Y. Lewis
 -/
 
-import algebra.invertible
+import algebra.char_p.invertible
 import data.mv_polynomial.variables
 import data.mv_polynomial.comm_ring
 import data.mv_polynomial.expand


### PR DESCRIPTION
I want to be able to import this in files where we use `is_unit`, to remove a few unecessary non-computables.

This moves all the lemmas about `char_p` and `char_zero` from `algebra.invertible` to `algebra.char_p.invertible`. This means that we can talk about `invertible` elements without having to build up the theory in `order_of_element` first.

This doesn't change any lemma statements or proofs, but it does move some type arguments into `variables` statements.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

CI will fail as I add transitive imports downstream, but making the PR now so it's easy for me to keep track.
