### PR TITLE
[Merged by Bors] - feat(algebra/normed_space/basic,algebra/group_with_zero/power): real.(f)?pow_{even,bit0}_norm and field fpow lemmas

### DIFF
--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -647,7 +647,7 @@ pow_bit0_pos h 1
 
 variables {x y : R}
 
-@[simp] theorem sqr_abs (x : R) : abs x ^ 2 = x ^ 2 :=
+theorem sqr_abs (x : R) : abs x ^ 2 = x ^ 2 :=
 by simpa only [pow_two] using abs_mul_abs_self x
 
 theorem abs_sqr (x : R) : abs (x ^ 2) = x ^ 2 :=

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -447,18 +447,6 @@ variables [linear_ordered_ring R] {a : R} {n : ℕ}
 @[simp] lemma abs_pow (a : R) (n : ℕ) : abs (a ^ n) = abs a ^ n :=
 abs_hom.to_monoid_hom.map_pow a n
 
-lemma abs_pow_even (a : R) {p : ℕ} (hp : even p) :
-  abs a ^ p = a ^ p :=
-begin
-  obtain ⟨k, rfl⟩ := hp,
-  rw [←abs_pow, abs_eq_self, two_mul, pow_add],
-  exact mul_self_nonneg (a ^ k)
-end
-
-@[simp] lemma abs_pow_bit0 (a : R) (p : ℕ) :
-  abs a ^ bit0 p = a ^ bit0 p :=
-abs_pow_even _ (even_bit0 _)
-
 @[simp] theorem pow_bit1_neg_iff : a ^ bit1 n < 0 ↔ a < 0 :=
 ⟨λ h, not_le.1 $ λ h', not_le.2 h $ pow_nonneg h' _,
   λ h, mul_neg_of_neg_of_pos h (pow_bit0_pos h.ne _)⟩
@@ -489,6 +477,17 @@ by cases hn with k hk; simpa only [hk, two_mul] using pow_bit1_nonpos_iff.mpr ha
 
 theorem pow_odd_neg (ha : a < 0) (hn : odd n) : a ^ n < 0:=
 by cases hn with k hk; simpa only [hk, two_mul] using pow_bit1_neg_iff.mpr ha
+
+lemma pow_even_abs (a : R) {p : ℕ} (hp : even p) :
+  abs a ^ p = a ^ p :=
+begin
+  rw [←abs_pow, abs_eq_self],
+  exact pow_even_nonneg _ hp
+end
+
+@[simp] lemma pow_bit0_abs (a : R) (p : ℕ) :
+  abs a ^ bit0 p = a ^ bit0 p :=
+pow_even_abs _ (even_bit0 _)
 
 lemma strict_mono_pow_bit1 (n : ℕ) : strict_mono (λ a : R, a ^ bit1 n) :=
 begin

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -258,18 +258,6 @@ begin
     @and.comm (b ≤ 0 ) _] }
 end
 
-lemma abs_pow_even {α : Type*} [linear_ordered_ring α] (x : α) {p : ℕ} (hp : even p) :
-  abs (x ^ p) = x ^ p :=
-begin
-  obtain ⟨k, rfl⟩ := hp,
-  rw [abs_eq_self, two_mul, pow_add],
-  exact mul_self_nonneg (x ^ k)
-end
-
-@[simp] lemma abs_pow_bit0 {α : Type*} [linear_ordered_ring α] (x : α) (p : ℕ) :
-  abs (x ^ bit0 p) = x ^ bit0 p :=
-abs_pow_even x (even_bit0 _)
-
 end ordered_add_comm_group
 
 section linear_ordered_add_comm_group
@@ -458,6 +446,18 @@ variables [linear_ordered_ring R] {a : R} {n : ℕ}
 
 @[simp] lemma abs_pow (a : R) (n : ℕ) : abs (a ^ n) = abs a ^ n :=
 abs_hom.to_monoid_hom.map_pow a n
