### PR TITLE
[Merged by Bors] - feat(data/list/basic): non-meta to_chunks

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4874,11 +4874,6 @@ theorem to_chunks_aux_eq (n) : ∀ xs i,
 | (x::xs) 0 := by rw [to_chunks_aux, drop, to_chunks]; cases to_chunks_aux n xs n; refl
 | (x::xs) (i+1) := by rw [to_chunks_aux, to_chunks_aux_eq]; refl
 
--- theorem to_chunks_eq_cons' (n) : ∀ (xs : list α),
---   xs.to_chunks (n+1) = xs.take (n+1) :: (xs.drop (n+1)).to_chunks (n+1)
--- | [] := rfl
--- | (x::xs) := by rw [to_chunks, to_chunks_aux_eq]; refl
-
 theorem to_chunks_eq_cons' (n) : ∀ {xs : list α} (h : xs ≠ []),
   xs.to_chunks (n+1) = xs.take (n+1) :: (xs.drop (n+1)).to_chunks (n+1)
 | [] e := (e rfl).elim
@@ -4899,7 +4894,7 @@ theorem to_chunks_aux_join {n} : ∀ {xs i l L}, @to_chunks_aux α n xs i = (l, 
       exact (congr_arg (cons x) (to_chunks_aux_join e') : _) }
   end
 
-theorem to_chunks_join : ∀ n xs, (@to_chunks α n xs).join = xs
+@[simp] theorem to_chunks_join : ∀ n xs, (@to_chunks α n xs).join = xs
 | n [] := by cases n; refl
 | 0 (x::xs) := by simp only [to_chunks, join]; rw append_nil
 | (n+1) (x::xs) := begin

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -4866,40 +4866,28 @@ end zip_right
 
 section to_chunks
 
-@[simp] theorem to_chunks_zero (l : list α) : to_chunks 0 l = [l] := rfl
-
-@[simp] theorem to_chunks_nil (n) : @to_chunks α n [] = [[]] := by cases n; refl
-
-@[simp] theorem to_chunks'_nil (n) : @to_chunks' α n [] = [] := by cases n; refl
+@[simp] theorem to_chunks_nil (n) : @to_chunks α n [] = [] := by cases n; refl
 
 theorem to_chunks_aux_eq (n) : ∀ xs i,
-  @to_chunks_aux α n xs i = (xs.take i, (xs.drop i).to_chunks' (n+1))
+  @to_chunks_aux α n xs i = (xs.take i, (xs.drop i).to_chunks (n+1))
 | [] i := by cases i; refl
-| (x::xs) 0 := by rw [to_chunks_aux, drop, to_chunks']; cases to_chunks_aux n xs n; refl
+| (x::xs) 0 := by rw [to_chunks_aux, drop, to_chunks]; cases to_chunks_aux n xs n; refl
 | (x::xs) (i+1) := by rw [to_chunks_aux, to_chunks_aux_eq]; refl
 
-theorem to_chunks_eq_cons' (n) : ∀ (xs : list α),
-  xs.to_chunks (n+1) = xs.take (n+1) :: (xs.drop (n+1)).to_chunks' (n+1)
-| [] := rfl
-| (x::xs) := by rw [to_chunks, to_chunks_aux_eq]; refl
+-- theorem to_chunks_eq_cons' (n) : ∀ (xs : list α),
+--   xs.to_chunks (n+1) = xs.take (n+1) :: (xs.drop (n+1)).to_chunks (n+1)
+-- | [] := rfl
+-- | (x::xs) := by rw [to_chunks, to_chunks_aux_eq]; refl
 
-theorem to_chunks_eq_cons : ∀ {n} (xs : list α), n ≠ 0 →
-  xs.to_chunks n = xs.take n :: (xs.drop n).to_chunks' n
+theorem to_chunks_eq_cons' (n) : ∀ {xs : list α} (h : xs ≠ []),
+  xs.to_chunks (n+1) = xs.take (n+1) :: (xs.drop (n+1)).to_chunks (n+1)
+| [] e := (e rfl).elim
+| (x::xs) _ := by rw [to_chunks, to_chunks_aux_eq]; refl
+
+theorem to_chunks_eq_cons : ∀ {n} {xs : list α} (n0 : n ≠ 0) (x0 : xs ≠ []),
+  xs.to_chunks n = xs.take n :: (xs.drop n).to_chunks n
 | 0 _ e := (e rfl).elim
-| (n+1) xs _ := to_chunks_eq_cons' n xs
-
-theorem to_chunks'_eq_to_chunks : ∀ n {xs : list α}, xs ≠ [] → xs.to_chunks' n = xs.to_chunks n
-| _ [] e := (e rfl).elim
-| 0 (x::xs) _ := rfl
-| (n+1) (x::xs) _ := by rw [to_chunks, to_chunks', to_chunks_aux_eq, to_chunks_aux_eq]; refl
-
-theorem to_chunks'_eq_cons {n} {xs : list α} (n0 : n ≠ 0) (x0 : xs ≠ []) :
-  xs.to_chunks' n = xs.take n :: (xs.drop n).to_chunks' n :=
-by rw [to_chunks'_eq_to_chunks n x0, to_chunks_eq_cons _ n0]
-
-theorem to_chunks'_eq_cons' {n} {xs : list α} (h : xs ≠ []) :
-  xs.to_chunks' (n+1) = xs.take (n+1) :: (xs.drop (n+1)).to_chunks' (n+1) :=
-by apply to_chunks'_eq_cons _ h; rintro ⟨⟩
+| (n+1) xs _ := to_chunks_eq_cons' _
 
 theorem to_chunks_aux_join {n} : ∀ {xs i l L}, @to_chunks_aux α n xs i = (l, L) → l ++ L.join = xs
 | [] _ _ _ rfl := rfl
@@ -4912,37 +4900,25 @@ theorem to_chunks_aux_join {n} : ∀ {xs i l L}, @to_chunks_aux α n xs i = (l, 
   end
 
 theorem to_chunks_join : ∀ n xs, (@to_chunks α n xs).join = xs
-| 0 xs := by simp only [join, to_chunks_zero, append_nil]
-| (n+1) xs := begin
+| n [] := by cases n; refl
+| 0 (x::xs) := by simp only [to_chunks, join]; rw append_nil
+| (n+1) (x::xs) := begin
     rw to_chunks,
-    cases e : to_chunks_aux n xs (n+1) with l L,
-    exact to_chunks_aux_join e,
+    cases e : to_chunks_aux n xs n with l L,
+    exact (congr_arg (cons x) (to_chunks_aux_join e) : _),
   end
 
-theorem to_chunks'_join : ∀ n xs, (@to_chunks' α n xs).join = xs
-| _ [] := by rw to_chunks'_nil; refl
-| n (x::xs) := by rw [to_chunks'_eq_to_chunks, to_chunks_join]; rintro ⟨⟩
-
-theorem to_chunks'_length_le : ∀ n xs, n ≠ 0 → ∀ l : list α,
-  l ∈ @to_chunks' α n xs → l.length ≤ n
+theorem to_chunks_length_le : ∀ n xs, n ≠ 0 → ∀ l : list α,
+  l ∈ @to_chunks α n xs → l.length ≤ n
 | 0 _ e _ := (e rfl).elim
 | (n+1) xs _ l := begin
   refine (measure_wf length).induction xs _, intros xs IH h,
   by_cases x0 : xs = [], {subst xs, cases h},
-  rw to_chunks'_eq_cons' x0 at h, rcases h with rfl|h,
+  rw to_chunks_eq_cons' _ x0 at h, rcases h with rfl|h,
   { apply length_take_le },
   { refine IH _ _ h,
     simp only [measure, inv_image, length_drop],
     exact nat.sub_lt_self (length_pos_iff_ne_nil.2 x0) (succ_pos _) },
-end
-
-theorem to_chunks_length_le : ∀ n xs, n ≠ 0 → ∀ l : list α,
-  l ∈ @to_chunks α n xs → l.length ≤ n
-| 0 _ e _ _ := (e rfl).elim
-| (n+1) [] _ l (or.inl rfl) := nat.zero_le _
-| n (_::_) n0 _ h := begin
-  rw ← to_chunks'_eq_to_chunks _ (cons_ne_nil _ _) at h,
-  exact to_chunks'_length_le _ _ n0 _ h,
 end
 
 end to_chunks

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -906,7 +906,7 @@ foldl_with_index (λ i mapp a, mapp.insert i a) mk_rb_map
 
 /-- Auxliary definition used to define `to_chunks`.
 
-  `to_chunks_aux n xs i` returns `(xs.take i, (xs.drop i).to_chunks' (n+1))`,
+  `to_chunks_aux n xs i` returns `(xs.take i, (xs.drop i).to_chunks (n+1))`,
   that is, the first `i` elements of `xs`, and the remaining elements chunked into
   sublists of length `n+1`. -/
 def to_chunks_aux {α} (n : ℕ) : list α → ℕ → list α × list (list α)

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -926,16 +926,6 @@ such that `(xs.to_chunks n).join = xs`.
 ```
 -/
 def to_chunks {α} : ℕ → list α → list (list α)
-| 0 xs := [xs]
-| (n+1) xs := let (l, L) := to_chunks_aux n xs (n+1) in l::L
-
-
-/--
-`xs.to_chunks' n` splits the list into sublists of size at most `n`,
-such that `(xs.to_chunks n).join = xs`. It differs from `to_chunks` in the handling
-of empty sublists: `to_chunks' n [] = []` but `to_chunks n [] = [[]]`.
--/
-def to_chunks' {α} : ℕ → list α → list (list α)
 | _ [] := []
 | 0 xs := [xs]
 | (n+1) (x::xs) := let (l, L) := to_chunks_aux n xs n in (x::l)::L

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -903,19 +903,42 @@ to_rb_map ['a', 'b', 'c'] = rb_map.of_list [(0, 'a'), (1, 'b'), (2, 'c')]
 meta def to_rb_map {α : Type} : list α → rb_map ℕ α :=
 foldl_with_index (λ i mapp a, mapp.insert i a) mk_rb_map
 
+
+/-- Auxliary definition used to define `to_chunks`.
+
+  `to_chunks_aux n xs i` returns `(xs.take i, (xs.drop i).to_chunks' (n+1))`,
+  that is, the first `i` elements of `xs`, and the remaining elements chunked into
+  sublists of length `n+1`. -/
+def to_chunks_aux {α} (n : ℕ) : list α → ℕ → list α × list (list α)
+| [] i := ([], [])
+| (x::xs) 0 := let (l, L) := to_chunks_aux xs n in ([], (x::l)::L)
+| (x::xs) (i+1) := let (l, L) := to_chunks_aux xs i in (x::l, L)
+
 /--
 `xs.to_chunks n` splits the list into sublists of size at most `n`,
 such that `(xs.to_chunks n).join = xs`.
 
-TODO: make non-meta; currently doesn't terminate, e.g.
 ```
-#eval [0].to_chunks 0
+[1, 2, 3, 4, 5, 6, 7, 8].to_chunks 10 = [[1, 2, 3, 4, 5, 6, 7, 8]]
+[1, 2, 3, 4, 5, 6, 7, 8].to_chunks 3 = [[1, 2, 3], [4, 5, 6], [7, 8]]
+[1, 2, 3, 4, 5, 6, 7, 8].to_chunks 2 = [[1, 2], [3, 4], [5, 6], [7, 8]]
+[1, 2, 3, 4, 5, 6, 7, 8].to_chunks 0 = [[1, 2, 3, 4, 5, 6, 7, 8]]
 ```
 -/
-meta def to_chunks {α} (n : ℕ) : list α → list (list α)
-| [] := []
-| xs :=
-  xs.take n :: (xs.drop n).to_chunks
+def to_chunks {α} : ℕ → list α → list (list α)
+| 0 xs := [xs]
+| (n+1) xs := let (l, L) := to_chunks_aux n xs (n+1) in l::L
+
+
+/--
+`xs.to_chunks' n` splits the list into sublists of size at most `n`,
+such that `(xs.to_chunks n).join = xs`. It differs from `to_chunks` in the handling
+of empty sublists: `to_chunks' n [] = []` but `to_chunks n [] = [[]]`.
+-/
+def to_chunks' {α} : ℕ → list α → list (list α)
+| _ [] := []
+| 0 xs := [xs]
+| (n+1) (x::xs) := let (l, L) := to_chunks_aux n xs n in (x::l)::L
 
 /--
 Asynchronous version of `list.map`.


### PR DESCRIPTION
A non-meta definition of the `list.to_chunks` method, plus some basic theorems about it.