### PR TITLE
[Merged by Bors] - refactor(ring_theory): use `x ∈ non_zero_divisors` over `x : non_zero_divisors`

### DIFF
--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -650,7 +650,7 @@ begin
   obtain ⟨z, ⟨x, hx⟩⟩ := g.exists_integer_multiple y,
   refine ⟨x, _, _⟩,
   { rw [ne.def, ← g.to_map_eq_zero_iff, hx],
-    exact mul_ne_zero (g.to_map_ne_zero_of_mem_non_zero_divisors _) y_ne_zero },
+    exact mul_ne_zero (g.to_map_ne_zero_of_mem_non_zero_divisors z.2) y_ne_zero },
   { rw hx,
     exact smul_mem _ _ y_mem }
 end

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1138,8 +1138,8 @@ begin
 end
 
 protected lemma to_map_ne_zero_of_mem_non_zero_divisors [nontrivial R] (f : localization_map M S)
-  (hM : M ≤ non_zero_divisors R) (x : non_zero_divisors R) : f.to_map x ≠ 0 :=
-map_ne_zero_of_mem_non_zero_divisors (f.injective hM)
+  (hM : M ≤ non_zero_divisors R) {x : R} (hx : x ∈ non_zero_divisors R) : f.to_map x ≠ 0 :=
+map_ne_zero_of_mem_non_zero_divisors (f.injective hM) hx
 
 /-- A `comm_ring` `S` which is the localization of an integral domain `R` at a subset of
 non-zero elements is an integral domain. -/
@@ -1321,8 +1321,8 @@ protected theorem injective [comm_ring K] (φ : fraction_map R K) :
 φ.injective (le_of_eq rfl)
 
 protected lemma to_map_ne_zero_of_mem_non_zero_divisors [nontrivial R] [comm_ring K]
-  (φ : fraction_map R K) (x : non_zero_divisors R) : φ.to_map x ≠ 0 :=
-φ.to_map_ne_zero_of_mem_non_zero_divisors (le_of_eq rfl) x
+  (φ : fraction_map R K) {x : R} (hx : x ∈ non_zero_divisors R) : φ.to_map x ≠ 0 :=
+φ.to_map_ne_zero_of_mem_non_zero_divisors (le_of_eq rfl) hx
 
 /-- A `comm_ring` `K` which is the localization of an integral domain `R` at `R - {0}` is an
 integral domain. -/
@@ -1356,18 +1356,18 @@ variables {B : Type*} [integral_domain B] [field K] {L : Type*} [field L]
 
 lemma mk'_eq_div {r s} : f.mk' r s = f.to_map r / f.to_map s :=
 f.mk'_eq_iff_eq_mul.2 $ (div_mul_cancel _
-    (f.to_map_ne_zero_of_mem_non_zero_divisors _)).symm
+    (f.to_map_ne_zero_of_mem_non_zero_divisors s.2)).symm
 
 lemma is_unit_map_of_injective (hg : function.injective g)
-  (y : non_zero_divisors A) : is_unit (g y) :=
-is_unit.mk0 (g y) $ map_ne_zero_of_mem_non_zero_divisors hg
+  {y : A} (hy : y ∈ non_zero_divisors A) : is_unit (g y) :=
+is_unit.mk0 (g y) $ map_ne_zero_of_mem_non_zero_divisors hg hy
 
 /-- Given an integral domain `A`, a localization map to its fields of fractions
 `f : A →+* K`, and an injective ring hom `g : A →+* L` where `L` is a field, we get a
 field hom sending `z : K` to `g x * (g y)⁻¹`, where `(x, y) : A × (non_zero_divisors A)` are
 such that `z = f x * (f y)⁻¹`. -/
 noncomputable def lift (hg : injective g) : K →+* L :=
-f.lift $ is_unit_map_of_injective hg
+f.lift $ λ y, is_unit_map_of_injective hg y.2
 
 /-- Given an integral domain `A`, a localization map to its fields of fractions
 `f : A →+* K`, and an injective ring hom `g : A →+* L` where `L` is a field,
