### PR TITLE
[Merged by Bors] - feat(topology/metric_space/basic): dist_ne_zero

### DIFF
--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1755,6 +1755,9 @@ iff.intro eq_of_dist_eq_zero (assume : x = y, this ▸ dist_self _)
 @[simp] theorem zero_eq_dist {x y : γ} : 0 = dist x y ↔ x = y :=
 by rw [eq_comm, dist_eq_zero]
 
+theorem dist_ne_zero {x y : γ} : dist x y ≠ 0 ↔ x ≠ y :=
+by simpa only [not_iff_not] using dist_eq_zero
+
 @[simp] theorem dist_le_zero {x y : γ} : dist x y ≤ 0 ↔ x = y :=
 by simpa [le_antisymm_iff, dist_nonneg] using @dist_eq_zero _ _ x y
 


### PR DESCRIPTION
---
I was surprised that we don't seem to have this (there's `dist_pos` but that's not so convenient if one wants to deduce `x ≠ y` from `dist x y ≠ 0`).
