### PR TITLE
[Merged by Bors] - feat(data/finset): erase is partially injective

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -897,6 +897,14 @@ subset_insert_iff.1 $ subset.refl _
 theorem insert_erase_subset (a : α) (s : finset α) : s ⊆ insert a (erase s a) :=
 subset_insert_iff.2 $ subset.refl _
 
+lemma erase_inj_on {α : Type*} [decidable_eq α] {x y : α} (s : finset α) (hx : x ∈ s)
+  (h : s.erase x = s.erase y) :
+  x = y :=
+begin
+  rw eq_of_mem_of_not_mem_erase hx,
+  simp [←h],
+end
+
 /-! ### sdiff -/
 
 /-- `s \ t` is the set consisting of the elements of `s` that are not in `t`. -/

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -897,12 +897,13 @@ subset_insert_iff.1 $ subset.refl _
 theorem insert_erase_subset (a : α) (s : finset α) : s ⊆ insert a (erase s a) :=
 subset_insert_iff.2 $ subset.refl _
 
-lemma erase_inj_of_mem {x y : α} (s : finset α) (hx : x ∈ s)
-  (h : s.erase x = s.erase y) :
-  x = y :=
+lemma erase_inj {x y : α} (s : finset α) (hx : x ∈ s) :
+  s.erase x = s.erase y ↔ x = y :=
 begin
+  refine ⟨λ h, _, congr_arg _⟩,
   rw eq_of_mem_of_not_mem_erase hx,
-  simp [←h],
+  rw ←h,
+  simp,
 end
 
 /-! ### sdiff -/

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -897,7 +897,7 @@ subset_insert_iff.1 $ subset.refl _
 theorem insert_erase_subset (a : α) (s : finset α) : s ⊆ insert a (erase s a) :=
 subset_insert_iff.2 $ subset.refl _
 
-lemma erase_inj_on {α : Type*} [decidable_eq α] {x y : α} (s : finset α) (hx : x ∈ s)
+lemma erase_inj_of_mem {x y : α} (s : finset α) (hx : x ∈ s)
   (h : s.erase x = s.erase y) :
   x = y :=
 begin


### PR DESCRIPTION
Show that erase is partially injective, ie that if `s.erase x = s.erase y` and `x` is in `s`, then `x = y`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
