### PR TITLE
[Merged by Bors] - chore(logic/small): reduce imports

### DIFF
--- a/src/data/equiv/encodable/small.lean
+++ b/src/data/equiv/encodable/small.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2021 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import data.equiv.encodable.basic
+import logic.small
+
+/-!
+# All encodable types are small.
+
+That is, any encodable type is equivalent to a type in any universe.
+-/
+
+universes w v
+
+@[priority 100]
+instance small_of_encodable (α : Type v) [encodable α] : small.{w} α :=
+small_of_injective _ (encodable.encode_injective)

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1435,7 +1435,7 @@ not_fintype α
 ⟨λ ⟨x⟩, ⟨x⟩, λ ⟨x⟩, ⟨x⟩⟩
 
 @[simp] lemma not_nonempty_fintype {α : Type*} : ¬ nonempty (fintype α) ↔ infinite α :=
-(not_nonempty_iff α).trans is_empty_fintype
+(not_nonempty_iff (fintype α)).trans is_empty_fintype
 
 /-- A non-infinite type is a fintype. -/
 noncomputable def fintype_of_not_infinite {α : Type*} (h : ¬ infinite α) : fintype α :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1435,7 +1435,7 @@ not_fintype α
 ⟨λ ⟨x⟩, ⟨x⟩, λ ⟨x⟩, ⟨x⟩⟩
 
 @[simp] lemma not_nonempty_fintype {α : Type*} : ¬ nonempty (fintype α) ↔ infinite α :=
-not_nonempty_iff.trans is_empty_fintype
+(not_nonempty_iff α).trans is_empty_fintype
 
 /-- A non-infinite type is a fintype. -/
 noncomputable def fintype_of_not_infinite {α : Type*} (h : ¬ infinite α) : fintype α :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -831,7 +831,7 @@ def card_eq_zero_equiv_equiv_empty : card α = 0 ≃ (α ≃ empty) :=
 (equiv.of_iff card_eq_zero_iff).trans (equiv.equiv_empty_equiv α).symm
 
 lemma card_pos_iff : 0 < card α ↔ nonempty α :=
-pos_iff_ne_zero.trans $ not_iff_comm.mp $ not_nonempty_iff.trans card_eq_zero_iff.symm
+pos_iff_ne_zero.trans $ not_iff_comm.mp $ (not_nonempty_iff α).trans card_eq_zero_iff.symm
 
 lemma card_le_one_iff : card α ≤ 1 ↔ (∀ a b : α, a = b) :=
 let n := card α in

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -831,7 +831,7 @@ def card_eq_zero_equiv_equiv_empty : card α = 0 ≃ (α ≃ empty) :=
 (equiv.of_iff card_eq_zero_iff).trans (equiv.equiv_empty_equiv α).symm
 
 lemma card_pos_iff : 0 < card α ↔ nonempty α :=
-pos_iff_ne_zero.trans $ not_iff_comm.mp $ (not_nonempty_iff α).trans card_eq_zero_iff.symm
+pos_iff_ne_zero.trans $ not_iff_comm.mp $ not_nonempty_iff.trans card_eq_zero_iff.symm
 
 lemma card_le_one_iff : card α ≤ 1 ↔ (∀ a b : α, a = b) :=
 let n := card α in
@@ -1435,7 +1435,7 @@ not_fintype α
 ⟨λ ⟨x⟩, ⟨x⟩, λ ⟨x⟩, ⟨x⟩⟩
 
 @[simp] lemma not_nonempty_fintype {α : Type*} : ¬ nonempty (fintype α) ↔ infinite α :=
-(not_nonempty_iff (fintype α)).trans is_empty_fintype
+not_nonempty_iff.trans is_empty_fintype
 
 /-- A non-infinite type is a fintype. -/
 noncomputable def fintype_of_not_infinite {α : Type*} (h : ¬ infinite α) : fintype α :=

--- a/src/data/fintype/small.lean
+++ b/src/data/fintype/small.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2021 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import data.fintype.basic
+import logic.small
+
+/-!
+# All finite types are small.
+
+That is, any `α` with `[fintype α]` is equivalent to a type in any universe.
+
+-/
+
+universes w v
+
+@[priority 100]
+instance small_of_fintype (α : Type v) [fintype α] : small.{w} α :=
+begin
+  rw small_congr (fintype.equiv_fin α),
+  apply_instance,
+end

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Yury Kudryashov
 -/
-import data.equiv.basic
 import algebra.group.defs
 import algebra.group.hom
 import logic.embedding

--- a/src/logic/is_empty.lean
+++ b/src/logic/is_empty.lean
@@ -83,16 +83,16 @@ instance : subsingleton α := ⟨is_empty_elim⟩
 
 end is_empty
 
