### PR TITLE
[Merged by Bors] - feat(data/list/forall2): defines sublist_forall2 relation

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -761,14 +761,6 @@ theorem head_mem_head' [inhabited α] : ∀ {l : list α} (h : l ≠ []), head l
 theorem cons_head_tail [inhabited α] {l : list α} (h : l ≠ []) : (head l)::(tail l) = l :=
 cons_head'_tail (head_mem_head' h)
 
-lemma mem_of_mem_tail {a : α} {l : list α} (h : a ∈ l.tail) : a ∈ l :=
-begin
-  cases l,
-  { rwa tail_nil at h },
-  rw tail_cons at h,
-  exact mem_cons_of_mem _ h,
-end
-
 lemma head_mem_self [inhabited α] {l : list α} (h : l ≠ nil) : l.head ∈ l :=
 begin
   have h' := mem_cons_self l.head l.tail,
@@ -959,9 +951,6 @@ instance decidable_sublist [decidable_eq α] : ∀ (l₁ l₂ : list α), decida
     | a, l₁, sublist.cons ._ ._ ._ s', h := s'
     | ._, ._, sublist.cons2 t ._ ._ s', h := absurd rfl h
     end⟩
-
-lemma tail_sublist (l : list α) : l.tail <+ l :=
-by { cases l; simp }
 
 /-! ### index_of -/
 
@@ -3477,7 +3466,9 @@ theorem drop_suffix (n) (l : list α) : drop n l <:+ l := ⟨_, take_append_drop
 
 theorem tail_suffix (l : list α) : tail l <:+ l := by rw ← drop_one; apply drop_suffix
 
-theorem tail_subset (l : list α) : tail l ⊆ l := (sublist_of_suffix (tail_suffix l)).subset
+lemma tail_sublist (l : list α) : l.tail <+ l := (sublist_of_suffix (tail_suffix l))
+
+theorem tail_subset (l : list α) : tail l ⊆ l := (tail_sublist l).subset
 
 theorem prefix_iff_eq_append {l₁ l₂ : list α} : l₁ <+: l₂ ↔ l₁ ++ drop (length l₁) l₂ = l₂ :=
 ⟨by rintros ⟨r, rfl⟩; rw drop_left, λ e, ⟨_, e⟩⟩

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -960,6 +960,9 @@ instance decidable_sublist [decidable_eq α] : ∀ (l₁ l₂ : list α), decida
     | ._, ._, sublist.cons2 t ._ ._ s', h := absurd rfl h
     end⟩
 
+lemma tail_sublist (l : list α) : l.tail <+ l :=
+by { cases l; simp }
+
 /-! ### index_of -/
 
 section index_of

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -3466,7 +3466,7 @@ theorem drop_suffix (n) (l : list α) : drop n l <:+ l := ⟨_, take_append_drop
 
 theorem tail_suffix (l : list α) : tail l <:+ l := by rw ← drop_one; apply drop_suffix
 
-lemma tail_sublist (l : list α) : l.tail <+ l := (sublist_of_suffix (tail_suffix l))
+lemma tail_sublist (l : list α) : l.tail <+ l := sublist_of_suffix (tail_suffix l)
 
 theorem tail_subset (l : list α) : tail l ⊆ l := (tail_sublist l).subset
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -761,6 +761,20 @@ theorem head_mem_head' [inhabited α] : ∀ {l : list α} (h : l ≠ []), head l
 theorem cons_head_tail [inhabited α] {l : list α} (h : l ≠ []) : (head l)::(tail l) = l :=
 cons_head'_tail (head_mem_head' h)
 
+lemma mem_of_mem_tail {a : α} {l : list α} (h : a ∈ l.tail) : a ∈ l :=
+begin
+  cases l,
+  { rwa tail_nil at h },
+  rw tail_cons at h,
+  exact mem_cons_of_mem _ h,
+end
+
+lemma head_mem_self [inhabited α] {l : list α} (h : l ≠ nil) : l.head ∈ l :=
+begin
+  have h' := mem_cons_self l.head l.tail,
+  rwa cons_head_tail h at h',
+end
+
 @[simp] theorem head'_map (f : α → β) (l) : head' (map f l) = (head' l).map f := by cases l; refl
 
 /-! ### Induction from the right -/

--- a/src/data/list/forall2.lean
+++ b/src/data/list/forall2.lean
@@ -271,9 +271,12 @@ instance sublist_forall₂.is_trans [is_trans α ra] :
     { exact sublist_forall₂.cons_right (ih _ _ h1 btc), } }
 end⟩
 
+lemma sublist.sublist_forall₂ {l₁ l₂ : list α} (h : l₁ <+ l₂) (r : α → α → Prop) [is_refl α r] :
+  sublist_forall₂ r l₁ l₂ :=
+sublist_forall₂_iff.2 ⟨l₁, forall₂_refl l₁, h⟩
 
 lemma tail_sublist_forall₂_self [is_refl α ra] (l : list α) :
   sublist_forall₂ ra l.tail l :=
-sublist_forall₂_iff.2 ⟨l.tail, forall₂_refl l.tail, l.tail_sublist⟩
+l.tail_sublist.sublist_forall₂ ra
 
 end list

--- a/src/data/list/forall2.lean
+++ b/src/data/list/forall2.lean
@@ -251,11 +251,7 @@ variable {ra : α → α → Prop}
 
 instance sublist_forall₂.is_refl [is_refl α ra] :
   is_refl (list α) (sublist_forall₂ ra) :=
-⟨λ l, begin
-  induction l with a t ih,
-  { exact sublist_forall₂.nil },
-  { exact sublist_forall₂.cons (refl a) ih }
-end⟩
+⟨λ l, sublist_forall₂_iff.2 ⟨l, forall₂_refl l, sublist.refl l⟩⟩
 
 instance sublist_forall₂.is_trans [is_trans α ra] :
   is_trans (list α) (sublist_forall₂ ra) :=
@@ -278,18 +274,6 @@ end⟩
 
 lemma tail_sublist_forall₂_self [is_refl α ra] (l : list α) :
   sublist_forall₂ ra l.tail l :=
-begin
-  by_cases h : l = list.nil,
-  { rw [h, list.tail_nil],
-    apply refl },
-  { have h0 : ¬ _ := λ con, h (list.eq_nil_iff_forall_not_mem.2 con),
-    push_neg at h0,
-    obtain ⟨a, ha⟩ := h0,
-    haveI : inhabited α := ⟨a⟩,
-    have h' := sublist_forall₂.cons_right (refl (l.tail)),
-    rwa [list.cons_head_tail h] at h',
-    apply_instance }
-end
-
+sublist_forall₂_iff.2 ⟨l.tail, forall₂_refl l.tail, l.tail_sublist⟩
 
 end list


### PR DESCRIPTION
Defines the `sublist_forall₂` relation, indicating that one list is related by `forall₂` to a sublist of another.
Provides two lemmas, `head_mem_self` and `mem_of_mem_tail`, which will be useful when proving Higman's Lemma about the `sublist_forall₂` relation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
