### PR TITLE
[Merged by Bors] - refactor(algebra/big_operators, *): specialize `finset.prod_bij` to `fintype.prod_equiv`

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1276,6 +1276,26 @@ end comm_group_with_zero
 
 end finset
 
+namespace fintype
+
+open finset
+
+/-- `fintype.prod_equiv` is a specialization of `finset.prod_bij` that
+automatically fills in most arguments. -/
+@[to_additive "`fintype.sum_equiv` is a specialization of `finset.sum_bij` that
+automatically fills in most arguments."]
+lemma prod_equiv {α β M : Type*} [fintype α] [fintype β] [comm_monoid M]
+  (e : α ≃ β) (f : α → M) (g : β → M) (h : ∀ x, f x = g (e x)) :
+  ∏ x : α, f x = ∏ x : β, g x :=
+prod_bij
+  (λ x _, e x)
+  (λ x _, mem_univ (e x))
+  (λ x _, h x)
+  (λ x x' _ _ h, e.injective h)
+  (λ y _, ⟨e.symm y, mem_univ _, (e.apply_symm_apply y).symm⟩)
+
+end fintype
+
 namespace list
 
 @[to_additive] lemma prod_to_finset {M : Type*} [decidable_eq α] [comm_monoid M]

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1280,9 +1280,13 @@ namespace fintype
 
 open finset
 
-/-- `fintype.prod_bijective` is a variant of `finset.prod_bij` that accepts `function.bijective`. -/
+/-- `fintype.prod_bijective` is a variant of `finset.prod_bij` that accepts `function.bijective`.
+
+See `function.bijective.prod_comp` for a version without `h`. -/
 @[to_additive "`fintype.sum_equiv` is a variant of `finset.sum_bij` that accepts
-`function.bijective`"]
+`function.bijective`.
+
+See `function.bijective.sum_comp` for a version without `h`. "]
 lemma prod_bijective {α β M : Type*} [fintype α] [fintype β] [comm_monoid M]
   (e : α → β) (he : function.bijective e) (f : α → M) (g : β → M) (h : ∀ x, f x = g (e x)) :
   ∏ x : α, f x = ∏ x : β, g x :=
@@ -1294,9 +1298,15 @@ prod_bij
   (λ y _, (he.surjective y).imp $ λ a h, ⟨mem_univ _, h.symm⟩)
 
 /-- `fintype.prod_equiv` is a specialization of `finset.prod_bij` that
-automatically fills in most arguments. -/
+automatically fills in most arguments.
+
+See `equiv.prod_comp` for a version without `h`. 
+-/
 @[to_additive "`fintype.sum_equiv` is a specialization of `finset.sum_bij` that
-automatically fills in most arguments."]
+automatically fills in most arguments.
+
+See `equiv.sum_comp` for a version without `h`. 
+"]
 lemma prod_equiv {α β M : Type*} [fintype α] [fintype β] [comm_monoid M]
   (e : α ≃ β) (f : α → M) (g : β → M) (h : ∀ x, f x = g (e x)) :
   ∏ x : α, f x = ∏ x : β, g x :=

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1280,6 +1280,19 @@ namespace fintype
 
 open finset
 
+/-- `fintype.prod_bijective` is a variant of `finset.prod_bij` that accepts `function.bijective`. -/
+@[to_additive "`fintype.sum_equiv` is a variant of `finset.sum_bij` that accepts
+`function.bijective`"]
+lemma prod_bijective {α β M : Type*} [fintype α] [fintype β] [comm_monoid M]
+  (e : α → β) (he : function.bijective e) (f : α → M) (g : β → M) (h : ∀ x, f x = g (e x)) :
+  ∏ x : α, f x = ∏ x : β, g x :=
+prod_bij
+  (λ x _, e x)
+  (λ x _, mem_univ (e x))
+  (λ x _, h x)
+  (λ x x' _ _ h, he.injective h)
+  (λ y _, (he.surjective y).imp $ λ a h, ⟨mem_univ _, h.symm⟩)
+
 /-- `fintype.prod_equiv` is a specialization of `finset.prod_bij` that
 automatically fills in most arguments. -/
 @[to_additive "`fintype.sum_equiv` is a specialization of `finset.sum_bij` that
@@ -1287,12 +1300,7 @@ automatically fills in most arguments."]
 lemma prod_equiv {α β M : Type*} [fintype α] [fintype β] [comm_monoid M]
   (e : α ≃ β) (f : α → M) (g : β → M) (h : ∀ x, f x = g (e x)) :
   ∏ x : α, f x = ∏ x : β, g x :=
-prod_bij
-  (λ x _, e x)
-  (λ x _, mem_univ (e x))
-  (λ x _, h x)
-  (λ x x' _ _ h, e.injective h)
-  (λ y _, ⟨e.symm y, mem_univ _, (e.apply_symm_apply y).symm⟩)
+prod_bijective e e.bijective f g h
 
 end fintype
 

--- a/src/algebra/polynomial/group_ring_action.lean
+++ b/src/algebra/polynomial/group_ring_action.lean
@@ -98,9 +98,8 @@ theorem prod_X_sub_smul.eval (x : R) : (prod_X_sub_smul G R x).eval x = 0 :=
 
 theorem prod_X_sub_smul.smul (x : R) (g : G) :
   g • prod_X_sub_smul G R x = prod_X_sub_smul G R x :=
-(smul_prod _ _ _ _ _).trans $ fintype.prod_equiv (equiv.of_bijective _ (mul_action.bijective g)) _ _
-  (λ g', by rw [equiv.of_bijective_apply, of_quotient_stabilizer_smul, smul_sub,
-                polynomial.smul_X, polynomial.smul_C])
+(smul_prod _ _ _ _ _).trans $ fintype.prod_bijective _ (mul_action.bijective g) _ _
+  (λ g', by rw [of_quotient_stabilizer_smul, smul_sub, polynomial.smul_X, polynomial.smul_C])
 
 theorem prod_X_sub_smul.coeff (x : R) (g : G) (n : ℕ) :
   g • (prod_X_sub_smul G R x).coeff n =

--- a/src/algebra/polynomial/group_ring_action.lean
+++ b/src/algebra/polynomial/group_ring_action.lean
@@ -98,10 +98,9 @@ theorem prod_X_sub_smul.eval (x : R) : (prod_X_sub_smul G R x).eval x = 0 :=
 
 theorem prod_X_sub_smul.smul (x : R) (g : G) :
   g • prod_X_sub_smul G R x = prod_X_sub_smul G R x :=
-(smul_prod _ _ _ _ _).trans $ finset.prod_bij (λ g' _, g • g') (λ _ _, finset.mem_univ _)
-  (λ g' _, by rw [of_quotient_stabilizer_smul, smul_sub, polynomial.smul_X, polynomial.smul_C])
-  (λ _ _ _ _ H, (mul_action.bijective g).1 H)
-  (λ g' _, ⟨g⁻¹ • g', finset.mem_univ _, by rw [smul_smul, mul_inv_self, one_smul]⟩)
+(smul_prod _ _ _ _ _).trans $ fintype.prod_equiv (equiv.of_bijective _ (mul_action.bijective g)) _ _
+  (λ g', by rw [equiv.of_bijective_apply, of_quotient_stabilizer_smul, smul_sub,
+                polynomial.smul_X, polynomial.smul_C])
 
 theorem prod_X_sub_smul.coeff (x : R) (g : G) (n : ℕ) :
   g • (prod_X_sub_smul G R x).coeff n =

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -129,6 +129,9 @@ def simps.symm_apply (e : α ≃ β) : β → α := e.symm
 
 initialize_simps_projections equiv (to_fun → apply, inv_fun → symm_apply)
 
+-- Generate the `simps` projections for previously defined equivs.
+attribute [simps] function.involutive.to_equiv
+
 /-- Composition of equivalences `e₁ : α ≃ β` and `e₂ : β ≃ γ`. -/
 @[trans] protected def trans (e₁ : α ≃ β) (e₂ : β ≃ γ) : α ≃ γ :=
 ⟨e₂ ∘ e₁, e₁.symm ∘ e₂.symm,
@@ -1345,6 +1348,7 @@ by { cases a, cases a_val, refl }
 
 /-- If a proposition holds for all elements, then the subtype is
 equivalent to the original type. -/
+@[simps apply symm_apply]
 def subtype_univ_equiv {α : Type u} {p : α → Prop} (h : ∀ x, p x) :
   subtype p ≃ α :=
 ⟨λ x, x, λ x, ⟨x, h x⟩, λ x, subtype.eq rfl, λ x, rfl⟩

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -249,7 +249,7 @@ by simpa using fintype.sum_pow_mul_eq_add_pow (fin n) a b
 lemma function.bijective.prod_comp [fintype α] [fintype β] [comm_monoid γ] {f : α → β}
   (hf : function.bijective f) (g : β → γ) :
   ∏ i, g (f i) = ∏ i, g i :=
-fintype.prod_equiv (equiv.of_bijective f hf) _ _ (λ x, rfl)
+fintype.prod_bijective f hf _ _ (λ x, rfl)
 
 @[to_additive]
 lemma equiv.prod_comp [fintype α] [fintype β] [comm_monoid γ] (e : α ≃ β) (f : β → γ) :

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -201,8 +201,7 @@ by rw fintype.of_equiv_card; simp
 @[simp, to_additive]
 lemma finset.prod_attach_univ [fintype α] [comm_monoid β] (f : {a : α // a ∈ @univ α _} → β) :
   ∏ x in univ.attach, f x = ∏ x, f ⟨x, (mem_univ _)⟩ :=
-prod_bij (λ x _, x.1) (λ _ _, mem_univ _) (λ _ _ , by simp) (by simp)
-  (λ b _, ⟨⟨b, mem_univ _⟩, by simp⟩)
+fintype.prod_equiv (equiv.subtype_univ_equiv (λ x, mem_univ _)) _ _ (λ x, by simp)
 
 /-- Taking a product over `univ.pi t` is the same as taking the product over `fintype.pi_finset t`.
   `univ.pi t` and `fintype.pi_finset t` are essentially the same `finset`, but differ
@@ -250,8 +249,7 @@ by simpa using fintype.sum_pow_mul_eq_add_pow (fin n) a b
 lemma function.bijective.prod_comp [fintype α] [fintype β] [comm_monoid γ] {f : α → β}
   (hf : function.bijective f) (g : β → γ) :
   ∏ i, g (f i) = ∏ i, g i :=
-prod_bij (λ i hi, f i) (λ i hi, mem_univ _) (λ i hi, rfl) (λ i j _ _ h, hf.1 h) $
-  λ i hi, (hf.2 i).imp $ λ j hj, ⟨mem_univ _, hj.symm⟩
+fintype.prod_equiv (equiv.of_bijective f hf) _ _ (λ x, rfl)
 
 @[to_additive]
 lemma equiv.prod_comp [fintype α] [fintype β] [comm_monoid γ] (e : α ≃ β) (f : β → γ) :

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -125,10 +125,7 @@ begin
     (λ σ _, σ * swap i j)
     (λ σ _,
       have ∏ x, M (σ x) (p x) = ∏ x, M ((σ * swap i j) x) (p x),
-        from prod_bij (λ a _, swap i j a) (λ _ _, mem_univ _)
-          (by simp [apply_swap_eq_self hpij])
-          (λ _ _ _ _ h, (swap i j).injective h)
-          (λ b _, ⟨swap i j b, mem_univ _, by simp⟩),
+        from fintype.prod_equiv (swap i j) _ _ (by simp [apply_swap_eq_self hpij]),
       by simp [this, sign_swap hij, prod_mul_distrib])
     (λ σ _ _, (not_congr mul_swap_eq_iff).mpr hij)
     (λ _ _, mem_univ _)
@@ -150,16 +147,15 @@ calc det (M ⬝ N) = ∑ p : n → n, ∑ σ : perm n, ε σ * ∏ i, (M (σ i) 
 ... = ∑ σ : perm n, ∑ τ : perm n, (∏ i, N (σ i) i) * ε τ * (∏ j, M (τ j) (σ j)) :
   by simp [mul_sum, det_apply', mul_comm, mul_left_comm, prod_mul_distrib, mul_assoc]
 ... = ∑ σ : perm n, ∑ τ : perm n, (((∏ i, N (σ i) i) * (ε σ * ε τ)) * ∏ i, M (τ i) i) :
-  sum_congr rfl (λ σ _, sum_bij (λ τ _, τ * σ⁻¹) (λ _ _, mem_univ _)
-    (λ τ _,
+  sum_congr rfl (λ σ _, fintype.sum_equiv (equiv.mul_right σ⁻¹) _ _
+    (λ τ,
       have ∏ j, M (τ j) (σ j) = ∏ j, M ((τ * σ⁻¹) j) j,
         by rw ← σ⁻¹.prod_comp; simp [mul_apply],
       have h : ε σ * ε (τ * σ⁻¹) = ε τ :=
         calc ε σ * ε (τ * σ⁻¹) = ε ((τ * σ⁻¹) * σ) :
           by rw [mul_comm, sign_mul (τ * σ⁻¹)]; simp
         ... = ε τ : by simp,
-      by rw h; simp [this, mul_comm, mul_assoc, mul_left_comm])
-    (λ _ _ _ _, mul_right_cancel) (λ τ _, ⟨τ * σ, by simp⟩))
+      by simp_rw [equiv.coe_mul_right, h]; simp [this, mul_comm, mul_assoc, mul_left_comm]))
 ... = det M * det N : by simp [det_apply', mul_assoc, mul_sum, mul_comm, mul_left_comm]
 
 instance : is_monoid_hom (det : matrix n n R → R) :=
@@ -170,18 +166,13 @@ instance : is_monoid_hom (det : matrix n n R → R) :=
 @[simp] lemma det_transpose (M : matrix n n R) : Mᵀ.det = M.det :=
 begin
   rw [det_apply', det_apply'],
-  apply sum_bij (λ σ _, σ⁻¹),
-  { intros σ _, apply mem_univ },
-  { intros σ _,
-    rw [sign_inv],
-    congr' 1,
-    apply prod_bij (λ i _, σ i),
-    { intros i _, apply mem_univ },
-    { intros i _, simp },
-    { intros i j _ _ h, simp at h, assumption },
-    { intros i _, use σ⁻¹ i, finish } },
-  { intros σ σ' _ _ h, simp at h, assumption },
-  { intros σ _, use σ⁻¹, finish }
+  refine fintype.sum_equiv (inv_involutive.to_equiv _) _ _ _,
+  intros σ,
+  rw [involutive.to_equiv_apply, sign_inv],
+  congr' 1,
+  apply fintype.prod_equiv σ,
+  intros,
+  simp
 end
 
 

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -166,9 +166,9 @@ instance : is_monoid_hom (det : matrix n n R → R) :=
 @[simp] lemma det_transpose (M : matrix n n R) : Mᵀ.det = M.det :=
 begin
   rw [det_apply', det_apply'],
-  refine fintype.sum_equiv (inv_involutive.to_equiv _) _ _ _,
+  refine fintype.sum_bijective _ inv_involutive.bijective _ _ _,
   intros σ,
-  rw [involutive.to_equiv_apply, sign_inv],
+  rw sign_inv,
   congr' 1,
   apply fintype.prod_equiv σ,
   intros,


### PR DESCRIPTION
Often we want to apply `finset.prod_bij` to the case where the product is taken over `finset.univ` and the bijection is already a bundled `equiv`. This PR adds `fintype.prod_equiv` as a specialization for exactly these cases, filling in most of the arguments already.

---

- [x] depends on: #7083 

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
