### PR TITLE
[Merged by Bors] - chore(field_theory/splitting_field): module doc and generalise one lemma

### DIFF
--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -144,7 +144,7 @@ begin
   intros x hx, simp [h x hx]
 end
 
-lemma nat_degree_multiset_prod [nontrivial R] {s : multiset (polynomial R)}
+lemma nat_degree_multiset_prod [nontrivial R] (s : multiset (polynomial R))
   (h : (0 : polynomial R) ∉ s) :
   nat_degree s.prod = (s.map nat_degree).sum :=
 begin

--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson, Jalex Stark.
 -/
 import data.polynomial.monic
+import data.polynomial.ring_division
 import tactic.linarith
 /-!
 # Lemmas for the interaction between polynomials and `∑` and `∏`.
@@ -141,6 +142,20 @@ begin
   apply nat_degree_prod',
   rw prod_ne_zero_iff,
   intros x hx, simp [h x hx],
+end
+
+lemma nat_degree_multiset_prod {S : Type*} [integral_domain S] {s : multiset (polynomial S)}
+  (h : (0 : polynomial S) ∉ s) :
+  nat_degree s.prod = (s.map nat_degree).sum :=
+begin
+  revert h,
+  refine s.induction_on _ _,
+  { simp },
+  intros p s ih h,
+  rw [multiset.mem_cons, not_or_distrib] at h,
+  have hprod : s.prod ≠ 0 := multiset.prod_ne_zero h.2,
+  rw [multiset.prod_cons, nat_degree_mul (ne.symm h.1) hprod, ih h.2,
+    multiset.map_cons, multiset.sum_cons],
 end
 
 /--

--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -141,11 +141,11 @@ lemma nat_degree_prod [nontrivial R] (h : ∀ i ∈ s, f i ≠ 0) :
 begin
   apply nat_degree_prod',
   rw prod_ne_zero_iff,
-  intros x hx, simp [h x hx],
+  intros x hx, simp [h x hx]
 end
 
-lemma nat_degree_multiset_prod {S : Type*} [integral_domain S] {s : multiset (polynomial S)}
-  (h : (0 : polynomial S) ∉ s) :
+lemma nat_degree_multiset_prod [nontrivial R] {s : multiset (polynomial R)}
+  (h : (0 : polynomial R) ∉ s) :
   nat_degree s.prod = (s.map nat_degree).sum :=
 begin
   revert h,
@@ -155,7 +155,7 @@ begin
   rw [multiset.mem_cons, not_or_distrib] at h,
   have hprod : s.prod ≠ 0 := multiset.prod_ne_zero h.2,
   rw [multiset.prod_cons, nat_degree_mul (ne.symm h.1) hprod, ih h.2,
-    multiset.map_cons, multiset.sum_cons],
+    multiset.map_cons, multiset.sum_cons]
 end
 
 /--

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -51,14 +51,11 @@ section no_zero_divisors
 variables [comm_ring R] [no_zero_divisors R] {p q : polynomial R}
 
 instance : no_zero_divisors (polynomial R) :=
-{ eq_zero_or_eq_zero_of_mul_eq_zero :=
-    begin
-      intros p q hpq,
-      have : leading_coeff 0 = leading_coeff p * leading_coeff q := hpq ▸ leading_coeff_mul p q,
-      rw [leading_coeff_zero, eq_comm] at this,
-      erw [← leading_coeff_eq_zero, ← leading_coeff_eq_zero],
-      exact eq_zero_or_eq_zero_of_mul_eq_zero this
-    end }
+{ eq_zero_or_eq_zero_of_mul_eq_zero := λ a b h, begin
+    rw [← leading_coeff_eq_zero, ← leading_coeff_eq_zero],
+    refine eq_zero_or_eq_zero_of_mul_eq_zero _,
+    rw [← leading_coeff_zero, ← leading_coeff_mul, h],
+  end }
 
 lemma nat_degree_mul (hp : p ≠ 0) (hq : q ≠ 0) : nat_degree (p * q) =
   nat_degree p + nat_degree q :=

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -52,13 +52,13 @@ variables [comm_ring R] [no_zero_divisors R] {p q : polynomial R}
 
 instance : no_zero_divisors (polynomial R) :=
 { eq_zero_or_eq_zero_of_mul_eq_zero :=
-begin
-  intros p q hpq,
-  have : leading_coeff 0 = leading_coeff p * leading_coeff q := hpq ▸ leading_coeff_mul p q,
-  rw [leading_coeff_zero, eq_comm] at this,
-  erw [← leading_coeff_eq_zero, ← leading_coeff_eq_zero],
-  exact eq_zero_or_eq_zero_of_mul_eq_zero this
-end }
+    begin
+      intros p q hpq,
+      have : leading_coeff 0 = leading_coeff p * leading_coeff q := hpq ▸ leading_coeff_mul p q,
+      rw [leading_coeff_zero, eq_comm] at this,
+      erw [← leading_coeff_eq_zero, ← leading_coeff_eq_zero],
+      exact eq_zero_or_eq_zero_of_mul_eq_zero this
+    end }
 
 lemma nat_degree_mul (hp : p ≠ 0) (hq : q ≠ 0) : nat_degree (p * q) =
   nat_degree p + nat_degree q :=

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -47,33 +47,24 @@ eval₂_mod_by_monic_eq_self_of_root hq hx
 
 end comm_ring
 
-section integral_domain
-variables [integral_domain R] {p q : polynomial R}
+section no_zero_divisors
+variables [comm_ring R] [no_zero_divisors R] {p q : polynomial R}
 
-instance : integral_domain (polynomial R) :=
-{ eq_zero_or_eq_zero_of_mul_eq_zero := λ a b h, begin
-    have : leading_coeff 0 = leading_coeff a * leading_coeff b := h ▸ leading_coeff_mul a b,
-    rw [leading_coeff_zero, eq_comm] at this,
-    erw [← leading_coeff_eq_zero, ← leading_coeff_eq_zero],
-    exact eq_zero_or_eq_zero_of_mul_eq_zero this
-  end,
-  ..polynomial.nontrivial,
-  ..polynomial.comm_ring }
+instance : no_zero_divisors (polynomial R) :=
+{ eq_zero_or_eq_zero_of_mul_eq_zero :=
+begin
+  intros p q hpq,
+  have : leading_coeff 0 = leading_coeff p * leading_coeff q := hpq ▸ leading_coeff_mul p q,
+  rw [leading_coeff_zero, eq_comm] at this,
+  erw [← leading_coeff_eq_zero, ← leading_coeff_eq_zero],
+  exact eq_zero_or_eq_zero_of_mul_eq_zero this
+end }
 
 lemma nat_degree_mul (hp : p ≠ 0) (hq : q ≠ 0) : nat_degree (p * q) =
   nat_degree p + nat_degree q :=
 by rw [← with_bot.coe_eq_coe, ← degree_eq_nat_degree (mul_ne_zero hp hq),
     with_bot.coe_add, ← degree_eq_nat_degree hp,
     ← degree_eq_nat_degree hq, degree_mul]
-
-lemma nat_trailing_degree_mul (hp : p ≠ 0) (hq : q ≠ 0) :
-  (p * q).nat_trailing_degree = p.nat_trailing_degree + q.nat_trailing_degree :=
-begin
-  simp only [←nat.sub_eq_of_eq_add (nat_degree_eq_reverse_nat_degree_add_nat_trailing_degree _)],
-  rw [reverse_mul_of_domain, nat_degree_mul hp hq, nat_degree_mul (mt reverse_eq_zero.mp hp)
-    (mt reverse_eq_zero.mp hq), reverse_nat_degree, reverse_nat_degree, ←nat.sub_sub, nat.add_comm,
-    nat.add_sub_assoc (nat.sub_le _ _), add_comm, nat.add_sub_assoc (nat.sub_le _ _)],
-end
 
 @[simp] lemma nat_degree_pow (p : polynomial R) (n : ℕ) :
   nat_degree (p ^ n) = n * nat_degree p :=
@@ -100,6 +91,25 @@ theorem nat_degree_le_of_dvd {p q : polynomial R} (h1 : p ∣ q) (h2 : q ≠ 0) 
 begin
   rcases h1 with ⟨q, rfl⟩, rw mul_ne_zero_iff at h2,
   rw [nat_degree_mul h2.1 h2.2], exact nat.le_add_right _ _
+end
+
+end no_zero_divisors
+
+section integral_domain
+variables [integral_domain R] {p q : polynomial R}
+
+instance : integral_domain (polynomial R) :=
+{ ..polynomial.no_zero_divisors,
+  ..polynomial.nontrivial,
+  ..polynomial.comm_ring }
+
+lemma nat_trailing_degree_mul (hp : p ≠ 0) (hq : q ≠ 0) :
+  (p * q).nat_trailing_degree = p.nat_trailing_degree + q.nat_trailing_degree :=
+begin
+  simp only [←nat.sub_eq_of_eq_add (nat_degree_eq_reverse_nat_degree_add_nat_trailing_degree _)],
+  rw [reverse_mul_of_domain, nat_degree_mul hp hq, nat_degree_mul (mt reverse_eq_zero.mp hp)
+    (mt reverse_eq_zero.mp hq), reverse_nat_degree, reverse_nat_degree, ←nat.sub_sub, nat.add_comm,
+    nat.add_sub_assoc (nat.sub_le _ _), add_comm, nat.add_sub_assoc (nat.sub_le _ _)],
 end
 
 section roots

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
-
-Definition of splitting fields, and definition of homomorphism into any field that splits
 -/
 import ring_theory.adjoin_root
 import ring_theory.algebra_tower
@@ -12,6 +10,37 @@ import ring_theory.polynomial
 import field_theory.minpoly
 import linear_algebra.finite_dimensional
 import tactic.field_simp
