### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal/operations): add apply_coe_mem_map

### DIFF
--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -792,7 +792,7 @@ lemma mem_map_of_mem (f : G →* N) {K : subgroup G} {x : G} (hx : x ∈ K) : f 
 mem_image_of_mem f hx
 
 @[to_additive]
-lemma apply_coe_mem_map (f : G →* N) {K : subgroup G} (x : K) : f x ∈ K.map f :=
+lemma apply_coe_mem_map (f : G →* N) (K : subgroup G) (x : K) : f x ∈ K.map f :=
 mem_map_of_mem f x.prop
 
 @[to_additive]

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -195,7 +195,7 @@ lemma mem_map_of_mem (f : M →* N) {S : submonoid M} {x : M} (hx : x ∈ S) : f
 mem_image_of_mem f hx
 
 @[to_additive]
-lemma apply_coe_mem_map (f : M →* N) {S : submonoid M} (x : S) : f x ∈ S.map f :=
+lemma apply_coe_mem_map (f : M →* N) (S : submonoid M) (x : S) : f x ∈ S.map f :=
 mem_map_of_mem f x.prop
 
 @[to_additive]

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -713,8 +713,11 @@ variables {f}
 theorem map_mono (h : I ≤ J) : map f I ≤ map f J :=
 span_mono $ set.image_subset _ h
 
-theorem mem_map_of_mem {x} (h : x ∈ I) : f x ∈ map f I :=
+theorem mem_map_of_mem (f : R →+* S) {I : ideal R} {x : R} (h : x ∈ I) : f x ∈ map f I :=
 subset_span ⟨x, h, rfl⟩
+
+lemma apply_coe_mem_map (f : R →+* S) (I : ideal R) (x : I) : f x ∈ I.map f :=
+mem_map_of_mem f x.prop
 
 theorem map_le_iff_le_comap :
   map f I ≤ K ↔ I ≤ comap f K :=
@@ -742,13 +745,13 @@ theorem map_top : map f ⊤ = ⊤ :=
 theorem map_mul : map f (I * J) = map f I * map f J :=
 le_antisymm (map_le_iff_le_comap.2 $ mul_le.2 $ λ r hri s hsj,
   show f (r * s) ∈ _, by rw f.map_mul;
-  exact mul_mem_mul (mem_map_of_mem hri) (mem_map_of_mem hsj))
+  exact mul_mem_mul (mem_map_of_mem f hri) (mem_map_of_mem f hsj))
 (trans_rel_right _ (span_mul_span _ _) $ span_le.2 $
   set.bUnion_subset $ λ i ⟨r, hri, hfri⟩,
   set.bUnion_subset $ λ j ⟨s, hsj, hfsj⟩,
   set.singleton_subset_iff.2 $ hfri ▸ hfsj ▸
   by rw [← f.map_mul];
-  exact mem_map_of_mem (mul_mem_mul hri hsj))
+  exact mem_map_of_mem f (mul_mem_mul hri hsj))
 
 variable (f)
 lemma gc_map_comap : galois_connection (ideal.map f) (ideal.comap f) :=
@@ -842,7 +845,7 @@ theorem map_inf_le : map f (I ⊓ J) ≤ map f I ⊓ map f J :=
 (gc_map_comap f).monotone_l.map_inf_le _ _
 
 theorem map_radical_le : map f (radical I) ≤ radical (map f I) :=
-map_le_iff_le_comap.2 $ λ r ⟨n, hrni⟩, ⟨n, f.map_pow r n ▸ mem_map_of_mem hrni⟩
+map_le_iff_le_comap.2 $ λ r ⟨n, hrni⟩, ⟨n, f.map_pow r n ▸ mem_map_of_mem f hrni⟩
 
 theorem le_comap_sup : comap f K ⊔ comap f L ≤ comap f (K ⊔ L) :=
 (gc_map_comap f).monotone_u.le_map_sup _ _
@@ -861,7 +864,7 @@ theorem map_comap_of_surjective (I : ideal S) :
   map f (comap f I) = I :=
 le_antisymm (map_le_iff_le_comap.2 (le_refl _))
 (λ s hsi, let ⟨r, hfrs⟩ := hf s in
-  hfrs ▸ (mem_map_of_mem $ show f r ∈ I, from hfrs.symm ▸ hsi))
+  hfrs ▸ (mem_map_of_mem f $ show f r ∈ I, from hfrs.symm ▸ hsi))
 
 /-- `map` and `comap` are adjoint, and the composition `map f ∘ comap f` is the
   identity -/
