### PR TITLE
[Merged by Bors] - feat(measure_theory/bochner_integration): extend the integral_smul lemmas

### DIFF
--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -68,6 +68,12 @@ The Bochner integral is defined following these steps:
 
 4. `tendsto_integral_of_dominated_convergence` : the Lebesgue dominated convergence theorem
 
+5. (In the file `set_integral`) integration commutes with continuous linear maps.
+
+  * `continuous_linear_map.integral_comp_comm`
+  * `linear_isometry.integral_comp_comm`
+
+
 ## Notes
 
 Some tips on how to prove a proposition if the API for the Bochner integral is not enough so that
@@ -278,7 +284,8 @@ begin
   { simp [hg0] }
 end
 
-variables [normed_space ℝ E]
+variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E] [normed_space ℝ E]
+  [smul_comm_class ℝ 𝕜 E]
 
 lemma integral_congr {f g : α →ₛ E} (hf : integrable f μ) (h : f =ᵐ[μ] g):
   f.integral μ = g.integral μ :=
@@ -352,13 +359,13 @@ begin
   exact hg.neg
 end
 
-lemma integral_smul (r : ℝ) {f : α →ₛ E} (hf : integrable f μ) :
-  integral μ (r • f) = r • integral μ f :=
-calc integral μ (r • f) = ∑ x in f.range, ennreal.to_real (μ (f ⁻¹' {x})) • r • x :
-  by rw [smul_eq_map r f, map_integral f _ hf (smul_zero _)]
-... = ∑ x in f.range, ((ennreal.to_real (μ (f ⁻¹' {x}))) * r) • x :
-  finset.sum_congr rfl $ λb hb, by apply smul_smul
-... = r • integral μ f :
+lemma integral_smul (c : 𝕜) {f : α →ₛ E} (hf : integrable f μ) :
+  integral μ (c • f) = c • integral μ f :=
+calc integral μ (c • f) = ∑ x in f.range, ennreal.to_real (μ (f ⁻¹' {x})) • c • x :
+  by rw [smul_eq_map c f, map_integral f _ hf (smul_zero _)]
+... = ∑ x in f.range, c • (ennreal.to_real (μ (f ⁻¹' {x}))) • x :
+  finset.sum_congr rfl $ λ b hb, by { exact smul_comm _ _ _}
+... = c • integral μ f :
 by simp only [integral, smul_sum, smul_smul, mul_comm]
 
 lemma norm_integral_le_integral_norm (f : α →ₛ E) (hf : integrable f μ) :
@@ -734,7 +741,8 @@ end pos_part
 section simple_func_integral
 /-! Define the Bochner integral on `α →₁ₛ[μ] E` and prove basic properties of this integral. -/
 
-variables [normed_space ℝ E]
+variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E] [normed_space ℝ E]
+  [smul_comm_class ℝ 𝕜 E]
 
 /-- The Bochner integral over simple functions in L1 space. -/
 def integral (f : α →₁ₛ[μ] E) : E := ((to_simple_func f)).integral μ
@@ -757,12 +765,13 @@ begin
   apply add_to_simple_func
 end
 
-lemma integral_smul (r : ℝ) (f : α →₁ₛ[μ] E) : integral (r • f) = r • integral f :=
+lemma integral_smul (c : 𝕜) (f : α →₁ₛ[μ] E) : integral (c • f) = c • integral f :=
 begin
   simp only [integral],
   rw ← simple_func.integral_smul _ (simple_func.integrable f),
-  apply measure_theory.simple_func.integral_congr (simple_func.integrable (r • f)),
-  apply smul_to_simple_func
+  apply measure_theory.simple_func.integral_congr (simple_func.integrable (c • f)),
+  apply smul_to_simple_func,
+  repeat { assumption },
 end
 
 lemma norm_integral_le_norm (f : α →₁ₛ[μ] E) : ∥integral f∥ ≤ ∥f∥ :=
@@ -773,9 +782,13 @@ end
 
 variables (α E μ)
 /-- The Bochner integral over simple functions in L1 space as a continuous linear map. -/
-def integral_clm : (α →₁ₛ[μ] E) →L[ℝ] E :=
+def integral_clm' (𝕜 : Type*) [normed_field 𝕜] [normed_space 𝕜 E] [smul_comm_class ℝ 𝕜 E] :
+  (α →₁ₛ[μ] E) →L[𝕜] E :=
 linear_map.mk_continuous ⟨integral, integral_add, integral_smul⟩
   1 (λf, le_trans (norm_integral_le_norm _) $ by rw one_mul)
+
+/-- The Bochner integral over simple functions in L1 space as a continuous linear map over ℝ. -/
+def integral_clm : (α →₁ₛ[μ] E) →L[ℝ] E := integral_clm' α E μ ℝ
 
 variables {α E μ}
 
@@ -858,7 +871,8 @@ open simple_func
 local notation `Integral` := @integral_clm α E _ _ _ _ _ μ _
 
 
-variables [normed_space ℝ E] [normed_space ℝ F] [complete_space E]
+variables [normed_space ℝ E] {𝕜 : Type*} [nondiscrete_normed_field 𝕜] [normed_space 𝕜 E]
+  [smul_comm_class ℝ 𝕜 E] [normed_space ℝ F] [complete_space E]
 
 section integration_in_L1
 
@@ -868,9 +882,14 @@ local attribute [instance] simple_func.normed_group simple_func.normed_space
 open continuous_linear_map
 
 /-- The Bochner integral in L1 space as a continuous linear map. -/
-def integral_clm : (α →₁[μ] E) →L[ℝ] E :=
-(integral_clm α E μ).extend
-  to_L1 simple_func.dense_range simple_func.uniform_inducing
+def integral_clm' (𝕜 : Type*) [nondiscrete_normed_field 𝕜] [normed_space 𝕜 E]
+  [smul_comm_class ℝ 𝕜 E] :
+  (α →₁[μ] E) →L[𝕜] E :=
+(integral_clm' α E μ 𝕜).extend
+  (coe_to_L1 α E 𝕜) simple_func.dense_range simple_func.uniform_inducing
+
+/-- The Bochner integral in L1 space as a continuous linear map over ℝ. -/
+def integral_clm : (α →₁[μ] E) →L[ℝ] E := integral_clm' ℝ
 
 /-- The Bochner integral in L1 space -/
 def integral (f : α →₁[μ] E) : E := integral_clm f
@@ -896,8 +915,8 @@ map_neg integral_clm f
 lemma integral_sub (f g : α →₁[μ] E) : integral (f - g) = integral f - integral g :=
 map_sub integral_clm f g
 
-lemma integral_smul (r : ℝ) (f : α →₁[μ] E) : integral (r • f) = r • integral f :=
-map_smul r integral_clm f
+lemma integral_smul (r : 𝕜) (f : α →₁[μ] E) : integral (r • f) = r • integral f :=
+map_smul r (integral_clm' 𝕜) f
 
 local notation `Integral` := @integral_clm α E _ _ _ _ _ μ _ _
 local notation `sIntegral` := @simple_func.integral_clm α E _ _ _ _ _ μ _
@@ -947,6 +966,7 @@ end L1
 
 variables [normed_group E] [second_countable_topology E] [normed_space ℝ E] [complete_space E]
   [measurable_space E] [borel_space E]
+          {𝕜 : Type*} [nondiscrete_normed_field 𝕜] [normed_space 𝕜 E] [smul_comm_class ℝ 𝕜 E]
           [normed_group F] [second_countable_topology F] [normed_space ℝ F] [complete_space F]
   [measurable_space F] [borel_space F]
 
@@ -1022,10 +1042,10 @@ lemma integral_sub' (hf : integrable f μ) (hg : integrable g μ) :
   ∫ a, (f - g) a ∂μ = ∫ a, f a ∂μ - ∫ a, g a ∂μ :=
 integral_sub hf hg
 
-lemma integral_smul (r : ℝ) (f : α → E) : ∫ a, r • (f a) ∂μ = r • ∫ a, f a ∂μ :=
+lemma integral_smul (r : 𝕜) (f : α → E) : ∫ a, r • (f a) ∂μ = r • ∫ a, f a ∂μ :=
 begin
   by_cases hf : integrable f μ,
-  { rw [integral_eq f hf, integral_eq (λa, r • (f a)), integrable.to_L1_smul, L1.integral_smul] },
+  { rw [integral_eq f hf, integral_eq (λa, r • (f a)), integrable.to_L1_smul, L1.integral_smul], },
   { by_cases hr : r = 0,
     { simp only [hr, measure_theory.integral_zero, zero_smul] },
     have hf' : ¬ integrable (λ x, r • f x) μ,

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -909,8 +909,8 @@ map_neg integral_clm f
 lemma integral_sub (f g : α →₁[μ] E) : integral (f - g) = integral f - integral g :=
 map_sub integral_clm f g
 
-lemma integral_smul (r : 𝕜) (f : α →₁[μ] E) : integral (r • f) = r • integral f :=
-map_smul r (integral_clm' 𝕜) f
+lemma integral_smul (c : 𝕜) (f : α →₁[μ] E) : integral (c • f) = c • integral f :=
+map_smul c (integral_clm' 𝕜) f
 
 local notation `Integral` := @integral_clm α E _ _ _ _ _ μ _ _
 local notation `sIntegral` := @simple_func.integral_clm α E _ _ _ _ _ μ _
@@ -1036,14 +1036,14 @@ lemma integral_sub' (hf : integrable f μ) (hg : integrable g μ) :
   ∫ a, (f - g) a ∂μ = ∫ a, f a ∂μ - ∫ a, g a ∂μ :=
 integral_sub hf hg
 
-lemma integral_smul (r : 𝕜) (f : α → E) : ∫ a, r • (f a) ∂μ = r • ∫ a, f a ∂μ :=
+lemma integral_smul (c : 𝕜) (f : α → E) : ∫ a, c • (f a) ∂μ = c • ∫ a, f a ∂μ :=
 begin
   by_cases hf : integrable f μ,
-  { rw [integral_eq f hf, integral_eq (λa, r • (f a)), integrable.to_L1_smul, L1.integral_smul], },
-  { by_cases hr : r = 0,
+  { rw [integral_eq f hf, integral_eq (λa, c • (f a)), integrable.to_L1_smul, L1.integral_smul], },
+  { by_cases hr : c = 0,
     { simp only [hr, measure_theory.integral_zero, zero_smul] },
-    have hf' : ¬ integrable (λ x, r • f x) μ,
-    { change ¬ integrable (r • f) μ, rwa [integrable_smul_iff hr f] },
+    have hf' : ¬ integrable (λ x, c • f x) μ,
+    { change ¬ integrable (c • f) μ, rwa [integrable_smul_iff hr f] },
     rw [integral_undef hf, integral_undef hf', smul_zero] }
 end
 

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -68,12 +68,6 @@ The Bochner integral is defined following these steps:
 
 4. `tendsto_integral_of_dominated_convergence` : the Lebesgue dominated convergence theorem
 
-5. (In the file `set_integral`) integration commutes with continuous linear maps.
-
-  * `continuous_linear_map.integral_comp_comm`
-  * `linear_isometry.integral_comp_comm`
-
-
 ## Notes
 
 Some tips on how to prove a proposition if the API for the Bochner integral is not enough so that

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -774,17 +774,16 @@ begin
   exact (to_simple_func f).norm_integral_le_integral_norm (simple_func.integrable f)
 end
 
-variables (α E μ)
+variables (α E μ 𝕜)
 /-- The Bochner integral over simple functions in L1 space as a continuous linear map. -/
-def integral_clm' (𝕜 : Type*) [normed_field 𝕜] [normed_space 𝕜 E] [smul_comm_class ℝ 𝕜 E] :
-  (α →₁ₛ[μ] E) →L[𝕜] E :=
+def integral_clm' : (α →₁ₛ[μ] E) →L[𝕜] E :=
 linear_map.mk_continuous ⟨integral, integral_add, integral_smul⟩
   1 (λf, le_trans (norm_integral_le_norm _) $ by rw one_mul)
 
 /-- The Bochner integral over simple functions in L1 space as a continuous linear map over ℝ. -/
 def integral_clm : (α →₁ₛ[μ] E) →L[ℝ] E := integral_clm' α E μ ℝ
 
-variables {α E μ}
+variables {α E μ 𝕜}
 
 local notation `Integral` := integral_clm α E μ
 
@@ -875,12 +874,13 @@ local attribute [instance] simple_func.normed_group simple_func.normed_space
 
 open continuous_linear_map
 
+variables (𝕜)
 /-- The Bochner integral in L1 space as a continuous linear map. -/
-def integral_clm' (𝕜 : Type*) [nondiscrete_normed_field 𝕜] [normed_space 𝕜 E]
-  [smul_comm_class ℝ 𝕜 E] :
-  (α →₁[μ] E) →L[𝕜] E :=
+def integral_clm' : (α →₁[μ] E) →L[𝕜] E :=
 (integral_clm' α E μ 𝕜).extend
   (coe_to_L1 α E 𝕜) simple_func.dense_range simple_func.uniform_inducing
+
+variables {𝕜}
 
 /-- The Bochner integral in L1 space as a continuous linear map over ℝ. -/
 def integral_clm : (α →₁[μ] E) →L[ℝ] E := integral_clm' ℝ

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -735,8 +735,7 @@ end pos_part
 section simple_func_integral
 /-! Define the Bochner integral on `α →₁ₛ[μ] E` and prove basic properties of this integral. -/
 
-variables [normed_field 𝕜] [normed_space 𝕜 E] [normed_space ℝ E]
-  [smul_comm_class ℝ 𝕜 E]
+variables [normed_field 𝕜] [normed_space 𝕜 E] [normed_space ℝ E] [smul_comm_class ℝ 𝕜 E]
 
 /-- The Bochner integral over simple functions in L1 space. -/
 def integral (f : α →₁ₛ[μ] E) : E := ((to_simple_func f)).integral μ

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -176,7 +176,7 @@ end measure_theory
 namespace measure_theory
 open set filter topological_space ennreal emetric
 
-variables {α E F : Type*} [measurable_space α]
+variables {α E F 𝕜 : Type*} [measurable_space α]
 
 local infixr ` →ₛ `:25 := simple_func
 
@@ -278,7 +278,7 @@ begin
   { simp [hg0] }
 end
 
-variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E] [normed_space ℝ E]
+variables [normed_field 𝕜] [normed_space 𝕜 E] [normed_space ℝ E]
   [smul_comm_class ℝ 𝕜 E]
 
 lemma integral_congr {f g : α →ₛ E} (hf : integrable f μ) (h : f =ᵐ[μ] g):
@@ -460,7 +460,7 @@ lemma coe_sub (f g : α →₁ₛ[μ] E) : ((f - g : α →₁ₛ[μ] E) : α �
 
 lemma norm_eq (f : α →₁ₛ[μ] E) : ∥f∥ = ∥(f : α →₁[μ] E)∥ := rfl
 
-variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E]
+variables [normed_field 𝕜] [normed_space 𝕜 E]
 
 /-- Not declared as an instance as `α →₁ₛ[μ] E` will only be useful in the construction of the
 Bochner integral. -/
@@ -523,7 +523,7 @@ lemma to_L1_sub (f g : α →ₛ E) (hf : integrable f μ) (hg : integrable g μ
   to_L1 (f - g) (hf.sub hg) = to_L1 f hf - to_L1 g hg :=
 by { simp only [sub_eq_add_neg, ← to_L1_neg, ← to_L1_add], refl }
 
-variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E]
+variables [normed_field 𝕜] [normed_space 𝕜 E]
 
 lemma to_L1_smul (f : α →ₛ E) (hf : integrable f μ) (c : 𝕜) :
   to_L1 (c • f) (hf.smul c) = c • to_L1 f hf := rfl
@@ -608,7 +608,7 @@ begin
   repeat { assume h, rw h }
 end
 
-variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E]
+variables [normed_field 𝕜] [normed_space 𝕜 E]
 
 lemma smul_to_simple_func (k : 𝕜) (f : α →₁ₛ[μ] E) :
   to_simple_func (k • f) =ᵐ[μ] k • to_simple_func f :=
@@ -695,9 +695,9 @@ simple_func.dense_embedding.to_dense_inducing
 protected lemma dense_range : dense_range (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
 simple_func.dense_inducing.dense
 
-variables (𝕜 : Type*) [normed_field 𝕜] [normed_space 𝕜 E]
+variables [normed_field 𝕜] [normed_space 𝕜 E]
 
-variables (α E)
+variables (α E 𝕜)
 
 /-- The uniform and dense embedding of L1 simple functions into L1 functions. -/
 def coe_to_L1 : (α →₁ₛ[μ] E) →L[𝕜] (α →₁[μ] E) :=
@@ -735,7 +735,7 @@ end pos_part
 section simple_func_integral
 /-! Define the Bochner integral on `α →₁ₛ[μ] E` and prove basic properties of this integral. -/
 
-variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E] [normed_space ℝ E]
+variables [normed_field 𝕜] [normed_space 𝕜 E] [normed_space ℝ E]
   [smul_comm_class ℝ 𝕜 E]
 
 /-- The Bochner integral over simple functions in L1 space. -/
@@ -781,7 +781,7 @@ linear_map.mk_continuous ⟨integral, integral_add, integral_smul⟩
   1 (λf, le_trans (norm_integral_le_norm _) $ by rw one_mul)
 
 /-- The Bochner integral over simple functions in L1 space as a continuous linear map over ℝ. -/
-def integral_clm : (α →₁ₛ[μ] E) →L[ℝ] E := integral_clm' α E μ ℝ
+def integral_clm : (α →₁ₛ[μ] E) →L[ℝ] E := integral_clm' α E ℝ μ
 
 variables {α E μ 𝕜}
 
@@ -864,7 +864,7 @@ open simple_func
 local notation `Integral` := @integral_clm α E _ _ _ _ _ μ _
 
 
-variables [normed_space ℝ E] {𝕜 : Type*} [nondiscrete_normed_field 𝕜] [normed_space 𝕜 E]
+variables [normed_space ℝ E] [nondiscrete_normed_field 𝕜] [normed_space 𝕜 E]
   [smul_comm_class ℝ 𝕜 E] [normed_space ℝ F] [complete_space E]
 
 section integration_in_L1
@@ -877,7 +877,7 @@ open continuous_linear_map
 variables (𝕜)
 /-- The Bochner integral in L1 space as a continuous linear map. -/
 def integral_clm' : (α →₁[μ] E) →L[𝕜] E :=
-(integral_clm' α E μ 𝕜).extend
+(integral_clm' α E 𝕜 μ).extend
   (coe_to_L1 α E 𝕜) simple_func.dense_range simple_func.uniform_inducing
 
 variables {𝕜}
@@ -960,7 +960,7 @@ end L1
 
 variables [normed_group E] [second_countable_topology E] [normed_space ℝ E] [complete_space E]
   [measurable_space E] [borel_space E]
-          {𝕜 : Type*} [nondiscrete_normed_field 𝕜] [normed_space 𝕜 E] [smul_comm_class ℝ 𝕜 E]
+          [nondiscrete_normed_field 𝕜] [normed_space 𝕜 E] [smul_comm_class ℝ 𝕜 E]
           [normed_group F] [second_countable_topology F] [normed_space ℝ F] [complete_space F]
   [measurable_space F] [borel_space F]
 


### PR DESCRIPTION
Extend the `integral_smul` lemmas to multiplication of a function `f : α → E` with scalars in `𝕜` with `[nondiscrete_normed_field 𝕜] [normed_space 𝕜 E] [smul_comm_class ℝ 𝕜 E]` instead of only `ℝ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

