### PR TITLE
[Merged by Bors] - feat(logic/function/basic): function.involutive.eq_iff

### DIFF
--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -571,8 +571,9 @@ protected lemma ite_not (P : Prop) [decidable P] (x : α) :
   f (ite P x (f x)) = ite (¬ P) x (f x) :=
 by rw [apply_ite f, h, ite_not]
 
+/-- An involution commutes across an equality. Compare to `function.injective.eq_iff`. -/
 protected lemma eq_iff {x y : α} : f x = y ↔ x = f y :=
-⟨λ H, h x ▸ congr_arg f H, λ H, h y ▸ congr_arg f H⟩
+h.injective.eq_iff' (h y)
 
 end involutive
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -571,6 +571,9 @@ protected lemma ite_not (P : Prop) [decidable P] (x : α) :
   f (ite P x (f x)) = ite (¬ P) x (f x) :=
 by rw [apply_ite f, h, ite_not]
 
+protected lemma eq_iff {x y : α} : f x = y ↔ x = f y :=
+⟨λ H, h x ▸ congr_arg f H, λ H, h y ▸ congr_arg f H⟩
+
 end involutive
 
 /-- The property of a binary function `f : α → β → γ` being injective.


### PR DESCRIPTION
The lemma name matches the brevity of `function.injective.eq_iff`.
The fact the definitions differ isn't important, as both are accessible from `hf : involutive f` as `hf.eq_iff` and `hf.injective.eq_iff`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
