### PR TITLE
[Merged by Bors] - feat(category_theory/opposites): Adds equivalences for functor categories.

### DIFF
--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -113,13 +113,11 @@ protected def unop (F : Cᵒᵖ ⥤ Dᵒᵖ) : C ⥤ D :=
   map := λ X Y f, (F.map f.op).unop }
 
 /-- The isomorphism between `F.op.unop` and `F`. -/
-@[simp]
-def op_unop_iso (F : C ⥤ D) : F.op.unop ≅ F :=
+@[simp] def op_unop_iso (F : C ⥤ D) : F.op.unop ≅ F :=
 nat_iso.of_components (λ X, iso.refl _) (by tidy)
 
 /-- The isomorphism between `F.unop.op` and `F`. -/
-@[simp]
-def unop_op_iso (F : Cᵒᵖ ⥤ Dᵒᵖ) : F.unop.op ≅ F :=
+@[simp] def unop_op_iso (F : Cᵒᵖ ⥤ Dᵒᵖ) : F.unop.op ≅ F :=
 nat_iso.of_components (λ X, iso.refl _) (by tidy)
 
 variables (C D)
@@ -373,6 +371,7 @@ namespace functor
 variables (C)
 variables (D : Type u₂) [category.{v₂} D]
 
+@[simps]
 def op_equiv : (C ⥤ D)ᵒᵖ ≌ Cᵒᵖ ⥤ Dᵒᵖ :=
 { functor := op_hom _ _,
   inverse := op_inv _ _,

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -113,10 +113,12 @@ protected def unop (F : Cᵒᵖ ⥤ Dᵒᵖ) : C ⥤ D :=
   map := λ X Y f, (F.map f.op).unop }
 
 /-- The isomorphism between `F.op.unop` and `F`. -/
+@[simp]
 def op_unop_iso (F : C ⥤ D) : F.op.unop ≅ F :=
 nat_iso.of_components (λ X, iso.refl _) (by tidy)
 
 /-- The isomorphism between `F.unop.op` and `F`. -/
+@[simp]
 def unop_op_iso (F : Cᵒᵖ ⥤ Dᵒᵖ) : F.unop.op ≅ F :=
 nat_iso.of_components (λ X, iso.refl _) (by tidy)
 
@@ -163,8 +165,6 @@ In informal mathematics no distinction is made.
 protected def right_op (F : Cᵒᵖ ⥤ D) : C ⥤ Dᵒᵖ :=
 { obj := λ X, op (F.obj (op X)),
   map := λ X Y f, (F.map f.op).op }
-
--- TODO show these form an equivalence
 
 instance {F : C ⥤ D} [full F] : full F.op :=
 { preimage := λ X Y f, (F.preimage f.unop).op }
@@ -367,5 +367,24 @@ quiver.hom.op (hom_of_le h)
 
 lemma le_of_op_hom {U V : αᵒᵖ} (h : U ⟶ V) : unop V ≤ unop U :=
 le_of_hom (h.unop)
