### PR TITLE
[Merged by Bors] - chore(data/fintype/basic): `fintype α/β` from `fintype α ⊕ β`

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -765,13 +765,13 @@ instance (α : Type u) (β : Type v) [fintype α] [fintype β] : fintype (α ⊕
 
 /-- Given that `α ⊕ β` is a fintype, `α` is also a fintype. This is non-computable as it uses
 that `sum.inl` is an injection, but there's no clear inverse if `α` is empty. -/
-noncomputable def fintype.sum_left {α β} [fintype (α ⊕ β)] :=
-fintype.of_injective (sum.inl : α → α ⊕ β) (λ _ _, sum.inl.inj)
+noncomputable def fintype.sum_left {α β} [fintype (α ⊕ β)] : fintype α :=
+fintype.of_injective (sum.inl : α → α ⊕ β) sum.inl_injective
 
 /-- Given that `α ⊕ β` is a fintype, `β` is also a fintype. This is non-computable as it uses
 that `sum.inr` is an injection, but there's no clear inverse if `β` is empty. -/
-noncomputable def fintype.sum_right {α β} [fintype (α ⊕ β)] :=
-fintype.of_injective (sum.inr : β → α ⊕ β) (λ _ _, sum.inr.inj)
+noncomputable def fintype.sum_right {α β} [fintype (α ⊕ β)] : fintype β :=
+fintype.of_injective (sum.inr : β → α ⊕ β) sum.inr_injective
 
 namespace fintype
 variables [fintype α] [fintype β]

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -763,9 +763,13 @@ instance (α : Type u) (β : Type v) [fintype α] [fintype β] : fintype (α ⊕
   ((equiv.sum_equiv_sigma_bool _ _).symm.trans
     (equiv.sum_congr equiv.ulift equiv.ulift))
 
+/-- Given that `α ⊕ β` is a fintype, `α` is also a fintype. This is non-computable as it uses
+that `sum.inl` is an injection, but there's no clear inverse if `α` is empty. -/
 noncomputable def fintype.sum_left {α β} [fintype (α ⊕ β)] :=
 fintype.of_injective (sum.inl : α → α ⊕ β) (λ _ _, sum.inl.inj)
 
+/-- Given that `α ⊕ β` is a fintype, `β` is also a fintype. This is non-computable as it uses
+that `sum.inr` is an injection, but there's no clear inverse if `β` is empty. -/
 noncomputable def fintype.sum_right {α β} [fintype (α ⊕ β)] :=
 fintype.of_injective (sum.inr : β → α ⊕ β) (λ _ _, sum.inr.inj)
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -763,6 +763,12 @@ instance (α : Type u) (β : Type v) [fintype α] [fintype β] : fintype (α ⊕
   ((equiv.sum_equiv_sigma_bool _ _).symm.trans
     (equiv.sum_congr equiv.ulift equiv.ulift))
 
+noncomputable def fintype.sum_left {α β} [fintype (α ⊕ β)] :=
+fintype.of_injective (sum.inl : α → α ⊕ β) (λ _ _, sum.inl.inj)
+
+noncomputable def fintype.sum_right {α β} [fintype (α ⊕ β)] :=
+fintype.of_injective (sum.inr : β → α ⊕ β) (λ _ _, sum.inr.inj)
+
 namespace fintype
 variables [fintype α] [fintype β]
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -733,12 +733,12 @@ rfl
 card_product _ _
 
 /-- Given that `α × β` is a fintype, `α` is also a fintype. -/
-def fintype.fintype_prod_left {α β} [decidable_eq α] [fintype (α × β)] [nonempty β] : fintype α :=
+def fintype.prod_left {α β} [decidable_eq α] [fintype (α × β)] [nonempty β] : fintype α :=
 ⟨(fintype.elems (α × β)).image prod.fst,
   assume a, let ⟨b⟩ := ‹nonempty β› in by simp; exact ⟨b, fintype.complete _⟩⟩
 
 /-- Given that `α × β` is a fintype, `β` is also a fintype. -/
-def fintype.fintype_prod_right {α β} [decidable_eq β] [fintype (α × β)] [nonempty α] : fintype β :=
+def fintype.prod_right {α β} [decidable_eq β] [fintype (α × β)] [nonempty α] : fintype β :=
 ⟨(fintype.elems (α × β)).image prod.snd,
   assume b, let ⟨a⟩ := ‹nonempty α› in by simp; exact ⟨a, fintype.complete _⟩⟩
 

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -736,9 +736,9 @@ begin
   have ft_prod : fintype (quotient (gpowers x) × (gpowers x)),
     from fintype.of_equiv G group_equiv_quotient_times_subgroup,
   have ft_s : fintype (gpowers x),
-    from @fintype.fintype_prod_right _ _ _ ft_prod _,
+    from @fintype.prod_right _ _ _ ft_prod _,
   have ft_cosets : fintype (quotient (gpowers x)),
-    from @fintype.fintype_prod_left _ _ _ ft_prod ⟨⟨1, (gpowers x).one_mem⟩⟩,
+    from @fintype.prod_left _ _ _ ft_prod ⟨⟨1, (gpowers x).one_mem⟩⟩,
   have eq₁ : fintype.card G = @fintype.card _ ft_cosets * @fintype.card _ ft_s,
     from calc fintype.card G = @fintype.card _ ft_prod :
         @fintype.card_congr _ _ _ ft_prod group_equiv_quotient_times_subgroup


### PR DESCRIPTION
Also renaming the equivalent `α × β` versions, for consistency.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


I don't see a clear way to make this computable without `inhabited α`, and if you have `inhabited α` and `fintype α ⊕ β` I would be _shocked_ if you didn't have `fintype α` already. Not an `instance` for typeclass-looping reasons.

(The issue with `equiv.of_left_inverse` is that I need `inhabited`, not `nonempty`)