### PR TITLE
[Merged by Bors] - chore(linear_algebra/finite_dimensional): change instance

### DIFF
--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -499,10 +499,8 @@ begin
   exact_mod_cast this
 end
 
-/-- The vector space of functions on a fintype has finite dimension. -/
-instance finite_dimensional_fintype_fun {ι : Type*} [fintype ι] :
-  finite_dimensional K (ι → K) :=
-by { rw [finite_dimensional_iff_dim_lt_omega, dim_fun'], exact nat_lt_omega _ }
+instance finite_dimensional_self : finite_dimensional K K :=
+by apply_instance
 
 /-- The vector space of functions on a fintype ι has findim equal to the cardinality of ι. -/
 @[simp] lemma findim_fintype_fun_eq_card {ι : Type v} [fintype ι] :


### PR DESCRIPTION
With the new instance `finite_dimensional K K` Lean can deduce the old instance automatically. I don not completely understand why it needs the new instance (`apply_instance` proves it), probably this is related to the order of unfolding `finite_dimensional` and applying `is_noetherian` instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
