### PR TITLE
[Merged by Bors] - feat(algebra/module/hom): Add missing smul instances on add_monoid_hom

### DIFF
--- a/src/algebra/module/hom.lean
+++ b/src/algebra/module/hom.lean
@@ -10,7 +10,7 @@ import algebra.module.pi
 
 This file defines instances for module, mul_action and related structures on bundled `_hom` types.
 
-These are analagous to the instances in `algebra.module.pi`, but for bundled instead of unbundled
+These are analogous to the instances in `algebra.module.pi`, but for bundled instead of unbundled
 functions.
 -/
 

--- a/src/algebra/module/hom.lean
+++ b/src/algebra/module/hom.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2021 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import algebra.module.pi
+
+/-!
+# Bundled hom instances for module and multiplicative actions
+
+This file defines instances for module, mul_action and related structures on bundled `_hom` types.
+
+These are analagous to the instances in `algebra.module.pi`, but for bundled instead of unbundled
+functions.
+-/
+
+variables {R S A B : Type*}
+
+namespace add_monoid_hom
+
+section
+variables [monoid R] [monoid S] [add_monoid A] [add_comm_monoid B]
+variables [distrib_mul_action R B] [distrib_mul_action S B]
+
+instance distrib_mul_action : distrib_mul_action R (A →+ B) :=
+{ smul := λ r f,
+  { to_fun := r • f,
+    map_zero' := by simp,
+    map_add' := λ x y, by simp [smul_add] },
+  one_smul := λ f, by simp,
+  mul_smul := λ r s f, by simp [mul_smul],
+  smul_add := λ r f g, ext $ λ x, by simp [smul_add],
+  smul_zero := λ r, ext $ λ x, by simp [smul_zero] }
+
+@[simp] lemma coe_smul (r : R) (f : A →+ B) : ⇑(r • f) = r • f := rfl
+lemma smul_apply (r : R) (f : A →+ B) (x : A) : (r • f) x = r • f x := rfl
+
+instance [smul_comm_class R S B] : smul_comm_class R S (A →+ B) :=
+⟨λ a b f, ext $ λ x, smul_comm _ _ _⟩
+
+instance [has_scalar R S] [is_scalar_tower R S B] : is_scalar_tower R S (A →+ B) :=
+⟨λ a b f, ext $ λ x, smul_assoc _ _ _⟩
+
+end
+
+instance [semiring R] [add_monoid A] [add_comm_monoid B] [semimodule R B] :
+  semimodule R (A →+ B) :=
+{ add_smul := λ r s x, ext $ λ y, by simp [add_smul],
+  zero_smul := λ x, ext $ λ y, by simp [zero_smul],
+  ..add_monoid_hom.distrib_mul_action }
+
+end add_monoid_hom

--- a/src/algebra/module/hom.lean
+++ b/src/algebra/module/hom.lean
@@ -22,7 +22,7 @@ section
 variables [monoid R] [monoid S] [add_monoid A] [add_comm_monoid B]
 variables [distrib_mul_action R B] [distrib_mul_action S B]
 
-instance distrib_mul_action : distrib_mul_action R (A →+ B) :=
+instance : distrib_mul_action R (A →+ B) :=
 { smul := λ r f,
   { to_fun := r • f,
     map_zero' := by simp,

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov
 -/
 import algebra.big_operators.pi
 import algebra.module.pi
+import algebra.module.hom
 import algebra.module.prod
 import algebra.module.submodule
 import algebra.module.submodule_lattice

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov
 -/
 import algebra.big_operators.pi
-import algebra.module.pi
 import algebra.module.hom
+import algebra.module.pi
 import algebra.module.prod
 import algebra.module.submodule
 import algebra.module.submodule_lattice


### PR DESCRIPTION
These are defeq to the smul instances on `linear_map`, in `linear_algebra/basic.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
