### PR TITLE
[Merged by Bors] - feat(group_theory/perm/sign): the alternating group

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -100,7 +100,7 @@ Group Theory:
     decomposition into transpositions: ''
     decomposition into cycles with disjoint support: 'equiv.perm.cycle_factors'
     signature: 'equiv.perm.sign'
-    alternating group: ''
+    alternating group: 'alternating_subgroup'
   Classical automorphism groups:
     general linear group: 'linear_map.general_linear_group'
     special linear group: 'matrix.special_linear_group'

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -8,6 +8,7 @@ import data.finset.sort
 import group_theory.perm.basic
 import group_theory.order_of_element
 import tactic.norm_swap
+import group_theory.quotient_group
 
 /-!
 # Sign of a permutation
@@ -529,6 +530,10 @@ permutations, `-1` for odd permutations. It is the unique surjective group homom
 def sign [fintype α] : perm α →* units ℤ := monoid_hom.mk'
 (λ f, sign_aux3 f mem_univ) (λ f g, (sign_aux3_mul_and_swap f g _ mem_univ).1)
 
+
+def alternating_subgroup (α) [fintype α] [decidable_eq α] : subgroup (perm α) :=
+sign.ker
+
 section sign
 
 variable [fintype α]
@@ -590,12 +595,61 @@ have h₁ : l.map sign = list.repeat (-1) l.length :=
   hg.2 ▸ (hl _ hg.1).sign_eq⟩,
 by rw [← list.prod_repeat, ← h₁, list.prod_hom _ (@sign α _ _)]
 
-lemma sign_surjective (hα : 1 < fintype.card α) : function.surjective (sign : perm α → units ℤ) :=
+variable (α)
+
+lemma sign_surjective [nontrivial α] : function.surjective (sign : perm α → units ℤ) :=
 λ a, (int.units_eq_one_or a).elim
   (λ h, ⟨1, by simp [h]⟩)
-  (λ h, let ⟨x⟩ := fintype.card_pos_iff.1 (lt_trans zero_lt_one hα) in
-    let ⟨y, hxy⟩ := fintype.exists_ne_of_one_lt_card hα x in
-    ⟨swap y x, by rw [sign_swap hxy, h]⟩ )
+  (λ h, let ⟨x, y, hxy⟩ := exists_pair_ne α in
+    ⟨swap x y, by rw [sign_swap hxy, h]⟩ )
+
+variable {α}
+
+section alternating_subgroup
+variable [decidable_eq α]
+
+lemma alternating_subgroup_eq_sign_ker : alternating_subgroup α = sign.ker := rfl
+
+@[simp]
+lemma mem_alternating_subgroup {f : perm α} :
+  f ∈ alternating_subgroup α ↔ sign f = 1 :=
+monoid_hom.mem_ker _
+
+instance alternating_subgroup.fintype :
+  fintype (alternating_subgroup α) :=
+fintype.subtype (univ.filter (λ x, sign x = 1)) (λ x, begin
+  simp only [true_and, mem_filter, mem_univ, ← mem_alternating_subgroup],
+  refl,
+end)
+
+lemma two_mul_card_alternating_subgroup [nontrivial α] :
+  2 * card (alternating_subgroup α) = (card α).factorial :=
+begin
+  classical,
+  rw [← card_perm, card_eq_card_quotient_mul_card_subgroup (alternating_subgroup α),
+    ← fintype.card_units_int],
+  convert congr (congr rfl (of_equiv_card (quotient_group.quotient_ker_equiv_of_surjective _
+    (sign_surjective α)).to_equiv)) rfl,
+end
+
+@[simp]
+lemma card_alternating_subgroup_eq_one [h : subsingleton α] :
+  card (alternating_subgroup α) = 1 :=
+begin
+  apply le_antisymm,
+  { apply le_trans (card_subtype_le _),
+    rw card_perm,
+    cases eq_or_lt_of_le (fintype.card_le_one_iff_subsingleton.2 h) with h1 h0,
+    { simp [h1] },
+    { rw [nat.lt_succ_iff, nat.le_zero_iff] at h0,
+      simp [h0] } },
+  { apply card_pos_iff.2,
+    apply_instance, }
+end
+
+lemma alternating_subgroup_normal : (alternating_subgroup α).normal := sign.normal_ker
+
+end alternating_subgroup
 
 lemma eq_sign_of_surjective_hom {s : perm α →* units ℤ} (hs : surjective s) : s = sign :=
 have ∀ {f}, is_swap f → s f = -1 :=

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -787,14 +787,14 @@ sign.mem_ker
 instance : decidable_pred ((alternating_subgroup α).carrier) :=
 sign.decidable_ker
 
