### PR TITLE
[Merged by Bors] - feat(order/conditionally_complete_lattice): add lemmas

### DIFF
--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -167,8 +167,14 @@ le_antisymm
   (finset.sup_le $ assume a ha, le_supr_of_le a $ le_supr _ ha)
   (supr_le $ assume a, supr_le $ assume ha, le_sup ha)
 
-lemma sup_eq_Sup [complete_lattice α] (s : finset α) : s.sup id = Sup s :=
+lemma sup_id_eq_Sup [complete_lattice α] (s : finset α) : s.sup id = Sup s :=
 by simp [Sup_eq_supr, sup_eq_supr]
+
+lemma sup_eq_Sup_image [complete_lattice β] (s : finset α) (f : α → β) : s.sup f = Sup (f '' s) :=
+begin
+  classical,
+  rw [←finset.coe_image, ←sup_id_eq_Sup, sup_image, function.comp.left_id],
+end
 
 /-! ### inf -/
 section inf
@@ -262,8 +268,11 @@ end inf
 lemma inf_eq_infi [complete_lattice β] (s : finset α) (f : α → β) : s.inf f = (⨅a∈s, f a) :=
 @sup_eq_supr _ (order_dual β) _ _ _
 
-lemma inf_eq_Inf [complete_lattice α] (s : finset α) : s.inf id = Inf s :=
-by simp [Inf_eq_infi, inf_eq_infi]
+lemma inf_id_eq_Inf [complete_lattice α] (s : finset α) : s.inf id = Inf s :=
+@sup_id_eq_Sup (order_dual α) _ _
+
+lemma inf_eq_Inf_image [complete_lattice β] (s : finset α) (f : α → β) : s.inf f = Inf (f '' s) :=
+@sup_eq_Sup_image _ (order_dual β) _ _ _
 
 section sup'
 variables [semilattice_sup α]

--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -57,7 +57,10 @@ instance punit.unique : unique punit.{u} :=
 { default := punit.star,
   uniq := λ x, punit_eq x _ }
 
-instance : unique true := { default := trivial, uniq := λ x, rfl }
+def unique_prop {p : Prop} (h : p) : unique p :=
+{ default := h, uniq := λ x, rfl }
+
+instance : unique true := unique_prop trivial
 
 lemma fin.eq_zero : ∀ n : fin 1, n = 0
 | ⟨n, hn⟩ := fin.eq_of_veq (nat.eq_zero_of_le_zero (nat.le_of_lt_succ hn))

--- a/src/order/compactly_generated.lean
+++ b/src/order/compactly_generated.lean
@@ -167,7 +167,7 @@ begin
     { use insert y t, simp, rw set.insert_subset, exact ⟨hy, ht₁⟩, },
     have hm' : m ≤ (insert y t).sup id, { rw ← ht₂, exact finset.sup_mono (t.subset_insert y), },
     rw ← hm _ hy' hm', simp, },
-  { rw [← ht₂, finset.sup_eq_Sup], exact Sup_le_Sup ht₁, },
+  { rw [← ht₂, finset.sup_id_eq_Sup], exact Sup_le_Sup ht₁, },
 end
 
 lemma is_Sup_finite_compact.is_sup_closed_compact (h : is_Sup_finite_compact α) :
@@ -298,7 +298,8 @@ le_antisymm (begin
   rw le_inf_iff at hcinf,
   rcases hc s hcinf.2 with ⟨t, ht1, ht2⟩,
   exact (le_inf hcinf.1 ht2).trans (le_bsupr t ht1),
-end) (supr_le $ λ t, supr_le $ λ h, inf_le_inf_left _ ((finset.sup_eq_Sup t).symm ▸ (Sup_le_Sup h)))
+end)
+  (supr_le $ λ t, supr_le $ λ h, inf_le_inf_left _ ((finset.sup_id_eq_Sup t).symm ▸ (Sup_le_Sup h)))
 
 theorem complete_lattice.set_independent_iff_finite {s : set α} :
   complete_lattice.set_independent s ↔
@@ -306,7 +307,7 @@ theorem complete_lattice.set_independent_iff_finite {s : set α} :
 ⟨λ hs t ht, hs.mono ht, λ h a ha, begin
   rw [disjoint_iff, inf_Sup_eq_supr_inf_sup_finset, supr_eq_bot],
   intro t,
