### PR TITLE
chore(linear_algebra/basic): add lemmas about endomorphism_semiring

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -463,6 +463,18 @@ instance endomorphism_semiring : semiring (M →ₗ[R] M) :=
 by refine {mul := (*), one := 1, ..linear_map.add_comm_monoid, ..};
   { intros, apply linear_map.ext, simp {proj := ff} }
 
+lemma one_def : (1 : M →ₗ[R] M) = id := rfl
+
+lemma coe_one : ((1 : M →ₗ[R] M) : M → M) = id := rfl
+
+lemma one_apply (x : M) : (1 : M →ₗ[R] M) x = x := rfl
+
+lemma mul_def (g f : M →ₗ[R] M) : g * f = g.comp f := rfl
+
+lemma coe_mul (f g : M →ₗ[R] M) (x : M) : ⇑(f * g) = f ∘ g := rfl
+
+lemma mul_apply (f g : M →ₗ[R] M) (x : M) : (f * g) x = f (g x) := rfl
+
 end semiring
 
 section ring

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -465,7 +465,7 @@ by refine {mul := (*), one := 1, ..linear_map.add_comm_monoid, ..};
 
 lemma one_def : (1 : M →ₗ[R] M) = id := rfl
 
-lemma coe_one : ((1 : M →ₗ[R] M) : M → M) = id := rfl
+lemma coe_one : ⇑(1 : M →ₗ[R] M) = id := rfl
 
 lemma one_apply (x : M) : (1 : M →ₗ[R] M) x = x := rfl
 


### PR DESCRIPTION
Cherry-picked from #4773

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I've not marked any of these simp because I suspect any simp normal form will be inconvenient, and non-simp lemmas are still better than no lemmas at all.

edit: whoops, we already have all these now, just with different names