### PR TITLE
[Merged by Bors] - feat(order/zorn): upward inclusion variant of Zorn's lemma

### DIFF
--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -297,7 +297,7 @@ zorn_nonempty_partial_order₀ _ (λ c cS hc y yc, H _ cS hc ⟨y, yc⟩) _ hx
 theorem zorn_superset {α : Type u} (S : set (set α))
   (h : ∀ c ⊆ S, zorn.chain (⊆) c → ∃ lb ∈ S, ∀ s ∈ c, lb ⊆ s) :
   ∃ m ∈ S, ∀ a ∈ S, a ⊆ m → a = m :=
-@zorn_partial_order₀ (order_dual (set α)) _ S $ λ c cS hc, h c cS (chain.symm hc)
+@zorn_partial_order₀ (order_dual (set α)) _ S $ λ c cS hc, h c cS hc.symm
 
 theorem zorn_superset_nonempty {α : Type u} (S : set (set α))
   (H : ∀ c ⊆ S, chain (⊆) c → c.nonempty → ∃ lb ∈ S, ∀ s ∈ c, lb ⊆ s) (x) (hx : x ∈ S) :

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -40,7 +40,7 @@ match H.total_of_refl hx hy with
 | or.inr h := ⟨x, hx, refl _, h⟩
 end
 
-theorem chain_insert {c : set α} {a : α} (hc : chain c) (ha : ∀b∈c, b ≠ a → a ≺ b ∨ b ≺ a) :
+theorem chain_insert {c : set α} {a : α} (hc : chain c) (ha : ∀ b∈c, b ≠ a → a ≺ b ∨ b ≺ a) :
   chain (insert a c) :=
 forall_insert_of_forall
   (assume x hx, forall_insert_of_forall (hc x hx) (assume hneq, (ha x hx hneq).symm))
@@ -51,14 +51,14 @@ forall_insert_of_forall
 def super_chain (c₁ c₂ : set α) : Prop := chain c₂ ∧ c₁ ⊂ c₂
 
 /-- A chain `c` is a maximal chain if there does not exists a chain strictly including `c`. -/
-def is_max_chain (c : set α) := chain c ∧ ¬ (∃c', super_chain c c')
+def is_max_chain (c : set α) := chain c ∧ ¬ (∃ c', super_chain c c')
 
 /-- Given a set `c`, if there exists a chain `c'` strictly including `c`, then `succ_chain c`
 is one of these chains. Otherwise it is `c`. -/
 def succ_chain (c : set α) : set α :=
-if h : ∃c', chain c ∧ super_chain c c' then some h else c
+if h : ∃ c', chain c ∧ super_chain c c' then some h else c
 
-theorem succ_spec {c : set α} (h : ∃c', chain c ∧ super_chain c c') :
+theorem succ_spec {c : set α} (h : ∃ c', chain c ∧ super_chain c c') :
   super_chain c (succ_chain c) :=
 let ⟨c', hc'⟩ := h in
 have chain c ∧ super_chain c (some h),
@@ -66,7 +66,7 @@ have chain c ∧ super_chain c (some h),
 by simp [succ_chain, dif_pos, h, this.right]
 
 theorem chain_succ {c : set α} (hc : chain c) : chain (succ_chain c) :=
-if h : ∃c', chain c ∧ super_chain c c' then
+if h : ∃ c', chain c ∧ super_chain c c' then
   (succ_spec h).left
 else
   by simp [succ_chain, dif_neg, h]; exact hc
@@ -80,15 +80,15 @@ begin
 end
 
 theorem succ_increasing {c : set α} : c ⊆ succ_chain c :=
-if h : ∃c', chain c ∧ super_chain c c' then
+if h : ∃ c', chain c ∧ super_chain c c' then
   have super_chain c (succ_chain c), from succ_spec h,
   this.right.left
 else by simp [succ_chain, dif_neg, h, subset.refl]
 
 /-- Set of sets reachable from `∅` using `succ_chain` and `⋃₀`. -/
 inductive chain_closure : set α → Prop
-| succ : ∀{s}, chain_closure s → chain_closure (succ_chain s)
-| union : ∀{s}, (∀a∈s, chain_closure a) → chain_closure (⋃₀ s)
+| succ : ∀ {s}, chain_closure s → chain_closure (succ_chain s)
+| union : ∀ {s}, (∀ a∈s, chain_closure a) → chain_closure (⋃₀ s)
 
 theorem chain_closure_empty : chain_closure ∅ :=
 have chain_closure (⋃₀ ∅),
@@ -101,7 +101,7 @@ chain_closure.union $ assume s hs, hs
 variables {c c₁ c₂ c₃ : set α}
 
 private lemma chain_closure_succ_total_aux (hc₁ : chain_closure c₁) (hc₂ : chain_closure c₂)
