### PR TITLE
[Merged by Bors] - feat(linear_algebra/finsupp): linear equivalence between `α × β →₀ M` and `α →₀ β →₀ M`

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1780,6 +1780,18 @@ finitely supported functions from `β` to `γ`. -/
 protected def curry (f : (α × β) →₀ M) : α →₀ (β →₀ M) :=
 f.sum $ λp c, single p.1 (single p.2 c)
 
+@[simp] lemma curry_apply (f : (α × β) →₀ M) (x : α) (y : β) :
+  f.curry x y = f (x, y) :=
+begin
+  have : ∀ (b : α × β), single b.fst (single b.snd (f b)) x y = if b = (x, y) then f b else 0,
+  { rintros ⟨b₁, b₂⟩,
+    simp [single_apply, ite_apply, prod.ext_iff, ite_and],
+    split_ifs; simp [single_apply, *] },
+  rw [finsupp.curry, sum_apply, sum_apply, finsupp.sum, finset.sum_eq_single, this, if_pos rfl],
+  { intros b hb b_ne, rw [this b, if_neg b_ne] },
+  { intros hxy, rw [this (x, y), if_pos rfl, not_mem_support_iff.mp hxy] }
+end
+
 lemma sum_curry_index (f : (α × β) →₀ M) (g : α → β → M → N)
   (hg₀ : ∀ a b, g a b 0 = 0) (hg₁ : ∀a b c₀ c₁, g a b (c₀ + c₁) = g a b c₀ + g a b c₁) :
   f.curry.sum (λa f, f.sum (g a)) = f.sum (λp c, g p.1 p.2 c) :=

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -698,6 +698,31 @@ rfl
 
 end sum
 
+section prod
+
+/-- The linear equivalence between `α × β →₀ M` and `α →₀ β →₀ M`.
+
+This is the `linear_equiv` version of `finsupp.finsupp_prod_equiv`. -/
+noncomputable def finsupp_prod_lequiv {α β : Type*} (R : Type*) {M : Type*}
+  [semiring R] [add_comm_monoid M] [module R M] :
+  (α × β →₀ M) ≃ₗ[R] (α →₀ β →₀ M) :=
+{ map_add' := λ f g, by { ext, simp [finsupp_prod_equiv, curry_apply] },
+  map_smul' := λ c f, by { ext, simp [finsupp_prod_equiv, curry_apply] },
+  .. finsupp_prod_equiv }
+
+@[simp] lemma finsupp_prod_lequiv_apply {α β R M : Type*}
+  [semiring R] [add_comm_monoid M] [module R M] (f : α × β →₀ M) (x y) :
+  finsupp_prod_lequiv R f x y = f (x, y) :=
+by rw [finsupp_prod_lequiv, linear_equiv.coe_mk, finsupp_prod_equiv, finsupp.curry_apply]
+
+@[simp] lemma finsupp_prod_lequiv_symm_apply {α β R M : Type*}
+  [semiring R] [add_comm_monoid M] [module R M] (f : α →₀ β →₀ M) (xy) :
+  (finsupp_prod_lequiv R).symm f xy = f xy.1 xy.2 :=
+by conv_rhs
+  { rw [← (finsupp_prod_lequiv R).apply_symm_apply f, finsupp_prod_lequiv_apply, prod.mk.eta] }
+
+end prod
+
 end finsupp
 
 variables {R : Type*} {M : Type*} {N : Type*}


### PR DESCRIPTION
This PR extends the equivalence `finsupp.finsupp_prod_equiv` to a linear equivalence (to be used in the `bundled-basis` refactor).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

 - [x] depends on: #7475

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
