### PR TITLE
[Merged by Bors] - chore(data/fintype): rework `fintype.equiv_fin` and dependencies

### DIFF
--- a/src/category_theory/Fintype.lean
+++ b/src/category_theory/Fintype.lean
@@ -82,7 +82,7 @@ instance : full incl := { preimage := λ _ _ f, f }
 instance : faithful incl := {}
 instance : ess_surj incl :=
 { mem_ess_image := λ X,
-  let F := trunc.out (fintype.equiv_fin X) in
+  let F := fintype.equiv_fin X in
   ⟨fintype.card X, ⟨⟨F.symm, F, F.self_comp_symm, F.symm_comp_self⟩⟩⟩ }
 
 noncomputable instance : is_equivalence incl :=

--- a/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
+++ b/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
@@ -383,8 +383,7 @@ def preserves_finite_coproducts_of_preserves_binary_and_initial
   preserves_colimits_of_shape.{v} (discrete J) F :=
 begin
   classical,
-  refine trunc.rec_on_subsingleton (fintype.equiv_fin J) _,
-  intro e,
+  let e := fintype.equiv_fin J,
   haveI := preserves_ulift_fin_of_preserves_binary_and_initial F (fintype.card J),
   apply preserves_colimits_of_shape_of_equiv (discrete.equivalence (e.trans equiv.ulift.symm)).symm,
 end

--- a/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
+++ b/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
@@ -136,7 +136,7 @@ end }
 lemma has_finite_products_of_has_binary_and_terminal : has_finite_products C :=
 ⟨λ J 𝒥₁ 𝒥₂, begin
   resetI,
-  obtain ⟨e⟩ := fintype.trunc_equiv_fin J,
+  let e := fintype.equiv_fin J,
   apply has_limits_of_shape_of_equivalence (discrete.equivalence (e.trans equiv.ulift.symm)).symm,
   refine has_limits_of_shape_ulift_fin (fintype.card J),
 end⟩

--- a/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
+++ b/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
@@ -136,7 +136,7 @@ end }
 lemma has_finite_products_of_has_binary_and_terminal : has_finite_products C :=
 ⟨λ J 𝒥₁ 𝒥₂, begin
   resetI,
-  let e := fintype.equiv_fin J,
+  obtain ⟨e⟩ := fintype.trunc_equiv_fin J,
   apply has_limits_of_shape_of_equivalence (discrete.equivalence (e.trans equiv.ulift.symm)).symm,
   refine has_limits_of_shape_ulift_fin (fintype.card J),
 end⟩

--- a/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
+++ b/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
@@ -136,7 +136,7 @@ end }
 lemma has_finite_products_of_has_binary_and_terminal : has_finite_products C :=
 ⟨λ J 𝒥₁ 𝒥₂, begin
   resetI,
-  rcases fintype.equiv_fin J with ⟨e⟩,
+  let e := fintype.equiv_fin J,
   apply has_limits_of_shape_of_equivalence (discrete.equivalence (e.trans equiv.ulift.symm)).symm,
   refine has_limits_of_shape_ulift_fin (fintype.card J),
 end⟩
@@ -205,8 +205,7 @@ def preserves_finite_products_of_preserves_binary_and_terminal
   preserves_limits_of_shape.{v} (discrete J) F :=
 begin
   classical,
-  refine trunc.rec_on_subsingleton (fintype.equiv_fin J) _,
-  intro e,
+  let e := fintype.equiv_fin J,
   haveI := preserves_ulift_fin_of_preserves_binary_and_terminal F (fintype.card J),
   apply preserves_limits_of_shape_of_equiv (discrete.equivalence (e.trans equiv.ulift.symm)).symm,
 end

--- a/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
+++ b/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
@@ -315,7 +315,7 @@ end }
 lemma has_finite_coproducts_of_has_binary_and_terminal : has_finite_coproducts C :=
 ⟨λ J 𝒥₁ 𝒥₂, begin
   resetI,
-  rcases fintype.equiv_fin J with ⟨e⟩,
+  let e := fintype.equiv_fin J,
   apply has_colimits_of_shape_of_equivalence (discrete.equivalence (e.trans equiv.ulift.symm)).symm,
   refine has_colimits_of_shape_ulift_fin (fintype.card J),
 end⟩

--- a/src/computability/turing_machine.lean
+++ b/src/computability/turing_machine.lean
@@ -1366,7 +1366,9 @@ theorem exists_enc_dec [fintype Γ] :
   ∃ n (enc : Γ → vector bool n) (dec : vector bool n → Γ),
     enc (default _) = vector.repeat ff n ∧ ∀ a, dec (enc a) = a :=
 begin
-  rcases fintype.exists_equiv_fin Γ with ⟨n, ⟨F⟩⟩,
+  letI := classical.dec_eq Γ,
+  let n := fintype.card Γ,
+  obtain ⟨F⟩ := fintype.trunc_equiv_fin Γ,
   let G : fin n ↪ fin n → bool := ⟨λ a b, a = b,
     λ a b h, of_to_bool_true $ (congr_fun h b).trans $ to_bool_tt rfl⟩,
   let H := (F.to_embedding.trans G).trans

--- a/src/data/equiv/list.lean
+++ b/src/data/equiv/list.lean
@@ -113,7 +113,7 @@ by haveI := decidable_eq_of_encodable α; exact
 
 def fintype_arrow (α : Type*) (β : Type*) [decidable_eq α] [fintype α] [encodable β] :
   trunc (encodable (α → β)) :=
