### PR TITLE
[Merged by Bors] - feat(set_theory/{pgame, surreal}): add `left_distrib_equiv` and `right_distrib_equiv` for pgames

### DIFF
--- a/src/set_theory/game.lean
+++ b/src/set_theory/game.lean
@@ -45,9 +45,9 @@ quotient.lift₂ (λ x y, x ≤ y) (λ x₁ y₁ x₂ y₂ hx hy, propext (le_co
 instance : has_le game :=
 { le := le }
 
-@[refl] theorem le_refl : ∀ x : game, x ≤ x :=
+theorem le_refl : ∀ x : game, x ≤ x :=
 by { rintro ⟨x⟩, apply pgame.le_refl }
-@[trans] theorem le_trans : ∀ x y z : game, x ≤ y → y ≤ z → x ≤ z :=
+theorem le_trans : ∀ x y z : game, x ≤ y → y ≤ z → x ≤ z :=
 by { rintro ⟨x⟩ ⟨y⟩ ⟨z⟩, apply pgame.le_trans }
 theorem le_antisymm : ∀ x y : game, x ≤ y → y ≤ x → x = y :=
 by { rintro ⟨x⟩ ⟨y⟩ h₁ h₂, apply quot.sound, exact ⟨h₁, h₂⟩ }

--- a/src/set_theory/game.lean
+++ b/src/set_theory/game.lean
@@ -130,7 +130,7 @@ end
 instance : add_comm_semigroup game :=
 { add_comm := add_comm,
   ..game.add_semigroup }
-  
+
 instance : add_comm_group game :=
 { ..game.add_comm_semigroup,
   ..game.add_group }

--- a/src/set_theory/game.lean
+++ b/src/set_theory/game.lean
@@ -32,7 +32,7 @@ instance pgame.setoid : setoid pgame :=
   reflecting that it is a proper class in ZFC.
   A combinatorial game is then constructed by quotienting by the equivalence
   `x ≈ y ↔ x ≤ y ∧ y ≤ x`. -/
-def game := quotient pgame.setoid
+abbreviation game := quotient pgame.setoid
 
 open pgame
 
@@ -130,15 +130,13 @@ end
 instance : add_comm_semigroup game :=
 { add_comm := add_comm,
   ..game.add_semigroup }
-
+  
 instance : add_comm_group game :=
 { ..game.add_comm_semigroup,
   ..game.add_group }
 
 theorem add_le_add_left : ∀ (a b : game), a ≤ b → ∀ (c : game), c + a ≤ c + b :=
 begin rintro ⟨a⟩ ⟨b⟩ h ⟨c⟩, apply pgame.add_le_add_left h, end
-
-instance : add_comm_group (quotient pgame.setoid) := game.add_comm_group
 
 @[simp] lemma quot_neg (a : pgame) : ⟦-a⟧ = -⟦a⟧ := rfl
 @[simp] lemma quot_add (a b : pgame) : ⟦a + b⟧ = ⟦a⟧ + ⟦b⟧ := rfl

--- a/src/set_theory/game.lean
+++ b/src/set_theory/game.lean
@@ -138,6 +138,12 @@ instance : add_comm_group game :=
 theorem add_le_add_left : ∀ (a b : game), a ≤ b → ∀ (c : game), c + a ≤ c + b :=
 begin rintro ⟨a⟩ ⟨b⟩ h ⟨c⟩, apply pgame.add_le_add_left h, end
 
+instance : add_comm_group (quotient pgame.setoid) := game.add_comm_group
+
+@[simp] lemma quot_neg (a : pgame) : ⟦-a⟧ = -⟦a⟧ := rfl
+@[simp] lemma quot_add (a b : pgame) : ⟦a + b⟧ = ⟦a⟧ + ⟦b⟧ := rfl
+@[simp] lemma quot_sub (a b : pgame) : ⟦a - b⟧ = ⟦a⟧ - ⟦b⟧ := rfl
+
 -- While it is very tempting to define a `partial_order` on games, and prove
 -- that games form an `ordered_add_comm_group`, it is a bit dangerous.
 

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -438,8 +438,8 @@ theorem equiv_congr_right {x₁ x₂} : x₁ ≈ x₂ ↔ ∀ y₁, x₁ ≈ y�
 
 theorem equiv_of_mk_equiv {x y : pgame}
   (L : x.left_moves ≃ y.left_moves) (R : x.right_moves ≃ y.right_moves)
-  (hl : ∀ (i : x.left_moves), (x.move_left i).equiv (y.move_left (L i)))
-  (hr : ∀ (j : y.right_moves), (x.move_right (R.symm j)).equiv (y.move_right j)) :
+  (hl : ∀ (i : x.left_moves), x.move_left i ≈ y.move_left (L i))
+  (hr : ∀ (j : y.right_moves), x.move_right (R.symm j) ≈ y.move_right j) :
   x.equiv y :=
 begin
   fsplit; rw le_def,

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -925,6 +925,9 @@ theorem add_congr {w x y z : pgame} (h₁ : w ≈ x) (h₂ : y ≈ z) : w + y �
  calc x + z ≤ x + y : add_le_add_left h₂.2
         ... ≤ w + y : add_le_add_right h₁.2⟩
 
+theorem sub_congr {w x y z : pgame} (h₁ : w ≈ x) (h₂ : y ≈ z) : w - y ≈ x - z :=
+add_congr h₁ (neg_congr h₂)
+
 theorem add_left_neg_le_zero : Π {x : pgame}, (-x) + x ≤ 0
 | ⟨xl, xr, xL, xR⟩ :=
 begin

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -800,6 +800,12 @@ using_well_founded { dec_tac := pgame_wf_tac }
 
 instance : has_sub pgame := ⟨λ x y, x + -y⟩
 
+/-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
+then `w - y` has the same moves as `x - z`. -/
+def relabelling.sub_congr {w x y z : pgame}
+  (h₁ : w.relabelling x) (h₂ : y.relabelling z) : (w - y).relabelling (x - z) :=
+h₁.add_congr h₂.neg_congr
+
 /-- `-(x+y)` has exactly the same moves as `-x + -y`. -/
 def neg_add_relabelling : Π (x y : pgame), relabelling (-(x + y)) (-x + -y)
 | (mk xl xr xL xR) (mk yl yr yL yR) :=
@@ -918,6 +924,9 @@ theorem add_congr {w x y z : pgame} (h₁ : w ≈ x) (h₂ : y ≈ z) : w + y �
         ... ≤ x + z : add_le_add_right h₁.1,
  calc x + z ≤ x + y : add_le_add_left h₂.2
         ... ≤ w + y : add_le_add_right h₁.2⟩
+
+theorem sub_congr {w x y z : pgame} (h₁ : w ≈ x) (h₂ : y ≈ z) : w - y ≈ x - z :=
+add_congr h₁ (neg_congr h₂)
 
 theorem add_left_neg_le_zero : Π {x : pgame}, (-x) + x ≤ 0
 | ⟨xl, xr, xL, xR⟩ :=

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -966,6 +966,9 @@ theorem zero_le_add_right_neg {x : pgame} : 0 ≤ x + (-x) :=
 calc 0 ≤ (-x) + x : zero_le_add_left_neg
      ... ≤ x + (-x) : add_comm_le
 
+theorem add_right_neg_equiv {x : pgame} : x + (-x) ≈ 0 :=
+⟨add_right_neg_le_zero, zero_le_add_right_neg⟩
+
 theorem add_lt_add_right {x y z : pgame} (h : x < y) : x + z < y + z :=
 suffices y + z ≤ x + z → y ≤ x, by { rw ←not_le at ⊢ h, exact mt this h },
 assume w,

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -440,7 +440,7 @@ theorem equiv_of_mk_equiv {x y : pgame}
   (L : x.left_moves ≃ y.left_moves) (R : x.right_moves ≃ y.right_moves)
   (hl : ∀ (i : x.left_moves), x.move_left i ≈ y.move_left (L i))
   (hr : ∀ (j : y.right_moves), x.move_right (R.symm j) ≈ y.move_right j) :
-  x.equiv y :=
+  x ≈ y :=
 begin
   fsplit; rw le_def,
   { exact ⟨λ i, or.inl ⟨L i, (hl i).1⟩, λ j, or.inr ⟨R.symm j, (hr j).1⟩⟩ },

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -436,6 +436,27 @@ theorem equiv_congr_right {x₁ x₂} : x₁ ≈ x₂ ↔ ∀ y₁, x₁ ≈ y�
 ⟨λ h y₁, ⟨λ h', equiv_trans (equiv_symm h) h', λ h', equiv_trans h h'⟩,
  λ h, (h x₂).2 $ equiv_refl _⟩
 
+theorem equiv_of_mk_equiv {x y : pgame}
+  (L : x.left_moves ≃ y.left_moves) (R : x.right_moves ≃ y.right_moves)
+  (hl : ∀ (i : x.left_moves), (x.move_left i).equiv (y.move_left (L i)))
+  (hr : ∀ (j : y.right_moves), (x.move_right (R.symm j)).equiv (y.move_right j)) :
+  x.equiv y :=
+begin
+  fsplit; rw le_def,
+  { exact ⟨λ i, or.inl ⟨L i, (hl i).1⟩, λ j, or.inr ⟨R.symm j, (hr j).1⟩⟩ },
+  { fsplit,
+    { intro i,
+      left,
+      specialize hl (L.symm i),
+      simp only [move_left_mk, equiv.apply_symm_apply] at hl,
+      use ⟨L.symm i, hl.2⟩ },
+    { intro j,
+      right,
+      specialize hr (R j),
+      simp only [move_right_mk, equiv.symm_apply_apply] at hr,
+      use ⟨R j, hr.2⟩ } }
+end
+
 /-- `restricted x y` says that Left always has no more moves in `x` than in `y`,
      and Right always has no more moves in `y` than in `x` -/
 inductive restricted : pgame.{u} → pgame.{u} → Type (u+1)

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -800,12 +800,6 @@ using_well_founded { dec_tac := pgame_wf_tac }
 
 instance : has_sub pgame := ⟨λ x y, x + -y⟩
 
-/-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
-then `w - y` has the same moves as `x - z`. -/
-def relabelling.sub_congr {w x y z : pgame}
-  (h₁ : w.relabelling x) (h₂ : y.relabelling z) : (w - y).relabelling (x - z) :=
-h₁.add_congr h₂.neg_congr
-
 /-- `-(x+y)` has exactly the same moves as `-x + -y`. -/
 def neg_add_relabelling : Π (x y : pgame), relabelling (-(x + y)) (-x + -y)
 | (mk xl xr xL xR) (mk yl yr yL yR) :=

--- a/src/set_theory/pgame.lean
+++ b/src/set_theory/pgame.lean
@@ -919,9 +919,6 @@ theorem add_congr {w x y z : pgame} (h₁ : w ≈ x) (h₂ : y ≈ z) : w + y �
  calc x + z ≤ x + y : add_le_add_left h₂.2
         ... ≤ w + y : add_le_add_right h₁.2⟩
 
-theorem sub_congr {w x y z : pgame} (h₁ : w ≈ x) (h₂ : y ≈ z) : w - y ≈ x - z :=
-add_congr h₁ (neg_congr h₂)
-
 theorem add_left_neg_le_zero : Π {x : pgame}, (-x) + x ≤ 0
 | ⟨xl, xr, xL, xR⟩ :=
 begin

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -182,6 +182,13 @@ def zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
 theorem zero_mul_equiv (x : pgame) : (0 * x).equiv 0 :=
 (zero_mul_relabelling x).equiv
 
+/-- Local tactic useful for resolving goals involving equivalences between types, such as, a × (b ⊕ c) ≃ a × b ⊕ a × c. -/
+meta def try_inl_inr : tactic unit :=
+`[assumption]
+    <|> (do `[apply sum.inl], try_inl_inr )
+    <|> (do `[apply sum.inr], try_inl_inr )
+    <|> (do `[apply prod.mk], try_inl_inr, try_inl_inr )
+
 /-- Because the two halves of the definition of `inv` produce more elements
 of each side, we have to define the two families inductively.
 This is the indexing set for the function, and `inv_val` is the function part. -/

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -146,10 +146,10 @@ begin
    ... ≃ xr × yl ⊕ xl × yr : equiv.sum_comm _ _
    ... ≃ yl × xr ⊕ yr × xl : equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _)
    ... ≃ (y * x).right_moves : by refl,
