### PR TITLE
[Merged by Bors] - feat(linear_algebra/determinant): specialize `linear_equiv.is_unit_det` to automorphisms

### DIFF
--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -191,6 +191,19 @@ by rw [linear_map.coe_det, dif_pos, det_aux_def' _ b]; assumption
 by { haveI := classical.dec_eq M,
      rw [det_eq_det_to_matrix_of_finset b.reindex_finset_range, det_to_matrix_eq_det_to_matrix b] }
 
+/-- To show `P f.det` it suffices to consider `P (to_matrix _ _ f).det` and `P 1`. -/
+@[elab_as_eliminator]
+lemma det_cases [decidable_eq M] {P : A → Prop} (f : M →ₗ[A] M)
+  (hb : ∀ (s : finset M) (b : basis s A M), P (to_matrix b b f).det) (h1 : P 1) :
+  P f.det :=
+begin
+  unfold linear_map.det,
+  split_ifs with h,
+  { convert hb _ h.some_spec.some,
+    apply det_aux_def' },
+  { exact h1 }
+end
+
 @[simp]
 lemma det_comp (f g : M →ₗ[A] M) : (f.comp g).det = f.det * g.det :=
 linear_map.det.map_mul f g
@@ -218,12 +231,8 @@ end
 /-- Specialization of `linear_equiv.is_unit_det` -/
 lemma linear_equiv.is_unit_det' {A : Type*} [integral_domain A] [module A M]
   (f : M ≃ₗ[A] M) : is_unit (linear_map.det (f : M →ₗ[A] M)) :=
-begin
-  unfold linear_map.det,
-  split_ifs with h,
-  { convert linear_equiv.is_unit_det f _ _ }, -- `convert` avoids `decidable_eq` issues
-  { simp },
-end
+by haveI := classical.dec_eq M; exact
+(f : M →ₗ[A] M).det_cases (λ s b, f.is_unit_det _ _) is_unit_one
 
 /-- Builds a linear equivalence from a linear map whose determinant in some bases is a unit. -/
 @[simps]

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -215,6 +215,16 @@ begin
   simpa using (linear_map.to_matrix_comp v v' v f.symm f).symm
 end
 
+/-- Specialization of `linear_equiv.is_unit_det` -/
+lemma linear_equiv.is_unit_det' {A : Type*} [integral_domain A] [module A M]
+  (f : M ≃ₗ[A] M) : is_unit (linear_map.det (f : M →ₗ[A] M)) :=
+begin
+  unfold linear_map.det,
+  split_ifs with h,
+  { convert linear_equiv.is_unit_det f _ _ }, -- `convert` avoids `decidable_eq` issues
+  { simp },
+end
+
 /-- Builds a linear equivalence from a linear map whose determinant in some bases is a unit. -/
 @[simps]
 def linear_equiv.of_is_unit_det {f : M →ₗ[R] M'} {v : basis ι R M} {v' : basis ι R M'}


### PR DESCRIPTION
`linear_equiv.is_unit_det` is defined for all equivs between equal-dimensional spaces, using `det (linear_map.to_matrix _ _ _)`, but I needed this result for `linear_map.det _` (which only exists between the exact same space). So I added the specialization `linear_equiv.is_unit_det'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #7635
- [x] depends on: #7778

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
