### PR TITLE
fix(refine_struct): fix regression from #2319

### DIFF
--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -305,10 +305,9 @@ do    tgt ← target >>= whnf,
       gs ← with_enable_tags (
         mzip_with (λ (n : name × name) v, do
            set_goals [v],
-           try (dsimp_target simp_lemmas.mk),
            apply_auto_param
              <|> apply_opt_param
-             <|> (set_main_tag [`_field,n.2,n.1]),
+             <|> (try (dsimp_target simp_lemmas.mk) >> (set_main_tag [`_field,n.2,n.1])),
            get_goals)
         missing_f' vs),
       set_goals gs.join,
@@ -328,7 +327,7 @@ literals. It creates a goal for each missing field and tags it with the name of 
 field so that `have_field` can be used to generically refer to the field currently
 being refined.
 
-As an example, we can use `refine_struct` to automate the construction semigroup
+As an example, we can use `refine_struct` to automate the construction of semigroup
 instances:
 
 ```lean

--- a/test/refine_struct.lean
+++ b/test/refine_struct.lean
@@ -160,3 +160,14 @@ begin
     guard_target ∀ a b c : α, mul (mul a b) c = mul a (mul b c),
     exact h.elim }
 end
+
+meta def exact_zero : tactic unit := `[exact 0]
+
+structure param_test :=
+(n : ℤ := 0)
+(m : ℕ . exact_zero)
+
+example : param_test :=
+begin
+  refine_struct { .. },
+end


### PR DESCRIPTION
`refine_struct` was originally intended to use optional and auto parameters.

The patch in #2319 applied `dsimp` slightly too early, erasing the wrappers that `apply_opt_param` and `apply_auto_param` look for. 

This fixes a problem in `transport` that arose in #7084.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
