### PR TITLE
[Merged by Bors] - refactor(algebraic_topology/simplex_category): Make simplex_category universe polymorphic.

### DIFF
--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -15,6 +15,19 @@ We construct a skeletal model of the simplex category, with objects `ℕ` and th
 morphism `n ⟶ m` being the monotone maps from `fin (n+1)` to `fin (m+1)`.
 
 We show that this category is equivalent to `NonemptyFinLinOrd`.
+
+## Remarks
+
+The definitions `simplex_category` and `simplex_category.hom` are marked as irreducible.
+
+We provide the following functions to work with these objects:
+1. `simplex_category.mk` creates an object of `simplex_category` out of a natural number.
+  Use the notation `[n]` in the `simplicial` locale.
+2. `simplex_category.len` gives the "length" of an object of `simplex_category`, as a natural.
+3. `simplex_category.hom.mk` makes a morphism out of a monotone map between `fin`'s.
+4. `simplex_category.hom.to_preorder_hom` gives the underlying monotone map associated to a
+  term of `simplex_category.hom`.
+
 -/
 
 universe variables u

--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -36,7 +36,7 @@ local attribute [semireducible] simplex_category
 /-- Interpet a natural number as an object of the simplex category. -/
 def mk (n : ℕ) : simplex_category := ulift.up n
 
-localized "notation `[`n`]` := mk n" in simplicial
+localized "notation `[`n`]` := simplex_category.mk n" in simplicial
 
 /-- The length of an object of `simplex_category`. -/
 def len (n : simplex_category) : ℕ := n.down

--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -25,13 +25,18 @@ open category_theory
 * objects are natural numbers `n : ℕ`
 * morphisms from `n` to `m` are monotone functions `fin (n+1) → fin (m+1)`
 -/
-@[derive inhabited]
+@[derive inhabited, irreducible]
 def simplex_category := ulift.{u} ℕ
 
 namespace simplex_category
+
+section
+local attribute [semireducible] simplex_category
+
 /-- Interpet a natural number as an object of the simplex category. -/
-@[reducible, simp] def mk (n : ℕ) : simplex_category := ulift.up n
-local notation `[`n`]` := mk n
+def mk (n : ℕ) : simplex_category := ulift.up n
+
+localized "notation `[`n`]` := mk n" in simplicial
 
 /-- The length of an object of `simplex_category`. -/
 def len (n : simplex_category) : ℕ := n.down
@@ -46,9 +51,34 @@ instance small_category : small_category.{u} simplex_category :=
   id := λ m, ulift.up preorder_hom.id,
   comp := λ _ _ _ f g, ulift.up $ preorder_hom.comp g.down f.down, }
 
+def mk_hom {n m : ℕ} (f : (fin (n+1)) →ₘ (fin (m+1))) : [n] ⟶ [m] :=
+ulift.up.{u} f
+
+@[simp] lemma mk_hom_comp_mk_hom_down
+  {l m n : ℕ} (f : (fin (l+1)) →ₘ (fin (m+1))) (g : (fin (m+1)) →ₘ (fin (n+1))) :
+  (mk_hom f ≫ mk_hom g).down = g.comp f :=
+rfl
+
+@[simp] lemma mk_hom_down {n m : ℕ} (f : (fin (n+1)) →ₘ (fin (m+1))) :
+  (mk_hom f).down = f :=
+rfl
+
+end
+
+open_locale simplicial
+
 instance {a b : simplex_category} : has_coe_to_fun (a ⟶ b) :=
 { F := λ _, fin (a.len + 1) → fin (b.len + 1),
   coe := λ f, (f.down : fin (a.len + 1) → fin (b.len + 1)) }
