### PR TITLE
[Merged by Bors] - refactor(group_theory/submonoid/basic): merge together similar lemmas and definitions

### DIFF
--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -107,38 +107,6 @@ add_decl_doc subgroup.to_submonoid
 /-- Reinterpret an `add_subgroup` as an `add_submonoid`. -/
 add_decl_doc add_subgroup.to_add_submonoid
 
-/-- Map from subgroups of group `G` to `add_subgroup`s of `additive G`. -/
-def subgroup.to_add_subgroup {G : Type*} [group G] (H : subgroup G) :
-  add_subgroup (additive G) :=
-{ neg_mem' := H.inv_mem',
-  .. submonoid.to_add_submonoid H.to_submonoid}
-
-/-- Map from `add_subgroup`s of `additive G` to subgroups of `G`. -/
-def subgroup.of_add_subgroup {G : Type*} [group G] (H : add_subgroup (additive G)) :
-  subgroup G :=
-{ inv_mem' := H.neg_mem',
-  .. submonoid.of_add_submonoid H.to_add_submonoid}
-
-/-- Map from `add_subgroup`s of `add_group G` to subgroups of `multiplicative G`. -/
-def add_subgroup.to_subgroup {G : Type*} [add_group G] (H : add_subgroup G) :
-  subgroup (multiplicative G) :=
-{ inv_mem' := H.neg_mem',
-  .. add_submonoid.to_submonoid H.to_add_submonoid}
-
-/-- Map from subgroups of `multiplicative G` to `add_subgroup`s of `add_group G`. -/
-def add_subgroup.of_subgroup {G : Type*} [add_group G] (H : subgroup (multiplicative G)) :
-  add_subgroup G :=
-{ neg_mem' := H.inv_mem',
-  .. add_submonoid.of_submonoid H.to_submonoid }
-
-/-- Subgroups of group `G` are isomorphic to additive subgroups of `additive G`. -/
-def subgroup.add_subgroup_equiv (G : Type*) [group G] :
-subgroup G ≃ add_subgroup (additive G) :=
-{ to_fun := subgroup.to_add_subgroup,
-  inv_fun := subgroup.of_add_subgroup,
-  left_inv := λ x, by cases x; refl,
-  right_inv := λ x, by cases x; refl }
-
 namespace subgroup
 
 @[to_additive]
@@ -147,6 +115,12 @@ instance : set_like (subgroup G) G :=
 
 @[simp, to_additive]
 lemma mem_carrier {s : subgroup G} {x : G} : x ∈ s.carrier ↔ x ∈ s := iff.rfl
+
+@[to_additive]
+def simps.coe (S : subgroup G) : set G := S
+
+initialize_simps_projections subgroup (carrier → coe)
+initialize_simps_projections add_subgroup (carrier → coe)
 
 @[simp, to_additive]
 lemma coe_to_submonoid (K : subgroup G) : (K.to_submonoid : set G) = K := rfl
