### PR TITLE
[Merged by Bors] - feat(data/equiv/basic): equiv.curry

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -610,6 +610,7 @@ lemma prod_assoc_preimage {α β γ} {s : set α} {t : set β} {u : set γ} :
   equiv.prod_assoc α β γ ⁻¹' s.prod (t.prod u) = (s.prod t).prod u :=
 by { ext, simp [and_assoc] }
 
+/-- Functions `α → β → γ` are equivalent to functions on `α × β`. -/
 @[simps {fully_applied := ff}] def curry (α β γ : Type*) :
   (α × β → γ) ≃ (α → β → γ) :=
 { to_fun := curry,
@@ -1154,10 +1155,6 @@ def arrow_prod_equiv_prod_arrow (α β γ : Type*) : (γ → α × β) ≃ (γ �
  λ p c, (p.1 c, p.2 c),
  λ f, funext $ λ c, prod.mk.eta,
  λ p, by { cases p, refl }⟩
-
-/-- Functions `α → β → γ` are equivalent to functions on `α × β`. -/
-def arrow_arrow_equiv_prod_arrow (α β γ : Sort*) : (α → β → γ) ≃ (α × β → γ) :=
-⟨uncurry, curry, curry_uncurry, uncurry_curry⟩
 
 open sum
 /-- The type of functions on a sum type `α ⊕ β` is equivalent to the type of pairs of functions

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -610,14 +610,20 @@ lemma prod_assoc_preimage {α β γ} {s : set α} {t : set β} {u : set γ} :
   equiv.prod_assoc α β γ ⁻¹' s.prod (t.prod u) = (s.prod t).prod u :=
 by { ext, simp [and_assoc] }
 
+@[simps {fully_applied := ff}] def curry (α β γ : Type*) :
+  (α × β → γ) ≃ (α → β → γ) :=
+{ to_fun := curry,
+  inv_fun := uncurry,
+  left_inv := uncurry_curry,
+  right_inv := curry_uncurry }
+
 section
 /-- `punit` is a right identity for type product up to an equivalence. -/
-@[simps apply] def prod_punit (α : Type*) : α × punit.{u+1} ≃ α :=
+@[simps] def prod_punit (α : Type*) : α × punit.{u+1} ≃ α :=
 ⟨λ p, p.1, λ a, (a, punit.star), λ ⟨_, punit.star⟩, rfl, λ a, rfl⟩
 
 /-- `punit` is a left identity for type product up to an equivalence. -/
-@[simps apply]
-def punit_prod (α : Type*) : punit.{u+1} × α ≃ α :=
+@[simps] def punit_prod (α : Type*) : punit.{u+1} × α ≃ α :=
 calc punit × α ≃ α × punit : prod_comm _ _
            ... ≃ α         : prod_punit _
 

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -610,7 +610,7 @@ lemma prod_assoc_preimage {α β γ} {s : set α} {t : set β} {u : set γ} :
   equiv.prod_assoc α β γ ⁻¹' s.prod (t.prod u) = (s.prod t).prod u :=
 by { ext, simp [and_assoc] }
 
-/-- Functions `α → β → γ` are equivalent to functions on `α × β`. -/
+/-- Functions on `α × β` are equivalent to functions `α → β → γ`. -/
 @[simps {fully_applied := ff}] def curry (α β γ : Type*) :
   (α × β → γ) ≃ (α → β → γ) :=
 { to_fun := curry,

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1946,7 +1946,7 @@ protected def uncurry :
   (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
 { map_add'  := λ _ _, by { ext ⟨⟩, refl },
   map_smul' := λ _ _, by { ext ⟨⟩, refl },
-  .. equiv.arrow_arrow_equiv_prod_arrow _ _ _}
+  .. equiv.curry _ _ _}
 
 @[simp] lemma coe_uncurry : ⇑(linear_equiv.uncurry R V V₂) = uncurry := rfl
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1942,15 +1942,15 @@ variables (V V₂ R)
 
 /-- Linear equivalence between a curried and uncurried function.
   Differs from `tensor_product.curry`. -/
-protected def uncurry :
-  (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
-{ map_add'  := λ _ _, by { ext ⟨⟩, refl },
-  map_smul' := λ _ _, by { ext ⟨⟩, refl },
-  .. (equiv.curry _ _ _).symm }
+protected def curry :
+  (V × V₂ → R) ≃ₗ[R] (V → V₂ → R) :=
+{ map_add'  := λ _ _, by { ext, refl },
+  map_smul' := λ _ _, by { ext, refl },
+  .. equiv.curry _ _ _ }
 
-@[simp] lemma coe_uncurry : ⇑(linear_equiv.uncurry R V V₂) = uncurry := rfl
+@[simp] lemma coe_curry : ⇑(linear_equiv.curry R V V₂) = curry := rfl
 
-@[simp] lemma coe_uncurry_symm : ⇑(linear_equiv.uncurry R V V₂).symm = curry := rfl
+@[simp] lemma coe_curry_symm : ⇑(linear_equiv.curry R V V₂).symm = uncurry := rfl
 
 end uncurry
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1946,7 +1946,7 @@ protected def uncurry :
   (V → V₂ → R) ≃ₗ[R] (V × V₂ → R) :=
 { map_add'  := λ _ _, by { ext ⟨⟩, refl },
   map_smul' := λ _ _, by { ext ⟨⟩, refl },
-  .. equiv.curry _ _ _}
+  .. (equiv.curry _ _ _).symm }
 
 @[simp] lemma coe_uncurry : ⇑(linear_equiv.uncurry R V V₂) = uncurry := rfl
 

--- a/src/linear_algebra/matrix.lean
+++ b/src/linear_algebra/matrix.lean
@@ -867,7 +867,7 @@ variables {m n : Type*} [fintype m] [fintype n]
 variables {R : Type v} [field R]
 
 instance : finite_dimensional R (matrix m n R) :=
-linear_equiv.finite_dimensional (linear_equiv.uncurry R m n).symm
+linear_equiv.finite_dimensional (linear_equiv.curry R m n)
 
 /--
 The dimension of the space of finite dimensional matrices
@@ -875,7 +875,7 @@ is the product of the number of rows and columns.
 -/
 @[simp] lemma finrank_matrix :
   finite_dimensional.finrank R (matrix m n R) = fintype.card m * fintype.card n :=
-by rw [@linear_equiv.finrank_eq R (matrix m n R) _ _ _ _ _ _ (linear_equiv.uncurry R m n),
+by rw [@linear_equiv.finrank_eq R (matrix m n R) _ _ _ _ _ _ (linear_equiv.curry R m n).symm,
        finite_dimensional.finrank_fintype_fun_eq_card, fintype.card_prod]
 
 end finite_dimensional

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -266,7 +266,7 @@ quotient.induction_on₃ a b c $ assume α β γ,
 theorem power_mul {a b c : cardinal} : (a ^ b) ^ c = a ^ (b * c) :=
 by rw [_root_.mul_comm b c];
 from (quotient.induction_on₃ a b c $ assume α β γ,
-  quotient.sound ⟨equiv.curry γ β α⟩)
+  quotient.sound ⟨(equiv.curry γ β α).symm⟩)
 
 @[simp] lemma pow_cast_right (κ : cardinal.{u}) :
   ∀ n : ℕ, (κ ^ (↑n : cardinal.{u})) = @has_pow.pow _ _ monoid.has_pow κ n

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -266,7 +266,7 @@ quotient.induction_on₃ a b c $ assume α β γ,
 theorem power_mul {a b c : cardinal} : (a ^ b) ^ c = a ^ (b * c) :=
 by rw [_root_.mul_comm b c];
 from (quotient.induction_on₃ a b c $ assume α β γ,
-  quotient.sound ⟨equiv.arrow_arrow_equiv_prod_arrow γ β α⟩)
+  quotient.sound ⟨equiv.curry γ β α⟩)
 
 @[simp] lemma pow_cast_right (κ : cardinal.{u}) :
   ∀ n : ℕ, (κ ^ (↑n : cardinal.{u})) = @has_pow.pow _ _ monoid.has_pow κ n

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -263,10 +263,10 @@ theorem power_add {a b c : cardinal} : a ^ (b + c) = a ^ b * a ^ c :=
 quotient.induction_on₃ a b c $ assume α β γ,
   quotient.sound ⟨equiv.sum_arrow_equiv_prod_arrow β γ α⟩
 
-theorem power_mul {a b c : cardinal} : (a ^ b) ^ c = a ^ (b * c) :=
+theorem power_mul {a b c : cardinal} : a ^ (b * c) = (a ^ b) ^ c :=
 by rw [_root_.mul_comm b c];
 from (quotient.induction_on₃ a b c $ assume α β γ,
-  quotient.sound ⟨(equiv.curry γ β α).symm⟩)
+  quotient.sound ⟨equiv.curry γ β α⟩)
 
 @[simp] lemma pow_cast_right (κ : cardinal.{u}) :
   ∀ n : ℕ, (κ ^ (↑n : cardinal.{u})) = @has_pow.pow _ _ monoid.has_pow κ n

--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -439,7 +439,7 @@ H3.symm ▸ (quotient.induction_on κ (λ α H1, nat.rec_on n
 lemma power_self_eq {c : cardinal} (h : omega ≤ c) : c ^ c = 2 ^ c :=
 begin
   apply le_antisymm,
-  { apply le_trans (power_le_power_right $ le_of_lt $ cantor c), rw [power_mul, mul_eq_self h] },
+  { apply le_trans (power_le_power_right $ le_of_lt $ cantor c), rw [← power_mul, mul_eq_self h] },
   { convert power_le_power_right (le_trans (le_of_lt $ nat_lt_omega 2) h), apply nat.cast_two.symm }
 end
 

--- a/src/set_theory/cofinality.lean
+++ b/src/set_theory/cofinality.lean
@@ -553,7 +553,7 @@ theorem lt_cof_power {a b : cardinal} (ha : omega ≤ a) (b1 : 1 < b) :
 begin
   have b0 : b ≠ 0 := ne_of_gt (lt_trans zero_lt_one b1),
   apply lt_imp_lt_of_le_imp_le (power_le_power_left $ power_ne_zero a b0),
-  rw [power_mul, mul_eq_self ha],
+  rw [← power_mul, mul_eq_self ha],
   exact lt_power_cof (le_trans ha $ le_of_lt $ cantor' _ b1),
 end
 


### PR DESCRIPTION
This renames `equiv.arrow_arrow_equiv_prod_arrow` to `(equiv.curry _ _ _).symm` to make it easier to find and match `function.curry`.

* `cardinal.power_mul` is swapped, so that its name makes sense.
* renames `linear_equiv.uncurry` to `linear_equiv.curry` and swaps sides

Also add `@[simps]` to two equivs.




---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)