### PR TITLE
[Merged by Bors] - feat(ring_theory/principal_ideal_domain): The generator of a principal prime ideal is a prime

### DIFF
--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -70,18 +70,12 @@ lemma eq_bot_iff_generator_eq_zero (S : submodule R M) [S.is_principal] :
   S = ⊥ ↔ generator S = 0 :=
 by rw [← @span_singleton_eq_bot R M, span_singleton_generator]
 
-lemma prime_generator_of_prime {α} [comm_ring α] (I: ideal α)
-  [submodule.is_principal I] [is_prime: ideal.is_prime I] (ne_bot: I ≠ ⊥) :
-  prime (submodule.is_principal.generator I) :=
-⟨ by { intro h,
-    rw ← submodule.is_principal.eq_bot_iff_generator_eq_zero I at h,
-    exact ne_bot h, },
-  by { intro h,
-    have p₁: I = ⊤,
-    from ideal.eq_top_of_is_unit_mem I (submodule.is_principal.generator_mem I) h,
-    exact is_prime.ne_top p₁, },
-  by { simp only [← submodule.is_principal.mem_iff_generator_dvd I], exact is_prime.2, }
-⟩
+lemma prime_generator_of_is_prime (S: ideal R) [submodule.is_principal S] [is_prime: S.is_prime]
+  (ne_bot: S ≠ ⊥) :
+  prime (generator S) :=
+⟨λ h, ne_bot ((eq_bot_iff_generator_eq_zero S).2 h),
+ λ h, is_prime.ne_top (S.eq_top_of_is_unit_mem (generator_mem S) h),
+ by simpa only [← mem_iff_generator_dvd S] using is_prime.2⟩
 
 end submodule.is_principal
 

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -70,6 +70,19 @@ lemma eq_bot_iff_generator_eq_zero (S : submodule R M) [S.is_principal] :
   S = ⊥ ↔ generator S = 0 :=
 by rw [← @span_singleton_eq_bot R M, span_singleton_generator]
 
+lemma prime_generator_of_prime {α} [comm_ring α] (I: ideal α)
+  [submodule.is_principal I] [is_prime: ideal.is_prime I] (ne_bot: I ≠ ⊥) :
+  prime (submodule.is_principal.generator I) :=
+⟨ by { intro h,
+    rw ← submodule.is_principal.eq_bot_iff_generator_eq_zero I at h,
+    exact ne_bot h, },
+  by { intro h,
+    have p₁: I = ⊤,
+    from ideal.eq_top_of_is_unit_mem I (submodule.is_principal.generator_mem I) h,
+    exact is_prime.ne_top p₁, },
+  by { simp only [← submodule.is_principal.mem_iff_generator_dvd I], exact is_prime.2, }
+⟩
+
 end submodule.is_principal
 
 namespace is_prime

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -70,8 +70,8 @@ lemma eq_bot_iff_generator_eq_zero (S : submodule R M) [S.is_principal] :
   S = ⊥ ↔ generator S = 0 :=
 by rw [← @span_singleton_eq_bot R M, span_singleton_generator]
 
-lemma prime_generator_of_is_prime (S: ideal R) [submodule.is_principal S] [is_prime: S.is_prime]
-  (ne_bot: S ≠ ⊥) :
+lemma prime_generator_of_is_prime (S : ideal R) [submodule.is_principal S] [is_prime : S.is_prime]
+  (ne_bot : S ≠ ⊥) :
   prime (generator S) :=
 ⟨λ h, ne_bot ((eq_bot_iff_generator_eq_zero S).2 h),
  λ h, is_prime.ne_top (S.eq_top_of_is_unit_mem (generator_mem S) h),


### PR DESCRIPTION
The generator of a principal prime ideal is a prime

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Proves that the generator of a principal prime ideal is a prime.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
