### PR TITLE
feat(data/list/forall2): add two lemmas about forall₂ and reverse

### DIFF
--- a/src/data/list/forall2.lean
+++ b/src/data/list/forall2.lean
@@ -173,10 +173,11 @@ lemma rel_reverse : (forall₂ r ⇒ forall₂ r) reverse reverse
   by simp only [reverse_cons];
   from rel_append (rel_reverse h₂) (forall₂.cons h₁ forall₂.nil)
 
-lemma forall₂_iff_reverse {l₁ l₂} : forall₂ r l₁ l₂ ↔ forall₂ r l₁.reverse l₂.reverse :=
+@[simp]
+lemma forall₂_reverse_iff {l₁ l₂} : forall₂ r l₁.reverse l₂.reverse ↔ forall₂ r l₁ l₂ :=
 iff.intro
-  (assume h, rel_reverse h)
   (assume h, by rw [← reverse_reverse l₁, ← reverse_reverse l₂]; from rel_reverse h)
+  (assume h, rel_reverse h)
 
 lemma rel_join : (forall₂ (forall₂ r) ⇒ forall₂ r) join join
 | [] [] forall₂.nil := forall₂.nil

--- a/src/data/list/forall2.lean
+++ b/src/data/list/forall2.lean
@@ -167,6 +167,17 @@ lemma rel_append : (forall₂ r ⇒ forall₂ r ⇒ forall₂ r) append append
 | [] [] h l₁ l₂ hl := hl
 | (a::as) (b::bs) (forall₂.cons h₁ h₂) l₁ l₂ hl := forall₂.cons h₁ (rel_append h₂ hl)
 
+lemma rel_reverse : (forall₂ r ⇒ forall₂ r) reverse reverse
+| [] [] forall₂.nil := forall₂.nil
+| (a::as) (b::bs) (forall₂.cons h₁ h₂) :=
+  by simp only [reverse_cons];
+  from rel_append (rel_reverse h₂) (forall₂.cons h₁ forall₂.nil)
+
+lemma forall₂_iff_reverse {l₁ l₂} : forall₂ r l₁ l₂ ↔ forall₂ r l₁.reverse l₂.reverse :=
+iff.intro
+  (assume h, rel_reverse h)
+  (assume h, by rw [← reverse_reverse l₁, ← reverse_reverse l₂]; from rel_reverse h)
+
 lemma rel_join : (forall₂ (forall₂ r) ⇒ forall₂ r) join join
 | [] [] forall₂.nil := forall₂.nil
 | (a::as) (b::bs) (forall₂.cons h₁ h₂) := rel_append h₁ (rel_join h₂)


### PR DESCRIPTION
rel_reverse shows that forall₂ is preserved across reversed lists,
forall₂_iff_reverse uses rel_reverse to show that it is preserved in
both directions.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
