### PR TITLE
[Merged by Bors] - chore(order/pilex): add docstring

### DIFF
--- a/src/order/pilex.lean
+++ b/src/order/pilex.lean
@@ -7,6 +7,13 @@ import algebra.ordered_pi
 import order.well_founded
 import algebra.order_functions
 
+/-!
+# Lexicographic order on Pi types
+
+This file defines the lexicographic relation for Pi types of partial orders and linear orders. We
+also provide a `pilex` analog of `pi.ordered_comm_group` (see `algebra.ordered_pi`).
+-/
+
 variables {ι : Type*} {β : ι → Type*} (r : ι → ι → Prop)
   (s : Π {i}, β i → β i → Prop)
 
@@ -29,7 +36,7 @@ set_option eqn_compiler.zeta true
 instance [linear_order ι] [∀ a, partial_order (β a)] : partial_order (pilex ι β) :=
 have lt_not_symm : ∀ {x y : pilex ι β}, ¬ (x < y ∧ y < x),
   from λ x y ⟨⟨i, hi⟩, ⟨j, hj⟩⟩, begin
-      rcases lt_trichotomy i j with hij | hij | hji,
+      obtain hij | hij | hji := lt_trichotomy i j,
       { exact lt_irrefl (x i) (by simpa [hj.1 _ hij] using hi.2) },
       { exact not_le_of_gt hj.2 (hij ▸ le_of_lt hi.2) },
       { exact lt_irrefl (x j) (by simpa [hi.1 _ hji] using hj.2) },
@@ -89,13 +96,15 @@ protected noncomputable def pilex.linear_order [linear_order ι]
   decidable_le := classical.dec_rel _,
   ..pilex.partial_order }
 
-instance [linear_order ι] [∀ a, ordered_add_comm_group (β a)] :
-  ordered_add_comm_group (pilex ι β) :=
-{ add_le_add_left := λ x y hxy z,
+--we might want the analog of `pi.ordered_cancel_comm_monoid` as well in the future
+@[to_additive]
+instance [linear_order ι] [∀ a, ordered_comm_group (β a)] :
+  ordered_comm_group (pilex ι β) :=
+{ mul_le_mul_left := λ x y hxy z,
     hxy.elim
       (λ ⟨i, hi⟩,
-        or.inl ⟨i, λ j hji, show z j + x j = z j + y j, by rw [hi.1 j hji],
-          add_lt_add_left hi.2 _⟩)
-      (λ hxy, hxy ▸ le_refl _),
+        or.inl ⟨i, λ j hji, show z j * x j = z j * y j, by rw hi.1 j hji,
+          mul_lt_mul_left' hi.2 _⟩)
+      (λ hxyz, hxyz ▸ le_refl _),
   ..pilex.partial_order,
-  ..pi.add_comm_group }
+  ..pi.comm_group }


### PR DESCRIPTION
- add module docstring
- extend `ordered_add_comm_group (pilex ι β)` using `to_additive`
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
