### PR TITLE
[Merged by Bors] - feat(algebra/group/basic): prove `a / 1 = a` and remove `sub_zero`

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -321,13 +321,13 @@ by simpa only [div_eq_mul_inv] using λ a a' h, mul_left_injective (b⁻¹) h
 lemma div_right_injective : function.injective (λ a, b / a) :=
 by simpa only [div_eq_mul_inv] using λ a a' h, inv_injective (mul_right_injective b h)
 
--- I removed `sub_zero` below, as it is the `to_additive` version of this lemma.
--- The unprimed version is used by group_with_zero
+-- The unprimed version is used by `group_with_zero`.  This is the preferred choice.
+-- See https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60div_one'.60
 @[simp, to_additive sub_zero]
 lemma div_one' (a : G) : a / 1 = a :=
 calc  a / 1 = a * 1⁻¹ : div_eq_mul_inv a 1
-          ... = a * 1   : congr_arg _ one_inv
-          ... = a       : mul_one a
+          ... = a * 1 : congr_arg _ one_inv
+          ... = a     : mul_one a
 
 end group
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -321,6 +321,14 @@ by simpa only [div_eq_mul_inv] using λ a a' h, mul_left_injective (b⁻¹) h
 lemma div_right_injective : function.injective (λ a, b / a) :=
 by simpa only [div_eq_mul_inv] using λ a a' h, inv_injective (mul_right_injective b h)
 
+-- I removed `sub_zero` below, as it is the `to_additive` version of this lemma.
+-- The unprimed version is used by group_with_zero
+@[simp, to_additive sub_zero]
+lemma div_one' (a : G) : a / 1 = a :=
+calc  a / 1 = a * 1⁻¹ : div_eq_mul_inv a 1
+          ... = a * 1   : congr_arg _ one_inv
+          ... = a       : mul_one a
+
 end group
 
 section add_group
@@ -341,9 +349,6 @@ by rw [sub_eq_add_neg, add_assoc, ←sub_eq_add_neg]
 lemma eq_of_sub_eq_zero (h : a - b = 0) : a = b :=
 calc a = a - b + b : (sub_add_cancel a b).symm
    ... = b         : by rw [h, zero_add]
-
-@[simp] lemma sub_zero (a : G) : a - 0 = a :=
-by rw [sub_eq_add_neg, neg_zero, add_zero]
 
 lemma sub_ne_zero_of_ne (h : a ≠ b) : a - b ≠ 0 :=
 mt eq_of_sub_eq_zero h


### PR DESCRIPTION
Add a proof that, in a group, `a / 1 = a`.  As a consequence, `sub_zero` is the `to_additive version of this lemma and I removed it.

The name of the lemma is `div_one'`, since the unprimed version is taken by `group_with_zero`.

Zulip:
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60div_one'.60

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
