### PR TITLE
[Merged by Bors] - feat(analysis/specific_limits): summability of `(λ i, 1 / m ^ f i)`

### DIFF
--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -846,7 +846,7 @@ begin
 end
 
 /-- A series whose terms are bounded by the terms of a converging geometric series converges. -/
-lemma summable_inv_pow_ge {m : ℝ} {f : ℕ → ℕ} (hm : 1 < m) (fi : ∀ i, i ≤ f i) :
+lemma summable_one_div_pow_of_le {m : ℝ} {f : ℕ → ℕ} (hm : 1 < m) (fi : ∀ i, i ≤ f i) :
   summable (λ i, 1 / m ^ f i) :=
 begin
   refine summable_of_nonneg_of_le

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -845,6 +845,19 @@ begin
   rwa ← le_div_iff (lt_of_le_of_ne (norm_nonneg _) h₁.symm)
 end
 
+/-- A series whose terms are bounded by the terms of a converging geometric series convergences. -/
+lemma summable_inv_pow_ge {m : ℝ} {f : ℕ → ℕ} (hm : 1 < m) (fi : ∀ i, i ≤ f i) :
+  summable (λ i, 1 / m ^ f i) :=
+begin
+  refine summable_of_nonneg_of_le
+    (λ a, one_div_nonneg.mpr (pow_nonneg (zero_le_one.trans hm.le) _)) (λ a, _)
+    (summable_geometric_of_lt_1 (one_div_nonneg.mpr (zero_le_one.trans hm.le))
+      ((one_div_lt (zero_lt_one.trans hm) zero_lt_one).mpr (one_div_one.le.trans_lt hm))),
+  rw [div_pow, one_pow],
+  refine (one_div_le_one_div _ _).mpr (pow_le_pow hm.le (fi a));
+  exact pow_pos (zero_lt_one.trans hm) _
+end
+
 /-! ### Positive sequences with small sums on encodable types -/
 
 /-- For any positive `ε`, define on an encodable type a positive sequence with sum less than `ε` -/

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -845,7 +845,7 @@ begin
   rwa ← le_div_iff (lt_of_le_of_ne (norm_nonneg _) h₁.symm)
 end
 
-/-- A series whose terms are bounded by the terms of a converging geometric series convergences. -/
+/-- A series whose terms are bounded by the terms of a converging geometric series converges. -/
 lemma summable_inv_pow_ge {m : ℝ} {f : ℕ → ℕ} (hm : 1 < m) (fi : ∀ i, i ≤ f i) :
   summable (λ i, 1 / m ^ f i) :=
 begin


### PR DESCRIPTION
This PR shows the summability of the series whose `i`th term is `1 / m ^ f i`, where `1 < m` is a fixed real number and `f : ℕ → ℕ` is a function bounded below by the identity function.  While a function eventually bounded below by a constant at least equal to 2 would have been enough, this specific shape is convenient for the Liouville application.

I extracted this lemma, following the discussion in PR #8001.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
