### PR TITLE
[Merged by Bors] - feat(data/nat/prime): norm_num plugin for factors

### DIFF
--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -1434,8 +1434,11 @@ do x₁ ← to_expr x,
 /--
 Normalises numerical expressions. It supports the operations `+` `-` `*` `/` `^` and `%` over
 numerical types such as `ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ`, and can prove goals of the form `A = B`, `A ≠ B`,
-`A < B` and `A ≤ B`, where `A` and `B` are
-numerical expressions. It also has a relatively simple primality prover.
+`A < B` and `A ≤ B`, where `A` and `B` are numerical expressions.
+
+Add-on tactics marked as `@[norm_num]` can extend the behavior of `norm_num` to include other
+functions. This is used to support several other functions on `nat` like `prime`, `min_fac` and
+`factors`.
 ```lean
 import data.real.basic
 

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -77,6 +77,7 @@ end
 
 example : nat.prime 1277 := by norm_num
 example : nat.min_fac 221 = 13 := by norm_num
+example : nat.factors 221 = [13, 17] := by norm_num
 
 example (h : (5 : ℤ) ∣ 2) : false := by norm_num at h
 example (h : false) : false := by norm_num at h


### PR DESCRIPTION
Implements a `norm_num` plugin to evaluate terms like `nat.factors 231 = [3, 7, 11]`.