### PR TITLE
[Merged by Bors] - feat(set_theory/game): add mul_one and mul_assoc for pgames

### DIFF
--- a/src/set_theory/game.lean
+++ b/src/set_theory/game.lean
@@ -268,6 +268,8 @@ by {cases x, cases y, refl}
 theorem quot_mul_comm : Π (x y : pgame.{u}), ⟦x * y⟧ = ⟦y * x⟧
 | (mk xl xr xL xR) (mk yl yr yL yR) :=
 begin
+  let x := mk xl xr xL xR,
+  let y := mk yl yr yL yR,
   refine quot_eq_of_mk_quot_eq _ _ _ _,
   apply equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _),
   calc
@@ -328,6 +330,8 @@ theorem zero_mul_equiv (x : pgame) : 0 * x ≈ 0 :=
 @[simp] theorem quot_neg_mul : Π (x y : pgame), ⟦-x * y⟧ = -⟦x * y⟧
 | (mk xl xr xL xR) (mk yl yr yL yR) :=
 begin
+  let x := mk xl xr xL xR,
+  let y := mk yl yr yL yR,
   refine quot_eq_of_mk_quot_eq _ _ _ _,
   { fsplit; rintro (⟨_, _⟩ | ⟨_, _⟩);
     solve_by_elim [sum.inl, sum.inr, prod.mk] { max_depth := 4 } },
@@ -368,6 +372,9 @@ by rw [quot_mul_comm, quot_neg_mul, quot_mul_comm]
 @[simp] theorem quot_left_distrib : Π (x y z : pgame), ⟦x * (y + z)⟧ = ⟦x * y⟧ + ⟦x * z⟧
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) :=
 begin