-  { rintro (⟨i, j⟩|⟨i, j⟩),
+  { rintro (⟨i, j⟩ | ⟨i, j⟩),
     { exact add_comm_sub_relabelling (IHxl i y) (IHyl j) (IHxl i (yL j)) },
     { exact add_comm_sub_relabelling (IHxr i y) (IHyr j) (IHxr i (yR j)) } },
-  { rintro (⟨i, j⟩|⟨i, j⟩),
+  { rintro (⟨i, j⟩ | ⟨i, j⟩),
     { exact add_comm_sub_relabelling (IHxr j y) (IHyl i) (IHxr j (yL i)) },
     { exact add_comm_sub_relabelling (IHxl j y) (IHyr i) (IHxl j (yR i)) } }
 end
@@ -501,7 +501,6 @@ end pgame
 
 /-- The equivalence on numeric pre-games. -/
 def surreal.equiv (x y : {x // pgame.numeric x}) : Prop := x.1.equiv y.1
-local infix ` ~ ` := surreal.equiv
 
 instance surreal.setoid : setoid {x // pgame.numeric x} :=
 ⟨λ x y, x.1.equiv y.1,

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -182,8 +182,6 @@ meta def try_inl_inr : tactic unit :=
     <|> (do `[apply sum.inr], try_inl_inr )
     <|> (do `[apply prod.mk], try_inl_inr, try_inl_inr )
 
-local infix ` ≈ ` := pgame.equiv
-
 lemma left_distrib_equiv_aux {a b c d e : pgame} : (a + b) + (c + d) - (e + b) ≈ a + c - e + d :=
 begin
   apply @quotient.exact pgame,
@@ -197,6 +195,8 @@ begin
   change (⟦b⟧ + ⟦a⟧ + (⟦d⟧ + ⟦c⟧) - (⟦b⟧ + ⟦e⟧) : game) = ⟦d⟧ + (⟦a⟧ + ⟦c⟧ + -⟦e⟧),
   abel,
 end
+
+local infix ` ~ ` := pgame.equiv
 
 /-- `x * (y + z)` is equivalent to `x * y + x * z.`-/
 theorem left_distrib_equiv : Π (x y z : pgame), (x * (y + z)).equiv (x * y + x * z)
@@ -219,53 +219,53 @@ begin
   { rintros (⟨i,(j|k)⟩|⟨i,(j|k)⟩),
     { calc
         xL i * (y + z) + x * (yL j + z) - xL i * (yL j + z)
-            ≈  (xL i * y + xL i * z) + (x * yL j + x * z) - (xL i * yL j + xL i * z)
+            ~  (xL i * y + xL i * z) + (x * yL j + x * z) - (xL i * yL j + xL i * z)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈ xL i * y + x * yL j - xL i * yL j + x * z : left_distrib_equiv_aux },
+        ... ~ xL i * y + x * yL j - xL i * yL j + x * z : left_distrib_equiv_aux },
     { calc
         xL i * (y + z) + x * (y + zL k) - xL i * (y + zL k)
-            ≈ (xL i * y + xL i * z) + (x * y + x * zL k) - (xL i * y + xL i * zL k)
+            ~ (xL i * y + xL i * z) + (x * y + x * zL k) - (xL i * y + xL i * zL k)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈  x * y + (xL i * z + x * zL k - xL i * zL k) : left_distrib_equiv_aux' },
+        ... ~  x * y + (xL i * z + x * zL k - xL i * zL k) : left_distrib_equiv_aux' },
     { calc
         xR i * (y + z) + x * (yR j + z) - xR i * (yR j + z)
-            ≈  (xR i * y + xR i * z) + (x * yR j + x * z) - (xR i * yR j + xR i * z)
+            ~  (xR i * y + xR i * z) + (x * yR j + x * z) - (xR i * yR j + xR i * z)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈ xR i * y + x * yR j - xR i * yR j + x * z : left_distrib_equiv_aux },
+        ... ~ xR i * y + x * yR j - xR i * yR j + x * z : left_distrib_equiv_aux },
     { calc
         xR i * (y + z) + x * (y + zR k) - xR i * (y + zR k)
-            ≈ (xR i * y + xR i * z) + (x * y + x * zR k) - (xR i * y + xR i * zR k)
+            ~ (xR i * y + xR i * z) + (x * y + x * zR k) - (xR i * y + xR i * zR k)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈ x * y + (xR i * z + x * zR k - xR i * zR k) : left_distrib_equiv_aux' } },
+        ... ~ x * y + (xR i * z + x * zR k - xR i * zR k) : left_distrib_equiv_aux' } },
   { rintros ((⟨i,j⟩|⟨i,j⟩)|(⟨i,k⟩|⟨i,k⟩)),
     { calc
         xL i * (y + z) + x * (yR j + z) - xL i * (yR j + z)
-            ≈  (xL i * y + xL i * z) + (x * yR j + x * z) - (xL i * yR j + xL i * z)
+            ~  (xL i * y + xL i * z) + (x * yR j + x * z) - (xL i * yR j + xL i * z)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈ xL i * y + x * yR j - xL i * yR j + x * z : left_distrib_equiv_aux },
+        ... ~ xL i * y + x * yR j - xL i * yR j + x * z : left_distrib_equiv_aux },
     { calc
         xR i * (y + z) + x * (yL j + z) - xR i * (yL j + z)
-            ≈  (xR i * y + xR i * z) + (x * yL j + x * z) - (xR i * yL j + xR i * z)
+            ~  (xR i * y + xR i * z) + (x * yL j + x * z) - (xR i * yL j + xR i * z)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈ xR i * y + x * yL j - xR i * yL j + x * z : left_distrib_equiv_aux },
+        ... ~ xR i * y + x * yL j - xR i * yL j + x * z : left_distrib_equiv_aux },
     { calc
         xL i * (y + z) + x * (y + zR k) - xL i * (y + zR k)
-            ≈ (xL i * y + xL i * z) + (x * y + x * zR k) - (xL i * y + xL i * zR k)
+            ~ (xL i * y + xL i * z) + (x * y + x * zR k) - (xL i * y + xL i * zR k)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈  x * y + (xL i * z + x * zR k - xL i * zR k) : left_distrib_equiv_aux' },
+        ... ~  x * y + (xL i * z + x * zR k - xL i * zR k) : left_distrib_equiv_aux' },
     { calc
         xR i * (y + z) + x * (y + zL k) - xR i * (y + zL k)
-            ≈ (xR i * y + xR i * z) + (x * y + x * zL k) - (xR i * y + xR i * zL k)
+            ~ (xR i * y + xR i * z) + (x * y + x * zL k) - (xR i * y + xR i * zL k)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈ x * y + (xR i * z + x * zL k - xR i * zL k) : left_distrib_equiv_aux' } }
+        ... ~ x * y + (xR i * z + x * zL k - xR i * zL k) : left_distrib_equiv_aux' } }
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
 /-- `(x + y) * z` is equivalent to `x * y + y * z.`-/
 theorem right_distrib_equiv (x y z : pgame) : ((x + y) * z).equiv (x * z + y * z) :=
-calc (x + y) * z ≈ z * (x + y) : mul_comm_equiv _ _
-             ... ≈ z * x + z * y : left_distrib_equiv _ _ _
-             ... ≈ (x * z + y * z) : add_congr (mul_comm_equiv _ _) (mul_comm_equiv _ _)
+calc (x + y) * z ~ z * (x + y) : mul_comm_equiv _ _
+             ... ~ z * x + z * y : left_distrib_equiv _ _ _
+             ... ~ (x * z + y * z) : add_congr (mul_comm_equiv _ _) (mul_comm_equiv _ _)
 
 /-- Because the two halves of the definition of `inv` produce more elements
 of each side, we have to define the two families inductively.

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -172,18 +172,10 @@ theorem zero_mul_equiv (x : pgame) : 0 * x ≈ 0 :=
 (zero_mul_relabelling x).equiv
 
 lemma left_distrib_equiv_aux {a b c d e : pgame} : a + b + (c + d) - (e + b) ≈ a + c - e + d :=
-begin
-  apply @quotient.exact pgame,
-  change (⟦a⟧ + ⟦b⟧ + (⟦c⟧ + ⟦d⟧) - (⟦e⟧ + ⟦b⟧) : game) = ⟦a⟧ + ⟦c⟧ + -⟦e⟧ + ⟦d⟧,
-  abel,
-end
+by { apply @quotient.exact pgame, simp, abel }
 
 lemma left_distrib_equiv_aux' {a b c d e : pgame} : b + a + (d + c) - (b + e) ≈ d + (a + c - e) :=
-begin
-  apply @quotient.exact pgame,
-  change (⟦b⟧ + ⟦a⟧ + (⟦d⟧ + ⟦c⟧) - (⟦b⟧ + ⟦e⟧) : game) = ⟦d⟧ + (⟦a⟧ + ⟦c⟧ + -⟦e⟧),
-  abel,
-end
+by { apply @quotient.exact pgame, simp, abel }
  
 /-- `x * (y + z)` is equivalent to `x * y + x * z.`-/
 theorem left_distrib_equiv : Π (x y z : pgame), x * (y + z) ≈ x * y + x * z

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -133,14 +133,14 @@ begin
    ... ≃ yl × xr ⊕ yr × xl : equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _),
   { rintro (⟨i, j⟩ | ⟨i, j⟩),
     { exact ((add_comm_relabelling _ _).trans
-                ((IHyl j).add_congr (IHxl i y))).add_congr (IHxl i (yL j)).neg_congr },
+                ((IHyl j).add_congr (IHxl i y))).sub_congr (IHxl i (yL j)) },
     { exact ((add_comm_relabelling _ _).trans
-                ((IHyr j).add_congr (IHxr i y))).add_congr (IHxr i (yR j)).neg_congr } },
+                ((IHyr j).add_congr (IHxr i y))).sub_congr (IHxr i (yR j)) } },
   { rintro (⟨i, j⟩ | ⟨i, j⟩),
     { exact ((add_comm_relabelling _ _).trans
-                ((IHyl i).add_congr (IHxr j y))).add_congr (IHxr j (yL i)).neg_congr },
+                ((IHyl i).add_congr (IHxr j y))).sub_congr (IHxr j (yL i)) },
     { exact ((add_comm_relabelling _ _).trans
-                ((IHyr i).add_congr (IHxl j y))).add_congr (IHxl j (yR i)).neg_congr } }
+                ((IHyr i).add_congr (IHxl j y))).sub_congr (IHxl j (yR i)) } }
 end
 
 /-- `x * y` is equivalent to `y * x`. -/
