### PR TITLE
[Merged by Bors] - chore(data/real/pi, analysis/special_functions/trigonometric.lean): speed up/simplify proofs

### DIFF
--- a/src/analysis/special_functions/trigonometric.lean
+++ b/src/analysis/special_functions/trigonometric.lean
@@ -2213,7 +2213,7 @@ then by rw [arg, if_pos hx₁];
 else
   have hx : x ≠ 0, from λ h, by simpa [h, lt_irrefl] using hx₁,
   if hx₂ : 0 ≤ x.im
-    then by { rw [arg, if_neg hx₁, if_pos hx₂, ← sub_lt_iff_lt_add'],
+  then by { rw [arg, if_neg hx₁, if_pos hx₂, ← sub_lt_iff_lt_add'],
     refine lt_of_lt_of_le _ real.pi_pos.le,
     rw [neg_im, sub_lt_iff_lt_add', add_zero, neg_lt, neg_div, real.arcsin_neg, neg_neg],
     exact (real.arcsin_le_pi_div_two _).trans_lt (half_lt_self real.pi_pos) }

--- a/src/analysis/special_functions/trigonometric.lean
+++ b/src/analysis/special_functions/trigonometric.lean
@@ -2213,8 +2213,10 @@ then by rw [arg, if_pos hx₁];
 else
   have hx : x ≠ 0, from λ h, by simpa [h, lt_irrefl] using hx₁,
   if hx₂ : 0 ≤ x.im
-  then by rw [arg, if_neg hx₁, if_pos hx₂, ← sub_lt_iff_lt_add];
-    exact (lt_of_lt_of_le (by linarith [real.pi_pos]) (real.neg_pi_div_two_le_arcsin _))
+    then by { rw [arg, if_neg hx₁, if_pos hx₂, ← sub_lt_iff_lt_add'],
+    refine lt_of_lt_of_le _ real.pi_pos.le,
+    rw [neg_im, sub_lt_iff_lt_add', add_zero, neg_lt, neg_div, real.arcsin_neg, neg_neg],
+    exact (real.arcsin_le_pi_div_two _).trans_lt (half_lt_self real.pi_pos) }
   else by rw [arg, if_neg hx₁, if_neg hx₂, lt_sub_iff_add_lt, neg_add_self, real.arcsin_pos,
     neg_im];
       exact div_pos (neg_pos.2 (lt_of_not_ge hx₂)) (abs_pos.2 hx)

--- a/src/data/real/pi.lean
+++ b/src/data/real/pi.lean
@@ -190,14 +190,15 @@ begin
   --     constructed from `u` tends to `0` at `+∞`
   let u := λ k : ℕ, (k:nnreal) ^ (-1 / (2 * (k:ℝ) + 1)),
   have H : tendsto (λ k : ℕ, (1:ℝ) - (u k) + (u k) ^ (2 * (k:ℝ) + 1)) at_top (𝓝 0),
-  { convert (((tendsto_rpow_div_mul_add (-1) 2 1 $ by norm_num).neg.const_add 1).add
+  { convert (((tendsto_rpow_div_mul_add (-1) 2 1 two_ne_zero.symm).neg.const_add 1).add
       tendsto_inv_at_top_zero).comp tendsto_coe_nat_at_top_at_top,
     { ext k,
       simp only [nnreal.coe_nat_cast, function.comp_app, nnreal.coe_rpow],
       rw [← rpow_mul (nat.cast_nonneg k) ((-1)/(2*(k:ℝ)+1)) (2*(k:ℝ)+1),
-          @div_mul_cancel _ _ _ (2*(k:ℝ)+1) (by { norm_cast, linarith }), rpow_neg_one k],
-      ring },
-    { simp } },
+         @div_mul_cancel _ _ _ (2*(k:ℝ)+1)
+            (by { norm_cast, simp only [nat.succ_ne_zero, not_false_iff]}), rpow_neg_one k,
+          tactic.ring.add_neg_eq_sub] },
+    { simp only [add_zero, add_right_neg] } },
   -- (2) We convert the limit in our goal to an inequality
   refine squeeze_zero_norm _ H,
   intro k,
@@ -216,7 +217,7 @@ begin
     { simpa only [U, hk] using zero_rpow_le_one _ },
     { exact rpow_le_one_of_one_le_of_nonpos (by { norm_cast, exact nat.succ_le_iff.mpr
         (nat.pos_of_ne_zero hk) }) (le_of_lt (@div_neg_of_neg_of_pos _ _ (-(1:ℝ)) (2*k+1)
-          (by norm_num) (by { norm_cast, linarith }))) } },
+          (neg_neg_iff_pos.mpr zero_lt_one) (by { norm_cast, exact nat.succ_pos' }))) } },
   have hU2 := nnreal.coe_nonneg U,
   -- (4) We compute the derivative of `f`, denoted by `f'`
   let f' := λ x : ℝ, (-x^2) ^ k / (1 + x^2),
@@ -235,7 +236,8 @@ begin
             pow_mul x 2 i, ← mul_pow (-1) (x^2) i],
         ring_nf } },
     convert (has_deriv_at_arctan x).sub (has_deriv_at.sum has_deriv_at_b),
-    have g_sum := @geom_sum_eq _ _ (-x^2) (by linarith [neg_nonpos.mpr (sq_nonneg x)]) k,
+    have g_sum :=
+      @geom_sum_eq _ _ (-x^2) ((neg_nonpos.mpr (sq_nonneg x)).trans_lt zero_lt_one).ne k,
     simp only [geom_sum, f'] at g_sum ⊢,
     rw [g_sum, ← neg_add' (x^2) 1, add_comm (x^2) 1, sub_eq_add_neg, neg_div', neg_div_neg_eq],
     ring },
@@ -247,10 +249,11 @@ begin
   have f'_bound : ∀ x ∈ Icc (-1:ℝ) 1, |f' x| ≤ |x|^(2*k),
   { intros x hx,
     rw [abs_div, is_absolute_value.abv_pow abs (-x^2) k, abs_neg, is_absolute_value.abv_pow abs x 2,
-        tactic.ring_exp.pow_e_pf_exp rfl rfl, @abs_of_pos _ _ (1+x^2) (by nlinarith)],
-    convert @div_le_div_of_le_left _ _ _ (1+x^2) 1 (pow_nonneg (abs_nonneg x) (2*k)) (by norm_num)
-      (by nlinarith),
-    simp },
+       tactic.ring_exp.pow_e_pf_exp rfl rfl],
+    refine div_le_of_nonneg_of_le_mul (abs_nonneg _) (pow_nonneg (abs_nonneg _) _) _,
+    refine le_mul_of_one_le_right (pow_nonneg (abs_nonneg _) _) _,
+    rw abs_of_nonneg ((add_nonneg zero_le_one (sq_nonneg x)) : (0 : ℝ) ≤ _),
+    exact (le_add_of_nonneg_right (sq_nonneg x) : (1 : ℝ) ≤ _) },
   have hbound1 : ∀ x ∈ Ico (U:ℝ) 1, |f' x| ≤ 1,
   { rintros x ⟨hx_left, hx_right⟩,
     have hincr := pow_le_pow_of_le_left (le_trans hU2 hx_left) (le_of_lt hx_right) (2*k),

--- a/src/data/real/pi.lean
+++ b/src/data/real/pi.lean
@@ -196,7 +196,7 @@ begin
       simp only [nnreal.coe_nat_cast, function.comp_app, nnreal.coe_rpow],
       rw [← rpow_mul (nat.cast_nonneg k) ((-1)/(2*(k:ℝ)+1)) (2*(k:ℝ)+1),
          @div_mul_cancel _ _ _ (2*(k:ℝ)+1)
-            (by { norm_cast, simp only [nat.succ_ne_zero, not_false_iff]}), rpow_neg_one k,
+            (by { norm_cast, simp only [nat.succ_ne_zero, not_false_iff] }), rpow_neg_one k,
           sub_eq_add_neg] },
     { simp only [add_zero, add_right_neg] } },
   -- (2) We convert the limit in our goal to an inequality

--- a/src/data/real/pi.lean
+++ b/src/data/real/pi.lean
@@ -197,7 +197,7 @@ begin
       rw [← rpow_mul (nat.cast_nonneg k) ((-1)/(2*(k:ℝ)+1)) (2*(k:ℝ)+1),
          @div_mul_cancel _ _ _ (2*(k:ℝ)+1)
             (by { norm_cast, simp only [nat.succ_ne_zero, not_false_iff]}), rpow_neg_one k,
-          tactic.ring.add_neg_eq_sub] },
+          sub_eq_add_neg] },
     { simp only [add_zero, add_right_neg] } },
   -- (2) We convert the limit in our goal to an inequality
   refine squeeze_zero_norm _ H,


### PR DESCRIPTION
These are mostly cosmetic changes, simplifying a couple of proofs.  I tried to remove the calls to `linarith` or `norm_num`, when the alternatives were either single lemmas or faster than automation.

The main motivation is to reduce the diff in the bigger PR #7645.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
