### PR TITLE
[Merged by Bors] - chore(group_theory): some new convenience lemmas

### DIFF
--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -281,12 +281,13 @@ set.ext $ λ z, by { rw [mem_left_coset_iff, set.mem_set_of_eq, eq_comm, quotien
 
 @[to_additive]
 lemma preimage_image_coe (N : subgroup α) (s : set α) :
-  coe ⁻¹' ((coe : α → quotient N) '' s) = ⋃ x : N, (λ y : α, y * x) '' s :=
+  coe ⁻¹' ((coe : α → quotient N) '' s) = ⋃ x : N, (λ y : α, y * x) ⁻¹' s :=
 begin
   ext x,
   simp only [quotient_group.eq, set_like.exists, exists_prop, set.mem_preimage, set.mem_Union,
     set.mem_image, subgroup.coe_mk, ← eq_inv_mul_iff_mul_eq],
-  exact ⟨λ ⟨y, hs, hN⟩, ⟨_, hN, y, hs, rfl⟩, λ ⟨z, hN, y, hs, hyz⟩, ⟨y, hs, hyz ▸ hN⟩⟩
+  exact ⟨λ ⟨y, hs, hN⟩, ⟨_, N.inv_mem hN, by simpa using hs⟩,
+         λ ⟨z, hz, hxz⟩, ⟨x*z, hxz, by simpa using hz⟩⟩,
 end
 
 end quotient_group

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -80,6 +80,47 @@ instance : group (quotient N) :=
 @[to_additive quotient_add_group.mk' "The additive group homomorphism from `G` to `G/N`."]
 def mk' : G →* quotient N := monoid_hom.mk' (quotient_group.mk) (λ _ _, rfl)
 
+@[to_additive, simp]
+lemma coe_mk' : (mk' N : G → quotient N) = coe := rfl
+
+@[to_additive, simp]
+lemma mk'_apply (x : G) : mk' N x = x := rfl
+
+@[to_additive]
+lemma mk'_eq_mk'_iff {x y : G} :  mk' N x = mk' N y ↔  x⁻¹*y ∈ N :=
+quotient_group.eq
+
+@[to_additive]
+lemma mk'_eq_mk'_iff' {x y : G} :  mk' N x = mk' N y ↔  y*x⁻¹ ∈ N :=
+begin
+  rw mk'_eq_mk'_iff,
+  split,
+  { intro h,
+    simpa using nN.conj_mem _ h x },
+  { intro h,
+    convert nN.conj_mem _ h x⁻¹ using 1,
+    rw [mul_assoc, inv_inv, mul_assoc y, mul_left_inv, mul_one] }
+end
+
+omit nN
+
+lemma _root_.quotient_add_group.mk'_eq_mk'_iff_sub {G : Type*} [add_group G]
+  [H : add_subgroup G] [H.normal] {x y : G} :
+quotient_add_group.mk' H x = quotient_add_group.mk' H y ↔ y - x ∈ H :=
+by rw [quotient_add_group.mk'_eq_mk'_iff', sub_eq_add_neg]
+
+lemma _root_.quotient_add_group.mk'_eq_mk'_iff_sub' {G : Type*} [add_group G]
+  [H : add_subgroup G] [H.normal] {x y : G} :
+quotient_add_group.mk' H x = quotient_add_group.mk' H y ↔ x - y ∈ H :=
+begin
+  rw [quotient_add_group.mk'_eq_mk'_iff'],
+  split ; intro h ; replace h := H.neg_mem h,
+  { rwa [neg_add_rev, neg_neg, ← sub_eq_add_neg] at h },
+  { rwa [sub_eq_add_neg, neg_add_rev, neg_neg] at h },
+end
+
+include nN
+
 @[simp, to_additive quotient_add_group.eq_zero_iff]
 lemma eq_one_iff {N : subgroup G} [nN : N.normal] (x : G) : (x : quotient N) = 1 ↔ x ∈ N :=
 begin

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -86,28 +86,6 @@ lemma coe_mk' : (mk' N : G → quotient N) = coe := rfl
 @[to_additive, simp]
 lemma mk'_apply (x : G) : mk' N x = x := rfl
 
-@[to_additive]
-lemma mk'_eq_mk'_iff {x y : G} :  mk' N x = mk' N y ↔  x⁻¹*y ∈ N :=
-quotient_group.eq
-
-@[to_additive]
-lemma mk'_eq_mk'_iff' {x y : G} : mk' N x = mk' N y ↔ y * x⁻¹ ∈ N :=
-by rw [mk'_eq_mk'_iff, nN.mem_comm_iff]
-
-omit nN
-
-lemma _root_.quotient_add_group.mk'_eq_mk'_iff_sub {G : Type*} [add_group G]
-  [H : add_subgroup G] [H.normal] {x y : G} :
-quotient_add_group.mk' H x = quotient_add_group.mk' H y ↔ y - x ∈ H :=
-by rw [quotient_add_group.mk'_eq_mk'_iff', sub_eq_add_neg]
-
-lemma _root_.quotient_add_group.mk'_eq_mk'_iff_sub' {G : Type*} [add_group G]
-  [H : add_subgroup G] [H.normal] {x y : G} :
-quotient_add_group.mk' H x = quotient_add_group.mk' H y ↔ x - y ∈ H :=
-by rw [eq_comm, quotient_add_group.mk'_eq_mk'_iff_sub]
-
-include nN
-
 @[simp, to_additive quotient_add_group.eq_zero_iff]
 lemma eq_one_iff {N : subgroup G} [nN : N.normal] (x : G) : (x : quotient N) = 1 ↔ x ∈ N :=
 begin

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -91,16 +91,8 @@ lemma mk'_eq_mk'_iff {x y : G} :  mk' N x = mk' N y ↔  x⁻¹*y ∈ N :=
 quotient_group.eq
 
 @[to_additive]
-lemma mk'_eq_mk'_iff' {x y : G} :  mk' N x = mk' N y ↔  y*x⁻¹ ∈ N :=
-begin
-  rw mk'_eq_mk'_iff,
-  split,
-  { intro h,
-    simpa using nN.conj_mem _ h x },
-  { intro h,
-    convert nN.conj_mem _ h x⁻¹ using 1,
-    rw [mul_assoc, inv_inv, mul_assoc y, mul_left_inv, mul_one] }
-end
+lemma mk'_eq_mk'_iff' {x y : G} : mk' N x = mk' N y ↔ y * x⁻¹ ∈ N :=
+by rw [mk'_eq_mk'_iff, nN.mem_comm_iff]
 
 omit nN
 
@@ -112,12 +104,7 @@ by rw [quotient_add_group.mk'_eq_mk'_iff', sub_eq_add_neg]
 lemma _root_.quotient_add_group.mk'_eq_mk'_iff_sub' {G : Type*} [add_group G]
   [H : add_subgroup G] [H.normal] {x y : G} :
 quotient_add_group.mk' H x = quotient_add_group.mk' H y ↔ x - y ∈ H :=
-begin
-  rw [quotient_add_group.mk'_eq_mk'_iff'],
-  split ; intro h ; replace h := H.neg_mem h,
-  { rwa [neg_add_rev, neg_neg, ← sub_eq_add_neg] at h },
-  { rwa [sub_eq_add_neg, neg_add_rev, neg_neg] at h },
-end
+by rw [eq_comm, quotient_add_group.mk'_eq_mk'_iff_sub]
 
 include nN
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1268,15 +1268,7 @@ lemma coe_ker (f : G →* N) : (f.ker : set G) = (f : G → N) ⁻¹' {1} := rfl
 
 @[to_additive]
 lemma eq_iff (f : G →* N) {x y : G} : f x = f y ↔ y⁻¹*x ∈ f.ker :=
-begin
-  rw [f.mem_ker, f.map_mul, f.map_inv],
-  split,
-  { intro h,
-    rw h,
-    exact inv_mul_self (f y) },
-  { intro h,
-    convert _root_.congr_arg (λ z : N, (f y)*z) h ; simp }
-end
+by rw [f.mem_ker, f.map_mul, f.map_inv, inv_mul_eq_one, eq_comm]
 
 @[to_additive]
 instance decidable_mem_ker [decidable_eq N] (f : G →* N) :

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1270,7 +1270,7 @@ lemma mem_ker (f : G →* N) {x : G} : x ∈ f.ker ↔ f x = 1 := iff.rfl
 lemma coe_ker (f : G →* N) : (f.ker : set G) = (f : G → N) ⁻¹' {1} := rfl
 
 @[to_additive]
-lemma eq_iff (f : G →* N) {x y : G} : f x = f y ↔ y⁻¹*x ∈ f.ker :=
+lemma eq_iff (f : G →* N) {x y : G} : f x = f y ↔ y⁻¹ * x ∈ f.ker :=
 by rw [f.mem_ker, f.map_mul, f.map_inv, inv_mul_eq_one, eq_comm]
 
 @[to_additive]

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1267,6 +1267,18 @@ lemma mem_ker (f : G →* N) {x : G} : x ∈ f.ker ↔ f x = 1 := iff.rfl
 lemma coe_ker (f : G →* N) : (f.ker : set G) = (f : G → N) ⁻¹' {1} := rfl
 
 @[to_additive]
+lemma eq_iff (f : G →* N) {x y : G} : f x = f y ↔ y⁻¹*x ∈ f.ker :=
+begin
+  rw [f.mem_ker, f.map_mul, f.map_inv],
+  split,
+  { intro h,
+    rw h,
+    exact inv_mul_self (f y) },
+  { intro h,
+    convert _root_.congr_arg (λ z : N, (f y)*z) h ; simp }
+end
+
+@[to_additive]
 instance decidable_mem_ker [decidable_eq N] (f : G →* N) :
   decidable_pred (∈ f.ker) :=
 λ x, decidable_of_iff (f x = 1) f.mem_ker

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -238,6 +238,9 @@ by simpa only [div_eq_mul_inv] using H.mul_mem' hx (H.inv_mem' hy)
 @[simp, to_additive] theorem inv_mem_iff {x : G} : x⁻¹ ∈ H ↔ x ∈ H :=
 ⟨λ h, inv_inv x ▸ H.inv_mem h, H.inv_mem⟩
 
+@[to_additive] lemma div_mem_comm_iff {a b : G} : a / b ∈ H ↔ b / a ∈ H :=
+by rw [← H.inv_mem_iff, div_eq_mul_inv, div_eq_mul_inv, mul_inv_rev, inv_inv]
+
 @[simp, to_additive]
 theorem inv_coe_set : (H : set G)⁻¹ = H :=
 by { ext, simp, }

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -372,7 +372,7 @@ begin
   intros s s_op,
   change is_open ((coe : G →  quotient N) ⁻¹' (coe '' s)),
   rw quotient_group.preimage_image_coe N s,
-  exact is_open_Union (λ n, is_open_map_mul_right n s s_op)
+  exact is_open_Union (λ n, (continuous_mul_right _).is_open_preimage s s_op)
 end
 
 @[to_additive]


### PR DESCRIPTION
from LTE


---

This does not decrease the mess with `group_theory/coset` vs `group_theory/quotient_group` and various implicit or explicit parameters, it's only adding more API on top of the mess. In particular I added ad hoc reformulations for additive groups in order to avoid the `x + -y` curse of `to_additive`.

I also changed slightly an old lemma since preimages are more convenient to use than direct images.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
