### PR TITLE
[Merged by Bors] - feat(logic/small): instances for Pi and sigma types

### DIFF
--- a/src/logic/small.lean
+++ b/src/logic/small.lean
@@ -94,4 +94,25 @@ end
 instance small_of_encodable (α : Type v) [encodable α] : small.{w} α :=
 small_of_injective _ (encodable.encode_injective)
 
+instance small_Pi {α} (β : α → Type*) [small.{w} α] [∀ a, small.{w} (β a)] :
+  small.{w} (Π a, β a) :=
+⟨⟨Π a' : shrink α, shrink (β ((equiv_shrink α).symm a')),
+  ⟨equiv.Pi_congr (equiv_shrink α) (λ a, by simpa using equiv_shrink (β a))⟩⟩⟩
+
+instance small_sigma {α} (β : α → Type*) [small.{w} α] [∀ a, small.{w} (β a)] :
+  small.{w} (Σ a, β a) :=
+⟨⟨Σ a' : shrink α, shrink (β ((equiv_shrink α).symm a')),
+  ⟨equiv.sigma_congr (equiv_shrink α) (λ a, by simpa using equiv_shrink (β a))⟩⟩⟩
+
+instance small_prod {α β} [small α] [small β] : small (α × β) :=
+⟨⟨shrink α × shrink β,
+  ⟨equiv.prod_congr (equiv_shrink α) (equiv_shrink β)⟩⟩⟩
+
+instance small_sum {α β} [small α] [small β] : small (α ⊕ β) :=
+⟨⟨shrink α ⊕ shrink β,
+  ⟨equiv.sum_congr (equiv_shrink α) (equiv_shrink β)⟩⟩⟩
+
+instance small_set {α} [small.{w} α] : small.{w} (set α) :=
+⟨⟨set (shrink α), ⟨equiv.set.congr (equiv_shrink α)⟩⟩⟩
+
 end

--- a/src/logic/small.lean
+++ b/src/logic/small.lean
@@ -104,11 +104,11 @@ instance small_sigma {α} (β : α → Type*) [small.{w} α] [∀ a, small.{w} (
 ⟨⟨Σ a' : shrink α, shrink (β ((equiv_shrink α).symm a')),
   ⟨equiv.sigma_congr (equiv_shrink α) (λ a, by simpa using equiv_shrink (β a))⟩⟩⟩
 
-instance small_prod {α β} [small α] [small β] : small (α × β) :=
+instance small_prod {α β} [small.{w} α] [small.{w} β] : small.{w} (α × β) :=
 ⟨⟨shrink α × shrink β,
   ⟨equiv.prod_congr (equiv_shrink α) (equiv_shrink β)⟩⟩⟩
 
-instance small_sum {α β} [small α] [small β] : small (α ⊕ β) :=
+instance small_sum {α β} [small.{w} α] [small.{w} β] : small.{w} (α ⊕ β) :=
 ⟨⟨shrink α ⊕ shrink β,
   ⟨equiv.sum_congr (equiv_shrink α) (equiv_shrink β)⟩⟩⟩
 


### PR DESCRIPTION
Add some instances to prove basic type formers preserve smallness.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
