### PR TITLE
[Merged by Bors] - feat(linear_algebra/bilinear_form): Unique adjoints with respect to a nondegenerate bilinear form

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -205,7 +205,7 @@ Bilinear and Quadratic Forms Over a Vector Space:
     polar form of a quadratic: 'quadratic_form.polar'
   Orthogonality:
     orthogonal elements: 'bilin_form.is_ortho'
-    adjoint endomorphism:
+    adjoint endomorphism: 'bilin_form.left_adjoint_of_nondegenerate'
     Sylvester's law of inertia:
     real classification:
     complex classification:

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1455,25 +1455,24 @@ end
 
 section linear_adjoints
 
-lemma comp_left_apply_eq_unique (B₁ B₂ : bilin_form R₁ M₁) (hB₂ : B₂.nondegenerate)
-  {φ ψ : M₁ →ₗ[R₁] M₁} (hφ : ∀ v w, B₁ v w = B₂ (φ v) w) (hψ : ∀ v w, B₁ v w = B₂ (ψ v) w) :
+lemma comp_left_ext (B₁ B₂ : bilin_form R₁ M₁) (hB₂ : B₂.nondegenerate)
+  {φ ψ : M₁ →ₗ[R₁] M₁} (hφ : B₁ = B₂.comp_left φ) (hψ : B₁ = B₂.comp_left ψ) :
   φ = ψ :=
 begin
   ext w,
   refine eq_of_sub_eq_zero (hB₂ _ _),
   { intro v,
-    rw [sub_left, ← hφ w v, ← hψ w v, sub_self] }
+    rw [sub_left, ← comp_left_apply, ← comp_left_apply, ← hφ, ← hψ, sub_self] }
 end
 
 lemma is_adjoint_pair_unique_of_nondegenerate (B : bilin_form R₁ M₁) (hB₁ : B.nondegenerate)
   (φ ψ₁ ψ₂ : M₁ →ₗ[R₁] M₁) (hψ₁ : is_adjoint_pair B B ψ₁ φ) (hψ₂ : is_adjoint_pair B B ψ₂ φ) :
   ψ₁ = ψ₂ :=
 begin
-  apply comp_left_apply_eq_unique (B.comp_right φ) _ hB₁,
-  { intros _ _,
-    rw hψ₁, refl },
-  { intros _ _,
-    rw hψ₂, refl }
+  apply comp_left_ext (B.comp_right φ) _ hB₁;
+  ext x y,
+  { rw [comp_left_apply, hψ₁], refl },
+  { rw [comp_left_apply, hψ₂], refl }
 end
 
 variable [finite_dimensional K V]

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1455,8 +1455,9 @@ end
 
 section linear_adjoints
 
-lemma comp_left_apply_eq_unique (B₁ B₂ : bilin_form K V) (hB₂ : B₂.nondegenerate) {φ ψ : V →ₗ[K] V}
-  (hφ : ∀ v w, B₁ v w = B₂ (φ v) w) (hψ : ∀ v w, B₁ v w = B₂ (ψ v) w) : φ = ψ :=
+lemma comp_left_apply_eq_unique (B₁ B₂ : bilin_form R₁ M₁) (hB₂ : B₂.nondegenerate)
+  {φ ψ : M₁ →ₗ[R₁] M₁} (hφ : ∀ v w, B₁ v w = B₂ (φ v) w) (hψ : ∀ v w, B₁ v w = B₂ (ψ v) w) :
+  φ = ψ :=
 begin
   ext w,
   refine eq_of_sub_eq_zero (hB₂ _ _),
@@ -1464,8 +1465,8 @@ begin
     rw [sub_left, ← hφ w v, ← hψ w v, sub_self] }
 end
 
