### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/integrals): integral of `sin x ^ n`

### DIFF
--- a/src/analysis/special_functions/integrals.lean
+++ b/src/analysis/special_functions/integrals.lean
@@ -12,8 +12,9 @@ This file contains proofs of the integrals of various specific functions. This i
 * Integrals of simple functions, such as `id`, `pow`, `exp`, `inv`
 * Integrals of some trigonometric functions, such as `sin`, `cos`, `1 / (1 + x^2)`
 * The integral of `cos x ^ 2 - sin x ^ 2`
-* The reduction formula for `∫ x in 0..π, sin x ^ n` for `n ≥ 2`
-* The computation of `∫ x in 0..π, sin x ^ n` as a product for even and odd `n`
+* The reduction of the integral of `sin x ^ n` for `n ≥ 2`
+* The computation of `∫ x in 0..π, sin x ^ n` as a product for even and odd `n` (used in proving the
+  Wallis product for pi)
 
 With these lemmas, many simple integrals can be computed by `simp` or `norm_num`.
 See `test/integration.lean` for specific examples.
@@ -240,7 +241,7 @@ end
 lemma integral_one_div_one_add_sq : ∫ x : ℝ in a..b, 1 / (1 + x^2) = arctan b - arctan a :=
 by simp only [one_div, integral_inv_one_add_sq]
 
-/-! ### Reduction of `∫ x in 0..π, sin x ^ n` -/
+/-! ### Integral of `sin x ^ n` -/
 
 lemma integral_sin_pow_aux :
   ∫ x in a..b, sin x ^ (n + 2) = sin a ^ (n + 1) * cos a - sin b ^ (n + 1) * cos b
@@ -263,7 +264,7 @@ begin
   all_goals { apply continuous.continuous_on, continuity },
 end
 
-/-- The reduction formula for the integral of `sin x ^ n` for all natural `n ≥ 2`. -/
+/-- The reduction formula for the integral of `sin x ^ n` for any natural `n ≥ 2`. -/
 lemma integral_sin_pow :
   ∫ x in a..b, sin x ^ (n + 2) = (sin a ^ (n + 1) * cos a - sin b ^ (n + 1) * cos b) / (n + 2)
     + (n + 1) / (n + 2) * ∫ x in a..b, sin x ^ n :=
@@ -303,4 +304,14 @@ begin
   refine mul_pos (by norm_num [pi_pos]) (prod_pos (λ n hn, div_pos _ _));
   norm_cast;
   linarith,
+end
+
+lemma integral_sin_pow_antimono :
+  ∫ x in 0..π, sin x ^ (n + 1) ≤ ∫ x in 0..π, sin x ^ n :=
+begin
+  refine integral_mono_on _ _ pi_pos.le (λ x hx, _),
+  { exact ((continuous_pow (n + 1)).comp continuous_sin).interval_integrable 0 π },
+  { exact ((continuous_pow n).comp continuous_sin).interval_integrable 0 π },
+  { refine pow_le_pow_of_le_one (sin_nonneg_of_mem_Icc _) (sin_le_one x) (nat.le_add_right n 1),
+    rwa interval_of_le pi_pos.le at hx },
 end

--- a/src/analysis/special_functions/integrals.lean
+++ b/src/analysis/special_functions/integrals.lean
@@ -250,9 +250,9 @@ begin
   let C := sin a ^ (n + 1) * cos a - sin b ^ (n + 1) * cos b,
   have h : ∀ α β γ : ℝ, α * (β * α * γ) = β * (α * α * γ) := λ α β γ, by ring,
   have hu : ∀ x ∈ _, has_deriv_at (λ y, sin y ^ (n + 1)) ((n + 1) * cos x * sin x ^ n) x :=
-    λ x hx, by simpa [mul_right_comm] using (has_deriv_at_pow _ _).comp x (has_deriv_at_sin x),
+    λ x hx, by simpa [mul_right_comm] using (has_deriv_at_sin x).pow,
   have hv : ∀ x ∈ interval a b, has_deriv_at (-cos) (sin x) x :=
