### PR TITLE
[Merged by Bors] - refactor(*): more choice-free proofs

### DIFF
--- a/src/algebra/order.lean
+++ b/src/algebra/order.lean
@@ -28,6 +28,7 @@ alias le_antisymm     ← has_le.le.antisymm
 alias lt_of_le_of_ne  ← has_le.le.lt_of_ne
 alias lt_of_le_not_le ← has_le.le.lt_of_not_le
 alias lt_or_eq_of_le  ← has_le.le.lt_or_eq
+alias decidable.lt_or_eq_of_le ← has_le.le.lt_or_eq_dec
 
 alias le_of_lt        ← has_lt.lt.le
 alias lt_trans        ← has_lt.lt.trans
@@ -116,26 +117,42 @@ lemma not_lt_of_le [preorder α] {a b : α} (h : a ≤ b) : ¬ b < a
 
 alias not_lt_of_le ← has_le.le.not_lt
 
+-- See Note [decidable namespace]
+protected lemma decidable.le_iff_eq_or_lt [partial_order α] [@decidable_rel α (≤)]
+  {a b : α} : a ≤ b ↔ a = b ∨ a < b :=
+decidable.le_iff_lt_or_eq.trans or.comm
+
 lemma le_iff_eq_or_lt [partial_order α] {a b : α} : a ≤ b ↔ a = b ∨ a < b :=
 le_iff_lt_or_eq.trans or.comm
 
 lemma lt_iff_le_and_ne [partial_order α] {a b : α} : a < b ↔ a ≤ b ∧ a ≠ b :=
 ⟨λ h, ⟨le_of_lt h, ne_of_lt h⟩, λ ⟨h1, h2⟩, h1.lt_of_ne h2⟩
 
-lemma eq_iff_le_not_lt [partial_order α] {a b : α} : a = b ↔ a ≤ b ∧ ¬ a < b :=
+-- See Note [decidable namespace]
+protected lemma decidable.eq_iff_le_not_lt [partial_order α] [@decidable_rel α (≤)]
+  {a b : α} : a = b ↔ a ≤ b ∧ ¬ a < b :=
 ⟨λ h, ⟨h.le, h ▸ lt_irrefl _⟩, λ ⟨h₁, h₂⟩, h₁.antisymm $
-  classical.by_contradiction $ λ h₃, h₂ (h₁.lt_of_not_le h₃)⟩
+  decidable.by_contradiction $ λ h₃, h₂ (h₁.lt_of_not_le h₃)⟩
+
+lemma eq_iff_le_not_lt [partial_order α] {a b : α} : a = b ↔ a ≤ b ∧ ¬ a < b :=
+by haveI := classical.dec; exact decidable.eq_iff_le_not_lt
 
 lemma eq_or_lt_of_le [partial_order α] {a b : α} (h : a ≤ b) : a = b ∨ a < b :=
 h.lt_or_eq.symm
 
+alias decidable.eq_or_lt_of_le ← has_le.le.eq_or_lt_dec
 alias eq_or_lt_of_le ← has_le.le.eq_or_lt
 
 lemma ne.le_iff_lt [partial_order α] {a b : α} (h : a ≠ b) : a ≤ b ↔ a < b :=
 ⟨λ h', lt_of_le_of_ne h' h, λ h, h.le⟩
 
+-- See Note [decidable namespace]
+@[simp] protected lemma decidable.ne_iff_lt_iff_le [partial_order α] [@decidable_rel α (≤)]
+  {a b : α} : (a ≠ b ↔ a < b) ↔ a ≤ b :=
+⟨λ h, decidable.by_cases le_of_eq (le_of_lt ∘ h.mp), λ h, ⟨lt_of_le_of_ne h, ne_of_lt⟩⟩
+
 @[simp] lemma ne_iff_lt_iff_le [partial_order α] {a b : α} : (a ≠ b ↔ a < b) ↔ a ≤ b :=
-⟨λ h, classical.by_cases le_of_eq (le_of_lt ∘ h.mp), λ h, ⟨lt_of_le_of_ne h, ne_of_lt⟩⟩
+by haveI := classical.dec; exact decidable.ne_iff_lt_iff_le
 
 lemma lt_of_not_ge' [linear_order α] {a b : α} (h : ¬ b ≤ a) : a < b :=
 ((le_total _ _).resolve_right h).lt_of_not_le h
@@ -147,7 +164,7 @@ lemma ne.lt_or_lt [linear_order α] {a b : α} (h : a ≠ b) : a < b ∨ b < a :
 lt_or_gt_of_ne h
 
 lemma not_lt_iff_eq_or_lt [linear_order α] {a b : α} : ¬ a < b ↔ a = b ∨ b < a :=
-not_lt.trans $ le_iff_eq_or_lt.trans $ or_congr eq_comm iff.rfl
+not_lt.trans $ decidable.le_iff_eq_or_lt.trans $ or_congr eq_comm iff.rfl
 
 lemma exists_ge_of_linear [linear_order α] (a b : α) : ∃ c, a ≤ c ∧ b ≤ c :=
 match le_total a b with
@@ -215,20 +232,6 @@ calc  c
     ≤ a : h₀
 ... ≤ b : h₂
 ... ≤ d : h₁
-
-namespace decidable
-
--- See Note [decidable namespace]
-lemma le_imp_le_iff_lt_imp_lt {β} [linear_order α] [linear_order β]
-  {a b : α} {c d : β} : (a ≤ b → c ≤ d) ↔ (d < c → b < a) :=
-⟨lt_imp_lt_of_le_imp_le, le_imp_le_of_lt_imp_lt⟩
-
--- See Note [decidable namespace]
-lemma le_iff_le_iff_lt_iff_lt {β} [linear_order α] [linear_order β]
-  {a b : α} {c d : β} : (a ≤ b ↔ c ≤ d) ↔ (b < a ↔ d < c) :=
-⟨lt_iff_lt_of_le_iff_le, λ H, not_lt.symm.trans $ (not_congr H).trans $ not_lt⟩
-
-end decidable
 
 /-- Like `cmp`, but uses a `≤` on the type instead of `<`. Given two elements
 `x` and `y`, returns a three-way comparison result `ordering`. -/
@@ -340,7 +343,7 @@ begin
   unfold cmp cmp_using,
   by_cases a < b; simp [h],
   by_cases h₂ : b < a; simp [h₂, gt],
-  exact (lt_or_eq_of_le (le_of_not_gt h₂)).resolve_left h
+  exact (decidable.lt_or_eq_of_le (le_of_not_gt h₂)).resolve_left h
 end
 
 theorem cmp_swap [preorder α] [@decidable_rel α (<)] (a b : α) : (cmp a b).swap = cmp b a :=
@@ -385,5 +388,5 @@ lemma lt_iff_lt_of_cmp_eq_cmp (h : cmp x y = cmp x' y') : x < y ↔ x' < y' :=
 by rw [←cmp_eq_lt_iff, ←cmp_eq_lt_iff, h]
 
 lemma le_iff_le_of_cmp_eq_cmp (h : cmp x y = cmp x' y') : x ≤ y ↔ x' ≤ y' :=
