### PR TITLE
[Merged by Bors] - feat(measure_theory/set_integral): the set integral is continuous

### DIFF
--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -450,7 +450,7 @@ variable [opens_measurable_space E]
 
 lemma mem_ℒp.norm {f : α → E} (h : mem_ℒp f p μ) : mem_ℒp (λ x, ∥f x∥) p μ :=
 h.of_le h.ae_measurable.norm (eventually_of_forall (λ x, by simp))
-
+d
 lemma snorm'_eq_zero_of_ae_zero {f : α → F} (hq0_lt : 0 < q) (hf_zero : f =ᵐ[μ] 0) :
   snorm' f q μ = 0 :=
 by rw [snorm'_congr_ae hf_zero, snorm'_zero hq0_lt]

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -413,7 +413,7 @@ lemma mem_ℒp.of_bound [finite_measure μ] {f : α → E} (hf : ae_measurable f
   mem_ℒp f p μ :=
 (mem_ℒp_const C).of_le hf (hfC.mono (λ x hx, le_trans hx (le_abs_self _)))
 
-lemma snorm'_mono_measure {μ ν : measure α} (f : α → F) (hμν : ν ≤ μ) (hq : 0 ≤ q) :
+@[mono] lemma snorm'_mono_measure {μ ν : measure α} (f : α → F) (hμν : ν ≤ μ) (hq : 0 ≤ q) :
   snorm' f q ν ≤ snorm' f q μ :=
 begin
   simp_rw snorm',
@@ -422,11 +422,11 @@ begin
   exact lintegral_mono' hμν le_rfl,
 end
 
-lemma snorm_ess_sup_mono_measure {μ ν : measure α} (f : α → F) (hμν : ν ≪ μ) :
+@[mono] lemma snorm_ess_sup_mono_measure {μ ν : measure α} (f : α → F) (hμν : ν ≪ μ) :
   snorm_ess_sup f ν ≤ snorm_ess_sup f μ :=
 by { simp_rw snorm_ess_sup, exact ess_sup_mono_measure hμν, }
 
-lemma snorm_mono_measure {μ ν : measure α} (f : α → F) (hμν : ν ≤ μ) :
+@[mono] lemma snorm_mono_measure {μ ν : measure α} (f : α → F) (hμν : ν ≤ μ) :
   snorm f p ν ≤ snorm f p μ :=
 begin
   by_cases hp0 : p = 0,

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -450,7 +450,7 @@ variable [opens_measurable_space E]
 
 lemma mem_ℒp.norm {f : α → E} (h : mem_ℒp f p μ) : mem_ℒp (λ x, ∥f x∥) p μ :=
 h.of_le h.ae_measurable.norm (eventually_of_forall (λ x, by simp))
-d
+
 lemma snorm'_eq_zero_of_ae_zero {f : α → F} (hq0_lt : 0 < q) (hf_zero : f =ᵐ[μ] 0) :
   snorm' f q μ = 0 :=
 by rw [snorm'_congr_ae hf_zero, snorm'_zero hq0_lt]

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -413,7 +413,7 @@ lemma mem_ℒp.of_bound [finite_measure μ] {f : α → E} (hf : ae_measurable f
   mem_ℒp f p μ :=
 (mem_ℒp_const C).of_le hf (hfC.mono (λ x hx, le_trans hx (le_abs_self _)))
 
-lemma snorm'_mono_measure {μ ν : measure α} {f : α → F} (hμν : ν ≤ μ) (hq : 0 ≤ q) :
+lemma snorm'_mono_measure {μ ν : measure α} (f : α → F) (hμν : ν ≤ μ) (hq : 0 ≤ q) :
   snorm' f q ν ≤ snorm' f q μ :=
 begin
   simp_rw snorm',
@@ -422,24 +422,24 @@ begin
   exact lintegral_mono' hμν le_rfl,
 end
 
-lemma snorm_ess_sup_mono_measure {μ ν : measure α} {f : α → F} (hμν : ν ≪ μ) :
+lemma snorm_ess_sup_mono_measure {μ ν : measure α} (f : α → F) (hμν : ν ≪ μ) :
   snorm_ess_sup f ν ≤ snorm_ess_sup f μ :=
 by { simp_rw snorm_ess_sup, exact ess_sup_mono_measure hμν, }
 
-lemma snorm_mono_measure {μ ν : measure α} {f : α → F} (hμν : ν ≤ μ) :
+lemma snorm_mono_measure {μ ν : measure α} (f : α → F) (hμν : ν ≤ μ) :
   snorm f p ν ≤ snorm f p μ :=
 begin
   by_cases hp0 : p = 0,
   { simp [hp0], },
   by_cases hp_top : p = ∞,
-  { simp [hp_top, snorm_ess_sup_mono_measure (measure.absolutely_continuous_of_le hμν)], },
+  { simp [hp_top, snorm_ess_sup_mono_measure f (measure.absolutely_continuous_of_le hμν)], },
   simp_rw snorm_eq_snorm' hp0 hp_top,
-  exact snorm'_mono_measure hμν ennreal.to_real_nonneg,
+  exact snorm'_mono_measure f hμν ennreal.to_real_nonneg,
 end
 
 lemma mem_ℒp.mono_measure {μ ν : measure α} {f : α → E} (hμν : ν ≤ μ) (hf : mem_ℒp f p μ) :
   mem_ℒp f p ν :=
-⟨hf.1.mono_measure hμν, (snorm_mono_measure hμν).trans_lt hf.2⟩
+⟨hf.1.mono_measure hμν, (snorm_mono_measure f hμν).trans_lt hf.2⟩
 
 lemma mem_ℒp.restrict (s : set α) {f : α → E} (hf : mem_ℒp f p μ) :
   mem_ℒp f p (μ.restrict s) :=

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -413,6 +413,38 @@ lemma mem_ℒp.of_bound [finite_measure μ] {f : α → E} (hf : ae_measurable f
   mem_ℒp f p μ :=
 (mem_ℒp_const C).of_le hf (hfC.mono (λ x hx, le_trans hx (le_abs_self _)))
 
+lemma snorm'_mono_measure {μ ν : measure α} {f : α → F} (hμν : ν ≤ μ) (hq : 0 ≤ q) :
+  snorm' f q ν ≤ snorm' f q μ :=
+begin
+  simp_rw snorm',
+  suffices h_integral_mono : (∫⁻ a, (nnnorm (f a) : ℝ≥0∞) ^ q ∂ν) ≤ ∫⁻ a, (nnnorm (f a)) ^ q ∂μ,
+    from ennreal.rpow_le_rpow h_integral_mono (by simp [hq]),
+  exact lintegral_mono' hμν le_rfl,
+end
+
+lemma snorm_ess_sup_mono_measure {μ ν : measure α} {f : α → F} (hμν : ν ≪ μ) :
+  snorm_ess_sup f ν ≤ snorm_ess_sup f μ :=
+by { simp_rw snorm_ess_sup, exact ess_sup_mono_measure hμν, }
+
+lemma snorm_mono_measure {μ ν : measure α} {f : α → F} (hμν : ν ≤ μ) :
+  snorm f p ν ≤ snorm f p μ :=
+begin
+  by_cases hp0 : p = 0,
+  { simp [hp0], },
+  by_cases hp_top : p = ∞,
+  { simp [hp_top, snorm_ess_sup_mono_measure (measure.absolutely_continuous_of_le hμν)], },
+  simp_rw snorm_eq_snorm' hp0 hp_top,
+  exact snorm'_mono_measure hμν ennreal.to_real_nonneg,
+end
+
+lemma mem_ℒp.mono_measure {μ ν : measure α} {f : α → E} (hμν : ν ≤ μ) (hf : mem_ℒp f p μ) :
+  mem_ℒp f p ν :=
+⟨hf.1.mono_measure hμν, (snorm_mono_measure hμν).trans_lt hf.2⟩
+
+lemma mem_ℒp.restrict (s : set α) {f : α → E} (hf : mem_ℒp f p μ) :
+  mem_ℒp f p (μ.restrict s) :=
+hf.mono_measure measure.restrict_le_self
+
 section opens_measurable_space
 variable [opens_measurable_space E]
 

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -286,14 +286,19 @@ end
 
 
 section continuous_set_integral
+/-! ### Continuity of the set integral
+
+We prove that for any set `s`, the function `λ f : α →₁[μ] E, ∫ x in s, f x ∂μ` is continuous. -/
 
 variables [measurable_space α] {μ : measure α}
-  {G : Type*} [normed_group G] [measurable_space G] [second_countable_topology G] [borel_space G]
+  [normed_group E] [measurable_space E] [second_countable_topology E] [borel_space E]
   {𝕂 : Type*} [is_R_or_C 𝕂] [measurable_space 𝕂]
+  [normed_group F] [measurable_space F] [second_countable_topology F] [borel_space F]
+  [normed_space 𝕂 F]
   {p : ℝ≥0∞}
 
-lemma Lp_to_Lp_restrict_add (f g : Lp G p μ) (s : set α) :
-  ((Lp.mem_ℒp (f+g)).restrict s).to_Lp ⇑(f + g)
+lemma Lp_to_Lp_restrict_add (f g : Lp E p μ) (s : set α) :
+  ((Lp.mem_ℒp (f + g)).restrict s).to_Lp ⇑(f + g)
     = ((Lp.mem_ℒp f).restrict s).to_Lp f + ((Lp.mem_ℒp g).restrict s).to_Lp g :=
 begin
   ext1,
@@ -318,19 +323,10 @@ begin
   rw [hx2, hx1, pi.smul_apply, hx3, hx4, pi.smul_apply],
 end
 
-variables (α F 𝕂)
-/-- Linear map sending a function of `Lp F p μ` to the same function in `Lp F p (μ.restrict s)`. -/
-def Lp_to_Lp_restrict_lm [borel_space 𝕂] (p : ℝ≥0∞) (s : set α) :
-  @linear_map 𝕂 (Lp F p μ) (Lp F p (μ.restrict s)) _ _ _ _ _ :=
-{ to_fun := λ f, mem_ℒp.to_Lp f ((Lp.mem_ℒp f).restrict s),
-  map_add' := λ f g, Lp_to_Lp_restrict_add f g s,
-  map_smul' := λ c f, Lp_to_Lp_restrict_smul c f s, }
-variables {α F 𝕂}
-
-lemma norm_Lp_to_Lp_restrict_le (s : set α) (f : Lp G p μ) :
+lemma norm_Lp_to_Lp_restrict_le (s : set α) (f : Lp E p μ) :
   ∥mem_ℒp.to_Lp f ((Lp.mem_ℒp f).restrict s)∥ ≤ ∥f∥ :=
 begin
-  rw [norm_def, norm_def, ennreal.to_real_le_to_real (snorm_ne_top _) (snorm_ne_top _)],
+  rw [Lp.norm_def, Lp.norm_def, ennreal.to_real_le_to_real (Lp.snorm_ne_top _) (Lp.snorm_ne_top _)],
   refine (le_of_eq _).trans (snorm_mono_measure measure.restrict_le_self),
   { exact s, },
   exact snorm_congr_ae (mem_ℒp.coe_fn_to_Lp _),
@@ -341,10 +337,11 @@ variables (α F 𝕂)
 `Lp F p (μ.restrict s)`. -/
 def Lp_to_Lp_restrict_clm [borel_space 𝕂] (μ : measure α) (p : ℝ≥0∞) [hp : fact(1 ≤ p)]
   (s : set α) :
-  @continuous_linear_map 𝕂 _ (Lp F p μ) _ _ (Lp F p (μ.restrict s)) _ _ _ _ :=
+  Lp F p μ →L[𝕂] Lp F p (μ.restrict s) :=
 @linear_map.mk_continuous 𝕂 (Lp F p μ) (Lp F p (μ.restrict s)) _ _ _ _ _
-  (Lp_to_Lp_restrict_lm α F 𝕂 p s) 1
-  (by { intro f, rw one_mul, exact norm_Lp_to_Lp_restrict_le s f, })
+  ⟨λ f, mem_ℒp.to_Lp f ((Lp.mem_ℒp f).restrict s), λ f g, Lp_to_Lp_restrict_add f g s,
+    λ c f, Lp_to_Lp_restrict_smul c f s⟩
+  1 (by { intro f, rw one_mul, exact norm_Lp_to_Lp_restrict_le s f, })
 
 @[continuity]
 lemma continuous_Lp_to_Lp_restrict [borel_space 𝕂] (p : ℝ≥0∞) [hp : fact(1 ≤ p)] (s : set α) :
@@ -359,15 +356,16 @@ mem_ℒp.coe_fn_to_Lp ((Lp.mem_ℒp f).restrict s)
 variables {𝕂}
 
 @[continuity]
-lemma continuous_set_integral (s : set α) : continuous (λ f : α →₁[μ] G', ∫ x in s, f x ∂μ) :=
+lemma continuous_set_integral [normed_space ℝ E] [complete_space E] (s : set α) :
+  continuous (λ f : α →₁[μ] E, ∫ x in s, f x ∂μ) :=
 begin
   haveI : fact((1 : ℝ≥0∞) ≤ 1) := ⟨le_rfl⟩,
-  have h_comp : (λ f : α →₁[μ] G', ∫ x in s, f x ∂μ)
-    = (integral (μ.restrict s)) ∘ (λ f, Lp_to_Lp_restrict_clm α G' ℝ μ 1 s f),
+  have h_comp : (λ f : α →₁[μ] E, ∫ x in s, f x ∂μ)
+    = (integral (μ.restrict s)) ∘ (λ f, Lp_to_Lp_restrict_clm α E ℝ μ 1 s f),
   { ext1 f,
     rw [function.comp_apply, integral_congr_ae (Lp_to_Lp_restrict_clm_coe_fn ℝ s f)], },
   rw h_comp,
-  exact continuous_integral.comp (continuous_Lp_to_Lp_restrict α G' ℝ 1 s),
+  exact continuous_integral.comp (continuous_Lp_to_Lp_restrict α E ℝ 1 s),
 end
 
 end continuous_set_integral

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -326,7 +326,7 @@ lemma norm_Lp_to_Lp_restrict_le (s : set α) (f : Lp E p μ) :
   ∥mem_ℒp.to_Lp f ((Lp.mem_ℒp f).restrict s)∥ ≤ ∥f∥ :=
 begin
   rw [Lp.norm_def, Lp.norm_def, ennreal.to_real_le_to_real (Lp.snorm_ne_top _) (Lp.snorm_ne_top _)],
-  refine (le_of_eq _).trans (snorm_mono_measure measure.restrict_le_self),
+  refine (le_of_eq _).trans (snorm_mono_measure _ measure.restrict_le_self),
   { exact s, },
   exact snorm_congr_ae (mem_ℒp.coe_fn_to_Lp _),
 end

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -360,7 +360,7 @@ variables {𝕜}
 lemma continuous_set_integral [normed_space ℝ E] [complete_space E] (s : set α) :
   continuous (λ f : α →₁[μ] E, ∫ x in s, f x ∂μ) :=
 begin
-  haveI : fact((1 : ℝ≥0∞) ≤ 1) := ⟨le_rfl⟩,
+  haveI : fact ((1 : ℝ≥0∞) ≤ 1) := ⟨le_rfl⟩,
   have h_comp : (λ f : α →₁[μ] E, ∫ x in s, f x ∂μ)
     = (integral (μ.restrict s)) ∘ (λ f, Lp_to_Lp_restrict_clm α E ℝ μ 1 s f),
   { ext1 f,

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -290,12 +290,11 @@ section continuous_set_integral
 
 We prove that for any set `s`, the function `λ f : α →₁[μ] E, ∫ x in s, f x ∂μ` is continuous. -/
 
-variables [measurable_space α] {μ : measure α}
-  [normed_group E] [measurable_space E] [second_countable_topology E] [borel_space E]
+variables [normed_group E] [measurable_space E] [second_countable_topology E] [borel_space E]
   {𝕂 : Type*} [is_R_or_C 𝕂] [measurable_space 𝕂]
   [normed_group F] [measurable_space F] [second_countable_topology F] [borel_space F]
   [normed_space 𝕂 F]
-  {p : ℝ≥0∞}
+  {p : ℝ≥0∞} {μ : measure α}
 
 lemma Lp_to_Lp_restrict_add (f g : Lp E p μ) (s : set α) :
   ((Lp.mem_ℒp (f + g)).restrict s).to_Lp ⇑(f + g)

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -291,11 +291,13 @@ section continuous_set_integral
 We prove that for any set `s`, the function `λ f : α →₁[μ] E, ∫ x in s, f x ∂μ` is continuous. -/
 
 variables [normed_group E] [measurable_space E] [second_countable_topology E] [borel_space E]
-  {𝕂 : Type*} [is_R_or_C 𝕂] [measurable_space 𝕂]
+  {𝕜 : Type*} [is_R_or_C 𝕜] [measurable_space 𝕜]
   [normed_group F] [measurable_space F] [second_countable_topology F] [borel_space F]
-  [normed_space 𝕂 F]
+  [normed_space 𝕜 F]
   {p : ℝ≥0∞} {μ : measure α}
 
+/-- For `f : Lp E p μ`, we can define an element of `Lp E p (μ.restrict s)` by
+`(Lp.mem_ℒp f).restrict s).to_Lp f`. This map is additive. -/
 lemma Lp_to_Lp_restrict_add (f g : Lp E p μ) (s : set α) :
   ((Lp.mem_ℒp (f + g)).restrict s).to_Lp ⇑(f + g)
     = ((Lp.mem_ℒp f).restrict s).to_Lp f + ((Lp.mem_ℒp g).restrict s).to_Lp g :=
@@ -310,7 +312,9 @@ begin
   rw [hx4, hx1, pi.add_apply, hx2, hx3, hx5, pi.add_apply],
 end
 
-lemma Lp_to_Lp_restrict_smul [opens_measurable_space 𝕂] (c : 𝕂) (f : Lp F p μ) (s : set α) :
+/-- For `f : Lp E p μ`, we can define an element of `Lp E p (μ.restrict s)` by
+`(Lp.mem_ℒp f).restrict s).to_Lp f`. This map commutes with scalar multiplication. -/
+lemma Lp_to_Lp_restrict_smul [opens_measurable_space 𝕜] (c : 𝕜) (f : Lp F p μ) (s : set α) :
   ((Lp.mem_ℒp (c • f)).restrict s).to_Lp ⇑(c • f) = c • (((Lp.mem_ℒp f).restrict s).to_Lp f) :=
 begin
   ext1,
@@ -322,8 +326,10 @@ begin
   rw [hx2, hx1, pi.smul_apply, hx3, hx4, pi.smul_apply],
 end
 
+/-- For `f : Lp E p μ`, we can define an element of `Lp E p (μ.restrict s)` by
+`(Lp.mem_ℒp f).restrict s).to_Lp f`. This map is non-expansive. -/
 lemma norm_Lp_to_Lp_restrict_le (s : set α) (f : Lp E p μ) :
-  ∥mem_ℒp.to_Lp f ((Lp.mem_ℒp f).restrict s)∥ ≤ ∥f∥ :=
+  ∥((Lp.mem_ℒp f).restrict s).to_Lp f∥ ≤ ∥f∥ :=
 begin
   rw [Lp.norm_def, Lp.norm_def, ennreal.to_real_le_to_real (Lp.snorm_ne_top _) (Lp.snorm_ne_top _)],
   refine (le_of_eq _).trans (snorm_mono_measure _ measure.restrict_le_self),
@@ -331,28 +337,24 @@ begin
   exact snorm_congr_ae (mem_ℒp.coe_fn_to_Lp _),
 end
 
-variables (α F 𝕂)
+variables (α F 𝕜)
 /-- Continuous linear map sending a function of `Lp F p μ` to the same function in
 `Lp F p (μ.restrict s)`. -/
-def Lp_to_Lp_restrict_clm [borel_space 𝕂] (μ : measure α) (p : ℝ≥0∞) [hp : fact(1 ≤ p)]
+def Lp_to_Lp_restrict_clm [borel_space 𝕜] (μ : measure α) (p : ℝ≥0∞) [hp : fact (1 ≤ p)]
   (s : set α) :
-  Lp F p μ →L[𝕂] Lp F p (μ.restrict s) :=
-@linear_map.mk_continuous 𝕂 (Lp F p μ) (Lp F p (μ.restrict s)) _ _ _ _ _
+  Lp F p μ →L[𝕜] Lp F p (μ.restrict s) :=
+@linear_map.mk_continuous 𝕜 (Lp F p μ) (Lp F p (μ.restrict s)) _ _ _ _ _
   ⟨λ f, mem_ℒp.to_Lp f ((Lp.mem_ℒp f).restrict s), λ f g, Lp_to_Lp_restrict_add f g s,
     λ c f, Lp_to_Lp_restrict_smul c f s⟩
   1 (by { intro f, rw one_mul, exact norm_Lp_to_Lp_restrict_le s f, })
 
-@[continuity]
-lemma continuous_Lp_to_Lp_restrict [borel_space 𝕂] (p : ℝ≥0∞) [hp : fact(1 ≤ p)] (s : set α) :
-  continuous (Lp_to_Lp_restrict_clm α F 𝕂 μ p s) :=
-continuous_linear_map.continuous _
-variables {α F 𝕂}
+variables {α F 𝕜}
 
-variables (𝕂)
-lemma Lp_to_Lp_restrict_clm_coe_fn [borel_space 𝕂] [hp : fact(1 ≤ p)] (s : set α) (f : Lp F p μ) :
-  Lp_to_Lp_restrict_clm α F 𝕂 μ p s f =ᵐ[μ.restrict s] f :=
+variables (𝕜)
+lemma Lp_to_Lp_restrict_clm_coe_fn [borel_space 𝕜] [hp : fact (1 ≤ p)] (s : set α) (f : Lp F p μ) :
+  Lp_to_Lp_restrict_clm α F 𝕜 μ p s f =ᵐ[μ.restrict s] f :=
 mem_ℒp.coe_fn_to_Lp ((Lp.mem_ℒp f).restrict s)
-variables {𝕂}
+variables {𝕜}
 
 @[continuity]
 lemma continuous_set_integral [normed_space ℝ E] [complete_space E] (s : set α) :
@@ -364,7 +366,7 @@ begin
   { ext1 f,
     rw [function.comp_apply, integral_congr_ae (Lp_to_Lp_restrict_clm_coe_fn ℝ s f)], },
   rw h_comp,
-  exact continuous_integral.comp (continuous_Lp_to_Lp_restrict α E ℝ 1 s),
+  exact continuous_integral.comp (Lp_to_Lp_restrict_clm α E ℝ μ 1 s).continuous,
 end
 
 end continuous_set_integral

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -284,6 +284,95 @@ begin
   exact (lintegral_mono_set' hst),
 end
 
+
+section continuous_set_integral
+
+variables [measurable_space α] {μ : measure α}
+  {G : Type*} [normed_group G] [measurable_space G] [second_countable_topology G] [borel_space G]
+  {𝕂 : Type*} [is_R_or_C 𝕂] [measurable_space 𝕂]
+  {p : ℝ≥0∞}
+
+lemma Lp_to_Lp_restrict_add (f g : Lp G p μ) (s : set α) :
+  ((Lp.mem_ℒp (f+g)).restrict s).to_Lp ⇑(f + g)
+    = ((Lp.mem_ℒp f).restrict s).to_Lp f + ((Lp.mem_ℒp g).restrict s).to_Lp g :=
+begin
+  ext1,
+  refine (ae_restrict_of_ae (Lp.coe_fn_add f g)).mp _,
+  refine (Lp.coe_fn_add (mem_ℒp.to_Lp f ((Lp.mem_ℒp f).restrict s))
+    (mem_ℒp.to_Lp g ((Lp.mem_ℒp g).restrict s))).mp _,
+  refine (mem_ℒp.coe_fn_to_Lp ((Lp.mem_ℒp f).restrict s)).mp _,
+  refine (mem_ℒp.coe_fn_to_Lp ((Lp.mem_ℒp g).restrict s)).mp _,
+  refine (mem_ℒp.coe_fn_to_Lp ((Lp.mem_ℒp (f+g)).restrict s)).mono (λ x hx1 hx2 hx3 hx4 hx5, _),
+  rw [hx4, hx1, pi.add_apply, hx2, hx3, hx5, pi.add_apply],
+end
+
+lemma Lp_to_Lp_restrict_smul [opens_measurable_space 𝕂] (c : 𝕂) (f : Lp F p μ) (s : set α) :
+  ((Lp.mem_ℒp (c • f)).restrict s).to_Lp ⇑(c • f) = c • (((Lp.mem_ℒp f).restrict s).to_Lp f) :=
+begin
+  ext1,
+  refine (ae_restrict_of_ae (Lp.coe_fn_smul c f)).mp _,
+  refine (mem_ℒp.coe_fn_to_Lp ((Lp.mem_ℒp f).restrict s)).mp _,
+  refine (mem_ℒp.coe_fn_to_Lp ((Lp.mem_ℒp (c • f)).restrict s)).mp _,
+  refine (Lp.coe_fn_smul c (mem_ℒp.to_Lp f ((Lp.mem_ℒp f).restrict s))).mono
+    (λ x hx1 hx2 hx3 hx4, _),
+  rw [hx2, hx1, pi.smul_apply, hx3, hx4, pi.smul_apply],
+end
+
+variables (α F 𝕂)
+/-- Linear map sending a function of `Lp F p μ` to the same function in `Lp F p (μ.restrict s)`. -/
+def Lp_to_Lp_restrict_lm [borel_space 𝕂] (p : ℝ≥0∞) (s : set α) :
+  @linear_map 𝕂 (Lp F p μ) (Lp F p (μ.restrict s)) _ _ _ _ _ :=
+{ to_fun := λ f, mem_ℒp.to_Lp f ((Lp.mem_ℒp f).restrict s),
+  map_add' := λ f g, Lp_to_Lp_restrict_add f g s,
+  map_smul' := λ c f, Lp_to_Lp_restrict_smul c f s, }
+variables {α F 𝕂}
+
+lemma norm_Lp_to_Lp_restrict_le (s : set α) (f : Lp G p μ) :
+  ∥mem_ℒp.to_Lp f ((Lp.mem_ℒp f).restrict s)∥ ≤ ∥f∥ :=
+begin
+  rw [norm_def, norm_def, ennreal.to_real_le_to_real (snorm_ne_top _) (snorm_ne_top _)],
+  refine (le_of_eq _).trans (snorm_mono_measure measure.restrict_le_self),
+  { exact s, },
+  exact snorm_congr_ae (mem_ℒp.coe_fn_to_Lp _),
+end
+
+variables (α F 𝕂)
+/-- Continuous linear map sending a function of `Lp F p μ` to the same function in
+`Lp F p (μ.restrict s)`. -/
+def Lp_to_Lp_restrict_clm [borel_space 𝕂] (μ : measure α) (p : ℝ≥0∞) [hp : fact(1 ≤ p)]
+  (s : set α) :
+  @continuous_linear_map 𝕂 _ (Lp F p μ) _ _ (Lp F p (μ.restrict s)) _ _ _ _ :=
+@linear_map.mk_continuous 𝕂 (Lp F p μ) (Lp F p (μ.restrict s)) _ _ _ _ _
+  (Lp_to_Lp_restrict_lm α F 𝕂 p s) 1
+  (by { intro f, rw one_mul, exact norm_Lp_to_Lp_restrict_le s f, })
+
+@[continuity]
+lemma continuous_Lp_to_Lp_restrict [borel_space 𝕂] (p : ℝ≥0∞) [hp : fact(1 ≤ p)] (s : set α) :
+  continuous (Lp_to_Lp_restrict_clm α F 𝕂 μ p s) :=
+continuous_linear_map.continuous _
+variables {α F 𝕂}
+
+variables (𝕂)
+lemma Lp_to_Lp_restrict_clm_coe_fn [borel_space 𝕂] [hp : fact(1 ≤ p)] (s : set α) (f : Lp F p μ) :
+  Lp_to_Lp_restrict_clm α F 𝕂 μ p s f =ᵐ[μ.restrict s] f :=
+mem_ℒp.coe_fn_to_Lp ((Lp.mem_ℒp f).restrict s)
+variables {𝕂}
+
+@[continuity]
+lemma continuous_set_integral (s : set α) : continuous (λ f : α →₁[μ] G', ∫ x in s, f x ∂μ) :=
+begin
+  haveI : fact((1 : ℝ≥0∞) ≤ 1) := ⟨le_rfl⟩,
+  have h_comp : (λ f : α →₁[μ] G', ∫ x in s, f x ∂μ)
+    = (integral (μ.restrict s)) ∘ (λ f, Lp_to_Lp_restrict_clm α G' ℝ μ 1 s f),
+  { ext1 f,
+    rw [function.comp_apply, integral_congr_ae (Lp_to_Lp_restrict_clm_coe_fn ℝ s f)], },
+  rw h_comp,
+  exact continuous_integral.comp (continuous_Lp_to_Lp_restrict α G' ℝ 1 s),
+end
+
+end continuous_set_integral
+
+
 end measure_theory
 
 open measure_theory asymptotics metric


### PR DESCRIPTION
Most of the code is dedicated to building a continuous linear map from Lp to the Lp space corresponding to the restriction of the measure to a set. The set integral is then continuous as composition of the integral and that map.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #7927

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
