### PR TITLE
[Merged by Bors] - feat(data/finsupp,linear_algebra/finsupp): `finsupp`s and sum types

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1873,6 +1873,37 @@ lemma sum_arrow_equiv_prod_arrow_symm_inr {α β γ : Type*} [has_zero γ]
   (sum_arrow_equiv_prod_arrow.symm fg) (sum.inr y) = fg.2 y :=
 rfl
 
+variables [add_monoid M]
+
+/-- The additive equivalence between `(α ⊕ β) →₀ M` and `(α →₀ M) × (β →₀ M)`. -/
+@[simps apply symm_apply] def sum_arrow_add_equiv_prod_arrow {α β : Type*} :
+  ((α ⊕ β) →₀ M) ≃+ (α →₀ M) × (β →₀ M) :=
+{ map_add' :=
+    by { intros, ext;
+          simp only [equiv.to_fun_as_coe, prod.fst_add, prod.snd_add, add_apply,
+              snd_sum_arrow_equiv_prod_arrow, fst_sum_arrow_equiv_prod_arrow] },
+  .. sum_arrow_equiv_prod_arrow }
+
+lemma fst_sum_arrow_add_equiv_prod_arrow {α β : Type*}
+  (f : (α ⊕ β) →₀ M) (x : α) :
+  (sum_arrow_add_equiv_prod_arrow f).1 x = f (sum.inl x) :=
+rfl
+
+lemma snd_sum_arrow_add_equiv_prod_arrow {α β : Type*}
+  (f : (α ⊕ β) →₀ M) (y : β) :
+  (sum_arrow_add_equiv_prod_arrow f).2 y = f (sum.inr y) :=
+rfl
+
+lemma sum_arrow_add_equiv_prod_arrow_symm_inl {α β : Type*}
+  (fg : (α →₀ M) × (β →₀ M)) (x : α) :
+  (sum_arrow_add_equiv_prod_arrow.symm fg) (sum.inl x) = fg.1 x :=
+rfl
+
+lemma sum_arrow_add_equiv_prod_arrow_symm_inr {α β : Type*}
+  (fg : (α →₀ M) × (β →₀ M)) (y : β) :
+  (sum_arrow_add_equiv_prod_arrow.symm fg) (sum.inr y) = fg.2 y :=
+rfl
+
 end sum
 
 section

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1818,6 +1818,58 @@ end
 
 end curry_uncurry
 
+section sum
+
+/-- `finsupp.sum_elim f g` maps `inl x` to `f x` and `inr y` to `g y`. -/
+def sum_elim {α β γ : Type*} [has_zero γ]
+  (f : α →₀ γ) (g : β →₀ γ) : α ⊕ β →₀ γ :=
+on_finset
+  ((f.support.map ⟨_, sum.inl_injective⟩) ∪ g.support.map ⟨_, sum.inr_injective⟩)
+  (sum.elim f g)
+  (λ ab h, by { cases ab with a b; simp only [sum.elim_inl, sum.elim_inr] at h; simpa })
+
+@[simp] lemma sum_elim_apply {α β γ : Type*} [has_zero γ]
+  (f : α →₀ γ) (g : β →₀ γ) (x : α ⊕ β) : sum_elim f g x = sum.elim f g x := rfl
+
+lemma sum_elim_inl {α β γ : Type*} [has_zero γ]
+  (f : α →₀ γ) (g : β →₀ γ) (x : α) : sum_elim f g (sum.inl x) = f x := rfl
+
+lemma sum_elim_inr {α β γ : Type*} [has_zero γ]
+  (f : α →₀ γ) (g : β →₀ γ) (x : β) : sum_elim f g (sum.inr x) = g x := rfl
+
+/-- The equivalence between `(α ⊕ β) →₀ γ` and `(α →₀ γ) × (β →₀ γ)`. -/
+@[simps apply symm_apply]
+def sum_arrow_equiv_prod_arrow {α β γ : Type*} [has_zero γ] :
+  ((α ⊕ β) →₀ γ) ≃ (α →₀ γ) × (β →₀ γ) :=
+{ to_fun := λ f,
+    ⟨f.comap_domain sum.inl (sum.inl_injective.inj_on _),
+     f.comap_domain sum.inr (sum.inr_injective.inj_on _)⟩,
+  inv_fun := λ fg, sum_elim fg.1 fg.2,
+  left_inv := λ f, by { ext ab, cases ab with a b; simp },
+  right_inv := λ fg, by { ext; simp } }
+
+lemma fst_sum_arrow_equiv_prod_arrow {α β γ : Type*} [has_zero γ]
+  (f : (α ⊕ β) →₀ γ) (x : α) :
+  (sum_arrow_equiv_prod_arrow f).1 x = f (sum.inl x) :=
+rfl
+
+lemma snd_sum_arrow_equiv_prod_arrow {α β γ : Type*} [has_zero γ]
+  (f : (α ⊕ β) →₀ γ) (y : β) :
+  (sum_arrow_equiv_prod_arrow f).2 y = f (sum.inr y) :=
+rfl
+
+lemma sum_arrow_equiv_prod_arrow_symm_inl {α β γ : Type*} [has_zero γ]
+  (fg : (α →₀ γ) × (β →₀ γ)) (x : α) :
+  (sum_arrow_equiv_prod_arrow.symm fg) (sum.inl x) = fg.1 x :=
+rfl
+
+lemma sum_arrow_equiv_prod_arrow_symm_inr {α β γ : Type*} [has_zero γ]
+  (fg : (α →₀ γ) × (β →₀ γ)) (y : β) :
+  (sum_arrow_equiv_prod_arrow.symm fg) (sum.inr y) = fg.2 y :=
+rfl
+
+end sum
+
 section
 variables [group G] [mul_action G α] [add_comm_monoid M]
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1837,7 +1837,9 @@ lemma sum_elim_inl {α β γ : Type*} [has_zero γ]
 lemma sum_elim_inr {α β γ : Type*} [has_zero γ]
   (f : α →₀ γ) (g : β →₀ γ) (x : β) : sum_elim f g (sum.inr x) = g x := rfl
 
