### PR TITLE
[Merged by Bors] - feat(algebra/covariant_and_contravariant): API for covariant_and_contravariant

### DIFF
--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2021 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import algebra.group.defs
+
+/-!
+# Covariants and contravariants
+This file contains general lemmas and instances to work with the interactions between a relation and
+an action on a Type.
+The intended application is the splitting of the ordering from the algebraic assumptions on the
+operations in the `ordered_[...]` hierarchy.
+The strategy is to introduce two more flexible typeclasses, `covariant_class` and
+`contravariant_class`.
+* `covariant_class` models the implication `a ≤ b → c * a ≤ c * b` (multiplication is monotone),
+* `contravariant_class` models the implication `a * b < a * c → b < c`.
+Since `co(ntra)variant_class` takes as input the operation (typically `(+)` or `(*)`) and the order
+relation (typically `(≤)` or `(<)`), these are the only two typeclasses that I have used.
+The general approach is to formulate the lemma that you are interested and prove it, with the
+`ordered_[...]` typeclass of your liking.  After that, you convert the single typeclass,
+say `[ordered_cancel_monoid M]`, with three typeclasses, e.g.
+`[partial_order M] [left_cancel_semigroup M] [covariant_class M M (function.swap (*)) (≤)]`
+and have a go at seeing if the proof still works!
+Note that it is possible to combine several co(ntra)variant_class assumptions together.
+Indeed, the usual ordered typeclasses arise from assuming the pair
+`[covariant_class M M (*) (≤)] [contravariant_class M M (*) (<)]`
+on top of order/algebraic assumptions.
+A formal remark is that normally covariant_class uses the `(≤)`-relation, while contravariant_class
+uses the `(<)`-relation. This need not be the case in general, but seems to be the most common
+usage. In the opposite direction, the implication
+```lean
+[semigroup α] [partial_order α] [contravariant_class α α (*) (≤)] => left_cancel_semigroup α
+```
+holds (note the `co*ntra*` assumption and the `(≤)`-relation).
+# Formalization notes
+We stick to the convention of using `function.swap (*)` (or `function.swap (+)`), for the
+typeclass assumptions, since `function.swap` is slightly better behaved than `flip`.
+However, sometimes as a **non-typeclass** assumption, we prefer `flip (*)` (or `flip (+)`),
+as it is easier to use. -/
+
+-- TODO: convert `has_exists_mul_of_le`, `has_exists_add_of_le`?
+-- TODO: relationship with `add_con`
+-- include equivalence of `left_cancel_semigroup` with
+-- `semigroup partial_order contravariant_class α α (*) (≤)`?
+-- use ⇒, as per Eric's suggestion?
+section variants
+
+variables {M N : Type*} (μ : M → N → N) (r : N → N → Prop)
+
+variables (M N)
+/-- `covariant` is useful to formulate succintly statements about the interactions between an
+action of a Type on another one and a relation on the acted-upon Type.
+See the `covariant_class` doc-string for its meaning. -/
+def covariant     : Prop := ∀ (m) {n₁ n₂}, r n₁ n₂ → r (μ m n₁) (μ m n₂)
+
+/-- `contravariant` is useful to formulate succintly statements about the interactions between an
+action of a Type on another one and a relation on the acted-upon Type.
+See the `contravariant_class` doc-string for its meaning. -/
+def contravariant : Prop := ∀ (m) {n₁ n₂}, r (μ m n₁) (μ m n₂) → r n₁ n₂
+
+/--  Given an action `μ` of a Type `M` on a Type `N` and a relation `r` on `N`, informally, the
+`covariant_class` says that "the action `μ` preserves the relation `r`.
+More precisely, the `covariant_class` is a class taking two Types `M N`, together with an "action"
+`μ : M → N → N` and a relation `r : N → N`.  Its unique field `covc` is the assertion that
+for all `m ∈ M` and all elements `n₁, n₂ ∈ N`, if the relation `r` holds for the pair
+`(n₁, n₂)`, then, the relation `r` also holds for the pair `(μ m n₁, μ m n₂)`,
+obtained from `(n₁, n₂)` by "acting upon it by `m`".
+If `m : M` and `h : r n₁ n₂`, then `covariant_class.covc m h : r (μ m n₁) (μ m n₂)`.
+-/
+class covariant_class : Prop :=
+(covc :  covariant M N μ r)
+
+/--  Given an action `μ` of a Type `M` on a Type `N` and a relation `r` on `N`, informally, the
+`contravariant_class` says that "if the result of the action `μ` on a pair satisfies the
+relation `r`, then the initial pair satisfied the relation `r`.
+More precisely, the `contravariant_class` is a class taking two Types `M N`, together with an
+"action" `μ : M → N → N` and a relation `r : N → N`.  Its unique field `covtc` is the assertion that
+for all `m ∈ M` and all elements `n₁, n₂ ∈ N`, if the relation `r` holds for the pair
+`(μ m n₁, μ m n₂)` obtained from `(n₁, n₂)` by "acting upon it by `m`"", then, the relation `r`
+also holds for the pair `(n₁, n₂)`.
+If `m : M` and `h : r (μ m n₁) (μ m n₂)`, then `contravariant_class.covtc m h : r n₁ n₂`.
+-/
+class contravariant_class : Prop :=
+(covtc : contravariant M N μ r)
+
+lemma rel_iff_cov [covariant_class M N μ r] [contravariant_class M N μ r] (m : M) {a b : N} :
+  r (μ m a) (μ m b) ↔ r a b :=
+⟨contravariant_class.covtc _, covariant_class.covc _⟩
+
+section covariant
+variables {M N μ r} [covariant_class M N μ r]
+
+lemma act_rel_act_of_rel (m : M) {a b : N} (ab : r a b) :
+  r (μ m a) (μ m b) :=
+covariant_class.covc _ ab
+
+lemma group.covariant_iff_contravariant [group N] :
+  covariant N N (*) r ↔ contravariant N N (*) r :=
+begin
+  refine ⟨λ h a b c bc, _, λ h a b c bc, _⟩,
+  { rw [← inv_mul_cancel_left a b, ← inv_mul_cancel_left a c],
+    exact h a⁻¹ bc },
+  { rw [← inv_mul_cancel_left a b, ← inv_mul_cancel_left a c] at bc,
+    exact h a⁻¹ bc }
+end
+
+lemma covconv [group N] [cov : covariant_class N N (*) r] : contravariant_class N N (*) r :=
+{ covtc := λ a b c bc, group.covariant_iff_contravariant.mp cov.covc _ bc }
+
+
+section is_trans
+variables [is_trans N r] (m n : M) {a b c d : N}
+
+/-  Lemmas with 3 elements. -/
+lemma act_rel_of_rel_of_act_rel (ab : r a b) (rl : r (μ m b) c) :
+  r (μ m a) c :=
+trans (act_rel_act_of_rel m ab) rl
+
+lemma rel_act_of_rel_of_rel_act (ab : r a b) (rr : r c (μ m a)) :
+  r c (μ m b) :=
+trans rr (act_rel_act_of_rel _ ab)
+
+end is_trans
+
+end covariant
+
+/-  Lemma with 4 elements. -/
+section M_eq_N
+variables {M N μ r} {mu : N → N → N} [is_trans N r]
+  [covariant_class N N mu r] [covariant_class N N (function.swap mu) r] {a b c d : N}
+
+lemma act_rel_act_of_rel_of_rel (ab : r a b) (cd : r c d) :
+  r (mu a c) (mu b d) :=
+trans (act_rel_act_of_rel c ab : _) (act_rel_act_of_rel b cd)
+
+end M_eq_N
+
+section contravariant
+variables {M N μ r} [contravariant_class M N μ r]
+
+lemma rel_of_act_rel_act (m : M) {a b : N} (ab : r (μ m a) (μ m b)) :
+  r a b :=
+contravariant_class.covtc _ ab
+
+section is_trans
+variables [is_trans N r] (m n : M) {a b c d : N}
+
+/-  Lemmas with 3 elements. -/
+lemma act_rel_of_act_rel_of_rel_act_rel (ab : r (μ m a) b) (rl : r (μ m b) (μ m c)) :
+  r (μ m a) c :=
+trans ab (rel_of_act_rel_act m rl)
+
+lemma rel_act_of_act_rel_act_of_rel_act (ab : r (μ m a) (μ m b)) (rr : r b (μ m c)) :
+  r a (μ m c) :=
+trans (rel_of_act_rel_act m ab) rr
+
+end is_trans
+
+end contravariant
+
+lemma covariant_le_of_covariant_lt [partial_order N] :
+  covariant M N μ (<) → covariant M N μ (≤) :=
+begin
+  refine λ h a b c bc, _,
+  rcases le_iff_eq_or_lt.mp bc with rfl | bc,
+  { exact rfl.le },
+  { exact (h _ bc).le }
+end
+
+lemma contravariant_lt_of_contravariant_le [partial_order N] :
+  contravariant M N μ (≤) → contravariant M N μ (<) :=
+begin
+  refine λ h a b c bc, lt_iff_le_and_ne.mpr ⟨h a bc.le, _⟩,
+  rintro rfl,
+  exact lt_irrefl _ bc,
+end
+
+lemma covariant_le_iff_contravariant_lt [linear_order N] :
+  covariant M N μ (≤) ↔ contravariant M N μ (<) :=
+⟨ λ h a b c bc, not_le.mp (λ k, not_le.mpr bc (h _ k)),
+  λ h a b c bc, not_lt.mp (λ k, not_lt.mpr bc (h _ k))⟩
+
+lemma covariant_lt_iff_contravariant_le [linear_order N] :
+  covariant M N μ (<) ↔ contravariant M N μ (≤) :=
+⟨ λ h a b c bc, not_lt.mp (λ k, not_lt.mpr bc (h _ k)),
+  λ h a b c bc, not_le.mp (λ k, not_le.mpr bc (h _ k))⟩
+
+@[to_additive]
+lemma covariant_iff_covariant_mul [comm_semigroup N] :
+  covariant N N (*) (r) ↔ covariant N N (flip (*)) (r) :=
+by rw is_symm_op.flip_eq
+
+@[to_additive]
+lemma contravariant_mul_iff_flip [comm_semigroup N] :
+  contravariant N N (*) (r) ↔ contravariant N N (flip (*)) (r) :=
+by rw is_symm_op.flip_eq
+
+@[to_additive]
+instance covariant_mul_le.to_contravariant_lt_mul [has_mul N] [linear_order N]
+  [covariant_class N N (*) (≤)] : contravariant_class N N (*) (<) :=
+{ covtc := (covariant_le_iff_contravariant_lt N N (*)).mp covariant_class.covc }
+
+@[to_additive]
+instance covariant_mul_le_left.to_covariant_mul_le_right [comm_semigroup N] [has_le N]
+  [covariant_class N N (*) (≤)] : covariant_class N N (function.swap (*)) (≤) :=
+{ covc := (covariant_iff_covariant_mul N (≤)).mp covariant_class.covc }
+
+@[to_additive]
+instance covariant_mul_lt_left.to_covariant_mul_lt_right [comm_semigroup N] [has_lt N]
+  [covariant_class N N (*) (<)] : covariant_class N N (function.swap (*)) (<) :=
+{ covc := (covariant_iff_covariant_mul N (<)).mp covariant_class.covc }
+
+@[to_additive]
+instance left_cancel_semigroup.to_covariant_mul_le_left [left_cancel_semigroup N] [partial_order N]
+  [covariant_class N N (*) (≤)] :
+  covariant_class N N (*) (<) :=
+{ covc := λ a b c bc, by { cases lt_iff_le_and_ne.mp bc with bc cb,
+    exact lt_iff_le_and_ne.mpr ⟨covariant_class.covc a bc, (mul_ne_mul_right a).mpr cb⟩ } }
+
+@[to_additive]
+instance right_cancel_semigroup.to_covariant_mul_le_right [right_cancel_semigroup N]
+  [partial_order N] [covariant_class N N (function.swap (*)) (≤)] :
+  covariant_class N N (function.swap (*)) (<) :=
+{ covc := λ a b c bc, by { cases lt_iff_le_and_ne.mp bc with bc cb,
+    exact lt_iff_le_and_ne.mpr ⟨covariant_class.covc a bc, (mul_ne_mul_left a).mpr cb⟩ } }
+
+@[to_additive]
+instance left_cancel_semigroup.to_contravariant_mul_lt [left_cancel_semigroup N] [partial_order N]
+  [contravariant_class N N (*) (<)] :
+  contravariant_class N N (*) (≤) :=
+{ covtc :=  λ  a b c bc, by { cases le_iff_eq_or_lt.mp bc with h h,
+      { exact ((mul_right_inj a).mp h).le },
+      { exact (contravariant_class.covtc _ h).le } } }
+
+@[to_additive]
+instance right_cancel_semigroup.to_contravariant_mul_lt {α : Type*} [right_cancel_semigroup α]
+  [partial_order α] [contravariant_class α α (function.swap (*)) (<)] :
+  contravariant_class α α (function.swap (*)) (≤) :=
+{ covtc :=  λ a b c bc, by { cases le_iff_eq_or_lt.mp bc with h h,
+      { exact ((mul_left_inj a).mp h).le },
+      { exact (contravariant_class.covtc _ h).le } } }
+
+end variants

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -121,7 +121,7 @@ begin
     exact h a⁻¹ bc }
 end
 