+
+/-!
+# Splitting fields
+
+Definition of splitting fields, and definition of homomorphism into any field that splits
+
+## Main definitions
+
+* `splits`: A predicate on a polynomial saying that it is zero or all of its irreducible factors
+  have degree `1`.
+* `splitting_field f`: A splitting field of the polynomial `f`.
+* `is_splitting_field`: A predicate on a field to be a splitting field of a polynomial `f`.
+
+## Main statements
+
+* `C_leading_coeff_mul_prod_multiset_X_sub_C`: If a polynomial has as many roots as its degree, it
+  can be written as the product of its leading coefficient with `∏ (X - a)` where `a` ranges through
+  its roots.
+* `lift_of_splits`: If `K` and `L` are field extensions of a field `F` and for some finite subset
+  `S` of `K`, the minimal polynomial of every `x ∈ K` splits as a polynomial with coefficients in
+  `L`, then `algebra.adjoin F S` embeds into `L`.
+* `lift`: An embedding of the splitting field of the polynomial `f` into another field such that `f`
+  splits.
+* `alg_equiv`: Every splitting field of a polynomial `f` is isomorpic to `splitting_field f` and
+  thus, being a splitting field is unique up to isomorphism.
+
+## TODO
+
+* Move `nat_degree_multiset_prod` to another file.
+
+-/
 
 noncomputable theory
 open_locale classical big_operators
@@ -343,7 +372,7 @@ begin
   exact splits_of_splits_id _ h
 end
 
-/-- A monic polynomial `p` that has as much roots as its degree
+/-- A monic polynomial `p` that has as many roots as its degree
 can be written `p = ∏(X - a)`, for `a` in `p.roots`. -/
 lemma prod_multiset_X_sub_C_of_monic_of_roots_card_eq {p : polynomial α}
   (hmonic : p.monic) (hroots : p.roots.card = p.nat_degree) :
@@ -372,7 +401,7 @@ begin
   exact eq_of_monic_of_associated hprodmonic hmonic hassoc
 end
 
-/-- A polynomial `p` that has as much roots as its degree
+/-- A polynomial `p` that has as many roots as its degree
 can be written `p = p.leading_coeff * ∏(X - a)`, for `a` in `p.roots`. -/
 lemma C_leading_coeff_mul_prod_multiset_X_sub_C {p : polynomial α}
   (hroots : p.roots.card = p.nat_degree) :
@@ -395,7 +424,7 @@ begin
     ... = p : by simp only [mul_one, ring_hom.map_one], },
 end
 
-/-- A polynomial splits if and only if it has as much roots as its degree. -/
+/-- A polynomial splits if and only if it has as many roots as its degree. -/
 lemma splits_iff_card_roots {p : polynomial α} :
   splits (ring_hom.id α) p ↔ p.roots.card = p.nat_degree :=
 begin

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -23,8 +23,8 @@ if it is the smallest field extension of `K` such that `f` splits.
 
 ## Main definitions
 
-* `polynomial.splits i f`: A predicate on a field homomorphism `i : K → L` and a polynomial `f` saying
-  that `f` is zero or all of its irreducible factors over `L` have degree `1`.
+* `polynomial.splits i f`: A predicate on a field homomorphism `i : K → L` and a polynomial `f`
+  saying that `f` is zero or all of its irreducible factors over `L` have degree `1`.
 * `polynomial.splitting_field f`: A fixed splitting field of the polynomial `f`.
 * `polynomial.is_splitting_field`: A predicate on a field to be a splitting field of a polynomial
   `f`.
@@ -295,7 +295,7 @@ begin
   have : (0 : polynomial L) ∉ (map i p).roots.map (λ a, X - C a),
     from zero_nmem_multiset_map_X_sub_C _ _,
   simp [nat_degree_mul (left_ne_zero_of_mul map_ne_zero) (right_ne_zero_of_mul map_ne_zero),
-        nat_degree_multiset_prod this]
+        nat_degree_multiset_prod _ this]
 end
 
 lemma degree_eq_card_roots {p : polynomial K} {i : K →+* L} (p_ne_zero : p ≠ 0)
@@ -370,7 +370,7 @@ begin
   { simp only [prod_multiset_root_eq_finset_root (ne_zero_of_monic hmonic),
       monic_prod_of_monic, monic_X_sub_C, monic_pow, forall_true_iff] },
   have hdegree : (multiset.map (λ (a : K), X - C a) p.roots).prod.nat_degree = p.nat_degree,
