### PR TITLE
fix(tactic/induction): fix generalisation with complex major premise

### DIFF
--- a/src/tactic/induction.lean
+++ b/src/tactic/induction.lean
@@ -1289,8 +1289,12 @@ remember the value of the major premise.
 meta def eliminate_expr (generate_induction_hyps : bool) (major_premise : expr)
   (eq_name : option name := none) (gm := generalization_mode.generalize_all_except [])
   (with_patterns : list with_pattern := []) : tactic unit := do
-  major_premise_revdeps ← reverse_dependencies_of_hyps [major_premise],
-  num_reverted ← unfreezing (revert_lst major_premise_revdeps),
+  ctx ← local_context,
+  revdeps ← ctx.mfilter $ λ h, do {
+    H ← infer_type h,
+    kdepends_on H major_premise
+  },
+  num_reverted ← revert_lst revdeps,
   hyp ← match eq_name with
       | some h := do
           x ← get_unused_name `x,

--- a/test/induction.lean
+++ b/test/induction.lean
@@ -667,20 +667,22 @@ end
 
 end topological_space_tests
 
--- When using `cases' t` or `induction' t`, where `t` is a complex term,
--- the context must be generalised over `t`.
+-- When using `cases' t` or `induction' t`, where `t` is a complex term, the
+-- context must be generalised over `t`.
 example {n m : ℕ} (h : n + 1 = m) : n + 1 = m :=
 begin
   cases' n + 1,
-  { exact h },
-  { exact h }
-end
-
-example {n m : ℕ} (h : n + 1 = m) : n + 1 = m :=
-begin
-  induction' n + 1,
-  { exact h },
-  { exact h }
+  { guard_hyp n : ℕ,
+    guard_hyp m : ℕ,
+    guard_hyp h : nat.zero = m,
+    guard_target nat.zero = m,
+    exact h },
+  { guard_hyp n : ℕ,
+    guard_hyp m : ℕ,
+    guard_hyp x : ℕ,
+    guard_hyp h : x.succ = m,
+    guard_target x.succ = m,
+    exact h }
 end
 
 --------------------------------------------------------------------------------

--- a/test/induction.lean
+++ b/test/induction.lean
@@ -667,6 +667,22 @@ end
 
 end topological_space_tests
 
+-- When using `cases' t` or `induction' t`, where `t` is a complex term,
+-- the context must be generalised over `t`.
+example {n m : ℕ} (h : n + 1 = m) : n + 1 = m :=
+begin
+  cases' n + 1,
+  { exact h },
+  { exact h }
+end
+
+example {n m : ℕ} (h : n + 1 = m) : n + 1 = m :=
+begin
+  induction' n + 1,
+  { exact h },
+  { exact h }
+end
+
 --------------------------------------------------------------------------------
 -- Logical Verification Use Cases
 --------------------------------------------------------------------------------


### PR DESCRIPTION
The induction' and cases' tactics would previously not generalise the goal
correctly when called with a complex term (i.e. not just a local constant) as
major premise. E.g. the call `cases' (n + 1)` would fail to replace `n + 1` in
the hypothesis `n + 1 = m`, leading to very weird goals.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
