### PR TITLE
[Merged by Bors] - docs(data/pnat): add module docstrings

### DIFF
--- a/src/data/pnat/factors.lean
+++ b/src/data/pnat/factors.lean
@@ -11,7 +11,7 @@ import algebra.group
 /-!
 # Prime factors of nonzero naturals
 
-This file defines the p-adic valuations of a nonzero natural number `n` as a multiset of primes,
+This file defines the factorization of a nonzero natural number `n` as a multiset of primes,
 the multiplicity of `p` in this factors multiset being the p-adic valuation of `n`.
 
 ## Main declarations

--- a/src/data/pnat/factors.lean
+++ b/src/data/pnat/factors.lean
@@ -8,6 +8,18 @@ import data.multiset.sort
 import data.int.gcd
 import algebra.group
 
+/-!
+# Prime factors of nonzero naturals
+
+This file defines the p-adic valuations of a nonzero natural number `n` as a multiset of primes,
+the multiplicity of `p` in this factors multiset being the p-adic valuation of `n`.
+
+## Main declarations
+
+* `prime_multiset`: Type of multisets of prime numbers.
+* `factor_multiset n`: Multiset of prime factors of `n`.
+-/
+
 /-- The type of multisets of prime numbers.  Unique factorization
  gives an equivalence between this set and ℕ+, as we will formalize
  below. -/
@@ -36,8 +48,7 @@ by { dsimp [prime_multiset], apply_instance }
 theorem add_sub_of_le {u v : prime_multiset} : u ≤ v → u + (v - u) = v :=
 multiset.add_sub_of_le
 
-/-- The multiset consisting of a single prime
--/
+/-- The multiset consisting of a single prime -/
 def of_prime (p : nat.primes) : prime_multiset := (p ::ₘ 0)
 
 theorem card_of_prime (p : nat.primes) : multiset.card (of_prime p) = 1 := rfl
@@ -50,7 +61,6 @@ theorem card_of_prime (p : nat.primes) : multiset.card (of_prime p) = 1 := rfl
  as a multiset of primes.  The next block of results records
  obvious properties of these coercions.
 -/
-
 def to_nat_multiset : prime_multiset → multiset ℕ :=
 λ v, v.map (λ p, (p : ℕ))
 
@@ -152,8 +162,7 @@ theorem prod_of_pnat_multiset (v : multiset ℕ+) (h) :
 by { dsimp [prod], rw [to_of_pnat_multiset] }
 
 /-- Lists can be coerced to multisets; here we have some results
- about how this interacts with our constructions on multisets.
--/
+about how this interacts with our constructions on multisets. -/
 def of_nat_list (l : list ℕ) (h : ∀ (p : ℕ), p ∈ l → p.prime) : prime_multiset :=
 of_nat_multiset (l : multiset ℕ) h
 
@@ -162,7 +171,7 @@ by { have := prod_of_nat_multiset (l : multiset ℕ) h,
      rw [multiset.coe_prod] at this, exact this }
 
 /-- If a `list ℕ+` consists only of primes, it can be recast as a `prime_multiset` with
-  the coercion from lists to multisets. -/
+the coercion from lists to multisets. -/
 def of_pnat_list (l : list ℕ+) (h : ∀ (p : ℕ+), p ∈ l → p.prime) : prime_multiset :=
 of_pnat_multiset (l : multiset ℕ+) h
 
@@ -171,9 +180,7 @@ by { have := prod_of_pnat_multiset (l : multiset ℕ+) h,
      rw [multiset.coe_prod] at this, exact this }
 
 /-- The product map gives a homomorphism from the additive monoid
- of multisets to the multiplicative monoid ℕ+.
--/
-
+of multisets to the multiplicative monoid ℕ+. -/
 theorem prod_zero : (0 : prime_multiset).prod = 1 :=
 by { dsimp [prod], exact multiset.prod_zero }
 
