### PR TITLE
[Merged by Bors] - feat(data/int/gcd): norm_num extension for gcd

### DIFF
--- a/src/data/int/gcd.lean
+++ b/src/data/int/gcd.lean
@@ -126,6 +126,8 @@ end nat
 /-! ### Divisibility over ℤ -/
 namespace int
 
+protected lemma coe_nat_gcd (m n : ℕ) : int.gcd ↑m ↑n = nat.gcd m n := rfl
+
 /-- The extended GCD `a` value in the equation `gcd x y = x * a + y * b`. -/
 def gcd_a : ℤ → ℤ → ℤ
 | (of_nat m) n := m.gcd_a n.nat_abs
@@ -189,6 +191,8 @@ end
 def lcm (i j : ℤ) : ℕ := nat.lcm (nat_abs i) (nat_abs j)
 
 theorem lcm_def (i j : ℤ) : lcm i j = nat.lcm (nat_abs i) (nat_abs j) := rfl
+
+protected lemma coe_nat_lcm (m n : ℕ) : int.lcm ↑m ↑n = nat.lcm m n := rfl
 
 theorem gcd_dvd_left (i j : ℤ) : (gcd i j : ℤ) ∣ i :=
 dvd_nat_abs.mp $ coe_nat_dvd.mpr $ nat.gcd_dvd_left _ _
@@ -359,3 +363,235 @@ begin
   rw [of_add_nsmul, of_add_zero, pow_gcd_eq_one];
   rwa [←of_add_nsmul, ←of_add_zero, equiv.apply_eq_iff_eq]
 end
