### PR TITLE
[Merged by Bors] - chore(category_theory/subobject): different proof of le_of_comm

### DIFF
--- a/src/category_theory/subobject/basic.lean
+++ b/src/category_theory/subobject/basic.lean
@@ -184,21 +184,21 @@ lemma eq_of_comp_arrow_eq {X Y : C} {P : subobject Y}
   {f g : X ⟶ P} (h : f ≫ P.arrow = g ≫ P.arrow) : f = g :=
 (cancel_mono P.arrow).mp h
 
--- TODO surely there is a cleaner proof here
+lemma mk_le_mk_of_comm {B A₁ A₂ : C} {f₁ : A₁ ⟶ B} {f₂ : A₂ ⟶ B} [mono f₁] [mono f₂] (g : A₁ ⟶ A₂)
+  (w : g ≫ f₂ = f₁) : mk f₁ ≤ mk f₂ :=
+⟨mono_over.hom_mk _ w⟩
+
+@[simp] lemma mk_arrow (P : subobject X) : mk P.arrow = P :=
+quotient.induction_on' P $ λ Q,
+begin
+  obtain ⟨e⟩ := @quotient.mk_out' _ (is_isomorphic_setoid _) Q,
+  refine quotient.sound' ⟨mono_over.iso_mk _ _ ≪≫ e⟩;
+  tidy
+end
+
 lemma le_of_comm {B : C} {X Y : subobject B} (f : (X : C) ⟶ (Y : C)) (w : f ≫ Y.arrow = X.arrow) :
   X ≤ Y :=
-begin
-  revert f w,
-  refine quotient.induction_on₂' X Y _,
-  intros P Q f w,
-  fsplit,
-  refine over.hom_mk ((representative_iso P).inv.left ≫ f ≫ (representative_iso Q).hom.left) _,
-  dsimp,
-  simp only [over.w, category.assoc],
-  erw [w, (representative_iso P).inv.w],
-  dsimp,
-  simp only [category.comp_id],
-end
+by convert mk_le_mk_of_comm _ w; simp
 
 lemma le_mk_of_comm {B A : C} {X : subobject B} {f : A ⟶ B} [mono f] (g : (X : C) ⟶ A)
   (w : g ≫ f = X.arrow) : X ≤ mk f :=
@@ -207,10 +207,6 @@ le_of_comm (g ≫ (underlying_iso f).inv) $ by simp [w]
 lemma mk_le_of_comm {B A : C} {X : subobject B} {f : A ⟶ B} [mono f] (g : A ⟶ (X : C))
   (w : g ≫ X.arrow = f) : mk f ≤ X :=
 le_of_comm ((underlying_iso f).hom ≫ g) $ by simp [w]
-
-lemma mk_le_mk_of_comm {B A₁ A₂ : C} {f₁ : A₁ ⟶ B} {f₂ : A₂ ⟶ B} [mono f₁] [mono f₂] (g : A₁ ⟶ A₂)
-  (w : g ≫ f₂ = f₁) : mk f₁ ≤ mk f₂ :=
-le_mk_of_comm ((underlying_iso f₁).hom ≫ g) $ by simp [w]
 
 /-- To show that two subobjects are equal, it suffices to exhibit an isomorphism commuting with
     the arrows. -/
@@ -344,9 +340,6 @@ def iso_of_mk_eq_mk {B A₁ A₂ : C} (f : A₁ ⟶ B) (g : A₂ ⟶ B) [mono f]
   A₁ ≅ A₂ :=
 { hom := of_mk_le_mk f g h.le,
   inv := of_mk_le_mk g f h.ge, }
-
-@[simp] lemma mk_arrow (P : subobject X) : mk P.arrow = P :=
-mk_eq_of_comm _ (iso.refl _) (by simp)
 
 end subobject
 


### PR DESCRIPTION
This is certainly a shorter proof of `le_of_comm`; whether it is "cleaner" like the comment asked for is perhaps a matter of taste.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
