### PR TITLE
[Merged by Bors] - feat(algebra/module/submodule_lattice): add lemmas for nat submodules

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1252,12 +1252,6 @@ end algebra
 
 end ring
 
-section nat
-
-variables (R : Type*) [semiring R]
-
-end nat
-
 section int
 
 variables (R : Type*) [ring R]

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1256,23 +1256,6 @@ section nat
 
 variables (R : Type*) [semiring R]
 
-section span_nat
-open submodule
-
-lemma span_nat_eq_add_group_closure (s : set R) :
-  (span ℕ s).to_add_submonoid = add_submonoid.closure s :=
-begin
-  refine eq.symm (add_submonoid.closure_eq_of_le subset_span _),
-  apply add_submonoid.to_nat_submodule.symm.to_galois_connection.l_le _,
-  rw span_le,
-  exact add_submonoid.subset_closure,
-end
-
-@[simp] lemma span_nat_eq (s : add_submonoid R) : (span ℕ (s : set R)).to_add_submonoid = s :=
-by rw [span_nat_eq_add_group_closure, s.closure_eq]
-
-end span_nat
-
 end nat
 
 section int

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1264,26 +1264,10 @@ instance algebra_int : algebra ℤ R :=
 
 variables {R}
 
-section
 variables {S : Type*} [ring S]
 
 instance int_algebra_subsingleton : subsingleton (algebra ℤ S) :=
 ⟨λ P Q, by { ext, simp, }⟩
-end
-
-section span_int
-open submodule
-
-lemma span_int_eq_add_group_closure (s : set R) :
-  (span ℤ s).to_add_subgroup = add_subgroup.closure s :=
-eq.symm $ add_subgroup.closure_eq_of_le _ subset_span $ λ x hx, span_induction hx
-  (λ x hx, add_subgroup.subset_closure hx) (add_subgroup.zero_mem _)
-  (λ _ _, add_subgroup.add_mem _) (λ _ _ _, add_subgroup.gsmul_mem _ ‹_› _)
-
-@[simp] lemma span_int_eq (s : add_subgroup R) : (span ℤ (s : set R)).to_add_subgroup = s :=
-by rw [span_int_eq_add_group_closure, s.closure_eq]
-
-end span_int
 
 end int
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1261,9 +1261,12 @@ open submodule
 
 lemma span_nat_eq_add_group_closure (s : set R) :
   (span ℕ s).to_add_submonoid = add_submonoid.closure s :=
-eq.symm $ add_submonoid.closure_eq_of_le subset_span $ λ x hx, span_induction hx
-  (λ x hx, add_submonoid.subset_closure hx) (add_submonoid.zero_mem _)
-  (λ _ _, add_submonoid.add_mem _) (λ _ _ _, add_submonoid.nsmul_mem _ ‹_› _)
+begin
+  refine eq.symm (add_submonoid.closure_eq_of_le subset_span _),
+  apply add_submonoid.to_nat_submodule.symm.to_galois_connection.l_le _,
+  rw span_le,
+  exact add_submonoid.subset_closure,
+end
 
 @[simp] lemma span_nat_eq (s : add_submonoid R) : (span ℕ (s : set R)).to_add_submonoid = s :=
 by rw [span_nat_eq_add_group_closure, s.closure_eq]

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -161,7 +161,7 @@ end submodule
 
 section nat_submodule
 