@@ -900,7 +903,7 @@ submodule.span_induction H (λ _, id) ⟨0, I.zero_mem, f.map_zero⟩
 lemma mem_map_iff_of_surjective {I : ideal R} {y} :
   y ∈ map f I ↔ ∃ x, x ∈ I ∧ f x = y :=
 ⟨λ h, (set.mem_image _ _ _).2 (mem_image_of_mem_map_of_surjective f hf h),
-  λ ⟨x, hx⟩, hx.right ▸ (mem_map_of_mem hx.left)⟩
+  λ ⟨x, hx⟩, hx.right ▸ (mem_map_of_mem f hx.left)⟩
 
 theorem comap_map_of_surjective (I : ideal R) :
   comap f (map f I) = I ⊔ comap f ⊥ :=
@@ -1160,10 +1163,10 @@ begin
     cases (mem_map_iff_of_surjective f hf).1 hy with x hx,
     cases (set.mem_image _ _ _).mp hj with J hJ,
     rw [← hJ.right, ← hx.right],
-    exact mem_map_of_mem (Inf_le_of_le hJ.left (le_of_eq rfl) hx.left) },
+    exact mem_map_of_mem f (Inf_le_of_le hJ.left (le_of_eq rfl) hx.left) },
   { intros y hy,
     cases hf y with x hx,
-    refine hx ▸ (mem_map_of_mem _),
+    refine hx ▸ (mem_map_of_mem f _),
     have : ∀ I ∈ A, y ∈ map f I, by simpa using hy,
     rw [submodule.mem_Inf],
     intros J hJ,
@@ -1188,7 +1191,7 @@ begin
     have : a * b ∈ I,
     { convert I.sub_mem hc (hk (hc' : c - a * b ∈ f.ker)),
       ring },
-    exact (H.mem_or_mem this).imp (λ h, ha ▸ mem_map_of_mem h) (λ h, hb ▸ mem_map_of_mem h) }
+    exact (H.mem_or_mem this).imp (λ h, ha ▸ mem_map_of_mem f h) (λ h, hb ▸ mem_map_of_mem f h) }
 end
 
 theorem map_is_prime_of_equiv (f : R ≃+* S) {I : ideal R} [is_prime I] :

--- a/src/ring_theory/ideal/over.lean
+++ b/src/ring_theory/ideal/over.lean
@@ -134,7 +134,7 @@ lemma exists_coeff_mem_comap_sdiff_comap_of_root_mem_sdiff
 begin
   obtain ⟨hrJ, hrI⟩ := hr,
   have rbar_ne_zero : quotient.mk I r ≠ 0 := mt (quotient.mk_eq_zero I).mp hrI,
-  have rbar_mem_J : quotient.mk I r ∈ J.map (quotient.mk I) := mem_map_of_mem hrJ,
+  have rbar_mem_J : quotient.mk I r ∈ J.map (quotient.mk I) := mem_map_of_mem _ hrJ,
   have quotient_f : ∀ x ∈ I.comap f, (quotient.mk I).comp f x = 0,
   { simp [quotient.eq_zero_iff_mem] },
   have rbar_root : (p.map (quotient.mk (I.comap f))).eval₂

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -267,14 +267,15 @@ lemma is_integral_localization_map_polynomial_quotient
   (ϕ : localization_map (submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff) Rₘ)
   (ϕ' : localization_map ((submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff).map
     (quotient_map P C le_rfl) : submonoid P.quotient) Sₘ) :
-  (ϕ.map (submonoid.apply_coe_mem_map (quotient_map P C le_rfl :
+  (ϕ.map ((submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff).apply_coe_mem_map
+      (quotient_map P C le_rfl :
   (P.comap C : ideal R).quotient →* P.quotient)) ϕ').is_integral :=
 begin
   let P' : ideal R := P.comap C,
   let M : submonoid P'.quotient :=
   submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff,
   let φ : P'.quotient →+* P.quotient := quotient_map P C le_rfl,
-  let φ' := (ϕ.map (submonoid.apply_coe_mem_map (φ : P'.quotient →* P.quotient)) ϕ'),
+  let φ' := (ϕ.map (M.apply_coe_mem_map (φ : P'.quotient →* P.quotient)) ϕ'),
   have hφ' : φ.comp (quotient.mk P') = (quotient.mk P).comp C := rfl,
   intro p,
   obtain ⟨⟨p', ⟨q, hq⟩⟩, hp⟩ := ϕ'.surj p,
