### PR TITLE
[Merged by Bors] - feat(group_theory/order_of_element): order_of is the same in a submonoid

### DIFF
--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -221,11 +221,11 @@ lemma order_of_injective {G H : Type*} [monoid G] [monoid H] {f : G →* H}
   (hf : function.injective f) (σ : G) : order_of (f σ) = order_of σ :=
 by simp_rw [order_of_eq_order_of_iff, ←f.map_pow, ←f.map_one, hf.eq_iff, iff_self, forall_const]
 
-@[simp] lemma order_of_submonoid {G : Type*} [monoid G] {H : submonoid G} (σ : H) :
+@[simp, norm_cast] lemma order_of_submonoid {G : Type*} [monoid G] {H : submonoid G} (σ : H) :
   order_of (σ : G) = order_of σ :=
 order_of_injective (show function.injective H.subtype, from subtype.coe_injective) σ
 
-@[simp] lemma order_of_subgroup {G : Type*} [group G] {H : subgroup G} (σ : H) :
+@[simp, norm_cast] lemma order_of_subgroup {G : Type*} [group G] {H : subgroup G} (σ : H) :
   order_of (σ : G) = order_of σ :=
 order_of_injective (show function.injective H.subtype, from subtype.coe_injective) σ
 

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -217,17 +217,17 @@ begin
   exact ⟨λ h n, by rw h, λ h, nat.dvd_antisymm ((h _).mpr (dvd_refl _)) ((h _).mp (dvd_refl _))⟩,
 end
 
-lemma order_of_injective {G H : Type*} [monoid G] [monoid H] {f : G →* H}
+lemma order_of_injective {G H : Type*} [monoid G] [monoid H] (f : G →* H)
   (hf : function.injective f) (σ : G) : order_of (f σ) = order_of σ :=
 by simp_rw [order_of_eq_order_of_iff, ←f.map_pow, ←f.map_one, hf.eq_iff, iff_self, forall_const]
 
 @[simp] lemma order_of_submonoid {G : Type*} [monoid G] {H : submonoid G} (σ : H) :
   order_of (σ : G) = order_of σ :=
-order_of_injective (show function.injective H.subtype, from subtype.coe_injective) σ
+order_of_injective H.subtype subtype.coe_injective σ
 
 @[simp] lemma order_of_subgroup {G : Type*} [group G] {H : subgroup G} (σ : H) :
   order_of (σ : G) = order_of σ :=
-order_of_injective (show function.injective H.subtype, from subtype.coe_injective) σ
+order_of_injective H.subtype subtype.coe_injective σ
 
 open nat
 

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -217,14 +217,17 @@ begin
   exact ⟨λ h n, by rw h, λ h, nat.dvd_antisymm ((h _).mpr (dvd_refl _)) ((h _).mp (dvd_refl _))⟩,
 end
 
+lemma order_of_injective {G H : Type*} [monoid G] [monoid H] {f : G →* H}
+  (hf : function.injective f) (σ : G) : order_of (f σ) = order_of σ :=
+by simp_rw [order_of_eq_order_of_iff, ←f.map_pow, ←f.map_one, hf.eq_iff, iff_self, forall_const]
+
 @[simp] lemma order_of_submonoid {G : Type*} [monoid G] {H : submonoid G} (σ : H) :
   order_of (σ : G) = order_of σ :=
-by simp_rw [order_of_eq_order_of_iff, ←submonoid.coe_pow, ←submonoid.coe_one H,
-  submonoid.coe_eq_coe, iff_self, forall_const]
+order_of_injective (show function.injective H.subtype, from subtype.coe_injective) σ
 
 @[simp] lemma order_of_subgroup {G : Type*} [group G] {H : subgroup G} (σ : H) :
   order_of (σ : G) = order_of σ :=
-@order_of_submonoid G _ H.to_submonoid σ
+order_of_injective (show function.injective H.subtype, from subtype.coe_injective) σ
 
 open nat
 

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -213,20 +213,8 @@ lemma order_of_eq_prime {p : ℕ} [hp : fact p.prime]
 lemma order_of_eq_order_of_iff {β : Type*} [monoid β] {b : β} :
   order_of a = order_of b ↔ ∀ n : ℕ, a ^ n = 1 ↔ b ^ n = 1 :=
 begin
