### PR TITLE
[Merged by Bors] - chore(algebra/lie/nilpotent): make proof of `module.derived_series_le_lower_central_series` less refl-heavy

### DIFF
--- a/src/algebra/lie/nilpotent.lean
+++ b/src/algebra/lie/nilpotent.lean
@@ -63,7 +63,8 @@ lemma derived_series_le_lower_central_series (k : ℕ) :
   derived_series R L k ≤ lower_central_series R L L k :=
 begin
   induction k with k h,
-  { exact le_refl _, },
+  { rw [derived_series_def, derived_series_of_ideal_zero, lower_central_series_zero],
+    exact le_refl _, },
   { have h' : derived_series R L k ≤ ⊤, { by simp only [le_top], },
     rw [derived_series_def, derived_series_of_ideal_succ, lower_central_series_succ],
     exact lie_submodule.mono_lie _ _ _ _ h' h, },


### PR DESCRIPTION
According to the list in [this Zulip remark](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20repo.20GitHub.20actions.20queue/near/235996204)
this lemma was the slowest task for Leanchecker.

The changes here should help. Using `set_option profiler true`, I see
about a ten-fold speedup in elaboration time for Lean, from approximately
2.4s to 0.24s



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
