### PR TITLE
[Merged by Bors] - feat(data/finsupp/basic): add `can_lift (α → M₀) (α →₀ M₀)`

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -318,7 +318,11 @@ by { rw nonempty_iff_ne_empty, exact not_not, }
 theorem eq_empty_or_nonempty (s : finset α) : s = ∅ ∨ s.nonempty :=
 classical.by_cases or.inl (λ h, or.inr (nonempty_of_ne_empty h))
 
-@[simp] lemma coe_empty : ((∅ : finset α) : set α) = ∅ := rfl
+@[simp, norm_cast] lemma coe_empty : ((∅ : finset α) : set α) = ∅ := rfl
+
+@[simp, norm_cast] lemma coe_eq_empty {s : finset α} :
+  (s : set α) = ∅ ↔ s = ∅ :=
+by rw [← coe_empty, coe_inj]
 
 /-- A `finset` for an empty type is empty. -/
 lemma eq_empty_of_not_nonempty (h : ¬ nonempty α) (s : finset α) : s = ∅ :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -14,7 +14,6 @@ import data.multiset.antidiagonal
 import data.indicator_function
 
 /-!
-
 # Type of functions with finite support
 
 For any type `α` and a type `M` with zero, we define the type `finsupp α M` (notation: `α →₀ M`)
@@ -106,9 +105,9 @@ instance : has_coe_to_fun (α →₀ M) := ⟨λ _, α → M, to_fun⟩
 @[simp] lemma coe_mk (f : α → M) (s : finset α) (h : ∀ a, a ∈ s ↔ f a ≠ 0) :
   ⇑(⟨s, f, h⟩ : α →₀ M) = f := rfl
 
-instance : has_zero (α →₀ M) := ⟨⟨∅, (λ _, 0), λ _, ⟨false.elim, λ H, H rfl⟩⟩⟩
+instance : has_zero (α →₀ M) := ⟨⟨∅, 0, λ _, ⟨false.elim, λ H, H rfl⟩⟩⟩
 
-@[simp] lemma coe_zero : ⇑(0 : α →₀ M) = (λ _, (0:M)) := rfl
+@[simp] lemma coe_zero : ⇑(0 : α →₀ M) = 0 := rfl
 lemma zero_apply {a : α} : (0 : α →₀ M) a = 0 := rfl
 @[simp] lemma support_zero : (0 : α →₀ M).support = ∅ := rfl
 
@@ -117,7 +116,7 @@ instance : inhabited (α →₀ M) := ⟨0⟩
 @[simp] lemma mem_support_iff {f : α →₀ M} : ∀{a:α}, a ∈ f.support ↔ f a ≠ 0 :=
 f.mem_support_to_fun
 
-@[simp] lemma fun_support_eq (f : α →₀ M) : function.support f = f.support :=
+@[simp, norm_cast] lemma fun_support_eq (f : α →₀ M) : function.support f = f.support :=
 set.ext $ λ x, mem_support_iff.symm
 
 lemma not_mem_support_iff {f : α →₀ M} {a} : a ∉ f.support ↔ f a = 0 :=
@@ -130,6 +129,12 @@ lemma coe_fn_injective : @function.injective (α →₀ M) (α → M) coe_fn
     have : s = t, { ext a, exact (hf a).trans (hg a).symm },
     subst this
   end
+
+@[simp, norm_cast] lemma coe_fn_inj {f g : α →₀ M} : (f : α → M) = g ↔ f = g :=
+coe_fn_injective.eq_iff
+
+@[simp, norm_cast] lemma coe_eq_zero {f : α →₀ M} : (f : α → M) = 0 ↔ f = 0 :=
+by rw [← coe_zero, coe_fn_inj]
 
 @[ext] lemma ext {f g : α →₀ M} (h : ∀a, f a = g a) : f = g := coe_fn_injective (funext h)
 
@@ -144,14 +149,13 @@ lemma ext_iff' {f g : α →₀ M} : f = g ↔ f.support = g.support ∧ ∀ x �
     by rw [hf, hg]⟩
 
 @[simp] lemma support_eq_empty {f : α →₀ M} : f.support = ∅ ↔ f = 0 :=
