### PR TITLE
chore(topology/algebra/open_subgroup): change to new structure

### DIFF
--- a/src/topology/algebra/open_subgroup.lean
+++ b/src/topology/algebra/open_subgroup.lean
@@ -10,11 +10,9 @@ import topology.algebra.ring
 open topological_space
 open_locale topological_space
 
-set_option old_structure_cmd true
-
 /-- The type of open subgroups of a topological additive group. -/
 @[ancestor add_subgroup]
-structure open_add_subgroup  (G : Type*) [add_group G] [topological_space G]
+structure open_add_subgroup (G : Type*) [add_group G] [topological_space G]
   extends add_subgroup G :=
 (is_open' : is_open carrier)
 
@@ -59,7 +57,11 @@ attribute [norm_cast] mem_coe mem_coe_opens mem_coe_subgroup open_add_subgroup.m
   open_add_subgroup.mem_coe_opens open_add_subgroup.mem_coe_add_subgroup
 
 @[to_additive] lemma coe_injective : injective (coe : open_subgroup G → set G) :=
-λ U V h, by cases U; cases V; congr; assumption
+begin
+  rintro ⟨⟨U, _, _, _⟩, _⟩ ⟨⟨V, _, _, _⟩, _⟩ h,
+  congr,
+  assumption,
+end
 
 @[ext, to_additive]
 lemma ext (h : ∀ x, x ∈ U ↔ x ∈ V) : (U = V) := coe_injective $ set.ext h


### PR DESCRIPTION
Change open subgroups to new structures.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

An experiment seeing how difficult it is to change an old structure to a new structure.