### PR TITLE
[Merged by Bors] - refactor(algebraic_geometry/structure_sheaf): Rename Spec.Top to prime_spectrum.Top

### DIFF
--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -375,7 +375,7 @@ rfl
   (to_open R U f).1 x = (localization.of _).to_map f :=
 rfl
 
-lemma to_open_eq_const (U : opens (Spec.Top R)) (f : R) : to_open R U f =
+lemma to_open_eq_const (U : opens (prime_spectrum.Top R)) (f : R) : to_open R U f =
   const R f 1 U (λ x _, (ideal.ne_top_iff_one _).1 x.2.1) :=
 subtype.eq $ funext $ λ x, eq.symm $ (localization.of _).mk'_one f
 

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -59,9 +59,9 @@ open opposite
 namespace algebraic_geometry
 
 /--
-$Spec R$, just as a topological space.
+The prime spectrum, just as a topological space.
 -/
-def Spec.Top : Top := Top.of (prime_spectrum R)
+def prime_spectrum.Top : Top := Top.of (prime_spectrum R)
 
 namespace structure_sheaf
 
@@ -69,9 +69,9 @@ namespace structure_sheaf
 The type family over `prime_spectrum R` consisting of the localization over each point.
 -/
 @[derive [comm_ring, local_ring]]
-def localizations (P : Spec.Top R) : Type u := localization.at_prime P.as_ideal
+def localizations (P : prime_spectrum.Top R) : Type u := localization.at_prime P.as_ideal
 
-instance (P : Spec.Top R) : inhabited (localizations R P) :=
+instance (P : prime_spectrum.Top R) : inhabited (localizations R P) :=
 ⟨(localization.of _).to_map 1⟩
 
 variables {R}
@@ -80,7 +80,7 @@ variables {R}
 The predicate saying that a dependent function on an open `U` is realised as a fixed fraction
 `r / s` in each of the stalks (which are localizations at various prime ideals).
 -/
-def is_fraction {U : opens (Spec.Top R)} (f : Π x : U, localizations R x) : Prop :=
+def is_fraction {U : opens (prime_spectrum.Top R)} (f : Π x : U, localizations R x) : Prop :=
 ∃ (r s : R), ∀ x : U,
   ¬ (s ∈ x.1.as_ideal) ∧ f x * (localization.of _).to_map s = (localization.of _).to_map r
 
@@ -118,7 +118,7 @@ def is_locally_fraction : local_predicate (localizations R) :=
 
 @[simp]
 lemma is_locally_fraction_pred
-  {U : opens (Spec.Top R)} (f : Π x : U, localizations R x) :
+  {U : opens (prime_spectrum.Top R)} (f : Π x : U, localizations R x) :
   (is_locally_fraction R).pred f =
   ∀ x : U, ∃ (V) (m : x.1 ∈ V) (i : V ⟶ U),
   ∃ (r s : R), ∀ y : V,
@@ -129,7 +129,7 @@ rfl
 /--
 The functions satisfying `is_locally_fraction` form a subring.
 -/
