### PR TITLE
[Merged by Bors] - feat(algebraic_geometry/prime_spectrum): More lemmas

### DIFF
--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -140,7 +140,7 @@ begin
   rw [submodule.mem_infi],
 end
 
-lemma mem_vanishing_ideal (t : set (prime_spectrum R)) (f : R) :
+@[simp] lemma mem_vanishing_ideal (t : set (prime_spectrum R)) (f : R) :
   f ∈ vanishing_ideal t ↔ ∀ x : prime_spectrum R, x ∈ t → f ∈ x.as_ideal :=
 by rw [← set_like.mem_coe, coe_vanishing_ideal, set.mem_set_of_eq]
 
@@ -208,7 +208,7 @@ lemma vanishing_ideal_anti_mono {s t : set (prime_spectrum R)} (h : s ⊆ t) :
   vanishing_ideal t ≤ vanishing_ideal s :=
 (gc R).monotone_u h
 
-lemma zero_locus_bot :
+@[simp] lemma zero_locus_bot :
   zero_locus ((⊥ : ideal R) : set R) = set.univ :=
 (gc R).l_bot
 
@@ -219,22 +219,6 @@ zero_locus_bot
 @[simp] lemma zero_locus_empty :
   zero_locus (∅ : set R) = set.univ :=
 (gc_set R).l_bot
-
-@[simp] lemma zero_locus_singleton_one :
-  zero_locus ({1} : set R) = ∅ :=
-set.ext $ λ x, by simpa [← ideal.ne_top_iff_one] using x.2.ne_top
-
-@[simp] lemma zero_locus_one_mem {s : set R} (h : (1 : R) ∈ s) :
-  zero_locus s = ∅ :=
-begin
-  rw ← set.subset_empty_iff,
-  convert zero_locus_anti_mono (set.singleton_subset_iff.mpr h),
-  exact zero_locus_singleton_one.symm,
-end
-
-@[simp] lemma zero_locus_top :
-  zero_locus ((⊤ : ideal R) : set R) = ∅ :=
-zero_locus_one_mem trivial
 
 @[simp] lemma vanishing_ideal_univ :
   vanishing_ideal (∅ : set (prime_spectrum R)) = ⊤ :=
@@ -250,6 +234,10 @@ begin
   have eq_top : x.as_ideal = ⊤, { rw ideal.eq_top_iff_one, exact hx h },
   apply x_prime.ne_top eq_top,
 end
+
+@[simp] lemma zero_locus_singleton_one :
+  zero_locus ({1} : set R) = ∅ :=
+zero_locus_empty_of_one_mem (set.mem_singleton (1 : R))
 
 lemma zero_locus_empty_iff_eq_top {I : ideal R} :
   zero_locus (I : set R) = ∅ ↔ I = ⊤ :=
@@ -368,8 +356,7 @@ begin
     obtain ⟨fs, rfl⟩ : ∃ s, t' = zero_locus s,
     by rwa [is_closed_iff_zero_locus] at ht',
     rw [subset_zero_locus_iff_subset_vanishing_ideal] at ht,
-    calc fs ⊆ vanishing_ideal t : ht
-        ... ⊆ x.as_ideal        : hx },
+    exact set.subset.trans ht hx },
   { rw (is_closed_zero_locus _).closure_subset_iff,
     exact subset_zero_locus_vanishing_ideal t }
 end
@@ -461,13 +448,10 @@ topological_space.opens.ext $ by {simp, refl}
 @[simp] lemma basic_open_zero : basic_open (0 : R) = ⊥ :=
 topological_space.opens.ext $ by {simp, refl}
 
-@[simp] lemma basic_open_mul (f g : R) : basic_open (f * g) = basic_open f ⊓ basic_open g :=
-begin
-  ext1, dsimp,
-  simp only [set.compl_union, basic_open_eq_zero_locus_compl, zero_locus_singleton_mul],
-end
+lemma basic_open_mul (f g : R) : basic_open (f * g) = basic_open f ⊓ basic_open g :=
+topological_space.opens.ext $ by {simp [zero_locus_singleton_mul]}
 
