### PR TITLE
[Merged by Bors] - feat(data/list/duplicate): prop that element is a duplicate

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -942,7 +942,7 @@ let ⟨s, t, e⟩ := mem_split h in e.symm ▸
 theorem eq_nil_of_sublist_nil {l : list α} (s : l <+ []) : l = [] :=
 eq_nil_of_subset_nil $ s.subset
 
-@[simp] theorem eq_nil_iff_sublist_nil {l : list α} : l <+ [] ↔ l = [] :=
+@[simp] theorem sublist_nil_iff_eq_nil {l : list α} : l <+ [] ↔ l = [] :=
 ⟨eq_nil_of_sublist_nil, λ H, H ▸ sublist.refl _⟩
 
 theorem repeat_sublist_repeat (a : α) {m n} : repeat a m <+ repeat a n ↔ m ≤ n :=

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -942,6 +942,9 @@ let ⟨s, t, e⟩ := mem_split h in e.symm ▸
 theorem eq_nil_of_sublist_nil {l : list α} (s : l <+ []) : l = [] :=
 eq_nil_of_subset_nil $ s.subset
 
+@[simp] theorem eq_nil_iff_sublist_nil {l : list α} : l <+ [] ↔ l = [] :=
+⟨eq_nil_of_sublist_nil, λ H, H ▸ sublist.refl _⟩
+
 theorem repeat_sublist_repeat (a : α) {m n} : repeat a m <+ repeat a n ↔ m ≤ n :=
 ⟨λ h, by simpa only [length_repeat] using length_le_of_sublist h,
  λ h, by induction h; [refl, simp only [*, repeat_succ, sublist.cons]] ⟩

