### PR TITLE
feat(algebra/direct_sum_graded): If `A i` forms a graded ring then `A 0` is itself a ring

### DIFF
--- a/src/algebra/direct_sum_graded.lean
+++ b/src/algebra/direct_sum_graded.lean
@@ -236,9 +236,118 @@ gcomm_monoid.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem mul
 
 end shorthands
 
+variables (A : ι → Type*)
+
+/-! ### Instances for `A 0` -/
+
+namespace grade_zero
+
+section one
+variables [has_zero ι] [ghas_one A]
+
+instance has_one : has_one (A 0) :=
+⟨ghas_one.one⟩
+
+end one
+
+section mul
+variables [add_monoid ι] [Π i, add_comm_monoid (A i)] [ghas_mul A]
+
+
+def cast_indexed {ι : Sort*} {A : ι → Sort*} {i j : ι} (h : i = j) : A i → A j :=
+cast (congr_arg A h)
+
+@[simp]
+lemma cast_indexed_pi {ι : Sort*} {A : ι → Sort*} :
+  ∀ {i j : ι} (h : i = j) (f : Π i, A i), cast_indexed h (f i) = f j
+| _ _ rfl f := rfl
+
+instance has_mul : has_mul (A 0) :=
+{ mul := λ x y, cast_indexed (zero_add (0 : ι)) (ghas_mul.mul x y)}
+
+instance mul_zero_class : mul_zero_class (A 0) :=
+{ mul := (*),
+  zero := 0,
+  zero_mul := λ a, by {
+    simp [has_mul.mul],
+    exact cast_indexed_pi (zero_add 0) (λ i : ι, (0 : A i)), },
+  mul_zero := λ a, by {
+    simp [has_mul.mul],
+    exact cast_indexed_pi (add_zero 0) (λ i : ι, (0 : A i)), }, }
+
+instance distrib : distrib (A 0) :=
+{ mul := (*),
+  add := (+),
+  left_distrib := λ a b c, by { unfold has_mul.mul, sorry },
+  right_distrib := λ a b c, by { unfold has_mul.mul, sorry } }
+
+end mul
+
+section semiring
+variables [Π i, add_comm_monoid (A i)] [add_monoid ι] [gmonoid A]
+
+/-- The `semiring` structure derived from `gmonoid A`. -/
+instance semiring : semiring (A 0) := {
+  one := 1,
+  mul := (*),
+  zero := 0,
+  add := (+),
+  one_mul := sorry,
+  mul_one := sorry,
+  mul_assoc := sorry,
+  ..direct_sum.grade_zero.mul_zero_class A,
+  ..direct_sum.grade_zero.distrib A,
+  ..(by apply_instance : add_comm_monoid (A 0)), }
+
+end semiring
+
+section comm_semiring
+
+variables [Π i, add_comm_monoid (A i)] [add_comm_monoid ι] [gcomm_monoid A]
+
+/-- The `comm_semiring` structure derived from `gcomm_monoid A`. -/
+instance comm_semiring : comm_semiring (A 0) := {
+  one := 1,
+  mul := (*),
+  zero := 0,
+  add := (+),
+  mul_comm := sorry,
+  ..direct_sum.grade_zero.semiring _, }
+
+end comm_semiring
+
+section ring
+variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gmonoid A]
+
+/-- The `ring` derived from `gmonoid A`. -/
+instance ring : ring (A 0) := {
+  one := 1,
+  mul := (*),
+  zero := 0,
+  add := (+),
+  neg := has_neg.neg,
+  ..(direct_sum.grade_zero.semiring _),
+  ..(by apply_instance : add_comm_group (A 0)), }
+
+end ring
+
+section comm_ring
+variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gcomm_monoid A]
+
+/-- The `comm_ring` derived from `gcomm_monoid A`. -/
+instance comm_ring : comm_ring (A 0) := {
+  one := 1,
+  mul := (*),
+  zero := 0,
+  add := (+),
+  neg := has_neg.neg,
+  ..(direct_sum.grade_zero.ring _),
+  ..(direct_sum.grade_zero.comm_semiring _), }
+
+end comm_ring
+
 /-! ### Instances for `⨁ i, A i` -/
 
-variables (A : ι → Type*)
 
 section one
 variables [has_zero ι] [ghas_one A] [Π i, add_comm_monoid (A i)]

--- a/src/algebra/direct_sum_graded.lean
+++ b/src/algebra/direct_sum_graded.lean
@@ -22,10 +22,22 @@ additively-graded ring. The typeclasses are:
 
 Respectively, these imbue the direct sum `⨁ i, A i` with:
 
-* `has_one`
-* `mul_zero_class`, `distrib`
-* `semiring`, `ring`
-* `comm_semiring`, `comm_ring`
+* `direct_sum.has_one`
+* `direct_sum.mul_zero_class`, `direct_sum.distrib`
+* `direct_sum.semiring`, `direct_sum.ring`
+* `direct_sum.comm_semiring`, `direct_sum.comm_ring`
+
+and the base ring `A 0` with:
+
+* `direct_sum.grade_zero.has_one`
+* `direct_sum.grade_zero.mul_zero_class`, `direct_sum.grade_zero.distrib`
+* `direct_sum.grade_zero.semiring`, `direct_sum.grade_zero.ring`
+* `direct_sum.grade_zero.comm_semiring`, `direct_sum.grade_zero.comm_ring`
+
+`direct_sum.of_zero_ring_hom : A 0 →+ ⨁ i, A i` provides `direct_sum.of A 0` as a ring
+homomorphism.
+
+## Direct sums of subobjects
 
 Additionally, this module provides helper functions to construct `gmonoid` and `gcomm_monoid`
 instances for:


### PR DESCRIPTION
The main results here are `direct_sum.grade_zero.comm_ring` and `direct_sum.of_zero_ring_hom`.

Note that we have no way to let the user provide their own ring structure on `A 0`, as `[Π i, add_comm_monoid (A i)] [semiring (A 0)]` provides `add_comm_monoid (A 0)` twice.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This goes into DTT hell and back again multiple times, possibly without good reason.

---

Edit: this is substantially more complex than but otherwise definitionally identical to the approach taken in #6851; although it might have some lemmas about eq_rec which are worth salvaging.