### PR TITLE
[Merged by Bors] - chore(data/set/basic): add `set.compl_eq_compl`

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -104,7 +104,7 @@ instance {α : Type*} : boolean_algebra (set α) :=
 @[simp] lemma sup_eq_union : ((⊔) : set α → set α → set α) = (∪) := rfl
 @[simp] lemma inf_eq_inter : ((⊓) : set α → set α → set α) = (∩) := rfl
 @[simp] lemma le_eq_subset : ((≤) : set α → set α → Prop) = (⊆) := rfl
-@[simp] lemma compl_eq_compl (s : set α) : s.compl = sᶜ := rfl
+@[simp] lemma compl_eq_compl : (has_compl.comp : set α → set α) = set.compl := rfl
 /-! `set.lt_eq_ssubset` is defined further down -/
 
 /-- Coercion from a set to the corresponding subtype. -/

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -104,8 +104,8 @@ instance {α : Type*} : boolean_algebra (set α) :=
 @[simp] lemma sup_eq_union : ((⊔) : set α → set α → set α) = (∪) := rfl
 @[simp] lemma inf_eq_inter : ((⊓) : set α → set α → set α) = (∩) := rfl
 @[simp] lemma le_eq_subset : ((≤) : set α → set α → Prop) = (⊆) := rfl
-@[simp] lemma compl_eq_compl : set.compl = (has_compl.compl : set α → set α) := rfl
 /-! `set.lt_eq_ssubset` is defined further down -/
+@[simp] lemma compl_eq_compl : set.compl = (has_compl.compl : set α → set α) := rfl
 
 /-- Coercion from a set to the corresponding subtype. -/
 instance {α : Type*} : has_coe_to_sort (set α) := ⟨_, λ s, {x // x ∈ s}⟩

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -104,7 +104,7 @@ instance {α : Type*} : boolean_algebra (set α) :=
 @[simp] lemma sup_eq_union : ((⊔) : set α → set α → set α) = (∪) := rfl
 @[simp] lemma inf_eq_inter : ((⊓) : set α → set α → set α) = (∩) := rfl
 @[simp] lemma le_eq_subset : ((≤) : set α → set α → Prop) = (⊆) := rfl
-@[simp] lemma compl_eq_compl : (has_compl.comp : set α → set α) = set.compl := rfl
+@[simp] lemma compl_eq_compl : set.compl = (has_compl.compl : set α → set α) := rfl
 /-! `set.lt_eq_ssubset` is defined further down -/
 
 /-- Coercion from a set to the corresponding subtype. -/

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -104,6 +104,7 @@ instance {α : Type*} : boolean_algebra (set α) :=
 @[simp] lemma sup_eq_union : ((⊔) : set α → set α → set α) = (∪) := rfl
 @[simp] lemma inf_eq_inter : ((⊓) : set α → set α → set α) = (∩) := rfl
 @[simp] lemma le_eq_subset : ((≤) : set α → set α → Prop) = (⊆) := rfl
+@[simp] lemma compl_eq_compl (s : set α) : s.compl = sᶜ := rfl
 /-! `set.lt_eq_ssubset` is defined further down -/
 
 /-- Coercion from a set to the corresponding subtype. -/


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I wasn't able to find some way to write it as the above ones, e.g. `((ᶜ) : set α → set α) = set.compl`. Maybe I'm just missing something simple though!