+
+namespace functor
+
+variables (C)
+variables (D : Type u₂) [category.{v₂} D]
+
+def op_equiv : (C ⥤ D)ᵒᵖ ≌ Cᵒᵖ ⥤ Dᵒᵖ :=
+{ functor := op_hom _ _,
+  inverse := op_inv _ _,
+  unit_iso := nat_iso.of_components (λ F, F.unop.op_unop_iso.op) begin
+    intros F G f,
+    dsimp [op_unop_iso],
+    rw [(show f = f.unop.op, by simp), ← op_comp, ← op_comp],
+    congr' 1,
+    tidy,
+  end,
+  counit_iso := nat_iso.of_components (λ F, F.unop_op_iso) (by tidy) }
+
+end functor
 
 end category_theory

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -177,10 +177,12 @@ instance right_op_faithful {F : Cᵒᵖ ⥤ D} [faithful F] : faithful F.right_o
 instance left_op_faithful {F : C ⥤ Dᵒᵖ} [faithful F] : faithful F.left_op :=
 { map_injective' := λ X Y f g h, quiver.hom.unop_inj (map_injective F (quiver.hom.unop_inj h)) }
 
+/-- The isomorphism between `F.left_op.right_op` and `F`. -/
 @[simps]
 def left_op_right_op_iso (F : C ⥤ Dᵒᵖ) : F.left_op.right_op ≅ F :=
 nat_iso.of_components (λ X, iso.refl _) (by tidy)
 
+/-- The isomorphism between `F.right_op.left_op` and `F`. -/
 @[simps]
 def right_op_left_op_iso (F : Cᵒᵖ ⥤ D) : F.right_op.left_op ≅ F :=
 nat_iso.of_components (λ X, iso.refl _) (by tidy)

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -142,8 +142,6 @@ def op_inv : (Cᵒᵖ ⥤ Dᵒᵖ) ⥤ (C ⥤ D)ᵒᵖ :=
   { app := λ X, (α.app (op X)).unop,
     naturality' := λ X Y f, quiver.hom.op_inj $ (α.naturality f.op).symm } }
 
--- TODO show these form an equivalence
-
 variables {C D}
 
 /--
@@ -371,6 +369,7 @@ namespace functor
 variables (C)
 variables (D : Type u₂) [category.{v₂} D]
 
+/-- An equivalence of functor categories induced by `op`. -/
 @[simps]
 def op_equiv : (C ⥤ D)ᵒᵖ ≌ Cᵒᵖ ⥤ Dᵒᵖ :=
 { functor := op_hom _ _,

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -113,11 +113,11 @@ protected def unop (F : Cᵒᵖ ⥤ Dᵒᵖ) : C ⥤ D :=
   map := λ X Y f, (F.map f.op).unop }
 
 /-- The isomorphism between `F.op.unop` and `F`. -/
-@[simp] def op_unop_iso (F : C ⥤ D) : F.op.unop ≅ F :=
+@[simps] def op_unop_iso (F : C ⥤ D) : F.op.unop ≅ F :=
 nat_iso.of_components (λ X, iso.refl _) (by tidy)
 
 /-- The isomorphism between `F.unop.op` and `F`. -/
-@[simp] def unop_op_iso (F : Cᵒᵖ ⥤ Dᵒᵖ) : F.unop.op ≅ F :=
+@[simps] def unop_op_iso (F : Cᵒᵖ ⥤ Dᵒᵖ) : F.unop.op ≅ F :=
 nat_iso.of_components (λ X, iso.refl _) (by tidy)
 
 variables (C D)
@@ -177,13 +177,13 @@ instance right_op_faithful {F : Cᵒᵖ ⥤ D} [faithful F] : faithful F.right_o
 instance left_op_faithful {F : C ⥤ Dᵒᵖ} [faithful F] : faithful F.left_op :=
 { map_injective' := λ X Y f g h, quiver.hom.unop_inj (map_injective F (quiver.hom.unop_inj h)) }
 
-@[simp]
-def left_op_right_op_iso (F : C ⥤ Dᵒᵖ) : F ≅ F.left_op.right_op := nat_iso.of_components
-(λ X, iso.refl _) (by tidy)
+@[simps]
+def left_op_right_op_iso (F : C ⥤ Dᵒᵖ) : F.left_op.right_op ≅ F :=
+nat_iso.of_components (λ X, iso.refl _) (by tidy)
 
-@[simp]
-def right_op_left_op_iso (F : Cᵒᵖ ⥤ D) : F ≅ F.right_op.left_op := nat_iso.of_components
-(λ X, iso.refl _) (by tidy)
+@[simps]
+def right_op_left_op_iso (F : Cᵒᵖ ⥤ D) : F.right_op.left_op ≅ F :=
+nat_iso.of_components (λ X, iso.refl _) (by tidy)
 
 end
 
@@ -442,14 +442,14 @@ def left_op_right_op_equiv : (Cᵒᵖ ⥤ D)ᵒᵖ ≌ (C ⥤ Dᵒᵖ) :=
   inverse :=
   { obj := λ F, op F.left_op,
     map := λ F G η, η.left_op.op },
-  unit_iso := nat_iso.of_components (λ F, F.unop.right_op_left_op_iso.symm.op) begin
+  unit_iso := nat_iso.of_components (λ F, F.unop.right_op_left_op_iso.op) begin
     intros F G η,
     dsimp,
     rw [(show η = η.unop.op, by simp), ← op_comp, ← op_comp],
     congr' 1,
     tidy,
   end,
-  counit_iso := nat_iso.of_components (λ F, F.left_op_right_op_iso.symm) (by tidy) }
+  counit_iso := nat_iso.of_components (λ F, F.left_op_right_op_iso) (by tidy) }
 
 end functor
 


### PR DESCRIPTION
This PR adds the following equivalences for categories `C` and `D`:
1. `(C ⥤ D)ᵒᵖ ≌ Cᵒᵖ ⥤ Dᵒᵖ` induced by `op` and `unop`.
2.  `(Cᵒᵖ ⥤ D)ᵒᵖ ≌ (C ⥤ Dᵒᵖ)` induced by `left_op` and `right_op`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