@@ -312,13 +313,13 @@ lemma jacobson_bot_of_integral_localization {R : Type*} [integral_domain R] [is_
   (φ : R →+* S) (hφ : function.injective φ) (x : R) (hx : x ≠ 0)
   (ϕ : localization_map (submonoid.powers x) Rₘ)
   (ϕ' : localization_map ((submonoid.powers x).map φ : submonoid S) Sₘ)
-  (hφ' : (ϕ.map (submonoid.apply_coe_mem_map (φ : R →* S)) ϕ').is_integral) :
+  (hφ' : (ϕ.map ((submonoid.powers x).apply_coe_mem_map (φ : R →* S)) ϕ').is_integral) :
   (⊥ : ideal S).jacobson = ⊥ :=
 begin
   have hM : ((submonoid.powers x).map φ : submonoid S) ≤ non_zero_divisors S :=
     map_le_non_zero_divisors_of_injective hφ (powers_le_non_zero_divisors_of_domain hx),
   letI : integral_domain Sₘ := localization_map.integral_domain_of_le_non_zero_divisors ϕ' hM,
-  let φ' : Rₘ →+* Sₘ := ϕ.map (submonoid.apply_coe_mem_map (φ : R →* S)) ϕ',
+  let φ' : Rₘ →+* Sₘ := ϕ.map ((submonoid.powers x).apply_coe_mem_map (φ : R →* S)) ϕ',
   suffices : ∀ I : ideal Sₘ, I.is_maximal → (I.comap ϕ'.to_map).is_maximal,
   { have hϕ' : comap ϕ'.to_map ⊥ = ⊥,
     { simpa [ring_hom.injective_iff_ker_eq_bot, ring_hom.ker_eq_comap_bot] using ϕ'.injective hM },
@@ -474,7 +475,7 @@ begin
   { let ϕ : localization_map M (localization M) := localization.of M,
     rw ← (ϕ.map_comp _),
     refine ring_hom.is_integral_trans ϕ.to_map
-      (ϕ.map (submonoid.apply_coe_mem_map (φ : P'.quotient →* P.quotient)) ϕ') _ _,
+      (ϕ.map (M.apply_coe_mem_map (φ : P'.quotient →* P.quotient)) ϕ') _ _,
     { exact ϕ.to_map.is_integral_of_surjective (localization_map_bijective_of_field hM
         ((quotient.maximal_ideal_iff_is_field_quotient _).mp
         (is_maximal_comap_C_of_is_maximal P hP')) _).2 },

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -820,7 +820,7 @@ begin
     use ⟨⟨⟨y, hy.left⟩, 1⟩, by simp [hy.right]⟩ },
   { rintros ⟨⟨a, s⟩, h⟩,
     rw [← ideal.unit_mul_mem_iff_mem _ (map_units f s), mul_comm],
-    exact h.symm ▸ ideal.mem_map_of_mem a.2 }
+    exact h.symm ▸ ideal.mem_map_of_mem _ a.2 }
 end
 
 theorem map_comap (J : ideal S) :
@@ -829,7 +829,7 @@ le_antisymm (ideal.map_le_iff_le_comap.2 (le_refl _)) $ λ x hJ,
 begin
   obtain ⟨r, s, hx⟩ := f.mk'_surjective x,
   rw ←hx at ⊢ hJ,
-  exact ideal.mul_mem_right _ _ (ideal.mem_map_of_mem (show f.to_map r ∈ J, from
+  exact ideal.mul_mem_right _ _ (ideal.mem_map_of_mem _ (show f.to_map r ∈ J, from
     f.mk'_spec r s ▸ J.mul_mem_right (f.to_map s) hJ)),
 end
 
@@ -1180,7 +1180,7 @@ include hI
 lemma at_prime.is_unit_to_map_iff (x : R) :
   is_unit (f.to_map x) ↔ x ∈ I.prime_compl :=
 ⟨λ h hx, (f.is_prime_of_is_prime_disjoint I hI disjoint_compl_left).ne_top $
-  (ideal.map f.to_map I).eq_top_of_is_unit_mem (ideal.mem_map_of_mem hx) h,
+  (ideal.map f.to_map I).eq_top_of_is_unit_mem (ideal.mem_map_of_mem _ hx) h,
 λ h, f.map_units ⟨x, h⟩⟩
 
 lemma at_prime.to_map_mem_maximal_iff (x : R) :
@@ -1502,7 +1502,7 @@ lemma map_injective_of_injective {R S : Type*} [comm_ring R] [comm_ring S]
   (ϕ : R →+* S) (hϕ : function.injective ϕ) (M : submonoid R)
   (f : localization_map M Rₘ) (g : localization_map (M.map ϕ : submonoid S) Sₘ)
   (hM : (M.map ϕ : submonoid S) ≤ non_zero_divisors S) :
-  function.injective (f.map (submonoid.apply_coe_mem_map (ϕ : R →* S)) g) :=
+  function.injective (f.map (M.apply_coe_mem_map (ϕ : R →* S)) g) :=
 begin
   rintros x y hxy,
   obtain ⟨a, b, rfl⟩ := localization_map.mk'_surjective f x,
@@ -1526,7 +1526,7 @@ lemma ring_hom.is_integral_elem_localization_at_leading_coeff
   (x : S) (p : polynomial R) (hf : p.eval₂ f x = 0) (M : submonoid R)
   (hM : p.leading_coeff ∈ M) {Rₘ Sₘ : Type*} [comm_ring Rₘ] [comm_ring Sₘ]
   (ϕ : localization_map M Rₘ) (ϕ' : localization_map (M.map ↑f : submonoid S) Sₘ) :
-  (ϕ.map (submonoid.apply_coe_mem_map (f : R →* S)) ϕ').is_integral_elem (ϕ'.to_map x) :=
+  (ϕ.map (M.apply_coe_mem_map (f : R →* S)) ϕ').is_integral_elem (ϕ'.to_map x) :=
 begin
   by_cases triv : (1 : Rₘ) = 0,
   { exact ⟨0, ⟨trans leading_coeff_zero triv.symm, eval₂_zero _ _⟩⟩ },
@@ -1578,7 +1578,7 @@ end
 
 lemma is_integral_localization' {R S : Type*} [comm_ring R] [comm_ring S]
   {f : R →+* S} (hf : f.is_integral) (M : submonoid R) :
-  ((localization.of M).map (submonoid.apply_coe_mem_map (f : R →* S))
+  ((localization.of M).map (M.apply_coe_mem_map (f : R →* S))
   (localization.of (M.map ↑f))).is_integral :=
 @is_integral_localization R _ M S _ _ _ _ _ f.to_algebra _ _ hf
 

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -343,7 +343,7 @@ begin
     refine (I.map C : ideal (polynomial R)).sum_mem (λ n hn, _),
     simp [monomial_eq_C_mul_X],
     rw mul_comm,
-    exact (I.map C : ideal (polynomial R)).mul_mem_left _ (mem_map_of_mem (hf n)) }
+    exact (I.map C : ideal (polynomial R)).mul_mem_left _ (mem_map_of_mem _ (hf n)) }
 end
 
 lemma quotient_map_C_eq_zero {I : ideal R} :
@@ -351,7 +351,7 @@ lemma quotient_map_C_eq_zero {I : ideal R} :
 begin
   intros a ha,
   rw [ring_hom.comp_apply, quotient.eq_zero_iff_mem],
-  exact mem_map_of_mem ha,
+  exact mem_map_of_mem _ ha,
 end
 
 lemma eval₂_C_mk_eq_zero {I : ideal R} :
@@ -853,7 +853,7 @@ lemma quotient_map_C_eq_zero {I : ideal R} {i : R} (hi : i ∈ I) :
   (ideal.quotient.mk (ideal.map C I : ideal (mv_polynomial σ R))).comp C i = 0 :=
 begin
   simp only [function.comp_app, ring_hom.coe_comp, ideal.quotient.eq_zero_iff_mem],
-  exact ideal.mem_map_of_mem hi
+  exact ideal.mem_map_of_mem _ hi
 end
 
 /-- If every coefficient of a polynomial is in an ideal `I`, then so is the polynomial itself,


### PR DESCRIPTION
This is a continuation of #7459. In this PR:

- We modify `ideal.mem_map_of_mem` in order to be consistent with `submonoid.mem_map_of_mem`.
- We modify `submonoid.apply_coe_mem_map` (and friends) to have the submonoid as an explicit variable. This was the case before #7459 (but with a different, and not consistent, name). It seems to me that this version makes the code more readable.
- We add `ideal.apply_coe_mem_map` (similar to `submonoid.apply_coe_mem_map`).

Note that `mem_map_of_mem` is used in other places, for example we have `multiset.mem_map_of_mem`, but since a multiset is not a type there is no `apply_coe_mem_map` to add there.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
