### PR TITLE
[Merged by Bors] - feat(ring_theory/localization): Characterize units in localization at prime ideal

### DIFF
--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1163,6 +1163,37 @@ integral_domain_localization (le_non_zero_divisors_of_domain (by simpa only [] u
 end localization_map
 
 section at_prime
+
+namespace localization_map
+
+variables (I : ideal R) [hI : I.is_prime] (f : at_prime S I)
+include hI
+
+lemma at_prime.is_unit_to_map_iff (x : R) :
+  is_unit (f.to_map x) ↔ x ∈ I.prime_compl :=
+⟨λ h hx, (f.is_prime_of_is_prime_disjoint I hI disjoint_compl_left).ne_top $
+  ideal.eq_top_of_is_unit_mem (ideal.map f.to_map I) (ideal.mem_map_of_mem hx) h,
+λ h, f.map_units ⟨x, h⟩⟩
+
+lemma at_prime.to_map_mem_maximal_iff (x : R) :
+  f.to_map x ∈ local_ring.maximal_ideal (f.codomain) ↔ x ∈ I :=
+not_iff_not.mp $ by
+simpa only [@local_ring.mem_maximal_ideal (f.codomain), mem_nonunits_iff, not_not]
+  using at_prime.is_unit_to_map_iff I f x
+
+lemma at_prime.is_unit_mk'_iff (x : R) (y : I.prime_compl) :
+  is_unit (f.mk' x y) ↔ x ∈ I.prime_compl :=
+⟨λ h hx, (mk'_mem_iff f).mpr ((at_prime.to_map_mem_maximal_iff I f x).mpr hx) h,
+λ h, is_unit_iff_exists_inv.mpr ⟨f.mk' y ⟨x, h⟩, f.mk'_mul_mk'_eq_one ⟨x, h⟩ y⟩⟩
+
+lemma at_prime.mk'_mem_maximal_iff (x : R) (y : I.prime_compl) :
+  f.mk' x y ∈ local_ring.maximal_ideal (f.codomain) ↔ x ∈ I :=
+not_iff_not.mp $ by
+simpa only [@local_ring.mem_maximal_ideal (f.codomain), mem_nonunits_iff, not_not]
+  using at_prime.is_unit_mk'_iff I f x y
+
+end localization_map
+
 namespace localization
 
 local attribute [instance] classical.prop_decidable

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1172,25 +1172,25 @@ include hI
 lemma at_prime.is_unit_to_map_iff (x : R) :
   is_unit (f.to_map x) ↔ x ∈ I.prime_compl :=
 ⟨λ h hx, (f.is_prime_of_is_prime_disjoint I hI disjoint_compl_left).ne_top $
-  ideal.eq_top_of_is_unit_mem (ideal.map f.to_map I) (ideal.mem_map_of_mem hx) h,
+  (ideal.map f.to_map I).eq_top_of_is_unit_mem (ideal.mem_map_of_mem hx) h,
 λ h, f.map_units ⟨x, h⟩⟩
 
 lemma at_prime.to_map_mem_maximal_iff (x : R) :
   f.to_map x ∈ local_ring.maximal_ideal (f.codomain) ↔ x ∈ I :=
 not_iff_not.mp $ by
 simpa only [@local_ring.mem_maximal_ideal (f.codomain), mem_nonunits_iff, not_not]
-  using at_prime.is_unit_to_map_iff I f x
+  using f.is_unit_to_map_iff I x
 
 lemma at_prime.is_unit_mk'_iff (x : R) (y : I.prime_compl) :
   is_unit (f.mk' x y) ↔ x ∈ I.prime_compl :=
-⟨λ h hx, (mk'_mem_iff f).mpr ((at_prime.to_map_mem_maximal_iff I f x).mpr hx) h,
+⟨λ h hx, (mk'_mem_iff f).mpr ((f.to_map_mem_maximal_iff I x).mpr hx) h,
 λ h, is_unit_iff_exists_inv.mpr ⟨f.mk' y ⟨x, h⟩, f.mk'_mul_mk'_eq_one ⟨x, h⟩ y⟩⟩
 
 lemma at_prime.mk'_mem_maximal_iff (x : R) (y : I.prime_compl) :
   f.mk' x y ∈ local_ring.maximal_ideal (f.codomain) ↔ x ∈ I :=
 not_iff_not.mp $ by
 simpa only [@local_ring.mem_maximal_ideal (f.codomain), mem_nonunits_iff, not_not]
-  using at_prime.is_unit_mk'_iff I f x y
+  using f.is_unit_mk'_iff I x y
 
 end localization_map
 


### PR DESCRIPTION
Adds a few lemmas characterizing units and nonunits (elements of the maximal ideal) in the localization at a prime ideal.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
