### PR TITLE
[Merged by Bors] - chore(*): speedup slow proofs

### DIFF
--- a/src/algebra/category/Algebra/basic.lean
+++ b/src/algebra/category/Algebra/basic.lean
@@ -87,15 +87,24 @@ def free : Type* ⥤ Algebra R :=
 { obj := λ S,
   { carrier := free_algebra R S,
     is_ring := algebra.semiring_to_ring R },
-  map := λ S T f, free_algebra.lift _ $ (free_algebra.ι _) ∘ f }
+  map := λ S T f, free_algebra.lift _ $ (free_algebra.ι _) ∘ f,
+  -- obviously can fill the next two goals, but it is slow
+  map_id' := by { intros X, ext1, simp only [free_algebra.ι_comp_lift], refl },
+  map_comp' := by { intros, ext1, simp only [free_algebra.ι_comp_lift], ext1,
+    simp only [free_algebra.lift_ι_apply, category_theory.coe_comp, function.comp_app,
+      types_comp_apply] } }
 
 /-- The free/forget ajunction for `R`-algebras. -/
 def adj : free R ⊣ forget (Algebra R) :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ X A, (free_algebra.lift _).symm,
   -- Relying on `obviously` to fill out these proofs is very slow :(
-  hom_equiv_naturality_left_symm' := by {intros, ext, simp},
-  hom_equiv_naturality_right' := by {intros, ext, simp} }
+  hom_equiv_naturality_left_symm' := by { intros, ext,
+    simp only [free_map, equiv.symm_symm, free_algebra.lift_ι_apply, category_theory.coe_comp,
+      function.comp_app, types_comp_apply] },
+  hom_equiv_naturality_right' := by { intros, ext,
+    simp only [forget_map_eq_coe, category_theory.coe_comp, function.comp_app,
+      free_algebra.lift_symm_apply, types_comp_apply] } }
 
 end Algebra
 

--- a/src/algebra/category/Algebra/limits.lean
+++ b/src/algebra/category/Algebra/limits.lean
@@ -53,7 +53,9 @@ end
 instance limit_algebra (F : J ⥤ Algebra R) :
   algebra R (types.limit_cone (F ⋙ forget (Algebra.{v} R))).X :=
 begin
-  change algebra R (sections_subalgebra F),
+  have : algebra R (types.limit_cone (F ⋙ forget (Algebra.{v} R))).X
+    = algebra R (sections_subalgebra F), by refl,
+  rw this,
   apply_instance,
 end
 
@@ -127,7 +129,7 @@ An auxiliary declaration to speed up typechecking.
 -/
 def forget₂_Module_preserves_limits_aux (F : J ⥤ Algebra R) :
   is_limit ((forget₂ (Algebra R) (Module R)).map_cone (limit_cone F)) :=
-Module.has_limits.limit_cone_is_limit (F ⋙ forget₂ (Algebra R) (Module R))
+by convert Module.has_limits.limit_cone_is_limit (F ⋙ forget₂ (Algebra R) (Module R))
 
 /--
 The forgetful functor from R-algebras to R-modules preserves all limits.

--- a/src/algebra/category/CommRing/limits.lean
+++ b/src/algebra/category/CommRing/limits.lean
@@ -144,6 +144,20 @@ instance limit_comm_semiring (F : J ⥤ CommSemiRing) :
 @subsemiring.to_comm_semiring (Π j, F.obj j) _
   (SemiRing.sections_subsemiring (F ⋙ forget₂ CommSemiRing SemiRing.{u}))
 
