### PR TITLE
[Merged by Bors] - chore(order/conditionally_complete_lattice): golf proofs with `order_dual`

### DIFF
--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -111,6 +111,25 @@ instance conditionally_complete_linear_order_of_complete_linear_order [complete_
   conditionally_complete_linear_order α :=
 { ..conditionally_complete_lattice_of_complete_lattice, .. ‹complete_linear_order α› }
 
+section order_dual
+
+instance (α : Type*) [conditionally_complete_lattice α] :
+  conditionally_complete_lattice (order_dual α) :=
+{ le_cSup := @conditionally_complete_lattice.cInf_le α _,
+  cSup_le := @conditionally_complete_lattice.le_cInf α _,
+  le_cInf := @conditionally_complete_lattice.cSup_le α _,
+  cInf_le := @conditionally_complete_lattice.le_cSup α _,
+  ..order_dual.has_Inf α,
+  ..order_dual.has_Sup α,
+  ..order_dual.lattice α }
+
+instance (α : Type*) [conditionally_complete_linear_order α] :
+  conditionally_complete_linear_order (order_dual α) :=
+{ ..order_dual.conditionally_complete_lattice α,
+  ..order_dual.linear_order α }
+
+end order_dual
+
 section conditionally_complete_lattice
 variables [conditionally_complete_lattice α] {s t : set α} {a b : α}
 
@@ -191,14 +210,7 @@ show Sup s = b, by finish
 /--Introduction rule to prove that b is the infimum of s: it suffices to check that b
 is smaller than all elements of s, and that this is not the case of any `w>b`.-/
 theorem cInf_intro (_ : s.nonempty) (_ : ∀a∈s, b ≤ a) (H : ∀w, b < w → (∃a∈s, a < w)) : Inf s = b :=
-have bdd_below s := ⟨b, by assumption⟩,
-have (b < Inf s) ∨ (b = Inf s) := lt_or_eq_of_le (le_cInf ‹_› ‹∀a∈s, b ≤ a›),
-have ¬(b < Inf s) :=
-  assume: b < Inf s,
-  let ⟨a, _, _⟩ := (H (Inf s) ‹b < Inf s›) in  /- a ∈ s, a < Inf s-/
-  have Inf s < Inf s := lt_of_le_of_lt (cInf_le ‹bdd_below s› ‹a ∈ s›) ‹a < Inf s› ,
-  show false, by finish [lt_irrefl (Inf s)],
-show Inf s = b, by finish
+@cSup_intro (order_dual α) _ _ _ ‹_› ‹_› ‹_›
 
 /--b < Sup s when there is an element a in s with b < a, when s is bounded above.
 This is essentially an iff, except that the assumptions for the two implications are
@@ -214,7 +226,7 @@ slightly different (one needs boundedness below for one direction, nonemptiness 
 order for the other one), so we formulate separately the two implications, contrary to
 the complete_lattice case.-/
 lemma cInf_lt_of_lt (_ : bdd_below s) (_ : a ∈ s) (_ : a < b) : Inf s < b :=
-lt_of_le_of_lt (cInf_le ‹bdd_below s› ‹a ∈ s›) ‹a < b›
+@lt_cSup_of_lt (order_dual α) _ _ _ _ ‹_› ‹_› ‹_›
 
 /-- If all elements of a nonempty set `s` are less than or equal to all elements
 of a nonempty set `t`, then there exists an element between these sets. -/
@@ -246,7 +258,7 @@ theorem cSup_union (hs : bdd_above s) (sne : s.nonempty) (ht : bdd_above t) (tne
 that all sets are bounded below and nonempty.-/
 theorem cInf_union (hs : bdd_below s) (sne : s.nonempty) (ht : bdd_below t) (tne : t.nonempty) :
   Inf (s ∪ t) = Inf s ⊓ Inf t :=
-((is_glb_cInf sne hs).union (is_glb_cInf tne ht)).cInf_eq sne.inl
+@cSup_union (order_dual α) _ _ _ hs sne ht tne
 
 /--The supremum of an intersection of two sets is bounded by the minimum of the suprema of each
 set, if all sets are bounded above and nonempty.-/
@@ -261,12 +273,8 @@ end
 /--The infimum of an intersection of two sets is bounded below by the maximum of the
 infima of each set, if all sets are bounded below and nonempty.-/
 theorem le_cInf_inter (_ : bdd_below s) (_ : bdd_below t) (hst : (s ∩ t).nonempty) :
-Inf s ⊔ Inf t ≤ Inf (s ∩ t) :=
-begin
-  apply le_cInf hst, simp only [and_imp, set.mem_inter_eq, sup_le_iff], intros b _ _, split,
-  apply cInf_le ‹bdd_below s› ‹b ∈ s›,
-  apply cInf_le ‹bdd_below t› ‹b ∈ t›
-end
+  Inf s ⊔ Inf t ≤ Inf (s ∩ t) :=
+@cSup_inter_le (order_dual α) _ _ _ ‹_› ‹_› hst
 
 /-- The supremum of insert a s is the maximum of a and the supremum of s, if s is
 nonempty and bounded above.-/
@@ -276,7 +284,7 @@ theorem cSup_insert (hs : bdd_above s) (sne : s.nonempty) : Sup (insert a s) = a
 /-- The infimum of insert a s is the minimum of a and the infimum of s, if s is
 nonempty and bounded below.-/
 theorem cInf_insert (hs : bdd_below s) (sne : s.nonempty) : Inf (insert a s) = a ⊓ Inf s :=
-((is_glb_cInf sne hs).insert a).cInf_eq (insert_nonempty a s)
+@cSup_insert (order_dual α) _ _ _ hs sne
 
 @[simp] lemma cInf_Icc (h : a ≤ b) : Inf (Icc a b) = a :=
 (is_glb_Icc h).cInf_eq (nonempty_Icc.2 h)
@@ -338,45 +346,34 @@ le_cSup H (mem_range_self _)
 /--The indexed infimum of two functions are comparable if the functions are pointwise comparable-/
 lemma cinfi_le_cinfi {f g : ι → α} (B : bdd_below (range f)) (H : ∀x, f x ≤ g x) :
   infi f ≤ infi g :=
-begin
-  classical, by_cases hι : nonempty ι,
-  { have Rg : (range g).nonempty, { exactI range_nonempty _ },
-    apply le_cInf Rg,
-    rintros y ⟨x, rfl⟩,
-    have : f x ∈ range f := ⟨x, rfl⟩,
-    exact cInf_le_of_le B this (H x) },
-  { have Rf : range f = ∅, from range_eq_empty.2 hι,
-    have Rg : range g = ∅, from range_eq_empty.2 hι,
-    unfold infi, rw [Rf, Rg] }
-end
+@csupr_le_csupr (order_dual α) _ _ _ _ B H
 
 /--The indexed minimum of a function is bounded below by a uniform lower bound-/
 lemma le_cinfi [nonempty ι] {f : ι → α} {c : α} (H : ∀x, c ≤ f x) : c ≤ infi f :=
-le_cInf (range_nonempty f) (by rwa forall_range_iff)
+@csupr_le (order_dual α) _ _ _ _ _ H
 
 /--The indexed infimum of a function is bounded above by the value taken at one point-/
 lemma cinfi_le {f : ι → α} (H : bdd_below (range f)) (c : ι) : infi f ≤ f c :=
-cInf_le H (mem_range_self _)
-
-@[simp] theorem cinfi_const [hι : nonempty ι] {a : α} : (⨅ b:ι, a) = a :=
-by rw [infi, range_const, cInf_singleton]
+@le_csupr (order_dual α) _ _ _ H c
 
 @[simp] theorem csupr_const [hι : nonempty ι] {a : α} : (⨆ b:ι, a) = a :=
 by rw [supr, range_const, cSup_singleton]
 
-theorem infi_unique [unique ι] {s : ι → α} : (⨅ i, s i) = s (default ι) :=
-have ∀ i, s i = s (default ι) := λ i, congr_arg s (unique.eq_default i),
-by simp only [this, cinfi_const]
+@[simp] theorem cinfi_const [hι : nonempty ι] {a : α} : (⨅ b:ι, a) = a :=
+@csupr_const (order_dual α) _ _ _ _
 
 theorem supr_unique [unique ι] {s : ι → α} : (⨆ i, s i) = s (default ι) :=
 have ∀ i, s i = s (default ι) := λ i, congr_arg s (unique.eq_default i),
 by simp only [this, csupr_const]
 
-@[simp] theorem infi_unit {f : unit → α} : (⨅ x, f x) = f () :=
-by { convert infi_unique, apply_instance }
+theorem infi_unique [unique ι] {s : ι → α} : (⨅ i, s i) = s (default ι) :=
+@supr_unique (order_dual α) _ _ _ _
 
 @[simp] theorem supr_unit {f : unit → α} : (⨆ x, f x) = f () :=
 by { convert supr_unique, apply_instance }
+
+@[simp] theorem infi_unit {f : unit → α} : (⨅ x, f x) = f () :=
+@supr_unit (order_dual α) _ _
 
 /-- Nested intervals lemma: if `f` is a monotonically increasing sequence, `g` is a monotonically
 decreasing sequence, and `f n ≤ g n` for all `n`, then `⨆ n, f n` belongs to all the intervals
@@ -443,10 +440,7 @@ let ⟨_, ⟨i, rfl⟩, h⟩ := exists_lt_of_lt_cSup (range_nonempty f) h in ⟨
 /--When Inf s < b, there is an element a in s with a < b, if s is nonempty and the order is
 a linear order.-/
 lemma exists_lt_of_cInf_lt (hs : s.nonempty) (hb : Inf s < b) : ∃a∈s, a < b :=
-begin
-  classical, contrapose! hb,
-  exact le_cInf hs hb
-end
+@exists_lt_of_lt_cSup (order_dual α) _ _ _ hs hb
 
 /--
 Indexed version of the above lemma `exists_lt_of_cInf_lt`
@@ -454,7 +448,7 @@ When `infi f < a`, there is an element `i` such that `f i < a`.
 -/
 lemma exists_lt_of_cinfi_lt [nonempty ι] {f : ι → α} (h : infi f < a) :
   (∃i, f i < a) :=
-let ⟨_, ⟨i, rfl⟩, h⟩ := exists_lt_of_cInf_lt (range_nonempty f) h in ⟨i, h⟩
+@exists_lt_of_lt_csupr (order_dual α) _ _ _ _ _ h
 
 /--Introduction rule to prove that b is the supremum of s: it suffices to check that
 1) b is an upper bound
@@ -715,24 +709,6 @@ noncomputable instance : complete_linear_order enat :=
 
 end enat
 
-section order_dual
-
-instance (α : Type*) [conditionally_complete_lattice α] :
-  conditionally_complete_lattice (order_dual α) :=
-{ le_cSup := @cInf_le α _,
-  cSup_le := @le_cInf α _,
-  le_cInf := @cSup_le α _,
-  cInf_le := @le_cSup α _,
-  ..order_dual.has_Inf α,
-  ..order_dual.has_Sup α,
-  ..order_dual.lattice α }
-
-instance (α : Type*) [conditionally_complete_linear_order α] :
-  conditionally_complete_linear_order (order_dual α) :=
-{ ..order_dual.conditionally_complete_lattice α,
-  ..order_dual.linear_order α }
-
-end order_dual
 
 namespace monotone
 variables [preorder α] [conditionally_complete_lattice β] {f : α → β} (h_mono : monotone f)


### PR DESCRIPTION
Even in the places where this doesn't result in a shorter proof, it makes it obvious that the `inf` lemmas have a matching `sup` lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
