### PR TITLE
[Merged by Bors] - feat(field_theory): state primitive element theorem using `power_basis`

### DIFF
--- a/src/field_theory/primitive_element.lean
+++ b/src/field_theory/primitive_element.lean
@@ -191,10 +191,9 @@ See also `exists_primitive_element`. -/
 noncomputable def power_basis_of_finite_of_separable
   [finite_dimensional F E] (F_sep : is_separable F E) :
   power_basis F E :=
-let α := (exists_primitive_element F_sep).some in
+let α := (exists_primitive_element F_sep).some,
+    pb := (adjoin.power_basis (F_sep.is_integral α)) in
 have e : F⟮α⟯ = ⊤ := (exists_primitive_element F_sep).some_spec,
--- TODO: times out if you get rid of the `@` and write `adjoin.power_basis (F_sep.is_integral α)`
-power_basis.map (@adjoin.power_basis _ _ _ _ _ _ (F_sep.is_integral α))
-  ((intermediate_field.equiv_of_eq e).trans intermediate_field.top_equiv)
+pb.map ((intermediate_field.equiv_of_eq e).trans intermediate_field.top_equiv)
 
 end field

--- a/src/field_theory/primitive_element.lean
+++ b/src/field_theory/primitive_element.lean
@@ -184,4 +184,17 @@ begin
     exact induction_on_adjoin P base ih ⊤ },
 end
 
+/-- Alternative phrasing of primitive element theorem:
+a finite separable field extension has a basis `1, α, α^2, ..., α^n`.
+
+See also `exists_primitive_element`. -/
+noncomputable def power_basis_of_finite_of_separable
+  [finite_dimensional F E] (F_sep : is_separable F E) :
+  power_basis F E :=
+let α := (exists_primitive_element F_sep).some in
+have e : F⟮α⟯ = ⊤ := (exists_primitive_element F_sep).some_spec,
+-- TODO: times out if you get rid of the `@` and write `adjoin.power_basis (F_sep.is_integral α)`
+power_basis.map (@adjoin.power_basis _ _ _ _ _ _ (F_sep.is_integral α))
+  ((intermediate_field.equiv_of_eq e).trans intermediate_field.top_equiv)
+
 end field


### PR DESCRIPTION
This PR adds an alternative formulation to the primitive element theorem: the original formulation was `∃ α : E, F⟮α⟯ = (⊤ : intermediate_field F E)`, which means a lot of pushing things across the equality/equiv from `F⟮α⟯` to `E` itself. I claim that working with a field `E` that has a power basis over `F` is nicer since you don't need to do a lot of transporting.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

 - [x] depends on: #8039
 - [x] depends on: #8069

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
