### PR TITLE
[Merged by Bors] - feat(tactic/simps): allow composite projections 

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -757,7 +757,7 @@ def symm (e : A₁ ≃ₐ[R] A₂) : A₂ ≃ₐ[R] A₁ :=
   ..e.to_ring_equiv.symm, }
 
 /-- See Note [custom simps projection] -/
-def simps.inv_fun (e : A₁ ≃ₐ[R] A₂) : A₂ → A₁ := e.symm
+def simps.symm_apply (e : A₁ ≃ₐ[R] A₂) : A₂ → A₁ := e.symm
 
 initialize_simps_projections alg_equiv (to_fun → apply, inv_fun → symm_apply)
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -435,7 +435,7 @@ def symm : M₂ ≃ₗ[R] M :=
   .. e.to_equiv.symm }
 
 /-- See Note [custom simps projection] -/
-def simps.inv_fun [semimodule R M] [semimodule R M₂] (e : M ≃ₗ[R] M₂) : M₂ → M := e.symm
+def simps.symm_apply [semimodule R M] [semimodule R M₂] (e : M ≃ₗ[R] M₂) : M₂ → M := e.symm
 
 initialize_simps_projections linear_equiv (to_fun → apply, inv_fun → symm_apply)
 

--- a/src/category_theory/monad/basic.lean
+++ b/src/category_theory/monad/basic.lean
@@ -60,18 +60,18 @@ def comonad.ε : (G : C ⥤ C) ⟶ 𝟭 _  := G.ε'
 def comonad.δ : (G : C ⥤ C) ⟶ (G : C ⥤ C) ⋙ G := G.δ'
 
 /-- A custom simps projection for the functor part of a monad, as a coercion. -/
-def monad.simps.to_functor := (T : C ⥤ C)
+def monad.simps.coe := (T : C ⥤ C)
 /-- A custom simps projection for the unit of a monad, in simp normal form. -/
-def monad.simps.η' : 𝟭 _ ⟶ (T : C ⥤ C) := T.η
+def monad.simps.η : 𝟭 _ ⟶ (T : C ⥤ C) := T.η
 /-- A custom simps projection for the multiplication of a monad, in simp normal form. -/
-def monad.simps.μ' : (T : C ⥤ C) ⋙ (T : C ⥤ C) ⟶ (T : C ⥤ C) := T.μ
+def monad.simps.μ : (T : C ⥤ C) ⋙ (T : C ⥤ C) ⟶ (T : C ⥤ C) := T.μ
 
 /-- A custom simps projection for the functor part of a comonad, as a coercion. -/
-def comonad.simps.to_functor := (G : C ⥤ C)
+def comonad.simps.coe := (G : C ⥤ C)
 /-- A custom simps projection for the counit of a comonad, in simp normal form. -/
-def comonad.simps.ε' : (G : C ⥤ C) ⟶ 𝟭 _ := G.ε
+def comonad.simps.ε : (G : C ⥤ C) ⟶ 𝟭 _ := G.ε
 /-- A custom simps projection for the comultiplication of a comonad, in simp normal form. -/
-def comonad.simps.δ' : (G : C ⥤ C) ⟶ (G : C ⥤ C) ⋙ (G : C ⥤ C) := G.δ
+def comonad.simps.δ : (G : C ⥤ C) ⟶ (G : C ⥤ C) ⋙ (G : C ⥤ C) := G.δ
 
 initialize_simps_projections category_theory.monad (to_functor → coe, η' → η, μ' → μ)
 initialize_simps_projections category_theory.comonad (to_functor → coe, ε' → ε, δ' → δ)

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -125,7 +125,7 @@ instance inhabited' : inhabited (α ≃ α) := ⟨equiv.refl α⟩
 @[symm] protected def symm (e : α ≃ β) : β ≃ α := ⟨e.inv_fun, e.to_fun, e.right_inv, e.left_inv⟩
 
 /-- See Note [custom simps projection] -/
