### PR TITLE
[Merged by Bors] - feat(group_theory/perm/sign): Order of product of disjoint permutations

### DIFF
--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -127,7 +127,7 @@ section order_of
 
 section monoid
 variables {α} [monoid α]
-variables {H : Type u} [add_monoid H] {x y : H}
+variables {H : Type u} [add_monoid H] {x : H}
 
 open_locale classical
 

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -127,7 +127,7 @@ section order_of
 
 section monoid
 variables {α} [monoid α]
-variables {H : Type u} [add_monoid H] {x : H}
+variables {H : Type u} [add_monoid H] {x y : H}
 
 open_locale classical
 
@@ -292,6 +292,11 @@ lemma add_order_of_dvd_iff_nsmul_eq_zero {n : ℕ} : add_order_of x ∣ n ↔ n 
 @[to_additive add_order_of_dvd_iff_nsmul_eq_zero]
 lemma order_of_dvd_iff_pow_eq_one {n : ℕ} : order_of a ∣ n ↔ a ^ n = 1 :=
 ⟨λ h, by rw [pow_eq_mod_order_of, nat.mod_eq_zero_of_dvd h, pow_zero], order_of_dvd_of_pow_eq_one⟩
+
+lemma commute.order_of_mul_dvd_lcm (H : commute a b) :
+  order_of (a * b) ∣ nat.lcm (order_of a) (order_of b) :=
+by rw [order_of_dvd_iff_pow_eq_one, H.mul_pow, order_of_dvd_iff_pow_eq_one.mp
+  (nat.dvd_lcm_left _ _), order_of_dvd_iff_pow_eq_one.mp (nat.dvd_lcm_right _ _), one_mul]
 
 lemma add_order_of_eq_prime {p : ℕ} [hp : fact p.prime]
 (hg : p •ℕ x = 0) (hg1 : x ≠ 0) : add_order_of x = p :=

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -293,9 +293,9 @@ lemma add_order_of_dvd_iff_nsmul_eq_zero {n : ℕ} : add_order_of x ∣ n ↔ n 
 lemma order_of_dvd_iff_pow_eq_one {n : ℕ} : order_of a ∣ n ↔ a ^ n = 1 :=
 ⟨λ h, by rw [pow_eq_mod_order_of, nat.mod_eq_zero_of_dvd h, pow_zero], order_of_dvd_of_pow_eq_one⟩
 
-lemma commute.order_of_mul_dvd_lcm (H : commute a b) :
+lemma commute.order_of_mul_dvd_lcm (h : commute a b) :
   order_of (a * b) ∣ nat.lcm (order_of a) (order_of b) :=