-/-- The equivalence between `(α ⊕ β) →₀ γ` and `(α →₀ γ) × (β →₀ γ)`. -/
+/-- The equivalence between `(α ⊕ β) →₀ γ` and `(α →₀ γ) × (β →₀ γ)`.
+
+This is the `finsupp` version of `equiv.sum_arrow_equiv_prod_arrow`. -/
 @[simps apply symm_apply]
 def sum_arrow_equiv_prod_arrow {α β γ : Type*} [has_zero γ] :
   ((α ⊕ β) →₀ γ) ≃ (α →₀ γ) × (β →₀ γ) :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1844,7 +1844,7 @@ lemma sum_elim_inr {α β γ : Type*} [has_zero γ]
 
 This is the `finsupp` version of `equiv.sum_arrow_equiv_prod_arrow`. -/
 @[simps apply symm_apply]
-def sum_arrow_equiv_prod_arrow {α β γ : Type*} [has_zero γ] :
+def sum_finsupp_equiv_prod_finsupp {α β γ : Type*} [has_zero γ] :
   ((α ⊕ β) →₀ γ) ≃ (α →₀ γ) × (β →₀ γ) :=
 { to_fun := λ f,
     ⟨f.comap_domain sum.inl (sum.inl_injective.inj_on _),
@@ -1853,55 +1853,57 @@ def sum_arrow_equiv_prod_arrow {α β γ : Type*} [has_zero γ] :
   left_inv := λ f, by { ext ab, cases ab with a b; simp },
   right_inv := λ fg, by { ext; simp } }
 
-lemma fst_sum_arrow_equiv_prod_arrow {α β γ : Type*} [has_zero γ]
+lemma fst_sum_finsupp_equiv_prod_finsupp {α β γ : Type*} [has_zero γ]
   (f : (α ⊕ β) →₀ γ) (x : α) :
-  (sum_arrow_equiv_prod_arrow f).1 x = f (sum.inl x) :=
+  (sum_finsupp_equiv_prod_finsupp f).1 x = f (sum.inl x) :=
 rfl
 
-lemma snd_sum_arrow_equiv_prod_arrow {α β γ : Type*} [has_zero γ]
+lemma snd_sum_finsupp_equiv_prod_finsupp {α β γ : Type*} [has_zero γ]
   (f : (α ⊕ β) →₀ γ) (y : β) :
-  (sum_arrow_equiv_prod_arrow f).2 y = f (sum.inr y) :=
+  (sum_finsupp_equiv_prod_finsupp f).2 y = f (sum.inr y) :=
 rfl
 
-lemma sum_arrow_equiv_prod_arrow_symm_inl {α β γ : Type*} [has_zero γ]
+lemma sum_finsupp_equiv_prod_finsupp_symm_inl {α β γ : Type*} [has_zero γ]
   (fg : (α →₀ γ) × (β →₀ γ)) (x : α) :