+
+@[simp] lemma mk_hom_id_coe {n : ℕ} :
+  (𝟙 [n] : fin (n+1) → fin (n+1)) = id :=
+rfl
+
+@[simp] lemma mk_hom_comp_mk_hom_coe
+  {l m n : ℕ} (f : (fin (l+1)) →ₘ (fin (m+1))) (g : (fin (m+1)) →ₘ (fin (n+1))) :
+  (mk_hom f ≫ mk_hom g : fin (l+1) → fin (n+1)) = g.comp f :=
+rfl
 
 @[ext] lemma ext_hom {a b : simplex_category} (f g : a ⟶ b) :
   (∀ i : fin (a.len + 1), f i = g i) → f = g := by tidy
@@ -72,10 +102,10 @@ one given by the following generators and relations.
 
 /-- The `i`-th face map from `[n]` to `[n+1]` -/
 def δ {n} (i : fin (n+2)) : [n] ⟶ [n+1] :=
-ulift.up (fin.succ_above i).to_preorder_hom
+mk_hom (fin.succ_above i).to_preorder_hom
 
 /-- The `i`-th degeneracy map from `[n+1]` to `[n]` -/
-def σ {n} (i : fin (n+1)) : [n+1] ⟶ [n] := ulift.up
+def σ {n} (i : fin (n+1)) : [n+1] ⟶ [n] := mk_hom
 { to_fun := fin.pred_above i,
   monotone' := fin.pred_above_right_monotone i }
 
@@ -268,7 +298,7 @@ instance : faithful skeletal_functor.{u} :=
   end }
 
 instance : ess_surj skeletal_functor.{u} :=
