### PR TITLE
[Merged by Bors] - feat(set_theory/surreal): add ordered_add_comm_group instance for surreal numbers

### DIFF
--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -348,11 +348,11 @@ instance : ordered_add_comm_group surreal :=
   le_antisymm       := by { rintros ⟨_⟩ ⟨_⟩ h₁ h₂, exact quotient.sound ⟨h₁, h₂⟩ },
   add_le_add_left   := by { rintros ⟨_⟩ ⟨_⟩ hx ⟨_⟩, exact pgame.add_le_add_left hx } }
   
-noncomputable instance : linear_order surreal :=
+noncomputable instance : linear_ordered_add_comm_group surreal :=
 { le_total := by rintro ⟨⟨x, ox⟩⟩ ⟨⟨y, oy⟩⟩; classical; exact
     or_iff_not_imp_left.2 (λ h, le_of_lt oy ox (pgame.not_le.1 h)),
   decidable_le := classical.dec_rel _,
-  ..(infer_instance : partial_order surreal) }
+  ..surreal.ordered_add_comm_group }
 
 -- We conclude with some ideas for further work on surreals; these would make fun projects.
 

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -341,26 +341,28 @@ surreal.lift₂
 
 instance : has_add surreal := ⟨add⟩
 
-theorem add_assoc : ∀ (x y z : surreal), (x + y) + z = x + (y + z) :=
-begin
-  rintros ⟨x⟩ ⟨y⟩ ⟨z⟩,
-  apply quot.sound,
-  exact add_assoc_equiv,
-end
+def neg : surreal → surreal :=
+surreal.lift (λ x ox, ⟦⟨-x, pgame.numeric_neg ox⟩⟧) (λ _ _ _ _ a, quotient.sound (pgame.neg_congr a))
 
-theorem zero_add : ∀ (x : surreal), 0 + x = x :=
-by { rintro ⟨x, ox⟩, exact quotient.sound (pgame.zero_add_equiv _) }
-
-theorem add_zero : ∀ (x : surreal), x + 0 = x :=
-by { rintro ⟨x, ox⟩, exact quotient.sound (pgame.add_zero_equiv _) }
-
-instance : add_monoid surreal :=
-{ add       := surreal.add,
-  add_assoc := surreal.add_assoc,
-  zero      := 0,
-  zero_add  := surreal.zero_add,
-  add_zero  := surreal.add_zero }
-
+instance : ordered_add_comm_group surreal :=
+{ add               := surreal.add,
+  add_assoc         := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, exact quot.sound add_assoc_equiv },
+  zero              := 0,
+  zero_add          := by { rintros ⟨_⟩, exact quotient.sound (pgame.zero_add_equiv _) },
+  add_zero          := by { rintros ⟨_⟩, exact quotient.sound (pgame.add_zero_equiv _) }, 
+  neg               := surreal.neg, 
+  sub               := λ x y, x + surreal.neg y,
+  sub_eq_add_neg    := by try_refl_tac,
+  add_left_neg      := by { rintros ⟨_⟩, exact quotient.sound pgame.add_left_neg_equiv }, 
+  add_comm          := by { rintros ⟨_⟩ ⟨_⟩, exact quotient.sound pgame.add_comm_equiv },
+  le                := surreal.le,
+  lt                := surreal.lt,
+  le_refl           := by { rintros ⟨_⟩, refl },
+  le_trans          := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, exact pgame.le_trans },
+  lt_iff_le_not_le  := by { rintros ⟨_, ox⟩ ⟨_, oy⟩, exact pgame.lt_iff_le_not_le ox oy },
+  le_antisymm       := by { rintros ⟨_⟩ ⟨_⟩ h₁ h₂, exact quotient.sound ⟨h₁, h₂⟩ },
+  add_le_add_left   := by { rintros ⟨_⟩ ⟨_⟩ hx ⟨_⟩, exact pgame.add_le_add_left hx } }
+  
 -- We conclude with some ideas for further work on surreals; these would make fun projects.
 
 -- TODO replace the `add_monoid` instance above with a stronger instance:

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -332,14 +332,12 @@ surreal.lift
   (λ _ _ _ _ a, quotient.sound (pgame.neg_congr a))
 
 instance : ordered_add_comm_group surreal :=
