### PR TITLE
[Merged by Bors] - fix(tactic/lint): punctuation of messages

### DIFF
--- a/src/tactic/lint/default.lean
+++ b/src/tactic/lint/default.lean
@@ -35,15 +35,20 @@ The following linters are run by default:
 8.  `impossible_instance` checks for instances that can never fire.
 9.  `incorrect_type_class_argument` checks for arguments in [square brackets] that are not classes.
 10. `dangerous_instance` checks for instances that generate type-class problems with metavariables.
-11. `fails_quickly` tests that type-class inference ends (relatively) quickly when applied to variables.
+11. `fails_quickly` tests that type-class inference ends (relatively) quickly when applied to
+    variables.
 12. `has_coe_variable` tests that there are no instances of type `has_coe α t` for a variable `α`.
-13. `inhabited_nonempty` checks for `inhabited` instance arguments that should be changed to `nonempty`.
+13. `inhabited_nonempty` checks for `inhabited` instance arguments that should be changed to
+    `nonempty`.
 14. `simp_nf` checks that the left-hand side of simp lemmas is in simp-normal form.
-15. `simp_var_head` checks that there are no variables as head symbol of left-hand sides of simp lemmas.
+15. `simp_var_head` checks that there are no variables as head symbol of left-hand sides of
+    simp lemmas.
 16. `simp_comm` checks that no commutativity lemmas (such as `add_comm`) are marked simp.
-17. `decidable_classical` checks for `decidable` hypotheses that are used in the proof of a proposition but not
-    in the statement, and could be removed using `classical`. Theorems in the `decidable` namespace are exempt.
-18. `has_coe_to_fun` checks that every type that coerces to a function has a direct `has_coe_to_fun` instance.
+17. `decidable_classical` checks for `decidable` hypotheses that are used in the proof of a
+    proposition but not in the statement, and could be removed using `classical`.
+    Theorems in the `decidable` namespace are exempt.
+18. `has_coe_to_fun` checks that every type that coerces to a function has a direct
+    `has_coe_to_fun` instance.
 19. `check_type` checks that the statement of a declaration is well-typed.
 
 Another linter, `doc_blame_thm`, checks for missing doc strings on lemmas and theorems.

--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -144,9 +144,9 @@ let formatted_results := results.map $ λ ⟨linter_name, linter, results⟩,
       | none := print_warnings env results
       | some dropped := grouped_by_filename env results dropped (print_warnings env)
       end in
-    report_str ++ "/- " ++ linter.errors_found ++ ": -/\n" ++ warnings ++ "\n"
+    report_str ++ "/- " ++ linter.errors_found ++ " -/\n" ++ warnings ++ "\n"
   else if verbose = lint_verbosity.high then
-    "/- OK: " ++ linter.no_errors_found ++ ". -/"
+    "/- OK: " ++ linter.no_errors_found ++ " -/"
   else format.nil,
 let s := format.intercalate "\n" (formatted_results.filter (λ f, ¬ f.is_nil)),
 let s := if verbose = lint_verbosity.low then s else

--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -150,8 +150,8 @@ let formatted_results := results.map $ λ ⟨linter_name, linter, results⟩,
   else format.nil,
 let s := format.intercalate "\n" (formatted_results.filter (λ f, ¬ f.is_nil)),
 let s := if verbose = lint_verbosity.low then s else
-  format!"/- Checking {non_auto_decls.length} declarations (plus " ++
-  "{decls.length - non_auto_decls.length} automatically generated ones) {where_desc} -/\n\n" ++ s,
+  format!("/- Checking {non_auto_decls.length} declarations (plus " ++
+  "{decls.length - non_auto_decls.length} automatically generated ones) {where_desc} -/\n\n") ++ s,
 let s := if slow then s else s ++ "/- (slow tests skipped) -/\n",
 s
 

--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -150,7 +150,8 @@ let formatted_results := results.map $ λ ⟨linter_name, linter, results⟩,
   else format.nil,
 let s := format.intercalate "\n" (formatted_results.filter (λ f, ¬ f.is_nil)),
 let s := if verbose = lint_verbosity.low then s else
