### PR TITLE
[Merged by Bors] - feat(category_theory/path_category): extensionality for functors out of path category

### DIFF
--- a/src/category_theory/category/Quiv.lean
+++ b/src/category_theory/category/Quiv.lean
@@ -52,8 +52,6 @@ end Quiv
 
 namespace Cat
 
-local attribute [ext] functor.ext
-
 /-- The functor sending each quiver to its path category. -/
 @[simps]
 def free : Quiv.{v u} ⥤ Cat.{(max u v) u} :=
@@ -62,31 +60,13 @@ def free : Quiv.{v u} ⥤ Cat.{(max u v) u} :=
   { obj := λ X, F.obj X,
     map := λ X Y f, F.map_path f,
     map_comp' := λ X Y Z f g, F.map_path_comp f g, },
-  map_id' := λ V, begin
-    ext; dsimp,
-    { induction f with b c p e ih,
-      { refl, },
-      { dsimp,
-        erw [ih, functor.id_map, functor.id_map, prefunctor.id_map],
-        simp, }, },
-    { intros X, erw [functor.id_obj, prefunctor.id_obj], refl, },
-  end,
+  map_id' := λ V, by { change (show paths V ⥤ _, from _) = _, ext, apply eq_conj_eq_to_hom, refl },
   map_comp' := λ U V W F G,
-  begin
-    ext; dsimp,
-    { induction f with b c p e ih,
-      { refl, },
-      { dsimp,
-        erw [ih, functor.id_map, functor.id_map, prefunctor.id_map],
-        simp, }, },
-    { intros X, erw [functor.id_obj, prefunctor.id_obj], refl, },
-  end }
+    by { change (show paths U ⥤ _, from _) = _, ext, apply eq_conj_eq_to_hom, refl } }
 
 end Cat
 
 namespace Quiv
-
-local attribute [ext] functor.ext
 
 /-- Any prefunctor into a category lifts to a functor from the path category. -/
 @[simps]
@@ -105,38 +85,18 @@ The adjunction between forming the free category on a quiver, and forgetting a c
 def adj : Cat.free ⊣ Quiv.forget :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ V C,
-  { to_fun := λ F,
-    -- This would be better as a composition `V ⥤ paths V ⥤ C ⥤ forget.obj C`
-    { obj := λ X, F.obj X,
-      map := λ X Y f, F.map f.to_path, },
+  { to_fun := λ F, paths.of.comp F.to_prefunctor,
     inv_fun := λ F, lift F,
-    left_inv := λ F, begin
-      ext,
-      { dsimp, simp,
-        induction f with Y' Z' f g ih,
-        { exact (F.map_id X).symm, },
-        { dsimp, simp only [ih],
-          exact (F.map_comp _ _).symm, }, },
-      { dsimp, simp, },
-    end,
+    left_inv := λ F, by { ext, { erw (eq_conj_eq_to_hom _).symm, apply category.id_comp }, refl },
     right_inv := begin
       rintro ⟨obj,map⟩,
-      dsimp,
+      dsimp only [prefunctor.comp],
       congr,
       ext X Y f,
       exact category.id_comp _,
     end, },
   hom_equiv_naturality_left_symm' := λ V W C f g,
-  begin
-    ext X Y h,
-    { dsimp,
-      erw [functor.comp_map],
-      simp only [category.comp_id, category.id_comp, Cat.free_map_map, Quiv.lift_map],
-      induction h with Y' Z h e ih,
-      { refl, },
-      { simp [ih], refl, }, },
-    { intro X, refl, },
-  end, }
+    by { change (show paths V ⥤ _, from _) = _, ext, apply eq_conj_eq_to_hom, refl } }
 
 end Quiv
 

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -140,4 +140,8 @@ lemma nat_trans.congr {F G : C ⥤ D} (α : F ⟶ G) {X Y : C} (h : X = Y) :
   α.app X = F.map (eq_to_hom h) ≫ α.app Y ≫ G.map (eq_to_hom h.symm) :=
 by { rw [α.naturality_assoc], simp }
 
+lemma eq_conj_eq_to_hom {X Y : C} (f : X ⟶ Y) :
+  f = eq_to_hom rfl ≫ f ≫ eq_to_hom rfl :=
+by simp only [category.id_comp, eq_to_hom_refl, category.comp_id]
+
 end category_theory

--- a/src/category_theory/path_category.lean
+++ b/src/category_theory/path_category.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.category
+import category_theory.eq_to_hom
 
 /-!
 # The category paths on a quiver.
@@ -40,6 +40,25 @@ The inclusion of a quiver `V` into its path category, as a prefunctor.
 def of : prefunctor V (paths V) :=
 { obj := λ X, X,
   map := λ X Y f, f.to_path, }
+
+local attribute [ext] functor.ext
+
+/-- Two functors out of a path category are equal when they agree on singleton paths. -/
+@[ext]
+lemma ext_functor {C} [category C]
+  {F G : paths V ⥤ C}
+  (h_obj : F.obj = G.obj)
+  (h : ∀ a b (e : a ⟶ b), F.map e.to_path =
+  eq_to_hom (congr_fun h_obj a) ≫ G.map e.to_path ≫ eq_to_hom (congr_fun h_obj.symm b)) :
+  F = G :=
+begin
+  ext X Y f,
+  { induction f with Y' Z' g e ih,
+    { erw [F.map_id, G.map_id, category.id_comp, eq_to_hom_trans, eq_to_hom_refl], },
+    { erw [F.map_comp g e.to_path, G.map_comp g e.to_path, ih, h],
+      simp only [category.id_comp, eq_to_hom_refl, eq_to_hom_trans_assoc, category.assoc], }, },
+  { intro X, rw h_obj, }
+end
 
 end paths
 

--- a/src/category_theory/path_category.lean
+++ b/src/category_theory/path_category.lean
@@ -48,7 +48,7 @@ local attribute [ext] functor.ext
 lemma ext_functor {C} [category C]
   {F G : paths V ⥤ C}
   (h_obj : F.obj = G.obj)
-  (h : ∀ a b (e : a ⟶ b), F.map e.to_path =
+  (h : ∀ (a b : V) (e : a ⟶ b), F.map e.to_path =
   eq_to_hom (congr_fun h_obj a) ≫ G.map e.to_path ≫ eq_to_hom (congr_fun h_obj.symm b)) :
   F = G :=
 begin


### PR DESCRIPTION
This adds an extensionality lemma for functors out of a path category, which simplifies some proofs in the free-forgetful adjunction.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
