### PR TITLE
[Merged by Bors] - feat(category_theory): equivalences preserve epis and monos

### DIFF
--- a/src/category_theory/epi_mono.lean
+++ b/src/category_theory/epi_mono.lean
@@ -40,6 +40,22 @@ begin
     cancel_mono, equiv.apply_eq_iff_eq] at H
 end
 
+instance equivalence.epi_functor {e : C ≌ D} {X Y : C} {f : X ⟶ Y} [h : epi f] :
+  epi (e.functor.map f) :=
+left_adjoint_preserves_epi e.to_adjunction h
+
+instance equivalence.epi_inverse {e : C ≌ D} {X Y : D} {f : X ⟶ Y} [h : epi f] :
+  epi (e.inverse.map f) :=
+left_adjoint_preserves_epi e.symm.to_adjunction h
+
+instance equivalence.mono_functor {e : C ≌ D} {X Y : C} {f : X ⟶ Y} [h : mono f] :
+  mono (e.functor.map f) :=
+right_adjoint_preserves_mono e.symm.to_adjunction h
+
+instance equivalence.mono_inverse {e : C ≌ D} {X Y : D} {f : X ⟶ Y} [h : mono f] :
+  mono (e.inverse.map f) :=
+right_adjoint_preserves_mono e.to_adjunction h
+
 lemma faithful_reflects_epi (F : C ⥤ D) [faithful F] {X Y : C} {f : X ⟶ Y}
   (hf : epi (F.map f)) : epi f :=
 ⟨λ Z g h H, F.map_injective $

--- a/src/category_theory/epi_mono.lean
+++ b/src/category_theory/epi_mono.lean
@@ -40,21 +40,13 @@ begin
     cancel_mono, equiv.apply_eq_iff_eq] at H
 end
 
-instance equivalence.epi_functor {e : C ≌ D} {X Y : C} {f : X ⟶ Y} [h : epi f] :
-  epi (e.functor.map f) :=
-left_adjoint_preserves_epi e.to_adjunction h
+instance is_equivalence.epi_map {F : C ⥤ D} [is_equivalence F] {X Y : C} {f : X ⟶ Y} [h : epi f] :
+  epi (F.map f) :=
+left_adjoint_preserves_epi F.as_equivalence.to_adjunction h
 
-instance equivalence.epi_inverse {e : C ≌ D} {X Y : D} {f : X ⟶ Y} [h : epi f] :
-  epi (e.inverse.map f) :=
-left_adjoint_preserves_epi e.symm.to_adjunction h
-
-instance equivalence.mono_functor {e : C ≌ D} {X Y : C} {f : X ⟶ Y} [h : mono f] :
-  mono (e.functor.map f) :=
-right_adjoint_preserves_mono e.symm.to_adjunction h
-
-instance equivalence.mono_inverse {e : C ≌ D} {X Y : D} {f : X ⟶ Y} [h : mono f] :
-  mono (e.inverse.map f) :=
-right_adjoint_preserves_mono e.to_adjunction h
+instance is_equivalence.mono_map {F : C ⥤ D} [is_equivalence F] {X Y : C} {f : X ⟶ Y} [h : mono f] :
+  mono (F.map f) :=
+right_adjoint_preserves_mono F.as_equivalence.symm.to_adjunction h
 
 lemma faithful_reflects_epi (F : C ⥤ D) [faithful F] {X Y : C} {f : X ⟶ Y}
   (hf : epi (F.map f)) : epi f :=

--- a/src/category_theory/epi_mono.lean
+++ b/src/category_theory/epi_mono.lean
@@ -40,13 +40,13 @@ begin
     cancel_mono, equiv.apply_eq_iff_eq] at H
 end
 
-instance is_equivalence.epi_map {F : C ⥤ D} [is_equivalence F] {X Y : C} {f : X ⟶ Y} [h : epi f] :
-  epi (F.map f) :=
-left_adjoint_preserves_epi F.as_equivalence.to_adjunction h
+instance is_equivalence.epi_map {F : C ⥤ D} [is_left_adjoint F] {X Y : C} {f : X ⟶ Y}
+  [h : epi f] : epi (F.map f) :=
+left_adjoint_preserves_epi (adjunction.of_left_adjoint F) h
 
-instance is_equivalence.mono_map {F : C ⥤ D} [is_equivalence F] {X Y : C} {f : X ⟶ Y} [h : mono f] :
-  mono (F.map f) :=
-right_adjoint_preserves_mono F.as_equivalence.symm.to_adjunction h
+instance is_equivalence.mono_map {F : C ⥤ D} [is_right_adjoint F] {X Y : C} {f : X ⟶ Y}
+  [h : mono f] : mono (F.map f) :=
+right_adjoint_preserves_mono (adjunction.of_right_adjoint F) h
 
 lemma faithful_reflects_epi (F : C ⥤ D) [faithful F] {X Y : C} {f : X ⟶ Y}
   (hf : epi (F.map f)) : epi f :=


### PR DESCRIPTION
Note that these don't follow from the results in `limits/constructions/epi_mono.lean`, since the results in that file are less universe polymorphic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