-  (h : ∀{c₃}, chain_closure c₃ → c₃ ⊆ c₂ → c₂ = c₃ ∨ succ_chain c₃ ⊆ c₂) :
+  (h : ∀ {c₃}, chain_closure c₃ → c₃ ⊆ c₂ → c₂ = c₃ ∨ succ_chain c₃ ⊆ c₂) :
   c₁ ⊆ c₂ ∨ succ_chain c₂ ⊆ c₁ :=
 begin
   induction hc₁,
@@ -181,7 +181,7 @@ begin
   case succ : c hc h {
     exact chain_succ h },
   case union : s hs h {
-    have h : ∀c∈s, zorn.chain c := h,
+    have h : ∀ c∈s, zorn.chain c := h,
     exact assume c₁ ⟨t₁, ht₁, (hc₁ : c₁ ∈ t₁)⟩ c₂ ⟨t₂, ht₂, (hc₂ : c₂ ∈ t₂)⟩ hneq,
       have t₁ ⊆ t₂ ∨ t₂ ⊆ t₁, from chain_closure_total (hs _ ht₁) (hs _ ht₂),
       or.elim this
@@ -211,11 +211,11 @@ h₃ this.symm
 
 If every chain has an upper bound, then there is a maximal element -/
 theorem exists_maximal_of_chains_bounded
-  (h : ∀c, chain c → ∃ub, ∀a∈c, a ≺ ub) (trans : ∀{a b c}, a ≺ b → b ≺ c → a ≺ c) :
-  ∃m, ∀a, m ≺ a → a ≺ m :=
-have ∃ub, ∀a∈max_chain, a ≺ ub,
+  (h : ∀ c, chain c → ∃ ub, ∀ a∈c, a ≺ ub) (trans : ∀ {a b c}, a ≺ b → b ≺ c → a ≺ c) :
+  ∃ m, ∀ a, m ≺ a → a ≺ m :=
+have ∃ ub, ∀ a∈max_chain, a ≺ ub,
   from h _ $ max_chain_spec.left,
-let ⟨ub, (hub : ∀a∈max_chain, a ≺ ub)⟩ := this in
+let ⟨ub, (hub : ∀ a∈max_chain, a ≺ ub)⟩ := this in
 ⟨ub, assume a ha,
   have chain (insert a max_chain),
     from chain_insert max_chain_spec.left $ assume b hb _, or.inr $ trans (hub b hb) ha,
@@ -229,8 +229,8 @@ If every nonempty chain of a nonempty type has an upper bound, then there is a m
 (A variant of Zorn's lemma.)
 -/
 theorem exists_maximal_of_nonempty_chains_bounded [nonempty α]
-  (h : ∀c, chain c → c.nonempty → ∃ub, ∀a∈c, a ≺ ub) (trans : ∀{a b c}, a ≺ b → b ≺ c → a ≺ c) :
-  ∃m, ∀a, m ≺ a → a ≺ m :=
+  (h : ∀ c, chain c → c.nonempty → ∃ ub, ∀ a∈c, a ≺ ub) (trans : ∀ {a b c}, a ≺ b → b ≺ c → a ≺ c) :
+  ∃ m, ∀ a, m ≺ a → a ≺ m :=
 exists_maximal_of_chains_bounded
   (λ c hc,
     (eq_empty_or_nonempty c).elim
@@ -241,12 +241,12 @@ exists_maximal_of_chains_bounded
 end chain
 
 theorem zorn_partial_order {α : Type u} [partial_order α]
-  (h : ∀c:set α, chain (≤) c → ∃ub, ∀a∈c, a ≤ ub) : ∃m:α, ∀a, m ≤ a → a = m :=
+  (h : ∀ c:set α, chain (≤) c → ∃ ub, ∀ a∈c, a ≤ ub) : ∃ m:α, ∀ a, m ≤ a → a = m :=
 let ⟨m, hm⟩ := @exists_maximal_of_chains_bounded α (≤) h (assume a b c, le_trans) in
 ⟨m, assume a ha, le_antisymm (hm a ha) ha⟩
 
 theorem zorn_nonempty_partial_order {α : Type u} [partial_order α] [nonempty α]
-  (h : ∀ (c : set α), chain (≤) c → c.nonempty → ∃ub, ∀ a ∈ c, a ≤ ub) :
+  (h : ∀ (c : set α), chain (≤) c → c.nonempty → ∃ ub, ∀ a ∈ c, a ≤ ub) :
   ∃ (m : α), ∀ a, m ≤ a → a = m :=
 let ⟨m, hm⟩ := @exists_maximal_of_nonempty_chains_bounded α (≤) _ h (λ a b c, le_trans) in
 ⟨m, λ a ha, le_antisymm (hm a ha) ha⟩
@@ -266,35 +266,65 @@ let ⟨⟨m, hms, hxm⟩, h⟩ := @zorn_partial_order {m // m ∈ s ∧ x ≤ m}
 ⟨m, hms, hxm, λ z hzs hmz, congr_arg subtype.val $ h ⟨z, hzs, le_trans hxm hmz⟩ hmz⟩
 
 theorem zorn_subset {α : Type u} (S : set (set α))
-  (h : ∀c ⊆ S, chain (⊆) c → ∃ub ∈ S, ∀ s ∈ c, s ⊆ ub) :
-  ∃ m ∈ S, ∀a ∈ S, m ⊆ a → a = m :=
+  (h : ∀ c ⊆ S, chain (⊆) c → ∃ ub ∈ S, ∀ s ∈ c, s ⊆ ub) :
+  ∃ m ∈ S, ∀ a ∈ S, m ⊆ a → a = m :=
 begin
   letI : partial_order S := partial_order.lift subtype.val (λ _ _, subtype.ext_val),
-  have : ∀c:set S, @chain S (≤) c → ∃ub, ∀a∈c, a ≤ ub,
-  { intros c hc,
-    rcases h (subtype.val '' c) (image_subset_iff.2 _) _ with ⟨s, sS, hs⟩,
-    { exact ⟨⟨s, sS⟩, λ ⟨x, hx⟩ H, hs _ (mem_image_of_mem _ H)⟩ },
-    { rintro ⟨x, hx⟩ _, exact hx },
-    { rintro _ ⟨x, cx, rfl⟩ _ ⟨y, cy, rfl⟩ xy,
-      exact hc x cx y cy (mt (congr_arg _) xy) } },
-  rcases zorn_partial_order this with ⟨⟨m, mS⟩, hm⟩,
-  exact ⟨m, mS, λ a aS ha, congr_arg subtype.val (hm ⟨a, aS⟩ ha)⟩
+  suffices : ∀ c : set S, @chain S (≤) c → ∃ ub, ∀ a ∈ c, a ≤ ub,
+  { obtain ⟨⟨m, mS⟩, hm⟩ := zorn_partial_order this,
+    exact ⟨m, mS, λ a aS ha, congr_arg subtype.val (hm ⟨a, aS⟩ ha)⟩ },
+  intros c hc,
+  obtain ⟨s, sS, hs⟩ := h (subtype.val '' c) (image_subset_iff.2 _) _,
+  { exact ⟨⟨s, sS⟩, λ ⟨x, hx⟩ H, hs _ (mem_image_of_mem _ H)⟩ },
+  { exact λ ⟨x, hx⟩ _, hx },
+  rintro _ ⟨x, cx, rfl⟩ _ ⟨y, cy, rfl⟩ xy,
+  exact hc x cx y cy (mt (congr_arg _) xy),
 end
 
 theorem zorn_subset₀ {α : Type u} (S : set (set α))
-  (H : ∀c ⊆ S, chain (⊆) c → c.nonempty → ∃ub ∈ S, ∀ s ∈ c, s ⊆ ub) (x) (hx : x ∈ S) :
-  ∃ m ∈ S, x ⊆ m ∧ ∀a ∈ S, m ⊆ a → a = m :=
+  (H : ∀ c ⊆ S, chain (⊆) c → c.nonempty → ∃ ub ∈ S, ∀ s ∈ c, s ⊆ ub) (x) (hx : x ∈ S) :
+  ∃ m ∈ S, x ⊆ m ∧ ∀ a ∈ S, m ⊆ a → a = m :=
 begin
   let T := {s ∈ S | x ⊆ s},
-  rcases zorn_subset T _ with ⟨m, ⟨mS, mx⟩, hm⟩,
+  obtain ⟨m, ⟨mS, mx⟩, hm⟩ := zorn_subset T _,
   { exact ⟨m, mS, mx, λ a ha ha', hm a ⟨ha, subset.trans mx ha'⟩ ha'⟩ },
-  { intros c cT hc,
-    cases c.eq_empty_or_nonempty with c0 c0,
-    { rw c0, exact ⟨x, ⟨hx, subset.refl _⟩, λ _, false.elim⟩ },
-    { rcases H _ (subset.trans cT (sep_subset _ _)) hc c0 with ⟨ub, us, h⟩,
-      refine ⟨ub, ⟨us, _⟩, h⟩,
-      rcases c0 with ⟨s, hs⟩,
-      exact subset.trans (cT hs).2 (h _ hs) } }
+  intros c cT hc,
+  cases c.eq_empty_or_nonempty with c0 c0,
+  { rw c0, exact ⟨x, ⟨hx, subset.refl _⟩, λ _, false.elim⟩ },
+  obtain ⟨ub, us, h⟩ := H _ (subset.trans cT (sep_subset _ _)) hc c0,
+  obtain ⟨s, hs⟩ := c0,
+  exact ⟨ub, ⟨us, subset.trans (cT hs).2 (h _ hs)⟩, h⟩,
+end
+
+theorem zorn_superset {α : Type*} (S : set (set α))
+  (h : ∀ c ⊆ S, zorn.chain (⊆) c → ∃ lb ∈ S, ∀ s ∈ c, lb ⊆ s) :
+  ∃ m ∈ S, ∀ a ∈ S, a ⊆ m → a = m :=
+begin
+  let rev : S → S → Prop := λ X Y, Y.1 ⊆ X.1,
+  suffices hS : ∀ (c : set S), zorn.chain rev c → ∃ ub, ∀ a ∈ c, rev a ub,
+  { obtain ⟨m, hm₁⟩ := zorn.exists_maximal_of_chains_bounded hS (λ x y z xy yz,
+    set.subset.trans yz xy),
+    exact ⟨m, m.prop, λ a ha ha₂, set.subset.antisymm ha₂ (hm₁ ⟨a, ha⟩ ha₂)⟩ },
+  intros c hc,
+  obtain ⟨t, ht₁, ht₂⟩ := h (coe '' c) (by simp)
+    (by { rintro _ ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩ ne,
+          exact (hc _ hx _ hy (λ t, ne (congr_arg coe t))).symm }),
+  exact ⟨⟨_, ht₁⟩, λ a ha, ht₂ a ⟨_, ha, rfl⟩⟩,
+end
+
+theorem zorn_superset₀ {α : Type u} (S : set (set α))
+  (H : ∀ c ⊆ S, chain (⊆) c → c.nonempty → ∃ lb ∈ S, ∀ s ∈ c, lb ⊆ s) (x) (hx : x ∈ S) :
+  ∃ m ∈ S, m ⊆ x ∧ ∀ a ∈ S, a ⊆ m → a = m :=
+begin
+  let T := {s ∈ S | s ⊆ x},
+  obtain ⟨m, ⟨mS, mx⟩, hm⟩ := zorn_superset T _,
+  { exact ⟨m, mS, mx, λ a ha ha', hm a ⟨ha, subset.trans ha' mx⟩ ha'⟩ },
+  intros c cT hc,
+  cases c.eq_empty_or_nonempty with c0 c0,
+  { rw c0, exact ⟨x, ⟨hx, subset.refl _⟩, λ _, false.elim⟩ },
+  obtain ⟨lb, ls, h⟩ := H _ (subset.trans cT (sep_subset _ _)) hc c0,
+  obtain ⟨s, hs⟩ := c0,
+  exact ⟨lb, ⟨ls, subset.trans (h _ hs) (cT hs).2⟩, h⟩,
 end
 
 theorem chain.total {α : Type u} [preorder α]

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -40,7 +40,7 @@ match H.total_of_refl hx hy with
 | or.inr h := ⟨x, hx, refl _, h⟩
 end
 
-theorem chain_insert {c : set α} {a : α} (hc : chain c) (ha : ∀ b∈c, b ≠ a → a ≺ b ∨ b ≺ a) :
+theorem chain_insert {c : set α} {a : α} (hc : chain c) (ha : ∀ b ∈ c, b ≠ a → a ≺ b ∨ b ≺ a) :
   chain (insert a c) :=
 forall_insert_of_forall
   (assume x hx, forall_insert_of_forall (hc x hx) (assume hneq, (ha x hx hneq).symm))
@@ -88,7 +88,7 @@ else by simp [succ_chain, dif_neg, h, subset.refl]
 /-- Set of sets reachable from `∅` using `succ_chain` and `⋃₀`. -/
 inductive chain_closure : set α → Prop
 | succ : ∀ {s}, chain_closure s → chain_closure (succ_chain s)
-| union : ∀ {s}, (∀ a∈s, chain_closure a) → chain_closure (⋃₀ s)
+| union : ∀ {s}, (∀ a ∈ s, chain_closure a) → chain_closure (⋃₀ s)
 
 theorem chain_closure_empty : chain_closure ∅ :=
 have chain_closure (⋃₀ ∅),
@@ -147,7 +147,8 @@ begin
     { exact (h₁ $ subset.trans succ_increasing h) } }
 end
 
-theorem chain_closure_total (hc₁ : chain_closure c₁) (hc₂ : chain_closure c₂) : c₁ ⊆ c₂ ∨ c₂ ⊆ c₁ :=
+theorem chain_closure_total (hc₁ : chain_closure c₁) (hc₂ : chain_closure c₂) :
+  c₁ ⊆ c₂ ∨ c₂ ⊆ c₁ :=
 have c₁ ⊆ c₂ ∨ succ_chain c₂ ⊆ c₁,
   from chain_closure_succ_total_aux hc₁ hc₂ $ assume c₃ hc₃, chain_closure_succ_total hc₃ hc₂,
 or.imp_right (assume : succ_chain c₂ ⊆ c₁, subset.trans succ_increasing this) this
@@ -181,7 +182,7 @@ begin
   case succ : c hc h {
     exact chain_succ h },
   case union : s hs h {
-    have h : ∀ c∈s, zorn.chain c := h,
+    have h : ∀ c ∈ s, zorn.chain c := h,
     exact assume c₁ ⟨t₁, ht₁, (hc₁ : c₁ ∈ t₁)⟩ c₂ ⟨t₂, ht₂, (hc₂ : c₂ ∈ t₂)⟩ hneq,
       have t₁ ⊆ t₂ ∨ t₂ ⊆ t₁, from chain_closure_total (hs _ ht₁) (hs _ ht₂),
       or.elim this
@@ -211,11 +212,11 @@ h₃ this.symm
 
 If every chain has an upper bound, then there is a maximal element -/
 theorem exists_maximal_of_chains_bounded
-  (h : ∀ c, chain c → ∃ ub, ∀ a∈c, a ≺ ub) (trans : ∀ {a b c}, a ≺ b → b ≺ c → a ≺ c) :
+  (h : ∀ c, chain c → ∃ ub, ∀ a ∈ c, a ≺ ub) (trans : ∀ {a b c}, a ≺ b → b ≺ c → a ≺ c) :
   ∃ m, ∀ a, m ≺ a → a ≺ m :=
-have ∃ ub, ∀ a∈max_chain, a ≺ ub,
+have ∃ ub, ∀ a ∈ max_chain, a ≺ ub,
   from h _ $ max_chain_spec.left,
-let ⟨ub, (hub : ∀ a∈max_chain, a ≺ ub)⟩ := this in
+let ⟨ub, (hub : ∀ a ∈ max_chain, a ≺ ub)⟩ := this in
 ⟨ub, assume a ha,
   have chain (insert a max_chain),
     from chain_insert max_chain_spec.left $ assume b hb _, or.inr $ trans (hub b hb) ha,
@@ -229,7 +230,8 @@ If every nonempty chain of a nonempty type has an upper bound, then there is a m
 (A variant of Zorn's lemma.)
 -/
 theorem exists_maximal_of_nonempty_chains_bounded [nonempty α]
-  (h : ∀ c, chain c → c.nonempty → ∃ ub, ∀ a∈c, a ≺ ub) (trans : ∀ {a b c}, a ≺ b → b ≺ c → a ≺ c) :
+  (h : ∀ c, chain c → c.nonempty → ∃ ub, ∀ a ∈ c, a ≺ ub)
+   (trans : ∀ {a b c}, a ≺ b → b ≺ c → a ≺ c) :
   ∃ m, ∀ a, m ≺ a → a ≺ m :=
 exists_maximal_of_chains_bounded
   (λ c hc,
@@ -240,8 +242,14 @@ exists_maximal_of_chains_bounded
 
 end chain
 
+--This lemma isn't under section `chain` because `parameters` messes up with it. Feel free to fix it
+theorem chain.symm {α : Type u} {s : set α} {q : α → α → Prop} (h : chain q s) :
+  chain (flip q) s :=
+h.mono' (λ _ _, or.symm)
+
 theorem zorn_partial_order {α : Type u} [partial_order α]
-  (h : ∀ c:set α, chain (≤) c → ∃ ub, ∀ a∈c, a ≤ ub) : ∃ m:α, ∀ a, m ≤ a → a = m :=
+  (h : ∀ c : set α, chain (≤) c → ∃ ub, ∀ a ∈ c, a ≤ ub) :
+  ∃ m : α, ∀ a, m ≤ a → a = m :=
 let ⟨m, hm⟩ := @exists_maximal_of_chains_bounded α (≤) h (assume a b c, le_trans) in
 ⟨m, assume a ha, le_antisymm (hm a ha) ha⟩
 
@@ -286,37 +294,16 @@ theorem zorn_subset_nonempty {α : Type u} (S : set (set α))
   ∃ m ∈ S, x ⊆ m ∧ ∀a ∈ S, m ⊆ a → a = m :=
 zorn_nonempty_partial_order₀ _ (λ c cS hc y yc, H _ cS hc ⟨y, yc⟩) _ hx
 
-theorem zorn_superset {α : Type*} (S : set (set α))
+theorem zorn_superset {α : Type u} (S : set (set α))
   (h : ∀ c ⊆ S, zorn.chain (⊆) c → ∃ lb ∈ S, ∀ s ∈ c, lb ⊆ s) :
   ∃ m ∈ S, ∀ a ∈ S, a ⊆ m → a = m :=
-begin
-  let rev : S → S → Prop := λ X Y, Y.1 ⊆ X.1,
-  suffices hS : ∀ (c : set S), zorn.chain rev c → ∃ ub, ∀ a ∈ c, rev a ub,
-  { obtain ⟨m, hm₁⟩ := zorn.exists_maximal_of_chains_bounded hS (λ x y z xy yz,
-    set.subset.trans yz xy),
-    exact ⟨m, m.prop, λ a ha ha₂, set.subset.antisymm ha₂ (hm₁ ⟨a, ha⟩ ha₂)⟩ },
-  intros c hc,
-  obtain ⟨t, ht₁, ht₂⟩ := h (coe '' c) (by simp)
-    (by { rintro _ ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩ ne,
-          exact (hc _ hx _ hy (λ t, ne (congr_arg coe t))).symm }),
-  exact ⟨⟨_, ht₁⟩, λ a ha, ht₂ a ⟨_, ha, rfl⟩⟩,
-end
+@zorn_partial_order₀ (order_dual (set α)) _ S $ λ c cS hc, h c cS (chain.symm hc)
 
 theorem zorn_superset_nonempty {α : Type u} (S : set (set α))
   (H : ∀ c ⊆ S, chain (⊆) c → c.nonempty → ∃ lb ∈ S, ∀ s ∈ c, lb ⊆ s) (x) (hx : x ∈ S) :
   ∃ m ∈ S, m ⊆ x ∧ ∀ a ∈ S, a ⊆ m → a = m :=
-begin
-  let T := {s ∈ S | s ⊆ x},
-  obtain ⟨m, ⟨mS, mx⟩, hm⟩ := zorn_superset T _,
-  { exact ⟨m, mS, mx, λ a ha ha', hm a ⟨ha, subset.trans ha' mx⟩ ha'⟩ },
-  intros c cT hc,
-  cases c.eq_empty_or_nonempty with c0 c0,
-  { rw c0, exact ⟨x, ⟨hx, subset.refl _⟩, λ _, false.elim⟩ },
-  obtain ⟨lb, ls, h⟩ := H _ (subset.trans cT (sep_subset _ _)) hc c0,
-  obtain ⟨s, hs⟩ := c0,
-  exact ⟨lb, ⟨ls, subset.trans (h _ hs) (cT hs).2⟩, h⟩,
-end
-
+@zorn_nonempty_partial_order₀ (order_dual (set α)) _ S (λ c cS hc y yc, H _ cS
+  (chain.symm hc) ⟨y, yc⟩) _ hx
 theorem chain.total {α : Type u} [preorder α]
   {c : set α} (H : chain (≤) c) :
   ∀ {x y}, x ∈ c → y ∈ c → x ≤ y ∨ y ≤ x :=

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -243,6 +243,7 @@ exists_maximal_of_chains_bounded
 end chain
 
 --This lemma isn't under section `chain` because `parameters` messes up with it. Feel free to fix it
+/-- This can be used to turn `zorn.chain (≥)` into `zorn.chain (≤)` and vice-versa. -/
 theorem chain.symm {α : Type u} {s : set α} {q : α → α → Prop} (h : chain q s) :
   chain (flip q) s :=
 h.mono' (λ _ _, or.symm)
@@ -295,7 +296,7 @@ theorem zorn_subset_nonempty {α : Type u} (S : set (set α))
 zorn_nonempty_partial_order₀ _ (λ c cS hc y yc, H _ cS hc ⟨y, yc⟩) _ hx
 
 theorem zorn_superset {α : Type u} (S : set (set α))
-  (h : ∀ c ⊆ S, zorn.chain (⊆) c → ∃ lb ∈ S, ∀ s ∈ c, lb ⊆ s) :
+  (h : ∀ c ⊆ S, chain (⊆) c → ∃ lb ∈ S, ∀ s ∈ c, lb ⊆ s) :
   ∃ m ∈ S, ∀ a ∈ S, a ⊆ m → a = m :=
 @zorn_partial_order₀ (order_dual (set α)) _ S $ λ c cS hc, h c cS hc.symm
 

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -330,7 +330,7 @@ end zorn
 
 theorem directed_of_chain {α β r} [is_refl β r] {f : α → β} {c : set α}
   (h : zorn.chain (f ⁻¹'o r) c) :
-  directed r (λx : {a : α // a ∈ c}, f x) :=
+  directed r (λ x : {a : α // a ∈ c}, f x) :=
 assume ⟨a, ha⟩ ⟨b, hb⟩, classical.by_cases
   (assume : a = b, by simp only [this, exists_prop, and_self, subtype.exists];
     exact ⟨b, hb, refl _⟩)

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -22,7 +22,7 @@ local infix ` ≺ `:50  := r
 
 /-- A chain is a subset `c` satisfying
   `x ≺ y ∨ x = y ∨ y ≺ x` for all `x y ∈ c`. -/
-def chain (c : set α) := pairwise_on c (λx y, x ≺ y ∨ y ≺ x)
+def chain (c : set α) := pairwise_on c (λ x y, x ≺ y ∨ y ≺ x)
 parameters {r}
 
 theorem chain.total_of_refl [is_refl α r]
@@ -30,10 +30,12 @@ theorem chain.total_of_refl [is_refl α r]
   x ≺ y ∨ y ≺ x :=
 if e : x = y then or.inl (e ▸ refl _) else H _ hx _ hy e
 
-theorem chain.mono {c c'} : c' ⊆ c → chain c → chain c' :=
+theorem chain.mono {c c'} :
+  c' ⊆ c → chain c → chain c' :=
 pairwise_on.mono
 
-theorem chain.directed_on [is_refl α r] {c} (H : chain c) : directed_on (≺) c :=
+theorem chain.directed_on [is_refl α r] {c} (H : chain c) :
+  directed_on (≺) c :=
 assume x hx y hy,
 match H.total_of_refl hx hy with
 | or.inl h := ⟨y, hy, h, refl _⟩
@@ -65,7 +67,8 @@ have chain c ∧ super_chain c (some h),
   from @some_spec _ (λc', chain c ∧ super_chain c c') _,
 by simp [succ_chain, dif_pos, h, this.right]
 
-theorem chain_succ {c : set α} (hc : chain c) : chain (succ_chain c) :=
+theorem chain_succ {c : set α} (hc : chain c) :
+  chain (succ_chain c) :=
 if h : ∃ c', chain c ∧ super_chain c c' then
   (succ_spec h).left
 else
@@ -79,7 +82,8 @@ begin
   exact succ_spec ⟨c', hc₁, hc'⟩
 end
 
-theorem succ_increasing {c : set α} : c ⊆ succ_chain c :=
+theorem succ_increasing {c : set α} :
+  c ⊆ succ_chain c :=
 if h : ∃ c', chain c ∧ super_chain c c' then
   have super_chain c (succ_chain c), from succ_spec h,
   this.right.left
@@ -90,12 +94,14 @@ inductive chain_closure : set α → Prop
 | succ : ∀ {s}, chain_closure s → chain_closure (succ_chain s)
 | union : ∀ {s}, (∀ a ∈ s, chain_closure a) → chain_closure (⋃₀ s)
 
-theorem chain_closure_empty : chain_closure ∅ :=
+theorem chain_closure_empty :
+  chain_closure ∅ :=
 have chain_closure (⋃₀ ∅),
   from chain_closure.union $ assume a h, h.rec _,
 by simp at this; assumption
 
-theorem chain_closure_closure : chain_closure (⋃₀ chain_closure) :=
+theorem chain_closure_closure :
+  chain_closure (⋃₀ chain_closure) :=
 chain_closure.union $ assume s hs, hs
 
 variables {c c₁ c₂ c₃ : set α}
@@ -154,7 +160,8 @@ have c₁ ⊆ c₂ ∨ succ_chain c₂ ⊆ c₁,
 or.imp_right (assume : succ_chain c₂ ⊆ c₁, subset.trans succ_increasing this) this
 
 theorem chain_closure_succ_fixpoint (hc₁ : chain_closure c₁) (hc₂ : chain_closure c₂)
-  (h_eq : succ_chain c₂ = c₂) : c₁ ⊆ c₂ :=
+  (h_eq : succ_chain c₂ = c₂) :
+  c₁ ⊆ c₂ :=
 begin
   induction hc₁,
   case succ : c₁ hc₁ h {
@@ -176,7 +183,8 @@ theorem chain_closure_succ_fixpoint_iff (hc : chain_closure c) :
       ... = c : this.symm)
     succ_increasing⟩
 
-theorem chain_chain_closure (hc : chain_closure c) : chain c :=
+theorem chain_chain_closure (hc : chain_closure c) :
+  chain c :=
 begin
   induction hc,
   case succ : c hc h {
@@ -197,7 +205,8 @@ def max_chain := ⋃₀ chain_closure
 
 There exists a maximal totally ordered subset of `α`.
 Note that we do not require `α` to be partially ordered by `r`. -/
-theorem max_chain_spec : is_max_chain max_chain :=
+theorem max_chain_spec :
+  is_max_chain max_chain :=
 classical.by_contradiction $
 assume : ¬ is_max_chain (⋃₀ chain_closure),
 have super_chain (⋃₀ chain_closure) (succ_chain (⋃₀ chain_closure)),
@@ -211,8 +220,8 @@ h₃ this.symm
 /-- Zorn's lemma
 
 If every chain has an upper bound, then there is a maximal element -/
-theorem exists_maximal_of_chains_bounded
-  (h : ∀ c, chain c → ∃ ub, ∀ a ∈ c, a ≺ ub) (trans : ∀ {a b c}, a ≺ b → b ≺ c → a ≺ c) :
+theorem exists_maximal_of_chains_bounded (h : ∀ c, chain c → ∃ ub, ∀ a ∈ c, a ≺ ub)
+  (trans : ∀ {a b c}, a ≺ b → b ≺ c → a ≺ c) :
   ∃ m, ∀ a, m ≺ a → a ≺ m :=
 have ∃ ub, ∀ a ∈ max_chain, a ≺ ub,
   from h _ $ max_chain_spec.left,
@@ -231,7 +240,7 @@ If every nonempty chain of a nonempty type has an upper bound, then there is a m
 -/
 theorem exists_maximal_of_nonempty_chains_bounded [nonempty α]
   (h : ∀ c, chain c → c.nonempty → ∃ ub, ∀ a ∈ c, a ≺ ub)
-   (trans : ∀ {a b c}, a ≺ b → b ≺ c → a ≺ c) :
+  (trans : ∀ {a b c}, a ≺ b → b ≺ c → a ≺ c) :
   ∃ m, ∀ a, m ≺ a → a ≺ m :=
 exists_maximal_of_chains_bounded
   (λ c hc,
@@ -272,8 +281,8 @@ let ⟨⟨m, hms⟩, h⟩ := @zorn_partial_order {m // m ∈ s} _
 in ⟨m, hms, λ z hzs hmz, congr_arg subtype.val (h ⟨z, hzs⟩ hmz)⟩
 
 theorem zorn_nonempty_partial_order₀ {α : Type u} [partial_order α] (s : set α)
-  (ih : ∀ c ⊆ s, chain (≤) c → ∀ y ∈ c, ∃ ub ∈ s, ∀ z ∈ c, z ≤ ub)
-  (x : α) (hxs : x ∈ s) : ∃ m ∈ s, x ≤ m ∧ ∀ z ∈ s, m ≤ z → z = m :=
+  (ih : ∀ c ⊆ s, chain (≤) c → ∀ y ∈ c, ∃ ub ∈ s, ∀ z ∈ c, z ≤ ub) (x : α) (hxs : x ∈ s) :
+  ∃ m ∈ s, x ≤ m ∧ ∀ z ∈ s, m ≤ z → z = m :=
 let ⟨⟨m, hms, hxm⟩, h⟩ := @zorn_partial_order {m // m ∈ s ∧ x ≤ m} _
   (λ c hc, c.eq_empty_or_nonempty.elim
     (assume hce, hce.symm ▸ ⟨⟨x, hxs, le_refl _⟩, λ _, false.elim⟩)
@@ -291,8 +300,8 @@ theorem zorn_subset {α : Type u} (S : set (set α))
 zorn_partial_order₀ S h
 
 theorem zorn_subset_nonempty {α : Type u} (S : set (set α))
-  (H : ∀c ⊆ S, chain (⊆) c → c.nonempty → ∃ub ∈ S, ∀ s ∈ c, s ⊆ ub) (x) (hx : x ∈ S) :
-  ∃ m ∈ S, x ⊆ m ∧ ∀a ∈ S, m ⊆ a → a = m :=
+  (H : ∀ c ⊆ S, chain (⊆) c → c.nonempty → ∃ ub ∈ S, ∀ s ∈ c, s ⊆ ub) (x) (hx : x ∈ S) :
+  ∃ m ∈ S, x ⊆ m ∧ ∀ a ∈ S, m ⊆ a → a = m :=
 zorn_nonempty_partial_order₀ _ (λ c cS hc y yc, H _ cS hc ⟨y, yc⟩) _ hx
 
 theorem zorn_superset {α : Type u} (S : set (set α))
@@ -304,16 +313,15 @@ theorem zorn_superset_nonempty {α : Type u} (S : set (set α))
   (H : ∀ c ⊆ S, chain (⊆) c → c.nonempty → ∃ lb ∈ S, ∀ s ∈ c, lb ⊆ s) (x) (hx : x ∈ S) :
   ∃ m ∈ S, m ⊆ x ∧ ∀ a ∈ S, a ⊆ m → a = m :=
 @zorn_nonempty_partial_order₀ (order_dual (set α)) _ S (λ c cS hc y yc, H _ cS
-  (chain.symm hc) ⟨y, yc⟩) _ hx
-theorem chain.total {α : Type u} [preorder α]
-  {c : set α} (H : chain (≤) c) :
+  hc.symm ⟨y, yc⟩) _ hx
+
+theorem chain.total {α : Type u} [preorder α] {c : set α} (H : chain (≤) c) :
   ∀ {x y}, x ∈ c → y ∈ c → x ≤ y ∨ y ≤ x :=
 λ x y, H.total_of_refl
 
-theorem chain.image {α β : Type*} (r : α → α → Prop)
-  (s : β → β → Prop) (f : α → β)
-  (h : ∀ x y, r x y → s (f x) (f y))
-  {c : set α} (hrc : chain r c) : chain s (f '' c) :=
+theorem chain.image {α β : Type*} (r : α → α → Prop) (s : β → β → Prop) (f : α → β)
+  (h : ∀ x y, r x y → s (f x) (f y)) {c : set α} (hrc : chain r c) :
+  chain s (f '' c) :=
 λ x ⟨a, ha₁, ha₂⟩ y ⟨b, hb₁, hb₂⟩, ha₂ ▸ hb₂ ▸ λ hxy,
   (hrc a ha₁ b hb₁ (mt (congr_arg f) $ hxy)).elim
     (or.inl ∘ h _ _) (or.inr ∘ h _ _)
@@ -322,7 +330,7 @@ end zorn
 
 theorem directed_of_chain {α β r} [is_refl β r] {f : α → β} {c : set α}
   (h : zorn.chain (f ⁻¹'o r) c) :
-  directed r (λx:{a:α // a ∈ c}, f x) :=
+  directed r (λx : {a : α // a ∈ c}, f x) :=
 assume ⟨a, ha⟩ ⟨b, hb⟩, classical.by_cases
   (assume : a = b, by simp only [this, exists_prop, and_self, subtype.exists];
     exact ⟨b, hb, refl _⟩)


### PR DESCRIPTION
add zorn_superset

This also add various missing bits of whitespace throughout the file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
