### PR TITLE
[Merged by Bors] - chore(*): speed up slow proofs

### DIFF
--- a/src/algebra/category/Algebra/limits.lean
+++ b/src/algebra/category/Algebra/limits.lean
@@ -129,7 +129,7 @@ An auxiliary declaration to speed up typechecking.
 -/
 def forget₂_Module_preserves_limits_aux (F : J ⥤ Algebra R) :
   is_limit ((forget₂ (Algebra R) (Module R)).map_cone (limit_cone F)) :=
-by convert Module.has_limits.limit_cone_is_limit (F ⋙ forget₂ (Algebra R) (Module R))
+by apply Module.has_limits.limit_cone_is_limit (F ⋙ forget₂ (Algebra R) (Module R))
 
 /--
 The forgetful functor from R-algebras to R-modules preserves all limits.

--- a/src/algebra/category/CommRing/limits.lean
+++ b/src/algebra/category/CommRing/limits.lean
@@ -13,6 +13,11 @@ import ring_theory.subring
 
 Further, these limits are preserved by the forgetful functor --- that is,
 the underlying types are just the limits in the category of types.
+
+## Implementation note
+
+Lean suffers in some unification steps, and has to do a lot of unfolding to check that types match.
+We use a hack that prefixing such proofs with `by convert` can give a huge speedup.
 -/
 
 open category_theory
@@ -95,7 +100,7 @@ An auxiliary declaration to speed up typechecking.
 -/
 def forget₂_AddCommMon_preserves_limits_aux (F : J ⥤ SemiRing) :
   is_limit ((forget₂ SemiRing AddCommMon).map_cone (limit_cone F)) :=
-AddCommMon.limit_cone_is_limit (F ⋙ forget₂ SemiRing AddCommMon)
+by convert AddCommMon.limit_cone_is_limit (F ⋙ forget₂ SemiRing AddCommMon)
 
 /--
 The forgetful functor from semirings to additive commutative monoids preserves all limits.
@@ -144,20 +149,6 @@ instance limit_comm_semiring (F : J ⥤ CommSemiRing) :
 @subsemiring.to_comm_semiring (Π j, F.obj j) _
   (SemiRing.sections_subsemiring (F ⋙ forget₂ CommSemiRing SemiRing.{u}))
 
