### PR TITLE
[Merged by Bors] - feat(ring_theory/hahn_series): extend the domain of a Hahn series by an `order_embedding`

### DIFF
--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -409,7 +409,7 @@ section domain
 variables {Γ' : Type*} [partial_order Γ']
 
 /-- Extending the domain of Hahn series is a linear map. -/
-def emb_domain_linear_map (f : Γ ↪o Γ') : hahn_series Γ R →ₗ[R] hahn_series Γ' R :=
+@[simps] def emb_domain_linear_map (f : Γ ↪o Γ') : hahn_series Γ R →ₗ[R] hahn_series Γ' R :=
 ⟨emb_domain f, λ x y, begin
   ext g,
   by_cases hg : g ∈ set.range f,
@@ -423,10 +423,6 @@ end, λ x y, begin
     simp },
   { simp [emb_domain_notin_range, hg] }
 end⟩
-
-@[simp]
-lemma emb_domain_linear_map_apply {f : Γ ↪o Γ'} {x : hahn_series Γ R} :
-  emb_domain_linear_map f x = emb_domain f x := rfl
 
 end domain
 
@@ -784,7 +780,7 @@ section domain
 variables {Γ' : Type*} [ordered_cancel_add_comm_monoid Γ']
 
 /-- Extending the domain of Hahn series is a ring homomorphism. -/
-def emb_domain_ring_hom (f : Γ →+ Γ') (hfi : function.injective f)
+@[simps] def emb_domain_ring_hom (f : Γ →+ Γ') (hfi : function.injective f)
   (hf : ∀ g g' : Γ, f g ≤ f g' ↔ g ≤ g') :
   hahn_series Γ R →+* hahn_series Γ' R :=
 ⟨emb_domain_linear_map ⟨⟨f, hfi⟩, hf⟩, emb_domain_single.trans begin
@@ -834,13 +830,6 @@ lemma emb_domain_ring_hom_C {f : Γ →+ Γ'} {hfi : function.injective f}
   emb_domain_ring_hom f hfi hf (C r) = C r :=
 emb_domain_single.trans (by simp)
 
-@[simp]
-lemma emb_domain_ring_hom_apply {f : Γ →+ Γ'} {hfi : function.injective f}
-  {hf : ∀ g g' : Γ, f g ≤ f g' ↔ g ≤ g'} {x : hahn_series Γ R} :
-  (emb_domain_ring_hom f hfi hf) x =
-    emb_domain_linear_map ⟨⟨f, hfi⟩, hf⟩ x :=
-rfl
-
 end domain
 
 end semiring
@@ -877,7 +866,7 @@ section domain
 variables {Γ' : Type*} [ordered_cancel_add_comm_monoid Γ']
 
 /-- Extending the domain of Hahn series is an algebra homomorphism. -/
-def emb_domain_alg_hom (f : Γ →+ Γ') (hfi : function.injective f)
+@[simps] def emb_domain_alg_hom (f : Γ →+ Γ') (hfi : function.injective f)
   (hf : ∀ g g' : Γ, f g ≤ f g' ↔ g ≤ g') :
   hahn_series Γ A →ₐ[R] hahn_series Γ' A :=
 { commutes' := λ r, emb_domain_ring_hom_C,

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -923,7 +923,7 @@ lemma coeff_to_power_series_symm {f : power_series R} {n : ℕ} :
 
 variables [ordered_semiring Γ] [nontrivial Γ]
 /-- Casts a power series as a Hahn series with coefficients from an `ordered_semiring`. -/
-def of_power_series : (power_series R) →+* hahn_series Γ R :=
+@[simps] def of_power_series : (power_series R) →+* hahn_series Γ R :=
 (hahn_series.emb_domain_ring_hom (nat.cast_add_monoid_hom Γ) nat.strict_mono_cast.injective
   (λ _ _, nat.cast_le)).comp
   (ring_equiv.to_ring_hom to_power_series.symm)
@@ -946,6 +946,14 @@ variables (R) [comm_semiring R] {A : Type*} [semiring A] [algebra R A]
       rw [power_series.coeff_C, if_neg n.succ_ne_zero] }
   end,
   .. to_power_series }
+
+variables [ordered_semiring Γ] [nontrivial Γ]
+/-- Casting a power series as a Hahn series with coefficients from an `ordered_semiring`
+  is an algebra homomorphism. -/
+@[simps] def of_power_series_alg : (power_series A) →ₐ[R] hahn_series Γ A :=
+(hahn_series.emb_domain_alg_hom (nat.cast_add_monoid_hom Γ) nat.strict_mono_cast.injective
+  (λ _ _, nat.cast_le)).comp
+  (alg_equiv.to_alg_hom (to_power_series_alg R).symm)
 
 end algebra
 


### PR DESCRIPTION
Defines `hahn_series.emb_domain`, which extends the domain of a Hahn series by embedding it into a larger domain in an order-preserving way.
Bundles `hahn_series.emb_domain` with additional properties as `emb_domain_linear_map`, `emb_domain_ring_hom`, and `emb_domain_alg_hom` under additional conditions.
Defines the ring homomorphism `hahn_series.of_power_series` and the algebra homomorphism `hahn_series.of_power_series_alg`, which map power series to Hahn series over an ordered semiring using `hahn_series.emb_domain` with `nat.cast` as the embedding.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Later, I will prove that `hahn_series.of_power_series` is the localization map from power series to Laurent series.