### PR TITLE
[Merged by Bors] - feat(algebra/big_operators/basic): add lemmas for a product with two non one factors

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -405,9 +405,9 @@ calc (∏ a in s.filter p, f a) = ∏ a in s.filter p, if p a then f a else 1 :
 
 @[to_additive]
 lemma prod_eq_single_of_mem {s : finset α} {f : α → β} (a : α) (h : a ∈ s)
-  (h₀ : ∀b∈s, b ≠ a → f b = 1) : (∏ x in s, f x) = f a :=
+  (h₀ : ∀ b ∈ s, b ≠ a → f b = 1) : (∏ x in s, f x) = f a :=
 begin
-  haveI := classical.dec_eq α;
+  haveI := classical.dec_eq α,
   calc (∏ x in s, f x) = ∏ x in {a}, f x :
       begin
         refine (prod_subset _ _).symm,
@@ -436,8 +436,14 @@ begin
   have hu : s' ⊆ s,
   { refine insert_subset.mpr _, apply and.intro ha, apply singleton_subset_iff.mpr hb },
   have hf : ∀ c ∈ s, c ∉ s' → f c = 1,
-  { intros c hc hcs, apply h₀ c hc, apply not_or_distrib.mp, intro hab,
-    apply hcs, apply mem_insert.mpr, rw mem_singleton, exact hab },
+  { intros c hc hcs,
+    apply h₀ c hc,
+    apply not_or_distrib.mp,
+    intro hab,
+    apply hcs,
+    apply mem_insert.mpr,
+    rw mem_singleton,
+    exact hab },
   rw ←prod_subset hu hf,
   exact finset.prod_pair hn
 end

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -404,7 +404,7 @@ calc (∏ a in s.filter p, f a) = ∏ a in s.filter p, if p a then f a else 1 :
     end
 
 @[to_additive]
-lemma prod_eq_single' {s : finset α} {f : α → β} (a : α) (h : a ∈ s)
+lemma prod_eq_single_of_mem {s : finset α} {f : α → β} (a : α) (h : a ∈ s)
   (h₀ : ∀b∈s, b ≠ a → f b = 1) : (∏ x in s, f x) = f a :=
 begin
   haveI := classical.dec_eq α;
@@ -422,13 +422,13 @@ lemma prod_eq_single {s : finset α} {f : α → β} (a : α)
   (h₀ : ∀b∈s, b ≠ a → f b = 1) (h₁ : a ∉ s → f a = 1) : (∏ x in s, f x) = f a :=
 by haveI := classical.dec_eq α;
 from classical.by_cases
