### PR TITLE
[Merged by Bors] - feat(combinatorics/quiver): weakly connected components

### DIFF
--- a/src/combinatorics/quiver.lean
+++ b/src/combinatorics/quiver.lean
@@ -96,8 +96,8 @@ inductive path {V} (G : quiver.{v u} V) (a : V) : V → Sort (max (u+1) v)
 | cons : Π {b c : V}, path b → G.arrow b c → path c
 
 /-- An arrow viewed as a path of length one. -/
-def arrow.to_path {V} {G : quiver V} {a b} : G.arrow a b → G.path a b :=
-λ e, path.nil.cons e
+def arrow.to_path {V} {G : quiver V} {a b} (e : G.arrow a b) : G.path a b :=
+path.nil.cons e
 
 namespace path
 
@@ -244,10 +244,10 @@ instance : has_reverse H.symmetrify := ⟨λ a b e, e.swap⟩
 /-- Two vertices are related in the zigzag setoid if there is a
     zigzag of arrows from one to the other. -/
 def zigzag_setoid : setoid V :=
-⟨ λ a b, nonempty (H.symmetrify.path a b),
-  λ a, ⟨path.nil⟩,
-  λ a b ⟨p⟩, ⟨p.reverse⟩,
-  λ a b c ⟨p⟩ ⟨q⟩, ⟨p.comp q⟩ ⟩
+⟨λ a b, nonempty (H.symmetrify.path a b),
+ λ a, ⟨path.nil⟩,
+ λ a b ⟨p⟩, ⟨p.reverse⟩,
+ λ a b c ⟨p⟩ ⟨q⟩, ⟨p.comp q⟩⟩
 
 /-- The type of weakly connected components of a directed graph. Two vertices are
     in the same weakly connected component if there is a zigzag of arrows from one


### PR DESCRIPTION
Define composition of paths and the weakly connected components of a directed graph. Two vertices are in the same weakly connected component if there is a zigzag of arrows from one to the other.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
