### PR TITLE
feat(tactic/noncomm_ring): expand out powers using `pow_succ`

### DIFF
--- a/src/tactic/noncomm_ring.lean
+++ b/src/tactic/noncomm_ring.lean
@@ -23,6 +23,9 @@ meta def noncomm_ring :=
              mul_assoc,
              -- Expand powers to numerals.
              pow_bit0, pow_bit1, pow_one,
+             -- Expand powers of add_one, preferring to multiply on the left,
+             -- and commuting multiplications on the right to the left across powers
+             pow_succ, ←pow_succ', pow_zero,
              -- Replace multiplication by numerals with `gsmul`.
              bit0_mul, mul_bit0, bit1_mul, mul_bit1, one_mul, mul_one, zero_mul, mul_zero,
              -- Pull `gsmul n` out the front so `abel` can see them.

--- a/test/noncomm_ring.lean
+++ b/test/noncomm_ring.lean
@@ -1,3 +1,4 @@
+import data.matrix.basic
 import tactic.noncomm_ring
 
 local notation `⁅`a`,` b`⁆` := a * b - b * a
@@ -53,3 +54,8 @@ example : ⁅a ⚬ b, c⁆ = a ⚬ ⁅b, c⁆ + ⁅a, c⁆ ⚬ b := by noncomm_r
 example : (a ⚬ b) ⚬ c - a ⚬ (b ⚬ c) = -⁅⁅a, b⁆, c⁆ + ⁅a, ⁅b, c⁆⁆ := by noncomm_ring
 
 example : a + -b = -b + a := by noncomm_ring
+
+variables {K ι : Type*} [comm_ring K] [fintype ι] [decidable_eq ι] (m : ℕ) (A : matrix ι ι K)
+
+example : 1 - A ^ m.succ = (1 - A) * A ^ m + (1 - A ^ m) := by noncomm_ring
+example : 1 - A ^ m.succ = A ^ m * 1 - A ^ m * A + (1 - A ^ m) := by noncomm_ring


### PR DESCRIPTION
Somehow, a previous commit broke `noncomm_ring`. This PR adds some more `pow_succ` power to it to revive it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/noncomm_ring.20regression