### PR TITLE
[Merged by Bors] - fix(algebra/direct_sum_graded): replace badly-stated and slow `simps` lemmas with manual ones 

### DIFF
--- a/src/algebra/direct_sum_graded.lean
+++ b/src/algebra/direct_sum_graded.lean
@@ -139,6 +139,7 @@ def ghas_one.of_add_submonoids [semiring R] [has_zero ι]
   ghas_one (λ i, carriers i) :=
 { one := ⟨1, one_mem⟩ }
 
+-- `@[simps]` doesn't generate a useful lemma, so we state one manually below.
 /-- Build a `ghas_mul` instance for a collection of `add_submonoids`. -/
 def ghas_mul.of_add_submonoids [semiring R] [has_add ι]
   (carriers : ι → add_submonoid R)
@@ -192,6 +193,7 @@ def ghas_one.of_add_subgroups [ring R] [has_zero ι]
   ghas_one (λ i, carriers i) :=
 ghas_one.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem
 
+-- `@[simps]` doesn't generate a useful lemma, so we state one manually below.
 /-- Build a `ghas_mul` instance for a collection of `add_subgroup`s. -/
 def ghas_mul.of_add_subgroups [ring R] [has_add ι]
   (carriers : ι → add_subgroup R)
@@ -236,6 +238,7 @@ def ghas_one.of_submodules
   ghas_one (λ i, carriers i) :=
 ghas_one.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem
 
+-- `@[simps]` doesn't generate a useful lemma, so we state one manually below.
 /-- Build a `ghas_mul` instance for a collection of `submodule`s. -/
 def ghas_mul.of_submodules
   [comm_semiring R] [semiring A] [algebra R A] [has_add ι]

--- a/src/algebra/direct_sum_graded.lean
+++ b/src/algebra/direct_sum_graded.lean
@@ -140,7 +140,6 @@ def ghas_one.of_add_submonoids [semiring R] [has_zero ι]
 { one := ⟨1, one_mem⟩ }
 
 /-- Build a `ghas_mul` instance for a collection of `add_submonoids`. -/
-@[simps mul]
 def ghas_mul.of_add_submonoids [semiring R] [has_add ι]
   (carriers : ι → add_submonoid R)
   (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : R) ∈ carriers (i + j)) :
@@ -152,6 +151,12 @@ def ghas_mul.of_add_submonoids [semiring R] [has_add ι]
       map_zero' := subtype.ext (mul_zero _), },
     map_add' := λ _ _, add_monoid_hom.ext $ λ _, subtype.ext (add_mul _ _ _),
     map_zero' := add_monoid_hom.ext $ λ _, subtype.ext (zero_mul _) }, }
+
+-- `@[simps]` doesn't generate this well
+lemma ghas_mul.of_add_submonoids_mul [semiring R] [has_add ι]
+  (carriers : ι → add_submonoid R) (mul_mem) {i j} (a : carriers i) (b : carriers j) :
+  @ghas_mul.mul _ _ _ _ _ (ghas_mul.of_add_submonoids carriers mul_mem) i j a b =
+    ⟨a * b, mul_mem a b⟩ := rfl
 
 /-- Build a `gmonoid` instance for a collection of `add_submonoid`s. -/
 @[simps to_ghas_one to_ghas_mul]
@@ -188,12 +193,16 @@ def ghas_one.of_add_subgroups [ring R] [has_zero ι]
 ghas_one.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem
 
 /-- Build a `ghas_mul` instance for a collection of `add_subgroup`s. -/
-@[simps mul]
 def ghas_mul.of_add_subgroups [ring R] [has_add ι]
   (carriers : ι → add_subgroup R)
   (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : R) ∈ carriers (i + j)) :
   ghas_mul (λ i, carriers i) :=
 ghas_mul.of_add_submonoids (λ i, (carriers i).to_add_submonoid) mul_mem