-  (sum_arrow_equiv_prod_arrow.symm fg) (sum.inl x) = fg.1 x :=
+  (sum_finsupp_equiv_prod_finsupp.symm fg) (sum.inl x) = fg.1 x :=
 rfl
 
-lemma sum_arrow_equiv_prod_arrow_symm_inr {α β γ : Type*} [has_zero γ]
+lemma sum_finsupp_equiv_prod_finsupp_symm_inr {α β γ : Type*} [has_zero γ]
   (fg : (α →₀ γ) × (β →₀ γ)) (y : β) :
-  (sum_arrow_equiv_prod_arrow.symm fg) (sum.inr y) = fg.2 y :=
+  (sum_finsupp_equiv_prod_finsupp.symm fg) (sum.inr y) = fg.2 y :=
 rfl
 
 variables [add_monoid M]
 
-/-- The additive equivalence between `(α ⊕ β) →₀ M` and `(α →₀ M) × (β →₀ M)`. -/
-@[simps apply symm_apply] def sum_arrow_add_equiv_prod_arrow {α β : Type*} :
+/-- The additive equivalence between `(α ⊕ β) →₀ M` and `(α →₀ M) × (β →₀ M)`.
+
+This is the `finsupp` version of `equiv.sum_arrow_equiv_prod_arrow`. -/
+@[simps apply symm_apply] def sum_finsupp_add_equiv_prod_finsupp {α β : Type*} :
   ((α ⊕ β) →₀ M) ≃+ (α →₀ M) × (β →₀ M) :=
 { map_add' :=
     by { intros, ext;
           simp only [equiv.to_fun_as_coe, prod.fst_add, prod.snd_add, add_apply,
-              snd_sum_arrow_equiv_prod_arrow, fst_sum_arrow_equiv_prod_arrow] },
-  .. sum_arrow_equiv_prod_arrow }
+              snd_sum_finsupp_equiv_prod_finsupp, fst_sum_finsupp_equiv_prod_finsupp] },
+  .. sum_finsupp_equiv_prod_finsupp }
 
-lemma fst_sum_arrow_add_equiv_prod_arrow {α β : Type*}
+lemma fst_sum_finsupp_add_equiv_prod_finsupp {α β : Type*}
   (f : (α ⊕ β) →₀ M) (x : α) :
-  (sum_arrow_add_equiv_prod_arrow f).1 x = f (sum.inl x) :=
+  (sum_finsupp_add_equiv_prod_finsupp f).1 x = f (sum.inl x) :=
 rfl
 
-lemma snd_sum_arrow_add_equiv_prod_arrow {α β : Type*}
+lemma snd_sum_finsupp_add_equiv_prod_finsupp {α β : Type*}
   (f : (α ⊕ β) →₀ M) (y : β) :
-  (sum_arrow_add_equiv_prod_arrow f).2 y = f (sum.inr y) :=
+  (sum_finsupp_add_equiv_prod_finsupp f).2 y = f (sum.inr y) :=
 rfl
 
-lemma sum_arrow_add_equiv_prod_arrow_symm_inl {α β : Type*}
+lemma sum_finsupp_add_equiv_prod_finsupp_symm_inl {α β : Type*}
   (fg : (α →₀ M) × (β →₀ M)) (x : α) :
-  (sum_arrow_add_equiv_prod_arrow.symm fg) (sum.inl x) = fg.1 x :=
+  (sum_finsupp_add_equiv_prod_finsupp.symm fg) (sum.inl x) = fg.1 x :=
 rfl
 
-lemma sum_arrow_add_equiv_prod_arrow_symm_inr {α β : Type*}
+lemma sum_finsupp_add_equiv_prod_finsupp_symm_inr {α β : Type*}
   (fg : (α →₀ M) × (β →₀ M)) (y : β) :
-  (sum_arrow_add_equiv_prod_arrow.symm fg) (sum.inr y) = fg.2 y :=
+  (sum_finsupp_add_equiv_prod_finsupp.symm fg) (sum.inr y) = fg.2 y :=
 rfl
 
 end sum

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1828,7 +1828,10 @@ on_finset
   (sum.elim f g)
   (λ ab h, by { cases ab with a b; simp only [sum.elim_inl, sum.elim_inr] at h; simpa })
 
-@[simp] lemma sum_elim_apply {α β γ : Type*} [has_zero γ]
+@[simp] lemma coe_sum_elim {α β γ : Type*} [has_zero γ]
+  (f : α →₀ γ) (g : β →₀ γ) : ⇑(sum_elim f g) = sum.elim f g := rfl
+  
+lemma sum_elim_apply {α β γ : Type*} [has_zero γ]
   (f : α →₀ γ) (g : β →₀ γ) (x : α ⊕ β) : sum_elim f g x = sum.elim f g x := rfl
 
 lemma sum_elim_inl {α β γ : Type*} [has_zero γ]

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -646,6 +646,45 @@ begin
     split_ifs; simp, },
 end
 
