### PR TITLE
[Merged by Bors] - feat(algebra/lie/weights): define product of root vectors and weight vectors

### DIFF
--- a/src/algebra/lie/abelian.lean
+++ b/src/algebra/lie/abelian.lean
@@ -266,7 +266,7 @@ begin
   simp only [_root_.eq_bot_iff, lie_ideal_oper_eq_span, lie_submodule.lie_span_le,
     lie_submodule.bot_coe, set.subset_singleton_iff, set.mem_set_of_eq, exists_imp_distrib],
   split; intros h,
-  { intros z x y hz, rw [← hz, ← coe_bracket, coe_zero_iff_zero], apply h.trivial, },
+  { intros z x y hz, rw [← hz, ← lie_subalgebra.coe_bracket, coe_zero_iff_zero], apply h.trivial, },
   { exact ⟨λ x y, by { rw ← coe_zero_iff_zero, apply h _ x y, refl, }⟩, },
 end
 

--- a/src/algebra/lie/subalgebra.lean
+++ b/src/algebra/lie/subalgebra.lean
@@ -148,11 +148,12 @@ instance : lie_module R L' M :=
 
 /-- An `L`-equivariant map of Lie modules `M → N` is `L'`-equivariant for any Lie subalgebra
 `L' ⊆ L`. -/
