### PR TITLE
[Merged by Bors] - feat(set/lattice): nonempty_of_union_eq_top_of_nonempty

### DIFF
--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -80,6 +80,22 @@ notation `⋂` binders `, ` r:(scoped f, Inter f) := r
   -- TODO: more rewrite rules wrt forall / existentials and logical connectives
   -- TODO: also eliminate ∃i, ... ∧ i = t ∧ ...
 
+lemma exists_set_mem_of_union_eq_top {ι : Type*} (t : set ι) (s : ι → set β)
+  (w : (⋃ i ∈ t, s i) = ⊤) (x : β) :
+  ∃ (i ∈ t), x ∈ s i :=
+begin
+  have p : x ∈ ⊤ := set.mem_univ x,
+  simpa only [←w, set.mem_Union] using p,
+end
+
+lemma nonempty_of_union_eq_top_of_nonempty
+  {ι : Type*} (t : set ι) (s : ι → set α) (H : nonempty α) (w : (⋃ i ∈ t, s i) = ⊤) :
+  t.nonempty :=
+begin
+  obtain ⟨x, m, -⟩ := exists_set_mem_of_union_eq_top t s w H.some,
+  exact ⟨x, m⟩,
+end
+
 theorem set_of_exists (p : ι → β → Prop) : {x | ∃ i, p i x} = ⋃ i, {x | p i x} :=
 ext $ λ i, mem_Union.symm
 


### PR DESCRIPTION
I have no idea where these lemmas belong. This is the earliest possible point. But perhaps they are too specific, and only belong at the point of use? I'm not certain here.

---

Prerequisites PR for Stone-Weierstrass

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
