### PR TITLE
[Merged by Bors] - feat(tactic/lint): add linter that type-checks statements 

### DIFF
--- a/src/algebra/category/Mon/adjunctions.lean
+++ b/src/algebra/category/Mon/adjunctions.lean
@@ -23,10 +23,6 @@ universe u
 
 open category_theory
 
--- typeclass inference cannot equate `with_one.monoid.to_mul_one_class` with
--- `with_one.mul_one_class` without this.
-local attribute [semireducible] with_one with_zero
-
 /-- The functor of adjoining a neutral element `one` to a semigroup.
  -/
 @[to_additive "The functor of adjoining a neutral element `zero` to a semigroup", simps]

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -93,15 +93,24 @@ instance [semigroup α] : monoid (with_one α) :=
 { mul_assoc := (option.lift_or_get_assoc _).1,
   ..with_one.mul_one_class }
 
+example [semigroup α] :
+  @monoid.to_mul_one_class _ (@with_one.monoid α _) = @with_one.mul_one_class α _ := rfl
+
 @[to_additive]
 instance [comm_semigroup α] : comm_monoid (with_one α) :=
 { mul_comm := (option.lift_or_get_comm _).1,
   ..with_one.monoid }
 
+section
+-- workaround: we make `with_one`/`with_zero` irreducible for this definition, otherwise `simps`
+-- will unfold it in the statement of the lemma it generates.
+local attribute [irreducible] with_one with_zero
 /-- `coe` as a bundled morphism -/
 @[to_additive "`coe` as a bundled morphism", simps apply]
 def coe_mul_hom [has_mul α] : mul_hom α (with_one α) :=
 { to_fun := coe, map_mul' := λ x y, rfl }
+
+end
 
 section lift
 

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -97,6 +97,7 @@ instance [semigroup α] : monoid (with_one α) :=
 instance [comm_semigroup α] : comm_monoid (with_one α) :=
 { mul_comm := (option.lift_or_get_comm _).1,
   ..with_one.monoid }
+
 /-- `coe` as a bundled morphism -/
 @[to_additive "`coe` as a bundled morphism", simps apply]
 def coe_mul_hom [has_mul α] : mul_hom α (with_one α) :=

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -34,6 +34,9 @@ instance : monad with_one := option.monad
 instance : has_one (with_one α) := ⟨none⟩
 
 @[to_additive]
+instance [has_mul α] : has_mul (with_one α) := ⟨option.lift_or_get (*)⟩
+
+@[to_additive]
 instance : inhabited (with_one α) := ⟨1⟩
 
 @[to_additive]
@@ -75,12 +78,15 @@ protected lemma cases_on {P : with_one α → Prop} :
   ∀ (x : with_one α), P 1 → (∀ a : α, P a) → P x :=
 option.cases_on
 
+-- the `show` statements in the proofs are important, because otherwise the generated lemmas
+-- `with_one.mul_one_class._proof_{1,2}` have an ill-typed statement after `with_one` is made
+-- irreducible.
 @[to_additive]
 instance [has_mul α] : mul_one_class (with_one α) :=
-{ mul := option.lift_or_get (*),
+{ mul := (*),
   one := (1),
-  one_mul   := (option.lift_or_get_is_left_id _).1,
-  mul_one   := (option.lift_or_get_is_right_id _).1 }
+  one_mul   := show ∀ x : with_one α, 1 * x = x, from (option.lift_or_get_is_left_id _).1,
+  mul_one   := show ∀ x : with_one α, x * 1 = x, from (option.lift_or_get_is_right_id _).1 }
 
 @[to_additive]
 instance [semigroup α] : monoid (with_one α) :=
@@ -91,7 +97,6 @@ instance [semigroup α] : monoid (with_one α) :=
 instance [comm_semigroup α] : comm_monoid (with_one α) :=
 { mul_comm := (option.lift_or_get_comm _).1,
   ..with_one.monoid }
-
 /-- `coe` as a bundled morphism -/
 @[to_additive "`coe` as a bundled morphism", simps apply]
 def coe_mul_hom [has_mul α] : mul_hom α (with_one α) :=

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -264,8 +264,6 @@ end
 section
 variables {F G : Cᵒᵖ ⥤ D}
 
-local attribute [semireducible] quiver.opposite
-
 /--
 Given a natural transformation `α : F ⟶ G`, for `F G : Cᵒᵖ ⥤ D`,
 taking `op` of each component gives a natural transformation `G.right_op ⟶ F.right_op`.
@@ -275,8 +273,7 @@ taking `op` of each component gives a natural transformation `G.right_op ⟶ F.r
   naturality' := begin
     intros X Y f,
     dsimp,
-    erw α.naturality,
-    refl,
+    simp_rw [← op_comp, α.naturality]
   end }
 
 /--

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -198,19 +198,17 @@ variables {D : Type u₂} [category.{v₂} D]
 section
 variables {F G : C ⥤ D}
 
-local attribute [semireducible] quiver.opposite
-
 /-- The opposite of a natural transformation. -/
 @[simps] protected def op (α : F ⟶ G) : G.op ⟶ F.op :=
 { app         := λ X, (α.app (unop X)).op,
-  naturality' := begin tidy, erw α.naturality, refl, end }
+  naturality' := begin tidy, simp_rw [← op_comp, α.naturality] end }
 
 @[simp] lemma op_id (F : C ⥤ D) : nat_trans.op (𝟙 F) = 𝟙 (F.op) := rfl
 
 /-- The "unopposite" of a natural transformation. -/
 @[simps] protected def unop {F G : Cᵒᵖ ⥤ Dᵒᵖ} (α : F ⟶ G) : G.unop ⟶ F.unop :=
 { app         := λ X, (α.app (op X)).unop,
-  naturality' := begin tidy, erw α.naturality, refl, end }
+  naturality' := begin tidy, simp_rw [← unop_comp, α.naturality] end }
 
 @[simp] lemma unop_id (F : Cᵒᵖ ⥤ Dᵒᵖ) : nat_trans.unop (𝟙 F) = 𝟙 (F.unop) := rfl
 
@@ -223,10 +221,9 @@ we can take the "unopposite" of each component obtaining a natural transformatio
   naturality' :=
   begin
     intros X Y f,
-    have := congr_arg quiver.hom.op (α.naturality f.op),
+    have := congr_arg quiver.hom.unop (α.naturality f.op),
     dsimp at this,
-    erw this,
-    refl,
+    rw this,
   end }
 
 @[simp] lemma remove_op_id (F : C ⥤ D) : nat_trans.remove_op (𝟙 F.op) = 𝟙 F := rfl
@@ -235,8 +232,6 @@ end
 
 section
 variables {F G : C ⥤ Dᵒᵖ}
-
-local attribute [semireducible] quiver.opposite
 
 /--
 Given a natural transformation `α : F ⟶ G`, for `F G : C ⥤ Dᵒᵖ`,
@@ -247,8 +242,7 @@ taking `unop` of each component gives a natural transformation `G.left_op ⟶ F.
   naturality' := begin
     intros X Y f,
     dsimp,
-    erw α.naturality,
-    refl,
+    simp_rw [← unop_comp, α.naturality]
   end }
 
 /--
