### PR TITLE
[Merged by Bors] - chore(algebra/*): add back nat_algebra_subsingleton and add_comm_monoid.nat_semimodule.subsingleton

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1291,6 +1291,13 @@ instance int_algebra_subsingleton : subsingleton (algebra ℤ S) :=
 ⟨λ P Q, by { ext, simp, }⟩
 end
 
+section
+variables {S : Type*} [semiring S]
+
+instance nat_algebra_subsingleton : subsingleton (algebra ℕ S) :=
+⟨λ P Q, by { ext, simp, }⟩
+end
+
 section span_int
 open submodule
 

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -290,19 +290,18 @@ begin
 end
 end
 
-/-- `nsmul` is equal to any `ℕ`-semimodule structure. Note that the `•` on the RHS is the one
-induced by `h`. -/
-lemma nsmul_eq_smul' (h : semimodule ℕ M) (n : ℕ) (b : M) :
-  nsmul n b = by {
-    have : ∀ {R : Type*} [semiring R], (by exactI semimodule R M → has_scalar R M) :=
-      λ r hr h, by resetI; apply_instance,
-    haveI := this h,
-    exact n • b } :=
-by rw [nsmul_eq_smul, nsmul_eq_smul_cast ℕ, nat.cast_id]
+/-- Convert back any exotic `ℕ`-smul to the canonical instance. This should not be needed since in
+mathlib all `add_comm_monoid`s should normally have exactly one `ℕ`-semimodule structure by design.
+-/
+lemma nat_smul_eq_nsmul (h : semimodule ℕ M) (n : ℕ) (x : M) :
+  @has_scalar.smul ℕ M h.to_has_scalar n x = n • x :=
+by rw [nsmul_eq_smul_cast ℕ n x, nat.cast_id]
 
-/-- All `ℕ`-semimodule structures are equal. -/
-instance add_comm_monoid.nat_semimodule.subsingleton : subsingleton (semimodule ℕ M) :=
-⟨λ P Q, semimodule_ext P Q $ λ n m, (nsmul_eq_smul' P n m).symm.trans (nsmul_eq_smul' Q n m) ⟩
+/-- All `ℕ`-module structures are equal. Not an instance since in mathlib all `add_comm_monoid`
+should normally have exactly one `ℕ`-module structure by design. -/
+def add_comm_monoid.nat_semimodule.unique : unique (semimodule ℕ M) :=
+{ default := by apply_instance,
+  uniq := λ P, semimodule_ext P _ $ λ n, nat_smul_eq_nsmul P n }
 
 instance add_comm_monoid.nat_is_scalar_tower :
   is_scalar_tower ℕ R M :=

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -200,6 +200,7 @@ semimodule R M
 To prove two semimodule structures on a fixed `add_comm_monoid` agree,
 it suffices to check the scalar multiplications agree.
 -/
+-- We'll later use this to show `semimodule ℕ M` and `module ℤ M` are subsingletons.
 @[ext]
 lemma semimodule_ext {R : Type*} [semiring R] {M : Type*} [add_comm_monoid M] (P Q : semimodule R M)
   (w : ∀ (r : R) (m : M), by { haveI := P, exact r • m } = by { haveI := Q, exact r • m }) :
@@ -288,6 +289,20 @@ begin
   { rw [nat.succ_eq_add_one, nat.cast_succ, add_smul, add_smul, one_smul, ih, one_smul], }
 end
 end
+
+/-- `nsmul` is equal to any `ℕ`-semimodule structure. Note that the `•` on the RHS is the one
+induced by `h`. -/
+lemma nsmul_eq_smul' (h : semimodule ℕ M) (n : ℕ) (b : M) :
+  nsmul n b = by {
+    have : ∀ {R : Type*} [semiring R], (by exactI semimodule R M → has_scalar R M) :=
+      λ r hr h, by resetI; apply_instance,
+    haveI := this h,
+    exact n • b } :=
+by rw [nsmul_eq_smul, nsmul_eq_smul_cast ℕ, nat.cast_id]
+
+/-- All `ℕ`-semimodule structures are equal. -/
+instance add_comm_monoid.nat_semimodule.subsingleton : subsingleton (semimodule ℕ M) :=
+⟨λ P Q, semimodule_ext P Q $ λ n m, (nsmul_eq_smul' P n m).symm.trans (nsmul_eq_smul' Q n m) ⟩
 
 instance add_comm_monoid.nat_is_scalar_tower :
   is_scalar_tower ℕ R M :=


### PR DESCRIPTION
As suggested in https://github.com/leanprover-community/mathlib/pull/7084#discussion_r613195167.

Even if we now have a design solution that makes this unnecessary, it still feels like a result worth stating.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
