### PR TITLE
[Merged by Bors] - feat(ring_theory/hahn_series): order of a nonzero Hahn series, reindexing summable families

### DIFF
--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -700,4 +700,16 @@ lemma finsum_mul {R : Type*} [semiring R] (f : α → R) (r : R)
   (∑ᶠ a : α, f a) * r = ∑ᶠ a : α, f a * r :=
 (add_monoid_hom.mul_right r).map_finsum h
 
+@[to_additive]
+lemma finprod_emb_domain (f : α ↪ β) [decidable_pred (∈ set.range f)] (g : α → M) :
+  ∏ᶠ (b : β), (if h : b ∈ set.range f then g (classical.some h) else 1) = ∏ᶠ (a : α), g a :=
+begin
+  transitivity ∏ᶠ b ∈ set.range f, (if h : b ∈ set.range f then g (classical.some h) else 1),
+  { simp_rw [← finprod_eq_dif],
+    refine finprod_congr (λ b, finprod_congr (λ h, _)),
+    rw [finprod_eq_dif, dif_pos h] },
+  rw [finprod_mem_range f.injective, finprod_congr (λ a, _)],
+  rw [dif_pos (set.mem_range_self a), f.injective (classical.some_spec (set.mem_range_self a))],
+end
+
 end type

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -701,15 +701,23 @@ lemma finsum_mul {R : Type*} [semiring R] (f : α → R) (r : R)
 (add_monoid_hom.mul_right r).map_finsum h
 
 @[to_additive]
-lemma finprod_emb_domain (f : α ↪ β) [decidable_pred (∈ set.range f)] (g : α → M) :
+lemma finprod_mem_dif_mem {s : set α} [decidable_pred (∈ s)] (f : (Π (a : α), a ∈ s → M)) :
+  (∏ᶠ (a : α) (h : a ∈ s), if h' : a ∈ s then f a h' else 1) = ∏ᶠ (a : α) (h : a ∈ s), f a h :=
+finprod_congr (λ a, finprod_congr (λ ha, dif_pos ha))
+
+@[to_additive]
+lemma finprod_emb_domain' {f : α → β} (hf : function.injective f)
+  [decidable_pred (∈ set.range f)] (g : α → M) :
   ∏ᶠ (b : β), (if h : b ∈ set.range f then g (classical.some h) else 1) = ∏ᶠ (a : α), g a :=
 begin
-  transitivity ∏ᶠ b ∈ set.range f, (if h : b ∈ set.range f then g (classical.some h) else 1),
-  { simp_rw [← finprod_eq_dif],
-    refine finprod_congr (λ b, finprod_congr (λ h, _)),
-    rw [finprod_eq_dif, dif_pos h] },
-  rw [finprod_mem_range f.injective, finprod_congr (λ a, _)],
-  rw [dif_pos (set.mem_range_self a), f.injective (classical.some_spec (set.mem_range_self a))],
+  simp_rw [← finprod_eq_dif],
+  rw [← finprod_mem_dif_mem, finprod_mem_range hf, finprod_congr (λ a, _)],
+  rw [dif_pos (set.mem_range_self a), hf (classical.some_spec (set.mem_range_self a))]
 end
+
+@[to_additive]
+lemma finprod_emb_domain (f : α ↪ β) [decidable_pred (∈ set.range f)] (g : α → M) :
+  ∏ᶠ (b : β), (if h : b ∈ set.range f then g (classical.some h) else 1) = ∏ᶠ (a : α), g a :=
+finprod_emb_domain' f.injective g
 
 end type

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -701,9 +701,9 @@ lemma finsum_mul {R : Type*} [semiring R] (f : α → R) (r : R)
 (add_monoid_hom.mul_right r).map_finsum h
 
 @[to_additive]
-lemma finprod_mem_dif_mem {s : set α} [decidable_pred (∈ s)] (f : (Π (a : α), a ∈ s → M)) :
-  (∏ᶠ (a : α) (h : a ∈ s), if h' : a ∈ s then f a h' else 1) = ∏ᶠ (a : α) (h : a ∈ s), f a h :=
-finprod_congr (λ a, finprod_congr (λ ha, dif_pos ha))
+lemma finprod_dmem {s : set α} [decidable_pred (∈ s)] (f : (Π (a : α), a ∈ s → M)) :
+  ∏ᶠ (a : α) (h : a ∈ s), f a h = ∏ᶠ (a : α) (h : a ∈ s), if h' : a ∈ s then f a h' else 1 :=
+finprod_congr (λ a, finprod_congr (λ ha, (dif_pos ha).symm))
 
 @[to_additive]
 lemma finprod_emb_domain' {f : α → β} (hf : function.injective f)
