### PR TITLE
[Merged by Bors] - feat(ring_theory/multiplicity): Multiplicity with units

### DIFF
--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -136,7 +136,7 @@ eq_some_iff.2 ⟨dvd_refl _, mt is_unit_iff_dvd_one.2 $ by simpa⟩
 get_eq_iff_eq_some.2 (eq_some_iff.2 ⟨dvd_refl _,
   by simpa [is_unit_iff_dvd_one.symm] using not_unit_of_finite ha⟩)
 
-@[simp] lemma unit_left {a : α} (u : units α) : multiplicity (u : α) a = ⊤ :=
+@[simp] lemma unit_left (a : α) (u : units α) : multiplicity (u : α) a = ⊤ :=
 is_unit_left a (is_unit_unit u)
 
 lemma unit_right {a : α} (ha : ¬is_unit a) (u : units α) : multiplicity a u = 0 :=

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -120,26 +120,26 @@ lemma eq_top_iff {a b : α} :
 (enat.find_eq_top_iff _).trans $
 by { simp only [not_not], exact ⟨λ h n, nat.cases_on n (one_dvd _) (λ n, h _), λ h n, h _⟩ }
 
-lemma one_right {a : α} (ha : ¬is_unit a) : multiplicity a 1 = 0 :=
-eq_some_iff.2 ⟨dvd_refl _, mt is_unit_iff_dvd_one.2 $ by simpa⟩
-
 @[simp] lemma get_one_right {a : α} (ha : finite a 1) : get (multiplicity a 1) ha = 0 :=
 get_eq_iff_eq_some.2 (eq_some_iff.2 ⟨dvd_refl _,
   by simpa [is_unit_iff_dvd_one.symm] using not_unit_of_finite ha⟩)
+
+@[simp] lemma is_unit_left {a : α} (b : α) (ha : is_unit a) : multiplicity a b = ⊤ :=
+eq_top_iff.2 (λ _, is_unit_iff_forall_dvd.1 (ha.pow _) _)
 
 lemma is_unit_right {a b : α} (ha : ¬is_unit a) (hb : is_unit b) :
   multiplicity a b = 0 :=
 eq_some_iff.2 ⟨by simp, by { rw pow_one, exact λ h, mt (is_unit_of_dvd_unit h) ha hb, }⟩
 
-@[simp] lemma multiplicity_unit {a : α} (b : α) (ha : is_unit a) : multiplicity a b = ⊤ :=
-eq_top_iff.2 (λ _, is_unit_iff_forall_dvd.1 (ha.pow _) _)
-
 @[simp] lemma one_left (b : α) : multiplicity 1 b = ⊤ := by simp [eq_top_iff]
 
-lemma multiplicity.unit_left {a: α} (u: units α): multiplicity (u: α) a = ⊤ :=
-multiplicity_unit a (is_unit_unit u)
+lemma one_right {a : α} (ha : ¬is_unit a) : multiplicity a 1 = 0 :=
+eq_some_iff.2 ⟨dvd_refl _, mt is_unit_iff_dvd_one.2 $ by simpa⟩
 
-lemma multiplicity.unit_right {a: α} (ha: ¬is_unit a) (u: units α): multiplicity a u = 0 :=
+@[simp] lemma unit_left {a: α} (u: units α): multiplicity (u: α) a = ⊤ :=
+is_unit_left a (is_unit_unit u)
+
+lemma unit_right {a: α} (ha: ¬is_unit a) (u: units α): multiplicity a u = 0 :=
 is_unit_right ha (is_unit_unit u)
 
 lemma multiplicity_eq_zero_of_not_dvd {a b : α} (ha : ¬a ∣ b) : multiplicity a b = 0 :=

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -127,10 +127,22 @@ eq_some_iff.2 ⟨dvd_refl _, mt is_unit_iff_dvd_one.2 $ by simpa⟩
 get_eq_iff_eq_some.2 (eq_some_iff.2 ⟨dvd_refl _,
   by simpa [is_unit_iff_dvd_one.symm] using not_unit_of_finite ha⟩)
 
