### PR TITLE
[Merged by Bors] - feat(algebra/geom_sum): rename geom_series to geom_sum, adds a lemma for the geometric sum

### DIFF
--- a/src/algebra/geom_sum.lean
+++ b/src/algebra/geom_sum.lean
@@ -229,6 +229,28 @@ begin
     sub_sub_sub_cancel_right (x ^ n) (x ^ m * y ^ (n - m)) (y ^ n)],
 end
 
+protected theorem commute.geom_sum₂_add_mul_eq_geom_sum₂ {α : Type u} [ring α] {x y : α}
+  (h : commute x y) {n : ℕ} :
+  x ^ n + y * (geom_series₂ x y n) = (geom_series₂ x y (n + 1)) :=
+begin
+  dunfold geom_series₂,
+  rw [mul_sum, sum_range_succ _ n, nat.add_succ_sub_one, add_zero, nat.sub_self, pow_zero, mul_one],
+  apply congr_arg (has_add.add (x ^ n)),
+  apply finset.sum_congr rfl,
+  intros i hi,
+  rw [←mul_assoc, (h.symm.pow_right i).eq, mul_assoc, (pow_succ _ _).symm],
+  have h : n - 1 - i + 1 = n - i,
+  { cases n,
+    { exact absurd (list.mem_range.mp hi) (nat.not_lt_zero i) },
+    { rw [nat.sub_add_eq_add_sub (nat.le_pred_of_lt (list.mem_range.mp hi)),
+        nat.sub_add_cancel (nat.succ_le_iff.mpr (nat.succ_pos n))] }},
+  rw h
+end
+
+theorem geom_sum₂_add_mul_eq_geom_sum₂ {α : Type u} [comm_ring α] (x y : α)  {n : ℕ} :
+  x ^ n + y * (geom_series₂ x y n) = (geom_series₂ x y (n + 1)) :=
+(commute.all x y).geom_sum₂_add_mul_eq_geom_sum₂
+
 theorem mul_geom_sum₂_Ico [comm_ring α] (x y : α) {m n : ℕ} (hmn : m ≤ n) :
   (x - y) * (∑ i in finset.Ico m n, x ^ i * y ^ (n - 1 - i)) = x ^ n - x ^ m * y ^ (n - m) :=
 (commute.all x y).mul_geom_sum₂_Ico hmn

--- a/src/algebra/geom_sum.lean
+++ b/src/algebra/geom_sum.lean
@@ -17,9 +17,9 @@ $\sum_{i=0}^{n-1} x^i y^{n-1-i}$ and variants thereof.
 
 ## Main definitions
 
-* `geom_series` defines for each $x$ in a semiring and each natural number $n$ the partial sum
+* `geom_sum` defines for each $x$ in a semiring and each natural number $n$ the partial sum
   $\sum_{i=0}^{n-1} x^i$ of the geometric series.
-* `geom_series₂` defines for each $x,y$ in a semiring and each natural number $n$ the partial sum
+* `geom_sum₂` defines for each $x,y$ in a semiring and each natural number $n$ the partial sum
   $\sum_{i=0}^{n-1} x^i y^{n-1-i}$ of the geometric series.
 
 ## Main statements
@@ -40,42 +40,42 @@ open finset opposite
 open_locale big_operators
 
 /-- Sum of the finite geometric series $\sum_{i=0}^{n-1} x^i$. -/
-def geom_series [semiring α] (x : α) (n : ℕ) :=
+def geom_sum [semiring α] (x : α) (n : ℕ) :=
 ∑ i in range n, x ^ i
 
-theorem geom_series_def [semiring α] (x : α) (n : ℕ) :
-  geom_series x n = ∑ i in range n, x ^ i := rfl
+theorem geom_sum_def [semiring α] (x : α) (n : ℕ) :
+  geom_sum x n = ∑ i in range n, x ^ i := rfl
 
-@[simp] theorem geom_series_zero [semiring α] (x : α) :
-  geom_series x 0 = 0 := rfl
+@[simp] theorem geom_sum_zero [semiring α] (x : α) :
+  geom_sum x 0 = 0 := rfl
 
-@[simp] theorem geom_series_one [semiring α] (x : α) :
-  geom_series x 1 = 1 :=
-by { rw [geom_series_def, sum_range_one, pow_zero] }
+@[simp] theorem geom_sum_one [semiring α] (x : α) :
+  geom_sum x 1 = 1 :=
+by { rw [geom_sum_def, sum_range_one, pow_zero] }
 
