### PR TITLE
[Merged by Bors] - feat(ring_theory/polynomial/homogenous): add a `direct_sum.gcomm_monoid` instance

### DIFF
--- a/src/algebra/direct_sum_graded.lean
+++ b/src/algebra/direct_sum_graded.lean
@@ -422,7 +422,7 @@ section comm_ring
 variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gcomm_monoid A]
 
 /-- The `comm_ring` derived from `gcomm_monoid A`. -/
-instance comm_ring : ring (⨁ i, A i) := {
+instance comm_ring : comm_ring (⨁ i, A i) := {
   one := 1,
   mul := (*),
   zero := 0,

--- a/src/ring_theory/polynomial/homogeneous.lean
+++ b/src/ring_theory/polynomial/homogeneous.lean
@@ -7,6 +7,7 @@ Authors: Johan Commelin
 import data.mv_polynomial
 import algebra.algebra.operations
 import data.fintype.card
+import algebra.direct_sum_graded
 
 /-!
 # Homogeneous polynomials
@@ -203,6 +204,18 @@ begin
     replace hd := finsupp.mem_support_iff.mpr hd,
     exact finset.le_sup hd, }
 end
+
+/--
+The homogenous submodules form a graded ring. This instance is used by `direct_sum.comm_semiring`.
+-/
+noncomputable instance homogeneous_submodule.gcomm_monoid :
+  direct_sum.gcomm_monoid (λ i, homogeneous_submodule σ R i) :=
+direct_sum.gcomm_monoid.of_submodules _
+  (is_homogeneous_one σ R)
+  (λ i j hi hj, is_homogeneous.mul hi.prop hj.prop)
+
+open_locale direct_sum
+noncomputable example : comm_semiring (⨁ i, homogeneous_submodule σ R i) := infer_instance
 
 end is_homogeneous
 


### PR DESCRIPTION
This also corrects a stupid typo I made in `direct_sum.comm_ring` which was previously declared a `ring`!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)



I started out on trying to show:
```lean
/-- `homogeneous_component` but better? -/
def homogeneous_component' [comm_semiring R] (n : ℕ) :
  mv_polynomial σ R →ₗ[R] homogeneous_submodule σ R n :=
let f := finsupp.restrict_dom R R {d : σ →₀ ℕ | ∑ i in d.support, d i = n} in
(submodule.of_le $ (homogenous_submodule_eq_finsupp_supported _ _ _).symm.le).comp f

-- the real goal would be to make this an alg_hom, but baby steps!
def homogeneous_components [comm_semiring R] (n : ℕ) :
  mv_polynomial σ R →+* (⨁ i, homogeneous_submodule σ R i) :=
add_monoid_algebra.lift_nc_ring_hom
  { to_fun := λ r, r • 1,  -- this is basically `algebra_map`, which doesn't exist yet.
    map_one' := by { ext, simp, },
    map_mul' := λ x y, by { ext, simp, sorry },
    map_zero' := zero_smul _ _,
    map_add' := λ x y, add_smul _ _ _,}
  sorry
  sorry
```
but I think there's some API missing around `direct_sum` before that becomes easy, so want to punt it to future work, possibly for someone else.