### PR TITLE
[Merged by Bors] - Change the bors timeout to 8 hours

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = ["Build mathlib", "Lint mathlib", "Run tests", "Lint style"]
 use_squash_merge = true
-timeout_sec = 21600
+timeout_sec = 28800
 block_labels = ["not-ready-to-merge", "WIP", "blocked-by-other-PR"]
 delete_merged_branches = true
 cut_body_after = "---"


### PR DESCRIPTION
We've hit a 6 hour timeout repeatedly in the last few days, resulting in nothing getting built.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
