### PR TITLE
[Merged by Bors] - fix(algebra/group/commute): use the right typeclass

### DIFF
--- a/src/algebra/group/commute.lean
+++ b/src/algebra/group/commute.lean
@@ -79,7 +79,7 @@ protected theorem all {S : Type*} [comm_semigroup S] (a b : S) : commute a b := 
 
 section mul_one_class
 
-variables {M : Type*} [monoid M]
+variables {M : Type*} [mul_one_class M]
 
 @[simp, to_additive] theorem one_right (a : M) : commute a 1 := semiconj_by.one_right a
 @[simp, to_additive] theorem one_left (a : M) : commute 1 a := semiconj_by.one_left a


### PR DESCRIPTION
This section is called `mul_one_class`, but I forgot to actually make it use `mul_one_class` instead of `monoid` in a previous PR...



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Followup to #7259