### PR TITLE
[Merged by Bors] - refactor(topology/metric_space/emetric_space): add pseudo_emetric

### DIFF
--- a/src/measure_theory/ae_eq_fun_metric.lean
+++ b/src/measure_theory/ae_eq_fun_metric.lean
@@ -57,8 +57,11 @@ instance : emetric_space (α →ₘ[μ] γ) :=
       measure_theory.lintegral_mono (λ a, edist_triangle (f a) (g a) (h a))
     ... = ∫⁻ a, edist (f a) (g a) ∂μ + ∫⁻ a, edist (g a) (h a) ∂μ :
       lintegral_add' (hf.edist hg) (hg.edist hh),
-  eq_of_edist_eq_zero := λ f g, induction_on₂ f g $ λ f hf g hg H, mk_eq_mk.2 $
-    ((lintegral_eq_zero_iff' (hf.edist hg)).1 H).mono $ λ x, eq_of_edist_eq_zero }
+  eq_of_edist_eq_zero := λ f g,
+  begin
+    exact induction_on₂ f g (λ f hf g hg H, mk_eq_mk.2 (((lintegral_eq_zero_iff'
+      (hf.edist hg)).1 H).mono (λ x, eq_of_edist_eq_zero)))
+  end }
 
 lemma edist_mk_mk {f g : α → γ} (hf hg) :
   edist (mk f hf : α →ₘ[μ] γ) (mk g hg) = ∫⁻ x, edist (f x) (g x) ∂μ :=

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -809,7 +809,7 @@ let m : metric_space α :=
   eq_of_dist_eq_zero := λx y hxy,
     by simpa [h, ennreal.to_real_eq_zero_iff, edist_ne_top x y] using hxy,
   dist_self          := λx, by simp [h],
-  dist_comm          := λx y, by simp [h, pseudoemetric_space.edist_comm],
+  dist_comm          := λx y, by simp [h, pseudo_emetric_space.edist_comm],
   dist_triangle      := λx y z, begin
     simp only [h],
     rw [← ennreal.to_real_add (edist_ne_top _ _) (edist_ne_top _ _),

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -809,7 +809,7 @@ let m : metric_space α :=
   eq_of_dist_eq_zero := λx y hxy,
     by simpa [h, ennreal.to_real_eq_zero_iff, edist_ne_top x y] using hxy,
   dist_self          := λx, by simp [h],
-  dist_comm          := λx y, by simp [h, emetric_space.edist_comm],
+  dist_comm          := λx y, by simp [h, pseudoemetric_space.edist_comm],
   dist_triangle      := λx y z, begin
     simp only [h],
     rw [← ennreal.to_real_add (edist_ne_top _ _) (edist_ne_top _ _),

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -451,8 +451,8 @@ instance pseudoemetric_space_pi [∀b, pseudoemetric_space (π b)] : pseudoemetr
 lemma pseudoedist_pi_def [Π b, pseudoemetric_space (π b)] (f g : Π b, π b) :
   edist f g = finset.sup univ (λb, edist (f b) (g b)) := rfl
 
-@[simp] lemma pseudoedist_pi_const [nonempty β] (a b : α) : edist (λ x : β, a) (λ _, b) = edist a b :=
-finset.sup_const univ_nonempty (edist a b)
+@[simp] lemma pseudoedist_pi_const [nonempty β] (a b : α) :
+  edist (λ x : β, a) (λ _, b) = edist a b := finset.sup_const univ_nonempty (edist a b)
 
 end pi
 

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -87,7 +87,7 @@ on a product.
 
 Continuity of `edist` is proved in `topology.instances.ennreal`
 -/
-class pseudoemetric_space (α : Type u) extends has_edist α : Type u :=
+class pseudo_emetric_space (α : Type u) extends has_edist α : Type u :=
 (edist_self : ∀ x : α, edist x x = 0)
 (edist_comm : ∀ x y : α, edist x y = edist y x)
 (edist_triangle : ∀ x y z : α, edist x z ≤ edist x y + edist y z)
@@ -97,13 +97,13 @@ class pseudoemetric_space (α : Type u) extends has_edist α : Type u :=
 
 /- emetric spaces are less common than metric spaces. Therefore, we work in a dedicated
 namespace, while notions associated to metric spaces are mostly in the root namespace. -/
-variables [pseudoemetric_space α]
+variables [pseudo_emetric_space α]
 
 @[priority 100] -- see Note [lower instance priority]
-instance pseudoemetric_space.to_uniform_space' : uniform_space α :=
-pseudoemetric_space.to_uniform_space
+instance pseudoe_emetric_space.to_uniform_space' : uniform_space α :=
+pseudo_emetric_space.to_uniform_space
 
-export pseudoemetric_space (edist_self edist_comm edist_triangle)
+export pseudo_emetric_space (edist_self edist_comm edist_triangle)
 
 attribute [simp] edist_self
 
@@ -159,7 +159,7 @@ finset.Ico.zero_bot n ▸ edist_le_Ico_sum_of_edist_le (zero_le n) (λ _ _, hd)
 /-- Reformulation of the uniform structure in terms of the extended distance -/
 theorem uniformity_pseudoedist :
   𝓤 α = ⨅ ε>0, 𝓟 {p:α×α | edist p.1 p.2 < ε} :=
-pseudoemetric_space.uniformity_edist
+pseudo_emetric_space.uniformity_edist
 
 theorem uniformity_basis_edist :
   (𝓤 α).has_basis (λ ε : ℝ≥0∞, 0 < ε) (λ ε, {p:α×α | edist p.1 p.2 < ε}) :=
@@ -253,19 +253,19 @@ theorem uniformity_has_countable_basis : is_countably_generated (𝓤 α) :=
 is_countably_generated_of_seq ⟨_, uniformity_basis_edist_inv_nat.eq_infi⟩
 
 /-- ε-δ characterization of uniform continuity on a set for pseudoemetric spaces -/
-theorem uniform_continuous_on_iff [pseudoemetric_space β] {f : α → β} {s : set α} :
+theorem uniform_continuous_on_iff [pseudo_emetric_space β] {f : α → β} {s : set α} :
   uniform_continuous_on f s ↔ ∀ ε > 0, ∃ δ > 0,
     ∀{a b}, a ∈ s → b ∈ s → edist a b < δ → edist (f a) (f b) < ε :=
 uniformity_basis_edist.uniform_continuous_on_iff uniformity_basis_edist
 
 /-- ε-δ characterization of uniform continuity on pseudoemetric spaces -/
-theorem uniform_continuous_iff [pseudoemetric_space β] {f : α → β} :
+theorem uniform_continuous_iff [pseudo_emetric_space β] {f : α → β} :
   uniform_continuous f ↔ ∀ ε > 0, ∃ δ > 0,
     ∀{a b:α}, edist a b < δ → edist (f a) (f b) < ε :=
 uniformity_basis_edist.uniform_continuous_iff uniformity_basis_edist
 
 /-- ε-δ characterization of uniform embeddings on pseudoemetric spaces -/
-theorem uniform_embedding_iff [pseudoemetric_space β] {f : α → β} :
+theorem uniform_embedding_iff [pseudo_emetric_space β] {f : α → β} :
   uniform_embedding f ↔ function.injective f ∧ uniform_continuous f ∧
     ∀ δ > 0, ∃ ε > 0, ∀ {a b : α}, edist (f a) (f b) < ε → edist a b < δ :=
 uniform_embedding_def'.trans $ and_congr iff.rfl $ and_congr iff.rfl
@@ -277,7 +277,7 @@ uniform_embedding_def'.trans $ and_congr iff.rfl $ and_congr iff.rfl
 
 /-- If a map between pseudoemetric spaces is a uniform embedding then the edistance between `f x`
 and `f y` is controlled in terms of the distance between `x` and `y`. -/
-theorem controlled_of_uniform_embedding [pseudoemetric_space β] {f : α → β} :
+theorem controlled_of_uniform_embedding [pseudo_emetric_space β] {f : α → β} :
   uniform_embedding f →
   (∀ ε > 0, ∃ δ > 0, ∀ {a b : α}, edist a b < δ → edist (f a) (f b) < ε) ∧
   (∀ δ > 0, ∃ ε > 0, ∀ {a b : α}, edist (f a) (f b) < ε → edist a b < δ) :=
@@ -356,19 +356,19 @@ This is useful if one wants to construct an emetric space with a
 specified uniformity. See Note [forgetful inheritance] explaining why having definitionally
 the right uniformity is often important.
 -/
-def pseudoemetric_space.replace_uniformity {α} [U : uniform_space α] (m : pseudoemetric_space α)
-  (H : @uniformity _ U = @uniformity _ pseudoemetric_space.to_uniform_space) :
-  pseudoemetric_space α :=
+def pseudoemetric_space.replace_uniformity {α} [U : uniform_space α] (m : pseudo_emetric_space α)
+  (H : @uniformity _ U = @uniformity _ pseudo_emetric_space.to_uniform_space) :
+  pseudo_emetric_space α :=
 { edist               := @edist _ m.to_has_edist,
   edist_self          := edist_self,
   edist_comm          := edist_comm,
   edist_triangle      := edist_triangle,
   to_uniform_space    := U,
-  uniformity_edist    := H.trans (@pseudoemetric_space.uniformity_edist α _) }
+  uniformity_edist    := H.trans (@pseudo_emetric_space.uniformity_edist α _) }
 
 /-- The extended metric induced by an injective function taking values in a pseudoemetric space. -/
-def pseudoemetric_space.induced {α β} (f : α → β) (hf : function.injective f)
-  (m : pseudoemetric_space β) : pseudoemetric_space α :=
+def pseudo_emetric_space.induced {α β} (f : α → β) (hf : function.injective f)
+  (m : pseudo_emetric_space β) : pseudo_emetric_space α :=
 { edist               := λ x y, edist (f x) (f y),
   edist_self          := λ x, edist_self _,
   edist_comm          := λ x y, edist_comm _ _,
@@ -386,8 +386,8 @@ def pseudoemetric_space.induced {α β} (f : α → β) (hf : function.injective
   end }
 
 /-- Pseudoemetric space instance on subsets of emetric spaces -/
-instance {α : Type*} {p : α → Prop} [t : pseudoemetric_space α] : pseudoemetric_space (subtype p) :=
-t.induced coe (λ x y, subtype.ext_iff_val.2)
+instance {α : Type*} {p : α → Prop} [t : pseudo_emetric_space α] :
+  pseudo_emetric_space (subtype p) := t.induced coe (λ x y, subtype.ext_iff_val.2)
 
 /-- The extended psuedodistance on a subset of a pseudoemetric space is the restriction of
 the original pseudodistance, by definition -/
@@ -396,7 +396,7 @@ theorem subtype.edist_eq {p : α → Prop} (x y : subtype p) : edist x y = edist
 /-- The product of two pseudoemetric spaces, with the max distance, is an extended
 pseudometric spaces. We make sure that the uniform structure thus constructed is the one
 corresponding to the product of uniform spaces, to avoid diamond problems. -/
-instance prod.pseudoemetric_space_max [pseudoemetric_space β] : pseudoemetric_space (α × β) :=
+instance prod.pseudoemetric_space_max [pseudo_emetric_space β] : pseudo_emetric_space (α × β) :=
 { edist := λ x y, max (edist x.1 y.1) (edist x.2 y.2),
   edist_self := λ x, by simp,
   edist_comm := λ x y, by simp [edist_comm],
@@ -405,14 +405,14 @@ instance prod.pseudoemetric_space_max [pseudoemetric_space β] : pseudoemetric_s
     (le_trans (edist_triangle _ _ _) (add_le_add (le_max_right _ _) (le_max_right _ _))),
   uniformity_edist := begin
     refine uniformity_prod.trans _,
-    simp [pseudoemetric_space.uniformity_edist, comap_infi],
+    simp [pseudo_emetric_space.uniformity_edist, comap_infi],
     rw ← infi_inf_eq, congr, funext,
     rw ← infi_inf_eq, congr, funext,
     simp [inf_principal, ext_iff, max_lt_iff]
   end,
   to_uniform_space := prod.uniform_space }
 
-lemma prod.pesudoedist_eq [pseudoemetric_space β] (x y : α × β) :
+lemma prod.pesudoedist_eq [pseudo_emetric_space β] (x y : α × β) :
   edist x y = max (edist x.1 y.1) (edist x.2 y.2) :=
 rfl
 
@@ -425,7 +425,7 @@ a pseudoemetric space.
 This construction would also work for infinite products, but it would not give rise
 to the product topology. Hence, we only formalize it in the good situation of finitely many
 spaces. -/
-instance pseudoemetric_space_pi [∀b, pseudoemetric_space (π b)] : pseudoemetric_space (Πb, π b) :=
+instance pseudoemetric_space_pi [∀b, pseudo_emetric_space (π b)] : pseudo_emetric_space (Πb, π b) :=
 { edist := λ f g, finset.sup univ (λb, edist (f b) (g b)),
   edist_self := assume f, bot_unique $ finset.sup_le $ by simp,
   edist_comm := assume f g, by unfold edist; congr; funext a; exact edist_comm _ _,
@@ -437,7 +437,7 @@ instance pseudoemetric_space_pi [∀b, pseudoemetric_space (π b)] : pseudoemetr
     end,
   to_uniform_space := Pi.uniform_space _,
   uniformity_edist := begin
-    simp only [Pi.uniformity, pseudoemetric_space.uniformity_edist, comap_infi, gt_iff_lt,
+    simp only [Pi.uniformity, pseudo_emetric_space.uniformity_edist, comap_infi, gt_iff_lt,
       preimage_set_of_eq, comap_principal],
     rw infi_comm, congr, funext ε,
     rw infi_comm, congr, funext εpos,
@@ -445,7 +445,7 @@ instance pseudoemetric_space_pi [∀b, pseudoemetric_space (π b)] : pseudoemetr
     simp [set.ext_iff, εpos]
   end }
 
-lemma pseudoedist_pi_def [Π b, pseudoemetric_space (π b)] (f g : Π b, π b) :
+lemma pseudoedist_pi_def [Π b, pseudo_emetric_space (π b)] (f g : Π b, π b) :
   edist f g = finset.sup univ (λb, edist (f b) (g b)) := rfl
 
 @[simp] lemma pseudoedist_pi_const [nonempty β] (a b : α) :
@@ -549,11 +549,11 @@ is_open_compl_iff.1 $ is_open_iff.2 $ λ y hy, ⟨⊤, ennreal.coe_lt_top, subse
 theorem ball_mem_nhds (x : α) {ε : ℝ≥0∞} (ε0 : 0 < ε) : ball x ε ∈ 𝓝 x :=
 mem_nhds_sets is_open_ball (mem_ball_self ε0)
 
-theorem ball_prod_same [pseudoemetric_space β] (x : α) (y : β) (r : ℝ≥0∞) :
+theorem ball_prod_same [pseudo_emetric_space β] (x : α) (y : β) (r : ℝ≥0∞) :
   (ball x r).prod (ball y r) = ball (x, y) r :=
 ext $ λ z, max_lt_iff.symm
 
-theorem closed_ball_prod_same [pseudoemetric_space β] (x : α) (y : β) (r : ℝ≥0∞) :
+theorem closed_ball_prod_same [pseudo_emetric_space β] (x : α) (y : β) (r : ℝ≥0∞) :
   (closed_ball x r).prod (closed_ball y r) = closed_ball (x, y) r :=
 ext $ λ z, max_le_iff.symm
 
@@ -737,7 +737,7 @@ end compact
 section first_countable
 
 @[priority 100] -- see Note [lower instance priority]
-instance (α : Type u) [pseudoemetric_space α] :
+instance (α : Type u) [pseudo_emetric_space α] :
   topological_space.first_countable_topology α :=
 uniform_space.first_countable_topology uniformity_has_countable_basis
 
@@ -750,7 +750,7 @@ open topological_space
 the balls centered at points in a dense subset, and with rational radii. We do not register
 this as an instance, as there is already an instance going in the other direction
 from second countable spaces to separable spaces, and we want to avoid loops. -/
-lemma second_countable_of_separable (α : Type u) [pseudoemetric_space α] [separable_space α] :
+lemma second_countable_of_separable (α : Type u) [pseudo_emetric_space α] [separable_space α] :
   second_countable_topology α :=
 uniform_space.second_countable_of_separable uniformity_has_countable_basis
 
@@ -841,14 +841,14 @@ end diam
 
 end emetric --namespace
 
-class emetric_space (α : Type u) extends pseudoemetric_space α : Type u :=
+class emetric_space (α : Type u) extends pseudo_emetric_space α : Type u :=
 (eq_of_edist_eq_zero : ∀ {x y : α}, edist x y = 0 → x = y)
 
 variables {γ : Type w} [emetric_space γ]
 
 @[priority 100] -- see Note [lower instance priority]
 instance emetric_space.to_uniform_space' : uniform_space γ :=
-pseudoemetric_space.to_uniform_space
+pseudo_emetric_space.to_uniform_space
 
 export emetric_space (eq_of_edist_eq_zero)
 
@@ -904,7 +904,7 @@ specified uniformity. See Note [forgetful inheritance] explaining why having def
 the right uniformity is often important.
 -/
 def emetric_space.replace_uniformity {γ} [U : uniform_space γ] (m : emetric_space γ)
-  (H : @uniformity _ U = @uniformity _ pseudoemetric_space.to_uniform_space) :
+  (H : @uniformity _ U = @uniformity _ pseudo_emetric_space.to_uniform_space) :
   emetric_space γ :=
 { edist               := @edist _ m.to_has_edist,
   edist_self          := edist_self,
@@ -912,7 +912,7 @@ def emetric_space.replace_uniformity {γ} [U : uniform_space γ] (m : emetric_sp
   edist_comm          := edist_comm,
   edist_triangle      := edist_triangle,
   to_uniform_space    := U,
-  uniformity_edist    := H.trans (@pseudoemetric_space.uniformity_edist γ _) }
+  uniformity_edist    := H.trans (@pseudo_emetric_space.uniformity_edist γ _) }
 
   /-- The extended metric induced by an injective function taking values in a emetric space. -/
 def emetric_space.induced {γ β} (f : γ → β) (hf : function.injective f)
@@ -956,7 +956,7 @@ instance prod.emetric_space_max [emetric_space β] : emetric_space (γ × β) :=
     (le_trans (edist_triangle _ _ _) (add_le_add (le_max_right _ _) (le_max_right _ _))),
   uniformity_edist := begin
     refine uniformity_prod.trans _,
-    simp [pseudoemetric_space.uniformity_edist, comap_infi],
+    simp [pseudo_emetric_space.uniformity_edist, comap_infi],
     rw ← infi_inf_eq, congr, funext,
     rw ← infi_inf_eq, congr, funext,
     simp [inf_principal, ext_iff, max_lt_iff]
@@ -970,7 +970,7 @@ rfl
 /-- Reformulation of the uniform structure in terms of the extended distance -/
 theorem uniformity_edist :
   𝓤 γ = ⨅ ε>0, 𝓟 {p:γ×γ | edist p.1 p.2 < ε} :=
-pseudoemetric_space.uniformity_edist
+pseudo_emetric_space.uniformity_edist
 
 section pi
 open finset

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -31,7 +31,7 @@ noncomputable theory
 open_locale uniformity topological_space big_operators filter nnreal ennreal
 
 universes u v w
-variables {α : Type u} {β : Type v} {γ : Type w}
+variables {α : Type u} {β : Type v}
 
 /-- Characterizing uniformities associated to a (generalized) distance function `D`
 in terms of the elements of the uniformity. -/
@@ -87,9 +87,8 @@ on a product.
 
 Continuity of `edist` is proved in `topology.instances.ennreal`
 -/
-class emetric_space (α : Type u) extends has_edist α : Type u :=
+class pseudoemetric_space (α : Type u) extends has_edist α : Type u :=
 (edist_self : ∀ x : α, edist x x = 0)
-(eq_of_edist_eq_zero : ∀ {x y : α}, edist x y = 0 → x = y)
 (edist_comm : ∀ x y : α, edist x y = edist y x)
 (edist_triangle : ∀ x y z : α, edist x z ≤ edist x y + edist y z)
 (to_uniform_space : uniform_space α :=
@@ -98,28 +97,18 @@ class emetric_space (α : Type u) extends has_edist α : Type u :=
 
 /- emetric spaces are less common than metric spaces. Therefore, we work in a dedicated
 namespace, while notions associated to metric spaces are mostly in the root namespace. -/
-variables [emetric_space α]
+variables [pseudoemetric_space α]
 
 @[priority 100] -- see Note [lower instance priority]
-instance emetric_space.to_uniform_space' : uniform_space α :=
-emetric_space.to_uniform_space
+instance pseudoemetric_space.to_uniform_space' : uniform_space α :=
+pseudoemetric_space.to_uniform_space
 
-export emetric_space (edist_self eq_of_edist_eq_zero edist_comm edist_triangle)
+export pseudoemetric_space (edist_self edist_comm edist_triangle)
 
 attribute [simp] edist_self
 
-/-- Characterize the equality of points by the vanishing of their extended distance -/
-@[simp] theorem edist_eq_zero {x y : α} : edist x y = 0 ↔ x = y :=
-iff.intro eq_of_edist_eq_zero (assume : x = y, this ▸ edist_self _)
-
-@[simp] theorem zero_eq_edist {x y : α} : 0 = edist x y ↔ x = y :=
-iff.intro (assume h, eq_of_edist_eq_zero (h.symm))
-          (assume : x = y, this ▸ (edist_self _).symm)
-
-theorem edist_le_zero {x y : α} : (edist x y ≤ 0) ↔ x = y :=
-nonpos_iff_eq_zero.trans edist_eq_zero
-
-@[simp] theorem edist_pos {x y : α} : 0 < edist x y ↔ x ≠ y := by simp [← not_le]
+@[simp] theorem edist_eq_zero_of_self {x y : α} : x = y → edist x y = 0 :=
+assume : x = y, this ▸ edist_self _
 
 /-- Triangle inequality for the extended distance -/
 theorem edist_triangle_left (x y z : α) : edist x y ≤ edist z x + edist z y :=
@@ -170,18 +159,14 @@ lemma edist_le_range_sum_of_edist_le {f : ℕ → α} (n : ℕ)
   edist (f 0) (f n) ≤ ∑ i in finset.range n, d i :=
 finset.Ico.zero_bot n ▸ edist_le_Ico_sum_of_edist_le (zero_le n) (λ _ _, hd)
 
-/-- Two points coincide if their distance is `< ε` for all positive ε -/
-theorem eq_of_forall_edist_le {x y : α} (h : ∀ε > 0, edist x y ≤ ε) : x = y :=
-eq_of_edist_eq_zero (eq_of_le_of_forall_le_of_dense bot_le h)
-
 /-- Reformulation of the uniform structure in terms of the extended distance -/
-theorem uniformity_edist :
+theorem uniformity_pseudoedist :
   𝓤 α = ⨅ ε>0, 𝓟 {p:α×α | edist p.1 p.2 < ε} :=
-emetric_space.uniformity_edist
+pseudoemetric_space.uniformity_edist
 
 theorem uniformity_basis_edist :
   (𝓤 α).has_basis (λ ε : ℝ≥0∞, 0 < ε) (λ ε, {p:α×α | edist p.1 p.2 < ε}) :=
-(@uniformity_edist α _).symm ▸ has_basis_binfi_principal
+(@uniformity_pseudoedist α _).symm ▸ has_basis_binfi_principal
   (λ r hr p hp, ⟨min r p, lt_min hr hp,
     λ x hx, lt_of_lt_of_le hx (min_le_left _ _),
     λ x hx, lt_of_lt_of_le hx (min_le_right _ _)⟩)
@@ -270,20 +255,20 @@ namespace emetric
 theorem uniformity_has_countable_basis : is_countably_generated (𝓤 α) :=
 is_countably_generated_of_seq ⟨_, uniformity_basis_edist_inv_nat.eq_infi⟩
 
-/-- ε-δ characterization of uniform continuity on a set for emetric spaces -/
-theorem uniform_continuous_on_iff [emetric_space β] {f : α → β} {s : set α} :
+/-- ε-δ characterization of uniform continuity on a set for pseudoemetric spaces -/
+theorem uniform_continuous_on_iff [pseudoemetric_space β] {f : α → β} {s : set α} :
   uniform_continuous_on f s ↔ ∀ ε > 0, ∃ δ > 0,
     ∀{a b}, a ∈ s → b ∈ s → edist a b < δ → edist (f a) (f b) < ε :=
 uniformity_basis_edist.uniform_continuous_on_iff uniformity_basis_edist
 
-/-- ε-δ characterization of uniform continuity on emetric spaces -/
-theorem uniform_continuous_iff [emetric_space β] {f : α → β} :
+/-- ε-δ characterization of uniform continuity on pseudoemetric spaces -/
+theorem uniform_continuous_iff [pseudoemetric_space β] {f : α → β} :
   uniform_continuous f ↔ ∀ ε > 0, ∃ δ > 0,
     ∀{a b:α}, edist a b < δ → edist (f a) (f b) < ε :=
 uniformity_basis_edist.uniform_continuous_iff uniformity_basis_edist
 
-/-- ε-δ characterization of uniform embeddings on emetric spaces -/
-theorem uniform_embedding_iff [emetric_space β] {f : α → β} :
+/-- ε-δ characterization of uniform embeddings on pseudoemetric spaces -/
+theorem uniform_embedding_iff [pseudoemetric_space β] {f : α → β} :
   uniform_embedding f ↔ function.injective f ∧ uniform_continuous f ∧
     ∀ δ > 0, ∃ ε > 0, ∀ {a b : α}, edist (f a) (f b) < ε → edist a b < δ :=
 uniform_embedding_def'.trans $ and_congr iff.rfl $ and_congr iff.rfl
@@ -293,29 +278,19 @@ uniform_embedding_def'.trans $ and_congr iff.rfl $ and_congr iff.rfl
  λ H s su, let ⟨δ, δ0, hδ⟩ := mem_uniformity_edist.1 su, ⟨ε, ε0, hε⟩ := H _ δ0 in
   ⟨_, edist_mem_uniformity ε0, λ a b h, hδ (hε h)⟩⟩
 
-/-- A map between emetric spaces is a uniform embedding if and only if the edistance between `f x`
-and `f y` is controlled in terms of the distance between `x` and `y` and conversely. -/
-theorem uniform_embedding_iff' [emetric_space β] {f : α → β} :
-  uniform_embedding f ↔
+/-- If a map between pseudoemetric spaces is a uniform embedding then the edistance between `f x`
+and `f y` is controlled in terms of the distance between `x` and `y`. -/
+theorem controlled_of_uniform_embedding [pseudoemetric_space β] {f : α → β} :
+  uniform_embedding f →
   (∀ ε > 0, ∃ δ > 0, ∀ {a b : α}, edist a b < δ → edist (f a) (f b) < ε) ∧
   (∀ δ > 0, ∃ ε > 0, ∀ {a b : α}, edist (f a) (f b) < ε → edist a b < δ) :=
 begin
-  split,
-  { assume h,
+  assume h,
     exact ⟨uniform_continuous_iff.1 (uniform_embedding_iff.1 h).2.1,
-          (uniform_embedding_iff.1 h).2.2⟩ },
-  { rintros ⟨h₁, h₂⟩,
-    refine uniform_embedding_iff.2 ⟨_, uniform_continuous_iff.2 h₁, h₂⟩,
-    assume x y hxy,
-    have : edist x y ≤ 0,
-    { refine le_of_forall_lt' (λδ δpos, _),
-      rcases h₂ δ δpos with ⟨ε, εpos, hε⟩,
-      have : edist (f x) (f y) < ε, by simpa [hxy],
-      exact hε this },
-    simpa using this }
+          (uniform_embedding_iff.1 h).2.2⟩,
 end
 
-/-- ε-δ characterization of Cauchy sequences on emetric spaces -/
+/-- ε-δ characterization of Cauchy sequences on pseudoemetric spaces -/
 protected lemma cauchy_iff {f : filter α} :
   cauchy f ↔ f ≠ ⊥ ∧ ∀ ε > 0, ∃ t ∈ f, ∀ x y ∈ t, edist x y < ε :=
 by rw ← ne_bot_iff; exact uniformity_basis_edist.cauchy_iff
@@ -333,7 +308,7 @@ uniform_space.complete_of_convergent_controlled_sequences
   uniformity_has_countable_basis
   (λ n, {p:α×α | edist p.1 p.2 < B n}) (λ n, edist_mem_uniformity $ hB n) H
 
-/-- A sequentially complete emetric space is complete. -/
+/-- A sequentially complete pseudoemetric space is complete. -/
 theorem complete_of_cauchy_seq_tendsto :
   (∀ u : ℕ → α, cauchy_seq u → ∃a, tendsto u at_top (𝓝 a)) → complete_space α :=
 uniform_space.complete_of_cauchy_seq_tendsto uniformity_has_countable_basis
@@ -378,35 +353,27 @@ end emetric
 
 open emetric
 
-/-- An emetric space is separated -/
-@[priority 100] -- see Note [lower instance priority]
-instance to_separated : separated_space α :=
-separated_def.2 $ λ x y h, eq_of_forall_edist_le $
-λ ε ε0, le_of_lt (h _ (edist_mem_uniformity ε0))
-
-/-- Auxiliary function to replace the uniformity on an emetric space with
+/-- Auxiliary function to replace the uniformity on a pseudoemetric space with
 a uniformity which is equal to the original one, but maybe not defeq.
 This is useful if one wants to construct an emetric space with a
 specified uniformity. See Note [forgetful inheritance] explaining why having definitionally
 the right uniformity is often important.
 -/
-def emetric_space.replace_uniformity {α} [U : uniform_space α] (m : emetric_space α)
-  (H : @uniformity _ U = @uniformity _ emetric_space.to_uniform_space) :
-  emetric_space α :=
+def pseudoemetric_space.replace_uniformity {α} [U : uniform_space α] (m : pseudoemetric_space α)
+  (H : @uniformity _ U = @uniformity _ pseudoemetric_space.to_uniform_space) :
+  pseudoemetric_space α :=
 { edist               := @edist _ m.to_has_edist,
   edist_self          := edist_self,
-  eq_of_edist_eq_zero := @eq_of_edist_eq_zero _ _,
   edist_comm          := edist_comm,
   edist_triangle      := edist_triangle,
   to_uniform_space    := U,
-  uniformity_edist    := H.trans (@emetric_space.uniformity_edist α _) }
+  uniformity_edist    := H.trans (@pseudoemetric_space.uniformity_edist α _) }
 
-/-- The extended metric induced by an injective function taking values in an emetric space. -/
-def emetric_space.induced {α β} (f : α → β) (hf : function.injective f)
-  (m : emetric_space β) : emetric_space α :=
+/-- The extended metric induced by an injective function taking values in a pseudoemetric space. -/
+def pseudoemetric_space.induced {α β} (f : α → β) (hf : function.injective f)
+  (m : pseudoemetric_space β) : pseudoemetric_space α :=
 { edist               := λ x y, edist (f x) (f y),
   edist_self          := λ x, edist_self _,
-  eq_of_edist_eq_zero := λ x y h, hf (edist_eq_zero.1 h),
   edist_comm          := λ x y, edist_comm _ _,
   edist_triangle      := λ x y z, edist_triangle _ _ _,
   to_uniform_space    := uniform_space.comap f m.to_uniform_space,
@@ -421,40 +388,34 @@ def emetric_space.induced {α β} (f : α → β) (hf : function.injective f)
       exact ⟨_, edist_mem_uniformity ε0, λ ⟨a, b⟩, hε⟩ }
   end }
 
-/-- Emetric space instance on subsets of emetric spaces -/
-instance {α : Type*} {p : α → Prop} [t : emetric_space α] : emetric_space (subtype p) :=
+/-- Pseudoemetric space instance on subsets of emetric spaces -/
+instance {α : Type*} {p : α → Prop} [t : pseudoemetric_space α] : pseudoemetric_space (subtype p) :=
 t.induced coe (λ x y, subtype.ext_iff_val.2)
 
-/-- The extended distance on a subset of an emetric space is the restriction of
-the original distance, by definition -/
+/-- The extended psuedodistance on a subset of a pseudoemetric space is the restriction of
+the original pseudodistance, by definition -/
 theorem subtype.edist_eq {p : α → Prop} (x y : subtype p) : edist x y = edist (x : α) y := rfl
 
-/-- The product of two emetric spaces, with the max distance, is an extended
-metric spaces. We make sure that the uniform structure thus constructed is the one
+/-- The product of two pseudoemetric spaces, with the max distance, is an extended
+pseudometric spaces. We make sure that the uniform structure thus constructed is the one
 corresponding to the product of uniform spaces, to avoid diamond problems. -/
-instance prod.emetric_space_max [emetric_space β] : emetric_space (α × β) :=
+instance prod.pseudoemetric_space_max [pseudoemetric_space β] : pseudoemetric_space (α × β) :=
 { edist := λ x y, max (edist x.1 y.1) (edist x.2 y.2),
   edist_self := λ x, by simp,
-  eq_of_edist_eq_zero := λ x y h, begin
-    cases max_le_iff.1 (le_of_eq h) with h₁ h₂,
-    have A : x.fst = y.fst := edist_le_zero.1 h₁,
-    have B : x.snd = y.snd := edist_le_zero.1 h₂,
-    exact prod.ext_iff.2 ⟨A, B⟩
-  end,
   edist_comm := λ x y, by simp [edist_comm],
   edist_triangle := λ x y z, max_le
     (le_trans (edist_triangle _ _ _) (add_le_add (le_max_left _ _) (le_max_left _ _)))
     (le_trans (edist_triangle _ _ _) (add_le_add (le_max_right _ _) (le_max_right _ _))),
   uniformity_edist := begin
     refine uniformity_prod.trans _,
-    simp [emetric_space.uniformity_edist, comap_infi],
+    simp [pseudoemetric_space.uniformity_edist, comap_infi],
     rw ← infi_inf_eq, congr, funext,
     rw ← infi_inf_eq, congr, funext,
     simp [inf_principal, ext_iff, max_lt_iff]
   end,
   to_uniform_space := prod.uniform_space }
 
-lemma prod.edist_eq [emetric_space β] (x y : α × β) :
+lemma prod.pesudoedist_eq [pseudoemetric_space β] (x y : α × β) :
   edist x y = max (edist x.1 y.1) (edist x.2 y.2) :=
 rfl
 
@@ -462,12 +423,12 @@ section pi
 open finset
 variables {π : β → Type*} [fintype β]
 
-/-- The product of a finite number of emetric spaces, with the max distance, is still
-an emetric space.
+/-- The product of a finite number of pseudoemetric spaces, with the max distance, is still
+a pseudoemetric space.
 This construction would also work for infinite products, but it would not give rise
 to the product topology. Hence, we only formalize it in the good situation of finitely many
 spaces. -/
-instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π b) :=
+instance pseudoemetric_space_pi [∀b, pseudoemetric_space (π b)] : pseudoemetric_space (Πb, π b) :=
 { edist := λ f g, finset.sup univ (λb, edist (f b) (g b)),
   edist_self := assume f, bot_unique $ finset.sup_le $ by simp,
   edist_comm := assume f g, by unfold edist; congr; funext a; exact edist_comm _ _,
@@ -477,15 +438,9 @@ instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π 
       assume b hb,
       exact le_trans (edist_triangle _ (g b) _) (add_le_add (le_sup hb) (le_sup hb))
     end,
-  eq_of_edist_eq_zero := assume f g eq0,
-    begin
-      have eq1 : sup univ (λ (b : β), edist (f b) (g b)) ≤ 0 := le_of_eq eq0,
-      simp only [finset.sup_le_iff] at eq1,
-      exact (funext $ assume b, edist_le_zero.1 $ eq1 b $ mem_univ b),
-    end,
   to_uniform_space := Pi.uniform_space _,
   uniformity_edist := begin
-    simp only [Pi.uniformity, emetric_space.uniformity_edist, comap_infi, gt_iff_lt,
+    simp only [Pi.uniformity, pseudoemetric_space.uniformity_edist, comap_infi, gt_iff_lt,
       preimage_set_of_eq, comap_principal],
     rw infi_comm, congr, funext ε,
     rw infi_comm, congr, funext εpos,
@@ -493,10 +448,10 @@ instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π 
     simp [set.ext_iff, εpos]
   end }
 
-lemma edist_pi_def [Π b, emetric_space (π b)] (f g : Π b, π b) :
+lemma pseudoedist_pi_def [Π b, pseudoemetric_space (π b)] (f g : Π b, π b) :
   edist f g = finset.sup univ (λb, edist (f b) (g b)) := rfl
 
-@[simp] lemma edist_pi_const [nonempty β] (a b : α) : edist (λ x : β, a) (λ _, b) = edist a b :=
+@[simp] lemma pseudoedist_pi_const [nonempty β] (a b : α) : edist (λ x : β, a) (λ _, b) = edist a b :=
 finset.sup_const univ_nonempty (edist a b)
 
 end pi
@@ -597,15 +552,15 @@ is_open_compl_iff.1 $ is_open_iff.2 $ λ y hy, ⟨⊤, ennreal.coe_lt_top, subse
 theorem ball_mem_nhds (x : α) {ε : ℝ≥0∞} (ε0 : 0 < ε) : ball x ε ∈ 𝓝 x :=
 mem_nhds_sets is_open_ball (mem_ball_self ε0)
 
-theorem ball_prod_same [emetric_space β] (x : α) (y : β) (r : ℝ≥0∞) :
+theorem ball_prod_same [pseudoemetric_space β] (x : α) (y : β) (r : ℝ≥0∞) :
   (ball x r).prod (ball y r) = ball (x, y) r :=
 ext $ λ z, max_lt_iff.symm
 
-theorem closed_ball_prod_same [emetric_space β] (x : α) (y : β) (r : ℝ≥0∞) :
+theorem closed_ball_prod_same [pseudoemetric_space β] (x : α) (y : β) (r : ℝ≥0∞) :
   (closed_ball x r).prod (closed_ball y r) = closed_ball (x, y) r :=
 ext $ λ z, max_le_iff.symm
 
-/-- ε-characterization of the closure in emetric spaces -/
+/-- ε-characterization of the closure in pseudoemetric spaces -/
 theorem mem_closure_iff :
   x ∈ closure s ↔ ∀ε>0, ∃y ∈ s, edist x y < ε :=
 (mem_closure_iff_nhds_basis nhds_basis_eball).trans $
@@ -780,52 +735,12 @@ begin
     exact not_lt.1 (λ hlt, Hgt I.1 hlt I.2 hI.some_spec) }
 end
 
-@[priority 100] -- see Note [lower instance priority]
-instance normal_of_emetric : normal_space α := normal_of_paracompact_t2
-
-/-- A compact set in an emetric space is separable, i.e., it is the closure of a countable set -/
-lemma countable_closure_of_compact {α : Type u} [emetric_space α] {s : set α} (hs : is_compact s) :
-  ∃ t ⊆ s, (countable t ∧ s = closure t) :=
-begin
-  have A : ∀ (e:ℝ≥0∞), e > 0 → ∃ t ⊆ s, (finite t ∧ s ⊆ (⋃x∈t, ball x e)) :=
-    totally_bounded_iff'.1 (compact_iff_totally_bounded_complete.1 hs).1,
---    assume e, finite_cover_balls_of_compact hs,
-  have B : ∀ (e:ℝ≥0∞), ∃ t ⊆ s, finite t ∧ (e > 0 → s ⊆ (⋃x∈t, ball x e)),
-  { intro e,
-    cases le_or_gt e 0 with h,
-    { exact ⟨∅, by finish⟩ },
-    { rcases A e h with ⟨s, ⟨finite_s, closure_s⟩⟩, existsi s, finish }},
-  /-The desired countable set is obtained by taking for each `n` the centers of a finite cover
-  by balls of radius `1/n`, and then the union over `n`. -/
-  choose T T_in_s finite_T using B,
-  let t := ⋃n:ℕ, T n⁻¹,
-  have T₁ : t ⊆ s := begin apply Union_subset, assume n, apply T_in_s end,
-  have T₂ : countable t := by finish [countable_Union, finite.countable],
-  have T₃ : s ⊆ closure t,
-  { intros x x_in_s,
-    apply mem_closure_iff.2,
-    intros ε εpos,
-    rcases ennreal.exists_inv_nat_lt (bot_lt_iff_ne_bot.1 εpos) with ⟨n, hn⟩,
-    have inv_n_pos : (0 : ℝ≥0∞) < (n : ℕ)⁻¹ := by simp [ennreal.bot_lt_iff_ne_bot],
-    have C : x ∈ (⋃y∈ T (n : ℕ)⁻¹, ball y (n : ℕ)⁻¹) :=
-      mem_of_mem_of_subset x_in_s ((finite_T (n : ℕ)⁻¹).2 inv_n_pos),
-    rcases mem_Union.1 C with ⟨y, _, ⟨y_in_T, rfl⟩, Dxy⟩,
-    simp at Dxy,  -- Dxy : edist x y < 1 / ↑n
-    have : y ∈ t := mem_of_mem_of_subset y_in_T (by apply subset_Union (λ (n:ℕ), T (n : ℕ)⁻¹)),
-    have : edist x y < ε := lt_trans Dxy hn,
-    exact ⟨y, ‹y ∈ t›, ‹edist x y < ε›⟩ },
-  have T₄ : closure t ⊆ s := calc
-    closure t ⊆ closure s : closure_mono T₁
-    ... = s : hs.is_closed.closure_eq,
-  exact ⟨t, ⟨T₁, T₂, subset.antisymm T₃ T₄⟩⟩
-end
-
 end compact
 
 section first_countable
 
 @[priority 100] -- see Note [lower instance priority]
-instance (α : Type u) [emetric_space α] :
+instance (α : Type u) [pseudoemetric_space α] :
   topological_space.first_countable_topology α :=
 uniform_space.first_countable_topology uniformity_has_countable_basis
 
@@ -838,7 +753,7 @@ open topological_space
 the balls centered at points in a dense subset, and with rational radii. We do not register
 this as an instance, as there is already an instance going in the other direction
 from second countable spaces to separable spaces, and we want to avoid loops. -/
-lemma second_countable_of_separable (α : Type u) [emetric_space α] [separable_space α] :
+lemma second_countable_of_separable (α : Type u) [pseudoemetric_space α] [separable_space α] :
   second_countable_topology α :=
 uniform_space.second_countable_of_separable uniformity_has_countable_basis
 
@@ -875,17 +790,6 @@ diam_subsingleton subsingleton_empty
 /-- The diameter of a singleton vanishes -/
 @[simp] lemma diam_singleton : diam ({x} : set α) = 0 :=
 diam_subsingleton subsingleton_singleton
-
-lemma diam_eq_zero_iff : diam s = 0 ↔ s.subsingleton :=
-⟨λ h x hx y hy, edist_le_zero.1 $ h ▸ edist_le_diam_of_mem hx hy, diam_subsingleton⟩
-
-lemma diam_pos_iff : 0 < diam s ↔ ∃ (x ∈ s) (y ∈ s), x ≠ y :=
-begin
-  have := not_congr (@diam_eq_zero_iff _ _ s),
-  dunfold set.subsingleton at this,
-  push_neg at this,
-  simpa only [pos_iff_ne_zero, exists_prop] using this
-end
 
 lemma diam_insert : diam (insert x s) = max (⨆ y ∈ s, edist x y) (diam s) :=
 eq_of_forall_ge_iff $ λ d, by simp only [diam_le_iff_forall_edist_le, ball_insert_iff,
@@ -939,3 +843,242 @@ le_trans (diam_mono ball_subset_closed_ball) diam_closed_ball
 end diam
 
 end emetric --namespace
+
+class emetric_space (α : Type u) extends pseudoemetric_space α : Type u :=
+(eq_of_edist_eq_zero : ∀ {x y : α}, edist x y = 0 → x = y)
+
+variables {γ : Type w} [emetric_space γ]
+
+@[priority 100] -- see Note [lower instance priority]
+instance emetric_space.to_uniform_space' : uniform_space γ :=
+pseudoemetric_space.to_uniform_space
+
+export emetric_space (eq_of_edist_eq_zero)
+
+/-- Characterize the equality of points by the vanishing of their extended distance -/
+@[simp] theorem edist_eq_zero {x y : γ} : edist x y = 0 ↔ x = y :=
+iff.intro eq_of_edist_eq_zero (assume : x = y, this ▸ edist_self _)
+
+@[simp] theorem zero_eq_edist {x y : γ} : 0 = edist x y ↔ x = y :=
+iff.intro (assume h, eq_of_edist_eq_zero (h.symm))
+          (assume : x = y, this ▸ (edist_self _).symm)
+
+theorem edist_le_zero {x y : γ} : (edist x y ≤ 0) ↔ x = y :=
+nonpos_iff_eq_zero.trans edist_eq_zero
+
+@[simp] theorem edist_pos {x y : γ} : 0 < edist x y ↔ x ≠ y := by simp [← not_le]
+
+/-- Two points coincide if their distance is `< ε` for all positive ε -/
+theorem eq_of_forall_edist_le {x y : γ} (h : ∀ε > 0, edist x y ≤ ε) : x = y :=
+eq_of_edist_eq_zero (eq_of_le_of_forall_le_of_dense bot_le h)
+
+/-- A map between emetric spaces is a uniform embedding if and only if the edistance between `f x`
+and `f y` is controlled in terms of the distance between `x` and `y` and conversely. -/
+theorem uniform_embedding_iff' [emetric_space β] {f : γ → β} :
+  uniform_embedding f ↔
+  (∀ ε > 0, ∃ δ > 0, ∀ {a b : γ}, edist a b < δ → edist (f a) (f b) < ε) ∧
+  (∀ δ > 0, ∃ ε > 0, ∀ {a b : γ}, edist (f a) (f b) < ε → edist a b < δ) :=
+begin
+  split,
+  { assume h,
+    exact ⟨emetric.uniform_continuous_iff.1 (uniform_embedding_iff.1 h).2.1,
+          (uniform_embedding_iff.1 h).2.2⟩ },
+  { rintros ⟨h₁, h₂⟩,
+    refine uniform_embedding_iff.2 ⟨_, emetric.uniform_continuous_iff.2 h₁, h₂⟩,
+    assume x y hxy,
+    have : edist x y ≤ 0,
+    { refine le_of_forall_lt' (λδ δpos, _),
+      rcases h₂ δ δpos with ⟨ε, εpos, hε⟩,
+      have : edist (f x) (f y) < ε, by simpa [hxy],
+      exact hε this },
+    simpa using this }
+end
+
+/-- An emetric space is separated -/
+@[priority 100] -- see Note [lower instance priority]
+instance to_separated : separated_space γ :=
+separated_def.2 $ λ x y h, eq_of_forall_edist_le $
+λ ε ε0, le_of_lt (h _ (edist_mem_uniformity ε0))
+
+/-- Auxiliary function to replace the uniformity on an emetric space with
+a uniformity which is equal to the original one, but maybe not defeq.
+This is useful if one wants to construct an emetric space with a
+specified uniformity. See Note [forgetful inheritance] explaining why having definitionally
+the right uniformity is often important.
+-/
+def emetric_space.replace_uniformity {γ} [U : uniform_space γ] (m : emetric_space γ)
+  (H : @uniformity _ U = @uniformity _ pseudoemetric_space.to_uniform_space) :
+  emetric_space γ :=
+{ edist               := @edist _ m.to_has_edist,
+  edist_self          := edist_self,
+  eq_of_edist_eq_zero := @eq_of_edist_eq_zero _ _,
+  edist_comm          := edist_comm,
+  edist_triangle      := edist_triangle,
+  to_uniform_space    := U,
+  uniformity_edist    := H.trans (@pseudoemetric_space.uniformity_edist γ _) }
+
+  /-- The extended metric induced by an injective function taking values in a emetric space. -/
+def emetric_space.induced {γ β} (f : γ → β) (hf : function.injective f)
+  (m : emetric_space β) : emetric_space γ :=
+{ edist               := λ x y, edist (f x) (f y),
+  edist_self          := λ x, edist_self _,
+  eq_of_edist_eq_zero := λ x y h, hf (edist_eq_zero.1 h),
+  edist_comm          := λ x y, edist_comm _ _,
+  edist_triangle      := λ x y z, edist_triangle _ _ _,
+  to_uniform_space    := uniform_space.comap f m.to_uniform_space,
+  uniformity_edist    := begin
+    apply @uniformity_dist_of_mem_uniformity _ _ _ _ _ (λ x y, edist (f x) (f y)),
+    refine λ s, mem_comap_sets.trans _,
+    split; intro H,
+    { rcases H with ⟨r, ru, rs⟩,
+      rcases mem_uniformity_edist.1 ru with ⟨ε, ε0, hε⟩,
+      refine ⟨ε, ε0, λ a b h, rs (hε _)⟩, exact h },
+    { rcases H with ⟨ε, ε0, hε⟩,
+      exact ⟨_, edist_mem_uniformity ε0, λ ⟨a, b⟩, hε⟩ }
+  end }
+
+/-- Emetric space instance on subsets of emetric spaces -/
+instance {α : Type*} {p : α → Prop} [t : emetric_space α] : emetric_space (subtype p) :=
+t.induced coe (λ x y, subtype.ext_iff_val.2)
+
+/-- The product of two emetric spaces, with the max distance, is an extended
+metric spaces. We make sure that the uniform structure thus constructed is the one
+corresponding to the product of uniform spaces, to avoid diamond problems. -/
+instance prod.emetric_space_max [emetric_space β] : emetric_space (γ × β) :=
+{ edist := λ x y, max (edist x.1 y.1) (edist x.2 y.2),
+  edist_self := λ x, by simp,
+  eq_of_edist_eq_zero := λ x y h, begin
+    cases max_le_iff.1 (le_of_eq h) with h₁ h₂,
+    have A : x.fst = y.fst := edist_le_zero.1 h₁,
+    have B : x.snd = y.snd := edist_le_zero.1 h₂,
+    exact prod.ext_iff.2 ⟨A, B⟩
+  end,
+  edist_comm := λ x y, by simp [edist_comm],
+  edist_triangle := λ x y z, max_le
+    (le_trans (edist_triangle _ _ _) (add_le_add (le_max_left _ _) (le_max_left _ _)))
+    (le_trans (edist_triangle _ _ _) (add_le_add (le_max_right _ _) (le_max_right _ _))),
+  uniformity_edist := begin
+    refine uniformity_prod.trans _,
+    simp [pseudoemetric_space.uniformity_edist, comap_infi],
+    rw ← infi_inf_eq, congr, funext,
+    rw ← infi_inf_eq, congr, funext,
+    simp [inf_principal, ext_iff, max_lt_iff]
+  end,
+  to_uniform_space := prod.uniform_space }
+
+  lemma prod.edist_eq [emetric_space β] (x y : α × β) :
+  edist x y = max (edist x.1 y.1) (edist x.2 y.2) :=
+rfl
+
+/-- Reformulation of the uniform structure in terms of the extended distance -/
+theorem uniformity_edist :
+  𝓤 γ = ⨅ ε>0, 𝓟 {p:γ×γ | edist p.1 p.2 < ε} :=
+pseudoemetric_space.uniformity_edist
+
+section pi
+open finset
+variables {π : β → Type*} [fintype β]
+
+/-- The product of a finite number of emetric spaces, with the max distance, is still
+an emetric space.
+This construction would also work for infinite products, but it would not give rise
+to the product topology. Hence, we only formalize it in the good situation of finitely many
+spaces. -/
+instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π b) :=
+{ edist := λ f g, finset.sup univ (λb, edist (f b) (g b)),
+  edist_self := assume f, bot_unique $ finset.sup_le $ by simp,
+  edist_comm := assume f g, by unfold edist; congr; funext a; exact edist_comm _ _,
+  edist_triangle := assume f g h,
+    begin
+      simp only [finset.sup_le_iff],
+      assume b hb,
+      exact le_trans (edist_triangle _ (g b) _) (add_le_add (le_sup hb) (le_sup hb))
+    end,
+  eq_of_edist_eq_zero := assume f g eq0,
+    begin
+      have eq1 : sup univ (λ (b : β), edist (f b) (g b)) ≤ 0 := le_of_eq eq0,
+      simp only [finset.sup_le_iff] at eq1,
+      exact (funext $ assume b, edist_le_zero.1 $ eq1 b $ mem_univ b),
+    end,
+  to_uniform_space := Pi.uniform_space _,
+  uniformity_edist := begin
+    simp only [Pi.uniformity, uniformity_edist, comap_infi, gt_iff_lt,
+      preimage_set_of_eq, comap_principal],
+    rw  infi_comm, congr, funext ε,
+    rw infi_comm, congr, funext εpos,
+    change 0 < ε at εpos,
+    simp [set.ext_iff, εpos]
+  end }
+
+lemma edist_pi_def [Π b, emetric_space (π b)] (f g : Π b, π b) :
+  edist f g = finset.sup univ (λb, edist (f b) (g b)) := rfl
+
+@[simp] lemma edist_pi_const [nonempty β] (a b : α) : edist (λ x : β, a) (λ _, b) = edist a b :=
+finset.sup_const univ_nonempty (edist a b)
+
+end pi
+
+namespace emetric
+
+section compact
+
+@[priority 100] -- see Note [lower instance priority]
+instance normal_of_emetric : normal_space γ := normal_of_paracompact_t2
+
+/-- A compact set in an emetric space is separable, i.e., it is the closure of a countable set -/
+lemma countable_closure_of_compact {α : Type u} [emetric_space α] {s : set α}
+  (hs : is_compact s) : ∃ t ⊆ s, (countable t ∧ s = closure t) :=
+begin
+  have A : ∀ (e:ℝ≥0∞), e > 0 → ∃ t ⊆ s, (finite t ∧ s ⊆ (⋃x∈t, ball x e)) :=
+    totally_bounded_iff'.1 (compact_iff_totally_bounded_complete.1 hs).1,
+--    assume e, finite_cover_balls_of_compact hs,
+  have B : ∀ (e:ℝ≥0∞), ∃ t ⊆ s, finite t ∧ (e > 0 → s ⊆ (⋃x∈t, ball x e)),
+  { intro e,
+    cases le_or_gt e 0 with h,
+    { exact ⟨∅, by finish⟩ },
+    { rcases A e h with ⟨s, ⟨finite_s, closure_s⟩⟩, existsi s, finish }},
+  /-The desired countable set is obtained by taking for each `n` the centers of a finite cover
+  by balls of radius `1/n`, and then the union over `n`. -/
+  choose T T_in_s finite_T using B,
+  let t := ⋃n:ℕ, T n⁻¹,
+  have T₁ : t ⊆ s := begin apply Union_subset, assume n, apply T_in_s end,
+  have T₂ : countable t := by finish [countable_Union, finite.countable],
+  have T₃ : s ⊆ closure t,
+  { intros x x_in_s,
+    apply emetric.mem_closure_iff.2,
+    intros ε εpos,
+    rcases ennreal.exists_inv_nat_lt (bot_lt_iff_ne_bot.1 εpos) with ⟨n, hn⟩,
+    have inv_n_pos : (0 : ℝ≥0∞) < (n : ℕ)⁻¹ := by simp [ennreal.bot_lt_iff_ne_bot],
+    have C : x ∈ (⋃y∈ T (n : ℕ)⁻¹, ball y (n : ℕ)⁻¹) :=
+      mem_of_mem_of_subset x_in_s ((finite_T (n : ℕ)⁻¹).2 inv_n_pos),
+    rcases mem_Union.1 C with ⟨y, _, ⟨y_in_T, rfl⟩, Dxy⟩,
+    simp at Dxy,  -- Dxy : edist x y < 1 / ↑n
+    have : y ∈ t := mem_of_mem_of_subset y_in_T (by apply subset_Union (λ (n:ℕ), T (n : ℕ)⁻¹)),
+    have : edist x y < ε := lt_trans Dxy hn,
+    exact ⟨y, ‹y ∈ t›, ‹edist x y < ε›⟩ },
+  have T₄ : closure t ⊆ s := calc
+    closure t ⊆ closure s : closure_mono T₁
+    ... = s : hs.is_closed.closure_eq,
+  exact ⟨t, ⟨T₁, T₂, subset.antisymm T₃ T₄⟩⟩
+end
+
+end compact
+
+section diam
+
+variables {s : set γ}
+
+lemma diam_eq_zero_iff : diam s = 0 ↔ s.subsingleton :=
+⟨λ h x hx y hy, edist_le_zero.1 $ h ▸ edist_le_diam_of_mem hx hy, diam_subsingleton⟩
+
+lemma diam_pos_iff : 0 < diam s ↔ ∃ (x ∈ s) (y ∈ s), x ≠ y :=
+begin
+  have := not_congr (@diam_eq_zero_iff _ _ s),
+  dunfold set.subsingleton at this,
+  push_neg at this,
+  simpa only [pos_iff_ne_zero, exists_prop] using this
+end
+
+end diam
+
+end emetric

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -107,9 +107,6 @@ export pseudoemetric_space (edist_self edist_comm edist_triangle)
 
 attribute [simp] edist_self
 
-@[simp] theorem edist_eq_zero_of_self {x y : α} : x = y → edist x y = 0 :=
-assume : x = y, this ▸ edist_self _
-
 /-- Triangle inequality for the extended distance -/
 theorem edist_triangle_left (x y z : α) : edist x y ≤ edist z x + edist z y :=
 by rw edist_comm z; apply edist_triangle

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -969,7 +969,6 @@ This construction would also work for infinite products, but it would not give r
 to the product topology. Hence, we only formalize it in the good situation of finitely many
 spaces. -/
 instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π b) :=
-instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π b) :=
 { eq_of_edist_eq_zero := assume f g eq0,
   begin
     have eq1 : sup univ (λ (b : β), edist (f b) (g b)) ≤ 0 := le_of_eq eq0,

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -385,7 +385,7 @@ def pseudo_emetric_space.induced {α β} (f : α → β) (hf : function.injectiv
       exact ⟨_, edist_mem_uniformity ε0, λ ⟨a, b⟩, hε⟩ }
   end }
 
