### PR TITLE
feat(ring_theory/int/basic): Induction, nat_abs and units

### DIFF
--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -354,3 +354,49 @@ begin
   { intros a p _ hp ha,
     exact h p a (nat.prime_iff_prime.2 hp) ha, },
 end
+
+lemma int.associated_nat_abs (k: ℤ): associated k k.nat_abs :=
+begin
+  apply associated.symm,
+  unfold associated,
+  cases int.nat_abs_eq k with h h,
+  use 1, simp, exact h.symm,
+  use -1, simp, exact h.symm,
+end
+
+lemma int.prime_iff_nat_abs_prime {k: ℤ}: prime k ↔ nat.prime k.nat_abs :=
+begin
+  rw nat.prime_iff_prime_int,
+  rw prime_iff_of_associated (int.associated_nat_abs k),
+end
+
+lemma int.associated_iff (a: ℤ) (b: ℤ): associated a b ↔ (a = b ∨ a = -b) :=
+begin
+  split,
+  {
+    intro h,
+    rcases h with ⟨ u, h ⟩,
+    have p₁ := fintype.complete u,
+    cases p₁,
+    left, rw ← mul_one a, rw p₁ at h, exact h,
+    cases p₁,
+    right, rw p₁ at h, simp at h, linarith only [h],
+    exfalso, exact list.not_mem_nil u p₁,
+  },
+  {
+    intro h,
+    cases h,
+    rw h,
+    use -1, simp, linarith [h],
+  },
+end
+
+lemma units_int.values (u: units ℤ): u = 1 ∨ u = -1 :=
+begin
+  have p₁ := fintype.complete u,
+  cases p₁,
+  left, exact p₁,
+  cases p₁,
+  right, exact p₁,
+  exfalso, exact list.not_mem_nil u p₁,
+end

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -341,3 +341,16 @@ instance decidable_int : decidable_rel (λ a b : ℤ, (multiplicity a b).dom) :=
 λ a b, decidable_of_iff _ finite_int_iff.symm
 
 end multiplicity
+
+lemma induction_on_primes [P: nat → Prop] (h₁: P 0) (h₂: P 1)
+  (h: ∀ p a: ℕ, nat.prime p → P a → P (p * a)): ∀ n: ℕ, P n :=
+begin
+  intro n,
+  apply unique_factorization_monoid.induction_on_prime,
+  exact h₁,
+  { intros n h,
+    rw nat.is_unit_iff.1 h,
+    exact h₂, },
+  { intros a p _ hp ha,
+    exact h p a (nat.prime_iff_prime.2 hp) ha, },
+end


### PR DESCRIPTION
Induction, nat_abs and units
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Proves : 
 * Induction on primes (special case for nat)
 * In `int`, a number and its `nat_abs` are associated
 * An integer is prime iff its `nat_abs` is prime
 * Two integers are associated iff they are equal or opposites
 * Classification of the units in `int` (trivial but handy lemma)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
