### PR TITLE
[Merged by Bors] - feat(number_theory/bernoulli): faulhaber'

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -271,7 +271,7 @@
   title  : Fourier Series
 77:
   title  : Sum of kth powers
-  decl   : sum_range_pow
+  decl   : sum_range_pow'
   author : mathlib (Moritz Firsching, Fabian Kruse, Ashvni Narayanan)
 78:
   title  : The Cauchy-Schwarz Inequality

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -271,7 +271,9 @@
   title  : Fourier Series
 77:
   title  : Sum of kth powers
-  decl   : sum_range_pow'
+  decls  :
+    - sum_range_pow
+    - sum_range_pow'
   author : mathlib (Moritz Firsching, Fabian Kruse, Ashvni Narayanan)
 78:
   title  : The Cauchy-Schwarz Inequality

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -393,8 +393,8 @@ end
 /-- Alternative form of Faulhaber's theorem, relating the sum of p-th powers with Bernoulli numbers.
 Deduced from `sum_range_pow`. -/
 theorem sum_range_pow' (n p : ℕ) :
-  ∑ k in Ico 1 (n + 1), (k : ℚ) ^ p
-    = ∑ i in range (p + 1), bernoulli' i * (p + 1).choose i * n ^ (p + 1 - i) / (p + 1) :=
+  ∑ k in Ico 1 (n + 1), (k : ℚ) ^ p =
+    ∑ i in range (p + 1), bernoulli' i * (p + 1).choose i * n ^ (p + 1 - i) / (p + 1) :=
 begin
   -- We extract the first two terms of the sum on the right hand side and then replace instances of
   -- `bernoulli'` by `bernoulli`, but the sum back together and apply `sum_range_pow`.
@@ -403,38 +403,37 @@ begin
   cases p with p hp,
   { simp, },
   -- extract the second term of the sum on the right hand side
