### PR TITLE
[Merged by Bors] - feat(category_theory/yoneda): develop API for representable functors

### DIFF
--- a/src/category_theory/sites/canonical.lean
+++ b/src/category_theory/sites/canonical.lean
@@ -215,9 +215,9 @@ lemma is_sheaf_yoneda_obj (X : C) : presieve.is_sheaf (canonical_topology C) (yo
 λ Y S hS, sheaf_for_finest_topology _ (set.mem_range_self _) _ hS
 
 /-- A representable functor is a sheaf for the canonical topology. -/
-lemma is_sheaf_of_representable (P : Cᵒᵖ ⥤ Type v) [representable P] :
+lemma is_sheaf_of_representable (P : Cᵒᵖ ⥤ Type v) [P.representable] :
   presieve.is_sheaf (canonical_topology C) P :=
-presieve.is_sheaf_iso (canonical_topology C) representable.w (is_sheaf_yoneda_obj _)
+presieve.is_sheaf_iso (canonical_topology C) P.repr_w (is_sheaf_yoneda_obj _)
 
 /--
 A subcanonical topology is a topology which is smaller than the canonical topology.
@@ -236,7 +236,7 @@ le_finest_topology _ _ (by { rintro P ⟨X, rfl⟩, apply h })
 
 /-- If `J` is subcanonical, then any representable is a `J`-sheaf. -/
 lemma is_sheaf_of_representable {J : grothendieck_topology C} (hJ : subcanonical J)
-  (P : Cᵒᵖ ⥤ Type v) [representable P] :
+  (P : Cᵒᵖ ⥤ Type v) [P.representable] :
   presieve.is_sheaf J P :=
 presieve.is_sheaf_of_le _ hJ (is_sheaf_of_representable P)
 

--- a/src/category_theory/sites/sheaf.lean
+++ b/src/category_theory/sites/sheaf.lean
@@ -84,7 +84,8 @@ lemma is_sheaf_iff_is_sheaf_of_type (P : Cᵒᵖ ⥤ Type v) :
 begin
   split,
   { intros hP,
-    exact presieve.is_sheaf_iso J (coyoneda.iso_comp_punit _) (hP punit) },
+    refine presieve.is_sheaf_iso J _ (hP punit),
+    exact iso_whisker_left _ coyoneda.punit_iso ≪≫ P.right_unitor },
   { intros hP X Y S hS z hz,
     refine ⟨λ x, (hP S hS).amalgamate (λ Z f hf, z f hf x) _, _, _⟩,
     { intros Y₁ Y₂ Z g₁ g₂ f₁ f₂ hf₁ hf₂ h,

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -44,18 +44,14 @@ The co-Yoneda embedding, as a functor from `Cᵒᵖ` into co-presheaves on `C`.
 @[simps] def coyoneda : Cᵒᵖ ⥤ (C ⥤ Type v₁) :=
 { obj := λ X,
   { obj := λ Y, unop X ⟶ Y,
-    map := λ Y Y' f g, g ≫ f,
-    map_comp' := λ _ _ _ f g, begin ext1, dsimp, erw [category.assoc] end,
-    map_id' := λ Y, begin ext1, dsimp, erw [category.comp_id] end },
-  map := λ X X' f, { app := λ Y g, f.unop ≫ g },
-  map_comp' := λ _ _ _ f g, begin ext, dsimp, erw [category.assoc] end,
-  map_id' := λ X, begin ext, dsimp, erw [category.id_comp] end }
+    map := λ Y Y' f g, g ≫ f },
+  map := λ X X' f, { app := λ Y g, f.unop ≫ g } }
 
 namespace yoneda
 
 lemma obj_map_id {X Y : C} (f : op X ⟶ op Y) :
-  ((@yoneda C _).obj X).map f (𝟙 X) = ((@yoneda C _).map f.unop).app (op Y) (𝟙 Y) :=
-by obviously
+  (yoneda.obj X).map f (𝟙 X) = (yoneda.map f.unop).app (op Y) (𝟙 Y) :=
+by { dsimp, simp }
 
 @[simp] lemma naturality {X Y : C} (α : yoneda.obj X ⟶ yoneda.obj Y)
   {Z Z' : C} (f : Z ⟶ Z') (h : Z' ⟶ X) : f ≫ α.app (op Z') h = α.app (op Z) (f ≫ h) :=
@@ -66,20 +62,16 @@ The Yoneda embedding is full.
 
 See https://stacks.math.columbia.edu/tag/001P.
 -/
-instance yoneda_full : full (@yoneda C _) :=
-{ preimage := λ X Y f, (f.app (op X)) (𝟙 X) }
+instance yoneda_full : full (yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁) :=
+{ preimage := λ X Y f, f.app (op X) (𝟙 X) }
 
 /--
 The Yoneda embedding is faithful.
 
 See https://stacks.math.columbia.edu/tag/001P.
 -/
-instance yoneda_faithful : faithful (@yoneda C _) :=
-{ map_injective' := λ X Y f g p,
-  begin
-    injection p with h,
-    convert (congr_fun (congr_fun h (op X)) (𝟙 X)); dsimp; simp,
-  end }
+instance yoneda_faithful : faithful (yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁) :=
+{ map_injective' := λ X Y f g p, by convert (congr_fun (congr_app p (op X)) (𝟙 X)); dsimp; simp }
 
 /-- Extensionality via Yoneda. The typical usage would be
 ```
@@ -108,16 +100,15 @@ namespace coyoneda
 
 @[simp] lemma naturality {X Y : Cᵒᵖ} (α : coyoneda.obj X ⟶ coyoneda.obj Y)
   {Z Z' : C} (f : Z' ⟶ Z) (h : unop X ⟶ Z') : (α.app Z' h) ≫ f = α.app Z (h ≫ f) :=
-begin erw [functor_to_types.naturality], refl end
+(functor_to_types.naturality _ _ α f h).symm
 
-instance coyoneda_full : full (@coyoneda C _) :=
-{ preimage := λ X Y f, ((f.app (unop X)) (𝟙 _)).op }
+instance coyoneda_full : full (coyoneda : Cᵒᵖ ⥤ C ⥤ Type v₁) :=
+{ preimage := λ X Y f, (f.app _ (𝟙 X.unop)).op }
 
-instance coyoneda_faithful : faithful (@coyoneda C _) :=
+instance coyoneda_faithful : faithful (coyoneda : Cᵒᵖ ⥤ C ⥤ Type v₁) :=
 { map_injective' := λ X Y f g p,
   begin
-    injection p with h,
-    have t := (congr_fun (congr_fun h (unop X)) (𝟙 _)),
+    have t := congr_fun (congr_app p X.unop) (𝟙 _),
     simpa using congr_arg quiver.hom.op t,
   end }
 
@@ -127,7 +118,12 @@ If `coyoneda.map f` is an isomorphism, so was `f`.
 lemma is_iso {X Y : Cᵒᵖ} (f : X ⟶ Y) [is_iso (coyoneda.map f)] : is_iso f :=
 is_iso_of_fully_faithful coyoneda f
 
--- No need to use Cᵒᵖ here, works with any category
+/-- The identity functor on `Type` is isomorphic to the coyoneda functor coming from `punit`. -/
+def punit_iso : coyoneda.obj (opposite.op punit) ≅ 𝟭 (Type v₁) :=
+nat_iso.of_components
+  (λ X, { hom := λ f, f ⟨⟩, inv := λ x _, x })
+  (by tidy)
+
 /-- A Type-valued presheaf `P` is isomorphic to the composition of `P` with the
   coyoneda functor coming from `punit`. -/
 @[simps] def iso_comp_punit (P : C ⥤ Type v₁) : (P ⋙ coyoneda.obj (op punit.{v₁+1})) ≅ P :=
@@ -136,27 +132,123 @@ is_iso_of_fully_faithful coyoneda f
 
 end coyoneda
 
+namespace functor
+
+
 /--
-A presheaf `F` is representable if there is object `X` so `F ≅ yoneda.obj X`.
+A functor `F : Cᵒᵖ ⥤ Type v₁` is representable if there is object `X` so `F ≅ yoneda.obj X`.
 
 See https://stacks.math.columbia.edu/tag/001Q.
 -/
--- TODO should we make this a Prop, merely asserting existence of such an object?
-class representable (F : Cᵒᵖ ⥤ Type v₁) :=
-(X : C)
-(w : yoneda.obj X ≅ F)
+class representable (F : Cᵒᵖ ⥤ Type v₁) : Prop :=
+(has_representation : ∃ X (f : yoneda.obj X ⟶ F), is_iso f)
 
-end category_theory
+/-- Given an object `X` and an isomorphism `yoneda.obj X ≅ F`, `F` is representable. -/
+def representable_of_nat_iso {F : Cᵒᵖ ⥤ Type v₁} (X : C) (i : yoneda.obj X ≅ F) :
+  F.representable :=
+{ has_representation := ⟨X, i.hom, infer_instance⟩ }
 
-namespace category_theory
--- For the rest of the file, we are using product categories,
--- so need to restrict to the case morphisms are in 'Type', not 'Sort'.
+instance {X : C} : representable (yoneda.obj X) :=
+representable_of_nat_iso _ (iso.refl _)
 
-universes v₁ u₁ u₂ -- morphism levels before object levels. See note [category_theory universes].
+/--
+A functor `F : C ⥤ Type v₁` is corepresentable if there is object `X` so `F ≅ coyoneda.obj X`.
+
+See https://stacks.math.columbia.edu/tag/001Q.
+-/
+class corepresentable (F : C ⥤ Type v₁) : Prop :=
+(has_corepresentation : ∃ X (f : coyoneda.obj X ⟶ F), is_iso f)
+
+def corepresentable_of_nat_iso {F : C ⥤ Type v₁} (X : Cᵒᵖ) (i : coyoneda.obj X ≅ F) :
+  F.corepresentable :=
+{ has_corepresentation := ⟨X, i.hom, infer_instance⟩ }
+
+instance {X : Cᵒᵖ} : corepresentable (coyoneda.obj X) :=
+corepresentable_of_nat_iso X (iso.refl _)
+
+instance : corepresentable (𝟭 (Type v₁)) :=
+corepresentable_of_nat_iso (op punit) coyoneda.punit_iso
+
+section representable
+variables (F : Cᵒᵖ ⥤ Type v₁)
+variable [F.representable]
+
+noncomputable def repr_X : C :=
+(representable.has_representation : ∃ X (f : _ ⟶ F), _).some
+
+noncomputable def repr_f : yoneda.obj F.repr_X ⟶ F :=
+representable.has_representation.some_spec.some
+
+noncomputable def repr_x : F.obj (op F.repr_X) :=
+F.repr_f.app (op F.repr_X) (𝟙 F.repr_X)
+
+instance : is_iso F.repr_f :=
+representable.has_representation.some_spec.some_spec
+
+/--
+Note the components `F_repr.w.app X` definitionally have type `F.repr_X ⟶ X ≅ F.obj X`.
+-/
+noncomputable def repr_w : yoneda.obj F.repr_X ≅ F := as_iso F.repr_f
+
+@[simp] lemma repr_w_hom : F.repr_w.hom = F.repr_f := rfl
+
+lemma repr_w_app_hom (X : Cᵒᵖ) (f : unop X ⟶ F.repr_X) :
+  (F.repr_w.app X).hom f = F.map f.op F.repr_x :=
+begin
+  change F.repr_f.app X f = (F.repr_f.app (op F.repr_X) ≫ F.map f.op) (𝟙 F.repr_X),
+  rw ←F.repr_f.naturality,
+  dsimp,
+  simp
+end
+
+end representable
+
+section corepresentable
+
+variables (F : C ⥤ Type v₁)
+variable [F.corepresentable]
+
+noncomputable def corepr_X : C :=
+(corepresentable.has_corepresentation : ∃ X (f : _ ⟶ F), _).some.unop
+
+noncomputable def corepr_f : coyoneda.obj (op F.corepr_X) ⟶ F :=
+corepresentable.has_corepresentation.some_spec.some
+
+noncomputable def corepr_x : F.obj F.corepr_X :=
+F.corepr_f.app F.corepr_X (𝟙 F.corepr_X)
+
+instance : is_iso F.corepr_f :=
+corepresentable.has_corepresentation.some_spec.some_spec
+
+/--
+Note the components `F.w.app X` definitionally have type `F.X ⟶ X ≅ F.obj X`.
+-/
+noncomputable def corepr_w : coyoneda.obj (op F.corepr_X) ≅ F := as_iso F.corepr_f
+
+lemma corepr_w_app_hom (X : C) (f : F.corepr_X ⟶ X) :
+  (F.corepr_w.app X).hom f = F.map f F.corepr_x :=
+begin
+  change F.corepr_f.app X f = (F.corepr_f.app F.corepr_X ≫ F.map f) (𝟙 F.corepr_X),
+  rw ←F.corepr_f.naturality,
+  dsimp,
+  simp
+end
+
+end corepresentable
+
+end functor
+
+lemma representable_of_nat_iso {F G : Cᵒᵖ ⥤ Type v₁} (i : F ≅ G) [F.representable] :
+  G.representable :=
+functor.representable_of_nat_iso _ (F.repr_w ≪≫ i)
+
+lemma corepresentable_of_nat_iso {F G : C ⥤ Type v₁} (i : F ≅ G) [F.corepresentable] :
+  G.corepresentable :=
+functor.corepresentable_of_nat_iso _ (F.corepr_w ≪≫ i)
 
 open opposite
 
-variables (C : Type u₁) [category.{v₁} C]
+variables (C)
 
 -- We need to help typeclass inference with some awkward universe levels here.
 instance prod_category_instance_1 : category ((Cᵒᵖ ⥤ Type v₁) × Cᵒᵖ) :=
@@ -239,7 +331,7 @@ The isomorphism between `yoneda.obj X ⟶ F` and `F.obj (op X)`
 (we need to insert a `ulift` to get the universes right!)
 given by the Yoneda lemma.
 -/
-@[simp] def yoneda_sections (X : C) (F : Cᵒᵖ ⥤ Type v₁) :
+@[simps] def yoneda_sections (X : C) (F : Cᵒᵖ ⥤ Type v₁) :
   (yoneda.obj X ⟶ F) ≅ ulift.{u₁} (F.obj (op X)) :=
 (yoneda_lemma C).app (op X, F)
 
@@ -249,15 +341,6 @@ and elements of `F.obj X`, without any universe switching.
 -/
 def yoneda_equiv {X : C} {F : Cᵒᵖ ⥤ Type v₁} : (yoneda.obj X ⟶ F) ≃ F.obj (op X) :=
 (yoneda_sections X F).to_equiv.trans equiv.ulift
-
-lemma yoneda_equiv_naturality {X Y : C} {F : Cᵒᵖ ⥤ Type v₁} (f : yoneda.obj X ⟶ F) (g : Y ⟶ X) :
-  F.map g.op (yoneda_equiv f) = yoneda_equiv (yoneda.map g ≫ f) :=
-begin
-  change (f.app (op X) ≫ F.map g.op) (𝟙 X) = f.app (op Y) (𝟙 Y ≫ g),
-  rw ← f.naturality,
-  dsimp,
-  simp,
-end
 
 @[simp]
 lemma yoneda_equiv_apply {X : C} {F : Cᵒᵖ ⥤ Type v₁} (f : yoneda.obj X ⟶ F) :
@@ -269,6 +352,15 @@ lemma yoneda_equiv_symm_app_apply {X : C} {F : Cᵒᵖ ⥤ Type v₁} (x : F.obj
   (Y : Cᵒᵖ) (f : Y.unop ⟶ X) :
   (yoneda_equiv.symm x).app Y f = F.map f.op x :=
 rfl
+
+lemma yoneda_equiv_naturality {X Y : C} {F : Cᵒᵖ ⥤ Type v₁} (f : yoneda.obj X ⟶ F) (g : Y ⟶ X) :
+  F.map g.op (yoneda_equiv f) = yoneda_equiv (yoneda.map g ≫ f) :=
+begin
+  change (f.app (op X) ≫ F.map g.op) (𝟙 X) = f.app (op Y) (𝟙 Y ≫ g),
+  rw ←f.naturality,
+  dsimp,
+  simp,
+end
 
 /--
 When `C` is a small category, we can restate the isomorphism from `yoneda_sections`

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -124,11 +124,6 @@ nat_iso.of_components
   (λ X, { hom := λ f, f ⟨⟩, inv := λ x _, x })
   (by tidy)
 
--- /-- A Type-valued presheaf `P` is isomorphic to the composition of `P` with the
---   coyoneda functor coming from `punit`. -/
--- @[simps] def iso_comp_punit (P : C ⥤ Type v₁) : (P ⋙ coyoneda.obj (op punit.{v₁+1})) ≅ P :=
--- iso_whisker_left P punit_iso ≪≫ P.right_unitor
-
 end coyoneda
 
 namespace functor

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -176,7 +176,7 @@ variable [F.representable]
 noncomputable def repr_X : C :=
 (representable.has_representation : ∃ X (f : _ ⟶ F), _).some
 
-/-- The (forward ddirection)   -/
+/-- The (forward direction)   -/
 noncomputable def repr_f : yoneda.obj F.repr_X ⟶ F :=
 representable.has_representation.some_spec.some
 

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -137,13 +137,8 @@ See https://stacks.math.columbia.edu/tag/001Q.
 class representable (F : Cᵒᵖ ⥤ Type v₁) : Prop :=
 (has_representation : ∃ X (f : yoneda.obj X ⟶ F), is_iso f)
 
-/-- Given an object `X` and an isomorphism `yoneda.obj X ≅ F`, `F` is representable. -/
-lemma representable_of_nat_iso {F : Cᵒᵖ ⥤ Type v₁} (X : C) (i : yoneda.obj X ≅ F) :
-  F.representable :=
-{ has_representation := ⟨X, i.hom, infer_instance⟩ }
-
 instance {X : C} : representable (yoneda.obj X) :=
-representable_of_nat_iso _ (iso.refl _)
+{ has_representation := ⟨X, 𝟙 _, infer_instance⟩ }
 
 /--
 A functor `F : C ⥤ Type v₁` is corepresentable if there is object `X` so `F ≅ coyoneda.obj X`.
@@ -153,15 +148,11 @@ See https://stacks.math.columbia.edu/tag/001Q.
 class corepresentable (F : C ⥤ Type v₁) : Prop :=
 (has_corepresentation : ∃ X (f : coyoneda.obj X ⟶ F), is_iso f)
 
-lemma corepresentable_of_nat_iso {F : C ⥤ Type v₁} (X : Cᵒᵖ) (i : coyoneda.obj X ≅ F) :
-  F.corepresentable :=
-{ has_corepresentation := ⟨X, i.hom, infer_instance⟩ }
-
 instance {X : Cᵒᵖ} : corepresentable (coyoneda.obj X) :=
-corepresentable_of_nat_iso X (iso.refl _)
+{ has_corepresentation := ⟨X, 𝟙 _, infer_instance⟩ }
 
-instance : corepresentable (𝟭 (Type v₁)) :=
-corepresentable_of_nat_iso (op punit) coyoneda.punit_iso
+-- instance : corepresentable (𝟭 (Type v₁)) :=
+-- corepresentable_of_nat_iso (op punit) coyoneda.punit_iso
 
 section representable
 variables (F : Cᵒᵖ ⥤ Type v₁)
@@ -186,8 +177,8 @@ instance : is_iso F.repr_f :=
 representable.has_representation.some_spec.some_spec
 
 /--
-An isomorphism between `F` and a functor of the form `C(-, F.repr X)`.  Note the components
-`F_repr.w.app X` definitionally have type `(X.unop ⟶ F.repr_X) ≅ F.obj X`.
+An isomorphism between `F` and a functor of the form `C(-, F.repr_X)`.  Note the components
+`F.repr_w.app X` definitionally have type `(X.unop ⟶ F.repr_X) ≅ F.obj X`.
 -/
 noncomputable def repr_w : yoneda.obj F.repr_X ≅ F := as_iso F.repr_f
 
@@ -228,8 +219,8 @@ instance : is_iso F.corepr_f :=
 corepresentable.has_corepresentation.some_spec.some_spec
 
 /--
-An isomorphism between `F` and a functor of the form `C(F.repr X, -)`. Note the components
-`F.corepr_w.app X` definitionally have type `F.repr_X ⟶ X ≅ F.obj X`.
+An isomorphism between `F` and a functor of the form `C(F.corepr X, -)`. Note the components
+`F.corepr_w.app X` definitionally have type `F.corepr_X ⟶ X ≅ F.obj X`.
 -/
 noncomputable def corepr_w : coyoneda.obj (op F.corepr_X) ≅ F := as_iso F.corepr_f
 
@@ -246,13 +237,16 @@ end corepresentable
 
 end functor
 
-lemma representable_of_nat_iso {F G : Cᵒᵖ ⥤ Type v₁} (i : F ≅ G) [F.representable] :
+lemma representable_of_nat_iso (F : Cᵒᵖ ⥤ Type v₁) {G} (i : F ≅ G) [F.representable] :
   G.representable :=
-functor.representable_of_nat_iso _ (F.repr_w ≪≫ i)
+{ has_representation := ⟨F.repr_X, F.repr_f ≫ i.hom, infer_instance⟩ }
 
-lemma corepresentable_of_nat_iso {F G : C ⥤ Type v₁} (i : F ≅ G) [F.corepresentable] :
+lemma corepresentable_of_nat_iso (F : C ⥤ Type v₁) {G} (i : F ≅ G) [F.corepresentable] :
   G.corepresentable :=
-functor.corepresentable_of_nat_iso _ (F.corepr_w ≪≫ i)
+{ has_corepresentation := ⟨op F.corepr_X, F.corepr_f ≫ i.hom, infer_instance⟩ }
+
+instance : functor.corepresentable (𝟭 (Type v₁)) :=
+corepresentable_of_nat_iso (coyoneda.obj (op punit)) coyoneda.punit_iso
 
 open opposite
 

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -124,11 +124,10 @@ nat_iso.of_components
   (λ X, { hom := λ f, f ⟨⟩, inv := λ x _, x })
   (by tidy)
 
-/-- A Type-valued presheaf `P` is isomorphic to the composition of `P` with the
-  coyoneda functor coming from `punit`. -/
-@[simps] def iso_comp_punit (P : C ⥤ Type v₁) : (P ⋙ coyoneda.obj (op punit.{v₁+1})) ≅ P :=
-{ hom := { app := λ X f, f punit.star},
-  inv := { app := λ X a _, a } }
+-- /-- A Type-valued presheaf `P` is isomorphic to the composition of `P` with the
+--   coyoneda functor coming from `punit`. -/
+-- @[simps] def iso_comp_punit (P : C ⥤ Type v₁) : (P ⋙ coyoneda.obj (op punit.{v₁+1})) ≅ P :=
+-- iso_whisker_left P punit_iso ≪≫ P.right_unitor
 
 end coyoneda
 

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -176,10 +176,14 @@ variable [F.representable]
 noncomputable def repr_X : C :=
 (representable.has_representation : ∃ X (f : _ ⟶ F), _).some
 
-/-- The (forward direction)   -/
+/-- The (forward direction) of the isomorphism witnessing `F` is representable. -/
 noncomputable def repr_f : yoneda.obj F.repr_X ⟶ F :=
 representable.has_representation.some_spec.some
 
+/--
+The representing element for the representable functor `F`, sometimes called the universal
+element of the functor.
+-/
 noncomputable def repr_x : F.obj (op F.repr_X) :=
 F.repr_f.app (op F.repr_X) (𝟙 F.repr_X)
 
@@ -187,7 +191,8 @@ instance : is_iso F.repr_f :=
 representable.has_representation.some_spec.some_spec
 
 /--
-Note the components `F_repr.w.app X` definitionally have type `F.repr_X ⟶ X ≅ F.obj X`.
+An isomorphism between `F` and a functor of the form `C(-, F.repr X)`.  Note the components
+`F_repr.w.app X` definitionally have type `(X.unop ⟶ F.repr_X) ≅ F.obj X`.
 -/
 noncomputable def repr_w : yoneda.obj F.repr_X ≅ F := as_iso F.repr_f
 
@@ -209,12 +214,18 @@ section corepresentable
 variables (F : C ⥤ Type v₁)
 variable [F.corepresentable]
 
+/-- The representing object for the corepresentable functor `F`. -/
 noncomputable def corepr_X : C :=
 (corepresentable.has_corepresentation : ∃ X (f : _ ⟶ F), _).some.unop
 
+/-- The (forward direction) of the isomorphism witnessing `F` is corepresentable. -/
 noncomputable def corepr_f : coyoneda.obj (op F.corepr_X) ⟶ F :=
 corepresentable.has_corepresentation.some_spec.some
 
+/--
+The representing element for the corepresentable functor `F`, sometimes called the universal
+element of the functor.
+-/
 noncomputable def corepr_x : F.obj F.corepr_X :=
 F.corepr_f.app F.corepr_X (𝟙 F.corepr_X)
 
@@ -222,7 +233,8 @@ instance : is_iso F.corepr_f :=
 corepresentable.has_corepresentation.some_spec.some_spec
 
 /--
-Note the components `F.w.app X` definitionally have type `F.X ⟶ X ≅ F.obj X`.
+An isomorphism between `F` and a functor of the form `C(F.repr X, -)`. Note the components
+`F.w.app X` definitionally have type `F.repr_X ⟶ X ≅ F.obj X`.
 -/
 noncomputable def corepr_w : coyoneda.obj (op F.corepr_X) ≅ F := as_iso F.corepr_f
 

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -171,7 +171,7 @@ variable [F.representable]
 noncomputable def repr_X : C :=
 (representable.has_representation : ∃ X (f : _ ⟶ F), _).some
 
-/-- The (forward direction) of the isomorphism witnessing `F` is representable. -/
+/-- The (forward direction of the) isomorphism witnessing `F` is representable. -/
 noncomputable def repr_f : yoneda.obj F.repr_X ⟶ F :=
 representable.has_representation.some_spec.some
 
@@ -213,7 +213,7 @@ variable [F.corepresentable]
 noncomputable def corepr_X : C :=
 (corepresentable.has_corepresentation : ∃ X (f : _ ⟶ F), _).some.unop
 
-/-- The (forward direction) of the isomorphism witnessing `F` is corepresentable. -/
+/-- The (forward direction of the) isomorphism witnessing `F` is corepresentable. -/
 noncomputable def corepr_f : coyoneda.obj (op F.corepr_X) ⟶ F :=
 corepresentable.has_corepresentation.some_spec.some
 
@@ -229,7 +229,7 @@ corepresentable.has_corepresentation.some_spec.some_spec
 
 /--
 An isomorphism between `F` and a functor of the form `C(F.repr X, -)`. Note the components
-`F.w.app X` definitionally have type `F.repr_X ⟶ X ≅ F.obj X`.
+`F.corepr_w.app X` definitionally have type `F.repr_X ⟶ X ≅ F.obj X`.
 -/
 noncomputable def corepr_w : coyoneda.obj (op F.corepr_X) ≅ F := as_iso F.corepr_f
 

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -143,7 +143,7 @@ class representable (F : Cᵒᵖ ⥤ Type v₁) : Prop :=
 (has_representation : ∃ X (f : yoneda.obj X ⟶ F), is_iso f)
 
 /-- Given an object `X` and an isomorphism `yoneda.obj X ≅ F`, `F` is representable. -/
-def representable_of_nat_iso {F : Cᵒᵖ ⥤ Type v₁} (X : C) (i : yoneda.obj X ≅ F) :
+lemma representable_of_nat_iso {F : Cᵒᵖ ⥤ Type v₁} (X : C) (i : yoneda.obj X ≅ F) :
   F.representable :=
 { has_representation := ⟨X, i.hom, infer_instance⟩ }
 
@@ -158,7 +158,7 @@ See https://stacks.math.columbia.edu/tag/001Q.
 class corepresentable (F : C ⥤ Type v₁) : Prop :=
 (has_corepresentation : ∃ X (f : coyoneda.obj X ⟶ F), is_iso f)
 
-def corepresentable_of_nat_iso {F : C ⥤ Type v₁} (X : Cᵒᵖ) (i : coyoneda.obj X ≅ F) :
+lemma corepresentable_of_nat_iso {F : C ⥤ Type v₁} (X : Cᵒᵖ) (i : coyoneda.obj X ≅ F) :
   F.corepresentable :=
 { has_corepresentation := ⟨X, i.hom, infer_instance⟩ }
 
@@ -172,9 +172,11 @@ section representable
 variables (F : Cᵒᵖ ⥤ Type v₁)
 variable [F.representable]
 
+/-- The representing object for the representable functor `F`. -/
 noncomputable def repr_X : C :=
 (representable.has_representation : ∃ X (f : _ ⟶ F), _).some
 
+/-- The (forward ddirection)   -/
 noncomputable def repr_f : yoneda.obj F.repr_X ⟶ F :=
 representable.has_representation.some_spec.some
 


### PR DESCRIPTION
Dualises and extends API for representable functors which was previously pretty minimal

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
