### PR TITLE
[Merged by Bors] - feat(linear_algebra/basis): use is_empty instead of ¬nonempty

### DIFF
--- a/src/analysis/analytic/composition.lean
+++ b/src/analysis/analytic/composition.lean
@@ -423,6 +423,10 @@ begin
 end
 
 /-! ### Summability properties of the composition of formal power series-/
+section
+
+-- this speeds up the proof below a lot, related to leanprover-community/lean#521
+local attribute [-instance] unique.subsingleton
 
 /-- If two formal multilinear series have positive radius of convergence, then the terms appearing
 in the definition of their composition are also summable (when multiplied by a suitable positive
@@ -488,6 +492,8 @@ begin
   rw [(this _).tsum_eq, nat.add_sub_cancel],
   field_simp [← mul_assoc, pow_succ', mul_pow, show (4 : ℝ≥0) = 2 * 2, from (two_mul 2).symm,
     mul_right_comm]
+end
+
 end
 
 /-- Bounding below the radius of the composition of two formal multilinear series assuming

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -2114,8 +2114,14 @@ lemma mul_sum (b : S) (s : α →₀ R) {f : α → R → S} :
   b * (s.sum f) = s.sum (λ a c, b * (f a c)) :=
 by simp only [finsupp.sum, finset.mul_sum]
 
+/-- The `finsupp` version of `pi.unique`. -/
 instance unique_of_right [subsingleton R] : unique (α →₀ R) :=
 { uniq := λ l, ext $ λ i, subsingleton.elim _ _,
+  .. finsupp.inhabited }
+
+/-- The `finsupp` version of `pi.unique_of_is_empty`. -/
+instance unique_of_left [is_empty α] : unique (α →₀ R) :=
+{ uniq := λ l, ext is_empty_elim,
   .. finsupp.inhabited }
 
 end

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -571,16 +571,10 @@ variables (M)
 
 /-- If `M` is a subsingleton and `ι` is empty, this is the unique `ι`-indexed basis for `M`. -/
 protected def empty [subsingleton M] [is_empty ι] : basis ι R M :=
-of_repr
-  { to_fun := λ x, 0,
-    inv_fun := λ f, 0,
-    left_inv := λ x, by simp,
-    right_inv := λ f, subsingleton.elim _ _,
-    map_add' := λ x y, by simp,
-    map_smul' := λ c x, by simp }
+of_repr 0
 
 instance empty_unique [subsingleton M] [is_empty ι] : unique (basis ι R M) :=
-{ default := basis.empty M, uniq := λ x, basis.eq_of_apply_eq is_empty_elim }
+{ default := basis.empty M, uniq := λ ⟨x⟩, congr_arg of_repr $ subsingleton.elim _ _ }
 
 end empty
 

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -560,18 +560,17 @@ section empty
 variables (M)
 
 /-- If `M` is a subsingleton and `ι` is empty, this is the unique `ι`-indexed basis for `M`. -/
-protected def empty [subsingleton M] (h_empty : ¬ nonempty ι) : basis ι R M :=
+protected def empty [subsingleton M] [is_empty ι] : basis ι R M :=
 of_repr
   { to_fun := λ x, 0,
     inv_fun := λ f, 0,
     left_inv := λ x, by simp,
-    right_inv := λ f, by { ext i, cases h_empty ⟨i⟩ },
+    right_inv := λ f, finsupp.ext is_empty_elim,
     map_add' := λ x y, by simp,
     map_smul' := λ c x, by simp }
 
-lemma empty_unique [subsingleton M] (h_empty : ¬ nonempty ι)
-  (b : basis ι R M) : b = basis.empty M h_empty :=
-by { ext i, cases h_empty ⟨i⟩ }
+instance empty_unique [subsingleton M] [is_empty ι] : unique (basis ι R M) :=
+{ default := basis.empty M, uniq := λ x, basis.eq_of_apply_eq is_empty_elim }
 
 end empty
 

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -565,7 +565,7 @@ of_repr
   { to_fun := λ x, 0,
     inv_fun := λ f, 0,
     left_inv := λ x, by simp,
-    right_inv := λ f, finsupp.ext is_empty_elim,
+    right_inv := λ f, subsingleton.elim _ _,
     map_add' := λ x y, by simp,
     map_smul' := λ c x, by simp }
 

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -261,9 +261,12 @@ theorem linear_equiv.nonempty_equiv_iff_dim_eq :
 ⟨λ ⟨h⟩, linear_equiv.dim_eq h, λ h, nonempty_linear_equiv_of_dim_eq h⟩
 
 @[simp] lemma dim_bot : module.rank K (⊥ : submodule K V) = 0 :=
-by letI := classical.dec_eq V;
-  rw [← cardinal.lift_inj, ← (basis.empty (⊥ : submodule K V) not_nonempty_pempty).mk_eq_dim,
-    cardinal.mk_pempty]
+begin
+  letI := classical.dec_eq V,
+  rw [← cardinal.lift_inj, ← (basis.empty (⊥ : submodule K V)).mk_eq_dim,
+    cardinal.mk_pempty],
+  apply_instance,
+end
 
 @[simp] lemma dim_top : module.rank K (⊤ : submodule K V) = module.rank K V :=
 linear_equiv.dim_eq (linear_equiv.of_top _ rfl)
@@ -580,31 +583,20 @@ dim_zero_iff_forall_zero.trans (subsingleton_iff_forall_eq 0).symm
 
 /-- The `ι` indexed basis on `V`, where `ι` is an empty type and `V` is zero-dimensional.
 
-See also `basis.of_dim_eq_zero'` and `finite_dimensional.fin_basis`.
+See also `finite_dimensional.fin_basis`.
 -/
-def basis.of_dim_eq_zero {ι : Type*} (h : ¬ nonempty ι) (hV : module.rank K V = 0) :
+def basis.of_dim_eq_zero {ι : Type*} [is_empty ι] (hV : module.rank K V = 0) :
   basis ι K V :=
 begin
   haveI : subsingleton V := dim_zero_iff.1 hV,
-  exact basis.empty _ h
+  exact basis.empty _
 end
 
-@[simp] lemma basis.of_dim_eq_zero_apply {ι : Type*} (h : ¬ nonempty ι)
-  (hV : module.rank K V = 0) (i) :
-  basis.of_dim_eq_zero h hV i = 0 :=
+@[simp] lemma basis.of_dim_eq_zero_apply {ι : Type*} [is_empty ι]
+  (hV : module.rank K V = 0) (i : ι) :
+  basis.of_dim_eq_zero hV i = 0 :=
 rfl
 
-/-- The `fin 0` indexed basis on `V`, where `V` is zero-dimensional.
-
-See also `basis.of_dim_eq_zero` and `finite_dimensional.fin_basis`.
--/
-def basis.of_dim_eq_zero' (hV : module.rank K V = 0) :
-  basis (fin 0) K V :=
-basis.of_dim_eq_zero (finset.univ_eq_empty.mp rfl) hV
-
-@[simp] lemma basis.of_dim_eq_zero'_apply (hV : module.rank K V = 0) (i) :
-  basis.of_dim_eq_zero' hV i = 0 :=
-rfl
 
 lemma dim_pos_iff_exists_ne_zero : 0 < module.rank K V ↔ ∃ x : V, x ≠ 0 :=
 begin

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -893,12 +893,6 @@ begin
   exact basis.empty _
 end
 
-/-- If `V` is zero-dimensional, there is a unique `fin 0`-indexed basis. -/
-noncomputable def basis_of_finrank_zero' [finite_dimensional K V]
-  (hV : finrank K V = 0) :
-  basis (fin 0) K V :=
-basis_of_finrank_zero (finset.univ_eq_empty.mp rfl) hV
-
 namespace linear_map
 
 theorem injective_iff_surjective_of_finrank_eq_finrank [finite_dimensional K V]

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -886,11 +886,11 @@ finrank_zero_iff.trans (subsingleton_iff_forall_eq 0)
 
 /-- If `ι` is an empty type and `V` is zero-dimensional, there is a unique `ι`-indexed basis. -/
 noncomputable def basis_of_finrank_zero [finite_dimensional K V]
-  {ι : Type*} (h : ¬ nonempty ι) (hV : finrank K V = 0) :
+  {ι : Type*} [is_empty ι] (hV : finrank K V = 0) :
   basis ι K V :=
 begin
   haveI : subsingleton V := finrank_zero_iff.1 hV,
-  exact basis.empty _ h
+  exact basis.empty _
 end
 
 /-- If `V` is zero-dimensional, there is a unique `fin 0`-indexed basis. -/

--- a/src/linear_algebra/free_module_pid.lean
+++ b/src/linear_algebra/free_module_pid.lean
@@ -286,13 +286,9 @@ begin
   have a_mem : generator (N.map ϕ) ∈ N.map ϕ := generator_mem _,
 
   -- If `a` is zero, then the submodule is trivial. So let's assume `a ≠ 0`, `N ≠ ⊥`
-  by_cases N_bot : N = ⊥,
-  { rw N_bot,
-    refine ⟨0, basis.empty _⟩,
-    rintro ⟨i, ⟨⟩⟩ },
   by_cases a_zero : generator (N.map ϕ) = 0,
-  { have := eq_bot_of_generator_maximal_map_eq_zero b ϕ_max a_zero,
-    contradiction },
+  { rw eq_bot_of_generator_maximal_map_eq_zero b ϕ_max a_zero,
+    exact ⟨0, basis.empty _⟩ },
 
   -- We claim that `ϕ⁻¹ a = y` can be taken as basis element of `N`.
   let y := a_mem.some,

--- a/src/linear_algebra/free_module_pid.lean
+++ b/src/linear_algebra/free_module_pid.lean
@@ -288,7 +288,7 @@ begin
   -- If `a` is zero, then the submodule is trivial. So let's assume `a ≠ 0`, `N ≠ ⊥`
   by_cases N_bot : N = ⊥,
   { rw N_bot,
-    refine ⟨0, basis.empty _ _⟩,
+    refine ⟨0, basis.empty _⟩,
     rintro ⟨i, ⟨⟩⟩ },
   by_cases a_zero : generator (N.map ϕ) = 0,
   { have := eq_bot_of_generator_maximal_map_eq_zero b ϕ_max a_zero,

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -756,7 +756,7 @@ lemma exists_orthogonal_basis' [hK : invertible (2 : K)]
 begin
   tactic.unfreeze_local_instances,
   induction hd : finrank K V with d ih generalizing V,
-  { exact ⟨basis_of_finrank_zero' hd, λ _ _ _, zero_left _, fin.elim0⟩ },
+  { exact ⟨basis_of_finrank_zero hd, λ _ _ _, zero_left _, fin.elim0⟩ },
   haveI := finrank_pos_iff.1 (hd.symm ▸ nat.succ_pos d : 0 < finrank K V),
   cases exists_bilin_form_self_neq_zero hB₁ hB₂ with x hx,
   have hd' := hd,


### PR DESCRIPTION
This removes the need for `basis.of_dim_eq_zero'` and `basis_of_finrank_zero'`, as these special cases are now covered by the unprimed versions and typeclass search.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
