### PR TITLE
[Merged by Bors] - feat(algebra/associated): Primes that divide each other are associated

### DIFF
--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -316,14 +316,13 @@ lemma prime_of_associated [comm_monoid_with_zero α] {p q : α} (h : p ~ᵤ q) (
     ⟨λ ⟨v, hv⟩, hp.not_unit ⟨v * u⁻¹, by simp [hv, hu.symm]⟩,
       hu ▸ by { simp [units.mul_right_dvd], intros a b, exact hp.div_or_div }⟩⟩
 
-lemma primes_associated_of_dvd {α} [comm_cancel_monoid_with_zero α] {p q: α}
-  (p_prime: prime p) (q_prime: prime q) (dvd: p ∣ q): associated p q :=
-begin
-  cases dvd with c hc,
-  cases ((irreducible_of_prime q_prime).is_unit_or_is_unit hc)
-    .resolve_left p_prime.not_unit with u hu,
-  exact ⟨ u, by rw [hu, hc] ⟩,
-end
+lemma associated_of_irreducible_of_dvd [comm_cancel_monoid_with_zero α] {p q : α}
+  (p_irr : irreducible p) (q_irr : irreducible q) (dvd : p ∣ q) : associated p q :=
+associated_of_dvd_dvd dvd (dvd_symm_of_irreducible p_irr q_irr dvd)
+
+lemma associated_of_prime_of_dvd [comm_cancel_monoid_with_zero α] {p q : α}
+  (p_prime : prime p) (q_prime : prime q) (dvd : p ∣ q) : associated p q :=
+associated_of_irreducible_of_dvd (irreducible_of_prime p_prime) (irreducible_of_prime q_prime) dvd
 
 lemma prime_iff_of_associated [comm_monoid_with_zero α] {p q : α}
   (h : p ~ᵤ q) : prime p ↔ prime q :=

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -316,6 +316,15 @@ lemma prime_of_associated [comm_monoid_with_zero α] {p q : α} (h : p ~ᵤ q) (
     ⟨λ ⟨v, hv⟩, hp.not_unit ⟨v * u⁻¹, by simp [hv, hu.symm]⟩,
       hu ▸ by { simp [units.mul_right_dvd], intros a b, exact hp.div_or_div }⟩⟩
 
+lemma primes_associated_of_dvd {α} [comm_cancel_monoid_with_zero α] {p q: α}
+  (p_prime: prime p) (q_prime: prime q) (dvd: p ∣ q): associated p q :=
+begin
+  cases dvd with c hc,
+  cases ((irreducible_of_prime q_prime).is_unit_or_is_unit hc)
+    .resolve_left p_prime.not_unit with u hu,
+  exact ⟨ u, by rw [hu, hc] ⟩,
+end
+
 lemma prime_iff_of_associated [comm_monoid_with_zero α] {p q : α}
   (h : p ~ᵤ q) : prime p ↔ prime q :=
 ⟨prime_of_associated h, prime_of_associated h.symm⟩


### PR DESCRIPTION
Primes that divide each other are associated


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Proves this result (in `comm_cancel_monoid_with_zero`'s).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
