### PR TITLE
[Merged by Bors] - feat(topology/algebra/ordered, topology/algebra/infinite_sum): bounded monotone sequences converge (variant versions)

### DIFF
--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -767,6 +767,14 @@ le_of_tendsto_of_tendsto' hf hg $ assume s, sum_le_sum $ assume b _, h b
 @[mono] lemma has_sum_mono (hf : has_sum f a₁) (hg : has_sum g a₂) (h : f ≤ g) : a₁ ≤ a₂ :=
 has_sum_le h hf hg
 
+lemma has_sum_le_of_sum_le (hf : has_sum f a) (h : ∀ s : finset β, ∑ b in s, f b ≤ a₂) :
+  a ≤ a₂ :=
+le_of_tendsto' hf h
+
+lemma le_has_sum_of_le_sum (hf : has_sum f a) (h : ∀ s : finset β, a₂ ≤ ∑ b in s, f b) :
+  a₂ ≤ a :=
+ge_of_tendsto' hf h
+
 lemma has_sum_le_inj {g : γ → α} (i : β → γ) (hi : injective i) (hs : ∀c∉set.range i, 0 ≤ g c)
   (h : ∀b, f b ≤ g (i b)) (hf : has_sum f a₁) (hg : has_sum g a₂) : a₁ ≤ a₂ :=
 have has_sum (λc, (partial_inv i c).cases_on' 0 f) a₁,
@@ -796,17 +804,21 @@ lemma tsum_le_tsum_of_inj {g : γ → α} (i : β → γ) (hi : injective i) (hs
   (h : ∀b, f b ≤ g (i b)) (hf : summable f) (hg : summable g) : tsum f ≤ tsum g :=
 has_sum_le_inj i hi hs h hf.has_sum hg.has_sum
 
-lemma sum_le_has_sum {f : β → α} (s : finset β) (hs : ∀ b∉s, 0 ≤ f b) (hf : has_sum f a) :
+lemma sum_le_has_sum (s : finset β) (hs : ∀ b∉s, 0 ≤ f b) (hf : has_sum f a) :
   ∑ b in s, f b ≤ a :=
 ge_of_tendsto hf (eventually_at_top.2 ⟨s, λ t hst,
   sum_le_sum_of_subset_of_nonneg hst $ λ b hbt hbs, hs b hbs⟩)
+
+lemma is_lub_has_sum (h : ∀ b, 0 ≤ f b) (hf : has_sum f a) :
+  is_lub (set.range (λ s : finset β, ∑ b in s, f b)) a :=
+is_lub_of_tendsto (finset.sum_mono_set_of_nonneg h) hf
 
 lemma le_has_sum (hf : has_sum f a) (b : β) (hb : ∀ b' ≠ b, 0 ≤ f b') : f b ≤ a :=
 calc f b = ∑ b in {b}, f b : finset.sum_singleton.symm
 ... ≤ a : sum_le_has_sum _ (by { convert hb, simp }) hf
 
 lemma sum_le_tsum {f : β → α} (s : finset β) (hs : ∀ b∉s, 0 ≤ f b) (hf : summable f) :
-  ∑ b in s, f b ≤ tsum f :=
+  ∑ b in s, f b ≤ ∑' b, f b :=
 sum_le_has_sum s hs hf.has_sum
 
 lemma le_tsum (hf : summable f) (b : β) (hb : ∀ b' ≠ b, 0 ≤ f b') : f b ≤ ∑' b, f b :=
@@ -818,6 +830,19 @@ has_sum_le h hf.has_sum hg.has_sum
 @[mono] lemma tsum_mono (hf : summable f) (hg : summable g) (h : f ≤ g) :
   ∑' n, f n ≤ ∑' n, g n :=
 tsum_le_tsum h hf hg
+
+lemma tsum_le_of_sum_le (hf : summable f) (h : ∀ s : finset β, ∑ b in s, f b ≤ a₂) :
+  ∑' b, f b ≤ a₂ :=
+has_sum_le_of_sum_le hf.has_sum h
+
+lemma tsum_le_of_sum_le' (ha₂ : 0 ≤ a₂) (h : ∀ s : finset β, ∑ b in s, f b ≤ a₂) :
+  ∑' b, f b ≤ a₂ :=
+begin
+  by_cases hf : summable f,
+  { exact tsum_le_of_sum_le hf h },
+  { rw tsum_eq_zero_of_not_summable hf,
+    exact ha₂ }
+end
 
 lemma has_sum.nonneg (h : ∀ b, 0 ≤ g b) (ha : has_sum g a) : 0 ≤ a :=
 has_sum_le h has_sum_zero ha
@@ -895,6 +920,9 @@ by rw [←has_sum_zero_iff, hf.has_sum_iff]
 
 lemma tsum_ne_zero_iff (hf : summable f) : ∑' i, f i ≠ 0 ↔ ∃ x, f x ≠ 0 :=
 by rw [ne.def, tsum_eq_zero_iff hf, not_forall]
+
+lemma is_lub_has_sum' (hf : has_sum f a) : is_lub (set.range (λ s : finset β, ∑ b in s, f b)) a :=
+is_lub_of_tendsto (finset.sum_mono_set f) hf
 
 end canonically_ordered
 
@@ -1048,6 +1076,27 @@ by { rw ←nat.cofinite_eq_at_top, exact hf.tendsto_cofinite_zero }
 
 end topological_group
 
+section linear_order
+
+/-! For infinite sums taking values in a linearly ordered monoid, the existence of a least upper
+bound for the finite sums is a criterion for summability.
+
+This criterion is useful when applied in a linearly ordered monoid which is also a complete or
+conditionally complete linear order, such as `ℝ`, `ℝ≥0`, `ℝ≥0∞`, because it is then easy to check
+the existence of a least upper bound.
+-/
+
+lemma has_sum_of_is_lub_of_nonneg [linear_ordered_add_comm_monoid β] [topological_space β]
+  [order_topology β] {f : α → β} (b : β) (h : ∀ b, 0 ≤ f b)
+  (hf : is_lub (set.range (λ s, ∑ a in s, f a)) b) :
+  has_sum f b :=
+tendsto_at_top_is_lub (finset.sum_mono_set_of_nonneg h) hf
+
+lemma has_sum_of_is_lub [canonically_linear_ordered_add_monoid β] [topological_space β]
+   [order_topology β] {f : α → β} (b : β) (hf : is_lub (set.range (λ s, ∑ a in s, f a)) b) :
+  has_sum f b :=
+tendsto_at_top_is_lub (finset.sum_mono_set f) hf
+
 lemma summable_abs_iff [linear_ordered_add_comm_group β] [uniform_space β]
   [uniform_add_group β] [complete_space β] {f : α → β} :
   summable (λ x, abs (f x)) ↔ summable f :=
@@ -1061,6 +1110,8 @@ calc summable (λ x, abs (f x)) ↔
 ... ↔ _ : by simp only [summable_neg_iff, summable_subtype_and_compl]
 
 alias summable_abs_iff ↔ summable.of_abs summable.abs
+
+end linear_order
 
 section cauchy_seq
 open finset.Ico filter

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -3110,16 +3110,19 @@ Related theorems above (`is_lub.is_lub_of_tendsto`, `is_glb.is_glb_of_tendsto` e
 when `f x` tends to `a` as `x` tends to some point `b` in the domain. -/
 
 lemma monotone.ge_of_tendsto {α β : Type*} [topological_space α] [preorder α]
-  [order_closed_topology α] [nonempty β] [semilattice_sup β] {f : β → α} {a : α} (hf : monotone f)
+  [order_closed_topology α] [semilattice_sup β] {f : β → α} {a : α} (hf : monotone f)
   (ha : tendsto f at_top (𝓝 a)) (b : β) :
   f b ≤ a :=
-ge_of_tendsto ha ((eventually_ge_at_top b).mono (λ _ hxy, hf hxy))
+begin
+  haveI : nonempty β := nonempty.intro b,
+  exact ge_of_tendsto ha ((eventually_ge_at_top b).mono (λ _ hxy, hf hxy))
+end
 
 lemma monotone.le_of_tendsto {α β : Type*} [topological_space α] [preorder α]
-  [order_closed_topology α] [nonempty β] [semilattice_inf β] {f : β → α} {a : α} (hf : monotone f)
+  [order_closed_topology α] [semilattice_inf β] {f : β → α} {a : α} (hf : monotone f)
   (ha : tendsto f at_bot (𝓝 a)) (b : β) :
   a ≤ f b :=
-le_of_tendsto ha ((eventually_le_at_bot b).mono (λ _ hxy, hf hxy))
+@monotone.ge_of_tendsto (order_dual α) (order_dual β) _ _ _ _ f _ hf.order_dual ha b
 
 lemma is_lub_of_tendsto {α β : Type*} [topological_space α] [preorder α] [order_closed_topology α]
   [nonempty β] [semilattice_sup β] {f : β → α} {a : α} (hf : monotone f)
@@ -3128,9 +3131,8 @@ lemma is_lub_of_tendsto {α β : Type*} [topological_space α] [preorder α] [or
 begin
   split,
   { rintros _ ⟨b, rfl⟩,
-    refine ge_of_tendsto ha ((eventually_ge_at_top b).mono (λ _ hxy, hf hxy)) },
-  { intros b hb,
-    exact le_of_tendsto' ha (λ x, hb (set.mem_range_self x)) }
+    exact hf.ge_of_tendsto ha b },
+  { exact λ _ hb, le_of_tendsto' ha (λ x, hb (set.mem_range_self x)) }
 end
 
 lemma is_glb_of_tendsto {α β : Type*} [topological_space α] [preorder α] [order_closed_topology α]


### PR DESCRIPTION
A bounded monotone sequence converges to a value `a`, if and only if `a` is a least upper bound for its range.

Mathlib had several variants of this fact previously (phrased in terms of, eg, `csupr`), but not quite this version (phrased in terms of `has_lub`).  This version has a couple of advantages:
- it applies to more general typeclasses (eg, `linear_order`) where the existence of suprema is not in general known
- it applies to algebraic typeclasses (`linear_ordered_add_comm_monoid`, etc) where, since completeness of orders is not a mix-in, it is not possible to simultaneously assume `(conditionally_)complete_linear_order`

The latter point makes these lemmas useful when dealing with `tsum`.  We get: a nonnegative function `f` satisfies `has_sum f a`, if and only if `a` is a least upper bound for its partial sums.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/monotone.20limits)