-  format!"/- Checking {non_auto_decls.length} declarations (plus {decls.length - non_auto_decls.length} automatically generated ones) {where_desc} -/\n\n" ++ s,
+  format!"/- Checking {non_auto_decls.length} declarations (plus " ++
+  "{decls.length - non_auto_decls.length} automatically generated ones) {where_desc} -/\n\n" ++ s,
 let s := if slow then s else s ++ "/- (slow tests skipped) -/\n",
 s
 

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -12,8 +12,8 @@ This file defines several small linters:
   - `ge_or_gt` checks that `>` and `≥` do not occur in the statement of theorems.
   - `dup_namespace` checks that no declaration has a duplicated namespace such as `list.list.monad`.
   - `unused_arguments` checks that definitions and theorems do not have unused arguments.
-  - `doc_blame` checks that every definition has a documentation string
-  - `doc_blame_thm` checks that every theorem has a documentation string (not enabled by default)
+  - `doc_blame` checks that every definition has a documentation string.
+  - `doc_blame_thm` checks that every theorem has a documentation string (not enabled by default).
   - `def_lemma` checks that a declaration is a lemma iff its type is a proposition.
   - `check_type` checks that the statement of a declaration is well-typed.
 -/
@@ -89,7 +89,7 @@ return $ if d.type.contains_constant (λ n, n ∈ illegal_ge_gt) &&
 @[linter] meta def linter.ge_or_gt : linter :=
 { test := ge_or_gt_in_statement,
   auto_decls := ff,
-  no_errors_found := "Not using ≥/> in declarations",
+  no_errors_found := "Not using ≥/> in declarations.",
   errors_found := "The following declarations use ≥/>, probably in a way where we would prefer
   to use ≤/< instead. See note [nolint_ge] for more information.",
   is_fast := ff }
@@ -122,8 +122,8 @@ return $ let nm := d.to_name.components in if nm.chain' (≠) ∨ is_inst then n
 @[linter] meta def linter.dup_namespace : linter :=
 { test := dup_namespace,
   auto_decls := ff,
-  no_errors_found := "No declarations have a duplicate namespace",
-  errors_found := "DUPLICATED NAMESPACES IN NAME" }
+  no_errors_found := "No declarations have a duplicate namespace.",
+  errors_found := "DUPLICATED NAMESPACES IN NAME:" }
 
 
 
@@ -173,8 +173,8 @@ private meta def unused_arguments (d : declaration) : tactic (option string) := 
 @[linter] meta def linter.unused_arguments : linter :=
 { test := unused_arguments,
   auto_decls := ff,
-  no_errors_found := "No unused arguments",
-  errors_found := "UNUSED ARGUMENTS" }
+  no_errors_found := "No unused arguments.",
+  errors_found := "UNUSED ARGUMENTS." }
 
 attribute [nolint unused_arguments] imp_intro
 
@@ -201,14 +201,14 @@ private meta def doc_blame_report_thm : declaration → tactic (option string)
     (doc_blame_report_defn d) (return none),
   auto_decls := ff,
   no_errors_found := "No definitions are missing documentation.",
-  errors_found := "DEFINITIONS ARE MISSING DOCUMENTATION STRINGS" }
+  errors_found := "DEFINITIONS ARE MISSING DOCUMENTATION STRINGS:" }
 
 /-- A linter for checking theorem doc strings. This is not in the default linter set. -/
 meta def linter.doc_blame_thm : linter :=
 { test := doc_blame_report_thm,
   auto_decls := ff,
   no_errors_found := "No theorems are missing documentation.",
-  errors_found := "THEOREMS ARE MISSING DOCUMENTATION STRINGS",
+  errors_found := "THEOREMS ARE MISSING DOCUMENTATION STRINGS:",
   is_fast := ff }
 
 
@@ -243,8 +243,8 @@ has been used. -/
 @[linter] meta def linter.def_lemma : linter :=
 { test := incorrect_def_lemma,
   auto_decls := ff,
-  no_errors_found := "All declarations correctly marked as def/lemma",
-  errors_found := "INCORRECT DEF/LEMMA" }
+  no_errors_found := "All declarations correctly marked as def/lemma.",
+  errors_found := "INCORRECT DEF/LEMMA:" }
 
 attribute [nolint def_lemma] classical.dec classical.dec_pred classical.dec_rel classical.dec_eq
 