-    λ x hx, by simpa using (has_deriv_at_cos x).neg,
+    λ x hx, by simpa only [neg_neg] using (has_deriv_at_cos x).neg,
   have H := integral_mul_deriv_eq_deriv_mul hu hv _ _,
   calc  ∫ x in a..b, sin x ^ (n + 2)
       = ∫ x in a..b, sin x ^ (n + 1) * sin x : by simp only [pow_succ']

--- a/src/data/real/pi.lean
+++ b/src/data/real/pi.lean
@@ -280,17 +280,6 @@ end
 
 open finset interval_integral
 
-lemma integral_sin_pow_antimono (n : ℕ) :
-  ∫ (x : ℝ) in 0..π, sin x ^ (n + 1) ≤ ∫ (x : ℝ) in 0..π, sin x ^ n :=
-begin
-  refine integral_mono_on _ _ pi_pos.le (λ x hx, _),
-  { exact ((continuous_pow (n + 1)).comp continuous_sin).interval_integrable 0 π },
-  { exact ((continuous_pow n).comp continuous_sin).interval_integrable 0 π },
-  refine pow_le_pow_of_le_one _ (sin_le_one x) (nat.le_add_right n 1),
-  rw interval_of_le pi_pos.le at hx,
-  exact sin_nonneg_of_mem_Icc hx,
-end
-
 lemma integral_sin_pow_div_tendsto_one :
   tendsto (λ k, (∫ x in 0..π, sin x ^ (2 * k + 1)) / ∫ x in 0..π, sin x ^ (2 * k)) at_top (𝓝 1) :=
 begin

--- a/src/data/real/pi.lean
+++ b/src/data/real/pi.lean
@@ -276,6 +276,8 @@ begin
                ... = 1 - (u k) + (u k)^(2*(k:ℝ)+1) : by { rw [← pow_succ' (U:ℝ) (2*k)], norm_cast },
 end
 
+/-! ### The Wallis Product for Pi -/
+
 open finset interval_integral
 
 lemma integral_sin_pow_antimono (n : ℕ) :
@@ -296,7 +298,7 @@ begin
     λ n, (div_le_one (integral_sin_pow_pos _)).mpr (integral_sin_pow_antimono _),
   have h₄ :
     ∀ n, (∫ x in 0..π, sin x ^ (2 * n + 1)) / ∫ x in 0..π, sin x ^ (2 * n) ≥ 2 * n / (2 * n + 1),
-  { intro, cases n,
+  { rintro ⟨n⟩,
     { have : 0 ≤ (1 + 1) / π, exact div_nonneg (by norm_num) pi_pos.le,
       simp [this] },
     calc (∫ x in 0..π, sin x ^ (2 * n.succ + 1)) / ∫ x in 0..π, sin x ^ (2 * n.succ) ≥
@@ -304,21 +306,19 @@ begin
       by { refine div_le_div (integral_sin_pow_pos _).le (le_refl _) (integral_sin_pow_pos _) _,
         convert integral_sin_pow_antimono (2 * n + 1) using 1 }
     ... = 2 * ↑(n.succ) / (2 * ↑(n.succ) + 1) :
-      by { symmetry, rw [eq_div_iff, nat.succ_eq_add_one],
-        convert (integral_sin_pow_succ_succ (2 * n + 1)).symm using 3,
-        simp [mul_add], ring, simp [mul_add], ring,
-        exact norm_num.ne_zero_of_pos  _ (integral_sin_pow_pos (2 * n + 1)) } },
+      by { rw div_eq_iff (integral_sin_pow_pos (2 * n + 1)).ne',
+           convert integral_sin_pow (2 * n + 1), simp with field_simps, norm_cast } },
   refine tendsto_of_tendsto_of_tendsto_of_le_of_le _ _ (λ n, (h₄ n).le) (λ n, (h₃ n)),
   { refine metric.tendsto_at_top.mpr (λ ε hε, ⟨nat_ceil (1 / ε), λ n hn, _⟩),
     have h : (2:ℝ) * n / (2 * n + 1) - 1 = -1 / (2 * n + 1),
     { conv_lhs { congr, skip, rw ← @div_self _ _ ((2:ℝ) * n + 1) (by { norm_cast, linarith }), },
       rw [← sub_div, ← sub_sub, sub_self, zero_sub] },
     have hpos : (0:ℝ) < 2 * n + 1, { norm_cast, norm_num },
-    rw [real.dist_eq, h, abs_div, abs_neg, abs_one, abs_of_pos hpos, one_div_lt hpos hε],
+    rw [dist_eq, h, abs_div, abs_neg, abs_one, abs_of_pos hpos, one_div_lt hpos hε],
     calc 1 / ε ≤ nat_ceil (1 / ε) : le_nat_ceil _
           ... ≤ n : by exact_mod_cast hn.le
           ... < 2 * n + 1 : by { norm_cast, linarith } },
-  exact tendsto_const_nhds,
+  { exact tendsto_const_nhds },
 end
 
 /-- This theorem establishes the Wallis Product for `π`. Our proof is largely about analyzing

--- a/test/integration.lean
+++ b/test/integration.lean
@@ -30,6 +30,7 @@ example : ∫ x in 0..π/4, cos x = sqrt 2 / 2 := by simp
 example : ∫ x in 0..π, 2 * sin x = 4 := by norm_num
 example : ∫ x in 0..π/2, cos x / 2 = 1 / 2 := by simp
 example : ∫ x : ℝ in 0..1, 1 / (1 + x ^ 2) = π/4 := by simp
+example : ∫ x in 0..2*π, sin x ^ 2 = π := by simp [mul_div_cancel_left]
 example : ∫ x in 0..π, cos x ^ 2 - sin x ^ 2 = 0 := by simp [integral_cos_sq_sub_sin_sq]
 
 /- the exponential function -/


### PR DESCRIPTION
The reduction of `∫ x in a..b, sin x ^ n`, ∀ n ∈ ℕ, 2 ≤ n.

We had this for the integral over [0, π] but I don't see any reason not to generalize it to any [a, b].

This also allows for the derivation of the integral of `sin x ^ 2` as a special case.

---
The integral of `cos x ^ n` will follow in a future PR.
