### PR TITLE
[Merged by Bors] - chore(.docker): fix alpine docker build

### DIFF
--- a/.docker/alpine/lean/Dockerfile
+++ b/.docker/alpine/lean/Dockerfile
@@ -32,7 +32,7 @@ FROM six8/pyinstaller-alpine:alpine-3.6-pyinstaller-v3.4 as leanproject-builder
 
 USER root
 # install prerequisites
-RUN apk update && apk add --no-cache python3 py3-pip py3-virtualenv
+RUN apk update && apk add --no-cache python3 py3-pip py3-virtualenv make
 # create a non-root user
 RUN adduser -D lean
 


### PR DESCRIPTION
A dependency for building mathlibtools had gained a requirement of having `make` available, so we install that.

This doesn't affect the produced image, and we only install `make` in an intermediate image.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
