### PR TITLE
[Merged by Bors] - chore(topology/continuous_function/algebra): add simp lemmas for smul coercion, move names out of global namespace

### DIFF
--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -112,7 +112,7 @@ instance continuous_map_monoid {α : Type*} {β : Type*} [topological_space α] 
   ..continuous_map.has_one }
 
 @[simp, norm_cast]
-lemma pow_coe {α : Type*} {β : Type*} [topological_space α] [topological_space β]
+lemma continuous_map.pow_coe {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [monoid β] [has_continuous_mul β] (f : C(α, β)) (n : ℕ) :
   ((f^n : C(α, β)) : α → β) = (f : α → β)^n :=
 begin
@@ -149,13 +149,13 @@ instance continuous_map_group {α : Type*} {β : Type*} [topological_space α] [
   ..continuous_map_monoid }
 
 @[simp, norm_cast, to_additive]
-lemma inv_coe {α : Type*} {β : Type*} [topological_space α] [topological_space β]
+lemma continuous_map.inv_coe {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [group β] [topological_group β] (f : C(α, β)) :
   ((f⁻¹ : C(α, β)) : α → β) = (f⁻¹ : α → β) :=
 rfl
 
 @[simp, norm_cast, to_additive]
-lemma div_coe {α : Type*} {β : Type*} [topological_space α] [topological_space β]
+lemma continuous_map.div_coe {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [group β] [topological_group β] (f g : C(α, β)) :
   ((f / g : C(α, β)) : α → β) = (f : α → β) / (g : α → β) :=
 by { simp only [div_eq_mul_inv], refl, }
@@ -247,17 +247,19 @@ topological semiring `R` inherit the structure of a semimodule.
 
 section subtype
 
-instance continuous_has_scalar {α : Type*} [topological_space α]
-  {R : Type*} [semiring R] [topological_space R]
-  {M : Type*} [topological_space M] [add_comm_group M]
-  [semimodule R M] [has_continuous_smul R M] :
-  has_scalar R { f : α → M | continuous f } :=
+variables {α : Type*} [topological_space α]
+variables {R : Type*} [semiring R] [topological_space R]
+variables {M : Type*} [topological_space M] [add_comm_group M]
+variables [semimodule R M] [has_continuous_smul R M]
+
+instance continuous_has_scalar : has_scalar R { f : α → M | continuous f } :=
 ⟨λ r f, ⟨r • f, f.property.const_smul r⟩⟩
 
-instance continuous_semimodule {α : Type*} [topological_space α]
-{R : Type*} [semiring R] [topological_space R]
-{M : Type*} [topological_space M] [add_comm_group M] [topological_add_group M]
-[semimodule R M] [has_continuous_smul R M] :
+@[simp, norm_cast]
+lemma continuous_functions.smul_coe (f : { f : α → M | continuous f }) (r : R) :
+  ⇑(r • f) = r • f := rfl
+
+instance continuous_semimodule [topological_add_group M] :
   semimodule R { f : α → M | continuous f } :=
   semimodule.of_core $
 { smul     := (•),
@@ -278,9 +280,13 @@ instance continuous_map_has_scalar
   has_scalar R C(α, M) :=
 ⟨λ r f, ⟨r • f, f.continuous.const_smul r⟩⟩
 
-@[simp] lemma continuous_map.smul_apply [semimodule R M] [has_continuous_smul R M]
+@[simp, norm_cast]
+lemma continuous_map.smul_coe [semimodule R M] [has_continuous_smul R M]
+  (c : R) (f : C(α, M)) : ⇑(c • f) = c • f := rfl
+
+lemma continuous_map.smul_apply [semimodule R M] [has_continuous_smul R M]
   (c : R) (f : C(α, M)) (a : α) : (c • f) a = c • (f a) :=
-rfl
+by simp
 
 @[simp] lemma continuous_map.smul_comp {α : Type*} {β : Type*}
   [topological_space α] [topological_space β]


### PR DESCRIPTION
The two new lemmas proposed are:

- `continuous_map.smul_coe`
- `continuous_functions.smul_coe`

---
Similar to #6867 and #6893, the lemma `continuous_functions.smul_coe` (proposed here) was required while working on https://github.com/leanprover-community/mathlib/tree/replace_algebra_def.