@@ -157,6 +131,46 @@ show fintype {g : G // g ∈ K}, from infer_instance
 
 end subgroup
 
+/-!
+### Conversion to/from `additive`/`multiplicative`
+-/
+section
+
+/-- Supgroups of a group `G` are isomorphic to additive subgroups of `additive G`. -/
+@[simps]
+def subgroup.to_add_subgroup : subgroup G ≃o add_subgroup (additive G) :=
+{ to_fun := λ S,
+  { neg_mem' := S.inv_mem',
+    ..S.to_submonoid.to_add_submonoid },
+  inv_fun := λ S,
+  { inv_mem' := S.neg_mem',
+    ..S.to_add_submonoid.to_submonoid' },
+  left_inv := λ x, by cases x; refl,
+  right_inv := λ x, by cases x; refl,
+  map_rel_iff' := λ a b, iff.rfl, }
+
+/-- Additive subgroup of an additive group `additive G` are isomorphic to subgroup of `G`. -/
+abbreviation add_subgroup.to_subgroup' : add_subgroup (additive G) ≃o subgroup G :=
+subgroup.to_add_subgroup.symm
+
+/-- Additive supgroups of an additive group `A` are isomorphic to subgroups of `multiplicative A`.
+-/
+@[simps]
+def add_subgroup.to_subgroup : add_subgroup A ≃o subgroup (multiplicative A) :=
+{ to_fun := λ S,
+  { inv_mem' := S.neg_mem',
+    ..S.to_add_submonoid.to_submonoid },
+  inv_fun := λ S,
+  { neg_mem' := S.inv_mem',
+    ..S.to_submonoid.to_add_submonoid' },
+  left_inv := λ x, by cases x; refl,
+  right_inv := λ x, by cases x; refl,
+  map_rel_iff' := λ a b, iff.rfl, }
+
+/-- Subgroups of an additive group `multiplicative A` are isomorphic to additive subgroups of `A`.
+-/
+abbreviation subgroup.to_add_subgroup' : subgroup (multiplicative A) ≃o add_subgroup A :=
+add_subgroup.to_subgroup.symm
 
 namespace subgroup
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -134,7 +134,7 @@ end subgroup
 /-!
 ### Conversion to/from `additive`/`multiplicative`
 -/
-section
+section mul_add
 
 /-- Supgroups of a group `G` are isomorphic to additive subgroups of `additive G`. -/
 @[simps]
@@ -171,6 +171,8 @@ def add_subgroup.to_subgroup : add_subgroup A ≃o subgroup (multiplicative A) :
 -/
 abbreviation subgroup.to_add_subgroup' : subgroup (multiplicative A) ≃o add_subgroup A :=
 add_subgroup.to_subgroup.symm
+
+end mul_add
 
 namespace subgroup
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -116,7 +116,8 @@ instance : set_like (subgroup G) G :=
 @[simp, to_additive]
 lemma mem_carrier {s : subgroup G} {x : G} : x ∈ s.carrier ↔ x ∈ s := iff.rfl
 
-@[to_additive]
+/-- See Note [custom simps projection] -/
+@[to_additive "See Note [custom simps projection]"]
 def simps.coe (S : subgroup G) : set G := S
 
 initialize_simps_projections subgroup (carrier → coe)

--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -79,7 +79,8 @@ namespace submonoid
 instance : set_like (submonoid M) M :=
 ⟨submonoid.carrier, λ p q h, by cases p; cases q; congr'⟩
 
-@[to_additive]
+/-- See Note [custom simps projection] -/
+@[to_additive " See Note [custom simps projection]"]
 def simps.coe (S : submonoid M) : set M := S
 
 initialize_simps_projections submonoid (carrier → coe)

--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -79,6 +79,12 @@ namespace submonoid
 instance : set_like (submonoid M) M :=
 ⟨submonoid.carrier, λ p q h, by cases p; cases q; congr'⟩
 
+@[to_additive]
+def simps.coe (S : submonoid M) : set M := S
+
+initialize_simps_projections submonoid (carrier → coe)
+initialize_simps_projections add_submonoid (carrier → coe)
+
 @[simp, to_additive]
 lemma mem_carrier {s : submonoid M} {x : M} : x ∈ s.carrier ↔ x ∈ s := iff.rfl
 

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -65,112 +65,81 @@ variables {M N P : Type*} [mul_one_class M] [mul_one_class N] [mul_one_class P] 
 ### Conversion to/from `additive`/`multiplicative`
 -/
 
-/-- Map from submonoids of monoid `M` to `add_submonoid`s of `additive M`. -/
-def submonoid.to_add_submonoid {M : Type*} [mul_one_class M] (S : submonoid M) :
-  add_submonoid (additive M) :=
-{ carrier := S.carrier,
-  zero_mem' := S.one_mem',
-  add_mem' := S.mul_mem' }
-
-/-- Map from `add_submonoid`s of `additive M` to submonoids of `M`. -/
-def submonoid.of_add_submonoid {M : Type*} [mul_one_class M] (S : add_submonoid (additive M)) :
-  submonoid M :=
-{ carrier := S.carrier,
-  one_mem' := S.zero_mem',
-  mul_mem' := S.add_mem' }
-
-/-- Map from `add_submonoid`s of `M` to submonoids of `multiplicative M`. -/
-def add_submonoid.to_submonoid {M : Type*} [add_zero_class M] (S : add_submonoid M) :
-  submonoid (multiplicative M) :=
-{ carrier := S.carrier,
-  one_mem' := S.zero_mem',
-  mul_mem' := S.add_mem' }
-
-/-- Map from submonoids of `M` to `add_submonoid`s of `add_monoid M`. -/
-def add_submonoid.of_submonoid {M : Type*} [add_zero_class M] (S : submonoid (multiplicative M)) :
-  add_submonoid M :=
-{ carrier := S.carrier,
-  zero_mem' := S.one_mem',
-  add_mem' := S.mul_mem' }
-
-lemma submonoid.to_add_submonoid_coe {M : Type*} [mul_one_class M] (S : submonoid M) :
-  (S.to_add_submonoid : set (additive M)) = additive.to_mul ⁻¹' S :=
-rfl
-
-lemma add_submonoid.to_submonoid_coe {M : Type*} [add_zero_class M] (S : add_submonoid M) :
-  (S.to_submonoid : set (multiplicative M)) = multiplicative.to_add ⁻¹' S :=
-rfl
-
-lemma submonoid.of_add_submonoid_coe {M : Type*} [mul_one_class M]
-  (S : add_submonoid (additive M)) :
-  (submonoid.of_add_submonoid S : set M) = additive.of_mul ⁻¹' S :=
-rfl
-
-lemma add_submonoid.of_submonoid_coe {M : Type*} [add_zero_class M]
-  (S : submonoid (multiplicative M)) :
-  (add_submonoid.of_submonoid S : set M) = multiplicative.of_add ⁻¹' S :=
-rfl
+section
 
 /-- Submonoids of monoid `M` are isomorphic to additive submonoids of `additive M`. -/
-def submonoid.add_submonoid_equiv (M : Type*) [mul_one_class M] :
-  submonoid M ≃o add_submonoid (additive M) :=
-{ to_fun := submonoid.to_add_submonoid,
-  inv_fun := submonoid.of_add_submonoid,
+@[simps]
+def submonoid.to_add_submonoid : submonoid M ≃o add_submonoid (additive M) :=
+{ to_fun := λ S,
+  { carrier := additive.to_mul ⁻¹' S,
+    zero_mem' := S.one_mem',
+    add_mem' := S.mul_mem' },
+  inv_fun := λ S,
+  { carrier := additive.of_mul ⁻¹' S,
+    one_mem' := S.zero_mem',
+    mul_mem' := S.add_mem' },
   left_inv := λ x, by cases x; refl,
   right_inv := λ x, by cases x; refl,
   map_rel_iff' := λ a b, iff.rfl, }
 
-/-- Additive submonoids of an additive monoid `M` are isomorphic to
-multiplicative submonoids of `multiplicative M`. -/
-def add_submonoid.submonoid_equiv (M : Type*) [add_zero_class M] :
-  add_submonoid M ≃o submonoid (multiplicative M) :=
-{ to_fun := add_submonoid.to_submonoid,
-  inv_fun := add_submonoid.of_submonoid,
-  left_inv := λ x, by cases x; refl,
-  right_inv := λ x, by cases x; refl,
-  map_rel_iff' := λ a b, iff.rfl, }
+/-- Additive submonoids of an additive monoid `additive M` are isomorphic to submonoids of `M`. -/
+abbreviation add_submonoid.to_submonoid' : add_submonoid (additive M) ≃o submonoid M :=
+submonoid.to_add_submonoid.symm
 
-lemma submonoid.add_submonoid_equiv_coe (M : Type*) [add_zero_class M] :
-  ⇑(add_submonoid.submonoid_equiv M) = add_submonoid.to_submonoid := rfl
-
-lemma add_submonoid.submonoid_equiv_symm_coe (M : Type*) [add_zero_class M] :
-  ⇑(add_submonoid.submonoid_equiv M).symm = add_submonoid.of_submonoid := rfl
-
-lemma add_submonoid.submonoid_equiv_coe (M : Type*) [mul_one_class M] :
-  ⇑(submonoid.add_submonoid_equiv M) = submonoid.to_add_submonoid := rfl
-
-lemma submonoid.add_submonoid_equiv_symm_coe (M : Type*) [mul_one_class M] :
-  ⇑(submonoid.add_submonoid_equiv M).symm = submonoid.of_add_submonoid := rfl
-
-lemma submonoid.to_add_submonoid_mono {M : Type*} [mul_one_class M] :
-  monotone (submonoid.to_add_submonoid : submonoid M → add_submonoid (additive M)) :=
-λ a b hab, hab
-
-lemma add_submonoid.to_submonoid_mono {M : Type*} [add_zero_class M] :
-  monotone (add_submonoid.to_submonoid : add_submonoid M → submonoid (multiplicative M)) :=
-λ a b hab, hab
-
-lemma submonoid.of_add_submonoid_mono {M : Type*} [mul_one_class M] :
-  monotone (submonoid.of_add_submonoid : add_submonoid (additive M) → submonoid M) :=
-λ a b hab, hab
-
-lemma add_submonoid.of_submonoid_mono {M : Type*} [add_zero_class M] :
-  monotone (add_submonoid.of_submonoid : submonoid (multiplicative M) → add_submonoid M) :=
-λ a b hab, hab
-
-lemma submonoid.to_add_submonoid_closure {M : Type*} [monoid M] (S : set M) :
+lemma submonoid.to_add_submonoid_closure (S : set M) :
   (submonoid.closure S).to_add_submonoid = add_submonoid.closure (additive.to_mul ⁻¹' S) :=
 le_antisymm
-  ((submonoid.add_submonoid_equiv M).to_galois_connection.l_le $
+  (submonoid.to_add_submonoid.to_galois_connection.l_le $
     submonoid.closure_le.2 add_submonoid.subset_closure)
   (add_submonoid.closure_le.2 submonoid.subset_closure)
 
-lemma add_submonoid.to_submonoid_closure {M : Type*} [add_monoid M] (S : set M) :
-  (add_submonoid.closure S).to_submonoid = submonoid.closure (multiplicative.to_add ⁻¹' S) :=
+lemma add_submonoid.to_submonoid'_closure (S : set (additive M)) :
+  (add_submonoid.closure S).to_submonoid' = submonoid.closure (multiplicative.of_add ⁻¹' S) :=
 le_antisymm
-  ((add_submonoid.submonoid_equiv M).to_galois_connection.l_le $
+  (add_submonoid.to_submonoid'.to_galois_connection.l_le $
     add_submonoid.closure_le.2 submonoid.subset_closure)
   (submonoid.closure_le.2 add_submonoid.subset_closure)
+
+end
+
+section
+
+variables {A : Type*} [add_zero_class A]
+
+/-- Additive submonoids of an additive monoid `A` are isomorphic to
+multiplicative submonoids of `multiplicative A`. -/
+@[simps]
+def add_submonoid.to_submonoid : add_submonoid A ≃o submonoid (multiplicative A) :=
+{ to_fun := λ S,
+  { carrier := multiplicative.to_add ⁻¹' S,
+    one_mem' := S.zero_mem',
+    mul_mem' := S.add_mem' },
+  inv_fun := λ S,
+  { carrier := multiplicative.of_add ⁻¹' S,
+    zero_mem' := S.one_mem',
+    add_mem' := S.mul_mem' },
+  left_inv := λ x, by cases x; refl,
+  right_inv := λ x, by cases x; refl,
+  map_rel_iff' := λ a b, iff.rfl, }
+
+/-- Submonoids of a monoid `multiplicative A` are isomorphic to additive submonoids of `A`. -/
+abbreviation submonoid.to_add_submonoid' : submonoid (multiplicative A) ≃o add_submonoid A :=
+add_submonoid.to_submonoid.symm
+
+lemma add_submonoid.to_submonoid_closure (S : set A) :
+  (add_submonoid.closure S).to_submonoid = submonoid.closure (multiplicative.to_add ⁻¹' S) :=
+le_antisymm
+  (add_submonoid.to_submonoid.to_galois_connection.l_le $
+    add_submonoid.closure_le.2 submonoid.subset_closure)
+  (submonoid.closure_le.2 add_submonoid.subset_closure)
+
+lemma submonoid.to_add_submonoid'_closure (S : set (multiplicative A)) :
+  (submonoid.closure S).to_add_submonoid' = add_submonoid.closure (additive.of_mul ⁻¹' S) :=
+le_antisymm
+  (submonoid.to_add_submonoid'.to_galois_connection.l_le $
+    submonoid.closure_le.2 add_submonoid.subset_closure)
+  (add_submonoid.closure_le.2 submonoid.subset_closure)
+end
 
 namespace submonoid
 

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -139,6 +139,7 @@ le_antisymm
   (submonoid.to_add_submonoid'.to_galois_connection.l_le $
     submonoid.closure_le.2 add_submonoid.subset_closure)
   (add_submonoid.closure_le.2 submonoid.subset_closure)
+
 end
 
 namespace submonoid

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -19,11 +19,9 @@ In this file we define various operations on `submonoid`s and `monoid_hom`s.
 
 ### Conversion between multiplicative and additive definitions
 
-* `submonoid.to_add_submonoid`, `submonoid.of_add_submonoid`, `add_submonoid.to_submonoid`,
-  `add_submonoid.of_submonoid`: convert between multiplicative and additive submonoids of `M`,
-  `multiplicative M`, and `additive M`.
-* `submonoid.add_submonoid_equiv`: equivalence between `submonoid M`
-  and `add_submonoid (additive M)`.
+* `submonoid.to_add_submonoid`, `submonoid.to_add_submonoid'`, `add_submonoid.to_submonoid`,
+  `add_submonoid.to_submonoid'`: convert between multiplicative and additive submonoids of `M`,
+  `multiplicative M`, and `additive M`. These are stated as `order_iso`s.
 
 ### (Commutative) monoid structure on a submonoid
 


### PR DESCRIPTION
This uses `simps` to generate lots of uninteresting coe lemmas, and removes the less-bundled versions of definitions.

The main changes are:

* `add_submonoid.to_submonoid_equiv` is now just called `add_submonoid.to_submonoid`. This means we can remove the `add_submonoid.to_submonoid_mono` lemma, as that's available as `add_submonoid.to_submonoid.monotone`. Ditto for the multiplicative version.
* `simps` now knows how to handled `(add_)submonoid` objects. Unfortunately it uses `coe` as a suffix rather than a prefix, so we can't use it everywhere yet. For now we restrict its use to just these additive / multiplicative lemmas which already had `coe` as a suffix.
* `submonoid.of_add_submonoid` has been renamed to `add_submonoid.to_submonoid'` to enable dot notation.
* `add_submonoid.of_submonoid` has been renamed to `submonoid.to_add_submonoid'` to enable dot notation.
* The above points, but applied to `(add_)subgroup`
* Two new variants of the closure lemmas about `add_submonoid` (`add_submonoid.to_submonoid'_closure` and `submonoid.to_add_submonoid'_closure`), taken from #7279

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
