### PR TITLE
[Merged by Bors] - fix(real/sign): make `real.sign 0 = 0` to match `int.sign 0`

### DIFF
--- a/src/data/real/sign.lean
+++ b/src/data/real/sign.lean
@@ -24,7 +24,8 @@ sign function
 
 namespace real
 
-/-- The sign function that maps negative real numbers to -1, positive numbers to 1, and 0 otherwise. -/
+/-- The sign function that maps negative real numbers to -1, positive numbers to 1, and 0
+otherwise. -/
 noncomputable
 def sign (r : ℝ) : ℝ :=
 if r < 0 then -1 else

--- a/src/data/real/sign.lean
+++ b/src/data/real/sign.lean
@@ -51,6 +51,15 @@ begin
   { exact (or.inr $ or.inr $ sign_of_pos hp) },
 end
 
+/-- This lemma is useful for working with `units ℝ` -/
+lemma sign_apply_eq_of_ne_zero (r : ℝ) (h : r ≠ 0) : sign r = -1 ∨ sign r = 1 :=
+begin
+  obtain hn | rfl | hp := lt_trichotomy r (0 : ℝ),
+  { exact (or.inl $ sign_of_neg hn) },
+  { exact (h rfl).elim },
+  { exact (or.inr $ sign_of_pos hp) },
+end
+
 @[simp]
 lemma sign_eq_zero_iff {r : ℝ} : sign r = 0 ↔ r = 0 :=
 begin

--- a/src/data/real/sign.lean
+++ b/src/data/real/sign.lean
@@ -9,11 +9,13 @@ import data.real.basic
 # Real sign function
 
 This file introduces and contains some results about `real.sign` which maps negative
-real numbers to -1 and nonnegative numbers to 1.
+real numbers to -1, positive real numbers to 1, and 0 to 0.
 
 ## Main definitions
 
- * `real.sign r` is -1 if `r < 0` and 1 otherwise
+ * `real.sign r` is $\begin{cases} -1 & \text{if } r < 0, \\
+                               ~~\, 0 & \text{if } r = 0, \\
+                               ~~\, 1 & \text{if } r > 0. \end{cases}$
 
 ## Tags
 
@@ -22,7 +24,7 @@ sign function
 
 namespace real
 
-/-- The sign function that maps negative real numbers to -1 and nonnegative numbers to 1. -/
+/-- The sign function that maps negative real numbers to -1 and positive numbers to 1. -/
 noncomputable
 def sign (r : ℝ) : ℝ :=
 if r < 0 then -1 else

--- a/src/data/real/sign.lean
+++ b/src/data/real/sign.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Kexing Ying. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kexing Ying
+Authors: Kexing Ying, Eric Wieser
 -/
 import data.real.basic
 
@@ -24,74 +24,93 @@ namespace real
 
 /-- The sign function that maps negative real numbers to -1 and nonnegative numbers to 1. -/
 noncomputable
-def sign (r : ℝ) : ℝ := if r < 0 then -1 else 1
+def sign (r : ℝ) : ℝ :=
+if r < 0 then -1 else
+if 0 < r then 1 else
+0
 
 lemma sign_of_neg {r : ℝ} (hr : r < 0) : sign r = -1 :=
 by rw [sign, if_pos hr]
 
-lemma sign_of_not_neg {r : ℝ} (hr : ¬ r < 0) : sign r = 1 :=
-by rw [sign, if_neg hr]
-
-lemma sign_of_zero_le {r : ℝ} (hr : 0 ≤ r) : sign r = 1 :=
-sign_of_not_neg (not_lt.2 hr)
+lemma sign_of_pos {r : ℝ} (hr : 0 < r) : sign r = 1 :=
+by rw [sign, if_pos hr, if_neg hr.not_lt]
 
 @[simp]
-lemma sign_zero : sign 0 = 1 :=
-sign_of_not_neg $ irrefl 0
+lemma sign_zero : sign 0 = 0 :=
+by rw [sign, if_neg (lt_irrefl _), if_neg (lt_irrefl _)]
 
 @[simp]
 lemma sign_one : sign 1 = 1 :=
-sign_of_not_neg $ by norm_num
+sign_of_pos $ by norm_num
 
-lemma sign_apply_eq (r : ℝ) : sign r = -1 ∨ sign r = 1 :=
+lemma sign_apply_eq (r : ℝ) : sign r = -1 ∨ sign r = 0 ∨ sign r = 1 :=
 begin
-  by_cases r < 0,
-  { exact or.intro_left _ (if_pos h) },
-  { exact or.intro_right _ (if_neg h) }
+  obtain hn | rfl | hp := lt_trichotomy r (0 : ℝ),
+  { exact (or.inl $ sign_of_neg hn) },
+  { exact (or.inr $ or.inl $ sign_zero) },
+  { exact (or.inr $ or.inr $ sign_of_pos hp) },
 end
 
-lemma sign_neg {r : ℝ} (hr : r ≠ 0) : sign (-r) = - sign r :=
+@[simp]
+lemma sign_eq_zero_iff {r : ℝ} : sign r = 0 ↔ r = 0 :=
 begin