@@ -211,43 +211,43 @@ begin
     { calc
         xL i * (y + z) + x * (yL j + z) - xL i * (yL j + z)
             ≈ (xL i * y + xL i * z) + (x * yL j + x * z) - (xL i * yL j + xL i * z)
-            : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
+            : by { refine sub_congr (add_congr _ _) _; apply left_distrib_equiv }
         ... ≈ xL i * y + x * yL j - xL i * yL j + x * z : left_distrib_equiv_aux },
     { calc
         xL i * (y + z) + x * (y + zL k) - xL i * (y + zL k)
             ≈ (xL i * y + xL i * z) + (x * y + x * zL k) - (xL i * y + xL i * zL k)
-            : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
+            : by { refine sub_congr (add_congr _ _) _; apply left_distrib_equiv }
         ... ≈  x * y + (xL i * z + x * zL k - xL i * zL k) : left_distrib_equiv_aux' },
     { calc
         xR i * (y + z) + x * (yR j + z) - xR i * (yR j + z)
             ≈  (xR i * y + xR i * z) + (x * yR j + x * z) - (xR i * yR j + xR i * z)
-            : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
+            : by { refine sub_congr (add_congr _ _) _; apply left_distrib_equiv }
         ... ≈ xR i * y + x * yR j - xR i * yR j + x * z : left_distrib_equiv_aux },
     { calc
         xR i * (y + z) + x * (y + zR k) - xR i * (y + zR k)
             ≈ (xR i * y + xR i * z) + (x * y + x * zR k) - (xR i * y + xR i * zR k)
-            : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
+            : by { refine sub_congr (add_congr _ _) _; apply left_distrib_equiv }
         ... ≈ x * y + (xR i * z + x * zR k - xR i * zR k) : left_distrib_equiv_aux' } },
   { rintros ((⟨i,j⟩|⟨i,j⟩)|(⟨i,k⟩|⟨i,k⟩)),
     { calc
         xL i * (y + z) + x * (yR j + z) - xL i * (yR j + z)
             ≈ (xL i * y + xL i * z) + (x * yR j + x * z) - (xL i * yR j + xL i * z)
-            : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
+            : by { refine sub_congr (add_congr _ _) _; apply left_distrib_equiv }
         ... ≈ xL i * y + x * yR j - xL i * yR j + x * z : left_distrib_equiv_aux },
     { calc
         xR i * (y + z) + x * (yL j + z) - xR i * (yL j + z)
             ≈ (xR i * y + xR i * z) + (x * yL j + x * z) - (xR i * yL j + xR i * z)
-            : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
+            : by { refine sub_congr (add_congr _ _) _; apply left_distrib_equiv }
         ... ≈ xR i * y + x * yL j - xR i * yL j + x * z : left_distrib_equiv_aux },
     { calc
         xL i * (y + z) + x * (y + zR k) - xL i * (y + zR k)
             ≈ (xL i * y + xL i * z) + (x * y + x * zR k) - (xL i * y + xL i * zR k)
-            : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
+            : by { refine sub_congr (add_congr _ _) _; apply left_distrib_equiv }
         ... ≈  x * y + (xL i * z + x * zR k - xL i * zR k) : left_distrib_equiv_aux' },
     { calc
         xR i * (y + z) + x * (y + zL k) - xR i * (y + zL k)
             ≈ (xR i * y + xR i * z) + (x * y + x * zL k) - (xR i * y + xR i * zL k)
-            : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
+            : by { refine sub_congr (add_congr _ _) _; apply left_distrib_equiv }
         ... ≈ x * y + (xR i * z + x * zL k - xR i * zL k) : left_distrib_equiv_aux' } }
 end
 using_well_founded { dec_tac := pgame_wf_tac }

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -47,6 +47,8 @@ universes u
 
 namespace pgame
 
+local infix ` ≈ ` := pgame.equiv
+
 /-! Multiplicative operations can be defined at the level of pre-games, but as
 they are only useful on surreal numbers, we define them here. -/
 
@@ -155,7 +157,7 @@ begin
 end
 
 /-- `x * y` is equivalent to `y * x`. -/
-theorem mul_comm_equiv (x y : pgame) : (x * y).equiv (y * x) :=
+theorem mul_comm_equiv (x y : pgame) : x * y ≈ y * x :=
 (mul_comm_relabelling x y).equiv
 
 /-- `x * 0` has exactly the same moves as `0`. -/
@@ -167,7 +169,7 @@ def mul_zero_relabelling : Π (x : pgame), relabelling (x * 0) 0
  by rintro ⟨⟩⟩
 
 /-- `x * 0` is equivalent to `0`. -/
-theorem mul_zero_equiv (x : pgame) : (x * 0).equiv 0 :=
+theorem mul_zero_equiv (x : pgame) : x * 0 ≈ 0 :=
 (mul_zero_relabelling x).equiv
 
 /-- `0 * x` has exactly the same moves as `0`. -/
@@ -179,18 +181,8 @@ def zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
  by rintro ⟨⟩⟩
 
 /-- `0 * x` is equivalent to `0`. -/
-theorem zero_mul_equiv (x : pgame) : (0 * x).equiv 0 :=
+theorem zero_mul_equiv (x : pgame) : 0 * x ≈ 0 :=
 (zero_mul_relabelling x).equiv
-
-/-- Local tactic useful for resolving goals involving equivalences between types,
-such as, a × (b ⊕ c) ≃ a × b ⊕ a × c. -/
-meta def try_inl_inr : tactic unit :=
-`[assumption]
-    <|> (do `[apply sum.inl], try_inl_inr )
-    <|> (do `[apply sum.inr], try_inl_inr )
-    <|> (do `[apply prod.mk], try_inl_inr, try_inl_inr )
-
-local infix ` ≈ ` := pgame.equiv
 
 lemma left_distrib_equiv_aux {a b c d e : pgame} : (a + b) + (c + d) - (e + b) ≈ a + c - e + d :=
 begin
@@ -233,7 +225,7 @@ calc (b + a) + (d + c) - (b + e)
   ... ≈ d + (a + c - e)   : (add_comm_relabelling _ _).equiv
 
 /-- `x * (y + z)` is equivalent to `x * y + x * z.`-/
-theorem left_distrib_equiv : Π (x y z : pgame), (x * (y + z)).equiv (x * y + x * z)
+theorem left_distrib_equiv : Π (x y z : pgame), x * (y + z) ≈ x * y + x * z
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) :=
 begin
   let x := mk xl xr xL xR,
@@ -241,19 +233,23 @@ begin
   let z := mk zl zr zL zR,
   refine equiv_of_mk_equiv _ _ _ _,
   { fsplit,
-    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩); try_inl_inr },
-    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)); try_inl_inr },
+    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩);
+      solve_by_elim [sum.inl, sum.inr, prod.mk] { max_depth := 5 } },
+    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩));
+      solve_by_elim [sum.inl, sum.inr, prod.mk] { max_depth := 5 } },
     { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩); refl },
     { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)); refl } },
   { fsplit,
-    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩); try_inl_inr },
-    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)); try_inl_inr },
+    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩);
+      solve_by_elim [sum.inl, sum.inr, prod.mk] { max_depth := 5 } },
+    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩));
+      solve_by_elim [sum.inl, sum.inr, prod.mk] { max_depth := 5 } },
     { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩); refl },
     { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)); refl } },
   { rintros (⟨i,(j|k)⟩|⟨i,(j|k)⟩),
     { calc
         xL i * (y + z) + x * (yL j + z) - xL i * (yL j + z)
-            ≈  (xL i * y + xL i * z) + (x * yL j + x * z) - (xL i * yL j + xL i * z)
+            ≈ (xL i * y + xL i * z) + (x * yL j + x * z) - (xL i * yL j + xL i * z)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
         ... ≈ xL i * y + x * yL j - xL i * yL j + x * z : left_distrib_equiv_aux },
     { calc
@@ -274,12 +270,12 @@ begin
   { rintros ((⟨i,j⟩|⟨i,j⟩)|(⟨i,k⟩|⟨i,k⟩)),
     { calc
         xL i * (y + z) + x * (yR j + z) - xL i * (yR j + z)
-            ≈  (xL i * y + xL i * z) + (x * yR j + x * z) - (xL i * yR j + xL i * z)
+            ≈ (xL i * y + xL i * z) + (x * yR j + x * z) - (xL i * yR j + xL i * z)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
         ... ≈ xL i * y + x * yR j - xL i * yR j + x * z : left_distrib_equiv_aux },
     { calc
         xR i * (y + z) + x * (yL j + z) - xR i * (yL j + z)
-            ≈  (xR i * y + xR i * z) + (x * yL j + x * z) - (xR i * yL j + xR i * z)
+            ≈ (xR i * y + xR i * z) + (x * yL j + x * z) - (xR i * yL j + xR i * z)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
         ... ≈ xR i * y + x * yL j - xR i * yL j + x * z : left_distrib_equiv_aux },
     { calc
@@ -296,7 +292,7 @@ end
 using_well_founded { dec_tac := pgame_wf_tac }
 
 /-- `(x + y) * z` is equivalent to `x * z + y * z.`-/
-theorem right_distrib_equiv (x y z : pgame) : ((x + y) * z).equiv (x * z + y * z) :=
+theorem right_distrib_equiv (x y z : pgame) : (x + y) * z ≈ x * z + y * z :=
 calc (x + y) * z ≈ z * (x + y)      : mul_comm_equiv _ _
              ... ≈ z * x + z * y    : left_distrib_equiv _ _ _
              ... ≈ (x * z + y * z)  : add_congr (mul_comm_equiv _ _) (mul_comm_equiv _ _)

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -117,14 +117,6 @@ rfl
 by {cases x, cases y, refl}
 
 /-- If `a` has the same moves as `x`, `b` has the same moves as `y`,
-and `c` has the same moves as `z`, then `a + b - c` has the same moves as `x + y - z`.
-This lemma is repeatedly used for simplifying multiplication of surreal numbers. -/
-def add_sub_relabelling {a b c x y z : pgame}
-  (h₁ : a.relabelling x) (h₂ : b.relabelling y) (h₃ : c.relabelling z) :
-  (a + b - c).relabelling (x + y - z) :=
-(h₁.add_congr h₂).sub_congr h₃
-
-/-- If `a` has the same moves as `x`, `b` has the same moves as `y`,
 and `c` has the same moves as `z`, then `a + b - c` has the same moves as `y + x - z`.
 This lemma is repeatedly used for simplifying multiplication of surreal numbers. -/
 def add_comm_sub_relabelling {a b c x y z : pgame}

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -145,12 +145,12 @@ begin
    ... ≃ xr × yl ⊕ xl × yr : equiv.sum_comm _ _
    ... ≃ yl × xr ⊕ yr × xl : equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _)
    ... ≃ (y * x).right_moves : by refl,
-  { rintro (⟨i, j⟩ | ⟨i, j⟩),
+  { rintro (⟨i, j⟩|⟨i, j⟩),
     { exact add_comm_sub_relabelling (IHxl i y) (IHyl j) (IHxl i (yL j)) },
-    { exact add_comm_sub_relabelling (IHxr i y) (IHyr j) (IHxr i (yR j)) }},
-  { rintro (⟨i, j⟩ | ⟨i, j⟩),
+    { exact add_comm_sub_relabelling (IHxr i y) (IHyr j) (IHxr i (yR j)) } },
+  { rintro (⟨i, j⟩|⟨i, j⟩),
     { exact add_comm_sub_relabelling (IHxr j y) (IHyl i) (IHxr j (yL i)) },
-    { exact add_comm_sub_relabelling (IHxl j y) (IHyr i) (IHxl j (yR i)) }}
+    { exact add_comm_sub_relabelling (IHxl j y) (IHyr i) (IHxl j (yR i)) } }
 end
 
 /-- `x * y` is equivalent to `y * x`. -/
@@ -160,9 +160,9 @@ theorem mul_comm_equiv (x y : pgame) : (x * y).equiv (y * x) :=
 /-- `x * 0` has exactly the same moves as `0`. -/
 def mul_zero_relabelling : Π (x : pgame), relabelling (x * 0) 0
 | (mk xl xr xL xR) :=
-⟨by fsplit; rintro (⟨_,⟨⟩⟩ | ⟨_,⟨⟩⟩),
- by fsplit; rintro (⟨_,⟨⟩⟩ | ⟨_,⟨⟩⟩),
- by rintro (⟨_,⟨⟩⟩ | ⟨_,⟨⟩⟩),
+⟨by fsplit; rintro (⟨_,⟨⟩⟩|⟨_,⟨⟩⟩),
+ by fsplit; rintro (⟨_,⟨⟩⟩|⟨_,⟨⟩⟩),
+ by rintro (⟨_,⟨⟩⟩|⟨_,⟨⟩⟩),
  by rintro ⟨⟩⟩
 
 /-- `x * 0` is equivalent to `0`. -/
@@ -172,9 +172,9 @@ theorem mul_zero_equiv (x : pgame) : (x * 0).equiv 0 :=
 /-- `0 * x` has exactly the same moves as `0`. -/
 def zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
 | (mk xl xr xL xR) :=
-⟨by fsplit; rintro (⟨⟨⟩,_⟩ | ⟨⟨⟩,_⟩),
- by fsplit; rintro (⟨⟨⟩,_⟩ | ⟨⟨⟩,_⟩),
- by rintro (⟨⟨⟩,_⟩ | ⟨⟨⟩,_⟩),
+⟨by fsplit; rintro (⟨⟨⟩,_⟩|⟨⟨⟩,_⟩),
+ by fsplit; rintro (⟨⟨⟩,_⟩|⟨⟨⟩,_⟩),
+ by rintro (⟨⟨⟩,_⟩|⟨⟨⟩,_⟩),
  by rintro ⟨⟩⟩
 
 /-- `0 * x` is equivalent to `0`. -/
@@ -191,16 +191,13 @@ meta def try_inl_inr : tactic unit :=
 
 local infix ` ≈ ` := pgame.equiv
 
-theorem sub_congr {w x y z : pgame} (h₁ : w ≈ x) (h₂ : y ≈ z) : w - y ≈ x - z :=
-add_congr h₁ (neg_congr h₂)
-
 lemma left_distrib_equiv_aux {a b c d e : pgame} : (a + b) + (c + d) - (e + b) ≈ a + c - e + d :=
 begin
-  have h₁ : b - (b + e) ≈ -e,
-  by calc b - (b + e) ≈ b + (-b + -e) : add_congr (equiv_refl _) (neg_add_relabelling _ _).equiv
-                  ... ≈ b - b + -e    : add_assoc_equiv.symm
-                  ... ≈ 0 + -e        : add_congr add_right_neg_equiv (equiv_refl _)
-                  ... ≈ -e            : zero_add_equiv _,
+  have h₁ : b - (b + e) ≈ -e, from
+    calc b - (b + e) ≈ b + (-b + -e) : add_congr (equiv_refl _) (neg_add_relabelling _ _).equiv
+                 ... ≈ b - b + -e    : add_assoc_equiv.symm
+                 ... ≈ 0 + -e        : add_congr add_right_neg_equiv (equiv_refl _)
+                 ... ≈ -e            : zero_add_equiv _,
   calc
     (a + b) + (c + d) - (e + b)
         ≈ a + (b + (c + d)) - (e + b)
@@ -224,16 +221,15 @@ begin
     ... ≈ (a + c) + (-e + d)
         : add_assoc_equiv.symm
     ... ≈ a + c - e + d
-        : add_assoc_equiv.symm,
+        : add_assoc_equiv.symm
 end
 
 lemma left_distrib_equiv_aux' {a b c d e : pgame} : (b + a) + (d + c) - (b + e) ≈ d + (a + c - e) :=
-calc
-  (b + a) + (d + c) - (b + e)
+calc (b + a) + (d + c) - (b + e)
       ≈ (a + b) + (c + d) - (e + b)
       : by {refine (add_sub_relabelling _ _ _).equiv, repeat {apply add_comm_relabelling} }
-  ... ≈ a + c - e + d : left_distrib_equiv_aux
-  ... ≈ d + (a + c - e) : (add_comm_relabelling _ _).equiv
+  ... ≈ a + c - e + d     : left_distrib_equiv_aux
+  ... ≈ d + (a + c - e)   : (add_comm_relabelling _ _).equiv
 
 /-- `x * (y + z)` is equivalent to `x * y + x * z.`-/
 theorem left_distrib_equiv : Π (x y z : pgame), (x * (y + z)).equiv (x * y + x * z)
@@ -300,9 +296,9 @@ using_well_founded { dec_tac := pgame_wf_tac }
 
 /-- `(x + y) * z` is equivalent to `x * y + y * z.`-/
 theorem right_distrib_equiv (x y z : pgame) : ((x + y) * z).equiv (x * z + y * z) :=
-calc (x + y) * z ≈ z * (x + y) : mul_comm_equiv _ _
-             ... ≈ z * x + z * y : left_distrib_equiv _ _ _
-             ... ≈ (x * z + y * z) : add_congr (mul_comm_equiv _ _) (mul_comm_equiv _ _)
+calc (x + y) * z ≈ z * (x + y)      : mul_comm_equiv _ _
+             ... ≈ z * x + z * y    : left_distrib_equiv _ _ _
+             ... ≈ (x * z + y * z)  : add_congr (mul_comm_equiv _ _) (mul_comm_equiv _ _)
 
 /-- Because the two halves of the definition of `inv` produce more elements
 of each side, we have to define the two families inductively.

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -3,7 +3,8 @@ Copyright (c) 2019 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Scott Morrison
 -/
-import set_theory.game tactic.abel
+import set_theory.game
+import tactic.abel
 
 /-!
 # Surreal numbers

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -118,22 +118,6 @@ rfl
    = x.move_right i * y + x * y.move_left j - x.move_right i * y.move_left j :=
 by {cases x, cases y, refl}
 
-/-- If `a` has the same moves as `x`, `b` has the same moves as `y`,
-and `c` has the same moves as `z`, then `a + b - c` has the same moves as `x + y - z`.
-This lemma is repeatedly used for simplifying multiplication of surreal numbers. -/
-def add_sub_relabelling {a b c x y z : pgame}
-  (h₁ : a.relabelling x) (h₂ : b.relabelling y) (h₃ : c.relabelling z) :
-  (a + b - c).relabelling (x + y - z) :=
-(h₁.add_congr h₂).sub_congr h₃
-
-/-- If `a` has the same moves as `x`, `b` has the same moves as `y`,
-and `c` has the same moves as `z`, then `a + b - c` has the same moves as `y + x - z`.
-This lemma is repeatedly used for simplifying multiplication of surreal numbers. -/
-def add_comm_sub_relabelling {a b c x y z : pgame}
-  (h₁ : a.relabelling x) (h₂ : b.relabelling y) (h₃ : c.relabelling z) :
-  (a + b - c).relabelling (y + x - z) :=
-((add_comm_relabelling a b).trans (h₂.add_congr h₁)).sub_congr h₃
-
 /-- `x * y` has exactly the same moves as `y * x`. -/
 def mul_comm_relabelling (x y : pgame.{u}) : (x * y).relabelling (y * x) :=
 begin
@@ -149,11 +133,15 @@ begin
    ... ≃ yl × xr ⊕ yr × xl : equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _)
    ... ≃ (y * x).right_moves : by refl,
   { rintro (⟨i, j⟩ | ⟨i, j⟩),
-    { exact add_comm_sub_relabelling (IHxl i y) (IHyl j) (IHxl i (yL j)) },
-    { exact add_comm_sub_relabelling (IHxr i y) (IHyr j) (IHxr i (yR j)) } },
+    { exact ((add_comm_relabelling _ _).trans
+                                   ((IHyl j).add_congr (IHxl i y))).sub_congr (IHxl i (yL j)) },
+    { exact ((add_comm_relabelling _ _).trans
+                                   ((IHyr j).add_congr (IHxr i y))).sub_congr (IHxr i (yR j)) } },
   { rintro (⟨i, j⟩ | ⟨i, j⟩),
-    { exact add_comm_sub_relabelling (IHxr j y) (IHyl i) (IHxr j (yL i)) },
-    { exact add_comm_sub_relabelling (IHxl j y) (IHyr i) (IHxl j (yR i)) } }
+    { exact ((add_comm_relabelling _ _).trans
+                                   ((IHyl i).add_congr (IHxr j y))).sub_congr (IHxr j (yL i)) },
+    { exact ((add_comm_relabelling _ _).trans
+                                   ((IHyr i).add_congr (IHxl j y))).sub_congr (IHxl j (yR i)) } }
 end
 
 /-- `x * y` is equivalent to `y * x`. -/
