### PR TITLE
[Merged by Bors] - feat(measure_theory/measure_space): define `quasi_measure_preserving`

### DIFF
--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -504,6 +504,10 @@ lemma measurable.comp {g : β → γ} {f : α → β} (hg : measurable g) (hf : 
   measurable (g ∘ f) :=
 λ t ht, hf (hg ht)
 
+lemma measurable.iterate {f : α → α} (hf : measurable f) : ∀ n, measurable (f^[n])
+| 0 := measurable_id
+| (n+1) := (measurable.iterate n).comp hf
+
 @[nontriviality] lemma subsingleton.measurable [subsingleton α] {f : α → β} : measurable f :=
 λ s hs, @subsingleton.measurable_set α _ _ _
 

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1394,10 +1394,10 @@ alias absolutely_continuous.ae_le ← ae_mono'
 lemma absolutely_continuous.ae_eq (h : μ ≪ ν) {f g : α → δ} (h' : f =ᵐ[ν] g) : f =ᵐ[μ] g :=
 h.ae_le h'
 
-/-! ### Quasi measure preserving maps -/
+/-! ### Quasi measure preserving maps (a.k.a. non-singular maps) -/
 
-/-- A map `f : α → β` is said to be *quasi measure preserving* w.r.t. measures `μa` and `μb`
-if it is measurable and `μb s = 0` implies `μa (f ⁻¹' s) = 0`. -/
+/-- A map `f : α → β` is said to be *quasi measure preserving* (a.k.a. non-singular) w.r.t. measures
+`μa` and `μb` if it is measurable and `μb s = 0` implies `μa (f ⁻¹' s) = 0`. -/
 @[protect_proj]
 structure quasi_measure_preserving (f : α → β) (μa : measure α . volume_tac)
   (μb : measure β . volume_tac) : Prop :=

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -357,6 +357,26 @@ alias measure_mono_ae ← filter.eventually_le.measure_le
 lemma measure_congr (H : s =ᵐ[μ] t) : μ s = μ t :=
 le_antisymm H.le.measure_le H.symm.le.measure_le
 
+/-- A measure space is a measurable space equipped with a
+  measure, referred to as `volume`. -/
+class measure_space (α : Type*) extends measurable_space α :=
+(volume : measure α)
+
+export measure_space (volume)
+
+/-- `volume` is the canonical  measure on `α`. -/
+add_decl_doc volume
+
+section measure_space
+
+notation `∀ᵐ` binders `, ` r:(scoped P, filter.eventually P
+  (measure_theory.measure.ae measure_theory.measure_space.volume)) := r
+
+/-- The tactic `exact volume`, to be used in optional (`auto_param`) arguments. -/
+meta def volume_tac : tactic unit := `[exact measure_theory.measure_space.volume]
+
+end measure_space
+
 lemma measure_Union [encodable β] {f : β → set α}
   (hn : pairwise (disjoint on f)) (h : ∀ i, measurable_set (f i)) :
   μ (⋃ i, f i) = ∑' i, μ (f i) :=
@@ -810,6 +830,10 @@ else 0
   map f μ s = μ (f ⁻¹' s) :=
 by simp [map, dif_pos hf, hs]
 
+theorem map_of_not_measurable {f : α → β} (hf : ¬measurable f) :
+  map f μ = 0 :=
+by rw [map, dif_neg hf, linear_map.zero_apply]
+
 @[simp] lemma map_id : map id μ = μ :=
 ext $ λ s, map_apply measurable_id
 
@@ -818,8 +842,9 @@ lemma map_map {g : β → γ} {f : α → β} (hg : measurable g) (hf : measurab
 ext $ λ s hs,
 by simp [hf, hg, hs, hg hs, hg.comp hf, ← preimage_comp]
 
-lemma map_mono {f : α → β} (hf : measurable f) (h : μ ≤ ν) : map f μ ≤ map f ν :=
-λ s hs, by simp [hf, hs, h _ (hf hs)]
+@[mono] lemma map_mono (f : α → β) (h : μ ≤ ν) : map f μ ≤ map f ν :=
+if hf : measurable f then λ s hs, by simp only [map_apply hf hs, h _ (hf hs)]
+else by simp only [map_of_not_measurable hf, le_rfl]
 
 /-- Even if `s` is not measurable, we can bound `map f μ s` from below.
   See also `measurable_equiv.map_apply`. -/
@@ -834,6 +859,9 @@ end
 lemma preimage_null_of_map_null {f : α → β} (hf : measurable f) {s : set β}
   (hs : map f μ s = 0) : μ (f ⁻¹' s) = 0 :=
 nonpos_iff_eq_zero.mp $ (le_map_apply hf s).trans_eq hs
+
+lemma tendsto_ae_map {f : α → β} (hf : measurable f) : tendsto f μ.ae (map f μ).ae :=
+λ s hs, preimage_null_of_map_null hf hs
 
 /-- Pullback of a `measure`. If `f` sends each `measurable` set to a `measurable` set, then for each
 measurable set `s` we have `comap f μ s = μ (f '' s)`. -/
@@ -1323,23 +1351,105 @@ def absolutely_continuous (μ ν : measure α) : Prop :=
 
 infix ` ≪ `:50 := absolutely_continuous
 
-lemma absolutely_continuous.mk (h : ∀ ⦃s : set α⦄, measurable_set s → ν s = 0 → μ s = 0) : μ ≪ ν :=
+lemma absolutely_continuous_of_le (h : μ ≤ ν) : μ ≪ ν :=
+λ s hs, nonpos_iff_eq_zero.1 $ hs ▸ le_iff'.1 h s
+
+alias absolutely_continuous_of_le ← has_le.le.absolutely_continuous
+
+lemma absolutely_continuous_of_eq (h : μ = ν) : μ ≪ ν :=
+h.le.absolutely_continuous
+
+alias absolutely_continuous_of_eq ← eq.absolutely_continuous
+
+namespace absolutely_continuous
+
+lemma mk (h : ∀ ⦃s : set α⦄, measurable_set s → ν s = 0 → μ s = 0) : μ ≪ ν :=
 begin
   intros s hs,
   rcases exists_measurable_superset_of_null hs with ⟨t, h1t, h2t, h3t⟩,
   exact measure_mono_null h1t (h h2t h3t),
 end
 
-@[refl] lemma absolutely_continuous.refl (μ : measure α) : μ ≪ μ := λ s hs, hs
+@[refl] protected lemma refl (μ : measure α) : μ ≪ μ := rfl.absolutely_continuous
 
-lemma absolutely_continuous.rfl : μ ≪ μ := λ s hs, hs
+protected lemma rfl : μ ≪ μ := λ s hs, hs
 
-lemma absolutely_continuous_of_eq (h : μ = ν) : μ ≪ ν := by rw h
-
-alias absolutely_continuous_of_eq ← eq.absolutely_continuous
-
-@[trans] lemma absolutely_continuous.trans (h1 : μ₁ ≪ μ₂) (h2 : μ₂ ≪ μ₃) : μ₁ ≪ μ₃ :=
+@[trans] protected lemma trans (h1 : μ₁ ≪ μ₂) (h2 : μ₂ ≪ μ₃) : μ₁ ≪ μ₃ :=
 λ s hs, h1 $ h2 hs
+
+@[mono] protected lemma map (h : μ ≪ ν) (f : α → β) : map f μ ≪ map f ν :=
+if hf : measurable f then absolutely_continuous.mk $ λ s hs, by simpa [hf, hs] using @h _
+else by simp only [map_of_not_measurable hf]
+
+end absolutely_continuous
+
+lemma ae_le_iff_absolutely_continuous : μ.ae ≤ ν.ae ↔ μ ≪ ν :=
+⟨λ h s, by { rw [measure_zero_iff_ae_nmem, measure_zero_iff_ae_nmem], exact λ hs, h hs },
+  λ h s hs, h hs⟩
+
+alias ae_le_iff_absolutely_continuous ↔ has_le.le.absolutely_continuous_of_ae
+  measure_theory.measure.absolutely_continuous.ae_le
+alias absolutely_continuous.ae_le ← ae_mono'
+
+lemma absolutely_continuous.ae_eq (h : μ ≪ ν) {f g : α → δ} (h' : f =ᵐ[ν] g) : f =ᵐ[μ] g :=
+h.ae_le h'
+
+/-! ### Quasi measure preserving maps -/
+
+/-- A map `f : α → β` is said to be *quasi measure preserving* w.r.t. measures `μa` and `μb`
+if it is measurable and `μb s = 0` implies `μa (f ⁻¹' s) = 0`. -/
+@[protect_proj]
+structure quasi_measure_preserving (f : α → β) (μa : measure α . volume_tac)
+  (μb : measure β . volume_tac) : Prop :=
+(measurable : measurable f)
+(absolutely_continuous : map f μa ≪ μb)
+
+namespace quasi_measure_preserving
+
+protected lemma id (μ : measure α) : quasi_measure_preserving id μ μ :=
+⟨measurable_id, map_id.absolutely_continuous⟩
+
+variables {μa μa' : measure α} {μb μb' : measure β} {μc : measure γ} {f : α → β}
+
+lemma mono_left (h : quasi_measure_preserving f μa μb)
+  (ha : μa' ≪ μa) : quasi_measure_preserving f μa' μb :=
+⟨h.1, (ha.map f).trans h.2⟩
+
+lemma mono_right (h : quasi_measure_preserving f μa μb)
+  (ha : μb ≪ μb') : quasi_measure_preserving f μa μb' :=
+⟨h.1, h.2.trans ha⟩
+
+@[mono] lemma mono (ha : μa' ≪ μa) (hb : μb ≪ μb') (h : quasi_measure_preserving f μa μb) :
+  quasi_measure_preserving f μa' μb' :=
+(h.mono_left ha).mono_right hb
+
+protected lemma comp {g : β → γ} {f : α → β} (hg : quasi_measure_preserving g μb μc)
+  (hf : quasi_measure_preserving f μa μb) :
+  quasi_measure_preserving (g ∘ f) μa μc :=
+⟨hg.measurable.comp hf.measurable, by { rw ← map_map hg.1 hf.1, exact (hf.2.map g).trans hg.2 }⟩
+
+protected lemma iterate {f : α → α} (hf : quasi_measure_preserving f μa μa) :
+  ∀ n, quasi_measure_preserving (f^[n]) μa μa
+| 0 := quasi_measure_preserving.id μa
+| (n + 1) := (iterate n).comp hf
+
+lemma ae_map_le (h : quasi_measure_preserving f μa μb) : (map f μa).ae ≤ μb.ae :=
+h.2.ae_le
+
+lemma tendsto_ae (h : quasi_measure_preserving f μa μb) : tendsto f μa.ae μb.ae :=
+(tendsto_ae_map h.1).mono_right h.ae_map_le
+
+lemma ae (h : quasi_measure_preserving f μa μb) {p : β → Prop} (hg : ∀ᵐ x ∂μb, p x) :
+  ∀ᵐ x ∂μa, p (f x) :=
+h.tendsto_ae hg
+
+lemma ae_eq (h : quasi_measure_preserving f μa μb) {g₁ g₂ : β → δ} (hg : g₁ =ᵐ[μb] g₂) :
+  g₁ ∘ f =ᵐ[μa] g₂ ∘ f :=
+h.ae hg
+
+end quasi_measure_preserving
+
+/-! ### The `cofinite` filter -/
 
 /-- The filter of sets `s` such that `sᶜ` has finite measure. -/
 def cofinite (μ : measure α) : filter α :=
@@ -1366,7 +1476,7 @@ by rw [← empty_in_sets_eq_bot, mem_ae_iff, compl_empty, measure_univ_eq_zero]
 @[simp] lemma ae_zero : (0 : measure α).ae = ⊥ := ae_eq_bot.2 rfl
 
 @[mono] lemma ae_mono {μ ν : measure α} (h : μ ≤ ν) : μ.ae ≤ ν.ae :=
-λ s hs, bot_unique $ trans_rel_left (≤) (measure.le_iff'.1 h _) hs
+h.absolutely_continuous.ae_le
 
 lemma mem_ae_map_iff {f : α → β} (hf : measurable f) {s : set β} (hs : measurable_set s) :
   s ∈ (map f μ).ae ↔ (f ⁻¹' s) ∈ μ.ae :=
@@ -1404,7 +1514,7 @@ eventually.filter_mono (ae_mono measure.restrict_le_self) h
 lemma ae_restrict_of_ae_restrict_of_subset {s t : set α} {p : α → Prop} (hst : s ⊆ t)
   (h : ∀ᵐ x ∂(μ.restrict t), p x) :
   (∀ᵐ x ∂(μ.restrict s), p x) :=
-eventually.filter_mono (ae_mono $ measure.restrict_mono hst (le_refl μ)) h
+h.filter_mono (ae_mono $ measure.restrict_mono hst (le_refl μ))
 
 lemma ae_smul_measure {p : α → Prop} (h : ∀ᵐ x ∂μ, p x) (c : ℝ≥0∞) : ∀ᵐ x ∂(c • μ), p x :=
 ae_iff.2 $ by rw [smul_apply, ae_iff.1 h, mul_zero]
@@ -1418,7 +1528,7 @@ add_eq_zero_iff
 
 lemma ae_eq_comp' {ν : measure β} {f : α → β} {g g' : β → δ} (hf : measurable f)
   (h : g =ᵐ[ν] g') (h2 : map f μ ≪ ν) : g ∘ f =ᵐ[μ] g' ∘ f :=
-preimage_null_of_map_null hf $ h2 h
+(quasi_measure_preserving.mk hf h2).ae_eq h
 
 lemma ae_eq_comp {f : α → β} {g g' : β → δ} (hf : measurable f)
   (h : g =ᵐ[measure.map f μ] g') : g ∘ f =ᵐ[μ] g' ∘ f :=
@@ -2288,30 +2398,6 @@ begin
 end
 
 end is_complete
-
-namespace measure_theory
-
-/-- A measure space is a measurable space equipped with a
-  measure, referred to as `volume`. -/
-class measure_space (α : Type*) extends measurable_space α :=
-(volume : measure α)
-
-export measure_space (volume)
-
-/-- `volume` is the canonical  measure on `α`. -/
-add_decl_doc volume
-
-section measure_space
-variables [measure_space α] {s₁ s₂ : set α}
-
-notation `∀ᵐ` binders `, ` r:(scoped P, filter.eventually P (measure.ae volume)) := r
-
-/-- The tactic `exact volume`, to be used in optional (`auto_param`) arguments. -/
-meta def volume_tac : tactic unit := `[exact measure_theory.measure_space.volume]
-
-end measure_space
-
-end measure_theory
 
 /-!
 # Almost everywhere measurable functions

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -431,7 +431,7 @@ lemma set_integral_map {β} [measurable_space β] {g : α → β} {f : β → E}
   ∫ y in s, f y ∂(measure.map g μ) = ∫ x in g ⁻¹' s, f (g x) ∂μ :=
 begin
   rw [measure.restrict_map hg hs, integral_map hg (hf.mono_measure _)],
-  exact measure.map_mono hg measure.restrict_le_self
+  exact measure.map_mono g measure.restrict_le_self
 end
 
 lemma norm_set_integral_le_of_norm_le_const_ae {C : ℝ} (hs : μ s < ∞)


### PR DESCRIPTION
* add `measurable.iterate`
* move section about `measure_space` up to make `volume_tac` available
  much earlier;
* add `map_of_not_measurable`;
* drop assumption `measurable f` in `map_mono`;
* add `tendsto_ae_map`;
* more API about `absolutely_continuous`;
* define `quasi_measure_preserving` and prove some properties.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