+/-- Auxiliary construction for the `creates_limit` instance below. -/
+def lifted_cone (F : J ⥤ CommSemiRing) : cone F :=
+{ X := CommSemiRing.of (types.limit_cone (F ⋙ forget _)).X,
+  π :=
+  { app := SemiRing.limit_π_ring_hom (F ⋙ forget₂ CommSemiRing SemiRing),
+    naturality' := (SemiRing.has_limits.limit_cone (F ⋙ forget₂ _ _)).π.naturality, } }
+
+/-- Auxiliary construction for the `creates_limit` instance below. -/
+def is_limit_lifted_cone (F : J ⥤ CommSemiRing) : is_limit (lifted_cone F) :=
+is_limit.of_faithful (forget₂ CommSemiRing SemiRing.{u})
+  (SemiRing.has_limits.limit_cone_is_limit _)
+  (λ s, (SemiRing.has_limits.limit_cone_is_limit _).lift ((forget₂ _ SemiRing).map_cone s))
+  (λ s, rfl)
+
 /--
 We show that the forgetful functor `CommSemiRing ⥤ SemiRing` creates limits.
 
@@ -152,15 +166,9 @@ and then reuse the existing limit.
 -/
 instance (F : J ⥤ CommSemiRing) : creates_limit F (forget₂ CommSemiRing SemiRing.{u}) :=
 creates_limit_of_reflects_iso (λ c' t,
-{ lifted_cone :=
-  { X := CommSemiRing.of (types.limit_cone (F ⋙ forget _)).X,
-    π :=
-    { app := SemiRing.limit_π_ring_hom (F ⋙ forget₂ CommSemiRing SemiRing),
-      naturality' := (SemiRing.has_limits.limit_cone (F ⋙ forget₂ _ _)).π.naturality, } },
+{ lifted_cone := lifted_cone F,
   valid_lift := is_limit.unique_up_to_iso (SemiRing.has_limits.limit_cone_is_limit _) t,
-  makes_limit := is_limit.of_faithful (forget₂ CommSemiRing SemiRing.{u})
-    (SemiRing.has_limits.limit_cone_is_limit _)
-    (λ s, _) (λ s, rfl) })
+  makes_limit := is_limit_lifted_cone F, })
 
 /--
 A choice of limit cone for a functor into `CommSemiRing`.
@@ -308,6 +316,20 @@ instance limit_comm_ring (F : J ⥤ CommRing) :
 @subring.to_comm_ring (Π j, F.obj j) _
   (Ring.sections_subring (F ⋙ forget₂ CommRing Ring.{u}))
 
+/-- Auxiliary construction for the `creates_limit` instance below. -/
+def lifted_cone (F : J ⥤ CommRing) : cone F :=
+{ X := CommRing.of (types.limit_cone (F ⋙ forget _)).X,
+  π :=
+  { app := SemiRing.limit_π_ring_hom (F ⋙ forget₂ CommRing Ring.{u} ⋙ forget₂ Ring SemiRing),
+    naturality' := (SemiRing.has_limits.limit_cone
+      (F ⋙ forget₂ _ Ring.{u} ⋙ forget₂ _ SemiRing)).π.naturality } }
+
+/-- Auxiliary construction for the `creates_limit` instance below. -/
+def is_limit_lifted_cone (F : J ⥤ CommRing) : is_limit (lifted_cone F) :=
+is_limit.of_faithful (forget₂ _ Ring.{u}) (Ring.limit_cone_is_limit _)
+  (λ s, (Ring.limit_cone_is_limit _).lift ((forget₂ _ Ring.{u}).map_cone s))
+  (λ s, rfl)
+
 /--
 We show that the forgetful functor `CommRing ⥤ Ring` creates limits.
 
@@ -323,15 +345,9 @@ creates_limit_of_fully_faithful_of_iso (CommRing.of (limit (F ⋙ forget _))) (i
 but it seems this would introduce additional identity morphisms in `limit.π`.
 -/
 creates_limit_of_reflects_iso (λ c' t,
-{ lifted_cone :=
-  { X := CommRing.of (types.limit_cone (F ⋙ forget _)).X,
-    π :=
-    { app := SemiRing.limit_π_ring_hom (F ⋙ forget₂ CommRing Ring.{u} ⋙ forget₂ Ring SemiRing),
-      naturality' := (SemiRing.has_limits.limit_cone
-        (F ⋙ forget₂ _ _ ⋙ forget₂ _ _)).π.naturality } },
+{ lifted_cone := lifted_cone F,
   valid_lift := is_limit.unique_up_to_iso (Ring.limit_cone_is_limit _) t,
-  makes_limit := is_limit.of_faithful (forget₂ CommRing Ring.{u}) (Ring.limit_cone_is_limit _)
-    (λ s, _) (λ s, rfl) })
+  makes_limit := is_limit_lifted_cone F, })
 
 /--
 A choice of limit cone for a functor into `CommRing`.

--- a/src/algebra/category/Group/colimits.lean
+++ b/src/algebra/category/Group/colimits.lean
@@ -303,7 +303,20 @@ agrees with the usual group-theoretical quotient.
 noncomputable def cokernel_iso_quotient {G H : AddCommGroup} (f : G ⟶ H) :
   cokernel f ≅ AddCommGroup.of (quotient (add_monoid_hom.range f)) :=
 { hom := cokernel.desc f (mk' _)
-    (by { ext, apply quotient.sound, fsplit, exact -x, simp, }),
-  inv := add_monoid_hom.of (quotient_add_group.lift _ (cokernel.π f) (by tidy)), }
+    (by { ext, apply quotient.sound, fsplit, exact -x,
+          simp only [add_zero, add_monoid_hom.map_neg], }),
+  inv := add_monoid_hom.of (quotient_add_group.lift _ (cokernel.π f)
+    (by { intros x H_1, cases H_1, induction H_1_h,
+          simp only [cokernel.condition_apply, zero_apply]})),
+  -- obviously can take care of the next goals, but it is really slow
+  hom_inv_id' := begin
+    ext1, simp only [coequalizer_as_cokernel, category.comp_id, cokernel.π_desc_assoc], ext1, refl,
+  end,
+  inv_hom_id' := begin
+    ext1, induction x,
+    { simp only [colimit.ι_desc_apply, coe_id, add_monoid_hom.coe_of, lift_quot_mk,
+                 cofork.of_π_ι_app, coe_comp], refl },
+    { refl }
+  end, }
 
 end AddCommGroup

--- a/src/analysis/normed_space/hahn_banach.lean
+++ b/src/analysis/normed_space/hahn_banach.lean
@@ -75,6 +75,8 @@ open is_R_or_C
 
 variables {𝕜 : Type*} [is_R_or_C 𝕜] {F : Type*} [normed_group F] [normed_space 𝕜 F]
 
+set_option profiler true
+
 /-- Hahn-Banach theorem for continuous linear functions over `𝕜` satisyfing `is_R_or_C 𝕜`. -/
 theorem exists_extension_norm_eq (p : subspace 𝕜 F) (f : p →L[𝕜] 𝕜) :
   ∃ g : F →L[𝕜] 𝕜, (∀ x : p, g x = f x) ∧ ∥g∥ = ∥f∥ :=
@@ -84,7 +86,7 @@ begin
   letI : normed_space ℝ F := normed_space.restrict_scalars _ 𝕜 _,
   -- Let `fr: p →L[ℝ] ℝ` be the real part of `f`.
   let fr := re_clm.comp (f.restrict_scalars ℝ),
-  have fr_apply : ∀ x, fr x = re (f x) := λ x, rfl,
+  have fr_apply : ∀ x, fr x = re (f x), by { assume x, refl },
   -- Use the real version to get a norm-preserving extension of `fr`, which
   -- we'll call `g : F →L[ℝ] ℝ`.
   rcases real.exists_extension_norm_eq (p.restrict_scalars ℝ) fr with ⟨g, ⟨hextends, hnormeq⟩⟩,
@@ -94,7 +96,9 @@ begin
   have h : ∀ x : p, g.extend_to_𝕜 x = f x,
   { assume x,
     rw [continuous_linear_map.extend_to_𝕜_apply, ←submodule.coe_smul, hextends, hextends],
-    change (re (f x) : 𝕜) - (I : 𝕜) * (re (f ((I : 𝕜) • x))) = f x,
+    have : (fr x : 𝕜) - I * ↑(fr (I • x)) = (re (f x) : 𝕜) - (I : 𝕜) * (re (f ((I : 𝕜) • x))),
+      by refl,
+    rw this,
     apply ext,
     { simp only [add_zero, algebra.id.smul_eq_mul, I_re, of_real_im, add_monoid_hom.map_add,
         zero_sub, I_im', zero_mul, of_real_re, eq_self_iff_true, sub_zero, mul_neg_eq_neg_mul_symm,

--- a/src/analysis/normed_space/hahn_banach.lean
+++ b/src/analysis/normed_space/hahn_banach.lean
@@ -75,8 +75,6 @@ open is_R_or_C
 
 variables {𝕜 : Type*} [is_R_or_C 𝕜] {F : Type*} [normed_group F] [normed_space 𝕜 F]
 
-set_option profiler true
-
 /-- Hahn-Banach theorem for continuous linear functions over `𝕜` satisyfing `is_R_or_C 𝕜`. -/
 theorem exists_extension_norm_eq (p : subspace 𝕜 F) (f : p →L[𝕜] 𝕜) :
   ∃ g : F →L[𝕜] 𝕜, (∀ x : p, g x = f x) ∧ ∥g∥ = ∥f∥ :=

--- a/src/category_theory/monoidal/internal/Module.lean
+++ b/src/category_theory/monoidal/internal/Module.lean
@@ -135,8 +135,12 @@ def Mon_Module_equivalence_Algebra : Mon_ (Module.{u} R) ≌ Algebra R :=
   inverse := inverse,
   unit_iso := nat_iso.of_components
     (λ A,
-    { hom := { hom := { to_fun := id, map_add' := λ x y, rfl, map_smul' := λ r a, rfl, } },
-      inv := { hom := { to_fun := id, map_add' := λ x y, rfl, map_smul' := λ r a, rfl, } } })
+    { hom := { hom := { to_fun := id, map_add' := λ x y, rfl, map_smul' := λ r a, rfl, },
+               mul_hom' := by { ext, dsimp at *,
+                                simp only [algebra.lmul'_apply, Mon_.X.ring_mul] } },
+      inv := { hom := { to_fun := id, map_add' := λ x y, rfl, map_smul' := λ r a, rfl, },
+               mul_hom' := by { ext, dsimp at *,
+                                simp only [algebra.lmul'_apply, Mon_.X.ring_mul]} } })
     (by tidy),
   counit_iso := nat_iso.of_components (λ A,
   { hom :=

--- a/src/data/mv_polynomial/equiv.lean
+++ b/src/data/mv_polynomial/equiv.lean
@@ -252,10 +252,10 @@ def sum_alg_equiv : mv_polynomial (S₁ ⊕ S₂) R ≃ₐ[R]
   mv_polynomial S₁ (mv_polynomial S₂ R) :=
 { commutes' := begin
     intro r,
-    change algebra_map R (mv_polynomial S₁ (mv_polynomial S₂ R)) r with C (C r),
-    change algebra_map R (mv_polynomial (S₁ ⊕ S₂) R) r with C r,
+    have A : algebra_map R (mv_polynomial S₁ (mv_polynomial S₂ R)) r = (C (C r) : _), by refl,
+    have B : algebra_map R (mv_polynomial (S₁ ⊕ S₂) R) r = C r, by refl,
     simp only [sum_ring_equiv, sum_to_iter_C, mv_polynomial_equiv_mv_polynomial_apply,
-      ring_equiv.to_fun_eq_coe],
+      ring_equiv.to_fun_eq_coe, A, B],
   end,
   ..sum_ring_equiv R S₁ S₂ }
 

--- a/src/linear_algebra/char_poly/coeff.lean
+++ b/src/linear_algebra/char_poly/coeff.lean
@@ -193,9 +193,9 @@ begin
     apply mat_poly_equiv.injective, swap, { apply_instance },
     rw [← mat_poly_equiv.coe_alg_hom, alg_hom.map_pow, mat_poly_equiv.coe_alg_hom,
           mat_poly_equiv_char_matrix, hk, sub_pow_char_pow_of_commute, ← C_pow],
-    { exact mat_poly_equiv_eq_X_pow_sub_C (p ^ k) M },
+    { exact (id (mat_poly_equiv_eq_X_pow_sub_C (p ^ k) M) : _) },
     { exact (C M).commute_X } },
-  { congr, apply @subsingleton.elim _ (subsingleton_of_empty_left hn) _ _, },
+  { apply congr_arg, apply @subsingleton.elim _ (subsingleton_of_empty_left hn) _ _, },
 end
 
 @[simp] lemma zmod.char_poly_pow_card (M : matrix n n (zmod p)) :

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -396,9 +396,8 @@ lemma generalized_eigenspace_restrict
 begin
   rw [generalized_eigenspace, generalized_eigenspace, ←linear_map.ker_comp],
   induction k with k ih,
-  { rw [pow_zero,pow_zero],
-    convert linear_map.ker_id,
-    apply submodule.ker_subtype },
+  { rw [pow_zero, pow_zero, linear_map.one_eq_id],
+    apply (submodule.ker_subtype _).symm },
   { erw [pow_succ', pow_succ', linear_map.ker_comp,
       ih, ←linear_map.ker_comp, linear_map.comp_assoc], }
 end

--- a/src/linear_algebra/exterior_algebra.lean
+++ b/src/linear_algebra/exterior_algebra.lean
@@ -45,8 +45,10 @@ The exterior algebra of `M` is constructed as a quotient of the tensor algebra, 
 
 -/
 
-variables (R : Type*) [comm_semiring R]
-variables (M : Type*) [add_comm_monoid M] [semimodule R M]
+universes u1 u2 u3
+
+variables (R : Type u1) [comm_semiring R]
+variables (M : Type u2) [add_comm_monoid M] [semimodule R M]
 
 namespace exterior_algebra
 open tensor_algebra
@@ -70,10 +72,8 @@ namespace exterior_algebra
 
 variables {M}
 
--- typeclass resolution times out here, so we give it a hand
-instance {S : Type*} [comm_ring S] [semimodule S M] : ring (exterior_algebra S M) :=
-let i : ring (tensor_algebra S M) := infer_instance in
-@ring_quot.ring (tensor_algebra S M) i (exterior_algebra.rel S M)
+instance {S : Type u3} [comm_ring S] [semimodule S M] : ring (exterior_algebra S M) :=
+ring_quot.ring (exterior_algebra.rel S M)
 
 /--
 The canonical linear map `M →ₗ[R] exterior_algebra R M`.

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -308,6 +308,8 @@ begin
     exact ring_hom.ker_coe_equiv (equiv.symm.to_ring_equiv), }
 end
 
+set_option profiler true
+
 /-- If `A` is a finitely presented `R`-algebra, then `mv_polynomial (fin n) A` is finitely presented
 as `R`-algebra. -/
 lemma mv_polynomial_of_finite_presentation (hfp : finite_presentation R A) (ι : Type*)
@@ -330,7 +332,8 @@ begin
   refine equiv _ ((@mv_polynomial.quotient_equiv_quotient_mv_polynomial
     _ (fin n) _ I).restrict_scalars R).symm,
   refine quotient (submodule.map_fg_of_fg I hfg _) _,
-  refine equiv _ (mv_polynomial.sum_alg_equiv _ _ _),
+  let := mv_polynomial.sum_alg_equiv R (fin n) (fin m),
+  refine equiv _ this,
   exact equiv (mv_polynomial R (fin (n + m))) (mv_polynomial.rename_equiv R fin_sum_fin_equiv).symm
 end
 

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -308,8 +308,6 @@ begin
     exact ring_hom.ker_coe_equiv (equiv.symm.to_ring_equiv), }
 end
 
-set_option profiler true
-
 /-- If `A` is a finitely presented `R`-algebra, then `mv_polynomial (fin n) A` is finitely presented
 as `R`-algebra. -/
 lemma mv_polynomial_of_finite_presentation (hfp : finite_presentation R A) (ι : Type*)

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -527,7 +527,8 @@ from hs ▸ λ x hx, submodule.span_induction hx (λ _ hx, ideal.subset_span hx)
 ⟨s, le_antisymm
   (ideal.span_le.2 $ λ x hx, have x ∈ I.degree_le N, from hs ▸ submodule.subset_span hx, this.2) $
 begin
-  change I ≤ ideal.span ↑s,
+  have : submodule.span (polynomial R) ↑s = ideal.span ↑s, by refl,
+  rw this,
   intros p hp, generalize hn : p.nat_degree = k,
   induction k using nat.strong_induction_on with k ih generalizing p,
   cases le_or_lt k N,

--- a/src/ring_theory/witt_vector/structure_polynomial.lean
+++ b/src/ring_theory/witt_vector/structure_polynomial.lean
@@ -160,8 +160,8 @@ begin
   have := X_in_terms_of_W_aux p ℚ n,
   replace := congr_arg (bind₁ (λ k : ℕ, bind₁ (λ i, rename (prod.mk i) (W_ ℚ k)) Φ)) this,
   rw [alg_hom.map_mul, bind₁_C_right] at this,
-  convert this using 1, clear this,
-  conv_rhs { simp only [alg_hom.map_sub, bind₁_X_right] },
+  rw [witt_structure_rat, this], clear this,
+  conv_lhs { simp only [alg_hom.map_sub, bind₁_X_right] },
   rw sub_right_inj,
   simp only [alg_hom.map_sum, alg_hom.map_mul, bind₁_C_right, alg_hom.map_pow],
   refl


### PR DESCRIPTION
Some proofs using heavy `rfl` or heavy `obviously` can be sped up considerably. Done in this PR for some outstanding examples.

---

Cherry-picked from #7084, in which all the original proofs fixed in this PR timed out because of the added complexity to the definition of `monoid`s and `add_monoid`s. I don't know how long #7084 will take to get merged (or if it will ever get merged), but these seem good to have anyway, as shaving a few minutes from every mathlib compilations can only help.