@@ -220,7 +208,7 @@ end
 lemma left_distrib_equiv_aux' {a b c d e : pgame} : (b + a) + (d + c) - (b + e) ≈ d + (a + c - e) :=
 calc (b + a) + (d + c) - (b + e)
       ≈ (a + b) + (c + d) - (e + b)
-      : by {refine (add_sub_relabelling _ _ _).equiv, repeat {apply add_comm_relabelling} }
+      : by { refine (sub_congr (add_congr _ _) _); apply (add_comm_relabelling _ _).equiv }
   ... ≈ a + c - e + d     : left_distrib_equiv_aux
   ... ≈ d + (a + c - e)   : (add_comm_relabelling _ _).equiv
 

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Scott Morrison
 -/
 import set_theory.pgame
+
 /-!
 # Surreal numbers
 
@@ -579,7 +580,7 @@ instance : ordered_add_comm_group surreal :=
   add_comm          := by { rintros ⟨_⟩ ⟨_⟩, exact quotient.sound pgame.add_comm_equiv },
   le                := (≤),
   lt                := (<),
-  le_refl           := by { rintros ⟨_⟩, apply pgame.le_refl },
+  le_refl           := by { rintros ⟨_⟩, refl },
   le_trans          := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, exact pgame.le_trans },
   lt_iff_le_not_le  := by { rintros ⟨_, ox⟩ ⟨_, oy⟩, exact pgame.lt_iff_le_not_le ox oy },
   le_antisymm       := by { rintros ⟨_⟩ ⟨_⟩ h₁ h₂, exact quotient.sound ⟨h₁, h₂⟩ },

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -127,21 +127,19 @@ begin
   let y := mk yl yr yL yR,
   refine ⟨equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _), _, _, _⟩,
   calc
