### PR TITLE
[Merged by Bors] - chore(algebra/ordered_monoid_lemmas): change additive name `left.add_nonneg` to `right.add_nonneg`

### DIFF
--- a/src/algebra/ordered_monoid_lemmas.lean
+++ b/src/algebra/ordered_monoid_lemmas.lean
@@ -9,16 +9,20 @@ import order.basic
 
 /-!
 # Ordered monoids
+
 This file develops the basics of ordered monoids.
 
 ## Implementation details
+
 Unfortunately, the number of `'` appended to lemmas in this file
 may differ between the multiplicative and the additive version of a lemma.
 The reason is that we did not want to change existing names in the library.
 
 ## Remark
+
 No monoid is actually present in this file: all assumptions have been generalized to `has_mul` or
 `mul_one_class`.
+
 -/
 
 -- TODO: If possible, uniformize lemma names, taking special care of `'`,
@@ -325,7 +329,7 @@ calc  a * b < 1 * b : mul_lt_mul_right' ha b
         ... < c     : hb
 
 /-- Assumes right covariance. -/
-@[to_additive left.add_nonneg]
+@[to_additive right.add_nonneg]
 lemma right.one_le_mul [covariant_class α α (function.swap (*)) (≤)]
   {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) : 1 ≤ a * b :=
 calc  1 ≤ b     : hb

--- a/src/algebra/ordered_monoid_lemmas.lean
+++ b/src/algebra/ordered_monoid_lemmas.lean
@@ -337,7 +337,7 @@ calc  1 ≤ b     : hb
     ... ≤ a * b : mul_le_mul_right' ha b
 
 /-- Assumes right covariance. -/
-@[to_additive right.pos_add]
+@[to_additive right.add_pos]
 lemma right.one_lt_mul [covariant_class α α (function.swap (*)) (<)]
   {b : α} (hb : 1 < b) {a: α} (ha : 1 < a) : 1 < a * b :=
 calc  1 < b     : hb


### PR DESCRIPTION
A copy-paste error in the name of a lemma that has not been used yet.

Change `pos_add` to `add_pos`.

I also added some paragraph breaks in the documentation.

Co-authored by Eric Wieser.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
