### PR TITLE
[Merged by Bors] - feat(order/complete_lattice): independence of an indexed family

### DIFF
--- a/src/order/compactly_generated.lean
+++ b/src/order/compactly_generated.lean
@@ -300,9 +300,9 @@ le_antisymm (begin
   exact (le_inf hcinf.1 ht2).trans (le_bsupr t ht1),
 end) (supr_le $ λ t, supr_le $ λ h, inf_le_inf_left _ ((finset.sup_eq_Sup t).symm ▸ (Sup_le_Sup h)))
 
-theorem complete_lattice.independent_iff_finite {s : set α} :
-  complete_lattice.independent s ↔
-    ∀ t : finset α, ↑t ⊆ s → complete_lattice.independent (↑t : set α) :=
+theorem complete_lattice.sindependent_iff_finite {s : set α} :
+  complete_lattice.sindependent s ↔
+    ∀ t : finset α, ↑t ⊆ s → complete_lattice.sindependent (↑t : set α) :=
 ⟨λ hs t ht, hs.mono ht, λ h a ha, begin
   rw [disjoint_iff, inf_Sup_eq_supr_inf_sup_finset, supr_eq_bot],
   intro t,
@@ -316,14 +316,14 @@ theorem complete_lattice.independent_iff_finite {s : set α} :
     exact ⟨ha, set.subset.trans ht (set.diff_subset _ _)⟩ }
 end⟩
 
-lemma complete_lattice.independent_Union_of_directed {η : Type*}
+lemma complete_lattice.sindependent_Union_of_directed {η : Type*}
   {s : η → set α} (hs : directed (⊆) s)
