### PR TITLE
[Merged by Bors] - refactor(algebra/group/inj_surj): eliminate the versions of the definitions without `has_div` / `has_sub`.

### DIFF
--- a/src/algebra/field.lean
+++ b/src/algebra/field.lean
@@ -335,8 +335,8 @@ protected def function.injective.division_ring [division_ring K] {K'}
   (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
   (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) (div : ∀ x y, f (x / y) = f x / f y) :
   division_ring K' :=
-{ .. hf.group_with_zero_div f zero one mul inv div,
-  .. hf.ring_sub f zero one add mul neg sub }
+{ .. hf.group_with_zero f zero one mul inv div,
+  .. hf.ring f zero one add mul neg sub }
 
 /-- Pullback a `field` along an injective function. -/
 protected def function.injective.field [field K] {K'}
@@ -347,5 +347,5 @@ protected def function.injective.field [field K] {K'}
   (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
   (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) (div : ∀ x y, f (x / y) = f x / f y) :
   field K' :=
-{ .. hf.comm_group_with_zero_div f zero one mul inv div,
-  .. hf.comm_ring_sub f zero one add mul neg sub }
+{ .. hf.comm_group_with_zero f zero one mul inv div,
+  .. hf.comm_ring f zero one add mul neg sub }

--- a/src/algebra/group/inj_surj.lean
+++ b/src/algebra/group/inj_surj.lean
@@ -123,7 +123,7 @@ protected def comm_monoid [comm_monoid M₂] (f : M₁ → M₂) (hf : injective
   comm_monoid M₁ :=
 { .. hf.comm_semigroup f mul, .. hf.monoid f one mul }
 
-variables [has_inv M₁]
+variables [has_inv M₁] [has_div M₁]
 
 /-- A type endowed with `1`, `*`, `⁻¹`, and `/` is a `div_inv_monoid`
 if it admits an injective map that preserves `1`, `*`, `⁻¹`, and `/` to a `div_inv_monoid`. -/
@@ -131,7 +131,7 @@ if it admits an injective map that preserves `1`, `*`, `⁻¹`, and `/` to a `di
 "A type endowed with `0`, `+`, unary `-`, and binary `-` is a `sub_neg_monoid`
 if it admits an injective map that preserves `0`, `+`, unary `-`, and binary `-` to
 a `sub_neg_monoid`."]
-protected def div_inv_monoid [has_div M₁] [div_inv_monoid M₂] (f : M₁ → M₂) (hf : injective f)
+protected def div_inv_monoid [div_inv_monoid M₂] (f : M₁ → M₂) (hf : injective f)
   (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f x⁻¹ = (f x)⁻¹)
   (div : ∀ x y, f (x / y) = f x / f y) :
   div_inv_monoid M₁ :=
@@ -144,28 +144,11 @@ if it admits an injective map that preserves `1`, `*` and `⁻¹` to a group. -/
 "A type endowed with `0` and `+` is an additive group,
 if it admits an injective map that preserves `0` and `+` to an additive group."]
 protected def group [group M₂] (f : M₁ → M₂) (hf : injective f)
-  (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) :
-  group M₁ :=
-{ mul_left_inv := λ x, hf $ by erw [mul, inv, mul_left_inv, one],
-  .. hf.monoid f one mul, ..‹has_inv M₁› }
-
-/-- A type endowed with `1`, `*`, `⁻¹` and `/` is a group,
-if it admits an injective map to a group that preserves these operations.
-
-This version of `injective.group` makes sure that the `/` operation is defeq
-to the specified division operator.
--/
-@[to_additive
-"A type endowed with `0`, `+` and `-` (unary and binary) is an additive group,
-if it admits an injective map to an additive group that preserves these operations.
-
-This version of `injective.add_group` makes sure that the `-` operation is defeq
-to the specified subtraction operator."]
-protected def group_div [has_div M₁] [group M₂] (f : M₁ → M₂) (hf : injective f)
   (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f (x⁻¹) = (f x)⁻¹)
   (div : ∀ x y, f (x / y) = f x / f y) :
   group M₁ :=
-{ .. hf.div_inv_monoid f one mul inv div, .. hf.group f one mul inv }
+{ mul_left_inv := λ x, hf $ by erw [mul, inv, mul_left_inv, one],
+  .. hf.div_inv_monoid f one mul inv div }
 
 /-- A type endowed with `1`, `*` and `⁻¹` is a commutative group,
 if it admits an injective map that preserves `1`, `*` and `⁻¹` to a commutative group. -/
@@ -173,27 +156,10 @@ if it admits an injective map that preserves `1`, `*` and `⁻¹` to a commutati
 "A type endowed with `0` and `+` is an additive commutative group,
 if it admits an injective map that preserves `0` and `+` to an additive commutative group."]
 protected def comm_group [comm_group M₂] (f : M₁ → M₂) (hf : injective f)
-  (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) :
-  comm_group M₁ :=
-{ .. hf.comm_monoid f one mul, .. hf.group f one mul inv }
-
-/-- A type endowed with `1`, `*`, `⁻¹` and `/` is a commutative group,
-if it admits an injective map to a commutative group that preserves these operations.
-
-This version of `injective.comm_group` makes sure that the `/` operation is defeq
-to the specified division operator.
--/
-@[to_additive
-"A type endowed with `0`, `+` and `-` is an additive commutative group,
-if it admits an injective map to an additive commutative group that preserves these operations.
-
-This version of `injective.add_comm_group` makes sure that the `-` operation is defeq
-to the specified subtraction operator."]
-protected def comm_group_div [has_div M₁] [comm_group M₂] (f : M₁ → M₂) (hf : injective f)
   (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f (x⁻¹) = (f x)⁻¹)
   (div : ∀ x y, f (x / y) = f x / f y) :
   comm_group M₁ :=
-{ .. hf.comm_monoid f one mul, .. hf.group_div f one mul inv div }
+{ .. hf.comm_monoid f one mul, .. hf.group f one mul inv div }
 
 end injective
 
@@ -260,76 +226,42 @@ protected def comm_monoid [comm_monoid M₁] (f : M₁ → M₂) (hf : surjectiv
   comm_monoid M₂ :=
 { .. hf.comm_semigroup f mul, .. hf.monoid f one mul }
 
-variables [has_inv M₂]
-
-/-- A type endowed with `1`, `*` and `⁻¹` is a group,
-if it admits a surjective map that preserves `1`, `*` and `⁻¹` from a group. -/
-@[to_additive
-"A type endowed with `0`, `+`, and unary `-` is an additive group,
-if it admits a surjective map that preserves `0`, `+`, and `-` from an additive group."]
-protected def group [group M₁] (f : M₁ → M₂) (hf : surjective f)
-  (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) :
-  group M₂ :=
-{ mul_left_inv := hf.forall.2 $ λ x, by erw [← inv, ← mul, mul_left_inv, one]; refl,
-  ..‹has_inv M₂›, .. hf.monoid f one mul }
+variables [has_inv M₂] [has_div M₂]
 
 /-- A type endowed with `1`, `*`, `⁻¹`, and `/` is a `div_inv_monoid`,
 if it admits a surjective map that preserves `1`, `*`, `⁻¹`, and `/` from a `div_inv_monoid` -/
 @[to_additive
 "A type endowed with `0`, `+`, and `-` (unary and binary) is an additive group,
 if it admits a surjective map that preserves `0`, `+`, and `-` from a `sub_neg_monoid`"]
-protected def div_inv_monoid [has_div M₂] [div_inv_monoid M₁] (f : M₁ → M₂) (hf : surjective f)
+protected def div_inv_monoid [div_inv_monoid M₁] (f : M₁ → M₂) (hf : surjective f)
   (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f (x⁻¹) = (f x)⁻¹)
   (div : ∀ x y, f (x / y) = f x / f y) :
   div_inv_monoid M₂ :=
 { div_eq_mul_inv := hf.forall₂.2 $ λ x y, by erw [← inv, ← mul, ← div, div_eq_mul_inv],
   .. hf.monoid f one mul, .. ‹has_div M₂›, .. ‹has_inv M₂› }
 
-/-- A type endowed with `1`, `*`, `⁻¹` and `/` is a group,
-if it admits an surjective map from a group that preserves these operations.
-
-This version of `surjective.group` makes sure that the `/` operation is defeq
-to the specified division operator.
--/
+/-- A type endowed with `1`, `*`, `⁻¹`, and `/` is a group,
+if it admits a surjective map that preserves `1`, `*`, `⁻¹`, and `/` from a group. -/
 @[to_additive
-"A type endowed with `0`, `+` and `-` is an additive group,
-if it admits an surjective map from an additive group that preserves these operations.
-
-This version of `surjective.add_group` makes sure that the `-` operation is defeq
-to the specified subtraction operator."]
-protected def group_div [has_div M₂] [group M₁] (f : M₁ → M₂) (hf : surjective f)
+"A type endowed with `0`, `+`, and unary `-` is an additive group,
+if it admits a surjective map that preserves `0`, `+`, and `-` from an additive group."]
+protected def group [group M₁] (f : M₁ → M₂) (hf : surjective f)
   (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f (x⁻¹) = (f x)⁻¹)
   (div : ∀ x y, f (x / y) = f x / f y) :
   group M₂ :=
-{ .. hf.div_inv_monoid f one mul inv div, .. hf.group f one mul inv }
+{ mul_left_inv := hf.forall.2 $ λ x, by erw [← inv, ← mul, mul_left_inv, one]; refl,
+  .. hf.div_inv_monoid f one mul inv div }
 
-/-- A type endowed with `1`, `*` and `⁻¹` is a commutative group,
-if it admits a surjective map that preserves `1`, `*` and `⁻¹` from a commutative group. -/
+/-- A type endowed with `1`, `*`, `⁻¹`, and `/` is a commutative group,
+if it admits a surjective map that preserves `1`, `*`, `⁻¹`, and `/` from a commutative group. -/
 @[to_additive
 "A type endowed with `0` and `+` is an additive commutative group,
 if it admits a surjective map that preserves `0` and `+` to an additive commutative group."]
 protected def comm_group [comm_group M₁] (f : M₁ → M₂) (hf : surjective f)
-  (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) :
-  comm_group M₂ :=
-{ .. hf.comm_monoid f one mul, .. hf.group f one mul inv }
-
-/-- A type endowed with `1`, `*`, `⁻¹` and `/` is a commutative group,
-if it admits an surjective map from a commutative group that preserves these operations.
-
-This version of `surjective.comm_group` makes sure that the `/` operation is defeq
-to the specified division operator.
--/
-@[to_additive
-"A type endowed with `0`, `+` and `-` is an additive commutative group,
-if it admits an surjective map from an additive commutative group that preserves these operations.
-
-This version of `surjective.add_comm_group` makes sure that the `-` operation is defeq
-to the specified subtraction operator."]
-protected def comm_group_div [has_div M₂] [comm_group M₁] (f : M₁ → M₂) (hf : surjective f)
   (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f (x⁻¹) = (f x)⁻¹)
   (div : ∀ x y, f (x / y) = f x / f y) :
   comm_group M₂ :=
-{ .. hf.comm_monoid f one mul, .. hf.group_div f one mul inv div }
+{ .. hf.comm_monoid f one mul, .. hf.group f one mul inv div }
 
 end surjective
 

--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -331,51 +331,29 @@ alias div_eq_mul_inv ← division_def
 
 /-- Pullback a `group_with_zero` class along an injective function. -/
 protected def function.injective.group_with_zero [has_zero G₀'] [has_mul G₀'] [has_one G₀']
-  [has_inv G₀'] (f : G₀' → G₀) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f x⁻¹ = (f x)⁻¹) :
-  group_with_zero G₀' :=
-{ inv := has_inv.inv,
-  inv_zero := hf $ by erw [inv, zero, inv_zero],
-  mul_inv_cancel := λ x hx, hf $ by erw [one, mul, inv, mul_inv_cancel ((hf.ne_iff' zero).2 hx)],
-  .. hf.monoid_with_zero f zero one mul,
-  .. pullback_nonzero f zero one }
-
-/-- Pullback a `group_with_zero` class along an injective function. This is a version of
-`function.injective.group_with_zero` that uses a specified `/` instead of the default
-`a / b = a * b⁻¹`. -/
-protected def function.injective.group_with_zero_div [has_zero G₀'] [has_mul G₀'] [has_one G₀']
   [has_inv G₀'] [has_div G₀'] (f : G₀' → G₀) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
   (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f x⁻¹ = (f x)⁻¹)
   (div : ∀ x y, f (x / y) = f x / f y) :
   group_with_zero G₀' :=
-{ .. hf.monoid_with_zero f zero one mul,
+{ inv_zero := hf $ by erw [inv, zero, inv_zero],
+  mul_inv_cancel := λ x hx, hf $ by erw [one, mul, inv, mul_inv_cancel ((hf.ne_iff' zero).2 hx)],
+  .. hf.monoid_with_zero f zero one mul,
   .. hf.div_inv_monoid f one mul inv div,
-  .. pullback_nonzero f zero one,
-  .. hf.group_with_zero f zero one mul inv }
+  .. pullback_nonzero f zero one, }
 
 /-- Pushforward a `group_with_zero` class along an surjective function. -/
 protected def function.surjective.group_with_zero [has_zero G₀'] [has_mul G₀'] [has_one G₀']
-  [has_inv G₀'] (h01 : (0:G₀') ≠ 1)
-  (f : G₀ → G₀') (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f x⁻¹ = (f x)⁻¹) :
-  group_with_zero G₀' :=
-{ inv := has_inv.inv,
-  inv_zero := by erw [← zero, ← inv, inv_zero],
-  mul_inv_cancel := hf.forall.2 $ λ x hx,
-    by erw [← inv, ← mul, mul_inv_cancel (mt (congr_arg f) $ trans_rel_left ne hx zero.symm)];
-      exact one,
-  exists_pair_ne := ⟨0, 1, h01⟩,
-  .. hf.monoid_with_zero f zero one mul }
-
-/-- Pushforward a `group_with_zero` class along a surjective function. This is a version of
-`function.surjective.group_with_zero` that uses a specified `/` instead of the default
-`a / b = a * b⁻¹`. -/
-protected def function.surjective.group_with_zero_div [has_zero G₀'] [has_mul G₀'] [has_one G₀']
   [has_inv G₀'] [has_div G₀'] (h01 : (0:G₀') ≠ 1) (f : G₀ → G₀') (hf : surjective f)
   (zero : f 0 = 0) (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y)
   (inv : ∀ x, f x⁻¹ = (f x)⁻¹) (div : ∀ x y, f (x / y) = f x / f y) :
   group_with_zero G₀' :=
-{ .. hf.div_inv_monoid f one mul inv div, .. hf.group_with_zero h01 f zero one mul inv }
+{ inv_zero := by erw [← zero, ← inv, inv_zero],
+  mul_inv_cancel := hf.forall.2 $ λ x hx,
+    by erw [← inv, ← mul, mul_inv_cancel (mt (congr_arg f) $ trans_rel_left ne hx zero.symm)];
+      exact one,
+  exists_pair_ne := ⟨0, 1, h01⟩,
+  .. hf.monoid_with_zero f zero one mul,
+  .. hf.div_inv_monoid f one mul inv div }
 
 @[simp] lemma mul_inv_cancel_right' {b : G₀} (h : b ≠ 0) (a : G₀) :
   (a * b) * b⁻¹ = a :=
@@ -684,34 +662,19 @@ instance comm_group_with_zero.comm_cancel_monoid_with_zero : comm_cancel_monoid_
 
 /-- Pullback a `comm_group_with_zero` class along an injective function. -/
 protected def function.injective.comm_group_with_zero [has_zero G₀'] [has_mul G₀'] [has_one G₀']
-  [has_inv G₀'] (f : G₀' → G₀) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f x⁻¹ = (f x)⁻¹) :
-  comm_group_with_zero G₀' :=
-{ .. hf.group_with_zero f zero one mul inv, .. hf.comm_semigroup f mul }
-
-/-- Pullback a `comm_group_with_zero` class along an injective function. -/
-protected def function.injective.comm_group_with_zero_div [has_zero G₀'] [has_mul G₀'] [has_one G₀']
   [has_inv G₀'] [has_div G₀'] (f : G₀' → G₀) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
   (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f x⁻¹ = (f x)⁻¹)
   (div : ∀ x y, f (x / y) = f x / f y) :
   comm_group_with_zero G₀' :=
-{ .. hf.group_with_zero_div f zero one mul inv div, .. hf.comm_semigroup f mul }
-
-/-- Pushforward a `comm_group_with_zero` class along an surjective function. -/
-protected def function.surjective.comm_group_with_zero [has_zero G₀'] [has_mul G₀'] [has_one G₀']
-  [has_inv G₀'] (h01 : (0:G₀') ≠ 1)
-  (f : G₀ → G₀') (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f x⁻¹ = (f x)⁻¹) :
-  comm_group_with_zero G₀' :=
-{ .. hf.group_with_zero h01 f zero one mul inv, .. hf.comm_semigroup f mul }
+{ .. hf.group_with_zero f zero one mul inv div, .. hf.comm_semigroup f mul }
 
 /-- Pushforward a `comm_group_with_zero` class along a surjective function. -/
-protected def function.surjective.comm_group_with_zero_div [has_zero G₀'] [has_mul G₀']
+protected def function.surjective.comm_group_with_zero [has_zero G₀'] [has_mul G₀']
   [has_one G₀'] [has_inv G₀'] [has_div G₀'] (h01 : (0:G₀') ≠ 1) (f : G₀ → G₀') (hf : surjective f)
   (zero : f 0 = 0) (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (inv : ∀ x, f x⁻¹ = (f x)⁻¹)
   (div : ∀ x y, f (x / y) = f x / f y) :
   comm_group_with_zero G₀' :=
-{ .. hf.group_with_zero_div h01 f zero one mul inv div, .. hf.comm_semigroup f mul }
+{ .. hf.group_with_zero h01 f zero one mul inv div, .. hf.comm_semigroup f mul }
 
 lemma mul_inv' : (a * b)⁻¹ = a⁻¹ * b⁻¹ :=
 by rw [mul_inv_rev', mul_comm]

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -425,7 +425,7 @@ def function.injective.ordered_comm_group {β : Type*}
   ordered_comm_group β :=
 { ..partial_order.lift f hf,
   ..hf.ordered_comm_monoid f one mul,
-  ..hf.comm_group_div f one mul inv div }
+  ..hf.comm_group f one mul inv div }
 
 end ordered_comm_group
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -655,7 +655,7 @@ def function.injective.ordered_ring {β : Type*}
   ordered_ring β :=
 { mul_pos := λ a b a0 b0, show f 0 < f (a * b), by { rw [zero, mul], apply mul_pos; rwa ← zero },
   ..hf.ordered_semiring f zero one add mul,
-  ..hf.ring_sub f zero one add mul neg sub }
+  ..hf.ring f zero one add mul neg sub }
 
 end ordered_ring
 
@@ -675,7 +675,7 @@ def function.injective.ordered_comm_ring [ordered_comm_ring α] {β : Type*}
   ordered_comm_ring β :=
 { ..hf.ordered_comm_semiring f zero one add mul,
   ..hf.ordered_ring f zero one add mul neg sub,
-  ..hf.comm_ring_sub f zero one add mul neg sub }
+  ..hf.comm_ring f zero one add mul neg sub }
 
 end ordered_comm_ring
 

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -489,40 +489,22 @@ instance ring.to_semiring : semiring α :=
   ..‹ring α› }
 
 /-- Pullback a `ring` instance along an injective function. -/
-protected def function.injective.ring [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) :
-  ring β :=
-{ .. hf.add_comm_group f zero add neg, .. hf.monoid f one mul, .. hf.distrib f add mul }
-
-/-- Pullback a `ring` instance along an injective function,
-with a subtraction (`-`) that is not necessarily defeq to `a + -b`. -/
-protected def function.injective.ring_sub
+protected def function.injective.ring
   [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
   (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
   (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
   (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y) :
   ring β :=
-{ .. hf.add_comm_group_sub f zero add neg sub, .. hf.monoid f one mul, .. hf.distrib f add mul }
+{ .. hf.add_comm_group f zero add neg sub, .. hf.monoid f one mul, .. hf.distrib f add mul }
 
 /-- Pullback a `ring` instance along an injective function. -/
-protected def function.surjective.ring [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β]
-  (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) :
-  ring β :=
-{ .. hf.add_comm_group f zero add neg, .. hf.monoid f one mul, .. hf.distrib f add mul }
-
-/-- Pullback a `ring` instance along an injective function,
-with a subtraction (`-`) that is not necessarily defeq to `a + -b`. -/
-protected def function.surjective.ring_sub
+protected def function.surjective.ring
   [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
   (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
   (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
   (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y) :
   ring β :=
-{ .. hf.add_comm_group_sub f zero add neg sub, .. hf.monoid f one mul, .. hf.distrib f add mul }
+{ .. hf.add_comm_group f zero add neg sub, .. hf.monoid f one mul, .. hf.distrib f add mul }
 
 lemma neg_mul_eq_neg_mul (a b : α) : -(a * b) = -a * b :=
 neg_eq_of_add_eq_zero
@@ -659,40 +641,22 @@ section comm_ring
 variables [comm_ring α] {a b c : α}
 
 /-- Pullback a `comm_ring` instance along an injective function. -/
-protected def function.injective.comm_ring [has_zero β] [has_one β] [has_add β] [has_mul β]
-  [has_neg β] (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) :
-  comm_ring β :=
-{ .. hf.ring f zero one add mul neg, .. hf.comm_semigroup f mul }
-
-/-- Pullback a `comm_ring` instance along an injective function,
-with a subtraction (`-`) that is not necessarily defeq to `a + -b`. -/
-protected def function.injective.comm_ring_sub
+protected def function.injective.comm_ring
   [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
   (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
   (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
   (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y) :
   comm_ring β :=
-{ .. hf.ring_sub f zero one add mul neg sub, .. hf.comm_semigroup f mul }
+{ .. hf.ring f zero one add mul neg sub, .. hf.comm_semigroup f mul }
 
 /-- Pullback a `comm_ring` instance along an injective function. -/
-protected def function.surjective.comm_ring [has_zero β] [has_one β] [has_add β] [has_mul β]
-  [has_neg β] (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) :
-  comm_ring β :=
-{ .. hf.ring f zero one add mul neg, .. hf.comm_semigroup f mul }
-
-/-- Pullback a `comm_ring` instance along an injective function,
-with a subtraction (`-`) that is not necessarily defeq to `a + -b`. -/
-protected def function.surjective.comm_ring_sub
+protected def function.surjective.comm_ring
   [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
   (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
   (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
   (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y) :
   comm_ring β :=
-{ .. hf.ring_sub f zero one add mul neg sub, .. hf.comm_semigroup f mul }
+{ .. hf.ring f zero one add mul neg sub, .. hf.comm_semigroup f mul }
 
 local attribute [simp] add_assoc add_comm add_left_comm mul_comm
 
@@ -827,11 +791,11 @@ instance domain.to_cancel_monoid_with_zero : cancel_monoid_with_zero α :=
 
 /-- Pullback a `domain` instance along an injective function. -/
 protected def function.injective.domain [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
+  [has_sub β] (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
   (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) :
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y) :
   domain β :=
-{ .. hf.ring f zero one add mul neg, .. pullback_nonzero f zero one,
+{ .. hf.ring f zero one add mul neg sub, .. pullback_nonzero f zero one,
   .. hf.no_zero_divisors f zero mul }
 
 end domain
@@ -854,12 +818,12 @@ instance integral_domain.to_comm_cancel_monoid_with_zero : comm_cancel_monoid_wi
 { ..comm_semiring.to_comm_monoid_with_zero, ..domain.to_cancel_monoid_with_zero }
 
 /-- Pullback an `integral_domain` instance along an injective function. -/
-protected def function.injective.integral_domain [has_zero β] [has_one β] [has_add β]
-  [has_mul β] [has_neg β] (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
+protected def function.injective.integral_domain [has_zero β] [has_one β] [has_add β] [has_mul β]
+  [has_neg β] [has_sub β] (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
   (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) :
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y) :
   integral_domain β :=
-{ .. hf.comm_ring f zero one add mul neg, .. hf.domain f zero one add mul neg }
+{ .. hf.comm_ring f zero one add mul neg sub, .. hf.domain f zero one add mul neg sub }
 
 lemma mul_self_eq_mul_self_iff {a b : α} : a * a = b * b ↔ a = b ∨ a = -b :=
 by rw [← sub_eq_zero, mul_self_sub_mul_self, mul_eq_zero, or_comm, sub_eq_zero,

--- a/src/analysis/analytic/composition.lean
+++ b/src/analysis/analytic/composition.lean
@@ -474,7 +474,9 @@ begin
         field_simp [mul_pow, (zero_lt_one.trans_le hCp1).ne'],
         ac_refl
       end },
-  refine ⟨r, r_pos, nnreal.summable_of_le I (summable.mul_left _ _)⟩,
+  refine ⟨r, r_pos, nnreal.summable_of_le I _⟩,
+  simp_rw div_eq_mul_inv,
+  refine summable.mul_left _ _,
   have h4 : ∀ n : ℕ, 0 < (4 ^ n : ℝ≥0)⁻¹ := λ n, nnreal.inv_pos.2 (pow_pos zero_lt_four _),
   have : ∀ n : ℕ, has_sum (λ c : composition n, (4 ^ n : ℝ≥0)⁻¹) (2 ^ (n - 1) / 4 ^ n),
   { intro n,

--- a/src/analysis/normed_space/normed_group_hom.lean
+++ b/src/analysis/normed_space/normed_group_hom.lean
@@ -319,7 +319,7 @@ instance : has_sub (normed_group_hom V₁ V₂) :=
 
 /-- Homs between two given normed groups form a commutative additive group. -/
 instance : add_comm_group (normed_group_hom V₁ V₂) :=
-coe_injective.add_comm_group_sub _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+coe_injective.add_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- Normed group homomorphisms themselves form a normed group with respect to
     the operator norm. -/

--- a/src/data/equiv/transfer_instance.lean
+++ b/src/data/equiv/transfer_instance.lean
@@ -163,7 +163,7 @@ by resetI; apply e.injective.group _; intros; exact e.apply_symm_apply _
 @[to_additive "Transfer `add_comm_group` across an `equiv`"]
 protected def comm_group [comm_group β] : comm_group α :=
 let one := e.has_one, mul := e.has_mul, inv := e.has_inv, div := e.has_div in
-by resetI; apply e.injective.comm_group_div _; intros; exact e.apply_symm_apply _
+by resetI; apply e.injective.comm_group _; intros; exact e.apply_symm_apply _
 
 /-- Transfer `semiring` across an `equiv` -/
 protected def semiring [semiring β] : semiring α :=
@@ -179,13 +179,13 @@ by resetI; apply e.injective.comm_semiring _; intros; exact e.apply_symm_apply _
 protected def ring [ring β] : ring α :=
 let zero := e.has_zero, add := e.has_add, one := e.has_one, mul := e.has_mul, neg := e.has_neg,
   sub := e.has_sub in
-by resetI; apply e.injective.ring_sub _; intros; exact e.apply_symm_apply _
+by resetI; apply e.injective.ring _; intros; exact e.apply_symm_apply _
 
 /-- Transfer `comm_ring` across an `equiv` -/
 protected def comm_ring [comm_ring β] : comm_ring α :=
 let zero := e.has_zero, add := e.has_add, one := e.has_one, mul := e.has_mul, neg := e.has_neg,
   sub := e.has_sub in
-by resetI; apply e.injective.comm_ring_sub _; intros; exact e.apply_symm_apply _
+by resetI; apply e.injective.comm_ring _; intros; exact e.apply_symm_apply _
 
 /-- Transfer `nonzero` across an `equiv` -/
 protected theorem nontrivial [nontrivial β] : nontrivial α :=

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -89,6 +89,7 @@ instance : has_add ℝ≥0   := ⟨λa b, ⟨a + b, add_nonneg a.2 b.2⟩⟩
 instance : has_sub ℝ≥0   := ⟨λa b, nnreal.of_real (a - b)⟩
 instance : has_mul ℝ≥0   := ⟨λa b, ⟨a * b, mul_nonneg a.2 b.2⟩⟩
 instance : has_inv ℝ≥0   := ⟨λa, ⟨(a.1)⁻¹, inv_nonneg.2 a.2⟩⟩
+instance : has_div ℝ≥0   := ⟨λa b, ⟨a / b, div_nonneg a.2 b.2⟩⟩
 instance : has_le ℝ≥0    := ⟨λ r s, (r:ℝ) ≤ s⟩
 instance : has_bot ℝ≥0   := ⟨0⟩
 instance : inhabited ℝ≥0 := ⟨0⟩
@@ -101,6 +102,7 @@ nnreal.coe_injective.eq_iff
 @[simp, norm_cast] protected lemma coe_add (r₁ r₂ : ℝ≥0) : ((r₁ + r₂ : ℝ≥0) : ℝ) = r₁ + r₂ := rfl
 @[simp, norm_cast] protected lemma coe_mul (r₁ r₂ : ℝ≥0) : ((r₁ * r₂ : ℝ≥0) : ℝ) = r₁ * r₂ := rfl
 @[simp, norm_cast] protected lemma coe_inv (r : ℝ≥0) : ((r⁻¹ : ℝ≥0) : ℝ) = r⁻¹ := rfl
+@[simp, norm_cast] protected lemma coe_div (r₁ r₂ : ℝ≥0) : ((r₁ / r₂ : ℝ≥0) : ℝ) = r₁ / r₂ := rfl
 @[simp, norm_cast] protected lemma coe_bit0 (r : ℝ≥0) : ((bit0 r : ℝ≥0) : ℝ) = bit0 r := rfl
 @[simp, norm_cast] protected lemma coe_bit1 (r : ℝ≥0) : ((bit1 r : ℝ≥0) : ℝ) = bit1 r := rfl
 
@@ -133,13 +135,13 @@ instance : comm_group_with_zero ℝ≥0 :=
   mul := (*),
   one := 1,
   inv := has_inv.inv,
-  .. nnreal.coe_injective.comm_group_with_zero _ rfl rfl (λ _ _, rfl) (λ _, rfl) }
+  div := (/),
+  .. nnreal.coe_injective.comm_group_with_zero _ rfl rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) }
 
 @[simp, norm_cast] lemma coe_indicator {α} (s : set α) (f : α → ℝ≥0) (a : α) :
   ((s.indicator f a : ℝ≥0) : ℝ) = s.indicator (λ x, f x) a :=
 (to_real_hom : ℝ≥0 →+ ℝ).map_indicator _ _ _
 
-@[simp, norm_cast] protected lemma coe_div (r₁ r₂ : ℝ≥0) : ((r₁ / r₂ : ℝ≥0) : ℝ) = r₁ / r₂ := rfl
 @[simp, norm_cast] lemma coe_pow (r : ℝ≥0) (n : ℕ) : ((r^n : ℝ≥0) : ℝ) = r^n :=
 to_real_hom.map_pow r n
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -273,12 +273,12 @@ attribute [norm_cast] add_subgroup.coe_add add_subgroup.coe_zero
 /-- A subgroup of a group inherits a group structure. -/
 @[to_additive "An `add_subgroup` of an `add_group` inherits an `add_group` structure."]
 instance to_group {G : Type*} [group G] (H : subgroup G) : group H :=
-subtype.coe_injective.group_div _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+subtype.coe_injective.group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- A subgroup of a `comm_group` is a `comm_group`. -/
 @[to_additive "An `add_subgroup` of an `add_comm_group` is an `add_comm_group`."]
 instance to_comm_group {G : Type*} [comm_group G] (H : subgroup G) : comm_group H :=
-subtype.coe_injective.comm_group_div _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+subtype.coe_injective.comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- A subgroup of an `ordered_comm_group` is an `ordered_comm_group`. -/
 @[to_additive "An `add_subgroup` of an `add_ordered_comm_group` is an `add_ordered_comm_group`."]

--- a/src/measure_theory/ae_eq_fun.lean
+++ b/src/measure_theory/ae_eq_fun.lean
@@ -346,25 +346,23 @@ variables [topological_space γ] [borel_space γ] [group γ] [topological_group 
 @[to_additive] lemma inv_to_germ (f : α →ₘ[μ] γ) : (f⁻¹).to_germ = f.to_germ⁻¹ := comp_to_germ _ _ _
 
 variables [second_countable_topology γ]
+
+@[to_additive] instance : has_div (α →ₘ[μ] γ) := ⟨comp₂ has_div.div measurable_div⟩
+
+@[to_additive, simp] lemma mk_div (f g : α → γ) (hf hg) :
+  mk (f / g) (ae_measurable.div hf hg) = (mk f hf : α →ₘ[μ] γ) / (mk g hg) :=
+rfl
+
+@[to_additive] lemma coe_fn_div (f g : α →ₘ[μ] γ) : ⇑(f / g) =ᵐ[μ] f / g := coe_fn_comp₂ _ _ _ _
+
+@[to_additive] lemma div_to_germ (f g : α →ₘ[μ] γ) : (f / g).to_germ = f.to_germ / g.to_germ :=
+comp₂_to_germ _ _ _ _
+
 @[to_additive]
-instance : group (α →ₘ[μ] γ) := to_germ_injective.group _ one_to_germ mul_to_germ inv_to_germ
+instance : group (α →ₘ[μ] γ) :=
+to_germ_injective.group _ one_to_germ mul_to_germ inv_to_germ div_to_germ
 
 end group
-
-section add_group
-
-variables [topological_space γ] [borel_space γ] [add_group γ] [topological_add_group γ]
-  [second_countable_topology γ]
-
-@[simp] lemma mk_sub (f g : α → γ) (hf hg) :
-  mk (f - g) (ae_measurable.sub hf hg) = (mk f hf : α →ₘ[μ] γ) - (mk g hg) :=
-by simp [sub_eq_add_neg]
-
-lemma coe_fn_sub (f g : α →ₘ[μ] γ) : ⇑(f - g) =ᵐ[μ] f - g :=
-by { simp only [sub_eq_add_neg],
-     exact ((coe_fn_add f (-g)).trans $ (coe_fn_neg g).mono $ λ x hx, congr_arg ((+) (f x)) hx) }
-
-end add_group
 
 @[to_additive]
 instance [topological_space γ] [borel_space γ] [comm_group γ] [topological_group γ]

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -301,11 +301,11 @@ rfl
 lemma sub_apply [has_sub β] (f g : α →ₛ β) (x : α) : (f - g) x = f x - g x := rfl
 
 instance [add_group β] : add_group (α →ₛ β) :=
-function.injective.add_group_sub (λ f, show α → β, from f) coe_injective
+function.injective.add_group (λ f, show α → β, from f) coe_injective
   coe_zero coe_add coe_neg coe_sub
 
 instance [add_comm_group β] : add_comm_group (α →ₛ β) :=
-function.injective.add_comm_group_sub (λ f, show α → β, from f) coe_injective
+function.injective.add_comm_group (λ f, show α → β, from f) coe_injective
   coe_zero coe_add coe_neg coe_sub
 
 variables {K : Type*}

--- a/src/measure_theory/l1_space.lean
+++ b/src/measure_theory/l1_space.lean
@@ -618,7 +618,7 @@ end
 
 lemma integrable.sub {f g : α →ₘ[μ] β} (hf : integrable f) (hg : integrable g) :
   integrable (f - g) :=
-hf.add hg.neg
+(sub_eq_add_neg f g).symm ▸ hf.add hg.neg
 
 end
 
@@ -730,8 +730,7 @@ lemma to_L1_neg (f : α → β) (hf : integrable f μ) :
   to_L1 (- f) (integrable.neg hf) = - to_L1 f hf := rfl
 
 lemma to_L1_sub (f g : α → β) (hf : integrable f μ) (hg : integrable g μ) :
-  to_L1 (f - g) (hf.sub hg) = to_L1 f hf - to_L1 g hg :=
-by simp only [sub_eq_add_neg, to_L1_add _ _ hf hg.neg, to_L1_neg]
+  to_L1 (f - g) (hf.sub hg) = to_L1 f hf - to_L1 g hg := rfl
 
 lemma norm_to_L1 (f : α → β) (hf : integrable f μ) :
   ∥hf.to_L1 f∥ = ennreal.to_real (∫⁻ a, edist (f a) 0 ∂μ) :=

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -899,8 +899,7 @@ lemma to_Lp_add {f g : α → E} (hf : mem_ℒp f p μ) (hg : mem_ℒp g p μ) :
 lemma to_Lp_neg {f : α → E} (hf : mem_ℒp f p μ) : hf.neg.to_Lp (-f) = - hf.to_Lp f := rfl
 
 lemma to_Lp_sub {f g : α → E} (hf : mem_ℒp f p μ) (hg : mem_ℒp g p μ) :
-  (hf.sub hg).to_Lp (f - g) = hf.to_Lp f - hg.to_Lp g :=
-by { convert hf.to_Lp_add hg.neg, exact sub_eq_add_neg f g }
+  (hf.sub hg).to_Lp (f - g) = hf.to_Lp f - hg.to_Lp g := rfl
 
 end mem_ℒp
 

--- a/src/ring_theory/witt_vector/basic.lean
+++ b/src/ring_theory/witt_vector/basic.lean
@@ -196,17 +196,17 @@ include hp
 
 local attribute [instance]
 private def comm_ring_aux₁ : comm_ring (𝕎 (mv_polynomial R ℚ)) :=
-(ghost_equiv' p (mv_polynomial R ℚ)).injective.comm_ring_sub (ghost_fun)
+(ghost_equiv' p (mv_polynomial R ℚ)).injective.comm_ring (ghost_fun)
   ghost_fun_zero ghost_fun_one ghost_fun_add ghost_fun_mul ghost_fun_neg ghost_fun_sub
 
 local attribute [instance]
 private def comm_ring_aux₂ : comm_ring (𝕎 (mv_polynomial R ℤ)) :=
-(map_fun.injective _ $ map_injective (int.cast_ring_hom ℚ) int.cast_injective).comm_ring_sub _
+(map_fun.injective _ $ map_injective (int.cast_ring_hom ℚ) int.cast_injective).comm_ring _
   (map_fun.zero _) (map_fun.one _) (map_fun.add _) (map_fun.mul _) (map_fun.neg _) (map_fun.sub _)
 
 /-- The commutative ring structure on `𝕎 R`. -/
 instance : comm_ring (𝕎 R) :=
-(map_fun.surjective _ $ counit_surjective _).comm_ring_sub (map_fun $ mv_polynomial.counit _)
+(map_fun.surjective _ $ counit_surjective _).comm_ring (map_fun $ mv_polynomial.counit _)
   (map_fun.zero _) (map_fun.one _) (map_fun.add _) (map_fun.mul _) (map_fun.neg _) (map_fun.sub _)
 
 variables {p R}

--- a/src/ring_theory/witt_vector/truncated.lean
+++ b/src/ring_theory/witt_vector/truncated.lean
@@ -175,6 +175,9 @@ instance : has_mul (truncated_witt_vector p n R) :=
 instance : has_neg (truncated_witt_vector p n R) :=
 ⟨λ x, truncate_fun n (- x.out)⟩
 
+instance : has_sub (truncated_witt_vector p n R) :=
+⟨λ x y, truncate_fun n (x.out - y.out)⟩
+
 @[simp] lemma coeff_zero (i : fin n) :
   (0 : truncated_witt_vector p n R).coeff i = 0 :=
 begin
@@ -189,7 +192,7 @@ meta def tactic.interactive.witt_truncate_fun_tac : tactic unit :=
 `[show _ = truncate_fun n _,
   apply truncated_witt_vector.out_injective,
   iterate { rw [out_truncate_fun] },
-  rw init_add <|> rw init_mul <|> rw init_neg]
+  rw init_add <|> rw init_mul <|> rw init_neg <|> rw init_sub]
 
 namespace witt_vector
 
@@ -224,6 +227,10 @@ lemma truncate_fun_neg (x : 𝕎 R) :
   truncate_fun n (-x) = -truncate_fun n x :=
 by witt_truncate_fun_tac
 
+lemma truncate_fun_sub (x y : 𝕎 R) :
+  truncate_fun n (x - y) = truncate_fun n x - truncate_fun n y :=
+by witt_truncate_fun_tac
+
 end witt_vector
 
 namespace truncated_witt_vector
@@ -239,6 +246,7 @@ instance : comm_ring (truncated_witt_vector p n R) :=
   (truncate_fun_add n)
   (truncate_fun_mul n)
   (truncate_fun_neg n)
+  (truncate_fun_sub n)
 
 end truncated_witt_vector
 

--- a/src/topology/algebra/multilinear.lean
+++ b/src/topology/algebra/multilinear.lean
@@ -266,7 +266,7 @@ instance : has_sub (continuous_multilinear_map R M₁ M₂) :=
 @[simp] lemma sub_apply (m : Πi, M₁ i) : (f - f') m = f m - f' m := rfl
 
 instance : add_comm_group (continuous_multilinear_map R M₁ M₂) :=
-to_multilinear_map_inj.add_comm_group_sub _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+to_multilinear_map_inj.add_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 end topological_add_group
 


### PR DESCRIPTION
The variables without the `_sub` / `_div` suffix were vestigial definitions that existed in order to prevent the already-large `div_inv_monoid` refactor becoming larger. This change removes all their remaining usages, allowing the `_sub` / `_div` versions to lose their suffix.

This changes the division operation on `α →ₘ[μ] γ` and the subtraction operator on `truncated_witt_vector p n R` to definitionally match the division operation on their components. In practice, this just shuffles some uses of `sub_eq_add_neg` around.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This will probably require some iteration to get passing CI.

This came up in https://github.com/leanprover-community/mathlib/pull/7028#discussion_r606834418