### PR TITLE
[Merged by Bors] - feat(algebra/ordered_field): a few monotonicity results for powers

### DIFF
--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -660,14 +660,12 @@ lemma abs_inv (a : α) : abs a⁻¹ = (abs a)⁻¹ :=
 lemma one_div_strict_mono_decr_on : strict_mono_decr_on (λ x : α, 1 / x) (set.Ioi 0) :=
 λ x x1 y y1 xy, (one_div_lt_one_div (set.mem_Ioi.mp y1) (set.mem_Ioi.mp x1)).mpr xy
 
-lemma one_div_mono_exp (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
-  1 / a ^ n ≤ 1 / a ^ m :=
-by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
+lemma one_div_mono_exp (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
+λ m n mn, by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
   exact pow_pos (lt_of_lt_of_le zero_lt_one a1) _
 
-lemma one_div_pow_strict_mono (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
-  1 / a ^ n < 1 / a ^ m :=
-by refine one_div_strict_mono_decr_on _ _ (pow_lt_pow a1 mn);
+lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
+λ m n mn, by refine one_div_strict_mono_decr_on _ _ (pow_lt_pow a1 mn);
   exact pow_pos (zero_lt_one.trans a1) _
 
 end linear_ordered_field

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -656,7 +656,7 @@ by rw [abs_div, abs_one]
 lemma abs_inv (a : α) : abs a⁻¹ = (abs a)⁻¹ :=
 (abs_hom : monoid_with_zero_hom α α).map_inv' a
 
-lemma one_div_pow_strict_mono_decr_on : strict_mono_decr_on (λ x : α, 1 / x) (set.Ioi 0) :=
+lemma one_div_strict_mono_decr_on : strict_mono_decr_on (λ x : α, 1 / x) (set.Ioi 0) :=
 λ x x1 y y1 xy, (one_div_lt_one_div (set.mem_Ioi.mp y1) (set.mem_Ioi.mp x1)).mpr xy
 
 lemma one_div_mono_exp (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
@@ -666,7 +666,7 @@ by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
 
 lemma one_div_pow_strict_mono (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
   1 / a ^ n < 1 / a ^ m :=
-by refine one_div_pow_strict_mono_decr_on _ _ (pow_lt_pow a1 mn);
+by refine one_div_strict_mono_decr_on _ _ (pow_lt_pow a1 mn);
   exact pow_pos (zero_lt_one.trans a1) _
 
 end linear_ordered_field

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -656,6 +656,7 @@ by rw [abs_div, abs_one]
 lemma abs_inv (a : α) : abs a⁻¹ = (abs a)⁻¹ :=
 (abs_hom : monoid_with_zero_hom α α).map_inv' a
 
+-- TODO: add lemmas with `a⁻¹`.
 lemma one_div_strict_mono_decr_on : strict_mono_decr_on (λ x : α, 1 / x) (set.Ioi 0) :=
 λ x x1 y y1 xy, (one_div_lt_one_div (set.mem_Ioi.mp y1) (set.mem_Ioi.mp x1)).mpr xy
 

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -661,20 +661,20 @@ lemma abs_inv (a : α) : abs a⁻¹ = (abs a)⁻¹ :=
 lemma one_div_strict_mono_decr_on : strict_mono_decr_on (λ x : α, 1 / x) (set.Ioi 0) :=
 λ x x1 y y1 xy, (one_div_lt_one_div (set.mem_Ioi.mp y1) (set.mem_Ioi.mp x1)).mpr xy
 
-lemma one_div_pow_le_one_div_le_pow (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
+lemma one_div_pow_le_one_div_pow_of_le (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
   1 / a ^ n ≤ 1 / a ^ m :=
 by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
   exact pow_pos (lt_of_lt_of_le zero_lt_one a1) _
 
-lemma one_div_pow_lt_one_div_pow_lt (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
+lemma one_div_pow_lt_one_div_pow_of_lt (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
   1 / a ^ n < 1 / a ^ m :=
 by refine (one_div_lt_one_div _ _).mpr (pow_lt_pow a1 mn);
   exact pow_pos (trans zero_lt_one a1) _
 
-lemma one_div_pow_mono (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
+lemma one_div_pow_mono (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual (1 / a ^ n)) :=
 λ m n mn, one_div_pow_le_one_div_le_pow a1 mn
 
-lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
+lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual (1 / a ^ n)) :=
 λ m n mn, one_div_pow_lt_one_div_pow_lt a1 mn
 
 end linear_ordered_field

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -6,6 +6,7 @@ Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
 import algebra.ordered_ring
 import algebra.field
 import tactic.monotonicity.basic
+import algebra.group_power.order
 
 /-!
 # Linear ordered fields
@@ -654,5 +655,18 @@ by rw [abs_div, abs_one]
 
 lemma abs_inv (a : α) : abs a⁻¹ = (abs a)⁻¹ :=
 (abs_hom : monoid_with_zero_hom α α).map_inv' a
+
+lemma one_div_pow_strict_mono_decr_on : strict_mono_decr_on (λ x : α, 1 / x) (set.Ioi 0) :=
+λ x x1 y y1 xy, (one_div_lt_one_div (set.mem_Ioi.mp y1) (set.mem_Ioi.mp x1)).mpr xy
+
+lemma one_div_mono_exp (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
+  1 / a ^ n ≤ 1 / a ^ m :=
+by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
+  exact pow_pos (lt_of_lt_of_le zero_lt_one a1) _
+
+lemma one_div_pow_strict_mono (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
+  1 / a ^ n < 1 / a ^ m :=
+by refine one_div_pow_strict_mono_decr_on _ _ (pow_lt_pow a1 mn);
+  exact pow_pos (zero_lt_one.trans a1) _
 
 end linear_ordered_field

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -664,7 +664,7 @@ lemma one_div_strict_mono_decr_on : strict_mono_decr_on (λ x : α, 1 / x) (set.
 lemma one_div_pow_le_one_div_pow_of_le (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
   1 / a ^ n ≤ 1 / a ^ m :=
 by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
-  exact pow_pos (lt_of_lt_of_le zero_lt_one a1) _
+  exact pow_pos (zero_lt_one.trans_le a1) _
 
 lemma one_div_pow_lt_one_div_pow_of_lt (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
   1 / a ^ n < 1 / a ^ m :=
@@ -672,9 +672,9 @@ by refine (one_div_lt_one_div _ _).mpr (pow_lt_pow a1 mn);
   exact pow_pos (trans zero_lt_one a1) _
 
 lemma one_div_pow_mono (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
-λ m n mn, one_div_pow_le_one_div_pow_of_le a1 mn
+λ m n, one_div_pow_le_one_div_pow_of_le a1
 
 lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
-λ m n mn, one_div_pow_lt_one_div_pow_of_lt a1 mn
+λ m n, one_div_pow_lt_one_div_pow_of_lt a1
 
 end linear_ordered_field

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -661,7 +661,7 @@ lemma abs_inv (a : α) : abs a⁻¹ = (abs a)⁻¹ :=
 lemma one_div_strict_mono_decr_on : strict_mono_decr_on (λ x : α, 1 / x) (set.Ioi 0) :=
 λ x x1 y y1 xy, (one_div_lt_one_div (set.mem_Ioi.mp y1) (set.mem_Ioi.mp x1)).mpr xy
 
-lemma one_div_mono_exp (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
+lemma one_div_pow_mono (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
 λ m n mn, by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
   exact pow_pos (lt_of_lt_of_le zero_lt_one a1) _
 

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -7,6 +7,7 @@ import algebra.ordered_ring
 import algebra.field
 import tactic.monotonicity.basic
 import algebra.group_power.order
+import order.order_dual
 
 /-!
 # Linear ordered fields

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -661,9 +661,19 @@ lemma abs_inv (a : α) : abs a⁻¹ = (abs a)⁻¹ :=
 lemma one_div_strict_mono_decr_on : strict_mono_decr_on (λ x : α, 1 / x) (set.Ioi 0) :=
 λ x x1 y y1 xy, (one_div_lt_one_div (set.mem_Ioi.mp y1) (set.mem_Ioi.mp x1)).mpr xy
 
-lemma one_div_pow_mono (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
-λ m n mn, by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
+lemma one_div_mono_exp (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
+  1 / a ^ n ≤ 1 / a ^ m :=
+by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
   exact pow_pos (lt_of_lt_of_le zero_lt_one a1) _
+
+lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
+λ m n mn, by refine one_div_strict_mono_decr_on _ _ (pow_lt_pow a1 mn);
+  exact pow_pos (zero_lt_one.trans a1) _
+
+lemma one_div_pow_mono (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
+λ m n mn, by { apply one_div_mono_exp,
+  refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
+  exact pow_pos (lt_of_lt_of_le zero_lt_one a1) _}
 
 lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
 λ m n mn, by refine one_div_strict_mono_decr_on _ _ (pow_lt_pow a1 mn);

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -661,22 +661,20 @@ lemma abs_inv (a : α) : abs a⁻¹ = (abs a)⁻¹ :=
 lemma one_div_strict_mono_decr_on : strict_mono_decr_on (λ x : α, 1 / x) (set.Ioi 0) :=
 λ x x1 y y1 xy, (one_div_lt_one_div (set.mem_Ioi.mp y1) (set.mem_Ioi.mp x1)).mpr xy
 
-lemma one_div_mono_exp (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
+lemma one_div_pow_le_one_div_le_pow (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
   1 / a ^ n ≤ 1 / a ^ m :=
 by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
   exact pow_pos (lt_of_lt_of_le zero_lt_one a1) _
 
-lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
-λ m n mn, by refine one_div_strict_mono_decr_on _ _ (pow_lt_pow a1 mn);
-  exact pow_pos (zero_lt_one.trans a1) _
+lemma one_div_pow_lt_one_div_pow_lt (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
+  1 / a ^ n < 1 / a ^ m :=
+by refine (one_div_lt_one_div _ _).mpr (pow_lt_pow a1 mn);
+  exact pow_pos (trans zero_lt_one a1) _
 
 lemma one_div_pow_mono (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
-λ m n mn, by { apply one_div_mono_exp,
-  refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
-  exact pow_pos (lt_of_lt_of_le zero_lt_one a1) _}
+λ m n mn, one_div_pow_le_one_div_le_pow a1 mn
 
 lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
-λ m n mn, by refine one_div_strict_mono_decr_on _ _ (pow_lt_pow a1 mn);
-  exact pow_pos (zero_lt_one.trans a1) _
+λ m n mn, one_div_pow_lt_one_div_pow_lt a1 mn
 
 end linear_ordered_field

--- a/src/algebra/ordered_field.lean
+++ b/src/algebra/ordered_field.lean
@@ -671,10 +671,10 @@ lemma one_div_pow_lt_one_div_pow_of_lt (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
 by refine (one_div_lt_one_div _ _).mpr (pow_lt_pow a1 mn);
   exact pow_pos (trans zero_lt_one a1) _
 
-lemma one_div_pow_mono (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual (1 / a ^ n)) :=
-λ m n mn, one_div_pow_le_one_div_le_pow a1 mn
+lemma one_div_pow_mono (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
+λ m n mn, one_div_pow_le_one_div_pow_of_le a1 mn
 
-lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual (1 / a ^ n)) :=
-λ m n mn, one_div_pow_lt_one_div_pow_lt a1 mn
+lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
+λ m n mn, one_div_pow_lt_one_div_pow_of_lt a1 mn
 
 end linear_ordered_field


### PR DESCRIPTION
This PR proves the monotonicity (strict and non-strict) of `n → 1 / a ^ n`, for a fixed `a < 1` in a linearly ordered field.  These are lemmas extracted from PR #8001: I moved them to a separate PR after the discussion there.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
