### PR TITLE
[Merged by Bors] - feat(linear_algebra/free_module): free of finite torsion free

### DIFF
--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -6,6 +6,7 @@ Authors: Anne Baanen
 import linear_algebra.basis
 import linear_algebra.finsupp_vector_space
 import ring_theory.principal_ideal_domain
+import ring_theory.finiteness
 
 /-! # Free modules
 
@@ -384,6 +385,12 @@ begin
   -- hence `M` is free.
   exact ⟨n, ψ.symm ∘ B, linear_equiv.is_basis hB ψ.symm⟩
 end
+
+/-- A finite type torsion free module over a PID is free. -/
+lemma module.free_of_finite_type_torsion_free' [module.finite R M] [no_zero_smul_divisors R M] :
+  ∃ (n : ℕ) (B : fin n → M), is_basis R B :=
+let ⟨n, s, hs⟩ := module.finite.exists_fin in module.free_of_finite_type_torsion_free hs
+
 end principal_ideal_domain
 
 /-- A set of linearly independent vectors in a module `M` over a semiring `S` is also linearly


### PR DESCRIPTION
This is a reformulation of module.free_of_finite_type_torsion_free in terms of `ring_theory.finiteness` (combining my recent algebra PRs). Note this adds an import but it seems ok to me.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
