### PR TITLE
[Merged by Bors] - chore(topology/algebra/infinite_sum): small todo

### DIFF
--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -610,12 +610,9 @@ lemma set.finite.summable_compl_iff {s : set β} (hs : s.finite) :
 lemma has_sum_ite_eq_extract [decidable_eq β] (hf : has_sum f a) (b : β) :
   has_sum (λ n, ite (n = b) 0 (f n)) (a - f b) :=
 begin
-  convert has_sum_subtype_iff_indicator.mp (({b} : finset β).has_sum_iff_compl.mp hf),
-  { ext,
-    rw ← ite_not,
-    congr,
-    simp },
-  { exact sum_singleton.symm }
+  convert hf.update b 0 using 1,
+  { ext n, rw function.update_apply, },
+  { rw [sub_add_eq_add_sub, zero_add], },
 end
 
 section tsum

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -615,7 +615,7 @@ begin
     rw ← ite_not,
     congr,
     simp },
-  { simp }
+  { exact sum_singleton.symm }
 end
 
 section tsum
@@ -638,7 +638,7 @@ lemma tsum_ite_eq_extract [decidable_eq β] (hf : summable f) (b : β) :
   ∑' n, f n = f b + ∑' n, ite (n = b) 0 (f n) :=
 begin
   rw (has_sum_ite_eq_extract hf.has_sum b).tsum_eq,
-  abel,
+  exact (add_sub_cancel'_right _ _).symm,
 end
 
 end tsum

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -607,6 +607,17 @@ lemma set.finite.summable_compl_iff {s : set β} (hs : s.finite) :
   summable (f ∘ coe : sᶜ → α) ↔ summable f :=
 (hs.summable f).summable_compl_iff
 
+lemma has_sum_ite_eq_extract [decidable_eq β] (hf : has_sum f a) (b : β) :
+  has_sum (λ n, ite (n = b) 0 (f n)) (a - f b) :=
+begin
+  convert has_sum_subtype_iff_indicator.mp (({b} : finset β).has_sum_iff_compl.mp hf),
+  { ext,
+    rw ← ite_not,
+    congr,
+    simp },
+  { simp }
+end
+
 section tsum
 variables [t2_space α]
 
@@ -619,6 +630,16 @@ lemma tsum_sub (hf : summable f) (hg : summable g) : ∑'b, (f b - g b) = ∑'b,
 lemma sum_add_tsum_compl {s : finset β} (hf : summable f) :
   (∑ x in s, f x) + (∑' x : (↑s : set β)ᶜ, f x) = ∑' x, f x :=
 ((s.has_sum f).add_compl (s.summable_compl_iff.2 hf).has_sum).tsum_eq.symm
+
+/-- Let `f : β → α` be a sequence with summable series and let `b ∈ β` be an index.
+Lemma `tsum_ite_eq_extract` writes `Σ f n` as the sum of `f b` plus the series of the
+remaining terms. -/
+lemma tsum_ite_eq_extract [decidable_eq β] (hf : summable f) (b : β) :
+  ∑' n, f n = f b + ∑' n, ite (n = b) 0 (f n) :=
+begin
+  rw (has_sum_ite_eq_extract hf.has_sum b).tsum_eq,
+  abel,
+end
 
 end tsum
 
@@ -1029,20 +1050,6 @@ tsum_prod' h h.prod_factor
 lemma tsum_comm [regular_space α] {f : β → γ → α} (h : summable (function.uncurry f)) :
   ∑' c b, f b c = ∑' b c, f b c :=
 tsum_comm' h h.prod_factor h.prod_symm.prod_factor
-
-/-- Let `f : ℕ → ℝ` be a sequence with summable series and let `i ∈ ℕ` be an index.
-Lemma `tsum_ite_eq_extract` writes `Σ f n` as the sum of `f i` plus the series of the
-remaining terms.
-
-TODO: generalize this to `f : β → α` with appropriate typeclass assumptions
--/
-lemma tsum_ite_eq_extract {f : ℕ → ℝ} (hf : summable f) (i : ℕ) :
-  ∑' n, f n = f i + ∑' n, ite (n = i) 0 (f n) :=
-begin
-  refine ((tsum_congr _).trans $ tsum_add (hf.summable_of_eq_zero_or_self _) $
-    hf.summable_of_eq_zero_or_self _).trans (add_right_cancel_iff.mpr (tsum_ite_eq i (f i)));
-  exact λ j, by { by_cases ji : j = i; simp [ji] }
-end
 
 end uniform_group
 


### PR DESCRIPTION
Generalize a lemma from `f : ℕ → ℝ` to `f : β → α`, with 
```lean
[add_comm_group α] [topological_space α] [topological_add_group α] [t2_space α] [decidable_eq β] 
```
This was marked as TODO after #6017/#6096.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

@adomani, I assume this lemma is from the LTE.  I hope the application there will work without change after this generalization, can you check?