-@[simp] lemma op_geom_series [ring α] (x : α) (n : ℕ) :
-  op (geom_series x n) = geom_series (op x) n :=
-by simp [geom_series_def]
+@[simp] lemma op_geom_sum [ring α] (x : α) (n : ℕ) :
+  op (geom_sum x n) = geom_sum (op x) n :=
+by simp [geom_sum_def]
 
 /-- Sum of the finite geometric series $\sum_{i=0}^{n-1} x^i y^{n-1-i}$. -/
-def geom_series₂ [semiring α] (x y : α) (n : ℕ) :=
+def geom_sum₂ [semiring α] (x y : α) (n : ℕ) :=
 ∑ i in range n, x ^ i * (y ^ (n - 1 - i))
 
-theorem geom_series₂_def [semiring α] (x y : α) (n : ℕ) :
-  geom_series₂ x y n = ∑ i in range n, x ^ i * y ^ (n - 1 - i) := rfl
+theorem geom_sum₂_def [semiring α] (x y : α) (n : ℕ) :
+  geom_sum₂ x y n = ∑ i in range n, x ^ i * y ^ (n - 1 - i) := rfl
 
-@[simp] theorem geom_series₂_zero [semiring α] (x y : α) :
-  geom_series₂ x y 0 = 0 := rfl
+@[simp] theorem geom_sum₂_zero [semiring α] (x y : α) :
+  geom_sum₂ x y 0 = 0 := rfl
 
-@[simp] theorem geom_series₂_one [semiring α] (x y : α) :
-  geom_series₂ x y 1 = 1 :=
+@[simp] theorem geom_sum₂_one [semiring α] (x y : α) :
+  geom_sum₂ x y 1 = 1 :=
 by { have : 1 - 1 - 0 = 0 := rfl,
-     rw [geom_series₂_def, sum_range_one, this, pow_zero, pow_zero, mul_one] }
+     rw [geom_sum₂_def, sum_range_one, this, pow_zero, pow_zero, mul_one] }
 
-@[simp] lemma op_geom_series₂ [ring α] (x y : α) (n : ℕ) :
-  op (geom_series₂ x y n) = geom_series₂ (op y) (op x) n :=
+@[simp] lemma op_geom_sum₂ [ring α] (x y : α) (n : ℕ) :
+  op (geom_sum₂ x y n) = geom_sum₂ (op y) (op x) n :=
 begin
-  simp only [geom_series₂_def, op_sum, op_mul, units.op_pow],
+  simp only [geom_sum₂_def, op_sum, op_mul, units.op_pow],
   rw ← sum_range_reflect,
   refine sum_congr rfl (λ j j_in, _),
   rw [mem_range, nat.lt_iff_add_one_le] at j_in,
@@ -84,13 +84,13 @@ begin
   exact nat.le_sub_right_of_add_le j_in
 end
 
-@[simp] theorem geom_series₂_with_one [semiring α] (x : α) (n : ℕ) :
-  geom_series₂ x 1 n = geom_series x n :=
+@[simp] theorem geom_sum₂_with_one [semiring α] (x : α) (n : ℕ) :
+  geom_sum₂ x 1 n = geom_sum x n :=
 sum_congr rfl (λ i _, by { rw [one_pow, mul_one] })
 
 /-- $x^n-y^n = (x-y) \sum x^ky^{n-1-k}$ reformulated without `-` signs. -/
 protected theorem commute.geom_sum₂_mul_add [semiring α] {x y : α} (h : commute x y) (n : ℕ) :
-  (geom_series₂ (x + y) y n) * x + y ^ n = (x + y) ^ n :=
+  (geom_sum₂ (x + y) y n) * x + y ^ n = (x + y) ^ n :=
 begin
   let f := λ (m i : ℕ), (x + y) ^ i * y ^ (m - 1 - i),
   change (∑ i in range n, (f n) i) * x + y ^ n = (x + y) ^ n,
@@ -118,8 +118,8 @@ begin
     rw[mul_assoc, ← mul_add y, ih] }
 end
 
-theorem geom_series₂_self {α : Type*} [comm_ring α] (x : α) (n : ℕ) :
-  geom_series₂ x x n = n * x ^ (n-1) :=
+theorem geom_sum₂_self {α : Type*} [comm_ring α] (x : α) (n : ℕ) :
+  geom_sum₂ x x n = n * x ^ (n-1) :=
 calc  ∑ i in finset.range n, x ^ i * x ^ (n - 1 - i)
     = ∑ i in finset.range n, x ^ (i + (n - 1 - i)) : by simp_rw [← pow_add]
 ... = ∑ i in finset.range n, x ^ (n - 1) : finset.sum_congr rfl
