### PR TITLE
[Merged by Bors] - feat(algebraic_topology/simplicial_object): Add augment construction

### DIFF
--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -131,7 +131,6 @@ without identifying `n` with `[n].len`.
 def mk_hom {n m : ℕ} (f : (fin (n+1)) →ₘ (fin (m+1))) : [n] ⟶ [m] :=
 simplex_category.hom.mk f
 
-@[simp]
 lemma hom_zero_zero (f : [0] ⟶ [0]) : f = 𝟙 _ :=
 by { ext : 2, dsimp, apply subsingleton.elim }
 

--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -131,6 +131,10 @@ without identifying `n` with `[n].len`.
 def mk_hom {n m : ℕ} (f : (fin (n+1)) →ₘ (fin (m+1))) : [n] ⟶ [m] :=
 simplex_category.hom.mk f
 
+@[simp]
+lemma hom_zero_zero (f : [0] ⟶ [0]) : f = 𝟙 _ :=
+by { ext : 2, dsimp, apply subsingleton.elim }
+
 end
 
 open_locale simplicial

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -246,7 +246,7 @@ def augment (X : simplicial_object C) (X₀ : C) (f : X _[0] ⟶ X₀)
     naturality' := begin
       intros i j g,
       dsimp,
-      rw (show g = g.unop.op, by simp),
+      rw ← (quiver.hom.op_unop : g.unop.op = g),
       simpa only [← X.map_comp, ← category.assoc, category.comp_id, ← op_comp] using w _ _ _,
     end } }
 

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -232,6 +232,28 @@ variable {C}
 
 end augmented
 
+open_locale simplicial
+
+@[simps]
+def augment (X : simplicial_object C) (X₀ : C) (f : X _[0] ⟶ X₀)
+  (w : ∀ (i : simplex_category) (g₁ g₂ : [0] ⟶ i),
+    X.map g₁.op ≫ f = X.map g₂.op ≫ f) : simplicial_object.augmented C :=
+{ left := X,
+  right := X₀,
+  hom :=
+  { app := λ i, X.map (simplex_category.const i.unop 0).op ≫ f,
+    naturality' := begin
+      intros i j g,
+      dsimp,
+      rw (show g = g.unop.op, by simp),
+      simpa only [← X.map_comp, ← category.assoc, category.comp_id, ← op_comp] using w _ _ _,
+    end } }
+
+@[simp]
+lemma augment_hom_zero (X : simplicial_object C) (X₀ : C) (f : X _[0] ⟶ X₀) (w) :
+  (X.augment X₀ f w).hom.app (op [0]) = f :=
+by { dsimp, erw [simplex_category.hom_zero_zero ([0].const 0), X.map_id, category.id_comp] }
+
 end simplicial_object
 
 /-- Cosimplicial objects. -/
@@ -434,6 +456,27 @@ def whiskering (D : Type*) [category.{v} D] :
 variable {C}
 
 end augmented
+
+open_locale simplicial
+
+@[simps]
+def augment (X : cosimplicial_object C) (X₀ : C) (f : X₀ ⟶ X.obj [0])
+  (w : ∀ (i : simplex_category) (g₁ g₂ : [0] ⟶ i),
+    f ≫ X.map g₁ = f ≫ X.map g₂) : cosimplicial_object.augmented C :=
+{ left := X₀,
+  right := X,
+  hom :=
+  { app := λ i, f ≫ X.map (simplex_category.const i 0),
+  naturality' := begin
+    intros i j g,
+    dsimp,
+    simpa [← X.map_comp] using w _ _ _,
+  end } }
+
+@[simp]
+lemma augment_hom_zero (X : cosimplicial_object C) (X₀ : C) (f : X₀ ⟶ X.obj [0]) (w) :
+  (X.augment X₀ f w).hom.app [0] = f :=
+by { dsimp, rw [simplex_category.hom_zero_zero ([0].const 0), X.map_id, category.comp_id] }
 
 end cosimplicial_object
 

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -234,6 +234,7 @@ end augmented
 
 open_locale simplicial
 
+/-- Aaugment a simplicial object with an object. -/
 @[simps]
 def augment (X : simplicial_object C) (X₀ : C) (f : X _[0] ⟶ X₀)
   (w : ∀ (i : simplex_category) (g₁ g₂ : [0] ⟶ i),
@@ -459,6 +460,7 @@ end augmented
 
 open_locale simplicial
 
+/-- Augment a cosimplicial object with an object. -/
 @[simps]
 def augment (X : cosimplicial_object C) (X₀ : C) (f : X₀ ⟶ X.obj [0])
   (w : ∀ (i : simplex_category) (g₁ g₂ : [0] ⟶ i),


### PR DESCRIPTION
Adds the augmentation construction for (co)simplicial objects.

From LTE.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
