### PR TITLE
[Merged by Bors] - feat(linear_algebra/determinant): specialize `is_basis.iff_det`

### DIFF
--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -123,3 +123,6 @@ begin
     rw ← this,
     exact ⟨v'.linear_independent, v'.span_eq⟩ },
 end
+
+lemma basis.is_unit_det (e' : basis ι R M) : is_unit (e.det e') :=
+(is_basis.iff_det e).mp ⟨e'.linear_independent, e'.span_eq⟩

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -105,7 +105,7 @@ lemma basis.det_apply (v : ι → M) : e.det v = det (e.to_matrix v) := rfl
 lemma basis.det_self : e.det e = 1 :=
 by simp [e.det_apply]
 
-lemma is_basis.iff_det {v : ι → M} :
+lemma is_basis_iff_det {v : ι → M} :
   linear_independent R v ∧ span R (set.range v) = ⊤ ↔ is_unit (e.det v) :=
 begin
   split,
@@ -125,4 +125,4 @@ begin
 end
 
 lemma basis.is_unit_det (e' : basis ι R M) : is_unit (e.det e') :=
-(is_basis.iff_det e).mp ⟨e'.linear_independent, e'.span_eq⟩
+(is_basis_iff_det e).mp ⟨e'.linear_independent, e'.span_eq⟩


### PR DESCRIPTION
After the bundled basis refactor, applying `is_basis.iff_det` in the forward direction is slightly more involved (since defining the `iff` requires an unbundled basis), so I added a lemma that does the necessary translation between "unbundled basis" and "bundled basis" for you.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
