### PR TITLE
[Merged by Bors] - feat(logic/function/basic): add injectivity/surjectivity of functions from/to subsingletons

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -59,7 +59,7 @@ instance psum.inhabited_right {α β} [inhabited β] : inhabited (psum α β) :=
   {α} [subsingleton α] : decidable_eq α
 | a b := is_true (subsingleton.elim a b)
 
-@[simp] lemma eq_iff_true_of_subsingleton [subsingleton α] (x y : α) :
+@[simp] lemma eq_iff_true_of_subsingleton {α : Sort*} [subsingleton α] (x y : α) :
   x = y ↔ true :=
 by cc
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -59,7 +59,7 @@ instance psum.inhabited_right {α β} [inhabited β] : inhabited (psum α β) :=
   {α} [subsingleton α] : decidable_eq α
 | a b := is_true (subsingleton.elim a b)
 
-@[simp] lemma eq_iff_true_of_subsingleton {α : Sort*} [subsingleton α] (x y : α) :
+@[simp] lemma eq_iff_true_of_subsingleton [subsingleton α] (x y : α) :
   x = y ↔ true :=
 by cc
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -92,7 +92,7 @@ lemma injective.of_comp_iff' (f : α → β) {g : γ → α} (hg : bijective g) 
     hx ▸ hy ▸ λ hf, h hf ▸ rfl,
   λ h, h.comp hg.injective⟩
 
-lemma injective_of_subsingleton {α β : Sort*} [subsingleton α] (f : α → β) :
+lemma injective_of_subsingleton [subsingleton α] (f : α → β) :
   injective f :=
 λ a b ab, subsingleton.elim _ _
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -354,7 +354,7 @@ lemma bijective_iff_has_inverse : bijective f ↔ ∃ g, left_inverse g f ∧ ri
 lemma injective_surj_inv (h : surjective f) : injective (surj_inv h) :=
 (right_inverse_surj_inv h).injective
 
-lemma surjective.to_subsingleton {α β : Type*} [na : nonempty α] [subsingleton β]
+lemma surjective.to_subsingleton [na : nonempty α] [subsingleton β]
   (f : α → β) :
   function.surjective f :=
 λ y, ⟨nonempty.some na, (eq_iff_true_of_subsingleton _ _).mpr trivial⟩

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -92,6 +92,11 @@ lemma injective.of_comp_iff' (f : α → β) {g : γ → α} (hg : bijective g) 
     hx ▸ hy ▸ λ hf, h hf ▸ rfl,
   λ h, h.comp hg.injective⟩
 