-   (x * y).right_moves
-       ≃ xl × yr ⊕ xr × yl : by refl
-   ... ≃ xr × yl ⊕ xl × yr : equiv.sum_comm _ _
-   ... ≃ yl × xr ⊕ yr × xl : equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _)
-   ... ≃ (y * x).right_moves : by refl,
+    xl × yr ⊕ xr × yl
+       ≃ xr × yl ⊕ xl × yr : equiv.sum_comm _ _
+   ... ≃ yl × xr ⊕ yr × xl : equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _),
   { rintro (⟨i, j⟩ | ⟨i, j⟩),
     { exact ((add_comm_relabelling _ _).trans
-                                   ((IHyl j).add_congr (IHxl i y))).sub_congr (IHxl i (yL j)) },
+                ((IHyl j).add_congr (IHxl i y))).add_congr (IHxl i (yL j)).neg_congr },
     { exact ((add_comm_relabelling _ _).trans
-                                   ((IHyr j).add_congr (IHxr i y))).sub_congr (IHxr i (yR j)) } },
+                ((IHyr j).add_congr (IHxr i y))).add_congr (IHxr i (yR j)).neg_congr } },
   { rintro (⟨i, j⟩ | ⟨i, j⟩),
     { exact ((add_comm_relabelling _ _).trans
-                                   ((IHyl i).add_congr (IHxr j y))).sub_congr (IHxr j (yL i)) },
+                ((IHyl i).add_congr (IHxr j y))).add_congr (IHxr j (yL i)).neg_congr },
     { exact ((add_comm_relabelling _ _).trans
-                                   ((IHyr i).add_congr (IHxl j y))).sub_congr (IHxl j (yR i)) } }
+                ((IHyr i).add_congr (IHxl j y))).add_congr (IHxl j (yR i)).neg_congr } }
 end
 
 /-- `x * y` is equivalent to `y * x`. -/

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -150,9 +150,9 @@ theorem mul_comm_equiv (x y : pgame) : x * y ≈ y * x :=
 /-- `x * 0` has exactly the same moves as `0`. -/
 def mul_zero_relabelling : Π (x : pgame), relabelling (x * 0) 0
 | (mk xl xr xL xR) :=
