### PR TITLE
[Merged by Bors] - feat(ring_theory/int/basic): Induction, nat_abs and units

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -264,7 +264,7 @@ begin
   simpa using w₂,
 end
 
-lemma int.nat_abs_eq_nat_abs_iff {a b : ℤ} : a.nat_abs = b.nat_abs ↔ a = b ∨ a = -b :=
+lemma nat_abs_eq_nat_abs_iff {a b : ℤ} : a.nat_abs = b.nat_abs ↔ a = b ∨ a = -b :=
 begin
   split; intro h,
   { cases int.nat_abs_eq a with h₁ h₁; cases int.nat_abs_eq b with h₂ h₂;

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -264,6 +264,14 @@ begin
   simpa using w₂,
 end
 
+lemma int.nat_abs_eq_nat_abs_iff {a b : ℤ} : a.nat_abs = b.nat_abs ↔ a = b ∨ a = -b :=
+begin
+  split; intro h,
+  { cases int.nat_abs_eq a with h₁ h₁; cases int.nat_abs_eq b with h₂ h₂;
+    rw [h₁, h₂]; simp [h], },
+  { cases h; rw h, rw int.nat_abs_neg, },
+end
+
 lemma nat_abs_eq_iff_mul_self_eq {a b : ℤ} : a.nat_abs = b.nat_abs ↔ a * a = b * b :=
 begin
   rw [← abs_eq_iff_mul_self_eq, abs_eq_nat_abs, abs_eq_nat_abs],

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -342,7 +342,7 @@ instance decidable_int : decidable_rel (λ a b : ℤ, (multiplicity a b).dom) :=
 
 end multiplicity
 
-lemma induction_on_primes [P: nat → Prop] (h₁: P 0) (h₂: P 1)
+lemma induction_on_primes {P: nat → Prop} (h₁: P 0) (h₂: P 1)
   (h: ∀ p a: ℕ, nat.prime p → P a → P (p * a)): ∀ n: ℕ, P n :=
 begin
   intro n,
@@ -391,4 +391,4 @@ lemma int.associated_iff (a: ℤ) (b: ℤ): associated a b ↔ (a = b ∨ a = -b
 begin
   rw int.associated_iff_nat_abs,
   exact int.nat_abs_eq_nat_abs_iff,
-end
+endf

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson
 -/
 
+import data.int.basic
 import data.int.gcd
 import ring_theory.multiplicity
 import ring_theory.principal_ideal_domain

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -342,15 +342,14 @@ instance decidable_int : decidable_rel (λ a b : ℤ, (multiplicity a b).dom) :=
 
 end multiplicity
 
-lemma induction_on_primes {P : nat → Prop} (h₁ : P 0) (h₂ : P 1)
-  (h : ∀ p a : ℕ, nat.prime p → P a → P (p * a)) : ∀ n: ℕ, P n :=
+lemma induction_on_primes {P : nat → Prop} (h₀ : P 0) (h₁ : P 1)
+  (h : ∀ p a : ℕ, nat.prime p → P a → P (p * a)) (n : ℕ) : P n :=
 begin
-  intro n,
   apply unique_factorization_monoid.induction_on_prime,
-  exact h₁,
+  exact h₀,
   { intros n h,
     rw nat.is_unit_iff.1 h,
-    exact h₂, },
+    exact h₁, },
   { intros a p _ hp ha,
     exact h p a (nat.prime_iff_prime.2 hp) ha, },
 end
@@ -388,7 +387,7 @@ begin
   exact associated_iff_eq,
 end
 
-lemma int.associated_iff (a : ℤ) (b : ℤ) : associated a b ↔ (a = b ∨ a = -b) :=
+lemma int.associated_iff {a b : ℤ} : associated a b ↔ (a = b ∨ a = -b) :=
 begin
   rw int.associated_iff_nat_abs,
   exact int.nat_abs_eq_nat_abs_iff,

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -354,3 +354,49 @@ begin
   { intros a p _ hp ha,
     exact h p a (nat.prime_iff_prime.2 hp) ha, },
 end
+
+lemma int.associated_nat_abs (k: ℤ): associated k k.nat_abs :=
+begin
+  apply associated.symm,
+  unfold associated,
+  cases int.nat_abs_eq k with h h,
+  use 1, simp, exact h.symm,
+  use -1, simp, exact h.symm,
+end
+
+lemma int.prime_iff_nat_abs_prime {k: ℤ}: prime k ↔ nat.prime k.nat_abs :=
+begin
+  rw nat.prime_iff_prime_int,
+  rw prime_iff_of_associated (int.associated_nat_abs k),
+end
+
+lemma int.associated_iff (a: ℤ) (b: ℤ): associated a b ↔ (a = b ∨ a = -b) :=
+begin
+  split,
+  {
+    intro h,
+    rcases h with ⟨ u, h ⟩,
+    have p₁ := fintype.complete u,
+    cases p₁,
+    left, rw ← mul_one a, rw p₁ at h, exact h,
+    cases p₁,
+    right, rw p₁ at h, simp at h, linarith only [h],
+    exfalso, exact list.not_mem_nil u p₁,
+  },
+  {
+    intro h,
+    cases h,
+    rw h,
+    use -1, simp, linarith [h],
+  },
+end
+
+lemma units_int.values (u: units ℤ): u = 1 ∨ u = -1 :=
+begin
+  have p₁ := fintype.complete u,
+  cases p₁,
+  left, exact p₁,
+  cases p₁,
+  right, exact p₁,
+  exfalso, exact list.not_mem_nil u p₁,
+end

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -343,7 +343,7 @@ instance decidable_int : decidable_rel (λ a b : ℤ, (multiplicity a b).dom) :=
 end multiplicity
 
 lemma induction_on_primes {P : ℕ → Prop} (h₀ : P 0) (h₁ : P 1)
-  (h : ∀ p a : ℕ, nat.prime p → P a → P (p * a)) (n : ℕ) : P n :=
+  (h : ∀ p a : ℕ, p.prime → P a → P (p * a)) (n : ℕ) : P n :=
 begin
   apply unique_factorization_monoid.induction_on_prime,
   exact h₀,
@@ -361,14 +361,6 @@ lemma int.prime_iff_nat_abs_prime {k : ℤ} : prime k ↔ nat.prime k.nat_abs :=
 begin
   rw nat.prime_iff_prime_int,
   rw prime_iff_of_associated (int.associated_nat_abs k),
-end
-
-lemma int.nat_abs_eq_nat_abs_iff {a b : ℤ} : a.nat_abs = b.nat_abs ↔ a = b ∨ a = -b :=
-begin
-  split; intro h,
-  { cases int.nat_abs_eq a with h₁ h₁; cases int.nat_abs_eq b with h₂ h₂;
-    rw [h₁, h₂]; simp [h], },
-  { cases h; rw h, rw int.nat_abs_neg, },
 end
 
 theorem int.associated_iff_nat_abs {a b : ℤ} : associated a b ↔ a.nat_abs = b.nat_abs :=

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -341,3 +341,16 @@ instance decidable_int : decidable_rel (λ a b : ℤ, (multiplicity a b).dom) :=
 λ a b, decidable_of_iff _ finite_int_iff.symm
 
 end multiplicity
+
+lemma induction_on_primes [P: nat → Prop] (h₁: P 0) (h₂: P 1)
+  (h: ∀ p a: ℕ, nat.prime p → P a → P (p * a)): ∀ n: ℕ, P n :=
+begin
+  intro n,
+  apply unique_factorization_monoid.induction_on_prime,
+  exact h₁,
+  { intros n h,
+    rw nat.is_unit_iff.1 h,
+    exact h₂, },
+  { intros a p _ hp ha,
+    exact h p a (nat.prime_iff_prime.2 hp) ha, },
+end

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -356,13 +356,7 @@ begin
 end
 
 lemma int.associated_nat_abs (k: ℤ): associated k k.nat_abs :=
-begin
-  apply associated.symm,
-  unfold associated,
-  cases int.nat_abs_eq k with h h,
-  use 1, simp, exact h.symm,
-  use -1, simp, exact h.symm,
-end
+associated_of_dvd_dvd (int.coe_nat_dvd_right.mpr (dvd_refl _)) (int.nat_abs_dvd.mpr (dvd_refl _))
 
 lemma int.prime_iff_nat_abs_prime {k: ℤ}: prime k ↔ nat.prime k.nat_abs :=
 begin
@@ -370,33 +364,31 @@ begin
   rw prime_iff_of_associated (int.associated_nat_abs k),
 end
 
-lemma int.associated_iff (a: ℤ) (b: ℤ): associated a b ↔ (a = b ∨ a = -b) :=
+lemma int.nat_abs_eq_nat_abs_iff {a b : ℤ} : a.nat_abs = b.nat_abs ↔ a = b ∨ a = -b :=
 begin
   split,
-  {
-    intro h,
-    rcases h with ⟨ u, h ⟩,
-    have p₁ := fintype.complete u,
-    cases p₁,
-    left, rw ← mul_one a, rw p₁ at h, exact h,
-    cases p₁,
-    right, rw p₁ at h, simp at h, linarith only [h],
-    exfalso, exact list.not_mem_nil u p₁,
-  },
-  {
-    intro h,
-    cases h,
-    rw h,
-    use -1, simp, linarith [h],
-  },
+  { intro h,
+    apply_fun coe at h,
+    cases int.nat_abs_eq a with ha ha;
+    cases int.nat_abs_eq b with hb hb;
+    rw [ha, hb],
+    { left, exact h },
+    { right, rwa neg_neg },
+    { right, rw h },
+    { left, rw h } },
+  { rintro (rfl|rfl),
+    { refl },
+    { exact int.nat_abs_neg b } },
 end
 
-lemma units_int.values (u: units ℤ): u = 1 ∨ u = -1 :=
+theorem int.associated_iff_nat_abs {a b : ℤ} : associated a b ↔ a.nat_abs = b.nat_abs :=
 begin
-  have p₁ := fintype.complete u,
-  cases p₁,
-  left, exact p₁,
-  cases p₁,
-  right, exact p₁,
-  exfalso, exact list.not_mem_nil u p₁,
+  rw [←dvd_dvd_iff_associated, ←int.nat_abs_dvd_abs_iff, ←int.nat_abs_dvd_abs_iff, dvd_dvd_iff_associated],
+  exact associated_iff_eq,
+end
+
+lemma int.associated_iff (a: ℤ) (b: ℤ): associated a b ↔ (a = b ∨ a = -b) :=
+begin
+  rw int.associated_iff_nat_abs,
+  exact int.nat_abs_eq_nat_abs_iff,
 end

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -383,7 +383,8 @@ end
 
 theorem int.associated_iff_nat_abs {a b : ℤ} : associated a b ↔ a.nat_abs = b.nat_abs :=
 begin
-  rw [←dvd_dvd_iff_associated, ←int.nat_abs_dvd_abs_iff, ←int.nat_abs_dvd_abs_iff, dvd_dvd_iff_associated],
+  rw [←dvd_dvd_iff_associated, ←int.nat_abs_dvd_abs_iff, ←int.nat_abs_dvd_abs_iff,
+    dvd_dvd_iff_associated],
   exact associated_iff_eq,
 end
 
@@ -391,4 +392,4 @@ lemma int.associated_iff (a: ℤ) (b: ℤ): associated a b ↔ (a = b ∨ a = -b
 begin
   rw int.associated_iff_nat_abs,
   exact int.nat_abs_eq_nat_abs_iff,
-endf
+end

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -342,8 +342,8 @@ instance decidable_int : decidable_rel (λ a b : ℤ, (multiplicity a b).dom) :=
 
 end multiplicity
 
-lemma induction_on_primes {P: nat → Prop} (h₁: P 0) (h₂: P 1)
-  (h: ∀ p a: ℕ, nat.prime p → P a → P (p * a)): ∀ n: ℕ, P n :=
+lemma induction_on_primes {P : nat → Prop} (h₁ : P 0) (h₂ : P 1)
+  (h : ∀ p a : ℕ, nat.prime p → P a → P (p * a)) : ∀ n: ℕ, P n :=
 begin
   intro n,
   apply unique_factorization_monoid.induction_on_prime,
@@ -355,10 +355,10 @@ begin
     exact h p a (nat.prime_iff_prime.2 hp) ha, },
 end
 
-lemma int.associated_nat_abs (k: ℤ): associated k k.nat_abs :=
+lemma int.associated_nat_abs (k : ℤ) : associated k k.nat_abs :=
 associated_of_dvd_dvd (int.coe_nat_dvd_right.mpr (dvd_refl _)) (int.nat_abs_dvd.mpr (dvd_refl _))
 
-lemma int.prime_iff_nat_abs_prime {k: ℤ}: prime k ↔ nat.prime k.nat_abs :=
+lemma int.prime_iff_nat_abs_prime {k : ℤ} : prime k ↔ nat.prime k.nat_abs :=
 begin
   rw nat.prime_iff_prime_int,
   rw prime_iff_of_associated (int.associated_nat_abs k),
@@ -388,7 +388,7 @@ begin
   exact associated_iff_eq,
 end
 
-lemma int.associated_iff (a: ℤ) (b: ℤ): associated a b ↔ (a = b ∨ a = -b) :=
+lemma int.associated_iff (a : ℤ) (b : ℤ) : associated a b ↔ (a = b ∨ a = -b) :=
 begin
   rw int.associated_iff_nat_abs,
   exact int.nat_abs_eq_nat_abs_iff,

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -342,7 +342,7 @@ instance decidable_int : decidable_rel (λ a b : ℤ, (multiplicity a b).dom) :=
 
 end multiplicity
 
-lemma induction_on_primes {P : nat → Prop} (h₀ : P 0) (h₁ : P 1)
+lemma induction_on_primes {P : ℕ → Prop} (h₀ : P 0) (h₁ : P 1)
   (h : ∀ p a : ℕ, nat.prime p → P a → P (p * a)) (n : ℕ) : P n :=
 begin
   apply unique_factorization_monoid.induction_on_prime,
@@ -365,19 +365,10 @@ end
 
 lemma int.nat_abs_eq_nat_abs_iff {a b : ℤ} : a.nat_abs = b.nat_abs ↔ a = b ∨ a = -b :=
 begin
-  split,
-  { intro h,
-    apply_fun coe at h,
-    cases int.nat_abs_eq a with ha ha;
-    cases int.nat_abs_eq b with hb hb;
-    rw [ha, hb],
-    { left, exact h },
-    { right, rwa neg_neg },
-    { right, rw h },
-    { left, rw h } },
-  { rintro (rfl|rfl),
-    { refl },
-    { exact int.nat_abs_neg b } },
+  split; intro h,
+  { cases int.nat_abs_eq a with h₁ h₁; cases int.nat_abs_eq b with h₂ h₂;
+    rw [h₁, h₂]; simp [h], },
+  { cases h; rw h, rw int.nat_abs_neg, },
 end
 
 theorem int.associated_iff_nat_abs {a b : ℤ} : associated a b ↔ a.nat_abs = b.nat_abs :=


### PR DESCRIPTION
Proves : 
 * Induction on primes (special case for nat)
 * In `int`, a number and its `nat_abs` are associated
 * An integer is prime iff its `nat_abs` is prime
 * Two integers are associated iff they are equal or opposites
 * Classification of the units in `int` (trivial but handy lemma)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