-  rw [supr_eq_bot, finset.sup_eq_Sup],
+  rw [supr_eq_bot, finset.sup_id_eq_Sup],
   intro ht,
   classical,
   have h' := (h (insert a t) _ (t.mem_insert_self a)).eq_bot,

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -749,11 +749,11 @@ le_antisymm le_top (le_infi $ assume i, false.elim i)
 @[simp] theorem supr_false {s : false → α} : supr s = ⊥ :=
 le_antisymm (supr_le $ assume i, false.elim i) bot_le
 
-@[simp] theorem infi_true {s : true → α} : infi s = s trivial :=
-le_antisymm (infi_le _ _) (le_infi $ assume ⟨⟩, le_refl _)
+theorem infi_true {s : true → α} : infi s = s trivial :=
+infi_pos trivial
 
-@[simp] theorem supr_true {s : true → α} : supr s = s trivial :=
-le_antisymm (supr_le $ assume ⟨⟩, le_refl _) (le_supr _ _)
+theorem supr_true {s : true → α} : supr s = s trivial :=
+supr_pos trivial
 
 @[simp] theorem infi_exists {p : ι → Prop} {f : Exists p → α} :
   (⨅ x, f x) = (⨅ i, ⨅ h:p i, f ⟨i, h⟩) :=

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -351,6 +351,9 @@ cSup_le (range_nonempty f) (by rwa forall_range_iff)
 lemma le_csupr {f : ι → α} (H : bdd_above (range f)) (c : ι) : f c ≤ supr f :=
 le_cSup H (mem_range_self _)
 
+lemma le_csupr_of_le {f : ι → α} (H : bdd_above (range f)) (c : ι) (h : a ≤ f c) : a ≤ supr f :=
+le_trans h (le_csupr H c)
+
 /--The indexed infimum of two functions are comparable if the functions are pointwise comparable-/
 lemma cinfi_le_cinfi {f g : ι → α} (B : bdd_below (range f)) (H : ∀x, f x ≤ g x) :
   infi f ≤ infi g :=
@@ -363,6 +366,9 @@ lemma le_cinfi [nonempty ι] {f : ι → α} {c : α} (H : ∀x, c ≤ f x) : c 
 /--The indexed infimum of a function is bounded above by the value taken at one point-/
 lemma cinfi_le {f : ι → α} (H : bdd_below (range f)) (c : ι) : infi f ≤ f c :=
 @le_csupr (order_dual α) _ _ _ H c