-⟨by fsplit; rintro (⟨_,⟨⟩⟩|⟨_,⟨⟩⟩),
- by fsplit; rintro (⟨_,⟨⟩⟩|⟨_,⟨⟩⟩),
- by rintro (⟨_,⟨⟩⟩|⟨_,⟨⟩⟩),
+⟨by fsplit; rintro (⟨_,⟨⟩⟩ | ⟨_,⟨⟩⟩),
+ by fsplit; rintro (⟨_,⟨⟩⟩ | ⟨_,⟨⟩⟩),
+ by rintro (⟨_,⟨⟩⟩ | ⟨_,⟨⟩⟩),
  by rintro ⟨⟩⟩
 
 /-- `x * 0` is equivalent to `0`. -/
@@ -162,9 +162,9 @@ theorem mul_zero_equiv (x : pgame) : x * 0 ≈ 0 :=
 /-- `0 * x` has exactly the same moves as `0`. -/
 def zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
 | (mk xl xr xL xR) :=
-⟨by fsplit; rintro (⟨⟨⟩,_⟩|⟨⟨⟩,_⟩),
- by fsplit; rintro (⟨⟨⟩,_⟩|⟨⟨⟩,_⟩),
- by rintro (⟨⟨⟩,_⟩|⟨⟨⟩,_⟩),
+⟨by fsplit; rintro (⟨⟨⟩,_⟩ | ⟨⟨⟩,_⟩),
+ by fsplit; rintro (⟨⟨⟩,_⟩ | ⟨⟨⟩,_⟩),
+ by rintro (⟨⟨⟩,_⟩ | ⟨⟨⟩,_⟩),
  by rintro ⟨⟩⟩
 
 /-- `0 * x` is equivalent to `0`. -/
