### PR TITLE
[Merged by Bors] - feat(group/hom_instances): add composition operators

### DIFF
--- a/src/algebra/group/hom_instances.lean
+++ b/src/algebra/group/hom_instances.lean
@@ -95,6 +95,7 @@ is commutative.
 
 namespace monoid_hom
 
+@[to_additive]
 lemma ext_iff₂ {mM : mul_one_class M} {mN : mul_one_class N} {mP : comm_monoid P}
   {f g : M →* N →* P} :
   f = g ↔ (∀ x y, f x y = g x y) :=
@@ -194,7 +195,7 @@ if the import structure permits them to be.
 
 section semiring
 
-variables {R : Type*} [semiring R]
+variables {R S : Type*} [semiring R] [semiring S]
 
 /-- Multiplication of an element of a (semi)ring is an `add_monoid_hom` in both arguments.
 
@@ -216,5 +217,14 @@ lemma add_monoid_hom.coe_mul :
 @[simp]
 lemma add_monoid_hom.coe_flip_mul :
   ⇑(add_monoid_hom.mul : R →+ R →+ R).flip = add_monoid_hom.mul_right := rfl
+
+/-- An `add_monoid_hom` preserves multiplication if pre- and post- composition with
+`add_monoid_hom.mul` are equivalent. By converting the statement into an equality of
+`add_monoid_hom`s, this lemma allows various specialized `ext` lemmas about `→+` to then be applied.
+-/
+lemma add_monoid_hom.map_mul_iff (f : R →+ S) :
+  (∀ x y, f (x * y) = f x * f y) ↔
+    (add_monoid_hom.mul : R →+ R →+ R).compr₂ f = (add_monoid_hom.mul.comp f).compl₂ f :=
+iff.symm add_monoid_hom.ext_iff₂
 
 end semiring

--- a/src/algebra/group/hom_instances.lean
+++ b/src/algebra/group/hom_instances.lean
@@ -56,7 +56,7 @@ instance [add_zero_class M] [add_comm_monoid N] : add_comm_monoid (M →+ N) :=
 
 attribute [to_additive] monoid_hom.comm_monoid
 
-/-- If `G` is a commutative group, then `M →* G` a commutative group too. -/
+/-- If `G` is a commutative group, then `M →* G` is a commutative group too. -/
 instance {M G} [mul_one_class M] [comm_group G] : comm_group (M →* G) :=
 { inv := has_inv.inv,
   div := has_div.div,
@@ -70,7 +70,7 @@ instance {M G} [mul_one_class M] [comm_group G] : comm_group (M →* G) :=
   gpow_neg'  := λ n f, by { ext x, simp },
   ..monoid_hom.comm_monoid }
 
-/-- If `G` is an additive commutative group, then `M →+ G` an additive commutative group too. -/
+/-- If `G` is an additive commutative group, then `M →+ G` is an additive commutative group too. -/
 instance {M G} [add_zero_class M] [add_comm_group G] : add_comm_group (M →+ G) :=
 { neg := has_neg.neg,
   sub := has_sub.sub,


### PR DESCRIPTION
This adds the analogous definitions to those we have for `linear_map`, namely:

* `monoid_hom.comp_hom'` (c.f. `linear_map.lcomp`, `l` = `linear`)
* `monoid_hom.compl₂` (c.f. `linear_map.compl₂`, `l` = `left`)
* `monoid_hom.compr₂` (c.f. `linear_map.compr₂`, `r` = `right`)

We already have `monoid_hom.comp_hom` (c.f. `linear_map.llcomp`, `ll` = `linear linear`)

It also adds an `ext_iff₂` lemma, which is occasionally useful (but not present for any other time at the moment).

The order of definitions in the file has been shuffled slightly to permit addition of a subheading to group things in doc-gen



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
