### PR TITLE
[Merged by Bors] - feat(linear_algebra): a finite free module has a unique findim

### DIFF
--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -229,6 +229,16 @@ begin
   exact basis.card_le_card_of_linear_independent_aux (fintype.card ι) _ hv,
 end
 
+/-- If we have two bases on the same space, their indices are in bijection. -/
+noncomputable def basis.index_equiv
+  {R : Type*} [integral_domain R] [module R M]
+  {ι : Type*} [fintype ι] (b : basis ι R M)
+  {ι' : Type*} [fintype ι'] (b' : basis ι' R M) :
+  ι ≃ ι' :=
+(fintype.card_eq.mp (le_antisymm
+  (b'.card_le_card_of_linear_independent b.linear_independent)
+  (b.card_le_card_of_linear_independent b'.linear_independent))).some
+
 /-- If `N` is a submodule in a free, finitely generated module,
 do induction on adjoining a linear independent element to a submodule. -/
 def submodule.induction_on_rank [fintype ι] (b : basis ι R M) (P : submodule R M → Sort*)

--- a/src/linear_algebra/free_module.lean
+++ b/src/linear_algebra/free_module.lean
@@ -230,10 +230,8 @@ begin
 end
 
 /-- If we have two bases on the same space, their indices are in bijection. -/
-noncomputable def basis.index_equiv
-  {R : Type*} [integral_domain R] [module R M]
-  {ι : Type*} [fintype ι] (b : basis ι R M)
-  {ι' : Type*} [fintype ι'] (b' : basis ι' R M) :
+noncomputable def basis.index_equiv {R ι ι' : Type*} [integral_domain R] [module R M]
+  [fintype ι] [fintype ι'] (b : basis ι R M) (b' : basis ι' R M) :
   ι ≃ ι' :=
 (fintype.card_eq.mp (le_antisymm
   (b'.card_le_card_of_linear_independent b.linear_independent)


### PR DESCRIPTION
I needed this easy corollary, so I PR'd it, even though it should be generalizable once we have a better theory of e.g. Gaussian elimination. (I also tried to generalize `mk_eq_mk_of_basis`, but the current proof really requires the existence of multiplicative inverses for the coefficients.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