-  { rw [← hroots, nat_degree_multiset_prod (zero_nmem_multiset_map_X_sub_C _ (λ a : K, a))],
+  { rw [← hroots, nat_degree_multiset_prod _ (zero_nmem_multiset_map_X_sub_C _ (λ a : K, a))],
     simp only [eq_self_iff_true, mul_one, nat.cast_id, nsmul_eq_mul, multiset.sum_repeat,
       multiset.map_const,nat_degree_X_sub_C, function.comp, multiset.map_map] },
   obtain ⟨q, hq⟩ := prod_multiset_X_sub_C_dvd p,

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -23,7 +23,7 @@ if it is the smallest field extension of `K` such that `f` splits.
 
 ## Main definitions
 
-* `polynomial.splits i f`: A predicate on a field homomorphism `f : K → L` and a polynomial saying
+* `polynomial.splits i f`: A predicate on a field homomorphism `i : K → L` and a polynomial `f` saying
   that `f` is zero or all of its irreducible factors over `L` have degree `1`.
 * `polynomial.splitting_field f`: A fixed splitting field of the polynomial `f`.
 * `polynomial.is_splitting_field`: A predicate on a field to be a splitting field of a polynomial

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -10,6 +10,7 @@ import ring_theory.polynomial
 import field_theory.minpoly
 import linear_algebra.finite_dimensional
 import tactic.field_simp
+import algebra.polynomial.big_operators
 
 /-!
 # Splitting fields
@@ -41,9 +42,6 @@ if it is the smallest field extension of `K` such that `f` splits.
 * `polynomial.is_splitting_field.alg_equiv`: Every splitting field of a polynomial `f` is isomorpic
   to `splitting_field f` and thus, being a splitting field is unique up to isomorphism.
 
-## TODO
-
-* Move `nat_degree_multiset_prod` to another file.
 -/
 
 noncomputable theory
@@ -283,20 +281,6 @@ begin
   apply polynomial.map_injective _ i.injective,
   rw [eq_prod_roots_of_splits h_splits, h_roots],
   simp,
-end
-
-lemma nat_degree_multiset_prod {R : Type*} [integral_domain R] {s : multiset (polynomial R)}
-  (h : (0 : polynomial R) ∉ s) :
-  nat_degree s.prod = (s.map nat_degree).sum :=
-begin
-  revert h,
-  refine s.induction_on _ _,
-  { simp },
-  intros p s ih h,
-  rw [multiset.mem_cons, not_or_distrib] at h,
-  have hprod : s.prod ≠ 0 := multiset.prod_ne_zero h.2,
-  rw [multiset.prod_cons, nat_degree_mul (ne.symm h.1) hprod, ih h.2,
-    multiset.map_cons, multiset.sum_cons],
 end
 
 lemma nat_degree_eq_card_roots {p : polynomial K} {i : K →+* L}

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -152,7 +152,7 @@ theorem splits_mul_iff {f g : polynomial K} (hf : f ≠ 0) (hg : g ≠ 0) :
   (f * g).splits i ↔ f.splits i ∧ g.splits i :=
 ⟨splits_of_splits_mul i (mul_ne_zero hf hg), λ ⟨hfs, hgs⟩, splits_mul i hfs hgs⟩
 
-theorem splits_prod {ι : Type w} {s : ι → polynomial K} {t : finset ι} :
+theorem splits_prod {ι : Type u} {s : ι → polynomial K} {t : finset ι} :
   (∀ j ∈ t, (s j).splits i) → (∏ x in t, s x).splits i :=
 begin
   refine finset.induction_on t (λ _, splits_one i) (λ a t hat ih ht, _),
@@ -168,7 +168,7 @@ end
 
 lemma splits_X_pow (n : ℕ) : (X ^ n).splits i := splits_pow i (splits_X i) n
 
-theorem splits_prod_iff {ι : Type w} {s : ι → polynomial K} {t : finset ι} :
+theorem splits_prod_iff {ι : Type u} {s : ι → polynomial K} {t : finset ι} :
   (∀ j ∈ t, s j ≠ 0) → ((∏ x in t, s x).splits i ↔ ∀ j ∈ t, (s j).splits i) :=
 begin
   refine finset.induction_on t (λ _, ⟨λ _ _ h, h.elim, λ _, splits_one i⟩) (λ a t hat ih ht, _),

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -49,7 +49,7 @@ open_locale classical big_operators
 
 universes u v w
 
-variables {K : Type u} {L : Type v} {F : Type w}
+variables {F : Type u} {K : Type v} {L : Type w}
 
 namespace polynomial
 
@@ -690,15 +690,15 @@ instance splitting_field (f : polynomial K) : is_splitting_field K (splitting_fi
 
 section scalar_tower
 
-variables {K L F} [algebra L F] [algebra K F] [is_scalar_tower K L F]
+variables {K L F} [algebra F K] [algebra F L] [is_scalar_tower F K L]
 
 variables {K}
-instance map (f : polynomial K) [is_splitting_field K F f] :
-  is_splitting_field L F (f.map $ algebra_map K L) :=
-⟨by { rw [splits_map_iff, ← is_scalar_tower.algebra_map_eq], exact splits F f },
- subalgebra.res_inj K $ by { rw [map_map, ← is_scalar_tower.algebra_map_eq, subalgebra.res_top,
-    eq_top_iff, ← adjoin_roots F f, algebra.adjoin_le_iff],
-  exact λ x hx, @algebra.subset_adjoin L _ _ _ _ _ _ hx }⟩
+instance map (f : polynomial F) [is_splitting_field F L f] :
+  is_splitting_field K L (f.map $ algebra_map F K) :=
+⟨by { rw [splits_map_iff, ← is_scalar_tower.algebra_map_eq], exact splits L f },
+ subalgebra.res_inj F $ by { rw [map_map, ← is_scalar_tower.algebra_map_eq, subalgebra.res_top,
+    eq_top_iff, ← adjoin_roots L f, algebra.adjoin_le_iff],
+  exact λ x hx, @algebra.subset_adjoin K _ _ _ _ _ _ hx }⟩
 
 variables {K} (L)
 theorem splits_iff (f : polynomial K) [is_splitting_field K L f] :
@@ -711,16 +711,16 @@ theorem splits_iff (f : polynomial K) [is_splitting_field K L f] :
   ring_equiv.trans_symm (ring_equiv.of_bijective _ $ algebra.bijective_algebra_map_iff.2 h) ▸
   by { rw ring_equiv.to_ring_hom_trans, exact splits_comp_of_splits _ _ (splits L f) }⟩
 
-theorem mul (f g : polynomial K) (hf : f ≠ 0) (hg : g ≠ 0) [is_splitting_field K L f]
-  [is_splitting_field L F (g.map $ algebra_map K L)] :
-  is_splitting_field K F (f * g) :=
-⟨(is_scalar_tower.algebra_map_eq K L F).symm ▸ splits_mul _
-  (splits_comp_of_splits _ _ (splits L f))
-  ((splits_map_iff _ _).1 (splits F $ g.map $ algebra_map K L)),
- by rw [map_mul, roots_mul (mul_ne_zero (map_ne_zero hf : f.map (algebra_map K F) ≠ 0)
+theorem mul (f g : polynomial F) (hf : f ≠ 0) (hg : g ≠ 0) [is_splitting_field F K f]
+  [is_splitting_field K L (g.map $ algebra_map F K)] :
+  is_splitting_field F L (f * g) :=
+⟨(is_scalar_tower.algebra_map_eq F K L).symm ▸ splits_mul _
+  (splits_comp_of_splits _ _ (splits K f))
+  ((splits_map_iff _ _).1 (splits L $ g.map $ algebra_map F K)),
+ by rw [map_mul, roots_mul (mul_ne_zero (map_ne_zero hf : f.map (algebra_map F L) ≠ 0)
         (map_ne_zero hg)), multiset.to_finset_add, finset.coe_union, algebra.adjoin_union,
-      is_scalar_tower.algebra_map_eq K L F, ← map_map,
-      roots_map (algebra_map L F) ((splits_id_iff_splits $ algebra_map K L).2 $ splits L f),
+      is_scalar_tower.algebra_map_eq F K L, ← map_map,
+      roots_map (algebra_map K L) ((splits_id_iff_splits $ algebra_map F K).2 $ splits K f),
       multiset.to_finset_map, finset.coe_image, algebra.adjoin_algebra_map, adjoin_roots,
       algebra.map_top, is_scalar_tower.range_under_adjoin, ← map_map, adjoin_roots,
       subalgebra.res_top]⟩

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -14,32 +14,36 @@ import tactic.field_simp
 /-!
 # Splitting fields
 
-Definition of splitting fields, and definition of homomorphism into any field that splits
+This file introduces the notion of a splitting field of a polynomial and provides an embedding from
+a splitting field to any field that splits the polynomial. A polynomial `f : polynomial K` splits
+over a field extension `L` of `K` if it is zero or all of its irreducible factors over `L` have
+degree `1`. A field extension of `K` of a polynomial `f : polynomial K` is called a splitting field
+if it is the smallest field extension of `K` such that `f` splits.
 
 ## Main definitions
 
-* `splits`: A predicate on a polynomial saying that it is zero or all of its irreducible factors
-  have degree `1`.
-* `splitting_field f`: A splitting field of the polynomial `f`.
-* `is_splitting_field`: A predicate on a field to be a splitting field of a polynomial `f`.
+* `polynomial.splits i f`: A predicate on a field homomorphism `f : K → L` and a polynomial saying
+  that `f` is zero or all of its irreducible factors over `L` have degree `1`.
+* `polynomial.splitting_field f`: A fixed splitting field of the polynomial `f`.
+* `polynomial.is_splitting_field`: A predicate on a field to be a splitting field of a polynomial
+  `f`.
 
 ## Main statements
 
-* `C_leading_coeff_mul_prod_multiset_X_sub_C`: If a polynomial has as many roots as its degree, it
-  can be written as the product of its leading coefficient with `∏ (X - a)` where `a` ranges through
-  its roots.
+* `polynomial.C_leading_coeff_mul_prod_multiset_X_sub_C`: If a polynomial has as many roots as its
+  degree, it can be written as the product of its leading coefficient with `∏ (X - a)` where `a`
+  ranges through its roots.
 * `lift_of_splits`: If `K` and `L` are field extensions of a field `F` and for some finite subset
   `S` of `K`, the minimal polynomial of every `x ∈ K` splits as a polynomial with coefficients in
   `L`, then `algebra.adjoin F S` embeds into `L`.
-* `lift`: An embedding of the splitting field of the polynomial `f` into another field such that `f`
-  splits.
-* `alg_equiv`: Every splitting field of a polynomial `f` is isomorpic to `splitting_field f` and
-  thus, being a splitting field is unique up to isomorphism.
+* `polynomial.is_splitting_field.lift`: An embedding of a splitting field of the polynomial `f` into
+  another field such that `f` splits.
+* `polynomial.is_splitting_field.alg_equiv`: Every splitting field of a polynomial `f` is isomorpic
+  to `splitting_field f` and thus, being a splitting field is unique up to isomorphism.
 
 ## TODO
 
 * Move `nat_degree_multiset_prod` to another file.
-
 -/
 
 noncomputable theory
@@ -47,25 +51,25 @@ open_locale classical big_operators
 
 universes u v w
 
-variables {α : Type u} {β : Type v} {γ : Type w}
+variables {K : Type u} {L : Type v} {F : Type w}
 
 namespace polynomial
 
-variables [field α] [field β] [field γ]
+variables [field K] [field L] [field F]
 open polynomial
 
 section splits
 
-variables (i : α →+* β)
+variables (i : K →+* L)
 
 /-- A polynomial `splits` iff it is zero or all of its irreducible factors have `degree` 1. -/
-def splits (f : polynomial α) : Prop :=
-f = 0 ∨ ∀ {g : polynomial β}, irreducible g → g ∣ f.map i → degree g = 1
+def splits (f : polynomial K) : Prop :=
+f = 0 ∨ ∀ {g : polynomial L}, irreducible g → g ∣ f.map i → degree g = 1
 
-@[simp] lemma splits_zero : splits i (0 : polynomial α) := or.inl rfl
+@[simp] lemma splits_zero : splits i (0 : polynomial K) := or.inl rfl
 
-@[simp] lemma splits_C (a : α) : splits i (C a) :=
-if ha : a = 0 then ha.symm ▸ (@C_0 α _).symm ▸ splits_zero i
+@[simp] lemma splits_C (a : K) : splits i (C a) :=
+if ha : a = 0 then ha.symm ▸ (@C_0 K _).symm ▸ splits_zero i
 else
 have hia : i a ≠ 0, from mt ((is_add_group_hom.injective_iff i).1
   i.injective _) ha,
@@ -74,14 +78,14 @@ or.inr $ λ g hg ⟨p, hp⟩, absurd hg.1 (not_not.2 (is_unit_iff_degree_eq_zero
     simp [degree_C hia, @eq_comm (with_bot ℕ) 0,
       nat.with_bot.add_eq_zero_iff] at this; clear _fun_match; tauto))
 
-lemma splits_of_degree_eq_one {f : polynomial α} (hf : degree f = 1) : splits i f :=
+lemma splits_of_degree_eq_one {f : polynomial K} (hf : degree f = 1) : splits i f :=
 or.inr $ λ g hg ⟨p, hp⟩,
   by have := congr_arg degree hp;
   simp [nat.with_bot.add_eq_one_iff, hf, @eq_comm (with_bot ℕ) 1,
     mt is_unit_iff_degree_eq_zero.2 hg.1] at this;
   clear _fun_match; tauto
 
-lemma splits_of_degree_le_one {f : polynomial α} (hf : degree f ≤ 1) : splits i f :=
+lemma splits_of_degree_le_one {f : polynomial K} (hf : degree f ≤ 1) : splits i f :=
 begin
   cases h : degree f with n,
   { rw [degree_eq_bot.1 h]; exact splits_zero i },
@@ -94,63 +98,63 @@ begin
       exact splits_of_degree_eq_one _ (by rw [h, hn]; refl) } }
 end
 
-lemma splits_of_nat_degree_le_one {f : polynomial α} (hf : nat_degree f ≤ 1) : splits i f :=
+lemma splits_of_nat_degree_le_one {f : polynomial K} (hf : nat_degree f ≤ 1) : splits i f :=
 splits_of_degree_le_one i (degree_le_of_nat_degree_le hf)
 
-lemma splits_of_nat_degree_eq_one {f : polynomial α} (hf : nat_degree f = 1) : splits i f :=
+lemma splits_of_nat_degree_eq_one {f : polynomial K} (hf : nat_degree f = 1) : splits i f :=
 splits_of_nat_degree_le_one i (le_of_eq hf)
 
-lemma splits_mul {f g : polynomial α} (hf : splits i f) (hg : splits i g) : splits i (f * g) :=
+lemma splits_mul {f g : polynomial K} (hf : splits i f) (hg : splits i g) : splits i (f * g) :=
 if h : f * g = 0 then by simp [h]
 else or.inr $ λ p hp hpf, ((principal_ideal_ring.irreducible_iff_prime.1 hp).2.2 _ _
     (show p ∣ map i f * map i g, by convert hpf; rw polynomial.map_mul)).elim
   (hf.resolve_left (λ hf, by simpa [hf] using h) hp)
   (hg.resolve_left (λ hg, by simpa [hg] using h) hp)
 
-lemma splits_of_splits_mul {f g : polynomial α} (hfg : f * g ≠ 0) (h : splits i (f * g)) :
+lemma splits_of_splits_mul {f g : polynomial K} (hfg : f * g ≠ 0) (h : splits i (f * g)) :
   splits i f ∧ splits i g :=
 ⟨or.inr $ λ g hgi hg, or.resolve_left h hfg hgi
    (by rw map_mul; exact dvd.trans hg (dvd_mul_right _ _)),
  or.inr $ λ g hgi hg, or.resolve_left h hfg hgi
    (by rw map_mul; exact dvd.trans hg (dvd_mul_left _ _))⟩
 
-lemma splits_of_splits_of_dvd {f g : polynomial α} (hf0 : f ≠ 0) (hf : splits i f) (hgf : g ∣ f) :
+lemma splits_of_splits_of_dvd {f g : polynomial K} (hf0 : f ≠ 0) (hf : splits i f) (hgf : g ∣ f) :
   splits i g :=
 by { obtain ⟨f, rfl⟩ := hgf, exact (splits_of_splits_mul i hf0 hf).1 }
 
-lemma splits_of_splits_gcd_left {f g : polynomial α} (hf0 : f ≠ 0) (hf : splits i f) :
+lemma splits_of_splits_gcd_left {f g : polynomial K} (hf0 : f ≠ 0) (hf : splits i f) :
   splits i (euclidean_domain.gcd f g) :=
 polynomial.splits_of_splits_of_dvd i hf0 hf (euclidean_domain.gcd_dvd_left f g)
 
-lemma splits_of_splits_gcd_right {f g : polynomial α} (hg0 : g ≠ 0) (hg : splits i g) :
+lemma splits_of_splits_gcd_right {f g : polynomial K} (hg0 : g ≠ 0) (hg : splits i g) :
   splits i (euclidean_domain.gcd f g) :=
 polynomial.splits_of_splits_of_dvd i hg0 hg (euclidean_domain.gcd_dvd_right f g)
 
-lemma splits_map_iff (j : β →+* γ) {f : polynomial α} :
+lemma splits_map_iff (j : L →+* F) {f : polynomial K} :
   splits j (f.map i) ↔ splits (j.comp i) f :=
 by simp [splits, polynomial.map_map]
 
 theorem splits_one : splits i 1 :=
 splits_C i 1
 
-theorem splits_of_is_unit {u : polynomial α} (hu : is_unit u) : u.splits i :=
+theorem splits_of_is_unit {u : polynomial K} (hu : is_unit u) : u.splits i :=
 splits_of_splits_of_dvd i one_ne_zero (splits_one _) $ is_unit_iff_dvd_one.1 hu
 
-theorem splits_X_sub_C {x : α} : (X - C x).splits i :=
+theorem splits_X_sub_C {x : K} : (X - C x).splits i :=
 splits_of_degree_eq_one _ $ degree_X_sub_C x
 
 theorem splits_X : X.splits i :=
 splits_of_degree_eq_one _ $ degree_X
 
-theorem splits_id_iff_splits {f : polynomial α} :
-  (f.map i).splits (ring_hom.id β) ↔ f.splits i :=
+theorem splits_id_iff_splits {f : polynomial K} :
+  (f.map i).splits (ring_hom.id L) ↔ f.splits i :=
 by rw [splits_map_iff, ring_hom.id_comp]
 
-theorem splits_mul_iff {f g : polynomial α} (hf : f ≠ 0) (hg : g ≠ 0) :
+theorem splits_mul_iff {f g : polynomial K} (hf : f ≠ 0) (hg : g ≠ 0) :
   (f * g).splits i ↔ f.splits i ∧ g.splits i :=
 ⟨splits_of_splits_mul i (mul_ne_zero hf hg), λ ⟨hfs, hgs⟩, splits_mul i hfs hgs⟩
 
-theorem splits_prod {ι : Type w} {s : ι → polynomial α} {t : finset ι} :
+theorem splits_prod {ι : Type w} {s : ι → polynomial K} {t : finset ι} :
   (∀ j ∈ t, (s j).splits i) → (∏ x in t, s x).splits i :=
 begin
   refine finset.induction_on t (λ _, splits_one i) (λ a t hat ih ht, _),
@@ -158,7 +162,7 @@ begin
   exact splits_mul i ht.1 (ih ht.2)
 end
 
-lemma splits_pow {f : polynomial α} (hf : f.splits i) (n : ℕ) : (f ^ n).splits i :=
+lemma splits_pow {f : polynomial K} (hf : f.splits i) (n : ℕ) : (f ^ n).splits i :=
 begin
   rw [←finset.card_range n, ←finset.prod_const],
   exact splits_prod i (λ j hj, hf),
@@ -166,7 +170,7 @@ end
 
 lemma splits_X_pow (n : ℕ) : (X ^ n).splits i := splits_pow i (splits_X i) n
 
-theorem splits_prod_iff {ι : Type w} {s : ι → polynomial α} {t : finset ι} :
+theorem splits_prod_iff {ι : Type w} {s : ι → polynomial K} {t : finset ι} :
   (∀ j ∈ t, s j ≠ 0) → ((∏ x in t, s x).splits i ↔ ∀ j ∈ t, (s j).splits i) :=
 begin
   refine finset.induction_on t (λ _, ⟨λ _ _ h, h.elim, λ _, splits_one i⟩) (λ a t hat ih ht, _),
@@ -174,8 +178,8 @@ begin
   rw [finset.prod_insert hat, splits_mul_iff i ht.1 (finset.prod_ne_zero_iff.2 ht.2), ih ht.2]
 end
 
-lemma degree_eq_one_of_irreducible_of_splits {p : polynomial β}
-  (h_nz : p ≠ 0) (hp : irreducible p) (hp_splits : splits (ring_hom.id β) p) :
+lemma degree_eq_one_of_irreducible_of_splits {p : polynomial L}
+  (h_nz : p ≠ 0) (hp : irreducible p) (hp_splits : splits (ring_hom.id L) p) :
   p.degree = 1 :=
 begin
   rcases hp_splits,
@@ -183,7 +187,7 @@ begin
   { apply hp_splits hp, simp }
 end
 
-lemma exists_root_of_splits {f : polynomial α} (hs : splits i f) (hf0 : degree f ≠ 0) :
+lemma exists_root_of_splits {f : polynomial K} (hs : splits i f) (hf0 : degree f ≠ 0) :
   ∃ x, eval₂ i x f = 0 :=
 if hf0 : f = 0 then ⟨37, by simp [hf0]⟩
 else
@@ -194,11 +198,11 @@ else
   let ⟨i, hi⟩ := hg.2 in
   ⟨x, by rw [← eval_map, hi, eval_mul, show _ = _, from hx, zero_mul]⟩
 
-lemma exists_multiset_of_splits {f : polynomial α} : splits i f →
-  ∃ (s : multiset β), f.map i = C (i f.leading_coeff) *
-  (s.map (λ a : β, (X : polynomial β) - C a)).prod :=
-suffices splits (ring_hom.id _) (f.map i) → ∃ s : multiset β, f.map i =
-  (C (f.map i).leading_coeff) * (s.map (λ a : β, (X : polynomial β) - C a)).prod,
+lemma exists_multiset_of_splits {f : polynomial K} : splits i f →
+  ∃ (s : multiset L), f.map i = C (i f.leading_coeff) *
+  (s.map (λ a : L, (X : polynomial L) - C a)).prod :=
+suffices splits (ring_hom.id _) (f.map i) → ∃ s : multiset L, f.map i =
+  (C (f.map i).leading_coeff) * (s.map (λ a : L, (X : polynomial L) - C a)).prod,
 by rwa [splits_map_iff, leading_coeff_map i] at this,
 wf_dvd_monoid.induction_on_irreducible (f.map i)
   (λ _, ⟨{37}, by simp [i.map_zero]⟩)
@@ -221,21 +225,21 @@ wf_dvd_monoid.induction_on_irreducible (f.map i)
       end⟩)
 
 /-- Pick a root of a polynomial that splits. -/
-def root_of_splits {f : polynomial α} (hf : f.splits i) (hfd : f.degree ≠ 0) : β :=
+def root_of_splits {f : polynomial K} (hf : f.splits i) (hfd : f.degree ≠ 0) : L :=
 classical.some $ exists_root_of_splits i hf hfd
 
-theorem map_root_of_splits {f : polynomial α} (hf : f.splits i) (hfd) :
+theorem map_root_of_splits {f : polynomial K} (hf : f.splits i) (hfd) :
   f.eval₂ i (root_of_splits i hf hfd) = 0 :=
 classical.some_spec $ exists_root_of_splits i hf hfd
 
-theorem roots_map {f : polynomial α} (hf : f.splits $ ring_hom.id α) :
+theorem roots_map {f : polynomial K} (hf : f.splits $ ring_hom.id K) :
   (f.map i).roots = (f.roots).map i :=
 if hf0 : f = 0 then by rw [hf0, map_zero, roots_zero, roots_zero, multiset.map_zero] else
 have hmf0 : f.map i ≠ 0 := map_ne_zero hf0,
 let ⟨m, hm⟩ := exists_multiset_of_splits _ hf in
-have h1 : (0 : polynomial α) ∉ m.map (λ r, X - C r),
+have h1 : (0 : polynomial K) ∉ m.map (λ r, X - C r),
   from zero_nmem_multiset_map_X_sub_C _ _,
-have h2 : (0 : polynomial β) ∉ m.map (λ r, X - C (i r)),
+have h2 : (0 : polynomial L) ∉ m.map (λ r, X - C (i r)),
   from zero_nmem_multiset_map_X_sub_C _ _,
 begin
   rw map_id at hm, rw hm at hf0 hmf0 ⊢, rw map_mul at hmf0 ⊢,
@@ -248,7 +252,7 @@ begin
       multiset.bind_cons, multiset.bind_zero, add_zero, multiset.map_id']
 end
 
-lemma eq_prod_roots_of_splits {p : polynomial α} {i : α →+* β}
+lemma eq_prod_roots_of_splits {p : polynomial K} {i : K →+* L}
   (hsplit : splits i p) :
   p.map i = C (i p.leading_coeff) * ((p.map i).roots.map (λ a, X - C a)).prod :=
 begin
@@ -260,7 +264,7 @@ begin
   have prod_ne_zero : C (i p.leading_coeff) * (multiset.map (λ a, X - C a) s).prod ≠ 0 :=
     by rwa hs at map_ne_zero,
 
-  have zero_nmem : (0 : polynomial β) ∉ s.map (λ a, X - C a),
+  have zero_nmem : (0 : polynomial L) ∉ s.map (λ a, X - C a),
     from zero_nmem_multiset_map_X_sub_C _ _,
   have map_bind_roots_eq : (s.map (λ a, X - C a)).bind (λ a, a.roots) = s,
   { refine multiset.induction_on s (by rw [multiset.map_zero, multiset.zero_bind]) _,
@@ -273,7 +277,7 @@ begin
       map_bind_roots_eq]
 end
 
-lemma eq_X_sub_C_of_splits_of_single_root {x : α} {h : polynomial α} (h_splits : splits i h)
+lemma eq_X_sub_C_of_splits_of_single_root {x : K} {h : polynomial K} (h_splits : splits i h)
   (h_roots : (h.map i).roots = {i x}) : h = (C (leading_coeff h)) * (X - C x) :=
 begin
   apply polynomial.map_injective _ i.injective,
@@ -295,7 +299,7 @@ begin
     multiset.map_cons, multiset.sum_cons],
 end
 
