### PR TITLE
[Merged by Bors] - feat(data/set/basic): pairwise_on.imp_on

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1850,6 +1850,10 @@ begin
     { exact h.left _ hb _ hc hn } }
 end
 
+lemma pairwise_on.imp {s : set α} {p q : α → α → Prop}
+  (h : pairwise_on s p) (hpq : ∀ ⦃a b : α⦄, p a b → q a b) : pairwise_on s q :=
+λ a ha b hb hab, hpq (h a ha b hb hab)
+
 end set
 
 open set

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1794,7 +1794,7 @@ end range
 /-- The set `s` is pairwise `r` if `r x y` for all *distinct* `x y ∈ s`. -/
 def pairwise_on (s : set α) (r : α → α → Prop) := ∀ x ∈ s, ∀ y ∈ s, x ≠ y → r x y
 
-lemma pairwise_on_forall (s : set α) (p : α → α → Prop) (h : ∀ (a b : α), p a b) :
+lemma pairwise_on_of_forall (s : set α) (p : α → α → Prop) (h : ∀ (a b : α), p a b) :
   pairwise_on s p :=
 λ a _ b _ _, h a b
 
@@ -1804,7 +1804,7 @@ lemma pairwise_on.imp_on {s : set α} {p q : α → α → Prop}
 
 lemma pairwise_on.imp {s : set α} {p q : α → α → Prop}
   (h : pairwise_on s p) (hpq : ∀ ⦃a b : α⦄, p a b → q a b) : pairwise_on s q :=
-h.imp_on (pairwise_on_forall s _ hpq)
+h.imp_on (pairwise_on_of_forall s _ hpq)
 
 theorem pairwise_on.mono {s t : set α} {r}
   (h : t ⊆ s) (hp : pairwise_on s r) : pairwise_on t r :=
@@ -1813,6 +1813,9 @@ theorem pairwise_on.mono {s t : set α} {r}
 theorem pairwise_on.mono' {s : set α} {r r' : α → α → Prop}
   (H : r ≤ r') (hp : pairwise_on s r) : pairwise_on s r' :=
 hp.imp H
+theorem pairiwise_on_top (s : set α) :
+  pairwise_on s ⊤ :=
+pairwise_on_of_forall s _ (λ a b, trivial)
 
 /-- If and only if `f` takes pairwise equal values on `s`, there is
 some value it takes everywhere on `s`. -/

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1850,9 +1850,17 @@ begin
     { exact h.left _ hb _ hc hn } }
 end
 
+lemma pairwise_on_forall (s : set α) (p : α → α → Prop) (h : ∀ (a b : α), p a b) :
+  pairwise_on s p :=
+λ a _ b _ _, h a b
+
+lemma pairwise_on.imp_on {s : set α} {p q : α → α → Prop}
+  (h : pairwise_on s p) (hpq : pairwise_on s (λ ⦃a b : α⦄, p a b → q a b)) : pairwise_on s q :=
+λ a ha b hb hab, hpq a ha b hb hab (h a ha b hb hab)
+
 lemma pairwise_on.imp {s : set α} {p q : α → α → Prop}
   (h : pairwise_on s p) (hpq : ∀ ⦃a b : α⦄, p a b → q a b) : pairwise_on s q :=
-λ a ha b hb hab, hpq (h a ha b hb hab)
+h.imp_on (pairwise_on_forall s _ hpq)
 
 end set
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1794,13 +1794,25 @@ end range
 /-- The set `s` is pairwise `r` if `r x y` for all *distinct* `x y ∈ s`. -/
 def pairwise_on (s : set α) (r : α → α → Prop) := ∀ x ∈ s, ∀ y ∈ s, x ≠ y → r x y
 
+lemma pairwise_on_forall (s : set α) (p : α → α → Prop) (h : ∀ (a b : α), p a b) :
+  pairwise_on s p :=
+λ a _ b _ _, h a b
+
+lemma pairwise_on.imp_on {s : set α} {p q : α → α → Prop}
+  (h : pairwise_on s p) (hpq : pairwise_on s (λ ⦃a b : α⦄, p a b → q a b)) : pairwise_on s q :=
+λ a ha b hb hab, hpq a ha b hb hab (h a ha b hb hab)
+
+lemma pairwise_on.imp {s : set α} {p q : α → α → Prop}
+  (h : pairwise_on s p) (hpq : ∀ ⦃a b : α⦄, p a b → q a b) : pairwise_on s q :=
+h.imp_on (pairwise_on_forall s _ hpq)
+
 theorem pairwise_on.mono {s t : set α} {r}
   (h : t ⊆ s) (hp : pairwise_on s r) : pairwise_on t r :=
 λ x xt y yt, hp x (h xt) y (h yt)
 
 theorem pairwise_on.mono' {s : set α} {r r' : α → α → Prop}
-  (H : ∀ a b, r a b → r' a b) (hp : pairwise_on s r) : pairwise_on s r' :=
-λ x xs y ys h, H _ _ (hp x xs y ys h)
+  (H : r ≤ r') (hp : pairwise_on s r) : pairwise_on s r' :=
+hp.imp H
 
 /-- If and only if `f` takes pairwise equal values on `s`, there is
 some value it takes everywhere on `s`. -/
@@ -1849,18 +1861,6 @@ begin
     { exact hr (h.right _ hb hn.symm) },
     { exact h.left _ hb _ hc hn } }
 end
-
-lemma pairwise_on_forall (s : set α) (p : α → α → Prop) (h : ∀ (a b : α), p a b) :
-  pairwise_on s p :=
-λ a _ b _ _, h a b
-
-lemma pairwise_on.imp_on {s : set α} {p q : α → α → Prop}
-  (h : pairwise_on s p) (hpq : pairwise_on s (λ ⦃a b : α⦄, p a b → q a b)) : pairwise_on s q :=
-λ a ha b hb hab, hpq a ha b hb hab (h a ha b hb hab)
-
-lemma pairwise_on.imp {s : set α} {p q : α → α → Prop}
-  (h : pairwise_on s p) (hpq : ∀ ⦃a b : α⦄, p a b → q a b) : pairwise_on s q :=
-h.imp_on (pairwise_on_forall s _ hpq)
 
 end set
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1813,7 +1813,7 @@ theorem pairwise_on.mono {s t : set α} {r}
 theorem pairwise_on.mono' {s : set α} {r r' : α → α → Prop}
   (H : r ≤ r') (hp : pairwise_on s r) : pairwise_on s r' :=
 hp.imp H
-theorem pairiwise_on_top (s : set α) :
+theorem pairwise_on_top (s : set α) :
   pairwise_on s ⊤ :=
 pairwise_on_of_forall s _ (λ a b, trivial)
 


### PR DESCRIPTION
Provide more helper lemmas for transferring `pairwise_on` between different relations. Provide a rephrase of `pairwise_on.mono'` as `pairwise_on.imp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
