### PR TITLE
[Merged by Bors] - refactor(linear_algebra/eigenspace): cleanup proof

### DIFF
--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -322,6 +322,7 @@ end is_linear_map
 abbreviation module.End (R : Type u) (M : Type v)
   [semiring R] [add_comm_monoid M] [semimodule R M] := M →ₗ[R] M
 
+
 /-- Reinterpret an additive homomorphism as a `ℤ`-linear map. -/
 def add_monoid_hom.to_int_linear_map [add_comm_group M] [add_comm_group M₂] (f : M →+ M₂) :
   M →ₗ[ℤ] M₂ :=

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -322,7 +322,6 @@ end is_linear_map
 abbreviation module.End (R : Type u) (M : Type v)
   [semiring R] [add_comm_monoid M] [semimodule R M] := M →ₗ[R] M
 
-
 /-- Reinterpret an additive homomorphism as a `ℤ`-linear map. -/
 def add_monoid_hom.to_int_linear_map [add_comm_group M] [add_comm_group M₂] (f : M →+ M₂) :
   M →ₗ[ℤ] M₂ :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -358,6 +358,17 @@ instance linear_map_apply_is_add_group_hom (a : M) :
 
 end add_comm_group
 
+section nontrivial
+variables [semiring R] [add_comm_monoid M] [semimodule R M]
+
+instance [nontrivial M] : nontrivial (module.End R M) :=
+begin
+  obtain ⟨m, ne⟩ := (nontrivial_iff_exists_ne (0 : M)).mp infer_instance,
+  exact nontrivial_of_ne 1 0 (λ p, ne (linear_map.congr_fun p m)),
+end
+
+end nontrivial
+
 section has_scalar
 variables {S : Type*} [semiring R] [monoid S]
   [add_comm_monoid M] [add_comm_monoid M₂] [add_comm_monoid M₃]

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -247,16 +247,11 @@ lemma mul_eq_comp (f g : M →ₗ[R] M) : f * g = f.comp g := rfl
 lemma coe_one : ⇑(1 : M →ₗ[R] M) = _root_.id := rfl
 lemma coe_mul (f g : M →ₗ[R] M) : ⇑(f * g) = f ∘ g := rfl
 
-section nontrivial
-variables [semiring R] [add_comm_monoid M] [semimodule R M]
-
 instance [nontrivial M] : nontrivial (module.End R M) :=
 begin
   obtain ⟨m, ne⟩ := (nontrivial_iff_exists_ne (0 : M)).mp infer_instance,
   exact nontrivial_of_ne 1 0 (λ p, ne (linear_map.congr_fun p m)),
 end
-
-end nontrivial
 
 @[simp] theorem comp_zero : f.comp (0 : M₃ →ₗ[R] M) = 0 :=
 ext $ assume c, by rw [comp_apply, zero_apply, zero_apply, f.map_zero]

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -247,6 +247,17 @@ lemma mul_eq_comp (f g : M →ₗ[R] M) : f * g = f.comp g := rfl
 lemma coe_one : ⇑(1 : M →ₗ[R] M) = _root_.id := rfl
 lemma coe_mul (f g : M →ₗ[R] M) : ⇑(f * g) = f ∘ g := rfl
 
+section nontrivial
+variables [semiring R] [add_comm_monoid M] [semimodule R M]
+
+instance [nontrivial M] : nontrivial (module.End R M) :=
+begin
+  obtain ⟨m, ne⟩ := (nontrivial_iff_exists_ne (0 : M)).mp infer_instance,
+  exact nontrivial_of_ne 1 0 (λ p, ne (linear_map.congr_fun p m)),
+end
+
+end nontrivial
+
 @[simp] theorem comp_zero : f.comp (0 : M₃ →ₗ[R] M) = 0 :=
 ext $ assume c, by rw [comp_apply, zero_apply, zero_apply, f.map_zero]
 
@@ -357,17 +368,6 @@ instance linear_map_apply_is_add_group_hom (a : M) :
 { map_add := λ f g, linear_map.add_apply f g a }
 
 end add_comm_group
