### PR TITLE
refactor(algebra/internal_direct_sum): give internal direct sums their own file

### DIFF
--- a/src/algebra/direct_sum.lean
+++ b/src/algebra/direct_sum.lean
@@ -170,26 +170,4 @@ protected def id (M : Type v) (ι : Type* := punit) [add_comm_monoid M] [unique 
   right_inv := λ x, to_add_monoid_of _ _ _,
   ..direct_sum.to_add_monoid (λ _, add_monoid_hom.id M) }
 
-/-- The `direct_sum` formed by a collection of `add_submonoid`s of `M` is said to be internal if the
-canonical map `(⨁ i, A i) →+ M` is bijective.
-
-See `direct_sum.add_subgroup_is_internal` for the same statement about `add_subgroup`s. -/
-def add_submonoid_is_internal {M : Type*} [decidable_eq ι] [add_comm_monoid M]
-  (A : ι → add_submonoid M) : Prop :=
-function.bijective (direct_sum.to_add_monoid (λ i, (A i).subtype) : (⨁ i, A i) →+ M)
-
-/-- The `direct_sum` formed by a collection of `add_subgroup`s of `M` is said to be internal if the
-canonical map `(⨁ i, A i) →+ M` is bijective.
-
-See `direct_sum.submodule_is_internal` for the same statement about `submodules`s. -/
-def add_subgroup_is_internal {M : Type*} [decidable_eq ι] [add_comm_group M]
-  (A : ι → add_subgroup M) : Prop :=
-function.bijective (direct_sum.to_add_monoid (λ i, (A i).subtype) : (⨁ i, A i) →+ M)
-
-lemma add_subgroup_is_internal.to_add_submonoid
-  {M : Type*} [decidable_eq ι] [add_comm_group M] (A : ι → add_subgroup M) :
-  add_subgroup_is_internal A ↔
-    add_submonoid_is_internal (λ i, (A i).to_add_submonoid) :=
-iff.rfl
-
 end direct_sum

--- a/src/algebra/internal_direct_sum.lean
+++ b/src/algebra/internal_direct_sum.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2021 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import algebra.direct_sum
+/-!
+# Internal direct sums
+
+The theory of abelian groups `A` equipped with an indexed family
+of submodules `G i` for `i : ι`, such that the induced map
+`⨁ i, G i →+ A` is an isomorphism of groups.
+
+Variants: abelian monoids with a family of submonoids, R-modules with a family
+of sub-R-modules.
+-/
+
+namespace direct_sum
+
+open_locale direct_sum
+
+variables {ι : Type*}
+
+/-- The `direct_sum` formed by a collection of `add_submonoid`s of `M` is said to be internal if the
+canonical map `(⨁ i, A i) →+ M` is bijective.
+
+See `direct_sum.add_subgroup_is_internal` for the same statement about `add_subgroup`s. -/
+def add_submonoid_is_internal {M : Type*} [decidable_eq ι] [add_comm_monoid M]
+  (A : ι → add_submonoid M) : Prop :=
+function.bijective (direct_sum.to_add_monoid (λ i, (A i).subtype) : (⨁ i, A i) →+ M)
+
+/-- The `direct_sum` formed by a collection of `add_subgroup`s of `M` is said to be internal if the
+canonical map `(⨁ i, A i) →+ M` is bijective.
+
+See `direct_sum.submodule_is_internal` for the same statement about `submodules`s. -/
+def add_subgroup_is_internal {M : Type*} [decidable_eq ι] [add_comm_group M]
+  (A : ι → add_subgroup M) : Prop :=
+function.bijective (direct_sum.to_add_monoid (λ i, (A i).subtype) : (⨁ i, A i) →+ M)
+
+lemma add_subgroup_is_internal.to_add_submonoid
+  {M : Type*} [decidable_eq ι] [add_comm_group M] (A : ι → add_subgroup M) :
+  add_subgroup_is_internal A ↔
+    add_submonoid_is_internal (λ i, (A i).to_add_submonoid) :=
+iff.rfl
+
+end direct_sum

--- a/src/linear_algebra/direct_sum_module.lean
+++ b/src/linear_algebra/direct_sum_module.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau
 Direct sum of modules over commutative rings, indexed by a discrete type.
 -/
 import algebra.direct_sum
+import algebra.internal_direct_sum
 import linear_algebra.dfinsupp
 
 /-!


### PR DESCRIPTION



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I have a plan for internal direct sums, but right now what little that we have is stuffed at the end of the external direct sum file. The key difference between internal and external direct sums is that if M is graded internally by submonoids M_i then there's a map M -> M corresponding to projection onto the i'th component and one can do things such as compose two such maps. We need all this infrastructure but before I build it I thought I'd move internal direct sums into their own file.