### PR TITLE
[Merged by Bors] - chore(group_theory/subgroup): translate map comap lemmas from linear_map

### DIFF
--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1544,9 +1544,9 @@ lemma is_simple_group_of_surjective {H : Type*} [group H] [is_simple_group G]
   [nontrivial H] (f : G →* H) (hf : function.surjective f) :
   is_simple_group H :=
 ⟨nontrivial.exists_pair_ne, λ H iH, begin
-  cases ((iH.comap f).eq_bot_or_eq_top),
-  { left, rw [←map_bot f, ←h, map_comap_eq_self_of_surjective hf] },
-  right, rw [←comap_top f] at h, exact comap_injective hf h,
+  refine ((iH.comap f).eq_bot_or_eq_top).imp (λ h, _) (λ h, _),
+  { rw [←map_bot f, ←h, map_comap_eq_self_of_surjective hf] },
+  { rw [←comap_top f] at h, exact comap_injective hf h }
 end⟩
 
 end is_simple_group

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1202,19 +1202,25 @@ open monoid_hom
 
 variables {H : Type*} [group H] {f : G →* H}
 
+@[to_additive]
 lemma map_le_range {K : subgroup G} : map f K ≤ f.range :=
 (range_eq_map f).symm ▸ map_mono le_top
 
+@[to_additive]
 lemma ker_le_comap {K : subgroup H} : f.ker ≤ comap f K :=
 comap_mono bot_le
 
 variable (f)
+
+@[to_additive]
 lemma map_comap_le (K : subgroup H) : map f (comap f K) ≤ K :=
 (gc_map_comap f).l_u_le _
 
+@[to_additive]
 lemma le_comap_map (K : subgroup G) : K ≤ comap f (map f K) :=
 (gc_map_comap f).le_u_l _
 
+@[to_additive]
 lemma map_comap_eq (K : subgroup H) :
   map f (comap f K) = f.range ⊓ K :=
 set_like.ext' begin
@@ -1222,6 +1228,7 @@ set_like.ext' begin
   simp [set.inter_comm],
 end
 
+@[to_additive]
 lemma comap_map_eq (K : subgroup G) :
   comap f (map f K) = K ⊔ f.ker :=
 begin
@@ -1232,6 +1239,33 @@ begin
   convert mul_mem _ (mem_sup_left hy) (mem_sup_right this),
   simp,
 end
+
+variable {f}
+
+@[to_additive]
+lemma map_comap_eq_self {K : subgroup H} (h : K ≤ f.range) :
+  map f (comap f K) = K :=
+by rwa [map_comap_eq, inf_eq_right]
+
+@[to_additive]
+lemma map_comap_eq_self_of_surjective (h : function.surjective f) {K : subgroup H} :
+  map f (comap f K) = K :=
+map_comap_eq_self ((range_top_of_surjective _ h).symm ▸ le_top)
+
+@[to_additive]
+lemma comap_map_eq_self {K : subgroup G} (h : f.ker ≤ K) :
+  comap f (map f K) = K :=
+by rwa [comap_map_eq, sup_eq_left]
+
+@[to_additive]
+lemma comap_map_eq_self_of_injective (h : function.injective f) {K : subgroup G} :
+  comap f (map f K) = K :=
+comap_map_eq_self (((ker_eq_bot_iff _).mpr h).symm ▸ bot_le)
+
+@[to_additive]
+lemma map_eq_comap_of_inverse {g : H →* G} (hl : function.left_inverse g f)
+  (hr : function.right_inverse g f) (K : subgroup G) : map f K = comap g K :=
+set_like.ext' $ by rw [coe_map, coe_comap, set.image_eq_preimage_of_inverse hl hr]
 
 end subgroup
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -655,6 +655,10 @@ lemma coe_comap (K : subgroup N) (f : G →* N) : (K.comap f : set G) = f ⁻¹'
 @[simp, to_additive]
 lemma mem_comap {K : subgroup N} {f : G →* N} {x : G} : x ∈ K.comap f ↔ f x ∈ K := iff.rfl
 