-  (assume : a ∈ s, prod_eq_single' a this h₀)
+  (assume : a ∈ s, prod_eq_single_of_mem a this h₀)
   (assume : a ∉ s,
     (prod_congr rfl $ λ b hb, h₀ b hb $ by rintro rfl; cc).trans $
       prod_const_one.trans (h₁ this).symm)
 
 @[to_additive]
-lemma prod_eq_mul' {s : finset α} {f : α → β} (a b : α) (ha : a ∈ s) (hb : b ∈ s) (hn : a ≠ b)
+lemma prod_eq_mul_of_mem {s : finset α} {f : α → β} (a b : α) (ha : a ∈ s) (hb : b ∈ s) (hn : a ≠ b)
   (h₀ : ∀ c ∈ s, c ≠ a ∧ c ≠ b → f c = 1) : (∏ x in s, f x) = (f a) * (f b) :=
 begin
   haveI := classical.dec_eq α;
@@ -449,12 +449,12 @@ lemma prod_eq_mul {s : finset α} {f : α → β} (a b : α) (hn : a ≠ b)
 begin
   haveI := classical.dec_eq α;
   by_cases ha : a ∈ s; by_cases hb : b ∈ s,
-  { exact prod_eq_mul' a b ha hb hn h₀ },
+  { exact prod_eq_mul_of_mem a b ha hb hn h₀ },
   { rw [h₁ b hb, mul_one],
-    apply prod_eq_single' a ha,
+    apply prod_eq_single_of_mem a ha,
     exact λ c hc hca, h₀ c hc ⟨hca, ne_of_mem_of_not_mem hc hb⟩ },
   { rw [h₁ a ha, one_mul],
-    apply prod_eq_single' b hb,
+    apply prod_eq_single_of_mem b hb,
     exact λ c hc hcb, h₀ c hc ⟨ne_of_mem_of_not_mem hc ha, hcb⟩ },
   { rw [h₁ a ha, h₁ b hb, mul_one],
     convert prod_const_one,

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -444,24 +444,22 @@ end
 
 @[to_additive]
 lemma prod_eq_mul {s : finset α} {f : α → β} (a b : α) (hn : a ≠ b)
-  (h₀ : ∀ c ∈ s, c ≠ a ∧ c ≠ b → f c = 1) (h₁ : ∀ (c : α), c ∉ s → f c = 1) :
+  (h₀ : ∀ c ∈ s, c ≠ a ∧ c ≠ b → f c = 1) (ha : a ∉ s → f a = 1) (hb : b ∉ s → f b = 1) :
   (∏ x in s, f x) = (f a) * (f b) :=
 begin
   haveI := classical.dec_eq α;
-  by_cases ha : a ∈ s; by_cases hb : b ∈ s,
-  { exact prod_eq_mul_of_mem a b ha hb hn h₀ },
-  { rw [h₁ b hb, mul_one],
-    apply prod_eq_single_of_mem a ha,
-    exact λ c hc hca, h₀ c hc ⟨hca, ne_of_mem_of_not_mem hc hb⟩ },
-  { rw [h₁ a ha, one_mul],
-    apply prod_eq_single_of_mem b hb,
-    exact λ c hc hcb, h₀ c hc ⟨ne_of_mem_of_not_mem hc ha, hcb⟩ },
-  { rw [h₁ a ha, h₁ b hb, mul_one],
-    convert prod_const_one,
-    ext c,
-    by_cases hc : c ∈ s,
-    { apply h₀ c hc, exact ⟨ne_of_mem_of_not_mem hc ha, ne_of_mem_of_not_mem hc hb⟩ },
-    { exact h₁ c hc }}
+  by_cases h₁ : a ∈ s; by_cases h₂ : b ∈ s,
+  { exact prod_eq_mul_of_mem a b h₁ h₂ hn h₀ },
+  { rw [hb h₂, mul_one],
+    apply prod_eq_single_of_mem a h₁,
+    exact λ c hc hca, h₀ c hc ⟨hca, ne_of_mem_of_not_mem hc h₂⟩ },
+  { rw [ha h₁, one_mul],
+    apply prod_eq_single_of_mem b h₂,
+    exact λ c hc hcb, h₀ c hc ⟨ne_of_mem_of_not_mem hc h₁, hcb⟩ },
+  { rw [ha h₁, hb h₂, mul_one],
+    exact trans
+      (prod_congr rfl (λ c hc, h₀ c hc ⟨ne_of_mem_of_not_mem hc h₁, ne_of_mem_of_not_mem hc h₂⟩))
+      prod_const_one }
 end
 
 @[to_additive]

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -428,7 +428,7 @@ from classical.by_cases
       prod_const_one.trans (h₁ this).symm)
 
 @[to_additive]
-lemma prod_eq_double' {s : finset α} {f : α → β} (a b : α) (ha : a ∈ s) (hb : b ∈ s) (hn : a ≠ b)
+lemma prod_eq_mul' {s : finset α} {f : α → β} (a b : α) (ha : a ∈ s) (hb : b ∈ s) (hn : a ≠ b)
   (h₀ : ∀ c ∈ s, c ≠ a ∧ c ≠ b → f c = 1) : (∏ x in s, f x) = (f a) * (f b) :=
 begin
   haveI := classical.dec_eq α;
@@ -443,13 +443,13 @@ begin
 end
 
 @[to_additive]
-lemma prod_eq_double {s : finset α} {f : α → β} (a b : α) (hn : a ≠ b)
+lemma prod_eq_mul {s : finset α} {f : α → β} (a b : α) (hn : a ≠ b)
   (h₀ : ∀ c ∈ s, c ≠ a ∧ c ≠ b → f c = 1) (h₁ : ∀ (c : α), c ∉ s → f c = 1) :
   (∏ x in s, f x) = (f a) * (f b) :=
 begin
   haveI := classical.dec_eq α;
   by_cases ha : a ∈ s; by_cases hb : b ∈ s,
-  { exact prod_eq_double' a b ha hb hn h₀ },
+  { exact prod_eq_mul' a b ha hb hn h₀ },
   { rw [h₁ b hb, mul_one],
     apply prod_eq_single' a ha,
     exact λ c hc hca, h₀ c hc ⟨hca, ne_of_mem_of_not_mem hc hb⟩ },

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -66,7 +66,10 @@ finset.prod_eq_single a (λ x _ hx, h x hx) $ λ ha, (ha (finset.mem_univ a)).el
 @[to_additive]
 lemma prod_eq_mul {f : α → M} (a b : α) (h₁ : a ≠ b) (h₂ : ∀ x, x ≠ a ∧ x ≠ b → f x = 1) :
   (∏ x, f x) = (f a) * (f b) :=
-finset.prod_eq_mul a b h₁ (λ x _ hx, h₂ x hx) $ λ c hc, (hc (finset.mem_univ c)).elim
+begin
+  apply finset.prod_eq_mul a b h₁ (λ x _ hx, h₂ x hx);
+  exact λ hc, (hc (finset.mem_univ _)).elim
+end
 
 @[to_additive]
 lemma prod_unique [unique β] (f : β → M) :

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -64,9 +64,9 @@ lemma prod_eq_single {f : α → M} (a : α) (h : ∀ x ≠ a, f x = 1) :
 finset.prod_eq_single a (λ x _ hx, h x hx) $ λ ha, (ha (finset.mem_univ a)).elim
 
 @[to_additive]
-lemma prod_eq_double {f : α → M} (a b : α) (h₁ : a ≠ b) (h₂ : ∀ x, x ≠ a ∧ x ≠ b → f x = 1) :
+lemma prod_eq_mul {f : α → M} (a b : α) (h₁ : a ≠ b) (h₂ : ∀ x, x ≠ a ∧ x ≠ b → f x = 1) :
   (∏ x, f x) = (f a) * (f b) :=
-finset.prod_eq_double a b h₁ (λ x _ hx, h₂ x hx) $ λ c hc, (hc (finset.mem_univ c)).elim
+finset.prod_eq_mul a b h₁ (λ x _ hx, h₂ x hx) $ λ c hc, (hc (finset.mem_univ c)).elim
 
 @[to_additive]
 lemma prod_unique [unique β] (f : β → M) :

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -64,6 +64,11 @@ lemma prod_eq_single {f : α → M} (a : α) (h : ∀ x ≠ a, f x = 1) :
 finset.prod_eq_single a (λ x _ hx, h x hx) $ λ ha, (ha (finset.mem_univ a)).elim
 
 @[to_additive]
+lemma prod_eq_double {f : α → M} (a b : α) (h₁ : a ≠ b) (h₂ : ∀ x, x ≠ a ∧ x ≠ b → f x = 1) :
+  (∏ x, f x) = (f a) * (f b) :=
+finset.prod_eq_double a b h₁ (λ x _ hx, h₂ x hx) $ λ c hc, (hc (finset.mem_univ c)).elim
+
+@[to_additive]
 lemma prod_unique [unique β] (f : β → M) :
   (∏ x, f x) = f (default β) :=
 by simp only [finset.prod_singleton, univ_unique]


### PR DESCRIPTION
Add another version of `prod_eq_one` and 3 versions of `prod_eq_double`, a lemma that says a product with only 2 non one factors is equal to the product of the 2 factors.