### PR TITLE
[Merged by Bors] - feat(data/{fin,nat,zmod}): prove `zmod.coe_add_eq_ite`

### DIFF
--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -359,6 +359,11 @@ lemma val_add {n : ℕ} : ∀ a b : fin n, (a + b).val = (a.val + b.val) % n
 lemma coe_add {n : ℕ} : ∀ a b : fin n, ((a + b : fin n) : ℕ) = (a + b) % n
 | ⟨_, _⟩ ⟨_, _⟩ := rfl
 
+lemma coe_add_eq_ite {n : ℕ} (a b : fin n) :
+  (↑(a + b) : ℕ) = if n ≤ a + b then a + b - n else a + b :=
+by rw [fin.coe_add, nat.add_mod_eq_ite,
+       nat.mod_eq_of_lt (show ↑a < n, from a.2), nat.mod_eq_of_lt (show ↑b < n, from b.2)]
+
 lemma coe_bit0 {n : ℕ} (k : fin n) : ((bit0 k : fin n) : ℕ) = bit0 (k : ℕ) % n :=
 by { cases k, refl }
 

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1062,6 +1062,18 @@ theorem add_mod_eq_add_mod_left {m n k : ℕ} (i : ℕ) (H : m % n = k % n) :
   (i + m) % n = (i + k) % n :=
 by rw [add_comm, add_mod_eq_add_mod_right _ H, add_comm]
 
+lemma add_mod_eq_ite {a b n : ℕ} :
+  (a + b) % n = if n ≤ a % n + b % n then a % n + b % n - n else a % n + b % n :=
+begin
+  cases n, { simp },
+  rw nat.add_mod,
+  split_ifs with h,
+  { rw [nat.mod_eq_sub_mod h, nat.mod_eq_of_lt],
+    exact (nat.sub_lt_right_iff_lt_add h).mpr
+        (nat.add_lt_add (a.mod_lt n.zero_lt_succ) (b.mod_lt n.zero_lt_succ)) },
+  { exact nat.mod_eq_of_lt (lt_of_not_ge h) }
+end
+
 lemma mul_mod (a b n : ℕ) : (a * b) % n = ((a % n) * (b % n)) % n :=
 begin
   conv_lhs {

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -243,6 +243,18 @@ congr_fun (nat_cast_comp_val R) i
 @[simp] lemma int_cast_cast (i : zmod n) : ((i : ℤ) : R) = i :=
 congr_fun (int_cast_comp_cast R) i
 
+lemma coe_add_eq_ite {n : ℕ} (a b : zmod n) :
+  (↑(a + b) : ℤ) = if (n : ℤ) ≤ a + b then a + b - n else a + b :=
+begin
+  cases n,
+  { simp },
+  simp only [coe_coe, fin.coe_add_eq_ite, int.nat_cast_eq_coe_nat,
+             ← int.coe_nat_add, ← int.coe_nat_succ, int.coe_nat_le],
+  split_ifs with h,
+  { exact int.coe_nat_sub h },
+  { refl }
+end
+
 section char_dvd
 /-! If the characteristic of `R` divides `n`, then `cast` is a homomorphism. -/
 


### PR DESCRIPTION
This PR adds a couple of lemmas relating addition modulo `n` (in `ℕ`, `fin n` or `zmod n`) and addition in `ℕ` or `ℤ`.

[Based on this Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Homomorphism.20from.20the.20integers.20descends.20to.20.24.24.5Cmathbb.7BZ.7D.2Fn.24.24)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