+
+/-! ### GCD prover -/
+
+namespace tactic
+namespace norm_num
+open norm_num
+
+lemma int_gcd_helper' {d : ℕ} {x y a b : ℤ} (h₁ : (d:ℤ) ∣ x) (h₂ : (d:ℤ) ∣ y)
+  (h₃ : x * a + y * b = d) : int.gcd x y = d :=
+begin
+  refine nat.dvd_antisymm _ (int.coe_nat_dvd.1 (int.dvd_gcd h₁ h₂)),
+  rw [← int.coe_nat_dvd, ← h₃],
+  apply dvd_add,
+  { exact dvd_mul_of_dvd_left (int.gcd_dvd_left _ _) _ },
+  { exact dvd_mul_of_dvd_left (int.gcd_dvd_right _ _) _ }
+end
+
+lemma nat_gcd_helper_dvd_left (x y a : ℕ) (h : x * a = y) : nat.gcd x y = x :=
+nat.gcd_eq_left ⟨a, h.symm⟩
+
+lemma nat_gcd_helper_dvd_right (x y a : ℕ) (h : y * a = x) : nat.gcd x y = y :=
+nat.gcd_eq_right ⟨a, h.symm⟩
+
+lemma nat_gcd_helper_2 (d x y a b u v tx ty : ℕ) (hu : d * u = x) (hv : d * v = y)
+  (hx : x * a = tx) (hy : y * b = ty) (h : ty + d = tx) : nat.gcd x y = d :=
+begin
+  rw ← int.coe_nat_gcd, apply @int_gcd_helper' _ _ _ a (-b)
+    (int.coe_nat_dvd.2 ⟨_, hu.symm⟩) (int.coe_nat_dvd.2 ⟨_, hv.symm⟩),
+  rw [mul_neg_eq_neg_mul_symm, ← sub_eq_add_neg, sub_eq_iff_eq_add'],
+  norm_cast, rw [hx, hy, h]
+end
+
+lemma nat_gcd_helper_1 (d x y a b u v tx ty : ℕ) (hu : d * u = x) (hv : d * v = y)
+  (hx : x * a = tx) (hy : y * b = ty) (h : tx + d = ty) : nat.gcd x y = d :=
+(nat.gcd_comm _ _).trans $ nat_gcd_helper_2 _ _ _ _ _ _ _ _ _ hv hu hy hx h
+
+lemma nat_lcm_helper (x y d m n : ℕ) (hd : nat.gcd x y = d) (d0 : 0 < d)
+  (xy : x * y = n) (dm : d * m = n) : nat.lcm x y = m :=
+(nat.mul_right_inj d0).1 $ by rw [dm, ← xy, ← hd, nat.gcd_mul_lcm]
+
+lemma nat_coprime_helper_zero_left (x : ℕ) (h : 1 < x) : ¬ nat.coprime 0 x :=
+mt (nat.coprime_zero_left _).1 $ ne_of_gt h
+
+lemma nat_coprime_helper_zero_right (x : ℕ) (h : 1 < x) : ¬ nat.coprime x 0 :=
+mt (nat.coprime_zero_right _).1 $ ne_of_gt h
+
+lemma nat_coprime_helper_1 (x y a b tx ty : ℕ)
+  (hx : x * a = tx) (hy : y * b = ty) (h : tx + 1 = ty) : nat.coprime x y :=
+nat_gcd_helper_1 _ _ _ _ _ _ _ _ _ (one_mul _) (one_mul _) hx hy h
+
+lemma nat_coprime_helper_2 (x y a b tx ty : ℕ)
+  (hx : x * a = tx) (hy : y * b = ty) (h : ty + 1 = tx) : nat.coprime x y :=
+nat_gcd_helper_2 _ _ _ _ _ _ _ _ _ (one_mul _) (one_mul _) hx hy h
+
+lemma nat_not_coprime_helper (d x y u v : ℕ) (hu : d * u = x) (hv : d * v = y)
+  (h : 1 < d) : ¬ nat.coprime x y :=
+nat.not_coprime_of_dvd_of_dvd h ⟨_, hu.symm⟩ ⟨_, hv.symm⟩
+
+lemma int_gcd_helper (x y : ℤ) (nx ny d : ℕ) (hx : (nx:ℤ) = x) (hy : (ny:ℤ) = y)
+  (h : nat.gcd nx ny = d) : int.gcd x y = d :=
+by rwa [← hx, ← hy, int.coe_nat_gcd]
+
+lemma int_gcd_helper_neg_left (x y : ℤ) (d : ℕ) (h : int.gcd x y = d) : int.gcd (-x) y = d :=
+by rw int.gcd at h ⊢; rwa int.nat_abs_neg
+
+lemma int_gcd_helper_neg_right (x y : ℤ) (d : ℕ) (h : int.gcd x y = d) : int.gcd x (-y) = d :=
+by rw int.gcd at h ⊢; rwa int.nat_abs_neg
+
+lemma int_lcm_helper (x y : ℤ) (nx ny d : ℕ) (hx : (nx:ℤ) = x) (hy : (ny:ℤ) = y)
+  (h : nat.lcm nx ny = d) : int.lcm x y = d :=
+by rwa [← hx, ← hy, int.coe_nat_lcm]
+
+lemma int_lcm_helper_neg_left (x y : ℤ) (d : ℕ) (h : int.lcm x y = d) : int.lcm (-x) y = d :=
+by rw int.lcm at h ⊢; rwa int.nat_abs_neg
+
+lemma int_lcm_helper_neg_right (x y : ℤ) (d : ℕ) (h : int.lcm x y = d) : int.lcm x (-y) = d :=
+by rw int.lcm at h ⊢; rwa int.nat_abs_neg
+
+/-- Evaluates the `nat.gcd` function. -/
+meta def prove_gcd_nat (c : instance_cache) (ex ey : expr) :
+  tactic (instance_cache × expr × expr) := do
+  x ← ex.to_nat,
+  y ← ey.to_nat,
+  match x, y with
+  | 0, _ := pure (c, ey, `(nat.gcd_zero_left).mk_app [ey])
+  | _, 0 := pure (c, ex, `(nat.gcd_zero_right).mk_app [ex])
+  | 1, _ := pure (c, `(1:ℕ), `(nat.gcd_one_left).mk_app [ey])
+  | _, 1 := pure (c, `(1:ℕ), `(nat.gcd_one_right).mk_app [ex])
+  | _, _ := do
+    let (d, a, b) := nat.xgcd_aux x 1 0 y 0 1,
+    if d = x then do
+      (c, ea) ← c.of_nat (y / x),
+      (c, _, p) ← prove_mul_nat c ex ea,
+      pure (c, ex, `(nat_gcd_helper_dvd_left).mk_app [ex, ey, ea, p])
+    else if d = y then do
+      (c, ea) ← c.of_nat (x / y),
+      (c, _, p) ← prove_mul_nat c ey ea,
+      pure (c, ey, `(nat_gcd_helper_dvd_right).mk_app [ex, ey, ea, p])
+    else do
+      (c, ed) ← c.of_nat d,
+      (c, ea) ← c.of_nat a.nat_abs,
+      (c, eb) ← c.of_nat b.nat_abs,
+      (c, eu) ← c.of_nat (x / d),
+      (c, ev) ← c.of_nat (y / d),
+      (c, _, pu) ← prove_mul_nat c ed eu,
+      (c, _, pv) ← prove_mul_nat c ed ev,
+      (c, etx, px) ← prove_mul_nat c ex ea,
+      (c, ety, py) ← prove_mul_nat c ey eb,
+      (c, p) ← if a ≥ 0 then prove_add_nat c ety ed etx else prove_add_nat c etx ed ety,
+      let pf : expr := if a ≥ 0 then `(nat_gcd_helper_2) else `(nat_gcd_helper_1),
+      pure (c, ed, pf.mk_app [ed, ex, ey, ea, eb, eu, ev, etx, ety, pu, pv, px, py, p])
+  end
+
+/-- Evaluates the `nat.lcm` function. -/
+meta def prove_lcm_nat (c : instance_cache) (ex ey : expr) :
+  tactic (instance_cache × expr × expr) := do
+  x ← ex.to_nat,
+  y ← ey.to_nat,
+  match x, y with
+  | 0, _ := pure (c, `(0:ℕ), `(nat.lcm_zero_left).mk_app [ey])
+  | _, 0 := pure (c, `(0:ℕ), `(nat.lcm_zero_right).mk_app [ex])
+  | 1, _ := pure (c, ey, `(nat.lcm_one_left).mk_app [ey])
+  | _, 1 := pure (c, ex, `(nat.lcm_one_right).mk_app [ex])
+  | _, _ := do
+    (c, ed, pd) ← prove_gcd_nat c ex ey,
+    (c, p0) ← prove_pos c ed,
+    (c, en, xy) ← prove_mul_nat c ex ey,
+    d ← ed.to_nat,
+    (c, em) ← c.of_nat ((x * y) / d),
+    (c, _, dm) ← prove_mul_nat c ed em,
+    pure (c, em, `(nat_lcm_helper).mk_app [ex, ey, ed, em, en, pd, p0, xy, dm])
+  end
+
+/-- Evaluates the `int.gcd` function. -/
+meta def prove_gcd_int (zc nc : instance_cache) : expr → expr →
+  tactic (instance_cache × instance_cache × expr × expr)
+| x y := match match_neg x with
+  | some x := do
+    (zc, nc, d, p) ← prove_gcd_int x y,
+    pure (zc, nc, d, `(int_gcd_helper_neg_left).mk_app [x, y, d, p])
+  | none := match match_neg y with
+    | some y := do
+      (zc, nc, d, p) ← prove_gcd_int x y,
+      pure (zc, nc, d, `(int_gcd_helper_neg_right).mk_app [x, y, d, p])
+    | none := do
+      (zc, nc, nx, px) ← prove_nat_uncast zc nc x,
+      (zc, nc, ny, py) ← prove_nat_uncast zc nc y,
+      (nc, d, p) ← prove_gcd_nat nc nx ny,
+      pure (zc, nc, d, `(int_gcd_helper).mk_app [x, y, nx, ny, d, px, py, p])
+    end
+  end
+
+/-- Evaluates the `int.lcm` function. -/
+meta def prove_lcm_int (zc nc : instance_cache) : expr → expr →
+  tactic (instance_cache × instance_cache × expr × expr)
+| x y := match match_neg x with
+  | some x := do
+    (zc, nc, d, p) ← prove_lcm_int x y,
+    pure (zc, nc, d, `(int_lcm_helper_neg_left).mk_app [x, y, d, p])
+  | none := match match_neg y with
+    | some y := do
+      (zc, nc, d, p) ← prove_lcm_int x y,
+      pure (zc, nc, d, `(int_lcm_helper_neg_right).mk_app [x, y, d, p])
+    | none := do
+      (zc, nc, nx, px) ← prove_nat_uncast zc nc x,
+      (zc, nc, ny, py) ← prove_nat_uncast zc nc y,
+      (nc, d, p) ← prove_lcm_nat nc nx ny,
+      pure (zc, nc, d, `(int_lcm_helper).mk_app [x, y, nx, ny, d, px, py, p])
+    end
+  end
+
+/-- Evaluates the `nat.coprime` function. -/
+meta def prove_coprime_nat (c : instance_cache) (ex ey : expr) :
+  tactic (instance_cache × (expr ⊕ expr)) := do
+  x ← ex.to_nat,
+  y ← ey.to_nat,
+  match x, y with
+  | 1, _ := pure (c, sum.inl $ `(nat.coprime_one_left).mk_app [ey])
+  | _, 1 := pure (c, sum.inl $ `(nat.coprime_one_right).mk_app [ex])
+  | 0, 0 := pure (c, sum.inr `(nat.not_coprime_zero_zero))
+  | 0, _ := do
+    c ← mk_instance_cache `(ℕ),
+    (c, p) ← prove_lt_nat c `(1) ey,
+    pure (c, sum.inr $ `(nat_coprime_helper_zero_left).mk_app [ey, p])
+  | _, 0 := do
+    c ← mk_instance_cache `(ℕ),
+    (c, p) ← prove_lt_nat c `(1) ex,
+    pure (c, sum.inr $ `(nat_coprime_helper_zero_right).mk_app [ex, p])
+  | _, _ := do
+    c ← mk_instance_cache `(ℕ),
+    let (d, a, b) := nat.xgcd_aux x 1 0 y 0 1,
+    if d = 1 then do
+      (c, ea) ← c.of_nat a.nat_abs,
+      (c, eb) ← c.of_nat b.nat_abs,
+      (c, etx, px) ← prove_mul_nat c ex ea,
+      (c, ety, py) ← prove_mul_nat c ey eb,
+      (c, p) ← if a ≥ 0 then prove_add_nat c ety `(1) etx else prove_add_nat c etx `(1) ety,
+      let pf : expr := if a ≥ 0 then `(nat_coprime_helper_2) else `(nat_coprime_helper_1),
+      pure (c, sum.inl $ pf.mk_app [ex, ey, ea, eb, etx, ety, px, py, p])
+    else do
+      (c, ed) ← c.of_nat d,
+      (c, eu) ← c.of_nat (x / d),
+      (c, ev) ← c.of_nat (y / d),
+      (c, _, pu) ← prove_mul_nat c ed eu,
+      (c, _, pv) ← prove_mul_nat c ed ev,
+      (c, p) ← prove_lt_nat c `(1) ed,
+      pure (c, sum.inr $ `(nat_not_coprime_helper).mk_app [ed, ex, ey, eu, ev, pu, pv, p])
+  end
+
+/-- Evaluates the `gcd`, `lcm`, and `coprime` functions. -/
+@[norm_num] meta def eval_gcd : expr → tactic (expr × expr)
+| `(nat.gcd %%ex %%ey) := do
+    c ← mk_instance_cache `(ℕ),
+    prod.snd <$> prove_gcd_nat c ex ey
+| `(nat.lcm %%ex %%ey) := do
+    c ← mk_instance_cache `(ℕ),
+    prod.snd <$> prove_lcm_nat c ex ey
+| `(nat.coprime %%ex %%ey) := do
+    c ← mk_instance_cache `(ℕ),
+    prove_coprime_nat c ex ey >>= sum.elim true_intro false_intro ∘ prod.snd
+| `(int.gcd %%ex %%ey) := do
+    zc ← mk_instance_cache `(ℤ),
+    nc ← mk_instance_cache `(ℕ),
+    (prod.snd ∘ prod.snd) <$> prove_gcd_int zc nc ex ey
+| `(int.lcm %%ex %%ey) := do
+    zc ← mk_instance_cache `(ℤ),
+    nc ← mk_instance_cache `(ℕ),
+    (prod.snd ∘ prod.snd) <$> prove_lcm_int zc nc ex ey
+| _ := failed
+
+end norm_num
+end tactic

--- a/src/data/nat/gcd.lean
+++ b/src/data/nat/gcd.lean
@@ -347,6 +347,8 @@ by simp [coprime]
 @[simp] theorem coprime_zero_right (n : ℕ) : coprime n 0 ↔ n = 1 :=
 by simp [coprime]
 
+theorem not_coprime_zero_zero : ¬ coprime 0 0 := by simp
+
 @[simp] theorem coprime_one_left_iff (n : ℕ) : coprime 1 n ↔ true :=
 by simp [coprime]
 

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -7,17 +7,15 @@ Tests for norm_num
 -/
 
 import tactic.norm_num
-import data.complex.basic
-import data.nat.prime
 
--- constant real : Type
--- notation `ℝ` := real
--- @[instance] constant real.linear_ordered_ring : linear_ordered_field ℝ
+constant real : Type
+notation `ℝ` := real
+@[instance] constant real.linear_ordered_ring : linear_ordered_field ℝ
 
--- constant complex : Type
--- notation `ℂ` := complex
--- @[instance] constant complex.field : field ℂ
--- @[instance] constant complex.char_zero : char_zero ℂ
+constant complex : Type
+notation `ℂ` := complex
+@[instance] constant complex.field : field ℂ
+@[instance] constant complex.char_zero : char_zero ℂ
 
 example : 374 + (32 - (2 * 8123) : ℤ) - 61 * 50 = 86 + 32 * 32 - 4 * 5000
       ∧ 43 ≤ 74 + (33 : ℤ) := by norm_num
@@ -74,10 +72,6 @@ begin
   guard_hyp h : 1 / 3 * a = a,
   trivial
 end
-
-example : nat.prime 1277 := by norm_num
-example : nat.min_fac 221 = 13 := by norm_num
-example : nat.factors 221 = [13, 17] := by norm_num
 
 example (h : (5 : ℤ) ∣ 2) : false := by norm_num at h
 example (h : false) : false := by norm_num at h

--- a/test/norm_num_ext.lean
+++ b/test/norm_num_ext.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2021 Mario Carneiro All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+
+Tests for norm_num extensions
+-/
+import data.nat.prime
+import data.int.gcd
+
+-- coverage tests
+example : nat.coprime 1 2 := by norm_num
+example : nat.coprime 2 1 := by norm_num
+example : ¬ nat.coprime 0 0 := by norm_num
+example : ¬ nat.coprime 0 3 := by norm_num
+example : ¬ nat.coprime 2 0 := by norm_num
+example : nat.coprime 2 3 := by norm_num
+example : ¬ nat.coprime 2 4 := by norm_num
+
+example : nat.gcd 1 2 = 1 := by norm_num
+example : nat.gcd 2 1 = 1 := by norm_num
+example : nat.gcd 0 0 = 0 := by norm_num
+example : nat.gcd 0 3 = 3 := by norm_num
+example : nat.gcd 2 0 = 2 := by norm_num
+example : nat.gcd 2 3 = 1 := by norm_num
+example : nat.gcd 2 4 = 2 := by norm_num
+
+example : nat.lcm 1 2 = 2 := by norm_num
+example : nat.lcm 2 1 = 2 := by norm_num
+example : nat.lcm 0 0 = 0 := by norm_num
+example : nat.lcm 0 3 = 0 := by norm_num
+example : nat.lcm 2 0 = 0 := by norm_num
+example : nat.lcm 2 3 = 6 := by norm_num
+example : nat.lcm 2 4 = 4 := by norm_num
+
+example : int.gcd 2 3 = 1 := by norm_num
+example : int.gcd (-2) 3 = 1 := by norm_num
+example : int.gcd 2 (-3) = 1 := by norm_num
+example : int.gcd (-2) (-3) = 1 := by norm_num
+
+example : int.lcm 2 3 = 6 := by norm_num
+example : int.lcm (-2) 3 = 6 := by norm_num
+example : int.lcm 2 (-3) = 6 := by norm_num
+example : int.lcm (-2) (-3) = 6 := by norm_num
+
+example : ¬ nat.prime 0 := by norm_num
+example : ¬ nat.prime 1 := by norm_num
+example : nat.prime 2 := by norm_num
+example : nat.prime 3 := by norm_num
+example : ¬ nat.prime 4 := by norm_num
+example : nat.prime 5 := by norm_num
+example : nat.prime 109 := by norm_num
+example : nat.prime 1277 := by norm_num
+example : ¬ nat.prime 1000000000000000000000000000000000000000000000000 := by norm_num
+
+example : nat.min_fac 0 = 2 := by norm_num
+example : nat.min_fac 1 = 1 := by norm_num
+example : nat.min_fac 2 = 2 := by norm_num
+example : nat.min_fac 3 = 3 := by norm_num
+example : nat.min_fac 4 = 2 := by norm_num
+example : nat.min_fac 121 = 11 := by norm_num
+example : nat.min_fac 221 = 13 := by norm_num
+
+example : nat.factors 0 = [] := by norm_num
+example : nat.factors 1 = [] := by norm_num
+example : nat.factors 2 = [2] := by norm_num
+example : nat.factors 3 = [3] := by norm_num
+example : nat.factors 4 = [2, 2] := by norm_num
+example : nat.factors 12 = [2, 2, 3] := by norm_num
+example : nat.factors 221 = [13, 17] := by norm_num
+
+-- randomized tests
+example : nat.gcd 35 29 = 1 := by norm_num
+example : int.gcd 35 29 = 1 := by norm_num
+example : nat.lcm 35 29 = 1015 := by norm_num
+example : int.gcd 35 29 = 1 := by norm_num
+example : nat.coprime 35 29 := by norm_num
+
+example : nat.gcd 80 2 = 2 := by norm_num
+example : int.gcd 80 2 = 2 := by norm_num
+example : nat.lcm 80 2 = 80 := by norm_num
+example : int.gcd 80 2 = 2 := by norm_num
+example : ¬ nat.coprime 80 2 := by norm_num
+
+example : nat.gcd 19 17 = 1 := by norm_num
+example : int.gcd 19 17 = 1 := by norm_num
+example : nat.lcm 19 17 = 323 := by norm_num
+example : int.gcd 19 17 = 1 := by norm_num
+example : nat.coprime 19 17 := by norm_num
+
+example : nat.gcd 11 18 = 1 := by norm_num
+example : int.gcd 11 18 = 1 := by norm_num
+example : nat.lcm 11 18 = 198 := by norm_num
+example : int.gcd 11 18 = 1 := by norm_num
+example : nat.coprime 11 18 := by norm_num
+
+example : nat.gcd 23 73 = 1 := by norm_num
+example : int.gcd 23 73 = 1 := by norm_num
+example : nat.lcm 23 73 = 1679 := by norm_num
+example : int.gcd 23 73 = 1 := by norm_num
+example : nat.coprime 23 73 := by norm_num
+
+example : nat.gcd 73 68 = 1 := by norm_num
+example : int.gcd 73 68 = 1 := by norm_num
+example : nat.lcm 73 68 = 4964 := by norm_num
+example : int.gcd 73 68 = 1 := by norm_num
+example : nat.coprime 73 68 := by norm_num
+
+example : nat.gcd 28 16 = 4 := by norm_num
+example : int.gcd 28 16 = 4 := by norm_num
+example : nat.lcm 28 16 = 112 := by norm_num
+example : int.gcd 28 16 = 4 := by norm_num
+example : ¬ nat.coprime 28 16 := by norm_num
+
+example : nat.gcd 44 98 = 2 := by norm_num
+example : int.gcd 44 98 = 2 := by norm_num
+example : nat.lcm 44 98 = 2156 := by norm_num
+example : int.gcd 44 98 = 2 := by norm_num
+example : ¬ nat.coprime 44 98 := by norm_num
+
+example : nat.gcd 21 79 = 1 := by norm_num
+example : int.gcd 21 79 = 1 := by norm_num
+example : nat.lcm 21 79 = 1659 := by norm_num
+example : int.gcd 21 79 = 1 := by norm_num
+example : nat.coprime 21 79 := by norm_num
+
+example : nat.gcd 93 34 = 1 := by norm_num
+example : int.gcd 93 34 = 1 := by norm_num
+example : nat.lcm 93 34 = 3162 := by norm_num
+example : int.gcd 93 34 = 1 := by norm_num
+example : nat.coprime 93 34 := by norm_num
+
+example : ¬ nat.prime 912 := by norm_num
+example : nat.min_fac 912 = 2 := by norm_num
+example : nat.factors 912 = [2, 2, 2, 2, 3, 19] := by norm_num
+
+example : ¬ nat.prime 681 := by norm_num
+example : nat.min_fac 681 = 3 := by norm_num
+example : nat.factors 681 = [3, 227] := by norm_num
+
+example : ¬ nat.prime 728 := by norm_num
+example : nat.min_fac 728 = 2 := by norm_num
+example : nat.factors 728 = [2, 2, 2, 7, 13] := by norm_num
+
+example : ¬ nat.prime 248 := by norm_num
+example : nat.min_fac 248 = 2 := by norm_num
+example : nat.factors 248 = [2, 2, 2, 31] := by norm_num
+
+example : ¬ nat.prime 682 := by norm_num
+example : nat.min_fac 682 = 2 := by norm_num
+example : nat.factors 682 = [2, 11, 31] := by norm_num
+
+example : ¬ nat.prime 115 := by norm_num
+example : nat.min_fac 115 = 5 := by norm_num
+example : nat.factors 115 = [5, 23] := by norm_num
+
+example : ¬ nat.prime 824 := by norm_num
+example : nat.min_fac 824 = 2 := by norm_num
+example : nat.factors 824 = [2, 2, 2, 103] := by norm_num
+
+example : ¬ nat.prime 942 := by norm_num
+example : nat.min_fac 942 = 2 := by norm_num
+example : nat.factors 942 = [2, 3, 157] := by norm_num
+
+example : ¬ nat.prime 34 := by norm_num
+example : nat.min_fac 34 = 2 := by norm_num
+example : nat.factors 34 = [2, 17] := by norm_num
+
+example : ¬ nat.prime 754 := by norm_num
+example : nat.min_fac 754 = 2 := by norm_num
+example : nat.factors 754 = [2, 13, 29] := by norm_num
+
+example : ¬ nat.prime 663 := by norm_num
+example : nat.min_fac 663 = 3 := by norm_num
+example : nat.factors 663 = [3, 13, 17] := by norm_num
+
+example : ¬ nat.prime 923 := by norm_num
+example : nat.min_fac 923 = 13 := by norm_num
+example : nat.factors 923 = [13, 71] := by norm_num
+
+example : ¬ nat.prime 77 := by norm_num
+example : nat.min_fac 77 = 7 := by norm_num
+example : nat.factors 77 = [7, 11] := by norm_num
+
+example : ¬ nat.prime 162 := by norm_num
+example : nat.min_fac 162 = 2 := by norm_num
+example : nat.factors 162 = [2, 3, 3, 3, 3] := by norm_num
+
+example : ¬ nat.prime 669 := by norm_num
+example : nat.min_fac 669 = 3 := by norm_num
+example : nat.factors 669 = [3, 223] := by norm_num
+
+example : ¬ nat.prime 476 := by norm_num
+example : nat.min_fac 476 = 2 := by norm_num
+example : nat.factors 476 = [2, 2, 7, 17] := by norm_num
+
+example : nat.prime 251 := by norm_num
+example : nat.min_fac 251 = 251 := by norm_num
+example : nat.factors 251 = [251] := by norm_num
+
+example : ¬ nat.prime 129 := by norm_num
+example : nat.min_fac 129 = 3 := by norm_num
+example : nat.factors 129 = [3, 43] := by norm_num
+
+example : ¬ nat.prime 471 := by norm_num
+example : nat.min_fac 471 = 3 := by norm_num
+example : nat.factors 471 = [3, 157] := by norm_num
+
+example : ¬ nat.prime 851 := by norm_num
+example : nat.min_fac 851 = 23 := by norm_num
+example : nat.factors 851 = [23, 37] := by norm_num


### PR DESCRIPTION
Implements a `norm_num` plugin to evaluate terms like `nat.gcd 6 8 = 2`, `nat.coprime 127 128`, and so on for `{nat, int}.{gcd, lcm, coprime}`.