-
-section nontrivial
-variables [semiring R] [add_comm_monoid M] [semimodule R M]
-
-instance [nontrivial M] : nontrivial (module.End R M) :=
-begin
-  obtain ⟨m, ne⟩ := (nontrivial_iff_exists_ne (0 : M)).mp infer_instance,
-  exact nontrivial_of_ne 1 0 (λ p, ne (linear_map.congr_fun p m)),
-end
-
-end nontrivial
 
 section has_scalar
 variables {S : Type*} [semiring R] [monoid S]

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -159,21 +159,14 @@ end minpoly
 lemma exists_eigenvalue [is_alg_closed K] [finite_dimensional K V] [nontrivial V] (f : End K V) :
   ∃ (c : K), f.has_eigenvalue c :=
 begin
-  classical,
-  -- Choose a nonzero vector `v`.
-  obtain ⟨v, hv⟩ : ∃ v : V, v ≠ 0 := exists_ne (0 : V),
-  -- The infinitely many vectors v, f v, f (f v), ... cannot be linearly independent
-  -- because the vector space is finite dimensional.
-  have h_lin_dep : ¬ linear_independent K (λ n : ℕ, (f ^ n) v),
-  { apply not_linear_independent_of_infinite, },
-  -- Therefore, there must be a nonzero polynomial `p` such that `p(f) v = 0`.
+  -- Since the vector space is finite dimensional,
+  -- there must be a nonzero polynomial `p` such that `aeval f p = 0` and hence not invertible.
   obtain ⟨p, ⟨h_mon, h_eval_p⟩⟩ := f.is_integral,
   have h_eval_p_not_unit : aeval f p ∉ is_unit.submonoid (End K V),
-  { rw [is_unit.mem_submonoid_iff, linear_map.is_unit_iff, linear_map.ker_eq_bot'],
-    intro h,
-    apply hv (h v _),
-    rw [aeval_def, h_eval_p, linear_map.zero_apply] },
-  -- Hence, there must be a factor `q` of `p` such that `q(f)` is not invertible.
+  { rw ←aeval_def at h_eval_p,
+    rw [h_eval_p, is_unit.mem_submonoid_iff],
+    exact not_is_unit_zero, },
+  -- Hence, there must be a factor `q` of `p` such that `aeval f q` is not invertible.
   obtain ⟨q, hq_factor, hq_nonunit⟩ : ∃ q, q ∈ factors p ∧ ¬ is_unit (aeval f q),
   { simp only [←not_imp, (is_unit.mem_submonoid_iff _).symm],
     apply not_forall.1 (λ h, h_eval_p_not_unit
@@ -186,10 +179,10 @@ begin
   have h_deg_q : q.degree = 1 := is_alg_closed.degree_eq_one_of_irreducible _
     (ne_zero_of_mem_factors h_mon.ne_zero hq_factor)
     ((factors_spec p h_mon.ne_zero).1 q hq_factor),
-  -- Then the kernel of `q(f)` is an eigenspace.
+  -- Then the kernel of `aeval f q` is an eigenspace.
   have h_eigenspace: eigenspace f (-q.coeff 0 / q.leading_coeff) = (aeval f q).ker,
     from eigenspace_aeval_polynomial_degree_1 f q h_deg_q,
-  -- Since `q(f)` is not invertible, the kernel is not `⊥`, and thus there exists an eigenvalue.
+  -- Since `aeval f q` is not invertible, the kernel is not `⊥`, and thus there exists an eigenvalue.
   show ∃ (c : K), f.has_eigenvalue c,
   { use -q.coeff 0 / q.leading_coeff,
     rw [has_eigenvalue, h_eigenspace],

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -182,7 +182,8 @@ begin
   -- Then the kernel of `aeval f q` is an eigenspace.
   have h_eigenspace: eigenspace f (-q.coeff 0 / q.leading_coeff) = (aeval f q).ker,
     from eigenspace_aeval_polynomial_degree_1 f q h_deg_q,
-  -- Since `aeval f q` is not invertible, the kernel is not `⊥`, and thus there exists an eigenvalue.
+  -- Since `aeval f q` is not invertible, the kernel is not `⊥`,
+  -- and thus there exists an eigenvalue.
   show ∃ (c : K), f.has_eigenvalue c,
   { use -q.coeff 0 / q.leading_coeff,
     rw [has_eigenvalue, h_eigenspace],


### PR DESCRIPTION
At some point we changed the proof of `exists_eigenvalue` so that it used the fact that any endomorphism of a vector space is integral. This means we don't actually need to pick a nonzero vector at any point, but the proof had been left in a hybrid state, which I've now cleaned up.

In a later PR I'll generalise this proof so it proves Schur's lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