+  let x := mk xl xr xL xR,
+  let y := mk yl yr yL yR,
+  let z := mk zl zr zL zR,
   refine quot_eq_of_mk_quot_eq _ _ _ _,
   { fsplit,
     { rintro (⟨_, _ | _⟩ | ⟨_, _ | _⟩);
@@ -432,6 +439,7 @@ by { change ⟦(y + -z) * x⟧ = ⟦y * x⟧ + -⟦z * x⟧, rw [quot_right_dist
 @[simp] theorem quot_mul_one : Π (x : pgame), ⟦x * 1⟧ = ⟦x⟧
 | (mk xl xr xL xR) :=
 begin
+  let x := mk xl xr xL xR,
   refine quot_eq_of_mk_quot_eq _ _ _ _,
   { fsplit,
      { rintro (⟨_, ⟨ ⟩⟩ | ⟨_, ⟨ ⟩⟩), assumption },
@@ -463,6 +471,9 @@ theorem one_mul_equiv (x : pgame) : 1 * x ≈ x := quotient.exact $ quot_one_mul
 theorem quot_mul_assoc : Π (x y z : pgame), ⟦x * y * z⟧ = ⟦x * (y * z)⟧
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) :=
 begin
+  let x := mk xl xr xL xR,
+  let y := mk yl yr yL yR,
+  let z := mk zl zr zL zR,
   refine quot_eq_of_mk_quot_eq _ _ _ _,
   { fsplit,
     { rintro (⟨⟨_, _⟩ | ⟨_, _⟩, _⟩ | ⟨⟨_, _⟩ | ⟨_, _⟩, _⟩);

--- a/src/set_theory/game.lean
+++ b/src/set_theory/game.lean
@@ -423,7 +423,7 @@ using_well_founded { dec_tac := pgame_wf_tac }
 theorem left_distrib_equiv (x y z : pgame) : x * (y + z) ≈ x * y + x * z :=
 quotient.exact $ quot_left_distrib _ _ _
 
-@[simp] theorem left_distrib_sub (x y z : pgame) : ⟦x * (y - z)⟧ = ⟦x * y⟧ - ⟦x * z⟧ :=
+@[simp] theorem quot_left_distrib_sub (x y z : pgame) : ⟦x * (y - z)⟧ = ⟦x * y⟧ - ⟦x * z⟧ :=
 by { change  ⟦x * (y + -z)⟧ = ⟦x * y⟧ + -⟦x * z⟧, rw [quot_left_distrib, quot_mul_neg] }
 
 @[simp] theorem quot_right_distrib (x y z : pgame) : ⟦(x + y) * z⟧ = ⟦x * z⟧ + ⟦y * z⟧ :=
@@ -433,7 +433,7 @@ by simp only [quot_mul_comm, quot_left_distrib]
 theorem right_distrib_equiv (x y z : pgame) : (x + y) * z ≈ x * z + y * z :=
 quotient.exact $ quot_right_distrib _ _ _
 
-@[simp] theorem right_distrib_sub (x y z : pgame) : ⟦(y - z) * x⟧ = ⟦y * x⟧ - ⟦z * x⟧ :=
+@[simp] theorem quot_right_distrib_sub (x y z : pgame) : ⟦(y - z) * x⟧ = ⟦y * x⟧ - ⟦z * x⟧ :=
 by { change ⟦(y + -z) * x⟧ = ⟦y * x⟧ + -⟦z * x⟧, rw [quot_right_distrib, quot_neg_mul] }
 
 @[simp] theorem quot_mul_one : Π (x : pgame), ⟦x * 1⟧ = ⟦x⟧

--- a/src/set_theory/game.lean
+++ b/src/set_theory/game.lean
@@ -392,29 +392,29 @@ begin
     { rintro (⟨⟨_, _⟩ | ⟨_, _⟩⟩ | ⟨_, _⟩ | ⟨_, _⟩); refl } },
     { rintro (⟨i, j | k⟩ | ⟨i, j | k⟩),
       { change ⟦xL i * (y + z) + x * (yL j + z) - xL i * (yL j + z)⟧
-                = ⟦xL i * y + x * yL j - xL i * yL j + x * z⟧,
+               = ⟦xL i * y + x * yL j - xL i * yL j + x * z⟧,
         simp [quot_left_distrib], abel },
       { change ⟦xL i * (y + z) + x * (y + zL k) - xL i * (y + zL k)⟧
-              = ⟦x * y + (xL i * z + x * zL k - xL i * zL k)⟧,
+               = ⟦x * y + (xL i * z + x * zL k - xL i * zL k)⟧,
         simp [quot_left_distrib], abel },
       { change ⟦xR i * (y + z) + x * (yR j + z) - xR i * (yR j + z)⟧
-              = ⟦xR i * y + x * yR j - xR i * yR j + x * z⟧,
+               = ⟦xR i * y + x * yR j - xR i * yR j + x * z⟧,
         simp [quot_left_distrib], abel },
       { change ⟦xR i * (y + z) + x * (y + zR k) - xR i * (y + zR k)⟧
-              = ⟦x * y + (xR i * z + x * zR k - xR i * zR k)⟧,
+               = ⟦x * y + (xR i * z + x * zR k - xR i * zR k)⟧,
         simp [quot_left_distrib], abel } },
     { rintro (⟨⟨i, j⟩ | ⟨i, j⟩⟩ | ⟨i, k⟩ | ⟨i, k⟩),
       { change ⟦xL i * (y + z) + x * (yR j + z) - xL i * (yR j + z)⟧
-              = ⟦xL i * y + x * yR j - xL i * yR j + x * z⟧,
+               = ⟦xL i * y + x * yR j - xL i * yR j + x * z⟧,
         simp [quot_left_distrib], abel },
       { change ⟦xR i * (y + z) + x * (yL j + z) - xR i * (yL j + z)⟧
-              = ⟦xR i * y + x * yL j - xR i * yL j + x * z⟧,
+               = ⟦xR i * y + x * yL j - xR i * yL j + x * z⟧,
         simp [quot_left_distrib], abel },
       { change ⟦xL i * (y + z) + x * (y + zR k) - xL i * (y + zR k)⟧
-              = ⟦x * y + (xL i * z + x * zR k - xL i * zR k)⟧,
+               = ⟦x * y + (xL i * z + x * zR k - xL i * zR k)⟧,
         simp [quot_left_distrib], abel },
       { change ⟦xR i * (y + z) + x * (y + zL k) - xR i * (y + zL k)⟧
-              = ⟦x * y + (xR i * z + x * zL k - xR i * zL k)⟧,
+               = ⟦x * y + (xR i * z + x * zL k - xR i * zL k)⟧,
         simp [quot_left_distrib], abel } }
 end
 using_well_founded { dec_tac := pgame_wf_tac }
@@ -490,55 +490,47 @@ begin
     { rintro (⟨⟨_, _⟩ | ⟨_, _⟩, _⟩ | ⟨⟨_, _⟩ | ⟨_, _⟩,_⟩); refl },
     { rintro (⟨_, ⟨_, _⟩ | ⟨_, _⟩⟩ | ⟨_, ⟨_, _⟩ | ⟨_, _⟩⟩); refl } },
   { rintro (⟨⟨i, j⟩ | ⟨i, j⟩, k⟩ | ⟨⟨i, j⟩ | ⟨i, j⟩, k⟩),
-    { change
-        ⟦(xL i * y + x * yL j - xL i * yL j) * z + (x * y) * zL k
-          - (xL i * y + x * yL j - xL i * yL j) * zL k⟧
-        = ⟦xL i * (y * z) + x * (yL j * z + y * zL k - yL j * zL k)
-          - xL i * (yL j * z + y * zL k - yL j * zL k)⟧,
-        simp [quot_mul_assoc], abel },
-    { change
-        ⟦(xR i * y + x * yR j - xR i * yR j) * z + (x * y) * zL k
-          - (xR i * y + x * yR j - xR i * yR j) * zL k⟧
-        = ⟦xR i * (y * z) + x * (yR j * z + y * zL k - yR j * zL k)
-          - xR i * (yR j * z + y * zL k - yR j * zL k)⟧,
-        simp [quot_mul_assoc], abel },
-    { change
-        ⟦(xL i * y + x * yR j - xL i * yR j) * z + (x * y) * zR k
-          - (xL i * y + x * yR j - xL i * yR j) * zR k⟧
-        = ⟦xL i * (y * z) + x * (yR j * z + y * zR k - yR j * zR k)
-          - xL i * (yR j * z + y * zR k - yR j * zR k)⟧,
-        simp [quot_mul_assoc], abel },
-    { change
-        ⟦(xR i * y + x * yL j - xR i * yL j) * z + (x * y) * zR k
-          - (xR i * y + x * yL j - xR i * yL j) * zR k⟧
-        = ⟦xR i * (y * z) + x * (yL j * z + y * zR k - yL j * zR k)
-          - xR i * (yL j * z + y * zR k - yL j * zR k)⟧,
-        simp [quot_mul_assoc], abel } },
+    { change ⟦(xL i * y + x * yL j - xL i * yL j) * z + (x * y) * zL k
+               - (xL i * y + x * yL j - xL i * yL j) * zL k⟧
+             = ⟦xL i * (y * z) + x * (yL j * z + y * zL k - yL j * zL k)
+               - xL i * (yL j * z + y * zL k - yL j * zL k)⟧,
+      simp [quot_mul_assoc], abel },
+    { change ⟦(xR i * y + x * yR j - xR i * yR j) * z + (x * y) * zL k
+               - (xR i * y + x * yR j - xR i * yR j) * zL k⟧
+             = ⟦xR i * (y * z) + x * (yR j * z + y * zL k - yR j * zL k)
+               - xR i * (yR j * z + y * zL k - yR j * zL k)⟧,
+      simp [quot_mul_assoc], abel },
+    { change ⟦(xL i * y + x * yR j - xL i * yR j) * z + (x * y) * zR k
+               - (xL i * y + x * yR j - xL i * yR j) * zR k⟧
+             = ⟦xL i * (y * z) + x * (yR j * z + y * zR k - yR j * zR k)
+               - xL i * (yR j * z + y * zR k - yR j * zR k)⟧,
+      simp [quot_mul_assoc], abel },
+    { change ⟦(xR i * y + x * yL j - xR i * yL j) * z + (x * y) * zR k
+               - (xR i * y + x * yL j - xR i * yL j) * zR k⟧
+             = ⟦xR i * (y * z) + x * (yL j * z + y * zR k - yL j * zR k)
+               - xR i * (yL j * z + y * zR k - yL j * zR k)⟧,
+      simp [quot_mul_assoc], abel } },
   { rintro (⟨i, ⟨j, k⟩ | ⟨j, k⟩⟩ | ⟨i, ⟨j, k⟩ | ⟨j, k⟩⟩),
-    { change
-        ⟦(xL i * y + x * yL j - xL i * yL j) * z + (x * y) * zR k
-          - (xL i * y + x * yL j - xL i * yL j) * zR k⟧
-        = ⟦xL i * (y * z) + x * (yL j * z + y * zR k - yL j * zR k)
-          - xL i * (yL j * z + y * zR k - yL j * zR k)⟧,
-        simp [quot_mul_assoc], abel },
-    { change
-        ⟦(xL i * y + x * yR j - xL i * yR j) * z + (x * y) * zL k
-          - (xL i * y + x * yR j - xL i * yR j) * zL k⟧
-        = ⟦xL i * (y * z) + x * (yR j * z + y * zL k - yR j * zL k)
-          - xL i * (yR j * z + y * zL k - yR j * zL k)⟧,
-        simp [quot_mul_assoc], abel },
-    { change
-        ⟦(xR i * y + x * yL j - xR i * yL j) * z + (x * y) * zL k
-          - (xR i * y + x * yL j - xR i * yL j) * zL k⟧
-        = ⟦xR i * (y * z) + x * (yL j * z + y * zL k - yL j * zL k)
-          - xR i * (yL j * z + y * zL k - yL j * zL k)⟧,
-        simp [quot_mul_assoc], abel },
-    { change
-        ⟦(xR i * y + x * yR j - xR i * yR j) * z + (x * y) * zR k
-          - (xR i * y + x * yR j - xR i * yR j) * zR k⟧
-        = ⟦xR i * (y * z) + x * (yR j * z + y * zR k - yR j * zR k)
-          - xR i * (yR j * z + y * zR k - yR j * zR k)⟧,
-        simp [quot_mul_assoc], abel } }
+    { change ⟦(xL i * y + x * yL j - xL i * yL j) * z + (x * y) * zR k
+               - (xL i * y + x * yL j - xL i * yL j) * zR k⟧
+             = ⟦xL i * (y * z) + x * (yL j * z + y * zR k - yL j * zR k)
+               - xL i * (yL j * z + y * zR k - yL j * zR k)⟧,
+      simp [quot_mul_assoc], abel },
+    { change ⟦(xL i * y + x * yR j - xL i * yR j) * z + (x * y) * zL k
+               - (xL i * y + x * yR j - xL i * yR j) * zL k⟧
+             = ⟦xL i * (y * z) + x * (yR j * z + y * zL k - yR j * zL k)
+               - xL i * (yR j * z + y * zL k - yR j * zL k)⟧,
+      simp [quot_mul_assoc], abel },
+    { change ⟦(xR i * y + x * yL j - xR i * yL j) * z + (x * y) * zL k
+               - (xR i * y + x * yL j - xR i * yL j) * zL k⟧
+             = ⟦xR i * (y * z) + x * (yL j * z + y * zL k - yL j * zL k)
+               - xR i * (yL j * z + y * zL k - yL j * zL k)⟧,
+      simp [quot_mul_assoc], abel },
+    { change ⟦(xR i * y + x * yR j - xR i * yR j) * z + (x * y) * zR k
+               - (xR i * y + x * yR j - xR i * yR j) * zR k⟧
+             = ⟦xR i * (y * z) + x * (yR j * z + y * zR k - yR j * zR k)
+               - xR i * (yR j * z + y * zR k - yR j * zR k)⟧,
+      simp [quot_mul_assoc], abel } }
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 

--- a/src/set_theory/game.lean
+++ b/src/set_theory/game.lean
@@ -494,50 +494,50 @@ begin
         ⟦(xL i * y + x * yL j - xL i * yL j) * z + (x * y) * zL k
           - (xL i * y + x * yL j - xL i * yL j) * zL k⟧
         = ⟦xL i * (y * z) + x * (yL j * z + y * zL k - yL j * zL k)
-                 - xL i * (yL j * z + y * zL k - yL j * zL k)⟧,
+          - xL i * (yL j * z + y * zL k - yL j * zL k)⟧,
         simp [quot_mul_assoc], abel },
     { change
         ⟦(xR i * y + x * yR j - xR i * yR j) * z + (x * y) * zL k
           - (xR i * y + x * yR j - xR i * yR j) * zL k⟧
         = ⟦xR i * (y * z) + x * (yR j * z + y * zL k - yR j * zL k)
-                 - xR i * (yR j * z + y * zL k - yR j * zL k)⟧,
+          - xR i * (yR j * z + y * zL k - yR j * zL k)⟧,
         simp [quot_mul_assoc], abel },
     { change
         ⟦(xL i * y + x * yR j - xL i * yR j) * z + (x * y) * zR k
           - (xL i * y + x * yR j - xL i * yR j) * zR k⟧
         = ⟦xL i * (y * z) + x * (yR j * z + y * zR k - yR j * zR k)
-                 - xL i * (yR j * z + y * zR k - yR j * zR k)⟧,
+          - xL i * (yR j * z + y * zR k - yR j * zR k)⟧,
         simp [quot_mul_assoc], abel },
     { change
         ⟦(xR i * y + x * yL j - xR i * yL j) * z + (x * y) * zR k
           - (xR i * y + x * yL j - xR i * yL j) * zR k⟧
         = ⟦xR i * (y * z) + x * (yL j * z + y * zR k - yL j * zR k)
-                 - xR i * (yL j * z + y * zR k - yL j * zR k)⟧,
+          - xR i * (yL j * z + y * zR k - yL j * zR k)⟧,
         simp [quot_mul_assoc], abel } },
   { rintro (⟨i, ⟨j, k⟩ | ⟨j, k⟩⟩ | ⟨i, ⟨j, k⟩ | ⟨j, k⟩⟩),
     { change
         ⟦(xL i * y + x * yL j - xL i * yL j) * z + (x * y) * zR k
           - (xL i * y + x * yL j - xL i * yL j) * zR k⟧
         = ⟦xL i * (y * z) + x * (yL j * z + y * zR k - yL j * zR k)
-                 - xL i * (yL j * z + y * zR k - yL j * zR k)⟧,
+          - xL i * (yL j * z + y * zR k - yL j * zR k)⟧,
         simp [quot_mul_assoc], abel },
     { change
         ⟦(xL i * y + x * yR j - xL i * yR j) * z + (x * y) * zL k
           - (xL i * y + x * yR j - xL i * yR j) * zL k⟧
         = ⟦xL i * (y * z) + x * (yR j * z + y * zL k - yR j * zL k)
-                 - xL i * (yR j * z + y * zL k - yR j * zL k)⟧,
+          - xL i * (yR j * z + y * zL k - yR j * zL k)⟧,
         simp [quot_mul_assoc], abel },
     { change
         ⟦(xR i * y + x * yL j - xR i * yL j) * z + (x * y) * zL k
           - (xR i * y + x * yL j - xR i * yL j) * zL k⟧
         = ⟦xR i * (y * z) + x * (yL j * z + y * zL k - yL j * zL k)
-                 - xR i * (yL j * z + y * zL k - yL j * zL k)⟧,
+          - xR i * (yL j * z + y * zL k - yL j * zL k)⟧,
         simp [quot_mul_assoc], abel },
     { change
         ⟦(xR i * y + x * yR j - xR i * yR j) * z + (x * y) * zR k
           - (xR i * y + x * yR j - xR i * yR j) * zR k⟧
         = ⟦xR i * (y * z) + x * (yR j * z + y * zR k - yR j * zR k)
-                 - xR i * (yR j * z + y * zR k - yR j * zR k)⟧,
+          - xR i * (yR j * z + y * zR k - yR j * zR k)⟧,
         simp [quot_mul_assoc], abel } }
 end
 using_well_founded { dec_tac := pgame_wf_tac }