+
+lemma abs_pow_even (a : R) {p : ℕ} (hp : even p) :
+  abs a ^ p = a ^ p :=
+begin
+  obtain ⟨k, rfl⟩ := hp,
+  rw [←abs_pow, abs_eq_self, two_mul, pow_add],
+  exact mul_self_nonneg (a ^ k)
+end
+
+@[simp] lemma abs_pow_bit0 (a : R) (p : ℕ) :
+  abs a ^ bit0 p = a ^ bit0 p :=
+abs_pow_even _ (even_bit0 _)
 
 @[simp] theorem pow_bit1_neg_iff : a ^ bit1 n < 0 ↔ a < 0 :=
 ⟨λ h, not_le.1 $ λ h', not_le.2 h $ pow_nonneg h' _,

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -258,6 +258,18 @@ begin
     @and.comm (b ≤ 0 ) _] }
 end
 
+lemma abs_pow_even {α : Type*} [linear_ordered_ring α] (x : α) {p : ℕ} (hp : even p) :
+  abs (x ^ p) = x ^ p :=
+begin
+  obtain ⟨k, rfl⟩ := hp,
+  rw [abs_eq_self, two_mul, pow_add],
+  exact mul_self_nonneg (x ^ k)
+end
+
+@[simp] lemma abs_pow_bit0 {α : Type*} [linear_ordered_ring α] (x : α) (p : ℕ) :
+  abs (x ^ bit0 p) = x ^ bit0 p :=
+abs_pow_even x (even_bit0 _)
+
 end ordered_add_comm_group
 
 section linear_ordered_add_comm_group

--- a/src/algebra/group_with_zero/power.lean
+++ b/src/algebra/group_with_zero/power.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import algebra.group_power
+import algebra.group_power.lemmas
 
 /-!
 # Powers of elements of groups with an adjoined zero element
@@ -207,6 +207,17 @@ theorem fpow_bit0' (a : G₀) (n : ℤ) : a ^ bit0 n = (a * a) ^ n :=
 theorem fpow_bit1' (a : G₀) (n : ℤ) : a ^ bit1 n = (a * a) ^ n * a :=
 by rw [fpow_bit1, (commute.refl a).mul_fpow]
 
+@[simp] lemma fpow_bit0_neg {F : Type*} [field F] (a : F) (n : ℤ) :
+  (-a) ^ bit0 n = a ^ bit0 n :=
+by rw [fpow_bit0', neg_mul_neg, fpow_bit0']
+
+lemma fpow_even_neg {F : Type*} [field F] (a : F) {n : ℤ} (h : even n) :
+  (-a) ^ n = a ^ n :=
+begin
+  obtain ⟨k, rfl⟩ := h,
+  simp [←bit0_eq_two_mul]
+end
+
 lemma fpow_eq_zero {x : G₀} {n : ℤ} (h : x ^ n = 0) : x = 0 :=
 classical.by_contradiction $ λ hx, fpow_ne_zero_of_ne_zero hx n h
 
