### PR TITLE
[Merged by Bors] - feat(data/finsupp,linear_algebra): `finsupp.split` is an equivalence

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -2232,6 +2232,36 @@ lemma sigma_sum [add_comm_monoid N] (f : (Σ (i : ι), αs i) → M → N) :
   l.sum f = ∑ i in split_support l, (split l i).sum (λ (a : αs i) b, f ⟨i, a⟩ b) :=
 by simp only [sum, sigma_support, sum_sigma, split_apply]
 
+variables {η : Type*} [fintype η] {ιs : η → Type*} [has_zero α]
+
+/-- On a `fintype η`, `finsupp.split` is an equivalence between `(Σ (j : η), ιs j) →₀ α`
+and `Π j, (ιs j →₀ α)`. -/
+noncomputable def sigma_finsupp_equiv_pi_finsupp :
+  ((Σ j, ιs j) →₀ α) ≃ Π j, (ιs j →₀ α) :=
+{ to_fun := λ f j, f.split j,
+  inv_fun := λ f, on_finset
+    (finset.sigma finset.univ (λ j, (f j).support))
+    (λ ji, f ji.1 ji.2)
+    (λ g hg, finset.mem_sigma.mpr ⟨finset.mem_univ _, mem_support_iff.mpr hg⟩),
+  left_inv := λ f, by { ext, simp [split] },
+  right_inv := λ f, by { ext, simp [split] } }
+
+@[simp] lemma sigma_finsupp_equiv_pi_finsupp_apply
+  (f : (Σ j, ιs j) →₀ α) (j i) :
+sigma_finsupp_equiv_pi_finsupp f j i = f ⟨j, i⟩ := rfl
+
+/-- On a `fintype η`, `finsupp.split` is an additive equivalence between
+`(Σ (j : η), ιs j) →₀ α` and `Π j, (ιs j →₀ α)`. -/
+noncomputable def sigma_finsupp_add_equiv_pi_finsupp
+  {α : Type*} {ιs : η → Type*} [add_monoid α] :
+  ((Σ j, ιs j) →₀ α) ≃+ Π j, (ιs j →₀ α) :=
+{ map_add' := λ f g, by { ext, simp },
+  .. sigma_finsupp_equiv_pi_finsupp }
+
+@[simp] lemma sigma_finsupp_add_equiv_pi_finsupp_apply
+  {α : Type*} {ιs : η → Type*} [add_monoid α] (f : (Σ j, ιs j) →₀ α) (j i) :
+sigma_finsupp_add_equiv_pi_finsupp f j i = f ⟨j, i⟩ := rfl
+
 end sigma
 
 end finsupp

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -2187,7 +2187,10 @@ variables {αs : ι → Type*} [has_zero M] (l : (Σ i, αs i) →₀ M)
 
 /-- Given `l`, a finitely supported function from the sigma type `Σ (i : ι), αs i` to `M` and
 an index element `i : ι`, `split l i` is the `i`th component of `l`,
-a finitely supported function from `as i` to `M`. -/
+a finitely supported function from `as i` to `M`.
+
+This is the `finsupp` version of `sigma.curry`.
+-/
 def split (i : ι) : αs i →₀ M :=
 l.comap_domain (sigma.mk i) (λ x1 x2 _ _ hx, heq_iff_eq.1 (sigma.mk.inj hx).2)
 
@@ -2235,7 +2238,9 @@ by simp only [sum, sigma_support, sum_sigma, split_apply]
 variables {η : Type*} [fintype η] {ιs : η → Type*} [has_zero α]
 
 /-- On a `fintype η`, `finsupp.split` is an equivalence between `(Σ (j : η), ιs j) →₀ α`