-lemma two_mul_card_alternating_subgroup [nontrivial α] :
-  2 * card (alternating_subgroup α) = (card α).factorial :=
+lemma card_perm_eq_two_mul_card_alternating_subgroup [nontrivial α] :
+  card (perm α) = 2 * card (alternating_subgroup α) :=
 begin
   classical,
-  rw [← card_perm, card_eq_card_quotient_mul_card_subgroup (alternating_subgroup α),
-    ← fintype.card_units_int],
-  convert congr (congr rfl (of_equiv_card (quotient_group.quotient_ker_equiv_of_surjective _
-    (sign_surjective α)).to_equiv)) rfl,
+  rw ← fintype.card_units_int,
+  convert card_eq_card_quotient_mul_card_subgroup (alternating_subgroup α),
+  convert of_equiv_card (quotient_group.quotient_ker_equiv_of_surjective _
+    (sign_surjective α)).to_equiv,
 end
 
 @[simp]

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -782,14 +782,10 @@ lemma alternating_subgroup_eq_sign_ker : alternating_subgroup α = sign.ker := r
 @[simp]
 lemma mem_alternating_subgroup {f : perm α} :
   f ∈ alternating_subgroup α ↔ sign f = 1 :=
-monoid_hom.mem_ker _
+sign.mem_ker
 
-instance alternating_subgroup.fintype :
-  fintype (alternating_subgroup α) :=
-fintype.subtype (univ.filter (λ x, sign x = 1)) (λ x, begin
-  simp only [true_and, mem_filter, mem_univ, ← mem_alternating_subgroup],
-  refl,
-end)
+instance : decidable_pred ((alternating_subgroup α).carrier) :=
+sign.decidable_ker
 
 lemma two_mul_card_alternating_subgroup [nontrivial α] :
   2 * card (alternating_subgroup α) = (card α).factorial :=

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -530,10 +530,6 @@ permutations, `-1` for odd permutations. It is the unique surjective group homom
 def sign [fintype α] : perm α →* units ℤ := monoid_hom.mk'
 (λ f, sign_aux3 f mem_univ) (λ f g, (sign_aux3_mul_and_swap f g _ mem_univ).1)
 
-
-def alternating_subgroup (α) [fintype α] [decidable_eq α] : subgroup (perm α) :=
-sign.ker
-
 section sign
 
 variable [fintype α]
@@ -604,52 +600,6 @@ lemma sign_surjective [nontrivial α] : function.surjective (sign : perm α → 
     ⟨swap x y, by rw [sign_swap hxy, h]⟩ )
 
 variable {α}
-
-section alternating_subgroup
-variable [decidable_eq α]
-
-lemma alternating_subgroup_eq_sign_ker : alternating_subgroup α = sign.ker := rfl
-
-@[simp]
-lemma mem_alternating_subgroup {f : perm α} :
-  f ∈ alternating_subgroup α ↔ sign f = 1 :=
-monoid_hom.mem_ker _
-
-instance alternating_subgroup.fintype :
-  fintype (alternating_subgroup α) :=
-fintype.subtype (univ.filter (λ x, sign x = 1)) (λ x, begin
-  simp only [true_and, mem_filter, mem_univ, ← mem_alternating_subgroup],
-  refl,
-end)
-
-lemma two_mul_card_alternating_subgroup [nontrivial α] :
-  2 * card (alternating_subgroup α) = (card α).factorial :=
-begin
-  classical,
-  rw [← card_perm, card_eq_card_quotient_mul_card_subgroup (alternating_subgroup α),
-    ← fintype.card_units_int],
-  convert congr (congr rfl (of_equiv_card (quotient_group.quotient_ker_equiv_of_surjective _
-    (sign_surjective α)).to_equiv)) rfl,
-end
-
-@[simp]
-lemma card_alternating_subgroup_eq_one [h : subsingleton α] :
-  card (alternating_subgroup α) = 1 :=
-begin
-  apply le_antisymm,
-  { apply le_trans (card_subtype_le _),
-    rw card_perm,
-    cases eq_or_lt_of_le (fintype.card_le_one_iff_subsingleton.2 h) with h1 h0,
-    { simp [h1] },
-    { rw [nat.lt_succ_iff, nat.le_zero_iff] at h0,
-      simp [h0] } },
-  { apply card_pos_iff.2,
-    apply_instance, }
-end
-
-lemma alternating_subgroup_normal : (alternating_subgroup α).normal := sign.normal_ker
-
-end alternating_subgroup
 
 lemma eq_sign_of_surjective_hom {s : perm α →* units ℤ} (hs : surjective s) : s = sign :=
 have ∀ {f}, is_swap f → s f = -1 :=
