### PR TITLE
[Merged by Bors] - ci(.github/workflows/{build,dependent-issues}.yml): auto-cancel workflows on previous commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,16 @@ on:
       - 'lean-3.*'
 
 jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    # timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
   lint_self_test:
     name: Ensure the linter works
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   cancel:
-    name: 'Cancel Previous Runs'
+    name: 'Cancel Previous Runs (CI)'
     runs-on: ubuntu-latest
     # timeout-minutes: 3
     steps:

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   cancel:
-    name: 'Cancel Previous Runs'
+    name: 'Cancel Previous Runs (dependent issues)'
     runs-on: ubuntu-latest
     # timeout-minutes: 3
     steps:

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -16,6 +16,16 @@ on:
     - cron: '15 * * * *' # schedule hourly check for external dependencies
 
 jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    # timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
   check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
After this is merged, pushing a new commit to a branch in this repo should cancel the "continuous integration" and "dependent issues" workflows running on any older commits on that branch.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Auto-canceling the build.yml workflows seemed to work here https://github.com/bryangingechen/mathlib/pull/44

~~When the queue clears a bit, we should see some cancellations on the commits here as well.~~ Actually, only the last commit is running in the main mathlib repo, so we won't see cancellations, unless there are further commits.

See https://github.com/styfle/cancel-workflow-action and https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/ddos.20attack.20on.20the.20PR.20queue
