### PR TITLE
feat(order/directed): Add codirected_order class and associated instances.

### DIFF
--- a/src/data/multiset/finset_ops.lean
+++ b/src/data/multiset/finset_ops.lean
@@ -134,7 +134,10 @@ quotient.induction_on₂ s t $ λ l₁ l₂, (union_sublist_append _ _).subperm
 
 theorem ndunion_le {s t u : multiset α} : ndunion s t ≤ u ↔ s ⊆ u ∧ t ≤ u :=
 multiset.induction_on s (by simp)
-  (by simp [ndinsert_le, and_comm, and.left_comm] {contextual := tt})
+begin
+  simp only [ndinsert_le, cons_ndunion, cons_subset] {contextual := tt},
+  tauto,
+end
 
 theorem subset_ndunion_left (s t : multiset α) : s ⊆ ndunion s t :=
 λ a h, mem_ndunion.2 $ or.inl h

--- a/src/order/directed.lean
+++ b/src/order/directed.lean
@@ -85,14 +85,6 @@ class codirected_order (α : Type u) extends preorder α :=
 (codirected : ∀ i j : α, ∃ k, k ≤ i ∧ k ≤ j)
 
 @[priority 100]  -- see Note [lower instance priority]
-instance linear_order.to_directed_order (α) [linear_order α] : directed_order α :=
-⟨λ i j, or.cases_on (le_total i j) (λ hij, ⟨j, hij, le_refl j⟩) (λ hji, ⟨i, le_refl i, hji⟩)⟩
-
-@[priority 100]  -- see Note [lower instance priority]
-instance linear_order.to_codirected_order (α) [linear_order α] : codirected_order α :=
-⟨λ i j, or.cases_on (le_total i j) (λ hij, ⟨i, le_refl _, hij⟩) (λ hij, ⟨j, hij, le_refl _⟩)⟩
-
-@[priority 100]  -- see Note [lower instance priority]
 instance semilattice_sup.to_directed_order (α) [semilattice_sup α] : directed_order α :=
 ⟨λ i j, ⟨i ⊔ j, le_sup_left, le_sup_right⟩⟩
 

--- a/src/order/directed.lean
+++ b/src/order/directed.lean
@@ -79,6 +79,23 @@ there is an element `k` such that `i ≤ k` and `j ≤ k`. -/
 class directed_order (α : Type u) extends preorder α :=
 (directed : ∀ i j : α, ∃ k, i ≤ k ∧ j ≤ k)
 
+/-- A `preorder` is a `codirected_order` if for any two elements `i`, `j`
+there is an element `k` such that `k ≤ i` and `k ≤ j`. -/
+class codirected_order (α : Type u) extends preorder α :=
+(codirected : ∀ i j : α, ∃ k, k ≤ i ∧ k ≤ j)
+
 @[priority 100]  -- see Note [lower instance priority]
 instance linear_order.to_directed_order (α) [linear_order α] : directed_order α :=
 ⟨λ i j, or.cases_on (le_total i j) (λ hij, ⟨j, hij, le_refl j⟩) (λ hji, ⟨i, le_refl i, hji⟩)⟩
+
+@[priority 100]  -- see Note [lower instance priority]
+instance linear_order.to_codirected_order (α) [linear_order α] : codirected_order α :=
+⟨λ i j, or.cases_on (le_total i j) (λ hij, ⟨i, le_refl _, hij⟩) (λ hij, ⟨j, hij, le_refl _⟩)⟩
+
+@[priority 100]  -- see Note [lower instance priority]
+instance semilattice_sup.to_directed_order (α) [semilattice_sup α] : directed_order α :=
+⟨λ i j, ⟨i ⊔ j, le_sup_left, le_sup_right⟩⟩
+
+@[priority 100]  -- see Note [lower instance priority]
+instance semilattice_inf.to_codirected_order (α) [semilattice_inf α] : codirected_order α :=
+⟨λ i j, ⟨i ⊓ j, inf_le_left, inf_le_right⟩⟩


### PR DESCRIPTION
The added instances break the original proof of `multiset.ndunion_le`, hence the modified proof in this PR. See related [zulip discussion here](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Help.20with.20build.20fail/near/242957737)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