-lemma elimonv [group N] [cov : covariant_class N N (*) r] : contravariant_class N N (*) r :=
+lemma covconv [group N] [cov : covariant_class N N (*) r] : contravariant_class N N (*) r :=
 { elim := λ a b c bc, group.covariant_iff_contravariant.mp cov.elim _ bc }
 
 

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -203,8 +203,8 @@ lemma covariant_lt_iff_contravariant_le [linear_order N] :
   λ h a b c bc, not_le.mp (λ k, not_le.mpr bc (h _ k))⟩
 
 @[to_additive]
-lemma covariant_iff_covariant_mul [comm_semigroup N] :
-  covariant N N (*) (r) ↔ covariant N N (flip (*)) (r) :=
+lemma covariant_flip_mul_iff [comm_semigroup N] :
+  covariant N N (flip (*)) (r) ↔ covariant N N (*) (r)  :=
 by rw is_symm_op.flip_eq
 
 @[to_additive]
@@ -220,12 +220,12 @@ instance covariant_mul_le.to_contravariant_lt_mul [has_mul N] [linear_order N]
 @[to_additive]
 instance covariant_mul_le_left.to_covariant_mul_le_right [comm_semigroup N] [has_le N]
   [covariant_class N N (*) (≤)] : covariant_class N N (function.swap (*)) (≤) :=
