### PR TITLE
[Merged by Bors] - feat(category_theory/action): currying

### DIFF
--- a/src/category_theory/action.lean
+++ b/src/category_theory/action.lean
@@ -4,8 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Wärn
 -/
 import category_theory.elements
+import category_theory.is_connected
 import category_theory.single_obj
 import group_theory.group_action.basic
+import group_theory.semidirect_product
 
 /-!
 # Actions as functors and as categories
@@ -18,7 +20,7 @@ A morphism `x ⟶ y` in this category is simply a scalar `m : M` such that `m �
 where M is a group, this category is a groupoid -- the `action groupoid'.
 -/
 
-open mul_action
+open mul_action semidirect_product
 namespace category_theory
 
 universes u
@@ -42,10 +44,6 @@ def action_category := (action_as_functor M X).elements
 
 namespace action_category
 
-noncomputable
-instance (G : Type*) [group G] [mul_action G X] : groupoid (action_category G X) :=
-category_theory.groupoid_of_elements _
-
 /-- The projection from the action category to the monoid, mapping a morphism to its
   label. -/
 def π : action_category M X ⥤ single_obj M :=
@@ -56,25 +54,42 @@ lemma π_map (p q : action_category M X) (f : p ⟶ q) : (π M X).map f = f.val 
 
 @[simp]
 lemma π_obj (p : action_category M X) : (π M X).obj p = single_obj.star M :=
-@subsingleton.elim unit _ _ _
+unit.ext
+
+variables {M X}
+/-- The canonical map `action_category M X → X`. It is given by `λ x, x.snd`, but
+  has a more explicit type. -/
+protected def back : action_category M X → X :=
+λ x, x.snd
+
+instance : has_coe_t X (action_category M X) :=
+⟨λ x, ⟨(), x⟩⟩
+
+@[simp] lemma coe_back (x : X) : (↑x : action_category M X).back = x := rfl
+@[simp] lemma back_coe (x : action_category M X) : ↑(x.back) = x := by ext; refl
+
+variables (M X)
 
 /-- An object of the action category given by M ↻ X corresponds to an element of X. -/
 def obj_equiv : X ≃ action_category M X :=
-{ to_fun := λ x, ⟨single_obj.star M, x⟩,
-  inv_fun := λ p, p.2,
-  left_inv := by tidy,
-  right_inv := by tidy }
+{ to_fun := coe,
+  inv_fun := λ x, x.back,
+  left_inv := coe_back,
+  right_inv := back_coe }
 
 lemma hom_as_subtype (p q : action_category M X) :
