### PR TITLE
[Merged by Bors] - chore(algebra/group): missed generalizations to mul_one_class

### DIFF
--- a/src/algebra/group/commute.lean
+++ b/src/algebra/group/commute.lean
@@ -77,12 +77,18 @@ end semigroup
 @[to_additive]
 protected theorem all {S : Type*} [comm_semigroup S] (a b : S) : commute a b := mul_comm a b
 
-section monoid
+section mul_one_class
 
 variables {M : Type*} [monoid M]
 
 @[simp, to_additive] theorem one_right (a : M) : commute a 1 := semiconj_by.one_right a
 @[simp, to_additive] theorem one_left (a : M) : commute 1 a := semiconj_by.one_left a
+
+end mul_one_class
+
+section monoid
+
+variables {M : Type*} [monoid M]
 
 @[to_additive] theorem units_inv_right {a : M} {u : units M} : commute a u → commute a ↑u⁻¹ :=
 semiconj_by.units_inv_right

--- a/src/algebra/group/pi.lean
+++ b/src/algebra/group/pi.lean
@@ -129,7 +129,7 @@ end pi
 
 section monoid_hom
 
-variables (f) [Π i, monoid (f i)]
+variables (f) [Π i, mul_one_class (f i)]
 
 /-- Evaluation of functions into an indexed collection of monoids at a point is a monoid
 homomorphism. -/

--- a/src/algebra/group/semiconj.lean
+++ b/src/algebra/group/semiconj.lean
@@ -57,9 +57,9 @@ by unfold semiconj_by; assoc_rw [hb.eq, ha.eq, mul_assoc]
 
 end semigroup
 
-section monoid
+section mul_one_class
 
-variables {M : Type u} [monoid M]
+variables {M : Type u} [mul_one_class M]
 
 /-- Any element semiconjugates `1` to `1`. -/
 @[simp, to_additive]
@@ -68,6 +68,12 @@ lemma one_right (a : M) : semiconj_by a 1 1 := by rw [semiconj_by, mul_one, one_
 /-- One semiconjugates any element to itself. -/
 @[simp, to_additive]
 lemma one_left (x : M) : semiconj_by 1 x x := eq.symm $ one_right x
+
+end mul_one_class
+
+section monoid
+
+variables {M : Type u} [monoid M]
 
 /-- If `a` semiconjugates a unit `x` to a unit `y`, then it semiconjugates `x⁻¹` to `y⁻¹`. -/
 @[to_additive] lemma units_inv_right {a : M} {x y : units M} (h : semiconj_by a x y) :

--- a/src/algebra/group/ulift.lean
+++ b/src/algebra/group/ulift.lean
@@ -35,15 +35,11 @@ namespace ulift
 @[to_additive] instance has_inv [has_inv α] : has_inv (ulift α) := ⟨λ f, ⟨f.down⁻¹⟩⟩
 @[simp, to_additive] lemma inv_down [has_inv α] : x⁻¹.down = (x.down)⁻¹ := rfl
 
-@[to_additive]
-instance semigroup [semigroup α] : semigroup (ulift α) :=
-by refine_struct { mul := (*), .. }; tactic.pi_instance_derive_field
-
 /--
 The multiplicative equivalence between `ulift α` and `α`.
 -/
 @[to_additive "The additive equivalence between `ulift α` and `α`."]
-def mul_equiv [semigroup α] : ulift α ≃* α :=
+def mul_equiv [has_mul α] : ulift α ≃* α :=
 { to_fun := ulift.down,
   inv_fun := ulift.up,
   map_mul' := λ x y, rfl,
@@ -51,8 +47,16 @@ def mul_equiv [semigroup α] : ulift α ≃* α :=
   right_inv := by tidy, }
 
 @[to_additive]
+instance semigroup [semigroup α] : semigroup (ulift α) :=
+by refine_struct { mul := (*), .. }; tactic.pi_instance_derive_field
+
+@[to_additive]
 instance comm_semigroup [comm_semigroup α] : comm_semigroup (ulift α) :=
 by refine_struct { mul := (*), .. }; tactic.pi_instance_derive_field
+
+@[to_additive]
+instance mul_one_class [mul_one_class α] : mul_one_class (ulift α) :=
+by refine_struct { mul := (*), one := (1 : ulift α), .. }; tactic.pi_instance_derive_field
 
 instance monoid [monoid α] : monoid (ulift α) :=
 by refine_struct { one := (1 : ulift α), mul := (*), npow := λ n f, ⟨npow n f.down⟩ };


### PR DESCRIPTION
This adds a missing `ulift` instance, relaxes some lemmas about `semiconj` and `commute` to apply more generally, and broadens the scope of the definitions `monoid_hom.apply` and `ulift.mul_equiv`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