-  by_cases r < 0,
-  { rw [sign_of_neg h, sign_of_zero_le, neg_neg],
-    rw [le_neg, neg_zero],
-    exact le_of_lt h },
-  { rw [sign_of_not_neg h, sign_of_neg],
-    rw [neg_lt, neg_zero],
-    exact lt_of_le_of_ne (le_of_not_lt h) hr.symm }
+  refine ⟨λ h, _, λ h, h.symm ▸ sign_zero⟩,
+  obtain hn | rfl | hp := lt_trichotomy r (0 : ℝ),
+  { rw [sign_of_neg hn, neg_eq_zero] at h, exact (one_ne_zero h).elim },
+  { refl },
+  { rw sign_of_pos hp at h, exact (one_ne_zero h).elim },
+end
+
+lemma sign_int_cast (z : ℤ) : sign (z : ℝ) = ↑(int.sign z) :=
+begin
+  obtain hn | rfl | hp := lt_trichotomy z (0 : ℤ),
+  { rw [sign_of_neg (int.cast_lt_zero.mpr hn), int.sign_eq_neg_one_of_neg hn, int.cast_neg,
+      int.cast_one], },
+  { rw [int.cast_zero, sign_zero, int.sign_zero, int.cast_zero], },
+  { rw [sign_of_pos (int.cast_pos.mpr hp), int.sign_eq_one_of_pos hp, int.cast_one] }
+end
+
+lemma sign_neg {r : ℝ} : sign (-r) = - sign r :=
+begin
+  obtain hn | rfl | hp := lt_trichotomy r (0 : ℝ),
+  { rw [sign_of_neg hn, sign_of_pos (neg_pos.mpr hn), neg_neg] },
+  { rw [sign_zero, neg_zero, sign_zero] },
+  { rw [sign_of_pos hp, sign_of_neg (neg_lt_zero.mpr hp)] },
 end
 
 lemma sign_mul_nonneg (r : ℝ) : 0 ≤ sign r * r :=
 begin
-  by_cases r < 0,
-  { rw sign_of_neg h,
-    exact mul_nonneg_of_nonpos_of_nonpos (by norm_num) (le_of_lt h) },
-  { rw [sign_of_not_neg h, one_mul],
-    exact not_lt.1 h }
+  obtain hn | rfl | hp := lt_trichotomy r (0 : ℝ),
+  { rw sign_of_neg hn,
+    exact mul_nonneg_of_nonpos_of_nonpos (by norm_num) hn.le },
+  { rw mul_zero, },
+  { rw [sign_of_pos hp, one_mul],
+    exact hp.le }
 end
 
 lemma sign_mul_pos_of_ne_zero (r : ℝ) (hr : r ≠ 0) : 0 < sign r * r :=
 begin
-  refine lt_of_le_of_ne (sign_mul_nonneg r) (λ h, _),
-  rw zero_eq_mul at h,
-  cases sign_apply_eq r with hneg hpos;
-  cases h; { linarith <|> exact hr h }
+  refine lt_of_le_of_ne (sign_mul_nonneg r) (λ h, hr _),
+  have hs0 := (zero_eq_mul.mp h).resolve_right hr,
+  exact sign_eq_zero_iff.mp hs0,
 end
 
 @[simp]
 lemma inv_sign (r : ℝ) : (sign r)⁻¹ = sign r :=
 begin
-  cases sign_apply_eq r with h h,
-  { rw h, norm_num },
-  { rw h, exact inv_one }
+  obtain (hn | hz | hp) := sign_apply_eq r,
+  { rw hn, norm_num },
+  { rw hz, exact inv_zero },
+  { rw hp, exact inv_one }
 end
 
 @[simp]
 lemma sign_inv (r : ℝ) : sign r⁻¹ = sign r :=
 begin
-  by_cases r < 0,
-  { rw [sign_of_neg h, sign_of_neg (inv_lt_zero.2 h)] },
-  { rw [sign_of_not_neg h, sign_of_zero_le (inv_nonneg.2 $ not_lt.1 h)] }
+  obtain hn | rfl | hp := lt_trichotomy r (0 : ℝ),
+  { rw [sign_of_neg hn, sign_of_neg (inv_lt_zero.mpr hn)] },
+  { rw [sign_zero, inv_zero, sign_zero] },
+  { rw [sign_of_pos hp, sign_of_pos (inv_pos.mpr hp)] },
 end
 
 end real

--- a/src/data/real/sign.lean
+++ b/src/data/real/sign.lean
@@ -24,7 +24,7 @@ sign function
 
 namespace real
 
-/-- The sign function that maps negative real numbers to -1 and positive numbers to 1. -/
+/-- The sign function that maps negative real numbers to -1, positive numbers to 1, and 0 otherwise. -/
 noncomputable
 def sign (r : ℝ) : ℝ :=
 if r < 0 then -1 else

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -986,7 +986,9 @@ theorem equivalent_one_neg_one_weighted_sum_squared
   ∃ w : fin (finite_dimensional.finrank ℝ M) → ℝ,
   (∀ i, w i = -1 ∨ w i = 1) ∧ equivalent Q (weighted_sum_squares ℝ w) :=
 let ⟨w, ⟨hw₁⟩⟩ := Q.equivalent_weighted_sum_squares_of_nondegenerate' hQ in
-  ⟨sign ∘ coe ∘ w, λ i, sign_apply_eq (w i), ⟨hw₁.trans (isometry_sign_weighted_sum_squares w)⟩⟩
+  ⟨sign ∘ coe ∘ w,
+   λ i, sign_apply_eq_of_ne_zero (w i) (w i).ne_zero,
+   ⟨hw₁.trans (isometry_sign_weighted_sum_squares w)⟩⟩
 
 end real
 


### PR DESCRIPTION
Previously `sign 0 = 1` which is quite an unusual definition. This definition brings things in line with `int.sign`, and include a proof of this fact.

A future refactor could probably introduce a sign for all rings with a partial order

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