-{ mem_ess_image := λ X, ⟨ulift.up (fintype.card X - 1 : ℕ), ⟨begin
+{ mem_ess_image := λ X, ⟨mk (fintype.card X - 1 : ℕ), ⟨begin
     have aux : fintype.card X = fintype.card X - 1 + 1,
     { exact (nat.succ_pred_eq_of_pos $ fintype.card_pos_iff.mpr ⟨⊥⟩).symm, },
     let f := mono_equiv_of_fin X aux,

--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -33,11 +33,13 @@ namespace simplex_category
 section
 local attribute [semireducible] simplex_category
 
+-- TODO: Make `mk` irreducible.
 /-- Interpet a natural number as an object of the simplex category. -/
 def mk (n : ℕ) : simplex_category := ulift.up n
 
 localized "notation `[`n`]` := simplex_category.mk n" in simplicial
 
+-- TODO: Make `len` irreducible.
 /-- The length of an object of `simplex_category`. -/
 def len (n : simplex_category) : ℕ := n.down
 
@@ -45,7 +47,8 @@ def len (n : simplex_category) : ℕ := n.down
 @[simp] lemma len_mk (n : ℕ) : [n].len = n := rfl
 @[simp] lemma mk_len (n : simplex_category) : [n.len] = n := by {cases n, refl}
 
-@[irreducible]
+/-- Morphisms in the simplex_category. -/
+@[irreducible, nolint has_inhabited_instance]
 protected def hom (a b : simplex_category.{u}) : Type u :=
 ulift (fin (a.len + 1) →ₘ fin (b.len + 1))
 
@@ -53,10 +56,12 @@ namespace hom
 
 local attribute [semireducible] simplex_category.hom
 
+/-- Make a moprhism in `simplex_category` from a monotone map of fin's. -/
 def mk {a b : simplex_category.{u}} (f : fin (a.len + 1) →ₘ fin (b.len + 1)) :
   simplex_category.hom a b :=
 ulift.up f
 
+/-- Recover the monotone map from a morphism in the simplex category. -/
 def to_preorder_hom {a b : simplex_category.{u}} (f : simplex_category.hom a b) :
   fin (a.len + 1) →ₘ fin (b.len + 1) :=
 ulift.down f
@@ -76,11 +81,13 @@ lemma mk_to_preorder_hom_apply {a b : simplex_category.{u}}
   (f : fin (a.len + 1) →ₘ fin (b.len + 1)) (i : fin (a.len + 1)) :
   (mk f).to_preorder_hom i = f i := rfl
 
+/-- Identity morphisms of `simplex_category`. -/
 @[simp]
 def id (a : simplex_category.{u}) :
   simplex_category.hom a a :=
 mk preorder_hom.id
 
+/-- Composition of morphisms of `simplex_category`. -/
 @[simp]
 def comp {a b c : simplex_category.{u}} (f : simplex_category.hom b c)
   (g : simplex_category.hom a b) : simplex_category.hom a c :=
@@ -94,47 +101,18 @@ instance small_category : small_category.{u} simplex_category :=
   id := λ m, simplex_category.hom.id _,
   comp := λ _ _ _ f g, simplex_category.hom.comp g f, }
 
+/--
+Make a morphism `[n] ⟶ [m]` from a monotone map between fin's.
+This is useful for constructing morphisms beetween `[n]` directly
+without identifying `n` with `[n].len`.
+-/
 @[simp]
 def mk_hom {n m : ℕ} (f : (fin (n+1)) →ₘ (fin (m+1))) : [n] ⟶ [m] :=
 simplex_category.hom.mk f
 
---@[simp] lemma mk_hom_comp_mk_hom_to_preorder_hom
---  {l m n : ℕ} (f : (fin (l+1)) →ₘ (fin (m+1))) (g : (fin (m+1)) →ₘ (fin (n+1))) :
---  (mk_hom f ≫ mk_hom g).to_preorder_hom = g.comp f :=
-
---@[simp] lemma mk_hom_to_preorder_hom {n m : ℕ} (f : (fin (n+1)) →ₘ (fin (m+1))) :
---  (mk_hom f).to_preorder_hom = f :=
-
 end
 
 open_locale simplicial
-
-/-
-instance {a b : simplex_category} : has_coe_to_fun (a ⟶ b) :=
-{ F := λ _, fin (a.len + 1) → fin (b.len + 1),
-  coe := λ f, (f.down : fin (a.len + 1) → fin (b.len + 1)) }
-
-@[simp] lemma mk_hom_id_coe {n : ℕ} :
-  (𝟙 [n] : fin (n+1) → fin (n+1)) = id :=
-rfl
-
-@[simp] lemma mk_hom_comp_mk_hom_coe
-  {l m n : ℕ} (f : (fin (l+1)) →ₘ (fin (m+1))) (g : (fin (m+1)) →ₘ (fin (n+1))) :
-  (mk_hom f ≫ mk_hom g : fin (l+1) → fin (n+1)) = g.comp f :=
-rfl
-
-@[ext] lemma ext_hom {a b : simplex_category} (f g : a ⟶ b) :
-  (∀ i : fin (a.len + 1), f i = g i) → f = g := by tidy
-
-@[simp] lemma apply_eq_down_apply {a b : simplex_category} (f : a ⟶ b)
-  (i : fin (a.len + 1)) : f i = f.down i := rfl
-
-@[simp] lemma id_apply {n : simplex_category} (i : fin (n.len+1)) :
-  (𝟙 n : n ⟶ n).down i = i := rfl
-
-@[simp] lemma comp_apply {l m n : simplex_category} (f : l ⟶ m) (g : m ⟶ n) (i : fin (l.len+1)) :
-  (f ≫ g).down i = g.down (f.down i) := rfl
--/
 
 section generators
 /-!
@@ -325,7 +303,8 @@ section skeleton
 of `NonemptyFinLinOrd` -/
 def skeletal_functor : simplex_category ⥤ NonemptyFinLinOrd :=
 { obj := λ a, NonemptyFinLinOrd.of $ ulift (fin (a.len + 1)),
-  map := λ a b f, ⟨λ i, ulift.up (f.to_preorder_hom i.down), λ i j h, f.to_preorder_hom.monotone h⟩ }
+  map := λ a b f,
+    ⟨λ i, ulift.up (f.to_preorder_hom i.down), λ i j h, f.to_preorder_hom.monotone h⟩ }
 
 lemma skeletal : skeletal simplex_category :=
 λ X Y ⟨I⟩,