-lemma is_adjoint_pair_unique_of_nondegenerate (B : bilin_form K V) (hB₁ : B.nondegenerate)
-  (φ ψ₁ ψ₂ : V →ₗ[K] V) (hψ₁ : is_adjoint_pair B B ψ₁ φ) (hψ₂ : is_adjoint_pair B B ψ₂ φ) :
+lemma is_adjoint_pair_unique_of_nondegenerate (B : bilin_form R₁ M₁) (hB₁ : B.nondegenerate)
+  (φ ψ₁ ψ₂ : M₁ →ₗ[R₁] M₁) (hψ₁ : is_adjoint_pair B B ψ₁ φ) (hψ₂ : is_adjoint_pair B B ψ₂ φ) :
   ψ₁ = ψ₂ :=
 begin
   apply comp_left_apply_eq_unique (B.comp_right φ) _ hB₁,

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1503,14 +1503,14 @@ lemma is_adjoint_pair_left_adjoint_of_nondegenerate
   is_adjoint_pair B B (B.left_adjoint_of_nondegenerate hB φ) φ :=
 λ x y, symm_comp_of_nondegenerate_left_apply (B.comp_right φ) B hB y x
 
-/-- Given the nondegenerate bilinear form `B`, the linear map `φ` has a unique left adjoint. -/
-theorem exists_unique_left_adjoint_of_nondegenerate
-  (B : bilin_form K V) (hB : B.nondegenerate) (φ : V →ₗ[K] V) :
-  ∃! ψ : V →ₗ[K] V, is_adjoint_pair B B ψ φ :=
-⟨B.left_adjoint_of_nondegenerate hB φ,
- is_adjoint_pair_left_adjoint_of_nondegenerate _ _ _,
- λ ψ hψ, B.is_adjoint_pair_unique_of_nondegenerate hB φ ψ _ hψ
-   (is_adjoint_pair_left_adjoint_of_nondegenerate _ _ _)⟩
+/-- Given the nondegenerate bilinear form `B`, the linear map `φ` has a unique left adjoint given by
+`left_adjoint_of_nondegenerate`. -/
+theorem is_adjoint_pair_iff_eq_of_nondegenerate
+  (B : bilin_form K V) (hB : B.nondegenerate) (ψ φ : V →ₗ[K] V) :
+  is_adjoint_pair B B ψ φ ↔ ψ = B.left_adjoint_of_nondegenerate hB φ :=
+⟨λ h, B.is_adjoint_pair_unique_of_nondegenerate hB φ ψ _ h
+   (is_adjoint_pair_left_adjoint_of_nondegenerate _ _ _),
+ λ h, h.symm ▸ is_adjoint_pair_left_adjoint_of_nondegenerate _ _ _⟩
 
 end linear_adjoints
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1483,7 +1483,7 @@ lemma comp_symm_comp_of_nondegenerate_apply {B₁ B₂ : bilin_form K V}
 by erw [symm_comp_of_nondegenerate, linear_equiv.apply_symm_apply (B₂.to_dual hB₂) _]
 
 @[simp]
-lemma symm_comp_of_nondegenerate_left_apply (B₁ B₂ : bilin_form K V)
+lemma symm_comp_of_nondegenerate_left_apply {B₁ B₂ : bilin_form K V}
   (hB₂ : B₂.nondegenerate) (v w : V) :
   B₂ (symm_comp_of_nondegenerate B₁ B₂ hB₂ w) v = B₁ w v :=
 begin
@@ -1501,7 +1501,7 @@ symm_comp_of_nondegenerate (B.comp_right φ) B hB₁
 lemma is_adjoint_pair_left_adjoint_of_nondegenerate
   (B : bilin_form K V) (hB : B.nondegenerate) (φ : V →ₗ[K] V) :
   is_adjoint_pair B B (B.left_adjoint_of_nondegenerate hB φ) φ :=
-λ x y, symm_comp_of_nondegenerate_left_apply (B.comp_right φ) B hB y x
+λ x y, symm_comp_of_nondegenerate_left_apply hB y x
 
 /-- Given the nondegenerate bilinear form `B`, the linear map `φ` has a unique left adjoint given by
 `left_adjoint_of_nondegenerate`. -/

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1455,6 +1455,26 @@ end
 
 section linear_adjoints
 