@@ -258,9 +258,9 @@ meta def linter.check_type : linter :=
 { test := check_type,
   auto_decls := ff,
   no_errors_found :=
-    "The statements of all declarations type-check with default reducibility settings",
+    "The statements of all declarations type-check with default reducibility settings.",
   errors_found := "THE STATEMENTS OF THE FOLLOWING DECLARATIONS DO NOT TYPE-CHECK.
 Some definitions in the statement are marked @[irreducible], which means that the statement is " ++
 "now ill-formed. It is likely that these definitions were locally marked as @[reducible] or " ++
-"@[semireducible]. This can especially cause problems with type class inference or @[simps]",
+"@[semireducible]. This can especially cause problems with type class inference or @[simps].",
   is_fast := tt }

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -260,7 +260,8 @@ meta def linter.check_type : linter :=
   no_errors_found :=
     "The statements of all declarations type-check with default reducibility settings.",
   errors_found := "THE STATEMENTS OF THE FOLLOWING DECLARATIONS DO NOT TYPE-CHECK.
-Some definitions in the statement are marked @[irreducible], which means that the statement is " ++
-"now ill-formed. It is likely that these definitions were locally marked as @[reducible] or " ++
-"@[semireducible]. This can especially cause problems with type class inference or @[simps].",
+Some definitions in the statement are marked `@[irreducible]`, which means that the statement " ++
+"is now ill-formed. It is likely that these definitions were locally marked as `@[reducible]` " ++
+"or `@[semireducible]`. This can especially cause problems with type class inference or " ++
+"`@[simps]`.",
   is_fast := tt }

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -76,7 +76,8 @@ return $ if d.type.contains_constant (λ n, n ∈ illegal_ge_gt) &&
 -- return $ if d.type.contains_constant (λ n, (n.get_prefix = `classical ∧
 --   n.last ∈ ["prop_decidable", "dec", "dec_rel", "dec_eq"]) ∨ n ∈ [`gt, `ge])
 -- then
---   let illegal1 := [`classical.prop_decidable, `classical.dec, `classical.dec_rel, `classical.dec_eq],
+--   let illegal1 := [`classical.prop_decidable, `classical.dec, `classical.dec_rel,
+--     `classical.dec_eq],
 --       illegal2 := [`gt, `ge],
 --       occur1 := illegal1.filter (λ n, d.type.contains_constant (eq n)),
 --       occur2 := illegal2.filter (λ n, d.type.contains_constant (eq n)) in

--- a/src/tactic/lint/simp.lean
+++ b/src/tactic/lint/simp.lean
@@ -112,15 +112,17 @@ else if ¬ lhs_in_nf then do
       ++ "to" ++ lhs'.group.indent 2 ++ format.line
       ++ "using " ++ (to_fmt prf1_lems).group.indent 2 ++ format.line
       ++ "Try to change the left-hand side to the simplified term!\n"
-else if ¬ is_cond ∧ lhs = lhs' then do
-  pure "Left-hand side does not simplify.\nYou need to debug this yourself using `set_option trace.simplify.rewrite true`"
+else if ¬ is_cond ∧ lhs = lhs' then
+  pure $ some $ "Left-hand side does not simplify.\nYou need to debug this yourself using " ++
+"`set_option trace.simplify.rewrite true`"
 else
   pure none
 
 /--
 This note gives you some tips to debug any errors that the simp-normal form linter raises.
 
-The reason that a lemma was considered faulty is because its left-hand side is not in simp-normal form.
+The reason that a lemma was considered faulty is because its left-hand side is not in simp-normal
+form.
 These lemmas are hence never used by the simplifier.
 
 This linter gives you a list of other simp lemmas: look at them!

--- a/src/tactic/lint/simp.lean
+++ b/src/tactic/lint/simp.lean
@@ -169,11 +169,10 @@ library_note "simp-normal form"
 @[linter] meta def linter.simp_nf : linter :=
 { test := simp_nf_linter,
   auto_decls := tt,
-  no_errors_found := "All left-hand sides of simp lemmas are in simp-normal form",
+  no_errors_found := "All left-hand sides of simp lemmas are in simp-normal form.",
   errors_found := "SOME SIMP LEMMAS ARE NOT IN SIMP-NORMAL FORM.
 see note [simp-normal form] for tips how to debug this.
-https://leanprover-community.github.io/mathlib_docs/notes.html#simp-normal%20form
-" }
+https://leanprover-community.github.io/mathlib_docs/notes.html#simp-normal%20form" }
 
 private meta def simp_var_head (d : declaration) : tactic (option string) := do
 tt ← is_simp_lemma d.to_name | pure none,
@@ -193,9 +192,9 @@ and which hence never fire.
 { test := simp_var_head,
   auto_decls := tt,
   no_errors_found :=
-    "No left-hand sides of a simp lemma has a variable as head symbol",
+    "No left-hand sides of a simp lemma has a variable as head symbol.",
   errors_found := "LEFT-HAND SIDE HAS VARIABLE AS HEAD SYMBOL.\n" ++
-    "Some simp lemmas have a variable as head symbol of the left-hand side" }
+    "Some simp lemmas have a variable as head symbol of the left-hand side:" }
 
 private meta def simp_comm (d : declaration) : tactic (option string) := do
 tt ← is_simp_lemma d.to_name | pure none,
@@ -215,6 +214,6 @@ pure $ "should not be marked simp"
 @[linter] meta def linter.simp_comm : linter :=
 { test := simp_comm,
   auto_decls := tt,
-  no_errors_found := "No commutativity lemma is marked simp",
+  no_errors_found := "No commutativity lemma is marked simp.",
   errors_found := "COMMUTATIVITY LEMMA IS SIMP.\n" ++
-    "Some commutativity lemmas are simp lemmas" }
+    "Some commutativity lemmas are simp lemmas:" }

--- a/src/tactic/lint/type_classes.lean
+++ b/src/tactic/lint/type_classes.lean
@@ -146,7 +146,9 @@ private meta def impossible_instance (d : declaration) : tactic (option string) 
   auto_decls := tt,
   no_errors_found := "All instances are applicable.",
   errors_found := "IMPOSSIBLE INSTANCES FOUND.
-These instances have an argument that cannot be found during type-class resolution, and therefore can never succeed. Either mark the arguments with square brackets (if it is a class), or don't make it an instance." }
+These instances have an argument that cannot be found during type-class resolution, and " ++
+"therefore can never succeed. Either mark the arguments with square brackets (if it is a " ++
+"class), or don't make it an instance." }
 
 /-- Checks whether an instance can never be applied. -/
 private meta def incorrect_type_class_argument (d : declaration) : tactic (option string) := do
@@ -184,16 +186,19 @@ private meta def dangerous_instance (d : declaration) : tactic (option string) :
       instance_arguments.any (λ nb, nb.2.local_type.has_local_constant x),
   let bad_arguments : list (ℕ × binder) := bad_arguments.map $ λ ⟨n, e⟩, ⟨n, e.to_binder⟩,
   _ :: _ ← return bad_arguments | return none,
-  (λ s, some $ "The following arguments become metavariables. " ++ s) <$> print_arguments bad_arguments
+  (λ s, some $ "The following arguments become metavariables. " ++ s) <$>
+    print_arguments bad_arguments
 
 /-- A linter object for `dangerous_instance`. -/
 @[linter] meta def linter.dangerous_instance : linter :=
 { test := dangerous_instance,
   no_errors_found := "No dangerous instances.",
-  errors_found := "DANGEROUS INSTANCES FOUND.\nThese instances are recursive, and create a new type-class problem which will have metavariables.
-  Possible solution: remove the instance attribute or make it a local instance instead.
+  errors_found := "DANGEROUS INSTANCES FOUND.\nThese instances are recursive, and create a new " ++
+"type-class problem which will have metavariables.
+Possible solution: remove the instance attribute or make it a local instance instead.
 
-  Currently this linter does not check whether the metavariables only occur in arguments marked with `out_param`, in which case this linter gives a false positive.",
+Currently this linter does not check whether the metavariables only occur in arguments marked " ++
+"with `out_param`, in which case this linter gives a false positive.",
   auto_decls := tt }
 
 /-- Applies expression `e` to local constants, but lifts all the arguments that are `Sort`-valued to
@@ -292,8 +297,9 @@ do tt ← is_prop d.type | return none,
   no_errors_found := "No uses of `inhabited` arguments should be replaced with `nonempty`.",
   errors_found := "USES OF `inhabited` SHOULD BE REPLACED WITH `nonempty`." }
 
-/-- Checks whether a declaration is `Prop`-valued and takes a `decidable* _` hypothesis that is unused
-elsewhere in the type. In this case, that hypothesis can be replaced with `classical` in the proof.
+/-- Checks whether a declaration is `Prop`-valued and takes a `decidable* _`
+hypothesis that is unused lsewhere in the type.
+In this case, that hypothesis can be replaced with `classical` in the proof.
 Theorems in the `decidable` namespace are exempt from the check. -/
 private meta def decidable_classical (d : declaration) : tactic (option string) :=
 do tt ← is_prop d.type | return none,

--- a/src/tactic/lint/type_classes.lean
+++ b/src/tactic/lint/type_classes.lean
@@ -11,20 +11,20 @@ import tactic.lint.basic
 This file defines several linters checking the correct usage of type classes
 and the appropriate definition of instances:
 
- * `instance_priority` ensures that blanket instances have low priority
- * `has_inhabited_instances` checks that every type has an `inhabited` instance
- * `impossible_instance` checks that there are no instances which can never apply
+ * `instance_priority` ensures that blanket instances have low priority.
+ * `has_inhabited_instances` checks that every type has an `inhabited` instance.
+ * `impossible_instance` checks that there are no instances which can never apply.
  * `incorrect_type_class_argument` checks that only type classes are used in
-   instance-implicit arguments
- * `dangerous_instance` checks for instances that generate subproblems with metavariables
- * `fails_quickly` checks that type class resolution finishes quickly
- * `class_structure` checks that every `class` is a structure, i.e. `@[class] def` is forbidden
- * `has_coe_variable` checks that there is no instance of type `has_coe α t`
+   instance-implicit arguments.
+ * `dangerous_instance` checks for instances that generate subproblems with metavariables.
+ * `fails_quickly` checks that type class resolution finishes quickly.
+ * `class_structure` checks that every `class` is a structure, i.e. `@[class] def` is forbidden.
+ * `has_coe_variable` checks that there is no instance of type `has_coe α t`.
  * `inhabited_nonempty` checks whether `[inhabited α]` arguments could be generalized
-   to `[nonempty α]`
+   to `[nonempty α]`.
  * `decidable_classical` checks propositions for `[decidable_... p]` hypotheses that are not used
    in the statement, and could thus be removed by using `classical` in the proof.
- * `linter.has_coe_to_fun` checks whether necessary `has_coe_to_fun` instances are declared
+ * `linter.has_coe_to_fun` checks whether necessary `has_coe_to_fun` instances are declared.
 -/
 
 open tactic
@@ -95,7 +95,7 @@ library_note "lower instance priority"
 This is in the default linter set. -/
 @[linter] meta def linter.instance_priority : linter :=
 { test := instance_priority,
-  no_errors_found := "All instance priorities are good",
+  no_errors_found := "All instance priorities are good.",
   errors_found := "DANGEROUS INSTANCE PRIORITIES.
 The following instances always apply, and therefore should have a priority < 1000.
 If you don't know what priority to choose, use priority 100.
@@ -126,8 +126,8 @@ else
 meta def linter.has_inhabited_instance : linter :=
 { test := has_inhabited_instance,
   auto_decls := ff,
-  no_errors_found := "No types have missing inhabited instances",
-  errors_found := "TYPES ARE MISSING INHABITED INSTANCES",
+  no_errors_found := "No types have missing inhabited instances.",
+  errors_found := "TYPES ARE MISSING INHABITED INSTANCES:",
   is_fast := ff }
 
 attribute [nolint has_inhabited_instance] pempty
@@ -144,9 +144,9 @@ private meta def impossible_instance (d : declaration) : tactic (option string) 
 @[linter] meta def linter.impossible_instance : linter :=
 { test := impossible_instance,
   auto_decls := tt,
-  no_errors_found := "All instances are applicable",
+  no_errors_found := "All instances are applicable.",
   errors_found := "IMPOSSIBLE INSTANCES FOUND.
-These instances have an argument that cannot be found during type-class resolution, and therefore can never succeed. Either mark the arguments with square brackets (if it is a class), or don't make it an instance" }
+These instances have an argument that cannot be found during type-class resolution, and therefore can never succeed. Either mark the arguments with square brackets (if it is a class), or don't make it an instance." }
 
 /-- Checks whether an instance can never be applied. -/
 private meta def incorrect_type_class_argument (d : declaration) : tactic (option string) := do
@@ -167,9 +167,9 @@ private meta def incorrect_type_class_argument (d : declaration) : tactic (optio
 @[linter] meta def linter.incorrect_type_class_argument : linter :=
 { test := incorrect_type_class_argument,
   auto_decls := tt,
-  no_errors_found := "All declarations have correct type-class arguments",
+  no_errors_found := "All declarations have correct type-class arguments.",
   errors_found := "INCORRECT TYPE-CLASS ARGUMENTS.
-Some declarations have non-classes between [square brackets]" }
+Some declarations have non-classes between [square brackets]:" }
 
 /-- Checks whether an instance is dangerous: it creates a new type-class problem with metavariable
 arguments. -/
@@ -189,7 +189,7 @@ private meta def dangerous_instance (d : declaration) : tactic (option string) :
 /-- A linter object for `dangerous_instance`. -/
 @[linter] meta def linter.dangerous_instance : linter :=
 { test := dangerous_instance,
-  no_errors_found := "No dangerous instances",
+  no_errors_found := "No dangerous instances.",
   errors_found := "DANGEROUS INSTANCES FOUND.\nThese instances are recursive, and create a new type-class problem which will have metavariables.
   Possible solution: remove the instance attribute or make it a local instance instead.
 
@@ -230,7 +230,7 @@ meta def fails_quickly (max_steps : ℕ) (d : declaration) : tactic (option stri
 @[linter] meta def linter.fails_quickly : linter :=
 { test := fails_quickly 3000,
   auto_decls := tt,
-  no_errors_found := "No type-class searches timed out",
+  no_errors_found := "No type-class searches timed out.",
   errors_found := "TYPE CLASS SEARCHES TIMED OUT.
 For the following classes, there is an instance that causes a loop, or an excessively long search.",
   is_fast := ff }
@@ -249,8 +249,8 @@ private meta def class_structure (n : name) : tactic (option string) := do
 @[linter] meta def linter.class_structure : linter :=
 { test := λ d, class_structure d.to_name,
   auto_decls := tt,
-  no_errors_found := "All classes are structures",
-  errors_found := "USE OF @[class] def IS DISALLOWED" }
+  no_errors_found := "All classes are structures.",
+  errors_found := "USE OF @[class] def IS DISALLOWED:" }
 
 /--
 Tests whether there is no instance of type `has_coe α t` where `α` is a variable,
@@ -271,7 +271,7 @@ else
 @[linter] meta def linter.has_coe_variable : linter :=
 { test := has_coe_variable,
   auto_decls := tt,
-  no_errors_found := "No invalid `has_coe` instances",
+  no_errors_found := "No invalid `has_coe` instances.",
   errors_found := "INVALID `has_coe` INSTANCES.
 Make the following declarations instances of the class `has_coe_t` instead of `has_coe`." }
 
@@ -289,7 +289,7 @@ do tt ← is_prop d.type | return none,
 @[linter] meta def linter.inhabited_nonempty : linter :=
 { test := inhabited_nonempty,
   auto_decls := ff,
-  no_errors_found := "No uses of `inhabited` arguments should be replaced with `nonempty`",
+  no_errors_found := "No uses of `inhabited` arguments should be replaced with `nonempty`.",
   errors_found := "USES OF `inhabited` SHOULD BE REPLACED WITH `nonempty`." }
 
 /-- Checks whether a declaration is `Prop`-valued and takes a `decidable* _` hypothesis that is unused
@@ -311,7 +311,7 @@ do tt ← is_prop d.type | return none,
 @[linter] meta def linter.decidable_classical : linter :=
 { test := decidable_classical,
   auto_decls := ff,
-  no_errors_found := "No uses of `decidable` arguments should be replaced with `classical`",
+  no_errors_found := "No uses of `decidable` arguments should be replaced with `classical`.",
   errors_found := "USES OF `decidable` SHOULD BE REPLACED WITH `classical` IN THE PROOF." }
 
 /- The file `logic/basic.lean` emphasizes the differences between what holds under classical

--- a/test/lint.lean
+++ b/test/lint.lean
@@ -57,8 +57,8 @@ return $ if d.to_name.last = "foo" then some "gotcha!" else none
 meta def linter.dummy_linter : linter :=
 { test := dummy_check,
   auto_decls := ff,
-  no_errors_found := "found nothing",
-  errors_found := "found something" }
+  no_errors_found := "found nothing.",
+  errors_found := "found something:" }
 
 @[nolint dummy_linter]
 def bar.foo : (if 3 = 3 then 1 else 2) = 1 := if_pos (by refl)


### PR DESCRIPTION
Previously, the linter framework would append punctuation (`.` or `:`) to the message provided by the linter, but this was confusing and lead to some double punctuation. Now all linters specify their own punctuation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
