### PR TITLE
[Merged by Bors] - feat(ring_theory): the field trace resp. norm is the sum resp. product of the conjugates

### DIFF
--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -289,6 +289,12 @@ def adjoin_simple.gen : F⟮α⟯ := ⟨α, mem_adjoin_simple_self F α⟩
 
 @[simp] lemma adjoin_simple.algebra_map_gen : algebra_map F⟮α⟯ E (adjoin_simple.gen F α) = α := rfl
 
+@[simp] lemma adjoin_simple.is_integral_gen :
+  is_integral F (adjoin_simple.gen F α) ↔ is_integral F α :=
+by { conv_rhs { rw ← adjoin_simple.algebra_map_gen F α },
+     rw is_integral_algebra_map_iff (algebra_map F⟮α⟯ E).injective,
+     apply_instance }
+
 lemma adjoin_simple_adjoin_simple (β : E) : ↑F⟮α⟯⟮β⟯ = F⟮α, β⟯ :=
 adjoin_adjoin_left _ _ _
 

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -501,6 +501,10 @@ theorem mem_span_image_iff_total {s : set α} {x : M} :
   x ∈ span R (v '' s) ↔ ∃ l ∈ supported R R s, finsupp.total α M R v l = x :=
 by { rw span_image_eq_map_total, simp, }
 
+@[simp] lemma total_fin_zero (f : fin 0 → M) :
+  finsupp.total (fin 0) M R f = 0 :=
+by { ext i, apply fin_zero_elim i }
+
 variables (α) (M) (v)
 
 /-- `finsupp.total_on M v s` interprets `p : α →₀ R` as a linear combination of a

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -40,8 +40,7 @@ universes u v w
 variables {R S T : Type*} [integral_domain R] [integral_domain S] [integral_domain T]
 variables [algebra R S] [algebra R T]
 variables {K L F : Type*} [field K] [field L] [field F]
-variables [algebra K L] [algebra L F] [algebra K F] [is_scalar_tower K L F]
-variables [algebra K S] [algebra S F] [is_scalar_tower K S F]
+variables [algebra K L] [algebra L F] [algebra K F]
 variables {ι : Type w} [fintype ι]
 
 open finite_dimensional
@@ -100,7 +99,7 @@ end
 
 section eq_prod_roots
 
-lemma norm_gen_eq_sum_roots (pb : power_basis K S)
+lemma norm_gen_eq_sum_roots [algebra K S] (pb : power_basis K S)
   (hf : (minpoly K pb.gen).splits (algebra_map K F)) :
   algebra_map K F (norm K S pb.gen) =
     ((minpoly K pb.gen).map (algebra_map K F)).roots.prod :=

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -99,7 +99,7 @@ end
 
 section eq_prod_roots
 
-lemma norm_gen_eq_sum_roots [algebra K S] (pb : power_basis K S)
+lemma norm_gen_eq_prod_roots [algebra K S] (pb : power_basis K S)
   (hf : (minpoly K pb.gen).splits (algebra_map K F)) :
   algebra_map K F (norm K pb.gen) =
     ((minpoly K pb.gen).map (algebra_map K F)).roots.prod :=

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -101,7 +101,7 @@ section eq_prod_roots
 
 lemma norm_gen_eq_sum_roots [algebra K S] (pb : power_basis K S)
   (hf : (minpoly K pb.gen).splits (algebra_map K F)) :
-  algebra_map K F (norm K S pb.gen) =
+  algebra_map K F (norm K pb.gen) =
     ((minpoly K pb.gen).map (algebra_map K F)).roots.prod :=
 begin
   -- Write the LHS as the 0'th coefficient of `minpoly K pb.gen`

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -5,6 +5,7 @@ Authors: Anne Baanen
 -/
 
 import linear_algebra.bilinear_form
+import linear_algebra.char_poly.coeff
 import linear_algebra.trace
 import ring_theory.power_basis
 
@@ -123,5 +124,39 @@ lemma trace_form_to_matrix_power_basis (h : power_basis R S) :
 by { ext, rw [trace_form_to_matrix, pow_add, h.basis_eq_pow, h.basis_eq_pow] }
 
 end trace_form
+
+section eq_prod_roots
+
+open polynomial
+
+variables {F : Type*} [field F]
+variables [algebra K S] [algebra K F]
+
+lemma trace_gen_eq_sum_roots [nontrivial S] (pb : power_basis K S)
+  (hf : (minpoly K pb.gen).splits (algebra_map K F)) :
+  algebra_map K F (trace K S pb.gen) =
+    ((minpoly K pb.gen).map (algebra_map K F)).roots.sum :=
+begin
+  have d_pos : 0 < pb.dim := power_basis.dim_pos pb,
+  have d_pos' : 0 < (minpoly K pb.gen).nat_degree, { simpa },
+  haveI : nonempty (fin pb.dim) := ⟨⟨0, d_pos⟩⟩,
+  -- Write the LHS as the `d-1`'th coefficient of `minpoly K pb.gen`
+  rw [trace_eq_matrix_trace pb.basis, trace_eq_neg_char_poly_coeff, char_poly_left_mul_matrix,
+      ring_hom.map_neg, ← pb.nat_degree_minpoly, fintype.card_fin,
+      ← next_coeff_of_pos_nat_degree _ d_pos',
+      ← next_coeff_map (algebra_map K F).injective],
+  -- Rewrite `minpoly K pb.gen` as a product over the roots.
+  conv_lhs { rw eq_prod_roots_of_splits hf },
+  rw [monic.next_coeff_mul, next_coeff_C_eq_zero, zero_add, monic.next_coeff_multiset_prod],
+  -- And conclude both sides are the same.
+  simp_rw [next_coeff_X_sub_C, multiset.sum_map_neg, neg_neg],
+  -- Now we deal with the side conditions.
+  { intros, apply monic_X_sub_C },
+  { convert monic_one, simp [(minpoly.monic pb.is_integral_gen).leading_coeff] },
+  { apply monic_multiset_prod_of_monic,
+    intros, apply monic_X_sub_C },
+end
+
+end eq_prod_roots
 
 end algebra


### PR DESCRIPTION
More precise statement of the main result: the field trace (resp. norm) of `x` in `K(x) / K`, mapped to a field `F` that contains all the conjugate roots over `K` of `x`, is equal to the sum (resp. product) of all of these conjugate roots.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

 - [x] depends on: #7631
 - [x] depends on: #7632
 - [x] depends on: #7633 
 - [x] depends on: #7635 
 - [x] depends on: #7636
 - [x] depends on: #7637
 - [x] depends on: #7638
 - [x] depends on: #7639

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
