### PR TITLE
[Merged by Bors] - feat(data/dfinsupp): copy map_range defs from finsupp

### DIFF
--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -18,7 +18,7 @@ universes u u₁ u₂ v v₁ v₂ v₃ w x y l
 
 open_locale big_operators
 
-variables (ι : Type u) (β : ι → Type v)
+variables (ι : Type u) (β : ι → Type v) {β₁ : ι → Type v₁} {β₂ : ι → Type v₂}
 
 namespace dfinsupp
 
@@ -52,17 +52,16 @@ infix ` →ₚ `:25 := dfinsupp
 namespace dfinsupp
 
 section basic
-variables [Π i, has_zero (β i)]
-variables {β₁ : ι → Type v₁} {β₂ : ι → Type v₂}
-variables [Π i, has_zero (β₁ i)] [Π i, has_zero (β₂ i)]
+variables [Π i, has_zero (β i)] [Π i, has_zero (β₁ i)] [Π i, has_zero (β₂ i)]
 
 instance : has_coe_to_fun (Π₀ i, β i) :=
 ⟨λ _, Π i, β i, λ f, quotient.lift_on f pre.to_fun $ λ _ _, funext⟩
 
-instance : has_zero (Π₀ i, β i) := ⟨⟦⟨λ i, 0, ∅, λ i, or.inr rfl⟩⟧⟩
+instance : has_zero (Π₀ i, β i) := ⟨⟦⟨0, ∅, λ i, or.inr rfl⟩⟧⟩
 instance : inhabited (Π₀ i, β i) := ⟨0⟩
 
-@[simp] lemma zero_apply (i : ι) : (0 : Π₀ i, β i) i = 0 := rfl
+@[simp] lemma coe_zero : ⇑(0 : Π₀ i, β i) = 0 := rfl
+lemma zero_apply (i : ι) : (0 : Π₀ i, β i) i = 0 := rfl
 
 lemma coe_fn_injective : @function.injective (Π₀ i, β i) (Π i, β i) coe_fn :=
 λ f g H, quotient.induction_on₂ f g (λ _ _ H, quotient.sound H) (congr_fun H)
@@ -71,7 +70,16 @@ lemma coe_fn_injective : @function.injective (Π₀ i, β i) (Π i, β i) coe_fn
 coe_fn_injective (funext H)
 
 /-- The composition of `f : β₁ → β₂` and `g : Π₀ i, β₁ i` is
-  `map_range f hf g : Π₀ i, β₂ i`, well defined when `f 0 = 0`. -/
+  `map_range f hf g : Π₀ i, β₂ i`, well defined when `f 0 = 0`.
+
+This preserves the structure on `f`, and exists in various bundled forms for when `f` is itself
+bundled:
+
+* `dfinsupp.map_range.add_monoid_hom`
+* `dfinsupp.map_range.add_equiv`
+* `dfinsupp.map_range.linear_map`
+* `dfinsupp.map_range.linear_equiv`
+-/
 def map_range (f : Π i, β₁ i → β₂ i) (hf : ∀ i, f i 0 = 0) (g : Π₀ i, β₁ i) : Π₀ i, β₂ i :=
 quotient.lift_on g (λ x, ⟦(⟨λ i, f i (x.1 i), x.2,
   λ i, or.cases_on (x.3 i) or.inl $ λ H, or.inr $ by rw [H, hf]⟩ : pre ι β₂)⟧) $ λ x y H,
@@ -81,6 +89,20 @@ quotient.sound $ λ i, by simp only [H i]
   (f : Π i, β₁ i → β₂ i) (hf : ∀ i, f i 0 = 0) (g : Π₀ i, β₁ i) (i : ι) :
   map_range f hf g i = f i (g i) :=
 quotient.induction_on g $ λ x, rfl
+
+@[simp] lemma map_range_id (h : ∀ i, id (0 : β₁ i) = 0 := λ i, rfl) (g : Π₀ (i : ι), β₁ i) :
+  map_range (λ i, (id : β₁ i → β₁ i)) h g = g :=
+by { ext, simp only [map_range_apply, id.def] }
+
+lemma map_range_comp (f : Π i, β₁ i → β₂ i) (f₂ : Π i, β i → β₁ i)
+  (hf : ∀ i, f i 0 = 0) (hf₂ : ∀ i, f₂ i 0 = 0) (h : ∀ i, (f i ∘ f₂ i) 0 = 0)
+  (g : Π₀ (i : ι), β i) :
+  map_range (λ i, f i ∘ f₂ i) h g = map_range f hf (map_range f₂ hf₂ g) :=
+by { ext, simp only [map_range_apply] }
+
+@[simp] lemma map_range_zero (f : Π i, β₁ i → β₂ i) (hf : ∀ i, f i 0 = 0) :
+  map_range f hf (0 : Π₀ i, β₁ i) = 0 :=
+by { ext, simp only [map_range_apply, coe_zero, pi.zero_apply, hf] }
 
 /-- Let `f i` be a binary operation `β₁ i → β₂ i → β i` such that `f i 0 0 = 0`.
 Then `zip_with f hf` is a binary operation `Π₀ i, β₁ i → Π₀ i, β₂ i → Π₀ i, β i`. -/