-def simps.inv_fun (e : α ≃ β) : β → α := e.symm
+def simps.symm_apply (e : α ≃ β) : β → α := e.symm
 
 initialize_simps_projections equiv (to_fun → apply, inv_fun → symm_apply)
 

--- a/src/data/equiv/local_equiv.lean
+++ b/src/data/equiv/local_equiv.lean
@@ -157,7 +157,7 @@ protected def symm : local_equiv β α :=
 instance : has_coe_to_fun (local_equiv α β) := ⟨_, local_equiv.to_fun⟩
 
 /-- See Note [custom simps projection] -/
-def simps.inv_fun (e : local_equiv α β) : β → α := e.symm
+def simps.symm_apply (e : local_equiv α β) : β → α := e.symm
 
 initialize_simps_projections local_equiv (to_fun → apply, inv_fun → symm_apply)
 

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -119,8 +119,8 @@ def symm (h : M ≃* N) : N ≃* M :=
 /-- See Note [custom simps projection] -/
 -- we don't hyperlink the note in the additive version, since that breaks syntax highlighting
 -- in the whole file.
-@[to_additive add_equiv.simps.inv_fun "See Note custom simps projection"]
-def simps.inv_fun (e : M ≃* N) : N → M := e.symm
+@[to_additive "See Note custom simps projection"]
+def simps.symm_apply (e : M ≃* N) : N → M := e.symm
 
 initialize_simps_projections add_equiv (to_fun → apply, inv_fun → symm_apply)
 initialize_simps_projections mul_equiv (to_fun → apply, inv_fun → symm_apply)

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -137,7 +137,7 @@ variables {R}
 { .. e.to_mul_equiv.symm, .. e.to_add_equiv.symm }
 
 /-- See Note [custom simps projection] -/
-def simps.inv_fun (e : R ≃+* S) : S → R := e.symm
+def simps.symm_apply (e : R ≃+* S) : S → R := e.symm
 
 initialize_simps_projections ring_equiv (to_fun → apply, inv_fun → symm_apply)
 

--- a/src/data/subtype.lean
+++ b/src/data/subtype.lean
@@ -13,7 +13,7 @@ namespace subtype
 variables {α : Sort*} {β : Sort*} {γ : Sort*} {p : α → Prop} {q : α → Prop}
 
 /-- See Note [custom simps projection] -/
-def simps.val (x : subtype p) : α := x
+def simps.coe (x : subtype p) : α := x
 
 initialize_simps_projections subtype (val → coe)
 

--- a/src/order/closure.lean
+++ b/src/order/closure.lean
@@ -41,7 +41,10 @@ structure closure_operator extends α →ₘ α :=
 instance : has_coe_to_fun (closure_operator α) :=
 { F := _, coe := λ c, c.to_fun }
 
