### PR TITLE
[Merged by Bors] - feat(ring_theory/power_basis): the dimension of a power basis is positive

### DIFF
--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -114,6 +114,9 @@ by { rw [← pb.basis.total_repr 1, finsupp.total_apply, finsupp.sum_fintype],
        cases x_lt },
      { simp } }
 
+lemma dim_pos [nontrivial S] (pb : power_basis R S) : 0 < pb.dim :=
+nat.pos_of_ne_zero pb.dim_ne_zero
+
 lemma exists_eq_aeval [nontrivial S] (pb : power_basis R S) (y : S) :
   ∃ f : polynomial R, f.nat_degree < pb.dim ∧ y = aeval pb.gen f :=
 (mem_span_pow pb.dim_ne_zero).mp (by simpa using pb.basis.mem_span y)


### PR DESCRIPTION
We already have `pb.dim_ne_zero : pb.dim ≠ 0` (assuming nontriviality), but it's also useful to also have it in the form `0 < pb.dim`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
