### PR TITLE
[Merged by Bors] - feat(combinatorics/quiver): define quivers

### DIFF
--- a/src/combinatorics/quiver.lean
+++ b/src/combinatorics/quiver.lean
@@ -13,6 +13,7 @@ is a very permissive notion of directed graph.
 -/
 
 -- We use the same universe order as in category theory.
+-- See note [category_theory universes]
 universes v u
 
 /-- A quiver `G` on a type `V` of vertices assigns to every pair `a b : V` of vertices
@@ -20,13 +21,13 @@ universes v u
 structure quiver (V : Type u) :=
 (arrow : V → V → Sort v)
 
-/-- A subquiver `H` of `G` picks out a set `H a b` of arrows from `a` to `b`
+/-- A wide subquiver `H` of `G` picks out a set `H a b` of arrows from `a` to `b`
     for every pair of vertices `a b`. -/
-def subquiver {V} (G : quiver V) :=
+def wide_subquiver {V} (G : quiver V) :=
 Π a b : V, set (G.arrow a b)
 
-/-- A subquiver viewed as a quiver on its own. -/
-def subquiver.quiver {V} {G : quiver V} (H : subquiver G) : quiver V :=
+/-- A wide subquiver viewed as a quiver on its own. -/
+def wide_subquiver.quiver {V} {G : quiver V} (H : wide_subquiver G) : quiver V :=
 ⟨λ a b, H a b⟩
 
 namespace quiver
@@ -35,9 +36,9 @@ namespace quiver
 protected def empty (V) : quiver.{v} V := ⟨λ a b, pempty⟩
 
 instance {V} : inhabited (quiver.{v} V) := ⟨quiver.empty V⟩
-instance {V} (G : quiver V) : has_bot (subquiver G) := ⟨λ a b, ∅⟩
-instance {V} (G : quiver V) : has_top (subquiver G) := ⟨λ a b, set.univ⟩
-instance {V} {G : quiver V} : inhabited (subquiver G) := ⟨⊤⟩
+instance {V} (G : quiver V) : has_bot (wide_subquiver G) := ⟨λ a b, ∅⟩
+instance {V} (G : quiver V) : has_top (wide_subquiver G) := ⟨λ a b, set.univ⟩
+instance {V} {G : quiver V} : inhabited (wide_subquiver G) := ⟨⊤⟩
 
 /-- `G.sum H` takes the disjoint union of the arrows of `G` and `H`. -/
 protected def sum {V} (G H : quiver V) : quiver V :=
@@ -51,6 +52,20 @@ protected def opposite {V} (G : quiver V) : quiver V :=
 def symmetrify {V} (G : quiver V) : quiver V :=
 G.sum G.opposite
 
+@[simp] lemma empty_arrow {V} (a b : V) : (quiver.empty V).arrow a b = pempty := rfl
+
+@[simp] lemma sum_arrow {V} (G H : quiver V) (a b : V) :
+  (G.sum H).arrow a b = (G.arrow a b ⊕ H.arrow a b) := rfl
+
+@[simp] lemma opposite_arrow {V} (G : quiver V) (a b : V) :
+  G.opposite.arrow a b = G.arrow b a := rfl
+
+@[simp] lemma symmetrify_arrow {V} (G : quiver V) (a b : V) :
+  G.symmetrify.arrow a b = (G.arrow a b ⊕ G.arrow b a) := rfl
+
+@[simp] lemma opposite_opposite {V} (G : quiver V) : G.opposite.opposite = G :=
+by { cases G, refl }
+
 /-- `G.total` is the type of _all_ arrows of `G`. -/
 @[ext] protected structure total {V} (G : quiver.{v u} V) : Sort (max (u+1) v) :=
 (source : V)
