### PR TITLE
[Merged by Bors] - refactor(analysis/normed_space/add_torsor): generalize to semi_normed_space

### DIFF
--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -43,6 +43,7 @@ class normed_add_torsor (V : out_param $ Type*) (P : Type*)
 (dist_eq_norm' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
 
 /-- A `normed_add_torsor` is a `semi_normed_add_torsor`. -/
+@[priority 100]
 instance normed_add_torsor.to_semi_normed_add_torsor {V P : Type*} [normed_group V] [metric_space P]
   [β : normed_add_torsor V P] : semi_normed_add_torsor V P := { ..β }
 

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -20,6 +20,17 @@ noncomputable theory
 open_locale nnreal topological_space
 open filter
 
+/-- A `semi_normed_add_torsor V P` is a torsor of an additive seminormed group
+action by a `semi_normed_group V` on points `P`. We bundle the pseudometric space
+structure and require the distance to be the same as results from the
+norm (which in fact implies the distance yields a pseudometric space, but
+bundling just the distance and using an instance for the pseudometric space
+results in type class problems). -/
+class semi_normed_add_torsor (V : out_param $ Type*) (P : Type*)
+  [out_param $ semi_normed_group V] [pseudo_metric_space P]
+  extends add_torsor V P :=
+(dist_eq_norm' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
+
 /-- A `normed_add_torsor V P` is a torsor of an additive normed group
 action by a `normed_group V` on points `P`. We bundle the metric space
 structure and require the distance to be the same as results from the
@@ -31,24 +42,35 @@ class normed_add_torsor (V : out_param $ Type*) (P : Type*)
   extends add_torsor V P :=
 (dist_eq_norm' : ∀ (x y : P), dist x y = ∥(x -ᵥ y : V)∥)
 
-variables {α V P : Type*} [normed_group V] [metric_space P] [normed_add_torsor V P]
+/-- A `normed_add_torsor` is a `semi_normed_add_torsor`. -/
+instance normed_add_torsor.to_semi_normed_add_torsor {V P : Type*} [normed_group V] [metric_space P]
+  [β : normed_add_torsor V P] : semi_normed_add_torsor V P := { ..β }
+
+variables {α V P : Type*} [semi_normed_group V] [pseudo_metric_space P] [semi_normed_add_torsor V P]
+variables {W Q : Type*} [normed_group W] [metric_space Q] [normed_add_torsor W Q]
+
+/-- A `semi_normed_group` is a `semi_normed_add_torsor` over itself. -/
+@[priority 100]
+instance semi_normed_group.normed_add_torsor : semi_normed_add_torsor V V :=
+{ dist_eq_norm' := dist_eq_norm }
+
+/-- A `normed_group` is a `normed_add_torsor` over itself. -/
+@[priority 100]
+instance normed_group.normed_add_torsor : normed_add_torsor W W :=
+{ dist_eq_norm' := dist_eq_norm }
+
 include V
 
 section
 
-variable (V)
+variables (V W)
 
 /-- The distance equals the norm of subtracting two points. In this
 lemma, it is necessary to have `V` as an explicit argument; otherwise
 `rw dist_eq_norm_vsub` sometimes doesn't work. -/
 lemma dist_eq_norm_vsub (x y : P) :
   dist x y = ∥(x -ᵥ y)∥ :=
-normed_add_torsor.dist_eq_norm' x y
-
-/-- A `normed_group` is a `normed_add_torsor` over itself. -/
-@[priority 100]
-instance normed_group.normed_add_torsor : normed_add_torsor V V :=
-{ dist_eq_norm' := dist_eq_norm }
+semi_normed_add_torsor.dist_eq_norm' x y
 
 end
 
@@ -98,6 +120,21 @@ lemma edist_vsub_vsub_le (p₁ p₂ p₃ p₄ : P) :
 by { simp only [edist_nndist], apply_mod_cast nndist_vsub_vsub_le }
 
 omit V
+
+/-- The pseudodistance defines a pseudometric space structure on the torsor. This
+is not an instance because it depends on `V` to define a `metric_space
+P`. -/
+def pseudo_metric_space_of_normed_group_of_add_torsor (V P : Type*) [semi_normed_group V]
+  [add_torsor V P] : pseudo_metric_space P :=
+{ dist := λ x y, ∥(x -ᵥ y : V)∥,
+  dist_self := λ x, by simp,
+  dist_comm := λ x y, by simp only [←neg_vsub_eq_vsub_rev y x, norm_neg],
+  dist_triangle := begin
+    intros x y z,
+    change ∥x -ᵥ z∥ ≤ ∥x -ᵥ y∥ + ∥y -ᵥ z∥,
+    rw ←vsub_add_vsub_cancel,
+    apply norm_add_le
+  end }
 
 /-- The distance defines a metric space structure on the torsor. This
 is not an instance because it depends on `V` to define a `metric_space
@@ -178,16 +215,15 @@ lemma dist_point_reflection_self' (x y : P) :
   dist (point_reflection x y) y = ∥bit0 (x -ᵥ y)∥ :=
 by rw [point_reflection_apply, dist_eq_norm_vsub V, vadd_vsub_assoc, bit0]
 
-lemma dist_point_reflection_self (𝕜 : Type*) [normed_field 𝕜] [normed_space 𝕜 V] (x y : P) :
+lemma dist_point_reflection_self (𝕜 : Type*) [normed_field 𝕜] [semi_normed_space 𝕜 V] (x y : P) :
   dist (point_reflection x y) y = ∥(2:𝕜)∥ * dist x y :=
 by rw [dist_point_reflection_self', ← two_smul' 𝕜 (x -ᵥ y), norm_smul, ← dist_eq_norm_vsub V]
 
-lemma point_reflection_fixed_iff (𝕜 : Type*) [normed_field 𝕜] [normed_space 𝕜 V] [invertible (2:𝕜)]
-  {x y : P} :
-  point_reflection x y = y ↔ y = x :=
+lemma point_reflection_fixed_iff (𝕜 : Type*) [normed_field 𝕜] [semi_normed_space 𝕜 V]
+  [invertible (2:𝕜)] {x y : P} : point_reflection x y = y ↔ y = x :=
 affine_equiv.point_reflection_fixed_iff_of_module 𝕜
 
-variables [normed_space ℝ V]
+variables [semi_normed_space ℝ V]
 
 lemma dist_point_reflection_self_real (x y : P) :
   dist (point_reflection x y) y = 2 * dist x y :=
@@ -203,7 +239,7 @@ affine_equiv.point_reflection_midpoint_right x y
 
 end isometric
 
-lemma lipschitz_with.vadd [emetric_space α] {f : α → V} {g : α → P} {Kf Kg : ℝ≥0}
+lemma lipschitz_with.vadd [pseudo_emetric_space α] {f : α → V} {g : α → P} {Kf Kg : ℝ≥0}
   (hf : lipschitz_with Kf f) (hg : lipschitz_with Kg g) :
   lipschitz_with (Kf + Kg) (f +ᵥ g) :=
 λ x y,
@@ -214,7 +250,7 @@ calc edist (f x +ᵥ g x) (f y +ᵥ g y) ≤ edist (f x) (f y) + edist (g x) (g 
 ... = (Kf + Kg) * edist x y :
   (add_mul _ _ _).symm
 
-lemma lipschitz_with.vsub [emetric_space α] {f g : α → P} {Kf Kg : ℝ≥0}
+lemma lipschitz_with.vsub [pseudo_emetric_space α] {f g : α → P} {Kf Kg : ℝ≥0}
   (hf : lipschitz_with Kf f) (hg : lipschitz_with Kg g) :
   lipschitz_with (Kf + Kg) (f -ᵥ g) :=
 λ x y,
@@ -226,10 +262,10 @@ calc edist (f x -ᵥ g x) (f y -ᵥ g y) ≤ edist (f x) (f y) + edist (g x) (g 
   (add_mul _ _ _).symm
 
 lemma uniform_continuous_vadd : uniform_continuous (λ x : V × P, x.1 +ᵥ x.2) :=
-((@lipschitz_with.prod_fst V P _ _).vadd lipschitz_with.prod_snd).uniform_continuous
+(lipschitz_with.prod_fst.vadd lipschitz_with.prod_snd).uniform_continuous
 
 lemma uniform_continuous_vsub : uniform_continuous (λ x : P × P, x.1 -ᵥ x.2) :=
-((@lipschitz_with.prod_fst P P _ _).vsub lipschitz_with.prod_snd).uniform_continuous
+(lipschitz_with.prod_fst.vsub lipschitz_with.prod_snd).uniform_continuous
 
 lemma continuous_vadd : continuous (λ x : V × P, x.1 +ᵥ x.2) :=
 uniform_continuous_vadd.continuous
@@ -280,7 +316,9 @@ hf.vsub hg
 
 end
 
-variables {V' : Type*} {P' : Type*} [normed_group V'] [metric_space P'] [normed_add_torsor V' P']
+variables {V' : Type*} {P' : Type*} [semi_normed_group V'] [pseudo_metric_space P']
+[semi_normed_add_torsor V' P']
+
 
 /-- The map `g` from `V1` to `V2` corresponding to a map `f` from `P1`
 to `P2`, at a base point `p`, is an isometry if `f` is one. -/
@@ -294,12 +332,12 @@ end
 
 section normed_space
 
-variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 V]
+variables {𝕜 : Type*} [normed_field 𝕜] [semi_normed_space 𝕜 V]
 
 open affine_map
 
 /-- If `f` is an affine map, then its linear part is continuous iff `f` is continuous. -/
-lemma affine_map.continuous_linear_iff [normed_space 𝕜 V'] {f : P →ᵃ[𝕜] P'} :
+lemma affine_map.continuous_linear_iff [semi_normed_space 𝕜 V'] {f : P →ᵃ[𝕜] P'} :
   continuous f.linear ↔ continuous f :=
 begin
   inhabit P,
@@ -349,15 +387,15 @@ by rw [dist_comm, dist_midpoint_right]
 
 end normed_space
 
-variables [normed_space ℝ V] [normed_space ℝ V']
-include V'
+variables [semi_normed_space ℝ V] [normed_space ℝ W]
+include W
 
 /-- A continuous map between two normed affine spaces is an affine map provided that
 it sends midpoints to midpoints. -/
-def affine_map.of_map_midpoint (f : P → P')
+def affine_map.of_map_midpoint (f : P → Q)
   (h : ∀ x y, f (midpoint ℝ x y) = midpoint ℝ (f x) (f y))
   (hfc : continuous f) :
-  P →ᵃ[ℝ] P' :=
+  P →ᵃ[ℝ] Q :=
 affine_map.mk' f
   ↑((add_monoid_hom.of_map_midpoint ℝ ℝ
     ((affine_equiv.vadd_const ℝ (f $ classical.arbitrary P)).symm ∘ f ∘


### PR DESCRIPTION
This part of a series of PR to include the theory of `semi_normed_space` in mathlib.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
