### PR TITLE
feat(algebra/order_operation_defs): introduce new typeclasses for mixing orders and binary operations

### DIFF
--- a/src/algebra/order_operation_defs.lean
+++ b/src/algebra/order_operation_defs.lean
@@ -44,8 +44,8 @@ We then introduce the 16 typeclasses obtained by choosing `M = N` and assuming
 There are two main reasons for introducing several typeclasses.  The first, is that it is much more
 human-friendly to have a class called `has_add_le_add_right M` than one called
 `covariant (flip (+)) (≤)`.  The second, is that this way, we bound better the space
-for typeclass inference: e.g. we ask the typeclass search to look for `has_add` and `has_le`
-instances, instead of extending the search to all possible functions among different Types.
+for typeclass inference: e.g. the typeclass system will only look through the `has_add_le_add_right` instances,
+without extending the search to instances of `covariant` applied to different functions or relations.
 
 The general approach is to formulate and prove a lemma, with the `ordered_[...]` typeclass of your
 liking.  After that, you convert the single typeclass, say `[ordered_cancel_monoid M]`, with three
@@ -122,8 +122,8 @@ lemma is_symm_op.swap_eq {α β} (op) [is_symm_op α β op] : flip op = op :=
 funext $ λ a, funext $ λ b, (is_symm_op.symm_op a b).symm
 
 @[to_additive]
-lemma covariant_iff_covariant_mul [comm_semigroup N] :
-  covariant ((*) : N → N → N) (r) ↔ covariant (flip (*) : N → N → N) (r) :=
+lemma covariant_iff_covariant_flip {α β} (op) [is_symm_op α β op] :
+  covariant op r ↔ covariant (flip op) r :=
 by rw is_symm_op.swap_eq
 
 @[to_additive]