@@ -1376,11 +1376,11 @@ field hom induced from `K` to `L` maps `f x / f y` to `g x / g y` for all
 @[simp] lemma lift_mk' (hg : injective g) (x y) :
   f.lift hg (f.mk' x y) = g x / g y :=
 begin
-  erw f.lift_mk' (is_unit_map_of_injective hg),
+  erw f.lift_mk' (λ y, is_unit_map_of_injective hg y.2),
   erw submonoid.localization_map.mul_inv_left
   (λ y : non_zero_divisors A, show is_unit (g.to_monoid_hom y), from
-    is_unit_map_of_injective hg y),
-  exact (mul_div_cancel' _ (map_ne_zero_of_mem_non_zero_divisors hg)).symm,
+    is_unit_map_of_injective hg y.2),
+  exact (mul_div_cancel' _ (map_ne_zero_of_mem_non_zero_divisors hg y.2)).symm,
 end
 
 /-- Given integral domains `A, B` and localization maps to their fields of fractions
@@ -1390,7 +1390,7 @@ such that `z = f x * (f y)⁻¹`. -/
 noncomputable def map (g : fraction_map B L) {j : A →+* B} (hj : injective j) :
   K →+* L :=
 f.map (λ y, mem_non_zero_divisors_iff_ne_zero.2 $
-  map_ne_zero_of_mem_non_zero_divisors hj) g
+  map_ne_zero_of_mem_non_zero_divisors hj y.2) g
 
 /-- Given integral domains `A, B` and localization maps to their fields of fractions
 `f : A →+* K, g : B →+* L`, an isomorphism `j : A ≃+* B` induces an isomorphism of
@@ -1477,7 +1477,7 @@ begin
       (mem_non_zero_divisors_iff_ne_zero.mp b_nonzero),
   obtain ⟨c'_nonzero, b'_nonzero⟩ := mul_mem_non_zero_divisors.mp b_nonzero,
   refine ⟨a', ⟨b', b'_nonzero⟩, @no_factor, _⟩,
-  apply mul_left_cancel' (φ.to_map_ne_zero_of_mem_non_zero_divisors ⟨c' * b', b_nonzero⟩),
+  apply mul_left_cancel' (φ.to_map_ne_zero_of_mem_non_zero_divisors b_nonzero),
   simp only [subtype.coe_mk, φ.to_map.map_mul] at *,
   erw [←hab, mul_assoc, φ.mk'_spec' a' ⟨b', b'_nonzero⟩],
 end
@@ -1519,7 +1519,7 @@ lemma is_integer_of_is_unit_denom {x : φ.codomain} (h : is_unit (φ.denom x : A
 begin
   cases h with d hd,
   have d_ne_zero : φ.to_map (φ.denom x) ≠ 0 :=
-    φ.to_map_ne_zero_of_mem_non_zero_divisors (φ.denom x),
+    φ.to_map_ne_zero_of_mem_non_zero_divisors (φ.denom x).2,
   use ↑d⁻¹ * φ.num x,
   refine trans _ (φ.mk'_num_denom x),
   rw [φ.to_map.map_mul, φ.to_map.map_units_inv, hd],

--- a/src/ring_theory/non_zero_divisors.lean
+++ b/src/ring_theory/non_zero_divisors.lean
@@ -50,13 +50,13 @@ lemma mem_non_zero_divisors_iff_ne_zero {x : A} : x ∈ non_zero_divisors A ↔ 
 λ hnx z, eq_zero_of_ne_zero_of_mul_right_eq_zero hnx⟩
 
 lemma map_ne_zero_of_mem_non_zero_divisors [nontrivial R] {B : Type*} [ring B] {g : R →+* B}
-  (hg : function.injective g) {x : non_zero_divisors R} : g x ≠ 0 :=
-λ h0, one_ne_zero (x.2 1 ((one_mul x.1).symm ▸ (hg (trans h0 g.map_zero.symm))))
+  (hg : function.injective g) {x : R} (h : x ∈ non_zero_divisors R) : g x ≠ 0 :=
+λ h0, one_ne_zero (h 1 ((one_mul x).symm ▸ (hg (trans h0 g.map_zero.symm))))
 
 lemma map_mem_non_zero_divisors {B : Type*} [integral_domain B] {g : A →+* B}
-  (hg : function.injective g) {x : non_zero_divisors A} : g x ∈ non_zero_divisors B :=
+  (hg : function.injective g) {x : A} (h : x ∈ non_zero_divisors A) : g x ∈ non_zero_divisors B :=
 λ z hz, eq_zero_of_ne_zero_of_mul_right_eq_zero
-  (map_ne_zero_of_mem_non_zero_divisors hg) hz
+  (map_ne_zero_of_mem_non_zero_divisors hg h) hz
 
 lemma le_non_zero_divisors_of_domain {M : submonoid A}
   (hM : ↑0 ∉ M) : M ≤ non_zero_divisors A :=
@@ -78,7 +78,7 @@ lemma prod_zero_iff_exists_zero {R : Type*} [comm_semiring R] [no_zero_divisors 
 begin
   split, swap,
   { rintros ⟨r, hrs, rfl⟩,
-    exact multiset.prod_eq_zero hrs, },   
+    exact multiset.prod_eq_zero hrs, },
   refine multiset.induction _ (λ a s ih, _) s,
   { intro habs,
     simpa using habs, },

--- a/src/ring_theory/polynomial/scale_roots.lean
+++ b/src/ring_theory/polynomial/scale_roots.lean
@@ -117,7 +117,7 @@ lemma scale_roots_eval₂_eq_zero_of_eval₂_div_eq_zero
 begin
   convert scale_roots_eval₂_eq_zero f hr,
   rw [←mul_div_assoc, mul_comm, mul_div_cancel],
-  exact @map_ne_zero_of_mem_non_zero_divisors _ _ _ _ _ _ hf ⟨s, hs⟩
+  exact map_ne_zero_of_mem_non_zero_divisors hf hs
 end
 
 lemma scale_roots_aeval_eq_zero_of_aeval_div_eq_zero [algebra A K]


### PR DESCRIPTION
`map_ne_zero_of_mem_non_zero_divisors` and `map_mem_non_zero_divisors` used to take `x : non_zero_divisors A` as an (implicit) argument. This is awkward if you only have `hx : x ∈ non_zero_divisors A`, requiring you to write out `@map_ne_zero_of_mem_non_zero_divisors _ _ _ _ _ _ hf ⟨x, hx⟩`. By making `x ∈ non_zero_divisors A` the explicit argument, we can avoid this annoyance.

See e.g. `ring_theory/polynomial/scale_roots.lean` for the improvement.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
