### PR TITLE
[Merged by Bors] - refactor(representation_theory/maschke): replaces `¬(ring_char k ∣ fintype.card G)` with `invertible (fintype.card G : k)` instance

### DIFF
--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -110,6 +110,9 @@ theorem eq_iff {p : ℕ} : ring_char R = p ↔ char_p R p :=
 theorem dvd {x : ℕ} (hx : (x : R) = 0) : ring_char R ∣ x :=
 (spec R x).1 hx
 
+@[simp]
+lemma eq_zero [char_zero R] : ring_char R = 0 := (eq R (char_p.of_char_zero R)).symm
+
 end ring_char
 
 theorem add_pow_char_of_commute (R : Type u) [semiring R] {p : ℕ} [hp : fact p.prime]

--- a/src/algebra/char_p/invertible.lean
+++ b/src/algebra/char_p/invertible.lean
@@ -27,6 +27,12 @@ def invertible_of_ring_char_not_dvd
   {t : ℕ} (not_dvd : ¬(ring_char K ∣ t)) : invertible (t : K) :=
 invertible_of_nonzero (λ h, not_dvd ((ring_char.spec K t).mp h))
 
+lemma ring_char_not_dvd_of_invertible {t : ℕ} [invertible (t : K)] :
+  ¬(ring_char K ∣ t) :=
+begin
+  rw [← ring_char.spec, ← ne.def],
+  exact nonzero_of_invertible (t : K)
+end
 
 /-- A natural number `t` is invertible in a field `K` of charactistic `p` if `p` does not divide
 `t`. -/

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -136,6 +136,15 @@ end
 end linear_map
 end
 
+namespace char_zero
+
+variables {k : Type u} [field k] {G : Type u} [fintype G] [group G] [char_zero k]
+
+instance : fact ¬(ring_char k ∣ fintype.card G) :=
+⟨by simp [fintype.card_eq_zero_iff]⟩
+
+end char_zero
+
 namespace monoid_algebra
 
 -- Now we work over a `[field k]`, and replace the assumption `[invertible (fintype.card G : k)]`
