### PR TITLE
chore(topology): making notation consistent with the smooth library

### DIFF
--- a/src/analysis/fourier.lean
+++ b/src/analysis/fourier.lean
@@ -27,7 +27,7 @@ The theorem `orthonormal_fourier` states that the functions `fourier n`, when se
 
 ## TODO
 
-* Show that `submodule.span fourier` is dense in `C(circle, ℂ)`, i.e. that its
+* Show that `submodule.span fourier` is dense in `C⟮circle, ℂ⟯`, i.e. that its
   `submodule.topological_closure` is `⊤`.  This follows from the Stone-Weierstrass theorem after
   checking that it is a subalgebra, closed under conjugation, and separates points.
 * Show that the image of `submodule.span fourier` under `continuous_map.to_Lp` is dense in the
@@ -63,7 +63,7 @@ section fourier
 
 /-- The family of monomials `λ z, z ^ n`, parametrized by `n : ℤ` and considered as bundled
 continuous maps from `circle` to `ℂ`. -/
-@[simps] def fourier (n : ℤ) : C(circle, ℂ) :=
+@[simps] def fourier (n : ℤ) : C⟮circle, ℂ⟯ :=
 { to_fun := λ z, z ^ n,
   continuous_to_fun := continuous_subtype_coe.fpow nonzero_of_mem_circle n }
 

--- a/src/analysis/special_functions/bernstein.lean
+++ b/src/analysis/special_functions/bernstein.lean
@@ -15,7 +15,7 @@ We prove that the Bernstein approximations
 ```
 ∑ k : fin (n+1), f (k/n : ℝ) * n.choose k * x^k * (1-x)^(n-k)
 ```