+section sum
+
+variables (R)
+
+/-- The linear equivalence between `(α ⊕ β) →₀ M` and `(α →₀ M) × (β →₀ M)`. -/
+@[simps apply symm_apply] def sum_arrow_lequiv_prod_arrow {α β : Type*} :
+  ((α ⊕ β) →₀ M) ≃ₗ[R] (α →₀ M) × (β →₀ M) :=
+{ map_add' :=
+    by { intros, ext;
+          simp only [equiv.to_fun_as_coe, prod.fst_add, prod.snd_add, add_apply,
+              snd_sum_arrow_equiv_prod_arrow, fst_sum_arrow_equiv_prod_arrow] },
+  map_smul' :=
+    by { intros, ext;
+          simp only [equiv.to_fun_as_coe, prod.smul_fst, prod.smul_snd, smul_apply,
+              snd_sum_arrow_equiv_prod_arrow, fst_sum_arrow_equiv_prod_arrow] },
+  .. sum_arrow_equiv_prod_arrow }
+
+lemma fst_sum_arrow_lequiv_prod_arrow {α β : Type*}
+  (f : (α ⊕ β) →₀ M) (x : α) :
+  (sum_arrow_lequiv_prod_arrow R f).1 x = f (sum.inl x) :=
+rfl
+
+lemma snd_sum_arrow_lequiv_prod_arrow {α β : Type*}
+  (f : (α ⊕ β) →₀ M) (y : β) :
+  (sum_arrow_lequiv_prod_arrow R f).2 y = f (sum.inr y) :=
+rfl
+
+lemma sum_arrow_lequiv_prod_arrow_symm_inl {α β : Type*}
+  (fg : (α →₀ M) × (β →₀ M)) (x : α) :
+  ((sum_arrow_lequiv_prod_arrow R).symm fg) (sum.inl x) = fg.1 x :=
+rfl
+
+lemma sum_arrow_lequiv_prod_arrow_symm_inr {α β : Type*}
+  (fg : (α →₀ M) × (β →₀ M)) (y : β) :
+  ((sum_arrow_lequiv_prod_arrow R).symm fg) (sum.inr y) = fg.2 y :=
+rfl
+
+end sum
+
 end finsupp
 
 variables {R : Type*} {M : Type*} {N : Type*}

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -657,9 +657,9 @@ This is the `linear_equiv` version of `finsupp.sum_finsupp_equiv_prod_finsupp`. 
   ((α ⊕ β) →₀ M) ≃ₗ[R] (α →₀ M) × (β →₀ M) :=
 { map_smul' :=
     by { intros, ext;
-          simp only [equiv.to_fun_as_coe, prod.smul_fst, prod.smul_snd, smul_apply,
-              snd_sum_arrow_equiv_prod_arrow, fst_sum_arrow_equiv_prod_arrow] },
-  .. sum_arrow_add_equiv_prod_arrow }
+          simp only [add_equiv.to_fun_eq_coe, prod.smul_fst, prod.smul_snd, smul_apply,
+              snd_sum_finsupp_add_equiv_prod_finsupp, fst_sum_finsupp_add_equiv_prod_finsupp] },
+  .. sum_finsupp_add_equiv_prod_finsupp }
 
 lemma fst_sum_finsupp_lequiv_prod_finsupp {α β : Type*}
   (f : (α ⊕ β) →₀ M) (x : α) :

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -655,15 +655,11 @@ variables (R)
 This is the `linear_equiv` version of `finsupp.sum_arrow_equiv_prod_arrow`. -/
 @[simps apply symm_apply] def sum_arrow_lequiv_prod_arrow {α β : Type*} :
   ((α ⊕ β) →₀ M) ≃ₗ[R] (α →₀ M) × (β →₀ M) :=
