### PR TITLE
[Merged by Bors] - chore(logic/basic): add simp lemmas about exist_unique to match those about exists

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -839,7 +839,7 @@ forall_true_iff' $ λ _, forall_2_true_iff
 @[simp] theorem exists_const (α : Sort*) [i : nonempty α] : (∃ x : α, b) ↔ b :=
 ⟨λ ⟨x, h⟩, h, i.elim exists.intro⟩
 
-@[simp] theorem exists_unique_const (α : Sort*) [i : nonempty α] [s : subsingleton α] :
+@[simp] theorem exists_unique_const (α : Sort*) [i : nonempty α] [subsingleton α] :
   (∃! x : α, b) ↔ b :=
 ⟨λ ⟨x, h, h'⟩, h, i.elim $ λ a b, ⟨a, b, λ _ _, subsingleton.elim _ _⟩⟩
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -833,15 +833,22 @@ forall_true_iff' $ λ _, forall_true_iff
   (∀ a (b : β a), γ a b → true) ↔ true :=
 forall_true_iff' $ λ _, forall_2_true_iff
 
+lemma exists_unique.exists {α : Sort*} {p : α → Prop} (h : ∃! x, p x) : ∃ x, p x :=
+exists.elim h (λ x hx, ⟨x, and.left hx⟩)
+
+@[simp] lemma exists_unique_iff_exists {α : Sort*} [subsingleton α] {p : α → Prop} :
+  (∃! x, p x) ↔ ∃ x, p x :=
+⟨λ h, h.exists, Exists.imp $ λ x hx, ⟨hx, λ y _, subsingleton.elim y x⟩⟩
+
 @[simp] theorem forall_const (α : Sort*) [i : nonempty α] : (α → b) ↔ b :=
 ⟨i.elim, λ hb x, hb⟩
 
 @[simp] theorem exists_const (α : Sort*) [i : nonempty α] : (∃ x : α, b) ↔ b :=
 ⟨λ ⟨x, h⟩, h, i.elim exists.intro⟩
 
-@[simp] theorem exists_unique_const (α : Sort*) [i : nonempty α] [subsingleton α] :
+theorem exists_unique_const (α : Sort*) [i : nonempty α] [subsingleton α] :
   (∃! x : α, b) ↔ b :=
-⟨λ ⟨x, h, h'⟩, h, i.elim $ λ a b, ⟨a, b, λ _ _, subsingleton.elim _ _⟩⟩
+by simp
 
 theorem forall_and_distrib : (∀ x, p x ∧ q x) ↔ (∀ x, p x) ∧ (∀ x, q x) :=
 ⟨λ h, ⟨λ x, (h x).left, λ x, (h x).right⟩, λ ⟨h₁, h₂⟩ x, ⟨h₁ x, h₂ x⟩⟩
@@ -971,8 +978,8 @@ theorem forall_iff_forall_surj
 @[simp] theorem exists_prop {p q : Prop} : (∃ h : p, q) ↔ p ∧ q :=
 ⟨λ ⟨h₁, h₂⟩, ⟨h₁, h₂⟩, λ ⟨h₁, h₂⟩, ⟨h₁, h₂⟩⟩
 
-@[simp] theorem exists_unique_prop {p q : Prop} : (∃! h : p, q) ↔ p ∧ q :=
-⟨λ ⟨h₁, h₂, _⟩, ⟨h₁, h₂⟩, λ ⟨h₁, h₂⟩, ⟨h₁, h₂, λ _ _, rfl⟩⟩
+theorem exists_unique_prop {p q : Prop} : (∃! h : p, q) ↔ p ∧ q :=
+by simp
 
 @[simp] theorem exists_false : ¬ (∃a:α, false) := assume ⟨a, h⟩, h
 
@@ -1014,9 +1021,6 @@ exists_prop_of_true _
 @[simp] lemma exists_false_left (p : false → Prop) : ¬ ∃ x, p x :=
 exists_prop_of_false not_false
 
