### PR TITLE
[Merged by Bors] - feat(category_theory/subobject): minor tweaks

### DIFF
--- a/src/category_theory/subobject/basic.lean
+++ b/src/category_theory/subobject/basic.lean
@@ -5,6 +5,7 @@ Authors: Bhavik Mehta, Scott Morrison
 -/
 import category_theory.subobject.mono_over
 import category_theory.skeletal
+import tactic.elementwise
 
 /-!
 # Subobjects
@@ -167,7 +168,7 @@ lemma underlying_arrow {X : C} {Y Z : subobject X} (f : Y ⟶ Z) :
   underlying.map f ≫ arrow Z = arrow Y :=
 over.w (representative.map f)
 
-@[simp, reassoc]
+@[simp, reassoc, elementwise]
 lemma underlying_iso_arrow {X Y : C} (f : X ⟶ Y) [mono f] :
   (underlying_iso f).inv ≫ (subobject.mk f).arrow = f :=
 over.w _
@@ -243,7 +244,22 @@ underlying.map $ hom_of_le h
   of_le X Y h ≫ Y.arrow = X.arrow :=
 underlying_arrow _
 
+instance {B : C} (X Y : subobject B) (h : X ≤ Y) : mono (of_le X Y h) :=
+begin
+  fsplit,
+  intros Z f g w,
+  replace w := w =≫ Y.arrow,
+  ext,
+  simpa using w,
+end
+
+lemma of_le_mk_le_mk_of_comm
+  {B A₁ A₂ : C} {f₁ : A₁ ⟶ B} {f₂ : A₂ ⟶ B} [mono f₁] [mono f₂] (g : A₁ ⟶ A₂) (w : g ≫ f₂ = f₁) :
+  of_le _ _ (mk_le_mk_of_comm g w) = (underlying_iso _).hom ≫ g ≫ (underlying_iso _).inv :=
+by { ext, simp [w], }
+
 /-- An inequality of subobjects is witnessed by some morphism between the corresponding objects. -/
+@[derive mono]
 def of_le_mk {B A : C} (X : subobject B) (f : A ⟶ B) [mono f] (h : X ≤ mk f) : (X : C) ⟶ A :=
 of_le X (mk f) h ≫ (underlying_iso f).hom
 
@@ -252,6 +268,7 @@ of_le X (mk f) h ≫ (underlying_iso f).hom
 by simp [of_le_mk]
 
 /-- An inequality of subobjects is witnessed by some morphism between the corresponding objects. -/
+@[derive mono]
 def of_mk_le {B A : C} (f : A ⟶ B) [mono f] (X : subobject B) (h : mk f ≤ X) : A ⟶ (X : C) :=
 (underlying_iso f).inv ≫ of_le (mk f) X h
 
@@ -260,6 +277,7 @@ def of_mk_le {B A : C} (f : A ⟶ B) [mono f] (X : subobject B) (h : mk f ≤ X)
 by simp [of_mk_le]
 
 /-- An inequality of subobjects is witnessed by some morphism between the corresponding objects. -/
+@[derive mono]
 def of_mk_le_mk {B A₁ A₂ : C} (f : A₁ ⟶ B) (g : A₂ ⟶ B) [mono f] [mono g] (h : mk f ≤ mk g) :
   A₁ ⟶ A₂ :=
 (underlying_iso f).inv ≫ of_le (mk f) (mk g) h ≫ (underlying_iso g).hom

--- a/src/category_theory/subobject/basic.lean
+++ b/src/category_theory/subobject/basic.lean
@@ -5,7 +5,6 @@ Authors: Bhavik Mehta, Scott Morrison
 -/
 import category_theory.subobject.mono_over
 import category_theory.skeletal
-import tactic.elementwise
 
 /-!
 # Subobjects
@@ -168,7 +167,7 @@ lemma underlying_arrow {X : C} {Y Z : subobject X} (f : Y ⟶ Z) :
   underlying.map f ≫ arrow Z = arrow Y :=
 over.w (representative.map f)
 
-@[simp, reassoc, elementwise]
+@[simp, reassoc]
 lemma underlying_iso_arrow {X Y : C} (f : X ⟶ Y) [mono f] :
   (underlying_iso f).inv ≫ (subobject.mk f).arrow = f :=
 over.w _

--- a/src/category_theory/subobject/factor_thru.lean
+++ b/src/category_theory/subobject/factor_thru.lean
@@ -123,7 +123,6 @@ begin
     ext, simp, },
 end
 
-@[simp]
 lemma factor_thru_right {X Y Z : C} {P : subobject Z} (f : X ⟶ Y) (g : Y ⟶ Z) (h : P.factors g) :
   f ≫ P.factor_thru g h = P.factor_thru (f ≫ g) (factors_of_factors_right f h) :=
 begin
@@ -138,11 +137,11 @@ lemma factor_thru_zero
 by simp
 
 -- `h` is an explicit argument here so we can use
--- `rw ←factor_thru_le h`, obtaining a subgoal `P.factors f`.
-@[simp]
-lemma factor_thru_comp_of_le
+-- `rw factor_thru_le h`, obtaining a subgoal `P.factors f`.
+-- (While the reverse direction looks plausible as a simp lemma, it seems to be unproductive.)
+lemma factor_thru_of_le
   {Y Z : C} {P Q : subobject Y} {f : Z ⟶ Y} (h : P ≤ Q) (w : P.factors f) :
-  P.factor_thru f w ≫ of_le P Q h = Q.factor_thru f (factors_of_le f h w) :=
+  Q.factor_thru f (factors_of_le f h w) = P.factor_thru f w ≫ of_le P Q h :=
 by { ext, simp, }
 
 section preadditive

--- a/src/category_theory/subobject/lattice.lean
+++ b/src/category_theory/subobject/lattice.lean
@@ -195,16 +195,16 @@ instance {X : C} : inhabited (subobject X) := ⟨⊤⟩
 
 lemma top_eq_id (B : C) : (⊤ : subobject B) = subobject.mk (𝟙 B) := rfl
 
-/-- The object underlying `⊤ : subobject B` is (up to isomorphism) `B`. -/
-def top_coe_iso_self {B : C} : ((⊤ : subobject B) : C) ≅ B := underlying_iso _
+lemma underlying_iso_top_hom {B : C} :
+  (underlying_iso (𝟙 B)).hom = (⊤ : subobject B).arrow :=
+by { convert underlying_iso_hom_comp_eq_mk (𝟙 B), simp only [comp_id], }
 
-@[simp]
-lemma underlying_iso_id_eq_top_coe_iso_self {B : C} : underlying_iso (𝟙 B) = top_coe_iso_self :=
-rfl
+instance top_arrow_is_iso {B : C} : is_iso ((⊤ : subobject B).arrow) :=
+by { rw ←underlying_iso_top_hom, apply_instance, }
 
 @[simp, reassoc]
 lemma underlying_iso_inv_top_arrow {B : C} :
-  top_coe_iso_self.inv ≫ (⊤ : subobject B).arrow = 𝟙 B :=
+  (underlying_iso _).inv ≫ (⊤ : subobject B).arrow = 𝟙 B :=
 underlying_iso_arrow _
 
 @[simp]


### PR DESCRIPTION
A few minor tweaks to the `subobject` API that I wanted while working on homology.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