@@ -619,7 +641,6 @@ support_mk_subset
 
 section map_range_and_zip_with
 
-variables {β₁ : ι → Type v₁} {β₂ : ι → Type v₂}
 variables [Π i, has_zero (β₁ i)] [Π i, has_zero (β₂ i)]
 
 lemma map_range_def [Π i (x : β₁ i), decidable (x ≠ 0)]
@@ -1037,6 +1058,65 @@ lemma subtype_domain_finsupp_sum {δ : γ → Type x} [decidable_eq γ]
 subtype_domain_sum
 
 end prod_and_sum
+
+/-! ### Bundled versions of `dfinsupp.map_range`
+
+The names should match the equivalent bundled `finsupp.map_range` definitions.
+-/
+
+section map_range
+
+variables [Π i, add_zero_class (β i)] [Π i, add_zero_class (β₁ i)] [Π i, add_zero_class (β₂ i)]
+
+lemma map_range_add (f : Π i, β₁ i → β₂ i) (hf : ∀ i, f i 0 = 0)
+  (hf' : ∀ i x y, f i (x + y) = f i x + f i y) (g₁ g₂ : Π₀ i, β₁ i):
+  map_range f hf (g₁ + g₂) = map_range f hf g₁ + map_range f hf g₂ :=
+begin
+  ext,
+  simp only [map_range_apply f, coe_add, pi.add_apply, hf']
+end
+
+/-- `dfinsupp.map_range` as an `add_monoid_hom`. -/
+@[simps apply]
+def map_range.add_monoid_hom (f : Π i, β₁ i →+ β₂ i) : (Π₀ i, β₁ i) →+ (Π₀ i, β₂ i) :=
+{ to_fun := map_range (λ i x, f i x) (λ i, (f i).map_zero),
+  map_zero' := map_range_zero _ _,
+  map_add' := map_range_add _ _ (λ i, (f i).map_add) }
+
+@[simp]
+lemma map_range.add_monoid_hom_id :
+  map_range.add_monoid_hom (λ i, add_monoid_hom.id (β₂ i)) = add_monoid_hom.id _ :=
+add_monoid_hom.ext map_range_id
+
+lemma map_range.add_monoid_hom_comp (f : Π i, β₁ i →+ β₂ i) (f₂ : Π i, β i →+ β₁ i):
+  map_range.add_monoid_hom (λ i, (f i).comp (f₂ i)) =
+    (map_range.add_monoid_hom f).comp (map_range.add_monoid_hom f₂) :=
+add_monoid_hom.ext $ map_range_comp (λ i x, f i x) (λ i x, f₂ i x) _ _ _
+
+/-- `dfinsupp.map_range.add_monoid_hom` as an `add_equiv`. -/
+@[simps apply]
+def map_range.add_equiv (e : Π i, β₁ i ≃+ β₂ i) : (Π₀ i, β₁ i) ≃+ (Π₀ i, β₂ i) :=
+{ to_fun := map_range (λ i x, e i x) (λ i, (e i).map_zero),
+  inv_fun := map_range (λ i x, (e i).symm x) (λ i, (e i).symm.map_zero),
+  left_inv := λ x, by rw ←map_range_comp; { simp_rw add_equiv.symm_comp_self, simp },
+  right_inv := λ x, by rw ←map_range_comp; { simp_rw add_equiv.self_comp_symm, simp },
+  .. map_range.add_monoid_hom (λ i, (e i).to_add_monoid_hom) }
+
+@[simp]
+lemma map_range.add_equiv_refl :
+  (map_range.add_equiv $ λ i, add_equiv.refl (β₁ i)) = add_equiv.refl _ :=
+add_equiv.ext map_range_id
+
+lemma map_range.add_equiv_trans (f : Π i, β i ≃+ β₁ i) (f₂ : Π i, β₁ i ≃+ β₂ i):
+  map_range.add_equiv (λ i, (f i).trans (f₂ i)) =
+    (map_range.add_equiv f).trans (map_range.add_equiv f₂) :=
+add_equiv.ext $ map_range_comp (λ i x, f₂ i x) (λ i x, f i x) _ _ _
+
+@[simp]
+lemma map_range.add_equiv_symm (e : Π i, β₁ i ≃+ β₂ i) :
+  (map_range.add_equiv e).symm = map_range.add_equiv (λ i, (e i).symm) := rfl
+
+end map_range
 
 end dfinsupp
 

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -1065,6 +1065,7 @@ The names should match the equivalent bundled `finsupp.map_range` definitions.
 -/
 
 section map_range
+omit dec
 
 variables [Π i, add_zero_class (β i)] [Π i, add_zero_class (β₁ i)] [Π i, add_zero_class (β₂ i)]
 

--- a/src/linear_algebra/dfinsupp.lean
+++ b/src/linear_algebra/dfinsupp.lean
@@ -141,7 +141,7 @@ variables [Π i, add_comm_monoid (β i)] [Π i, add_comm_monoid (β₁ i)] [Π i
 variables [Π i, semimodule R (β i)] [Π i, semimodule R (β₁ i)] [Π i, semimodule R (β₂ i)]
 
 lemma map_range_smul (f : Π i, β₁ i → β₂ i) (hf : ∀ i, f i 0 = 0)
-  (hf' : ∀ i r x, f i (r • x) = r • f i y) (r : R) (g : Π₀ i, β₁ i):
+  (r : R) (hf' : ∀ i x, f i (r • x) = r • f i x) (g : Π₀ i, β₁ i):
   map_range f hf (r • g) = r • map_range f hf g :=
 begin
   ext,
@@ -152,12 +152,12 @@ end
 @[simps apply]
 def map_range.linear_map (f : Π i, β₁ i →ₗ[R] β₂ i) : (Π₀ i, β₁ i) →ₗ[R] (Π₀ i, β₂ i) :=
 { to_fun := map_range (λ i x, f i x) (λ i, (f i).map_zero),
-  map_smul' := map_range_smul _ _ (λ i, (f i).map_smul),
-  .. map_range.linear_map (λ i, (f i).to_add_monoid_hom) }
+  map_smul' := λ r, map_range_smul _ _ _ (λ i, (f i).map_smul r),
+  .. map_range.add_monoid_hom (λ i, (f i).to_add_monoid_hom) }
 
 @[simp]
 lemma map_range.linear_map_id :
-  map_range.linear_map (λ i, linear_map.id (β₂ i)) = linear_map.id _ :=
+  map_range.linear_map (λ i, (linear_map.id : (β₂ i) →ₗ[R] _)) = linear_map.id :=
 linear_map.ext map_range_id
 
 lemma map_range.linear_map_comp (f : Π i, β₁ i →ₗ[R] β₂ i) (f₂ : Π i, β i →ₗ[R] β₁ i):
@@ -170,13 +170,12 @@ linear_map.ext $ map_range_comp (λ i x, f i x) (λ i x, f₂ i x) _ _ _
 def map_range.linear_equiv (e : Π i, β₁ i ≃ₗ[R] β₂ i) : (Π₀ i, β₁ i) ≃ₗ[R] (Π₀ i, β₂ i) :=
 { to_fun := map_range (λ i x, e i x) (λ i, (e i).map_zero),
   inv_fun := map_range (λ i x, (e i).symm x) (λ i, (e i).symm.map_zero),
-  left_inv := λ x, by rw ←map_range_comp; { simp_rw linear_equiv.symm_comp_self, simp },
-  right_inv := λ x, by rw ←map_range_comp; { simp_rw linear_equiv.self_comp_symm, simp },
+  .. map_range.add_equiv (λ i, (e i).to_add_equiv),
   .. map_range.linear_map (λ i, (e i).to_linear_map) }
 
 @[simp]
 lemma map_range.linear_equiv_refl :
-  (map_range.linear_equiv $ λ i, linear_equiv.refl (β₁ i)) = linear_equiv.refl _ :=
+  (map_range.linear_equiv $ λ i, linear_equiv.refl R (β₁ i)) = linear_equiv.refl _ _ :=
 linear_equiv.ext map_range_id
 
 lemma map_range.linear_equiv_trans (f : Π i, β i ≃ₗ[R] β₁ i) (f₂ : Π i, β₁ i ≃ₗ[R] β₂ i):


### PR DESCRIPTION
This adds the bundled homs:

* `dfinsupp.map_range.add_monoid_hom`
* `dfinsupp.map_range.add_equiv`
* `dfinsupp.map_range.linear_map`
* `dfinsupp.map_range.linear_equiv`

and lemmas

* `dfinsupp.map_range_zero`
* `dfinsupp.map_range_add`
* `dfinsupp.map_range_smul`

For which we already have identical lemmas for `finsupp`.

Split from #7217, since `map_range.add_equiv` can be used in conjunction with `submonoid.mrange_restrict`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
