### PR TITLE
[Merged by Bors] - chore(algebra/opposite): add missing `monoid_with_zero` instance

### DIFF
--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -138,10 +138,20 @@ instance [distrib α] : distrib (opposite α) :=
   right_distrib := λ x y z, unop_injective $ mul_add (unop z) (unop x) (unop y),
   .. opposite.has_add α, .. opposite.has_mul α }
 
+instance [mul_zero_class α] : mul_zero_class (opposite α) :=
+{ zero := 0,
+  mul := (*),
+  zero_mul := λ x, unop_injective $ mul_zero $ unop x,
+  mul_zero := λ x, unop_injective $ zero_mul $ unop x }
+
+instance [mul_zero_one_class α] : mul_zero_one_class (opposite α) :=
+{ .. opposite.mul_zero_class α, .. opposite.mul_one_class α }
+
+instance [monoid_with_zero α] : monoid_with_zero (opposite α) :=
+{ .. opposite.monoid α, .. opposite.mul_zero_one_class α }
+
 instance [semiring α] : semiring (opposite α) :=
-{ zero_mul := λ x, unop_injective $ mul_zero $ unop x,
-  mul_zero := λ x, unop_injective $ zero_mul $ unop x,
-  .. opposite.add_comm_monoid α, .. opposite.monoid α, .. opposite.distrib α }
+{ .. opposite.add_comm_monoid α, .. opposite.monoid_with_zero α, .. opposite.distrib α }
 
 instance [ring α] : ring (opposite α) :=
 { .. opposite.add_comm_group α, .. opposite.monoid α, .. opposite.semiring α }


### PR DESCRIPTION
Along with the `mul_zero_one_class` and `mul_zero_class` instances needed to build it

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
