### PR TITLE
[Merged by Bors] - feat(topology/category/Profinite): Profinite_to_Top creates limits.

### DIFF
--- a/src/topology/category/CompHaus.lean
+++ b/src/topology/category/CompHaus.lean
@@ -7,6 +7,7 @@ Authors: Adam Topaz, Bhavik Mehta
 import category_theory.adjunction.reflective
 import topology.category.Top
 import topology.stone_cech
+import category_theory.monad.limits
 
 /-!
 
@@ -118,3 +119,6 @@ The category of compact Hausdorff spaces is reflective in the category of topolo
 -/
 noncomputable instance CompHaus_to_Top.reflective : reflective CompHaus_to_Top :=
 { to_is_right_adjoint := ⟨Top_to_CompHaus, adjunction.adjunction_of_equiv_left _ _⟩ }
+
+noncomputable instance CompHaus_to_Top.creates_limits : creates_limits CompHaus_to_Top :=
+monadic_creates_limits _

--- a/src/topology/category/CompHaus.lean
+++ b/src/topology/category/CompHaus.lean
@@ -26,6 +26,8 @@ introduced.
 
 -/
 
+universe u
+
 open category_theory
 
 /-- The type of Compact Hausdorff topological spaces. -/
@@ -64,7 +66,7 @@ end CompHaus
 
 /-- The fully faithful embedding of `CompHaus` in `Top`. -/
 @[simps {rhs_md := semireducible}, derive [full, faithful]]
-def CompHaus_to_Top : CompHaus ⥤ Top := induced_functor _
+def CompHaus_to_Top : CompHaus.{u} ⥤ Top.{u} := induced_functor _
 
 /--
 (Implementation) The object part of the compactification functor from topological spaces to
@@ -105,8 +107,8 @@ noncomputable def stone_cech_equivalence (X : Top) (Y : CompHaus) :
 The Stone-Cech compactification functor from topological spaces to compact Hausdorff spaces,
 left adjoint to the inclusion functor.
 -/
-noncomputable def Top_to_CompHaus : Top ⥤ CompHaus :=
-adjunction.left_adjoint_of_equiv stone_cech_equivalence (λ _ _ _ _ _, rfl)
+noncomputable def Top_to_CompHaus : Top.{u} ⥤ CompHaus.{u} :=
+adjunction.left_adjoint_of_equiv stone_cech_equivalence.{u u} (λ _ _ _ _ _, rfl)
 
 lemma Top_to_CompHaus_obj (X : Top) : ↥(Top_to_CompHaus.obj X) = stone_cech X :=
 rfl

--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -134,6 +134,10 @@ instance Profinite.to_CompHaus.reflective : reflective Profinite.to_CompHaus :=
 { to_is_right_adjoint := ⟨CompHaus.to_Profinite, Profinite.to_Profinite_adj_to_CompHaus⟩ }
 
 noncomputable
+instance Profinite.to_CompHaus.creates_limits : creates_limits Profinite.to_CompHaus :=
+monadic_creates_limits _
+
+noncomputable
 instance Profinite.to_Top.reflective : reflective (Profinite_to_Top : Profinite ⥤ Top) :=
 reflective.comp Profinite.to_CompHaus CompHaus_to_Top
 

--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -8,6 +8,7 @@ import topology.category.CompHaus
 import topology.connected
 import topology.subset_properties
 import category_theory.adjunction.reflective
+import category_theory.limits.creates
 
 /-!
 # The category of Profinite Types
@@ -28,9 +29,8 @@ compact, Hausdorff and totally disconnected.
 ## TODO
 
 0. Link to category of projective limits of finite discrete sets.
-1. existence of products, limits(?), finite coproducts
-2. `Profinite_to_Top` creates limits?
-3. Clausen/Scholze topology on the category `Profinite`.
+1. finite coproducts
+2. Clausen/Scholze topology on the category `Profinite`.
 
 ## Tags
 
@@ -67,6 +67,71 @@ end Profinite
 /-- The fully faithful embedding of `Profinite` in `Top`. -/
 @[simps, derive [full, faithful]]
 def Profinite_to_Top : Profinite ⥤ Top := induced_functor _
