### PR TITLE
[Merged by Bors] - feat(set_theory/{surreal, pgame}): `mul_comm` for surreal numbers 

### DIFF
--- a/src/set_theory/game/impartial.lean
+++ b/src/set_theory/game/impartial.lean
@@ -69,7 +69,7 @@ begin
   introsI hG hH,
   rw impartial_def,
   split,
-  { apply equiv_trans _ (equiv_of_relabelling (neg_add_relabelling G H)).symm,
+  { apply equiv_trans _ (neg_add_relabelling G H).equiv.symm,
     exact add_congr (neg_equiv_self _) (neg_equiv_self _) },
   split,
   all_goals

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -781,7 +781,7 @@ instance : has_sub pgame := ⟨λ x y, x + -y⟩
 
 /-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
 then `w - y` has the same moves as `x - z`. -/
-theorem sub_congr_relabelling {w x y z : pgame}
+def sub_congr_relabelling {w x y z : pgame}
   (h₁ : w.relabelling x) (h₂ : y.relabelling z) : (w - y).relabelling (x - z) :=
 add_congr_relabelling h₁ (neg_congr_relabelling h₂)
 

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -518,10 +518,10 @@ theorem le_of_relabelling {x y : pgame} (r : relabelling x y) : x ≤ y :=
 le_of_restricted (restricted_of_relabelling r)
 
 /-- A relabelling lets us prove equivalence of games. -/
-theorem equiv_of_relabelling {x y : pgame} (r : relabelling x y) : x ≈ y :=
+theorem relabelling.equiv {x y : pgame} (r : relabelling x y) : x ≈ y :=
 ⟨le_of_relabelling r, le_of_relabelling r.symm⟩
 
-instance {x y : pgame} : has_coe (relabelling x y) (x ≈ y) := ⟨equiv_of_relabelling⟩
+instance {x y : pgame} : has_coe (relabelling x y) (x ≈ y) := ⟨relabelling.equiv⟩
 
 /-- Replace the types indexing the next moves for Left and Right by equivalent types. -/
 def relabel {x : pgame} {xl' xr'} (el : x.left_moves ≃ xl') (er : x.right_moves ≃ xr') :=
@@ -601,11 +601,11 @@ end
 by { cases x, refl }
 
 /-- If `x` has the same moves as `y`, then `-x` has the sames moves as `-y`. -/
-def neg_congr_relabelling : ∀ {x y : pgame}, x.relabelling y → (-x).relabelling (-y)
+def relabelling.neg_congr : ∀ {x y : pgame}, x.relabelling y → (-x).relabelling (-y)
 | (mk xl xr xL xR) (mk yl yr yL yR) ⟨L_equiv, R_equiv, L_relabelling, R_relabelling⟩ :=
   ⟨R_equiv, L_equiv,
-    λ i, neg_congr_relabelling (by simpa using R_relabelling (R_equiv i)),
-    λ i, neg_congr_relabelling (by simpa using L_relabelling (L_equiv.symm i))⟩
+    λ i, relabelling.neg_congr (by simpa using R_relabelling (R_equiv i)),
+    λ i, relabelling.neg_congr (by simpa using L_relabelling (L_equiv.symm i))⟩
 
 theorem le_iff_neg_ge : Π {x y : pgame}, x ≤ y ↔ -y ≤ -x
 | (mk xl xr xL xR) (mk yl yr yL yR) :=
@@ -692,7 +692,7 @@ end
 
 /-- `x + 0` is equivalent to `x`. -/
 lemma add_zero_equiv (x : pgame.{u}) : x + 0 ≈ x :=
-equiv_of_relabelling (add_zero_relabelling x)
+(add_zero_relabelling x).equiv
 
 /-- `0 + x` has exactly the same moves as `x`. -/
 def zero_add_relabelling : Π (x : pgame.{u}), relabelling (0 + x) x
@@ -707,7 +707,7 @@ end
 
 /-- `0 + x` is equivalent to `x`. -/
 lemma zero_add_equiv (x : pgame.{u}) : 0 + x ≈ x :=
-equiv_of_relabelling (zero_add_relabelling x)
+(zero_add_relabelling x).equiv
 
 /-- An explicit equivalence between the moves for Left in `x + y` and the type-theory sum
     of the moves for Left in `x` and in `y`. -/
@@ -753,7 +753,7 @@ by { cases x, cases y, refl, }
 
 /-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
 then `w + y` has the same moves as `x + z`. -/
-def add_congr_relabelling : ∀ {w x y z : pgame.{u}},
+def relabelling.add_congr : ∀ {w x y z : pgame.{u}},
 w.relabelling x → y.relabelling z → (w + y).relabelling (x + z)
 | (mk wl wr wL wR) (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR)
   ⟨L_equiv₁, R_equiv₁, L_relabelling₁, R_relabelling₁⟩
@@ -761,17 +761,17 @@ w.relabelling x → y.relabelling z → (w + y).relabelling (x + z)
 begin
   refine ⟨equiv.sum_congr L_equiv₁ L_equiv₂, equiv.sum_congr R_equiv₁ R_equiv₂, _, _⟩,
   { rintro (i|j),
-    { exact add_congr_relabelling
+    { exact relabelling.add_congr
         (L_relabelling₁ i)
         (⟨L_equiv₂, R_equiv₂, L_relabelling₂, R_relabelling₂⟩) },
-    { exact add_congr_relabelling
+    { exact relabelling.add_congr
         (⟨L_equiv₁, R_equiv₁, L_relabelling₁, R_relabelling₁⟩)
         (L_relabelling₂ j) }},
   { rintro (i|j),
-    { exact add_congr_relabelling
+    { exact relabelling.add_congr
         (R_relabelling₁ i)
         (⟨L_equiv₂, R_equiv₂, L_relabelling₂, R_relabelling₂⟩) },
-    { exact add_congr_relabelling
+    { exact relabelling.add_congr
         (⟨L_equiv₁, R_equiv₁, L_relabelling₁, R_relabelling₁⟩)
         (R_relabelling₂ j) }}
 end
@@ -781,9 +781,9 @@ instance : has_sub pgame := ⟨λ x y, x + -y⟩
 
 /-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
 then `w - y` has the same moves as `x - z`. -/
-def sub_congr_relabelling {w x y z : pgame}
+def relabelling.sub_congr {w x y z : pgame}
   (h₁ : w.relabelling x) (h₂ : y.relabelling z) : (w - y).relabelling (x - z) :=
-add_congr_relabelling h₁ (neg_congr_relabelling h₂)
+h₁.add_congr (h₂.neg_congr)
 
 /-- `-(x+y)` has exactly the same moves as `-x + -y`. -/
 def neg_add_relabelling : Π (x y : pgame), relabelling (-(x + y)) (-x + -y)
@@ -814,7 +814,7 @@ theorem add_comm_le {x y : pgame} : x + y ≤ y + x :=
 le_of_relabelling (add_comm_relabelling x y)
 
 theorem add_comm_equiv {x y : pgame} : x + y ≈ y + x :=
-equiv_of_relabelling (add_comm_relabelling x y)
+(add_comm_relabelling x y).equiv
 
 /-- `(x + y) + z` has exactly the same moves as `x + (y + z)`. -/
 def add_assoc_relabelling : Π (x y z : pgame.{u}), relabelling ((x + y) + z) (x + (y + z))
@@ -841,7 +841,7 @@ end
 using_well_founded { dec_tac := pgame_wf_tac }
 
 theorem add_assoc_equiv {x y z : pgame} : (x + y) + z ≈ x + (y + z) :=
-equiv_of_relabelling (add_assoc_relabelling x y z)
+(add_assoc_relabelling x y z).equiv
 
 theorem add_le_add_right : Π {x y z : pgame} (h : x ≤ y), x + z ≤ y + z
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) :=

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -779,6 +779,12 @@ using_well_founded { dec_tac := pgame_wf_tac }
 
 instance : has_sub pgame := ⟨λ x y, x + -y⟩
 
+/-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
+then `w - y` has the same moves as `x - z`. -/
+theorem sub_congr_relabelling {w x y z : pgame}
+  (h₁ : w.relabelling x) (h₂ : y.relabelling z) : (w - y).relabelling (x - z) :=
+add_congr_relabelling h₁ (neg_congr_relabelling h₂)
+
 /-- `-(x+y)` has exactly the same moves as `-x + -y`. -/
 def neg_add_relabelling : Π (x y : pgame), relabelling (-(x + y)) (-x + -y)
 | (mk xl xr xL xR) (mk yl yr yL yR) :=

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -453,14 +453,14 @@ using_well_founded { dec_tac := pgame_wf_tac }
 
 -- TODO trans for restricted
 
-theorem le_of_restricted : Π {x y : pgame} (r : restricted x y), x ≤ y
+theorem restricted.le : Π {x y : pgame} (r : restricted x y), x ≤ y
 | (mk xl xr xL xR) (mk yl yr yL yR)
   (restricted.mk L_embedding R_embedding L_restriction R_restriction) :=
 begin
   rw le_def,
   exact
-    ⟨λ i, or.inl ⟨L_embedding i, le_of_restricted (L_restriction i)⟩,
-     λ i, or.inr ⟨R_embedding i, le_of_restricted (R_restriction i)⟩⟩
+    ⟨λ i, or.inl ⟨L_embedding i, (L_restriction i).le⟩,
+     λ i, or.inr ⟨R_embedding i, (R_restriction i).le⟩⟩
 end
 
 /--
@@ -476,11 +476,11 @@ inductive relabelling : pgame.{u} → pgame.{u} → Type (u+1)
 
 /-- If `x` is a relabelling of `y`, then Left and Right have the same moves in either game,
     so `x` is a restriction of `y`. -/
-def restricted_of_relabelling : Π {x y : pgame} (r : relabelling x y), restricted x y
+def relabelling.restricted: Π {x y : pgame} (r : relabelling x y), restricted x y
 | (mk xl xr xL xR) (mk yl yr yL yR) (relabelling.mk L_equiv R_equiv L_relabelling R_relabelling) :=
 restricted.mk L_equiv.to_embedding R_equiv.symm.to_embedding
-  (λ i, restricted_of_relabelling (L_relabelling i))
-  (λ j, restricted_of_relabelling (R_relabelling j))
+  (λ i, (L_relabelling i).restricted)
+  (λ j, (R_relabelling j).restricted)
 
 -- It's not the case that `restricted x y → restricted y x → relabelling x y`,
 -- but if we insisted that the maps in a restriction were injective, then one
@@ -514,12 +514,12 @@ begin
   { intro j, simpa using (R_relabelling₁ _).trans (R_relabelling₂ _) },
 end
 
-theorem le_of_relabelling {x y : pgame} (r : relabelling x y) : x ≤ y :=
-le_of_restricted (restricted_of_relabelling r)
+theorem relabelling.le {x y : pgame} (r : relabelling x y) : x ≤ y :=
+(r.restricted).le
 
 /-- A relabelling lets us prove equivalence of games. -/
 theorem relabelling.equiv {x y : pgame} (r : relabelling x y) : x ≈ y :=
-⟨le_of_relabelling r, le_of_relabelling r.symm⟩
+⟨r.le, r.symm.le⟩
 
 instance {x y : pgame} : has_coe (relabelling x y) (x ≈ y) := ⟨relabelling.equiv⟩
 
@@ -798,7 +798,7 @@ def neg_add_relabelling : Π (x y : pgame), relabelling (-(x + y)) (-x + -y)
 using_well_founded { dec_tac := pgame_wf_tac }
 
 theorem neg_add_le {x y : pgame} : -(x + y) ≤ -x + -y :=
-le_of_relabelling (neg_add_relabelling x y)
+(neg_add_relabelling x y).le
 
 /-- `x+y` has exactly the same moves as `y+x`. -/
 def add_comm_relabelling : Π (x y : pgame.{u}), relabelling (x + y) (y + x)
@@ -811,7 +811,7 @@ end
 using_well_founded { dec_tac := pgame_wf_tac }
 
 theorem add_comm_le {x y : pgame} : x + y ≤ y + x :=
-le_of_relabelling (add_comm_relabelling x y)
+(add_comm_relabelling x y).le
 
 theorem add_comm_equiv {x y : pgame} : x + y ≈ y + x :=
 (add_comm_relabelling x y).equiv
@@ -948,13 +948,13 @@ calc 0 ≤ (-x) + x : zero_le_add_left_neg
 theorem add_lt_add_right {x y z : pgame} (h : x < y) : x + z < y + z :=
 suffices y + z ≤ x + z → y ≤ x, by { rw ←not_le at ⊢ h, exact mt this h },
 assume w,
-calc y ≤ y + 0            : le_of_relabelling (add_zero_relabelling _).symm
+calc y ≤ y + 0            : (add_zero_relabelling _).symm.le
      ... ≤ y + (z + -z)   : add_le_add_left zero_le_add_right_neg
-     ... ≤ (y + z) + (-z) : le_of_relabelling (add_assoc_relabelling _ _ _).symm
+     ... ≤ (y + z) + (-z) : (add_assoc_relabelling _ _ _).symm.le
      ... ≤ (x + z) + (-z) : add_le_add_right w
-     ... ≤ x + (z + -z)   : le_of_relabelling (add_assoc_relabelling _ _ _)
+     ... ≤ x + (z + -z)   : (add_assoc_relabelling _ _ _).le
      ... ≤ x + 0          : add_le_add_left add_right_neg_le_zero
-     ... ≤ x              : le_of_relabelling (add_zero_relabelling _)
+     ... ≤ x              : (add_zero_relabelling _).le
 
 theorem add_lt_add_left {x y z : pgame} (h : y < z) : x + y < x + z :=
 calc x + y ≤ y + x : add_comm_le
@@ -964,19 +964,19 @@ calc x + y ≤ y + x : add_comm_le
 theorem le_iff_sub_nonneg {x y : pgame} : x ≤ y ↔ 0 ≤ y - x :=
 ⟨λ h, le_trans zero_le_add_right_neg (add_le_add_right h),
  λ h,
-  calc x ≤ 0 + x : le_of_relabelling (zero_add_relabelling x).symm
+  calc x ≤ 0 + x : (zero_add_relabelling x).symm.le
      ... ≤ (y - x) + x : add_le_add_right h
-     ... ≤ y + (-x + x) : le_of_relabelling (add_assoc_relabelling _ _ _)
+     ... ≤ y + (-x + x) : (add_assoc_relabelling _ _ _).le
      ... ≤ y + 0 : add_le_add_left (add_left_neg_le_zero)
-     ... ≤ y : le_of_relabelling (add_zero_relabelling y)⟩
+     ... ≤ y : (add_zero_relabelling y).le⟩
 theorem lt_iff_sub_pos {x y : pgame} : x < y ↔ 0 < y - x :=
 ⟨λ h, lt_of_le_of_lt zero_le_add_right_neg (add_lt_add_right h),
  λ h,
-  calc x ≤ 0 + x : le_of_relabelling (zero_add_relabelling x).symm
+  calc x ≤ 0 + x : (zero_add_relabelling x).symm.le
      ... < (y - x) + x : add_lt_add_right h
-     ... ≤ y + (-x + x) : le_of_relabelling (add_assoc_relabelling _ _ _)
+     ... ≤ y + (-x + x) : (add_assoc_relabelling _ _ _).le
      ... ≤ y + 0 : add_le_add_left (add_left_neg_le_zero)
-     ... ≤ y : le_of_relabelling (add_zero_relabelling y)⟩
+     ... ≤ y : (add_zero_relabelling y).le⟩
 
 /-- The pre-game `star`, which is fuzzy/confused with zero. -/
 def star : pgame := pgame.of_lists [0] [0]

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -744,6 +744,32 @@ rfl
   (x + y).move_right ((@right_moves_add x y).symm (sum.inr i)) = x + y.move_right i :=
 by { cases x, cases y, refl, }
 
+/-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
+then `w + y` has the same moves as `x + z`. -/
+def add_congr_relabelling : ∀ {w x y z : pgame},
+w.relabelling x → y.relabelling z → (w + y).relabelling (x + z)
+| (mk wl wr wL wR) (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR)
+  ⟨L_equiv₁, R_equiv₁, L_relabelling₁, R_relabelling₁⟩
+  ⟨L_equiv₂, R_equiv₂, L_relabelling₂, R_relabelling₂⟩ :=
+begin
+  refine ⟨equiv.sum_congr L_equiv₁ L_equiv₂, equiv.sum_congr R_equiv₁ R_equiv₂, _, _⟩,
+  { rintro (i|j),
+    { exact add_congr_relabelling
+        (L_relabelling₁ i)
+        (⟨L_equiv₂, R_equiv₂, L_relabelling₂, R_relabelling₂⟩) },
+    { exact add_congr_relabelling
+        (⟨L_equiv₁, R_equiv₁, L_relabelling₁, R_relabelling₁⟩)
+        (L_relabelling₂ j) }},
+  { rintro (i|j),
+    { exact add_congr_relabelling
+        (R_relabelling₁ i)
+        (⟨L_equiv₂, R_equiv₂, L_relabelling₂, R_relabelling₂⟩) },
+    { exact add_congr_relabelling
+        (⟨L_equiv₁, R_equiv₁, L_relabelling₁, R_relabelling₁⟩)
+        (R_relabelling₂ j) }}
+end
+using_well_founded { dec_tac := pgame_wf_tac }
+
 instance : has_sub pgame := ⟨λ x y, x + -y⟩
 
 /-- `-(x+y)` has exactly the same moves as `-x + -y`. -/

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -515,7 +515,7 @@ begin
 end
 
 theorem relabelling.le {x y : pgame} (r : relabelling x y) : x ≤ y :=
-(r.restricted).le
+r.restricted.le
 
 /-- A relabelling lets us prove equivalence of games. -/
 theorem relabelling.equiv {x y : pgame} (r : relabelling x y) : x ≈ y :=
@@ -754,7 +754,7 @@ by { cases x, cases y, refl, }
 /-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
 then `w + y` has the same moves as `x + z`. -/
 def relabelling.add_congr : ∀ {w x y z : pgame.{u}},
-w.relabelling x → y.relabelling z → (w + y).relabelling (x + z)
+  w.relabelling x → y.relabelling z → (w + y).relabelling (x + z)
 | (mk wl wr wL wR) (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR)
   ⟨L_equiv₁, R_equiv₁, L_relabelling₁, R_relabelling₁⟩
   ⟨L_equiv₂, R_equiv₂, L_relabelling₂, R_relabelling₂⟩ :=
@@ -783,7 +783,7 @@ instance : has_sub pgame := ⟨λ x y, x + -y⟩
 then `w - y` has the same moves as `x - z`. -/
 def relabelling.sub_congr {w x y z : pgame}
   (h₁ : w.relabelling x) (h₂ : y.relabelling z) : (w - y).relabelling (x - z) :=
-h₁.add_congr (h₂.neg_congr)
+h₁.add_congr h₂.neg_congr
 
 /-- `-(x+y)` has exactly the same moves as `-x + -y`. -/
 def neg_add_relabelling : Π (x y : pgame), relabelling (-(x + y)) (-x + -y)

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -600,6 +600,13 @@ end
   move_right (-x) ((right_moves_neg x).symm i) = -(move_left x i) :=
 by { cases x, refl }
 
+/-- If `x` has the same moves as `y`, then `-x` has the sames moves as `-y`. -/
+def neg_congr_relabelling : ∀ {x y : pgame}, x.relabelling y → (-x).relabelling (-y)
+| (mk xl xr xL xR) (mk yl yr yL yR) ⟨L_equiv, R_equiv, L_relabelling, R_relabelling⟩ :=
+  ⟨R_equiv, L_equiv,
+    λ i, neg_congr_relabelling (by simpa using R_relabelling (R_equiv i)),
+    λ i, neg_congr_relabelling (by simpa using L_relabelling (L_equiv.symm i))⟩
+
 theorem le_iff_neg_ge : Π {x y : pgame}, x ≤ y ↔ -y ≤ -x
 | (mk xl xr xL xR) (mk yl yr yL yR) :=
 begin

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -753,7 +753,7 @@ by { cases x, cases y, refl, }
 
 /-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
 then `w + y` has the same moves as `x + z`. -/
-def add_congr_relabelling : ∀ {w x y z : pgame},
+def add_congr_relabelling : ∀ {w x y z : pgame.{u}},
 w.relabelling x → y.relabelling z → (w + y).relabelling (x + z)
 | (mk wl wr wL wR) (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR)
   ⟨L_equiv₁, R_equiv₁, L_relabelling₁, R_relabelling₁⟩

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -77,44 +77,44 @@ def right_moves_mul (x y : pgame) : (x * y).right_moves
 by { cases x, cases y, refl, }
 
 @[simp] lemma mk_mul_move_left_inl {xl xr yl yr} {xL xR yL yR} {i j} :
-  (mk xl xr xL xR * mk yl yr yL yR).move_left (sum.inl (i,j))
-  = xL i * (mk yl yr yL yR) + (mk xl xr xL xR) * yL j - xL i * yL j
-:= rfl
+  (mk xl xr xL xR * mk yl yr yL yR).move_left (sum.inl (i, j))
+  = xL i * (mk yl yr yL yR) + (mk xl xr xL xR) * yL j - xL i * yL j :=
+ rfl
 
 @[simp] lemma mul_move_left_inl {x y : pgame} {i j} :
-   (x * y).move_left ((left_moves_mul x y).symm (sum.inl (i,j)))
-   = x.move_left i * y + x * y.move_left j - x.move_left i * y.move_left j
-:= by {cases x, cases y, refl}
+   (x * y).move_left ((left_moves_mul x y).symm (sum.inl (i, j)))
+   = x.move_left i * y + x * y.move_left j - x.move_left i * y.move_left j :=
+by {cases x, cases y, refl}
 
 @[simp] lemma mk_mul_move_left_inr {xl xr yl yr} {xL xR yL yR} {i j} :
-  (mk xl xr xL xR * mk yl yr yL yR).move_left (sum.inr (i,j))
-  = xR i * (mk yl yr yL yR) + (mk xl xr xL xR) * yR j - xR i * yR j
-:= rfl
+  (mk xl xr xL xR * mk yl yr yL yR).move_left (sum.inr (i, j))
+  = xR i * (mk yl yr yL yR) + (mk xl xr xL xR) * yR j - xR i * yR j :=
+rfl
 
 @[simp] lemma mul_move_left_inr {x y : pgame} {i j} :
-   (x * y).move_left ((left_moves_mul x y).symm (sum.inr (i,j)))
-   = x.move_right i * y + x * y.move_right j - x.move_right i * y.move_right j
-:= by {cases x, cases y, refl}
+   (x * y).move_left ((left_moves_mul x y).symm (sum.inr (i, j)))
+   = x.move_right i * y + x * y.move_right j - x.move_right i * y.move_right j :=
+by {cases x, cases y, refl}
 
 @[simp] lemma mk_mul_move_right_inl {xl xr yl yr} {xL xR yL yR} {i j} :
-  (mk xl xr xL xR * mk yl yr yL yR).move_right (sum.inl (i,j))
-  = xL i * (mk yl yr yL yR) + (mk xl xr xL xR) * yR j - xL i * yR j
-:= rfl
+  (mk xl xr xL xR * mk yl yr yL yR).move_right (sum.inl (i, j))
+  = xL i * (mk yl yr yL yR) + (mk xl xr xL xR) * yR j - xL i * yR j :=
+rfl
 
 @[simp] lemma mul_move_right_inl {x y : pgame} {i j} :
    (x * y).move_right ((right_moves_mul x y).symm (sum.inr (i, j)))
-   = x.move_right i * y + x * y.move_left j - x.move_right i * y.move_left j
-:= by {cases x, cases y, refl}
+   = x.move_right i * y + x * y.move_left j - x.move_right i * y.move_left j :=
+by {cases x, cases y, refl}
 
 @[simp] lemma mk_mul_move_right_inr {xl xr yl yr} {xL xR yL yR} {i j} :
   (mk xl xr xL xR * mk yl yr yL yR).move_right (sum.inr (i,j))
-  = xR i * (mk yl yr yL yR) + (mk xl xr xL xR) * yL j - xR i * yL j
-:= rfl
+  = xR i * (mk yl yr yL yR) + (mk xl xr xL xR) * yL j - xR i * yL j :=
+rfl
 
 @[simp] lemma mul_move_right_inr {x y : pgame} {i j} :
-   (x * y).move_right ((right_moves_mul x y).symm (sum.inr (i,j)))
-   = x.move_right i * y + x * y.move_left j - x.move_right i * y.move_left j
-:= by {cases x, cases y, refl}
+   (x * y).move_right ((right_moves_mul x y).symm (sum.inr (i, j)))
+   = x.move_right i * y + x * y.move_left j - x.move_right i * y.move_left j :=
+by {cases x, cases y, refl}
 
 /-- If `a` has the same moves as `x`, `b` has the same moves as `y`,
 and `c` has the same moves as `z`, then `a + b - c` has the same moves as `x + y - z`.

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -102,8 +102,8 @@ by {cases x, cases y, refl}
 rfl
 
 @[simp] lemma mul_move_right_inl {x y : pgame} {i j} :
-   (x * y).move_right ((right_moves_mul x y).symm (sum.inr (i, j)))
-   = x.move_right i * y + x * y.move_left j - x.move_right i * y.move_left j :=
+   (x * y).move_right ((right_moves_mul x y).symm (sum.inl (i, j)))
+   = x.move_left i * y + x * y.move_right j - x.move_left i * y.move_right j :=
 by {cases x, cases y, refl}
 
 @[simp] lemma mk_mul_move_right_inr {xl xr yl yr} {xL xR yL yR} {i j} :

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -66,6 +66,56 @@ end
 
 instance : has_mul pgame := ⟨mul⟩
 
+/-- An explicit description of the moves for Left in `x * y`. -/
+def left_moves_mul {x y : pgame} : (x * y).left_moves
+  ≃ x.left_moves × y.left_moves ⊕ x.right_moves × y.right_moves :=
+by { cases x, cases y, refl, }
+
+/-- An explicit description of the moves for Right in `x * y`. -/
+def right_moves_mul {x y : pgame} : (x * y).right_moves
+  ≃ x.left_moves × y.right_moves ⊕ x.right_moves × y.left_moves :=
+by { cases x, cases y, refl, }
+
+@[simp] lemma mk_mul_move_left_inl {xl xr yl yr} {xL xR yL yR} {i j} :
+  (mk xl xr xL xR * mk yl yr yL yR).move_left (sum.inl (i,j))
+  = xL i * (mk yl yr yL yR) + (mk xl xr xL xR) * yL j - xL i * yL j
+:= rfl
+
+@[simp] lemma mul_move_left_inl {x y : pgame} {i j} :
+   (x * y).move_left ((@left_moves_mul x y).symm (sum.inl (i,j)))
+   = x.move_left i * y + x * y.move_left j - x.move_left i * y.move_left j
+:= by {cases x, cases y, refl}
+
+@[simp] lemma mk_mul_move_left_inr {xl xr yl yr} {xL xR yL yR} {i j} :
+  (mk xl xr xL xR * mk yl yr yL yR).move_left (sum.inr (i,j))
+  = xR i * (mk yl yr yL yR) + (mk xl xr xL xR) * yR j - xR i * yR j
+:= rfl
+
+@[simp] lemma mul_move_left_inr {x y : pgame} {i j} :
+   (x * y).move_left ((@left_moves_mul x y).symm (sum.inr (i,j)))
+   = x.move_right i * y + x * y.move_right j - x.move_right i * y.move_right j
+:= by {cases x, cases y, refl}
+
+@[simp] lemma mk_mul_move_right_inl {xl xr yl yr} {xL xR yL yR} {i j} :
+  (mk xl xr xL xR * mk yl yr yL yR).move_right (sum.inl (i,j))
+  = xL i * (mk yl yr yL yR) + (mk xl xr xL xR) * yR j - xL i * yR j
+:= rfl
+
+@[simp] lemma mul_move_right_inl {x y : pgame} {i j} :
+   (x * y).move_right ((@right_moves_mul x y).symm (sum.inr (i, j)))
+   = x.move_right i * y + x * y.move_left j - x.move_right i * y.move_left j
+:= by {cases x, cases y, refl}
+
+@[simp] lemma mk_mul_move_right_inr {xl xr yl yr} {xL xR yL yR} {i j} :
+  (mk xl xr xL xR * mk yl yr yL yR).move_right (sum.inr (i,j))
+  = xR i * (mk yl yr yL yR) + (mk xl xr xL xR) * yL j - xR i * yL j
+:= rfl
+
+@[simp] lemma mul_move_right_inr {x y : pgame} {i j} :
+   (x * y).move_right ((@right_moves_mul x y).symm (sum.inr (i,j)))
+   = x.move_right i * y + x * y.move_left j - x.move_right i * y.move_left j
+:= by {cases x, cases y, refl}
+
 /-- Because the two halves of the definition of `inv` produce more elements
 of each side, we have to define the two families inductively.
 This is the indexing set for the function, and `inv_val` is the function part. -/

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -133,6 +133,55 @@ lemma add_comm_sub_relabelling {a b c x y z : pgame}
 sub_congr_relabelling
   (relabelling.trans (add_comm_relabelling a b) (add_congr_relabelling h₂ h₁)) h₃
 
+/-- `x * y` has exactly the same moves as `y * x`. -/
+theorem mul_comm_relabelling (x y : pgame) : (x * y).relabelling (y * x) :=
+begin
+  induction x with xl xr xL xR IHxl IHxr generalizing y,
+  induction y with yl yr yL yR IHyl IHyr,
+  let x := mk xl xr xL xR,
+  let y := mk yl yr yL yR,
+  refine ⟨equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _), _ ,_,_⟩,
+  calc
+   (x * y).right_moves
+       ≃ xl × yr ⊕ xr × yl : by refl
+   ... ≃ xr × yl ⊕ xl × yr : equiv.sum_comm _ _
+   ... ≃ yl × xr ⊕ yr × xl : equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _)
+   ... ≃ (y * x).right_moves : by refl,
+  { rintro (⟨i, j⟩ | ⟨i, j⟩),
+    { exact add_comm_sub_relabelling (IHxl i y) (IHyl j) (IHxl i (yL j)) },
+    { exact add_comm_sub_relabelling (IHxr i y) (IHyr j) (IHxr i (yR j)) }},
+  { rintro (⟨i, j⟩ | ⟨i, j⟩),
+    { exact add_comm_sub_relabelling (IHxr j y) (IHyl i) (IHxr j (yL i)) },
+    { exact add_comm_sub_relabelling (IHxl j y) (IHyr i) (IHxl j (yR i)) }}
+end
+
+/-- `x * y` is equivalent to `y * x`. -/
+theorem mul_comm_equiv (x y : pgame) : (x * y).equiv (y * x) :=
+equiv_of_relabelling (mul_comm_relabelling x y)
+
+/-- `x * 0` has exactly the same moves as `0`. -/
+theorem mul_zero_relabelling : Π (x : pgame), relabelling (x * 0) 0
+| (mk xl xr xL xR) :=
+⟨by fsplit; rintro (⟨_,⟨⟩⟩ | ⟨_,⟨⟩⟩),
+ by fsplit; rintro (⟨_,⟨⟩⟩ | ⟨_,⟨⟩⟩),
+ by rintro (⟨_,⟨⟩⟩ | ⟨_,⟨⟩⟩),
+ by rintro ⟨⟩⟩
+
+/-- `x * 0` is equivalent to `0`. -/
+theorem mul_zero_equiv (x : pgame) : (x * 0).equiv 0 :=
+equiv_of_relabelling (mul_zero_relabelling x)
+
+/-- `0 * x` has exactly the same moves as `0`. -/
+theorem zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
+| (mk xl xr xL xR) :=
+⟨by fsplit; rintro (⟨⟨⟩,_⟩ | ⟨⟨⟩,_⟩),
+ by fsplit; rintro (⟨⟨⟩,_⟩ | ⟨⟨⟩,_⟩),
+ by rintro (⟨⟨⟩,_⟩ | ⟨⟨⟩,_⟩),
+ by rintro ⟨⟩⟩
+
+/-- `0 * x` is equivalent to `0`. -/
+theorem zero_mul_equiv (x : pgame) : (0 * x).equiv 0 :=
+equiv_of_relabelling (zero_mul_relabelling x)
 /-- Because the two halves of the definition of `inv` produce more elements
 of each side, we have to define the two families inductively.
 This is the indexing set for the function, and `inv_val` is the function part. -/

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -131,7 +131,7 @@ lemma add_comm_sub_relabelling {a b c x y z : pgame}
   (h₁ : a.relabelling x) (h₂ : b.relabelling y) (h₃ : c.relabelling z) :
   (a + b - c).relabelling (y + x - z) :=
 sub_congr_relabelling
-  (relabelling.trans (add_comm_relabelling a b) (add_congr_relabelling h₂ h₁)) h₃
+  ((add_comm_relabelling a b).trans (add_congr_relabelling h₂ h₁)) h₃
 
 /-- `x * y` has exactly the same moves as `y * x`. -/
 theorem mul_comm_relabelling (x y : pgame) : (x * y).relabelling (y * x) :=

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -182,6 +182,7 @@ theorem zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
 /-- `0 * x` is equivalent to `0`. -/
 theorem zero_mul_equiv (x : pgame) : (0 * x).equiv 0 :=
 equiv_of_relabelling (zero_mul_relabelling x)
+
 /-- Because the two halves of the definition of `inv` produce more elements
 of each side, we have to define the two families inductively.
 This is the indexing set for the function, and `inv_val` is the function part. -/

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -140,7 +140,7 @@ begin
   induction y with yl yr yL yR IHyl IHyr,
   let x := mk xl xr xL xR,
   let y := mk yl yr yL yR,
-  refine ⟨equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _), _ ,_,_⟩,
+  refine ⟨equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _), _, _, _⟩,
   calc
    (x * y).right_moves
        ≃ xl × yr ⊕ xr × yl : by refl

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -122,7 +122,7 @@ This lemma is repeatedly used for simplifying multiplication of surreal numbers.
 def add_sub_relabelling {a b c x y z : pgame}
   (h₁ : a.relabelling x) (h₂ : b.relabelling y) (h₃ : c.relabelling z) :
   (a + b - c).relabelling (x + y - z) :=
