### PR TITLE
[Merged by Bors] - chore(logic/embedding): move some algebra content

### DIFF
--- a/src/algebra/regular.lean
+++ b/src/algebra/regular.lean
@@ -293,7 +293,7 @@ by left multiplication by a fixed element.
 @[to_additive
   "The embedding of a left cancellative additive semigroup into itself
    by left translation by a fixed element.", simps]
-def mul_left_embedding {G : Type u} [left_cancel_semigroup G] (g : G) : G ↪ G :=
+def mul_left_embedding {G : Type*} [left_cancel_semigroup G] (g : G) : G ↪ G :=
 { to_fun := λ h, g * h, inj' := mul_right_injective g }
 
 /--
@@ -303,7 +303,7 @@ by right multiplication by a fixed element.
 @[to_additive
   "The embedding of a right cancellative additive semigroup into itself
    by right translation by a fixed element.", simps]
-def mul_right_embedding {G : Type u} [right_cancel_semigroup G] (g : G) : G ↪ G :=
+def mul_right_embedding {G : Type*} [right_cancel_semigroup G] (g : G) : G ↪ G :=
 { to_fun := λ h, h * g, inj' := mul_left_injective g }
 
 /--  Elements of a left cancel semigroup are left regular. -/

--- a/src/algebra/regular.lean
+++ b/src/algebra/regular.lean
@@ -286,6 +286,26 @@ end monoid
 
 section left_or_right_cancel_semigroup
 
+/--
+The embedding of a left cancellative semigroup into itself
+by left multiplication by a fixed element.
+ -/
+@[to_additive
+  "The embedding of a left cancellative additive semigroup into itself
+   by left translation by a fixed element.", simps]
+def mul_left_embedding {G : Type u} [left_cancel_semigroup G] (g : G) : G ↪ G :=
+{ to_fun := λ h, g * h, inj' := mul_right_injective g }
+
+/--
+The embedding of a right cancellative semigroup into itself
+by right multiplication by a fixed element.
+ -/
+@[to_additive
+  "The embedding of a right cancellative additive semigroup into itself
+   by right translation by a fixed element.", simps]
+def mul_right_embedding {G : Type u} [right_cancel_semigroup G] (g : G) : G ↪ G :=
+{ to_fun := λ h, h * g, inj' := mul_left_injective g }
+
 /--  Elements of a left cancel semigroup are left regular. -/
 lemma is_left_regular_of_left_cancel_semigroup [left_cancel_semigroup R] (g : R) :
   is_left_regular g :=

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl, Mario Carneiro
 -/
 import data.equiv.basic
 import data.sigma.basic
-import algebra.group.defs
 
 /-!
 # Injective functions
@@ -291,26 +290,3 @@ namespace set
 ⟨λ x, ⟨x.1, h x.2⟩, λ ⟨x, hx⟩ ⟨y, hy⟩ h, by { congr, injection h }⟩
 
 end set
-
--- TODO: these two definitions probably belong somewhere else, so that we can remove the
--- `algebra.group.defs` import.
-
-/--
-The embedding of a left cancellative semigroup into itself
-by left multiplication by a fixed element.
- -/
-@[to_additive
-  "The embedding of a left cancellative additive semigroup into itself
-   by left translation by a fixed element.", simps]
-def mul_left_embedding {G : Type u} [left_cancel_semigroup G] (g : G) : G ↪ G :=
-{ to_fun := λ h, g * h, inj' := mul_right_injective g }
-
-/--
-The embedding of a right cancellative semigroup into itself
-by right multiplication by a fixed element.
- -/
-@[to_additive
-  "The embedding of a right cancellative additive semigroup into itself
-   by right translation by a fixed element.", simps]
-def mul_right_embedding {G : Type u} [right_cancel_semigroup G] (g : G) : G ↪ G :=
-{ to_fun := λ h, h * g, inj' := mul_left_injective g }

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -7,7 +7,6 @@ import algebra.monoid_algebra
 import algebra.char_p.invertible
 import algebra.regular
 import linear_algebra.basis
-import ring_theory.simple_module
 
 /-!
 # Maschke's theorem

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import algebra.monoid_algebra
 import algebra.char_p.invertible
+import algebra.regular
 import linear_algebra.basis
 import ring_theory.simple_module
 


### PR DESCRIPTION
This moves a lemma about multiplication by an element in a left/right cancellative semigroup being an embedding out of `logic.embedding`. I didn't find a great home for it, but put it with some content about regular elements, which is at least talking about similar mathematics.

This removes the only direct import from the `logic/` directory to the `algebra/` directory. There are still indirect imports from `logic.small`, which currently brings in `fintype` and hence the whole algebra hierarchy. I'll look at that separately.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