-  split,
-  { exact λ h n, by rw [←order_of_dvd_iff_pow_eq_one, ←order_of_dvd_iff_pow_eq_one, h] },
-  { intro h,
-    by_cases h' : ∃ n, 0 < n ∧ b ^ n = 1,
-    { rw [order_of, order_of, dif_pos, dif_pos],
-      { congr,
-        simp_rw h },
-      { exact h' },
-      { simp_rw h,
-        exact h' } },
-    { rw [order_of, order_of, dif_neg, dif_neg],
-      { exact h' },
-      { simp_rw h,
-        exact h' } } }
+  simp_rw ← order_of_dvd_iff_pow_eq_one,
+  exact ⟨λ h n, by rw h, λ h, nat.dvd_antisymm ((h _).mpr (dvd_refl _)) ((h _).mp (dvd_refl _))⟩,
 end
 
 @[simp] lemma order_of_submonoid {G : Type*} [monoid G] {H : submonoid G} (σ : H) :

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -181,6 +181,27 @@ end
 @[simp] lemma order_of_eq_one_iff : order_of a = 1 ↔ a = 1 :=
 ⟨λ h, by conv_lhs { rw [← pow_one a, ← h, pow_order_of_eq_one] }, λ h, by simp [h]⟩
 
+@[simp] lemma order_of_submonoid {G : Type*} [monoid G] {H : submonoid G} (σ : H) :
+  order_of (σ : G) = order_of σ :=
+begin
+  have key : (λ n, 0 < n ∧ (σ : G) ^ n = 1) = (λ n, 0 < n ∧ σ ^ n = 1),
+  { ext n,
+    rw [←submonoid.coe_pow, ←submonoid.coe_one H, submonoid.coe_eq_coe] },
+  by_cases h : ∃ n, 0 < n ∧ σ ^ n = 1,
+  { rw [order_of, order_of, dif_pos, dif_pos],
+    { congr,
+      exact key },
+    { exact h },
+    { rwa key } },
+  { rw [order_of, order_of, dif_neg, dif_neg],
+    { exact h },
+    { rwa key } },
+end
+
+@[simp] lemma order_of_subgroup {G : Type*} [group G] {H : subgroup G} (σ : H) :
+  order_of (σ : G) = order_of σ :=
+@order_of_submonoid G _ H.to_submonoid σ
+
 lemma pow_eq_mod_order_of {n : ℕ} : a ^ n = a ^ (n % order_of a) :=
 calc a ^ n = a ^ (n % order_of a + order_of a * (n / order_of a)) : by rw [nat.mod_add_div]
        ... = a ^ (n % order_of a) : by simp [pow_add, pow_mul, pow_order_of_eq_one]

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -181,27 +181,6 @@ end
 @[simp] lemma order_of_eq_one_iff : order_of a = 1 ↔ a = 1 :=
 ⟨λ h, by conv_lhs { rw [← pow_one a, ← h, pow_order_of_eq_one] }, λ h, by simp [h]⟩
 
-@[simp] lemma order_of_submonoid {G : Type*} [monoid G] {H : submonoid G} (σ : H) :
-  order_of (σ : G) = order_of σ :=
-begin
-  have key : (λ n, 0 < n ∧ (σ : G) ^ n = 1) = (λ n, 0 < n ∧ σ ^ n = 1),
-  { ext n,
-    rw [←submonoid.coe_pow, ←submonoid.coe_one H, submonoid.coe_eq_coe] },
-  by_cases h : ∃ n, 0 < n ∧ σ ^ n = 1,
-  { rw [order_of, order_of, dif_pos, dif_pos],
-    { congr,
-      exact key },
-    { exact h },
-    { rwa key } },
-  { rw [order_of, order_of, dif_neg, dif_neg],
-    { exact h },
-    { rwa key } },
-end
-
-@[simp] lemma order_of_subgroup {G : Type*} [group G] {H : subgroup G} (σ : H) :
-  order_of (σ : G) = order_of σ :=
-@order_of_submonoid G _ H.to_submonoid σ
-
 lemma pow_eq_mod_order_of {n : ℕ} : a ^ n = a ^ (n % order_of a) :=
 calc a ^ n = a ^ (n % order_of a + order_of a * (n / order_of a)) : by rw [nat.mod_add_div]
        ... = a ^ (n % order_of a) : by simp [pow_add, pow_mul, pow_order_of_eq_one]
@@ -230,6 +209,34 @@ lemma order_of_dvd_iff_pow_eq_one {n : ℕ} : order_of a ∣ n ↔ a ^ n = 1 :=
 lemma order_of_eq_prime {p : ℕ} [hp : fact p.prime]
   (hg : a^p = 1) (hg1 : a ≠ 1) : order_of a = p :=
 (hp.out.2 _ (order_of_dvd_of_pow_eq_one hg)).resolve_left (mt order_of_eq_one_iff.1 hg1)
+
+lemma order_of_eq_order_of_iff {β : Type*} [monoid β] {b : β} :
+  order_of a = order_of b ↔ ∀ n : ℕ, a ^ n = 1 ↔ b ^ n = 1 :=
+begin
+  split,
+  { exact λ h n, by rw [←order_of_dvd_iff_pow_eq_one, ←order_of_dvd_iff_pow_eq_one, h] },
+  { intro h,
+    by_cases h' : ∃ n, 0 < n ∧ b ^ n = 1,
+    { rw [order_of, order_of, dif_pos, dif_pos],
+      { congr,
+        simp_rw h },
+      { exact h' },
+      { simp_rw h,
+        exact h' } },
+    { rw [order_of, order_of, dif_neg, dif_neg],
+      { exact h' },
+      { simp_rw h,
+        exact h' } } }
+end
+
+@[simp] lemma order_of_submonoid {G : Type*} [monoid G] {H : submonoid G} (σ : H) :
+  order_of (σ : G) = order_of σ :=
+by simp_rw [order_of_eq_order_of_iff, ←submonoid.coe_pow, ←submonoid.coe_one H,
+  submonoid.coe_eq_coe, iff_self, forall_const]
+
+@[simp] lemma order_of_subgroup {G : Type*} [group G] {H : subgroup G} (σ : H) :
+  order_of (σ : G) = order_of σ :=
+@order_of_submonoid G _ H.to_submonoid σ
 
 open nat
 


### PR DESCRIPTION
The first lemma shows that `order_of` is the same in a submonoid, but it seems like you also need a lemma for subgroups.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
