### PR TITLE
[Merged by Bors] - chore(data/int/basic): rationalize the arguments implicitness (mostly to_nat_sub_of_le)

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -171,7 +171,7 @@ theorem lt_add_one_iff {a b : ℤ} : a < b + 1 ↔ a ≤ b :=
 @[simp] lemma succ_coe_nat_pos (n : ℕ) : 0 < (n : ℤ) + 1 :=
 lt_add_one_iff.mpr (by simp)
 
-@[norm_cast] lemma coe_pred_of_pos (n : ℕ) (h : 0 < n) : ((n - 1 : ℕ) : ℤ) = (n : ℤ) - 1 :=
+@[norm_cast] lemma coe_pred_of_pos {n : ℕ} (h : 0 < n) : ((n - 1 : ℕ) : ℤ) = (n : ℤ) - 1 :=
 by { cases n, cases h, simp, }
 
 lemma le_add_one {a b : ℤ} (h : a ≤ b) : a ≤ b + 1 :=
@@ -188,13 +188,13 @@ le_sub_iff_add_le
   λ a0, (abs_eq_zero.mpr a0).le.trans_lt zero_lt_one⟩
 
 @[elab_as_eliminator] protected lemma induction_on {p : ℤ → Prop}
-  (i : ℤ) (hz : p 0) (hp : ∀i : ℕ, p i → p (i + 1)) (hn : ∀i : ℕ, p (-i) → p (-i - 1)) : p i :=
+  (i : ℤ) (hz : p 0) (hp : ∀ i : ℕ, p i → p (i + 1)) (hn : ∀ i : ℕ, p (-i) → p (-i - 1)) : p i :=
 begin
   induction i,
   { induction i,
     { exact hz },
     { exact hp _ i_ih } },
