### PR TITLE
[Merged by Bors] - feat(data/finset/basic): a finset has card at most one iff it is contained in a singleton

### DIFF
--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -241,7 +241,7 @@ lemma to_ring_hom_injective : function.injective (to_ring_hom : (R ≃+* S) → 
 
 instance has_coe_to_ring_hom : has_coe (R ≃+* S) (R →+* S) := ⟨ring_equiv.to_ring_hom⟩
 
-@[simp] lemma to_ring_hom_eq_coe (f : R ≃+* S) : f.to_ring_hom = ↑f := rfl
+lemma to_ring_hom_eq_coe (f : R ≃+* S) : f.to_ring_hom = ↑f := rfl
 
 @[simp, norm_cast] lemma coe_to_ring_hom (f : R ≃+* S) : ⇑(f : R →+* S) = f := rfl
 

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -241,7 +241,7 @@ lemma to_ring_hom_injective : function.injective (to_ring_hom : (R ≃+* S) → 
 
 instance has_coe_to_ring_hom : has_coe (R ≃+* S) (R →+* S) := ⟨ring_equiv.to_ring_hom⟩
 
-lemma to_ring_hom_eq_coe (f : R ≃+* S) : f.to_ring_hom = ↑f := rfl
+@[simp] lemma to_ring_hom_eq_coe (f : R ≃+* S) : f.to_ring_hom = ↑f := rfl
 
 @[simp, norm_cast] lemma coe_to_ring_hom (f : R ≃+* S) : ⇑(f : R →+* S) = f := rfl
 

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -2054,8 +2054,7 @@ begin
     by_cases h : ∃ x, x ∈ s,
     { rcases h with ⟨x, hx⟩,
       refine ⟨x, λ y hy, _⟩,
-      rw card_le_one.1 H y hy x hx,
-      simp only [mem_singleton] },
+      rw [card_le_one.1 H y hy x hx, mem_singleton] },
     { push_neg at h,
       inhabit α,
       exact ⟨default α, λ y hy, (h y hy).elim⟩ } },
@@ -2073,7 +2072,7 @@ by { rw ← not_iff_not, push_neg, exact card_le_one }
 
 lemma one_lt_card_iff {s : finset α} :
   1 < s.card ↔ ∃ x y, (x ∈ s) ∧ (y ∈ s) ∧ x ≠ y :=
-by { rw ← not_iff_not, push_neg, simpa [or_iff_not_imp_left] using finset.card_le_one_iff }
+by { rw one_lt_card, simp only [exists_prop, exists_and_distrib_left] }
 
 @[simp] theorem card_insert_of_not_mem [decidable_eq α]
   {a : α} {s : finset α} (h : a ∉ s) : card (insert a s) = card s + 1 :=

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -2020,6 +2020,9 @@ theorem card_def (s : finset α) : s.card = s.1.card := rfl
 
 @[simp] theorem card_empty : card (∅ : finset α) = 0 := rfl
 
+theorem card_le_of_subset {s t : finset α} : s ⊆ t → card s ≤ card t :=
+multiset.card_le_of_le ∘ val_le_iff.mpr
+
 @[simp] theorem card_eq_zero {s : finset α} : card s = 0 ↔ s = ∅ :=
 card_eq_zero.trans val_eq_zero
 
@@ -2040,8 +2043,37 @@ begin
   { exact λ h, ⟨x, eq_singleton_iff_unique_mem.2 ⟨hx, λ y hy, h _ hy _ hx⟩⟩ }
 end
 
+theorem card_le_one_iff {s : finset α} : s.card ≤ 1 ↔ ∀ {a b}, a ∈ s → b ∈ s → a = b :=
+by { rw card_le_one, tauto }
+
+lemma card_le_one_iff_subset_singleton [nonempty α] {s : finset α} :
+  s.card ≤ 1 ↔ ∃ (x : α), s ⊆ {x} :=
+begin
+  split,
+  { assume H,
+    by_cases h : ∃ x, x ∈ s,
+    { rcases h with ⟨x, hx⟩,
+      refine ⟨x, λ y hy, _⟩,
+      rw card_le_one.1 H y hy x hx,
+      simp only [mem_singleton] },
+    { push_neg at h,
+      inhabit α,
+      exact ⟨default α, λ y hy, (h y hy).elim⟩ } },
+  { rintros ⟨x, hx⟩,
+    rw ← card_singleton x,
+    exact card_le_of_subset hx }
+end
+
+/-- A `finset` of a subsingleton type has cardinality at most one. -/
+lemma card_le_one_of_subsingleton [subsingleton α] (s : finset α) : s.card ≤ 1 :=
+finset.card_le_one_iff.2 $ λ _ _ _ _, subsingleton.elim _ _
+
 theorem one_lt_card {s : finset α} : 1 < s.card ↔ ∃ (a ∈ s) (b ∈ s), a ≠ b :=
 by { rw ← not_iff_not, push_neg, exact card_le_one }