-{ add               := surreal.add,
+{ add               := (+),
   add_assoc         := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, exact quotient.sound add_assoc_equiv },
   zero              := 0,
   zero_add          := by { rintros ⟨_⟩, exact quotient.sound (pgame.zero_add_equiv _) },
   add_zero          := by { rintros ⟨_⟩, exact quotient.sound (pgame.add_zero_equiv _) }, 
-  neg               := surreal.neg, 
-  sub               := λ x y, x + surreal.neg y,
-  sub_eq_add_neg    := by try_refl_tac,
+  neg               := has_neg.neg, 
   add_left_neg      := by { rintros ⟨_⟩, exact quotient.sound pgame.add_left_neg_equiv }, 
   add_comm          := by { rintros ⟨_⟩ ⟨_⟩, exact quotient.sound pgame.add_comm_equiv },
   le                := surreal.le,

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -324,6 +324,8 @@ surreal.lift₂
 
 instance : has_add surreal := ⟨add⟩
 
+/-- Negation for surreal numbers is inherited from pre-game negation:
+the negation of `{L | R}` is `{-R | -L}`. -/
 def neg : surreal → surreal :=
 surreal.lift
   (λ x ox, ⟦⟨-x, pgame.numeric_neg ox⟩⟧)

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -322,14 +322,17 @@ surreal.lift₂
   (λ (x y : pgame) (ox) (oy), ⟦⟨x + y, numeric_add ox oy⟩⟧)
   (λ x₁ y₁ x₂ y₂ _ _ _ _ hx hy, quotient.sound (pgame.add_congr hx hy))
 
-instance : has_add surreal := ⟨add⟩
-
 /-- Negation for surreal numbers is inherited from pre-game negation:
 the negation of `{L | R}` is `{-R | -L}`. -/
 def neg : surreal → surreal :=
 surreal.lift
   (λ x ox, ⟦⟨-x, pgame.numeric_neg ox⟩⟧)
   (λ _ _ _ _ a, quotient.sound (pgame.neg_congr a))
+
+instance : has_le surreal   := ⟨le⟩
+instance : has_lt surreal   := ⟨lt⟩
+instance : has_add surreal  := ⟨add⟩
+instance : has_neg surreal  := ⟨neg⟩
 
 instance : ordered_add_comm_group surreal :=
 { add               := (+),
@@ -340,8 +343,8 @@ instance : ordered_add_comm_group surreal :=
   neg               := has_neg.neg, 
   add_left_neg      := by { rintros ⟨_⟩, exact quotient.sound pgame.add_left_neg_equiv }, 
   add_comm          := by { rintros ⟨_⟩ ⟨_⟩, exact quotient.sound pgame.add_comm_equiv },
-  le                := surreal.le,
-  lt                := surreal.lt,
+  le                := (≤),
+  lt                := (<),
   le_refl           := by { rintros ⟨_⟩, refl },
   le_trans          := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, exact pgame.le_trans },
   lt_iff_le_not_le  := by { rintros ⟨_, ox⟩ ⟨_, oy⟩, exact pgame.lt_iff_le_not_le ox oy },

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -320,7 +320,7 @@ the sum of `x = {xL | xR}` and `y = {yL | yR}` is `{xL + y, x + yL | xR + y, x +
 def add : surreal → surreal → surreal :=
 surreal.lift₂
   (λ (x y : pgame) (ox) (oy), ⟦⟨x + y, numeric_add ox oy⟩⟧)
-  (λ x₁ y₁ x₂ y₂ _ _ _ _ hx hy, quot.sound (pgame.add_congr hx hy))
+  (λ x₁ y₁ x₂ y₂ _ _ _ _ hx hy, quotient.sound (pgame.add_congr hx hy))
 
 instance : has_add surreal := ⟨add⟩
 
@@ -329,7 +329,7 @@ surreal.lift (λ x ox, ⟦⟨-x, pgame.numeric_neg ox⟩⟧) (λ _ _ _ _ a, quot
 
 instance : ordered_add_comm_group surreal :=
 { add               := surreal.add,
-  add_assoc         := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, exact quot.sound add_assoc_equiv },
+  add_assoc         := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, exact quotient.sound add_assoc_equiv },
   zero              := 0,
   zero_add          := by { rintros ⟨_⟩, exact quotient.sound (pgame.zero_add_equiv _) },
   add_zero          := by { rintros ⟨_⟩, exact quotient.sound (pgame.add_zero_equiv _) }, 

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -356,10 +356,6 @@ noncomputable instance : linear_order surreal :=
 
 -- We conclude with some ideas for further work on surreals; these would make fun projects.
 
--- TODO replace the `add_monoid` instance above with a stronger instance:
---   add_group, add_comm_semigroup, add_comm_group, ordered_add_comm_group,
--- as per the instances for `game`
-
 -- TODO define the inclusion of groups `surreal → game`
 
 -- TODO define the dyadic rationals, and show they map into the surreals via the formula

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -315,23 +315,6 @@ lift₂ (λ x y _ _, x < y) (λ x₁ y₁ x₂ y₂ _ _ _ _ hx hy, propext (lt_c
 theorem not_le : ∀ {x y : surreal}, ¬ le x y ↔ lt y x :=
 by rintro ⟨⟨x, ox⟩⟩ ⟨⟨y, oy⟩⟩; exact not_le
 
-instance : preorder surreal :=
-{ le := le,
-  lt := lt,
-  le_refl := by rintro ⟨⟨x, ox⟩⟩; exact le_refl _,
-  le_trans := by rintro ⟨⟨x, ox⟩⟩ ⟨⟨y, oy⟩⟩ ⟨⟨z, oz⟩⟩; exact le_trans,
-  lt_iff_le_not_le := by rintro ⟨⟨x, ox⟩⟩ ⟨⟨y, oy⟩⟩; exact lt_iff_le_not_le ox oy }
-
-instance : partial_order surreal :=
-{ le_antisymm := by rintro ⟨⟨x, ox⟩⟩ ⟨⟨y, oy⟩⟩ h₁ h₂; exact quot.sound ⟨h₁, h₂⟩,
-  ..surreal.preorder }
-
-noncomputable instance : linear_order surreal :=
-{ le_total := by rintro ⟨⟨x, ox⟩⟩ ⟨⟨y, oy⟩⟩; classical; exact
-    or_iff_not_imp_left.2 (λ h, le_of_lt oy ox (pgame.not_le.1 h)),
-  decidable_le := classical.dec_rel _,
-  ..surreal.partial_order }
-
 /-- Addition on surreals is inherited from pre-game addition:
 the sum of `x = {xL | xR}` and `y = {yL | yR}` is `{xL + y, x + yL | xR + y, x + yR}`. -/
 def add : surreal → surreal → surreal :=
@@ -363,6 +346,12 @@ instance : ordered_add_comm_group surreal :=
   le_antisymm       := by { rintros ⟨_⟩ ⟨_⟩ h₁ h₂, exact quotient.sound ⟨h₁, h₂⟩ },
   add_le_add_left   := by { rintros ⟨_⟩ ⟨_⟩ hx ⟨_⟩, exact pgame.add_le_add_left hx } }
   
+noncomputable instance : linear_order surreal :=
+{ le_total := by rintro ⟨⟨x, ox⟩⟩ ⟨⟨y, oy⟩⟩; classical; exact
+    or_iff_not_imp_left.2 (λ h, le_of_lt oy ox (pgame.not_le.1 h)),
+  decidable_le := classical.dec_rel _,
+  ..(infer_instance : partial_order surreal) }
+
 -- We conclude with some ideas for further work on surreals; these would make fun projects.
 
 -- TODO replace the `add_monoid` instance above with a stronger instance:

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -325,7 +325,9 @@ surreal.lift₂
 instance : has_add surreal := ⟨add⟩
 
 def neg : surreal → surreal :=
-surreal.lift (λ x ox, ⟦⟨-x, pgame.numeric_neg ox⟩⟧) (λ _ _ _ _ a, quotient.sound (pgame.neg_congr a))
+surreal.lift
+  (λ x ox, ⟦⟨-x, pgame.numeric_neg ox⟩⟧)
+  (λ _ _ _ _ a, quotient.sound (pgame.neg_congr a))
 
 instance : ordered_add_comm_group surreal :=
 { add               := surreal.add,


### PR DESCRIPTION
[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Surreal.20numbers/near/235213851)

Add ordered_add_comm_group instance for surreal numbers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
