### PR TITLE
[Merged by Bors] - chore(topology/continuous_function/algebra): delete old instances, use bundled sub[monoid, group, ring]s

### DIFF
--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -345,7 +345,7 @@ section subtype
 variables {α : Type*} [topological_space α]
 {R : Type*} [comm_semiring R]
 {A : Type*} [topological_space A] [semiring A]
-[algebra R A] [topological_semiring A] [topological_space R] [has_continuous_smul R A]
+[algebra R A] [topological_semiring A]
 
 /-- The `R`-subalgebra of continuous maps `α → A`. -/
 def continuous_subalgebra : subalgebra R (α → A) :=

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -71,32 +71,33 @@ the structure of a group.
 section subtype
 
 @[to_additive]
-instance continuous_submonoid (α : Type*) (β : Type*) [topological_space α] [topological_space β]
-  [monoid β] [has_continuous_mul β] : is_submonoid { f : α → β | continuous f } :=
-{ one_mem := @continuous_const _ _ _ _ 1,
-  mul_mem := λ f g fc gc, continuous.comp
-  has_continuous_mul.continuous_mul (continuous.prod_mk fc gc : _) }
+def continuous_submonoid (α : Type*) (β : Type*) [topological_space α] [topological_space β]
+  [monoid β] [has_continuous_mul β] : submonoid (α → β) :=
+{ carrier := { f : α → β | continuous f },
+  one_mem' := @continuous_const _ _ _ _ 1,
+  mul_mem' := λ f g fc gc, continuous.comp
+    has_continuous_mul.continuous_mul (continuous.prod_mk fc gc : _) }
 
 @[to_additive]
