### PR TITLE
[Merged by Bors] - chore(topology/bases): Rename + unprotect some lemmas

### DIFF
--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -167,7 +167,7 @@ begin
   exact ⟨λ h o hb ⟨a, ha⟩, h a o hb ha, λ h a o hb ha, h o hb ⟨a, ha⟩⟩
 end
 
-protected lemma is_topological_basis.univ : is_topological_basis { U : set α | is_open U } :=
+lemma is_topological_basis_opens : is_topological_basis { U : set α | is_open U } :=
 is_topological_basis_of_open_of_nhds (by tauto) (by tauto)
 
 protected lemma is_topological_basis.prod {β} [topological_space β] {B₁ : set (set α)}
@@ -185,7 +185,7 @@ end
 
 protected lemma is_topological_basis.inducing {β} [topological_space β]
   {f : α → β} {T : set (set β)} (hf : inducing f) (h : is_topological_basis T) :
-  is_topological_basis {U : set α | ∃ (V : set β), V ∈ T ∧ f ⁻¹' V  = U } :=
+  is_topological_basis (image (preimage f) T) :=
 begin
   refine is_topological_basis_of_open_of_nhds _ _,
   { rintros _ ⟨V, hV, rfl⟩,
@@ -260,7 +260,7 @@ end topological_space
 
 open topological_space
 
-protected lemma is_topological_basis.pi {ι : Type*} {X : ι → Type*}
+lemma is_topological_basis.pi {ι : Type*} {X : ι → Type*}
   [∀ i, topological_space (X i)] {T : Π i, set (set (X i))}
   (cond : ∀ i, is_topological_basis (T i)) :
   is_topological_basis {S : set (Π i, X i) | ∃ (U : Π i, set (X i)) (F : finset ι),
@@ -305,7 +305,7 @@ begin
       rw dif_pos p, } },
 end
 
-protected lemma is_topological_basis.infi {β : Type*} {ι : Type*} {X : ι → Type*}
+lemma is_topological_basis.infi {β : Type*} {ι : Type*} {X : ι → Type*}
   [t : ∀ i, topological_space (X i)] {T : Π i, set (set (X i))}
   (cond : ∀ i, is_topological_basis (T i)) (f : Π i, β → X i) :
   @is_topological_basis β (⨅ i, induced (f i) (t i))

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -260,7 +260,7 @@ end topological_space
 
 open topological_space
 
-lemma is_topological_basis.pi {ι : Type*} {X : ι → Type*}
+lemma is_topological_basis_pi {ι : Type*} {X : ι → Type*}
   [∀ i, topological_space (X i)] {T : Π i, set (set (X i))}
   (cond : ∀ i, is_topological_basis (T i)) :
   is_topological_basis {S : set (Π i, X i) | ∃ (U : Π i, set (X i)) (F : finset ι),
@@ -305,15 +305,14 @@ begin
       rw dif_pos p, } },
 end
 
-lemma is_topological_basis.infi {β : Type*} {ι : Type*} {X : ι → Type*}
+lemma is_topological_basis_infi {β : Type*} {ι : Type*} {X : ι → Type*}
   [t : ∀ i, topological_space (X i)] {T : Π i, set (set (X i))}
   (cond : ∀ i, is_topological_basis (T i)) (f : Π i, β → X i) :
   @is_topological_basis β (⨅ i, induced (f i) (t i))
   { S | ∃ (U : Π i, set (X i)) (F : finset ι),
     (∀ i, i ∈ F → U i ∈ T i) ∧ S = ⋂ i (hi : i ∈ F), (f i) ⁻¹' (U i) } :=
 begin
-  convert is_topological_basis.inducing
-    (inducing_infi_to_pi _) (is_topological_basis.pi cond),
+  convert (is_topological_basis_pi cond).inducing (inducing_infi_to_pi _),
   ext V,
   split,
   { rintros ⟨U, F, h1, h2⟩,


### PR DESCRIPTION
@PatrickMassot Unfortunately I saw your comments after #7753 was already merged, so here is a followup PR with the changes you requested. I also unprotected and renamed `is_topological_basis_pi` and `is_topological_basis_infi` since dot notation will also not work for those.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