-lemma nat_degree_eq_card_roots {p : polynomial α} {i : α →+* β}
+lemma nat_degree_eq_card_roots {p : polynomial K} {i : K →+* L}
   (hsplit : splits i p) : p.nat_degree = (p.map i).roots.card :=
 begin
   by_cases p_eq_zero : p = 0,
@@ -304,13 +308,13 @@ begin
   rw eq_prod_roots_of_splits hsplit at map_ne_zero,
 
   conv_lhs { rw [← nat_degree_map i, eq_prod_roots_of_splits hsplit] },
-  have : (0 : polynomial β) ∉ (map i p).roots.map (λ a, X - C a),
+  have : (0 : polynomial L) ∉ (map i p).roots.map (λ a, X - C a),
     from zero_nmem_multiset_map_X_sub_C _ _,
   simp [nat_degree_mul (left_ne_zero_of_mul map_ne_zero) (right_ne_zero_of_mul map_ne_zero),
         nat_degree_multiset_prod this]
 end
 
-lemma degree_eq_card_roots {p : polynomial α} {i : α →+* β} (p_ne_zero : p ≠ 0)
+lemma degree_eq_card_roots {p : polynomial K} {i : K →+* L} (p_ne_zero : p ≠ 0)
   (hsplit : splits i p) : p.degree = (p.map i).roots.card :=
 by rw [degree_eq_nat_degree p_ne_zero, nat_degree_eq_card_roots hsplit]
 
