### PR TITLE
[Merged by Bors] - chore(algebra/field_power, data/set/intervals/basic): simpler proofs in the first file, fewer parentheses in the second one

### DIFF
--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -212,8 +212,8 @@ lemma fpow_strict_mono {x : K} (hx : 1 < x) :
   strict_mono (λ n:ℤ, x ^ n) :=
 λ m n h, show x ^ m < x ^ n,
 begin
-  have xpos : 0 < x := by linarith,
-  have h₀ : x ≠ 0 := by linarith,
+  have xpos : 0 < x := zero_lt_one.trans hx,
+  have h₀ : x ≠ 0 := xpos.ne',
   have hxm : 0 < x^m := fpow_pos_of_pos xpos m,
   have hxm₀ : x^m ≠ 0 := ne_of_gt hxm,
   suffices : 1 < x^(n-m),

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1470,7 +1470,7 @@ calc cos 1 ≤ abs' (1 : ℝ) ^ 4 * (5 / 96) + (1 - 1 ^ 2 / 2) :
   sub_le_iff_le_add.1 (abs_sub_le_iff.1 (cos_bound (by simp))).1
 ... ≤ 2 / 3 : by norm_num
 
-lemma cos_one_pos : 0 < cos 1 := cos_pos_of_le_one abs_one.le
+lemma cos_one_pos : 0 < cos 1 := cos_pos_of_le_one (le_of_eq abs_one)
 
 lemma cos_two_neg : cos 2 < 0 :=
 calc cos 2 = cos (2 * 1) : congr_arg cos (mul_one _).symm

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1470,18 +1470,15 @@ calc cos 1 ≤ abs' (1 : ℝ) ^ 4 * (5 / 96) + (1 - 1 ^ 2 / 2) :
   sub_le_iff_le_add.1 (abs_sub_le_iff.1 (cos_bound (by simp))).1
 ... ≤ 2 / 3 : by norm_num
 
-lemma cos_one_pos : 0 < cos 1 := cos_pos_of_le_one (by simp)
+lemma cos_one_pos : 0 < cos 1 := cos_pos_of_le_one (le_of_eq abs_one)
 
 lemma cos_two_neg : cos 2 < 0 :=
 calc cos 2 = cos (2 * 1) : congr_arg cos (mul_one _).symm
-... = _ : real.cos_two_mul 1
-... ≤ 2 * (2 / 3) ^ 2 - 1 :
-  sub_le_sub_right (mul_le_mul_of_nonneg_left
-    (by rw [sq, sq]; exact
-      mul_self_le_mul_self (le_of_lt cos_one_pos)
-        cos_one_le)
-    (by norm_num)) _
-... < 0 : by norm_num
+  ... = _ : real.cos_two_mul 1
+  ... ≤ 2 * (2 / 3) ^ 2 - 1 : sub_le_sub_right (mul_le_mul_of_nonneg_left
+          (by { rw [sq, sq], exact mul_self_le_mul_self (le_of_lt cos_one_pos) cos_one_le })
+          zero_le_two) _
+  ... < 0 : by norm_num
 
 end real
 

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1470,7 +1470,7 @@ calc cos 1 ≤ abs' (1 : ℝ) ^ 4 * (5 / 96) + (1 - 1 ^ 2 / 2) :
   sub_le_iff_le_add.1 (abs_sub_le_iff.1 (cos_bound (by simp))).1
 ... ≤ 2 / 3 : by norm_num
 
-lemma cos_one_pos : 0 < cos 1 := cos_pos_of_le_one (le_of_eq abs_one)
+lemma cos_one_pos : 0 < cos 1 := cos_pos_of_le_one abs_one.le
 
 lemma cos_two_neg : cos 2 < 0 :=
 calc cos 2 = cos (2 * 1) : congr_arg cos (mul_one _).symm

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -1193,13 +1193,13 @@ variables {α : Type*} [ordered_comm_group α] {a b c d : α}
 
 /-! `inv_mem_Ixx_iff`, `sub_mem_Ixx_iff` -/
 @[to_additive] lemma inv_mem_Icc_iff : a⁻¹ ∈ set.Icc c d ↔ a ∈ set.Icc (d⁻¹) (c⁻¹) :=