-{ covc := (covariant_iff_covariant_mul N (≤)).mp covariant_class.covc }
+{ covc := (covariant_flip_mul_iff N (≤)).mpr covariant_class.covc }
 
 @[to_additive]
 instance covariant_mul_lt_left.to_covariant_mul_lt_right [comm_semigroup N] [has_lt N]
   [covariant_class N N (*) (<)] : covariant_class N N (function.swap (*)) (<) :=
-{ covc := (covariant_iff_covariant_mul N (<)).mp covariant_class.covc }
+{ covc := (covariant_flip_mul_iff N (<)).mpr covariant_class.covc }
 
 @[to_additive]
 instance left_cancel_semigroup.to_covariant_mul_le_left [left_cancel_semigroup N] [partial_order N]

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -208,8 +208,8 @@ lemma covariant_flip_mul_iff [comm_semigroup N] :
 by rw is_symm_op.flip_eq
 
 @[to_additive]
-lemma contravariant_mul_iff_flip [comm_semigroup N] :
-  contravariant N N (*) (r) ↔ contravariant N N (flip (*)) (r) :=
+lemma contravariant_flip_mul_iff [comm_semigroup N] :
+  contravariant N N (flip (*)) (r) ↔ contravariant N N (*) (r) :=
 by rw is_symm_op.flip_eq
 
 @[to_additive]

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2021 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import algebra.group.defs
+
+/-!
+# Covariants and contravariants
+This file contains general lemmas and instances to work with the interactions between a relation and
+an action on a Type.
+The intended application is the splitting of the ordering from the algebraic assumptions on the
+operations in the `ordered_[...]` hierarchy.
+The strategy is to introduce two more flexible typeclasses, `covariant_class` and
+`contravariant_class`.
+* `covariant_class` models the implication `a ≤ b → c * a ≤ c * b` (multiplication is monotone),
+* `contravariant_class` models the implication `a * b < a * c → b < c`.
+Since `co(ntra)variant_class` takes as input the operation (typically `(+)` or `(*)`) and the order
+relation (typically `(≤)` or `(<)`), these are the only two typeclasses that I have used.
+The general approach is to formulate the lemma that you are interested and prove it, with the
+`ordered_[...]` typeclass of your liking.  After that, you convert the single typeclass,
+say `[ordered_cancel_monoid M]`, with three typeclasses, e.g.
+`[partial_order M] [left_cancel_semigroup M] [covariant_class M M (function.swap (*)) (≤)]`
+and have a go at seeing if the proof still works!
+Note that it is possible to combine several co(ntra)variant_class assumptions together.
+Indeed, the usual ordered typeclasses arise from assuming the pair
+`[covariant_class M M (*) (≤)] [contravariant_class M M (*) (<)]`
+on top of order/algebraic assumptions.
+A formal remark is that normally covariant_class uses the `(≤)`-relation, while contravariant_class
+uses the `(<)`-relation. This need not be the case in general, but seems to be the most common
+usage. In the opposite direction, the implication
+```lean
+[semigroup α] [partial_order α] [contravariant_class α α (*) (≤)] => left_cancel_semigroup α
+```
+holds (note the `co*ntra*` assumption and the `(≤)`-relation).
+# Formalization notes
+We stick to the convention of using `function.swap (*)` (or `function.swap (+)`), for the
+typeclass assumptions, since `function.swap` is slightly better behaved than `flip`.
+However, sometimes as a **non-typeclass** assumption, we prefer `flip (*)` (or `flip (+)`),
+as it is easier to use. -/
+
+-- TODO: convert `has_exists_mul_of_le`, `has_exists_add_of_le`?
+-- TODO: relationship with `add_con`
+-- include equivalence of `left_cancel_semigroup` with
+-- `semigroup partial_order contravariant_class α α (*) (≤)`?
+-- use ⇒, as per Eric's suggestion?
+
+section variants
+
+variables {M N : Type*} (μ : M → N → N) (r s : N → N → Prop) (m : M) {a b c : N}
+
+
+variables (M N)
+/-- `covariant` is useful to formulate succintly statements about the interactions between an
+action of a Type on another one and a relation on the acted-upon Type.
+
+See the `covariant_class` doc-string for its meaning. -/
+def covariant     : Prop := ∀ (m) {n₁ n₂}, r n₁ n₂ → r (μ m n₁) (μ m n₂)
+
+/-- `contravariant` is useful to formulate succintly statements about the interactions between an
+action of a Type on another one and a relation on the acted-upon Type.
+
+See the `contravariant_class` doc-string for its meaning. -/
+def contravariant : Prop := ∀ (m) {n₁ n₂}, s (μ m n₁) (μ m n₂) → s n₁ n₂
+
+/--  Given an action `μ` of a Type `M` on a Type `N` and a relation `r` on `N`, informally, the
+`covariant_class` says that "the action `μ` preserves the relation `r`.
+
+More precisely, the `covariant_class` is a class taking two Types `M N`, together with an "action"
+`μ : M → N → N` and a relation `r : N → N`.  Its unique field `covc` is the assertion that
+for all `m ∈ M` and all elements `n₁, n₂ ∈ N`, if the relation `r` holds for the pair
+`(n₁, n₂)`, then, the relation `r` also holds for the pair `(μ m n₁, μ m n₂)`,
+obtained from `(n₁, n₂)` by "acting upon it by `m`".
+
+If `m : M` and `h : r n₁ n₂`, then `covariant_class.covc m h : r (μ m n₁) (μ m n₂)`.
+-/
+class covariant_class :=
+(covc :  covariant M N μ r)
+
+/--  Given an action `μ` of a Type `M` on a Type `N` and a relation `r` on `N`, informally, the
+`contravariant_class` says that "if the result of the action `μ` on a pair satisfies the
+relation `r`, then the initial pair satisfied the relation `r`.
+
+More precisely, the `contravariant_class` is a class taking two Types `M N`, together with an
+"action" `μ : M → N → N` and a relation `r : N → N`.  Its unique field `covtc` is the assertion that
+for all `m ∈ M` and all elements `n₁, n₂ ∈ N`, if the relation `r` holds for the pair
+`(μ m n₁, μ m n₂)` obtained from `(n₁, n₂)` by "acting upon it by `m`"", then, the relation `r`
+also holds for the pair `(n₁, n₂)`.
+
+If `m : M` and `h : r (μ m n₁) (μ m n₂)`, then `covariant_class.covc m h : r n₁ n₂`.
+-/
+class contravariant_class :=
+(covtc : contravariant M N μ s)
+
+end variants

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -213,17 +213,17 @@ lemma contravariant_flip_mul_iff [comm_semigroup N] :
 by rw is_symm_op.flip_eq
 
 @[to_additive]
