### PR TITLE
[Merged by Bors] - doc(field_theory/normal): Add authors

### DIFF
--- a/src/field_theory/normal.lean
+++ b/src/field_theory/normal.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kenny Lau
+Authors: Kenny Lau, Thomas Browning, Patrick Lutz
 -/
 
 import field_theory.adjoin


### PR DESCRIPTION
Adds Patrick Lutz and I as authors to normal.lean. The last three-quarters of the file are from our work on Abel-Ruffini.

https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Author.20on.20normal.2Elean.3F

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
