### PR TITLE
[Merged by Bors] - hack(ci): run lean make twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T100000 --make src | python scripts/detect_errors.py
+          lean --json -T100000 --make src | python scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/leanprover-community/mathlib)
 
 [Mathlib](https://leanprover-community.github.io) is a user maintained library for the [Lean theorem prover](https://leanprover.github.io).
-It contains both programming infrastructure and mathematics, as well as tactics that use the former and allow to develop the latter.
+It contains both programming infrastructure and mathematics,
+as well as tactics that use the former and allow to develop the latter.
 
 ## Installation
 


### PR DESCRIPTION
At the moment running `lean --make src` after `leanproject up` will recompile some files.  Merging this PR should have the effect of uploading these newly compiled olean files.

This also makes github actions call `lean --make src` twice to prevent this problem from happening in the first place.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
