### PR TITLE
[Merged by Bors] - feat(field_theory/polynomial_galois_group): More flexible version of gal_action_hom_bijective_of_prime_degree

### DIFF
--- a/src/field_theory/polynomial_galois_group.lean
+++ b/src/field_theory/polynomial_galois_group.lean
@@ -393,7 +393,7 @@ end
 
 /-- An irreducible polynomial of prime degree with two non-real roots has full Galois group -/
 lemma gal_action_hom_bijective_of_prime_degree
-  {p : polynomial ℚ} (p_irr : irreducible p) (p_deg : p.nat_degree.prime)
+  (p : polynomial ℚ) (p_irr : irreducible p) (p_deg : p.nat_degree.prime)
   (p_roots : fintype.card (p.root_set ℂ) = fintype.card (p.root_set ℝ) + 2) :
   function.bijective (gal_action_hom p ℂ) :=
 begin
@@ -416,6 +416,34 @@ begin
     apply nat.add_left_cancel,
     rw [←p_roots, ←set.to_finset_card (root_set p ℝ), ←set.to_finset_card (root_set p ℂ)],
     exact gal_action_hom_bijective_of_prime_degree_aux.symm },
+end
+
+/-- Same as above, but with extra flexibility -/
+lemma gal_action_hom_bijective_of_prime_degree'
+  (p : polynomial ℚ) (p_irr : irreducible p) (p_deg : p.nat_degree.prime)
+  (p_roots1 : fintype.card (p.root_set ℝ) + 1 ≤ fintype.card (p.root_set ℂ))
+  (p_roots2 : fintype.card (p.root_set ℂ) ≤ fintype.card (p.root_set ℝ) + 3) :
+  function.bijective (gal_action_hom p ℂ) :=
+begin
+  let n := (gal_action_hom p ℂ (restrict p ℂ
+    (complex.conj_alg_equiv.restrict_scalars ℚ))).support.card,
+  have hn : 2 ∣ n :=
+  equiv.perm.two_dvd_card_support (by rw [←monoid_hom.map_pow, ←monoid_hom.map_pow,
+    show alg_equiv.restrict_scalars ℚ complex.conj_alg_equiv ^ 2 = 1,
+    from alg_equiv.ext complex.conj_conj, monoid_hom.map_one, monoid_hom.map_one]),
+  apply gal_action_hom_bijective_of_prime_degree p_irr p_deg,
+  have key := gal_action_hom_bijective_of_prime_degree_aux p,
+  simp_rw [set.to_finset_card] at key,
+  rw [key, add_le_add_iff_left] at p_roots1 p_roots2,
+  rw [key, add_right_inj],
+  change 1 ≤ n at p_roots1,
+  change n ≤ 3 at p_roots2,
+  change n = 2,
+  obtain ⟨m, hm⟩ := hn,
+  rw two_mul at hm,
+  rw hm at *,
+  exact nat.bit0_eq_bit0.mpr (le_antisymm (nat.bit0_le_bit1_iff.mp p_roots2)
+    (nat.succ_le_iff.mpr (nat.bit1_le_bit0_iff.mp p_roots1))),
 end
 
 end gal

--- a/src/field_theory/polynomial_galois_group.lean
+++ b/src/field_theory/polynomial_galois_group.lean
@@ -340,7 +340,7 @@ local attribute [instance] splits_ℚ_ℂ
 
 /-- The number of complex roots equals the number of real roots plus
   the number of roots not fixed by complex conjugation -/
-lemma gal_action_hom_bijective_of_prime_degree_aux {p : polynomial ℚ} :
+lemma gal_action_hom_bijective_of_prime_degree_aux (p : polynomial ℚ) :
   (p.root_set ℂ).to_finset.card = (p.root_set ℝ).to_finset.card +
   (gal_action_hom p ℂ (restrict p ℂ (complex.conj_alg_equiv.restrict_scalars ℚ))).support.card :=
 begin
@@ -393,7 +393,7 @@ end
 
 /-- An irreducible polynomial of prime degree with two non-real roots has full Galois group -/
 lemma gal_action_hom_bijective_of_prime_degree
-  (p : polynomial ℚ) (p_irr : irreducible p) (p_deg : p.nat_degree.prime)
+  {p : polynomial ℚ} (p_irr : irreducible p) (p_deg : p.nat_degree.prime)
   (p_roots : fintype.card (p.root_set ℂ) = fintype.card (p.root_set ℝ) + 2) :
   function.bijective (gal_action_hom p ℂ) :=
 begin
@@ -415,12 +415,12 @@ begin
   { rw ← equiv.perm.card_support_eq_two,
     apply nat.add_left_cancel,
     rw [←p_roots, ←set.to_finset_card (root_set p ℝ), ←set.to_finset_card (root_set p ℂ)],
-    exact gal_action_hom_bijective_of_prime_degree_aux.symm },
+    exact (gal_action_hom_bijective_of_prime_degree_aux p).symm },
 end
 
 /-- Same as above, but with extra flexibility -/
 lemma gal_action_hom_bijective_of_prime_degree'