--- a/src/algebra/order_operation_defs.lean
+++ b/src/algebra/order_operation_defs.lean
@@ -61,7 +61,7 @@ while the relation that is an input to `contravariant` is `(<)`. This need not b
 general, but seems to be the most common usage. In the opposite direction, the implication
 
 ```lean
-[semigroup M] [partial_order M] [has_le_of_mul_le_mul M] → left_cancel_semigroup α
+[semigroup M] [partial_order M] [has_le_of_mul_le_mul M] → left_cancel_semigroup M
 ```
 holds (note the `has_le_[...]` as opposed to the more common idioms `has_lt_[...]` and
 `has_mul_le_[...]`.
@@ -137,79 +137,97 @@ end covariants_and_contravariants
 section typeclasses_for_relating_orders_and_binary_operations
 variable (α : Type*)
 
-/--  A typeclass assuming the implication `b ≤ c → a + b ≤ a + c`. -/
+/--  A typeclass assuming the implication `b ≤ c → a + b ≤ a + c`:
+left-addition is monotone. -/
 class has_add_le_add_left [has_add α] [has_le α] : Prop :=
 (add_le_add_left : covariant ((+) : α → α → α) (≤))
 
-/--  A typeclass assuming the implication `b ≤ c → a * b ≤ a * c`. -/
+/--  A typeclass assuming the implication `b ≤ c → a * b ≤ a * c`:
+left-multiplication is monotone. -/
 @[to_additive]
 class has_mul_le_mul_left [has_mul α] [has_le α] : Prop :=
 (mul_le_mul_left : covariant ((*) : α → α → α) (≤))
 
-/--  A typeclass assuming the implication `b ≤ c → b + a ≤ c + a`. -/
+/--  A typeclass assuming the implication `b ≤ c → b + a ≤ c + a`:
+right-addition is monotone. -/
 class has_add_le_add_right [has_add α] [has_le α] : Prop :=
 (add_le_add_right : covariant (function.swap (+) : α → α → α) (≤))
 
-/--  A typeclass assuming the implication `b ≤ c → b * a ≤ c * a`. -/
+/--  A typeclass assuming the implication `b ≤ c → b * a ≤ c * a`:
+right-multiplication is monotone. -/
 @[to_additive]
 class has_mul_le_mul_right [has_mul α] [has_le α] : Prop :=
 (mul_le_mul_right : covariant (function.swap (*) : α → α → α) (≤))
 
-/--  A typeclass assuming the implication `b < c → a + b < a + c`. -/
+/--  A typeclass assuming the implication `b < c → a + b < a + c`:
+left-addition is strictly monotone. -/
 class has_add_lt_add_left [has_add α] [has_lt α] : Prop :=
 (add_lt_add_left : covariant ((+) : α → α → α) (<))
 
-/--  A typeclass assuming the implication `b < c → a * b < a * c`. -/
+/--  A typeclass assuming the implication `b < c → a * b < a * c`:
+left-multiplication is strictly monotone. -/
 @[to_additive]
 class has_mul_lt_mul_left [has_mul α] [has_lt α] : Prop :=
 (mul_lt_mul_left : covariant ((*) : α → α → α) (<))
 
-/--  A typeclass assuming the implication `b < c → b + a < c + a`. -/
+/--  A typeclass assuming the implication `b < c → b + a < c + a`:
+right-addition is strictly monotone. -/
 class has_add_lt_add_right [has_add α] [has_lt α] : Prop :=
 (add_lt_add_right : covariant (function.swap (+) : α → α → α) (<))
 
-/--  A typeclass assuming the implication `b < c → b * a < c * a`. -/
+/--  A typeclass assuming the implication `b < c → b * a < c * a`:
+right-multiplication is strictly monotone. -/
 @[to_additive]
 class has_mul_lt_mul_right [has_mul α] [has_lt α] : Prop :=
 (mul_lt_mul_right : covariant (function.swap (*) : α → α → α) (<))
 
-/--  A typeclass assuming the implication `a + b ≤ a + c → b ≤ c`. -/
+/--  A typeclass assuming the implication `a + b ≤ a + c → b ≤ c`:
+left-addition is "reverse" monotone. -/
 class has_le_of_add_le_add_left [has_add α] [has_le α] : Prop :=
 (le_of_add_le_add_left : contravariant ((+) : α → α → α) (≤))
 
-/--  A typeclass assuming the implication `a * b ≤ a * c → b ≤ c`. -/
+/--  A typeclass assuming the implication `a * b ≤ a * c → b ≤ c`:
+left-multiplication is "reverse" monotone. -/
 @[to_additive]
 class has_le_of_mul_le_mul_left [has_mul α] [has_le α] : Prop :=
 (le_of_mul_le_mul_left : contravariant ((*) : α → α → α) (≤))
 
-/--  A typeclass assuming the implication `b + a ≤ c + a → b ≤ c`. -/
+/--  A typeclass assuming the implication `b + a ≤ c + a → b ≤ c`:
+right-addition is "reverse" monotone. -/
 class has_le_of_add_le_add_right [has_add α] [has_le α] : Prop :=
 (le_of_add_le_add_right : contravariant (function.swap (+) : α → α → α) (≤))
 
-/--  A typeclass assuming the implication `b * a ≤ c * a → b ≤ c`. -/
+/--  A typeclass assuming the implication `b * a ≤ c * a → b ≤ c`:
+right-multiplication is "reverse" monotone. -/
 @[to_additive]
 class has_le_of_mul_le_mul_right [has_mul α] [has_le α] : Prop :=
 (le_of_mul_le_mul_right : contravariant (function.swap (*) : α → α → α) (≤))
 
-/--  A typeclass assuming the implication `a + b < a + c → b < c`. -/
+/--  A typeclass assuming the implication `a + b < a + c → b < c`:
+left-addition is "reverse" strictly monotone. -/
 class has_lt_of_add_lt_add_left [has_add α] [has_lt α] : Prop :=
 (lt_of_add_lt_add_left : contravariant ((+) : α → α → α) (<))
 
-/--  A typeclass assuming the implication `a * b < a * c → b < c`. -/
+/--  A typeclass assuming the implication `a * b < a * c → b < c`:
+left-multiplication is "reverse" strictly monotone. -/
 @[to_additive]
 class has_lt_of_mul_lt_mul_left [has_mul α] [has_lt α] : Prop :=
 (lt_of_mul_lt_mul_left : contravariant ((*) : α → α → α) (<))
 
-/--  A typeclass assuming the implication `b + a < c + a → b < c`. -/
+/--  A typeclass assuming the implication `b + a < c + a → b < c`:
+right-addition is "reverse" strictly monotone. -/
 class has_lt_of_add_lt_add_right [has_add α] [has_lt α] : Prop :=
 (lt_of_add_lt_add_right : contravariant (function.swap (+) : α → α → α) (<))
 
-/--  A typeclass assuming the implication `b * a < c * a → b < c`. -/
+/--  A typeclass assuming the implication `b * a < c * a → b < c`:
+right-multiplication is "reverse" strictly monotone. -/
 @[to_additive]
 class has_lt_of_mul_lt_mul_right [has_mul α] [has_lt α] : Prop :=
 (lt_of_mul_lt_mul_right : contravariant (function.swap (*) : α → α → α) (<))
 
 section le_implies_lt
+/-!  In this section, we show that, for a linear order, monotonicity of an operation implies
+"reverse" strict monotonicity of the same operation. -/
 variable [linear_order α]
 
 @[priority 100, to_additive] -- see Note [lower instance priority]
@@ -241,6 +259,8 @@ instance has_le_of_mul_le_mul_right.to_has_mul_lt_mul_right [has_mul α]
 end le_implies_lt
 
 section left_implies_right
+/-!  In this section, we show that, for a commutative operation, left monotonicity assumptions
+imply the corresponding right monotonicity. -/
 variable [comm_semigroup α]
 
 @[priority 100, to_additive] -- see Note [lower instance priority]

--- a/src/algebra/order_operation_defs.lean
+++ b/src/algebra/order_operation_defs.lean
@@ -38,12 +38,12 @@ We then introduce the 16 typeclasses obtained by choosing `M = N` and assuming
 * one of `covariant` and `contravariant`, with
 * the relation `r` being one of `(≤)` or `(<)`,
 * the operation `μ : M → M → M` being one of `(+)` or `(*)`, for left monotonicity,
-* the operation `μ : M → M → M` being one of `(function.swap (+))` or `(function.swap(*))`,
+* the operation `μ : M → M → M` being one of `(flip (+))` or `(flip(*))`,
   for right monotonicity.
 
 There are two main reasons for introducing several typeclasses.  The first, is that it is much more
 human-friendly to have a class called `has_add_le_add_right M` than one called
-`covariant (function.swap (+)) (≤)`.  The second, is that this way, we bound better the space
+`covariant (flip (+)) (≤)`.  The second, is that this way, we bound better the space
 for typeclass inference: e.g. we ask the typeclass search to look for `has_add` and `has_le`
 instances, instead of extending the search to all possible functions among different Types.
 
@@ -117,20 +117,19 @@ lemma covariant_iff_contravariant_lt [linear_order N] :
 ⟨ λ h a b c bc, not_lt.mp (λ k, not_lt.mpr bc (h _ k)),
   λ h a b c bc, not_le.mp (λ k, not_le.mpr bc (h _ k))⟩
 
-@[to_additive]
-lemma mul_eq_function_swap [comm_semigroup M] :
-  (function.swap (*) : M → M → M) = (*) :=
-funext $ λ _, funext (λ _, mul_comm _ _)
+
+lemma is_symm_op.swap_eq {α β} (op) [is_symm_op α β op] : flip op = op :=
+funext $ λ a, funext $ λ b, (is_symm_op.symm_op a b).symm
 
 @[to_additive]
 lemma covariant_iff_covariant_mul [comm_semigroup N] :
-  covariant ((*) : N → N → N) (r) ↔ covariant (function.swap (*) : N → N → N) (r) :=
-by rw mul_eq_function_swap
+  covariant ((*) : N → N → N) (r) ↔ covariant (flip (*) : N → N → N) (r) :=
+by rw is_symm_op.swap_eq
 
 @[to_additive]
 lemma contravariant_iff_contravariant_mul [comm_semigroup N] :
-  contravariant ((*) : N → N → N) (r) ↔ contravariant (function.swap (*) : N → N → N) (r) :=
-by rw mul_eq_function_swap
+  contravariant ((*) : N → N → N) (r) ↔ contravariant (flip (*) : N → N → N) (r) :=
+by rw is_symm_op.swap_eq
 
 end covariants_and_contravariants
 
@@ -151,13 +150,13 @@ class has_mul_le_mul_left [has_mul α] [has_le α] : Prop :=
 /--  A typeclass assuming the implication `b ≤ c → b + a ≤ c + a`:
 right-addition is monotone. -/
 class has_add_le_add_right [has_add α] [has_le α] : Prop :=
-(add_le_add_right : covariant (function.swap (+) : α → α → α) (≤))
+(add_le_add_right : covariant (flip (+) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `b ≤ c → b * a ≤ c * a`:
 right-multiplication is monotone. -/
 @[to_additive]
 class has_mul_le_mul_right [has_mul α] [has_le α] : Prop :=
-(mul_le_mul_right : covariant (function.swap (*) : α → α → α) (≤))
+(mul_le_mul_right : covariant (flip (*) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `b < c → a + b < a + c`:
 left-addition is strictly monotone. -/
@@ -173,13 +172,13 @@ class has_mul_lt_mul_left [has_mul α] [has_lt α] : Prop :=
 /--  A typeclass assuming the implication `b < c → b + a < c + a`:
 right-addition is strictly monotone. -/
 class has_add_lt_add_right [has_add α] [has_lt α] : Prop :=
-(add_lt_add_right : covariant (function.swap (+) : α → α → α) (<))
+(add_lt_add_right : covariant (flip (+) : α → α → α) (<))
 
 /--  A typeclass assuming the implication `b < c → b * a < c * a`:
 right-multiplication is strictly monotone. -/
 @[to_additive]
 class has_mul_lt_mul_right [has_mul α] [has_lt α] : Prop :=
-(mul_lt_mul_right : covariant (function.swap (*) : α → α → α) (<))
+(mul_lt_mul_right : covariant (flip (*) : α → α → α) (<))
 
 /--  A typeclass assuming the implication `a + b ≤ a + c → b ≤ c`:
 left-addition is "reverse" monotone. -/
@@ -195,13 +194,13 @@ class has_le_of_mul_le_mul_left [has_mul α] [has_le α] : Prop :=
 /--  A typeclass assuming the implication `b + a ≤ c + a → b ≤ c`:
 right-addition is "reverse" monotone. -/
 class has_le_of_add_le_add_right [has_add α] [has_le α] : Prop :=
-(le_of_add_le_add_right : contravariant (function.swap (+) : α → α → α) (≤))
+(le_of_add_le_add_right : contravariant (flip (+) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `b * a ≤ c * a → b ≤ c`:
 right-multiplication is "reverse" monotone. -/
 @[to_additive]
 class has_le_of_mul_le_mul_right [has_mul α] [has_le α] : Prop :=
-(le_of_mul_le_mul_right : contravariant (function.swap (*) : α → α → α) (≤))
+(le_of_mul_le_mul_right : contravariant (flip (*) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `a + b < a + c → b < c`:
 left-addition is "reverse" strictly monotone. -/
@@ -217,13 +216,13 @@ class has_lt_of_mul_lt_mul_left [has_mul α] [has_lt α] : Prop :=
 /--  A typeclass assuming the implication `b + a < c + a → b < c`:
 right-addition is "reverse" strictly monotone. -/
 class has_lt_of_add_lt_add_right [has_add α] [has_lt α] : Prop :=
-(lt_of_add_lt_add_right : contravariant (function.swap (+) : α → α → α) (<))
+(lt_of_add_lt_add_right : contravariant (flip (+) : α → α → α) (<))
 
 /--  A typeclass assuming the implication `b * a < c * a → b < c`:
 right-multiplication is "reverse" strictly monotone. -/
 @[to_additive]
 class has_lt_of_mul_lt_mul_right [has_mul α] [has_lt α] : Prop :=
-(lt_of_mul_lt_mul_right : contravariant (function.swap (*) : α → α → α) (<))
+(lt_of_mul_lt_mul_right : contravariant (flip (*) : α → α → α) (<))
 
 section le_implies_lt
 /-!  In this section, we show that, for a linear order, monotonicity of an operation implies

--- a/src/algebra/order_operation_defs.lean
+++ b/src/algebra/order_operation_defs.lean
@@ -77,38 +77,44 @@ section covariants_and_contravariants
 variables {M N : Type*} (μ : M → N → N) (r : N → N → Prop) (m : M) {a b c : N}
 
 
-variables (M N)
-/-- `covariant` is useful to formulate succintly statements about the interactions between an
-action of a Type on another one and a relation on the acted-upon Type.
+--variables (M N)
+/--  Given Types `M` and `N`, an action `μ : M → N → N` and a relation `r N → N → Prop` on `N`,
+informally, `covariant μ r` says that "the action `μ` preserves the relation `r`.
 
-See the `covariant_class` doc-string for its meaning. -/
+More precisely, `covariant μ r` is a class taking two Types `M N`, together with an "action"
+`μ : M → N → N` and a relation `r : N → N`.  It asserts that for all `m ∈ M` and all elements
+`n₁, n₂ ∈ N`, if the relation `r` holds for the pair `(n₁, n₂)`, then, the relation `r` also holds
+for the pair `(μ m n₁, μ m n₂)`, obtained from `(n₁, n₂)` by "acting upon it by `m`". -/
 def covariant     : Prop := ∀ (m) {n₁ n₂}, r n₁ n₂ → r (μ m n₁) (μ m n₂)
 
-/-- `contravariant` is useful to formulate succintly statements about the interactions between an
-action of a Type on another one and a relation on the acted-upon Type.
+/--  Given Types `M` and `N`, an action `μ : M → N → N` and a relation `r N → N → Prop` on `N`,
+informally, `contravariant μ r` says that "the action `μ` preserves the relation `r`.
 
-See the `contravariant_class` doc-string for its meaning. -/
+More precisely, `contravariant μ r` is a class taking two Types `M N`, together with an "action"
+`μ : M → N → N` and a relation `r : N → N`.  It asserts that for all `m ∈ M` and all elements
+`n₁, n₂ ∈ N`, if the relation `r` holds for the pair `(μ m n₁, μ m n₂)`, obtained from `(n₁, n₂)` by
+"acting upon it by `m`", then, the relation `r` also holds for the pair `(n₁, n₂)`. -/
 def contravariant : Prop := ∀ (m) {n₁ n₂}, r (μ m n₁) (μ m n₂) → r n₁ n₂
 
 variables {M N}
 
 @[simp]
 lemma covariant_def :
-  covariant M N μ r ↔ ∀ (m) {n₁ n₂}, r n₁ n₂ → r (μ m n₁) (μ m n₂) :=
+  covariant μ r ↔ ∀ (m) {n₁ n₂}, r n₁ n₂ → r (μ m n₁) (μ m n₂) :=
 iff.rfl
 
 @[simp]
 lemma contravariant_def :
-  contravariant M N μ r ↔ ∀ (m) {n₁ n₂}, r (μ m n₁) (μ m n₂) → r n₁ n₂ :=
+  contravariant μ r ↔ ∀ (m) {n₁ n₂}, r (μ m n₁) (μ m n₂) → r n₁ n₂ :=
 iff.rfl
 
 lemma covariant_iff_contravariant_le [linear_order N] :
-  covariant M N μ (≤) ↔ contravariant M N μ (<) :=
+  covariant μ (≤) ↔ contravariant μ (<) :=
 ⟨ λ h a b c bc, not_le.mp (λ k, not_le.mpr bc (h _ k)),
   λ h a b c bc, not_lt.mp (λ k, not_lt.mpr bc (h _ k))⟩
 
 lemma covariant_iff_contravariant_lt [linear_order N] :
-  covariant M N μ (<) ↔ contravariant M N μ (≤) :=
+  covariant μ (<) ↔ contravariant μ (≤) :=
 ⟨ λ h a b c bc, not_lt.mp (λ k, not_lt.mpr bc (h _ k)),
   λ h a b c bc, not_le.mp (λ k, not_le.mpr bc (h _ k))⟩
 
@@ -119,12 +125,12 @@ funext $ λ _, funext (λ _, mul_comm _ _)
 
 @[to_additive]
 lemma covariant_iff_covariant_mul [comm_semigroup N] :
-  covariant N N (*) (r) ↔ covariant N N (function.swap (*)) (r) :=
+  covariant ((*) : N → N → N) (r) ↔ covariant (function.swap (*) : N → N → N) (r) :=
 by rw mul_eq_function_swap
 
 @[to_additive]
 lemma contravariant_iff_contravariant_mul [comm_semigroup N] :
-  contravariant N N (*) (r) ↔ contravariant N N (function.swap (*)) (r) :=
+  contravariant ((*) : N → N → N) (r) ↔ contravariant (function.swap (*) : N → N → N) (r) :=
 by rw mul_eq_function_swap
 
 end covariants_and_contravariants
@@ -134,75 +140,75 @@ variable (α : Type*)
 
 /--  A typeclass assuming the implication `b ≤ c → a + b ≤ a + c`. -/
 class has_add_le_add_left [has_add α] [has_le α] : Prop :=
-(add_le_add_left : covariant α α (+) (≤))
+(add_le_add_left : covariant ((+) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `b ≤ c → a * b ≤ a * c`. -/
 @[to_additive]
 class has_mul_le_mul_left [has_mul α] [has_le α] : Prop :=
-(mul_le_mul_left : covariant α α (*) (≤))
+(mul_le_mul_left : covariant ((*) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `b ≤ c → b + a ≤ c + a`. -/
 class has_add_le_add_right [has_add α] [has_le α] : Prop :=
-(add_le_add_right : covariant α α (function.swap (+)) (≤))
+(add_le_add_right : covariant (function.swap (+) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `b ≤ c → b * a ≤ c * a`. -/
 @[to_additive]
 class has_mul_le_mul_right [has_mul α] [has_le α] : Prop :=
-(mul_le_mul_right : covariant α α (function.swap (*)) (≤))
+(mul_le_mul_right : covariant (function.swap (*) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `b < c → a + b < a + c`. -/
 class has_add_lt_add_left [has_add α] [has_lt α] : Prop :=
-(add_lt_add_left : covariant α α (+) (<))
+(add_lt_add_left : covariant ((+) : α → α → α) (<))
 
 /--  A typeclass assuming the implication `b < c → a * b < a * c`. -/
 @[to_additive]
 class has_mul_lt_mul_left [has_mul α] [has_lt α] : Prop :=
-(mul_lt_mul_left : covariant α α (*) (<))
+(mul_lt_mul_left : covariant ((*) : α → α → α) (<))
 
 /--  A typeclass assuming the implication `b < c → b + a < c + a`. -/
 class has_add_lt_add_right [has_add α] [has_lt α] : Prop :=
-(add_lt_add_right : covariant α α (function.swap (+)) (<))
+(add_lt_add_right : covariant (function.swap (+) : α → α → α) (<))
 
 /--  A typeclass assuming the implication `b < c → b * a < c * a`. -/
 @[to_additive]
 class has_mul_lt_mul_right [has_mul α] [has_lt α] : Prop :=
-(mul_lt_mul_right : covariant α α (function.swap (*)) (<))
+(mul_lt_mul_right : covariant (function.swap (*) : α → α → α) (<))
 
 /--  A typeclass assuming the implication `a + b ≤ a + c → b ≤ c`. -/
 class has_le_of_add_le_add_left [has_add α] [has_le α] : Prop :=
-(le_of_add_le_add_left : contravariant α α (+) (≤))
+(le_of_add_le_add_left : contravariant ((+) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `a * b ≤ a * c → b ≤ c`. -/
 @[to_additive]
 class has_le_of_mul_le_mul_left [has_mul α] [has_le α] : Prop :=
-(le_of_mul_le_mul_left : contravariant α α (*) (≤))
+(le_of_mul_le_mul_left : contravariant ((*) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `b + a ≤ c + a → b ≤ c`. -/
 class has_le_of_add_le_add_right [has_add α] [has_le α] : Prop :=
-(le_of_add_le_add_right : contravariant α α (function.swap (+)) (≤))
+(le_of_add_le_add_right : contravariant (function.swap (+) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `b * a ≤ c * a → b ≤ c`. -/
 @[to_additive]
 class has_le_of_mul_le_mul_right [has_mul α] [has_le α] : Prop :=
-(le_of_mul_le_mul_right : contravariant α α (function.swap (*)) (≤))
+(le_of_mul_le_mul_right : contravariant (function.swap (*) : α → α → α) (≤))
 
 /--  A typeclass assuming the implication `a + b < a + c → b < c`. -/
 class has_lt_of_add_lt_add_left [has_add α] [has_lt α] : Prop :=
-(lt_of_add_lt_add_left : contravariant α α (+) (<))
+(lt_of_add_lt_add_left : contravariant ((+) : α → α → α) (<))
 
 /--  A typeclass assuming the implication `a * b < a * c → b < c`. -/
 @[to_additive]
 class has_lt_of_mul_lt_mul_left [has_mul α] [has_lt α] : Prop :=
-(lt_of_mul_lt_mul_left : contravariant α α (*) (<))
+(lt_of_mul_lt_mul_left : contravariant ((*) : α → α → α) (<))
 
 /--  A typeclass assuming the implication `b + a < c + a → b < c`. -/
 class has_lt_of_add_lt_add_right [has_add α] [has_lt α] : Prop :=
-(lt_of_add_lt_add_right : contravariant α α (function.swap (+)) (<))
+(lt_of_add_lt_add_right : contravariant (function.swap (+) : α → α → α) (<))
 
 /--  A typeclass assuming the implication `b * a < c * a → b < c`. -/
 @[to_additive]
 class has_lt_of_mul_lt_mul_right [has_mul α] [has_lt α] : Prop :=
-(lt_of_mul_lt_mul_right : contravariant α α (function.swap (*)) (<))
+(lt_of_mul_lt_mul_right : contravariant (function.swap (*) : α → α → α) (<))
 
 section le_implies_lt
 variable [linear_order α]

--- a/src/algebra/order_operation_defs.lean
+++ b/src/algebra/order_operation_defs.lean
@@ -17,7 +17,7 @@ and binary operations.  These model the implications
 * `b ≤ c → a * b ≤ a * c`, (left-multiplication is monotone),
 * `a * b < a * c → b < c`, (a kind of contrapositive version of monotonicity of multiplication).
 
-Since we want to have the freedom to apply them indepdently to
+Since we want to have the freedom to apply them independently to
 
 * each relation `(≤)` and `(<)`,
 * each binary operation `(+)` and `(*)`,
@@ -39,30 +39,29 @@ We then introduce the 16 typeclasses obtained by choosing `M = N` and assuming
 * the relation `r` being one of `(≤)` or `(<)`,
 * the operation `μ : M → M → M` being one of `(+)` or `(*)`, for left monotonicity,
 * the operation `μ : M → M → M` being one of `(function.swap (+))` or `(function.swap(*))`,
-  for right monotonicity,
+  for right monotonicity.
 
 There are two main reasons for introducing several typeclasses.  The first, is that it is much more
 human-friendly to have a class called `has_add_le_add_right M` than one called
-`covariant M M (function.swap (+)) (≤)`.  The second, is that this way, we bound better the space
+`covariant (function.swap (+)) (≤)`.  The second, is that this way, we bound better the space
 for typeclass inference: e.g. we ask the typeclass search to look for `has_add` and `has_le`
 instances, instead of extending the search to all possible functions among different Types.
 
-The general approach is to formulate the lemma that you are interested and prove it, with the
-`ordered_[...]` typeclass of your liking.  After that, you convert the single typeclass,
-say `[ordered_cancel_monoid M]`, with three typeclasses, e.g.
-`[partial_order M] [left_cancel_semigroup M] [has_mul_le_mul_right M]`
-and have a go at seeing if the proof still works!
+The general approach is to formulate and prove a lemma, with the `ordered_[...]` typeclass of your
+liking.  After that, you convert the single typeclass, say `[ordered_cancel_monoid M]`, with three
+typeclasses, e.g. `[partial_order M] [left_cancel_semigroup M] [has_mul_le_mul_right M]` and see
+if the proof still works: chances are that it might!
 
-Note that it is possible to combine several `co(ntra)variant` assumptions together.
+It is possible (and even expected) to combine several `co(ntra)variant` assumptions together.
 Indeed, the usual ordered typeclasses arise from assuming the pair
 `[has_mul_le_mul_left M] [has_lt_of_mul_le_mul_left M]` on top of order/algebraic assumptions.
 
-A formal remark is that normally the direct implication of `covariant` uses the `(≤)`-relation,
-while inverse implication of `contravariant` uses the `(<)`-relation. This need not be the case in
+A formal remark is that normally the relation that is an input to `covariant` is `(≤)`,
+while the relation that is an input to `contravariant` is `(<)`. This need not be the case in
 general, but seems to be the most common usage. In the opposite direction, the implication
 
 ```lean
-[semigroup M] [partial_order M] [has_le_of_mul_le_mul M] => left_cancel_semigroup α
+[semigroup M] [partial_order M] [has_le_of_mul_le_mul M] → left_cancel_semigroup α
 ```
 holds (note the `has_le_[...]` as opposed to the more common idioms `has_lt_[...]` and
 `has_mul_le_[...]`.

--- a/src/algebra/order_operation_defs.lean
+++ b/src/algebra/order_operation_defs.lean
@@ -75,23 +75,23 @@ section covariants_and_contravariants
 
 variables {M N : Type*} (μ : M → N → N) (r : N → N → Prop) (m : M) {a b c : N}
 
+/--  Let `M` and `N` be Types, with an action `μ : M → N → N` and a relation `r N → N → Prop`
+ on `N`.
 
---variables (M N)
-/--  Given Types `M` and `N`, an action `μ : M → N → N` and a relation `r N → N → Prop` on `N`,
-informally, `covariant μ r` says that "the action `μ` preserves the relation `r`.
+Informally, `covariant μ r` says that "the action `μ` preserves the relation `r`.
 
-More precisely, `covariant μ r` is a class taking two Types `M N`, together with an "action"
-`μ : M → N → N` and a relation `r : N → N`.  It asserts that for all `m ∈ M` and all elements
-`n₁, n₂ ∈ N`, if the relation `r` holds for the pair `(n₁, n₂)`, then, the relation `r` also holds
-for the pair `(μ m n₁, μ m n₂)`, obtained from `(n₁, n₂)` by "acting upon it by `m`". -/
+More precisely, `covariant μ r` asserts that for all `m ∈ M` and all elements `n₁, n₂ ∈ N`, if the
+relation `r` holds for the pair `(n₁, n₂)`, then, the relation `r` also holds for the pair
+`(μ m n₁, μ m n₂)`, obtained from `(n₁, n₂)` by "acting upon it by `m`". -/
 def covariant     : Prop := ∀ (m) {n₁ n₂}, r n₁ n₂ → r (μ m n₁) (μ m n₂)
 
-/--  Given Types `M` and `N`, an action `μ : M → N → N` and a relation `r N → N → Prop` on `N`,
-informally, `contravariant μ r` says that "the action `μ` preserves the relation `r`.
+/--  Let `M` and `N` be Types, with an action `μ : M → N → N` and a relation `r N → N → Prop`
+ on `N`.
 
-More precisely, `contravariant μ r` is a class taking two Types `M N`, together with an "action"
-`μ : M → N → N` and a relation `r : N → N`.  It asserts that for all `m ∈ M` and all elements
-`n₁, n₂ ∈ N`, if the relation `r` holds for the pair `(μ m n₁, μ m n₂)`, obtained from `(n₁, n₂)` by
+Informally, `contravariant μ r` says that "the action `μ` preserves the relation `r`.
+
+More precisely, `contravariant μ r` asserts that for all `m ∈ M` and all elements `n₁, n₂ ∈ N`,
+if the relation `r` holds for the pair `(μ m n₁, μ m n₂)`, obtained from `(n₁, n₂)` by
 "acting upon it by `m`", then, the relation `r` also holds for the pair `(n₁, n₂)`. -/
 def contravariant : Prop := ∀ (m) {n₁ n₂}, r (μ m n₁) (μ m n₂) → r n₁ n₂
 


### PR DESCRIPTION
This PR revises and splits off the definitions of PR #7371.

I introduce two definitions, like in the other PR: `covariant` and `contravariant`.  They are *definitions* instead of *classes* since, if I understood correctly, Sébastien said that they would burden the typeclass search system.

Using these definitions, I then introduce 16 new classes, each one saying that addition/multiplication is left/right monotone in various convenient ways.  They system is heavily based on the original `ordered_[...]` hierarchy, except that now it is possible to mix-and-match assumptions on the algebraic side and on the order side.

I also provide instances to show that

* "left" assumptions imply "right" assumptions, if the operation is commutative, and
* `(≤)` assumptions imply `(<)` assumptions, if the order is linear.

Zulip discussion:
https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/ordered.20stuff

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