-(fintype.equiv_fin α).map $
+(fintype.trunc_equiv_fin α).map $
   λf, encodable.of_equiv (fin (fintype.card α) → β) $
   equiv.arrow_congr f (equiv.refl _)
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -241,10 +241,11 @@ def equiv_fin_of_forall_mem_list {α} [decidable_eq α]
  λ ⟨i, h⟩, fin.eq_of_veq $ list.nodup_iff_nth_le_inj.1 nd _ _
    (list.index_of_lt_length.2 (list.nth_le_mem _ _ _)) h $ by simp⟩
 
-/-- There is (computably) a bijection between `α` and `fin n` where
-  `n = card α`. Since it is not unique, and depends on which permutation
-  of the universe list is used, the bijection is wrapped in `trunc` to
-  preserve computability.
+/-- There is (computably) a bijection between `α` and `fin (card α)`.
+
+Since it is not unique, and depends on which permutation
+of the universe list is used, the bijection is wrapped in `trunc` to
+preserve computability.
 
 See `fintype.equiv_fin` for the noncomputable version,
 and `fintype.trunc_equiv_fin_of_card_eq` and `fintype.equiv_fin_of_card_eq`
@@ -256,7 +257,7 @@ quot.rec_on_subsingleton (@univ α _).1
   (λ l (h : ∀ x:α, x ∈ l) (nd : l.nodup), trunc.mk (equiv_fin_of_forall_mem_list h nd))
   mem_univ_val univ.2
 
-/-- There is a (noncomputable) bijection between `α` and `fin n` where `n = card α`.
+/-- There is a (noncomputable) bijection between `α` and `fin (card α)`.
 
 See `fintype.trunc_equiv_fin` for the computable version,
 and `fintype.trunc_equiv_fin_of_card_eq` and `fintype.equiv_fin_of_card_eq`

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -266,9 +266,6 @@ for an equiv `α ≃ fin n` given `fintype.card α = n`.
 noncomputable def equiv_fin (α) [fintype α] : α ≃ fin (card α) :=
 by { letI := classical.dec_eq α, exact (trunc_equiv_fin α).out }
 