-instance covariant_mul_le.to_contravariant_lt_mul [has_mul N] [linear_order N]
+instance contravariant_mul_lt_of_covariant_mul_le [has_mul N] [linear_order N]
   [covariant_class N N (*) (≤)] : contravariant_class N N (*) (<) :=
 { covtc := (covariant_le_iff_contravariant_lt N N (*)).mp covariant_class.covc }
 
 @[to_additive]
-instance covariant_mul_le_left.to_covariant_mul_le_right [comm_semigroup N] [has_le N]
+instance covariant_swap_mul_le_of_covariant_mul_le [comm_semigroup N] [has_le N]
   [covariant_class N N (*) (≤)] : covariant_class N N (function.swap (*)) (≤) :=
 { covc := (covariant_flip_mul_iff N (≤)).mpr covariant_class.covc }
 
 @[to_additive]
-instance covariant_mul_lt_left.to_covariant_mul_lt_right [comm_semigroup N] [has_lt N]
+instance covariant_swap_mul_lt_of_covariant_mul_lt [comm_semigroup N] [has_lt N]
   [covariant_class N N (*) (<)] : covariant_class N N (function.swap (*)) (<) :=
 { covc := (covariant_flip_mul_iff N (<)).mpr covariant_class.covc }
 

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -228,31 +228,31 @@ instance covariant_swap_mul_lt_of_covariant_mul_lt [comm_semigroup N] [has_lt N]
 { covc := (covariant_flip_mul_iff N (<)).mpr covariant_class.covc }
 
 @[to_additive]
-instance left_cancel_semigroup.to_covariant_mul_le_left [left_cancel_semigroup N] [partial_order N]
-  [covariant_class N N (*) (≤)] :
+instance left_cancel_semigroup.covariant_mul_lt_of_covariant_mul_le
+  [left_cancel_semigroup N] [partial_order N] [covariant_class N N (*) (≤)] :
   covariant_class N N (*) (<) :=
 { covc := λ a b c bc, by { cases lt_iff_le_and_ne.mp bc with bc cb,
     exact lt_iff_le_and_ne.mpr ⟨covariant_class.covc a bc, (mul_ne_mul_right a).mpr cb⟩ } }
 
 @[to_additive]
-instance right_cancel_semigroup.to_covariant_mul_le_right [right_cancel_semigroup N]
-  [partial_order N] [covariant_class N N (function.swap (*)) (≤)] :
+instance right_cancel_semigroup.covariant_swap_mul_lt_of_covariant_swap_mul_le
+  [right_cancel_semigroup N] [partial_order N] [covariant_class N N (function.swap (*)) (≤)] :
   covariant_class N N (function.swap (*)) (<) :=
 { covc := λ a b c bc, by { cases lt_iff_le_and_ne.mp bc with bc cb,
     exact lt_iff_le_and_ne.mpr ⟨covariant_class.covc a bc, (mul_ne_mul_left a).mpr cb⟩ } }
 
 @[to_additive]
-instance left_cancel_semigroup.to_contravariant_mul_lt [left_cancel_semigroup N] [partial_order N]
-  [contravariant_class N N (*) (<)] :
+instance left_cancel_semigroup.contravariant_mul_le_of_contravariant_mul_lt
+  [left_cancel_semigroup N] [partial_order N] [contravariant_class N N (*) (<)] :
   contravariant_class N N (*) (≤) :=
 { covtc :=  λ  a b c bc, by { cases le_iff_eq_or_lt.mp bc with h h,
       { exact ((mul_right_inj a).mp h).le },
       { exact (contravariant_class.covtc _ h).le } } }
 
 @[to_additive]
-instance right_cancel_semigroup.to_contravariant_mul_lt {α : Type*} [right_cancel_semigroup α]
-  [partial_order α] [contravariant_class α α (function.swap (*)) (<)] :
-  contravariant_class α α (function.swap (*)) (≤) :=
+instance right_cancel_semigroup.contravariant_swap_mul_le_of_contravariant_swap_mul_lt
+  [right_cancel_semigroup N] [partial_order N] [contravariant_class N N (function.swap (*)) (<)] :
+  contravariant_class N N (function.swap (*)) (≤) :=
 { covtc :=  λ a b c bc, by { cases le_iff_eq_or_lt.mp bc with h h,
       { exact ((mul_left_inj a).mp h).le },
       { exact (contravariant_class.covtc _ h).le } } }

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -75,15 +75,15 @@ def contravariant : Prop := ∀ (m) {n₁ n₂}, r (μ m n₁) (μ m n₂) → r
 /--  Given an action `μ` of a Type `M` on a Type `N` and a relation `r` on `N`, informally, the
 `covariant_class` says that "the action `μ` preserves the relation `r`.
 More precisely, the `covariant_class` is a class taking two Types `M N`, together with an "action"
-`μ : M → N → N` and a relation `r : N → N`.  Its unique field `covc` is the assertion that
+`μ : M → N → N` and a relation `r : N → N`.  Its unique field `elim` is the assertion that
 for all `m ∈ M` and all elements `n₁, n₂ ∈ N`, if the relation `r` holds for the pair
 `(n₁, n₂)`, then, the relation `r` also holds for the pair `(μ m n₁, μ m n₂)`,
 obtained from `(n₁, n₂)` by "acting upon it by `m`".
 
-If `m : M` and `h : r n₁ n₂`, then `covariant_class.covc m h : r (μ m n₁) (μ m n₂)`.
+If `m : M` and `h : r n₁ n₂`, then `covariant_class.elim m h : r (μ m n₁) (μ m n₂)`.
 -/