-by rw [order_of_dvd_iff_pow_eq_one, H.mul_pow, order_of_dvd_iff_pow_eq_one.mp
+by rw [order_of_dvd_iff_pow_eq_one, h.mul_pow, order_of_dvd_iff_pow_eq_one.mp
   (nat.dvd_lcm_left _ _), order_of_dvd_iff_pow_eq_one.mp (nat.dvd_lcm_right _ _), one_mul]
 
 lemma add_order_of_eq_prime {p : ℕ} [hp : fact p.prime]

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -218,21 +218,23 @@ lemma disjoint.mul_eq_one_iff {σ τ : perm α} (hστ : disjoint σ τ) :
   σ * τ = 1 ↔ σ = 1 ∧ τ = 1 :=
 by simp_rw [ext_iff, one_apply, hστ.mul_apply_eq_iff, forall_and_distrib]
 
+lemma disjoint.gpow_disjoint_gpow {σ τ : perm α} (hστ : disjoint σ τ) (m n : ℤ) :
+  disjoint (σ ^ m) (τ ^ n) :=
+λ x, or.imp (λ h, gpow_apply_eq_self_of_apply_eq_self h m)
+  (λ h, gpow_apply_eq_self_of_apply_eq_self h n) (hστ x)
+
+lemma disjoint.pow_disjoint_pow {σ τ : perm α} (hστ : disjoint σ τ) (m n : ℕ) :
+  disjoint (σ ^ m) (τ ^ n) :=
+hστ.gpow_disjoint_gpow m n
+
 lemma disjoint.order_of {σ τ : perm α} (hστ : disjoint σ τ) :
   order_of (σ * τ) = nat.lcm (order_of σ) (order_of τ) :=
 begin
-  have h : ∀ n : ℕ, (σ * τ) ^ n = 1 ↔ σ ^ n = 1 ∧ τ ^ n = 1,
-  { intro n,
-    rw commute.mul_pow hστ.mul_comm,
-    exact disjoint.mul_eq_one_iff (λ x, or.imp (λ h, pow_apply_eq_self_of_apply_eq_self h n)
-      (λ h, pow_apply_eq_self_of_apply_eq_self h n) (hστ x)) },
-  exact nat.dvd_antisymm
-    (order_of_dvd_of_pow_eq_one ((h (nat.lcm (order_of σ) (order_of τ))).mpr
-      ⟨order_of_dvd_iff_pow_eq_one.mp (nat.dvd_lcm_left (order_of σ) (order_of τ)),
-      order_of_dvd_iff_pow_eq_one.mp (nat.dvd_lcm_right (order_of σ) (order_of τ))⟩))
-    (nat.lcm_dvd
-      (order_of_dvd_of_pow_eq_one ((h (order_of (σ * τ))).mp (pow_order_of_eq_one (σ * τ))).1)
-      (order_of_dvd_of_pow_eq_one ((h (order_of (σ * τ))).mp (pow_order_of_eq_one (σ * τ))).2)),
+  have h : ∀ n : ℕ, (σ * τ) ^ n = 1 ↔ σ ^ n = 1 ∧ τ ^ n = 1 :=
+  λ n, by rw [commute.mul_pow hστ.mul_comm, disjoint.mul_eq_one_iff (hστ.pow_disjoint_pow n n)],
+  exact nat.dvd_antisymm (commute.order_of_mul_dvd_lcm hστ.mul_comm) (nat.lcm_dvd
+    (order_of_dvd_of_pow_eq_one ((h (order_of (σ * τ))).mp (pow_order_of_eq_one (σ * τ))).1)
+    (order_of_dvd_of_pow_eq_one ((h (order_of (σ * τ))).mp (pow_order_of_eq_one (σ * τ))).2)),
 end
 
 variable [decidable_eq α]

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -205,17 +205,18 @@ lemma gpow_apply_eq_of_apply_apply_eq_self {f : perm α} {x : α} (hffx : f (f x
     ← pow_succ, eq_comm, inv_eq_iff_eq, ← mul_apply, ← pow_succ', @eq_comm _ x, or.comm],
   exact pow_apply_eq_of_apply_apply_eq_self hffx _ }
 
-lemma disjoint.mul_eq_one_iff {σ τ : perm α} (hστ : disjoint σ τ) :
-  σ * τ = 1 ↔ σ = 1 ∧ τ = 1 :=
+lemma disjoint.mul_apply_eq_iff {σ τ : perm α} (hστ : disjoint σ τ) {a : α} :
+  (σ * τ) a = a ↔ σ a = a ∧ τ a = a :=
 begin
-  refine ⟨λ h, _, λ h, by rw [h.1, h.2, mul_one]⟩,
-  rw [ext_iff, ext_iff, ←forall_and_distrib],
-  intro x,
-  replace h := (mul_apply σ τ x).symm.trans (ext_iff.mp h x),
-  cases hστ x with hσ hτ,
+  refine ⟨λ h, _, λ h, by rw [mul_apply, h.2, h.1]⟩,
+  cases hστ a with hσ hτ,
   { exact ⟨hσ, σ.injective (h.trans hσ.symm)⟩ },
   { exact ⟨(congr_arg σ hτ).symm.trans h, hτ⟩ },
 end
+
+lemma disjoint.mul_eq_one_iff {σ τ : perm α} (hστ : disjoint σ τ) :
+  σ * τ = 1 ↔ σ = 1 ∧ τ = 1 :=
+by simp_rw [ext_iff, one_apply, hστ.mul_apply_eq_iff, forall_and_distrib]
 
 lemma disjoint.order_of {σ τ : perm α} (hστ : disjoint σ τ) :
   order_of (σ * τ) = nat.lcm (order_of σ) (order_of τ) :=

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -205,6 +205,35 @@ lemma gpow_apply_eq_of_apply_apply_eq_self {f : perm α} {x : α} (hffx : f (f x
     ← pow_succ, eq_comm, inv_eq_iff_eq, ← mul_apply, ← pow_succ', @eq_comm _ x, or.comm],
   exact pow_apply_eq_of_apply_apply_eq_self hffx _ }
 
+lemma disjoint.mul_eq_one_iff {σ τ : perm α} (hστ : disjoint σ τ) :
+  σ * τ = 1 ↔ σ = 1 ∧ τ = 1 :=
+begin
+  refine ⟨λ h, _, λ h, by rw [h.1, h.2, mul_one]⟩,
+  rw [ext_iff, ext_iff, ←forall_and_distrib],
+  intro x,
+  replace h := (mul_apply σ τ x).symm.trans (ext_iff.mp h x),
+  cases hστ x with hσ hτ,
+  { exact ⟨hσ, σ.injective (h.trans hσ.symm)⟩ },
+  { exact ⟨(congr_arg σ hτ).symm.trans h, hτ⟩ },
+end
+
+lemma disjoint.order_of {σ τ : perm α} (hστ : disjoint σ τ) :
+  order_of (σ * τ) = nat.lcm (order_of σ) (order_of τ) :=
+begin
+  have h : ∀ n : ℕ, (σ * τ) ^ n = 1 ↔ σ ^ n = 1 ∧ τ ^ n = 1,
+  { intro n,
+    rw commute.mul_pow hστ.mul_comm,
+    exact disjoint.mul_eq_one_iff (λ x, or.imp (λ h, pow_apply_eq_self_of_apply_eq_self h n)
+      (λ h, pow_apply_eq_self_of_apply_eq_self h n) (hστ x)) },
+  exact nat.dvd_antisymm
+    (order_of_dvd_of_pow_eq_one ((h (nat.lcm (order_of σ) (order_of τ))).mpr
+      ⟨order_of_dvd_iff_pow_eq_one.mp (nat.dvd_lcm_left (order_of σ) (order_of τ)),
+      order_of_dvd_iff_pow_eq_one.mp (nat.dvd_lcm_right (order_of σ) (order_of τ))⟩))
+    (nat.lcm_dvd
+      (order_of_dvd_of_pow_eq_one ((h (order_of (σ * τ))).mp (pow_order_of_eq_one (σ * τ))).1)
+      (order_of_dvd_of_pow_eq_one ((h (order_of (σ * τ))).mp (pow_order_of_eq_one (σ * τ))).2)),
+end
+
 variable [decidable_eq α]
 
 /-- The `finset` of nonfixed points of a permutation. -/


### PR DESCRIPTION
The order of the product of disjoint permutations is the lcm of the orders.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