+lemma comp_left_apply_eq_unique (B₁ B₂ : bilin_form K V) (hB₂ : B₂.nondegenerate) {φ ψ : V →ₗ[K] V}
+  (hφ : ∀ v w, B₁ w v = B₂ (φ w) v) (hψ : ∀ v w, B₁ w v = B₂ (ψ w) v) : φ = ψ :=
+begin
+  ext w,
+  refine eq_of_sub_eq_zero (hB₂ _ _),
+  { intro v,
+    rw [sub_left, ← hφ v w, ← hψ v w, sub_self] }
+end
+
+lemma is_adjoint_pair_unique_of_nondegenerate (B : bilin_form K V) (hB₁ : B.nondegenerate)
+  (φ ψ₁ ψ₂ : V →ₗ[K] V) (hψ₁ : is_adjoint_pair B B ψ₁ φ) (hψ₂ : is_adjoint_pair B B ψ₂ φ) :
+  ψ₁ = ψ₂ :=
+begin
+  apply comp_left_apply_eq_unique (B.comp_right φ) _ hB₁,
+  { intros _ _,
+    rw hψ₁, refl },
+  { intros _ _,
+    rw hψ₂, refl }
+end
+
 variable [finite_dimensional K V]
 
 /-- Given bilinear forms `B₁, B₂` where `B₂` is nondegenerate, `symm_comp_of_nondegenerate`
@@ -1477,15 +1497,6 @@ begin
   refl,
 end
 
-lemma comp_left_apply_eq_unique (B₁ B₂ : bilin_form K V) (hB₂ : B₂.nondegenerate) {φ ψ : V →ₗ[K] V}
-  (hφ : ∀ v w, B₁ w v = B₂ (φ w) v) (hψ : ∀ v w, B₁ w v = B₂ (ψ w) v) : φ = ψ :=
-begin
-  ext w,
-  refine eq_of_sub_eq_zero (hB₂ _ _),
-  { intro v,
-    rw [sub_left, ← hφ v w, ← hψ v w, sub_self] }
-end
-
 /-- Given the nondegenerate bilinear form `B` and the linear map `φ`,
 `left_adjoint_of_nondegenerate` provides the left adjoint of `φ` with respect to `B`.
 The lemma proving this property is `is_adjoint_pair_left_adjoint_of_nondegenerate`. -/
@@ -1497,17 +1508,6 @@ lemma is_adjoint_pair_left_adjoint_of_nondegenerate
   (B : bilin_form K V) (hB : B.nondegenerate) (φ : V →ₗ[K] V) :
   is_adjoint_pair B B (B.left_adjoint_of_nondegenerate hB φ) φ :=
 λ x y, symm_comp_of_nondegenerate_left_apply (B.comp_right φ) B hB y x
-
-lemma is_adjoint_pair_unique_of_nondegenerate (B : bilin_form K V) (hB₁ : B.nondegenerate)
-  (φ ψ₁ ψ₂ : V →ₗ[K] V) (hψ₁ : is_adjoint_pair B B ψ₁ φ) (hψ₂ : is_adjoint_pair B B ψ₂ φ) :
-  ψ₁ = ψ₂ :=
-begin
-  apply comp_left_apply_eq_unique (B.comp_right φ) _ hB₁,
-  { intros _ _,
-    rw hψ₁, refl },
-  { intros _ _,
-    rw hψ₂, refl }
-end
 
 /-- Given the nondegenerate bilinear form `B`, the linear map `φ` has a unique left adjoint. -/
 theorem exists_unique_left_adjoint_of_nondegenerate

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1486,16 +1486,16 @@ begin
     rw [sub_left, ← hφ v w, ← hψ v w, sub_self] }
 end
 
-/-- Given the nondegenerate bilinear form `B` the linear map `φ`, `is_adjoint_pair_of_nondegenerate`
+/-- Given the nondegenerate bilinear form `B` the linear map `φ`, `left_adjoint_of_nondegenerate`
 provides the left adjoint of `φ` with respect to `B`. The lemma proving this property is
-`is_adjoint_pair_is_adjoint_pair_of_nondegenerate`. -/
-noncomputable def is_adjoint_pair_of_nondegenerate
+`is_adjoint_pair_left_adjoint_of_nondegenerate`. -/
+noncomputable def left_adjoint_of_nondegenerate
   (B : bilin_form K V) (hB₁ : B.nondegenerate) (φ : V →ₗ[K] V) : V →ₗ[K] V :=
 symm_comp_of_nondegenerate (B.comp_right φ) B hB₁
 
