### PR TITLE
[Merged by Bors] - feat(data/fin): help `simp` reduce expressions containing `fin.succ_above`

### DIFF
--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -1042,15 +1042,15 @@ succ_succ_above_zero 0
 simplification using `succ_above_zero` or `succ_succ_above_zero`. -/
 @[simp] lemma succ_succ_above_one {n : ℕ} (i : fin (n + 2)) :
   (i.succ).succ_above 1 = (i.succ_above 0).succ :=
-by rw [← succ_zero_eq_one, succ_succ_above_succ]
+succ_succ_above_succ i 0
 
 @[simp] lemma one_succ_above_succ {n : ℕ} (j : fin n) :
   (1 : fin (n + 2)).succ_above j.succ = j.succ.succ :=
-by rw [← succ_zero_eq_one, succ_succ_above_succ 0 j, succ_above_zero]
+succ_succ_above_succ 0 j
 
 @[simp] lemma one_succ_above_one {n : ℕ} :
   (1 : fin (n + 3)).succ_above 1 = 2 :=
-succ_above_above _ _ (le_refl 1)
+succ_succ_above_succ 0 0
 
 end succ_above
 

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -1038,6 +1038,8 @@ succ_above_below _ _ (succ_pos _)
   (1 : fin (n + 2)).succ_above 0 = 0 :=
 succ_succ_above_zero 0
 
+/-- By moving `succ` to the outside of this expression, we create opportunities for further simplification
+using `succ_above_zero` or `succ_succ_above_zero`. -/
 @[simp] lemma succ_succ_above_one {n : ℕ} (i : fin (n + 2)) :
   (i.succ).succ_above 1 = (i.succ_above 0).succ :=
 by rw [← succ_zero_eq_one, succ_succ_above_succ]

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -1038,8 +1038,8 @@ succ_above_below _ _ (succ_pos _)
   (1 : fin (n + 2)).succ_above 0 = 0 :=
 succ_succ_above_zero 0
 
-/-- By moving `succ` to the outside of this expression, we create opportunities for further simplification
-using `succ_above_zero` or `succ_succ_above_zero`. -/
+/-- By moving `succ` to the outside of this expression, we create opportunities for further
+simplification using `succ_above_zero` or `succ_succ_above_zero`. -/
 @[simp] lemma succ_succ_above_one {n : ℕ} (i : fin (n + 2)) :
   (i.succ).succ_above 1 = (i.succ_above 0).succ :=
 by rw [← succ_zero_eq_one, succ_succ_above_succ]

--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -1022,6 +1022,34 @@ lemma succ_above_left_inj {x y : fin (n + 1)} :
   x.succ_above = y.succ_above ↔ x = y :=
 succ_above_left_injective.eq_iff
 
+@[simp] lemma succ_succ_above_zero {n : ℕ} (i : fin (n + 1)) :
+  (i.succ).succ_above 0 = 0 :=
+succ_above_below _ _ (succ_pos _)
+
+@[simp] lemma succ_succ_above_succ {n : ℕ} (i : fin (n + 1)) (j : fin n) :
+  (i.succ).succ_above j.succ = (i.succ_above j).succ :=
+(lt_or_ge j.cast_succ i).elim
+  (λ h, have h' : j.succ.cast_succ < i.succ, by simpa [lt_iff_coe_lt_coe] using h,
+        by { ext, simp [succ_above_below _ _ h, succ_above_below _ _ h'] })
+  (λ h, have h' : i.succ ≤ j.succ.cast_succ, by simpa [le_iff_coe_le_coe] using h,
+        by { ext, simp [succ_above_above _ _ h, succ_above_above _ _ h'] })
+
+@[simp] lemma one_succ_above_zero {n : ℕ} :
+  (1 : fin (n + 2)).succ_above 0 = 0 :=
+succ_succ_above_zero 0
+
+@[simp] lemma succ_succ_above_one {n : ℕ} (i : fin (n + 2)) :
+  (i.succ).succ_above 1 = (i.succ_above 0).succ :=
+by rw [← succ_zero_eq_one, succ_succ_above_succ]
+
+@[simp] lemma one_succ_above_succ {n : ℕ} (j : fin n) :
+  (1 : fin (n + 2)).succ_above j.succ = j.succ.succ :=
+by rw [← succ_zero_eq_one, succ_succ_above_succ 0 j, succ_above_zero]
+
+@[simp] lemma one_succ_above_one {n : ℕ} :
+  (1 : fin (n + 3)).succ_above 1 = 2 :=
+succ_above_above _ _ (le_refl 1)
+
 end succ_above
 
 section pred_above


### PR DESCRIPTION
With these `simp` lemmas, in combination with #6897, `simp; ring` can almost automatically compute the determinant of matrices like `![![a, b], ![c, d]]`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