@@ -321,14 +325,14 @@ local infix ` ~ᵤ ` : 50 := associated
 
 open unique_factorization_monoid associates
 
-lemma splits_of_exists_multiset {f : polynomial α} {s : multiset β}
-  (hs : f.map i = C (i f.leading_coeff) * (s.map (λ a : β, (X : polynomial β) - C a)).prod) :
+lemma splits_of_exists_multiset {f : polynomial K} {s : multiset L}
+  (hs : f.map i = C (i f.leading_coeff) * (s.map (λ a : L, (X : polynomial L) - C a)).prod) :
   splits i f :=
 if hf0 : f = 0 then or.inl hf0
 else
   or.inr $ λ p hp hdp,
     have ht : multiset.rel associated
-      (factors (f.map i)) (s.map (λ a : β, (X : polynomial β) - C a)) :=
+      (factors (f.map i)) (s.map (λ a : L, (X : polynomial L) - C a)) :=
     factors_unique
       (λ p hp, irreducible_of_factor _ hp)
       (λ p' m, begin
@@ -336,7 +340,7 @@ else
           exact irreducible_of_degree_eq_one (degree_X_sub_C _),
         end)
       (associated.symm $ calc _ ~ᵤ f.map i :
-        ⟨(units.map' C : units β →* units (polynomial β)) (units.mk0 (f.map i).leading_coeff
+        ⟨(units.map' C : units L →* units (polynomial L)) (units.mk0 (f.map i).leading_coeff
             (mt leading_coeff_eq_zero.1 (map_ne_zero hf0))),
           by conv_rhs {rw [hs, ← leading_coeff_map i, mul_comm]}; refl⟩
         ... ~ᵤ _ : associated.symm (unique_factorization_monoid.factors_prod (by simpa using hf0))),
@@ -346,7 +350,7 @@ else
   by rw [← degree_X_sub_C a, ha.2];
     exact degree_eq_degree_of_associated (hpq.trans hqq')
 
-lemma splits_of_splits_id {f : polynomial α} : splits (ring_hom.id _) f → splits i f :=
+lemma splits_of_splits_id {f : polynomial K} : splits (ring_hom.id _) f → splits i f :=
 unique_factorization_monoid.induction_on_prime f (λ _, splits_zero _)
   (λ _ hu _, splits_of_degree_le_one _
     ((is_unit_iff_degree_eq_zero.1 hu).symm ▸ dec_trivial))
@@ -358,12 +362,12 @@ unique_factorization_monoid.induction_on_prime f (λ _, splits_zero _)
 
 end UFD
 
-lemma splits_iff_exists_multiset {f : polynomial α} : splits i f ↔
-  ∃ (s : multiset β), f.map i = C (i f.leading_coeff) *
-  (s.map (λ a : β, (X : polynomial β) - C a)).prod :=
+lemma splits_iff_exists_multiset {f : polynomial K} : splits i f ↔
+  ∃ (s : multiset L), f.map i = C (i f.leading_coeff) *
+  (s.map (λ a : L, (X : polynomial L) - C a)).prod :=
 ⟨exists_multiset_of_splits i, λ ⟨s, hs⟩, splits_of_exists_multiset i hs⟩
 
-lemma splits_comp_of_splits (j : β →+* γ) {f : polynomial α}
+lemma splits_comp_of_splits (j : L →+* F) {f : polynomial K}
   (h : splits i f) : splits (j.comp i) f :=
 begin
   change i with ((ring_hom.id _).comp i) at h,
@@ -374,38 +378,38 @@ end
 
 /-- A monic polynomial `p` that has as many roots as its degree
 can be written `p = ∏(X - a)`, for `a` in `p.roots`. -/
-lemma prod_multiset_X_sub_C_of_monic_of_roots_card_eq {p : polynomial α}
+lemma prod_multiset_X_sub_C_of_monic_of_roots_card_eq {p : polynomial K}
   (hmonic : p.monic) (hroots : p.roots.card = p.nat_degree) :
-  (multiset.map (λ (a : α), X - C a) p.roots).prod = p :=
+  (multiset.map (λ (a : K), X - C a) p.roots).prod = p :=
 begin
-  have hprodmonic : (multiset.map (λ (a : α), X - C a) p.roots).prod.monic,
+  have hprodmonic : (multiset.map (λ (a : K), X - C a) p.roots).prod.monic,
   { simp only [prod_multiset_root_eq_finset_root (ne_zero_of_monic hmonic),
       monic_prod_of_monic, monic_X_sub_C, monic_pow, forall_true_iff] },
-  have hdegree : (multiset.map (λ (a : α), X - C a) p.roots).prod.nat_degree = p.nat_degree,
-  { rw [← hroots, nat_degree_multiset_prod (zero_nmem_multiset_map_X_sub_C _ (λ a : α, a))],
+  have hdegree : (multiset.map (λ (a : K), X - C a) p.roots).prod.nat_degree = p.nat_degree,
+  { rw [← hroots, nat_degree_multiset_prod (zero_nmem_multiset_map_X_sub_C _ (λ a : K, a))],
     simp only [eq_self_iff_true, mul_one, nat.cast_id, nsmul_eq_mul, multiset.sum_repeat,
       multiset.map_const,nat_degree_X_sub_C, function.comp, multiset.map_map] },
   obtain ⟨q, hq⟩ := prod_multiset_X_sub_C_dvd p,
   have qzero : q ≠ 0,
   { rintro rfl, apply hmonic.ne_zero, simpa only [mul_zero] using hq },
   have degp :
-    p.nat_degree = (multiset.map (λ (a : α), X - C a) p.roots).prod.nat_degree + q.nat_degree,
+    p.nat_degree = (multiset.map (λ (a : K), X - C a) p.roots).prod.nat_degree + q.nat_degree,
   { nth_rewrite 0 [hq],
     simp only [nat_degree_mul (ne_zero_of_monic hprodmonic) qzero] },
   have degq : q.nat_degree = 0,
   { rw hdegree at degp,
     exact (add_right_inj p.nat_degree).mp (tactic.ring_exp.add_pf_sum_z degp rfl).symm },
   obtain ⟨u, hu⟩ := is_unit_iff_degree_eq_zero.2 ((degree_eq_iff_nat_degree_eq qzero).2 degq),
-  have hassoc : associated (multiset.map (λ (a : α), X - C a) p.roots).prod p,
+  have hassoc : associated (multiset.map (λ (a : K), X - C a) p.roots).prod p,
   { rw associated, use u, rw [hu, ← hq] },
   exact eq_of_monic_of_associated hprodmonic hmonic hassoc
 end
 
 /-- A polynomial `p` that has as many roots as its degree
 can be written `p = p.leading_coeff * ∏(X - a)`, for `a` in `p.roots`. -/
-lemma C_leading_coeff_mul_prod_multiset_X_sub_C {p : polynomial α}
+lemma C_leading_coeff_mul_prod_multiset_X_sub_C {p : polynomial K}
   (hroots : p.roots.card = p.nat_degree) :
-  (C p.leading_coeff) * (multiset.map (λ (a : α), X - C a) p.roots).prod = p :=
+  (C p.leading_coeff) * (multiset.map (λ (a : K), X - C a) p.roots).prod = p :=
 begin
   by_cases hzero : p = 0,
   { rw [hzero, leading_coeff_zero, ring_hom.map_zero, zero_mul], },
@@ -417,7 +421,7 @@ begin
     have hprod := prod_multiset_X_sub_C_of_monic_of_roots_card_eq (monic_normalize hzero)
                     hrootsnorm,
     rw [roots_normalize, normalize_apply, coe_norm_unit_of_ne_zero hzero] at hprod,
-    calc (C p.leading_coeff) * (multiset.map (λ (a : α), X - C a) p.roots).prod
+    calc (C p.leading_coeff) * (multiset.map (λ (a : K), X - C a) p.roots).prod
         = p * C ((p.leading_coeff)⁻¹ * p.leading_coeff) :
         by rw [hprod, mul_comm, mul_assoc, ← C_mul]
     ... = p * C 1 : by field_simp
@@ -425,13 +429,13 @@ begin
 end
 
 /-- A polynomial splits if and only if it has as many roots as its degree. -/
-lemma splits_iff_card_roots {p : polynomial α} :
-  splits (ring_hom.id α) p ↔ p.roots.card = p.nat_degree :=
+lemma splits_iff_card_roots {p : polynomial K} :
+  splits (ring_hom.id K) p ↔ p.roots.card = p.nat_degree :=
 begin
   split,
   { intro H, rw [nat_degree_eq_card_roots H, map_id] },
   { intro hroots,
-    apply (splits_iff_exists_multiset (ring_hom.id α)).2,
+    apply (splits_iff_exists_multiset (ring_hom.id K)).2,
     use p.roots,
     simp only [ring_hom.id_apply, map_id],
     exact (C_leading_coeff_mul_prod_multiset_X_sub_C hroots).symm },
@@ -444,7 +448,7 @@ end polynomial
 
 section embeddings
 
-variables (F : Type*) [field F]
+variables (F) [field F]
 
 /-- If `p` is the minimal polynomial of `a` over `F` then `F[a] ≃ₐ[F] F[x]/(p)` -/
 def alg_equiv.adjoin_singleton_equiv_adjoin_root_minpoly
@@ -504,120 +508,120 @@ end embeddings
 
 namespace polynomial
 
-variables [field α] [field β] [field γ]
+variables [field K] [field L] [field F]
 open polynomial
 
 section splitting_field
 
 /-- Non-computably choose an irreducible factor from a polynomial. -/
-def factor (f : polynomial α) : polynomial α :=
+def factor (f : polynomial K) : polynomial K :=
 if H : ∃ g, irreducible g ∧ g ∣ f then classical.some H else X
 
-instance irreducible_factor (f : polynomial α) : irreducible (factor f) :=
+instance irreducible_factor (f : polynomial K) : irreducible (factor f) :=
 begin
   rw factor, split_ifs with H, { exact (classical.some_spec H).1 }, { exact irreducible_X }
 end
 
-theorem factor_dvd_of_not_is_unit {f : polynomial α} (hf1 : ¬is_unit f) : factor f ∣ f :=
+theorem factor_dvd_of_not_is_unit {f : polynomial K} (hf1 : ¬is_unit f) : factor f ∣ f :=
 begin
   by_cases hf2 : f = 0, { rw hf2, exact dvd_zero _ },
   rw [factor, dif_pos (wf_dvd_monoid.exists_irreducible_factor hf1 hf2)],
   exact (classical.some_spec $ wf_dvd_monoid.exists_irreducible_factor hf1 hf2).2
 end
 
-theorem factor_dvd_of_degree_ne_zero {f : polynomial α} (hf : f.degree ≠ 0) : factor f ∣ f :=
+theorem factor_dvd_of_degree_ne_zero {f : polynomial K} (hf : f.degree ≠ 0) : factor f ∣ f :=
 factor_dvd_of_not_is_unit (mt degree_eq_zero_of_is_unit hf)
 
-theorem factor_dvd_of_nat_degree_ne_zero {f : polynomial α} (hf : f.nat_degree ≠ 0) :
+theorem factor_dvd_of_nat_degree_ne_zero {f : polynomial K} (hf : f.nat_degree ≠ 0) :
   factor f ∣ f :=
 factor_dvd_of_degree_ne_zero (mt nat_degree_eq_of_degree_eq_some hf)
 
 /-- Divide a polynomial f by X - C r where r is a root of f in a bigger field extension. -/
-def remove_factor (f : polynomial α) : polynomial (adjoin_root $ factor f) :=
+def remove_factor (f : polynomial K) : polynomial (adjoin_root $ factor f) :=
 map (adjoin_root.of f.factor) f /ₘ (X - C (adjoin_root.root f.factor))
 
-theorem X_sub_C_mul_remove_factor (f : polynomial α) (hf : f.nat_degree ≠ 0) :
+theorem X_sub_C_mul_remove_factor (f : polynomial K) (hf : f.nat_degree ≠ 0) :
   (X - C (adjoin_root.root f.factor)) * f.remove_factor = map (adjoin_root.of f.factor) f :=
 let ⟨g, hg⟩ := factor_dvd_of_nat_degree_ne_zero hf in
 mul_div_by_monic_eq_iff_is_root.2 $ by rw [is_root.def, eval_map, hg, eval₂_mul, ← hg,
     adjoin_root.eval₂_root, zero_mul]
 
-theorem nat_degree_remove_factor (f : polynomial α) :
+theorem nat_degree_remove_factor (f : polynomial K) :
   f.remove_factor.nat_degree = f.nat_degree - 1 :=
 by rw [remove_factor, nat_degree_div_by_monic _ (monic_X_sub_C _), nat_degree_map,
        nat_degree_X_sub_C]
 
-theorem nat_degree_remove_factor' {f : polynomial α} {n : ℕ} (hfn : f.nat_degree = n+1) :
+theorem nat_degree_remove_factor' {f : polynomial K} {n : ℕ} (hfn : f.nat_degree = n+1) :
   f.remove_factor.nat_degree = n :=
 by rw [nat_degree_remove_factor, hfn, n.add_sub_cancel]
 
 /-- Auxiliary construction to a splitting field of a polynomial. Uses induction on the degree. -/
-def splitting_field_aux (n : ℕ) : Π {α : Type u} [field α], by exactI Π (f : polynomial α),
+def splitting_field_aux (n : ℕ) : Π {K : Type u} [field K], by exactI Π (f : polynomial K),
   f.nat_degree = n → Type u :=
-nat.rec_on n (λ α _ _ _, α) $ λ n ih α _ f hf, by exactI
+nat.rec_on n (λ K _ _ _, K) $ λ n ih K _ f hf, by exactI
 ih f.remove_factor (nat_degree_remove_factor' hf)
 
 namespace splitting_field_aux
 
-theorem succ (n : ℕ) (f : polynomial α) (hfn : f.nat_degree = n + 1) :
+theorem succ (n : ℕ) (f : polynomial K) (hfn : f.nat_degree = n + 1) :
   splitting_field_aux (n+1) f hfn =
     splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn) := rfl
 
-instance field (n : ℕ) : Π {α : Type u} [field α], by exactI
-  Π {f : polynomial α} (hfn : f.nat_degree = n), field (splitting_field_aux n f hfn) :=
-nat.rec_on n (λ α _ _ _, ‹field α›) $ λ n ih α _ f hf, ih _
+instance field (n : ℕ) : Π {K : Type u} [field K], by exactI
+  Π {f : polynomial K} (hfn : f.nat_degree = n), field (splitting_field_aux n f hfn) :=
+nat.rec_on n (λ K _ _ _, ‹field K›) $ λ n ih K _ f hf, ih _
 
-instance inhabited {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n) :
+instance inhabited {n : ℕ} {f : polynomial K} (hfn : f.nat_degree = n) :
   inhabited (splitting_field_aux n f hfn) := ⟨37⟩
 
-instance algebra (n : ℕ) : Π {α : Type u} [field α], by exactI
-  Π {f : polynomial α} (hfn : f.nat_degree = n), algebra α (splitting_field_aux n f hfn) :=
-nat.rec_on n (λ α _ _ _, by exactI algebra.id α) $ λ n ih α _ f hfn,
+instance algebra (n : ℕ) : Π {K : Type u} [field K], by exactI
+  Π {f : polynomial K} (hfn : f.nat_degree = n), algebra K (splitting_field_aux n f hfn) :=
+nat.rec_on n (λ K _ _ _, by exactI algebra.id K) $ λ n ih K _ f hfn,
 by exactI @@algebra.comap.algebra _ _ _ _ _ _ _ (ih _)
 
-instance algebra' {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n + 1) :
+instance algebra' {n : ℕ} {f : polynomial K} (hfn : f.nat_degree = n + 1) :
   algebra (adjoin_root f.factor) (splitting_field_aux _ _ hfn) :=
 splitting_field_aux.algebra n _
 
-instance algebra'' {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n + 1) :
-  algebra α (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)) :=
+instance algebra'' {n : ℕ} {f : polynomial K} (hfn : f.nat_degree = n + 1) :
+  algebra K (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)) :=
 splitting_field_aux.algebra (n+1) hfn
 
-instance algebra''' {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n + 1) :
+instance algebra''' {n : ℕ} {f : polynomial K} (hfn : f.nat_degree = n + 1) :
   algebra (adjoin_root f.factor)
     (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)) :=
 splitting_field_aux.algebra n _
 