-  { rw [sum_range_succ', ← bernoulli_eq_bernoulli'_of_ne_one zero_ne_one],
-  have hb1: bernoulli' (0 + 1) = bernoulli (0 + 1) + 1, { norm_num, },
+  rw [sum_range_succ', ← bernoulli_eq_bernoulli'_of_ne_one zero_ne_one],
+  have hb1 : bernoulli' (0 + 1) = bernoulli (0 + 1) + 1, { norm_num, },
   -- transform `bernoulli' 1` into `bernoulli 1`
   rw [hb1, mul_div_assoc, mul_assoc, add_mul, ← mul_assoc, ← mul_div_assoc, ← add_assoc],
   -- replace `bernoulli'` by `bernoulli` in the remaider of the sum
-  have hsum:  ∑ (i : ℕ) in   range p,  bernoulli' (i + 1 + 1) * ↑((p.succ + 1).choose (i + 1 + 1))
+  have hsum : ∑ (i : ℕ) in range p,  bernoulli' (i + 1 + 1) * ↑((p.succ + 1).choose (i + 1 + 1))
     * ↑n ^ (p.succ + 1 - (i + 1 + 1)) / (↑(p.succ) + 1)
       =  ∑ (i : ℕ) in   range p, bernoulli (i + 1 + 1) * ↑((p.succ + 1).choose (i + 1 + 1))
     * ↑n ^ (p.succ + 1 - (i + 1 + 1)) / (↑(p.succ) + 1),
-    { refine sum_congr rfl _,
-      intros x h,
-      have hx: x + 1 + 1 ≠ 1,
-      { simp only [add_left_eq_self, add_eq_zero_iff, ne.def, not_false_iff, one_ne_zero,
+  { refine sum_congr rfl (λ x h, _),
+    have hx : x + 1 + 1 ≠ 1,
+    { simp only [add_left_eq_self, add_eq_zero_iff, ne.def, not_false_iff, one_ne_zero,
         and_false], },
-      simp only [bernoulli_eq_bernoulli'_of_ne_one hx], },
+    simp only [bernoulli_eq_bernoulli'_of_ne_one hx], },
   rw [hsum],
   let f := (λ i, bernoulli (i + 1) * ↑((p.succ + 1).choose (i + 1))
     * ↑n ^ (p.succ + 1 - (i + 1)) / (↑(p.succ) + 1)),
-  let g :=  (λ i, bernoulli i * (p.succ + 1).choose i * n ^ (p.succ + 1 - i) / (p.succ + 1)),
+  let g := (λ i, bernoulli i * (p.succ + 1).choose i * n ^ (p.succ + 1 - i) / (p.succ + 1)),
   -- put the sum back together and apply key lemma `sum_range_pow`
   rw [← sum_range_succ' f, add_assoc, add_comm _ (bernoulli 0 * ↑((p.succ + 1).choose 0)
     * ↑n ^ (p.succ + 1 - 0) / (↑(p.succ) + 1)), ← add_assoc, ← sum_range_succ' g, ← sum_range_pow],
-  have hn1: 1 ≤ n + 1, { simp only [le_add_iff_nonneg_left 1, nat.zero_le], },
+  have hn1 : 1 ≤ n + 1, { simp only [le_add_iff_nonneg_left 1, nat.zero_le], },
   -- replace sum over `Ico` by sums over `range` and make massage lhs and rhs to be equal
   rw [sum_Ico_eq_sub (λ k, (k : ℚ) ^ p.succ) hn1, sum_range_succ, succ_eq_add_one],
   simp only [one_mul, cast_one, cast_add, sub_zero, succ_add_sub_one, cast_zero, add_eq_zero_iff,
     ne.def, sum_singleton, not_false_iff, one_ne_zero, and_false, zero_pow', choose_one_right,
     range_one, cast_id],
-  have hp: (p : ℚ) + 1 + 1 ≠ 0,
+  have hp : (p : ℚ) + 1 + 1 ≠ 0,
   { norm_cast,
     simp only [add_eq_zero_iff, not_false_iff, one_ne_zero, and_false], },
-  rw [mul_comm, div_mul_cancel _ hp, add_comm], },
+  rw [mul_comm, div_mul_cancel _ hp, add_comm],
 end
 
 end faulhaber

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -390,4 +390,51 @@ begin
   field_simp [mul_right_comm _ ↑p!, ←mul_assoc _ _ ↑p!, cast_add_one_ne_zero, hne],
 end
 
+/-- Alternative form of Faulhaber's theorem, relating the sum of p-th powers with Bernoulli numbers.
+Deduced from `sum_range_pow`. -/
+theorem sum_range_pow' (n p : ℕ) :
+  ∑ k in Ico 1 (n + 1), (k : ℚ) ^ p
+    = ∑ i in range (p + 1), bernoulli' i * (p + 1).choose i * n ^ (p + 1 - i) / (p + 1) :=
+begin
+  -- We extract the first two terms of the sum on the right hand side and then replace instances of
+  -- `bernoulli'` by `bernoulli`, but the sum back together and apply `sum_range_pow`.
+  rw [sum_range_succ'],
+  -- if p is zero, there is no second term, so we make a special case
+  cases p with p hp,
+  { simp, },
+  -- extract the second term of the sum on the right hand side
+  { rw [sum_range_succ', ← bernoulli_eq_bernoulli'_of_ne_one zero_ne_one],
+  have hb1: bernoulli' (0 + 1) = bernoulli (0 + 1) + 1, { norm_num, },
+  -- transform `bernoulli' 1` into `bernoulli 1`
+  rw [hb1, mul_div_assoc, mul_assoc, add_mul, ← mul_assoc, ← mul_div_assoc, ← add_assoc],
+  -- replace `bernoulli'` by `bernoulli` in the remaider of the sum
+  have hsum:  ∑ (i : ℕ) in   range p,  bernoulli' (i + 1 + 1) * ↑((p.succ + 1).choose (i + 1 + 1))
+    * ↑n ^ (p.succ + 1 - (i + 1 + 1)) / (↑(p.succ) + 1)
+      =  ∑ (i : ℕ) in   range p, bernoulli (i + 1 + 1) * ↑((p.succ + 1).choose (i + 1 + 1))
+    * ↑n ^ (p.succ + 1 - (i + 1 + 1)) / (↑(p.succ) + 1),
+    { refine sum_congr rfl _,
+      intros x h,
+      have hx: x + 1 + 1 ≠ 1,
+      { simp only [add_left_eq_self, add_eq_zero_iff, ne.def, not_false_iff, one_ne_zero,
+        and_false], },
+      simp only [bernoulli_eq_bernoulli'_of_ne_one hx], },
+  rw [hsum],
+  let f := (λ i, bernoulli (i + 1) * ↑((p.succ + 1).choose (i + 1))
+    * ↑n ^ (p.succ + 1 - (i + 1)) / (↑(p.succ) + 1)),
+  let g :=  (λ i, bernoulli i * (p.succ + 1).choose i * n ^ (p.succ + 1 - i) / (p.succ + 1)),
+  -- put the sum back together and apply key lemma `sum_range_pow`
+  rw [← sum_range_succ' f, add_assoc, add_comm _ (bernoulli 0 * ↑((p.succ + 1).choose 0)
+    * ↑n ^ (p.succ + 1 - 0) / (↑(p.succ) + 1)), ← add_assoc, ← sum_range_succ' g, ← sum_range_pow],
+  have hn1: 1 ≤ n + 1, { simp only [le_add_iff_nonneg_left 1, nat.zero_le], },
+  -- replace sum over `Ico` by sums over `range` and make massage lhs and rhs to be equal
+  rw [sum_Ico_eq_sub (λ k, (k : ℚ) ^ p.succ) hn1, sum_range_succ, succ_eq_add_one],
+  simp only [one_mul, cast_one, cast_add, sub_zero, succ_add_sub_one, cast_zero, add_eq_zero_iff,
+    ne.def, sum_singleton, not_false_iff, one_ne_zero, and_false, zero_pow', choose_one_right,
+    range_one, cast_id],
+  have hp: (p : ℚ) + 1 + 1 ≠ 0,
+  { norm_cast,
+    simp only [add_eq_zero_iff, not_false_iff, one_ne_zero, and_false], },
+  rw [mul_comm, div_mul_cancel _ hp, add_comm], },
+end
+
 end faulhaber


### PR DESCRIPTION
This deduces an alternative form `faulhaber'` of Faulhaber's theorem from `faulhaber`. In this version, we 

1. sum over `1` to `n` instead of `0` to `n - 1` and
2. use `bernoulli'` instead of `bernoulli`.
Arguably, this is the more common form one finds Faulhaber's theorem in the literature. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #6409 [contains the harder part of actually proving Faulhaber's theorem]
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