--- a/src/set_theory/game.lean
+++ b/src/set_theory/game.lean
@@ -148,12 +148,6 @@ instance : add_comm_group game :=
 theorem add_le_add_left : ∀ (a b : game), a ≤ b → ∀ (c : game), c + a ≤ c + b :=
 begin rintro ⟨a⟩ ⟨b⟩ h ⟨c⟩, apply pgame.add_le_add_left h, end
 
-@[simp] lemma quot_neg (a : pgame) : ⟦-a⟧ = -⟦a⟧ := rfl
-
-@[simp] lemma quot_add (a b : pgame) : ⟦a + b⟧ = ⟦a⟧ + ⟦b⟧ := rfl
-
-@[simp] lemma quot_sub (a b : pgame) : ⟦a - b⟧ = ⟦a⟧ - ⟦b⟧ := rfl
-
 -- While it is very tempting to define a `partial_order` on games, and prove
 -- that games form an `ordered_add_comm_group`, it is a bit dangerous.
 
@@ -183,6 +177,11 @@ end game
 
 namespace pgame
 
+@[simp] lemma quot_neg (a : pgame) : ⟦-a⟧ = -⟦a⟧ := rfl
+
+@[simp] lemma quot_add (a b : pgame) : ⟦a + b⟧ = ⟦a⟧ + ⟦b⟧ := rfl
+
+@[simp] lemma quot_sub (a b : pgame) : ⟦a - b⟧ = ⟦a⟧ - ⟦b⟧ := rfl
 
 theorem quot_eq_of_mk_quot_eq {x y : pgame}
   (L : x.left_moves ≃ y.left_moves) (R : x.right_moves ≃ y.right_moves)
