### PR TITLE
[Merged by Bors] - chore(data/equiv/basic): Show that `Pi_curry` is really just `sigma.curry`

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
 import data.set.function
+import data.sigma.basic
 
 /-!
 # Equivalence between types
@@ -951,13 +952,15 @@ def Pi_congr_right {α} {β₁ β₂ : α → Sort*} (F : Π a, β₁ a ≃ β�
  λ H, funext $ by simp, λ H, funext $ by simp⟩
 
 /-- Dependent `curry` equivalence: the type of dependent functions on `Σ i, β i` is equivalent
-to the type of dependent functions of two arguments (i.e., functions to the space of functions). -/
+to the type of dependent functions of two arguments (i.e., functions to the space of functions).
+
+This is `sigma.curry` and `sigma.uncurry` together as an equiv. -/
 def Pi_curry {α} {β : α → Sort*} (γ : Π a, β a → Sort*) :
   (Π x : Σ i, β i, γ x.1 x.2) ≃ (Π a b, γ a b) :=
-{ to_fun := λ f x y, f ⟨x,y⟩,
-  inv_fun := λ f x, f x.1 x.2,
-  left_inv := λ f, funext $ λ ⟨x,y⟩, rfl,
-  right_inv := λ f, funext $ λ x, funext $ λ y, rfl }
+{ to_fun := sigma.curry,
+  inv_fun := sigma.uncurry,
+  left_inv := sigma.uncurry_curry,
+  right_inv := sigma.curry_uncurry }
 
 end
 

--- a/src/data/sigma/basic.lean
+++ b/src/data/sigma/basic.lean
@@ -98,6 +98,16 @@ f ⟨x,y⟩
 def sigma.uncurry {γ : Π a, β a → Type*} (f : Π x (y : β x), γ x y) (x : sigma β) : γ x.1 x.2 :=
 f x.1 x.2
 
+@[simp]
+def sigma.uncurry_curry {γ : Π a, β a → Type*} (f : Π x : sigma β, γ x.1 x.2) :
+  sigma.uncurry (sigma.curry f) = f :=
+funext $ λ ⟨i, j⟩, rfl
+
+@[simp]
+def sigma.curry_uncurry {γ : Π a, β a → Type*} (f : Π x (y : β x), γ x y) :
+  sigma.curry (sigma.uncurry f) = f :=
+rfl
+
 /-- Convert a product type to a Σ-type. -/
 @[simp]
 def prod.to_sigma {α β} : α × β → Σ _ : α, β

--- a/src/data/sigma/basic.lean
+++ b/src/data/sigma/basic.lean
@@ -90,11 +90,15 @@ begin
   exact ⟨⟨i, x⟩, rfl⟩
 end
 
-/-- Interpret a function on `Σ x : α, β x` as a dependent function with two arguments. -/
+/-- Interpret a function on `Σ x : α, β x` as a dependent function with two arguments.
+
+This also exists as an `equiv` as `equiv.Pi_curry γ`. -/
 def sigma.curry {γ : Π a, β a → Type*} (f : Π x : sigma β, γ x.1 x.2) (x : α) (y : β x) : γ x y :=
 f ⟨x,y⟩
 
-/-- Interpret a dependent function with two arguments as a function on `Σ x : α, β x` -/
+/-- Interpret a dependent function with two arguments as a function on `Σ x : α, β x`.
+
+This also exists as an `equiv` as `(equiv.Pi_curry γ).symm`. -/
 def sigma.uncurry {γ : Π a, β a → Type*} (f : Π x (y : β x), γ x y) (x : sigma β) : γ x.1 x.2 :=
 f x.1 x.2
 

--- a/src/data/sigma/basic.lean
+++ b/src/data/sigma/basic.lean
@@ -99,12 +99,12 @@ def sigma.uncurry {γ : Π a, β a → Type*} (f : Π x (y : β x), γ x y) (x :
 f x.1 x.2
 
 @[simp]
-def sigma.uncurry_curry {γ : Π a, β a → Type*} (f : Π x : sigma β, γ x.1 x.2) :
+lemma sigma.uncurry_curry {γ : Π a, β a → Type*} (f : Π x : sigma β, γ x.1 x.2) :
   sigma.uncurry (sigma.curry f) = f :=
 funext $ λ ⟨i, j⟩, rfl
 
 @[simp]
-def sigma.curry_uncurry {γ : Π a, β a → Type*} (f : Π x (y : β x), γ x y) :
+lemma sigma.curry_uncurry {γ : Π a, β a → Type*} (f : Π x (y : β x), γ x y) :
   sigma.curry (sigma.uncurry f) = f :=
 rfl
 


### PR DESCRIPTION
Extracts some proofs to their own lemmas, and replaces definitions with existing ones.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
