### PR TITLE
[Merged by Bors] - fix(tactic/simps): remove occurrence of mk_mapp

### DIFF
--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -596,7 +596,8 @@ meta def intron_no_renames : ℕ → tactic unit
 /-- `get_univ_level t` returns the universe level of a type `t` -/
 meta def get_univ_level (t : expr) (md := semireducible) (unfold_ginductive := tt) :
   tactic level :=
-do expr.sort u ← infer_type t >>= λ s, whnf s md unfold_ginductive,
+do expr.sort u ← infer_type t >>= λ s, whnf s md unfold_ginductive |
+    fail "get_univ_level: argument is not a type",
    return u
 
 /-!

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -593,6 +593,12 @@ meta def intron_no_renames : ℕ → tactic unit
   intro pp_n,
   intron_no_renames n
 
+/-- `get_univ_level t` returns the universe level of a type `t` -/
+meta def get_univ_level (t : expr) (md := semireducible) (unfold_ginductive := tt) :
+  tactic level :=
+do expr.sort u ← infer_type t >>= λ s, whnf s md unfold_ginductive,
+   return u
+
 /-!
 ### Various tactics related to local definitions (local constants of the form `x : α := t`)
 

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -452,7 +452,8 @@ meta def simps_add_projection (nm : name) (type lhs rhs : expr) (args : list exp
       "[simps] > `simp` simplified rhs to\n        > {rhsprf1}",
     return (prod.mk rhsprf1 rhsprf2) }
     <|> prod.mk rhs <$> mk_app `eq.refl [type, lhs],
-  eq_ap ← mk_mapp `eq $ [type, lhs, rhs].map some,
+  sort lvl ← infer_type type,
+  let eq_ap := (const `eq [lvl]).app_of_list [type, lhs, rhs],
   decl_name ← get_unused_decl_name nm,
   let decl_type := eq_ap.pis args,
   let decl_value := prf.lambdas args,

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -453,7 +453,7 @@ meta def simps_add_projection (nm : name) (type lhs rhs : expr) (args : list exp
     return (prod.mk rhsprf1 rhsprf2) }
     <|> prod.mk rhs <$> mk_app `eq.refl [type, lhs],
   sort lvl ← infer_type type,
-  let eq_ap := (const `eq [lvl]).app_of_list [type, lhs, rhs],
+  let eq_ap := const `eq [lvl] type lhs rhs,
   decl_name ← get_unused_decl_name nm,
   let decl_type := eq_ap.pis args,
   let decl_value := prf.lambdas args,

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -954,3 +954,18 @@ by { dsimp, guard_target (x = x), refl }
 def fffoo2 (α : Type) : one_more α α := fffoo α
 
 end comp_projs
+
+section
+/-! Check that the tactic also works if the elaborated type of `type` reduces to `Sort*`, but is
+  not `Sort*` itself. -/
+structure my_functor (C D : Type*) :=
+(obj []    : C → D)
+local infixr ` ⥤ `:26 := my_functor
+
+@[simps]
+def foo_sum {I J : Type*} (C : I → Type*) {D : J → Type*} :
+  (Π i, C i) ⥤ (Π j, D j) ⥤ (Π s : I ⊕ J, sum.elim C D s) :=
+{ obj := λ f, { obj := λ g s, sum.rec f g s }}
+
+
+end


### PR DESCRIPTION
Fixes the slowdown reported on Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/simps.20is.20very.20slow
On my laptop, the minimized example in that topic now takes 33ms instead of ~5000ms

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
