### PR TITLE
[Merged by Bors] - feat(algebra/polynomial): generalize to `multiset` products

### DIFF
--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -35,23 +35,23 @@ variables {R : Type u} {ι : Type w}
 
 namespace polynomial
 
-variables (s : finset ι) (t : multiset ι)
+variables (s : finset ι)
 
 section comm_semiring
-variables [comm_semiring R] (f : ι → polynomial R)
+variables [comm_semiring R] (f : ι → polynomial R) (t : multiset (polynomial R))
 
 lemma nat_degree_multiset_prod_le :
-  (t.map f).prod.nat_degree ≤ (t.map (λ i, (f i).nat_degree)).sum :=
+  t.prod.nat_degree ≤ (t.map (λ f, nat_degree f)).sum :=
 begin
   refine multiset.induction_on t _ (λ a t ih, _), { simp },
-  rw [map_cons, prod_cons, map_cons, sum_cons],
-  transitivity (f a).nat_degree + (t.map f).prod.nat_degree,
+  rw [prod_cons, map_cons, sum_cons],
+  transitivity a.nat_degree + t.prod.nat_degree,
   { apply polynomial.nat_degree_mul_le },
   { exact add_le_add (le_refl _) ih }
 end
 
 lemma nat_degree_prod_le : (∏ i in s, f i).nat_degree ≤ ∑ i in s, (f i).nat_degree :=
-nat_degree_multiset_prod_le s.1 f
+by simpa using nat_degree_multiset_prod_le (s.1.map f)
 
 /--
 The leading coefficient of a product of polynomials is equal to
@@ -60,8 +60,8 @@ the product of the leading coefficients, provided that this product is nonzero.
 See `polynomial.leading_coeff_multiset_prod` (without the `'`) for a version for integral domains,
 where this condition is automatically satisfied.
 -/
-lemma leading_coeff_multiset_prod' (h : (t.map (λ i, (f i).leading_coeff)).prod ≠ 0) :
-  (t.map f).prod.leading_coeff = (t.map (λ i, (f i).leading_coeff)).prod :=
+lemma leading_coeff_multiset_prod' (h : (t.map (λ f, leading_coeff f)).prod ≠ 0) :
+  t.prod.leading_coeff = (t.map (λ f, leading_coeff f)).prod :=
 begin
   revert h,
   refine multiset.induction_on t _ (λ a t ih ht, _), { simp },
@@ -79,7 +79,7 @@ where this condition is automatically satisfied.
 -/
 lemma leading_coeff_prod' (h : ∏ i in s, (f i).leading_coeff ≠ 0) :
   (∏ i in s, f i).leading_coeff = ∏ i in s, (f i).leading_coeff :=
-leading_coeff_multiset_prod' s.1 f h
+by simpa using leading_coeff_multiset_prod' (s.1.map f) (by simpa using h)
 
 /--
 The degree of a product of polynomials is equal to
@@ -88,13 +88,13 @@ the sum of the degrees, provided that the product of leading coefficients is non
 See `polynomial.nat_degree_multiset_prod` (without the `'`) for a version for integral domains,
 where this condition is automatically satisfied.
 -/
-lemma nat_degree_multiset_prod' (h : (t.map (λ i, (f i).leading_coeff)).prod ≠ 0) :
-  (t.map f).prod.nat_degree = (t.map (λ i, (f i).nat_degree)).sum :=
+lemma nat_degree_multiset_prod' (h : (t.map (λ f, leading_coeff f)).prod ≠ 0) :
+  t.prod.nat_degree = (t.map (λ f, nat_degree f)).sum :=
 begin
   revert h,
   refine multiset.induction_on t _ (λ a t ih ht, _), { simp },
   rw [map_cons, prod_cons] at ht ⊢,
