### PR TITLE
[Merged by Bors] - chore(category_theory/abelian): enable instances

### DIFF
--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -118,9 +118,11 @@ namespace category_theory.abelian
 variables {C : Type u} [category.{v} C] [abelian C]
 
 /-- An abelian category has finite biproducts. -/
+@[priority 100]
 instance has_finite_biproducts : has_finite_biproducts C :=
 limits.has_finite_biproducts.of_has_finite_products
 
+@[priority 100]
 instance has_binary_biproducts : has_binary_biproducts C :=
 limits.has_binary_biproducts_of_finite_biproducts _
 
@@ -324,10 +326,12 @@ end cokernel_of_kernel
 
 section
 
+@[priority 100]
 instance has_equalizers : has_equalizers C :=
 preadditive.has_equalizers_of_has_kernels
 
 /-- Any abelian category has pullbacks -/
+@[priority 100]
 instance has_pullbacks : has_pullbacks C :=
 has_pullbacks_of_has_binary_products_of_has_equalizers C
 
@@ -335,10 +339,12 @@ end
 
 section
 
+@[priority 100]
 instance has_coequalizers : has_coequalizers C :=
 preadditive.has_coequalizers_of_has_cokernels
 
 /-- Any abelian category has pushouts -/
+@[priority 100]
 instance has_pushouts : has_pushouts C :=
 has_pushouts_of_has_binary_coproducts_of_has_coequalizers C
 

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -118,12 +118,13 @@ namespace category_theory.abelian
 variables {C : Type u} [category.{v} C] [abelian C]
 
 /-- An abelian category has finite biproducts. -/
-lemma has_finite_biproducts : has_finite_biproducts C :=
+instance has_finite_biproducts : has_finite_biproducts C :=
 limits.has_finite_biproducts.of_has_finite_products
 
-section to_non_preadditive_abelian
+instance has_binary_biproducts : has_binary_biproducts C :=
+limits.has_binary_biproducts_of_finite_biproducts _
 
-local attribute [instance] has_finite_biproducts
+section to_non_preadditive_abelian
 
 /-- Every abelian category is, in particular, `non_preadditive_abelian`. -/
 def non_preadditive_abelian : non_preadditive_abelian C := { ..‹abelian C› }
@@ -322,28 +323,29 @@ non_preadditive_abelian.mono_is_kernel_of_cokernel s h
 end cokernel_of_kernel
 
 section
-local attribute [instance] preadditive.has_equalizers_of_has_kernels
+
+instance has_equalizers : has_equalizers C :=
+preadditive.has_equalizers_of_has_kernels
 
 /-- Any abelian category has pullbacks -/
-lemma has_pullbacks : has_pullbacks C :=
+instance has_pullbacks : has_pullbacks C :=
 has_pullbacks_of_has_binary_products_of_has_equalizers C
 
 end
 
 section
-local attribute [instance] preadditive.has_coequalizers_of_has_cokernels
-local attribute [instance] has_binary_biproducts.of_has_binary_products
+
+instance has_coequalizers : has_coequalizers C :=
+preadditive.has_coequalizers_of_has_cokernels
 
 /-- Any abelian category has pushouts -/
-lemma has_pushouts : has_pushouts C :=
+instance has_pushouts : has_pushouts C :=
 has_pushouts_of_has_binary_coproducts_of_has_coequalizers C
 
 end
 
 namespace pullback_to_biproduct_is_kernel
 variables [limits.has_pullbacks C] {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z)
-
-local attribute [instance] has_binary_biproducts.of_has_binary_products
 
 /-! This section contains a slightly technical result about pullbacks and biproducts.
     We will need it in the proof that the pullback of an epimorphism is an epimorpism. -/
@@ -359,8 +361,6 @@ biprod.lift pullback.fst pullback.snd
 abbreviation pullback_to_biproduct_fork : kernel_fork (biprod.desc f (-g)) :=
 kernel_fork.of_ι (pullback_to_biproduct f g) $
 by rw [biprod.lift_desc, comp_neg, pullback.condition, add_right_neg]