@@ -430,7 +424,7 @@ namespace functor
 variables (C)
 variables (D : Type u₂) [category.{v₂} D]
 
-/-- 
+/--
 The equivalence of functor categories induced by `op` and `unop`.
 -/
 @[simps]

--- a/src/tactic/lint/default.lean
+++ b/src/tactic/lint/default.lean
@@ -44,6 +44,7 @@ The following linters are run by default:
 17. `decidable_classical` checks for `decidable` hypotheses that are used in the proof of a proposition but not
     in the statement, and could be removed using `classical`. Theorems in the `decidable` namespace are exempt.
 18. `has_coe_to_fun` checks that every type that coerces to a function has a direct `has_coe_to_fun` instance.
+19. `check_type` checks that the statement of a declaration is well-typed.
 
 Another linter, `doc_blame_thm`, checks for missing doc strings on lemmas and theorems.
 This is not run by default.

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -15,6 +15,7 @@ This file defines several small linters:
   - `doc_blame` checks that every definition has a documentation string
   - `doc_blame_thm` checks that every theorem has a documentation string (not enabled by default)
   - `def_lemma` checks that a declaration is a lemma iff its type is a proposition.
+  - `check_type` checks that the statement of a declaration is well-typed
 -/
 
 open tactic expr
@@ -243,3 +244,20 @@ has been used. -/
   errors_found := "INCORRECT DEF/LEMMA" }
 
 attribute [nolint def_lemma] classical.dec classical.dec_pred classical.dec_rel classical.dec_eq
+
+/-- Checks whether the statement of a declaration is well-typed. -/
+meta def check_type (d : declaration) : tactic (option string) :=
+(type_check d.type >> return none) <|> return "The statement doesn't type-check"
+
+/-- A linter for missing checking whether statements of declarations are well-typed. -/
+@[linter]
+meta def linter.check_type : linter :=
+{ test := check_type,
+  auto_decls := ff,
+  no_errors_found :=
+    "The statements of all declarations type-check with default reducibility settings",
+  errors_found := "THE STATEMENTS OF THE FOLLOWING DECLARATIONS DO NOT TYPE-CHECK.
+Some definitions in the statement are marked @[irreducible], which means that the statement is " ++
+"now ill-formed. It is likely that these definitions were locally marked @[reducible], and that " ++
+"type-class instances were applied that don't apply when the definitions are @[irreducible].",
+  is_fast := tt }

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -258,6 +258,6 @@ meta def linter.check_type : linter :=
     "The statements of all declarations type-check with default reducibility settings",
   errors_found := "THE STATEMENTS OF THE FOLLOWING DECLARATIONS DO NOT TYPE-CHECK.
 Some definitions in the statement are marked @[irreducible], which means that the statement is " ++
-"now ill-formed. It is likely that these definitions were locally marked @[reducible], and that " ++
-"type-class instances were applied that don't apply when the definitions are @[irreducible].",
+"now ill-formed. It is likely that these definitions were locally marked as @[reducible] or " ++
+"@[semireducible]. This can especially cause problems with type class inference or @[simps]",
   is_fast := tt }

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -15,7 +15,7 @@ This file defines several small linters:
   - `doc_blame` checks that every definition has a documentation string
   - `doc_blame_thm` checks that every theorem has a documentation string (not enabled by default)
   - `def_lemma` checks that a declaration is a lemma iff its type is a proposition.
-  - `check_type` checks that the statement of a declaration is well-typed
+  - `check_type` checks that the statement of a declaration is well-typed.
 -/
 
 open tactic expr


### PR DESCRIPTION
* Add linter that type-checks the statements of all declarations with the default reducibility settings. A statement might not type-check if locally a declaration was made not `@[irreducible]` while globally it is.
* Fix an issue where  `with_one.monoid.to_mul_one_class` did not unify with `with_one.mul_one_class`.
* Fix some proofs in `category_theory.opposites` so that they work while keeping `quiver.opposite` irreducible.

---

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.280.20.3A.20.CE.B1.E1.B5.92.E1.B5.96.29.20.3D.20.280.20.3A.20.CE.B1.E1.B5.92.E1.B5.96.29)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
