### PR TITLE
[Merged by Bors] - chore(data/complex/{module, is_R_or_C}, analysis/complex/basic): rationalize the structure provided for `conj` and `of_real`

### DIFF
--- a/src/algebra/quaternion.lean
+++ b/src/algebra/quaternion.lean
@@ -271,14 +271,14 @@ instance : star_ring ℍ[R, c₁, c₂] :=
 open opposite
 
 /-- Quaternion conjugate as an `alg_equiv` to the opposite ring. -/
-def conj_alg_equiv : ℍ[R, c₁, c₂] ≃ₐ[R] (ℍ[R, c₁, c₂]ᵒᵖ) :=
+def conj_ae : ℍ[R, c₁, c₂] ≃ₐ[R] (ℍ[R, c₁, c₂]ᵒᵖ) :=
 { to_fun := op ∘ conj,
   inv_fun := conj ∘ unop,
   map_mul' := λ x y, by simp,
   commutes' := λ r, by simp,
   .. conj.to_add_equiv.trans op_add_equiv }
 
-@[simp] lemma coe_conj_alg_equiv : ⇑(conj_alg_equiv : ℍ[R, c₁, c₂] ≃ₐ[R] _) = op ∘ conj := rfl
+@[simp] lemma coe_conj_ae : ⇑(conj_ae : ℍ[R, c₁, c₂] ≃ₐ[R] _) = op ∘ conj := rfl
 
 end quaternion_algebra
 
@@ -451,9 +451,9 @@ lemma mul_conj_eq_coe : a * conj a = (a * conj a).re := a.mul_conj_eq_coe
 open opposite
 
 /-- Quaternion conjugate as an `alg_equiv` to the opposite ring. -/
-def conj_alg_equiv : ℍ[R] ≃ₐ[R] (ℍ[R]ᵒᵖ) := quaternion_algebra.conj_alg_equiv
+def conj_ae : ℍ[R] ≃ₐ[R] (ℍ[R]ᵒᵖ) := quaternion_algebra.conj_ae
 
-@[simp] lemma coe_conj_alg_equiv : ⇑(conj_alg_equiv : ℍ[R] ≃ₐ[R] ℍ[R]ᵒᵖ) = op ∘ conj := rfl
+@[simp] lemma coe_conj_ae : ⇑(conj_ae : ℍ[R] ≃ₐ[R] ℍ[R]ᵒᵖ) = op ∘ conj := rfl
 
 /-- Square of the norm. -/
 def norm_sq : monoid_with_zero_hom ℍ[R] R :=

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -138,8 +138,6 @@ def of_real_clm : ℝ →L[ℝ] ℂ := of_real_li.to_continuous_linear_map
 
 @[simp] lemma of_real_clm_norm : ∥of_real_clm∥ = 1 := of_real_li.norm_to_continuous_linear_map
 