-instance scalar_tower {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n + 1) :
-  is_scalar_tower α (adjoin_root f.factor) (splitting_field_aux _ _ hfn) :=
+instance scalar_tower {n : ℕ} {f : polynomial K} (hfn : f.nat_degree = n + 1) :
+  is_scalar_tower K (adjoin_root f.factor) (splitting_field_aux _ _ hfn) :=
 is_scalar_tower.of_algebra_map_eq $ λ x, rfl
 
-instance scalar_tower' {n : ℕ} {f : polynomial α} (hfn : f.nat_degree = n + 1) :
-  is_scalar_tower α (adjoin_root f.factor)
+instance scalar_tower' {n : ℕ} {f : polynomial K} (hfn : f.nat_degree = n + 1) :
+  is_scalar_tower K (adjoin_root f.factor)
     (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)) :=
 is_scalar_tower.of_algebra_map_eq $ λ x, rfl
 
-theorem algebra_map_succ (n : ℕ) (f : polynomial α) (hfn : f.nat_degree = n + 1) :
-  by exact algebra_map α (splitting_field_aux _ _ hfn) =
+theorem algebra_map_succ (n : ℕ) (f : polynomial K) (hfn : f.nat_degree = n + 1) :
+  by exact algebra_map K (splitting_field_aux _ _ hfn) =
     (algebra_map (adjoin_root f.factor)
         (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn))).comp
       (adjoin_root.of f.factor) :=
 rfl
 
