### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/exp_log): strengthen statement of `continuous_log'`

### DIFF
--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -519,8 +519,11 @@ begin
   exact exp_order_iso.symm.continuous.comp (continuous_subtype_mk _ continuous_subtype_coe.norm)
 end
 
-@[continuity] lemma continuous_log' : continuous (λ x : {x : ℝ // x ≠ 0}, log x) :=
+@[continuity] lemma continuous_log : continuous (λ x : {x : ℝ // x ≠ 0}, log x) :=
 continuous_on_iff_continuous_restrict.1 $ continuous_on_log.mono $ λ x hx, hx
+
+@[continuity] lemma continuous_log' : continuous (λ x : {x : ℝ // 0 < x}, log x) :=
+continuous_on_iff_continuous_restrict.1 $ continuous_on_log.mono $ λ x hx, ne_of_gt hx
 
 lemma continuous_at_log (hx : x ≠ 0) : continuous_at log x :=
 (continuous_on_log x hx).continuous_at $ mem_nhds_sets is_open_compl_singleton hx

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -519,8 +519,8 @@ begin
   exact exp_order_iso.symm.continuous.comp (continuous_subtype_mk _ continuous_subtype_coe.norm)
 end
 
-@[continuity] lemma continuous_log' : continuous (λ x : {x : ℝ // 0 < x}, log x) :=
-continuous_on_iff_continuous_restrict.1 $ continuous_on_log.mono $ λ x hx, ne_of_gt hx
+@[continuity] lemma continuous_log' : continuous (λ x : {x : ℝ // x ≠ 0}, log x) :=
+continuous_on_iff_continuous_restrict.1 $ continuous_on_log.mono $ λ x hx, hx
 
 lemma continuous_at_log (hx : x ≠ 0) : continuous_at log x :=
 (continuous_on_log x hx).continuous_at $ mem_nhds_sets is_open_compl_singleton hx


### PR DESCRIPTION
The proof of `continuous (λ x : {x : ℝ // 0 < x}, log x)` also works for `continuous (λ x : {x : ℝ // x ≠ 0}, log x)`.

I keep the preexisting lemma as well since it is used in a number of places and seems generally useful.
