### PR TITLE
[Merged by Bors] - feat(group_theory): computable 1st isomorphism theorem

### DIFF
--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -823,12 +823,12 @@ def quotient_ker_equiv_of_right_inverse (f : M →* P) (g : P → M)
 
 /-- The first isomorphism theorem for monoids in the case of a surjective homomorphism.
 
-See `quotient_ker_equiv_of_right_inverse` for a computable version.
+For a `computable` version, see `con.quotient_ker_equiv_of_right_inverse`.
 -/
 @[to_additive "The first isomorphism theorem for `add_monoid`s in the case of a surjective
 homomorphism.
 
-See `quotient_ker_equiv_of_right_inverse` for a computable version.
+For a `computable` version, see `add_con.quotient_ker_equiv_of_right_inverse`.
 "]
 noncomputable def quotient_ker_equiv_of_surjective (f : M →* P) (hf : surjective f) :
   (ker f).quotient ≃* P :=

--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -809,14 +809,30 @@ noncomputable def quotient_ker_equiv_range (f : M →* P) : (ker f).quotient ≃
         ⟨λ x y h, ker_lift_injective f $ by rcases x; rcases y; injections,
          λ ⟨w, z, hz⟩, ⟨z, by rcases hz; rcases _x; refl⟩⟩ }
 