+@[simp, to_additive]
+lemma comap_mono {f : G →* H} {K K' : subgroup H} : K ≤ K' → comap f K ≤ comap f K' :=
+preimage_mono
+
 @[to_additive]
 lemma comap_comap (K : subgroup P) (g : N →* P) (f : G →* N) :
   (K.comap g).comap f = K.comap (g.comp f) :=
@@ -676,6 +680,10 @@ lemma coe_map (f : G →* N) (K : subgroup G) :
 lemma mem_map {f : G →* N} {K : subgroup G} {y : N} :
   y ∈ K.map f ↔ ∃ x ∈ K, f x = y :=
 mem_image_iff_bex
+
+@[simp, to_additive]
+lemma map_mono {f : G →* H} {K K' : subgroup G} : K ≤ K' → map f K ≤ map f K' :=
+image_subset _
 
 @[to_additive]
 lemma map_map (g : N →* P) (f : G →* N) : (K.map f).map g = K.map (g.comp f) :=

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1203,19 +1203,34 @@ open monoid_hom
 variables {H : Type*} [group H] {f : G →* H}
 
 lemma map_le_range {K : subgroup G} : map f K ≤ f.range :=
-(monoid_hom.range_eq_map f).symm ▸ map_mono le_top
+(range_eq_map f).symm ▸ map_mono le_top
+
+lemma ker_le_comap {K : subgroup H} : f.ker ≤ comap f K :=
+comap_mono bot_le
 
 variable (f)
 lemma map_comap_le (K : subgroup H) : map f (comap f K) ≤ K :=
 (gc_map_comap f).l_u_le _
 
+lemma le_comap_map (K : subgroup G) : K ≤ comap f (map f K) :=
+(gc_map_comap f).le_u_l _
+
 lemma map_comap_eq (K : subgroup H) :
   map f (comap f K) = f.range ⊓ K :=
-le_antisymm (le_inf map_le_range $ map_comap_le _ _) $
-λ x hx, begin
-  simp only [exists_prop, mem_map, mem_comap],
-  rcases mem_range.mp (mem_inf.mp hx).1 with ⟨y, rfl⟩,
-  use [y, (mem_inf.mp hx).2],
+set_like.ext' begin
+  convert set.image_preimage_eq_inter_range,
+  simp [set.inter_comm],
+end
+
+lemma comap_map_eq (K : subgroup G) :
+  comap f (map f K) = K ⊔ f.ker :=
+begin
+  refine le_antisymm _ (sup_le (le_comap_map _ _) ker_le_comap),
+  intros x hx, simp only [exists_prop, mem_map, mem_comap] at hx,
+  rcases hx with ⟨y, hy, hy'⟩,
+  have : y⁻¹ * x ∈ f.ker, { rw mem_ker, simp [hy'] },
+  convert mul_mem _ (mem_sup_left hy) (mem_sup_right this),
+  simp,
 end
 
 end subgroup

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1253,6 +1253,10 @@ lemma map_comap_eq_self_of_surjective (h : function.surjective f) (K : subgroup 
 map_comap_eq_self ((range_top_of_surjective _ h).symm ▸ le_top)
 
 @[to_additive]
+lemma comap_injective (h : function.surjective f) : function.injective (comap f) :=
+λ K L hKL, by { apply_fun map f at hKL, simpa [map_comap_eq_self_of_surjective h] using hKL }
+
+@[to_additive]
 lemma comap_map_eq_self {K : subgroup G} (h : f.ker ≤ K) :
   comap f (map f K) = K :=
 by rwa [comap_map_eq, sup_eq_left]
@@ -1263,9 +1267,14 @@ lemma comap_map_eq_self_of_injective (h : function.injective f) (K : subgroup G)
 comap_map_eq_self (((ker_eq_bot_iff _).mpr h).symm ▸ bot_le)
 
 @[to_additive]
+lemma map_injective (h : function.injective f) : function.injective (map f) :=
+λ K L hKL, by { apply_fun comap f at hKL, simpa [comap_map_eq_self_of_injective h] using hKL }
+
+@[to_additive]
 lemma map_eq_comap_of_inverse {g : H →* G} (hl : function.left_inverse g f)
   (hr : function.right_inverse g f) (K : subgroup G) : map f K = comap g K :=
 set_like.ext' $ by rw [coe_map, coe_comap, set.image_eq_preimage_of_inverse hl hr]
+
 
 end subgroup
 
@@ -1537,8 +1546,7 @@ lemma is_simple_group_of_surjective {H : Type*} [group H] [is_simple_group G]
 ⟨nontrivial.exists_pair_ne, λ H iH, begin
   cases ((iH.comap f).eq_bot_or_eq_top),
   { left, rw [←map_bot f, ←h, map_comap_eq_self_of_surjective hf] },
-  right, rw [←comap_top f] at h,
-  rw [←map_comap_eq_self_of_surjective hf ⊤, ←h, map_comap_eq_self_of_surjective hf],
+  right, rw [←comap_top f] at h, exact comap_injective hf h,
 end⟩
 
 end is_simple_group

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1200,28 +1200,26 @@ namespace subgroup
 
 open monoid_hom
 
-variables {H : Type*} [group H] {f : G →* H}
+variables {H : Type*} [group H]
 
 @[to_additive]
-lemma map_le_range {K : subgroup G} : map f K ≤ f.range :=
+lemma map_le_range (f : G →* H) (K : subgroup G) : map f K ≤ f.range :=
 (range_eq_map f).symm ▸ map_mono le_top
 
 @[to_additive]
-lemma ker_le_comap {K : subgroup H} : f.ker ≤ comap f K :=
+lemma ker_le_comap (f : G →* H) (K : subgroup H) : f.ker ≤ comap f K :=
 comap_mono bot_le
 
-variable (f)
-
 @[to_additive]
-lemma map_comap_le (K : subgroup H) : map f (comap f K) ≤ K :=
+lemma map_comap_le (f : G →* H) (K : subgroup H) : map f (comap f K) ≤ K :=
 (gc_map_comap f).l_u_le _
 
 @[to_additive]
-lemma le_comap_map (K : subgroup G) : K ≤ comap f (map f K) :=
+lemma le_comap_map (f : G →* H) (K : subgroup G) : K ≤ comap f (map f K) :=
 (gc_map_comap f).le_u_l _
 
 @[to_additive]
-lemma map_comap_eq (K : subgroup H) :
+lemma map_comap_eq (f : G →* H) (K : subgroup H) :
   map f (comap f K) = f.range ⊓ K :=
 set_like.ext' begin
   convert set.image_preimage_eq_inter_range,
@@ -1229,10 +1227,10 @@ set_like.ext' begin
 end
 
 @[to_additive]
-lemma comap_map_eq (K : subgroup G) :
+lemma comap_map_eq (f : G →* H) (K : subgroup G) :
   comap f (map f K) = K ⊔ f.ker :=
 begin
-  refine le_antisymm _ (sup_le (le_comap_map _ _) ker_le_comap),
+  refine le_antisymm _ (sup_le (le_comap_map _ _) (ker_le_comap _ _)),
   intros x hx, simp only [exists_prop, mem_map, mem_comap] at hx,
   rcases hx with ⟨y, hy, hy'⟩,
   have : y⁻¹ * x ∈ f.ker, { rw mem_ker, simp [hy'] },
@@ -1240,38 +1238,36 @@ begin
   simp,
 end
 
-variable {f}
-
 @[to_additive]
-lemma map_comap_eq_self {K : subgroup H} (h : K ≤ f.range) :
+lemma map_comap_eq_self {f : G →* H} {K : subgroup H} (h : K ≤ f.range) :
   map f (comap f K) = K :=
 by rwa [map_comap_eq, inf_eq_right]
 
 @[to_additive]
-lemma map_comap_eq_self_of_surjective (h : function.surjective f) (K : subgroup H) :
+lemma map_comap_eq_self_of_surjective {f : G →* H} (h : function.surjective f) (K : subgroup H) :
   map f (comap f K) = K :=
 map_comap_eq_self ((range_top_of_surjective _ h).symm ▸ le_top)
 
 @[to_additive]
-lemma comap_injective (h : function.surjective f) : function.injective (comap f) :=
+lemma comap_injective {f : G →* H} (h : function.surjective f) : function.injective (comap f) :=
 λ K L hKL, by { apply_fun map f at hKL, simpa [map_comap_eq_self_of_surjective h] using hKL }
 
 @[to_additive]
-lemma comap_map_eq_self {K : subgroup G} (h : f.ker ≤ K) :
+lemma comap_map_eq_self {f : G →* H} {K : subgroup G} (h : f.ker ≤ K) :
   comap f (map f K) = K :=
 by rwa [comap_map_eq, sup_eq_left]
 
 @[to_additive]
-lemma comap_map_eq_self_of_injective (h : function.injective f) (K : subgroup G) :
+lemma comap_map_eq_self_of_injective {f : G →* H} (h : function.injective f) (K : subgroup G) :
   comap f (map f K) = K :=
 comap_map_eq_self (((ker_eq_bot_iff _).mpr h).symm ▸ bot_le)
 
 @[to_additive]
-lemma map_injective (h : function.injective f) : function.injective (map f) :=
+lemma map_injective {f : G →* H} (h : function.injective f) : function.injective (map f) :=
 λ K L hKL, by { apply_fun comap f at hKL, simpa [comap_map_eq_self_of_injective h] using hKL }
 
 @[to_additive]
-lemma map_eq_comap_of_inverse {g : H →* G} (hl : function.left_inverse g f)
+lemma map_eq_comap_of_inverse {f : G →* H} {g : H →* G} (hl : function.left_inverse g f)
   (hr : function.right_inverse g f) (K : subgroup G) : map f K = comap g K :=
 set_like.ext' $ by rw [coe_map, coe_comap, set.image_eq_preimage_of_inverse hl hr]
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -655,7 +655,7 @@ lemma coe_comap (K : subgroup N) (f : G →* N) : (K.comap f : set G) = f ⁻¹'
 @[simp, to_additive]
 lemma mem_comap {K : subgroup N} {f : G →* N} {x : G} : x ∈ K.comap f ↔ f x ∈ K := iff.rfl
 
-@[simp, to_additive]
+@[to_additive]
 lemma comap_mono {f : G →* N} {K K' : subgroup N} : K ≤ K' → comap f K ≤ comap f K' :=
 preimage_mono
 
@@ -681,7 +681,7 @@ lemma mem_map {f : G →* N} {K : subgroup G} {y : N} :
   y ∈ K.map f ↔ ∃ x ∈ K, f x = y :=
 mem_image_iff_bex
 
-@[simp, to_additive]
+@[to_additive]
 lemma map_mono {f : G →* N} {K K' : subgroup G} : K ≤ K' → map f K ≤ map f K' :=
 image_subset _
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -656,7 +656,7 @@ lemma coe_comap (K : subgroup N) (f : G →* N) : (K.comap f : set G) = f ⁻¹'
 lemma mem_comap {K : subgroup N} {f : G →* N} {x : G} : x ∈ K.comap f ↔ f x ∈ K := iff.rfl
 
 @[simp, to_additive]
-lemma comap_mono {f : G →* H} {K K' : subgroup H} : K ≤ K' → comap f K ≤ comap f K' :=
+lemma comap_mono {f : G →* N} {K K' : subgroup N} : K ≤ K' → comap f K ≤ comap f K' :=
 preimage_mono
 
 @[to_additive]
@@ -682,7 +682,7 @@ lemma mem_map {f : G →* N} {K : subgroup G} {y : N} :
 mem_image_iff_bex
 
 @[simp, to_additive]
-lemma map_mono {f : G →* H} {K K' : subgroup G} : K ≤ K' → map f K ≤ map f K' :=
+lemma map_mono {f : G →* N} {K K' : subgroup G} : K ≤ K' → map f K ≤ map f K' :=
 image_subset _
 
 @[to_additive]
@@ -1193,6 +1193,30 @@ end
 @[to_additive]
 lemma map_eq_bot_iff_of_injective {f : G →* N} (hf : function.injective f) : H.map f = ⊥ ↔ H = ⊥ :=
 by rw [map_eq_bot_iff, f.ker_eq_bot_iff.mpr hf, le_bot_iff]
+
+end subgroup
+
+namespace subgroup
+
+open monoid_hom
+
+variables {H : Type*} [group H] {f : G →* H}
+
+lemma map_le_range {K : subgroup G} : map f K ≤ f.range :=
+(monoid_hom.range_eq_map f).symm ▸ map_mono le_top
+
+variable (f)
+lemma map_comap_le (K : subgroup H) : map f (comap f K) ≤ K :=
+(gc_map_comap f).l_u_le _
+
+lemma map_comap_eq (K : subgroup H) :
+  map f (comap f K) = f.range ⊓ K :=
+le_antisymm (le_inf map_le_range $ map_comap_le _ _) $
+λ x hx, begin
+  simp only [exists_prop, mem_map, mem_comap],
+  rcases mem_range.mp (mem_inf.mp hx).1 with ⟨y, rfl⟩,
+  use [y, (mem_inf.mp hx).2],
+end
 
 end subgroup
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1248,7 +1248,7 @@ lemma map_comap_eq_self {K : subgroup H} (h : K ≤ f.range) :
 by rwa [map_comap_eq, inf_eq_right]
 
 @[to_additive]
-lemma map_comap_eq_self_of_surjective (h : function.surjective f) {K : subgroup H} :
+lemma map_comap_eq_self_of_surjective (h : function.surjective f) (K : subgroup H) :
   map f (comap f K) = K :=
 map_comap_eq_self ((range_top_of_surjective _ h).symm ▸ le_top)
 
@@ -1258,7 +1258,7 @@ lemma comap_map_eq_self {K : subgroup G} (h : f.ker ≤ K) :
 by rwa [comap_map_eq, sup_eq_left]
 
 @[to_additive]
-lemma comap_map_eq_self_of_injective (h : function.injective f) {K : subgroup G} :
+lemma comap_map_eq_self_of_injective (h : function.injective f) (K : subgroup G) :
   comap f (map f K) = K :=
 comap_map_eq_self (((ker_eq_bot_iff _).mpr h).symm ▸ bot_le)
 
@@ -1528,22 +1528,17 @@ instance {C : Type*} [comm_group C] [is_simple_group C] :
   is_simple_lattice (subgroup C) :=
 ⟨λ H, H.normal_of_comm.eq_bot_or_eq_top⟩
 
+open subgroup
+
 @[to_additive]
 lemma is_simple_group_of_surjective {H : Type*} [group H] [is_simple_group G]
   [nontrivial H] (f : G →* H) (hf : function.surjective f) :
   is_simple_group H :=
 ⟨nontrivial.exists_pair_ne, λ H iH, begin
-  refine ((iH.comap f).eq_bot_or_eq_top).imp (λ h, _) (λ h, _),
-  { rw subgroup.eq_bot_iff_forall at *,
-    simp_rw subgroup.mem_comap at h,
-    intros x hx,
-    obtain ⟨y, hy⟩ := hf x,
-    rw ← hy at hx,
-    rw h y hx at hy,
-    rw [← hy, f.map_one] },
-  { rw [← top_le_iff, ← subgroup.map_le_iff_le_comap, ← monoid_hom.range_eq_map,
-      monoid_hom.range_top_of_surjective f hf, top_le_iff] at h,
-    exact h }
+  cases ((iH.comap f).eq_bot_or_eq_top),
+  { left, rw [←map_bot f, ←h, map_comap_eq_self_of_surjective hf] },
+  right, rw [←comap_top f] at h,
+  rw [←map_comap_eq_self_of_surjective hf ⊤, ←h, map_comap_eq_self_of_surjective hf],
 end⟩
 
 end is_simple_group


### PR DESCRIPTION
Introduce the analogues of `linear_map.map_comap_eq` and `linear_map.comap_map_eq` to subgroups.
Also add `subgroup.map_eq_comap_of_inverse` which is a translation of `set.image_eq_preimage_of_inverse`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
