### PR TITLE
[Merged by Bors] - refactor(order/well_founded_set): partially well ordered sets using relations other than `has_le.le`

### DIFF
--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -276,3 +276,19 @@ end
 
 @[simp] lemma not_unbounded_iff {r : α → α → Prop} (s : set α) : ¬unbounded r s ↔ bounded r s :=
 by { classical, rw [not_iff_comm, not_bounded_iff] }
+
+namespace prod
+
+instance is_refl_preimage_fst {r : α → α → Prop} [h : is_refl α r] :
+  is_refl (α × α) (prod.fst ⁻¹'o r) := ⟨λ a, refl_of r a.1⟩
+
+instance is_refl_preimage_snd {r : α → α → Prop} [h : is_refl α r] :
+  is_refl (α × α) (prod.snd ⁻¹'o r) := ⟨λ a, refl_of r a.2⟩
+
+instance is_trans_preimage_fst {r : α → α → Prop} [h : is_trans α r] :
+  is_trans (α × α) (prod.fst ⁻¹'o r) := ⟨λ _ _ _, trans_of r⟩
+
+instance is_trans_preimage_snd {r : α → α → Prop} [h : is_trans α r] :
+  is_trans (α × α) (prod.snd ⁻¹'o r) := ⟨λ _ _ _, trans_of r⟩
+
+end prod

--- a/src/order/well_founded_set.lean
+++ b/src/order/well_founded_set.lean
@@ -288,6 +288,10 @@ theorem is_wf.is_pwo [linear_order α] {s : set α}
   apply mem_range_self,
 end
 
+theorem is_wf_iff_is_pwo [linear_order α] {s : set α} :
+  s.is_wf ↔ s.is_pwo :=
+⟨is_wf.is_pwo, is_pwo.is_wf⟩
+
 end set
 
 @[simp]

--- a/src/order/well_founded_set.lean
+++ b/src/order/well_founded_set.lean
@@ -18,7 +18,7 @@ A well-founded subset of an ordered type is one on which the relation `<` is wel
  * `set.well_founded_on s r` indicates that the relation `r` is
   well-founded when restricted to the set `s`.
  * `set.is_wf s` indicates that `<` is well-founded when restricted to `s`.
- * `set.is_partially_well_ordered s` indicates that any infinite sequence of elements in `s`
+ * `set.is_pwo s` indicates that any infinite sequence of elements in `s`
   contains an infinite monotone subsequence.
 
 ### Definitions for Hahn Series
@@ -60,6 +60,32 @@ begin
     exact ⟨m, mt, λ x xt ⟨xm, xs, ms⟩, hst ⟨m, ⟨ms, mt⟩⟩⟩ }
 end
 
+instance is_strict_order.subset {s : set α} {r : α → α → Prop} [is_strict_order α r] :
+  is_strict_order α (λ (a b : α), r a b ∧ a ∈ s ∧ b ∈ s) :=
+{ to_is_irrefl := ⟨λ a con, irrefl_of r a con.1 ⟩,
+  to_is_trans := ⟨λ a b c ab bc, ⟨trans_of r ab.1 bc.1, ab.2.1, bc.2.2⟩ ⟩ }
+
+theorem well_founded_on_iff_no_descending_seq {s : set α} {r : α → α → Prop} [is_strict_order α r] :
+  s.well_founded_on r ↔ ∀ (f : ((>) : ℕ → ℕ → Prop) ↪r r), ¬ (range f) ⊆ s :=
+begin
+  rw [well_founded_on_iff, rel_embedding.well_founded_iff_no_descending_seq],
+  refine ⟨λ h f con, h begin
+    use f,
+      { exact f.injective },
+      { intros a b,
+        simp only [con (mem_range_self a), con (mem_range_self b), and_true, gt_iff_lt,
+          function.embedding.coe_fn_mk, f.map_rel_iff] }
+    end, λ h con, _⟩,
+  rcases con with ⟨f, hf⟩,
+  have hfs' : ∀ n : ℕ, f n ∈ s := λ n, (hf.2 n.lt_succ_self).2.2,
+  refine h ⟨f, λ a b, _⟩ (λ n hn, _),
+  { rw ← hf,
+    exact ⟨λ h, ⟨h, hfs' _, hfs' _⟩, λ h, h.1⟩ },
+  { rcases set.mem_range.1 hn with ⟨m, hm⟩,
+    rw ← hm,
+    apply hfs' }
+end
+
 section has_lt
 variables [has_lt α]
 
@@ -89,27 +115,9 @@ begin
     to_is_irrefl := ⟨λ x con, lt_irrefl x con.1⟩,
     to_is_trans := ⟨λ a b c ab bc, ⟨lt_trans ab.1 bc.1, ab.2.1, bc.2.2⟩⟩,
   },
-  rw [is_wf, well_founded_on_iff, rel_embedding.well_founded_iff_no_descending_seq],
-  refine ⟨λ h f con, h begin
-    use f,
-      { exact f.injective },
-      { intros a b,
-        simp only [con (mem_range_self a), con (mem_range_self b), and_true, gt_iff_lt,
-          function.embedding.coe_fn_mk, order_embedding.lt_iff_lt],
-        refl } end, λ h con, _⟩,
-  rcases con with ⟨f, hf⟩,
-  have hfs' : ∀ n : ℕ, f n ∈ s := λ n, (hf.2 n.lt_succ_self).2.2,
-  refine h ⟨f, λ a b, _⟩ (λ n hn, _),
-  { split; intro hle,
-    { cases lt_or_eq_of_le hle with hlt heq,
-      { exact le_of_lt (hf.1 ⟨hlt, hfs' _, hfs' _⟩) },
-      { rw [f.injective heq] } },
-    { cases lt_or_eq_of_le hle with hlt heq,
-      { exact le_of_lt (hf.2 hlt).1, },
-      { rw [heq] } } },
-  { rcases set.mem_range.1 hn with ⟨m, hm⟩,
-    rw ← hm,
-    apply hfs' }
+  rw [is_wf, well_founded_on_iff_no_descending_seq],
+  exact ⟨λ h f, h f.lt_embedding, λ h f, h (order_embedding.of_strict_mono
+    f (λ _ _, f.map_rel_iff.2))⟩,
 end
 
 theorem is_wf.union (hs : is_wf s) (ht : is_wf t) : is_wf (s ∪ t) :=
@@ -143,9 +151,180 @@ end partial_order
 
 end set
 
+namespace set
+
+/-- A subset is partially well-ordered by a relation `r` when any infinite sequence contains
+  two elements where the first is related to the second by `r`. -/
+def partially_well_ordered_on (s) (r : α → α → Prop) : Prop :=
+  ∀ (f : ℕ → α), range f ⊆ s → ∃ (m n : ℕ), m < n ∧ r (f m) (f n)
+
+/-- A subset of a preorder is partially well-ordered when any infinite sequence contains
+  a monotone subsequence of length 2 (or equivalently, an infinite monotone subsequence). -/
+def is_pwo [preorder α] (s) : Prop :=
+partially_well_ordered_on s ((≤) : α → α → Prop)
+
+theorem partially_well_ordered_on.image_of_monotone {s : set α}
+  {r : α → α → Prop} {β : Type*} {r' : β → β → Prop}
+  (hs : s.partially_well_ordered_on r) {f : α → β} (hf : ∀ a1 a2 : α, r a1 a2 → r' (f a1) (f a2)) :
+  (f '' s).partially_well_ordered_on r' :=
+λ g hg, begin
+  have h := λ (n : ℕ), ((mem_image _ _ _).1 (hg (mem_range_self n))),
+  obtain ⟨m, n, hlt, hmn⟩ := hs (λ n, classical.some (h n)) _,
+  { refine ⟨m, n, hlt, _⟩,
+    rw [← (classical.some_spec (h m)).2,
+      ← (classical.some_spec (h n)).2],
+    apply hf _ _ hmn },
+  { rintros _ ⟨n, rfl⟩,
+    exact (classical.some_spec (h n)).1 }
+end
+
+section partial_order
+variables {s : set α} {t : set α} {r : α → α → Prop}
+
+theorem partially_well_ordered_on.exists_monotone_subseq [is_refl α r] [is_trans α r]
+  (h : s.partially_well_ordered_on r) (f : ℕ → α) (hf : range f ⊆ s) :
+  ∃ (g : ℕ ↪o ℕ), ∀ m n : ℕ, m ≤ n → r (f (g m)) (f (g n)) :=
+begin
+  obtain ⟨g, h1 | h2⟩ := exists_increasing_or_nonincreasing_subseq r f,
+  { refine ⟨g, λ m n hle, _⟩,
+    obtain hlt | heq := lt_or_eq_of_le hle,
+    { exact h1 m n hlt, },
+    { rw [heq],
+      apply refl_of r } },
+  { exfalso,
+    obtain ⟨m, n, hlt, hle⟩ := h (f ∘ g) (subset.trans (range_comp_subset_range _ _) hf),
+    exact h2 m n hlt hle }
+end
+
+theorem partially_well_ordered_on_iff_exists_monotone_subseq [is_refl α r] [is_trans α r] :
+  s.partially_well_ordered_on r ↔
+    ∀ f : ℕ → α, range f ⊆ s → ∃ (g : ℕ ↪o ℕ), ∀ m n : ℕ, m ≤ n → r (f (g m)) (f (g n)) :=
+begin
+  classical,
+  split; intros h f hf,
+  { exact h.exists_monotone_subseq f hf },
+  { obtain ⟨g, gmon⟩ := h f hf,
+    refine ⟨g 0, g 1, g.lt_iff_lt.2 zero_lt_one, gmon _ _ zero_le_one⟩, }
+end
+
+lemma partially_well_ordered_on.well_founded_on [is_partial_order α r]
+  (h : s.partially_well_ordered_on r) :
+  s.well_founded_on (λ a b, r a b ∧ a ≠ b) :=
+begin
+  haveI : is_strict_order α (λ a b, r a b ∧ a ≠ b) :=
+  { to_is_irrefl := ⟨λ a con, con.2 rfl⟩,
+    to_is_trans := ⟨λ a b c ab bc, ⟨trans ab.1 bc.1,
+      λ ac, ab.2 (antisymm ab.1 (ac.symm ▸ bc.1))⟩⟩ },
+  rw well_founded_on_iff_no_descending_seq,
+  intros f con,
+  obtain ⟨m, n, hlt, hle⟩ := h f con,
+  exact (f.map_rel_iff.2 hlt).2 (antisymm hle (f.map_rel_iff.2 hlt).1).symm,
+end
+
+variables [partial_order α]
+
+lemma is_pwo.is_wf (h : s.is_pwo) :
+  s.is_wf :=
+begin
+  rw [is_wf],
+  convert h.well_founded_on,
+  ext x y,
+  rw lt_iff_le_and_ne,
+end
+
+theorem is_pwo.exists_monotone_subseq
+  (h : s.is_pwo) (f : ℕ → α) (hf : range f ⊆ s) :
+  ∃ (g : ℕ ↪o ℕ), monotone (f ∘ g) :=
+h.exists_monotone_subseq f hf
+
+theorem is_pwo_iff_exists_monotone_subseq :
+  s.is_pwo ↔
+    ∀ f : ℕ → α, range f ⊆ s → ∃ (g : ℕ ↪o ℕ), monotone (f ∘ g) :=
+partially_well_ordered_on_iff_exists_monotone_subseq
+
+lemma is_pwo.prod (hs : s.is_pwo)
+  (ht : t.is_pwo) :
+  (s.prod t).is_pwo :=
+begin
+  classical,
+  rw is_pwo_iff_exists_monotone_subseq at *,
+  intros f hf,
+  obtain ⟨g1, h1⟩ := hs (prod.fst ∘ f) _,
+  swap,
+  { rw [range_comp, image_subset_iff],
+    refine subset.trans hf _,
+    rintros ⟨x1, x2⟩ hx,
+    simp only [mem_preimage, hx.1] },
+  obtain ⟨g2, h2⟩ := ht (prod.snd ∘ f ∘ g1) _,
+  refine ⟨g2.trans g1, λ m n mn, _⟩,
+  swap,
+  { rw [range_comp, image_subset_iff],
+    refine subset.trans (range_comp_subset_range _ _) (subset.trans hf _),
+    rintros ⟨x1, x2⟩ hx,
+    simp only [mem_preimage, hx.2] },
+  simp only [rel_embedding.coe_trans, function.comp_app],
+  exact ⟨h1 (g2.le_iff_le.2 mn), h2 mn⟩,
+end
+
+theorem is_pwo.image_of_monotone {β : Type*} [partial_order β]
+  (hs : s.is_pwo) {f : α → β} (hf : monotone f) :
+  is_pwo (f '' s) :=
+hs.image_of_monotone hf
+
+end partial_order
+
+theorem is_wf.is_pwo [linear_order α] {s : set α}
+  (hs : s.is_wf) : s.is_pwo :=
+λ f hf, begin
+  rw [is_wf, well_founded_on_iff] at hs,
+  have hrange : (range f).nonempty := ⟨f 0, mem_range_self 0⟩,
+  let a := hs.min (range f) hrange,
+  obtain ⟨m, hm⟩ := hs.min_mem (range f) hrange,
+  refine ⟨m, m.succ, m.lt_succ_self, le_of_not_lt (λ con, _)⟩,
+  rw hm at con,
+  apply hs.not_lt_min (range f) hrange (mem_range_self m.succ)
+    ⟨con, hf (mem_range_self m.succ), hf _⟩,
+  rw ← hm,
+  apply mem_range_self,
+end
+
+end set
+
+@[simp]
+theorem finset.partially_well_ordered_on {r : α → α → Prop} [is_refl α r] {f : finset α} :
+  set.partially_well_ordered_on (↑f : set α) r :=
+begin
+  intros g hg,
+  by_cases hinj : function.injective g,
+  { exact (set.infinite_of_injective_forall_mem hinj (set.range_subset_iff.1 hg)
+      f.finite_to_set).elim },
+  { rw [function.injective] at hinj,
+    push_neg at hinj,
+    obtain ⟨m, n, gmgn, hne⟩ := hinj,
+    cases lt_or_gt_of_ne hne with hlt hlt;
+    { refine ⟨_, _, hlt, _⟩,
+      rw gmgn,
+      exact refl_of r _, } }
+end
+
+@[simp]
+theorem finset.is_pwo [partial_order α] {f : finset α} :
+  set.is_pwo (↑f : set α) :=
+finset.partially_well_ordered_on
+
+@[simp]
+theorem finset.well_founded_on {r : α → α → Prop} [is_strict_order α r] {f : finset α} :
+  set.well_founded_on (↑f : set α) r :=
+begin
+  rw [set.well_founded_on_iff_no_descending_seq],
+  intros g con,
+  apply set.infinite_of_injective_forall_mem g.injective (set.range_subset_iff.1 con),
+  exact f.finite_to_set,
+end
+
 @[simp]
 theorem finset.is_wf [partial_order α] {f : finset α} : set.is_wf (↑f : set α) :=
-fintype.preorder.well_founded
+finset.is_pwo.is_wf
 
 namespace set
 variables [partial_order α] {s : set α} {a : α}
@@ -218,119 +397,20 @@ end set
 
 namespace set
 
-/-- A subset of a preorder is partially well-ordered when any infinite sequence contains
-  a monotone subsequence of length 2 (or equivalently, an infinite monotone subsequence). -/
-def is_partially_well_ordered [preorder α] (s) : Prop :=
-  ∀ (f : ℕ → α), range f ⊆ s → ∃ (m n : ℕ), m < n ∧ f m ≤ f n
-
-section partial_order
-variables [partial_order α] {s : set α} {t : set α}
-
-lemma is_partially_well_ordered.is_wf (h : s.is_partially_well_ordered) :
-  s.is_wf :=
-begin
-  rw is_wf_iff_no_descending_seq,
-  intros f con,
-  obtain ⟨m, n, hlt, hle⟩ := h f con,
-  exact not_lt_of_le hle (f.lt_iff_lt.2 hlt),
-end
-
-theorem is_partially_well_ordered.exists_monotone_subseq
-  (h : s.is_partially_well_ordered) (f : ℕ → α) (hf : range f ⊆ s) :
-  ∃ (g : ℕ ↪o ℕ), monotone (f ∘ g) :=
-begin
-  obtain ⟨g, h1 | h2⟩ := exists_increasing_or_nonincreasing_subseq (≤) f,
-  { refine ⟨g, λ m n hle, _⟩,
-    obtain hlt | heq := lt_or_eq_of_le hle,
-    { exact h1 m n hlt, },
-    { rw [heq] } },
-  { exfalso,
-    obtain ⟨m, n, hlt, hle⟩ := h (f ∘ g) (subset.trans (range_comp_subset_range _ _) hf),
-    exact h2 m n hlt hle }
-end
-
-theorem is_partially_well_ordered_iff_exists_monotone_subseq :
-  s.is_partially_well_ordered ↔
-    ∀ f : ℕ → α, range f ⊆ s → ∃ (g : ℕ ↪o ℕ), monotone (f ∘ g) :=
-begin
-  classical,
-  split; intros h f hf,
-  { exact h.exists_monotone_subseq f hf },
-  { obtain ⟨g, gmon⟩ := h f hf,
-    refine ⟨g 0, g 1, g.lt_iff_lt.2 zero_lt_one, gmon zero_le_one⟩, }
-end
-
-lemma is_partially_well_ordered.prod (hs : s.is_partially_well_ordered)
-  (ht : t.is_partially_well_ordered) :
-  (s.prod t).is_partially_well_ordered :=
-begin
-  classical,
-  rw is_partially_well_ordered_iff_exists_monotone_subseq at *,
-  intros f hf,
-  obtain ⟨g1, h1⟩ := hs (prod.fst ∘ f) _,
-  swap,
-  { rw [range_comp, image_subset_iff],
-    refine subset.trans hf _,
-    rintros ⟨x1, x2⟩ hx,
-    simp only [mem_preimage, hx.1] },
-  obtain ⟨g2, h2⟩ := ht (prod.snd ∘ f ∘ g1) _,
-  refine ⟨g2.trans g1, λ m n mn, _⟩,
-  swap,
-  { rw [range_comp, image_subset_iff],
-    refine subset.trans (range_comp_subset_range _ _) (subset.trans hf _),
-    rintros ⟨x1, x2⟩ hx,
-    simp only [mem_preimage, hx.2] },
-  simp only [rel_embedding.coe_trans, function.comp_app],
-  exact ⟨h1 (g2.le_iff_le.2 mn), h2 mn⟩,
-end
-
-theorem is_partially_well_ordered.image_of_monotone {β : Type*} [partial_order β]
-  (hs : s.is_partially_well_ordered) {f : α → β} (hf : monotone f) :
-  is_partially_well_ordered (f '' s) :=
-λ g hg, begin
-  have h := λ (n : ℕ), ((mem_image _ _ _).1 (hg (mem_range_self n))),
-  obtain ⟨m, n, hlt, hmn⟩ := hs (λ n, classical.some (h n)) _,
-  { refine ⟨m, n, hlt, _⟩,
-    rw [← (classical.some_spec (h m)).2,
-      ← (classical.some_spec (h n)).2],
-    apply hf hmn },
-  { rintros _ ⟨n, rfl⟩,
-    exact (classical.some_spec (h n)).1 }
-end
-
-end partial_order
-
-theorem is_wf.is_partially_well_ordered [linear_order α] {s : set α}
-  (hs : s.is_wf) : s.is_partially_well_ordered :=
-λ f hf, begin
-  rw [is_wf, well_founded_on_iff] at hs,
-  have hrange : (range f).nonempty := ⟨f 0, mem_range_self 0⟩,
-  let a := hs.min (range f) hrange,
-  obtain ⟨m, hm⟩ := hs.min_mem (range f) hrange,
-  refine ⟨m, m.succ, m.lt_succ_self, le_of_not_lt (λ con, _)⟩,
-  rw hm at con,
-  apply hs.not_lt_min (range f) hrange (mem_range_self m.succ)
-    ⟨con, hf (mem_range_self m.succ), hf _⟩,
-  rw ← hm,
-  apply mem_range_self,
-end
-
-section
-
 variables [linear_ordered_cancel_comm_monoid α] {s : set α} {t : set α}
 
 @[to_additive]
-theorem is_partially_well_ordered.mul
-  (hs : s.is_partially_well_ordered) (ht : t.is_partially_well_ordered) :
-  is_partially_well_ordered (s * t) :=
+theorem is_pwo.mul
+  (hs : s.is_pwo) (ht : t.is_pwo) :
+  is_pwo (s * t) :=
 begin
   rw ← image_mul_prod,
-  exact (is_partially_well_ordered.prod hs ht).image_of_monotone (λ _ _ h, mul_le_mul' h.1 h.2),
+  exact (is_pwo.prod hs ht).image_of_monotone (λ _ _ h, mul_le_mul' h.1 h.2),
 end
 
 @[to_additive]
 theorem is_wf.mul (hs : s.is_wf) (ht : t.is_wf) : is_wf (s * t) :=
-(hs.is_partially_well_ordered.mul ht.is_partially_well_ordered).is_wf
+(hs.is_pwo.mul ht.is_pwo).is_wf
 
 @[to_additive]
 theorem is_wf.min_mul (hs : s.is_wf) (ht : t.is_wf) (hsn : s.nonempty) (htn : t.nonempty) :
@@ -342,28 +422,7 @@ begin
   exact mul_le_mul' (hs.min_le _ hx) (ht.min_le _ hy),
 end
 
-end
-
 end set
-
-theorem not_well_founded_swap_of_infinite_of_well_order
-  [infinite α] {r : α → α → Prop} [is_well_order α r] :
-  ¬ well_founded (function.swap r) :=
-begin
-  haveI : is_strict_order α (function.swap r) := is_strict_order.swap _,
-  rw [rel_embedding.well_founded_iff_no_descending_seq, not_not],
-  obtain ⟨g, h1 | h2⟩ := exists_increasing_or_nonincreasing_subseq' r (infinite.nat_embedding α),
-  { exact ⟨rel_embedding.nat_gt ((infinite.nat_embedding α) ∘ g) h1⟩ },
-  { exfalso,
-    have h : well_founded r := is_well_order.wf,
-    rw [rel_embedding.well_founded_iff_no_descending_seq] at h,
-    refine h ⟨rel_embedding.nat_gt ((infinite.nat_embedding α) ∘ g) (λ n, _)⟩,
-    obtain c1 | c2 | c3 := (is_trichotomous.trichotomous _ _ : r _ _ ∨ _),
-    { exact c1 },
-    { exfalso,
-      exact ne_of_gt n.lt_succ_self (g.injective ((infinite.nat_embedding α).injective c2)) },
-    { exact (h2 n (n + 1) n.lt_succ_self c3).elim } }
-end
 
 namespace set
 
@@ -380,6 +439,7 @@ namespace mul_antidiagonal
 lemma mem_mul_antidiagonal [monoid α] {s t : set α} {a : α} {x : α × α} :
   x ∈ mul_antidiagonal s t a ↔ x.1 * x.2 = a ∧ x.1 ∈ s ∧ x.2 ∈ t := iff.refl _
 
+section cancel_comm_monoid
 variables [cancel_comm_monoid α] {s t : set α} {a : α}
 
 @[to_additive]
@@ -405,56 +465,61 @@ lemma eq_of_snd_eq_snd {x y : (mul_antidiagonal s t a)}
   (h : (x : α × α).snd = (y : α × α).snd) : x = y :=
 subtype.ext (prod.ext (mul_antidiagonal.fst_eq_fst_iff_snd_eq_snd.2 h) h)
 
-end mul_antidiagonal
-end set
+end cancel_comm_monoid
 
-namespace set
-namespace mul_antidiagonal
+section ordered_cancel_comm_monoid
+variables [ordered_cancel_comm_monoid α] (s t : set α) (a : α)
 
-variables [linear_ordered_cancel_comm_monoid α] (s t : set α) (a : α)
-
-/-- The relation on `set.mul_antidagonal s t a` given by `<` on the first coordinate. -/
-@[to_additive "The relation on `set.add_antidagonal s t a` given by `<` on the first coordinate."]
-def lt_left (x y : mul_antidiagonal s t a) : Prop := (x : α × α).1 < (y : α × α).1
-
-/-- `set.mul_antidiagonal s t a` ordered by `lt_left` embeds into `s` -/
-@[to_additive "`set.add_antidiagonal s t a` ordered by `lt_left` embeds into `s`"]
-def fst_rel_embedding : (lt_left s t a) ↪r ((<) : s → s → Prop) :=
-⟨⟨λ x, ⟨(↑x : α × α).1, x.2.2.1⟩, λ x y hxy,
-    mul_antidiagonal.eq_of_fst_eq_fst (subtype.mk_eq_mk.1 hxy)⟩, λ x y, iff.refl _⟩
-
-/-- `set.mul_antidiagonal s t a` ordered by `lt_left` embeds into the dual of `t` -/
-@[to_additive "`set.add_antidiagonal s t a` ordered by `lt_left` embeds into the dual of `t`"]
-def snd_rel_embedding : (lt_left s t a) ↪r ((>) : t → t → Prop) :=
-⟨⟨λ x, ⟨(↑x : α × α).2, x.2.2.2⟩, λ x y hxy, eq_of_snd_eq_snd (subtype.mk_eq_mk.1 hxy)⟩,
-  begin
-    rintro ⟨⟨x1, x2⟩, rfl, _⟩,
-    rintro ⟨⟨y1, y2⟩, h, _⟩,
-    change x2 > y2 ↔ x1 < y1,
-    change y1 * y2 = x1 * x2 at h,
-    rw [← mul_lt_mul_iff_right x2, ← h, mul_lt_mul_iff_left],
-  end⟩
+@[to_additive]
+lemma eq_of_fst_le_fst_of_snd_le_snd {x y : (mul_antidiagonal s t a)}
+  (h1 : (x : α × α).fst ≤ (y : α × α).fst) (h2 : (x : α × α).snd ≤ (y : α × α).snd ) :
+  x = y :=
+begin
+  apply eq_of_fst_eq_fst,
+  cases eq_or_lt_of_le h1 with heq hlt,
+  { exact heq },
+  exfalso,
+  exact ne_of_lt (mul_lt_mul_of_lt_of_le hlt h2)
+    ((mem_mul_antidiagonal.1 x.2).1.trans (mem_mul_antidiagonal.1 y.2).1.symm)
+end
 
 variables {s} {t}
 
 @[to_additive]
-theorem finite_of_is_wf (hs : s.is_wf) (ht : t.is_wf) (a) :
+theorem finite_of_is_pwo (hs : s.is_pwo) (ht : t.is_pwo) (a) :
   (mul_antidiagonal s t a).finite :=
 begin
   by_contra h,
-  rw [← set.infinite, ← infinite_coe_iff] at h,
-  haveI := h,
-  haveI : is_well_order s (<) := {
-    wf := hs,
-    .. (infer_instance : is_strict_total_order _ _),
-  },
-  haveI : is_well_order (mul_antidiagonal s t a) (lt_left s t a) :=
-    (fst_rel_embedding s t a).is_well_order,
-  have hwf : well_founded
-    (function.swap (lt_left s t a)) :=
-    (snd_rel_embedding s t a).swap.well_founded ht,
-  exact not_well_founded_swap_of_infinite_of_well_order (hwf),
+  rw [← set.infinite] at h,
+  have h1 : (mul_antidiagonal s t a).partially_well_ordered_on (prod.fst ⁻¹'o (≤)),
+  { intros f hf,
+    refine hs (prod.fst ∘ f) _,
+    rw range_comp,
+    rintros _ ⟨⟨x, y⟩, hxy, rfl⟩,
+    exact (mem_mul_antidiagonal.1 (hf hxy)).2.1 },
+  have h2 : (mul_antidiagonal s t a).partially_well_ordered_on (prod.snd ⁻¹'o (≤)),
+  { intros f hf,
+    refine ht (prod.snd ∘ f) _,
+    rw range_comp,
+    rintros _ ⟨⟨x, y⟩, hxy, rfl⟩,
+    exact (mem_mul_antidiagonal.1 (hf hxy)).2.2 },
+  obtain ⟨g, hg⟩ := h1.exists_monotone_subseq (λ x, h.nat_embedding _ x) _,
+  swap, { rintro _ ⟨k, rfl⟩,
+    exact ((infinite.nat_embedding (s.mul_antidiagonal t a) h) _).2 },
+  obtain ⟨m, n, mn, h2'⟩ := h2 (λ x, (h.nat_embedding _) (g x)) _,
+  swap, { rintro _ ⟨k, rfl⟩,
+    exact ((infinite.nat_embedding (s.mul_antidiagonal t a) h) _).2, },
+  apply ne_of_lt mn (g.injective ((h.nat_embedding _).injective _)),
+  exact eq_of_fst_le_fst_of_snd_le_snd _ _ _ (hg _ _ (le_of_lt mn)) h2',
 end
+
+end ordered_cancel_comm_monoid
+
+@[to_additive]
+theorem finite_of_is_wf [linear_ordered_cancel_comm_monoid α] {s t : set α}
+  (hs : s.is_wf) (ht : t.is_wf) (a) :
+  (mul_antidiagonal s t a).finite :=
+finite_of_is_pwo hs.is_pwo ht.is_pwo a
 
 end mul_antidiagonal
 end set


### PR DESCRIPTION
Introduces `set.partially_well_ordered_on` to generalize `set.is_partially_well_ordered` to relations that do not necessarily come from a `has_le` instance
Renames `set.is_partially_well_ordered` to `set.is_pwo` in analogy with `set.is_wf`
Prepares to refactor Hahn series to use `set.is_pwo` and avoid the assumption of a linear order

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
