### PR TITLE
[Merged by Bors] - chore(geometry/manifold/instances/circle): provide instance

### DIFF
--- a/src/geometry/manifold/instances/circle.lean
+++ b/src/geometry/manifold/instances/circle.lean
@@ -76,6 +76,9 @@ instance : topological_group circle :=
 follows by definition from the corresponding result for `metric.sphere`. -/
 instance : charted_space (euclidean_space ℝ (fin 1)) circle := metric.sphere.charted_space
 
+instance : smooth_manifold_with_corners (𝓡 1) circle :=
+metric.sphere.smooth_manifold_with_corners
+
 /-- The unit circle in `ℂ` is a Lie group. -/
 instance : lie_group (𝓡 1) circle :=
 { smooth_mul := begin
@@ -85,10 +88,7 @@ instance : lie_group (𝓡 1) circle :=
     have h₂ : times_cont_mdiff (𝓘(ℝ, ℂ).prod 𝓘(ℝ, ℂ)) 𝓘(ℝ, ℂ) ∞ (λ (z : ℂ × ℂ), z.fst * z.snd),
     { rw times_cont_mdiff_iff,
       exact ⟨continuous_mul, λ x y, (times_cont_diff_mul.restrict_scalars ℝ).times_cont_diff_on⟩ },
-    convert (h₂.comp h₁).cod_restrict_sphere _,
-    convert smooth_manifold_with_corners.prod circle circle,
-    { exact metric.sphere.smooth_manifold_with_corners },
-    { exact metric.sphere.smooth_manifold_with_corners }
+    exact (h₂.comp h₁).cod_restrict_sphere _,
   end,
   smooth_inv := (complex.conj_clm.times_cont_diff.times_cont_mdiff.comp
     times_cont_mdiff_coe_sphere).cod_restrict_sphere _,


### PR DESCRIPTION
Assist typeclass inference when proving the circle is a Lie group, by providing an instance.

(Mostly cosmetic, but as this proof is going on a poster I wanted to streamline.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
