### PR TITLE
[Merged by Bors] - fix(tactic/lift): elaborate the type better

### DIFF
--- a/src/tactic/lift.lean
+++ b/src/tactic/lift.lean
@@ -15,14 +15,13 @@ under a specified condition.
 lift, tactic
 -/
 
-universe variables u v w
-
 /-- A class specifying that you can lift elements from `α` to `β` assuming `cond` is true.
   Used by the tactic `lift`. -/
-class can_lift (α : Type u) (β : Type v) : Type (max u v) :=
+class can_lift (α β : Sort*) :=
 (coe : β → α)
 (cond : α → Prop)
 (prf : ∀(x : α), cond x → ∃(y : β), coe y = x)
+
 
 open tactic
 
@@ -45,7 +44,7 @@ instance : can_lift ℤ ℕ :=
 ⟨coe, λ n, 0 ≤ n, λ n hn, ⟨n.nat_abs, int.nat_abs_of_nonneg hn⟩⟩
 
 /-- Enable automatic handling of pi types in `can_lift`. -/
-instance pi.can_lift (ι : Type u) (α : Π i : ι, Type v) (β : Π i : ι, Type w)
+instance pi.can_lift (ι : Type*) (α : Π i : ι, Type*) (β : Π i : ι, Type*)
   [Π i : ι, can_lift (α i) (β i)] :
   can_lift (Π i : ι, α i) (Π i : ι, β i) :=
 { coe := λ f i, can_lift.coe (f i),
@@ -53,7 +52,7 @@ instance pi.can_lift (ι : Type u) (α : Π i : ι, Type v) (β : Π i : ι, Typ
   prf := λ f hf, ⟨λ i, classical.some (can_lift.prf (f i) (hf i)), funext $ λ i,
     classical.some_spec (can_lift.prf (f i) (hf i))⟩ }
 
-instance pi_subtype.can_lift (ι : Type u) (α : Π i : ι, Type v) [ne : Π i, nonempty (α i)]
+instance pi_subtype.can_lift (ι : Type*) (α : Π i : ι, Type*) [ne : Π i, nonempty (α i)]
   (p : ι → Prop) :
   can_lift (Π i : subtype p, α i) (Π i, α i) :=
 { coe := λ f i, f i,
@@ -66,7 +65,7 @@ instance pi_subtype.can_lift (ι : Type u) (α : Π i : ι, Type v) [ne : Π i, 
       exact dif_pos hi
     end }
 
-instance pi_subtype.can_lift' (ι : Type u) (α : Type v) [ne : nonempty α] (p : ι → Prop) :
+instance pi_subtype.can_lift' (ι : Type*) (α : Type*) [ne : nonempty α] (p : ι → Prop) :
   can_lift (subtype p → α) (ι → α) :=
 pi_subtype.can_lift ι (λ _, α) p
 
@@ -108,7 +107,7 @@ do
     fail "lift tactic failed. Tactic is only applicable when the target is a proposition.",
   e ← i_to_expr p,
   old_tp ← infer_type e,
-  new_tp ← i_to_expr ``(%%t : Type*),
+  new_tp ← i_to_expr ``(%%t : Sort*),
   inst_type ← mk_app ``can_lift [old_tp, new_tp],
   inst ← mk_instance inst_type <|>
     pformat!"Failed to find a lift from {old_tp} to {new_tp}. Provide an instance of\n  {inst_type}"

--- a/src/tactic/lift.lean
+++ b/src/tactic/lift.lean
@@ -108,7 +108,7 @@ do
     fail "lift tactic failed. Tactic is only applicable when the target is a proposition.",
   e ← i_to_expr p,
   old_tp ← infer_type e,
-  new_tp ← i_to_expr t,
+  new_tp ← i_to_expr ``(%%t : Type*),
   inst_type ← mk_app ``can_lift [old_tp, new_tp],
   inst ← mk_instance inst_type <|>
     pformat!"Failed to find a lift from {old_tp} to {new_tp}. Provide an instance of\n  {inst_type}"

--- a/test/lift.lean
+++ b/test/lift.lean
@@ -1,0 +1,19 @@
+import tactic.lift
+import data.set.basic
+
+instance can_lift_subtype (R : Type*) (P : R → Prop) : can_lift R {x // P x} :=
+{ coe := coe,
+  cond := λ x, P x,
+  prf := λ x hx, ⟨⟨x, hx⟩, rfl⟩ }
+
+instance can_lift_set (R : Type*) (s : set R) : can_lift R s :=
+{ coe := coe,
+  cond := λ x, x ∈ s,
+  prf := λ x hx, ⟨⟨x, hx⟩, rfl⟩ }
+
+example {R : Type*} {P : R → Prop} (x : R) (hx : P x) : true :=
+by { lift x to {x // P x} using hx with y, trivial }
+
+/-! Test that `lift` elaborates `s` as a type, not as a set. -/
+example {R : Type*} {s : set R} (x : R) (hx : x ∈ s) : true :=
+by { lift x to s using hx with y, trivial }


### PR DESCRIPTION
* When writing `lift x to t` it will now elaborating `t` using that `t` must be a sort (inserting a coercion if needed).
* Generalize `Type*` to `Sort*` in the tactic

---
Reported in https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Proving.20that.20a.20variable.20is.20of.20a.20given.20type

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
