### PR TITLE
[Merged by Bors] - chore(data/nat/sqrt): Alternative phrasings of data.nat.sqrt lemmas

### DIFF
--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -152,8 +152,7 @@ theorem le_sqrt {m n : ℕ} : m ≤ sqrt n ↔ m*m ≤ n :=
    lt_of_le_of_lt h (lt_succ_sqrt n)⟩
 
 theorem le_sqrt' {m n : ℕ} : m ≤ sqrt n ↔ m ^ 2 ≤ n :=
-⟨λ h, eq.trans_le (sq m) (le_sqrt.1 h),
- λ h, le_sqrt.2 ((eq.symm (sq m)).trans_le h)⟩
+by simpa only [pow_two] using le_sqrt
 
 theorem sqrt_lt {m n : ℕ} : sqrt m < n ↔ m < n*n :=
 lt_iff_lt_of_le_iff_le le_sqrt
@@ -180,11 +179,7 @@ theorem eq_sqrt {n q} : q = sqrt n ↔ q*q ≤ n ∧ n < (q+1)*(q+1) :=
  λ ⟨h₁, h₂⟩, le_antisymm (le_sqrt.2 h₁) (le_of_lt_succ $ sqrt_lt.2 h₂)⟩
 
 theorem eq_sqrt' {n q} : q = sqrt n ↔ q ^ 2 ≤ n ∧ n < (q+1) ^ 2 :=
-⟨λ e,
-  ⟨eq.trans_le (sq q) ((@eq_sqrt n q).1 e).1,
-   trans_rel_left (λ i j, i < j) ((@eq_sqrt n q).1 e).2 (sq _).symm⟩,
- λ ⟨e1, e2⟩,
-  (@eq_sqrt n q).2 ⟨eq.trans_le (sq _).symm e1, trans_rel_left (λ i j, i < j) e2 (sq _)⟩⟩
+by simpa only [pow_two] using eq_sqrt
 
 theorem le_three_of_sqrt_eq_one {n : ℕ} (h : sqrt n = 1) : n ≤ 3 :=
 le_of_lt_succ $ (@sqrt_lt n 2).1 $
@@ -224,10 +219,7 @@ theorem exists_mul_self (x : ℕ) :
 
 theorem exists_mul_self' (x : ℕ) :
   (∃ n, n ^ 2 = x) ↔ (sqrt x) ^ 2 = x :=
-⟨λ ⟨n, h⟩, (sq (sqrt x)).trans ((exists_mul_self x).1 ⟨n, (sq n).symm.trans h⟩),
- λ h, by
-   rcases (exists_mul_self x).2 ((sq (sqrt x)).symm.trans h) with ⟨n, pr⟩;
-   exact ⟨n, (sq n).trans pr⟩⟩
+by simpa only [pow_two] using exists_mul_self x
 
 theorem sqrt_mul_sqrt_lt_succ (n : ℕ) : sqrt n * sqrt n < n + 1 :=
 lt_succ_iff.mpr (sqrt_le _)
@@ -253,11 +245,6 @@ end
 
 theorem not_exists_sq' {n m : ℕ} (hl : m ^ 2 < n) (hr : n < (m + 1) ^ 2) :
   ¬ ∃ t, t ^ 2 = n :=
-begin
-  rintro ⟨t, pr⟩,
-  have h1 : t * t = n := (sq t).symm.trans pr,
-  have h2 : m * m < n := trans_rel_right (λ i j, i < j) (sq m).symm hl,
-  exact not_exists_sq h2 (trans_rel_left (λ i j, i < j) hr (sq (m + 1))) ⟨t, h1⟩,
-end
+  by simpa only [pow_two] using (@not_exists_sq n m (by simpa only [pow_two] using hl) (by simpa only [pow_two] using hr))
 
 end nat

--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -245,6 +245,7 @@ end
 
 theorem not_exists_sq' {n m : ℕ} (hl : m ^ 2 < n) (hr : n < (m + 1) ^ 2) :
   ¬ ∃ t, t ^ 2 = n :=
-  by simpa only [pow_two] using (@not_exists_sq n m (by simpa only [pow_two] using hl) (by simpa only [pow_two] using hr))
+  by simpa only [pow_two]
+  using not_exists_sq (by simpa only [pow_two] using hl) (by simpa only [pow_two] using hr)
 
 end nat

--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -134,8 +134,14 @@ end
 theorem sqrt_le (n : ℕ) : sqrt n * sqrt n ≤ n :=
 (sqrt_is_sqrt n).left
 
