### PR TITLE
[Merged by Bors] - chore(tactic/elementwise): fixes

### DIFF
--- a/src/category_theory/concrete_category/basic.lean
+++ b/src/category_theory/concrete_category/basic.lean
@@ -57,6 +57,9 @@ attribute [instance] concrete_category.forget_faithful
 @[reducible] def forget (C : Type v) [category C] [concrete_category.{u} C] : C ⥤ Type u :=
 concrete_category.forget C
 
+instance concrete_category.types : concrete_category (Type u) :=
+{ forget := 𝟭 _ }
+
 /--
 Provide a coercion to `Type u` for a concrete category. This is not marked as an instance
 as it could potentially apply to every type, and so is too expensive in typeclass search.
@@ -132,10 +135,11 @@ lemma concrete_category.epi_of_surjective {X Y : C} (f : X ⟶ Y) (s : function.
   epi f :=
 faithful_reflects_epi (forget C) ((epi_iff_surjective f).2 s)
 
-end
+@[simp] lemma concrete_category.has_coe_to_fun_Type {X Y : Type u} (f : X ⟶ Y) :
+  coe_fn f = f :=
+rfl
 
-instance concrete_category.types : concrete_category (Type u) :=
-{ forget := 𝟭 _ }
+end
 
 /--
 `has_forget₂ C D`, where `C` and `D` are both concrete categories, provides a functor

--- a/src/tactic/elementwise.lean
+++ b/src/tactic/elementwise.lean
@@ -108,11 +108,16 @@ do
    let s := simp_lemmas.mk,
    s ← s.add_simp ``coe_id,
    s ← s.add_simp ``coe_comp,
-   (t'', pr', _) ← simplify s [] t',
+   (t'', pr', _) ← simplify s [] t' {fail_if_unchanged := ff},
    pr' ← mk_eq_mp pr' pr,
+   -- Further, if we're in `Type`, get rid of the coercions entirely.
+   let s := simp_lemmas.mk,
+   s ← s.add_simp ``concrete_category.has_coe_to_fun_Type,
+   (t'', pr'', _) ← simplify s [] t'' {fail_if_unchanged := ff},
+   pr'' ← mk_eq_mp pr'' pr',
    t'' ← pis (vs ++ (if CC_found then [x] else [CC, x])) t'',
-   pr' ← lambdas (vs ++ (if CC_found then [x] else [CC, x])) pr',
-   pure (t'', pr', n)
+   pr'' ← lambdas (vs ++ (if CC_found then [x] else [CC, x])) pr'',
+   pure (t'', pr'', n)
 
 /-- (implementation for `@[elementwise]`)
 Given a declaration named `n` of the form `∀ ..., f = g`, proves a new lemma named `n'`

--- a/test/elementwise.lean
+++ b/test/elementwise.lean
@@ -45,3 +45,15 @@ begin
   elementwise! w,
   apply w,
 end
+
+example {α β : Type} (f g : α ⟶ β) (w : f = g) (a : α) : f a = g a :=
+begin
+  elementwise! w, -- make sure this works even when there is no simplification to do
+  rw w,
+end
+
+example {α β : Type} (f g : α ⟶ β) (w : f ≫ 𝟙 β = g) (a : α) : f a = g a :=
+begin
+  elementwise! w,
+  rw w,  -- this used to not work, because we produced `w : ⇑f a = ⇑g a`.
+end


### PR DESCRIPTION
These fixes, while an improvement, still don't fix the problem @justus-springer observed in #7092.

Really we should generate a second copy of the `_apply` lemma, with the category specialized to `Type u`, and in that one remove all the coercions. Maybe later.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
