### PR TITLE
[Merged by Bors] - feat(group_theory/is_free_group): promote `is_free_group.lift'` to an equiv

### DIFF
--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -410,6 +410,7 @@ by cases H with _ _ _ b; cases b; simp [lift.aux]
 /-- If `β` is a group, then any function from `α` to `β`
 extends uniquely to a group homomorphism from
 the free group over `α` to `β` -/
+@[simps symm_apply]
 def lift : (α → β) ≃ (free_group α →* β) :=
 { to_fun := λ f,
     monoid_hom.mk' (quot.lift (lift.aux f) $ λ L₁ L₂, red.step.lift) $ begin

--- a/src/group_theory/is_free_group.lean
+++ b/src/group_theory/is_free_group.lean
@@ -39,10 +39,10 @@ variables {G H : Type u} [group G] [group H] [is_free_group G]
 given by those generators. -/
 @[simps symm_apply]
 def lift' : (generators G → H) ≃ (G →* H) :=
-{ to_fun := λ f, classical.some (unique_lift f),
+{ to_fun := λ f, classical.some (unique_lift' f),
   inv_fun := λ F, F ∘ of,
-  left_inv := λ f, funext (classical.some_spec (unique_lift f)).left,
-  right_inv := λ F, ((classical.some_spec (unique_lift (F ∘ of))).right F (λ _, rfl)).symm }
+  left_inv := λ f, funext (classical.some_spec (unique_lift' f)).left,
+  right_inv := λ F, ((classical.some_spec (unique_lift' (F ∘ of))).right F (λ _, rfl)).symm }
 
 @[simp] lemma lift'_of (f : generators G → H) (a : generators G) : (lift' f) (of a) = f a :=
 congr_fun (lift'.symm_apply_apply f) a

--- a/src/group_theory/is_free_group.lean
+++ b/src/group_theory/is_free_group.lean
@@ -1,13 +1,29 @@
 /-
 Copyright (c) 2021 David Wärn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: David Wärn
+Authors: David Wärn, Eric Wieser
 -/
 import group_theory.free_group
 /-!
+# Free groups structures on arbitrary types
+
 This file defines the universal property of free groups, and proves some things about
 groups with this property. For an explicit construction of free groups, see
 `group_theory/free_group`.
+
+## Main definitions
+
+* `is_free_group G` - a typeclass to indicate that `G` is free over some generators
+* `is_free_group.lift` - the (noncomputable) universal property of the free group
+* `is_free_group.to_free_group` - any free group with generators `A` is equivalent to
+  `free_group A`.
+
+## Implementation notes
+
+While the typeclass only requires the universal property hold within a single universe `u`, our
+explicit construction of `free_group` allows this to be extended universe polymorphically. The
+primed definition names in this file refer to the non-polymorphic versions.
+
 -/
 noncomputable theory
 universes u w
@@ -74,7 +90,7 @@ ext_hom h
 
 variable (G)
 /-- Any free group is isomorphic to "the" free group. -/
-@[simps] def iso_free_group_of_is_free_group : G ≃* free_group (generators G) :=
+@[simps] def to_free_group : G ≃* free_group (generators G) :=
 { to_fun := lift' free_group.of,
   inv_fun := free_group.lift of,
   left_inv :=
@@ -106,12 +122,12 @@ def of_mul_equiv (h : G ≃* H) : is_free_group H :=
   end }
 
 private lemma lift_right_inv_aux  {X : Type w} [group X] (F : G →* X) :
-  free_group.lift.symm (F.comp (iso_free_group_of_is_free_group G).symm.to_monoid_hom) = F ∘ of :=
+  free_group.lift.symm (F.comp (to_free_group G).symm.to_monoid_hom) = F ∘ of :=
 by { ext, simp }
 
 /-- A universe-polymorphic version of `is_free_group.lift'`. -/
 protected def lift {X : Type w} [group X] : (generators G → X) ≃ (G →* X) :=
-{ to_fun := λ f, (free_group.lift f).comp (iso_free_group_of_is_free_group G).to_monoid_hom,
+{ to_fun := λ f, (free_group.lift f).comp (to_free_group G).to_monoid_hom,
   inv_fun := λ F, F ∘ of,
   left_inv := λ f, free_group.lift.injective begin
     ext x,


### PR DESCRIPTION
While non-computable, this makes the API of `is_free_group` align more closely with `free_group`.

Based on discussion in the original PR, this doesn't go as far as changing the definition of `is_free_group` to take the equiv directly.

This additionally:
* adds the definition `lift`, a universe polymorphic version of `lift'`
* adds the lemmas:
  * `lift'_eq_free_group_lift`
  * `lift_eq_free_group_lift`
  * `of_eq_free_group_of`
  * `ext_hom'`
  * `ext_hom`
* renames `is_free_group.iso_free_group_of_is_free_group` to the shorter `is_free_group.to_free_group`
* removes lemmas absent from the `free_group` API that are no longer needed for the proofs here:
  * `end_is_id`
  * `eq_lift`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
