### PR TITLE
[Merged by Bors] - refactor(algebra/big_operators/order): use `to_additive`

### DIFF
--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -288,6 +288,15 @@ begin
     exact hle x hx h'x.2 }
 end
 
+@[to_additive single_lt_sum]
+lemma single_lt_prod' {i j : ι} (hij : j ≠ i) (hi : i ∈ s) (hj : j ∈ s) (hlt : 1 < f j)
+  (hle : ∀ k ∈ s, k ≠ i → 1 ≤ f k) :
+  f i < ∏ k in s, f k :=
+calc f i = ∏ k in {i}, f k : prod_singleton.symm
+     ... < ∏ k in s, f k   :
+  prod_lt_prod_of_subset' (singleton_subset_iff.2 hi) hj (mt mem_singleton.1 hij) hlt $
+    λ k hks hki, hle k hks (mt mem_singleton.2 hki)
+
 end ordered_cancel_comm_monoid
 
 section linear_ordered_cancel_comm_monoid

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -9,279 +9,340 @@ import algebra.big_operators.basic
 /-!
 # Results about big operators with values in an ordered algebraic structure.
 
-Mostly monotonicity results for the `∑` operation.
+Mostly monotonicity results for the `∏` and `∑` operations.
 
 -/
 
-universes u v w
-
 open_locale big_operators
 
-variables {α : Type u} {β : Type v} {γ : Type w}
+variables {ι α β M N G k R : Type*}
 
 namespace finset
-variables {s s₁ s₂ : finset α} {a : α} {f g : α → β}
 
+section
+
+variables [comm_monoid M] [ordered_comm_monoid N]
+
+/-- Let `{x | p x}` be a subsemigroup of a commutative monoid `M`. Let `f : M → N` be a map
+submultiplicative on `{x | p x}`, i.e., `p x → p y → f (x * y) ≤ f x * f y`. Let `g i`, `i ∈ s`, be
+a nonempty finite family of elements of `M` such that `∀ i ∈ s, p (g i)`. Then
+`f (∏ x in s, g x) ≤ ∏ x in s, f (g x)`. -/
 @[to_additive le_sum_nonempty_of_subadditive_on_pred]
-lemma le_prod_nonempty_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (p : α → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
-  (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : γ → α) (s : finset γ) (hs_nonempty : s.nonempty)
-  (hs : ∀ x, x ∈ s → p (g x)) :
-  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
+lemma le_prod_nonempty_of_submultiplicative_on_pred
+  (f : M → N) (p : M → Prop) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
+  (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : ι → M) (s : finset ι) (hs_nonempty : s.nonempty)
+  (hs : ∀ i ∈ s, p (g i)) :
+  f (∏ i in s, g i) ≤ ∏ i in s, f (g i) :=
 begin
   refine le_trans (multiset.le_prod_nonempty_of_submultiplicative_on_pred f p h_mul hp_mul _ _ _) _,
-  { simp [nonempty_iff_ne_empty.mp hs_nonempty], },
+  { simp [hs_nonempty.ne_empty], },
   { exact multiset.forall_mem_map_iff.mpr hs, },
   rw multiset.map_map,
   refl,
 end
 
-@[to_additive le_sum_nonempty_of_subadditive]
-lemma le_prod_nonempty_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_mul : ∀ x y, f (x * y) ≤ f x * f y) {s : finset γ} (hs : s.nonempty) (g : γ → α) :
-  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
-le_prod_nonempty_of_submultiplicative_on_pred f (λ i, true) (by simp [h_mul]) (by simp) g s hs
-  (by simp)
+/-- Let `{x | p x}` be an additive subsemigroup of an additive commutative monoid `M`. Let `f : M →
+N` be a map subadditive on `{x | p x}`, i.e., `p x → p y → f (x + y) ≤ f x + f y`. Let `g i`, `i ∈
+s`, be a nonempty finite family of elements of `M` such that `∀ i ∈ s, p (g i)`. Then 
+`f (∑ i in s, g i) ≤ ∏ i in s, f (g i)`. -/
+add_decl_doc le_sum_nonempty_of_subadditive_on_pred
 
+/-- If `f : M → N` is a submultiplicative function, `f (x * y) ≤ f x * f y` and `g i`, `i ∈ s`, is a
+nonempty finite family of elements of `M`, then `f (∏ i in s, g i) ≤ ∏ i in s, f (g i)`. -/
+@[to_additive le_sum_nonempty_of_subadditive]
+lemma le_prod_nonempty_of_submultiplicative
+  (f : M → N) (h_mul : ∀ x y, f (x * y) ≤ f x * f y) {s : finset ι} (hs : s.nonempty) (g : ι → M) :
+  f (∏ i in s, g i) ≤ ∏ i in s, f (g i) :=
+le_prod_nonempty_of_submultiplicative_on_pred f (λ i, true) (λ x y _ _, h_mul x y)
+  (λ _ _ _ _, trivial) g s hs (λ _ _, trivial)
+
+/-- If `f : M → N` is a subadditive function, `f (x + y) ≤ f x + f y` and `g i`, `i ∈ s`, is a
+nonempty finite family of elements of `M`, then `f (∑ i in s, g i) ≤ ∑ i in s, f (g i)`. -/
+add_decl_doc le_sum_nonempty_of_subadditive
+
+/-- Let `{x | p x}` be a subsemigroup of a commutative monoid `M`. Let `f : M → N` be a map
+such that `f 1 = 1` and `f` is submultiplicative on `{x | p x}`, i.e.,
+`p x → p y → f (x * y) ≤ f x * f y`. Let `g i`, `i ∈ s`, be a finite family of elements of `M` such
+that `∀ i ∈ s, p (g i)`. Then `f (∏ i in s, g i) ≤ ∏ i in s, f (g i)`. -/
 @[to_additive le_sum_of_subadditive_on_pred]
