### PR TITLE
[Merged by Bors] - chore(topology/vector_bundle): generalize to topological semimodules

### DIFF
--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -22,7 +22,7 @@ which has the disjoint union topology.
 To have a topological vector bundle structure on `bundle.total_space E`,
 one should addtionally have the following data:
 
-* `F` should be a topological vector space over a semiring `R`;
+* `F` should be a topological space and a semimodule over a semiring `R`;
 * There should be a topology on `bundle.total_space E`, for which the projection to `B` is
 a topological fiber bundle with fiber `F` (in particular, each fiber `E x` is homeomorphic to `F`);
 * For each `x`, the fiber `E x` should be a topological vector space over `R`, and the injection

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -5,7 +5,7 @@ Authors: Nicolò Cavalleri, Sebastien Gouezel
 -/
 
 import topology.topological_fiber_bundle
-import analysis.calculus.deriv
+import topology.algebra.module
 import linear_algebra.dual
 
 /-!
@@ -22,29 +22,29 @@ which has the disjoint union topology.
 To have a topological vector bundle structure on `bundle.total_space E`,
 one should addtionally have the following data:
 
-* `F` should be a topological vector space over a field `𝕜`;
+* `F` should be a topological vector space over a semiring `R`;
 * There should be a topology on `bundle.total_space E`, for which the projection to `B` is
 a topological fiber bundle with fiber `F` (in particular, each fiber `E x` is homeomorphic to `F`);
-* For each `x`, the fiber `E x` should be a topological vector space over `𝕜`, and the injection
+* For each `x`, the fiber `E x` should be a topological vector space over `R`, and the injection
 from `E x` to `bundle.total_space F E` should be an embedding;
 * The most important condition: around each point, there should be a bundle trivialization which
 is a continuous linear equiv in the fibers.
 
 If all these conditions are satisfied, we register the typeclass
-`topological_vector_bundle 𝕜 F E`. We emphasize that the data is provided by other classes, and
+`topological_vector_bundle R F E`. We emphasize that the data is provided by other classes, and
 that the `topological_vector_bundle` class is `Prop`-valued.
 
 The point of this formalism is that it is unbundled in the sense that the total space of the bundle
 is a type with a topology, with which one can work or put further structure, and still one can
 perform operations on topological vector bundles (which are yet to be formalized). For instance,
-assume that `E₁ : B → Type*` and `E₂ : B → Type*` define two topological vector bundles over `𝕜`
+assume that `E₁ : B → Type*` and `E₂ : B → Type*` define two topological vector bundles over `R`
 with fiber models `F₁` and `F₂` which are normed spaces. Then one can construct the vector bundle of
