### PR TITLE
feat(ring_theory/multiplicity): Multiplicity with units

### DIFF
--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -169,6 +169,20 @@ lemma eq_of_associated_right {a b c : α} (h : associated b c) :
 le_antisymm (multiplicity_le_multiplicity_of_dvd_right (dvd_of_associated h))
   (multiplicity_le_multiplicity_of_dvd_right (dvd_of_associated h.symm))
 
+lemma multiplicity.unit_left {a: α}
+  (u: units α): multiplicity (u: α) a = ⊤ :=
+begin
+  rw ← multiplicity.eq_of_associated_left unit_associated_one,
+  exact multiplicity.one_left a,
+end
+
+lemma multiplicity.unit_right {a: α} (ha: ¬is_unit a)
+  (u: units α): multiplicity a u = 0 :=
+begin
+  rw multiplicity.eq_of_associated_right unit_associated_one,
+  exact multiplicity.one_right ha,
+end
+
 lemma dvd_of_multiplicity_pos {a b : α} (h : (0 : enat) < multiplicity a b) : a ∣ b :=
 by rw [← pow_one a]; exact pow_dvd_of_le_multiplicity (enat.pos_iff_one_le.1 h)
 


### PR DESCRIPTION
Multiplicity with units
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Generalizes `multiplicity.one_left` and `multiplicity.one_right` to units.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