-@[simp] lemma basic_open_pow (f : R) (n : ℕ) (hn : n > 0) : basic_open (f ^ n) = basic_open f :=
+lemma basic_open_pow (f : R) (n : ℕ) (hn : n > 0) : basic_open (f ^ n) = basic_open f :=
 topological_space.opens.ext $ by simpa using zero_locus_singleton_pow f n hn
 
 lemma is_topological_basis_basic_opens : topological_space.is_topological_basis

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -295,6 +295,13 @@ lemma zero_locus_singleton_mul (f g : R) :
   zero_locus ({f * g} : set R) = zero_locus {f} ∪ zero_locus {g} :=
 set.ext $ λ x, by simpa using x.2.mem_or_mem_iff
 
+@[simp] lemma zero_locus_pow (I : ideal R) {n : ℕ} (hn : n > 0) :
+  zero_locus ((I ^ n : ideal R) : set R) = zero_locus I :=
+zero_locus_radical (I ^ n) ▸ (I.radical_pow n hn).symm ▸ zero_locus_radical I
+
+@[simp] lemma zero_locus_singleton_pow (f : R) (n : ℕ) (hn : n > 0) : zero_locus ({f ^ n} : set R) = zero_locus {f} :=
+set.ext $ λ x, by simpa using x.2.pow_mem_iff_mem n hn
+
 lemma sup_vanishing_ideal_le (t t' : set (prime_spectrum R)) :
   vanishing_ideal t ⊔ vanishing_ideal t' ≤ vanishing_ideal (t ∩ t') :=
 begin
@@ -422,10 +429,13 @@ def basic_open (r : R) : topological_space.opens (prime_spectrum R) :=
 { val := { x | r ∉ x.as_ideal },
   property := ⟨{r}, set.ext $ λ x, set.singleton_subset_iff.trans $ not_not.symm⟩ }
 
+@[simp] lemma mem_basic_open (f : R) (x : prime_spectrum R) :
+  x ∈ basic_open f ↔ f ∉ x.as_ideal := iff.rfl
+
 lemma is_open_basic_open {a : R} : is_open ((basic_open a) : set (prime_spectrum R)) :=
 (basic_open a).property
 
-lemma basic_open_eq_zero_locus_compl (r : R) :
+@[simp] lemma basic_open_eq_zero_locus_compl (r : R) :
   (basic_open r : set (prime_spectrum R)) = (zero_locus {r})ᶜ :=
 set.ext $ λ x, by simpa only [set.mem_compl_eq, mem_zero_locus, set.singleton_subset_iff]
 
@@ -434,6 +444,9 @@ begin
   ext1, dsimp,
   simp only [set.compl_union, basic_open_eq_zero_locus_compl, zero_locus_singleton_mul],
 end
+
+@[simp] lemma basic_open_pow (f : R) (n : ℕ) (hn : n > 0) : basic_open (f ^ n) = basic_open f :=
+topological_space.opens.ext $ by simpa using zero_locus_singleton_pow f n hn
 
 lemma is_topological_basis_basic_opens : topological_space.is_topological_basis
   (set.range (λ (r : R), (basic_open r : set (prime_spectrum R)))) :=

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -140,7 +140,7 @@ begin
   rw [submodule.mem_infi],
 end
 
-@[simp] lemma mem_vanishing_ideal (t : set (prime_spectrum R)) (f : R) :
+lemma mem_vanishing_ideal (t : set (prime_spectrum R)) (f : R) :
   f ∈ vanishing_ideal t ↔ ∀ x : prime_spectrum R, x ∈ t → f ∈ x.as_ideal :=
 by rw [← set_like.mem_coe, coe_vanishing_ideal, set.mem_set_of_eq]
 
@@ -303,7 +303,8 @@ set.ext $ λ x, by simpa using x.2.mul_mem_iff_mem_or_mem
   zero_locus ((I ^ n : ideal R) : set R) = zero_locus I :=
 zero_locus_radical (I ^ n) ▸ (I.radical_pow n hn).symm ▸ zero_locus_radical I
 