-/-- Auxiliary construction for the `creates_limit` instance below. -/
-def lifted_cone (F : J ⥤ CommSemiRing) : cone F :=
-{ X := CommSemiRing.of (types.limit_cone (F ⋙ forget _)).X,
-  π :=
-  { app := SemiRing.limit_π_ring_hom (F ⋙ forget₂ CommSemiRing SemiRing),
-    naturality' := (SemiRing.has_limits.limit_cone (F ⋙ forget₂ _ _)).π.naturality, } }
-
-/-- Auxiliary construction for the `creates_limit` instance below. -/
-def is_limit_lifted_cone (F : J ⥤ CommSemiRing) : is_limit (lifted_cone F) :=
-is_limit.of_faithful (forget₂ CommSemiRing SemiRing.{u})
-  (SemiRing.has_limits.limit_cone_is_limit _)
-  (λ s, (SemiRing.has_limits.limit_cone_is_limit _).lift ((forget₂ _ SemiRing).map_cone s))
-  (λ s, rfl)
-
 /--
 We show that the forgetful functor `CommSemiRing ⥤ SemiRing` creates limits.
 
@@ -166,9 +157,16 @@ and then reuse the existing limit.
 -/
 instance (F : J ⥤ CommSemiRing) : creates_limit F (forget₂ CommSemiRing SemiRing.{u}) :=
 creates_limit_of_reflects_iso (λ c' t,
-{ lifted_cone := lifted_cone F,
-  valid_lift := is_limit.unique_up_to_iso (SemiRing.has_limits.limit_cone_is_limit _) t,
-  makes_limit := is_limit_lifted_cone F, })
+{ lifted_cone :=
+  { X := CommSemiRing.of (types.limit_cone (F ⋙ forget _)).X,
+    π :=
+    { app := by convert SemiRing.limit_π_ring_hom (F ⋙ forget₂ CommSemiRing SemiRing),
+      naturality' := (SemiRing.has_limits.limit_cone (F ⋙ forget₂ _ _)).π.naturality, } },
+  valid_lift := by convert is_limit.unique_up_to_iso (SemiRing.has_limits.limit_cone_is_limit _) t,
+  makes_limit := is_limit.of_faithful (forget₂ CommSemiRing SemiRing.{u})
+    (by convert SemiRing.has_limits.limit_cone_is_limit _)
+    (λ s, (SemiRing.has_limits.limit_cone_is_limit _).lift ((forget₂ _ SemiRing).map_cone s))
+    (λ s, rfl) })
 
 /--
 A choice of limit cone for a functor into `CommSemiRing`.
@@ -242,11 +240,11 @@ creates_limit_of_reflects_iso (λ c' t,
 { lifted_cone :=
   { X := Ring.of (types.limit_cone (F ⋙ forget _)).X,
     π :=
-    { app := SemiRing.limit_π_ring_hom (F ⋙ forget₂ Ring SemiRing),
+    { app := by convert SemiRing.limit_π_ring_hom (F ⋙ forget₂ Ring SemiRing),
       naturality' := (SemiRing.has_limits.limit_cone (F ⋙ forget₂ _ _)).π.naturality, } },
-  valid_lift := is_limit.unique_up_to_iso (SemiRing.has_limits.limit_cone_is_limit _) t,
+  valid_lift := by convert is_limit.unique_up_to_iso (SemiRing.has_limits.limit_cone_is_limit _) t,
   makes_limit := is_limit.of_faithful (forget₂ Ring SemiRing.{u})
-    (SemiRing.has_limits.limit_cone_is_limit _)
+    (by convert SemiRing.has_limits.limit_cone_is_limit _)
     (λ s, _) (λ s, rfl) })
 
 /--
@@ -316,20 +314,6 @@ instance limit_comm_ring (F : J ⥤ CommRing) :
 @subring.to_comm_ring (Π j, F.obj j) _
   (Ring.sections_subring (F ⋙ forget₂ CommRing Ring.{u}))
 
-/-- Auxiliary construction for the `creates_limit` instance below. -/
-def lifted_cone (F : J ⥤ CommRing) : cone F :=
-{ X := CommRing.of (types.limit_cone (F ⋙ forget _)).X,
-  π :=
-  { app := SemiRing.limit_π_ring_hom (F ⋙ forget₂ CommRing Ring.{u} ⋙ forget₂ Ring SemiRing),
-    naturality' := (SemiRing.has_limits.limit_cone
-      (F ⋙ forget₂ _ Ring.{u} ⋙ forget₂ _ SemiRing)).π.naturality } }
-
-/-- Auxiliary construction for the `creates_limit` instance below. -/
-def is_limit_lifted_cone (F : J ⥤ CommRing) : is_limit (lifted_cone F) :=
-is_limit.of_faithful (forget₂ _ Ring.{u}) (Ring.limit_cone_is_limit _)
-  (λ s, (Ring.limit_cone_is_limit _).lift ((forget₂ _ Ring.{u}).map_cone s))
-  (λ s, rfl)
-
 /--
 We show that the forgetful functor `CommRing ⥤ Ring` creates limits.
 
@@ -345,9 +329,17 @@ creates_limit_of_fully_faithful_of_iso (CommRing.of (limit (F ⋙ forget _))) (i
 but it seems this would introduce additional identity morphisms in `limit.π`.
 -/
 creates_limit_of_reflects_iso (λ c' t,
-{ lifted_cone := lifted_cone F,
-  valid_lift := is_limit.unique_up_to_iso (Ring.limit_cone_is_limit _) t,
-  makes_limit := is_limit_lifted_cone F, })
+{ lifted_cone :=
+  { X := CommRing.of (types.limit_cone (F ⋙ forget _)).X,
+    π :=
+    { app := by convert
+        SemiRing.limit_π_ring_hom (F ⋙ forget₂ CommRing Ring.{u} ⋙ forget₂ Ring SemiRing),
+      naturality' := (SemiRing.has_limits.limit_cone
+        (F ⋙ forget₂ _ Ring.{u} ⋙ forget₂ _ SemiRing)).π.naturality } },
+  valid_lift := by convert is_limit.unique_up_to_iso (Ring.limit_cone_is_limit _) t,
+  makes_limit := is_limit.of_faithful (forget₂ _ Ring.{u})
+    (by convert Ring.limit_cone_is_limit (F ⋙ forget₂ CommRing Ring))
+    (λ s, (Ring.limit_cone_is_limit _).lift ((forget₂ _ Ring.{u}).map_cone s)) (λ s, rfl) })
 
 /--
 A choice of limit cone for a functor into `CommRing`.
@@ -382,7 +374,7 @@ An auxiliary declaration to speed up typechecking.
 -/
 def forget₂_CommSemiRing_preserves_limits_aux (F : J ⥤ CommRing) :
   is_limit ((forget₂ CommRing CommSemiRing).map_cone (limit_cone F)) :=
-CommSemiRing.limit_cone_is_limit (F ⋙ forget₂ CommRing CommSemiRing)
+by convert CommSemiRing.limit_cone_is_limit (F ⋙ forget₂ CommRing CommSemiRing)
 
 /--
 The forgetful functor from commutative rings to commutative semirings preserves all limits.

--- a/src/algebra/category/CommRing/limits.lean
+++ b/src/algebra/category/CommRing/limits.lean
@@ -13,12 +13,16 @@ import ring_theory.subring
 
 Further, these limits are preserved by the forgetful functor --- that is,
 the underlying types are just the limits in the category of types.
-
-## Implementation note
-
-Lean suffers in some unification steps, and has to do a lot of unfolding to check that types match.
-We use a hack that prefixing such proofs with `by convert` can give a huge speedup.
 -/
+
+/- We use the following trick a lot of times in this file.-/
+/--
+Some definitions may be extremely slow to elaborate, when the target type to be constructed
+is complicated and when the type of the term given in the definition is also complicated and does
+not obviously match the target type. In this case, instead of just giving the term, prefixing it
+with `by apply` may speed up things considerably as the types are not elaborated in the same order.
+-/
+library_note "change elaboration strategy with `by apply`"
 
 open category_theory
 open category_theory.limits
@@ -100,7 +104,7 @@ An auxiliary declaration to speed up typechecking.
 -/
 def forget₂_AddCommMon_preserves_limits_aux (F : J ⥤ SemiRing) :
   is_limit ((forget₂ SemiRing AddCommMon).map_cone (limit_cone F)) :=
-by convert AddCommMon.limit_cone_is_limit (F ⋙ forget₂ SemiRing AddCommMon)
+by apply AddCommMon.limit_cone_is_limit (F ⋙ forget₂ SemiRing AddCommMon)
 
 /--
 The forgetful functor from semirings to additive commutative monoids preserves all limits.
@@ -115,7 +119,7 @@ An auxiliary declaration to speed up typechecking.
 -/
 def forget₂_Mon_preserves_limits_aux (F : J ⥤ SemiRing) :
   is_limit ((forget₂ SemiRing Mon).map_cone (limit_cone F)) :=
-Mon.has_limits.limit_cone_is_limit (F ⋙ forget₂ SemiRing Mon)
+by apply Mon.has_limits.limit_cone_is_limit (F ⋙ forget₂ SemiRing Mon)
 
 /--
 The forgetful functor from semirings to monoids preserves all limits.
@@ -160,11 +164,11 @@ creates_limit_of_reflects_iso (λ c' t,
 { lifted_cone :=
   { X := CommSemiRing.of (types.limit_cone (F ⋙ forget _)).X,
     π :=
-    { app := by convert SemiRing.limit_π_ring_hom (F ⋙ forget₂ CommSemiRing SemiRing),
+    { app := by apply SemiRing.limit_π_ring_hom (F ⋙ forget₂ CommSemiRing SemiRing),
       naturality' := (SemiRing.has_limits.limit_cone (F ⋙ forget₂ _ _)).π.naturality, } },
-  valid_lift := by convert is_limit.unique_up_to_iso (SemiRing.has_limits.limit_cone_is_limit _) t,
+  valid_lift := by apply is_limit.unique_up_to_iso (SemiRing.has_limits.limit_cone_is_limit _) t,
   makes_limit := is_limit.of_faithful (forget₂ CommSemiRing SemiRing.{u})
-    (by convert SemiRing.has_limits.limit_cone_is_limit _)
+    (by apply SemiRing.has_limits.limit_cone_is_limit _)
     (λ s, (SemiRing.has_limits.limit_cone_is_limit _).lift ((forget₂ _ SemiRing).map_cone s))
     (λ s, rfl) })
 
@@ -240,11 +244,11 @@ creates_limit_of_reflects_iso (λ c' t,
 { lifted_cone :=
   { X := Ring.of (types.limit_cone (F ⋙ forget _)).X,
     π :=
-    { app := by convert SemiRing.limit_π_ring_hom (F ⋙ forget₂ Ring SemiRing),
+    { app := by apply SemiRing.limit_π_ring_hom (F ⋙ forget₂ Ring SemiRing),
       naturality' := (SemiRing.has_limits.limit_cone (F ⋙ forget₂ _ _)).π.naturality, } },
-  valid_lift := by convert is_limit.unique_up_to_iso (SemiRing.has_limits.limit_cone_is_limit _) t,
+  valid_lift := by apply is_limit.unique_up_to_iso (SemiRing.has_limits.limit_cone_is_limit _) t,
   makes_limit := is_limit.of_faithful (forget₂ Ring SemiRing.{u})
-    (by convert SemiRing.has_limits.limit_cone_is_limit _)
+    (by apply SemiRing.has_limits.limit_cone_is_limit _)
     (λ s, _) (λ s, rfl) })
 
 /--
@@ -279,7 +283,7 @@ An auxiliary declaration to speed up typechecking.
 -/
 def forget₂_AddCommGroup_preserves_limits_aux (F : J ⥤ Ring) :
   is_limit ((forget₂ Ring AddCommGroup).map_cone (limit_cone F)) :=
-AddCommGroup.limit_cone_is_limit (F ⋙ forget₂ Ring AddCommGroup)
+by apply AddCommGroup.limit_cone_is_limit (F ⋙ forget₂ Ring AddCommGroup)
 
 /--
 The forgetful functor from rings to additive commutative groups preserves all limits.
@@ -332,13 +336,13 @@ creates_limit_of_reflects_iso (λ c' t,
 { lifted_cone :=
   { X := CommRing.of (types.limit_cone (F ⋙ forget _)).X,
     π :=
-    { app := by convert
+    { app := by apply
         SemiRing.limit_π_ring_hom (F ⋙ forget₂ CommRing Ring.{u} ⋙ forget₂ Ring SemiRing),
       naturality' := (SemiRing.has_limits.limit_cone
         (F ⋙ forget₂ _ Ring.{u} ⋙ forget₂ _ SemiRing)).π.naturality } },
-  valid_lift := by convert is_limit.unique_up_to_iso (Ring.limit_cone_is_limit _) t,
+  valid_lift := by apply is_limit.unique_up_to_iso (Ring.limit_cone_is_limit _) t,
   makes_limit := is_limit.of_faithful (forget₂ _ Ring.{u})
-    (by convert Ring.limit_cone_is_limit (F ⋙ forget₂ CommRing Ring))
+    (by apply Ring.limit_cone_is_limit (F ⋙ forget₂ CommRing Ring))
     (λ s, (Ring.limit_cone_is_limit _).lift ((forget₂ _ Ring.{u}).map_cone s)) (λ s, rfl) })
 
 /--
@@ -374,7 +378,7 @@ An auxiliary declaration to speed up typechecking.
 -/
 def forget₂_CommSemiRing_preserves_limits_aux (F : J ⥤ CommRing) :
   is_limit ((forget₂ CommRing CommSemiRing).map_cone (limit_cone F)) :=
-by convert CommSemiRing.limit_cone_is_limit (F ⋙ forget₂ CommRing CommSemiRing)
+by apply CommSemiRing.limit_cone_is_limit (F ⋙ forget₂ CommRing CommSemiRing)
 
 /--
 The forgetful functor from commutative rings to commutative semirings preserves all limits.

--- a/src/algebra/category/Group/abelian.lean
+++ b/src/algebra/category/Group/abelian.lean
@@ -38,9 +38,11 @@ equivalence_reflects_normal_epi (forget₂ (Module.{u} ℤ) AddCommGroup.{u}).in
 end
 
 /-- The category of abelian groups is abelian. -/
-instance : abelian AddCommGroup :=
+instance : abelian AddCommGroup.{u} :=
 { has_finite_products := ⟨by apply_instance⟩,
   normal_mono := λ X Y, normal_mono,
-  normal_epi := λ X Y, normal_epi }
+  normal_epi := λ X Y, normal_epi,
+  add_comp' := by { intros, simp only [preadditive.add_comp] },
+  comp_add' := by { intros, simp only [preadditive.comp_add] } }
 
 end AddCommGroup

--- a/src/algebra/category/Group/limits.lean
+++ b/src/algebra/category/Group/limits.lean
@@ -148,9 +148,9 @@ creates_limit_of_reflects_iso (λ c' t,
     π :=
     { app := Mon.limit_π_monoid_hom (F ⋙ forget₂ CommGroup Group.{u} ⋙ forget₂ Group Mon),
       naturality' := (Mon.has_limits.limit_cone _).π.naturality, } },
-  valid_lift := is_limit.unique_up_to_iso (Group.limit_cone_is_limit _) t,
+  valid_lift := by convert is_limit.unique_up_to_iso (Group.limit_cone_is_limit _) t,
   makes_limit := is_limit.of_faithful (forget₂ _ Group.{u} ⋙ forget₂ _ Mon.{u})
-    (Mon.has_limits.limit_cone_is_limit _) (λ s, _) (λ s, rfl) })
+    (by convert Mon.has_limits.limit_cone_is_limit _) (λ s, _) (λ s, rfl) })
 
 /--
 A choice of limit cone for a functor into `CommGroup`.

--- a/src/algebra/category/Group/limits.lean
+++ b/src/algebra/category/Group/limits.lean
@@ -148,9 +148,9 @@ creates_limit_of_reflects_iso (λ c' t,
     π :=
     { app := Mon.limit_π_monoid_hom (F ⋙ forget₂ CommGroup Group.{u} ⋙ forget₂ Group Mon),
       naturality' := (Mon.has_limits.limit_cone _).π.naturality, } },
-  valid_lift := by convert is_limit.unique_up_to_iso (Group.limit_cone_is_limit _) t,
+  valid_lift := by apply is_limit.unique_up_to_iso (Group.limit_cone_is_limit _) t,
   makes_limit := is_limit.of_faithful (forget₂ _ Group.{u} ⋙ forget₂ _ Mon.{u})
-    (by convert Mon.has_limits.limit_cone_is_limit _) (λ s, _) (λ s, rfl) })
+    (by apply Mon.has_limits.limit_cone_is_limit _) (λ s, _) (λ s, rfl) })
 
 /--
 A choice of limit cone for a functor into `CommGroup`.

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -85,28 +85,37 @@ variable {D : sesq_form R M I}
 @[ext] lemma ext (H : ∀ (x y : M), S x y = D x y) : S = D :=
 by {cases S, cases D, congr, funext, exact H _ _}
 
-instance : add_comm_group (sesq_form R M I) :=
-{ add := λ S D, { sesq := λ x y, S x y + D x y,
-                  sesq_add_left := λ x y z, by {rw add_left, rw add_left, ac_refl},
+instance : has_add (sesq_form R M I) :=
+⟨λ S D, { sesq := λ x y, S x y + D x y,
+                  sesq_add_left := λ x y z, by {rw add_left, rw add_left, abel},
                   sesq_smul_left := λ a x y, by {rw [smul_left, smul_left, mul_add]},
-                  sesq_add_right := λ x y z, by {rw add_right, rw add_right, ac_refl},
-                  sesq_smul_right := λ a x y, by {rw [smul_right, smul_right, mul_add]} },
-  add_assoc := by {intros, ext,
-    unfold coe_fn has_coe_to_fun.coe sesq coe_fn has_coe_to_fun.coe sesq, rw add_assoc},
-  zero := { sesq := λ x y, 0,
+                  sesq_add_right := λ x y z, by {rw add_right, rw add_right, abel},
+                  sesq_smul_right := λ a x y, by {rw [smul_right, smul_right, mul_add]} }⟩
+
+instance : has_zero (sesq_form R M I) :=
+⟨{ sesq := λ x y, 0,
             sesq_add_left := λ x y z, (add_zero 0).symm,
             sesq_smul_left := λ a x y, (mul_zero a).symm,
             sesq_add_right := λ x y z, (zero_add 0).symm,
-            sesq_smul_right := λ a x y, (mul_zero (I a).unop).symm },
-  zero_add := by {intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw zero_add},
-  add_zero := by {intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw add_zero},
-  neg := λ S, { sesq := λ x y, - (S.1 x y),
+            sesq_smul_right := λ a x y, (mul_zero (I a).unop).symm }⟩
+
+instance : has_neg (sesq_form R M I) :=
+⟨λ S, { sesq := λ x y, - (S.1 x y),
                 sesq_add_left := λ x y z, by rw [sesq_add_left, neg_add],
                 sesq_smul_left := λ a x y, by rw [sesq_smul_left, mul_neg_eq_neg_mul_symm],
                 sesq_add_right := λ x y z, by rw [sesq_add_right, neg_add],
-                sesq_smul_right := λ a x y, by rw [sesq_smul_right, mul_neg_eq_neg_mul_symm] },
-  add_left_neg := by {intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw neg_add_self},
-  add_comm := by {intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw add_comm} }
+                sesq_smul_right := λ a x y, by rw [sesq_smul_right, mul_neg_eq_neg_mul_symm] }⟩
+
+instance : add_comm_group (sesq_form R M I) :=
+{ add := (+),
+  add_assoc := by { intros, ext,
+    unfold coe_fn has_coe_to_fun.coe sesq coe_fn has_coe_to_fun.coe sesq, rw add_assoc },
+  zero := 0,
+  zero_add := by { intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw zero_add },
+  add_zero := by { intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw add_zero },
+  neg := has_neg.neg,
+  add_left_neg := by { intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw neg_add_self },
+  add_comm := by { intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw add_comm } }
 
 instance : inhabited (sesq_form R M I) := ⟨0⟩
 

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -490,8 +490,8 @@ local attribute [instance, priority 10000] simple_func.has_scalar
 protected def semimodule : semimodule 𝕜 (α →₁ₛ[μ] E) :=
 { one_smul  := λf, simple_func.eq (by { simp only [coe_smul], exact one_smul _ _ }),
   mul_smul  := λx y f, simple_func.eq (by { simp only [coe_smul], exact mul_smul _ _ _ }),
-  smul_add  := λx f g, simple_func.eq (by { simp only [coe_smul, coe_add], exact smul_add _ _ _ }),
-  smul_zero := λx, simple_func.eq (by { simp only [coe_zero, coe_smul], exact smul_zero _ }),
+  smul_add  := λx f g, simple_func.eq (by { simp only [coe_smul], exact smul_add _ _ _ }),
+  smul_zero := λx, simple_func.eq (by { simp only [coe_smul], exact smul_zero _ }),
   add_smul  := λx y f, simple_func.eq (by { simp only [coe_smul], exact add_smul _ _ _ }),
   zero_smul := λf, simple_func.eq (by { simp only [coe_smul], exact zero_smul _ _ }) }
 

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -364,7 +364,8 @@ begin
     obtain ⟨p, pP, p0⟩ := exists_nonzero_mem_of_ne_bot Pb hP,
     refine jacobson_bot_of_integral_localization (quotient_map P C le_rfl) quotient_map_injective
       _ _ (localization.of (submonoid.powers (p.map (quotient.mk (P.comap C))).leading_coeff))
-      (localization.of _) (is_integral_localization_map_polynomial_quotient P _ pP _ _),
+      (localization.of _)
+      (by convert (is_integral_localization_map_polynomial_quotient P _ pP _ _)),
     rwa [ne.def, leading_coeff_eq_zero] }
 end
 
@@ -446,7 +447,8 @@ begin
   { rw le_antisymm bot_le (comap_bot_le_of_injective _ (map_injective_of_injective _
       quotient_map_injective M ϕ ϕ' (le_non_zero_divisors_of_domain hM'))),
     refine is_maximal_comap_of_is_integral_of_is_maximal' _ _ ⊥ this,
-    refine is_integral_localization_map_polynomial_quotient P _ (submodule.coe_mem m) ϕ ϕ', },
+    have := is_integral_localization_map_polynomial_quotient P _ (submodule.coe_mem m) ϕ (ϕ' : _),
+    exact this },
   rw (map_bot.symm : (⊥ : ideal (localization M')) = map ϕ'.to_map ⊥),
   refine map.is_maximal ϕ'.to_map (localization_map_bijective_of_field hM' _ ϕ') hP,
   rwa [← quotient.maximal_ideal_iff_is_field_quotient, ← bot_quotient_is_maximal_iff],

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -416,8 +416,6 @@ variables (P : ideal (polynomial R)) [hP : P.is_maximal]
 
 include P hP
 
-set_option profiler true
-
 lemma is_maximal_comap_C_of_is_maximal (hP' : ∀ (x : R), C x ∈ P → x = 0) :
   is_maximal (comap C P : ideal R) :=
 begin

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -365,7 +365,7 @@ begin
     refine jacobson_bot_of_integral_localization (quotient_map P C le_rfl) quotient_map_injective
       _ _ (localization.of (submonoid.powers (p.map (quotient.mk (P.comap C))).leading_coeff))
       (localization.of _)
-      (by convert (is_integral_localization_map_polynomial_quotient P _ pP _ _)),
+      (by apply (is_integral_localization_map_polynomial_quotient P _ pP _ _)),
     rwa [ne.def, leading_coeff_eq_zero] }
 end
 
@@ -416,6 +416,8 @@ variables (P : ideal (polynomial R)) [hP : P.is_maximal]
 
 include P hP
 
+set_option profiler true
+
 lemma is_maximal_comap_C_of_is_maximal (hP' : ∀ (x : R), C x ∈ P → x = 0) :
   is_maximal (comap C P : ideal R) :=
 begin
@@ -447,8 +449,7 @@ begin
   { rw le_antisymm bot_le (comap_bot_le_of_injective _ (map_injective_of_injective _
       quotient_map_injective M ϕ ϕ' (le_non_zero_divisors_of_domain hM'))),
     refine is_maximal_comap_of_is_integral_of_is_maximal' _ _ ⊥ this,
-    have := is_integral_localization_map_polynomial_quotient P _ (submodule.coe_mem m) ϕ (ϕ' : _),
-    exact this },
+    apply is_integral_localization_map_polynomial_quotient P _ (submodule.coe_mem m) ϕ (ϕ' : _) },
   rw (map_bot.symm : (⊥ : ideal (localization M')) = map ϕ'.to_map ⊥),
   refine map.is_maximal ϕ'.to_map (localization_map_bijective_of_field hM' _ ϕ') hP,
   rwa [← quotient.maximal_ideal_iff_is_field_quotient, ← bot_quotient_is_maximal_iff],


### PR DESCRIPTION
Proofs that are too slow for the forthcoming `gsmul` refactor. I learnt that `by convert ...` is extremely useful even to close a goal, when elaboration using the expected type is a bad idea.
