### PR TITLE
[Merged by Bors] - feat(data/equiv,linear_algebra): `Pi_congr_right` for `mul_equiv` and `linear_equiv`

### DIFF
--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -319,7 +319,7 @@ multiplicative equivalence between `Π j, Ms j` and `Π j, Ns j`.
 
 This is the `mul_equiv` version of `equiv.Pi_congr_right`.
 -/
-@[to_additive add_equiv.Pi_congr_right "A family of additive equivalences `Π j, (Ms j ≃* Ns j)` generates an
+@[to_additive add_equiv.Pi_congr_right "A family of additive equivalences `Π j, (Ms j ≃+ Ns j)` generates an
 additive equivalence between `Π j, Ms j` and `Π j, Ns j`.
 
 This is the `add_equiv` version of `equiv.Pi_congr_right.`"]

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -317,12 +317,14 @@ def monoid_hom_congr {M N P Q} [mul_one_class M] [mul_one_class N] [comm_monoid 
 /-- A family of multiplicative equivalences `Π j, (Ms j ≃* Ns j)` generates a
 multiplicative equivalence between `Π j, Ms j` and `Π j, Ns j`.
 
-This is the `mul_equiv` version of `equiv.Pi_congr_right`.
+This is the `mul_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
+`mul_equiv.arrow_congr`.
 -/
 @[to_additive add_equiv.Pi_congr_right "A family of additive equivalences `Π j, (Ms j ≃+ Ns j)` generates an
 additive equivalence between `Π j, Ms j` and `Π j, Ns j`.
 
-This is the `add_equiv` version of `equiv.Pi_congr_right.`"]
+This is the `add_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
+`add_equiv.arrow_congr`."]
 def Pi_congr_right {η : Type*}
   {Ms Ns : η → Type*} [Π j, mul_one_class (Ms j)] [Π j, mul_one_class (Ns j)]
   (es : ∀ j, Ms j ≃* Ns j) : (Π j, Ms j) ≃* (Π j, Ns j) :=

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -314,6 +314,29 @@ def monoid_hom_congr {M N P Q} [mul_one_class M] [mul_one_class N] [comm_monoid 
   right_inv := λ k, by { ext, simp, },
   map_mul' := λ h k, by { ext, simp, }, }
 
+/-- A family of multiplicative equivalences `Π j, (Ms j ≃* Ns j)` generates a
+multiplicative equivalence between `Π j, Ms j` and `Π j, Ns j`.
+
+This is the `mul_equiv` version of `equiv.Pi_congr_right`.
+-/
+@[to_additive add_equiv.Pi_congr_right "A family of additive equivalences `Π j, (Ms j ≃* Ns j)` generates an
+additive equivalence between `Π j, Ms j` and `Π j, Ns j`.
+
+This is the `add_equiv` version of `equiv.Pi_congr_right.`"]
+def Pi_congr_right {η : Type*}
+  {Ms Ns : η → Type*} [Π j, monoid (Ms j)] [Π j, monoid (Ns j)]
+  (es : ∀ j, Ms j ≃* Ns j) : (Π j, Ms j) ≃* (Π j, Ns j) :=
+{ map_mul' := λ x y,
+  by { ext j,
+       simp_rw [equiv.Pi_congr_right, pi.mul_apply, mul_equiv.coe_to_equiv, mul_equiv.map_mul] },
+  .. equiv.Pi_congr_right (λ j, (es j).to_equiv) }
+
+@[simp, to_additive add_equiv.Pi_congr_right_apply]
+lemma Pi_congr_right_apply {η : Type*}
+  {Ms Ns : η → Type*} [Π j, monoid (Ms j)] [Π j, monoid (Ns j)]
+  (es : ∀ j, Ms j ≃* Ns j) (x j) :
+  mul_equiv.Pi_congr_right es x j = es j (x j) := rfl
+
 /-!
 # Groups
 -/

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -324,7 +324,7 @@ additive equivalence between `Π j, Ms j` and `Π j, Ns j`.
 
 This is the `add_equiv` version of `equiv.Pi_congr_right.`"]
 def Pi_congr_right {η : Type*}
-  {Ms Ns : η → Type*} [Π j, monoid (Ms j)] [Π j, monoid (Ns j)]
+  {Ms Ns : η → Type*} [Π j, mul_one_class (Ms j)] [Π j, mul_one_class (Ns j)]
   (es : ∀ j, Ms j ≃* Ns j) : (Π j, Ms j) ≃* (Π j, Ns j) :=
 { map_mul' := λ x y,
   by { ext j,
@@ -333,7 +333,7 @@ def Pi_congr_right {η : Type*}
 
 @[simp, to_additive add_equiv.Pi_congr_right_apply]
 lemma Pi_congr_right_apply {η : Type*}
-  {Ms Ns : η → Type*} [Π j, monoid (Ms j)] [Π j, monoid (Ns j)]
+  {Ms Ns : η → Type*} [Π j, mul_one_class (Ms j)] [Π j, mul_one_class (Ns j)]
   (es : ∀ j, Ms j ≃* Ns j) (x j) :
   mul_equiv.Pi_congr_right es x j = es j (x j) := rfl
 

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -320,8 +320,8 @@ multiplicative equivalence between `Π j, Ms j` and `Π j, Ns j`.
 This is the `mul_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
 `mul_equiv.arrow_congr`.
 -/
-@[to_additive add_equiv.Pi_congr_right "A family of additive equivalences `Π j, (Ms j ≃+ Ns j)` generates an
-additive equivalence between `Π j, Ms j` and `Π j, Ns j`.
+@[to_additive add_equiv.Pi_congr_right "A family of additive equivalences `Π j, (Ms j ≃+ Ns j)`
+generates an additive equivalence between `Π j, Ms j` and `Π j, Ns j`.
 
 This is the `add_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
 `add_equiv.arrow_congr`.", simps]

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -329,8 +329,20 @@ def Pi_congr_right {η : Type*}
   {Ms Ns : η → Type*} [Π j, mul_one_class (Ms j)] [Π j, mul_one_class (Ns j)]
   (es : ∀ j, Ms j ≃* Ns j) : (Π j, Ms j) ≃* (Π j, Ns j) :=
 { to_fun := λ x j, es j (x j),
+  inv_fun := λ x j, (es j).symm (x j),
   map_mul' := λ x y, funext $ λ j, (es j).map_mul (x j) (y j),
   .. equiv.Pi_congr_right (λ j, (es j).to_equiv) }
+
+@[simp]
+lemma Pi_congr_right_refl {η : Type*} {Ms : η → Type*} [Π j, mul_one_class (Ms j)] :
+  Pi_congr_right (λ j, mul_equiv.refl (Ms j)) = mul_equiv.refl _ := rfl
+
+@[simp]
+lemma Pi_congr_right_trans {η : Type*}
+  {Ms Ns Ps : η → Type*} [Π j, mul_one_class (Ms j)] [Π j, mul_one_class (Ns j)]
+  [Π j, mul_one_class (Ps j)]
+  (es : ∀ j, Ms j ≃* Ns j) (fs : ∀ j, Ns j ≃* Ps j) :
+  (Pi_congr_right es).trans (Pi_congr_right fs) = (Pi_congr_right $ λ i, (es i).trans (fs i)) := rfl
 
 /-!
 # Groups

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -324,20 +324,13 @@ This is the `mul_equiv` version of `equiv.Pi_congr_right`, and the dependent ver
 additive equivalence between `Π j, Ms j` and `Π j, Ns j`.
 
 This is the `add_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
-`add_equiv.arrow_congr`."]
+`add_equiv.arrow_congr`.", simps]
 def Pi_congr_right {η : Type*}
   {Ms Ns : η → Type*} [Π j, mul_one_class (Ms j)] [Π j, mul_one_class (Ns j)]
   (es : ∀ j, Ms j ≃* Ns j) : (Π j, Ms j) ≃* (Π j, Ns j) :=
-{ map_mul' := λ x y,
-  by { ext j,
-       simp_rw [equiv.Pi_congr_right, pi.mul_apply, mul_equiv.coe_to_equiv, mul_equiv.map_mul] },
+{ to_fun := λ x j, es j (x j),
+  map_mul' := λ x y, funext $ λ j, (es j).map_mul (x j) (y j),
   .. equiv.Pi_congr_right (λ j, (es j).to_equiv) }
-
-@[simp, to_additive add_equiv.Pi_congr_right_apply]
-lemma Pi_congr_right_apply {η : Type*}
-  {Ms Ns : η → Type*} [Π j, mul_one_class (Ms j)] [Π j, mul_one_class (Ns j)]
-  (es : ∀ j, Ms j ≃* Ns j) (x j) :
-  mul_equiv.Pi_congr_right es x j = es j (x j) := rfl
 
 /-!
 # Groups

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -324,7 +324,7 @@ This is the `mul_equiv` version of `equiv.Pi_congr_right`, and the dependent ver
 generates an additive equivalence between `Π j, Ms j` and `Π j, Ns j`.
 
 This is the `add_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
-`add_equiv.arrow_congr`.", simps]
+`add_equiv.arrow_congr`.", simps apply]
 def Pi_congr_right {η : Type*}
   {Ms Ns : η → Type*} [Π j, mul_one_class (Ms j)] [Π j, mul_one_class (Ns j)]
   (es : ∀ j, Ms j ≃* Ns j) : (Π j, Ms j) ≃* (Π j, Ns j) :=
@@ -336,6 +336,11 @@ def Pi_congr_right {η : Type*}
 @[simp]
 lemma Pi_congr_right_refl {η : Type*} {Ms : η → Type*} [Π j, mul_one_class (Ms j)] :
   Pi_congr_right (λ j, mul_equiv.refl (Ms j)) = mul_equiv.refl _ := rfl
+
+@[simp]
+lemma Pi_congr_right_symm {η : Type*}
+  {Ms Ns : η → Type*} [Π j, mul_one_class (Ms j)] [Π j, mul_one_class (Ns j)]
+  (es : ∀ j, Ms j ≃* Ns j) : (Pi_congr_right es).symm = (Pi_congr_right $ λ i, (es i).symm) := rfl
 
 @[simp]
 lemma Pi_congr_right_trans {η : Type*}

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1937,7 +1937,7 @@ end
 
 /-- A family of linear equivalences `Π j, (Ms j ≃ₗ[R] Ns j)` generates a
 linear equivalence between `Π j, Ms j` and `Π j, Ns j`. -/
-@[simps]
+@[simps apply]
 def Pi_congr_right {η : Type*} {Ms Ns : η → Type*}
   [Π j, add_comm_monoid (Ms j)] [Π j, module R (Ms j)]
   [Π j, add_comm_monoid (Ns j)] [Π j, module R (Ns j)]
@@ -1951,6 +1951,13 @@ def Pi_congr_right {η : Type*} {Ms Ns : η → Type*}
 lemma Pi_congr_right_refl {η : Type*} {Ms : η → Type*}
   [Π j, add_comm_monoid (Ms j)] [Π j, module R (Ms j)] :
   Pi_congr_right (λ j, refl R (Ms j)) = refl _ _ := rfl
+
+@[simp]
+lemma Pi_congr_right_symm {η : Type*} {Ms Ns Ps : η → Type*}
+[Π j, add_comm_monoid (Ms j)] [Π j, module R (Ms j)]
+[Π j, add_comm_monoid (Ns j)] [Π j, module R (Ns j)]
+  (es : ∀ j, Ms j ≃ₗ[R] Ns j) :
+(Pi_congr_right es).symm = (Pi_congr_right $ λ i, (es i).symm) := rfl
 
 @[simp]
 lemma Pi_congr_right_trans {η : Type*} {Ms Ns Ps : η → Type*}

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1935,6 +1935,21 @@ def of_submodule (p : submodule R M) : p ≃ₗ[R] ↥(p.map ↑e : submodule R 
 
 end
 
+/-- A family of linear equivalences `Π j, (Ms j ≃ₗ[R] Ns j)` generates a
+linear equivalence between `Π j, Ms j` and `Π j, Ns j`. -/
+def linear_equiv.Pi_congr_right {η : Type*} {Ms Ns : η → Type*}
+  [Π j, add_comm_monoid (Ms j)] [Π j, module R (Ms j)]
+  [Π j, add_comm_monoid (Ns j)] [Π j, module R (Ns j)]
+  (es : ∀ j, Ms j ≃ₗ[R] Ns j) : (Π j, Ms j) ≃ₗ[R] (Π j, Ns j) :=
+{ map_smul' := λ m x, by { ext j, simp },
+  .. add_equiv.Pi_congr_right (λ j, (es j).to_add_equiv) }
+
+@[simp]
+lemma linear_equiv.Pi_congr_right_apply {η : Type*} {Ms Ns : η → Type*}
+  [Π j, add_comm_monoid (Ms j)] [Π j, module R (Ms j)]
+  [Π j, add_comm_monoid (Ns j)] [Π j, module R (Ns j)]
+  (es : ∀ j, Ms j ≃ₗ[R] Ns j) (x j) :
+  linear_equiv.Pi_congr_right es x j = es j (x j) := rfl
 
 section uncurry
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1937,19 +1937,29 @@ end
 
 /-- A family of linear equivalences `Π j, (Ms j ≃ₗ[R] Ns j)` generates a
 linear equivalence between `Π j, Ms j` and `Π j, Ns j`. -/
-def linear_equiv.Pi_congr_right {η : Type*} {Ms Ns : η → Type*}
+@[simps]
+def Pi_congr_right {η : Type*} {Ms Ns : η → Type*}
   [Π j, add_comm_monoid (Ms j)] [Π j, module R (Ms j)]
   [Π j, add_comm_monoid (Ns j)] [Π j, module R (Ns j)]
   (es : ∀ j, Ms j ≃ₗ[R] Ns j) : (Π j, Ms j) ≃ₗ[R] (Π j, Ns j) :=
-{ map_smul' := λ m x, by { ext j, simp },
+{ to_fun := λ x j, es j (x j),
+  inv_fun := λ x j, (es j).symm (x j),
+  map_smul' := λ m x, by { ext j, simp },
   .. add_equiv.Pi_congr_right (λ j, (es j).to_add_equiv) }
 
 @[simp]
-lemma linear_equiv.Pi_congr_right_apply {η : Type*} {Ms Ns : η → Type*}
+lemma Pi_congr_right_refl {η : Type*} {Ms : η → Type*}
+  [Π j, add_comm_monoid (Ms j)] [Π j, module R (Ms j)] :
+  Pi_congr_right (λ j, refl R (Ms j)) = refl _ _ := rfl
+
+@[simp]
+lemma Pi_congr_right_trans {η : Type*} {Ms Ns Ps : η → Type*}
   [Π j, add_comm_monoid (Ms j)] [Π j, module R (Ms j)]
   [Π j, add_comm_monoid (Ns j)] [Π j, module R (Ns j)]
-  (es : ∀ j, Ms j ≃ₗ[R] Ns j) (x j) :
-  linear_equiv.Pi_congr_right es x j = es j (x j) := rfl
+  [Π j, add_comm_monoid (Ps j)] [Π j, module R (Ps j)]
+  (es : ∀ j, Ms j ≃ₗ[R] Ns j) (fs : ∀ j, Ns j ≃ₗ[R] Ps j) :
+  (Pi_congr_right es).trans (Pi_congr_right fs) = (Pi_congr_right $ λ i, (es i).trans (fs i)) :=
+rfl
 
 section uncurry
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1954,8 +1954,8 @@ lemma Pi_congr_right_refl {η : Type*} {Ms : η → Type*}
 
 @[simp]
 lemma Pi_congr_right_symm {η : Type*} {Ms Ns Ps : η → Type*}
-[Π j, add_comm_monoid (Ms j)] [Π j, module R (Ms j)]
-[Π j, add_comm_monoid (Ns j)] [Π j, module R (Ns j)]
+  [Π j, add_comm_monoid (Ms j)] [Π j, module R (Ms j)]
+  [Π j, add_comm_monoid (Ns j)] [Π j, module R (Ns j)]
   (es : ∀ j, Ms j ≃ₗ[R] Ns j) :
 (Pi_congr_right es).symm = (Pi_congr_right $ λ i, (es i).symm) := rfl
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1953,7 +1953,7 @@ lemma Pi_congr_right_refl {η : Type*} {Ms : η → Type*}
   Pi_congr_right (λ j, refl R (Ms j)) = refl _ _ := rfl
 
 @[simp]
-lemma Pi_congr_right_symm {η : Type*} {Ms Ns Ps : η → Type*}
+lemma Pi_congr_right_symm {η : Type*} {Ms Ns : η → Type*}
   [Π j, add_comm_monoid (Ms j)] [Π j, module R (Ms j)]
   [Π j, add_comm_monoid (Ns j)] [Π j, module R (Ns j)]
   (es : ∀ j, Ms j ≃ₗ[R] Ns j) :


### PR DESCRIPTION
This PR generalizes `equiv.Pi_congr_right` to linear equivs, adding the `mul_equiv`/`add_equiv` version as well.

To be used in the `bundled-basis` refactor



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