+
+lemma cinfi_le_of_le {f : ι → α} (H : bdd_below (range f)) (c : ι) (h : f c ≤ a) : infi f ≤ a :=
+@le_csupr_of_le (order_dual α) _ _ _ _ H c h
 
 @[simp] theorem csupr_const [hι : nonempty ι] {a : α} : (⨆ b:ι, a) = a :=
 by rw [supr, range_const, cSup_singleton]

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -762,6 +762,42 @@ lemma le_cInf_image {s : set α} (hs : s.nonempty) {B : α} (hB: B ∈ lower_bou
 
 end monotone
 
+/-!
+### Relation between `Sup` / `Inf` and `finset.sup'` / `finset.inf'`
+
+Like the `Sup` of a `conditionally_complete_lattice`, `finset.sup'` also requires the set to be
+non-empty. As a result, we can translate between the two.
+-/
+
+namespace finset
+
+lemma sup'_eq_cSup_image [conditionally_complete_lattice β] (s : finset α) (H) (f : α → β) :
+  s.sup' H f = Sup (f '' s) :=
+begin
+  apply le_antisymm,
+  { refine (finset.sup'_le _ _ $ λ a ha, _),
+    refine le_cSup ⟨s.sup' H f, _⟩ ⟨a, ha, rfl⟩,
+    rintros i ⟨j, hj, rfl⟩,
+    exact finset.le_sup' _ hj },
+  { apply cSup_le ((coe_nonempty.mpr H).image _),
+    rintros _ ⟨a, ha, rfl⟩,
+    exact finset.le_sup' _ ha, }
+end
+
+lemma inf'_eq_cInf_image [conditionally_complete_lattice β] (s : finset α) (H) (f : α → β) :
+  s.inf' H f = Inf (f '' s) :=
+@sup'_eq_cSup_image _ (order_dual β) _ _ _ _
+
+lemma sup'_id_eq_cSup [conditionally_complete_lattice α] (s : finset α) (H) :
+  s.sup' H id = Sup s :=
+by rw [sup'_eq_cSup_image s H, set.image_id]
+
+lemma inf'_id_eq_cInf [conditionally_complete_lattice α] (s : finset α) (H) :
+  s.inf' H id = Inf s :=
+@sup'_id_eq_cSup (order_dual α) _ _ _
+
+end finset
+
 section with_top_bot
 
 /-!

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -53,6 +53,14 @@ noncomputable instance {α : Type*} [has_Sup α] : has_Sup (with_bot α) :=
 noncomputable instance {α : Type*} [preorder α] [has_Inf α] : has_Inf (with_bot α) :=
 ⟨(@with_top.has_Sup (order_dual α) _ _).Sup⟩
 
+@[simp]
+theorem with_top.cInf_empty {α : Type*} [has_Inf α] : Inf (∅ : set (with_top α)) = ⊤ :=
+if_pos $ set.empty_subset _
+
+@[simp]
+theorem with_bot.cSup_empty {α : Type*} [has_Sup α] : Sup (∅ : set (with_bot α)) = ⊥ :=
+if_pos $ set.empty_subset _
+
 end -- section
 
 /-- A conditionally complete lattice is a lattice in which
@@ -784,13 +792,6 @@ noncomputable instance with_top.with_bot.bounded_lattice {α : Type*}
 { ..with_top.order_bot,
   ..with_top.order_top,
   ..conditionally_complete_lattice.to_lattice _ }
-
-theorem with_bot.cSup_empty {α : Type*} [conditionally_complete_lattice α] :
-  Sup (∅ : set (with_bot α)) = ⊥ :=
-begin
-  show ite _ _ _ = ⊥,
-  split_ifs; finish,
-end
 
 noncomputable instance with_top.with_bot.complete_lattice {α : Type*}
   [conditionally_complete_lattice α] : complete_lattice (with_top (with_bot α)) :=

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -389,6 +389,12 @@ by { convert supr_unique, apply_instance }
 @[simp] theorem infi_unit {f : unit → α} : (⨅ x, f x) = f () :=
 @supr_unit (order_dual α) _ _
 
+@[simp] lemma csupr_pos {p : Prop} {f : p → α} (hp : p) : (⨆ h : p, f h) = f hp :=
+by haveI := unique_prop hp; exact supr_unique
+
+@[simp] lemma cinfi_pos {p : Prop} {f : p → α} (hp : p) : (⨅ h : p, f h) = f hp :=
+@csupr_pos (order_dual α) _ _ _ hp
+
 /-- Nested intervals lemma: if `f` is a monotonically increasing sequence, `g` is a monotonically
 decreasing sequence, and `f n ≤ g n` for all `n`, then `⨆ n, f n` belongs to all the intervals
 `[f n, g n]`. -/
@@ -477,8 +483,16 @@ end conditionally_complete_linear_order
 
 section conditionally_complete_linear_order_bot
 
-lemma cSup_empty [conditionally_complete_linear_order_bot α] : (Sup ∅ : α) = ⊥ :=
+variables [conditionally_complete_linear_order_bot α]
+
+lemma cSup_empty : (Sup ∅ : α) = ⊥ :=
 conditionally_complete_linear_order_bot.cSup_empty
+
+@[simp] lemma csupr_neg {p : Prop} {f : p → α} (hp : ¬ p) : (⨆ h : p, f h) = ⊥ :=
+begin
+  have : ¬nonempty p := by simp [hp],
+  rw [supr, range_eq_empty.mpr this, cSup_empty],
+end
 
 end conditionally_complete_linear_order_bot
 

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -310,7 +310,7 @@ begin
     obtain ⟨u, ⟨huspan, husup⟩⟩ := h (sp '' ↑s) (le_of_eq sSup),
     have ssup : s = u.sup id,
     { suffices : u.sup id ≤ s, from le_antisymm husup this,
-      rw [sSup, finset.sup_eq_Sup], exact Sup_le_Sup huspan, },
+      rw [sSup, finset.sup_id_eq_Sup], exact Sup_le_Sup huspan, },
     obtain ⟨t, ⟨hts, rfl⟩⟩ := finset.subset_image_iff.mp huspan,
     rw [finset.sup_finset_image, function.comp.left_id, finset.sup_eq_supr, supr_rw,
       ←span_eq_supr_of_singleton_spans, eq_comm] at ssup,


### PR DESCRIPTION
These lemmas names match the version that already exist without the `c` prefix.

This also renames `finset.sup_eq_Sup` to `finset.sup_id_eq_Sup`, and introduces a new `finset.sup_eq_Sup_image`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:

- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #7688

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
