### PR TITLE
[Merged by Bors] - refactor(ring_theory/polynomial/content): Define is_primitive more generally

### DIFF
--- a/src/ring_theory/eisenstein_criterion.lean
+++ b/src/ring_theory/eisenstein_criterion.lean
@@ -3,9 +3,6 @@ Copyright (c) 2020 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import ring_theory.ideal.operations
-import data.polynomial.ring_division
-import tactic.apply_fun
 import ring_theory.prime
 import ring_theory.polynomial.content
 /-!

--- a/src/ring_theory/eisenstein_criterion.lean
+++ b/src/ring_theory/eisenstein_criterion.lean
@@ -7,6 +7,7 @@ import ring_theory.ideal.operations
 import data.polynomial.ring_division
 import tactic.apply_fun
 import ring_theory.prime
+import ring_theory.polynomial.content
 /-!
 # Eisenstein's criterion
 
@@ -73,7 +74,7 @@ theorem irreducible_of_eisenstein_criterion {f : polynomial R} {P : ideal R} (hP
   (hfl : f.leading_coeff ∉ P)
   (hfP : ∀ n : ℕ, ↑n < degree f → f.coeff n ∈ P)
   (hfd0 : 0 < degree f) (h0 : f.coeff 0 ∉ P^2)
-  (hu : ∀ x : R, C x ∣ f → is_unit x) : irreducible f :=
+  (hu : f.is_primitive) : irreducible f :=
 have hf0 : f ≠ 0, from λ _, by simp only [*, not_true, submodule.zero_mem, coeff_zero] at *,
 have hf : f.map (mk P) = C (mk P (leading_coeff f)) * X ^ nat_degree f,
   from map_eq_C_mul_X_pow_of_forall_coeff_mem hfP hf0,

--- a/src/ring_theory/polynomial/content.lean
+++ b/src/ring_theory/polynomial/content.lean
@@ -33,7 +33,7 @@ section primitive
 
 variables {R : Type*} [comm_semiring R]
 
-/-- A polynomial over a GCD domain is primitive when the `gcd` of its coefficients is 1 -/
+/-- A polynomial is primitive when the only constant polynomials dividing it are units -/
 def is_primitive (p : polynomial R) : Prop :=
 ∀ (r : R), C r ∣ p → is_unit r
 

--- a/src/ring_theory/polynomial/content.lean
+++ b/src/ring_theory/polynomial/content.lean
@@ -27,9 +27,40 @@ Let `p : polynomial R`.
 
 -/
 
+namespace polynomial
+
+section primitive
+
+variables {R : Type*} [comm_semiring R]
+
+/-- A polynomial over a GCD domain is primitive when the `gcd` of its coefficients is 1 -/
+def is_primitive (p : polynomial R) : Prop :=
+∀ (r : R), C r ∣ p → is_unit r
+
+lemma is_primitive_iff_is_unit_of_C_dvd {p : polynomial R} :
+  p.is_primitive ↔ ∀ (r : R), C r ∣ p → is_unit r :=
+iff.rfl
+
+@[simp]
+lemma is_primitive_one : is_primitive (1 : polynomial R) :=
+λ r h, is_unit_C.mp (is_unit_of_dvd_one (C r) h)
+
+lemma monic.is_primitive {p : polynomial R} (hp : p.monic) : p.is_primitive :=
+begin
+  rintros r ⟨q, h⟩,
+  exact is_unit_of_mul_eq_one r (q.coeff p.nat_degree) (by rwa [←coeff_C_mul, ←h]),
+end
+
+lemma is_primitive.ne_zero [nontrivial R] {p : polynomial R} (hp : p.is_primitive) : p ≠ 0 :=
+begin
+  rintro rfl,
+  exact (hp 0 (dvd_zero (C 0))).ne_zero rfl,
+end
+
+end primitive
+
 variables {R : Type*} [integral_domain R]
 
-namespace polynomial
 section gcd_monoid
 variable [gcd_monoid R]
 
@@ -170,13 +201,6 @@ end
 lemma C_content_dvd (p : polynomial R) : C p.content ∣ p :=
 dvd_content_iff_C_dvd.1 (dvd_refl _)
 
-/-- A polynomial over a GCD domain is primitive when the `gcd` of its coefficients is 1 -/
-def is_primitive (p : polynomial R) : Prop := ∀ (r : R), C r ∣ p → is_unit r
-
-lemma is_primitive_iff_is_unit_of_C_dvd {p : polynomial R} :
-  p.is_primitive ↔ ∀ (r : R), C r ∣ p → is_unit r :=
-iff.rfl
-
 lemma is_primitive_iff_content_eq_one {p : polynomial R} : p.is_primitive ↔ p.content = 1 :=
 begin
   rw [←normalize_content, normalize_eq_one, is_primitive],
@@ -186,21 +210,6 @@ end
 
 lemma is_primitive.content_eq_one {p : polynomial R} (hp : p.is_primitive) : p.content = 1 :=
 is_primitive_iff_content_eq_one.mp hp
-
-@[simp]
-lemma is_primitive_one : is_primitive (1 : polynomial R) :=
-by rw [is_primitive_iff_content_eq_one, content_one]
-
-lemma monic.is_primitive {p : polynomial R} (hp : p.monic) : p.is_primitive :=
-by rw [is_primitive_iff_content_eq_one, content_eq_gcd_leading_coeff_content_erase_lead,
-  hp.leading_coeff, gcd_one_left]
-
-lemma is_primitive.ne_zero {p : polynomial R} (hp : p.is_primitive) : p ≠ 0 :=
-begin
-  rintro rfl,
-  rw [is_primitive_iff_content_eq_one, content_zero] at hp,
-  exact zero_ne_one hp,
-end
 
 open_locale classical
 noncomputable theory

--- a/src/ring_theory/polynomial/gauss_lemma.lean
+++ b/src/ring_theory/polynomial/gauss_lemma.lean
@@ -41,7 +41,8 @@ begin
   rcases is_unit_iff.1 h with ⟨_, ⟨u, rfl⟩, hu⟩,
   have hdeg := degree_C u.ne_zero,
   rw [hu, degree_map' hinj] at hdeg,
-  rw [eq_C_of_degree_eq_zero hdeg, is_primitive, content_C, normalize_eq_one] at hf,
+  rw [eq_C_of_degree_eq_zero hdeg, is_primitive_iff_content_eq_one,
+      content_C, normalize_eq_one] at hf,
   rwa [eq_C_of_degree_eq_zero hdeg, is_unit_C],
 end
 

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -869,7 +869,7 @@ begin
   have PQprim : is_primitive (P * Q) := Pmonic.is_primitive.mul Qmonic.is_primitive,
   have prod : P * Q ∣ X ^ n - 1,
   { apply (is_primitive.int.dvd_iff_map_cast_dvd_map_cast (P * Q) (X ^ n - 1) PQprim
-      ((monic_X_pow_sub_C 1 (ne_of_lt hpos).symm).is_primitive)).2,
+      (monic_X_pow_sub_C (1 : ℤ) (ne_of_gt hpos)).is_primitive).mpr,
     rw [map_mul],
     refine is_coprime.mul_dvd _ _ _,
     { have aux := is_primitive.int.irreducible_iff_irreducible_map_cast Pmonic.is_primitive,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -868,9 +868,8 @@ begin
     minpoly.irreducible ((h.pow_of_prime hprime.1 hdiv).is_integral hpos),
   have PQprim : is_primitive (P * Q) := Pmonic.is_primitive.mul Qmonic.is_primitive,
   have prod : P * Q ∣ X ^ n - 1,
-  { apply (is_primitive.int.dvd_iff_map_cast_dvd_map_cast (P * Q) (X ^ n - 1) PQprim
-      (monic_X_pow_sub_C (1 : ℤ) (ne_of_gt hpos)).is_primitive).mpr,
-    rw [map_mul],
+  { rw [(is_primitive.int.dvd_iff_map_cast_dvd_map_cast (P * Q) (X ^ n - 1) PQprim
+      (monic_X_pow_sub_C (1 : ℤ) (ne_of_gt hpos)).is_primitive), map_mul],
     refine is_coprime.mul_dvd _ _ _,
     { have aux := is_primitive.int.irreducible_iff_irreducible_map_cast Pmonic.is_primitive,
       refine (dvd_or_coprime _ _ (aux.1 Pirr)).resolve_left _,


### PR DESCRIPTION
The lemma `is_primitive_iff_is_unit_of_C_dvd` shows that `polynomial.is_primitive` can be defined without the `gcd_monoid` assumption.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