@@ -145,13 +154,14 @@ variables {V : Type u} [add_comm_group V] [module k V] [module (monoid_algebra k
 variables [is_scalar_tower k (monoid_algebra k G) V]
 variables {W : Type u} [add_comm_group W] [module k W] [module (monoid_algebra k G) W]
 variables [is_scalar_tower k (monoid_algebra k G) W]
+variables [fact ¬(ring_char k ∣ fintype.card G)]
+
+instance : invertible (fintype.card G : k) := invertible_of_ring_char_not_dvd (fact.out _)
 
 lemma exists_left_inverse_of_injective
-  (not_dvd : ¬(ring_char k ∣ fintype.card G)) (f : V →ₗ[monoid_algebra k G] W) (hf : f.ker = ⊥) :
+  (f : V →ₗ[monoid_algebra k G] W) (hf : f.ker = ⊥) :
   ∃ (g : W →ₗ[monoid_algebra k G] V), g.comp f = linear_map.id :=
 begin
-  haveI : invertible (fintype.card G : k) :=
-    invertible_of_ring_char_not_dvd not_dvd,
   obtain ⟨φ, hφ⟩ := (f.restrict_scalars k).exists_left_inverse_of_injective
     (by simp only [hf, submodule.restrict_scalars_bot, linear_map.ker_restrict_scalars]),
   refine ⟨φ.equivariant_projection G, _⟩,
@@ -165,19 +175,17 @@ end
 
 namespace submodule
 
+variable [fact ¬(ring_char k ∣ fintype.card G)]
+
 lemma exists_is_compl
-  (not_dvd : ¬(ring_char k ∣ fintype.card G)) (p : submodule (monoid_algebra k G) V) :
+  (p : submodule (monoid_algebra k G) V) :
   ∃ q : submodule (monoid_algebra k G) V, is_compl p q :=
-let ⟨f, hf⟩ := monoid_algebra.exists_left_inverse_of_injective not_dvd p.subtype p.ker_subtype in
+let ⟨f, hf⟩ := monoid_algebra.exists_left_inverse_of_injective p.subtype p.ker_subtype in
 ⟨f.ker, linear_map.is_compl_of_proj $ linear_map.ext_iff.1 hf⟩
 
-theorem is_complemented (not_dvd : ¬(ring_char k ∣ fintype.card G)) :
-  is_complemented (submodule (monoid_algebra k G) V) := ⟨exists_is_compl not_dvd⟩
+/-- This also implies an instance `is_semisimple_module (monoid_algebra k G) V`. -/
+instance is_complemented : is_complemented (submodule (monoid_algebra k G) V) :=
+⟨exists_is_compl⟩
 
 end submodule
-
-theorem is_semisimple_module (not_dvd : ¬(ring_char k ∣ fintype.card G)) :
-  is_semisimple_module (monoid_algebra k G) V :=
-submodule.is_complemented not_dvd
-
 end monoid_algebra

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -13,14 +13,19 @@ import ring_theory.simple_module
 
 We prove Maschke's theorem for finite groups,
 in the formulation that every submodule of a `k[G]` module has a complement,
-when `k` is a field with `invertible (fintype.card G : k)`, which can be derived from
-`¬(ring_char k ∣ fintype.card G)` using `invertible_of_ring_char_not_dvd`.
+when `k` is a field with `invertible (fintype.card G : k)`.
 
 We do the core computation in greater generality.
 For any `[comm_ring k]` in which  `[invertible (fintype.card G : k)]`,
 and a `k[G]`-linear map `i : V → W` which admits a `k`-linear retraction `π`,
 we produce a `k[G]`-linear retraction by
 taking the average over `G` of the conjugates of `π`.
+
+## Implementation Notes
+* These results assume `invertible (fintype.card G : k)` which is equivalent to the more
+familiar `¬(ring_char k ∣ fintype.card G)`. It is possible to convert between them using
+`invertible_of_ring_char_not_dvd` and `ring_char_not_dvd_of_invertible`.
+
 
 ## Future work
 It's not so far to give the usual statement, that every finite dimensional representation

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -148,15 +148,15 @@ end char_zero
 namespace monoid_algebra
 
 -- Now we work over a `[field k]`, and replace the assumption `[invertible (fintype.card G : k)]`
--- with `¬(ring_char k ∣ fintype.card G)`.
-variables {k : Type u} [field k] {G : Type u} [fintype G] [group G]
+-- with `[fact ¬(ring_char k ∣ fintype.card G)]`.
+variables {k : Type u} [field k] {G : Type u} [fintype G] [fact ¬(ring_char k ∣ fintype.card G)]
+instance : invertible (fintype.card G : k) := invertible_of_ring_char_not_dvd (fact.out _)
+
+variables [group G]
 variables {V : Type u} [add_comm_group V] [module k V] [module (monoid_algebra k G) V]
 variables [is_scalar_tower k (monoid_algebra k G) V]
 variables {W : Type u} [add_comm_group W] [module k W] [module (monoid_algebra k G) W]
 variables [is_scalar_tower k (monoid_algebra k G) W]
-variables [fact ¬(ring_char k ∣ fintype.card G)]
-
-instance : invertible (fintype.card G : k) := invertible_of_ring_char_not_dvd (fact.out _)
 
 lemma exists_left_inverse_of_injective
   (f : V →ₗ[monoid_algebra k G] W) (hf : f.ker = ⊥) :
@@ -174,8 +174,6 @@ begin
 end
 
 namespace submodule
-
-variable [fact ¬(ring_char k ∣ fintype.card G)]
 
 lemma exists_is_compl
   (p : submodule (monoid_algebra k G) V) :

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -13,7 +13,8 @@ import ring_theory.simple_module
 
 We prove Maschke's theorem for finite groups,
 in the formulation that every submodule of a `k[G]` module has a complement,
-when `k` is a field with `¬(ring_char k ∣ fintype.card G)`.
+when `k` is a field with `invertible (fintype.card G : k)`, which can be derived from
+`¬(ring_char k ∣ fintype.card G)` using `invertible_of_ring_char_not_dvd`.
 
 We do the core computation in greater generality.
 For any `[comm_ring k]` in which  `[invertible (fintype.card G : k)]`,
@@ -140,18 +141,15 @@ namespace char_zero
 
 variables {k : Type u} [field k] {G : Type u} [fintype G] [group G] [char_zero k]
 
-instance : fact ¬(ring_char k ∣ fintype.card G) :=
-⟨by simp [fintype.card_eq_zero_iff]⟩
+instance : invertible (fintype.card G : k) :=
+invertible_of_ring_char_not_dvd (by simp [fintype.card_eq_zero_iff])
 
 end char_zero
 
 namespace monoid_algebra
 
--- Now we work over a `[field k]`, and replace the assumption `[invertible (fintype.card G : k)]`
--- with `[fact ¬(ring_char k ∣ fintype.card G)]`.
-variables {k : Type u} [field k] {G : Type u} [fintype G] [fact ¬(ring_char k ∣ fintype.card G)]
-instance : invertible (fintype.card G : k) := invertible_of_ring_char_not_dvd (fact.out _)
-
+-- Now we work over a `[field k]`.
+variables {k : Type u} [field k] {G : Type u} [fintype G] [invertible (fintype.card G : k)]
 variables [group G]
 variables {V : Type u} [add_comm_group V] [module k V] [module (monoid_algebra k G) V]
 variables [is_scalar_tower k (monoid_algebra k G) V]


### PR DESCRIPTION
Refactors Maschke's theorem to take an instance of `invertible (fintype.card G : k)` instead of an explicit `not_dvd : ¬(ring_char k ∣ fintype.card G)`.
Provides that instance in the context `char_zero k`.
Allows `monoid_algebra.submodule.is_complemented` to be an instance.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
