### PR TITLE
[Merged by Bors] - feat(linear_algebra/eigenspace): define the maximal generalized eigenspace

### DIFF
--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -330,6 +330,26 @@ begin
   exact h linear_map.ker_id
 end
 
+/-- The union of the kernels of `(f - μ • id) ^ k` over all `k`. -/
+def maximal_generalized_eigenspace (f : End R M) (μ : R) : submodule R M :=
+⨆ k, f.generalized_eigenspace μ k
+
+/-- If there exists a natural number `k` such that the kernel of `(f - μ • id) ^ k` is the
+maximal generalized eigenspace, then this value is the least such `k`. If not, this value is not
+meaningful. -/
+noncomputable def maximal_generalized_eigenspace_index (f : End R M) (μ : R) :=
+monotonic_sequence_limit_index (f.generalized_eigenspace μ)
+
+/-- For an endomorphism of a Noetherian module, the maximal eigenspace is always of the form kernel
+`(f - μ • id) ^ k` for some `k`. -/
+lemma maximal_generalized_eigenspace_eq [h : is_noetherian R M] (f : End R M) (μ : R) :
+  maximal_generalized_eigenspace f μ =
+  f.generalized_eigenspace μ (maximal_generalized_eigenspace_index f μ) :=
+begin
+  rw is_noetherian_iff_well_founded at h,
+  exact (well_founded.supr_eq_monotonic_sequence_limit h (f.generalized_eigenspace μ) : _),
+end
+
 /-- A generalized eigenvalue for some exponent `k` is also
     a generalized eigenvalue for exponents larger than `k`. -/
 lemma has_generalized_eigenvalue_of_has_generalized_eigenvalue_of_le

--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -8,6 +8,7 @@ import data.equiv.denumerable
 import data.set.finite
 import order.rel_iso
 import order.preorder_hom
+import order.conditionally_complete_lattice
 import logic.function.iterate
 
 namespace rel_embedding
@@ -156,4 +157,35 @@ begin
   { rw rel_embedding.well_founded_iff_no_descending_seq, rintros ⟨a⟩,
     obtain ⟨n, hn⟩ := h (a.swap : ((<) : ℕ → ℕ → Prop) →r ((<) : α → α → Prop)).to_preorder_hom,
     exact n.succ_ne_self.symm (rel_embedding.to_preorder_hom_injective _ (hn _ n.le_succ)), },
+end
+
+/-- Given an eventually-constant monotonic sequence `a₀ ≤ a₁ ≤ a₂ ≤ ...` in a partially-ordered
+type, `monotonic_sequence_limit_index a` is the least natural number `n` for which `aₙ` reaches the
+constant value. For sequences that are not eventually constant, `monotonic_sequence_limit_index a`
+is defined, but is a junk value. -/
+noncomputable def monotonic_sequence_limit_index {α : Type*} [partial_order α] (a : ℕ →ₘ α) : ℕ :=
+Inf { n | ∀ m, n ≤ m → a n = a m }
+
+/-- The constant value of an eventually-constant monotonic sequence `a₀ ≤ a₁ ≤ a₂ ≤ ...` in a
+partially-ordered type. -/
+noncomputable def monotonic_sequence_limit {α : Type*} [partial_order α] (a : ℕ →ₘ α) :=
+a (monotonic_sequence_limit_index a)
+
+lemma well_founded.supr_eq_monotonic_sequence_limit {α : Type*} [complete_lattice α]
+  (h : well_founded ((>) : α → α → Prop)) (a : ℕ →ₘ α) :
+  (⨆ m, a m) = monotonic_sequence_limit a :=
+begin
+  suffices : (⨆ (m : ℕ), a m) ≤ monotonic_sequence_limit a,
+  { exact le_antisymm this (le_supr a _), },
+  apply supr_le,
+  intros m,
+  by_cases hm : m ≤ monotonic_sequence_limit_index a,
+  { exact a.monotone hm, },
+  { replace hm := le_of_not_le hm,
+    let S := { n | ∀ m, n ≤ m → a n = a m },
+    have hInf : Inf S ∈ S,
+    { refine nat.Inf_mem _, rw well_founded.monotone_chain_condition at h, exact h a, },
+    change Inf S ≤ m at hm,
+    change a m ≤ a (Inf S),
+    rw hInf m hm, },
 end


### PR DESCRIPTION
And prove that it is of the form kernel of `(f - μ • id) ^ k` for some finite `k` for endomorphisms of Noetherian modules.

---

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
