### PR TITLE
[Merged by Bors] - refactor(ring_theory/discrete_valuation_ring): `discrete_valuation_ring.add_val` as an `add_valuation`

### DIFF
--- a/src/algebra/squarefree.lean
+++ b/src/algebra/squarefree.lean
@@ -110,7 +110,7 @@ begin
     by_cases h0 : a = 0,
     { simp [h0, x0] },
     rcases wf_dvd_monoid.exists_irreducible_factor hu h0 with ⟨b, hib, hdvd⟩,
-    apply le_trans (multiplicity.multiplicity_le_multiplicity_of_dvd hdvd),
+    apply le_trans (multiplicity.multiplicity_le_multiplicity_of_dvd_left hdvd),
     rw [multiplicity_eq_count_factors hib x0],
     specialize h (normalize b),
     assumption_mod_cast }

--- a/src/ring_theory/discrete_valuation_ring.lean
+++ b/src/ring_theory/discrete_valuation_ring.lean
@@ -396,13 +396,6 @@ noncomputable def add_val (R : Type u) [integral_domain R] [discrete_valuation_r
   add_valuation R enat :=
 add_valuation (classical.some_spec (exists_prime R))
 
-theorem add_val_spec {r : R} (hr : r ≠ 0) :
-  let ϖ := classical.some (exists_irreducible R) in
-  let n := classical.some
-    (associated_pow_irreducible hr (classical.some_spec (exists_irreducible R))) in
-  associated r (ϖ ^ n) :=
-classical.some_spec (associated_pow_irreducible hr (classical.some_spec $ exists_irreducible R))
-
 lemma add_val_def (r : R) (u : units R) {ϖ : R} (hϖ : irreducible ϖ) (n : ℕ) (hr : r = u * ϖ ^ n) :
   add_val R r = n :=
 by rw [add_val, add_valuation_apply, hr,

--- a/src/ring_theory/discrete_valuation_ring.lean
+++ b/src/ring_theory/discrete_valuation_ring.lean
@@ -98,7 +98,7 @@ by {simp_rw [irreducible_iff_uniformizer],
 
 /-- Uniformisers exist in a DVR -/
 theorem exists_prime : ∃ ϖ : R, prime ϖ :=
-exists_imp_exists (λ _, principal_ideal_ring.irreducible_iff_prime.1) (exists_irreducible R)
+(exists_irreducible R).imp (λ _, principal_ideal_ring.irreducible_iff_prime.1)
 
 /-- an integral domain is a DVR iff it's a PID with a unique non-zero prime ideal -/
 theorem iff_pid_with_one_nonzero_prime (R : Type u) [integral_domain R] :

--- a/src/ring_theory/discrete_valuation_ring.lean
+++ b/src/ring_theory/discrete_valuation_ring.lean
@@ -28,10 +28,7 @@ Let R be an integral domain, assumed to be a principal ideal ring and a local ri
 
 ### Definitions
 
-* `add_val R : R → ℕ` : the additive valuation on a DVR (sending 0 to 0 rather than the
-     mathematically correct +∞).
-TODO -- the multiplicative valuation, taking values in something
-  like `with_zero (multiplicative ℤ)`?
+* `add_val R : add_valuation R enat` : the additive valuation on a DVR.
 
 ## Implementation notes
 

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -151,9 +151,23 @@ lemma multiplicity_le_multiplicity_iff {a b c d : α} : multiplicity a b ≤ mul
     by rw [eq_top_iff_not_finite.2 hab, eq_top_iff_not_finite.2
       (not_finite_iff_forall.2 this)]⟩
 
-lemma multiplicity_le_multiplicity_of_dvd {a b c : α} (hdvd : a ∣ b) :
+lemma multiplicity_le_multiplicity_of_dvd_left {a b c : α} (hdvd : a ∣ b) :
   multiplicity b c ≤ multiplicity a c :=
 multiplicity_le_multiplicity_iff.2 $ λ n h, dvd_trans (pow_dvd_pow_of_dvd hdvd n) h
+
+lemma eq_of_associated_left {a b c : α} (h : associated a b) :
+  multiplicity b c = multiplicity a c :=
+le_antisymm (multiplicity_le_multiplicity_of_dvd_left (dvd_of_associated h))
+  (multiplicity_le_multiplicity_of_dvd_left (dvd_of_associated h.symm))
+
+lemma multiplicity_le_multiplicity_of_dvd_right {a b c : α} (h : b ∣ c) :
+  multiplicity a b ≤ multiplicity a c :=
+multiplicity_le_multiplicity_iff.2 $ λ n hb, dvd.trans hb h
+
+lemma eq_of_associated_right {a b c : α} (h : associated b c) :
+  multiplicity a b = multiplicity a c :=
+le_antisymm (multiplicity_le_multiplicity_of_dvd_right (dvd_of_associated h))
+  (multiplicity_le_multiplicity_of_dvd_right (dvd_of_associated h.symm))
 
 lemma dvd_of_multiplicity_pos {a b : α} (h : (0 : enat) < multiplicity a b) : a ∣ b :=
 by rw [← pow_one a]; exact pow_dvd_of_le_multiplicity (enat.pos_iff_one_le.1 h)


### PR DESCRIPTION
Refactors `discrete_valuation_ring.add_val` to be an `enat`-valued `add_valuation`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
