### PR TITLE
[Merged by Bors] - feat(data/set/basic): default_coe_singleton

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -711,6 +711,9 @@ lemma eq_singleton_iff_nonempty_unique_mem {s : set α} {a : α} :
   s = {a} ↔ s.nonempty ∧ ∀ x ∈ s, x = a :=
 eq_singleton_iff_unique_mem.trans $ and_congr_left $ λ H, ⟨λ h', ⟨_, h'⟩, λ ⟨x, h⟩, H x h ▸ h⟩
 
+@[simp] lemma default_coe_sort_singleton {α : Sort*} (x : α) :
+  default ({x} : set α) = ⟨x, rfl⟩ := rfl
+
 /-! ### Lemmas about sets defined as `{x ∈ s | p x}`. -/
 
 theorem mem_sep {s : set α} {p : α → Prop} {x : α} (xs : x ∈ s) (px : p x) : x ∈ {x ∈ s | p x} :=

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -711,6 +711,7 @@ lemma eq_singleton_iff_nonempty_unique_mem {s : set α} {a : α} :
   s = {a} ↔ s.nonempty ∧ ∀ x ∈ s, x = a :=
 eq_singleton_iff_unique_mem.trans $ and_congr_left $ λ H, ⟨λ h', ⟨_, h'⟩, λ ⟨x, h⟩, H x h ▸ h⟩
 
+-- while `simp` is capable of proving this, it is not capable of turning the LHS into the RHS.
 @[simp] lemma default_coe_singleton (x : α) :
   default ({x} : set α) = ⟨x, rfl⟩ := rfl
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -711,7 +711,7 @@ lemma eq_singleton_iff_nonempty_unique_mem {s : set α} {a : α} :
   s = {a} ↔ s.nonempty ∧ ∀ x ∈ s, x = a :=
 eq_singleton_iff_unique_mem.trans $ and_congr_left $ λ H, ⟨λ h', ⟨_, h'⟩, λ ⟨x, h⟩, H x h ▸ h⟩
 
-@[simp] lemma default_coe_sort_singleton {α : Sort*} (x : α) :
+@[simp] lemma default_coe_singleton (x : α) :
   default ({x} : set α) = ⟨x, rfl⟩ := rfl
 
 /-! ### Lemmas about sets defined as `{x ∈ s | p x}`. -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

A surprisingly tricky lemma. Consider the following mwe:
```lean
import group_theory.perm.fin
import tactic.fin_cases

lemma default_singleton' {α : Sort*} (x : α) :
  default ({x} : set α) = ⟨x, rfl⟩ := by simp -- can be proven by simp only [eq_iff_true_of_subsingleton], but doesn't fire below

example (t : ({1, equiv.swap 0 1} : set (equiv.perm (fin 2)))) :
  (λ (x : equiv.perm (fin 2)), ite (x = 1)
    (⟨1, by simp⟩ : ({1, equiv.swap 0 1} : set (equiv.perm (fin 2))))
    ⟨equiv.swap 0 1, by simp⟩) t.val = t :=
begin
  fin_cases t,
  { simp },
  { simp [eq_comm], -- default doesn't simplify
    sorry
  },
end

@[simp] lemma default_singleton {α : Sort*} (x : α) :
  default ({x} : set α) = ⟨x, rfl⟩ := rfl

example (t : ({1, equiv.swap 0 1} : set (equiv.perm (fin 2)))) :
  (λ (x : equiv.perm (fin 2)), ite (x = 1)
    (⟨1, by simp⟩ : ({1, equiv.swap 0 1} : set (equiv.perm (fin 2))))
    ⟨equiv.swap 0 1, by simp⟩) t.val = t :=
begin
  fin_cases t,
  { simp },
  { simp [eq_comm] }
end
```

Without providing the lemma directly into the global simp set, the subsingleton reduction does not occur.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
