### PR TITLE
[Merged by Bors] - chore(group/ring_hom): fix a nat nsmul diamond

### DIFF
--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -679,55 +679,6 @@ by { ext, simp only [map_one, coe_comp, function.comp_app, one_apply] }
   g.comp (f₁ * f₂) = g.comp f₁ * g.comp f₂ :=
 by { ext, simp only [mul_apply, function.comp_app, map_mul, coe_comp] }
 
-/-- (M →* N) is a comm_monoid if N is commutative. -/
-@[to_additive]
-instance {M N} [mul_one_class M] [comm_monoid N] : comm_monoid (M →* N) :=
-{ mul := (*),
-  mul_assoc := by intros; ext; apply mul_assoc,
-  one := 1,
-  one_mul := by intros; ext; apply one_mul,
-  mul_one := by intros; ext; apply mul_one,
-  mul_comm := by intros; ext; apply mul_comm }
-
-/-- `flip` arguments of `f : M →* N →* P` -/
-@[to_additive "`flip` arguments of `f : M →+ N →+ P`"]
-def flip {mM : mul_one_class M} {mN : mul_one_class N} {mP : comm_monoid P} (f : M →* N →* P) :
-  N →* M →* P :=
-{ to_fun := λ y, ⟨λ x, f x y, by rw [f.map_one, one_apply], λ x₁ x₂, by rw [f.map_mul, mul_apply]⟩,
-  map_one' := ext $ λ x, (f x).map_one,
-  map_mul' := λ y₁ y₂, ext $ λ x, (f x).map_mul y₁ y₂ }
-
-@[simp, to_additive] lemma flip_apply
-  {mM : mul_one_class M} {mN : mul_one_class N} {mP : comm_monoid P}
-  (f : M →* N →* P) (x : M) (y : N) :
-  f.flip y x = f x y :=
-rfl
-
-/-- Evaluation of a `monoid_hom` at a point as a monoid homomorphism. See also `monoid_hom.apply`
-for the evaluation of any function at a point. -/
-@[to_additive "Evaluation of an `add_monoid_hom` at a point as an additive monoid homomorphism.
-See also `add_monoid_hom.apply` for the evaluation of any function at a point."]
-def eval [mul_one_class M] [comm_monoid N] : M →* (M →* N) →* N := (monoid_hom.id (M →* N)).flip
-
-@[simp, to_additive]
-lemma eval_apply [mul_one_class M] [comm_monoid N] (x : M) (f : M →* N) : eval x f = f x := rfl
-
-/-- Composition of monoid morphisms (`monoid_hom.comp`) as a monoid morphism. -/
-@[to_additive "Composition of additive monoid morphisms
-(`add_monoid_hom.comp`) as an additive monoid morphism.", simps]
-def comp_hom [mul_one_class M] [comm_monoid N] [comm_monoid P] :
-  (N →* P) →* (M →* N) →* (M →* P) :=
-{ to_fun := λ g, { to_fun := g.comp, map_one' := comp_one g, map_mul' := comp_mul g },
-  map_one' := by { ext1 f, exact one_comp f },
-  map_mul' := λ g₁ g₂, by { ext1 f, exact mul_comp g₁ g₂ f } }
-
-/-- Flipping arguments of monoid morphisms (`monoid_hom.flip`) as a monoid morphism. -/
-@[to_additive "Flipping arguments of additive monoid morphisms (`add_monoid_hom.flip`)
-as an additive monoid morphism.", simps]
-def flip_hom {mM : mul_one_class M} {mN : mul_one_class N} {mP : comm_monoid P}
-  : (M →* N →* P) →* (N →* M →* P) :=
-{ to_fun := monoid_hom.flip, map_one' := rfl, map_mul' := λ f g, rfl }
-
 /-- If two homomorphism from a group to a monoid are equal at `x`, then they are equal at `x⁻¹`. -/
 @[to_additive "If two homomorphism from an additive group to an additive monoid are equal at `x`,
 then they are equal at `-x`." ]
@@ -820,18 +771,6 @@ add_decl_doc add_monoid_hom.has_sub
 @[simp, to_additive] lemma div_apply {M G} {mM : mul_one_class M} {gG : comm_group G}
   (f g : M →* G) (x : M) :
   (f / g) x = f x / g x := rfl
-
-/-- If `G` is a commutative group, then `M →* G` a commutative group too. -/
-@[to_additive]
-instance {M G} [mul_one_class M] [comm_group G] : comm_group (M →* G) :=
-{ inv := has_inv.inv,
-  div := has_div.div,
-  div_eq_mul_inv := by { intros, ext, apply div_eq_mul_inv },
-  mul_left_inv := by intros; ext; apply mul_left_inv,
-  ..monoid_hom.comm_monoid }
-
-/-- If `G` is an additive commutative group, then `M →+ G` an additive commutative group too. -/
-add_decl_doc add_monoid_hom.add_comm_group
 
 end monoid_hom
 

--- a/src/algebra/group/hom_instances.lean
+++ b/src/algebra/group/hom_instances.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2018 Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot, Kevin Buzzard, Scott Morrison, Johan Commelin, Chris Hughes,
+  Johannes Hölzl, Yury Kudryashov
+-/
+
+import algebra.group_power.basic
+
+/-!
+# instances on spaces of monoid and group morphisms
+
+We endow the space of monoid morphisms `M →* N` with a `comm_monoid` structure when the target is
+commutative, through pointwise multipliplication, and with a `comm_group` structure when the target
+is a commutative group. We also prove the same instances for additive situations.
+-/
+
+universes uM uN uP
+variables {M : Type uM} {N : Type uN} {P : Type uP}
+
+lemma nat.succ_eq_one_add (n : ℕ) : n.succ = 1 + n :=
+by rw [nat.succ_eq_add_one, nat.add_comm]
+
+/-- `(M →* N)` is a `comm_monoid` if `N` is commutative. -/
+instance [mul_one_class M] [comm_monoid N] : comm_monoid (M →* N) :=
+{ mul := (*),
+  mul_assoc := by intros; ext; apply mul_assoc,
+  one := 1,
+  one_mul := by intros; ext; apply one_mul,
+  mul_one := by intros; ext; apply mul_one,
+  mul_comm := by intros; ext; apply mul_comm,
+  npow := λ n f,
+  { to_fun := λ x, npow n (f x),
+    map_one' := by simp,
+    map_mul' := λ x y, by simp [mul_pow] },
+  npow_zero' := λ f, by { ext x, simp },
+  npow_succ' := λ n f, by { ext x, simp [pow_succ] } }
+
+/-- `(M →+ N)` is an `add_comm_monoid` if `N` is commutative. -/
+instance [add_zero_class M] [add_comm_monoid N] : add_comm_monoid (M →+ N) :=
+{ add := (+),
+  add_assoc := by intros; ext; apply add_assoc,
+  zero := 0,
+  zero_add := by intros; ext; apply zero_add,
+  add_zero := by intros; ext; apply add_zero,
+  add_comm := by intros; ext; apply add_comm,
+  nsmul := λ n f,
+  { to_fun := λ x, nsmul n (f x),
+    map_zero' := by simp [nsmul_zero],
+    map_add' := λ x y, by simp [nsmul_add] },
+  nsmul_zero' := λ f, by { ext x, simp [zero_nsmul], },
+  nsmul_succ' := λ n f, by { ext x, simp [nat.succ_eq_one_add, add_nsmul] } }
+
+attribute [to_additive] monoid_hom.comm_monoid
+
+namespace monoid_hom
+
+/-- `flip` arguments of `f : M →* N →* P` -/
+@[to_additive "`flip` arguments of `f : M →+ N →+ P`"]
+def flip {mM : mul_one_class M} {mN : mul_one_class N} {mP : comm_monoid P} (f : M →* N →* P) :
+  N →* M →* P :=
+{ to_fun := λ y, ⟨λ x, f x y, by rw [f.map_one, one_apply], λ x₁ x₂, by rw [f.map_mul, mul_apply]⟩,
+  map_one' := ext $ λ x, (f x).map_one,
+  map_mul' := λ y₁ y₂, ext $ λ x, (f x).map_mul y₁ y₂ }
+
+@[simp, to_additive] lemma flip_apply
+  {mM : mul_one_class M} {mN : mul_one_class N} {mP : comm_monoid P}
+  (f : M →* N →* P) (x : M) (y : N) :
+  f.flip y x = f x y :=
+rfl
+
+/-- Evaluation of a `monoid_hom` at a point as a monoid homomorphism. See also `monoid_hom.apply`
+for the evaluation of any function at a point. -/
+@[to_additive "Evaluation of an `add_monoid_hom` at a point as an additive monoid homomorphism.
+See also `add_monoid_hom.apply` for the evaluation of any function at a point."]
+def eval [mul_one_class M] [comm_monoid N] : M →* (M →* N) →* N := (monoid_hom.id (M →* N)).flip
+
+@[simp, to_additive]
+lemma eval_apply [mul_one_class M] [comm_monoid N] (x : M) (f : M →* N) : eval x f = f x := rfl
+
+/-- Composition of monoid morphisms (`monoid_hom.comp`) as a monoid morphism. -/
+@[to_additive "Composition of additive monoid morphisms
+(`add_monoid_hom.comp`) as an additive monoid morphism.", simps]
+def comp_hom [mul_one_class M] [comm_monoid N] [comm_monoid P] :
+  (N →* P) →* (M →* N) →* (M →* P) :=
+{ to_fun := λ g, { to_fun := g.comp, map_one' := comp_one g, map_mul' := comp_mul g },
+  map_one' := by { ext1 f, exact one_comp f },
+  map_mul' := λ g₁ g₂, by { ext1 f, exact mul_comp g₁ g₂ f } }
+
+/-- Flipping arguments of monoid morphisms (`monoid_hom.flip`) as a monoid morphism. -/
+@[to_additive "Flipping arguments of additive monoid morphisms (`add_monoid_hom.flip`)
+as an additive monoid morphism.", simps]
+def flip_hom {mM : mul_one_class M} {mN : mul_one_class N} {mP : comm_monoid P}
+  : (M →* N →* P) →* (N →* M →* P) :=
+{ to_fun := monoid_hom.flip, map_one' := rfl, map_mul' := λ f g, rfl }
+
+end monoid_hom
+
+/-- If `G` is a commutative group, then `M →* G` a commutative group too. -/
+@[to_additive]
+instance {M G} [mul_one_class M] [comm_group G] : comm_group (M →* G) :=
+{ inv := has_inv.inv,
+  div := has_div.div,
+  div_eq_mul_inv := by { intros, ext, apply div_eq_mul_inv },
+  mul_left_inv := by intros; ext; apply mul_left_inv,
+  ..monoid_hom.comm_monoid }
+
+/-- If `G` is an additive commutative group, then `M →+ G` an additive commutative group too. -/
+add_decl_doc add_monoid_hom.add_comm_group

--- a/src/algebra/group/hom_instances.lean
+++ b/src/algebra/group/hom_instances.lean
@@ -8,7 +8,7 @@ Authors: Patrick Massot, Kevin Buzzard, Scott Morrison, Johan Commelin, Chris Hu
 import algebra.group_power.basic
 
 /-!
-# instances on spaces of monoid and group morphisms
+# Instances on spaces of monoid and group morphisms
 
 We endow the space of monoid morphisms `M →* N` with a `comm_monoid` structure when the target is
 commutative, through pointwise multipliplication, and with a `comm_group` structure when the target

--- a/src/algebra/group/pi.lean
+++ b/src/algebra/group/pi.lean
@@ -6,8 +6,8 @@ Authors: Simon Hudon, Patrick Massot
 import data.pi
 import data.set.function
 import tactic.pi_instances
-import algebra.group.defs
-import algebra.group.hom
+import algebra.group.hom_instances
+
 /-!
 # Pi instances for groups and monoids
 

--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -46,10 +46,13 @@ instance monoid.has_pow [monoid M] : has_pow M ℕ := ⟨λ x n, npow n x⟩
 
 instance add_monoid.has_scalar_nat [add_monoid M] : has_scalar ℕ M := ⟨nsmul⟩
 
+attribute [to_additive add_monoid.has_scalar_nat] monoid.has_pow
+
 @[simp] lemma npow_eq_pow {M : Type*} [monoid M] (n : ℕ) (x : M) : npow n x = x^n := rfl
 
 @[simp] lemma nsmul_eq_smul {M : Type*} [add_monoid M] (n : ℕ) (x : M) : nsmul n x = n • x := rfl
 
+attribute [to_additive nsmul_eq_smul] npow_eq_pow
 
 /-!
 ### Commutativity

--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -46,13 +46,9 @@ instance monoid.has_pow [monoid M] : has_pow M ℕ := ⟨λ x n, npow n x⟩
 
 instance add_monoid.has_scalar_nat [add_monoid M] : has_scalar ℕ M := ⟨nsmul⟩
 
-attribute [to_additive add_monoid.has_scalar_nat] monoid.has_pow
-
 @[simp] lemma npow_eq_pow {M : Type*} [monoid M] (n : ℕ) (x : M) : npow n x = x^n := rfl
 
 @[simp] lemma nsmul_eq_smul {M : Type*} [add_monoid M] (n : ℕ) (x : M) : nsmul n x = n • x := rfl
-
-attribute [to_additive nsmul_eq_smul] npow_eq_pow
 
 /-!
 ### Commutativity

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -413,15 +413,6 @@ lemma map_rat_module_smul {E : Type*} [add_comm_group E] [vector_space ℚ E]
   f (c • x) = c • f x :=
 rat.cast_id c ▸ f.map_rat_cast_smul c x
 
-@[simp] lemma nat_smul_apply [add_monoid M] [add_comm_monoid M₂]
-  (n : ℕ) (f : M →+ M₂) (a : M) :
-  (n • f) a = n • (f a) :=
-begin
-  induction n with n IH,
-  { simp only [zero_smul, zero_apply] },
-  { simp only [nat.succ_eq_add_one, add_smul, IH, one_smul, add_apply] }
-end
-
 @[simp] lemma int_smul_apply [add_monoid M] [add_comm_group M₂]
   [module ℤ (M →+ M₂)] [module ℤ M₂]
   (n : ℤ) (f : M →+ M₂) (a : M) :

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2014 Floris van Doorn (c) 2016 Microsoft Corporation. All rights r
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
-import algebra.group_power.basic
+import algebra.group.hom_instances
 import algebra.order_functions
 import algebra.ordered_monoid
 
@@ -22,9 +22,6 @@ This file contains:
 -/
 
 universes u v
-
-lemma nat.succ_eq_one_add (n : ℕ) : n.succ = 1 + n :=
-by rw [nat.succ_eq_add_one, nat.add_comm]
 
 /-! ### instances -/
 


### PR DESCRIPTION
The space of additive monoid should be given a proper `nat`-action, by the pointwise action, to avoid diamonds.

---

The only difficulty in the PR is that the file `algebra/group/hom.lean` containing the additive monoid instance on the space of morphisms comes before the file `algebra/group_power/basic`, which contains all the useful properties of `nsmul`. So, we split the file `algebra/group/hom.lean` into two, where the second part can come later in the import hierarchy (below `algebra/group_power/basic`), and we declare the instances in this second part.