### PR TITLE
[Merged by Bors] - feat(tactic/simps): trace with @[simps?]

### DIFF
--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -323,6 +323,9 @@ meta def simps_get_projection_exprs (e : environment) (tgt : expr)
     recursively apply projections. For example, given an equivalence `α × β ≃ β × α` one usually
     wants to only apply the projections for `equiv`, and not also those for `×`. This option is
     only relevant if no explicit projection names are given as argument to `@[simps]`.
+  * The option `trace` is set to `tt` when you write `@[simps?]`. In this case, the attribute will
+    print all generated lemmas. It is almost the same as setting the option `trace.simps.verbose`,
+    except that it doesn't print information about the found projections.
 -/
 @[derive [has_reflect, inhabited]] structure simps_cfg :=
 (attrs         := [`simp])

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -32,7 +32,7 @@ There are three attributes being defined here
 structures, projections, simp, simplifier, generates declarations
 -/
 
-open tactic expr option
+open option tactic expr
 
 setup_tactic_parser
 declare_trace simps.verbose

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -32,7 +32,7 @@ There are three attributes being defined here
 structures, projections, simp, simplifier, generates declarations
 -/
 
-open tactic expr
+open tactic expr option
 
 setup_tactic_parser
 declare_trace simps.verbose
@@ -112,7 +112,7 @@ attribute [notation_class* coe_fn] has_coe_to_fun
   def equiv.simps.inv_fun {α β} (e : α ≃ β) : β → α := e.symm
 ```
 
-  Optionally, this command accepts two optional arguments
+  Optionally, this command accepts three optional arguments
   * If `trace_if_exists` the command will always generate a trace message when the structure already
     has the attribute `@[_simps_str]`.
   * The `name_changes` argument accepts a list of pairs `(old_name, new_name)`. This is used to
@@ -120,11 +120,14 @@ attribute [notation_class* coe_fn] has_coe_to_fun
     for the structure `equiv` the projection `to_fun` could be renamed `apply`. This name will be
     used for parsing and generating projection names. This argument is ignored if the structure
     already has an existing attribute.
+  * if `trc` is true, this tactic will trace information.
 -/
 -- if performance becomes a problem, possible heuristic: use the names of the projections to
 -- skip all classes that don't have the corresponding field.
 meta def simps_get_raw_projections (e : environment) (str : name) (trace_if_exists : bool := ff)
-  (name_changes : list (name × name) := []) : tactic (list name × list (name × expr)) := do
+  (name_changes : list (name × name) := []) (trc := ff) :
+  tactic (list name × list (name × expr)) := do
+  let trc := trc || is_trace_enabled_for `simps.verbose,
   has_attr ← has_attribute' `_simps_str str,
   if has_attr then do
     data ← simps_str_attr.get_param str,
@@ -133,11 +136,11 @@ meta def simps_get_raw_projections (e : environment) (str : name) (trace_if_exis
     -- We always trace this when called by `initialize_simps_projections`,
     -- because this doesn't do anything extra (so should not occur in mathlib).
     -- It can be useful to find the projection names.
-    when (is_trace_enabled_for `simps.verbose || trace_if_exists) trace!
+    when (trc || trace_if_exists) trace!
       "[simps] > Already found projection information for structure {str}:\n        > {to_print}",
     return data
   else do
-    when_tracing `simps.verbose trace!
+    when trc trace!
       "[simps] > generating projection information for structure {str}:",
     d_str ← e.get str,
     projs ← e.structure_fields_full str,
@@ -149,7 +152,7 @@ meta def simps_get_raw_projections (e : environment) (str : name) (trace_if_exis
       custom_proj ← (do
         decl ← e.get (str ++ `simps ++ proj.last),
         let custom_proj := decl.value.instantiate_univ_params $ decl.univ_params.zip raw_levels,
-        when_tracing `simps.verbose trace!
+        when trc trace!
           "[simps] > found custom projection for {proj}:\n        > {custom_proj}",
         return custom_proj) <|> return raw_expr,
       is_def_eq custom_proj raw_expr <|>
@@ -194,7 +197,7 @@ Expected type:\n  {raw_expr_type}" },
         not been overrriden by the user. -/
       guard (projs.any (= relevant_proj) ∧ ¬ e.contains (str ++ `simps ++ relevant_proj.last)),
       let pos := projs.find_index (= relevant_proj),
-      when_tracing `simps.verbose trace!
+      when trc trace!
         "        > using {proj_nm} instead of the default projection {relevant_proj.last}.",
       return $ raw_exprs.update_nth pos lambda_raw_expr) <|> return raw_exprs) raw_exprs,
     proj_names ← e.structure_fields str,
@@ -202,7 +205,7 @@ Expected type:\n  {raw_expr_type}" },
     let proj_names : list name := proj_names.map $
       λ nm, (name_changes.find $ λ p : _ × _, p.1 = nm).elim nm prod.snd,
     let projs := proj_names.zip raw_exprs,
-    when_tracing `simps.verbose $ do {
+    when trc $ do {
       to_print ← projs.mmap $ λ s, to_string <$> pformat!"Projection {s.1}: {s.2}",
       let to_print := string.join $ to_print.intersperse "\n        > ",
       trace!"[simps] > generated projections for {str}:\n        > {to_print}" },
@@ -229,16 +232,16 @@ library_note "custom simps projection"
   You can specify custom names by writing e.g.
   `initialize_simps_projections equiv (to_fun → apply, inv_fun → symm_apply)`.
   Set `trace.simps.verbose` to true to see the generated projections.
-  If the projections were already specified before, you can call `initialize_simps_projections`
-  again to see the generated projections. -/
+  Run `initialize_simps_projections?` to see which projections are generated. -/
 @[user_command] meta def initialize_simps_projections_cmd
   (_ : parse $ tk "initialize_simps_projections") : parser unit := do
   env ← get_env,
+  trc ← is_some <$> (tk "?")?,
   ns ← (prod.mk <$> ident <*> (tk "(" >>
     sep_by (tk ",") (prod.mk <$> ident <*> (tk "->" >> ident)) <* tk ")")?)*,
   ns.mmap' $ λ data, do
     nm ← resolve_constant data.1,
-    simps_get_raw_projections env nm tt $ data.2.get_or_else []
+    simps_get_raw_projections env nm tt (data.2.get_or_else []) trc
 
 /--
   Get the projections of a structure used by `@[simps]` applied to the appropriate arguments.
@@ -276,7 +279,7 @@ meta def simps_get_projection_exprs (e : environment) (tgt : expr)
     <|> fail "unreachable code (1)",
   let str := tgt.get_app_fn.const_name,
   let rhs_args := (get_app_args rhs).drop params.length, -- the fields of the object
-  (raw_univs, projs_and_raw_exprs) ← simps_get_raw_projections e str,
+  (raw_univs, projs_and_raw_exprs) ← simps_get_raw_projections e str ff,
   guard (rhs_args.length = projs_and_raw_exprs.length) <|> fail "unreachable code (2)",
   let univs := raw_univs.zip tgt.get_app_fn.univ_levels,
   let projs := projs_and_raw_exprs.map $ prod.fst,
@@ -329,6 +332,7 @@ meta def simps_get_projection_exprs (e : environment) (tgt : expr)
 (rhs_md        := transparency.none)
 (fully_applied := tt)
 (not_recursive := [`prod, `pprod])
+(trace         := ff)
 
 /-- Add a lemma with `nm` stating that `lhs = rhs`. `type` is the type of both `lhs` and `rhs`,
   `args` is the list of local constants occurring, and `univs` is the list of universe variables.
@@ -352,7 +356,7 @@ meta def simps_add_projection (nm : name) (type lhs rhs : expr) (args : list exp
   let decl_type := eq_ap.pis args,
   let decl_value := prf.lambdas args,
   let decl := declaration.thm decl_name univs decl_type (pure decl_value),
-  when_tracing `simps.verbose trace!
+  when cfg.trace trace!
     "[simps] > adding projection {decl_name}:\n        > {decl_type}",
   decorate_error ("failed to add projection lemma " ++ decl_name.to_string ++ ". Nested error:") $
     add_decl decl,
@@ -441,7 +445,7 @@ Note: the projection names used by @[simps] might not correspond to the projecti
               ff cfg new_todo
     -- if I'm about to run into an error, try to set the transparency for `rhs_md` higher.
     else if cfg.rhs_md = transparency.none ∧ (must_be_str ∨ todo_next ≠ []) then do
-      when_tracing `simps.verbose trace!
+      when cfg.trace trace!
         "[simps] > The given definition is not a constructor application:
         >   {rhs_ap}
         > Retrying with the options {{ rhs_md := semireducible, simp_rhs := tt}.",
@@ -468,8 +472,9 @@ Projection {(todo_next.head.split_on '_').tail.head} doesn't exist, because targ
 
 /-- `simps_tac` derives simp-lemmas for all (nested) non-Prop projections of the declaration.
   If `todo` is non-empty, it will generate exactly the names in `todo`.
-  If `short_nm` is true, the generated names will only use the last projection name. -/
-meta def simps_tac (nm : name) (cfg : simps_cfg := {}) (todo : list string := []) :
+  If `short_nm` is true, the generated names will only use the last projection name.
+  If `trc` is true, trace as if `trace.simps.verbose` is true. -/
+meta def simps_tac (nm : name) (cfg : simps_cfg := {}) (todo : list string := []) (trc := ff) :
   tactic unit :=
 do
   e ← get_env,
@@ -478,13 +483,17 @@ do
   let todo := todo.erase_dup.map $ λ proj, "_" ++ proj,
   b ← has_attribute' `to_additive nm,
   let cfg := if b then { attrs := cfg.attrs ++ [`to_additive], ..cfg } else cfg,
+  let cfg := { trace := cfg.trace || is_trace_enabled_for `simps.verbose || trc, ..cfg },
+  when (cfg.trace ∧ `to_additive ∈ cfg.attrs)
+    trace!"[simps] > @[to_additive] will be added to all generated lemmas.",
   simps_add_projections e nm "" d.type lhs d.value [] d.univ_params tt cfg todo
 
 /-- The parser for the `@[simps]` attribute. -/
-meta def simps_parser : parser (list string × simps_cfg) := do
+meta def simps_parser : parser (bool × list string × simps_cfg) := do
 /- note: we don't check whether the user has written a nonsense namespace in an argument. -/
-prod.mk <$> many (name.last <$> ident) <*>
-  (do some e ← parser.pexpr? | return {}, eval_pexpr simps_cfg e)
+prod.mk <$> is_some <$> (tk "?")? <*>
+  (prod.mk <$> many (name.last <$> ident) <*>
+  (do some e ← parser.pexpr? | return {}, eval_pexpr simps_cfg e))
 
 /--
 The `@[simps]` attribute automatically derives lemmas specifying the projections of this
@@ -578,7 +587,8 @@ derives two simp-lemmas:
 * If one of the fields is a partially applied constructor, we will eta-expand it
   (this likely never happens).
 * When option `trace.simps.verbose` is true, `simps` will print the projections it finds and the
-  lemmas it generates.
+  lemmas it generates. The same can be achieved by using `@[simps?]`, except that in this case it
+  will not print projection information.
 * Use `@[to_additive, simps]` to apply both `to_additive` and `simps` to a definition, making sure
   that `simps` comes after `to_additive`. This will also generate the additive versions of all
   simp-lemmas. Note however, that the additive versions of the simp-lemmas always use the default
@@ -586,15 +596,15 @@ derives two simp-lemmas:
   definition.
   -/
 
-@[user_attribute] meta def simps_attr : user_attribute unit (list string × simps_cfg) :=
+@[user_attribute] meta def simps_attr : user_attribute unit (bool × list string × simps_cfg) :=
 { name := `simps,
   descr := "Automatically derive lemmas specifying the projections of this declaration.",
   parser := simps_parser,
   after_set := some $
     λ n _ persistent, do
       guard persistent <|> fail "`simps` currently cannot be used as a local attribute",
-      (todo, cfg) ← simps_attr.get_param n,
-      simps_tac n cfg todo }
+      (trc, todo, cfg) ← simps_attr.get_param n,
+      simps_tac n cfg todo trc }
 
 add_tactic_doc
 { name                     := "simps",


### PR DESCRIPTION
also trace with initialize_simps_projections?
trace when to_additive is applied to generated lemmas
with @[simps?] projection information is not printed (since that is often not as useful)



---

@semorrison 

Example:
```lean
@[simps?] protected def rfl {α} : α ≃ α :=
⟨id, λ x, x, λ x, rfl, λ x, rfl⟩
```
gives
```
[simps] > adding projection foo.rfl_to_fun:
        > ∀ {α : Sort u_1} (a : α), foo.rfl.to_fun a = id a
[simps] > adding projection foo.rfl_inv_fun:
        > ∀ {α : Sort u_1} (x : α), foo.rfl.inv_fun x = x
```

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[related Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/simps.3F.2C.20reassoc.3F.2C.20mk_iff.3F)