### PR TITLE
[Merged by Bors] - feat(group_theory/submonoid/operations): add lemmas

### DIFF
--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -103,21 +103,7 @@ eq.symm (set.image_id S)
 
 lemma submonoid.to_add_submonoid_le_iff {M : Type*} [mul_one_class M] (S₁ S₂ : submonoid M) :
   S₁ ≤ S₂ ↔ S₁.to_add_submonoid ≤ S₂.to_add_submonoid :=
-begin
-  split,
-  { intro h,
-    change (S₁.to_add_submonoid : set (additive M)) ⊆ S₂.to_add_submonoid,
-    rw [submonoid.to_add_submonoid_coe, submonoid.to_add_submonoid_coe],
-    simp only [h, set_like.coe_subset_coe, equiv.image_subset] },
-  { intro h,
-    change (S₁.to_add_submonoid : set (additive M)) ⊆ S₂.to_add_submonoid at h,
-    rw [submonoid.to_add_submonoid_coe, submonoid.to_add_submonoid_coe, equiv.subset_image] at h,
-    intros s₁ hs₁,
-    simp only [set.image_subset_iff, additive.of_mul_symm_eq] at h,
-    replace h := h hs₁,
-    simp only [set.mem_preimage, set_like.mem_coe, to_mul_of_mul] at h,
-    exact h }
-end
+iff.rfl
 
 lemma add_submonoid.to_submonoid_le_iff {M : Type*} [add_zero_class M] (S₁ S₂ : add_submonoid M) :
   S₁ ≤ S₂ ↔ S₁.to_submonoid ≤ S₂.to_submonoid :=

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -101,13 +101,15 @@ lemma add_submonoid.to_submonoid_coe {M : Type*} [add_zero_class M] (S : add_sub
   (S.to_submonoid : set (multiplicative M)) = multiplicative.of_add '' S :=
 eq.symm (set.image_id S)
 
-lemma submonoid.to_add_submonoid_le_iff {M : Type*} [mul_one_class M] (S₁ S₂ : submonoid M) :
-  S₁ ≤ S₂ ↔ S₁.to_add_submonoid ≤ S₂.to_add_submonoid :=
-iff.rfl
+lemma submonoid.of_add_submonoid_coe {M : Type*} [mul_one_class M]
+  (S : add_submonoid (additive M)) :
+  (submonoid.of_add_submonoid S : set M) = additive.to_mul '' S :=
+eq.symm (set.image_id S)
 
-lemma add_submonoid.to_submonoid_le_iff {M : Type*} [add_zero_class M] (S₁ S₂ : add_submonoid M) :
-  S₁ ≤ S₂ ↔ S₁.to_submonoid ≤ S₂.to_submonoid :=
-iff.rfl
+lemma add_submonoid.of_submonoid_coe {M : Type*} [add_zero_class M]
+  (S : submonoid (multiplicative M)) :
+  (add_submonoid.of_submonoid S : set M) = multiplicative.to_add '' S :=
+eq.symm (set.image_id S)
 
 /-- Submonoids of monoid `M` are isomorphic to additive submonoids of `additive M`. -/
 def submonoid.add_submonoid_equiv (M : Type*) [mul_one_class M] :
@@ -118,38 +120,58 @@ def submonoid.add_submonoid_equiv (M : Type*) [mul_one_class M] :
   right_inv := λ x, by cases x; refl,
   map_rel_iff' := λ a b, iff.rfl, }
 
+/-- Additive submonoids of monoid `M` are isomorphic to multiplicative submonoids of
+  `multiplicative M`. -/
+def add_submonoid.submonoid_equiv (M : Type*) [add_zero_class M] :
+  add_submonoid M ≃o submonoid (multiplicative M) :=
+{ to_fun := add_submonoid.to_submonoid,
+  inv_fun := add_submonoid.of_submonoid,
+  left_inv := λ x, by cases x; refl,
+  right_inv := λ x, by cases x; refl,
+  map_rel_iff' := λ a b, iff.rfl, }
+
+lemma submonoid.add_submonoid_equiv_coe (M : Type*) [add_zero_class M] :
+  ⇑(add_submonoid.submonoid_equiv M) = add_submonoid.to_submonoid := rfl
+
+lemma add_submonoid.submonoid_equiv_symm_coe (M : Type*) [add_zero_class M] :
+  ⇑(add_submonoid.submonoid_equiv M).symm = add_submonoid.of_submonoid := rfl
+
+lemma add_submonoid.submonoid_equiv_coe (M : Type*) [mul_one_class M] :
+  ⇑(submonoid.add_submonoid_equiv M) = submonoid.to_add_submonoid := rfl
+
+lemma submonoid.add_submonoid_equiv_symm_coe (M : Type*) [mul_one_class M] :
+  ⇑(submonoid.add_submonoid_equiv M).symm = submonoid.of_add_submonoid := rfl
+
+lemma submonoid.to_add_submonoid_mono {M : Type*} [mul_one_class M] :
+  monotone (submonoid.to_add_submonoid : submonoid M → add_submonoid (additive M)) :=
+λ a b hab, hab
+
+lemma add_submonoid.to_submonoid_mono {M : Type*} [add_zero_class M] :
+  monotone (add_submonoid.to_submonoid : add_submonoid M → submonoid (multiplicative M)) :=
+λ a b hab, hab
+
 lemma submonoid.closure.to_add_submonoid {M : Type*} [monoid M] (S : set M) :
   (submonoid.closure S).to_add_submonoid = add_submonoid.closure (additive.of_mul '' S) :=
 begin
-  refine (add_submonoid.closure_eq_of_le _ _).symm,
-  { simp only [set.image_subset_iff],
-    exact submonoid.subset_closure },
-  { have : (add_submonoid.closure (additive.of_mul '' S)).to_submonoid.to_add_submonoid =
-      add_submonoid.closure (additive.of_mul '' S) := rfl,
-    rw [← this, (submonoid.to_add_submonoid_le_iff _ _).symm, submonoid.closure_le,
-      add_submonoid.to_submonoid_coe],
-    intros s hs,
-    rw [← of_add_to_add s],
-    simp only [set.mem_image, set_like.mem_coe, of_add_to_add],
-    refine ⟨additive.of_mul s, ⟨_, rfl⟩⟩,
-    simpa using add_submonoid.subset_closure (set.mem_image_of_mem additive.of_mul hs) }
+  apply le_antisymm,
+  { apply (submonoid.add_submonoid_equiv M).to_galois_connection.l_le _,
+    rw [submonoid.closure_le, submonoid.add_submonoid_equiv_symm_coe,
+      submonoid.of_add_submonoid_coe, equiv.subset_image],
+    exact add_submonoid.subset_closure },
+  { rw [add_submonoid.closure_le, submonoid.to_add_submonoid_coe, equiv.image_subset],
+    exact submonoid.subset_closure }
 end
 
 lemma add_submonoid.closure.to_submonoid {M : Type*} [add_monoid M] (S : set M) :
   (add_submonoid.closure S).to_submonoid = submonoid.closure (multiplicative.of_add '' S) :=
 begin
-  refine (submonoid.closure_eq_of_le _ _).symm,
-  { simp only [set.image_subset_iff],
-    exact add_submonoid.subset_closure },
-  { have : (submonoid.closure (multiplicative.of_add '' S)).to_add_submonoid.to_submonoid =
-      submonoid.closure (multiplicative.of_add '' S) := rfl,
-    rw [← this, (add_submonoid.to_submonoid_le_iff _ _).symm, add_submonoid.closure_le,
-      submonoid.to_add_submonoid_coe],
-    intros s hs,
-    rw [← of_mul_to_mul s],
-    simp only [set.mem_image, set_like.mem_coe, of_mul_to_mul],
-    refine ⟨multiplicative.of_add s, ⟨_, rfl⟩⟩,
-    simpa using submonoid.subset_closure (set.mem_image_of_mem multiplicative.of_add hs) }
+  apply le_antisymm,
+  { apply (add_submonoid.submonoid_equiv M).to_galois_connection.l_le _,
+    rw [add_submonoid.closure_le, add_submonoid.submonoid_equiv_symm_coe,
+      add_submonoid.of_submonoid_coe, equiv.subset_image],
+    exact submonoid.subset_closure },
+  { rw [submonoid.closure_le, add_submonoid.to_submonoid_coe, equiv.image_subset],
+    exact add_submonoid.subset_closure }
 end
 
 namespace submonoid

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -120,8 +120,8 @@ def submonoid.add_submonoid_equiv (M : Type*) [mul_one_class M] :
   right_inv := λ x, by cases x; refl,
   map_rel_iff' := λ a b, iff.rfl, }
 
-/-- Additive submonoids of monoid `M` are isomorphic to multiplicative submonoids of
-  `multiplicative M`. -/
+/-- Additive submonoids of an additive monoid `M` are isomorphic to
+multiplicative submonoids of `multiplicative M`. -/
 def add_submonoid.submonoid_equiv (M : Type*) [add_zero_class M] :
   add_submonoid M ≃o submonoid (multiplicative M) :=
 { to_fun := add_submonoid.to_submonoid,

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -151,16 +151,11 @@ lemma add_submonoid.to_submonoid_mono {M : Type*} [add_zero_class M] :
 λ a b hab, hab
 
 lemma submonoid.closure.to_add_submonoid {M : Type*} [monoid M] (S : set M) :
-  (submonoid.closure S).to_add_submonoid = add_submonoid.closure (additive.of_mul '' S) :=
-begin
-  apply le_antisymm,
-  { apply (submonoid.add_submonoid_equiv M).to_galois_connection.l_le _,
-    rw [submonoid.closure_le, submonoid.add_submonoid_equiv_symm_coe,
-      submonoid.of_add_submonoid_coe, equiv.subset_image],
-    exact add_submonoid.subset_closure },
-  { rw [add_submonoid.closure_le, submonoid.to_add_submonoid_coe, equiv.image_subset],
-    exact submonoid.subset_closure }
-end
+  (submonoid.closure S).to_add_submonoid = add_submonoid.closure (additive.to_mul ⁻¹' S) :=
+le_antisymm
+  ((submonoid.add_submonoid_equiv' M).to_galois_connection.l_le $
+    submonoid.closure_le.2 add_submonoid.subset_closure)
+  (add_submonoid.closure_le.2 submonoid.subset_closure)
 
 lemma add_submonoid.closure.to_submonoid {M : Type*} [add_monoid M] (S : set M) :
   (add_submonoid.closure S).to_submonoid = submonoid.closure (multiplicative.of_add '' S) :=

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -94,22 +94,22 @@ def add_submonoid.of_submonoid {M : Type*} [add_zero_class M] (S : submonoid (mu
   add_mem' := S.mul_mem' }
 
 lemma submonoid.to_add_submonoid_coe {M : Type*} [mul_one_class M] (S : submonoid M) :
-  (S.to_add_submonoid : set (additive M)) = additive.of_mul '' S :=
-eq.symm (set.image_id S)
+  (S.to_add_submonoid : set (additive M)) = additive.to_mul ⁻¹' S :=
+rfl
 
 lemma add_submonoid.to_submonoid_coe {M : Type*} [add_zero_class M] (S : add_submonoid M) :
-  (S.to_submonoid : set (multiplicative M)) = multiplicative.of_add '' S :=
-eq.symm (set.image_id S)
+  (S.to_submonoid : set (multiplicative M)) = multiplicative.to_add ⁻¹' S :=
+rfl
 
 lemma submonoid.of_add_submonoid_coe {M : Type*} [mul_one_class M]
   (S : add_submonoid (additive M)) :
-  (submonoid.of_add_submonoid S : set M) = additive.to_mul '' S :=
-eq.symm (set.image_id S)
+  (submonoid.of_add_submonoid S : set M) = additive.of_mul ⁻¹' S :=
+rfl
 
 lemma add_submonoid.of_submonoid_coe {M : Type*} [add_zero_class M]
   (S : submonoid (multiplicative M)) :
-  (add_submonoid.of_submonoid S : set M) = multiplicative.to_add '' S :=
-eq.symm (set.image_id S)
+  (add_submonoid.of_submonoid S : set M) = multiplicative.of_add ⁻¹' S :=
+rfl
 
 /-- Submonoids of monoid `M` are isomorphic to additive submonoids of `additive M`. -/
 def submonoid.add_submonoid_equiv (M : Type*) [mul_one_class M] :
@@ -153,21 +153,16 @@ lemma add_submonoid.to_submonoid_mono {M : Type*} [add_zero_class M] :
 lemma submonoid.closure.to_add_submonoid {M : Type*} [monoid M] (S : set M) :
   (submonoid.closure S).to_add_submonoid = add_submonoid.closure (additive.to_mul ⁻¹' S) :=
 le_antisymm
-  ((submonoid.add_submonoid_equiv' M).to_galois_connection.l_le $
+  ((submonoid.add_submonoid_equiv M).to_galois_connection.l_le $
     submonoid.closure_le.2 add_submonoid.subset_closure)
   (add_submonoid.closure_le.2 submonoid.subset_closure)
 
 lemma add_submonoid.closure.to_submonoid {M : Type*} [add_monoid M] (S : set M) :
-  (add_submonoid.closure S).to_submonoid = submonoid.closure (multiplicative.of_add '' S) :=
-begin
-  apply le_antisymm,
-  { apply (add_submonoid.submonoid_equiv M).to_galois_connection.l_le _,
-    rw [add_submonoid.closure_le, add_submonoid.submonoid_equiv_symm_coe,
-      add_submonoid.of_submonoid_coe, equiv.subset_image],
-    exact submonoid.subset_closure },
-  { rw [submonoid.closure_le, add_submonoid.to_submonoid_coe, equiv.image_subset],
-    exact add_submonoid.subset_closure }
-end
+  (add_submonoid.closure S).to_submonoid = submonoid.closure (multiplicative.to_add ⁻¹' S) :=
+le_antisymm
+  ((add_submonoid.submonoid_equiv M).to_galois_connection.l_le $
+    add_submonoid.closure_le.2 submonoid.subset_closure)
+  (submonoid.closure_le.2 add_submonoid.subset_closure)
 
 namespace submonoid
 

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -150,14 +150,14 @@ lemma add_submonoid.to_submonoid_mono {M : Type*} [add_zero_class M] :
   monotone (add_submonoid.to_submonoid : add_submonoid M → submonoid (multiplicative M)) :=
 λ a b hab, hab
 
-lemma submonoid.closure.to_add_submonoid {M : Type*} [monoid M] (S : set M) :
+lemma submonoid.to_add_submonoid_closure {M : Type*} [monoid M] (S : set M) :
   (submonoid.closure S).to_add_submonoid = add_submonoid.closure (additive.to_mul ⁻¹' S) :=
 le_antisymm
   ((submonoid.add_submonoid_equiv M).to_galois_connection.l_le $
     submonoid.closure_le.2 add_submonoid.subset_closure)
   (add_submonoid.closure_le.2 submonoid.subset_closure)
 
-lemma add_submonoid.closure.to_submonoid {M : Type*} [add_monoid M] (S : set M) :
+lemma add_submonoid.to_submonoid_closure {M : Type*} [add_monoid M] (S : set M) :
   (add_submonoid.closure S).to_submonoid = submonoid.closure (multiplicative.to_add ⁻¹' S) :=
 le_antisymm
   ((add_submonoid.submonoid_equiv M).to_galois_connection.l_le $

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -107,21 +107,7 @@ iff.rfl
 
 lemma add_submonoid.to_submonoid_le_iff {M : Type*} [add_zero_class M] (S₁ S₂ : add_submonoid M) :
   S₁ ≤ S₂ ↔ S₁.to_submonoid ≤ S₂.to_submonoid :=
-begin
-  split,
-  { intro h,
-    change (S₁.to_submonoid : set (multiplicative M)) ⊆ S₂.to_submonoid,
-    rw [add_submonoid.to_submonoid_coe, add_submonoid.to_submonoid_coe],
-    simp only [h, set_like.coe_subset_coe, equiv.image_subset] },
-  { intro h,
-    change (S₁.to_submonoid : set (multiplicative M)) ⊆ S₂.to_submonoid at h,
-    rw [add_submonoid.to_submonoid_coe, add_submonoid.to_submonoid_coe, equiv.subset_image] at h,
-    intros s₁ hs₁,
-    simp only [set.image_subset_iff, additive.of_mul_symm_eq] at h,
-    replace h := h hs₁,
-    simp only [set.mem_preimage, set_like.mem_coe, to_mul_of_mul] at h,
-    exact h }
-end
+iff.rfl
 
 /-- Submonoids of monoid `M` are isomorphic to additive submonoids of `additive M`. -/
 def submonoid.add_submonoid_equiv (M : Type*) [mul_one_class M] :

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -93,23 +93,15 @@ def add_submonoid.of_submonoid {M : Type*} [add_zero_class M] (S : submonoid (mu
   zero_mem' := S.one_mem',
   add_mem' := S.mul_mem' }
 
-/-- Submonoids of monoid `M` are isomorphic to additive submonoids of `additive M`. -/
-def submonoid.add_submonoid_equiv (M : Type*) [mul_one_class M] :
-  submonoid M ≃ add_submonoid (additive M) :=
-{ to_fun := submonoid.to_add_submonoid,
-  inv_fun := submonoid.of_add_submonoid,
-  left_inv := λ x, by cases x; refl,
-  right_inv := λ x, by cases x; refl }
-
-lemma submonoid.to_add_submonoid_coe {M : Type*} [monoid M] (S : submonoid M) :
+lemma submonoid.to_add_submonoid_coe {M : Type*} [mul_one_class M] (S : submonoid M) :
   (S.to_add_submonoid : set (additive M)) = additive.of_mul '' S :=
 eq.symm (set.image_id S)
 
-lemma add_submonoid.to_submonoid_coe {M : Type*} [add_monoid M] (S : add_submonoid M) :
+lemma add_submonoid.to_submonoid_coe {M : Type*} [add_zero_class M] (S : add_submonoid M) :
   (S.to_submonoid : set (multiplicative M)) = multiplicative.of_add '' S :=
 eq.symm (set.image_id S)
 
-lemma submonoid.to_add_submonoid_le_iff {M : Type*} [monoid M] (S₁ S₂ : submonoid M) :
+lemma submonoid.to_add_submonoid_le_iff {M : Type*} [mul_one_class M] (S₁ S₂ : submonoid M) :
   S₁ ≤ S₂ ↔ S₁.to_add_submonoid ≤ S₂.to_add_submonoid :=
 begin
   split,
@@ -127,7 +119,7 @@ begin
     exact h }
 end
 
-lemma add_submonoid.to_submonoid_le_iff {M : Type*} [add_monoid M] (S₁ S₂ : add_submonoid M) :
+lemma add_submonoid.to_submonoid_le_iff {M : Type*} [add_zero_class M] (S₁ S₂ : add_submonoid M) :
   S₁ ≤ S₂ ↔ S₁.to_submonoid ≤ S₂.to_submonoid :=
 begin
   split,
@@ -144,6 +136,15 @@ begin
     simp only [set.mem_preimage, set_like.mem_coe, to_mul_of_mul] at h,
     exact h }
 end
+
+/-- Submonoids of monoid `M` are isomorphic to additive submonoids of `additive M`. -/
+def submonoid.add_submonoid_equiv (M : Type*) [mul_one_class M] :
+  submonoid M ≃o add_submonoid (additive M) :=
+{ to_fun := submonoid.to_add_submonoid,
+  inv_fun := submonoid.of_add_submonoid,
+  left_inv := λ x, by cases x; refl,
+  right_inv := λ x, by cases x; refl,
+  map_rel_iff' := λ a b, (submonoid.to_add_submonoid_le_iff a b).symm, }
 
 lemma submonoid.closure.to_add_submonoid {M : Type*} [monoid M] (S : set M) :
   (submonoid.closure S).to_add_submonoid = add_submonoid.closure (additive.of_mul '' S) :=

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -150,6 +150,14 @@ lemma add_submonoid.to_submonoid_mono {M : Type*} [add_zero_class M] :
   monotone (add_submonoid.to_submonoid : add_submonoid M → submonoid (multiplicative M)) :=
 λ a b hab, hab
 
+lemma submonoid.of_add_submonoid_mono {M : Type*} [mul_one_class M] :
+  monotone (submonoid.of_add_submonoid : add_submonoid (additive M) → submonoid M) :=
+λ a b hab, hab
+
+lemma add_submonoid.of_submonoid_mono {M : Type*} [add_zero_class M] :
+  monotone (add_submonoid.of_submonoid : submonoid (multiplicative M) → add_submonoid M) :=
+λ a b hab, hab
+
 lemma submonoid.to_add_submonoid_closure {M : Type*} [monoid M] (S : set M) :
   (submonoid.closure S).to_add_submonoid = add_submonoid.closure (additive.to_mul ⁻¹' S) :=
 le_antisymm

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -116,7 +116,7 @@ def submonoid.add_submonoid_equiv (M : Type*) [mul_one_class M] :
   inv_fun := submonoid.of_add_submonoid,
   left_inv := λ x, by cases x; refl,
   right_inv := λ x, by cases x; refl,
-  map_rel_iff' := λ a b, (submonoid.to_add_submonoid_le_iff a b).symm, }
+  map_rel_iff' := λ a b, iff.rfl, }
 
 lemma submonoid.closure.to_add_submonoid {M : Type*} [monoid M] (S : set M) :
   (submonoid.closure S).to_add_submonoid = add_submonoid.closure (additive.of_mul '' S) :=

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -101,6 +101,84 @@ def submonoid.add_submonoid_equiv (M : Type*) [mul_one_class M] :
   left_inv := λ x, by cases x; refl,
   right_inv := λ x, by cases x; refl }
 
+lemma submonoid.to_add_submonoid_coe {M : Type*} [monoid M] (S : submonoid M) :
+  (S.to_add_submonoid : set (additive M)) = additive.of_mul '' S :=
+eq.symm (set.image_id S)
+
+lemma add_submonoid.to_submonoid_coe {M : Type*} [add_monoid M] (S : add_submonoid M) :
+  (S.to_submonoid : set (multiplicative M)) = multiplicative.of_add '' S :=
+eq.symm (set.image_id S)
+
+lemma submonoid.to_add_submonoid_le_iff {M : Type*} [monoid M] (S₁ S₂ : submonoid M) :
+  S₁ ≤ S₂ ↔ S₁.to_add_submonoid ≤ S₂.to_add_submonoid :=
+begin
+  split,
+  { intro h,
+    change (S₁.to_add_submonoid : set (additive M)) ⊆ S₂.to_add_submonoid,
+    rw [submonoid.to_add_submonoid_coe, submonoid.to_add_submonoid_coe],
+    simp only [h, set_like.coe_subset_coe, equiv.image_subset] },
+  { intro h,
+    change (S₁.to_add_submonoid : set (additive M)) ⊆ S₂.to_add_submonoid at h,
+    rw [submonoid.to_add_submonoid_coe, submonoid.to_add_submonoid_coe, equiv.subset_image] at h,
+    intros s₁ hs₁,
+    simp only [set.image_subset_iff, additive.of_mul_symm_eq] at h,
+    replace h := h hs₁,
+    simp only [set.mem_preimage, set_like.mem_coe, to_mul_of_mul] at h,
+    exact h }
+end
+
+lemma add_submonoid.to_submonoid_le_iff {M : Type*} [add_monoid M] (S₁ S₂ : add_submonoid M) :
+  S₁ ≤ S₂ ↔ S₁.to_submonoid ≤ S₂.to_submonoid :=
+begin
+  split,
+  { intro h,
+    change (S₁.to_submonoid : set (multiplicative M)) ⊆ S₂.to_submonoid,
+    rw [add_submonoid.to_submonoid_coe, add_submonoid.to_submonoid_coe],
+    simp only [h, set_like.coe_subset_coe, equiv.image_subset] },
+  { intro h,
+    change (S₁.to_submonoid : set (multiplicative M)) ⊆ S₂.to_submonoid at h,
+    rw [add_submonoid.to_submonoid_coe, add_submonoid.to_submonoid_coe, equiv.subset_image] at h,
+    intros s₁ hs₁,
+    simp only [set.image_subset_iff, additive.of_mul_symm_eq] at h,
+    replace h := h hs₁,
+    simp only [set.mem_preimage, set_like.mem_coe, to_mul_of_mul] at h,
+    exact h }
+end
+
+lemma submonoid.closure.to_add_submonoid {M : Type*} [monoid M] (S : set M) :
+  (submonoid.closure S).to_add_submonoid = add_submonoid.closure (additive.of_mul '' S) :=
+begin
+  refine (add_submonoid.closure_eq_of_le _ _).symm,
+  { simp only [set.image_subset_iff],
+    exact submonoid.subset_closure },
+  { have : (add_submonoid.closure (additive.of_mul '' S)).to_submonoid.to_add_submonoid =
+      add_submonoid.closure (additive.of_mul '' S) := rfl,
+    rw [← this, (submonoid.to_add_submonoid_le_iff _ _).symm, submonoid.closure_le,
+      add_submonoid.to_submonoid_coe],
+    intros s hs,
+    rw [← of_add_to_add s],
+    simp only [set.mem_image, set_like.mem_coe, of_add_to_add],
+    refine ⟨additive.of_mul s, ⟨_, rfl⟩⟩,
+    simpa using add_submonoid.subset_closure (set.mem_image_of_mem additive.of_mul hs) }
+end
+
+lemma add_submonoid.closure.to_submonoid {M : Type*} [add_monoid M] (S : set M) :
+  (add_submonoid.closure S).to_submonoid = submonoid.closure (multiplicative.of_add '' S) :=
+begin
+  refine (submonoid.closure_eq_of_le _ _).symm,
+  { simp only [set.image_subset_iff],
+    exact add_submonoid.subset_closure },
+  { have : (submonoid.closure (multiplicative.of_add '' S)).to_add_submonoid.to_submonoid =
+      submonoid.closure (multiplicative.of_add '' S) := rfl,
+    rw [← this, (add_submonoid.to_submonoid_le_iff _ _).symm, add_submonoid.closure_le,
+      submonoid.to_add_submonoid_coe],
+    intros s hs,
+    rw [← of_mul_to_mul s],
+    simp only [set.mem_image, set_like.mem_coe, of_mul_to_mul],
+    refine ⟨multiplicative.of_add s, ⟨_, rfl⟩⟩,
+    simpa using submonoid.subset_closure (set.mem_image_of_mem multiplicative.of_add hs) }
+end
+
 namespace submonoid
 
 open set


### PR DESCRIPTION
Some lemmas about the interaction between additive and multiplicative submonoids.

I provided the two version (from additive to multiplicative and the other way), I am not sure if `@[to_additive]` can automatize this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
