### PR TITLE
[Merged by Bors] - feat(order/filter/*, topology/subset_properties): Filter Coprod

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -2173,9 +2173,9 @@ end prod
 section pi
 variables {ι : Type*} {α : ι → Type*} {s s₁ : set ι} {t t₁ t₂ : Π i, set (α i)}
 
-/-- Given an index set `i` and a family of sets `s : Π i, set (α i)`, `pi i s`
-is the set of dependent functions `f : Πa, π a` such that `f a` belongs to `s a`
-whenever `a ∈ i`. -/
+/-- Given an index set `ι` and a family of sets `t : Π i, set (α i)`, `pi s t`
+is the set of dependent functions `f : Πa, π a` such that `f a` belongs to `t a`
+whenever `a ∈ s`. -/
 def pi (s : set ι) (t : Π i, set (α i)) : set (Π i, α i) := { f | ∀i ∈ s, f i ∈ t i }
 
 @[simp] lemma mem_pi {f : Π i, α i} : f ∈ s.pi t ↔ ∀ i ∈ s, f i ∈ t i :=

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -405,6 +405,15 @@ lemma finite.image2 (f : α → β → γ) {s : set α} {t : set β} (hs : finit
   finite (image2 f s t) :=
 by { rw ← image_prod, exact (hs.prod ht).image _ }
 
+/-- Finite product of finite sets is finite -/
+lemma finite.pi [fintype δ] {t : Π d, set (κ  d)} (ht : ∀ d, (t d).finite) :
+  (pi univ t).finite :=
+begin
+  convert (fintype.pi_finset (λ d, (ht d).to_finset)).finite_to_set,
+  ext,
+  simp,
+end
+
 /-- If `s : set α` is a set with `fintype` instance and `f : α → set β` is a function such that
 each `f a`, `a ∈ s`, has a `fintype` structure, then `s >>= f` has a `fintype` structure. -/
 def fintype_bUnion {α β} [decidable_eq β] (s : set α) [fintype s]

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -405,15 +405,6 @@ lemma finite.image2 (f : α → β → γ) {s : set α} {t : set β} (hs : finit
   finite (image2 f s t) :=
 by { rw ← image_prod, exact (hs.prod ht).image _ }
 
-/-- Finite product of finite sets is finite -/
-lemma finite.pi [fintype δ] {t : Π d, set (κ  d)} (ht : ∀ d, (t d).finite) :
-  (pi univ t).finite :=
-begin
-  convert (fintype.pi_finset (λ d, (ht d).to_finset)).finite_to_set,
-  ext,
-  simp,
-end
-
 /-- If `s : set α` is a set with `fintype` instance and `f : α → set β` is a function such that
 each `f a`, `a ∈ s`, has a `fintype` structure, then `s >>= f` has a `fintype` structure. -/
 def fintype_bUnion {α β} [decidable_eq β] (s : set α) [fintype s]
@@ -478,6 +469,16 @@ by { ext, rw [set.finite.mem_to_finset, mem_coe] }
 end finset
 
 namespace set
+
+/-- Finite product of finite sets is finite -/
+lemma finite.pi {δ : Type*} [decidable_eq δ] [fintype δ] {κ : δ → Type*} {t : Π d, set (κ d)}
+  (ht : ∀ d, (t d).finite) :
+  (pi univ t).finite :=
+begin
+  convert (fintype.pi_finset (λ d, (ht d).to_finset)).finite_to_set,
+  ext,
+  simp,
+end
 
 lemma finite_subset_Union {s : set α} (hs : finite s)
   {ι} {t : ι → set α} (h : s ⊆ ⋃ i, t i) : ∃ I : set ι, finite I ∧ s ⊆ ⋃ i ∈ I, t i :=

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -471,10 +471,11 @@ end finset
 namespace set
 
 /-- Finite product of finite sets is finite -/
-lemma finite.pi {δ : Type*} [decidable_eq δ] [fintype δ] {κ : δ → Type*} {t : Π d, set (κ d)}
+lemma finite.pi {δ : Type*} [fintype δ] {κ : δ → Type*} {t : Π d, set (κ d)}
   (ht : ∀ d, (t d).finite) :
   (pi univ t).finite :=
 begin
+  classical,
   convert (fintype.pi_finset (λ d, (ht d).to_finset)).finite_to_set,
   ext,
   simp,

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2541,7 +2541,7 @@ by simp [filter.Coprod]
   filter.Coprod f₁ ≤ filter.Coprod f₂ :=
 supr_le_supr $ λ d, comap_mono (hf d)
 
-lemma map_prod_map_Coprod_le {μ : δ → Type*}
+lemma map_pi_map_Coprod_le {μ : δ → Type*}
   {f : Π d, filter (κ d)} {m : Π d, κ d → μ d} :
   map (λ (k : Π d, κ d), λ d, m d (k d)) (filter.Coprod f) ≤ filter.Coprod (λ d, map (m d) (f d)) :=
 begin
@@ -2558,10 +2558,10 @@ begin
   exact set.mem_of_subset_of_mem hH (mem_preimage.mpr hx),
 end
 
-lemma tendsto.prod_map_Coprod {μ : δ → Type*} {f : Π d, filter (κ d)} {m : Π d, κ d → μ d}
+lemma tendsto.pi_map_Coprod {μ : δ → Type*} {f : Π d, filter (κ d)} {m : Π d, κ d → μ d}
   {g : Π d, filter (μ d)} (hf : ∀ d, tendsto (m d) (f d) (g d)) :
   tendsto (λ (k : Π d, κ d), λ d, m d (k d)) (filter.Coprod f) (filter.Coprod g) :=
-map_prod_map_Coprod_le.trans (Coprod_mono hf)
+map_pi_map_Coprod_le.trans (Coprod_mono hf)
 
 end Coprod
 

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2470,7 +2470,7 @@ begin
   simp ; tauto,
 end
 
--- this inequality can be strict; see `map_const_principal_coprod_map_id_principal` and 
+-- this inequality can be strict; see `map_const_principal_coprod_map_id_principal` and
 -- `map_prod_map_const_id_principal_coprod_principal` below.
 lemma map_prod_map_coprod_le {α₁ : Type u} {α₂ : Type v} {β₁ : Type w} {β₂ : Type x}
   {f₁ : filter α₁} {f₂ : filter α₂} {m₁ : α₁ → β₁} {m₂ : α₂ → β₂} :
@@ -2523,6 +2523,48 @@ lemma tendsto.prod_map_coprod {δ : Type*} {f : α → γ} {g : β → δ} {a : 
 map_prod_map_coprod_le.trans (coprod_mono hf hg)
 
 end coprod
+
+
+/-! ### Finitary coproducts of filters -/
+
+section Coprod
+variables {δ : Type*} [fintype δ] {κ : δ → Type*}  -- {f : Π d, filter (κ d)}
+
+/-- Coproduct of filters. -/
+protected def Coprod (f : Π d, filter (κ d)) : filter (Π d, κ d) :=
+⨆ d : δ, (f d).comap (λ k, k d)
+
+lemma mem_Coprod_iff {s : set (Π d, κ d)} {f : Π d, filter (κ d)} :
+  (s ∈ (filter.Coprod f)) ↔ (∀ d : δ, (∃ t₁ ∈ f d, (λ k : (Π d, κ d), k d) ⁻¹' t₁ ⊆ s)) :=
+by simp [filter.Coprod]
+
+@[mono] lemma Coprod_mono {f₁ f₂ : Π d, filter (κ d)} (hf : ∀ d, f₁ d ≤ f₂ d) :
+  filter.Coprod f₁ ≤ filter.Coprod f₂ :=
+Sup_le_Sup begin
+  have := (λ d : δ, comap_mono (hf d)) ,
+  -- Heather homework
+  repeat {sorry},
+end
+
+lemma map_prod_map_Coprod_le {μ : δ → Type*}
+  {f : Π d, filter (κ d)} {m : Π d, κ d → μ d} :
+  map (λ (k : Π d, κ d), λ d, m d (k d)) (filter.Coprod f) ≤ filter.Coprod (λ d, map (m d) (f d)) :=
+begin
+  intros s h,
+  -- Alex homework
+  sorry,
+  simp only [mem_map, mem_coprod_iff],
+  rintros ⟨u₁, hu₁, h₁⟩,
+  refine ⟨⟨m₁ ⁻¹' u₁, hu₁, λ _ hx, h₁ _⟩, ⟨m₂ ⁻¹' u₂, hu₂, λ _ hx, h₂ _⟩⟩; convert hx
+end
+
+lemma tendsto.prod_map_Coprod {μ : δ → Type*} {f : Π d, filter (κ d)} {m : Π d, κ d → μ d}
+  {g : Π d, filter (μ d)} (hf : ∀ d, tendsto (m d) (f d) (g d)) :
+  tendsto (λ (k : Π d, κ d), λ d, m d (k d)) (filter.Coprod f) (filter.Coprod g) :=
+map_prod_map_Coprod_le.trans (Coprod_mono hf)
+
+end Coprod
+
 
 end filter
 

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2524,11 +2524,10 @@ map_prod_map_coprod_le.trans (coprod_mono hf hg)
 
 end coprod
 
-
-/-! ### Finitary coproducts of filters -/
+/-! ### `n`-ary coproducts of filters -/
 
 section Coprod
-variables {δ : Type*} [fintype δ] {κ : δ → Type*}  -- {f : Π d, filter (κ d)}
+variables {δ : Type*} {κ : δ → Type*}  -- {f : Π d, filter (κ d)}
 
 /-- Coproduct of filters. -/
 protected def Coprod (f : Π d, filter (κ d)) : filter (Π d, κ d) :=
@@ -2540,11 +2539,7 @@ by simp [filter.Coprod]
 
 @[mono] lemma Coprod_mono {f₁ f₂ : Π d, filter (κ d)} (hf : ∀ d, f₁ d ≤ f₂ d) :
   filter.Coprod f₁ ≤ filter.Coprod f₂ :=
-Sup_le_Sup begin
-  have := (λ d : δ, comap_mono (hf d)) ,
-  -- Heather homework
-  repeat {sorry},
-end
+supr_le_supr $ λ d, comap_mono (hf d)
 
 lemma map_prod_map_Coprod_le {μ : δ → Type*}
   {f : Π d, filter (κ d)} {m : Π d, κ d → μ d} :
@@ -2578,7 +2573,6 @@ lemma tendsto.prod_map_Coprod {μ : δ → Type*} {f : Π d, filter (κ d)} {m :
 map_prod_map_Coprod_le.trans (Coprod_mono hf)
 
 end Coprod
-
 
 end filter
 

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2546,25 +2546,16 @@ lemma map_prod_map_Coprod_le {μ : δ → Type*}
   map (λ (k : Π d, κ d), λ d, m d (k d)) (filter.Coprod f) ≤ filter.Coprod (λ d, map (m d) (f d)) :=
 begin
   intros s h,
-  rw mem_Coprod_iff at h,
-  rw mem_map,
-  rw mem_Coprod_iff,
+  rw [mem_map, mem_Coprod_iff],
   intros d,
-  obtain ⟨t, ht⟩ := h d,
-  obtain ⟨H, hH⟩ := ht,
+  rw mem_Coprod_iff at h,
+  obtain ⟨t, H, hH⟩ := h d,
   rw mem_map at H,
-  use {x : κ d | m d x ∈ t},
-  split,
-  exact H,
+  refine ⟨{x : κ d | m d x ∈ t}, H, _⟩,
   intros x hx,
-  simp at hx,
-  simp,
-
-  -- Alex homework
-  sorry,
-  simp only [mem_map, mem_coprod_iff],
-  rintros ⟨u₁, hu₁, h₁⟩,
-  refine ⟨⟨m₁ ⁻¹' u₁, hu₁, λ _ hx, h₁ _⟩, ⟨m₂ ⁻¹' u₂, hu₂, λ _ hx, h₂ _⟩⟩; convert hx
+  simp only [mem_set_of_eq, preimage_set_of_eq] at hx,
+  rw mem_set_of_eq,
+  exact set.mem_of_subset_of_mem hH (mem_preimage.mpr hx),
 end
 
 lemma tendsto.prod_map_Coprod {μ : δ → Type*} {f : Π d, filter (κ d)} {m : Π d, κ d → μ d}

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2551,6 +2551,20 @@ lemma map_prod_map_Coprod_le {μ : δ → Type*}
   map (λ (k : Π d, κ d), λ d, m d (k d)) (filter.Coprod f) ≤ filter.Coprod (λ d, map (m d) (f d)) :=
 begin
   intros s h,
+  rw mem_Coprod_iff at h,
+  rw mem_map,
+  rw mem_Coprod_iff,
+  intros d,
+  obtain ⟨t, ht⟩ := h d,
+  obtain ⟨H, hH⟩ := ht,
+  rw mem_map at H,
+  use {x : κ d | m d x ∈ t},
+  split,
+  exact H,
+  intros x hx,
+  simp at hx,
+  simp,
+
   -- Alex homework
   sorry,
   simp only [mem_map, mem_coprod_iff],

--- a/src/order/filter/cofinite.lean
+++ b/src/order/filter/cofinite.lean
@@ -66,6 +66,36 @@ begin
     { simpa [compl_subset_comm] using subset_preimage_image prod.snd Sᶜ } },
 end
 
+/-- Finite product of finite sets is finite -/
+lemma Coprod_cofinite {δ : Type*} {κ : δ → Type*} [fintype δ] :
+  filter.Coprod (λ d, (cofinite : filter (κ d))) = cofinite :=
+begin
+  ext S,
+  simp only [mem_coprod_iff, exists_prop, mem_comap_sets, mem_cofinite],
+  split,
+  { rintros h,
+    rw mem_Coprod_iff at h,
+    choose t ht1 ht2 using h,
+    have ht1d : ∀ (d : δ), (t d)ᶜ.finite := λ d, mem_cofinite.mp (ht1 d),
+    refine (set.finite.pi ht1d).subset _,
+    have ht2d : ∀ (d : δ), Sᶜ ⊆ ((λ (k : Π (d1 : δ), (λ (d2 : δ), κ d2) d1), k d) ⁻¹' ((t d)ᶜ)) :=
+     λ d, compl_subset_compl.mpr (ht2 d),
+    convert set.subset_Inter ht2d,
+    ext,
+    simp },
+  { intro hS,
+    rw mem_Coprod_iff,
+    intros d,
+    refine ⟨((λ (k : Π (d1 : δ), κ d1), k d) '' (Sᶜ))ᶜ, _, _⟩,
+    { rw [mem_cofinite, compl_compl],
+      exact set.finite.image _ hS },
+    { intros x,
+      contrapose,
+      intros hx,
+      simp only [not_not, mem_preimage, mem_compl_eq, not_forall],
+      exact ⟨x, hx, rfl⟩ } },
+end
+
 end filter
 
 open filter

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -723,6 +723,39 @@ by { convert compact_pi_infinite h, simp only [pi, forall_prop_of_true, mem_univ
 instance pi.compact_space [∀ i, compact_space (π i)] : compact_space (Πi, π i) :=
 ⟨by { rw [← pi_univ univ], exact compact_univ_pi (λ i, compact_univ) }⟩
 
+/-- Product of compact sets is compact -/
+lemma filter.Coprod_cocompact {δ : Type*} {κ : δ → Type*} [Π d, topological_space (κ d)] :
+  filter.Coprod (λ d, filter.cocompact (κ d)) = filter.cocompact (Π d, κ d) :=
+begin
+  ext S,
+  simp only [mem_coprod_iff, exists_prop, mem_comap_sets, filter.mem_cocompact],
+  split,
+  { intros h,
+    rw filter.mem_Coprod_iff at h,
+    choose t ht1 ht2 using h,
+    choose t1 ht11 ht12 using λ d, filter.mem_cocompact.mp (ht1 d),
+    refine ⟨set.pi set.univ t1, _, _⟩,
+    { convert compact_pi_infinite ht11,
+      ext,
+      simp },
+    { refine subset.trans _ (set.Union_subset ht2),
+      intros x,
+      simp only [mem_Union, mem_univ_pi, exists_imp_distrib, mem_compl_eq, not_forall],
+      intros d h,
+      exact ⟨d, ht12 d h⟩ } },
+  { rintros ⟨t, h1, h2⟩,
+    rw filter.mem_Coprod_iff,
+    intros d,
+    refine ⟨((λ (k : Π (d : δ), κ d), k d) '' t)ᶜ, _, _⟩,
+    { rw filter.mem_cocompact,
+      refine ⟨(λ (k : Π (d : δ), κ d), k d) '' t, _, set.subset.refl _⟩,
+      exact is_compact.image h1 (continuous_pi_iff.mp (continuous_id) d) },
+    refine subset.trans _ h2,
+    intros x hx,
+    simp only [not_exists, mem_image, mem_preimage, mem_compl_eq] at hx,
+    simpa using mt (hx x) },
+end
+
 end tychonoff
 
 instance quot.compact_space {r : α → α → Prop} [compact_space α] :


### PR DESCRIPTION
Define the "coproduct" of many filters (not just two) as

`protected def Coprod (f : Π d, filter (κ d)) : filter (Π d, κ d) :=
⨆ d : δ, (f d).comap (λ k, k d)`

and prove the three lemmas which motivated this construction: (finite!) coproduct of cofinite filters is the cofinite filter, coproduct of cocompact filters is the cocompact filter, and monotonicity; see also #6372

Co-authored by: Heather Macbeth @hrmacbeth 


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
