### PR TITLE
[Merged by Bors] - feat(measure_theory/interval_integral): weaken assumption in `integral_non_ae_measurable`

### DIFF
--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -303,9 +303,14 @@ lemma integral_cases (f : α → E) (a b) :
 (le_total a b).imp (λ h, by simp [h, integral_of_le]) (λ h, by simp [h, integral_of_ge])
 
 lemma integral_non_ae_measurable {f : α → E} {a b}
-  (h : a ≤ b) (hf : ¬ ae_measurable f (μ.restrict (Ioc a b))) :
+  (hf : ¬ ae_measurable f (μ.restrict (Ioc (min a b) (max a b)))) :
   ∫ x in a..b, f x ∂μ = 0 :=
-by rw [integral_of_le h, integral_non_ae_measurable hf]
+by cases le_total a b; simpa [integral_of_le, integral_of_ge, h] using integral_non_ae_measurable hf
+
+lemma integral_non_ae_measurable_of_le {f : α → E} {a b} (h : a ≤ b)
+  (hf : ¬ ae_measurable f (μ.restrict (Ioc a b))) :
+  ∫ x in a..b, f x ∂μ = 0 :=
+integral_non_ae_measurable $ by simpa [h] using hf
 
 lemma norm_integral_eq_norm_integral_Ioc :
   ∥∫ x in a..b, f x ∂μ∥ = ∥∫ x in Ioc (min a b) (max a b), f x ∂μ∥ :=

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -303,9 +303,9 @@ lemma integral_cases (f : α → E) (a b) :
 (le_total a b).imp (λ h, by simp [h, integral_of_le]) (λ h, by simp [h, integral_of_ge])
 
 lemma integral_non_ae_measurable {f : α → E} {a b}
-  (h : a < b) (hf : ¬ ae_measurable f (μ.restrict (Ioc a b))) :
+  (h : a ≤ b) (hf : ¬ ae_measurable f (μ.restrict (Ioc a b))) :
   ∫ x in a..b, f x ∂μ = 0 :=
-by rw [integral_of_le h.le, integral_non_ae_measurable hf]
+by rw [integral_of_le h, integral_non_ae_measurable hf]
 
 lemma norm_integral_eq_norm_integral_Ioc :
   ∥∫ x in a..b, f x ∂μ∥ = ∥∫ x in Ioc (min a b) (max a b), f x ∂μ∥ :=


### PR DESCRIPTION
I don't see any reason for having a strict inequality here.