--- a/src/data/list/duplicate.lean
+++ b/src/data/list/duplicate.lean
@@ -1,0 +1,167 @@
+/-
+Copyright (c) 2018 Yakov Pechersky. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yakov Pechersky, Chris Hughes
+-/
+import data.list.basic
+
+/-!
+# List duplicates
+
+## Main definitions
+
+* `list.duplicate x l : Prop` is an inductive property that holds when `x` is a duplicate in `l`
+
+-/
+
+variable {α : Type*}
+
+namespace list
+
+/-- Property that an element `x : α` of `l : list α` can be found in the list more than once. -/
+inductive duplicate (x : α) : list α → Prop
+| cons_mem {l : list α} : x ∈ l → duplicate (x :: l)
+| cons_duplicate {y : α} {l : list α} : duplicate l → duplicate (y :: l)
+
+local infix ` ∈+ `:1 := list.duplicate
+
+variables {l : list α} {x : α}
+
+lemma mem.duplicate_cons_self (h : x ∈ l) : x ∈+ x :: l := duplicate.cons_mem h
+
+lemma duplicate.duplicate_cons (h : x ∈+ l) (y : α) : x ∈+ y :: l := duplicate.cons_duplicate h
+
+lemma duplicate.mem (h : x ∈+ l) : x ∈ l :=
+begin
+  induction h with l' h y l' h hm,
+  { exact mem_cons_self _ _ },
+  { exact mem_cons_of_mem _ hm }
+end
+
+lemma duplicate.mem_cons_self (h : x ∈+ x :: l) : x ∈ l :=
+begin
+  cases h with _ h _ _ h,
+  { exact h },
+  { exact h.mem }
+end
+
+@[simp] lemma duplicate_cons_self_iff : (x ∈+ x :: l) ↔ x ∈ l :=
+⟨duplicate.mem_cons_self, mem.duplicate_cons_self⟩
+
+lemma duplicate.ne_nil (h : x ∈+ l) : l ≠ [] :=
+λ H, (mem_nil_iff x).mp (H ▸ h.mem)
+
+@[simp] lemma not_duplicate_nil (x : α) : ¬ (x ∈+ []) :=
+λ H, by simpa using H.ne_nil
+
+lemma duplicate.ne_singleton (h : x ∈+ l) (y : α) : l ≠ [y] :=
+begin
+  induction h with l' h z l' h hm,
+  { simp [ne_nil_of_mem h] },
+  { simp [ne_nil_of_mem h.mem] }
+end
+
+@[simp] lemma not_duplicate_singleton (x y : α) : ¬ (x ∈+ [y]) :=
+λ H, by simpa using H.ne_singleton _
+
+lemma duplicate.eq_and_mem_or_duplicate {y : α} (h : x ∈+ y :: l) : (y = x ∧ x ∈ l) ∨ (x ∈+ l) :=
+begin
+  cases h with _ hm _ _ hm,
+  { exact or.inl ⟨rfl, hm⟩ },
+  { exact or.inr hm }
+end
+
+lemma duplicate.cons_imp_of_ne {y : α} (h : x ∈+ y :: l) (hx : x ≠ y) : x ∈+ l :=
+begin
+  refine h.eq_and_mem_or_duplicate.resolve_left _,
+  simp [and.comm, hx.symm]
+end
+
+lemma duplicate_cons_iff_of_ne {y : α} (hne : x ≠ y) : (x ∈+ y :: l) ↔ (x ∈+ l) :=
+⟨λ h, h.cons_imp_of_ne hne, λ h, h.duplicate_cons _⟩
+
+lemma duplicate.mono_sublist {l' : list α} (hx : x ∈+ l) (h : l <+ l') : x ∈+ l' :=
+begin
+  induction h with l₁ l₂ y h IH l₁ l₂ y h IH,
+  { simpa using hx.ne_nil },
+  { exact (IH hx).duplicate_cons _ },
+  { rcases hx.eq_and_mem_or_duplicate with ⟨rfl, hm⟩|hm,
+    { exact (h.subset hx.mem_cons_self).duplicate_cons_self },
+    { exact (IH hm).duplicate_cons _ } }
+end
+
+/-- The contrapositive of `list.nodup_iff_sublist`. -/
+lemma duplicate_iff_sublist : (x ∈+ l) ↔ [x, x] <+ l :=
+begin
+  induction l with y l IH,
+  { simp },
+  { by_cases hx : x = y,
+    { simp [hx, cons_sublist_cons_iff, singleton_sublist] },
+    { rw [duplicate_cons_iff_of_ne hx, IH],
+      refine ⟨sublist_cons_of_sublist y, λ h, _⟩,
+      cases h,
+      { assumption },
+      { contradiction } } }
+end
+
+lemma duplicate_iff_count_le_two [decidable_eq α] : (x ∈+ l) ↔ 2 ≤ count x l :=
+by simp [duplicate_iff_sublist, le_count_iff_repeat_sublist]
+
+lemma duplicate_nth_le_iff_exists_distinct {n : ℕ} {hn : n < l.length} :
+  (l.nth_le n hn ∈+ l) ↔ ∃ (m : ℕ) (hm : m < l.length) (h : n ≠ m), l.nth_le n hn = l.nth_le m hm :=
+begin
+  induction l with y l IH generalizing n,
+  { simp },
+  { cases n,
+    { simp only [mem_iff_nth_le, exists_prop, duplicate_cons_self_iff, nat.nat_zero_eq_zero, length,
+                 exists_and_distrib_left, ne.def, nth_le],
+      split,
+      { rintro ⟨m, hm, rfl⟩,
+        use m + 1,
+        simpa [hm, m.zero_lt_succ.ne] },
+      { rintro ⟨_ | m, h, hm, hy⟩,
+        { contradiction },
+        { use m,
+          simp only [length, nat.succ_lt_succ_iff] at hm,
+          rw hy,
+          simpa [hm] } } },
+    { by_cases hy : (y :: l).nth_le n.succ hn = y,
+      { rw hy,
+        simp only [mem_iff_nth_le, exists_prop, duplicate_cons_self_iff, length,
+                   exists_and_distrib_left, ne.def, nth_le],
+        split,
+        { intro,
+          use 0,
+          simp },
+        { intro,
+          simp only [nat.succ_lt_succ_iff, length] at hn,
+          use [n, hn],
+          simpa using hy } },
+      { rw duplicate_cons_iff_of_ne hy,
+        simp only [IH, exists_prop, length, exists_and_distrib_left, ne.def, nth_le],
+        split,
+        { rintro ⟨m, h, hm, hy⟩,
+          use m + 1,
+          simpa [nat.succ_inj', hm, h] using hy },
+        { rintro ⟨_ | m, h, hm, hy⟩,
+          { contradiction },
+          { use m,
+            rw [nat.succ_inj'] at h,
+            simp only [length, nat.succ_lt_succ_iff] at hm,
+            rw hy,
+            simpa [h, hm] } } } } }
+end
+
+instance decidable_duplicate [decidable_eq α] (x : α) : ∀ (l : list α), decidable (x ∈+ l)
+| []       := is_false (not_duplicate_nil x)
+| (y :: l) := match decidable_duplicate l with
+  | is_true  h := is_true (h.duplicate_cons y)
+  | is_false h :=
+    if hx : x ∈ l
+      then if hy : x = y
+        then is_true (hy ▸ hx.duplicate_cons_self)
+        else is_false (λ H, h (H.cons_imp_of_ne hy))
+      else is_false (λ H, hx (or.cases_on H.eq_and_mem_or_duplicate and.elim_right duplicate.mem))
+  end
+
+end list

--- a/src/data/list/duplicate.lean
+++ b/src/data/list/duplicate.lean
@@ -13,6 +13,10 @@ import data.fin
 
 * `list.duplicate x l : Prop` is an inductive property that holds when `x` is a duplicate in `l`
 
+## Implementation details
+
+In this file, `x ∈+ l` notation is shorthand fot `list.duplicate x l`.
+
 -/
 
 variable {α : Type*}
@@ -53,7 +57,7 @@ lemma duplicate.ne_nil (h : x ∈+ l) : l ≠ [] :=
 λ H, (mem_nil_iff x).mp (H ▸ h.mem)
 
 @[simp] lemma not_duplicate_nil (x : α) : ¬ x ∈+ [] :=
-λ H, by simpa using H.ne_nil
+λ H, H.ne_nil rfl
 
 lemma duplicate.ne_singleton (h : x ∈+ l) (y : α) : l ≠ [y] :=
 begin
@@ -63,7 +67,13 @@ begin
 end
 
 @[simp] lemma not_duplicate_singleton (x y : α) : ¬ x ∈+ [y] :=
-λ H, by simpa using H.ne_singleton _
+λ H, H.ne_singleton _ rfl
+
+lemma duplicate.elim_nil (h : x ∈+ []) : false :=
+not_duplicate_nil x h
+
+lemma duplicate.elim_singleton {y : α} (h : x ∈+ [y]) : false :=
+not_duplicate_singleton x y h
 
 lemma duplicate_cons_iff {y : α} : x ∈+ y :: l ↔ (y = x ∧ x ∈ l) ∨ x ∈+ l :=
 begin
@@ -73,7 +83,7 @@ begin
     { exact or.inr hm } },
   { rcases h with ⟨rfl|h⟩|h,
     { simpa },
-    { exact h.duplicate_cons _ } }
+    { exact h.cons_duplicate } }
 end
 
 lemma duplicate.of_duplicate_cons {y : α} (h : x ∈+ y :: l) (hx : x ≠ y) : x ∈+ l :=
@@ -85,7 +95,7 @@ by simp [duplicate_cons_iff, hne.symm]
 lemma duplicate.mono_sublist {l' : list α} (hx : x ∈+ l) (h : l <+ l') : x ∈+ l' :=
 begin
   induction h with l₁ l₂ y h IH l₁ l₂ y h IH,
-  { simpa using hx.ne_nil },
+  { exact hx },
   { exact (IH hx).duplicate_cons _ },
   { rw duplicate_cons_iff at hx ⊢,
     rcases hx with ⟨rfl, hx⟩|hx,
@@ -110,117 +120,14 @@ end
 lemma nodup_iff_forall_not_duplicate : nodup l ↔ ∀ (x : α), ¬ x ∈+ l :=
 by simp_rw [nodup_iff_sublist, duplicate_iff_sublist]
 
+lemma exists_duplicate_iff_not_nodup : (∃ (x : α), x ∈+ l) ↔ ¬ nodup l :=
+by simp [nodup_iff_forall_not_duplicate]
+
 lemma duplicate.not_nodup (h : x ∈+ l) : ¬ nodup l :=
 λ H, nodup_iff_forall_not_duplicate.mp H _ h
 
-lemma duplicate_iff_count_le_two [decidable_eq α] : (x ∈+ l) ↔ 2 ≤ count x l :=
+lemma duplicate_iff_two_le_count [decidable_eq α] : (x ∈+ l) ↔ 2 ≤ count x l :=
 by simp [duplicate_iff_sublist, le_count_iff_repeat_sublist]
-
-lemma sublist_of_order_embedding {l l' : list α} (f : ℕ ↪o ℕ)
-  (hf : ∀ (ix : ℕ), l.nth ix = l'.nth (f ix)) :
-  l <+ l' :=
-begin
-  induction l with hd tl IH generalizing l' f,
-  { simp },
-  have : some hd = _ := hf 0,
-  rw [eq_comm, list.nth_eq_some] at this,
-  obtain ⟨w, h⟩ := this,
-  let f' : ℕ ↪o ℕ := order_embedding.of_map_rel_iff (λ i, f (i + 1) - (f 0 + 1))
-    (λ a b, by simp [nat.sub_le_sub_right_iff, nat.succ_le_iff, nat.lt_succ_iff]),
-  have : ∀ ix, tl.nth ix = (l'.drop (f 0 + 1)).nth (f' ix),
-  { intro ix,
-    simp [list.nth_drop, nat.add_sub_of_le, nat.succ_le_iff, ←hf] },
-  rw [←list.take_append_drop (f 0 + 1) l', ←list.singleton_append],
-  apply list.sublist.append _ (IH _ this),
-  rw [list.singleton_sublist, ←h, l'.nth_le_take _ (nat.lt_succ_self _)],
-  apply list.nth_le_mem
-end
-
-lemma sublist_iff_nth_eq {l l' : list α} :
-  l <+ l' ↔ ∃ (f : ℕ ↪o ℕ), ∀ (ix : ℕ), l.nth ix = l'.nth (f ix) :=
-begin
-  split,
-  { intro H,
-    induction H with xs ys y H IH xs ys x H IH,
-    { simp },
-    { obtain ⟨f, hf⟩ := IH,
-      refine ⟨f.trans (order_embedding.of_strict_mono (+ 1) (λ _, by simp)), _⟩,
-      simpa using hf },
-    { obtain ⟨f, hf⟩ := IH,
-      refine ⟨order_embedding.of_map_rel_iff
-        (λ (ix : ℕ), if ix = 0 then 0 else (f ix.pred).succ) _, _⟩,
-      { rintro ⟨_|a⟩ ⟨_|b⟩;
-        simp [nat.succ_le_succ_iff] },
-      { rintro ⟨_|i⟩,
-        { simp },
-        { simpa using hf _ } } } },
-  { rintro ⟨f, hf⟩,
-    exact sublist_of_order_embedding f hf }
-end
-
-lemma sublist_iff_nth_le_eq {l l' : list α} :
-  l <+ l' ↔ ∃ (f : fin l.length ↪o fin l'.length),
-    ∀ (ix : fin l.length), l.nth_le ix ix.is_lt = l'.nth_le (f ix) (f ix).is_lt :=
-begin
-  rw sublist_iff_nth_eq,
-  split,
-  { rintro ⟨f, hf⟩,
-    have h : ∀ {i : ℕ} (h : i < l.length), f i < l'.length,
-    { intros i hi,
-      specialize hf i,
-      rw [nth_le_nth hi, eq_comm, nth_eq_some] at hf,
-      obtain ⟨h, -⟩ := hf,
-      exact h },
-    refine ⟨order_embedding.of_map_rel_iff (λ ix, ⟨f ix, h ix.is_lt⟩) _, _⟩,
-    { simp },
-    { intro i,
-      apply option.some_injective,
-      simpa [←nth_le_nth] using hf _ } },
-  { rintro ⟨f, hf⟩,
-    refine ⟨order_embedding.of_strict_mono
-      (λ i, if hi : i < l.length then f ⟨i, hi⟩ else i + l'.length) _, _⟩,
-    { intros i j h,
-      dsimp only,
-      split_ifs with hi hj hj hi,
-      { simpa using h },
-      { rw add_comm,
-        exact lt_add_of_lt_of_pos (fin.is_lt _) (i.zero_le.trans_lt h) },
-      { exact absurd (h.trans hj) hi },
-      { simpa using h } },
-    { intro i,
-      simp only [order_embedding.coe_of_strict_mono],
-      split_ifs with hi,
-      { rw [nth_le_nth hi, nth_le_nth, ←hf],
-        simp },
-      { rw [nth_len_le, nth_len_le],
-        { simp },
-        { simpa using hi } } } }
-end
-
-lemma duplicate_iff_exists_distinct :
-  x ∈+ l ↔ ∃ (n : ℕ) (hn : n < l.length) (m : ℕ) (hm : m < l.length) (h : n < m),
-    x = l.nth_le n hn ∧ x = l.nth_le m hm :=
-begin
-  classical,
-  rw [duplicate_iff_count_le_two, le_count_iff_repeat_sublist, sublist_iff_nth_le_eq],
-  split,
-  { rintro ⟨f, hf⟩,
-    refine ⟨f ⟨0, by simp⟩, fin.is_lt _, f ⟨1, by simp⟩, fin.is_lt _, by simp, _, _⟩,
-    { simpa using hf ⟨0, by simp⟩ },
-    { simpa using hf ⟨1, by simp⟩ } },
-  { rintro ⟨n, hn, m, hm, hnm, h, h'⟩,
-    refine ⟨order_embedding.of_strict_mono (λ i, if (i : ℕ) = 0 then ⟨n, hn⟩ else ⟨m, hm⟩) _, _⟩,
-    { rintros ⟨⟨_|i⟩, hi⟩ ⟨⟨_|j⟩, hj⟩,
-      { simp  },
-      { simp [hnm] },
-      { simp },
-      { simp only [nat.lt_succ_iff, nat.succ_le_succ_iff, repeat, length, nonpos_iff_eq_zero]
-          at hi hj,
-        simp [hi, hj] } },
-    { rintros ⟨⟨_|i⟩, hi⟩,
-      { simpa using h },
-      { simpa using h' } } }
-end
 
 instance decidable_duplicate [decidable_eq α] (x : α) : ∀ (l : list α), decidable (x ∈+ l)
 | []       := is_false (not_duplicate_nil x)

--- a/src/data/list/duplicate.lean
+++ b/src/data/list/duplicate.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Yakov Pechersky. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yakov Pechersky, Chris Hughes
 -/
-import data.list.basic
+import data.list.nodup
 import data.fin
 
 /-!
@@ -107,8 +107,15 @@ begin
       { contradiction } } }
 end
 
+lemma nodup_iff_forall_not_duplicate : nodup l ↔ ∀ (x : α), ¬ x ∈+ l :=
+by simp_rw [nodup_iff_sublist, duplicate_iff_sublist]
+
+lemma duplicate.not_nodup (h : x ∈+ l) : ¬ nodup l :=
+λ H, nodup_iff_forall_not_duplicate.mp H _ h
+
 lemma duplicate_iff_count_le_two [decidable_eq α] : (x ∈+ l) ↔ 2 ≤ count x l :=
 by simp [duplicate_iff_sublist, le_count_iff_repeat_sublist]
+
 lemma sublist_of_order_embedding {l l' : list α} (f : ℕ ↪o ℕ)
   (hf : ∀ (ix : ℕ), l.nth ix = l'.nth (f ix)) :
   l <+ l' :=
@@ -212,7 +219,7 @@ begin
         simp [hi, hj] } },
     { rintros ⟨⟨_|i⟩, hi⟩,
       { simpa using h },
-      { simpa using h' } } },
+      { simpa using h' } } }
 end
 
 instance decidable_duplicate [decidable_eq α] (x : α) : ∀ (l : list α), decidable (x ∈+ l)

--- a/src/data/list/duplicate.lean
+++ b/src/data/list/duplicate.lean
@@ -15,7 +15,7 @@ import data.fin
 
 ## Implementation details
 
-In this file, `x ∈+ l` notation is shorthand fot `list.duplicate x l`.
+In this file, `x ∈+ l` notation is shorthand for `list.duplicate x l`.
 
 -/
 

--- a/src/data/list/nodup_equiv_fin.lean
+++ b/src/data/list/nodup_equiv_fin.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury G. Kudryashov
 -/
 import data.list.sort
+import data.list.duplicate
 import data.fin
 
 /-!
@@ -69,4 +70,135 @@ variables (H : sorted (<) l) {x : {x // x ∈ l}} {i : fin l.length}
 @[simp] lemma coe_nth_le_iso_symm_apply : ((H.nth_le_iso l).symm x : ℕ) = index_of ↑x l := rfl
 
 end sorted
+
+section sublist
+
+/--
+If there is `f`, an order-preserving embedding of `ℕ` into `ℕ` such that
+any element of `l` found at index `ix` can be found at index `f ix` in `l'`,
+then `sublist l l'`.
+-/
+lemma sublist_of_order_embedding_nth_eq {l l' : list α} (f : ℕ ↪o ℕ)
+  (hf : ∀ (ix : ℕ), l.nth ix = l'.nth (f ix)) :
+  l <+ l' :=
+begin
+  induction l with hd tl IH generalizing l' f,
+  { simp },
+  have : some hd = _ := hf 0,
+  rw [eq_comm, list.nth_eq_some] at this,
+  obtain ⟨w, h⟩ := this,
+  let f' : ℕ ↪o ℕ := order_embedding.of_map_rel_iff (λ i, f (i + 1) - (f 0 + 1))
+    (λ a b, by simp [nat.sub_le_sub_right_iff, nat.succ_le_iff, nat.lt_succ_iff]),
+  have : ∀ ix, tl.nth ix = (l'.drop (f 0 + 1)).nth (f' ix),
+  { intro ix,
+    simp [list.nth_drop, nat.add_sub_of_le, nat.succ_le_iff, ←hf] },
+  rw [←list.take_append_drop (f 0 + 1) l', ←list.singleton_append],
+  apply list.sublist.append _ (IH _ this),
+  rw [list.singleton_sublist, ←h, l'.nth_le_take _ (nat.lt_succ_self _)],
+  apply list.nth_le_mem
+end
+
+/--
+A `l : list α` is `sublist l l'` for `l' : list α` iff
+there is `f`, an order-preserving embedding of `ℕ` into `ℕ` such that
+any element of `l` found at index `ix` can be found at index `f ix` in `l'`.
+-/
+lemma sublist_iff_exists_order_embedding_nth_eq {l l' : list α} :
+  l <+ l' ↔ ∃ (f : ℕ ↪o ℕ), ∀ (ix : ℕ), l.nth ix = l'.nth (f ix) :=
+begin
+  split,
+  { intro H,
+    induction H with xs ys y H IH xs ys x H IH,
+    { simp },
+    { obtain ⟨f, hf⟩ := IH,
+      refine ⟨f.trans (order_embedding.of_strict_mono (+ 1) (λ _, by simp)), _⟩,
+      simpa using hf },
+    { obtain ⟨f, hf⟩ := IH,
+      refine ⟨order_embedding.of_map_rel_iff
+        (λ (ix : ℕ), if ix = 0 then 0 else (f ix.pred).succ) _, _⟩,
+      { rintro ⟨_|a⟩ ⟨_|b⟩;
+        simp [nat.succ_le_succ_iff] },
+      { rintro ⟨_|i⟩,
+        { simp },
+        { simpa using hf _ } } } },
+  { rintro ⟨f, hf⟩,
+    exact sublist_of_order_embedding_nth_eq f hf }
+end
+
+/--
+A `l : list α` is `sublist l l'` for `l' : list α` iff
+there is `f`, an order-preserving embedding of `fin l.length` into `fin l'.length` such that
+any element of `l` found at index `ix` can be found at index `f ix` in `l'`.
+-/
+lemma sublist_iff_exists_fin_order_embedding_nth_le_eq {l l' : list α} :
+  l <+ l' ↔ ∃ (f : fin l.length ↪o fin l'.length),
+    ∀ (ix : fin l.length), l.nth_le ix ix.is_lt = l'.nth_le (f ix) (f ix).is_lt :=
+begin
+  rw sublist_iff_exists_order_embedding_nth_eq,
+  split,
+  { rintro ⟨f, hf⟩,
+    have h : ∀ {i : ℕ} (h : i < l.length), f i < l'.length,
+    { intros i hi,
+      specialize hf i,
+      rw [nth_le_nth hi, eq_comm, nth_eq_some] at hf,
+      obtain ⟨h, -⟩ := hf,
+      exact h },
+    refine ⟨order_embedding.of_map_rel_iff (λ ix, ⟨f ix, h ix.is_lt⟩) _, _⟩,
+    { simp },
+    { intro i,
+      apply option.some_injective,
+      simpa [←nth_le_nth] using hf _ } },
+  { rintro ⟨f, hf⟩,
+    refine ⟨order_embedding.of_strict_mono
+      (λ i, if hi : i < l.length then f ⟨i, hi⟩ else i + l'.length) _, _⟩,
+    { intros i j h,
+      dsimp only,
+      split_ifs with hi hj hj hi,
+      { simpa using h },
+      { rw add_comm,
+        exact lt_add_of_lt_of_pos (fin.is_lt _) (i.zero_le.trans_lt h) },
+      { exact absurd (h.trans hj) hi },
+      { simpa using h } },
+    { intro i,
+      simp only [order_embedding.coe_of_strict_mono],
+      split_ifs with hi,
+      { rw [nth_le_nth hi, nth_le_nth, ←hf],
+        simp },
+      { rw [nth_len_le, nth_len_le],
+        { simp },
+        { simpa using hi } } } }
+end
+
+/--
+An element `x : α` of `l : list α` is a duplicate iff it can be found
+at two distinct indices `n m : ℕ` inside the list `l`.
+-/
+lemma duplicate_iff_exists_distinct_nth_le {l : list α} {x : α} :
+  l.duplicate x ↔ ∃ (n : ℕ) (hn : n < l.length) (m : ℕ) (hm : m < l.length) (h : n < m),
+    x = l.nth_le n hn ∧ x = l.nth_le m hm :=
+begin
+  classical,
+  rw [duplicate_iff_two_le_count, le_count_iff_repeat_sublist,
+      sublist_iff_exists_fin_order_embedding_nth_le_eq],
+  split,
+  { rintro ⟨f, hf⟩,
+    refine ⟨f ⟨0, by simp⟩, fin.is_lt _, f ⟨1, by simp⟩, fin.is_lt _, by simp, _, _⟩,
+    { simpa using hf ⟨0, by simp⟩ },
+    { simpa using hf ⟨1, by simp⟩ } },
+  { rintro ⟨n, hn, m, hm, hnm, h, h'⟩,
+    refine ⟨order_embedding.of_strict_mono (λ i, if (i : ℕ) = 0 then ⟨n, hn⟩ else ⟨m, hm⟩) _, _⟩,
+    { rintros ⟨⟨_|i⟩, hi⟩ ⟨⟨_|j⟩, hj⟩,
+      { simp  },
+      { simp [hnm] },
+      { simp },
+      { simp only [nat.lt_succ_iff, nat.succ_le_succ_iff, repeat, length, nonpos_iff_eq_zero]
+          at hi hj,
+        simp [hi, hj] } },
+    { rintros ⟨⟨_|i⟩, hi⟩,
+      { simpa using h },
+      { simpa using h' } } }
+end
+
+end sublist
+
 end list


### PR DESCRIPTION
As discussed in https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/nodup.20and.20decidability and #7587 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
