### PR TITLE
[Merged by Bors] - feat(topology/topological_fiber_bundle): a new standard construction for topological fiber bundles

### DIFF
--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -87,6 +87,23 @@ begin
   exact (nhds a).sets_of_superset ((nhds a).inter_sets Hw h1) hw,
 end
 
+lemma preimage_nhds_within_coinduced {π : α → β} {s : set β} {t : set α} {a : α}
+  (h : a ∈ t) (ht : is_open t)
+  (hs : s ∈ @nhds β (topological_space.coinduced (λ x : t, π x) subtype.topological_space) (π a)) :
+  π ⁻¹' s ∈ 𝓝[t] a :=
+begin
+  letI := topological_space.coinduced (λ x : t, π x) subtype.topological_space,
+  rcases mem_nhds_iff.mp hs with ⟨V, hVs, V_op, mem_V⟩,
+  refine mem_nhds_within_iff_exists_mem_nhds_inter.mpr ⟨π ⁻¹' V, mem_nhds_iff.mpr ⟨t ∩ π ⁻¹' V,
+    inter_subset_right t (π ⁻¹' V), _, mem_sep h mem_V⟩, subset.trans (inter_subset_left _ _)
+    (preimage_mono hVs)⟩,
+  obtain ⟨u, hu1, hu2⟩ := is_open_induced_iff.mp (is_open_coinduced.1 V_op),
+  rw [preimage_comp] at hu2,
+  rw [set.inter_comm, ←(subtype.preimage_coe_eq_preimage_coe_iff.mp hu2)],
+  exact hu1.inter ht,
+end
+
+
 lemma mem_nhds_within_of_mem_nhds {s t : set α} {a : α} (h : s ∈ 𝓝 a) :
   s ∈ 𝓝[t] a :=
 mem_inf_sets_of_left h

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -87,7 +87,7 @@ begin
   exact (nhds a).sets_of_superset ((nhds a).inter_sets Hw h1) hw,
 end
 
-lemma preimage_nhds_within_coinduced {π : α → β} {s : set β} {t : set α} {a : α}
+lemma preimage_nhds_within_coinduced' {π : α → β} {s : set β} {t : set α} {a : α}
   (h : a ∈ t) (ht : is_open t)
   (hs : s ∈ @nhds β (topological_space.coinduced (λ x : t, π x) subtype.topological_space) (π a)) :
   π ⁻¹' s ∈ 𝓝[t] a :=
@@ -102,7 +102,6 @@ begin
   rw [set.inter_comm, ←(subtype.preimage_coe_eq_preimage_coe_iff.mp hu2)],
   exact hu1.inter ht,
 end
-
 
 lemma mem_nhds_within_of_mem_nhds {s t : set α} {a : α} (h : s ∈ 𝓝 a) :
   s ∈ 𝓝[t] a :=
@@ -167,6 +166,12 @@ by rw [nhds_within_restrict t h₀ h₁, nhds_within_restrict u h₀ h₁, h₂]
 theorem nhds_within_eq_of_open {a : α} {s : set α} (h₀ : a ∈ s) (h₁ : is_open s) :
   𝓝[s] a = 𝓝 a :=
 inf_eq_left.2 $ le_principal_iff.2 $ is_open.mem_nhds h₁ h₀
+
+lemma preimage_nhds_within_coinduced {π : α → β} {s : set β} {t : set α} {a : α}
+  (h : a ∈ t) (ht : is_open t)
+  (hs : s ∈ @nhds β (topological_space.coinduced (λ x : t, π x) subtype.topological_space) (π a)) :
+  π ⁻¹' s ∈ 𝓝 a :=
+by { rw ←nhds_within_eq_of_open h ht, exact preimage_nhds_within_coinduced' h ht hs }
 
 @[simp] theorem nhds_within_empty (a : α) : 𝓝[∅] a = ⊥ :=
 by rw [nhds_within, principal_empty, inf_bot_eq]

--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -256,7 +256,7 @@ namespace bundle_trivialization
 
 variables {F} (e : bundle_trivialization F proj) {x : Z}
 
-\-- Natural identification as `prebundle_trivialization` -\
+/-- Natural identification as `prebundle_trivialization`. -/
 def to_prebundle_trivialization : prebundle_trivialization F proj := { ..e }
 
 instance : has_coe_to_fun (bundle_trivialization F proj) := ⟨_, λ e, e.to_fun⟩

--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -1050,8 +1050,6 @@ end
 
 end topological_fiber_bundle_core
 
-section topological_fiber_prebundle
-
 variables (F) {Z : Type*} [topological_space B] [topological_space F] {proj : Z → B}
 
 /-- This structure permits to define a fiber bundle when trivializations are given as local
@@ -1066,24 +1064,24 @@ structure topological_fiber_prebundle (proj : Z → B) :=
   (trivialization_at y).to_local_equiv.symm) ((trivialization_at y).target ∩
   ((trivialization_at y).to_local_equiv.symm ⁻¹' (trivialization_at x).source)))
 
-variable {F}
+namespace topological_fiber_prebundle
+
+variables {F} (a : topological_fiber_prebundle F proj) (x : B)
 
 /-- Topology on the total space that will make the prebundle into a bundle. -/
-def topological_fiber_prebundle.total_space_topology (a : topological_fiber_prebundle F proj) :
-  topological_space Z :=
+def total_space_topology (a : topological_fiber_prebundle F proj) : topological_space Z :=
 ⨆ x : B, coinduced (a.trivialization_at x).set_symm (subtype.topological_space)
 
-lemma topological_fiber_prebundle.continuous_inv_triv_at (a : topological_fiber_prebundle F proj)
-  (x : B) : @continuous_on _ _ _ a.total_space_topology (a.trivialization_at x).to_local_equiv.symm
-  (a.trivialization_at x).target :=
+lemma continuous_symm_trivialization_at : @continuous_on _ _ _ a.total_space_topology
+  (a.trivialization_at x).to_local_equiv.symm (a.trivialization_at x).target :=
 begin
   refine id (λ z H, id (λ U h, preimage_nhds_within_coinduced' H (a.trivialization_at x).open_target
   (le_def.1 (nhds_mono _) U h))),
   exact le_supr _ x,
 end
 
-lemma topological_fiber_prebundle.triv_at_open_source (a : topological_fiber_prebundle F proj)
-  (x : B) : @is_open _ a.total_space_topology (a.trivialization_at x).source :=
+lemma is_open_source_trivialization_at :
+  @is_open _ a.total_space_topology (a.trivialization_at x).source :=
 begin
   letI := a.total_space_topology,
   refine is_open_supr_iff.mpr (λ y, is_open_coinduced.mpr (is_open_induced_iff.mpr
@@ -1094,21 +1092,21 @@ begin
     prebundle_trivialization.preimage_symm_proj_inter],
 end
 
-lemma topological_fiber_prebundle.triv_at_open_inter (a : topological_fiber_prebundle F proj)
-  (x y : B) : is_open ((a.trivialization_at y).to_local_equiv.target ∩
+lemma is_open_target_trivialization_at_inter (x y : B) :
+  is_open ((a.trivialization_at y).to_local_equiv.target ∩
   (a.trivialization_at y).to_local_equiv.symm ⁻¹' (a.trivialization_at x).source) :=
 begin
   letI := a.total_space_topology,
-  obtain ⟨u, hu1, hu2⟩ := continuous_on_iff'.mp (a.continuous_inv_triv_at y)
-    (a.trivialization_at x).source (a.triv_at_open_source x),
+  obtain ⟨u, hu1, hu2⟩ := continuous_on_iff'.mp (a.continuous_symm_trivialization_at y)
+    (a.trivialization_at x).source (a.is_open_source_trivialization_at x),
   rw [inter_comm, hu2],
   exact hu1.inter (a.trivialization_at y).open_target,
 end
 
 /-- Promotion from a `prebundle_trivialization` to a `bundle_trivialization`. -/
-def topological_fiber_prebundle.bundle_trivialization_at (a : topological_fiber_prebundle F proj)
-  (x : B) : @bundle_trivialization B F Z _ _ a.total_space_topology proj :=
-{ open_source := a.triv_at_open_source x,
+def bundle_trivialization_at (a : topological_fiber_prebundle F proj) (x : B) :
+  @bundle_trivialization B F Z _ _ a.total_space_topology proj :=
+{ open_source := a.is_open_source_trivialization_at x,
   continuous_to_fun := begin
     letI := a.total_space_topology,
     refine continuous_on_iff'.mpr (λ s hs, ⟨(a.trivialization_at x) ⁻¹' s ∩
@@ -1122,18 +1120,16 @@ def topological_fiber_prebundle.bundle_trivialization_at (a : topological_fiber_
       ((a.trivialization_at y).to_local_equiv.symm ⁻¹' (a.trivialization_at x).source), _, by
       { simp only [preimage_inter, inter_univ, subtype.coe_preimage_self, hu3.symm], refl }⟩,
     rw inter_assoc,
-    exact hu1.inter (a.triv_at_open_inter x y),
+    exact hu1.inter (a.is_open_target_trivialization_at_inter x y),
   end,
-  continuous_inv_fun := a.continuous_inv_triv_at x,
+  continuous_inv_fun := a.continuous_symm_trivialization_at x,
   ..(a.trivialization_at x) }
 
-lemma topological_fiber_prebundle.is_topological_fiber_bundle
-  (a : topological_fiber_prebundle F proj) :
+lemma is_topological_fiber_bundle :
   @is_topological_fiber_bundle B F Z _ _ a.total_space_topology proj :=
 λ x, ⟨a.bundle_trivialization_at x, a.mem_base_trivialization_at x ⟩
 
-lemma topological_fiber_prebundle.continuous_proj (a : topological_fiber_prebundle F proj) :
-  @continuous _ _ a.total_space_topology _ proj :=
+lemma continuous_proj : @continuous _ _ a.total_space_topology _ proj :=
 by { letI := a.total_space_topology, exact a.is_topological_fiber_bundle.continuous_proj, }
 
 end topological_fiber_prebundle

--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -1077,7 +1077,7 @@ lemma topological_fiber_prebundle.continuous_inv_triv_at (a : topological_fiber_
   (x : B) : @continuous_on _ _ _ a.total_space_topology (a.trivialization_at x).to_local_equiv.symm
   (a.trivialization_at x).target :=
 begin
-  refine id (λ z H, id (λ U h, preimage_nhds_within_coinduced H (a.trivialization_at x).open_target
+  refine id (λ z H, id (λ U h, preimage_nhds_within_coinduced' H (a.trivialization_at x).open_target
   (le_def.1 (nhds_mono _) U h))),
   exact le_supr _ x,
 end

--- a/src/topology/topological_fiber_bundle.lean
+++ b/src/topology/topological_fiber_bundle.lean
@@ -256,6 +256,7 @@ namespace bundle_trivialization
 
 variables {F} (e : bundle_trivialization F proj) {x : Z}
 
+\-- Natural identification as `prebundle_trivialization` -\
 def to_prebundle_trivialization : prebundle_trivialization F proj := { ..e }
 
 instance : has_coe_to_fun (bundle_trivialization F proj) := ⟨_, λ e, e.to_fun⟩


### PR DESCRIPTION
In this PR we implement a new standard construction for topological fiber bundles: namely a structure that permits to define a fiber bundle when trivializations are given as local equivalences but there is not yet a topology on the total space. The total space is hence given a topology in such a way that there is a fiber bundle structure for which the local equivalences
are also local homeomorphism and hence local trivializations.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