-  (h : ∀ i, complete_lattice.independent (s i)) :
-  complete_lattice.independent (⋃ i, s i) :=
+  (h : ∀ i, complete_lattice.sindependent (s i)) :
+  complete_lattice.sindependent (⋃ i, s i) :=
 begin
   by_cases hη : nonempty η,
   { resetI,
-    rw complete_lattice.independent_iff_finite,
+    rw complete_lattice.sindependent_iff_finite,
     intros t ht,
     obtain ⟨I, fi, hI⟩ := set.finite_subset_Union t.finite_to_set ht,
     obtain ⟨i, hi⟩ := hs.finset_le fi.to_finset,
@@ -335,10 +335,10 @@ end
 
 lemma complete_lattice.independent_sUnion_of_directed {s : set (set α)}
   (hs : directed_on (⊆) s)
-  (h : ∀ a ∈ s, complete_lattice.independent a) :
-  complete_lattice.independent (⋃₀ s) :=
+  (h : ∀ a ∈ s, complete_lattice.sindependent a) :
+  complete_lattice.sindependent (⋃₀ s) :=
 by rw set.sUnion_eq_Union; exact
-  complete_lattice.independent_Union_of_directed hs.directed_coe (by simpa using h)
+  complete_lattice.sindependent_Union_of_directed hs.directed_coe (by simpa using h)
 
 
 end
@@ -422,7 +422,7 @@ end, λ _, and.left⟩⟩
 theorem is_complemented_of_Sup_atoms_eq_top (h : Sup {a : α | is_atom a} = ⊤) : is_complemented α :=
 ⟨λ b, begin
   obtain ⟨s, ⟨s_ind, b_inf_Sup_s, s_atoms⟩, s_max⟩ := zorn.zorn_subset
-    {s : set α | complete_lattice.independent s ∧ b ⊓ Sup s = ⊥ ∧ ∀ a ∈ s, is_atom a} _,
+    {s : set α | complete_lattice.sindependent s ∧ b ⊓ Sup s = ⊥ ∧ ∀ a ∈ s, is_atom a} _,
   { refine ⟨Sup s, le_of_eq b_inf_Sup_s, _⟩,
     rw [← h, Sup_le_iff],
     intros a ha,

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1243,6 +1243,6 @@ subset of the rest. -/
 lemma independent.disjoint_bsupr {ι : Type*} {α : Type*} [complete_lattice α]
   {t : ι → α} (ht : independent t) {x : ι} {y : set ι} (hx : x ∉ y) :
   disjoint (t x) (⨆ i ∈ y, t i) :=
-disjoint.mono_right (bsupr_le_bsupr' $ λ i hi, show i ≠ x, from λ hix, hx $ hix ▸ hi) (ht x)
+disjoint.mono_right (bsupr_le_bsupr' $ λ i hi, (ne_of_mem_of_not_mem hi hx : _)) (ht x)
 
 end complete_lattice

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1174,7 +1174,7 @@ end
 
 omit hs
 
-/-- An independent indexed family of elements in a complete lattice is one in which every element
+/-- An indexed family of elements in a complete lattice is independent if every element
   is disjoint from the `Sup` of the rest. -/
 def independent {ι : Sort*} {α : Type*} [complete_lattice α] (s : ι → α): Prop :=
 ∀ ⦃i : ι⦄, disjoint (s i) (⨆ (j ≠ i), s j)

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1201,4 +1201,8 @@ lemma independent_pempty (t : pempty → α) : independent t.
 lemma independent.disjoint {x y : ι} (h : x ≠ y) : disjoint (t x) (t y) :=
 disjoint_Sup_right (@ht x) ⟨y, by simp [h.symm]⟩
 
+lemma independent.mono {ι : Type*} {α : Type*} [complete_lattice α]
+  {s t : ι → α} (hs : independent s) (hst : t ≤ s) :
+  independent t :=
+λ i, (hs i).mono (hst i) (supr_le_supr $ λ j, supr_le_supr $ λ _, hst j)
 end complete_lattice

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1144,32 +1144,50 @@ variables [complete_lattice α]
 
 /-- An independent set of elements in a complete lattice is one in which every element is disjoint
   from the `Sup` of the rest. -/
-def independent (s : set α) : Prop := ∀ ⦃a⦄, a ∈ s → disjoint a (Sup (s \ {a}))
+def sindependent (s : set α) : Prop := ∀ ⦃a⦄, a ∈ s → disjoint a (Sup (s \ {a}))
 
-variables {s : set α} (hs : independent s)
+variables {s : set α} (hs : sindependent s)
 
 @[simp]
-lemma independent_empty : independent (∅ : set α) :=
+lemma sindependent_empty : sindependent (∅ : set α) :=
 λ x hx, (set.not_mem_empty x hx).elim
 
-theorem independent.mono {t : set α} (hst : t ⊆ s) :
-  independent t :=
+theorem sindependent.mono {t : set α} (hst : t ⊆ s) :
+  sindependent t :=
 λ a ha, (hs (hst ha)).mono_right (Sup_le_Sup (diff_subset_diff_left hst))
 
 /-- If the elements of a set are independent, then any pair within that set is disjoint. -/
-lemma independent.disjoint {x y : α} (hx : x ∈ s) (hy : y ∈ s) (h : x ≠ y) : disjoint x y :=
+lemma sindependent.disjoint {x y : α} (hx : x ∈ s) (hy : y ∈ s) (h : x ≠ y) : disjoint x y :=
 disjoint_Sup_right (hs hx) ((mem_diff y).mpr ⟨hy, by simp [h.symm]⟩)
 
 include hs
 
 /-- If the elements of a set are independent, then any element is disjoint from the `Sup` of some
 subset of the rest. -/
-lemma independent.disjoint_Sup {x : α} {y : set α} (hx : x ∈ s) (hy : y ⊆ s) (hxy : x ∉ y) :
+lemma sindependent.disjoint_Sup {x : α} {y : set α} (hx : x ∈ s) (hy : y ⊆ s) (hxy : x ∉ y) :
   disjoint x (Sup y) :=
 begin
   have := (hs.mono $ insert_subset.mpr ⟨hx, hy⟩) (mem_insert x _),
   rw [insert_diff_of_mem _ (mem_singleton _), diff_singleton_eq_self hxy] at this,
   exact this,
 end
+
+omit hs
+
+/-- An independent indexed family of elements in a complete lattice is one in which every element
+  is disjoint from the `Sup` of the rest. -/
+def independent (t : ι → α) : Prop := ∀ ⦃i⦄, disjoint (t i) (Sup {a : α | ∃ j ≠ i, t j = a})
+
+variables {t : ι → α} (ht : independent t)
+
+@[simp]
+lemma independent_empty (t : empty → α) : independent t.
+
+@[simp]
+lemma independent_pempty (t : pempty → α) : independent t.
+
+/-- If the elements of a set are independent, then any pair within that set is disjoint. -/
+lemma independent.disjoint {x y : ι} (h : x ≠ y) : disjoint (t x) (t y) :=
+disjoint_Sup_right (@ht x) ⟨y, h.symm, rfl⟩
 
 end complete_lattice

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1176,7 +1176,8 @@ omit hs
 
 /-- An independent indexed family of elements in a complete lattice is one in which every element
   is disjoint from the `Sup` of the rest. -/
-def independent (t : ι → α) : Prop := ∀ ⦃i⦄, disjoint (t i) (Sup {a : α | ∃ j ≠ i, t j = a})
+def independent {ι : Sort*} {α : Type*} [complete_lattice α] (s : ι → α): Prop :=
+∀ ⦃i : ι⦄, disjoint (s i) (⨆ (j ≠ i), s j)
 
 variables {t : ι → α} (ht : independent t)
 
@@ -1188,6 +1189,6 @@ lemma independent_pempty (t : pempty → α) : independent t.
 
 /-- If the elements of a set are independent, then any pair within that set is disjoint. -/
 lemma independent.disjoint {x y : ι} (h : x ≠ y) : disjoint (t x) (t y) :=
-disjoint_Sup_right (@ht x) ⟨y, h.symm, rfl⟩
+disjoint_Sup_right (@ht x) ⟨y, by simp [h.symm]⟩
 
 end complete_lattice

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1212,4 +1212,5 @@ lemma independent.mono {ι : Type*} {α : Type*} [complete_lattice α]
   {s t : ι → α} (hs : independent s) (hst : t ≤ s) :
   independent t :=
 λ i, (hs i).mono (hst i) (supr_le_supr $ λ j, supr_le_supr $ λ _, hst j)
+
 end complete_lattice

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1183,7 +1183,7 @@ omit hs
 
   Example: an indexed family of submodules of a module is independent in this sense if
   and only the natural map from the direct sum of the submodules to the module is injective. -/
-def independent {ι : Sort*} {α : Type*} [complete_lattice α] (s : ι → α): Prop :=
+def independent {ι : Sort*} {α : Type*} [complete_lattice α] (s : ι → α) : Prop :=
 ∀ i : ι, disjoint (s i) (⨆ (j ≠ i), s j)
 
 lemma set_independent_iff {α : Type*} [complete_lattice α] (s : set α) :

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -432,12 +432,12 @@ theorem bsupr_le_bsupr {p : ι → Prop} {f g : Π i (hi : p i), α} (h : ∀ i 
   (⨆ i hi, f i hi) ≤ ⨆ i hi, g i hi :=
 bsupr_le $ λ i hi, le_trans (h i hi) (le_bsupr i hi)
 
-theorem bsupr_le_bsupr' {p q : ι → Prop} (hpq : ∀ i, p i → q i) {f : ι → α} :
-  (⨆ i (hpi : p i), f i) ≤ ⨆ i (hqi : q i), f i :=
-supr_le_supr $ λ i, Sup_le_Sup $ λ x ⟨a, ha⟩, ⟨hpq i a, ha⟩
-
 theorem supr_le_supr_const (h : ι → ι₂) : (⨆ i:ι, a) ≤ (⨆ j:ι₂, a) :=
 supr_le $ le_supr _ ∘ h
+
+theorem bsupr_le_bsupr' {p q : ι → Prop} (hpq : ∀ i, p i → q i) {f : ι → α} :
+  (⨆ i (hpi : p i), f i) ≤ ⨆ i (hqi : q i), f i :=
+supr_le_supr $ λ i, supr_le_supr_const (hpq i)
 
 @[simp] theorem supr_le_iff : supr s ≤ a ↔ (∀i, s i ≤ a) :=
 (is_lub_le_iff is_lub_supr).trans forall_range_iff

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1179,6 +1179,16 @@ omit hs
 def independent {ι : Sort*} {α : Type*} [complete_lattice α] (s : ι → α): Prop :=
 ∀ ⦃i : ι⦄, disjoint (s i) (⨆ (j ≠ i), s j)
 
+lemma sindependent_iff {α : Type*} [complete_lattice α] (s : set α) :
+  sindependent s ↔ independent (coe : s → α) :=
+begin
+  simp_rw [independent, sindependent, set_coe.forall, Sup_eq_supr],
+  apply forall_congr, intro a, apply forall_congr, intro ha,
+  congr' 2,
+  convert supr_subtype.symm,
+  simp [supr_and],
+end
+
 variables {t : ι → α} (ht : independent t)
 
 @[simp]

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1175,9 +1175,16 @@ end
 omit hs
 
 /-- An independent indexed family of elements in a complete lattice is one in which every element
-  is disjoint from the `Sup` of the rest. -/
+  is disjoint from the `supr` of the rest.
+
+  Example: an indexed family of non-zero elements in a
+  vector space is linearly independent iff the indexed family of subspaces they generate is
+  independent in this sense.
+
+  Example: an indexed family of submodules of a module is independent in this sense if
+  and only the natural map from the direct sum of the submodules to the module is injective. -/
 def independent {ι : Sort*} {α : Type*} [complete_lattice α] (s : ι → α): Prop :=
-∀ ⦃i : ι⦄, disjoint (s i) (⨆ (j ≠ i), s j)
+∀ i : ι, disjoint (s i) (⨆ (j ≠ i), s j)
 
 lemma sindependent_iff {α : Type*} [complete_lattice α] (s : set α) :
   sindependent s ↔ independent (coe : s → α) :=
@@ -1199,6 +1206,6 @@ lemma independent_pempty (t : pempty → α) : independent t.
 
 /-- If the elements of a set are independent, then any pair within that set is disjoint. -/
 lemma independent.disjoint {x y : ι} (h : x ≠ y) : disjoint (t x) (t y) :=
-disjoint_Sup_right (@ht x) ⟨y, by simp [h.symm]⟩
+disjoint_Sup_right (ht x) ⟨y, by simp [h.symm]⟩
 
 end complete_lattice


### PR DESCRIPTION
This PR reclaims the concept of `independent` for elements of a complete lattice. 
Right now it's defined on subsets -- a subset of a complete lattice L is independent if every
element of it is disjoint from (i.e. bot is the meet of it with) the Sup of all the other elements. 
The problem with this is that if you have an indexed family f:I->L of elements of L then
duplications get lost if you ask for the image of f to be independent (rather like the issue
with a basis of a vector space being a subset rather than an indexed family). This is
an issue when defining gradings on rings, for example: if M is a monoid and R is
a ring, then I don't want the map which sends every m to (top : subgroup R) to
be independent. 

I have renamed the set-theoretic version of `independent` to `set_independent`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

A previously suggested name was `sindependent` (cf `Union` and `sUnion`) but am certainly open to other ideas!