### PR TITLE
[Merged by Bors] - feat(data/fintype/basic): The cardinality of a set is at most the cardinality of the universe

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -947,7 +947,7 @@ instance subtype.fintype (p : α → Prop) [decidable_pred p] [fintype α] : fin
 fintype.subtype (univ.filter p) (by simp)
 
 /-- A set on a fintype, when coerced to a type, is a fintype. -/
-def set_fintype {α} [fintype α] (s : set α) [decidable_pred s] : fintype s :=
+instance set_fintype {α} [fintype α] (s : set α) [decidable_pred s] : fintype s :=
 subtype.fintype (λ x, x ∈ s)
 
 lemma set_fintype_card_le_univ {α : Type*} [fintype α] (s : set α) [fintype ↥s] :

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -947,7 +947,7 @@ instance subtype.fintype (p : α → Prop) [decidable_pred p] [fintype α] : fin
 fintype.subtype (univ.filter p) (by simp)
 
 /-- A set on a fintype, when coerced to a type, is a fintype. -/
-instance set_fintype {α} [fintype α] (s : set α) [decidable_pred s] : fintype s :=
+instance set_fintype {α} [fintype α] (s : set α) [decidable_pred (∈ s)] : fintype s :=
 subtype.fintype (λ x, x ∈ s)
 
 lemma set_fintype_card_le_univ {α : Type*} [fintype α] (s : set α) [fintype ↥s] :

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -950,6 +950,10 @@ fintype.subtype (univ.filter p) (by simp)
 def set_fintype {α} [fintype α] (s : set α) [decidable_pred s] : fintype s :=
 subtype.fintype (λ x, x ∈ s)
 
+lemma set_fintype_card_le_univ {α : Type*} [fintype α] (s : set α) [fintype ↥s] :
+  fintype.card ↥s ≤ fintype.card α :=
+fintype.card_le_of_embedding (function.embedding.subtype s)
+
 namespace function.embedding
 
 /-- An embedding from a `fintype` to itself can be promoted to an equivalence. -/

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -947,7 +947,7 @@ instance subtype.fintype (p : α → Prop) [decidable_pred p] [fintype α] : fin
 fintype.subtype (univ.filter p) (by simp)
 
 /-- A set on a fintype, when coerced to a type, is a fintype. -/
-instance set_fintype {α} [fintype α] (s : set α) [decidable_pred s] : fintype s :=
+def set_fintype {α} [fintype α] (s : set α) [decidable_pred s] : fintype s :=
 subtype.fintype (λ x, x ∈ s)
 
 lemma set_fintype_card_le_univ {α : Type*} [fintype α] (s : set α) [fintype ↥s] :


### PR DESCRIPTION
I think that the hypothesis `[fintype ↥s]` can be avoided with the use of classical logic. E.g.,
`noncomputable instance set_fintype' {α : Type*} [fintype α] (s : set α) : fintype s :=by { classical, exact set_fintype s }`
Would it make sense to add this?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