@@ -340,7 +319,7 @@ end
 namespace skeletal_functor
 
 instance : full skeletal_functor :=
-{ preimage := λ a b f, simplex_category.hom.mk $ ⟨λ i, (f (ulift.up i)).down, λ i j h, f.monotone h⟩,
+{ preimage := λ a b f, simplex_category.hom.mk ⟨λ i, (f (ulift.up i)).down, λ i j h, f.monotone h⟩,
   witness' := by { intros m n f, dsimp at *, ext1 ⟨i⟩, ext1, refl } }
 
 instance : faithful skeletal_functor :=

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -32,7 +32,10 @@ def simplicial_object := simplex_category.{v}ᵒᵖ ⥤ C
 
 namespace simplicial_object
 
-open_locale simplicial
+-- TODO: find a sensible value for `1000`.
+localized
+  "notation X `_[`:1000 n `]` := (X : simplicial_object _).obj (op (simplex_category.mk n))"
+  in simplicial
 
 instance {J : Type v} [small_category J] [has_limits_of_shape J C] :
   has_limits_of_shape J (simplicial_object C) := by {dsimp [simplicial_object], apply_instance}
@@ -47,19 +50,16 @@ instance [has_colimits C] : has_colimits (simplicial_object C) := ⟨infer_insta
 variables {C} (X : simplicial_object C)
 
 /-- Face maps for a simplicial object. -/
-def δ {n} (i : fin (n+2)) :
-  X.obj (op [n+1]) ⟶ X.obj (op [n]) :=
+def δ {n} (i : fin (n+2)) : X _[n+1] ⟶ X _[n] :=
 X.map (simplex_category.δ i).op
 
 /-- Degeneracy maps for a simplicial object. -/
-def σ {n} (i : fin (n+1)) :
-  X.obj (op [n]) ⟶ X.obj (op [n+1]) :=
+def σ {n} (i : fin (n+1)) : X _[n] ⟶ X _[n+1] :=
 X.map (simplex_category.σ i).op
 
 
 /-- Isomorphisms from identities in ℕ. -/
-def eq_to_iso {n m : ℕ} (h : n = m) :
-  X.obj (op [n]) ≅ X.obj (op [m]) :=
+def eq_to_iso {n m : ℕ} (h : n = m) : X _[n] ≅ X _[m] :=
 X.map_iso (eq_to_iso (by rw h))
 
 @[simp] lemma eq_to_iso_refl {n : ℕ} (h : n = n) : X.eq_to_iso h = iso.refl _ :=

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johan Commelin, Scott Morrison
+Authors: Johan Commelin, Scott Morrison, Adam Topaz
 -/
 import algebraic_topology.simplex_category
 import category_theory.category.ulift
@@ -28,39 +28,36 @@ variables (C : Type u) [category.{v} C]
 /-- The category of simplicial objects valued in a category `C`.
 This is the category of contravariant functors from `simplex_category` to `C`. -/
 @[derive category, nolint has_inhabited_instance]
-def simplicial_object := simplex_categoryᵒᵖ ⥤ C
+def simplicial_object := simplex_category.{v}ᵒᵖ ⥤ C
 
 namespace simplicial_object
 
 instance {J : Type v} [small_category J] [has_limits_of_shape J C] :
-  has_limits_of_shape J (simplicial_object C) :=
-let E : (simplex_categoryᵒᵖ ⥤ C) ≌ (ulift.{v} simplex_category)ᵒᵖ ⥤ C :=
-  ulift.equivalence.op.congr_left in
-  adjunction.has_limits_of_shape_of_equivalence E.functor
+  has_limits_of_shape J (simplicial_object C) := by {dsimp [simplicial_object], apply_instance}
 
 instance [has_limits C] : has_limits (simplicial_object C) := ⟨infer_instance⟩
 
 instance {J : Type v} [small_category J] [has_colimits_of_shape J C] :
-  has_colimits_of_shape J (simplicial_object C) :=
-let E : (simplex_categoryᵒᵖ ⥤ C) ≌ (ulift.{v} simplex_category)ᵒᵖ ⥤ C :=
-  ulift.equivalence.op.congr_left in
-  adjunction.has_colimits_of_shape_of_equivalence E.functor
+  has_colimits_of_shape J (simplicial_object C) := by {dsimp [simplicial_object], apply_instance}
 
 instance [has_colimits C] : has_colimits (simplicial_object C) := ⟨infer_instance⟩
 
 variables {C} (X : simplicial_object C)
 
 /-- Face maps for a simplicial object. -/
-def δ {n} (i : fin (n+2)) : X.obj (op (n+1 : ℕ)) ⟶ X.obj (op n) :=
+def δ {n} (i : fin (n+2)) :
+  X.obj (op (simplex_category.mk (n+1))) ⟶ X.obj (op (simplex_category.mk n)) :=
 X.map (simplex_category.δ i).op
 
 /-- Degeneracy maps for a simplicial object. -/
-def σ {n} (i : fin (n+1)) : X.obj (op n) ⟶ X.obj (op (n+1 : ℕ)) :=
+def σ {n} (i : fin (n+1)) :
+  X.obj (op (simplex_category.mk n)) ⟶ X.obj (op (simplex_category.mk (n+1))) :=
 X.map (simplex_category.σ i).op
 
 
 /-- Isomorphisms from identities in ℕ. -/
-def eq_to_iso {n m : ℕ} (h : n = m) : X.obj (op n) ≅ X.obj (op m) :=
+def eq_to_iso {n m : ℕ} (h : n = m) :
+  X.obj (op (simplex_category.mk n)) ≅ X.obj (op (simplex_category.mk m)) :=
 X.map_iso (eq_to_iso (by rw h))
 
 @[simp] lemma eq_to_iso_refl {n : ℕ} (h : n = n) : X.eq_to_iso h = iso.refl _ :=
@@ -110,24 +107,18 @@ by { dsimp [δ, σ], simp only [←X.map_comp, ←op_comp, simplex_category.σ_c
 variable (C)
 /-- Truncated simplicial objects. -/
 @[derive category, nolint has_inhabited_instance]
-def truncated (n : ℕ) := (simplex_category.truncated n)ᵒᵖ ⥤ C
+def truncated (n : ℕ) := (simplex_category.truncated.{v} n)ᵒᵖ ⥤ C
 variable {C}
 
 namespace truncated
 
 instance {n} {J : Type v} [small_category J] [has_limits_of_shape J C] :
-  has_limits_of_shape J (simplicial_object.truncated C n) :=
-let E : (simplex_category.truncated n)ᵒᵖ ⥤ C ≌ (ulift.{v} (simplex_category.truncated n))ᵒᵖ ⥤ C :=
-  ulift.equivalence.op.congr_left in
-  adjunction.has_limits_of_shape_of_equivalence E.functor
+  has_limits_of_shape J (simplicial_object.truncated C n) := by {dsimp [truncated], apply_instance}
 
 instance {n} [has_limits C] : has_limits (simplicial_object.truncated C n) := ⟨infer_instance⟩
 
 instance {n} {J : Type v} [small_category J] [has_colimits_of_shape J C] :
-  has_colimits_of_shape J (simplicial_object.truncated C n) :=
-let E : (simplex_category.truncated n)ᵒᵖ ⥤ C ≌ (ulift.{v} (simplex_category.truncated n))ᵒᵖ ⥤ C :=
-  ulift.equivalence.op.congr_left in
-  adjunction.has_colimits_of_shape_of_equivalence E.functor
+  has_colimits_of_shape J (simplicial_object.truncated C n) := by {dsimp [truncated], apply_instance}
 
 instance {n} [has_colimits C] : has_colimits (simplicial_object.truncated C n) := ⟨infer_instance⟩
 

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -13,6 +13,10 @@ import category_theory.adjunction.limits
 # Simplicial objects in a category.
 
 A simplicial object in a category `C` is a `C`-valued presheaf on `simplex_category`.
+
+Use the notation `X _[n]` in the `simplicial` locacle to obtain the `n`-th term of a
+simplicial object `X`, where `n` is a natural number.
+
 -/
 
 open opposite

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -14,7 +14,7 @@ import category_theory.adjunction.limits
 
 A simplicial object in a category `C` is a `C`-valued presheaf on `simplex_category`.
 
-Use the notation `X _[n]` in the `simplicial` locacle to obtain the `n`-th term of a
+Use the notation `X _[n]` in the `simplicial` locale to obtain the `n`-th term of a
 simplicial object `X`, where `n` is a natural number.
 
 -/
@@ -36,7 +36,6 @@ def simplicial_object := simplex_category.{v}ᵒᵖ ⥤ C
 
 namespace simplicial_object
 
--- TODO: find a sensible value for `1000`.
 localized
   "notation X `_[`:1000 n `]` :=
     (X : simplicial_object _).obj (opposite.op (simplex_category.mk n))"

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -32,6 +32,8 @@ def simplicial_object := simplex_category.{v}ᵒᵖ ⥤ C
 
 namespace simplicial_object
 
+open_locale simplicial
+
 instance {J : Type v} [small_category J] [has_limits_of_shape J C] :
   has_limits_of_shape J (simplicial_object C) := by {dsimp [simplicial_object], apply_instance}
 
@@ -46,18 +48,18 @@ variables {C} (X : simplicial_object C)
 
 /-- Face maps for a simplicial object. -/
 def δ {n} (i : fin (n+2)) :
-  X.obj (op (simplex_category.mk (n+1))) ⟶ X.obj (op (simplex_category.mk n)) :=
+  X.obj (op [n+1]) ⟶ X.obj (op [n]) :=
 X.map (simplex_category.δ i).op
 
 /-- Degeneracy maps for a simplicial object. -/
 def σ {n} (i : fin (n+1)) :
-  X.obj (op (simplex_category.mk n)) ⟶ X.obj (op (simplex_category.mk (n+1))) :=
+  X.obj (op [n]) ⟶ X.obj (op [n+1]) :=
 X.map (simplex_category.σ i).op
 
 
 /-- Isomorphisms from identities in ℕ. -/
 def eq_to_iso {n m : ℕ} (h : n = m) :
-  X.obj (op (simplex_category.mk n)) ≅ X.obj (op (simplex_category.mk m)) :=
+  X.obj (op [n]) ≅ X.obj (op [m]) :=
 X.map_iso (eq_to_iso (by rw h))
 
 @[simp] lemma eq_to_iso_refl {n : ℕ} (h : n = n) : X.eq_to_iso h = iso.refl _ :=

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -121,7 +121,8 @@ instance {n} {J : Type v} [small_category J] [has_limits_of_shape J C] :
 instance {n} [has_limits C] : has_limits (simplicial_object.truncated C n) := ⟨infer_instance⟩
 
 instance {n} {J : Type v} [small_category J] [has_colimits_of_shape J C] :
-  has_colimits_of_shape J (simplicial_object.truncated C n) := by {dsimp [truncated], apply_instance}
+  has_colimits_of_shape J (simplicial_object.truncated C n) :=
+by {dsimp [truncated], apply_instance}
 
 instance {n} [has_colimits C] : has_colimits (simplicial_object.truncated C n) := ⟨infer_instance⟩
 

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -34,7 +34,8 @@ namespace simplicial_object
 
 -- TODO: find a sensible value for `1000`.
 localized
-  "notation X `_[`:1000 n `]` := (X : simplicial_object _).obj (op (simplex_category.mk n))"
+  "notation X `_[`:1000 n `]` :=
+    (X : simplicial_object _).obj (opposite.op (simplex_category.mk n))"
   in simplicial
 
 instance {J : Type v} [small_category J] [has_limits_of_shape J C] :

--- a/src/algebraic_topology/simplicial_set.lean
+++ b/src/algebraic_topology/simplicial_set.lean
@@ -45,7 +45,7 @@ namespace sSet
 is the Yoneda embedding of `n`. -/
 def standard_simplex : simplex_category ⥤ sSet := yoneda
 
-localized "notation `Δ[`n`]` := standard_simplex.obj (simplex_category.mk n)" in sSet
+localized "notation `Δ[`n`]` := standard_simplex.obj (simplex_category.mk n)" in simplicial
 
 instance : inhabited sSet := ⟨Δ[0]⟩
 
@@ -65,7 +65,7 @@ def boundary (n : ℕ) : sSet :=
   map := λ m₁ m₂ f α, ⟨f.unop ≫ (α : Δ[n].obj m₁),
   by { intro h, apply α.property, exact function.surjective.of_comp h }⟩ }
 
-localized "notation `∂Δ[`n`]` := boundary n" in sSet
+localized "notation `∂Δ[`n`]` := boundary n" in simplicial
 
 /-- The inclusion of the boundary of the `n`-th standard simplex into that standard simplex. -/
 def boundary_inclusion (n : ℕ) :
@@ -88,7 +88,7 @@ def horn (n : ℕ) (i : fin (n+1)) : sSet :=
     exact set.range_comp_subset_range _ _ hj,
   end⟩ }
 
-localized "notation `Λ[`n`, `i`]` := horn (n : ℕ) i" in sSet
+localized "notation `Λ[`n`, `i`]` := horn (n : ℕ) i" in simplicial
 
 /-- The inclusion of the `i`-th horn of the `n`-th standard simplex into that standard simplex. -/
 def horn_inclusion (n : ℕ) (i : fin (n+1)) :
@@ -97,7 +97,7 @@ def horn_inclusion (n : ℕ) (i : fin (n+1)) :
 
 section examples
 
-open_locale sSet
+open_locale simplicial
 
 /-- The simplicial circle. -/
 noncomputable def S1 : sSet :=

--- a/src/algebraic_topology/simplicial_set.lean
+++ b/src/algebraic_topology/simplicial_set.lean
@@ -47,10 +47,13 @@ localized "notation `Δ[`n`]` := standard_simplex.obj (simplex_category.mk n)" i
 
 instance : inhabited sSet := ⟨standard_simplex.obj (simplex_category.mk 0)⟩
 
+section
+
 /-- The `m`-simplices of the `n`-th standard simplex are
 the monotone maps from `fin (m+1)` to `fin (n+1)`. -/
 def as_preorder_hom {n} {m} (α : Δ[n].obj m) :
   preorder_hom (fin (m.unop.len+1)) (fin (n+1)) := α.down
+end
 
 /-- The boundary `∂Δ[n]` of the `n`-th standard simplex consists of
 all `m`-simplices of `standard_simplex n` that are not surjective

--- a/src/algebraic_topology/simplicial_set.lean
+++ b/src/algebraic_topology/simplicial_set.lean
@@ -31,6 +31,8 @@ universes v u
 
 open category_theory
 
+open_locale simplicial
+
 /-- The category of simplicial sets.
 This is the category of contravariant functors from
 `simplex_category` to `Type u`. -/
@@ -45,7 +47,7 @@ def standard_simplex : simplex_category ⥤ sSet := yoneda
 
 localized "notation `Δ[`n`]` := standard_simplex.obj (simplex_category.mk n)" in sSet
 
-instance : inhabited sSet := ⟨standard_simplex.obj (simplex_category.mk 0)⟩
+instance : inhabited sSet := ⟨Δ[0]⟩
 
 section
 
@@ -112,7 +114,6 @@ def truncated (n : ℕ) := simplicial_object.truncated (Type u) n
 /-- The skeleton functor on simplicial sets. -/
 def sk (n : ℕ) : sSet ⥤ sSet.truncated n := simplicial_object.sk n
 
-instance {n} : inhabited (sSet.truncated n) :=
-  ⟨(sk n).obj $ standard_simplex.obj (simplex_category.mk 0)⟩
+instance {n} : inhabited (sSet.truncated n) := ⟨(sk n).obj $ Δ[0]⟩
 
 end sSet

--- a/src/algebraic_topology/simplicial_set.lean
+++ b/src/algebraic_topology/simplicial_set.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johan Commelin, Scott Morrison
+Authors: Johan Commelin, Scott Morrison, Adam Topaz
 -/
 import algebraic_topology.simplicial_object
 import category_theory.yoneda
@@ -43,14 +43,14 @@ namespace sSet
 is the Yoneda embedding of `n`. -/
 def standard_simplex : simplex_category ⥤ sSet := yoneda
 
-localized "notation `Δ[`n`]` := standard_simplex.obj (n : ℕ)" in sSet
+localized "notation `Δ[`n`]` := standard_simplex.obj (simplex_category.mk n)" in sSet
 
-instance : inhabited sSet := ⟨standard_simplex.obj (0 : ℕ)⟩
+instance : inhabited sSet := ⟨standard_simplex.obj (simplex_category.mk 0)⟩
 
 /-- The `m`-simplices of the `n`-th standard simplex are
 the monotone maps from `fin (m+1)` to `fin (n+1)`. -/
 def as_preorder_hom {n} {m} (α : Δ[n].obj m) :
-  preorder_hom (fin (m.unop+1)) (fin (n+1)) := α
+  preorder_hom (fin (m.unop.len+1)) (fin (n+1)) := α.down
 
 /-- The boundary `∂Δ[n]` of the `n`-th standard simplex consists of
 all `m`-simplices of `standard_simplex n` that are not surjective
@@ -109,6 +109,7 @@ def truncated (n : ℕ) := simplicial_object.truncated (Type u) n
 /-- The skeleton functor on simplicial sets. -/
 def sk (n : ℕ) : sSet ⥤ sSet.truncated n := simplicial_object.sk n
 
-instance {n} : inhabited (sSet.truncated n) := ⟨(sk n).obj $ standard_simplex.obj (0 : ℕ)⟩
+instance {n} : inhabited (sSet.truncated n) :=
+  ⟨(sk n).obj $ standard_simplex.obj (simplex_category.mk 0)⟩
 
 end sSet

--- a/src/algebraic_topology/simplicial_set.lean
+++ b/src/algebraic_topology/simplicial_set.lean
@@ -52,7 +52,7 @@ section
 /-- The `m`-simplices of the `n`-th standard simplex are
 the monotone maps from `fin (m+1)` to `fin (n+1)`. -/
 def as_preorder_hom {n} {m} (α : Δ[n].obj m) :
-  preorder_hom (fin (m.unop.len+1)) (fin (n+1)) := α.down
+  preorder_hom (fin (m.unop.len+1)) (fin (n+1)) := α.to_preorder_hom
 end
 
 /-- The boundary `∂Δ[n]` of the `n`-th standard simplex consists of


### PR DESCRIPTION
This PR changes the definition of `simplex_category` so that it becomes universe polymorphic.
This is useful when we want to take (co)limits of simplicial objects indexed by categories constructed out of `simplex_category`.
This PR also makes a small wrapper around morphisms in `simplex_category` for hygiene purposes, and introduces a notation `X _[n]` for the n-th term of a simplicial object X.

Note: this PR makes `simplex_category` and `simplex_category.hom` irreducible.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