+lemma is_unit_right {a b : α} (ha : ¬is_unit a) (hb : is_unit b) :
+  multiplicity a b = 0 :=
+eq_some_iff.2 ⟨by simp, by { rw pow_one, exact λ h, mt (is_unit_of_dvd_unit h) ha hb, }⟩
+
 @[simp] lemma multiplicity_unit {a : α} (b : α) (ha : is_unit a) : multiplicity a b = ⊤ :=
 eq_top_iff.2 (λ _, is_unit_iff_forall_dvd.1 (ha.pow _) _)
 
 @[simp] lemma one_left (b : α) : multiplicity 1 b = ⊤ := by simp [eq_top_iff]
+
+lemma multiplicity.unit_left {a: α}
+  (u: units α): multiplicity (u: α) a = ⊤ :=
+multiplicity_unit a (is_unit_unit u)
+
+lemma multiplicity.unit_right {a: α} (ha: ¬is_unit a)
+  (u: units α): multiplicity a u = 0 :=
+is_unit_right ha (is_unit_unit u)
 
 lemma multiplicity_eq_zero_of_not_dvd {a b : α} (ha : ¬a ∣ b) : multiplicity a b = 0 :=
 eq_some_iff.2 (by simpa)
@@ -168,20 +180,6 @@ lemma eq_of_associated_right {a b c : α} (h : associated b c) :
   multiplicity a b = multiplicity a c :=
 le_antisymm (multiplicity_le_multiplicity_of_dvd_right (dvd_of_associated h))
   (multiplicity_le_multiplicity_of_dvd_right (dvd_of_associated h.symm))
-
-lemma multiplicity.unit_left {a: α}
-  (u: units α): multiplicity (u: α) a = ⊤ :=
-begin
-  rw ← multiplicity.eq_of_associated_left unit_associated_one,
-  exact multiplicity.one_left a,
-end
-
-lemma multiplicity.unit_right {a: α} (ha: ¬is_unit a)
-  (u: units α): multiplicity a u = 0 :=
-begin
-  rw multiplicity.eq_of_associated_right unit_associated_one,
-  exact multiplicity.one_right ha,
-end
 
 lemma dvd_of_multiplicity_pos {a b : α} (h : (0 : enat) < multiplicity a b) : a ∣ b :=
 by rw [← pow_one a]; exact pow_dvd_of_le_multiplicity (enat.pos_iff_one_le.1 h)

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -169,6 +169,20 @@ lemma eq_of_associated_right {a b c : α} (h : associated b c) :
 le_antisymm (multiplicity_le_multiplicity_of_dvd_right (dvd_of_associated h))
   (multiplicity_le_multiplicity_of_dvd_right (dvd_of_associated h.symm))
 
+lemma multiplicity.unit_left {a: α}
+  (u: units α): multiplicity (u: α) a = ⊤ :=
+begin
+  rw ← multiplicity.eq_of_associated_left unit_associated_one,
+  exact multiplicity.one_left a,
+end
+
+lemma multiplicity.unit_right {a: α} (ha: ¬is_unit a)
+  (u: units α): multiplicity a u = 0 :=
+begin
+  rw multiplicity.eq_of_associated_right unit_associated_one,
+  exact multiplicity.one_right ha,
+end
+
 lemma dvd_of_multiplicity_pos {a b : α} (h : (0 : enat) < multiplicity a b) : a ∣ b :=
 by rw [← pow_one a]; exact pow_dvd_of_le_multiplicity (enat.pos_iff_one_le.1 h)
 

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -127,10 +127,9 @@ lemma is_unit_right {a b : α} (ha : ¬is_unit a) (hb : is_unit b) :
   multiplicity a b = 0 :=
 eq_some_iff.2 ⟨by simp, by { rw pow_one, exact λ h, mt (is_unit_of_dvd_unit h) ha hb, }⟩
 
-@[simp] lemma one_left (b : α) : multiplicity 1 b = ⊤ := by simp [eq_top_iff]
+@[simp] lemma one_left (b : α) : multiplicity 1 b = ⊤ := is_unit_left b is_unit_one
 