+theorem sqrt_le' (n : ℕ) : (sqrt n) ^ 2 ≤ n :=
+eq.trans_le (sq (sqrt n)) (sqrt_le n)
+
 theorem lt_succ_sqrt (n : ℕ) : n < succ (sqrt n) * succ (sqrt n) :=
 (sqrt_is_sqrt n).right
+
+theorem lt_succ_sqrt' (n : ℕ) : n < (succ (sqrt n)) ^ 2 :=
+trans_rel_left (λ i j, i < j) (lt_succ_sqrt n) (sq (succ (sqrt n))).symm
 
 theorem sqrt_le_add (n : ℕ) : n ≤ sqrt n * sqrt n + sqrt n + sqrt n :=
 by rw ← succ_mul; exact le_of_lt_succ (lt_succ_sqrt n)
@@ -145,8 +151,15 @@ theorem le_sqrt {m n : ℕ} : m ≤ sqrt n ↔ m*m ≤ n :=
  λ h, le_of_lt_succ $ mul_self_lt_mul_self_iff.2 $
    lt_of_le_of_lt h (lt_succ_sqrt n)⟩
 
+theorem le_sqrt' {m n : ℕ} : m ≤ sqrt n ↔ m ^ 2 ≤ n :=
+⟨λ h, eq.trans_le (sq m) (le_sqrt.1 h),
+ λ h, le_sqrt.2 ((eq.symm (sq m)).trans_le h)⟩
+
 theorem sqrt_lt {m n : ℕ} : sqrt m < n ↔ m < n*n :=
 lt_iff_lt_of_le_iff_le le_sqrt
+
+theorem sqrt_lt' {m n : ℕ} : sqrt m < n ↔ m < n ^ 2 :=
+lt_iff_lt_of_le_iff_le le_sqrt'
 
 theorem sqrt_le_self (n : ℕ) : sqrt n ≤ n :=
 le_trans (le_mul_self _) (sqrt_le n)
@@ -166,6 +179,10 @@ theorem eq_sqrt {n q} : q = sqrt n ↔ q*q ≤ n ∧ n < (q+1)*(q+1) :=
 ⟨λ e, e.symm ▸ sqrt_is_sqrt n,
  λ ⟨h₁, h₂⟩, le_antisymm (le_sqrt.2 h₁) (le_of_lt_succ $ sqrt_lt.2 h₂)⟩
 
+theorem eq_sqrt' {n q} : q = sqrt n ↔ q ^ 2 ≤ n ∧ n < (q+1) ^ 2 :=
+⟨λ e, ⟨eq.trans_le (sq q) ((@eq_sqrt n q).1 e).1, trans_rel_left (λ i j, i < j) ((@eq_sqrt n q).1 e).2 (sq _).symm⟩,
+ λ ⟨e1, e2⟩, (@eq_sqrt n q).2 ⟨eq.trans_le (sq _).symm e1, trans_rel_left (λ i j, i < j) e2 (sq _)⟩⟩
+
 theorem le_three_of_sqrt_eq_one {n : ℕ} (h : sqrt n = 1) : n ≤ 3 :=
 le_of_lt_succ $ (@sqrt_lt n 2).1 $
 by rw [h]; exact dec_trivial
@@ -183,8 +200,14 @@ le_antisymm
     exact lt_succ_of_le (nat.add_le_add_left h _))
   (le_sqrt.2 $ nat.le_add_right _ _)
 
+theorem sqrt_add_eq' (n : ℕ) {a : ℕ} (h : a ≤ n + n) : sqrt (n ^ 2 + a) = n :=
+(congr_arg (λ i, sqrt (i + a)) (sq n)).trans (sqrt_add_eq n h)
+
 theorem sqrt_eq (n : ℕ) : sqrt (n*n) = n :=
 sqrt_add_eq n (zero_le _)
+
+theorem sqrt_eq' (n : ℕ) : sqrt (n ^ 2) = n :=
+sqrt_add_eq' n (zero_le _)
 
 theorem sqrt_succ_le_succ_sqrt (n : ℕ) : sqrt n.succ ≤ n.sqrt.succ :=
 le_of_lt_succ $ sqrt_lt.2 $ lt_succ_of_le $ succ_le_succ $
@@ -196,11 +219,24 @@ theorem exists_mul_self (x : ℕ) :
   (∃ n, n * n = x) ↔ sqrt x * sqrt x = x :=
 ⟨λ ⟨n, hn⟩, by rw [← hn, sqrt_eq], λ h, ⟨sqrt x, h⟩⟩
 
