### PR TITLE
[Merged by Bors] - feat(category_theory/limits/shapes/wide_pullbacks): Adds some wrappers around the (co)limit api for wide pullbacks/pushouts

### DIFF
--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -234,8 +234,7 @@ limit.π (wide_pullback_shape.wide_cospan _ _ _) option.none
 
 @[simp]
 lemma π_arrow (j : J) : π arrows j ≫ arrows _ = base arrows :=
-by apply (limit.cone (wide_pullback_shape.wide_cospan B objs arrows)).w
-  (wide_pullback_shape.hom.term j)
+by apply limit.w (wide_pullback_shape.wide_cospan _ _ _) (wide_pullback_shape.hom.term j)
 
 variables {arrows}
 
@@ -307,8 +306,7 @@ colimit.ι (wide_pushout_shape.wide_span _ _ _) option.none
 
 @[simp]
 lemma head_ι (j : J) : arrows j ≫ ι arrows j = head arrows :=
-by apply (colimit.cocone (wide_pushout_shape.wide_span B objs arrows)).w
-  (wide_pushout_shape.hom.init j)
+by apply colimit.w (wide_pushout_shape.wide_span _ _ _) (wide_pushout_shape.hom.init j)
 
 variables {arrows}
 

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -250,11 +250,11 @@ variables (arrows)
 variables {X : C} (f : X ⟶ B) (fs : Π (j : J), X ⟶ objs j)
   (w : ∀ j, fs j ≫ arrows j = f)
 
-@[simp]
+@[simp, reassoc]
 lemma lift_π (j : J) : lift f fs w ≫ π arrows j = fs _ :=
 by { simp, refl }
 
-@[simp]
+@[simp, reassoc]
 lemma lift_base : lift f fs w ≫ base arrows = f :=
 by { simp, refl }
 
@@ -323,11 +323,11 @@ variables (arrows)
 variables {X : C} (f : B ⟶ X) (fs : Π (j : J), objs j ⟶ X)
   (w : ∀ j, arrows j ≫ fs j = f)
 
-@[simp]
+@[simp, reassoc]
 lemma ι_desc (j : J) : ι arrows j ≫ desc f fs w = fs _ :=
 by { simp, refl }
 
-@[simp]
+@[simp, reassoc]
 lemma head_desc : head arrows ≫ desc f fs w = f :=
 by { simp, refl }
 

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -219,7 +219,7 @@ variable (C)
 
 namespace wide_pullback
 
-variables {C} {B : C} {objs : J → C} {arrows : Π (j : J), objs j ⟶ B}
+variables {C} {B : C} {objs : J → C} (arrows : Π (j : J), objs j ⟶ B)
 variables [has_wide_pullback B objs arrows]
 
 /-- The `j`-th projection from the pullback. -/
@@ -233,9 +233,11 @@ abbreviation base : wide_pullback _ _ arrows ⟶ B :=
 limit.π (wide_pullback_shape.wide_cospan _ _ _) option.none
 
 @[simp]
-lemma π_arrow (j : J) : (π j : wide_pullback _ _ arrows ⟶ _) ≫ arrows _ = base :=
+lemma π_arrow (j : J) : π arrows j ≫ arrows _ = base arrows :=
 by apply (limit.cone (wide_pullback_shape.wide_cospan B objs arrows)).w
   (wide_pullback_shape.hom.term j)
+
+variables {arrows}
 
 /-- Lift a a collection of morphisms to a morphism to the pullback. -/
 noncomputable
@@ -244,19 +246,21 @@ abbreviation lift {X : C} (f : X ⟶ B) (fs : Π (j : J), X ⟶ objs j)
 limit.lift (wide_pullback_shape.wide_cospan _ _ _)
   (wide_pullback_shape.mk_cone f fs $ by exact w)
 
+variables (arrows)
+
 variables {X : C} (f : X ⟶ B) (fs : Π (j : J), X ⟶ objs j)
   (w : ∀ j, fs j ≫ arrows j = f)
 
 @[simp]
