### PR TITLE
[Merged by Bors] - feat(data/padics/padic_norm): p-adic norm of primes other than p

### DIFF
--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -538,6 +538,17 @@ See also `padic_norm.padic_norm_p` for a version that assumes `1 < p`.
 @[simp] lemma padic_norm_p_of_prime (p : ℕ) [fact p.prime] : padic_norm p p = 1 / p :=
 padic_norm_p $ nat.prime.one_lt ‹_›
 
+/-
+The p-adic norm of `q` is `1` if `q` is another prime than `p`.
+-/
+lemma padic_norm_primes {p q: ℕ} [p_prime: fact (nat.prime p)] [q_prime: fact (nat.prime q)]
+  (neq: p ≠ q): padic_norm p q = 1 :=
+begin
+  have p: padic_val_rat p q = 0,
+  exact_mod_cast @padic_val_nat_primes p q p_prime q_prime neq,
+  simp [padic_norm, p, q_prime.1, nat.prime.ne_zero q_prime],
+end
+
 /--
 The p-adic norm of `p` is less than 1 if `1 < p`.
 

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -1,5 +1,3 @@
-/- for data.padics.padic_norm -/
-
 /-
 Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -1,3 +1,5 @@
+/- for data.padics.padic_norm -/
+
 /-
 Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
@@ -538,15 +540,13 @@ See also `padic_norm.padic_norm_p` for a version that assumes `1 < p`.
 @[simp] lemma padic_norm_p_of_prime (p : ℕ) [fact p.prime] : padic_norm p p = 1 / p :=
 padic_norm_p $ nat.prime.one_lt ‹_›
 
-/-
-The p-adic norm of `q` is `1` if `q` is another prime than `p`.
--/
-lemma padic_norm_primes {p q: ℕ} [p_prime: fact (nat.prime p)] [q_prime: fact (nat.prime q)]
-  (neq: p ≠ q): padic_norm p q = 1 :=
+/-- The p-adic norm of `q` is `1` if `q` is prime and not equal to `p`. -/
+lemma padic_norm_of_prime_of_ne {p q : ℕ} [p_prime : fact p.prime] [q_prime : fact q.prime]
+  (neq : p ≠ q) : padic_norm p q = 1 :=
 begin
-  have p: padic_val_rat p q = 0,
-  exact_mod_cast @padic_val_nat_primes p q p_prime q_prime neq,
-  simp [padic_norm, p, q_prime.1, nat.prime.ne_zero q_prime],
+  have p : padic_val_rat p q = 0,
+  { exact_mod_cast @padic_val_nat_primes p q p_prime q_prime neq },
+  simp [padic_norm, p, q_prime.1, q_prime.ne_zero],
 end
 
 /--


### PR DESCRIPTION
The p-adic norm of `q` is `1` if `q` is another prime than `p`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
