### PR TITLE
[Merged by Bors] - fix(tactic/lint): allow pattern def

### DIFF
--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -229,10 +229,13 @@ private meta def incorrect_def_lemma (d : declaration) : tactic (option string) 
     is_instance_d ← is_instance d.to_name,
     if is_instance_d then return none else do
       -- the following seems to be a little quicker than `is_prop d.type`.
-      expr.sort n ← infer_type d.type, return $
-      if d.is_theorem ↔ n = level.zero then none
-      else if (d.is_definition : bool) then "is a def, should be a lemma/theorem"
-      else "is a lemma/theorem, should be a def"
+      expr.sort n ← infer_type d.type,
+      is_pattern ← has_attribute' `pattern d.to_name,
+      return $
+        if d.is_theorem ↔ n = level.zero then none
+        else if d.is_theorem then "is a lemma/theorem, should be a def"
+        else if is_pattern then none -- declarations with `@[pattern]` are allowed to be a `def`.
+        else "is a def, should be a lemma/theorem"
 
 /-- A linter for checking whether the correct declaration constructor (definition or theorem)
 has been used. -/

--- a/test/lint.lean
+++ b/test/lint.lean
@@ -7,6 +7,8 @@ lemma foo3 (n m : ℕ) : ℕ := n - m
 lemma foo.foo (n m : ℕ) : n ≥ n := le_refl n
 instance bar.bar : has_add ℕ := by apply_instance  -- we don't check the name of instances
 lemma foo.bar (ε > 0) : ε = ε := rfl -- >/≥ is allowed in binders (and in fact, in all hypotheses)
+/-- Test exception in `def_lemma` linter. -/
+@[pattern] def my_exists_intro := @Exists.intro
 -- section
 -- local attribute [instance, priority 1001] classical.prop_decidable
 -- lemma foo4 : (if 3 = 3 then 1 else 2) = 1 := if_pos (by refl)
@@ -119,3 +121,9 @@ run_cmd do
   `(@id %%α %%a) ← instantiate_mvars e2,
   expr.sort (level.succ $ level.mvar u) ← infer_type α,
   skip
+
+/- Test exception in `def_lemma` linter. -/
+run_cmd do
+  d ← get_decl `my_exists_intro,
+  t ← linter.def_lemma.test d,
+  guard $ t = none


### PR DESCRIPTION

`Prop` sorted declarations are allowed to be `def` if they have the `@[pattern]` attribute

---

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/tpil.20issue.3A.20'equation.20compiler.20failed')

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