-  (p : polynomial ℚ) (p_irr : irreducible p) (p_deg : p.nat_degree.prime)
+  {p : polynomial ℚ} (p_irr : irreducible p) (p_deg : p.nat_degree.prime)
   (p_roots1 : fintype.card (p.root_set ℝ) + 1 ≤ fintype.card (p.root_set ℂ))
   (p_roots2 : fintype.card (p.root_set ℂ) ≤ fintype.card (p.root_set ℝ) + 3) :
   function.bijective (gal_action_hom p ℂ) :=

--- a/src/field_theory/polynomial_galois_group.lean
+++ b/src/field_theory/polynomial_galois_group.lean
@@ -418,32 +418,30 @@ begin
     exact (gal_action_hom_bijective_of_prime_degree_aux p).symm },
 end
 
-/-- Same as above, but with extra flexibility -/
+/-- An irreducible polynomial of prime degree with 1-3 non-real roots has full Galois group -/
 lemma gal_action_hom_bijective_of_prime_degree'
   {p : polynomial ℚ} (p_irr : irreducible p) (p_deg : p.nat_degree.prime)
   (p_roots1 : fintype.card (p.root_set ℝ) + 1 ≤ fintype.card (p.root_set ℂ))
   (p_roots2 : fintype.card (p.root_set ℂ) ≤ fintype.card (p.root_set ℝ) + 3) :
   function.bijective (gal_action_hom p ℂ) :=
 begin
+  apply gal_action_hom_bijective_of_prime_degree p_irr p_deg,
   let n := (gal_action_hom p ℂ (restrict p ℂ
     (complex.conj_alg_equiv.restrict_scalars ℚ))).support.card,
   have hn : 2 ∣ n :=
   equiv.perm.two_dvd_card_support (by rw [←monoid_hom.map_pow, ←monoid_hom.map_pow,
     show alg_equiv.restrict_scalars ℚ complex.conj_alg_equiv ^ 2 = 1,
     from alg_equiv.ext complex.conj_conj, monoid_hom.map_one, monoid_hom.map_one]),
-  apply gal_action_hom_bijective_of_prime_degree p_irr p_deg,
   have key := gal_action_hom_bijective_of_prime_degree_aux p,
   simp_rw [set.to_finset_card] at key,
   rw [key, add_le_add_iff_left] at p_roots1 p_roots2,
   rw [key, add_right_inj],
-  change 1 ≤ n at p_roots1,
-  change n ≤ 3 at p_roots2,
-  change n = 2,
-  obtain ⟨m, hm⟩ := hn,
-  rw two_mul at hm,
-  rw hm at *,
-  exact nat.bit0_eq_bit0.mpr (le_antisymm (nat.bit0_le_bit1_iff.mp p_roots2)
-    (nat.succ_le_iff.mpr (nat.bit1_le_bit0_iff.mp p_roots1))),
+  suffices : ∀ m : ℕ, 2 ∣ m → 1 ≤ m → m ≤ 3 → m = 2,
+  { exact this n hn p_roots1 p_roots2 },
+  rintros m ⟨k, rfl⟩ h2 h3,
+  exact le_antisymm (nat.lt_succ_iff.mp (lt_of_le_of_ne h3 (show 2 * k ≠ 2 * 1 + 1,
+    from nat.two_mul_ne_two_mul_add_one))) (nat.succ_le_iff.mpr (lt_of_le_of_ne h2
+    (show 2 * 0 + 1 ≠ 2 * k, from nat.two_mul_ne_two_mul_add_one.symm))),
 end
 
 end gal

--- a/src/group_theory/perm/cycle_type.lean
+++ b/src/group_theory/perm/cycle_type.lean
@@ -202,6 +202,11 @@ begin
   exact dvd_lcm h,
 end
 
+lemma two_dvd_card_support {σ : perm α} (hσ : σ ^ 2 = 1) : 2 ∣ σ.support.card :=
+(congr_arg (has_dvd.dvd 2) σ.sum_cycle_type).mp
+  (multiset.dvd_sum (λ n hn, by rw le_antisymm (nat.le_of_dvd zero_lt_two (dvd_trans
+  (dvd_of_mem_cycle_type hn) (order_of_dvd_of_pow_eq_one hσ))) (two_le_of_mem_cycle_type hn)))
+
 lemma cycle_type_prime_order {σ : perm α} (hσ : (order_of σ).prime) :
   ∃ n : ℕ, σ.cycle_type = repeat (order_of σ) (n + 1) :=
 begin


### PR DESCRIPTION
Since the number of non-real roots is even, we can make a more flexible version of `gal_action_hom_bijective_of_prime_degree`. This flexibility will be helpful when working with a specific polynomial.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
