### PR TITLE
[Merged by Bors] - refactor(geometry/manifold/algebra/smooth_functions): make `smooth_map_group` division defeq to `pi.has_div`

### DIFF
--- a/src/geometry/manifold/algebra/lie_group.lean
+++ b/src/geometry/manifold/algebra/lie_group.lean
@@ -117,6 +117,16 @@ lemma smooth_on.inv {f : M → G} {s : set M}
   (hf : smooth_on I' I f s) : smooth_on I' I (λx, (f x)⁻¹) s :=
 (smooth_inv I).comp_smooth_on hf
 
+@[to_additive]
+lemma smooth.div {f g : M → G}
+  (hf : smooth I' I f) (hg : smooth I' I g) : smooth I' I (f / g) :=
+by { rw div_eq_mul_inv, exact ((smooth_mul I).comp (hf.prod_mk hg.inv) : _), }
+
+@[to_additive]
+lemma smooth_on.div {f g : M → G} {s : set M}
+  (hf : smooth_on I' I f s) (hg : smooth_on I' I g s) : smooth_on I' I (f / g) s :=
+by { rw div_eq_mul_inv, exact ((smooth_mul I).comp_smooth_on (hf.prod_mk hg.inv) : _), }
+
 end lie_group
 
 section prod_lie_group

--- a/src/geometry/manifold/algebra/smooth_functions.lean
+++ b/src/geometry/manifold/algebra/smooth_functions.lean
@@ -87,6 +87,8 @@ instance smooth_map_group {G : Type*} [group G] [topological_space G]
   group C^∞⟮I, N; I', G⟯ :=
 { inv := λ f, ⟨λ x, (f x)⁻¹, f.smooth.inv⟩,
   mul_left_inv := λ a, by ext; exact mul_left_inv _,
+  div := λ f g, ⟨f / g, f.smooth.div g.smooth⟩,
+  div_eq_mul_inv := λ f g, by ext; exact div_eq_mul_inv _ _,
   .. smooth_map_monoid }
 
 @[simp, to_additive]
@@ -98,7 +100,7 @@ lemma smooth_map.coe_inv {G : Type*} [group G] [topological_space G]
 lemma smooth_map.coe_div {G : Type*} [group G] [topological_space G]
   [charted_space H' G] [lie_group I' G] (f g : C^∞⟮I, N; I', G⟯) :
   ⇑(f / g) = f / g :=
-by simp only [div_eq_mul_inv, smooth_map.coe_inv, smooth_map.coe_mul]
+rfl
 
 @[to_additive]
 instance smooth_map_comm_group {G : Type*} [comm_group G] [topological_space G]


### PR DESCRIPTION
The motivation was the fact that this allows `smooth_map.coe_div` to be `rfl` but this should be more generally useful.

---

cf https://github.com/leanprover-community/mathlib/pull/6893#pullrequestreview-622472497

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