-variables (α)
-
 @[simp] lemma not_nonempty_iff : ¬ nonempty α ↔ is_empty α :=
 ⟨λ h, ⟨λ x, h ⟨x⟩⟩, λ h1 h2, h2.elim h1.elim⟩
 
 @[simp] lemma not_is_empty_iff : ¬ is_empty α ↔ nonempty α :=
-not_iff_comm.mp (not_nonempty_iff α)
+not_iff_comm.mp not_nonempty_iff
+
+variables (α)
 
 lemma is_empty_or_nonempty : is_empty α ∨ nonempty α :=
-(em $ is_empty α).elim or.inl $ or.inr ∘ (not_is_empty_iff α).mp
+(em $ is_empty α).elim or.inl $ or.inr ∘ not_is_empty_iff.mp
 
 @[simp] lemma not_is_empty_of_nonempty [h : nonempty α] : ¬ is_empty α :=
-(not_is_empty_iff α).mpr h
+not_is_empty_iff.mpr h

--- a/src/logic/is_empty.lean
+++ b/src/logic/is_empty.lean
@@ -83,14 +83,16 @@ instance : subsingleton α := ⟨is_empty_elim⟩
 
 end is_empty
 
+variables (α)
+
 @[simp] lemma not_nonempty_iff : ¬ nonempty α ↔ is_empty α :=
 ⟨λ h, ⟨λ x, h ⟨x⟩⟩, λ h1 h2, h2.elim h1.elim⟩
 
 @[simp] lemma not_is_empty_iff : ¬ is_empty α ↔ nonempty α :=
-not_iff_comm.mp not_nonempty_iff
+not_iff_comm.mp (not_nonempty_iff α)
 
 lemma is_empty_or_nonempty : is_empty α ∨ nonempty α :=
-(em $ is_empty α).elim or.inl $ or.inr ∘ not_is_empty_iff.mp
+(em $ is_empty α).elim or.inl $ or.inr ∘ (not_is_empty_iff α).mp
 
 @[simp] lemma not_is_empty_of_nonempty [h : nonempty α] : ¬ is_empty α :=
-not_is_empty_iff.mpr h
+(not_is_empty_iff α).mpr h

--- a/src/logic/small.lean
+++ b/src/logic/small.lean
@@ -91,8 +91,10 @@ begin
     apply small_self, assumption, assumption, },
 end
 
--- We don't define `small_fintype` or `small_encodable` yet,
--- to keep imports to `logic` to a minimum.
+/-!
+We don't define `small_of_fintype` or `small_of_encodable` in this file,
+to keep imports to `logic` to a minimum.
+-/
 
 instance small_Pi {α} (β : α → Type*) [small.{w} α] [∀ a, small.{w} (β a)] :
   small.{w} (Π a, β a) :=

--- a/src/logic/small.lean
+++ b/src/logic/small.lean
@@ -3,8 +3,7 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import data.equiv.encodable.basic
-import data.fintype.basic
+import data.equiv.basic
 
 /-!
 # Small types
@@ -77,13 +76,6 @@ begin
   apply_instance,
 end
 
-@[priority 100]
-instance small_of_fintype (α : Type v) [fintype α] : small.{w} α :=
-begin
-  rw small_congr (fintype.equiv_fin α),
-  apply_instance,
-end
-
 theorem small_of_injective {α : Type*} {β : Type*} [small.{w} β]
   (f : α → β) (hf : function.injective f) : small.{w} α :=
 begin
@@ -91,9 +83,16 @@ begin
   apply_instance,
 end
 
-@[priority 100]
-instance small_of_encodable (α : Type v) [encodable α] : small.{w} α :=
-small_of_injective _ (encodable.encode_injective)
+instance small_subsingleton (α : Type v) [subsingleton α] : small.{w} α :=
+begin
+  rcases is_empty_or_nonempty α; resetI,
+  { rw small_congr (equiv.equiv_pempty α), apply small_self, },
+  { rw small_congr equiv.punit_of_nonempty_of_subsingleton,
+    apply small_self, assumption, assumption, },
+end
+
+-- We don't define `small_fintype` or `small_encodable` yet,
+-- to keep imports to `logic` to a minimum.
 
 instance small_Pi {α} (β : α → Type*) [small.{w} α] [∀ a, small.{w} (β a)] :
   small.{w} (Π a, β a) :=

--- a/src/logic/small.lean
+++ b/src/logic/small.lean
@@ -83,6 +83,7 @@ begin
   apply_instance,
 end
 
+@[priority 100]
 instance small_subsingleton (α : Type v) [subsingleton α] : small.{w} α :=
 begin
   rcases is_empty_or_nonempty α; resetI,


### PR DESCRIPTION
By delaying the `fintype` and `encodable` instances for `small`, I think we can now avoid importing `algebra` at all into `logic`.

~~Since some of the `is_empty` lemmas haven't been used yet,~~ I took the liberty of making some arguments explicit, as one was painful to use as is. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