-@[simp] lemma of_real_clm_to_linear : of_real_clm.to_linear_map = of_real_lm.to_linear_map := rfl
-
 noncomputable instance : is_R_or_C ℂ :=
 { re := ⟨complex.re, complex.zero_re, complex.add_re⟩,
   im := ⟨complex.im, complex.zero_im, complex.add_im⟩,

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -104,9 +104,9 @@ calc 1 = ∥im_clm I∥ : by simp
    ... ≤ ∥im_clm∥ : unit_le_op_norm _ _ (by simp)
 
 /-- The complex-conjugation function from `ℂ` to itself is an isometric linear map. -/
-def conj_li : ℂ →ₗᵢ[ℝ] ℂ := ⟨conj_lm, λ x, by simp⟩
+def conj_li : ℂ →ₗᵢ[ℝ] ℂ := ⟨conj_alg_equiv.to_linear_map, λ x, by simp⟩
 
-@[simp] lemma conj_li_apply (z : ℂ) : conj_li z = conj_lm z := rfl
+@[simp] lemma conj_li_apply (z : ℂ) : conj_li z = conj z := rfl
 
 /-- Continuous linear map version of the conj function, from `ℂ` to `ℂ`. -/
 def conj_clm : ℂ →L[ℝ] ℂ := conj_li.to_continuous_linear_map
@@ -115,14 +115,14 @@ lemma isometry_conj : isometry (conj : ℂ → ℂ) := conj_li.isometry
 
 @[continuity] lemma continuous_conj : continuous conj := conj_clm.continuous
 
-@[simp] lemma conj_clm_coe : (coe (conj_clm) : ℂ →ₗ[ℝ] ℂ) = conj_lm := rfl
+@[simp] lemma conj_clm_coe : (coe (conj_clm) : ℂ →ₗ[ℝ] ℂ) = conj_alg_equiv.to_linear_map := rfl
 
 @[simp] lemma conj_clm_apply (z : ℂ) : (conj_clm : ℂ → ℂ) z = z.conj := rfl
 
 @[simp] lemma conj_clm_norm : ∥conj_clm∥ = 1 := conj_li.norm_to_continuous_linear_map
 
 /-- Linear isometry version of the canonical embedding of `ℝ` in `ℂ`. -/
-def of_real_li : ℝ →ₗᵢ[ℝ] ℂ := ⟨of_real_lm, λ x, by simp⟩
+def of_real_li : ℝ →ₗᵢ[ℝ] ℂ := ⟨of_real_lm.to_linear_map, λ x, by simp⟩
 
 /-- Continuous linear map version of the canonical embedding of `ℝ` in `ℂ`. -/
 def of_real_clm : ℝ →L[ℝ] ℂ := of_real_li.to_continuous_linear_map
@@ -131,11 +131,13 @@ lemma isometry_of_real : isometry (coe : ℝ → ℂ) := of_real_li.isometry
 
 @[continuity] lemma continuous_of_real : continuous (coe : ℝ → ℂ) := isometry_of_real.continuous
 
-@[simp] lemma of_real_clm_coe : (coe (of_real_clm) : ℝ →ₗ[ℝ] ℂ) = of_real_lm := rfl
+@[simp] lemma of_real_clm_coe : (coe (of_real_clm) : ℝ →ₗ[ℝ] ℂ) = of_real_lm.to_linear_map := rfl
 
 @[simp] lemma of_real_clm_apply (x : ℝ) : (of_real_clm : ℝ → ℂ) x = x := rfl
 
 @[simp] lemma of_real_clm_norm : ∥of_real_clm∥ = 1 := of_real_li.norm_to_continuous_linear_map
+
+@[simp] lemma of_real_clm_to_linear : of_real_clm.to_linear_map = of_real_lm.to_linear_map := rfl
 
 noncomputable instance : is_R_or_C ℂ :=
 { re := ⟨complex.re, complex.zero_re, complex.add_re⟩,

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -24,7 +24,7 @@ it defines functions:
 
 They are bundled versions of the real part, the imaginary part, the embedding of `ℝ` in `ℂ`, and
 the complex conjugate as continuous `ℝ`-linear maps. The last two are also bundled as linear
-isometries in `of_real_li` and `conj_li`.
+isometries in `of_real_li` and `conj_lie`.
 
 We also register the fact that `ℂ` is an `is_R_or_C` field.
 -/
@@ -104,23 +104,23 @@ calc 1 = ∥im_clm I∥ : by simp
    ... ≤ ∥im_clm∥ : unit_le_op_norm _ _ (by simp)
 
 /-- The complex-conjugation function from `ℂ` to itself is an isometric linear equivalence. -/
-def conj_li : ℂ ≃ₗᵢ[ℝ] ℂ := ⟨conj_ae.to_linear_equiv, abs_conj⟩
+def conj_lie : ℂ ≃ₗᵢ[ℝ] ℂ := ⟨conj_ae.to_linear_equiv, abs_conj⟩
 
-@[simp] lemma conj_li_apply (z : ℂ) : conj_li z = conj z := rfl
+@[simp] lemma conj_lie_apply (z : ℂ) : conj_lie z = conj z := rfl
 
-lemma isometry_conj : isometry (conj : ℂ → ℂ) := conj_li.isometry
+lemma isometry_conj : isometry (conj : ℂ → ℂ) := conj_lie.isometry
 
-@[continuity] lemma continuous_conj : continuous conj := conj_li.continuous
+@[continuity] lemma continuous_conj : continuous conj := conj_lie.continuous
 
 /-- Continuous linear equiv version of the conj function, from `ℂ` to `ℂ`. -/
-def conj_cle : ℂ ≃L[ℝ] ℂ := conj_li
+def conj_cle : ℂ ≃L[ℝ] ℂ := conj_lie
 
 @[simp] lemma conj_cle_coe : conj_cle.to_linear_equiv = conj_ae.to_linear_equiv := rfl
 
 @[simp] lemma conj_cle_apply (z : ℂ) : conj_cle z = z.conj := rfl
 
 @[simp] lemma conj_cle_norm : ∥(conj_cle : ℂ →L[ℝ] ℂ)∥ = 1 :=
-conj_li.to_linear_isometry.norm_to_continuous_linear_map
+conj_lie.to_linear_isometry.norm_to_continuous_linear_map
 
 /-- Linear isometry version of the canonical embedding of `ℝ` in `ℂ`. -/
 def of_real_li : ℝ →ₗᵢ[ℝ] ℂ := ⟨of_real_am.to_linear_map, norm_real⟩

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -20,7 +20,7 @@ it defines functions:
 * `re_clm`
 * `im_clm`
 * `of_real_clm`
-* `conj_clm`
+* `conj_cle`
 
 They are bundled versions of the real part, the imaginary part, the embedding of `ℝ` in `ℂ`, and
 the complex conjugate as continuous `ℝ`-linear maps. The last two are also bundled as linear
@@ -104,7 +104,7 @@ calc 1 = ∥im_clm I∥ : by simp
    ... ≤ ∥im_clm∥ : unit_le_op_norm _ _ (by simp)
 
 /-- The complex-conjugation function from `ℂ` to itself is an isometric linear equivalence. -/
-def conj_li : ℂ ≃ₗᵢ[ℝ] ℂ := ⟨conj_alg_equiv.to_linear_equiv, abs_conj⟩
+def conj_li : ℂ ≃ₗᵢ[ℝ] ℂ := ⟨conj_ae.to_linear_equiv, abs_conj⟩
 
 @[simp] lemma conj_li_apply (z : ℂ) : conj_li z = conj z := rfl
 
@@ -113,17 +113,17 @@ lemma isometry_conj : isometry (conj : ℂ → ℂ) := conj_li.isometry
 @[continuity] lemma continuous_conj : continuous conj := conj_li.continuous
 
 /-- Continuous linear equiv version of the conj function, from `ℂ` to `ℂ`. -/
-def conj_clm : ℂ ≃L[ℝ] ℂ := conj_li
+def conj_cle : ℂ ≃L[ℝ] ℂ := conj_li
 
-@[simp] lemma conj_clm_coe : conj_clm.to_linear_equiv = conj_alg_equiv.to_linear_equiv := rfl
+@[simp] lemma conj_cle_coe : conj_cle.to_linear_equiv = conj_ae.to_linear_equiv := rfl
 
-@[simp] lemma conj_clm_apply (z : ℂ) : conj_clm z = z.conj := rfl
+@[simp] lemma conj_cle_apply (z : ℂ) : conj_cle z = z.conj := rfl
 
-@[simp] lemma conj_clm_norm : ∥(conj_clm : ℂ →L[ℝ] ℂ)∥ = 1 :=
+@[simp] lemma conj_cle_norm : ∥(conj_cle : ℂ →L[ℝ] ℂ)∥ = 1 :=
 conj_li.to_linear_isometry.norm_to_continuous_linear_map
 
 /-- Linear isometry version of the canonical embedding of `ℝ` in `ℂ`. -/
-def of_real_li : ℝ →ₗᵢ[ℝ] ℂ := ⟨of_real_lm.to_linear_map, λ x, by simp⟩
+def of_real_li : ℝ →ₗᵢ[ℝ] ℂ := ⟨of_real_am.to_linear_map, norm_real⟩
 
 lemma isometry_of_real : isometry (coe : ℝ → ℂ) := of_real_li.isometry
 
@@ -132,7 +132,7 @@ lemma isometry_of_real : isometry (coe : ℝ → ℂ) := of_real_li.isometry
 /-- Continuous linear map version of the canonical embedding of `ℝ` in `ℂ`. -/
 def of_real_clm : ℝ →L[ℝ] ℂ := of_real_li.to_continuous_linear_map
 
-@[simp] lemma of_real_clm_coe : (of_real_clm : ℝ →ₗ[ℝ] ℂ) = of_real_lm.to_linear_map := rfl
+@[simp] lemma of_real_clm_coe : (of_real_clm : ℝ →ₗ[ℝ] ℂ) = of_real_am.to_linear_map := rfl
 
 @[simp] lemma of_real_clm_apply (x : ℝ) : of_real_clm x = x := rfl
 

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -103,37 +103,38 @@ le_antisymm (linear_map.mk_continuous_norm_le _ zero_le_one _) $
 calc 1 = ∥im_clm I∥ : by simp
    ... ≤ ∥im_clm∥ : unit_le_op_norm _ _ (by simp)
 
-/-- The complex-conjugation function from `ℂ` to itself is an isometric linear map. -/
-def conj_li : ℂ →ₗᵢ[ℝ] ℂ := ⟨conj_alg_equiv.to_linear_map, λ x, by simp⟩
+/-- The complex-conjugation function from `ℂ` to itself is an isometric linear equivalence. -/
+def conj_li : ℂ ≃ₗᵢ[ℝ] ℂ := ⟨conj_alg_equiv.to_linear_equiv, abs_conj⟩
 
 @[simp] lemma conj_li_apply (z : ℂ) : conj_li z = conj z := rfl
 
-/-- Continuous linear map version of the conj function, from `ℂ` to `ℂ`. -/
-def conj_clm : ℂ →L[ℝ] ℂ := conj_li.to_continuous_linear_map
-
 lemma isometry_conj : isometry (conj : ℂ → ℂ) := conj_li.isometry
 
-@[continuity] lemma continuous_conj : continuous conj := conj_clm.continuous
+@[continuity] lemma continuous_conj : continuous conj := conj_li.continuous
 
-@[simp] lemma conj_clm_coe : (coe (conj_clm) : ℂ →ₗ[ℝ] ℂ) = conj_alg_equiv.to_linear_map := rfl
+/-- Continuous linear equiv version of the conj function, from `ℂ` to `ℂ`. -/
+def conj_clm : ℂ ≃L[ℝ] ℂ := conj_li
 
-@[simp] lemma conj_clm_apply (z : ℂ) : (conj_clm : ℂ → ℂ) z = z.conj := rfl
+@[simp] lemma conj_clm_coe : conj_clm.to_linear_equiv = conj_alg_equiv.to_linear_equiv := rfl
 
-@[simp] lemma conj_clm_norm : ∥conj_clm∥ = 1 := conj_li.norm_to_continuous_linear_map
+@[simp] lemma conj_clm_apply (z : ℂ) : conj_clm z = z.conj := rfl
+
+@[simp] lemma conj_clm_norm : ∥(conj_clm : ℂ →L[ℝ] ℂ)∥ = 1 :=
+conj_li.to_linear_isometry.norm_to_continuous_linear_map
 
 /-- Linear isometry version of the canonical embedding of `ℝ` in `ℂ`. -/
 def of_real_li : ℝ →ₗᵢ[ℝ] ℂ := ⟨of_real_lm.to_linear_map, λ x, by simp⟩
 
+lemma isometry_of_real : isometry (coe : ℝ → ℂ) := of_real_li.isometry
+
+@[continuity] lemma continuous_of_real : continuous (coe : ℝ → ℂ) := of_real_li.continuous
+
 /-- Continuous linear map version of the canonical embedding of `ℝ` in `ℂ`. -/
 def of_real_clm : ℝ →L[ℝ] ℂ := of_real_li.to_continuous_linear_map
 
-lemma isometry_of_real : isometry (coe : ℝ → ℂ) := of_real_li.isometry
+@[simp] lemma of_real_clm_coe : (of_real_clm : ℝ →ₗ[ℝ] ℂ) = of_real_lm.to_linear_map := rfl
 
-@[continuity] lemma continuous_of_real : continuous (coe : ℝ → ℂ) := isometry_of_real.continuous
-
-@[simp] lemma of_real_clm_coe : (coe (of_real_clm) : ℝ →ₗ[ℝ] ℂ) = of_real_lm.to_linear_map := rfl
-
-@[simp] lemma of_real_clm_apply (x : ℝ) : (of_real_clm : ℝ → ℂ) x = x := rfl
+@[simp] lemma of_real_clm_apply (x : ℝ) : of_real_clm x = x := rfl
 
 @[simp] lemma of_real_clm_norm : ∥of_real_clm∥ = 1 := of_real_li.norm_to_continuous_linear_map
 

--- a/src/analysis/complex/circle.lean
+++ b/src/analysis/complex/circle.lean
@@ -81,7 +81,7 @@ instance : topological_group circle :=
 { continuous_mul := let h : continuous (λ x : circle, (x : ℂ)) := continuous_subtype_coe in
     continuous_induced_rng (continuous_mul.comp (h.prod_map h)),
   continuous_inv := continuous_induced_rng $
-    complex.conj_clm.continuous.comp continuous_subtype_coe }
+    complex.conj_cle.continuous.comp continuous_subtype_coe }
 
 /-- The map `λ t, exp (t * I)` from `ℝ` to the unit circle in `ℂ`. -/
 def exp_map_circle (t : ℝ) : circle :=

--- a/src/analysis/complex/isometry.lean
+++ b/src/analysis/complex/isometry.lean
@@ -96,7 +96,7 @@ begin
     { simp [h] },
     { simp only [matrix.head_cons, linear_isometry.coe_to_linear_map,
         linear_map.id_coe, id.def, matrix.cons_val_one], simpa } },