-sub_congr_relabelling (add_congr_relabelling h₁ h₂) h₃
+(h₁.add_congr h₂).sub_congr h₃
 
 /-- If `a` has the same moves as `x`, `b` has the same moves as `y`,
 and `c` has the same moves as `z`, then `a + b - c` has the same moves as `y + x - z`.
@@ -130,8 +130,7 @@ This lemma is repeatedly used for simplifying multiplication of surreal numbers.
 def add_comm_sub_relabelling {a b c x y z : pgame}
   (h₁ : a.relabelling x) (h₂ : b.relabelling y) (h₃ : c.relabelling z) :
   (a + b - c).relabelling (y + x - z) :=
-sub_congr_relabelling
-  ((add_comm_relabelling a b).trans (add_congr_relabelling h₂ h₁)) h₃
+((add_comm_relabelling a b).trans (h₂.add_congr h₁)).sub_congr h₃
 
 /-- `x * y` has exactly the same moves as `y * x`. -/
 def mul_comm_relabelling (x y : pgame.{u}) : (x * y).relabelling (y * x) :=
@@ -157,7 +156,7 @@ end
 
 /-- `x * y` is equivalent to `y * x`. -/
 theorem mul_comm_equiv (x y : pgame) : (x * y).equiv (y * x) :=
