### PR TITLE
[Merged by Bors] - feat(algebra/group_power/basic): `pow_ne_zero_iff` and `pow_pos_iff`

### DIFF
--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -462,6 +462,10 @@ begin
   exact zero_pow hn,
 end
 
+lemma pow_ne_zero_iff [monoid_with_zero R] [no_zero_divisors R] {a : R} {n : ℕ} (hn : 0 < n) :
+  a ^ n ≠ 0 ↔ a ≠ 0 :=
+by rwa [not_iff_not, pow_eq_zero_iff]
+
 @[field_simps] theorem pow_ne_zero [monoid_with_zero R] [no_zero_divisors R]
   {a : R} (n : ℕ) (h : a ≠ 0) : a ^ n ≠ 0 :=
 mt pow_eq_zero h

--- a/src/algebra/linear_ordered_comm_group_with_zero.lean
+++ b/src/algebra/linear_ordered_comm_group_with_zero.lean
@@ -132,6 +132,9 @@ lemma zero_lt_iff : 0 < a ↔ a ≠ 0 :=
 lemma ne_zero_of_lt (h : b < a) : a ≠ 0 :=
 λ h1, not_lt_zero' $ show b < 0, from h1 ▸ h
 
+lemma pow_pos_iff [no_zero_divisors α] {n : ℕ} (hn : 0 < n) : 0 < a ^ n ↔ 0 < a :=
+by simp_rw [zero_lt_iff, pow_ne_zero_iff hn]
+
 instance : linear_ordered_add_comm_monoid_with_top (additive (order_dual α)) :=
 { top := (0 : α),
   top_add' := λ a, (zero_mul a : (0 : α) * a = 0),


### PR DESCRIPTION
For natural `n > 0`, 
- `a ^ n ≠ 0 ↔ a ≠ 0`
- `0 < a ^ n ↔ 0 < a` where `a` is a member of a `linear_ordered_comm_monoid_with_zero`

---
I noticed that these were missing. Please let me know if I can further generalize their assumptions.
