### PR TITLE
[Merged by Bors] - feat(combinatorics/quiver): every connected graph has a spanning tree

### DIFF
--- a/src/combinatorics/quiver.lean
+++ b/src/combinatorics/quiver.lean
@@ -95,10 +95,16 @@ inductive path {V} (G : quiver.{v u} V) (a : V) : V → Sort (max (u+1) v)
 | nil  : path a
 | cons : Π {b c : V}, path b → G.arrow b c → path c
 
-/-- The length of a path is the number of edges it uses. -/
-def path.length {V} {G : quiver V} {a : V} : Π {b}, G.path a b → ℕ
+/-- The length of a path is the number of arrows it uses. -/
+@[simp] def path.length {V} {G : quiver V} {a : V} : Π {b}, G.path a b → ℕ
 | _ path.nil        := 0
 | _ (path.cons p _) := p.length + 1
+
+@[simp] lemma path.length_nil {V} {G : quiver V} {a : V} :
+  (path.nil : G.path a a).length = 0 := rfl
+
+@[simp] lemma path.length_cons {V} {G : quiver V} (a b c : V) (p : G.path a b)
+  (e : G.arrow b c) : (p.cons e).length = p.length + 1 := rfl
 
 /-- A quiver is an arborescence when there is a unique path from the default vertex
     to every other vertex. -/
@@ -118,5 +124,69 @@ def labelling {V} (G : quiver V) (L) := Π a b, G.arrow a b → L
 
 instance {V} (G : quiver V) (L) [inhabited L] : inhabited (G.labelling L) :=
 ⟨λ a b e, default L⟩
+
+/-- To show that `T : quiver V` is an arborescence with root `r : V`, it suffices to
+  - provide a height function `V → ℕ` such that every arrow goes from a
+    lower vertex to a higher vertex,
+  - show that every vertex has at most one arrow to it, and
+  - show that every vertex other than `r` has an arrow to it. -/
+noncomputable def arborescence_mk {V} (T : quiver V) (r : V)
+  (height : V → ℕ)
+  (height_lt : ∀ ⦃a b⦄, T.arrow a b → height a < height b)
+  (unique_arrow : ∀ ⦃a b c⦄ (e : T.arrow a c) (f : T.arrow b c), a = b ∧ e == f)
+  (root_or_arrow : ∀ b, b = r ∨ ∃ a, nonempty (T.arrow a b)) : arborescence T :=
+{ root := r,
+  unique_path := λ b, ⟨classical.inhabited_of_nonempty
+    begin
+      rcases (show ∃ n, height b < n, from ⟨_, lt_add_one _⟩) with ⟨n, hn⟩,
+      induction n with n ih generalizing b,
+      { exact false.elim (nat.not_lt_zero _ hn) },
+      rcases root_or_arrow b with ⟨⟨⟩⟩ | ⟨a, ⟨e⟩⟩,
+      { exact ⟨path.nil⟩ },
+      { rcases ih a (lt_of_lt_of_le (height_lt e) (nat.lt_succ_iff.mp hn)) with ⟨p⟩,
+        exact ⟨p.cons e⟩ }
+    end,
+    begin
+      have height_le : ∀ {a b}, T.path a b → height a ≤ height b,
+      { intros a b p, induction p with b c p e ih, refl,
+        exact le_of_lt (lt_of_le_of_lt ih (height_lt e)) },
+      suffices : ∀ p q : T.path r b, p = q,
+      { intro p, apply this },
+      intros p q, induction p with a c p e ih; cases q with b _ q f,
+      { refl },
+      { exact false.elim (lt_irrefl _ (lt_of_le_of_lt (height_le q) (height_lt f))) },
+      { exact false.elim (lt_irrefl _ (lt_of_le_of_lt (height_le p) (height_lt e))) },
+      { rcases unique_arrow e f with ⟨⟨⟩, ⟨⟩⟩, rw ih },
+    end ⟩ }
+
+/-- `G.rooted_connected r` means that there is a path from `r` to any other vertex. -/
+class rooted_connected {V} (G : quiver V) (r : V) : Prop :=
+(nonempty_path : ∀ b : V, nonempty (G.path r b))
+
+attribute [instance] rooted_connected.nonempty_path
+
+variables {V : Type*} (G : quiver.{v+1} V) (r : V) [G.rooted_connected r]
+
+/-- A path from `r` of minimal length. -/
+noncomputable def shortest_path (b : V) : G.path r b :=
+well_founded.min (measure_wf path.length) set.univ set.univ_nonempty
+
+/-- The length of a path is at least the length of the shortest path -/
+lemma shortest_path_spec {a : V} (p : G.path r a) :
+  (G.shortest_path r a).length ≤ p.length :=
+not_lt.mp (well_founded.not_lt_min (measure_wf _) set.univ _ trivial)
+
+/-- A subquiver which by construction is an arborescence. -/
+def geodesic_subtree : wide_subquiver G :=
+λ a b, { e | ∃ p : G.path r a, shortest_path G r b = p.cons e }
+
+noncomputable instance geodesic_arborescence : (G.geodesic_subtree r).quiver.arborescence :=
+arborescence_mk _ r (λ a, (G.shortest_path r a).length)
+(by { rintros a b ⟨e, p, h⟩,
+  rw [h, path.length_cons, nat.lt_succ_iff], apply shortest_path_spec })
+(by { rintros a b c ⟨e, p, h⟩ ⟨f, q, j⟩, cases h.symm.trans j, split; refl })
+(by { intro b, have : ∃ p, G.shortest_path r b = p := ⟨_, rfl⟩,
+  rcases this with ⟨p, hp⟩, cases p with a _ p e,
+  { exact or.inl rfl }, { exact or.inr ⟨a, ⟨⟨e, p, hp⟩⟩⟩ } })
 
 end quiver

--- a/src/combinatorics/quiver.lean
+++ b/src/combinatorics/quiver.lean
@@ -96,7 +96,7 @@ inductive path {V} (G : quiver.{v u} V) (a : V) : V → Sort (max (u+1) v)
 | cons : Π {b c : V}, path b → G.arrow b c → path c
 
 /-- The length of a path is the number of arrows it uses. -/
-@[simp] def path.length {V} {G : quiver V} {a : V} : Π {b}, G.path a b → ℕ
+def path.length {V} {G : quiver V} {a : V} : Π {b}, G.path a b → ℕ
 | _ path.nil        := 0
 | _ (path.cons p _) := p.length + 1
 


### PR DESCRIPTION
Prove a directed version of the fact that a connected graph has a
spanning tree. The subtree we use is what you would get from 'running a
DFS from the root'. This proof avoids any use of Zorn's lemma. Currently
we have no notion of undirected tree, but once that is in place, this
proof should also give undirected spanning trees.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
