### PR TITLE
[Merged by Bors] - feat(group_theory/subgroup linear_algebra/prod): add ker_prod_map

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -2230,6 +2230,9 @@ set.subset.antisymm (snd_image_prod_subset _ _)
 lemma prod_diff_prod : s.prod t \ s₁.prod t₁ = s.prod (t \ t₁) ∪ (s \ s₁).prod t :=
 by { ext x, by_cases h₁ : x.1 ∈ s₁; by_cases h₂ : x.2 ∈ t₁; simp * }
 
+lemma prod.map_preimage_set_prod (f : α → γ) (g : β → δ) (c : set γ) (d : set δ) :
+  prod.map f g ⁻¹' c.prod d = (f ⁻¹' c).prod (g ⁻¹' d) := rfl
+
 /-- A product set is included in a product set if and only factors are included, or a factor of the
 first set is empty. -/
 lemma prod_subset_prod_iff :

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -2230,7 +2230,7 @@ set.subset.antisymm (snd_image_prod_subset _ _)
 lemma prod_diff_prod : s.prod t \ s₁.prod t₁ = s.prod (t \ t₁) ∪ (s \ s₁).prod t :=
 by { ext x, by_cases h₁ : x.1 ∈ s₁; by_cases h₂ : x.2 ∈ t₁; simp * }
 
-lemma prod.map_preimage_set_prod (f : α → γ) (g : β → δ) (c : set γ) (d : set δ) :
+lemma _root_.prod.map_preimage_set_prod (f : α → γ) (g : β → δ) (c : set γ) (d : set δ) :
   prod.map f g ⁻¹' c.prod d = (f ⁻¹' c).prod (g ⁻¹' d) := rfl
 
 /-- A product set is included in a product set if and only factors are included, or a factor of the

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -2230,9 +2230,6 @@ set.subset.antisymm (snd_image_prod_subset _ _)
 lemma prod_diff_prod : s.prod t \ s₁.prod t₁ = s.prod (t \ t₁) ∪ (s \ s₁).prod t :=
 by { ext x, by_cases h₁ : x.1 ∈ s₁; by_cases h₂ : x.2 ∈ t₁; simp * }
 
-lemma map_preimage_prod (f : α → γ) (g : β → δ) (c : set γ) (d : set δ) :
-  prod.map f g ⁻¹' c.prod d = (f ⁻¹' c).prod (g ⁻¹' d) := rfl
-
 /-- A product set is included in a product set if and only factors are included, or a factor of the
 first set is empty. -/
 lemma prod_subset_prod_iff :

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -2230,7 +2230,7 @@ set.subset.antisymm (snd_image_prod_subset _ _)
 lemma prod_diff_prod : s.prod t \ s₁.prod t₁ = s.prod (t \ t₁) ∪ (s \ s₁).prod t :=
 by { ext x, by_cases h₁ : x.1 ∈ s₁; by_cases h₂ : x.2 ∈ t₁; simp * }
 
-lemma _root_.prod.map_preimage_set_prod (f : α → γ) (g : β → δ) (c : set γ) (d : set δ) :
+lemma map_preimage_prod (f : α → γ) (g : β → δ) (c : set γ) (d : set δ) :
   prod.map f g ⁻¹' c.prod d = (f ⁻¹' c).prod (g ⁻¹' d) := rfl
 
 /-- A product set is included in a product set if and only factors are included, or a factor of the

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1312,14 +1312,14 @@ end
 lemma prod_map_comap_prod {G' : Type*} {N' : Type*} [group G'] [group N']
   (f : G →* N) (g : G' →* N') (S : subgroup N) (S' : subgroup N') :
   (S.prod S').comap (prod_map f g) = (S.comap f).prod (S'.comap g) :=
-set_like.coe_injective $ prod.map_preimage_set_prod f g _ _  -- or even just `set_like.coe_injective rfl`
+set_like.coe_injective $ set.prod.map_preimage_set_prod f g _ _
 
 @[to_additive]
 lemma ker_prod_map {G' : Type*} {N' : Type*} [group G'] [group N'] (f : G →* N) (g : G' →* N') :
   (prod_map f g).ker = f.ker.prod g.ker :=
 begin
   dsimp only [ker],
-  rw [←prod_comap_prod_map, bot_prod_bot],
+  rw [←prod_map_comap_prod, bot_prod_bot],
 end
 
 /-- The subgroup of elements `x : G` such that `f x = g x` -/

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1312,7 +1312,7 @@ end
 lemma prod_map_comap_prod {G' : Type*} {N' : Type*} [group G'] [group N']
   (f : G →* N) (g : G' →* N') (S : subgroup N) (S' : subgroup N') :
   (S.prod S').comap (prod_map f g) = (S.comap f).prod (S'.comap g) :=
-set_like.coe_injective $ set.prod.map_preimage_set_prod f g _ _
+set_like.coe_injective $ set.preimage_prod_map_prod f g _ _
 
 @[to_additive]
 lemma ker_prod_map {G' : Type*} {N' : Type*} [group G'] [group N'] (f : G →* N) (g : G' →* N') :

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1309,15 +1309,17 @@ begin
 end
 
 @[to_additive]
+lemma prod_map_comap_prod {G' : Type*} {N' : Type*} [group G'] [group N']
+  (f : G →* N) (g : G' →* N') (S : subgroup N) (S' : subgroup N') :
+  (S.prod S').comap (prod_map f g) = (S.comap f).prod (S'.comap g) :=
+set_like.coe_injective $ prod.map_preimage_set_prod f g _ _  -- or even just `set_like.coe_injective rfl`
+
+@[to_additive]
 lemma ker_prod_map {G' : Type*} {N' : Type*} [group G'] [group N'] (f : G →* N) (g : G' →* N') :
-  (prod_map f g).ker = prod f.ker g.ker :=
+  (prod_map f g).ker = f.ker.prod g.ker :=
 begin
-  ext x,
-  refine ⟨λ h, _, λ h, _⟩,
-  { rw mem_ker at h,
-    simpa [mem_prod, mem_ker] using h },
-  { rw [mem_prod, mem_ker, mem_ker] at h,
-    simpa [mem_ker] using h }
+  dsimp only [ker],
+  rw [←prod_comap_prod_map, bot_prod_bot],
 end
 
 /-- The subgroup of elements `x : G` such that `f x = g x` -/

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1308,6 +1308,18 @@ begin
   { exact λ h, le_bot_iff.mp (λ x hx, h (hx.trans f.map_one.symm)) },
 end
 
+@[to_additive]
+lemma ker_prod_map {G' : Type*} {N' : Type*} [group G'] [group N'] (f : G →* N) (g : G' →* N') :
+  (prod_map f g).ker = prod f.ker g.ker :=
+begin
+  ext x,
+  refine ⟨λ h, _, λ h, _⟩,
+  { rw mem_ker at h,
+    simpa [mem_prod, mem_ker] using h },
+  { rw [mem_prod, mem_ker, mem_ker] at h,
+    simpa [mem_ker] using h }
+end
+
 /-- The subgroup of elements `x : G` such that `f x = g x` -/
 @[to_additive "The additive subgroup of elements `x : G` such that `f x = g x`"]
 def eq_locus (f g : G →* N) : subgroup G :=

--- a/src/linear_algebra/prod.lean
+++ b/src/linear_algebra/prod.lean
@@ -182,7 +182,7 @@ def prod_map (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₄) : (M × M₂) →�
 lemma prod_map_comap_prod (f : M →ₗ[R] M₂) (g : M₃ →ₗ[R] M₄) (S : submodule R M₂)
   (S' : submodule R M₄) :
   (submodule.prod S S').comap (linear_map.prod_map f g) = (S.comap f).prod (S'.comap g) :=
-set_like.coe_injective $ set.prod.map_preimage_set_prod f g _ _
+set_like.coe_injective $ set.preimage_prod_map_prod f g _ _
 
 lemma ker_prod_map (f : M →ₗ[R] M₂) (g : M₃ →ₗ[R] M₄) :
   (linear_map.prod_map f g).ker = submodule.prod f.ker g.ker :=

--- a/src/linear_algebra/prod.lean
+++ b/src/linear_algebra/prod.lean
@@ -179,15 +179,16 @@ def prod_map (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₄) : (M × M₂) →�
 @[simp] theorem prod_map_apply (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₄) (x) :
   f.prod_map g x = (f x.1, g x.2) := rfl
 
+lemma prod_map_comap_prod (f : M →ₗ[R] M₂) (g : M₃ →ₗ[R] M₄) (S : submodule R M₂)
+  (S' : submodule R M₄) :
+  (submodule.prod S S').comap (linear_map.prod_map f g) = (S.comap f).prod (S'.comap g) :=
+set_like.coe_injective $ set.prod.map_preimage_set_prod f g _ _
+
 lemma ker_prod_map (f : M →ₗ[R] M₂) (g : M₃ →ₗ[R] M₄) :
   (linear_map.prod_map f g).ker = submodule.prod f.ker g.ker :=
 begin
-  ext x,
-  refine ⟨λ h, _, λ h, _⟩,
-  { rw mem_ker at h,
-    simpa [submodule.mem_prod, mem_ker] using h },
-  { rw [submodule.mem_prod, mem_ker, mem_ker] at h,
-    simpa [mem_ker] using h }
+  dsimp only [ker],
+  rw [←prod_map_comap_prod, submodule.prod_bot],
 end
 
 end linear_map

--- a/src/linear_algebra/prod.lean
+++ b/src/linear_algebra/prod.lean
@@ -179,6 +179,17 @@ def prod_map (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₄) : (M × M₂) →�
 @[simp] theorem prod_map_apply (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₄) (x) :
   f.prod_map g x = (f x.1, g x.2) := rfl
 
+lemma ker_prod_map (f : M →ₗ[R] M₂) (g : M₃ →ₗ[R] M₄) :
+  (linear_map.prod_map f g).ker = submodule.prod f.ker g.ker :=
+begin
+  ext x,
+  refine ⟨λ h, _, λ h, _⟩,
+  { rw mem_ker at h,
+    simpa [submodule.mem_prod, mem_ker] using h },
+  { rw [submodule.mem_prod, mem_ker, mem_ker] at h,
+    simpa [mem_ker] using h }
+end
+
 end linear_map
 
 end prod


### PR DESCRIPTION
The kernel of the product of two `group_hom` is the product of the kernels (and similarly for monoids).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
