### PR TITLE
[Merged by Bors] - chore(analysis/analytic/composition): remove one `have`

### DIFF
--- a/src/analysis/analytic/composition.lean
+++ b/src/analysis/analytic/composition.lean
@@ -481,7 +481,6 @@ begin
   refine ⟨r, r_pos, nnreal.summable_of_le I _⟩,
   simp_rw div_eq_mul_inv,
   refine summable.mul_left _ _,
-  have h4 : ∀ n : ℕ, 0 < (4 ^ n : ℝ≥0)⁻¹ := λ n, nnreal.inv_pos.2 (pow_pos zero_lt_four _),
   have : ∀ n : ℕ, has_sum (λ c : composition n, (4 ^ n : ℝ≥0)⁻¹) (2 ^ (n - 1) / 4 ^ n),
   { intro n,
     convert has_sum_fintype (λ c : composition n, (4 ^ n : ℝ≥0)⁻¹),


### PR DESCRIPTION
A `have` in a proof is not necessary.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