@@ -176,7 +176,7 @@ by { apply @quotient.exact pgame, simp, abel }
 
 lemma left_distrib_equiv_aux' {a b c d e : pgame} : b + a + (d + c) - (b + e) ≈ d + (a + c - e) :=
 by { apply @quotient.exact pgame, simp, abel }
- 
+
 /-- `x * (y + z)` is equivalent to `x * y + x * z.`-/
 theorem left_distrib_equiv : Π (x y z : pgame), x * (y + z) ≈ x * y + x * z
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) :=

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -375,6 +375,7 @@ begin
   rw lt_def_le,
   left,
   use i,
+  apply le_refl,
 end
 
 theorem numeric.move_left_le {x : pgame} (o : numeric x) (i : x.left_moves) :
@@ -387,6 +388,7 @@ begin
   rw lt_def_le,
   right,
   use j,
+  apply le_refl,
 end
 
 theorem numeric.le_move_right {x : pgame} (o : numeric x) (j : x.right_moves) :
@@ -546,7 +548,7 @@ instance : ordered_add_comm_group surreal :=
   add_comm          := by { rintros ⟨_⟩ ⟨_⟩, exact quotient.sound pgame.add_comm_equiv },
   le                := (≤),
   lt                := (<),
-  le_refl           := by { rintros ⟨_⟩, refl },
+  le_refl           := by { rintros ⟨_⟩, apply pgame.le_refl },
   le_trans          := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, exact pgame.le_trans },
   lt_iff_le_not_le  := by { rintros ⟨_, ox⟩ ⟨_, oy⟩, exact pgame.lt_iff_le_not_le ox oy },
   le_antisymm       := by { rintros ⟨_⟩ ⟨_⟩ h₁ h₂, exact quotient.sound ⟨h₁, h₂⟩ },

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Scott Morrison
 -/
-import set_theory.pgame
+import set_theory.game tactic.abel
 
 /-!
 # Surreal numbers
@@ -170,46 +170,20 @@ def zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
 theorem zero_mul_equiv (x : pgame) : 0 * x ≈ 0 :=
 (zero_mul_relabelling x).equiv
 
-lemma left_distrib_equiv_aux {a b c d e : pgame} : (a + b) + (c + d) - (e + b) ≈ a + c - e + d :=
+lemma left_distrib_equiv_aux {a b c d e : pgame} : a + b + (c + d) - (e + b) ≈ a + c - e + d :=
 begin
-  have h₁ : b - (b + e) ≈ -e, from
-    calc b - (b + e) ≈ b + (-b + -e) : add_congr (equiv_refl _) (neg_add_relabelling _ _).equiv
-                 ... ≈ b - b + -e    : add_assoc_equiv.symm
-                 ... ≈ 0 + -e        : add_congr add_right_neg_equiv (equiv_refl _)
-                 ... ≈ -e            : zero_add_equiv _,
-  calc
-    (a + b) + (c + d) - (e + b)
-        ≈ a + (b + (c + d)) - (e + b)
-        : sub_congr add_assoc_equiv (equiv_refl _)
-    ... ≈ a + ((c + d) + b) - (e + b)
-        : sub_congr (add_congr (equiv_refl _) add_comm_equiv) (equiv_refl _)
-    ... ≈ (a + (c + d)) + b - (e + b)
-        : sub_congr add_assoc_equiv.symm (equiv_refl _)
-    ... ≈ (a + (c + d)) + (b - (e + b))
-        : add_assoc_equiv
-    ... ≈ (a + (c + d)) + (b - (b + e))
-        : add_congr (equiv_refl _) (sub_congr (equiv_refl _) add_comm_equiv)
-    ... ≈ (a + (c + d)) + - e
-        : add_congr (equiv_refl _) h₁
-    ... ≈ a + ((c + d) + - e)
-        : add_assoc_equiv
-    ... ≈ a + (c + (d + - e))
-        : add_congr (equiv_refl _) add_assoc_equiv
-    ... ≈ a + (c + (-e + d))
-        : add_congr (equiv_refl _) (add_congr (equiv_refl _) add_comm_equiv)
-    ... ≈ (a + c) + (-e + d)
-        : add_assoc_equiv.symm
-    ... ≈ a + c - e + d
-        : add_assoc_equiv.symm
+  apply @quotient.exact pgame,
+  change (⟦a⟧ + ⟦b⟧ + (⟦c⟧ + ⟦d⟧) - (⟦e⟧ + ⟦b⟧) : game) = ⟦a⟧ + ⟦c⟧ + -⟦e⟧ + ⟦d⟧,
+  abel,
 end
 