@@ -711,7 +711,7 @@ lemma finprod_emb_domain' {f : α → β} (hf : function.injective f)
   ∏ᶠ (b : β), (if h : b ∈ set.range f then g (classical.some h) else 1) = ∏ᶠ (a : α), g a :=
 begin
   simp_rw [← finprod_eq_dif],
-  rw [← finprod_mem_dif_mem, finprod_mem_range hf, finprod_congr (λ a, _)],
+  rw [finprod_dmem, finprod_mem_range hf, finprod_congr (λ a, _)],
   rw [dif_pos (set.mem_range_self a), hf (classical.some_spec (set.mem_range_self a))]
 end
 

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -144,24 +144,39 @@ instance [nonempty Γ] [nontrivial R] : nontrivial (hahn_series Γ R) :=
   rw [← single_coeff_same (arbitrary Γ) r, con, single_coeff_same],
 end⟩
 
+section order
+variable [has_zero Γ]
+
 /-- The order of a nonzero Hahn series `x` is a minimal element of `Γ` where `x` has a
-  nonzero coefficient. -/
-def order (x : hahn_series Γ R) (hx : x ≠ 0) : Γ := x.is_wf_support.min (support_nonempty_iff.2 hx)
+  nonzero coefficient, the order of 0 is 0. -/
+def order (x : hahn_series Γ R) : Γ :=
+if h : x = 0 then 0 else x.is_wf_support.min (support_nonempty_iff.2 h)
+
+@[simp]
+lemma order_zero : order (0 : hahn_series Γ R) = 0 := dif_pos rfl
+
+lemma order_of_ne {x : hahn_series Γ R} (hx : x ≠ 0) :
+  order x = x.is_wf_support.min (support_nonempty_iff.2 hx) := dif_neg hx
 
 lemma coeff_order_ne_zero {x : hahn_series Γ R} (hx : x ≠ 0) :
-  x.coeff (x.order hx) ≠ 0 :=
-x.is_wf_support.min_mem (support_nonempty_iff.2 hx)
+  x.coeff x.order ≠ 0 :=
+begin
+  rw order_of_ne hx,
+  exact x.is_wf_support.min_mem (support_nonempty_iff.2 hx)
+end
 
 lemma order_le_of_coeff_ne_zero {Γ} [linear_ordered_cancel_add_comm_monoid Γ]
   {x : hahn_series Γ R} {g : Γ} (h : x.coeff g ≠ 0) :
-  x.order (ne_zero_of_coeff_ne_zero h) ≤ g :=
-set.is_wf.min_le _ _ ((mem_support _ _).2 h)
+  x.order ≤ g :=
+le_trans (le_of_eq (order_of_ne (ne_zero_of_coeff_ne_zero h)))
+  (set.is_wf.min_le _ _ ((mem_support _ _).2 h))
 
 @[simp]
-lemma order_single (h : r ≠ 0) : (single a r).order (single_ne_zero h) = a :=
-support_single_subset ((single a r).is_wf_support.min_mem
-  (support_nonempty_iff.2 (single_ne_zero h)))
+lemma order_single (h : r ≠ 0) : (single a r).order = a :=
+(order_of_ne (single_ne_zero h)).trans (support_single_subset ((single a r).is_wf_support.min_mem
+    (support_nonempty_iff.2 (single_ne_zero h))))
 
+end order
 end zero
 
 section addition
@@ -201,13 +216,13 @@ end
 
 lemma min_order_le_order_add {Γ} [linear_ordered_cancel_add_comm_monoid Γ] {x y : hahn_series Γ R}
   (hx : x ≠ 0) (hy : y ≠ 0) (hxy : x + y ≠ 0) :
-  min (x.order hx) (y.order hy) ≤ (x + y).order hxy :=
+  min x.order y.order ≤ (x + y).order :=
 begin
+  rw [order_of_ne hx, order_of_ne hy, order_of_ne hxy],
   refine le_trans _ (set.is_wf.min_le_min_of_subset support_add_subset),
   { exact x.is_wf_support.union y.is_wf_support },
   { exact set.nonempty.mono (set.subset_union_left _ _) (support_nonempty_iff.2 hx) },
   rw set.is_wf.min_union,
-  refl,
 end
 
 /-- `single` as an additive monoid/group homomorphism -/
@@ -330,9 +345,13 @@ lemma support_one [semiring R] [nontrivial R] :
 support_single_of_ne one_ne_zero
 
 @[simp]
