### PR TITLE
[Merged by Bors] - chore(linear_algebra/finsupp): remove useless lemma

### DIFF
--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -430,14 +430,6 @@ theorem total_unique [unique α] (l : α →₀ R) (v) :
   finsupp.total α M R v l = l (default α) • v (default α) :=
 by rw [← total_single, ← unique_single l]
 
-theorem total_range (h : function.surjective v) : (finsupp.total α M R v).range = ⊤ :=
-begin
-  apply range_eq_top.2,
-  intros x,
-  apply exists.elim (h x),
-  exact λ i hi, ⟨single i 1, by simp [hi]⟩
-end
-
 lemma range_total : (finsupp.total α M R v).range = span R (range v) :=
 begin
   ext x,


### PR DESCRIPTION
The lemma is not used in mathlib, it's mathematically useless (you'd never have a surjective function from an indexing set to a module), and it's badly named, so I propose removing it entirely.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
