### PR TITLE
[Merged by Bors] - fix(algebra): change local transparency to semireducible

### DIFF
--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -52,10 +52,10 @@ let ⟨x, y, h⟩ := exists_pair_ne α in nontrivial_of_ne (op x) (op y) (op_inj
 
 section
 local attribute [semireducible] opposite
-@[simp] lemma unop_eq_zero_iff [has_zero α] (a : αᵒᵖ) : a.unop = (0 : α) ↔ a = (0 : αᵒᵖ) :=
+@[simp] lemma unop_eq_zero_iff {α} [has_zero α] (a : αᵒᵖ) : a.unop = (0 : α) ↔ a = (0 : αᵒᵖ) :=
 iff.refl _
 
-@[simp] lemma op_eq_zero_iff [has_zero α] (a : α) : op a = (0 : αᵒᵖ) ↔ a = (0 : α) :=
+@[simp] lemma op_eq_zero_iff {α} [has_zero α] (a : α) : op a = (0 : αᵒᵖ) ↔ a = (0 : α) :=
 iff.refl _
 end
 
@@ -105,10 +105,10 @@ instance [has_one α] : has_one (opposite α) :=
 
 section
 local attribute [semireducible] opposite
-@[simp] lemma unop_eq_one_iff [has_one α] (a : αᵒᵖ) : a.unop = 1 ↔ a = 1 :=
+@[simp] lemma unop_eq_one_iff {α} [has_one α] (a : αᵒᵖ) : a.unop = 1 ↔ a = 1 :=
 iff.refl _
 
-@[simp] lemma op_eq_one_iff [has_one α] (a : α) : op a = 1 ↔ a = 1 :=
+@[simp] lemma op_eq_one_iff {α} [has_one α] (a : α) : op a = 1 ↔ a = 1 :=
 iff.refl _
 end
 

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -51,7 +51,7 @@ instance [nontrivial α] : nontrivial (opposite α) :=
 let ⟨x, y, h⟩ := exists_pair_ne α in nontrivial_of_ne (op x) (op y) (op_injective.ne h)
 
 section
-local attribute [reducible] opposite
+local attribute [semireducible] opposite
 @[simp] lemma unop_eq_zero_iff [has_zero α] (a : αᵒᵖ) : a.unop = (0 : α) ↔ a = (0 : αᵒᵖ) :=
 iff.refl _
 
@@ -104,7 +104,7 @@ instance [has_one α] : has_one (opposite α) :=
 { one := op 1 }
 
 section
-local attribute [reducible] opposite
+local attribute [semireducible] opposite
 @[simp] lemma unop_eq_one_iff [has_one α] (a : αᵒᵖ) : a.unop = 1 ↔ a = 1 :=
 iff.refl _
 

--- a/src/algebra/ordered_monoid.lean
+++ b/src/algebra/ordered_monoid.lean
@@ -340,7 +340,7 @@ end has_one
 instance [has_add α] : has_add (with_top α) :=
 ⟨λ o₁ o₂, o₁.bind (λ a, o₂.map (λ b, a + b))⟩
 
-local attribute [reducible] with_zero
+local attribute [semireducible] with_zero
 
 instance [add_semigroup α] : add_semigroup (with_top α) :=
 { add := (+),
@@ -749,7 +749,7 @@ lemma with_bot.add_lt_add_iff_left :
     { norm_cast, exact add_lt_add_iff_left _ }
   end
 
-local attribute [reducible] with_zero
+local attribute [semireducible] with_zero
 
 lemma with_top.add_lt_add_iff_right
   {a b c : with_top α} : a < ⊤ → (c + a < b + a ↔ c < b) :=

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -113,7 +113,7 @@ section roots
 
 open multiset
 
-local attribute [reducible] with_zero
+local attribute [semireducible] with_zero
 
 lemma degree_eq_zero_of_is_unit (h : is_unit p) : degree p = 0 :=
 let ⟨q, hq⟩ := is_unit_iff_dvd_one.1 h in


### PR DESCRIPTION
* When a type is `[irreducible]` it should locally be made `[semireducible]` and (almost) never `[reducible]`. 
* If it is made `[reducible]`, type-class inference will unfold this definition, and will apply instances that would not type-check when the definition is `[irreducible]`

---

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.280.20.3A.20.CE.B1.E1.B5.92.E1.B5.96.29.20.3D.20.280.20.3A.20.CE.B1.E1.B5.92.E1.B5.96.29)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
