### PR TITLE
[Merged by Bors] - feat(algebra/{algebra, module}/basic): make 3 multiplication by 1 `simp` lemmas

### DIFF
--- a/docs/tutorial/Zmod37.lean
+++ b/docs/tutorial/Zmod37.lean
@@ -167,7 +167,7 @@ instance : add_comm_group (Zmod37)  :=
       rw add_assoc, -- done :-) because after a rw a goal is closed if it's of the form x ≈ x,
                     -- as ≈ is known by Lean to be reflexive.
     end),
-  add_zero     := -- I will intrroduce some more sneaky stuff now now
+  add_zero     := -- I will introduce some more sneaky stuff now
                   -- add_zero for Zmod37 follows from add_zero on Z.
                   -- Note use of $ instead of the brackets
     λ abar, quotient.induction_on abar $ λ a, quotient.sound $ by rw add_zero,

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -609,10 +609,6 @@ variables [algebra R A] [algebra R B] (φ : A →ₐ[R] B)
 @[simp] lemma map_div (x y) : φ (x / y) = φ x / φ y :=
 φ.to_ring_hom.map_div x y
 
-@[simp] lemma rat.smul_one_eq_coe [algebra ℚ A] (m : ℚ) :
-  m • (1 : A) = ↑m :=
-by rw [algebra.smul_def, mul_one, ring_hom.eq_rat_cast]
-
 end division_ring
 
 theorem injective_iff {R A B : Type*} [comm_semiring R] [ring A] [semiring B]
@@ -621,6 +617,10 @@ theorem injective_iff {R A B : Type*} [comm_semiring R] [ring A] [semiring B]
 ring_hom.injective_iff (f : A →+* B)
 
 end alg_hom
+
+@[simp] lemma rat.smul_one_eq_coe {A : Type*} [division_ring A] [algebra ℚ A] (m : ℚ) :
+  m • (1 : A) = ↑m :=
+by rw [algebra.smul_def, mul_one, ring_hom.eq_rat_cast]
 
 set_option old_structure_cmd true
 /-- An equivalence of algebras is an equivalence of rings commuting with the actions of scalars. -/

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -609,7 +609,7 @@ variables [algebra R A] [algebra R B] (φ : A →ₐ[R] B)
 @[simp] lemma map_div (x y) : φ (x / y) = φ x / φ y :=
 φ.to_ring_hom.map_div x y
 
-lemma rat.smul_one_eq_coe [algebra ℚ A] (m : ℚ) :
+@[simp] lemma rat.smul_one_eq_coe [algebra ℚ A] (m : ℚ) :
   m • (1 : A) = ↑m :=
 by rw [algebra.smul_def, mul_one, ring_hom.eq_rat_cast]
 

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -577,10 +577,10 @@ end no_zero_smul_divisors
 -- lemmas about nat semimodules above are specific to these instances.
 attribute [instance] add_comm_monoid.nat_semimodule add_comm_group.int_module
 
-lemma nat.smul_one_eq_coe {R : Type*} [semiring R] [semimodule ℕ R] (m : ℕ) :
+@[simp] lemma nat.smul_one_eq_coe {R : Type*} [semiring R] [semimodule ℕ R] (m : ℕ) :
   m • (1 : R) = ↑m :=
 by rw [←nsmul_eq_smul, nsmul_eq_mul, mul_one]
 
-lemma int.smul_one_eq_coe {R : Type*} [ring R] [semimodule ℤ R] (m : ℤ) :
+@[simp] lemma int.smul_one_eq_coe {R : Type*} [ring R] [semimodule ℤ R] (m : ℤ) :
   m • (1 : R) = ↑m :=
 by rw [← gsmul_eq_smul, gsmul_eq_mul, mul_one]


### PR DESCRIPTION
The three lemmas in the merged PR #7094 could be simp lemmas.  This PR makes this suggestion.

While I was at it,
* I moved one of the lemmas outside of the `alg_hom` namespace,
* I fixed a typo in a doc string of a tutorial.

Zulip:
https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/trying.20out.20a.20.60simp.60.20lemma


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