-continuous linear maps from `E₁ x` to `E₂ x` with fiber `E x := (E₁ x →L[𝕜] E₂ x)` (and with the
-topology inherited from the norm-topology on `F₁ →L[𝕜] F₂`, without the need to define the strong
+continuous linear maps from `E₁ x` to `E₂ x` with fiber `E x := (E₁ x →L[R] E₂ x)` (and with the
+topology inherited from the norm-topology on `F₁ →L[R] F₂`, without the need to define the strong
 topology on continuous linear maps between general topological vector spaces). Let
-`vector_bundle_continuous_linear_map 𝕜 F₁ E₁ F₂ E₂ (x : B)` be a type synonym for `E₁ x →L[𝕜] E₂ x`.
+`vector_bundle_continuous_linear_map R F₁ E₁ F₂ E₂ (x : B)` be a type synonym for `E₁ x →L[R] E₂ x`.
 Then one can endow
-`bundle.total_space (vector_bundle_continuous_linear_map 𝕜 F₁ E₁ F₂ E₂)`
+`bundle.total_space (vector_bundle_continuous_linear_map R F₁ E₁ F₂ E₂)`
 with a topology and a topological vector bundle structure.
 
 Similar constructions can be done for tensor products of topological vector bundles, exterior
@@ -54,12 +54,11 @@ helps.
 
 noncomputable theory
 
+open bundle set
 
-open bundle
-
-variables (𝕜 : Type*) {B : Type*} (F : Type*) (E : B → Type*)
-[normed_field 𝕜] [∀ x, add_comm_group (E x)] [∀ x, semimodule 𝕜 (E x)]
-[topological_space F] [add_comm_group F] [semimodule 𝕜 F]
+variables (R : Type*) {B : Type*} (F : Type*) (E : B → Type*)
+[semiring R] [∀ x, add_comm_monoid (E x)] [∀ x, semimodule R (E x)]
+[topological_space F] [add_comm_monoid F] [semimodule R F]
 [topological_space (total_space E)] [topological_space B]
 
 section
@@ -67,20 +66,20 @@ section
 /-- Local trivialization for vector bundles. -/
 @[nolint has_inhabited_instance]
 structure topological_vector_bundle.trivialization extends bundle_trivialization F (proj E) :=
-(linear : ∀ x ∈ base_set, is_linear_map 𝕜 (λ y : (E x), (to_fun y).2))
+(linear : ∀ x ∈ base_set, is_linear_map R (λ y : (E x), (to_fun y).2))
 
-instance : has_coe_to_fun (topological_vector_bundle.trivialization 𝕜 F E) :=
+instance : has_coe_to_fun (topological_vector_bundle.trivialization R F E) :=
 ⟨λ _, (total_space E → B × F), λ e, e.to_bundle_trivialization⟩
 
-instance : has_coe (topological_vector_bundle.trivialization 𝕜 F E)
+instance : has_coe (topological_vector_bundle.trivialization R F E)
   (bundle_trivialization F (proj E)) :=
 ⟨topological_vector_bundle.trivialization.to_bundle_trivialization⟩
 
 namespace topological_vector_bundle
 
-variables {𝕜 F E}
+variables {R F E}
 
-lemma trivialization.mem_source (e : trivialization 𝕜 F E)
+lemma trivialization.mem_source (e : trivialization R F E)
   {x : total_space E} : x ∈ e.source ↔ proj E x ∈ e.base_set := bundle_trivialization.mem_source e
 
 end topological_vector_bundle
@@ -91,35 +90,35 @@ variables [∀ x, topological_space (E x)]
 
 /-- The space `total_space E` (for `E : B → Type*` such that each `E x` is a topological vector
 space) has a topological vector space structure with fiber `F` (denoted with
-`topological_vector_bundle 𝕜 F E`) if around every point there is a fiber bundle trivialization
+`topological_vector_bundle R F E`) if around every point there is a fiber bundle trivialization
 which is linear in the fibers. -/
 class topological_vector_bundle : Prop :=
 (inducing [] : ∀ (b : B), inducing (λ x : (E b), (id ⟨b, x⟩ : total_space E)))
-(locally_trivial [] : ∀ b : B, ∃ e : topological_vector_bundle.trivialization 𝕜 F E, b ∈ e.base_set)
+(locally_trivial [] : ∀ b : B, ∃ e : topological_vector_bundle.trivialization R F E, b ∈ e.base_set)
 
-variable [topological_vector_bundle 𝕜 F E]
+variable [topological_vector_bundle R F E]
 
 namespace topological_vector_bundle
 
-/-- `trivialization_at 𝕜 F E b` is some choice of trivialization of a vector bundle whose base set
+/-- `trivialization_at R F E b` is some choice of trivialization of a vector bundle whose base set
 contains a given point `b`. -/
-def trivialization_at : Π b : B, trivialization 𝕜 F E :=
-λ b, classical.some (topological_vector_bundle.locally_trivial 𝕜 F E b)
+def trivialization_at : Π b : B, trivialization R F E :=
+λ b, classical.some (topological_vector_bundle.locally_trivial R F E b)
 
 @[simp, mfld_simps] lemma mem_base_set_trivialization_at (b : B) :
