### PR TITLE
[Merged by Bors] - chore(algebra/char_p/basic): weaken assumptions integral_domain --> semiring+

### DIFF
--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -300,15 +300,19 @@ absurd (@nat.cast_injective α _ _ this) (not_injective_infinite_fintype coe)
 
 end
 
-section integral_domain
+section semiring
 open nat
 
-variables (α : Type u) [integral_domain α]
+variables (α : Type u) [semiring α]
 
-theorem char_ne_one (p : ℕ) [hc : char_p α p] : p ≠ 1 :=
+theorem char_ne_one [nontrivial α] (p : ℕ) [hc : char_p α p] : p ≠ 1 :=
 assume hp : p = 1,
 have ( 1 : α) = 0, by simpa using (cast_eq_zero_iff α p 1).mpr (hp ▸ dvd_refl p),
 absurd this one_ne_zero
+
+section no_zero_divisors
+
+variable [no_zero_divisors α]
 
 theorem char_is_prime_of_two_le (p : ℕ) [hc : char_p α p] (hp : 2 ≤ p) : nat.prime p :=
 suffices ∀d ∣ p, d = 1 ∨ d = p, from ⟨hp, this⟩,
@@ -328,20 +332,35 @@ or.elim (eq_zero_or_eq_zero_of_mul_eq_zero this)
   have d * p = 1 * p, by rw ‹e = p› at hmul; rw [one_mul]; exact eq.symm hmul,
   show d = 1 ∨ d = p, from or.inl (eq_of_mul_eq_mul_right h₀ this))
 
+section nontrivial
+
+variables [nontrivial α]
+
 theorem char_is_prime_or_zero (p : ℕ) [hc : char_p α p] : nat.prime p ∨ p = 0 :=
 match p, hc with
 | 0,     _  := or.inr rfl
-| 1,     hc := absurd (eq.refl (1 : ℕ)) (@char_ne_one α _ (1 : ℕ) hc)
-| (m+2), hc := or.inl (@char_is_prime_of_two_le α _ (m+2) hc (nat.le_add_left 2 m))
+| 1,     hc := absurd (eq.refl (1 : ℕ)) (@char_ne_one α _ _ (1 : ℕ) hc)
+| (m+2), hc := or.inl (@char_is_prime_of_two_le α _ _ (m+2) hc (nat.le_add_left 2 m))
 end
 
 lemma char_is_prime_of_pos (p : ℕ) [h : fact (0 < p)] [char_p α p] : fact p.prime :=
 (char_p.char_is_prime_or_zero α _).resolve_right (pos_iff_ne_zero.1 h)
 
-theorem char_is_prime [fintype α] (p : ℕ) [char_p α p] : p.prime :=
+end nontrivial
+
+end no_zero_divisors
+
+end semiring
+
+section ring
+
+variables {α : Type*} [ring α] [no_zero_divisors α] [nontrivial α] [fintype α]
+
+theorem char_is_prime (p : ℕ) [char_p α p] :
+  p.prime :=
 or.resolve_right (char_is_prime_or_zero α p) (char_ne_zero_of_fintype α p)
 
-end integral_domain
+end ring
 
 section char_one
 

--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -226,8 +226,6 @@ theorem frobenius_mul : frobenius R p (x * y) = frobenius R p x * frobenius R p 
 
 theorem frobenius_one : frobenius R p 1 = 1 := one_pow _
 
-variable {R}
-
 theorem monoid_hom.map_frobenius : f (frobenius R p x) = frobenius S p (f x) :=
 f.map_pow x p
 
@@ -303,29 +301,29 @@ end
 section semiring
 open nat
 
-variables (α : Type u) [semiring α]
+variables (R : Type u) [semiring R]
 
-theorem char_ne_one [nontrivial α] (p : ℕ) [hc : char_p α p] : p ≠ 1 :=
+theorem char_ne_one [nontrivial R] (p : ℕ) [hc : char_p R p] : p ≠ 1 :=
 assume hp : p = 1,
-have ( 1 : α) = 0, by simpa using (cast_eq_zero_iff α p 1).mpr (hp ▸ dvd_refl p),
+have ( 1 : R) = 0, by simpa using (cast_eq_zero_iff R p 1).mpr (hp ▸ dvd_refl p),
 absurd this one_ne_zero
 
 section no_zero_divisors
 
-variable [no_zero_divisors α]
+variable [no_zero_divisors R]
 
