### PR TITLE
[Merged by Bors] - feat(ring_theory): define `left_mul_matrix` and `algebra.trace`

### DIFF
--- a/src/algebra/algebra/tower.lean
+++ b/src/algebra/algebra/tower.lean
@@ -45,6 +45,10 @@ def lsmul : A →ₐ[R] module.End R M :=
 
 @[simp] lemma lsmul_coe (a : A) : (lsmul R M a : M → M) = (•) a := rfl
 
+@[simp] lemma lmul_algebra_map (x : R) :
+  lmul R A (algebra_map R A x) = algebra.lsmul R A x :=
+linear_map.ext (λ s, by simp [smul_def''])
+
 end algebra
 
 namespace is_scalar_tower

--- a/src/algebra/algebra/tower.lean
+++ b/src/algebra/algebra/tower.lean
@@ -47,7 +47,7 @@ def lsmul : A →ₐ[R] module.End R M :=
 
 @[simp] lemma lmul_algebra_map (x : R) :
   lmul R A (algebra_map R A x) = algebra.lsmul R A x :=
-linear_map.ext (λ s, by simp [smul_def''])
+eq.symm $ linear_map.ext $ smul_def'' x
 
 end algebra
 

--- a/src/algebra/lie/matrix.lean
+++ b/src/algebra/lie/matrix.lean
@@ -53,7 +53,7 @@ def lie_equiv_matrix' : module.End R (n → R) ≃ₗ⁅R⁆ matrix n n R :=
 /-- An invertible matrix induces a Lie algebra equivalence from the space of matrices to itself. -/
 noncomputable def matrix.lie_conj (P : matrix n n R) (h : is_unit P) :
   matrix n n R ≃ₗ⁅R⁆ matrix n n R :=