@@ -311,8 +318,7 @@ end prime_multiset
 namespace pnat
 
 /-- The gcd and lcm operations on positive integers correspond
- to the inf and sup operations on multisets.
--/
+ to the inf and sup operations on multisets. -/
 theorem factor_multiset_gcd (m n : ℕ+) :
  factor_multiset (gcd m n) = (factor_multiset m) ⊓ (factor_multiset n) :=
 begin

--- a/src/data/pnat/xgcd.lean
+++ b/src/data/pnat/xgcd.lean
@@ -1,29 +1,39 @@
 /-
-Copyright (c) 2019 Neil Strickland.  All rights reserved.
+Copyright (c) 2019 Neil Strickland. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Neil Strickland
-
-This file sets up a version of the Euclidean algorithm that works
-only with natural numbers.  Given a, b > 0, it computes the unique
-system (w, x, y, z, d) such that the following identities hold:
-
- w * z = x * y + 1
- a = (w + x) d
- b = (y + z) d
-
-These equations force w, z, d > 0.  They also imply that
-the integers a' = w + x = a / d and b' = y + z = b / d are coprime,
-and that d is the gcd of a and b.
-
-This story is closely related to the structure of SL₂(ℕ) (as a
-free monoid on two generators) and the theory of continued fractions.
 -/
 import tactic.ring
-import tactic.abel
 import data.pnat.prime
 
+/-!
+# Euclidean algorithm for ℕ
+
+This file sets up a version of the Euclidean algorithm that only works with natural numbers.
+Given `0 < a, b`, it computes the unique `(w, x, y, z, d)` such that the following identities hold:
+* `a = (w + x) d`
+* `b = (y + z) d`
+* `w * z = x * y + 1`
+`d` is then the gcd of `a` and `b`, and `a' := a / d = w + x` and `b' := b / d = y + z` are coprime.
+
+This story is closely related to the structure of SL₂(ℕ) (as a free monoid on two generators) and
+the theory of continued fractions.
+
+## Main declarations
+
+* `xgcd_type`: Helper type in defining the gcd. Encapsulates `(wp, x, y, zp, ap, bp)`. where `wp`
+  `zp`, `ap`, `bp` are the variables getting changed through the algorithm.
+* `is_special`: States `wp * zp = x * y + 1`
+* `is_reduced`: States `ap = a ∧ bp = b`
+
+## Notes
+
+See `nat.xgcd` for a very similar algorithm allowing values in `ℤ`.
+-/
+
+open nat
+
 namespace pnat
-open nat pnat
 
 /-- A term of xgcd_type is a system of six naturals.  They should
  be thought of as representing the matrix
@@ -258,7 +268,7 @@ section gcd
 
 variables (a b : ℕ+)
 
-def xgcd: xgcd_type := (xgcd_type.start a b).reduce
+def xgcd : xgcd_type := (xgcd_type.start a b).reduce
 
 def gcd_d : ℕ+ := (xgcd a b).a
 def gcd_w : ℕ+ := (xgcd a b).w


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
I don't like those two files, `xgcd` in particular, for several reasons:

For `xgcd`,
- `xgcd_type` is literally `ℕ × ℕ × ℕ × ℕ × ℕ × ℕ` with custom fields names. At least `is_special` could be bundled with it.
- It basically is `nat.xgcd` (which already existed at the time of Neil Strickland's commit, #1073) but with no mention to `ℤ`.
- Instead of proving an equivalence between a definition and another condition, it defines this other condition separately and then proves its equivalence with the original one (see `is_special`/`is_special'`, `is_reduced`/`is_reduced'`), and this isn't justified by `defeq` concerns or similar.
- It outsources all steps out of the algorithm while it's not very long and none of these steps is truly useful beyond that scope. This results in multiple lemmas being sexplicated.

For `factors`,
- Most of the file is rederiving instances by hand, from the fact that `prime_multiset` is a subtype.
- It is not general enough.

Neither file is ever imported, which suggests that they are currently of limited use.

Any opinion?
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
