### PR TITLE
[Merged by Bors] - refactor(ring_theory/hahn_series): non-linearly-ordered Hahn series

### DIFF
--- a/src/order/well_founded_set.lean
+++ b/src/order/well_founded_set.lean
@@ -163,6 +163,11 @@ def partially_well_ordered_on (s) (r : α → α → Prop) : Prop :=
 def is_pwo [preorder α] (s) : Prop :=
 partially_well_ordered_on s ((≤) : α → α → Prop)
 
+theorem partially_well_ordered_on.mono {s t : set α} {r : α → α → Prop}
+  (ht : t.partially_well_ordered_on r) (hsub : s ⊆ t) :
+  s.partially_well_ordered_on r :=
+λ f hf, ht f (set.subset.trans hf hsub)
+
 theorem partially_well_ordered_on.image_of_monotone {s : set α}
   {r : α → α → Prop} {β : Type*} {r' : β → β → Prop}
   (hs : s.partially_well_ordered_on r) {f : α → β} (hf : ∀ a1 a2 : α, r a1 a2 → r' (f a1) (f a2)) :
@@ -271,6 +276,36 @@ theorem is_pwo.image_of_monotone {β : Type*} [partial_order β]
   is_pwo (f '' s) :=
 hs.image_of_monotone hf
 
+theorem is_pwo.union (hs : is_pwo s) (ht : is_pwo t) : is_pwo (s ∪ t) :=
+begin
+  classical,
+  rw [is_pwo_iff_exists_monotone_subseq] at *,
+  rintros f fst,
+  have h : infinite (f ⁻¹' s) ∨ infinite (f ⁻¹' t),
+  { have h : infinite (univ : set ℕ) := infinite_univ,
+    have hpre : f ⁻¹' (s ∪ t) = set.univ,
+    { rw [← image_univ, image_subset_iff, univ_subset_iff] at fst,
+      exact fst },
+    rw preimage_union at hpre,
+    rw ← hpre at h,
+    rw [infinite, infinite],
+    rw infinite at h,
+    contrapose! h,
+    exact finite.union h.1 h.2, },
+  rw [← infinite_coe_iff, ← infinite_coe_iff] at h,
+  cases h with inf inf; haveI := inf,
+  { obtain ⟨g, hg⟩ := hs (f ∘ (nat.order_embedding_of_set (f ⁻¹' s))) _,
+    { rw [function.comp.assoc, ← rel_embedding.coe_trans] at hg,
+      exact ⟨_, hg⟩ },
+    rw [range_comp, image_subset_iff],
+    simp },
+  { obtain ⟨g, hg⟩ := ht (f ∘ (nat.order_embedding_of_set (f ⁻¹' t))) _,
+    { rw [function.comp.assoc, ← rel_embedding.coe_trans] at hg,
+      exact ⟨_, hg⟩ },
+    rw [range_comp, image_subset_iff],
+    simp }
+end
+
 end partial_order
 
 theorem is_wf.is_pwo [linear_order α] {s : set α}
@@ -294,8 +329,10 @@ theorem is_wf_iff_is_pwo [linear_order α] {s : set α} :
 
 end set
 
+namespace finset
+
 @[simp]
-theorem finset.partially_well_ordered_on {r : α → α → Prop} [is_refl α r] {f : finset α} :
+theorem partially_well_ordered_on {r : α → α → Prop} [is_refl α r] {f : finset α} :
   set.partially_well_ordered_on (↑f : set α) r :=
 begin
   intros g hg,
@@ -312,12 +349,12 @@ begin
 end
 
 @[simp]
-theorem finset.is_pwo [partial_order α] {f : finset α} :
+theorem is_pwo [partial_order α] {f : finset α} :
   set.is_pwo (↑f : set α) :=
 finset.partially_well_ordered_on
 
 @[simp]
-theorem finset.well_founded_on {r : α → α → Prop} [is_strict_order α r] {f : finset α} :
+theorem well_founded_on {r : α → α → Prop} [is_strict_order α r] {f : finset α} :
   set.well_founded_on (↑f : set α) r :=
 begin
   rw [set.well_founded_on_iff_no_descending_seq],
@@ -327,31 +364,33 @@ begin
 end
 
 @[simp]
-theorem finset.is_wf [partial_order α] {f : finset α} : set.is_wf (↑f : set α) :=
+theorem is_wf [partial_order α] {f : finset α} : set.is_wf (↑f : set α) :=
 finset.is_pwo.is_wf
+
+end finset
 
 namespace set
 variables [partial_order α] {s : set α} {a : α}
 
-theorem finite.is_wf (h : s.finite) : s.is_wf :=
+theorem finite.is_pwo (h : s.finite) : s.is_pwo :=
 begin
   rw ← h.coe_to_finset,
-  exact finset.is_wf,
+  exact finset.is_pwo,
 end
 
 @[simp]
-theorem fintype.is_wf [fintype α] : s.is_wf := (finite.of_fintype s).is_wf
+theorem fintype.is_pwo [fintype α] : s.is_pwo := (finite.of_fintype s).is_pwo
 
 @[simp]
-theorem is_wf_empty : is_wf (∅ : set α) :=
-finite_empty.is_wf
+theorem is_pwo_empty : is_pwo (∅ : set α) :=
+finite_empty.is_pwo
 
 @[simp]
-theorem is_wf_singleton (a) : is_wf ({a} : set α) :=
-(finite_singleton a).is_wf
+theorem is_pwo_singleton (a) : is_pwo ({a} : set α) :=
+(finite_singleton a).is_pwo
 
-theorem is_wf.insert (a) (hs : is_wf s) : is_wf (insert a s) :=
-by { rw ← union_singleton, exact hs.union (is_wf_singleton a) }
+theorem is_pwo.insert (a) (hs : is_pwo s) : is_pwo (insert a s) :=
+by { rw ← union_singleton, exact hs.union (is_pwo_singleton a) }
 
 /-- `is_wf.min` returns a minimal element of a nonempty well-founded set. -/
 noncomputable def is_wf.min (hs : is_wf s) (hn : s.nonempty) : α :=
@@ -378,7 +417,22 @@ begin
   revert hf,
   apply f.induction_on,
   { intro h,
-    simp, },
+    simp [set.is_pwo_empty.is_wf], },
+  { intros s f sf hf hsf,
+    rw finset.sup_insert,
+    exact (hsf s (finset.mem_insert_self _ _)).union  (hf (λ s' s'f, hsf _
+      (finset.mem_insert_of_mem s'f))) }
+end
+
+@[simp]
+theorem finset.is_pwo_sup {ι : Type*} [partial_order α] (f : finset ι) (g : ι → set α)
+  (hf : ∀ i : ι, i ∈ f → (g i).is_pwo) : (f.sup g).is_pwo :=
+begin
+  classical,
+  revert hf,
+  apply f.induction_on,
+  { intro h,
+    simp [set.is_pwo_empty.is_wf], },
   { intros s f sf hf hsf,
     rw finset.sup_insert,
     exact (hsf s (finset.mem_insert_self _ _)).union  (hf (λ s' s'f, hsf _
@@ -416,16 +470,17 @@ end set
 
 namespace set
 
-variables [linear_ordered_cancel_comm_monoid α] {s : set α} {t : set α}
+variables {s : set α} {t : set α}
 
 @[to_additive]
-theorem is_pwo.mul
-  (hs : s.is_pwo) (ht : t.is_pwo) :
+theorem is_pwo.mul [ordered_cancel_comm_monoid α] (hs : s.is_pwo) (ht : t.is_pwo) :
   is_pwo (s * t) :=
 begin
   rw ← image_mul_prod,
   exact (is_pwo.prod hs ht).image_of_monotone (λ _ _ h, mul_le_mul' h.1 h.2),
 end
+
+variable [linear_ordered_cancel_comm_monoid α]
 
 @[to_additive]
 theorem is_wf.mul (hs : s.is_wf) (ht : t.is_wf) : is_wf (s * t) :=
@@ -545,8 +600,8 @@ end set
 
 namespace finset
 
-variables [linear_ordered_cancel_comm_monoid α]
-variables {s t : set α} (hs : s.is_wf) (ht : t.is_wf) (a : α)
+variables [ordered_cancel_comm_monoid α]
+variables {s t : set α} (hs : s.is_pwo) (ht : t.is_pwo) (a : α)
 
 /-- `finset.mul_antidiagonal_of_is_wf hs ht a` is the set of all pairs of an element in
   `s` and an element in `t` that multiply to `a`, but its construction requires proofs
@@ -555,9 +610,9 @@ variables {s t : set α} (hs : s.is_wf) (ht : t.is_wf) (a : α)
   `s` and an element in `t` that add to `a`, but its construction requires proofs
   `hs` and `ht` that `s` and `t` are well-ordered."]
 noncomputable def mul_antidiagonal : finset (α × α) :=
-(set.mul_antidiagonal.finite_of_is_wf hs ht a).to_finset
+(set.mul_antidiagonal.finite_of_is_pwo hs ht a).to_finset
 
-variables {hs} {ht} {u : set α} {hu : u.is_wf} {a} {x : α × α}
+variables {hs} {ht} {u : set α} {hu : u.is_pwo} {a} {x : α × α}
 
 @[simp, to_additive]
 lemma mem_mul_antidiagonal :
@@ -589,13 +644,16 @@ lemma support_mul_antidiagonal_subset_mul :
 end)
 
 @[to_additive]
-theorem is_wf_support_mul_antidiagonal :
-  { a : α | (mul_antidiagonal hs ht a).nonempty }.is_wf :=
+theorem is_pwo_support_mul_antidiagonal :
+  { a : α | (mul_antidiagonal hs ht a).nonempty }.is_pwo :=
 (hs.mul ht).mono support_mul_antidiagonal_subset_mul
 
 @[to_additive]
-theorem mul_antidiagonal_min_mul_min (hns : s.nonempty) (hnt : t.nonempty) :
-  mul_antidiagonal hs ht ((hs.min hns) * (ht.min hnt)) = {(hs.min hns, ht.min hnt)} :=
+theorem mul_antidiagonal_min_mul_min {α} [linear_ordered_cancel_comm_monoid α] {s t : set α}
+  (hs : s.is_wf) (ht : t.is_wf)
+  (hns : s.nonempty) (hnt : t.nonempty) :
+  mul_antidiagonal hs.is_pwo ht.is_pwo ((hs.min hns) * (ht.min hnt)) =
+    {(hs.min hns, ht.min hnt)} :=
 begin
   ext ⟨a1, a2⟩,
   rw [mem_mul_antidiagonal, finset.mem_singleton, prod.ext_iff],

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -13,11 +13,12 @@ import ring_theory.power_series.basic
 # Hahn Series
 
 ## Main Definitions
-  * If `Γ` is linearly ordered and `R` has zero, then `hahn_series Γ R` consists of
-  formal series over `Γ` with coefficients in `R`, whose supports are well-founded.
+  * If `Γ` is ordered and `R` has zero, then `hahn_series Γ R` consists of
+  formal series over `Γ` with coefficients in `R`, whose supports are partially well-ordered.
   * If `R` is a (commutative) additive monoid or group, then so is `hahn_series Γ R`.
   * If `R` is a (comm_)(semi)ring, then so is `hahn_series Γ R`.
-  * `hahn_series.add_val Γ R` defines an `add_valuation` on `hahn_series Γ R`.
+  * `hahn_series.add_val Γ R` defines an `add_valuation` on `hahn_series Γ R` when `Γ` is linearly
+    ordered.
   * A `hahn_series.summable_family` is a family of Hahn series such that the union of their supports
   is well-founded and only finitely many are nonzero at any given coefficient. They have a formal
   sum, `hahn_series.summable_family.hsum`, which can be bundled as a `linear_map` as
@@ -40,30 +41,33 @@ noncomputable theory
 /-- If `Γ` is linearly ordered and `R` has zero, then `hahn_series Γ R` consists of
   formal series over `Γ` with coefficients in `R`, whose supports are well-founded. -/
 @[ext]
-structure hahn_series (Γ : Type*) (R : Type*) [linear_order Γ] [has_zero R] :=
+structure hahn_series (Γ : Type*) (R : Type*) [partial_order Γ] [has_zero R] :=
 (coeff : Γ → R)
-(is_wf_support' : (function.support coeff).is_wf)
+(is_pwo_support' : (function.support coeff).is_pwo)
 
 variables {Γ : Type*} {R : Type*}
 
 namespace hahn_series
 
 section zero
-variables [linear_order Γ] [has_zero R]
+variables [partial_order Γ] [has_zero R]
 
 /-- The support of a Hahn series is just the set of indices whose coefficients are nonzero.
   Notably, it is well-founded. -/
 def support (x : hahn_series Γ R) : set Γ := function.support x.coeff
 
 @[simp]
-lemma is_wf_support (x : hahn_series Γ R) : x.support.is_wf := x.is_wf_support'
+lemma is_pwo_support (x : hahn_series Γ R) : x.support.is_pwo := x.is_pwo_support'
+
+@[simp]
+lemma is_wf_support (x : hahn_series Γ R) : x.support.is_wf := x.is_pwo_support.is_wf
 
 @[simp]
 lemma mem_support (x : hahn_series Γ R) (a : Γ) : a ∈ x.support ↔ x.coeff a ≠ 0 := iff.refl _
 
 instance : has_zero (hahn_series Γ R) :=
 ⟨{ coeff := 0,
-   is_wf_support' := by simp }⟩
+   is_pwo_support' := by simp }⟩
 
 instance : inhabited (hahn_series Γ R) := ⟨0⟩
 
@@ -95,7 +99,7 @@ end
 /-- `single a r` is the Hahn series which has coefficient `r` at `a` and zero otherwise. -/
 def single (a : Γ) : zero_hom R (hahn_series Γ R) :=
 { to_fun := λ r, { coeff := pi.single a r,
-    is_wf_support' := (set.is_wf_singleton a).mono pi.support_single_subset },
+    is_pwo_support' := (set.is_pwo_singleton a).mono pi.support_single_subset },
   map_zero' := ext _ _ (pi.single_zero _) }
 
 variables {a b : Γ} {r : R}
@@ -138,14 +142,14 @@ end zero
 
 section addition
 
-variable [linear_order Γ]
+variable [partial_order Γ]
 
 section add_monoid
 variable [add_monoid R]
 
 instance : has_add (hahn_series Γ R) :=
 { add := λ x y, { coeff := x.coeff + y.coeff,
-                  is_wf_support' := (x.is_wf_support.union y.is_wf_support).mono
+                  is_pwo_support' := (x.is_pwo_support.union y.is_pwo_support).mono
                     (function.support_add _ _) } }
 
 instance : add_monoid (hahn_series Γ R) :=
@@ -193,8 +197,8 @@ variable [add_group R]
 
 instance : add_group (hahn_series Γ R) :=
 { neg := λ x, { coeff := λ a, - x.coeff a,
-                is_wf_support' := by { rw function.support_neg,
-                  exact x.is_wf_support }, },
+                is_pwo_support' := by { rw function.support_neg,
+                  exact x.is_pwo_support }, },
   add_left_neg := λ x, by { ext, apply add_left_neg },
   .. hahn_series.add_monoid }
 
@@ -223,11 +227,11 @@ instance [add_comm_group R] : add_comm_group (hahn_series Γ R) :=
 end addition
 
 section distrib_mul_action
-variables [linear_order Γ] {V : Type*} [monoid R] [add_monoid V] [distrib_mul_action R V]
+variables [partial_order Γ] {V : Type*} [monoid R] [add_monoid V] [distrib_mul_action R V]
 
 instance : has_scalar R (hahn_series Γ V) :=
 ⟨λ r x, { coeff := r • x.coeff,
-          is_wf_support' := x.is_wf_support.mono (function.support_smul_subset_right r x.coeff) }⟩
+          is_pwo_support' := x.is_pwo_support.mono (function.support_smul_subset_right r x.coeff) }⟩
 
 @[simp]
 lemma smul_coeff {r : R} {x : hahn_series Γ V} {a : Γ} : (r • x).coeff a = r • (x.coeff a) := rfl
@@ -252,7 +256,7 @@ instance [smul_comm_class R S V] :
 end distrib_mul_action
 
 section module
-variables [linear_order Γ] [semiring R] {V : Type*} [add_comm_monoid V] [module R V]
+variables [partial_order Γ] [semiring R] {V : Type*} [add_comm_monoid V] [module R V]
 
 instance : module R (hahn_series Γ V) :=
 { zero_smul := λ _, by { ext, simp },
@@ -273,7 +277,7 @@ end module
 
 section multiplication
 
-variable [linear_ordered_cancel_add_comm_monoid Γ]
+variable [ordered_cancel_add_comm_monoid Γ]
 
 instance [has_zero R] [has_one R] : has_one (hahn_series Γ R) :=
 ⟨single 0 1⟩
@@ -292,26 +296,26 @@ support_single_of_ne one_ne_zero
 
 instance [semiring R] : has_mul (hahn_series Γ R) :=
 { mul := λ x y, { coeff := λ a,
-    ∑ ij in (add_antidiagonal x.is_wf_support y.is_wf_support a),
+    ∑ ij in (add_antidiagonal x.is_pwo_support y.is_pwo_support a),
     x.coeff ij.fst * y.coeff ij.snd,
-    is_wf_support' := begin
-      have h : {a : Γ | ∑ (ij : Γ × Γ) in add_antidiagonal x.is_wf_support
-        y.is_wf_support a, x.coeff ij.fst * y.coeff ij.snd ≠ 0} ⊆
-        {a : Γ | (add_antidiagonal x.is_wf_support y.is_wf_support a).nonempty},
+    is_pwo_support' := begin
+      have h : {a : Γ | ∑ (ij : Γ × Γ) in add_antidiagonal x.is_pwo_support
+        y.is_pwo_support a, x.coeff ij.fst * y.coeff ij.snd ≠ 0} ⊆
+        {a : Γ | (add_antidiagonal x.is_pwo_support y.is_pwo_support a).nonempty},
       { intros a ha,
         contrapose! ha,
         simp [not_nonempty_iff_eq_empty.1 ha] },
-      exact is_wf_support_add_antidiagonal.mono h,
+      exact is_pwo_support_add_antidiagonal.mono h,
     end, }, }
 
 @[simp]
 lemma mul_coeff [semiring R] {x y : hahn_series Γ R} {a : Γ} :
-  (x * y).coeff a = ∑ ij in (add_antidiagonal x.is_wf_support y.is_wf_support a),
+  (x * y).coeff a = ∑ ij in (add_antidiagonal x.is_pwo_support y.is_pwo_support a),
     x.coeff ij.fst * y.coeff ij.snd := rfl
 
-lemma mul_coeff_right' [semiring R] {x y : hahn_series Γ R} {a : Γ} {s : set Γ} (hs : s.is_wf)
+lemma mul_coeff_right' [semiring R] {x y : hahn_series Γ R} {a : Γ} {s : set Γ} (hs : s.is_pwo)
   (hys : y.support ⊆ s) :
-  (x * y).coeff a = ∑ ij in (add_antidiagonal x.is_wf_support hs a),
+  (x * y).coeff a = ∑ ij in (add_antidiagonal x.is_pwo_support hs a),
     x.coeff ij.fst * y.coeff ij.snd :=
 begin
   rw mul_coeff,
@@ -322,9 +326,9 @@ begin
   rw [(hb.2 hb.1.1 hb.1.2.1), mul_zero]
 end
 
-lemma mul_coeff_left' [semiring R] {x y : hahn_series Γ R} {a : Γ} {s : set Γ} (hs : s.is_wf)
+lemma mul_coeff_left' [semiring R] {x y : hahn_series Γ R} {a : Γ} {s : set Γ} (hs : s.is_pwo)
   (hxs : x.support ⊆ s) :
-  (x * y).coeff a = ∑ ij in (add_antidiagonal hs y.is_wf_support a),
+  (x * y).coeff a = ∑ ij in (add_antidiagonal hs y.is_pwo_support a),
     x.coeff ij.fst * y.coeff ij.snd :=
 begin
   rw mul_coeff,
@@ -338,7 +342,7 @@ end
 instance [semiring R] : distrib (hahn_series Γ R) :=
 { left_distrib := λ x y z, begin
     ext a,
-    have hwf := (y.is_wf_support.union z.is_wf_support),
+    have hwf := (y.is_pwo_support.union z.is_pwo_support),
     rw [mul_coeff_right' hwf, add_coeff, mul_coeff_right' hwf (set.subset_union_right _ _),
       mul_coeff_right' hwf (set.subset_union_left _ _)],
     { simp only [add_coeff, mul_add, sum_add_distrib] },
@@ -350,7 +354,7 @@ instance [semiring R] : distrib (hahn_series Γ R) :=
   end,
   right_distrib := λ x y z, begin
     ext a,
-    have hwf := (x.is_wf_support.union y.is_wf_support),
+    have hwf := (x.is_pwo_support.union y.is_pwo_support),
     rw [mul_coeff_left' hwf, add_coeff, mul_coeff_left' hwf (set.subset_union_right _ _),
       mul_coeff_left' hwf (set.subset_union_left _ _)],
     { simp only [add_coeff, add_mul, sum_add_distrib] },
@@ -440,15 +444,16 @@ theorem support_mul_subset_add_support [semiring R] {x y : hahn_series Γ R} :
   support (x * y) ⊆ support x + support y :=
 begin
   apply set.subset.trans (λ x hx, _) support_add_antidiagonal_subset_add,
-  { exact x.is_wf_support },
-  { exact y.is_wf_support },
+  { exact x.is_pwo_support },
+  { exact y.is_pwo_support },
   contrapose! hx,
   simp only [not_nonempty_iff_eq_empty, ne.def, set.mem_set_of_eq] at hx,
   simp [hx],
 end
 
 @[simp]
-lemma mul_coeff_min_add_min [semiring R] {x y : hahn_series Γ R} (hx : x ≠ 0) (hy : y ≠ 0) :
+lemma mul_coeff_min_add_min {Γ} [linear_ordered_cancel_add_comm_monoid Γ] [semiring R]
+  {x y : hahn_series Γ R} (hx : x ≠ 0) (hy : y ≠ 0) :
   (x * y).coeff (x.is_wf_support.min (support_nonempty_iff.2 hx) +
     y.is_wf_support.min (support_nonempty_iff.2 hy)) =
     (x.coeff (x.is_wf_support.min (support_nonempty_iff.2 hx))) *
@@ -459,8 +464,8 @@ private lemma mul_assoc' [semiring R] (x y z : hahn_series Γ R) :
   x * y * z = x * (y * z) :=
 begin
   ext b,
-  rw [mul_coeff_left' (x.is_wf_support.add y.is_wf_support) support_mul_subset_add_support,
-      mul_coeff_right' (y.is_wf_support.add z.is_wf_support) support_mul_subset_add_support],
+  rw [mul_coeff_left' (x.is_pwo_support.add y.is_pwo_support) support_mul_subset_add_support,
+      mul_coeff_right' (y.is_pwo_support.add z.is_pwo_support) support_mul_subset_add_support],
   simp only [mul_coeff, add_coeff, sum_mul, mul_sum, sum_sigma'],
   refine sum_bij_ne_zero (λ a has ha0, ⟨⟨a.2.1, a.2.2 + a.1.2⟩, ⟨a.2.2, a.1.2⟩⟩) _ _ _ _,
   { rintros ⟨⟨i,j⟩, ⟨k,l⟩⟩ H1 H2,
@@ -527,7 +532,8 @@ instance [comm_ring R] : comm_ring (hahn_series Γ R) :=
 { .. hahn_series.comm_semiring,
   .. hahn_series.ring }
 
-instance [integral_domain R] : integral_domain (hahn_series Γ R) :=
+instance {Γ} [linear_ordered_cancel_add_comm_monoid Γ] [integral_domain R] :
+  integral_domain (hahn_series Γ R) :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := λ x y xy, begin
     by_cases hx : x = 0,
     { left, exact hx },
@@ -617,13 +623,13 @@ variables [semiring R]
 /-- The ring `hahn_series ℕ R` is isomorphic to `power_series R`. -/
 @[simps] def to_power_series : (hahn_series ℕ R) ≃+* power_series R :=
 { to_fun := λ f, power_series.mk f.coeff,
-  inv_fun := λ f, ⟨λ n, power_series.coeff R n f, nat.lt_wf.is_wf _⟩,
+  inv_fun := λ f, ⟨λ n, power_series.coeff R n f, (nat.lt_wf.is_wf _).is_pwo⟩,
   left_inv := λ f, by { ext, simp },
   right_inv := λ f, by { ext, simp },
   map_add' := λ f g, by { ext, simp },
   map_mul' := λ f g, begin
     ext n,
-    simp only [power_series.coeff_mul, power_series.coeff_mk, mul_coeff, is_wf_support],
+    simp only [power_series.coeff_mul, power_series.coeff_mk, mul_coeff, is_pwo_support],
     classical,
     refine sum_filter_ne_zero.symm.trans
       ((sum_congr _ (λ _ _, rfl)).trans sum_filter_ne_zero),
@@ -729,14 +735,14 @@ dif_neg hx
 end valuation
 
 section
-variables (Γ) (R) [linear_order Γ] [add_comm_monoid R]
+variables (Γ) (R) [partial_order Γ] [add_comm_monoid R]
 
 /-- An infinite family of Hahn series which has a formal coefficient-wise sum.
   The requirements for this are that the union of the supports of the series is well-founded,
   and that only finitely many series are nonzero at any given coefficient. -/
 structure summable_family (α : Type*) :=
 (to_fun : α → hahn_series Γ R)
-(is_wf_Union_support' : set.is_wf (⋃ (a : α), (to_fun a).support))
+(is_pwo_Union_support' : set.is_pwo (⋃ (a : α), (to_fun a).support))
 (co_support : Γ → finset α)
 (mem_co_support' : ∀ (a : α) (g : Γ), a ∈ co_support g ↔ (to_fun a).coeff g ≠ 0)
 
@@ -745,13 +751,13 @@ end
 namespace summable_family
 section add_comm_monoid
 
-variables [linear_order Γ] [add_comm_monoid R] {α : Type*}
+variables [partial_order Γ] [add_comm_monoid R] {α : Type*}
 
 instance : has_coe_to_fun (summable_family Γ R α) :=
 ⟨λ _, (α → hahn_series Γ R), to_fun⟩
 
-lemma is_wf_Union_support (s : summable_family Γ R α) : set.is_wf (⋃ (a : α), (s a).support) :=
-s.is_wf_Union_support'
+lemma is_pwo_Union_support (s : summable_family Γ R α) : set.is_pwo (⋃ (a : α), (s a).support) :=
+s.is_pwo_Union_support'
 
 @[simp]
 lemma mem_co_support {s : summable_family Γ R α} {a : α} {g : Γ} :
@@ -774,7 +780,7 @@ coe_injective $ funext h
 
 instance : has_add (summable_family Γ R α) :=
 ⟨λ x y, { to_fun := x + y,
-    is_wf_Union_support' := (x.is_wf_Union_support.union y.is_wf_Union_support).mono (begin
+    is_pwo_Union_support' := (x.is_pwo_Union_support.union y.is_pwo_Union_support).mono (begin
       rw ← set.Union_union_distrib,
       exact set.Union_subset_Union (λ a, support_add_subset)
     end),
@@ -815,7 +821,7 @@ instance : add_comm_monoid (summable_family Γ R α) :=
 def hsum (s : summable_family Γ R α) :
   hahn_series Γ R :=
 { coeff := λ g, ∑ i in s.co_support g, (s i).coeff g,
-  is_wf_support' := s.is_wf_Union_support.mono (λ g, begin
+  is_pwo_support' := s.is_pwo_Union_support.mono (λ g, begin
     contrapose,
     rw [set.mem_Union, not_exists, function.mem_support, not_not],
     simp_rw [mem_support, not_not],
@@ -859,11 +865,11 @@ end
 end add_comm_monoid
 
 section add_comm_group
-variables [linear_order Γ] [add_comm_group R] {α : Type*} {s t : summable_family Γ R α} {a : α}
+variables [partial_order Γ] [add_comm_group R] {α : Type*} {s t : summable_family Γ R α} {a : α}
 
 instance : add_comm_group (summable_family Γ R α) :=
 { neg := λ s, { to_fun := λ a, - s a,
-    is_wf_Union_support' := by { simp_rw [support_neg], exact s.is_wf_Union_support' },
+    is_pwo_Union_support' := by { simp_rw [support_neg], exact s.is_pwo_Union_support' },
     co_support := s.co_support,
     mem_co_support' := by simp },
   add_left_neg := λ a, by { ext, apply add_left_neg },
@@ -882,24 +888,24 @@ end add_comm_group
 
 section semiring
 
-variables [linear_ordered_add_comm_group Γ] [semiring R] {α : Type*}
+variables [ordered_cancel_add_comm_monoid Γ] [semiring R] {α : Type*}
 
 instance : has_scalar (hahn_series Γ R) (summable_family Γ R α) :=
 { smul := λ x s, { to_fun := λ a, x * (s a),
-    is_wf_Union_support' := begin
-      apply (x.is_wf_support.add s.is_wf_Union_support).mono,
+    is_pwo_Union_support' := begin
+      apply (x.is_pwo_support.add s.is_pwo_Union_support).mono,
       refine set.subset.trans (set.Union_subset_Union (λ a, support_mul_subset_add_support)) _,
       intro g,
       simp only [set.mem_Union, exists_imp_distrib],
       exact λ a ha, (set.add_subset_add (set.subset.refl _) (set.subset_Union _ a)) ha,
     end,
-    co_support := λ g, ((add_antidiagonal x.is_wf_support s.is_wf_Union_support g).bUnion
+    co_support := λ g, ((add_antidiagonal x.is_pwo_support s.is_pwo_Union_support g).bUnion
       (λ ij, s.co_support ij.snd)).filter (λ a, (x * (s a)).coeff g ≠ 0),
     mem_co_support' := λ a g, begin
       rw [mem_filter],
       apply and_iff_right_of_imp,
       simp only [mem_bUnion, exists_prop, set.mem_Union, mem_add_antidiagonal, mem_co_support,
-        mul_coeff, ne.def, mem_support, is_wf_support, prod.exists],
+        mul_coeff, ne.def, mem_support, is_pwo_support, prod.exists],
       contrapose!,
       intro h,
       rw sum_eq_zero,
@@ -932,7 +938,7 @@ begin
   rw [mul_coeff, sum_subset (add_antidiagonal_mono_right support_hsum_subset)],
   { rw hsum_coeff,
     have h : (x • s).co_support g ⊆
-      (add_antidiagonal x.is_wf_support s.is_wf_Union_support g).bUnion (λ ij, s.co_support ij.snd),
+      (add_antidiagonal x.is_pwo_support s.is_pwo_Union_support g).bUnion (λ ij, s.co_support ij.snd),
     { intros a ha,
       rw [mem_co_support, smul_apply, mul_coeff] at ha,
       obtain ⟨ij, h1, h2⟩ := exists_ne_zero_of_sum_ne_zero ha,
@@ -940,13 +946,13 @@ begin
       exact ⟨ij, add_antidiagonal_mono_right (set.subset_Union _ a) h1,
         mem_co_support.2 (right_ne_zero_of_mul h2)⟩ },
     refine eq.trans (sum_subset h _) _,
-    { apply is_wf_Union_support },
+    { apply is_pwo_Union_support },
     { intros a h1 h2,
       contrapose! h2,
       rw [mem_co_support],
       exact h2 },
     have h' : ∀ a, ((x • s) a).coeff g =
-      ∑ (ij : Γ × Γ) in add_antidiagonal x.is_wf_support s.is_wf_Union_support g,
+      ∑ (ij : Γ × Γ) in add_antidiagonal x.is_pwo_support s.is_pwo_Union_support g,
       x.coeff ij.fst * (s a).coeff ij.snd,
     { intro a,
       rw [smul_apply, mul_coeff],
@@ -979,14 +985,14 @@ end
 end semiring
 
 section of_finsupp
-variables [linear_order Γ] [add_comm_monoid R] {α : Type*}
+variables [partial_order Γ] [add_comm_monoid R] {α : Type*}
 
 /-- A family with only finitely many nonzero elements is summable. -/
 def of_finsupp (f : α →₀ (hahn_series Γ R)) :
   summable_family Γ R α :=
 { to_fun := f,
-  is_wf_Union_support' := begin
-      apply (f.support.is_wf_sup (λ a, (f a).support) (λ a ha, (f a).is_wf_support)).mono,
+  is_pwo_Union_support' := begin
+      apply (f.support.is_pwo_sup (λ a, (f a).support) (λ a ha, (f a).is_pwo_support)).mono,
       intros g hg,
       obtain ⟨a, ha⟩ := set.mem_Union.1 hg,
       have haf : a ∈ f.support,

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -937,8 +937,8 @@ begin
   ext g,
   rw [mul_coeff, sum_subset (add_antidiagonal_mono_right support_hsum_subset)],
   { rw hsum_coeff,
-    have h : (x • s).co_support g ⊆
-      (add_antidiagonal x.is_pwo_support s.is_pwo_Union_support g).bUnion (λ ij, s.co_support ij.snd),
+    have h : (x • s).co_support g ⊆ (add_antidiagonal x.is_pwo_support s.is_pwo_Union_support
+      g).bUnion (λ ij, s.co_support ij.snd),
     { intros a ha,
       rw [mem_co_support, smul_apply, mul_coeff] at ha,
       obtain ⟨ij, h1, h2⟩ := exists_ne_zero_of_sum_ne_zero ha,


### PR DESCRIPTION
Refactors Hahn series to use `set.is_pwo` instead of `set.is_wf`, allowing them to be defined on non-linearly-ordered monomial types

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