-def sections_subring (U : (opens (Spec.Top R))ᵒᵖ) :
+def sections_subring (U : (opens (prime_spectrum.Top R))ᵒᵖ) :
   subring (Π x : unop U, localizations R x) :=
 { carrier := { f | (is_locally_fraction R).pred f },
   zero_mem' :=
@@ -199,10 +199,10 @@ open structure_sheaf
 The structure sheaf (valued in `Type`, not yet `CommRing`) is the subsheaf consisting of
 functions satisfying `is_locally_fraction`.
 -/
-def structure_sheaf_in_Type : sheaf (Type u) (Spec.Top R):=
+def structure_sheaf_in_Type : sheaf (Type u) (prime_spectrum.Top R):=
 subsheaf_to_Types (is_locally_fraction R)
 
-instance comm_ring_structure_sheaf_in_Type_obj (U : (opens (Spec.Top R))ᵒᵖ) :
+instance comm_ring_structure_sheaf_in_Type_obj (U : (opens (prime_spectrum.Top R))ᵒᵖ) :
   comm_ring ((structure_sheaf_in_Type R).presheaf.obj U) :=
 (sections_subring R U).to_comm_ring
 
@@ -213,7 +213,7 @@ The structure presheaf, valued in `CommRing`, constructed by dressing up the `Ty
 structure presheaf.
 -/
 @[simps]
-def structure_presheaf_in_CommRing : presheaf CommRing (Spec.Top R) :=
+def structure_presheaf_in_CommRing : presheaf CommRing (prime_spectrum.Top R) :=
 { obj := λ U, CommRing.of ((structure_sheaf_in_Type R).presheaf.obj U),
   map := λ U V i,
   { to_fun := ((structure_sheaf_in_Type R).presheaf.map i),
@@ -239,7 +239,7 @@ The structure sheaf on $Spec R$, valued in `CommRing`.
 
 This is provided as a bundled `SheafedSpace` as `Spec.SheafedSpace R` later.
 -/
-def structure_sheaf : sheaf CommRing (Spec.Top R) :=
+def structure_sheaf : sheaf CommRing (prime_spectrum.Top R) :=
 { presheaf := structure_presheaf_in_CommRing R,
   sheaf_condition :=
     -- We check the sheaf condition under `forget CommRing`.
@@ -247,7 +247,7 @@ def structure_sheaf : sheaf CommRing (Spec.Top R) :=
       (sheaf_condition_equiv_of_iso (structure_presheaf_comp_forget R).symm
         (structure_sheaf_in_Type R).sheaf_condition), }
 
-@[simp] lemma res_apply (U V : opens (Spec.Top R)) (i : V ⟶ U)
+@[simp] lemma res_apply (U V : opens (prime_spectrum.Top R)) (i : V ⟶ U)
   (s : (structure_sheaf R).presheaf.obj (op U)) (x : V) :
   ((structure_sheaf R).presheaf.map i.op s).1 x = (s.1 (i x) : _) :=
 rfl
@@ -279,25 +279,26 @@ In the square brackets we list the dependencies of a construction on the previou
 
 /-- The section of `structure_sheaf R` on an open `U` sending each `x ∈ U` to the element
 `f/g` in the localization of `R` at `x`. -/
-def const (f g : R) (U : opens (Spec.Top R))
-  (hu : ∀ x ∈ U, g ∈ (x : Spec.Top R).as_ideal.prime_compl) :
+def const (f g : R) (U : opens (prime_spectrum.Top R))
+  (hu : ∀ x ∈ U, g ∈ (x : prime_spectrum.Top R).as_ideal.prime_compl) :
   (structure_sheaf R).presheaf.obj (op U) :=
 ⟨λ x, (localization.of _).mk' f ⟨g, hu x x.2⟩,
  λ x, ⟨U, x.2, 𝟙 _, f, g, λ y, ⟨hu y y.2, localization_map.mk'_spec _ _ _⟩⟩⟩
 
-@[simp] lemma const_apply (f g : R) (U : opens (Spec.Top R))
-  (hu : ∀ x ∈ U, g ∈ (x : Spec.Top R).as_ideal.prime_compl) (x : U) :
+@[simp] lemma const_apply (f g : R) (U : opens (prime_spectrum.Top R))
+  (hu : ∀ x ∈ U, g ∈ (x : prime_spectrum.Top R).as_ideal.prime_compl) (x : U) :
   (const R f g U hu).1 x = (localization.of _).mk' f ⟨g, hu x x.2⟩ :=
 rfl
 
-lemma const_apply' (f g : R) (U : opens (Spec.Top R))
-  (hu : ∀ x ∈ U, g ∈ (x : Spec.Top R).as_ideal.prime_compl) (x : U)
+lemma const_apply' (f g : R) (U : opens (prime_spectrum.Top R))
+  (hu : ∀ x ∈ U, g ∈ (x : prime_spectrum.Top R).as_ideal.prime_compl) (x : U)
   (hx : g ∈ (as_ideal x.1).prime_compl) :
   (const R f g U hu).1 x = (localization.of _).mk' f ⟨g, hx⟩ :=
 rfl
 
-lemma exists_const (U) (s : (structure_sheaf R).presheaf.obj (op U)) (x : Spec.Top R) (hx : x ∈ U) :
-  ∃ (V : opens (Spec.Top R)) (hxV : x ∈ V) (i : V ⟶ U) (f g : R) hg,
+lemma exists_const (U) (s : (structure_sheaf R).presheaf.obj (op U)) (x : prime_spectrum.Top R)
+  (hx : x ∈ U) :
+  ∃ (V : opens (prime_spectrum.Top R)) (hxV : x ∈ V) (i : V ⟶ U) (f g : R) hg,
   const R f g V hg = (structure_sheaf R).presheaf.map i.op s :=
 let ⟨V, hxV, iVU, f, g, hfg⟩ := s.2 ⟨x, hx⟩ in
 ⟨V, hxV, iVU, f, g, λ y hyV, (hfg ⟨y, hyV⟩).1, subtype.eq $ funext $ λ y,
@@ -356,7 +357,8 @@ by rw [mul_comm, const_mul_cancel]
 
 /-- The canonical ring homomorphism interpreting an element of `R` as
 a section of the structure sheaf. -/
-def to_open (U : opens (Spec.Top R)) : CommRing.of R ⟶ (structure_sheaf R).presheaf.obj (op U) :=
+def to_open (U : opens (prime_spectrum.Top R)) :
+  CommRing.of R ⟶ (structure_sheaf R).presheaf.obj (op U) :=
 { to_fun := λ f, ⟨λ x, (localization.of _).to_map f,
     λ x, ⟨U, x.2, 𝟙 _, f, 1, λ y, ⟨(ideal.ne_top_iff_one _).1 y.1.2.1,
       by { rw [ring_hom.map_one, mul_one], refl } ⟩⟩⟩,
@@ -365,11 +367,11 @@ def to_open (U : opens (Spec.Top R)) : CommRing.of R ⟶ (structure_sheaf R).pre
   map_zero' := subtype.eq $ funext $ λ x, ring_hom.map_zero _,
   map_add' := λ f g, subtype.eq $ funext $ λ x, ring_hom.map_add _ _ _ }
 
-@[simp] lemma to_open_res (U V : opens (Spec.Top R)) (i : V ⟶ U) :
+@[simp] lemma to_open_res (U V : opens (prime_spectrum.Top R)) (i : V ⟶ U) :
   to_open R U ≫ (structure_sheaf R).presheaf.map i.op = to_open R V :=
 rfl
 
-@[simp] lemma to_open_apply (U : opens (Spec.Top R)) (f : R) (x : U) :
+@[simp] lemma to_open_apply (U : opens (prime_spectrum.Top R)) (f : R) (x : U) :
   (to_open R U f).1 x = (localization.of _).to_map f :=
 rfl
 
@@ -379,20 +381,21 @@ subtype.eq $ funext $ λ x, eq.symm $ (localization.of _).mk'_one f
 
 /-- The canonical ring homomorphism interpreting an element of `R` as an element of
 the stalk of `structure_sheaf R` at `x`. -/
-def to_stalk (x : Spec.Top R) : CommRing.of R ⟶ (structure_sheaf R).presheaf.stalk x :=
+def to_stalk (x : prime_spectrum.Top R) : CommRing.of R ⟶ (structure_sheaf R).presheaf.stalk x :=
 (to_open R ⊤ ≫ (structure_sheaf R).presheaf.germ ⟨x, ⟨⟩⟩ : _)
 
-@[simp] lemma to_open_germ (U : opens (Spec.Top R)) (x : U) :
+@[simp] lemma to_open_germ (U : opens (prime_spectrum.Top R)) (x : U) :
   to_open R U ≫ (structure_sheaf R).presheaf.germ x =
   to_stalk R x :=
 by { rw [← to_open_res R ⊤ U (hom_of_le le_top : U ⟶ ⊤), category.assoc, presheaf.germ_res], refl }
 
-@[simp] lemma germ_to_open (U : opens (Spec.Top R)) (x : U) (f : R) :
+@[simp] lemma germ_to_open (U : opens (prime_spectrum.Top R)) (x : U) (f : R) :
   (structure_sheaf R).presheaf.germ x (to_open R U f) = to_stalk R x f :=
 by { rw ← to_open_germ, refl }
 
-lemma germ_to_top (x : Spec.Top R) (f : R) :
-  (structure_sheaf R).presheaf.germ (⟨x, trivial⟩ : (⊤ : opens (Spec.Top R))) (to_open R ⊤ f) =
+lemma germ_to_top (x : prime_spectrum.Top R) (f : R) :
+  (structure_sheaf R).presheaf.germ (⟨x, trivial⟩ : (⊤ : opens (prime_spectrum.Top R)))
+    (to_open R ⊤ f) =
     to_stalk R x f :=
 rfl
 
@@ -400,22 +403,23 @@ lemma is_unit_to_basic_open_self (f : R) : is_unit (to_open R (basic_open f) f) 
 is_unit_of_mul_eq_one _ (const R 1 f (basic_open f) (λ _, id)) $
 by rw [to_open_eq_const, const_mul_rev]
 
-lemma is_unit_to_stalk (x : Spec.Top R) (f : x.as_ideal.prime_compl) :
+lemma is_unit_to_stalk (x : prime_spectrum.Top R) (f : x.as_ideal.prime_compl) :
   is_unit (to_stalk R x (f : R)) :=
 by { erw ← germ_to_open R (basic_open (f : R)) ⟨x, f.2⟩ (f : R),
     exact ring_hom.is_unit_map _ (is_unit_to_basic_open_self R f) }
 
 /-- The canonical ring homomorphism from the localization of `R` at `p` to the stalk
 of the structure sheaf at the point `p`. -/
-def localization_to_stalk (x : Spec.Top R) :
+def localization_to_stalk (x : prime_spectrum.Top R) :
   CommRing.of (localization.at_prime x.as_ideal) ⟶ (structure_sheaf R).presheaf.stalk x :=
 (localization.of _).lift (is_unit_to_stalk R x)
 
-@[simp] lemma localization_to_stalk_of (x : Spec.Top R) (f : R) :
+@[simp] lemma localization_to_stalk_of (x : prime_spectrum.Top R) (f : R) :
   localization_to_stalk R x ((localization.of _).to_map f) = to_stalk R x f :=
 (localization.of _).lift_eq _ f
 
-@[simp] lemma localization_to_stalk_mk' (x : Spec.Top R) (f : R) (s : (as_ideal x).prime_compl) :
+@[simp] lemma localization_to_stalk_mk' (x : prime_spectrum.Top R) (f : R)
+  (s : (as_ideal x).prime_compl) :
   localization_to_stalk R x ((localization.of _).mk' f s) =
   (structure_sheaf R).presheaf.germ (⟨x, s.2⟩ : basic_open (s : R))
     (const R f s (basic_open s) (λ _, id)) :=
@@ -426,7 +430,8 @@ by erw [← germ_to_open R (basic_open s) ⟨x, s.2⟩, ← germ_to_open R (basi
 /-- The ring homomorphism that takes a section of the structure sheaf of `R` on the open set `U`,
 implemented as a subtype of dependent functions to localizations at prime ideals, and evaluates
 the section on the point corresponding to a given prime ideal. -/
-def open_to_localization (U : opens (Spec.Top R)) (x : Spec.Top R) (hx : x ∈ U) :
+def open_to_localization (U : opens (prime_spectrum.Top R)) (x : prime_spectrum.Top R)
+  (hx : x ∈ U) :
   (structure_sheaf R).presheaf.obj (op U) ⟶ CommRing.of (localization.at_prime x.as_ideal) :=
 { to_fun := λ s, (s.1 ⟨x, hx⟩ : _),
   map_one' := rfl,
@@ -434,13 +439,15 @@ def open_to_localization (U : opens (Spec.Top R)) (x : Spec.Top R) (hx : x ∈ U
   map_zero' := rfl,
   map_add' := λ _ _, rfl }
 
-@[simp] lemma coe_open_to_localization (U : opens (Spec.Top R)) (x : Spec.Top R) (hx : x ∈ U) :
+@[simp] lemma coe_open_to_localization (U : opens (prime_spectrum.Top R)) (x : prime_spectrum.Top R)
+  (hx : x ∈ U) :
   (open_to_localization R U x hx :
     (structure_sheaf R).presheaf.obj (op U) → localization.at_prime x.as_ideal) =
   (λ s, (s.1 ⟨x, hx⟩ : _)) :=
 rfl
 
-lemma open_to_localization_apply (U : opens (Spec.Top R)) (x : Spec.Top R) (hx : x ∈ U)
+lemma open_to_localization_apply (U : opens (prime_spectrum.Top R)) (x : prime_spectrum.Top R)
+  (hx : x ∈ U)
   (s : (structure_sheaf R).presheaf.obj (op U)) :
   open_to_localization R U x hx s = (s.1 ⟨x, hx⟩ : _) :=
 rfl
@@ -448,39 +455,39 @@ rfl
 /-- The ring homomorphism from the stalk of the structure sheaf of `R` at a point corresponding to
 a prime ideal `p` to the localization of `R` at `p`,
 formed by gluing the `open_to_localization` maps. -/
-def stalk_to_fiber_ring_hom (x : Spec.Top R) :
+def stalk_to_fiber_ring_hom (x : prime_spectrum.Top R) :
   (structure_sheaf R).presheaf.stalk x ⟶ CommRing.of (localization.at_prime x.as_ideal) :=
 limits.colimit.desc (((open_nhds.inclusion x).op) ⋙ (structure_sheaf R).presheaf)
   { X := _,
     ι :=
     { app := λ U, open_to_localization R ((open_nhds.inclusion _).obj (unop U)) x (unop U).2, } }
 
-@[simp] lemma germ_comp_stalk_to_fiber_ring_hom (U : opens (Spec.Top R)) (x : U) :
+@[simp] lemma germ_comp_stalk_to_fiber_ring_hom (U : opens (prime_spectrum.Top R)) (x : U) :
   (structure_sheaf R).presheaf.germ x ≫ stalk_to_fiber_ring_hom R x =
   open_to_localization R U x x.2 :=
 limits.colimit.ι_desc _ _
 
-@[simp] lemma stalk_to_fiber_ring_hom_germ' (U : opens (Spec.Top R)) (x : Spec.Top R) (hx : x ∈ U)
-  (s : (structure_sheaf R).presheaf.obj (op U)) :
+@[simp] lemma stalk_to_fiber_ring_hom_germ' (U : opens (prime_spectrum.Top R))
+  (x : prime_spectrum.Top R) (hx : x ∈ U) (s : (structure_sheaf R).presheaf.obj (op U)) :
   stalk_to_fiber_ring_hom R x ((structure_sheaf R).presheaf.germ ⟨x, hx⟩ s) = (s.1 ⟨x, hx⟩ : _) :=
 ring_hom.ext_iff.1 (germ_comp_stalk_to_fiber_ring_hom R U ⟨x, hx⟩ : _) s
 
-@[simp] lemma stalk_to_fiber_ring_hom_germ (U : opens (Spec.Top R)) (x : U)
+@[simp] lemma stalk_to_fiber_ring_hom_germ (U : opens (prime_spectrum.Top R)) (x : U)
   (s : (structure_sheaf R).presheaf.obj (op U)) :
   stalk_to_fiber_ring_hom R x ((structure_sheaf R).presheaf.germ x s) = s.1 x :=
 by { cases x, exact stalk_to_fiber_ring_hom_germ' R U _ _ _ }
 
-@[simp] lemma to_stalk_comp_stalk_to_fiber_ring_hom (x : Spec.Top R) :
+@[simp] lemma to_stalk_comp_stalk_to_fiber_ring_hom (x : prime_spectrum.Top R) :
   to_stalk R x ≫ stalk_to_fiber_ring_hom R x = (localization.of _).to_map :=
 by { erw [to_stalk, category.assoc, germ_comp_stalk_to_fiber_ring_hom], refl }
 
-@[simp] lemma stalk_to_fiber_ring_hom_to_stalk (x : Spec.Top R) (f : R) :
+@[simp] lemma stalk_to_fiber_ring_hom_to_stalk (x : prime_spectrum.Top R) (f : R) :
   stalk_to_fiber_ring_hom R x (to_stalk R x f) = (localization.of _).to_map f :=
 ring_hom.ext_iff.1 (to_stalk_comp_stalk_to_fiber_ring_hom R x) _
 
 /-- The ring isomorphism between the stalk of the structure sheaf of `R` at a point `p`
 corresponding to a prime ideal in `R` and the localization of `R` at `p`. -/
-def stalk_iso (x : Spec.Top R) :
+def stalk_iso (x : prime_spectrum.Top R) :
   (structure_sheaf R).presheaf.stalk x ≅ CommRing.of (localization.at_prime x.as_ideal) :=
 { hom := stalk_to_fiber_ring_hom R x,
   inv := localization_to_stalk R x,
@@ -499,7 +506,7 @@ def stalk_iso (x : Spec.Top R) :
 
 /-- The canonical ring homomorphism interpreting `s ∈ R_f` as a section of the structure sheaf
 on the basic open defined by `f ∈ R`. -/
-def to_basic_open (f : R) : CommRing.of (localization (submonoid.powers f)) ⟶
+def to_basic_open (f : R) : CommRing.of (localization.away f) ⟶
   (structure_sheaf R).presheaf.obj (op $ basic_open f) :=
 localization_map.away_map.lift f (localization.away.of f) (is_unit_to_basic_open_self R f)
 
@@ -511,8 +518,8 @@ by rw [to_open_eq_const, to_open_eq_const, const_mul_cancel']
 
 @[simp] lemma localization_to_basic_open (f : R) :
   @category_theory.category_struct.comp _ _ (CommRing.of R)
-      (CommRing.of (localization (submonoid.powers f))) _
-    (localization.of $ submonoid.powers f).to_map
+      (CommRing.of (localization.away f)) _
+    (localization.away.of f).to_map
     (to_basic_open R f) =
   to_open R (basic_open f) :=
 ring_hom.ext $ λ g, (localization.of _).lift_eq _ _
@@ -556,7 +563,7 @@ end
 Auxiliary lemma for surjectivity of `to_basic_open`.
 Every section can locally be represented on basic opens `basic_opens g` as a fraction `f/g`
 -/
-lemma locally_const_basic_open (U : opens (Spec.Top R))
+lemma locally_const_basic_open (U : opens (prime_spectrum.Top R))
   (s : (structure_sheaf R).presheaf.obj (op U)) (x : U) :
   ∃ (f g : R) (i : basic_open g ⟶ U), x.1 ∈ basic_open g ∧
     const R f g (basic_open g) (λ y hy, hy) = (structure_sheaf R).presheaf.map i.op s :=
@@ -597,7 +604,7 @@ Auxiliary lemma for surjectivity of `to_basic_open`.
 A local representation of a section `s` as fractions `a i / h i` on finitely many basic opens
 `basic_open (h i)` can be "normalized" in such a way that `a i * h j = h i * a j` for all `i, j`
 -/
-lemma normalize_finite_fraction_representation (U : opens (Spec.Top R))
+lemma normalize_finite_fraction_representation (U : opens (prime_spectrum.Top R))
   (s : (structure_sheaf R).presheaf.obj (op U)) {ι : Type*} (t : finset ι) (a h : ι → R)
   (iDh : Π i : ι, basic_open (h i) ⟶ U)  (h_cover : U.1 ⊆ ⋃ i ∈ t, (basic_open (h i)).1)
   (hs : ∀ i : ι, const R (a i) (h i) (basic_open (h i)) (λ y hy, hy) =
@@ -716,7 +723,7 @@ begin
 
   -- Finally, we have all the ingredients.
   -- We claim that our preimage is given by `(∑ (i : ι) in t, b i * a i) / f ^ (n+1)`
-  use (localization.of (submonoid.powers f)).mk' (∑ (i : ι) in t, b i * a i) ⟨f ^ (n+1), n+1, rfl⟩,
+  use (localization.away.of f).mk' (∑ (i : ι) in t, b i * a i) ⟨f ^ (n+1), n+1, rfl⟩,
   rw to_basic_open_mk',
 
   -- Since the structure sheaf is a sheaf, we can show the desired equality locally.
@@ -767,7 +774,7 @@ end
 /-- The ring isomorphism between the structure sheaf on `basic_open f` and the localization of `R`
 at the submonoid of powers of `f`. -/
 def basic_open_iso (f : R) : (structure_sheaf R).presheaf.obj (op (basic_open f)) ≅
-  CommRing.of (localization (submonoid.powers f)) :=
+  CommRing.of (localization.away f) :=
 (as_iso (to_basic_open R f)).symm
 
 end algebraic_geometry


### PR DESCRIPTION
Renames `Spec.Top` to `prime_specturm.Top` to free up the namespace for the Spec functor.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

For consistency with my later PR's on the Spec functor, I think the `Spec` namespace should be reserved operations taking a bundled `CommRing`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