@@ -815,3 +765,57 @@ end congr
 end sign
 
 end equiv.perm
+
+section alternating_subgroup
+open equiv.perm
+variables (α) [fintype α] [decidable_eq α]
+
+/-- The alternating group on a finite type, realized as a subgroup of `equiv.perm`.
+  For $A_n$, use `alternating_subgroup (fin n)`. -/
+def alternating_subgroup : subgroup (perm α) :=
+sign.ker
+
+variables {α}
+
+lemma alternating_subgroup_eq_sign_ker : alternating_subgroup α = sign.ker := rfl
+
+@[simp]
+lemma mem_alternating_subgroup {f : perm α} :
+  f ∈ alternating_subgroup α ↔ sign f = 1 :=
+monoid_hom.mem_ker _
+
+instance alternating_subgroup.fintype :
+  fintype (alternating_subgroup α) :=
+fintype.subtype (univ.filter (λ x, sign x = 1)) (λ x, begin
+  simp only [true_and, mem_filter, mem_univ, ← mem_alternating_subgroup],
+  refl,
+end)
+
+lemma two_mul_card_alternating_subgroup [nontrivial α] :
+  2 * card (alternating_subgroup α) = (card α).factorial :=
+begin
+  classical,
+  rw [← card_perm, card_eq_card_quotient_mul_card_subgroup (alternating_subgroup α),
+    ← fintype.card_units_int],
+  convert congr (congr rfl (of_equiv_card (quotient_group.quotient_ker_equiv_of_surjective _
+    (sign_surjective α)).to_equiv)) rfl,
+end
+
+@[simp]
+lemma card_alternating_subgroup_eq_one [h : subsingleton α] :
+  card (alternating_subgroup α) = 1 :=
+begin
+  apply le_antisymm,
+  { apply le_trans (card_subtype_le _),
+    rw card_perm,
+    cases eq_or_lt_of_le (fintype.card_le_one_iff_subsingleton.2 h) with h1 h0,
+    { simp [h1] },
+    { rw [nat.lt_succ_iff, nat.le_zero_iff] at h0,
+      simp [h0] } },
+  { apply card_pos_iff.2,
+    apply_instance, }
+end
+
+lemma alternating_subgroup_normal : (alternating_subgroup α).normal := sign.normal_ker
+
+end alternating_subgroup

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -772,7 +772,7 @@ variables (α) [fintype α] [decidable_eq α]
 
 /-- The alternating group on a finite type, realized as a subgroup of `equiv.perm`.
   For $A_n$, use `alternating_subgroup (fin n)`. -/
-def alternating_subgroup : subgroup (perm α) :=
+@[derive fintype] def alternating_subgroup : subgroup (perm α) :=
 sign.ker
 
 variables {α}
@@ -784,15 +784,12 @@ lemma mem_alternating_subgroup {f : perm α} :
   f ∈ alternating_subgroup α ↔ sign f = 1 :=
 sign.mem_ker
 
