### PR TITLE
[Merged by Bors] - chore(linear_algebra/multilinear): relax requirements on `multilinear_map.pi_ring_equiv`

### DIFF
--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -793,7 +793,7 @@ end range_add_comm_group
 
 section add_comm_group
 
-variables [semiring R] [∀i, add_comm_monoid (M₁ i)] [add_comm_monoid M₂]
+variables [semiring R] [∀i, add_comm_group (M₁ i)] [add_comm_group M₂]
 [∀i, semimodule R (M₁ i)] [semimodule R M₂]
 (f : multilinear_map R M₁ M₂)
 
@@ -809,7 +809,7 @@ end add_comm_group
 
 section comm_semiring
 
-variables [comm_semiring R] [∀i, add_comm_group (M₁ i)] [add_comm_group M₂]
+variables [comm_semiring R] [∀i, add_comm_monoid (M₁ i)] [add_comm_monoid M₂]
 [∀i, semimodule R (M₁ i)] [semimodule R M₂]
 
 /-- When `ι` is finite, multilinear maps on `R^ι` with values in `M₂` are in bijection with `M₂`,

--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -793,7 +793,7 @@ end range_add_comm_group
 
 section add_comm_group
 
-variables [semiring R] [∀i, add_comm_group (M₁ i)] [add_comm_group M₂]
+variables [semiring R] [∀i, add_comm_monoid (M₁ i)] [add_comm_monoid M₂]
 [∀i, semimodule R (M₁ i)] [semimodule R M₂]
 (f : multilinear_map R M₁ M₂)
 


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