-class covariant_class : Prop :=
-(covc :  covariant M N μ r)
+@[protect_proj] class covariant_class : Prop :=
+(elim :  covariant M N μ r)
 
 /--  Given an action `μ` of a Type `M` on a Type `N` and a relation `r` on `N`, informally, the
 `contravariant_class` says that "if the result of the action `μ` on a pair satisfies the
@@ -102,14 +102,14 @@ If `m : M` and `h : r (μ m n₁) (μ m n₂)`, then `contravariant_class.elim m
 
 lemma rel_iff_cov [covariant_class M N μ r] [contravariant_class M N μ r] (m : M) {a b : N} :
   r (μ m a) (μ m b) ↔ r a b :=
-⟨contravariant_class.elim _, covariant_class.covc _⟩
+⟨contravariant_class.elim _, covariant_class.elim _⟩
 
 section covariant
 variables {M N μ r} [covariant_class M N μ r]
 
 lemma act_rel_act_of_rel (m : M) {a b : N} (ab : r a b) :
   r (μ m a) (μ m b) :=
-covariant_class.covc _ ab
+covariant_class.elim _ ab
 
 lemma group.covariant_iff_contravariant [group N] :
   covariant N N (*) r ↔ contravariant N N (*) r :=
@@ -121,8 +121,8 @@ begin
     exact h a⁻¹ bc }
 end
 
-lemma covconv [group N] [cov : covariant_class N N (*) r] : contravariant_class N N (*) r :=
-{ elim := λ a b c bc, group.covariant_iff_contravariant.mp cov.covc _ bc }
+lemma elimonv [group N] [cov : covariant_class N N (*) r] : contravariant_class N N (*) r :=
+{ elim := λ a b c bc, group.covariant_iff_contravariant.mp cov.elim _ bc }
 
 
 section is_trans
@@ -215,31 +215,31 @@ by rw is_symm_op.flip_eq
 @[to_additive]
 instance contravariant_mul_lt_of_covariant_mul_le [has_mul N] [linear_order N]
   [covariant_class N N (*) (≤)] : contravariant_class N N (*) (<) :=
-{ elim := (covariant_le_iff_contravariant_lt N N (*)).mp covariant_class.covc }
+{ elim := (covariant_le_iff_contravariant_lt N N (*)).mp covariant_class.elim }
 
 @[to_additive]
 instance covariant_swap_mul_le_of_covariant_mul_le [comm_semigroup N] [has_le N]
   [covariant_class N N (*) (≤)] : covariant_class N N (function.swap (*)) (≤) :=
-{ covc := (covariant_flip_mul_iff N (≤)).mpr covariant_class.covc }
+{ elim := (covariant_flip_mul_iff N (≤)).mpr covariant_class.elim }
 
 @[to_additive]
 instance covariant_swap_mul_lt_of_covariant_mul_lt [comm_semigroup N] [has_lt N]
   [covariant_class N N (*) (<)] : covariant_class N N (function.swap (*)) (<) :=
-{ covc := (covariant_flip_mul_iff N (<)).mpr covariant_class.covc }
+{ elim := (covariant_flip_mul_iff N (<)).mpr covariant_class.elim }
 
 @[to_additive]
 instance left_cancel_semigroup.covariant_mul_lt_of_covariant_mul_le
   [left_cancel_semigroup N] [partial_order N] [covariant_class N N (*) (≤)] :
   covariant_class N N (*) (<) :=
-{ covc := λ a b c bc, by { cases lt_iff_le_and_ne.mp bc with bc cb,
-    exact lt_iff_le_and_ne.mpr ⟨covariant_class.covc a bc, (mul_ne_mul_right a).mpr cb⟩ } }
+{ elim := λ a b c bc, by { cases lt_iff_le_and_ne.mp bc with bc cb,
+    exact lt_iff_le_and_ne.mpr ⟨covariant_class.elim a bc, (mul_ne_mul_right a).mpr cb⟩ } }
 
 @[to_additive]
 instance right_cancel_semigroup.covariant_swap_mul_lt_of_covariant_swap_mul_le
   [right_cancel_semigroup N] [partial_order N] [covariant_class N N (function.swap (*)) (≤)] :
   covariant_class N N (function.swap (*)) (<) :=
-{ covc := λ a b c bc, by { cases lt_iff_le_and_ne.mp bc with bc cb,
-    exact lt_iff_le_and_ne.mpr ⟨covariant_class.covc a bc, (mul_ne_mul_left a).mpr cb⟩ } }
+{ elim := λ a b c bc, by { cases lt_iff_le_and_ne.mp bc with bc cb,
+    exact lt_iff_le_and_ne.mpr ⟨covariant_class.elim a bc, (mul_ne_mul_left a).mpr cb⟩ } }
 
 @[to_additive]
 instance left_cancel_semigroup.contravariant_mul_le_of_contravariant_mul_lt

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -90,19 +90,19 @@ class covariant_class : Prop :=
 relation `r`, then the initial pair satisfied the relation `r`.
 
 More precisely, the `contravariant_class` is a class taking two Types `M N`, together with an
-"action" `μ : M → N → N` and a relation `r : N → N`.  Its unique field `covtc` is the assertion that
+"action" `μ : M → N → N` and a relation `r : N → N`.  Its unique field `elim` is the assertion that
 for all `m ∈ M` and all elements `n₁, n₂ ∈ N`, if the relation `r` holds for the pair
 `(μ m n₁, μ m n₂)` obtained from `(n₁, n₂)` by "acting upon it by `m`"", then, the relation `r`
 also holds for the pair `(n₁, n₂)`.
 
-If `m : M` and `h : r (μ m n₁) (μ m n₂)`, then `contravariant_class.covtc m h : r n₁ n₂`.
+If `m : M` and `h : r (μ m n₁) (μ m n₂)`, then `contravariant_class.elim m h : r n₁ n₂`.
 -/
-class contravariant_class : Prop :=
-(covtc : contravariant M N μ r)
+@[protect_proj] class contravariant_class : Prop :=
+(elim : contravariant M N μ r)
 
 lemma rel_iff_cov [covariant_class M N μ r] [contravariant_class M N μ r] (m : M) {a b : N} :
   r (μ m a) (μ m b) ↔ r a b :=
-⟨contravariant_class.covtc _, covariant_class.covc _⟩
+⟨contravariant_class.elim _, covariant_class.covc _⟩
 
 section covariant
 variables {M N μ r} [covariant_class M N μ r]
@@ -122,7 +122,7 @@ begin
 end
 
 lemma covconv [group N] [cov : covariant_class N N (*) r] : contravariant_class N N (*) r :=
-{ covtc := λ a b c bc, group.covariant_iff_contravariant.mp cov.covc _ bc }
+{ elim := λ a b c bc, group.covariant_iff_contravariant.mp cov.covc _ bc }
 
 
 section is_trans
@@ -157,7 +157,7 @@ variables {M N μ r} [contravariant_class M N μ r]
 
 lemma rel_of_act_rel_act (m : M) {a b : N} (ab : r (μ m a) (μ m b)) :
   r a b :=
-contravariant_class.covtc _ ab
+contravariant_class.elim _ ab
 
 section is_trans
 variables [is_trans N r] (m n : M) {a b c d : N}
@@ -215,7 +215,7 @@ by rw is_symm_op.flip_eq
 @[to_additive]
 instance contravariant_mul_lt_of_covariant_mul_le [has_mul N] [linear_order N]
   [covariant_class N N (*) (≤)] : contravariant_class N N (*) (<) :=
-{ covtc := (covariant_le_iff_contravariant_lt N N (*)).mp covariant_class.covc }
+{ elim := (covariant_le_iff_contravariant_lt N N (*)).mp covariant_class.covc }
 
 @[to_additive]
 instance covariant_swap_mul_le_of_covariant_mul_le [comm_semigroup N] [has_le N]
@@ -245,16 +245,16 @@ instance right_cancel_semigroup.covariant_swap_mul_lt_of_covariant_swap_mul_le
 instance left_cancel_semigroup.contravariant_mul_le_of_contravariant_mul_lt
   [left_cancel_semigroup N] [partial_order N] [contravariant_class N N (*) (<)] :
   contravariant_class N N (*) (≤) :=
-{ covtc :=  λ  a b c bc, by { cases le_iff_eq_or_lt.mp bc with h h,
+{ elim :=  λ  a b c bc, by { cases le_iff_eq_or_lt.mp bc with h h,
       { exact ((mul_right_inj a).mp h).le },
-      { exact (contravariant_class.covtc _ h).le } } }
+      { exact (contravariant_class.elim _ h).le } } }
 
 @[to_additive]
 instance right_cancel_semigroup.contravariant_swap_mul_le_of_contravariant_swap_mul_lt
   [right_cancel_semigroup N] [partial_order N] [contravariant_class N N (function.swap (*)) (<)] :
   contravariant_class N N (function.swap (*)) (≤) :=
-{ covtc :=  λ a b c bc, by { cases le_iff_eq_or_lt.mp bc with h h,
+{ elim :=  λ a b c bc, by { cases le_iff_eq_or_lt.mp bc with h h,
       { exact ((mul_left_inj a).mp h).le },
-      { exact (contravariant_class.covtc _ h).le } } }
+      { exact (contravariant_class.elim _ h).le } } }
 
 end variants

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -39,7 +39,7 @@ attribute [to_additive] ordered_comm_group
 @[to_additive]
 instance units.covariant_class [ordered_comm_monoid α] :
   covariant_class (units α) (units α) (*) (≤) :=
-{ covc := λ a b c bc, by {
+{ elim := λ a b c bc, by {
   rcases le_iff_eq_or_lt.mp bc with ⟨rfl, h⟩,
   { exact rfl.le },
   refine le_iff_eq_or_lt.mpr (or.inr _),

--- a/src/algebra/ordered_monoid.lean
+++ b/src/algebra/ordered_monoid.lean
@@ -54,12 +54,12 @@ section ordered_instances
 @[to_additive]
 instance ordered_comm_monoid.to_covariant_class_left (M : Type*) [ordered_comm_monoid M] :
   covariant_class M M (*) (≤) :=
-{ covc := λ a b c bc, ordered_comm_monoid.mul_le_mul_left _ _ bc a }
+{ elim := λ a b c bc, ordered_comm_monoid.mul_le_mul_left _ _ bc a }
 
 @[to_additive]
 instance ordered_comm_monoid.to_covariant_class_right (M : Type*) [ordered_comm_monoid M] :
   covariant_class M M (function.swap (*)) (≤) :=
-{ covc := λ a b c bc,
+{ elim := λ a b c bc,
     by { convert ordered_comm_monoid.mul_le_mul_left _ _ bc a; simp_rw mul_comm } }
 
 @[to_additive]
@@ -247,7 +247,7 @@ begin
   { exact false.elim (not_lt_of_le h (with_zero.zero_lt_coe a))},
   { simp_rw [some_eq_coe] at h ⊢,
     norm_cast at h ⊢,
-    exact covariant_class.covc _ h }
+    exact covariant_class.elim _ h }
 end
 
 lemma lt_of_mul_lt_mul_left  {α : Type u} [has_mul α] [partial_order α]

--- a/src/algebra/ordered_monoid.lean
+++ b/src/algebra/ordered_monoid.lean
@@ -65,12 +65,12 @@ instance ordered_comm_monoid.to_covariant_class_right (M : Type*) [ordered_comm_
 @[to_additive]
 instance ordered_comm_monoid.to_contravariant_class_left (M : Type*) [ordered_comm_monoid M] :
   contravariant_class M M (*) (<) :=
-{ covtc := λ a b c bc, ordered_comm_monoid.lt_of_mul_lt_mul_left _ _ _ bc }
+{ elim := λ a b c bc, ordered_comm_monoid.lt_of_mul_lt_mul_left _ _ _ bc }
 
 @[to_additive]
 instance ordered_comm_monoid.to_contravariant_class_right (M : Type*) [ordered_comm_monoid M] :
   contravariant_class M M (function.swap (*)) (<) :=
-{ covtc := λ a b c (bc : b * a < c * a), by { rw [mul_comm _ a, mul_comm _ a] at bc,
+{ elim := λ a b c (bc : b * a < c * a), by { rw [mul_comm _ a, mul_comm _ a] at bc,
     exact ordered_comm_monoid.lt_of_mul_lt_mul_left _ _ _ bc } }
 
 end ordered_instances

--- a/src/algebra/ordered_monoid_lemmas.lean
+++ b/src/algebra/ordered_monoid_lemmas.lean
@@ -3,93 +3,23 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl, Damiano Testa
 -/
-import algebra.group.defs
+import algebra.covariant_and_contravariant
 import order.basic
+
 /-!
-This file begins the splitting of the ordering assumptions from the algebraic assumptions on the
-operations in the `ordered_[...]` hierarchy.
-
-The strategy is to introduce two more flexible typeclasses, covariant_class and contravariant_class.
-
-* covariant_class models the implication a ≤ b → c * a ≤ c * b (multiplication is monotone),
-* contravariant_class models the implication a * b < a * c → b < c.
-
-Since `co(ntra)variant_class` takes as input the operation (typically `(+)` or `(*)`) and the order
-relation (typically `(≤)` or `(<)`), these are the only two typeclasses that I have used.
-
-The general approach is to formulate the lemma that you are interested and prove it, with the
-`ordered_[...]` typeclass of your liking.  After that, you convert the single typeclass,
-say `[ordered_cancel_monoid M]`, with three typeclasses, e.g.
-`[partial_order M] [left_cancel_semigroup M] [covariant_class M M (function.swap (*)) (≤)]`
-and have a go at seeing if the proof still works!
-
-Note that it is possible to combine several co(ntra)variant_class assumptions together.
-Indeed, the usual ordered typeclasses arise from assuming the pair
-`[covariant_class M M (*) (≤)] [contravariant_class M M (*) (<)]`
-on top of order/algebraic assumptions.
-
-A formal remark is that normally covariant_class uses the `(≤)`-relation, while contravariant_class
-uses the `(<)`-relation. This need not be the case in general, but seems to be the most common
-usage. In the opposite direction, the implication
-
-```lean
-[semigroup α] [partial_order α] [contravariant_class α α (*) (≤)] => left_cancel_semigroup α
-```
-holds (note the `co*ntra*` assumption and the `(≤)`-relation).
+# Ordered monoids
+This file develops the basics of ordered monoids.
+## Implementation details
+Unfortunately, the number of `'` appended to lemmas in this file
+may differ between the multiplicative and the additive version of a lemma.
+The reason is that we did not want to change existing names in the library.
+## Remark
+No monoid is actually present in this file: all assumptions have been generalized to `has_mul` or
+`mul_one_class`.
 -/