-protected theorem splits (n : ℕ) : ∀ {α : Type u} [field α], by exactI
-  ∀ (f : polynomial α) (hfn : f.nat_degree = n),
-    splits (algebra_map α $ splitting_field_aux n f hfn) f :=
-nat.rec_on n (λ α _ _ hf, by exactI splits_of_degree_le_one _
-  (le_trans degree_le_nat_degree $ hf.symm ▸ with_bot.coe_le_coe.2 zero_le_one)) $ λ n ih α _ f hf,
+protected theorem splits (n : ℕ) : ∀ {K : Type u} [field K], by exactI
+  ∀ (f : polynomial K) (hfn : f.nat_degree = n),
+    splits (algebra_map K $ splitting_field_aux n f hfn) f :=
+nat.rec_on n (λ K _ _ hf, by exactI splits_of_degree_le_one _
+  (le_trans degree_le_nat_degree $ hf.symm ▸ with_bot.coe_le_coe.2 zero_le_one)) $ λ n ih K _ f hf,
 by { resetI, rw [← splits_id_iff_splits, algebra_map_succ, ← map_map, splits_id_iff_splits,
     ← X_sub_C_mul_remove_factor f (λ h, by { rw h at hf, cases hf })],
 exact splits_mul _ (splits_X_sub_C _) (ih _ _) }
 
-theorem exists_lift (n : ℕ) : ∀ {α : Type u} [field α], by exactI
-  ∀ (f : polynomial α) (hfn : f.nat_degree = n) {β : Type*} [field β], by exactI
-    ∀ (j : α →+* β) (hf : splits j f), ∃ k : splitting_field_aux n f hfn →+* β,
+theorem exists_lift (n : ℕ) : ∀ {K : Type u} [field K], by exactI
+  ∀ (f : polynomial K) (hfn : f.nat_degree = n) {L : Type*} [field L], by exactI
+    ∀ (j : K →+* L) (hf : splits j f), ∃ k : splitting_field_aux n f hfn →+* L,
       k.comp (algebra_map _ _) = j :=
