### PR TITLE
[Merged by Bors] - chore(order/complete_boolean_algebra): speed up Inf_sup_Inf

### DIFF
--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -55,7 +55,9 @@ theorem sup_infi_eq (a : α) (f : ι → α) : a ⊔ (⨅ i, f i) = ⨅ i, a ⊔
 theorem Inf_sup_Inf : Inf s ⊔ Inf t = (⨅p ∈ set.prod s t, (p : α × α).1 ⊔ p.2) :=
 begin
   apply le_antisymm,
-  { finish },
+  { simp only [and_imp, prod.forall, le_infi_iff, set.mem_prod],
+    intros a b ha hb,
+    exact sup_le_sup (Inf_le ha) (Inf_le hb) },
   { have : ∀ a ∈ s, (⨅p ∈ set.prod s t, (p : α × α).1 ⊔ p.2) ≤ a ⊔ Inf t,
     { assume a ha,
       have : (⨅p ∈ set.prod s t, ((p : α × α).1 : α) ⊔ p.2) ≤


### PR DESCRIPTION
On my machine, avoiding `finish` takes the proof from 13s to 0.3s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
