### PR TITLE
[Merged by Bors] - feat(algebra/subalgebra): two equal subalgebras are equivalent

### DIFF
--- a/src/algebra/algebra/subalgebra.lean
+++ b/src/algebra/algebra/subalgebra.lean
@@ -599,13 +599,17 @@ instance : unique (subalgebra R R) :=
   .. algebra.subalgebra.inhabited }
 
 /-- Two subalgebras that are equal are also equivalent as algebras. -/
-@[simps]
+@[simps apply]
 def equiv_of_eq (S T : subalgebra R A) (h : S = T) : S ≃ₐ[R] T :=
 { to_fun := λ x, ⟨x, h ▸ x.2⟩,
   inv_fun := λ x, ⟨x, h.symm ▸ x.2⟩,
   map_mul' := λ _ _, rfl,
   commutes' := λ _, rfl,
   .. linear_equiv.of_eq _ _ (congr_arg to_submodule h) }
+
+@[simp] lemma equiv_of_eq_symm (S T : subalgebra R A) (h : S = T) :
+  (equiv_of_eq S T h).symm = equiv_of_eq T S h.symm :=
+rfl
 
 end subalgebra
 

--- a/src/algebra/algebra/subalgebra.lean
+++ b/src/algebra/algebra/subalgebra.lean
@@ -613,6 +613,14 @@ def equiv_of_eq (S T : subalgebra R A) (h : S = T) : S ≃ₐ[R] T :=
   (equiv_of_eq S T h).symm = equiv_of_eq T S h.symm :=
 rfl
 
+@[simp] lemma equiv_of_eq_rfl (S : subalgebra R A) :
+  equiv_of_eq S S rfl = alg_equiv.refl :=
+by { ext, refl }
+
+@[simp] lemma equiv_of_eq_trans (S T U : subalgebra R A) (hST : S = T) (hTU : T = U) :
+  (equiv_of_eq S T hST).trans (equiv_of_eq T U hTU) = equiv_of_eq S U (trans hST hTU) :=
+rfl
+
 end subalgebra
 
 section nat

--- a/src/algebra/algebra/subalgebra.lean
+++ b/src/algebra/algebra/subalgebra.lean
@@ -598,7 +598,9 @@ instance : unique (subalgebra R R) :=
   end
   .. algebra.subalgebra.inhabited }
 
-/-- Two subalgebras that are equal are also equivalent as algebras. -/
+/-- Two subalgebras that are equal are also equivalent as algebras.
+
+This is the `subalgebra` version of `linear_equiv.of_eq` and `equiv.set.of_eq`. -/
 @[simps apply]
 def equiv_of_eq (S T : subalgebra R A) (h : S = T) : S ≃ₐ[R] T :=
 { to_fun := λ x, ⟨x, h ▸ x.2⟩,

--- a/src/algebra/algebra/subalgebra.lean
+++ b/src/algebra/algebra/subalgebra.lean
@@ -598,6 +598,15 @@ instance : unique (subalgebra R R) :=
   end
   .. algebra.subalgebra.inhabited }
 
+/-- Two subalgebras that are equal are also equivalent as algebras. -/
+@[simps]
+def equiv_of_eq (S T : subalgebra R A) (h : S = T) : S ≃ₐ[R] T :=
+{ to_fun := λ x, ⟨x, h ▸ x.2⟩,
+  inv_fun := λ x, ⟨x, h.symm ▸ x.2⟩,
+  map_mul' := λ _ _, rfl,
+  commutes' := λ _, rfl,
+  .. linear_equiv.of_eq _ _ (congr_arg to_submodule h) }
+
 end subalgebra
 
 section nat


### PR DESCRIPTION
This extends `linear_equiv.of_eq` to an `alg_equiv` between two `subalgebra`s.

[Zulip discussion starts around here](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/towers.20of.20algebras/near/238452076)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
