### PR TITLE
[Merged by Bors] - feat(data/matrix): `has_repr` instances for `fin` vectors and matrices

### DIFF
--- a/src/data/matrix/notation.lean
+++ b/src/data/matrix/notation.lean
@@ -89,7 +89,7 @@ instance [has_repr α] : has_repr (fin n → α) :=
 ```
 -/
 instance [has_repr α] : has_repr (matrix (fin m) (fin n) α) :=
-(infer_instance : has_repr (fin m → fin n → α))
+(by apply_instance : has_repr (fin m → fin n → α))
 
 end matrix_notation
 

--- a/src/data/matrix/notation.lean
+++ b/src/data/matrix/notation.lean
@@ -71,6 +71,26 @@ v 0
 def vec_tail {n : ℕ} (v : fin n.succ → α) : fin n → α :=
 v ∘ fin.succ
 
+variables {m n : ℕ}
+
+/-- Use `![...]` notation for displaying a vector `fin n → α`, for example:
+
+```
+#eval ![1, 2] + ![3, 4] -- ![4, 6]
+```
+-/
+instance [has_repr α] : has_repr (fin n → α) :=
+{ repr := λ f, "![" ++ (string.intercalate ", " ((list.fin_range n).map (λ n, repr (f n)))) ++ "]" }
+
+/-- Use `![...]` notation for displaying a `fin`-indexed matrix, for example:
+
+```
+#eval ![![1, 2], ![3, 4]] + ![![3, 4], ![5, 6]] -- ![![4, 6], ![8, 10]]
+```
+-/
+instance [has_repr α] : has_repr (matrix (fin m) (fin n) α) :=
+(infer_instance : has_repr (fin m → fin n → α))
+
 end matrix_notation
 
 variables {m n o : ℕ} {m' n' o' : Type*} [fintype m'] [fintype n'] [fintype o']


### PR DESCRIPTION
This PR provides `has_repr` instances for the types `fin n → α` and `matrix (fin m) (fin n) α`, displaying in the `![...]` matrix notation. This is especially useful if you want to `#eval` a calculation involving matrices.

[Based on this Zulip post.](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Matrix.20operations/near/242766110)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