-and `Π j, (ιs j →₀ α)`. -/
+and `Π j, (ιs j →₀ α)`.
+
+This is the `finsupp` version of `equiv.Pi_curry`. -/
 noncomputable def sigma_finsupp_equiv_pi_finsupp :
   ((Σ j, ιs j) →₀ α) ≃ Π j, (ιs j →₀ α) :=
 { to_fun := split,
@@ -2251,7 +2256,10 @@ noncomputable def sigma_finsupp_equiv_pi_finsupp :
 sigma_finsupp_equiv_pi_finsupp f j i = f ⟨j, i⟩ := rfl
 
 /-- On a `fintype η`, `finsupp.split` is an additive equivalence between
-`(Σ (j : η), ιs j) →₀ α` and `Π j, (ιs j →₀ α)`. -/
+`(Σ (j : η), ιs j) →₀ α` and `Π j, (ιs j →₀ α)`.
+
+This is the `add_equiv` version of `finsupp.sigma_finsupp_equiv_pi_finsupp`.
+-/
 noncomputable def sigma_finsupp_add_equiv_pi_finsupp
   {α : Type*} {ιs : η → Type*} [add_monoid α] :
   ((Σ j, ιs j) →₀ α) ≃+ Π j, (ιs j →₀ α) :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -2238,9 +2238,9 @@ variables {η : Type*} [fintype η] {ιs : η → Type*} [has_zero α]
 and `Π j, (ιs j →₀ α)`. -/
 noncomputable def sigma_finsupp_equiv_pi_finsupp :
   ((Σ j, ιs j) →₀ α) ≃ Π j, (ιs j →₀ α) :=
-{ to_fun := λ f j, f.split j,
+{ to_fun := split,
   inv_fun := λ f, on_finset
-    (finset.sigma finset.univ (λ j, (f j).support))
+    (finset.univ.sigma (λ j, (f j).support))
     (λ ji, f ji.1 ji.2)
     (λ g hg, finset.mem_sigma.mpr ⟨finset.mem_univ _, mem_support_iff.mpr hg⟩),
   left_inv := λ f, by { ext, simp [split] },

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -704,7 +704,9 @@ variables {η : Type*} [fintype η] {ιs : η → Type*} [has_zero α]
 variables (R)
 
 /-- On a `fintype η`, `finsupp.split` is a linear equivalence between
-`(Σ (j : η), ιs j) →₀ M` and `Π j, (ιs j →₀ M)`. -/
+`(Σ (j : η), ιs j) →₀ M` and `Π j, (ιs j →₀ M)`.
+
+This is the `linear_equiv` version of `finsupp.sigma_finsupp_add_equiv_pi_finsupp`. -/
 noncomputable def sigma_finsupp_lequiv_pi_finsupp
   {M : Type*} {ιs : η → Type*} [add_comm_monoid M] [module R M] :
   ((Σ j, ιs j) →₀ M) ≃ₗ[R] Π j, (ιs j →₀ M) :=

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -698,6 +698,31 @@ rfl
 
 end sum
 
+section sigma
+
+variables {η : Type*} [fintype η] {ιs : η → Type*} [has_zero α]
+variables (R)
+
+/-- On a `fintype η`, `finsupp.split` is a linear equivalence between
+`(Σ (j : η), ιs j) →₀ M` and `Π j, (ιs j →₀ M)`. -/
+noncomputable def sigma_finsupp_lequiv_pi_finsupp
+  {M : Type*} {ιs : η → Type*} [add_comm_monoid M] [module R M] :
+  ((Σ j, ιs j) →₀ M) ≃ₗ[R] Π j, (ιs j →₀ M) :=
+{ map_smul' := λ c f, by { ext, simp },
+  .. sigma_finsupp_add_equiv_pi_finsupp }
+
+@[simp] lemma sigma_finsupp_lequiv_pi_finsupp_apply
+  {M : Type*} {ιs : η → Type*} [add_comm_monoid M] [module R M]
+  (f : (Σ j, ιs j) →₀ M) (j i) :
+  sigma_finsupp_lequiv_pi_finsupp R f j i = f ⟨j, i⟩ := rfl
+
+@[simp] lemma sigma_finsupp_lequiv_pi_finsupp_symm_apply
+  {M : Type*} {ιs : η → Type*} [add_comm_monoid M] [module R M]
+  (f : Π j, (ιs j →₀ M)) (ji) :
+  (finsupp.sigma_finsupp_lequiv_pi_finsupp R).symm f ji = f ji.1 ji.2 := rfl
+
+end sigma
+
 section prod
 
 /-- The linear equivalence between `α × β →₀ M` and `α →₀ β →₀ M`.


### PR DESCRIPTION
This PR shows that for finite types `η`, `finsupp.split` is an equivalence between `(Σ (j : η), ιs j) →₀ α` and `Π j, (ιs j →₀ α)`.

To be used in the `bundled-basis` refactor



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
