### PR TITLE
[Merged by Bors] - chore(logic/basic): actually fixup `eq_or_ne`

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -252,7 +252,7 @@ theorem or_not {p : Prop} : p ∨ ¬p := em _
 
 section eq_or_ne
 
-variables {α : Sort*} {x y : α}
+variables {α : Sort*} (x y : α)
 
 theorem decidable.eq_or_ne [decidable (x = y)] : x = y ∨ x ≠ y := dec_em $ x = y
 


### PR DESCRIPTION
this lemma loves being broken...



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
