### PR TITLE
[Merged by Bors] - chore(group_theory/order_of_element): move some lemmas

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -242,7 +242,7 @@
   author : Aaron Anderson
 71:
   title  : Order of a Subgroup
-  decl   : card_subgroup_dvd_card
+  decl   : subgroup.card_subgroup_dvd_card
   author : mathlib
 72:
   title  : Sylow’s Theorem

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1777,6 +1777,34 @@ by simp only [insert_eq, image_singleton, image_union]
 ⟨λ h, eq_empty_of_forall_not_mem $
  λ a m, ne_empty_of_mem (mem_image_of_mem _ m) h, λ e, e.symm ▸ rfl⟩
 
+lemma mem_range_iff_mem_finset_range_of_mod_eq' [decidable_eq α] {f : ℕ → α} {a : α} {n : ℕ}
+  (hn : 0 < n) (h : ∀i, f (i % n) = f i) :
+  a ∈ set.range f ↔ a ∈ (finset.range n).image (λi, f i) :=
+begin
+  split,
+  { rintros ⟨i, hi⟩,
+    simp only [mem_image, exists_prop, mem_range],
+    exact ⟨i % n, nat.mod_lt i hn, (rfl.congr hi).mp (h i)⟩ },
+  { rintro h,
+    simp only [mem_image, exists_prop, set.mem_range, mem_range] at *,
+    rcases h with ⟨i, hi, ha⟩,
+    use ⟨i, ha⟩ },
+end
+
+lemma mem_range_iff_mem_finset_range_of_mod_eq [decidable_eq α] {f : ℤ → α} {a : α} {n : ℕ}
+  (hn : 0 < n) (h : ∀i, f (i % n) = f i) :
+  a ∈ set.range f ↔ a ∈ (finset.range n).image (λi, f i) :=
+suffices (∃i, f (i % n) = a) ↔ ∃i, i < n ∧ f ↑i = a, by simpa [h],
+have hn' : 0 < (n : ℤ), from int.coe_nat_lt.mpr hn,
+iff.intro
+  (assume ⟨i, hi⟩,
+    have 0 ≤ i % ↑n, from int.mod_nonneg _ (ne_of_gt hn'),
+    ⟨int.to_nat (i % n),
+      by rw [←int.coe_nat_lt, int.to_nat_of_nonneg this]; exact ⟨int.mod_lt_of_pos i hn', hi⟩⟩)
+  (assume ⟨i, hi, ha⟩,
+    ⟨i, by rw [int.mod_eq_of_lt (int.coe_zero_le _) (int.coe_nat_lt_coe_nat_of_lt hi), ha]⟩)
+
+
 lemma attach_image_val [decidable_eq α] {s : finset α} : s.attach.image subtype.val = s :=
 eq_of_veq $ by rw [image_val, attach_val, multiset.attach_map_val, erase_dup_eq_self]
 

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -330,6 +330,19 @@ calc α ≃ Σ L : quotient s, {x : α // (x : quotient s) = L} :
     ... ≃ quotient s × s :
   equiv.sigma_equiv_prod _ _
 
+lemma card_eq_card_quotient_mul_card_subgroup [fintype α] (s : subgroup α) [fintype s]
+  [decidable_pred (λ a, a ∈ s)] : fintype.card α = fintype.card (quotient s) * fintype.card s :=
+by rw ← fintype.card_prod;
+  exact fintype.card_congr (subgroup.group_equiv_quotient_times_subgroup)
+
+lemma card_subgroup_dvd_card [fintype α] (s : subgroup α) [fintype s] :
+  fintype.card s ∣ fintype.card α :=
+by haveI := classical.prop_decidable; simp [card_eq_card_quotient_mul_card_subgroup s]
+
+lemma card_quotient_dvd_card [fintype α] (s : subgroup α) [decidable_pred (λ a, a ∈ s)] [fintype s] :
+  fintype.card (quotient s) ∣ fintype.card α :=
+by simp [card_eq_card_quotient_mul_card_subgroup s]
+
 end subgroup
 
 namespace quotient_group

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -339,8 +339,8 @@ lemma card_subgroup_dvd_card [fintype α] (s : subgroup α) [fintype s] :
   fintype.card s ∣ fintype.card α :=
 by haveI := classical.prop_decidable; simp [card_eq_card_quotient_mul_card_subgroup s]
 
-lemma card_quotient_dvd_card [fintype α] (s : subgroup α) [decidable_pred (λ a, a ∈ s)] [fintype s] :
-  fintype.card (quotient s) ∣ fintype.card α :=
+lemma card_quotient_dvd_card [fintype α] (s : subgroup α) [decidable_pred (λ a, a ∈ s)]
+  [fintype s] : fintype.card (quotient s) ∣ fintype.card α :=
 by simp [card_eq_card_quotient_mul_card_subgroup s]
 
 end subgroup

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -84,45 +84,6 @@ iff.intro
 
 end finset
 
-lemma mem_normalizer_fintype [group α] {s : set α} [fintype s] {x : α}
-  (h : ∀ n, n ∈ s → x * n * x⁻¹ ∈ s) : x ∈ subgroup.set_normalizer s :=
-by haveI := classical.prop_decidable;
-haveI := set.fintype_image s (λ n, x * n * x⁻¹); exact
-λ n, ⟨h n, λ h₁,
-have heq : (λ n, x * n * x⁻¹) '' s = s := set.eq_of_subset_of_card_le
-  (λ n ⟨y, hy⟩, hy.2 ▸ h y hy.1) (by rw set.card_image_of_injective s conj_injective),
-have x * n * x⁻¹ ∈ (λ n, x * n * x⁻¹) '' s := heq.symm ▸ h₁,
-let ⟨y, hy⟩ := this in conj_injective hy.2 ▸ hy.1⟩
-
-section order_of
-variable [group α]
-open quotient_group set
-
-instance fintype_bot : fintype (⊥ : subgroup α) := ⟨{1},
-by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
-
-@[simp] lemma card_trivial :
-  fintype.card (⊥ : subgroup α) = 1 :=
-fintype.card_eq_one_iff.2
-  ⟨⟨(1 : α), set.mem_singleton 1⟩, λ ⟨y, hy⟩, subtype.eq $ subgroup.mem_bot.1 hy⟩
-
-variables [fintype α] [dec : decidable_eq α]
-
-lemma card_eq_card_quotient_mul_card_subgroup (s : subgroup α) [fintype s]
-  [decidable_pred (λ a, a ∈ s)] : fintype.card α = fintype.card (quotient s) * fintype.card s :=
-by rw ← fintype.card_prod;
-  exact fintype.card_congr (subgroup.group_equiv_quotient_times_subgroup)
-
-lemma card_subgroup_dvd_card (s : subgroup α) [fintype s] :
-  fintype.card s ∣ fintype.card α :=
-by haveI := classical.prop_decidable; simp [card_eq_card_quotient_mul_card_subgroup s]
-
-lemma card_quotient_dvd_card (s : subgroup α) [decidable_pred (λ a, a ∈ s)] [fintype s] :
-  fintype.card (quotient s) ∣ fintype.card α :=
-by simp [card_eq_card_quotient_mul_card_subgroup s]
-
-end order_of
-
 section order_of
 
 section monoid

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -51,39 +51,6 @@ universe u
 
 variables {α : Type u} {s : set α} {a a₁ a₂ b c: α}
 
--- TODO mem_range_iff_mem_finset_range_of_mod_eq should be moved elsewhere.
-namespace finset
-open finset
-
-lemma mem_range_iff_mem_finset_range_of_mod_eq' [decidable_eq α] {f : ℕ → α} {a : α} {n : ℕ}
-  (hn : 0 < n) (h : ∀i, f (i % n) = f i) :
-  a ∈ set.range f ↔ a ∈ (finset.range n).image (λi, f i) :=
-begin
-  split,
-  { rintros ⟨i, hi⟩,
-    simp only [mem_image, exists_prop, mem_range],
-    exact ⟨i % n, nat.mod_lt i hn, (rfl.congr hi).mp (h i)⟩ },
-  { rintro h,
-    simp only [mem_image, exists_prop, set.mem_range, mem_range] at *,
-    rcases h with ⟨i, hi, ha⟩,
-    use ⟨i, ha⟩ },
-end
-
-lemma mem_range_iff_mem_finset_range_of_mod_eq [decidable_eq α] {f : ℤ → α} {a : α} {n : ℕ}
-  (hn : 0 < n) (h : ∀i, f (i % n) = f i) :
-  a ∈ set.range f ↔ a ∈ (finset.range n).image (λi, f i) :=
-suffices (∃i, f (i % n) = a) ↔ ∃i, i < n ∧ f ↑i = a, by simpa [h],
-have hn' : 0 < (n : ℤ), from int.coe_nat_lt.mpr hn,
-iff.intro
-  (assume ⟨i, hi⟩,
-    have 0 ≤ i % ↑n, from int.mod_nonneg _ (ne_of_gt hn'),
-    ⟨int.to_nat (i % n),
-      by rw [←int.coe_nat_lt, int.to_nat_of_nonneg this]; exact ⟨int.mod_lt_of_pos i hn', hi⟩⟩)
-  (assume ⟨i, hi, ha⟩,
-    ⟨i, by rw [int.mod_eq_of_lt (int.coe_zero_le _) (int.coe_nat_lt_coe_nat_of_lt hi), ha]⟩)
-
-end finset
-
 section order_of
 
 section monoid

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -818,7 +818,7 @@ lemma two_mul_card_alternating_subgroup [nontrivial α] :
 begin
   let := (quotient_group.quotient_ker_equiv_of_surjective _ (sign_surjective α)).to_equiv,
   rw [←fintype.card_units_int, ←fintype.card_congr this],
-  exact (card_eq_card_quotient_mul_card_subgroup _).symm,
+  exact (subgroup.card_eq_card_quotient_mul_card_subgroup _).symm,
 end
 
 lemma alternating_subgroup_normal : (alternating_subgroup α).normal := sign.normal_ker

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -875,7 +875,7 @@ def set_normalizer (S : set G) : subgroup G :=
   inv_mem' := λ a (ha : ∀ n, n ∈ S ↔ a * n * a⁻¹ ∈ S) n,
     by { rw [ha (a⁻¹ * n * a⁻¹⁻¹)], simp [mul_assoc] } }
 
-lemma mem_normalizer_fintype [group G] {S : set G} [fintype S] {x : G}
+lemma mem_normalizer_fintype {S : set G} [fintype S] {x : G}
   (h : ∀ n, n ∈ S → x * n * x⁻¹ ∈ S) : x ∈ subgroup.set_normalizer S :=
 by haveI := classical.prop_decidable;
 haveI := set.fintype_image S (λ n, x * n * x⁻¹); exact

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -356,11 +356,12 @@ end
 @[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
 by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
-@[simp] lemma card_trivial_add : fintype.card (⊥ : add_subgroup A) = 1 :=
+@[simp] lemma addsubgroup.card_bot : fintype.card (⊥ : add_subgroup A) = 1 :=
 fintype.card_eq_one_iff.2
   ⟨⟨(0 : A), set.mem_singleton 0⟩, λ ⟨y, hy⟩, subtype.eq $ add_subgroup.mem_bot.1 hy⟩
 
-@[simp] lemma card_trivial : fintype.card (⊥ : subgroup G) = 1 :=
+-- `@[to_additive]` doesn't work, because it converts the `1 : ℕ` to `0`.
+@[simp] lemma subgroup.card_bot : fintype.card (⊥ : subgroup G) = 1 :=
 fintype.card_eq_one_iff.2
   ⟨⟨(1 : G), set.mem_singleton 1⟩, λ ⟨y, hy⟩, subtype.eq $ subgroup.mem_bot.1 hy⟩
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -353,6 +353,17 @@ begin
   rw [← subgroup.coe_mk H y hy, subsingleton.elim (⟨y, hy⟩ : H) 1, subgroup.coe_one],
 end
 
+@[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
+by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
+
+@[simp] lemma card_trivial_add : fintype.card (⊥ : add_subgroup A) = 1 :=
+fintype.card_eq_one_iff.2
+  ⟨⟨(0 : A), set.mem_singleton 0⟩, λ ⟨y, hy⟩, subtype.eq $ add_subgroup.mem_bot.1 hy⟩
+
+@[simp] lemma card_trivial : fintype.card (⊥ : subgroup G) = 1 :=
+fintype.card_eq_one_iff.2
+  ⟨⟨(1 : G), set.mem_singleton 1⟩, λ ⟨y, hy⟩, subtype.eq $ subgroup.mem_bot.1 hy⟩
+
 @[to_additive] lemma eq_top_of_card_eq [fintype H] [fintype G]
   (h : fintype.card H = fintype.card G) : H = ⊤ :=
 begin
@@ -863,6 +874,16 @@ def set_normalizer (S : set G) : subgroup G :=
     by { rw [hb, ha], simp [mul_assoc] },
   inv_mem' := λ a (ha : ∀ n, n ∈ S ↔ a * n * a⁻¹ ∈ S) n,
     by { rw [ha (a⁻¹ * n * a⁻¹⁻¹)], simp [mul_assoc] } }
+
+lemma mem_normalizer_fintype [group G] {S : set G} [fintype S] {x : G}
+  (h : ∀ n, n ∈ S → x * n * x⁻¹ ∈ S) : x ∈ subgroup.set_normalizer S :=
+by haveI := classical.prop_decidable;
+haveI := set.fintype_image S (λ n, x * n * x⁻¹); exact
+λ n, ⟨h n, λ h₁,
+have heq : (λ n, x * n * x⁻¹) '' S = S := set.eq_of_subset_of_card_le
+  (λ n ⟨y, hy⟩, hy.2 ▸ h y hy.1) (by rw set.card_image_of_injective S conj_injective),
+have x * n * x⁻¹ ∈ (λ n, x * n * x⁻¹) '' S := heq.symm ▸ h₁,
+let ⟨y, hy⟩ := this in conj_injective hy.2 ▸ hy.1⟩
 
 variable {H}
 @[to_additive] lemma mem_normalizer_iff {g : G} :

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -356,12 +356,12 @@ end
 @[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
 by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
-@[simp] lemma addsubgroup.card_bot : fintype.card (⊥ : add_subgroup A) = 1 :=
+@[simp] lemma _root_.add_subgroup.card_bot : fintype.card (⊥ : add_subgroup A) = 1 :=
 fintype.card_eq_one_iff.2
   ⟨⟨(0 : A), set.mem_singleton 0⟩, λ ⟨y, hy⟩, subtype.eq $ add_subgroup.mem_bot.1 hy⟩
 
 -- `@[to_additive]` doesn't work, because it converts the `1 : ℕ` to `0`.
-@[simp] lemma subgroup.card_bot : fintype.card (⊥ : subgroup G) = 1 :=
+@[simp] lemma card_bot : fintype.card (⊥ : subgroup G) = 1 :=
 fintype.card_eq_one_iff.2
   ⟨⟨(1 : G), set.mem_singleton 1⟩, λ ⟨y, hy⟩, subtype.eq $ subgroup.mem_bot.1 hy⟩
 

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -226,7 +226,7 @@ def fixed_points_mul_left_cosets_equiv_quotient (H : subgroup G) [fintype (H : s
 /-- The first of the Sylow theorems. -/
 theorem exists_subgroup_card_pow_prime [fintype G] (p : ℕ) : ∀ {n : ℕ} [hp : fact p.prime]
   (hdvd : p ^ n ∣ card G), ∃ H : subgroup G, fintype.card H = p ^ n
-| 0 := λ _ _, ⟨(⊥ : subgroup G), by convert subgroup.card_bot⟩
+| 0 := λ _ _, ⟨(⊥ : subgroup G), by convert card_bot⟩
 | (n+1) := λ hp hdvd,
 let ⟨H, hH2⟩ := @exists_subgroup_card_pow_prime _ hp
   (dvd.trans (pow_dvd_pow _ (nat.le_succ _)) hdvd) in

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -226,7 +226,7 @@ def fixed_points_mul_left_cosets_equiv_quotient (H : subgroup G) [fintype (H : s
 /-- The first of the Sylow theorems. -/
 theorem exists_subgroup_card_pow_prime [fintype G] (p : ℕ) : ∀ {n : ℕ} [hp : fact p.prime]
   (hdvd : p ^ n ∣ card G), ∃ H : subgroup G, fintype.card H = p ^ n
-| 0 := λ _ _, ⟨(⊥ : subgroup G), by convert card_trivial⟩
+| 0 := λ _ _, ⟨(⊥ : subgroup G), by convert subgroup.card_bot⟩
 | (n+1) := λ hp hdvd,
 let ⟨H, hH2⟩ := @exists_subgroup_card_pow_prime _ hp
   (dvd.trans (pow_dvd_pow _ (nat.le_succ _)) hdvd) in


### PR DESCRIPTION
I moved a few lemmas to `group_theory.subgroup` and to `group_theory.coset` and to `data.finset.basic`. Feel free to suggest different locations if they don't quite fit. This resolves #1563.

Renamed `card_trivial` to `subgroup.card_bot`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
