### PR TITLE
[Merged by Bors] - feat(data/polynomial): the `d-1`th coefficient of `polynomial.map`

### DIFF
--- a/src/data/polynomial/degree/lemmas.lean
+++ b/src/data/polynomial/degree/lemmas.lean
@@ -148,8 +148,6 @@ lemma nat_degree_lt_coeff_mul (h : p.nat_degree + q.nat_degree < m + n) :
   (p * q).coeff (m + n) = 0 :=
 coeff_eq_zero_of_nat_degree_lt (nat_degree_mul_le.trans_lt h)
 
-
-
 variables [semiring S]
 
 lemma nat_degree_pos_of_eval₂_root {p : polynomial R} (hp : p ≠ 0) (f : R →+* S)
@@ -191,6 +189,14 @@ lemma leading_coeff_map' (p : polynomial R) :
 begin
   unfold leading_coeff,
   rw [coeff_map, nat_degree_map' hf p],
+end
+
+lemma next_coeff_map (p : polynomial R) :
+  (p.map f).next_coeff = f p.next_coeff :=
+begin
+  unfold next_coeff,
+  rw nat_degree_map' hf,
+  split_ifs; simp
 end
 
 end injective


### PR DESCRIPTION
We prove `polynomial.next_coeff_map` just like `polynomial.leading_coeff_map'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