-/-- a submonoid is equivalent to a ℕ submodule -/
+/-- An addditive submonoid is equivalent to a ℕ-submodule. -/
 def add_submonoid.to_nat_submodule : add_submonoid M ≃o submodule ℕ M :=
 { to_fun := λ S,
   { smul_mem' := λ r s hs, S.nsmul_mem hs _, ..S },

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -171,6 +171,10 @@ def add_submonoid.to_nat_submodule : add_submonoid M ≃o submodule ℕ M :=
   map_rel_iff' := λ a b, iff.rfl }
 
 @[simp]
+lemma add_submonoid.to_nat_submodule_symm :
+  ⇑(add_submonoid.to_nat_submodule.symm : _ ≃o add_submonoid M) = submodule.to_add_submonoid := rfl
+  
+@[simp]
 lemma add_submonoid.coe_to_nat_submodule (S : add_submonoid M) :
   (S.to_nat_submodule : set M) = S := rfl
 

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -159,4 +159,31 @@ show s ≤ Sup S, from le_Sup hs
 
 end submodule
 
+section nat_submodule
+
+/-- a submonoid is equivalent to a ℕ submodule -/
+def add_submonoid.to_nat_submodule : add_submonoid M ≃o submodule ℕ M :=
+{ to_fun := λ S,
+  { smul_mem' := λ r s hs, S.nsmul_mem hs _, ..S },
+  inv_fun := submodule.to_add_submonoid,
+  left_inv := λ ⟨S, _, _⟩, rfl,
+  right_inv := λ ⟨S, _, _, _⟩, rfl,
+  map_rel_iff' := λ a b, iff.rfl }
+
+@[simp]
+lemma add_submonoid.coe_to_nat_submodule (S : add_submonoid M) :
+  (S.to_nat_submodule : set M) = S := rfl
+
+@[simp]
+lemma add_submonoid.to_nat_submodule_to_add_submonoid (S : add_submonoid M) :
+  S.to_nat_submodule.to_add_submonoid = S :=
+add_submonoid.to_nat_submodule.symm_apply_apply S
+
+@[simp]
+lemma submodule.to_add_submonoid_to_nat_submodule (S : submodule ℕ M) :
+  S.to_add_submonoid.to_nat_submodule = S :=
+add_submonoid.to_nat_submodule.apply_symm_apply S
+
+end nat_submodule
+
 end add_comm_monoid

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -161,7 +161,7 @@ end submodule
 
 section nat_submodule
 
-/-- An addditive submonoid is equivalent to a ℕ-submodule. -/
+/-- An additive submonoid is equivalent to a ℕ-submodule. -/
 def add_submonoid.to_nat_submodule : add_submonoid M ≃o submodule ℕ M :=
 { to_fun := λ S,
   { smul_mem' := λ r s hs, S.nsmul_mem hs _, ..S },

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -175,6 +175,10 @@ lemma add_submonoid.to_nat_submodule_symm :
   ⇑(add_submonoid.to_nat_submodule.symm : _ ≃o add_submonoid M) = submodule.to_add_submonoid := rfl
   
 @[simp]
+lemma add_submonoid.to_nat_submodule_symm :
+  ⇑(add_submonoid.to_nat_submodule.symm : _ ≃o add_submonoid M) = submodule.to_add_submonoid := rfl
+  
+@[simp]
 lemma add_submonoid.coe_to_nat_submodule (S : add_submonoid M) :
   (S.to_nat_submodule : set M) = S := rfl
 

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -173,11 +173,7 @@ def add_submonoid.to_nat_submodule : add_submonoid M ≃o submodule ℕ M :=
 @[simp]
 lemma add_submonoid.to_nat_submodule_symm :
   ⇑(add_submonoid.to_nat_submodule.symm : _ ≃o add_submonoid M) = submodule.to_add_submonoid := rfl
-  
-@[simp]
-lemma add_submonoid.to_nat_submodule_symm :
-  ⇑(add_submonoid.to_nat_submodule.symm : _ ≃o add_submonoid M) = submodule.to_add_submonoid := rfl
-  
+
 @[simp]
 lemma add_submonoid.coe_to_nat_submodule (S : add_submonoid M) :
   (S.to_nat_submodule : set M) = S := rfl

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -773,8 +773,6 @@ end
 @[simp] lemma span_nat_eq (s : add_submonoid M) : (span ℕ (s : set M)).to_add_submonoid = s :=
 by rw [span_nat_eq_add_group_closure, s.closure_eq]
 
-end span_nat
-
 section
 variables (R M)
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -770,7 +770,7 @@ end
 @[simp] lemma span_nat_eq (s : add_submonoid M) : (span ℕ (s : set M)).to_add_submonoid = s :=
 by rw [span_nat_eq_add_group_closure, s.closure_eq]
 
-lemma span_int_eq_add_group_closure {M : Type*} [add_comm_group M] (s : set M) :
+lemma span_int_eq_add_subgroup_closure {M : Type*} [add_comm_group M] (s : set M) :
   (span ℤ s).to_add_subgroup = add_subgroup.closure s :=
 eq.symm $ add_subgroup.closure_eq_of_le _ subset_span $ λ x hx, span_induction hx
   (λ x hx, add_subgroup.subset_closure hx) (add_subgroup.zero_mem _)

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -761,7 +761,7 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
 section span_nat
 open submodule
 
-lemma span_nat_eq_add_group_closure (s : set R) :
+lemma span_nat_eq_add_group_closure (s : set M) :
   (span ℕ s).to_add_submonoid = add_submonoid.closure s :=
 begin
   refine eq.symm (add_submonoid.closure_eq_of_le subset_span _),
@@ -770,7 +770,7 @@ begin
   exact add_submonoid.subset_closure,
 end
 
-@[simp] lemma span_nat_eq (s : add_submonoid R) : (span ℕ (s : set R)).to_add_submonoid = s :=
+@[simp] lemma span_nat_eq (s : add_submonoid M) : (span ℕ (s : set M)).to_add_submonoid = s :=
 by rw [span_nat_eq_add_group_closure, s.closure_eq]
 
 end span_nat

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -758,9 +758,6 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
   (H2 : ∀ (a:R) x, p x → p (a • x)) : p x :=
 (@span_le _ _ _ _ _ _ ⟨p, H0, H1, H2⟩).2 Hs h
 
-section span_nat
-open submodule
-
 lemma span_nat_eq_add_group_closure (s : set M) :
   (span ℕ s).to_add_submonoid = add_submonoid.closure s :=
 begin

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -758,7 +758,7 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
   (H2 : ∀ (a:R) x, p x → p (a • x)) : p x :=
 (@span_le _ _ _ _ _ _ ⟨p, H0, H1, H2⟩).2 Hs h
 
-lemma span_nat_eq_add_group_closure (s : set M) :
+lemma span_nat_eq_add_submonoid_closure (s : set M) :
   (span ℕ s).to_add_submonoid = add_submonoid.closure s :=
 begin
   refine eq.symm (add_submonoid.closure_eq_of_le subset_span _),

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -758,14 +758,15 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
   (H2 : ∀ (a:R) x, p x → p (a • x)) : p x :=
 (@span_le _ _ _ _ _ _ ⟨p, H0, H1, H2⟩).2 Hs h
 
-lemma span_eq_add_submonoid.closure {M : Type*} [add_comm_monoid M] (S : set M) :
+lemma span_eq_add_submonoid.closure (S : set M) :
   (span ℕ S).to_add_submonoid = add_submonoid.closure S :=
 begin
-  refine (add_submonoid.closure_eq_of_le (by exact subset_span) _).symm,
-  rintros m (hm : m ∈ (span ℕ S)),
-  exact submodule.span_induction hm (λ s hs, add_submonoid.subset_closure hs)
-    (add_submonoid.zero_mem _) (λ x y hx hy, add_submonoid.add_mem _ hx hy)
-    (λ a m hm, add_submonoid.nsmul_mem _ hm _)
+  apply le_antisymm,
+  { apply add_submonoid.to_nat_submodule.symm.to_galois_connection.l_le _,
+    rw span_le,
+    exact add_submonoid.subset_closure },
+  { rw add_submonoid.closure_le,
+    exact subset_span, }
 end
 
 section

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -758,17 +758,6 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
   (H2 : ∀ (a:R) x, p x → p (a • x)) : p x :=
 (@span_le _ _ _ _ _ _ ⟨p, H0, H1, H2⟩).2 Hs h
 
-lemma span_eq_add_submonoid.closure (S : set M) :
-  (span ℕ S).to_add_submonoid = add_submonoid.closure S :=
-begin
-  apply le_antisymm,
-  { apply add_submonoid.to_nat_submodule.symm.to_galois_connection.l_le _,
-    rw span_le,
-    exact add_submonoid.subset_closure },
-  { rw add_submonoid.closure_le,
-    exact subset_span, }
-end
-
 section
 variables (R M)
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -770,6 +770,16 @@ end
 @[simp] lemma span_nat_eq (s : add_submonoid M) : (span ℕ (s : set M)).to_add_submonoid = s :=
 by rw [span_nat_eq_add_group_closure, s.closure_eq]
 
+lemma span_int_eq_add_group_closure {M : Type*} [add_comm_group M] (s : set M) :
+  (span ℤ s).to_add_subgroup = add_subgroup.closure s :=
+eq.symm $ add_subgroup.closure_eq_of_le _ subset_span $ λ x hx, span_induction hx
+  (λ x hx, add_subgroup.subset_closure hx) (add_subgroup.zero_mem _)
+  (λ _ _, add_subgroup.add_mem _) (λ _ _ _, add_subgroup.gsmul_mem _ ‹_› _)
+
+@[simp] lemma span_int_eq {M : Type*} [add_comm_group M] (s : add_subgroup M) :
+  (span ℤ (s : set M)).to_add_subgroup = s :=
+by rw [span_int_eq_add_group_closure, s.closure_eq]
+
 section
 variables (R M)
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -768,7 +768,7 @@ begin
 end
 
 @[simp] lemma span_nat_eq (s : add_submonoid M) : (span ℕ (s : set M)).to_add_submonoid = s :=
-by rw [span_nat_eq_add_group_closure, s.closure_eq]
+by rw [span_nat_eq_add_submonoid_closure, s.closure_eq]
 
 lemma span_int_eq_add_subgroup_closure {M : Type*} [add_comm_group M] (s : set M) :
   (span ℤ s).to_add_subgroup = add_subgroup.closure s :=
@@ -778,7 +778,7 @@ eq.symm $ add_subgroup.closure_eq_of_le _ subset_span $ λ x hx, span_induction 
 
 @[simp] lemma span_int_eq {M : Type*} [add_comm_group M] (s : add_subgroup M) :
   (span ℤ (s : set M)).to_add_subgroup = s :=
-by rw [span_int_eq_add_group_closure, s.closure_eq]
+by rw [span_int_eq_add_subgroup_closure, s.closure_eq]
 
 section
 variables (R M)

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -758,6 +758,23 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
   (H2 : ∀ (a:R) x, p x → p (a • x)) : p x :=
 (@span_le _ _ _ _ _ _ ⟨p, H0, H1, H2⟩).2 Hs h
 
+section span_nat
+open submodule
+
+lemma span_nat_eq_add_group_closure (s : set R) :
+  (span ℕ s).to_add_submonoid = add_submonoid.closure s :=
+begin
+  refine eq.symm (add_submonoid.closure_eq_of_le subset_span _),
+  apply add_submonoid.to_nat_submodule.symm.to_galois_connection.l_le _,
+  rw span_le,
+  exact add_submonoid.subset_closure,
+end
+
+@[simp] lemma span_nat_eq (s : add_submonoid R) : (span ℕ (s : set R)).to_add_submonoid = s :=
+by rw [span_nat_eq_add_group_closure, s.closure_eq]
+
+end span_nat
+
 section
 variables (R M)
 


### PR DESCRIPTION
This has been suggested by @eric-wieser (who also wrote everything) in #7200.

This also:
* Merges `span_nat_eq_add_group_closure` and `submodule.span_eq_add_submonoid.closure` which are the same statement into `submodule.span_nat_eq_add_submonoid_closure`, which generalizes the former from `semiring` to `add_comm_monoid`.
* Renames `span_int_eq_add_group_closure` to `submodule.span_nat_eq_add_subgroup_closure`, and generalizes it from `ring` to `add_comm_group`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
