### PR TITLE
[Merged by Bors] - chore(algebraic_topology/simplex_category): golf proof

### DIFF
--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -171,18 +171,7 @@ end
 
 /-- The special case of the first simplicial identity -/
 lemma δ_comp_δ_self {n} {i : fin (n+2)} : δ i ≫ δ i.cast_succ = δ i ≫ δ i.succ :=
-begin
-  ext j,
-  dsimp [δ, fin.succ_above],
-  simp only [order_embedding.to_preorder_hom_coe,
-    order_embedding.coe_of_strict_mono,
-    function.comp_app,
-    simplex_category.hom.to_preorder_hom_mk,
-    preorder_hom.comp_coe],
-  rcases i with ⟨i, _⟩,
-  rcases j with ⟨j, _⟩,
-  split_ifs; { simp at *; linarith },
-end
+(δ_comp_δ (le_refl i)).symm
 
 /-- The second simplicial identity -/
 lemma δ_comp_σ_of_le {n} {i : fin (n+2)} {j : fin (n+1)} (H : i ≤ j.cast_succ) :


### PR DESCRIPTION
The "special case of the first simplicial identity" is a trivial consequence of the "generic case". This makes me wonder whether the special case should be there at all but I do not know the standard references for this stuff.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
