### PR TITLE
[Merged by Bors] - feat(algebra/big_operators/finsupp): relax assumptions `semiring` to `non_unital_non_assoc_semiring`

### DIFF
--- a/src/algebra/big_operators/finsupp.lean
+++ b/src/algebra/big_operators/finsupp.lean
@@ -39,7 +39,7 @@ by simp_rw [finset.sum_insert has, finsupp.sum_add_index h0 h1, ih]
 end
 
 section
-variables {R S : Type*} [semiring R] [semiring S]
+variables {R S : Type*} [non_unital_non_assoc_semiring R] [non_unital_non_assoc_semiring S]
 
 lemma finsupp.sum_mul (b : S) (s : α →₀ R) {f : α → R → S} :
   (s.sum f) * b = s.sum (λ a c, (f a c) * b) :=


### PR DESCRIPTION
---

I have an application for this but don't want to push until various other PRs are settled first so I think worth getting this out on its own.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
