### PR TITLE
[Merged by Bors] - chore(data/pi,algebra/group/pi): reorganize proofs

### DIFF
--- a/src/algebra/group/pi.lean
+++ b/src/algebra/group/pi.lean
@@ -133,7 +133,7 @@ into a dependent family of values, as functions supported at a point.
 This is the `zero_hom` version of `pi.single`. -/
 @[simps] def zero_hom.single [Π i, has_zero $ f i] (i : I) : zero_hom (f i) (Π i, f i) :=
 { to_fun := single i,
-  map_zero' := function.update_eq_self i 0 }
+  map_zero' := single_zero i }
 
 /-- The additive monoid homomorphism including a single additive monoid
 into a dependent family of additive monoids, as functions supported at a point.
@@ -141,29 +141,18 @@ into a dependent family of additive monoids, as functions supported at a point.
 This is the `add_monoid_hom` version of `pi.single`. -/
 @[simps] def add_monoid_hom.single [Π i, add_monoid $ f i] (i : I) : f i →+ Π i, f i :=
 { to_fun := single i,
-  map_add' := λ x y, funext $ λ j, begin
-    refine (apply_single₂ _ (λ _, _) i x y j).symm,
-    exact zero_add 0,
-  end,
+  map_add' := single_binop (λ _, (+)) (λ _, zero_add _) _,
   .. (zero_hom.single f i) }
 
 /-- The multiplicative homomorphism including a single `monoid_with_zero`
 into a dependent family of monoid_with_zeros, as functions supported at a point.
 
 This is the `mul_hom` version of `pi.single`. -/
-@[simps] def mul_hom.single [Π i, monoid_with_zero $ f i] (i : I) : mul_hom (f i) (Π i, f i) :=
+@[simps] def mul_hom.single [Π i, mul_zero_class $ f i] (i : I) : mul_hom (f i) (Π i, f i) :=
 { to_fun := single i,
-  map_mul' := λ x y, funext $ λ j, begin
-    refine (apply_single₂ _ (λ _, _) i x y j).symm,
-    exact zero_mul 0,
-  end, }
+  map_mul' := single_binop (λ _, (*)) (λ _, zero_mul _) _, }
 
 variables {f}
-
-@[simp]
-lemma pi.single_zero [Π i, has_zero $ f i] (i : I) :
-  single i (0 : f i) = 0 :=
-(zero_hom.single f i).map_zero
 
 lemma pi.single_add [Π i, add_monoid $ f i] (i : I) (x y : f i) :
   single i (x + y) = single i x + single i y :=
@@ -177,7 +166,7 @@ lemma pi.single_sub [Π i, add_group $ f i] (i : I) (x y : f i) :
   single i (x - y) = single i x - single i y :=
 (add_monoid_hom.single f i).map_sub x y
 
-lemma pi.single_mul [Π i, monoid_with_zero $ f i] (i : I) (x y : f i) :
+lemma pi.single_mul [Π i, mul_zero_class $ f i] (i : I) (x y : f i) :
   single i (x * y) = single i x * single i y :=
 (mul_hom.single f i).map_mul x y
 

--- a/src/algebra/group/pi.lean
+++ b/src/algebra/group/pi.lean
@@ -144,8 +144,8 @@ This is the `add_monoid_hom` version of `pi.single`. -/
   map_add' := single_op₂ (λ _, (+)) (λ _, zero_add _) _,
   .. (zero_hom.single f i) }
 
-/-- The multiplicative homomorphism including a single `monoid_with_zero`
-into a dependent family of monoid_with_zeros, as functions supported at a point.
+/-- The multiplicative homomorphism including a single `mul_zero_class`
+into a dependent family of `mul_zero_class`es, as functions supported at a point.
 
 This is the `mul_hom` version of `pi.single`. -/
 @[simps] def mul_hom.single [Π i, mul_zero_class $ f i] (i : I) : mul_hom (f i) (Π i, f i) :=