-nat.rec_on n (λ α _ _ _ β _ j _, by exactI ⟨j, j.comp_id⟩) $ λ n ih α _ f hf β _ j hj, by exactI
+nat.rec_on n (λ K _ _ _ L _ j _, by exactI ⟨j, j.comp_id⟩) $ λ n ih K _ f hf L _ j hj, by exactI
 have hndf : f.nat_degree ≠ 0, by { intro h, rw h at hf, cases hf },
 have hfn0 : f ≠ 0, by { intro h, rw h at hndf, exact hndf rfl },
 let ⟨r, hr⟩ := exists_root_of_splits _ (splits_of_splits_of_dvd j hfn0 hj
@@ -631,108 +635,108 @@ by { rw ← X_sub_C_mul_remove_factor _ hndf at hmf0, refine (splits_of_splits_m
 let ⟨k, hk⟩ := ih f.remove_factor (nat_degree_remove_factor' hf) (adjoin_root.lift j r hr) hsf in
 ⟨k, by rw [algebra_map_succ, ← ring_hom.comp_assoc, hk, adjoin_root.lift_comp_of]⟩
 
-theorem adjoin_roots (n : ℕ) : ∀ {α : Type u} [field α], by exactI
-  ∀ (f : polynomial α) (hfn : f.nat_degree = n),
-    algebra.adjoin α (↑(f.map $ algebra_map α $ splitting_field_aux n f hfn).roots.to_finset :
+theorem adjoin_roots (n : ℕ) : ∀ {K : Type u} [field K], by exactI
+  ∀ (f : polynomial K) (hfn : f.nat_degree = n),
+    algebra.adjoin K (↑(f.map $ algebra_map K $ splitting_field_aux n f hfn).roots.to_finset :
       set (splitting_field_aux n f hfn)) = ⊤ :=
-nat.rec_on n (λ α _ f hf, by exactI algebra.eq_top_iff.2 (λ x, subalgebra.range_le _ ⟨x, rfl⟩)) $
-λ n ih α _ f hfn, by exactI
+nat.rec_on n (λ K _ f hf, by exactI algebra.eq_top_iff.2 (λ x, subalgebra.range_le _ ⟨x, rfl⟩)) $
+λ n ih K _ f hfn, by exactI
 have hndf : f.nat_degree ≠ 0, by { intro h, rw h at hfn, cases hfn },
 have hfn0 : f ≠ 0, by { intro h, rw h at hndf, exact hndf rfl },
-have hmf0 : map (algebra_map α (splitting_field_aux n.succ f hfn)) f ≠ 0 := map_ne_zero hfn0,
+have hmf0 : map (algebra_map K (splitting_field_aux n.succ f hfn)) f ≠ 0 := map_ne_zero hfn0,
 by { rw [algebra_map_succ, ← map_map, ← X_sub_C_mul_remove_factor _ hndf, map_mul] at hmf0 ⊢,
 rw [roots_mul hmf0, map_sub, map_X, map_C, roots_X_sub_C, multiset.to_finset_add, finset.coe_union,
     multiset.to_finset_cons, multiset.to_finset_zero, insert_emptyc_eq, finset.coe_singleton,
-    algebra.adjoin_union, ← set.image_singleton, algebra.adjoin_algebra_map α (adjoin_root f.factor)
+    algebra.adjoin_union, ← set.image_singleton, algebra.adjoin_algebra_map K (adjoin_root f.factor)
       (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)),
     adjoin_root.adjoin_root_eq_top, algebra.map_top,
-    is_scalar_tower.range_under_adjoin α (adjoin_root f.factor)
+    is_scalar_tower.range_under_adjoin K (adjoin_root f.factor)
       (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)),
     ih, subalgebra.res_top] }
 
 end splitting_field_aux
 
 /-- A splitting field of a polynomial. -/
-def splitting_field (f : polynomial α) :=
+def splitting_field (f : polynomial K) :=
 splitting_field_aux _ f rfl
 
 namespace splitting_field
 
-variables (f : polynomial α)
+variables (f : polynomial K)
 
 instance : field (splitting_field f) :=
 splitting_field_aux.field _ _
 
 instance inhabited : inhabited (splitting_field f) := ⟨37⟩
 
-instance : algebra α (splitting_field f) :=
+instance : algebra K (splitting_field f) :=
 splitting_field_aux.algebra _ _
 
-protected theorem splits : splits (algebra_map α (splitting_field f)) f :=
+protected theorem splits : splits (algebra_map K (splitting_field f)) f :=
 splitting_field_aux.splits _ _ _
 
-variables [algebra α β] (hb : splits (algebra_map α β) f)
+variables [algebra K L] (hb : splits (algebra_map K L) f)
 
 /-- Embeds the splitting field into any other field that splits the polynomial. -/
-def lift : splitting_field f →ₐ[α] β :=
+def lift : splitting_field f →ₐ[K] L :=
 { commutes' := λ r, by { have := classical.some_spec (splitting_field_aux.exists_lift _ _ _ _ hb),
     exact ring_hom.ext_iff.1 this r },
   .. classical.some (splitting_field_aux.exists_lift _ _ _ _ hb) }
 
-theorem adjoin_roots : algebra.adjoin α
-    (↑(f.map (algebra_map α $ splitting_field f)).roots.to_finset : set (splitting_field f)) = ⊤ :=
+theorem adjoin_roots : algebra.adjoin K
+    (↑(f.map (algebra_map K $ splitting_field f)).roots.to_finset : set (splitting_field f)) = ⊤ :=
 splitting_field_aux.adjoin_roots _ _ _
 
-theorem adjoin_root_set : algebra.adjoin α (f.root_set f.splitting_field) = ⊤ :=
+theorem adjoin_root_set : algebra.adjoin K (f.root_set f.splitting_field) = ⊤ :=
 adjoin_roots f
 
 end splitting_field
 
-variables (α β) [algebra α β]
+variables (K L) [algebra K L]
 /-- Typeclass characterising splitting fields. -/
-class is_splitting_field (f : polynomial α) : Prop :=
-(splits [] : splits (algebra_map α β) f)
-(adjoin_roots [] : algebra.adjoin α (↑(f.map (algebra_map α β)).roots.to_finset : set β) = ⊤)
+class is_splitting_field (f : polynomial K) : Prop :=
+(splits [] : splits (algebra_map K L) f)
+(adjoin_roots [] : algebra.adjoin K (↑(f.map (algebra_map K L)).roots.to_finset : set L) = ⊤)
 
 namespace is_splitting_field
 
-variables {α}
-instance splitting_field (f : polynomial α) : is_splitting_field α (splitting_field f) f :=
+variables {K}
+instance splitting_field (f : polynomial K) : is_splitting_field K (splitting_field f) f :=
 ⟨splitting_field.splits f, splitting_field.adjoin_roots f⟩
 
 section scalar_tower
 
-variables {α β γ} [algebra β γ] [algebra α γ] [is_scalar_tower α β γ]
+variables {K L F} [algebra L F] [algebra K F] [is_scalar_tower K L F]
 
-variables {α}
-instance map (f : polynomial α) [is_splitting_field α γ f] :
-  is_splitting_field β γ (f.map $ algebra_map α β) :=
-⟨by { rw [splits_map_iff, ← is_scalar_tower.algebra_map_eq], exact splits γ f },
- subalgebra.res_inj α $ by { rw [map_map, ← is_scalar_tower.algebra_map_eq, subalgebra.res_top,
-    eq_top_iff, ← adjoin_roots γ f, algebra.adjoin_le_iff],
-  exact λ x hx, @algebra.subset_adjoin β _ _ _ _ _ _ hx }⟩
+variables {K}
+instance map (f : polynomial K) [is_splitting_field K F f] :
+  is_splitting_field L F (f.map $ algebra_map K L) :=
+⟨by { rw [splits_map_iff, ← is_scalar_tower.algebra_map_eq], exact splits F f },
+ subalgebra.res_inj K $ by { rw [map_map, ← is_scalar_tower.algebra_map_eq, subalgebra.res_top,
+    eq_top_iff, ← adjoin_roots F f, algebra.adjoin_le_iff],
+  exact λ x hx, @algebra.subset_adjoin L _ _ _ _ _ _ hx }⟩
 
-variables {α} (β)
-theorem splits_iff (f : polynomial α) [is_splitting_field α β f] :
-  polynomial.splits (ring_hom.id α) f ↔ (⊤ : subalgebra α β) = ⊥ :=
-⟨λ h, eq_bot_iff.2 $ adjoin_roots β f ▸ (roots_map (algebra_map α β) h).symm ▸
+variables {K} (L)
+theorem splits_iff (f : polynomial K) [is_splitting_field K L f] :
+  polynomial.splits (ring_hom.id K) f ↔ (⊤ : subalgebra K L) = ⊥ :=
+⟨λ h, eq_bot_iff.2 $ adjoin_roots L f ▸ (roots_map (algebra_map K L) h).symm ▸
   algebra.adjoin_le_iff.2 (λ y hy,
     let ⟨x, hxs, hxy⟩ := finset.mem_image.1 (by rwa multiset.to_finset_map at hy) in
     hxy ▸ subalgebra.algebra_map_mem _ _),
- λ h, @ring_equiv.to_ring_hom_refl α _ ▸
+ λ h, @ring_equiv.to_ring_hom_refl K _ ▸
   ring_equiv.trans_symm (ring_equiv.of_bijective _ $ algebra.bijective_algebra_map_iff.2 h) ▸
-  by { rw ring_equiv.to_ring_hom_trans, exact splits_comp_of_splits _ _ (splits β f) }⟩
+  by { rw ring_equiv.to_ring_hom_trans, exact splits_comp_of_splits _ _ (splits L f) }⟩
 
-theorem mul (f g : polynomial α) (hf : f ≠ 0) (hg : g ≠ 0) [is_splitting_field α β f]
-  [is_splitting_field β γ (g.map $ algebra_map α β)] :
-  is_splitting_field α γ (f * g) :=
-⟨(is_scalar_tower.algebra_map_eq α β γ).symm ▸ splits_mul _
-  (splits_comp_of_splits _ _ (splits β f))
-  ((splits_map_iff _ _).1 (splits γ $ g.map $ algebra_map α β)),
- by rw [map_mul, roots_mul (mul_ne_zero (map_ne_zero hf : f.map (algebra_map α γ) ≠ 0)
+theorem mul (f g : polynomial K) (hf : f ≠ 0) (hg : g ≠ 0) [is_splitting_field K L f]
+  [is_splitting_field L F (g.map $ algebra_map K L)] :
+  is_splitting_field K F (f * g) :=
+⟨(is_scalar_tower.algebra_map_eq K L F).symm ▸ splits_mul _
+  (splits_comp_of_splits _ _ (splits L f))
+  ((splits_map_iff _ _).1 (splits F $ g.map $ algebra_map K L)),
+ by rw [map_mul, roots_mul (mul_ne_zero (map_ne_zero hf : f.map (algebra_map K F) ≠ 0)
         (map_ne_zero hg)), multiset.to_finset_add, finset.coe_union, algebra.adjoin_union,
-      is_scalar_tower.algebra_map_eq α β γ, ← map_map,
-      roots_map (algebra_map β γ) ((splits_id_iff_splits $ algebra_map α β).2 $ splits β f),
+      is_scalar_tower.algebra_map_eq K L F, ← map_map,
+      roots_map (algebra_map L F) ((splits_id_iff_splits $ algebra_map K L).2 $ splits L f),
       multiset.to_finset_map, finset.coe_image, algebra.adjoin_algebra_map, adjoin_roots,
       algebra.map_top, is_scalar_tower.range_under_adjoin, ← map_map, adjoin_roots,
       subalgebra.res_top]⟩
@@ -740,48 +744,48 @@ theorem mul (f g : polynomial α) (hf : f ≠ 0) (hg : g ≠ 0) [is_splitting_fi
 end scalar_tower
 
 /-- Splitting field of `f` embeds into any field that splits `f`. -/
-def lift [algebra α γ] (f : polynomial α) [is_splitting_field α β f]
-  (hf : polynomial.splits (algebra_map α γ) f) : β →ₐ[α] γ :=
-if hf0 : f = 0 then (algebra.of_id α γ).comp $
-  (algebra.bot_equiv α β : (⊥ : subalgebra α β) →ₐ[α] α).comp $
-  by { rw ← (splits_iff β f).1 (show f.splits (ring_hom.id α), from hf0.symm ▸ splits_zero _),
+def lift [algebra K F] (f : polynomial K) [is_splitting_field K L f]
+  (hf : polynomial.splits (algebra_map K F) f) : L →ₐ[K] F :=
+if hf0 : f = 0 then (algebra.of_id K F).comp $
+  (algebra.bot_equiv K L : (⊥ : subalgebra K L) →ₐ[K] K).comp $
+  by { rw ← (splits_iff L f).1 (show f.splits (ring_hom.id K), from hf0.symm ▸ splits_zero _),
   exact algebra.to_top } else
-alg_hom.comp (by { rw ← adjoin_roots β f, exact classical.choice (lift_of_splits _ $ λ y hy,
+alg_hom.comp (by { rw ← adjoin_roots L f, exact classical.choice (lift_of_splits _ $ λ y hy,
     have aeval y f = 0, from (eval₂_eq_eval_map _).trans $
       (mem_roots $ by exact map_ne_zero hf0).1 (multiset.mem_to_finset.mp hy),
     ⟨(is_algebraic_iff_is_integral _).1 ⟨f, hf0, this⟩,
       splits_of_splits_of_dvd _ hf0 hf $ minpoly.dvd _ _ this⟩) })
   algebra.to_top
 
-theorem finite_dimensional (f : polynomial α) [is_splitting_field α β f] : finite_dimensional α β :=
-finite_dimensional.iff_fg.2 $ @algebra.coe_top α β _ _ _ ▸ adjoin_roots β f ▸
+theorem finite_dimensional (f : polynomial K) [is_splitting_field K L f] : finite_dimensional K L :=
+finite_dimensional.iff_fg.2 $ @algebra.coe_top K L _ _ _ ▸ adjoin_roots L f ▸
   fg_adjoin_of_finite (set.finite_mem_finset _) (λ y hy,
   if hf : f = 0
   then by { rw [hf, map_zero, roots_zero] at hy, cases hy }
   else (is_algebraic_iff_is_integral _).1 ⟨f, hf, (eval₂_eq_eval_map _).trans $
     (mem_roots $ by exact map_ne_zero hf).1 (multiset.mem_to_finset.mp hy)⟩)
 
-instance (f : polynomial α) : _root_.finite_dimensional α f.splitting_field :=
+instance (f : polynomial K) : _root_.finite_dimensional K f.splitting_field :=
 finite_dimensional f.splitting_field f
 
 /-- Any splitting field is isomorphic to `splitting_field f`. -/
-def alg_equiv (f : polynomial α) [is_splitting_field α β f] : β ≃ₐ[α] splitting_field f :=
+def alg_equiv (f : polynomial K) [is_splitting_field K L f] : L ≃ₐ[K] splitting_field f :=
 begin
-  refine alg_equiv.of_bijective (lift β f $ splits (splitting_field f) f)
-    ⟨ring_hom.injective (lift β f $ splits (splitting_field f) f).to_ring_hom, _⟩,
+  refine alg_equiv.of_bijective (lift L f $ splits (splitting_field f) f)
+    ⟨ring_hom.injective (lift L f $ splits (splitting_field f) f).to_ring_hom, _⟩,
   haveI := finite_dimensional (splitting_field f) f,
-  haveI := finite_dimensional β f,
-  have : finite_dimensional.findim α β = finite_dimensional.findim α (splitting_field f) :=
+  haveI := finite_dimensional L f,
+  have : finite_dimensional.findim K L = finite_dimensional.findim K (splitting_field f) :=
   le_antisymm
     (linear_map.findim_le_findim_of_injective
-      (show function.injective (lift β f $ splits (splitting_field f) f).to_linear_map, from
-        ring_hom.injective (lift β f $ splits (splitting_field f) f : β →+* f.splitting_field)))
+      (show function.injective (lift L f $ splits (splitting_field f) f).to_linear_map, from
+        ring_hom.injective (lift L f $ splits (splitting_field f) f : L →+* f.splitting_field)))
     (linear_map.findim_le_findim_of_injective
-      (show function.injective (lift (splitting_field f) f $ splits β f).to_linear_map, from
-        ring_hom.injective (lift (splitting_field f) f $ splits β f : f.splitting_field →+* β))),
-  change function.surjective (lift β f $ splits (splitting_field f) f).to_linear_map,
+      (show function.injective (lift (splitting_field f) f $ splits L f).to_linear_map, from
+        ring_hom.injective (lift (splitting_field f) f $ splits L f : f.splitting_field →+* L))),
+  change function.surjective (lift L f $ splits (splitting_field f) f).to_linear_map,
   refine (linear_map.injective_iff_surjective_of_findim_eq_findim this).1 _,
-  exact ring_hom.injective (lift β f $ splits (splitting_field f) f : β →+* f.splitting_field)
+  exact ring_hom.injective (lift L f $ splits (splitting_field f) f : L →+* f.splitting_field)
 end
 
 end is_splitting_field


### PR DESCRIPTION
This PR provides a module doc for `field_theory.splitting_field`, which is the last file without module doc in `field_theory`. Furthermore, I took the opportunity of renaming the fields in that file from `\alpha`, `\beta`, `\gamma` to `K`, `L`, `F` to make it more readable for newcomers.

Moved `nat_degree_multiset_prod`, to `algebra.polynomial.big_operators`). In order to get the `no_zero_divisors` instance on `polynomial R`, I had to include `data.polynomial.ring_division` in that file. Furthermore, with the help of Damiano, generalised this lemma to `no_zero_divisors R`.

Coauthored by: Damiano Testa adomani@gmail.com

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
