### PR TITLE
feat(geometry/manifold/*): transferring geometrical structures through homeomorphisms and open embeddings

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -372,7 +372,7 @@ begin
   { exact equiv.symm_image_image _ _ }
 end
 
-@[simp] lemma image_symm_image {α β} (e : α ≃ β) (s : set β) : e '' (e.symm '' s) = s :=
+lemma image_symm_image {α β} (e : α ≃ β) (s : set β) : e '' (e.symm '' s) = s :=
 e.symm.symm_image_image s
 
 @[simp] lemma image_preimage {α β} (e : α ≃ β) (s : set β) : e '' (e ⁻¹' s) = s :=
@@ -387,11 +387,11 @@ set.image_compl_eq f.bijective
 
 lemma symm_preimage_preimage {α β} (e : α ≃ β) (s : set β) :
   e.symm ⁻¹' (e ⁻¹' s) = s :=
-by ext; simp
+by rw [symm_preimage_eq_image, image_preimage]
 
-@[simp] lemma preimage_symm_preimage {α β} (e : α ≃ β) (s : set α) :
+lemma preimage_symm_preimage {α β} (e : α ≃ β) (s : set α) :
   e ⁻¹' (e.symm ⁻¹' s) = s :=
-by ext; simp
+by rw [symm_preimage_eq_image, preimage_image]
 
 @[simp] lemma preimage_subset {α β} (e : α ≃ β) (s t : set β) : e ⁻¹' s ⊆ e ⁻¹' t ↔ s ⊆ t :=
 e.surjective.preimage_subset_preimage_iff

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -350,6 +350,12 @@ end perm_congr
 protected lemma image_eq_preimage {α β} (e : α ≃ β) (s : set α) : e '' s = e.symm ⁻¹' s :=
 set.ext $ assume x, set.mem_image_iff_of_inverse e.left_inv e.right_inv
 
+@[simp] lemma symm_preimage_eq_image {α β} (e : α ≃ β) (s : set α) : e.symm ⁻¹' s = e '' s :=
+(e.image_eq_preimage s).symm
+
+@[simp] lemma symm_image_eq_preimage {α β} (e : α ≃ β) (s : set β) : e.symm '' s = e ⁻¹' s :=
+by conv_lhs {rw [←symm_preimage_eq_image, symm_symm e]}
+
 protected lemma subset_image {α β} (e : α ≃ β) (s : set α) (t : set β) :
   t ⊆ e '' s ↔ e.symm '' t ⊆ s :=
 by rw [set.image_subset_iff, e.image_eq_preimage]
@@ -379,7 +385,7 @@ protected lemma image_compl {α β} (f : equiv α β) (s : set α) :
   f '' sᶜ = (f '' s)ᶜ :=
 set.image_compl_eq f.bijective
 
-@[simp] lemma symm_preimage_preimage {α β} (e : α ≃ β) (s : set β) :
+lemma symm_preimage_preimage {α β} (e : α ≃ β) (s : set β) :
   e.symm ⁻¹' (e ⁻¹' s) = s :=
 by ext; simp
 

--- a/src/data/equiv/local_equiv.lean
+++ b/src/data/equiv/local_equiv.lean
@@ -735,6 +735,18 @@ hf.bij_on_image.to_local_equiv f s (f '' s)
 
 end set
 
+namespace function
+
+/-- A map injective provides a local equivalence. -/
+@[simp, mfld_simps] noncomputable def injective.to_local_equiv [nonempty α] {f : α → β}
+  (hf : injective f) : local_equiv α β :=
+(hf.inj_on univ).bij_on_image.to_local_equiv f univ (f '' univ)
+
+lemma injective_to_local_equiv_apply [nonempty α] {f : α → β} (hf : injective f) (a : α) :
+  hf.to_local_equiv a = f a := rfl
+
+end function
+
 namespace equiv
 /- equivs give rise to local_equiv. We set up simp lemmas to reduce most properties of the local
 equiv to that of the equiv. -/

--- a/src/data/equiv/local_equiv.lean
+++ b/src/data/equiv/local_equiv.lean
@@ -737,7 +737,7 @@ end set
 
 namespace function
 
-/-- A map injective provides a local equivalence. -/
+/-- An injective map provides a local equivalence. -/
 @[simp, mfld_simps] noncomputable def injective.to_local_equiv [nonempty α] {f : α → β}
   (hf : injective f) : local_equiv α β :=
 (hf.inj_on univ).bij_on_image.to_local_equiv f univ (f '' univ)

--- a/src/data/set/function.lean
+++ b/src/data/set/function.lean
@@ -232,6 +232,8 @@ theorem eq_on.inj_on_iff (H : eq_on f₁ f₂ s) : inj_on f₁ s ↔ inj_on f₂
 theorem inj_on.mono (h : s₁ ⊆ s₂) (ht : inj_on f s₂) : inj_on f s₁ :=
 λ x hx y hy H, ht (h hx) (h hy) H
 
+lemma inj_on.injective (h : inj_on f univ) : injective f := λ _ _ heq, h trivial trivial heq
+
 theorem inj_on_insert {f : α → β} {s : set α} {a : α} (has : a ∉ s) :
   set.inj_on f (insert a s) ↔ set.inj_on f s ∧ f a ∉ f '' s :=
 ⟨λ hf, ⟨hf.mono $ subset_insert a s,
@@ -245,7 +247,7 @@ theorem inj_on_insert {f : α → β} {s : set α} {a : α} (has : a ∉ s) :
     (λ hys : y ∈ s, h1 hxs hys hfxy))⟩
 
 lemma injective_iff_inj_on_univ : injective f ↔ inj_on f univ :=
-⟨λ h x hx y hy hxy, h hxy, λ h _ _ heq, h trivial trivial heq⟩
+⟨λ h x hx y hy hxy, h hxy, inj_on.injective⟩
 
 lemma inj_on_of_injective (h : injective f) (s : set α) : inj_on f s :=
 λ x hx y hy hxy, h hxy

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -493,6 +493,15 @@ by simp [atlas, charted_space.atlas]
   chart_at H x = local_homeomorph.refl H :=
 by simpa using chart_mem_atlas H x
 
+/-- Transfers the instance of charted space through equivalences. -/
+def homeomorph.charted_space (H : Type*) [topological_space H]
+  {M : Type*} [topological_space M] [charted_space H M]
+  {M' : Type*} [topological_space M'] (e : homeomorph M M') : charted_space H M' :=
+{ atlas := {ϕ : local_homeomorph M' H | ∃ ψ ∈ atlas H M, ϕ = e.symm.to_local_homeomorph.trans ψ},
+  chart_at := λ y, e.symm.to_local_homeomorph.trans (chart_at H (e.symm y)),
+  mem_chart_source := λ y, by simp only with mfld_simps,
+  chart_mem_atlas := λ y, ⟨chart_at H (e.symm y), chart_mem_atlas H (e.symm y), rfl⟩ }
+
 section
 
 variables (H) [topological_space H] [topological_space M] [charted_space H M]
@@ -852,6 +861,17 @@ instance [closed_under_restriction G] : has_groupoid s G :=
   end }
 
 end topological_space.opens
+
+lemma homeomorph.has_groupoid {H : Type*} [topological_space H]
+  {M : Type*} [topological_space M] [charted_space H M]
+  {M' : Type*} [topological_space M'] (G : structure_groupoid H) [has_groupoid M G]
+  (e : homeomorph M M') : @has_groupoid H _ M' _ (e.charted_space H) G :=
+{ compatible := λ f f' hf hf', begin rcases hf with ⟨ϕ, hϕ1, hϕ2⟩,
+    rcases hf' with ⟨ψ, hψ1, hψ2⟩,
+    rw [hϕ2, hψ2, homeomorph.symm_to_local_homeomorph, trans_symm_eq_symm_trans_symm, symm_symm,
+    trans_assoc, ←trans_assoc e.to_local_homeomorph, homeomorph.trans_symm_to_local_homeomorph,
+    refl_trans],
+    exact has_groupoid.compatible G hϕ1 hψ1 end }
 
 /-! ### Structomorphisms -/
 

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -619,6 +619,23 @@ instance prod {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 
 end smooth_manifold_with_corners
 
+lemma homeomorph.smooth_manifold_with_corners {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
+  {E : Type*} [normed_group E] [normed_space 𝕜 E]
+  {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
+  {M : Type*} [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
+  {M' : Type*} [topological_space M']
+  (e : homeomorph M M') : @smooth_manifold_with_corners 𝕜 _ E _ _ H _ I M' _ (e.charted_space H) :=
+{ compatible := λ f f' hf hf', begin rcases hf with ⟨ϕ, hϕ1, hϕ2⟩,
+    rcases hf' with ⟨ψ, hψ1, hψ2⟩,
+    rw [hϕ2, hψ2, homeomorph.symm_to_local_homeomorph,
+      local_homeomorph.trans_symm_eq_symm_trans_symm, local_homeomorph.symm_symm,
+      local_homeomorph.trans_assoc, ←local_homeomorph.trans_assoc e.to_local_homeomorph,
+      homeomorph.trans_symm_to_local_homeomorph, local_homeomorph.refl_trans],
+    exact has_groupoid.compatible (times_cont_diff_groupoid ∞ I) hϕ1 hψ1 end }
+/-
+{ ..e.has_groupoid (times_cont_diff_groupoid ∞ I) } does not work. Why!?
+-/
+
 section extended_charts
 open_locale topological_space
 

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -274,6 +274,55 @@ continuous.comp (continuous_pow n) h
 
 end has_continuous_mul
 
+section embedding
+
+variable [monoid M]
+
+@[to_additive]
+lemma function.injective_mul [monoid β] {f : β →* M} (h : function.injective f) (a b : β) :
+  a * b = h.to_local_equiv.symm ((f a) * (f b)) :=
+begin
+  rw [←local_equiv.left_inv h.to_local_equiv (mem_univ (a * b)),
+    function.injective_to_local_equiv_apply h],
+  exact congr_arg h.to_local_equiv.symm (f.map_mul a b),
+end
+
+variable [topological_space M]
+
+@[to_additive]
+lemma embedding_mul [monoid β] [topological_space β] [nonempty β]
+  {f : β →* M} (h : open_embedding f) (a b : β) :
+  a * b = ((h.to_local_homeomorph f).symm) ((f a) * (f b)) :=
+begin
+  rw [←local_homeomorph.left_inv (h.to_local_homeomorph f) (mem_univ (a * b)),
+    open_embedding.to_local_homeomorph_coe],
+  exact congr_arg (h.to_local_homeomorph f).symm (f.map_mul a b),
+end
+
+variable [has_continuous_mul M]
+
+@[to_additive]
+lemma open_embedding.continuous_mul [topological_space β] [monoid β]
+  {f : β →* M} (h : open_embedding f) :
+  continuous (λ p : β × β, p.1 * p.2) :=
+begin
+  rw continuous_iff_continuous_at,
+  intro x,
+  simp only [embedding_mul h],
+  have h' : (f x.fst) * (f x.snd) ∈ (h.to_local_homeomorph f).target :=
+    by { rw [←monoid_hom.map_mul, open_embedding.target], exact mem_range_self (x.fst * x.snd), },
+  exact continuous_at.comp ((h.to_local_homeomorph f).continuous_inv_fun.continuous_at
+    (mem_nhds_sets (h.to_local_homeomorph f).open_target h')) (continuous_mul.continuous_at.comp
+    (h.continuous.continuous_at.prod_map h.continuous.continuous_at)),
+end
+
+@[to_additive]
+lemma open_embedding.has_continuous_mul [topological_space β] [monoid β]
+  {f : β →* M} (h : open_embedding f) : has_continuous_mul β :=
+{ continuous_mul := h.continuous_mul }
+
+end embedding
+
 section
 
 variables [topological_space M] [comm_monoid M]

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -7,6 +7,7 @@ import topology.continuous_on
 import group_theory.submonoid.operations
 import algebra.group.prod
 import algebra.pointwise
+import topology.local_homeomorph
 
 /-!
 # Theory of topological monoids

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -308,3 +308,23 @@ homeomorph_of_continuous_open (equiv.sigma_prod_distrib σ β).symm
 end distrib
 
 end homeomorph
+
+section equiv
+
+/-- If the topology is transferred from one type to another via an equivalence, the equivalence
+will clearly also be a homeomorphism. -/
+def equiv.homeomorph {α : Type*} {β : Type*} [tα : topological_space α] (e : α ≃ β) :
+  @homeomorph α β _ (tα.induced e.symm) :=
+{ to_fun := e,
+  continuous_to_fun := begin
+    dsimp,
+    rw continuous_iff_le_induced,
+    rintros a ⟨c, ⟨⟨b, ⟨hb, hbc⟩⟩, hca⟩⟩,
+    induction hca,
+    induction hbc,
+    simp only [equiv.preimage_image, equiv.symm_preimage_eq_image],
+    exact hb,
+  end,
+  ..e }
+
+  end equiv

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -65,11 +65,23 @@ rfl
 @[continuity]
 protected lemma continuous (h : α ≃ₜ β) : continuous h := h.continuous_to_fun
 
-@[simp] lemma apply_symm_apply (h : α ≃ₜ β) (x : β) : h (h.symm x) = x :=
-h.to_equiv.apply_symm_apply x
+@[simp] lemma refl_apply (x : α) : homeomorph.refl α x = x := rfl
+@[simp] lemma coe_trans (f : α ≃ₜ β) (g : β ≃ₜ γ) : ⇑(f.trans g) = g ∘ f := rfl
+@[simp] lemma trans_apply (f : α ≃ₜ β) (g : β ≃ₜ γ) (a : α) : (f.trans g) a = g (f a) := rfl
+@[simp] lemma apply_symm_apply  (e : α ≃ₜ β) (x : β) : e (e.symm x) = x := e.right_inv x
+@[simp] lemma symm_apply_apply (e : α ≃ₜ β) (x : α) : e.symm (e x) = x := e.left_inv x
 
-@[simp] lemma symm_apply_apply (h : α ≃ₜ β) (x : α) : h.symm (h x) = x :=
-h.to_equiv.symm_apply_apply x
+@[simp] lemma refl_trans (e : α ≃ₜ β) : (homeomorph.refl α).trans e = e :=
+by { ext, simp only [trans_apply, refl_apply] }
+
+@[simp] lemma symm_trans (e : α ≃ₜ β) : e.symm.trans e = homeomorph.refl β :=
+by { ext, simp only [trans_apply, refl_apply, apply_symm_apply] }
+
+@[simp] lemma trans_symm (e : α ≃ₜ β) : e.trans e.symm = homeomorph.refl α :=
+by { ext, simp only [symm_apply_apply, trans_apply, refl_apply] }
+
+@[simp] lemma symm_trans_apply (f : α ≃ₜ β) (g : β ≃ₜ γ) (a : γ) :
+  (f.trans g).symm a = f.symm (g.symm a) := rfl
 
 protected lemma bijective (h : α ≃ₜ β) : function.bijective h := h.to_equiv.bijective
 protected lemma injective (h : α ≃ₜ β) : function.injective h := h.to_equiv.injective
@@ -153,6 +165,9 @@ lemma image_closure (h : α ≃ₜ β) (s : set α) : h '' (closure s) = closure
 by rw [← preimage_symm, preimage_closure]
 
 protected lemma is_open_map (h : α ≃ₜ β) : is_open_map h := λ s, h.is_open_image.2
+
+protected lemma open_embedding (h : α ≃ₜ β) : open_embedding h :=
+open_embedding_of_embedding_open h.embedding h.is_open_map
 
 protected lemma is_closed_map (h : α ≃ₜ β) : is_closed_map h := λ s, h.is_closed_image.2
 

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -956,6 +956,10 @@ correspond to the fields of the original homeomorphism. -/
   (e.trans e').to_local_homeomorph = e.to_local_homeomorph.trans e'.to_local_homeomorph :=
 local_homeomorph.eq_of_local_equiv_eq $ equiv.trans_to_local_equiv _ _
 
+@[simp, mfld_simps] lemma trans_symm_to_local_homeomorph :
+  (e.to_local_homeomorph.trans e.to_local_homeomorph.symm) = local_homeomorph.refl α :=
+by rw [←symm_to_local_homeomorph, ←trans_to_local_homeomorph, trans_symm, refl_to_local_homeomorph]
+
 end homeomorph
 
 namespace open_embedding


### PR DESCRIPTION
This is just the part of the code that was before part of the PR on GLn and that was removed because the strategy changed, but that can still be useful in other situations.

It mainly proves that if `X` is a topological space and a monoid, `M` is a topological monoid, and `f: X \to M` is both an open embedding and a homomorphism, then multiplication in `X` is continuous.

This PR also contains some definitions to transfer smooth structures through homomorphisms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