-equiv_of_relabelling (mul_comm_relabelling x y)
+(mul_comm_relabelling x y).equiv
 
 /-- `x * 0` has exactly the same moves as `0`. -/
 def mul_zero_relabelling : Π (x : pgame), relabelling (x * 0) 0
@@ -169,7 +168,7 @@ def mul_zero_relabelling : Π (x : pgame), relabelling (x * 0) 0
 
 /-- `x * 0` is equivalent to `0`. -/
 theorem mul_zero_equiv (x : pgame) : (x * 0).equiv 0 :=
-equiv_of_relabelling (mul_zero_relabelling x)
+(mul_zero_relabelling x).equiv
 
 /-- `0 * x` has exactly the same moves as `0`. -/
 def zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
@@ -181,7 +180,7 @@ def zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
 
 /-- `0 * x` is equivalent to `0`. -/
 theorem zero_mul_equiv (x : pgame) : (0 * x).equiv 0 :=
-equiv_of_relabelling (zero_mul_relabelling x)
+(zero_mul_relabelling x).equiv
 
 /-- Because the two halves of the definition of `inv` produce more elements
 of each side, we have to define the two families inductively.
@@ -456,9 +455,9 @@ instance : ordered_add_comm_group surreal :=
   add_assoc         := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, exact quotient.sound add_assoc_equiv },
   zero              := 0,
   zero_add          := by { rintros ⟨_⟩, exact quotient.sound (pgame.zero_add_equiv _) },
