### PR TITLE
[Merged by Bors] - fix(tactic/linarith/preprocessing): capture result of zify_proof

### DIFF
--- a/src/tactic/linarith/preprocessing.lean
+++ b/src/tactic/linarith/preprocessing.lean
@@ -158,6 +158,7 @@ match tp with
 | _ := return [h]
 end }
 
+
 /--
 If `h` is an equality or inequality between natural numbers,
 `nat_to_int` lifts this inequality to the integers.
@@ -167,22 +168,15 @@ To avoid adding the same nonnegativity facts many times, it is a global preproce
 meta def nat_to_int : global_preprocessor :=
 { name := "move nats to ints",
   transform := λ l,
-let zify_proof_or_return (h : expr) : tactic expr := do {
-  infer_type h >>= guardb ∘ is_nat_prop,
-  σ ← tactic.read,
-  -- capture result of zify_proof if it succeeds,
-  -- while backtracking the state
-  match (zify_proof [] h) σ with
-  | (interaction_monad.result.success res _) := pure res
-  | (interaction_monad.result.exception th _ _) :=
-    tactic.fail $ (th.get_or_else (λ _, format! "failed"))()
-  end
-} <|> return h in
-do l ← l.mmap zify_proof_or_return,
+-- we lock the tactic state here because a `simplify` call inside of
+-- `zify_proof` corrupts the tactic state when run under `io.run_tactic`.
+do l ← lock_tactic_state $ l.mmap $ λ h,
+         infer_type h >>= guardb ∘ is_nat_prop >> zify_proof [] h <|> return h,
    nonnegs ← l.mfoldl (λ (es : expr_set) h, do
      (a, b) ← infer_type h >>= get_rel_sides,
      return $ (es.insert_list (get_nat_comps a)).insert_list (get_nat_comps b)) mk_rb_set,
    (++) l <$> nonnegs.to_list.mmap mk_coe_nat_nonneg_prf }
+
 
 /-- `strengthen_strict_int h` turns a proof `h` of a strict integer inequality `t1 < t2`
 into a proof of `t1 ≤ t2 + 1`. -/

--- a/src/tactic/linarith/preprocessing.lean
+++ b/src/tactic/linarith/preprocessing.lean
@@ -170,6 +170,8 @@ meta def nat_to_int : global_preprocessor :=
 let zify_proof_or_return (h : expr) : tactic expr := do {
   infer_type h >>= guardb ∘ is_nat_prop,
   σ ← tactic.read,
+  -- capture result of zify_proof if it succeeds,
+  -- while backtracking the state
   match (zify_proof [] h) σ with
   | (interaction_monad.result.success res _) := pure res
   | (interaction_monad.result.exception th _ _) :=


### PR DESCRIPTION
this fixes the error encountered in the MWE in this Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F.20tactics/topic/delayed_abstraction.20meta-variables/near/242376874

the `simplify` call inside of `zify_proof` does something bad to the tactic state when called in the scope of an `io.run_tactic`, not entirely sure why ¯\_(ツ)_/¯ --- the changes in this PR circumvent the issue with no negative effect to `linarith`