-lemma is_adjoint_pair_is_adjoint_pair_of_nondegenerate
+lemma is_adjoint_pair_left_adjoint_of_nondegenerate
   (B : bilin_form K V) (hB : B.nondegenerate) (φ : V →ₗ[K] V) :
-  is_adjoint_pair B B (B.is_adjoint_pair_of_nondegenerate hB φ) φ :=
+  is_adjoint_pair B B (B.left_adjoint_of_nondegenerate hB φ) φ :=
 λ x y, symm_comp_of_nondegenerate_left_apply (B.comp_right φ) B hB y x
 
 lemma is_adjoint_pair_unique_of_nondegenerate (B : bilin_form K V) (hB₁ : B.nondegenerate)
@@ -1510,13 +1510,13 @@ begin
 end
 
 /-- Given the nondegenerate bilinear form `B`, the linear map `φ` has an unique left adjoint. -/
-theorem exists_unique_is_adjoint_pair_of_nondegenerate
+theorem exists_unique_left_adjoint_of_nondegenerate
   (B : bilin_form K V) (hB : B.nondegenerate) (φ : V →ₗ[K] V) :
   ∃! ψ : V →ₗ[K] V, is_adjoint_pair B B ψ φ :=
-⟨B.is_adjoint_pair_of_nondegenerate hB φ,
- is_adjoint_pair_is_adjoint_pair_of_nondegenerate _ _ _,
+⟨B.left_adjoint_of_nondegenerate hB φ,
+ is_adjoint_pair_left_adjoint_of_nondegenerate _ _ _,
  λ ψ hψ, B.is_adjoint_pair_unique_of_nondegenerate hB φ ψ _ hψ
-   (is_adjoint_pair_is_adjoint_pair_of_nondegenerate _ _ _)⟩
+   (is_adjoint_pair_left_adjoint_of_nondegenerate _ _ _)⟩
 
 end linear_adjoints
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1464,10 +1464,10 @@ lemma comp_left_injective (B : bilin_form R₁ M₁) (hB : B.nondegenerate) :
   rw [sub_left, ← comp_left_apply, ← comp_left_apply, ← h, sub_self]
 end
 
-lemma is_adjoint_pair_unique_of_nondegenerate (B : bilin_form R₁ M₁) (hB₁ : B.nondegenerate)
+lemma is_adjoint_pair_unique_of_nondegenerate (B : bilin_form R₁ M₁) (hB : B.nondegenerate)
   (φ ψ₁ ψ₂ : M₁ →ₗ[R₁] M₁) (hψ₁ : is_adjoint_pair B B ψ₁ φ) (hψ₂ : is_adjoint_pair B B ψ₂ φ) :
   ψ₁ = ψ₂ :=
-B.comp_left_injective hB₁ $ ext $ λ v w, by rw [comp_left_apply, comp_left_apply, hψ₁, hψ₂]
+B.comp_left_injective hB $ ext $ λ v w, by rw [comp_left_apply, comp_left_apply, hψ₁, hψ₂]
 
 variable [finite_dimensional K V]
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1493,7 +1493,7 @@ end
 
 /-- Given the nondegenerate bilinear form `B` and the linear map `φ`,
 `left_adjoint_of_nondegenerate` provides the left adjoint of `φ` with respect to `B`.
-The lemma proving this property is `is_adjoint_pair_left_adjoint_of_nondegenerate`. -/
+The lemma proving this property is `bilin_form.is_adjoint_pair_left_adjoint_of_nondegenerate`. -/
 noncomputable def left_adjoint_of_nondegenerate
   (B : bilin_form K V) (hB₁ : B.nondegenerate) (φ : V →ₗ[K] V) : V →ₗ[K] V :=
 symm_comp_of_nondegenerate (B.comp_right φ) B hB₁
@@ -1504,7 +1504,7 @@ lemma is_adjoint_pair_left_adjoint_of_nondegenerate
 λ x y, (B.comp_right φ).symm_comp_of_nondegenerate_left_apply hB y x
 
 /-- Given the nondegenerate bilinear form `B`, the linear map `φ` has a unique left adjoint given by