-instance : decidable_pred ((alternating_subgroup α).carrier) :=
-sign.decidable_ker
-
-lemma card_perm_eq_two_mul_card_alternating_subgroup [nontrivial α] :
-  card (perm α) = 2 * card (alternating_subgroup α) :=
+lemma two_mul_card_alternating_subgroup [nontrivial α] :
+  2 * card (alternating_subgroup α) = card (perm α) :=
 begin
   classical,
   rw ← fintype.card_units_int,
-  convert card_eq_card_quotient_mul_card_subgroup (alternating_subgroup α),
+  convert (card_eq_card_quotient_mul_card_subgroup (alternating_subgroup α)).symm,
   convert of_equiv_card (quotient_group.quotient_ker_equiv_of_surjective _
     (sign_surjective α)).to_equiv,
 end

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -812,10 +812,10 @@ lemma two_mul_card_alternating_subgroup [nontrivial α] :
   2 * card (alternating_subgroup α) = card (perm α) :=
 begin
   classical,
-  rw ← fintype.card_units_int,
+  rw [← fintype.card_units_int,
+    ← (fintype.card_congr (quotient_group.quotient_ker_equiv_of_surjective _
+    (sign_surjective α)).to_equiv)],
   convert (card_eq_card_quotient_mul_card_subgroup (alternating_subgroup α)).symm,
-  convert of_equiv_card (quotient_group.quotient_ker_equiv_of_surjective _
-    (sign_surjective α)).to_equiv,
 end
 
 lemma alternating_subgroup_normal : (alternating_subgroup α).normal := sign.normal_ker

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -215,15 +215,6 @@ def support [fintype α] (f : perm α) : finset α := univ.filter (λ x, f x ≠
 @[simp] lemma mem_support [fintype α] {f : perm α} {x : α} : x ∈ f.support ↔ f x ≠ x :=
 by simp only [support, true_and, mem_filter, mem_univ]
 
-lemma support_mul_subset [fintype α] {f g : perm α} :
-  (f * g).support ⊆ f.support ∪ g.support :=
-λ x, begin
-  simp only [mem_union, perm.coe_mul, comp_app, ne.def, mem_support],
-  contrapose!,
-  rintro ⟨hf, hg⟩,
-  rw [hg, hf]
-end
-
 lemma support_pow_le [fintype α] (σ : perm α) (n : ℤ) :
   (σ ^ n).support ≤ σ.support :=
 λ x h1, mem_support.mpr (λ h2, mem_support.mp h1 (gpow_apply_eq_self_of_apply_eq_self h2 n))

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -775,6 +775,9 @@ variables (α) [fintype α] [decidable_eq α]
 @[derive fintype] def alternating_subgroup : subgroup (perm α) :=
 sign.ker
 
+instance [subsingleton α] : unique (alternating_subgroup α) :=
+⟨⟨1⟩, λ ⟨p, hp⟩, subtype.eq (subsingleton.elim p _)⟩
+
 variables {α}
 
 lemma alternating_subgroup_eq_sign_ker : alternating_subgroup α = sign.ker := rfl
@@ -797,13 +800,7 @@ end
 @[simp]
 lemma card_alternating_subgroup_eq_one [h : subsingleton α] :
   card (alternating_subgroup α) = 1 :=
-begin
-  apply le_antisymm,
-  { apply le_trans (card_subtype_le _),
-    convert (card_of_subsingleton (1 : perm α)).le },
-  { apply card_pos_iff.2,
-    apply_instance, }
-end
+by convert card_of_subsingleton (1 : alternating_subgroup α)
 
 lemma alternating_subgroup_normal : (alternating_subgroup α).normal := sign.normal_ker
 

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -811,11 +811,9 @@ end
 lemma two_mul_card_alternating_subgroup [nontrivial α] :
   2 * card (alternating_subgroup α) = card (perm α) :=
 begin
-  classical,
-  rw [← fintype.card_units_int,
-    ← (fintype.card_congr (quotient_group.quotient_ker_equiv_of_surjective _
-    (sign_surjective α)).to_equiv)],
-  convert (card_eq_card_quotient_mul_card_subgroup (alternating_subgroup α)).symm,
+  let := (quotient_group.quotient_ker_equiv_of_surjective _ (sign_surjective α)).to_equiv,
+  rw [←fintype.card_units_int, ←fintype.card_congr (this)],
+  exact (card_eq_card_quotient_mul_card_subgroup _).symm,
 end
 
 lemma alternating_subgroup_normal : (alternating_subgroup α).normal := sign.normal_ker

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -827,11 +827,6 @@ begin
     (sign_surjective α)).to_equiv,
 end
 