@@ -129,19 +129,19 @@ calc  ∑ i in finset.range n, x ^ i * x ^ (n - 1 - i)
 
 /-- $x^n-y^n = (x-y) \sum x^ky^{n-1-k}$ reformulated without `-` signs. -/
 theorem geom_sum₂_mul_add [comm_semiring α] (x y : α) (n : ℕ) :
-  (geom_series₂ (x + y) y n) * x + y ^ n = (x + y) ^ n :=
+  (geom_sum₂ (x + y) y n) * x + y ^ n = (x + y) ^ n :=
 (commute.all x y).geom_sum₂_mul_add n
 
 theorem geom_sum_mul_add [semiring α] (x : α) (n : ℕ) :
-  (geom_series (x + 1) n) * x + 1 = (x + 1) ^ n :=
+  (geom_sum (x + 1) n) * x + 1 = (x + 1) ^ n :=
 begin
   have := (commute.one_right x).geom_sum₂_mul_add n,
-  rw [one_pow, geom_series₂_with_one] at this,
+  rw [one_pow, geom_sum₂_with_one] at this,
   exact this
 end
 
 protected theorem commute.geom_sum₂_mul [ring α] {x y : α} (h : commute x y) (n : ℕ) :
-  (geom_series₂ x y n) * (x - y) = x ^ n - y ^ n :=
+  (geom_sum₂ x y n) * (x - y) = x ^ n - y ^ n :=
 begin
   have := (h.sub_left (commute.refl y)).geom_sum₂_mul_add n,
   rw [sub_add_cancel] at this,
@@ -149,38 +149,38 @@ begin
 end
 
 lemma commute.mul_neg_geom_sum₂ [ring α] {x y : α} (h : commute x y) (n : ℕ) :
-  (y - x) * (geom_series₂ x y n) = y ^ n - x ^ n :=
+  (y - x) * (geom_sum₂ x y n) = y ^ n - x ^ n :=
 begin
   rw ← op_inj_iff,
-  simp only [op_mul, op_sub, op_geom_series₂, units.op_pow],
+  simp only [op_mul, op_sub, op_geom_sum₂, units.op_pow],
   exact (commute.op h.symm).geom_sum₂_mul n
 end
 
 lemma commute.mul_geom_sum₂ [ring α] {x y : α} (h : commute x y) (n : ℕ) :
-  (x - y) * (geom_series₂ x y n) = x ^ n - y ^ n :=
+  (x - y) * (geom_sum₂ x y n) = x ^ n - y ^ n :=
 by rw [← neg_sub (y ^ n), ← h.mul_neg_geom_sum₂, ← neg_mul_eq_neg_mul_symm, neg_sub]
 
 theorem geom_sum₂_mul [comm_ring α] (x y : α) (n : ℕ) :
-  (geom_series₂ x y n) * (x - y) = x ^ n - y ^ n :=
+  (geom_sum₂ x y n) * (x - y) = x ^ n - y ^ n :=
 (commute.all x y).geom_sum₂_mul n
 
 theorem geom_sum_mul [ring α] (x : α) (n : ℕ) :
-  (geom_series x n) * (x - 1) = x ^ n - 1 :=
+  (geom_sum x n) * (x - 1) = x ^ n - 1 :=
 begin
   have := (commute.one_right x).geom_sum₂_mul n,
-  rw [one_pow, geom_series₂_with_one] at this,
+  rw [one_pow, geom_sum₂_with_one] at this,
   exact this
 end
 
 lemma mul_geom_sum [ring α] (x : α) (n : ℕ) :
-  (x - 1) * (geom_series x n) = x ^ n - 1 :=
+  (x - 1) * (geom_sum x n) = x ^ n - 1 :=
 begin
   rw ← op_inj_iff,
   simpa using geom_sum_mul (op x) n,
 end
 
 theorem geom_sum_mul_neg [ring α] (x : α) (n : ℕ) :
-  (geom_series x n) * (1 - x) = 1 - x ^ n :=
+  (geom_sum x n) * (1 - x) = 1 - x ^ n :=
 begin
   have := congr_arg has_neg.neg (geom_sum_mul x n),
   rw [neg_sub, ← mul_neg_eq_neg_mul_symm, neg_sub] at this,
@@ -188,23 +188,23 @@ begin
 end
 
 lemma mul_neg_geom_sum [ring α] (x : α) (n : ℕ) :