-def restrict_lie_module_hom (f : M →ₗ⁅R,L⁆ N) : M →ₗ⁅R,L'⁆ N :=
+def _root_.lie_module_hom.restrict_lie (f : M →ₗ⁅R,L⁆ N) (L' : lie_subalgebra R L) : M →ₗ⁅R,L'⁆ N :=
 { map_lie' := λ x m, f.map_lie ↑x m,
   .. (f : M →ₗ[R] N)}
 
-@[simp] lemma coe_restrict_lie_module_hom (f : M →ₗ⁅R,L⁆ N) : ⇑(restrict_lie_module_hom L' f) = f :=
+@[simp] lemma _root_.lie_module_hom.coe_restrict_lie (f : M →ₗ⁅R,L⁆ N) :
+  ⇑(f.restrict_lie L') = f :=
 rfl
 
 end lie_module

--- a/src/algebra/lie/subalgebra.lean
+++ b/src/algebra/lie/subalgebra.lean
@@ -126,6 +126,7 @@ lemma coe_to_submodule : ((L' : submodule R L) : set L) = L' := rfl
 section lie_module
 
 variables {M : Type w} [add_comm_group M] [lie_ring_module L M]
+variables {N : Type w₁} [add_comm_group N] [lie_ring_module L N] [module R N] [lie_module R L N]
 
 /-- Given a Lie algebra `L` containing a Lie subalgebra `L' ⊆ L`, together with a Lie ring module
 `M` of `L`, we may regard `M` as a Lie ring module of `L'` by restriction. -/
@@ -137,11 +138,22 @@ instance : lie_ring_module L' M :=
 
 @[simp] lemma coe_bracket_of_module (x : L') (m : M) : ⁅x, m⁆ = ⁅(x : L), m⁆ := rfl
 
+variables [module R M] [lie_module R L M]
+
 /-- Given a Lie algebra `L` containing a Lie subalgebra `L' ⊆ L`, together with a Lie module `M` of
 `L`, we may regard `M` as a Lie module of `L'` by restriction. -/
-instance [module R M] [lie_module R L M] : lie_module R L' M :=
+instance : lie_module R L' M :=
 { smul_lie := λ t x m, by simp only [coe_bracket_of_module, smul_lie, submodule.coe_smul_of_tower],
   lie_smul := λ t x m, by simp only [coe_bracket_of_module, lie_smul], }
+
+/-- An `L`-equivariant map of Lie modules `M → N` is `L'`-equivariant for any Lie subalgebra
+`L' ⊆ L`. -/
+def restrict_lie_module_hom (f : M →ₗ⁅R,L⁆ N) : M →ₗ⁅R,L'⁆ N :=
+{ map_lie' := λ x m, f.map_lie ↑x m,
+  .. (f : M →ₗ[R] N)}
+
+@[simp] lemma coe_restrict_lie_module_hom (f : M →ₗ⁅R,L⁆ N) : ⇑(restrict_lie_module_hom L' f) = f :=
+rfl
 
 end lie_module
 

--- a/src/algebra/lie/submodule.lean
+++ b/src/algebra/lie/submodule.lean
@@ -112,6 +112,18 @@ instance : lie_module R L N :=
 { lie_smul := by { intros t x y, apply set_coe.ext, apply lie_smul, },
   smul_lie := by { intros t x y, apply set_coe.ext, apply smul_lie, }, }
 
+@[simp, norm_cast] lemma coe_zero : ((0 : N) : M) = (0 : M) := rfl
+
+@[simp, norm_cast] lemma coe_add (m m' : N) : (↑(m + m') : M) = (m : M) + (m' : M) := rfl
+
+@[simp, norm_cast] lemma coe_neg (m : N) : (↑(-m) : M) = -(m : M) := rfl
+
+@[simp, norm_cast] lemma coe_sub (m m' : N) : (↑(m - m') : M) = (m : M) - (m' : M) := rfl
+
+@[simp, norm_cast] lemma coe_smul (t : R) (m : N) : (↑(t • m) : M) = t • (m : M) := rfl
+
+@[simp, norm_cast] lemma coe_bracket (x : L) (m : N) : (↑⁅x, m⁆ : M) = ⁅x, ↑m⁆ := rfl
+
 end lie_submodule
 
 section lie_ideal
@@ -155,7 +167,21 @@ namespace lie_subalgebra
 
 variables {L}
 
-lemma exists_lie_ideal_coe_eq_iff (K : lie_subalgebra R L):
+/-- Given a Lie subalgebra `K ⊆ L`, if we view `L` as a `K`-module by restriction, it contains
+a distinguished Lie submodule for the action of `K`, namely `K` itself. -/
+def to_lie_submodule (K : lie_subalgebra R L) : lie_submodule R K L :=
+{ lie_mem := λ x y hy, K.lie_mem x.property hy,
+  .. (K : submodule R L) }
+
+@[simp] lemma coe_to_lie_submodule (K : lie_subalgebra R L) :
+  (K.to_lie_submodule : submodule R L) = K :=
+rfl
+
+@[simp] lemma mem_to_lie_submodule {K : lie_subalgebra R L} (x : L) :
+  x ∈ K.to_lie_submodule ↔ x ∈ K :=
+iff.rfl
+
+lemma exists_lie_ideal_coe_eq_iff (K : lie_subalgebra R L) :
   (∃ (I : lie_ideal R L), ↑I = K) ↔ ∀ (x y : L), y ∈ K → ⁅x, y⁆ ∈ K :=
 begin
   simp only [← coe_to_submodule_eq_iff, lie_ideal.coe_to_lie_subalgebra_to_submodule,

--- a/src/algebra/lie/weights.lean
+++ b/src/algebra/lie/weights.lean
@@ -67,6 +67,8 @@ lemma mem_pre_weight_space (χ : L → R) (m : M) :
   m ∈ pre_weight_space M χ ↔ ∀ x, ∃ (k : ℕ), ((to_endomorphism R L M x - (χ x) • 1)^k) m = 0 :=
 by simp [pre_weight_space, -linear_map.pow_apply]
 
+variables (L)
+
 /-- See also `bourbaki1975b` Chapter VII §1.1, Proposition 2 (ii). -/
 protected lemma weight_vector_multiplication (M₁ : Type w₁) (M₂ : Type w₂) (M₃ : Type w₃)
   [add_comm_group M₁] [module R M₁] [lie_ring_module L M₁] [lie_module R L M₁]
@@ -153,13 +155,13 @@ begin
   { rw [linear_map.mul_apply, linear_map.pow_map_zero_of_le hj hf₂, linear_map.map_zero], },
 end
 
-variables {M}
+variables {L M}
 
 lemma lie_mem_pre_weight_space_of_mem_pre_weight_space {χ₁ χ₂ : L → R} {x : L} {m : M}
   (hx : x ∈ pre_weight_space L χ₁) (hm : m ∈ pre_weight_space M χ₂) :
   ⁅x, m⁆ ∈ pre_weight_space M (χ₁ + χ₂) :=
 begin
-  apply lie_module.weight_vector_multiplication L M M (to_module_hom R L M) χ₁ χ₂,
+  apply lie_module.weight_vector_multiplication L L M M (to_module_hom R L M) χ₁ χ₂,
   simp only [lie_module_hom.coe_to_linear_map, function.comp_app, linear_map.coe_comp,
     tensor_product.map_incl, linear_map.mem_range],
   use [⟨x, hx⟩ ⊗ₜ ⟨m, hm⟩],
@@ -273,13 +275,13 @@ variables {H M}
 lemma lie_mem_weight_space_of_mem_weight_space {χ₁ χ₂ : H → R} {x : L} {m : M}
   (hx : x ∈ root_space H χ₁) (hm : m ∈ weight_space M χ₂) : ⁅x, m⁆ ∈ weight_space M (χ₁ + χ₂) :=
 begin
-  apply lie_module.weight_vector_multiplication L M M
-    (H.restrict_lie_module_hom (to_module_hom R L M)) χ₁ χ₂,
+  apply lie_module.weight_vector_multiplication
+    H L M M ((to_module_hom R L M).restrict_lie H) χ₁ χ₂,
   simp only [lie_module_hom.coe_to_linear_map, function.comp_app, linear_map.coe_comp,
     tensor_product.map_incl, linear_map.mem_range],
   use [⟨x, hx⟩ ⊗ₜ ⟨m, hm⟩],
   simp only [submodule.subtype_apply, to_module_hom_apply, submodule.coe_mk,
-    lie_subalgebra.coe_restrict_lie_module_hom, tensor_product.map_tmul],
+    lie_module_hom.coe_restrict_lie, tensor_product.map_tmul],
 end
 
 variables (R L H M)

--- a/src/algebra/lie/weights.lean
+++ b/src/algebra/lie/weights.lean
@@ -306,8 +306,8 @@ lift_lie R H (root_space H χ₁) (weight_space M χ₂) (weight_space M (χ₁ 
     lie_subalgebra.coe_bracket_of_module, lie_lie], }
 
 @[simp] lemma coe_root_space_weight_space_product_tmul
-  (μ χ : H → R) (x : root_space H μ) (m : weight_space M χ) :
-  (root_space_weight_space_product R L H M μ χ (x ⊗ₜ m) : M) = ⁅(x : L), (m : M)⁆ :=
+  (χ₁ χ₂ : H → R) (x : root_space H χ₁) (m : weight_space M χ₂) :
+  (root_space_weight_space_product R L H M χ₁ χ₂ (x ⊗ₜ m) : M) = ⁅(x : L), (m : M)⁆ :=
 by simp only [root_space_weight_space_product, lift_apply, lie_module_hom.coe_to_linear_map,
   coe_lift_lie_eq_lift_coe, submodule.coe_mk, linear_map.coe_mk, lie_module_hom.coe_mk]
 

--- a/src/algebra/lie/weights.lean
+++ b/src/algebra/lie/weights.lean
@@ -30,6 +30,8 @@ Basic definitions and properties of the above ideas are provided in this file.
   * `lie_module.is_weight`
   * `lie_algebra.root_space`
   * `lie_algebra.is_root`
+  * `lie_algebra.root_space_weight_space_product`
+  * `lie_algebra.root_space_product`
 
 ## References
 
@@ -287,7 +289,7 @@ end
 variables (R L H M)
 
 /-- Given a nilpotent Lie subalgebra `H ⊆ L` together with `χ₁ χ₂ : H → R`, there is a natural
-`R`-linear product of root vectors and weight vectors, compatible with the actions of `H`. -/
+`R`-bilinear product of root vectors and weight vectors, compatible with the actions of `H`. -/
 def root_space_weight_space_product (χ₁ χ₂ : H → R) :
   (root_space H χ₁) ⊗[R] (weight_space M χ₂) →ₗ⁅R,H⁆ weight_space M (χ₁ + χ₂) :=
 lift_lie R H (root_space H χ₁) (weight_space M χ₂) (weight_space M (χ₁ + χ₂))
@@ -314,7 +316,7 @@ by simp only [root_space_weight_space_product, lift_apply, lie_module_hom.coe_to
   coe_lift_lie_eq_lift_coe, submodule.coe_mk, linear_map.coe_mk, lie_module_hom.coe_mk]
 
 /-- Given a nilpotent Lie subalgebra `H ⊆ L` together with `χ₁ χ₂ : H → R`, there is a natural
-`R`-linear product of root vectors, compatible with the actions of `H`. -/
+`R`-bilinear product of root vectors, compatible with the actions of `H`. -/
 def root_space_product (χ₁ χ₂ : H → R) :
   (root_space H χ₁) ⊗[R] (root_space H χ₂) →ₗ⁅R,H⁆ root_space H (χ₁ + χ₂) :=
 root_space_weight_space_product R L H L χ₁ χ₂


### PR DESCRIPTION
Also some related results, most notably that the zero root space is a subalgebra.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
