### PR TITLE
[Merged by Bors] - chore(ring_theory/ideal/operations): golf and remove @

### DIFF
--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -230,15 +230,13 @@ end
   Remainder Theorem. It is bijective if the ideals `f i` are comaximal. -/
 def quotient_inf_to_pi_quotient (f : ι → ideal R) :
   (⨅ i, f i).quotient →+* Π i, (f i).quotient :=
-begin
-  refine quotient.lift (⨅ i, f i) _ _,
-  { convert @@pi.ring_hom (λ i, quotient (f i)) (λ i, ring.to_semiring) ring.to_semiring
-      (λ i, quotient.mk (f i)) },
-  { intros r hr,
+quotient.lift (⨅ i, f i)
+  (pi.ring_hom (λ i : ι, (quotient.mk (f i) : _))) $
+  λ r hr, begin
     rw submodule.mem_infi at hr,
     ext i,
-    exact quotient.eq_zero_iff_mem.2 (hr i) }
-end
+    exact quotient.eq_zero_iff_mem.2 (hr i)
+  end
 
 theorem quotient_inf_to_pi_quotient_bijective [fintype ι] {f : ι → ideal R}
   (hf : ∀ i j, i ≠ j → f i ⊔ f j = ⊤) :


### PR DESCRIPTION
Instead of passing all these arguments explicitly, it's sufficient to just use `(... : _)` to get the elaborator to do the right thing.
This makes this proof less fragile to argument changes to `pi.ring_hom`, such as the planned generalization to non-associative rings



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
