### PR TITLE
[Merged by Bors] - fix(order/closure): unincorporated reviewer comments from #7446

### DIFF
--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -1224,7 +1224,7 @@ closure_operator.closure_mem_mk₃ s
 variable {s}
 
 lemma convex_hull_min (hst : s ⊆ t) (ht : convex t) : convex_hull s ⊆ t :=
-closure_operator.closure_le_mk₃_iff begin exact hst end ht
+closure_operator.closure_le_mk₃_iff (show s ≤ t, from hst) ht
 
 lemma convex_hull_mono (hst : s ⊆ t) : convex_hull s ⊆ convex_hull t :=
 convex_hull.monotone hst

--- a/src/order/closure.lean
+++ b/src/order/closure.lean
@@ -11,9 +11,11 @@ import tactic.monotonicity
 
 /-!
 # Closure operators between preorders
+
 We define (bundled) closure operators on a preorder as monotone (increasing), extensive
 (inflationary) and idempotent functions.
 We define closed elements for the operator as elements which are fixed by it.
+
 Lower adjoints to a function between preorders `u : β → α` allow to generalise closure operators to
 situations where the closure operator we are dealing with naturally decomposes as `u ∘ l` where `l`
 is a worthy function to have on its own. Typical examples include
@@ -23,17 +25,24 @@ connections/insertions: every Galois connection induces a lower adjoint which it
 closure operator by composition (see `galois_connection.lower_adjoint` and
 `lower_adjoint.closure_operator`), and every closure operator on a partial order induces a Galois
 insertion from the set of closed elements to the underlying type (see `closure_operator.gi`).
+
 ## Main definitions
+
 * `closure_operator`: A closure operator is a monotone function `f : α → α` such that
   `∀ x, x ≤ f x` and `∀ x, f (f x) = f x`.
 * `lower_adjoint`: A lower adjoint to `u : β → α` is a function `l : α → β` such that `l` and `u`
   form a Galois connection.
+
 ## Implementation details
+
 Although `lower_adjoint` is technically a generalisation of `closure_operator` (by defining
 `to_fun := id`), it is desirable to have both as otherwise `id`s would be carried all over the
 place when using concrete closure operators such as `convex_hull`.
+
 `lower_adjoint` really is a semibundled `structure` version of `galois_connection`.
+
 ## References
+
 * https://en.wikipedia.org/wiki/Closure_operator#Closure_operators_on_partially_ordered_sets
 -/
 


### PR DESCRIPTION

---

(`(hst : _)` or `(hst : s ≤ t)` do not elaborate correctly)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