+theorem exists_mul_self' (x : ℕ) :
+  (∃ n, n ^ 2 = x) ↔ (sqrt x) ^ 2 = x :=
+⟨λ ⟨n, h⟩, (sq (sqrt x)).trans ((exists_mul_self x).1 ⟨n, (sq n).symm.trans h⟩),
+ λ h, by
+   rcases (exists_mul_self x).2 ((sq (sqrt x)).symm.trans h) with ⟨n, pr⟩;
+   exact ⟨n, (sq n).trans pr⟩⟩
+
 theorem sqrt_mul_sqrt_lt_succ (n : ℕ) : sqrt n * sqrt n < n + 1 :=
 lt_succ_iff.mpr (sqrt_le _)
 
+theorem sqrt_mul_sqrt_lt_succ' (n : ℕ) : (sqrt n) ^ 2 < n + 1 :=
+lt_succ_iff.mpr (sqrt_le' _)
+
 theorem succ_le_succ_sqrt (n : ℕ) : n + 1 ≤ (sqrt n + 1) * (sqrt n + 1) :=
 le_of_pred_lt (lt_succ_sqrt _)
+
+theorem succ_le_succ_sqrt' (n : ℕ) : n + 1 ≤ (sqrt n + 1) ^ 2 :=
+le_of_pred_lt (lt_succ_sqrt' _)
 
 /-- There are no perfect squares strictly between m² and (m+1)² -/
 theorem not_exists_sq {n m : ℕ} (hl : m * m < n) (hr : n < (m + 1) * (m + 1)) :
@@ -210,6 +246,15 @@ begin
   have h1 : m < t, from nat.mul_self_lt_mul_self_iff.mpr hl,
   have h2 : t < m + 1, from nat.mul_self_lt_mul_self_iff.mpr hr,
   exact (not_lt_of_ge $ le_of_lt_succ h2) h1
+end
+
+theorem not_exists_sq' {n m : ℕ} (hl : m ^ 2 < n) (hr : n < (m + 1) ^ 2) :
+  ¬ ∃ t, t ^ 2 = n :=
+begin
+  rintro ⟨t, pr⟩,
+  have h1 : t * t = n := (sq t).symm.trans pr,
+  have h2 : m * m < n := trans_rel_right (λ i j, i < j) (sq m).symm hl,
+  exact not_exists_sq h2 (trans_rel_left (λ i j, i < j) hr (sq (m + 1))) ⟨t, h1⟩,
 end
 
 end nat

--- a/src/data/nat/sqrt.lean
+++ b/src/data/nat/sqrt.lean
@@ -180,8 +180,11 @@ theorem eq_sqrt {n q} : q = sqrt n ↔ q*q ≤ n ∧ n < (q+1)*(q+1) :=
  λ ⟨h₁, h₂⟩, le_antisymm (le_sqrt.2 h₁) (le_of_lt_succ $ sqrt_lt.2 h₂)⟩
 
 theorem eq_sqrt' {n q} : q = sqrt n ↔ q ^ 2 ≤ n ∧ n < (q+1) ^ 2 :=
-⟨λ e, ⟨eq.trans_le (sq q) ((@eq_sqrt n q).1 e).1, trans_rel_left (λ i j, i < j) ((@eq_sqrt n q).1 e).2 (sq _).symm⟩,
- λ ⟨e1, e2⟩, (@eq_sqrt n q).2 ⟨eq.trans_le (sq _).symm e1, trans_rel_left (λ i j, i < j) e2 (sq _)⟩⟩
+⟨λ e,
+  ⟨eq.trans_le (sq q) ((@eq_sqrt n q).1 e).1,
+   trans_rel_left (λ i j, i < j) ((@eq_sqrt n q).1 e).2 (sq _).symm⟩,
+ λ ⟨e1, e2⟩,
+  (@eq_sqrt n q).2 ⟨eq.trans_le (sq _).symm e1, trans_rel_left (λ i j, i < j) e2 (sq _)⟩⟩
 
 theorem le_three_of_sqrt_eq_one {n : ℕ} (h : sqrt n = 1) : n ≤ 3 :=
 le_of_lt_succ $ (@sqrt_lt n 2).1 $


### PR DESCRIPTION
Add versions of the `data.nat.sqrt` lemmas to talk about `n^2` where the current versions talk about `n * n`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I found this gap while working on https://github.com/leanprover-community/mathlib/pull/2784 .

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
