### PR TITLE
[Merged by Bors] - fix(tactic/itauto): reset after or split

### DIFF
--- a/test/itauto.lean
+++ b/test/itauto.lean
@@ -39,6 +39,11 @@ example (p : Prop) : p → ¬ (p → ¬ p) := by itauto
 
 example (p : Prop) (em : p ∨ ¬ p) : ¬ (p ↔ ¬ p) := by itauto
 
+example (xl yl zl xr yr zr : Prop) :
+  (xl ∧ yl ∨ xr ∧ yr) ∧ zl ∨ (xl ∧ yr ∨ xr ∧ yl) ∧ zr ↔
+    xl ∧ (yl ∧ zl ∨ yr ∧ zr) ∨ xr ∧ (yl ∧ zr ∨ yr ∧ zl) :=
+by itauto
+
 -- failure tests
 example (p q r : Prop) : true :=
 begin


### PR DESCRIPTION
Fixes a bug [reported on zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/.60ring.60.20tactic.20for.20types/near/236368947)