### PR TITLE
[Merged by Bors] - chore(algebra/{ordered_monoid,linear_ordered_comm_group_with_zero}): remove some uses of @

### DIFF
--- a/src/algebra/linear_ordered_comm_group_with_zero.lean
+++ b/src/algebra/linear_ordered_comm_group_with_zero.lean
@@ -184,8 +184,9 @@ have hb : b ≠ 0 := ne_zero_of_lt hab,
 have hd : d ≠ 0 := ne_zero_of_lt hcd,
 if ha : a = 0 then by { rw [ha, zero_mul, zero_lt_iff], exact mul_ne_zero hb hd } else
 if hc : c = 0 then by { rw [hc, mul_zero, zero_lt_iff], exact mul_ne_zero hb hd } else
-@mul_lt_mul''' _
-  (units.mk0 a ha) (units.mk0 b hb) (units.mk0 c hc) (units.mk0 d hd) _ _ _ _ _ _ hab hcd
+have hab0 : (units.mk0 a ha) < (units.mk0 b hb) := hab,
+have hcd0 : (units.mk0 c hc) < (units.mk0 d hd) := hcd,
+mul_lt_mul''' hab0 hcd0
 
 lemma mul_inv_lt_of_lt_mul' (h : x < y * z) : x * z⁻¹ < y :=
 have hz : z ≠ 0 := (mul_ne_zero_iff.1 $ ne_zero_of_lt h).2,

--- a/src/algebra/linear_ordered_comm_group_with_zero.lean
+++ b/src/algebra/linear_ordered_comm_group_with_zero.lean
@@ -186,7 +186,7 @@ if ha : a = 0 then by { rw [ha, zero_mul, zero_lt_iff], exact mul_ne_zero hb hd 
 if hc : c = 0 then by { rw [hc, mul_zero, zero_lt_iff], exact mul_ne_zero hb hd } else
 have hab0 : (units.mk0 a ha) < (units.mk0 b hb) := hab,
 have hcd0 : (units.mk0 c hc) < (units.mk0 d hd) := hcd,
-mul_lt_mul''' hab0 hcd0
+by apply mul_lt_mul''' hab0 hcd0
 
 lemma mul_inv_lt_of_lt_mul' (h : x < y * z) : x * z⁻¹ < y :=
 have hz : z ≠ 0 := (mul_ne_zero_iff.1 $ ne_zero_of_lt h).2,

--- a/src/algebra/ordered_monoid.lean
+++ b/src/algebra/ordered_monoid.lean
@@ -855,8 +855,10 @@ instance [h : has_mul α] : has_mul (order_dual α) := h
 
 @[to_additive]
 instance [ordered_comm_monoid α] : ordered_comm_monoid (order_dual α) :=
-{ mul_le_mul_left := λ a b h c, @mul_le_mul_left' α _ _ _ _ _ h _,
-  lt_of_mul_lt_mul_left := λ a b c h, @lt_of_mul_lt_mul_left' α a c b _ _ _ h,
+{ mul_le_mul_left := λ a b h c, show (id c : α) * b ≤ c * a, from mul_le_mul_left' h _,
+  lt_of_mul_lt_mul_left := λ a b c h, begin
+    apply lt_of_mul_lt_mul_left' (by convert h : (id a : α) * c < a * b),
+  end,
   ..order_dual.partial_order α,
   ..show comm_monoid α, by apply_instance }
 

--- a/src/algebra/ordered_monoid.lean
+++ b/src/algebra/ordered_monoid.lean
@@ -856,9 +856,8 @@ instance [h : has_mul α] : has_mul (order_dual α) := h
 @[to_additive]
 instance [ordered_comm_monoid α] : ordered_comm_monoid (order_dual α) :=
 { mul_le_mul_left := λ a b h c, show (id c : α) * b ≤ c * a, from mul_le_mul_left' h _,
-  lt_of_mul_lt_mul_left := λ a b c h, begin
+  lt_of_mul_lt_mul_left := λ a b c h, by
     apply lt_of_mul_lt_mul_left' (by convert h : (id a : α) * c < a * b),
-  end,
   ..order_dual.partial_order α,
   ..show comm_monoid α, by apply_instance }
 

--- a/src/algebra/ordered_monoid.lean
+++ b/src/algebra/ordered_monoid.lean
@@ -148,10 +148,10 @@ def function.injective.ordered_comm_monoid [ordered_comm_monoid α] {β : Type*}
   (f : β → α) (hf : function.injective f) (one : f 1 = 1)
   (mul : ∀ x y, f (x * y) = f x * f y) :
   ordered_comm_monoid β :=
-{ mul_le_mul_left := λ a b ab c,
-    show f (c * a) ≤ f (c * b), by simp [mul, @mul_le_mul_left' α _ _ _ _ _ ab _],
+{ mul_le_mul_left := λ a b ab c, show f (c * a) ≤ f (c * b), by
+  { rw [mul, mul], apply mul_le_mul_left', exact ab },
   lt_of_mul_lt_mul_left :=
-    λ a b c bc, @lt_of_mul_lt_mul_left' α (f a) _ _ _ _ _ (by rwa [← mul, ← mul]),
+    λ a b c bc, show f b < f c, from lt_of_mul_lt_mul_left' (by rwa [← mul, ← mul] : (f a) * _ < _),
   ..partial_order.lift f hf,
   ..hf.comm_monoid f one mul }
 


### PR DESCRIPTION
This PR replaces a couple of uses of `@` with slightly more verbose proofs that only use the given explicit arguments.

The `by apply mul_lt_mul''' hab0 hcd0` line also works with `mul_lt_mul''' hab0 hcd0` alone (at least on my machine).  The reason for the slightly more elaborate proof is that once the typeclass assumptions will change, the direct term-mode proof will break, while the `by apply` version is more stable.

Besides its aesthetic value, this is useful in PR #7645, as the typeclass arguments of the involved lemmas will change and this will keep the diff (slightly) shorter.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
