### PR TITLE
[Merged by Bors] - fix(tactic/simps): fix bug

### DIFF
--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -119,7 +119,8 @@ meta def get_composite_of_projections_aux : Π (str : name) (proj : string) (x :
     type ← infer_type new_x,
     (type_args, tgt) ← open_pis_whnf type,
     let new_str := tgt.get_app_fn.const_name,
-    get_composite_of_projections_aux new_str proj_rest new_x new_pos (args ++ type_args)
+    get_composite_of_projections_aux new_str proj_rest (new_x.mk_app type_args) new_pos
+      (args ++ type_args)
 
 /-- Given a structure `str` and a projection `proj`, that could be multiple nested projections
   (separated by `_`), returns an expression that is the composition of these projections and a
@@ -222,6 +223,9 @@ meta def simps_get_raw_projections (e : environment) (str : name) (trace_if_exis
         projs ++ [(nm, nm, ff)]
       end) projs,
     when_tracing `simps.debug trace!"[simps] > Projection info after applying the rules: {projs}.",
+    when ¬ (projs.map (λ x : name × name × bool, x.2.1)).nodup $
+      fail "Invalid projection names. Two projections have the same name.
+This is likely because a custom composition of projections was given the same name as an existing projection. Solution: rename the existing projection (before renaming the custom projection).",
     /- Define the raw expressions for the projections, by default as the projections
     (as an expression), but this can be overriden by the user. -/
     raw_exprs_and_nrs ← projs.mmap $ λ ⟨orig_nm, new_nm, _⟩, do {
@@ -240,7 +244,7 @@ meta def simps_get_raw_projections (e : environment) (str : name) (trace_if_exis
           raw_expr_type ← infer_type raw_expr,
           b ← succeeds (is_def_eq custom_proj_type raw_expr_type),
           if b then fail!"Invalid custom projection:\n  {custom_proj}
-Expression is not definitionally equal to {raw_expr}."
+Expression is not definitionally equal to\n  {raw_expr}"
           else fail!"Invalid custom projection:\n  {custom_proj}
 Expression has different type than {str ++ orig_nm}. Given type:\n  {custom_proj_type}
 Expected type:\n  {raw_expr_type}" },
@@ -592,7 +596,7 @@ meta def simps_tac (nm : name) (cfg : simps_cfg := {}) (todo : list string := []
 do
   e ← get_env,
   d ← e.get nm,
-  let lhs : expr := const d.to_name (d.univ_params.map level.param),
+  let lhs : expr := const d.to_name d.univ_levels,
   let todo := todo.erase_dup.map $ λ proj, "_" ++ proj,
   b ← has_attribute' `to_additive nm,
   let cfg := if b then { attrs := cfg.attrs ++ [`to_additive], ..cfg } else cfg,

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -225,7 +225,9 @@ meta def simps_get_raw_projections (e : environment) (str : name) (trace_if_exis
     when_tracing `simps.debug trace!"[simps] > Projection info after applying the rules: {projs}.",
     when ¬ (projs.map (λ x : name × name × bool, x.2.1)).nodup $
       fail $ "Invalid projection names. Two projections have the same name.
-This is likely because a custom composition of projections was given the same name as an " ++ "existing projection. Solution: rename the existing projection (before renaming the custom " ++ "projection).",
+This is likely because a custom composition of projections was given the same name as an " ++
+"existing projection. Solution: rename the existing projection (before renaming the custom " ++
+"projection).",
     /- Define the raw expressions for the projections, by default as the projections
     (as an expression), but this can be overriden by the user. -/
     raw_exprs_and_nrs ← projs.mmap $ λ ⟨orig_nm, new_nm, _⟩, do {

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -224,8 +224,8 @@ meta def simps_get_raw_projections (e : environment) (str : name) (trace_if_exis
       end) projs,
     when_tracing `simps.debug trace!"[simps] > Projection info after applying the rules: {projs}.",
     when ¬ (projs.map (λ x : name × name × bool, x.2.1)).nodup $
-      fail "Invalid projection names. Two projections have the same name.
-This is likely because a custom composition of projections was given the same name as an existing projection. Solution: rename the existing projection (before renaming the custom projection).",
+      fail $ "Invalid projection names. Two projections have the same name.
+This is likely because a custom composition of projections was given the same name as an " ++ "existing projection. Solution: rename the existing projection (before renaming the custom " ++ "projection).",
     /- Define the raw expressions for the projections, by default as the projections
     (as an expression), but this can be overriden by the user. -/
     raw_exprs_and_nrs ← projs.mmap $ λ ⟨orig_nm, new_nm, _⟩, do {

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -525,7 +525,8 @@ noncomputable def equiv.simps.inv_fun (e : α ≃ β) : β → α := classical.c
 run_cmd do e ← get_env, success_if_fail_with_msg (simps_get_raw_projections e `faulty_manual_coercion.equiv)
 "Invalid custom projection:
   λ {α : Sort u_1} {β : Sort u_2} (e : α ≃ β), classical.choice _
-Expression is not definitionally equal to λ (α : Sort u_1) (β : Sort u_2) (x : α ≃ β), x.inv_fun."
+Expression is not definitionally equal to
+  λ (α : Sort u_1) (β : Sort u_2) (x : α ≃ β), x.inv_fun"
 
 end faulty_manual_coercion
 

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -953,4 +953,27 @@ by { dsimp, guard_target (x = x), refl }
 @[simps apply to_dequiv_apply to_further_decorated_equiv_apply to_dequiv]
 def fffoo2 (α : Type) : one_more α α := fffoo α
 
+/- test the case where a projection takes additional arguments. -/
+variables {ι : Type*} [decidable_eq ι] (A : ι → Type*)
+
+class something [has_add ι] [Π i, add_comm_monoid (A i)] :=
+(mul {i} : A i →+ A i)
+
+def something.simps.apply [has_add ι] [Π i, add_comm_monoid (A i)] [something A] {i : ι} (x : A i) :
+  A i :=
+something.mul ι x
+
+initialize_simps_projections something (mul_to_fun → apply, -mul)
+
+class something2 [has_add ι] :=
+(mul {i j} : A i ≃ (A j ≃ A (i + j)))
+
+def something2.simps.mul [has_add ι] [something2 A] {i j : ι}
+  (x : A i) (y : A j) : A (i + j) :=
+something2.mul x y
+
+-- set_option trace.simps.debug true
+initialize_simps_projections something2 (-mul, mul → mul', mul_to_fun_to_fun → mul)
+
+
 end comp_projs

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -972,8 +972,7 @@ def something2.simps.mul [has_add ι] [something2 A] {i j : ι}
   (x : A i) (y : A j) : A (i + j) :=
 something2.mul x y
 
--- set_option trace.simps.debug true
-initialize_simps_projections something2 (-mul, mul → mul', mul_to_fun_to_fun → mul)
+initialize_simps_projections something2 (mul → mul', mul_to_fun_to_fun → mul, -mul')
 
 
 end comp_projs

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -937,6 +937,7 @@ initialize_simps_projections one_more
    to_further_decorated_equiv_to_decorated_equiv_to_equiv_inv_fun → symm_apply,
   -to_further_decorated_equiv, to_further_decorated_equiv_to_decorated_equiv → to_dequiv,
   -to_dequiv)
+set_option trace.simps.debug true
 
 @[simps] def fffoo (α : Type) : one_more α α :=
 { to_fun    := λ x, x,
@@ -973,7 +974,27 @@ def something2.simps.mul [has_add ι] [something2 A] {i j : ι}
   (x : A i) (y : A j) : A (i + j) :=
 something2.mul x y
 
-initialize_simps_projections something2 (mul → mul', mul_to_fun_to_fun → mul, -mul')
+initialize_simps_projections? something2 (mul → mul', mul_to_fun_to_fun → mul, -mul')
 
 
+set_option trace.simps.verbose true
+set_option trace.simps.debug true
+set_option trace.app_builder true
+
+attribute [ext] equiv
+
+@[simps]
+def thing (h : bool ≃ (bool ≃ bool)) : something2 (λ x : ℕ, bool) :=
+{ mul := λ i j, { to_fun := λ b, { to_fun := h b,
+  inv_fun := (h b).symm,
+  left_inv := (h b).left_inv,
+  right_inv := (h b).right_inv },
+  inv_fun := h.symm,
+  left_inv := by { convert h.left_inv, ext x; refl },
+  right_inv := by { convert h.right_inv, ext x; refl } } }
+
+-- λ {i j : ℕ} (x : (λ (x : ℕ), bool) i) (y : (λ (x : ℕ), bool) j),
+--   ⇑(⇑something2.mul x) y = (⇑(⇑h b) ᾰ : bool)
+
+--         > ⇑((fffoo α).symm) x = (x : α)
 end comp_projs

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -184,6 +184,9 @@ structure partially_applied_str :=
 @[simps]
 def partially_applied_term : partially_applied_str := ⟨my_prod.mk 3⟩
 
+@[simps]
+def another_term : partially_applied_str := ⟨λ n, ⟨n + 1, n + 2⟩⟩
+
 run_cmd do
   e ← get_env,
   e.get `partially_applied_term_data_fst,
@@ -937,7 +940,6 @@ initialize_simps_projections one_more
    to_further_decorated_equiv_to_decorated_equiv_to_equiv_inv_fun → symm_apply,
   -to_further_decorated_equiv, to_further_decorated_equiv_to_decorated_equiv → to_dequiv,
   -to_dequiv)
-set_option trace.simps.debug true
 
 @[simps] def fffoo (α : Type) : one_more α α :=
 { to_fun    := λ x, x,
@@ -974,12 +976,7 @@ def something2.simps.mul [has_add ι] [something2 A] {i j : ι}
   (x : A i) (y : A j) : A (i + j) :=
 something2.mul x y
 
-initialize_simps_projections? something2 (mul → mul', mul_to_fun_to_fun → mul, -mul')
-
-
-set_option trace.simps.verbose true
-set_option trace.simps.debug true
-set_option trace.app_builder true
+initialize_simps_projections something2 (mul → mul', mul_to_fun_to_fun → mul, -mul')
 
 attribute [ext] equiv
 
@@ -993,8 +990,8 @@ def thing (h : bool ≃ (bool ≃ bool)) : something2 (λ x : ℕ, bool) :=
   left_inv := by { convert h.left_inv, ext x; refl },
   right_inv := by { convert h.right_inv, ext x; refl } } }
 
--- λ {i j : ℕ} (x : (λ (x : ℕ), bool) i) (y : (λ (x : ℕ), bool) j),
---   ⇑(⇑something2.mul x) y = (⇑(⇑h b) ᾰ : bool)
+example (h : bool ≃ (bool ≃ bool)) (i j : ℕ) (b1 b2 : bool) :
+  @something2.mul _ _ _ _ (thing h) i j b1 b2 = h b1 b2 :=
+by simp only [thing_mul]
 
---         > ⇑((fffoo α).symm) x = (x : α)
 end comp_projs


### PR DESCRIPTION
* Custom projections that were compositions of multiple projections failed when the projection has additional arguments.
* Also adds an error when two projections are given the same simps-name

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