-theorem char_is_prime_of_two_le (p : ℕ) [hc : char_p α p] (hp : 2 ≤ p) : nat.prime p :=
+theorem char_is_prime_of_two_le (p : ℕ) [hc : char_p R p] (hp : 2 ≤ p) : nat.prime p :=
 suffices ∀d ∣ p, d = 1 ∨ d = p, from ⟨hp, this⟩,
 assume (d : ℕ) (hdvd : ∃ e, p = d * e),
 let ⟨e, hmul⟩ := hdvd in
-have (p : α) = 0, from (cast_eq_zero_iff α p p).mpr (dvd_refl p),
-have (d : α) * e = 0, from (@cast_mul α _ d e) ▸ (hmul ▸ this),
+have (p : R) = 0, from (cast_eq_zero_iff R p p).mpr (dvd_refl p),
+have (d : R) * e = 0, from (@cast_mul R _ d e) ▸ (hmul ▸ this),
 or.elim (eq_zero_or_eq_zero_of_mul_eq_zero this)
-  (assume hd : (d : α) = 0,
-  have p ∣ d, from (cast_eq_zero_iff α p d).mp hd,
+  (assume hd : (d : R) = 0,
+  have p ∣ d, from (cast_eq_zero_iff R p d).mp hd,
   show d = 1 ∨ d = p, from or.inr (dvd_antisymm ⟨e, hmul⟩ this))
-  (assume he : (e : α) = 0,
-  have p ∣ e, from (cast_eq_zero_iff α p e).mp he,
+  (assume he : (e : R) = 0,
+  have p ∣ e, from (cast_eq_zero_iff R p e).mp he,
   have e ∣ p, from dvd_of_mul_left_eq d (eq.symm hmul),
   have e = p, from dvd_antisymm ‹e ∣ p› ‹p ∣ e›,
   have h₀ : p > 0, from gt_of_ge_of_gt hp (nat.zero_lt_succ 1),
@@ -334,17 +332,17 @@ or.elim (eq_zero_or_eq_zero_of_mul_eq_zero this)
 
 section nontrivial
 
-variables [nontrivial α]
+variables [nontrivial R]
 
-theorem char_is_prime_or_zero (p : ℕ) [hc : char_p α p] : nat.prime p ∨ p = 0 :=
+theorem char_is_prime_or_zero (p : ℕ) [hc : char_p R p] : nat.prime p ∨ p = 0 :=
 match p, hc with
 | 0,     _  := or.inr rfl
-| 1,     hc := absurd (eq.refl (1 : ℕ)) (@char_ne_one α _ _ (1 : ℕ) hc)
-| (m+2), hc := or.inl (@char_is_prime_of_two_le α _ _ (m+2) hc (nat.le_add_left 2 m))
+| 1,     hc := absurd (eq.refl (1 : ℕ)) (@char_ne_one R _ _ (1 : ℕ) hc)
+| (m+2), hc := or.inl (@char_is_prime_of_two_le R _ _ (m+2) hc (nat.le_add_left 2 m))
 end
 
-lemma char_is_prime_of_pos (p : ℕ) [h : fact (0 < p)] [char_p α p] : fact p.prime :=
-(char_p.char_is_prime_or_zero α _).resolve_right (pos_iff_ne_zero.1 h)
+lemma char_is_prime_of_pos (p : ℕ) [h : fact (0 < p)] [char_p R p] : fact p.prime :=
+(char_p.char_is_prime_or_zero R _).resolve_right (pos_iff_ne_zero.1 h)
 
 end nontrivial
 
@@ -354,11 +352,11 @@ end semiring
 
 section ring
 
-variables {α : Type*} [ring α] [no_zero_divisors α] [nontrivial α] [fintype α]
+variables {R : Type*} [ring R] [no_zero_divisors R] [nontrivial R] [fintype R]
 
-theorem char_is_prime (p : ℕ) [char_p α p] :
+theorem char_is_prime (p : ℕ) [char_p R p] :
   p.prime :=
-or.resolve_right (char_is_prime_or_zero α p) (char_ne_zero_of_fintype α p)
+or.resolve_right (char_is_prime_or_zero R p) (char_ne_zero_of_fintype R p)
 
 end ring
 

--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -352,7 +352,7 @@ end semiring
 
 section ring
 
-variables {R : Type*} [ring R] [no_zero_divisors R] [nontrivial R] [fintype R]
+variables (R : Type*) [ring R] [no_zero_divisors R] [nontrivial R] [fintype R]
 
 theorem char_is_prime (p : ℕ) [char_p R p] :
   p.prime :=


### PR DESCRIPTION
Taking advantage of the `no_zero_divisors` typeclass, the assumptions on some of the results can be weakened.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
