### PR TITLE
[Merged by Bors] - feat(data/matrix/basic.lean) : added map_scalar and linear_map.map_matrix

### DIFF
--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -110,6 +110,10 @@ lemma map_sub [add_group α] [add_group β] (f : α →+ β)
   (M N : matrix m n α) : (M - N).map f = M.map f - N.map f :=
 by { ext, simp }
 
+lemma map_scalar [has_scalar R α] [has_scalar R β] (f : α →[R] β) (r : R)
+  (M : matrix m n α) : (r • M).map f = r • (M.map f) :=
+by { ext, simp, }
+
 lemma subsingleton_of_empty_left (hm : ¬ nonempty m) : subsingleton (matrix m n α) :=
 ⟨λ M N, by { ext, contrapose! hm, use i }⟩
 
@@ -128,6 +132,17 @@ def add_monoid_hom.map_matrix [add_monoid α] [add_monoid β] (f : α →+ β) :
 
 @[simp] lemma add_monoid_hom.map_matrix_apply [add_monoid α] [add_monoid β]
   (f : α →+ β) (M : matrix m n α) : f.map_matrix M = M.map f := rfl
+
+/-- The `linear_map` between spaces of matrices induced by a `linear_map` between their
+coefficients. -/
+def linear_map.map_matrix [semiring R] [add_comm_monoid α] [add_comm_monoid β]
+  [module R α] [module R β] (f : α →ₗ[R] β) : matrix m n α →ₗ[R] matrix m n β :=
+{ to_fun := λ M, M.map f,
+  map_add' := matrix.map_add f.to_add_monoid_hom,
+  map_smul' := matrix.map_scalar f.to_mul_action_hom, }
+
+@[simp] lemma linear_map.map_matrix_apply [semiring R] [add_comm_monoid α] [add_comm_monoid β]
+  [module R α] [module R β] (f : α →ₗ[R] β) (M : matrix m n α) : f.map_matrix M = M.map f := rfl
 
 open_locale matrix
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -135,14 +135,12 @@ def add_monoid_hom.map_matrix [add_monoid α] [add_monoid β] (f : α →+ β) :
 
 /-- The `linear_map` between spaces of matrices induced by a `linear_map` between their
 coefficients. -/
+@[simps]
 def linear_map.map_matrix [semiring R] [add_comm_monoid α] [add_comm_monoid β]
   [module R α] [module R β] (f : α →ₗ[R] β) : matrix m n α →ₗ[R] matrix m n β :=
 { to_fun := λ M, M.map f,
   map_add' := matrix.map_add f.to_add_monoid_hom,
   map_smul' := matrix.map_scalar f.to_mul_action_hom, }
-
-@[simp] lemma linear_map.map_matrix_apply [semiring R] [add_comm_monoid α] [add_comm_monoid β]
-  [module R α] [module R β] (f : α →ₗ[R] β) (M : matrix m n α) : f.map_matrix M = M.map f := rfl
 
 open_locale matrix
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -110,7 +110,7 @@ lemma map_sub [add_group α] [add_group β] (f : α →+ β)
   (M N : matrix m n α) : (M - N).map f = M.map f - N.map f :=
 by { ext, simp }
 
-lemma map_scalar [has_scalar R α] [has_scalar R β] (f : α →[R] β) (r : R)
+lemma map_smul [has_scalar R α] [has_scalar R β] (f : α →[R] β) (r : R)
   (M : matrix m n α) : (r • M).map f = r • (M.map f) :=
 by { ext, simp, }
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -140,7 +140,7 @@ def linear_map.map_matrix [semiring R] [add_comm_monoid α] [add_comm_monoid β]
   [module R α] [module R β] (f : α →ₗ[R] β) : matrix m n α →ₗ[R] matrix m n β :=
 { to_fun := λ M, M.map f,
   map_add' := matrix.map_add f.to_add_monoid_hom,
-  map_smul' := matrix.map_scalar f.to_mul_action_hom, }
+  map_smul' := matrix.map_smul f.to_mul_action_hom, }
 
 open_locale matrix
 


### PR DESCRIPTION
Added two lemmas (`map_scalar` and `linear_map.map_matrix_apply`) and a definition (`linear_map.map_matrix`) showing that a map between coefficients induces the same type of map between matrices with those coefficients.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