--- a/src/algebra/group/pi.lean
+++ b/src/algebra/group/pi.lean
@@ -141,7 +141,7 @@ into a dependent family of additive monoids, as functions supported at a point.
 This is the `add_monoid_hom` version of `pi.single`. -/
 @[simps] def add_monoid_hom.single [Π i, add_monoid $ f i] (i : I) : f i →+ Π i, f i :=
 { to_fun := single i,
-  map_add' := single_binop (λ _, (+)) (λ _, zero_add _) _,
+  map_add' := single_op₂ (λ _, (+)) (λ _, zero_add _) _,
   .. (zero_hom.single f i) }
 
 /-- The multiplicative homomorphism including a single `monoid_with_zero`
@@ -150,7 +150,7 @@ into a dependent family of monoid_with_zeros, as functions supported at a point.
 This is the `mul_hom` version of `pi.single`. -/
 @[simps] def mul_hom.single [Π i, mul_zero_class $ f i] (i : I) : mul_hom (f i) (Π i, f i) :=
 { to_fun := single i,
-  map_mul' := single_binop (λ _, (*)) (λ _, zero_mul _) _, }
+  map_mul' := single_op₂ (λ _, (*)) (λ _, zero_mul _) _, }
 
 variables {f}
 

--- a/src/algebra/module/pi.lean
+++ b/src/algebra/module/pi.lean
@@ -91,11 +91,7 @@ instance distrib_mul_action' {g : I → Type*} {m : Π i, monoid (f i)} {n : Π 
 lemma single_smul {α} [monoid α] [Π i, add_monoid $ f i]
   [Π i, distrib_mul_action α $ f i] [decidable_eq I] (i : I) (r : α) (x : f i) :
   single i (r • x) = r • single i x :=
-begin
-  ext j,
-  refine (apply_single _ (λ _, _) i x j).symm,
-  exact smul_zero _,
-end
+by { refine single_op (λ _, (•) c) (λ j, _) _ _, apply smul_zero }
 
 lemma single_smul' {g : I → Type*} [Π i, monoid_with_zero (f i)] [Π i, add_monoid (g i)]
   [Π i, distrib_mul_action (f i) (g i)] [decidable_eq I] (i : I) (r : f i) (x : g i) :

--- a/src/algebra/module/pi.lean
+++ b/src/algebra/module/pi.lean
@@ -91,16 +91,12 @@ instance distrib_mul_action' {g : I → Type*} {m : Π i, monoid (f i)} {n : Π 
 lemma single_smul {α} [monoid α] [Π i, add_monoid $ f i]
   [Π i, distrib_mul_action α $ f i] [decidable_eq I] (i : I) (r : α) (x : f i) :
   single i (r • x) = r • single i x :=
-by { refine single_op (λ _, (•) c) (λ j, _) _ _, apply smul_zero }
+single_op (λ i : I, ((•) r : f i → f i)) (λ j, smul_zero _) _ _
 
 lemma single_smul' {g : I → Type*} [Π i, monoid_with_zero (f i)] [Π i, add_monoid (g i)]
   [Π i, distrib_mul_action (f i) (g i)] [decidable_eq I] (i : I) (r : f i) (x : g i) :
   single i (r • x) = single i r • single i x :=
-begin
-  ext j,
-  refine (apply_single₂ _ (λ _, _) i r x j).symm,
-  exact smul_zero _,
-end
+single_binop (λ i : I, ((•) : f i → g i → g i)) (λ j, smul_zero _) _ _ _
 
 variables (I f)
 

--- a/src/algebra/module/pi.lean
+++ b/src/algebra/module/pi.lean
@@ -96,7 +96,7 @@ single_op (λ i : I, ((•) r : f i → f i)) (λ j, smul_zero _) _ _
 lemma single_smul' {g : I → Type*} [Π i, monoid_with_zero (f i)] [Π i, add_monoid (g i)]
   [Π i, distrib_mul_action (f i) (g i)] [decidable_eq I] (i : I) (r : f i) (x : g i) :
   single i (r • x) = single i r • single i x :=
-single_binop (λ i : I, ((•) : f i → g i → g i)) (λ j, smul_zero _) _ _ _
+single_op₂ (λ i : I, ((•) : f i → g i → g i)) (λ j, smul_zero _) _ _ _
 
 variables (I f)
 

--- a/src/data/pi.lean
+++ b/src/data/pi.lean
@@ -78,8 +78,8 @@ lemma apply_single₂ (f' : Π i, f i → g i → h i) (hf' : ∀ i, f' i 0 0 = 
   f' j (single i x j) (single i y j) = single i (f' i x y) j :=
 begin
   by_cases h : j = i,
-  { subst h, simp only [single_eq_same], },
-  { simp only [h, single_eq_of_ne, ne.def, not_false_iff, hf'], },
+  { subst h, simp only [single_eq_same] },
+  { simp only [single_eq_of_ne h, hf'] },
 end
 
 lemma single_op {g : I → Type*} [Π i, has_zero (g i)] (op : Π i, f i → g i) (h : ∀ i, op i 0 = 0)
@@ -87,7 +87,7 @@ lemma single_op {g : I → Type*} [Π i, has_zero (g i)] (op : Π i, f i → g i
   single i (op i x) = λ j, op j (single i x j) :=
 eq.symm $ funext $ apply_single op h i x
 
-lemma single_binop {g₁ g₂ : I → Type*} [Π i, has_zero (g₁ i)] [Π i, has_zero (g₂ i)]
+lemma single_op₂ {g₁ g₂ : I → Type*} [Π i, has_zero (g₁ i)] [Π i, has_zero (g₂ i)]
   (op : Π i, g₁ i → g₂ i → f i) (h : ∀ i, op i 0 0 = 0) (i : I) (x₁ : g₁ i) (x₂ : g₂ i) :
   single i (op i x₁ x₂) = λ j, op j (single i x₁ j) (single i x₂ j) :=
 eq.symm $ funext $ apply_single₂ op h i x₁ x₂

--- a/src/data/pi.lean
+++ b/src/data/pi.lean
@@ -38,6 +38,8 @@ instance has_mul [∀ i, has_mul $ f i] :
 ⟨λ f g i, f i * g i⟩
 @[simp, to_additive] lemma mul_apply [∀ i, has_mul $ f i] : (x * y) i = x i * y i := rfl
 
+@[to_additive] lemma mul_def [Π i, has_mul $ f i] : x * y = λ i, x i * y i := rfl
+
 @[to_additive] instance has_inv [∀ i, has_inv $ f i] :
   has_inv (Π i : I, f i) :=
   ⟨λ f i, (f i)⁻¹⟩
@@ -58,13 +60,14 @@ variables [Π i, has_zero (f i)] [Π i, has_zero (g i)] [Π i, has_zero (h i)]
 def single (i : I) (x : f i) : Π i, f i :=
 function.update 0 i x
 
-@[simp]
-lemma single_eq_same (i : I) (x : f i) : single i x i = x :=
+@[simp] lemma single_eq_same (i : I) (x : f i) : single i x i = x :=
 function.update_same i x _
 
-@[simp]
-lemma single_eq_of_ne {i i' : I} (h : i' ≠ i) (x : f i) : single i x i' = 0 :=
+@[simp] lemma single_eq_of_ne {i i' : I} (h : i' ≠ i) (x : f i) : single i x i' = 0 :=
 function.update_noteq h x _
+
+@[simp] lemma single_zero (i : I) : single i (0 : f i) = 0 :=
+function.update_eq_self _ _
 
 lemma apply_single (f' : Π i, f i → g i) (hf' : ∀ i, f' i 0 = 0) (i : I) (x : f i) (j : I):
   f' j (single i x j) = single i (f' i x) j :=
@@ -78,6 +81,16 @@ begin
   { subst h, simp only [single_eq_same], },
   { simp only [h, single_eq_of_ne, ne.def, not_false_iff, hf'], },
 end
+
+lemma single_op {g : I → Type*} [Π i, has_zero (g i)] (op : Π i, f i → g i) (h : ∀ i, op i 0 = 0)
+  (i : I) (x : f i) :
+  single i (op i x) = λ j, op j (single i x j) :=
+eq.symm $ funext $ apply_single op h i x
+
+lemma single_binop {g₁ g₂ : I → Type*} [Π i, has_zero (g₁ i)] [Π i, has_zero (g₂ i)]
+  (op : Π i, g₁ i → g₂ i → f i) (h : ∀ i, op i 0 0 = 0) (i : I) (x₁ : g₁ i) (x₂ : g₂ i) :
+  single i (op i x₁ x₂) = λ j, op j (single i x₁ j) (single i x₂ j) :=
+by simp only [single, ← function.update_binop op, pi.zero_def, h]
 
 variables (f)
 

--- a/src/data/pi.lean
+++ b/src/data/pi.lean
@@ -90,7 +90,7 @@ eq.symm $ funext $ apply_single op h i x
 lemma single_binop {g₁ g₂ : I → Type*} [Π i, has_zero (g₁ i)] [Π i, has_zero (g₂ i)]
   (op : Π i, g₁ i → g₂ i → f i) (h : ∀ i, op i 0 0 = 0) (i : I) (x₁ : g₁ i) (x₂ : g₂ i) :
   single i (op i x₁ x₂) = λ j, op j (single i x₁ j) (single i x₂ j) :=
-by simp only [single, ← function.update_binop op, pi.zero_def, h]
+eq.symm $ funext $ apply_single₂ op h i x₁ x₂
 
 variables (f)
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -432,6 +432,13 @@ lemma comp_update {α' : Sort*} {β : Sort*} (f : α' → β) (g : α → α') (
   f ∘ (update g i v) = update (f ∘ g) i (f v) :=
 funext $ apply_update _ _ _ _
 
+lemma update_binop {ι : Sort*} [decidable_eq ι] {α β γ : ι → Sort*}
+  (f : Π i, α i → β i → γ i) (ga : Π i, α i) (gb : Π i, β i) (i : ι)
+  (va : α i) (vb : β i) :
+  update (λ k, f k (ga k) (gb k)) i (f i va vb) =
+    λ j, f j (update ga i va j) (update gb i vb j) :=
+update_eq_iff.2 ⟨by simp, λ j hj, by simp [hj]⟩
+
 theorem update_comm {α} [decidable_eq α] {β : α → Sort*}
   {a b : α} (h : a ≠ b) (v : β a) (w : β b) (f : Πa, β a) :
   update (update f a v) b w = update (update f b w) a v :=

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -432,13 +432,6 @@ lemma comp_update {α' : Sort*} {β : Sort*} (f : α' → β) (g : α → α') (
   f ∘ (update g i v) = update (f ∘ g) i (f v) :=
 funext $ apply_update _ _ _ _
 
-lemma update_binop {ι : Sort*} [decidable_eq ι] {α β γ : ι → Sort*}
-  (f : Π i, α i → β i → γ i) (ga : Π i, α i) (gb : Π i, β i) (i : ι)
-  (va : α i) (vb : β i) :
-  update (λ k, f k (ga k) (gb k)) i (f i va vb) =
-    λ j, f j (update ga i va j) (update gb i vb j) :=
-update_eq_iff.2 ⟨by simp, λ j hj, by simp [hj]⟩
-
 theorem update_comm {α} [decidable_eq α] {β : α → Sort*}
   {a b : α} (h : a ≠ b) (v : β a) (w : β b) (f : Πa, β a) :
   update (update f a v) b w = update (update f b w) a v :=


### PR DESCRIPTION
Add `pi.single_op` and `pi.single_binop` and use them in the proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