-lemma lift_π (j : J) : lift f fs w ≫ (π j : wide_pullback _ _ arrows ⟶ _) = fs _ :=
+lemma lift_π (j : J) : lift f fs w ≫ π arrows j = fs _ :=
 by { simp, refl }
 
 @[simp]
-lemma lift_base : lift f fs w ≫ base = f :=
+lemma lift_base : lift f fs w ≫ base arrows = f :=
 by { simp, refl }
 
 lemma eq_lift_of_comp_eq (g : X ⟶ wide_pullback _ _ arrows) :
-  (∀ j : J, g ≫ π j = fs j) → g ≫ base = f → g = lift f fs w :=
+  (∀ j : J, g ≫ π arrows j = fs j) → g ≫ base arrows = f → g = lift f fs w :=
 begin
   intros h1 h2,
   apply (limit.is_limit (wide_pullback_shape.wide_cospan B objs arrows)).uniq
@@ -267,7 +271,7 @@ begin
 end
 
 lemma hom_eq_lift (g : X ⟶ wide_pullback _ _ arrows) :
-  g = lift (g ≫ base) (λ j, g ≫ π j) (by tidy) :=
+  g = lift (g ≫ base arrows) (λ j, g ≫ π arrows j) (by tidy) :=
 begin
   apply eq_lift_of_comp_eq,
   tidy,
@@ -275,10 +279,11 @@ end
 
 @[ext]
 lemma hom_ext (g1 g2 : X ⟶ wide_pullback _ _ arrows) :
-  (∀ j : J, g1 ≫ π j = g2 ≫ π j) → g1 ≫ base = g2 ≫ base → g1 = g2 :=
+  (∀ j : J, g1 ≫ π arrows j = g2 ≫ π arrows j) →
+  g1 ≫ base arrows = g2 ≫ base arrows → g1 = g2 :=
 begin
   intros h1 h2,
-  rw hom_eq_lift g2,
+  rw hom_eq_lift _ g2,
   apply eq_lift_of_comp_eq,
   assumption'
 end
@@ -287,7 +292,7 @@ end wide_pullback
 
 namespace wide_pushout
 
-variables {C} {B : C} {objs : J → C} {arrows : Π (j : J), B ⟶ objs j}
+variables {C} {B : C} {objs : J → C} (arrows : Π (j : J), B ⟶ objs j)
 variables [has_wide_pushout B objs arrows]
 
 /-- The `j`-th inclusion to the pushout. -/
@@ -301,9 +306,11 @@ abbreviation head : B ⟶ wide_pushout B objs arrows :=
 colimit.ι (wide_pushout_shape.wide_span _ _ _) option.none
 
 @[simp]
-lemma head_ι (j : J) : arrows j ≫ (ι j : _ ⟶ wide_pushout B objs arrows) = head :=
+lemma head_ι (j : J) : arrows j ≫ ι arrows j = head arrows :=
 by apply (colimit.cocone (wide_pushout_shape.wide_span B objs arrows)).w
   (wide_pushout_shape.hom.init j)
+
+variables {arrows}
 
 /-- Descend a collection of morphisms to a morphism from the pushout. -/
 noncomputable
@@ -312,19 +319,21 @@ abbreviation desc {X : C} (f : B ⟶ X) (fs : Π (j : J), objs j ⟶ X)
 colimit.desc (wide_pushout_shape.wide_span B objs arrows)
   (wide_pushout_shape.mk_cocone f fs $ by exact w)
 
+variables (arrows)
+
 variables {X : C} (f : B ⟶ X) (fs : Π (j : J), objs j ⟶ X)
   (w : ∀ j, arrows j ≫ fs j = f)
 
 @[simp]
-lemma ι_desc (j : J) : (ι j : _ ⟶ wide_pushout _ _ arrows) ≫ desc f fs w = fs _ :=
+lemma ι_desc (j : J) : ι arrows j ≫ desc f fs w = fs _ :=
 by { simp, refl }
 
 @[simp]
