### PR TITLE
[Merged by Bors] - chore(topology/metric_space): cleanup Gromov-Hausdorff files

### DIFF
--- a/src/topology/metric_space/gluing.lean
+++ b/src/topology/metric_space/gluing.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Gluing metric spaces
 Authors: Sébastien Gouëzel
 -/
 import topology.metric_space.isometry
@@ -13,25 +12,25 @@ Gluing two metric spaces along a common subset. Formally, we are given
 
 ```
      Φ
-  γ ---> α
+  Z ---> X
   |
   |Ψ
   v
-  β
+  Y
 ```
 where `hΦ : isometry Φ` and `hΨ : isometry Ψ`.
 We want to complete the square by a space `glue_space hΦ hΨ` and two isometries
 `to_glue_l hΦ hΨ` and `to_glue_r hΦ hΨ` that make the square commute.
-We start by defining a predistance on the disjoint union `α ⊕ β`, for which
+We start by defining a predistance on the disjoint union `X ⊕ Y`, for which
 points `Φ p` and `Ψ p` are at distance 0. The (quotient) metric space associated
 to this predistance is the desired space.
 
 This is an instance of a more general construction, where `Φ` and `Ψ` do not have to be isometries,
 but the distances in the image almost coincide, up to `2ε` say. Then one can almost glue the two
-spaces so that the images of a point under `Φ` and `Ψ` are ε-close. If `ε > 0`, this yields a metric
-space structure on `α ⊕ β`, without the need to take a quotient. In particular, when `α` and `β` are
-inhabited, this gives a natural metric space structure on `α ⊕ β`, where the basepoints are at
-distance 1, say, and the distances between other points are obtained by going through the two
+spaces so that the images of a point under `Φ` and `Ψ` are `ε`-close. If `ε > 0`, this yields a
+metric space structure on `X ⊕ Y`, without the need to take a quotient. In particular, when `X`
+and `Y` are inhabited, this gives a natural metric space structure on `X ⊕ Y`, where the basepoints
+are at distance 1, say, and the distances between other points are obtained by going through the two
 basepoints.
 
 We also define the inductive limit of metric spaces. Given
@@ -49,34 +48,34 @@ isometrically and in a way compatible with `f n`.
 noncomputable theory
 
 universes u v w
-variables {α : Type u} {β : Type v} {γ : Type w}
-
 open function set
 open_locale uniformity
 
 namespace metric
 section approx_gluing
 
-variables [metric_space α] [metric_space β]
-          {Φ : γ → α} {Ψ : γ → β} {ε : ℝ}
+variables {X : Type u} {Y : Type v} {Z : Type w}
+
+variables [metric_space X] [metric_space Y]
+          {Φ : Z → X} {Ψ : Z → Y} {ε : ℝ}
 open sum (inl inr)
 
-/-- Define a predistance on α ⊕ β, for which Φ p and Ψ p are at distance ε -/
-def glue_dist (Φ : γ → α) (Ψ : γ → β) (ε : ℝ) : α ⊕ β → α ⊕ β → ℝ
+/-- Define a predistance on `X ⊕ Y`, for which `Φ p` and `Ψ p` are at distance `ε` -/
+def glue_dist (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ) : X ⊕ Y → X ⊕ Y → ℝ
 | (inl x) (inl y) := dist x y
 | (inr x) (inr y) := dist x y
 | (inl x) (inr y) := (⨅ p, dist x (Φ p) + dist y (Ψ p)) + ε
 | (inr x) (inl y) := (⨅ p, dist y (Φ p) + dist x (Ψ p)) + ε
 
-private lemma glue_dist_self (Φ : γ → α) (Ψ : γ → β) (ε : ℝ) : ∀x, glue_dist Φ Ψ ε x x = 0
+private lemma glue_dist_self (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ) : ∀ x, glue_dist Φ Ψ ε x x = 0
 | (inl x) := dist_self _
 | (inr x) := dist_self _
 
-lemma glue_dist_glued_points [nonempty γ] (Φ : γ → α) (Ψ : γ → β) (ε : ℝ) (p : γ) :
+lemma glue_dist_glued_points [nonempty Z] (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ) (p : Z) :
   glue_dist Φ Ψ ε (inl (Φ p)) (inr (Ψ p)) = ε :=
 begin
   have : (⨅ q, dist (Φ p) (Φ q) + dist (Ψ p) (Ψ q)) = 0,