-  { have : ∀n:ℕ, p (- n),
+  { have : ∀ n:ℕ, p (- n),
     { intro n, induction n,
       { simp [hz] },
       { convert hn _ n_ih using 1, simp [sub_eq_neg_add] } },
@@ -599,7 +599,7 @@ local attribute [simp] -- Will be generalized to Euclidean domains.
 theorem mod_self {a : ℤ} : a % a = 0 :=
 by have := mul_mod_left 1 a; rwa one_mul at this
 
-@[simp] theorem mod_mod_of_dvd (n : int) {m k : int} (h : m ∣ k) : n % k % m = n % m :=
+@[simp] theorem mod_mod_of_dvd (n : ℤ) {m k : ℤ} (h : m ∣ k) : n % k % m = n % m :=
 begin
   conv { to_rhs, rw ←mod_add_div n k },
   rcases h with ⟨t, rfl⟩, rw [mul_assoc, add_mul_mod_self_left]
@@ -641,11 +641,11 @@ end,
   end
 end
 
-@[simp] theorem mul_div_mul_of_pos_left (a : ℤ) {b : ℤ} (c : ℤ) (H : 0 < b) :
+@[simp] theorem mul_div_mul_of_pos_left (a : ℤ) {b : ℤ} (H : 0 < b) (c : ℤ) :
   a * b / (c * b) = a / c :=
 by rw [mul_comm, mul_comm c, mul_div_mul_of_pos _ _ H]
 
-@[simp] theorem mul_mod_mul_of_pos {a : ℤ} (b c : ℤ) (H : 0 < a) : a * b % (a * c) = a * (b % c) :=
+@[simp] theorem mul_mod_mul_of_pos {a : ℤ} (H : 0 < a) (b c : ℤ) : a * b % (a * c) = a * (b % c) :=
 by rw [mod_def, mod_def, mul_div_mul_of_pos _ _ H, mul_sub_left_distrib, mul_assoc]
 
 theorem lt_div_add_one_mul_self (a : ℤ) {b : ℤ} (H : 0 < b) : a < (a / b + 1) * b :=
@@ -785,7 +785,7 @@ theorem neg_div_of_dvd : ∀ {a b : ℤ} (H : b ∣ a), -a / b = -(a / b)
 | ._ b ⟨c, rfl⟩ := if bz : b = 0 then by simp [bz] else
   by rw [neg_mul_eq_mul_neg, int.mul_div_cancel_left _ bz, int.mul_div_cancel_left _ bz]
 
-lemma sub_div_of_dvd {a b c : ℤ} (hcb : c ∣ b) : (a - b) / c = a / c - b / c :=
+lemma sub_div_of_dvd (a : ℤ) {b c : ℤ} (hcb : c ∣ b) : (a - b) / c = a / c - b / c :=
 begin
   rw [sub_eq_add_neg, sub_eq_add_neg, int.add_div_of_dvd_right ((dvd_neg c b).mpr hcb)],
   congr,
@@ -861,19 +861,19 @@ lemma dvd_nat_abs_of_of_nat_dvd {a : ℕ} : ∀ {z : ℤ} (haz : ↑a ∣ z), a 
   int.coe_nat_dvd.1 haz'
 
 lemma pow_dvd_of_le_of_pow_dvd {p m n : ℕ} {k : ℤ} (hmn : m ≤ n) (hdiv : ↑(p ^ n) ∣ k) :
-      ↑(p ^ m) ∣ k :=
+  ↑(p ^ m) ∣ k :=
 begin
   induction k,
-    { apply int.coe_nat_dvd.2,
-      apply pow_dvd_of_le_of_pow_dvd hmn,
-      apply int.coe_nat_dvd.1 hdiv },
-    { change -[1+k] with -(↑(k+1) : ℤ),
-      apply dvd_neg_of_dvd,
-      apply int.coe_nat_dvd.2,
-      apply pow_dvd_of_le_of_pow_dvd hmn,
-      apply int.coe_nat_dvd.1,
-      apply dvd_of_dvd_neg,
-      exact hdiv }
+  { apply int.coe_nat_dvd.2,
+    apply pow_dvd_of_le_of_pow_dvd hmn,
+    apply int.coe_nat_dvd.1 hdiv },
+  change -[1+k] with -(↑(k+1) : ℤ),
+  apply dvd_neg_of_dvd,
+  apply int.coe_nat_dvd.2,
+  apply pow_dvd_of_le_of_pow_dvd hmn,
+  apply int.coe_nat_dvd.1,
+  apply dvd_of_dvd_neg,
+  exact hdiv,
 end
 
 lemma dvd_of_pow_dvd {p k : ℕ} {m : ℤ} (hk : 1 ≤ k) (hpk : ↑(p^k) ∣ m) : ↑p ∣ m :=
@@ -950,7 +950,8 @@ by rw [← int.mul_div_assoc _ H2]; exact
 (int.div_eq_of_eq_mul_left H4 H5.symm).symm
 
 theorem eq_mul_div_of_mul_eq_mul_of_dvd_left {a b c d : ℤ} (hb : b ≠ 0) (hbc : b ∣ c)
-      (h : b * a = c * d) : a = c / b * d :=
+    (h : b * a = c * d) :
+  a = c / b * d :=
 begin
   cases hbc with k hk,
   subst hk,
@@ -979,23 +980,23 @@ lemma eq_of_mod_eq_of_nat_abs_sub_lt_nat_abs {a b c : ℤ} (h1 : a % b = c)
   a = c :=
 eq_of_sub_eq_zero (eq_zero_of_dvd_of_nat_abs_lt_nat_abs (dvd_sub_of_mod_eq h1) h2)
 
-theorem of_nat_add_neg_succ_of_nat_of_lt {m n : ℕ}
-  (h : m < n.succ) : of_nat m + -[1+n] = -[1+ n - m] :=
+theorem of_nat_add_neg_succ_of_nat_of_lt {m n : ℕ} (h : m < n.succ) :
+  of_nat m + -[1+n] = -[1+ n - m] :=
 begin
- change sub_nat_nat _ _ = _,
- have h' : n.succ - m = (n - m).succ,
- apply succ_sub,
- apply le_of_lt_succ h,
- simp [*, sub_nat_nat]
+  change sub_nat_nat _ _ = _,
+  have h' : n.succ - m = (n - m).succ,
+  apply succ_sub,
+  apply le_of_lt_succ h,
+  simp [*, sub_nat_nat]
 end
 
 theorem of_nat_add_neg_succ_of_nat_of_ge {m n : ℕ}
   (h : n.succ ≤ m) : of_nat m + -[1+n] = of_nat (m - n.succ) :=
 begin
- change sub_nat_nat _ _ = _,
- have h' : n.succ - m = 0,
- apply sub_eq_zero_of_le h,
- simp [*, sub_nat_nat]
+  change sub_nat_nat _ _ = _,
+  have h' : n.succ - m = 0,
+  apply sub_eq_zero_of_le h,
+  simp [*, sub_nat_nat]
 end
 
 @[simp] theorem neg_add_neg (m n : ℕ) : -[1+m] + -[1+n] = -[1+nat.succ(m+n)] := rfl
@@ -1013,7 +1014,7 @@ theorem to_nat_eq_max : ∀ (a : ℤ), (to_nat a : ℤ) = max a 0
 @[simp] theorem to_nat_of_nonneg {a : ℤ} (h : 0 ≤ a) : (to_nat a : ℤ) = a :=
 by rw [to_nat_eq_max, max_eq_left h]
 
-@[simp] lemma to_nat_sub_of_le (a b : ℤ) (h : b ≤ a) : (to_nat (a + -b) : ℤ) = a + - b :=
+@[simp] lemma to_nat_sub_of_le {a b : ℤ} (h : b ≤ a) : (to_nat (a - b) : ℤ) = a - b :=
 int.to_nat_of_nonneg (sub_nonneg_of_le h)
 
 @[simp] theorem to_nat_coe_nat (n : ℕ) : to_nat ↑n = n := rfl

--- a/src/data/int/modeq.lean
+++ b/src/data/int/modeq.lean
@@ -53,7 +53,7 @@ modeq_iff_dvd.2 $ dvd_trans d (modeq_iff_dvd.1 h)
 theorem modeq_mul_left' (hc : 0 ≤ c) (h : a ≡ b [ZMOD n]) : c * a ≡ c * b [ZMOD (c * n)] :=
 or.cases_on (lt_or_eq_of_le hc) (λ hc,
   by unfold modeq;
-  simp [mul_mod_mul_of_pos _ _ hc, (show _ = _, from h)] )
+  simp [mul_mod_mul_of_pos hc, (show _ = _, from h)] )
 (λ hc, by simp [hc.symm])
 
 theorem modeq_mul_right' (hc : 0 ≤ c) (h : a ≡ b [ZMOD n]) : a * c ≡ b * c [ZMOD (n * c)] :=


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
