### PR TITLE
[Merged by Bors] - chore(order/filter/lift,topology/algebra/ordered): drop `[nonempty ι]`

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1020,6 +1020,9 @@ theorem monotone_powerset : monotone (powerset : set α → set (set α)) :=
 @[simp] theorem powerset_empty : 𝒫 (∅ : set α) = {∅} :=
 ext $ λ s, subset_empty_iff
 
+@[simp] theorem powerset_univ : 𝒫 (univ : set α) = univ :=
+eq_univ_of_forall subset_univ
+
 /-! ### If-then-else for sets -/
 
 /-- `ite` for sets: `set.ite t s s' ∩ t = s ∩ t`, `set.ite t s s' ∩ tᶜ = s' ∩ tᶜ`.

--- a/src/order/filter/lift.lean
+++ b/src/order/filter/lift.lean
@@ -25,6 +25,9 @@ protected def lift (f : filter α) (g : set α → filter β) :=
 
 variables {f f₁ f₂ : filter α} {g g₁ g₂ : set α → filter β}
 
+@[simp] lemma lift_top (g : set α → filter β) : (⊤ : filter α).lift g = g univ :=
+by simp [filter.lift]
+
 /-- If `(p : ι → Prop, s : ι → set α)` is a basis of a filter `f`, `g` is a monotone function
 `set α → filter γ`, and for each `i`, `(pg : β i → Prop, sg : β i → set α)` is a basis
 of the filter `g (s i)`, then `(λ (i : ι) (x : β i), p i ∧ pg i x, λ (i : ι) (x : β i), sg i x)`
@@ -217,6 +220,9 @@ f.lift (𝓟 ∘ h)
 
 variables {f f₁ f₂ : filter α} {h h₁ h₂ : set α → set β}
 
+@[simp] lemma lift'_top (h : set α → set β) : (⊤ : filter α).lift' h = 𝓟 (h univ) :=
+lift_top _
+
 lemma mem_lift' {t : set α} (ht : t ∈ f) : h t ∈ (f.lift' h) :=
 le_principal_iff.mp $ show f.lift' h ≤ 𝓟 (h t),
   from infi_le_of_le t $ infi_le_of_le ht $ le_refl _
@@ -360,9 +366,13 @@ theorem comap_eq_lift' {f : filter β} {m : α → β} :
   comap m f = f.lift' (preimage m) :=
 filter.ext $ λ s, (mem_lift'_sets monotone_preimage).symm
 
-lemma lift'_infi_powerset [nonempty ι] {f : ι → filter α} :
+lemma lift'_infi_powerset {f : ι → filter α} :
   (infi f).lift' powerset = (⨅i, (f i).lift' powerset) :=
-lift'_infi $ λ _ _, (powerset_inter _ _).symm
+begin
+  by_cases hι : nonempty ι,
+  { exactI (lift'_infi $ λ _ _, (powerset_inter _ _).symm) },
+  { rw [infi_of_empty hι, infi_of_empty hι, lift'_top, powerset_univ, principal_univ] }
+end
 
 lemma lift'_inf_powerset (f g : filter α) :
   (f ⊓ g).lift' powerset = f.lift' powerset ⊓ g.lift' powerset :=

--- a/src/topology/algebra/ordered.lean
+++ b/src/topology/algebra/ordered.lean
@@ -712,7 +712,7 @@ instance tendsto_Ixx_nhds_within {α : Type*} [preorder α] [topological_space �
   tendsto_Ixx_class Ixx (𝓝[s] a) (𝓝[t] a) :=
 filter.tendsto_Ixx_class_inf
 
-instance tendsto_Icc_class_nhds_pi {ι : Type*} {α : ι → Type*} [nonempty ι]
+instance tendsto_Icc_class_nhds_pi {ι : Type*} {α : ι → Type*}
   [Π i, partial_order (α i)] [Π i, topological_space (α i)] [∀ i, order_topology (α i)]
   (f : Π i, α i) :
   tendsto_Ixx_class Icc (𝓝 f) (𝓝 f) :=


### PR DESCRIPTION
* add `set.powerset_univ`, `filter.lift_top`, `filter.lift'_top`;
* remove `[nonempty ι]` from `filter.lift'_infi_powerset` and `tendsto_Icc_class_nhds_pi`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)