### PR TITLE
[Merged by Bors] - feat(algebra/opposite): inversion is a mul_equiv to the opposite group

### DIFF
--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -274,7 +274,7 @@ end opposite
 
 open opposite
 
-/- Inversion on a group is a `mul_equiv` to the opposite group. When `G` is commutative, there is
+/-<span class="x x-first x-last">-</span> Inversion on a group is a `mul_equiv` to the opposite group. When `G` is commutative, there is
 `mul_equiv.inv`. -/
 @[simps {fully_applied := ff}]
 def mul_equiv.inv' (G : Type*) [group G] : G ≃* Gᵒᵖ :=

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -274,13 +274,29 @@ end opposite
 
 open opposite
 
+/- Inversion on a group is a `mul_equiv` to the opposite group. When `G` is commutative, there is
+`mul_equiv.inv`. -/
+@[simps {fully_applied := ff}]
+def mul_equiv.inv' (G : Type*) [group G] : G ≃* Gᵒᵖ :=
+{ to_fun := opposite.op ∘ has_inv.inv,
+  inv_fun := has_inv.inv ∘ opposite.unop,
+  map_mul' := λ x y, unop_injective $ mul_inv_rev x y,
+  ..(equiv.inv G).trans equiv_to_opposite}
+
+/-- A monoid homomorphism `f : R →* S` such that `f x` commutes with `f y` for all `x, y` defines
+a monoid homomorphism to `Sᵒᵖ`. -/
+@[simps {fully_applied := ff}]
+def monoid_hom.to_opposite {R S : Type*} [mul_one_class R] [mul_one_class S] (f : R →* S)
+  (hf : ∀ x y, commute (f x) (f y)) : R →* Sᵒᵖ :=
+{ to_fun := opposite.op ∘ f,
+  map_one' := congr_arg op f.map_one,
+  map_mul' := λ x y, by simp [(hf x y).eq] }
+
 /-- A ring homomorphism `f : R →+* S` such that `f x` commutes with `f y` for all `x, y` defines
 a ring homomorphism to `Sᵒᵖ`. -/
+@[simps {fully_applied := ff}]
 def ring_hom.to_opposite {R S : Type*} [semiring R] [semiring S] (f : R →+* S)
   (hf : ∀ x y, commute (f x) (f y)) : R →+* Sᵒᵖ :=
-{ map_one' := congr_arg op f.map_one,
-  map_mul' := λ x y, by simp [(hf x y).eq],
-  .. (opposite.op_add_equiv : S ≃+ Sᵒᵖ).to_add_monoid_hom.comp ↑f }
-
-@[simp] lemma ring_hom.coe_to_opposite {R S : Type*} [semiring R] [semiring S] (f : R →+* S)
-  (hf : ∀ x y, commute (f x) (f y)) : ⇑(f.to_opposite hf) = op ∘ f := rfl
+{ to_fun := opposite.op ∘ f,
+  .. ((opposite.op_add_equiv : S ≃+ Sᵒᵖ).to_add_monoid_hom.comp ↑f : R →+ Sᵒᵖ),
+  .. f.to_monoid_hom.to_opposite hf }

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -274,7 +274,7 @@ end opposite
 
 open opposite
 
-/-<span class="x x-first x-last">-</span> Inversion on a group is a `mul_equiv` to the opposite group. When `G` is commutative, there is
+/-- Inversion on a group is a `mul_equiv` to the opposite group. When `G` is commutative, there is
 `mul_equiv.inv`. -/
 @[simps {fully_applied := ff}]
 def mul_equiv.inv' (G : Type*) [group G] : G ≃* Gᵒᵖ :=

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -490,6 +490,15 @@ end group_with_zero
 
 end equiv
 
+/-- When the group is commutative, `equiv.inv` is a `mul_equiv`. There is a variant of this
+`mul_equiv.inv' G : G ≃* Gᵒᵖ` for the non-commutative case. -/
+@[to_additive "When the `add_group` is commutative, `equiv.neg` is an `add_equiv`."]
+def mul_equiv.inv (G : Type*) [comm_group G] : G ≃* G :=
+{ to_fun := has_inv.inv,
+  inv_fun := has_inv.inv,
+  map_mul' := mul_inv,
+  ..equiv.inv G}
+
 section type_tags
 
 /-- Reinterpret `G ≃+ H` as `multiplicative G ≃* multiplicative H`. -/


### PR DESCRIPTION
This also splits out `monoid_hom.to_opposite` from `ring_hom.to_opposite`, and adds `add_equiv.neg` and `mul_equiv.inv` for the case when the `(add_)group` is commutative.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
