### PR TITLE
[Merged by Bors] - chore(data/matrix/basic): lemmas for `minor` about `diagonal`, `one`, and `mul`

### DIFF
--- a/src/algebra/lie/matrix.lean
+++ b/src/algebra/lie/matrix.lean
@@ -70,8 +70,8 @@ types, `matrix.reindex`, is an equivalence of Lie algebras. -/
 def matrix.reindex_lie_equiv {m : Type w₁} [decidable_eq m] [fintype m]
   (e : n ≃ m) : matrix n n R ≃ₗ⁅R⁆ matrix m m R :=
 { to_fun := matrix.reindex e e,
-  map_lie' := λ M N, by { simp only [lie_ring.of_associative_ring_bracket, matrix.reindex_mul,
-    matrix.mul_eq_mul], refl },
+  map_lie' := λ M N, by simp only [lie_ring.of_associative_ring_bracket, matrix.reindex_apply,
+    ←matrix.minor_mul_equiv _ _ _ _, matrix.mul_eq_mul, matrix.minor_sub, pi.sub_apply],
   ..(matrix.reindex_linear_equiv e e) }
 
 @[simp] lemma matrix.reindex_lie_equiv_apply {m : Type w₁} [decidable_eq m] [fintype m]

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -878,11 +878,7 @@ lemma minor_mul [semiring α] {p q : Type*} [fintype p] [fintype q]
   (M : matrix m n α) (N : matrix n p α)
   (e₁ : l → m) (e₂ : o → n) (e₃ : q → p) (he₂ : function.bijective e₂) :
   (M ⬝ N).minor e₁ e₃ = (M.minor e₁ e₂) ⬝ (N.minor e₂ e₃) :=
-begin
-  ext i j,
-  dsimp only [matrix.mul, matrix.dot_product, matrix.minor_apply],
-  rw ←he₂.sum_comp,
-end
+ext $ λ _ _, (he₂.sum_comp _).symm
 
 /-! `simp` lemmas for `matrix.minor`s interaction with `matrix.diagonal`, `1`, and `matrix.mul` for
 when the mappings are bundled. -/

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -849,11 +849,70 @@ lemma minor_neg [has_neg α] (A : matrix m n α) :
 lemma minor_sub [has_sub α] (A B : matrix m n α) :
   ((A - B).minor : (l → m) → (o → n) → matrix l o α) = A.minor - B.minor := rfl
 
+@[simp]
 lemma minor_zero [has_zero α] :
   ((0 : matrix m n α).minor : (l → m) → (o → n) → matrix l o α) = 0 := rfl
 
-lemma minor_smul [semiring α] (r : α) (A : matrix m n α) :
+lemma minor_smul {R : Type*} [semiring R] [add_comm_monoid α] [semimodule R α] (r : R)
+  (A : matrix m n α) :
   ((r • A : matrix m n α).minor : (l → m) → (o → n) → matrix l o α) = r • A.minor := rfl
