### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/inner_product): isometry of ℂ with Euclidean space

### DIFF
--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1814,6 +1814,7 @@ begin
   { rw [← h.equiv_fun.symm_apply_apply y, h.equiv_fun_symm_apply] }
 end
 
+/-- `ℂ` is isometric to ℝ² with the Euclidean inner product. -/
 def complex.isometry_euclidean : ℂ ≃ₗᵢ[ℝ] (euclidean_space ℝ (fin 2)) :=
 complex.is_basis_one_I.isometry_euclidean_of_orthonormal
 begin

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1828,8 +1828,7 @@ end
   complex.isometry_euclidean.symm x = (x 0) + (x 1) * I :=
 begin
   convert complex.is_basis_one_I.equiv_fun_symm_apply x,
-  { simp only [fin.mk_zero, mul_one, complex.smul_coe, fin.mk_eq_subtype_mk, matrix.cons_val_zero],
-    refl },
+  { simpa },
   { simp },
 end
 

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1824,6 +1824,28 @@ begin
   simp [real_inner_eq_re_inner]
 end
 
+@[simp] lemma complex.isometry_euclidean_symm_apply (x : euclidean_space ℝ (fin 2)) :
+  complex.isometry_euclidean.symm x = (x 0) + (x 1) * I :=
+begin
+  convert complex.is_basis_one_I.equiv_fun_symm_apply x,
+  { simp only [fin.mk_zero, mul_one, complex.smul_coe, fin.mk_eq_subtype_mk, matrix.cons_val_zero],
+    refl },
+  { simp },
+end
+
+lemma complex.isometry_euclidean_proj_eq_self (z : ℂ) :
+  ↑(complex.isometry_euclidean z 0) + ↑(complex.isometry_euclidean z 1) * (I : ℂ) = z :=
+by rw [← complex.isometry_euclidean_symm_apply (complex.isometry_euclidean z),
+  complex.isometry_euclidean.symm_apply_apply z]
+
+@[simp] lemma complex.isometry_euclidean_apply_zero (z : ℂ) :
+  complex.isometry_euclidean z 0 = z.re :=
+by { conv_rhs { rw ← complex.isometry_euclidean_proj_eq_self z }, simp }
+
+@[simp] lemma complex.isometry_euclidean_apply_one (z : ℂ) :
+  complex.isometry_euclidean z 1 = z.im :=
+by { conv_rhs { rw ← complex.isometry_euclidean_proj_eq_self z }, simp }
+
 end pi_Lp
 
 

--- a/src/analysis/normed_space/inner_product.lean
+++ b/src/analysis/normed_space/inner_product.lean
@@ -1814,6 +1814,15 @@ begin
   { rw [← h.equiv_fun.symm_apply_apply y, h.equiv_fun_symm_apply] }
 end
 
+def complex.isometry_euclidean : ℂ ≃ₗᵢ[ℝ] (euclidean_space ℝ (fin 2)) :=
+complex.is_basis_one_I.isometry_euclidean_of_orthonormal
+begin
+  rw orthonormal_iff_ite,
+  intros i, fin_cases i;
+  intros j; fin_cases j;
+  simp [real_inner_eq_re_inner]
+end
+
 end pi_Lp
 
 


### PR DESCRIPTION
`ℂ` is isometric to `fin 2 → ℝ` with the Euclidean inner product.  The isometry given here is that defined by the ordered basis {1, i} for `ℂ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/.60inner_product_space.20.E2.84.9D.20%28euclidean_space.20.F0.9D.95.9C.20n%29.60.3F/near/230766844