-lemma one_right {a : α} (ha : ¬is_unit a) : multiplicity a 1 = 0 :=
-eq_some_iff.2 ⟨dvd_refl _, mt is_unit_iff_dvd_one.2 $ by simpa⟩
+lemma one_right {a : α} (ha : ¬is_unit a) : multiplicity a 1 = 0 := is_unit_right ha is_unit_one
 
 @[simp] lemma get_one_right {a : α} (ha : finite a 1) : get (multiplicity a 1) ha = 0 :=
 get_eq_iff_eq_some.2 (eq_some_iff.2 ⟨dvd_refl _,

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -120,10 +120,6 @@ lemma eq_top_iff {a b : α} :
 (enat.find_eq_top_iff _).trans $
 by { simp only [not_not], exact ⟨λ h n, nat.cases_on n (one_dvd _) (λ n, h _), λ h n, h _⟩ }
 
-@[simp] lemma get_one_right {a : α} (ha : finite a 1) : get (multiplicity a 1) ha = 0 :=
-get_eq_iff_eq_some.2 (eq_some_iff.2 ⟨dvd_refl _,
-  by simpa [is_unit_iff_dvd_one.symm] using not_unit_of_finite ha⟩)
-
 @[simp] lemma is_unit_left {a : α} (b : α) (ha : is_unit a) : multiplicity a b = ⊤ :=
 eq_top_iff.2 (λ _, is_unit_iff_forall_dvd.1 (ha.pow _) _)
 
@@ -136,10 +132,14 @@ eq_some_iff.2 ⟨by simp, by { rw pow_one, exact λ h, mt (is_unit_of_dvd_unit h
 lemma one_right {a : α} (ha : ¬is_unit a) : multiplicity a 1 = 0 :=
 eq_some_iff.2 ⟨dvd_refl _, mt is_unit_iff_dvd_one.2 $ by simpa⟩
 
-@[simp] lemma unit_left {a: α} (u: units α): multiplicity (u: α) a = ⊤ :=
+@[simp] lemma get_one_right {a : α} (ha : finite a 1) : get (multiplicity a 1) ha = 0 :=
+get_eq_iff_eq_some.2 (eq_some_iff.2 ⟨dvd_refl _,
+  by simpa [is_unit_iff_dvd_one.symm] using not_unit_of_finite ha⟩)
+
+@[simp] lemma unit_left {a : α} (u : units α) : multiplicity (u : α) a = ⊤ :=
 is_unit_left a (is_unit_unit u)
 
-lemma unit_right {a: α} (ha: ¬is_unit a) (u: units α): multiplicity a u = 0 :=
+lemma unit_right {a : α} (ha : ¬is_unit a) (u : units α) : multiplicity a u = 0 :=
 is_unit_right ha (is_unit_unit u)
 
 lemma multiplicity_eq_zero_of_not_dvd {a b : α} (ha : ¬a ∣ b) : multiplicity a b = 0 :=

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -136,12 +136,10 @@ eq_top_iff.2 (λ _, is_unit_iff_forall_dvd.1 (ha.pow _) _)
 
 @[simp] lemma one_left (b : α) : multiplicity 1 b = ⊤ := by simp [eq_top_iff]
 
-lemma multiplicity.unit_left {a: α}
-  (u: units α): multiplicity (u: α) a = ⊤ :=
+lemma multiplicity.unit_left {a: α} (u: units α): multiplicity (u: α) a = ⊤ :=
 multiplicity_unit a (is_unit_unit u)
 
-lemma multiplicity.unit_right {a: α} (ha: ¬is_unit a)
-  (u: units α): multiplicity a u = 0 :=
+lemma multiplicity.unit_right {a: α} (ha: ¬is_unit a) (u: units α): multiplicity a u = 0 :=
 is_unit_right ha (is_unit_unit u)
 
 lemma multiplicity_eq_zero_of_not_dvd {a b : α} (ha : ¬a ∣ b) : multiplicity a b = 0 :=


### PR DESCRIPTION
Renames `multiplicity.multiplicity_unit` into `multiplicity.is_unit_left`.

Adds : 
 * `multiplicity.is_unit_right`
 * `multiplicity.unit_left`
 * `multiplicity.unit_right`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
