### PR TITLE
[Merged by Bors] - chore(topology/category): some lemmas for Profinite functions

### DIFF
--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -64,7 +64,7 @@ instance {X : Profinite} : totally_disconnected_space X := X.is_totally_disconne
 lemma coe_to_Top {X : Profinite} : (X.to_Top : Type*) = X :=
 rfl
 
-@[simp] lemma coe_id (X : Profinite) (x : X) : (𝟙 X : X → X) = id := rfl
+@[simp] lemma coe_id (X : Profinite) : (𝟙 X : X → X) = id := rfl
 
 @[simp] lemma coe_comp {X Y Z : Profinite} (f : X ⟶ Y) (g : Y ⟶ Z) : (f ≫ g : X → Z) = g ∘ f := rfl
 

--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -64,11 +64,9 @@ instance {X : Profinite} : totally_disconnected_space X := X.is_totally_disconne
 lemma coe_to_Top {X : Profinite} : (X.to_Top : Type*) = X :=
 rfl
 
-@[simp] lemma id_app (X : Profinite) (x : X) :
-  (𝟙 X : X → X) x = x := rfl
+@[simp] lemma coe_id (X : Profinite) (x : X) : (𝟙 X : X → X) = id := rfl
 
-@[simp] lemma comp_app {X Y Z : Profinite} (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) :
-  (f ≫ g : X → Z) x = g (f x) := rfl
+@[simp] lemma coe_comp {X Y Z : Profinite} (f : X ⟶ Y) (g : Y ⟶ Z) : (f ≫ g : X → Z) = g ∘ f := rfl
 
 end Profinite
 

--- a/src/topology/category/Profinite.lean
+++ b/src/topology/category/Profinite.lean
@@ -51,22 +51,30 @@ namespace Profinite
 
 instance : inhabited Profinite := ⟨{to_Top := { α := pempty }}⟩
 
+instance category : category Profinite := induced_category.category to_Top
+instance concrete_category : concrete_category Profinite := induced_category.concrete_category _
+instance has_forget₂ : has_forget₂ Profinite Top := induced_category.has_forget₂ _
+
 instance : has_coe_to_sort Profinite := ⟨Type*, λ X, X.to_Top⟩
 instance {X : Profinite} : compact_space X := X.is_compact
 instance {X : Profinite} : t2_space X := X.is_t2
 instance {X : Profinite} : totally_disconnected_space X := X.is_totally_disconnected
 
-instance category : category Profinite := induced_category.category to_Top
-
 @[simp]
 lemma coe_to_Top {X : Profinite} : (X.to_Top : Type*) = X :=
 rfl
+
+@[simp] lemma id_app (X : Profinite) (x : X) :
+  (𝟙 X : X → X) x = x := rfl
+
+@[simp] lemma comp_app {X Y Z : Profinite} (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) :
+  (f ≫ g : X → Z) x = g (f x) := rfl
 
 end Profinite
 
 /-- The fully faithful embedding of `Profinite` in `Top`. -/
 @[simps, derive [full, faithful]]
-def Profinite_to_Top : Profinite ⥤ Top := induced_functor _
+def Profinite_to_Top : Profinite ⥤ Top := forget₂ _ _
 
 /-- The fully faithful embedding of `Profinite` in `CompHaus`. -/
 @[simps] def Profinite.to_CompHaus : Profinite ⥤ CompHaus :=


### PR DESCRIPTION
Adds `concrete_category`  and `has_forget₂` instances for Profinite, and `id_app` and `comp_app` lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