-theorem exists_equiv_fin (α) [fintype α] : ∃ n, nonempty (α ≃ fin n) :=
-by haveI := classical.dec_eq α; exact ⟨card α, (trunc_equiv_fin α).nonempty⟩
-
 instance (α : Type*) : subsingleton (fintype α) :=
 ⟨λ ⟨s₁, h₁⟩ ⟨s₂, h₂⟩, by congr; simp [finset.ext_iff, h₁, h₂]⟩
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -463,7 +463,7 @@ by { letI := classical.dec_eq α, letI := classical.dec_eq β,
 end
 
 theorem card_eq {α β} [F : fintype α] [G : fintype β] : card α = card β ↔ nonempty (α ≃ β) :=
-⟨λ h, ⟨equiv_of_card_eq h⟩,
+⟨λ h, by { haveI := classical.prop_decidable, exact (trunc_equiv_of_card_eq h).nonempty },
  λ ⟨f⟩, card_congr f⟩
 
 /-- Any subsingleton type with a witness is a fintype (with one term). -/

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -244,15 +244,29 @@ def equiv_fin_of_forall_mem_list {α} [decidable_eq α]
 /-- There is (computably) a bijection between `α` and `fin n` where
   `n = card α`. Since it is not unique, and depends on which permutation
   of the universe list is used, the bijection is wrapped in `trunc` to
-  preserve computability.  -/
-def equiv_fin (α) [decidable_eq α] [fintype α] : trunc (α ≃ fin (card α)) :=
+  preserve computability.
+
+See `fintype.equiv_fin` for the noncomputable version,
+and `fintype.trunc_equiv_fin_of_card_eq` and `fintype.equiv_fin_of_card_eq`
+for an equiv `α ≃ fin n` given `fintype.card α = n`.
+-/
+def trunc_equiv_fin (α) [decidable_eq α] [fintype α] : trunc (α ≃ fin (card α)) :=
 by unfold card finset.card; exact
 quot.rec_on_subsingleton (@univ α _).1
   (λ l (h : ∀ x:α, x ∈ l) (nd : l.nodup), trunc.mk (equiv_fin_of_forall_mem_list h nd))
   mem_univ_val univ.2
 
+/-- There is a (noncomputable0 )bijection between `α` and `fin n` where `n = card α`.
+
+See `fintype.trunc_equiv_fin` for the computable version,
+and `fintype.trunc_equiv_fin_of_card_eq` and `fintype.equiv_fin_of_card_eq`
+for an equiv `α ≃ fin n` given `fintype.card α = n`.
+-/
+noncomputable def equiv_fin (α) [fintype α] : α ≃ fin (card α) :=
+by { letI := classical.dec_eq α, exact (trunc_equiv_fin α).out }
+
 theorem exists_equiv_fin (α) [fintype α] : ∃ n, nonempty (α ≃ fin n) :=
-by haveI := classical.dec_eq α; exact ⟨card α, (equiv_fin α).nonempty⟩
+by haveI := classical.dec_eq α; exact ⟨card α, (trunc_equiv_fin α).nonempty⟩
 
 instance (α : Type*) : subsingleton (fintype α) :=
 ⟨λ ⟨s₁, h₁⟩ ⟨s₂, h₂⟩, by congr; simp [finset.ext_iff, h₁, h₂]⟩
@@ -405,12 +419,54 @@ multiset.card_map _ _
 theorem card_congr {α β} [fintype α] [fintype β] (f : α ≃ β) : card α = card β :=
 by rw ← of_equiv_card f; congr
 
+section
+
+variables [fintype α] [fintype β]
+
+/-- If the cardinality of `α` is `n`, there is computably a bijection between `α` and `fin n`.
+
+See `fintype.equiv_fin_of_card_eq` for the noncomputable definition,
+and `fintype.trunc_equiv_fin` and `fintype.equiv_fin` for the bijection `α ≃ fin (card α)`.
+-/
+def trunc_equiv_fin_of_card_eq [decidable_eq α] {n : ℕ} (h : fintype.card α = n) :
+  trunc (α ≃ fin n) :=
+(trunc_equiv_fin α).map (λ e, e.trans (fin.cast h).to_equiv)
+
+
+/-- If the cardinality of `α` is `n`, there is noncomputably a bijection between `α` and `fin n`.
+
+See `fintype.trunc_equiv_fin_of_card_eq` for the computable definition,
+and `fintype.trunc_equiv_fin` and `fintype.equiv_fin` for the bijection `α ≃ fin (card α)`.
+-/
+noncomputable def equiv_fin_of_card_eq {n : ℕ} (h : fintype.card α = n) :
+  α ≃ fin n :=
+by { letI := classical.dec_eq α, exact (trunc_equiv_fin_of_card_eq h).out }
+
+/-- Two `fintype`s with the same cardinality are (computably) in bijection.
+
+See `fintype.equiv_of_card_eq` for the noncomputable version,
+and `fintype.trunc_equiv_fin_of_card_eq` and `fintype.equiv_fin_of_card_eq` for
+the specialization to `fin`.
+-/
+def trunc_equiv_of_card_eq [decidable_eq α] [decidable_eq β] (h : card α = card β) :
+  trunc (α ≃ β) :=
+(trunc_equiv_fin_of_card_eq h).bind (λ e, (trunc_equiv_fin β).map (λ e', e.trans e'.symm))
+
+/-- Two `fintype`s with the same cardinality are (noncomputably) in bijection.
+
+See `fintype.trunc_equiv_of_card_eq` for the computable version,
+and `fintype.trunc_equiv_fin_of_card_eq` and `fintype.equiv_fin_of_card_eq` for
+the specialization to `fin`.
+-/
+noncomputable def equiv_of_card_eq (h : card α = card β) : α ≃ β :=
+by { letI := classical.dec_eq α, letI := classical.dec_eq β,
+     exact (trunc_equiv_of_card_eq h).out }
+
+end
+
 theorem card_eq {α β} [F : fintype α] [G : fintype β] : card α = card β ↔ nonempty (α ≃ β) :=
-⟨λ h, ⟨by classical;
-  calc α ≃ fin (card α) : trunc.out (equiv_fin α)
-     ... ≃ fin (card β) : by rw h
-     ... ≃ β : (trunc.out (equiv_fin β)).symm⟩,
-λ ⟨f⟩, card_congr f⟩
+⟨λ h, ⟨equiv_of_card_eq h⟩,
+ λ ⟨f⟩, card_congr f⟩
 
 /-- Any subsingleton type with a witness is a fintype (with one term). -/
 def of_subsingleton (a : α) [subsingleton α] : fintype α :=
@@ -829,20 +885,6 @@ have injective (e.symm ∘ f) ↔ surjective (e.symm ∘ f), from injective_iff_
 λ hsurj, by simpa [function.comp] using
   e.injective.comp (this.2 (e.symm.surjective.comp hsurj))⟩
 
-lemma nonempty_equiv_of_card_eq (h : card α = card β) :
-  nonempty (α ≃ β) :=
-begin
-  obtain ⟨m, ⟨f⟩⟩ := exists_equiv_fin α,
-  obtain ⟨n, ⟨g⟩⟩ := exists_equiv_fin β,
-  suffices : m = n,
-  { subst this, exact ⟨f.trans g.symm⟩ },
-  calc m = card (fin m) : (card_fin m).symm
-     ... = card α       : card_congr f.symm
-     ... = card β       : h
-     ... = card (fin n) : card_congr g
-     ... = n            : card_fin n
-end
-
 lemma bijective_iff_injective_and_card (f : α → β) :
   bijective f ↔ injective f ∧ card α = card β :=
 begin
@@ -850,8 +892,7 @@ begin
   { intro h, exact ⟨h.1, card_congr (equiv.of_bijective f h)⟩ },
   { rintro ⟨hf, h⟩,
     refine ⟨hf, _⟩,
-    obtain ⟨e⟩ : nonempty (α ≃ β) := nonempty_equiv_of_card_eq h,
-    rwa ← injective_iff_surjective_of_equiv e }
+    rwa ← injective_iff_surjective_of_equiv (equiv_of_card_eq h) }
 end
 
 lemma bijective_iff_surjective_and_card (f : α → β) :
@@ -861,8 +902,7 @@ begin
   { intro h, exact ⟨h.2, card_congr (equiv.of_bijective f h)⟩, },
   { rintro ⟨hf, h⟩,
     refine ⟨_, hf⟩,
-    obtain ⟨e⟩ : nonempty (α ≃ β) := nonempty_equiv_of_card_eq h,
-    rwa injective_iff_surjective_of_equiv e }
+    rwa injective_iff_surjective_of_equiv (equiv_of_card_eq h) }
 end
 
 end fintype
@@ -1285,8 +1325,8 @@ def fintype_perm [fintype α] : fintype (perm α) :=
 
 instance [fintype α] [fintype β] : fintype (α ≃ β) :=
 if h : fintype.card β = fintype.card α