-lemma head_desc : head ≫ desc f fs w = f :=
+lemma head_desc : head arrows ≫ desc f fs w = f :=
 by { simp, refl }
 
 lemma eq_desc_of_comp_eq (g : wide_pushout _ _ arrows ⟶ X) :
-  (∀ j : J, ι j ≫ g = fs j) → head ≫ g = f → g = desc f fs w :=
+  (∀ j : J, ι arrows j ≫ g = fs j) → head arrows ≫ g = f → g = desc f fs w :=
 begin
   intros h1 h2,
   apply (colimit.is_colimit (wide_pushout_shape.wide_span B objs arrows)).uniq
@@ -335,7 +344,7 @@ begin
 end
 
 lemma hom_eq_desc (g : wide_pushout _ _ arrows ⟶ X) :
-  g = desc (head ≫ g) (λ j, ι j ≫ g) (λ j, by { rw ← category.assoc, simp }) :=
+  g = desc (head arrows ≫ g) (λ j, ι arrows j ≫ g) (λ j, by { rw ← category.assoc, simp }) :=
 begin
   apply eq_desc_of_comp_eq,
   tidy,
@@ -343,10 +352,11 @@ end
 
 @[ext]
 lemma hom_ext (g1 g2 : wide_pushout _ _ arrows ⟶ X) :
-  (∀ j : J, ι j ≫ g1= ι j ≫ g2) → head ≫ g1 = head ≫ g2 → g1 = g2 :=
+  (∀ j : J, ι arrows j ≫ g1= ι arrows j ≫ g2) →
+  head arrows ≫ g1 = head arrows ≫ g2 → g1 = g2 :=
 begin
   intros h1 h2,
-  rw hom_eq_desc g2,
+  rw hom_eq_desc _ g2,
   apply eq_desc_of_comp_eq,
   assumption'
 end

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -282,9 +282,10 @@ lemma hom_ext (g1 g2 : X ⟶ wide_pullback _ _ arrows) :
   g1 ≫ base arrows = g2 ≫ base arrows → g1 = g2 :=
 begin
   intros h1 h2,
-  rw hom_eq_lift _ g2,
-  apply eq_lift_of_comp_eq,
-  assumption'
+  apply limit.hom_ext,
+  rintros (_|_),
+  { apply h2 },
+  { apply h1 },
 end
 
 end wide_pullback
@@ -350,13 +351,14 @@ end
 
 @[ext]
 lemma hom_ext (g1 g2 : wide_pushout _ _ arrows ⟶ X) :
-  (∀ j : J, ι arrows j ≫ g1= ι arrows j ≫ g2) →
+  (∀ j : J, ι arrows j ≫ g1 = ι arrows j ≫ g2) →
   head arrows ≫ g1 = head arrows ≫ g2 → g1 = g2 :=
 begin
   intros h1 h2,
-  rw hom_eq_desc _ g2,
-  apply eq_desc_of_comp_eq,
-  assumption'
+  apply colimit.hom_ext,
+  rintros (_|_),
+  { apply h2 },
+  { apply h1 },
 end
 
 end wide_pushout

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -323,7 +323,7 @@ by { simp, refl }
 lemma head_desc : head ≫ desc f fs w = f :=
 by { simp, refl }
 
-lemma eq_lift_of_comp_eq (g : wide_pushout _ _ arrows ⟶ X) :
+lemma eq_desc_of_comp_eq (g : wide_pushout _ _ arrows ⟶ X) :
   (∀ j : J, ι j ≫ g = fs j) → head ≫ g = f → g = desc f fs w :=
 begin
   intros h1 h2,
@@ -334,10 +334,10 @@ begin
   { apply h1 }
 end
 
-lemma hom_eq_lift (g : wide_pushout _ _ arrows ⟶ X) :
+lemma hom_eq_desc (g : wide_pushout _ _ arrows ⟶ X) :
   g = desc (head ≫ g) (λ j, ι j ≫ g) (λ j, by { rw ← category.assoc, simp }) :=
 begin
