### PR TITLE
[Merged by Bors] - chore(data/set/finite): rename some lemmas

### DIFF
--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -473,18 +473,26 @@ instance fintype_bind' {α β} [decidable_eq β] (s : set α) [fintype s]
   (f : α → set β) [H : ∀ a, fintype (f a)] : fintype (s >>= f) :=
 fintype_bind _ _ (λ i _, H i)
 
-theorem finite.bind {α β} {s : set α} {f : α → set β} :
-  finite s → (∀ a ∈ s, finite (f a)) → finite (s >>= f)
-| ⟨hs⟩ H := ⟨@fintype_bind _ _ (classical.dec_eq β) _ hs _ (λ a ha, (H a ha).fintype)⟩
+theorem finite.bind {α β} {s : set α} {f : α → set β} (h : finite s) (hf : ∀ a ∈ s, finite (f a)) :
+  finite (s >>= f) :=
+h.bUnion hf
 
-instance fintype_seq {α β : Type u} [decidable_eq β]
+instance fintype_seq [decidable_eq β] (f : set (α → β)) (s : set α) [fintype f] [fintype s] :
+  fintype (f.seq s) :=
+by { rw seq_def, apply set.fintype_bUnion' }
+
+instance fintype_seq' {α β : Type u} [decidable_eq β]
   (f : set (α → β)) (s : set α) [fintype f] [fintype s] :
   fintype (f <*> s) :=
-by rw seq_eq_bind_map; apply set.fintype_bUnion'
+set.fintype_seq f s
 
-theorem finite.seq {α β : Type u} {f : set (α → β)} {s : set α} :
-  finite f → finite s → finite (f <*> s)
-| ⟨hf⟩ ⟨hs⟩ := by { haveI := classical.dec_eq β, exactI ⟨set.fintype_seq _ _⟩ }
+theorem finite.seq {f : set (α → β)} {s : set α} (hf : finite f) (hs : finite s) :
+  finite (f.seq s) :=
+by { rw seq_def, exact hf.bUnion (λ f _, hs.image _) }
+
+theorem finite.seq' {α β : Type u} {f : set (α → β)} {s : set α} (hf : finite f) (hs : finite s) :
+  finite (f <*> s) :=
+hf.seq hs
 
 /-- There are finitely many subsets of a given finite set -/
 lemma finite.finite_subsets {α : Type u} {a : set α} (h : finite a) : finite {b | b ⊆ a} :=

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -417,14 +417,14 @@ theorem finite_Union {ι : Type*} [fintype ι] {f : ι → set α} (H : ∀i, fi
 
 /-- A union of sets with `fintype` structure over a set with `fintype` structure has a `fintype`
 structure. -/
-def fintype_set_bUnion [decidable_eq α] {ι : Type*} {s : set ι} [fintype s]
+def fintype_bUnion [decidable_eq α] {ι : Type*} {s : set ι} [fintype s]
   (f : ι → set α) (H : ∀ i ∈ s, fintype (f i)) : fintype (⋃ i ∈ s, f i) :=
 by rw bUnion_eq_Union; exact
 @set.fintype_Union _ _ _ _ _ (by rintro ⟨i, hi⟩; exact H i hi)
 
-instance fintype_set_bUnion' [decidable_eq α] {ι : Type*} {s : set ι} [fintype s]
+instance fintype_bUnion' [decidable_eq α] {ι : Type*} {s : set ι} [fintype s]
   (f : ι → set α) [H : ∀ i, fintype (f i)] : fintype (⋃ i ∈ s, f i) :=
-fintype_set_bUnion _ (λ i _, H i)
+fintype_bUnion _ (λ i _, H i)
 
 theorem finite.sUnion {s : set (set α)} (h : finite s) (H : ∀t∈s, finite t) : finite (⋃₀ s) :=
 by rw sUnion_eq_Union; haveI := finite.fintype h;
@@ -433,6 +433,10 @@ by rw sUnion_eq_Union; haveI := finite.fintype h;
 theorem finite.bUnion {α} {ι : Type*} {s : set ι} {f : Π i ∈ s, set α} :
   finite s → (∀ i ∈ s, finite (f i ‹_›)) → finite (⋃ i∈s, f i ‹_›)
 | ⟨hs⟩ h := by rw [bUnion_eq_Union]; exactI finite_Union (λ i, h _ _)
+
+theorem finite_Union_Prop {p : Prop} {f : p → set α} (hf : ∀ h, finite (f h)) :
+  finite (⋃ h : p, f h) :=
+by by_cases p; simp *
 
 instance fintype_lt_nat (n : ℕ) : fintype {i | i < n} :=
 fintype.of_finset (finset.range n) $ by simp
@@ -461,17 +465,17 @@ by { rw ← image_prod, exact (hs.prod ht).image _ }
 
 /-- If `s : set α` is a set with `fintype` instance and `f : α → set β` is a function such that
 each `f a`, `a ∈ s`, has a `fintype` structure, then `s >>= f` has a `fintype` structure. -/
-def fintype_bUnion {α β} [decidable_eq β] (s : set α) [fintype s]
+def fintype_bind {α β} [decidable_eq β] (s : set α) [fintype s]
   (f : α → set β) (H : ∀ a ∈ s, fintype (f a)) : fintype (s >>= f) :=
-set.fintype_set_bUnion _ H
+set.fintype_bUnion _ H
 
-instance fintype_bUnion' {α β} [decidable_eq β] (s : set α) [fintype s]
+instance fintype_bind' {α β} [decidable_eq β] (s : set α) [fintype s]
   (f : α → set β) [H : ∀ a, fintype (f a)] : fintype (s >>= f) :=
-fintype_bUnion _ _ (λ i _, H i)
+fintype_bind _ _ (λ i _, H i)
 
-theorem finite_bUnion {α β} {s : set α} {f : α → set β} :
+theorem finite.bind {α β} {s : set α} {f : α → set β} :
   finite s → (∀ a ∈ s, finite (f a)) → finite (s >>= f)
-| ⟨hs⟩ H := ⟨@fintype_bUnion _ _ (classical.dec_eq β) _ hs _ (λ a ha, (H a ha).fintype)⟩
+| ⟨hs⟩ H := ⟨@fintype_bind _ _ (classical.dec_eq β) _ hs _ (λ a ha, (H a ha).fintype)⟩
 
 instance fintype_seq {α β : Type u} [decidable_eq β]
   (f : set (α → β)) (s : set α) [fintype f] [fintype s] :

--- a/src/ring_theory/polynomial/dickson.lean
+++ b/src/ring_theory/polynomial/dickson.lean
@@ -211,8 +211,7 @@ begin
     suffices : (set.univ : set K) =
       {x : K | ∃ (y : K), x = y + y⁻¹ ∧ y ≠ 0} >>= (λ x, {y | x = y + y⁻¹ ∨ y = 0}),
     { rw this, clear this,
-      apply set.finite_bUnion h,
-      rintro x hx,
+      refine h.bUnion (λ x hx, _),
       -- The following quadratic polynomial has as solutions the `y` for which `x = y + y⁻¹`.
       let φ : polynomial K := X ^ 2 - C x * X + 1,
       have hφ : φ ≠ 0,


### PR DESCRIPTION
### Revert some name changes from #5813

* `set.fintype_set_bUnion` → `set.fintype_bUnion`;
* `set.fintype_set_bUnion'` → `set.fintype_bUnion'`;
* `set.fintype_bUnion` → `set.fintype_bind`;
* `set.fintype_bUnion'` → `set.fintype_bind'`;
* `set.finite_bUnion` → `set.finite.bind`;

### Add a few lemmas
* `set.finite_Union_Prop`;
* add `set.seq` versions of lemmas/defs about `<*>` (they work for `α`, `β` in different universes).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