-by { rw [←not_lt, ←not_lt, not_iff_not],
+by { rw [←not_lt, ←not_lt], apply not_congr,
   apply lt_iff_lt_of_cmp_eq_cmp, rwa cmp_eq_cmp_symm }

--- a/src/algebra/order.lean
+++ b/src/algebra/order.lean
@@ -38,6 +38,7 @@ alias lt_asymm        ← has_lt.lt.asymm has_lt.lt.not_lt
 
 alias le_of_eq        ← eq.le
 
+attribute [nolint decidable_classical] has_le.le.lt_or_eq_dec
 
 /-- A version of `le_refl` where the argument is implicit -/
 lemma le_rfl [preorder α] {x : α} : x ≤ x := le_refl x
@@ -143,11 +144,13 @@ h.lt_or_eq.symm
 alias decidable.eq_or_lt_of_le ← has_le.le.eq_or_lt_dec
 alias eq_or_lt_of_le ← has_le.le.eq_or_lt
 
+attribute [nolint decidable_classical] has_le.le.eq_or_lt_dec
+
 lemma ne.le_iff_lt [partial_order α] {a b : α} (h : a ≠ b) : a ≤ b ↔ a < b :=
 ⟨λ h', lt_of_le_of_ne h' h, λ h, h.le⟩
 
 -- See Note [decidable namespace]
-@[simp] protected lemma decidable.ne_iff_lt_iff_le [partial_order α] [@decidable_rel α (≤)]
+protected lemma decidable.ne_iff_lt_iff_le [partial_order α] [@decidable_rel α (≤)]
   {a b : α} : (a ≠ b ↔ a < b) ↔ a ≤ b :=
 ⟨λ h, decidable.by_cases le_of_eq (le_of_lt ∘ h.mp), λ h, ⟨lt_of_le_of_ne h, ne_of_lt⟩⟩
 

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -654,7 +654,7 @@ end
 @[to_additive exists_zero_lt]
 lemma exists_one_lt' [nontrivial α] : ∃ (a:α), 1 < a :=
 begin
-  obtain ⟨y, hy⟩ := exists_ne (1 : α),
+  obtain ⟨y, hy⟩ := decidable.exists_ne (1 : α),
   cases hy.lt_or_lt,
   { exact ⟨y⁻¹, one_lt_inv'.mpr h⟩ },
   { exact ⟨y, h⟩ }
@@ -761,7 +761,7 @@ lemma abs_nonneg (a : α) : 0 ≤ abs a :=
 abs_of_nonneg $ abs_nonneg a
 
 @[simp] lemma abs_eq_zero : abs a = 0 ↔ a = 0 :=
-not_iff_not.1 $ ne_comm.trans $ (abs_nonneg a).lt_iff_ne.symm.trans abs_pos
+decidable.not_iff_not.1 $ ne_comm.trans $ (abs_nonneg a).lt_iff_ne.symm.trans abs_pos
 
 @[simp] lemma abs_nonpos_iff {a : α} : abs a ≤ 0 ↔ a = 0 :=
 (abs_nonneg a).le_iff_eq.trans abs_eq_zero

--- a/src/algebra/ordered_monoid.lean
+++ b/src/algebra/ordered_monoid.lean
@@ -72,28 +72,22 @@ attribute [to_additive] has_exists_mul_of_le
 class linear_ordered_add_comm_monoid (α : Type*)
   extends linear_order α, ordered_add_comm_monoid α :=
 (lt_of_add_lt_add_left := λ x y z, by {
-  apply imp_of_not_imp_not,
-  intro h,
-  apply not_lt_of_le,
-  apply add_le_add_left,
   -- type-class inference uses `a : linear_order α` which it can't unfold, unless we provide this!
   -- `lt_iff_le_not_le` gets filled incorrectly with `autoparam` if we don't provide that field.
   letI : linear_order α := by refine { le := le, lt := lt, lt_iff_le_not_le := _, .. }; assumption,
-  exact le_of_not_lt h })
+  apply lt_imp_lt_of_le_imp_le,
+  exact λ h, add_le_add_left _ _ h _ })
 
 /-- A linearly ordered commutative monoid. -/
 @[protect_proj, ancestor linear_order ordered_comm_monoid, to_additive]
 class linear_ordered_comm_monoid (α : Type*)
   extends linear_order α, ordered_comm_monoid α :=
 (lt_of_mul_lt_mul_left := λ x y z, by {
-  apply imp_of_not_imp_not,
-  intro h,
-  apply not_lt_of_le,
-  apply mul_le_mul_left,
   -- type-class inference uses `a : linear_order α` which it can't unfold, unless we provide this!
   -- `lt_iff_le_not_le` gets filled incorrectly with `autoparam` if we don't provide that field.
   letI : linear_order α := by refine { le := le, lt := lt, lt_iff_le_not_le := _, .. }; assumption,
-  exact le_of_not_lt h })
+  apply lt_imp_lt_of_le_imp_le,
+  exact λ h, mul_le_mul_left _ _ h _ })
 
 /-- A linearly ordered commutative monoid with a zero element. -/
 class linear_ordered_comm_monoid_with_zero (α : Type*)

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -63,32 +63,32 @@ lemma mul_lt_mul_of_pos_right (h₁ : a < b) (h₂ : 0 < c) : a * c < b * c :=
 ordered_semiring.mul_lt_mul_of_pos_right a b c h₁ h₂
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_le_mul_of_nonneg_left [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_le_mul_of_nonneg_left [@decidable_rel α (≤)]
   (h₁ : a ≤ b) (h₂ : 0 ≤ c) : c * a ≤ c * b :=
 begin
-  cases decidable.em (b ≤ a), { simp [h.antisymm h₁] },
-  cases decidable.em (c ≤ 0), { simp [h_1.antisymm h₂] },
-  exact (mul_lt_mul_of_pos_left (h₁.lt_of_not_le h) (h₂.lt_of_not_le h_1)).le,
-end
-
--- See Note [decidable namespace]
-protected lemma decidable.mul_le_mul_of_nonneg_right [decidable_rel ((≤) : α → α → Prop)]
-  (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≤ b * c :=
-begin
-  cases decidable.em (b ≤ a), { simp [h.antisymm h₁] },
-  cases decidable.em (c ≤ 0), { simp [h_1.antisymm h₂] },
-  exact (mul_lt_mul_of_pos_right (h₁.lt_of_not_le h) (h₂.lt_of_not_le h_1)).le,
+  by_cases ba : b ≤ a, { simp [ba.antisymm h₁] },
+  by_cases c0 : c ≤ 0, { simp [c0.antisymm h₂] },
+  exact (mul_lt_mul_of_pos_left (h₁.lt_of_not_le ba) (h₂.lt_of_not_le c0)).le,
 end
 
 lemma mul_le_mul_of_nonneg_left : a ≤ b → 0 ≤ c → c * a ≤ c * b :=
 by classical; exact decidable.mul_le_mul_of_nonneg_left
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_le_mul_of_nonneg_right [@decidable_rel α (≤)]
+  (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≤ b * c :=
+begin
+  by_cases ba : b ≤ a, { simp [ba.antisymm h₁] },
+  by_cases c0 : c ≤ 0, { simp [c0.antisymm h₂] },
+  exact (mul_lt_mul_of_pos_right (h₁.lt_of_not_le ba) (h₂.lt_of_not_le c0)).le,
+end
 
 lemma mul_le_mul_of_nonneg_right : a ≤ b → 0 ≤ c → a * c ≤ b * c :=
 by classical; exact decidable.mul_le_mul_of_nonneg_right
 
 -- TODO: there are four variations, depending on which variables we assume to be nonneg
 -- See Note [decidable namespace]
-protected lemma decidable.mul_le_mul [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_le_mul [@decidable_rel α (≤)]
   (hac : a ≤ c) (hbd : b ≤ d) (nn_b : 0 ≤ b) (nn_c : 0 ≤ c) : a * b ≤ c * d :=
 calc
   a * b ≤ c * b : decidable.mul_le_mul_of_nonneg_right hac nn_b
@@ -99,7 +99,7 @@ by classical; exact decidable.mul_le_mul
 
 -- See Note [decidable namespace]
 protected lemma decidable.mul_nonneg_le_one_le {α : Type*} [ordered_semiring α]
-  [decidable_rel ((≤) : α → α → Prop)] {a b c : α}
+  [@decidable_rel α (≤)] {a b c : α}
   (h₁ : 0 ≤ c) (h₂ : a ≤ c) (h₃ : 0 ≤ b) (h₄ : b ≤ 1) : a * b ≤ c :=
 by simpa only [mul_one] using decidable.mul_le_mul h₂ h₄ h₃ h₁
 
@@ -108,7 +108,7 @@ lemma mul_nonneg_le_one_le {α : Type*} [ordered_semiring α] {a b c : α} :
 by classical; exact decidable.mul_nonneg_le_one_le
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_nonneg [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_nonneg [@decidable_rel α (≤)]
   (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a * b :=
 have h : 0 * b ≤ a * b, from decidable.mul_le_mul_of_nonneg_right ha hb,
 by rwa [zero_mul] at h
@@ -116,7 +116,7 @@ by rwa [zero_mul] at h
 lemma mul_nonneg : 0 ≤ a → 0 ≤ b → 0 ≤ a * b := by classical; exact decidable.mul_nonneg
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_nonpos_of_nonneg_of_nonpos [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_nonpos_of_nonneg_of_nonpos [@decidable_rel α (≤)]
   (ha : 0 ≤ a) (hb : b ≤ 0) : a * b ≤ 0 :=
 have h : a * b ≤ a * 0, from decidable.mul_le_mul_of_nonneg_left hb ha,
 by rwa mul_zero at h
@@ -125,7 +125,7 @@ lemma mul_nonpos_of_nonneg_of_nonpos : 0 ≤ a → b ≤ 0 → a * b ≤ 0 :=
  by classical; exact decidable.mul_nonpos_of_nonneg_of_nonpos
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_nonpos_of_nonpos_of_nonneg [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_nonpos_of_nonpos_of_nonneg [@decidable_rel α (≤)]
   (ha : a ≤ 0) (hb : 0 ≤ b) : a * b ≤ 0 :=
 have h : a * b ≤ 0 * b, from decidable.mul_le_mul_of_nonneg_right ha hb,
 by rwa zero_mul at h
@@ -134,7 +134,7 @@ lemma mul_nonpos_of_nonpos_of_nonneg : a ≤ 0 → 0 ≤ b → a * b ≤ 0 :=
 by classical; exact decidable.mul_nonpos_of_nonpos_of_nonneg
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_lt_mul [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_lt_mul [@decidable_rel α (≤)]
   (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) (nn_c : 0 ≤ c) : a * b < c * d :=
 calc
   a * b < c * b : mul_lt_mul_of_pos_right hac pos_b
@@ -144,7 +144,7 @@ lemma mul_lt_mul : a < c → b ≤ d → 0 < b → 0 ≤ c → a * b < c * d :=
 by classical; exact decidable.mul_lt_mul
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_lt_mul' [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_lt_mul' [@decidable_rel α (≤)]
   (h1 : a ≤ c) (h2 : b < d) (h3 : 0 ≤ b) (h4 : 0 < c) : a * b < c * d :=
 calc
    a * b ≤ c * b : decidable.mul_le_mul_of_nonneg_right h1 h3
@@ -166,7 +166,7 @@ have h : a * b < 0 * b, from mul_lt_mul_of_pos_right ha hb,
 by rwa zero_mul at  h
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_self_lt_mul_self [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_self_lt_mul_self [@decidable_rel α (≤)]
   (h1 : 0 ≤ a) (h2 : a < b) : a * a < b * b :=
 decidable.mul_lt_mul' h2.le h2 h1 $ h1.trans_lt h2
 
@@ -174,7 +174,7 @@ lemma mul_self_lt_mul_self (h1 : 0 ≤ a) (h2 : a < b) : a * a < b * b :=
 mul_lt_mul' h2.le h2 h1 $ h1.trans_lt h2
 
 -- See Note [decidable namespace]
-protected lemma decidable.strict_mono_incr_on_mul_self [decidable_rel ((≤) : α → α → Prop)] :
+protected lemma decidable.strict_mono_incr_on_mul_self [@decidable_rel α (≤)] :
   strict_mono_incr_on (λ x : α, x * x) (set.Ici 0) :=
 λ x hx y hy hxy, decidable.mul_self_lt_mul_self hx hxy
 
@@ -182,7 +182,7 @@ lemma strict_mono_incr_on_mul_self : strict_mono_incr_on (λ x : α, x * x) (set
 λ x hx y hy hxy, mul_self_lt_mul_self hx hxy
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_self_le_mul_self [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_self_le_mul_self [@decidable_rel α (≤)]
   (h1 : 0 ≤ a) (h2 : a ≤ b) : a * a ≤ b * b :=
 decidable.mul_le_mul h2 h2 h1 $ h1.trans h2
 
@@ -190,7 +190,7 @@ lemma mul_self_le_mul_self (h1 : 0 ≤ a) (h2 : a ≤ b) : a * a ≤ b * b :=
 mul_le_mul h2 h2 h1 $ h1.trans h2
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_lt_mul'' [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_lt_mul'' [@decidable_rel α (≤)]
   (h1 : a < c) (h2 : b < d) (h3 : 0 ≤ a) (h4 : 0 ≤ b) : a * b < c * d :=
 h4.lt_or_eq_dec.elim
   (λ b0, decidable.mul_lt_mul h1 h2.le b0 $ h3.trans h1.le)
@@ -201,7 +201,7 @@ lemma mul_lt_mul'' : a < c → b < d → 0 ≤ a → 0 ≤ b → a * b < c * d :
 by classical; exact decidable.mul_lt_mul''
 
 -- See Note [decidable namespace]
-protected lemma decidable.le_mul_of_one_le_right [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.le_mul_of_one_le_right [@decidable_rel α (≤)]
   (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ b * a :=
 suffices b * 1 ≤ b * a, by rwa mul_one at this,
 decidable.mul_le_mul_of_nonneg_left h hb
@@ -210,7 +210,7 @@ lemma le_mul_of_one_le_right : 0 ≤ b → 1 ≤ a → b ≤ b * a :=
 by classical; exact decidable.le_mul_of_one_le_right
 
 -- See Note [decidable namespace]
-protected lemma decidable.le_mul_of_one_le_left [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.le_mul_of_one_le_left [@decidable_rel α (≤)]
   (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ a * b :=
 suffices 1 * b ≤ a * b, by rwa one_mul at this,
 decidable.mul_le_mul_of_nonneg_right h hb
@@ -219,7 +219,7 @@ lemma le_mul_of_one_le_left : 0 ≤ b → 1 ≤ a → b ≤ a * b :=
 by classical; exact decidable.le_mul_of_one_le_left
 
 -- See Note [decidable namespace]
-protected lemma decidable.lt_mul_of_one_lt_right [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.lt_mul_of_one_lt_right [@decidable_rel α (≤)]
   (hb : 0 < b) (h : 1 < a) : b < b * a :=
 suffices b * 1 < b * a, by rwa mul_one at this,
 decidable.mul_lt_mul' (le_refl _) h zero_le_one hb
@@ -228,7 +228,7 @@ lemma lt_mul_of_one_lt_right : 0 < b → 1 < a → b < b * a :=
 by classical; exact decidable.lt_mul_of_one_lt_right
 
 -- See Note [decidable namespace]
-protected lemma decidable.lt_mul_of_one_lt_left [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.lt_mul_of_one_lt_left [@decidable_rel α (≤)]
   (hb : 0 < b) (h : 1 < a) : b < a * b :=
 suffices 1 * b < a * b, by rwa one_mul at this,
 decidable.mul_lt_mul h (le_refl _) hb (zero_le_one.trans h.le)
@@ -237,7 +237,7 @@ lemma lt_mul_of_one_lt_left : 0 < b → 1 < a → b < a * b :=
 by classical; exact decidable.lt_mul_of_one_lt_left
 
 -- See Note [decidable namespace]
-protected lemma decidable.add_le_mul_two_add [decidable_rel ((≤) : α → α → Prop)] {a b : α}
+protected lemma decidable.add_le_mul_two_add [@decidable_rel α (≤)] {a b : α}
   (a2 : 2 ≤ a) (b0 : 0 ≤ b) : a + (2 + b) ≤ a * (2 + b) :=
 calc a + (2 + b) ≤ a + (a + a * b) :
       add_le_add_left (add_le_add a2 (decidable.le_mul_of_one_le_left b0 (one_le_two.trans a2))) a
@@ -247,7 +247,7 @@ lemma add_le_mul_two_add {a b : α} : 2 ≤ a → 0 ≤ b → a + (2 + b) ≤ a 
 by classical; exact decidable.add_le_mul_two_add
 
 -- See Note [decidable namespace]
-protected lemma decidable.one_le_mul_of_one_le_of_one_le [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.one_le_mul_of_one_le_of_one_le [@decidable_rel α (≤)]
   {a b : α} (a1 : 1 ≤ a) (b1 : 1 ≤ b) : (1 : α) ≤ a * b :=
 (mul_one (1 : α)).symm.le.trans (decidable.mul_le_mul a1 b1 zero_le_one (zero_le_one.trans a1))
 
@@ -297,7 +297,7 @@ begin
 end
 
 -- See Note [decidable namespace]
-protected lemma decidable.one_lt_mul [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.one_lt_mul [@decidable_rel α (≤)]
   (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=
 begin
   nontriviality,
@@ -308,7 +308,7 @@ lemma one_lt_mul : 1 ≤ a → 1 < b → 1 < a * b :=
 by classical; exact decidable.one_lt_mul
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_le_one [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_le_one [@decidable_rel α (≤)]
   (ha : a ≤ 1) (hb' : 0 ≤ b) (hb : b ≤ 1) : a * b ≤ 1 :=
 begin rw ← one_mul (1 : α), apply decidable.mul_le_mul; {assumption <|> apply zero_le_one} end
 
@@ -316,7 +316,7 @@ lemma mul_le_one : a ≤ 1 → 0 ≤ b → b ≤ 1 → a * b ≤ 1 :=
 by classical; exact decidable.mul_le_one
 
 -- See Note [decidable namespace]
-protected lemma decidable.one_lt_mul_of_le_of_lt [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.one_lt_mul_of_le_of_lt [@decidable_rel α (≤)]
   (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=
 begin
   nontriviality,
@@ -328,7 +328,7 @@ lemma one_lt_mul_of_le_of_lt : 1 ≤ a → 1 < b → 1 < a * b :=
 by classical; exact decidable.one_lt_mul_of_le_of_lt
 
 -- See Note [decidable namespace]
-protected lemma decidable.one_lt_mul_of_lt_of_le [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.one_lt_mul_of_lt_of_le [@decidable_rel α (≤)]
   (ha : 1 < a) (hb : 1 ≤ b) : 1 < a * b :=
 begin
   nontriviality,
@@ -340,7 +340,7 @@ lemma one_lt_mul_of_lt_of_le : 1 < a → 1 ≤ b → 1 < a * b :=
 by classical; exact decidable.one_lt_mul_of_lt_of_le
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_le_of_le_one_right [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_le_of_le_one_right [@decidable_rel α (≤)]
   (ha : 0 ≤ a) (hb1 : b ≤ 1) : a * b ≤ a :=
 calc a * b ≤ a * 1 : decidable.mul_le_mul_of_nonneg_left hb1 ha
 ... = a : mul_one a
@@ -349,7 +349,7 @@ lemma mul_le_of_le_one_right : 0 ≤ a → b ≤ 1 → a * b ≤ a :=
 by classical; exact decidable.mul_le_of_le_one_right
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_le_of_le_one_left [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_le_of_le_one_left [@decidable_rel α (≤)]
   (hb : 0 ≤ b) (ha1 : a ≤ 1) : a * b ≤ b :=
 calc a * b ≤ 1 * b : decidable.mul_le_mul ha1 le_rfl hb zero_le_one
 ... = b : one_mul b
@@ -358,7 +358,7 @@ lemma mul_le_of_le_one_left : 0 ≤ b → a ≤ 1 → a * b ≤ b :=
 by classical; exact decidable.mul_le_of_le_one_left
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_lt_one_of_nonneg_of_lt_one_left [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_lt_one_of_nonneg_of_lt_one_left [@decidable_rel α (≤)]
   (ha0 : 0 ≤ a) (ha : a < 1) (hb : b ≤ 1) : a * b < 1 :=
 calc a * b ≤ a : decidable.mul_le_of_le_one_right ha0 hb
 ... < 1 : ha
@@ -367,7 +367,7 @@ lemma mul_lt_one_of_nonneg_of_lt_one_left : 0 ≤ a → a < 1 → b ≤ 1 → a 
 by classical; exact decidable.mul_lt_one_of_nonneg_of_lt_one_left
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_lt_one_of_nonneg_of_lt_one_right [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_lt_one_of_nonneg_of_lt_one_right [@decidable_rel α (≤)]
   (ha : a ≤ 1) (hb0 : 0 ≤ b) (hb : b < 1) : a * b < 1 :=
 calc a * b ≤ b : decidable.mul_le_of_le_one_left hb0 ha
 ... < 1 : hb
@@ -748,7 +748,7 @@ section ordered_ring
 variables [ordered_ring α] {a b c : α}
 
 -- See Note [decidable namespace]
-protected lemma decidable.ordered_ring.mul_nonneg [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.ordered_ring.mul_nonneg [@decidable_rel α (≤)]
   {a b : α} (h₁ : 0 ≤ a) (h₂ : 0 ≤ b) : 0 ≤ a * b :=
 begin
   by_cases ha : a ≤ 0, { simp [le_antisymm ha h₁] },
@@ -761,7 +761,7 @@ by classical; exact decidable.ordered_ring.mul_nonneg
 
 -- See Note [decidable namespace]
 protected lemma decidable.ordered_ring.mul_le_mul_of_nonneg_left
-  [decidable_rel ((≤) : α → α → Prop)] (h₁ : a ≤ b) (h₂ : 0 ≤ c) : c * a ≤ c * b :=
+  [@decidable_rel α (≤)] (h₁ : a ≤ b) (h₂ : 0 ≤ c) : c * a ≤ c * b :=
 begin
   rw [← sub_nonneg, ← mul_sub],
   exact decidable.ordered_ring.mul_nonneg h₂ (sub_nonneg.2 h₁),
@@ -772,7 +772,7 @@ by classical; exact decidable.ordered_ring.mul_le_mul_of_nonneg_left
 
 -- See Note [decidable namespace]
 protected lemma decidable.ordered_ring.mul_le_mul_of_nonneg_right
-  [decidable_rel ((≤) : α → α → Prop)] (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≤ b * c :=
+  [@decidable_rel α (≤)] (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≤ b * c :=
 begin
   rw [← sub_nonneg, ← sub_mul],
   exact decidable.ordered_ring.mul_nonneg (sub_nonneg.2 h₁) h₂,
@@ -804,7 +804,7 @@ instance ordered_ring.to_ordered_semiring : ordered_semiring α :=
   ..‹ordered_ring α› }
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_le_mul_of_nonpos_left [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_le_mul_of_nonpos_left [@decidable_rel α (≤)]
   {a b c : α} (h : b ≤ a) (hc : c ≤ 0) : c * a ≤ c * b :=
 have -c ≥ 0,              from neg_nonneg_of_nonpos hc,
 have -c * b ≤ -c * a,     from decidable.mul_le_mul_of_nonneg_left h this,
@@ -815,7 +815,7 @@ lemma mul_le_mul_of_nonpos_left {a b c : α} : b ≤ a → c ≤ 0 → c * a ≤
 by classical; exact decidable.mul_le_mul_of_nonpos_left
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_le_mul_of_nonpos_right [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_le_mul_of_nonpos_right [@decidable_rel α (≤)]
   {a b c : α} (h : b ≤ a) (hc : c ≤ 0) : a * c ≤ b * c :=
 have -c ≥ 0,              from neg_nonneg_of_nonpos hc,
 have b * -c ≤ a * -c,     from decidable.mul_le_mul_of_nonneg_right h this,
@@ -826,7 +826,7 @@ lemma mul_le_mul_of_nonpos_right {a b c : α} : b ≤ a → c ≤ 0 → a * c �
 by classical; exact decidable.mul_le_mul_of_nonpos_right
 
 -- See Note [decidable namespace]
-protected lemma decidable.mul_nonneg_of_nonpos_of_nonpos [decidable_rel ((≤) : α → α → Prop)]
+protected lemma decidable.mul_nonneg_of_nonpos_of_nonpos [@decidable_rel α (≤)]
   {a b : α} (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a * b :=
 have 0 * b ≤ a * b, from decidable.mul_le_mul_of_nonpos_right ha hb,
 by rwa zero_mul at this

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -62,51 +62,96 @@ ordered_semiring.mul_lt_mul_of_pos_left a b c h₁ h₂
 lemma mul_lt_mul_of_pos_right (h₁ : a < b) (h₂ : 0 < c) : a * c < b * c :=
 ordered_semiring.mul_lt_mul_of_pos_right a b c h₁ h₂
 
-lemma mul_le_mul_of_nonneg_left (h₁ : a ≤ b) (h₂ : 0 ≤ c) : c * a ≤ c * b :=
+-- See Note [decidable namespace]
+protected lemma decidable.mul_le_mul_of_nonneg_left [decidable_rel ((≤) : α → α → Prop)]
+  (h₁ : a ≤ b) (h₂ : 0 ≤ c) : c * a ≤ c * b :=
 begin
-  cases classical.em (b ≤ a), { simp [h.antisymm h₁] },
-  cases classical.em (c ≤ 0), { simp [h_1.antisymm h₂] },
+  cases decidable.em (b ≤ a), { simp [h.antisymm h₁] },
+  cases decidable.em (c ≤ 0), { simp [h_1.antisymm h₂] },
   exact (mul_lt_mul_of_pos_left (h₁.lt_of_not_le h) (h₂.lt_of_not_le h_1)).le,
 end
 
-lemma mul_le_mul_of_nonneg_right (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≤ b * c :=
+-- See Note [decidable namespace]
+protected lemma decidable.mul_le_mul_of_nonneg_right [decidable_rel ((≤) : α → α → Prop)]
+  (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≤ b * c :=
 begin
-  cases classical.em (b ≤ a), { simp [h.antisymm h₁] },
-  cases classical.em (c ≤ 0), { simp [h_1.antisymm h₂] },
+  cases decidable.em (b ≤ a), { simp [h.antisymm h₁] },
+  cases decidable.em (c ≤ 0), { simp [h_1.antisymm h₂] },
   exact (mul_lt_mul_of_pos_right (h₁.lt_of_not_le h) (h₂.lt_of_not_le h_1)).le,
 end
 
+lemma mul_le_mul_of_nonneg_left : a ≤ b → 0 ≤ c → c * a ≤ c * b :=
+by classical; exact decidable.mul_le_mul_of_nonneg_left
+
+lemma mul_le_mul_of_nonneg_right : a ≤ b → 0 ≤ c → a * c ≤ b * c :=
+by classical; exact decidable.mul_le_mul_of_nonneg_right
+
 -- TODO: there are four variations, depending on which variables we assume to be nonneg
-lemma mul_le_mul (hac : a ≤ c) (hbd : b ≤ d) (nn_b : 0 ≤ b) (nn_c : 0 ≤ c) : a * b ≤ c * d :=
+-- See Note [decidable namespace]
+protected lemma decidable.mul_le_mul [decidable_rel ((≤) : α → α → Prop)]
+  (hac : a ≤ c) (hbd : b ≤ d) (nn_b : 0 ≤ b) (nn_c : 0 ≤ c) : a * b ≤ c * d :=
 calc
-  a * b ≤ c * b : mul_le_mul_of_nonneg_right hac nn_b
-    ... ≤ c * d : mul_le_mul_of_nonneg_left hbd nn_c
+  a * b ≤ c * b : decidable.mul_le_mul_of_nonneg_right hac nn_b
+    ... ≤ c * d : decidable.mul_le_mul_of_nonneg_left hbd nn_c
 
-lemma mul_nonneg_le_one_le {α : Type*} [ordered_semiring α] {a b c : α}
+lemma mul_le_mul : a ≤ c → b ≤ d → 0 ≤ b → 0 ≤ c → a * b ≤ c * d :=
+by classical; exact decidable.mul_le_mul
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_nonneg_le_one_le {α : Type*} [ordered_semiring α]
+  [decidable_rel ((≤) : α → α → Prop)] {a b c : α}
   (h₁ : 0 ≤ c) (h₂ : a ≤ c) (h₃ : 0 ≤ b) (h₄ : b ≤ 1) : a * b ≤ c :=
-by simpa only [mul_one] using mul_le_mul h₂ h₄ h₃ h₁
+by simpa only [mul_one] using decidable.mul_le_mul h₂ h₄ h₃ h₁
 
-lemma mul_nonneg (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a * b :=
-have h : 0 * b ≤ a * b, from mul_le_mul_of_nonneg_right ha hb,
+lemma mul_nonneg_le_one_le {α : Type*} [ordered_semiring α] {a b c : α} :
+  0 ≤ c → a ≤ c → 0 ≤ b → b ≤ 1 → a * b ≤ c :=
+by classical; exact decidable.mul_nonneg_le_one_le
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_nonneg [decidable_rel ((≤) : α → α → Prop)]
+  (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a * b :=
+have h : 0 * b ≤ a * b, from decidable.mul_le_mul_of_nonneg_right ha hb,
 by rwa [zero_mul] at h
 
-lemma mul_nonpos_of_nonneg_of_nonpos (ha : 0 ≤ a) (hb : b ≤ 0) : a * b ≤ 0 :=
-have h : a * b ≤ a * 0, from mul_le_mul_of_nonneg_left hb ha,
+lemma mul_nonneg : 0 ≤ a → 0 ≤ b → 0 ≤ a * b := by classical; exact decidable.mul_nonneg
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_nonpos_of_nonneg_of_nonpos [decidable_rel ((≤) : α → α → Prop)]
+  (ha : 0 ≤ a) (hb : b ≤ 0) : a * b ≤ 0 :=
+have h : a * b ≤ a * 0, from decidable.mul_le_mul_of_nonneg_left hb ha,
 by rwa mul_zero at h
 
-lemma mul_nonpos_of_nonpos_of_nonneg (ha : a ≤ 0) (hb : 0 ≤ b) : a * b ≤ 0 :=
-have h : a * b ≤ 0 * b, from mul_le_mul_of_nonneg_right ha hb,
+lemma mul_nonpos_of_nonneg_of_nonpos : 0 ≤ a → b ≤ 0 → a * b ≤ 0 :=
+ by classical; exact decidable.mul_nonpos_of_nonneg_of_nonpos
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_nonpos_of_nonpos_of_nonneg [decidable_rel ((≤) : α → α → Prop)]
+  (ha : a ≤ 0) (hb : 0 ≤ b) : a * b ≤ 0 :=
+have h : a * b ≤ 0 * b, from decidable.mul_le_mul_of_nonneg_right ha hb,
 by rwa zero_mul at h
 
-lemma mul_lt_mul (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) (nn_c : 0 ≤ c) : a * b < c * d :=
+lemma mul_nonpos_of_nonpos_of_nonneg : a ≤ 0 → 0 ≤ b → a * b ≤ 0 :=
+by classical; exact decidable.mul_nonpos_of_nonpos_of_nonneg
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_lt_mul [decidable_rel ((≤) : α → α → Prop)]
+  (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) (nn_c : 0 ≤ c) : a * b < c * d :=
 calc
   a * b < c * b : mul_lt_mul_of_pos_right hac pos_b
-    ... ≤ c * d : mul_le_mul_of_nonneg_left hbd nn_c
+    ... ≤ c * d : decidable.mul_le_mul_of_nonneg_left hbd nn_c
 
-lemma mul_lt_mul' (h1 : a ≤ c) (h2 : b < d) (h3 : 0 ≤ b) (h4 : 0 < c) : a * b < c * d :=
+lemma mul_lt_mul : a < c → b ≤ d → 0 < b → 0 ≤ c → a * b < c * d :=
+by classical; exact decidable.mul_lt_mul
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_lt_mul' [decidable_rel ((≤) : α → α → Prop)]
+  (h1 : a ≤ c) (h2 : b < d) (h3 : 0 ≤ b) (h4 : 0 < c) : a * b < c * d :=
 calc
-   a * b ≤ c * b : mul_le_mul_of_nonneg_right h1 h3
+   a * b ≤ c * b : decidable.mul_le_mul_of_nonneg_right h1 h3
      ... < c * d : mul_lt_mul_of_pos_left h2 h4
+
+lemma mul_lt_mul' : a ≤ c → b < d → 0 ≤ b → 0 < c → a * b < c * d :=
+by classical; exact decidable.mul_lt_mul'
 
 lemma mul_pos (ha : 0 < a) (hb : 0 < b) : 0 < a * b :=
 have h : 0 * b < a * b, from mul_lt_mul_of_pos_right ha hb,
@@ -120,46 +165,94 @@ lemma mul_neg_of_neg_of_pos (ha : a < 0) (hb : 0 < b) : a * b < 0 :=
 have h : a * b < 0 * b, from mul_lt_mul_of_pos_right ha hb,
 by rwa zero_mul at  h
 
+-- See Note [decidable namespace]
+protected lemma decidable.mul_self_lt_mul_self [decidable_rel ((≤) : α → α → Prop)]
+  (h1 : 0 ≤ a) (h2 : a < b) : a * a < b * b :=
+decidable.mul_lt_mul' h2.le h2 h1 $ h1.trans_lt h2
+
 lemma mul_self_lt_mul_self (h1 : 0 ≤ a) (h2 : a < b) : a * a < b * b :=
 mul_lt_mul' h2.le h2 h1 $ h1.trans_lt h2
+
+-- See Note [decidable namespace]
+protected lemma decidable.strict_mono_incr_on_mul_self [decidable_rel ((≤) : α → α → Prop)] :
+  strict_mono_incr_on (λ x : α, x * x) (set.Ici 0) :=
+λ x hx y hy hxy, decidable.mul_self_lt_mul_self hx hxy
 
 lemma strict_mono_incr_on_mul_self : strict_mono_incr_on (λ x : α, x * x) (set.Ici 0) :=
 λ x hx y hy hxy, mul_self_lt_mul_self hx hxy
 
+-- See Note [decidable namespace]
+protected lemma decidable.mul_self_le_mul_self [decidable_rel ((≤) : α → α → Prop)]
+  (h1 : 0 ≤ a) (h2 : a ≤ b) : a * a ≤ b * b :=
+decidable.mul_le_mul h2 h2 h1 $ h1.trans h2
+
 lemma mul_self_le_mul_self (h1 : 0 ≤ a) (h2 : a ≤ b) : a * a ≤ b * b :=
 mul_le_mul h2 h2 h1 $ h1.trans h2
 
-lemma mul_lt_mul'' (h1 : a < c) (h2 : b < d) (h3 : 0 ≤ a) (h4 : 0 ≤ b) : a * b < c * d :=
-(lt_or_eq_of_le h4).elim
-  (λ b0, mul_lt_mul h1 h2.le b0 $ h3.trans h1.le)
+-- See Note [decidable namespace]
+protected lemma decidable.mul_lt_mul'' [decidable_rel ((≤) : α → α → Prop)]
+  (h1 : a < c) (h2 : b < d) (h3 : 0 ≤ a) (h4 : 0 ≤ b) : a * b < c * d :=
+h4.lt_or_eq_dec.elim
+  (λ b0, decidable.mul_lt_mul h1 h2.le b0 $ h3.trans h1.le)
   (λ b0, by rw [← b0, mul_zero]; exact
     mul_pos (h3.trans_lt h1) (h4.trans_lt h2))
 
-lemma le_mul_of_one_le_right (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ b * a :=
+lemma mul_lt_mul'' : a < c → b < d → 0 ≤ a → 0 ≤ b → a * b < c * d :=
+by classical; exact decidable.mul_lt_mul''
+
+-- See Note [decidable namespace]
+protected lemma decidable.le_mul_of_one_le_right [decidable_rel ((≤) : α → α → Prop)]
+  (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ b * a :=
 suffices b * 1 ≤ b * a, by rwa mul_one at this,
-mul_le_mul_of_nonneg_left h hb
+decidable.mul_le_mul_of_nonneg_left h hb
 
-lemma le_mul_of_one_le_left (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ a * b :=
+lemma le_mul_of_one_le_right : 0 ≤ b → 1 ≤ a → b ≤ b * a :=
+by classical; exact decidable.le_mul_of_one_le_right
+
+-- See Note [decidable namespace]
+protected lemma decidable.le_mul_of_one_le_left [decidable_rel ((≤) : α → α → Prop)]
+  (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ a * b :=
 suffices 1 * b ≤ a * b, by rwa one_mul at this,
-mul_le_mul_of_nonneg_right h hb
+decidable.mul_le_mul_of_nonneg_right h hb
 
-lemma lt_mul_of_one_lt_right (hb : 0 < b) (h : 1 < a) : b < b * a :=
+lemma le_mul_of_one_le_left : 0 ≤ b → 1 ≤ a → b ≤ a * b :=
+by classical; exact decidable.le_mul_of_one_le_left
+
+-- See Note [decidable namespace]
+protected lemma decidable.lt_mul_of_one_lt_right [decidable_rel ((≤) : α → α → Prop)]
+  (hb : 0 < b) (h : 1 < a) : b < b * a :=
 suffices b * 1 < b * a, by rwa mul_one at this,
-mul_lt_mul' (le_refl _) h zero_le_one hb
+decidable.mul_lt_mul' (le_refl _) h zero_le_one hb
 
-lemma lt_mul_of_one_lt_left (hb : 0 < b) (h : 1 < a) : b < a * b :=
+lemma lt_mul_of_one_lt_right : 0 < b → 1 < a → b < b * a :=
+by classical; exact decidable.lt_mul_of_one_lt_right
+
+-- See Note [decidable namespace]
+protected lemma decidable.lt_mul_of_one_lt_left [decidable_rel ((≤) : α → α → Prop)]
+  (hb : 0 < b) (h : 1 < a) : b < a * b :=
 suffices 1 * b < a * b, by rwa one_mul at this,
-mul_lt_mul h (le_refl _) hb (zero_le_one.trans h.le)
+decidable.mul_lt_mul h (le_refl _) hb (zero_le_one.trans h.le)
 
-lemma add_le_mul_two_add {a b : α}
+lemma lt_mul_of_one_lt_left : 0 < b → 1 < a → b < a * b :=
+by classical; exact decidable.lt_mul_of_one_lt_left
+
+-- See Note [decidable namespace]
+protected lemma decidable.add_le_mul_two_add [decidable_rel ((≤) : α → α → Prop)] {a b : α}
   (a2 : 2 ≤ a) (b0 : 0 ≤ b) : a + (2 + b) ≤ a * (2 + b) :=
 calc a + (2 + b) ≤ a + (a + a * b) :
-      add_le_add_left (add_le_add a2 (le_mul_of_one_le_left b0 (one_le_two.trans a2))) a
+      add_le_add_left (add_le_add a2 (decidable.le_mul_of_one_le_left b0 (one_le_two.trans a2))) a
              ... ≤ a * (2 + b) : by rw [mul_add, mul_two, add_assoc]
 
-lemma one_le_mul_of_one_le_of_one_le {a b : α} (a1 : 1 ≤ a) (b1 : 1 ≤ b) :
-  (1 : α) ≤ a * b :=
-(mul_one (1 : α)).symm.le.trans (mul_le_mul a1 b1 zero_le_one (zero_le_one.trans a1))
+lemma add_le_mul_two_add {a b : α} : 2 ≤ a → 0 ≤ b → a + (2 + b) ≤ a * (2 + b) :=
+by classical; exact decidable.add_le_mul_two_add
+
+-- See Note [decidable namespace]
+protected lemma decidable.one_le_mul_of_one_le_of_one_le [decidable_rel ((≤) : α → α → Prop)]
+  {a b : α} (a1 : 1 ≤ a) (b1 : 1 ≤ b) : (1 : α) ≤ a * b :=
+(mul_one (1 : α)).symm.le.trans (decidable.mul_le_mul a1 b1 zero_le_one (zero_le_one.trans a1))
+
+lemma one_le_mul_of_one_le_of_one_le {a b : α} : 1 ≤ a → 1 ≤ b → (1 : α) ≤ a * b :=
+by classical; exact decidable.one_le_mul_of_one_le_of_one_le
 
 /-- Pullback an `ordered_semiring` under an injective map. -/
 def function.injective.ordered_semiring {β : Type*}
@@ -203,44 +296,84 @@ begin
   exact bit1_pos h.le,
 end
 
-lemma one_lt_mul (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=
+-- See Note [decidable namespace]
+protected lemma decidable.one_lt_mul [decidable_rel ((≤) : α → α → Prop)]
+  (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=
 begin
   nontriviality,
-  exact (one_mul (1 : α)) ▸ mul_lt_mul' ha hb zero_le_one (zero_lt_one.trans_le ha)
+  exact (one_mul (1 : α)) ▸ decidable.mul_lt_mul' ha hb zero_le_one (zero_lt_one.trans_le ha)
 end
 
-lemma mul_le_one (ha : a ≤ 1) (hb' : 0 ≤ b) (hb : b ≤ 1) : a * b ≤ 1 :=
-begin rw ← one_mul (1 : α), apply mul_le_mul; {assumption <|> apply zero_le_one} end
+lemma one_lt_mul : 1 ≤ a → 1 < b → 1 < a * b :=
+by classical; exact decidable.one_lt_mul
 
-lemma one_lt_mul_of_le_of_lt (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=
+-- See Note [decidable namespace]
+protected lemma decidable.mul_le_one [decidable_rel ((≤) : α → α → Prop)]
+  (ha : a ≤ 1) (hb' : 0 ≤ b) (hb : b ≤ 1) : a * b ≤ 1 :=
+begin rw ← one_mul (1 : α), apply decidable.mul_le_mul; {assumption <|> apply zero_le_one} end
+
+lemma mul_le_one : a ≤ 1 → 0 ≤ b → b ≤ 1 → a * b ≤ 1 :=
+by classical; exact decidable.mul_le_one
+
+-- See Note [decidable namespace]
+protected lemma decidable.one_lt_mul_of_le_of_lt [decidable_rel ((≤) : α → α → Prop)]
+  (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=
 begin
   nontriviality,
   calc 1 = 1 * 1 : by rw one_mul
-     ... < a * b : mul_lt_mul' ha hb zero_le_one (zero_lt_one.trans_le ha)
+     ... < a * b : decidable.mul_lt_mul' ha hb zero_le_one (zero_lt_one.trans_le ha)
 end
 
-lemma one_lt_mul_of_lt_of_le (ha : 1 < a) (hb : 1 ≤ b) : 1 < a * b :=
+lemma one_lt_mul_of_le_of_lt : 1 ≤ a → 1 < b → 1 < a * b :=
+by classical; exact decidable.one_lt_mul_of_le_of_lt
+
+-- See Note [decidable namespace]
+protected lemma decidable.one_lt_mul_of_lt_of_le [decidable_rel ((≤) : α → α → Prop)]
+  (ha : 1 < a) (hb : 1 ≤ b) : 1 < a * b :=
 begin
   nontriviality,
   calc 1 = 1 * 1 : by rw one_mul
-    ... < a * b : mul_lt_mul ha hb zero_lt_one $ zero_le_one.trans ha.le
+    ... < a * b : decidable.mul_lt_mul ha hb zero_lt_one $ zero_le_one.trans ha.le
 end
 
-lemma mul_le_of_le_one_right (ha : 0 ≤ a) (hb1 : b ≤ 1) : a * b ≤ a :=
-calc a * b ≤ a * 1 : mul_le_mul_of_nonneg_left hb1 ha
+lemma one_lt_mul_of_lt_of_le : 1 < a → 1 ≤ b → 1 < a * b :=
+by classical; exact decidable.one_lt_mul_of_lt_of_le
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_le_of_le_one_right [decidable_rel ((≤) : α → α → Prop)]
+  (ha : 0 ≤ a) (hb1 : b ≤ 1) : a * b ≤ a :=
+calc a * b ≤ a * 1 : decidable.mul_le_mul_of_nonneg_left hb1 ha
 ... = a : mul_one a
 
-lemma mul_le_of_le_one_left (hb : 0 ≤ b) (ha1 : a ≤ 1) : a * b ≤ b :=
-calc a * b ≤ 1 * b : mul_le_mul ha1 le_rfl hb zero_le_one
+lemma mul_le_of_le_one_right : 0 ≤ a → b ≤ 1 → a * b ≤ a :=
+by classical; exact decidable.mul_le_of_le_one_right
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_le_of_le_one_left [decidable_rel ((≤) : α → α → Prop)]
+  (hb : 0 ≤ b) (ha1 : a ≤ 1) : a * b ≤ b :=
+calc a * b ≤ 1 * b : decidable.mul_le_mul ha1 le_rfl hb zero_le_one
 ... = b : one_mul b
 
-lemma mul_lt_one_of_nonneg_of_lt_one_left (ha0 : 0 ≤ a) (ha : a < 1) (hb : b ≤ 1) : a * b < 1 :=
-calc a * b ≤ a : mul_le_of_le_one_right ha0 hb
+lemma mul_le_of_le_one_left : 0 ≤ b → a ≤ 1 → a * b ≤ b :=
+by classical; exact decidable.mul_le_of_le_one_left
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_lt_one_of_nonneg_of_lt_one_left [decidable_rel ((≤) : α → α → Prop)]
+  (ha0 : 0 ≤ a) (ha : a < 1) (hb : b ≤ 1) : a * b < 1 :=
+calc a * b ≤ a : decidable.mul_le_of_le_one_right ha0 hb
 ... < 1 : ha
 
-lemma mul_lt_one_of_nonneg_of_lt_one_right (ha : a ≤ 1) (hb0 : 0 ≤ b) (hb : b < 1) : a * b < 1 :=
-calc a * b ≤ b : mul_le_of_le_one_left hb0 ha
+lemma mul_lt_one_of_nonneg_of_lt_one_left : 0 ≤ a → a < 1 → b ≤ 1 → a * b < 1 :=
+by classical; exact decidable.mul_lt_one_of_nonneg_of_lt_one_left
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_lt_one_of_nonneg_of_lt_one_right [decidable_rel ((≤) : α → α → Prop)]
+  (ha : a ≤ 1) (hb0 : 0 ≤ b) (hb : b < 1) : a * b < 1 :=
+calc a * b ≤ b : decidable.mul_le_of_le_one_left hb0 ha
 ... < 1 : hb
+
+lemma mul_lt_one_of_nonneg_of_lt_one_right : a ≤ 1 → 0 ≤ b → b < 1 → a * b < 1 :=
+by classical; exact decidable.mul_lt_one_of_nonneg_of_lt_one_right
 
 end ordered_semiring
 
@@ -284,15 +417,15 @@ variables [linear_ordered_semiring α] {a b c d : α}
 lemma zero_lt_one' : 0 < (1 : α) := zero_lt_one
 
 lemma lt_of_mul_lt_mul_left (h : c * a < c * b) (hc : 0 ≤ c) : a < b :=
-lt_of_not_ge
+by haveI := @linear_order.decidable_le α _; exact lt_of_not_ge
   (assume h1 : b ≤ a,
-   have h2 : c * b ≤ c * a, from mul_le_mul_of_nonneg_left h1 hc,
+   have h2 : c * b ≤ c * a, from decidable.mul_le_mul_of_nonneg_left h1 hc,
    h2.not_lt h)
 
 lemma lt_of_mul_lt_mul_right (h : a * c < b * c) (hc : 0 ≤ c) : a < b :=
-lt_of_not_ge
+by haveI := @linear_order.decidable_le α _; exact lt_of_not_ge
   (assume h1 : b ≤ a,
-   have h2 : b * c ≤ a * c, from mul_le_mul_of_nonneg_right h1 hc,
+   have h2 : b * c ≤ a * c, from decidable.mul_le_mul_of_nonneg_right h1 hc,
    h2.not_lt h)
 
 lemma le_of_mul_le_mul_left (h : c * a ≤ c * b) (hc : 0 < c) : a ≤ b :=
@@ -310,23 +443,24 @@ le_of_not_gt
 lemma pos_and_pos_or_neg_and_neg_of_mul_pos (hab : 0 < a * b) :
   (0 < a ∧ 0 < b) ∨ (a < 0 ∧ b < 0) :=
 begin
+  haveI := @linear_order.decidable_le α _,
   rcases lt_trichotomy 0 a with (ha|rfl|ha),
-  { refine or.inl ⟨ha, _⟩,
-    contrapose! hab,
-    exact mul_nonpos_of_nonneg_of_nonpos ha.le hab },
+  { refine or.inl ⟨ha, lt_imp_lt_of_le_imp_le (λ hb, _) hab⟩,
+    exact decidable.mul_nonpos_of_nonneg_of_nonpos ha.le hb },
   { rw [zero_mul] at hab, exact hab.false.elim },
-  { refine or.inr ⟨ha, _⟩,
-    contrapose! hab,
-    exact mul_nonpos_of_nonpos_of_nonneg ha.le hab }
+  { refine or.inr ⟨ha, lt_imp_lt_of_le_imp_le (λ hb, _) hab⟩,
+    exact decidable.mul_nonpos_of_nonpos_of_nonneg ha.le hb }
 end
 
 lemma nonneg_and_nonneg_or_nonpos_and_nonpos_of_mul_nnonneg (hab : 0 ≤ a * b) :
     (0 ≤ a ∧ 0 ≤ b) ∨ (a ≤ 0 ∧ b ≤ 0) :=
 begin
-  contrapose! hab,
+  haveI := @linear_order.decidable_le α _,
+  refine decidable.or_iff_not_and_not.2 _,
+  simp only [not_and, not_le], intros ab nab, apply not_lt_of_le hab _,
   rcases lt_trichotomy 0 a with (ha|rfl|ha),
-  exacts [mul_neg_of_pos_of_neg ha (hab.1 ha.le), ((hab.1 le_rfl).asymm (hab.2 le_rfl)).elim,
-    mul_neg_of_neg_of_pos ha (hab.2 ha.le)]
+  exacts [mul_neg_of_pos_of_neg ha (ab ha.le), ((ab le_rfl).asymm (nab le_rfl)).elim,
+    mul_neg_of_neg_of_pos ha (nab ha.le)]
 end
 
 lemma pos_of_mul_pos_left (h : 0 < a * b) (ha : 0 ≤ a) : 0 < b :=
@@ -360,13 +494,16 @@ end
 by simp only [← not_le, inv_of_nonneg]
 
 @[simp] lemma inv_of_le_one [invertible a] (h : 1 ≤ a) : ⅟a ≤ 1 :=
-mul_inv_of_self a ▸ le_mul_of_one_le_left (inv_of_nonneg.2 $ zero_le_one.trans h) h
+by haveI := @linear_order.decidable_le α _; exact
+mul_inv_of_self a ▸ decidable.le_mul_of_one_le_left (inv_of_nonneg.2 $ zero_le_one.trans h) h
 
 lemma neg_of_mul_neg_left (h : a * b < 0) (h1 : 0 ≤ a) : b < 0 :=
-lt_of_not_ge (assume h2 : b ≥ 0, (mul_nonneg h1 h2).not_lt h)
+by haveI := @linear_order.decidable_le α _; exact
+lt_of_not_ge (assume h2 : b ≥ 0, (decidable.mul_nonneg h1 h2).not_lt h)
 
 lemma neg_of_mul_neg_right (h : a * b < 0) (h1 : 0 ≤ b) : a < 0 :=
-lt_of_not_ge (assume h2 : a ≥ 0, (mul_nonneg h2 h1).not_lt h)
+by haveI := @linear_order.decidable_le α _; exact
+lt_of_not_ge (assume h2 : a ≥ 0, (decidable.mul_nonneg h2 h1).not_lt h)
 
 lemma nonpos_of_mul_nonpos_left (h : a * b ≤ 0) (h1 : 0 < a) : b ≤ 0 :=
 le_of_not_gt (assume h2 : b > 0, (mul_pos h1 h2).not_le h)
@@ -375,17 +512,21 @@ lemma nonpos_of_mul_nonpos_right (h : a * b ≤ 0) (h1 : 0 < b) : a ≤ 0 :=
 le_of_not_gt (assume h2 : a > 0, (mul_pos h2 h1).not_le h)
 
 @[simp] lemma mul_le_mul_left (h : 0 < c) : c * a ≤ c * b ↔ a ≤ b :=
-⟨λ h', le_of_mul_le_mul_left h' h, λ h', mul_le_mul_of_nonneg_left h' h.le⟩
+by haveI := @linear_order.decidable_le α _; exact
+⟨λ h', le_of_mul_le_mul_left h' h, λ h', decidable.mul_le_mul_of_nonneg_left h' h.le⟩
 
 @[simp] lemma mul_le_mul_right (h : 0 < c) : a * c ≤ b * c ↔ a ≤ b :=
-⟨λ h', le_of_mul_le_mul_right h' h, λ h', mul_le_mul_of_nonneg_right h' h.le⟩
+by haveI := @linear_order.decidable_le α _; exact
+⟨λ h', le_of_mul_le_mul_right h' h, λ h', decidable.mul_le_mul_of_nonneg_right h' h.le⟩
 
 @[simp] lemma mul_lt_mul_left (h : 0 < c) : c * a < c * b ↔ a < b :=
-⟨lt_imp_lt_of_le_imp_le $ λ h', mul_le_mul_of_nonneg_left h' h.le,
+by haveI := @linear_order.decidable_le α _; exact
+⟨lt_imp_lt_of_le_imp_le $ λ h', decidable.mul_le_mul_of_nonneg_left h' h.le,
  λ h', mul_lt_mul_of_pos_left h' h⟩
 
 @[simp] lemma mul_lt_mul_right (h : 0 < c) : a * c < b * c ↔ a < b :=
-⟨lt_imp_lt_of_le_imp_le $ λ h', mul_le_mul_of_nonneg_right h' h.le,
+by haveI := @linear_order.decidable_le α _; exact
+⟨lt_imp_lt_of_le_imp_le $ λ h', decidable.mul_le_mul_of_nonneg_right h' h.le,
  λ h', mul_lt_mul_of_pos_right h' h⟩
 
 @[simp] lemma zero_le_mul_left (h : 0 < c) : 0 ≤ c * b ↔ 0 ≤ b :=
@@ -470,8 +611,9 @@ lemma lt_mul_iff_one_lt_right (hb : 0 < b) : b < b * a ↔ 1 < a :=
 suffices b * 1 < b * a ↔ 1 < a, by rwa mul_one at this,
 mul_lt_mul_left hb
 
-theorem mul_nonneg_iff_right_nonneg_of_pos (h : 0 < a) : 0 ≤ b * a ↔ 0 ≤ b :=
-⟨assume : 0 ≤ b * a, nonneg_of_mul_nonneg_right this h, assume : 0 ≤ b, mul_nonneg this h.le⟩
+theorem mul_nonneg_iff_right_nonneg_of_pos (ha : 0 < a) : 0 ≤ b * a ↔ 0 ≤ b :=
+by haveI := @linear_order.decidable_le α _; exact
+⟨λ h, nonneg_of_mul_nonneg_right h ha, λ h, decidable.mul_nonneg h ha.le⟩
 
 lemma mul_le_iff_le_one_left (hb : 0 < b) : a * b ≤ b ↔ a ≤ 1 :=
 ⟨ λ h, le_of_not_lt (mt (lt_mul_iff_one_lt_left hb).2 h.not_lt),
@@ -496,10 +638,12 @@ lemma nonpos_of_mul_nonneg_right (h : 0 ≤ a * b) (ha : a < 0) : b ≤ 0 :=
 le_of_not_gt (λ hb, absurd h (mul_neg_of_neg_of_pos ha hb).not_le)
 
 lemma neg_of_mul_pos_left (h : 0 < a * b) (hb : b ≤ 0) : a < 0 :=
-lt_of_not_ge (λ ha, absurd h (mul_nonpos_of_nonneg_of_nonpos ha hb).not_lt)
+by haveI := @linear_order.decidable_le α _; exact
+lt_of_not_ge (λ ha, absurd h (decidable.mul_nonpos_of_nonneg_of_nonpos ha hb).not_lt)
 
 lemma neg_of_mul_pos_right (h : 0 < a * b) (ha : a ≤ 0) : b < 0 :=
-lt_of_not_ge (λ hb, absurd h (mul_nonpos_of_nonpos_of_nonneg ha hb).not_lt)
+by haveI := @linear_order.decidable_le α _; exact
+lt_of_not_ge (λ hb, absurd h (decidable.mul_nonpos_of_nonpos_of_nonneg ha hb).not_lt)
 
 @[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_semiring.to_no_top_order {α : Type*} [linear_ordered_semiring α] :
@@ -522,10 +666,12 @@ section mono
 variables {β : Type*} [linear_ordered_semiring α] [preorder β] {f g : β → α} {a : α}
 
 lemma monotone_mul_left_of_nonneg (ha : 0 ≤ a) : monotone (λ x, a*x) :=
-assume b c b_le_c, mul_le_mul_of_nonneg_left b_le_c ha
+by haveI := @linear_order.decidable_le α _; exact
+assume b c b_le_c, decidable.mul_le_mul_of_nonneg_left b_le_c ha
 
 lemma monotone_mul_right_of_nonneg (ha : 0 ≤ a) : monotone (λ x, x*a) :=
-assume b c b_le_c, mul_le_mul_of_nonneg_right b_le_c ha
+by haveI := @linear_order.decidable_le α _; exact
+assume b c b_le_c, decidable.mul_le_mul_of_nonneg_right b_le_c ha
 
 lemma monotone.mul_const (hf : monotone f) (ha : 0 ≤ a) :
   monotone (λ x, (f x) * a) :=
@@ -537,7 +683,8 @@ lemma monotone.const_mul (hf : monotone f) (ha : 0 ≤ a) :
 
 lemma monotone.mul (hf : monotone f) (hg : monotone g) (hf0 : ∀ x, 0 ≤ f x) (hg0 : ∀ x, 0 ≤ g x) :
   monotone (λ x, f x * g x) :=
-λ x y h, mul_le_mul (hf h) (hg h) (hg0 x) (hf0 y)
+by haveI := @linear_order.decidable_le α _; exact
+λ x y h, decidable.mul_le_mul (hf h) (hg h) (hg0 x) (hf0 y)
 
 lemma strict_mono_mul_left_of_pos (ha : 0 < a) : strict_mono (λ x, a * x) :=
 assume b c b_lt_c, (mul_lt_mul_left ha).2 b_lt_c
@@ -556,28 +703,25 @@ lemma strict_mono.const_mul (hf : strict_mono f) (ha : 0 < a) :
 lemma strict_mono.mul_monotone (hf : strict_mono f) (hg : monotone g) (hf0 : ∀ x, 0 ≤ f x)
   (hg0 : ∀ x, 0 < g x) :
   strict_mono (λ x, f x * g x) :=
-λ x y h, mul_lt_mul (hf h) (hg h.le) (hg0 x) (hf0 y)
+by haveI := @linear_order.decidable_le α _; exact
+λ x y h, decidable.mul_lt_mul (hf h) (hg h.le) (hg0 x) (hf0 y)
 
 lemma monotone.mul_strict_mono (hf : monotone f) (hg : strict_mono g) (hf0 : ∀ x, 0 < f x)
   (hg0 : ∀ x, 0 ≤ g x) :
   strict_mono (λ x, f x * g x) :=
-λ x y h, mul_lt_mul' (hf h.le) (hg h) (hg0 x) (hf0 y)
+by haveI := @linear_order.decidable_le α _; exact
+λ x y h, decidable.mul_lt_mul' (hf h.le) (hg h) (hg0 x) (hf0 y)
 
 lemma strict_mono.mul (hf : strict_mono f) (hg : strict_mono g) (hf0 : ∀ x, 0 ≤ f x)
   (hg0 : ∀ x, 0 ≤ g x) :
   strict_mono (λ x, f x * g x) :=
-λ x y h, mul_lt_mul'' (hf h) (hg h) (hf0 x) (hg0 x)
+by haveI := @linear_order.decidable_le α _; exact
+λ x y h, decidable.mul_lt_mul'' (hf h) (hg h) (hf0 x) (hg0 x)
 
 end mono
 
 section linear_ordered_semiring
 variables [linear_ordered_semiring α] {a b c : α}
-
-@[simp] lemma decidable.mul_le_mul_left (h : 0 < c) : c * a ≤ c * b ↔ a ≤ b :=
-decidable.le_iff_le_iff_lt_iff_lt.2 $ mul_lt_mul_left h
-
-@[simp] lemma decidable.mul_le_mul_right (h : 0 < c) : a * c ≤ b * c ↔ a ≤ b :=
-decidable.le_iff_le_iff_lt_iff_lt.2 $ mul_lt_mul_right h
 
 lemma mul_max_of_nonneg (b c : α) (ha : 0 ≤ a) : a * max b c = max (a * b) (a * c) :=
 (monotone_mul_left_of_nonneg ha).map_max
@@ -603,24 +747,39 @@ class ordered_ring (α : Type u) extends ring α, ordered_add_comm_group α :=
 section ordered_ring
 variables [ordered_ring α] {a b c : α}
 
-lemma ordered_ring.mul_nonneg (a b : α) (h₁ : 0 ≤ a) (h₂ : 0 ≤ b) : 0 ≤ a * b :=
+-- See Note [decidable namespace]
+protected lemma decidable.ordered_ring.mul_nonneg [decidable_rel ((≤) : α → α → Prop)]
+  {a b : α} (h₁ : 0 ≤ a) (h₂ : 0 ≤ b) : 0 ≤ a * b :=
 begin
-  cases classical.em (a ≤ 0), { simp [le_antisymm h h₁] },
-  cases classical.em (b ≤ 0), { simp [le_antisymm h_1 h₂] },
-  exact (le_not_le_of_lt (ordered_ring.mul_pos a b (h₁.lt_of_not_le h) (h₂.lt_of_not_le h_1))).left,
+  by_cases ha : a ≤ 0, { simp [le_antisymm ha h₁] },
+  by_cases hb : b ≤ 0, { simp [le_antisymm hb h₂] },
+  exact (le_not_le_of_lt (ordered_ring.mul_pos a b (h₁.lt_of_not_le ha) (h₂.lt_of_not_le hb))).1,
 end
 
-lemma ordered_ring.mul_le_mul_of_nonneg_left (h₁ : a ≤ b) (h₂ : 0 ≤ c) : c * a ≤ c * b :=
+lemma ordered_ring.mul_nonneg : 0 ≤ a → 0 ≤ b → 0 ≤ a * b :=
+by classical; exact decidable.ordered_ring.mul_nonneg
+
+-- See Note [decidable namespace]
+protected lemma decidable.ordered_ring.mul_le_mul_of_nonneg_left
+  [decidable_rel ((≤) : α → α → Prop)] (h₁ : a ≤ b) (h₂ : 0 ≤ c) : c * a ≤ c * b :=
 begin
   rw [← sub_nonneg, ← mul_sub],
-  exact ordered_ring.mul_nonneg c (b - a) h₂ (sub_nonneg.2 h₁),
+  exact decidable.ordered_ring.mul_nonneg h₂ (sub_nonneg.2 h₁),
 end
 
-lemma ordered_ring.mul_le_mul_of_nonneg_right (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≤ b * c :=
+lemma ordered_ring.mul_le_mul_of_nonneg_left : a ≤ b → 0 ≤ c → c * a ≤ c * b :=
+by classical; exact decidable.ordered_ring.mul_le_mul_of_nonneg_left
+
+-- See Note [decidable namespace]
+protected lemma decidable.ordered_ring.mul_le_mul_of_nonneg_right
+  [decidable_rel ((≤) : α → α → Prop)] (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≤ b * c :=
 begin
   rw [← sub_nonneg, ← sub_mul],
-  exact ordered_ring.mul_nonneg _ _ (sub_nonneg.2 h₁) h₂,
+  exact decidable.ordered_ring.mul_nonneg (sub_nonneg.2 h₁) h₂,
 end
+
+lemma ordered_ring.mul_le_mul_of_nonneg_right : a ≤ b → 0 ≤ c → a * c ≤ b * c :=
+by classical; exact decidable.ordered_ring.mul_le_mul_of_nonneg_right
 
 lemma ordered_ring.mul_lt_mul_of_pos_left (h₁ : a < b) (h₂ : 0 < c) : c * a < c * b :=
 begin
@@ -644,21 +803,36 @@ instance ordered_ring.to_ordered_semiring : ordered_semiring α :=
   mul_lt_mul_of_pos_right    := @ordered_ring.mul_lt_mul_of_pos_right α _,
   ..‹ordered_ring α› }
 
-lemma mul_le_mul_of_nonpos_left {a b c : α} (h : b ≤ a) (hc : c ≤ 0) : c * a ≤ c * b :=
+-- See Note [decidable namespace]
+protected lemma decidable.mul_le_mul_of_nonpos_left [decidable_rel ((≤) : α → α → Prop)]
+  {a b c : α} (h : b ≤ a) (hc : c ≤ 0) : c * a ≤ c * b :=
 have -c ≥ 0,              from neg_nonneg_of_nonpos hc,
-have -c * b ≤ -c * a,     from mul_le_mul_of_nonneg_left h this,
+have -c * b ≤ -c * a,     from decidable.mul_le_mul_of_nonneg_left h this,
 have -(c * b) ≤ -(c * a), by rwa [← neg_mul_eq_neg_mul, ← neg_mul_eq_neg_mul] at this,
 le_of_neg_le_neg this
 
-lemma mul_le_mul_of_nonpos_right {a b c : α} (h : b ≤ a) (hc : c ≤ 0) : a * c ≤ b * c :=
+lemma mul_le_mul_of_nonpos_left {a b c : α} : b ≤ a → c ≤ 0 → c * a ≤ c * b :=
+by classical; exact decidable.mul_le_mul_of_nonpos_left
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_le_mul_of_nonpos_right [decidable_rel ((≤) : α → α → Prop)]
+  {a b c : α} (h : b ≤ a) (hc : c ≤ 0) : a * c ≤ b * c :=
 have -c ≥ 0,              from neg_nonneg_of_nonpos hc,
-have b * -c ≤ a * -c,     from mul_le_mul_of_nonneg_right h this,
+have b * -c ≤ a * -c,     from decidable.mul_le_mul_of_nonneg_right h this,
 have -(b * c) ≤ -(a * c), by rwa [← neg_mul_eq_mul_neg, ← neg_mul_eq_mul_neg] at this,
 le_of_neg_le_neg this
 
-lemma mul_nonneg_of_nonpos_of_nonpos {a b : α} (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a * b :=
-have 0 * b ≤ a * b, from mul_le_mul_of_nonpos_right ha hb,
+lemma mul_le_mul_of_nonpos_right {a b c : α} : b ≤ a → c ≤ 0 → a * c ≤ b * c :=
+by classical; exact decidable.mul_le_mul_of_nonpos_right
+
+-- See Note [decidable namespace]
+protected lemma decidable.mul_nonneg_of_nonpos_of_nonpos [decidable_rel ((≤) : α → α → Prop)]
+  {a b : α} (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a * b :=
+have 0 * b ≤ a * b, from decidable.mul_le_mul_of_nonpos_right ha hb,
 by rwa zero_mul at this
+
+lemma mul_nonneg_of_nonpos_of_nonpos {a b : α} : a ≤ 0 → b ≤ 0 → 0 ≤ a * b :=
+by classical; exact decidable.mul_nonneg_of_nonpos_of_nonpos
 
 lemma mul_lt_mul_of_neg_left {a b c : α} (h : b < a) (hc : c < 0) : c * a < c * b :=
 have -c > 0,              from neg_pos_of_neg hc,
@@ -738,8 +912,8 @@ instance linear_ordered_ring.to_domain : domain α :=
 { eq_zero_or_eq_zero_of_mul_eq_zero :=
     begin
       intros a b hab,
-      contrapose! hab,
-      cases (lt_or_gt_of_ne hab.1) with ha ha; cases (lt_or_gt_of_ne hab.2) with hb hb,
+      refine decidable.or_iff_not_and_not.2 (λ h, _), revert hab,
+      cases lt_or_gt_of_ne h.1 with ha ha; cases lt_or_gt_of_ne h.2 with hb hb,
       exacts [(mul_pos_of_neg_of_neg ha hb).ne.symm, (mul_neg_of_neg_of_pos ha hb).ne,
         (mul_neg_of_pos_of_neg ha hb).ne, (mul_pos ha hb).ne.symm]
     end,
@@ -750,9 +924,11 @@ instance linear_ordered_ring.to_domain : domain α :=
 
 lemma abs_mul (a b : α) : abs (a * b) = abs a * abs b :=
 begin
-  rw [abs_eq (mul_nonneg (abs_nonneg a) (abs_nonneg b))],
+  haveI := @linear_order.decidable_le α _,
+  rw [abs_eq (decidable.mul_nonneg (abs_nonneg a) (abs_nonneg b))],
   cases le_total a 0 with ha ha; cases le_total b 0 with hb hb;
-    simp [abs_of_nonpos, abs_of_nonneg, *]
+    simp only [abs_of_nonpos, abs_of_nonneg, true_or, or_true, eq_self_iff_true,
+      neg_mul_eq_neg_mul_symm, mul_neg_eq_neg_mul_symm, neg_neg, *]
 end
 
 /-- `abs` as a `monoid_with_zero_hom`. -/
@@ -772,8 +948,9 @@ lemma mul_neg_iff : a * b < 0 ↔ 0 < a ∧ b < 0 ∨ a < 0 ∧ 0 < b :=
 by rw [← neg_pos, neg_mul_eq_mul_neg, mul_pos_iff, neg_pos, neg_lt_zero]
 
 lemma mul_nonneg_iff : 0 ≤ a * b ↔ 0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 :=
+by haveI := @linear_order.decidable_le α _; exact
 ⟨nonneg_and_nonneg_or_nonpos_and_nonpos_of_mul_nnonneg,
-  λ h, h.elim (and_imp.2 mul_nonneg) (and_imp.2 mul_nonneg_of_nonpos_of_nonpos)⟩
+  λ h, h.elim (and_imp.2 decidable.mul_nonneg) (and_imp.2 decidable.mul_nonneg_of_nonpos_of_nonpos)⟩
 
 lemma mul_nonpos_iff : a * b ≤ 0 ↔ 0 ≤ a ∧ b ≤ 0 ∨ a ≤ 0 ∧ 0 ≤ b :=
 by rw [← neg_nonneg, neg_mul_eq_mul_neg, mul_nonneg_iff, neg_nonneg, neg_nonpos]
@@ -812,33 +989,39 @@ lt_of_mul_lt_mul_left h3 nhc
 
 lemma neg_one_lt_zero : -1 < (0:α) := neg_lt_zero.2 zero_lt_one
 
-lemma le_of_mul_le_of_one_le {a b c : α} (h : a * c ≤ b) (hb : 0 ≤ b) (hc : 1 ≤ c) :
-  a ≤ b :=
+lemma le_of_mul_le_of_one_le {a b c : α} (h : a * c ≤ b) (hb : 0 ≤ b) (hc : 1 ≤ c) : a ≤ b :=
+by haveI := @linear_order.decidable_le α _; exact
 have h' : a * c ≤ b * c, from calc
      a * c ≤ b : h
        ... = b * 1 : by rewrite mul_one
-       ... ≤ b * c : mul_le_mul_of_nonneg_left hc hb,
+       ... ≤ b * c : decidable.mul_le_mul_of_nonneg_left hc hb,
 le_of_mul_le_mul_right h' (zero_lt_one.trans_le hc)
 
 lemma nonneg_le_nonneg_of_sq_le_sq {a b : α} (hb : 0 ≤ b) (h : a * a ≤ b * b) : a ≤ b :=
-le_of_not_gt (λhab, (mul_self_lt_mul_self hb hab).not_le h)
+by haveI := @linear_order.decidable_le α _; exact
+le_of_not_gt (λhab, (decidable.mul_self_lt_mul_self hb hab).not_le h)
 
 lemma mul_self_le_mul_self_iff {a b : α} (h1 : 0 ≤ a) (h2 : 0 ≤ b) : a ≤ b ↔ a * a ≤ b * b :=
-⟨mul_self_le_mul_self h1, nonneg_le_nonneg_of_sq_le_sq h2⟩
+by haveI := @linear_order.decidable_le α _; exact
+⟨decidable.mul_self_le_mul_self h1, nonneg_le_nonneg_of_sq_le_sq h2⟩
 
 lemma mul_self_lt_mul_self_iff {a b : α} (h1 : 0 ≤ a) (h2 : 0 ≤ b) : a < b ↔ a * a < b * b :=
-((@strict_mono_incr_on_mul_self α _).lt_iff_lt h1 h2).symm
+by haveI := @linear_order.decidable_le α _; exact
+((@decidable.strict_mono_incr_on_mul_self α _ _).lt_iff_lt h1 h2).symm
 
 lemma mul_self_inj {a b : α} (h1 : 0 ≤ a) (h2 : 0 ≤ b) : a * a = b * b ↔ a = b :=
-(@strict_mono_incr_on_mul_self α _).inj_on.eq_iff h1 h2
+by haveI := @linear_order.decidable_le α _; exact
+(@decidable.strict_mono_incr_on_mul_self α _ _).inj_on.eq_iff h1 h2
 
 @[simp] lemma mul_le_mul_left_of_neg {a b c : α} (h : c < 0) : c * a ≤ c * b ↔ b ≤ a :=
+by haveI := @linear_order.decidable_le α _; exact
 ⟨le_imp_le_of_lt_imp_lt $ λ h', mul_lt_mul_of_neg_left h' h,
-  λ h', mul_le_mul_of_nonpos_left h' h.le⟩
+  λ h', decidable.mul_le_mul_of_nonpos_left h' h.le⟩
 
 @[simp] lemma mul_le_mul_right_of_neg {a b c : α} (h : c < 0) : a * c ≤ b * c ↔ b ≤ a :=
+by haveI := @linear_order.decidable_le α _; exact
 ⟨le_imp_le_of_lt_imp_lt $ λ h', mul_lt_mul_of_neg_right h' h,
-  λ h', mul_le_mul_of_nonpos_right h' h.le⟩
+  λ h', decidable.mul_le_mul_of_nonpos_right h' h.le⟩
 
 @[simp] lemma mul_lt_mul_left_of_neg {a b c : α} (h : c < 0) : c * a < c * b ↔ b < a :=
 lt_iff_lt_of_le_iff_le (mul_le_mul_left_of_neg h)
@@ -855,8 +1038,9 @@ by rcases lt_trichotomy a 0 with h|h|h;
 
 lemma mul_self_le_mul_self_of_le_of_neg_le {x y : α} (h₁ : x ≤ y) (h₂ : -x ≤ y) : x * x ≤ y * y :=
 begin
+  haveI := @linear_order.decidable_le α _,
   rw [← abs_mul_abs_self x],
-  exact mul_self_le_mul_self (abs_nonneg x) (abs_le.2 ⟨neg_le.2 h₂, h₁⟩)
+  exact decidable.mul_self_le_mul_self (abs_nonneg x) (abs_le.2 ⟨neg_le.2 h₂, h₁⟩)
 end
 
 lemma nonneg_of_mul_nonpos_left {a b : α} (h : a * b ≤ 0) (hb : b < 0) : 0 ≤ a :=
@@ -866,10 +1050,12 @@ lemma nonneg_of_mul_nonpos_right {a b : α} (h : a * b ≤ 0) (ha : a < 0) : 0 �
 le_of_not_gt (λ hb, absurd h (mul_pos_of_neg_of_neg ha hb).not_le)
 
 lemma pos_of_mul_neg_left {a b : α} (h : a * b < 0) (hb : b ≤ 0) : 0 < a :=
-lt_of_not_ge (λ ha, absurd h (mul_nonneg_of_nonpos_of_nonpos ha hb).not_lt)
+by haveI := @linear_order.decidable_le α _; exact
+lt_of_not_ge (λ ha, absurd h (decidable.mul_nonneg_of_nonpos_of_nonpos ha hb).not_lt)
 
 lemma pos_of_mul_neg_right {a b : α} (h : a * b < 0) (ha : a ≤ 0) : 0 < b :=
-lt_of_not_ge (λ hb, absurd h (mul_nonneg_of_nonpos_of_nonpos ha hb).not_lt)
+by haveI := @linear_order.decidable_le α _; exact
+lt_of_not_ge (λ hb, absurd h (decidable.mul_nonneg_of_nonpos_of_nonpos ha hb).not_lt)
 
 /-- The sum of two squares is zero iff both elements are zero. -/
 lemma mul_self_add_mul_self_eq_zero {x y : α} : x * x + y * y = 0 ↔ x = 0 ∧ y = 0 :=
@@ -959,10 +1145,11 @@ variables [linear_ordered_comm_ring α] {a b c d : α}
 
 lemma max_mul_mul_le_max_mul_max (b c : α) (ha : 0 ≤ a) (hd: 0 ≤ d) :
   max (a * b) (d * c) ≤ max a c * max d b :=
-have ba : b * a ≤ max d b * max c a,
-  from mul_le_mul (le_max_right d b) (le_max_right c a) ha (le_trans hd (le_max_left d b)),
-have cd : c * d ≤ max a c * max b d,
-  from mul_le_mul (le_max_right a c) (le_max_right b d) hd (le_trans ha (le_max_left a c)),
+by haveI := @linear_order.decidable_le α _; exact
+have ba : b * a ≤ max d b * max c a, from
+  decidable.mul_le_mul (le_max_right d b) (le_max_right c a) ha (le_trans hd (le_max_left d b)),
+have cd : c * d ≤ max a c * max b d, from
+  decidable.mul_le_mul (le_max_right a c) (le_max_right b d) hd (le_trans ha (le_max_left a c)),
 max_le
   (by simpa [mul_comm, max_comm] using ba)
   (by simpa [mul_comm, max_comm] using cd)
@@ -970,7 +1157,8 @@ max_le
 lemma abs_sub_sq (a b : α) : abs (a - b) * abs (a - b) = a * a + b * b - (1 + 1) * a * b :=
 begin
   rw abs_mul_abs_self,
-  simp [left_distrib, right_distrib, add_assoc, add_comm, add_left_comm, mul_comm, sub_eq_add_neg],
+  simp only [mul_add, add_comm, add_left_comm, mul_comm, sub_eq_add_neg,
+    mul_one, mul_neg_eq_neg_mul_symm, neg_add_rev, neg_neg],
 end
 
 /-- Pullback a `linear_ordered_comm_ring` under an injective map. -/
@@ -999,6 +1187,7 @@ class linear_nonneg_ring (α : Type*) extends domain α, nonneg_add_comm_group �
 (one_pos : pos 1)
 (mul_nonneg : ∀ {a b}, nonneg a → nonneg b → nonneg (a * b))
 (nonneg_total : ∀ a, nonneg a ∨ nonneg (-a))
+[dec_nonneg : decidable_pred nonneg]
 
 namespace nonneg_ring
 open nonneg_add_comm_group
@@ -1006,7 +1195,7 @@ variable [nonneg_ring α]
 
 /-- `to_linear_nonneg_ring` shows that a `nonneg_ring` with a total order is a `domain`,
 hence a `linear_nonneg_ring`. -/
-def to_linear_nonneg_ring [nontrivial α]
+def to_linear_nonneg_ring [nontrivial α] [decidable_pred (@nonneg α _)]
   (nonneg_total : ∀ a : α, nonneg a ∨ nonneg (-a))
   : linear_nonneg_ring α :=
 { one_pos := (pos_iff 1).mpr ⟨one_nonneg, λ h, zero_ne_one (nonneg_antisymm one_nonneg h).symm⟩,
@@ -1018,9 +1207,9 @@ def to_linear_nonneg_ring [nontrivial α]
     suffices ∀ {a b : α}, nonneg a → nonneg b → a * b = 0 → a = 0 ∨ b = 0,
     from λ a b na, (nonneg_total b).elim (this na)
       (λ nb, by simpa using this na nb),
-    λ a b na nb z, classical.by_cases
+    λ a b na nb z, decidable.by_cases
       (λ nna : nonneg (-a), or.inl (nonneg_antisymm na nna))
-      (λ pa, classical.by_cases
+      (λ pa, decidable.by_cases
         (λ nnb : nonneg (-b), or.inr (nonneg_antisymm nb nnb))
         (λ pb, absurd z $ ne_of_gt $ pos_def.1 $ mul_pos
           ((pos_iff _).2 ⟨na, pa⟩)

--- a/src/computability/halting.lean
+++ b/src/computability/halting.lean
@@ -166,7 +166,7 @@ theorem to_re {p : α → Prop} (hp : computable_pred p) : re_pred p :=
 begin
   rcases computable_iff.1 hp with ⟨f, hf, rfl⟩,
   unfold re_pred,
-  refine (partrec.cond hf (partrec.const' (roption.some ())) partrec.none).of_eq
+  refine (partrec.cond hf (decidable.partrec.const' (roption.some ())) partrec.none).of_eq
     (λ n, roption.ext $ λ a, _),
   cases a, cases f n; simp
 end
@@ -190,7 +190,7 @@ end
 theorem rice₂ (C : set code)
   (H : ∀ cf cg, eval cf = eval cg → (cf ∈ C ↔ cg ∈ C)) :
   computable_pred (λ c, c ∈ C) ↔ C = ∅ ∨ C = set.univ :=
-by haveI := classical.dec; exact
+by classical; exact
 have hC : ∀ f, f ∈ C ↔ eval f ∈ eval '' C,
 from λ f, ⟨set.mem_image_of_mem _, λ ⟨g, hg, e⟩, (H _ _ e).1 hg⟩,
 ⟨λ h, or_iff_not_imp_left.2 $ λ C0,

--- a/src/computability/partrec.lean
+++ b/src/computability/partrec.lean
@@ -642,8 +642,7 @@ nat_cases_right (encode_iff.2 ho) hf.part $
     (hg.comp (fst.comp fst) snd).to₂,
 this.of_eq $ λ a, by cases o a with b; simp [encodek]
 
-theorem sum_cases_right
-  {f : α → β ⊕ γ} {g : α → β → σ} {h : α → γ →. σ}
+theorem sum_cases_right {f : α → β ⊕ γ} {g : α → β → σ} {h : α → γ →. σ}
   (hf : computable f) (hg : computable₂ g) (hh : partrec₂ h) :
   @partrec _ σ _ _ (λ a, sum.cases_on (f a) (λ b, some (g a b)) (h a)) :=
 have partrec (λ a, (option.cases_on
@@ -657,15 +656,14 @@ option_cases_right
   (option_some_iff.2 hh),
 option_some_iff.1 $ this.of_eq $ λ a, by cases f a; simp
 
-theorem sum_cases_left
-  {f : α → β ⊕ γ} {g : α → β →. σ} {h : α → γ → σ}
+theorem sum_cases_left {f : α → β ⊕ γ} {g : α → β →. σ} {h : α → γ → σ}
   (hf : computable f) (hg : partrec₂ g) (hh : computable₂ h) :
   @partrec _ σ _ _ (λ a, sum.cases_on (f a) (g a) (λ c, some (h a c))) :=
 (sum_cases_right (sum_cases hf
   (sum_inr.comp snd).to₂ (sum_inl.comp snd).to₂) hh hg).of_eq $
 λ a, by cases f a; simp
 
-lemma fix_aux (f : α →. σ ⊕ α) (a : α) (b : σ) :
+lemma fix_aux {α σ} (f : α →. σ ⊕ α) (a : α) (b : σ) :
   let F : α → ℕ →. σ ⊕ α := λ a n,
     n.elim (some (sum.inr a)) $ λ y IH, IH.bind $ λ s,
     sum.cases_on s (λ _, roption.some s) f in
@@ -706,8 +704,7 @@ begin
       { simp [F], exact ⟨_, hk, am₃⟩ } } }
 end
 
-theorem fix
-  {f : α →. σ ⊕ α} (hf : partrec f) : partrec (pfun.fix f) :=
+theorem fix {f : α →. σ ⊕ α} (hf : partrec f) : partrec (pfun.fix f) :=
 let F : α → ℕ →. σ ⊕ α := λ a n,
   n.elim (some (sum.inr a)) $ λ y IH, IH.bind $ λ s,
   sum.cases_on s (λ _, roption.some s) f in

--- a/src/computability/partrec.lean
+++ b/src/computability/partrec.lean
@@ -665,9 +665,7 @@ theorem sum_cases_left
   (sum_inr.comp snd).to₂ (sum_inl.comp snd).to₂) hh hg).of_eq $
 λ a, by cases f a; simp
 
-lemma fix_aux
-  {f : α →. σ ⊕ α} (hf : partrec f)
-  (a : α) (b : σ) :
+lemma fix_aux (f : α →. σ ⊕ α) (a : α) (b : σ) :
   let F : α → ℕ →. σ ⊕ α := λ a n,
     n.elim (some (sum.inr a)) $ λ y IH, IH.bind $ λ s,
     sum.cases_on s (λ _, roption.some s) f in
@@ -724,6 +722,6 @@ have hp : partrec₂ p := hF.map ((sum_cases computable.id
   (const tt).to₂ (const ff).to₂).comp snd).to₂,
 (hp.rfind.bind (hF.bind
   (sum_cases_right snd snd.to₂ none.to₂).to₂).to₂).of_eq $
-λ a, ext $ λ b, by simp; apply fix_aux hf
+λ a, ext $ λ b, by simp; apply fix_aux f
 
 end partrec

--- a/src/computability/partrec.lean
+++ b/src/computability/partrec.lean
@@ -22,6 +22,8 @@ using the `roption` monad, and there is an additional operation, called
 
 open encodable denumerable roption
 
+local attribute [-simp] not_forall
+
 namespace nat
 
 section rfind
@@ -56,7 +58,7 @@ from this 0 (λ n, (nat.not_lt_zero _).elim),
   cases e : (p m).get pm,
   { suffices,
     exact IH _ ⟨rfl, this⟩ (λ n h, this _ (le_of_lt_succ h)),
-    intros n h, cases decidable.lt_or_eq_of_le h with h h,
+    intros n h, cases h.lt_or_eq_dec with h h,
     { exact al _ h },
     { rw h, exact ⟨_, e⟩ } },
   { exact ⟨m, ⟨_, e⟩, al⟩ }
@@ -81,7 +83,7 @@ iff.rfl
 theorem rfind_dom' {p : ℕ →. bool} :
   (rfind p).dom ↔ ∃ n, tt ∈ p n ∧ ∀ {m : ℕ}, m ≤ n → (p m).dom :=
 exists_congr $ λ n, and_congr_right $ λ pn,
-⟨λ H m h, (eq_or_lt_of_le h).elim (λ e, e.symm ▸ pn.fst) (H _),
+⟨λ H m h, (decidable.eq_or_lt_of_le h).elim (λ e, e.symm ▸ pn.fst) (H _),
  λ H m h, H (le_of_lt h)⟩
 
 @[simp] theorem mem_rfind {p : ℕ →. bool} {n : ℕ} :
@@ -340,9 +342,11 @@ nat.partrec.none.of_eq $ λ n, by cases decode α n; simp
 
 protected theorem some : partrec (@roption.some α) := computable.id
 
-theorem const' (s : roption σ) : partrec (λ a : α, s) :=
-by haveI := classical.dec s.dom; exact
+theorem _root_.decidable.partrec.const' (s : roption σ) [decidable s.dom] : partrec (λ a : α, s) :=
 (of_option (const (to_option s))).of_eq (λ a, of_to_option s)
+
+theorem const' (s : roption σ) : partrec (λ a : α, s) :=
+by haveI := classical.dec s.dom; exact decidable.partrec.const' s
 
 protected theorem bind {f : α →. β} {g : α → β →. σ}
   (hf : partrec f) (hg : partrec₂ g) : partrec (λ a, (f a).bind (g a)) :=
@@ -661,7 +665,7 @@ theorem sum_cases_left
   (sum_inr.comp snd).to₂ (sum_inl.comp snd).to₂) hh hg).of_eq $
 λ a, by cases f a; simp
 
-private lemma fix_aux
+lemma fix_aux
   {f : α →. σ ⊕ α} (hf : partrec f)
   (a : α) (b : σ) :
   let F : α → ℕ →. σ ⊕ α := λ a n,
@@ -698,7 +702,7 @@ begin
       { rwa le_antisymm (nat.le_of_lt_succ mk) km } },
     { rcases IH _ fa₃ am₃ k.succ _ with ⟨n, hn₁, hn₂⟩,
       { refine ⟨n, hn₁, λ m mn km, _⟩,
-        cases lt_or_eq_of_le km with km km,
+        cases km.lt_or_eq_dec with km km,
         { exact hn₂ _ mn km },
         { exact km ▸ ⟨_, hk⟩ } },
       { simp [F], exact ⟨_, hk, am₃⟩ } } }

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1345,6 +1345,9 @@ congr_arg coe (nat.one_shiftl _)
 
 /-! ### Least upper bound property for integers -/
 
+/-- A computable version of `exists_least_of_bdd`: given a decidable predicate on the
+integers, with an explicit lower bound and a proof that it is somewhere true, return
+the least value for which the predicate is true. -/
 def least_of_bdd {P : ℤ → Prop} [decidable_pred P]
   (b : ℤ) (Hb : ∀ z : ℤ, P z → b ≤ z) (Hinh : ∃ z : ℤ, P z) :
   {lb : ℤ // P lb ∧ (∀ z : ℤ, P z → lb ≤ z)} :=
@@ -1364,6 +1367,9 @@ theorem exists_least_of_bdd {P : ℤ → Prop}
   ∃ lb : ℤ, P lb ∧ (∀ z : ℤ, P z → lb ≤ z) :=
 by classical; exact let ⟨b, Hb⟩ := Hbdd, ⟨lb, H⟩ := least_of_bdd b Hb Hinh in ⟨lb, H⟩
 
+/-- A computable version of `exists_greatest_of_bdd`: given a decidable predicate on the
+integers, with an explicit upper bound and a proof that it is somewhere true, return
+the greatest value for which the predicate is true. -/
 def greatest_of_bdd {P : ℤ → Prop} [decidable_pred P]
   (b : ℤ) (Hb : ∀ z : ℤ, P z → z ≤ b) (Hinh : ∃ z : ℤ, P z) :
   {ub : ℤ // P ub ∧ (∀ z : ℤ, P z → z ≤ ub)} :=

--- a/src/data/list/range.lean
+++ b/src/data/list/range.lean
@@ -30,7 +30,7 @@ by rw [← length_eq_zero, length_range']
   have m = s → m < s + n + 1,
     from λ e, e ▸ lt_succ_of_le (le_add_right _ _),
   have l : m = s ∨ s + 1 ≤ m ↔ s ≤ m,
-    by simpa only [eq_comm] using (@le_iff_eq_or_lt _ _ s m).symm,
+    by simpa only [eq_comm] using (@decidable.le_iff_eq_or_lt _ _ _ s m).symm,
   (mem_cons_iff _ _ _).trans $ by simp only [mem_range',
     or_and_distrib_left, or_iff_right_of_imp this, l, add_right_comm]; refl
 

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -293,7 +293,7 @@ lemma one_add_le_iff {a b : ℕ} : 1 + a ≤ b ↔ a < b :=
 by simp only [add_comm, add_one_le_iff]
 
 theorem of_le_succ {n m : ℕ} (H : n ≤ m.succ) : n ≤ m ∨ n = m.succ :=
-(lt_or_eq_of_le H).imp le_of_lt_succ id
+H.lt_or_eq_dec.imp le_of_lt_succ id
 
 lemma succ_lt_succ_iff {m n : ℕ} : succ m < succ n ↔ m < n :=
 ⟨lt_of_succ_lt_succ, succ_lt_succ⟩
@@ -587,19 +587,17 @@ lemma succ_mul_pos (m : ℕ) (hn : 0 < n) : 0 < (succ m) * n :=
 mul_pos (succ_pos m) hn
 
 theorem mul_self_le_mul_self {n m : ℕ} (h : n ≤ m) : n * n ≤ m * m :=
-mul_le_mul h h (zero_le _) (zero_le _)
+decidable.mul_le_mul h h (zero_le _) (zero_le _)
 
 theorem mul_self_lt_mul_self : Π {n m : ℕ}, n < m → n * n < m * m
 | 0        m h := mul_pos h h
-| (succ n) m h := mul_lt_mul h (le_of_lt h) (succ_pos _) (zero_le _)
+| (succ n) m h := decidable.mul_lt_mul h (le_of_lt h) (succ_pos _) (zero_le _)
 
 theorem mul_self_le_mul_self_iff {n m : ℕ} : n ≤ m ↔ n * n ≤ m * m :=
-⟨mul_self_le_mul_self, λh, decidable.by_contradiction $
-  λhn, not_lt_of_ge h $ mul_self_lt_mul_self $ lt_of_not_ge hn⟩
+⟨mul_self_le_mul_self, le_imp_le_of_lt_imp_lt mul_self_lt_mul_self⟩
 
 theorem mul_self_lt_mul_self_iff {n m : ℕ} : n < m ↔ n * n < m * m :=
-iff.trans (lt_iff_not_ge _ _) $ iff.trans (not_iff_not_of_iff mul_self_le_mul_self_iff) $
-  iff.symm (lt_iff_not_ge _ _)
+le_iff_le_iff_lt_iff_lt.1 mul_self_le_mul_self_iff
 
 theorem le_mul_self : Π (n : ℕ), n ≤ n * n
 | 0     := le_refl _
@@ -608,13 +606,13 @@ theorem le_mul_self : Π (n : ℕ), n ≤ n * n
 lemma le_mul_of_pos_left {m n : ℕ} (h : 0 < n) : m ≤ n * m :=
 begin
   conv {to_lhs, rw [← one_mul(m)]},
-  exact mul_le_mul_of_nonneg_right (nat.succ_le_of_lt h) dec_trivial,
+  exact decidable.mul_le_mul_of_nonneg_right (nat.succ_le_of_lt h) dec_trivial,
 end
 
 lemma le_mul_of_pos_right {m n : ℕ} (h : 0 < n) : m ≤ m * n :=
 begin
   conv {to_lhs, rw [← mul_one(m)]},
-  exact mul_le_mul_of_nonneg_left (nat.succ_le_of_lt h) dec_trivial,
+  exact decidable.mul_le_mul_of_nonneg_left (nat.succ_le_of_lt h) dec_trivial,
 end
 
 theorem two_mul_ne_two_mul_add_one {n m} : 2 * n ≠ 2 * m + 1 :=
@@ -626,9 +624,10 @@ lemma mul_eq_one_iff : ∀ {a b : ℕ}, a * b = 1 ↔ a = 1 ∧ b = 1
 | 1     0     := dec_trivial
 | (a+2) 0     := by simp
 | 0     (b+2) := by simp
-| (a+1) (b+1) := ⟨λ h, by simp only [add_mul, mul_add, mul_add, one_mul, mul_one,
+| (a+1) (b+1) := ⟨
+  λ h, by simp only [add_mul, mul_add, mul_add, one_mul, mul_one,
     (add_assoc _ _ _).symm, nat.succ_inj', add_eq_zero_iff] at h; simp [h.1.2, h.2],
-  by clear_aux_decl; finish⟩
+  λ h, by simp only [h, mul_one]⟩
 
 protected theorem mul_left_inj {a b c : ℕ} (ha : 0 < a) : b * a = c * a ↔ b = c :=
 ⟨nat.eq_of_mul_eq_mul_right ha, λ e, e ▸ rfl⟩
@@ -656,7 +655,7 @@ lemma mul_left_eq_self_iff {a b : ℕ} (hb : 0 < b) : a * b = b ↔ a = 1 :=
 by rw [mul_comm, nat.mul_right_eq_self_iff hb]
 
 lemma lt_succ_iff_lt_or_eq {n i : ℕ} : n < i.succ ↔ (n < i ∨ n = i) :=
-lt_succ_iff.trans le_iff_lt_or_eq
+lt_succ_iff.trans decidable.le_iff_lt_or_eq
 
 theorem mul_self_inj {n m : ℕ} : n * n = m * m ↔ n = m :=
 le_antisymm_iff.trans (le_antisymm_iff.trans
@@ -788,7 +787,7 @@ attribute [simp] nat.div_self
 protected lemma div_le_of_le_mul' {m n : ℕ} {k} (h : m ≤ k * n) : m / k ≤ n :=
 (eq_zero_or_pos k).elim
   (λ k0, by rw [k0, nat.div_zero]; apply zero_le)
-  (λ k0, (decidable.mul_le_mul_left k0).1 $
+  (λ k0, (_root_.mul_le_mul_left k0).1 $
     calc k * (m / k)
         ≤ m % k + k * (m / k) : le_add_left _ _
     ... = m                   : mod_add_div _ _
@@ -815,8 +814,8 @@ protected theorem div_le_div_right {n m : ℕ} (h : n ≤ m) {k : ℕ} : n / k �
 (nat.eq_zero_or_pos k).elim (λ k0, by simp [k0]) $ λ hk,
 (le_div_iff_mul_le' hk).2 $ le_trans (nat.div_mul_le_self _ _) h
 
-lemma lt_of_div_lt_div {m n k : ℕ} (h : m / k < n / k) : m < n :=
-by_contradiction $ λ h₁, absurd h (not_lt_of_ge (nat.div_le_div_right (not_lt.1 h₁)))
+lemma lt_of_div_lt_div {m n k : ℕ} : m / k < n / k → m < n :=
+lt_imp_lt_of_le_imp_le $ λ h, nat.div_le_div_right h
 
 protected lemma div_pos {a b : ℕ} (hba : b ≤ a) (hb : 0 < b) : 0 < a / b :=
 nat.pos_of_ne_zero (λ h, lt_irrefl a
@@ -913,8 +912,8 @@ protected lemma div_div_self : ∀ {a b : ℕ}, b ∣ a → 0 < a → a / (a / b
 
 lemma mod_mul_right_div_self (a b c : ℕ) : a % (b * c) / b = (a / b) % c :=
 begin
-  rcases (zero_le b).eq_or_lt with rfl|hb, { simp },
-  rcases (zero_le c).eq_or_lt with rfl|hc, { simp },
+  rcases eq_zero_or_pos b with rfl|hb, { simp },
+  rcases eq_zero_or_pos c with rfl|hc, { simp },
   conv_rhs { rw ← mod_add_div a (b * c) },
   rw [mul_assoc, nat.add_mul_div_left _ _ hb, add_mul_mod_self_left,
     mod_eq_of_lt (nat.div_lt_of_lt_mul (mod_lt _ (mul_pos hb hc)))]
@@ -1182,7 +1181,7 @@ canonically_ordered_semiring.pow_le_pow_of_le_left H
 
 theorem pow_le_pow_of_le_right {x : ℕ} (H : x > 0) {i : ℕ} : ∀ {j}, i ≤ j → x^i ≤ x^j
 | 0        h := by rw eq_zero_of_le_zero h; apply le_refl
-| (succ j) h := (lt_or_eq_of_le h).elim
+| (succ j) h := h.lt_or_eq_dec.elim
   (λhl, by rw [pow_succ', ← nat.mul_one (x^i)]; exact
     nat.mul_le_mul (pow_le_pow_of_le_right $ le_of_lt_succ hl) H)
   (λe, by rw e; refl)
@@ -1394,7 +1393,7 @@ end
 by simp only [exists_prop, ← lt_succ_iff, find_lt_iff]
 
 @[simp] lemma le_find_iff (h : ∃ (n : ℕ), p n) (n : ℕ) : n ≤ nat.find h ↔ ∀ m < n, ¬ p m :=
-by simp_rw [← not_lt, not_iff_comm, not_forall, not_not, find_lt_iff]
+by simp_rw [← not_lt, find_lt_iff, not_exists]
 
 @[simp] lemma lt_find_iff (h : ∃ n : ℕ, p n) (n : ℕ) : n < nat.find h ↔ ∀ m ≤ n, ¬ p m :=
 by simp only [← succ_le_iff, le_find_iff, succ_le_succ_iff]
@@ -1403,7 +1402,7 @@ by simp only [← succ_le_iff, le_find_iff, succ_le_succ_iff]
 by simp [find_eq_iff]
 
 @[simp] lemma find_pos (h : ∃ n : ℕ, p n) : 0 < nat.find h ↔ ¬ p 0 :=
-by rw [pos_iff_ne_zero, not_iff_not, nat.find_eq_zero]
+by rw [pos_iff_ne_zero, ne, nat.find_eq_zero]
 
 theorem find_le (h : ∀ n, q n → p n) (hp : ∃ n, p n) (hq : ∃ n, q n) :
   nat.find hp ≤ nat.find hq :=
@@ -1453,13 +1452,13 @@ begin
       { rintro rfl,
         exact ⟨le_refl _, λ _, hb, λ n hlt hle, (hlt.not_le hle).elim⟩ },
       { rintros ⟨hle, h0, hm⟩,
-        rcases hle.eq_or_lt with rfl|hlt,
+        rcases decidable.eq_or_lt_of_le hle with rfl|hlt,
         exacts [rfl, (hm hlt (le_refl _) hb).elim] } },
     { rw [find_greatest_of_not hb, ihb],
       split,
       { rintros ⟨hle, hP, hm⟩,
         refine ⟨hle.trans b.le_succ, hP, λ n hlt hle, _⟩,
-        rcases hle.eq_or_lt with rfl|hlt',
+        rcases decidable.eq_or_lt_of_le hle with rfl|hlt',
         exacts [hb, hm hlt $ lt_succ_iff.1 hlt'] },
       { rintros ⟨hle, hP, hm⟩,
         refine ⟨lt_succ_iff.1 (hle.lt_of_ne _), hP, λ n hlt hle, hm hlt (hle.trans b.le_succ)⟩,
@@ -1704,14 +1703,14 @@ begin
 end⟩
 
 theorem lt_size {m n : ℕ} : m < size n ↔ 2^m ≤ n :=
-by rw [← not_lt, iff_not_comm, not_lt, size_le]
+by rw [← not_lt, decidable.iff_not_comm, not_lt, size_le]
 
 theorem size_pos {n : ℕ} : 0 < size n ↔ 0 < n :=
 by rw lt_size; refl
 
 theorem size_eq_zero {n : ℕ} : size n = 0 ↔ n = 0 :=
 by have := @size_pos n; simp [pos_iff_ne_zero] at this;
-   exact not_iff_not.1 this
+   exact decidable.not_iff_not.1 this
 
 theorem size_pow {n : ℕ} : size (2^n) = n+1 :=
 le_antisymm
@@ -1732,7 +1731,7 @@ begin
   { refine is_false (mt _ h), intros hn k h, apply hn },
   by_cases p : P n (lt_succ_self n),
   { exact is_true (λ k h',
-     (lt_or_eq_of_le $ le_of_lt_succ h').elim (h _)
+     (le_of_lt_succ h').lt_or_eq_dec.elim (h _)
        (λ e, match k, e, h' with _, rfl, h := p end)) },
   { exact is_false (mt (λ hn, hn _ _) p) }
 end

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -50,8 +50,7 @@ ne.symm $ ne_of_lt hp.one_lt
 theorem prime_def_lt {p : ℕ} : prime p ↔ 2 ≤ p ∧ ∀ m < p, m ∣ p → m = 1 :=
 and_congr_right $ λ p2, forall_congr $ λ m,
 ⟨λ h l d, (h d).resolve_right (ne_of_lt l),
- λ h d, (decidable.lt_or_eq_of_le $
-   le_of_dvd (le_of_succ_le p2) d).imp_left (λ l, h l d)⟩
+ λ h d, (le_of_dvd (le_of_succ_le p2) d).lt_or_eq_dec.imp_left (λ l, h l d)⟩
 
 theorem prime_def_lt' {p : ℕ} : prime p ↔ 2 ≤ p ∧ ∀ m, 2 ≤ m → m < p → ¬ m ∣ p :=
 prime_def_lt.trans $ and_congr_right $ λ p2, forall_congr $ λ m,

--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -63,6 +63,8 @@ end
 
 private def is_sqrt (n q : ℕ) : Prop := q*q ≤ n ∧ n < (q+1)*(q+1)
 
+local attribute [-simp] mul_eq_mul_left_iff mul_eq_mul_right_iff
+
 private lemma sqrt_aux_is_sqrt_lemma (m r n : ℕ)
   (h₁ : r*r ≤ n)
   (m') (hm : shiftr (2^m * 2^m) 2 = m')

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1288,7 +1288,8 @@ by finish [subset_def, mem_image_eq]
 
 theorem image_union (f : α → β) (s t : set α) :
   f '' (s ∪ t) = f '' s ∪ f '' t :=
-by finish [ext_iff, iff_def, mem_image_eq]
+ext $ λ x, ⟨by rintro ⟨a, h|h, rfl⟩; [left, right]; exact ⟨_, h, rfl⟩,
+  by rintro (⟨a, h, rfl⟩ | ⟨a, h, rfl⟩); refine ⟨_, _, rfl⟩; [left, right]; exact h⟩
 
 @[simp] theorem image_empty (f : α → β) : f '' ∅ = ∅ := by { ext, simp }
 

--- a/src/logic/nontrivial.lean
+++ b/src/logic/nontrivial.lean
@@ -34,7 +34,8 @@ lemma nontrivial_iff : nontrivial α ↔ ∃ (x y : α), x ≠ y :=
 lemma exists_pair_ne (α : Type*) [nontrivial α] : ∃ (x y : α), x ≠ y :=
 nontrivial.exists_pair_ne
 
-lemma exists_ne [nontrivial α] (x : α) : ∃ y, y ≠ x :=
+-- See Note [decidable namespace]
+protected lemma decidable.exists_ne [nontrivial α] [decidable_eq α] (x : α) : ∃ y, y ≠ x :=
 begin
   rcases exists_pair_ne α with ⟨y, y', h⟩,
   by_cases hx : x = y,
@@ -42,6 +43,9 @@ begin
     exact ⟨y', h.symm⟩ },
   { exact ⟨y, ne.symm hx⟩ }
 end
+
+lemma exists_ne [nontrivial α] (x : α) : ∃ y, y ≠ x :=
+by classical; exact decidable.exists_ne x
 
 -- `x` and `y` are explicit here, as they are often needed to guide typechecking of `h`.
 lemma nontrivial_of_ne (x y : α) (h : x ≠ y) : nontrivial α :=

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -247,7 +247,7 @@ variables [linear_order α] [preorder β] {f : α → β} {s : set α} {x y : α
 lemma le_iff_le (H : strict_mono_incr_on f s) (hx : x ∈ s) (hy : y ∈ s) :
   f x ≤ f y ↔ x ≤ y :=
 ⟨λ h, le_of_not_gt $ λ h', not_le_of_lt (H hy hx h') h,
- λ h, (lt_or_eq_of_le h).elim (λ h', le_of_lt (H hx hy h')) (λ h', h' ▸ le_refl _)⟩
+ λ h, h.lt_or_eq_dec.elim (λ h', le_of_lt (H hx hy h')) (λ h', h' ▸ le_refl _)⟩
 
 lemma lt_iff_lt (H : strict_mono_incr_on f s) (hx : x ∈ s) (hy : y ∈ s) :
   f x < f y ↔ x < y :=

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -56,12 +56,7 @@ assume h, lt_irrefl a (lt_of_le_of_lt le_top h)
 theorem eq_top_mono (h : a ≤ b) (h₂ : a = ⊤) : b = ⊤ :=
 top_le_iff.1 $ h₂ ▸ h
 
-lemma lt_top_iff_ne_top : a < ⊤ ↔ a ≠ ⊤ :=
-begin
-  haveI := classical.dec_eq α,
-  haveI : decidable (⊤ ≤ a) := decidable_of_iff' _ top_le_iff,
-  by simp [-top_le_iff, lt_iff_le_not_le, not_iff_not.2 (@top_le_iff _ _ a)]
-end
+lemma lt_top_iff_ne_top : a < ⊤ ↔ a ≠ ⊤ := le_top.lt_iff_ne
 
 lemma ne_top_of_lt (h : a < b) : a ≠ ⊤ :=
 lt_top_iff_ne_top.1 $ lt_of_lt_of_le h le_top

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -184,10 +184,16 @@ lemma sup_ind [is_total α (≤)] (a b : α) {p : α → Prop} (ha : p a) (hb : 
 ⟨λ h, ⟨le_sup_left.trans_lt h, le_sup_right.trans_lt h⟩, λ h, sup_ind b c h.1 h.2⟩
 
 @[simp] lemma le_sup_iff [is_total α (≤)] {a b c : α} : a ≤ b ⊔ c ↔ a ≤ b ∨ a ≤ c :=
-by rw [← not_iff_not]; simp only [not_or_distrib, @sup_lt_iff α, @not_le (as_linear_order α)]
+⟨λ h, (total_of (≤) c b).imp
+  (λ bc, by rwa sup_eq_left.2 bc at h)
+  (λ bc, by rwa sup_eq_right.2 bc at h),
+ λ h, h.elim le_sup_left_of_le le_sup_right_of_le⟩
 
 @[simp] lemma lt_sup_iff [is_total α (≤)] {a b c : α} : a < b ⊔ c ↔ a < b ∨ a < c :=
-by { rw ← not_iff_not, simp only [not_or_distrib, @not_lt (as_linear_order α), sup_le_iff] }
+⟨λ h, (total_of (≤) c b).imp
+  (λ bc, by rwa sup_eq_left.2 bc at h)
+  (λ bc, by rwa sup_eq_right.2 bc at h),
+ λ h, h.elim (λ h, h.trans_le le_sup_left) (λ h, h.trans_le le_sup_right)⟩
 
 @[simp] theorem sup_idem : a ⊔ a = a :=
 by apply le_antisymm; simp


### PR DESCRIPTION
Now that lean v3.30 has landed (and specifically leanprover-community/lean#560), we can finally make some progress on making a significant fraction of mathlib foundations choice-free. This PR does the following:

* No existing theorem statements have changed (except `linear_nonneg_ring` as noted below).
* A number of new theorems have been added to the `decidable` namespace, proving choice-free versions of lemmas under the assumption that something is decidable. These are primarily concentrated in partial orders and ordered rings, because total orders are already decidable, but there are some interesting lemmas about partial orders that require decidability of `le`.
* `linear_nonneg_ring` was changed to include decidability of `nonneg`, for consistency with linear ordered rings. No one is using this anyway so there shouldn't be any fallout.
* A lot of the `ordered_semiring` lemmas need `decidable` versions now because one of the core axioms, `mul_le_mul_of_nonneg_left`, is derived by LEM from an equivalent statement about lt instead of being an actual axiom. If this is refactored, these theorems can be removed again.
* The main files which were scoured of choicy proofs are: `algebra.ordered_group`,  `algebra.ordered_ring`, `data.nat.basic`, `data.int.basic`, `data.list.basic`, and `computability.halting`.
* The end goal of this was to prove `computable_pred.halting_problem` without assuming choice, finally validating a claim I made more than two years ago in my [paper](https://arxiv.org/abs/1810.08380) on the formalization.

I have not yet investigated a linter for making sure that these proofs stay choice-free; this can be done in a follow-up PR.