-lemma exists_unique.exists {α : Sort*} {p : α → Prop} (h : ∃! x, p x) : ∃ x, p x :=
-exists.elim h (λ x hx, ⟨x, and.left hx⟩)
-
 lemma exists_unique.unique {α : Sort*} {p : α → Prop} (h : ∃! x, p x)
   {y₁ y₂ : α} (py₁ : p y₁) (py₂ : p y₂) : y₁ = y₂ :=
 unique_of_exists_unique h py₁ py₂
@@ -1034,10 +1038,6 @@ forall_prop_of_true _
 
 @[simp] lemma forall_false_left (p : false → Prop) : (∀ x, p x) ↔ true :=
 forall_prop_of_false not_false
-
-@[simp] lemma exists_unique_iff_exists {α : Sort*} [subsingleton α] {p : α → Prop} :
-  (∃! x, p x) ↔ ∃ x, p x :=
-⟨λ h, h.exists, Exists.imp $ λ x hx, ⟨hx, λ y _, subsingleton.elim y x⟩⟩
 
 lemma exists_unique.elim2 {α : Sort*} {p : α → Sort*} [∀ x, subsingleton (p x)]
   {q : Π x (h : p x), Prop} {b : Prop} (h₂ : ∃! x (h : p x), q x h)

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -839,6 +839,10 @@ forall_true_iff' $ λ _, forall_2_true_iff
 @[simp] theorem exists_const (α : Sort*) [i : nonempty α] : (∃ x : α, b) ↔ b :=
 ⟨λ ⟨x, h⟩, h, i.elim exists.intro⟩
 
+@[simp] theorem exists_unique_const (α : Sort*) [i : nonempty α] [s : subsingleton α] :
+  (∃! x : α, b) ↔ b :=
+⟨λ ⟨x, h, h'⟩, h, i.elim $ λ a b, ⟨a, b, λ _ _, subsingleton.elim _ _⟩⟩
+
 theorem forall_and_distrib : (∀ x, p x ∧ q x) ↔ (∀ x, p x) ∧ (∀ x, q x) :=
 ⟨λ h, ⟨λ x, (h x).left, λ x, (h x).right⟩, λ ⟨h₁, h₂⟩ x, ⟨h₁ x, h₂ x⟩⟩
 
@@ -967,6 +971,9 @@ theorem forall_iff_forall_surj
 @[simp] theorem exists_prop {p q : Prop} : (∃ h : p, q) ↔ p ∧ q :=
 ⟨λ ⟨h₁, h₂⟩, ⟨h₁, h₂⟩, λ ⟨h₁, h₂⟩, ⟨h₁, h₂⟩⟩
 
+@[simp] theorem exists_unique_prop {p q : Prop} : (∃! h : p, q) ↔ p ∧ q :=
+⟨λ ⟨h₁, h₂, _⟩, ⟨h₁, h₂⟩, λ ⟨h₁, h₂⟩, ⟨h₁, h₂, λ _ _, rfl⟩⟩
+
 @[simp] theorem exists_false : ¬ (∃a:α, false) := assume ⟨a, h⟩, h
 
 @[simp] lemma exists_unique_false : ¬ (∃! (a : α), false) := assume ⟨a, h, h'⟩, h
@@ -982,6 +989,9 @@ theorem forall_prop_of_true {p : Prop} {q : p → Prop} (h : p) : (∀ h' : p, q
 
 theorem exists_prop_of_true {p : Prop} {q : p → Prop} (h : p) : (∃ h' : p, q h') ↔ q h :=
 @exists_const (q h) p ⟨h⟩
+
+theorem exists_unique_prop_of_true {p : Prop} {q : p → Prop} (h : p) : (∃! h' : p, q h') ↔ q h :=
+@exists_unique_const (q h) p ⟨h⟩ _
 
 theorem forall_prop_of_false {p : Prop} {q : p → Prop} (hn : ¬ p) :
   (∀ h' : p, q h') ↔ true :=


### PR DESCRIPTION
Adds:

* `exists_unique_const` to match `exists_const` (provable by simp)
* `exists_unique_prop` to match `exists_prop` (provable by simp)
* `exists_unique_prop_of_true` to match `exists_prop_of_true`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I noticed when looking at formal-ml that we were missing this lemma:

https://github.com/google/formal-ml/blob/630011d19fdd9539c8d6493a69fe70af5d193590/src/formal_ml/exists_unique.lean#L19-L32

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
