### PR TITLE
[Merged by Bors] - feat(data/nat/parity): update to match int/parity

### DIFF
--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -63,7 +63,10 @@ begin
 end
 
 lemma odd_gt_zero (h : odd n) : 0 < n :=
-by { obtain ⟨k, hk⟩ := h, rw hk, exact succ_pos', }
+by { obtain ⟨k, rfl⟩ := h, exact succ_pos' }
+
+@[simp] theorem two_dvd_ne_zero : ¬ 2 ∣ n ↔ n % 2 = 1 :=
+not_even_iff
 
 instance : decidable_pred (even : ℕ → Prop) :=
 λ n, decidable_of_decidable_of_iff (by apply_instance) even_iff.symm
@@ -92,13 +95,13 @@ begin
 end
 
 theorem even.add_even (hm : even m) (hn : even n) : even (m + n) :=
-even_add.2 $ by simp only [*]
+even_add.2 $ iff_of_true hm hn
 
 theorem even_add' : even (m + n) ↔ (odd m ↔ odd n) :=
 by rw [even_add, even_iff_not_odd, even_iff_not_odd, not_iff_not]
 
 theorem odd.add_odd (hm : odd m) (hn : odd n) : even (m + n) :=
-even_add'.2 $ by simp only [*]
+even_add'.2 $ iff_of_true hm hn
 
 @[simp] theorem not_even_bit1 (n : ℕ) : ¬ even (bit1 n) :=
 by simp [bit1] with parity_simps
@@ -164,7 +167,7 @@ if and only if `m` is even and `n` is positive. -/
 @[parity_simps] theorem even_pow : even (m^n) ↔ even m ∧ n ≠ 0 :=
 by { induction n with n ih; simp [*, pow_succ', even_mul], tauto }
 
-theorem even_div  : even (m / n) ↔ m % (2 * n) / n = 0 :=
+theorem even_div : even (m / n) ↔ m % (2 * n) / n = 0 :=
 by rw [even_iff_two_dvd, dvd_iff_mod_eq_zero, nat.div_mod_eq_mod_mul_div, mul_comm]
 
 @[parity_simps] theorem odd_add : odd (m + n) ↔ (odd m ↔ even n) :=
@@ -175,13 +178,16 @@ begin
 end
 
 theorem odd.add_even (hm : odd m) (hn : even n) : odd (m + n) :=
-odd_add.2 $ by simp only [*]
+odd_add.2 $ iff_of_true hm hn
 
 theorem odd_add' : odd (m + n) ↔ (odd n ↔ even m) :=
 by rw [add_comm, odd_add]
 
 theorem even.add_odd (hm : even m) (hn : odd n) : odd (m + n) :=
-odd_add'.2 $ by simp only [*]
+odd_add'.2 $ iff_of_true hn hm
+
+lemma ne_of_odd_sum (h : odd (m + n)) : m ≠ n :=
+λ hnot, by simpa [hnot] with parity_simps using h
 
 @[parity_simps] theorem odd_sub (h : n ≤ m) : odd (m - n) ↔ (odd m ↔ even n) :=
 begin
@@ -191,7 +197,7 @@ begin
 end
 
 theorem odd.sub_even (h : n ≤ m) (hm : odd m) (hn : even n) : odd (m - n) :=
-(odd_sub h).mpr (iff_of_true hm hn)
+(odd_sub h).mpr $ iff_of_true hm hn
 
 theorem odd_sub' (h : n ≤ m) : odd (m - n) ↔ (odd n ↔ even m) :=
 begin
@@ -202,7 +208,7 @@ begin
 end
 
 theorem even.sub_odd (h : n ≤ m) (hm : even m) (hn : odd n) : odd (m - n) :=
-(odd_sub' h).mpr (iff_of_true hn hm)
+(odd_sub' h).mpr $ iff_of_true hn hm
 
 lemma even_mul_succ_self (n : ℕ) : even (n * (n + 1)) :=
 begin

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -2,10 +2,14 @@
 Copyright (c) 2019 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Benjamin Davidson
-
-The `even` and `odd` predicates on the natural numbers.
 -/
 import data.nat.modeq
+
+/-!
+# Parity of natural numbers
+
+This file contains theorems about the `even` and `odd` predicates on the natural numbers.
+-/
 
 namespace nat
 
@@ -40,7 +44,7 @@ lemma is_compl_even_odd : is_compl {n : ℕ | even n} {n | odd n} :=
 by simp [← set.compl_set_of, is_compl_compl]
 
 lemma even_or_odd (n : ℕ) : even n ∨ odd n :=
-or.imp_right (odd_iff_not_even.2) (em (even n))
+or.imp_right (odd_iff_not_even.2) $ em (even n)
 
 lemma even_or_odd' (n : ℕ) : ∃ k, n = 2 * k ∨ n = 2 * k + 1 :=
 by simpa only [exists_or_distrib, ← odd, ← even] using even_or_odd n
@@ -48,8 +52,8 @@ by simpa only [exists_or_distrib, ← odd, ← even] using even_or_odd n
 lemma even_xor_odd (n : ℕ) : xor (even n) (odd n) :=
 begin
   cases (even_or_odd n) with h,
-  { exact or.inl ⟨h, (even_iff_not_odd.mp h)⟩ },
-  { exact or.inr ⟨h, (odd_iff_not_even.mp h)⟩ },
+  { exact or.inl ⟨h, even_iff_not_odd.mp h⟩ },
+  { exact or.inr ⟨h, odd_iff_not_even.mp h⟩ },
 end
 
 lemma even_xor_odd' (n : ℕ) : ∃ k, xor (n = 2 * k) (n = 2 * k + 1) :=

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -9,6 +9,10 @@ import data.nat.modeq
 # Parity of natural numbers
 
 This file contains theorems about the `even` and `odd` predicates on the natural numbers.
+
+## Tags
+
+even, odd
 -/
 
 namespace nat
@@ -44,7 +48,7 @@ lemma is_compl_even_odd : is_compl {n : ℕ | even n} {n | odd n} :=
 by simp [← set.compl_set_of, is_compl_compl]
 
 lemma even_or_odd (n : ℕ) : even n ∨ odd n :=
-or.imp_right (odd_iff_not_even.2) $ em (even n)
+or.imp_right odd_iff_not_even.2 $ em $ even n
 
 lemma even_or_odd' (n : ℕ) : ∃ k, n = 2 * k ∨ n = 2 * k + 1 :=
 by simpa only [exists_or_distrib, ← odd, ← even] using even_or_odd n

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -55,18 +55,18 @@ by simpa only [exists_or_distrib, ← odd, ← even] using even_or_odd n
 
 lemma even_xor_odd (n : ℕ) : xor (even n) (odd n) :=
 begin
-  cases (even_or_odd n) with h,
+  cases even_or_odd n with h,
   { exact or.inl ⟨h, even_iff_not_odd.mp h⟩ },
   { exact or.inr ⟨h, odd_iff_not_even.mp h⟩ },
 end
 
 lemma even_xor_odd' (n : ℕ) : ∃ k, xor (n = 2 * k) (n = 2 * k + 1) :=
 begin
-  rcases (even_or_odd n) with ⟨k, h⟩ | ⟨k, h⟩;
+  rcases even_or_odd n with ⟨k, rfl⟩ | ⟨k, rfl⟩;
   use k,
-  { simpa only [xor, h, true_and, eq_self_iff_true, not_true, or_false, and_false]
+  { simpa only [xor, true_and, eq_self_iff_true, not_true, or_false, and_false]
       using (succ_ne_self (2*k)).symm },
-  { simp only [xor, h, add_right_eq_self, false_or, eq_self_iff_true, not_true, not_false_iff,
+  { simp only [xor, add_right_eq_self, false_or, eq_self_iff_true, not_true, not_false_iff,
               one_ne_zero, and_self] },
 end
 
@@ -179,11 +179,7 @@ theorem even_div : even (m / n) ↔ m % (2 * n) / n = 0 :=
 by rw [even_iff_two_dvd, dvd_iff_mod_eq_zero, nat.div_mod_eq_mod_mul_div, mul_comm]
 
 @[parity_simps] theorem odd_add : odd (m + n) ↔ (odd m ↔ even n) :=
-begin
-  by_contra hnot,
-  rw [not_iff, ← even_iff_not_odd, even_add, odd_iff_not_even, ← not_iff] at hnot,
-  exact (iff_not_self _).mp hnot,
-end
+by rw [odd_iff_not_even, even_add, not_iff, odd_iff_not_even]
 
 theorem odd.add_even (hm : odd m) (hn : even n) : odd (m + n) :=
 odd_add.2 $ iff_of_true hm hn
@@ -198,22 +194,13 @@ lemma ne_of_odd_sum (h : odd (m + n)) : m ≠ n :=
 λ hnot, by simpa [hnot] with parity_simps using h
 
 @[parity_simps] theorem odd_sub (h : n ≤ m) : odd (m - n) ↔ (odd m ↔ even n) :=
-begin
-  by_contra hnot,
-  rw [not_iff, ← even_iff_not_odd, even_sub h, odd_iff_not_even, ← not_iff] at hnot,
-  exact (iff_not_self _).mp hnot,
-end
+by rw [odd_iff_not_even, even_sub h, not_iff, odd_iff_not_even]
 
 theorem odd.sub_even (h : n ≤ m) (hm : odd m) (hn : even n) : odd (m - n) :=
 (odd_sub h).mpr $ iff_of_true hm hn
 
 theorem odd_sub' (h : n ≤ m) : odd (m - n) ↔ (odd n ↔ even m) :=
-begin
-  by_contra hnot,
-  rw [not_iff, ← even_iff_not_odd, even_sub h, odd_iff_not_even, ← not_iff,
-      @iff.comm _ (even n)] at hnot,
-  exact (iff_not_self _).mp hnot,
-end
+by rw [odd_iff_not_even, even_sub h, not_iff, not_iff_comm, odd_iff_not_even]
 
 theorem even.sub_odd (h : n ≤ m) (hm : even m) (hn : odd n) : odd (m - n) :=
 (odd_sub' h).mpr $ iff_of_true hn hm


### PR DESCRIPTION
A couple of lemmas existed for `int` but not for `nat`, so I add them. I also tidy some lemmas I added in prior PRs and add a file-level docstring.