-@[simp] lemma zero_locus_singleton_pow (f : R) (n : ℕ) (hn : n > 0) : zero_locus ({f ^ n} : set R) = zero_locus {f} :=
+@[simp] lemma zero_locus_singleton_pow (f : R) (n : ℕ) (hn : n > 0) :
+  zero_locus ({f ^ n} : set R) = zero_locus {f} :=
 set.ext $ λ x, by simpa using x.2.pow_mem_iff_mem n hn
 
 lemma sup_vanishing_ideal_le (t t' : set (prime_spectrum R)) :

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -452,7 +452,7 @@ topological_space.opens.ext $ by {simp, refl}
 lemma basic_open_mul (f g : R) : basic_open (f * g) = basic_open f ⊓ basic_open g :=
 topological_space.opens.ext $ by {simp [zero_locus_singleton_mul]}
 
-lemma basic_open_pow (f : R) (n : ℕ) (hn : n > 0) : basic_open (f ^ n) = basic_open f :=
+@[simp] lemma basic_open_pow (f : R) (n : ℕ) (hn : n > 0) : basic_open (f ^ n) = basic_open f :=
 topological_space.opens.ext $ by simpa using zero_locus_singleton_pow f n hn
 
 lemma is_topological_basis_basic_opens : topological_space.is_topological_basis

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -213,12 +213,28 @@ lemma zero_locus_bot :
 (gc R).l_bot
 
 @[simp] lemma zero_locus_singleton_zero :
-  zero_locus (0 : set R) = set.univ :=
+  zero_locus ({0} : set R) = set.univ :=
 zero_locus_bot
 
 @[simp] lemma zero_locus_empty :
   zero_locus (∅ : set R) = set.univ :=
 (gc_set R).l_bot
+
+@[simp] lemma zero_locus_singleton_one :
+  zero_locus ({1} : set R) = ∅ :=
+set.ext $ λ x, by simpa [← ideal.ne_top_iff_one] using x.2.ne_top
+
+@[simp] lemma zero_locus_one_mem {s : set R} (h : (1 : R) ∈ s) :
+  zero_locus s = ∅ :=
+begin
+  rw ← set.subset_empty_iff,
+  convert zero_locus_anti_mono (set.singleton_subset_iff.mpr h),
+  exact zero_locus_singleton_one.symm,
+end
+
+@[simp] lemma zero_locus_top :
+  zero_locus ((⊤ : ideal R) : set R) = ∅ :=
+zero_locus_one_mem trivial
 
 @[simp] lemma vanishing_ideal_univ :
   vanishing_ideal (∅ : set (prime_spectrum R)) = ⊤ :=
@@ -293,7 +309,7 @@ set.ext $ λ x, by simpa using x.2.mul_le
 
 lemma zero_locus_singleton_mul (f g : R) :
   zero_locus ({f * g} : set R) = zero_locus {f} ∪ zero_locus {g} :=
-set.ext $ λ x, by simpa using x.2.mem_or_mem_iff
+set.ext $ λ x, by simpa using x.2.mul_mem_iff_mem_or_mem
 
 @[simp] lemma zero_locus_pow (I : ideal R) {n : ℕ} (hn : n > 0) :
   zero_locus ((I ^ n : ideal R) : set R) = zero_locus I :=
@@ -439,7 +455,13 @@ lemma is_open_basic_open {a : R} : is_open ((basic_open a) : set (prime_spectrum
   (basic_open r : set (prime_spectrum R)) = (zero_locus {r})ᶜ :=
 set.ext $ λ x, by simpa only [set.mem_compl_eq, mem_zero_locus, set.singleton_subset_iff]
 
-lemma inf_basic_open (f g : R) : basic_open f ⊓ basic_open g = basic_open (f * g) :=
+@[simp] lemma basic_open_one : basic_open (1 : R) = ⊤ :=
+topological_space.opens.ext $ by {simp, refl}
+
+@[simp] lemma basic_open_zero : basic_open (0 : R) = ⊥ :=
+topological_space.opens.ext $ by {simp, refl}
+
+@[simp] lemma basic_open_mul (f g : R) : basic_open (f * g) = basic_open f ⊓ basic_open g :=
 begin
   ext1, dsimp,
   simp only [set.compl_union, basic_open_eq_zero_locus_compl, zero_locus_singleton_mul],

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -281,30 +281,19 @@ lemma vanishing_ideal_Union {ι : Sort*} (t : ι → set (prime_spectrum R)) :
 
 lemma zero_locus_inf (I J : ideal R) :
   zero_locus ((I ⊓ J : ideal R) : set R) = zero_locus I ∪ zero_locus J :=
-begin
-  ext x,
-  split,
-  { rintro h,
-    rw set.mem_union,
-    simp only [mem_zero_locus] at h ⊢,
-    -- TODO: The rest of this proof should be factored out.
-    rw or_iff_not_imp_right,
-    intros hs r hr,
-    rw set.not_subset at hs,
-    rcases hs with ⟨s, hs1, hs2⟩,
-    apply (ideal.is_prime.mem_or_mem (by apply_instance) _).resolve_left hs2,
-    apply h,
-    exact ⟨I.mul_mem_left _ hr, J.mul_mem_right _ hs1⟩ },
-  { rintro (h|h),
-    all_goals
-    { rw mem_zero_locus at h ⊢,
-      refine set.subset.trans _ h,
-      intros r hr, cases hr, assumption } }
-end
+set.ext $ λ x, by simpa using x.2.inf_le
 
 lemma union_zero_locus (s s' : set R) :
   zero_locus s ∪ zero_locus s' = zero_locus ((ideal.span s) ⊓ (ideal.span s') : ideal R) :=
 by { rw zero_locus_inf, simp }
+
+lemma zero_locus_mul (I J : ideal R) :
+  zero_locus ((I * J : ideal R) : set R) = zero_locus I ∪ zero_locus J :=
+set.ext $ λ x, by simpa using x.2.mul_le
+
+lemma zero_locus_singleton_mul (f g : R) :
+  zero_locus ({f * g} : set R) = zero_locus {f} ∪ zero_locus {g} :=
+set.ext $ λ x, by simpa using x.2.mem_or_mem_iff
 
 lemma sup_vanishing_ideal_le (t t' : set (prime_spectrum R)) :
   vanishing_ideal t ⊔ vanishing_ideal t' ≤ vanishing_ideal (t ∩ t') :=
@@ -439,6 +428,12 @@ lemma is_open_basic_open {a : R} : is_open ((basic_open a) : set (prime_spectrum
 lemma basic_open_eq_zero_locus_compl (r : R) :
   (basic_open r : set (prime_spectrum R)) = (zero_locus {r})ᶜ :=
 set.ext $ λ x, by simpa only [set.mem_compl_eq, mem_zero_locus, set.singleton_subset_iff]
+
+lemma inf_basic_open (f g : R) : basic_open f ⊓ basic_open g = basic_open (f * g) :=
+begin
+  ext1, dsimp,
+  simp only [set.compl_union, basic_open_eq_zero_locus_compl, zero_locus_singleton_mul],
+end
 
 lemma is_topological_basis_basic_opens : topological_space.is_topological_basis
   (set.range (λ (r : R), (basic_open r : set (prime_spectrum R)))) :=

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -184,14 +184,14 @@ lemma le_vanishing_ideal_zero_locus (I : ideal R) :
 (gc R).le_u_l I
 
 @[simp] lemma vanishing_ideal_zero_locus_eq_radical (I : ideal R) :
-  vanishing_ideal (zero_locus (I : set R)) = I.radical :=
+  vanishing_ideal (zero_locus (I : set R)) = I.radical := ideal.ext $ λ f,
 begin
-  ext f,
   rw [mem_vanishing_ideal, ideal.radical_eq_Inf, submodule.mem_Inf],
-  split ; intros h x hx,
-  { exact h ⟨x, hx.2⟩ hx.1 },
-  { exact h x.1 ⟨hx, x.2⟩ }
+  exact ⟨(λ h x hx, h ⟨x, hx.2⟩ hx.1), (λ h x hx, h x.1 ⟨hx, x.2⟩)⟩
 end
+
+@[simp] lemma zero_locus_radical (I : ideal R) : zero_locus (I.radical : set R) = zero_locus I :=
+vanishing_ideal_zero_locus_eq_radical I ▸ congr_fun (gc R).l_u_l_eq_l I
 
 lemma subset_zero_locus_vanishing_ideal (t : set (prime_spectrum R)) :
   t ⊆ zero_locus (vanishing_ideal t) :=
@@ -348,6 +348,24 @@ lemma is_closed_zero_locus (s : set R) :
   is_closed (zero_locus s) :=
 by { rw [is_closed_iff_zero_locus], exact ⟨s, rfl⟩ }
 
+lemma zero_locus_vanishing_ideal_eq_closure (t : set (prime_spectrum R)) :
+  zero_locus (vanishing_ideal t : set R) = closure t :=
+begin
+  apply set.subset.antisymm,
+  { rintro x hx t' ⟨ht', ht⟩,
+    obtain ⟨fs, rfl⟩ : ∃ s, t' = zero_locus s,
+    by rwa [is_closed_iff_zero_locus] at ht',
+    rw [subset_zero_locus_iff_subset_vanishing_ideal] at ht,
+    calc fs ⊆ vanishing_ideal t : ht
+        ... ⊆ x.as_ideal        : hx },
+  { rw (is_closed_zero_locus _).closure_subset_iff,
+    exact subset_zero_locus_vanishing_ideal t }
+end
+
+lemma vanishing_ideal_closure (t : set (prime_spectrum R)) :
+  vanishing_ideal (closure t) = vanishing_ideal t :=
+zero_locus_vanishing_ideal_eq_closure t ▸ congr_fun (gc R).u_l_u_eq_u t
+
 section comap
 variables {S : Type v} [comm_ring S] {S' : Type*} [comm_ring S']
 
@@ -386,20 +404,6 @@ begin
 end
 
 end comap
-
-lemma zero_locus_vanishing_ideal_eq_closure (t : set (prime_spectrum R)) :
-  zero_locus (vanishing_ideal t : set R) = closure t :=
-begin
-  apply set.subset.antisymm,
-  { rintro x hx t' ⟨ht', ht⟩,
-    obtain ⟨fs, rfl⟩ : ∃ s, t' = zero_locus s,
-    by rwa [is_closed_iff_zero_locus] at ht',
-    rw [subset_zero_locus_iff_subset_vanishing_ideal] at ht,
-    calc fs ⊆ vanishing_ideal t : ht
-        ... ⊆ x.as_ideal        : hx },
-  { rw (is_closed_zero_locus _).closure_subset_iff,
-    exact subset_zero_locus_vanishing_ideal t }
-end
 
 /-- The prime spectrum of a commutative ring is a compact topological space. -/
 instance : compact_space (prime_spectrum R) :=

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -208,7 +208,7 @@ lemma vanishing_ideal_anti_mono {s t : set (prime_spectrum R)} (h : s ⊆ t) :
   vanishing_ideal t ≤ vanishing_ideal s :=
 (gc R).monotone_u h
 
-@[simp] lemma zero_locus_bot :
+lemma zero_locus_bot :
   zero_locus ((⊥ : ideal R) : set R) = set.univ :=
 (gc R).l_bot
 
@@ -299,11 +299,11 @@ lemma zero_locus_singleton_mul (f g : R) :
   zero_locus ({f * g} : set R) = zero_locus {f} ∪ zero_locus {g} :=
 set.ext $ λ x, by simpa using x.2.mul_mem_iff_mem_or_mem
 
-@[simp] lemma zero_locus_pow (I : ideal R) {n : ℕ} (hn : n > 0) :
+@[simp] lemma zero_locus_pow (I : ideal R) {n : ℕ} (hn : 0 < n) :
   zero_locus ((I ^ n : ideal R) : set R) = zero_locus I :=
 zero_locus_radical (I ^ n) ▸ (I.radical_pow n hn).symm ▸ zero_locus_radical I
 
-@[simp] lemma zero_locus_singleton_pow (f : R) (n : ℕ) (hn : n > 0) :
+@[simp] lemma zero_locus_singleton_pow (f : R) (n : ℕ) (hn : 0 < n) :
   zero_locus ({f ^ n} : set R) = zero_locus {f} :=
 set.ext $ λ x, by simpa using x.2.pow_mem_iff_mem n hn
 
@@ -452,7 +452,7 @@ topological_space.opens.ext $ by {simp, refl}
 lemma basic_open_mul (f g : R) : basic_open (f * g) = basic_open f ⊓ basic_open g :=
 topological_space.opens.ext $ by {simp [zero_locus_singleton_mul]}
 
-@[simp] lemma basic_open_pow (f : R) (n : ℕ) (hn : n > 0) : basic_open (f ^ n) = basic_open f :=
+@[simp] lemma basic_open_pow (f : R) (n : ℕ) (hn : 0 < n) : basic_open (f ^ n) = basic_open f :=
 topological_space.opens.ext $ by simpa using zero_locus_singleton_pow f n hn
 
 lemma is_topological_basis_basic_opens : topological_space.is_topological_basis

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -509,6 +509,37 @@ ring_hom.ext $ λ g, (localization.of _).lift_eq _ _
   const R f 1 (basic_open s) (λ _ _, submonoid.one_mem _) :=
 ((localization.of _).lift_eq _ _).trans $ to_open_eq_const _ _ _
 
+lemma to_basic_open_injective (f : R) : function.injective (to_basic_open R f) :=
+begin
+  intros s t h_eq,
+  obtain ⟨a, ⟨b, hb⟩, rfl⟩ := (localization.of _).mk'_surjective s,
+  obtain ⟨c, ⟨d, hd⟩, rfl⟩ := (localization.of _).mk'_surjective t,
+  simp only [to_basic_open_mk'] at h_eq,
+  let I : ideal R :=
+  { carrier := {r : R | a * d * r = c * b * r},
+    zero_mem' := sorry,
+    add_mem' := sorry,
+    smul_mem' := sorry},
+  suffices : f ∈ I.radical,
+  { obtain ⟨n, hn⟩ := this,
+    rw localization_map.eq,
+    use [f ^ n, n, hn] },
+  rw [← vanishing_ideal_zero_locus_eq_radical, mem_vanishing_ideal],
+  intros p hfp,
+  contrapose hfp,
+  have := congr_fun (congr_arg subtype.val h_eq) ⟨p,hfp⟩,
+  rw [const_apply, const_apply, localization_map.eq] at this,
+  obtain ⟨r, hr⟩ := this,
+  rw [mem_zero_locus, set.not_subset],
+  exact ⟨r.1, hr, r.2⟩
+end
+
+lemma to_basic_open_surjective (f : R) : function.surjective (to_basic_open R f) :=
+begin
+  sorry
+end
+
+
 lemma is_unit_to_stalk (x : Spec.Top R) (f : x.as_ideal.prime_compl) :
   is_unit (to_stalk R x (f : R)) :=
 by { erw ← germ_to_open R (basic_open (f : R)) ⟨x, f.2⟩ (f : R),

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -509,42 +509,6 @@ ring_hom.ext $ λ g, (localization.of _).lift_eq _ _
   const R f 1 (basic_open s) (λ _ _, submonoid.one_mem _) :=
 ((localization.of _).lift_eq _ _).trans $ to_open_eq_const _ _ _
 
--- The proof here follows the argument in Hartshorne's Algebraic Geometry, Proposition II.2.2.
-lemma to_basic_open_injective (f : R) : function.injective (to_basic_open R f) :=
-begin
-  intros s t h_eq,
-  obtain ⟨a, ⟨b, hb⟩, rfl⟩ := (localization.of _).mk'_surjective s,
-  obtain ⟨c, ⟨d, hd⟩, rfl⟩ := (localization.of _).mk'_surjective t,
-  simp only [to_basic_open_mk'] at h_eq,
-  rw localization_map.eq,
-  -- We know that the fractions `a/b` and `c/d` are equal as sections of the structure sheaf on
-  -- `basic_open f`. We need to show that they agree as elements in the localization of `R` at `f`.
-  -- This amounts showing that `a * d * r = c * b * r`, for some power `r = f ^ n` of `f`.
-  -- We define `I` as the ideal of *all* elements `r` satisfying the above equation.
-  let I : ideal R :=
-  { carrier := {r : R | a * d * r = c * b * r},
-    zero_mem' := by simp only [set.mem_set_of_eq, mul_zero],
-    add_mem' := λ r₁ r₂ hr₁ hr₂, by { dsimp at hr₁ hr₂ ⊢, simp only [mul_add, hr₁, hr₂] },
-    smul_mem' := λ r₁ r₂ hr₂, by { dsimp at hr₂ ⊢, simp only [mul_comm r₁ r₂, ← mul_assoc, hr₂] }},
-  -- Our claim now reduces to showing that `f` is contained in the radical of `I`
-  suffices : f ∈ I.radical,
-  { obtain ⟨n, hn⟩ := this,
-    use [f ^ n, n, hn] },
-  rw [← vanishing_ideal_zero_locus_eq_radical, mem_vanishing_ideal],
-  intros p hfp,
-  contrapose hfp,
-  rw [mem_zero_locus, set.not_subset],
-  have := congr_fun (congr_arg subtype.val h_eq) ⟨p,hfp⟩,
-  rw [const_apply, const_apply, localization_map.eq] at this,
-  obtain ⟨r, hr⟩ := this,
-  exact ⟨r.1, hr, r.2⟩
-end
-
-lemma to_basic_open_surjective (f : R) : function.surjective (to_basic_open R f) :=
-begin
-  sorry
-end
-
 lemma is_unit_to_stalk (x : Spec.Top R) (f : x.as_ideal.prime_compl) :
   is_unit (to_stalk R x (f : R)) :=
 by { erw ← germ_to_open R (basic_open (f : R)) ⟨x, f.2⟩ (f : R),

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -509,28 +509,34 @@ ring_hom.ext $ λ g, (localization.of _).lift_eq _ _
   const R f 1 (basic_open s) (λ _ _, submonoid.one_mem _) :=
 ((localization.of _).lift_eq _ _).trans $ to_open_eq_const _ _ _
 
+-- The proof here follows the argument in Hartshorne's Algebraic Geometry, Proposition II.2.2.
 lemma to_basic_open_injective (f : R) : function.injective (to_basic_open R f) :=
 begin
   intros s t h_eq,
   obtain ⟨a, ⟨b, hb⟩, rfl⟩ := (localization.of _).mk'_surjective s,
   obtain ⟨c, ⟨d, hd⟩, rfl⟩ := (localization.of _).mk'_surjective t,
   simp only [to_basic_open_mk'] at h_eq,
+  rw localization_map.eq,
+  -- We know that the fractions `a/b` and `c/d` are equal as sections of the structure sheaf on
+  -- `basic_open f`. We need to show that they agree as elements in the localization of `R` at `f`.
+  -- This amounts showing that `a * d * r = c * b * r`, for some power `r = f ^ n` of `f`.
+  -- We define `I` as the ideal of *all* elements `r` satisfying the above equation.
   let I : ideal R :=
   { carrier := {r : R | a * d * r = c * b * r},
-    zero_mem' := sorry,
-    add_mem' := sorry,
-    smul_mem' := sorry},
+    zero_mem' := by simp only [set.mem_set_of_eq, mul_zero],
+    add_mem' := λ r₁ r₂ hr₁ hr₂, by { dsimp at hr₁ hr₂ ⊢, simp only [mul_add, hr₁, hr₂] },
+    smul_mem' := λ r₁ r₂ hr₂, by { dsimp at hr₂ ⊢, simp only [mul_comm r₁ r₂, ← mul_assoc, hr₂] }},
+  -- Our claim now reduces to showing that `f` is contained in the radical of `I`
   suffices : f ∈ I.radical,
   { obtain ⟨n, hn⟩ := this,
-    rw localization_map.eq,
     use [f ^ n, n, hn] },
   rw [← vanishing_ideal_zero_locus_eq_radical, mem_vanishing_ideal],
   intros p hfp,
   contrapose hfp,
+  rw [mem_zero_locus, set.not_subset],
   have := congr_fun (congr_arg subtype.val h_eq) ⟨p,hfp⟩,
   rw [const_apply, const_apply, localization_map.eq] at this,
   obtain ⟨r, hr⟩ := this,
-  rw [mem_zero_locus, set.not_subset],
   exact ⟨r.1, hr, r.2⟩
 end
 
@@ -538,7 +544,6 @@ lemma to_basic_open_surjective (f : R) : function.surjective (to_basic_open R f)
 begin
   sorry
 end
-
 
 lemma is_unit_to_stalk (x : Spec.Top R) (f : x.as_ideal.prime_compl) :
   is_unit (to_stalk R x (f : R)) :=

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -52,7 +52,7 @@ variables (b)
 lemma mul_mem_right (h : a ∈ I) : a * b ∈ I := mul_comm b a ▸ I.mul_mem_left b h
 variables {b}
 
-lemma pow_mem_of_mem (ha : a ∈ I) (n : ℕ) (hn : n > 0) : a ^ n ∈ I :=
+lemma pow_mem_of_mem (ha : a ∈ I) (n : ℕ) (hn : 0 < n) : a ^ n ∈ I :=
 nat.cases_on n (not.elim dec_trivial) (λ m hm, (pow_succ a m).symm ▸ I.mul_mem_right (a^m) ha) hn
 
 end ideal
@@ -192,7 +192,7 @@ begin
 end
 
 theorem is_prime.pow_mem_iff_mem {I : ideal α} (hI : I.is_prime)
-  {r : α} (n : ℕ) (hn : n > 0) : r ^ n ∈ I ↔ r ∈ I :=
+  {r : α} (n : ℕ) (hn : 0 < n) : r ^ n ∈ I ↔ r ∈ I :=
 ⟨hI.mem_of_pow_mem n, (λ hr, I.pow_mem_of_mem hr n hn)⟩
 
 lemma not_is_prime_iff {I : ideal α} : ¬ I.is_prime ↔ I = ⊤ ∨ ∃ (x ∉ I) (y ∉ I), x * y ∈ I :=

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -171,6 +171,10 @@ theorem is_prime.ne_top {I : ideal α} (hI : I.is_prime) : I ≠ ⊤ := hI.1
 theorem is_prime.mem_or_mem {I : ideal α} (hI : I.is_prime) :
   ∀ {x y : α}, x * y ∈ I → x ∈ I ∨ y ∈ I := hI.2
 
+theorem is_prime.mem_or_mem_iff {I : ideal α} (hI : I.is_prime) :
+  ∀ {x y : α}, x * y ∈ I ↔ x ∈ I ∨ y ∈ I :=
+λ x y, ⟨hI.mem_or_mem, by { rintro (h | h), exacts [I.mul_mem_right y h, I.mul_mem_left x h] }⟩
+
 theorem is_prime.mem_or_mem_of_mul_eq_zero {I : ideal α} (hI : I.is_prime)
   {x y : α} (h : x * y = 0) : x ∈ I ∨ y ∈ I :=
 hI.mem_or_mem (h.symm ▸ I.zero_mem)

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -175,7 +175,7 @@ theorem is_prime.ne_top {I : ideal α} (hI : I.is_prime) : I ≠ ⊤ := hI.1
 theorem is_prime.mem_or_mem {I : ideal α} (hI : I.is_prime) :
   ∀ {x y : α}, x * y ∈ I → x ∈ I ∨ y ∈ I := hI.2
 
-theorem is_prime.mem_or_mem_iff {I : ideal α} (hI : I.is_prime) :
+theorem is_prime.mul_mem_iff_mem_or_mem {I : ideal α} (hI : I.is_prime) :
   ∀ {x y : α}, x * y ∈ I ↔ x ∈ I ∨ y ∈ I :=
 λ x y, ⟨hI.mem_or_mem, by { rintro (h | h), exacts [I.mul_mem_right y h, I.mul_mem_left x h] }⟩
 

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -51,6 +51,10 @@ variables {a}
 variables (b)
 lemma mul_mem_right (h : a ∈ I) : a * b ∈ I := mul_comm b a ▸ I.mul_mem_left b h
 variables {b}
+
+lemma pow_mem_of_mem (ha : a ∈ I) (n : ℕ) (hn : n > 0) : a ^ n ∈ I :=
+nat.cases_on n (not.elim dec_trivial) (λ m hm, (pow_succ a m).symm ▸ I.mul_mem_right (a^m) ha) hn
+
 end ideal
 
 variables {a b : α}
@@ -186,6 +190,10 @@ begin
   { rw pow_zero at H, exact (mt (eq_top_iff_one _).2 hI.1).elim H },
   { rw pow_succ at H, exact or.cases_on (hI.mem_or_mem H) id ih }
 end
+
+theorem is_prime.pow_mem_iff_mem {I : ideal α} (hI : I.is_prime)
+  {r : α} (n : ℕ) (hn : n > 0) : r ^ n ∈ I ↔ r ∈ I :=
+⟨hI.mem_of_pow_mem n, (λ hr, I.pow_mem_of_mem hr n hn)⟩
 
 lemma not_is_prime_iff {I : ideal α} : ¬ I.is_prime ↔ I = ⊤ ∨ ∃ (x ∉ I) (y ∉ I), x * y ∈ I :=
 begin


### PR DESCRIPTION
Adding and refactoring some lemmas about zero loci and basic opens. Also adds three lemmas in `ideal/basic.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

For context: I am currently working on expanding `structure_sheaf.lean` with the eventual goal of making `Spec` into a functor. These Lemmas have turned out useful, so I thought I'd add them in a separate PR.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