+
+lemma one_lt_card_iff {s : finset α} :
+  1 < s.card ↔ ∃ x y, (x ∈ s) ∧ (y ∈ s) ∧ x ≠ y :=
+by { rw ← not_iff_not, push_neg, simpa [or_iff_not_imp_left] using finset.card_le_one_iff }
 
 @[simp] theorem card_insert_of_not_mem [decidable_eq α]
   {a : α} {s : finset α} (h : a ∉ s) : card (insert a s) = card s + 1 :=
@@ -2170,9 +2202,6 @@ iff.intro
     ⟨a, s.erase a, s.not_mem_erase a, insert_erase has,
       by simp only [eq, card_erase_of_mem has, pred_succ]⟩)
   (assume ⟨a, t, hat, s_eq, n_eq⟩, s_eq ▸ n_eq ▸ card_insert_of_not_mem hat)
-
-theorem card_le_of_subset {s t : finset α} : s ⊆ t → card s ≤ card t :=
-multiset.card_le_of_le ∘ val_le_iff.mpr
 
 theorem card_filter_le (s : finset α) (p : α → Prop) [decidable_pred p] :
   card (s.filter p) ≤ card s :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -888,51 +888,6 @@ finset.subtype.fintype s
 
 lemma finset.attach_eq_univ {s : finset α} : s.attach = finset.univ := rfl
 
-lemma finset.card_le_one_iff {s : finset α} :
-  s.card ≤ 1 ↔ ∀ {x y}, x ∈ s → y ∈ s → x = y :=
-begin
-  let t : set α := ↑s,
-  letI : fintype t := finset_coe.fintype s,
-  have : fintype.card t = s.card := fintype.card_coe s,
-  rw [← this, fintype.card_le_one_iff],
-  split,
-  { assume H x y hx hy,
-    exact subtype.mk.inj (H ⟨x, hx⟩ ⟨y, hy⟩) },
-  { assume H x y,
-    exact subtype.eq (H x.2 y.2) }
-end
-
-lemma finset.card_le_one_iff_subset_singleton [nonempty α] {s : finset α} :
-  s.card ≤ 1 ↔ ∃ (x : α), s ⊆ {x} :=
-begin
-  split,
-  { assume H,
-    by_cases h : ∃ x, x ∈ s,
-    { rcases h with ⟨x, hx⟩,
-      refine ⟨x, λ y hy, _⟩,
-      rw finset.card_le_one_iff.1 H hy hx,
-      simp only [mem_singleton] },
-    { push_neg at h,
-      inhabit α,
-      exact ⟨default α, λ y hy, (h y hy).elim⟩ } },
-  { rintros ⟨x, hx⟩,
-    rw ← card_singleton x,
-    exact card_le_of_subset hx }
-end
-
-/-- A `finset` of a subsingleton type has cardinality at most one. -/
-lemma finset.card_le_one_of_subsingleton [subsingleton α] (s : finset α) : s.card ≤ 1 :=
-finset.card_le_one_iff.2 $ λ _ _ _ _, subsingleton.elim _ _
-
-lemma finset.one_lt_card_iff {s : finset α} :
-  1 < s.card ↔ ∃ x y, (x ∈ s) ∧ (y ∈ s) ∧ x ≠ y :=
-begin
-  classical,
-  rw ← not_iff_not,
-  push_neg,
-  simpa [or_iff_not_imp_left] using finset.card_le_one_iff
-end
-
 instance plift.fintype (p : Prop) [decidable p] : fintype (plift p) :=
 ⟨if h : p then {⟨h⟩} else ∅, λ ⟨h⟩, by simp [h]⟩
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -902,6 +902,24 @@ begin
     exact subtype.eq (H x.2 y.2) }
 end
 
+lemma finset.card_le_one_iff_subset_singleton [nonempty α] {s : finset α} :
+  s.card ≤ 1 ↔ ∃ (x : α), s ⊆ {x} :=
+begin
+  split,
+  { assume H,
+    by_cases h : ∃ x, x ∈ s,
+    { rcases h with ⟨x, hx⟩,
+      refine ⟨x, λ y hy, _⟩,
+      rw finset.card_le_one_iff.1 H hy hx,
+      simp only [mem_singleton] },
+    { push_neg at h,
+      inhabit α,
+      exact ⟨default α, λ y hy, (h y hy).elim⟩ } },
+  { rintros ⟨x, hx⟩,
+    rw ← card_singleton x,
+    exact card_le_of_subset hx }
+end
+
 /-- A `finset` of a subsingleton type has cardinality at most one. -/
 lemma finset.card_le_one_of_subsingleton [subsingleton α] (s : finset α) : s.card ≤ 1 :=
 finset.card_le_one_iff.2 $ λ _ _ _ _, subsingleton.elim _ _


### PR DESCRIPTION
---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This variation around already existing facts turns out to be handy for further applications
