### PR TITLE
[Merged by Bors] - feat(group_theory/sub{group,monoid,semiring,ring}): subobjects inherit the actions of their carrier type

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -243,17 +243,17 @@ variables {R A B}
 
 end prod
 
-/-- Algebra over a subsemiring. -/
+/-- Algebra over a subsemiring. This builds upon `subsemiring.module`. -/
 instance of_subsemiring (S : subsemiring R) : algebra S A :=
-{ smul := λ s x, (s : R) • x,
+{ smul := (•),
   commutes' := λ r x, algebra.commutes r x,
   smul_def' := λ r x, algebra.smul_def r x,
   .. (algebra_map R A).comp (subsemiring.subtype S) }
 
-/-- Algebra over a subring. -/
+/-- Algebra over a subring. This builds upon `subring.module`. -/
 instance of_subring {R A : Type*} [comm_ring R] [ring A] [algebra R A]
   (S : subring R) : algebra S A :=
-{ smul := λ s x, (s : R) • x,
+{ smul := (•),
   commutes' := λ r x, algebra.commutes r x,
   smul_def' := λ r x, algebra.smul_def r x,
   .. (algebra_map R A).comp (subring.subtype S) }

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -248,15 +248,14 @@ instance of_subsemiring (S : subsemiring R) : algebra S A :=
 { smul := (•),
   commutes' := λ r x, algebra.commutes r x,
   smul_def' := λ r x, algebra.smul_def r x,
-  .. (algebra_map R A).comp (subsemiring.subtype S) }
+  .. (algebra_map R A).comp S.subtype }
 
 /-- Algebra over a subring. This builds upon `subring.module`. -/
 instance of_subring {R A : Type*} [comm_ring R] [ring A] [algebra R A]
   (S : subring R) : algebra S A :=
 { smul := (•),
-  commutes' := λ r x, algebra.commutes r x,
-  smul_def' := λ r x, algebra.smul_def r x,
-  .. (algebra_map R A).comp (subring.subtype S) }
+  .. algebra.of_subsemiring S.to_subsemiring,
+  .. (algebra_map R A).comp S.subtype }
 
 lemma algebra_map_of_subring {R : Type*} [comm_ring R] (S : subring R) :
   (algebra_map S R : S →+* R) = subring.subtype S := rfl

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1814,24 +1814,40 @@ section actions
 
 namespace subgroup
 
