### PR TITLE
[Merged by Bors] - feat(linear_algebra/free_module): a set of linearly independent vectors over a ring S is also linearly independent over a subring R of S

### DIFF
--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -335,3 +335,14 @@ lemma submodule.exists_is_basis_of_le_span
 submodule.exists_is_basis_of_le le (is_basis_span hb)
 
 end principal_ideal_domain
+
+lemma algebra_map.injective.linear_independent {R S M ι : Type*} [comm_semiring R] [semiring S]
+  [add_comm_monoid M] [algebra R S] [semimodule R M] [semimodule S M] [is_scalar_tower R S M]
+  (hinj : function.injective (algebra_map R S)) {v : ι → M} (li : linear_independent S v) :
+  linear_independent R v :=
+begin
+  refine linear_independent_iff'.mpr (λ s g hg i hi, hinj (eq.trans _ (ring_hom.map_zero _).symm)),
+  refine (((@linear_independent_iff' _ _ _ v _ _ _).mp li) _ _ _) i hi,
+  simp_rw algebra_map_smul,
+  exact hg,
+end

--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -336,13 +336,20 @@ submodule.exists_is_basis_of_le le (is_basis_span hb)
 
 end principal_ideal_domain
 
-lemma linear_independent.restrict_scalars {R S M ι : Type*} [comm_semiring R] [semiring S]
+lemma linear_independent.restrict_scalars {R S M ι : Type*} [semiring R] [semiring S]
+  [add_comm_monoid M] [smul_with_zero R S] [semimodule R M] [semimodule S M] [is_scalar_tower R S M]
+  (hinj : function.injective (λ r : R, r • (1 : S))) {v : ι → M} (li : linear_independent S v) :
+  linear_independent R v :=
+begin
+  refine linear_independent_iff'.mpr (λ s g hg i hi, hinj (eq.trans _ (zero_smul _ _).symm)),
+  refine (linear_independent_iff'.mp li : _) _ _ _ i hi,
+  simp_rw [smul_assoc, one_smul],
+  exact hg,
+end
+
+lemma linear_independent.restrict_scalars_algebras {R S M ι : Type*} [comm_semiring R] [semiring S]
   [add_comm_monoid M] [algebra R S] [semimodule R M] [semimodule S M] [is_scalar_tower R S M]
   (hinj : function.injective (algebra_map R S)) {v : ι → M} (li : linear_independent S v) :
   linear_independent R v :=
-begin
-  refine linear_independent_iff'.mpr (λ s g hg i hi, hinj (eq.trans _ (ring_hom.map_zero _).symm)),
-  refine (linear_independent_iff'.mp li : _) _ _ _ i hi,
-  simp_rw algebra_map_smul,
-  exact hg,
-end
+linear_independent.restrict_scalars (λ x y xy, hinj ((algebra.algebra_map_eq_smul_one _).trans
+  (xy.trans (algebra.algebra_map_eq_smul_one _).symm))) li

--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -336,7 +336,7 @@ submodule.exists_is_basis_of_le le (is_basis_span hb)
 
 end principal_ideal_domain
 
-lemma algebra_map.injective.linear_independent {R S M ι : Type*} [comm_semiring R] [semiring S]
+lemma linear_independent.restrict_scalars {R S M ι : Type*} [comm_semiring R] [semiring S]
   [add_comm_monoid M] [algebra R S] [semimodule R M] [semimodule S M] [is_scalar_tower R S M]
   (hinj : function.injective (algebra_map R S)) {v : ι → M} (li : linear_independent S v) :
   linear_independent R v :=

--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -351,5 +351,4 @@ lemma linear_independent.restrict_scalars_algebras {R S M ι : Type*} [comm_semi
   [add_comm_monoid M] [algebra R S] [semimodule R M] [semimodule S M] [is_scalar_tower R S M]
   (hinj : function.injective (algebra_map R S)) {v : ι → M} (li : linear_independent S v) :
   linear_independent R v :=
-linear_independent.restrict_scalars (λ x y xy, hinj ((algebra.algebra_map_eq_smul_one _).trans
-  (xy.trans (algebra.algebra_map_eq_smul_one _).symm))) li
+linear_independent.restrict_scalars (by rwa algebra.algebra_map_eq_smul_one' at hinj) li

--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -336,6 +336,8 @@ submodule.exists_is_basis_of_le le (is_basis_span hb)
 
 end principal_ideal_domain
 
+/-- A set of linearly independent vectors in a module `M` over a semiring `S` is also linearly
+independent over a subring `R` of `K`. -/
 lemma linear_independent.restrict_scalars_algebras {R S M ι : Type*} [comm_semiring R] [semiring S]
   [add_comm_monoid M] [algebra R S] [semimodule R M] [semimodule S M] [is_scalar_tower R S M]
   (hinj : function.injective (algebra_map R S)) {v : ι → M} (li : linear_independent S v) :

--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -336,17 +336,6 @@ submodule.exists_is_basis_of_le le (is_basis_span hb)
 
 end principal_ideal_domain
 
-lemma linear_independent.restrict_scalars {R S M ι : Type*} [semiring R] [semiring S]
-  [add_comm_monoid M] [smul_with_zero R S] [semimodule R M] [semimodule S M] [is_scalar_tower R S M]
-  (hinj : function.injective (λ r : R, r • (1 : S))) {v : ι → M} (li : linear_independent S v) :
-  linear_independent R v :=
-begin
-  refine linear_independent_iff'.mpr (λ s g hg i hi, hinj (eq.trans _ (zero_smul _ _).symm)),
-  refine (linear_independent_iff'.mp li : _) _ _ _ i hi,
-  simp_rw [smul_assoc, one_smul],
-  exact hg,
-end
-
 lemma linear_independent.restrict_scalars_algebras {R S M ι : Type*} [comm_semiring R] [semiring S]
   [add_comm_monoid M] [algebra R S] [semimodule R M] [semimodule S M] [is_scalar_tower R S M]
   (hinj : function.injective (algebra_map R S)) {v : ι → M} (li : linear_independent S v) :

--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -342,7 +342,7 @@ lemma linear_independent.restrict_scalars {R S M ι : Type*} [comm_semiring R] [
   linear_independent R v :=
 begin
   refine linear_independent_iff'.mpr (λ s g hg i hi, hinj (eq.trans _ (ring_hom.map_zero _).symm)),
-  refine (((@linear_independent_iff' _ _ _ v _ _ _).mp li) _ _ _) i hi,
+  refine (linear_independent_iff'.mp li : _) _ _ _ i hi,
   simp_rw algebra_map_smul,
   exact hg,
 end

--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -354,6 +354,17 @@ lemma linear_independent_bUnion_of_directed {η} {s : set η} {t : η → set M}
 by rw bUnion_eq_Union; exact
 linear_independent_Union_of_directed (directed_comp.2 $ hs.directed_coe) (by simpa using h)
 
+lemma linear_independent.restrict_scalars [semiring K] [smul_with_zero R K] [semimodule K M]
+  [is_scalar_tower R K M]
+  (hinj : function.injective (λ r : R, r • (1 : K))) (li : linear_independent K v) :
+  linear_independent R v :=
+begin
+  refine linear_independent_iff'.mpr (λ s g hg i hi, hinj (eq.trans _ (zero_smul _ _).symm)),
+  refine (linear_independent_iff'.mp li : _) _ _ _ i hi,
+  simp_rw [smul_assoc, one_smul],
+  exact hg,
+end
+
 end subtype
 
 end semimodule
@@ -984,14 +995,3 @@ have finite s, from u.finite_to_set.subset hsu,
 ⟨this, by rw [←eq]; exact (finset.card_le_of_subset $ finset.coe_subset.mp $ by simp [hsu])⟩
 
 end vector_space
-
-lemma linear_independent.restrict_scalars {R S M ι : Type*} [semiring R] [semiring S]
-  [add_comm_monoid M] [smul_with_zero R S] [semimodule R M] [semimodule S M] [is_scalar_tower R S M]
-  (hinj : function.injective (λ r : R, r • (1 : S))) {v : ι → M} (li : linear_independent S v) :
-  linear_independent R v :=
-begin
-  refine linear_independent_iff'.mpr (λ s g hg i hi, hinj (eq.trans _ (zero_smul _ _).symm)),
-  refine (linear_independent_iff'.mp li : _) _ _ _ i hi,
-  simp_rw [smul_assoc, one_smul],
-  exact hg,
-end

--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -260,6 +260,22 @@ begin
   simpa only [this, zero_smul, zero_add] using total_eq
 end
 
+/-- A set of linearly independent vectors in a semimodule `M` over a semiring `K` is also linearly
+independent over a subring `R` of `K`.
+The implementation uses minimal assumptions about the relationship between `R`, `K` and `M`.
+The version where `K` is an `R`-algebra is `linear_independent.restrict_scalars_algebras`.
+ -/
+lemma linear_independent.restrict_scalars [semiring K] [smul_with_zero R K] [semimodule K M]
+  [is_scalar_tower R K M]
+  (hinj : function.injective (λ r : R, r • (1 : K))) (li : linear_independent K v) :
+  linear_independent R v :=
+begin
+  refine linear_independent_iff'.mpr (λ s g hg i hi, hinj (eq.trans _ (zero_smul _ _).symm)),
+  refine (linear_independent_iff'.mp li : _) _ _ _ i hi,
+  simp_rw [smul_assoc, one_smul],
+  exact hg,
+end
+
 section subtype
 /-! The following lemmas use the subtype defined by a set in `M` as the index set `ι`. -/
 
@@ -353,22 +369,6 @@ lemma linear_independent_bUnion_of_directed {η} {s : set η} {t : η → set M}
   linear_independent R (λ x, x : (⋃a∈s, t a) → M) :=
 by rw bUnion_eq_Union; exact
 linear_independent_Union_of_directed (directed_comp.2 $ hs.directed_coe) (by simpa using h)
-
-/-- A set of linearly independent vectors in a semimodule `M` over a semiring `K` is also linearly
-independent over a subring `R` of `K`.
-The implementation uses minimal assumptions about the relationship between `R`, `K` and `M`.
-The version where `K` is an `R`-algebra is `linear_independent.restrict_scalars_algebras`.
- -/
-lemma linear_independent.restrict_scalars [semiring K] [smul_with_zero R K] [semimodule K M]
-  [is_scalar_tower R K M]
-  (hinj : function.injective (λ r : R, r • (1 : K))) (li : linear_independent K v) :
-  linear_independent R v :=
-begin
-  refine linear_independent_iff'.mpr (λ s g hg i hi, hinj (eq.trans _ (zero_smul _ _).symm)),
-  refine (linear_independent_iff'.mp li : _) _ _ _ i hi,
-  simp_rw [smul_assoc, one_smul],
-  exact hg,
-end
 
 end subtype
 

--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -984,3 +984,14 @@ have finite s, from u.finite_to_set.subset hsu,
 ⟨this, by rw [←eq]; exact (finset.card_le_of_subset $ finset.coe_subset.mp $ by simp [hsu])⟩
 
 end vector_space
+
+lemma linear_independent.restrict_scalars {R S M ι : Type*} [semiring R] [semiring S]
+  [add_comm_monoid M] [smul_with_zero R S] [semimodule R M] [semimodule S M] [is_scalar_tower R S M]
+  (hinj : function.injective (λ r : R, r • (1 : S))) {v : ι → M} (li : linear_independent S v) :
+  linear_independent R v :=
+begin
+  refine linear_independent_iff'.mpr (λ s g hg i hi, hinj (eq.trans _ (zero_smul _ _).symm)),
+  refine (linear_independent_iff'.mp li : _) _ _ _ i hi,
+  simp_rw [smul_assoc, one_smul],
+  exact hg,
+end

--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -354,6 +354,11 @@ lemma linear_independent_bUnion_of_directed {η} {s : set η} {t : η → set M}
 by rw bUnion_eq_Union; exact
 linear_independent_Union_of_directed (directed_comp.2 $ hs.directed_coe) (by simpa using h)
 
+/-- A set of linearly independent vectors in a semimodule `M` over a semiring `K` is also linearly
+independent over a subring `R` of `K`.
+The implementation uses minimal assumptions about the relationship between `R`, `K` and `M`.
+The version where `K` is an `R`-algebra is `linear_independent.restrict_scalars_algebras`.
+ -/
 lemma linear_independent.restrict_scalars [semiring K] [smul_with_zero R K] [semimodule K M]
   [is_scalar_tower R K M]
   (hinj : function.injective (λ r : R, r • (1 : K))) (li : linear_independent K v) :


### PR DESCRIPTION


Zulip:
https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/.60algebra_map.2Einjective.2Elinear_independent.60



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
