### PR TITLE
[Merged by Bors] - feat(linear_algebra): the determinant of an endomorphism

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -35,7 +35,7 @@ Linear algebra:
   Multilinearity:
     multilinear map: 'multilinear_map'
     determinant of vectors: 'basis.det'
-    determinant of endomorphisms: ''
+    determinant of endomorphisms: 'linear_map.det'
     special linear group: ''
     orientation of a $\R$-valued vector space: ''
   Matrices:

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -113,6 +113,11 @@ by rw [← linear_map_to_matrix_mul_basis_to_matrix c b c,
 /-- The determinant of an endomorphism given a basis.
 
 See `linear_map.det` for a version that populates the basis non-computably.
+
+Although the `trunc (basis ι A M)` parameter makes it slightly more convenient to switch bases,
+there is no good way to generalize over universe parameters, so we can't fully state in `det_aux`'s
+type that it does not depend on the choice of basis. Instead you can use the `det_aux_def'` lemma,
+or avoid mentioning a basis at all using `linear_map.det`.
 -/
 def det_aux : trunc (basis ι A M) → (M →ₗ[A] M) →* A :=
 trunc.lift

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -128,6 +128,7 @@ lemma det_aux_def (b : basis ι A M) (f : M →ₗ[A] M) :
   linear_map.det_aux (trunc.mk b) f = matrix.det (linear_map.to_matrix b b f) :=
 rfl
 
+-- Discourage the elaborator from unfolding `det_aux` and producing a huge term.
 attribute [irreducible] linear_map.det_aux
 
 lemma det_aux_def' {ι' : Type*} [fintype ι'] [decidable_eq ι']
@@ -167,6 +168,7 @@ by { ext, unfold linear_map.det,
 
 end
 
+-- Discourage the elaborator from unfolding `det` and producing a huge term.
 attribute [irreducible] linear_map.det
 
 -- Auxiliary lemma, the `simp` normal form goes in the other direction

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -108,7 +108,7 @@ lemma det_to_matrix_eq_det_to_matrix [decidable_eq κ]
   det (linear_map.to_matrix b b f) = det (linear_map.to_matrix c c f) :=
 by rw [← linear_map_to_matrix_mul_basis_to_matrix c b c,
        ← basis_to_matrix_mul_linear_map_to_matrix b c b,
-       matrix.det_conjugate]; rw [basis.to_matrix_mul_to_matrix, basis.to_matrix_self]
+       matrix.det_conj]; rw [basis.to_matrix_mul_to_matrix, basis.to_matrix_self]
 
 /-- The determinant of an endomorphism given a basis.
 

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -172,7 +172,7 @@ attribute [irreducible] linear_map.det
 -- Auxiliary lemma, the `simp` normal form goes in the other direction
 -- (using `linear_map.det_to_matrix`)
 lemma det_eq_det_to_matrix_of_finite_set [decidable_eq M]
-  {s : set M} (b : basis s A M) (hs : fintype s) (f : M →ₗ[A] M) :
+  {s : set M} (b : basis s A M) [hs : fintype s] (f : M →ₗ[A] M) :
   f.det = matrix.det (linear_map.to_matrix b b f) :=
 have ∃ (s : set M) (b : basis s A M), s.finite,
 from ⟨s, b, ⟨hs⟩⟩,
@@ -182,8 +182,7 @@ by rw [linear_map.coe_det, dif_pos, det_aux_def' _ b]; assumption
   (b : basis ι A M) (f : M →ₗ[A] M) :
   matrix.det (to_matrix b b f) = f.det :=
 by { haveI := classical.dec_eq M,
-     rw [det_eq_det_to_matrix_of_finite_set b.reindex_range (set.fintype_range _),
-         det_to_matrix_eq_det_to_matrix b] }
+     rw [det_eq_det_to_matrix_of_finite_set b.reindex_range, det_to_matrix_eq_det_to_matrix b] }
 
 @[simp]
 lemma det_comp (f g : M →ₗ[A] M) : (f.comp g).det = f.det * g.det :=


### PR DESCRIPTION
 `linear_map.det` is the determinant of an endomorphism, which is defined independent of a basis. If there is no finite basis, the determinant is defined to be equal to `1`.

This approach is inspired by `linear_map.trace`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #7631
- [x] depends on: #7633

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
