### PR TITLE
[Merged by Bors] - feat(logic/function/iterate): `f^[n]^[m] = f^[m]^[n]`

### DIFF
--- a/src/logic/function/conjugate.lean
+++ b/src/logic/function/conjugate.lean
@@ -21,7 +21,10 @@ namespace function
 
 variables {α : Type*} {β : Type*} {γ : Type*}
 
-/-- We say that `f : α → β` semiconjugates `ga : α → α` to `gb : β → β` if `f ∘ ga = gb ∘ f`. -/
+/-- We say that `f : α → β` semiconjugates `ga : α → α` to `gb : β → β` if `f ∘ ga = gb ∘ f`.
+We use `∀ x, f (ga x) = gb (f x)` as the definition, so given `h : function.semiconj f ga gb` and
+`a : α`, `h a` has type `f (ga x) = gb (f x)`. Functional equality of compositions is available
+as `h.comp_eq`. -/
 def semiconj (f : α → β) (ga : α → α) (gb : β → β) : Prop := ∀ x, f (ga x) = gb (f x)
 
 namespace semiconj
@@ -51,8 +54,9 @@ lemma inverses_right (h : semiconj f ga gb) (ha : right_inverse ga' ga)
 
 end semiconj
 
-/-- Two maps `f g : α → α` commute if `f ∘ g = g ∘ f`.
-Given `h : function.commute f g` and `a : α`, we have `h a : f (g a) = g (f a)`. -/
+/-- Two maps `f g : α → α` commute if `f (g x) = g (f x)` for all `x : α`.
+Given `h : function.commute f g` and `a : α`, we have `h a : f (g a) = g (f a)` and
+`h.comp_eq : f ∘ g = g ∘ f`. -/
 def commute (f g : α → α) : Prop := semiconj f g g
 
 lemma semiconj.commute {f g : α → α} (h : semiconj f g g) : commute f g := h

--- a/src/logic/function/conjugate.lean
+++ b/src/logic/function/conjugate.lean
@@ -55,7 +55,7 @@ end semiconj
 Given `h : function.commute f g` and `a : α`, the term `h a` has Type `h a : f (g a) = g (f a)`. -/
 def commute (f g : α → α) : Prop := semiconj f g g
 
-lemma apply {f g : α → α} (h : function.commute f g) (x : α) :
+lemma commute.apply {f g : α → α} (h : function.commute f g) (x : α) :
   f (g x) = g (f x) :=
 h _
 

--- a/src/logic/function/conjugate.lean
+++ b/src/logic/function/conjugate.lean
@@ -23,8 +23,7 @@ variables {α : Type*} {β : Type*} {γ : Type*}
 
 /-- We say that `f : α → β` semiconjugates `ga : α → α` to `gb : β → β` if `f ∘ ga = gb ∘ f`.
 We use `∀ x, f (ga x) = gb (f x)` as the definition, so given `h : function.semiconj f ga gb` and
-`a : α`, `h a` has type `f (ga x) = gb (f x)`. Functional equality of compositions is available
-as `h.comp_eq`. -/
+`a : α`, we have `h a : f (ga a) = gb (f a)` and `h.comp_eq : f ∘ ga = gb ∘ f`. -/
 def semiconj (f : α → β) (ga : α → α) (gb : β → β) : Prop := ∀ x, f (ga x) = gb (f x)
 
 namespace semiconj

--- a/src/logic/function/conjugate.lean
+++ b/src/logic/function/conjugate.lean
@@ -51,7 +51,8 @@ lemma inverses_right (h : semiconj f ga gb) (ha : right_inverse ga' ga)
 
 end semiconj
 
-/-- Two maps `f g : α → α` commute if `f ∘ g = g ∘ f`. -/
+/-- Two maps `f g : α → α` commute if `f ∘ g = g ∘ f`.
+Given `h : function.commute f g` and `a : α`, the term `h a ` has Type `h a : f (g a) = g (f a)`. -/
 def commute (f g : α → α) : Prop := semiconj f g g
 
 lemma semiconj.commute {f g : α → α} (h : semiconj f g g) : commute f g := h

--- a/src/logic/function/conjugate.lean
+++ b/src/logic/function/conjugate.lean
@@ -52,7 +52,7 @@ lemma inverses_right (h : semiconj f ga gb) (ha : right_inverse ga' ga)
 end semiconj
 
 /-- Two maps `f g : α → α` commute if `f ∘ g = g ∘ f`.
-Given `h : function.commute f g` and `a : α`, the term `h a` has Type `h a : f (g a) = g (f a)`. -/
+Given `h : function.commute f g` and `a : α`, we have `h a : f (g a) = g (f a)`. -/
 def commute (f g : α → α) : Prop := semiconj f g g
 
 lemma semiconj.commute {f g : α → α} (h : semiconj f g g) : commute f g := h

--- a/src/logic/function/conjugate.lean
+++ b/src/logic/function/conjugate.lean
@@ -55,10 +55,6 @@ end semiconj
 Given `h : function.commute f g` and `a : α`, the term `h a` has Type `h a : f (g a) = g (f a)`. -/
 def commute (f g : α → α) : Prop := semiconj f g g
 
-lemma commute.apply {f g : α → α} (h : function.commute f g) (x : α) :
-  f (g x) = g (f x) :=
-h _
-
 lemma semiconj.commute {f g : α → α} (h : semiconj f g g) : commute f g := h
 
 namespace commute

--- a/src/logic/function/conjugate.lean
+++ b/src/logic/function/conjugate.lean
@@ -52,7 +52,7 @@ lemma inverses_right (h : semiconj f ga gb) (ha : right_inverse ga' ga)
 end semiconj
 
 /-- Two maps `f g : α → α` commute if `f ∘ g = g ∘ f`.
-Given `h : function.commute f g` and `a : α`, the term `h a ` has Type `h a : f (g a) = g (f a)`. -/
+Given `h : function.commute f g` and `a : α`, the term `h a` has Type `h a : f (g a) = g (f a)`. -/
 def commute (f g : α → α) : Prop := semiconj f g g
 
 lemma semiconj.commute {f g : α → α} (h : semiconj f g g) : commute f g := h

--- a/src/logic/function/conjugate.lean
+++ b/src/logic/function/conjugate.lean
@@ -55,6 +55,10 @@ end semiconj
 Given `h : function.commute f g` and `a : α`, the term `h a ` has Type `h a : f (g a) = g (f a)`. -/
 def commute (f g : α → α) : Prop := semiconj f g g
 
+lemma apply {f g : α → α} (h : function.commute f g) (x : α) :
+  f (g x) = g (f x) :=
+h _
+
 lemma semiconj.commute {f g : α → α} (h : semiconj f g g) : commute f g := h
 
 namespace commute

--- a/src/logic/function/iterate.lean
+++ b/src/logic/function/iterate.lean
@@ -93,10 +93,6 @@ namespace commute
 
 variable {g : α → α}
 
-lemma apply (h : function.commute f g) (x : α) :
-  f (g x) = g (f x) :=
-h _
-
 lemma iterate_right (h : commute f g) (n : ℕ) : commute f (g^[n]) := h.iterate_right n
 
 lemma iterate_left (h : commute f g) (n : ℕ) : commute (f^[n]) g := (h.symm.iterate_right n).symm

--- a/src/logic/function/iterate.lean
+++ b/src/logic/function/iterate.lean
@@ -149,7 +149,10 @@ theorem right_inverse.iterate {g : α → α} (hg : right_inverse g f) (n : ℕ)
   right_inverse (g^[n]) (f^[n]) :=
 hg.iterate n
 
-lemma iterate_comm (m n : ℕ) : commute (λ f : α → α, f^[m]) (λ f, f^[n]) :=
-λ f, (iterate_mul _ _ _).symm.trans (eq.trans (by rw nat.mul_comm) (iterate_mul _ _ _))
+lemma iterate_comm {m n : ℕ} : f^[n]^[m] = (f^[m]^[n] : α → α) :=
+(iterate_mul _ _ _).symm.trans (eq.trans (by rw nat.mul_comm) (iterate_mul _ _ _))
+
+lemma iterate_commute (m n : ℕ) : commute (λ f : α → α, f^[m]) (λ f, f^[n]) :=
+λ f, iterate_comm
 
 end function

--- a/src/logic/function/iterate.lean
+++ b/src/logic/function/iterate.lean
@@ -149,4 +149,7 @@ theorem right_inverse.iterate {g : α → α} (hg : right_inverse g f) (n : ℕ)
   right_inverse (g^[n]) (f^[n]) :=
 hg.iterate n
 
+lemma comm {m n : ℕ} : f^[n]^[m] = (f^[m]^[n] : α → α) :=
+(iterate_mul _ _ _).symm.trans (eq.trans (by rw nat.mul_comm) (iterate_mul _ _ _))
+
 end function

--- a/src/logic/function/iterate.lean
+++ b/src/logic/function/iterate.lean
@@ -149,7 +149,7 @@ theorem right_inverse.iterate {g : α → α} (hg : right_inverse g f) (n : ℕ)
   right_inverse (g^[n]) (f^[n]) :=
 hg.iterate n
 
-lemma iterate_comm {m n : ℕ} : f^[n]^[m] = (f^[m]^[n] : α → α) :=
-(iterate_mul _ _ _).symm.trans (eq.trans (by rw nat.mul_comm) (iterate_mul _ _ _))
+lemma iterate_comm (m n : ℕ) : commute (λ f : α → α, f^[m]) (λ f, f^[n]) :=
+λ f, (iterate_mul _ _ _).symm.trans (eq.trans (by rw nat.mul_comm) (iterate_mul _ _ _))
 
 end function

--- a/src/logic/function/iterate.lean
+++ b/src/logic/function/iterate.lean
@@ -153,7 +153,7 @@ theorem right_inverse.iterate {g : α → α} (hg : right_inverse g f) (n : ℕ)
   right_inverse (g^[n]) (f^[n]) :=
 hg.iterate n
 
-lemma comm {m n : ℕ} : f^[n]^[m] = (f^[m]^[n] : α → α) :=
+lemma iterate_comm {m n : ℕ} : f^[n]^[m] = (f^[m]^[n] : α → α) :=
 (iterate_mul _ _ _).symm.trans (eq.trans (by rw nat.mul_comm) (iterate_mul _ _ _))
 
 end function

--- a/src/logic/function/iterate.lean
+++ b/src/logic/function/iterate.lean
@@ -93,6 +93,10 @@ namespace commute
 
 variable {g : α → α}
 
+lemma apply (h : function.commute f g) (x : α) :
+  f (g x) = g (f x) :=
+h _
+
 lemma iterate_right (h : commute f g) (n : ℕ) : commute f (g^[n]) := h.iterate_right n
 
 lemma iterate_left (h : commute f g) (n : ℕ) : commute (f^[n]) g := (h.symm.iterate_right n).symm

--- a/src/logic/function/iterate.lean
+++ b/src/logic/function/iterate.lean
@@ -149,10 +149,10 @@ theorem right_inverse.iterate {g : α → α} (hg : right_inverse g f) (n : ℕ)
   right_inverse (g^[n]) (f^[n]) :=
 hg.iterate n
 
-lemma iterate_comm {m n : ℕ} : f^[n]^[m] = (f^[m]^[n] : α → α) :=
+lemma iterate_comm (f : α → α) (m n : ℕ) : f^[n]^[m] = (f^[m]^[n]) :=
 (iterate_mul _ _ _).symm.trans (eq.trans (by rw nat.mul_comm) (iterate_mul _ _ _))
 
 lemma iterate_commute (m n : ℕ) : commute (λ f : α → α, f^[m]) (λ f, f^[n]) :=
-λ f, iterate_comm
+λ f, iterate_comm f m n
 
 end function


### PR DESCRIPTION
Prove `f^[n]^[m]=f^[m]^[n]` and improve some docs.

Co-authored-by: Yakov Pechersky <ffxen158@gmail.com>
Co-authored-by: Yury Kudryashov <urkud@urkud.name>

---

Zulip discussion:
https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