-/-- Pseudoemetric space instance on subsets of emetric spaces -/
+/-- Pseudoemetric space instance on subsets of pseudoemetric spaces -/
 instance {α : Type*} {p : α → Prop} [t : pseudo_emetric_space α] :
   pseudo_emetric_space (subtype p) := t.induced coe (λ x y, subtype.ext_iff_val.2)
 

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -982,30 +982,14 @@ This construction would also work for infinite products, but it would not give r
 to the product topology. Hence, we only formalize it in the good situation of finitely many
 spaces. -/
 instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π b) :=
-{ edist := λ f g, finset.sup univ (λb, edist (f b) (g b)),
-  edist_self := assume f, bot_unique $ finset.sup_le $ by simp,
-  edist_comm := assume f g, by unfold edist; congr; funext a; exact edist_comm _ _,
-  edist_triangle := assume f g h,
-    begin
-      simp only [finset.sup_le_iff],
-      assume b hb,
-      exact le_trans (edist_triangle _ (g b) _) (add_le_add (le_sup hb) (le_sup hb))
-    end,
-  eq_of_edist_eq_zero := assume f g eq0,
-    begin
-      have eq1 : sup univ (λ (b : β), edist (f b) (g b)) ≤ 0 := le_of_eq eq0,
-      simp only [finset.sup_le_iff] at eq1,
-      exact (funext $ assume b, edist_le_zero.1 $ eq1 b $ mem_univ b),
-    end,
-  to_uniform_space := Pi.uniform_space _,
-  uniformity_edist := begin
-    simp only [Pi.uniformity, uniformity_edist, comap_infi, gt_iff_lt,
-      preimage_set_of_eq, comap_principal],
-    rw  infi_comm, congr, funext ε,
-    rw infi_comm, congr, funext εpos,
-    change 0 < ε at εpos,
-    simp [set.ext_iff, εpos]
-  end }
+instance emetric_space_pi [∀b, emetric_space (π b)] : emetric_space (Πb, π b) :=
+{ eq_of_edist_eq_zero := assume f g eq0,
+  begin
+    have eq1 : sup univ (λ (b : β), edist (f b) (g b)) ≤ 0 := le_of_eq eq0,
+    simp only [finset.sup_le_iff] at eq1,
+    exact (funext $ assume b, edist_le_zero.1 $ eq1 b $ mem_univ b),
+  end,
+  ..pseudoemetric_space_pi }
 
 lemma edist_pi_def [Π b, emetric_space (π b)] (f g : Π b, π b) :
   edist f g = finset.sup univ (λb, edist (f b) (g b)) := rfl

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -352,7 +352,7 @@ open emetric
 
 /-- Auxiliary function to replace the uniformity on a pseudoemetric space with
 a uniformity which is equal to the original one, but maybe not defeq.
