### PR TITLE
[Merged by Bors] - feat(algebra/archimedean): rat.cast_round for non-archimedean fields

### DIFF
--- a/src/algebra/archimedean.lean
+++ b/src/algebra/archimedean.lean
@@ -303,27 +303,15 @@ end
 theorem exists_pos_rat_lt {x : α} (x0 : 0 < x) : ∃ q : ℚ, 0 < q ∧ (q : α) < x :=
 by simpa only [rat.cast_pos] using exists_rat_btwn x0
 
-include α
-@[simp] theorem rat.cast_floor (x : ℚ) :
-  by haveI := archimedean.floor_ring α; exact ⌊(x:α)⌋ = ⌊x⌋ :=
-begin
-  haveI := archimedean.floor_ring α,
-  apply le_antisymm,
-  { rw [le_floor, ← @rat.cast_le α, rat.cast_coe_int],
-    apply floor_le },
-  { rw [le_floor, ← rat.cast_coe_int, rat.cast_le],
-    apply floor_le }
-end
-
 end linear_ordered_field
 
 section
-variables [linear_ordered_field α]
+variables [linear_ordered_field α] [floor_ring α]
 
 /-- `round` rounds a number to the nearest integer. `round (1 / 2) = 1` -/
-def round [floor_ring α] (x : α) : ℤ := ⌊x + 1 / 2⌋
+def round (x : α) : ℤ := ⌊x + 1 / 2⌋
 
-lemma abs_sub_round [floor_ring α] (x : α) : abs (x - round x) ≤ 1 / 2 :=
+lemma abs_sub_round (x : α) : abs (x - round x) ≤ 1 / 2 :=
 begin
   rw [round, abs_sub_le_iff],
   have := floor_le (x + 1 / 2),
@@ -331,7 +319,20 @@ begin
   split; linarith
 end
 
-variable [archimedean α]
+@[simp, norm_cast] theorem rat.cast_floor (x : ℚ) : ⌊(x:α)⌋ = ⌊x⌋ :=
+floor_eq_iff.2 (by exact_mod_cast floor_eq_iff.1 (eq.refl ⌊x⌋))
+
+@[simp, norm_cast] theorem rat.cast_ceil (x : ℚ) : ⌈(x:α)⌉ = ⌈x⌉ :=
+by rw [ceil, ← rat.cast_neg, rat.cast_floor, ← ceil]
+
+@[simp, norm_cast] theorem rat.cast_round (x : ℚ) : round (x:α) = round x :=
+have ((x + 1 / 2 : ℚ) : α) = x + 1 / 2, by simp,
+by rw [round, round, ← this, rat.cast_floor]
+
+end
+
+section
+variables [linear_ordered_field α] [archimedean α]
 
 theorem exists_rat_near (x : α) {ε : α} (ε0 : 0 < ε) :
   ∃ q : ℚ, abs (x - q) < ε :=
@@ -341,10 +342,5 @@ let ⟨q, h₁, h₂⟩ := exists_rat_btwn $
 
 instance : archimedean ℚ :=
 archimedean_iff_rat_le.2 $ λ q, ⟨q, by rw rat.cast_id⟩
-
-@[simp] theorem rat.cast_round (x : ℚ) : by haveI := archimedean.floor_ring α;
-  exact round (x:α) = round x :=
-have ((x + (1 : ℚ) / (2 : ℚ) : ℚ) : α) = x + 1 / 2, by simp,
-by rw [round, round, ← this, rat.cast_floor]
 
 end

--- a/src/algebra/continued_fractions/computation/terminates_iff_rat.lean
+++ b/src/algebra/continued_fractions/computation/terminates_iff_rat.lean
@@ -152,8 +152,8 @@ To do this, we proceed bottom-up, showing the correspondence between the basic f
 the computation first and then lift the results step-by-step.
 -/
 
-/- The lifting works for arbitrary linear ordered, archimedean fields with a floor function. -/
-variables [archimedean K] {v : K} {q : ℚ} (v_eq_q : v = (↑q : K)) (n : ℕ)
+/- The lifting works for arbitrary linear ordered fields with a floor function. -/
+variables {v : K} {q : ℚ} (v_eq_q : v = (↑q : K)) (n : ℕ)
 include v_eq_q
 
 /-! First, we show the correspondence for the very basic functions in
@@ -340,7 +340,7 @@ end terminates_of_rat
 /--
 The continued fraction `generalized_continued_fraction.of v` terminates if and only if `v ∈ ℚ`.
 -/
-theorem terminates_iff_rat [archimedean K] (v : K) :
+theorem terminates_iff_rat (v : K) :
   (gcf.of v).terminates ↔ ∃ (q : ℚ), v = (q : K) :=
 iff.intro
 ( assume terminates_v : (gcf.of v).terminates,

--- a/src/algebra/continued_fractions/computation/terminates_iff_rat.lean
+++ b/src/algebra/continued_fractions/computation/terminates_iff_rat.lean
@@ -162,8 +162,7 @@ namespace int_fract_pair
 
 lemma coe_of_rat_eq :
   ((int_fract_pair.of q).mapFr coe : int_fract_pair K) = int_fract_pair.of v :=
-suffices ⌊q⌋ = ⌊(↑q : K)⌋, by simpa [int_fract_pair.of, v_eq_q, fract],
-by rw [←(@rat.cast_floor K _ _ q), floor_ring_unique]
+by simp [int_fract_pair.of, v_eq_q, fract]
 
 lemma coe_stream_nth_rat_eq :
     ((int_fract_pair.stream q n).map (mapFr coe) : option $ int_fract_pair K)


### PR DESCRIPTION
The theorem still applies to the non-canonical archimedean instance (at least if you use simp).  I've also added `rat.cast_ceil` because it seems to fit here.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