-{ map_add' :=
-    by { intros, ext;
-          simp only [equiv.to_fun_as_coe, prod.fst_add, prod.snd_add, add_apply,
-              snd_sum_arrow_equiv_prod_arrow, fst_sum_arrow_equiv_prod_arrow] },
-  map_smul' :=
+{ map_smul' :=
     by { intros, ext;
           simp only [equiv.to_fun_as_coe, prod.smul_fst, prod.smul_snd, smul_apply,
               snd_sum_arrow_equiv_prod_arrow, fst_sum_arrow_equiv_prod_arrow] },
-  .. sum_arrow_equiv_prod_arrow }
+  .. sum_arrow_add_equiv_prod_arrow }
 
 lemma fst_sum_arrow_lequiv_prod_arrow {α β : Type*}
   (f : (α ⊕ β) →₀ M) (x : α) :

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -652,8 +652,8 @@ variables (R)
 
 /-- The linear equivalence between `(α ⊕ β) →₀ M` and `(α →₀ M) × (β →₀ M)`.
 
-This is the `linear_equiv` version of `finsupp.sum_arrow_equiv_prod_arrow`. -/
-@[simps apply symm_apply] def sum_arrow_lequiv_prod_arrow {α β : Type*} :
+This is the `linear_equiv` version of `finsupp.sum_finsupp_equiv_prod_finsupp`. -/
+@[simps apply symm_apply] def sum_finsupp_lequiv_prod_finsupp {α β : Type*} :
   ((α ⊕ β) →₀ M) ≃ₗ[R] (α →₀ M) × (β →₀ M) :=
 { map_smul' :=
     by { intros, ext;
@@ -661,24 +661,24 @@ This is the `linear_equiv` version of `finsupp.sum_arrow_equiv_prod_arrow`. -/
               snd_sum_arrow_equiv_prod_arrow, fst_sum_arrow_equiv_prod_arrow] },
   .. sum_arrow_add_equiv_prod_arrow }
 
-lemma fst_sum_arrow_lequiv_prod_arrow {α β : Type*}
+lemma fst_sum_finsupp_lequiv_prod_finsupp {α β : Type*}
   (f : (α ⊕ β) →₀ M) (x : α) :
-  (sum_arrow_lequiv_prod_arrow R f).1 x = f (sum.inl x) :=
+  (sum_finsupp_lequiv_prod_finsupp R f).1 x = f (sum.inl x) :=
 rfl
 
-lemma snd_sum_arrow_lequiv_prod_arrow {α β : Type*}
+lemma snd_sum_finsupp_lequiv_prod_finsupp {α β : Type*}
   (f : (α ⊕ β) →₀ M) (y : β) :
-  (sum_arrow_lequiv_prod_arrow R f).2 y = f (sum.inr y) :=
+  (sum_finsupp_lequiv_prod_finsupp R f).2 y = f (sum.inr y) :=
 rfl
 
-lemma sum_arrow_lequiv_prod_arrow_symm_inl {α β : Type*}
+lemma sum_finsupp_lequiv_prod_finsupp_symm_inl {α β : Type*}
   (fg : (α →₀ M) × (β →₀ M)) (x : α) :
-  ((sum_arrow_lequiv_prod_arrow R).symm fg) (sum.inl x) = fg.1 x :=
+  ((sum_finsupp_lequiv_prod_finsupp R).symm fg) (sum.inl x) = fg.1 x :=
 rfl
 
-lemma sum_arrow_lequiv_prod_arrow_symm_inr {α β : Type*}
+lemma sum_finsupp_lequiv_prod_finsupp_symm_inr {α β : Type*}
   (fg : (α →₀ M) × (β →₀ M)) (y : β) :
-  ((sum_arrow_lequiv_prod_arrow R).symm fg) (sum.inr y) = fg.2 y :=
+  ((sum_finsupp_lequiv_prod_finsupp R).symm fg) (sum.inr y) = fg.2 y :=
 rfl
 
 end sum

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -650,7 +650,9 @@ section sum
 
 variables (R)
 
-/-- The linear equivalence between `(α ⊕ β) →₀ M` and `(α →₀ M) × (β →₀ M)`. -/
+/-- The linear equivalence between `(α ⊕ β) →₀ M` and `(α →₀ M) × (β →₀ M)`.
+
+This is the `linear_equiv` version of `finsupp.sum_arrow_equiv_prod_arrow`. -/
 @[simps apply symm_apply] def sum_arrow_lequiv_prod_arrow {α β : Type*} :
   ((α ⊕ β) →₀ M) ≃ₗ[R] (α →₀ M) × (β →₀ M) :=
 { map_add' :=


### PR DESCRIPTION
This PR contains a few definitions relating sum types and `finsupp`. The main result is `finsupp.sum_arrow_equiv_prod_arrow`, a `finsupp` version of `equiv.sum_arrow_equiv_prod_arrow`. This is turned into a `linear_equiv` by `finsupp.sum_arrow_lequiv_prod_arrow`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