-  add_zero          := by { rintros ⟨_⟩, exact quotient.sound (pgame.add_zero_equiv _) }, 
-  neg               := has_neg.neg, 
-  add_left_neg      := by { rintros ⟨_⟩, exact quotient.sound pgame.add_left_neg_equiv }, 
+  add_zero          := by { rintros ⟨_⟩, exact quotient.sound (pgame.add_zero_equiv _) },
+  neg               := has_neg.neg,
+  add_left_neg      := by { rintros ⟨_⟩, exact quotient.sound pgame.add_left_neg_equiv },
   add_comm          := by { rintros ⟨_⟩ ⟨_⟩, exact quotient.sound pgame.add_comm_equiv },
   le                := (≤),
   lt                := (<),
@@ -467,7 +466,7 @@ instance : ordered_add_comm_group surreal :=
   lt_iff_le_not_le  := by { rintros ⟨_, ox⟩ ⟨_, oy⟩, exact pgame.lt_iff_le_not_le ox oy },
   le_antisymm       := by { rintros ⟨_⟩ ⟨_⟩ h₁ h₂, exact quotient.sound ⟨h₁, h₂⟩ },
   add_le_add_left   := by { rintros ⟨_⟩ ⟨_⟩ hx ⟨_⟩, exact pgame.add_le_add_left hx } }