-  apply eq_lift_of_comp_eq,
+  apply eq_desc_of_comp_eq,
   tidy,
 end
 
@@ -346,8 +346,8 @@ lemma hom_ext (g1 g2 : wide_pushout _ _ arrows ⟶ X) :
   (∀ j : J, ι j ≫ g1= ι j ≫ g2) → head ≫ g1 = head ≫ g2 → g1 = g2 :=
 begin
   intros h1 h2,
-  rw hom_eq_lift g2,
-  apply eq_lift_of_comp_eq,
+  rw hom_eq_desc g2,
+  apply eq_desc_of_comp_eq,
   assumption'
 end
 

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -249,11 +249,11 @@ variables {X : C} (f : X ⟶ B) (fs : Π (j : J), X ⟶ objs j)
 
 @[simp]
 lemma lift_π (j : J) : lift f fs w ≫ (π j : wide_pullback _ _ arrows ⟶ _) = fs _ :=
-by {simp, refl}
+by { simp, refl }
 
 @[simp]
 lemma lift_base : lift f fs w ≫ base = f :=
-by {simp, refl}
+by { simp, refl }
 
 lemma eq_lift_of_comp_eq (g : X ⟶ wide_pullback _ _ arrows) :
   (∀ j : J, g ≫ π j = fs j) → g ≫ base = f → g = lift f fs w :=
@@ -317,11 +317,11 @@ variables {X : C} (f : B ⟶ X) (fs : Π (j : J), objs j ⟶ X)
 
 @[simp]
 lemma ι_desc (j : J) : (ι j : _ ⟶ wide_pushout _ _ arrows) ≫ desc f fs w = fs _ :=
-by {simp, refl}
+by { simp, refl }
 
 @[simp]
 lemma head_desc : head ≫ desc f fs w = f :=
-by {simp, refl}
+by { simp, refl }
 
 lemma eq_lift_of_comp_eq (g : wide_pushout _ _ arrows ⟶ X) :
   (∀ j : J, ι j ≫ g = fs j) → head ≫ g = f → g = desc f fs w :=
@@ -335,7 +335,7 @@ begin
 end
 
 lemma hom_eq_lift (g : wide_pushout _ _ arrows ⟶ X) :
-  g = desc (head ≫ g) (λ j, ι j ≫ g) (λ j, by {rw ← category.assoc, simp}) :=
+  g = desc (head ≫ g) (λ j, ι j ≫ g) (λ j, by { rw ← category.assoc, simp }) :=
 begin
   apply eq_lift_of_comp_eq,
   tidy,

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -232,7 +232,7 @@ noncomputable
 abbreviation base : wide_pullback _ _ arrows ⟶ B :=
 limit.π (wide_pullback_shape.wide_cospan _ _ _) option.none
 
-@[simp]
+@[simp, reassoc]
 lemma π_arrow (j : J) : π arrows j ≫ arrows _ = base arrows :=
 by apply limit.w (wide_pullback_shape.wide_cospan _ _ _) (wide_pullback_shape.hom.term j)
 
@@ -304,8 +304,8 @@ noncomputable
 abbreviation head : B ⟶ wide_pushout B objs arrows :=
 colimit.ι (wide_pushout_shape.wide_span _ _ _) option.none
 
-@[simp]
-lemma head_ι (j : J) : arrows j ≫ ι arrows j = head arrows :=
+@[simp, reassoc]
+lemma arrow_ι (j : J) : arrows j ≫ ι arrows j = head arrows :=
 by apply colimit.w (wide_pushout_shape.wide_span _ _ _) (wide_pushout_shape.hom.init j)
 
 variables {arrows}


### PR DESCRIPTION
This PR adds some wrappers (mostly abbreviations) around the (co)limit api specifically for wide pullbacks and wide pushouts.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