-
-local attribute [irreducible] has_limit_cospan_of_has_limit_pair_of_has_limit_parallel_pair
 
 /-- The canonical map `pullback f g ⟶ X ⊞ Y` is a kernel of the map induced by
     `(f, -g)`. -/
@@ -381,8 +381,6 @@ end pullback_to_biproduct_is_kernel
 
 namespace biproduct_to_pushout_is_cokernel
 variables [limits.has_pushouts C] {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z)
-
-local attribute [instance] has_binary_biproducts.of_has_binary_products
 
 /-- The canonical map `Y ⊞ Z ⟶ pushout f g` -/
 abbreviation biproduct_to_pushout : Y ⊞ Z ⟶ pushout f g :=
@@ -408,8 +406,6 @@ end biproduct_to_pushout_is_cokernel
 
 section epi_pullback
 variables [limits.has_pullbacks C] {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z)
-
-local attribute [instance] has_binary_biproducts.of_has_binary_products
 
 /-- In an abelian category, the pullback of an epimorphism is an epimorphism.
     Proof from [aluffi2016, IX.2.3], cf. [borceux-vol2, 1.7.6] -/
@@ -484,8 +480,6 @@ end epi_pullback
 
 section mono_pushout
 variables [limits.has_pushouts C] {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z)
-
-local attribute [instance] has_binary_biproducts.of_has_binary_products
 
 instance mono_pushout_of_mono_f [mono f] : mono (pushout.inr : Z ⟶ pushout f g) :=
 mono_of_cancel_zero _ $ λ R e h,

--- a/src/category_theory/abelian/pseudoelements.lean
+++ b/src/category_theory/abelian/pseudoelements.lean
@@ -104,7 +104,6 @@ lemma pseudo_equal_symm {P : C} : symmetric (pseudo_equal P) :=
 variables [abelian.{v} C]
 
 section
-local attribute [instance] has_pullbacks
 
 /-- Pseudoequality is transitive: Just take the pullback. The pullback morphisms will
     be epimorphisms since in an abelian category, pullbacks of epimorphisms are epimorphisms. -/
@@ -251,7 +250,6 @@ theorem mono_of_zero_of_map_zero {P Q : C} (f : P ⟶ Q) : (∀ a, f a = 0 → a
   show f g = 0, from (pseudo_zero_iff (g ≫ f : over Q)).2 hg
 
 section
-local attribute [instance] has_pullbacks
 
 /-- An epimorphism is surjective on pseudoelements. -/
 theorem pseudo_surjective_of_epi {P Q : C} (f : P ⟶ Q) [epi f] : function.surjective f :=
@@ -274,8 +272,6 @@ theorem epi_of_pseudo_surjective {P Q : C} (f : P ⟶ Q) : function.surjective f
 end
 
 section
-local attribute [instance] preadditive.has_equalizers_of_has_kernels
-local attribute [instance] has_pullbacks
 
 /-- Two morphisms in an exact sequence are exact on pseudoelements. -/
 theorem pseudo_exact_of_exact {P Q R : C} {f : P ⟶ Q} {g : Q ⟶ R} [exact f g] :
@@ -315,8 +311,6 @@ lemma apply_eq_zero_of_comp_eq_zero {P Q R : C} (f : Q ⟶ R) (a : P ⟶ Q) : a 
 λ h, by simp [over_coe_def, pseudo_apply_mk, over.coe_hom, h]
 
 section
-local attribute [instance] preadditive.has_equalizers_of_has_kernels
-local attribute [instance] has_pullbacks
 
 /-- If two morphisms are exact on pseudoelements, they are exact. -/
 theorem exact_of_pseudo_exact {P Q R : C} (f : P ⟶ Q) (g : Q ⟶ R) :


### PR DESCRIPTION
This PR is extracted from Markus' `projective` branch. It just turns on, as global instances, various instances provided by an `abelian` category. In the past these weren't instances, because `has_limit` carried data which could conflict.

Co-authored-by: Markus Himmel <markus@himmel-villmar.de>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