-  
+
 noncomputable instance : linear_ordered_add_comm_group surreal :=
 { le_total := by rintro ⟨⟨x, ox⟩⟩ ⟨⟨y, oy⟩⟩; classical; exact
     or_iff_not_imp_left.2 (λ h, le_of_lt oy ox (pgame.not_le.1 h)),

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -116,6 +116,23 @@ by { cases x, cases y, refl, }
    = x.move_right i * y + x * y.move_left j - x.move_right i * y.move_left j
 := by {cases x, cases y, refl}
 
+/-- If `a` has the same moves as `x`, `b` has the same moves as `y`,
+and `c` has the same moves as `z`, then `a + b - c` has the same moves as `x + y - z`.
+This lemma is repeatedly used for simplifying multiplication of surreal numbers. -/
+lemma add_sub_relabelling {a b c x y z : pgame}
+  (h₁ : a.relabelling x) (h₂ : b.relabelling y) (h₃ : c.relabelling z) :
+  (a + b - c).relabelling (x + y - z) :=
+sub_congr_relabelling (add_congr_relabelling h₁ h₂) h₃
+
+/-- If `a` has the same moves as `x`, `b` has the same moves as `y`,
+and `c` has the same moves as `z`, then `a + b - c` has the same moves as `y + x - z`.
+This lemma is repeatedly used for simplifying multiplication of surreal numbers. -/
+lemma add_comm_sub_relabelling {a b c x y z : pgame}
+  (h₁ : a.relabelling x) (h₂ : b.relabelling y) (h₃ : c.relabelling z) :
+  (a + b - c).relabelling (y + x - z) :=
+sub_congr_relabelling
+  (relabelling.trans (add_comm_relabelling a b) (add_congr_relabelling h₂ h₁)) h₃
+
 /-- Because the two halves of the definition of `inv` produce more elements
 of each side, we have to define the two families inductively.
 This is the indexing set for the function, and `inv_val` is the function part. -/

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -67,12 +67,12 @@ end
 instance : has_mul pgame := ⟨mul⟩
 
 /-- An explicit description of the moves for Left in `x * y`. -/
-def left_moves_mul {x y : pgame} : (x * y).left_moves
+def left_moves_mul (x y : pgame) : (x * y).left_moves
   ≃ x.left_moves × y.left_moves ⊕ x.right_moves × y.right_moves :=
 by { cases x, cases y, refl, }
 
 /-- An explicit description of the moves for Right in `x * y`. -/
-def right_moves_mul {x y : pgame} : (x * y).right_moves
+def right_moves_mul (x y : pgame) : (x * y).right_moves
   ≃ x.left_moves × y.right_moves ⊕ x.right_moves × y.left_moves :=
 by { cases x, cases y, refl, }
 
@@ -82,7 +82,7 @@ by { cases x, cases y, refl, }
 := rfl
 
 @[simp] lemma mul_move_left_inl {x y : pgame} {i j} :
-   (x * y).move_left ((@left_moves_mul x y).symm (sum.inl (i,j)))
+   (x * y).move_left ((left_moves_mul x y).symm (sum.inl (i,j)))
    = x.move_left i * y + x * y.move_left j - x.move_left i * y.move_left j
 := by {cases x, cases y, refl}
 
@@ -92,7 +92,7 @@ by { cases x, cases y, refl, }
 := rfl
 
 @[simp] lemma mul_move_left_inr {x y : pgame} {i j} :
-   (x * y).move_left ((@left_moves_mul x y).symm (sum.inr (i,j)))
+   (x * y).move_left ((left_moves_mul x y).symm (sum.inr (i,j)))
    = x.move_right i * y + x * y.move_right j - x.move_right i * y.move_right j
 := by {cases x, cases y, refl}
 
@@ -102,7 +102,7 @@ by { cases x, cases y, refl, }
 := rfl
 
 @[simp] lemma mul_move_right_inl {x y : pgame} {i j} :
-   (x * y).move_right ((@right_moves_mul x y).symm (sum.inr (i, j)))
+   (x * y).move_right ((right_moves_mul x y).symm (sum.inr (i, j)))
    = x.move_right i * y + x * y.move_left j - x.move_right i * y.move_left j
 := by {cases x, cases y, refl}
 
@@ -112,7 +112,7 @@ by { cases x, cases y, refl, }
 := rfl
 
 @[simp] lemma mul_move_right_inr {x y : pgame} {i j} :
-   (x * y).move_right ((@right_moves_mul x y).symm (sum.inr (i,j)))
+   (x * y).move_right ((right_moves_mul x y).symm (sum.inr (i,j)))
    = x.move_right i * y + x * y.move_left j - x.move_right i * y.move_left j
 := by {cases x, cases y, refl}
 

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -119,7 +119,7 @@ by {cases x, cases y, refl}
 /-- If `a` has the same moves as `x`, `b` has the same moves as `y`,
 and `c` has the same moves as `z`, then `a + b - c` has the same moves as `x + y - z`.
 This lemma is repeatedly used for simplifying multiplication of surreal numbers. -/
-lemma add_sub_relabelling {a b c x y z : pgame}
+def add_sub_relabelling {a b c x y z : pgame}
   (h₁ : a.relabelling x) (h₂ : b.relabelling y) (h₃ : c.relabelling z) :
   (a + b - c).relabelling (x + y - z) :=
 sub_congr_relabelling (add_congr_relabelling h₁ h₂) h₃
@@ -127,14 +127,14 @@ sub_congr_relabelling (add_congr_relabelling h₁ h₂) h₃
 /-- If `a` has the same moves as `x`, `b` has the same moves as `y`,
 and `c` has the same moves as `z`, then `a + b - c` has the same moves as `y + x - z`.
 This lemma is repeatedly used for simplifying multiplication of surreal numbers. -/
-lemma add_comm_sub_relabelling {a b c x y z : pgame}
+def add_comm_sub_relabelling {a b c x y z : pgame}
   (h₁ : a.relabelling x) (h₂ : b.relabelling y) (h₃ : c.relabelling z) :
   (a + b - c).relabelling (y + x - z) :=
 sub_congr_relabelling
   ((add_comm_relabelling a b).trans (add_congr_relabelling h₂ h₁)) h₃
 
 /-- `x * y` has exactly the same moves as `y * x`. -/
-theorem mul_comm_relabelling (x y : pgame) : (x * y).relabelling (y * x) :=
+def mul_comm_relabelling (x y : pgame.{u}) : (x * y).relabelling (y * x) :=
 begin
   induction x with xl xr xL xR IHxl IHxr generalizing y,
   induction y with yl yr yL yR IHyl IHyr,
@@ -160,7 +160,7 @@ theorem mul_comm_equiv (x y : pgame) : (x * y).equiv (y * x) :=
 equiv_of_relabelling (mul_comm_relabelling x y)
 
 /-- `x * 0` has exactly the same moves as `0`. -/
-theorem mul_zero_relabelling : Π (x : pgame), relabelling (x * 0) 0
+def mul_zero_relabelling : Π (x : pgame), relabelling (x * 0) 0
 | (mk xl xr xL xR) :=
 ⟨by fsplit; rintro (⟨_,⟨⟩⟩ | ⟨_,⟨⟩⟩),
  by fsplit; rintro (⟨_,⟨⟩⟩ | ⟨_,⟨⟩⟩),
@@ -172,7 +172,7 @@ theorem mul_zero_equiv (x : pgame) : (x * 0).equiv 0 :=
 equiv_of_relabelling (mul_zero_relabelling x)
 
 /-- `0 * x` has exactly the same moves as `0`. -/
-theorem zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
+def zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
 | (mk xl xr xL xR) :=
 ⟨by fsplit; rintro (⟨⟨⟩,_⟩ | ⟨⟨⟩,_⟩),
  by fsplit; rintro (⟨⟨⟩,_⟩ | ⟨⟨⟩,_⟩),


### PR DESCRIPTION
This PR adds a proof of commutativity of multiplication for surreal numbers. 
We also add `mul_zero` and `zero_mul` along with several useful lemmas.

Finally, this renames a handful of lemmas about `relabelling` in order to enable dot notation.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Surreal.20numbers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
