### PR TITLE
[Merged by Bors] - chore(logic/unique): a true prop is unique

### DIFF
--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -57,7 +57,10 @@ instance punit.unique : unique punit.{u} :=
 { default := punit.star,
   uniq := λ x, punit_eq x _ }
 
-instance : unique true := { default := trivial, uniq := λ x, rfl }
+def unique_prop {p : Prop} (h : p) : unique p :=
+{ default := h, uniq := λ x, rfl }
+
+instance : unique true := unique_prop trivial
 
 lemma fin.eq_zero : ∀ n : fin 1, n = 0
 | ⟨n, hn⟩ := fin.eq_of_veq (nat.eq_zero_of_le_zero (nat.le_of_lt_succ hn))

--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -57,6 +57,7 @@ instance punit.unique : unique punit.{u} :=
 { default := punit.star,
   uniq := λ x, punit_eq x _ }
 
+/-- Every provable proposition is unique, as all proofs are equal. -/
 def unique_prop {p : Prop} (h : p) : unique p :=
 { default := h, uniq := λ x, rfl }
 


### PR DESCRIPTION
I found myself needing to construct this instance by hand somewhere; since we already need it to construct `unique true`, we may as well make a def.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
