### PR TITLE
chore(data/mv_polynomial/basic): make monomial an add_monoid_hom, tidy

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -281,11 +281,12 @@ begin
     { rw [single_zero, single_zero] } }
 end
 
-lemma single_left_inj (h : b ≠ 0) :
-  single a b = single a' b ↔ a = a' :=
-⟨λ H, by simpa only [h, single_eq_single_iff,
-  and_false, or_false, eq_self_iff_true, and_true] using H,
- λ H, by rw [H]⟩
+lemma single_left_injective (h : b ≠ 0) : function.injective (λ a : α, single a b) :=
+λ a a' H, by simpa only [h, single_eq_single_iff,
+  and_false, or_false, eq_self_iff_true, and_true] using H
+
+lemma single_left_inj (h : b ≠ 0) : single a b = single a' b ↔ a = a' :=
+(single_left_injective h).eq_iff
 
 lemma support_single_ne_bot (i : α) (h : b ≠ 0) :
   (single i b).support ≠ ⊥ :=

--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -245,22 +245,6 @@ begin
     { intros, rw pow_add, }, }
 end
 
-instance infinite_of_infinite (σ : Type*) (R : Type*) [comm_semiring R] [infinite R] :
-  infinite (mv_polynomial σ R) :=
-infinite.of_injective C (C_injective _ _)
-
-instance infinite_of_nonempty (σ : Type*) (R : Type*) [nonempty σ] [comm_semiring R]
-  [nontrivial R] :
-  infinite (mv_polynomial σ R) :=
-infinite.of_injective (λ i : ℕ, monomial (single (classical.arbitrary σ) i) 1)
-begin
-  intros m n h,
-  have := (single_eq_single_iff _ _ _ _).mp h,
-  simp only [and_true, eq_self_iff_true, or_false, one_ne_zero, and_self,
-             single_eq_single_iff, eq_self_iff_true, true_and] at this,
-  rcases this with (rfl|⟨rfl, rfl⟩); refl
-end
-
 /-! ### Induction and extensionality principles -/
 
 @[recursor 5]
@@ -313,6 +297,19 @@ hom_eq_hom f (ring_hom.id _) hC hX p
   {f g : mv_polynomial σ R →ₐ[R] A} (hf : ∀ i : σ, f (X i) = g (X i)) :
   f = g :=
 by { ext, exact hf _ }
+
+instance infinite_of_infinite (σ : Type*) (R : Type*) [comm_semiring R] [infinite R] :
+  infinite (mv_polynomial σ R) :=
+infinite.of_injective C (C_injective _ _)
+
+instance infinite_of_nonempty (σ : Type*) (R : Type*) [nonempty σ] [comm_semiring R]
+  [nontrivial R] :
+  infinite (mv_polynomial σ R) :=
+infinite.of_injective ((λ s : σ →₀ ℕ, monomial s 1) ∘ (single (classical.arbitrary σ)))
+begin
+  refine function.injective.comp _ (finsupp.single_injective _),
+  exact single_left_injective one_ne_zero,
+end
 
 section support
 


### PR DESCRIPTION
This additionally:
 * reorders lemmas to avoid repeated proofs, and to make the file more organized. No lemmas have been removed.
 * strengthens `ring_hom_ext` and `alg_hom_ext` to allow further extensionality lemmas to chain onto the `C` hypothesis.
 * adds `smul_monomial` to match `polynomial`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

- [x] depends on: #7207 (adds `finsupp.single_left_injective`)
- [x] depends on: #7209