### PR TITLE
Add nontrivial instance for nnreal

### DIFF
--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -191,6 +191,9 @@ to_real_hom.to_add_monoid_hom.map_nsmul _ _
 @[simp, norm_cast] protected lemma coe_nat_cast (n : ℕ) : (↑(↑n : ℝ≥0) : ℝ) = n :=
 to_real_hom.map_nat_cast n
 
+instance : nontrivial ℝ≥0 :=
+nontrivial.mk ⟨0, ⟨1, zero_ne_one⟩⟩
+
 instance : linear_order ℝ≥0 :=
 linear_order.lift (coe : ℝ≥0 → ℝ) nnreal.coe_injective
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -191,8 +191,7 @@ to_real_hom.to_add_monoid_hom.map_nsmul _ _
 @[simp, norm_cast] protected lemma coe_nat_cast (n : ℕ) : (↑(↑n : ℝ≥0) : ℝ) = n :=
 to_real_hom.map_nat_cast n
 
-instance : nontrivial ℝ≥0 :=
-nontrivial.mk ⟨0, ⟨1, zero_ne_one⟩⟩
+instance : nontrivial ℝ≥0 := infinite.nontrivial ℝ≥0
 
 instance : linear_order ℝ≥0 :=
 linear_order.lift (coe : ℝ≥0 → ℝ) nnreal.coe_injective


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I don't know what the right way to do this is, I'm afraid. It seems likely that this could be derived automatically from e.g. the fact that the non-negative reals are already a `semiring`, but I'm not familiar with the type class hierarchy of mathlib.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
