### PR TITLE
[Merged by Bors] - feat(src/set_theory/surreal): add numeric_add and numeric_omega lemmas

### DIFF
--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -260,7 +260,7 @@ theorem numeric_nat : Π (n : ℕ), numeric n
 
 /-- The pre-game omega is numeric. -/
 theorem numeric_omega : numeric omega :=
-⟨by rintros ⟨⟩ ⟨⟩, λ i, by simp [numeric_nat i.down], by rintros ⟨⟩⟩
+⟨by rintros ⟨⟩ ⟨⟩, λ i, numeric_nat i.down, by rintros ⟨⟩⟩
 
 end pgame
 

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -253,9 +253,17 @@ theorem numeric_add : Π {x y : pgame} (ox : numeric x) (oy : numeric y), numeri
  end⟩
 using_well_founded { dec_tac := pgame_wf_tac }
 
--- TODO prove
--- theorem numeric_nat (n : ℕ) : numeric n := sorry
--- theorem numeric_omega : numeric omega := sorry
+/-- Pre-games defined by natural numbers are numeric. -/
+theorem numeric_nat (n : ℕ) : numeric n :=
+begin
+  induction n with n hn,
+  apply numeric_zero,
+  apply numeric_add hn numeric_one,
+end
+
+/-- The pre-game omega is numeric. -/
+theorem numeric_omega : numeric omega :=
+⟨by rintros ⟨ ⟩ ⟨ ⟩, λ i, by simp [numeric_nat i.down] , by rintros ⟨ ⟩⟩
 
 end pgame
 

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -260,7 +260,7 @@ theorem numeric_nat : Π (n : ℕ), numeric n
 
 /-- The pre-game omega is numeric. -/
 theorem numeric_omega : numeric omega :=
-⟨by rintros ⟨ ⟩ ⟨ ⟩, λ i, by simp [numeric_nat i.down] , by rintros ⟨ ⟩⟩
+⟨by rintros ⟨⟩ ⟨⟩, λ i, by simp [numeric_nat i.down], by rintros ⟨⟩⟩
 
 end pgame
 

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -254,12 +254,9 @@ theorem numeric_add : Π {x y : pgame} (ox : numeric x) (oy : numeric y), numeri
 using_well_founded { dec_tac := pgame_wf_tac }
 
 /-- Pre-games defined by natural numbers are numeric. -/
-theorem numeric_nat (n : ℕ) : numeric n :=
-begin
-  induction n with n hn,
-  apply numeric_zero,
-  apply numeric_add hn numeric_one,
-end
+theorem numeric_nat : Π (n : ℕ), numeric n
+| 0 := numeric_zero
+| (n + 1) := numeric_add (numeric_nat n) numeric_one
 
 /-- The pre-game omega is numeric. -/
 theorem numeric_omega : numeric omega :=


### PR DESCRIPTION
Adds a couple of lemmas about surreal numbers: proving that natural numbers and omega are numeric.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Surreal.20numbers/near/234243582)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
