### PR TITLE
[Merged by Bors] - feat(topology/category/limits): Topological bases in cofiltered limits

### DIFF
--- a/src/topology/category/Top/basic.lean
+++ b/src/topology/category/Top/basic.lean
@@ -59,12 +59,12 @@ def trivial : Type u ⥤ Top.{u} :=
   map := λ X Y f, { to_fun := f, continuous_to_fun := continuous_top } }
 
 /-- Any homeomorphisms induces an isomorphism in `Top`. -/
-def iso_of_homeo {X Y : Top.{u}} (f : X ≃ₜ Y) : X ≅ Y :=
+@[simps] def iso_of_homeo {X Y : Top.{u}} (f : X ≃ₜ Y) : X ≅ Y :=
 { hom := ⟨f⟩,
   inv := ⟨f.symm⟩ }
 
 /-- Any isomorphism in `Top` induces a homeomorphism. -/
-def homeo_of_iso {X Y : Top.{u}} (f : X ≅ Y) : X ≃ₜ Y :=
+@[simps] def homeo_of_iso {X Y : Top.{u}} (f : X ≅ Y) : X ≃ₜ Y :=
 { to_fun := f.hom,
   inv_fun := f.inv,
   left_inv := λ x, by simp,

--- a/src/topology/category/Top/basic.lean
+++ b/src/topology/category/Top/basic.lean
@@ -58,4 +58,24 @@ def trivial : Type u ⥤ Top.{u} :=
 { obj := λ X, ⟨X, ⊤⟩,
   map := λ X Y f, { to_fun := f, continuous_to_fun := continuous_top } }
 
+/-- Any homeomorphisms induces an isomorphism in `Top`. -/
+def iso_of_homeo {X Y : Top.{u}} (f : X ≃ₜ Y) : X ≅ Y :=
+{ hom := ⟨f⟩,
+  inv := ⟨f.symm⟩ }
+
+/-- Any isomorphism in `Top` induces a homeomorphism. -/
+def homeo_of_iso {X Y : Top.{u}} (f : X ≅ Y) : X ≃ₜ Y :=
+{ to_fun := f.hom,
+  inv_fun := f.inv,
+  left_inv := λ x, by simp,
+  right_inv := λ x, by simp,
+  continuous_to_fun := f.hom.continuous,
+  continuous_inv_fun := f.inv.continuous }
+
+@[simp] lemma of_iso_of_homeo {X Y : Top.{u}} (f : X ≃ₜ Y) : homeo_of_iso (iso_of_homeo f) = f :=
+by { ext, refl }
+
+@[simp] lemma of_homeo_of_iso {X Y : Top.{u}} (f : X ≅ Y) : iso_of_homeo (homeo_of_iso f) = f :=
+by { ext, refl }
+
 end Top


### PR DESCRIPTION
This PR proves a theorem which provides a simple characterization of certain topological bases in a cofiltered limit of topological spaces.

Eventually I will specialize this assertion to the case where the topological spaces are profinite, and the `T i` are the topological bases given by clopen sets.

This generalizes a lemma from LTE.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
