### PR TITLE
[Merged by Bors] - refactor(ring_theory/ideal/operations.lean): make is_prime.comap an instance

### DIFF
--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -383,7 +383,7 @@ variables {S : Type v} [comm_ring S] {S' : Type*} [comm_ring S']
 /-- The function between prime spectra of commutative rings induced by a ring homomorphism.
 This function is continuous. -/
 def comap (f : R →+* S) : prime_spectrum S → prime_spectrum R :=
-λ y, ⟨ideal.comap f y.as_ideal, by exact ideal.is_prime.comap _⟩
+λ y, ⟨ideal.comap f y.as_ideal, infer_instance⟩
 
 variables (f : R →+* S)
 

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -59,9 +59,8 @@ lemma dimension_le_one.integral_closure [nontrivial R] [algebra R A]
 begin
   intros p ne_bot prime,
   haveI := prime,
-  refine integral_closure.is_maximal_of_is_maximal_comap p
-    (h _ (integral_closure.comap_ne_bot ne_bot) _),
-  apply is_prime.comap
+  exact integral_closure.is_maximal_of_is_maximal_comap p
+    (h _ (integral_closure.comap_ne_bot ne_bot) infer_instance),
 end
 end ring
 

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -56,12 +56,10 @@ lemma dimension_le_one.principal_ideal_ring
 
 lemma dimension_le_one.integral_closure [nontrivial R] [algebra R A]
   (h : dimension_le_one R) : dimension_le_one (integral_closure R A) :=
-begin
-  intros p ne_bot prime,
-  haveI := prime,
-  exact integral_closure.is_maximal_of_is_maximal_comap p
-    (h _ (integral_closure.comap_ne_bot ne_bot) infer_instance),
-end
+λ p ne_bot prime, by exactI
+  integral_closure.is_maximal_of_is_maximal_comap p
+    (h _ (integral_closure.comap_ne_bot ne_bot) infer_instance)
+
 end ring
 
 /--

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -730,7 +730,7 @@ theorem comap_ne_top (hK : K ≠ ⊤) : comap f K ≠ ⊤ :=
 (ne_top_iff_one _).2 $ by rw [mem_comap, f.map_one];
   exact (ne_top_iff_one _).1 hK
 
-theorem is_prime.comap [hK : K.is_prime] : (comap f K).is_prime :=
+instance is_prime.comap [hK : K.is_prime] : (comap f K).is_prime :=
 ⟨comap_ne_top _ hK.1, λ x y,
   by simp only [mem_comap, f.map_mul]; apply hK.2⟩
 


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

When I was defining the local ring homomorphism on the localizations at a prime ideal, I needed this to be an instance.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
