### PR TITLE
[Merged by Bors] - feat(set_theory/surreal): add add_monoid instance

### DIFF
--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -353,10 +353,10 @@ instance : add_semigroup surreal :=
   ..(by apply_instance : has_add surreal) }
 
 theorem zero_add : ∀ (x : surreal), 0 + x = x :=
-by rintro ⟨x, ox⟩; exact quotient.sound (pgame.zero_add_equiv _)
+by { rintro ⟨x, ox⟩, exact quotient.sound (pgame.zero_add_equiv _) }
 
 theorem add_zero : ∀ (x : surreal), x + 0 = x :=
-by rintro ⟨x, ox⟩; exact quotient.sound (pgame.add_zero_equiv _)
+by { rintro ⟨x, ox⟩, exact quotient.sound (pgame.add_zero_equiv _) }
 
 instance : add_monoid surreal :=
 { add := add,

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -348,10 +348,6 @@ begin
   exact add_assoc_equiv,
 end
 
-instance : add_semigroup surreal :=
-{ add_assoc := add_assoc,
-  ..(by apply_instance : has_add surreal) }
-
 theorem zero_add : ∀ (x : surreal), 0 + x = x :=
 by { rintro ⟨x, ox⟩, exact quotient.sound (pgame.zero_add_equiv _) }
 
@@ -359,11 +355,13 @@ theorem add_zero : ∀ (x : surreal), x + 0 = x :=
 by { rintro ⟨x, ox⟩, exact quotient.sound (pgame.add_zero_equiv _) }
 
 instance : add_monoid surreal :=
-{ add := add,
-  add_assoc := add_assoc,
-  zero := 0,
-  zero_add := zero_add,
-  add_zero := add_zero }
+{ add       := surreal.add,
+  add_assoc := surreal.add_assoc,
+  zero      := 0,
+  zero_add  := surreal.zero_add,
+  add_zero  := surreal.add_zero }
+
+instance : add_semigroup surreal := by apply_instance
 
 -- We conclude with some ideas for further work on surreals; these would make fun projects.
 

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -352,10 +352,23 @@ instance : add_semigroup surreal :=
 { add_assoc := add_assoc,
   ..(by apply_instance : has_add surreal) }
 
+theorem zero_add : ∀ x : surreal, 0 + x = x :=
+by rintro ⟨x, ox⟩; exact quotient.sound (pgame.zero_add_equiv _)
+
+theorem add_zero : ∀ x : surreal, x + 0 = x :=
+by rintro ⟨x, ox⟩; exact quotient.sound (pgame.add_zero_equiv _)
+
+instance : add_monoid surreal :=
+{ add := add,
+  add_assoc := add_assoc,
+  zero := 0,
+  zero_add := zero_add,
+  add_zero := add_zero }
+
 -- We conclude with some ideas for further work on surreals; these would make fun projects.
 
 -- TODO construct the remaining instances:
---   add_monoid, add_group, add_comm_semigroup, add_comm_group, ordered_add_comm_group,
+--   add_group, add_comm_semigroup, add_comm_group, ordered_add_comm_group,
 -- as per the instances for `game`
 
 -- TODO define the inclusion of groups `surreal → game`

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -352,10 +352,10 @@ instance : add_semigroup surreal :=
 { add_assoc := add_assoc,
   ..(by apply_instance : has_add surreal) }
 
-theorem zero_add : ∀ x : surreal, 0 + x = x :=
+theorem zero_add : ∀ (x : surreal), 0 + x = x :=
 by rintro ⟨x, ox⟩; exact quotient.sound (pgame.zero_add_equiv _)
 
-theorem add_zero : ∀ x : surreal, x + 0 = x :=
+theorem add_zero : ∀ (x : surreal), x + 0 = x :=
 by rintro ⟨x, ox⟩; exact quotient.sound (pgame.add_zero_equiv _)
 
 instance : add_monoid surreal :=

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -363,7 +363,7 @@ instance : add_monoid surreal :=
 
 -- We conclude with some ideas for further work on surreals; these would make fun projects.
 
--- TODO construct the remaining instances:
+-- TODO replace the `add_monoid` instance above with a stronger instance:
 --   add_group, add_comm_semigroup, add_comm_group, ordered_add_comm_group,
 -- as per the instances for `game`
 

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -361,8 +361,6 @@ instance : add_monoid surreal :=
   zero_add  := surreal.zero_add,
   add_zero  := surreal.add_zero }
 
-instance : add_semigroup surreal := by apply_instance
-
 -- We conclude with some ideas for further work on surreals; these would make fun projects.
 
 -- TODO construct the remaining instances:


### PR DESCRIPTION
This PR is a part of a project for putting ordered abelian group structure on surreal numbers.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Surreal.20numbers/near/234694758)

We construct add_monoid instance for surreal numbers.

The "term_type" proofs suggested on the above Zulip thread are not working nicely as Lean is unable to infer the type of the setoid.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
