### PR TITLE
[Merged by Bors] - doc(tactic/congr): example where congr fails, but exact works

### DIFF
--- a/src/tactic/congr.lean
+++ b/src/tactic/congr.lean
@@ -161,7 +161,8 @@ The `convert` tactic applies congruence lemmas eagerly before reducing,
 therefore it can fail in cases where `exact` succeeds:
 ```lean
 def p (n : ℕ) := true
-example (h : p 0) : p 1 := by convert h -- produces goal 1 = 0
+example (h : p 0) : p 1 := by exact h -- succeeds
+example (h : p 0) : p 1 := by convert h -- fails, with leftover goal `1 = 0`
 ```
 
 If `x y : t`, and an instance `subsingleton t` is in scope, then any goals of the form

--- a/src/tactic/congr.lean
+++ b/src/tactic/congr.lean
@@ -157,6 +157,13 @@ the tactic `convert e` will change the goal to
 
 In this example, the new goal can be solved using `ring`.
 
+The `convert` tactic applies congruence lemmas eagerly before reducing,
+therefore it can fail in cases where `exact` succeeds:
+```lean
+def p (n : ℕ) := true
+example (h : p 0) : p 1 := by convert h -- produces goal 1 = 0
+```
+
 If `x y : t`, and an instance `subsingleton t` is in scope, then any goals of the form
 `x = y` are solved automatically.
 


### PR DESCRIPTION
As requested on zulip:
https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.237084/near/234652967


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