-lemma left_distrib_equiv_aux' {a b c d e : pgame} : (b + a) + (d + c) - (b + e) ≈ d + (a + c - e) :=
-calc (b + a) + (d + c) - (b + e)
-      ≈ (a + b) + (c + d) - (e + b)
-      : by { refine (sub_congr (add_congr _ _) _); apply (add_comm_relabelling _ _).equiv }
-  ... ≈ a + c - e + d     : left_distrib_equiv_aux
-  ... ≈ d + (a + c - e)   : (add_comm_relabelling _ _).equiv
-
+lemma left_distrib_equiv_aux' {a b c d e : pgame} : b + a + (d + c) - (b + e) ≈ d + (a + c - e) :=
+begin
+  apply @quotient.exact pgame,
+  change (⟦b⟧ + ⟦a⟧ + (⟦d⟧ + ⟦c⟧) - (⟦b⟧ + ⟦e⟧) : game) = ⟦d⟧ + (⟦a⟧ + ⟦c⟧ + -⟦e⟧),
+  abel,
+end
+ 
 /-- `x * (y + z)` is equivalent to `x * y + x * z.`-/
 theorem left_distrib_equiv : Π (x y z : pgame), x * (y + z) ≈ x * y + x * z
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) :=

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -182,7 +182,8 @@ def zero_mul_relabelling : Π (x : pgame), relabelling (0 * x) 0
 theorem zero_mul_equiv (x : pgame) : (0 * x).equiv 0 :=
 (zero_mul_relabelling x).equiv
 
-/-- Local tactic useful for resolving goals involving equivalences between types, such as, a × (b ⊕ c) ≃ a × b ⊕ a × c. -/
+/-- Local tactic useful for resolving goals involving equivalences between types,
+such as, a × (b ⊕ c) ≃ a × b ⊕ a × c. -/
 meta def try_inl_inr : tactic unit :=
 `[assumption]
     <|> (do `[apply sum.inl], try_inl_inr )
@@ -191,7 +192,7 @@ meta def try_inl_inr : tactic unit :=
 
 local infix ` ≈ ` := pgame.equiv
 
-lemma left_distrib_aux {a b c d e : pgame} : (a + b) + (c + d) - (e + b) ≈ a + c - e + d :=
+lemma left_distrib_equiv_aux {a b c d e : pgame} : (a + b) + (c + d) - (e + b) ≈ a + c - e + d :=
 begin
   apply @quotient.exact pgame,
   change (⟦a⟧ + ⟦b⟧ + (⟦c⟧ + ⟦d⟧) - (⟦e⟧ + ⟦b⟧) : game) = ⟦a⟧ + ⟦c⟧ + -⟦e⟧ + ⟦d⟧,
@@ -205,6 +206,7 @@ begin
   abel,
 end
 
+/-- `x * (y + z)` is equivalent to `x * y + x * z.`-/
 theorem left_distrib_equiv : Π (x y z : pgame), (x * (y + z)).equiv (x * y + x * z)
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) :=
 begin
@@ -213,21 +215,21 @@ begin
   let z := mk zl zr zL zR,
   refine equiv_of_mk_equiv _ _ _ _,
   { fsplit,
-    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩), repeat {try_inl_inr}},
-    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)), repeat {try_inl_inr} },
-    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩), repeat {refl} },
-    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)), repeat {refl} }},
+    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩); try_inl_inr },
+    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)); try_inl_inr },
+    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩); refl },
+    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)); refl } },
   { fsplit,
-    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩), repeat {try_inl_inr} },
-    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)), repeat {try_inl_inr} },
-    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩), repeat {refl} },
-    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)), repeat {refl} }},
+    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩); try_inl_inr },
+    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)); try_inl_inr },
+    { rintros (⟨_,(_|_)⟩|⟨_,(_|_)⟩); refl },
+    { rintros ((⟨_,_⟩|⟨_,_⟩)|(⟨_,_⟩|⟨_,_⟩)); refl } },
   { rintros (⟨i,(j|k)⟩|⟨i,(j|k)⟩),
     { calc
         xL i * (y + z) + x * (yL j + z) - xL i * (yL j + z)
             ≈  (xL i * y + xL i * z) + (x * yL j + x * z) - (xL i * yL j + xL i * z)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈ xL i * y + x * yL j - xL i * yL j + x * z : left_distrib_aux },
+        ... ≈ xL i * y + x * yL j - xL i * yL j + x * z : left_distrib_equiv_aux },
     { calc
         xL i * (y + z) + x * (y + zL k) - xL i * (y + zL k)
             ≈ (xL i * y + xL i * z) + (x * y + x * zL k) - (xL i * y + xL i * zL k)
@@ -237,7 +239,7 @@ begin
         xR i * (y + z) + x * (yR j + z) - xR i * (yR j + z)
             ≈  (xR i * y + xR i * z) + (x * yR j + x * z) - (xR i * yR j + xR i * z)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈ xR i * y + x * yR j - xR i * yR j + x * z : left_distrib_aux },
+        ... ≈ xR i * y + x * yR j - xR i * yR j + x * z : left_distrib_equiv_aux },
     { calc
         xR i * (y + z) + x * (y + zR k) - xR i * (y + zR k)
             ≈ (xR i * y + xR i * z) + (x * y + x * zR k) - (xR i * y + xR i * zR k)
@@ -248,12 +250,12 @@ begin
         xL i * (y + z) + x * (yR j + z) - xL i * (yR j + z)
             ≈  (xL i * y + xL i * z) + (x * yR j + x * z) - (xL i * yR j + xL i * z)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈ xL i * y + x * yR j - xL i * yR j + x * z : left_distrib_aux },
+        ... ≈ xL i * y + x * yR j - xL i * yR j + x * z : left_distrib_equiv_aux },
     { calc
         xR i * (y + z) + x * (yL j + z) - xR i * (yL j + z)
             ≈  (xR i * y + xR i * z) + (x * yL j + x * z) - (xR i * yL j + xR i * z)
             : by { refine add_congr (add_congr _ _) (neg_congr _); apply left_distrib_equiv }
-        ... ≈ xR i * y + x * yL j - xR i * yL j + x * z : left_distrib_aux },
+        ... ≈ xR i * y + x * yL j - xR i * yL j + x * z : left_distrib_equiv_aux },
     { calc
         xL i * (y + z) + x * (y + zR k) - xL i * (y + zR k)
             ≈ (xL i * y + xL i * z) + (x * y + x * zR k) - (xL i * y + xL i * zR k)
@@ -267,6 +269,7 @@ begin
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
+/-- `(x + y) * z` is equivalent to `x * y + y * z.`-/
 theorem right_distrib_equiv (x y z : pgame) : ((x + y) * z).equiv (x * z + y * z) :=
 calc (x + y) * z ≈ z * (x + y) : mul_comm_equiv _ _
              ... ≈ z * x + z * y : left_distrib_equiv _ _ _

--- a/src/set_theory/surreal.lean
+++ b/src/set_theory/surreal.lean
@@ -295,7 +295,7 @@ begin
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
-/-- `(x + y) * z` is equivalent to `x * y + y * z.`-/
+/-- `(x + y) * z` is equivalent to `x * z + y * z.`-/
 theorem right_distrib_equiv (x y z : pgame) : ((x + y) * z).equiv (x * z + y * z) :=
 calc (x + y) * z ≈ z * (x + y)      : mul_comm_equiv _ _
              ... ≈ z * x + z * y    : left_distrib_equiv _ _ _


### PR DESCRIPTION
and several other auxiliary lemmas.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Surreal.20numbers)

---


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