-`left_adjoint_of_nondegenerate`. -/
+`bilin_form.left_adjoint_of_nondegenerate`. -/
 theorem is_adjoint_pair_iff_eq_of_nondegenerate
   (B : bilin_form K V) (hB : B.nondegenerate) (ψ φ : V →ₗ[K] V) :
   is_adjoint_pair B B ψ φ ↔ ψ = B.left_adjoint_of_nondegenerate hB φ :=

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1509,7 +1509,7 @@ begin
     rw hψ₂, refl }
 end
 
-/-- Given the nondegenerate bilinear form `B`, the linear map `φ` has an unique left adjoint. -/
+/-- Given the nondegenerate bilinear form `B`, the linear map `φ` has a unique left adjoint. -/
 theorem exists_unique_left_adjoint_of_nondegenerate
   (B : bilin_form K V) (hB : B.nondegenerate) (φ : V →ₗ[K] V) :
   ∃! ψ : V →ₗ[K] V, is_adjoint_pair B B ψ φ :=

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1455,25 +1455,19 @@ end
 
 section linear_adjoints
 
-lemma comp_left_ext (B₁ B₂ : bilin_form R₁ M₁) (hB₂ : B₂.nondegenerate)
-  {φ ψ : M₁ →ₗ[R₁] M₁} (hφ : B₁ = B₂.comp_left φ) (hψ : B₁ = B₂.comp_left ψ) :
-  φ = ψ :=
-begin
+lemma comp_left_injective (B : bilin_form R₁ M₁) (hB : B.nondegenerate) :
+  function.injective B.comp_left :=
+λ φ ψ h, begin
   ext w,
-  refine eq_of_sub_eq_zero (hB₂ _ _),
-  { intro v,
-    rw [sub_left, ← comp_left_apply, ← comp_left_apply, ← hφ, ← hψ, sub_self] }
+  refine eq_of_sub_eq_zero (hB _ _),
+  intro v,
+  rw [sub_left, ← comp_left_apply, ← comp_left_apply, ← h, sub_self]
 end
 
 lemma is_adjoint_pair_unique_of_nondegenerate (B : bilin_form R₁ M₁) (hB₁ : B.nondegenerate)
   (φ ψ₁ ψ₂ : M₁ →ₗ[R₁] M₁) (hψ₁ : is_adjoint_pair B B ψ₁ φ) (hψ₂ : is_adjoint_pair B B ψ₂ φ) :
   ψ₁ = ψ₂ :=
-begin
-  apply comp_left_ext (B.comp_right φ) _ hB₁;
-  ext x y,
-  { rw [comp_left_apply, hψ₁], refl },
-  { rw [comp_left_apply, hψ₂], refl }
-end
+B.comp_left_injective hB₁ $ ext $ λ v w, by rw [comp_left_apply, comp_left_apply, hψ₁, hψ₂]
 
 variable [finite_dimensional K V]
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1456,12 +1456,12 @@ end
 section linear_adjoints
 
 lemma comp_left_apply_eq_unique (B₁ B₂ : bilin_form K V) (hB₂ : B₂.nondegenerate) {φ ψ : V →ₗ[K] V}
-  (hφ : ∀ v w, B₁ w v = B₂ (φ w) v) (hψ : ∀ v w, B₁ w v = B₂ (ψ w) v) : φ = ψ :=
+  (hφ : ∀ v w, B₁ v w = B₂ (φ v) w) (hψ : ∀ v w, B₁ v w = B₂ (ψ v) w) : φ = ψ :=
 begin
   ext w,
   refine eq_of_sub_eq_zero (hB₂ _ _),
   { intro v,
-    rw [sub_left, ← hφ v w, ← hψ v w, sub_self] }
+    rw [sub_left, ← hφ w v, ← hψ w v, sub_self] }
 end
 
 lemma is_adjoint_pair_unique_of_nondegenerate (B : bilin_form K V) (hB₁ : B.nondegenerate)

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1495,8 +1495,8 @@ end
 `left_adjoint_of_nondegenerate` provides the left adjoint of `φ` with respect to `B`.
 The lemma proving this property is `bilin_form.is_adjoint_pair_left_adjoint_of_nondegenerate`. -/
 noncomputable def left_adjoint_of_nondegenerate