--- TODO: convert `has_exists_mul_of_le`, `has_exists_add_of_le`?
--- TODO: relationship with add_con
--- include equivalence of `left_cancel_semigroup` with
--- `semigroup partial_order contravariant_class α α (*) (≤)`?
--- use ⇒, as per Eric's suggestion?
-section variants
 
-variables {M N : Type*} (μ : M → N → N) (r s : N → N → Prop) (m : M) {a b c : N}
-
-
-variables (M N)
-/-- `covariant` is useful to formulate succintly statements about the interactions between an
-action of a Type on another one and a relation on the acted-upon Type.
-
-See the `covariant_class` doc-string for its meaning. -/
-def covariant     : Prop := ∀ (m) {n₁ n₂}, r n₁ n₂ → r (μ m n₁) (μ m n₂)
-
-/-- `contravariant` is useful to formulate succintly statements about the interactions between an
-action of a Type on another one and a relation on the acted-upon Type.
-
-See the `contravariant_class` doc-string for its meaning. -/
-def contravariant : Prop := ∀ (m) {n₁ n₂}, s (μ m n₁) (μ m n₂) → s n₁ n₂
-
-/--  Given an action `μ` of a Type `M` on a Type `N` and a relation `r` on `N`, informally, the
-`covariant_class` says that "the action `μ` preserves the relation `r`.
-
-More precisely, the `covariant_class` is a class taking two Types `M N`, together with an "action"
-`μ : M → N → N` and a relation `r : N → N`.  Its unique field `covc` is the assertion that
-for all `m ∈ M` and all elements `n₁, n₂ ∈ N`, if the relation `r` holds for the pair
-`(n₁, n₂)`, then, the relation `r` also holds for the pair `(μ m n₁, μ m n₂)`,
-obtained from `(n₁, n₂)` by "acting upon it by `m`".
-
-If `m : M` and `h : r n₁ n₂`, then `covariant_class.covc m h : r (μ m n₁) (μ m n₂)`.
--/
-class covariant_class :=
-(covc :  covariant M N μ r)
-
-/--  Given an action `μ` of a Type `M` on a Type `N` and a relation `r` on `N`, informally, the
-`contravariant_class` says that "if the result of the action `μ` on a pair satisfies the
-relation `r`, then the initial pair satisfied the relation `r`.
-
-More precisely, the `contravariant_class` is a class taking two Types `M N`, together with an
-"action" `μ : M → N → N` and a relation `r : N → N`.  Its unique field `covtc` is the assertion that
-for all `m ∈ M` and all elements `n₁, n₂ ∈ N`, if the relation `r` holds for the pair
-`(μ m n₁, μ m n₂)` obtained from `(n₁, n₂)` by "acting upon it by `m`"", then, the relation `r`
-also holds for the pair `(n₁, n₂)`.
-
-If `m : M` and `h : r (μ m n₁) (μ m n₂)`, then `covariant_class.covc m h : r n₁ n₂`.
--/
-class contravariant_class :=
-(covtc : contravariant M N μ s)
-
-end variants
+-- TODO: If possible, uniformize lemma names, taking special care of `'`,
+-- after the `ordered`-refactor is done
 
 variables {α : Type*} {a b c d : α}
 