-  (1 - x) * (geom_series x n) = 1 - x ^ n :=
+  (1 - x) * (geom_sum x n) = 1 - x ^ n :=
 begin
   rw ← op_inj_iff,
   simpa using geom_sum_mul_neg (op x) n,
 end
 
 protected theorem commute.geom_sum₂ [division_ring α] {x y : α} (h' : commute x y) (h : x ≠ y)
-  (n : ℕ) : (geom_series₂ x y n) = (x ^ n - y ^ n) / (x - y) :=
+  (n : ℕ) : (geom_sum₂ x y n) = (x ^ n - y ^ n) / (x - y) :=
 have x - y ≠ 0, by simp [*, -sub_eq_add_neg, sub_eq_iff_eq_add] at *,
 by rw [← h'.geom_sum₂_mul, mul_div_cancel _ this]
 
 theorem geom₂_sum [field α] {x y : α} (h : x ≠ y) (n : ℕ) :
-  (geom_series₂ x y n) = (x ^ n - y ^ n) / (x - y) :=
+  (geom_sum₂ x y n) = (x ^ n - y ^ n) / (x - y) :=
 (commute.all x y).geom_sum₂ h n
 
-theorem geom_sum [division_ring α] {x : α} (h : x ≠ 1) (n : ℕ) :
-  (geom_series x n) = (x ^ n - 1) / (x - 1) :=
+theorem geom_sum_eq [division_ring α] {x : α} (h : x ≠ 1) (n : ℕ) :
+  (geom_sum x n) = (x ^ n - 1) / (x - 1) :=
 have x - 1 ≠ 0, by simp [*, -sub_eq_add_neg, sub_eq_iff_eq_add] at *,
 by rw [← geom_sum_mul, mul_div_cancel _ this]
 
@@ -212,7 +212,7 @@ protected theorem commute.mul_geom_sum₂_Ico [ring α] {x y : α} (h : commute 
   (hmn : m ≤ n) :
   (x - y) * (∑ i in finset.Ico m n, x ^ i * y ^ (n - 1 - i)) = x ^ n - x ^ m * y ^ (n - m) :=
 begin
-  rw [sum_Ico_eq_sub _ hmn, ← geom_series₂_def],
+  rw [sum_Ico_eq_sub _ hmn, ← geom_sum₂_def],
   have : ∑ k in range m, x ^ k * y ^ (n - 1 - k)
     = ∑ k in range m, x ^ k * (y ^ (n - m) * y ^ (m - 1 - k)),
     { refine sum_congr rfl (λ j j_in, _),
@@ -224,16 +224,16 @@ begin
   rw this,
   simp_rw pow_mul_comm y (n-m) _,
   simp_rw ← mul_assoc,
-  rw [← sum_mul, ← geom_series₂_def, mul_sub, h.mul_geom_sum₂, ← mul_assoc,
+  rw [← sum_mul, ← geom_sum₂_def, mul_sub, h.mul_geom_sum₂, ← mul_assoc,
     h.mul_geom_sum₂, sub_mul, ← pow_add, nat.add_sub_of_le hmn,
     sub_sub_sub_cancel_right (x ^ n) (x ^ m * y ^ (n - m)) (y ^ n)],
 end
 
-protected theorem commute.geom_sum₂_add_mul_eq_geom_sum₂ {α : Type u} [ring α] {x y : α}
+protected theorem commute.geom_sum₂_succ_eq {α : Type u} [ring α] {x y : α}
   (h : commute x y) {n : ℕ} :
-  x ^ n + y * (geom_series₂ x y n) = (geom_series₂ x y (n + 1)) :=
+  geom_sum₂ x y (n + 1) = x ^ n + y * (geom_sum₂ x y n) :=
 begin
-  dunfold geom_series₂,
+  dunfold geom_sum₂,
   rw [mul_sum, sum_range_succ _ n, nat.add_succ_sub_one, add_zero, nat.sub_self, pow_zero, mul_one],
   apply congr_arg (has_add.add (x ^ n)),
   apply finset.sum_congr rfl,
@@ -247,9 +247,9 @@ begin
   rw h
 end
 
-theorem geom_sum₂_add_mul_eq_geom_sum₂ {α : Type u} [comm_ring α] (x y : α)  {n : ℕ} :
-  x ^ n + y * (geom_series₂ x y n) = (geom_series₂ x y (n + 1)) :=
-(commute.all x y).geom_sum₂_add_mul_eq_geom_sum₂
+theorem geom_sum₂_succ_eq {α : Type u} [comm_ring α] (x y : α)  {n : ℕ} :
+  geom_sum₂ x y (n + 1) = x ^ n + y * (geom_sum₂ x y n) :=
+(commute.all x y).geom_sum₂_succ_eq
 
 theorem mul_geom_sum₂_Ico [comm_ring α] (x y : α) {m n : ℕ} (hmn : m ≤ n) :
   (x - y) * (∑ i in finset.Ico m n, x ^ i * y ^ (n - 1 - i)) = x ^ n - x ^ m * y ^ (n - m) :=
@@ -271,12 +271,12 @@ end
 
 theorem geom_sum_Ico_mul [ring α] (x : α) {m n : ℕ} (hmn : m ≤ n) :
   (∑ i in finset.Ico m n, x ^ i) * (x - 1) = x^n - x^m :=
-by rw [sum_Ico_eq_sub _ hmn, ← geom_series_def, ← geom_series_def, sub_mul,
+by rw [sum_Ico_eq_sub _ hmn, ← geom_sum_def, ← geom_sum_def, sub_mul,
   geom_sum_mul, geom_sum_mul, sub_sub_sub_cancel_right]
 
 theorem geom_sum_Ico_mul_neg [ring α] (x : α) {m n : ℕ} (hmn : m ≤ n) :
   (∑ i in finset.Ico m n, x ^ i) * (1 - x) = x^m - x^n :=
-by rw [sum_Ico_eq_sub _ hmn, ← geom_series_def, ← geom_series_def, sub_mul,
+by rw [sum_Ico_eq_sub _ hmn, ← geom_sum_def, ← geom_sum_def, sub_mul,
   geom_sum_mul_neg, geom_sum_mul_neg, sub_sub_sub_cancel_left]
 
 protected theorem commute.geom_sum₂_Ico [division_ring α] {x y : α} (h : commute x y) (hxy : x ≠ y)
@@ -291,7 +291,7 @@ theorem geom_sum₂_Ico [field α] {x y : α} (hxy : x ≠ y) {m n : ℕ} (hmn :
 
 theorem geom_sum_Ico [division_ring α] {x : α} (hx : x ≠ 1) {m n : ℕ} (hmn : m ≤ n) :
   ∑ i in finset.Ico m n, x ^ i = (x ^ n - x ^ m) / (x - 1) :=
-by simp only [sum_Ico_eq_sub _ hmn, (geom_series_def _ _).symm, geom_sum hx, div_sub_div_same,
+by simp only [sum_Ico_eq_sub _ hmn, (geom_sum_def _ _).symm, geom_sum_eq hx, div_sub_div_same,
   sub_sub_sub_cancel_right]
 
 theorem geom_sum_Ico' [division_ring α] {x : α} (hx : x ≠ 1) {m n : ℕ} (hmn : m ≤ n) :
@@ -299,7 +299,7 @@ theorem geom_sum_Ico' [division_ring α] {x : α} (hx : x ≠ 1) {m n : ℕ} (hm
 by { simp only [geom_sum_Ico hx hmn], convert neg_div_neg_eq (x^m - x^n) (1-x); abel }
 
 lemma geom_sum_inv [division_ring α] {x : α} (hx1 : x ≠ 1) (hx0 : x ≠ 0) (n : ℕ) :
-  (geom_series x⁻¹ n) = (x - 1)⁻¹ * (x - x⁻¹ ^ n * x) :=
+  (geom_sum x⁻¹ n) = (x - 1)⁻¹ * (x - x⁻¹ ^ n * x) :=
 have h₁ : x⁻¹ ≠ 1, by rwa [inv_eq_one_div, ne.def, div_eq_iff_mul_eq hx0, one_mul],
 have h₂ : x⁻¹ - 1 ≠ 0, from mt sub_eq_zero.1 h₁,
 have h₃ : x - 1 ≠ 0, from mt sub_eq_zero.1 hx1,
@@ -308,7 +308,7 @@ have h₄ : x * (x ^ n)⁻¹ = (x ^ n)⁻¹ * x :=
   (λ n h, by rw [pow_succ, mul_inv_rev', ←mul_assoc, h, mul_assoc, mul_inv_cancel hx0, mul_assoc,
     inv_mul_cancel hx0]),
 begin
-  rw [geom_sum h₁, div_eq_iff_mul_eq h₂, ← mul_right_inj' h₃,
+  rw [geom_sum_eq h₁, div_eq_iff_mul_eq h₂, ← mul_right_inj' h₃,
     ← mul_assoc, ← mul_assoc, mul_inv_cancel h₃],
   simp [mul_add, add_mul, mul_inv_cancel hx0, mul_assoc, h₄, sub_eq_add_neg, add_comm,
     add_left_comm],
@@ -316,10 +316,10 @@ end
 
 variables {β : Type*}
 
-theorem ring_hom.map_geom_series [semiring α] [semiring β] (x : α) (n : ℕ) (f : α →+* β) :
-  f (geom_series x n) = geom_series (f x) n :=
-by simp [geom_series_def, f.map_sum]
+theorem ring_hom.map_geom_sum [semiring α] [semiring β] (x : α) (n : ℕ) (f : α →+* β) :
+  f (geom_sum x n) = geom_sum (f x) n :=
+by simp [geom_sum_def, f.map_sum]
 
-theorem ring_hom.map_geom_series₂ [semiring α] [semiring β] (x y : α) (n : ℕ) (f : α →+* β) :
-  f (geom_series₂ x y n) = geom_series₂ (f x) (f y) n :=
-by simp [geom_series₂_def, f.map_sum]
+theorem ring_hom.map_geom_sum₂ [semiring α] [semiring β] (x y : α) (n : ℕ) (f : α →+* β) :
+  f (geom_sum₂ x y n) = geom_sum₂ (f x) (f y) n :=
+by simp [geom_sum₂_def, f.map_sum]

--- a/src/algebra/geom_sum.lean
+++ b/src/algebra/geom_sum.lean
@@ -238,13 +238,12 @@ begin
   apply congr_arg (has_add.add (x ^ n)),
   apply finset.sum_congr rfl,
   intros i hi,
-  rw [←mul_assoc, (h.symm.pow_right i).eq, mul_assoc, (pow_succ _ _).symm],
-  have h : n - 1 - i + 1 = n - i,
-  { cases n,
-    { exact absurd (list.mem_range.mp hi) (nat.not_lt_zero i) },
-    { rw [nat.sub_add_eq_add_sub (nat.le_pred_of_lt (list.mem_range.mp hi)),
-        nat.sub_add_cancel (nat.succ_le_iff.mpr (nat.succ_pos n))] }},
-  rw h
+  rw [←mul_assoc, (h.symm.pow_right i).eq, mul_assoc, ←pow_succ],
+  suffices : n - 1 - i + 1 = n - i , { rw this },
+  cases n,
+  { exact absurd (list.mem_range.mp hi) i.not_lt_zero },
+  { rw [nat.sub_add_eq_add_sub (nat.le_pred_of_lt (list.mem_range.mp hi)),
+        nat.sub_add_cancel (nat.succ_le_iff.mpr n.succ_pos)] },
 end
 
 theorem geom_sum₂_succ_eq {α : Type u} [comm_ring α] (x y : α)  {n : ℕ} :

--- a/src/analysis/normed_space/units.lean
+++ b/src/analysis/normed_space/units.lean
@@ -125,14 +125,14 @@ begin
   simp only [inverse_one_sub t ht, set.mem_set_of_eq],
   have h : 1 = ((range n).sum (λ i, t ^ i)) * (units.one_sub t ht) + t ^ n,
   { simp only [units.one_sub_coe],
-    rw [← geom_series, geom_sum_mul_neg],
+    rw [← geom_sum, geom_sum_mul_neg],
     simp },
   rw [← one_mul ↑(units.one_sub t ht)⁻¹, h, add_mul],
   congr,
   { rw [mul_assoc, (units.one_sub t ht).mul_inv],
     simp },
   { simp only [units.one_sub_coe],
-    rw [← add_mul, ← geom_series, geom_sum_mul_neg],
+    rw [← add_mul, ← geom_sum, geom_sum_mul_neg],
     simp }
 end
 

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -790,7 +790,7 @@ begin
     { congr' with i,
       have : (i : ℝ) + 1 ≠ 0 := ne_of_gt (nat.cast_add_one_pos i),
       field_simp [this, mul_comm] },
-    field_simp [F, this, ← geom_series_def, geom_sum (ne_of_lt hy.2),
+    field_simp [F, this, ← geom_sum_def, geom_sum_eq (ne_of_lt hy.2),
                 sub_ne_zero_of_ne (ne_of_gt hy.2), sub_ne_zero_of_ne (ne_of_lt hy.2)],
     ring },
   -- second step: show that the derivative of `F` is small

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -295,9 +295,9 @@ lemma has_sum_geometric_of_lt_1 {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) :
 have r ≠ 1, from ne_of_lt h₂,
 have tendsto (λn, (r ^ n - 1) * (r - 1)⁻¹) at_top (𝓝 ((0 - 1) * (r - 1)⁻¹)),
   from ((tendsto_pow_at_top_nhds_0_of_lt_1 h₁ h₂).sub tendsto_const_nhds).mul tendsto_const_nhds,
-have (λ n, (∑ i in range n, r ^ i)) = (λ n, geom_series r n) := rfl,
+have (λ n, (∑ i in range n, r ^ i)) = (λ n, geom_sum r n) := rfl,
 (has_sum_iff_tendsto_nat_of_nonneg (pow_nonneg h₁) _).mpr $
-  by simp [neg_inv, geom_sum, div_eq_mul_inv, *] at *
+  by simp [neg_inv, geom_sum_eq, div_eq_mul_inv, *] at *
 
 lemma summable_geometric_of_lt_1 {r : ℝ} (h₁ : 0 ≤ r) (h₂ : r < 1) : summable (λn:ℕ, r ^ n) :=
 ⟨_, has_sum_geometric_of_lt_1 h₁ h₂⟩
@@ -375,9 +375,9 @@ begin
   have xi_ne_one : ξ ≠ 1, by { contrapose! h, simp [h] },
   have A : tendsto (λn, (ξ ^ n - 1) * (ξ - 1)⁻¹) at_top (𝓝 ((0 - 1) * (ξ - 1)⁻¹)),
     from ((tendsto_pow_at_top_nhds_0_of_norm_lt_1 h).sub tendsto_const_nhds).mul tendsto_const_nhds,
-  have B : (λ n, (∑ i in range n, ξ ^ i)) = (λ n, geom_series ξ n) := rfl,
+  have B : (λ n, (∑ i in range n, ξ ^ i)) = (λ n, geom_sum ξ n) := rfl,
   rw [has_sum_iff_tendsto_nat_of_summable_norm, B],
-  { simpa [geom_sum, xi_ne_one, neg_inv] using A },
+  { simpa [geom_sum_eq, xi_ne_one, neg_inv] using A },
   { simp [normed_field.norm_pow, summable_geometric_of_lt_1 (norm_nonneg _) h] }
 end
 
@@ -677,7 +677,7 @@ begin
   { simpa using tendsto_const_nhds.sub (tendsto_pow_at_top_nhds_0_of_norm_lt_1 h) },
   convert ← this,
   ext n,
-  rw [←geom_sum_mul_neg, geom_series_def, finset.sum_mul],
+  rw [←geom_sum_mul_neg, geom_sum_def, finset.sum_mul],
 end
 
 lemma mul_neg_geom_series (x : R) (h : ∥x∥ < 1) :
@@ -690,7 +690,7 @@ begin
       (tendsto_pow_at_top_nhds_0_of_norm_lt_1 h) },
   convert ← this,
   ext n,
-  rw [←mul_neg_geom_sum, geom_series_def, finset.mul_sum]
+  rw [←mul_neg_geom_sum, geom_sum_def, finset.mul_sum]
 end
 
 end normed_ring_geometric

--- a/src/combinatorics/colex.lean
+++ b/src/combinatorics/colex.lean
@@ -92,7 +92,7 @@ lemma nat.sum_pow_two_lt {k : ℕ} {A : finset ℕ} (h₁ : ∀ {x}, x ∈ A →
 begin
   apply lt_of_le_of_lt (sum_le_sum_of_subset (λ t, mem_range.2 ∘ h₁)),
   have z := geom_sum_mul_add 1 k,
-  rw [geom_series, mul_one, one_add_one_eq_two] at z,
+  rw [geom_sum, mul_one, one_add_one_eq_two] at z,
   rw ← z,
   apply nat.lt_succ_self,
 end

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -132,8 +132,8 @@ is_cau_series_of_abv_cau
 begin
   simp only [abv_pow abv] {eta := ff},
   have : (λ (m : ℕ), ∑ n in range m, (abv x) ^ n) =
-   λ m, geom_series (abv x) m := rfl,
-  simp only [this, geom_sum hx1'] {eta := ff},
+   λ m, geom_sum (abv x) m := rfl,
+  simp only [this, geom_sum_eq hx1'] {eta := ff},
   conv in (_ / _) { rw [← neg_div_neg_eq, neg_sub, neg_sub] },
   refine @is_cau_of_mono_bounded _ _ _ _ ((1 : α) / (1 - abv x)) 0 _ _,
   { assume n hn,
@@ -1228,7 +1228,7 @@ calc ∑ m in filter (λ k, n ≤ k) (range j), (1 / m! : α)
     from mul_ne_zero (nat.cast_ne_zero.2 (pos_iff_ne_zero.1 (nat.factorial_pos _)))
     (nat.cast_ne_zero.2 (pos_iff_ne_zero.1 hn)),
   have h₄ : (n.succ - 1 : α) = n, by simp,
-  by rw [← geom_series_def, geom_sum_inv h₁ h₂, eq_div_iff_mul_eq h₃,
+  by rw [← geom_sum_def, geom_sum_inv h₁ h₂, eq_div_iff_mul_eq h₃,
       mul_comm _ (n! * n : α), ← mul_assoc (n!⁻¹ : α), ← mul_inv_rev', h₄,
       ← mul_assoc (n! * n : α), mul_comm (n : α) n!, mul_inv_cancel h₃];
     simp [mul_add, add_mul, mul_assoc, mul_comm]

--- a/src/data/real/pi.lean
+++ b/src/data/real/pi.lean
@@ -235,8 +235,8 @@ begin
             pow_mul x 2 i, ← mul_pow (-1) (x^2) i],
         ring } },
     convert (has_deriv_at_arctan x).sub (has_deriv_at.sum has_deriv_at_b),
-    have g_sum := @geom_sum _ _ (-x^2) (by linarith [neg_nonpos.mpr (pow_two_nonneg x)]) k,
-    simp only [geom_series, f'] at g_sum ⊢,
+    have g_sum := @geom_sum_eq _ _ (-x^2) (by linarith [neg_nonpos.mpr (pow_two_nonneg x)]) k,
+    simp only [geom_sum, f'] at g_sum ⊢,
     rw [g_sum, ← neg_add' (x^2) 1, add_comm (x^2) 1, sub_eq_add_neg, neg_div', neg_div_neg_eq],
     ring },
   have hderiv1 : ∀ x ∈ Icc (U:ℝ) 1, has_deriv_within_at f (f' x) (Icc (U:ℝ) 1) x :=

--- a/src/number_theory/basic.lean
+++ b/src/number_theory/basic.lean
@@ -37,8 +37,8 @@ begin
   have hp : (p : ideal.quotient I) = 0,
   { rw [← f.map_nat_cast, eq_zero_iff_mem, mem_span_singleton] },
   rw [← mem_span_singleton, ← ideal.quotient.eq] at h,
-  rw [← mem_span_singleton, ← eq_zero_iff_mem, ring_hom.map_geom_series₂,
-      ring_hom.map_pow, ring_hom.map_pow, h, geom_series₂_self, hp, zero_mul],
+  rw [← mem_span_singleton, ← eq_zero_iff_mem, ring_hom.map_geom_sum₂,
+      ring_hom.map_pow, ring_hom.map_pow, h, geom_sum₂_self, hp, zero_mul],
 end
 
 end

--- a/src/number_theory/bernoulli.lean
+++ b/src/number_theory/bernoulli.lean
@@ -381,7 +381,7 @@ begin
     { have h_const : C ℚ (constant_coeff ℚ (exp ℚ ^ n)) = 1 := by simp,
       rw [←h_const, sub_const_eq_X_mul_shift] },
     -- key step: a chain of equalities of power series
-    rw [←mul_right_inj' hexp, mul_comm, ←exp_pow_sum, ←geom_series_def, geom_sum_mul, h_r,
+    rw [←mul_right_inj' hexp, mul_comm, ←exp_pow_sum, ←geom_sum_def, geom_sum_mul, h_r,
         ←bernoulli_power_series_mul_exp_sub_one, bernoulli_power_series, mul_right_comm],
     simp [h_cauchy, mul_comm] },
   -- the rest is showing that `hps` can be massaged into our goal

--- a/src/ring_theory/integral_domain.lean
+++ b/src/ring_theory/integral_domain.lean
@@ -151,7 +151,7 @@ begin
       (λ b hb, let ⟨n, hn⟩ := hx b in ⟨n % order_of x, mem_range.2 (nat.mod_lt _ (order_of_pos _)),
         by rw [← pow_eq_mod_order_of, hn]⟩)
   ... = 0 : _,
-  rw [← mul_left_inj' hx1, zero_mul, ← geom_series, geom_sum_mul, coe_coe],
+  rw [← mul_left_inj' hx1, zero_mul, ← geom_sum, geom_sum_mul, coe_coe],
   norm_cast,
   rw [pow_order_of_eq_one, is_submonoid.coe_one, units.coe_one, sub_self],
 end

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -531,9 +531,9 @@ begin
     exact monic.ne_zero prod_monic (degree_eq_bot.1 h) },
 end
 
-/-- If `p` is prime, then `cyclotomic p R = geom_series X p`. -/
-lemma cyclotomic_eq_geom_series {R : Type*} [comm_ring R] [nontrivial R] {p : ℕ}
-  (hp : nat.prime p) : cyclotomic p R = geom_series X p :=
+/-- If `p` is prime, then `cyclotomic p R = geom_sum X p`. -/
+lemma cyclotomic_eq_geom_sum {R : Type*} [comm_ring R] [nontrivial R] {p : ℕ}
+  (hp : nat.prime p) : cyclotomic p R = geom_sum X p :=
 begin
   symmetry,
   refine (eq_cyclotomic_iff hp.pos _).mpr _,


### PR DESCRIPTION
Declarations with names including `geom_series` have been renamed to use `geom_sum`, instead.

Also adds the lemma `geom_sum₂_succ_eq`: `geom_sum₂ x y (n + 1) = x ^ n + y * (geom_sum₂ x y n)`