### PR TITLE
[Merged by Bors] - chore(logic/nontrivial): adjust priority of `nonempty` instances

### DIFF
--- a/src/logic/nontrivial.lean
+++ b/src/logic/nontrivial.lean
@@ -62,9 +62,17 @@ lemma subtype.nontrivial_iff_exists_ne (p : α → Prop) (x : subtype p) :
   nontrivial (subtype p) ↔ ∃ (y : α) (hy : p y), y ≠ x :=
 by simp only [nontrivial_iff_exists_ne x, subtype.exists, ne.def, subtype.ext_iff, subtype.coe_mk]
 
-@[priority 100] -- see Note [lower instance priority]
+/--
+See Note [lower instance priority]
+
+Note that since this and `nonempty_of_inhabited` are the most "obvious" way to find a nonempty
+instance if no direct instance can be found, we give this a higher priority than the usual `100`.
+-/
+@[priority 500]
 instance nontrivial.to_nonempty [nontrivial α] : nonempty α :=
 let ⟨x, _⟩ := exists_pair_ne α in ⟨x⟩
+
+attribute [instance, priority 500] nonempty_of_inhabited
 
 /-- An inhabited type is either nontrivial, or has a unique element. -/
 noncomputable def nontrivial_psum_unique (α : Type*) [inhabited α] :


### PR DESCRIPTION
This makes `nontrivial.to_nonempty` and `nonempty_of_inhabited` higher priority so they are tried before things like `add_torsor.nonempty` which starts traversing the algebra heirarchy.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/char_zero/near/238103102)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