@@ -61,16 +76,16 @@ instance {V} [inhabited V] {G : quiver V} [inhabited (G.arrow (default V) (defau
   inhabited G.total :=
 ⟨⟨default V, default V, default _⟩⟩
 
-/-- A subquiver `H` of `G.symmetrify` determines a subquiver of `G`, containing an
+/-- A wide subquiver `H` of `G.symmetrify` determines a wide subquiver of `G`, containing an
     an arrow `e` if either `e` or its reversal is in `H`. -/
-def subquiver_symmetrify {V} {G : quiver V} :
-  subquiver G.symmetrify → subquiver G :=
+def wide_subquiver_symmetrify {V} {G : quiver V} :
+  wide_subquiver G.symmetrify → wide_subquiver G :=
 λ H a b, { e | sum.inl e ∈ H a b ∨ sum.inr e ∈ H b a }
 
-/-- A subquiver of `G` can equivalently be viewed as a total set of arrows. -/
-def subquiver_equiv_set_total {V} {G : quiver V} :
-  subquiver G ≃ set G.total :=
-{ to_fun := λ H, {e | e.arrow ∈ H e.source e.target },
+/-- A wide subquiver of `G` can equivalently be viewed as a total set of arrows. -/
+def wide_subquiver_equiv_set_total {V} {G : quiver V} :
+  wide_subquiver G ≃ set G.total :=
+{ to_fun := λ H, { e | e.arrow ∈ H e.source e.target },
   inv_fun := λ S a b, { e | total.mk a b e ∈ S },
   left_inv := λ H, rfl,
   right_inv := by { intro S, ext, cases x, refl } }
@@ -97,5 +112,11 @@ arborescence.root T
 
 instance {V} (T : quiver V) [arborescence T] (b : V) : unique (T.path T.root b) :=
 arborescence.unique_path b
+
+/-- An `L`-labelling of a quiver assigns to every arrow an element of `L`. -/
+def labelling {V} (G : quiver V) (L) := Π a b, G.arrow a b → L
+
+instance {V} (G : quiver V) (L) [inhabited L] : inhabited (G.labelling L) :=
+⟨λ a b e, default L⟩
 
 end quiver

--- a/src/combinatorics/quiver.lean
+++ b/src/combinatorics/quiver.lean
@@ -61,7 +61,7 @@ instance {V} [inhabited V] {G : quiver V} [inhabited (G.arrow (default V) (defau
   inhabited G.total :=
 ⟨⟨default V, default V, default _⟩⟩
 
-/-- A `H` subquiver of `G.symmetrify` determines a subquiver of `G`, containing an
+/-- A subquiver `H` of `G.symmetrify` determines a subquiver of `G`, containing an
     an arrow `e` if either `e` or its reversal is in `H`. -/
 def subquiver_symmetrify {V} {G : quiver V} :
   subquiver G.symmetrify → subquiver G :=

--- a/src/combinatorics/quiver.lean
+++ b/src/combinatorics/quiver.lean
@@ -8,76 +8,77 @@ import tactic
 # Quivers
 
 This module defines quivers. A quiver `G` on a type `V` of vertices assigns to every
-pair `a b : V` of vertices a type `G a b`, thought of as edges from `a` to `b`. This
-is a very permissive notion of graph.
+pair `a b : V` of vertices a type `G.arrow a b` of arrows from `a` to `b`. This
+is a very permissive notion of directed graph.
 -/
 
 -- We use the same universe order as in category theory.
 universes v u
 
 /-- A quiver `G` on a type `V` of vertices assigns to every pair `a b : V` of vertices
-    a type `G a b`, thought of as edges from `a` to `b`. -/
-def quiver (V : Type u) := V → V → Type v
+    a type `G.arrow a b` of arrows from `a` to `b`. -/
+structure quiver (V : Type u) :=
+(arrow : V → V → Sort v)
 
-/-- The default quiver on `V` is the empty quiver. -/
-instance {V} : inhabited (quiver.{v} V) :=
-⟨λ a b, pempty⟩
-
-/-- A subquiver `H` of `G` picks out subset `H a b` of the edges from `a` to `b`
+/-- A subquiver `H` of `G` picks out a set `H a b` of arrows from `a` to `b`
     for every pair of vertices `a b`. -/
 def subquiver {V} (G : quiver V) :=
-Π a b : V, set (G a b)
-
-/-- The default subquiver of `G` contains every edge. -/
-instance {V} {G : quiver V} : inhabited (subquiver G) :=
-⟨λ a b, set.univ⟩
+Π a b : V, set (G.arrow a b)
 
 /-- A subquiver viewed as a quiver on its own. -/
 def subquiver.quiver {V} {G : quiver V} (H : subquiver G) : quiver V :=
-λ a b, H a b
+⟨λ a b, H a b⟩
 
 namespace quiver
 
-/-- `G.sum H` takes the disjoint union of the edges of `G` and `H`. -/
+/-- The quiver with no arrows. -/
+def empty (V) : quiver.{v} V := ⟨λ a b, pempty⟩
+
+instance {V} : inhabited (quiver.{v} V) := ⟨empty V⟩
+instance {V} (G : quiver V) : has_bot (subquiver G) := ⟨λ a b, ∅⟩
+instance {V} (G : quiver V) : has_top (subquiver G) := ⟨λ a b, set.univ⟩
+instance {V} {G : quiver V} : inhabited (subquiver G) := ⟨⊤⟩
+
+/-- `G.sum H` takes the disjoint union of the arrows of `G` and `H`. -/
 def sum {V} (G H : quiver V) : quiver V :=
-λ a b, G a b ⊕ H a b
+⟨λ a b, G.arrow a b ⊕ H.arrow a b⟩
 
-/-- `G.opposite` reverses the direction of all edges of `G`. -/
+/-- `G.opposite` reverses the direction of all arrows of `G`. -/
 def opposite {V} (G : quiver V) : quiver V :=
-flip G
+⟨flip G.arrow⟩
 
-/-- `G.symmetrify` adds to `G` the reversal of all edges of `G`. -/
+/-- `G.symmetrify` adds to `G` the reversal of all arrows of `G`. -/
 def symmetrify {V} (G : quiver V) : quiver V :=
 G.sum G.opposite
 
-/-- `G.total` is the type of _all_ edges of `G`. -/
+/-- `G.total` is the type of _all_ arrows of `G`. -/
 @[ext] structure total {V} (G : quiver.{v u} V) : Type (max u v) :=
 (source : V)
 (target : V)
-(edge : G source target)
+(arrow : G.arrow source target)
 
-instance {V} [inhabited V] {G : quiver V} [inhabited (G (default V) (default V))] :
+instance {V} [inhabited V] {G : quiver V} [inhabited (G.arrow (default V) (default V))] :
   inhabited G.total :=
 ⟨⟨default V, default V, default _⟩⟩
 
 /-- A `H` subquiver of `G.symmetrify` determines a subquiver of `G`, containing an
-    an edge `e` if either `e` or its reversal is in `H`. -/
+    an arrow `e` if either `e` or its reversal is in `H`. -/
 def subquiver_symmetrify {V} (G : quiver V) :
   subquiver G.symmetrify → subquiver G :=
 λ H a b, { e | sum.inl e ∈ H a b ∨ sum.inr e ∈ H b a }
 
-/-- A subquiver of `G` can equivalently be viewed as a total set of edges. -/
+/-- A subquiver of `G` can equivalently be viewed as a total set of arrows. -/
 def subquiver_equiv_set_total {V} (G : quiver V) :
   subquiver G ≃ set G.total :=
-{ to_fun := λ H, {e | e.edge ∈ H e.source e.target },
+{ to_fun := λ H, {e | e.arrow ∈ H e.source e.target },
   inv_fun := λ S a b, { e | total.mk a b e ∈ S },
   left_inv := λ H, rfl,
   right_inv := by { intro S, ext, cases x, refl } }
 
-/-- `G.path a b` is the type of paths from `a` to `b` through the edges of `G`. -/
+/-- `G.path a b` is the type of paths from `a` to `b` through the arrows of `G`. -/
 inductive path {V} (G : quiver.{v u} V) (a : V) : V → Type (max u v)
 | nil  : path a
-| cons : Π {b c : V}, path b → G b c → path c
+| cons : Π {b c : V}, path b → G.arrow b c → path c
 
 /-- A quiver is an arborescence when there is a unique path from the default vertex
     to every other vertex. -/

--- a/src/combinatorics/quiver.lean
+++ b/src/combinatorics/quiver.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2021 David Wärn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Wärn
+-/
+import tactic
+/-!
+# Quivers
+
+This module defines quivers. A quiver `G` on a type `V` of vertices assigns to every
+pair `a b : V` of vertices a type `G a b`, thought of as edges from `a` to `b`. This
+is a very permissive notion of graph.
+-/
+
+-- We use the same universe order as in category theory.
+universes v u
+
+/-- A quiver `G` on a type `V` of vertices assigns to every pair `a b : V` of vertices
+    a type `G a b`, thought of as edges from `a` to `b`. -/
+def quiver (V : Type u) := V → V → Type v
+
+/-- The default quiver on `V` is the empty quiver. -/
+instance {V} : inhabited (quiver.{v} V) :=
+⟨λ a b, pempty⟩
+
+/-- A subquiver `H` of `G` picks out subset `H a b` of the edges from `a` to `b`
+    for every pair of vertices `a b`. -/
+def subquiver {V} (G : quiver V) :=
+Π a b : V, set (G a b)
+
+/-- The default subquiver of `G` contains every edge. -/
+instance {V} {G : quiver V} : inhabited (subquiver G) :=
+⟨λ a b, set.univ⟩
+
+/-- A subquiver viewed as a quiver on its own. -/
+def subquiver.quiver {V} {G : quiver V} (H : subquiver G) : quiver V :=
+λ a b, H a b
+
+namespace quiver
+
+/-- `G.sum H` takes the disjoint union of the edges of `G` and `H`. -/
+def sum {V} (G H : quiver V) : quiver V :=
+λ a b, G a b ⊕ H a b
+
+/-- `G.opposite` reverses the direction of all edges of `G`. -/
+def opposite {V} (G : quiver V) : quiver V :=
+flip G
+
+/-- `G.symmetrify` adds to `G` the reversal of all edges of `G`. -/
+def symmetrify {V} (G : quiver V) : quiver V :=
+G.sum G.opposite
+
+/-- `G.total` is the type of _all_ edges of `G`. -/
+@[ext] structure total {V} (G : quiver.{v u} V) : Type (max u v) :=
+(source : V)
+(target : V)
+(edge : G source target)
+
+instance {V} [inhabited V] {G : quiver V} [inhabited (G (default V) (default V))] :
+  inhabited G.total :=
+⟨⟨default V, default V, default _⟩⟩
+
+/-- A `H` subquiver of `G.symmetrify` determines a subquiver of `G`, containing an
+    an edge `e` if either `e` or its reversal is in `H`. -/
+def subquiver_symmetrify {V} (G : quiver V) :
+  subquiver G.symmetrify → subquiver G :=
+λ H a b, { e | sum.inl e ∈ H a b ∨ sum.inr e ∈ H b a }
+
+/-- A subquiver of `G` can equivalently be viewed as a total set of edges. -/
+def subquiver_equiv_set_total {V} (G : quiver V) :
+  subquiver G ≃ set G.total :=
+{ to_fun := λ H, {e | e.edge ∈ H e.source e.target },
+  inv_fun := λ S a b, { e | total.mk a b e ∈ S },
+  left_inv := λ H, rfl,
+  right_inv := by { intro S, ext, cases x, refl } }
+
+/-- `G.path a b` is the type of paths from `a` to `b` through the edges of `G`. -/
+inductive path {V} (G : quiver.{v u} V) (a : V) : V → Type (max u v)
+| nil  : path a
+| cons : Π {b c : V}, path b → G b c → path c
+
+/-- A quiver is an arborescence when there is a unique path from the default vertex
+    to every other vertex. -/
+class arborescence {V} [inhabited V] (G : quiver.{v u} V) : Type (max u v) :=
+(unique_path : Π (b : V), unique (G.path (default V) b))
+
+attribute [instance] arborescence.unique_path
+
+end quiver


### PR DESCRIPTION
Define quivers (a very permissive notion of graph), subquivers, paths
and arborescences, which are like rooted trees.

This PR comes from https://github.com/dwarn/nielsen-schreier-2 .



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
