### PR TITLE
[Merged by Bors] - feat(analysis/convex): add dual cone

### DIFF
--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -557,7 +557,7 @@ noncomputable def set.inner_dual_cone (s : set H) : convex_cone H :=
     exact add_nonneg (hu x hx) (hv x hx)
   end }
 
-lemma inner_dual_cone_empty : (∅ : set H).inner_dual_cone = ⊤ :=
+@[simp] lemma inner_dual_cone_empty : (∅ : set H).inner_dual_cone = ⊤ :=
 convex_cone.ext' (eq_univ_of_forall
   (λ x y hy, false.elim (set.not_mem_empty _ hy)))
 

--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -557,6 +557,9 @@ noncomputable def set.inner_dual_cone (s : set H) : convex_cone H :=
     exact add_nonneg (hu x hx) (hv x hx)
   end }
 
+lemma mem_inner_dual_cone (y : H) (s : set H) :
+  y ∈ s.inner_dual_cone ↔ ∀ x ∈ s, 0 ≤ ⟪ x, y ⟫ := by refl
+
 @[simp] lemma inner_dual_cone_empty : (∅ : set H).inner_dual_cone = ⊤ :=
 convex_cone.ext' (eq_univ_of_forall
   (λ x y hy, false.elim (set.not_mem_empty _ hy)))

--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -21,7 +21,7 @@ convex cones and ordered modules.
 
 We also define `convex.to_cone` to be the minimal cone that includes a given convex set.
 
-We define `set.to_dual_cone` to be the cone consisting of all points `y` such that for
+We define `set.inner_dual_cone` to be the cone consisting of all points `y` such that for
 all points `x` in a given set `0 ≤ ⟪ x, y ⟫`.
 
 ## Main statements
@@ -544,7 +544,7 @@ open_locale real_inner_product_space
 
 /-- The dual cone is the cone consisting of all points `y` such that for
 all points `x` in a given set `0 ≤ ⟪ x, y ⟫`. -/
-noncomputable def set.to_dual_cone (s : set H) : convex_cone H :=
+noncomputable def set.inner_dual_cone (s : set H) : convex_cone H :=
 { carrier := { y | ∀ x ∈ s, 0 ≤ ⟪ x, y ⟫ },
   smul_mem' := λ c hc y hy x hx,
   begin
@@ -557,15 +557,15 @@ noncomputable def set.to_dual_cone (s : set H) : convex_cone H :=
     exact add_nonneg (hu x hx) (hv x hx)
   end }
 
-lemma to_dual_cone_empty : (∅ : set H).to_dual_cone = ⊤ :=
+lemma inner_dual_cone_empty : (∅ : set H).inner_dual_cone = ⊤ :=
 convex_cone.ext' (eq_univ_of_forall
   (λ x y hy, false.elim (set.not_mem_empty _ hy)))
 
-lemma to_dual_cone_le_to_dual_cone (h : t ⊆ s) :
-  s.to_dual_cone ≤ t.to_dual_cone :=
+lemma inner_dual_cone_le_inner_dual_cone (h : t ⊆ s) :
+  s.inner_dual_cone ≤ t.inner_dual_cone :=
 λ y hy x hx, hy x (h hx)
 
-lemma pointed_to_dual_cone : s.to_dual_cone.pointed :=
+lemma pointed_inner_dual_cone : s.inner_dual_cone.pointed :=
 λ x hx, by rw inner_zero_right
 
 end dual

--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -544,8 +544,8 @@ open_locale real_inner_product_space
 
 /-- The dual cone is the cone consisting of all points `y` such that for
 all points `x` in a given set `0 ≤ ⟪ x, y ⟫`. -/
-noncomputable def set.to_dual_cone (s : set H) : convex_cone H := {
-  carrier := { y | ∀ x ∈ s, 0 ≤ ⟪ x, y ⟫ },
+noncomputable def set.to_dual_cone (s : set H) : convex_cone H :=
+{ carrier := { y | ∀ x ∈ s, 0 ≤ ⟪ x, y ⟫ },
   smul_mem' := λ c hc y hy x hx,
   begin
     rw real_inner_smul_right,
@@ -555,8 +555,7 @@ noncomputable def set.to_dual_cone (s : set H) : convex_cone H := {
   begin
     rw inner_add_right,
     exact add_nonneg (hu x hx) (hv x hx)
-  end
-}
+  end }
 
 lemma to_dual_cone_empty : (∅ : set H).to_dual_cone = ⊤ :=
 convex_cone.ext' (eq_univ_of_forall

--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov, Frédéric Dupuis
 import linear_algebra.linear_pmap
 import analysis.convex.basic
 import order.zorn
+import analysis.normed_space.inner_product
 
 /-!
 # Convex cones
@@ -19,6 +20,9 @@ We define pointed, blunt, flat and salient cones, and prove the correspondence b
 convex cones and ordered modules.
 
 We also define `convex.to_cone` to be the minimal cone that includes a given convex set.
+
+We define `set.to_dual_cone` to be the cone consisting of all points `y` such that for
+all points `x` in a given set `0 ≤ ⟪ x, y ⟫`.
 
 ## Main statements
 
@@ -45,9 +49,6 @@ While `convex` is a predicate on sets, `convex_cone` is a bundled convex cone.
 
 * https://en.wikipedia.org/wiki/Convex_cone
 
-## TODO
-
-* Define the dual cone.
 -/
 
 universes u v
@@ -532,3 +533,40 @@ begin
     simp only [convex_cone.mem_mk, mem_set_of_eq, subtype.coe_mk, prod.fst_add, prod.snd_add,
       zero_add, sub_add_cancel] }
 end
+
+/-!
+### The dual cone
+-/
+section dual
+
+variables {H : Type*} [inner_product_space ℝ H] (s t : set H)
+open_locale real_inner_product_space
+
+/-- The dual cone is the cone consisting of all points `y` such that for
+all points `x` in a given set `0 ≤ ⟪ x, y ⟫`. -/
+noncomputable def set.to_dual_cone (s : set H) : convex_cone H := {
+  carrier := { y | ∀ x ∈ s, 0 ≤ ⟪ x, y ⟫ },
+  smul_mem' := λ c hc y hy x hx,
+  begin
+    rw real_inner_smul_right,
+    exact mul_nonneg (le_of_lt hc) (hy x hx)
+  end,
+  add_mem' := λ u hu v hv x hx,
+  begin
+    rw inner_add_right,
+    exact add_nonneg (hu x hx) (hv x hx)
+  end
+}
+
+lemma to_dual_cone_empty : (∅ : set H).to_dual_cone = ⊤ :=
+convex_cone.ext' (eq_univ_of_forall
+  (λ x y hy, false.elim (set.not_mem_empty _ hy)))
+
+lemma to_dual_cone_le_to_dual_cone (h : t ⊆ s) :
+  s.to_dual_cone ≤ t.to_dual_cone :=
+λ y hy x hx, hy x (h hx)
+
+lemma pointed_to_dual_cone : s.to_dual_cone.pointed :=
+λ x hx, by rw inner_zero_right
+
+end dual


### PR DESCRIPTION
Add definition of the dual cone of a set in a real inner product space
---

Hello! I am not sure if this is the "right" definition of a dual cone. An alternative would be to define the dual cone as a cone in the dual vector space and to use `y(x)` instead of `⟪ x, y ⟫`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