--- a/src/algebra/ordered_monoid_lemmas.lean
+++ b/src/algebra/ordered_monoid_lemmas.lean
@@ -35,7 +35,7 @@ variables [has_mul α]
 @[to_additive lt_of_add_lt_add_left]
 lemma lt_of_mul_lt_mul_left' [contravariant_class α α (*) (<)] :
   a * b < a * c → b < c :=
-contravariant_class.covtc a
+contravariant_class.elim a
 
 variable [covariant_class α α (*) (≤)]
 
@@ -110,7 +110,7 @@ variables [has_mul α]
 lemma lt_of_mul_lt_mul_right' [contravariant_class α α (function.swap (*)) (<)]
   (h : a * b < c * b) :
   a < c :=
-contravariant_class.covtc b h
+contravariant_class.elim b h
 
 variable  [covariant_class α α (function.swap (*)) (≤)]
 

--- a/src/algebra/ordered_monoid_lemmas.lean
+++ b/src/algebra/ordered_monoid_lemmas.lean
@@ -42,7 +42,7 @@ variable [covariant_class α α (*) (≤)]
 @[to_additive add_le_add_left]
 lemma mul_le_mul_left' (h : a ≤ b) (c) :
   c * a ≤ c * b :=
-covariant_class.covc c h
+covariant_class.elim c h
 
 @[to_additive]
 lemma mul_lt_of_mul_lt_left (h : a * b < c) (hle : d ≤ b) :
@@ -117,7 +117,7 @@ variable  [covariant_class α α (function.swap (*)) (≤)]
 @[to_additive add_le_add_right]
 lemma mul_le_mul_right' (h : a ≤ b) (c) :
   a * c ≤ b * c :=
-covariant_class.covc c h
+covariant_class.elim c h
 
 @[to_additive]
 lemma mul_lt_of_mul_lt_right (h : a * b < c) (hle : d ≤ a) :
@@ -447,7 +447,7 @@ variables [right_cancel_monoid α]
 
 @[to_additive]
 lemma mul_lt_mul_of_lt_of_le (h₁ : a < b) (h₂ : c ≤ d) : a * c < b * d :=
