### PR TITLE
[Merged by Bors] - feat(ring_theory/finiteness): add finite_type_iff_group_fg

### DIFF
--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -714,7 +714,7 @@ finite_type_iff_fg.2 h
 /-- An additive group `G` is finitely generated if and only if `add_monoid_algebra R G` is of
 finite type. -/
 lemma finite_type_iff_group_fg {G : Type*} [add_comm_group G] [comm_ring R] [nontrivial R] :
-add_group.fg G ↔ finite_type R (add_monoid_algebra R G) :=
+  add_group.fg G ↔ finite_type R (add_monoid_algebra R G) :=
 by simpa [add_group.fg_iff_add_monoid.fg] using finite_type_iff_fg
 
 end add_monoid_algebra

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -695,9 +695,9 @@ end
 /-- An additive monoid `M` is finitely generated if and only if `add_monoid_algebra R M` is of
 finite type. -/
 lemma finite_type_iff_fg [comm_ring R] [nontrivial R] :
-  add_monoid.fg M ↔ finite_type R (add_monoid_algebra R M) :=
+  finite_type R (add_monoid_algebra R M) ↔ add_monoid.fg M :=
 begin
-  refine ⟨λ h, @add_monoid_algebra.finite_type_of_fg _ _ _ _ h, λ h, _⟩,
+  refine ⟨λ h, _, λ h, @add_monoid_algebra.finite_type_of_fg _ _ _ _ h⟩,
   obtain ⟨S, hS⟩ := @exists_finset_adjoin_eq_top R M _ _ h,
   refine add_monoid.fg_def.2 ⟨S, (eq_top_iff' _).2 (λ m, _)⟩,
   have hm : of' R M m ∈ (adjoin R (of' R M '' ↑S)).to_submodule,
@@ -709,12 +709,12 @@ end
 /-- If `add_monoid_algebra R M` is of finite type then `M` is finitely generated. -/
 lemma fg_of_finite_type [comm_ring R] [nontrivial R] [h : finite_type R (add_monoid_algebra R M)] :
   add_monoid.fg M :=
-finite_type_iff_fg.2 h
+finite_type_iff_fg.1 h
 
 /-- An additive group `G` is finitely generated if and only if `add_monoid_algebra R G` is of
 finite type. -/
 lemma finite_type_iff_group_fg {G : Type*} [add_comm_group G] [comm_ring R] [nontrivial R] :
-add_group.fg G ↔ finite_type R (add_monoid_algebra R G) :=
+  finite_type R (add_monoid_algebra R G) ↔ add_group.fg G :=
 by simpa [add_group.fg_iff_add_monoid.fg] using finite_type_iff_fg
 
 end add_monoid_algebra
@@ -837,18 +837,18 @@ add_monoid_algebra.finite_type_of_fg.equiv (to_additive_alg_equiv R M).symm
 
 /-- A monoid `M` is finitely generated if and only if `monoid_algebra R M` is of finite type. -/
 lemma finite_type_iff_fg [comm_ring R] [nontrivial R] :
-  monoid.fg M ↔ finite_type R (monoid_algebra R M) :=
-⟨λ h, @monoid_algebra.finite_type_of_fg _ _ _ _ h, λ h, monoid.fg_iff_add_fg.2 $
-  add_monoid_algebra.finite_type_iff_fg.2 $ h.equiv $ to_additive_alg_equiv R M⟩
+  finite_type R (monoid_algebra R M) ↔ monoid.fg M :=
+⟨λ h, monoid.fg_iff_add_fg.2 $ add_monoid_algebra.finite_type_iff_fg.1 $ h.equiv $
+  to_additive_alg_equiv R M, λ h, @monoid_algebra.finite_type_of_fg _ _ _ _ h⟩
 
 /-- If `monoid_algebra R M` is of finite type then `M` is finitely generated. -/
 lemma fg_of_finite_type [comm_ring R] [nontrivial R] [h : finite_type R (monoid_algebra R M)] :
   monoid.fg M :=
-finite_type_iff_fg.2 h
+finite_type_iff_fg.1 h
 
 /-- A group `G` is finitely generated if and only if `add_monoid_algebra R G` is of finite type. -/
 lemma finite_type_iff_group_fg {G : Type*} [comm_group G] [comm_ring R] [nontrivial R] :
-group.fg G ↔ finite_type R (monoid_algebra R G) :=
+finite_type R (monoid_algebra R G) ↔ group.fg G :=
 by simpa [group.fg_iff_monoid.fg] using finite_type_iff_fg
 
 end monoid_algebra

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -848,7 +848,7 @@ finite_type_iff_fg.2 h
 
 /-- A group `G` is finitely generated if and only if `add_monoid_algebra R G` is of finite type. -/
 lemma finite_type_iff_group_fg {G : Type*} [comm_group G] [comm_ring R] [nontrivial R] :
-group.fg G ↔ finite_type R (monoid_algebra R G) :=
+  group.fg G ↔ finite_type R (monoid_algebra R G) :=
 by simpa [group.fg_iff_monoid.fg] using finite_type_iff_fg
 
 end monoid_algebra

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -711,6 +711,12 @@ lemma fg_of_finite_type [comm_ring R] [nontrivial R] [h : finite_type R (add_mon
   add_monoid.fg M :=
 finite_type_iff_fg.2 h
 
+/-- An additive group `G` is finitely generated if and only if `add_monoid_algebra R G` is of
+finite type. -/
+lemma finite_type_iff_group_fg {G : Type*} [add_comm_group G] [comm_ring R] [nontrivial R] :
+add_group.fg G ↔ finite_type R (add_monoid_algebra R G) :=
+by simpa [add_group.fg_iff_add_monoid.fg] using finite_type_iff_fg
+
 end add_monoid_algebra
 
 namespace monoid_algebra
@@ -839,6 +845,11 @@ lemma finite_type_iff_fg [comm_ring R] [nontrivial R] :
 lemma fg_of_finite_type [comm_ring R] [nontrivial R] [h : finite_type R (monoid_algebra R M)] :
   monoid.fg M :=
 finite_type_iff_fg.2 h
+
+/-- A group `G` is finitely generated if and only if `add_monoid_algebra R G` is of finite type. -/
+lemma finite_type_iff_group_fg {G : Type*} [comm_group G] [comm_ring R] [nontrivial R] :
+group.fg G ↔ finite_type R (monoid_algebra R G) :=
+by simpa [group.fg_iff_monoid.fg] using finite_type_iff_fg
 
 end monoid_algebra
 


### PR DESCRIPTION
We add here a simple modification of `monoid_algebra.fg_of_finite_type`: a group algebra is of finite type if and only if the group is finitely generated (as group opposed to as monoid).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
