### PR TITLE
[Merged by Bors] - chore(linear_algebra/determinant): redefine det using multilinear_map.alternatization

### DIFF
--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -153,18 +153,6 @@ f.to_multilinear_map.map_update_zero m i
 @[simp] lemma map_zero [nonempty ι] : f 0 = 0 :=
 f.to_multilinear_map.map_zero
 
-/-- Make a copy of `m` that when applied is defeq to `f`. -/
-@[simps]
-def copy (m : alternating_map R M N ι) (f : (ι → M) → N) (hf : ⇑m = f) : alternating_map R M N ι :=
-{ to_fun := f,
-  map_add' := λ v i x y, by simp only [←hf, m.map_add],
-  map_smul' := λ v i c x, by simp only [←hf, m.map_smul],
-  map_eq_zero_of_eq' := λ v i j hv hij, by simp only [←hf, m.map_eq_zero_of_eq _ hv hij]}
-
-lemma copy_eq (m : alternating_map R M N ι) (f : (ι → M) → N) {hf : ⇑m = f} :
-  m.copy f hf = m :=
-ext $ _root_.congr_fun hf.symm
-
 /-!
 ### Algebraic structure inherited from `multilinear_map`
 

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -144,6 +144,27 @@ f.to_multilinear_map.map_smul' v i r x
   f v = 0 :=
 f.map_eq_zero_of_eq' v i j h hij
 
+lemma map_coord_zero {m : ι → M} (i : ι) (h : m i = 0) : f m = 0 :=
+f.to_multilinear_map.map_coord_zero i h
+
+@[simp] lemma map_update_zero (m : ι → M) (i : ι) : f (update m i 0) = 0 :=
+f.to_multilinear_map.map_update_zero m i
+
+@[simp] lemma map_zero [nonempty ι] : f 0 = 0 :=
+f.to_multilinear_map.map_zero
+
+/-- Make a copy of `m` that when applied is defeq to `f`. -/
+@[simps]
+def copy (m : alternating_map R M N ι) (f : (ι → M) → N) (hf : ⇑m = f) : alternating_map R M N ι :=
+{ to_fun := f,
+  map_add' := λ v i x y, by simp only [←hf, m.map_add],
+  map_smul' := λ v i c x, by simp only [←hf, m.map_smul],
+  map_eq_zero_of_eq' := λ v i j hv hij, by simp only [←hf, m.map_eq_zero_of_eq _ hv hij]}
+
+lemma copy_eq (m : alternating_map R M N ι) (f : (ι → M) → N) {hf : ⇑m = f} :
+  m.copy f hf = m :=
+ext $ _root_.congr_fun hf.symm
+
 /-!
 ### Algebraic structure inherited from `multilinear_map`
 

--- a/src/linear_algebra/char_poly/coeff.lean
+++ b/src/linear_algebra/char_poly/coeff.lean
@@ -58,7 +58,7 @@ variable (M)
 lemma char_poly_sub_diagonal_degree_lt :
 (char_poly M - ∏ (i : n), (X - C (M i i))).degree < ↑(fintype.card n - 1) :=
 begin
-  rw [char_poly, det, ← insert_erase (mem_univ (equiv.refl n)),
+  rw [char_poly, det_apply', ← insert_erase (mem_univ (equiv.refl n)),
     sum_insert (not_mem_erase (equiv.refl n) univ), add_comm],
   simp only [char_matrix_apply_eq, one_mul, equiv.perm.sign_refl, id.def, int.cast_one,
     units.coe_one, add_sub_cancel, equiv.coe_refl],

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -949,7 +949,7 @@ lemma det_reindex_self' [decidable_eq m] [decidable_eq n] [comm_ring R]
   (e : m ≃ n) (A : matrix m m R) :
   det (λ i j, A (e.symm i) (e.symm j)) = det A :=
 begin
-  unfold det,
+  rw [det_apply', det_apply'],
   apply finset.sum_bij' (λ σ _, equiv.perm_congr e.symm σ) _ _ (λ σ _, equiv.perm_congr e σ),
   { intros σ _, ext, simp only [equiv.symm_symm, equiv.perm_congr_apply, equiv.apply_symm_apply] },
   { intros σ _, ext, simp only [equiv.symm_symm, equiv.perm_congr_apply, equiv.symm_apply_apply] },
@@ -1185,7 +1185,7 @@ lemma det_to_block (M : matrix m m R) (p : m → Prop) [decidable_pred p] :
     (to_block M (λ j, ¬p j) p) (to_block M (λ j, ¬p j) (λ j, ¬p j))).det :=
 begin
   rw ← matrix.det_reindex_self (equiv.sum_compl p).symm M,
-  unfold det,
+  rw [det_apply', det_apply'],
   congr, ext σ, congr, ext,
   generalize hy : σ x = y,
   cases x; cases y;

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -220,8 +220,7 @@ h (adjugate A).det (calc A.det * (adjugate A).det = (A ⬝ adjugate A).det   : (
 
 lemma adjugate_eq_one_of_card_eq_one {A : matrix n n α} (h : fintype.card n = 1) : adjugate A = 1 :=
 begin
-  obtain ⟨k, heq⟩ := fintype.card_eq_one_iff.mp h,
-  haveI : subsingleton n := subsingleton_of_forall_eq k heq,
+  haveI : subsingleton n := fintype.card_le_one_iff_subsingleton.mp h.le,
   ext i j,
   simp [subsingleton.elim i j, adjugate_apply, det_eq_elem_of_card_eq_one h j],
 end

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -66,13 +66,8 @@ variables (A : matrix n n α) (b : n → α)
 def cramer_map (i : n) : α := (A.update_column i b).det
 
 lemma cramer_map_is_linear (i : n) : is_linear_map α (λ b, cramer_map A b i) :=
-begin
-  split,
-  { intros x y,
-    exact det_update_column_add _ _ _ _ },
-  { intros c x,
-    exact det_update_column_smul _ _ _ _ },
-end
+{ map_add := det_update_column_add _ _,
+  map_smul := det_update_column_smul _ _ }
 
 lemma cramer_is_linear : is_linear_map α (cramer_map A) :=
 begin

--- a/src/linear_algebra/nonsingular_inverse.lean
+++ b/src/linear_algebra/nonsingular_inverse.lean
@@ -67,29 +67,11 @@ def cramer_map (i : n) : α := (A.update_column i b).det
 
 lemma cramer_map_is_linear (i : n) : is_linear_map α (λ b, cramer_map A b i) :=
 begin
-  have : Π {f : n → n} {i : n} (x : n → α),
-    (∏ i' : n, (update_column A i x) (f i') i')
-    = (∏ i' : n, if i' = i then x (f i') else A (f i') i'),
-  { intros, congr' with i', apply update_column_apply, },
   split,
   { intros x y,
-    repeat { rw [cramer_map, det] },
-    rw [←sum_add_distrib],
-    congr' with σ,
-    rw [←mul_add ↑↑(sign σ)],
-    congr,
-    repeat { erw [this, finset.prod_ite] },
-    erw [finset.filter_eq', if_pos (mem_univ i), prod_singleton, prod_singleton,
-      prod_singleton, ←add_mul],
-    refl },
+    exact det_update_column_add _ _ _ _ },
   { intros c x,
-    repeat { rw [cramer_map, det] },
-    rw [smul_eq_mul, mul_sum],
-    congr' with σ,
-    rw [←mul_assoc, mul_comm c, mul_assoc], congr,
-    repeat { erw [this, finset.prod_ite] },
-    erw [finset.filter_eq', if_pos (mem_univ i),
-      prod_singleton, prod_singleton, mul_assoc], }
+    exact det_update_column_smul _ _ _ _ },
 end
 
 lemma cramer_is_linear : is_linear_map α (cramer_map A) :=
@@ -171,6 +153,7 @@ lemma adjugate_transpose (A : matrix n n α) : (adjugate A)ᵀ = adjugate (Aᵀ)
 begin
   ext i j,
   rw [transpose_apply, adjugate_apply, adjugate_apply, update_row_transpose, det_transpose],
+  rw [det_apply', det_apply'],
   apply finset.sum_congr rfl,
   intros σ _,
   congr' 1,
@@ -242,13 +225,10 @@ h (adjugate A).det (calc A.det * (adjugate A).det = (A ⬝ adjugate A).det   : (
 
 lemma adjugate_eq_one_of_card_eq_one {A : matrix n n α} (h : fintype.card n = 1) : adjugate A = 1 :=
 begin
+  obtain ⟨k, heq⟩ := fintype.card_eq_one_iff.mp h,
+  haveI : subsingleton n := subsingleton_of_forall_eq k heq,
   ext i j,
-  have univ_eq_i := univ_eq_singleton_of_card_one i h,
-  have univ_eq_j := univ_eq_singleton_of_card_one j h,
-  have i_eq_j : i = j := singleton_inj.mp (by rw [←univ_eq_i, univ_eq_j]),
-  have perm_eq : (univ : finset (perm n)) = {1} :=
-    univ_eq_singleton_of_card_one (1 : perm n) (by simp [card_univ, fintype.card_perm, h]),
-  simp [adjugate_apply, det, univ_eq_i, perm_eq, i_eq_j]
+  simp [subsingleton.elim i j, adjugate_apply, det_eq_elem_of_card_eq_one h j],
 end
 
 @[simp] lemma adjugate_zero (h : 1 < fintype.card n) : adjugate (0 : matrix n n α) = 0 :=

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -61,7 +61,7 @@ example {α : Type*} [comm_ring α] {a b c d : α} :
   matrix.det ![![a, b], ![c, d]] = a * d - b * c :=
 begin
   -- TODO: can we make this require less steering?
-  simp [matrix.det, finset.univ_perm_fin_succ, ←finset.univ_product_univ, finset.sum_product,
+  simp [matrix.det_apply', finset.univ_perm_fin_succ, ←finset.univ_product_univ, finset.sum_product,
         fin.sum_univ_succ, fin.prod_univ_succ],
   ring
 end
@@ -71,7 +71,7 @@ example {α : Type*} [comm_ring α] (A : matrix (fin 3) (fin 3) α) {a b c d e f
           a * e * i - a * f * h - b * d * i + b * f * g + c * d * h - c * e * g :=
 begin
   -- We utilize the `norm_swap` plugin for `norm_num` to reduce swap terms
-  norm_num [matrix.det, finset.univ_perm_fin_succ, ←finset.univ_product_univ,
+  norm_num [matrix.det_apply', finset.univ_perm_fin_succ, ←finset.univ_product_univ,
             finset.sum_product, fin.sum_univ_succ, fin.prod_univ_succ],
   ring
 end


### PR DESCRIPTION
This slightly changes the definitional unfolding of `matrix.det` (moving a function application outside a sum and adjusting the version of int-multiplication used).

By doing this, a large number of proofs become a trivial application of a more general statement about alternating maps.

`det_row_multilinear` already existed prior to this commit, but now `det` is defined in terms of it instead of the other way around.
We still need both, as otherwise we would break `M.det` dot notation, as `det_row_multilinear` does not have its argument expressed as a matrix.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
