### PR TITLE
[Merged by Bors] - feat(logic/basic): `is_trans Prop iff` instance

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -191,6 +191,9 @@ variables {a b c d : Prop}
 
 /-! ### Declarations about `implies` -/
 
+instance : is_refl Prop iff := ⟨iff.refl⟩
+instance : is_trans Prop iff := ⟨λ _ _ _, iff.trans⟩
+
 theorem iff_of_eq (e : a = b) : a ↔ b := e ▸ iff.rfl
 
 theorem iff_iff_eq : (a ↔ b) ↔ a = b := ⟨propext, iff_of_eq⟩


### PR DESCRIPTION
If you've ever wondered why `trans h1 h2` works for `≤` but not for `↔`, this is the reason.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
