### PR TITLE
[Merged by Bors] - feat(data/matrix/basic): add lemma for assoc of mul_vec w.r.t. smul

### DIFF
--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -730,10 +730,7 @@ by { ext, apply dot_product_neg }
 
 lemma smul_mul_vec_assoc (A : matrix m n α) (b : n → α) (a : α) :
   (a • A).mul_vec b = a • (A.mul_vec b) :=
-begin
-  ext i, change dot_product ((a • A) i) b = _,
-  simp only [mul_vec, smul_eq_mul, pi.smul_apply, smul_dot_product],
-end
+by { ext, apply smul_dot_product }
 
 end ring
 
@@ -743,13 +740,7 @@ variables [comm_ring α]
 
 lemma mul_vec_smul_assoc (A : matrix m n α) (b : n → α) (a : α) :
   A.mul_vec (a • b) = a • (A.mul_vec b) :=
-begin
-  ext i,
-  change dot_product (A i) (a • b) = _,
-  rw [← smul_mul_vec_assoc A b a, dot_product_comm],
-  change _ = dot_product ((a • A) i) b,
-  simp only [dot_product_comm, dot_product_smul, pi.smul_apply],
-end
+by { ext, apply dot_product_smul }
 
 end comm_ring
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -728,7 +728,7 @@ by { ext, apply neg_dot_product }
 lemma mul_vec_neg (v : n → α) (A : matrix m n α) : mul_vec A (-v) = - mul_vec A v :=
 by { ext, apply dot_product_neg }
 
-lemma smul_mul_vec_assoc (A : matrix n n α) (b : n → α) (a : α) :
+lemma smul_mul_vec_assoc (A : matrix m n α) (b : n → α) (a : α) :
   (a • A).mul_vec b = a • (A.mul_vec b) :=
 begin
   ext i, change dot_product ((a • A) i) b = _,
@@ -736,6 +736,22 @@ begin
 end
 
 end ring
+
+section comm_ring
+
+variables [comm_ring α]
+
+lemma mul_vec_smul_assoc (A : matrix m n α) (b : n → α) (a : α) :
+  A.mul_vec (a • b) = a • (A.mul_vec b) :=
+begin
+  ext i,
+  change dot_product (A i) (a • b) = _,
+  rw [← smul_mul_vec_assoc A b a, dot_product_comm],
+  change _ = dot_product ((a • A) i) b,
+  simp only [dot_product_comm, dot_product_smul, pi.smul_apply],
+end
+
+end comm_ring
 
 section transpose
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -734,15 +734,15 @@ by { ext, apply smul_dot_product }
 
 end ring
 
-section comm_ring
+section comm_semiring
 
-variables [comm_ring α]
+variables [comm_semiring α]
 
 lemma mul_vec_smul_assoc (A : matrix m n α) (b : n → α) (a : α) :
   A.mul_vec (a • b) = a • (A.mul_vec b) :=
 by { ext, apply dot_product_smul }
 
-end comm_ring
+end comm_semiring
 
 section transpose
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -732,17 +732,29 @@ lemma smul_mul_vec_assoc (A : matrix m n α) (b : n → α) (a : α) :
   (a • A).mul_vec b = a • (A.mul_vec b) :=
 by { ext, apply smul_dot_product }
 
+lemma mul_vec_vec_mul (A : matrix m n α) (v : m → α) (w : n → α) :
+  dot_product v (mul_vec A w) = dot_product (vec_mul v A) w :=
+begin
+  have key : vec_mul v A = λ j, dot_product v (λ i, A i j),
+  {ext, unfold vec_mul},
+  rw key,
+  rw dot_product_assoc v A w,
+  have key : mul_vec A w = λ i, dot_product (A i) w,
+  {ext, unfold mul_vec},
+  rw key,
+end
+
 end ring
 
-section comm_semiring
+section semiring
 
-variables [comm_semiring α]
+variables [semiring α]
 
 lemma mul_vec_smul_assoc (A : matrix m n α) (b : n → α) (a : α) :
   A.mul_vec (a • b) = a • (A.mul_vec b) :=
 by { ext, apply dot_product_smul }
 
-end comm_semiring
+end semiring
 
 section transpose
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -640,6 +640,10 @@ lemma vec_mul_vec_eq (w : m → α) (v : n → α) :
   vec_mul_vec w v = (col w) ⬝ (row v) :=
 by { ext i j, simp [vec_mul_vec, mul_apply], refl }
 
+lemma smul_mul_vec_assoc (A : matrix m n α) (b : n → α) (a : α) :
+  (a • A).mul_vec b = a • (A.mul_vec b) :=
+by { ext, apply smul_dot_product }
+
 variables [decidable_eq m] [decidable_eq n]
 
 /--
@@ -728,33 +732,17 @@ by { ext, apply neg_dot_product }
 lemma mul_vec_neg (v : n → α) (A : matrix m n α) : mul_vec A (-v) = - mul_vec A v :=
 by { ext, apply dot_product_neg }
 
-lemma smul_mul_vec_assoc (A : matrix m n α) (b : n → α) (a : α) :
-  (a • A).mul_vec b = a • (A.mul_vec b) :=
-by { ext, apply smul_dot_product }
-
-lemma mul_vec_vec_mul (A : matrix m n α) (v : m → α) (w : n → α) :
-  dot_product v (mul_vec A w) = dot_product (vec_mul v A) w :=
-begin
-  have key : vec_mul v A = λ j, dot_product v (λ i, A i j),
-  {ext, unfold vec_mul},
-  rw key,
-  rw dot_product_assoc v A w,
-  have key : mul_vec A w = λ i, dot_product (A i) w,
-  {ext, unfold mul_vec},
-  rw key,
-end
-
 end ring
 
-section semiring
+section comm_semiring
 
-variables [semiring α]
+variables [comm_semiring α]
 
 lemma mul_vec_smul_assoc (A : matrix m n α) (b : n → α) (a : α) :
   A.mul_vec (a • b) = a • (A.mul_vec b) :=
 by { ext, apply dot_product_smul }
 
-end semiring
+end comm_semiring
 
 section transpose
 


### PR DESCRIPTION

Add a new lemma for the other direction of smul_mul_vec_assoc, which works on commutative rings.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
