### PR TITLE
[Merged by Bors] - feat(data/finset/lattice): mem_sup, mem_sup'

### DIFF
--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -146,9 +146,9 @@ end
 -- the hypotheses should be reformulated as `s : subsemilattice_inf_bot`
 lemma sup_mem
   (s : set α) (w₁ : ⊥ ∈ s) (w₂ : ∀ x y ∈ s, x ⊔ y ∈ s)
-  {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i, p i ∈ s) :
+  {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i ∈ t, p i ∈ s) :
   t.sup p ∈ s :=
-@sup_induction _ _ _ _ _ s w₁ w₂ (λ i _, h i)
+@sup_induction _ _ _ _ _ s w₁ w₂ h
 
 end sup
 
@@ -239,9 +239,9 @@ lemma inf_induction {p : α → Prop} (ht : p ⊤) (hp : ∀ (a₁ a₂ : α), p
 
 lemma inf_mem
   (s : set α) (w₁ : ⊤ ∈ s) (w₂ : ∀ x y ∈ s, x ⊓ y ∈ s)
-  {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i, p i ∈ s) :
+  {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i ∈ t, p i ∈ s) :
   t.inf p ∈ s :=
-@inf_induction _ _ _ _ _ s w₁ w₂ (λ i _, h i)
+@inf_induction _ _ _ _ _ s w₁ w₂ h
 
 end inf
 
@@ -334,9 +334,9 @@ end
 
 lemma sup'_mem
   (s : set α) (w : ∀ x y ∈ s, x ⊔ y ∈ s)
-  {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i, p i ∈ s) :
+  {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i ∈ t , p i ∈ s) :
   t.sup' H p ∈ s :=
-sup'_induction H p w (λ i _, h i)
+sup'_induction H p w h
 
 end sup'
 
@@ -395,9 +395,9 @@ lemma exists_mem_eq_inf' [is_total α (≤)] : ∃ b, b ∈ s ∧ s.inf' H f = f
 @exists_mem_eq_sup' (order_dual α) _ _ _ H f _
 
 lemma inf'_mem (s : set α) (w : ∀ x y ∈ s, x ⊓ y ∈ s)
-  {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i, p i ∈ s) :
+  {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i ∈ t, p i ∈ s) :
   t.inf' H p ∈ s :=
-inf'_induction H p w (λ i _, h i)
+inf'_induction H p w h
 
 end inf'
 

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -148,14 +148,7 @@ lemma sup_mem
   (s : set α) (w₁ : ⊥ ∈ s) (w₂ : ∀ x y ∈ s, x ⊔ y ∈ s)
   {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i, p i ∈ s) :
   t.sup p ∈ s :=
-begin
-  classical,
-  apply finset.cons_induction_on t,
-  { exact w₁, },
-  { intros a s' nm ih,
-    rw finset.sup_cons,
-    apply w₂ _ _ (h a) ih, },
-end
+@sup_induction _ _ _ _ _ s w₁ w₂ (λ i _, h i)
 
 end sup
 
@@ -248,7 +241,7 @@ lemma inf_mem
   (s : set α) (w₁ : ⊤ ∈ s) (w₂ : ∀ x y ∈ s, x ⊓ y ∈ s)
   {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i, p i ∈ s) :
   t.inf p ∈ s :=
-@sup_mem (order_dual α) _ s w₁ w₂ _ t p h
+@inf_induction _ _ _ _ _ s w₁ w₂ (λ i _, h i)
 
 end inf
 
@@ -343,19 +336,7 @@ lemma sup'_mem
   (s : set α) (w : ∀ x y ∈ s, x ⊔ y ∈ s)
   {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i, p i ∈ s) :
   t.sup' H p ∈ s :=
-begin
-  classical,
-  revert H,
-  apply finset.cons_induction_on t,
-  { rintro ⟨-, ⟨⟩⟩, },
-  { intros a s' nm ih H,
-    by_cases H' : s'.nonempty,
-    { rw finset.sup'_cons H',
-      apply w _ _ (h a) (ih H'), },
-    { have p : s' = ∅ := finset.not_nonempty_iff_eq_empty.mp H',
-      subst p,
-      simp [h a], }, },
-end
+sup'_induction H p w (λ i _, h i)
 
 end sup'
 
@@ -417,7 +398,7 @@ lemma inf'_mem {α : Type*} [semilattice_inf α]
   (s : set α) (w : ∀ x y ∈ s, x ⊓ y ∈ s)
   {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i, p i ∈ s) :
   t.inf' H p ∈ s :=
-@sup'_mem (order_dual α) _ s w _ t H p h
+inf'_induction H p w (λ i _, h i)
 
 end inf'
 

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -142,6 +142,21 @@ begin
     exact ⟨le_trans hay hyz, le_trans hsx_sup hxz⟩, },
 end
 
+-- If we acquire sublattices
+-- the hypotheses should be reformulated as `s : subsemilattice_inf_bot`
+lemma finset.sup_mem {α : Type*} [semilattice_sup_bot α]
+  (s : set α) (w₁ : ⊥ ∈ s) (w₂ : ∀ x y ∈ s, x ⊔ y ∈ s)
+  {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i, p i ∈ s) :
+  t.sup p ∈ s :=
+begin
+  classical,
+  apply finset.cons_induction_on t,
+  { exact w₁, },
+  { intros a s' nm ih,
+    rw finset.sup_cons,
+    apply w₂ _ _ (h a) ih, },
+end
+
 end sup
 
 lemma sup_eq_supr [complete_lattice β] (s : finset α) (f : α → β) : s.sup f = (⨆a∈s, f a) :=
@@ -228,6 +243,12 @@ lemma inf_coe {P : α → Prop}
 lemma inf_induction {p : α → Prop} (ht : p ⊤) (hp : ∀ (a₁ a₂ : α), p a₁ → p a₂ → p (a₁ ⊓ a₂))
   (hs : ∀ b ∈ s, p (f b)) : p (s.inf f) :=
 @sup_induction (order_dual α) _ _ _ _ _ ht hp hs
+
+lemma finset.inf_mem {α : Type*} [semilattice_inf_top α]
+  (s : set α) (w₁ : ⊤ ∈ s) (w₂ : ∀ x y ∈ s, x ⊓ y ∈ s)
+  {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i, p i ∈ s) :
+  t.inf p ∈ s :=
+@finset.sup_mem (order_dual α) _ s w₁ w₂ _ t p h
 
 end inf
 
@@ -318,6 +339,24 @@ begin
       { exact ⟨b, mem_cons.2 (or.inr hb), sup_eq_right.2 h⟩, }, }, },
 end
 