-This is useful if one wants to construct an emetric space with a
+This is useful if one wants to construct a pseudoemetric space with a
 specified uniformity. See Note [forgetful inheritance] explaining why having definitionally
 the right uniformity is often important.
 -/

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -47,6 +47,7 @@ le_antisymm
   (λ r ur, let ⟨ε, ε0, h⟩ := (H _).1 ur in
     mem_infi_sets ε $ mem_infi_sets ε0 $ mem_principal_sets.2 $ λ ⟨a, b⟩, h)
 
+/-- `has_edist α` means that `α` is equipped with an extended distance. -/
 class has_edist (α : Type*) := (edist : α → α → ℝ≥0∞)
 export has_edist (edist)
 
@@ -373,7 +374,7 @@ def pseudoemetric_space.replace_uniformity {α} [U : uniform_space α] (m : pseu
 
 /-- The extended pseudometric induced by an injective function taking values in a
 pseudoemetric space. -/
-def pseudo_emetric_space.induced {α β} (f : α → β) (hf : function.injective f)
+def pseudo_emetric_space.induced {α β} (f : α → β)
   (m : pseudo_emetric_space β) : pseudo_emetric_space α :=
 { edist               := λ x y, edist (f x) (f y),
   edist_self          := λ x, edist_self _,
@@ -393,7 +394,7 @@ def pseudo_emetric_space.induced {α β} (f : α → β) (hf : function.injectiv
 
 /-- Pseudoemetric space instance on subsets of pseudoemetric spaces -/
 instance {α : Type*} {p : α → Prop} [t : pseudo_emetric_space α] :
-  pseudo_emetric_space (subtype p) := t.induced coe (λ x y, subtype.ext_iff_val.2)
+  pseudo_emetric_space (subtype p) := t.induced coe
 
 /-- The extended psuedodistance on a subset of a pseudoemetric space is the restriction of
 the original pseudodistance, by definition -/
@@ -454,7 +455,8 @@ instance pseudoemetric_space_pi [∀b, pseudo_emetric_space (π b)] : pseudo_eme
 lemma pseudoedist_pi_def [Π b, pseudo_emetric_space (π b)] (f g : Π b, π b) :
   edist f g = finset.sup univ (λb, edist (f b) (g b)) := rfl
 
-@[simp] lemma pseudoedist_pi_const [nonempty β] (a b : α) :
+@[priority 1100]
+lemma pseudoedist_pi_const [nonempty β] (a b : α) :
   edist (λ x : β, a) (λ _, b) = edist a b := finset.sup_const univ_nonempty (edist a b)
 
 end pi

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -942,26 +942,13 @@ t.induced coe (λ x y, subtype.ext_iff_val.2)
 metric spaces. We make sure that the uniform structure thus constructed is the one
 corresponding to the product of uniform spaces, to avoid diamond problems. -/
 instance prod.emetric_space_max [emetric_space β] : emetric_space (γ × β) :=
-{ edist := λ x y, max (edist x.1 y.1) (edist x.2 y.2),
-  edist_self := λ x, by simp,
-  eq_of_edist_eq_zero := λ x y h, begin
+{ eq_of_edist_eq_zero := λ x y h, begin
     cases max_le_iff.1 (le_of_eq h) with h₁ h₂,
     have A : x.fst = y.fst := edist_le_zero.1 h₁,
     have B : x.snd = y.snd := edist_le_zero.1 h₂,
     exact prod.ext_iff.2 ⟨A, B⟩
   end,
-  edist_comm := λ x y, by simp [edist_comm],
-  edist_triangle := λ x y z, max_le
-    (le_trans (edist_triangle _ _ _) (add_le_add (le_max_left _ _) (le_max_left _ _)))
-    (le_trans (edist_triangle _ _ _) (add_le_add (le_max_right _ _) (le_max_right _ _))),
-  uniformity_edist := begin
-    refine uniformity_prod.trans _,
-    simp [pseudo_emetric_space.uniformity_edist, comap_infi],
-    rw ← infi_inf_eq, congr, funext,
-    rw ← infi_inf_eq, congr, funext,
-    simp [inf_principal, ext_iff, max_lt_iff]
-  end,
-  to_uniform_space := prod.uniform_space }
+  ..prod.pseudoemetric_space_max }
 
   lemma prod.edist_eq [emetric_space β] (x y : α × β) :
   edist x y = max (edist x.1 y.1) (edist x.2 y.2) :=

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -25,7 +25,7 @@ uniform continuity.
 The class `emetric_space` therefore extends `uniform_space` (and `topological_space`).
 
 Since a lot of elementary properties don't require `eq_of_edist_eq_zero` we start setting up the
-theory of `pseudo_emetric_space`, where we don't require `d(x,y) = 0 → x = y` and we specialize to
+theory of `pseudo_emetric_space`, where we don't require `edist x y = 0 → x = y` and we specialize to
 `emetric_space` at the end.
 -/
 

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -25,8 +25,8 @@ uniform continuity.
 The class `emetric_space` therefore extends `uniform_space` (and `topological_space`).
 
 Since a lot of elementary properties don't require `eq_of_edist_eq_zero` we start setting up the
-theory of `pseudo_emetric_space`, where we don't require `edist x y = 0 → x = y` and we specialize to
-`emetric_space` at the end.
+theory of `pseudo_emetric_space`, where we don't require `edist x y = 0 → x = y` and we specialize
+to `emetric_space` at the end.
 -/
 
 open set filter classical

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -23,6 +23,10 @@ and topological spaces. For example: open and closed sets, compactness, complete
 uniform continuity.
 
 The class `emetric_space` therefore extends `uniform_space` (and `topological_space`).
+
+Since a lot of elementary properties don't require `eq_of_edist_eq_zero` we start setting up the
+theory of `pseudo_emetric_space`, where we don't require `d(x,y) = 0 → x = y` and we specialize to
+`emetric_space` at the end.
 -/
 
 open set filter classical
@@ -75,14 +79,15 @@ uniform_space.of_core {
 -- the uniform structure is embedded in the emetric space structure
 -- to avoid instance diamond issues. See Note [forgetful inheritance].
 
-/-- Extended metric spaces, with an extended distance `edist` possibly taking the
+/-- Extended (pseudo) metric spaces, with an extended distance `edist` possibly taking the
 value ∞
 
-Each emetric space induces a canonical `uniform_space` and hence a canonical `topological_space`.
+Each pseudo_emetric space induces a canonical `uniform_space` and hence a canonical
+`topological_space`.
 This is enforced in the type class definition, by extending the `uniform_space` structure. When
-instantiating an `emetric_space` structure, the uniformity fields are not necessary, they will be
-filled in by default. There is a default value for the uniformity, that can be substituted
-in cases of interest, for instance when instantiating an `emetric_space` structure
+instantiating a `pseudo_emetric_space` structure, the uniformity fields are not necessary, they
+will be filled in by default. There is a default value for the uniformity, that can be substituted
+in cases of interest, for instance when instantiating a `pseudo_emetric_space` structure
 on a product.
 
 Continuity of `edist` is proved in `topology.instances.ennreal`
@@ -95,7 +100,7 @@ class pseudo_emetric_space (α : Type u) extends has_edist α : Type u :=
   uniform_space_of_edist edist edist_self edist_comm edist_triangle)
 (uniformity_edist : 𝓤 α = ⨅ ε>0, 𝓟 {p:α×α | edist p.1 p.2 < ε} . control_laws_tac)
 
-/- emetric spaces are less common than metric spaces. Therefore, we work in a dedicated
+/- Pseudoemetric spaces are less common than metric spaces. Therefore, we work in a dedicated
 namespace, while notions associated to metric spaces are mostly in the root namespace. -/
 variables [pseudo_emetric_space α]
 
@@ -366,7 +371,8 @@ def pseudoemetric_space.replace_uniformity {α} [U : uniform_space α] (m : pseu
   to_uniform_space    := U,
   uniformity_edist    := H.trans (@pseudo_emetric_space.uniformity_edist α _) }
 
-/-- The extended metric induced by an injective function taking values in a pseudoemetric space. -/
+/-- The extended pseudometric induced by an injective function taking values in a
+pseudoemetric space. -/
 def pseudo_emetric_space.induced {α β} (f : α → β) (hf : function.injective f)
   (m : pseudo_emetric_space β) : pseudo_emetric_space α :=
 { edist               := λ x y, edist (f x) (f y),
@@ -572,8 +578,8 @@ theorem tendsto_at_top [nonempty β] [semilattice_sup β] {u : β → α} {a : �
 (at_top_basis.tendsto_iff nhds_basis_eball).trans $
   by simp only [exists_prop, true_and, mem_Ici, mem_ball]
 
-/-- In an emetric space, Cauchy sequences are characterized by the fact that, eventually,
-the edistance between its elements is arbitrarily small -/
+/-- In a pseudoemetric space, Cauchy sequences are characterized by the fact that, eventually,
+the pseudoedistance between its elements is arbitrarily small -/
 @[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem cauchy_seq_iff [nonempty β] [semilattice_sup β] {u : β → α} :
   cauchy_seq u ↔ ∀ε>0, ∃N, ∀m n≥N, edist (u m) (u n) < ε :=
@@ -746,7 +752,7 @@ end first_countable
 section second_countable
 open topological_space
 
-/-- A separable emetric space is second countable: one obtains a countable basis by taking
+/-- A separable pseudoemetric space is second countable: one obtains a countable basis by taking
 the balls centered at points in a dense subset, and with rational radii. We do not register
 this as an instance, as there is already an instance going in the other direction
 from second countable spaces to separable spaces, and we want to avoid loops. -/
@@ -758,7 +764,7 @@ end second_countable
 
 section diam
 
-/-- The diameter of a set in an emetric space, named `emetric.diam` -/
+/-- The diameter of a set in a pseudoemetric space, named `emetric.diam` -/
 def diam (s : set α) := ⨆ (x ∈ s) (y ∈ s), edist x y
 
 lemma diam_le_iff_forall_edist_le {d : ℝ≥0∞} :
@@ -840,6 +846,8 @@ le_trans (diam_mono ball_subset_closed_ball) diam_closed_ball
 end diam
 
 end emetric --namespace
+
+/-- We now define `emetric_space`, extending `pseudo_emetric_space`. -/
 
 class emetric_space (α : Type u) extends pseudo_emetric_space α : Type u :=
 (eq_of_edist_eq_zero : ∀ {x y : α}, edist x y = 0 → x = y)


### PR DESCRIPTION
Working on the Liquid Tensor Experiment, we realize we need seminorms ~~pseudonorms~~ (meaning we don't require `∥x∥ = 0 → x = 0`). For this reason I would like to include seminorms, pseudometric and pseudoemetric to mathlib. (We currently have `premetric_space`, my plan is to change the name to `pseudometric_space`, that seems to be the standard terminology.)

I started modifying `emetric_space` since it seems the more fundamental (looking at the structure of the imports). What I did here is to define a new class `pseudo_emetric_space`, generalize almost all the results about `emetric_space` to this case (I mean, all the results that are actually true) and at the end of the file I defined `emetric_space` and prove the remaining results. It is the first time I did a refactor like this, so I probably did something wrong, but at least it compiles on my computer.

I don't know why one proof in `measure_theory/ae_eq_fun_metric.lean` stopped working, the same proof in tactic mode works.