### PR TITLE
[Merged by Bors] - feat(measure_theory/interval_integral): `interval_integrable.mono`

### DIFF
--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -149,7 +149,7 @@ integrable_on f (Ioc a b) μ ∧ integrable_on f (Ioc b a) μ
   defintion of `interval_integrable`. -/
 lemma interval_integrable_iff {f : α → E} {a b : α} {μ : measure α} :
   interval_integrable f μ a b ↔ integrable_on f (Ioc (min a b) (max a b)) μ :=
-by cases le_total a b; simp [*, interval_integrable]
+by cases le_total a b; simp [h, interval_integrable]
 
 /-- If a function is interval integrable with respect to a given measure `μ` on `interval a b` then
   it is integrable on `Ioc (min a b) (max a b)` with respect to `μ`. -/

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -144,8 +144,24 @@ intervals is always empty, so this property is equivalent to `f` being integrabl
 def interval_integrable (f : α → E) (μ : measure α) (a b : α) :=
 integrable_on f (Ioc a b) μ ∧ integrable_on f (Ioc b a) μ
 
-lemma measure_theory.integrable.interval_integrable {f : α → E} {μ : measure α}
-  (hf : integrable f μ) {a b : α} :
+/-- A function is interval integrable with respect to a given measure `μ` on `interval a b` if and
+  only if it is integrable on `Ioc (min a b) (max a b)` with respect to `μ`. This is an equivalent
+  defintion of `interval_integrable`. -/
+lemma interval_integrable_iff {f : α → E} {a b : α} {μ : measure α} :
+  interval_integrable f μ a b ↔ integrable_on f (Ioc (min a b) (max a b)) μ :=
+by cases le_total a b; simp [*, interval_integrable]
+
+/-- If a function is interval integrable with respect to a given measure `μ` on `interval a b` then
+  it is integrable on `Ioc (min a b) (max a b)` with respect to `μ`. -/
+lemma interval_integrable.def {f : α → E} {a b : α} {μ : measure α}
+  (h : interval_integrable f μ a b) :
+  integrable_on f (Ioc (min a b) (max a b)) μ :=
+interval_integrable_iff.mp h
+
+/-- If a function is integrable with respect to a given measure `μ` then it is interval integrable
+  with respect to `μ` on `interval a b`. -/
+lemma measure_theory.integrable.interval_integrable {f : α → E} {a b : α} {μ : measure α}
+  (hf : integrable f μ) :
   interval_integrable f μ a b :=
 ⟨hf.integrable_on, hf.integrable_on⟩
 
@@ -153,7 +169,7 @@ namespace interval_integrable
 
 section
 
-variables {f : α → E} {a b c : α} {μ : measure α}
+variables {f : α → E} {a b c d : α} {μ ν : measure α}
 
 @[symm] lemma symm (h : interval_integrable f μ a b) : interval_integrable f μ b a :=
 h.symm
@@ -161,13 +177,34 @@ h.symm
 @[refl] lemma refl : interval_integrable f μ a a :=
 by split; simp
 
-@[trans] lemma trans  (hab : interval_integrable f μ a b) (hbc : interval_integrable f μ b c) :
+@[trans] lemma trans (hab : interval_integrable f μ a b) (hbc : interval_integrable f μ b c) :
   interval_integrable f μ a c :=
 ⟨(hab.1.union hbc.1).mono_set Ioc_subset_Ioc_union_Ioc,
   (hbc.2.union hab.2).mono_set Ioc_subset_Ioc_union_Ioc⟩
 
 lemma neg [borel_space E] (h : interval_integrable f μ a b) : interval_integrable (-f) μ a b :=
 ⟨h.1.neg, h.2.neg⟩
+
+lemma mono
+  (hf : interval_integrable f ν a b) (h1 : interval c d ⊆ interval a b) (h2 : μ ≤ ν) :
+  interval_integrable f μ c d :=
+let ⟨h1₁, h1₂⟩ := interval_subset_interval_iff_le.mp h1 in
+interval_integrable_iff.mpr $ hf.def.mono (Ioc_subset_Ioc h1₁ h1₂) h2
+
+lemma mono_set
+  (hf : interval_integrable f μ a b) (h : interval c d ⊆ interval a b) :
+  interval_integrable f μ c d :=
+hf.mono h rfl.le
+
+lemma mono_measure
+  (hf : interval_integrable f ν a b) (h : μ ≤ ν) :
+  interval_integrable f μ a b :=
+hf.mono rfl.subset h
+
+lemma mono_set_ae
+  (hf : interval_integrable f μ a b) (h : Ioc (min c d) (max c d) ≤ᵐ[μ] Ioc (min a b) (max a b)) :
+  interval_integrable f μ c d :=
+interval_integrable_iff.mpr $ hf.def.mono_set_ae h
 
 protected lemma ae_measurable (h : interval_integrable f μ a b) :
   ae_measurable f (μ.restrict (Ioc a b)):=


### PR DESCRIPTION
`interval_integrable f ν a b → interval c d ⊆ interval a b → μ ≤ ν → interval_integrable f μ c d`