@@ -338,31 +337,19 @@ begin
   { fsplit; rintro (⟨_, _⟩ | ⟨_, _⟩);
     solve_by_elim [sum.inl, sum.inr, prod.mk] { max_depth := 4 } },
   { rintro (⟨i, j⟩ | ⟨i, j⟩),
-    { calc
-        ⟦-xR i * y + (-x) * yL j - (-xR i) * yL j⟧
-          = ⟦-xR i * y⟧ + ⟦(-x) * yL j⟧ - ⟦(-xR i) * yL j⟧ : by simp
-      ... = -⟦xR i * y⟧ + -⟦x * yL j⟧ - -⟦xR i * yL j⟧
-          : by rw [quot_neg_mul (xR i) y, quot_neg_mul x (yL j), quot_neg_mul (xR i) (yL j)]
-      ... = ⟦-(xR i * y + x * yL j - xR i * yL j)⟧ : by { simp, abel } },
-    { calc
-        ⟦-xL i * y + (-x) * yR j - (-xL i) * yR j⟧
-          = ⟦-xL i * y⟧ + ⟦(-x) * yR j⟧ - ⟦(-xL i) * yR j⟧ : by simp
-      ... = -⟦xL i * y⟧ + -⟦x * yR j⟧ - -⟦xL i * yR j⟧
-          : by rw [quot_neg_mul (xL i) y, quot_neg_mul x (yR j), quot_neg_mul (xL i) (yR j)]
-      ... = ⟦-(xL i * y + x * yR j - xL i * yR j)⟧ : by { simp, abel } } },
+    { change ⟦-xR i * y + (-x) * yL j - (-xR i) * yL j⟧ = ⟦-(xR i * y + x * yL j - xR i * yL j)⟧,
+      simp only [quot_add, quot_sub, quot_neg_mul],
+      simp, abel },
+    { change ⟦-xL i * y + (-x) * yR j - (-xL i) * yR j⟧ = ⟦-(xL i * y + x * yR j - xL i * yR j)⟧,
+      simp only [quot_add, quot_sub, quot_neg_mul],
+      simp, abel } },
   { rintro (⟨i, j⟩ | ⟨i, j⟩),
-    { calc
-        ⟦-xL i * y + (-x) * yL j - (-xL i) * yL j⟧
-          = ⟦-xL i * y⟧ + ⟦(-x) * yL j⟧ - ⟦(-xL i) * yL j⟧ : by simp
-      ... = -⟦xL i * y⟧ + -⟦x * yL j⟧ - -⟦xL i * yL j⟧
-          : by rw [quot_neg_mul (xL i) y, quot_neg_mul x (yL j), quot_neg_mul (xL i) (yL j)]
-      ... = ⟦-(xL i * y + x * yL j - xL i * yL j)⟧ : by { simp, abel } },
-    { calc
-        ⟦-xR i * y + (-x) * yR j - (-xR i) * yR j⟧
-          = ⟦-xR i * y⟧ + ⟦(-x) * yR j⟧ - ⟦(-xR i) * yR j⟧ : by simp
-      ... = -⟦xR i * y⟧ + -⟦x * yR j⟧ - -⟦xR i * yR j⟧
-          : by rw [quot_neg_mul (xR i) y, quot_neg_mul x (yR j), quot_neg_mul (xR i) (yR j)]
-      ... = ⟦-(xR i * y + x * yR j - xR i * yR j)⟧ : by { simp, abel } } },
+    { change ⟦-xL i * y + (-x) * yL j - (-xL i) * yL j⟧ = ⟦-(xL i * y + x * yL j - xL i * yL j)⟧,
+      simp only [quot_add, quot_sub, quot_neg_mul],
+      simp, abel },
+    { change ⟦-xR i * y + (-x) * yR j - (-xR i) * yR j⟧ = ⟦-(xR i * y + x * yR j - xR i * yR j)⟧,
+      simp only [quot_add, quot_sub, quot_neg_mul],
+      simp, abel } },
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 


### PR DESCRIPTION
and several `simp` lemmas. I also simplified some of the existing proofs using `rw` and `simp` and made them easier to read.

This is the final PR for multiplication of pgames (hopefully)!

Next step:  prove `numeric_mul` and define multiplication for `surreal`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