+
+/-- If the minor doesn't repeat elements, then when applied to a diagonal matrix the result is
+diagonal. -/
+lemma minor_diagonal [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α) (e : l → m)
+  (he : function.injective e) :
+  (diagonal d).minor e e = diagonal (d ∘ e) :=
+ext $ λ i j, begin
+  rw minor_apply,
+  by_cases h : i = j,
+  { rw [h, diagonal_apply_eq, diagonal_apply_eq], },
+  { rw [diagonal_apply_ne h, diagonal_apply_ne (he.ne h)], },
+end
+
+lemma minor_one [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l → m)
+  (he : function.injective e) :
+  (1 : matrix m m α).minor e e = 1 :=
+minor_diagonal _ e he
+
+lemma minor_mul [semiring α] {p q : Type*} [fintype p] [fintype q]
+  (M : matrix m n α) (N : matrix n p α)
+  (e₁ : l → m) (e₂ : o → n) (e₃ : q → p) (he₂ : function.bijective e₂) :
+  (M ⬝ N).minor e₁ e₃ = (M.minor e₁ e₂) ⬝ (N.minor e₂ e₃) :=
+begin
+  ext i j,
+  dsimp only [matrix.mul, matrix.dot_product, matrix.minor_apply],
+  rw ←he₂.sum_comp,
+end
+
+/-! `simp` lemmas for `matrix.minor`s interaction with `matrix.diagonal`, `1`, and `matrix.mul` for
+when the mappings are bundled. -/
+
+@[simp]
+lemma minor_diagonal_embedding [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α)
+  (e : l ↪ m) :
+  (diagonal d).minor e e = diagonal (d ∘ e) :=
+minor_diagonal d e e.injective
+
+@[simp]
+lemma minor_diagonal_equiv [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α)
+  (e : l ≃ m) :
+  (diagonal d).minor e e = diagonal (d ∘ e) :=
+minor_diagonal d e e.injective
+
+@[simp]
+lemma minor_one_embedding [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l ↪ m) :
+  (1 : matrix m m α).minor e e = 1 :=
+minor_one e e.injective
+
+@[simp]
+lemma minor_one_equiv [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l ≃ m) :
+  (1 : matrix m m α).minor e e = 1 :=
+minor_one e e.injective
+
+lemma minor_mul_equiv [semiring α] {p q : Type*} [fintype p] [fintype q]
+  (M : matrix m n α) (N : matrix n p α) (e₁ : l → m) (e₂ : o ≃ n) (e₃ : q → p)  :
+  (M ⬝ N).minor e₁ e₃ = (M.minor e₁ e₂) ⬝ (N.minor e₂ e₃) :=
+minor_mul M N e₁ e₂ e₃ e₂.bijective
 
 /-- The natural map that reindexes a matrix's rows and columns with equivalent types is an
 equivalence. -/

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -907,22 +907,12 @@ rfl
   reindex_linear_equiv (equiv.refl m) (equiv.refl n) = linear_equiv.refl R _ :=
 linear_equiv.ext $ λ _, rfl
 
-lemma reindex_mul [semiring R]
-  (eₘ : m ≃ m') (eₙ : n ≃ n') (eₗ : l ≃ l') (M : matrix m n R) (N : matrix n l R) :
-  (reindex eₘ eₙ M) ⬝ (reindex eₙ eₗ N) = reindex eₘ eₗ (M ⬝ N) :=
-begin
-  ext i j,
-  dsimp only [matrix.mul, matrix.dot_product],
-  rw [←finset.univ_map_equiv_to_embedding eₙ, finset.sum_map finset.univ eₙ.to_embedding],
-  simp,
-end
-
 /-- For square matrices, the natural map that reindexes a matrix's rows and columns with equivalent
 types, `matrix.reindex`, is an equivalence of algebras. -/
 def reindex_alg_equiv [comm_semiring R] [decidable_eq m] [decidable_eq n]
   (e : m ≃ n) : matrix m m R ≃ₐ[R] matrix n n R :=
 { to_fun    := reindex e e,
-  map_mul'  := λ M N, (reindex_mul e e e M N).symm,
+  map_mul'  := λ M N, minor_mul_equiv M N e e e,
   commutes' := λ r,
                  by { ext, simp [algebra_map, algebra.to_ring_hom], by_cases h : i = j; simp [h], },
 ..(reindex_linear_equiv e e) }

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -912,10 +912,9 @@ types, `matrix.reindex`, is an equivalence of algebras. -/
 def reindex_alg_equiv [comm_semiring R] [decidable_eq m] [decidable_eq n]
   (e : m ≃ n) : matrix m m R ≃ₐ[R] matrix n n R :=
 { to_fun    := reindex e e,
-  map_mul'  := λ M N, minor_mul_equiv M N e e e,
-  commutes' := λ r,
-                 by { ext, simp [algebra_map, algebra.to_ring_hom], by_cases h : i = j; simp [h], },
-..(reindex_linear_equiv e e) }
+  map_mul'  := λ M N, minor_mul_equiv M N e.symm e.symm e.symm,
+  commutes' := λ r, by simp [algebra_map, algebra.to_ring_hom, minor_smul],
+  ..(reindex_linear_equiv e e) }
 
 @[simp] lemma reindex_alg_equiv_apply [comm_semiring R] [decidable_eq m] [decidable_eq n]
   (e : m ≃ n) (M : matrix m m R) :


### PR DESCRIPTION
The `minor_mul` lemma here has weaker hypotheses than the previous `reindex_mul`, as it only requires one mapping to be bijective.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


I expect one failure in a downstream file due to the removed `reindex_mul` lemma, but it should be easy to resolve once the cache is built.