-(and_comm _ _).trans $ (and_congr inv_le' le_inv')
+(and_comm _ _).trans $ and_congr inv_le' le_inv'
 @[to_additive] lemma inv_mem_Ico_iff : a⁻¹ ∈ set.Ico c d ↔ a ∈ set.Ioc (d⁻¹) (c⁻¹) :=
-(and_comm _ _).trans $ (and_congr inv_lt' le_inv')
+(and_comm _ _).trans $ and_congr inv_lt' le_inv'
 @[to_additive] lemma inv_mem_Ioc_iff : a⁻¹ ∈ set.Ioc c d ↔ a ∈ set.Ico (d⁻¹) (c⁻¹) :=
-(and_comm _ _).trans $ (and_congr inv_le' lt_inv')
+(and_comm _ _).trans $ and_congr inv_le' lt_inv'
 @[to_additive] lemma inv_mem_Ioo_iff : a⁻¹ ∈ set.Ioo c d ↔ a ∈ set.Ioo (d⁻¹) (c⁻¹) :=
-(and_comm _ _).trans $ (and_congr inv_lt' lt_inv')
+(and_comm _ _).trans $ and_congr inv_lt' lt_inv'
 
 end ordered_comm_group
 
@@ -1229,23 +1229,23 @@ lemma add_mem_Ioo_iff_right : a + b ∈ set.Ioo c d ↔ b ∈ set.Ioo (c - a) (d
 
 /-! `sub_mem_Ixx_iff_left` -/
 lemma sub_mem_Icc_iff_left : a - b ∈ set.Icc c d ↔ a ∈ set.Icc (c + b) (d + b) :=
-(and_congr le_sub_iff_add_le sub_le_iff_le_add)
+and_congr le_sub_iff_add_le sub_le_iff_le_add
 lemma sub_mem_Ico_iff_left : a - b ∈ set.Ico c d ↔ a ∈ set.Ico (c + b) (d + b) :=
-(and_congr le_sub_iff_add_le sub_lt_iff_lt_add)
+and_congr le_sub_iff_add_le sub_lt_iff_lt_add
 lemma sub_mem_Ioc_iff_left : a - b ∈ set.Ioc c d ↔ a ∈ set.Ioc (c + b) (d + b) :=
-(and_congr lt_sub_iff_add_lt sub_le_iff_le_add)
+and_congr lt_sub_iff_add_lt sub_le_iff_le_add
 lemma sub_mem_Ioo_iff_left : a - b ∈ set.Ioo c d ↔ a ∈ set.Ioo (c + b) (d + b) :=
-(and_congr lt_sub_iff_add_lt sub_lt_iff_lt_add)
+and_congr lt_sub_iff_add_lt sub_lt_iff_lt_add
 
 /-! `sub_mem_Ixx_iff_right` -/
 lemma sub_mem_Icc_iff_right : a - b ∈ set.Icc c d ↔ b ∈ set.Icc (a - d) (a - c) :=
-(and_comm _ _).trans $ (and_congr sub_le le_sub)
+(and_comm _ _).trans $ and_congr sub_le le_sub
 lemma sub_mem_Ico_iff_right : a - b ∈ set.Ico c d ↔ b ∈ set.Ioc (a - d) (a - c) :=
-(and_comm _ _).trans $ (and_congr sub_lt le_sub)
+(and_comm _ _).trans $ and_congr sub_lt le_sub
 lemma sub_mem_Ioc_iff_right : a - b ∈ set.Ioc c d ↔ b ∈ set.Ico (a - d) (a - c) :=
-(and_comm _ _).trans $ (and_congr sub_le lt_sub)
+(and_comm _ _).trans $ and_congr sub_le lt_sub
 lemma sub_mem_Ioo_iff_right : a - b ∈ set.Ioo c d ↔ b ∈ set.Ioo (a - d) (a - c) :=
-(and_comm _ _).trans $ (and_congr sub_lt lt_sub)
+(and_comm _ _).trans $ and_congr sub_lt lt_sub
 
 -- I think that symmetric intervals deserve attention and API: they arise all the time,
 -- for instance when considering metric balls in `ℝ`.


### PR DESCRIPTION
This is mostly a cosmetic PR: I removed two calls to `linarith`, where a term-mode proof was very simple.

I also removed some unnecessary parentheses in a different file.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