-initialize_simps_projections closure_operator (to_fun → apply)
+/-- See Note [custom simps projection] -/
+def closure_operator.simps.apply (f : closure_operator α) : α → α := f
+
+initialize_simps_projections closure_operator (to_preorder_hom_to_fun → apply, -to_preorder_hom)
 
 namespace closure_operator
 

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -145,14 +145,19 @@ meta def get_composite_of_projections (str : name) (proj : string) : tactic (exp
   are three cases
   * If the declaration `{structure_name}.simps.{projection_name}` has been declared, then the value
     of this declaration is used (after checking that it is definitionally equal to the actual
-    projection
+    projection. If you rename the projection name, the declaration should have the *new* projection
+    name.
+  * You can also declare a custom projection that is a composite of multiple projections.
   * Otherwise, for every class with the `notation_class` attribute, and the structure has an
     instance of that notation class, then the projection of that notation class is used for the
     projection that is definitionally equal to it (if there is such a projection).
     This means in practice that coercions to function types and sorts will be used instead of
     a projection, if this coercion is definitionally equal to a projection. Furthermore, for
     notation classes like `has_mul` and `has_zero` those projections are used instead of the
-    corresponding projection
+    corresponding projection.
+    Projections for coercions and notation classes are not automatically generated if they are
+    composites of multiple projections (for example when you use `extend` without the
+    `old_structure_cmd`).
   * Otherwise, the projection of the structure is chosen.
     For example: ``simps_get_raw_projections env `prod`` gives the default projections
 ```
@@ -268,7 +273,8 @@ Expected type:\n  {raw_expr_type}" },
       let relevant_proj := raw_expr_whnf.binding_body.get_app_fn.const_name,
       /- Use this as projection, if the function reduces to a projection, and this projection has
         not been overrriden by the user. -/
-      guard (projs.any (λ x, x.1 = relevant_proj.last ∧ ¬ e.contains (str ++ `simps ++ x.2.1.last))),
+      guard $ projs.any $
+        λ x, x.1 = relevant_proj.last ∧ ¬ e.contains (str ++ `simps ++ x.2.1.last),
       let pos := projs.find_index (λ x, x.1 = relevant_proj.last),
       when trc trace!
         "        > using {proj_nm} instead of the default projection {relevant_proj.last}.",
@@ -283,7 +289,8 @@ Expected type:\n  {raw_expr_type}" },
       is_proof proj.2.1 >>= λ b, return $ if b then (proj.1, proj.2.1, proj.2.2.1, ff) else proj,
     when trc $ projections_info projs "generated projections for" str >>= trace,
     simps_str_attr.set str (raw_univs, projs) tt,
-    when_tracing `simps.debug trace!"[simps] > Generated raw projection data: \n{(raw_univs, projs)}",
+    when_tracing `simps.debug trace!
+      "[simps] > Generated raw projection data: \n{(raw_univs, projs)}",
     return (raw_univs, projs)
 
 /-- Parse a rule for `initialize_simps_projections`. It is either `<name>→<name>` or `-<name>`.-/
@@ -292,12 +299,16 @@ meta def simps_parse_rule : parser (name × name ⊕ name) :=
 
 /--
   You can specify custom projections for the `@[simps]` attribute.
-  To do this for the projection `my_structure.awesome_projection` by adding a declaration
-  `my_structure.simps.awesome_projection` that is definitionally equal to
-  `my_structure.awesome_projection` but has the projection in the desired (simp-normal) form.
+  To do this for the projection `my_structure.original_projection` by adding a declaration
+  `my_structure.simps.my_projection` that is definitionally equal to
+  `my_structure.original_projection` but has the projection in the desired (simp-normal) form.
+  Then you can call
+  ```
+  initialize_simps_projections (original_projection → my_projection, ...)
+  ```
+  to register this projection.
 
-  You can initialize the projections `@[simps]` uses with `initialize_simps_projections`
-  (after declaring any custom projections). This is not necessary, it has the same effect
+  Running `initialize_simps_projections` without arguments is not necessary, it has the same effect
   if you just add `@[simps]` to a declaration.
 
   If you do anything to change the default projections, make sure to call either `@[simps]` or
@@ -371,6 +382,12 @@ library_note "custom simps projection"
 (fully_applied := tt)
 (not_recursive := [`prod, `pprod])
 (trace         := ff)
+
+/-- A common configuration for `@[simps]`: generate equalities between functions instead equalities
+  between fully applied expressions. -/
+def as_fn : simps_cfg := {fully_applied := ff}
+/-- A common configuration for `@[simps]`: don't tag the generated lemmas with `@[simp]`. -/
+def lemmas_only : simps_cfg := {attrs := []}
 
 /--
   Get the projections of a structure used by `@[simps]` applied to the appropriate arguments.
@@ -511,7 +528,6 @@ meta def simps_add_projections : Π (e : environment) (nm : name) (suffix : stri
       automatically choose projections -/
       when ¬(to_apply ≠ [] ∨ todo = [""] ∨ (eta.is_some ∧ todo = [])) $ do
         let todo := if to_apply = [] then todo_next else todo,
-
         -- check whether all elements in `todo` have a projection as prefix
         guard (todo.all $ λ x, projs.any $ λ proj, ("_" ++ proj.last).is_prefix_of x) <|>
           let x := (todo.find $ λ x, projs.all $ λ proj, ¬ ("_" ++ proj.last).is_prefix_of x).iget,
@@ -523,7 +539,7 @@ The known projections are:
   {projs}
 You can also see this information by running
   `initialize_simps_projections? {str}`.
-Note: the projection names used by @[simps] might not correspond to the projection names in the structure.",
+Note: these projection names might not correspond to the projection names of the structure.",
         tuples.mmap_with_index' $ λ proj_nr ⟨proj_expr, proj, new_rhs, proj_nrs, is_default⟩, do
           new_type ← infer_type new_rhs,
           let new_todo :=

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -416,7 +416,7 @@ def lemmas_only : simps_cfg := {attrs := []}
   The last two fields of the list correspond to the propositional fields of the structure,
   and are rarely/never used.
 -/
--- This function does not use `tactic.mk_app` or `tactic.mk_mapp`, because the the given arguments
+-- This function does not use `tactic.mk_app` or `tactic.mk_mapp`, because the given arguments
 -- might not uniquely specify the universe levels yet.
 meta def simps_get_projection_exprs (e : environment) (tgt : expr)
   (rhs : expr) (cfg : simps_cfg) : tactic $ list $ expr × name × expr × list ℕ × bool := do

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -244,14 +244,14 @@ The known projections are:
   [fst, snd]
 You can also see this information by running
   `initialize_simps_projections? prod`.
-Note: the projection names used by @[simps] might not correspond to the projection names in the structure.",
+Note: these projection names might not correspond to the projection names of the structure.",
   success_if_fail_with_msg (simps_tac `specify.specify1 {} ["snd_bar"])
     "Invalid simp-lemma specify.specify1_snd_bar. Structure prod does not have projection bar.
 The known projections are:
   [fst, snd]
 You can also see this information by running
   `initialize_simps_projections? prod`.
-Note: the projection names used by @[simps] might not correspond to the projection names in the structure.",
+Note: these projection names might not correspond to the projection names of the structure.",
   success_if_fail_with_msg (simps_tac `specify.specify5 {} ["snd_snd"])
     "Invalid simp-lemma specify.specify5_snd_snd.
 The given definition is not a constructor application:


### PR DESCRIPTION
* Allows custom simps-projections that are compositions of multiple projections. This is useful when extending structures without the `old_structure_cmd`.
* Coercions that are compositions of multiple projections are *not* automatically recognized, and should be declared manually (coercions that are definitionally equal to a single projection are still automatically recognized).
* Custom simps projections should now be declared using the name used by `simps`. E.g. `equiv.simps.symm_apply` instead of `equiv.simps.inv_fun`.
* You can disable a projection `proj` being generated by default by `simps` using `initialize_simps_projections (-proj)`
---

Zulip threads: [1](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/simps.20and.20new.20structure.20cmd) [2](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/How.20do.20I.20configure.20an.20.60equiv.60.20to.20work.20with.20.60simps.60.3F). Implements items 1 & 6 of #5489.

Example:

```lean
namespace homeomorph
-- this has to be given manually if the coercion is a composition of multiple projections
def simps.apply (e : α ≃ₜ β) : α → β := e 
def simps.symm_apply (e : α ≃ₜ β) : β → α := e.symm

initialize_simps_projections homeomorph (to_equiv_to_fun → apply, to_equiv_inv_fun → symm_apply, -to_equiv)
end homeomorph
```
The above code (modulo typos) should setup `@[simps]` to automatically generate `foo_apply` and `foo_symm_apply` lemmas when definition a homeomorphism `foo`. 
The `-to_equiv` is a command that means that `@[simps]` will not generate `foo_to_equiv` lemmas (unless explicitly asked with `@[simps to_equiv]`). This could of course be omitted if such lemmas are desirable.

Todo:
* [x] fix any compilation errors
* [x] test it out in a couple of places of mathlib

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