-/-- The first isomorphism theorem for monoids in the case of a surjective homomorphism. -/
+/-- The first isomorphism theorem for monoids in the case of a homomorphism with right inverse. -/
+@[to_additive "The first isomorphism theorem for `add_monoid`s in the case of a homomorphism
+with right inverse."]
+def quotient_ker_equiv_of_right_inverse (f : M →* P) (g : P → M)
+  (hf : function.right_inverse g f) :
+  (ker f).quotient ≃* P :=
+{ to_fun := ker_lift f,
+  inv_fun := coe ∘ g,
+  left_inv := λ x, ker_lift_injective _ (by rw [function.comp_app, ker_lift_mk, hf]),
+  right_inv := hf,
+  .. ker_lift f }
+
+/-- The first isomorphism theorem for monoids in the case of a surjective homomorphism.
+
+See `quotient_ker_equiv_of_right_inverse` for a computable version.
+-/
 @[to_additive "The first isomorphism theorem for `add_monoid`s in the case of a surjective
-homomorphism."]
+homomorphism.
+
+See `quotient_ker_equiv_of_right_inverse` for a computable version.
+"]
 noncomputable def quotient_ker_equiv_of_surjective (f : M →* P) (hf : surjective f) :
   (ker f).quotient ≃* P :=
-{ map_mul' := monoid_hom.map_mul _,
-  ..equiv.of_bijective (ker_lift f)
-      ⟨ker_lift_injective f, lift_surjective_of_surjective (le_refl _) hf⟩ }
+quotient_ker_equiv_of_right_inverse _ _ hf.has_right_inverse.some_spec
 
 /-- The second isomorphism theorem for monoids. -/
 @[to_additive "The second isomorphism theorem for `add_monoid`s."]

--- a/src/group_theory/congruence.lean
+++ b/src/group_theory/congruence.lean
@@ -811,7 +811,7 @@ noncomputable def quotient_ker_equiv_range (f : M →* P) : (ker f).quotient ≃
 
 /-- The first isomorphism theorem for monoids in the case of a homomorphism with right inverse. -/
 @[to_additive "The first isomorphism theorem for `add_monoid`s in the case of a homomorphism
-with right inverse."]
+with right inverse.", simps]
 def quotient_ker_equiv_of_right_inverse (f : M →* P) (g : P → M)
   (hf : function.right_inverse g f) :
   (ker f).quotient ≃* P :=

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -243,12 +243,12 @@ def quotient_ker_equiv_of_right_inverse (ψ : H → G) (hφ : function.right_inv
 
 /-- The canonical isomorphism `G/(ker φ) ≃* H` induced by a surjection `φ : G →* H`.
 
-For a `computable` version, see `quotient_ker_equiv_of_right_inverse`.
+For a `computable` version, see `quotient_group.quotient_ker_equiv_of_right_inverse`.
 -/
 @[to_additive quotient_add_group.quotient_ker_equiv_of_surjective "The canonical isomorphism
 `G/(ker φ) ≃+ H` induced by a surjection `φ : G →+ H`.
 
-For a `computable` version, see `quotient_ker_equiv_of_right_inverse`."]
+For a `computable` version, see `quotient_add_group.quotient_ker_equiv_of_right_inverse`."]
 noncomputable def quotient_ker_equiv_of_surjective (hφ : function.surjective φ) :
   (quotient (ker φ)) ≃* H :=
 quotient_ker_equiv_of_right_inverse φ _ hφ.has_right_inverse.some_spec

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -235,7 +235,7 @@ with a right inverse `ψ : H → G`. -/
 `G/(ker φ) ≃+ H` induced by a homomorphism `φ : G →+ H` with a right inverse `ψ : H → G`.",
   simps]
 def quotient_ker_equiv_of_right_inverse (ψ : H → G) (hφ : function.right_inverse ψ φ) :
-  (quotient (ker φ)) ≃* H :=
+  quotient (ker φ) ≃* H :=
 { to_fun := ker_lift φ,
   inv_fun := mk ∘ ψ,
   left_inv := λ x, ker_lift_injective φ (by rw [function.comp_app, ker_lift_mk', hφ]),
@@ -251,7 +251,7 @@ For a `computable` version, see `quotient_group.quotient_ker_equiv_of_right_inve
 
 For a `computable` version, see `quotient_add_group.quotient_ker_equiv_of_right_inverse`."]
 noncomputable def quotient_ker_equiv_of_surjective (hφ : function.surjective φ) :
-  (quotient (ker φ)) ≃* H :=
+  quotient (ker φ) ≃* H :=
 quotient_ker_equiv_of_right_inverse φ _ hφ.has_right_inverse.some_spec
 
 /-- If two normal subgroups `M` and `N` of `G` are the same, their quotient groups are

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -232,7 +232,8 @@ mul_equiv.of_bijective (range_ker_lift φ) ⟨range_ker_lift_injective φ, range
 /-- The canonical isomorphism `G/(ker φ) ≃* H` induced by a homomorphism `φ : G →* H`
 with a right inverse `ψ : H →* G`. -/
 @[to_additive quotient_add_group.quotient_ker_equiv_of_right_inverse "The canonical isomorphism
-`G/(ker φ) ≃+ H` induced by a homomorphism `φ : G →+ H` with a right inverse `ψ : H →+ G`."]
+`G/(ker φ) ≃+ H` induced by a homomorphism `φ : G →+ H` with a right inverse `ψ : H →+ G`.",
+  simps]
 def quotient_ker_equiv_of_right_inverse (ψ : H → G) (hφ : function.right_inverse ψ φ) :
   (quotient (ker φ)) ≃* H :=
 { to_fun := ker_lift φ,

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -229,16 +229,29 @@ end
 noncomputable def quotient_ker_equiv_range : (quotient (ker φ)) ≃* range φ :=
 mul_equiv.of_bijective (range_ker_lift φ) ⟨range_ker_lift_injective φ, range_ker_lift_surjective φ⟩
 
-/-- The canonical isomorphism `G/(ker φ) ≃* H` induced by a surjection `φ : G →* H`. -/
+/-- The canonical isomorphism `G/(ker φ) ≃* H` induced by a homomorphism `φ : G →* H`
+with a right inverse `ψ : H →* G`. -/
+@[to_additive quotient_add_group.quotient_ker_equiv_of_right_inverse "The canonical isomorphism
+`G/(ker φ) ≃+ H` induced by a homomorphism `φ : G →+ H` with a right inverse `ψ : H →+ G`."]
+def quotient_ker_equiv_of_right_inverse (ψ : H → G) (hφ : function.right_inverse ψ φ) :
+  (quotient (ker φ)) ≃* H :=
+{ to_fun := ker_lift φ,
+  inv_fun := mk ∘ ψ,
+  left_inv := λ x, ker_lift_injective φ (by rw [function.comp_app, ker_lift_mk', hφ]),
+  right_inv := hφ,
+  .. ker_lift φ }
+
+/-- The canonical isomorphism `G/(ker φ) ≃* H` induced by a surjection `φ : G →* H`.
+
+For a `computable` version, see `quotient_ker_equiv_of_right_inverse`.
+-/
 @[to_additive quotient_add_group.quotient_ker_equiv_of_surjective "The canonical isomorphism
-`G/(ker φ) ≃+ H` induced by a surjection `φ : G →+ H`."]
+`G/(ker φ) ≃+ H` induced by a surjection `φ : G →+ H`.
+
+For a `computable` version, see `quotient_ker_equiv_of_right_inverse`."]
 noncomputable def quotient_ker_equiv_of_surjective (hφ : function.surjective φ) :
   (quotient (ker φ)) ≃* H :=
-mul_equiv.of_bijective (ker_lift φ) ⟨ker_lift_injective φ, λ h, begin
-  rcases hφ h with ⟨g, rfl⟩,
-  use mk g,
-  refl
-end⟩
+quotient_ker_equiv_of_right_inverse φ _ hφ.has_right_inverse.some_spec
 
 /-- If two normal subgroups `M` and `N` of `G` are the same, their quotient groups are
 isomorphic. -/

--- a/src/group_theory/quotient_group.lean
+++ b/src/group_theory/quotient_group.lean
@@ -230,9 +230,9 @@ noncomputable def quotient_ker_equiv_range : (quotient (ker φ)) ≃* range φ :
 mul_equiv.of_bijective (range_ker_lift φ) ⟨range_ker_lift_injective φ, range_ker_lift_surjective φ⟩
 
 /-- The canonical isomorphism `G/(ker φ) ≃* H` induced by a homomorphism `φ : G →* H`
-with a right inverse `ψ : H →* G`. -/
+with a right inverse `ψ : H → G`. -/
 @[to_additive quotient_add_group.quotient_ker_equiv_of_right_inverse "The canonical isomorphism
-`G/(ker φ) ≃+ H` induced by a homomorphism `φ : G →+ H` with a right inverse `ψ : H →+ G`.",
+`G/(ker φ) ≃+ H` induced by a homomorphism `φ : G →+ H` with a right inverse `ψ : H → G`.",
   simps]
 def quotient_ker_equiv_of_right_inverse (ψ : H → G) (hφ : function.right_inverse ψ φ) :
   (quotient (ker φ)) ≃* H :=


### PR DESCRIPTION
This PR defines a computable version of the first isomorphism theorem for groups and monoids that takes a right inverse of the map, `quotient_ker_equiv_of_right_inverse`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
