### PR TITLE
[Merged by Bors] - feat(topology/locally_constant): Adds a few useful constructions

### DIFF
--- a/src/topology/locally_constant/basic.lean
+++ b/src/topology/locally_constant/basic.lean
@@ -168,7 +168,7 @@ begin
   intros a,
   have : f ⁻¹' {a} = (g ∘ f) ⁻¹' { g a },
   { ext x,
-    simp only [←cond, mem_singleton_iff, function.comp_app, mem_preimage],
+    simp only [mem_singleton_iff, function.comp_app, mem_preimage],
     exact ⟨λ h, by rw h, λ h, inj h⟩ },
   rw this,
   apply h,

--- a/src/topology/locally_constant/basic.lean
+++ b/src/topology/locally_constant/basic.lean
@@ -161,6 +161,8 @@ lemma div [has_div Y] ⦃f g : X → Y⦄ (hf : is_locally_constant f) (hg : is_
   is_locally_constant (f / g) :=
 hf.comp₂ hg (/)
 
+/-- If a composition of a function `f` followed by an injection `g` is locally 
+constant, then the locally constant property descends to `f`. -/
 lemma desc {α β : Type*} (f : X → α) (g : α → β)
   (h : is_locally_constant (g ∘ f)) (inj : function.injective g) : is_locally_constant f :=
 begin

--- a/src/topology/locally_constant/basic.lean
+++ b/src/topology/locally_constant/basic.lean
@@ -220,6 +220,7 @@ def const (X : Type*) {Y : Type*} [topological_space X] (y : Y) :
   locally_constant X Y :=
 ⟨function.const X y, is_locally_constant.const _⟩
 
+/-- The locally constant function to `fin 2` associated to a clopen set. -/
 def of_clopen {X : Type*} [topological_space X] {U : set X} [∀ x, decidable (x ∈ U)]
   (hU : is_clopen U) : locally_constant X (fin 2) :=
 { to_fun := λ x, if x ∈ U then 0 else 1,

--- a/src/topology/locally_constant/basic.lean
+++ b/src/topology/locally_constant/basic.lean
@@ -7,6 +7,7 @@ import topology.subset_properties
 import topology.connected
 import topology.algebra.monoid
 import tactic.tfae
+import tactic.fin_cases
 
 /-!
 # Locally constant functions
@@ -160,6 +161,19 @@ lemma div [has_div Y] ⦃f g : X → Y⦄ (hf : is_locally_constant f) (hg : is_
   is_locally_constant (f / g) :=
 hf.comp₂ hg (/)
 
+lemma desc {α β : Type*} (f : X → α) (g : α → β)
+  (h : is_locally_constant (g ∘ f)) (inj : function.injective g) : is_locally_constant f :=
+begin
+  rw (is_locally_constant.tfae f).out 0 3,
+  intros a,
+  have : f ⁻¹' {a} = (g ∘ f) ⁻¹' { g a },
+  { ext x,
+    simp only [←cond, mem_singleton_iff, function.comp_app, mem_preimage],
+    exact ⟨λ h, by rw h, λ h, inj h⟩ },
+  rw this,
+  apply h,
+end
+
 end is_locally_constant
 
 /-- A (bundled) locally constant function from a topological space `X` to a type `Y`. -/
@@ -206,6 +220,54 @@ def const (X : Type*) {Y : Type*} [topological_space X] (y : Y) :
   locally_constant X Y :=
 ⟨function.const X y, is_locally_constant.const _⟩
 
+def of_clopen {X : Type*} [topological_space X] {U : set X} [∀ x, decidable (x ∈ U)]
+  (hU : is_clopen U) : locally_constant X (fin 2) :=
+{ to_fun := λ x, if x ∈ U then 0 else 1,
+  is_locally_constant := begin
+    rw (is_locally_constant.tfae (λ x, if x ∈ U then (0 : fin 2) else 1)).out 0 3,
+    intros e,
+    fin_cases e,
+    { convert hU.1 using 1,
+      ext,
+      simp only [nat.one_ne_zero, mem_singleton_iff, fin.one_eq_zero_iff,
+        mem_preimage, ite_eq_left_iff],
+      tauto },
+    { rw ← is_closed_compl_iff,
+      convert hU.2,
+      ext,
+      simp }
+  end }
+
+@[simp] lemma of_clopen_fiber_zero {X : Type*} [topological_space X] {U : set X}
+  [∀ x, decidable (x ∈ U)] (hU : is_clopen U) : of_clopen hU ⁻¹' ({0} : set (fin 2)) = U :=
+begin
+  ext,
+  simp only [of_clopen, nat.one_ne_zero, mem_singleton_iff,
+    fin.one_eq_zero_iff, coe_mk, mem_preimage, ite_eq_left_iff],
+  tauto,
+end
+
+@[simp] lemma of_clopen_fiber_one {X : Type*} [topological_space X] {U : set X}
+  [∀ x, decidable (x ∈ U)] (hU : is_clopen U) : of_clopen hU ⁻¹' ({1} : set (fin 2)) = Uᶜ :=
+begin
+  ext,
+  simp only [of_clopen, nat.one_ne_zero, mem_singleton_iff, coe_mk,
+    fin.zero_eq_one_iff, mem_preimage, ite_eq_right_iff,
+    mem_compl_eq],
+  tauto,
+end
+
+lemma locally_constant_eq_of_fiber_zero_eq {X : Type*} [topological_space X]
+  (f g : locally_constant X (fin 2)) (h : f ⁻¹' ({0} : set (fin 2)) = g ⁻¹' {0}) : f = g :=
+begin
+  simp only [set.ext_iff, mem_singleton_iff, mem_preimage] at h,
+  ext1 x,
+  have := h x,
+  set a := f x,
+  set b := g x,
+  fin_cases a; fin_cases b; finish
+end
+
 lemma range_finite [compact_space X] (f : locally_constant X Y) :
   (set.range f).finite :=
 f.is_locally_constant.range_finite
@@ -241,6 +303,34 @@ def map (f : Y → Z) : locally_constant X Y → locally_constant X Z :=
 
 @[simp] lemma map_comp {Y₁ Y₂ Y₃ : Type*} (g : Y₂ → Y₃) (f : Y₁ → Y₂) :
   @map X _ _ _ g ∘ map f = map (g ∘ f) := by { ext, refl }
+
+/-- Given a locally constant function to `α → β`, construct a family of locally constant
+functions with values in β indexed by α. -/
+def flip {X α β : Type*} [topological_space X] (f : locally_constant X (α → β)) (a : α) :
+  locally_constant X β := f.map (λ f, f a)
+
+/-- If α is finite, this constructs a locally constant function to `α → β` given a
+family of locally constant functions with values in β indexed by α. -/
+def unflip {X α β : Type*} [fintype α] [topological_space X] (f : α → locally_constant X β) :
+  locally_constant X (α → β) :=
+{ to_fun := λ x a, f a x,
+  is_locally_constant := begin
+    rw (is_locally_constant.tfae (λ x a, f a x)).out 0 3,
+    intros g,
+    have : (λ (x : X) (a : α), f a x) ⁻¹' {g} = ⋂ (a : α), (f a) ⁻¹' {g a}, by tidy,
+    rw this,
+    apply is_open_Inter,
+    intros a,
+    apply (f a).is_locally_constant,
+  end }
+
+@[simp]
+lemma unflip_flip {X α β : Type*} [fintype α] [topological_space X]
+  (f : locally_constant X (α → β)) : unflip f.flip = f := by { ext, refl }
+
+@[simp]
+lemma flip_unflip {X α β : Type*} [fintype α] [topological_space X]
+  (f : α → locally_constant X β) : (unflip f).flip = f := by { ext, refl }
 
 section comap
 
@@ -289,5 +379,21 @@ begin
 end
 
 end comap
+
+section desc
+
+/-- If a locally constant function factors through an injection, then it factors through a locally
+constant function. -/
+def desc {X α β : Type*} [topological_space X] {g : α → β} (f : X → α) (h : locally_constant X β)
+  (cond : g ∘ f = h) (inj : function.injective g) : locally_constant X α :=
+{ to_fun := f,
+  is_locally_constant := is_locally_constant.desc _ g (by { rw cond, exact h.2 }) inj }
+
+@[simp]
+lemma coe_desc {X α β : Type*} [topological_space X] (f : X → α) (g : α → β)
+  (h : locally_constant X β) (cond : g ∘ f = h) (inj : function.injective g) :
+  ⇑(desc f h cond inj) = f := rfl
+
+end desc
 
 end locally_constant


### PR DESCRIPTION
This PR adds a few useful constructions around locallly constant functions:
1. A locally constant function to `fin 2` associated to a clopen set.
2. Flipping a locally constant function taking values in a function type.
3. Unflipping a finite family of locally constant function.
4. Descending locally constant functions along an injective map.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