-then trunc.rec_on_subsingleton (fintype.equiv_fin α)
-  (λ eα, trunc.rec_on_subsingleton (fintype.equiv_fin β)
+then trunc.rec_on_subsingleton (fintype.trunc_equiv_fin α)
+  (λ eα, trunc.rec_on_subsingleton (fintype.trunc_equiv_fin β)
     (λ eβ, @fintype.of_equiv _ (perm α) fintype_perm
       (equiv_congr (equiv.refl α) (eα.trans (eq.rec_on h eβ.symm)) : (α ≃ α) ≃ (α ≃ β))))
 else ⟨∅, λ x, false.elim (h (fintype.card_eq.2 ⟨x.symm⟩))⟩

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -256,7 +256,7 @@ quot.rec_on_subsingleton (@univ α _).1
   (λ l (h : ∀ x:α, x ∈ l) (nd : l.nodup), trunc.mk (equiv_fin_of_forall_mem_list h nd))
   mem_univ_val univ.2
 
-/-- There is a (noncomputable0 )bijection between `α` and `fin n` where `n = card α`.
+/-- There is a (noncomputable) bijection between `α` and `fin n` where `n = card α`.
 
 See `fintype.trunc_equiv_fin` for the computable version,
 and `fintype.trunc_equiv_fin_of_card_eq` and `fintype.equiv_fin_of_card_eq`

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -189,7 +189,7 @@ theorem exists_fin_rename (p : mv_polynomial σ R) :
 begin
   obtain ⟨s, q, rfl⟩ := exists_finset_rename p,
   let n := fintype.card {x // x ∈ s},
-  obtain ⟨e⟩ := fintype.trunc_equiv_fin {x // x ∈ s},
+  let e := fintype.equiv_fin {x // x ∈ s},
   refine ⟨n, coe ∘ e.symm, subtype.val_injective.comp e.symm.injective, rename e q, _⟩,
   rw [← rename_rename, rename_rename e],
   simp only [function.comp, equiv.symm_apply_apply, rename_rename]

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -188,7 +188,8 @@ theorem exists_fin_rename (p : mv_polynomial σ R) :
   ∃ (n : ℕ) (f : fin n → σ) (hf : injective f) (q : mv_polynomial (fin n) R), p = rename f q :=
 begin
   obtain ⟨s, q, rfl⟩ := exists_finset_rename p,
-  obtain ⟨n, ⟨e⟩⟩ := fintype.exists_equiv_fin {x // x ∈ s},
+  let n := fintype.card {x // x ∈ s},
+  let e := fintype.equiv_fin {x // x ∈ s},
   refine ⟨n, coe ∘ e.symm, subtype.val_injective.comp e.symm.injective, rename e q, _⟩,
   rw [← rename_rename, rename_rename e],
   simp only [function.comp, equiv.symm_apply_apply, rename_rename]

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -189,7 +189,7 @@ theorem exists_fin_rename (p : mv_polynomial σ R) :
 begin
   obtain ⟨s, q, rfl⟩ := exists_finset_rename p,
   let n := fintype.card {x // x ∈ s},
-  let e := fintype.equiv_fin {x // x ∈ s},
+  obtain ⟨e⟩ := fintype.trunc_equiv_fin {x // x ∈ s},
   refine ⟨n, coe ∘ e.symm, subtype.val_injective.comp e.symm.injective, rename e q, _⟩,
   rw [← rename_rename, rename_rename e],
   simp only [function.comp, equiv.symm_apply_apply, rename_rename]

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -86,7 +86,7 @@ theorem exists_finite_iff_finset {p : set α → Prop} :
 lemma finite.fin_embedding {s : set α} (h : finite s) : ∃ (n : ℕ) (f : fin n ↪ α), range f = s :=
 begin
   classical,
-  obtain ⟨f⟩ := (fintype.equiv_fin (h.to_finset : set α)).nonempty,
+  let f := fintype.equiv_fin (h.to_finset : set α),
   exact ⟨_, f.symm.as_embedding, by simp⟩
 end
 

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -84,11 +84,7 @@ theorem exists_finite_iff_finset {p : set α → Prop} :
   λ ⟨s, hs⟩, ⟨↑s, finite_mem_finset s, hs⟩⟩
 
 lemma finite.fin_embedding {s : set α} (h : finite s) : ∃ (n : ℕ) (f : fin n ↪ α), range f = s :=
-begin
-  classical,
-  obtain ⟨f⟩ := fintype.trunc_equiv_fin (h.to_finset : set α),
-  exact ⟨_, f.symm.as_embedding, by simp⟩
-end
+⟨_, (fintype.equiv_fin (h.to_finset : set α)).symm.as_embedding, by simp⟩
 
 lemma finite.fin_param {s : set α} (h : finite s) :
   ∃ (n : ℕ) (f : fin n → α), injective f ∧ range f = s :=

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -86,7 +86,7 @@ theorem exists_finite_iff_finset {p : set α → Prop} :
 lemma finite.fin_embedding {s : set α} (h : finite s) : ∃ (n : ℕ) (f : fin n ↪ α), range f = s :=
 begin
   classical,
-  let f := fintype.equiv_fin (h.to_finset : set α),
+  obtain ⟨f⟩ := fintype.trunc_equiv_fin (h.to_finset : set α),
   exact ⟨_, f.symm.as_embedding, by simp⟩
 end
 

--- a/src/field_theory/finite/polynomial.lean
+++ b/src/field_theory/finite/polynomial.lean
@@ -173,7 +173,7 @@ calc module.rank K (R σ K) =
     quotient.sound ⟨equiv.arrow_congr (equiv.refl σ) (equiv.fin_equiv_subtype _).symm⟩
   ... = cardinal.mk (σ → K) :
   begin
-    let e := fintype.equiv_fin K,
+    obtain ⟨e⟩ := fintype.trunc_equiv_fin K,
     refine quotient.sound ⟨equiv.arrow_congr (equiv.refl σ) e.symm⟩
   end
   ... = fintype.card (σ → K) : cardinal.fintype_card _

--- a/src/field_theory/finite/polynomial.lean
+++ b/src/field_theory/finite/polynomial.lean
@@ -173,7 +173,7 @@ calc module.rank K (R σ K) =
     quotient.sound ⟨equiv.arrow_congr (equiv.refl σ) (equiv.fin_equiv_subtype _).symm⟩
   ... = cardinal.mk (σ → K) :
   begin
-    refine (trunc.induction_on (fintype.equiv_fin K) $ assume (e : K ≃ fin (fintype.card K)), _),
+    let e := fintype.equiv_fin K,
     refine quotient.sound ⟨equiv.arrow_congr (equiv.refl σ) e.symm⟩
   end
   ... = fintype.card (σ → K) : cardinal.fintype_card _

--- a/src/field_theory/finite/polynomial.lean
+++ b/src/field_theory/finite/polynomial.lean
@@ -172,10 +172,7 @@ calc module.rank K (R σ K) =
   ... = cardinal.mk (σ → fin (fintype.card K)) :
     quotient.sound ⟨equiv.arrow_congr (equiv.refl σ) (equiv.fin_equiv_subtype _).symm⟩
   ... = cardinal.mk (σ → K) :
-  begin
-    obtain ⟨e⟩ := fintype.trunc_equiv_fin K,
-    refine quotient.sound ⟨equiv.arrow_congr (equiv.refl σ) e.symm⟩
-  end
+    quotient.sound ⟨equiv.arrow_congr (equiv.refl σ) (fintype.equiv_fin K).symm⟩
   ... = fintype.card (σ → K) : cardinal.fintype_card _
 
 instance : finite_dimensional K (R σ K) :=

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -652,7 +652,7 @@ end
   `sign_aux2 f _` recursively calculates the sign of `f`. -/
 def sign_aux3 [fintype α] (f : perm α) {s : multiset α} : (∀ x, x ∈ s) → units ℤ :=
 quotient.hrec_on s (λ l h, sign_aux2 l f)
-  (trunc.induction_on (trunc_equiv_fin α)
+  (trunc.induction_on (fintype.trunc_equiv_fin α)
     (λ e l₁ l₂ h, function.hfunext
       (show (∀ x, x ∈ l₁) = ∀ x, x ∈ l₂, by simp only [h.mem_iff])
       (λ h₁ h₂ _, by rw [← sign_aux_eq_sign_aux2 _ _ e (λ _ _, h₁ _),
@@ -664,7 +664,7 @@ lemma sign_aux3_mul_and_swap [fintype α] (f g : perm α) (s : multiset α) (hs 
 let ⟨l, hl⟩ := quotient.exists_rep s in
 let e := equiv_fin α in
 begin
-  clear _let_match _let_match,
+  clear _let_match,
   subst hl,
   show sign_aux2 l (f * g) = sign_aux2 l f * sign_aux2 l g ∧
     ∀ x y, x ≠ y → sign_aux2 l (swap x y) = -1,

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -652,7 +652,7 @@ end
   `sign_aux2 f _` recursively calculates the sign of `f`. -/
 def sign_aux3 [fintype α] (f : perm α) {s : multiset α} : (∀ x, x ∈ s) → units ℤ :=
 quotient.hrec_on s (λ l h, sign_aux2 l f)
-  (trunc.induction_on (equiv_fin α)
+  (trunc.induction_on (trunc_equiv_fin α)
     (λ e l₁ l₂ h, function.hfunext
       (show (∀ x, x ∈ l₁) = ∀ x, x ∈ l₂, by simp only [h.mem_iff])
       (λ h₁ h₂ _, by rw [← sign_aux_eq_sign_aux2 _ _ e (λ _ _, h₁ _),
@@ -662,7 +662,7 @@ lemma sign_aux3_mul_and_swap [fintype α] (f g : perm α) (s : multiset α) (hs 
   sign_aux3 (f * g) hs = sign_aux3 f hs * sign_aux3 g hs ∧ ∀ x y, x ≠ y →
   sign_aux3 (swap x y) hs = -1 :=
 let ⟨l, hl⟩ := quotient.exists_rep s in
-let ⟨e, _⟩ := (equiv_fin α).exists_rep in
+let e := equiv_fin α in
 begin
   clear _let_match _let_match,
   subst hl,
@@ -722,7 +722,7 @@ lemma sign_aux3_symm_trans_trans [decidable_eq β] [fintype β] (f : perm α)
   sign_aux3 ((e.symm.trans f).trans e) ht = sign_aux3 f hs :=
 quotient.induction_on₂ t s
   (λ l₁ l₂ h₁ h₂, show sign_aux2 _ _ = sign_aux2 _ _,
-    from let n := (equiv_fin β).out in
+    from let n := equiv_fin β in
     by { rw [← sign_aux_eq_sign_aux2 _ _ n (λ _ _, h₁ _),
         ← sign_aux_eq_sign_aux2 _ _ (e.trans n) (λ _ _, h₂ _)],
       exact congr_arg sign_aux

--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -221,8 +221,8 @@ lemma is_basis.card_le_card_of_linear_independent
 begin
   haveI := classical.dec_eq ι,
   haveI := classical.dec_eq ι',
-  obtain ⟨e⟩ := fintype.trunc_equiv_fin ι,
-  obtain ⟨e'⟩ := fintype.trunc_equiv_fin ι',
+  let e := fintype.equiv_fin ι,
+  let e' := fintype.equiv_fin ι',
   have hb := hb.comp _ e.symm.bijective,
   have hv := (linear_independent_equiv e'.symm).mpr hv,
   have hv := hv.map' _ hb.equiv_fun.ker,

--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -221,8 +221,8 @@ lemma is_basis.card_le_card_of_linear_independent
 begin
   haveI := classical.dec_eq ι,
   haveI := classical.dec_eq ι',
-  obtain ⟨e⟩ := fintype.equiv_fin ι,
-  obtain ⟨e'⟩ := fintype.equiv_fin ι',
+  let e := fintype.equiv_fin ι,
+  let e' := fintype.equiv_fin ι',
   have hb := hb.comp _ e.symm.bijective,
   have hv := (linear_independent_equiv e'.symm).mpr hv,
   have hv := hv.map' _ hb.equiv_fun.ker,

--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -221,8 +221,8 @@ lemma is_basis.card_le_card_of_linear_independent
 begin
   haveI := classical.dec_eq ι,
   haveI := classical.dec_eq ι',
-  let e := fintype.equiv_fin ι,
-  let e' := fintype.equiv_fin ι',
+  obtain ⟨e⟩ := fintype.trunc_equiv_fin ι,
+  obtain ⟨e'⟩ := fintype.trunc_equiv_fin ι',
   have hb := hb.comp _ e.symm.bijective,
   have hv := (linear_independent_equiv e'.symm).mpr hv,
   have hv := hv.map' _ hb.equiv_fun.ker,

--- a/src/logic/small.lean
+++ b/src/logic/small.lean
@@ -80,8 +80,7 @@ end
 @[priority 100]
 instance small_of_fintype (α : Type v) [fintype α] : small.{w} α :=
 begin
-  obtain ⟨e⟩ := fintype.trunc_equiv_fin α,
-  rw small_congr e,
+  rw small_congr (fintype.equiv_fin α),
   apply_instance,
 end
 

--- a/src/logic/small.lean
+++ b/src/logic/small.lean
@@ -80,7 +80,7 @@ end
 @[priority 100]
 instance small_of_fintype (α : Type v) [fintype α] : small.{w} α :=
 begin
-  let e := fintype.equiv_fin α,
+  obtain ⟨e⟩ := fintype.trunc_equiv_fin α,
   rw small_congr e,
   apply_instance,
 end

--- a/src/logic/small.lean
+++ b/src/logic/small.lean
@@ -80,7 +80,7 @@ end
 @[priority 100]
 instance small_of_fintype (α : Type v) [fintype α] : small.{w} α :=
 begin
-  obtain ⟨n, ⟨e⟩⟩ := fintype.exists_equiv_fin α,
+  let e := fintype.equiv_fin α,
   rw small_congr e,
   apply_instance,
 end

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -196,9 +196,10 @@ begin
   split,
   { rw iff_quotient_mv_polynomial',
     rintro ⟨ι, hfintype, ⟨f, hsur⟩⟩,
-    obtain ⟨n, equiv⟩ := @fintype.exists_equiv_fin ι hfintype,
-    replace equiv := mv_polynomial.rename_equiv R (nonempty.some equiv),
-    exact ⟨n, alg_hom.comp f equiv.symm, function.surjective.comp hsur
+    letI := hfintype,
+    obtain ⟨equiv⟩ := @fintype.trunc_equiv_fin ι (classical.dec_eq ι) hfintype,
+    replace equiv := mv_polynomial.rename_equiv R equiv,
+    exact ⟨fintype.card ι, alg_hom.comp f equiv.symm, function.surjective.comp hsur
       (alg_equiv.symm equiv).surjective⟩ },
   { rintro ⟨n, ⟨f, hsur⟩⟩,
     exact finite_type.of_surjective (finite_type.mv_polynomial R (fin n)) f hsur }
@@ -252,9 +253,9 @@ variable (R)
 /-- The ring of polynomials in finitely many variables is finitely presented. -/
 lemma mv_polynomial (ι : Type u_2) [fintype ι] : finite_presentation R (mv_polynomial ι R) :=
 begin
-  obtain ⟨n, equiv⟩ := @fintype.exists_equiv_fin ι _,
-  replace equiv := mv_polynomial.rename_equiv R (nonempty.some equiv),
-  use [n, alg_equiv.to_alg_hom equiv.symm],
+  obtain ⟨equiv⟩ := @fintype.trunc_equiv_fin ι (classical.dec_eq ι) _,
+  replace equiv := mv_polynomial.rename_equiv R equiv,
+  refine ⟨_, alg_equiv.to_alg_hom equiv.symm, _⟩,
   split,
   { exact (alg_equiv.symm equiv).surjective },
   suffices hinj : function.injective equiv.symm.to_alg_hom.to_ring_hom,
@@ -312,9 +313,9 @@ begin
     exact ring_hom.ker_coe_equiv ulift_var.to_ring_equiv, },
   { rintro ⟨ι, hfintype, f, hf⟩,
     haveI : fintype ι := hfintype,
-    obtain ⟨n, equiv⟩ := fintype.exists_equiv_fin ι,
-    replace equiv := mv_polynomial.rename_equiv R (nonempty.some equiv),
-    refine ⟨n, f.comp equiv.symm,
+    obtain ⟨equiv⟩ := @fintype.trunc_equiv_fin ι (classical.dec_eq ι) _,
+    replace equiv := mv_polynomial.rename_equiv R equiv,
+    refine ⟨fintype.card ι, f.comp equiv.symm,
       hf.1.comp (alg_equiv.symm equiv).surjective,
       submodule.fg_ker_ring_hom_comp _ f _ hf.2 equiv.symm.surjective⟩,
     convert submodule.fg_bot,
@@ -326,8 +327,10 @@ as `R`-algebra. -/
 lemma mv_polynomial_of_finite_presentation (hfp : finite_presentation R A) (ι : Type*)
   [fintype ι] : finite_presentation R (_root_.mv_polynomial ι A) :=
 begin
-  obtain ⟨n, e⟩ := fintype.exists_equiv_fin ι,
-  replace e := (mv_polynomial.rename_equiv A (nonempty.some e)).restrict_scalars R,
+  classical,
+  let n := fintype.card ι,
+  obtain ⟨e⟩ := fintype.trunc_equiv_fin ι,
+  replace e := (mv_polynomial.rename_equiv A e).restrict_scalars R,
   refine equiv _ e.symm,
   obtain ⟨m, I, e, hfg⟩ := iff.1 hfp,
   refine equiv _ (mv_polynomial.map_alg_equiv (fin n) e),

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -552,7 +552,7 @@ instance {R : Type*} [comm_ring R] {ι : Type*} [fintype ι] [is_jacobson R] :
   is_jacobson (mv_polynomial ι R) :=
 begin
   haveI := classical.dec_eq ι,
-  obtain ⟨e⟩ := fintype.equiv_fin ι,
+  let e := fintype.equiv_fin ι,
   rw is_jacobson_iso (rename_equiv R e).to_ring_equiv,
   exact is_jacobson_mv_polynomial_fin _
 end
@@ -595,7 +595,7 @@ lemma comp_C_integral_of_surjective_of_jacobson {R : Type*} [integral_domain R] 
   (hf : function.surjective f) : (f.comp C).is_integral :=
 begin
   haveI := classical.dec_eq σ,
-  obtain ⟨e⟩ := fintype.equiv_fin σ,
+  let e := fintype.equiv_fin σ,
   let f' : mv_polynomial (fin _) R →+* S :=
     f.comp (rename_equiv R e.symm).to_ring_equiv.to_ring_hom,
   have hf' : function.surjective f' :=

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -552,7 +552,7 @@ instance {R : Type*} [comm_ring R] {ι : Type*} [fintype ι] [is_jacobson R] :
   is_jacobson (mv_polynomial ι R) :=
 begin
   haveI := classical.dec_eq ι,
-  let e := fintype.equiv_fin ι,
+  obtain ⟨e⟩ := fintype.trunc_equiv_fin ι,
   rw is_jacobson_iso (rename_equiv R e).to_ring_equiv,
   exact is_jacobson_mv_polynomial_fin _
 end
@@ -595,7 +595,7 @@ lemma comp_C_integral_of_surjective_of_jacobson {R : Type*} [integral_domain R] 
   (hf : function.surjective f) : (f.comp C).is_integral :=
 begin
   haveI := classical.dec_eq σ,
-  let e := fintype.equiv_fin σ,
+  obtain ⟨e⟩ := fintype.trunc_equiv_fin σ,
   let f' : mv_polynomial (fin _) R →+* S :=
     f.comp (rename_equiv R e.symm).to_ring_equiv.to_ring_hom,
   have hf' : function.surjective f' :=

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -552,7 +552,7 @@ instance {R : Type*} [comm_ring R] {ι : Type*} [fintype ι] [is_jacobson R] :
   is_jacobson (mv_polynomial ι R) :=
 begin
   haveI := classical.dec_eq ι,
-  obtain ⟨e⟩ := fintype.trunc_equiv_fin ι,
+  let e := fintype.equiv_fin ι,
   rw is_jacobson_iso (rename_equiv R e).to_ring_equiv,
   exact is_jacobson_mv_polynomial_fin _
 end

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -682,9 +682,8 @@ theorem is_noetherian_ring_fin [is_noetherian_ring R] :
 is itself a noetherian ring. -/
 instance is_noetherian_ring [fintype σ] [is_noetherian_ring R] :
   is_noetherian_ring (mv_polynomial σ R) :=
-trunc.induction_on (fintype.trunc_equiv_fin σ) $ λ e,
 @is_noetherian_ring_of_ring_equiv (mv_polynomial (fin (fintype.card σ)) R) _ _ _
-  (rename_equiv R e.symm).to_ring_equiv is_noetherian_ring_fin
+  (rename_equiv R (fintype.equiv_fin σ).symm).to_ring_equiv is_noetherian_ring_fin
 
 lemma is_integral_domain_fin_zero (R : Type u) [comm_ring R] (hR : is_integral_domain R) :
   is_integral_domain (mv_polynomial (fin 0) R) :=
@@ -708,10 +707,9 @@ lemma is_integral_domain_fin (R : Type u) [comm_ring R] (hR : is_integral_domain
 
 lemma is_integral_domain_fintype (R : Type u) (σ : Type v) [comm_ring R] [fintype σ]
   (hR : is_integral_domain R) : is_integral_domain (mv_polynomial σ R) :=
-trunc.induction_on (fintype.trunc_equiv_fin σ) $ λ e,
 @ring_equiv.is_integral_domain _ (mv_polynomial (fin $ fintype.card σ) R) _ _
   (mv_polynomial.is_integral_domain_fin _ hR _)
-  (rename_equiv R e).to_ring_equiv
+  (rename_equiv R (fintype.equiv_fin σ)).to_ring_equiv
 
 /-- Auxilliary definition:
 Multivariate polynomials in finitely many variables over an integral domain form an integral domain.

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -682,7 +682,7 @@ theorem is_noetherian_ring_fin [is_noetherian_ring R] :
 is itself a noetherian ring. -/
 instance is_noetherian_ring [fintype σ] [is_noetherian_ring R] :
   is_noetherian_ring (mv_polynomial σ R) :=
-let e := fintype.equiv_fin σ in
+trunc.induction_on (fintype.trunc_equiv_fin σ) $ λ e,
 @is_noetherian_ring_of_ring_equiv (mv_polynomial (fin (fintype.card σ)) R) _ _ _
   (rename_equiv R e.symm).to_ring_equiv is_noetherian_ring_fin
 
@@ -708,7 +708,7 @@ lemma is_integral_domain_fin (R : Type u) [comm_ring R] (hR : is_integral_domain
 
 lemma is_integral_domain_fintype (R : Type u) (σ : Type v) [comm_ring R] [fintype σ]
   (hR : is_integral_domain R) : is_integral_domain (mv_polynomial σ R) :=
-let e := fintype.equiv_fin σ in
+trunc.induction_on (fintype.trunc_equiv_fin σ) $ λ e,
 @ring_equiv.is_integral_domain _ (mv_polynomial (fin $ fintype.card σ) R) _ _
   (mv_polynomial.is_integral_domain_fin _ hR _)
   (rename_equiv R e).to_ring_equiv

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -682,7 +682,7 @@ theorem is_noetherian_ring_fin [is_noetherian_ring R] :
 is itself a noetherian ring. -/
 instance is_noetherian_ring [fintype σ] [is_noetherian_ring R] :
   is_noetherian_ring (mv_polynomial σ R) :=
-trunc.induction_on (fintype.equiv_fin σ) $ λ e,
+let e := fintype.equiv_fin σ in
 @is_noetherian_ring_of_ring_equiv (mv_polynomial (fin (fintype.card σ)) R) _ _ _
   (rename_equiv R e.symm).to_ring_equiv is_noetherian_ring_fin
 
@@ -708,7 +708,7 @@ lemma is_integral_domain_fin (R : Type u) [comm_ring R] (hR : is_integral_domain
 
 lemma is_integral_domain_fintype (R : Type u) (σ : Type v) [comm_ring R] [fintype σ]
   (hR : is_integral_domain R) : is_integral_domain (mv_polynomial σ R) :=
-trunc.induction_on (fintype.equiv_fin σ) $ λ e,
+let e := fintype.equiv_fin σ in
 @ring_equiv.is_integral_domain _ (mv_polynomial (fin $ fintype.card σ) R) _ _
   (mv_polynomial.is_integral_domain_fin _ hR _)
   (rename_equiv R e).to_ring_equiv

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -615,8 +615,8 @@ begin
   have : ∀p:GH_space, ∀t:set (p.rep), finite t → ∃n:ℕ, ∃e:equiv t (fin n), true,
   { assume p t ht,
     letI : fintype t := finite.fintype ht,
-    rcases fintype.exists_equiv_fin t with ⟨n, hn⟩,
-    rcases hn with ⟨e⟩,
+    let n := fintype.card t,
+    let e := fintype.equiv_fin t,
     exact ⟨n, e, trivial⟩ },
   choose N e hne using this,
   -- cardinality of the nice finite subset `s p` of `p.rep`, called `N p`

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -615,9 +615,7 @@ begin
   have : ∀p:GH_space, ∀t:set (p.rep), finite t → ∃n:ℕ, ∃e:equiv t (fin n), true,
   { assume p t ht,
     letI : fintype t := finite.fintype ht,
-    let n := fintype.card t,
-    obtain ⟨e⟩ := fintype.trunc_equiv_fin t,
-    exact ⟨n, e, trivial⟩ },
+    exact ⟨fintype.card t, fintype.equiv_fin t, trivial⟩ },
   choose N e hne using this,
   -- cardinality of the nice finite subset `s p` of `p.rep`, called `N p`
   let N := λp:GH_space, N p (s p) (hs p).1,

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -616,7 +616,7 @@ begin
   { assume p t ht,
     letI : fintype t := finite.fintype ht,
     let n := fintype.card t,
-    let e := fintype.equiv_fin t,
+    obtain ⟨e⟩ := fintype.trunc_equiv_fin t,
     exact ⟨n, e, trivial⟩ },
   choose N e hne using this,
   -- cardinality of the nice finite subset `s p` of `p.rep`, called `N p`


### PR DESCRIPTION
These changes should make the declarations `fintype.equiv_fin`, `fintype.card_eq`
and `fintype.equiv_of_card_eq` more convenient to use.

Renamed:
 * `fintype.equiv_fin` -> `fintype.trunc_equiv_fin`

Deleted:
 * `fintype.nonempty_equiv_of_card_eq` (use `fintype.equiv_of_card_eq` instead)
 * `fintype.exists_equiv_fin` (use `fintype.card` and `fintype.(trunc_)equiv_fin` instead)

Added:
 * `fintype.equiv_fin`: noncomputable, non-`trunc` version of `fintype.equiv_fin`
 * `fintype.equiv_of_card_eq`: noncomputable, non-`trunc` version of `fintype.trunc_equiv_of_card_eq`
 * `fintype.(trunc_)equiv_fin_of_card_eq` (intermediate result/specialization of `fintype.(trunc_)equiv_of_card_eq`

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/.60fintype.2Eequiv_fin.60.20.2B.20.60fin.2Ecast.60)

---
Marking as WIP until it builds.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
