### PR TITLE
[Merged by Bors] - feat(category_theory/types): add explicit pullbacks in `Type u`

### DIFF
--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -200,6 +200,14 @@ lemma cone_iso_of_hom_iso {K : J ⥤ C} {c d : cone K} (f : c ⟶ d) [i : is_iso
     w' := λ j, (as_iso f.hom).inv_comp_eq.2 (f.w j).symm }, by tidy⟩⟩
 
 /--
+Given an isomorphism of cones, extract the underlying isomorphism between their vertices.
+-/
+def hom_iso_of_cone_iso {K : J ⥤ C} {c d : cone K} (i : c ≅ d) : c.X ≅ d.X :=
+{ hom := i.hom.hom, inv := i.inv.hom,
+  hom_inv_id' := by { transitivity (i.hom ≫ i.inv).hom, { dsimp, refl }, simp },
+  inv_hom_id' := by { transitivity (i.inv ≫ i.hom).hom, { dsimp, refl }, simp } }
+
+/--
 Functorially postcompose a cone for `F` by a natural transformation `F ⟶ G` to give a cone for `G`.
 -/
 @[simps] def postcompose {G : J ⥤ C} (α : F ⟶ G) : cone F ⥤ cone G :=

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -200,14 +200,6 @@ lemma cone_iso_of_hom_iso {K : J ⥤ C} {c d : cone K} (f : c ⟶ d) [i : is_iso
     w' := λ j, (as_iso f.hom).inv_comp_eq.2 (f.w j).symm }, by tidy⟩⟩
 
 /--
-Given an isomorphism of cones, extract the underlying isomorphism between their vertices.
--/
-def hom_iso_of_cone_iso {K : J ⥤ C} {c d : cone K} (i : c ≅ d) : c.X ≅ d.X :=
-{ hom := i.hom.hom, inv := i.inv.hom,
-  hom_inv_id' := by { transitivity (i.hom ≫ i.inv).hom, { dsimp, refl }, simp },
-  inv_hom_id' := by { transitivity (i.inv ≫ i.hom).hom, { dsimp, refl }, simp } }
-
-/--
 Functorially postcompose a cone for `F` by a natural transformation `F ⟶ G` to give a cone for `G`.
 -/
 @[simps] def postcompose {G : J ⥤ C} (α : F ⟶ G) : cone F ⥤ cone G :=

--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -37,11 +37,11 @@ The type of objects for the diagram indexing a pullback, defined as a special ca
 abbreviation walking_cospan : Type v := wide_pullback_shape walking_pair
 
 /-- The left point of the walking cospan. -/
-abbreviation walking_cospan.left : walking_cospan := some walking_pair.left
+@[pattern] abbreviation walking_cospan.left : walking_cospan := some walking_pair.left
 /-- The right point of the walking cospan. -/
-abbreviation walking_cospan.right : walking_cospan := some walking_pair.right
+@[pattern] abbreviation walking_cospan.right : walking_cospan := some walking_pair.right
 /-- The central point of the walking cospan. -/
-abbreviation walking_cospan.one : walking_cospan := none
+@[pattern] abbreviation walking_cospan.one : walking_cospan := none
 
 /--
 The type of objects for the diagram indexing a pushout, defined as a special case of
@@ -50,11 +50,11 @@ The type of objects for the diagram indexing a pushout, defined as a special cas
 abbreviation walking_span : Type v := wide_pushout_shape walking_pair
 
 /-- The left point of the walking span. -/
-abbreviation walking_span.left : walking_span := some walking_pair.left
+@[pattern] abbreviation walking_span.left : walking_span := some walking_pair.left
 /-- The right point of the walking span. -/
-abbreviation walking_span.right : walking_span := some walking_pair.right
+@[pattern] abbreviation walking_span.right : walking_span := some walking_pair.right
 /-- The central point of the walking span. -/
-abbreviation walking_span.zero : walking_span := none
+@[pattern] abbreviation walking_span.zero : walking_span := none
 
 namespace walking_cospan
 
@@ -62,11 +62,11 @@ namespace walking_cospan
 abbreviation hom : walking_cospan → walking_cospan → Type v := wide_pullback_shape.hom
 
 /-- The left arrow of the walking cospan. -/
-abbreviation hom.inl : left ⟶ one := wide_pullback_shape.hom.term _
+@[pattern] abbreviation hom.inl : left ⟶ one := wide_pullback_shape.hom.term _
 /-- The right arrow of the walking cospan. -/
-abbreviation hom.inr : right ⟶ one := wide_pullback_shape.hom.term _
+@[pattern] abbreviation hom.inr : right ⟶ one := wide_pullback_shape.hom.term _
 /-- The identity arrows of the walking cospan. -/
-abbreviation hom.id (X : walking_cospan) : X ⟶ X := wide_pullback_shape.hom.id X
+@[pattern] abbreviation hom.id (X : walking_cospan) : X ⟶ X := wide_pullback_shape.hom.id X
 
 instance (X Y : walking_cospan) : subsingleton (X ⟶ Y) := by tidy
 
@@ -78,11 +78,11 @@ namespace walking_span
 abbreviation hom : walking_span → walking_span → Type v := wide_pushout_shape.hom
 
 /-- The left arrow of the walking span. -/
-abbreviation hom.fst : zero ⟶ left := wide_pushout_shape.hom.init _
+@[pattern] abbreviation hom.fst : zero ⟶ left := wide_pushout_shape.hom.init _
 /-- The right arrow of the walking span. -/
-abbreviation hom.snd : zero ⟶ right := wide_pushout_shape.hom.init _
+@[pattern] abbreviation hom.snd : zero ⟶ right := wide_pushout_shape.hom.init _
 /-- The identity arrows of the walking span. -/
-abbreviation hom.id (X : walking_span) : X ⟶ X := wide_pushout_shape.hom.id X
+@[pattern] abbreviation hom.id (X : walking_span) : X ⟶ X := wide_pushout_shape.hom.id X
 
 instance (X Y : walking_span) : subsingleton (X ⟶ Y) := by tidy
 

--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -161,7 +161,7 @@ abbreviation snd (t : pullback_cone f g) : t.X ⟶ Y := t.π.app walking_cospan.
 
 /-- This is a slightly more convenient method to verify that a pullback cone is a limit cone. It
     only asks for a proof of facts that carry any mathematical content -/
-def is_limit_aux (t : pullback_cone f g) (lift : Π (s : cone (cospan f g)), s.X ⟶ t.X)
+def is_limit_aux (t : pullback_cone f g) (lift : Π (s : pullback_cone f g), s.X ⟶ t.X)
   (fac_left : ∀ (s : pullback_cone f g), lift s ≫ t.fst = s.fst)
   (fac_right : ∀ (s : pullback_cone f g), lift s ≫ t.snd = s.snd)
   (uniq : ∀ (s : pullback_cone f g) (m : s.X ⟶ t.X)

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -247,7 +247,7 @@ This is bundled with the `is_limit` data as `pullback_limit_cone f g`.
 -/
 @[simps]
 def pullback_cone : limits.pullback_cone f g :=
-pullback_cone.mk (λ p : pullback_obj f g, p.1.1) (λ p, p.1.2) (by exact funext (λ p, p.2))
+pullback_cone.mk (λ p : pullback_obj f g, p.1.1) (λ p, p.1.2) (funext (λ p, p.2))
 
 /--
 The explicit pullback in the category of types, bundled up as a `limit_cone`
@@ -283,11 +283,11 @@ noncomputable def pullback_iso_pullback : pullback f g ≅ pullback_obj f g :=
 (cones.forget _).map_iso $ pullback_cone_iso_pullback f g
 
 @[simp] lemma pullback_fst'
-  : (pullback_iso_pullback f g).hom ≫ (pullback_cone f g).fst = limits.pullback.fst :=
+  : (pullback_iso_pullback f g).hom ≫ (pullback_cone f g).fst = pullback.fst :=
 (pullback_cone_iso_pullback f g).hom.w _
 
 @[simp] lemma pullback_snd'
-  : (pullback_iso_pullback f g).hom ≫ (pullback_cone f g).snd = limits.pullback.snd :=
+  : (pullback_iso_pullback f g).hom ≫ (pullback_cone f g).snd = pullback.snd :=
 (pullback_cone_iso_pullback f g).hom.w _
 
 end pullback

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -264,11 +264,10 @@ lemma pullback_commutes :
 The explicit pullback cone on `pullback_obj f g`.
 This is bundled with the `is_limit` data as `pullback_limit_cone f g`.
 -/
+@[simps]
 def pullback_cone : cone (cospan f g) :=
 { X := pullback_obj f g,
   π := { app := pullback_proj f g, naturality' := pullback_commutes f g } }
-
-@[simp] lemma pullback_cone_app : (pullback_cone f g).π.app = pullback_proj f g := rfl
 
 instance : has_coe (pullback_cone f g).X (X × Y) := ⟨λ w, ⟨w.val.1, w.val.2⟩⟩
 
@@ -309,7 +308,7 @@ def pullback_limit : is_limit (pullback_cone f g) :=
 
     all_goals {
       funext w,
-      rw [pullback_cone_app, types_comp_apply],
+      rw [types_comp_apply, pullback_cone_π_app],
       try { rw [types_comp_apply, cospan_map_inl] },
       rw pullback_proj_base <|> rw pullback_proj_fst <|> rw pullback_proj_snd,
       dsimp only [],
@@ -321,7 +320,7 @@ def pullback_limit : is_limit (pullback_cone f g) :=
     intro s,
     rintros (lift: s.X ⟶ pullback_obj f g) h_lift,
     funext w,
-    rw pullback_cone_app at h_lift,
+    rw pullback_cone_app at h_lift, -- TODO broken now -- but going away anyway
     have h_fst : (lift w).val.fst = (pullback_lift f g s w).val.fst,
       by rw [pullback_lift_val, ←h_lift left, types_comp_apply, pullback_proj_fst],
     have h_snd : (lift w).val.snd = (pullback_lift f g s w).val.snd,
@@ -350,15 +349,15 @@ The pullback given by the instance `has_pullbacks (Type u)` is isomorphic to the
 explicit pullback object given by `pullback_limit_obj`.
 -/
 noncomputable def pullback_iso_pullback : pullback f g ≅ pullback_obj f g :=
-cones.hom_iso_of_cone_iso (pullback_cone_iso_pullback f g)
+(cones.forget _).map_iso $ pullback_cone_iso_pullback f g
 
 @[simp] lemma pullback_fst'
-  : limits.pullback.fst = (pullback_iso_pullback f g).hom ≫ pullback_fst f g :=
-eq.symm $ (pullback_cone_iso_pullback f g).hom.w _
+  : (pullback_iso_pullback f g).hom ≫ pullback_fst f g = limits.pullback.fst :=
+(pullback_cone_iso_pullback f g).hom.w _
 
 @[simp] lemma pullback_snd'
-  : limits.pullback.snd = (pullback_iso_pullback f g).hom ≫ pullback_snd f g :=
-eq.symm $ (pullback_cone_iso_pullback f g).hom.w _
+  : (pullback_iso_pullback f g).hom ≫ pullback_snd f g = limits.pullback.snd :=
+(pullback_cone_iso_pullback f g).hom.w _
 
 end pullback
 

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -282,12 +282,12 @@ noncomputable def pullback_iso_pullback : pullback f g ≅ pullback_obj f g :=
 (cones.forget _).map_iso $ pullback_cone_iso_pullback f g
 
 @[simp] lemma pullback_fst'
-  : (pullback_iso_pullback f g).hom ≫ (pullback_cone f g).fst = pullback.fst :=
-(pullback_cone_iso_pullback f g).hom.w _
+  : (pullback_iso_pullback f g).hom ≫ (λ p, (p : X × Y).fst) = pullback.fst :=
+(pullback_cone_iso_pullback f g).hom.w left
 
 @[simp] lemma pullback_snd'
-  : (pullback_iso_pullback f g).hom ≫ (pullback_cone f g).snd = pullback.snd :=
-(pullback_cone_iso_pullback f g).hom.w _
+  : (pullback_iso_pullback f g).hom ≫ (λ p, (p : X × Y).snd) = pullback.snd :=
+(pullback_cone_iso_pullback f g).hom.w right
 
 end pullback
 

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -245,8 +245,7 @@ def pullback_obj : Type u := { p : X × Y // f p.1 = g p.2 }
 The explicit pullback cone on `pullback_obj f g`.
 This is bundled with the `is_limit` data as `pullback_limit_cone f g`.
 -/
-@[simps]
-def pullback_cone : limits.pullback_cone f g :=
+abbreviation pullback_cone : limits.pullback_cone f g :=
 pullback_cone.mk (λ p : pullback_obj f g, p.1.1) (λ p, p.1.2) (funext (λ p, p.2))
 
 /--

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -281,19 +281,19 @@ explicit pullback object given by `pullback_limit_obj`.
 noncomputable def pullback_iso_pullback : pullback f g ≅ pullback_obj f g :=
 (cones.forget _).map_iso $ pullback_cone_iso_pullback f g
 
-@[simp] lemma pullback_iso_fst_eq_fst (p : pullback f g) :
+@[simp] lemma pullback_iso_pullback_hom_fst (p : pullback f g) :
   ((pullback_iso_pullback f g).hom p : X × Y).fst = (pullback.fst : _ ⟶ X) p :=
 congr_fun ((pullback_cone_iso_pullback f g).hom.w left) p
 
-@[simp] lemma pullback_iso_snd_eq_snd (p : pullback f g) :
+@[simp] lemma pullback_iso_pullback_hom_snd (p : pullback f g) :
   ((pullback_iso_pullback f g).hom p : X × Y).snd = (pullback.snd : _ ⟶ Y) p :=
 congr_fun ((pullback_cone_iso_pullback f g).hom.w right) p
 
-@[simp] lemma iso_pullback_fst_eq_coe_fst :
+@[simp] lemma pullback_iso_pullback_inv_fst :
   (pullback_iso_pullback f g).inv ≫ pullback.fst = (λ p, (p : X × Y).fst) :=
 (pullback_cone_iso_pullback f g).inv.w left
 
-@[simp] lemma iso_pullback_snd_eq_coe_snd :
+@[simp] lemma pullback_iso_pullback_inv_snd :
   (pullback_iso_pullback f g).inv ≫ pullback.snd = (λ p, (p : X × Y).snd) :=
 (pullback_cone_iso_pullback f g).inv.w right
 

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -239,7 +239,10 @@ variables (f : X ⟶ Z) (g : Y ⟶ Z)
 The usual explicit pullback in the category of types, as a subtype of the product.
 The full `limit_cone` data is bundled as `pullback_limit_cone f g`.
 -/
-def pullback_obj : Type u := { p : X × Y // f p.1 = g p.2 }
+abbreviation pullback_obj : Type u := { p : X × Y // f p.1 = g p.2 }
+
+-- `pullback_obj f g` comes with a coercion to the product type `X × Y`.
+example (p : pullback_obj f g) : X × Y := p
 
 /--
 The explicit pullback cone on `pullback_obj f g`.

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -255,16 +255,15 @@ for given `f` and `g`.
 @[simps]
 def pullback_limit_cone (f : X ⟶ Z) (g : Y ⟶ Z) : limits.limit_cone (cospan f g) :=
 { cone := pullback_cone f g,
-  is_limit :=
-  begin
-    fapply pullback_cone.is_limit_aux _,
-    exact λ s x, ⟨⟨s.fst x, s.snd x⟩, congr_fun s.condition x⟩,
-    { tidy, },
-    { tidy, },
-    intros, ext,
-    exact congr_fun (w walking_cospan.left) x,
-    exact congr_fun (w walking_cospan.right) x,
-  end }
+  is_limit := pullback_cone.is_limit_aux _
+    (λ s x, ⟨⟨s.fst x, s.snd x⟩, congr_fun s.condition x⟩)
+    (by tidy)
+    (by tidy)
+    begin
+      intros, ext,
+      exact congr_fun (w walking_cospan.left) x,
+      exact congr_fun (w walking_cospan.right) x,
+    end }
 
 /--
 The pullback cone given by the instance `has_pullbacks (Type u)` is isomorphic to the

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -258,8 +258,7 @@ def pullback_limit_cone (f : X ⟶ Z) (g : Y ⟶ Z) : limits.limit_cone (cospan 
   is_limit :=
   begin
     fapply pullback_cone.is_limit_aux _,
-    exact λ (s : limits.pullback_cone _ _) x,
-            ⟨⟨s.fst x, s.snd x⟩, congr_fun s.condition x⟩,
+    exact λ s x, ⟨⟨s.fst x, s.snd x⟩, congr_fun s.condition x⟩,
     { tidy, },
     { tidy, },
     intros, ext,

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -281,6 +281,14 @@ explicit pullback object given by `pullback_limit_obj`.
 noncomputable def pullback_iso_pullback : pullback f g ≅ pullback_obj f g :=
 (cones.forget _).map_iso $ pullback_cone_iso_pullback f g
 
+@[simp] lemma pullback_fst'' (p : pullback f g) :
+  ((pullback_iso_pullback f g).hom p : X × Y).fst = (pullback.fst : _ ⟶ X) p :=
+congr_fun ((pullback_cone_iso_pullback f g).hom.w left) p
+
+@[simp] lemma pullback_snd'' (p : pullback f g) :
+  ((pullback_iso_pullback f g).hom p : X × Y).snd = (pullback.snd : _ ⟶ Y) p :=
+congr_fun ((pullback_cone_iso_pullback f g).hom.w right) p
+
 @[simp] lemma pullback_fst' :
   (pullback_iso_pullback f g).hom ≫ (λ p, (p : X × Y).fst) = pullback.fst :=
 (pullback_cone_iso_pullback f g).hom.w left

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -295,6 +295,7 @@ rfl
 The explicit pullback given by `pullback_cone f g` is a limit.
 This is bundled with the cone itself as `pullback_limit_cone f g`.
 -/
+@[simps]
 def pullback_limit : is_limit (pullback_cone f g) :=
 { lift := pullback_lift f g,
 
@@ -333,6 +334,7 @@ def pullback_limit : is_limit (pullback_cone f g) :=
 The explicit pullback in the category of types, bundled up as a `limit_cone`
 for given `f` and `g`.
 -/
+@[simps]
 def pullback_limit_cone (f : X ⟶ Z) (g : Y ⟶ Z) : limits.limit_cone (cospan f g) :=
 { cone := pullback_cone f g,
   is_limit := pullback_limit f g, }

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -281,27 +281,19 @@ explicit pullback object given by `pullback_limit_obj`.
 noncomputable def pullback_iso_pullback : pullback f g ≅ pullback_obj f g :=
 (cones.forget _).map_iso $ pullback_cone_iso_pullback f g
 
-@[simp] lemma pullback_fst'' (p : pullback f g) :
+@[simp] lemma pullback_iso_fst_eq_fst (p : pullback f g) :
   ((pullback_iso_pullback f g).hom p : X × Y).fst = (pullback.fst : _ ⟶ X) p :=
 congr_fun ((pullback_cone_iso_pullback f g).hom.w left) p
 
-@[simp] lemma pullback_snd'' (p : pullback f g) :
+@[simp] lemma pullback_iso_snd_eq_snd (p : pullback f g) :
   ((pullback_iso_pullback f g).hom p : X × Y).snd = (pullback.snd : _ ⟶ Y) p :=
 congr_fun ((pullback_cone_iso_pullback f g).hom.w right) p
 
-@[simp] lemma pullback_fst' :
-  (pullback_iso_pullback f g).hom ≫ (λ p, (p : X × Y).fst) = pullback.fst :=
-(pullback_cone_iso_pullback f g).hom.w left
-
-@[simp] lemma pullback_snd' :
-  (pullback_iso_pullback f g).hom ≫ (λ p, (p : X × Y).snd) = pullback.snd :=
-(pullback_cone_iso_pullback f g).hom.w right
-
-@[simp] lemma pullback_fst :
+@[simp] lemma iso_pullback_fst_eq_coe_fst :
   (pullback_iso_pullback f g).inv ≫ pullback.fst = (λ p, (p : X × Y).fst) :=
 (pullback_cone_iso_pullback f g).inv.w left
 
-@[simp] lemma pullback_snd :
+@[simp] lemma iso_pullback_snd_eq_coe_snd :
   (pullback_iso_pullback f g).inv ≫ pullback.snd = (λ p, (p : X × Y).snd) :=
 (pullback_cone_iso_pullback f g).inv.w right
 

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -239,6 +239,7 @@ variables (f : X ⟶ Z) (g : Y ⟶ Z)
 The usual explicit pullback in the category of types, as a subtype of the product.
 The full `limit_cone` data is bundled as `pullback_limit_cone f g`.
 -/
+@[nolint has_inhabited_instance]
 abbreviation pullback_obj : Type u := { p : X × Y // f p.1 = g p.2 }
 
 -- `pullback_obj f g` comes with a coercion to the product type `X × Y`.

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -281,12 +281,12 @@ explicit pullback object given by `pullback_limit_obj`.
 noncomputable def pullback_iso_pullback : pullback f g ≅ pullback_obj f g :=
 (cones.forget _).map_iso $ pullback_cone_iso_pullback f g
 
-@[simp] lemma pullback_fst'
-  : (pullback_iso_pullback f g).hom ≫ (λ p, (p : X × Y).fst) = pullback.fst :=
+@[simp] lemma pullback_fst' :
+  (pullback_iso_pullback f g).hom ≫ (λ p, (p : X × Y).fst) = pullback.fst :=
 (pullback_cone_iso_pullback f g).hom.w left
 
-@[simp] lemma pullback_snd'
-  : (pullback_iso_pullback f g).hom ≫ (λ p, (p : X × Y).snd) = pullback.snd :=
+@[simp] lemma pullback_snd' :
+  (pullback_iso_pullback f g).hom ≫ (λ p, (p : X × Y).snd) = pullback.snd :=
 (pullback_cone_iso_pullback f g).hom.w right
 
 end pullback

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -289,6 +289,14 @@ noncomputable def pullback_iso_pullback : pullback f g ≅ pullback_obj f g :=
   (pullback_iso_pullback f g).hom ≫ (λ p, (p : X × Y).snd) = pullback.snd :=
 (pullback_cone_iso_pullback f g).hom.w right
 
+@[simp] lemma pullback_fst :
+  (pullback_iso_pullback f g).inv ≫ pullback.fst = (λ p, (p : X × Y).fst) :=
+(pullback_cone_iso_pullback f g).inv.w left
+
+@[simp] lemma pullback_snd :
+  (pullback_iso_pullback f g).inv ≫ pullback.snd = (λ p, (p : X × Y).snd) :=
+(pullback_cone_iso_pullback f g).inv.w right
+
 end pullback
 
 end category_theory.limits.types

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -259,11 +259,9 @@ def pullback_limit_cone (f : X ⟶ Z) (g : Y ⟶ Z) : limits.limit_cone (cospan 
     (λ s x, ⟨⟨s.fst x, s.snd x⟩, congr_fun s.condition x⟩)
     (by tidy)
     (by tidy)
-    begin
-      intros, ext,
-      exact congr_fun (w walking_cospan.left) x,
-      exact congr_fun (w walking_cospan.right) x,
-    end }
+    (λ s m w, funext $ λ x, subtype.ext $
+     prod.ext (congr_fun (w walking_cospan.left) x)
+              (congr_fun (w walking_cospan.right) x)) }
 
 /--
 The pullback cone given by the instance `has_pullbacks (Type u)` is isomorphic to the


### PR DESCRIPTION
Add an explicit construction of binary pullbacks in the
category of types.

Zulip discussion:
https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/pullbacks.20in.20Type.20u

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The construction of the `is_limit` feels messy to me -- that's an area where I'd be especially glad for suggestions on how to write it better, though really I'm happy to hear feedback anywhere.

I don't love these names, partly because I don't feel like they particularly signal the distinction between these explicit pullbacks and the general ones provided by the `has_pullbacks` instance through `category_theory.limits.pullback`, `category_theory.limits.pullback.fst`, and so on. I'm not sure what would be the best names to use instead, though. Perhaps the most reasonable way to express that distinction is just the difference in namespace -- `category_theory.limits.foo` vs. `category_theory.limits.types.foo`? In that case perhaps most of these should just go under the `pullback` sub-namespace: so `category_theory.limits.types.pullback.fst` and so on.

In the module docstring at the top of the file, it seemed like a couple of existing features were missing from the inventory, so I added those along with this one. I think a couple of other parts of that module docstring need updates for refactors that have happened -- I don't see `limit_data` or `types_has_terminal` mentioned in the code -- but I'm not sure what the right story is for each of those, so those updates may be easier to get right for someone more familiar with the history of this file.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