-for a continuous function `f : C([0,1], ℝ)` converge uniformly to `f` as `n` tends to infinity.
+for a continuous function `f : C⟮[0,1], ℝ⟯` converge uniformly to `f` as `n` tends to infinity.
 
 Our proof follows [Richard Beals' *Analysis, an introduction*][beals-analysis], §7D.
 The original proof, due to [Bernstein](bernstein1912) in 1912, is probabilistic,
@@ -39,7 +39,7 @@ but can also be given a probabilistic account.
 
 (You don't need to think in these terms to follow the proof below: it's a giant `calc` block!)
 
-This result proves Weierstrass' theorem that polynomials are dense in `C([0,1], ℝ)`,
+This result proves Weierstrass' theorem that polynomials are dense in `C⟮[0,1], ℝ⟯`,
 although we defer an abstract statement of this until later.
 -/
 
@@ -53,7 +53,7 @@ open_locale unit_interval
 /--
 The Bernstein polynomials, as continuous functions on `[0,1]`.
 -/
-def bernstein (n ν : ℕ) : C(I, ℝ) :=
+def bernstein (n ν : ℕ) : C⟮I, ℝ⟯ :=
 (bernstein_polynomial ℝ n ν).to_continuous_map_on I
 
 @[simp] lemma bernstein_apply (n ν : ℕ) (x : I) :
@@ -137,7 +137,7 @@ local notation `|`x`|` := abs x
 The `n`-th approximation of a continuous function on `[0,1]` by Bernstein polynomials,
 given by `∑ k, f (k/n) * bernstein n k x`.
 -/
-def bernstein_approximation (n : ℕ) (f : C(I, ℝ)) : C(I, ℝ) :=
+def bernstein_approximation (n : ℕ) (f : C⟮I, ℝ⟯) : C⟮I, ℝ⟯ :=
 ∑ k : fin (n+1), f k/ₙ • bernstein n k
 
 /-!
@@ -145,7 +145,7 @@ We now set up some of the basic machinery of the proof that the Bernstein approx
 converge uniformly.
 
 A key player is the set `S f ε h n x`,
-for some function `f : C(I, ℝ)`, `h : 0 < ε`, `n : ℕ` and `x : I`.
+for some function `f : C⟮I, ℝ⟯`, `h : 0 < ε`, `n : ℕ` and `x : I`.
 
 This is the set of points `k` in `fin (n+1)` such that
 `k/n` is within `δ` of `x`, where `δ` is the modulus of uniform continuity for `f`,
@@ -156,26 +156,26 @@ We show that if `k ∉ S`, then `1 ≤ δ^-2 * (x - k/n)^2`.
 
 namespace bernstein_approximation
 
-@[simp] lemma apply (n : ℕ) (f : C(I, ℝ)) (x : I) :
+@[simp] lemma apply (n : ℕ) (f : C⟮I, ℝ⟯) (x : I) :
   bernstein_approximation n f x = ∑ k : fin (n+1), f k/ₙ * bernstein n k x :=
 by simp [bernstein_approximation]
 
 /--
 The modulus of (uniform) continuity for `f`, chosen so `|f x - f y| < ε/2` when `|x - y| < δ`.
 -/
-def δ (f : C(I, ℝ)) (ε : ℝ) (h : 0 < ε) : ℝ := f.modulus (ε/2) (half_pos h)
+def δ (f : C⟮I, ℝ⟯) (ε : ℝ) (h : 0 < ε) : ℝ := f.modulus (ε/2) (half_pos h)
 
 /--
 The set of points `k` so `k/n` is within `δ` of `x`.
 -/
-def S (f : C(I, ℝ)) (ε : ℝ) (h : 0 < ε) (n : ℕ) (x : I) : finset (fin (n+1)) :=
+def S (f : C⟮I, ℝ⟯) (ε : ℝ) (h : 0 < ε) (n : ℕ) (x : I) : finset (fin (n+1)) :=
 { k : fin (n+1) | dist k/ₙ x < δ f ε h }.to_finset
 
 /--
 If `k ∈ S`, then `f(k/n)` is close to `f x`.
 -/
 lemma lt_of_mem_S
-  {f : C(I, ℝ)} {ε : ℝ} {h : 0 < ε} {n : ℕ} {x : I} {k : fin (n+1)} (m : k ∈ S f ε h n x) :
+  {f : C⟮I, ℝ⟯} {ε : ℝ} {h : 0 < ε} {n : ℕ} {x : I} {k : fin (n+1)} (m : k ∈ S f ε h n x) :
   |f k/ₙ - f x| < ε/2 :=
 begin
   apply f.dist_lt_of_dist_lt_modulus (ε/2) (half_pos h),
@@ -187,7 +187,7 @@ If `k ∉ S`, then as `δ ≤ |x - k/n|`, we have the inequality `1 ≤ δ^-2 * 
 This particular formulation will be helpful later.
 -/
 lemma le_of_mem_S_compl
-  {f : C(I, ℝ)} {ε : ℝ} {h : 0 < ε} {n : ℕ} {x : I} {k : fin (n+1)} (m : k ∈ (S f ε h n x)ᶜ) :
+  {f : C⟮I, ℝ⟯} {ε : ℝ} {h : 0 < ε} {n : ℕ} {x : I} {k : fin (n+1)} (m : k ∈ (S f ε h n x)ᶜ) :
   (1 : ℝ) ≤ (δ f ε h)^(-2 : ℤ) * (x - k/ₙ) ^ 2 :=
 begin
   simp only [finset.mem_compl, not_lt, set.mem_to_finset, set.mem_set_of_eq, S] at m,
@@ -212,12 +212,12 @@ The Bernstein approximations
 ```
 ∑ k : fin (n+1), f (k/n : ℝ) * n.choose k * x^k * (1-x)^(n-k)
 ```
-for a continuous function `f : C([0,1], ℝ)` converge uniformly to `f` as `n` tends to infinity.
+for a continuous function `f : C⟮[0,1], ℝ⟯` converge uniformly to `f` as `n` tends to infinity.
 
 This is the proof given in [Richard Beals' *Analysis, an introduction*][beals-analysis], §7D,
 and reproduced on wikipedia.
 -/
-theorem bernstein_approximation_uniform (f : C(I, ℝ)) :
+theorem bernstein_approximation_uniform (f : C⟮I, ℝ⟯) :
   tendsto (λ n : ℕ, bernstein_approximation n f) at_top (𝓝 f) :=
 begin
   simp only [metric.nhds_basis_ball.tendsto_right_iff, metric.mem_ball, dist_eq_norm],

--- a/src/category_theory/full_subcategory.lean
+++ b/src/category_theory/full_subcategory.lean
@@ -16,7 +16,7 @@ section induced
   Given a category D and a function F : C → D from a type C to the
   objects of D, there is an essentially unique way to give C a
   category structure such that F becomes a fully faithful functor,
-  namely by taking Hom_C(X, Y) = Hom_D(FX, FY). We call this the
+  namely by taking Hom_C⟮X, Y⟯ = Hom_D(FX, FY). We call this the
   category induced from D along F.
 
   As a special case, if C is a subtype of D, this produces the full

--- a/src/geometry/manifold/times_cont_mdiff_map.lean
+++ b/src/geometry/manifold/times_cont_mdiff_map.lean
@@ -49,7 +49,7 @@ namespace times_cont_mdiff_map
 variables {I} {I'} {M} {M'} {n}
 
 instance : has_coe_to_fun C^n⟮I, M; I', M'⟯ := ⟨_, times_cont_mdiff_map.to_fun⟩
-instance : has_coe C^n⟮I, M; I', M'⟯ C(M, M') :=
+instance : has_coe C^n⟮I, M; I', M'⟯ C⟮M, M'⟯ :=
 ⟨λ f, ⟨f.to_fun, f.times_cont_mdiff_to_fun.continuous⟩⟩
 
 variables {f g : C^n⟮I, M; I', M'⟯}

--- a/src/measure_theory/ae_eq_fun.lean
+++ b/src/measure_theory/ae_eq_fun.lean
@@ -449,10 +449,10 @@ variables [topological_space β] [measurable_space β] [borel_space β]
 
 /-- The equivalence class of `μ`-almost-everywhere measurable functions associated to a continuous
 map. -/
-def to_ae_eq_fun (f : C(α, β)) : α →ₘ[μ] β :=
+def to_ae_eq_fun (f : C⟮α, β⟯) : α →ₘ[μ] β :=
 ae_eq_fun.mk f f.continuous.measurable.ae_measurable
 
-lemma coe_fn_to_ae_eq_fun (f : C(α, β)) : f.to_ae_eq_fun μ =ᵐ[μ] f :=
+lemma coe_fn_to_ae_eq_fun (f : C⟮α, β⟯) : f.to_ae_eq_fun μ =ᵐ[μ] f :=
 ae_eq_fun.coe_fn_mk f _
 
 variables [group β] [topological_group β] [second_countable_topology β]
@@ -461,7 +461,7 @@ variables [group β] [topological_group β] [second_countable_topology β]
 classes of `μ`-almost-everywhere measurable functions. -/
 @[to_additive "The `add_hom` from the group of continuous maps from `α` to `β` to the group of
 equivalence classes of `μ`-almost-everywhere measurable functions."]
-def to_ae_eq_fun_mul_hom : C(α, β) →* α →ₘ[μ] β :=
+def to_ae_eq_fun_mul_hom : C⟮α, β⟯ →* α →ₘ[μ] β :=
 { to_fun := continuous_map.to_ae_eq_fun μ,
   map_one' := rfl,
   map_mul' := λ f g, ae_eq_fun.mk_mul_mk f g f.continuous.measurable.ae_measurable
@@ -475,7 +475,7 @@ variables [topological_space γ] [measurable_space γ] [borel_space γ] [add_com
 
 /-- The linear map from the group of continuous maps from `α` to `β` to the group of equivalence
 classes of `μ`-almost-everywhere measurable functions. -/
-def to_ae_eq_fun_linear_map : C(α, γ) →ₗ[𝕜] α →ₘ[μ] γ :=
+def to_ae_eq_fun_linear_map : C⟮α, γ⟯ →ₗ[𝕜] α →ₘ[μ] γ :=
 { map_smul' := λ c f, ae_eq_fun.smul_mk c f f.continuous.measurable.ae_measurable,
   .. to_ae_eq_fun_add_hom μ }
 

--- a/src/measure_theory/l2_space.lean
+++ b/src/measure_theory/l2_space.lean
@@ -167,7 +167,7 @@ variables [compact_space α]
 
 /-- For continuous functions `f`, `g` on a compact, finite-measure topological space `α`, the L^2
 inner product is the integral of their pointwise inner product. -/
-lemma continuous_map.inner_to_Lp (f g : C(α, 𝕜)) :
+lemma continuous_map.inner_to_Lp (f g : C⟮α, 𝕜⟯) :
   ⟪continuous_map.to_Lp 2 μ 𝕜 f, continuous_map.to_Lp 2 μ 𝕜 g⟫
   = ∫ x, is_R_or_C.conj (f x) * g x ∂μ :=
 begin

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -1811,21 +1811,21 @@ variables [finite_measure μ]
 variables (𝕜 : Type*) [measurable_space 𝕜] (p μ) [fact (1 ≤ p)]
 
 /-- The bounded linear map of considering a continuous function on a compact finite-measure
-space `α` as an element of `Lp`.  By definition, the norm on `C(α, E)` is the sup-norm, transferred
+space `α` as an element of `Lp`.  By definition, the norm on `C⟮α, E⟯` is the sup-norm, transferred
 from the space `α →ᵇ E` of bounded continuous functions, so this construction is just a matter of
 transferring the structure from `bounded_continuous_function.to_Lp` along the isometry. -/
 def to_Lp [normed_field 𝕜] [opens_measurable_space 𝕜] [normed_space 𝕜 E] :
-  C(α, E) →L[𝕜] (Lp E p μ) :=
+  C⟮α, E⟯ →L[𝕜] (Lp E p μ) :=
 (bounded_continuous_function.to_Lp p μ 𝕜).comp
   (linear_isometry_bounded_of_compact α E 𝕜).to_linear_isometry.to_continuous_linear_map
 
 variables {p 𝕜}
 
-lemma coe_fn_to_Lp [normed_field 𝕜] [opens_measurable_space 𝕜] [normed_space 𝕜 E] (f : C(α,  E)) :
+lemma coe_fn_to_Lp [normed_field 𝕜] [opens_measurable_space 𝕜] [normed_space 𝕜 E] (f : C⟮α,  E⟯) :
   to_Lp p μ 𝕜 f =ᵐ[μ] f :=
 ae_eq_fun.coe_fn_mk f _
 
-lemma to_Lp_def [normed_field 𝕜] [opens_measurable_space 𝕜] [normed_space 𝕜 E] (f : C(α, E)) :
+lemma to_Lp_def [normed_field 𝕜] [opens_measurable_space 𝕜] [normed_space 𝕜 E] (f : C⟮α, E⟯) :
   to_Lp p μ 𝕜 f
   = bounded_continuous_function.to_Lp p μ 𝕜 (linear_isometry_bounded_of_compact α E 𝕜 f) :=
 rfl
@@ -1837,7 +1837,7 @@ rfl
 rfl
 
 @[simp] lemma coe_to_Lp [normed_field 𝕜] [opens_measurable_space 𝕜] [normed_space 𝕜 E]
-  (f : C(α, E)) :
+  (f : C⟮α, E⟯) :
   (to_Lp p μ 𝕜 f : α →ₘ[μ] E) = f.to_ae_eq_fun μ :=
 rfl
 

--- a/src/ring_theory/polynomial/bernstein.lean
+++ b/src/ring_theory/polynomial/bernstein.lean
@@ -28,7 +28,7 @@ We prove the basic identities
 ## Notes
 
 See also `analysis.special_functions.bernstein`, which defines the Bernstein approximations
-of a continuous function `f : C([0,1], ℝ)`, and shows that these converge uniformly to `f`.
+of a continuous function `f : C⟮[0,1], ℝ⟯`, and shows that these converge uniformly to `f`.
 -/
 
 noncomputable theory

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -163,7 +163,7 @@ begin
   rw hps,
   apply is_closed_Inter,
   rintros ⟨j', f⟩,
-  let proj : Π (j' : Jᵒᵖ), C((Π (j : Jᵒᵖ), F.obj j), F.obj j') :=
+  let proj : Π (j' : Jᵒᵖ), C⟮(Π (j : Jᵒᵖ), F.obj j⟯, F.obj j') :=
     λ j', ⟨λ u, u j', continuous_apply j'⟩,
   exact is_closed_eq
     (((F.map f).continuous.comp (proj j).continuous).comp continuous_id)

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -163,7 +163,7 @@ begin
   rw hps,
   apply is_closed_Inter,
   rintros ⟨j', f⟩,
-  let proj : Π (j' : Jᵒᵖ), C⟮(Π (j : Jᵒᵖ), F.obj j⟯, F.obj j') :=
+  let proj : Π (j' : Jᵒᵖ), C⟮(Π (j : Jᵒᵖ), F.obj j), F.obj j'⟯ :=
     λ j', ⟨λ u, u j', continuous_apply j'⟩,
   exact is_closed_eq
     (((F.map f).continuous.comp (proj j).continuous).comp continuous_id)

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -18,16 +18,16 @@ topological spaces.
 
 ## Main definitions
 
-* `compact_open` is the compact-open topology on `C(α, β)`. It is declared as an instance.
-* `ev` is the evaluation map `C(α, β) × α → β`. It is continuous as long as `α` is locally compact.
-* `coev` is the coevaluation map `β → C(α, β × α)`. It is always continuous.
-* `continuous_map.curry` is the currying map `C(α × β, γ) → C(α, C(β, γ))`. This map always exists
+* `compact_open` is the compact-open topology on `C⟮α, β⟯`. It is declared as an instance.
+* `ev` is the evaluation map `C⟮α, β⟯ × α → β`. It is continuous as long as `α` is locally compact.
+* `coev` is the coevaluation map `β → C⟮α, β × α⟯`. It is always continuous.
+* `continuous_map.curry` is the currying map `C⟮α × β, γ⟯ → C⟮α, C⟮β, γ⟯⟯`. This map always exists
   and it is continuous as long as `α × β` is locally compact.
-* `continuous_map.uncurry` is the uncurrying map `C(α, C(β, γ)) → C(α × β, γ)`. For this map to
+* `continuous_map.uncurry` is the uncurrying map `C⟮α, C⟮β, γ⟯⟯ → C⟮α × β, γ⟯`. For this map to
   exist, we need `β` to be locally compact. If `α` is also locally compact, then this map is
   continuous.
 * `homeomorph.curry` combines the currying and uncurrying operations into a homeomorphism
-  `C(α × β, γ) ≃ₜ C(α, C(β, γ))`. This homeomorphism exists if `α` and `β` are locally compact.
+  `C⟮α × β, γ⟯ ≃ₜ C⟮α, C⟮β, γ⟯⟯`. This homeomorphism exists if `α` and `β` are locally compact.
 
 
 ## Tags
@@ -44,10 +44,10 @@ section compact_open
 variables {α : Type*} {β : Type*} {γ : Type*}
 variables [topological_space α] [topological_space β] [topological_space γ]
 
-def compact_open.gen (s : set α) (u : set β) : set C(α,β) := {f | f '' s ⊆ u}
+def compact_open.gen (s : set α) (u : set β) : set C⟮α,β⟯ := {f | f '' s ⊆ u}
 
 -- The compact-open topology on the space of continuous maps α → β.
-instance compact_open : topological_space C(α, β) :=
+instance compact_open : topological_space C⟮α, β⟯ :=
 topological_space.generate_from
   {m | ∃ (s : set α) (hs : is_compact s) (u : set β) (hu : is_open u), m = compact_open.gen s u}
 
@@ -59,7 +59,7 @@ section functorial
 
 variables {g : β → γ} (hg : continuous g)
 
-def induced (f : C(α, β)) : C(α, γ) := ⟨g ∘ f, hg.comp f.continuous⟩
+def induced (f : C⟮α, β⟯) : C⟮α, γ⟯ := ⟨g ∘ f, hg.comp f.continuous⟩
 
 private lemma preimage_gen {s : set α} (hs : is_compact s) {u : set γ} (hu : is_open u) :
   continuous_map.induced hg ⁻¹' (compact_open.gen s u) = compact_open.gen s (g ⁻¹' u) :=
@@ -69,8 +69,8 @@ begin
   rw [image_comp, image_subset_iff]
 end
 
-/-- C(α, -) is a functor. -/
-lemma continuous_induced : continuous (continuous_map.induced hg : C(α, β) → C(α, γ)) :=
+/-- C⟮α, -⟯ is a functor. -/
+lemma continuous_induced : continuous (continuous_map.induced hg : C⟮α, β⟯ → C⟮α, γ⟯) :=
 continuous_generated_from $ assume m ⟨s, hs, u, hu, hm⟩,
   by rw [hm, preimage_gen hg hs hu]; exact is_open_gen hs (hu.preimage hg)
 
@@ -79,10 +79,10 @@ end functorial
 section ev
 
 variables (α β)
-def ev (p : C(α, β) × α) : β := p.1 p.2
+def ev (p : C⟮α, β⟯ × α) : β := p.1 p.2
 
 variables {α β}
--- The evaluation map C(α, β) × α → β is continuous if α is locally compact.
+-- The evaluation map C⟮α, β⟯ × α → β is continuous if α is locally compact.
 lemma continuous_ev [locally_compact_space α] : continuous (ev α β) :=
 continuous_iff_continuous_at.mpr $ assume ⟨f, x⟩ n hn,
   let ⟨v, vn, vo, fxv⟩ := mem_nhds_iff.mp hn in
@@ -106,12 +106,12 @@ end ev
 section coev
 
 variables (α β)
-def coev (b : β) : C(α, β × α) := ⟨λ a, (b, a), continuous.prod_mk continuous_const continuous_id⟩
+def coev (b : β) : C⟮α, β × α⟯ := ⟨λ a, (b, a), continuous.prod_mk continuous_const continuous_id⟩
 
 variables {α β}
 lemma image_coev {y : β} (s : set α) : (coev α β y) '' s = set.prod {y} s := by tidy
 
--- The coevaluation map β → C(α, β × α) is continuous (always).
+-- The coevaluation map β → C⟮α, β × α⟯ is continuous (always).
 lemma continuous_coev : continuous (coev α β) :=
 continuous_generated_from $ begin
   rintros _ ⟨s, sc, u, uo, rfl⟩,
@@ -133,28 +133,28 @@ end coev
 section curry
 
 /-- Auxiliary definition, see `continuous_map.curry` and `homeomorph.curry`. -/
-def curry' (f : C(α × β, γ)) (a : α) : C(β, γ) := ⟨function.curry f a⟩
+def curry' (f : C⟮α × β, γ⟯) (a : α) : C⟮β, γ⟯ := ⟨function.curry f a⟩
 
-/-- If a map `α × β → γ` is continuous, then its curried form `α → C(β, γ)` is continuous. -/
-lemma continuous_curry' (f : C(α × β, γ)) : continuous (curry' f) :=
+/-- If a map `α × β → γ` is continuous, then its curried form `α → C⟮β, γ⟯` is continuous. -/
+lemma continuous_curry' (f : C⟮α × β, γ⟯) : continuous (curry' f) :=
 have hf : curry' f = continuous_map.induced f.continuous_to_fun ∘ coev _ _, by { ext, refl },
 hf ▸ continuous.comp (continuous_induced f.continuous_to_fun) continuous_coev
 
-/-- To show continuity of a map `α → C(β, γ)`, it suffices to show that its uncurried form
+/-- To show continuity of a map `α → C⟮β, γ⟯`, it suffices to show that its uncurried form
     `α × β → γ` is continuous. -/
-lemma continuous_of_continuous_uncurry (f : α → C(β, γ))
+lemma continuous_of_continuous_uncurry (f : α → C⟮β, γ⟯)
   (h : continuous (function.uncurry (λ x y, f x y))) : continuous f :=
 by { convert continuous_curry' ⟨_, h⟩, ext, refl }
 
-/-- The curried form of a continuous map `α × β → γ` as a continuous map `α → C(β, γ)`.
+/-- The curried form of a continuous map `α × β → γ` as a continuous map `α → C⟮β, γ⟯`.
     If `a × β` is locally compact, this is continuous. If `α` and `β` are both locally
     compact, then this is a homeomorphism, see `homeomorph.curry`. -/
-def curry (f : C(α × β, γ)) : C(α, C(β, γ)) :=
+def curry (f : C⟮α × β, γ⟯) : C⟮α, C⟮β, γ⟯⟯ :=
 ⟨_, continuous_curry' f⟩
 
 /-- The currying process is a continuous map between function spaces. -/
 lemma continuous_curry [locally_compact_space (α × β)] :
-  continuous (curry : C(α × β, γ) → C(α, C(β, γ))) :=
+  continuous (curry : C⟮α × β, γ⟯ → C⟮α, C⟮β, γ⟯⟯) :=
 begin
   apply continuous_of_continuous_uncurry,
   apply continuous_of_continuous_uncurry,
@@ -163,21 +163,21 @@ begin
   tidy
 end
 
-/-- The uncurried form of a continuous map `α → C(β, γ)` is a continuous map `α × β → γ`. -/
-lemma continuous_uncurry_of_continuous [locally_compact_space β] (f : C(α, C(β, γ))) :
+/-- The uncurried form of a continuous map `α → C⟮β, γ⟯` is a continuous map `α × β → γ`. -/
+lemma continuous_uncurry_of_continuous [locally_compact_space β] (f : C⟮α, C⟮β, γ⟯⟯) :
   continuous (function.uncurry (λ x y, f x y)) :=
 have hf : function.uncurry (λ x y, f x y) = ev β γ ∘ prod.map f id, by { ext, refl },
 hf ▸ continuous.comp continuous_ev $ continuous.prod_map f.2 id.2
 
-/-- The uncurried form of a continuous map `α → C(β, γ)` as a continuous map `α × β → γ` (if `β` is
+/-- The uncurried form of a continuous map `α → C⟮β, γ⟯` as a continuous map `α × β → γ` (if `β` is
     locally compact). If `α` is also locally compact, then this is a homeomorphism between the two
     function spaces, see `homeomorph.curry`. -/
-def uncurry [locally_compact_space β] (f : C(α, C(β, γ))) : C(α × β, γ) :=
+def uncurry [locally_compact_space β] (f : C⟮α, C⟮β, γ⟯⟯) : C⟮α × β, γ⟯ :=
 ⟨_, continuous_uncurry_of_continuous f⟩
 
 /-- The uncurrying process is a continuous map between function spaces. -/
 lemma continuous_uncurry [locally_compact_space α] [locally_compact_space β] :
-  continuous (uncurry : C(α, C(β, γ)) → C(α × β, γ)) :=
+  continuous (uncurry : C⟮α, C⟮β, γ⟯⟯ → C⟮α × β, γ⟯) :=
 begin
   apply continuous_of_continuous_uncurry,
   rw ←homeomorph.comp_continuous_iff' (homeomorph.prod_assoc _ _ _),
@@ -197,12 +197,12 @@ namespace homeomorph
 variables {α : Type*} {β : Type*} {γ : Type*}
 variables [topological_space α] [topological_space β] [topological_space γ]
 
-/-- Currying as a homeomorphism between the function spaces `C(α × β, γ)` and `C(α, C(β, γ))`. -/
-def curry [locally_compact_space α] [locally_compact_space β] : C(α × β, γ) ≃ₜ C(α, C(β, γ)) :=
+/-- Currying as a homeomorphism between the function spaces `C⟮α × β, γ⟯` and `C⟮α, C⟮β, γ⟯⟯`. -/
+def curry [locally_compact_space α] [locally_compact_space β] : C⟮α × β, γ⟯ ≃ₜ C⟮α, C⟮β, γ⟯⟯ :=
 ⟨⟨curry, uncurry, by tidy, by tidy⟩, continuous_curry, continuous_uncurry⟩
 
-/-- If `α` has a single element, then `β` is homeomorphic to `C(α, β)`. -/
-def continuous_map_of_unique [unique α] : β ≃ₜ C(α, β) :=
+/-- If `α` has a single element, then `β` is homeomorphic to `C⟮α, β⟯`. -/
+def continuous_map_of_unique [unique α] : β ≃ₜ C⟮α, β⟯ :=
 { to_fun := continuous_map.induced continuous_fst ∘ coev α β,
   inv_fun := ev α β ∘ (λ f, (f, default α)),
   left_inv := λ a, rfl,
@@ -215,7 +215,7 @@ def continuous_map_of_unique [unique α] : β ≃ₜ C(α, β) :=
   continuous_map_of_unique b a = b :=
 rfl
 
-@[simp] lemma continuous_map_of_unique_symm_apply [unique α] (f : C(α, β)) :
+@[simp] lemma continuous_map_of_unique_symm_apply [unique α] (f : C⟮α, β⟯) :
   continuous_map_of_unique.symm f = f (default α) :=
 rfl
 

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -32,29 +32,29 @@ namespace continuous_map
 variables {α : Type*} {β : Type*} [topological_space α] [topological_space β]
 
 @[to_additive]
-instance has_mul [has_mul β] [has_continuous_mul β] : has_mul C(α, β) :=
+instance has_mul [has_mul β] [has_continuous_mul β] : has_mul C⟮α, β⟯ :=
 ⟨λ f g, ⟨f * g, continuous_mul.comp (f.continuous.prod_mk g.continuous : _)⟩⟩
 
 @[simp, norm_cast, to_additive]
-lemma mul_coe [has_mul β] [has_continuous_mul β] (f g : C(α, β)) :
-  ((f * g : C(α, β)) : α → β) = (f : α → β) * (g : α → β) := rfl
+lemma mul_coe [has_mul β] [has_continuous_mul β] (f g : C⟮α, β⟯) :
+  ((f * g : C⟮α, β⟯) : α → β) = (f : α → β) * (g : α → β) := rfl
 
 @[to_additive]
-instance [has_one β] : has_one C(α, β) := ⟨const (1 : β)⟩
+instance [has_one β] : has_one C⟮α, β⟯ := ⟨const (1 : β)⟩
 
 @[simp, norm_cast, to_additive]
 lemma one_coe [has_one β]  :
-  ((1 : C(α, β)) : α → β) = (1 : α → β) := rfl
+  ((1 : C⟮α, β⟯) : α → β) = (1 : α → β) := rfl
 
 @[simp, to_additive] lemma mul_comp {α : Type*} {β : Type*} {γ : Type*}
   [topological_space α] [topological_space β] [topological_space γ]
-  [semigroup γ] [has_continuous_mul γ] (f₁ f₂ : C(β, γ)) (g : C(α, β)) :
+  [semigroup γ] [has_continuous_mul γ] (f₁ f₂ : C⟮β, γ⟯) (g : C⟮α, β⟯) :
   (f₁ * f₂).comp g = f₁.comp g * f₂.comp g :=
 by { ext, simp, }
 
 @[simp, to_additive] lemma one_comp {α : Type*} {β : Type*} {γ : Type*}
-  [topological_space α] [topological_space β] [topological_space γ] [has_one γ] (g : C(α, β)) :
-  (1 : C(β, γ)).comp g = 1 :=
+  [topological_space α] [topological_space β] [topological_space γ] [has_one γ] (g : C⟮α, β⟯) :
+  (1 : C⟮β, γ⟯).comp g = 1 :=
 by { ext, simp, }
 
 end continuous_map
@@ -104,13 +104,13 @@ namespace continuous_map
 
 @[to_additive]
 instance {α : Type*} {β : Type*} [topological_space α]
-  [topological_space β] [semigroup β] [has_continuous_mul β] : semigroup C(α, β) :=
+  [topological_space β] [semigroup β] [has_continuous_mul β] : semigroup C⟮α, β⟯ :=
 { mul_assoc := λ a b c, by ext; exact mul_assoc _ _ _,
   ..continuous_map.has_mul}
 
 @[to_additive]
 instance {α : Type*} {β : Type*} [topological_space α] [topological_space β]
-  [monoid β] [has_continuous_mul β] : monoid C(α, β) :=
+  [monoid β] [has_continuous_mul β] : monoid C⟮α, β⟯ :=
 { one_mul := λ a, by ext; exact one_mul _,
   mul_one := λ a, by ext; exact mul_one _,
   ..continuous_map.semigroup,
@@ -120,7 +120,7 @@ instance {α : Type*} {β : Type*} [topological_space α] [topological_space β]
 @[to_additive "Coercion to a function as an `add_monoid_hom`. Similar to `add_monoid_hom.coe_fn`.",
   simps]
 def coe_fn_monoid_hom {α : Type*} {β : Type*} [topological_space α] [topological_space β]
-  [monoid β] [has_continuous_mul β] : C(α, β) →* (α → β) :=
+  [monoid β] [has_continuous_mul β] : C⟮α, β⟯ →* (α → β) :=
 { to_fun := coe_fn, map_one' := one_coe, map_mul' := mul_coe }
 
 /-- Composition on the right as an `monoid_hom`. Similar to `monoid_hom.comp_hom'`. -/
@@ -128,24 +128,24 @@ def coe_fn_monoid_hom {α : Type*} {β : Type*} [topological_space α] [topologi
 `add_monoid_hom.comp_hom'`.", simps]
 def comp_monoid_hom' {α : Type*} {β : Type*} {γ : Type*}
   [topological_space α] [topological_space β] [topological_space γ]
-  [monoid γ] [has_continuous_mul γ] (g : C(α, β)) : C(β, γ) →* C(α, γ) :=
+  [monoid γ] [has_continuous_mul γ] (g : C⟮α, β⟯) : C⟮β, γ⟯ →* C⟮α, γ⟯ :=
 { to_fun := λ f, f.comp g, map_one' := one_comp g, map_mul' := λ f₁ f₂, mul_comp f₁ f₂ g }
 
 @[simp, norm_cast]
 lemma pow_coe {α : Type*} {β : Type*} [topological_space α] [topological_space β]
-  [monoid β] [has_continuous_mul β] (f : C(α, β)) (n : ℕ) :
-  ((f^n : C(α, β)) : α → β) = (f : α → β)^n :=
-(coe_fn_monoid_hom : C(α, β) →* _).map_pow f n
+  [monoid β] [has_continuous_mul β] (f : C⟮α, β⟯) (n : ℕ) :
+  ((f^n : C⟮α, β⟯) : α → β) = (f : α → β)^n :=
+(coe_fn_monoid_hom : C⟮α, β⟯ →* _).map_pow f n
 
 @[simp] lemma pow_comp {α : Type*} {β : Type*} {γ : Type*}
   [topological_space α] [topological_space β] [topological_space γ]
-  [monoid γ] [has_continuous_mul γ] (f : C(β, γ)) (n : ℕ) (g : C(α, β)) :
+  [monoid γ] [has_continuous_mul γ] (f : C⟮β, γ⟯) (n : ℕ) (g : C⟮α, β⟯) :
   (f^n).comp g = (f.comp g)^n :=
 (comp_monoid_hom' g).map_pow f n
 
 @[to_additive]
 instance {α : Type*} {β : Type*} [topological_space α]
-[topological_space β] [comm_monoid β] [has_continuous_mul β] : comm_monoid C(α, β) :=
+[topological_space β] [comm_monoid β] [has_continuous_mul β] : comm_monoid C⟮α, β⟯ :=
 { one_mul := λ a, by ext; exact one_mul _,
   mul_one := λ a, by ext; exact mul_one _,
   mul_comm := λ a b, by ext; exact mul_comm _ _,
@@ -155,51 +155,51 @@ instance {α : Type*} {β : Type*} [topological_space α]
 open_locale big_operators
 @[simp, to_additive] lemma coe_prod {α : Type*} {β : Type*} [comm_monoid β]
   [topological_space α] [topological_space β] [has_continuous_mul β]
-  {ι : Type*} (s : finset ι) (f : ι → C(α, β)) :
+  {ι : Type*} (s : finset ι) (f : ι → C⟮α, β⟯) :
   ⇑(∏ i in s, f i) = (∏ i in s, (f i : α → β)) :=
-(coe_fn_monoid_hom : C(α, β) →* _).map_prod f s
+(coe_fn_monoid_hom : C⟮α, β⟯ →* _).map_prod f s
 
 @[to_additive]
 lemma prod_apply {α : Type*} {β : Type*} [comm_monoid β]
   [topological_space α] [topological_space β] [has_continuous_mul β]
-  {ι : Type*} (s : finset ι) (f : ι → C(α, β)) (a : α) :
+  {ι : Type*} (s : finset ι) (f : ι → C⟮α, β⟯) (a : α) :
   (∏ i in s, f i) a = (∏ i in s, f i a) :=
 by simp
 
 @[to_additive]
 instance {α : Type*} {β : Type*} [topological_space α] [topological_space β]
-  [group β] [topological_group β] : group C(α, β) :=
+  [group β] [topological_group β] : group C⟮α, β⟯ :=
 { inv := λ f, ⟨λ x, (f x)⁻¹, continuous_inv.comp f.continuous⟩,
   mul_left_inv := λ a, by ext; exact mul_left_inv _,
   ..continuous_map.monoid }
 
 @[simp, norm_cast, to_additive]
 lemma inv_coe {α : Type*} {β : Type*} [topological_space α] [topological_space β]
-  [group β] [topological_group β] (f : C(α, β)) :
-  ((f⁻¹ : C(α, β)) : α → β) = (f⁻¹ : α → β) :=
+  [group β] [topological_group β] (f : C⟮α, β⟯) :
+  ((f⁻¹ : C⟮α, β⟯) : α → β) = (f⁻¹ : α → β) :=
 rfl
 
 @[simp, norm_cast, to_additive]
 lemma div_coe {α : Type*} {β : Type*} [topological_space α] [topological_space β]
-  [group β] [topological_group β] (f g : C(α, β)) :
-  ((f / g : C(α, β)) : α → β) = (f : α → β) / (g : α → β) :=
+  [group β] [topological_group β] (f g : C⟮α, β⟯) :
+  ((f / g : C⟮α, β⟯) : α → β) = (f : α → β) / (g : α → β) :=
 by { simp only [div_eq_mul_inv], refl, }
 
 @[simp, to_additive] lemma inv_comp {α : Type*} {β : Type*} {γ : Type*}
   [topological_space α] [topological_space β] [topological_space γ]
-  [group γ] [topological_group γ] (f : C(β, γ)) (g : C(α, β)) :
+  [group γ] [topological_group γ] (f : C⟮β, γ⟯) (g : C⟮α, β⟯) :
   (f⁻¹).comp g = (f.comp g)⁻¹ :=
 by { ext, simp, }
 
 @[simp, to_additive] lemma div_comp {α : Type*} {β : Type*} {γ : Type*}
   [topological_space α] [topological_space β] [topological_space γ]
-  [group γ] [topological_group γ] (f g : C(β, γ)) (h : C(α, β)) :
+  [group γ] [topological_group γ] (f g : C⟮β, γ⟯) (h : C⟮α, β⟯) :
   (f / g).comp h = (f.comp h) / (g.comp h) :=
 by { ext, simp, }
 
 @[to_additive]
 instance {α : Type*} {β : Type*} [topological_space α]
-  [topological_space β] [comm_group β] [topological_group β] : comm_group C(α, β) :=
+  [topological_space β] [comm_group β] [topological_group β] : comm_group C⟮α, β⟯ :=
 { ..continuous_map.group,
   ..continuous_map.comm_monoid }
 
@@ -236,7 +236,7 @@ end subtype
 namespace continuous_map
 
 instance {α : Type*} {β : Type*} [topological_space α] [topological_space β]
-  [semiring β] [topological_semiring β] : semiring C(α, β) :=
+  [semiring β] [topological_semiring β] : semiring C⟮α, β⟯ :=
 { left_distrib := λ a b c, by ext; exact left_distrib _ _ _,
   right_distrib := λ a b c, by ext; exact right_distrib _ _ _,
   zero_mul := λ a, by ext; exact zero_mul _,
@@ -245,12 +245,12 @@ instance {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   ..continuous_map.monoid }
 
 instance {α : Type*} {β : Type*} [topological_space α] [topological_space β]
-  [ring β] [topological_ring β] : ring C(α, β) :=
+  [ring β] [topological_ring β] : ring C⟮α, β⟯ :=
 { ..continuous_map.semiring,
   ..continuous_map.add_comm_group, }
 
 instance {α : Type*} {β : Type*} [topological_space α]
-  [topological_space β] [comm_ring β] [topological_ring β] : comm_ring C(α, β) :=
+  [topological_space β] [comm_ring β] [topological_ring β] : comm_ring C⟮α, β⟯ :=
 { ..continuous_map.semiring,
   ..continuous_map.add_comm_group,
   ..continuous_map.comm_monoid,}
@@ -258,10 +258,10 @@ instance {α : Type*} {β : Type*} [topological_space α]
 /-- Coercion to a function as a `ring_hom`. -/
 @[simps]
 def coe_fn_ring_hom {α : Type*} {β : Type*} [topological_space α] [topological_space β]
-  [ring β] [topological_ring β] : C(α, β) →+* (α → β) :=
+  [ring β] [topological_ring β] : C⟮α, β⟯ →+* (α → β) :=
 { to_fun := coe_fn,
-  ..(coe_fn_monoid_hom : C(α, β) →* _),
-  ..(coe_fn_add_monoid_hom : C(α, β) →+ _) }
+  ..(coe_fn_monoid_hom : C⟮α, β⟯ →* _),
+  ..(coe_fn_add_monoid_hom : C⟮α, β⟯ →+ _) }
 
 end continuous_map
 
@@ -310,26 +310,26 @@ variables {α : Type*} [topological_space α]
 
 instance
   [module R M] [has_continuous_smul R M] :
-  has_scalar R C(α, M) :=
+  has_scalar R C⟮α, M⟯ :=
 ⟨λ r f, ⟨r • f, f.continuous.const_smul r⟩⟩
 
 @[simp, norm_cast]
 lemma smul_coe [module R M] [has_continuous_smul R M]
-  (c : R) (f : C(α, M)) : ⇑(c • f) = c • f := rfl
+  (c : R) (f : C⟮α, M⟯) : ⇑(c • f) = c • f := rfl
 
 lemma smul_apply [module R M] [has_continuous_smul R M]
-  (c : R) (f : C(α, M)) (a : α) : (c • f) a = c • (f a) :=
+  (c : R) (f : C⟮α, M⟯) (a : α) : (c • f) a = c • (f a) :=
 by simp
 
 @[simp] lemma smul_comp {α : Type*} {β : Type*}
   [topological_space α] [topological_space β]
-   [module R M] [has_continuous_smul R M] (r : R) (f : C(β, M)) (g : C(α, β)) :
+   [module R M] [has_continuous_smul R M] (r : R) (f : C⟮β, M⟯) (g : C⟮α, β⟯) :
   (r • f).comp g = r • (f.comp g) :=
 by { ext, simp, }
 
 variables [has_continuous_add M] [module R M] [has_continuous_smul R M]
 
-instance module : module R C(α, M) :=
+instance module : module R C⟮α, M⟯ :=
 { smul     := (•),
   smul_add := λ c f g, by { ext, exact smul_add c (f x) (g x) },
   add_smul := λ c₁ c₂ f, by { ext, exact add_smul c₁ c₂ (f x) },
@@ -342,10 +342,10 @@ variables (R)
 
 /-- Coercion to a function as a `linear_map`. -/
 @[simps]
-def coe_fn_linear_map : C(α, M) →ₗ[R] (α → M) :=
+def coe_fn_linear_map : C⟮α, M⟯ →ₗ[R] (α → M) :=
 { to_fun := coe_fn,
   map_smul' := smul_coe,
-  ..(coe_fn_add_monoid_hom : C(α, M) →+ _) }
+  ..(coe_fn_add_monoid_hom : C⟮α, M⟯ →+ _) }
 
 end continuous_map
 
@@ -403,7 +403,7 @@ variables {α : Type*} [topological_space α]
 [algebra R A] [topological_semiring A]
 
 /-- Continuous constant functions as a `ring_hom`. -/
-def continuous_map.C : R →+* C(α, A) :=
+def continuous_map.C : R →+* C⟮α, A⟯ :=
 { to_fun    := λ c : R, ⟨λ x: α, ((algebra_map R A) c), continuous_const⟩,
   map_one'  := by ext x; exact (algebra_map R A).map_one,
   map_mul'  := λ c₁ c₂, by ext x; exact (algebra_map R A).map_mul _ _,
@@ -415,7 +415,7 @@ rfl
 
 variables [topological_space R] [has_continuous_smul R A]
 
-instance continuous_map.algebra : algebra R C(α, A) :=
+instance continuous_map.algebra : algebra R C⟮α, A⟯ :=
 { to_ring_hom := continuous_map.C,
   commutes' := λ c f, by ext x; exact algebra.commutes' _ _,
   smul_def' := λ c f, by ext x; exact algebra.smul_def' _ _, }
@@ -424,10 +424,10 @@ variables (R)
 
 /-- Coercion to a function as an `alg_hom`. -/
 @[simps]
-def continuous_map.coe_fn_alg_hom : C(α, A) →ₐ[R] (α → A) :=
+def continuous_map.coe_fn_alg_hom : C⟮α, A⟯ →ₐ[R] (α → A) :=
 { to_fun := coe_fn,
   commutes' := λ r, rfl,
-  -- `..(continuous_map.coe_fn_ring_hom : C(α, A) →+* _)` times out for some reason
+  -- `..(continuous_map.coe_fn_ring_hom : C⟮α, A⟯ →+* _)` times out for some reason
   map_zero' := continuous_map.zero_coe,
   map_one' := continuous_map.one_coe,
   map_add' := continuous_map.add_coe,
@@ -439,11 +439,11 @@ variables {R}
 A version of `separates_points` for subalgebras of the continuous functions,
 used for stating the Stone-Weierstrass theorem.
 -/
-abbreviation subalgebra.separates_points (s : subalgebra R C(α, A)) : Prop :=
-set.separates_points ((λ f : C(α, A), (f : α → A)) '' (s : set C(α, A)))
+abbreviation subalgebra.separates_points (s : subalgebra R C⟮α, A⟯) : Prop :=
+set.separates_points ((λ f : C⟮α, A⟯, (f : α → A)) '' (s : set C⟮α, A⟯))
 
 lemma subalgebra.separates_points_monotone :
-  monotone (λ s : subalgebra R C(α, A), s.separates_points) :=
+  monotone (λ s : subalgebra R C⟮α, A⟯, s.separates_points) :=
 λ s s' r h x y n,
 begin
   obtain ⟨f, m, w⟩ := h n,
@@ -452,7 +452,7 @@ begin
 end
 
 @[simp] lemma algebra_map_apply (k : R) (a : α) :
-  algebra_map R C(α, A) k a = k • 1 :=
+  algebra_map R C⟮α, A⟯ k a = k • 1 :=
 by { rw algebra.algebra_map_eq_smul_one, refl, }
 
 variables {𝕜 : Type*} [topological_space 𝕜]
@@ -470,7 +470,7 @@ writing it this way avoids having to deal with casts inside the set.
 (This may need to change if we do Stone-Weierstrass on non-compact spaces,
 where the functions would be continuous functions vanishing at infinity.)
 -/
-def set.separates_points_strongly (s : set C(α, 𝕜)) : Prop :=
+def set.separates_points_strongly (s : set C⟮α, 𝕜⟯) : Prop :=
 ∀ (v : α → 𝕜) (x y : α), ∃ f : s, (f x : 𝕜) = v x ∧ f y = v y
 
 variables [field 𝕜] [topological_ring 𝕜]
@@ -482,13 +482,13 @@ a subalgebra of functions that separates points also separates points strongly.
 By the hypothesis, we can find a function `f` so `f x ≠ f y`.
 By an affine transformation in the field we can arrange so that `f x = a` and `f x = b`.
 -/
-lemma subalgebra.separates_points.strongly {s : subalgebra 𝕜 C(α, 𝕜)} (h : s.separates_points) :
-  (s : set C(α, 𝕜)).separates_points_strongly :=
+lemma subalgebra.separates_points.strongly {s : subalgebra 𝕜 C⟮α, 𝕜⟯} (h : s.separates_points) :
+  (s : set C⟮α, 𝕜⟯).separates_points_strongly :=
 λ v x y,
 begin
   by_cases n : x = y,
   { subst n,
-    use ((v x) • 1 : C(α, 𝕜)),
+    use ((v x) • 1 : C⟮α, 𝕜⟯),
     { apply s.smul_mem,
       apply s.one_mem, },
     { simp, }, },
@@ -514,14 +514,14 @@ end continuous_map
 -- TODO[gh-6025]: make this an instance once safe to do so
 lemma continuous_map.subsingleton_subalgebra (α : Type*) [topological_space α]
   (R : Type*) [comm_semiring R] [topological_space R] [topological_semiring R]
-  [subsingleton α] : subsingleton (subalgebra R C(α, R)) :=
+  [subsingleton α] : subsingleton (subalgebra R C⟮α, R⟯) :=
 begin
   fsplit,
   intros s₁ s₂,
   by_cases n : nonempty α,
   { obtain ⟨x⟩ := n,
     ext f,
-    have h : f = algebra_map R C(α, R) (f x),
+    have h : f = algebra_map R C⟮α, R⟯ (f x),
     { ext x', simp only [mul_one, algebra.id.smul_eq_mul, algebra_map_apply], congr, },
     rw h,
     simp only [subalgebra.algebra_map_mem], },
@@ -571,14 +571,14 @@ instance has_scalar' {α : Type*} [topological_space α]
   {R : Type*} [semiring R] [topological_space R]
   {M : Type*} [topological_space M] [add_comm_monoid M]
   [module R M] [has_continuous_smul R M] :
-  has_scalar C(α, R) C(α, M) :=
+  has_scalar C⟮α, R⟯ C⟮α, M⟯ :=
 ⟨λ f g, ⟨λ x, (f x) • (g x), (continuous.smul f.2 g.2)⟩⟩
 
 instance module' {α : Type*} [topological_space α]
   (R : Type*) [ring R] [topological_space R] [topological_ring R]
   (M : Type*) [topological_space M] [add_comm_monoid M] [has_continuous_add M]
   [module R M] [has_continuous_smul R M] :
-  module C(α, R) C(α, M) :=
+  module C⟮α, R⟯ C⟮α, M⟯ :=
 { smul     := (•),
   smul_add := λ c f g, by ext x; exact smul_add (c x) (f x) (g x),
   add_smul := λ c₁ c₂ f, by ext x; exact add_smul (c₁ x) (c₂ x) (f x),
@@ -592,7 +592,7 @@ end continuous_map
 end module_over_continuous_functions
 
 /-!
-We now provide formulas for `f ⊓ g` and `f ⊔ g`, where `f g : C(α, β)`,
+We now provide formulas for `f ⊓ g` and `f ⊔ g`, where `f g : C⟮α, β⟯`,
 in terms of `continuous_map.abs`.
 -/
 
@@ -626,11 +626,11 @@ variables {α : Type*} [topological_space α]
 variables {β : Type*} [linear_ordered_field β] [topological_space β]
   [order_topology β] [topological_ring β]
 
-lemma inf_eq (f g : C(α, β)) : f ⊓ g = (2⁻¹ : β) • (f + g - (f - g).abs) :=
+lemma inf_eq (f g : C⟮α, β⟯) : f ⊓ g = (2⁻¹ : β) • (f + g - (f - g).abs) :=
 ext (λ x, by simpa using min_eq_half_add_sub_abs_sub)
 
 -- Not sure why this is grosser than `inf_eq`:
-lemma sup_eq (f g : C(α, β)) : f ⊔ g = (2⁻¹ : β) • (f + g + (f - g).abs) :=
+lemma sup_eq (f g : C⟮α, β⟯) : f ⊔ g = (2⁻¹ : β) • (f + g + (f - g).abs) :=
 ext (λ x, by simpa [mul_add] using @max_eq_half_add_add_abs_sub _ _ (f x) (g x))
 
 end lattice

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -21,7 +21,7 @@ structure continuous_map (α : Type*) (β : Type*)
 (to_fun             : α → β)
 (continuous_to_fun  : continuous to_fun . tactic.interactive.continuity')
 
-notation `C(` α `, ` β `)` := continuous_map α β
+notation `C⟮` α `, ` β `⟯` := continuous_map α β
 
 namespace continuous_map
 
@@ -30,25 +30,25 @@ attribute [continuity] continuous_map.continuous_to_fun
 variables {α : Type*} {β : Type*} {γ : Type*}
 variables [topological_space α] [topological_space β] [topological_space γ]
 
-instance : has_coe_to_fun (C(α, β)) := ⟨_, continuous_map.to_fun⟩
+instance : has_coe_to_fun (C⟮α, β⟯) := ⟨_, continuous_map.to_fun⟩
 
-@[simp] lemma to_fun_eq_coe {f : C(α, β)} : f.to_fun = (f : α → β) := rfl
+@[simp] lemma to_fun_eq_coe {f : C⟮α, β⟯} : f.to_fun = (f : α → β) := rfl
 
 variables {α β} {f g : continuous_map α β}
 
-@[continuity] protected lemma continuous (f : C(α, β)) : continuous f := f.continuous_to_fun
-@[continuity] lemma continuous_set_coe (s : set C(α, β)) (f : s) : continuous f :=
+@[continuity] protected lemma continuous (f : C⟮α, β⟯) : continuous f := f.continuous_to_fun
+@[continuity] lemma continuous_set_coe (s : set C⟮α, β⟯) (f : s) : continuous f :=
 by { cases f, dsimp, continuity, }
 
-protected lemma continuous_at (f : C(α, β)) (x : α) : continuous_at f x :=
+protected lemma continuous_at (f : C⟮α, β⟯) (x : α) : continuous_at f x :=
 f.continuous.continuous_at
 
-protected lemma continuous_within_at (f : C(α, β)) (s : set α) (x : α) :
+protected lemma continuous_within_at (f : C⟮α, β⟯) (s : set α) (x : α) :
   continuous_within_at f s x :=
 f.continuous.continuous_within_at
 
-protected lemma congr_fun {f g : C(α, β)} (H : f = g) (x : α) : f x = g x := H ▸ rfl
-protected lemma congr_arg (f : C(α, β)) {x y : α} (h : x = y) : f x = f y := h ▸ rfl
+protected lemma congr_fun {f g : C⟮α, β⟯} (H : f = g) (x : α) : f x = g x := H ▸ rfl
+protected lemma congr_arg (f : C⟮α, β⟯) {x y : α} (h : x = y) : f x = f y := h ▸ rfl
 
 @[ext] theorem ext (H : ∀ x, f x = g x) : f = g :=
 by cases f; cases g; congr'; exact funext H
@@ -56,10 +56,10 @@ by cases f; cases g; congr'; exact funext H
 lemma ext_iff : f = g ↔ ∀ x, f x = g x :=
 ⟨continuous_map.congr_fun, ext⟩
 
-instance [inhabited β] : inhabited C(α, β) :=
+instance [inhabited β] : inhabited C⟮α, β⟯ :=
 ⟨{ to_fun := λ _, default _, }⟩
 
-lemma coe_inj ⦃f g : C(α, β)⦄ (h : (f : α → β) = g) : f = g :=
+lemma coe_inj ⦃f g : C⟮α, β⟯⦄ (h : (f : α → β) = g) : f = g :=
 by cases f; cases g; cases h; refl
 
 @[simp] lemma coe_mk (f : α → β) (h : continuous f) :
@@ -72,31 +72,31 @@ variables (α β)
 The continuous functions from `α` to `β` are the same as the plain functions when `α` is discrete.
 -/
 @[simps]
-def equiv_fn_of_discrete [discrete_topology α] : C(α, β) ≃ (α → β) :=
+def equiv_fn_of_discrete [discrete_topology α] : C⟮α, β⟯ ≃ (α → β) :=
 ⟨(λ f, f), (λ f, ⟨f, continuous_of_discrete_topology⟩),
   λ f, by { ext, refl, }, λ f, by { ext, refl, }⟩
 
 end
 
 /-- The identity as a continuous map. -/
-def id : C(α, α) := ⟨id⟩
+def id : C⟮α, α⟯ := ⟨id⟩
 
 @[simp] lemma id_coe : (id : α → α) = id := rfl
 lemma id_apply (a : α) : id a = a := rfl
 
 /-- The composition of continuous maps, as a continuous map. -/
-def comp (f : C(β, γ)) (g : C(α, β)) : C(α, γ) := ⟨f ∘ g⟩
+def comp (f : C⟮β, γ⟯) (g : C⟮α, β⟯) : C⟮α, γ⟯ := ⟨f ∘ g⟩
 
-@[simp] lemma comp_coe (f : C(β, γ)) (g : C(α, β)) : (comp f g : α → γ) = f ∘ g := rfl
-lemma comp_apply (f : C(β, γ)) (g : C(α, β)) (a : α) : comp f g a = f (g a) := rfl
+@[simp] lemma comp_coe (f : C⟮β, γ⟯) (g : C⟮α, β⟯) : (comp f g : α → γ) = f ∘ g := rfl
+lemma comp_apply (f : C⟮β, γ⟯) (g : C⟮α, β⟯) (a : α) : comp f g a = f (g a) := rfl
 
 /-- Constant map as a continuous map -/
-def const (b : β) : C(α, β) := ⟨λ x, b⟩
+def const (b : β) : C⟮α, β⟯ := ⟨λ x, b⟩
 
 @[simp] lemma const_coe (b : β) : (const b : α → β) = (λ x, b) := rfl
 lemma const_apply (b : β) (a : α) : const b a = b := rfl
 
-instance [nonempty α] [nontrivial β] : nontrivial C(α, β) :=
+instance [nonempty α] [nontrivial β] : nontrivial C⟮α, β⟯ :=
 { exists_pair_ne := begin
     obtain ⟨b₁, b₂, hb⟩ := exists_pair_ne β,
     refine ⟨const b₁, const b₂, _⟩,
@@ -110,10 +110,10 @@ section
 variables [linear_ordered_add_comm_group β] [order_topology β]
 
 /-- The pointwise absolute value of a continuous function as a continuous function. -/
-def abs (f : C(α, β)) : C(α, β) :=
+def abs (f : C⟮α, β⟯) : C⟮α, β⟯ :=
 { to_fun := λ x, abs (f x), }
 
-@[simp] lemma abs_apply (f : C(α, β)) (x : α) : f.abs x = _root_.abs (f x) :=
+@[simp] lemma abs_apply (f : C⟮α, β⟯) (x : α) : f.abs x = _root_.abs (f x) :=
 rfl
 
 end
@@ -125,53 +125,53 @@ on continuous functions.
 section lattice
 
 instance partial_order [partial_order β] :
-  partial_order C(α, β) :=
+  partial_order C⟮α, β⟯ :=
 partial_order.lift (λ f, f.to_fun) (by tidy)
 
-lemma le_def [partial_order β] {f g : C(α, β)} : f ≤ g ↔ ∀ a, f a ≤ g a :=
+lemma le_def [partial_order β] {f g : C⟮α, β⟯} : f ≤ g ↔ ∀ a, f a ≤ g a :=
 pi.le_def
 
-lemma lt_def [partial_order β] {f g : C(α, β)} :
+lemma lt_def [partial_order β] {f g : C⟮α, β⟯} :
   f < g ↔ (∀ a, f a ≤ g a) ∧ (∃ a, f a < g a) :=
 pi.lt_def
 
-instance has_sup [linear_order β] [order_closed_topology β] : has_sup C(α, β) :=
+instance has_sup [linear_order β] [order_closed_topology β] : has_sup C⟮α, β⟯ :=
 { sup := λ f g, { to_fun := λ a, max (f a) (g a), } }
 
-@[simp, norm_cast] lemma sup_coe [linear_order β] [order_closed_topology β] (f g : C(α, β)) :
-  ((f ⊔ g : C(α, β)) : α → β) = (f ⊔ g : α → β) :=
+@[simp, norm_cast] lemma sup_coe [linear_order β] [order_closed_topology β] (f g : C⟮α, β⟯) :
+  ((f ⊔ g : C⟮α, β⟯) : α → β) = (f ⊔ g : α → β) :=
 rfl
 
-@[simp] lemma sup_apply [linear_order β] [order_closed_topology β] (f g : C(α, β)) (a : α) :
+@[simp] lemma sup_apply [linear_order β] [order_closed_topology β] (f g : C⟮α, β⟯) (a : α) :
   (f ⊔ g) a = max (f a) (g a) :=
 rfl
 
-instance [linear_order β] [order_closed_topology β] : semilattice_sup C(α, β) :=
+instance [linear_order β] [order_closed_topology β] : semilattice_sup C⟮α, β⟯ :=
 { le_sup_left := λ f g, le_def.mpr (by simp [le_refl]),
   le_sup_right := λ f g, le_def.mpr (by simp [le_refl]),
   sup_le := λ f₁ f₂ g w₁ w₂, le_def.mpr (λ a, by simp [le_def.mp w₁ a, le_def.mp w₂ a]),
   ..continuous_map.partial_order,
   ..continuous_map.has_sup, }
 
-instance has_inf [linear_order β] [order_closed_topology β] : has_inf C(α, β) :=
+instance has_inf [linear_order β] [order_closed_topology β] : has_inf C⟮α, β⟯ :=
 { inf := λ f g, { to_fun := λ a, min (f a) (g a), } }
 
-@[simp, norm_cast] lemma inf_coe [linear_order β] [order_closed_topology β] (f g : C(α, β)) :
-  ((f ⊓ g : C(α, β)) : α → β) = (f ⊓ g : α → β) :=
+@[simp, norm_cast] lemma inf_coe [linear_order β] [order_closed_topology β] (f g : C⟮α, β⟯) :
+  ((f ⊓ g : C⟮α, β⟯) : α → β) = (f ⊓ g : α → β) :=
 rfl
 
-@[simp] lemma inf_apply [linear_order β] [order_closed_topology β] (f g : C(α, β)) (a : α) :
+@[simp] lemma inf_apply [linear_order β] [order_closed_topology β] (f g : C⟮α, β⟯) (a : α) :
   (f ⊓ g) a = min (f a) (g a) :=
 rfl
 
-instance [linear_order β] [order_closed_topology β] : semilattice_inf C(α, β) :=
+instance [linear_order β] [order_closed_topology β] : semilattice_inf C⟮α, β⟯ :=
 { inf_le_left := λ f g, le_def.mpr (by simp [le_refl]),
   inf_le_right := λ f g, le_def.mpr (by simp [le_refl]),
   le_inf := λ f₁ f₂ g w₁ w₂, le_def.mpr (λ a, by simp [le_def.mp w₁ a, le_def.mp w₂ a]),
   ..continuous_map.partial_order,
   ..continuous_map.has_inf, }
 
-instance [linear_order β] [order_closed_topology β] : lattice C(α, β) :=
+instance [linear_order β] [order_closed_topology β] : lattice C⟮α, β⟯ :=
 { ..continuous_map.semilattice_inf,
   ..continuous_map.semilattice_sup }
 
@@ -180,13 +180,13 @@ instance [linear_order β] [order_closed_topology β] : lattice C(α, β) :=
 section sup'
 variables [linear_order γ] [order_closed_topology γ]
 
-lemma sup'_apply {ι : Type*} {s : finset ι} (H : s.nonempty) (f : ι → C(β, γ)) (b : β) :
+lemma sup'_apply {ι : Type*} {s : finset ι} (H : s.nonempty) (f : ι → C⟮β, γ⟯) (b : β) :
   s.sup' H f b = s.sup' H (λ a, f a b) :=
-finset.comp_sup'_eq_sup'_comp H (λ f : C(β, γ), f b) (λ i j, rfl)
+finset.comp_sup'_eq_sup'_comp H (λ f : C⟮β, γ⟯, f b) (λ i j, rfl)
 
 @[simp, norm_cast]
-lemma sup'_coe {ι : Type*} {s : finset ι} (H : s.nonempty) (f : ι → C(β, γ)) :
-  ((s.sup' H f : C(β, γ)) : ι → β) = s.sup' H (λ a, (f a : β → γ)) :=
+lemma sup'_coe {ι : Type*} {s : finset ι} (H : s.nonempty) (f : ι → C⟮β, γ⟯) :
+  ((s.sup' H f : C⟮β, γ⟯) : ι → β) = s.sup' H (λ a, (f a : β → γ)) :=
 by { ext, simp [sup'_apply], }
 
 end sup'
@@ -194,13 +194,13 @@ end sup'
 section inf'
 variables [linear_order γ] [order_closed_topology γ]
 
-lemma inf'_apply {ι : Type*} {s : finset ι} (H : s.nonempty) (f : ι → C(β, γ)) (b : β) :
+lemma inf'_apply {ι : Type*} {s : finset ι} (H : s.nonempty) (f : ι → C⟮β, γ⟯) (b : β) :
   s.inf' H f b = s.inf' H (λ a, f a b) :=
 @sup'_apply _ (order_dual γ) _ _ _ _ _ _ H f b
 
 @[simp, norm_cast]
-lemma inf'_coe {ι : Type*} {s : finset ι} (H : s.nonempty) (f : ι → C(β, γ)) :
-  ((s.inf' H f : C(β, γ)) : ι → β) = s.inf' H (λ a, (f a : β → γ)) :=
+lemma inf'_coe {ι : Type*} {s : finset ι} (H : s.nonempty) (f : ι → C⟮β, γ⟯) :
+  ((s.inf' H f : C⟮β, γ⟯) : ι → β) = s.inf' H (λ a, (f a : β → γ)) :=
 @sup'_coe _ (order_dual γ) _ _ _ _ _ _ H f
 
 end inf'
@@ -214,4 +214,4 @@ The forward direction of a homeomorphism, as a bundled continuous map.
 -/
 @[simps]
 def homeomorph.to_continuous_map {α β : Type*} [topological_space α] [topological_space β]
-  (e : α ≃ₜ β) : C(α, β) := ⟨e⟩
+  (e : α ≃ₜ β) : C⟮α, β⟯ := ⟨e⟩

--- a/src/topology/continuous_function/bounded.lean
+++ b/src/topology/continuous_function/bounded.lean
@@ -51,17 +51,17 @@ lemma bounded_range : bounded (range f) :=
 bounded_range_iff.2 f.bounded
 
 /-- A continuous function with an explicit bound is a bounded continuous function. -/
-def mk_of_bound (f : C(α, β)) (C : ℝ) (h : ∀ x y : α, dist (f x) (f y) ≤ C) : α →ᵇ β :=
+def mk_of_bound (f : C⟮α, β⟯) (C : ℝ) (h : ∀ x y : α, dist (f x) (f y) ≤ C) : α →ᵇ β :=
 ⟨f, ⟨C, h⟩⟩
 
 @[simp] lemma mk_of_bound_coe {f} {C} {h} : (mk_of_bound f C h : α → β) = (f : α → β) :=
 rfl
 
 /-- A continuous function on a compact space is automatically a bounded continuous function. -/
-def mk_of_compact [compact_space α] (f : C(α, β)) : α →ᵇ β :=
+def mk_of_compact [compact_space α] (f : C⟮α, β⟯) : α →ᵇ β :=
 ⟨f, bounded_range_iff.1 $ bounded_of_compact $ is_compact_range f.continuous⟩
 
-@[simp] lemma mk_of_compact_apply [compact_space α] (f : C(α, β)) (a : α) :
+@[simp] lemma mk_of_compact_apply [compact_space α] (f : C⟮α, β⟯) (a : α) :
   mk_of_compact f a = f a :=
 rfl
 
@@ -81,7 +81,7 @@ variables (α β)
 /--
 The map forgetting that a bounded continuous function is bounded.
 -/
-def forget_boundedness : (α →ᵇ β) → C(α, β) :=
+def forget_boundedness : (α →ᵇ β) → C⟮α, β⟯ :=
 λ f, f.1
 
 @[simp] lemma forget_boundedness_coe (f : α →ᵇ β) : (forget_boundedness α β f : α → β) = f :=
@@ -590,7 +590,7 @@ variables (α β)
 The additive map forgetting that a bounded continuous function is bounded.
 -/
 @[simps]
-def forget_boundedness_add_hom : (α →ᵇ β) →+ C(α, β) :=
+def forget_boundedness_add_hom : (α →ᵇ β) →+ C⟮α, β⟯ :=
 { to_fun := forget_boundedness α β,
   map_zero' := by { ext, simp, },
   map_add' := by { intros, ext, simp, }, }
@@ -642,7 +642,7 @@ variables (α β)
 
 /-- The linear map forgetting that a bounded continuous function is bounded. -/
 @[simps]
-def forget_boundedness_linear_map : (α →ᵇ β) →ₗ[𝕜] C(α, β) :=
+def forget_boundedness_linear_map : (α →ᵇ β) →ₗ[𝕜] C⟮α, β⟯ :=
 { to_fun := forget_boundedness α β,
   map_smul' := by { intros, ext, simp, },
   map_add' := by { intros, ext, simp, }, }

--- a/src/topology/continuous_function/compact.lean
+++ b/src/topology/continuous_function/compact.lean
@@ -11,13 +11,13 @@ import tactic.equiv_rw
 /-!
 # Continuous functions on a compact space
 
-Continuous functions `C(α, β)` from a compact space `α` to a metric space `β`
+Continuous functions `C⟮α, β⟯` from a compact space `α` to a metric space `β`
 are automatically bounded, and so acquire various structures inherited from `α →ᵇ β`.
 
 This file transfers these structures, and restates some lemmas
 characterising these structures.
 
-If you need a lemma which is proved about `α →ᵇ β` but not for `C(α, β)` when `α` is compact,
+If you need a lemma which is proved about `α →ᵇ β` but not for `C⟮α, β⟯` when `α` is compact,
 you should restate it here. You can also use
 `bounded_continuous_function.equiv_continuous_map_of_compact` to move functions back and forth.
 
@@ -36,25 +36,25 @@ variables (α : Type*) (β : Type*) [topological_space α] [compact_space α] [n
 
 /--
 When `α` is compact, the bounded continuous maps `α →ᵇ 𝕜` are
-equivalent to `C(α, 𝕜)`.
+equivalent to `C⟮α, 𝕜⟯`.
 -/
 @[simps]
-def equiv_bounded_of_compact : C(α, β) ≃ (α →ᵇ β) :=
+def equiv_bounded_of_compact : C⟮α, β⟯ ≃ (α →ᵇ β) :=
 ⟨mk_of_compact, forget_boundedness α β, λ f, by { ext, refl, }, λ f, by { ext, refl, }⟩
 
 /--
 When `α` is compact, the bounded continuous maps `α →ᵇ 𝕜` are
-additively equivalent to `C(α, 𝕜)`.
+additively equivalent to `C⟮α, 𝕜⟯`.
 -/
 @[simps]
-def add_equiv_bounded_of_compact : C(α, β) ≃+ (α →ᵇ β) :=
+def add_equiv_bounded_of_compact : C⟮α, β⟯ ≃+ (α →ᵇ β) :=
 ({ ..forget_boundedness_add_hom α β,
-  ..(equiv_bounded_of_compact α β).symm, } : (α →ᵇ β) ≃+ C(α, β)).symm
+  ..(equiv_bounded_of_compact α β).symm, } : (α →ᵇ β) ≃+ C⟮α, β⟯).symm
 
 -- It would be nice if `@[simps]` produced this directly,
 -- instead of the unhelpful `add_equiv_bounded_of_compact_apply_to_continuous_map`.
 @[simp]
-lemma add_equiv_bounded_of_compact_apply_apply (f : C(α, β)) (a : α) :
+lemma add_equiv_bounded_of_compact_apply_apply (f : C⟮α, β⟯) (a : α) :
   add_equiv_bounded_of_compact α β f a = f a :=
 rfl
 
@@ -63,14 +63,14 @@ lemma add_equiv_bounded_of_compact_to_equiv :
   (add_equiv_bounded_of_compact α β).to_equiv = equiv_bounded_of_compact α β :=
 rfl
 
-instance : metric_space C(α,β) :=
+instance : metric_space C⟮α,β⟯ :=
 metric_space.induced
   (equiv_bounded_of_compact α β)
   (equiv_bounded_of_compact α β).injective
   (by apply_instance)
 
 section
-variables {α β} (f g : C(α, β)) {C : ℝ}
+variables {α β} (f g : C⟮α, β⟯) {C : ℝ}
 
 /-- The distance between two functions is controlled by the supremum of the pointwise distances -/
 lemma dist_le (C0 : (0 : ℝ) ≤ C) : dist f g ≤ C ↔ ∀x:α, dist (f x) (g x) ≤ C :=
@@ -103,20 +103,20 @@ variables (α β)
 
 /--
 When `α` is compact, and `β` is a metric space, the bounded continuous maps `α →ᵇ β` are
-isometric to `C(α, β)`.
+isometric to `C⟮α, β⟯`.
 -/
 @[simps]
 def isometric_bounded_of_compact :
-  C(α, β) ≃ᵢ (α →ᵇ β) :=
+  C⟮α, β⟯ ≃ᵢ (α →ᵇ β) :=
 { isometry_to_fun := λ x y, rfl,
   to_equiv := equiv_bounded_of_compact α β }
 
 -- TODO at some point we will need lemmas characterising this norm!
--- At the moment the only way to reason about it is to transfer `f : C(α,β)` back to `α →ᵇ β`.
-instance : has_norm C(α,β) :=
+-- At the moment the only way to reason about it is to transfer `f : C⟮α,β⟯` back to `α →ᵇ β`.
+instance : has_norm C⟮α,β⟯ :=
 { norm := λ x, dist x 0 }
 
-instance : normed_group C(α,β) :=
+instance : normed_group C⟮α,β⟯ :=
 { dist_eq := λ x y,
   begin
     change dist x y = dist (x-y) 0,
@@ -129,7 +129,7 @@ instance : normed_group C(α,β) :=
   end, }
 
 section
-variables {α β} (f : C(α, β))
+variables {α β} (f : C⟮α, β⟯)
 -- The corresponding lemmas for `bounded_continuous_function` are stated with `{f}`,
 -- and so can not be used in dot notation.
 
@@ -158,10 +158,10 @@ lemma norm_lt_iff_of_nonempty [nonempty α] {M : ℝ} :
 @bounded_continuous_function.norm_lt_iff_of_nonempty_compact _ _ _ _ _ _
   ((equiv_bounded_of_compact α β) f) _
 
-lemma apply_le_norm (f : C(α, ℝ)) (x : α) : f x ≤ ∥f∥ :=
+lemma apply_le_norm (f : C⟮α, ℝ⟯) (x : α) : f x ≤ ∥f∥ :=
 le_trans (le_abs.mpr (or.inl (le_refl (f x)))) (f.norm_coe_le_norm x)
 
-lemma neg_norm_le_apply (f : C(α, ℝ)) (x : α) : -∥f∥ ≤ f x :=
+lemma neg_norm_le_apply (f : C⟮α, ℝ⟯) (x : α) : -∥f∥ ≤ f x :=
 le_trans (neg_le_neg (f.norm_coe_le_norm x)) (neg_le.mp (neg_le_abs_self (f x)))
 
 end
@@ -169,21 +169,21 @@ end
 section
 variables {R : Type*} [normed_ring R]
 
-instance : normed_ring C(α,R) :=
+instance : normed_ring C⟮α,R⟯ :=
 { norm_mul := λ f g,
   begin
     equiv_rw (equiv_bounded_of_compact α R) at f,
     equiv_rw (equiv_bounded_of_compact α R) at g,
     exact norm_mul_le f g,
   end,
-  ..(infer_instance : normed_group C(α,R)) }
+  ..(infer_instance : normed_group C⟮α,R⟯) }
 
 end
 
 section
 variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 β]
 
-instance : normed_space 𝕜 C(α,β) :=
+instance : normed_space 𝕜 C⟮α,β⟯ :=
 { norm_smul_le := λ c f,
   begin
     equiv_rw (equiv_bounded_of_compact α β) at f,
@@ -195,10 +195,10 @@ variables (α 𝕜)
 /--
 When `α` is compact and `𝕜` is a normed field,
 the `𝕜`-algebra of bounded continuous maps `α →ᵇ β` is
-`𝕜`-linearly isometric to `C(α, β)`.
+`𝕜`-linearly isometric to `C⟮α, β⟯`.
 -/
 def linear_isometry_bounded_of_compact :
-  C(α, β) ≃ₗᵢ[𝕜] (α →ᵇ β) :=
+  C⟮α, β⟯ ≃ₗᵢ[𝕜] (α →ᵇ β) :=
 { map_smul' := λ c f, by { ext, simp, },
   norm_map' := λ f, rfl,
   ..add_equiv_bounded_of_compact α β }
@@ -226,7 +226,7 @@ end
 section
 variables {𝕜 : Type*} {γ : Type*} [normed_field 𝕜] [normed_ring γ] [normed_algebra 𝕜 γ]
 
-instance [nonempty α] : normed_algebra 𝕜 C(α, γ) :=
+instance [nonempty α] : normed_algebra 𝕜 C⟮α, γ⟯ :=
 { norm_algebra_map_eq := λ c, (norm_algebra_map_eq (α →ᵇ γ) c : _), }
 
 end
@@ -244,7 +244,7 @@ We now set up some declarations making it convenient to use uniform continuity.
 -/
 
 lemma uniform_continuity
-  (f : C(α, β)) (ε : ℝ) (h : 0 < ε) :
+  (f : C⟮α, β⟯) (ε : ℝ) (h : 0 < ε) :
   ∃ δ > 0, ∀ {x y}, dist x y < δ → dist (f x) (f y) < ε :=
 metric.uniform_continuous_iff.mp
   (compact_space.uniform_continuous_of_continuous f.continuous) ε h
@@ -255,23 +255,23 @@ An arbitrarily chosen modulus of uniform continuity for a given function `f` and
 -- This definition allows us to separate the choice of some `δ`,
 -- and the corresponding use of `dist a b < δ → dist (f a) (f b) < ε`,
 -- even across different declarations.
-def modulus (f : C(α, β)) (ε : ℝ) (h : 0 < ε) : ℝ :=
+def modulus (f : C⟮α, β⟯) (ε : ℝ) (h : 0 < ε) : ℝ :=
 classical.some (uniform_continuity f ε h)
 
-lemma modulus_pos (f : C(α, β)) {ε : ℝ} {h : 0 < ε} : 0 < f.modulus ε h :=
+lemma modulus_pos (f : C⟮α, β⟯) {ε : ℝ} {h : 0 < ε} : 0 < f.modulus ε h :=
 classical.some (classical.some_spec (uniform_continuity f ε h))
 
 lemma dist_lt_of_dist_lt_modulus
-  (f : C(α, β)) (ε : ℝ) (h : 0 < ε) {a b : α} (w : dist a b < f.modulus ε h) :
+  (f : C⟮α, β⟯) (ε : ℝ) (h : 0 < ε) {a b : α} (w : dist a b < f.modulus ε h) :
   dist (f a) (f b) < ε :=
 classical.some_spec (classical.some_spec (uniform_continuity f ε h)) w
 
 end uniform_continuity
 
 /-!
-We now setup variations on `comp_right_* f`, where `f : C(X, Y)`
+We now setup variations on `comp_right_* f`, where `f : C⟮X, Y⟯`
 (that is, precomposition by a continuous map),
-as a morphism `C(Y, T) → C(X, T)`, respecting various types of structure.
+as a morphism `C⟮Y, T⟯ → C⟮X, T⟯`, respecting various types of structure.
 
 In particular:
 * `comp_right_continuous_map`, the bundled continuous map (for this we need `X Y` compact).
@@ -285,7 +285,7 @@ Precomposition by a continuous map is itself a continuous map between spaces of 
 -/
 def comp_right_continuous_map {X Y : Type*} (T : Type*)
   [topological_space X] [compact_space X] [topological_space Y] [compact_space Y] [normed_group T]
-  (f : C(X, Y)) : C(C(Y, T), C(X, T)) :=
+  (f : C⟮X, Y⟯) : C⟮C⟮Y, T⟯, C⟮X, T⟯⟯ :=
 { to_fun := λ g, g.comp f,
   continuous_to_fun :=
   begin
@@ -298,7 +298,7 @@ def comp_right_continuous_map {X Y : Type*} (T : Type*)
 
 @[simp] lemma comp_right_continuous_map_apply {X Y : Type*} (T : Type*)
   [topological_space X] [compact_space X] [topological_space Y] [compact_space Y] [normed_group T]
-  (f : C(X, Y)) (g : C(Y, T)) :
+  (f : C⟮X, Y⟯) (g : C⟮Y, T⟯) :
   (comp_right_continuous_map T f) g = g.comp f :=
 rfl
 
@@ -307,7 +307,7 @@ Precomposition by a homeomorphism is itself a homeomorphism between spaces of co
 -/
 def comp_right_homeomorph {X Y : Type*} (T : Type*)
   [topological_space X] [compact_space X] [topological_space Y] [compact_space Y] [normed_group T]
-  (f : X ≃ₜ Y) : C(Y, T) ≃ₜ C(X, T) :=
+  (f : X ≃ₜ Y) : C⟮Y, T⟯ ≃ₜ C⟮X, T⟯ :=
 { to_fun := comp_right_continuous_map T f.to_continuous_map,
   inv_fun := comp_right_continuous_map T f.symm.to_continuous_map,
   left_inv := by tidy,
@@ -317,8 +317,8 @@ def comp_right_homeomorph {X Y : Type*} (T : Type*)
 Precomposition of functions into a normed ring by continuous map is an algebra homomorphism.
 -/
 def comp_right_alg_hom {X Y : Type*} (R : Type*)
-  [topological_space X] [topological_space Y] [normed_comm_ring R] (f : C(X, Y)) :
-  C(Y, R) →ₐ[R] C(X, R) :=
+  [topological_space X] [topological_space Y] [normed_comm_ring R] (f : C⟮X, Y⟯) :
+  C⟮Y, R⟯ →ₐ[R] C⟮X, R⟯ :=
 { to_fun := λ g, g.comp f,
   map_zero' := by { ext, simp, },
   map_add' := λ g₁ g₂, by { ext, simp, },
@@ -327,13 +327,13 @@ def comp_right_alg_hom {X Y : Type*} (R : Type*)
   commutes' := λ r, by { ext, simp, }, }
 
 @[simp] lemma comp_right_alg_hom_apply {X Y : Type*} (R : Type*)
-  [topological_space X] [topological_space Y] [normed_comm_ring R] (f : C(X, Y)) (g : C(Y, R)) :
+  [topological_space X] [topological_space Y] [normed_comm_ring R] (f : C⟮X, Y⟯) (g : C⟮Y, R⟯) :
   (comp_right_alg_hom R f) g = g.comp f :=
 rfl
 
 lemma comp_right_alg_hom_continuous {X Y : Type*} (R : Type*)
   [topological_space X] [compact_space X] [topological_space Y] [compact_space Y]
-  [normed_comm_ring R] (f : C(X, Y)) :
+  [normed_comm_ring R] (f : C⟮X, Y⟯) :
   continuous (comp_right_alg_hom R f) :=
 begin
   change continuous (comp_right_continuous_map R f),

--- a/src/topology/continuous_function/polynomial.lean
+++ b/src/topology/continuous_function/polynomial.lean
@@ -14,9 +14,9 @@ import topology.unit_interval
 ## Main definitions
 
 * `polynomial.to_continuous_map_on p X`: for `X : set R`, interprets a polynomial `p`
-  as a bundled continuous function in `C(X, R)`.
+  as a bundled continuous function in `C⟮X, R⟯`.
 * `polynomial.to_continuous_map_on_alg_hom`: the same, as an `R`-algebra homomorphism.
-* `polynomial_functions (X : set R) : subalgebra R C(X, R)`: polynomial functions as a subalgebra.
+* `polynomial_functions (X : set R) : subalgebra R C⟮X, R⟯`: polynomial functions as a subalgebra.
 * `polynomial_functions_separates_points (X : set R) : (polynomial_functions X).separates_points`:
   the polynomial functions separate points.
 
@@ -33,7 +33,7 @@ variables [semiring R] [topological_space R] [topological_semiring R]
 Every polynomial with coefficients in a topological semiring gives a (bundled) continuous function.
 -/
 @[simps]
-def to_continuous_map (p : polynomial R) : C(R, R) :=
+def to_continuous_map (p : polynomial R) : C⟮R, R⟯ :=
 ⟨λ x : R, p.eval x, by continuity⟩
 
 /--
@@ -43,7 +43,7 @@ with domain restricted to some subset of the semiring of coefficients.
 (This is particularly useful when restricting to compact sets, e.g. `[0,1]`.)
 -/
 @[simps]
-def to_continuous_map_on (p : polynomial R) (X : set R) : C(X, R) :=
+def to_continuous_map_on (p : polynomial R) (X : set R) : C⟮X, R⟯ :=
 ⟨λ x : X, p.to_continuous_map x, by continuity⟩
 
 -- TODO some lemmas about when `to_continuous_map_on` is injective?
@@ -54,7 +54,7 @@ section
 variables {α : Type*} [topological_space α]
   [comm_semiring R] [topological_space R] [topological_semiring R]
 
-@[simp] lemma aeval_continuous_map_apply (g : polynomial R) (f : C(α, R)) (x : α) :
+@[simp] lemma aeval_continuous_map_apply (g : polynomial R) (f : C⟮α, R⟯) (x : α) :
   ((polynomial.aeval f) g) x = g.eval (f x) :=
 begin
   apply polynomial.induction_on' g,
@@ -72,10 +72,10 @@ noncomputable theory
 variables [comm_semiring R] [topological_space R] [topological_semiring R]
 
 /--
-The algebra map from `polynomial R` to continuous functions `C(R, R)`.
+The algebra map from `polynomial R` to continuous functions `C⟮R, R⟯`.
 -/
 @[simps]
-def to_continuous_map_alg_hom : polynomial R →ₐ[R] C(R, R) :=
+def to_continuous_map_alg_hom : polynomial R →ₐ[R] C⟮R, R⟯ :=
 { to_fun := λ p, p.to_continuous_map,
   map_zero' := by { ext, simp, },
   map_add' := by { intros, ext, simp, },
@@ -84,10 +84,10 @@ def to_continuous_map_alg_hom : polynomial R →ₐ[R] C(R, R) :=
   commutes' := by { intros, ext, simp [algebra.algebra_map_eq_smul_one], }, }
 
 /--
-The algebra map from `polynomial R` to continuous functions `C(X, R)`, for any subset `X` of `R`.
+The algebra map from `polynomial R` to continuous functions `C⟮X, R⟯`, for any subset `X` of `R`.
 -/
 @[simps]
-def to_continuous_map_on_alg_hom (X : set R) : polynomial R →ₐ[R] C(X, R)  :=
+def to_continuous_map_on_alg_hom (X : set R) : polynomial R →ₐ[R] C⟮X, R⟯  :=
 { to_fun := λ p, p.to_continuous_map_on X,
   map_zero' := by { ext, simp, },
   map_add' := by { intros, ext, simp, },
@@ -103,20 +103,20 @@ section
 variables [comm_semiring R] [topological_space R] [topological_semiring R]
 
 /--
-The subalgebra of polynomial functions in `C(X, R)`, for `X` a subset of some topological ring `R`.
+The subalgebra of polynomial functions in `C⟮X, R⟯`, for `X` a subset of some topological ring `R`.
 -/
-def polynomial_functions (X : set R) : subalgebra R C(X, R) :=
+def polynomial_functions (X : set R) : subalgebra R C⟮X, R⟯ :=
 (⊤ : subalgebra R (polynomial R)).map (polynomial.to_continuous_map_on_alg_hom X)
 
 @[simp]
 lemma polynomial_functions_coe (X : set R) :
-  (polynomial_functions X : set C(X, R)) = set.range (polynomial.to_continuous_map_on_alg_hom X) :=
+  (polynomial_functions X : set C⟮X, R⟯) = set.range (polynomial.to_continuous_map_on_alg_hom X) :=
 by { ext, simp [polynomial_functions], }
 
 -- TODO:
 -- if `f : R → R` is an affine equivalence, then pulling back along `f`
 -- induces a normed algebra isomorphism between `polynomial_functions X` and
--- `polynomial_functions (f ⁻¹' X)`, intertwining the pullback along `f` of `C(R, R)` to itself.
+-- `polynomial_functions (f ⁻¹' X)`, intertwining the pullback along `f` of `C⟮R, R⟯` to itself.
 
 lemma polynomial_functions_separates_points (X : set R) :
   (polynomial_functions X).separates_points :=

--- a/src/topology/continuous_function/stone_weierstrass.lean
+++ b/src/topology/continuous_function/stone_weierstrass.lean
@@ -49,7 +49,7 @@ variables {X : Type*} [topological_space X] [compact_space X]
 Turn a function `f : C⟮X, ℝ⟯` into a continuous map into `set.Icc (-∥f∥) (∥f∥)`,
 thereby explicitly attaching bounds.
 -/
-def attach_bound (f : C⟮X, ℝ⟯) : C⟮X, set.Icc (-∥f∥⟯ (∥f∥)) :=
+def attach_bound (f : C⟮X, ℝ⟯) : C⟮X, set.Icc (-∥f∥) (∥f∥)⟯ :=
 { to_fun := λ x, ⟨f x, ⟨neg_norm_le_apply f x, apply_le_norm f x⟩⟩ }
 
 @[simp] lemma attach_bound_apply_coe (f : C⟮X, ℝ⟯) (x : X) : ((attach_bound f) x : ℝ) = f x := rfl

--- a/src/topology/continuous_function/stone_weierstrass.lean
+++ b/src/topology/continuous_function/stone_weierstrass.lean
@@ -8,18 +8,18 @@ import topology.continuous_function.weierstrass
 /-!
 # The Stone-Weierstrass theorem
 
-If a subalgebra `A` of `C(X, ℝ)`, where `X` is a compact topological space,
+If a subalgebra `A` of `C⟮X, ℝ⟯`, where `X` is a compact topological space,
 separates points, then it is dense.
 
 We argue as follows.
 
-* In any subalgebra `A` of `C(X, ℝ)`, if `f ∈ A`, then `abs f ∈ A.topological_closure`.
+* In any subalgebra `A` of `C⟮X, ℝ⟯`, if `f ∈ A`, then `abs f ∈ A.topological_closure`.
   This follows from the Weierstrass approximation theorem on `[-∥f∥, ∥f∥]` by
   approximating `abs` uniformly thereon by polynomials.
 * This ensures that `A.topological_closure` is actually a sublattice:
   if it contains `f` and `g`, then it contains the pointwise supremum `f ⊔ g`
   and the pointwise infimum `f ⊓ g`.
-* Any nonempty sublattice `L` of `C(X, ℝ)` which separates points is dense,
+* Any nonempty sublattice `L` of `C⟮X, ℝ⟯` which separates points is dense,
   by a nice argument approximating a given `f` above and below using separating functions.
   For each `x y : X`, we pick a function `g x y ∈ L` so `g x y x = f x` and `g x y y = f y`.
   By continuity these functions remain close to `f` on small patches around `x` and `y`.
@@ -46,16 +46,16 @@ namespace continuous_map
 variables {X : Type*} [topological_space X] [compact_space X]
 
 /--
-Turn a function `f : C(X, ℝ)` into a continuous map into `set.Icc (-∥f∥) (∥f∥)`,
+Turn a function `f : C⟮X, ℝ⟯` into a continuous map into `set.Icc (-∥f∥) (∥f∥)`,
 thereby explicitly attaching bounds.
 -/
-def attach_bound (f : C(X, ℝ)) : C(X, set.Icc (-∥f∥) (∥f∥)) :=
+def attach_bound (f : C⟮X, ℝ⟯) : C⟮X, set.Icc (-∥f∥⟯ (∥f∥)) :=
 { to_fun := λ x, ⟨f x, ⟨neg_norm_le_apply f x, apply_le_norm f x⟩⟩ }
 
-@[simp] lemma attach_bound_apply_coe (f : C(X, ℝ)) (x : X) : ((attach_bound f) x : ℝ) = f x := rfl
+@[simp] lemma attach_bound_apply_coe (f : C⟮X, ℝ⟯) (x : X) : ((attach_bound f) x : ℝ) = f x := rfl
 
-lemma polynomial_comp_attach_bound (A : subalgebra ℝ C(X, ℝ)) (f : A) (g : polynomial ℝ) :
-  (g.to_continuous_map_on (set.Icc (-∥f∥) ∥f∥)).comp (f : C(X, ℝ)).attach_bound =
+lemma polynomial_comp_attach_bound (A : subalgebra ℝ C⟮X, ℝ⟯) (f : A) (g : polynomial ℝ) :
+  (g.to_continuous_map_on (set.Icc (-∥f∥) ∥f∥)).comp (f : C⟮X, ℝ⟯).attach_bound =
     polynomial.aeval f g :=
 begin
   ext,
@@ -68,7 +68,7 @@ begin
 end
 
 /--
-Given a continuous function `f` in a subalgebra of `C(X, ℝ)`, postcomposing by a polynomial
+Given a continuous function `f` in a subalgebra of `C⟮X, ℝ⟯`, postcomposing by a polynomial
 gives another function in `A`.
 
 This lemma proves something slightly more subtle than this:
@@ -76,15 +76,15 @@ we take `f`, and think of it as a function into the restricted target `set.Icc (
 and then postcompose with a polynomial function on that interval.
 This is in fact the same situation as above, and so also gives a function in `A`.
 -/
-lemma polynomial_comp_attach_bound_mem (A : subalgebra ℝ C(X, ℝ)) (f : A) (g : polynomial ℝ) :
-  (g.to_continuous_map_on (set.Icc (-∥f∥) ∥f∥)).comp (f : C(X, ℝ)).attach_bound ∈ A :=
+lemma polynomial_comp_attach_bound_mem (A : subalgebra ℝ C⟮X, ℝ⟯) (f : A) (g : polynomial ℝ) :
+  (g.to_continuous_map_on (set.Icc (-∥f∥) ∥f∥)).comp (f : C⟮X, ℝ⟯).attach_bound ∈ A :=
 begin
   rw polynomial_comp_attach_bound,
   apply set_like.coe_mem,
 end
 
 theorem comp_attach_bound_mem_closure
-  (A : subalgebra ℝ C(X, ℝ)) (f : A) (p : C(set.Icc (-∥f∥) (∥f∥), ℝ)) :
+  (A : subalgebra ℝ C⟮X, ℝ⟯) (f : A) (p : C⟮set.Icc (-∥f∥) (∥f∥), ℝ⟯) :
   p.comp (attach_bound f) ∈ A.topological_closure :=
 begin
   -- `p` itself is in the closure of polynomials, by the Weierstrass theorem,
@@ -96,7 +96,7 @@ begin
   -- we show there are elements of `A` arbitrarily close.
   apply mem_closure_iff_frequently.mpr,
   -- To show that, we pull back the polynomials close to `p`,
-  refine ((comp_right_continuous_map ℝ (attach_bound (f : C(X, ℝ)))).continuous_at p).tendsto
+  refine ((comp_right_continuous_map ℝ (attach_bound (f : C⟮X, ℝ⟯))).continuous_at p).tendsto
     .frequently_map _ _ frequently_mem_polynomials,
   -- but need to show that those pullbacks are actually in `A`.
   rintros _ ⟨g, ⟨-,rfl⟩⟩,
@@ -105,19 +105,19 @@ begin
   apply polynomial_comp_attach_bound_mem,
 end
 
-theorem abs_mem_subalgebra_closure (A : subalgebra ℝ C(X, ℝ)) (f : A) :
-  (f : C(X, ℝ)).abs ∈ A.topological_closure :=
+theorem abs_mem_subalgebra_closure (A : subalgebra ℝ C⟮X, ℝ⟯) (f : A) :
+  (f : C⟮X, ℝ⟯).abs ∈ A.topological_closure :=
 begin
   let M := ∥f∥,
-  let f' := attach_bound (f : C(X, ℝ)),
-  let abs : C(set.Icc (-∥f∥) (∥f∥), ℝ) :=
+  let f' := attach_bound (f : C⟮X, ℝ⟯),
+  let abs : C⟮set.Icc (-∥f∥) (∥f∥), ℝ⟯ :=
   { to_fun := λ x : set.Icc (-∥f∥) (∥f∥), _root_.abs (x : ℝ) },
   change (abs.comp f') ∈ A.topological_closure,
   apply comp_attach_bound_mem_closure,
 end
 
-theorem inf_mem_subalgebra_closure (A : subalgebra ℝ C(X, ℝ)) (f g : A) :
-  (f : C(X, ℝ)) ⊓ (g : C(X, ℝ)) ∈ A.topological_closure :=
+theorem inf_mem_subalgebra_closure (A : subalgebra ℝ C⟮X, ℝ⟯) (f g : A) :
+  (f : C⟮X, ℝ⟯) ⊓ (g : C⟮X, ℝ⟯) ∈ A.topological_closure :=
 begin
   rw inf_eq,
   refine A.topological_closure.smul_mem
@@ -127,8 +127,8 @@ begin
   exact_mod_cast abs_mem_subalgebra_closure A _,
 end
 
-theorem inf_mem_closed_subalgebra (A : subalgebra ℝ C(X, ℝ)) (h : is_closed (A : set C(X, ℝ)))
-  (f g : A) : (f : C(X, ℝ)) ⊓ (g : C(X, ℝ)) ∈ A :=
+theorem inf_mem_closed_subalgebra (A : subalgebra ℝ C⟮X, ℝ⟯) (h : is_closed (A : set C⟮X, ℝ⟯))
+  (f g : A) : (f : C⟮X, ℝ⟯) ⊓ (g : C⟮X, ℝ⟯) ∈ A :=
 begin
   convert inf_mem_subalgebra_closure A f g,
   apply set_like.ext',
@@ -137,8 +137,8 @@ begin
   exact h,
 end
 
-theorem sup_mem_subalgebra_closure (A : subalgebra ℝ C(X, ℝ)) (f g : A) :
-  (f : C(X, ℝ)) ⊔ (g : C(X, ℝ)) ∈ A.topological_closure :=
+theorem sup_mem_subalgebra_closure (A : subalgebra ℝ C⟮X, ℝ⟯) (f g : A) :
+  (f : C⟮X, ℝ⟯) ⊔ (g : C⟮X, ℝ⟯) ∈ A.topological_closure :=
 begin
   rw sup_eq,
   refine A.topological_closure.smul_mem
@@ -148,8 +148,8 @@ begin
   exact_mod_cast abs_mem_subalgebra_closure A _,
 end
 
-theorem sup_mem_closed_subalgebra (A : subalgebra ℝ C(X, ℝ)) (h : is_closed (A : set C(X, ℝ)))
-  (f g : A) : (f : C(X, ℝ)) ⊔ (g : C(X, ℝ)) ∈ A :=
+theorem sup_mem_closed_subalgebra (A : subalgebra ℝ C⟮X, ℝ⟯) (h : is_closed (A : set C⟮X, ℝ⟯))
+  (f g : A) : (f : C⟮X, ℝ⟯) ⊔ (g : C⟮X, ℝ⟯) ∈ A :=
 begin
   convert sup_mem_subalgebra_closure A f g,
   apply set_like.ext',
@@ -162,7 +162,7 @@ open_locale topological_space
 
 -- Here's the fun part of Stone-Weierstrass!
 theorem sublattice_closure_eq_top
-  (L : set C(X, ℝ)) (nA : L.nonempty)
+  (L : set C⟮X, ℝ⟯) (nA : L.nonempty)
   (inf_mem : ∀ f g ∈ L, f ⊓ g ∈ L) (sup_mem : ∀ f g ∈ L, f ⊔ g ∈ L)
   (sep : L.separates_points_strongly) :
   closure L = ⊤ :=
@@ -223,7 +223,7 @@ begin
   -- Thus for each `x` we have the desired `h x : A` so `f z - ε < h x z` everywhere
   -- and `h x x = f x`.
   let h : Π x, L := λ x,
-    ⟨(ys x).sup' (ys_nonempty x) (λ y, (g x y : C(X, ℝ))),
+    ⟨(ys x).sup' (ys_nonempty x) (λ y, (g x y : C⟮X, ℝ⟯)),
       finset.sup'_mem _ sup_mem _ _ _ (λ y _, (g x y).2)⟩,
   have lt_h : ∀ x z, f z - ε < h x z,
   { intros x z,
@@ -254,7 +254,7 @@ begin
   -- Finally our candidate function is the infimum over `x ∈ xs` of the `h x`.
   -- This function is then globally less than `f z + ε`.
   let k : (L : Type*) :=
-    ⟨xs.inf' xs_nonempty (λ x, (h x : C(X, ℝ))),
+    ⟨xs.inf' xs_nonempty (λ x, (h x : C⟮X, ℝ⟯)),
       finset.inf'_mem _ inf_mem _ _ _ (λ x _, (h x).2)⟩,
 
   refine ⟨k.1, _, k.2⟩,
@@ -280,11 +280,11 @@ end
 
 /--
 The Stone-Weierstrass approximation theorem,
-that a subalgebra `A` of `C(X, ℝ)`, where `X` is a compact topological space,
+that a subalgebra `A` of `C⟮X, ℝ⟯`, where `X` is a compact topological space,
 is dense if it separates points.
 -/
 theorem subalgebra_topological_closure_eq_top_of_separates_points
-  (A : subalgebra ℝ C(X, ℝ)) (w : A.separates_points) :
+  (A : subalgebra ℝ C⟮X, ℝ⟯) (w : A.separates_points) :
   A.topological_closure = ⊤ :=
 begin
   -- The closure of `A` is closed under taking `sup` and `inf`,
@@ -292,10 +292,10 @@ begin
   -- so we can apply `sublattice_closure_eq_top`.
   apply set_like.ext',
   let L := A.topological_closure,
-  have n : set.nonempty (L : set C(X, ℝ)) :=
-    ⟨(1 : C(X, ℝ)), A.subalgebra_topological_closure A.one_mem⟩,
+  have n : set.nonempty (L : set C⟮X, ℝ⟯) :=
+    ⟨(1 : C⟮X, ℝ⟯), A.subalgebra_topological_closure A.one_mem⟩,
   convert sublattice_closure_eq_top
-    (L : set C(X, ℝ)) n
+    (L : set C⟮X, ℝ⟯) n
     (λ f g fm gm, inf_mem_closed_subalgebra L A.is_closed_topological_closure ⟨f, fm⟩ ⟨g, gm⟩)
     (λ f g fm gm, sup_mem_closed_subalgebra L A.is_closed_topological_closure ⟨f, fm⟩ ⟨g, gm⟩)
     (subalgebra.separates_points.strongly
@@ -307,12 +307,12 @@ end
 /--
 An alternative statement of the Stone-Weierstrass theorem.
 
-If `A` is a subalgebra of `C(X, ℝ)` which separates points (and `X` is compact),
+If `A` is a subalgebra of `C⟮X, ℝ⟯` which separates points (and `X` is compact),
 every real-valued continuous function on `X` is a uniform limit of elements of `A`.
 -/
 theorem continuous_map_mem_subalgebra_closure_of_separates_points
-  (A : subalgebra ℝ C(X, ℝ)) (w : A.separates_points)
-  (f : C(X, ℝ)) :
+  (A : subalgebra ℝ C⟮X, ℝ⟯) (w : A.separates_points)
+  (f : C⟮X, ℝ⟯) :
   f ∈ A.topological_closure :=
 begin
   rw subalgebra_topological_closure_eq_top_of_separates_points A w,
@@ -323,13 +323,13 @@ end
 An alternative statement of the Stone-Weierstrass theorem,
 for those who like their epsilons.
 
-If `A` is a subalgebra of `C(X, ℝ)` which separates points (and `X` is compact),
+If `A` is a subalgebra of `C⟮X, ℝ⟯` which separates points (and `X` is compact),
 every real-valued continuous function on `X` is within any `ε > 0` of some element of `A`.
 -/
 theorem exists_mem_subalgebra_near_continuous_map_of_separates_points
-  (A : subalgebra ℝ C(X, ℝ)) (w : A.separates_points)
-  (f : C(X, ℝ)) (ε : ℝ) (pos : 0 < ε) :
-  ∃ (g : A), ∥(g : C(X, ℝ)) - f∥ < ε :=
+  (A : subalgebra ℝ C⟮X, ℝ⟯) (w : A.separates_points)
+  (f : C⟮X, ℝ⟯) (ε : ℝ) (pos : 0 < ε) :
+  ∃ (g : A), ∥(g : C⟮X, ℝ⟯) - f∥ < ε :=
 begin
   have w := mem_closure_iff_frequently.mp
     (continuous_map_mem_subalgebra_closure_of_separates_points A w f),
@@ -343,11 +343,11 @@ end
 An alternative statement of the Stone-Weierstrass theorem,
 for those who like their epsilons and don't like bundled continuous functions.
 
-If `A` is a subalgebra of `C(X, ℝ)` which separates points (and `X` is compact),
+If `A` is a subalgebra of `C⟮X, ℝ⟯` which separates points (and `X` is compact),
 every real-valued continuous function on `X` is within any `ε > 0` of some element of `A`.
 -/
 theorem exists_mem_subalgebra_near_continuous_of_separates_points
-  (A : subalgebra ℝ C(X, ℝ)) (w : A.separates_points)
+  (A : subalgebra ℝ C⟮X, ℝ⟯) (w : A.separates_points)
   (f : X → ℝ) (c : continuous f) (ε : ℝ) (pos : 0 < ε) :
   ∃ (g : A), ∀ x, ∥g x - f x∥ < ε :=
 begin

--- a/src/topology/continuous_function/weierstrass.lean
+++ b/src/topology/continuous_function/weierstrass.lean
@@ -57,15 +57,15 @@ begin
   by_cases h : a < b, -- (Otherwise it's easy; we'll deal with that later.)
   { -- We can pullback continuous functions on `[a,b]` to continuous functions on `[0,1]`,
     -- by precomposing with an affine map.
-    let W : C(set.Icc a b, ℝ) →ₐ[ℝ] C(I, ℝ) :=
+    let W : C⟮set.Icc a b, ℝ⟯ →ₐ[ℝ] C⟮I, ℝ⟯ :=
       comp_right_alg_hom ℝ (Icc_homeo_I a b h).symm.to_continuous_map,
     -- This operation is itself a homeomorphism
     -- (with respect to the norm topologies on continuous functions).
-    let W' : C(set.Icc a b, ℝ) ≃ₜ C(I, ℝ) := comp_right_homeomorph ℝ (Icc_homeo_I a b h).symm,
-    have w : (W : C(set.Icc a b, ℝ) → C(I, ℝ)) = W' := rfl,
+    let W' : C⟮set.Icc a b, ℝ⟯ ≃ₜ C⟮I, ℝ⟯ := comp_right_homeomorph ℝ (Icc_homeo_I a b h).symm,
+    have w : (W : C⟮set.Icc a b, ℝ⟯ → C⟮I, ℝ⟯) = W' := rfl,
     -- Thus we take the statement of the Weierstrass approximation theorem for `[0,1]`,
     have p := polynomial_functions_closure_eq_top',
-    -- and pullback both sides, obtaining an equation between subalgebras of `C([a,b], ℝ)`.
+    -- and pullback both sides, obtaining an equation between subalgebras of `C⟮[a,b], ℝ⟯`.
     apply_fun (λ s, s.comap' W) at p,
     simp only [algebra.comap_top] at p,
     -- Since the pullback operation is continuous, it commutes with taking `topological_closure`,
@@ -87,7 +87,7 @@ An alternative statement of Weierstrass' theorem.
 
 Every real-valued continuous function on `[a,b]` is a uniform limit of polynomials.
 -/
-theorem continuous_map_mem_polynomial_functions_closure (a b : ℝ) (f : C(set.Icc a b, ℝ)) :
+theorem continuous_map_mem_polynomial_functions_closure (a b : ℝ) (f : C⟮set.Icc a b, ℝ⟯) :
   f ∈ (polynomial_functions (set.Icc a b)).topological_closure :=
 begin
   rw polynomial_functions_closure_eq_top _ _,
@@ -100,7 +100,7 @@ for those who like their epsilons.
 
 Every real-valued continuous function on `[a,b]` is within any `ε > 0` of some polynomial.
 -/
-theorem exists_polynomial_near_continuous_map (a b : ℝ) (f : C(set.Icc a b, ℝ))
+theorem exists_polynomial_near_continuous_map (a b : ℝ) (f : C⟮set.Icc a b, ℝ⟯)
   (ε : ℝ) (pos : 0 < ε) :
   ∃ (p : polynomial ℝ), ∥p.to_continuous_map_on _ - f∥ < ε :=
 begin
@@ -122,7 +122,7 @@ theorem exists_polynomial_near_of_continuous_on
   (a b : ℝ) (f : ℝ → ℝ) (c : continuous_on f (set.Icc a b)) (ε : ℝ) (pos : 0 < ε) :
   ∃ (p : polynomial ℝ), ∀ x ∈ set.Icc a b, abs (p.eval x - f x) < ε :=
 begin
-  let f' : C(set.Icc a b, ℝ) := ⟨λ x, f x, continuous_on_iff_continuous_restrict.mp c⟩,
+  let f' : C⟮set.Icc a b, ℝ⟯ := ⟨λ x, f x, continuous_on_iff_continuous_restrict.mp c⟩,
   obtain ⟨p, b⟩ := exists_polynomial_near_continuous_map a b f' ε pos,
   use p,
   rw norm_lt_iff _ pos at b,

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -830,7 +830,7 @@ quot.compact_space
 
 /-- There are various definitions of "locally compact space" in the literature, which agree for
 Hausdorff spaces but not in general. This one is the precise condition on X needed for the
-evaluation `map C(X, Y) × X → Y` to be continuous for all `Y` when `C(X, Y)` is given the
+evaluation `map C⟮X, Y⟯ × X → Y` to be continuous for all `Y` when `C⟮X, Y⟯` is given the
 compact-open topology. -/
 class locally_compact_space (α : Type*) [topological_space α] : Prop :=
 (local_compact_nhds : ∀ (x : α) (n ∈ 𝓝 x), ∃ s ∈ 𝓝 x, s ⊆ n ∧ is_compact s)


### PR DESCRIPTION
Changing the notation of continuous functions from `C(α, β)` to `C⟮α, β⟯`. If it is to be merged, it should probably be merged quickly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