+lemma finset.sup'_mem {α : Type*} [semilattice_sup α]
+  (s : set α) (w : ∀ x y ∈ s, x ⊔ y ∈ s)
+  {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i, p i ∈ s) :
+  t.sup' H p ∈ s :=
+begin
+  classical,
+  revert H,
+  apply finset.cons_induction_on t,
+  { rintro ⟨-, ⟨⟩⟩, },
+  { intros a s' nm ih H,
+    by_cases H' : s'.nonempty,
+    { rw finset.sup'_cons H',
+      apply w _ _ (h a) (ih H'), },
+    { have p : s' = ∅ := finset.not_nonempty_iff_eq_empty.mp H',
+      subst p,
+      simp [h a], }, },
+end
+
 end sup'
 
 section inf'
@@ -373,6 +412,12 @@ lemma inf'_induction {p : α → Prop} (hp : ∀ (a₁ a₂ : α), p a₁ → p 
 
 lemma exists_mem_eq_inf' [is_total α (≤)] : ∃ b, b ∈ s ∧ s.inf' H f = f b :=
 @exists_mem_eq_sup' (order_dual α) _ _ _ H f _
+
+lemma finset.inf'_mem {α : Type*} [semilattice_inf α]
+  (s : set α) (w : ∀ x y ∈ s, x ⊓ y ∈ s)
+  {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i, p i ∈ s) :
+  t.inf' H p ∈ s :=
+@finset.sup'_mem (order_dual α) _ s w _ t H p h
 
 end inf'
 

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -394,8 +394,7 @@ lemma inf'_induction {p : α → Prop} (hp : ∀ (a₁ a₂ : α), p a₁ → p 
 lemma exists_mem_eq_inf' [is_total α (≤)] : ∃ b, b ∈ s ∧ s.inf' H f = f b :=
 @exists_mem_eq_sup' (order_dual α) _ _ _ H f _
 
-lemma inf'_mem {α : Type*} [semilattice_inf α]
-  (s : set α) (w : ∀ x y ∈ s, x ⊓ y ∈ s)
+lemma inf'_mem (s : set α) (w : ∀ x y ∈ s, x ⊓ y ∈ s)
   {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i, p i ∈ s) :
   t.inf' H p ∈ s :=
 inf'_induction H p w (λ i _, h i)

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -144,7 +144,7 @@ end
 
 -- If we acquire sublattices
 -- the hypotheses should be reformulated as `s : subsemilattice_inf_bot`
-lemma finset.sup_mem {α : Type*} [semilattice_sup_bot α]
+lemma sup_mem
   (s : set α) (w₁ : ⊥ ∈ s) (w₂ : ∀ x y ∈ s, x ⊔ y ∈ s)
   {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i, p i ∈ s) :
   t.sup p ∈ s :=
@@ -244,11 +244,11 @@ lemma inf_induction {p : α → Prop} (ht : p ⊤) (hp : ∀ (a₁ a₂ : α), p
   (hs : ∀ b ∈ s, p (f b)) : p (s.inf f) :=
 @sup_induction (order_dual α) _ _ _ _ _ ht hp hs
 
-lemma finset.inf_mem {α : Type*} [semilattice_inf_top α]
+lemma inf_mem
   (s : set α) (w₁ : ⊤ ∈ s) (w₂ : ∀ x y ∈ s, x ⊓ y ∈ s)
   {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i, p i ∈ s) :
   t.inf p ∈ s :=
-@finset.sup_mem (order_dual α) _ s w₁ w₂ _ t p h
+@sup_mem (order_dual α) _ s w₁ w₂ _ t p h
 
 end inf
 
@@ -339,7 +339,7 @@ begin
       { exact ⟨b, mem_cons.2 (or.inr hb), sup_eq_right.2 h⟩, }, }, },
 end
 
-lemma finset.sup'_mem {α : Type*} [semilattice_sup α]
+lemma sup'_mem
   (s : set α) (w : ∀ x y ∈ s, x ⊔ y ∈ s)
   {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i, p i ∈ s) :
   t.sup' H p ∈ s :=
@@ -413,11 +413,11 @@ lemma inf'_induction {p : α → Prop} (hp : ∀ (a₁ a₂ : α), p a₁ → p 
 lemma exists_mem_eq_inf' [is_total α (≤)] : ∃ b, b ∈ s ∧ s.inf' H f = f b :=
 @exists_mem_eq_sup' (order_dual α) _ _ _ H f _
 
-lemma finset.inf'_mem {α : Type*} [semilattice_inf α]
+lemma inf'_mem {α : Type*} [semilattice_inf α]
   (s : set α) (w : ∀ x y ∈ s, x ⊓ y ∈ s)
   {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i, p i ∈ s) :
   t.inf' H p ∈ s :=
-@finset.sup'_mem (order_dual α) _ s w _ t H p h
+@sup'_mem (order_dual α) _ s w _ t H p h
 
 end inf'
 

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -143,7 +143,7 @@ begin
 end
 
 -- If we acquire sublattices
--- the hypotheses should be reformulated as `s : subsemilattice_inf_bot`
+-- the hypotheses should be reformulated as `s : subsemilattice_sup_bot`
 lemma sup_mem
   (s : set α) (w₁ : ⊥ ∈ s) (w₂ : ∀ x y ∈ s, x ⊔ y ∈ s)
   {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i ∈ t, p i ∈ s) :
@@ -334,7 +334,7 @@ end
 
 lemma sup'_mem
   (s : set α) (w : ∀ x y ∈ s, x ⊔ y ∈ s)
-  {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i ∈ t , p i ∈ s) :
+  {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i ∈ t, p i ∈ s) :
   t.sup' H p ∈ s :=
 sup'_induction H p w h
 

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -148,7 +148,7 @@ lemma sup_mem
   (s : set α) (w₁ : ⊥ ∈ s) (w₂ : ∀ x y ∈ s, x ⊔ y ∈ s)
   {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i ∈ t, p i ∈ s) :
   t.sup p ∈ s :=
-@sup_induction _ _ _ _ _ s w₁ w₂ h
+@sup_induction _ _ _ _ _ (∈ s) w₁ w₂ h
 
 end sup
 
@@ -241,7 +241,7 @@ lemma inf_mem
   (s : set α) (w₁ : ⊤ ∈ s) (w₂ : ∀ x y ∈ s, x ⊓ y ∈ s)
   {ι : Type*} (t : finset ι) (p : ι → α) (h : ∀ i ∈ t, p i ∈ s) :
   t.inf p ∈ s :=
-@inf_induction _ _ _ _ _ s w₁ w₂ h
+@inf_induction _ _ _ _ _ (∈ s) w₁ w₂ h
 
 end inf
 


### PR DESCRIPTION
Sets with `bot` and closed under `sup` are closed under `finset.sup`, and variations for `inf`, `sup'`, and `inf'`.

---

Prerequisites PR for Stone-Weierstrass.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