+lemma function.surjective.to_subsingleton {α β : Type*} [na : nonempty α] [subsingleton β]
+  (f : α → β) :
+  function.surjective f :=
+λ y, ⟨nonempty.some na, (eq_iff_true_of_subsingleton _ _).mpr trivial⟩
+
 lemma injective.dite (p : α → Prop) [decidable_pred p]
   {f : {a : α // p a} → β} {f' : {a : α // ¬ p a} → β}
   (hf : injective f) (hf' : injective f')

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -350,6 +350,15 @@ lemma bijective_iff_has_inverse : bijective f ↔ ∃ g, left_inverse g f ∧ ri
 lemma injective_surj_inv (h : surjective f) : injective (surj_inv h) :=
 (right_inverse_surj_inv h).injective
 
+lemma function.surjective.to_subsingleton {α β : Type*} (f : α → β) [nonempty α] [subsingleton β] :
+  function.surjective f :=
+begin
+  refine function.surjective_iff_has_right_inverse.mpr ⟨function.inv_fun f, _⟩,
+
+--  refine ⟨function.inv_fun f, _⟩,
+--  ⟨function.inv_fun f, by finish⟩
+end
+
 end surj_inv
 
 section update

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -354,8 +354,7 @@ lemma bijective_iff_has_inverse : bijective f ↔ ∃ g, left_inverse g f ∧ ri
 lemma injective_surj_inv (h : surjective f) : injective (surj_inv h) :=
 (right_inverse_surj_inv h).injective
 
-lemma surjective_to_subsingleton [na : nonempty α] [subsingleton β]
-  (f : α → β) :
+lemma surjective_to_subsingleton [na : nonempty α] [subsingleton β] (f : α → β) :
   surjective f :=
 λ y, let ⟨a⟩ := na in ⟨a, subsingleton.elim _ _⟩
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -92,10 +92,9 @@ lemma injective.of_comp_iff' (f : α → β) {g : γ → α} (hg : bijective g) 
     hx ▸ hy ▸ λ hf, h hf ▸ rfl,
   λ h, h.comp hg.injective⟩
 
-lemma function.surjective.to_subsingleton {α β : Type*} [na : nonempty α] [subsingleton β]
-  (f : α → β) :
-  function.surjective f :=
-λ y, ⟨nonempty.some na, (eq_iff_true_of_subsingleton _ _).mpr trivial⟩
+lemma injective.of_subsingleton {α β : Type*} [h : subsingleton α] (f : α → β) :
+  function.injective f :=
+λ a b ab, (eq_iff_true_of_subsingleton _ _).mpr trivial
 
 lemma injective.dite (p : α → Prop) [decidable_pred p]
   {f : {a : α // p a} → β} {f' : {a : α // ¬ p a} → β}
@@ -355,7 +354,7 @@ lemma bijective_iff_has_inverse : bijective f ↔ ∃ g, left_inverse g f ∧ ri
 lemma injective_surj_inv (h : surjective f) : injective (surj_inv h) :=
 (right_inverse_surj_inv h).injective
 
-lemma function.surjective.to_subsingleton {α β : Type*} [na : nonempty α] [subsingleton β]
+lemma surjective.to_subsingleton {α β : Type*} [na : nonempty α] [subsingleton β]
   (f : α → β) :
   function.surjective f :=
 λ y, ⟨nonempty.some na, (eq_iff_true_of_subsingleton _ _).mpr trivial⟩

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -92,9 +92,9 @@ lemma injective.of_comp_iff' (f : α → β) {g : γ → α} (hg : bijective g) 
     hx ▸ hy ▸ λ hf, h hf ▸ rfl,
   λ h, h.comp hg.injective⟩
 
-lemma injective.of_subsingleton {α β : Type*} [h : subsingleton α] (f : α → β) :
+lemma injective_of_subsingleton {α β : Sort*} [subsingleton α] (f : α → β) :
   function.injective f :=
-λ a b ab, (eq_iff_true_of_subsingleton _ _).mpr trivial
+λ a b ab, subsingleton.elim _ _
 
 lemma injective.dite (p : α → Prop) [decidable_pred p]
   {f : {a : α // p a} → β} {f' : {a : α // ¬ p a} → β}
@@ -354,10 +354,10 @@ lemma bijective_iff_has_inverse : bijective f ↔ ∃ g, left_inverse g f ∧ ri
 lemma injective_surj_inv (h : surjective f) : injective (surj_inv h) :=
 (right_inverse_surj_inv h).injective
 
-lemma surjective.to_subsingleton {α β : Type*} [na : nonempty α] [subsingleton β]
+lemma surjective_to_subsingleton {α β : Sort*} [na : nonempty α] [subsingleton β]
   (f : α → β) :
   function.surjective f :=
-λ y, ⟨nonempty.some na, (eq_iff_true_of_subsingleton _ _).mpr trivial⟩
+λ y, let ⟨a⟩ := na in ⟨a, subsingleton.elim _ _⟩
 
 end surj_inv
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -93,7 +93,7 @@ lemma injective.of_comp_iff' (f : α → β) {g : γ → α} (hg : bijective g) 
   λ h, h.comp hg.injective⟩
 
 lemma injective_of_subsingleton {α β : Sort*} [subsingleton α] (f : α → β) :
-  function.injective f :=
+  injective f :=
 λ a b ab, subsingleton.elim _ _
 
 lemma injective.dite (p : α → Prop) [decidable_pred p]
@@ -354,9 +354,9 @@ lemma bijective_iff_has_inverse : bijective f ↔ ∃ g, left_inverse g f ∧ ri
 lemma injective_surj_inv (h : surjective f) : injective (surj_inv h) :=
 (right_inverse_surj_inv h).injective
 
-lemma surjective.to_subsingleton [na : nonempty α] [subsingleton β]
+lemma surjective_to_subsingleton [na : nonempty α] [subsingleton β]
   (f : α → β) :
-  function.surjective f :=
+  surjective f :=
 λ y, let ⟨a⟩ := na in ⟨a, subsingleton.elim _ _⟩
 
 end surj_inv

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -350,14 +350,10 @@ lemma bijective_iff_has_inverse : bijective f ↔ ∃ g, left_inverse g f ∧ ri
 lemma injective_surj_inv (h : surjective f) : injective (surj_inv h) :=
 (right_inverse_surj_inv h).injective
 
-lemma function.surjective.to_subsingleton {α β : Type*} (f : α → β) [nonempty α] [subsingleton β] :
+lemma function.surjective.to_subsingleton {α β : Type*} [na : nonempty α] [subsingleton β]
+  (f : α → β) :
   function.surjective f :=
-begin
-  refine function.surjective_iff_has_right_inverse.mpr ⟨function.inv_fun f, _⟩,
-
---  refine ⟨function.inv_fun f, _⟩,
---  ⟨function.inv_fun f, by finish⟩
-end
+λ y, ⟨nonempty.some na, (eq_iff_true_of_subsingleton _ _).mpr trivial⟩
 
 end surj_inv
 


### PR DESCRIPTION
In the surjective lemma (`function.surjective.to_subsingleton`), ~~I had to assume `Type*`, instead of `Sort*`, since I was not able to make the proof work in the more general case.~~ [Edit: Eric fixed the proof so that now they work in full generality.] 🎉

Zulip:
https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/lemmas.20on.20int.20and.20subsingleton


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
