### PR TITLE
[Merged by Bors] - feat(linear_algebra/matrix): generalize `basis.to_matrix_mul_to_matrix`

### DIFF
--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Alexander Bentkamp
 -/
+import algebra.big_operators.finsupp
 import data.fintype.card
 import linear_algebra.finsupp
 import linear_algebra.linear_independent
@@ -685,6 +686,15 @@ b.constr_basis R _ _
 @[simp] lemma equiv'_symm_apply (f : M → M') (g : M' → M) (hf hg hgf hfg) (i : ι') :
   (b.equiv' b' f g hf hg hgf hfg).symm (b' i) = g (b' i) :=
 b'.constr_basis R _ _
+
+lemma sum_repr_mul_repr {ι'} [fintype ι'] (b' : basis ι' R M) (x : M) (i : ι) :
+  ∑ (j : ι'), b.repr (b' j) i * b'.repr x j = b.repr x i :=
+begin
+  conv_rhs { rw [← b'.sum_repr x] },
+  simp_rw [linear_equiv.map_sum, linear_equiv.map_smul, finset.sum_apply'],
+  refine finset.sum_congr rfl (λ j _, _),
+  rw [finsupp.smul_apply, smul_eq_mul, mul_comm]
+end
 
 end basis
 

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
+import algebra.big_operators.finsupp
 import linear_algebra.matrix.to_lin
 
 /-!
@@ -140,17 +141,24 @@ open linear_map
 by { haveI := classical.dec_eq ι',
       rw [← basis_to_matrix_mul_linear_map_to_matrix b b', to_matrix_id, matrix.mul_one] }
 
+lemma sum_repr_aux (x : M) : ∑ (j : ι'), b.repr (b' j) i * b'.repr x j = b.repr x i :=
+begin
+  conv_rhs { rw [← b'.sum_repr x] },
+  simp_rw [linear_equiv.map_sum, linear_equiv.map_smul, finset.sum_apply'],
+  refine finset.sum_congr rfl (λ j _, _),
+  rw [finsupp.smul_apply, smul_eq_mul, mul_comm]
+end
+
 /-- A generalization of `basis.to_matrix_self`, in the opposite direction. -/
 @[simp] lemma basis.to_matrix_mul_to_matrix
-  {ι'' : Type*} [fintype ι''] (b'' : basis ι'' R M) :
+  {ι'' : Type*} [fintype ι''] (b'' : ι'' → M) :
   b.to_matrix b' ⬝ b'.to_matrix b'' = b.to_matrix b'' :=
 begin
   haveI := classical.dec_eq ι,
   haveI := classical.dec_eq ι',
   haveI := classical.dec_eq ι'',
-  rw [← linear_map.to_matrix_id_eq_basis_to_matrix b' b,
-      ← linear_map.to_matrix_id_eq_basis_to_matrix b'' b',
-      ← to_matrix_comp, id_comp, linear_map.to_matrix_id_eq_basis_to_matrix],
+  ext i j,
+  simp only [matrix.mul_apply, basis.to_matrix_apply, sum_repr_aux],
 end
 
 end mul_linear_map_to_matrix

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
-import algebra.big_operators.finsupp
 import linear_algebra.matrix.to_lin
 
 /-!
@@ -141,15 +140,6 @@ open linear_map
 by { haveI := classical.dec_eq ι',
       rw [← basis_to_matrix_mul_linear_map_to_matrix b b', to_matrix_id, matrix.mul_one] }
 
-lemma sum_repr_aux {ι} (b : basis ι R M) (x : M) (i : ι) :
-  ∑ (j : ι'), b.repr (b' j) i * b'.repr x j = b.repr x i :=
-begin
-  conv_rhs { rw [← b'.sum_repr x] },
-  simp_rw [linear_equiv.map_sum, linear_equiv.map_smul, finset.sum_apply'],
-  refine finset.sum_congr rfl (λ j _, _),
-  rw [finsupp.smul_apply, smul_eq_mul, mul_comm]
-end
-
 /-- A generalization of `basis.to_matrix_self`, in the opposite direction. -/
 @[simp] lemma basis.to_matrix_mul_to_matrix
   {ι'' : Type*} [fintype ι''] (b'' : ι'' → M) :
@@ -159,7 +149,7 @@ begin
   haveI := classical.dec_eq ι',
   haveI := classical.dec_eq ι'',
   ext i j,
-  simp only [matrix.mul_apply, basis.to_matrix_apply, sum_repr_aux],
+  simp only [matrix.mul_apply, basis.to_matrix_apply, basis.sum_repr_mul_repr],
 end
 
 end mul_linear_map_to_matrix

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -141,7 +141,8 @@ open linear_map
 by { haveI := classical.dec_eq ι',
       rw [← basis_to_matrix_mul_linear_map_to_matrix b b', to_matrix_id, matrix.mul_one] }
 
-lemma sum_repr_aux (x : M) : ∑ (j : ι'), b.repr (b' j) i * b'.repr x j = b.repr x i :=
+lemma sum_repr_aux {ι} (b : basis ι R M) (x : M) (i : ι) :
+  ∑ (j : ι'), b.repr (b' j) i * b'.repr x j = b.repr x i :=
 begin
   conv_rhs { rw [← b'.sum_repr x] },
   simp_rw [linear_equiv.map_sum, linear_equiv.map_smul, finset.sum_apply'],


### PR DESCRIPTION
Now the second family of vectors does not have to form a basis.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