-((@lie_equiv_matrix' R _ n _ _).symm.trans (P.to_linear_equiv h).lie_conj).trans lie_equiv_matrix'
+((@lie_equiv_matrix' R _ n _ _).symm.trans (P.to_linear_equiv' h).lie_conj).trans lie_equiv_matrix'
 
 @[simp] lemma matrix.lie_conj_apply (P A : matrix n n R) (h : is_unit P) :
   P.lie_conj h A = P ⬝ A ⬝ P⁻¹ :=

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -543,6 +543,10 @@ begin
   rw h, norm_cast
 end
 
+lemma findim_eq_zero_of_not_exists_basis
+  (h : ¬ ∃ s : finset V, is_basis K (λ x, x : (↑s : set V) → V)) : findim K V = 0 :=
+dif_neg (mt (λ h, @exists_is_basis_finset K V _ _ _ (finite_dimensional_iff_dim_lt_omega.mpr h)) h)
+
 variables (K V)
 
 lemma finite_dimensional_bot : finite_dimensional K (⊥ : submodule K V) :=

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -1114,7 +1114,7 @@ def trace_aux (R : Type u) [comm_ring R] {M : Type v} [add_comm_group M] [module
   (M →ₗ[R] M) →ₗ[R] R :=
 (matrix.trace ι R R).comp $ linear_map.to_matrix hb hb
 
-lemma trace_aux_def (R : Type u) [comm_ring R] {M : Type v} [add_comm_group M] [module R M]
+@[simp] lemma trace_aux_def (R : Type u) [comm_ring R] {M : Type v} [add_comm_group M] [module R M]
   {ι : Type w} [decidable_eq ι] [fintype ι] {b : ι → M} (hb : is_basis R b) (f : M →ₗ[R] M) :
   trace_aux R hb f = matrix.trace ι R R (linear_map.to_matrix hb hb f) :=
 rfl

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -328,6 +328,14 @@ lemma linear_map.to_matrix_mul (f g : M₁ →ₗ[R] M₁) :
 by { rw [show (@has_mul.mul (M₁ →ₗ[R] M₁) _) = linear_map.comp, from rfl,
          linear_map.to_matrix_comp hv₁ hv₁ hv₁ f g] }
 
+lemma linear_map.to_matrix_mul_vec_repr (f : M₁ →ₗ[R] M₂) (x : M₁) :
+  (linear_map.to_matrix hv₁ hv₂ f).mul_vec (hv₁.repr x) = hv₂.repr (f x) :=
+by { ext i,
+     rw [← matrix.to_lin'_apply, linear_map.to_matrix, linear_equiv.trans_apply,
+         matrix.to_lin'_to_matrix', linear_equiv.arrow_congr_apply, hv₂.equiv_fun_apply],
+     congr,
+     exact hv₁.equiv_fun.symm_apply_apply x }
+
 lemma matrix.to_lin_mul [decidable_eq m] (A : matrix l m R) (B : matrix m n R) :
   matrix.to_lin hv₁ hv₃ (A ⬝ B) =
   (matrix.to_lin hv₂ hv₃ A).comp (matrix.to_lin hv₁ hv₂ B) :=
@@ -1077,6 +1085,10 @@ lemma left_mul_matrix_apply (x : S) :
 lemma left_mul_matrix_eq_repr_mul (x : S) (i j) :
   left_mul_matrix hb x i j = hb.repr (x * b j) i :=
 by rw [left_mul_matrix_apply, linear_map.to_matrix_apply, algebra.lmul_apply, hb.equiv_fun_apply]
+
+lemma left_mul_matrix_mul_vec_repr (x y : S) :
+  (left_mul_matrix hb x).mul_vec (hb.repr y) = hb.repr (x * y) :=
+linear_map.to_matrix_mul_vec_repr hb hb (algebra.lmul R S x) y
 
 @[simp] lemma to_matrix_lmul_eq (x : S) :
   linear_map.to_matrix hb hb (lmul R S x) = left_mul_matrix hb x :=

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -1049,10 +1049,6 @@ variables {b : m → S} (hb : is_basis R b) {c : n → T} (hc : is_basis S c)
 
 open algebra
 
-@[simp] lemma lmul_algebra_map (x : R) :
-  lmul R S (algebra_map R S x) = algebra.lsmul R S x :=
-linear_map.ext (λ s, by simp [smul_def''])
-
 lemma to_matrix_lmul' (x : S) (i j) :
   linear_map.to_matrix hb hb (lmul R S x) i j = hb.repr (x * b j) i :=
 by rw [linear_map.to_matrix_apply', lmul_apply]

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -1080,7 +1080,9 @@ lemma left_mul_matrix_apply (x : S) :
 
 lemma left_mul_matrix_eq_repr_mul (x : S) (i j) :
   left_mul_matrix hb x i j = hb.repr (x * b j) i :=
-by rw [left_mul_matrix_apply, linear_map.to_matrix_apply, algebra.lmul_apply, hb.equiv_fun_apply]
+-- This is defeq to just `to_matrix_lmul' hb x i j`,
+-- but the unfolding goes a lot faster with this explicit `rw`.
+by rw [left_mul_matrix_apply, to_matrix_lmul' hb x i j]
 
 lemma left_mul_matrix_mul_vec_repr (x y : S) :
   (left_mul_matrix hb x).mul_vec (hb.repr y) = hb.repr (x * y) :=

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -759,8 +759,11 @@ lemma diagonal_to_lin' (w : n → R) :
   (diagonal w).to_lin' = linear_map.pi (λi, w i • linear_map.proj i) :=
 by ext v j; simp [mul_vec_diagonal]
 
-/-- An invertible matrix yields a linear equivalence from the free module to itself. -/
-def to_linear_equiv (P : matrix n n R) (h : is_unit P) : (n → R) ≃ₗ[R] (n → R) :=
+/-- An invertible matrix yields a linear equivalence from the free module to itself.
+
+See `matrix.to_linear_equiv` for the same map on arbitrary modules.
+-/
+def to_linear_equiv' (P : matrix n n R) (h : is_unit P) : (n → R) ≃ₗ[R] (n → R) :=
 have h' : is_unit P.det := P.is_unit_iff_is_unit_det.mp h,
 { inv_fun   := P⁻¹.to_lin',
   left_inv  := λ v,
@@ -771,11 +774,11 @@ have h' : is_unit P.det := P.is_unit_iff_is_unit_det.mp h,
     by rw [← matrix.to_lin'_mul, P.mul_nonsing_inv h', matrix.to_lin'_one, linear_map.id_apply],
   ..P.to_lin' }
 
-@[simp] lemma to_linear_equiv_apply (P : matrix n n R) (h : is_unit P) :
-  (↑(P.to_linear_equiv h) : module.End R (n → R)) = P.to_lin' := rfl
+@[simp] lemma to_linear_equiv'_apply (P : matrix n n R) (h : is_unit P) :
+  (↑(P.to_linear_equiv' h) : module.End R (n → R)) = P.to_lin' := rfl
 
-@[simp] lemma to_linear_equiv_symm_apply (P : matrix n n R) (h : is_unit P) :
-  (↑(P.to_linear_equiv h).symm : module.End R (n → R)) = P⁻¹.to_lin' := rfl
+@[simp] lemma to_linear_equiv'_symm_apply (P : matrix n n R) (h : is_unit P) :
+  (↑(P.to_linear_equiv' h).symm : module.End R (n → R)) = P⁻¹.to_lin' := rfl
 
 end ring
 
@@ -834,7 +837,10 @@ variables {b : n → M} (hb : is_basis R b)
 include hb
 
 /-- Given `hA : is_unit A.det` and `hb : is_basis R b`, `A.to_linear_equiv hb hA` is
-the `linear_equiv` arising from `to_lin hb hb A`. -/
+the `linear_equiv` arising from `to_lin hb hb A`.
+
+See `matrix.to_linear_equiv'` for this result on `n → R`.
+-/
 @[simps apply]
 def to_linear_equiv [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
   M ≃ₗ[R] M :=

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -820,31 +820,25 @@ begin
   apply h₂,
 end
 
-variables {V : Type*} [add_comm_group V] [vector_space K V]
-variables {v₁ : n → V} (hv₁ : is_basis K v₁)
+variables {R M : Type*} [comm_ring R] [add_comm_group M] [module R M]
+variables {b : n → M} (hb : is_basis R b)
 
-lemma ker_to_lin_eq_bot [decidable_eq n] (M : matrix n n K) (hM : M.det ≠ 0) :
-  (to_lin hv₁ hv₁ M).ker = ⊥ :=
+lemma to_lin_bijective [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
+  function.bijective (to_lin hb hb A) :=
 begin
-  rw submodule.eq_bot_iff,
-  intros x hx,
-  calc x = to_lin hv₁ hv₁ (M⁻¹ ⬝ M) x : by simp [nonsing_inv_mul M (is_unit.mk0 _ hM)]
-     ... = to_lin hv₁ hv₁ M⁻¹ (to_lin hv₁ hv₁ M x) : by simp [to_lin_mul hv₁ hv₁ hv₁]
-     ... = (to_lin hv₁ hv₁ M⁻¹) 0 : by rw mem_ker.mp hx
-     ... = 0 : linear_map.map_zero _
+  refine function.bijective_iff_has_inverse.mpr ⟨to_lin hb hb A⁻¹, λ x, _, λ x, _⟩;
+    simp only [← linear_map.comp_apply, ← to_lin_mul,
+               matrix.nonsing_inv_mul _ hA, matrix.mul_nonsing_inv _ hA,
+               to_lin_one, linear_map.id_apply]
 end
 
-lemma range_to_lin_eq_top [decidable_eq n] (M : matrix n n K) (hM : M.det ≠ 0) :
-  (to_lin hv₁ hv₁ M).range = ⊤ :=
-begin
-  rw eq_top_iff,
-  rintros x -,
-  rw linear_map.mem_range,
-  use to_lin hv₁ hv₁ M⁻¹ x,
-  rw [← linear_map.comp_apply, ← to_lin_mul, mul_nonsing_inv _ (is_unit.mk0 _ hM),
-      to_lin_one, linear_map.id_apply]
-end
+lemma ker_to_lin_eq_bot [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
+  (to_lin hb hb A).ker = ⊥ :=
+ker_eq_bot.mpr (to_lin_bijective hb A hA).injective
 
+lemma range_to_lin_eq_top [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
+  (to_lin hb hb A).range = ⊤ :=
+range_eq_top.mpr (to_lin_bijective hb A hA).surjective
 
 end vector_space
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -1068,7 +1068,7 @@ noncomputable def left_mul_matrix : S →ₐ[R] matrix m m R :=
   commutes' := λ r, by { ext, rw [lmul_algebra_map, to_matrix_lsmul,
                                   algebra_map_matrix_apply, id.map_eq_self] } }
 
-lemma left_mul_matrix_apply (x : S) (i j) :
+lemma left_mul_matrix_apply (x : S) :
   left_mul_matrix hb x = linear_map.to_matrix hb hb (lmul R S x) := rfl
 
 @[simp] lemma to_matrix_lmul_eq (x : S) :

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -1027,6 +1027,10 @@ det_reindex_self' e A
 
 end reindexing
 
+end matrix
+
+namespace algebra
+
 section lmul
 
 variables {R S T : Type*} [comm_ring R] [comm_ring S] [comm_ring T]
@@ -1050,12 +1054,12 @@ by { rw [linear_map.to_matrix_apply', algebra.lsmul_coe, linear_map.map_smul, fi
          hb.repr_self_apply, smul_eq_mul, mul_boole],
      congr' 1; simp only [eq_comm] }
 
-/-- `matrix.lmul hb x` is the matrix corresponding to the linear map `λ y, x * y`.
+/-- `left_mul_matrix hb x` is the matrix corresponding to the linear map `λ y, x * y`
 
 This definition is useful for doing (more) explicit computations with `algebra.lmul`,
 such as the trace form or norm map for algebras.
 -/
-protected noncomputable def lmul : S →ₐ[R] matrix m m R :=
+noncomputable def left_mul_matrix : S →ₐ[R] matrix m m R :=
 { to_fun := λ x, linear_map.to_matrix hb hb (algebra.lmul R S x),
   map_zero' := by rw [alg_hom.map_zero, linear_equiv.map_zero],
   map_one' := by rw [alg_hom.map_one, linear_map.to_matrix_one],
@@ -1064,43 +1068,43 @@ protected noncomputable def lmul : S →ₐ[R] matrix m m R :=
   commutes' := λ r, by { ext, rw [lmul_algebra_map, to_matrix_lsmul,
                                   algebra_map_matrix_apply, id.map_eq_self] } }
 
-lemma lmul_apply (x : S) (i j) :
-  matrix.lmul hb x i j = linear_map.to_matrix hb hb (lmul R S x) i j := rfl
+lemma left_mul_matrix_apply (x : S) (i j) :
+  left_mul_matrix hb x i j = linear_map.to_matrix hb hb (lmul R S x) i j := rfl
 
 @[simp] lemma to_matrix_lmul_eq (x : S) :
-  linear_map.to_matrix hb hb (lmul R S x) = matrix.lmul hb x :=
+  linear_map.to_matrix hb hb (lmul R S x) = left_mul_matrix hb x :=
 rfl
 
-lemma lmul_injective : function.injective (matrix.lmul hb) :=
+lemma left_mul_matrix_injective : function.injective (left_mul_matrix hb) :=
 λ x x' h, calc x = algebra.lmul R S x 1 : (mul_one x).symm
              ... = algebra.lmul R S x' 1 : by rw (linear_map.to_matrix hb hb).injective h
              ... = x' : mul_one x'
 
-lemma smul_lmul (x) (i j) (k k') :
-  matrix.lmul (hb.smul hc) x (i, k) (j, k') = matrix.lmul hb (matrix.lmul hc x k k') i j :=
-by simp only [matrix.lmul_apply, linear_map.to_matrix_apply, is_basis.equiv_fun_apply, mul_comm,
+lemma smul_left_mul_matrix (x) (i j) (k k') :
+  left_mul_matrix (hb.smul hc) x (i, k) (j, k') = left_mul_matrix hb (left_mul_matrix hc x k k') i j :=
+by simp only [left_mul_matrix_apply, linear_map.to_matrix_apply, is_basis.equiv_fun_apply, mul_comm,
               is_basis.smul_repr, finsupp.smul_apply, algebra.lmul_apply, id.smul_eq_mul,
               linear_map.map_smul, mul_smul_comm]
 
-lemma smul_lmul_algebra_map (x : S) :
-  matrix.lmul (hb.smul hc) (algebra_map _ _ x) = block_diagonal (λ k, matrix.lmul hb x) :=
+lemma smul_left_mul_matrix_algebra_map (x : S) :
+  left_mul_matrix (hb.smul hc) (algebra_map _ _ x) = block_diagonal (λ k, left_mul_matrix hb x) :=
 begin
   ext ⟨i, k⟩ ⟨j, k'⟩,
-  rw [smul_lmul, alg_hom.commutes, block_diagonal_apply, algebra_map_matrix_apply],
+  rw [smul_left_mul_matrix, alg_hom.commutes, block_diagonal_apply, algebra_map_matrix_apply],
   split_ifs with h; simp [h],
 end
 
-lemma smul_lmul_algebra_map_eq (x : S) (i j k) :
-  matrix.lmul (hb.smul hc) (algebra_map _ _ x) (i, k) (j, k) = matrix.lmul hb x i j :=
-by rw [smul_lmul_algebra_map, block_diagonal_apply_eq]
+lemma smul_left_mul_matrix_algebra_map_eq (x : S) (i j k) :
+  left_mul_matrix (hb.smul hc) (algebra_map _ _ x) (i, k) (j, k) = left_mul_matrix hb x i j :=
+by rw [smul_left_mul_matrix_algebra_map, block_diagonal_apply_eq]
 
-lemma smul_lmul_algebra_map_ne (x : S) (i j) {k k'}
-  (h : k ≠ k') : matrix.lmul (hb.smul hc) (algebra_map _ _ x) (i, k) (j, k') = 0 :=
-by rw [smul_lmul_algebra_map, block_diagonal_apply_ne _ _ _ h]
+lemma smul_left_mul_matrix_algebra_map_ne (x : S) (i j) {k k'}
+  (h : k ≠ k') : left_mul_matrix (hb.smul hc) (algebra_map _ _ x) (i, k) (j, k') = 0 :=
+by rw [smul_left_mul_matrix_algebra_map, block_diagonal_apply_ne _ _ _ h]
 
 end lmul
 
-end matrix
+end algebra
 
 namespace linear_map
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -1108,7 +1108,8 @@ def trace_aux (R : Type u) [comm_ring R] {M : Type v} [add_comm_group M] [module
   (M →ₗ[R] M) →ₗ[R] R :=
 (matrix.trace ι R R).comp $ linear_map.to_matrix hb hb
 
-@[simp] lemma trace_aux_def (R : Type u) [comm_ring R] {M : Type v} [add_comm_group M] [module R M]
+-- Can't be `simp` because it would cause a loop.
+lemma trace_aux_def (R : Type u) [comm_ring R] {M : Type v} [add_comm_group M] [module R M]
   {ι : Type w} [decidable_eq ι] [fintype ι] {b : ι → M} (hb : is_basis R b) (f : M →ₗ[R] M) :
   trace_aux R hb f = matrix.trace ι R R (linear_map.to_matrix hb hb f) :=
 rfl

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -1056,6 +1056,8 @@ by { rw [linear_map.to_matrix_apply', algebra.lsmul_coe, linear_map.map_smul, fi
 
 /-- `left_mul_matrix hb x` is the matrix corresponding to the linear map `λ y, x * y`
 
+`left_mul_matrix_eq_repr_mul` gives a formula for the entries of `left_mul_matrix`.
+
 This definition is useful for doing (more) explicit computations with `algebra.lmul`,
 such as the trace form or norm map for algebras.
 -/
@@ -1070,6 +1072,10 @@ noncomputable def left_mul_matrix : S →ₐ[R] matrix m m R :=
 
 lemma left_mul_matrix_apply (x : S) :
   left_mul_matrix hb x = linear_map.to_matrix hb hb (lmul R S x) := rfl
+
+lemma left_mul_matrix_eq_repr_mul (x : S) (i j) :
+  left_mul_matrix hb x i j = hb.repr (x * b j) i :=
+by rw [left_mul_matrix_apply, linear_map.to_matrix_apply, algebra.lmul_apply, hb.equiv_fun_apply]
 
 @[simp] lemma to_matrix_lmul_eq (x : S) :
   linear_map.to_matrix hb hb (lmul R S x) = left_mul_matrix hb x :=

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -825,7 +825,8 @@ variables {b : n → M} (hb : is_basis R b)
 
 include hb
 
-/-- `to_lin hb hb A` is a linear_equiv if `is_unit A.det` -/
+/-- Given `hA : is_unit A.det` and `hb : is_basis R b`, `A.to_lin_equiv hb hA` is the `linear_equiv`
+arising from `to_lin hb hb A`. -/
 @[simps apply]
 def to_lin_equiv [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
   M ≃ₗ[R] M :=
@@ -1054,7 +1055,7 @@ by { rw [linear_map.to_matrix_apply', algebra.lsmul_coe, linear_map.map_smul, fi
          hb.repr_self_apply, smul_eq_mul, mul_boole],
      congr' 1; simp only [eq_comm] }
 
-/-- `left_mul_matrix hb x` is the matrix corresponding to the linear map `λ y, x * y`
+/-- `left_mul_matrix hb x` is the matrix corresponding to the linear map `λ y, x * y`.
 
 `left_mul_matrix_eq_repr_mul` gives a formula for the entries of `left_mul_matrix`.
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -1081,7 +1081,8 @@ lemma left_mul_matrix_injective : function.injective (left_mul_matrix hb) :=
              ... = x' : mul_one x'
 
 lemma smul_left_mul_matrix (x) (i j) (k k') :
-  left_mul_matrix (hb.smul hc) x (i, k) (j, k') = left_mul_matrix hb (left_mul_matrix hc x k k') i j :=
+  left_mul_matrix (hb.smul hc) x (i, k) (j, k') =
+    left_mul_matrix hb (left_mul_matrix hc x k k') i j :=
 by simp only [left_mul_matrix_apply, linear_map.to_matrix_apply, is_basis.equiv_fun_apply, mul_comm,
               is_basis.smul_repr, finsupp.smul_apply, algebra.lmul_apply, id.smul_eq_mul,
               linear_map.map_smul, mul_smul_comm]

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -830,7 +830,8 @@ include hb
 def to_lin_equiv [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
   M ≃ₗ[R] M :=
 begin
-  refine ⟨to_lin hb hb A, linear_map.map_add _, linear_map.map_smul _, to_lin hb hb A⁻¹, λ x, _, λ x, _⟩;
+  refine ⟨to_lin hb hb A, linear_map.map_add _, linear_map.map_smul _, to_lin hb hb A⁻¹,
+          λ x, _, λ x, _⟩;
   simp only [← linear_map.comp_apply, ← to_lin_mul,
              matrix.nonsing_inv_mul _ hA, matrix.mul_nonsing_inv _ hA,
              to_lin_one, linear_map.id_apply]

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -823,22 +823,25 @@ end
 variables {R M : Type*} [comm_ring R] [add_comm_group M] [module R M]
 variables {b : n → M} (hb : is_basis R b)
 
-lemma to_lin_bijective [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
-  function.bijective (to_lin hb hb A) :=
-begin
-  refine function.bijective_iff_has_inverse.mpr ⟨to_lin hb hb A⁻¹, λ x, _, λ x, _⟩;
-    simp only [← linear_map.comp_apply, ← to_lin_mul,
-               matrix.nonsing_inv_mul _ hA, matrix.mul_nonsing_inv _ hA,
-               to_lin_one, linear_map.id_apply]
-end
+include hb
 
+/-- `to_lin hb hb A` is a linear_equiv if `is_unit A.det` -/
+@[simps apply]
+def to_lin_equiv [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
+  M ≃ₗ[R] M :=
+begin
+  refine ⟨to_lin hb hb A, linear_map.map_add _, linear_map.map_smul _, to_lin hb hb A⁻¹, λ x, _, λ x, _⟩;
+  simp only [← linear_map.comp_apply, ← to_lin_mul,
+             matrix.nonsing_inv_mul _ hA, matrix.mul_nonsing_inv _ hA,
+             to_lin_one, linear_map.id_apply]
+end
 lemma ker_to_lin_eq_bot [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
   (to_lin hb hb A).ker = ⊥ :=
-ker_eq_bot.mpr (to_lin_bijective hb A hA).injective
+ker_eq_bot.mpr (to_lin_equiv hb A hA).injective
 
 lemma range_to_lin_eq_top [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
   (to_lin hb hb A).range = ⊤ :=
-range_eq_top.mpr (to_lin_bijective hb A hA).surjective
+range_eq_top.mpr (to_lin_equiv hb A hA).surjective
 
 end vector_space
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -833,10 +833,10 @@ variables {b : n → M} (hb : is_basis R b)
 
 include hb
 
-/-- Given `hA : is_unit A.det` and `hb : is_basis R b`, `A.to_lin_equiv hb hA` is the `linear_equiv`
-arising from `to_lin hb hb A`. -/
+/-- Given `hA : is_unit A.det` and `hb : is_basis R b`, `A.to_linear_equiv hb hA` is
+the `linear_equiv` arising from `to_lin hb hb A`. -/
 @[simps apply]
-def to_lin_equiv [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
+def to_linear_equiv [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
   M ≃ₗ[R] M :=
 begin
   refine ⟨to_lin hb hb A, linear_map.map_add _, linear_map.map_smul _, to_lin hb hb A⁻¹,
@@ -847,11 +847,11 @@ begin
 end
 lemma ker_to_lin_eq_bot [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
   (to_lin hb hb A).ker = ⊥ :=
-ker_eq_bot.mpr (to_lin_equiv hb A hA).injective
+ker_eq_bot.mpr (to_linear_equiv hb A hA).injective
 
 lemma range_to_lin_eq_top [decidable_eq n] (A : matrix n n R) (hA : is_unit A.det) :
   (to_lin hb hb A).range = ⊤ :=
-range_eq_top.mpr (to_lin_equiv hb A hA).surjective
+range_eq_top.mpr (to_linear_equiv hb A hA).surjective
 
 end vector_space
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -1170,8 +1170,9 @@ if H : ∃ s : finset M, is_basis R (λ x, x : (↑s : set M) → M)
 then trace_aux R (classical.some_spec H)
 else 0
 
-theorem trace_eq_matrix_trace (R : Type u) [comm_ring R] {M : Type v} [add_comm_group M] [module R M]
-  {ι : Type w} [fintype ι] [decidable_eq ι] {b : ι → M} (hb : is_basis R b) (f : M →ₗ[R] M) :
+theorem trace_eq_matrix_trace (R : Type u) [comm_ring R] {M : Type v} [add_comm_group M]
+  [module R M] {ι : Type w} [fintype ι] [decidable_eq ι] {b : ι → M} (hb : is_basis R b)
+  (f : M →ₗ[R] M) :
   trace R M f = matrix.trace ι R R (linear_map.to_matrix hb hb f) :=
 have ∃ s : finset M, is_basis R (λ x, x : (↑s : set M) → M),
 from ⟨finset.univ.image b,

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -1069,7 +1069,7 @@ noncomputable def left_mul_matrix : S →ₐ[R] matrix m m R :=
                                   algebra_map_matrix_apply, id.map_eq_self] } }
 
 lemma left_mul_matrix_apply (x : S) (i j) :
-  left_mul_matrix hb x i j = linear_map.to_matrix hb hb (lmul R S x) i j := rfl
+  left_mul_matrix hb x = linear_map.to_matrix hb hb (lmul R S x) := rfl
 
 @[simp] lemma to_matrix_lmul_eq (x : S) :
   linear_map.to_matrix hb hb (lmul R S x) = left_mul_matrix hb x :=

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -33,7 +33,6 @@ For now, the definitions assume `S` is commutative, so the choice doesn't matter
 universes u v w
 
 variables {R S T : Type*} [comm_ring R] [comm_ring S] [comm_ring T]
-variables {A: Type*} [integral_domain A] [algebra A S]
 variables [algebra R S] [algebra R T]
 variables {K L : Type*} [field K] [field L] [algebra K L]
 variables {ι : Type w} [fintype ι]

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Anne Baanen
+Authors: Anne Baanen
 -/
 
 import linear_algebra.bilinear_form

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -63,10 +63,6 @@ lemma trace_eq_zero_of_not_exists_basis
   (h : ¬ ∃ s : finset S, is_basis R (λ x, x : (↑s : set S) → S)) : trace R S = 0 :=
 by { ext s, simp [linear_map.trace, h] }
 
-lemma findim_eq_zero_of_not_exists_basis
-  (h : ¬ ∃ s : finset L, is_basis K (λ x, x : (↑s : set L) → L)) : findim K L = 0 :=
-dif_neg (mt (λ h, @exists_is_basis_finset K L _ _ _ (finite_dimensional_iff_dim_lt_omega.mpr h)) h)
-
 include hb
 
 variables {R}

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -20,7 +20,8 @@ Typically, the trace is defined specifically for finite field extensions.
 The definition is as general as possible and the assumption that we have
 fields or that the extension is finite is added to the lemmas as needed.
 
-We only define the trace for left multiplication (`matrix.lmul`, i.e. `algebra.lmul_left`).
+We only define the trace for left multiplication (`algebra.left_mul_matrix`,
+i.e. `algebra.lmul_left`).
 For now, the definitions assume `S` is commutative, so the choice doesn't matter anyway.
 
 ## References
@@ -68,7 +69,7 @@ variables {R}
 
 -- Can't be a `simp` lemma because it depends on a choice of basis
 lemma trace_eq_matrix_trace [decidable_eq ι] (hb : is_basis R b) (s : S) :
-  trace R S s = matrix.trace _ R _ (matrix.lmul hb s) :=
+  trace R S s = matrix.trace _ R _ (algebra.left_mul_matrix hb s) :=
 by rw [trace_apply, linear_map.trace_eq_matrix_trace _ hb, to_matrix_lmul_eq]
 
 /-- If `x` is in the base field `K`, then the trace is `[L : K] * x`. -/

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -101,15 +101,13 @@ variables (R S)
 
 /-- The `trace_form` maps `x y : S` to the trace of `x * y`.
 It is a symmetric bilinear form and is nondegenerate if the extension is separable. -/
-@[simps]
 noncomputable def trace_form : bilin_form R S :=
-{ bilin := λ x y, trace R S (x * y),
-  bilin_add_left := λ x y z, by rw [add_mul, linear_map.map_add],
-  bilin_smul_left := λ x y z, by rw [smul_mul_assoc, linear_map.map_smul, smul_eq_mul],
-  bilin_add_right := λ x y z, by rw [mul_add, linear_map.map_add],
-  bilin_smul_right := λ x y z, by rw [mul_smul_comm, linear_map.map_smul, smul_eq_mul], }
+(linear_map.compr₂ (lmul R S).to_linear_map (trace R S)).to_bilin
 
 variables {S}
+
+-- This is a nicer lemma than the one produced by `@[simps] def trace_form`.
+@[simp] lemma trace_form_apply (x y : S) : trace_form R S x y = trace R S (x * y) := rfl
 
 lemma trace_form_is_sym : sym_bilin_form.is_sym (trace_form R S) :=
 λ x y, congr_arg (trace R S) (mul_comm _ _)

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2020 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Anne Baanen
+-/
+
+import linear_algebra.bilinear_form
+import ring_theory.power_basis
+
+/-!
+# Trace for (finite) ring extensions.
+
+Suppose we have an `R`-algebra `S` with a finite basis. For each `s : S`,
+the trace of the linear map given by multiplying by `s` gives information about
+the roots of the minimal polynomial of `s` over `R`.
+
+## Implementation notes
+
+Typically, the trace is defined specifically for finite field extensions.
+The definition is as general as possible and the assumption that we have
+fields or that the extension is finite is added to the lemmas as needed.
+
+We only define the trace for left multiplication (`matrix.lmul`, i.e. `algebra.lmul_left`).
+For now, the definitions assume `S` is commutative, so the choice doesn't matter anyway.
+
+## References
+
+ * https://en.wikipedia.org/wiki/Field_trace
+
+-/
+
+universes u v w
+
+variables {R S T : Type*} [comm_ring R] [comm_ring S] [comm_ring T]
+variables {A: Type*} [integral_domain A] [algebra A S]
+variables [algebra R S] [algebra R T]
+variables {K L : Type*} [field K] [field L] [algebra K L]
+variables {ι : Type w} [fintype ι]
+
+open finite_dimensional
+open linear_map
+open matrix
+
+open_locale big_operators
+open_locale matrix
+
+namespace algebra
+
+variables {b : ι → S} (hb : is_basis R b)
+
+variables (R S)
+
+/-- The trace of an element `s` of an `R`-algebra is the trace of `(*) s`,
+as an `R`-linear map. -/
+noncomputable def trace : S →ₗ[R] R :=
+(linear_map.trace R S).comp (lmul R S).to_linear_map
+
+variables {S}
+
+@[simp] lemma trace_apply (s : S) : trace R S s = linear_map.trace R S (lmul R S s) := rfl
+
+lemma trace_eq_zero_of_not_exists_basis
+  (h : ¬ ∃ s : finset S, is_basis R (λ x, x : (↑s : set S) → S)) : trace R S = 0 :=
+by { ext s, simp [linear_map.trace, h] }
+
+lemma findim_eq_zero_of_not_exists_basis
+  (h : ¬ ∃ s : finset L, is_basis K (λ x, x : (↑s : set L) → L)) : findim K L = 0 :=
+dif_neg (mt (λ h, @exists_is_basis_finset K L _ _ _ (finite_dimensional_iff_dim_lt_omega.mpr h)) h)
+
+include hb
+
+variables {R}
+
+-- Can't be a `simp` lemma because it depends on a choice of basis
+lemma trace_eq_matrix_trace [decidable_eq ι] (hb : is_basis R b) (s : S) :
+  trace R S s = matrix.trace _ R _ (matrix.lmul hb s) :=
+by rw [trace_apply, linear_map.trace_eq_matrix_trace _ hb, to_matrix_lmul_eq]
+
+/-- If `x` is in the base field `K`, then the trace is `[L : K] * x`. -/
+lemma trace_algebra_map_of_basis (x : R) :
+  trace R S (algebra_map R S x) = fintype.card ι • x :=
+begin
+  haveI := classical.dec_eq ι,
+  rw [trace_apply, linear_map.trace_eq_matrix_trace R hb, trace_diag],
+  convert finset.sum_const _,
+  ext i,
+  simp,
+end
+omit hb
+
+/-- If `x` is in the base field `K`, then the trace is `[L : K] * x`.
+
+(If `L` is not finite-dimensional over `K`, then `trace` and `findim` return `0`.)
+-/
+@[simp]
+lemma trace_algebra_map (x : K) : trace K L (algebra_map K L x) = findim K L • x :=
+begin
+  by_cases H : ∃ s : finset L, is_basis K (λ x, x : (↑s : set L) → L),
+  { rw [trace_algebra_map_of_basis H.some_spec, findim_eq_card_basis H.some_spec] },
+  { simp [trace_eq_zero_of_not_exists_basis K H, findim_eq_zero_of_not_exists_basis H] },
+end
+
+section trace_form
+
+variables (R S)
+
+/-- The `trace_form` maps `x y : S` to the trace of `x * y`.
+It is a symmetric bilinear form and is nondegenerate if the extension is separable. -/
+noncomputable def trace_form : bilin_form R S :=
+{ bilin := λ x y, trace R S (x * y),
+  bilin_add_left := λ x y z, by rw [add_mul, linear_map.map_add],
+  bilin_smul_left := λ x y z, by rw [smul_mul_assoc, linear_map.map_smul, smul_eq_mul],
+  bilin_add_right := λ x y z, by rw [mul_add, linear_map.map_add],
+  bilin_smul_right := λ x y z, by rw [mul_smul_comm, linear_map.map_smul, smul_eq_mul], }
+
+variables {S}
+
+@[simp] lemma trace_form_apply (x y : S) : trace_form R S x y = trace R S (x * y) := rfl
+
+lemma trace_form_is_sym : sym_bilin_form.is_sym (trace_form R S) :=
+λ x y, congr_arg (trace R S) (mul_comm _ _)
+
+lemma trace_form_to_matrix [decidable_eq ι] (i j) :
+  bilin_form.to_matrix hb (trace_form R S) i j = trace R S (b i * b j) :=
+by rw [bilin_form.to_matrix_apply, trace_form_apply]
+
+lemma trace_form_to_matrix_power_basis (h : power_basis R S) :
+  bilin_form.to_matrix h.is_basis (trace_form R S) = λ i j, (trace R S (h.gen ^ (i + j : ℕ))) :=
+by { ext, rw [trace_form_to_matrix, pow_add] }
+
+end trace_form
+
+end algebra

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -52,12 +52,11 @@ variables (R S)
 
 /-- The trace of an element `s` of an `R`-algebra is the trace of `(*) s`,
 as an `R`-linear map. -/
+@[simps]
 noncomputable def trace : S →ₗ[R] R :=
 (linear_map.trace R S).comp (lmul R S).to_linear_map
 
 variables {S}
-
-@[simp] lemma trace_apply (s : S) : trace R S s = linear_map.trace R S (lmul R S s) := rfl
 
 lemma trace_eq_zero_of_not_exists_basis
   (h : ¬ ∃ s : finset S, is_basis R (λ x, x : (↑s : set S) → S)) : trace R S = 0 :=
@@ -102,6 +101,7 @@ variables (R S)
 
 /-- The `trace_form` maps `x y : S` to the trace of `x * y`.
 It is a symmetric bilinear form and is nondegenerate if the extension is separable. -/
+@[simps]
 noncomputable def trace_form : bilin_form R S :=
 { bilin := λ x y, trace R S (x * y),
   bilin_add_left := λ x y z, by rw [add_mul, linear_map.map_add],
@@ -110,8 +110,6 @@ noncomputable def trace_form : bilin_form R S :=
   bilin_smul_right := λ x y z, by rw [mul_smul_comm, linear_map.map_smul, smul_eq_mul], }
 
 variables {S}
-
-@[simp] lemma trace_form_apply (x y : S) : trace_form R S x y = trace R S (x * y) := rfl
 
 lemma trace_form_is_sym : sym_bilin_form.is_sym (trace_form R S) :=
 λ x y, congr_arg (trace R S) (mul_comm _ _)


### PR DESCRIPTION
This PR defines the algebra trace, and the bilinear trace form, for an algebra `S` over a ring `R`, for example a field extension `L / K`.

Follow-up PRs will prove that `algebra.trace K L x` is the sum of the conjugate roots of `x` in `L`, that `trace_form` is nondegenerate and that `trace K L x` is integral over `K`. Then we'll use this to find an integral basis for field extensions, and then we can prove that the integral closure of a Dedekind domain is again a Dedekind domain.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
