### PR TITLE
[Merged by Bors] - chore(data/polynomial/eval, ring_theory/polynomial_algebra): golfs

### DIFF
--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -471,12 +471,24 @@ end
 
 @[simp] lemma map_one : (1 : polynomial R).map f = 1 := eval₂_one _ _
 
+@[simp] lemma map_mul : (p * q).map f = p.map f * q.map f :=
+by { rw [map, eval₂_mul_noncomm], exact λ k, (commute_X _).symm }
+
+@[simp] lemma map_smul (r : R) : (r • p).map f = f r • p.map f :=
+by rw [map, eval₂_smul, ring_hom.comp_apply, C_mul']
+
+/-- `polynomial.map` as a `ring_hom` -/
+def map_ring_hom (f : R →+* S) : polynomial R →+* polynomial S :=
+{ to_fun := polynomial.map f,
+  map_add' := λ _ _, map_add f,
+  map_zero' := map_zero f,
+  map_mul' := λ _ _, map_mul f,
+  map_one' := map_one f }
+
+@[simp] lemma coe_map_ring_hom (f : R →+* S) : ⇑(map_ring_hom f) = map f := rfl
+
 @[simp] theorem map_nat_cast (n : ℕ) : (n : polynomial R).map f = n :=
-begin
-  induction n with n ih,
-  { simp },
-  { rw [n.cast_succ, map_add, ih, map_one, n.cast_succ] }
-end
+(map_ring_hom f).map_nat_cast n
 
 @[simp]
 lemma coeff_map (n : ℕ) : coeff (p.map f) n = f (coeff p n) :=
@@ -535,24 +547,8 @@ variables (f)
 
 open is_semiring_hom
 
-@[simp] lemma map_mul : (p * q).map f = p.map f * q.map f :=
-by { rw [map, eval₂_mul_noncomm], exact λ k, (commute_X _).symm }
-
 instance map.is_semiring_hom : is_semiring_hom (map f) :=
-{ map_zero := eval₂_zero _ _,
-  map_one := eval₂_one _ _,
-  map_add := λ _ _, eval₂_add _ _,
-  map_mul := λ _ _, map_mul f, }
-
-/-- `polynomial.map` as a `ring_hom` -/
-def map_ring_hom (f : R →+* S) : polynomial R →+* polynomial S :=
-{ to_fun := polynomial.map f,
-  map_add' := λ _ _, eval₂_add _ _,
-  map_zero' := eval₂_zero _ _,
-  map_mul' := λ _ _, map_mul f,
-  map_one' := eval₂_one _ _ }
-
-@[simp] lemma coe_map_ring_hom (f : R →+* S) : ⇑(map_ring_hom f) = map f := rfl
+(map_ring_hom f).is_semiring_hom
 
 @[simp] lemma map_ring_hom_id : map_ring_hom (ring_hom.id R) = ring_hom.id (polynomial R) :=
 ring_hom.ext $ λ x, map_id

--- a/src/ring_theory/polynomial_algebra.lean
+++ b/src/ring_theory/polynomial_algebra.lean
@@ -43,58 +43,24 @@ namespace poly_equiv_tensor
 
 /--
 (Implementation detail).
-The bare function underlying `A ⊗[R] polynomial R →ₐ[R] polynomial A`, on pure tensors.
--/
-def to_fun (a : A) (p : polynomial R) : polynomial A :=
-p.sum (λ n r, monomial n (a * algebra_map R A r))
-
-/--
-(Implementation detail).
-The function underlying `A ⊗[R] polynomial R →ₐ[R] polynomial A`,
-as a linear map in the second factor.
--/
-def to_fun_linear_right (a : A) : polynomial R →ₗ[R] polynomial A :=
-{ to_fun := to_fun R A a,
-  map_smul' := λ r p,
-  begin
-    dsimp [to_fun],
-    rw sum_smul_index,
-    { dsimp [sum_def],
-      rw finset.smul_sum,
-      apply finset.sum_congr rfl,
-      intros k hk,
-      rw [monomial_eq_smul_X, monomial_eq_smul_X, algebra.smul_def, ← C_mul', ← C_mul',
-          ← mul_assoc],
-      congr' 1,
-      rw [← algebra.commutes, ← algebra.commutes],
-      simp only [ring_hom.map_mul, polynomial.algebra_map_apply, mul_assoc], },
-    { intro i, simp only [ring_hom.map_zero, mul_zero, monomial_zero_right] },
-  end,
-  map_add' := λ p q,
-  begin
-    simp only [to_fun],
-    rw sum_add_index,
-    { simp only [monomial_zero_right, forall_const, ring_hom.map_zero, mul_zero], },
-    { intros i r s, simp only [ring_hom.map_add, mul_add, monomial_add], },
-  end, }
-
-/--
-(Implementation detail).
 The function underlying `A ⊗[R] polynomial R →ₐ[R] polynomial A`,
 as a bilinear function of two arguments.
 -/
+@[simps apply]
 def to_fun_bilinear : A →ₗ[R] polynomial R →ₗ[R] polynomial A :=
-{ to_fun := to_fun_linear_right R A,
-  map_smul' := by {
-    intros, unfold to_fun_linear_right,
-    congr, simp only [linear_map.coe_mk],
-    simp_rw [to_fun, sum_def, finset.smul_sum, smul_monomial,  ← algebra.smul_mul_assoc],
-    refl },
-  map_add' := by {
-    intros, unfold to_fun_linear_right,
-    congr, simp only [linear_map.coe_mk],
-    simp_rw [to_fun, sum_def, ← finset.sum_add_distrib, ← monomial_add, ← add_mul],
-    refl } }
+{ to_fun := λ a, a • (aeval (polynomial.X : polynomial A)).to_linear_map,
+  map_smul' := λ r x, smul_assoc _ _ _,
+  map_add' := λ x y, add_smul _ _ _ }
+
+lemma to_fun_bilinear_apply_eq_sum (a : A) (p : polynomial R) :
+  to_fun_bilinear R A a p = p.sum (λ n r, monomial n (a * algebra_map R A r)) :=
+begin
+  dsimp [to_fun_bilinear, aeval_def, eval₂_eq_sum, polynomial.sum],
+  rw finset.smul_sum,
+  congr' with i : 1,
+  rw [←algebra.smul_def, ←C_mul', mul_smul_comm, C_mul_X_pow_eq_monomial, ←algebra.commutes,
+    ←algebra.smul_def, smul_monomial],
+end
 
 /--
 (Implementation detail).
@@ -103,6 +69,10 @@ as a linear map.
 -/
 def to_fun_linear : A ⊗[R] polynomial R →ₗ[R] polynomial A :=
 tensor_product.lift (to_fun_bilinear R A)
+
+@[simp]
+lemma to_fun_linear_tmul_apply (a : A) (p : polynomial R) :
+  to_fun_linear R A (a ⊗ₜ[R] p) = to_fun_bilinear R A a p := lift.tmul _ _
 
 -- We apparently need to provide the decidable instance here
 -- in order to successfully rewrite by this lemma.
@@ -125,9 +95,7 @@ lemma to_fun_linear_mul_tmul_mul (a₁ a₂ : A) (p₁ p₂ : polynomial R) :
   (to_fun_linear R A) ((a₁ * a₂) ⊗ₜ[R] (p₁ * p₂)) =
     (to_fun_linear R A) (a₁ ⊗ₜ[R] p₁) * (to_fun_linear R A) (a₂ ⊗ₜ[R] p₂) :=
 begin
-  dsimp [to_fun_linear],
-  simp only [lift.tmul],
-  dsimp [to_fun_bilinear, to_fun_linear_right, to_fun],
+  simp only [to_fun_linear_tmul_apply, to_fun_bilinear_apply_eq_sum],
   ext k,
   simp_rw [coeff_sum, coeff_monomial, sum_def, finset.sum_ite_eq', mem_support_iff, ne.def],
   conv_rhs { rw [coeff_mul] },
@@ -141,13 +109,9 @@ end
 
 lemma to_fun_linear_algebra_map_tmul_one (r : R) :
   (to_fun_linear R A) ((algebra_map R A) r ⊗ₜ[R] 1) = (algebra_map R (polynomial A)) r :=
-begin
-  dsimp [to_fun_linear],
-  simp only [lift.tmul],
-  dsimp [to_fun_bilinear, to_fun_linear_right, to_fun],
-  rw [← C_1, ←monomial_zero_left, sum_monomial_index];
-  simp [algebra_map_apply],
-end
+by rw [to_fun_linear_tmul_apply, to_fun_bilinear_apply, linear_map.smul_apply,
+  alg_hom.to_linear_map_apply, polynomial.aeval_one, algebra_map_smul,
+  algebra.algebra_map_eq_smul_one]
 
 /--
 (Implementation detail).
@@ -161,7 +125,10 @@ alg_hom_of_linear_map_tensor_product
 
 @[simp] lemma to_fun_alg_hom_apply_tmul (a : A) (p : polynomial R) :
   to_fun_alg_hom R A (a ⊗ₜ[R] p) = p.sum (λ n r, monomial n (a * (algebra_map R A) r)) :=
-by simp [to_fun_alg_hom, to_fun_linear, to_fun_bilinear, to_fun_linear_right, to_fun]
+begin
+  dsimp [to_fun_alg_hom],
+  rw [to_fun_linear_tmul_apply, to_fun_bilinear_apply_eq_sum],
+end
 
 /--
 (Implementation detail.)
@@ -242,10 +209,7 @@ rfl
 @[simp]
 lemma poly_equiv_tensor_symm_apply_tmul (a : A) (p : polynomial R) :
   (poly_equiv_tensor R A).symm (a ⊗ₜ p) = p.sum (λ n r, monomial n (a * algebra_map R A r)) :=
-begin
-  simp [poly_equiv_tensor, to_fun_alg_hom, alg_hom_of_linear_map_tensor_product, to_fun_linear],
-  refl,
-end
+to_fun_alg_hom_apply_tmul _ _ _ _
 
 open dmatrix matrix
 open_locale big_operators

--- a/src/ring_theory/polynomial_algebra.lean
+++ b/src/ring_theory/polynomial_algebra.lean
@@ -46,16 +46,14 @@ namespace poly_equiv_tensor
 The function underlying `A ⊗[R] polynomial R →ₐ[R] polynomial A`,
 as a bilinear function of two arguments.
 -/
-@[simps apply]
-def to_fun_bilinear : A →ₗ[R] polynomial R →ₗ[R] polynomial A :=
-{ to_fun := λ a, a • (aeval (polynomial.X : polynomial A)).to_linear_map,
-  map_smul' := λ r x, smul_assoc _ _ _,
-  map_add' := λ x y, add_smul _ _ _ }
+@[simps]
+def to_fun_bilinear : A →ₗ[A] polynomial R →ₗ[R] polynomial A :=
+linear_map.to_span_singleton A _ (aeval (polynomial.X : polynomial A)).to_linear_map
 
 lemma to_fun_bilinear_apply_eq_sum (a : A) (p : polynomial R) :
   to_fun_bilinear R A a p = p.sum (λ n r, monomial n (a * algebra_map R A r)) :=
 begin
-  dsimp [to_fun_bilinear, aeval_def, eval₂_eq_sum, polynomial.sum],
+  dsimp [to_fun_bilinear_apply_apply, aeval_def, eval₂_eq_sum, polynomial.sum],
   rw finset.smul_sum,
   congr' with i : 1,
   rw [←algebra.smul_def, ←C_mul', mul_smul_comm, C_mul_X_pow_eq_monomial, ←algebra.commutes,
@@ -109,9 +107,8 @@ end
 
 lemma to_fun_linear_algebra_map_tmul_one (r : R) :
   (to_fun_linear R A) ((algebra_map R A) r ⊗ₜ[R] 1) = (algebra_map R (polynomial A)) r :=
-by rw [to_fun_linear_tmul_apply, to_fun_bilinear_apply, linear_map.smul_apply,
-  alg_hom.to_linear_map_apply, polynomial.aeval_one, algebra_map_smul,
-  algebra.algebra_map_eq_smul_one]
+by rw [to_fun_linear_tmul_apply, to_fun_bilinear_apply_apply, polynomial.aeval_one,
+  algebra_map_smul, algebra.algebra_map_eq_smul_one]
 
 /--
 (Implementation detail).


### PR DESCRIPTION
This golfs:

* `polynomial.map_nat_cast` to use `ring_hom.map_nat_cast`
* `polynomial.map.is_semiring_hom` to use `ring_hom.is_semiring_hom`
* `poly_equiv_tensor.to_fun` and `poly_equiv_tensor.to_fun_linear_right` out of existence

And adds a new (unused) lemma `polynomial.map_smul`.
All the other changes in `polynomial/eval` are just reorderings of lemmas to allow the golfing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