-lt_of_lt_of_le ((covariant_class.covc c h₁.le).lt_of_ne (λ h, h₁.ne ((mul_left_inj c).mp h)))
+lt_of_lt_of_le ((covariant_class.elim c h₁.le).lt_of_ne (λ h, h₁.ne ((mul_left_inj c).mp h)))
   (mul_le_mul_left' h₂ b)
 
 @[to_additive]

--- a/src/algebra/ordered_monoid_lemmas.lean
+++ b/src/algebra/ordered_monoid_lemmas.lean
@@ -3,93 +3,21 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl, Damiano Testa
 -/
-import algebra.group.defs
+
+import algebra.covariant_and_contravariant
 import order.basic
+
 /-!
-This file begins the splitting of the ordering assumptions from the algebraic assumptions on the
-operations in the `ordered_[...]` hierarchy.
-
-The strategy is to introduce two more flexible typeclasses, covariant_class and contravariant_class.
-
-* covariant_class models the implication a ≤ b → c * a ≤ c * b (multiplication is monotone),
-* contravariant_class models the implication a * b < a * c → b < c.
-
-Since `co(ntra)variant_class` takes as input the operation (typically `(+)` or `(*)`) and the order
-relation (typically `(≤)` or `(<)`), these are the only two typeclasses that I have used.
-
-The general approach is to formulate the lemma that you are interested and prove it, with the
-`ordered_[...]` typeclass of your liking.  After that, you convert the single typeclass,
-say `[ordered_cancel_monoid M]`, with three typeclasses, e.g.
-`[partial_order M] [left_cancel_semigroup M] [covariant_class M M (function.swap (*)) (≤)]`
-and have a go at seeing if the proof still works!
-
-Note that it is possible to combine several co(ntra)variant_class assumptions together.
-Indeed, the usual ordered typeclasses arise from assuming the pair
-`[covariant_class M M (*) (≤)] [contravariant_class M M (*) (<)]`
-on top of order/algebraic assumptions.
-
-A formal remark is that normally covariant_class uses the `(≤)`-relation, while contravariant_class
-uses the `(<)`-relation. This need not be the case in general, but seems to be the most common
-usage. In the opposite direction, the implication
-
-```lean
-[semigroup α] [partial_order α] [contravariant_class α α (*) (≤)] => left_cancel_semigroup α
-```
-holds (note the `co*ntra*` assumption and the `(≤)`-relation).
+# Ordered monoids
+This file develops the basics of ordered monoids.
+## Implementation details
+Unfortunately, the number of `'` appended to lemmas in this file
+may differ between the multiplicative and the additive version of a lemma.
+The reason is that we did not want to change existing names in the library.
+## Remark
+No monoid is actually present in this file: all assumptions have been generalized to `has_mul` or
+`mul_one_class`.
 -/
--- TODO: convert `has_exists_mul_of_le`, `has_exists_add_of_le`?
--- TODO: relationship with add_con
--- include equivalence of `left_cancel_semigroup` with
--- `semigroup partial_order contravariant_class α α (*) (≤)`?
--- use ⇒, as per Eric's suggestion?
-section variants
-
-variables {M N : Type*} (μ : M → N → N) (r s : N → N → Prop) (m : M) {a b c : N}
-
-
-variables (M N)
-/-- `covariant` is useful to formulate succintly statements about the interactions between an
-action of a Type on another one and a relation on the acted-upon Type.
-
-See the `covariant_class` doc-string for its meaning. -/
-def covariant     : Prop := ∀ (m) {n₁ n₂}, r n₁ n₂ → r (μ m n₁) (μ m n₂)
-
-/-- `contravariant` is useful to formulate succintly statements about the interactions between an
-action of a Type on another one and a relation on the acted-upon Type.
-
-See the `contravariant_class` doc-string for its meaning. -/
-def contravariant : Prop := ∀ (m) {n₁ n₂}, s (μ m n₁) (μ m n₂) → s n₁ n₂
-
-/--  Given an action `μ` of a Type `M` on a Type `N` and a relation `r` on `N`, informally, the
-`covariant_class` says that "the action `μ` preserves the relation `r`.
-
-More precisely, the `covariant_class` is a class taking two Types `M N`, together with an "action"
-`μ : M → N → N` and a relation `r : N → N`.  Its unique field `covc` is the assertion that
-for all `m ∈ M` and all elements `n₁, n₂ ∈ N`, if the relation `r` holds for the pair
-`(n₁, n₂)`, then, the relation `r` also holds for the pair `(μ m n₁, μ m n₂)`,
-obtained from `(n₁, n₂)` by "acting upon it by `m`".
-
-If `m : M` and `h : r n₁ n₂`, then `covariant_class.covc m h : r (μ m n₁) (μ m n₂)`.
--/
-class covariant_class :=
-(covc :  covariant M N μ r)
-
-/--  Given an action `μ` of a Type `M` on a Type `N` and a relation `r` on `N`, informally, the
-`contravariant_class` says that "if the result of the action `μ` on a pair satisfies the
-relation `r`, then the initial pair satisfied the relation `r`.
-
-More precisely, the `contravariant_class` is a class taking two Types `M N`, together with an
-"action" `μ : M → N → N` and a relation `r : N → N`.  Its unique field `covtc` is the assertion that
-for all `m ∈ M` and all elements `n₁, n₂ ∈ N`, if the relation `r` holds for the pair
-`(μ m n₁, μ m n₂)` obtained from `(n₁, n₂)` by "acting upon it by `m`"", then, the relation `r`
-also holds for the pair `(n₁, n₂)`.
-
-If `m : M` and `h : r (μ m n₁) (μ m n₂)`, then `covariant_class.covc m h : r n₁ n₂`.
--/
-class contravariant_class :=
-(covtc : contravariant M N μ s)
-
-end variants
 
 variables {α : Type*} {a b c d : α}
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -654,3 +654,6 @@ lemma cast_inj {α β : Type*} (h : α = β) {x y : α} : cast h x = cast h y �
 if for each pair of distinct points there is a function taking different values on them. -/
 def set.separates_points {α β : Type*} (A : set (α → β)) : Prop :=
 ∀ ⦃x y : α⦄, x ≠ y → ∃ f ∈ A, (f x : β) ≠ f y
+
+lemma is_symm_op.flip_eq {α β} (op) [is_symm_op α β op] : flip op = op :=
+funext $ λ a, funext $ λ b, (is_symm_op.symm_op a b).symm


### PR DESCRIPTION
This PR introduces more API for `covariant` and `contravariant` stuff .

Besides the API, I have not actually made further use of the typeclasses or of the API.  This happens in subsequent PRs.

This is a step towards PR #7645.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #7871 [The PR with the `symm_op` lemma]
- [x] depends on: #7890 [The PR where the actual content is simply moved and the documentation is updated]

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