@@ -257,3 +268,20 @@ lemma monoid_with_zero_hom.map_fpow {G₀ G₀' : Type*} [group_with_zero G₀] 
   ∀ n : ℤ, f (x ^ n) = f x ^ n
 | (n : ℕ) := f.to_monoid_hom.map_pow x n
 | -[1+n] := (f.map_inv' _).trans $ congr_arg _ $ f.to_monoid_hom.map_pow x _
+
+section abs
+
+variables {F : Type*} [linear_ordered_field F]
+
+lemma abs_fpow_even (a : F) {p : ℤ} (hp : even p) :
+  abs a ^ p = a ^ p :=
+begin
+  cases le_or_lt a (-a) with h h;
+  simp [abs, h, max_eq_left_of_lt, fpow_even_neg _ hp]
+end
+
+@[simp] lemma abs_fpow_bit0 (a : F) (p : ℤ) :
+  abs a ^ bit0 p = a ^ bit0 p :=
+abs_fpow_even _ (even_bit0 _)
+
+end abs

--- a/src/algebra/group_with_zero/power.lean
+++ b/src/algebra/group_with_zero/power.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import algebra.group_power.lemmas
+import algebra.group_power
 
 /-!
 # Powers of elements of groups with an adjoined zero element

--- a/src/algebra/group_with_zero/power.lean
+++ b/src/algebra/group_with_zero/power.lean
@@ -87,6 +87,13 @@ lemma zero_fpow : ∀ z : ℤ, z ≠ 0 → (0 : G₀) ^ z = 0
 | (of_nat n) h := zero_pow' _ $ by rintro rfl; exact h rfl
 | -[1+n]     h := show (0*0 ^ n)⁻¹ = (0 : G₀), by simp
 
+lemma fzero_pow_eq (n : ℤ) : (0 : G₀) ^ n = if n = 0 then 1 else 0 :=
+begin
+  split_ifs with h,
+  { rw [h, fpow_zero] },
+  { rw [zero_fpow _ h] }
+end
+
 @[simp] theorem fpow_neg (a : G₀) : ∀ (n : ℤ), a ^ -n = (a ^ n)⁻¹
 | (n+1:ℕ) := rfl
 | 0       := inv_one.symm
@@ -243,6 +250,116 @@ by simp only [one_div, inv_fpow]
   (a ⁻¹) ^ n = a ^ (-n) :=
 by { rw [inv_fpow, ← fpow_neg_one, ← fpow_mul], simp }
 
+section field
+
+variables {F : Type*} [linear_ordered_field F] {a : F} {n : ℤ}
+
+lemma fpow_eq_zero_iff (hn : 0 < n) :
+  a ^ n = 0 ↔ a = 0 :=
+begin
+  refine ⟨fpow_eq_zero, _⟩,
+  rintros rfl,
+  exact zero_fpow _ hn.ne'
+end
+
+lemma fpow_nonneg (h : 0 ≤ a) (n : ℤ) : 0 ≤ a ^ n :=
+begin
+  by_cases ha : a = 0,
+  { rw [ha, fzero_pow_eq],
+    split_ifs;
+    simp [le_refl, zero_le_one] },
+  induction n using int.induction_on with n hn n hn,
+  { simpa using zero_le_one },
+  { rw [fpow_add_one ha],
+    exact mul_nonneg hn h },
+  { rw [fpow_sub_one ha],
+    exact mul_nonneg hn (inv_nonneg.mpr h) }
+end
+
+theorem fpow_bit0_nonneg (a : F) (n : ℤ) : 0 ≤ a ^ bit0 n :=
+by { rw fpow_bit0, exact mul_self_nonneg _ }
+
+theorem fpow_two_nonneg (a : F) : 0 ≤ a ^ 2 :=
+pow_bit0_nonneg a 1
+
+theorem fpow_bit0_pos {a : F} (h : a ≠ 0) (n : ℤ) : 0 < a ^ bit0 n :=
+(fpow_bit0_nonneg a n).lt_of_ne (fpow_ne_zero _ h).symm
+
+theorem fpow_two_pos_of_ne_zero (a : F) (h : a ≠ 0) : 0 < a ^ 2 :=
+pow_bit0_pos h 1
+
+@[simp] theorem fpow_bit1_neg_iff : a ^ bit1 n < 0 ↔ a < 0 :=
+⟨λ h, not_le.1 $ λ h', not_le.2 h $ fpow_nonneg h' _,
+ λ h, by rw [bit1, fpow_add_one h.ne]; exact mul_neg_of_pos_of_neg (fpow_bit0_pos h.ne _) h⟩
+
+@[simp] theorem fpow_bit1_nonneg_iff : 0 ≤ a ^ bit1 n ↔ 0 ≤ a :=
+le_iff_le_iff_lt_iff_lt.2 fpow_bit1_neg_iff
+
+@[simp] theorem fpow_bit1_nonpos_iff : a ^ bit1 n ≤ 0 ↔ a ≤ 0 :=
+begin
+  rw [le_iff_lt_or_eq, fpow_bit1_neg_iff],
+  split,
+  { rintro (h | h),
+    { exact h.le },
+    { exact (fpow_eq_zero h).le } },
+  { intro h,
+    rcases eq_or_lt_of_le h with rfl|h,
+    { exact or.inr (zero_fpow _ (bit1_ne_zero n)) },
+    { exact or.inl h } }
+end
+
+@[simp] theorem fpow_bit1_pos_iff : 0 < a ^ bit1 n ↔ 0 < a :=
+lt_iff_lt_of_le_iff_le fpow_bit1_nonpos_iff
+
+lemma fpow_even_nonneg (a : F) {n : ℤ} (hn : even n) :
+  0 ≤ a ^ n :=
+begin
+  cases le_or_lt 0 a with h h,
+  { exact fpow_nonneg h _ },
+  { rw [←fpow_even_neg _ hn],
+    replace h : 0 ≤ -a := neg_nonneg_of_nonpos (le_of_lt h),
+    exact fpow_nonneg h _ }
+end
+
+theorem fpow_even_pos (ha : a ≠ 0) (hn : even n) : 0 < a ^ n :=
+by cases hn with k hk; simpa only [hk, two_mul] using fpow_bit0_pos ha k
+
+theorem fpow_odd_nonneg (ha : 0 ≤ a) (hn : odd n) : 0 ≤ a ^ n :=
+by cases hn with k hk; simpa only [hk, two_mul] using fpow_bit1_nonneg_iff.mpr ha
+
+theorem fpow_odd_pos (ha : 0 < a) (hn : odd n) : 0 < a ^ n :=
+by cases hn with k hk; simpa only [hk, two_mul] using fpow_bit1_pos_iff.mpr ha
+
+theorem fpow_odd_nonpos (ha : a ≤ 0) (hn : odd n) : a ^ n ≤ 0:=
+by cases hn with k hk; simpa only [hk, two_mul] using fpow_bit1_nonpos_iff.mpr ha
+
+theorem fpow_odd_neg (ha : a < 0) (hn : odd n) : a ^ n < 0:=
+by cases hn with k hk; simpa only [hk, two_mul] using fpow_bit1_neg_iff.mpr ha
+
+lemma fpow_even_abs (a : F) {p : ℤ} (hp : even p) :
+  abs a ^ p = a ^ p :=
+begin
+  cases le_or_lt a (-a) with h h;
+  simp [abs, h, max_eq_left_of_lt, fpow_even_neg _ hp]
+end
+
+@[simp] lemma fpow_bit0_abs (a : F) (p : ℤ) :
+  (abs a) ^ bit0 p = a ^ bit0 p :=
+fpow_even_abs _ (even_bit0 _)
+
+lemma abs_fpow_even (a : F) {p : ℤ} (hp : even p) :
+  abs (a ^ p) = a ^ p :=
+begin
+  rw [←fpow_even_abs _ hp, abs_eq_self],
+  exact fpow_even_nonneg _ hp
+end
+
+@[simp] lemma abs_fpow_bit0 (a : F) (p : ℤ) :
+  abs (a ^ bit0 p) = a ^ bit0 p :=
+abs_fpow_even _ (even_bit0 _)
+
+end field
+
 end int_pow
 
 section
@@ -268,20 +385,3 @@ lemma monoid_with_zero_hom.map_fpow {G₀ G₀' : Type*} [group_with_zero G₀] 
   ∀ n : ℤ, f (x ^ n) = f x ^ n
 | (n : ℕ) := f.to_monoid_hom.map_pow x n
 | -[1+n] := (f.map_inv' _).trans $ congr_arg _ $ f.to_monoid_hom.map_pow x _
-
-section abs
-
-variables {F : Type*} [linear_ordered_field F]
-
-lemma abs_fpow_even (a : F) {p : ℤ} (hp : even p) :
-  abs a ^ p = a ^ p :=
-begin
-  cases le_or_lt a (-a) with h h;
-  simp [abs, h, max_eq_left_of_lt, fpow_even_neg _ hp]
-end
-
-@[simp] lemma abs_fpow_bit0 (a : F) (p : ℤ) :
-  abs a ^ bit0 p = a ^ bit0 p :=
-abs_fpow_even _ (even_bit0 _)
-
-end abs

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -181,6 +181,9 @@ by { ext x, simp [even, eq_comm] }
 /-- An element `a` of a semiring is odd if there exists `k` such `a = 2*k + 1`. -/
 def odd (a : α) : Prop := ∃ k, a = 2*k + 1
 
+@[simp] lemma odd_bit1 (a : α) : odd (bit1 a) :=
+⟨a, by rw [bit1, bit0, two_mul]⟩
+
 @[simp] lemma range_two_mul_add_one (α : Type*) [semiring α] :
   set.range (λ x : α, 2 * x + 1) = {a | odd a} :=
 by { ext x, simp [odd, eq_comm] }

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -175,6 +175,9 @@ lemma even_iff_two_dvd {a : α} : even a ↔ 2 ∣ a := iff.rfl
   set.range (λ x : α, 2 * x) = {a | even a} :=
 by { ext x, simp [even, eq_comm] }
 
+@[simp] lemma even_bit0 (a : α) : even (bit0 a) :=
+⟨a, by rw [bit0, two_mul]⟩
+
 /-- An element `a` of a semiring is odd if there exists `k` such `a = 2*k + 1`. -/
 def odd (a : α) : Prop := ∃ k, a = 2*k + 1
 

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -94,7 +94,7 @@ begin
     exact (differentiable_on_fpow (lt_irrefl _)).const_mul _ },
   { intros x hx,
     simp only [iter_deriv_fpow (ne_of_gt hx)],
-    refine mul_nonneg (int.cast_nonneg.2 _) (fpow_nonneg_of_nonneg (le_of_lt hx) _),
+    refine mul_nonneg (int.cast_nonneg.2 _) (fpow_nonneg (le_of_lt hx) _),
     exact int_prod_range_nonneg _ _ (nat.even_bit0 1) }
 end
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -80,19 +80,19 @@ lemma real.norm_eq_abs (r : ℝ) : ∥r∥ = abs r := rfl
 
 lemma real.pow_even_norm (x : ℝ) {p : ℕ} (hp : even p) :
   ∥x∥ ^ p = x ^ p :=
-by rw [real.norm_eq_abs, ←abs_pow, abs_pow_even x hp]
+by rw [real.norm_eq_abs, abs_pow_even x hp]
 
 lemma real.norm_pow_even (x : ℝ) {p : ℕ} (hp : even p) :
   ∥x ^ p∥ = x ^ p :=
-by rw [real.norm_eq_abs, abs_pow_even x hp]
+by rw [real.norm_eq_abs, abs_pow, abs_pow_even x hp]
 
 @[simp] lemma real.pow_bit0_norm (x : ℝ) (p : ℕ) :
   ∥x∥ ^ bit0 p = x ^ bit0 p :=
-by simp [real.norm_eq_abs, ←abs_pow]
+real.pow_even_norm _ (even_bit0 _)
 
 @[simp] lemma real.norm_pow_bit0 (x : ℝ) (p : ℕ) :
   ∥x ^ bit0 p∥ = x ^ bit0 p :=
-by simp [real.norm_eq_abs, ←abs_pow]
+real.norm_pow_even _ (even_bit0 _)
 
 section normed_group
 variables [normed_group α] [normed_group β]

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -78,6 +78,14 @@ instance : normed_group ℝ :=
 
 lemma real.norm_eq_abs (r : ℝ) : ∥r∥ = abs r := rfl
 
+lemma real.norm_pow_even (x : ℝ) {p : ℕ} (hp : even p) :
+  ∥x∥ ^ p = x ^ p :=
+by rw [real.norm_eq_abs, ←abs_pow, abs_pow_even x hp]
+
+@[simp] lemma real.norm_pow_bit0 (x : ℝ) (p : ℕ) :
+  ∥x∥ ^ bit0 p = x ^ bit0 p :=
+by simp [real.norm_eq_abs, ←abs_pow]
+
 section normed_group
 variables [normed_group α] [normed_group β]
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -78,12 +78,20 @@ instance : normed_group ℝ :=
 
 lemma real.norm_eq_abs (r : ℝ) : ∥r∥ = abs r := rfl
 
-lemma real.norm_pow_even (x : ℝ) {p : ℕ} (hp : even p) :
+lemma real.pow_even_norm (x : ℝ) {p : ℕ} (hp : even p) :
   ∥x∥ ^ p = x ^ p :=
 by rw [real.norm_eq_abs, ←abs_pow, abs_pow_even x hp]
 
-@[simp] lemma real.norm_pow_bit0 (x : ℝ) (p : ℕ) :
+lemma real.norm_pow_even (x : ℝ) {p : ℕ} (hp : even p) :
+  ∥x ^ p∥ = x ^ p :=
+by rw [real.norm_eq_abs, abs_pow_even x hp]
+
+@[simp] lemma real.pow_bit0_norm (x : ℝ) (p : ℕ) :
   ∥x∥ ^ bit0 p = x ^ bit0 p :=
+by simp [real.norm_eq_abs, ←abs_pow]
+
+@[simp] lemma real.norm_pow_bit0 (x : ℝ) (p : ℕ) :
+  ∥x ^ bit0 p∥ = x ^ bit0 p :=
 by simp [real.norm_eq_abs, ←abs_pow]
 
 section normed_group

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -80,19 +80,19 @@ lemma real.norm_eq_abs (r : ℝ) : ∥r∥ = abs r := rfl
 
 lemma real.pow_even_norm (x : ℝ) {p : ℕ} (hp : even p) :
   ∥x∥ ^ p = x ^ p :=
-by rw [real.norm_eq_abs, abs_pow_even x hp]
-
-lemma real.norm_pow_even (x : ℝ) {p : ℕ} (hp : even p) :
-  ∥x ^ p∥ = x ^ p :=
-by rw [real.norm_eq_abs, abs_pow, abs_pow_even x hp]
+by rw [real.norm_eq_abs, pow_even_abs x hp]
 
 @[simp] lemma real.pow_bit0_norm (x : ℝ) (p : ℕ) :
   ∥x∥ ^ bit0 p = x ^ bit0 p :=
 real.pow_even_norm _ (even_bit0 _)
 
-@[simp] lemma real.norm_pow_bit0 (x : ℝ) (p : ℕ) :
-  ∥x ^ bit0 p∥ = x ^ bit0 p :=
-real.norm_pow_even _ (even_bit0 _)
+lemma real.fpow_even_norm (x : ℝ) {p : ℤ} (hp : even p) :
+  ∥x∥ ^ p = x ^ p :=
+by rw [real.norm_eq_abs, fpow_even_abs x hp]
+
+@[simp] lemma real.fpow_bit0_norm (x : ℝ) (p : ℤ) :
+  ∥x∥ ^ bit0 p = x ^ bit0 p :=
+real.fpow_even_norm _ (even_bit0 _)
 
 section normed_group
 variables [normed_group α] [normed_group β]

--- a/src/data/padics/padic_norm.lean
+++ b/src/data/padics/padic_norm.lean
@@ -508,7 +508,7 @@ if hq : q = 0 then by simp [hq, padic_norm]
 else
   begin
     unfold padic_norm; split_ifs,
-    apply fpow_nonneg_of_nonneg,
+    apply fpow_nonneg,
     exact_mod_cast nat.zero_le _
   end
 


### PR DESCRIPTION
Simplifcation of `norm` when to an even numeral power.

Additionally, add `fpow` lemmas to match `pow` lemmas, and change `fpow_nonneg_to_nonneg` to `fpow_nonneg` to match `pow` naming.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