-lemma order_one [semiring R] [nontrivial R] :
-  order (1 : hahn_series Γ R) (single_ne_zero one_ne_zero) = 0 :=
-order_single one_ne_zero
+lemma order_one [semiring R] :
+  order (1 : hahn_series Γ R) = 0 :=
+begin
+  cases subsingleton_or_nontrivial R with h h; haveI := h,
+  { rw [subsingleton.elim (1 : hahn_series Γ R) 0, order_zero] },
+  { exact order_single one_ne_zero }
+end
 
 instance [semiring R] : has_mul (hahn_series Γ R) :=
 { mul := λ x y, { coeff := λ a,
@@ -494,9 +513,9 @@ end
 @[simp]
 lemma mul_coeff_order_add_order {Γ} [linear_ordered_cancel_add_comm_monoid Γ] [semiring R]
   {x y : hahn_series Γ R} (hx : x ≠ 0) (hy : y ≠ 0) :
-  (x * y).coeff (x.order hx + y.order hy) =
-    (x.coeff (x.order hx)) * y.coeff (y.order hy) :=
-by rw [order, order, mul_coeff, finset.add_antidiagonal_min_add_min, finset.sum_singleton]
+  (x * y).coeff (x.order + y.order) = x.coeff x.order * y.coeff y.order :=
+by rw [order_of_ne hx, order_of_ne hy, mul_coeff, finset.add_antidiagonal_min_add_min,
+  finset.sum_singleton]
 
 private lemma mul_assoc' [semiring R] (x y z : hahn_series Γ R) :
   x * y * z = x * (y * z) :=
@@ -578,8 +597,8 @@ instance {Γ} [linear_ordered_cancel_add_comm_monoid Γ] [integral_domain R] :
     right,
     contrapose! xy,
     rw [hahn_series.ext_iff, function.funext_iff, not_forall],
-    refine ⟨x.order hx + y.order xy, _⟩,
-    rw [mul_coeff_order_add_order, zero_coeff, mul_eq_zero],
+    refine ⟨x.order + y.order, _⟩,
+    rw [mul_coeff_order_add_order hx xy, zero_coeff, mul_eq_zero],
     simp [coeff_order_ne_zero, hx, xy],
   end,
   .. hahn_series.nontrivial,
@@ -588,13 +607,13 @@ instance {Γ} [linear_ordered_cancel_add_comm_monoid Γ] [integral_domain R] :
 @[simp]
 lemma order_mul {Γ} [linear_ordered_cancel_add_comm_monoid Γ] [integral_domain R]
   {x y : hahn_series Γ R} (hx : x ≠ 0) (hy : y ≠ 0) :
-  (x * y).order (mul_ne_zero hx hy) = x.order hx + y.order hy :=
+  (x * y).order = x.order + y.order :=
 begin
   apply le_antisymm,
   { apply order_le_of_coeff_ne_zero,
-    rw [mul_coeff_order_add_order],
+    rw [mul_coeff_order_add_order hx hy],
     exact mul_ne_zero (coeff_order_ne_zero hx) (coeff_order_ne_zero hy) },
-  { rw [order, order, ← set.is_wf.min_add],
+  { rw [order_of_ne hx, order_of_ne hy, order_of_ne (mul_ne_zero hx hy), ← set.is_wf.min_add],
     exact set.is_wf.min_le_min_of_subset (support_mul_subset_add_support) },
 end
 
@@ -648,8 +667,12 @@ begin
   exact C_injective h,
 end
 
-lemma order_C {r : R} (h : r ≠ 0) : order (C r : hahn_series Γ R) (C_ne_zero h) = 0 :=
-order_single h
+lemma order_C {r : R} : order (C r : hahn_series Γ R) = 0 :=
+begin
+  by_cases h : r = 0,
+  { rw [h, C_zero, order_zero] },
+  { exact order_single h }
+end
 
 end semiring
 
@@ -757,47 +780,45 @@ variables (Γ) (R)
 /-- The additive valuation on `hahn_series Γ R`, returning the smallest index at which
   a Hahn Series has a nonzero coefficient, or `⊤` for the 0 series.  -/
 def add_val : add_valuation (hahn_series Γ R) (with_top Γ) :=
-add_valuation.of (λ x, if h : x = (0 : hahn_series Γ R) then (⊤ : with_top Γ)
-    else x.order h)
-  (dif_pos rfl)
-  ((dif_neg one_ne_zero).trans (by simp [order]))
+add_valuation.of (λ x, if x = (0 : hahn_series Γ R) then (⊤ : with_top Γ) else x.order)
+  (if_pos rfl)
+  ((if_neg one_ne_zero).trans (by simp [order_of_ne]))
   (λ x y, begin
     by_cases hx : x = 0,
     { by_cases hy : y = 0; { simp [hx, hy] } },
     { by_cases hy : y = 0,
       { simp [hx, hy] },
-      { simp only [hx, hy, support_nonempty_iff, dif_neg, not_false_iff, is_wf_support],
+      { simp only [hx, hy, support_nonempty_iff, if_neg, not_false_iff, is_wf_support],
         by_cases hxy : x + y = 0,
         { simp [hxy] },
-        rw [dif_neg hxy, ← with_top.coe_min, with_top.coe_le_coe],
-        apply min_order_le_order_add, } },
+        rw [if_neg hxy, ← with_top.coe_min, with_top.coe_le_coe],
+        exact min_order_le_order_add hx hy hxy } },
   end)
   (λ x y, begin
     by_cases hx : x = 0,
     { simp [hx] },
     by_cases hy : y = 0,
     { simp [hy] },
-    rw [dif_neg hx, dif_neg hy, dif_neg (mul_ne_zero hx hy),
+    rw [if_neg hx, if_neg hy, if_neg (mul_ne_zero hx hy),
       ← with_top.coe_add, with_top.coe_eq_coe, order_mul hx hy],
   end)
 
 variables {Γ} {R}
 
 lemma add_val_apply {x : hahn_series Γ R} :
-  add_val Γ R x = if h : x = (0 : hahn_series Γ R) then (⊤ : with_top Γ)
-    else x.order h :=
+  add_val Γ R x = if x = (0 : hahn_series Γ R) then (⊤ : with_top Γ) else x.order :=
 add_valuation.of_apply _
 
 @[simp]
 lemma add_val_apply_of_ne {x : hahn_series Γ R} (hx : x ≠ 0) :
-  add_val Γ R x = x.order hx :=
-dif_neg hx
+  add_val Γ R x = x.order :=
+if_neg hx
 
 lemma add_val_le_of_coeff_ne_zero {x : hahn_series Γ R} {g : Γ} (h : x.coeff g ≠ 0) :
   add_val Γ R x ≤ g :=
 begin
   rw [add_val_apply_of_ne (ne_zero_of_coeff_ne_zero h), with_top.coe_le_coe],
-  exact order_le_of_coeff_ne_zero h,
+  exact order_le_of_coeff_ne_zero h
 end
 
 end valuation

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -510,7 +510,6 @@ begin
   simp [hx],
 end
 
-@[simp]
 lemma mul_coeff_order_add_order {Γ} [linear_ordered_cancel_add_comm_monoid Γ] [semiring R]
   {x y : hahn_series Γ R} (hx : x ≠ 0) (hy : y ≠ 0) :
   (x * y).coeff (x.order + y.order) = x.coeff x.order * y.coeff y.order :=

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -329,6 +329,11 @@ lemma support_one [semiring R] [nontrivial R] :
   support (1 : hahn_series Γ R) = {0} :=
 support_single_of_ne one_ne_zero
 
+@[simp]
+lemma order_one [semiring R] [nontrivial R] :
+  order (1 : hahn_series Γ R) (single_ne_zero one_ne_zero) = 0 :=
+order_single one_ne_zero
+
 instance [semiring R] : has_mul (hahn_series Γ R) :=
 { mul := λ x y, { coeff := λ a,
     ∑ ij in (add_antidiagonal x.is_pwo_support y.is_pwo_support a),

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -79,10 +79,7 @@ lemma zero_coeff {a : Γ} : (0 : hahn_series Γ R).coeff a = 0 := rfl
 
 lemma ne_zero_of_coeff_ne_zero {x : hahn_series Γ R} {g : Γ} (h : x.coeff g ≠ 0) :
   x ≠ 0 :=
-begin
-  contrapose! h,
-  rw [h, zero_coeff]
-end
+mt (λ x0, (x0.symm ▸ zero_coeff : x.coeff g = 0)) h
 
 @[simp]
 lemma support_zero : support (0 : hahn_series Γ R) = ∅ := function.support_zero
@@ -133,13 +130,11 @@ support_single_subset h
 @[simp]
 lemma single_eq_zero : (single a (0 : R)) = 0 := (single a).map_zero
 
+lemma single_injective (a : Γ) : function.injective (single a : R → hahn_series Γ R) :=
+λ r s rs, by rw [← single_coeff_same a r, ← single_coeff_same a s, rs]
+
 lemma single_ne_zero (h : r ≠ 0) : single a r ≠ 0 :=
-begin
-  have h := support_single_of_ne h,
-  contrapose! h,
-  rw [h, support_zero, ne_comm],
-  exact (set.singleton_nonempty a).ne_empty,
-end
+λ con, h (single_injective a (con.trans single_eq_zero.symm))
 
 instance [nonempty Γ] [nontrivial R] : nontrivial (hahn_series Γ R) :=
 ⟨begin


### PR DESCRIPTION
Defines `hahn_series.order`, the order of a nonzero Hahn series
Restates `add_val` in terms of `hahn_series.order`
Defines `hahn_series.summable_family.emb_domain`, reindexing a summable family using an embedding

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The two things being introduced in this PR are not directly related, but they are both fairly straightforward, and came up in defining the field structure.