+
+namespace Profinite
+
+universe u
+
+/-- An explicit limit cone for a functor to `Profinite`. -/
+def limit_cone {J : Type u} [small_category J] (F : J ⥤ Profinite.{u}) : limits.cone F :=
+{ X :=
+  { to_Top := (Top.limit_cone' $ F ⋙ Profinite_to_Top).X,
+    is_compact := begin
+      erw ← compact_iff_compact_space,
+      dsimp [functor.sections],
+      apply is_closed.compact,
+      have : {u : Π (j : J), (F.obj j) | ∀ {j j' : J} (f : j ⟶ j'), (F.map f) (u j) = u j'} =
+        ⋂ (a b : J) (f : a ⟶ b), { u : Π (j : J), F.obj j | F.map f (u a) = u b }, by tidy,
+      rw this, clear this,
+      apply is_closed_Inter,
+      intros a,
+      apply is_closed_Inter,
+      intros b,
+      apply is_closed_Inter,
+      intros f,
+      let π : (Π (j : J), F.obj j) → F.obj a × F.obj b := λ x, (x a, x b),
+      change is_closed (π ⁻¹' { x | F.map f x.1 = x.2 }),
+      refine is_closed.preimage (continuous.prod_mk (continuous_apply _) (continuous_apply _)) _,
+      refine is_closed_eq _ continuous_snd,
+      continuity,
+    end,
+    is_t2 := begin
+      dsimp [Top.limit_cone', limits.types.limit_cone, functor.sections],
+      apply_instance
+    end,
+    is_totally_disconnected := begin
+      dsimp [Top.limit_cone', limits.types.limit_cone, functor.sections],
+      apply_instance
+    end },
+  π := { app := λ j, (Top.limit_cone' $ F ⋙ Profinite_to_Top).π.app j } }
+
+/-- An auxiliary definition used in `creates_limit`. -/
+def limit_cone_to_Top {J : Type u} [small_category J] (F : J ⥤ Profinite.{u}) :
+  Profinite_to_Top.map_cone (limit_cone F) ≅ Top.limit_cone' _ := eq_to_iso rfl
+
+/-- `Profinite_to_Top` creates a limit of a functor. -/
+def creates_limit {J : Type u} [small_category J] (F : J ⥤ Profinite.{u}) :
+  creates_limit F Profinite_to_Top :=
+{ reflects := λ C hC,
+  { lift := λ S, hC.lift (Profinite_to_Top.map_cone _),
+    fac' := λ A j, hC.fac _ _,
+  uniq' := λ A m h, hC.uniq (Profinite_to_Top.map_cone A) m h },
+  lifts := λ A hA,
+  { lifted_cone := limit_cone _,
+    valid_lift := let I := limit_cone_to_Top F in I ≪≫ limits.is_limit.unique_up_to_iso
+      (Top.limit_cone'_is_limit _) hA } }
+
+instance : creates_limits Profinite_to_Top :=
+{ creates_limits_of_shape := λ J hJ, { creates_limit := λ F, by exactI creates_limit _ } }
+
+/-- `limit_cone` is indeed a limit cone. -/
+def limit_cone_is_limit {J : Type u} [small_category J] (F : J ⥤ Profinite.{u}) :
+  limits.is_limit (limit_cone F) :=
+limits.is_limit_of_reflects Profinite_to_Top (Top.limit_cone'_is_limit _)
+
+instance : limits.has_limits Profinite := has_limits_of_has_limits_creates_limits Profinite_to_Top
+
+end Profinite
 
 /-- The fully faithful embedding of `Profinite` in `CompHaus`. -/
 @[simps] def Profinite.to_CompHaus : Profinite ⥤ CompHaus :=

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -44,25 +44,6 @@ def limit_cone (F : J ⥤ Top.{u}) : cone F :=
                    continuous_map.coe_inj ((types.limit_cone (F ⋙ forget)).π.naturality f) } }
 
 /--
-An alternative choice of limit cone for a functor `F : J ⥤ Top`.
-Generally you should just use `limit.cone F`, unless you need the actual definition
-(which is in terms of `types.limit_cone`).
-This differs from `limit_cone` only in the definition of the topology itself,
-which is defined as a subspace topology as opposed to an infemum as in limit_cone.
--/
-def limit_cone' (F : J ⥤ Top.{u}) : cone F :=
-{ X :=
-  { α := (types.limit_cone (F ⋙ forget)).X,
-    str := by {dsimp [types.limit_cone, functor.sections], apply_instance} },
-  π :=
-  { app := λ j,
-    { to_fun := (types.limit_cone (F ⋙ forget)).π.app j,
-      continuous_to_fun := begin
-        change continuous ((λ t : (Π j : J, F.obj j), t j) ∘ subtype.val),
-        continuity,
-      end } } }
-
-/--
 The chosen cone `Top.limit_cone F` for a functor `F : J ⥤ Top` is a limit cone.
 Generally you should just use `limit.is_limit F`, unless you need the actual definition
 (which is in terms of `types.limit_cone_is_limit`).
@@ -72,20 +53,6 @@ by { refine is_limit.of_faithful forget (types.limit_cone_is_limit _) (λ s, ⟨
      exact continuous_iff_coinduced_le.mpr (le_infi $ λ j,
        coinduced_le_iff_le_induced.mp $ (continuous_iff_coinduced_le.mp (s.π.app j).continuous :
          _) ) }
-
-/--
-The alternative cone `Top.limit_cone' F`, for a functor `F : J ⥤ Top`, is a limit cone.
-Generally you should just use `limit.is_limit F`, unless you need the actual definition
-(which is in terms of `types.limit_cone_is_limit`).
--/
-def limit_cone'_is_limit (F : J ⥤ Top.{u}) : is_limit (limit_cone' F) :=
-begin
-  refine is_limit.of_faithful forget (types.limit_cone_is_limit _) (λ s, ⟨_, _⟩) (λ s, rfl),
-  apply continuous_subtype_mk,
-  rw continuous_pi_iff,
-  intros j,
-  apply (s.π.app j).continuous,
-end
 
 instance Top_has_limits : has_limits.{u} Top.{u} :=
 { has_limits_of_shape := λ J 𝒥, by exactI

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -44,6 +44,25 @@ def limit_cone (F : J ⥤ Top.{u}) : cone F :=
                    continuous_map.coe_inj ((types.limit_cone (F ⋙ forget)).π.naturality f) } }
 
 /--
+An alternative choice of limit cone for a functor `F : J ⥤ Top`.
+Generally you should just use `limit.cone F`, unless you need the actual definition
+(which is in terms of `types.limit_cone`).
+This differs from `limit_cone` only in the definition of the topology itself,
+which is defined as a subspace topology as opposed to an infemum as in limit_cone.
+-/
+def limit_cone' (F : J ⥤ Top.{u}) : cone F :=
+{ X :=
+  { α := (types.limit_cone (F ⋙ forget)).X,
+    str := by {dsimp [types.limit_cone, functor.sections], apply_instance} },
+  π :=
+  { app := λ j,
+    { to_fun := (types.limit_cone (F ⋙ forget)).π.app j,
+      continuous_to_fun := begin
+        change continuous ((λ t : (Π j : J, F.obj j), t j) ∘ subtype.val),
+        continuity,
+      end } } }
+
+/--
 The chosen cone `Top.limit_cone F` for a functor `F : J ⥤ Top` is a limit cone.
 Generally you should just use `limit.is_limit F`, unless you need the actual definition
 (which is in terms of `types.limit_cone_is_limit`).
@@ -53,6 +72,20 @@ by { refine is_limit.of_faithful forget (types.limit_cone_is_limit _) (λ s, ⟨
      exact continuous_iff_coinduced_le.mpr (le_infi $ λ j,
        coinduced_le_iff_le_induced.mp $ (continuous_iff_coinduced_le.mp (s.π.app j).continuous :
          _) ) }
+
+/--
+The alternative cone `Top.limit_cone' F`, for a functor `F : J ⥤ Top`, is a limit cone.
+Generally you should just use `limit.is_limit F`, unless you need the actual definition
+(which is in terms of `types.limit_cone_is_limit`).
+-/
+def limit_cone'_is_limit (F : J ⥤ Top.{u}) : is_limit (limit_cone' F) :=
+begin
+  refine is_limit.of_faithful forget (types.limit_cone_is_limit _) (λ s, ⟨_, _⟩) (λ s, rfl),
+  apply continuous_subtype_mk,
+  rw continuous_pi_iff,
+  intros j,
+  apply (s.π.app j).continuous,
+end
 
 instance Top_has_limits : has_limits.{u} Top.{u} :=
 { has_limits_of_shape := λ J 𝒥, by exactI


### PR DESCRIPTION
This PR adds a proof that `Profinite` has limits by showing that the forgetful functor to `Top` creates limits.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
