### PR TITLE
[Merged by Bors] - feat(data/set/basic): allow dot notation for trans and antisymm

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -87,6 +87,12 @@ lemma has_subset.subset.trans {α : Type*} [has_subset α] [is_trans α (⊆)]
 lemma has_subset.subset.antisymm {α : Type*} [has_subset α] [is_antisymm α (⊆)]
   {a b : α} (h : a ⊆ b) (h': b ⊆ a) : a = b := antisymm h h'
 
+lemma has_ssubset.ssubset.trans {α : Type*} [has_ssubset α] [is_trans α (⊂)]
+  {a b c : α} (h : a ⊂ b) (h': b ⊂ c) : a ⊂ c := trans h h'
+
+lemma has_ssubset.ssubset.asymm {α : Type*} [has_ssubset α] [is_asymm α (⊂)]
+  {a b : α} (h : a ⊂ b) : ¬(b ⊂ a) := asymm h
+
 namespace set
 
 variable {α : Type*}

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -81,6 +81,12 @@ universe variables u v w x
 run_cmd do e ← tactic.get_env,
   tactic.set_env $ e.mk_protected `set.compl
 
+lemma has_subset.subset.trans {α : Type*} [has_subset α] [is_trans α (⊆)]
+  {a b c : α} (h : a ⊆ b)  (h': b ⊆ c) : a ⊆ c := trans h h'
+
+lemma has_subset.subset.antisymm {α : Type*} [has_subset α] [is_antisymm α (⊆)]
+  {a b : α} (h : a ⊆ b)  (h': b ⊆ a) : a = b := antisymm h h'
+
 namespace set
 
 variable {α : Type*}
@@ -227,6 +233,12 @@ hx.symm ▸ h
 
 theorem subset.antisymm {a b : set α} (h₁ : a ⊆ b) (h₂ : b ⊆ a) : a = b :=
 set.ext $ λ x, ⟨@h₁ _, @h₂ _⟩
+
+instance {α : Type*} : is_trans (set α) set.subset :=
+⟨λ _ _ _, set.subset.trans⟩
+
+instance {α : Type*} : is_antisymm (set α) set.subset :=
+⟨λ _ _, set.subset.antisymm⟩
 
 theorem subset.antisymm_iff {a b : set α} : a = b ↔ a ⊆ b ∧ b ⊆ a :=
 ⟨λ e, ⟨e.subset, e.symm.subset⟩, λ ⟨h₁, h₂⟩, subset.antisymm h₁ h₂⟩

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -82,13 +82,13 @@ run_cmd do e ← tactic.get_env,
   tactic.set_env $ e.mk_protected `set.compl
 
 lemma has_subset.subset.trans {α : Type*} [has_subset α] [is_trans α (⊆)]
-  {a b c : α} (h : a ⊆ b) (h': b ⊆ c) : a ⊆ c := trans h h'
+  {a b c : α} (h : a ⊆ b) (h' : b ⊆ c) : a ⊆ c := trans h h'
 
 lemma has_subset.subset.antisymm {α : Type*} [has_subset α] [is_antisymm α (⊆)]
-  {a b : α} (h : a ⊆ b) (h': b ⊆ a) : a = b := antisymm h h'
+  {a b : α} (h : a ⊆ b) (h' : b ⊆ a) : a = b := antisymm h h'
 
 lemma has_ssubset.ssubset.trans {α : Type*} [has_ssubset α] [is_trans α (⊂)]
-  {a b c : α} (h : a ⊂ b) (h': b ⊂ c) : a ⊂ c := trans h h'
+  {a b c : α} (h : a ⊂ b) (h' : b ⊂ c) : a ⊂ c := trans h h'
 
 lemma has_ssubset.ssubset.asymm {α : Type*} [has_ssubset α] [is_asymm α (⊂)]
   {a b : α} (h : a ⊂ b) : ¬(b ⊂ a) := asymm h

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -82,10 +82,10 @@ run_cmd do e ← tactic.get_env,
   tactic.set_env $ e.mk_protected `set.compl
 
 lemma has_subset.subset.trans {α : Type*} [has_subset α] [is_trans α (⊆)]
-  {a b c : α} (h : a ⊆ b)  (h': b ⊆ c) : a ⊆ c := trans h h'
+  {a b c : α} (h : a ⊆ b) (h': b ⊆ c) : a ⊆ c := trans h h'
 
 lemma has_subset.subset.antisymm {α : Type*} [has_subset α] [is_antisymm α (⊆)]
-  {a b : α} (h : a ⊆ b)  (h': b ⊆ a) : a = b := antisymm h h'
+  {a b : α} (h : a ⊆ b) (h': b ⊆ a) : a = b := antisymm h h'
 
 namespace set
 
@@ -233,12 +233,6 @@ hx.symm ▸ h
 
 theorem subset.antisymm {a b : set α} (h₁ : a ⊆ b) (h₂ : b ⊆ a) : a = b :=
 set.ext $ λ x, ⟨@h₁ _, @h₂ _⟩
-
-instance {α : Type*} : is_trans (set α) set.subset :=
-⟨λ _ _ _, set.subset.trans⟩
-
-instance {α : Type*} : is_antisymm (set α) set.subset :=
-⟨λ _ _, set.subset.antisymm⟩
 
 theorem subset.antisymm_iff {a b : set α} : a = b ↔ a ⊆ b ∧ b ⊆ a :=
 ⟨λ e, ⟨e.subset, e.symm.subset⟩, λ ⟨h₁, h₂⟩, subset.antisymm h₁ h₂⟩


### PR DESCRIPTION
Allow to write
```lean
example {α : Type*} {a b c : set α} (h : a ⊆ b)  (h': b ⊆ c) : a ⊆ c :=
h.trans h'

example {α : Type*} {a b : set α} (h : a ⊆ b)  (h': b ⊆ a) : 
  a = b := h.antisymm h'

example {α : Type*} {a b c : finset α} (h : a ⊆ b)  (h': b ⊆ c) : a ⊆ c :=
h.trans h'

example {α : Type*} {a b : finset α} (h : a ⊆ b)  (h': b ⊆ a) : a = b :=
h.antisymm h'
```

---

See https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Capricious.20dot.20notation

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