-  (p ⟶ q) = { m : M // m • (obj_equiv M X).symm p = (obj_equiv M X).symm q } := rfl
+  (p ⟶ q) = { m : M // m • p.back = q.back } := rfl
 
 instance [inhabited X] : inhabited (action_category M X) :=
-{ default := obj_equiv M X (default X) }
+{ default := ↑(default X) }
+
+instance [nonempty X] : nonempty (action_category M X) :=
+nonempty.map (obj_equiv M X) infer_instance
 
 variables {X} (x : X)
 /-- The stabilizer of a point is isomorphic to the endomorphism monoid at the
   corresponding point. In fact they are definitionally equivalent. -/
-def stabilizer_iso_End : stabilizer.submonoid M x ≃* End (obj_equiv M X x) :=
+def stabilizer_iso_End : stabilizer.submonoid M x ≃* End (↑x : action_category M X) :=
 mul_equiv.refl _
 
 @[simp]
@@ -84,6 +99,80 @@ lemma stabilizer_iso_End_apply (f : stabilizer.submonoid M x) :
 @[simp]
 lemma stabilizer_iso_End_symm_apply (f : End _) :
   (stabilizer_iso_End M x).inv_fun f = f := rfl
+
+variables {M X}
+
+@[simp] protected lemma id_val (x : action_category M X) : subtype.val (𝟙 x) = 1 := rfl
+
+@[simp] protected lemma comp_val {x y z : action_category M X}
+  (f : x ⟶ y) (g : y ⟶ z) : (f ≫ g).val = g.val * f.val := rfl
+
+instance [is_pretransitive M X] [nonempty X] : is_connected (action_category M X) :=
+zigzag_is_connected $ λ x y, relation.refl_trans_gen.single $ or.inl $
+  nonempty_subtype.mpr (show _, from exists_smul_eq M x.back y.back)
+
+section group
+
+variables {G : Type*} [group G] [mul_action G X]
+
+noncomputable instance : groupoid (action_category G X) :=
+category_theory.groupoid_of_elements _
+
+/-- Any subgroup of `G` is a vertex group in its action groupoid. -/
+def End_mul_equiv_subgroup (H : subgroup G) :
+  End (obj_equiv G (quotient_group.quotient H) ↑(1 : G)) ≃* H :=
+mul_equiv.trans
+  (stabilizer_iso_End G ((1 : G) : quotient_group.quotient H)).symm
+  (mul_equiv.subgroup_congr $ stabilizer_quotient H)
+
+/-- A target vertex `t` and a scalar `g` determine a morphism in the action groupoid. -/
+def hom_of_pair (t : X) (g : G) : ↑(g⁻¹ • t) ⟶ (t : action_category G X) :=
+subtype.mk g (smul_inv_smul g t)
+
+@[simp] lemma hom_of_pair.val (t : X) (g : G) : (hom_of_pair t g).val = g := rfl
+
+/-- Any morphism in the action groupoid is given by some pair. -/
+protected def cases {P : Π ⦃a b : action_category G X⦄, (a ⟶ b) → Sort*}
+  (hyp : ∀ t g, P (hom_of_pair t g)) ⦃a b⦄ (f : a ⟶ b) : P f :=
+begin
+  refine cast _ (hyp b.back f.val),
+  rcases a with ⟨⟨⟩, a : X⟩,
+  rcases b with ⟨⟨⟩, b : X⟩,
+  rcases f with ⟨g : G, h : g • a = b⟩,
+  cases (inv_smul_eq_iff.mpr h.symm),
+  refl
+end
+
+variables {H : Type*} [group H]
+
+/-- Given `G` acting on `X`, a functor from the corresponding action groupoid to a group `H`
+    can be curried to a group homomorphism `G →* (X → H) ⋊ G`. -/
+@[simps] def curry (F : action_category G X ⥤ single_obj H) :
+  G →* (X → H) ⋊[mul_aut_arrow] G :=
+have F_map_eq : ∀ {a b} {f : a ⟶ b}, F.map f = (F.map (hom_of_pair b.back f.val) : H) :=
+  action_category.cases (λ _ _, rfl),
+{ to_fun := λ g, ⟨λ b, F.map (hom_of_pair b g), g⟩,
+  map_one' := by { congr, funext, exact F_map_eq.symm.trans (F.map_id b) },
+  map_mul' := begin
+    intros g h,
+    congr, funext,
+    exact F_map_eq.symm.trans (F.map_comp (hom_of_pair (g⁻¹ • b) h) (hom_of_pair b g)),
+  end }
+
+/-- Given `G` acting on `X`, a group homomorphism `φ : G →* (X → H) ⋊ G` can be uncurried to
+    a functor from the action groupoid to `H`, provided that `φ g = (_, g)` for all `g`. -/
+@[simps] def uncurry (F : G →* (X → H) ⋊[mul_aut_arrow] G) (sane : ∀ g, (F g).right = g) :
+  action_category G X ⥤ single_obj H :=
+{ obj := λ _, (),
+  map := λ a b f, ((F f.val).left b.back),
+  map_id' := by { intro x, rw [action_category.id_val, F.map_one], refl },
+  map_comp' := begin
+    intros x y z f g, revert y z g,
+    refine action_category.cases _,
+    simp [single_obj.comp_as_mul, sane],
+  end }
+
+end group
 
 end action_category
 end category_theory

--- a/src/category_theory/single_obj.lean
+++ b/src/category_theory/single_obj.lean
@@ -57,6 +57,11 @@ instance category [monoid α] : category (single_obj α) :=
   id_comp' := λ _ _, mul_one,
   assoc' := λ _ _ _ _ x y z, (mul_assoc z y x).symm }
 
+lemma id_as_one [monoid α] (x : single_obj α) : 𝟙 x = 1 := rfl
+
+lemma comp_as_mul [monoid α] {x y z : single_obj α} (f : x ⟶ y) (g : y ⟶ z) :
+  f ≫ g = g * f := rfl
+
 /--
 Groupoid structure on `single_obj α`.
 
@@ -66,6 +71,9 @@ instance groupoid [group α] : groupoid (single_obj α) :=
 { inv := λ _ _ x, x⁻¹,
   inv_comp' := λ _ _, mul_right_inv,
   comp_inv' := λ _ _, mul_left_inv }
+
+lemma inv_as_inv [group α] {x y : single_obj α} (f : x ⟶ y) : inv f = f⁻¹ :=
+by { ext, rw [comp_as_mul, inv_mul_self, id_as_one] }
 
 /-- The single object in `single_obj α`. -/
 protected def star : single_obj α := unit.star

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -178,6 +178,10 @@ equiv.symm $ equiv.of_bijective
   ((orbit_equiv_quotient_stabilizer α b).symm a : β) = a • b :=
 rfl
 
+@[simp] lemma stabilizer_quotient {G} [group G] (H : subgroup G) :
+  mul_action.stabilizer G ((1 : G) : quotient H) = H :=
+by { ext, simp [quotient_group.eq] }
+
 end mul_action
 
 section
@@ -201,3 +205,19 @@ lemma finset.smul_sum {r : α} {f : γ → β} {s : finset γ} :
 (const_smul_hom β r).map_sum f s
 
 end
+
+/-- `G` acts pretransitively on `X` if for any `x y` there is `g` such that `g • x = y`.
+  A transitive action should furthermore have `X` nonempty. -/
+class is_pretransitive (G X) [monoid G] [mul_action G X] : Prop :=
+(exists_smul_eq : ∀ x y : X, ∃ g : G, g • x = y)
+
+lemma exists_smul_eq (M) {X} [monoid M] [mul_action M X] [is_pretransitive M X] (x y : X) :
+  ∃ m : M, m • x = y := is_pretransitive.exists_smul_eq x y
+
+instance is_pretransitive_quotient (G) [group G] (H : subgroup G) :
+  is_pretransitive G (quotient_group.quotient H) :=
+{ exists_smul_eq := begin
+    rintros ⟨x⟩ ⟨y⟩,
+    refine ⟨y * x⁻¹, quotient_group.eq.mpr _⟩,
+    simp only [H.one_mem, mul_left_inv, inv_mul_cancel_right],
+  end }

--- a/src/group_theory/group_action/group.lean
+++ b/src/group_theory/group_action/group.lean
@@ -7,6 +7,7 @@ import group_theory.group_action.defs
 import algebra.group.units
 import algebra.group_with_zero
 import data.equiv.mul_add
+import data.equiv.mul_add_aut
 import group_theory.perm.basic
 
 /-!
@@ -139,3 +140,27 @@ not_congr u.smul_eq_zero
 exists.elim hu $ λ u hu, hu ▸ u.smul_eq_zero
 
 end distrib_mul_action
+
+section arrow
+
+/-- If `G` acts on `A`, then it acts also on `A → B`, by `(g • F) a = F (g⁻¹ • a)`. -/
+@[simps] def arrow_action {G A B : Type*} [group G] [mul_action G A] : mul_action G (A → B) :=
+{ smul := λ g F a, F (g⁻¹ • a),
+  one_smul := by { intro, simp only [one_inv, one_smul] },
+  mul_smul := by { intros, simp only [mul_smul, mul_inv_rev] } }
+
+local attribute [instance] arrow_action
+
+/-- Given groups `G H` with `G` acting on `A`, `G` acts by
+  multiplicative automorphisms on `A → H`. -/
+@[simps] def mul_aut_arrow {G A H} [group G] [mul_action G A] [group H] : G →* mul_aut (A → H) :=
+{ to_fun := λ g,
+  { to_fun := λ F, g • F,
+    inv_fun := λ F, g⁻¹ • F,
+    left_inv := λ F, inv_smul_smul g F,
+    right_inv := λ F, smul_inv_smul g F,
+    map_mul' := by { intros, ext, simp only [arrow_action_to_has_scalar_smul, pi.mul_apply] } },
+  map_one' := by { ext, simp only [mul_aut.one_apply, mul_equiv.coe_mk, one_smul] },
+  map_mul' := by { intros, ext, simp only [mul_smul, mul_equiv.coe_mk, mul_aut.mul_apply] } }
+
+end arrow


### PR DESCRIPTION
A functor from an action category can be 'curried' to an ordinary group homomorphism. Also defines transitive group actions.

---
Split from #6840 
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