-instance continuous_subgroup (α : Type*) (β : Type*) [topological_space α] [topological_space β]
-  [group β] [topological_group β] : is_subgroup { f : α → β | continuous f } :=
-{ inv_mem := λ f fc, continuous.comp (@topological_group.continuous_inv β _ _ _) fc,
+def continuous_subgroup (α : Type*) (β : Type*) [topological_space α] [topological_space β]
+  [group β] [topological_group β] : subgroup (α → β) :=
+{ inv_mem' := λ f fc, continuous.comp (@topological_group.continuous_inv β _ _ _) fc,
   ..continuous_submonoid α β, }.
 
 @[to_additive]
 instance continuous_monoid {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [monoid β] [has_continuous_mul β] : monoid { f : α → β | continuous f } :=
-subtype.monoid
+(continuous_submonoid α β).to_monoid
 
 @[to_additive]
 instance continuous_group {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [group β] [topological_group β] : group { f : α → β | continuous f } :=
-subtype.group
+(continuous_subgroup α β).to_group
 
 @[to_additive]
 instance continuous_comm_group {α : Type*} {β : Type*} [topological_space α] [topological_space β]
   [comm_group β] [topological_group β] : comm_group { f : α → β | continuous f } :=
-@subtype.comm_group _ _ _ (continuous_subgroup α β) -- infer_instance doesn't work?!
+(continuous_subgroup α β).to_comm_group
 
 end subtype
 
@@ -218,18 +219,31 @@ the structure of a ring.
 
 section subtype
 
-instance continuous_subring (α : Type*) (R : Type*) [topological_space α] [topological_space R]
-  [ring R] [topological_ring R] : is_subring { f : α → R | continuous f } :=
-{ ..continuous_add_subgroup α R,
+def continuous_subsemiring (α : Type*) (R : Type*) [topological_space α] [topological_space R]
+  [semiring R] [topological_semiring R] : subsemiring (α → R) :=
+{ ..continuous_add_submonoid α R,
   ..continuous_submonoid α R }.
+
+instance continuous_semiring {α : Type*} {R : Type*} [topological_space α] [topological_space R]
+  [semiring R] [topological_semiring R] : semiring { f : α → R | continuous f } :=
+(continuous_subsemiring α R).to_semiring
+
+instance continuous_comm_semiring {α : Type*} {R : Type*} [topological_space α] [topological_space R]
+  [comm_semiring R] [topological_semiring R] : comm_semiring { f : α → R | continuous f } :=
+(continuous_subsemiring α R).to_comm_semiring
+
+def continuous_subring (α : Type*) (R : Type*) [topological_space α] [topological_space R]
+  [ring R] [topological_ring R] : subring (α → R) :=
+{ ..continuous_subsemiring α R,
+  ..continuous_add_subgroup α R }.
 
 instance continuous_ring {α : Type*} {R : Type*} [topological_space α] [topological_space R]
   [ring R] [topological_ring R] : ring { f : α → R | continuous f } :=
-@subtype.ring _ _ _ (continuous_subring α R) -- infer_instance doesn't work?!
+(continuous_subring α R).to_ring
 
 instance continuous_comm_ring {α : Type*} {R : Type*} [topological_space α] [topological_space R]
   [comm_ring R] [topological_ring R] : comm_ring { f : α → R | continuous f } :=
-@subtype.comm_ring _ _ _ (continuous_subring α R) -- infer_instance doesn't work?!
+(continuous_subring α R).to_comm_ring
 
 end subtype
 
@@ -280,9 +294,11 @@ topological semiring `R` inherit the structure of a module.
 
 section subtype
 
+section add_comm_monoid
+
 variables {α : Type*} [topological_space α]
 variables {R : Type*} [semiring R] [topological_space R]
-variables {M : Type*} [topological_space M] [add_comm_group M]
+variables {M : Type*} [topological_space M] [add_comm_monoid M]
 variables [module R M] [has_continuous_smul R M]
 
 instance continuous_has_scalar : has_scalar R { f : α → M | continuous f } :=
@@ -292,6 +308,15 @@ instance continuous_has_scalar : has_scalar R { f : α → M | continuous f } :=
 lemma continuous_functions.coe_smul (f : { f : α → M | continuous f }) (r : R) :
   ⇑(r • f) = r • f := rfl
 
+end add_comm_monoid
+
+section add_comm_group
+
+variables {α : Type*} [topological_space α]
+variables {R : Type*} [semiring R] [topological_space R]
+variables {M : Type*} [topological_space M] [add_comm_group M]
+variables [module R M] [has_continuous_smul R M]
+
 instance continuous_module [topological_add_group M] :
   module R { f : α → M | continuous f } :=
   module.of_core $
@@ -300,6 +325,8 @@ instance continuous_module [topological_add_group M] :
   add_smul := λ c₁ c₂ f, by ext x; exact add_smul c₁ c₂ (f x),
   mul_smul := λ c₁ c₂ f, by ext x; exact mul_smul c₁ c₂ (f x),
   one_smul := λ f, by ext x; exact one_smul R (f x) }
+
+end add_comm_group
 
 end subtype
 
@@ -365,8 +392,8 @@ section subtype
 
 variables {α : Type*} [topological_space α]
 {R : Type*} [comm_semiring R]
-{A : Type*} [topological_space A] [ring A]
-[algebra R A] [topological_ring A]
+{A : Type*} [topological_space A] [semiring A]
+[algebra R A] [topological_semiring A]
 
 /-- Continuous constant functions as a `ring_hom`. -/
 def continuous.C : R →+* { f : α → A | continuous f } :=
@@ -381,17 +408,7 @@ variables [topological_space R] [has_continuous_smul R A]
 instance : algebra R { f : α → A | continuous f } :=
 { to_ring_hom := continuous.C,
   commutes' := λ c f, by ext x; exact algebra.commutes' _ _,
-  smul_def' := λ c f, by ext x; exact algebra.smul_def' _ _,
-  ..continuous_module,
-  ..continuous_ring }
-
-/- TODO: We are assuming `A` to be a ring and not a semiring just because there is not yet an
-instance of semiring. In turn, we do not want to define yet an instance of semiring because there is
-no `is_subsemiring` but only `subsemiring`, and it will make sense to change this when the whole
-file will have no more `is_subobject`s but only `subobject`s. It does not make sense to change
-it yet in this direction as `subring` does not exist yet, so everything is being blocked by
-`subring`: afterwards everything will need to be updated to the new conventions of Mathlib.
-Then the instance of `topological_ring` can also be removed, as it is below for `continuous_map`. -/
+  smul_def' := λ c f, by ext x; exact algebra.smul_def' _ _, }
 
 end subtype
 

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -70,7 +70,8 @@ the structure of a group.
 
 section subtype
 
-@[to_additive]
+/-- The `submonoid` of continuous maps `α → β`. -/
+@[to_additive "The `add_submonoid` of continuous maps `α → β`. "]
 def continuous_submonoid (α : Type*) (β : Type*) [topological_space α] [topological_space β]
   [monoid β] [has_continuous_mul β] : submonoid (α → β) :=
 { carrier := { f : α → β | continuous f },
@@ -78,7 +79,8 @@ def continuous_submonoid (α : Type*) (β : Type*) [topological_space α] [topol
   mul_mem' := λ f g fc gc, continuous.comp
     has_continuous_mul.continuous_mul (continuous.prod_mk fc gc : _) }
 
-@[to_additive]
+/-- The subgroup of continuous maps `α → β`. -/
+@[to_additive "The `add_subgroup` of continuous maps `α → β`. "]
 def continuous_subgroup (α : Type*) (β : Type*) [topological_space α] [topological_space β]
   [group β] [topological_group β] : subgroup (α → β) :=
 { inv_mem' := λ f fc, continuous.comp (@topological_group.continuous_inv β _ _ _) fc,
@@ -219,6 +221,7 @@ the structure of a ring.
 
 section subtype
 
+/-- The subsemiring of continuous maps `α → β`. -/
 def continuous_subsemiring (α : Type*) (R : Type*) [topological_space α] [topological_space R]
   [semiring R] [topological_semiring R] : subsemiring (α → R) :=
 { ..continuous_add_submonoid α R,
@@ -233,6 +236,7 @@ instance continuous_comm_semiring {α : Type*} {R : Type*} [topological_space α
   comm_semiring { f : α → R | continuous f } :=
 (continuous_subsemiring α R).to_comm_semiring
 
+/-- The subring of continuous maps `α → β`. -/
 def continuous_subring (α : Type*) (R : Type*) [topological_space α] [topological_space R]
   [ring R] [topological_ring R] : subring (α → R) :=
 { ..continuous_subsemiring α R,

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -228,8 +228,9 @@ instance continuous_semiring {α : Type*} {R : Type*} [topological_space α] [to
   [semiring R] [topological_semiring R] : semiring { f : α → R | continuous f } :=
 (continuous_subsemiring α R).to_semiring
 
-instance continuous_comm_semiring {α : Type*} {R : Type*} [topological_space α] [topological_space R]
-  [comm_semiring R] [topological_semiring R] : comm_semiring { f : α → R | continuous f } :=
+instance continuous_comm_semiring {α : Type*} {R : Type*} [topological_space α]
+  [topological_space R] [comm_semiring R] [topological_semiring R] :
+  comm_semiring { f : α → R | continuous f } :=
 (continuous_subsemiring α R).to_comm_semiring
 
 def continuous_subring (α : Type*) (R : Type*) [topological_space α] [topological_space R]

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -11,12 +11,16 @@ import algebra.algebra.subalgebra
 # Algebraic structures over continuous functions
 
 In this file we define instances of algebraic structures over the type `continuous_map α β`
-(denoted `C(α, β)`) of **bundled** continuous maps from `α` to `β`. Note that we don't provide
-instances about `{ f : α → β | continuous f }` anymore, because `C(α, β)` should be used instead.
+(denoted `C(α, β)`) of **bundled** continuous maps from `α` to `β`. For example, `C(α, β)`
+is a group when `β` is a group, a ring when `β` is a ring, etc.
 
-However, we also define subobject of `α → β` with carrier `{ f : α → β | continuous f }` because
-we need a subset of `α → β` to define a subobject of it (see for example `continuous_subring`,
-`continuous_subalgebra`, ...).
+For each type of algebraic structure, we also define an appropriate subobject of `α → β`
+with carrier `{ f : α → β | continuous f }`. For example, when `β` is a group, a subgroup
+`continuous_subgroup α β` of `α → β` is constructed with carrier `{ f : α → β | continuous f }`.
+
+Note that, rather than using the derived algebraic structures on these subobjects
+(for example, when `β` is a group, the derived group structure on `continuous_subgroup α β`),
+one should use `C(α, β)` with the appropriate instance of the structure.
 -/
 
 local attribute [elab_simple] continuous.comp


### PR DESCRIPTION
We remove the `monoid`, `group`, ... instances on `{ f : α → β | continuous f }` since `C(α, β)` should be used instead, and we replacce the `sub[monoid, group, ...]` instances on `{ f : α → β | continuous f }` by definitions of bundled subobjects with carrier `{ f : α → β | continuous f }`. We keep the `set_of` for subobjects since we need a subset to be the carrier.

Zulip : https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/instances.20on.20continuous.20subtype

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Just had some time to spend

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