-variables {M : Type*} [group G]
+variables {α β : Type*}
 
 /-- The action by a subgroup is the action by the underlying group. -/
 @[to_additive /-"The additive action by an add_subgroup is the action by the underlying
 add_group. "-/]
-instance [mul_action G M] (S : subgroup G) : mul_action S M :=
+instance [mul_action G α] (S : subgroup G) : mul_action S α :=
 mul_action.comp_hom _ S.subtype
 
 @[to_additive]
-lemma smul_def [mul_action G M] {S : subgroup G} (g : S) (m : M) : g • m = (g : G) • m := rfl
+lemma smul_def [mul_action G α] {S : subgroup G} (g : S) (m : α) : g • m = (g : G) • m := rfl
 
-instance is_scalar_tower_right [mul_action G M] [is_scalar_tower G G M] (S : subgroup G) :
-  is_scalar_tower S S M :=
-⟨λ a b, (smul_assoc (a : G) (b : G) : _)⟩
+@[to_additive]
+instance smul_comm_class_left
+  [mul_action G β] [has_scalar α β] [smul_comm_class G α β] (S : submonoid G) :
+  smul_comm_class S α β :=
+⟨λ a, (smul_comm (a : G) : _)⟩
+
+@[to_additive]
+instance smul_comm_class_right
+  [has_scalar α β] [mul_action G β] [smul_comm_class α G β] (S : submonoid G) :
+  smul_comm_class α S β :=
+⟨λ a s, (smul_comm a (s : G) : _)⟩
+
+/-- Note that this provides `is_scalar_tower S G G` which is needed by `smul_mul_assoc.`. -/
+instance
+  [has_scalar α β] [mul_action G α] [mul_action G β] [is_scalar_tower G α β] (S : submonoid G) :
+  is_scalar_tower S α β :=
+⟨λ s, (smul_assoc (s : G) : _)⟩
 
 /-- The action by a subgroup is the action by the underlying group. -/
-instance [add_monoid M] [distrib_mul_action G M] (S : subgroup G) : distrib_mul_action S M :=
+instance [add_monoid α] [distrib_mul_action G α] (S : subgroup G) : distrib_mul_action S α :=
 distrib_mul_action.comp_hom _ S.subtype
+
+example {S : submonoid G} : is_scalar_tower S G G := by apply_instance
 
 end subgroup
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1809,7 +1809,10 @@ end subgroup
 
 end pointwise
 
-/-! Actions by subgroups -/
+/-! ### Actions by `subgroup`s
+
+These are just copies of the definitions about `submonoid` starting from `submonoid.mul_action`.
+-/
 section actions
 
 namespace subgroup
@@ -1820,34 +1823,32 @@ variables {α β : Type*}
 @[to_additive /-"The additive action by an add_subgroup is the action by the underlying
 add_group. "-/]
 instance [mul_action G α] (S : subgroup G) : mul_action S α :=
-mul_action.comp_hom _ S.subtype
+S.to_submonoid.mul_action
 
 @[to_additive]
 lemma smul_def [mul_action G α] {S : subgroup G} (g : S) (m : α) : g • m = (g : G) • m := rfl
 
 @[to_additive]
 instance smul_comm_class_left
-  [mul_action G β] [has_scalar α β] [smul_comm_class G α β] (S : submonoid G) :
+  [mul_action G β] [has_scalar α β] [smul_comm_class G α β] (S : subgroup G) :
   smul_comm_class S α β :=
-⟨λ a, (smul_comm (a : G) : _)⟩
+S.to_submonoid.smul_comm_class_left
 
 @[to_additive]
 instance smul_comm_class_right
-  [has_scalar α β] [mul_action G β] [smul_comm_class α G β] (S : submonoid G) :
+  [has_scalar α β] [mul_action G β] [smul_comm_class α G β] (S : subgroup G) :
   smul_comm_class α S β :=
-⟨λ a s, (smul_comm a (s : G) : _)⟩
+S.to_submonoid.smul_comm_class_right
 
-/-- Note that this provides `is_scalar_tower S G G` which is needed by `smul_mul_assoc.`. -/
+/-- Note that this provides `is_scalar_tower S G G` which is needed by `smul_mul_assoc`. -/
 instance
-  [has_scalar α β] [mul_action G α] [mul_action G β] [is_scalar_tower G α β] (S : submonoid G) :
+  [has_scalar α β] [mul_action G α] [mul_action G β] [is_scalar_tower G α β] (S : subgroup G) :
   is_scalar_tower S α β :=
-⟨λ s, (smul_assoc (s : G) : _)⟩
+S.to_submonoid.is_scalar_tower
 
 /-- The action by a subgroup is the action by the underlying group. -/
 instance [add_monoid α] [distrib_mul_action G α] (S : subgroup G) : distrib_mul_action S α :=
-distrib_mul_action.comp_hom _ S.subtype
-
-example {S : submonoid G} : is_scalar_tower S G G := by apply_instance
+S.to_submonoid.distrib_mul_action
 
 end subgroup
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1808,3 +1808,31 @@ set.subset.antisymm
 end subgroup
 
 end pointwise
+
+/-! Actions by subgroups -/
+section actions
+
+namespace subgroup
+
+variables {M : Type*} [group G]
+
+/-- The action by a subgroup is the action by the underlying group. -/
+@[to_additive /-"The additive action by an add_subgroup is the action by the underlying
+add_group. "-/]
+instance [mul_action G M] (S : subgroup G) : mul_action S M :=
+mul_action.comp_hom _ S.subtype
+
+@[to_additive]
+lemma smul_def [mul_action G M] {S : subgroup G} (g : S) (m : M) : g • m = (g : G) • m := rfl
+
+instance is_scalar_tower_right [mul_action G M] [is_scalar_tower G G M] (S : subgroup G) :
+  is_scalar_tower S S M :=
+⟨λ a b, (smul_assoc (a : G) (b : G) : _)⟩
+
+/-- The action by a subgroup is the action by the underlying group. -/
+instance [add_monoid M] [distrib_mul_action G M] (S : subgroup G) : distrib_mul_action S M :=
+distrib_mul_action.comp_hom _ S.subtype
+
+end subgroup
+
+end actions

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -731,7 +731,14 @@ def submonoid_congr (h : S = T) : S ≃* T :=
 
 end mul_equiv
 
-/-! Actions by submonoids -/
+/-! ### Actions by `submonoid`s
+
+These instances tranfer the action by an element `m : M` of a monoid `M` written as `m • a` onto the
+action by an element `s : S` of a submonoid `S : submonoid M` such that `s • a = (s : M) • a`.
+
+These instances work particularly well in conjunction with `monoid.to_mul_action`, enabling
+`s • m` as an alias for `↑s * m`.
+-/
 section actions
 
 namespace submonoid
@@ -763,7 +770,7 @@ instance smul_comm_class_right
   smul_comm_class α S β :=
 ⟨λ a s, (smul_comm a (s : M') : _)⟩
 
-/-- Note that this provides `is_scalar_tower S M' M'` which is needed by `smul_mul_assoc.`. -/
+/-- Note that this provides `is_scalar_tower S M' M'` which is needed by `smul_mul_assoc`. -/
 instance
   [has_scalar α β] [mul_action M' α] [mul_action M' β] [is_scalar_tower M' α β] (S : submonoid M') :
   is_scalar_tower S α β :=

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -736,24 +736,40 @@ section actions
 
 namespace submonoid
 
-variables {M' : Type*} {A : Type*} [monoid M']
+variables {M' : Type*} {α β : Type*} [monoid M']
 
-/-- The action by a submonoid is the action by the underlying group. -/
-@[to_additive /-"The additive action by an add_subgroup is the action by the underlying
-add_group. "-/]
-instance [mul_action M' A] (S : submonoid M') : mul_action S A :=
+/-- The action by a submonoid is the action by the underlying monoid. -/
+@[to_additive /-"The additive action by an add_submonoid is the action by the underlying
+add_monoid. "-/]
+instance [mul_action M' α] (S : submonoid M') : mul_action S α :=
 mul_action.comp_hom _ S.subtype
 
 @[to_additive]
-lemma smul_def [mul_action M' A] {S : submonoid M'} (g : S) (m : A) : g • m = (g : M') • m := rfl
+lemma smul_def [mul_action M' α] {S : submonoid M'} (g : S) (m : α) : g • m = (g : M') • m := rfl
 
-/-- The action by a submonoid is the action by the underlying group. -/
-instance [add_monoid A] [distrib_mul_action M' A] (S : submonoid M') : distrib_mul_action S A :=
+/-- The action by a submonoid is the action by the underlying monoid. -/
+instance [add_monoid α] [distrib_mul_action M' α] (S : submonoid M') : distrib_mul_action S α :=
 distrib_mul_action.comp_hom _ S.subtype
 
-instance is_scalar_tower_right [mul_action M' A] [is_scalar_tower M' M' A] (S : submonoid M') :
-  is_scalar_tower S S M' :=
-⟨λ a b, (smul_assoc (a : M') (b : M') : _)⟩
+@[to_additive]
+instance smul_comm_class_left
+  [mul_action M' β] [has_scalar α β] [smul_comm_class M' α β] (S : submonoid M') :
+  smul_comm_class S α β :=
+⟨λ a, (smul_comm (a : M') : _)⟩
+
+@[to_additive]
+instance smul_comm_class_right
+  [has_scalar α β] [mul_action M' β] [smul_comm_class α M' β] (S : submonoid M') :
+  smul_comm_class α S β :=
+⟨λ a s, (smul_comm a (s : M') : _)⟩
+
+/-- Note that this provides `is_scalar_tower S M' M'` which is needed by `smul_mul_assoc.`. -/
+instance
+  [has_scalar α β] [mul_action M' α] [mul_action M' β] [is_scalar_tower M' α β] (S : submonoid M') :
+  is_scalar_tower S α β :=
+⟨λ a, (smul_assoc (a : M') : _)⟩
+
+example {S : submonoid M'} : is_scalar_tower S M' M' := by apply_instance
 
 end submonoid
 

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -28,6 +28,11 @@ In this file we define various operations on `submonoid`s and `monoid_hom`s.
 * `submonoid.to_monoid`, `submonoid.to_comm_monoid`: a submonoid inherits a (commutative) monoid
   structure.
 
+### Group actions by submonoids
+
+* `submonoid.mul_action`, `submonoid.distrib_mul_action`: a submonoid inherits (distributive)
+  multiplicative actions.
+
 ### Operations on submonoids
 
 * `submonoid.comap`: preimage of a submonoid under a monoid homomorphism as a submonoid of the
@@ -725,3 +730,31 @@ def submonoid_congr (h : S = T) : S ≃* T :=
 { map_mul' :=  λ _ _, rfl, ..equiv.set_congr $ congr_arg _ h }
 
 end mul_equiv
+
+/-! Actions by submonoids -/
+section actions
+
+namespace submonoid
+
+variables {M' : Type*} {A : Type*} [monoid M']
+
+/-- The action by a submonoid is the action by the underlying group. -/
+@[to_additive /-"The additive action by an add_subgroup is the action by the underlying
+add_group. "-/]
+instance [mul_action M' A] (S : submonoid M') : mul_action S A :=
+mul_action.comp_hom _ S.subtype
+
+@[to_additive]
+lemma smul_def [mul_action M' A] {S : submonoid M'} (g : S) (m : A) : g • m = (g : M') • m := rfl
+
+/-- The action by a submonoid is the action by the underlying group. -/
+instance [add_monoid A] [distrib_mul_action M' A] (S : submonoid M') : distrib_mul_action S A :=
+distrib_mul_action.comp_hom _ S.subtype
+
+instance is_scalar_tower_right [mul_action M' A] [is_scalar_tower M' M' A] (S : submonoid M') :
+  is_scalar_tower S S M' :=
+⟨λ a b, (smul_assoc (a : M') (b : M') : _)⟩
+
+end submonoid
+
+end actions

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -845,8 +845,8 @@ by { convert add_subgroup.gsmul_mem G h k, simp }
 These are just copies of the definitions about `subsemiring` starting from
 `subsemiring.mul_action`.
 
-A stronger result is provided elsewhere as `algebra.of_subring` which uses the same scalar
-action.
+When `R` is commutative, `algebra.of_subring` provides a stronger result than those found in
+this file, which uses the same scalar action.
 -/
 section actions
 

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -838,3 +838,49 @@ end subring
 lemma add_subgroup.int_mul_mem {G : add_subgroup R} (k : ℤ) {g : R} (h : g ∈ G) :
   (k : R) * g ∈ G :=
 by { convert add_subgroup.gsmul_mem G h k, simp }
+
+
+/-! ### Actions by `subring`s
+
+These are just copies of the definitions about `subsemiring` starting from
+`subsemiring.mul_action`.
+-/
+section actions
+
+namespace subring
+
+variables {α β : Type*}
+
+/-- The action by a subring is the action by the underlying ring. -/
+instance [mul_action R α] (S : subring R) : mul_action S α :=
+S.to_subsemiring.mul_action
+
+lemma smul_def [mul_action R α] {S : subring R} (g : S) (m : α) : g • m = (g : R) • m := rfl
+
+instance smul_comm_class_left
+  [mul_action R β] [has_scalar α β] [smul_comm_class R α β] (S : subring R) :
+  smul_comm_class S α β :=
+S.to_subsemiring.smul_comm_class_left
+
+instance smul_comm_class_right
+  [has_scalar α β] [mul_action R β] [smul_comm_class α R β] (S : subring R) :
+  smul_comm_class α S β :=
+S.to_subsemiring.smul_comm_class_right
+
+/-- Note that this provides `is_scalar_tower S R R` which is needed by `smul_mul_assoc`. -/
+instance
+  [has_scalar α β] [mul_action R α] [mul_action R β] [is_scalar_tower R α β] (S : subring R) :
+  is_scalar_tower S α β :=
+S.to_subsemiring.is_scalar_tower
+
+/-- The action by a subring is the action by the underlying ring. -/
+instance [add_monoid α] [distrib_mul_action R α] (S : subring R) : distrib_mul_action S α :=
+S.to_subsemiring.distrib_mul_action
+
+/-- The action by a subring is the action by the underlying ring. -/
+instance [add_comm_monoid α] [module R α] (S : subring R) : module S α :=
+S.to_subsemiring.module
+
+end subring
+
+end actions

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -844,6 +844,9 @@ by { convert add_subgroup.gsmul_mem G h k, simp }
 
 These are just copies of the definitions about `subsemiring` starting from
 `subsemiring.mul_action`.
+
+A stronger result is provided elsewhere as `algebra.of_subring` which uses the same scalar
+action.
 -/
 section actions
 

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -710,8 +710,8 @@ end ring_equiv
 These are just copies of the definitions about `submonoid` starting from `submonoid.mul_action`.
 The only new result is `subsemiring.module`.
 
-A stronger result is provided elsewhere as `algebra.of_subsemiring` which uses the same scalar
-action.
+When `R` is commutative, `algebra.of_subsemiring` provides a stronger result than those found in
+this file, which uses the same scalar action.
 -/
 section actions
 

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -709,6 +709,9 @@ end ring_equiv
 
 These are just copies of the definitions about `submonoid` starting from `submonoid.mul_action`.
 The only new result is `subsemiring.module`.
+
+A stronger result is provided elsewhere as `algebra.of_subsemiring` which uses the same scalar
+action.
 -/
 section actions
 

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -704,3 +704,48 @@ def sof_left_inverse {g : S → R} {f : R →+* S} (h : function.left_inverse g 
   (sof_left_inverse h).symm x = g x := rfl
 
 end ring_equiv
+
+/-! ### Actions by `subsemiring`s
+
+These are just copies of the definitions about `submonoid` starting from `submonoid.mul_action`.
+The only new result is `subsemiring.module`.
+-/
+section actions
+
+namespace subsemiring
+
+variables {α β : Type*}
+
+/-- The action by a subsemiring is the action by the underlying semiring. -/
+instance [mul_action R α] (S : subsemiring R) : mul_action S α :=
+S.to_submonoid.mul_action
+
+lemma smul_def [mul_action R α] {S : subsemiring R} (g : S) (m : α) : g • m = (g : R) • m := rfl
+
+instance smul_comm_class_left
+  [mul_action R β] [has_scalar α β] [smul_comm_class R α β] (S : subsemiring R) :
+  smul_comm_class S α β :=
+S.to_submonoid.smul_comm_class_left
+
+instance smul_comm_class_right
+  [has_scalar α β] [mul_action R β] [smul_comm_class α R β] (S : subsemiring R) :
+  smul_comm_class α S β :=
+S.to_submonoid.smul_comm_class_right
+
+/-- Note that this provides `is_scalar_tower S R R` which is needed by `smul_mul_assoc`. -/
+instance
+  [has_scalar α β] [mul_action R α] [mul_action R β] [is_scalar_tower R α β] (S : subsemiring R) :
+  is_scalar_tower S α β :=
+S.to_submonoid.is_scalar_tower
+
+/-- The action by a subsemiring is the action by the underlying semiring. -/
+instance [add_monoid α] [distrib_mul_action R α] (S : subsemiring R) : distrib_mul_action S α :=
+S.to_submonoid.distrib_mul_action
+
+/-- The action by a subsemiring is the action by the underlying semiring. -/
+instance [add_comm_monoid α] [module R α] (S : subsemiring R) : module S α :=
+{ smul := (•), .. module.comp_hom _ S.subtype }
+
+end subsemiring
+
+end actions


### PR DESCRIPTION
This acts as a generalization of `algebra.of_subsemiring` and `algebra.of_subring`, and transfers the weaker action structures too.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
