### PR TITLE
[Merged by Bors] -  feat(linear_algebra/pi): add linear_equiv.Pi_congr_left

### DIFF
--- a/src/linear_algebra/pi.lean
+++ b/src/linear_algebra/pi.lean
@@ -261,6 +261,8 @@ lemma Pi_congr_right_trans (e : Π i, φ i ≃ₗ[R] ψ i) (f : Π i, ψ i ≃�
   (Pi_congr_right e).trans (Pi_congr_right f) = (Pi_congr_right $ λ i, (e i).trans (f i)) :=
 rfl
 
+variables (R φ)
+
 /-- Transport dependent functions through an equivalence of the base space.
 
 This is `equiv.Pi_congr_left'` as a `linear_equiv`. -/
@@ -273,7 +275,7 @@ expressed as a "simplification".
 
 This is `equiv.Pi_congr_left` as a `linear_equiv` -/
 def Pi_congr_left (e : ι' ≃ ι) : (Π i', φ (e i')) ≃ₗ[R] (Π i, φ i) :=
-(Pi_congr_left' e.symm : (Π i, φ i) ≃ₗ[R] _).symm
+(Pi_congr_left' R φ e.symm).symm
 
 variables (ι R M) (S : Type*) [fintype ι] [decidable_eq ι] [semiring S]
   [add_comm_monoid M] [module R M] [module S M] [smul_comm_class R S M]

--- a/src/linear_algebra/pi.lean
+++ b/src/linear_algebra/pi.lean
@@ -23,9 +23,9 @@ It contains theorems relating these to each other, as well as to `linear_map.ker
 
 -/
 
-universes u v w x y z u' v' w' y'
+universes u v w x y z u' v' w' x' y'
 variables {R : Type u} {K : Type u'} {M : Type v} {V : Type v'} {M₂ : Type w} {V₂ : Type w'}
-variables {M₃ : Type y} {V₃ : Type y'} {M₄ : Type z} {ι : Type x}
+variables {M₃ : Type y} {V₃ : Type y'} {M₄ : Type z} {ι : Type x} {ι' : Type x'}
 
 open function submodule
 open_locale big_operators
@@ -240,12 +240,13 @@ variables [semiring R] {φ ψ χ : ι → Type*} [∀ i, add_comm_monoid (φ i)]
 variables [∀ i, add_comm_monoid (ψ i)] [∀ i, module R (ψ i)]
 variables [∀ i, add_comm_monoid (χ i)] [∀ i, module R (χ i)]
 
-/-- Combine a family of linear equivalences into a linear equivalence of `pi`-types. -/
+/-- Combine a family of linear equivalences into a linear equivalence of `pi`-types.
+
+This is `equiv.Pi_congr_right` as a `linear_equiv` -/
 @[simps apply] def Pi_congr_right (e : Π i, φ i ≃ₗ[R] ψ i) : (Π i, φ i) ≃ₗ[R] (Π i, ψ i) :=
 { to_fun := λ f i, e i (f i),
   inv_fun := λ f i, (e i).symm (f i),
   map_smul' := λ c f, by { ext, simp },
-  left_inv := λ f, by { ext, simp },
   .. add_equiv.Pi_congr_right (λ j, (e j).to_add_equiv) }
 
 @[simp]
@@ -259,6 +260,20 @@ lemma Pi_congr_right_symm (e : Π i, φ i ≃ₗ[R] ψ i) :
 lemma Pi_congr_right_trans (e : Π i, φ i ≃ₗ[R] ψ i) (f : Π i, ψ i ≃ₗ[R] χ i) :
   (Pi_congr_right e).trans (Pi_congr_right f) = (Pi_congr_right $ λ i, (e i).trans (f i)) :=
 rfl
+
+/-- Transport dependent functions through an equivalence of the base space.
+
+This is `equiv.Pi_congr_left'` as a `linear_equiv`. -/
+@[simps {simp_rhs := tt}]
+def Pi_congr_left' (e : ι ≃ ι') : (Π i', φ i') ≃ₗ[R] (Π i, φ $ e.symm i) :=
+{ map_add' := λ x y, rfl, map_smul' := λ x y, rfl, .. equiv.Pi_congr_left' φ e }
+
+/-- Transporting dependent functions through an equivalence of the base,
+expressed as a "simplification".
+
+This is `equiv.Pi_congr_left` as a `linear_equiv` -/
+def Pi_congr_left (e : ι' ≃ ι) : (Π i', φ (e i')) ≃ₗ[R] (Π i, φ i) :=
+(Pi_congr_left' e.symm : (Π i, φ i) ≃ₗ[R] _).symm
 
 variables (ι R M) (S : Type*) [fintype ι] [decidable_eq ι] [semiring S]
   [add_comm_monoid M] [module R M] [module S M] [smul_comm_class R S M]

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -384,29 +384,22 @@ have s ⊓ linear_map.ker (linear_map.snd R M P) ≤ linear_map.range (linear_ma
 from λ x ⟨hx1, hx2⟩, ⟨x.1, prod.ext rfl $ eq.symm $ linear_map.mem_ker.1 hx2⟩,
 linear_map.map_comap_eq_self this ▸ submodule.fg_map (noetherian _)⟩
 
-#exit
-
 instance is_noetherian_pi {R ι : Type*} {M : ι → Type*} [ring R]
   [Π i, add_comm_group (M i)] [Π i, module R (M i)] [fintype ι]
   [∀ i, is_noetherian R (M i)] : is_noetherian R (Π i, M i) :=
 begin
   haveI := classical.dec_eq ι,
-  suffices : ∀ s : finset ι, is_noetherian R (Π i : (↑s : set ι), M i),
-  { letI := this finset.univ,
-    refine @is_noetherian_of_linear_equiv _ _ _ _ _ _ _ _
-      ⟨_, _, _, _, _, _⟩ (this finset.univ),
-    { exact λ f i, f ⟨i, finset.mem_univ _⟩ },
-    { intros, ext, refl },
-    { intros, ext, refl },
-    { exact λ f i, f i.1 },
-    { intro, ext ⟨⟩, refl },
-    { intro, ext i, refl } },
+  suffices on_finset : ∀ s : finset ι, is_noetherian R (Π i : s, M i),
+  { let coe_e := equiv.subtype_univ_equiv finset.mem_univ,
+    letI : is_noetherian R (Π i : finset.univ, M (coe_e i)) := on_finset finset.univ,
+    exact is_noetherian_of_linear_equiv (linear_equiv.Pi_congr_left R M coe_e), },
   intro s,
   induction s using finset.induction with a s has ih,
   { split, intro s, convert submodule.fg_bot, apply eq_bot_iff.2,
     intros x hx, refine (submodule.mem_bot R).2 _, ext i, cases i.2 },
   refine @is_noetherian_of_linear_equiv _ _ _ _ _ _ _ _
-    ⟨_, _, _, _, _, _⟩ (@is_noetherian_prod _ (M a) _ _ _ _ _ _ _ ih),
+    _ (@is_noetherian_prod _ (M a) _ _ _ _ _ _ _ ih),
+  fconstructor,
   { exact λ f i, or.by_cases (finset.mem_insert.1 i.2)
       (λ h : i.1 = a, show M i.1, from (eq.rec_on h.symm f.1))
       (λ h : i.1 ∈ s, show M i.1, from f.2 ⟨i.1, h⟩) },
@@ -429,9 +422,9 @@ begin
       rw [dif_neg this, dif_pos his] } },
   { intro f, ext ⟨i, hi⟩,
     rcases finset.mem_insert.1 hi with rfl | h,
-    { simp only [or.by_cases, dif_pos], refl },
+    { simp only [or.by_cases, dif_pos], },
     { have : ¬i = a, { rintro rfl, exact has h },
-      simp only [or.by_cases, dif_neg this, dif_pos h], refl } }
+      simp only [or.by_cases, dif_neg this, dif_pos h], } }
 end
 
 end

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -384,6 +384,8 @@ have s ⊓ linear_map.ker (linear_map.snd R M P) ≤ linear_map.range (linear_ma
 from λ x ⟨hx1, hx2⟩, ⟨x.1, prod.ext rfl $ eq.symm $ linear_map.mem_ker.1 hx2⟩,
 linear_map.map_comap_eq_self this ▸ submodule.fg_map (noetherian _)⟩
 
+#exit
+
 instance is_noetherian_pi {R ι : Type*} {M : ι → Type*} [ring R]
   [Π i, add_comm_group (M i)] [Π i, module R (M i)] [fintype ι]
   [∀ i, is_noetherian R (M i)] : is_noetherian R (Π i, M i) :=


### PR DESCRIPTION
This definition was hiding inside the proof for `is_noetherian_pi`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