-  rw [map_cons, sum_cons, polynomial.nat_degree_mul', ih],
+  rw [sum_cons, polynomial.nat_degree_mul', ih],
   { apply right_ne_zero_of_mul ht },
   { rwa polynomial.leading_coeff_multiset_prod', apply right_ne_zero_of_mul ht },
 end
@@ -108,13 +108,13 @@ where this condition is automatically satisfied.
 -/
 lemma nat_degree_prod' (h : ∏ i in s, (f i).leading_coeff ≠ 0) :
   (∏ i in s, f i).nat_degree = ∑ i in s, (f i).nat_degree :=
-nat_degree_multiset_prod' s.1 f h
+by simpa using nat_degree_multiset_prod' (s.1.map f) (by simpa using h)
 
-lemma nat_degree_multiset_prod_of_monic [nontrivial R] (h : ∀ i ∈ t, (f i).monic) :
-  (t.map f).prod.nat_degree = (t.map (λ i, (f i).nat_degree)).sum :=
+lemma nat_degree_multiset_prod_of_monic [nontrivial R] (h : ∀ f ∈ t, monic f) :
+  t.prod.nat_degree = (t.map (λ f, nat_degree f)).sum :=
 begin
   apply nat_degree_multiset_prod',
-  suffices : (t.map (λ i, (f i).leading_coeff)).prod = 1, { rw this, simp },
+  suffices : (t.map (λ f, leading_coeff f)).prod = 1, { rw this, simp },
   convert prod_repeat (1 : R) t.card,
   { simp only [eq_repeat, multiset.card_map, eq_self_iff_true, true_and],
     rintros i hi,
@@ -125,19 +125,18 @@ end
 
 lemma nat_degree_prod_of_monic [nontrivial R] (h : ∀ i ∈ s, (f i).monic) :
   (∏ i in s, f i).nat_degree = ∑ i in s, (f i).nat_degree :=
-nat_degree_multiset_prod_of_monic s.1 f h
+by simpa using nat_degree_multiset_prod_of_monic (s.1.map f) (by simpa using h)
 
 lemma coeff_zero_multiset_prod :
-  (t.map f).prod.coeff 0 = (t.map (λ i, (f i).coeff 0)).prod :=
+  t.prod.coeff 0 = (t.map (λ f, coeff f 0)).prod :=
 begin
   refine multiset.induction_on t _ (λ a t ht, _), { simp },
-  rw [map_cons, prod_cons, map_cons, prod_cons,
-      polynomial.mul_coeff_zero, ht],
+  rw [prod_cons, map_cons, prod_cons, polynomial.mul_coeff_zero, ht]
 end
 
 lemma coeff_zero_prod :
   (∏ i in s, f i).coeff 0 = ∏ i in s, (f i).coeff 0 :=
-coeff_zero_multiset_prod s.1 f
+by simpa using coeff_zero_multiset_prod (s.1.map f)
 
 end comm_semiring
 
@@ -147,43 +146,41 @@ variables [comm_ring R]
 open monic
 -- Eventually this can be generalized with Vieta's formulas
 -- plus the connection between roots and factorization.
-lemma multiset_prod_X_sub_C_next_coeff [nontrivial R] {t : multiset ι} (f : ι → R) :
-  next_coeff (t.map (λ i, X - C (f i))).prod = -(t.map f).sum :=
+lemma multiset_prod_X_sub_C_next_coeff [nontrivial R] (t : multiset R) :
+  next_coeff (t.map (λ x, X - C x)).prod = -t.sum :=
 begin
   rw next_coeff_multiset_prod,
   { simp only [next_coeff_X_sub_C],
-    rw ← multiset.map_map,
-    refine (t.map _).sum_hom ⟨has_neg.neg, _, _⟩; simp [add_comm] },
+    refine t.sum_hom ⟨has_neg.neg, _, _⟩; simp [add_comm] },
   { intros, apply monic_X_sub_C }
 end
 
 lemma prod_X_sub_C_next_coeff [nontrivial R] {s : finset ι} (f : ι → R) :
   next_coeff ∏ i in s, (X - C (f i)) = -∑ i in s, f i :=
-multiset_prod_X_sub_C_next_coeff f
+by simpa using multiset_prod_X_sub_C_next_coeff (s.1.map f)
 
-lemma multiset_prod_X_sub_C_coeff_card_pred [nontrivial R] (t : multiset ι)
-  (f : ι → R) (hs : 0 < t.card) :
-  (t.map (λ i, (X - C (f i)))).prod.coeff (t.card - 1) = -(t.map f).sum :=
+lemma multiset_prod_X_sub_C_coeff_card_pred [nontrivial R] (t : multiset R) (ht : 0 < t.card) :
+  (t.map (λ x, (X - C x))).prod.coeff (t.card - 1) = -t.sum :=
 begin
   convert multiset_prod_X_sub_C_next_coeff (by assumption),
   rw next_coeff, split_ifs,
-  { rw nat_degree_multiset_prod_of_monic at h,
-    swap, { intros, apply monic_X_sub_C },
-    simp_rw [multiset.sum_eq_zero_iff, multiset.mem_map, nat_degree_X_sub_C] at h,
+  { rw nat_degree_multiset_prod_of_monic at h; simp only [multiset.mem_map] at *,
+    swap, { rintros _ ⟨_, _, rfl⟩, apply monic_X_sub_C },
+    simp_rw [multiset.sum_eq_zero_iff, multiset.mem_map] at h,
     contrapose! h,
-    obtain ⟨x, hx⟩ := card_pos_iff_exists_mem.mp hs,
-    exact ⟨_, ⟨x, hx, rfl⟩, one_ne_zero⟩ },
+    obtain ⟨x, hx⟩ := card_pos_iff_exists_mem.mp ht,
+    exact ⟨_, ⟨_, ⟨x, hx, rfl⟩, nat_degree_X_sub_C _⟩, one_ne_zero⟩ },
   congr, rw nat_degree_multiset_prod_of_monic; { simp [nat_degree_X_sub_C, monic_X_sub_C] },
 end
 
 lemma prod_X_sub_C_coeff_card_pred [nontrivial R] (s : finset ι) (f : ι → R) (hs : 0 < s.card) :
   (∏ i in s, (X - C (f i))).coeff (s.card - 1) = - ∑ i in s, f i :=
-multiset_prod_X_sub_C_coeff_card_pred s.1 f hs
+by simpa using multiset_prod_X_sub_C_coeff_card_pred (s.1.map f) (by simpa using hs)
 
 end comm_ring
 
 section no_zero_divisors
-variables [comm_ring R] [no_zero_divisors R] (f : ι → polynomial R)
+variables [comm_ring R] [no_zero_divisors R] (f : ι → polynomial R) (t : multiset (polynomial R))
 
 /--
 The degree of a product of polynomials is equal to
@@ -204,8 +201,8 @@ lemma nat_degree_multiset_prod [nontrivial R] (s : multiset (polynomial R))
   (h : (0 : polynomial R) ∉ s) :
   nat_degree s.prod = (s.map nat_degree).sum :=
 begin
-  rw [← s.map_id, nat_degree_multiset_prod'], simp,
-  simp_rw [ne.def, multiset.prod_eq_zero_iff, multiset.mem_map, leading_coeff_eq_zero, id],
+  rw nat_degree_multiset_prod',
+  simp_rw [ne.def, multiset.prod_eq_zero_iff, multiset.mem_map, leading_coeff_eq_zero],
   rintro ⟨_, h, rfl⟩,
   contradiction
 end
@@ -215,10 +212,10 @@ The degree of a product of polynomials is equal to
 the sum of the degrees, where the degree of the zero polynomial is ⊥.
 -/
 lemma degree_multiset_prod [nontrivial R] :
-  (t.map f).prod.degree = (t.map (λ i, (f i).degree)).sum :=
+  t.prod.degree = (t.map (λ f, degree f)).sum :=
 begin
   refine multiset.induction_on t _ (λ a t ht, _), { simp },
-  { rw [map_cons, prod_cons, degree_mul, ht, map_cons, sum_cons] }
+  { rw [prod_cons, degree_mul, ht, map_cons, sum_cons] }
 end
 
 /--
@@ -226,7 +223,7 @@ The degree of a product of polynomials is equal to
 the sum of the degrees, where the degree of the zero polynomial is ⊥.
 -/
 lemma degree_prod [nontrivial R] : (∏ i in s, f i).degree = ∑ i in s, (f i).degree :=
-degree_multiset_prod s.1 f
+by simpa using degree_multiset_prod (s.1.map f)
 
 /--
 The leading coefficient of a product of polynomials is equal to
@@ -236,8 +233,8 @@ See `polynomial.leading_coeff_multiset_prod'` (with a `'`) for a version for com
 where additionally, the product of the leading coefficients must be nonzero.
 -/
 lemma leading_coeff_multiset_prod :
-  (t.map f).prod.leading_coeff = (t.map (λ i, (f i).leading_coeff)).prod :=
-by { rw [← leading_coeff_hom_apply, monoid_hom.map_multiset_prod, multiset.map_map], refl }
+  t.prod.leading_coeff = (t.map (λ f, leading_coeff f)).prod :=
+by { rw [← leading_coeff_hom_apply, monoid_hom.map_multiset_prod], refl }
 
 /--
 The leading coefficient of a product of polynomials is equal to
@@ -248,7 +245,7 @@ where additionally, the product of the leading coefficients must be nonzero.
 -/
 lemma leading_coeff_prod :
   (∏ i in s, f i).leading_coeff = ∏ i in s, (f i).leading_coeff :=
-leading_coeff_multiset_prod s.1 f
+by simpa using leading_coeff_multiset_prod (s.1.map f)
 
 end no_zero_divisors
 end polynomial

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -137,9 +137,22 @@ end semiring
 section comm_semiring
 variables [comm_semiring R] {p : polynomial R}
 
+lemma monic_multiset_prod_of_monic (t : multiset ι) (f : ι → polynomial R)
+  (ht : ∀ i ∈ t, monic (f i)) :
+  monic (t.map f).prod :=
+begin
+  revert ht,
+  refine t.induction_on _ _, { simp },
+  intros a t ih ht,
+  rw [multiset.map_cons, multiset.prod_cons],
+  exact monic_mul
+    (ht _ (multiset.mem_cons_self _ _))
+    (ih (λ _ hi, ht _ (multiset.mem_cons_of_mem hi)))
+end
+
 lemma monic_prod_of_monic (s : finset ι) (f : ι → polynomial R) (hs : ∀ i ∈ s, monic (f i)) :
-monic (∏ i in s, f i) :=
-prod_induction _ _ (@monic_mul _ _) monic_one hs
+  monic (∏ i in s, f i) :=
+monic_multiset_prod_of_monic s.1 f hs
 
 lemma is_unit_C {x : R} : is_unit (C x) ↔ is_unit x :=
 begin
@@ -172,19 +185,24 @@ have degree p ≤ 0,
 by rw [eq_C_of_degree_le_zero this, ← nat_degree_eq_zero_iff_degree_le_zero.2 this,
     ← leading_coeff, hm.leading_coeff, C_1]
 
-lemma monic.next_coeff_prod (s : finset ι) (f : ι → polynomial R) (h : ∀ i ∈ s, monic (f i)) :
-next_coeff (∏ i in s, f i) = ∑ i in s, next_coeff (f i) :=
+lemma monic.next_coeff_multiset_prod (t : multiset ι) (f : ι → polynomial R)
+  (h : ∀ i ∈ t, monic (f i)) :
+  next_coeff (t.map f).prod = (t.map (λ i, next_coeff (f i))).sum :=
 begin
-  classical,
-  revert h, apply finset.induction_on s,
-  { simp only [finset.not_mem_empty, forall_prop_of_true, forall_prop_of_false, finset.sum_empty,
-  finset.prod_empty, not_false_iff, forall_true_iff],
-  rw ← C_1, rw next_coeff_C_eq_zero },
-  { intros a s ha hs H,
-    rw [finset.prod_insert ha, finset.sum_insert ha, monic.next_coeff_mul, hs],
-    exacts [λ i hi, H i (mem_insert_of_mem hi), H a (mem_insert_self _ _),
-      monic_prod_of_monic _ _ (λ b bs, H _ (finset.mem_insert_of_mem bs))] }
+  revert h,
+  refine multiset.induction_on t _ (λ a t ih ht, _),
+  { simp only [multiset.not_mem_zero, forall_prop_of_true, forall_prop_of_false, multiset.map_zero,
+               multiset.prod_zero, multiset.sum_zero, not_false_iff, forall_true_iff],
+    rw ← C_1, rw next_coeff_C_eq_zero },
+  { rw [multiset.map_cons, multiset.prod_cons, multiset.map_cons, multiset.sum_cons,
+        monic.next_coeff_mul, ih],
+    exacts [λ i hi, ht i (multiset.mem_cons_of_mem hi), ht a (multiset.mem_cons_self _ _),
+            monic_multiset_prod_of_monic _ _ (λ b bs, ht _ (multiset.mem_cons_of_mem bs))] }
 end
+
+lemma monic.next_coeff_prod (s : finset ι) (f : ι → polynomial R) (h : ∀ i ∈ s, monic (f i)) :
+  next_coeff (∏ i in s, f i) = ∑ i in s, next_coeff (f i) :=
+monic.next_coeff_multiset_prod s.1 f h
 
 end comm_semiring
 


### PR DESCRIPTION
This PR generalizes the results in `algebra.polynomial.big_operators` to sums and products of multisets.

The new multiset results are stated for `multiset.prod t`, not `(multiset.map t f).prod`. To get the latter, you can simply rewrite with `multiset.map_map`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