-  b ∈ (trivialization_at 𝕜 F E b).base_set :=
-classical.some_spec (topological_vector_bundle.locally_trivial 𝕜 F E b)
+  b ∈ (trivialization_at R F E b).base_set :=
+classical.some_spec (topological_vector_bundle.locally_trivial R F E b)
 
 @[simp, mfld_simps] lemma mem_source_trivialization_at (z : total_space E) :
-  z ∈ (trivialization_at 𝕜 F E z.1).source :=
+  z ∈ (trivialization_at R F E z.1).source :=
 by { rw bundle_trivialization.mem_source, apply mem_base_set_trivialization_at }
 
-variables {𝕜 F E}
+variables {R F E}
 
 /-- In a topological vector bundle, a trivialization in the fiber (which is a priori only linear)
 is in fact a continuous linear equiv between the fibers and the model fiber. -/
-def trivialization.continuous_linear_equiv_at (e : trivialization 𝕜 F E) (b : B)
-  (hb : b ∈ e.base_set) : continuous_linear_equiv 𝕜 (E b) F :=
+def trivialization.continuous_linear_equiv_at (e : trivialization R F E) (b : B)
+  (hb : b ∈ e.base_set) : E b ≃L[R] F :=
 { to_fun := λ y, (e ⟨b, y⟩).2,
   inv_fun := λ z, begin
     have : ((e.to_local_homeomorph.symm) (b, z)).fst = b :=
@@ -160,12 +159,12 @@ def trivialization.continuous_linear_equiv_at (e : trivialization 𝕜 F E) (b :
   continuous_to_fun := begin
     refine continuous_snd.comp _,
     apply continuous_on.comp_continuous e.to_local_homeomorph.continuous_on
-      (topological_vector_bundle.inducing 𝕜 F E b).continuous (λ x, _),
+      (topological_vector_bundle.inducing R F E b).continuous (λ x, _),
     rw bundle_trivialization.mem_source,
     exact hb,
   end,
   continuous_inv_fun := begin
-    rw (topological_vector_bundle.inducing 𝕜 F E b).continuous_iff,
+    rw (topological_vector_bundle.inducing R F E b).continuous_iff,
     dsimp,
     have : continuous (λ (z : F), (e.to_bundle_trivialization.to_local_homeomorph.symm) (b, z)),
     { apply e.to_local_homeomorph.symm.continuous_on.comp_continuous
@@ -178,10 +177,10 @@ def trivialization.continuous_linear_equiv_at (e : trivialization 𝕜 F E) (b :
     { exact cast_heq _ _ },
   end }
 
-@[simp] lemma trivialization.continuous_linear_equiv_at_apply (e : trivialization 𝕜 F E) (b : B)
+@[simp] lemma trivialization.continuous_linear_equiv_at_apply (e : trivialization R F E) (b : B)
   (hb : b ∈ e.base_set) (y : E b) : e.continuous_linear_equiv_at b hb y = (e ⟨b, y⟩).2 := rfl
 
-@[simp] lemma trivialization.continuous_linear_equiv_at_apply' (e : trivialization 𝕜 F E)
+@[simp] lemma trivialization.continuous_linear_equiv_at_apply' (e : trivialization R F E)
   (x : total_space E) (hx : x ∈ e.source) :
   e.continuous_linear_equiv_at (proj E x) (e.mem_source.1 hx) x.2 = (e x).2 :=
 by { cases x, refl }
@@ -189,23 +188,26 @@ by { cases x, refl }
 section
 local attribute [reducible] bundle.trivial
 
-instance {B : Type*} {F : Type*} [add_comm_group F] (b : B) :
-  add_comm_group (bundle.trivial B F b) := by apply_instance
+instance {B : Type*} {F : Type*} [add_comm_monoid F] (b : B) :
+  add_comm_monoid (bundle.trivial B F b) := ‹add_comm_monoid F›
 
-instance {B : Type*} {F : Type*} [add_comm_group F] [semimodule 𝕜 F] (b : B) :
-  semimodule 𝕜 (bundle.trivial B F b) := by apply_instance
+instance {B : Type*} {F : Type*} [add_comm_group F] (b : B) :
+  add_comm_group (bundle.trivial B F b) := ‹add_comm_group F›
+
+instance {B : Type*} {F : Type*} [add_comm_monoid F] [semimodule R F] (b : B) :
+  semimodule R (bundle.trivial B F b) := ‹semimodule R F›
 
 end
 
-variables (𝕜 B F)
+variables (R B F)
 /-- Local trivialization for trivial bundle. -/
-def trivial_bundle_trivialization : trivialization 𝕜 F (bundle.trivial B F) :=
+def trivial_bundle_trivialization : trivialization R F (bundle.trivial B F) :=
 { to_fun := λ x, (x.fst, x.snd),
   inv_fun := λ y, ⟨y.fst, y.snd⟩,
-  source := set.univ,
-  target := set.univ,
-  map_source' := λ x h, set.mem_univ (x.fst, x.snd),
-  map_target' :=λ y h,  set.mem_univ ⟨y.fst, y.snd⟩,
+  source := univ,
+  target := univ,
+  map_source' := λ x h, mem_univ (x.fst, x.snd),
+  map_target' :=λ y h,  mem_univ ⟨y.fst, y.snd⟩,
   left_inv' := λ x h, sigma.eq rfl rfl,
   right_inv' := λ x h, prod.ext rfl rfl,
   open_source := is_open_univ,
@@ -215,16 +217,16 @@ def trivial_bundle_trivialization : trivialization 𝕜 F (bundle.trivial B F) :
   continuous_inv_fun := by { rw [←continuous_iff_continuous_on_univ, continuous_iff_le_induced],
     simp only [bundle.total_space.topological_space, induced_inf, induced_compose],
     exact le_refl _, },
-  base_set := set.univ,
+  base_set := univ,
   open_base_set := is_open_univ,
   source_eq := rfl,
-  target_eq := by simp only [set.univ_prod_univ],
+  target_eq := by simp only [univ_prod_univ],
   proj_to_fun := λ y hy, rfl,
   linear := λ x hx, ⟨λ y z, rfl, λ c y, rfl⟩ }
 
 instance trivial_bundle.topological_vector_bundle :
-  topological_vector_bundle 𝕜 F (bundle.trivial B F) :=
-{ locally_trivial := λ x, ⟨trivial_bundle_trivialization 𝕜 B F, set.mem_univ x⟩,
+  topological_vector_bundle R F (bundle.trivial B F) :=
+{ locally_trivial := λ x, ⟨trivial_bundle_trivialization R B F, mem_univ x⟩,
   inducing := λ b, ⟨begin
     have : (λ (x : trivial B F b), x) = @id F, by { ext x, refl },
     simp only [total_space.topological_space, induced_inf, induced_compose, function.comp, proj,
@@ -232,11 +234,11 @@ instance trivial_bundle.topological_vector_bundle :
       induced_id],
   end⟩ }
 
-variables {𝕜 B F}
+variables {R B F}
 
 /- Not registered as an instance because of a metavariable. -/
 lemma is_topological_vector_bundle_is_topological_fiber_bundle :
   is_topological_fiber_bundle F (proj E) :=
-λ x, ⟨(trivialization_at 𝕜 F E x).to_bundle_trivialization, mem_base_set_trivialization_at 𝕜 F E x⟩
+λ x, ⟨(trivialization_at R F E x).to_bundle_trivialization, mem_base_set_trivialization_at R F E x⟩
 
 end topological_vector_bundle


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I have no specific applications in mind right now but it may be useful to depend on the topology only, because, e.g., topology on `euclidean_space` is the same as on the pi space.

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
