### PR TITLE
[Merged by Bors] - feat(analysis/calculus/deriv): `has_deriv_at.continuous_on`

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -967,6 +967,9 @@ has_deriv_at_filter.tendsto_nhds inf_le_left h
 theorem has_deriv_at.continuous_at (h : has_deriv_at f f' x) : continuous_at f x :=
 has_deriv_at_filter.tendsto_nhds (le_refl _) h
 
+theorem has_deriv_at.continuous_on (hderiv : ∀ x ∈ s, has_deriv_at f f' x) : continuous_on f s :=
+λ x hx, (hderiv x hx).continuous_at.continuous_within_at
+
 end continuous
 
 section cartesian_product

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -967,7 +967,7 @@ has_deriv_at_filter.tendsto_nhds inf_le_left h
 theorem has_deriv_at.continuous_at (h : has_deriv_at f f' x) : continuous_at f x :=
 has_deriv_at_filter.tendsto_nhds (le_refl _) h
 
-theorem has_deriv_at.continuous_on {f f' : 𝕜 → F} (hderiv : ∀ x ∈ s, has_deriv_at f f' x) :
+theorem has_deriv_at.continuous_on {f f' : 𝕜 → F} (hderiv : ∀ x ∈ s, has_deriv_at f (f' x) x) :
   continuous_on f s :=
 λ x hx, (hderiv x hx).continuous_at.continuous_within_at
 

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -967,8 +967,8 @@ has_deriv_at_filter.tendsto_nhds inf_le_left h
 theorem has_deriv_at.continuous_at (h : has_deriv_at f f' x) : continuous_at f x :=
 has_deriv_at_filter.tendsto_nhds (le_refl _) h
 
-theorem has_deriv_at.continuous_on {f f' : 𝕜 → F} (hderiv : ∀ x ∈ s, has_deriv_at f (f' x) x) :
-  continuous_on f s :=
+protected theorem has_deriv_at.continuous_on {f f' : 𝕜 → F}
+  (hderiv : ∀ x ∈ s, has_deriv_at f (f' x) x) : continuous_on f s :=
 λ x hx, (hderiv x hx).continuous_at.continuous_within_at
 
 end continuous

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -967,7 +967,8 @@ has_deriv_at_filter.tendsto_nhds inf_le_left h
 theorem has_deriv_at.continuous_at (h : has_deriv_at f f' x) : continuous_at f x :=
 has_deriv_at_filter.tendsto_nhds (le_refl _) h
 
-theorem has_deriv_at.continuous_on (hderiv : ∀ x ∈ s, has_deriv_at f f' x) : continuous_on f s :=
+theorem has_deriv_at.continuous_on {f f' : 𝕜 → F} (hderiv : ∀ x ∈ s, has_deriv_at f f' x) :
+  continuous_on f s :=
 λ x hx, (hderiv x hx).continuous_at.continuous_within_at
 
 end continuous

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -1570,7 +1570,7 @@ begin
   have hcu : continuous_on u _ := λ x hx, (hu x hx).continuous_at.continuous_within_at,
   have hcv : continuous_on v _ := λ x hx, (hv x hx).continuous_at.continuous_within_at,
   rw integral_eq_sub_of_has_deriv_at,
-  intros x hx;
+  intros x hx,
   { exact (hu x hx).mul (hv x hx) },
   { exact (hcu'.mul hcv).add (hcu.mul hcv') }
 end

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -1541,7 +1541,7 @@ integral_eq_sub_of_has_deriv_at' hcont (by rwa [min_eq_left hab, max_eq_right ha
 theorem integral_eq_sub_of_has_deriv_at (hderiv : ∀ x ∈ interval a b, has_deriv_at f (f' x) x)
   (hcont' : continuous_on f' (interval a b)) :
   ∫ y in a..b, f' y = f b - f a :=
-integral_eq_sub_of_has_deriv_at' (λ x hx, (hderiv x hx).continuous_at.continuous_within_at)
+integral_eq_sub_of_has_deriv_at' (has_deriv_at.continuous_on hderiv)
   (λ x hx, hderiv _ (mem_Icc_of_Ioo hx)) hcont'
 
 /-- Fundamental theorem of calculus-2: If `f : ℝ → E` is differentiable at every `x` in `[a, b]` and
@@ -1566,14 +1566,8 @@ lemma integral_deriv_mul_eq_sub {u v u' v' : ℝ → ℝ}
   (hv : ∀ x ∈ interval a b, has_deriv_at v (v' x) x)
   (hcu' : continuous_on u' (interval a b)) (hcv' : continuous_on v' (interval a b)) :
   ∫ x in a..b, u' x * v x + u x * v' x = u b * v b - u a * v a :=
-begin
-  have hcu : continuous_on u _ := λ x hx, (hu x hx).continuous_at.continuous_within_at,
-  have hcv : continuous_on v _ := λ x hx, (hv x hx).continuous_at.continuous_within_at,
-  rw integral_eq_sub_of_has_deriv_at,
-  intros x hx,
-  { exact (hu x hx).mul (hv x hx) },
-  { exact (hcu'.mul hcv).add (hcu.mul hcv') }
-end
+integral_eq_sub_of_has_deriv_at (λ x hx, (hu x hx).mul (hv x hx)) $
+  (hcu'.mul (has_deriv_at.continuous_on hv)).add ((has_deriv_at.continuous_on hu).mul hcv')
 
 theorem integral_mul_deriv_eq_deriv_mul {u v u' v' : ℝ → ℝ}
   (hu : ∀ x ∈ interval a b, has_deriv_at u (u' x) x)
@@ -1581,12 +1575,10 @@ theorem integral_mul_deriv_eq_deriv_mul {u v u' v' : ℝ → ℝ}
   (hcu' : continuous_on u' (interval a b)) (hcv' : continuous_on v' (interval a b)) :
   ∫ x in a..b, u x * v' x = u b * v b - u a * v a - ∫ x in a..b, v x * u' x :=
 begin
-  have hcu : continuous_on u _ := λ x hx, (hu x hx).continuous_at.continuous_within_at,
-  have hcv : continuous_on v _ := λ x hx, (hv x hx).continuous_at.continuous_within_at,
+  have hcv := has_deriv_at.continuous_on hv,
   rw [← integral_deriv_mul_eq_sub hu hv hcu' hcv', ← integral_sub],
-  { apply integral_congr,
-    exact λ x hx, by simp [mul_comm] },
-  { exact ((hcu'.mul hcv).add (hcu.mul hcv')).interval_integrable },
+  { exact integral_congr (λ x hx, by simp only [mul_comm, add_sub_cancel']) },
+  { exact ((hcu'.mul hcv).add ((has_deriv_at.continuous_on hu).mul hcv')).interval_integrable },
   { exact (hcv.mul hcu').interval_integrable },
 end
 

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -619,6 +619,10 @@ lemma continuous_on.continuous_at {f : α → β} {s : set α} {x : α}
   (h : continuous_on f s) (hx : s ∈ 𝓝 x) : continuous_at f x :=
 (h x (mem_of_nhds hx)).continuous_at hx
 
+lemma continuous_at.continuous_on {f : α → β} {s : set α} (hcont : ∀ x ∈ s, continuous_at f x) :
+  continuous_on f s :=
+λ x hx, (hcont x hx).continuous_within_at
+
 lemma continuous_within_at.comp {g : β → γ} {f : α → β} {s : set α} {t : set β} {x : α}
   (hg : continuous_within_at g t (f x)) (hf : continuous_within_at f s x) (h : s ⊆ f ⁻¹' t) :
   continuous_within_at (g ∘ f) s x :=


### PR DESCRIPTION
See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/has_deriv_at.2Econtinuous_on/near/235034547).