### PR TITLE
[Merged by Bors] - chore(src/testing/slim_check/sampleable): simply add explicit namespace `nat.`

### DIFF
--- a/src/testing/slim_check/sampleable.lean
+++ b/src/testing/slim_check/sampleable.lean
@@ -227,7 +227,7 @@ if h : n ≤ 1
     let m := n / 2 in
     have h₀ : m ≤ k, from le_trans (le_of_lt this) hn,
     have h₃ : 0 < m,
-      by simp only [m, lt_iff_add_one_le, zero_add]; rw [le_div_iff_mul_le]; linarith,
+      by simp only [m, lt_iff_add_one_le, zero_add]; rw [nat.le_div_iff_mul_le]; linarith,
     have h₁ : k - m < k,
       from nat.sub_lt (lt_of_lt_of_le h₂ hn) h₃,
     nat.shrink' m h₀ (⟨k - m, h₁⟩ :: ls)


### PR DESCRIPTION
This PR only introduces the explicit namespace `nat.` when calling `le_div_iff_mul_le`.  The reason for doing this is that PR #7645 introduces a lemma `le_div_iff_mul_le` in the root namespace and this one then becomes ambiguous.  Note that CI *does build* on this branch even without the explicit namespace.  The change would only become necessary once/if PR #7645 gets merged.

I isolated this change to a separate PR to reduce the diff of #7645 and also to bring attention to this issue, in case someone has some comment about it.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
