### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/exp_log): log_nonzero_of_ne_one and log_inj_pos

### DIFF
--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -475,8 +475,7 @@ end
 lemma log_nonpos (hx : 0 ≤ x) (h'x : x ≤ 1) : log x ≤ 0 :=
 (log_nonpos_iff' hx).2 h'x
 
-lemma log_inj_pos {x y : ℝ} (x_pos : 0 < x) (y_pos : 0 < y)
-  (h : log x = log y) : x = y :=
+lemma log_inj_pos {x y : ℝ} (x_pos : 0 < x) (y_pos : 0 < y) (h : log x = log y) : x = y :=
 le_antisymm
   ((log_le_log x_pos y_pos).1 $ h.le)
   ((log_le_log y_pos x_pos).1 $ h.symm.le)

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -476,15 +476,15 @@ lemma log_nonpos (hx : 0 ≤ x) (h'x : x ≤ 1) : log x ≤ 0 :=
 (log_nonpos_iff' hx).2 h'x
 
 lemma log_inj_pos {x y : ℝ} (x_pos : 0 < x) (y_pos : 0 < y)
-  (h : real.log x = real.log y) : x = y :=
+  (h : log x = log y) : x = y :=
 le_antisymm
   ((log_le_log x_pos y_pos).1 $ h.le)
   ((log_le_log y_pos x_pos).1 $ h.symm.le)
 
-lemma one_of_pos_of_log_eq_zero {x : ℝ} (h₁ : 0 < x) (h₂ : real.log x = 0) : x = 1 :=
+lemma one_of_pos_of_log_eq_zero {x : ℝ} (h₁ : 0 < x) (h₂ : log x = 0) : x = 1 :=
 log_inj_pos h₁ zero_lt_one (h₂.trans real.log_one.symm)
 
-lemma log_nonzero_of_ne_one (x : ℝ) (hx_pos : 0 < x) (hx : x ≠ 1) : real.log x ≠ 0 :=
+lemma log_nonzero_of_ne_one (x : ℝ) (hx_pos : 0 < x) (hx : x ≠ 1) : log x ≠ 0 :=
 mt (one_of_pos_of_log_eq_zero hx_pos) hx
 
 lemma strict_mono_incr_on_log : strict_mono_incr_on log (set.Ioi 0) :=

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -482,10 +482,7 @@ le_antisymm
   ((log_le_log y_pos x_pos).1 $ h.symm.le)
 
 lemma one_of_pos_of_log_eq_zero {x : ℝ} (h₁: 0 < x) (h₂: real.log x = 0) : x = 1 :=
-begin
-  apply log_inj_pos h₁ zero_lt_one,
-  rwa real.log_one,
-end
+log_inj_pos h₁ zero_lt_one (h₂.trans real.log_one.symm)
 
 lemma log_nonzero_of_ne_one (x : ℝ) (hx_pos : 0 < x) (hx : x ≠ 1) : real.log x ≠ 0 :=
 mt (one_of_pos_of_log_eq_zero hx_pos) hx

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -481,7 +481,7 @@ le_antisymm
   ((log_le_log x_pos y_pos).1 $ h.le)
   ((log_le_log y_pos x_pos).1 $ h.symm.le)
 
-lemma one_of_pos_of_log_eq_zero {x : ℝ} (h₁: 0 < x) (h₂: real.log x = 0) : x = 1 :=
+lemma one_of_pos_of_log_eq_zero {x : ℝ} (h₁ : 0 < x) (h₂ : real.log x = 0) : x = 1 :=
 log_inj_pos h₁ zero_lt_one (h₂.trans real.log_one.symm)
 
 lemma log_nonzero_of_ne_one (x : ℝ) (hx_pos : 0 < x) (hx : x ≠ 1) : real.log x ≠ 0 :=

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -475,19 +475,25 @@ end
 lemma log_nonpos (hx : 0 ≤ x) (h'x : x ≤ 1) : log x ≤ 0 :=
 (log_nonpos_iff' hx).2 h'x
 
-lemma log_nonzero_of_ne_one (x: ℝ) (hx_pos: 0 < x) (hx: x ≠ 1): real.log x ≠ 0 :=
+lemma log_nonzero_of_ne_one (x : ℝ) (hx_pos : 0 < x) (hx : x ≠ 1) : real.log x ≠ 0 :=
 begin
-  by_cases (1 < x),
-  exact ne_of_gt (log_pos h),
-  push_neg at h,
-  exact ne_of_lt (log_neg hx_pos (lt_of_le_of_ne h hx)),
+  by_cases h: 1 < x,
+  { exact ne_of_gt (log_pos h), },
+  { push_neg at h,
+   exact ne_of_lt (log_neg hx_pos (lt_of_le_of_ne h hx)), },
 end
 
-lemma log_inj_pos {x y: ℝ} (x_pos: 0 < x) (y_pos: 0 < y):
-  real.log x = real.log y → x = y :=
-λ h, le_antisymm
+lemma log_inj_pos {x y : ℝ} (x_pos : 0 < x) (y_pos : 0 < y)
+  (h: real.log x = real.log y) : x = y :=
+le_antisymm
   ((log_le_log x_pos y_pos).1 $ le_of_eq h)
-  ((log_le_log y_pos x_pos).1 $ le_of_eq $ eq.symm h)
+  ((log_le_log y_pos x_pos).1 $ h.symm.le)
+
+lemma one_of_pos_of_log_eq_zero {x : ℝ} (h₁: 0 < x) (h₂: real.log x = 0) : x = 1 :=
+begin
+  apply log_inj_pos h₁ zero_lt_one,
+  rwa real.log_one,
+end
 
 lemma strict_mono_incr_on_log : strict_mono_incr_on log (set.Ioi 0) :=
 λ x hx y hy hxy, log_lt_log hx hxy

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -492,7 +492,7 @@ strict_mono_incr_on_log.inj_on
 lemma one_of_pos_of_log_eq_zero {x : ℝ} (h₁ : 0 < x) (h₂ : log x = 0) : x = 1 :=
 log_inj_on_pos (set.mem_Ioi.2 h₁) (set.mem_Ioi.2 zero_lt_one) (h₂.trans real.log_one.symm)
 
-lemma log_nonzero_of_ne_one (x : ℝ) (hx_pos : 0 < x) (hx : x ≠ 1) : log x ≠ 0 :=
+lemma log_ne_zero_of_ne_one {x : ℝ} (hx_pos : 0 < x) (hx : x ≠ 1) : log x ≠ 0 :=
 mt (one_of_pos_of_log_eq_zero hx_pos) hx
 
 /-- The real logarithm function tends to `+∞` at `+∞`. -/

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -475,18 +475,10 @@ end
 lemma log_nonpos (hx : 0 ≤ x) (h'x : x ≤ 1) : log x ≤ 0 :=
 (log_nonpos_iff' hx).2 h'x
 
-lemma log_nonzero_of_ne_one (x : ℝ) (hx_pos : 0 < x) (hx : x ≠ 1) : real.log x ≠ 0 :=
-begin
-  by_cases h: 1 < x,
-  { exact ne_of_gt (log_pos h), },
-  { push_neg at h,
-   exact ne_of_lt (log_neg hx_pos (lt_of_le_of_ne h hx)), },
-end
-
 lemma log_inj_pos {x y : ℝ} (x_pos : 0 < x) (y_pos : 0 < y)
-  (h: real.log x = real.log y) : x = y :=
+  (h : real.log x = real.log y) : x = y :=
 le_antisymm
-  ((log_le_log x_pos y_pos).1 $ le_of_eq h)
+  ((log_le_log x_pos y_pos).1 $ h.le)
   ((log_le_log y_pos x_pos).1 $ h.symm.le)
 
 lemma one_of_pos_of_log_eq_zero {x : ℝ} (h₁: 0 < x) (h₂: real.log x = 0) : x = 1 :=
@@ -494,6 +486,9 @@ begin
   apply log_inj_pos h₁ zero_lt_one,
   rwa real.log_one,
 end
+
+lemma log_nonzero_of_ne_one (x : ℝ) (hx_pos : 0 < x) (hx : x ≠ 1) : real.log x ≠ 0 :=
+mt (one_of_pos_of_log_eq_zero hx_pos) hx
 
 lemma strict_mono_incr_on_log : strict_mono_incr_on log (set.Ioi 0) :=
 λ x hx y hy hxy, log_lt_log hx hxy

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -475,18 +475,6 @@ end
 lemma log_nonpos (hx : 0 ≤ x) (h'x : x ≤ 1) : log x ≤ 0 :=
 (log_nonpos_iff' hx).2 h'x
 
-lemma log_inj_pos {x y : ℝ} (x_pos : 0 < x) (y_pos : 0 < y)
-  (h : log x = log y) : x = y :=
-le_antisymm
-  ((log_le_log x_pos y_pos).1 $ h.le)
-  ((log_le_log y_pos x_pos).1 $ h.symm.le)
-
-lemma one_of_pos_of_log_eq_zero {x : ℝ} (h₁ : 0 < x) (h₂ : log x = 0) : x = 1 :=
-log_inj_pos h₁ zero_lt_one (h₂.trans real.log_one.symm)
-
-lemma log_nonzero_of_ne_one (x : ℝ) (hx_pos : 0 < x) (hx : x ≠ 1) : log x ≠ 0 :=
-mt (one_of_pos_of_log_eq_zero hx_pos) hx
-
 lemma strict_mono_incr_on_log : strict_mono_incr_on log (set.Ioi 0) :=
 λ x hx y hy hxy, log_lt_log hx hxy
 
@@ -497,6 +485,15 @@ begin
   refine log_lt_log (abs_pos.2 hy.ne) _,
   rwa [abs_of_neg hy, abs_of_neg hx, neg_lt_neg_iff]
 end
+
+lemma log_inj_on_pos : set.inj_on log (set.Ioi 0) :=
+strict_mono_incr_on_log.inj_on
+
+lemma one_of_pos_of_log_eq_zero {x : ℝ} (h₁ : 0 < x) (h₂ : log x = 0) : x = 1 :=
+log_inj_on_pos (set.mem_Ioi.2 h₁) (set.mem_Ioi.2 zero_lt_one) (h₂.trans real.log_one.symm)
+
+lemma log_nonzero_of_ne_one (x : ℝ) (hx_pos : 0 < x) (hx : x ≠ 1) : log x ≠ 0 :=
+mt (one_of_pos_of_log_eq_zero hx_pos) hx
 
 /-- The real logarithm function tends to `+∞` at `+∞`. -/
 lemma tendsto_log_at_top : tendsto log at_top at_top :=

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -489,11 +489,11 @@ end
 lemma log_inj_on_pos : set.inj_on log (set.Ioi 0) :=
 strict_mono_incr_on_log.inj_on
 
-lemma one_of_pos_of_log_eq_zero {x : ℝ} (h₁ : 0 < x) (h₂ : log x = 0) : x = 1 :=
+lemma eq_one_of_pos_of_log_eq_zero {x : ℝ} (h₁ : 0 < x) (h₂ : log x = 0) : x = 1 :=
 log_inj_on_pos (set.mem_Ioi.2 h₁) (set.mem_Ioi.2 zero_lt_one) (h₂.trans real.log_one.symm)
 
-lemma log_ne_zero_of_ne_one {x : ℝ} (hx_pos : 0 < x) (hx : x ≠ 1) : log x ≠ 0 :=
-mt (one_of_pos_of_log_eq_zero hx_pos) hx
+lemma log_ne_zero_of_pos_of_ne_one {x : ℝ} (hx_pos : 0 < x) (hx : x ≠ 1) : log x ≠ 0 :=
+mt (eq_one_of_pos_of_log_eq_zero hx_pos) hx
 
 /-- The real logarithm function tends to `+∞` at `+∞`. -/
 lemma tendsto_log_at_top : tendsto log at_top at_top :=

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -475,6 +475,20 @@ end
 lemma log_nonpos (hx : 0 ≤ x) (h'x : x ≤ 1) : log x ≤ 0 :=
 (log_nonpos_iff' hx).2 h'x
 
+lemma log_nonzero_of_ne_one (x: ℝ) (hx_pos: 0 < x) (hx: x ≠ 1): real.log x ≠ 0 :=
+begin
+  by_cases (1 < x),
+  exact ne_of_gt (log_pos h),
+  push_neg at h,
+  exact ne_of_lt (log_neg hx_pos (lt_of_le_of_ne h hx)),
+end
+
+lemma log_inj_pos {x y: ℝ} (x_pos: 0 < x) (y_pos: 0 < y):
+  real.log x = real.log y → x = y :=
+λ h, le_antisymm
+  ((log_le_log x_pos y_pos).1 $ le_of_eq h)
+  ((log_le_log y_pos x_pos).1 $ le_of_eq $ eq.symm h)
+
 lemma strict_mono_incr_on_log : strict_mono_incr_on log (set.Ioi 0) :=
 λ x hx y hy hxy, log_lt_log hx hxy
 


### PR DESCRIPTION
log_nonzero_of_ne_one and log_inj_pos

Proves : 
 * When `x > 0`, `log(x)` is `0` iff `x = 1`
 * The real logarithm is injective (when restraining the domain to the positive reals)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