-@[simp]
-lemma card_alternating_subgroup_eq_one [h : subsingleton α] :
-  card (alternating_subgroup α) = 1 :=
-by convert card_of_subsingleton (1 : alternating_subgroup α)
-
 lemma alternating_subgroup_normal : (alternating_subgroup α).normal := sign.normal_ker
 
 end alternating_subgroup

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -812,7 +812,7 @@ lemma two_mul_card_alternating_subgroup [nontrivial α] :
   2 * card (alternating_subgroup α) = card (perm α) :=
 begin
   let := (quotient_group.quotient_ker_equiv_of_surjective _ (sign_surjective α)).to_equiv,
-  rw [←fintype.card_units_int, ←fintype.card_congr (this)],
+  rw [←fintype.card_units_int, ←fintype.card_congr this],
   exact (card_eq_card_quotient_mul_card_subgroup _).symm,
 end
 

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -800,11 +800,7 @@ lemma card_alternating_subgroup_eq_one [h : subsingleton α] :
 begin
   apply le_antisymm,
   { apply le_trans (card_subtype_le _),
-    rw card_perm,
-    cases eq_or_lt_of_le (fintype.card_le_one_iff_subsingleton.2 h) with h1 h0,
-    { simp [h1] },
-    { rw [nat.lt_succ_iff, nat.le_zero_iff] at h0,
-      simp [h0] } },
+    convert (card_of_subsingleton (1 : perm α)).le },
   { apply card_pos_iff.2,
     apply_instance, }
 end

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -162,8 +162,8 @@ attribute [norm_cast] add_subgroup.mem_coe
 attribute [norm_cast] add_subgroup.coe_coe
 
 @[to_additive]
-instance (K : subgroup G) [d : decidable_pred K.carrier] [fintype G] : fintype K :=
-show fintype {g : G // g ∈ K.carrier}, from infer_instance
+instance (K : subgroup G) [d : decidable_pred (∈ K)] [fintype G] : fintype K :=
+show fintype {g : G // g ∈ K}, from infer_instance
 
 end subgroup
 
@@ -1171,8 +1171,8 @@ def ker (f : G →* N) := (⊥ : subgroup N).comap f
 @[to_additive]
 lemma mem_ker (f : G →* N) {x : G} : x ∈ f.ker ↔ f x = 1 := iff.rfl
 
-instance decidable_ker [decidable_eq N] (f : G →* N) :
-  decidable_pred (f.ker.carrier) :=
+instance decidable_mem_ker [decidable_eq N] (f : G →* N) :
+  decidable_pred (∈ f.ker) :=
 λ x, decidable_of_iff (f x = 1) f.mem_ker
 
 @[to_additive]

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1171,6 +1171,7 @@ def ker (f : G →* N) := (⊥ : subgroup N).comap f
 @[to_additive]
 lemma mem_ker (f : G →* N) {x : G} : x ∈ f.ker ↔ f x = 1 := iff.rfl
 
+@[to_additive]
 instance decidable_mem_ker [decidable_eq N] (f : G →* N) :
   decidable_pred (∈ f.ker) :=
 λ x, decidable_of_iff (f x = 1) f.mem_ker

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1171,6 +1171,10 @@ def ker (f : G →* N) := (⊥ : subgroup N).comap f
 @[to_additive]
 lemma mem_ker (f : G →* N) {x : G} : x ∈ f.ker ↔ f x = 1 := iff.rfl
 
+instance decidable_ker [decidable_eq N] (f : G →* N) :
+  decidable_pred (f.ker.carrier) :=
+λ x, decidable_of_iff (f x = 1) f.mem_ker
+
 @[to_additive]
 lemma comap_ker (g : N →* P) (f : G →* N) : g.ker.comap f = (g.comp f).ker := rfl
 


### PR DESCRIPTION
Defines `alternating_subgroup` to be `sign.ker`
Proves a few basic lemmas about its cardinality

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