-  { have A : ∀q, 0 ≤ dist (Φ p) (Φ q) + dist (Ψ p) (Ψ q) :=
+  { have A : ∀ q, 0 ≤ dist (Φ p) (Φ q) + dist (Ψ p) (Ψ q) :=
       λq, by rw ← add_zero (0 : ℝ); exact add_le_add dist_nonneg dist_nonneg,
     refine le_antisymm _ (le_cinfi A),
     have : 0 = dist (Φ p) (Φ p) + dist (Ψ p) (Ψ p), by simp,
@@ -85,22 +84,22 @@ begin
   rw [glue_dist, this, zero_add]
 end
 
-private lemma glue_dist_comm (Φ : γ → α) (Ψ : γ → β) (ε : ℝ) :
-  ∀x y, glue_dist Φ Ψ ε x y = glue_dist Φ Ψ ε y x
+private lemma glue_dist_comm (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ) :
+  ∀ x y, glue_dist Φ Ψ ε x y = glue_dist Φ Ψ ε y x
 | (inl x) (inl y) := dist_comm _ _
 | (inr x) (inr y) := dist_comm _ _
 | (inl x) (inr y) := rfl
 | (inr x) (inl y) := rfl
 
-variable [nonempty γ]
+variable [nonempty Z]
 
-private lemma glue_dist_triangle (Φ : γ → α) (Ψ : γ → β) (ε : ℝ)
-  (H : ∀p q, abs (dist (Φ p) (Φ q) - dist (Ψ p) (Ψ q)) ≤ 2 * ε) :
-  ∀x y z, glue_dist Φ Ψ ε x z ≤ glue_dist Φ Ψ ε x y + glue_dist Φ Ψ ε y z
+private lemma glue_dist_triangle (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ)
+  (H : ∀ p q, abs (dist (Φ p) (Φ q) - dist (Ψ p) (Ψ q)) ≤ 2 * ε) :
+  ∀ x y z, glue_dist Φ Ψ ε x z ≤ glue_dist Φ Ψ ε x y + glue_dist Φ Ψ ε y z
 | (inl x) (inl y) (inl z) := dist_triangle _ _ _
 | (inr x) (inr y) (inr z) := dist_triangle _ _ _
 | (inr x) (inl y) (inl z) := begin
-    have B : ∀a b, bdd_below (range (λ (p : γ), dist a (Φ p) + dist b (Ψ p))) :=
+    have B : ∀ a b, bdd_below (range (λ (p : Z), dist a (Φ p) + dist b (Ψ p))) :=
       λa b, ⟨0, forall_range_iff.2 (λp, add_nonneg dist_nonneg dist_nonneg)⟩,
     unfold glue_dist,
     have : (⨅ p, dist z (Φ p) + dist x (Ψ p)) ≤ (⨅ p, dist y (Φ p) + dist x (Ψ p)) + dist y z,
@@ -118,7 +117,7 @@ private lemma glue_dist_triangle (Φ : γ → α) (Ψ : γ → β) (ε : ℝ)
     linarith
   end
 | (inr x) (inr y) (inl z) := begin
-    have B : ∀a b, bdd_below (range (λ (p : γ), dist a (Φ p) + dist b (Ψ p))) :=
+    have B : ∀ a b, bdd_below (range (λ (p : Z), dist a (Φ p) + dist b (Ψ p))) :=
       λa b, ⟨0, forall_range_iff.2 (λp, add_nonneg dist_nonneg dist_nonneg)⟩,
     unfold glue_dist,
     have : (⨅ p, dist z (Φ p) + dist x (Ψ p)) ≤ dist x y + ⨅ p, dist z (Φ p) + dist y (Ψ p),
@@ -136,7 +135,7 @@ private lemma glue_dist_triangle (Φ : γ → α) (Ψ : γ → β) (ε : ℝ)
     linarith
   end
 | (inl x) (inl y) (inr z) := begin
-    have B : ∀a b, bdd_below (range (λ (p : γ), dist a (Φ p) + dist b (Ψ p))) :=
+    have B : ∀ a b, bdd_below (range (λ (p : Z), dist a (Φ p) + dist b (Ψ p))) :=
       λa b, ⟨0, forall_range_iff.2 (λp, add_nonneg dist_nonneg dist_nonneg)⟩,
     unfold glue_dist,
     have : (⨅ p, dist x (Φ p) + dist z (Ψ p)) ≤ dist x y + ⨅ p, dist y (Φ p) + dist z (Ψ p),
@@ -154,7 +153,7 @@ private lemma glue_dist_triangle (Φ : γ → α) (Ψ : γ → β) (ε : ℝ)
     linarith
   end
 | (inl x) (inr y) (inr z) := begin
-    have B : ∀a b, bdd_below (range (λ (p : γ), dist a (Φ p) + dist b (Ψ p))) :=
+    have B : ∀ a b, bdd_below (range (λ (p : Z), dist a (Φ p) + dist b (Ψ p))) :=
       λa b, ⟨0, forall_range_iff.2 (λp, add_nonneg dist_nonneg dist_nonneg)⟩,
     unfold glue_dist,
     have : (⨅ p, dist x (Φ p) + dist z (Ψ p)) ≤ (⨅ p, dist x (Φ p) + dist y (Ψ p)) + dist y z,
@@ -200,8 +199,8 @@ private lemma glue_dist_triangle (Φ : γ → α) (Ψ : γ → β) (ε : ℝ)
             ((⨅ p, dist y (Φ p) + dist z (Ψ p)) + ε) + δ : by linarith
   end
 
-private lemma glue_eq_of_dist_eq_zero (Φ : γ → α) (Ψ : γ → β) (ε : ℝ) (ε0 : 0 < ε) :
-  ∀p q : α ⊕ β, glue_dist Φ Ψ ε p q = 0 → p = q
+private lemma glue_eq_of_dist_eq_zero (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ) (ε0 : 0 < ε) :
+  ∀ p q : X ⊕ Y, glue_dist Φ Ψ ε p q = 0 → p = q
 | (inl x) (inl y) h := by rw eq_of_dist_eq_zero h
 | (inl x) (inr y) h := begin
     have : 0 ≤ (⨅ p, dist x (Φ p) + dist y (Ψ p)) :=
@@ -220,11 +219,12 @@ private lemma glue_eq_of_dist_eq_zero (Φ : γ → α) (Ψ : γ → β) (ε : �
   end
 | (inr x) (inr y) h := by rw eq_of_dist_eq_zero h
 
-/-- Given two maps Φ and Ψ intro metric spaces α and β such that the distances between Φ p and Φ q,
-and between Ψ p and Ψ q, coincide up to 2 ε where ε > 0, one can almost glue the two spaces α
-and β along the images of Φ and Ψ, so that Φ p and Ψ p are at distance ε. -/
-def glue_metric_approx (Φ : γ → α) (Ψ : γ → β) (ε : ℝ) (ε0 : 0 < ε)
-  (H : ∀p q, abs (dist (Φ p) (Φ q) - dist (Ψ p) (Ψ q)) ≤ 2 * ε) : metric_space (α ⊕ β) :=
+/-- Given two maps `Φ` and `Ψ` intro metric spaces `X` and `Y` such that the distances between
+`Φ p` and `Φ q`, and between `Ψ p` and `Ψ q`, coincide up to `2 ε` where `ε > 0`, one can almost
+glue the two spaces `X` and `Y` along the images of `Φ` and `Ψ`, so that `Φ p` and `Ψ p` are
+at distance `ε`. -/
+def glue_metric_approx (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ) (ε0 : 0 < ε)
+  (H : ∀ p q, abs (dist (Φ p) (Φ q) - dist (Ψ p) (Ψ q)) ≤ 2 * ε) : metric_space (X ⊕ Y) :=
 { dist               := glue_dist Φ Ψ ε,
   dist_self          := glue_dist_self Φ Ψ ε,
   dist_comm          := glue_dist_comm Φ Ψ ε,
@@ -234,57 +234,58 @@ def glue_metric_approx (Φ : γ → α) (Ψ : γ → β) (ε : ℝ) (ε0 : 0 < �
 end approx_gluing
 
 section sum
-/- A particular case of the previous construction is when one uses basepoints in α and β and one
+/- A particular case of the previous construction is when one uses basepoints in `X` and `Y` and one
 glues only along the basepoints, putting them at distance 1. We give a direct definition of
 the distance, without infi, as it is easier to use in applications, and show that it is equal to
 the gluing distance defined above to take advantage of the lemmas we have already proved. -/
 
-variables [metric_space α] [metric_space β] [inhabited α] [inhabited β]
+
+variables {X : Type u} {Y : Type v} {Z : Type w}
+variables [metric_space X] [metric_space Y] [inhabited X] [inhabited Y]
 open sum (inl inr)
 
-/- Distance on a disjoint union. There are many (noncanonical) ways to put a distance compatible
+/-- Distance on a disjoint union. There are many (noncanonical) ways to put a distance compatible
 with each factor.
 If the two spaces are bounded, one can say for instance that each point in the first is at distance
-`diam α + diam β + 1` of each point in the second.
+`diam X + diam Y + 1` of each point in the second.
 Instead, we choose a construction that works for unbounded spaces, but requires basepoints.
 We embed isometrically each factor, set the basepoints at distance 1,
 arbitrarily, and say that the distance from `a` to `b` is the sum of the distances of `a` and `b` to
 their respective basepoints, plus the distance 1 between the basepoints.
 Since there is an arbitrary choice in this construction, it is not an instance by default. -/
-
-def sum.dist : α ⊕ β → α ⊕ β → ℝ
+def sum.dist : X ⊕ Y → X ⊕ Y → ℝ
 | (inl a) (inl a') := dist a a'
 | (inr b) (inr b') := dist b b'
-| (inl a) (inr b)  := dist a (default α) + 1 + dist (default β) b
-| (inr b) (inl a)  := dist b (default β) + 1 + dist (default α) a
+| (inl a) (inr b)  := dist a (default X) + 1 + dist (default Y) b
+| (inr b) (inl a)  := dist b (default Y) + 1 + dist (default X) a
 
-lemma sum.dist_eq_glue_dist {p q : α ⊕ β} :
-  sum.dist p q = glue_dist (λ_ : unit, default α) (λ_ : unit, default β) 1 p q :=
+lemma sum.dist_eq_glue_dist {p q : X ⊕ Y} :
+  sum.dist p q = glue_dist (λ_ : unit, default X) (λ_ : unit, default Y) 1 p q :=
 by cases p; cases q; refl <|> simp [sum.dist, glue_dist, dist_comm, add_comm, add_left_comm]
 
-private lemma sum.dist_comm (x y : α ⊕ β) : sum.dist x y = sum.dist y x :=
+private lemma sum.dist_comm (x y : X ⊕ Y) : sum.dist x y = sum.dist y x :=
 by cases x; cases y; simp only [sum.dist, dist_comm, add_comm, add_left_comm]
 
-lemma sum.one_dist_le {x : α} {y : β} : 1 ≤ sum.dist (inl x) (inr y) :=
+lemma sum.one_dist_le {x : X} {y : Y} : 1 ≤ sum.dist (inl x) (inr y) :=
 le_trans (le_add_of_nonneg_right dist_nonneg) $
 add_le_add_right (le_add_of_nonneg_left dist_nonneg) _
 
-lemma sum.one_dist_le' {x : α} {y : β} : 1 ≤ sum.dist (inr y) (inl x) :=
+lemma sum.one_dist_le' {x : X} {y : Y} : 1 ≤ sum.dist (inr y) (inl x) :=
 by rw sum.dist_comm; exact sum.one_dist_le
 
-private lemma sum.mem_uniformity (s : set ((α ⊕ β) × (α ⊕ β))) :
-  s ∈ 𝓤 (α ⊕ β) ↔ ∃ ε > 0, ∀ a b, sum.dist a b < ε → (a, b) ∈ s :=
+private lemma sum.mem_uniformity (s : set ((X ⊕ Y) × (X ⊕ Y))) :
+  s ∈ 𝓤 (X ⊕ Y) ↔ ∃ ε > 0, ∀ a b, sum.dist a b < ε → (a, b) ∈ s :=
 begin
   split,
-  { rintro ⟨hsα, hsβ⟩,
-    rcases mem_uniformity_dist.1 hsα with ⟨εα, εα0, hα⟩,
-    rcases mem_uniformity_dist.1 hsβ with ⟨εβ, εβ0, hβ⟩,
-    refine ⟨min (min εα εβ) 1, lt_min (lt_min εα0 εβ0) zero_lt_one, _⟩,
+  { rintro ⟨hsX, hsY⟩,
+    rcases mem_uniformity_dist.1 hsX with ⟨εX, εX0, hX⟩,
+    rcases mem_uniformity_dist.1 hsY with ⟨εY, εY0, hY⟩,
+    refine ⟨min (min εX εY) 1, lt_min (lt_min εX0 εY0) zero_lt_one, _⟩,
     rintro (a|a) (b|b) h,
-    { exact hα (lt_of_lt_of_le h (le_trans (min_le_left _ _) (min_le_left _ _))) },
+    { exact hX (lt_of_lt_of_le h (le_trans (min_le_left _ _) (min_le_left _ _))) },
     { cases not_le_of_lt (lt_of_lt_of_le h (min_le_right _ _)) sum.one_dist_le },
     { cases not_le_of_lt (lt_of_lt_of_le h (min_le_right _ _)) sum.one_dist_le' },
-    { exact hβ (lt_of_lt_of_le h (le_trans (min_le_left _ _) (min_le_right _ _))) } },
+    { exact hY (lt_of_lt_of_le h (le_trans (min_le_left _ _) (min_le_right _ _))) } },
   { rintro ⟨ε, ε0, H⟩,
     split; rw [filter.mem_sets, filter.mem_map, mem_uniformity_dist];
       exact ⟨ε, ε0, λ x y h, H _ _ (by exact h)⟩ }
@@ -293,7 +294,7 @@ end
 /-- The distance on the disjoint union indeed defines a metric space. All the distance properties
 follow from our choice of the distance. The harder work is to show that the uniform structure
 defined by the distance coincides with the disjoint union uniform structure. -/
-def metric_space_sum : metric_space (α ⊕ β) :=
+def metric_space_sum : metric_space (X ⊕ Y) :=
 { dist               := sum.dist,
   dist_self          := λx, by cases x; simp only [sum.dist, dist_self],
   dist_comm          := sum.dist_comm,
@@ -306,14 +307,14 @@ def metric_space_sum : metric_space (α ⊕ β) :=
 
 local attribute [instance] metric_space_sum
 
-lemma sum.dist_eq {x y : α ⊕ β} : dist x y = sum.dist x y := rfl
+lemma sum.dist_eq {x y : X ⊕ Y} : dist x y = sum.dist x y := rfl
 
 /-- The left injection of a space in a disjoint union in an isometry -/
-lemma isometry_on_inl : isometry (sum.inl : α → (α ⊕ β)) :=
+lemma isometry_on_inl : isometry (sum.inl : X → (X ⊕ Y)) :=
 isometry_emetric_iff_metric.2 $ λx y, rfl
 
 /-- The right injection of a space in a disjoint union in an isometry -/
-lemma isometry_on_inr : isometry (sum.inr : β → (α ⊕ β)) :=
+lemma isometry_on_inr : isometry (sum.inr : Y → (X ⊕ Y)) :=
 isometry_emetric_iff_metric.2 $ λx y, rfl
 
 end sum
@@ -321,17 +322,22 @@ end sum
 section gluing
 /- Exact gluing of two metric spaces along isometric subsets. -/
 
-variables [nonempty γ] [metric_space γ] [metric_space α] [metric_space β]
-          {Φ : γ → α} {Ψ : γ → β} {ε : ℝ}
+variables {X : Type u} {Y : Type v} {Z : Type w}
+variables [nonempty Z] [metric_space Z] [metric_space X] [metric_space Y]
+          {Φ : Z → X} {Ψ : Z → Y} {ε : ℝ}
 open sum (inl inr)
 local attribute [instance] pseudo_metric.dist_setoid
 
-def glue_premetric (hΦ : isometry Φ) (hΨ : isometry Ψ) : pseudo_metric_space (α ⊕ β) :=
+/-- Given two isometric embeddings `Φ : Z → X` and `Ψ : Z → Y`, we define a pseudo metric space
+structure on `X ⊕ Y` by declaring that `Φ x` and `Ψ x` are at distance `0`. -/
+def glue_premetric (hΦ : isometry Φ) (hΨ : isometry Ψ) : pseudo_metric_space (X ⊕ Y) :=
 { dist          := glue_dist Φ Ψ 0,
   dist_self     := glue_dist_self Φ Ψ 0,
   dist_comm     := glue_dist_comm Φ Ψ 0,
   dist_triangle := glue_dist_triangle Φ Ψ 0 $ λp q, by rw [hΦ.dist_eq, hΨ.dist_eq]; simp }
 
+/-- Given two isometric embeddings `Φ : Z → X` and `Ψ : Z → Y`, we define a
+space  `glue_space hΦ hΨ` by identifying in `X ⊕ Y` the points `Φ x` and `Ψ x`. -/
 def glue_space (hΦ : isometry Φ) (hΨ : isometry Ψ) : Type* :=
 @pseudo_metric_quot _ (glue_premetric hΦ hΨ)
 
@@ -339,24 +345,26 @@ instance metric_space_glue_space (hΦ : isometry Φ) (hΨ : isometry Ψ) :
   metric_space (glue_space hΦ hΨ) :=
 @metric_space_quot _ (glue_premetric hΦ hΨ)
 
-def to_glue_l (hΦ : isometry Φ) (hΨ : isometry Ψ) (x : α) : glue_space hΦ hΨ :=
-by letI : pseudo_metric_space (α ⊕ β) := glue_premetric hΦ hΨ; exact ⟦inl x⟧
+/-- The canonical map from `X` to the space obtained by gluing isometric subsets in `X` and `Y`. -/
+def to_glue_l (hΦ : isometry Φ) (hΨ : isometry Ψ) (x : X) : glue_space hΦ hΨ :=
+by letI : pseudo_metric_space (X ⊕ Y) := glue_premetric hΦ hΨ; exact ⟦inl x⟧
 
-def to_glue_r (hΦ : isometry Φ) (hΨ : isometry Ψ) (y : β) : glue_space hΦ hΨ :=
-by letI : pseudo_metric_space (α ⊕ β) := glue_premetric hΦ hΨ; exact ⟦inr y⟧
+/-- The canonical map from `Y` to the space obtained by gluing isometric subsets in `X` and `Y`. -/
+def to_glue_r (hΦ : isometry Φ) (hΨ : isometry Ψ) (y : Y) : glue_space hΦ hΨ :=
+by letI : pseudo_metric_space (X ⊕ Y) := glue_premetric hΦ hΨ; exact ⟦inr y⟧
 
-instance inhabited_left (hΦ : isometry Φ) (hΨ : isometry Ψ) [inhabited α] :
+instance inhabited_left (hΦ : isometry Φ) (hΨ : isometry Ψ) [inhabited X] :
   inhabited (glue_space hΦ hΨ) :=
 ⟨to_glue_l _ _ (default _)⟩
 
-instance inhabited_right (hΦ : isometry Φ) (hΨ : isometry Ψ) [inhabited β] :
+instance inhabited_right (hΦ : isometry Φ) (hΨ : isometry Ψ) [inhabited Y] :
   inhabited (glue_space hΦ hΨ) :=
 ⟨to_glue_r _ _ (default _)⟩
 
 lemma to_glue_commute (hΦ : isometry Φ) (hΨ : isometry Ψ) :
   (to_glue_l hΦ hΨ) ∘ Φ = (to_glue_r hΦ hΨ) ∘ Ψ :=
 begin
-  letI : pseudo_metric_space (α ⊕ β) := glue_premetric hΦ hΨ,
+  letI : pseudo_metric_space (X ⊕ Y) := glue_premetric hΦ hΨ,
   funext,
   simp only [comp, to_glue_l, to_glue_r, quotient.eq],
   exact glue_dist_glued_points Φ Ψ 0 x
@@ -375,22 +383,23 @@ section inductive_limit
      f 0        f 1        f 2        f 3
 X 0 -----> X 1 -----> X 2 -----> X 3 -----> ...
 where the X n are metric spaces and f n isometric embeddings. We do it by defining a premetric
-space structure on Σn, X n, where the predistance dist x y is obtained by pushing x and y in a
+space structure on Σ n, X n, where the predistance dist x y is obtained by pushing x and y in a
 common X k using composition by the f n, and taking the distance there. This does not depend on
 the choice of k as the f n are isometries. The metric space associated to this premetric space
 is the desired inductive limit.-/
 open nat
 
-variables {X : ℕ → Type u} [∀n, metric_space (X n)] {f : Πn, X n → X (n+1)}
+variables {X : ℕ → Type u} [∀ n, metric_space (X n)] {f : Π n, X n → X (n+1)}
 
-/-- Predistance on the disjoint union Σn, X n. -/
-def inductive_limit_dist (f : Πn, X n → X (n+1)) (x y : Σn, X n) : ℝ :=
+/-- Predistance on the disjoint union `Σ n, X n`. -/
+def inductive_limit_dist (f : Π n, X n → X (n+1)) (x y : Σ n, X n) : ℝ :=
 dist (le_rec_on (le_max_left  x.1 y.1) f x.2 : X (max x.1 y.1))
      (le_rec_on (le_max_right x.1 y.1) f y.2 : X (max x.1 y.1))
 
-/-- The predistance on the disjoint union Σn, X n can be computed in any X k for large enough k.-/
-lemma inductive_limit_dist_eq_dist (I : ∀n, isometry (f n))
-  (x y : Σn, X n) (m : ℕ) : ∀hx : x.1 ≤ m, ∀hy : y.1 ≤ m,
+/-- The predistance on the disjoint union `Σ n, X n` can be computed in any `X k` for large
+enough `k`. -/
+lemma inductive_limit_dist_eq_dist (I : ∀ n, isometry (f n))
+  (x y : Σ n, X n) (m : ℕ) : ∀ hx : x.1 ≤ m, ∀ hy : y.1 ≤ m,
   inductive_limit_dist f x y = dist (le_rec_on hx f x.2 : X m) (le_rec_on hy f y.2 : X m) :=
 begin
   induction m with m hm,
@@ -410,9 +419,9 @@ begin
       exact hm xm ym }}
 end
 
-/-- Premetric space structure on Σn, X n.-/
-def inductive_premetric (I : ∀n, isometry (f n)) :
-  pseudo_metric_space (Σn, X n) :=
+/-- Premetric space structure on `Σ n, X n`.-/
+def inductive_premetric (I : ∀ n, isometry (f n)) :
+  pseudo_metric_space (Σ n, X n) :=
 { dist          := inductive_limit_dist f,
   dist_self     := λx, by simp [dist, inductive_limit_dist],
   dist_comm     := λx y, begin
@@ -442,23 +451,23 @@ def inductive_premetric (I : ∀n, isometry (f n)) :
 local attribute [instance] inductive_premetric pseudo_metric.dist_setoid
 
 /-- The type giving the inductive limit in a metric space context. -/
-def inductive_limit (I : ∀n, isometry (f n)) : Type* :=
+def inductive_limit (I : ∀ n, isometry (f n)) : Type* :=
 @pseudo_metric_quot _ (inductive_premetric I)
 
 /-- Metric space structure on the inductive limit. -/
-instance metric_space_inductive_limit (I : ∀n, isometry (f n)) :
+instance metric_space_inductive_limit (I : ∀ n, isometry (f n)) :
   metric_space (inductive_limit I) :=
 @metric_space_quot _ (inductive_premetric I)
 
 /-- Mapping each `X n` to the inductive limit. -/
-def to_inductive_limit (I : ∀n, isometry (f n)) (n : ℕ) (x : X n) : metric.inductive_limit I :=
-by letI : pseudo_metric_space (Σn, X n) := inductive_premetric I; exact ⟦sigma.mk n x⟧
+def to_inductive_limit (I : ∀ n, isometry (f n)) (n : ℕ) (x : X n) : metric.inductive_limit I :=
+by letI : pseudo_metric_space (Σ n, X n) := inductive_premetric I; exact ⟦sigma.mk n x⟧
 
 instance (I : ∀ n, isometry (f n)) [inhabited (X 0)] : inhabited (inductive_limit I) :=
 ⟨to_inductive_limit _ 0 (default _)⟩
 
 /-- The map `to_inductive_limit n` mapping `X n` to the inductive limit is an isometry. -/
-lemma to_inductive_limit_isometry (I : ∀n, isometry (f n)) (n : ℕ) :
+lemma to_inductive_limit_isometry (I : ∀ n, isometry (f n)) (n : ℕ) :
   isometry (to_inductive_limit I n) := isometry_emetric_iff_metric.2 $ λx y,
 begin
   change inductive_limit_dist f ⟨n, x⟩ ⟨n, y⟩ = dist x y,
@@ -467,7 +476,7 @@ begin
 end
 
 /-- The maps `to_inductive_limit n` are compatible with the maps `f n`. -/
-lemma to_inductive_limit_commute (I : ∀n, isometry (f n)) (n : ℕ) :
+lemma to_inductive_limit_commute (I : ∀ n, isometry (f n)) (n : ℕ) :
   (to_inductive_limit I n.succ) ∘ (f n) = to_inductive_limit I n :=
 begin
   funext,

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -61,11 +61,11 @@ compact type to `GH_space`. -/
 /-- Equivalence relation identifying two nonempty compact sets which are isometric -/
 private definition isometry_rel :
   nonempty_compacts ℓ_infty_ℝ → nonempty_compacts ℓ_infty_ℝ → Prop :=
-  λx y, nonempty (x.val ≃ᵢ y.val)
+  λ x y, nonempty (x.val ≃ᵢ y.val)
 
 /-- This is indeed an equivalence relation -/
 private lemma is_equivalence_isometry_rel : equivalence isometry_rel :=
-⟨λx, ⟨isometric.refl _⟩, λx y ⟨e⟩, ⟨e.symm⟩, λ x y z ⟨e⟩ ⟨f⟩, ⟨e.trans f⟩⟩
+⟨λ x, ⟨isometric.refl _⟩, λ x y ⟨e⟩, ⟨e.symm⟩, λ x y z ⟨e⟩ ⟨f⟩, ⟨e.trans f⟩⟩
 
 /-- setoid instance identifying two isometric nonempty compact subspaces of ℓ^∞(ℝ) -/
 instance isometry_rel.setoid : setoid (nonempty_compacts ℓ_infty_ℝ) :=
@@ -75,32 +75,33 @@ setoid.mk isometry_rel is_equivalence_isometry_rel
 definition GH_space : Type := quotient (isometry_rel.setoid)
 
 /-- Map any nonempty compact type to `GH_space` -/
-definition to_GH_space (α : Type u) [metric_space α] [compact_space α] [nonempty α] : GH_space :=
-  ⟦nonempty_compacts.Kuratowski_embedding α⟧
+definition to_GH_space (X : Type u) [metric_space X] [compact_space X] [nonempty X] : GH_space :=
+  ⟦nonempty_compacts.Kuratowski_embedding X⟧
 
 instance : inhabited GH_space := ⟨quot.mk _ ⟨{0}, by simp⟩⟩
 
 /-- A metric space representative of any abstract point in `GH_space` -/
+@[nolint has_inhabited_instance]
 definition GH_space.rep (p : GH_space) : Type := (quot.out p).val
 
-lemma eq_to_GH_space_iff {α : Type u} [metric_space α] [compact_space α] [nonempty α]
+lemma eq_to_GH_space_iff {X : Type u} [metric_space X] [compact_space X] [nonempty X]
   {p : nonempty_compacts ℓ_infty_ℝ} :
-  ⟦p⟧ = to_GH_space α ↔ ∃Ψ : α → ℓ_infty_ℝ, isometry Ψ ∧ range Ψ = p.val :=
+  ⟦p⟧ = to_GH_space X ↔ ∃ Ψ : X → ℓ_infty_ℝ, isometry Ψ ∧ range Ψ = p.val :=
 begin
   simp only [to_GH_space, quotient.eq],
   split,
   { assume h,
     rcases setoid.symm h with ⟨e⟩,
-    have f := (Kuratowski_embedding.isometry α).isometric_on_range.trans e,
-    use λx, f x,
+    have f := (Kuratowski_embedding.isometry X).isometric_on_range.trans e,
+    use λ x, f x,
     split,
     { apply isometry_subtype_coe.comp f.isometry },
     { rw [range_comp, f.range_eq_univ, set.image_univ, subtype.range_coe] } },
   { rintros ⟨Ψ, ⟨isomΨ, rangeΨ⟩⟩,
-    have f := ((Kuratowski_embedding.isometry α).isometric_on_range.symm.trans
+    have f := ((Kuratowski_embedding.isometry X).isometric_on_range.symm.trans
                isomΨ.isometric_on_range).symm,
-    have E : (range Ψ ≃ᵢ (nonempty_compacts.Kuratowski_embedding α).val) =
-        (p.val ≃ᵢ range (Kuratowski_embedding α)),
+    have E : (range Ψ ≃ᵢ (nonempty_compacts.Kuratowski_embedding X).val) =
+        (p.val ≃ᵢ range (Kuratowski_embedding X)),
       by { dunfold nonempty_compacts.Kuratowski_embedding, rw [rangeΨ]; refl },
     have g := cast E f,
     exact ⟨g⟩ }
@@ -108,7 +109,7 @@ end
 
 lemma eq_to_GH_space {p : nonempty_compacts ℓ_infty_ℝ} : ⟦p⟧ = to_GH_space p.val :=
 begin
- refine eq_to_GH_space_iff.2 ⟨((λx, x) : p.val → ℓ_infty_ℝ), _, subtype.range_coe⟩,
+ refine eq_to_GH_space_iff.2 ⟨((λ x, x) : p.val → ℓ_infty_ℝ), _, subtype.range_coe⟩,
  apply isometry_subtype_coe
 end
 
@@ -134,32 +135,32 @@ end
 
 /-- Two nonempty compact spaces have the same image in `GH_space` if and only if they are
 isometric. -/
-lemma to_GH_space_eq_to_GH_space_iff_isometric {α : Type u} [metric_space α] [compact_space α]
-  [nonempty α] {β : Type u} [metric_space β] [compact_space β] [nonempty β] :
-  to_GH_space α = to_GH_space β ↔ nonempty (α ≃ᵢ β) :=
+lemma to_GH_space_eq_to_GH_space_iff_isometric {X : Type u} [metric_space X] [compact_space X]
+  [nonempty X] {Y : Type v} [metric_space Y] [compact_space Y] [nonempty Y] :
+  to_GH_space X = to_GH_space Y ↔ nonempty (X ≃ᵢ Y) :=
 ⟨begin
   simp only [to_GH_space, quotient.eq],
   assume h,
   rcases h with ⟨e⟩,
-  have I : ((nonempty_compacts.Kuratowski_embedding α).val ≃ᵢ
-             (nonempty_compacts.Kuratowski_embedding β).val)
-          = ((range (Kuratowski_embedding α)) ≃ᵢ (range (Kuratowski_embedding β))),
+  have I : ((nonempty_compacts.Kuratowski_embedding X).val ≃ᵢ
+             (nonempty_compacts.Kuratowski_embedding Y).val)
+          = ((range (Kuratowski_embedding X)) ≃ᵢ (range (Kuratowski_embedding Y))),
     by { dunfold nonempty_compacts.Kuratowski_embedding, refl },
   have e' := cast I e,
-  have f := (Kuratowski_embedding.isometry α).isometric_on_range,
-  have g := (Kuratowski_embedding.isometry β).isometric_on_range.symm,
+  have f := (Kuratowski_embedding.isometry X).isometric_on_range,
+  have g := (Kuratowski_embedding.isometry Y).isometric_on_range.symm,
   have h := (f.trans e').trans g,
   exact ⟨h⟩
 end,
 begin
   rintros ⟨e⟩,
   simp only [to_GH_space, quotient.eq],
-  have f := (Kuratowski_embedding.isometry α).isometric_on_range.symm,
-  have g := (Kuratowski_embedding.isometry β).isometric_on_range,
+  have f := (Kuratowski_embedding.isometry X).isometric_on_range.symm,
+  have g := (Kuratowski_embedding.isometry Y).isometric_on_range,
   have h := (f.trans e).trans g,
-  have I : ((range (Kuratowski_embedding α)) ≃ᵢ (range (Kuratowski_embedding β))) =
-    ((nonempty_compacts.Kuratowski_embedding α).val ≃ᵢ
-      (nonempty_compacts.Kuratowski_embedding β).val),
+  have I : ((range (Kuratowski_embedding X)) ≃ᵢ (range (Kuratowski_embedding Y))) =
+    ((nonempty_compacts.Kuratowski_embedding X).val ≃ᵢ
+      (nonempty_compacts.Kuratowski_embedding Y).val),
     by { dunfold nonempty_compacts.Kuratowski_embedding, refl },
   have h' := cast I h,
   exact ⟨h'⟩
@@ -169,39 +170,39 @@ end⟩
 Hausdorff distance between isometric copies of the two spaces in a metric space. For the definition,
 we only consider embeddings in `ℓ^∞(ℝ)`, but we will prove below that it works for all spaces. -/
 instance : has_dist (GH_space) :=
-{ dist := λx y, Inf $
+{ dist := λ x y, Inf $
     (λ p : nonempty_compacts ℓ_infty_ℝ × nonempty_compacts ℓ_infty_ℝ,
       Hausdorff_dist p.1.val p.2.val) '' (set.prod {a | ⟦a⟧ = x} {b | ⟦b⟧ = y}) }
 
 /-- The Gromov-Hausdorff distance between two nonempty compact metric spaces, equal by definition to
 the distance of the equivalence classes of these spaces in the Gromov-Hausdorff space. -/
-def GH_dist (α : Type u) (β : Type v) [metric_space α] [nonempty α] [compact_space α]
-  [metric_space β] [nonempty β] [compact_space β] : ℝ := dist (to_GH_space α) (to_GH_space β)
+def GH_dist (X : Type u) (Y : Type v) [metric_space X] [nonempty X] [compact_space X]
+  [metric_space Y] [nonempty Y] [compact_space Y] : ℝ := dist (to_GH_space X) (to_GH_space Y)
 
 lemma dist_GH_dist (p q : GH_space) : dist p q = GH_dist (p.rep) (q.rep) :=
 by rw [GH_dist, p.to_GH_space_rep, q.to_GH_space_rep]
 
 /-- The Gromov-Hausdorff distance between two spaces is bounded by the Hausdorff distance
 of isometric copies of the spaces, in any metric space. -/
-theorem GH_dist_le_Hausdorff_dist {α : Type u} [metric_space α] [compact_space α] [nonempty α]
-  {β : Type v} [metric_space β] [compact_space β] [nonempty β]
-  {γ : Type w} [metric_space γ] {Φ : α → γ} {Ψ : β → γ} (ha : isometry Φ) (hb : isometry Ψ) :
-  GH_dist α β ≤ Hausdorff_dist (range Φ) (range Ψ) :=
+theorem GH_dist_le_Hausdorff_dist {X : Type u} [metric_space X] [compact_space X] [nonempty X]
+  {Y : Type v} [metric_space Y] [compact_space Y] [nonempty Y]
+  {γ : Type w} [metric_space γ] {Φ : X → γ} {Ψ : Y → γ} (ha : isometry Φ) (hb : isometry Ψ) :
+  GH_dist X Y ≤ Hausdorff_dist (range Φ) (range Ψ) :=
 begin
   /- For the proof, we want to embed `γ` in `ℓ^∞(ℝ)`, to say that the Hausdorff distance is realized
   in `ℓ^∞(ℝ)` and therefore bounded below by the Gromov-Hausdorff-distance. However, `γ` is not
-  separable in general. We restrict to the union of the images of `α` and `β` in `γ`, which is
+  separable in general. We restrict to the union of the images of `X` and `Y` in `γ`, which is
   separable and therefore embeddable in `ℓ^∞(ℝ)`. -/
-  rcases exists_mem_of_nonempty α with ⟨xα, _⟩,
+  rcases exists_mem_of_nonempty X with ⟨xX, _⟩,
   let s : set γ := (range Φ) ∪ (range Ψ),
-  let Φ' : α → subtype s := λy, ⟨Φ y, mem_union_left _ (mem_range_self _)⟩,
-  let Ψ' : β → subtype s := λy, ⟨Ψ y, mem_union_right _ (mem_range_self _)⟩,
-  have IΦ' : isometry Φ' := λx y, ha x y,
-  have IΨ' : isometry Ψ' := λx y, hb x y,
+  let Φ' : X → subtype s := λ y, ⟨Φ y, mem_union_left _ (mem_range_self _)⟩,
+  let Ψ' : Y → subtype s := λ y, ⟨Ψ y, mem_union_right _ (mem_range_self _)⟩,
+  have IΦ' : isometry Φ' := λ x y, ha x y,
+  have IΨ' : isometry Ψ' := λ x y, hb x y,
   have : is_compact s, from (is_compact_range ha.continuous).union (is_compact_range hb.continuous),
   letI : metric_space (subtype s) := by apply_instance,
   haveI : compact_space (subtype s) := ⟨is_compact_iff_is_compact_univ.1 ‹is_compact s›⟩,
-  haveI : nonempty (subtype s) := ⟨Φ' xα⟩,
+  haveI : nonempty (subtype s) := ⟨Φ' xX⟩,
   have ΦΦ' : Φ = subtype.val ∘ Φ', by { funext, refl },
   have ΨΨ' : Ψ = subtype.val ∘ Ψ', by { funext, refl },
   have : Hausdorff_dist (range Φ) (range Ψ) = Hausdorff_dist (range Φ') (range Ψ'),
@@ -213,86 +214,86 @@ begin
   have : Hausdorff_dist (F '' (range Φ')) (F '' (range Ψ')) =
     Hausdorff_dist (range Φ') (range Ψ') := Hausdorff_dist_image (Kuratowski_embedding.isometry _),
   rw ← this,
-  -- Let `A` and `B` be the images of `α` and `β` under this embedding. They are in `ℓ^∞(ℝ)`, and
+  -- Let `A` and `B` be the images of `X` and `Y` under this embedding. They are in `ℓ^∞(ℝ)`, and
   -- their Hausdorff distance is the same as in the original space.
   let A : nonempty_compacts ℓ_infty_ℝ := ⟨F '' (range Φ'), ⟨(range_nonempty _).image _,
       (is_compact_range IΦ'.continuous).image (Kuratowski_embedding.isometry _).continuous⟩⟩,
   let B : nonempty_compacts ℓ_infty_ℝ := ⟨F '' (range Ψ'), ⟨(range_nonempty _).image _,
       (is_compact_range IΨ'.continuous).image (Kuratowski_embedding.isometry _).continuous⟩⟩,
-  have Aα : ⟦A⟧ = to_GH_space α,
+  have AX : ⟦A⟧ = to_GH_space X,
   { rw eq_to_GH_space_iff,
-    exact ⟨λx, F (Φ' x), ⟨(Kuratowski_embedding.isometry _).comp IΦ', by rw range_comp⟩⟩ },
-  have Bβ : ⟦B⟧ = to_GH_space β,
+    exact ⟨λ x, F (Φ' x), ⟨(Kuratowski_embedding.isometry _).comp IΦ', by rw range_comp⟩⟩ },
+  have BY : ⟦B⟧ = to_GH_space Y,
   { rw eq_to_GH_space_iff,
-    exact ⟨λx, F (Ψ' x), ⟨(Kuratowski_embedding.isometry _).comp IΨ', by rw range_comp⟩⟩ },
+    exact ⟨λ x, F (Ψ' x), ⟨(Kuratowski_embedding.isometry _).comp IΨ', by rw range_comp⟩⟩ },
   refine cInf_le ⟨0,
     begin simp [lower_bounds], assume t _ _ _ _ ht, rw ← ht, exact Hausdorff_dist_nonneg end⟩ _,
   apply (mem_image _ _ _).2,
   existsi (⟨A, B⟩ : nonempty_compacts ℓ_infty_ℝ × nonempty_compacts ℓ_infty_ℝ),
-  simp [Aα, Bβ]
+  simp [AX, BY]
 end
 
 /-- The optimal coupling constructed above realizes exactly the Gromov-Hausdorff distance,
 essentially by design. -/
-lemma Hausdorff_dist_optimal {α : Type u} [metric_space α] [compact_space α] [nonempty α]
-  {β : Type v} [metric_space β] [compact_space β] [nonempty β] :
-  Hausdorff_dist (range (optimal_GH_injl α β)) (range (optimal_GH_injr α β)) = GH_dist α β :=
+lemma Hausdorff_dist_optimal {X : Type u} [metric_space X] [compact_space X] [nonempty X]
+  {Y : Type v} [metric_space Y] [compact_space Y] [nonempty Y] :
+  Hausdorff_dist (range (optimal_GH_injl X Y)) (range (optimal_GH_injr X Y)) = GH_dist X Y :=
 begin
-  inhabit α, inhabit β,
+  inhabit X, inhabit Y,
   /- we only need to check the inequality `≤`, as the other one follows from the previous lemma.
      As the Gromov-Hausdorff distance is an infimum, we need to check that the Hausdorff distance
      in the optimal coupling is smaller than the Hausdorff distance of any coupling.
      First, we check this for couplings which already have small Hausdorff distance: in this
-     case, the induced "distance" on `α ⊕ β` belongs to the candidates family introduced in the
+     case, the induced "distance" on `X ⊕ Y` belongs to the candidates family introduced in the
      definition of the optimal coupling, and the conclusion follows from the optimality
      of the optimal coupling within this family.
   -/
-  have A : ∀p q : nonempty_compacts (ℓ_infty_ℝ), ⟦p⟧ = to_GH_space α → ⟦q⟧ = to_GH_space β →
-        Hausdorff_dist (p.val) (q.val) < diam (univ : set α) + 1 + diam (univ : set β) →
-        Hausdorff_dist (range (optimal_GH_injl α β)) (range (optimal_GH_injr α β)) ≤
+  have A : ∀ p q : nonempty_compacts (ℓ_infty_ℝ), ⟦p⟧ = to_GH_space X → ⟦q⟧ = to_GH_space Y →
+        Hausdorff_dist (p.val) (q.val) < diam (univ : set X) + 1 + diam (univ : set Y) →
+        Hausdorff_dist (range (optimal_GH_injl X Y)) (range (optimal_GH_injr X Y)) ≤
         Hausdorff_dist (p.val) (q.val),
   { assume p q hp hq bound,
     rcases eq_to_GH_space_iff.1 hp with ⟨Φ, ⟨Φisom, Φrange⟩⟩,
     rcases eq_to_GH_space_iff.1 hq with ⟨Ψ, ⟨Ψisom, Ψrange⟩⟩,
-    have I : diam (range Φ ∪ range Ψ) ≤ 2 * diam (univ : set α) + 1 + 2 * diam (univ : set β),
-    { rcases exists_mem_of_nonempty α with ⟨xα, _⟩,
-      have : ∃y ∈ range Ψ, dist (Φ xα) y < diam (univ : set α) + 1 + diam (univ : set β),
+    have I : diam (range Φ ∪ range Ψ) ≤ 2 * diam (univ : set X) + 1 + 2 * diam (univ : set Y),
+    { rcases exists_mem_of_nonempty X with ⟨xX, _⟩,
+      have : ∃ y ∈ range Ψ, dist (Φ xX) y < diam (univ : set X) + 1 + diam (univ : set Y),
       { rw Ψrange,
-        have : Φ xα ∈ p.val := Φrange ▸ mem_range_self _,
+        have : Φ xX ∈ p.val := Φrange ▸ mem_range_self _,
         exact exists_dist_lt_of_Hausdorff_dist_lt this bound
           (Hausdorff_edist_ne_top_of_nonempty_of_bounded p.2.1 q.2.1 p.2.2.bounded q.2.2.bounded) },
       rcases this with ⟨y, hy, dy⟩,
       rcases mem_range.1 hy with ⟨z, hzy⟩,
       rw ← hzy at dy,
-      have DΦ : diam (range Φ) = diam (univ : set α) := Φisom.diam_range,
-      have DΨ : diam (range Ψ) = diam (univ : set β) := Ψisom.diam_range,
+      have DΦ : diam (range Φ) = diam (univ : set X) := Φisom.diam_range,
+      have DΨ : diam (range Ψ) = diam (univ : set Y) := Ψisom.diam_range,
       calc
-        diam (range Φ ∪ range Ψ) ≤ diam (range Φ) + dist (Φ xα) (Ψ z) + diam (range Ψ) :
+        diam (range Φ ∪ range Ψ) ≤ diam (range Φ) + dist (Φ xX) (Ψ z) + diam (range Ψ) :
           diam_union (mem_range_self _) (mem_range_self _)
-        ... ≤ diam (univ : set α) + (diam (univ : set α) + 1 + diam (univ : set β)) +
-              diam (univ : set β) :
+        ... ≤ diam (univ : set X) + (diam (univ : set X) + 1 + diam (univ : set Y)) +
+              diam (univ : set Y) :
           by { rw [DΦ, DΨ], apply add_le_add (add_le_add (le_refl _) (le_of_lt dy)) (le_refl _) }
-        ... = 2 * diam (univ : set α) + 1 + 2 * diam (univ : set β) : by ring },
+        ... = 2 * diam (univ : set X) + 1 + 2 * diam (univ : set Y) : by ring },
 
-    let f : α ⊕ β → ℓ_infty_ℝ := λx, match x with | inl y := Φ y | inr z := Ψ z end,
-    let F : (α ⊕ β) × (α ⊕ β) → ℝ := λp, dist (f p.1) (f p.2),
+    let f : X ⊕ Y → ℓ_infty_ℝ := λ x, match x with | inl y := Φ y | inr z := Ψ z end,
+    let F : (X ⊕ Y) × (X ⊕ Y) → ℝ := λ p, dist (f p.1) (f p.2),
     -- check that the induced "distance" is a candidate
-    have Fgood : F ∈ candidates α β,
+    have Fgood : F ∈ candidates X Y,
     { simp only [candidates, forall_const, and_true, add_comm, eq_self_iff_true, dist_eq_zero,
                  and_self, set.mem_set_of_eq],
       repeat {split},
-      { exact λx y, calc
+      { exact λ x y, calc
         F (inl x, inl y) = dist (Φ x) (Φ y) : rfl
         ... = dist x y : Φisom.dist_eq x y },
-      { exact λx y, calc
+      { exact λ x y, calc
         F (inr x, inr y) = dist (Ψ x) (Ψ y) : rfl
         ... = dist x y : Ψisom.dist_eq x y },
-      { exact λx y, dist_comm _ _ },
-      { exact λx y z, dist_triangle _ _ _ },
-      { exact λx y, calc
+      { exact λ x y, dist_comm _ _ },
+      { exact λ x y z, dist_triangle _ _ _ },
+      { exact λ x y, calc
         F (x, y) ≤ diam (range Φ ∪ range Ψ) :
         begin
-          have A : ∀z : α ⊕ β, f z ∈ range Φ ∪ range Ψ,
+          have A : ∀ z : X ⊕ Y, f z ∈ range Φ ∪ range Ψ,
           { assume z,
             cases z,
             { apply mem_union_left, apply mem_range_self },
@@ -301,12 +302,12 @@ begin
           rw [Φrange, Ψrange],
           exact (p.2.2.union q.2.2).bounded,
         end
-        ... ≤ 2 * diam (univ : set α) + 1 + 2 * diam (univ : set β) : I } },
+        ... ≤ 2 * diam (univ : set X) + 1 + 2 * diam (univ : set Y) : I } },
     let Fb := candidates_b_of_candidates F Fgood,
-    have : Hausdorff_dist (range (optimal_GH_injl α β)) (range (optimal_GH_injr α β)) ≤ HD Fb :=
+    have : Hausdorff_dist (range (optimal_GH_injl X Y)) (range (optimal_GH_injr X Y)) ≤ HD Fb :=
       Hausdorff_dist_optimal_le_HD _ _ (candidates_b_of_candidates_mem F Fgood),
-    refine le_trans this (le_of_forall_le_of_dense (λr hr, _)),
-    have I1 : ∀x : α, (⨅ y, Fb (inl x, inr y)) ≤ r,
+    refine le_trans this (le_of_forall_le_of_dense (λ r hr, _)),
+    have I1 : ∀ x : X, (⨅ y, Fb (inl x, inr y)) ≤ r,
     { assume x,
       have : f (inl x) ∈ p.val, by { rw [← Φrange], apply mem_range_self },
       rcases exists_dist_lt_of_Hausdorff_dist_lt this hr
@@ -319,7 +320,7 @@ begin
         ... = dist (Φ x) (Ψ y) : rfl
         ... = dist (f (inl x)) z : by rw hy
         ... ≤ r : le_of_lt hz },
-    have I2 : ∀y : β, (⨅ x, Fb (inl x, inr y)) ≤ r,
+    have I2 : ∀ y : Y, (⨅ x, Fb (inl x, inr y)) ≤ r,
     { assume y,
       have : f (inr y) ∈ q.val, by { rw [← Ψrange], apply mem_range_self },
       rcases exists_dist_lt_of_Hausdorff_dist_lt' this hr
@@ -335,51 +336,46 @@ begin
     simp [HD, csupr_le I1, csupr_le I2] },
   /- Get the same inequality for any coupling. If the coupling is quite good, the desired
   inequality has been proved above. If it is bad, then the inequality is obvious. -/
-  have B : ∀p q : nonempty_compacts (ℓ_infty_ℝ), ⟦p⟧ = to_GH_space α → ⟦q⟧ = to_GH_space β →
-        Hausdorff_dist (range (optimal_GH_injl α β)) (range (optimal_GH_injr α β)) ≤
+  have B : ∀ p q : nonempty_compacts (ℓ_infty_ℝ), ⟦p⟧ = to_GH_space X → ⟦q⟧ = to_GH_space Y →
+        Hausdorff_dist (range (optimal_GH_injl X Y)) (range (optimal_GH_injr X Y)) ≤
         Hausdorff_dist (p.val) (q.val),
   { assume p q hp hq,
-    by_cases h : Hausdorff_dist (p.val) (q.val) < diam (univ : set α) + 1 + diam (univ : set β),
+    by_cases h : Hausdorff_dist (p.val) (q.val) < diam (univ : set X) + 1 + diam (univ : set Y),
     { exact A p q hp hq h },
-    { calc Hausdorff_dist (range (optimal_GH_injl α β)) (range (optimal_GH_injr α β))
-               ≤ HD (candidates_b_dist α β) :
+    { calc Hausdorff_dist (range (optimal_GH_injl X Y)) (range (optimal_GH_injr X Y))
+               ≤ HD (candidates_b_dist X Y) :
              Hausdorff_dist_optimal_le_HD _ _ (candidates_b_dist_mem_candidates_b)
-           ... ≤ diam (univ : set α) + 1 + diam (univ : set β) : HD_candidates_b_dist_le
+           ... ≤ diam (univ : set X) + 1 + diam (univ : set Y) : HD_candidates_b_dist_le
            ... ≤ Hausdorff_dist (p.val) (q.val) : not_lt.1 h } },
   refine le_antisymm _ _,
   { apply le_cInf,
     { refine (set.nonempty.prod _ _).image _; exact ⟨_, rfl⟩ },
     { rintro b ⟨⟨p, q⟩, ⟨hp, hq⟩, rfl⟩,
       exact B p q hp hq } },
-  { exact GH_dist_le_Hausdorff_dist (isometry_optimal_GH_injl α β) (isometry_optimal_GH_injr α β) }
+  { exact GH_dist_le_Hausdorff_dist (isometry_optimal_GH_injl X Y) (isometry_optimal_GH_injr X Y) }
 end
 
 /-- The Gromov-Hausdorff distance can also be realized by a coupling in `ℓ^∞(ℝ)`, by embedding
 the optimal coupling through its Kuratowski embedding. -/
-theorem GH_dist_eq_Hausdorff_dist (α : Type u) [metric_space α] [compact_space α] [nonempty α]
-  (β : Type v) [metric_space β] [compact_space β] [nonempty β] :
-  ∃Φ : α → ℓ_infty_ℝ, ∃Ψ : β → ℓ_infty_ℝ, isometry Φ ∧ isometry Ψ ∧
-  GH_dist α β = Hausdorff_dist (range Φ) (range Ψ) :=
+theorem GH_dist_eq_Hausdorff_dist (X : Type u) [metric_space X] [compact_space X] [nonempty X]
+  (Y : Type v) [metric_space Y] [compact_space Y] [nonempty Y] :
+  ∃ Φ : X → ℓ_infty_ℝ, ∃ Ψ : Y → ℓ_infty_ℝ, isometry Φ ∧ isometry Ψ ∧
+  GH_dist X Y = Hausdorff_dist (range Φ) (range Ψ) :=
 begin
-  let F := Kuratowski_embedding (optimal_GH_coupling α β),
-  let Φ := F ∘ optimal_GH_injl α β,
-  let Ψ := F ∘ optimal_GH_injr α β,
+  let F := Kuratowski_embedding (optimal_GH_coupling X Y),
+  let Φ := F ∘ optimal_GH_injl X Y,
+  let Ψ := F ∘ optimal_GH_injr X Y,
   refine ⟨Φ, Ψ, _, _, _⟩,
-  { exact (Kuratowski_embedding.isometry _).comp (isometry_optimal_GH_injl α β) },
-  { exact (Kuratowski_embedding.isometry _).comp (isometry_optimal_GH_injr α β) },
-  { rw [← image_univ, ← image_univ, image_comp F, image_univ, image_comp F (optimal_GH_injr α β),
+  { exact (Kuratowski_embedding.isometry _).comp (isometry_optimal_GH_injl X Y) },
+  { exact (Kuratowski_embedding.isometry _).comp (isometry_optimal_GH_injr X Y) },
+  { rw [← image_univ, ← image_univ, image_comp F, image_univ, image_comp F (optimal_GH_injr X Y),
       image_univ, ← Hausdorff_dist_optimal],
     exact (Hausdorff_dist_image (Kuratowski_embedding.isometry _)).symm },
 end
 
--- without the next two lines, `{ exact hΦ.is_closed }` in the next
--- proof is very slow, as the `t2_space` instance is very hard to find
-local attribute [instance, priority 10] order_topology.t2_space
-local attribute [instance, priority 10] order_closed_topology.to_t2_space
-
 /-- The Gromov-Hausdorff distance defines a genuine distance on the Gromov-Hausdorff space. -/
-instance GH_space_metric_space : metric_space GH_space :=
-{ dist_self := λx, begin
+instance : metric_space GH_space :=
+{ dist_self := λ x, begin
     rcases exists_rep x with ⟨y, hy⟩,
     refine le_antisymm _ _,
     { apply cInf_le,
@@ -389,7 +385,7 @@ instance GH_space_metric_space : metric_space GH_space :=
       { exact (nonempty.prod ⟨y, hy⟩ ⟨y, hy⟩).image _ },
       { rintro b ⟨⟨u, v⟩, ⟨hu, hv⟩, rfl⟩, exact Hausdorff_dist_nonneg } },
   end,
-  dist_comm := λx y, begin
+  dist_comm := λ x y, begin
     have A : (λ (p : nonempty_compacts ℓ_infty_ℝ × nonempty_compacts ℓ_infty_ℝ),
                  Hausdorff_dist ((p.fst).val) ((p.snd).val)) ''
              (set.prod {a | ⟦a⟧ = x} {b | ⟦b⟧ = y})
@@ -399,7 +395,7 @@ instance GH_space_metric_space : metric_space GH_space :=
       by { congr, funext, simp, rw Hausdorff_dist_comm },
     simp only [dist, A, image_comp, image_swap_prod],
   end,
-  eq_of_dist_eq_zero := λx y hxy, begin
+  eq_of_dist_eq_zero := λ x y hxy, begin
     /- To show that two spaces at zero distance are isometric, we argue that the distance
     is realized by some coupling. In this coupling, the two spaces are at zero Hausdorff distance,
     i.e., they coincide. Therefore, the original spaces are isometric. -/
@@ -419,7 +415,7 @@ instance GH_space_metric_space : metric_space GH_space :=
     rw [← x.to_GH_space_rep, ← y.to_GH_space_rep, to_GH_space_eq_to_GH_space_iff_isometric],
     exact ⟨e⟩
   end,
-  dist_triangle := λx y z, begin
+  dist_triangle := λ x y z, begin
     /- To show the triangular inequality between `X`, `Y` and `Z`, realize an optimal coupling
     between `X` and `Y` in a space `γ1`, and an optimal coupling between `Y` and `Z` in a space
     `γ2`. Then, glue these metric spaces along `Y`. We get a new space `γ` in which `X` and `Y` are
@@ -479,35 +475,35 @@ end Gromov_Hausdorff
 
 /-- In particular, nonempty compacts of a metric space map to `GH_space`. We register this
 in the topological_space namespace to take advantage of the notation `p.to_GH_space`. -/
-definition topological_space.nonempty_compacts.to_GH_space {α : Type u} [metric_space α]
-  (p : nonempty_compacts α) : Gromov_Hausdorff.GH_space := Gromov_Hausdorff.to_GH_space p.val
+definition topological_space.nonempty_compacts.to_GH_space {X : Type u} [metric_space X]
+  (p : nonempty_compacts X) : Gromov_Hausdorff.GH_space := Gromov_Hausdorff.to_GH_space p.val
 
 open topological_space
 
 namespace Gromov_Hausdorff
 
 section nonempty_compacts
-variables {α : Type u} [metric_space α]
+variables {X : Type u} [metric_space X]
 
-theorem GH_dist_le_nonempty_compacts_dist (p q : nonempty_compacts α) :
+theorem GH_dist_le_nonempty_compacts_dist (p q : nonempty_compacts X) :
   dist p.to_GH_space q.to_GH_space ≤ dist p q :=
 begin
-  have ha : isometry (coe : p.val → α) := isometry_subtype_coe,
-  have hb : isometry (coe : q.val → α) := isometry_subtype_coe,
+  have ha : isometry (coe : p.val → X) := isometry_subtype_coe,
+  have hb : isometry (coe : q.val → X) := isometry_subtype_coe,
   have A : dist p q = Hausdorff_dist p.val q.val := rfl,
-  have I : p.val = range (coe : p.val → α), by simp,
-  have J : q.val = range (coe : q.val → α), by simp,
+  have I : p.val = range (coe : p.val → X), by simp,
+  have J : q.val = range (coe : q.val → X), by simp,
   rw [I, J] at A,
   rw A,
   exact GH_dist_le_Hausdorff_dist ha hb
 end
 
 lemma to_GH_space_lipschitz :
-  lipschitz_with 1 (nonempty_compacts.to_GH_space : nonempty_compacts α → GH_space) :=
+  lipschitz_with 1 (nonempty_compacts.to_GH_space : nonempty_compacts X → GH_space) :=
 lipschitz_with.mk_one GH_dist_le_nonempty_compacts_dist
 
 lemma to_GH_space_continuous :
-  continuous (nonempty_compacts.to_GH_space : nonempty_compacts α → GH_space) :=
+  continuous (nonempty_compacts.to_GH_space : nonempty_compacts X → GH_space) :=
 to_GH_space_lipschitz.continuous
 
 end nonempty_compacts
@@ -520,45 +516,45 @@ distance between the spaces is bounded by `ε₁ + ε₂/2 + ε₃`. For this, w
 coupling between the two spaces, by gluing them (approximately) along the two matching subsets. -/
 
 
-variables {α : Type u} [metric_space α] [compact_space α] [nonempty α]
-          {β : Type v} [metric_space β] [compact_space β] [nonempty β]
+variables {X : Type u} [metric_space X] [compact_space X] [nonempty X]
+          {Y : Type v} [metric_space Y] [compact_space Y] [nonempty Y]
 
 -- we want to ignore these instances in the following theorem
 local attribute [instance, priority 10] sum.topological_space sum.uniform_space
 /-- If there are subsets which are `ε₁`-dense and `ε₃`-dense in two spaces, and
 isometric up to `ε₂`, then the Gromov-Hausdorff distance between the spaces is bounded by
 `ε₁ + ε₂/2 + ε₃`. -/
-theorem GH_dist_le_of_approx_subsets {s : set α} (Φ : s → β) {ε₁ ε₂ ε₃ : ℝ}
-  (hs : ∀x : α, ∃y ∈ s, dist x y ≤ ε₁) (hs' : ∀x : β, ∃y : s, dist x (Φ y) ≤ ε₃)
-  (H : ∀x y : s, abs (dist x y - dist (Φ x) (Φ y)) ≤ ε₂) :
-  GH_dist α β ≤ ε₁ + ε₂ / 2 + ε₃ :=
+theorem GH_dist_le_of_approx_subsets {s : set X} (Φ : s → Y) {ε₁ ε₂ ε₃ : ℝ}
+  (hs : ∀ x : X, ∃ y ∈ s, dist x y ≤ ε₁) (hs' : ∀ x : Y, ∃ y : s, dist x (Φ y) ≤ ε₃)
+  (H : ∀ x y : s, abs (dist x y - dist (Φ x) (Φ y)) ≤ ε₂) :
+  GH_dist X Y ≤ ε₁ + ε₂ / 2 + ε₃ :=
 begin
-  refine le_of_forall_pos_le_add (λδ δ0, _),
-  rcases exists_mem_of_nonempty α with ⟨xα, _⟩,
-  rcases hs xα with ⟨xs, hxs, Dxs⟩,
+  refine le_of_forall_pos_le_add (λ δ δ0, _),
+  rcases exists_mem_of_nonempty X with ⟨xX, _⟩,
+  rcases hs xX with ⟨xs, hxs, Dxs⟩,
   have sne : s.nonempty := ⟨xs, hxs⟩,
   letI : nonempty s := sne.to_subtype,
   have : 0 ≤ ε₂ := le_trans (abs_nonneg _) (H ⟨xs, hxs⟩ ⟨xs, hxs⟩),
-  have : ∀ p q : s, abs (dist p q - dist (Φ p) (Φ q)) ≤ 2 * (ε₂/2 + δ) := λp q, calc
+  have : ∀ p q : s, abs (dist p q - dist (Φ p) (Φ q)) ≤ 2 * (ε₂/2 + δ) := λ p q, calc
     abs (dist p q - dist (Φ p) (Φ q)) ≤ ε₂ : H p q
     ... ≤ 2 * (ε₂/2 + δ) : by linarith,
-  -- glue `α` and `β` along the almost matching subsets
-  letI : metric_space (α ⊕ β) :=
-    glue_metric_approx (λ x:s, (x:α)) (λx, Φ x) (ε₂/2 + δ) (by linarith) this,
-  let Fl := @sum.inl α β,
-  let Fr := @sum.inr α β,
-  have Il : isometry Fl := isometry_emetric_iff_metric.2 (λx y, rfl),
-  have Ir : isometry Fr := isometry_emetric_iff_metric.2 (λx y, rfl),
+  -- glue `X` and `Y` along the almost matching subsets
+  letI : metric_space (X ⊕ Y) :=
+    glue_metric_approx (λ x:s, (x:X)) (λ x, Φ x) (ε₂/2 + δ) (by linarith) this,
+  let Fl := @sum.inl X Y,
+  let Fr := @sum.inr X Y,
+  have Il : isometry Fl := isometry_emetric_iff_metric.2 (λ x y, rfl),
+  have Ir : isometry Fr := isometry_emetric_iff_metric.2 (λ x y, rfl),
   /- The proof goes as follows : the `GH_dist` is bounded by the Hausdorff distance of the images
   in the coupling, which is bounded (using the triangular inequality) by the sum of the Hausdorff
-  distances of `α` and `s` (in the coupling or, equivalently in the original space), of `s` and
-  `Φ s`, and of `Φ s` and `β` (in the coupling or, equivalently, in the original space). The first
+  distances of `X` and `s` (in the coupling or, equivalently in the original space), of `s` and
+  `Φ s`, and of `Φ s` and `Y` (in the coupling or, equivalently, in the original space). The first
   term is bounded by `ε₁`, by `ε₁`-density. The third one is bounded by `ε₃`. And the middle one is
   bounded by `ε₂/2` as in the coupling the points `x` and `Φ x` are at distance `ε₂/2` by
   construction of the coupling (in fact `ε₂/2 + δ` where `δ` is an arbitrarily small positive
   constant where positivity is used to ensure that the coupling is really a metric space and not a
-  premetric space on `α ⊕ β`). -/
-  have : GH_dist α β ≤ Hausdorff_dist (range Fl) (range Fr) :=
+  premetric space on `X ⊕ Y`). -/
+  have : GH_dist X Y ≤ Hausdorff_dist (range Fl) (range Fr) :=
     GH_dist_le_Hausdorff_dist Il Ir,
   have : Hausdorff_dist (range Fl) (range Fr) ≤ Hausdorff_dist (range Fl) (Fl '' s)
                                               + Hausdorff_dist (Fl '' s) (range Fr),
@@ -574,27 +570,27 @@ begin
   have : Hausdorff_dist (range Fl) (Fl '' s) ≤ ε₁,
   { rw [← image_univ, Hausdorff_dist_image Il],
     have : 0 ≤ ε₁ := le_trans dist_nonneg Dxs,
-    refine Hausdorff_dist_le_of_mem_dist this (λx hx, hs x)
-      (λx hx, ⟨x, mem_univ _, by simpa⟩) },
+    refine Hausdorff_dist_le_of_mem_dist this (λ x hx, hs x)
+      (λ x hx, ⟨x, mem_univ _, by simpa⟩) },
   have : Hausdorff_dist (Fl '' s) (Fr '' (range Φ)) ≤ ε₂/2 + δ,
   { refine Hausdorff_dist_le_of_mem_dist (by linarith) _ _,
     { assume x' hx',
       rcases (set.mem_image _ _ _).1 hx' with ⟨x, ⟨x_in_s, xx'⟩⟩,
       rw ← xx',
       use [Fr (Φ ⟨x, x_in_s⟩), mem_image_of_mem Fr (mem_range_self _)],
-      exact le_of_eq (glue_dist_glued_points (λ x:s, (x:α)) Φ (ε₂/2 + δ) ⟨x, x_in_s⟩) },
+      exact le_of_eq (glue_dist_glued_points (λ x:s, (x:X)) Φ (ε₂/2 + δ) ⟨x, x_in_s⟩) },
     { assume x' hx',
       rcases (set.mem_image _ _ _).1 hx' with ⟨y, ⟨y_in_s', yx'⟩⟩,
       rcases mem_range.1 y_in_s' with ⟨x, xy⟩,
       use [Fl x, mem_image_of_mem _ x.2],
       rw [← yx', ← xy, dist_comm],
-      exact le_of_eq (glue_dist_glued_points (@subtype.val α s) Φ (ε₂/2 + δ) x) } },
+      exact le_of_eq (glue_dist_glued_points (@subtype.val X s) Φ (ε₂/2 + δ) x) } },
   have : Hausdorff_dist (Fr '' (range Φ)) (range Fr) ≤ ε₃,
   { rw [← @image_univ _ _ Fr, Hausdorff_dist_image Ir],
-    rcases exists_mem_of_nonempty β with ⟨xβ, _⟩,
-    rcases hs' xβ with ⟨xs', Dxs'⟩,
+    rcases exists_mem_of_nonempty Y with ⟨xY, _⟩,
+    rcases hs' xY with ⟨xs', Dxs'⟩,
     have : 0 ≤ ε₃ := le_trans dist_nonneg Dxs',
-    refine Hausdorff_dist_le_of_mem_dist this (λx hx, ⟨x, mem_univ _, by simpa⟩) (λx _, _),
+    refine Hausdorff_dist_le_of_mem_dist this (λ x hx, ⟨x, mem_univ _, by simpa⟩) (λ x _, _),
     rcases hs' x with ⟨y, Dy⟩,
     exact ⟨Φ y, mem_range_self _, Dy⟩ },
   linarith
@@ -602,30 +598,30 @@ end
 end --section
 
 /-- The Gromov-Hausdorff space is second countable. -/
-instance second_countable : second_countable_topology GH_space :=
+instance : second_countable_topology GH_space :=
 begin
-  refine second_countable_of_countable_discretization (λδ δpos, _),
+  refine second_countable_of_countable_discretization (λ δ δpos, _),
   let ε := (2/5) * δ,
   have εpos : 0 < ε := mul_pos (by norm_num) δpos,
-  have : ∀p:GH_space, ∃s : set (p.rep), finite s ∧ (univ ⊆ (⋃x∈s, ball x ε)) :=
-    λp, by simpa using finite_cover_balls_of_compact (@compact_univ p.rep _ _) εpos,
+  have : ∀ p:GH_space, ∃ s : set (p.rep), finite s ∧ (univ ⊆ (⋃x∈s, ball x ε)) :=
+    λ p, by simpa using finite_cover_balls_of_compact (@compact_univ p.rep _ _) εpos,
   -- for each `p`, `s p` is a finite `ε`-dense subset of `p` (or rather the metric space
   -- `p.rep` representing `p`)
   choose s hs using this,
-  have : ∀p:GH_space, ∀t:set (p.rep), finite t → ∃n:ℕ, ∃e:equiv t (fin n), true,
+  have : ∀ p:GH_space, ∀ t:set (p.rep), finite t → ∃ n:ℕ, ∃ e:equiv t (fin n), true,
   { assume p t ht,
     letI : fintype t := finite.fintype ht,
     exact ⟨fintype.card t, fintype.equiv_fin t, trivial⟩ },
   choose N e hne using this,
   -- cardinality of the nice finite subset `s p` of `p.rep`, called `N p`
-  let N := λp:GH_space, N p (s p) (hs p).1,
+  let N := λ p:GH_space, N p (s p) (hs p).1,
   -- equiv from `s p`, a nice finite subset of `p.rep`, to `fin (N p)`, called `E p`
-  let E := λp:GH_space, e p (s p) (hs p).1,
+  let E := λ p:GH_space, e p (s p) (hs p).1,
   -- A function `F` associating to `p : GH_space` the data of all distances between points
   -- in the `ε`-dense set `s p`.
   let F : GH_space → Σn:ℕ, (fin n → fin n → ℤ) :=
-    λp, ⟨N p, λa b, floor (ε⁻¹ * dist ((E p).symm a) ((E p).symm b))⟩,
-  refine ⟨_, by apply_instance, F, λp q hpq, _⟩,
+    λ p, ⟨N p, λ a b, floor (ε⁻¹ * dist ((E p).symm a) ((E p).symm b))⟩,
+  refine ⟨_, by apply_instance, F, λ p q hpq, _⟩,
   /- As the target space of F is countable, it suffices to show that two points
   `p` and `q` with `F p = F q` are at distance `≤ δ`.
   For this, we construct a map `Φ` from `s p ⊆ p.rep` (representing `p`)
@@ -635,19 +631,19 @@ begin
   the fact that `N p = N q`, this constructs `Ψ` between `s p` and `s q`, and then
   composing with the canonical inclusion we get `Φ`. -/
   have Npq : N p = N q := (sigma.mk.inj_iff.1 hpq).1,
-  let Ψ : s p → s q := λx, (E q).symm (fin.cast Npq ((E p) x)),
-  let Φ : s p → q.rep := λx, Ψ x,
+  let Ψ : s p → s q := λ x, (E q).symm (fin.cast Npq ((E p) x)),
+  let Φ : s p → q.rep := λ x, Ψ x,
   -- Use the almost isometry `Φ` to show that `p.rep` and `q.rep`
   -- are within controlled Gromov-Hausdorff distance.
   have main : GH_dist p.rep q.rep ≤ ε + ε/2 + ε,
   { refine GH_dist_le_of_approx_subsets Φ  _ _ _,
-    show ∀x : p.rep, ∃ (y : p.rep) (H : y ∈ s p), dist x y ≤ ε,
+    show ∀ x : p.rep, ∃ (y : p.rep) (H : y ∈ s p), dist x y ≤ ε,
     { -- by construction, `s p` is `ε`-dense
       assume x,
       have : x ∈ ⋃y∈(s p), ball y ε := (hs p).2 (mem_univ _),
       rcases mem_bUnion_iff.1 this with ⟨y, ys, hy⟩,
       exact ⟨y, ys, le_of_lt hy⟩ },
-    show ∀x : q.rep, ∃ (z : s p), dist x (Φ z) ≤ ε,
+    show ∀ x : q.rep, ∃ (z : s p), dist x (Φ z) ≤ ε,
     { -- by construction, `s q` is `ε`-dense, and it is the range of `Φ`
       assume x,
       have : x ∈ ⋃y∈(s q), ball y ε := (hs q).2 (mem_univ _),
@@ -667,7 +663,7 @@ begin
         by { simp only [Φ, Ψ], rw [C1, C2, C3], refl },
       rw this,
       exact le_of_lt hy },
-    show ∀x y : s p, abs (dist x y - dist (Φ x) (Φ y)) ≤ ε,
+    show ∀ x y : s p, abs (dist x y - dist (Φ x) (Φ y)) ≤ ε,
     { /- the distance between `x` and `y` is encoded in `F p`, and the distance between
       `Φ x` and `Φ y` (two points of `s q`) is encoded in `F q`, all this up to `ε`.
       As `F p = F q`, the distances are almost equal. -/
@@ -732,8 +728,8 @@ to cover the spaces is uniformly bounded. This is an equivalence, but we only pr
 interesting direction that these conditions imply compactness. -/
 lemma totally_bounded {t : set GH_space} {C : ℝ} {u : ℕ → ℝ} {K : ℕ → ℕ}
   (ulim : tendsto u at_top (𝓝 0))
-  (hdiam : ∀p ∈ t, diam (univ : set (GH_space.rep p)) ≤ C)
-  (hcov : ∀p ∈ t, ∀n:ℕ, ∃s : set (GH_space.rep p),
+  (hdiam : ∀ p ∈ t, diam (univ : set (GH_space.rep p)) ≤ C)
+  (hcov : ∀ p ∈ t, ∀ n:ℕ, ∃ s : set (GH_space.rep p),
     cardinal.mk s ≤ K n ∧ univ ⊆ ⋃x∈s, ball x (u n)) :
   totally_bounded t :=
 begin
@@ -741,7 +737,7 @@ begin
   is `ε`-dense and has cardinality at most `K n`. Encoding the mutual distances of points in `s p`,
   up to `ε`, we will get a map `F` associating to `p` finitely many data, and making it possible to
   reconstruct `p` up to `ε`. This is enough to prove total boundedness. -/
-  refine metric.totally_bounded_of_finite_discretization (λδ δpos, _),
+  refine metric.totally_bounded_of_finite_discretization (λ δ δpos, _),
   let ε := (1/5) * δ,
   have εpos : 0 < ε := mul_pos (by norm_num) δpos,
   -- choose `n` for which `u n < ε`
@@ -751,7 +747,7 @@ begin
     simp only [real.dist_eq, add_zero, sub_eq_add_neg, neg_zero] at this,
     exact le_of_lt (lt_of_le_of_lt (le_abs_self _) this) },
   -- construct a finite subset `s p` of `p` which is `ε`-dense and has cardinal `≤ K n`
-  have : ∀p:GH_space, ∃s : set (p.rep), ∃N ≤ K n, ∃E : equiv s (fin N),
+  have : ∀ p:GH_space, ∃ s : set (p.rep), ∃ N ≤ K n, ∃ E : equiv s (fin N),
     p ∈ t → univ ⊆ ⋃x∈s, ball x (u n),
   { assume p,
     by_cases hp : p ∉ t,
@@ -770,27 +766,27 @@ begin
   -- to reconstruct it up to `ε`, namely the (discretized) distances between elements of `s p`.
   let M := (floor (ε⁻¹ * max C 0)).to_nat,
   let F : GH_space → (Σk:fin ((K n).succ), (fin k → fin k → fin (M.succ))) :=
-    λp, ⟨⟨N p, lt_of_le_of_lt (hN p) (nat.lt_succ_self _)⟩,
-         λa b, ⟨min M (floor (ε⁻¹ * dist ((E p).symm a) ((E p).symm b))).to_nat,
+    λ p, ⟨⟨N p, lt_of_le_of_lt (hN p) (nat.lt_succ_self _)⟩,
+         λ a b, ⟨min M (floor (ε⁻¹ * dist ((E p).symm a) ((E p).symm b))).to_nat,
                 lt_of_le_of_lt ( min_le_left _ _) (nat.lt_succ_self _) ⟩ ⟩,
-  refine ⟨_, by apply_instance, (λp, F p), _⟩,
+  refine ⟨_, by apply_instance, (λ p, F p), _⟩,
   -- It remains to show that if `F p = F q`, then `p` and `q` are `ε`-close
   rintros ⟨p, pt⟩ ⟨q, qt⟩ hpq,
   have Npq : N p = N q := (fin.ext_iff _ _).1 (sigma.mk.inj_iff.1 hpq).1,
-  let Ψ : s p → s q := λx, (E q).symm (fin.cast Npq ((E p) x)),
-  let Φ : s p → q.rep := λx, Ψ x,
+  let Ψ : s p → s q := λ x, (E q).symm (fin.cast Npq ((E p) x)),
+  let Φ : s p → q.rep := λ x, Ψ x,
   have main : GH_dist (p.rep) (q.rep) ≤ ε + ε/2 + ε,
   { -- to prove the main inequality, argue that `s p` is `ε`-dense in `p`, and `s q` is `ε`-dense
     -- in `q`, and `s p` and `s q` are almost isometric. Then closeness follows
     -- from `GH_dist_le_of_approx_subsets`
     refine GH_dist_le_of_approx_subsets Φ  _ _ _,
-    show ∀x : p.rep, ∃ (y : p.rep) (H : y ∈ s p), dist x y ≤ ε,
+    show ∀ x : p.rep, ∃ (y : p.rep) (H : y ∈ s p), dist x y ≤ ε,
     { -- by construction, `s p` is `ε`-dense
       assume x,
       have : x ∈ ⋃y∈(s p), ball y (u n) := (hs p pt) (mem_univ _),
       rcases mem_bUnion_iff.1 this with ⟨y, ys, hy⟩,
       exact ⟨y, ys, le_trans (le_of_lt hy) u_le_ε⟩ },
-    show ∀x : q.rep, ∃ (z : s p), dist x (Φ z) ≤ ε,
+    show ∀ x : q.rep, ∃ (z : s p), dist x (Φ z) ≤ ε,
     { -- by construction, `s q` is `ε`-dense, and it is the range of `Φ`
       assume x,
       have : x ∈ ⋃y∈(s q), ball y (u n) := (hs q qt) (mem_univ _),
@@ -810,7 +806,7 @@ begin
         by { simp only [Φ, Ψ], rw [C1, C2, C3], refl },
       rw this,
       exact le_trans (le_of_lt hy) u_le_ε },
-    show ∀x y : s p, abs (dist x y - dist (Φ x) (Φ y)) ≤ ε,
+    show ∀ x y : s p, abs (dist x y - dist (Φ x) (Φ y)) ≤ ε,
     { /- the distance between `x` and `y` is encoded in `F p`, and the distance between
       `Φ x` and `Φ y` (two points of `s q`) is encoded in `F q`, all this up to `ε`.
       As `F p = F q`, the distances are almost equal. -/
@@ -911,7 +907,7 @@ form a Cauchy sequence for the Hausdorff distance. By completeness (of `Z`, and 
 set of nonempty compact subsets), they converge to a limit `L`. This is the nonempty
 compact metric space we are looking for.  -/
 
-variables (X : ℕ → Type) [∀n, metric_space (X n)] [∀n, compact_space (X n)] [∀n, nonempty (X n)]
+variables (X : ℕ → Type) [∀ n, metric_space (X n)] [∀ n, compact_space (X n)] [∀ n, nonempty (X n)]
 
 /-- Auxiliary structure used to glue metric spaces below, recording an isometric embedding
 of a type `A` in another metric space. -/
@@ -921,6 +917,12 @@ structure aux_gluing_struct (A : Type) [metric_space A] : Type 1 :=
 (embed  : A → space)
 (isom   : isometry embed)
 
+instance (A : Type) [metric_space A] : inhabited (aux_gluing_struct A) :=
+⟨{ space := A,
+  metric := by apply_instance,
+  embed := id,
+  isom := λ x y, rfl }⟩
+
 /-- Auxiliary sequence of metric spaces, containing copies of `X 0`, ..., `X n`, where each
 `X i` is glued to `X (i+1)` in an optimal way. The space at step `n+1` is obtained from the space
 at step `n` by adding `X (n+1)`, glued in an optimal way to the `X n` already sitting there. -/
@@ -928,34 +930,34 @@ def aux_gluing (n : ℕ) : aux_gluing_struct (X n) := nat.rec_on n
   { space  := X 0,
     metric := by apply_instance,
     embed  := id,
-    isom   := λx y, rfl }
-(λn a, by letI : metric_space a.space := a.metric; exact
-  { space  := glue_space a.isom (isometry_optimal_GH_injl (X n) (X n.succ)),
-    metric := metric.metric_space_glue_space a.isom (isometry_optimal_GH_injl (X n) (X n.succ)),
-    embed  := (to_glue_r a.isom (isometry_optimal_GH_injl (X n) (X n.succ)))
-              ∘ (optimal_GH_injr (X n) (X n.succ)),
-    isom   := (to_glue_r_isometry _ _).comp (isometry_optimal_GH_injr (X n) (X n.succ)) })
+    isom   := λ x y, rfl }
+(λ n Y, by letI : metric_space Y.space := Y.metric; exact
+  { space  := glue_space Y.isom (isometry_optimal_GH_injl (X n) (X (n+1))),
+    metric := by apply_instance,
+    embed  := (to_glue_r Y.isom (isometry_optimal_GH_injl (X n) (X (n+1))))
+              ∘ (optimal_GH_injr (X n) (X (n+1))),
+    isom   := (to_glue_r_isometry _ _).comp (isometry_optimal_GH_injr (X n) (X (n+1))) })
 
 /-- The Gromov-Hausdorff space is complete. -/
-instance : complete_space (GH_space) :=
+instance : complete_space GH_space :=
 begin
   have : ∀ (n : ℕ), 0 < ((1:ℝ) / 2) ^ n, by { apply pow_pos, norm_num },
   -- start from a sequence of nonempty compact metric spaces within distance `1/2^n` of each other
-  refine metric.complete_of_convergent_controlled_sequences (λn, (1/2)^n) this (λu hu, _),
+  refine metric.complete_of_convergent_controlled_sequences (λ n, (1/2)^n) this (λ u hu, _),
   -- `X n` is a representative of `u n`
-  let X := λn, (u n).rep,
+  let X := λ n, (u n).rep,
   -- glue them together successively in an optimal way, getting a sequence of metric spaces `Y n`
   let Y := aux_gluing X,
-  letI : ∀n, metric_space (Y n).space := λn, (Y n).metric,
+  letI : ∀ n, metric_space (Y n).space := λ n, (Y n).metric,
   have E : ∀ n : ℕ,
     glue_space (Y n).isom (isometry_optimal_GH_injl (X n) (X n.succ)) = (Y n.succ).space :=
     λ n, by { simp [Y, aux_gluing], refl },
-  let c := λn, cast (E n),
-  have ic : ∀n, isometry (c n) := λn x y, rfl,
+  let c := λ n, cast (E n),
+  have ic : ∀ n, isometry (c n) := λ n x y, rfl,
   -- there is a canonical embedding of `Y n` in `Y (n+1)`, by construction
   let f : Πn, (Y n).space → (Y n.succ).space :=
-    λn, (c n) ∘ (to_glue_l (aux_gluing X n).isom (isometry_optimal_GH_injl (X n) (X n.succ))),
-  have I : ∀n, isometry (f n),
+    λ n, (c n) ∘ (to_glue_l (aux_gluing X n).isom (isometry_optimal_GH_injl (X n) (X n.succ))),
+  have I : ∀ n, isometry (f n),
   { assume n,
     apply isometry.comp,
     { assume x y, refl },
@@ -966,15 +968,15 @@ begin
   let Φ := to_inductive_limit I,
   let coeZ := (coe : Z0 → Z),
   -- let `X2 n` be the image of `X n` in the space `Z`
-  let X2 := λn, range (coeZ ∘ (Φ n) ∘ (Y n).embed),
-  have isom : ∀n, isometry (coeZ ∘ (Φ n) ∘ (Y n).embed),
+  let X2 := λ n, range (coeZ ∘ (Φ n) ∘ (Y n).embed),
+  have isom : ∀ n, isometry (coeZ ∘ (Φ n) ∘ (Y n).embed),
   { assume n,
     apply isometry.comp completion.coe_isometry _,
     apply isometry.comp _ (Y n).isom,
     apply to_inductive_limit_isometry },
   -- The Hausdorff distance of `X2 n` and `X2 (n+1)` is by construction the distance between
   -- `u n` and `u (n+1)`, therefore bounded by `1/2^n`
-  have D2 : ∀n, Hausdorff_dist (X2 n) (X2 n.succ) < (1/2)^n,
+  have D2 : ∀ n, Hausdorff_dist (X2 n) (X2 n.succ) < (1/2)^n,
   { assume n,
     have X2n : X2 n = range ((coeZ ∘ (Φ n.succ) ∘ (c n)
       ∘ (to_glue_r (Y n).isom (isometry_optimal_GH_injl (X n) (X n.succ))))
@@ -998,21 +1000,21 @@ begin
       apply to_inductive_limit_isometry } },
   -- consider `X2 n` as a member `X3 n` of the type of nonempty compact subsets of `Z`, which
   -- is a metric space
-  let X3 : ℕ → nonempty_compacts Z := λn, ⟨X2 n,
+  let X3 : ℕ → nonempty_compacts Z := λ n, ⟨X2 n,
     ⟨range_nonempty _, is_compact_range (isom n).continuous ⟩⟩,
   -- `X3 n` is a Cauchy sequence by construction, as the successive distances are
   -- bounded by `(1/2)^n`
   have : cauchy_seq X3,
-  { refine cauchy_seq_of_le_geometric (1/2) 1 (by norm_num) (λn, _),
+  { refine cauchy_seq_of_le_geometric (1/2) 1 (by norm_num) (λ n, _),
     rw one_mul,
     exact le_of_lt (D2 n) },
   -- therefore, it converges to a limit `L`
   rcases cauchy_seq_tendsto_of_complete this with ⟨L, hL⟩,
   -- the images of `X3 n` in the Gromov-Hausdorff space converge to the image of `L`
-  have M : tendsto (λn, (X3 n).to_GH_space) at_top (𝓝 L.to_GH_space) :=
+  have M : tendsto (λ n, (X3 n).to_GH_space) at_top (𝓝 L.to_GH_space) :=
     tendsto.comp (to_GH_space_continuous.tendsto _) hL,
   -- By construction, the image of `X3 n` in the Gromov-Hausdorff space is `u n`.
-  have : ∀n, (X3 n).to_GH_space = u n,
+  have : ∀ n, (X3 n).to_GH_space = u n,
   { assume n,
     rw [nonempty_compacts.to_GH_space, ← (u n).to_GH_space_rep,
         to_GH_space_eq_to_GH_space_iff_isometric],

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -2,13 +2,32 @@
 Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
-
-Construction of a good coupling between nonempty compact metric spaces, minimizing
-their Hausdorff distance. This construction is instrumental to study the Gromov-Hausdorff
-distance between nonempty compact metric spaces -/
+-/
 import topology.metric_space.gluing
 import topology.metric_space.hausdorff_distance
 import topology.continuous_function.bounded
+
+/-!
+# The Gromov-Hausdorff distance is realized
+
+In this file, we construct of a good coupling between nonempty compact metric spaces, minimizing
+their Hausdorff distance. This construction is instrumental to study the Gromov-Hausdorff
+distance between nonempty compact metric spaces.
+
+Given two nonempty compact metric spaces `X` and `Y`, we define `optimal_GH_coupling X Y` as a
+compact metric space, together with two isometric embeddings `optimal_GH_injl` and `optimal_GH_injr`
+respectively of `X` and `Y` into `optimal_GH_coupling X Y`. The main property of the optimal
+coupling is that the Hausdorff distance between `X` and `Y` in `optimal_GH_coupling X Y` is smaller
+than the corresponding distance in any other coupling. We do not prove completely this fact in this
+file, but we show a good enough approximation of this fact in `Hausdorff_dist_optimal_le_HD`, that
+will suffice to obtain the full statement once the Gromov-Hausdorff distance is properly defined,
+in `Hausdorff_dist_optimal`.
+
+The key point in the construction is that the set of possible distances coming from isometric
+embeddings of `X` and `Y` in metric spaces is a set of equicontinuous functions. By Arzela-Ascoli,
+it is compact, and one can find such a distance which is minimal. This distance defines a premetric
+space structure on `X ⊕ Y`. The corresponding metric quotient is `optimal_GH_coupling X Y`.
+-/
 
 noncomputable theory
 open_locale classical topological_space nnreal
@@ -25,75 +44,75 @@ namespace Gromov_Hausdorff
 section Gromov_Hausdorff_realized
 /- This section shows that the Gromov-Hausdorff distance
 is realized. For this, we consider candidate distances on the disjoint union
-α ⊕ β of two compact nonempty metric spaces, almost realizing the Gromov-Hausdorff
+`X ⊕ Y` of two compact nonempty metric spaces, almost realizing the Gromov-Hausdorff
 distance, and show that they form a compact family by applying Arzela-Ascoli
 theorem. The existence of a minimizer follows. -/
 
 section definitions
-variables (α : Type u) (β : Type v)
-  [metric_space α] [compact_space α] [nonempty α]
-  [metric_space β] [compact_space β] [nonempty β]
+variables (X : Type u) (Y : Type v)
+  [metric_space X] [compact_space X] [nonempty X]
+  [metric_space Y] [compact_space Y] [nonempty Y]
 
-@[reducible] private def prod_space_fun : Type* := ((α ⊕ β) × (α ⊕ β)) → ℝ
-@[reducible] private def Cb : Type* := bounded_continuous_function ((α ⊕ β) × (α ⊕ β)) ℝ
+@[reducible] private def prod_space_fun : Type* := ((X ⊕ Y) × (X ⊕ Y)) → ℝ
+@[reducible] private def Cb : Type* := bounded_continuous_function ((X ⊕ Y) × (X ⊕ Y)) ℝ
 
 private def max_var : ℝ≥0 :=
-2 * ⟨diam (univ : set α), diam_nonneg⟩ + 1 + 2 * ⟨diam (univ : set β), diam_nonneg⟩
+2 * ⟨diam (univ : set X), diam_nonneg⟩ + 1 + 2 * ⟨diam (univ : set Y), diam_nonneg⟩
 
-private lemma one_le_max_var : 1 ≤ max_var α β := calc
+private lemma one_le_max_var : 1 ≤ max_var X Y := calc
   (1 : real) = 2 * 0 + 1 + 2 * 0 : by simp
-  ... ≤ 2 * diam (univ : set α) + 1 + 2 * diam (univ : set β) :
+  ... ≤ 2 * diam (univ : set X) + 1 + 2 * diam (univ : set Y) :
   by apply_rules [add_le_add, mul_le_mul_of_nonneg_left, diam_nonneg]; norm_num
 
-/-- The set of functions on α ⊕ β that are candidates distances to realize the
-minimum of the Hausdorff distances between α and β in a coupling -/
-def candidates : set (prod_space_fun α β) :=
-  {f | (((((∀x y : α, f (sum.inl x, sum.inl y) = dist x y)
-    ∧ (∀x y : β, f (sum.inr x, sum.inr y) = dist x y))
-    ∧ (∀x y,     f (x, y) = f (y, x)))
-    ∧ (∀x y z,   f (x, z) ≤ f (x, y) + f (y, z)))
-    ∧ (∀x,       f (x, x) = 0))
-    ∧ (∀x y,     f (x, y) ≤ max_var α β) }
+/-- The set of functions on `X ⊕ Y` that are candidates distances to realize the
+minimum of the Hausdorff distances between `X` and `Y` in a coupling -/
+def candidates : set (prod_space_fun X Y) :=
+  {f | (((((∀ x y : X, f (sum.inl x, sum.inl y) = dist x y)
+    ∧ (∀ x y : Y, f (sum.inr x, sum.inr y) = dist x y))
+    ∧ (∀ x y,     f (x, y) = f (y, x)))
+    ∧ (∀ x y z,   f (x, z) ≤ f (x, y) + f (y, z)))
+    ∧ (∀ x,       f (x, x) = 0))
+    ∧ (∀ x y,     f (x, y) ≤ max_var X Y) }
 
 /-- Version of the set of candidates in bounded_continuous_functions, to apply
 Arzela-Ascoli -/
-private def candidates_b : set (Cb α β) := {f : Cb α β | f.to_fun ∈ candidates α β}
+private def candidates_b : set (Cb X Y) := {f : Cb X Y | f.to_fun ∈ candidates X Y}
 
 end definitions --section
 
 section constructions
 
-variables {α : Type u} {β : Type v}
-[metric_space α] [compact_space α] [nonempty α] [metric_space β] [compact_space β] [nonempty β]
-{f : prod_space_fun α β} {x y z t : α ⊕ β}
+variables {X : Type u} {Y : Type v}
+[metric_space X] [compact_space X] [nonempty X] [metric_space Y] [compact_space Y] [nonempty Y]
+{f : prod_space_fun X Y} {x y z t : X ⊕ Y}
 local attribute [instance, priority 10] inhabited_of_nonempty'
 
-private lemma max_var_bound : dist x y ≤ max_var α β := calc
-  dist x y ≤ diam (univ : set (α ⊕ β)) :
+private lemma max_var_bound : dist x y ≤ max_var X Y := calc
+  dist x y ≤ diam (univ : set (X ⊕ Y)) :
     dist_le_diam_of_mem (bounded_of_compact compact_univ) (mem_univ _) (mem_univ _)
-  ... = diam (inl '' (univ : set α) ∪ inr '' (univ : set β)) :
+  ... = diam (inl '' (univ : set X) ∪ inr '' (univ : set Y)) :
     by apply congr_arg; ext x y z; cases x; simp [mem_univ, mem_range_self]
-  ... ≤ diam (inl '' (univ : set α)) + dist (inl (default α)) (inr (default β)) +
-          diam (inr '' (univ : set β)) :
+  ... ≤ diam (inl '' (univ : set X)) + dist (inl (default X)) (inr (default Y)) +
+          diam (inr '' (univ : set Y)) :
     diam_union (mem_image_of_mem _ (mem_univ _)) (mem_image_of_mem _ (mem_univ _))
-  ... = diam (univ : set α) + (dist (default α) (default α) + 1 + dist (default β) (default β)) +
-          diam (univ : set β) :
+  ... = diam (univ : set X) + (dist (default X) (default X) + 1 + dist (default Y) (default Y)) +
+          diam (univ : set Y) :
     by { rw [isometry_on_inl.diam_image, isometry_on_inr.diam_image], refl }
-  ... = 1 * diam (univ : set α) + 1 + 1 * diam (univ : set β) : by simp
-  ... ≤ 2 * diam (univ : set α) + 1 + 2 * diam (univ : set β) :
+  ... = 1 * diam (univ : set X) + 1 + 1 * diam (univ : set Y) : by simp
+  ... ≤ 2 * diam (univ : set X) + 1 + 2 * diam (univ : set Y) :
   begin
     apply_rules [add_le_add, mul_le_mul_of_nonneg_right, diam_nonneg, le_refl],
     norm_num, norm_num
   end
 
-private lemma candidates_symm (fA : f ∈ candidates α β) : f (x, y) = f (y ,x) := fA.1.1.1.2 x y
+private lemma candidates_symm (fA : f ∈ candidates X Y) : f (x, y) = f (y, x) := fA.1.1.1.2 x y
 
-private lemma candidates_triangle (fA : f ∈ candidates α β) : f (x, z) ≤ f (x, y) + f (y, z) :=
+private lemma candidates_triangle (fA : f ∈ candidates X Y) : f (x, z) ≤ f (x, y) + f (y, z) :=
   fA.1.1.2 x y z
 
-private lemma candidates_refl (fA : f ∈ candidates α β) : f (x, x) = 0 := fA.1.2 x
+private lemma candidates_refl (fA : f ∈ candidates X Y) : f (x, x) = 0 := fA.1.2 x
 
-private lemma candidates_nonneg (fA : f ∈ candidates α β) : 0 ≤ f (x, y) :=
+private lemma candidates_nonneg (fA : f ∈ candidates X Y) : 0 ≤ f (x, y) :=
 begin
   have : 0 ≤ 2 * f (x, y) := calc
     0 = f (x, x) : (candidates_refl fA).symm
@@ -103,68 +122,68 @@ begin
   by linarith
 end
 
-private lemma candidates_dist_inl (fA : f ∈ candidates α β) (x y: α) :
+private lemma candidates_dist_inl (fA : f ∈ candidates X Y) (x y: X) :
   f (inl x, inl y) = dist x y :=
 fA.1.1.1.1.1 x y
 
-private lemma candidates_dist_inr (fA : f ∈ candidates α β) (x y : β) :
+private lemma candidates_dist_inr (fA : f ∈ candidates X Y) (x y : Y) :
   f (inr x, inr y) = dist x y :=
 fA.1.1.1.1.2 x y
 
-private lemma candidates_le_max_var (fA : f ∈ candidates α β) : f (x, y) ≤ max_var α β :=
+private lemma candidates_le_max_var (fA : f ∈ candidates X Y) : f (x, y) ≤ max_var X Y :=
 fA.2 x y
 
-/-- candidates are bounded by max_var α β -/
-private lemma candidates_dist_bound  (fA : f ∈ candidates α β) :
-  ∀ {x y : α ⊕ β}, f (x, y) ≤ max_var α β * dist x y
+/-- candidates are bounded by `max_var X Y` -/
+private lemma candidates_dist_bound  (fA : f ∈ candidates X Y) :
+  ∀ {x y : X ⊕ Y}, f (x, y) ≤ max_var X Y * dist x y
 | (inl x) (inl y) := calc
     f (inl x, inl y) = dist x y : candidates_dist_inl fA x y
-    ... = dist (inl x) (inl y) : by { rw @sum.dist_eq α β, refl }
+    ... = dist (inl x) (inl y) : by { rw @sum.dist_eq X Y, refl }
     ... = 1 * dist (inl x) (inl y) : by simp
-    ... ≤ max_var α β * dist (inl x) (inl y) :
-      mul_le_mul_of_nonneg_right (one_le_max_var α β) dist_nonneg
+    ... ≤ max_var X Y * dist (inl x) (inl y) :
+      mul_le_mul_of_nonneg_right (one_le_max_var X Y) dist_nonneg
 | (inl x) (inr y) := calc
-    f (inl x, inr y) ≤ max_var α β : candidates_le_max_var fA
-    ... = max_var α β * 1 : by simp
-    ... ≤ max_var α β * dist (inl x) (inr y) :
-      mul_le_mul_of_nonneg_left sum.one_dist_le (le_trans (zero_le_one) (one_le_max_var α β))
+    f (inl x, inr y) ≤ max_var X Y : candidates_le_max_var fA
+    ... = max_var X Y * 1 : by simp
+    ... ≤ max_var X Y * dist (inl x) (inr y) :
+      mul_le_mul_of_nonneg_left sum.one_dist_le (le_trans (zero_le_one) (one_le_max_var X Y))
 | (inr x) (inl y) := calc
-    f (inr x, inl y) ≤ max_var α β : candidates_le_max_var fA
-    ... = max_var α β * 1 : by simp
-    ... ≤ max_var α β * dist (inl x) (inr y) :
-      mul_le_mul_of_nonneg_left sum.one_dist_le (le_trans (zero_le_one) (one_le_max_var α β))
+    f (inr x, inl y) ≤ max_var X Y : candidates_le_max_var fA
+    ... = max_var X Y * 1 : by simp
+    ... ≤ max_var X Y * dist (inl x) (inr y) :
+      mul_le_mul_of_nonneg_left sum.one_dist_le (le_trans (zero_le_one) (one_le_max_var X Y))
 | (inr x) (inr y) := calc
     f (inr x, inr y) = dist x y : candidates_dist_inr fA x y
-    ... = dist (inr x) (inr y) : by { rw @sum.dist_eq α β, refl }
+    ... = dist (inr x) (inr y) : by { rw @sum.dist_eq X Y, refl }
     ... = 1 * dist (inr x) (inr y) : by simp
-    ... ≤ max_var α β * dist (inr x) (inr y) :
-      mul_le_mul_of_nonneg_right (one_le_max_var α β) dist_nonneg
+    ... ≤ max_var X Y * dist (inr x) (inr y) :
+      mul_le_mul_of_nonneg_right (one_le_max_var X Y) dist_nonneg
 
 /-- Technical lemma to prove that candidates are Lipschitz -/
-private lemma candidates_lipschitz_aux (fA : f ∈ candidates α β) :
-  f (x, y) - f (z, t) ≤ 2 * max_var α β * dist (x, y) (z, t) :=
+private lemma candidates_lipschitz_aux (fA : f ∈ candidates X Y) :
+  f (x, y) - f (z, t) ≤ 2 * max_var X Y * dist (x, y) (z, t) :=
 calc
   f (x, y) - f(z, t) ≤ f (x, t) + f (t, y) - f (z, t) : sub_le_sub_right (candidates_triangle fA) _
   ... ≤ (f (x, z) + f (z, t) + f(t, y)) - f (z, t) :
     sub_le_sub_right (add_le_add_right (candidates_triangle fA) _ ) _
   ... = f (x, z) + f (t, y) : by simp [sub_eq_add_neg, add_assoc]
-  ... ≤ max_var α β * dist x z + max_var α β * dist t y :
+  ... ≤ max_var X Y * dist x z + max_var X Y * dist t y :
     add_le_add (candidates_dist_bound fA) (candidates_dist_bound fA)
-  ... ≤ max_var α β * max (dist x z) (dist t y) + max_var α β * max (dist x z) (dist t y) :
+  ... ≤ max_var X Y * max (dist x z) (dist t y) + max_var X Y * max (dist x z) (dist t y) :
   begin
     apply add_le_add,
     apply mul_le_mul_of_nonneg_left (le_max_left (dist x z) (dist t y))
-      (zero_le_one.trans (one_le_max_var α β)),
+      (zero_le_one.trans (one_le_max_var X Y)),
     apply mul_le_mul_of_nonneg_left (le_max_right (dist x z) (dist t y))
-      (zero_le_one.trans (one_le_max_var α β)),
+      (zero_le_one.trans (one_le_max_var X Y)),
   end
-  ... = 2 * max_var α β * max (dist x z) (dist y t) :
+  ... = 2 * max_var X Y * max (dist x z) (dist y t) :
     by { simp [dist_comm], ring }
-  ... = 2 * max_var α β * dist (x, y) (z, t) : by refl
+  ... = 2 * max_var X Y * dist (x, y) (z, t) : by refl
 
 /-- Candidates are Lipschitz -/
-private lemma candidates_lipschitz (fA : f ∈ candidates α β) :
-  lipschitz_with (2 * max_var α β) f :=
+private lemma candidates_lipschitz (fA : f ∈ candidates X Y) :
+  lipschitz_with (2 * max_var X Y) f :=
 begin
   apply lipschitz_with.of_dist_le_mul,
   rintros ⟨x, y⟩ ⟨z, t⟩,
@@ -175,14 +194,14 @@ begin
 end
 
 /-- candidates give rise to elements of bounded_continuous_functions -/
-def candidates_b_of_candidates (f : prod_space_fun α β) (fA : f ∈ candidates α β) : Cb α β :=
+def candidates_b_of_candidates (f : prod_space_fun X Y) (fA : f ∈ candidates X Y) : Cb X Y :=
 bounded_continuous_function.mk_of_compact ⟨f, (candidates_lipschitz fA).continuous⟩
 
-lemma candidates_b_of_candidates_mem (f : prod_space_fun α β) (fA : f ∈ candidates α β) :
-  candidates_b_of_candidates f fA ∈ candidates_b α β := fA
+lemma candidates_b_of_candidates_mem (f : prod_space_fun X Y) (fA : f ∈ candidates X Y) :
+  candidates_b_of_candidates f fA ∈ candidates_b X Y := fA
 
-/-- The distance on α ⊕ β is a candidate -/
-private lemma dist_mem_candidates : (λp : (α ⊕ β) × (α ⊕ β), dist p.1 p.2) ∈ candidates α β :=
+/-- The distance on `X ⊕ Y` is a candidate -/
+private lemma dist_mem_candidates : (λp : (X ⊕ Y) × (X ⊕ Y), dist p.1 p.2) ∈ candidates X Y :=
 begin
   simp only [candidates, dist_comm, forall_const, and_true, add_comm, eq_self_iff_true,
              and_self, sum.forall, set.mem_set_of_eq, dist_self],
@@ -192,38 +211,39 @@ begin
     <|> exact (λx y, max_var_bound) }
 end
 
-def candidates_b_dist (α : Type u) (β : Type v) [metric_space α] [compact_space α] [inhabited α]
-  [metric_space β] [compact_space β] [inhabited β] : Cb α β :=
+/-- The distance on `X ⊕ Y` as a candidate -/
+def candidates_b_dist (X : Type u) (Y : Type v) [metric_space X] [compact_space X] [inhabited X]
+  [metric_space Y] [compact_space Y] [inhabited Y] : Cb X Y :=
 candidates_b_of_candidates _ dist_mem_candidates
 
-lemma candidates_b_dist_mem_candidates_b : candidates_b_dist α β ∈ candidates_b α β :=
+lemma candidates_b_dist_mem_candidates_b : candidates_b_dist X Y ∈ candidates_b X Y :=
 candidates_b_of_candidates_mem _ _
 
-private lemma candidates_b_nonempty : (candidates_b α β).nonempty :=
+private lemma candidates_b_nonempty : (candidates_b X Y).nonempty :=
 ⟨_,  candidates_b_dist_mem_candidates_b⟩
 
 /-- To apply Arzela-Ascoli, we need to check that the set of candidates is closed and
 equicontinuous. Equicontinuity follows from the Lipschitz control, we check closedness. -/
-private lemma closed_candidates_b : is_closed (candidates_b α β) :=
+private lemma closed_candidates_b : is_closed (candidates_b X Y) :=
 begin
-  have I1 : ∀x y, is_closed {f : Cb α β | f (inl x, inl y) = dist x y} :=
+  have I1 : ∀ x y, is_closed {f : Cb X Y | f (inl x, inl y) = dist x y} :=
     λx y, is_closed_eq continuous_evalx continuous_const,
-  have I2 : ∀x y, is_closed {f : Cb α β | f (inr x, inr y) = dist x y } :=
+  have I2 : ∀ x y, is_closed {f : Cb X Y | f (inr x, inr y) = dist x y } :=
     λx y, is_closed_eq continuous_evalx continuous_const,
-  have I3 : ∀x y, is_closed {f : Cb α β | f (x, y) = f (y, x)} :=
+  have I3 : ∀ x y, is_closed {f : Cb X Y | f (x, y) = f (y, x)} :=
     λx y, is_closed_eq continuous_evalx continuous_evalx,
-  have I4 : ∀x y z, is_closed {f : Cb α β | f (x, z) ≤ f (x, y) + f (y, z)} :=
+  have I4 : ∀ x y z, is_closed {f : Cb X Y | f (x, z) ≤ f (x, y) + f (y, z)} :=
     λx y z, is_closed_le continuous_evalx (continuous_evalx.add continuous_evalx),
-  have I5 : ∀x, is_closed {f : Cb α β | f (x, x) = 0} :=
+  have I5 : ∀ x, is_closed {f : Cb X Y | f (x, x) = 0} :=
     λx, is_closed_eq continuous_evalx continuous_const,
-  have I6 : ∀x y, is_closed {f : Cb α β | f (x, y) ≤ max_var α β} :=
+  have I6 : ∀ x y, is_closed {f : Cb X Y | f (x, y) ≤ max_var X Y} :=
     λx y, is_closed_le continuous_evalx continuous_const,
-  have : candidates_b α β = (⋂x y, {f : Cb α β | f ((@inl α β x), (@inl α β y)) = dist x y})
-               ∩ (⋂x y, {f : Cb α β | f ((@inr α β x), (@inr α β y)) = dist x y})
-               ∩ (⋂x y, {f : Cb α β | f (x, y) = f (y, x)})
-               ∩ (⋂x y z, {f : Cb α β | f (x, z) ≤ f (x, y) + f (y, z)})
-               ∩ (⋂x, {f : Cb α β | f (x, x) = 0})
-               ∩ (⋂x y, {f : Cb α β | f (x, y) ≤ max_var α β}) :=
+  have : candidates_b X Y = (⋂x y, {f : Cb X Y | f ((@inl X Y x), (@inl X Y y)) = dist x y})
+               ∩ (⋂x y, {f : Cb X Y | f ((@inr X Y x), (@inr X Y y)) = dist x y})
+               ∩ (⋂x y, {f : Cb X Y | f (x, y) = f (y, x)})
+               ∩ (⋂x y z, {f : Cb X Y | f (x, z) ≤ f (x, y) + f (y, z)})
+               ∩ (⋂x, {f : Cb X Y | f (x, x) = 0})
+               ∩ (⋂x y, {f : Cb X Y | f (x, y) ≤ max_var X Y}) :=
     begin ext, unfold candidates_b, unfold candidates, simp [-sum.forall], refl end,
   rw this,
   repeat { apply is_closed.inter _ _
@@ -238,15 +258,15 @@ begin
 end
 
 /-- Compactness of candidates (in bounded_continuous_functions) follows. -/
-private lemma compact_candidates_b : is_compact (candidates_b α β) :=
+private lemma compact_candidates_b : is_compact (candidates_b X Y) :=
 begin
-  refine arzela_ascoli₂ (Icc 0 (max_var α β)) compact_Icc (candidates_b α β)
+  refine arzela_ascoli₂ (Icc 0 (max_var X Y)) compact_Icc (candidates_b X Y)
   closed_candidates_b _ _,
   { rintros f ⟨x1, x2⟩ hf,
     simp only [set.mem_Icc],
     exact ⟨candidates_nonneg hf, candidates_le_max_var hf⟩ },
-  { refine equicontinuous_of_continuity_modulus (λt, 2 * max_var α β * t) _ _ _,
-    { have : tendsto (λ (t : ℝ), 2 * (max_var α β : ℝ) * t) (𝓝 0) (𝓝 (2 * max_var α β * 0)) :=
+  { refine equicontinuous_of_continuity_modulus (λt, 2 * max_var X Y * t) _ _ _,
+    { have : tendsto (λ (t : ℝ), 2 * (max_var X Y : ℝ) * t) (𝓝 0) (𝓝 (2 * max_var X Y * 0)) :=
         tendsto_const_nhds.mul tendsto_id,
       simpa using this },
     { assume x y f hf,
@@ -256,56 +276,56 @@ end
 /-- We will then choose the candidate minimizing the Hausdorff distance. Except that we are not
 in a metric space setting, so we need to define our custom version of Hausdorff distance,
 called HD, and prove its basic properties. -/
-def HD (f : Cb α β) := max (⨆ x, ⨅ y, f (inl x, inr y)) (⨆ y, ⨅ x, f (inl x, inr y))
+def HD (f : Cb X Y) := max (⨆ x, ⨅ y, f (inl x, inr y)) (⨆ y, ⨅ x, f (inl x, inr y))
 
 /- We will show that HD is continuous on bounded_continuous_functions, to deduce that its
 minimum on the compact set candidates_b is attained. Since it is defined in terms of
-infimum and supremum on ℝ, which is only conditionnally complete, we will need all the time
+infimum and supremum on `ℝ`, which is only conditionnally complete, we will need all the time
 to check that the defining sets are bounded below or above. This is done in the next few
 technical lemmas -/
 
-lemma HD_below_aux1 {f : Cb α β} (C : ℝ) {x : α} :
-  bdd_below (range (λ (y : β), f (inl x, inr y) + C)) :=
+lemma HD_below_aux1 {f : Cb X Y} (C : ℝ) {x : X} :
+  bdd_below (range (λ (y : Y), f (inl x, inr y) + C)) :=
 let ⟨cf, hcf⟩ := (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 in
 ⟨cf + C, forall_range_iff.2 (λi, add_le_add_right ((λx, hcf (mem_range_self x)) _) _)⟩
 
-private lemma HD_bound_aux1 (f : Cb α β) (C : ℝ) :
-  bdd_above (range (λ (x : α), ⨅ y, f (inl x, inr y) + C)) :=
+private lemma HD_bound_aux1 (f : Cb X Y) (C : ℝ) :
+  bdd_above (range (λ (x : X), ⨅ y, f (inl x, inr y) + C)) :=
 begin
   rcases (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).2 with ⟨Cf, hCf⟩,
   refine ⟨Cf + C, forall_range_iff.2 (λx, _)⟩,
-  calc (⨅ y, f (inl x, inr y) + C) ≤ f (inl x, inr (default β)) + C :
-    cinfi_le (HD_below_aux1 C) (default β)
+  calc (⨅ y, f (inl x, inr y) + C) ≤ f (inl x, inr (default Y)) + C :
+    cinfi_le (HD_below_aux1 C) (default Y)
     ... ≤ Cf + C : add_le_add ((λx, hCf (mem_range_self x)) _) (le_refl _)
 end
 
-lemma HD_below_aux2 {f : Cb α β} (C : ℝ) {y : β} :
-  bdd_below (range (λ (x : α), f (inl x, inr y) + C)) :=
+lemma HD_below_aux2 {f : Cb X Y} (C : ℝ) {y : Y} :
+  bdd_below (range (λ (x : X), f (inl x, inr y) + C)) :=
 let ⟨cf, hcf⟩ := (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 in
 ⟨cf + C, forall_range_iff.2 (λi, add_le_add_right ((λx, hcf (mem_range_self x)) _) _)⟩
 
-private lemma HD_bound_aux2 (f : Cb α β) (C : ℝ) :
-  bdd_above (range (λ (y : β), ⨅ x, f (inl x, inr y) + C)) :=
+private lemma HD_bound_aux2 (f : Cb X Y) (C : ℝ) :
+  bdd_above (range (λ (y : Y), ⨅ x, f (inl x, inr y) + C)) :=
 begin
   rcases (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).2 with ⟨Cf, hCf⟩,
   refine ⟨Cf + C, forall_range_iff.2 (λy, _)⟩,
-  calc (⨅ x, f (inl x, inr y) + C) ≤ f (inl (default α), inr y) + C :
-    cinfi_le (HD_below_aux2 C) (default α)
+  calc (⨅ x, f (inl x, inr y) + C) ≤ f (inl (default X), inr y) + C :
+    cinfi_le (HD_below_aux2 C) (default X)
   ... ≤ Cf + C : add_le_add ((λx, hCf (mem_range_self x)) _) (le_refl _)
 end
 
-/-- Explicit bound on HD (dist). This means that when looking for minimizers it will
-be sufficient to look for functions with HD(f) bounded by this bound. -/
+/-- Explicit bound on `HD (dist)`. This means that when looking for minimizers it will
+be sufficient to look for functions with `HD(f)` bounded by this bound. -/
 lemma HD_candidates_b_dist_le :
-  HD (candidates_b_dist α β) ≤ diam (univ : set α) + 1 + diam (univ : set β) :=
+  HD (candidates_b_dist X Y) ≤ diam (univ : set X) + 1 + diam (univ : set Y) :=
 begin
   refine max_le (csupr_le (λx, _)) (csupr_le (λy, _)),
-  { have A : (⨅ y, candidates_b_dist α β (inl x, inr y)) ≤
-      candidates_b_dist α β (inl x, inr (default β)) :=
-      cinfi_le (by simpa using HD_below_aux1 0) (default β),
-    have B : dist (inl x) (inr (default β)) ≤ diam (univ : set α) + 1 + diam (univ : set β) := calc
-      dist (inl x) (inr (default β)) = dist x (default α) + 1 + dist (default β) (default β) : rfl
-      ... ≤ diam (univ : set α) + 1 + diam (univ : set β) :
+  { have A : (⨅ y, candidates_b_dist X Y (inl x, inr y)) ≤
+      candidates_b_dist X Y (inl x, inr (default Y)) :=
+      cinfi_le (by simpa using HD_below_aux1 0) (default Y),
+    have B : dist (inl x) (inr (default Y)) ≤ diam (univ : set X) + 1 + diam (univ : set Y) := calc
+      dist (inl x) (inr (default Y)) = dist x (default X) + 1 + dist (default Y) (default Y) : rfl
+      ... ≤ diam (univ : set X) + 1 + diam (univ : set Y) :
       begin
         apply add_le_add (add_le_add _ (le_refl _)),
         exact dist_le_diam_of_mem (bounded_of_compact (compact_univ)) (mem_univ _) (mem_univ _),
@@ -314,12 +334,12 @@ begin
         exact dist_le_diam_of_mem (bounded_of_compact (compact_univ)) (mem_univ _) (mem_univ _),
       end,
     exact le_trans A B },
-  { have A : (⨅ x, candidates_b_dist α β (inl x, inr y)) ≤
-      candidates_b_dist α β (inl (default α), inr y) :=
-      cinfi_le (by simpa using HD_below_aux2 0) (default α),
-    have B : dist (inl (default α)) (inr y) ≤ diam (univ : set α) + 1 + diam (univ : set β) := calc
-      dist (inl (default α)) (inr y) = dist (default α) (default α) + 1 + dist (default β) y : rfl
-      ... ≤ diam (univ : set α) + 1 + diam (univ : set β) :
+  { have A : (⨅ x, candidates_b_dist X Y (inl x, inr y)) ≤
+      candidates_b_dist X Y (inl (default X), inr y) :=
+      cinfi_le (by simpa using HD_below_aux2 0) (default X),
+    have B : dist (inl (default X)) (inr y) ≤ diam (univ : set X) + 1 + diam (univ : set Y) := calc
+      dist (inl (default X)) (inr y) = dist (default X) (default X) + 1 + dist (default Y) y : rfl
+      ... ≤ diam (univ : set X) + 1 + diam (univ : set Y) :
       begin
         apply add_le_add (add_le_add _ (le_refl _)),
         exact dist_le_diam_of_mem (bounded_of_compact (compact_univ)) (mem_univ _) (mem_univ _),
@@ -332,13 +352,13 @@ end
 
 /- To check that HD is continuous, we check that it is Lipschitz. As HD is a max, we
 prove separately inequalities controlling the two terms (relying too heavily on copy-paste...) -/
-private lemma HD_lipschitz_aux1 (f g : Cb α β) :
+private lemma HD_lipschitz_aux1 (f g : Cb X Y) :
   (⨆ x, ⨅ y, f (inl x, inr y)) ≤ (⨆ x, ⨅ y, g (inl x, inr y)) + dist f g :=
 begin
   rcases (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 with ⟨cg, hcg⟩,
-  have Hcg : ∀x, cg ≤ g x := λx, hcg (mem_range_self x),
+  have Hcg : ∀ x, cg ≤ g x := λx, hcg (mem_range_self x),
   rcases (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 with ⟨cf, hcf⟩,
-  have Hcf : ∀x, cf ≤ f x := λx, hcf (mem_range_self x),
+  have Hcf : ∀ x, cf ≤ f x := λx, hcf (mem_range_self x),
 
   -- prove the inequality but with `dist f g` inside, by using inequalities comparing
   -- supr to supr and infi to infi
@@ -347,11 +367,11 @@ begin
       (λx, cinfi_le_cinfi ⟨cf, forall_range_iff.2(λi, Hcf _)⟩ (λy, coe_le_coe_add_dist)),
   -- move the `dist f g` out of the infimum and the supremum, arguing that continuous monotone maps
   -- (here the addition of `dist f g`) preserve infimum and supremum
-  have E1 : ∀x, (⨅ y, g (inl x, inr y)) + dist f g = ⨅ y, g (inl x, inr y) + dist f g,
+  have E1 : ∀ x, (⨅ y, g (inl x, inr y)) + dist f g = ⨅ y, g (inl x, inr y) + dist f g,
   { assume x,
     refine map_cinfi_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _ _,
     { assume x y hx, simpa },
-    { show bdd_below (range (λ (y : β), g (inl x, inr y))),
+    { show bdd_below (range (λ (y : Y), g (inl x, inr y))),
         from ⟨cg, forall_range_iff.2(λi, Hcg _)⟩ } },
   have E2 : (⨆ x, ⨅ y, g (inl x, inr y)) + dist f g = ⨆ x, (⨅ y, g (inl x, inr y)) + dist f g,
   { refine map_csupr_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _ _,
@@ -361,13 +381,13 @@ begin
   simpa [E2, E1, function.comp]
 end
 
-private lemma HD_lipschitz_aux2 (f g : Cb α β) :
+private lemma HD_lipschitz_aux2 (f g : Cb X Y) :
   (⨆ y, ⨅ x, f (inl x, inr y)) ≤ (⨆ y, ⨅ x, g (inl x, inr y)) + dist f g :=
 begin
   rcases (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 with ⟨cg, hcg⟩,
-  have Hcg : ∀x, cg ≤ g x := λx, hcg (mem_range_self x),
+  have Hcg : ∀ x, cg ≤ g x := λx, hcg (mem_range_self x),
   rcases (real.bounded_iff_bdd_below_bdd_above.1 bounded_range).1 with ⟨cf, hcf⟩,
-  have Hcf : ∀x, cf ≤ f x := λx, hcf (mem_range_self x),
+  have Hcf : ∀ x, cf ≤ f x := λx, hcf (mem_range_self x),
 
   -- prove the inequality but with `dist f g` inside, by using inequalities comparing
   -- supr to supr and infi to infi
@@ -376,11 +396,11 @@ begin
       (λy, cinfi_le_cinfi  ⟨cf, forall_range_iff.2(λi, Hcf _)⟩ (λy, coe_le_coe_add_dist)),
   -- move the `dist f g` out of the infimum and the supremum, arguing that continuous monotone maps
   -- (here the addition of `dist f g`) preserve infimum and supremum
-  have E1 : ∀y, (⨅ x, g (inl x, inr y)) + dist f g = ⨅ x, g (inl x, inr y) + dist f g,
+  have E1 : ∀ y, (⨅ x, g (inl x, inr y)) + dist f g = ⨅ x, g (inl x, inr y) + dist f g,
   { assume y,
     refine map_cinfi_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _ _,
     { assume x y hx, simpa },
-    { show bdd_below (range (λx:α, g (inl x, inr y))),
+    { show bdd_below (range (λx:X, g (inl x, inr y))),
         from ⟨cg, forall_range_iff.2 (λi, Hcg _)⟩ } },
   have E2 : (⨆ y, ⨅ x, g (inl x, inr y)) + dist f g = ⨆ y, (⨅ x, g (inl x, inr y)) + dist f g,
   { refine map_csupr_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _ _,
@@ -390,132 +410,133 @@ begin
   simpa [E2, E1]
 end
 
-private lemma HD_lipschitz_aux3 (f g : Cb α β) : HD f ≤ HD g + dist f g :=
+private lemma HD_lipschitz_aux3 (f g : Cb X Y) : HD f ≤ HD g + dist f g :=
 max_le (le_trans (HD_lipschitz_aux1 f g) (add_le_add_right (le_max_left _ _) _))
        (le_trans (HD_lipschitz_aux2 f g) (add_le_add_right (le_max_right _ _) _))
 
 /-- Conclude that HD, being Lipschitz, is continuous -/
-private lemma HD_continuous : continuous (HD : Cb α β → ℝ) :=
+private lemma HD_continuous : continuous (HD : Cb X Y → ℝ) :=
 lipschitz_with.continuous (lipschitz_with.of_le_add HD_lipschitz_aux3)
 
 end constructions --section
 
 section consequences
-variables (α : Type u) (β : Type v) [metric_space α] [compact_space α] [nonempty α] [metric_space β]
-  [compact_space β] [nonempty β]
+variables (X : Type u) (Y : Type v) [metric_space X] [compact_space X] [nonempty X] [metric_space Y]
+  [compact_space Y] [nonempty Y]
 
 /- Now that we have proved that the set of candidates is compact, and that HD is continuous,
 we can finally select a candidate minimizing HD. This will be the candidate realizing the
 optimal coupling. -/
-private lemma exists_minimizer : ∃f ∈ candidates_b α β, ∀g ∈ candidates_b α β, HD f ≤ HD g :=
+private lemma exists_minimizer : ∃ f ∈ candidates_b X Y, ∀ g ∈ candidates_b X Y, HD f ≤ HD g :=
 compact_candidates_b.exists_forall_le candidates_b_nonempty HD_continuous.continuous_on
 
-private definition optimal_GH_dist : Cb α β := classical.some (exists_minimizer α β)
+private definition optimal_GH_dist : Cb X Y := classical.some (exists_minimizer X Y)
 
-private lemma optimal_GH_dist_mem_candidates_b : optimal_GH_dist α β ∈ candidates_b α β :=
-by cases (classical.some_spec (exists_minimizer α β)); assumption
+private lemma optimal_GH_dist_mem_candidates_b : optimal_GH_dist X Y ∈ candidates_b X Y :=
+by cases (classical.some_spec (exists_minimizer X Y)); assumption
 
-private lemma HD_optimal_GH_dist_le (g : Cb α β) (hg : g ∈ candidates_b α β) :
-  HD (optimal_GH_dist α β) ≤ HD g :=
-let ⟨Z1, Z2⟩ := classical.some_spec (exists_minimizer α β) in Z2 g hg
+private lemma HD_optimal_GH_dist_le (g : Cb X Y) (hg : g ∈ candidates_b X Y) :
+  HD (optimal_GH_dist X Y) ≤ HD g :=
+let ⟨Z1, Z2⟩ := classical.some_spec (exists_minimizer X Y) in Z2 g hg
 
-/-- With the optimal candidate, construct a premetric space structure on α ⊕ β, on which the
-predistance is given by the candidate. Then, we will identify points at 0 predistance
+/-- With the optimal candidate, construct a premetric space structure on `X ⊕ Y`, on which the
+predistance is given by the candidate. Then, we will identify points at `0` predistance
 to obtain a genuine metric space -/
-def premetric_optimal_GH_dist : pseudo_metric_space (α ⊕ β) :=
-{ dist := λp q, optimal_GH_dist α β (p, q),
-  dist_self := λx, candidates_refl (optimal_GH_dist_mem_candidates_b α β),
-  dist_comm := λx y, candidates_symm (optimal_GH_dist_mem_candidates_b α β),
-  dist_triangle := λx y z, candidates_triangle (optimal_GH_dist_mem_candidates_b α β) }
+def premetric_optimal_GH_dist : pseudo_metric_space (X ⊕ Y) :=
+{ dist := λp q, optimal_GH_dist X Y (p, q),
+  dist_self := λx, candidates_refl (optimal_GH_dist_mem_candidates_b X Y),
+  dist_comm := λx y, candidates_symm (optimal_GH_dist_mem_candidates_b X Y),
+  dist_triangle := λx y z, candidates_triangle (optimal_GH_dist_mem_candidates_b X Y) }
 
 local attribute [instance] premetric_optimal_GH_dist pseudo_metric.dist_setoid
 
-/-- A metric space which realizes the optimal coupling between α and β -/
-@[derive [metric_space]] definition optimal_GH_coupling : Type* :=
-pseudo_metric_quot (α ⊕ β)
+/-- A metric space which realizes the optimal coupling between `X` and `Y` -/
+@[derive metric_space, nolint has_inhabited_instance]
+definition optimal_GH_coupling : Type* :=
+pseudo_metric_quot (X ⊕ Y)
 
-/-- Injection of α in the optimal coupling between α and β -/
-def optimal_GH_injl (x : α) : optimal_GH_coupling α β := ⟦inl x⟧
+/-- Injection of `X` in the optimal coupling between `X` and `Y` -/
+def optimal_GH_injl (x : X) : optimal_GH_coupling X Y := ⟦inl x⟧
 
-/-- The injection of α in the optimal coupling between α and β is an isometry. -/
-lemma isometry_optimal_GH_injl : isometry (optimal_GH_injl α β) :=
+/-- The injection of `X` in the optimal coupling between `X` and `Y` is an isometry. -/
+lemma isometry_optimal_GH_injl : isometry (optimal_GH_injl X Y) :=
 begin
   refine isometry_emetric_iff_metric.2 (λx y, _),
   change dist ⟦inl x⟧ ⟦inl y⟧ = dist x y,
-  exact candidates_dist_inl (optimal_GH_dist_mem_candidates_b α β) _ _,
+  exact candidates_dist_inl (optimal_GH_dist_mem_candidates_b X Y) _ _,
 end
 
-/-- Injection of β  in the optimal coupling between α and β -/
-def optimal_GH_injr (y : β) : optimal_GH_coupling α β := ⟦inr y⟧
+/-- Injection of `Y` in the optimal coupling between `X` and `Y` -/
+def optimal_GH_injr (y : Y) : optimal_GH_coupling X Y := ⟦inr y⟧
 
-/-- The injection of β in the optimal coupling between α and β is an isometry. -/
-lemma isometry_optimal_GH_injr : isometry (optimal_GH_injr α β) :=
+/-- The injection of `Y` in the optimal coupling between `X` and `Y` is an isometry. -/
+lemma isometry_optimal_GH_injr : isometry (optimal_GH_injr X Y) :=
 begin
   refine isometry_emetric_iff_metric.2 (λx y, _),
   change dist ⟦inr x⟧ ⟦inr y⟧ = dist x y,
-  exact candidates_dist_inr (optimal_GH_dist_mem_candidates_b α β) _ _,
+  exact candidates_dist_inr (optimal_GH_dist_mem_candidates_b X Y) _ _,
 end
 
-/-- The optimal coupling between two compact spaces α and β is still a compact space -/
-instance compact_space_optimal_GH_coupling : compact_space (optimal_GH_coupling α β) :=
+/-- The optimal coupling between two compact spaces `X` and `Y` is still a compact space -/
+instance compact_space_optimal_GH_coupling : compact_space (optimal_GH_coupling X Y) :=
 ⟨begin
-  have : (univ : set (optimal_GH_coupling α β)) =
-           (optimal_GH_injl α β '' univ) ∪ (optimal_GH_injr α β '' univ),
+  have : (univ : set (optimal_GH_coupling X Y)) =
+           (optimal_GH_injl X Y '' univ) ∪ (optimal_GH_injr X Y '' univ),
   { refine subset.antisymm (λxc hxc, _) (subset_univ _),
     rcases quotient.exists_rep xc with ⟨x, hx⟩,
     cases x; rw ← hx,
-    { have : ⟦inl x⟧ = optimal_GH_injl α β x := rfl,
+    { have : ⟦inl x⟧ = optimal_GH_injl X Y x := rfl,
       rw this,
       exact mem_union_left _ (mem_image_of_mem _ (mem_univ _)) },
-    { have : ⟦inr x⟧ = optimal_GH_injr α β x := rfl,
+    { have : ⟦inr x⟧ = optimal_GH_injr X Y x := rfl,
       rw this,
       exact mem_union_right _ (mem_image_of_mem _ (mem_univ _)) } },
   rw this,
-  exact (compact_univ.image (isometry_optimal_GH_injl α β).continuous).union
-    (compact_univ.image (isometry_optimal_GH_injr α β).continuous)
+  exact (compact_univ.image (isometry_optimal_GH_injl X Y).continuous).union
+    (compact_univ.image (isometry_optimal_GH_injr X Y).continuous)
 end⟩
 
-/-- For any candidate f, HD(f) is larger than or equal to the Hausdorff distance in the
+/-- For any candidate `f`, `HD(f)` is larger than or equal to the Hausdorff distance in the
 optimal coupling. This follows from the fact that HD of the optimal candidate is exactly
 the Hausdorff distance in the optimal coupling, although we only prove here the inequality
 we need. -/
-lemma Hausdorff_dist_optimal_le_HD {f} (h : f ∈ candidates_b α β) :
-  Hausdorff_dist (range (optimal_GH_injl α β)) (range (optimal_GH_injr α β)) ≤ HD f :=
+lemma Hausdorff_dist_optimal_le_HD {f} (h : f ∈ candidates_b X Y) :
+  Hausdorff_dist (range (optimal_GH_injl X Y)) (range (optimal_GH_injr X Y)) ≤ HD f :=
 begin
-  refine le_trans (le_of_forall_le_of_dense (λr hr, _)) (HD_optimal_GH_dist_le α β f h),
-  have A : ∀ x ∈ range (optimal_GH_injl α β), ∃ y ∈ range (optimal_GH_injr α β), dist x y ≤ r,
+  refine le_trans (le_of_forall_le_of_dense (λr hr, _)) (HD_optimal_GH_dist_le X Y f h),
+  have A : ∀ x ∈ range (optimal_GH_injl X Y), ∃ y ∈ range (optimal_GH_injr X Y), dist x y ≤ r,
   { assume x hx,
     rcases mem_range.1 hx with ⟨z, hz⟩,
     rw ← hz,
-    have I1 : (⨆ x, ⨅ y, optimal_GH_dist α β (inl x, inr y)) < r :=
+    have I1 : (⨆ x, ⨅ y, optimal_GH_dist X Y (inl x, inr y)) < r :=
       lt_of_le_of_lt (le_max_left _ _) hr,
-    have I2 : (⨅ y, optimal_GH_dist α β (inl z, inr y)) ≤
-        ⨆ x, ⨅ y, optimal_GH_dist α β (inl x, inr y) :=
+    have I2 : (⨅ y, optimal_GH_dist X Y (inl z, inr y)) ≤
+        ⨆ x, ⨅ y, optimal_GH_dist X Y (inl x, inr y) :=
       le_cSup (by simpa using HD_bound_aux1 _ 0) (mem_range_self _),
-    have I : (⨅ y, optimal_GH_dist α β (inl z, inr y)) < r := lt_of_le_of_lt I2 I1,
+    have I : (⨅ y, optimal_GH_dist X Y (inl z, inr y)) < r := lt_of_le_of_lt I2 I1,
     rcases exists_lt_of_cInf_lt (range_nonempty _) I with ⟨r', r'range, hr'⟩,
     rcases mem_range.1 r'range with ⟨z', hz'⟩,
-    existsi [optimal_GH_injr α β z', mem_range_self _],
-    have : (optimal_GH_dist α β) (inl z, inr z') ≤ r := begin rw hz', exact le_of_lt hr' end,
+    existsi [optimal_GH_injr X Y z', mem_range_self _],
+    have : (optimal_GH_dist X Y) (inl z, inr z') ≤ r, by { rw hz', exact le_of_lt hr' },
     exact this },
   refine Hausdorff_dist_le_of_mem_dist _ A _,
-  { rcases exists_mem_of_nonempty α with ⟨xα, _⟩,
-    have : optimal_GH_injl α β xα ∈ range (optimal_GH_injl α β) := mem_range_self _,
+  { rcases exists_mem_of_nonempty X with ⟨xX, _⟩,
+    have : optimal_GH_injl X Y xX ∈ range (optimal_GH_injl X Y) := mem_range_self _,
     rcases A _ this with ⟨y, yrange, hy⟩,
     exact le_trans dist_nonneg hy },
   { assume y hy,
     rcases mem_range.1 hy with ⟨z, hz⟩,
     rw ← hz,
-    have I1 : (⨆ y, ⨅ x, optimal_GH_dist α β (inl x, inr y)) < r :=
+    have I1 : (⨆ y, ⨅ x, optimal_GH_dist X Y (inl x, inr y)) < r :=
       lt_of_le_of_lt (le_max_right _ _) hr,
-    have I2 : (⨅ x, optimal_GH_dist α β (inl x, inr z)) ≤
-        ⨆ y, ⨅ x, optimal_GH_dist α β (inl x, inr y) :=
+    have I2 : (⨅ x, optimal_GH_dist X Y (inl x, inr z)) ≤
+        ⨆ y, ⨅ x, optimal_GH_dist X Y (inl x, inr y) :=
       le_cSup (by simpa using HD_bound_aux2 _ 0) (mem_range_self _),
-    have I : (⨅ x, optimal_GH_dist α β (inl x, inr z)) < r := lt_of_le_of_lt I2 I1,
+    have I : (⨅ x, optimal_GH_dist X Y (inl x, inr z)) < r := lt_of_le_of_lt I2 I1,
     rcases exists_lt_of_cInf_lt (range_nonempty _) I with ⟨r', r'range, hr'⟩,
     rcases mem_range.1 r'range with ⟨z', hz'⟩,
-    existsi [optimal_GH_injl α β z', mem_range_self _],
-    have : (optimal_GH_dist α β) (inl z', inr z) ≤ r := begin rw hz', exact le_of_lt hr' end,
+    existsi [optimal_GH_injl X Y z', mem_range_self _],
+    have : (optimal_GH_dist X Y) (inl z', inr z) ≤ r, by { rw hz', exact le_of_lt hr' },
     rw dist_comm,
     exact this }
 end


### PR DESCRIPTION
Rename greek type variables to meaningful uppercase letters. Lint the files. Add a header where needed. Add spaces after forall or exist to conform to current style guide. Absolutely no new mathematical content.

---

Don't spend too much time on this. I won't add the "easy" label because the diff is too big, but it would definitely deserve it otherwise.