### PR TITLE
feat(analysis/special_functions/exp_log): log_nonzero_of_ne_one and log_inj_pos

### DIFF
--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -475,6 +475,20 @@ end
 lemma log_nonpos (hx : 0 ≤ x) (h'x : x ≤ 1) : log x ≤ 0 :=
 (log_nonpos_iff' hx).2 h'x
 
+lemma log_nonzero_of_ne_one (x: ℝ) (hx_pos: 0 < x) (hx: x ≠ 1): real.log x ≠ 0 :=
+begin
+  by_cases (1 < x),
+  exact ne_of_gt (log_pos h),
+  push_neg at h,
+  exact ne_of_lt (log_neg hx_pos (lt_of_le_of_ne h hx)),
+end
+
+lemma log_inj_pos {x y: ℝ} (x_pos: 0 < x) (y_pos: 0 < y):
+  real.log x = real.log y → x = y :=
+λ h, le_antisymm
+  ((log_le_log x_pos y_pos).1 $ le_of_eq h)
+  ((log_le_log y_pos x_pos).1 $ le_of_eq $ eq.symm h)
+
 lemma strict_mono_incr_on_log : strict_mono_incr_on log (set.Ioi 0) :=
 λ x hx y hy hxy, log_lt_log hx hxy
 


### PR DESCRIPTION
log_nonzero_of_ne_one and log_inj_pos
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Proves : 
 * When `x > 0`, `log(x)` is `0` iff `x = 1`
 * The real logarithm is injective (when restraining the domain to the positive reals)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