+
+lemma ghas_mul.of_add_subgroups_mul [ring R] [has_add ι]
+  (carriers : ι → add_subgroup R) (mul_mem) {i j} (a : carriers i) (b : carriers j) :
+  @ghas_mul.mul _ _ _ _ _ (ghas_mul.of_add_subgroups carriers mul_mem) i j a b =
+    ⟨a * b, mul_mem a b⟩ := rfl
 
 /-- Build a `gmonoid` instance for a collection of `add_subgroup`s. -/
 @[simps to_ghas_one to_ghas_mul]
@@ -227,13 +236,19 @@ def ghas_one.of_submodules
 ghas_one.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem
 
 /-- Build a `ghas_mul` instance for a collection of `submodule`s. -/
-@[simps mul]
 def ghas_mul.of_submodules
   [comm_semiring R] [semiring A] [algebra R A] [has_add ι]
   (carriers : ι → submodule R A)
   (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : A) ∈ carriers (i + j)) :
   ghas_mul (λ i, carriers i) :=
 ghas_mul.of_add_submonoids (λ i, (carriers i).to_add_submonoid) mul_mem
+
+-- `@[simps]` doesn't generate this well
+lemma ghas_mul.of_submodules_mul
+  [comm_semiring R] [semiring A] [algebra R A] [has_add ι]
+  (carriers : ι → submodule R A) (mul_mem) {i j} (a : carriers i) (b : carriers j) :
+  @ghas_mul.mul _ _ _ _ _ (ghas_mul.of_submodules carriers mul_mem) i j a b =
+    ⟨a * b, mul_mem a b⟩ := rfl
 
 /-- Build a `gmonoid` instance for a collection of `submodules`s. -/
 @[simps to_ghas_one to_ghas_mul]

--- a/src/algebra/direct_sum_graded.lean
+++ b/src/algebra/direct_sum_graded.lean
@@ -153,7 +153,7 @@ def ghas_mul.of_add_submonoids [semiring R] [has_add ι]
     map_zero' := add_monoid_hom.ext $ λ _, subtype.ext (zero_mul _) }, }
 
 -- `@[simps]` doesn't generate this well
-lemma ghas_mul.of_add_submonoids_mul [semiring R] [has_add ι]
+@[simp] lemma ghas_mul.of_add_submonoids_mul [semiring R] [has_add ι]
   (carriers : ι → add_submonoid R) (mul_mem) {i j} (a : carriers i) (b : carriers j) :
   @ghas_mul.mul _ _ _ _ _ (ghas_mul.of_add_submonoids carriers mul_mem) i j a b =
     ⟨a * b, mul_mem a b⟩ := rfl
@@ -199,7 +199,8 @@ def ghas_mul.of_add_subgroups [ring R] [has_add ι]
   ghas_mul (λ i, carriers i) :=
 ghas_mul.of_add_submonoids (λ i, (carriers i).to_add_submonoid) mul_mem
 
-lemma ghas_mul.of_add_subgroups_mul [ring R] [has_add ι]
+-- `@[simps]` doesn't generate this well
+@[simp] lemma ghas_mul.of_add_subgroups_mul [ring R] [has_add ι]
   (carriers : ι → add_subgroup R) (mul_mem) {i j} (a : carriers i) (b : carriers j) :
   @ghas_mul.mul _ _ _ _ _ (ghas_mul.of_add_subgroups carriers mul_mem) i j a b =
     ⟨a * b, mul_mem a b⟩ := rfl
@@ -244,7 +245,7 @@ def ghas_mul.of_submodules
 ghas_mul.of_add_submonoids (λ i, (carriers i).to_add_submonoid) mul_mem
 
 -- `@[simps]` doesn't generate this well
-lemma ghas_mul.of_submodules_mul
+@[simp] lemma ghas_mul.of_submodules_mul
   [comm_semiring R] [semiring A] [algebra R A] [has_add ι]
   (carriers : ι → submodule R A) (mul_mem) {i j} (a : carriers i) (b : carriers j) :
   @ghas_mul.mul _ _ _ _ _ (ghas_mul.of_submodules carriers mul_mem) i j a b =


### PR DESCRIPTION
[Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/simps.20is.20very.20slow/near/236636962). The `simps mul` attribute on `direct_sum.ghas_mul.of_add_subgroups` was taking 44s, only to produce a lemma that wasn't very useful anyway.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
