### PR TITLE
[Merged by Bors] - feat(algebra/ordered_ring): more granular typeclasses for `with_top α` and `with_bot α`

### DIFF
--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -1524,8 +1524,8 @@ with_top.mul_eq_top_iff
 
 lemma bot_lt_mul [partial_order α] {a b : with_bot α} (ha : ⊥ < a) (hb : ⊥ < b) : ⊥ < a * b :=
 begin
-  lift a to α using ne_bot_of_lt ha,
-  lift b to α using ne_bot_of_lt hb,
+  lift a to α using ne_bot_of_gt ha,
+  lift b to α using ne_bot_of_gt hb,
   simp only [← coe_mul, coe_lt_top]
 end
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -1334,7 +1334,7 @@ end canonically_ordered_semiring
 
 /-! ### Structures involving `*` and `0` on `with_top` and `with_bot`
 
-The main results of this section are `with_top.canonically_ordered_comm_semiring` an
+The main results of this section are `with_top.canonically_ordered_comm_semiring` and
 `with_bot.comm_monoid_with_zero`.
 -/
 

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -1437,7 +1437,7 @@ instance [semigroup_with_zero α] [no_zero_divisors α] : semigroup_with_zero (w
         simp [*, none_eq_top, some_eq_coe] },
     simp [some_eq_coe, coe_mul.symm, mul_assoc]
   end,
-  ..with_top.mul_zero_class }
+  .. with_top.mul_zero_class }
 
 instance [monoid_with_zero α] [no_zero_divisors α] [nontrivial α] : monoid_with_zero (with_top α) :=
 { .. with_top.mul_zero_one_class, .. with_top.semigroup_with_zero }
@@ -1466,6 +1466,9 @@ begin
     repeat { refl <|> exact congr_arg some (add_mul _ _ _) } }
 end
 
+/-- This instance requires `canonically_ordered_comm_semiring` as it is the smallest class
+that derives from both `non_assoc_non_unital_semiring` and `canonically_ordered_add_monoid`, both
+of which are required for distributivity. -/
 instance [nontrivial α] : comm_semiring (with_top α) :=
 { right_distrib   := distrib',
   left_distrib    := assume a b c, by rw [mul_comm, distrib', mul_comm b, mul_comm c]; refl,
@@ -1474,8 +1477,7 @@ instance [nontrivial α] : comm_semiring (with_top α) :=
 instance [nontrivial α] : canonically_ordered_comm_semiring (with_top α) :=
 { .. with_top.comm_semiring,
   .. with_top.canonically_ordered_add_monoid,
-  .. with_top.no_zero_divisors, .. with_top.nontrivial }
-
+  .. with_top.no_zero_divisors, }
 
 end with_top
 
@@ -1526,7 +1528,7 @@ lemma bot_lt_mul [partial_order α] {a b : with_bot α} (ha : ⊥ < a) (hb : ⊥
 begin
   lift a to α using ne_bot_of_gt ha,
   lift b to α using ne_bot_of_gt hb,
-  simp only [← coe_mul, coe_lt_top]
+  simp only [← coe_mul, bot_lt_coe],
 end
 
 end mul_zero_class
@@ -1548,7 +1550,7 @@ instance [comm_monoid_with_zero α] [no_zero_divisors α] [nontrivial α] :
   comm_monoid_with_zero (with_bot α) :=
 with_top.comm_monoid_with_zero
 
-instance [canonically_ordered_comm_semiring α] : comm_semiring (with_bot α) :=
+instance [canonically_ordered_comm_semiring α] [nontrivial α] : comm_semiring (with_bot α) :=
 with_top.comm_semiring
 
 end with_bot

--- a/src/data/real/ereal.lean
+++ b/src/data/real/ereal.lean
@@ -442,6 +442,8 @@ end
 
 /-! ### Multiplication -/
 
+@[simp] lemma coe_one : ((1 : ℝ) : ereal) = 1 := rfl
+
 @[simp, norm_cast] lemma coe_mul (x y : ℝ) : ((x * y : ℝ) : ereal) = (x : ereal) * (y : ereal) :=
 eq.trans (with_bot.coe_eq_coe.mpr with_bot.coe_mul) with_top.coe_mul
 
@@ -456,12 +458,14 @@ with_top.coe_mul.symm.trans $
 with_top.coe_mul.symm.trans $
   with_bot.coe_eq_coe.mpr $ with_bot.mul_bot $ function.injective.ne (@option.some.inj _) h
 
-lemma to_real_mul : ∀ {x y : ereal} (hx : x ≠ ⊤) (h'x : x ≠ ⊥) (hy : y ≠ ⊤) (h'y : y ≠ ⊥),
-  to_real (x * y) = to_real x * to_real y
-| ⊥ y hx h'x hy h'y := (h'x rfl).elim
-| ⊤ y hx h'x hy h'y := (hx rfl).elim
-| x ⊤ hx h'x hy h'y := (hy rfl).elim
-| x ⊥ hx h'x hy h'y := (h'y rfl).elim
-| (x : ℝ) (y : ℝ) hx h'x hy h'y := by simp [← ereal.coe_mul]
+@[simp] lemma to_real_one : to_real 1 = 1 := rfl
+
+lemma to_real_mul : ∀ {x y : ereal}, to_real (x * y) = to_real x * to_real y
+| ⊤ y := by by_cases hy : y = 0; simp [hy]
+| x ⊤ := by by_cases hx : x = 0; simp [hx]
+| (x : ℝ) (y : ℝ) := by simp [← ereal.coe_mul]
+| ⊥ (y : ℝ) := by by_cases hy : y = 0; simp [hy]
+| (x : ℝ) ⊥ := by by_cases hx : x = 0; simp [hx]
+| ⊥ ⊥ := by simp
 
 end ereal

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -447,6 +447,11 @@ lemma bot_lt_some [has_lt α] (a : α) : (⊥ : with_bot α) < some a :=
 
 lemma bot_lt_coe [has_lt α] (a : α) : (⊥ : with_bot α) < a := bot_lt_some a
 
+instance : can_lift (with_bot α) α :=
+{ coe := coe,
+  cond := λ r, r ≠ ⊥,
+  prf := λ x hx, ⟨option.get $ option.ne_none_iff_is_some.1 hx, option.some_get _⟩ }
+
 instance [preorder α] : preorder (with_bot α) :=
 { le          := λ o₁ o₂ : option α, ∀ a ∈ o₁, ∃ b ∈ o₂, a ≤ b,
   lt          := (<),


### PR DESCRIPTION
`with_top α` and `with_bot α` now inherit the following typeclasses from `α` with suitable assumptions:

* `mul_zero_one_class`
* `semigroup_with_zero`
* `monoid_with_zero`
* `comm_monoid_with_zero`

These were all split out of the existing `canonically_ordered_comm_semiring`, with their proofs unchanged.
The same instances are added for `with_bot`.

It is not possible to split further, as `distrib'` requires `add_eq_zero_iff`, and `canonically_ordered_comm_semiring` is the smallest typeclass that provides both this lemma and `mul_zero_class`.

With these instances in place, we can now show `comm_monoid_with_zero ereal`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