-lemma le_prod_of_submultiplicative_on_pred [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (p : α → Prop) (h_one : f 1 = 1) (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
-  (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : γ → α) {s : finset γ} (hs : ∀ x, x ∈ s → p (g x)) :
-  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
+lemma le_prod_of_submultiplicative_on_pred (f : M → N) (p : M → Prop) (h_one : f 1 = 1)
+  (h_mul : ∀ x y, p x → p y → f (x * y) ≤ f x * f y)
+  (hp_mul : ∀ x y, p x → p y → p (x * y)) (g : ι → M) {s : finset ι} (hs : ∀ i ∈ s, p (g i)) :
+  f (∏ i in s, g i) ≤ ∏ i in s, f (g i) :=
 begin
-  by_cases hs_nonempty : s.nonempty,
+  rcases eq_empty_or_nonempty s with rfl|hs_nonempty,
+  { simp [h_one] },
   { exact le_prod_nonempty_of_submultiplicative_on_pred f p h_mul hp_mul g s hs_nonempty hs, },
-  { simp [not_nonempty_iff_eq_empty.mp hs_nonempty, h_one], },
 end
 
+/-- Let `{x | p x}` be a subsemigroup of a commutative monoid `M`. Let `f : M → N` be a map
+such that `f 1 = 1` and `f` is submultiplicative on `{x | p x}`, i.e.,
+`p x → p y → f (x * y) ≤ f x * f y`. Let `g i`, `i ∈ s`, be a finite family of elements of `M` such
+that `∀ i ∈ s, p (g i)`. Then `f (∏ x in s, g x) ≤ ∏ x in s, f (g x)`. -/
+add_decl_doc le_sum_of_subadditive_on_pred
+
+/-- If `f : M → N` is a submultiplicative function, `f (x * y) ≤ f x * f y`, `f 1 = 1`, and `g i`,
+`i ∈ s`, is a finite family of elements of `M`, then `f (∏ i in s, g i) ≤ ∏ i in s, f (g i)`. -/
 @[to_additive le_sum_of_subadditive]
-lemma le_prod_of_submultiplicative [comm_monoid α] [ordered_comm_monoid β]
-  (f : α → β) (h_one : f 1 = 1) (h_mul : ∀ x y, f (x * y) ≤ f x * f y) (s : finset γ) (g : γ → α) :
-  f (∏ x in s, g x) ≤ ∏ x in s, f (g x) :=
+lemma le_prod_of_submultiplicative (f : M → N) (h_one : f 1 = 1)
+  (h_mul : ∀ x y, f (x * y) ≤ f x * f y) (s : finset ι) (g : ι → M) :
+  f (∏ i in s, g i) ≤ ∏ i in s, f (g i) :=
 begin
   refine le_trans (multiset.le_prod_of_submultiplicative f h_one h_mul _) _,
   rw multiset.map_map,
   refl,
 end
 
-lemma abs_sum_le_sum_abs [linear_ordered_field α] {f : β → α} {s : finset β} :
-  abs (∑ x in s, f x) ≤ ∑ x in s, abs (f x) :=
-le_sum_of_subadditive _ abs_zero abs_add s f
+/-- If `f : M → N` is a submultiplicative function, `f (x * y) ≤ f x * f y`, `f 1 = 1`, and `g i`,
+`i ∈ s`, is a finite family of elements of `M`, then `f (∏ i in s, g i) ≤ ∏ i in s, f (g i)`. -/
+add_decl_doc le_sum_of_subadditive
 
-lemma abs_prod [linear_ordered_comm_ring α] {f : β → α} {s : finset β} :
-  abs (∏ x in s, f x) = ∏ x in s, abs (f x) :=
-(abs_hom.to_monoid_hom : α →* α).map_prod _ _
+variables {f g : ι → N} {s t : finset ι}
 
-section ordered_add_comm_monoid
-variables [ordered_add_comm_monoid β]
+/-- In an ordered commutative monoid, if each factor `f i` of one finite product is less than or
+equal to the corresponding factor `g i` of another finite product, then
+`∏ i in s, f i ≤ ∏ i in s, g i`. -/
+@[to_additive sum_le_sum]
+lemma prod_le_prod'' (h : ∀ i ∈ s, f i ≤ g i) : ∏ i in s, f i ≤ ∏ i in s, g i :=
+begin
+  classical,
+  induction s using finset.induction_on with i s hi ihs h,
+  { refl },
+  { simp only [prod_insert hi],
+    exact mul_le_mul' (h _ (mem_insert_self _ _)) (ihs $ λ j hj, h j (mem_insert_of_mem hj)) }
+end
 
-lemma sum_le_sum : (∀x∈s, f x ≤ g x) → (∑ x in s, f x) ≤ (∑ x in s, g x) :=
+/-- In an ordered additive commutative monoid, if each summand `f i` of one finite sum is less than
+or equal to the corresponding summand `g i` of another finite sum, then
+`∑ i in s, f i ≤ ∑ i in s, g i`. -/
+add_decl_doc sum_le_sum
+
+@[to_additive sum_nonneg]  lemma one_le_prod' (h : ∀i ∈ s, 1 ≤ f i) : 1 ≤ (∏ i in s, f i) :=
+le_trans (by rw prod_const_one) (prod_le_prod'' h)
+
+@[to_additive sum_nonpos] lemma prod_le_one' (h : ∀i ∈ s, f i ≤ 1) : (∏ i in s, f i) ≤ 1 :=
+(prod_le_prod'' h).trans_eq (by rw prod_const_one)
+
+@[to_additive sum_le_sum_of_subset_of_nonneg]
+lemma prod_le_prod_of_subset_of_one_le' (h : s ⊆ t) (hf : ∀ i ∈ t, i ∉ s → 1 ≤ f i) :
+  ∏ i in s, f i ≤ ∏ i in t, f i :=
+by classical;
+calc (∏ i in s, f i) ≤ (∏ i in t \ s, f i) * (∏ i in s, f i) :
+    le_mul_of_one_le_left' $ one_le_prod' $ by simpa only [mem_sdiff, and_imp]
+  ... = ∏ i in t \ s ∪ s, f i : (prod_union sdiff_disjoint).symm
+  ... = ∏ i in t, f i         : by rw [sdiff_union_of_subset h]
+
+@[to_additive sum_mono_set_of_nonneg]
+lemma prod_mono_set_of_one_le' (hf : ∀ x, 1 ≤ f x) : monotone (λ s, ∏ x in s, f x) :=
+λ s t hst, prod_le_prod_of_subset_of_one_le' hst $ λ x _ _, hf x
+
+@[to_additive sum_eq_zero_iff_of_nonneg]
+lemma prod_eq_one_iff_of_one_le' : (∀ i ∈ s, 1 ≤ f i) → (∏ i in s, f i = 1 ↔ ∀ i ∈ s, f i = 1) :=
 begin
   classical,
   apply finset.induction_on s,
-  exact (λ _, le_refl _),
-  assume a s ha ih h,
-  have : f a + (∑ x in s, f x) ≤ g a + (∑ x in s, g x),
-    from add_le_add (h _ (mem_insert_self _ _)) (ih $ assume x hx, h _ $ mem_insert_of_mem hx),
-  by simpa only [sum_insert ha]
+  exact λ _, ⟨λ _ _, false.elim, λ _, rfl⟩,
+  assume a s ha ih H,
+  have : ∀ i ∈ s, 1 ≤ f i, from λ _, H _ ∘ mem_insert_of_mem,
+  rw [prod_insert ha, mul_eq_one_iff' (H _ $ mem_insert_self _ _) (one_le_prod' this),
+    forall_mem_insert, ih this]
 end
 
-theorem card_le_mul_card_image_of_maps_to [decidable_eq γ] {f : α → γ} {s : finset α} {t : finset γ}
+@[to_additive sum_eq_zero_iff_of_nonneg]
+lemma prod_eq_one_iff_of_le_one' : (∀ i ∈ s, f i ≤ 1) → (∏ i in s, f i = 1 ↔ ∀ i ∈ s, f i = 1) :=
+@prod_eq_one_iff_of_one_le' _ (order_dual N) _ _ _
+
+@[to_additive single_le_sum]
+lemma single_le_prod' (hf : ∀ i ∈ s, 1 ≤ f i) {a} (h : a ∈ s) : f a ≤ (∏ x in s, f x) :=
+calc f a = ∏ i in {a}, f i : prod_singleton.symm
+     ... ≤ ∏ i in s, f i   :
+  prod_le_prod_of_subset_of_one_le' (singleton_subset_iff.2 h) $ λ i hi _, hf i hi
+
+variables {ι' : Type*} [decidable_eq ι']
+
+@[to_additive sum_fiberwise_le_sum_of_sum_fiber_nonneg]
+lemma prod_fiberwise_le_prod_of_one_le_prod_fiber' {t : finset ι'}
+  {g : ι → ι'} {f : ι → N} (h : ∀ y ∉ t, (1 : N) ≤ ∏ x in s.filter (λ x, g x = y), f x) :
+  ∏ y in t, ∏ x in s.filter (λ x, g x = y), f x ≤ ∏ x in s, f x :=
+calc (∏ y in t, ∏ x in s.filter (λ x, g x = y), f x) ≤
+  (∏ y in t ∪ s.image g, ∏ x in s.filter (λ x, g x = y), f x) :
+  prod_le_prod_of_subset_of_one_le' (subset_union_left _ _) $ λ y hyts, h y
+... = ∏ x in s, f x :
+  prod_fiberwise_of_maps_to (λ x hx, mem_union.2 $ or.inr $ mem_image_of_mem _ hx) _
+
+@[to_additive sum_le_sum_fiberwise_of_sum_fiber_nonpos]
+lemma prod_le_prod_fiberwise_of_prod_fiber_le_one' {t : finset ι'}
+  {g : ι → ι'} {f : ι → N} (h : ∀ y ∉ t, (∏ x in s.filter (λ x, g x = y), f x) ≤ 1) :
+  (∏ x in s, f x) ≤ ∏ y in t, ∏ x in s.filter (λ x, g x = y), f x :=
+@prod_fiberwise_le_prod_of_one_le_prod_fiber' _ (order_dual N) _ _ _ _ _ _ _ h
+
+end
+
+lemma abs_sum_le_sum_abs {G : Type*} [linear_ordered_add_comm_group G] (f : ι → G) (s : finset ι) :
+  abs (∑ i in s, f i) ≤ ∑ i in s, abs (f i) :=
+le_sum_of_subadditive _ abs_zero abs_add s f
+
+lemma abs_prod {R : Type*} [linear_ordered_comm_ring R] {f : ι → R} {s : finset ι} :
+  abs (∏ x in s, f x) = ∏ x in s, abs (f x) :=
+(abs_hom.to_monoid_hom : R →* R).map_prod _ _
+
+section pigeonhole
+
+variable [decidable_eq β]
+
+theorem card_le_mul_card_image_of_maps_to {f : α → β} {s : finset α} {t : finset β}
   (Hf : ∀ a ∈ s, f a ∈ t) (n : ℕ) (hn : ∀ a ∈ t, (s.filter (λ x, f x = a)).card ≤ n) :
   s.card ≤ n * t.card :=
 calc s.card = (∑ a in t, (s.filter (λ x, f x = a)).card) : card_eq_sum_card_fiberwise Hf
         ... ≤ (∑ _ in t, n)                              : sum_le_sum hn
         ... = _                                          : by simp [mul_comm]
 
-theorem card_le_mul_card_image [decidable_eq γ] {f : α → γ} (s : finset α)
+theorem card_le_mul_card_image {f : α → β} (s : finset α)
   (n : ℕ) (hn : ∀ a ∈ s.image f, (s.filter (λ x, f x = a)).card ≤ n) :
   s.card ≤ n * (s.image f).card :=
 card_le_mul_card_image_of_maps_to (λ x, mem_image_of_mem _) n hn
 
-theorem mul_card_image_le_card_of_maps_to [decidable_eq γ] {f : α → γ} {s : finset α} {t : finset γ}
+theorem mul_card_image_le_card_of_maps_to {f : α → β} {s : finset α} {t : finset β}
   (Hf : ∀ a ∈ s, f a ∈ t) (n : ℕ) (hn : ∀ a ∈ t, n ≤ (s.filter (λ x, f x = a)).card) :
   n * t.card ≤ s.card :=
 calc n * t.card = (∑ _ in t, n) : by simp [mul_comm]
             ... ≤ (∑ a in t, (s.filter (λ x, f x = a)).card) : sum_le_sum hn
             ... = s.card : by rw ← card_eq_sum_card_fiberwise Hf
 
-theorem mul_card_image_le_card [decidable_eq γ] {f : α → γ} (s : finset α)
+theorem mul_card_image_le_card {f : α → β} (s : finset α)
   (n : ℕ) (hn : ∀ a ∈ s.image f, n ≤ (s.filter (λ x, f x = a)).card) :
   n * (s.image f).card ≤ s.card :=
 mul_card_image_le_card_of_maps_to (λ x, mem_image_of_mem _) n hn
 
-lemma sum_nonneg (h : ∀x∈s, 0 ≤ f x) : 0 ≤ (∑ x in s, f x) :=
-le_trans (by rw [sum_const_zero]) (sum_le_sum h)
+end pigeonhole
 
-lemma sum_nonpos (h : ∀x∈s, f x ≤ 0) : (∑ x in s, f x) ≤ 0 :=
-le_trans (sum_le_sum h) (by rw [sum_const_zero])
+section canonically_ordered_monoid
 
-lemma sum_le_sum_of_subset_of_nonneg
-  (h : s₁ ⊆ s₂) (hf : ∀x∈s₂, x ∉ s₁ → 0 ≤ f x) : (∑ x in s₁, f x) ≤ (∑ x in s₂, f x) :=
+variables [canonically_ordered_monoid M] {f : ι → M} {s t : finset ι}
+
+@[simp, to_additive sum_eq_zero_iff]
+lemma prod_eq_one_iff' : ∏ x in s, f x = 1 ↔ ∀ x ∈ s, f x = 1 :=
+prod_eq_one_iff_of_one_le' $ λ x hx, one_le (f x)
+
+@[to_additive sum_le_sum_of_subset]
+lemma prod_le_prod_of_subset' (h : s ⊆ t) : ∏ x in s, f x ≤ ∏ x in t, f x :=
+prod_le_prod_of_subset_of_one_le' h $ assume x h₁ h₂, one_le _
+
+@[to_additive sum_mono_set]
+lemma prod_mono_set' (f : ι → M) : monotone (λ s, ∏ x in s, f x) :=
+λ s₁ s₂ hs, prod_le_prod_of_subset' hs
+
+@[to_additive sum_le_sum_of_ne_zero]
+lemma prod_le_prod_of_ne_one' (h : ∀ x ∈ s, f x ≠ 1 → x ∈ t) :
+  ∏ x in s, f x ≤ ∏ x in t, f x :=
 by classical;
-calc (∑ x in s₁, f x) ≤ (∑ x in s₂ \ s₁, f x) + (∑ x in s₁, f x) :
-    le_add_of_nonneg_left $ sum_nonneg $ by simpa only [mem_sdiff, and_imp]
-  ... = ∑ x in s₂ \ s₁ ∪ s₁, f x : (sum_union sdiff_disjoint).symm
-  ... = (∑ x in s₂, f x)         : by rw [sdiff_union_of_subset h]
-
-lemma sum_mono_set_of_nonneg (hf : ∀ x, 0 ≤ f x) : monotone (λ s, ∑ x in s, f x) :=
-λ s₁ s₂ hs, sum_le_sum_of_subset_of_nonneg hs $ λ x _ _, hf x
-
-lemma sum_fiberwise_le_sum_of_sum_fiber_nonneg [decidable_eq γ] {s : finset α} {t : finset γ}
-  {g : α → γ} {f : α → β} (h : ∀ y ∉ t, (0 : β) ≤ ∑ x in s.filter (λ x, g x = y), f x) :
-  (∑ y in t, ∑ x in s.filter (λ x, g x = y), f x) ≤ ∑ x in s, f x :=
-calc (∑ y in t, ∑ x in s.filter (λ x, g x = y), f x) ≤
-  (∑ y in t ∪ s.image g, ∑ x in s.filter (λ x, g x = y), f x) :
-  sum_le_sum_of_subset_of_nonneg (subset_union_left _ _) $ λ y hyts, h y
-... = ∑ x in s, f x :
-  sum_fiberwise_of_maps_to (λ x hx, mem_union.2 $ or.inr $ mem_image_of_mem _ hx) _
-
-lemma sum_le_sum_fiberwise_of_sum_fiber_nonpos [decidable_eq γ] {s : finset α} {t : finset γ}
-  {g : α → γ} {f : α → β} (h : ∀ y ∉ t, (∑ x in s.filter (λ x, g x = y), f x) ≤ 0) :
-  (∑ x in s, f x) ≤ ∑ y in t, ∑ x in s.filter (λ x, g x = y), f x :=
-@sum_fiberwise_le_sum_of_sum_fiber_nonneg α (order_dual β) _ _ _ _ _ _ _ h
-
-lemma sum_eq_zero_iff_of_nonneg : (∀x∈s, 0 ≤ f x) → ((∑ x in s, f x) = 0 ↔ ∀x∈s, f x = 0) :=
-begin
-  classical,
-  apply finset.induction_on s,
-  exact λ _, ⟨λ _ _, false.elim, λ _, rfl⟩,
-  assume a s ha ih H,
-  have : ∀ x ∈ s, 0 ≤ f x, from λ _, H _ ∘ mem_insert_of_mem,
-  rw [sum_insert ha, add_eq_zero_iff' (H _ $ mem_insert_self _ _) (sum_nonneg this),
-    forall_mem_insert, ih this]
-end
-
-lemma sum_eq_zero_iff_of_nonpos : (∀x∈s, f x ≤ 0) → ((∑ x in s, f x) = 0 ↔ ∀x∈s, f x = 0) :=
-@sum_eq_zero_iff_of_nonneg _ (order_dual β) _ _ _
-
-lemma single_le_sum (hf : ∀x∈s, 0 ≤ f x) {a} (h : a ∈ s) : f a ≤ (∑ x in s, f x) :=
-have ∑ x in {a}, f x ≤ (∑ x in s, f x),
-  from sum_le_sum_of_subset_of_nonneg
-  (λ x e, (mem_singleton.1 e).symm ▸ h) (λ x h _, hf x h),
-by rwa sum_singleton at this
-
-end ordered_add_comm_monoid
-
-section canonically_ordered_add_monoid
-variables [canonically_ordered_add_monoid β]
-
-@[simp] lemma sum_eq_zero_iff : ∑ x in s, f x = 0 ↔ ∀ x ∈ s, f x = 0 :=
-sum_eq_zero_iff_of_nonneg $ λ x hx, zero_le (f x)
-
-lemma sum_le_sum_of_subset (h : s₁ ⊆ s₂) : (∑ x in s₁, f x) ≤ (∑ x in s₂, f x) :=
-sum_le_sum_of_subset_of_nonneg h $ assume x h₁ h₂, zero_le _
-
-lemma sum_mono_set (f : α → β) : monotone (λ s, ∑ x in s, f x) :=
-λ s₁ s₂ hs, sum_le_sum_of_subset hs
-
-lemma sum_le_sum_of_ne_zero (h : ∀x∈s₁, f x ≠ 0 → x ∈ s₂) :
-  (∑ x in s₁, f x) ≤ (∑ x in s₂, f x) :=
-by classical;
-calc (∑ x in s₁, f x) = ∑ x in s₁.filter (λx, f x = 0), f x + ∑ x in s₁.filter (λx, f x ≠ 0), f x :
-    by rw [←sum_union, filter_union_filter_neg_eq];
+calc ∏ x in s, f x = (∏ x in s.filter (λ x, f x = 1), f x) * ∏ x in s.filter (λ x, f x ≠ 1), f x :
+    by rw [← prod_union, filter_union_filter_neg_eq];
        exact disjoint_filter.2 (assume _ _ h n_h, n_h h)
-  ... ≤ (∑ x in s₂, f x) : add_le_of_nonpos_of_le'
-      (sum_nonpos $ by simp only [mem_filter, and_imp]; exact λ _ _, le_of_eq)
-      (sum_le_sum_of_subset $ by simpa only [subset_iff, mem_filter, and_imp])
+  ... ≤ (∏ x in t, f x) : mul_le_of_le_one_of_le'
+      (prod_le_one' $ by simp only [mem_filter, and_imp]; exact λ _ _, le_of_eq)
+      (prod_le_prod_of_subset' $ by simpa only [subset_iff, mem_filter, and_imp])
 
-end canonically_ordered_add_monoid
+end canonically_ordered_monoid
 
 section ordered_cancel_comm_monoid
 
-variables [ordered_cancel_add_comm_monoid β]
+variables [ordered_cancel_comm_monoid M] {f g : ι → M} {s t : finset ι}
 
-theorem sum_lt_sum (Hle : ∀ i ∈ s, f i ≤ g i) (Hlt : ∃ i ∈ s, f i < g i) :
-  (∑ x in s, f x) < (∑ x in s, g x) :=
+@[to_additive sum_lt_sum]
+theorem prod_lt_prod' (Hle : ∀ i ∈ s, f i ≤ g i) (Hlt : ∃ i ∈ s, f i < g i) :
+  ∏ i in s, f i < ∏ i in s, g i :=
 begin
   classical,
   rcases Hlt with ⟨i, hi, hlt⟩,
-  rw [← insert_erase hi, sum_insert (not_mem_erase _ _), sum_insert (not_mem_erase _ _)],
-  exact add_lt_add_of_lt_of_le hlt (sum_le_sum $ λ j hj, Hle j  $ mem_of_mem_erase hj)
+  rw [← insert_erase hi, prod_insert (not_mem_erase _ _), prod_insert (not_mem_erase _ _)],
+  exact mul_lt_mul_of_lt_of_le hlt (prod_le_prod'' $ λ j hj, Hle j  $ mem_of_mem_erase hj)
 end
 
-lemma sum_lt_sum_of_nonempty (hs : s.nonempty) (Hlt : ∀ x ∈ s, f x < g x) :
-  (∑ x in s, f x) < (∑ x in s, g x) :=
+@[to_additive sum_lt_sum_of_nonempty]
+lemma prod_lt_prod_of_nonempty' (hs : s.nonempty) (Hlt : ∀ i ∈ s, f i < g i) :
+  ∏ i in s, f i < ∏ i in s, g i :=
 begin
-  apply sum_lt_sum,
+  apply prod_lt_prod',
   { intros i hi, apply le_of_lt (Hlt i hi) },
   cases hs with i hi,
   exact ⟨i, hi, Hlt i hi⟩,
 end
 
-lemma sum_lt_sum_of_subset [decidable_eq α]
-  (h : s₁ ⊆ s₂) {i : α} (hi : i ∈ s₂ \ s₁) (hpos : 0 < f i) (hnonneg : ∀ j ∈ s₂ \ s₁, 0 ≤ f j) :
-  (∑ x in s₁, f x) < (∑ x in s₂, f x) :=
-calc (∑ x in s₁, f x) < (∑ x in insert i s₁, f x) :
+@[to_additive sum_lt_sum_of_subset]
+lemma prod_lt_prod_of_subset' (h : s ⊆ t) {i : ι} (ht : i ∈ t) (hs : i ∉ s) (hlt : 1 < f i)
+  (hle : ∀ j ∈ t, j ∉ s → 1 ≤ f j) :
+  ∏ j in s, f j < ∏ j in t, f j :=
+by classical;
+calc ∏ j in s, f j < ∏ j in insert i s, f j :
 begin
-  simp only [mem_sdiff] at hi,
-  rw sum_insert hi.2,
-  exact lt_add_of_pos_left (∑ x in s₁, f x) hpos,
+  rw prod_insert hs,
+  exact lt_mul_of_one_lt_left' (∏ j in s, f j) hlt,
 end
-... ≤ (∑ x in s₂, f x) :
+... ≤ ∏ j in t, f j :
 begin
-  simp only [mem_sdiff] at hi,
-  apply sum_le_sum_of_subset_of_nonneg,
-  { simp [finset.insert_subset, h, hi.1] },
+  apply prod_le_prod_of_subset_of_one_le',
+  { simp [finset.insert_subset, h, ht] },
   { assume x hx h'x,
-    apply hnonneg x,
-    simp [mem_insert, not_or_distrib] at h'x,
-    rw mem_sdiff,
-    simp [hx, h'x] }
+    simp only [mem_insert, not_or_distrib] at h'x,
+    exact hle x hx h'x.2 }
 end
 
 end ordered_cancel_comm_monoid
 
 section linear_ordered_cancel_comm_monoid
 
-variables [linear_ordered_cancel_add_comm_monoid β]
+variables [linear_ordered_cancel_comm_monoid M] {f g : ι → M} {s t : finset ι}
 
-theorem exists_lt_of_sum_lt (Hlt : (∑ x in s, f x) < ∑ x in s, g x) :
+@[to_additive exists_lt_of_sum_lt]
+theorem exists_lt_of_prod_lt' (Hlt : ∏ i in s, f i < ∏ i in s, g i) :
   ∃ i ∈ s, f i < g i :=
 begin
   contrapose! Hlt with Hle,
-  exact sum_le_sum Hle
+  exact prod_le_prod'' Hle
 end
 
-theorem exists_le_of_sum_le (hs : s.nonempty) (Hle : (∑ x in s, f x) ≤ ∑ x in s, g x) :
+@[to_additive exists_le_of_sum_le]
+theorem exists_le_of_prod_le' (hs : s.nonempty) (Hle : ∏ i in s, f i ≤ ∏ i in s, g i) :
   ∃ i ∈ s, f i ≤ g i :=
 begin
   contrapose! Hle with Hlt,
-  rcases hs with ⟨i, hi⟩,
-  exact sum_lt_sum (λ i hi, le_of_lt (Hlt i hi)) ⟨i, hi, Hlt i hi⟩
+  exact prod_lt_prod_of_nonempty' hs Hlt
 end
 
-lemma exists_pos_of_sum_zero_of_exists_nonzero (f : α → β)
-  (h₁ : ∑ e in s, f e = 0) (h₂ : ∃ x ∈ s, f x ≠ 0) :
-  ∃ x ∈ s, 0 < f x :=
+@[to_additive exists_pos_of_sum_zero_of_exists_nonzero]
+lemma exists_one_lt_of_prod_one_of_exists_ne_one' (f : ι → M)
+  (h₁ : ∏ i in s, f i = 1) (h₂ : ∃ i ∈ s, f i ≠ 1) :
+  ∃ i ∈ s, 1 < f i :=
 begin
   contrapose! h₁,
-  obtain ⟨x, m, x_nz⟩ : ∃ x ∈ s, f x ≠ 0 := h₂,
+  obtain ⟨i, m, i_ne⟩ : ∃ i ∈ s, f i ≠ 1 := h₂,
   apply ne_of_lt,
-  calc ∑ e in s, f e < ∑ e in s, 0 : sum_lt_sum h₁ ⟨x, m, lt_of_le_of_ne (h₁ x m) x_nz⟩
-                 ... = 0           : by rw [finset.sum_const, nsmul_zero],
+  calc ∏ j in s, f j < ∏ j in s, 1 : prod_lt_prod' h₁ ⟨i, m, (h₁ i m).lt_of_ne i_ne⟩
+                 ... = 1           : prod_const_one
 end
 
 end linear_ordered_cancel_comm_monoid
 
 section ordered_comm_semiring
 
-variables [ordered_comm_semiring β]
+variables [ordered_comm_semiring R] {f g : ι → R} {s t : finset ι}
 open_locale classical
 
 /- this is also true for a ordered commutative multiplicative monoid -/
-lemma prod_nonneg {s : finset α} {f : α → β}
-  (h0 : ∀(x ∈ s), 0 ≤ f x) : 0 ≤ (∏ x in s, f x) :=
-prod_induction f (λ x, 0 ≤ x) (λ _ _ ha hb, mul_nonneg ha hb) zero_le_one h0
+lemma prod_nonneg (h0 : ∀ i ∈ s, 0 ≤ f i) : 0 ≤ ∏ i in s, f i :=
+prod_induction f (λ i, 0 ≤ i) (λ _ _ ha hb, mul_nonneg ha hb) zero_le_one h0
 
 /- this is also true for a ordered commutative multiplicative monoid -/
-lemma prod_pos [nontrivial β] {s : finset α} {f : α → β} (h0 : ∀(x ∈ s), 0 < f x) :
-  0 < (∏ x in s, f x) :=
+lemma prod_pos [nontrivial R] (h0 : ∀ i ∈ s, 0 < f i) :
+  0 < ∏ i in s, f i :=
 prod_induction f (λ x, 0 < x) (λ _ _ ha hb, mul_pos ha hb) zero_lt_one h0
 
-/- this is also true for a ordered commutative multiplicative monoid -/
-lemma prod_le_prod {s : finset α} {f g : α → β} (h0 : ∀(x ∈ s), 0 ≤ f x)
-  (h1 : ∀(x ∈ s), f x ≤ g x) : (∏ x in s, f x) ≤ (∏ x in s, g x) :=
+/-- If all `f i`, `i ∈ s`, are nonnegative and each `f i` is less than or equal to `g i`, then the
+product of `f i` is less than or equal to the product of `g i`. See also `finset.prod_le_prod''` for
+the case of an ordered commutative multiplicative monoid. -/
+lemma prod_le_prod (h0 : ∀ i ∈ s, 0 ≤ f i) (h1 : ∀ i ∈ s, f i ≤ g i) :
+  ∏ i in s, f i ≤ ∏ i in s, g i :=
 begin
   induction s using finset.induction with a s has ih h,
   { simp },
@@ -292,8 +353,10 @@ begin
     { apply le_trans (h0 a (mem_insert_self a s)) (h1 a (mem_insert_self a s)) } }
 end
 
-lemma prod_le_one {s : finset α} {f : α → β} (h0 : ∀(x ∈ s), 0 ≤ f x)
-  (h1 : ∀(x ∈ s), f x ≤ 1) : (∏ x in s, f x) ≤ 1 :=
+/-- If each `f i`, `i ∈ s` belongs to `[0, 1]`, then their product is less than or equal to one.
+See also `finset.prod_le_one'` for the case of an ordered commutative multiplicative monoid. -/
+lemma prod_le_one (h0 : ∀ i ∈ s, 0 ≤ f i) (h1 : ∀ i ∈ s, f i ≤ 1) :
+  ∏ i in s, f i ≤ 1 :=
 begin
   convert ← prod_le_prod h0 h1,
   exact finset.prod_const_one
@@ -301,7 +364,7 @@ end
 
 /-- If `g, h ≤ f` and `g i + h i ≤ f i`, then the product of `f` over `s` is at least the
   sum of the products of `g` and `h`. This is the version for `ordered_comm_semiring`. -/
-lemma prod_add_prod_le {s : finset α} {i : α} {f g h : α → β}
+lemma prod_add_prod_le {i : ι} {f g h : ι → R}
   (hi : i ∈ s) (h2i : g i + h i ≤ f i) (hgf : ∀ j ∈ s, j ≠ i → g j ≤ f j)
   (hhf : ∀ j ∈ s, j ≠ i → h j ≤ f j) (hg : ∀ i ∈ s, 0 ≤ g i) (hh : ∀ i ∈ s, 0 ≤ h i) :
   ∏ i in s, g i + ∏ i in s, h i ≤ ∏ i in s, f i :=
@@ -319,10 +382,10 @@ end ordered_comm_semiring
 
 section canonically_ordered_comm_semiring
 
-variables [canonically_ordered_comm_semiring β]
+variables [canonically_ordered_comm_semiring R] {f g h : ι → R} {s : finset ι} {i : ι}
 
-lemma prod_le_prod' {s : finset α} {f g : α → β} (h : ∀ i ∈ s, f i ≤ g i) :
-  (∏ x in s, f x) ≤ (∏ x in s, g x) :=
+lemma prod_le_prod' (h : ∀ i ∈ s, f i ≤ g i) :
+  ∏ i in s, f i ≤ ∏ i in s, g i :=
 begin
   classical,
   induction s using finset.induction with a s has ih h,
@@ -336,7 +399,7 @@ end
 /-- If `g, h ≤ f` and `g i + h i ≤ f i`, then the product of `f` over `s` is at least the
   sum of the products of `g` and `h`. This is the version for `canonically_ordered_comm_semiring`.
 -/
-lemma prod_add_prod_le' {s : finset α} {i : α} {f g h : α → β} (hi : i ∈ s) (h2i : g i + h i ≤ f i)
+lemma prod_add_prod_le' (hi : i ∈ s) (h2i : g i + h i ≤ f i)
   (hgf : ∀ j ∈ s, j ≠ i → g j ≤ f j) (hhf : ∀ j ∈ s, j ≠ i → h j ≤ f j) :
   ∏ i in s, g i + ∏ i in s, h i ≤ ∏ i in s, f i :=
 begin
@@ -353,14 +416,16 @@ end finset
 
 namespace fintype
 
-variables [fintype α]
+variables [fintype ι]
 
-@[mono] lemma sum_mono [ordered_add_comm_monoid β] : monotone (λ f : α → β, ∑ x, f x) :=
-λ f g hfg, finset.sum_le_sum $ λ x _, hfg x
+@[mono, to_additive sum_mono]
+lemma prod_mono' [ordered_comm_monoid M] : monotone (λ f : ι → M, ∏ i, f i) :=
+λ f g hfg, finset.prod_le_prod'' $ λ x _, hfg x
 
-lemma sum_strict_mono [ordered_cancel_add_comm_monoid β] : strict_mono (λ f : α → β, ∑ x, f x) :=
+@[to_additive sum_strict_mono]
+lemma prod_strict_mono' [ordered_cancel_comm_monoid M] : strict_mono (λ f : ι → M, ∏ x, f x) :=
 λ f g hfg, let ⟨hle, i, hlt⟩ := pi.lt_def.mp hfg in
-  finset.sum_lt_sum (λ i _, hle i) ⟨i, finset.mem_univ i, hlt⟩
+  finset.prod_lt_prod' (λ i _, hle i) ⟨i, finset.mem_univ i, hlt⟩
 
 end fintype
 
@@ -368,29 +433,31 @@ namespace with_top
 open finset
 
 /-- A product of finite numbers is still finite -/
-lemma prod_lt_top [canonically_ordered_comm_semiring β] [nontrivial β] [decidable_eq β]
-  {s : finset α} {f : α → with_top β} (h : ∀ a ∈ s, f a < ⊤) :
-  (∏ x in s, f x) < ⊤ :=
+lemma prod_lt_top [canonically_ordered_comm_semiring R] [nontrivial R] [decidable_eq R]
+  {s : finset ι} {f : ι → with_top R} (h : ∀ i ∈ s, f i < ⊤) :
+  ∏ i in s, f i < ⊤ :=
 prod_induction f (λ a, a < ⊤) (λ a b, mul_lt_top) (coe_lt_top 1) h
 
 /-- A sum of finite numbers is still finite -/
-lemma sum_lt_top [ordered_add_comm_monoid β] {s : finset α} {f : α → with_top β} :
-  (∀a∈s, f a < ⊤) → (∑ x in s, f x) < ⊤ :=
-λ h, sum_induction f (λ a, a < ⊤) (by { simp_rw add_lt_top, tauto }) zero_lt_top h
-
-/-- A sum of finite numbers is still finite -/
-lemma sum_lt_top_iff [canonically_ordered_add_monoid β] {s : finset α} {f : α → with_top β} :
-  (∑ x in s, f x) < ⊤ ↔ (∀a∈s, f a < ⊤) :=
-iff.intro (λh a ha, lt_of_le_of_lt (single_le_sum (λa ha, zero_le _) ha) h) sum_lt_top
+lemma sum_lt_top [ordered_add_comm_monoid M] {s : finset ι} {f : ι → with_top M} :
+  (∀ i ∈ s, f i < ⊤) → (∑ i in s, f i) < ⊤ :=
+sum_induction f (λ a, a < ⊤) (by { simp_rw add_lt_top, tauto }) zero_lt_top
 
 /-- A sum of numbers is infinite iff one of them is infinite -/
-lemma sum_eq_top_iff [canonically_ordered_add_monoid β] {s : finset α} {f : α → with_top β} :
-  (∑ x in s, f x) = ⊤ ↔ (∃a∈s, f a = ⊤) :=
+lemma sum_eq_top_iff [ordered_add_comm_monoid M] {s : finset ι} {f : ι → with_top M} :
+  ∑ i in s, f i = ⊤ ↔ ∃ i ∈ s, f i = ⊤ :=
 begin
-  rw ← not_iff_not,
-  push_neg,
-  simp only [← lt_top_iff_ne_top],
-  exact sum_lt_top_iff
+  classical,
+  split,
+  { contrapose!,
+    exact λ h, (sum_lt_top $ λ i hi, lt_top_iff_ne_top.2 (h i hi)).ne },
+  { rintro ⟨i, his, hi⟩,
+    rw [sum_eq_add_sum_diff_singleton his, hi, top_add] }
 end
+
+/-- A sum of finite numbers is still finite -/
+lemma sum_lt_top_iff [ordered_add_comm_monoid M] {s : finset ι} {f : ι → with_top M} :
+  ∑ i in s, f i < ⊤ ↔ ∀ i ∈ s, f i < ⊤ :=
+by simp only [lt_top_iff_ne_top, ne.def, sum_eq_top_iff, not_exists]
 
 end with_top

--- a/src/combinatorics/composition.lean
+++ b/src/combinatorics/composition.lean
@@ -543,12 +543,10 @@ begin
     { intros j,
       by_contradiction ji,
       apply lt_irrefl ∑ k, c.blocks_fun k,
-      calc ∑ k, c.blocks_fun k ≤ ∑ k in {i}, c.blocks_fun k : by simp [c.sum_blocks_fun, hi]
-      ... < ∑ k, c.blocks_fun k : begin
-        have : j ∈ finset.univ \ {i}, by { rw [finset.mem_sdiff, finset.mem_singleton], simp [ji] },
-        refine finset.sum_lt_sum_of_subset (finset.subset_univ _) this (c.one_le_blocks_fun j) _,
-        exact λ k hk, zero_le_one.trans (c.one_le_blocks_fun k)
-      end },
+      calc ∑ k, c.blocks_fun k ≤ c.blocks_fun i      : by simp only [c.sum_blocks_fun, hi]
+                           ... < ∑ k, c.blocks_fun k :
+        finset.single_lt_sum ji (finset.mem_univ _) (finset.mem_univ _) (c.one_le_blocks_fun j)
+          (λ _ _ _, zero_le _) },
     simpa using fintype.card_eq_one_of_forall_eq this }
 end
 


### PR DESCRIPTION
* Replace many lemmas about `finset.sum` with lemmas about `finset.prod` + `@[to_additive]`;
* Avoid `s \ t` in `finset.sum_lt_sum_of_subset`.
* Use `M`, `N` instead of `α`, `β` for types with algebraic structures.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
