### PR TITLE
[Merged by Bors] - chore(ring_theory/ideal): use `ideal.mul_mem_left` instead of `ideal.smul_mem`

### DIFF
--- a/src/field_theory/mv_polynomial.lean
+++ b/src/field_theory/mv_polynomial.lean
@@ -32,8 +32,8 @@ begin
   refine (ring_hom.injective_iff _).2 (λ x hx, _),
   rw [ring_hom.comp_apply, ideal.quotient.eq_zero_iff_mem] at hx,
   refine classical.by_contradiction (λ hx0, absurd (I.eq_top_iff_one.2 _) hI),
-  have := I.smul_mem (mv_polynomial.C x⁻¹) hx,
-  rwa [smul_eq_mul, ← mv_polynomial.C.map_mul, inv_mul_cancel hx0, mv_polynomial.C_1] at this,
+  have := I.mul_mem_left (mv_polynomial.C x⁻¹) hx,
+  rwa [← mv_polynomial.C.map_mul, inv_mul_cancel hx0, mv_polynomial.C_1] at this,
 end
 
 end mv_polynomial

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -323,7 +323,7 @@ lemma coe_add (I J : fractional_ideal f) : (↑(I + J) : submodule R f.codomain)
 lemma fractional_mul (I J : fractional_ideal f) : is_fractional f (I.1 * J.1) :=
 begin
   rcases I with ⟨I, aI, haI, hI⟩,
-  rcases J with ⟨I, aJ, haJ, hJ⟩,
+  rcases J with ⟨J, aJ, haJ, hJ⟩,
   use aI * aJ,
   use S.mul_mem haI haJ,
   intros b hb,

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -299,11 +299,11 @@ begin
   split;
   intro h,
   { rw [← mk'_spec f x y, mul_comm],
-    exact I.smul_mem (f.to_map y) h },
+    exact I.mul_mem_left (f.to_map y) h },
   { rw ← mk'_spec f x y at h,
     obtain ⟨b, hb⟩ := is_unit_iff_exists_inv.1 (map_units f y),
-    have := I.smul_mem b h,
-    rwa [smul_eq_mul, mul_comm, mul_assoc, hb, mul_one] at this }
+    have := I.mul_mem_left b h,
+    rwa [mul_comm, mul_assoc, hb, mul_one] at this }
 end
 
 protected lemma eq {a₁ b₁} {a₂ b₂ : M} :
@@ -794,7 +794,7 @@ private def to_map_ideal (I : ideal R) : ideal S :=
   zero_mem' := ⟨⟨0, 1⟩, by simp⟩,
   add_mem' := begin
     rintros a b ⟨a', ha⟩ ⟨b', hb⟩,
-    use ⟨a'.2 * b'.1 + b'.2 * a'.1, I.add_mem (I.smul_mem _ b'.1.2) (I.smul_mem _ a'.1.2)⟩,
+    use ⟨a'.2 * b'.1 + b'.2 * a'.1, I.add_mem (I.mul_mem_left _ b'.1.2) (I.mul_mem_left _ a'.1.2)⟩,
     use a'.2 * b'.2,
     simp only [ring_hom.map_add, submodule.coe_mk, submonoid.coe_mul, ring_hom.map_mul],
     rw [add_mul, ← mul_assoc a, ha, mul_comm (f.to_map a'.2) (f.to_map b'.2), ← mul_assoc b, hb],
@@ -803,7 +803,7 @@ private def to_map_ideal (I : ideal R) : ideal S :=
   smul_mem' := begin
     rintros c x ⟨x', hx⟩,
     obtain ⟨c', hc⟩ := localization_map.surj f c,
-    use ⟨c'.1 * x'.1, I.smul_mem c'.1 x'.1.2⟩,
+    use ⟨c'.1 * x'.1, I.mul_mem_left c'.1 x'.1.2⟩,
     use c'.2 * x'.2,
     simp only [←hx, ←hc, smul_eq_mul, submodule.coe_mk, submonoid.coe_mul, ring_hom.map_mul],
     ring
@@ -926,8 +926,8 @@ begin
   { have : I = ⊤,
     { rw ideal.eq_top_iff_one,
       rw [ideal.quotient.eq_zero_iff_mem, ideal.mem_comap] at hM,
-      convert I.smul_mem (f.mk' 1 ⟨m, hm⟩) hM,
-      rw [smul_eq_mul, mul_comm, ← f.mk'_eq_mul_mk'_one, f.mk'_self] },
+      convert I.mul_mem_right (f.mk' 1 ⟨m, hm⟩) hM,
+      rw [← f.mk'_eq_mul_mk'_one, f.mk'_self] },
     exact ⟨0, eq_comm.1 (by simp [ideal.quotient.eq_zero_iff_mem, this])⟩ },
   { rw ideal.quotient.maximal_ideal_iff_is_field_quotient at hI,
     obtain ⟨n, hn⟩ := hI.3 hM,

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -252,10 +252,10 @@ begin
       exact I.sum_mem (λ c hc, I.smul_mem (f.coeff c.fst) (hg c.snd)) } },
   { intros hf,
     rw ← sum_monomial_eq f,
-    refine (map C I : ideal (polynomial R)).sum_mem (λ n hn, _),
+    refine (I.map C : ideal (polynomial R)).sum_mem (λ n hn, _),
     simp [single_eq_C_mul_X],
     rw mul_comm,
-    exact (map C I : ideal (polynomial R)).smul_mem _ (mem_map_of_mem (hf n)) }
+    exact (I.map C : ideal (polynomial R)).mul_mem_left _ (mem_map_of_mem (hf n)) }
 end
 
 lemma quotient_map_C_eq_zero {I : ideal R} :
@@ -389,7 +389,7 @@ def of_polynomial (I : ideal (polynomial R)) : submodule R (polynomial R) :=
 { carrier := I.carrier,
   zero_mem' := I.zero_mem,
   add_mem' := λ _ _, I.add_mem,
-  smul_mem' := λ c x H, by rw [← C_mul']; exact submodule.smul_mem _ _ H }
+  smul_mem' := λ c x H, by { rw [← C_mul'], exact I.mul_mem_left _ H } }
 
 variables {I : ideal (polynomial R)}
 theorem mem_of_polynomial (x) : x ∈ I.of_polynomial ↔ x ∈ I := iff.rfl


### PR DESCRIPTION
Lots of proofs are relying on the fact that mul and smul are defeq, but this makes them hard to follow, as the goal state never contains the smul referenced by these lemmas.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