-  { suffices : f.to_linear_map = conj_li.to_linear_map,
+  { suffices : f.to_linear_map = conj_li.to_linear_equiv,
     { rw [←linear_isometry.coe_to_linear_map, this],
       simp only [linear_isometry.coe_to_linear_map], refl },
     apply basis.ext basis_one_I,

--- a/src/analysis/complex/isometry.lean
+++ b/src/analysis/complex/isometry.lean
@@ -96,7 +96,7 @@ begin
     { simp [h] },
     { simp only [matrix.head_cons, linear_isometry.coe_to_linear_map,
         linear_map.id_coe, id.def, matrix.cons_val_one], simpa } },
-  { suffices : f.to_linear_map = conj_li.to_linear_equiv,
+  { suffices : f.to_linear_map = conj_lie.to_linear_equiv,
     { rw [←linear_isometry.coe_to_linear_map, this],
       simp only [linear_isometry.coe_to_linear_map], refl },
     apply basis.ext basis_one_I,

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -1098,8 +1098,8 @@ def continuous_multilinear_map.uncurry_right
   continuous_multilinear_map 𝕜 Ei G :=
 let f' : multilinear_map 𝕜 (λ(i : fin n), Ei i.cast_succ) (Ei (last n) →ₗ[𝕜] G) :=
 { to_fun    := λ m, (f m).to_linear_map,
-  map_add'  := λ m i x y, by { simp, refl },
-  map_smul' := λ m i c x, by { simp, refl } } in
+  map_add'  := λ m i x y, by simp,
+  map_smul' := λ m i c x, by simp } in
 (@multilinear_map.uncurry_right 𝕜 n Ei G _ _ _ _ _ f').mk_continuous
   (∥f∥) (λm, f.norm_map_init_le m)
 

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -745,15 +745,13 @@ linear_map.mk_continuous im_lm 1 $ by
 
 @[continuity] lemma continuous_im : continuous (im : K → ℝ) := im_clm.continuous
 
-/-- Conjugate as an `ℝ`-algebra homomorphism -/
+/-- Conjugate as an `ℝ`-algebra equivalence -/
 noncomputable def conj_ae : K ≃ₐ[ℝ] K :=
 { inv_fun := conj,
   left_inv := conj_conj,
   right_inv := conj_conj,
   commutes' := conj_of_real,
   .. conj }
-
--- { to_fun := λ x, conj x, map_add' := by simp, map_smul' := conj_smul, }
 
 @[simp] lemma conj_ae_coe : (conj_ae : K → K) = conj := rfl
 
@@ -762,7 +760,7 @@ noncomputable def conj_li : K ≃ₗᵢ[ℝ] K := ⟨conj_ae.to_linear_equiv, λ
 
 @[simp] lemma conj_li_apply : (conj_li : K → K) = conj := rfl
 
-/-- Conjugate as a continuous linear map -/
+/-- Conjugate as a continuous linear equivalence -/
 noncomputable def conj_cle : K ≃L[ℝ] K := @conj_li K _
 
 @[simp] lemma conj_cle_coe : (@conj_cle K _).to_linear_equiv = conj_ae.to_linear_equiv := rfl

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -756,21 +756,21 @@ noncomputable def conj_ae : K ≃ₐ[ℝ] K :=
 @[simp] lemma conj_ae_coe : (conj_ae : K → K) = conj := rfl
 
 /-- Conjugate as a linear isometry -/
-noncomputable def conj_li : K ≃ₗᵢ[ℝ] K := ⟨conj_ae.to_linear_equiv, λ z, by simp [norm_eq_abs]⟩
+noncomputable def conj_lie : K ≃ₗᵢ[ℝ] K := ⟨conj_ae.to_linear_equiv, λ z, by simp [norm_eq_abs]⟩
 
-@[simp] lemma conj_li_apply : (conj_li : K → K) = conj := rfl
+@[simp] lemma conj_lie_apply : (conj_lie : K → K) = conj := rfl
 
 /-- Conjugate as a continuous linear equivalence -/
-noncomputable def conj_cle : K ≃L[ℝ] K := @conj_li K _
+noncomputable def conj_cle : K ≃L[ℝ] K := @conj_lie K _
 
 @[simp] lemma conj_cle_coe : (@conj_cle K _).to_linear_equiv = conj_ae.to_linear_equiv := rfl
 
 @[simp] lemma conj_cle_apply : (conj_cle : K → K) = conj := rfl
 
 @[simp] lemma conj_cle_norm : ∥(@conj_cle K _ : K →L[ℝ] K)∥ = 1 :=
-(@conj_li K _).to_linear_isometry.norm_to_continuous_linear_map
+(@conj_lie K _).to_linear_isometry.norm_to_continuous_linear_map
 
-@[continuity] lemma continuous_conj : continuous (conj : K → K) := conj_li.continuous
+@[continuity] lemma continuous_conj : continuous (conj : K → K) := conj_lie.continuous
 
 /-- The `ℝ → K` coercion, as a linear map -/
 noncomputable def of_real_am : ℝ →ₐ[ℝ] K := algebra.of_id ℝ K

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -745,46 +745,50 @@ linear_map.mk_continuous im_lm 1 $ by
 
 @[continuity] lemma continuous_im : continuous (im : K → ℝ) := im_clm.continuous
 
-/-- Conjugate as a linear map -/
-noncomputable def conj_lm : K →ₗ[ℝ] K :=
-{ to_fun := λ x, conj x, map_add' := by simp, map_smul' := conj_smul, }
+/-- Conjugate as an `ℝ`-algebra homomorphism -/
+noncomputable def conj_ae : K ≃ₐ[ℝ] K :=
+{ inv_fun := conj,
+  left_inv := conj_conj,
+  right_inv := conj_conj,
+  commutes' := conj_of_real,
+  .. conj }
 
-@[simp] lemma conj_lm_coe : (conj_lm : K → K) = conj := rfl
+-- { to_fun := λ x, conj x, map_add' := by simp, map_smul' := conj_smul, }
+
+@[simp] lemma conj_ae_coe : (conj_ae : K → K) = conj := rfl
 
 /-- Conjugate as a linear isometry -/
-noncomputable def conj_li : K →ₗᵢ[ℝ] K :=
-{ to_linear_map := conj_lm, norm_map' := by simp [norm_eq_abs] }
+noncomputable def conj_li : K ≃ₗᵢ[ℝ] K := ⟨conj_ae.to_linear_equiv, λ z, by simp [norm_eq_abs]⟩
 
 @[simp] lemma conj_li_apply : (conj_li : K → K) = conj := rfl
 
 /-- Conjugate as a continuous linear map -/
-noncomputable def conj_clm : K →L[ℝ] K := conj_li.to_continuous_linear_map
+noncomputable def conj_cle : K ≃L[ℝ] K := @conj_li K _
 
-@[simp] lemma conj_clm_coe : ((conj_clm  : K →L[ℝ] K) : K →ₗ[ℝ] K) = conj_lm := rfl
+@[simp] lemma conj_cle_coe : (@conj_cle K _).to_linear_equiv = conj_ae.to_linear_equiv := rfl
 
-@[simp] lemma conj_clm_apply : (conj_clm : K → K) = conj := rfl
+@[simp] lemma conj_cle_apply : (conj_cle : K → K) = conj := rfl
 
-@[simp] lemma conj_clm_norm : ∥(conj_clm : K →L[ℝ] K)∥ = 1 :=
-linear_isometry.norm_to_continuous_linear_map conj_li
+@[simp] lemma conj_cle_norm : ∥(@conj_cle K _ : K →L[ℝ] K)∥ = 1 :=
+(@conj_li K _).to_linear_isometry.norm_to_continuous_linear_map
 
 @[continuity] lemma continuous_conj : continuous (conj : K → K) := conj_li.continuous
 
 /-- The `ℝ → K` coercion, as a linear map -/
-noncomputable def of_real_lm : ℝ →ₗ[ℝ] K :=
-{ to_fun := λ x, (x : K), map_add' := by simp, map_smul' := by simp, }
+noncomputable def of_real_am : ℝ →ₐ[ℝ] K := algebra.of_id ℝ K
 
-@[simp] lemma of_real_lm_coe : (of_real_lm : ℝ → K) = coe := rfl
+@[simp] lemma of_real_am_coe : (of_real_am : ℝ → K) = coe := rfl
 
 /-- The ℝ → K coercion, as a linear isometry -/
 noncomputable def of_real_li : ℝ →ₗᵢ[ℝ] K :=
-{ to_linear_map := of_real_lm, norm_map' := by simp [norm_eq_abs] }
+{ to_linear_map := of_real_am.to_linear_map, norm_map' := by simp [norm_eq_abs] }
 
-@[simp] lemma of_real_li_apply : ((of_real_li : ℝ →ₗᵢ[ℝ] K) : ℝ → K) = coe := rfl
+@[simp] lemma of_real_li_apply : (of_real_li : ℝ → K) = coe := rfl
 
 /-- The `ℝ → K` coercion, as a continuous linear map -/
 noncomputable def of_real_clm : ℝ →L[ℝ] K := of_real_li.to_continuous_linear_map
 
-@[simp] lemma of_real_clm_coe : ((of_real_clm  : ℝ →L[ℝ] K) : ℝ →ₗ[ℝ] K) = of_real_lm := rfl
+@[simp] lemma of_real_clm_coe : ((@of_real_clm K _) : ℝ →ₗ[ℝ] K) = of_real_am.to_linear_map := rfl
 
 @[simp] lemma of_real_clm_apply : (of_real_clm : ℝ → K) = coe := rfl
 

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -26,7 +26,7 @@ part, the embedding of `ℝ` in `ℂ`, and the complex conjugate):
 
 * `complex.re_lm` (`ℝ`-linear map);
 * `complex.im_lm` (`ℝ`-linear map);
-* `complex.of_real_am` (`ℝ`-algebra homomorphism);
+* `complex.of_real_am` (`ℝ`-algebra (homo)morphism);
 * `complex.conj_ae` (`ℝ`-algebra equivalence).
 
 -/
@@ -193,7 +193,7 @@ def im_lm : ℂ →ₗ[ℝ] ℝ :=
 
 @[simp] lemma im_lm_coe : ⇑im_lm = im := rfl
 
-/-- `ℝ`-algebra homomorphism version of the canonical embedding of `ℝ` in `ℂ`. -/
+/-- `ℝ`-algebra morphism version of the canonical embedding of `ℝ` in `ℂ`. -/
 def of_real_am : ℝ →ₐ[ℝ] ℂ := algebra.of_id ℝ ℂ
 
 @[simp] lemma of_real_am_coe : ⇑of_real_am = coe := rfl

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -79,14 +79,6 @@ instance [comm_semiring R] [algebra R ℝ] : algebra R ℂ :=
   commutes' := λ r ⟨xr, xi⟩, by ext; simp [smul_re, smul_im, algebra.commutes],
   ..complex.of_real.comp (algebra_map R ℝ) }
 
-/-- Complex conjugation as an `ℝ`-algebra isomorphism  -/
-def conj_alg_equiv : ℂ ≃ₐ[ℝ] ℂ :=
-{ inv_fun := complex.conj,
-  left_inv := complex.conj_conj,
-  right_inv := complex.conj_conj,
-  commutes' := complex.conj_of_real,
-  .. complex.conj }
-
 section
 open_locale complex_order
 
@@ -202,19 +194,19 @@ def im_lm : ℂ →ₗ[ℝ] ℝ :=
 
 @[simp] lemma im_lm_coe : ⇑im_lm = im := rfl
 
-/-- Linear map version of the canonical embedding of `ℝ` in `ℂ`. -/
-def of_real_lm : ℝ →ₗ[ℝ] ℂ :=
-{ to_fun := coe,
-  map_add' := of_real_add,
-  map_smul' := λc x, by simp [algebra.smul_def] }
+/-- `ℝ`-algebra homomorphism version of the canonical embedding of `ℝ` in `ℂ`. -/
+def of_real_lm : ℝ →ₐ[ℝ] ℂ := algebra.of_id ℝ ℂ
 
 @[simp] lemma of_real_lm_coe : ⇑of_real_lm = coe := rfl
 
-/-- `ℝ`-linear map version of the complex conjugation function from `ℂ` to `ℂ`. -/
-def conj_lm : ℂ →ₗ[ℝ] ℂ :=
-{ map_smul' := by simp [restrict_scalars_smul_def],
-  ..conj }
+/-- `ℝ`-algebra isomorphism version of the complex conjugation function from `ℂ` to `ℂ` -/
+def conj_alg_equiv : ℂ ≃ₐ[ℝ] ℂ :=
+{ inv_fun := conj,
+  left_inv := conj_conj,
+  right_inv := conj_conj,
+  commutes' := conj_of_real,
+  .. conj }
 
-@[simp] lemma conj_lm_coe : ⇑conj_lm = conj := rfl
+@[simp] lemma conj_alg_equiv_coe : ⇑conj_alg_equiv = conj := rfl
 
 end complex

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -21,15 +21,14 @@ This file contains the following instances:
 * the space of `ℝ`-linear maps from a real vector space to a complex vector space is a complex
   vector space.
 
-It also defines three linear maps:
+It also defines bundled versions of four standard maps (respectively, the real part, the imaginary
+part, the embedding of `ℝ` in `ℂ`, and the complex conjugate):
 
-* `complex.re_lm`;
-* `complex.im_lm`;
-* `complex.of_real_lm`;
-* `complex.conj_lm`.
+* `complex.re_lm` (`ℝ`-linear map);
+* `complex.im_lm` (`ℝ`-linear map);
+* `complex.of_real_am` (`ℝ`-algebra homomorphism);
+* `complex.conj_ae` (`ℝ`-algebra equivalence).
 
-They are bundled versions of the real part, the imaginary part, the embedding of `ℝ` in `ℂ`, and
-the complex conjugate as `ℝ`-linear maps.
 -/
 noncomputable theory
 
@@ -195,18 +194,18 @@ def im_lm : ℂ →ₗ[ℝ] ℝ :=
 @[simp] lemma im_lm_coe : ⇑im_lm = im := rfl
 
 /-- `ℝ`-algebra homomorphism version of the canonical embedding of `ℝ` in `ℂ`. -/
-def of_real_lm : ℝ →ₐ[ℝ] ℂ := algebra.of_id ℝ ℂ
+def of_real_am : ℝ →ₐ[ℝ] ℂ := algebra.of_id ℝ ℂ
 
-@[simp] lemma of_real_lm_coe : ⇑of_real_lm = coe := rfl
+@[simp] lemma of_real_am_coe : ⇑of_real_am = coe := rfl
 
 /-- `ℝ`-algebra isomorphism version of the complex conjugation function from `ℂ` to `ℂ` -/
-def conj_alg_equiv : ℂ ≃ₐ[ℝ] ℂ :=
+def conj_ae : ℂ ≃ₐ[ℝ] ℂ :=
 { inv_fun := conj,
   left_inv := conj_conj,
   right_inv := conj_conj,
   commutes' := conj_of_real,
   .. conj }
 
-@[simp] lemma conj_alg_equiv_coe : ⇑conj_alg_equiv = conj := rfl
+@[simp] lemma conj_ae_coe : ⇑conj_ae = conj := rfl
 
 end complex

--- a/src/field_theory/polynomial_galois_group.lean
+++ b/src/field_theory/polynomial_galois_group.lean
@@ -351,7 +351,7 @@ local attribute [instance] splits_ℚ_ℂ
     the number of roots not fixed by complex conjugation (i.e. with some imaginary component). -/
 lemma card_complex_roots_eq_card_real_add_card_not_gal_inv (p : polynomial ℚ) :
   (p.root_set ℂ).to_finset.card = (p.root_set ℝ).to_finset.card +
-  (gal_action_hom p ℂ (restrict p ℂ (complex.conj_alg_equiv.restrict_scalars ℚ))).support.card :=
+  (gal_action_hom p ℂ (restrict p ℂ (complex.conj_ae.restrict_scalars ℚ))).support.card :=
 begin
   by_cases hp : p = 0,
   { simp_rw [hp, root_set_zero, set.to_finset_eq_empty_iff.mpr rfl, finset.card_empty, zero_add],
@@ -377,7 +377,7 @@ begin
       have key : is_scalar_tower.to_alg_hom ℚ ℝ ℂ z.re = z := by { ext, refl, rw hz2, refl },
       exact ⟨z.re, inj (by rwa [←aeval_alg_hom_apply, key, alg_hom.map_zero]), key⟩ } },
   have hc0 : ∀ w : p.root_set ℂ, gal_action_hom p ℂ
-    (restrict p ℂ (complex.conj_alg_equiv.restrict_scalars ℚ)) w = w ↔ w.val.im = 0,
+    (restrict p ℂ (complex.conj_ae.restrict_scalars ℚ)) w = w ↔ w.val.im = 0,
   { intro w,
     rw [subtype.ext_iff, gal_action_hom_restrict],
     exact complex.eq_conj_iff_im },
@@ -413,7 +413,7 @@ begin
     { exact nodup_roots ((separable_map (algebra_map ℚ ℂ)).mpr p_irr.separable) } },
   have h2 : fintype.card p.gal = fintype.card (gal_action_hom p ℂ).range :=
   fintype.card_congr (monoid_hom.of_injective (gal_action_hom_injective p ℂ)).to_equiv,
-  let conj := restrict p ℂ (complex.conj_alg_equiv.restrict_scalars ℚ),
+  let conj := restrict p ℂ (complex.conj_ae.restrict_scalars ℚ),
   refine ⟨gal_action_hom_injective p ℂ, λ x, (congr_arg (has_mem.mem x)
     (show (gal_action_hom p ℂ).range = ⊤, from _)).mpr (subgroup.mem_top x)⟩,
   apply equiv.perm.subgroup_eq_top_of_swap_mem,
@@ -436,10 +436,10 @@ lemma gal_action_hom_bijective_of_prime_degree'
 begin
   apply gal_action_hom_bijective_of_prime_degree p_irr p_deg,
   let n := (gal_action_hom p ℂ (restrict p ℂ
-    (complex.conj_alg_equiv.restrict_scalars ℚ))).support.card,
+    (complex.conj_ae.restrict_scalars ℚ))).support.card,
   have hn : 2 ∣ n :=
   equiv.perm.two_dvd_card_support (by rw [←monoid_hom.map_pow, ←monoid_hom.map_pow,
-    show alg_equiv.restrict_scalars ℚ complex.conj_alg_equiv ^ 2 = 1,
+    show alg_equiv.restrict_scalars ℚ complex.conj_ae ^ 2 = 1,
     from alg_equiv.ext complex.conj_conj, monoid_hom.map_one, monoid_hom.map_one]),
   have key := card_complex_roots_eq_card_real_add_card_not_gal_inv p,
   simp_rw [set.to_finset_card] at key,

--- a/src/geometry/manifold/instances/sphere.lean
+++ b/src/geometry/manifold/instances/sphere.lean
@@ -412,7 +412,7 @@ instance : lie_group (𝓡 1) circle :=
       exact ⟨continuous_mul, λ x y, (times_cont_diff_mul.restrict_scalars ℝ).times_cont_diff_on⟩ },
     exact (h₂.comp h₁).cod_restrict_sphere _,
   end,
-  smooth_inv := (complex.conj_clm.times_cont_diff.times_cont_mdiff.comp
+  smooth_inv := (complex.conj_cle.times_cont_diff.times_cont_mdiff.comp
     times_cont_mdiff_coe_sphere).cod_restrict_sphere _,
   .. metric.sphere.smooth_manifold_with_corners }
 

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -503,7 +503,7 @@ linear_isometry.integral_comp_comm (@is_R_or_C.of_real_li 𝕜 _) f
 
 lemma integral_conj {𝕜 : Type*} [is_R_or_C 𝕜] [measurable_space 𝕜] [borel_space 𝕜] {f : α → 𝕜} :
   ∫ a, is_R_or_C.conj (f a) ∂μ = is_R_or_C.conj ∫ a, f a ∂μ :=
-linear_isometry.integral_comp_comm (@is_R_or_C.conj_li 𝕜 _) f
+(@is_R_or_C.conj_li 𝕜 _).to_linear_isometry.integral_comp_comm f
 
 lemma fst_integral {f : α → E × F} (hf : integrable f μ) :
   (∫ x, f x ∂μ).1 = ∫ x, (f x).1 ∂μ :=

--- a/src/measure_theory/set_integral.lean
+++ b/src/measure_theory/set_integral.lean
@@ -503,7 +503,7 @@ linear_isometry.integral_comp_comm (@is_R_or_C.of_real_li 𝕜 _) f
 
 lemma integral_conj {𝕜 : Type*} [is_R_or_C 𝕜] [measurable_space 𝕜] [borel_space 𝕜] {f : α → 𝕜} :
   ∫ a, is_R_or_C.conj (f a) ∂μ = is_R_or_C.conj ∫ a, f a ∂μ :=
-(@is_R_or_C.conj_li 𝕜 _).to_linear_isometry.integral_comp_comm f
+(@is_R_or_C.conj_lie 𝕜 _).to_linear_isometry.integral_comp_comm f
 
 lemma fst_integral {f : α → E × F} (hf : integrable f μ) :
   (∫ x, f x ∂μ).1 = ∫ x, (f x).1 ∂μ :=

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -170,6 +170,9 @@ variables
 /-- Coerce continuous linear maps to linear maps. -/
 instance : has_coe (M →L[R] M₂) (M →ₗ[R] M₂) := ⟨to_linear_map⟩
 
+-- make the coercion the preferred form
+@[simp] lemma to_linear_map_eq_coe (f : M →L[R] M₂) : f.to_linear_map = f := rfl
+
 /-- Coerce continuous linear maps to functions. -/
 -- see Note [function coercion]
 instance to_fun : has_coe_to_fun $ M →L[R] M₂ := ⟨λ _, M → M₂, λ f, f⟩


### PR DESCRIPTION
We have many bundled versions of the four operations associated with the complex-real interaction (real & imaginary parts, real-to-complex coercion `of_real`, complex conjugation `conj`).

This PR adjusts the versions provided, according to the following principles:
- `conj` is always an equivalence, there is never a need for the map version
- Both `of_real` and `conj` are `ℝ`-algebra homomorphisms, and since this in typical applications requires no more imports than `ℝ`-linear maps, they can entirely supersede the `ℝ`-linear map versions.
- Name according to the base map name together with an acronym for the bundled map type, for example `conj_ae` for `conj` as an algebra-equivalence (this principle had been largely, but not entirely, followed previously).

The following specific changes result:
- `quaternion.conj_alg_equiv` renamed to `quaternion.conj_ae`, likewise for `quaternion_algebra.conj_alg_equiv`
- `complex.conj_li` upgraded from a map to an equivalence
- `complex.conj_clm` (continuous linear map) upgraded to `complex.conj_cle` (continuous linear equivalence)
- `complex.conj_alg_equiv` renamed to `complex.conj_ae`
- `complex.conj_lm` gone, use `complex.conj_ae` instead
- `complex.of_real_lm` (linear map) upgraded to `complex.of_real_am` (algebra homomorphism)
- all the same changes for `is_R_or_C.*` as for `complex.*`

Associated lemmas are also renamed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
