### PR TITLE
feat(measure_theory/measure_space): define ae_measurable', variant of ae_measurable for a sub-sigma-algebra

### DIFF
--- a/src/measure_theory/arithmetic.lean
+++ b/src/measure_theory/arithmetic.lean
@@ -35,7 +35,7 @@ universes u v
 open_locale big_operators
 open measure_theory
 
-variables {α : Type*} [measurable_space α]
+variables {α : Type*} {m : measurable_space α} [measurable_space α] {μ : measure α}
 
 /-!
 ### Binary operations: `(+)`, `(*)`, `(-)`, `(/)`
@@ -81,10 +81,16 @@ lemma measurable.mul [has_measurable_mul₂ M] {f g : α → M} (hf : measurable
 measurable_mul.comp (hf.prod_mk hg)
 
 @[to_additive]
-lemma ae_measurable.mul [has_measurable_mul₂ M] {μ : measure α} {f g : α → M}
+lemma ae_measurable'.mul [has_measurable_mul₂ M] {f g : α → M}
+  (hf : ae_measurable' m f μ) (hg : ae_measurable' m g μ) :
+  ae_measurable' m (λ a, f a * g a) μ :=
+measurable_mul.comp_ae_measurable' (hf.prod_mk hg)
+
+@[to_additive]
+lemma ae_measurable.mul [has_measurable_mul₂ M] {f g : α → M}
   (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
   ae_measurable (λ a, f a * g a) μ :=
-measurable_mul.comp_ae_measurable (hf.prod_mk hg)
+hf.mul hg
 
 @[priority 100, to_additive]
 instance has_measurable_mul₂.to_has_measurable_mul [has_measurable_mul₂ M] :
@@ -97,10 +103,15 @@ lemma measurable.const_mul [has_measurable_mul M] {f : α → M} (hf : measurabl
 (measurable_const_mul c).comp hf
 
 @[to_additive]
-lemma ae_measurable.const_mul [has_measurable_mul M] {f : α → M} {μ : measure α}
-  (hf : ae_measurable f μ) (c : M) :
+lemma ae_measurable'.const_mul [has_measurable_mul M] {f : α → M}
+  (hf : ae_measurable' m f μ) (c : M) :
+  ae_measurable' m (λ x, c * f x) μ :=
+(has_measurable_mul.measurable_const_mul c).comp_ae_measurable' hf
+
+@[to_additive]
+lemma ae_measurable.const_mul [has_measurable_mul M] {f : α → M} (hf : ae_measurable f μ) (c : M) :
   ae_measurable (λ x, c * f x) μ :=
-(has_measurable_mul.measurable_const_mul c).comp_ae_measurable hf
+hf.const_mul c
 
 @[to_additive]
 lemma measurable.mul_const [has_measurable_mul M] {f : α → M} (hf : measurable f) (c : M) :
@@ -108,10 +119,15 @@ lemma measurable.mul_const [has_measurable_mul M] {f : α → M} (hf : measurabl
 (measurable_mul_const c).comp hf
 
 @[to_additive]
-lemma ae_measurable.mul_const [has_measurable_mul M] {f : α → M} {μ : measure α}
-  (hf : ae_measurable f μ) (c : M) :
+lemma ae_measurable'.mul_const [has_measurable_mul M] {f : α → M}
+  (hf : ae_measurable' m f μ) (c : M) :
+  ae_measurable' m (λ x, f x * c) μ :=
+(measurable_mul_const c).comp_ae_measurable' hf
+
+@[to_additive]
+lemma ae_measurable.mul_const [has_measurable_mul M] {f : α → M} (hf : ae_measurable f μ) (c : M) :
   ae_measurable (λ x, f x * c) μ :=
-(measurable_mul_const c).comp_ae_measurable hf
+hf.mul_const c
 
 end mul
 
@@ -140,16 +156,24 @@ lemma measurable.pow {f : α → β} {g : α → γ} (hf : measurable f) (hg : m
   measurable (λ x, f x ^ g x) :=
 measurable_pow.comp (hf.prod_mk hg)
 
-lemma ae_measurable.pow {μ : measure α} {f : α → β} {g : α → γ} (hf : ae_measurable f μ)
-  (hg : ae_measurable g μ) :
+lemma ae_measurable'.pow  {f : α → β} {g : α → γ} (hf : ae_measurable' m f μ)
+  (hg : ae_measurable' m g μ) :
+  ae_measurable' m (λ x, f x ^ g x) μ :=
+measurable_pow.comp_ae_measurable' (hf.prod_mk hg)
+
+lemma ae_measurable.pow {f : α → β} {g : α → γ} (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
   ae_measurable (λ x, f x ^ g x) μ :=
-measurable_pow.comp_ae_measurable (hf.prod_mk hg)
+hf.pow hg
 
 lemma measurable.pow_const {f : α → β} (hf : measurable f) (c : γ) :
   measurable (λ x, f x ^ c) :=
 hf.pow measurable_const
 
-lemma ae_measurable.pow_const {μ : measure α} {f : α → β} (hf : ae_measurable f μ) (c : γ) :
+lemma ae_measurable'.pow_const {f : α → β} (hf : ae_measurable' m f μ) (c : γ) :
+  ae_measurable' m (λ x, f x ^ c) μ :=
+hf.pow (ae_measurable'_const m)
+
+lemma ae_measurable.pow_const {f : α → β} (hf : ae_measurable f μ) (c : γ) :
   ae_measurable (λ x, f x ^ c) μ :=
 hf.pow ae_measurable_const
 
@@ -157,7 +181,11 @@ lemma measurable.const_pow {f : α → γ} (hf : measurable f) (c : β) :
   measurable (λ x, c ^ f x) :=
 measurable_const.pow hf
 
-lemma ae_measurable.const_pow {μ : measure α} {f : α → γ} (hf : ae_measurable f μ) (c : β) :
+lemma ae_measurable'.const_pow {f : α → γ} (hf : ae_measurable' m f μ) (c : β) :
+  ae_measurable' m (λ x, c ^ f x) μ :=
+(ae_measurable'_const m).pow hf
+
+lemma ae_measurable.const_pow {f : α → γ} (hf : ae_measurable f μ) (c : β) :
   ae_measurable (λ x, c ^ f x) μ :=
 ae_measurable_const.pow hf
 
@@ -200,10 +228,16 @@ lemma measurable.div [has_measurable_div₂ G] {f g : α → G} (hf : measurable
 measurable_div.comp (hf.prod_mk hg)
 
 @[to_additive]
-lemma ae_measurable.div [has_measurable_div₂ G] {f g : α → G} {μ : measure α}
+lemma ae_measurable'.div [has_measurable_div₂ G] {f g : α → G}
+  (hf : ae_measurable' m f μ) (hg : ae_measurable' m g μ) :
+  ae_measurable' m (λ a, f a / g a) μ :=
+measurable_div.comp_ae_measurable' (hf.prod_mk hg)
+
+@[to_additive]
+lemma ae_measurable.div [has_measurable_div₂ G] {f g : α → G}
   (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
   ae_measurable (λ a, f a / g a) μ :=
-measurable_div.comp_ae_measurable (hf.prod_mk hg)
+hf.div hg
 
 @[priority 100, to_additive]
 instance has_measurable_div₂.to_has_measurable_div [has_measurable_div₂ G] :
@@ -216,10 +250,15 @@ lemma measurable.const_div [has_measurable_div G] {f : α → G} (hf : measurabl
 (has_measurable_div.measurable_const_div c).comp hf
 
 @[to_additive]
-lemma ae_measurable.const_div [has_measurable_div G] {f : α → G} {μ : measure α}
-  (hf : ae_measurable f μ) (c : G) :
+lemma ae_measurable'.const_div [has_measurable_div G] {f : α → G}
+  (hf : ae_measurable' m f μ) (c : G) :
+  ae_measurable' m (λ x, c / f x) μ :=
+(has_measurable_div.measurable_const_div c).comp_ae_measurable' hf
+
+@[to_additive]
+lemma ae_measurable.const_div [has_measurable_div G] {f : α → G} (hf : ae_measurable f μ) (c : G) :
   ae_measurable (λ x, c / f x) μ :=
-(has_measurable_div.measurable_const_div c).comp_ae_measurable hf
+hf.const_div c
 
 @[to_additive]
 lemma measurable.div_const [has_measurable_div G] {f : α → G} (hf : measurable f) (c : G) :
@@ -227,10 +266,15 @@ lemma measurable.div_const [has_measurable_div G] {f : α → G} (hf : measurabl
 (has_measurable_div.measurable_div_const c).comp hf
 
 @[to_additive]
-lemma ae_measurable.div_const [has_measurable_div G] {f : α → G} {μ : measure α}
-  (hf : ae_measurable f μ) (c : G) :
+lemma ae_measurable'.div_const [has_measurable_div G] {f : α → G}
+  (hf : ae_measurable' m f μ) (c : G) :
+  ae_measurable' m (λ x, f x / c) μ :=
+(has_measurable_div.measurable_div_const c).comp_ae_measurable' hf
+
+@[to_additive]
+lemma ae_measurable.div_const [has_measurable_div G] {f : α → G} (hf : ae_measurable f μ) (c : G) :
   ae_measurable (λ x, f x / c) μ :=
-(has_measurable_div.measurable_div_const c).comp_ae_measurable hf
+hf.div_const c
 
 end div
 
@@ -262,28 +306,42 @@ variables {G : Type*} [has_inv G] [measurable_space G] [has_measurable_inv G]
   measurable (λ x, (f x)⁻¹) :=
 measurable_inv.comp hf
 
-@[to_additive] lemma ae_measurable.inv {f : α → G} {μ : measure α} (hf : ae_measurable f μ) :
+@[to_additive] lemma ae_measurable'.inv {f : α → G} (hf : ae_measurable' m f μ) :
+  ae_measurable' m (λ x, (f x)⁻¹) μ :=
+measurable_inv.comp_ae_measurable' hf
+
+@[to_additive] lemma ae_measurable.inv {f : α → G} (hf : ae_measurable f μ) :
   ae_measurable (λ x, (f x)⁻¹) μ :=
-measurable_inv.comp_ae_measurable hf
+hf.inv
 
 @[simp, to_additive] lemma measurable_inv_iff {G : Type*} [group G] [measurable_space G]
   [has_measurable_inv G] {f : α → G} : measurable (λ x, (f x)⁻¹) ↔ measurable f :=
 ⟨λ h, by simpa only [inv_inv] using h.inv, λ h, h.inv⟩
 
-@[simp, to_additive] lemma ae_measurable_inv_iff {G : Type*} [group G] [measurable_space G]
-  [has_measurable_inv G] {f : α → G} {μ : measure α} :
-  ae_measurable (λ x, (f x)⁻¹) μ ↔ ae_measurable f μ :=
+@[simp, to_additive] lemma ae_measurable'_inv_iff {G : Type*} [group G] [measurable_space G]
+  [has_measurable_inv G] {f : α → G} :
+  ae_measurable' m (λ x, (f x)⁻¹) μ ↔ ae_measurable' m f μ :=
 ⟨λ h, by simpa only [inv_inv] using h.inv, λ h, h.inv⟩
+
+@[simp, to_additive] lemma ae_measurable_inv_iff {G : Type*} [group G] [measurable_space G]
+  [has_measurable_inv G] {f : α → G} :
+  ae_measurable (λ x, (f x)⁻¹) μ ↔ ae_measurable f μ :=
+ae_measurable'_inv_iff
 
 @[simp] lemma measurable_inv_iff' {G₀ : Type*} [group_with_zero G₀]
   [measurable_space G₀] [has_measurable_inv G₀] {f : α → G₀} :
   measurable (λ x, (f x)⁻¹) ↔ measurable f :=
 ⟨λ h, by simpa only [inv_inv'] using h.inv, λ h, h.inv⟩
 
-@[simp] lemma ae_measurable_inv_iff' {G₀ : Type*} [group_with_zero G₀]
-  [measurable_space G₀] [has_measurable_inv G₀] {f : α → G₀} {μ : measure α} :
-  ae_measurable (λ x, (f x)⁻¹) μ ↔ ae_measurable f μ :=
+@[simp] lemma ae_measurable'_inv_iff' {G₀ : Type*} [group_with_zero G₀]
+  [measurable_space G₀] [has_measurable_inv G₀] {f : α → G₀} :
+  ae_measurable' m (λ x, (f x)⁻¹) μ ↔ ae_measurable' m f μ :=
 ⟨λ h, by simpa only [inv_inv'] using h.inv, λ h, h.inv⟩
+
+@[simp] lemma ae_measurable_inv_iff' {G₀ : Type*} [group_with_zero G₀]
+  [measurable_space G₀] [has_measurable_inv G₀] {f : α → G₀} :
+  ae_measurable (λ x, (f x)⁻¹) μ ↔ ae_measurable f μ :=
+ae_measurable'_inv_iff'
 
 end inv
 
@@ -352,36 +410,53 @@ lemma measurable.smul [has_measurable_smul₂ M β]
   measurable (λ x, f x • g x) :=
 measurable_smul.comp (hf.prod_mk hg)
 
+lemma ae_measurable'.smul [has_measurable_smul₂ M β]
+  {f : α → M} {g : α → β} (hf : ae_measurable' m f μ) (hg : ae_measurable' m g μ) :
+  ae_measurable' m (λ x, f x • g x) μ :=
+has_measurable_smul₂.measurable_smul.comp_ae_measurable' (hf.prod_mk hg)
+
 lemma ae_measurable.smul [has_measurable_smul₂ M β]
-  {f : α → M} {g : α → β} {μ : measure α} (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
+  {f : α → M} {g : α → β} (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
   ae_measurable (λ x, f x • g x) μ :=
-has_measurable_smul₂.measurable_smul.comp_ae_measurable (hf.prod_mk hg)
+hf.smul hg
 
 @[priority 100]
 instance has_measurable_smul₂.to_has_measurable_smul [has_measurable_smul₂ M β] :
   has_measurable_smul M β :=
 ⟨λ c, measurable_const.smul measurable_id, λ y, measurable_id.smul measurable_const⟩
 
-variables [has_measurable_smul M β] {μ : measure α}
+variables [has_measurable_smul M β]
 
 lemma measurable.smul_const {f : α → M} (hf : measurable f) (y : β) : measurable (λ x, f x • y) :=
 (has_measurable_smul.measurable_smul_const y).comp hf
 
+lemma ae_measurable'.smul_const {f : α → M} (hf : ae_measurable' m f μ) (y : β) :
+  ae_measurable' m (λ x, f x • y) μ :=
+(has_measurable_smul.measurable_smul_const y).comp_ae_measurable' hf
+
 lemma ae_measurable.smul_const {f : α → M} (hf : ae_measurable f μ) (y : β) :
   ae_measurable (λ x, f x • y) μ :=
-(has_measurable_smul.measurable_smul_const y).comp_ae_measurable hf
+hf.smul_const y
 
 lemma measurable.const_smul' {f : α → β} (hf : measurable f) (c : M) :
   measurable (λ x, c • f x) :=
 (has_measurable_smul.measurable_const_smul c).comp hf
 
+lemma ae_measurable'.const_smul' {f : α → β} (hf : ae_measurable' m f μ) (c : M) :
+  ae_measurable' m (λ x, c • f x) μ :=
+(has_measurable_smul.measurable_const_smul c).comp_ae_measurable' hf
+
+lemma ae_measurable.const_smul' {f : α → β} (hf : ae_measurable f μ) (c : M) :
+  ae_measurable (λ x, c • f x) μ :=
+hf.const_smul' c
+
 lemma measurable.const_smul {f : α → β} (hf : measurable f) (c : M) :
   measurable (c • f) :=
 hf.const_smul' c
 
-lemma ae_measurable.const_smul' {f : α → β} (hf : ae_measurable f μ) (c : M) :
-  ae_measurable (λ x, c • f x) μ :=
-(has_measurable_smul.measurable_const_smul c).comp_ae_measurable hf
+lemma ae_measurable'.const_smul {f : α → β} (hf : ae_measurable' m f μ) (c : M) :
+  ae_measurable' m (c • f) μ :=
+hf.const_smul' c
 
 lemma ae_measurable.const_smul {f : α → β} (hf : ae_measurable f μ) (c : M) :
   ae_measurable (c • f) μ :=
@@ -392,7 +467,7 @@ end smul
 section mul_action
 
 variables {M β : Type*} [measurable_space M] [measurable_space β] [monoid M] [mul_action M β]
-  [has_measurable_smul M β] {f : α → β} {μ : measure α}
+  [has_measurable_smul M β] {f : α → β}
 
 variables {G : Type*} [group G] [measurable_space G] [mul_action G β]
   [has_measurable_smul G β]
@@ -401,9 +476,13 @@ lemma measurable_const_smul_iff (c : G) :
   measurable (λ x, c • f x) ↔ measurable f :=
 ⟨λ h, by simpa only [inv_smul_smul] using h.const_smul' c⁻¹, λ h, h.const_smul c⟩
 
+lemma ae_measurable'_const_smul_iff (c : G) :
+  ae_measurable' m (λ x, c • f x) μ ↔ ae_measurable' m f μ :=
+⟨λ h, by simpa only [inv_smul_smul] using h.const_smul' c⁻¹, λ h, h.const_smul c⟩
+
 lemma ae_measurable_const_smul_iff (c : G) :
   ae_measurable (λ x, c • f x) μ ↔ ae_measurable f μ :=
-⟨λ h, by simpa only [inv_smul_smul] using h.const_smul' c⁻¹, λ h, h.const_smul c⟩
+ae_measurable'_const_smul_iff c
 
 instance : measurable_space (units M) := measurable_space.comap (coe : units M → M) ‹_›
 
@@ -416,9 +495,13 @@ lemma is_unit.measurable_const_smul_iff {c : M} (hc : is_unit c) :
   measurable (λ x, c • f x) ↔ measurable f :=
 let ⟨u, hu⟩ := hc in hu ▸ measurable_const_smul_iff u
 
+lemma is_unit.ae_measurable'_const_smul_iff {c : M} (hc : is_unit c) :
+  ae_measurable' m (λ x, c • f x) μ ↔ ae_measurable' m f μ :=
+let ⟨u, hu⟩ := hc in hu ▸ ae_measurable'_const_smul_iff u
+
 lemma is_unit.ae_measurable_const_smul_iff {c : M} (hc : is_unit c) :
   ae_measurable (λ x, c • f x) μ ↔ ae_measurable f μ :=
-let ⟨u, hu⟩ := hc in hu ▸ ae_measurable_const_smul_iff u
+is_unit.ae_measurable'_const_smul_iff hc
 
 variables {G₀ : Type*} [group_with_zero G₀] [measurable_space G₀] [mul_action G₀ β]
   [has_measurable_smul G₀ β]
@@ -427,9 +510,13 @@ lemma measurable_const_smul_iff' {c : G₀} (hc : c ≠ 0) :
   measurable (λ x, c • f x) ↔ measurable f :=
 (is_unit.mk0 c hc).measurable_const_smul_iff
 
+lemma ae_measurable'_const_smul_iff' {c : G₀} (hc : c ≠ 0) :
+  ae_measurable' m (λ x, c • f x) μ ↔ ae_measurable' m f μ :=
+(is_unit.mk0 c hc).ae_measurable'_const_smul_iff
+
 lemma ae_measurable_const_smul_iff' {c : G₀} (hc : c ≠ 0) :
   ae_measurable (λ x, c • f x) μ ↔ ae_measurable f μ :=
-(is_unit.mk0 c hc).ae_measurable_const_smul_iff
+ae_measurable'_const_smul_iff' hc
 
 end mul_action
 
@@ -449,15 +536,21 @@ begin
 end
 
 @[to_additive]
-lemma list.ae_measurable_prod' {M : Type*} [monoid M] [measurable_space M] [has_measurable_mul₂ M]
-  {μ : measure α} (l : list (α → M)) (hl : ∀ f ∈ l, ae_measurable f μ) :
-  ae_measurable l.prod μ :=
+lemma list.ae_measurable'_prod' {M : Type*} [monoid M] [measurable_space M] [has_measurable_mul₂ M]
+  (l : list (α → M)) (hl : ∀ f ∈ l, ae_measurable' m f μ) :
+  ae_measurable' m l.prod μ :=
 begin
-  induction l with f l ihl, { exact ae_measurable_one },
+  induction l with f l ihl, { exact ae_measurable'_one m, },
   rw [list.forall_mem_cons] at hl,
   rw [list.prod_cons],
   exact hl.1.mul (ihl hl.2)
 end
+
+@[to_additive]
+lemma list.ae_measurable_prod' {M : Type*} [monoid M] [measurable_space M] [has_measurable_mul₂ M]
+  (l : list (α → M)) (hl : ∀ f ∈ l, ae_measurable f μ) :
+  ae_measurable l.prod μ :=
+list.ae_measurable'_prod' l hl
 
 @[to_additive]
 lemma list.measurable_prod {M : Type*} [monoid M] [measurable_space M] [has_measurable_mul₂ M]
@@ -466,10 +559,16 @@ lemma list.measurable_prod {M : Type*} [monoid M] [measurable_space M] [has_meas
 by simpa only [← pi.list_prod_apply] using l.measurable_prod' hl
 
 @[to_additive]
+lemma list.ae_measurable'_prod {M : Type*} [monoid M] [measurable_space M] [has_measurable_mul₂ M]
+  (l : list (α → M)) (hl : ∀ f ∈ l, ae_measurable' m f μ) :
+  ae_measurable' m (λ x, (l.map (λ f : α → M, f x)).prod) μ :=
+by simpa only [← pi.list_prod_apply] using l.ae_measurable'_prod' hl
+
+@[to_additive]
 lemma list.ae_measurable_prod {M : Type*} [monoid M] [measurable_space M] [has_measurable_mul₂ M]
-  {μ : measure α} (l : list (α → M)) (hl : ∀ f ∈ l, ae_measurable f μ) :
+  (l : list (α → M)) (hl : ∀ f ∈ l, ae_measurable f μ) :
   ae_measurable (λ x, (l.map (λ f : α → M, f x)).prod) μ :=
-by simpa only [← pi.list_prod_apply] using l.ae_measurable_prod' hl
+list.ae_measurable'_prod l hl
 
 @[to_additive]
 lemma multiset.measurable_prod' {M : Type*} [comm_monoid M] [measurable_space M]
@@ -478,10 +577,16 @@ lemma multiset.measurable_prod' {M : Type*} [comm_monoid M] [measurable_space M]
 by { rcases l with ⟨l⟩, simpa using l.measurable_prod' (by simpa using hl) }
 
 @[to_additive]
+lemma multiset.ae_measurable'_prod' {M : Type*} [comm_monoid M] [measurable_space M]
+  [has_measurable_mul₂ M] (l : multiset (α → M)) (hl : ∀ f ∈ l, ae_measurable' m f μ) :
+  ae_measurable' m l.prod μ :=
+by { rcases l with ⟨l⟩, simpa using l.ae_measurable'_prod' (by simpa using hl) }
+
+@[to_additive]
 lemma multiset.ae_measurable_prod' {M : Type*} [comm_monoid M] [measurable_space M]
-  [has_measurable_mul₂ M] {μ : measure α} (l : multiset (α → M)) (hl : ∀ f ∈ l, ae_measurable f μ) :
+  [has_measurable_mul₂ M] (l : multiset (α → M)) (hl : ∀ f ∈ l, ae_measurable f μ) :
   ae_measurable l.prod μ :=
-by { rcases l with ⟨l⟩, simpa using l.ae_measurable_prod' (by simpa using hl) }
+multiset.ae_measurable'_prod' l hl
 
 @[to_additive]
 lemma multiset.measurable_prod {M : Type*} [comm_monoid M] [measurable_space M]
@@ -490,10 +595,16 @@ lemma multiset.measurable_prod {M : Type*} [comm_monoid M] [measurable_space M]
 by simpa only [← pi.multiset_prod_apply] using s.measurable_prod' hs
 
 @[to_additive]
+lemma multiset.ae_measurable'_prod {M : Type*} [comm_monoid M] [measurable_space M]
+  [has_measurable_mul₂ M] (s : multiset (α → M)) (hs : ∀ f ∈ s, ae_measurable' m f μ) :
+  ae_measurable' m (λ x, (s.map (λ f : α → M, f x)).prod) μ :=
+by simpa only [← pi.multiset_prod_apply] using s.ae_measurable'_prod' hs
+
+@[to_additive]
 lemma multiset.ae_measurable_prod {M : Type*} [comm_monoid M] [measurable_space M]
-  [has_measurable_mul₂ M] {μ : measure α} (s : multiset (α → M)) (hs : ∀ f ∈ s, ae_measurable f μ) :
+  [has_measurable_mul₂ M] (s : multiset (α → M)) (hs : ∀ f ∈ s, ae_measurable f μ) :
   ae_measurable (λ x, (s.map (λ f : α → M, f x)).prod) μ :=
-by simpa only [← pi.multiset_prod_apply] using s.ae_measurable_prod' hs
+s.ae_measurable'_prod hs
 
 @[to_additive]
 lemma finset.measurable_prod' {ι M : Type*} [comm_monoid M] [measurable_space M]
@@ -502,22 +613,32 @@ lemma finset.measurable_prod' {ι M : Type*} [comm_monoid M] [measurable_space M
 finset.prod_induction _ _ (λ _ _, measurable.mul) (@measurable_one M _ _ _ _) hf
 
 @[to_additive]
+lemma finset.ae_measurable'_prod' {ι M : Type*} [comm_monoid M] [measurable_space M]
+  [has_measurable_mul₂ M] {f : ι → α → M} (s : finset ι) (hf : ∀i ∈ s, ae_measurable' m (f i) μ) :
+  ae_measurable' m (∏ i in s, f i) μ :=
+multiset.ae_measurable'_prod' _ $
+  λ g hg, let ⟨i, hi, hg⟩ := multiset.mem_map.1 hg in (hg ▸ hf _ hi)
+
+@[to_additive]
+lemma finset.ae_measurable_prod' {ι M : Type*} [comm_monoid M] [measurable_space M]
+  [has_measurable_mul₂ M] {f : ι → α → M} (s : finset ι) (hf : ∀i ∈ s, ae_measurable (f i) μ) :
+  ae_measurable (∏ i in s, f i) μ :=
+s.ae_measurable'_prod' hf
+
+@[to_additive]
 lemma finset.measurable_prod {ι M : Type*} [comm_monoid M] [measurable_space M]
   [has_measurable_mul₂ M] {f : ι → α → M} (s : finset ι) (hf : ∀i ∈ s, measurable (f i)) :
   measurable (λ a, ∏ i in s, f i a) :=
 by simpa only [← finset.prod_apply] using s.measurable_prod' hf
 
 @[to_additive]
-lemma finset.ae_measurable_prod' {ι M : Type*} [comm_monoid M] [measurable_space M]
-  [has_measurable_mul₂ M] {μ : measure α} {f : ι → α → M} (s : finset ι)
-  (hf : ∀i ∈ s, ae_measurable (f i) μ) :
-  ae_measurable (∏ i in s, f i) μ :=
-multiset.ae_measurable_prod' _ $
-  λ g hg, let ⟨i, hi, hg⟩ := multiset.mem_map.1 hg in (hg ▸ hf _ hi)
+lemma finset.ae_measurable'_prod {ι M : Type*} [comm_monoid M] [measurable_space M]
+  [has_measurable_mul₂ M] {f : ι → α → M} (s : finset ι) (hf : ∀i ∈ s, ae_measurable' m (f i) μ) :
+  ae_measurable' m (λ a, ∏ i in s, f i a) μ :=
+by simpa only [← finset.prod_apply] using s.ae_measurable'_prod' hf
 
 @[to_additive]
 lemma finset.ae_measurable_prod {ι M : Type*} [comm_monoid M] [measurable_space M]
-  [has_measurable_mul₂ M] {f : ι → α → M} {μ : measure α} (s : finset ι)
-  (hf : ∀i ∈ s, ae_measurable (f i) μ) :
+  [has_measurable_mul₂ M] {f : ι → α → M} (s : finset ι) (hf : ∀i ∈ s, ae_measurable (f i) μ) :
   ae_measurable (λ a, ∏ i in s, f i a) μ :=
-by simpa only [← finset.prod_apply] using s.ae_measurable_prod' hf
+s.ae_measurable'_prod hf

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -1147,47 +1147,40 @@ by { simp_rw [ennreal.tsum_eq_supr_sum], apply ae_measurable_supr,
 section normed_group
 
 variables [normed_group α] [opens_measurable_space α] {mβ : measurable_space β} [measurable_space β]
+  {f : β → α} {μ : measure β}
 
-lemma measurable_norm : measurable (norm : α → ℝ) :=
-continuous_norm.measurable
+lemma measurable_norm : measurable (norm : α → ℝ) := continuous_norm.measurable
 
-lemma measurable.norm {f : β → α} (hf : measurable f) : measurable (λ a, norm (f a)) :=
-measurable_norm.comp hf
+lemma measurable.norm (hf : measurable f) : measurable (λ a, norm (f a)) := measurable_norm.comp hf
 
-lemma ae_measurable'.norm {f : β → α} {μ : measure β} (hf : ae_measurable' mβ f μ) :
-  ae_measurable' mβ (λ a, norm (f a)) μ :=
+lemma ae_measurable'.norm (hf : ae_measurable' mβ f μ) : ae_measurable' mβ (λ a, norm (f a)) μ :=
 measurable_norm.comp_ae_measurable' hf
 
-lemma ae_measurable.norm {f : β → α} {μ : measure β} (hf : ae_measurable f μ) :
-  ae_measurable (λ a, norm (f a)) μ :=
+lemma ae_measurable.norm (hf : ae_measurable f μ) : ae_measurable (λ a, norm (f a)) μ :=
 hf.norm
 
-lemma measurable_nnnorm : measurable (nnnorm : α → ℝ≥0) :=
-continuous_nnnorm.measurable
+lemma measurable_nnnorm : measurable (nnnorm : α → ℝ≥0) := continuous_nnnorm.measurable
 
-lemma measurable.nnnorm {f : β → α} (hf : measurable f) : measurable (λ a, nnnorm (f a)) :=
+lemma measurable.nnnorm (hf : measurable f) : measurable (λ a, nnnorm (f a)) :=
 measurable_nnnorm.comp hf
 
-lemma ae_measurable'.nnnorm {f : β → α} {μ : measure β} (hf : ae_measurable' mβ f μ) :
+lemma ae_measurable'.nnnorm (hf : ae_measurable' mβ f μ) :
   ae_measurable' mβ (λ a, nnnorm (f a)) μ :=
 measurable_nnnorm.comp_ae_measurable' hf
 
-lemma ae_measurable.nnnorm {f : β → α} {μ : measure β} (hf : ae_measurable f μ) :
-  ae_measurable (λ a, nnnorm (f a)) μ :=
+lemma ae_measurable.nnnorm (hf : ae_measurable f μ) : ae_measurable (λ a, nnnorm (f a)) μ :=
 hf.nnnorm
 
-lemma measurable_ennnorm : measurable (λ x : α, (nnnorm x : ℝ≥0∞)) :=
-measurable_nnnorm.ennreal_coe
+lemma measurable_ennnorm : measurable (λ x : α, (nnnorm x : ℝ≥0∞)) := measurable_nnnorm.ennreal_coe
 
-lemma measurable.ennnorm {f : β → α} (hf : measurable f) :
-  measurable (λ a, (nnnorm (f a) : ℝ≥0∞)) :=
+lemma measurable.ennnorm (hf : measurable f) : measurable (λ a, (nnnorm (f a) : ℝ≥0∞)) :=
 hf.nnnorm.ennreal_coe
 
-lemma ae_measurable'.ennnorm {f : β → α} {μ : measure β} (hf : ae_measurable' mβ f μ) :
+lemma ae_measurable'.ennnorm (hf : ae_measurable' mβ f μ) :
   ae_measurable' mβ (λ a, (nnnorm (f a) : ℝ≥0∞)) μ :=
 measurable_ennnorm.comp_ae_measurable' hf
 
-lemma ae_measurable.ennnorm {f : β → α} {μ : measure β} (hf : ae_measurable f μ) :
+lemma ae_measurable.ennnorm (hf : ae_measurable f μ) :
   ae_measurable (λ a, (nnnorm (f a) : ℝ≥0∞)) μ :=
 hf.ennnorm
 

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -181,10 +181,10 @@ instance subtype.opens_measurable_space {α : Type*} [topological_space α] [mea
 
 section
 variables [topological_space α] [measurable_space α] [opens_measurable_space α]
-   [topological_space β] [measurable_space β] [opens_measurable_space β]
-   [topological_space γ] [measurable_space γ] [borel_space γ]
-   [topological_space γ₂] [measurable_space γ₂] [borel_space γ₂]
-   [measurable_space δ]
+  [topological_space β] [measurable_space β] [opens_measurable_space β]
+  [topological_space γ] [measurable_space γ] [borel_space γ]
+  [topological_space γ₂] [measurable_space γ₂] [borel_space γ₂]
+  {mδ : measurable_space δ} [measurable_space δ]
 
 lemma is_open.measurable_set (h : is_open s) : measurable_set s :=
 opens_measurable_space.borel_le _ $ generate_measurable.basic _ h
@@ -363,19 +363,31 @@ lemma measurable.max {f g : δ → α} (hf : measurable f) (hg : measurable g) :
   measurable (λ a, max (f a) (g a)) :=
 hf.piecewise (measurable_set_le hg hf) hg
 
+lemma ae_measurable'.max {f g : δ → α} {μ : measure δ}
+  (hf : ae_measurable' mδ f μ) (hg : ae_measurable' mδ g μ) :
+  ae_measurable' mδ (λ a, max (f a) (g a)) μ :=
+⟨λ a, max (hf.mk f a) (hg.mk g a),
+  @measurable.max _ δ _ _ _ mδ _ _ _ _ _ hf.measurable_mk hg.measurable_mk,
+  eventually_eq.comp₂ hf.ae_eq_mk _ hg.ae_eq_mk⟩
+
 lemma ae_measurable.max {f g : δ → α} {μ : measure δ}
   (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ a, max (f a) (g a)) μ :=
-⟨λ a, max (hf.mk f a) (hg.mk g a), hf.measurable_mk.max hg.measurable_mk,
-  eventually_eq.comp₂ hf.ae_eq_mk _ hg.ae_eq_mk⟩
+hf.max hg
 
 lemma measurable.min {f g : δ → α} (hf : measurable f) (hg : measurable g) :
   measurable (λ a, min (f a) (g a)) :=
 hf.piecewise (measurable_set_le hf hg) hg
 
+lemma ae_measurable'.min {f g : δ → α} {μ : measure δ}
+  (hf : ae_measurable' mδ f μ) (hg : ae_measurable' mδ g μ) :
+  ae_measurable' mδ (λ a, min (f a) (g a)) μ :=
+⟨λ a, min (hf.mk f a) (hg.mk g a),
+  @measurable.min _ δ _ _ _ mδ _ _ _ _ _ hf.measurable_mk hg.measurable_mk,
+  eventually_eq.comp₂ hf.ae_eq_mk _ hg.ae_eq_mk⟩
+
 lemma ae_measurable.min {f g : δ → α} {μ : measure δ}
   (hf : ae_measurable f μ) (hg : ae_measurable g μ) : ae_measurable (λ a, min (f a) (g a)) μ :=
-⟨λ a, min (hf.mk f a) (hg.mk g a), hf.measurable_mk.min hg.measurable_mk,
-  eventually_eq.comp₂ hf.ae_eq_mk _ hg.ae_eq_mk⟩
+hf.min hg
 
 end linear_order
 
@@ -1002,7 +1014,7 @@ end
 
 end real
 
-variable [measurable_space α]
+variables {mα : measurable_space α} [measurable_space α]
 
 lemma measurable.nnreal_of_real {f : α → ℝ} (hf : measurable f) :
   measurable (λ x, nnreal.of_real (f x)) :=
@@ -1105,9 +1117,13 @@ lemma measurable.to_real {f : α → ℝ≥0∞} (hf : measurable f) :
   measurable (λ x, ennreal.to_real (f x)) :=
 ennreal.measurable_to_real.comp hf
 
+lemma ae_measurable'.to_real {f : α → ℝ≥0∞} {μ : measure α} (hf : ae_measurable' mα f μ) :
+  ae_measurable' mα (λ x, ennreal.to_real (f x)) μ :=
+ennreal.measurable_to_real.comp_ae_measurable' hf
+
 lemma ae_measurable.to_real {f : α → ℝ≥0∞} {μ : measure α} (hf : ae_measurable f μ) :
   ae_measurable (λ x, ennreal.to_real (f x)) μ :=
-ennreal.measurable_to_real.comp_ae_measurable hf
+hf.to_real
 
 /-- note: `ℝ≥0∞` can probably be generalized in a future version of this lemma. -/
 lemma measurable.ennreal_tsum {ι} [encodable ι] {f : ι → α → ℝ≥0∞} (h : ∀ i, measurable (f i)) :
@@ -1130,7 +1146,7 @@ by { simp_rw [ennreal.tsum_eq_supr_sum], apply ae_measurable_supr,
 
 section normed_group
 
-variables [normed_group α] [opens_measurable_space α] [measurable_space β]
+variables [normed_group α] [opens_measurable_space α] {mβ : measurable_space β} [measurable_space β]
 
 lemma measurable_norm : measurable (norm : α → ℝ) :=
 continuous_norm.measurable
@@ -1138,9 +1154,13 @@ continuous_norm.measurable
 lemma measurable.norm {f : β → α} (hf : measurable f) : measurable (λ a, norm (f a)) :=
 measurable_norm.comp hf
 
+lemma ae_measurable'.norm {f : β → α} {μ : measure β} (hf : ae_measurable' mβ f μ) :
+  ae_measurable' mβ (λ a, norm (f a)) μ :=
+measurable_norm.comp_ae_measurable' hf
+
 lemma ae_measurable.norm {f : β → α} {μ : measure β} (hf : ae_measurable f μ) :
   ae_measurable (λ a, norm (f a)) μ :=
-measurable_norm.comp_ae_measurable hf
+hf.norm
 
 lemma measurable_nnnorm : measurable (nnnorm : α → ℝ≥0) :=
 continuous_nnnorm.measurable
@@ -1148,9 +1168,13 @@ continuous_nnnorm.measurable
 lemma measurable.nnnorm {f : β → α} (hf : measurable f) : measurable (λ a, nnnorm (f a)) :=
 measurable_nnnorm.comp hf
 
+lemma ae_measurable'.nnnorm {f : β → α} {μ : measure β} (hf : ae_measurable' mβ f μ) :
+  ae_measurable' mβ (λ a, nnnorm (f a)) μ :=
+measurable_nnnorm.comp_ae_measurable' hf
+
 lemma ae_measurable.nnnorm {f : β → α} {μ : measure β} (hf : ae_measurable f μ) :
   ae_measurable (λ a, nnnorm (f a)) μ :=
-measurable_nnnorm.comp_ae_measurable hf
+hf.nnnorm
 
 lemma measurable_ennnorm : measurable (λ x : α, (nnnorm x : ℝ≥0∞)) :=
 measurable_nnnorm.ennreal_coe
@@ -1159,9 +1183,13 @@ lemma measurable.ennnorm {f : β → α} (hf : measurable f) :
   measurable (λ a, (nnnorm (f a) : ℝ≥0∞)) :=
 hf.nnnorm.ennreal_coe
 
+lemma ae_measurable'.ennnorm {f : β → α} {μ : measure β} (hf : ae_measurable' mβ f μ) :
+  ae_measurable' mβ (λ a, (nnnorm (f a) : ℝ≥0∞)) μ :=
+measurable_ennnorm.comp_ae_measurable' hf
+
 lemma ae_measurable.ennnorm {f : β → α} {μ : measure β} (hf : ae_measurable f μ) :
   ae_measurable (λ a, (nnnorm (f a) : ℝ≥0∞)) μ :=
-measurable_ennnorm.comp_ae_measurable hf
+hf.ennnorm
 
 end normed_group
 


### PR DESCRIPTION
For two `measurable_space` structures `m, m0` and a measure `µ` on `m0`, this PR defines `ae_measurable' m f µ`, property that `f` is `µ`-almost-everywhere equal to a `m`-measurable function. It also redefines `ae_measurable f µ` to mean `ae_measurable' m0 f µ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The intended use is for `m ≤ m0`, but this property is not necessary in most lemmas. In a future PR towards defining a conditional expectation, I want to define the subspace of Lp which contains `m`-measurable "functions": since the element of Lp are classes of `µ`-a.e. equal functions, two measurable space structures `m` and `m0` are present.

I decided to add a new definition instead of replacing the existing definition of `ae_measurable` in order to keep the simpler one available in the many contexts in which only one measurable space is considered. This results in a lot of duplication: even though the ae_measurable' lemmas apply to ae_measurable, having both versions prevents `refine` from introducing `ae_measurable'` where only `ae_measurable` is necessary.

I reordered the lemmas in `measure_space` but every result should still be there. There are also two new lemmas about `ae_measurable'/ae_measurable`: `ae_measurable.restrict` and `ae_measurable.indicator`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
