### PR TITLE
[Merged by Bors] - feat(measure_theory): continuity of primitives

### DIFF
--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -1159,6 +1159,16 @@ by rw [inter_comm, Ioc_inter_Ioo_of_right_le h, max_comm]
 lemma Ioo_inter_Ioc_of_right_lt (h : b₂ < b₁) : Ioo a₁ b₁ ∩ Ioc a₂ b₂ = Ioc (max a₁ a₂) b₂ :=
 by rw [inter_comm, Ioc_inter_Ioo_of_left_lt h, max_comm]
 
+lemma Iic_inter_Ioc_of_le (h : a₂ ≤ a) : Iic a₂ ∩ Ioc a₁ a = Ioc a₁ a₂ :=
+begin
+  ext x,
+  split,
+  { rintros ⟨H, H', H''⟩,
+    exact ⟨H', H⟩ },
+  { rintros ⟨H, H'⟩,
+    exact ⟨H', H, H'.trans h⟩ }
+end
+
 @[simp] lemma Ico_diff_Iio : Ico a b \ Iio c = Ico (max a c) b :=
 ext $ by simp [Ico, Iio, iff_def, max_le_iff] {contextual:=tt}
 

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -1160,14 +1160,7 @@ lemma Ioo_inter_Ioc_of_right_lt (h : b₂ < b₁) : Ioo a₁ b₁ ∩ Ioc a₂ b
 by rw [inter_comm, Ioc_inter_Ioo_of_left_lt h, max_comm]
 
 lemma Iic_inter_Ioc_of_le (h : a₂ ≤ a) : Iic a₂ ∩ Ioc a₁ a = Ioc a₁ a₂ :=
-begin
-  ext x,
-  split,
-  { rintros ⟨H, H', H''⟩,
-    exact ⟨H', H⟩ },
-  { rintros ⟨H, H'⟩,
-    exact ⟨H', H, H'.trans h⟩ }
-end
+ext $ λ x, ⟨λ H, ⟨H.2.1, H.1⟩, λ H, ⟨H.2, H.1, H.2.trans h⟩⟩
 
 @[simp] lemma Ico_diff_Iio : Ico a b \ Iio c = Ico (max a c) b :=
 ext $ by simp [Ico, Iio, iff_def, max_le_iff] {contextual:=tt}

--- a/src/data/set/intervals/unordered_interval.lean
+++ b/src/data/set/intervals/unordered_interval.lean
@@ -114,6 +114,22 @@ begin
   { rintro ⟨a, b, h⟩, exact ⟨min a b, max a b, h⟩ }
 end
 
+/-- The open-closed interval with unordered bounds. -/
+def interval_oc : α → α → set α := λ a b, Ioc (min a b) (max a b)
+
+-- Below is a capital iota
+localized "notation `Ι` := interval_oc" in interval
+
+lemma interval_oc_of_le (h : a ≤ b) : Ι a b = Ioc a b :=
+by simp [interval_oc, h]
+
+lemma interval_oc_of_lt (h : b < a) : Ι a b = Ioc b a :=
+by simp [interval_oc, le_of_lt h]
+
+lemma forall_interval_oc_iff  {P : α → Prop} :
+  (∀ x ∈ Ι a b, P x) ↔ (∀ x ∈ Ioc a b, P x) ∧ (∀ x ∈ Ioc b a, P x) :=
+by { dsimp [interval_oc], cases le_total a b with hab hab ; simp [hab] }
+
 end linear_order
 
 open_locale interval

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -610,7 +610,7 @@ begin
   { have : μ.restrict (Icc a b) = μ.restrict (Ioc a b),
     { rw [← Ioc_union_left hab,
           measure_theory.measure.restrict_union _ measurable_set_Ioc (measurable_set_singleton a)],
-      { simp [ha] },
+      { simp [measure_theory.measure.restrict_zero_set ha] },
       { simp } },
     rw this },
   { simp [hab, hab.le] }

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -702,21 +702,21 @@ by simp only [interval_integral, set_integral_congr_ae (measurable_set_Ioc) h,
 
 lemma congr_ae {f g : α → E} (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = g x) :
   ∫ (x : α) in a..b, f x ∂μ = ∫ (x : α) in a..b, g x ∂μ :=
-interval_integral.congr_ae' (ae_interval_oc_iff.mp h).1 (ae_interval_oc_iff.mp h).2
+congr_ae' (ae_interval_oc_iff.mp h).1 (ae_interval_oc_iff.mp h).2
 
 lemma integral_zero_ae {f : α → E} (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = 0) :
   ∫ (x : α) in a..b, f x ∂μ = 0 :=
-calc ∫ x in a..b, f x ∂μ = ∫ x in a..b, 0 ∂μ : interval_integral.congr_ae h
-                     ... = 0                 : interval_integral.integral_zero
+calc ∫ x in a..b, f x ∂μ = ∫ x in a..b, 0 ∂μ : congr_ae h
+                     ... = 0                 : integral_zero
 
 lemma integral_indicator {a₁ a₂ a₃ : α} (h : a₂ ∈ Icc a₁ a₃) {f : α → E} :
   ∫ x in a₁..a₃, indicator {x | x ≤ a₂} f x ∂ μ = ∫ x in a₁..a₂, f x ∂ μ :=
 begin
   have : {x | x ≤ a₂} ∩ Ioc a₁ a₃ = Ioc a₁ a₂, from Iic_inter_Ioc_of_le h.2,
-  rw [interval_integral.integral_of_le h.1, interval_integral.integral_of_le (h.1.trans h.2),
+  rw [integral_of_le h.1, integral_of_le (h.1.trans h.2),
       integral_indicator, measure.restrict_restrict, this],
   exact measurable_set_Iic,
-  all_goals { apply measurable_set_Iic},
+  all_goals { apply measurable_set_Iic },
 end
 
 end order_closed_topology
@@ -814,7 +814,7 @@ begin
                 le_max_right_of_le $ h₂.trans $ le_max_right _ _⟩ } },
     have : ∀ b ∈ Icc b₁ b₂, ∫ x in a..b, f x ∂μ = ∫ x in a..b₁, f x ∂μ + ∫ x in b₁..b, f x ∂μ,
     { rintros b ⟨h₁, h₂⟩,
-      rw ← interval_integral.integral_add_adjacent_intervals _ (h_int' ⟨h₁, h₂⟩),
+      rw ← integral_add_adjacent_intervals _ (h_int' ⟨h₁, h₂⟩),
       apply h_int.mono_set,
       apply interval_subset_interval,
       { exact ⟨min_le_left_of_le (min_le_left a b₁), le_max_right_of_le (le_max_left _ _)⟩ },
@@ -907,7 +907,7 @@ lemma continuous_on_primitive'' {f : α → E} {a b : α} [has_no_atoms μ]
 variables [no_bot_order α] [no_top_order α] [has_no_atoms μ]
 
 lemma continuous_primitive {f : α → E} (h_int : ∀ a b : α, interval_integrable f μ a b) (a : α) :
-  continuous (λ b, ∫ x in a .. b, f x ∂ μ) :=
+  continuous (λ b, ∫ x in a..b, f x ∂ μ) :=
 begin
   rw continuous_iff_continuous_at,
   intro b₀,
@@ -918,7 +918,7 @@ begin
 end
 
 lemma measure_theory.integrable.continuous_primitive {f : α → E} (h_int : integrable f μ) (a : α) :
-  continuous (λ b, ∫ x in a .. b, f x ∂ μ) :=
+  continuous (λ b, ∫ x in a..b, f x ∂ μ) :=
 continuous_primitive (λ _ _, h_int.interval_integrable) a
 
 end continuous_primitive

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -168,7 +168,7 @@ lemma ae_measurable_interval_oc_iff {μ : measure α} {β : Type*} [measurable_s
   (ae_measurable f $ μ.restrict $ Ioc a b) ∧ (ae_measurable f $ μ.restrict $ Ioc b a) :=
 by { dsimp [interval_oc], cases le_total a b with hab hab ; simp [hab] }
 
-variables  [topological_space α] [opens_measurable_space α] [order_closed_topology α]
+variables [topological_space α] [opens_measurable_space α] [order_closed_topology α]
 
 lemma ae_interval_oc_iff' : (∀ᵐ x ∂μ, x ∈ Ι a b → P x) ↔
   (∀ᵐ x ∂ (μ.restrict $ Ioc a b), P x) ∧ (∀ᵐ x ∂ (μ.restrict $ Ioc b a), P x) :=
@@ -606,15 +606,14 @@ variables [topological_space α] [order_closed_topology α] [opens_measurable_sp
 lemma integral_Icc_eq_integral_Ioc {f : α → E} {a b : α} (ha : μ {a} = 0) :
   ∫ t in Icc a b, f t ∂μ = ∫ t in Ioc a b, f t ∂μ :=
 begin
-  by_cases hab : a ≤ b,
+  cases le_or_lt a b with hab hab,
   { have : μ.restrict (Icc a b) = μ.restrict (Ioc a b),
     { rw [← Ioc_union_left hab,
           measure_theory.measure.restrict_union _ measurable_set_Ioc (measurable_set_singleton a)],
       { simp [ha] },
       { simp } },
     rw this },
-  { push_neg at hab,
-    simp [hab, hab.le] }
+  { simp [hab, hab.le] }
 end
 
 /-- If two functions are equal in the relevant interval, their interval integrals are also equal. -/
@@ -745,11 +744,11 @@ lemma continuous_within_at_of_dominated_interval
 begin
   have gcs := is_countably_generated_nhds_within x₀ s,
   cases bound_integrable,
-  cases le_or_gt a b with hab hab;
+  cases le_or_lt a b with hab hab;
   [{ rw interval_oc_of_le hab at *,
      simp_rw interval_integral.integral_of_le hab },
    { rw interval_oc_of_lt hab at *,
-     simp_rw interval_integral.integral_of_ge (le_of_lt hab),
+     simp_rw interval_integral.integral_of_ge hab.le,
      refine tendsto.neg _ }];
   apply tendsto_integral_filter_of_dominated_convergence bound gcs hF_meas hF_meas₀ h_bound,
   exacts [bound_integrable_left, h_cont, bound_integrable_right, h_cont]
@@ -787,7 +786,7 @@ lemma continuous_of_dominated_interval {F : X → α → E} {bound : α → ℝ}
   (h_cont : ∀ᵐ t ∂(μ.restrict $ Ι a b), continuous (λ x, F x t)) :
   continuous (λ x, ∫ t in a..b, F x t ∂μ) :=
 continuous_iff_continuous_at.mpr (λ x₀, continuous_at_of_dominated_interval
-  (eventually_of_forall hF_meas) (eventually_of_forall h_bound) ‹_› $ h_cont.mono $
+  (eventually_of_forall hF_meas) (eventually_of_forall h_bound) bound_integrable $ h_cont.mono $
   λ _, continuous.continuous_at)
 
 end continuity_wrt_parameter
@@ -809,18 +808,18 @@ begin
     { rintros x ⟨h₁, h₂⟩,
       apply h_int.mono_set,
       apply interval_subset_interval,
-      exact ⟨min_le_left_of_le (min_le_right a b₁),
-              h₁.trans (h₂.trans $ le_max_right_of_le $ le_max_right _ _)⟩,
-      exact ⟨min_le_left_of_le $ (min_le_right _ _).trans h₁,
-              le_max_right_of_le $ h₂.trans $ le_max_right _ _⟩ },
+      { exact ⟨min_le_left_of_le (min_le_right a b₁),
+                h₁.trans (h₂.trans $ le_max_right_of_le $ le_max_right _ _)⟩ },
+      { exact ⟨min_le_left_of_le $ (min_le_right _ _).trans h₁,
+                le_max_right_of_le $ h₂.trans $ le_max_right _ _⟩ } },
     have : ∀ b ∈ Icc b₁ b₂, ∫ x in a..b, f x ∂μ = ∫ x in a..b₁, f x ∂μ + ∫ x in b₁..b, f x ∂μ,
     { rintros b ⟨h₁, h₂⟩,
       rw ← interval_integral.integral_add_adjacent_intervals _ (h_int' ⟨h₁, h₂⟩),
       apply h_int.mono_set,
       apply interval_subset_interval,
-      exact ⟨min_le_left_of_le (min_le_left a b₁), le_max_right_of_le (le_max_left _ _)⟩,
-      exact ⟨min_le_left_of_le (min_le_right _ _),
-              le_max_right_of_le (h₁.trans $ h₂.trans (le_max_right a b₂))⟩ },
+      { exact ⟨min_le_left_of_le (min_le_left a b₁), le_max_right_of_le (le_max_left _ _)⟩ },
+      { exact ⟨min_le_left_of_le (min_le_right _ _),
+                le_max_right_of_le (h₁.trans $ h₂.trans (le_max_right a b₂))⟩ } },
     apply continuous_within_at.congr _ this (this _ h₀), clear this,
     refine continuous_within_at_const.add _,
     have : (λ b, ∫ x in b₁..b, f x ∂μ) =ᶠ[𝓝[Icc b₁ b₂] b₀]
@@ -848,7 +847,7 @@ begin
     { refine eventually_of_forall (λ (x : α), eventually_of_forall (λ (t : α), _)),
       dsimp [indicator],
       split_ifs ; simp },
-    { have : ∀ᵐ t ∂μ.restrict (Ι b₁ b₂), t < b₀ ∨ t > b₀,
+    { have : ∀ᵐ t ∂μ.restrict (Ι b₁ b₂), t < b₀ ∨ b₀ < t,
       { apply ae_restrict_of_ae,
         apply eventually.mono (compl_mem_ae_iff.mpr hb₀),
         intros x hx,
@@ -868,7 +867,6 @@ begin
           intros x hx,
           simp [hx] },
         apply continuous_within_at_const.congr_of_eventually_eq this,
-        change _ < _ at hx₀,
         simp [hx₀] } } },
   { apply continuous_within_at_of_not_mem_closure,
     rwa [closure_Icc] }
@@ -878,7 +876,7 @@ lemma continuous_on_primitive {f : α → E} {a b : α} [has_no_atoms μ]
   (h_int : integrable_on f (Icc a b) μ) :
   continuous_on (λ x, ∫ t in Ioc a x, f t ∂ μ) (Icc a b) :=
 begin
-  by_cases H : a ≤ b,
+  cases le_or_lt a b with H H,
   { have : ∀ x ∈ Icc a b, ∫ (t : α) in Ioc a x, f t ∂μ = ∫ (t : α) in a..x, f t ∂μ,
     { intros x x_in,
       simp_rw [← interval_oc_of_le H, integral_of_le x_in.1] },
@@ -888,8 +886,7 @@ begin
     rw interval_integrable_iff,
     simp only [H, max_eq_right, min_eq_left],
     exact h_int.mono Ioc_subset_Icc_self le_rfl },
-  { push_neg at H,
-    rw Icc_eq_empty H,
+  { rw Icc_eq_empty H,
     apply continuous_on_empty },
 end
 

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -691,7 +691,7 @@ lemma congr_ae {f g : α → E} (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = g x)
   ∫ (x : α) in a..b, f x ∂μ = ∫ (x : α) in a..b, g x ∂μ :=
 interval_integral.congr_ae' (ae_interval_oc_iff.mp h).1 (ae_interval_oc_iff.mp h).2
 
-lemma integral_zero_ae  {f : α → E} (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = 0) :
+lemma integral_zero_ae {f : α → E} (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = 0) :
   ∫ (x : α) in a..b, f x ∂μ = 0 :=
 calc ∫ x in a..b, f x ∂μ = ∫ x in a..b, 0 ∂μ : interval_integral.congr_ae h
                      ... = 0                 : interval_integral.integral_zero

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -694,19 +694,19 @@ begin
     simp [h] }
 end
 
-lemma congr_ae' {f g : α → E} (h : ∀ᵐ x ∂μ, x ∈ Ioc a b → f x = g x)
+lemma integral_congr_ae' {f g : α → E} (h : ∀ᵐ x ∂μ, x ∈ Ioc a b → f x = g x)
   (h' : ∀ᵐ x ∂μ, x ∈ Ioc b a → f x = g x) :
   ∫ (x : α) in a..b, f x ∂μ = ∫ (x : α) in a..b, g x ∂μ :=
 by simp only [interval_integral, set_integral_congr_ae (measurable_set_Ioc) h,
               set_integral_congr_ae (measurable_set_Ioc) h']
 
-lemma congr_ae {f g : α → E} (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = g x) :
+lemma integral_congr_ae {f g : α → E} (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = g x) :
   ∫ (x : α) in a..b, f x ∂μ = ∫ (x : α) in a..b, g x ∂μ :=
-congr_ae' (ae_interval_oc_iff.mp h).1 (ae_interval_oc_iff.mp h).2
+integral_congr_ae' (ae_interval_oc_iff.mp h).1 (ae_interval_oc_iff.mp h).2
 
 lemma integral_zero_ae {f : α → E} (h : ∀ᵐ x ∂μ, x ∈ Ι a b → f x = 0) :
   ∫ (x : α) in a..b, f x ∂μ = 0 :=
-calc ∫ x in a..b, f x ∂μ = ∫ x in a..b, 0 ∂μ : congr_ae h
+calc ∫ x in a..b, f x ∂μ = ∫ x in a..b, 0 ∂μ : integral_congr_ae h
                      ... = 0                 : integral_zero
 
 lemma integral_indicator {a₁ a₂ a₃ : α} (h : a₂ ∈ Icc a₁ a₃) {f : α → E} :
@@ -917,8 +917,8 @@ begin
   exact continuous_within_at_primitive (measure_singleton b₀) (h_int _ _)
 end
 
-lemma measure_theory.integrable.continuous_primitive {f : α → E} (h_int : integrable f μ) (a : α) :
-  continuous (λ b, ∫ x in a..b, f x ∂ μ) :=
+lemma _root_.measure_theory.integrable.continuous_primitive {f : α → E} (h_int : integrable f μ)
+  (a : α) : continuous (λ b, ∫ x in a..b, f x ∂ μ) :=
 continuous_primitive (λ _ _, h_int.interval_integrable) a
 
 end continuous_primitive

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -823,11 +823,12 @@ begin
               le_max_right_of_le (h₁.trans $ h₂.trans (le_max_right a b₂))⟩ },
     apply continuous_within_at.congr _ this (this _ h₀), clear this,
     refine continuous_within_at_const.add _,
-    have : (λ b, ∫ x in b₁..b, f x ∂μ) =ᶠ[𝓝[Icc b₁ b₂] b₀] λ b, ∫ x in b₁..b₂, indicator {x | x ≤ b} f x ∂ μ,
+    have : (λ b, ∫ x in b₁..b, f x ∂μ) =ᶠ[𝓝[Icc b₁ b₂] b₀]
+            λ b, ∫ x in b₁..b₂, indicator {x | x ≤ b} f x ∂ μ,
     { apply eventually_eq_of_mem self_mem_nhds_within,
       exact λ b b_in, (integral_indicator b_in).symm },
 
-    apply continuous_within_at.congr_of_eventually_eq _ this (integral_indicator h₀).symm, clear this,
+    apply continuous_within_at.congr_of_eventually_eq _ this (integral_indicator h₀).symm,
     have : interval_integrable (λ x, ∥f x∥) μ b₁ b₂,
       from interval_integrable.norm (h_int' $ right_mem_Icc.mpr h₁₂),
     refine continuous_within_at_of_dominated_interval _ _ _ this _ ; clear this,

--- a/src/measure_theory/interval_integral.lean
+++ b/src/measure_theory/interval_integral.lean
@@ -770,7 +770,7 @@ begin
   refine continuous_at_of_dominated_interval _ _ (h_int b₁ b₂).norm _,
   { apply eventually.mono (Ioo_mem_nhds hb₁ hb₂),
     intros x hx,
-    erw [← ae_measurable_indicator_iff, measure.restrict_restrict, Iic_inter_Ioc],
+    erw [← ae_measurable_indicator_iff, measure.restrict_restrict, Iic_inter_Ioc_of_le],
     { exact (h_int _ _).2.ae_measurable },
     { simp [hb₁, hb₂, hx.1, hx.2.le] },
     exacts [measurable_set_Iic, measurable_set_Iic] },

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -997,7 +997,7 @@ end
 @[simp] lemma restrict_eq_zero : μ.restrict s = 0 ↔ μ s = 0 :=
 by rw [← measure_univ_eq_zero, restrict_apply_univ]
 
-@[simp] lemma measure_theory.measure.restrict_singleton {a : α} (ha : μ {a} = 0) :
+@[simp] lemma measure.restrict_singleton {a : α} (ha : μ {a} = 0) :
   μ.restrict {a} = 0 :=
 by simp only [measure.restrict_eq_zero, ha]
 

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -997,7 +997,7 @@ end
 @[simp] lemma restrict_eq_zero : μ.restrict s = 0 ↔ μ s = 0 :=
 by rw [← measure_univ_eq_zero, restrict_apply_univ]
 
-@[simp] lemma measure.restrict_zero_set {s : set α} (h : μ s = 0) :
+lemma restrict_zero_set {s : set α} (h : μ s = 0) :
   μ.restrict s = 0 :=
 by simp only [measure.restrict_eq_zero, h]
 
@@ -1701,7 +1701,7 @@ export probability_measure (measure_univ) has_no_atoms (measure_singleton)
 
 attribute [simp] measure_singleton
 
-@[simp] lemma measure_theory.measure.restrict_singleton' [has_no_atoms μ] {a : α} :
+@[simp] lemma measure.restrict_singleton' [has_no_atoms μ] {a : α} :
   μ.restrict {a} = 0 :=
 by simp only [measure_singleton, measure.restrict_eq_zero]
 

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -997,6 +997,9 @@ end
 @[simp] lemma restrict_eq_zero : μ.restrict s = 0 ↔ μ s = 0 :=
 by rw [← measure_univ_eq_zero, restrict_apply_univ]
 
+@[simp] lemma measure_theory.measure.restrict_singleton {a : α} (ha : μ {a} = 0) : μ.restrict {a} = 0 :=
+by simp only [measure.restrict_eq_zero, ha]
+
 @[simp] lemma restrict_empty : μ.restrict ∅ = 0 := ext $ λ s hs, by simp [hs]
 
 @[simp] lemma restrict_univ : μ.restrict univ = μ := ext $ λ s hs, by simp [hs]
@@ -1696,6 +1699,10 @@ class has_no_atoms (μ : measure α) : Prop :=
 export probability_measure (measure_univ) has_no_atoms (measure_singleton)
 
 attribute [simp] measure_singleton
+
+@[simp] lemma measure_theory.measure.restrict_singleton' [has_no_atoms μ] {a : α} :
+  μ.restrict {a} = 0 :=
+by simp only [measure_singleton, measure.restrict_eq_zero]
 
 lemma measure_lt_top (μ : measure α) [finite_measure μ] (s : set α) : μ s < ∞ :=
 (measure_mono (subset_univ s)).trans_lt finite_measure.measure_univ_lt_top

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -997,7 +997,8 @@ end
 @[simp] lemma restrict_eq_zero : μ.restrict s = 0 ↔ μ s = 0 :=
 by rw [← measure_univ_eq_zero, restrict_apply_univ]
 
-@[simp] lemma measure_theory.measure.restrict_singleton {a : α} (ha : μ {a} = 0) : μ.restrict {a} = 0 :=
+@[simp] lemma measure_theory.measure.restrict_singleton {a : α} (ha : μ {a} = 0) :
+  μ.restrict {a} = 0 :=
 by simp only [measure.restrict_eq_zero, ha]
 
 @[simp] lemma restrict_empty : μ.restrict ∅ = 0 := ext $ λ s hs, by simp [hs]

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -997,9 +997,9 @@ end
 @[simp] lemma restrict_eq_zero : μ.restrict s = 0 ↔ μ s = 0 :=
 by rw [← measure_univ_eq_zero, restrict_apply_univ]
 
-@[simp] lemma measure.restrict_singleton {a : α} (ha : μ {a} = 0) :
-  μ.restrict {a} = 0 :=
-by simp only [measure.restrict_eq_zero, ha]
+@[simp] lemma measure.restrict_zero_set {s : set α} (h : μ s = 0) :
+  μ.restrict s = 0 :=
+by simp only [measure.restrict_eq_zero, h]
 
 @[simp] lemma restrict_empty : μ.restrict ∅ = 0 := ext $ λ s hs, by simp [hs]
 


### PR DESCRIPTION
From the sphere eversion project

This proves some continuity of interval integrals with respect to parameters and continuity of primitives of measurable functions. The statements are a bit abstract, but they allow to have:
```lean
example {f : ℝ → E} (h_int : integrable f) (a : ℝ) :  
  continuous (λ b, ∫ x in a .. b, f x ∂ volume) :=
h_int.continuous_primitive a
```
under the usual assumptions on `E`: `normed_group E`, `second_countable_topology E`,  `normed_space ℝ E`
`complete_space E`, `measurable_space E`, `borel_space E`, say `E = ℝ` for instance. Of course global integrability is not needed, assuming integrability on all finite length intervals is enough:
```lean
example {f : ℝ → E} (h_int : ∀ a b : ℝ, interval_integrable f volume a b) (a : ℝ) :  
  continuous (λ b, ∫ x in a .. b, f x ∂ volume) :=
continuous_primitive h_int a
```


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
