### PR TITLE
[Merged by Bors] - chore(algebra/category): remove duplicated proofs

### DIFF
--- a/src/algebra/category/Module/basic.lean
+++ b/src/algebra/category/Module/basic.lean
@@ -229,29 +229,6 @@ instance : preadditive (Module.{v} R) :=
 
 end preadditive
 
-section epi_mono
-variables {M N : Module.{v} R} (f : M ⟶ N)
-
-lemma ker_eq_bot_of_mono [mono f] : f.ker = ⊥ :=
-linear_map.ker_eq_bot_of_cancel $ λ u v, (@cancel_mono _ _ _ _ _ f _ ↟u ↟v).1
-
-lemma range_eq_top_of_epi [epi f] : f.range = ⊤ :=
-linear_map.range_eq_top_of_cancel $ λ u v, (@cancel_epi _ _ _ _ _ f _ ↟u ↟v).1
-
-lemma mono_of_ker_eq_bot (hf : f.ker = ⊥) : mono f :=
-concrete_category.mono_of_injective _ $ linear_map.ker_eq_bot.1 hf
-
-lemma epi_of_range_eq_top (hf : f.range = ⊤) : epi f :=
-concrete_category.epi_of_surjective _ $ linear_map.range_eq_top.1 hf
-
-instance mono_as_hom'_subtype (U : submodule R M) : mono ↾U.subtype :=
-mono_of_ker_eq_bot _ (submodule.ker_subtype U)
-
-instance epi_as_hom''_mkq (U : submodule R M) : epi ↿U.mkq :=
-epi_of_range_eq_top _ $ submodule.range_mkq _
-
-end epi_mono
-
 end Module
 
 instance (M : Type u) [add_comm_group M] [module R M] : has_coe (submodule R M) (Module R) :=

--- a/src/algebra/category/Module/kernels.lean
+++ b/src/algebra/category/Module/kernels.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
-import algebra.category.Module.basic
+import algebra.category.Module.epi_mono
 
 /-!
 # The concrete (co)kernels in the category of modules are (co)kernels in the categorical sense.
@@ -48,7 +48,7 @@ cofork.is_colimit.mk _
   (λ s, f.range.liftq_mkq (cofork.π s) _)
   (λ s m h,
   begin
-    haveI : epi (as_hom f.range.mkq) := epi_of_range_eq_top _ (submodule.range_mkq _),
+    haveI : epi (as_hom f.range.mkq) := (epi_iff_range_eq_top _).mpr (submodule.range_mkq _),
     apply (cancel_epi (as_hom f.range.mkq)).1,
     convert h walking_parallel_pair.one,
     exact submodule.liftq_mkq _ _ _

--- a/src/algebra/category/Module/subobject.lean
+++ b/src/algebra/category/Module/subobject.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
-import algebra.category.Module.basic
+import algebra.category.Module.epi_mono
 import category_theory.subobject.well_powered
 
 /-!


### PR DESCRIPTION
The results added in #7100 already exist. I moved them to the place where Scott added the duplicates. Hopefully that will make them more discoverable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