-  (B : bilin_form K V) (hB₁ : B.nondegenerate) (φ : V →ₗ[K] V) : V →ₗ[K] V :=
-symm_comp_of_nondegenerate (B.comp_right φ) B hB₁
+  (B : bilin_form K V) (hB : B.nondegenerate) (φ : V →ₗ[K] V) : V →ₗ[K] V :=
+symm_comp_of_nondegenerate (B.comp_right φ) B hB
 
 lemma is_adjoint_pair_left_adjoint_of_nondegenerate
   (B : bilin_form K V) (hB : B.nondegenerate) (φ : V →ₗ[K] V) :

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1477,14 +1477,14 @@ noncomputable def symm_comp_of_nondegenerate
   (B₁ B₂ : bilin_form K V) (hB₂ : B₂.nondegenerate) : V →ₗ[K] V :=
 (B₂.to_dual hB₂).symm.to_linear_map.comp B₁.to_lin
 
-lemma comp_symm_comp_of_nondegenerate_apply {B₁ B₂ : bilin_form K V}
-  (hB₂ : B₂.nondegenerate) (v : V) :
+lemma comp_symm_comp_of_nondegenerate_apply (B₁ : bilin_form K V)
+  {B₂ : bilin_form K V} (hB₂ : B₂.nondegenerate) (v : V) :
   to_lin B₂ (B₁.symm_comp_of_nondegenerate B₂ hB₂ v) = to_lin B₁ v :=
 by erw [symm_comp_of_nondegenerate, linear_equiv.apply_symm_apply (B₂.to_dual hB₂) _]
 
 @[simp]
-lemma symm_comp_of_nondegenerate_left_apply {B₁ B₂ : bilin_form K V}
-  (hB₂ : B₂.nondegenerate) (v w : V) :
+lemma symm_comp_of_nondegenerate_left_apply (B₁ : bilin_form K V)
+  {B₂ : bilin_form K V} (hB₂ : B₂.nondegenerate) (v w : V) :
   B₂ (symm_comp_of_nondegenerate B₁ B₂ hB₂ w) v = B₁ w v :=
 begin
   conv_lhs { rw [← bilin_form.to_lin_apply, comp_symm_comp_of_nondegenerate_apply] },
@@ -1501,7 +1501,7 @@ symm_comp_of_nondegenerate (B.comp_right φ) B hB₁
 lemma is_adjoint_pair_left_adjoint_of_nondegenerate
   (B : bilin_form K V) (hB : B.nondegenerate) (φ : V →ₗ[K] V) :
   is_adjoint_pair B B (B.left_adjoint_of_nondegenerate hB φ) φ :=
-λ x y, symm_comp_of_nondegenerate_left_apply hB y x
+λ x y, (B.comp_right φ).symm_comp_of_nondegenerate_left_apply hB y x
 
 /-- Given the nondegenerate bilinear form `B`, the linear map `φ` has a unique left adjoint given by
 `left_adjoint_of_nondegenerate`. -/

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1486,9 +1486,9 @@ begin
     rw [sub_left, ← hφ v w, ← hψ v w, sub_self] }
 end
 
-/-- Given the nondegenerate bilinear form `B` the linear map `φ`, `left_adjoint_of_nondegenerate`
-provides the left adjoint of `φ` with respect to `B`. The lemma proving this property is
-`is_adjoint_pair_left_adjoint_of_nondegenerate`. -/
+/-- Given the nondegenerate bilinear form `B` and the linear map `φ`,
+`left_adjoint_of_nondegenerate` provides the left adjoint of `φ` with respect to `B`.
+The lemma proving this property is `is_adjoint_pair_left_adjoint_of_nondegenerate`. -/
 noncomputable def left_adjoint_of_nondegenerate
   (B : bilin_form K V) (hB₁ : B.nondegenerate) (φ : V →ₗ[K] V) : V →ₗ[K] V :=
 symm_comp_of_nondegenerate (B.comp_right φ) B hB₁


### PR DESCRIPTION
---
A linear map has a unique adjoint with respect to a nondegenerate bilinear form.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