-⟨assume h, ext $ assume a, by_contradiction $ λ H, (finset.ext_iff.1 h a).1 $
-  mem_support_iff.2 H, by rintro rfl; refl⟩
+by exact_mod_cast @function.support_eq_empty_iff _ _ _ f
 
 lemma support_nonempty_iff {f : α →₀ M} : f.support.nonempty ↔ f ≠ 0 :=
 by simp only [finsupp.support_eq_empty, finset.nonempty_iff_ne_empty, ne.def]
 
 lemma nonzero_iff_exists {f : α →₀ M} : f ≠ 0 ↔ ∃ a : α, f a ≠ 0 :=
-by simp [finsupp.support_eq_empty.symm, finset.eq_empty_iff_forall_not_mem]
+by simp [← finsupp.support_eq_empty, finset.eq_empty_iff_forall_not_mem]
 
 lemma card_support_eq_zero {f : α →₀ M} : card f.support = 0 ↔ f = 0 :=
 by simp
@@ -352,6 +356,11 @@ lemma support_on_finset
   {s : finset α} {f : α → M} (hf : ∀ (a : α), f a ≠ 0 → a ∈ s) :
   (finsupp.on_finset s f hf).support = s.filter (λ a, f a ≠ 0) :=
 rfl
+
+instance : can_lift (α → M) (α →₀ M) :=
+{ coe := coe_fn,
+  cond := λ f, (function.support f).finite,
+  prf := λ f hf, ⟨on_finset hf.to_finset f (λ a ha, by simpa), rfl⟩ }
 
 end on_finset
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -163,8 +163,8 @@ by simp
 instance finsupp.decidable_eq [decidable_eq α] [decidable_eq M] : decidable_eq (α →₀ M) :=
 assume f g, decidable_of_iff (f.support = g.support ∧ (∀a∈f.support, f a = g a)) ext_iff'.symm
 
-lemma finite_supp (f : α →₀ M) : set.finite {a | f a ≠ 0} :=
-⟨fintype.of_finset f.support (λ _, mem_support_iff)⟩
+lemma finite_support (f : α →₀ M) : set.finite (function.support f) :=
+f.fun_support_eq.symm ▸ f.support.finite_to_set
 
 lemma support_subset_iff {s : set α} {f : α →₀ M} :
   ↑f.support ⊆ s ↔ (∀a∉s, f a = 0) :=
@@ -357,12 +357,28 @@ lemma support_on_finset
   (finsupp.on_finset s f hf).support = s.filter (λ a, f a ≠ 0) :=
 rfl
 
+end on_finset
+
+section of_support_finite
+
+variables [has_zero M]
+
+/-- The natural `finsupp` induced by the function `f` given that it has finite support. -/
+noncomputable def of_support_finite
+  (f : α → M) (hf : (function.support f).finite) : α →₀ M :=
+{ support := hf.to_finset,
+  to_fun := f,
+  mem_support_to_fun := λ _, hf.mem_to_finset }
+
+lemma of_support_finite_coe {f : α → M} {hf : (function.support f).finite} :
+  (of_support_finite f hf : α → M) = f := rfl
+
 instance : can_lift (α → M) (α →₀ M) :=
 { coe := coe_fn,
   cond := λ f, (function.support f).finite,
-  prf := λ f hf, ⟨on_finset hf.to_finset f (λ a ha, by simpa), rfl⟩ }
+  prf := λ f hf, ⟨of_support_finite f hf, rfl⟩ }
 
-end on_finset
+end of_support_finite
 
 /-! ### Declarations about `map_range` -/
 

--- a/src/ring_theory/polynomial/homogeneous.lean
+++ b/src/ring_theory/polynomial/homogeneous.lean
@@ -243,7 +243,7 @@ lemma homogeneous_component_zero : homogeneous_component 0 φ = C (coeff 0 φ) :
 begin
   ext1 d,
   rcases em (d = 0) with (rfl|hd),
-  { simp only [coeff_homogeneous_component, sum_eq_zero_iff, finsupp.coe_zero, if_true, coeff_C,
+  { simp only [coeff_homogeneous_component, sum_eq_zero_iff, finsupp.zero_apply, if_true, coeff_C,
       eq_self_iff_true, forall_true_iff] },
   { rw [coeff_homogeneous_component, if_neg, coeff_C, if_neg (ne.symm hd)],
     simp only [finsupp.ext_iff, finsupp.zero_apply] at hd,


### PR DESCRIPTION
Also add a few missing `simp`/`norm_cast` lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

`finsupp.of_support_finite` was copied from #6355. I'm not sure who should I add as a co-author to this PR. @kbuzzard ? @JasonKYi ?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)