### PR TITLE
[Merged by Bors] - feat(category_theory/triangulated/pretriangulated): add definition of pretriangulated categories and triangulated functors between them 

### DIFF
--- a/src/category_theory/preadditive/additive_functor.lean
+++ b/src/category_theory/preadditive/additive_functor.lean
@@ -137,6 +137,17 @@ def map_biproduct {J : Type v} [fintype J] [decidable_eq J] (f : J → C) [has_b
 end
 
 end functor
+
+namespace equivalence
+
+variables {C D : Type*} [category C] [category D] [preadditive C] [preadditive D]
+
+instance inverse_additive (e : C ≌ D) [e.functor.additive] : e.inverse.additive :=
+{ map_zero' := λ X Y, by { apply e.functor.map_injective, simp, },
+  map_add' := λ X Y f g, by { apply e.functor.map_injective, simp, }, }
+
+end equivalence
+
 end preadditive
 
 end category_theory

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -28,7 +28,7 @@ namespace category_theory.triangulated
 open category_theory.category
 
 /-
-We work in an additive category C equipped with an additive shift.
+We work in an additive category `C` equipped with an additive shift.
 -/
 variables (C : Type u) [category.{v} C] [additive_category C]
 
@@ -39,8 +39,8 @@ categories are additive functors
 -/
 
 /--
-A triangle in C is a sextuple (X,Y,Z,f,g,h) where X,Y,Z are objects of C,
-and f : X ⟶ Y, g : Y ⟶ Z, h : Z ⟶ X⟦1⟧ are morphisms in C.
+A triangle in `C` is a sextuple `(X,Y,Z,f,g,h)` where `X,Y,Z` are objects of `C`,
+and `f : X ⟶ Y`, `g : Y ⟶ Z`, `h : Z ⟶ X⟦1⟧` are morphisms in `C`.
 See https://stacks.math.columbia.edu/tag/0144.
 -/
 structure triangle :=
@@ -56,8 +56,9 @@ instance [has_zero_object C] : inhabited (triangle C) :=
 ⟨⟨0,0,0,0,0,0⟩⟩
 
 /--
-For each object in C, there is a triangle of the form (X,X,0,𝟙_X,0,0)
+For each object in `C`, there is a triangle of the form `(X,X,0,𝟙_X,0,0)`
 -/
+@[simps]
 def contractible_triangle (X : C) : triangle C :=
 { obj₁ := X,
   obj₂ := X,
@@ -75,11 +76,11 @@ A morphism of triangles `(X,Y,Z,f,g,h) ⟶ (X',Y',Z',f',g',h')` in `C` is a trip
 In other words, we have a commutative diagram:
 ```
      f      g      h
-  X  --> Y  --> Z  --> X⟦1⟧
-  |      |      |       |
-  |a     |b     |c      |a⟦1⟧'
-  V      V      V       V
-  X' --> Y' --> Z' --> X'⟦1⟧
+  X  ───> Y  ───> Z  ───> X⟦1⟧
+  │       │       │        │
+  │a      │b      │c       │a⟦1⟧'
+  V       V       V        V
+  X' ───> Y' ───> Z' ───> X'⟦1⟧
      f'     g'     h'
 ```
 See https://stacks.math.columbia.edu/tag/0144.

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -28,13 +28,9 @@ namespace category_theory.triangulated
 open category_theory.category
 
 /-
-We work in an additive category `C` equipped with an additive shift.
+We work in a category `C` equipped with a shift.
 -/
-variables (C : Type u) [category.{v} C] [has_zero_object C] [has_zero_morphisms C] [has_shift C]
-/-
-Eventually can remove conditions on shift functor and inverse, as all equivalences of additive
-categories are additive functors
--/
+variables (C : Type u) [category.{v} C] [has_shift C]
 
 /--
 A triangle in `C` is a sextuple `(X,Y,Z,f,g,h)` where `X,Y,Z` are objects of `C`,
@@ -49,10 +45,6 @@ structure triangle := mk' ::
 (mor₂ : obj₂ ⟶ obj₃)
 (mor₃ : obj₃ ⟶ obj₁⟦1⟧)
 
-local attribute [instance] has_zero_object.has_zero
-instance [has_zero_object C] : inhabited (triangle C) :=
-⟨⟨0,0,0,0,0,0⟩⟩
-
 /--
 A triangle `(X,Y,Z,f,g,h)` in `C` is defined by the morphisms `f : X ⟶ Y`, `g : Y ⟶ Z`
 and `h : Z ⟶ X⟦1⟧`.
@@ -66,11 +58,20 @@ def triangle.mk {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (h : Z ⟶ X⟦1⟧) : t
   mor₂ := g,
   mor₃ := h }
 
+section
+variables [has_zero_object C] [has_zero_morphisms C]
+
+local attribute [instance] has_zero_object.has_zero
+instance [has_zero_object C] : inhabited (triangle C) :=
+⟨⟨0,0,0,0,0,0⟩⟩
+
 /--
 For each object in `C`, there is a triangle of the form `(X,X,0,𝟙 X,0,0)`
 -/
 @[simps]
 def contractible_triangle (X : C) : triangle C := triangle.mk C (𝟙 X) (0 : X ⟶ 0) 0
+
+end
 
 variable {C}
 

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -60,9 +60,9 @@ def triangle.mk {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (h : Z ⟶ X⟦1⟧) : t
 
 section
 variables [has_zero_object C] [has_zero_morphisms C]
-
 local attribute [instance] has_zero_object.has_zero
-instance [has_zero_object C] : inhabited (triangle C) :=
+
+instance : inhabited (triangle C) :=
 ⟨⟨0,0,0,0,0,0⟩⟩
 
 /--

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -30,8 +30,7 @@ open category_theory.category
 /-
 We work in an additive category `C` equipped with an additive shift.
 -/
-variables (C : Type u) [category.{v} C] [additive_category C]
-  [has_shift C] [functor.additive (shift C).functor] [functor.additive (shift C).inverse]
+variables (C : Type u) [category.{v} C] [has_zero_object C] [has_zero_morphisms C] [has_shift C]
 /-
 Eventually can remove conditions on shift functor and inverse, as all equivalences of additive
 categories are additive functors

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -31,7 +31,6 @@ open category_theory.category
 We work in an additive category `C` equipped with an additive shift.
 -/
 variables (C : Type u) [category.{v} C] [additive_category C]
-
   [has_shift C] [functor.additive (shift C).functor] [functor.additive (shift C).inverse]
 /-
 Eventually can remove conditions on shift functor and inverse, as all equivalences of additive
@@ -43,7 +42,7 @@ A triangle in `C` is a sextuple `(X,Y,Z,f,g,h)` where `X,Y,Z` are objects of `C`
 and `f : X ⟶ Y`, `g : Y ⟶ Z`, `h : Z ⟶ X⟦1⟧` are morphisms in `C`.
 See https://stacks.math.columbia.edu/tag/0144.
 -/
-structure triangle :=
+structure triangle := mk' ::
 (obj₁ : C)
 (obj₂ : C)
 (obj₃ : C)
@@ -56,16 +55,23 @@ instance [has_zero_object C] : inhabited (triangle C) :=
 ⟨⟨0,0,0,0,0,0⟩⟩
 
 /--
-For each object in `C`, there is a triangle of the form `(X,X,0,𝟙_X,0,0)`
+A triangle `(X,Y,Z,f,g,h)` in `C` is defined by the morphisms `f : X ⟶ Y`, `g : Y ⟶ Z`
+and `h : Z ⟶ X⟦1⟧`.
 -/
 @[simps]
-def contractible_triangle (X : C) : triangle C :=
+def triangle.mk {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (h : Z ⟶ X⟦1⟧) : triangle C :=
 { obj₁ := X,
-  obj₂ := X,
-  obj₃ := 0,
-  mor₁ := 𝟙 X,
-  mor₂ := 0,
-  mor₃ := 0 }
+  obj₂ := Y,
+  obj₃ := Z,
+  mor₁ := f,
+  mor₂ := g,
+  mor₃ := h }
+
+/--
+For each object in `C`, there is a triangle of the form `(X,X,0,𝟙 X,0,0)`
+-/
+@[simps]
+def contractible_triangle (X : C) : triangle C := triangle.mk C (𝟙 X) (0 : X ⟶ 0) 0
 
 variable {C}
 

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -207,7 +207,7 @@ triangle.mk _ (F.map T.mor₁) (F.map T.mor₂) (F.map T.mor₃ ≫ F.comm_shift
 Given a `triangulated_functor` and a distinguished triangle `T` of `C`, then the triangle it
 maps onto in `D` is also distinguished.
 -/
-def triangulated_functor.map_distinguished (F : triangulated_functor C D) (T : triangle C)
+lemma triangulated_functor.map_distinguished (F : triangulated_functor C D) (T : triangle C)
   (h : T ∈ dist_triang C) : (F.map_triangle T) ∈ dist_triang D := F.map_distinguished' T h
 
 

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -150,17 +150,16 @@ variables (D : Type u₂) [category.{v₂} D] [has_shift D] [additive_category D
 [functor.additive (shift D).functor] [functor.additive (shift D).inverse]
 
 /--
-A triangulated functor between pretriangulated categories `C` and `D` is a functor `F : C ⥤ D`
-together with given functorial isomorphisms `ξ X : F(X⟦1⟧) ⟶ F(X)⟦1⟧` with extra conditions
-involving images of triangles.
+The underlying structure of a triangulated functor between pretriangulated categories `C` and `D`
+is a functor `F : C ⥤ D` together with given functorial isomorphisms `ξ X : F(X⟦1⟧) ⟶ F(X)⟦1⟧`.
 -/
 structure triangulated_functor_struct extends (C ⥤ D) :=
-(nat_iso : (shift C).functor ⋙ to_functor ≅ to_functor ⋙ (shift D).functor)
+(comm_shift : (shift C).functor ⋙ to_functor ≅ to_functor ⋙ (shift D).functor)
 
 instance : inhabited (triangulated_functor_struct C C) :=
 ⟨{ obj := λ X, X,
   map := λ _ _ f, f,
-  nat_iso := by refl }⟩
+  comm_shift := by refl }⟩
 
 variables {C D}
 /--
@@ -170,12 +169,7 @@ triangles of `D`.
 @[simp]
 def triangulated_functor_struct.map_triangle (F : triangulated_functor_struct C D)
   (T : triangle C) : triangle D :=
-{ obj₁ := F.obj T.obj₁,
-  obj₂ := F.obj T.obj₂,
-  obj₃ := F.obj T.obj₃,
-  mor₁ := F.map T.mor₁,
-  mor₂ := F.map T.mor₂,
-  mor₃ := F.map T.mor₃ ≫ F.nat_iso.hom.app T.obj₁ }
+triangle.mk _ (F.map T.mor₁) (F.map T.mor₂) (F.map T.mor₃ ≫ F.comm_shift.hom.app T.obj₁)
 
 variables (C D)
 /--
@@ -187,18 +181,35 @@ See https://stacks.math.columbia.edu/tag/014V
 -/
 structure triangulated_functor [pretriangulated C] [pretriangulated D] extends
   triangulated_functor_struct C D :=
-(map_distinguished : Π (T: triangle C), (T ∈ dist_triang C) →
+(map_distinguished' : Π (T: triangle C), (T ∈ dist_triang C) →
   (to_triangulated_functor_struct.map_triangle T ∈ dist_triang D) )
 
 instance [pretriangulated C] : inhabited (triangulated_functor C C) :=
 ⟨{obj := λ X, X,
   map := λ _ _ f, f,
-  nat_iso := by refl ,
-  map_distinguished := begin
+  comm_shift := by refl ,
+  map_distinguished' := begin
     rintros ⟨_,_,_,_⟩ Tdt,
     dsimp at *,
     rwa category.comp_id,
   end }⟩
+
+variables {C D} [pretriangulated C] [pretriangulated D]
+/--
+Given a `triangulated_functor` we can define a function from triangles of `C` to triangles of `D`.
+-/
+@[simp]
+def triangulated_functor.map_triangle (F : triangulated_functor C D) (T : triangle C) :
+  triangle D :=
+triangle.mk _ (F.map T.mor₁) (F.map T.mor₂) (F.map T.mor₃ ≫ F.comm_shift.hom.app T.obj₁)
+
+/--
+Given a `triangulated_functor` and a distinguished triangle `T` of `C`, then the triangle it
+maps onto in `D` is also distinguished.
+-/
+def triangulated_functor.map_distinguished (F : triangulated_functor C D) (T : triangle C)
+  (h : T ∈ dist_triang C) : (F.map_triangle T) ∈ dist_triang D := F.map_distinguished' T h
+
 
 end pretriangulated
 end category_theory.triangulated

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -12,7 +12,8 @@ import category_theory.triangulated.rotate
 /-!
 # Pre-triangulated Categories
 
-This file contains the definition of pre-triangulated categories and triangulated functors between them.
+This file contains the definition of pre-triangulated categories and triangulated functors
+between them.
 
 TODO: generalise this to n-angulated categories as in https://arxiv.org/abs/1006.4592
 -/
@@ -115,7 +116,7 @@ end -- TODO : tidy this proof up
 Given any distinguished triangle
 ```
       f       g       h
-  X  ---> Y  ---> Z  ---> X⟦1⟧
+  X  ───> Y  ───> Z  ───> X⟦1⟧
 ```
 the composition `g ≫ h = 0`.
 See https://stacks.math.columbia.edu/tag/0146
@@ -131,7 +132,7 @@ end
 Given any distinguished triangle
 ```
       f       g       h
-  X  ---> Y  ---> Z  ---> X⟦1⟧
+  X  ───> Y  ───> Z  ───> X⟦1⟧
 ```
 the composition `h ≫ f⟦1⟧ = 0`.
 See https://stacks.math.columbia.edu/tag/0146

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -22,6 +22,7 @@ noncomputable theory
 
 open category_theory
 open category_theory.preadditive
+open category_theory.limits
 
 universes v v₀ v₁ v₂ u u₀ u₁ u₂
 
@@ -31,7 +32,7 @@ open category_theory.category
 /-
 We work in an additive category `C` equipped with an additive shift.
 -/
-variables (C : Type u) [category.{v} C] [has_shift C] [additive_category C]
+variables (C : Type u) [category.{v} C] [has_zero_object C] [has_shift C] [preadditive C]
 [functor.additive (shift C).functor] [functor.additive (shift C).inverse]
 
 /--
@@ -144,9 +145,9 @@ end category_theory.triangulated
 namespace category_theory.triangulated
 namespace pretriangulated
 
-variables (C : Type u₁) [category.{v₁} C] [has_shift C] [additive_category C]
+variables (C : Type u₁) [category.{v₁} C] [has_zero_object C] [has_shift C] [preadditive C]
 [functor.additive (shift C).functor] [functor.additive (shift C).inverse]
-variables (D : Type u₂) [category.{v₂} D] [has_shift D] [additive_category D]
+variables (D : Type u₂) [category.{v₂} D] [has_zero_object D] [has_shift D] [preadditive D]
 [functor.additive (shift D).functor] [functor.additive (shift D).inverse]
 
 /--

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -39,10 +39,10 @@ An additive category `C` with an additive shift, and a class of "distinguished t
 relative to that shift is called pretriangulated if the following hold:
 * Any triangle that is isomorphic to a distinguished triangle is also distinguished.
 * Any triangle of the form `(X,X,0,id,0,0)` is distinguished.
-* For any morphism `f: X ⟶ Y` there exists a distinguished triangle of the form `(X,Y,Z,f,g,h)`.
+* For any morphism `f : X ⟶ Y` there exists a distinguished triangle of the form `(X,Y,Z,f,g,h)`.
 * The triangle `(X,Y,Z,f,g,h)` is distinguished if and only if `(Y,Z,X⟦1⟧,g,h,-f⟦1⟧)` is.
-* Given a commutative diagram:
-```
+* Given a diagram:
+  ```
         f       g       h
     X  ───> Y  ───> Z  ───> X⟦1⟧
     │       │                │
@@ -50,41 +50,41 @@ relative to that shift is called pretriangulated if the following hold:
     V       V                V
     X' ───> Y' ───> Z' ───> X'⟦1⟧
         f'      g'      h'
-```
-  whose rows are distinguished triangles, there exists a morphism `c: Z ⟶ Z'` such that `(a,b,c)`
-  is a triangle morphism.
+  ```
+  where the left square commutes, and whose rows are distinguished triangles,
+  there exists a morphism `c : Z ⟶ Z'` such that `(a,b,c)` is a triangle morphism.
 See https://stacks.math.columbia.edu/tag/0145
 -/
 class pretriangulated :=
-(distinguished_triangles : set(triangle C))
+(distinguished_triangles [] : set (triangle C))
 (isomorphic_distinguished : Π (T₁ ∈ distinguished_triangles) (T₂ : triangle C) (T₁ ≅ T₂),
   T₂ ∈ distinguished_triangles)
 (contractible_distinguished : Π (X : C), (contractible_triangle C X) ∈ distinguished_triangles)
-(distinguished_cocone_triangle : Π (X:C) (Y:C) (f: X ⟶ Y), (∃ (Z : C) (g : Y ⟶ Z) (h : Z ⟶ X⟦1⟧),
-  ({ obj₁ := X, obj₂ := Y, obj₃ := Z, mor₁ := f, mor₂ := g, mor₃ := h} : triangle C) ∈
-    distinguished_triangles))
+(distinguished_cocone_triangle : Π (X Y : C) (f: X ⟶ Y), (∃ (Z : C) (g : Y ⟶ Z) (h : Z ⟶ X⟦1⟧),
+  triangle.mk _ f g h ∈ distinguished_triangles))
 (rotate_distinguished_triangle : Π (T : triangle C),
-  T ∈ distinguished_triangles ↔ T.rotate C ∈ distinguished_triangles)
+  T ∈ distinguished_triangles ↔ T.rotate ∈ distinguished_triangles)
 (complete_distinguished_triangle_morphism : Π (T₁ T₂ : triangle C)
-  (h₁ :T₁ ∈ distinguished_triangles) (h₂ :T₂ ∈ distinguished_triangles) (a : T₁.obj₁ ⟶ T₂.obj₁)
+  (h₁ : T₁ ∈ distinguished_triangles) (h₂ : T₂ ∈ distinguished_triangles) (a : T₁.obj₁ ⟶ T₂.obj₁)
   (b : T₁.obj₂ ⟶ T₂.obj₂) (comm₁ : T₁.mor₁ ≫ b = a ≫ T₂.mor₁),
   (∃ (c : T₁.obj₃ ⟶ T₂.obj₃), (T₁.mor₂ ≫ c = b ≫ T₂.mor₂) ∧ (T₁.mor₃ ≫ a⟦1⟧' = c ≫ T₂.mor₃) ))
 
+namespace pretriangulated
+variables [pretriangulated C]
+
+notation `dist_triang`:20 C := distinguished_triangles C
 /--
 Given any distinguished triangle `T`, then we know `T.rotate C` is also distinguished.
 -/
-lemma rot_of_dist_triangle [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
-  (T.rotate C ∈ CT.distinguished_triangles) :=
-(pretriangulated.rotate_distinguished_triangle T).mp H
+lemma rot_of_dist_triangle (T ∈ dist_triang C) : (T.rotate ∈ dist_triang C) :=
+(rotate_distinguished_triangle T).mp H
 
 /--
 Given any distinguished triangle `T`, then we know `T.inv_rotate C` is also distinguished.
 -/
-lemma inv_rot_of_dist_triangle [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
-  (T.inv_rotate C ∈ CT.distinguished_triangles) :=
-(pretriangulated.rotate_distinguished_triangle (T.inv_rotate C)).mpr
-  (pretriangulated.isomorphic_distinguished T H (triangulated.triangle.rotate C
-    (triangulated.triangle.inv_rotate C T)) T ((inv_rot_comp_rot C).symm.app T))
+lemma inv_rot_of_dist_triangle (T ∈ dist_triang C) : (T.inv_rotate ∈ dist_triang C) :=
+(rotate_distinguished_triangle (T.inv_rotate)).mpr
+  (isomorphic_distinguished T H (T.inv_rotate.rotate) T (inv_rot_comp_rot.symm.app T))
 
 /--
 Given any distinguished triangle
@@ -95,18 +95,17 @@ Given any distinguished triangle
 the composition `f ≫ g = 0`.
 See https://stacks.math.columbia.edu/tag/0146
 -/
-lemma comp_dist_triangle_mor_zero₁₂ [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
-  T.mor₁ ≫ T.mor₂ = 0 :=
+lemma comp_dist_triangle_mor_zero₁₂ (T ∈ dist_triang C) : T.mor₁ ≫ T.mor₂ = 0 :=
 begin
-  have h := pretriangulated.contractible_distinguished T.obj₁,
-  have f := CT.complete_distinguished_triangle_morphism,
+  have h := contractible_distinguished T.obj₁,
+  have f := complete_distinguished_triangle_morphism,
   specialize f (contractible_triangle C T.obj₁) T h H (𝟙 T.obj₁) T.mor₁,
-  have t : (triangulated.contractible_triangle C T.obj₁).mor₁ ≫ T.mor₁ = 𝟙 T.obj₁ ≫ T.mor₁,
+  have t : (contractible_triangle C T.obj₁).mor₁ ≫ T.mor₁ = 𝟙 T.obj₁ ≫ T.mor₁,
     by refl,
   specialize f t,
   cases f with c f,
   rw ← f.left,
-  simp only [limits.zero_comp, triangulated.contractible_triangle_mor₂],
+  simp only [limits.zero_comp, contractible_triangle_mor₂],
 end -- TODO : tidy this proof up
 
 /--
@@ -118,9 +117,8 @@ Given any distinguished triangle
 the composition `g ≫ h = 0`.
 See https://stacks.math.columbia.edu/tag/0146
 -/
-lemma comp_dist_triangle_mor_zero₂₃  [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
-  T.mor₂ ≫ T.mor₃ = 0 :=
-comp_dist_triangle_mor_zero₁₂ C (triangulated.triangle.rotate C T) (rot_of_dist_triangle C T H)
+lemma comp_dist_triangle_mor_zero₂₃  (T ∈ dist_triang C) : T.mor₂ ≫ T.mor₃ = 0 :=
+comp_dist_triangle_mor_zero₁₂ C T.rotate (rot_of_dist_triangle C T H)
 
 /--
 Given any distinguished triangle
@@ -131,19 +129,20 @@ Given any distinguished triangle
 the composition `h ≫ f⟦1⟧ = 0`.
 See https://stacks.math.columbia.edu/tag/0146
 -/
-lemma comp_dist_triangle_mor_zero₃₁  [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
+lemma comp_dist_triangle_mor_zero₃₁ (T ∈ dist_triang C) :
   T.mor₃ ≫ ((shift C).functor.map T.mor₁) = 0 :=
-have H₂ : _ := rot_of_dist_triangle C (triangle.rotate C T) (rot_of_dist_triangle C T H),
-by simpa using comp_dist_triangle_mor_zero₁₂ C (triangle.rotate C (triangle.rotate C T)) H₂
+have H₂ : _ := rot_of_dist_triangle C T.rotate (rot_of_dist_triangle C T H),
+by simpa using comp_dist_triangle_mor_zero₁₂ C (T.rotate.rotate) H₂
 
 /-
 TODO: If `C` is pretriangulated with respect to a shift,
 then `Cᵒᵖ` is pretriangulated with respect to the inverse shift.
 -/
-
+end pretriangulated
 end category_theory.triangulated
 
 namespace category_theory.triangulated
+namespace pretriangulated
 
 variables (C : Type u₁) [category.{v₁} C] [has_shift C] [additive_category C]
 [functor.additive (shift C).functor] [functor.additive (shift C).inverse]
@@ -156,12 +155,12 @@ together with given functorial isomorphisms `ξ X : F(X⟦1⟧) ⟶ F(X)⟦1⟧`
 involving images of triangles.
 -/
 structure triangulated_functor_struct extends (C ⥤ D) :=
-(natural_isom : (shift C).functor ⋙ to_functor ≅ to_functor ⋙ (shift D).functor)
+(nat_iso : (shift C).functor ⋙ to_functor ≅ to_functor ⋙ (shift D).functor)
 
 instance : inhabited (triangulated_functor_struct C C) :=
 ⟨{ obj := λ X, X,
   map := λ _ _ f, f,
-  natural_isom := by refl }⟩
+  nat_iso := by refl }⟩
 
 variables {C D}
 /--
@@ -176,7 +175,7 @@ def triangulated_functor_struct.map_triangle (F : triangulated_functor_struct C 
   obj₃ := F.obj T.obj₃,
   mor₁ := F.map T.mor₁,
   mor₂ := F.map T.mor₂,
-  mor₃ := F.map T.mor₃ ≫ F.natural_isom.hom.app T.obj₁ }
+  mor₃ := F.map T.mor₃ ≫ F.nat_iso.hom.app T.obj₁ }
 
 variables (C D)
 /--
@@ -186,21 +185,19 @@ distinguished triangle `(X,Y,Z,f,g,h)` of `C`, the triangle
 `(F(X), F(Y), F(Z), F(f), F(g), F(h) ≫ (ξ X))` is a distinguished triangle of `D`.
 See https://stacks.math.columbia.edu/tag/014V
 -/
-structure triangulated_functor [CT : pretriangulated C] [DT : pretriangulated D] :=
-(F : triangulated_functor_struct C D)
-(map_distinguished : Π (T: triangle C), (T ∈ CT.distinguished_triangles) →
-  (F.map_triangle T ∈ DT.distinguished_triangles) )
+structure triangulated_functor [pretriangulated C] [pretriangulated D] extends triangulated_functor_struct C D :=
+(map_distinguished : Π (T: triangle C), (T ∈ dist_triang C) →
+  (to_triangulated_functor_struct.map_triangle T ∈ dist_triang D) )
 
-instance [CT : pretriangulated C] : inhabited (triangulated_functor C C) :=
-⟨{ F:= {obj := λ X, X,
+instance [pretriangulated C] : inhabited (triangulated_functor C C) :=
+⟨{obj := λ X, X,
   map := λ _ _ f, f,
-  natural_isom := by refl },
+  nat_iso := by refl ,
   map_distinguished := begin
     rintros ⟨_,_,_,_⟩ Tdt,
     dsimp at *,
     rwa category.comp_id,
-  end
-}⟩
+  end }⟩
 
-
+end pretriangulated
 end category_theory.triangulated

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -10,9 +10,9 @@ import category_theory.triangulated.basic
 import category_theory.triangulated.rotate
 
 /-!
-# Pre-triangulated Categories
+# Pretriangulated Categories
 
-This file contains the definition of pre-triangulated categories and triangulated functors
+This file contains the definition of pretriangulated categories and triangulated functors
 between them.
 
 TODO: generalise this to n-angulated categories as in https://arxiv.org/abs/1006.4592
@@ -29,7 +29,7 @@ namespace category_theory.triangulated
 open category_theory.category
 
 /-
-We work in an additive category C equipped with an additive shift.
+We work in an additive category `C` equipped with an additive shift.
 -/
 variables (C : Type u) [category.{v} C] [has_shift C] [additive_category C]
 [functor.additive (shift C).functor] [functor.additive (shift C).inverse]
@@ -75,18 +75,16 @@ Given any distinguished triangle `T`, then we know `T.rotate C` is also distingu
 -/
 lemma rot_of_dist_triangle [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
   (T.rotate C ∈ CT.distinguished_triangles) :=
-by exact (pretriangulated.rotate_distinguished_triangle T).mp H
+(pretriangulated.rotate_distinguished_triangle T).mp H
 
 /--
 Given any distinguished triangle `T`, then we know `T.inv_rotate C` is also distinguished.
 -/
 lemma inv_rot_of_dist_triangle [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
   (T.inv_rotate C ∈ CT.distinguished_triangles) :=
-begin
-  apply (pretriangulated.rotate_distinguished_triangle (T.inv_rotate C)).mpr,
-  exact pretriangulated.isomorphic_distinguished T H (triangulated.triangle.rotate C
-    (triangulated.triangle.inv_rotate C T)) T ((inv_rot_comp_rot C).symm.app T),
-end
+(pretriangulated.rotate_distinguished_triangle (T.inv_rotate C)).mpr
+  (pretriangulated.isomorphic_distinguished T H (triangulated.triangle.rotate C
+    (triangulated.triangle.inv_rotate C T)) T ((inv_rot_comp_rot C).symm.app T))
 
 /--
 Given any distinguished triangle
@@ -107,7 +105,6 @@ begin
     by refl,
   specialize f t,
   cases f with c f,
-  simp at c,
   rw ← f.left,
   simp only [limits.zero_comp, triangulated.contractible_triangle_mor₂],
 end -- TODO : tidy this proof up
@@ -149,7 +146,7 @@ end
 
 /-
 TODO: If `C` is pretriangulated with respect to a shift,
-then `C^{op}` is pretriangulated with respect to the inverse shift.
+then `Cᵒᵖ` is pretriangulated with respect to the inverse shift.
 -/
 
 end category_theory.triangulated
@@ -162,7 +159,7 @@ variables (D : Type u₂) [category.{v₂} D] [has_shift D] [additive_category D
 [functor.additive (shift D).functor] [functor.additive (shift D).inverse]
 
 /--
-A triangulated functor between pretriangulated categories C and D is a functor `F : C ⥤ D`
+A triangulated functor between pretriangulated categories `C` and `D` is a functor `F : C ⥤ D`
 together with given functorial isomorphisms `ξ X : F(X⟦1⟧) ⟶ F(X)⟦1⟧` with extra conditions
 involving images of triangles.
 -/
@@ -191,7 +188,7 @@ def triangulated_functor_struct.map_triangle (F : triangulated_functor_struct C 
 
 variables (C D)
 /--
-A triangulated functor between pretriangulated categories C and D is a functor `F : C ⥤ D`
+A triangulated functor between pretriangulated categories `C` and `D` is a functor `F : C ⥤ D`
 together with given functorial isomorphisms `ξ X : F(X⟦1⟧) ⟶ F(X)⟦1⟧` such that for every
 distinguished triangle `(X,Y,Z,f,g,h)` of `C`, the triangle
 `(F(X), F(Y), F(Z), F(f), F(g), F(h) ≫ (ξ X))` is a distinguished triangle of `D`.
@@ -210,8 +207,7 @@ instance [CT : pretriangulated C] : inhabited (triangulated_functor C C) :=
     intros T Tdt,
     cases T,
     dsimp at *,
-    rw category.comp_id,
-    assumption,
+    rwa category.comp_id,
   end
 }⟩
 

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -74,13 +74,13 @@ variables [pretriangulated C]
 
 notation `dist_triang`:20 C := distinguished_triangles C
 /--
-Given any distinguished triangle `T`, then we know `T.rotate C` is also distinguished.
+Given any distinguished triangle `T`, then we know `T.rotate` is also distinguished.
 -/
 lemma rot_of_dist_triangle (T ∈ dist_triang C) : (T.rotate ∈ dist_triang C) :=
 (rotate_distinguished_triangle T).mp H
 
 /--
-Given any distinguished triangle `T`, then we know `T.inv_rotate C` is also distinguished.
+Given any distinguished triangle `T`, then we know `T.inv_rotate` is also distinguished.
 -/
 lemma inv_rot_of_dist_triangle (T ∈ dist_triang C) : (T.inv_rotate ∈ dist_triang C) :=
 (rotate_distinguished_triangle (T.inv_rotate)).mpr
@@ -185,7 +185,8 @@ distinguished triangle `(X,Y,Z,f,g,h)` of `C`, the triangle
 `(F(X), F(Y), F(Z), F(f), F(g), F(h) ≫ (ξ X))` is a distinguished triangle of `D`.
 See https://stacks.math.columbia.edu/tag/014V
 -/
-structure triangulated_functor [pretriangulated C] [pretriangulated D] extends triangulated_functor_struct C D :=
+structure triangulated_functor [pretriangulated C] [pretriangulated D] extends
+  triangulated_functor_struct C D :=
 (map_distinguished : Π (T: triangle C), (T ∈ dist_triang C) →
   (to_triangulated_functor_struct.map_triangle T ∈ dist_triang D) )
 

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2021 Luke Kershaw. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Luke Kershaw
+-/
+import category_theory.additive.basic
+import category_theory.shift
+import category_theory.preadditive.additive_functor
+import category_theory.triangulated.basic
+import category_theory.triangulated.rotate
+
+/-!
+# Pre-triangulated Categories
+
+This file contains the definition of pre-triangulated categories and triangulated functors between them.
+
+TODO: generalise this to n-angulated categories as in https://arxiv.org/abs/1006.4592
+-/
+
+noncomputable theory
+
+open category_theory
+open category_theory.preadditive
+
+universes v v₀ v₁ v₂ u u₀ u₁ u₂
+
+namespace category_theory.triangulated
+open category_theory.category
+
+/-
+We work in an additive category C equipped with an additive shift.
+-/
+variables (C : Type u) [category.{v} C] [has_shift C] [additive_category C]
+[functor.additive (shift C).functor] [functor.additive (shift C).inverse]
+
+/--
+An additive category `C` with an additive shift, and a class of "distinguished triangles"
+relative to that shift is called pretriangulated if the following hold:
+* Any triangle that is isomorphic to a distinguished triangle is also distinguished.
+* Any triangle of the form `(X,X,0,id,0,0)` is distinguished.
+* For any morphism `f: X ⟶ Y` there exists a distinguished triangle of the form `(X,Y,Z,f,g,h)`.
+* The triangle `(X,Y,Z,f,g,h)` is distinguished if and only if `(Y,Z,X⟦1⟧,g,h,-f⟦1⟧)` is.
+* Given a commutative diagram:
+```
+        f       g       h
+    X  ───> Y  ───> Z  ───> X⟦1⟧
+    │       │                │
+    │a      │b               │a⟦1⟧'
+    V       V                V
+    X' ───> Y' ───> Z' ───> X'⟦1⟧
+        f'      g'      h'
+```
+  whose rows are distinguished triangles, there exists a morphism `c: Z ⟶ Z'` such that `(a,b,c)`
+  is a triangle morphism.
+See https://stacks.math.columbia.edu/tag/0145
+-/
+class pretriangulated :=
+(distinguished_triangles : set(triangle C))
+(isomorphic_distinguished : Π (T₁ ∈ distinguished_triangles) (T₂ : triangle C) (T₁ ≅ T₂),
+  T₂ ∈ distinguished_triangles)
+(contractible_distinguished : Π (X : C), (contractible_triangle C X) ∈ distinguished_triangles)
+(distinguished_cocone_triangle : Π (X:C) (Y:C) (f: X ⟶ Y), (∃ (Z : C) (g : Y ⟶ Z) (h : Z ⟶ X⟦1⟧),
+  ({ obj₁ := X, obj₂ := Y, obj₃ := Z, mor₁ := f, mor₂ := g, mor₃ := h} : triangle C) ∈
+    distinguished_triangles))
+(rotate_distinguished_triangle : Π (T : triangle C),
+  T ∈ distinguished_triangles ↔ T.rotate C ∈ distinguished_triangles)
+(complete_distinguished_triangle_morphism : Π (T₁ T₂ : triangle C)
+  (h₁ :T₁ ∈ distinguished_triangles) (h₂ :T₂ ∈ distinguished_triangles) (a : T₁.obj₁ ⟶ T₂.obj₁)
+  (b : T₁.obj₂ ⟶ T₂.obj₂) (comm₁ : T₁.mor₁ ≫ b = a ≫ T₂.mor₁),
+  (∃ (c : T₁.obj₃ ⟶ T₂.obj₃), (T₁.mor₂ ≫ c = b ≫ T₂.mor₂) ∧ (T₁.mor₃ ≫ a⟦1⟧' = c ≫ T₂.mor₃) ))
+
+/--
+Given any distinguished triangle `T`, then we know `T.rotate C` is also distinguished.
+-/
+lemma rot_of_dist_triangle [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
+  (T.rotate C ∈ CT.distinguished_triangles) :=
+by exact (pretriangulated.rotate_distinguished_triangle T).mp H
+
+/--
+Given any distinguished triangle `T`, then we know `T.inv_rotate C` is also distinguished.
+-/
+lemma inv_rot_of_dist_triangle [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
+  (T.inv_rotate C ∈ CT.distinguished_triangles) :=
+begin
+  apply (pretriangulated.rotate_distinguished_triangle (T.inv_rotate C)).mpr,
+  exact pretriangulated.isomorphic_distinguished T H (triangulated.triangle.rotate C
+    (triangulated.triangle.inv_rotate C T)) T ((inv_rot_comp_rot C).symm.app T),
+end
+
+/--
+Given any distinguished triangle
+```
+      f       g       h
+  X  ───> Y  ───> Z  ───> X⟦1⟧
+```
+the composition `f ≫ g = 0`.
+See https://stacks.math.columbia.edu/tag/0146
+-/
+lemma comp_dist_triangle_mor_zero₁₂ [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
+  T.mor₁ ≫ T.mor₂ = 0 :=
+begin
+  have h := pretriangulated.contractible_distinguished T.obj₁,
+  have f := CT.complete_distinguished_triangle_morphism,
+  specialize f (contractible_triangle C T.obj₁) T h H (𝟙 T.obj₁) T.mor₁,
+  have t : (triangulated.contractible_triangle C T.obj₁).mor₁ ≫ T.mor₁ = 𝟙 T.obj₁ ≫ T.mor₁,
+    by refl,
+  specialize f t,
+  cases f with c f,
+  simp at c,
+  rw ← f.left,
+  simp only [limits.zero_comp, triangulated.contractible_triangle_mor₂],
+end -- TODO : tidy this proof up
+
+/--
+Given any distinguished triangle
+```
+      f       g       h
+  X  ---> Y  ---> Z  ---> X⟦1⟧
+```
+the composition `g ≫ h = 0`.
+See https://stacks.math.columbia.edu/tag/0146
+-/
+lemma comp_dist_triangle_mor_zero₂₃  [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
+  T.mor₂ ≫ T.mor₃ = 0 :=
+begin
+    have H₁ := rot_of_dist_triangle C T H,
+    exact comp_dist_triangle_mor_zero₁₂ C (triangulated.triangle.rotate C T) H₁
+end
+
+/--
+Given any distinguished triangle
+```
+      f       g       h
+  X  ---> Y  ---> Z  ---> X⟦1⟧
+```
+the composition `h ≫ f⟦1⟧ = 0`.
+See https://stacks.math.columbia.edu/tag/0146
+-/
+lemma comp_dist_triangle_mor_zero₃₁  [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
+  T.mor₃ ≫ ((shift C).functor.map T.mor₁) = 0 :=
+begin
+    have H₂ := rot_of_dist_triangle C (triangle.rotate C T) (rot_of_dist_triangle C T H),
+    have t := comp_dist_triangle_mor_zero₁₂ C (triangle.rotate C (triangle.rotate C T)) H₂,
+    dsimp at t,
+    rw [comp_neg, neg_eq_zero] at t,
+    exact t,
+end
+
+/-
+TODO: If `C` is pretriangulated with respect to a shift,
+then `C^{op}` is pretriangulated with respect to the inverse shift.
+-/
+
+end category_theory.triangulated
+
+namespace category_theory.triangulated
+
+variables (C : Type u₁) [category.{v₁} C] [has_shift C] [additive_category C]
+[functor.additive (shift C).functor] [functor.additive (shift C).inverse]
+variables (D : Type u₂) [category.{v₂} D] [has_shift D] [additive_category D]
+[functor.additive (shift D).functor] [functor.additive (shift D).inverse]
+
+/--
+A triangulated functor between pretriangulated categories C and D is a functor `F : C ⥤ D`
+together with given functorial isomorphisms `ξ X : F(X⟦1⟧) ⟶ F(X)⟦1⟧` with extra conditions
+involving images of triangles.
+-/
+structure triangulated_functor_struct extends (C ⥤ D) :=
+(natural_isom : (shift C).functor ⋙ to_functor ≅ to_functor ⋙ (shift D).functor)
+
+instance : inhabited (triangulated_functor_struct C C) :=
+⟨{ obj := λ X, X,
+  map := λ _ _ f, f,
+  natural_isom := by refl }⟩
+
+variables {C D}
+/--
+Given a `triangulated_functor_struct` we can define a function from triangles of `C` to
+triangles of `D`.
+-/
+@[simp]
+def triangulated_functor_struct.map_triangle (F : triangulated_functor_struct C D)
+  (T : triangle C) : triangle D :=
+{ obj₁ := F.obj T.obj₁,
+  obj₂ := F.obj T.obj₂,
+  obj₃ := F.obj T.obj₃,
+  mor₁ := F.map T.mor₁,
+  mor₂ := F.map T.mor₂,
+  mor₃ := F.map T.mor₃ ≫ F.natural_isom.hom.app T.obj₁ }
+
+variables (C D)
+/--
+A triangulated functor between pretriangulated categories C and D is a functor `F : C ⥤ D`
+together with given functorial isomorphisms `ξ X : F(X⟦1⟧) ⟶ F(X)⟦1⟧` such that for every
+distinguished triangle `(X,Y,Z,f,g,h)` of `C`, the triangle
+`(F(X), F(Y), F(Z), F(f), F(g), F(h) ≫ (ξ X))` is a distinguished triangle of `D`.
+See https://stacks.math.columbia.edu/tag/014V
+-/
+structure triangulated_functor [CT : pretriangulated C] [DT : pretriangulated D] :=
+(F : triangulated_functor_struct C D)
+(map_distinguished : Π (T: triangle C), (T ∈ CT.distinguished_triangles) →
+  (F.map_triangle T ∈ DT.distinguished_triangles) )
+
+instance [CT : pretriangulated C] : inhabited (triangulated_functor C C) :=
+⟨{ F:= {obj := λ X, X,
+  map := λ _ _ f, f,
+  natural_isom := by refl },
+  map_distinguished := begin
+    intros T Tdt,
+    cases T,
+    dsimp at *,
+    rw category.comp_id,
+    assumption,
+  end
+}⟩
+
+
+end category_theory.triangulated

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -15,6 +15,11 @@ import category_theory.triangulated.rotate
 This file contains the definition of pretriangulated categories and triangulated functors
 between them.
 
+## Implementation Notes
+
+We work under the assumption that pretriangulated categories are preadditive categories,
+but not necessarily additive categories, as is assumed in some sources.
+
 TODO: generalise this to n-angulated categories as in https://arxiv.org/abs/1006.4592
 -/
 

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -30,7 +30,7 @@ namespace category_theory.triangulated
 open category_theory.category
 
 /-
-We work in an additive category `C` equipped with an additive shift.
+We work in an preadditive category `C` equipped with an additive shift.
 -/
 variables (C : Type u) [category.{v} C] [has_zero_object C] [has_shift C] [preadditive C]
 [functor.additive (shift C).functor] [functor.additive (shift C).inverse]

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -120,10 +120,7 @@ See https://stacks.math.columbia.edu/tag/0146
 -/
 lemma comp_dist_triangle_mor_zero₂₃  [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
   T.mor₂ ≫ T.mor₃ = 0 :=
-begin
-    have H₁ := rot_of_dist_triangle C T H,
-    exact comp_dist_triangle_mor_zero₁₂ C (triangulated.triangle.rotate C T) H₁
-end
+comp_dist_triangle_mor_zero₁₂ C (triangulated.triangle.rotate C T) (rot_of_dist_triangle C T H)
 
 /--
 Given any distinguished triangle
@@ -136,13 +133,8 @@ See https://stacks.math.columbia.edu/tag/0146
 -/
 lemma comp_dist_triangle_mor_zero₃₁  [CT : pretriangulated C] (T ∈ CT.distinguished_triangles) :
   T.mor₃ ≫ ((shift C).functor.map T.mor₁) = 0 :=
-begin
-    have H₂ := rot_of_dist_triangle C (triangle.rotate C T) (rot_of_dist_triangle C T H),
-    have t := comp_dist_triangle_mor_zero₁₂ C (triangle.rotate C (triangle.rotate C T)) H₂,
-    dsimp at t,
-    rw [comp_neg, neg_eq_zero] at t,
-    exact t,
-end
+have H₂ : _ := rot_of_dist_triangle C (triangle.rotate C T) (rot_of_dist_triangle C T H),
+by simpa using comp_dist_triangle_mor_zero₁₂ C (triangle.rotate C (triangle.rotate C T)) H₂
 
 /-
 TODO: If `C` is pretriangulated with respect to a shift,
@@ -204,8 +196,7 @@ instance [CT : pretriangulated C] : inhabited (triangulated_functor C C) :=
   map := λ _ _ f, f,
   natural_isom := by refl },
   map_distinguished := begin
-    intros T Tdt,
-    cases T,
+    rintros ⟨_,_,_,_⟩ Tdt,
     dsimp at *,
     rwa category.comp_id,
   end

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -33,10 +33,10 @@ open category_theory.category
 We work in an preadditive category `C` equipped with an additive shift.
 -/
 variables (C : Type u) [category.{v} C] [has_zero_object C] [has_shift C] [preadditive C]
-[functor.additive (shift C).functor] [functor.additive (shift C).inverse]
+  [functor.additive (shift C).functor]
 
 /--
-An additive category `C` with an additive shift, and a class of "distinguished triangles"
+A preadditive category `C` with an additive shift, and a class of "distinguished triangles"
 relative to that shift is called pretriangulated if the following hold:
 * Any triangle that is isomorphic to a distinguished triangle is also distinguished.
 * Any triangle of the form `(X,X,0,id,0,0)` is distinguished.

--- a/src/category_theory/triangulated/rotate.lean
+++ b/src/category_theory/triangulated/rotate.lean
@@ -29,7 +29,7 @@ namespace category_theory.triangulated
 open category_theory.category
 
 /--
-We work in an additive category C equipped with an additive shift.
+We work in an additive category `C` equipped with an additive shift.
 -/
 variables (C : Type u) [category.{v} C] [has_shift C] [additive_category C]
   [functor.additive (shift C).functor] [functor.additive (shift C).inverse]
@@ -40,12 +40,12 @@ If you rotate a triangle, you get another triangle.
 Given a triangle of the form:
 ```
       f       g       h
-  X  ---> Y  ---> Z  ---> X[1]
+  X  ───> Y  ───> Z  ───> X⟦1⟧
 ```
 applying `rotate` gives a triangle of the form:
 ```
-      g        h       -f[1]
-  Y  ---> Z  --->  X[1] ---> Y[1]
+      g       h        -f⟦1⟧'
+  Y  ───> Z  ───>  X⟦1⟧ ───> Y⟦1⟧
 ```
 -/
 @[simps]
@@ -61,15 +61,15 @@ def triangle.rotate (T : triangle C) : triangle C :=
 Given a triangle of the form:
 ```
       f       g       h
-  X  ---> Y  ---> Z  ---> X[1]
+  X  ───> Y  ───> Z  ───> X⟦1⟧
 ```
 applying `inv_rotate` gives a triangle that can be thought of as:
 ```
-        -h[-1]     f       g
-  Z[-1]  --->  X  ---> Y  ---> Z
+        -h⟦-1⟧'     f       g
+  Z⟦-1⟧  ───>  X  ───> Y  ───> Z
 ```
-(note that this diagram doesn't technically fit the definition of triangle, as `Z[-1][1]` is
-not necessarily equal to `Z`, but it is isomorphic, by the counit_iso of (shift C))
+(note that this diagram doesn't technically fit the definition of triangle, as `Z⟦-1⟧⟦1⟧` is
+not necessarily equal to `Z`, but it is isomorphic, by the `counit_iso` of `shift C`)
 -/
 @[simps]
 def triangle.inv_rotate (T : triangle C) : triangle C :=
@@ -90,22 +90,23 @@ You can also rotate a triangle morphism to get a morphism between the two rotate
 Given a triangle morphism of the form:
 ```
       f       g       h
-  X  ---> Y  ---> Z  ---> X[1]
-  |       |       |        |
-  |a      |b      |c       |a[1]
+  X  ───> Y  ───> Z  ───> X⟦1⟧
+  │       │       │        │
+  │a      │b      │c       │a⟦1⟧
   V       V       V        V
-  X' ---> Y' ---> Z' ---> X'[1]
+  X' ───> Y' ───> Z' ───> X'⟦1⟧
       f'      g'      h'
 ```
 applying `rotate` gives a triangle morphism of the form:
+⟦⟧
 ```
-      g        h       -f[1]
-  Y  ---> Z  --->  X[1] ---> Y[1]
-  |       |         |         |
-  |b      |c        |a[1]     |b[1]
+      g        h       -f⟦1⟧
+  Y  ───> Z  ───>  X⟦1⟧ ───> Y⟦1⟧
+  │       │         │         │
+  │b      │c        │a⟦1⟧     │b⟦1⟧'
   V       V         V         V
-  Y' ---> Z' ---> X'[1] ---> Y'[1]
-      g'      h'       -f'[1]
+  Y' ───> Z' ───> X'⟦1⟧ ───> Y'⟦1⟧
+      g'      h'       -f'⟦1⟧
 ```
 -/
 @[simps]
@@ -120,25 +121,25 @@ def rotate (f : triangle_morphism T₁ T₂) :
 Given a triangle morphism of the form:
 ```
       f       g       h
-  X  ---> Y  ---> Z  ---> X[1]
-  |       |       |        |
-  |a      |b      |c       |a[1]
+  X  ───> Y  ───> Z  ───> X⟦1⟧
+  │       │       │        │
+  │a      │b      │c       │a⟦1⟧
   V       V       V        V
-  X' ---> Y' ---> Z' ---> X'[1]
+  X' ───> Y' ───> Z' ───> X'⟦1⟧
       f'      g'      h'
 ```
 applying `inv_rotate` gives a triangle morphism that can be thought of as:
 ```
-        -h[-1]      f         g
-  Z[-1]  --->  X   --->  Y   --->  Z
-    |          |         |         |
-    |a         |b        |c        |a[1]
+        -h⟦-1⟧      f         g
+  Z⟦-1⟧  ───>  X   ───>  Y   ───>  Z
+    │          │         │         │
+    │c⟦-1⟧'    │a        │b        │c
     V          V         V         V
-  Z'[-1] --->  X'  --->  Y'  --->  Z'
-        -h'[-1]     f'        g'
+  Z'⟦-1⟧ ───>  X'  ───>  Y'  ───>  Z'
+       -h'⟦-1⟧     f'        g'
 ```
 (note that this diagram doesn't technically fit the definition of triangle morphism,
-as `Z[-1][1]` is not necessarily equal to `Z`, and `Z'[-1][1]` is not necessarily equal to `Z'`,
+as `Z⟦-1⟧⟦1⟧` is not necessarily equal to `Z`, and `Z'⟦-1⟧⟦1⟧` is not necessarily equal to `Z'`,
 but they are isomorphic, by the `counit_iso` of `shift C`)
 -/
 @[simps]
@@ -158,7 +159,7 @@ def inv_rotate (f : triangle_morphism T₁ T₂) :
 end triangle_morphism
 
 /--
-Rotating triangles gives an endofunctor on the category of triangles in C.
+Rotating triangles gives an endofunctor on the category of triangles in `C`.
 -/
 @[simps]
 def rotate : (triangle C) ⥤ (triangle C) :=
@@ -174,7 +175,7 @@ def inv_rotate : (triangle C) ⥤ (triangle C) :=
   map := λ _ _ f, f.inv_rotate C }
 
 /--
-There is a natural transformation between the identity functor on triangles,
+There is a natural transformation between the identity functor on triangles in `C`,
 and the composition of a rotation with an inverse rotation.
 -/
 @[simps]
@@ -190,7 +191,7 @@ def rot_comp_inv_rot_hom : 𝟭 (triangle C) ⟶ (rotate C) ⋙ (inv_rotate C) :
 
 /--
 There is a natural transformation between the composition of a rotation with an inverse rotation
-on triangles, and the identity functor.
+on triangles in `C`, and the identity functor.
 -/
 @[simps]
 def rot_comp_inv_rot_inv : (rotate C) ⋙ (inv_rotate C) ⟶ 𝟭 (triangle C) :=
@@ -200,7 +201,7 @@ def rot_comp_inv_rot_inv : (rotate C) ⋙ (inv_rotate C) ⟶ 𝟭 (triangle C) :
     hom₃ := 𝟙 T.obj₃ } }
 
 /--
-The natural transformations between the identity functor on triangles and the composition
+The natural transformations between the identity functor on triangles in `C` and the composition
 of a rotation with an inverse rotation are natural isomorphisms (they are isomorphisms in the
 category of functors).
 -/
@@ -211,7 +212,7 @@ def rot_comp_inv_rot : 𝟭 (triangle C) ≅ (rotate C) ⋙ (inv_rotate C) :=
 
 /--
 There is a natural transformation between the composition of an inverse rotation with a rotation
-on triangles, and the identity functor.
+on triangles in `C`, and the identity functor.
 -/
 @[simps]
 def inv_rot_comp_rot_hom : (inv_rotate C) ⋙ (rotate C) ⟶ 𝟭 (triangle C) :=
@@ -221,7 +222,7 @@ def inv_rot_comp_rot_hom : (inv_rotate C) ⋙ (rotate C) ⟶ 𝟭 (triangle C) :
     hom₃ := (shift C).counit.app T.obj₃ } }
 
 /--
-There is a natural transformation between the identity functor on triangles,
+There is a natural transformation between the identity functor on triangles in `C`,
 and  the composition of an inverse rotation with a rotation.
 -/
 @[simps]
@@ -233,7 +234,7 @@ def inv_rot_comp_rot_inv : 𝟭 (triangle C) ⟶ (inv_rotate C) ⋙ (rotate C) :
 
 /--
 The natural transformations between the composition of a rotation with an inverse rotation
-on triangles, and the identity functor on triangles are natural isomorphisms
+on triangles in `C`, and the identity functor on triangles are natural isomorphisms
 (they are isomorphisms in the category of functors).
 -/
 @[simps]
@@ -242,7 +243,7 @@ def inv_rot_comp_rot : (inv_rotate C) ⋙ (rotate C) ≅ 𝟭 (triangle C) :=
   inv := inv_rot_comp_rot_inv C }
 
 /--
-Rotating triangles gives an auto-equivalence on the category of triangles.
+Rotating triangles gives an auto-equivalence on the category of triangles in `C`.
 -/
 def triangle_rotation : equivalence (triangle C) (triangle C) :=
 { functor := rotate C,

--- a/src/category_theory/triangulated/rotate.lean
+++ b/src/category_theory/triangulated/rotate.lean
@@ -32,7 +32,7 @@ open category_theory.category
 We work in an preadditive category `C` equipped with an additive shift.
 -/
 variables {C : Type u} [category.{v} C] [has_shift C] [preadditive C]
-  [functor.additive (shift C).functor] [functor.additive (shift C).inverse]
+  [functor.additive (shift C).functor]
 variables (X : C)
 
 /--
@@ -215,7 +215,7 @@ def inv_rot_comp_rot_hom : inv_rotate ⋙ rotate  ⟶ 𝟭 (triangle C) :=
 
 /--
 There is a natural transformation between the identity functor on triangles in `C`,
-and  the composition of an inverse rotation with a rotation.
+and the composition of an inverse rotation with a rotation.
 -/
 @[simps]
 def inv_rot_comp_rot_inv : 𝟭 (triangle C) ⟶ inv_rotate ⋙ rotate :=

--- a/src/category_theory/triangulated/rotate.lean
+++ b/src/category_theory/triangulated/rotate.lean
@@ -31,7 +31,7 @@ open category_theory.category
 /--
 We work in an additive category `C` equipped with an additive shift.
 -/
-variables (C : Type u) [category.{v} C] [has_shift C] [additive_category C]
+variables {C : Type u} [category.{v} C] [has_shift C] [additive_category C]
   [functor.additive (shift C).functor] [functor.additive (shift C).inverse]
 variables (X : C)
 
@@ -49,13 +49,7 @@ applying `rotate` gives a triangle of the form:
 ```
 -/
 @[simps]
-def triangle.rotate (T : triangle C) : triangle C :=
-{ obj₁ := T.obj₂,
-  obj₂ := T.obj₃,
-  obj₃ := T.obj₁⟦1⟧,
-  mor₁ := T.mor₂,
-  mor₂ := T.mor₃,
-  mor₃ := -T.mor₁⟦1⟧' }
+def triangle.rotate (T : triangle C) : triangle C := triangle.mk _ T.mor₂ T.mor₃ (-T.mor₁⟦1⟧')
 
 /--
 Given a triangle of the form:
@@ -73,13 +67,8 @@ not necessarily equal to `Z`, but it is isomorphic, by the `counit_iso` of `shif
 -/
 @[simps]
 def triangle.inv_rotate (T : triangle C) : triangle C :=
-{ obj₁ := T.obj₃⟦-1⟧,
-  obj₂ := T.obj₁,
-  obj₃ := T.obj₂,
-  mor₁ := -T.mor₃⟦-1⟧' ≫ (shift C).unit_iso.inv.app T.obj₁,
-  mor₂ := T.mor₁,
-  mor₃ := T.mor₂ ≫ (shift C).counit_iso.inv.app T.obj₃ }
-
+triangle.mk _ (-T.mor₃⟦-1⟧' ≫ (shift C).unit_iso.inv.app T.obj₁) T.mor₁
+  (T.mor₂ ≫ (shift C).counit_iso.inv.app T.obj₃)
 
 
 namespace triangle_morphism
@@ -111,11 +100,14 @@ applying `rotate` gives a triangle morphism of the form:
 -/
 @[simps]
 def rotate (f : triangle_morphism T₁ T₂) :
-  triangle_morphism (T₁.rotate C) (T₂.rotate C):=
+  triangle_morphism (T₁.rotate) (T₂.rotate):=
 { hom₁ := f.hom₂,
   hom₂ := f.hom₃,
   hom₃ := f.hom₁⟦1⟧',
-  comm₃' := by simp only [rotate_mor₃, comp_neg, neg_comp, ← functor.map_comp, f.comm₁] }
+  comm₃' := begin
+    dsimp,
+    simp only [rotate_mor₃, comp_neg, neg_comp, ← functor.map_comp, f.comm₁]
+  end}
 
 /--
 Given a triangle morphism of the form:
@@ -144,7 +136,7 @@ but they are isomorphic, by the `counit_iso` of `shift C`)
 -/
 @[simps]
 def inv_rotate (f : triangle_morphism T₁ T₂) :
-  triangle_morphism (T₁.inv_rotate C) (T₂.inv_rotate C) :=
+  triangle_morphism (T₁.inv_rotate) (T₂.inv_rotate) :=
 { hom₁ := f.hom₃⟦-1⟧',
   hom₂ := f.hom₁,
   hom₃ := f.hom₂,
@@ -163,23 +155,23 @@ Rotating triangles gives an endofunctor on the category of triangles in `C`.
 -/
 @[simps]
 def rotate : (triangle C) ⥤ (triangle C) :=
-{ obj := triangle.rotate C,
-  map := λ _ _ f, f.rotate C }
+{ obj := triangle.rotate,
+  map := λ _ _ f, f.rotate }
 
 /--
 The inverse rotation of triangles gives an endofunctor on the category of triangles in `C`.
 -/
 @[simps]
 def inv_rotate : (triangle C) ⥤ (triangle C) :=
-{ obj := triangle.inv_rotate C,
-  map := λ _ _ f, f.inv_rotate C }
+{ obj := triangle.inv_rotate,
+  map := λ _ _ f, f.inv_rotate }
 
 /--
 There is a natural transformation between the identity functor on triangles in `C`,
 and the composition of a rotation with an inverse rotation.
 -/
 @[simps]
-def rot_comp_inv_rot_hom : 𝟭 (triangle C) ⟶ (rotate C) ⋙ (inv_rotate C) :=
+def rot_comp_inv_rot_hom : 𝟭 (triangle C) ⟶ rotate ⋙ inv_rotate :=
 { app := λ T,
   { hom₁ := (shift C).unit.app T.obj₁,
     hom₂ := 𝟙 T.obj₂,
@@ -194,7 +186,7 @@ There is a natural transformation between the composition of a rotation with an 
 on triangles in `C`, and the identity functor.
 -/
 @[simps]
-def rot_comp_inv_rot_inv : (rotate C) ⋙ (inv_rotate C) ⟶ 𝟭 (triangle C) :=
+def rot_comp_inv_rot_inv : rotate  ⋙ inv_rotate ⟶ 𝟭 (triangle C) :=
 { app := λ T,
   { hom₁ := (shift C).unit_inv.app T.obj₁,
     hom₂ := 𝟙 T.obj₂,
@@ -206,16 +198,16 @@ of a rotation with an inverse rotation are natural isomorphisms (they are isomor
 category of functors).
 -/
 @[simps]
-def rot_comp_inv_rot : 𝟭 (triangle C) ≅ (rotate C) ⋙ (inv_rotate C) :=
-{ hom := rot_comp_inv_rot_hom C,
-  inv := rot_comp_inv_rot_inv C }
+def rot_comp_inv_rot : 𝟭 (triangle C) ≅ rotate ⋙ inv_rotate :=
+{ hom := rot_comp_inv_rot_hom,
+  inv := rot_comp_inv_rot_inv }
 
 /--
 There is a natural transformation between the composition of an inverse rotation with a rotation
 on triangles in `C`, and the identity functor.
 -/
 @[simps]
-def inv_rot_comp_rot_hom : (inv_rotate C) ⋙ (rotate C) ⟶ 𝟭 (triangle C) :=
+def inv_rot_comp_rot_hom : inv_rotate ⋙ rotate  ⟶ 𝟭 (triangle C) :=
 { app := λ T,
   { hom₁ := 𝟙 T.obj₁,
     hom₂ := 𝟙 T.obj₂,
@@ -226,7 +218,7 @@ There is a natural transformation between the identity functor on triangles in `
 and  the composition of an inverse rotation with a rotation.
 -/
 @[simps]
-def inv_rot_comp_rot_inv : 𝟭 (triangle C) ⟶ (inv_rotate C) ⋙ (rotate C) :=
+def inv_rot_comp_rot_inv : 𝟭 (triangle C) ⟶ inv_rotate ⋙ rotate :=
 { app := λ T,
   { hom₁ := 𝟙 T.obj₁,
     hom₂ := 𝟙 T.obj₂,
@@ -238,17 +230,17 @@ on triangles in `C`, and the identity functor on triangles are natural isomorphi
 (they are isomorphisms in the category of functors).
 -/
 @[simps]
-def inv_rot_comp_rot : (inv_rotate C) ⋙ (rotate C) ≅ 𝟭 (triangle C) :=
-{ hom := inv_rot_comp_rot_hom C,
-  inv := inv_rot_comp_rot_inv C }
+def inv_rot_comp_rot : inv_rotate ⋙ rotate ≅ 𝟭 (triangle C) :=
+{ hom := inv_rot_comp_rot_hom,
+  inv := inv_rot_comp_rot_inv }
 
 /--
 Rotating triangles gives an auto-equivalence on the category of triangles in `C`.
 -/
 def triangle_rotation : equivalence (triangle C) (triangle C) :=
-{ functor := rotate C,
-  inverse := inv_rotate C,
-  unit_iso := rot_comp_inv_rot C,
-  counit_iso := inv_rot_comp_rot C }
+{ functor := rotate,
+  inverse := inv_rotate,
+  unit_iso := rot_comp_inv_rot,
+  counit_iso := inv_rot_comp_rot }
 
 end category_theory.triangulated

--- a/src/category_theory/triangulated/rotate.lean
+++ b/src/category_theory/triangulated/rotate.lean
@@ -186,7 +186,7 @@ There is a natural transformation between the composition of a rotation with an 
 on triangles in `C`, and the identity functor.
 -/
 @[simps]
-def rot_comp_inv_rot_inv : rotate  ⋙ inv_rotate ⟶ 𝟭 (triangle C) :=
+def rot_comp_inv_rot_inv : rotate ⋙ inv_rotate ⟶ 𝟭 (triangle C) :=
 { app := λ T,
   { hom₁ := (shift C).unit_inv.app T.obj₁,
     hom₂ := 𝟙 T.obj₂,

--- a/src/category_theory/triangulated/rotate.lean
+++ b/src/category_theory/triangulated/rotate.lean
@@ -32,7 +32,7 @@ open category_theory.category
 We work in an preadditive category `C` equipped with an additive shift.
 -/
 variables {C : Type u} [category.{v} C] [has_shift C] [preadditive C]
-  [functor.additive (shift C).functor]
+
 variables (X : C)
 
 /--
@@ -166,6 +166,8 @@ def inv_rotate : (triangle C) ⥤ (triangle C) :=
 { obj := triangle.inv_rotate,
   map := λ _ _ f, f.inv_rotate }
 
+variables [functor.additive (shift C).functor]
+
 /--
 There is a natural transformation between the identity functor on triangles in `C`,
 and the composition of a rotation with an inverse rotation.
@@ -237,6 +239,7 @@ def inv_rot_comp_rot : inv_rotate ⋙ rotate ≅ 𝟭 (triangle C) :=
 /--
 Rotating triangles gives an auto-equivalence on the category of triangles in `C`.
 -/
+@[simps]
 def triangle_rotation : equivalence (triangle C) (triangle C) :=
 { functor := rotate,
   inverse := inv_rotate,

--- a/src/category_theory/triangulated/rotate.lean
+++ b/src/category_theory/triangulated/rotate.lean
@@ -29,9 +29,9 @@ namespace category_theory.triangulated
 open category_theory.category
 
 /--
-We work in an additive category `C` equipped with an additive shift.
+We work in an preadditive category `C` equipped with an additive shift.
 -/
-variables {C : Type u} [category.{v} C] [has_zero_object C] [has_shift C] [preadditive C]
+variables {C : Type u} [category.{v} C] [has_shift C] [preadditive C]
   [functor.additive (shift C).functor] [functor.additive (shift C).inverse]
 variables (X : C)
 

--- a/src/category_theory/triangulated/rotate.lean
+++ b/src/category_theory/triangulated/rotate.lean
@@ -31,7 +31,7 @@ open category_theory.category
 /--
 We work in an additive category `C` equipped with an additive shift.
 -/
-variables {C : Type u} [category.{v} C] [has_shift C] [additive_category C]
+variables {C : Type u} [category.{v} C] [has_zero_object C] [has_shift C] [preadditive C]
   [functor.additive (shift C).functor] [functor.additive (shift C).inverse]
 variables (X : C)
 


### PR DESCRIPTION
Adds a definition of pretriangulated categories and triangulated functors between them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
