### PR TITLE
[Merged by Bors] - feat(data/nat/choose/sum): Add lower bound lemma for central binomial coefficient

### DIFF
--- a/src/data/nat/choose/sum.lean
+++ b/src/data/nat/choose/sum.lean
@@ -105,13 +105,12 @@ end
 
 lemma four_pow_le_two_mul_add_one_mul_central_binom (n : ℕ) :
   4 ^ n ≤ (2 * n + 1) * choose (2 * n) n :=
-begin
-  calc 4 ^ n = (1 + 1) ^ (2 * n) : by norm_num [pow_mul]
-  ...        = ∑ m in range (2 * n + 1), choose (2 * n) m : by simp [add_pow]
-  ...        ≤ ∑ m in range (2 * n + 1), choose (2 * n) (2 * n / 2) :
-    sum_le_sum (λ i hi, choose_le_middle i (2 * n))
-  ...        = (2 * n + 1) * choose (2 * n) n : by simp
-end
+calc 4 ^ n = (1 + 1) ^ (2 * n) : by norm_num [pow_mul]
+...        = ∑ m in range (2 * n + 1), choose (2 * n) m : by simp [add_pow]
+...        ≤ ∑ m in range (2 * n + 1), choose (2 * n) (2 * n / 2) :
+  sum_le_sum (λ i hi, choose_le_middle i (2 * n))
+...        = (2 * n + 1) * choose (2 * n) n : by simp
+
 
 
 end nat

--- a/src/data/nat/choose/sum.lean
+++ b/src/data/nat/choose/sum.lean
@@ -111,8 +111,6 @@ calc 4 ^ n = (1 + 1) ^ (2 * n) : by norm_num [pow_mul]
   sum_le_sum (λ i hi, choose_le_middle i (2 * n))
 ...        = (2 * n + 1) * choose (2 * n) n : by simp
 
-
-
 end nat
 
 theorem int.alternating_sum_range_choose {n : ℕ} :

--- a/src/data/nat/choose/sum.lean
+++ b/src/data/nat/choose/sum.lean
@@ -103,6 +103,30 @@ begin
   simpa [sum_range_choose_halfway n] using t
 end
 
+lemma choose_middle_upper_bound (n : ℕ) : 4 ^ n ≤ (2 * n + 1) * choose (2 * n) n :=
+begin
+  calc 4 ^ n = (1 + 1) ^ (2 * n) : begin
+      rw one_add_one_eq_two,
+      rw pow_mul,
+      suffices h : 2 ^ 2 = 4,
+      rw h,
+      dec_trivial,
+    end
+  ...        = ∑ m in range (2 * n + 1), choose (2 * n) m : by simp [add_pow 1 1 (2 * n)]
+  ...        ≤ ∑ m in range (2 * n + 1), choose (2 * n) (2 * n / 2) : begin
+      apply sum_le_sum,
+      intros i hi,
+      apply choose_le_middle i (2 * n),
+    end
+  ...        = ∑ m in range (2 * n + 1), choose (2 * n) n : by simp
+  ...        = (2 * n + 1) * choose (2 * n) n : begin
+      rw sum_const,
+      rw finset.card_range,
+      simp,
+    end
+end
+
+
 end nat
 
 theorem int.alternating_sum_range_choose {n : ℕ} :

--- a/src/data/nat/choose/sum.lean
+++ b/src/data/nat/choose/sum.lean
@@ -103,7 +103,8 @@ begin
   simpa [sum_range_choose_halfway n] using t
 end
 
-lemma choose_middle_upper_bound (n : ℕ) : 4 ^ n ≤ (2 * n + 1) * choose (2 * n) n :=
+lemma four_pow_le_two_mul_add_one_mul_central_binom (n : ℕ) :
+  4 ^ n ≤ (2 * n + 1) * choose (2 * n) n :=
 begin
   calc 4 ^ n = (1 + 1) ^ (2 * n) : begin
       rw one_add_one_eq_two,

--- a/src/data/nat/choose/sum.lean
+++ b/src/data/nat/choose/sum.lean
@@ -106,25 +106,11 @@ end
 lemma four_pow_le_two_mul_add_one_mul_central_binom (n : ℕ) :
   4 ^ n ≤ (2 * n + 1) * choose (2 * n) n :=
 begin
-  calc 4 ^ n = (1 + 1) ^ (2 * n) : begin
-      rw one_add_one_eq_two,
-      rw pow_mul,
-      suffices h : 2 ^ 2 = 4,
-      rw h,
-      dec_trivial,
-    end
+  calc 4 ^ n = (1 + 1) ^ (2 * n) : by norm_num [pow_mul]
   ...        = ∑ m in range (2 * n + 1), choose (2 * n) m : by simp [add_pow 1 1 (2 * n)]
-  ...        ≤ ∑ m in range (2 * n + 1), choose (2 * n) (2 * n / 2) : begin
-      apply sum_le_sum,
-      intros i hi,
-      apply choose_le_middle i (2 * n),
-    end
-  ...        = ∑ m in range (2 * n + 1), choose (2 * n) n : by simp
-  ...        = (2 * n + 1) * choose (2 * n) n : begin
-      rw sum_const,
-      rw finset.card_range,
-      simp,
-    end
+  ...        ≤ ∑ m in range (2 * n + 1), choose (2 * n) (2 * n / 2) :
+    sum_le_sum (λ i hi, choose_le_middle i (2 * n))
+  ...        = (2 * n + 1) * choose (2 * n) n : by simp
 end
 
 

--- a/src/data/nat/choose/sum.lean
+++ b/src/data/nat/choose/sum.lean
@@ -107,7 +107,7 @@ lemma four_pow_le_two_mul_add_one_mul_central_binom (n : ℕ) :
   4 ^ n ≤ (2 * n + 1) * choose (2 * n) n :=
 begin
   calc 4 ^ n = (1 + 1) ^ (2 * n) : by norm_num [pow_mul]
-  ...        = ∑ m in range (2 * n + 1), choose (2 * n) m : by simp [add_pow 1 1 (2 * n)]
+  ...        = ∑ m in range (2 * n + 1), choose (2 * n) m : by simp [add_pow]
   ...        ≤ ∑ m in range (2 * n + 1), choose (2 * n) (2 * n / 2) :
     sum_le_sum (λ i hi, choose_le_middle i (2 * n))
   ...        = (2 * n + 1) * choose (2 * n) n : by simp


### PR DESCRIPTION
This lemma complements the one above it, and will be useful in proving Bertrand's postulate from the 100 theorems list.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
