### PR TITLE
[Merged by Bors] - fix(equiv/ring): fix bad typeclasses on ring_equiv.trans_apply

### DIFF
--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -158,9 +158,7 @@ symm_bijective.injective $ ext $ λ x, rfl
 @[trans] protected def trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') : R ≃+* S' :=
 { .. (e₁.to_mul_equiv.trans e₂.to_mul_equiv), .. (e₁.to_add_equiv.trans e₂.to_add_equiv) }
 
-@[simp] lemma trans_apply {A B C : Type*}
-  [has_mul A] [has_add A] [has_mul B] [has_add B] [has_mul C] [has_add C]
-  (e : A ≃+* B) (f : B ≃+* C) (a : A) :
+@[simp] lemma trans_apply (e₁ : R ≃+* S) (e₂ : S ≃+* S') (a : R) :
   e.trans f a = f (e a) := rfl
 
 protected lemma bijective (e : R ≃+* S) : function.bijective e := e.to_equiv.bijective

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -159,7 +159,8 @@ symm_bijective.injective $ ext $ λ x, rfl
 { .. (e₁.to_mul_equiv.trans e₂.to_mul_equiv), .. (e₁.to_add_equiv.trans e₂.to_add_equiv) }
 
 @[simp] lemma trans_apply {A B C : Type*}
-  [semiring A] [semiring B] [semiring C] (e : A ≃+* B) (f : B ≃+* C) (a : A) :
+  [has_mul A] [has_add A] [has_mul B] [has_add B] [has_mul C] [has_add C]
+  (e : A ≃+* B) (f : B ≃+* C) (a : A) :
   e.trans f a = f (e a) := rfl
 
 protected lemma bijective (e : R ≃+* S) : function.bijective e := e.to_equiv.bijective

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -159,7 +159,7 @@ symm_bijective.injective $ ext $ λ x, rfl
 { .. (e₁.to_mul_equiv.trans e₂.to_mul_equiv), .. (e₁.to_add_equiv.trans e₂.to_add_equiv) }
 
 @[simp] lemma trans_apply (e₁ : R ≃+* S) (e₂ : S ≃+* S') (a : R) :
-  e.trans f a = f (e a) := rfl
+  e₁.trans e₂ a = e₂ (e₁ a) := rfl
 
 protected lemma bijective (e : R ≃+* S) : function.bijective e := e.to_equiv.bijective
 protected lemma injective (e : R ≃+* S) : function.injective e := e.to_equiv.injective


### PR DESCRIPTION
`ring_equiv.trans` had weaker typeclasses than the lemma which unfolds it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
