### PR TITLE
[Merged by Bors] - chore(data/set/intervals): syntax clean up

### DIFF
--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -108,20 +108,20 @@ set.ext $ λ x, and_comm _ _
 set.ext $ λ x, and_comm _ _
 
 @[simp] lemma nonempty_Icc : (Icc a b).nonempty ↔ a ≤ b :=
-⟨λ ⟨x, hx⟩, le_trans hx.1 hx.2, λ h, ⟨a, left_mem_Icc.2 h⟩⟩
+⟨λ ⟨x, hx⟩, hx.1.trans hx.2, λ h, ⟨a, left_mem_Icc.2 h⟩⟩
 
 @[simp] lemma nonempty_Ico : (Ico a b).nonempty ↔ a < b :=
-⟨λ ⟨x, hx⟩, lt_of_le_of_lt hx.1 hx.2, λ h, ⟨a, left_mem_Ico.2 h⟩⟩
+⟨λ ⟨x, hx⟩, hx.1.trans_lt hx.2, λ h, ⟨a, left_mem_Ico.2 h⟩⟩
 
 @[simp] lemma nonempty_Ioc : (Ioc a b).nonempty ↔ a < b :=
-⟨λ ⟨x, hx⟩, lt_of_lt_of_le hx.1 hx.2, λ h, ⟨b, right_mem_Ioc.2 h⟩⟩
+⟨λ ⟨x, hx⟩, hx.1.trans_le hx.2, λ h, ⟨b, right_mem_Ioc.2 h⟩⟩
 
 @[simp] lemma nonempty_Ici : (Ici a).nonempty := ⟨a, left_mem_Ici⟩
 
 @[simp] lemma nonempty_Iic : (Iic a).nonempty := ⟨a, right_mem_Iic⟩
 
 @[simp] lemma nonempty_Ioo [densely_ordered α] : (Ioo a b).nonempty ↔ a < b :=
-⟨λ ⟨x, ha, hb⟩, lt_trans ha hb, exists_between⟩
+⟨λ ⟨x, ha, hb⟩, ha.trans hb, exists_between⟩
 
 @[simp] lemma nonempty_Ioi [no_top_order α] : (Ioi a).nonempty := no_top a
 
@@ -156,66 +156,66 @@ instance nonempty_Iio_subtype [no_bot_order α] : nonempty (Iio a) :=
 nonempty.to_subtype nonempty_Iio
 
 @[simp] lemma Ioo_eq_empty (h : b ≤ a) : Ioo a b = ∅ :=
-eq_empty_iff_forall_not_mem.2 $ λ x ⟨h₁, h₂⟩, not_le_of_lt (lt_trans h₁ h₂) h
+eq_empty_iff_forall_not_mem.2 $ λ x ⟨h₁, h₂⟩, (h₁.trans h₂).not_le h
 
 @[simp] lemma Ico_eq_empty (h : b ≤ a) : Ico a b = ∅ :=
-eq_empty_iff_forall_not_mem.2 $ λ x ⟨h₁, h₂⟩, not_le_of_lt (lt_of_le_of_lt h₁ h₂) h
+eq_empty_iff_forall_not_mem.2 $ λ x ⟨h₁, h₂⟩, (h₁.trans_lt h₂).not_le h
 
 @[simp] lemma Icc_eq_empty (h : b < a) : Icc a b = ∅ :=
-eq_empty_iff_forall_not_mem.2 $ λ x ⟨h₁, h₂⟩, not_lt_of_le (le_trans h₁ h₂) h
+eq_empty_iff_forall_not_mem.2 $ λ x ⟨h₁, h₂⟩, (h₁.trans h₂).not_lt h
 
 @[simp] lemma Ioc_eq_empty (h : b ≤ a) : Ioc a b = ∅ :=
-eq_empty_iff_forall_not_mem.2 $ λ x ⟨h₁, h₂⟩, not_lt_of_le (le_trans h₂ h) h₁
+eq_empty_iff_forall_not_mem.2 $ λ x ⟨h₁, h₂⟩, (h₂.trans h).not_lt h₁
 
 @[simp] lemma Ioo_self (a : α) : Ioo a a = ∅ := Ioo_eq_empty $ le_refl _
 @[simp] lemma Ico_self (a : α) : Ico a a = ∅ := Ico_eq_empty $ le_refl _
 @[simp] lemma Ioc_self (a : α) : Ioc a a = ∅ := Ioc_eq_empty $ le_refl _
 
 lemma Ici_subset_Ici : Ici a ⊆ Ici b ↔ b ≤ a :=
-⟨λ h, h $ left_mem_Ici, λ h x hx, le_trans h hx⟩
+⟨λ h, h $ left_mem_Ici, λ h x hx, h.trans hx⟩
 
 lemma Iic_subset_Iic : Iic a ⊆ Iic b ↔ a ≤ b :=
 @Ici_subset_Ici (order_dual α) _ _ _
 
 lemma Ici_subset_Ioi : Ici a ⊆ Ioi b ↔ b < a :=
-⟨λ h, h left_mem_Ici, λ h x hx, lt_of_lt_of_le h hx⟩
+⟨λ h, h left_mem_Ici, λ h x hx, h.trans_le hx⟩
 
 lemma Iic_subset_Iio : Iic a ⊆ Iio b ↔ a < b :=
 ⟨λ h, h right_mem_Iic, λ h x hx, lt_of_le_of_lt hx h⟩
 
 lemma Ioo_subset_Ioo (h₁ : a₂ ≤ a₁) (h₂ : b₁ ≤ b₂) :
   Ioo a₁ b₁ ⊆ Ioo a₂ b₂ :=
-λ x ⟨hx₁, hx₂⟩, ⟨lt_of_le_of_lt h₁ hx₁, lt_of_lt_of_le hx₂ h₂⟩
+λ x ⟨hx₁, hx₂⟩, ⟨h₁.trans_lt hx₁, hx₂.trans_le h₂⟩
 
 lemma Ioo_subset_Ioo_left (h : a₁ ≤ a₂) : Ioo a₂ b ⊆ Ioo a₁ b :=
-Ioo_subset_Ioo h (le_refl _)
+Ioo_subset_Ioo h le_rfl
 
 lemma Ioo_subset_Ioo_right (h : b₁ ≤ b₂) : Ioo a b₁ ⊆ Ioo a b₂ :=
-Ioo_subset_Ioo (le_refl _) h
+Ioo_subset_Ioo le_rfl h
 
 lemma Ico_subset_Ico (h₁ : a₂ ≤ a₁) (h₂ : b₁ ≤ b₂) :
   Ico a₁ b₁ ⊆ Ico a₂ b₂ :=
-λ x ⟨hx₁, hx₂⟩, ⟨le_trans h₁ hx₁, lt_of_lt_of_le hx₂ h₂⟩
+λ x ⟨hx₁, hx₂⟩, ⟨h₁.trans hx₁, hx₂.trans_le h₂⟩
 
 lemma Ico_subset_Ico_left (h : a₁ ≤ a₂) : Ico a₂ b ⊆ Ico a₁ b :=
-Ico_subset_Ico h (le_refl _)
+Ico_subset_Ico h le_rfl
 
 lemma Ico_subset_Ico_right (h : b₁ ≤ b₂) : Ico a b₁ ⊆ Ico a b₂ :=
-Ico_subset_Ico (le_refl _) h
+Ico_subset_Ico le_rfl h
 
 lemma Icc_subset_Icc (h₁ : a₂ ≤ a₁) (h₂ : b₁ ≤ b₂) :
   Icc a₁ b₁ ⊆ Icc a₂ b₂ :=
-λ x ⟨hx₁, hx₂⟩, ⟨le_trans h₁ hx₁, le_trans hx₂ h₂⟩
+λ x ⟨hx₁, hx₂⟩, ⟨h₁.trans hx₁, le_trans hx₂ h₂⟩
 
 lemma Icc_subset_Icc_left (h : a₁ ≤ a₂) : Icc a₂ b ⊆ Icc a₁ b :=
-Icc_subset_Icc h (le_refl _)
+Icc_subset_Icc h le_rfl
 
 lemma Icc_subset_Icc_right (h : b₁ ≤ b₂) : Icc a b₁ ⊆ Icc a b₂ :=
-Icc_subset_Icc (le_refl _) h
+Icc_subset_Icc le_rfl h
 
 lemma Icc_subset_Ioo (ha : a₂ < a₁) (hb : b₁ < b₂) :
   Icc a₁ b₁ ⊆ Ioo a₂ b₂ :=
-λ x hx, ⟨lt_of_lt_of_le ha hx.1, lt_of_le_of_lt hx.2 hb⟩
+λ x hx, ⟨ha.trans_le hx.1, hx.2.trans_lt hb⟩
 
 lemma Icc_subset_Ici_self : Icc a b ⊆ Ici a := λ x, and.left
 
@@ -225,22 +225,22 @@ lemma Ioc_subset_Iic_self : Ioc a b ⊆ Iic b := λ x, and.right
 
 lemma Ioc_subset_Ioc (h₁ : a₂ ≤ a₁) (h₂ : b₁ ≤ b₂) :
   Ioc a₁ b₁ ⊆ Ioc a₂ b₂ :=
-λ x ⟨hx₁, hx₂⟩, ⟨lt_of_le_of_lt h₁ hx₁, le_trans hx₂ h₂⟩
+λ x ⟨hx₁, hx₂⟩, ⟨h₁.trans_lt hx₁, hx₂.trans h₂⟩
 
 lemma Ioc_subset_Ioc_left (h : a₁ ≤ a₂) : Ioc a₂ b ⊆ Ioc a₁ b :=
-Ioc_subset_Ioc h (le_refl _)
+Ioc_subset_Ioc h le_rfl
 
 lemma Ioc_subset_Ioc_right (h : b₁ ≤ b₂) : Ioc a b₁ ⊆ Ioc a b₂ :=
-Ioc_subset_Ioc (le_refl _) h
+Ioc_subset_Ioc le_rfl h
 
 lemma Ico_subset_Ioo_left (h₁ : a₁ < a₂) : Ico a₂ b ⊆ Ioo a₁ b :=
-λ x, and.imp_left $ lt_of_lt_of_le h₁
+λ x, and.imp_left h₁.trans_le
 
 lemma Ioc_subset_Ioo_right (h : b₁ < b₂) : Ioc a b₁ ⊆ Ioo a b₂ :=
-λ x, and.imp_right $ λ h', lt_of_le_of_lt h' h
+λ x, and.imp_right $ λ h', h'.trans_lt h
 
 lemma Icc_subset_Ico_right (h₁ : b₁ < b₂) : Icc a b₁ ⊆ Ico a b₂ :=
-λ x, and.imp_right $ λ h₂, lt_of_le_of_lt h₂ h₁
+λ x, and.imp_right $ λ h₂, h₂.trans_lt h₁
 
 lemma Ioo_subset_Ico_self : Ioo a b ⊆ Ico a b := λ x, and.imp_left le_of_lt
 
@@ -261,62 +261,62 @@ lemma Ioc_subset_Ioi_self : Ioc a b ⊆ Ioi a := λ x, and.left
 
 lemma Ioo_subset_Ioi_self : Ioo a b ⊆ Ioi a := λ x, and.left
 
-lemma Ioi_subset_Ici_self : Ioi a ⊆ Ici a := λx hx, le_of_lt hx
+lemma Ioi_subset_Ici_self : Ioi a ⊆ Ici a := λ x hx, le_of_lt hx
 
-lemma Iio_subset_Iic_self : Iio a ⊆ Iic a := λx hx, le_of_lt hx
+lemma Iio_subset_Iic_self : Iio a ⊆ Iic a := λ x hx, le_of_lt hx
 
 lemma Ico_subset_Ici_self : Ico a b ⊆ Ici a := λ x, and.left
 
 lemma Icc_subset_Icc_iff (h₁ : a₁ ≤ b₁) :
   Icc a₁ b₁ ⊆ Icc a₂ b₂ ↔ a₂ ≤ a₁ ∧ b₁ ≤ b₂ :=
-⟨λ h, ⟨(h ⟨le_refl _, h₁⟩).1, (h ⟨h₁, le_refl _⟩).2⟩,
- λ ⟨h, h'⟩ x ⟨hx, hx'⟩, ⟨le_trans h hx, le_trans hx' h'⟩⟩
+⟨λ h, ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩,
+ λ ⟨h, h'⟩ x ⟨hx, hx'⟩, ⟨h.trans hx, hx'.trans h'⟩⟩
 
 lemma Icc_subset_Ioo_iff (h₁ : a₁ ≤ b₁) :
   Icc a₁ b₁ ⊆ Ioo a₂ b₂ ↔ a₂ < a₁ ∧ b₁ < b₂ :=
-⟨λ h, ⟨(h ⟨le_refl _, h₁⟩).1, (h ⟨h₁, le_refl _⟩).2⟩,
- λ ⟨h, h'⟩ x ⟨hx, hx'⟩, ⟨lt_of_lt_of_le h hx, lt_of_le_of_lt hx' h'⟩⟩
+⟨λ h, ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩,
+ λ ⟨h, h'⟩ x ⟨hx, hx'⟩, ⟨h.trans_le hx, hx'.trans_lt h'⟩⟩
 
 lemma Icc_subset_Ico_iff (h₁ : a₁ ≤ b₁) :
   Icc a₁ b₁ ⊆ Ico a₂ b₂ ↔ a₂ ≤ a₁ ∧ b₁ < b₂ :=
-⟨λ h, ⟨(h ⟨le_refl _, h₁⟩).1, (h ⟨h₁, le_refl _⟩).2⟩,
- λ ⟨h, h'⟩ x ⟨hx, hx'⟩, ⟨le_trans h hx, lt_of_le_of_lt hx' h'⟩⟩
+⟨λ h, ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩,
+ λ ⟨h, h'⟩ x ⟨hx, hx'⟩, ⟨h.trans hx, hx'.trans_lt h'⟩⟩
 
 lemma Icc_subset_Ioc_iff (h₁ : a₁ ≤ b₁) :
   Icc a₁ b₁ ⊆ Ioc a₂ b₂ ↔ a₂ < a₁ ∧ b₁ ≤ b₂ :=
-⟨λ h, ⟨(h ⟨le_refl _, h₁⟩).1, (h ⟨h₁, le_refl _⟩).2⟩,
- λ ⟨h, h'⟩ x ⟨hx, hx'⟩, ⟨lt_of_lt_of_le h hx, le_trans hx' h'⟩⟩
+⟨λ h, ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩,
+ λ ⟨h, h'⟩ x ⟨hx, hx'⟩, ⟨h.trans_le hx, hx'.trans h'⟩⟩
 
 lemma Icc_subset_Iio_iff (h₁ : a₁ ≤ b₁) :
   Icc a₁ b₁ ⊆ Iio b₂ ↔ b₁ < b₂ :=
-⟨λ h, h ⟨h₁, le_refl _⟩, λ h x ⟨hx, hx'⟩, lt_of_le_of_lt hx' h⟩
+⟨λ h, h ⟨h₁, le_rfl⟩, λ h x ⟨hx, hx'⟩, hx'.trans_lt h⟩
 
 lemma Icc_subset_Ioi_iff (h₁ : a₁ ≤ b₁) :
   Icc a₁ b₁ ⊆ Ioi a₂ ↔ a₂ < a₁ :=
-⟨λ h, h ⟨le_refl _, h₁⟩, λ h x ⟨hx, hx'⟩, lt_of_lt_of_le h hx⟩
+⟨λ h, h ⟨le_rfl, h₁⟩, λ h x ⟨hx, hx'⟩, h.trans_le hx⟩
 
 lemma Icc_subset_Iic_iff (h₁ : a₁ ≤ b₁) :
   Icc a₁ b₁ ⊆ Iic b₂ ↔ b₁ ≤ b₂ :=
-⟨λ h, h ⟨h₁, le_refl _⟩, λ h x ⟨hx, hx'⟩, le_trans hx' h⟩
+⟨λ h, h ⟨h₁, le_rfl⟩, λ h x ⟨hx, hx'⟩, hx'.trans h⟩
 
 lemma Icc_subset_Ici_iff (h₁ : a₁ ≤ b₁) :
   Icc a₁ b₁ ⊆ Ici a₂ ↔ a₂ ≤ a₁ :=
-⟨λ h, h ⟨le_refl _, h₁⟩, λ h x ⟨hx, hx'⟩, le_trans h hx⟩
+⟨λ h, h ⟨le_rfl, h₁⟩, λ h x ⟨hx, hx'⟩, h.trans hx⟩
 
 lemma Icc_ssubset_Icc_left (hI : a₂ ≤ b₂) (ha : a₂ < a₁) (hb : b₁ ≤ b₂) :
   Icc a₁ b₁ ⊂ Icc a₂ b₂ :=
 (ssubset_iff_of_subset (Icc_subset_Icc (le_of_lt ha) hb)).mpr
-  ⟨a₂, left_mem_Icc.mpr hI, not_and.mpr (λ f g, lt_irrefl a₂ (lt_of_lt_of_le ha f))⟩
+  ⟨a₂, left_mem_Icc.mpr hI, not_and.mpr (λ f g, lt_irrefl a₂ (ha.trans_le f))⟩
 
 lemma Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b₁ < b₂) :
   Icc a₁ b₁ ⊂ Icc a₂ b₂ :=
 (ssubset_iff_of_subset (Icc_subset_Icc ha (le_of_lt hb))).mpr
-  ⟨b₂, right_mem_Icc.mpr hI, (λ f, lt_irrefl b₁ (lt_of_lt_of_le hb f.2))⟩
+  ⟨b₂, right_mem_Icc.mpr hI, (λ f, lt_irrefl b₁ (hb.trans_le f.2))⟩
 
 /-- If `a ≤ b`, then `(b, +∞) ⊆ (a, +∞)`. In preorders, this is just an implication. If you need
 the equivalence in linear orders, use `Ioi_subset_Ioi_iff`. -/
 lemma Ioi_subset_Ioi (h : a ≤ b) : Ioi b ⊆ Ioi a :=
-λx hx, lt_of_le_of_lt h hx
+λ x hx, h.trans_lt hx
 
 /-- If `a ≤ b`, then `(b, +∞) ⊆ [a, +∞)`. In preorders, this is just an implication. If you need
 the equivalence in dense linear orders, use `Ioi_subset_Ici_iff`. -/
@@ -326,7 +326,7 @@ subset.trans (Ioi_subset_Ioi h) Ioi_subset_Ici_self
 /-- If `a ≤ b`, then `(-∞, a) ⊆ (-∞, b)`. In preorders, this is just an implication. If you need
 the equivalence in linear orders, use `Iio_subset_Iio_iff`. -/
 lemma Iio_subset_Iio (h : a ≤ b) : Iio a ⊆ Iio b :=
-λx hx, lt_of_lt_of_le hx h
+λ x hx, lt_of_lt_of_le hx h
 
 /-- If `a ≤ b`, then `(-∞, a) ⊆ (-∞, b]`. In preorders, this is just an implication. If you need
 the equivalence in dense linear orders, use `Iio_subset_Iic_iff`. -/
@@ -475,7 +475,7 @@ end
 lemma Ici_singleton_of_top {a : α} (h_top : ∀ x, x ≤ a) : Ici a = {a} :=
 begin
   ext,
-  exact ⟨λ h, le_antisymm (h_top _) h, λ h, le_of_eq h.symm⟩,
+  exact ⟨λ h, (h_top _).antisymm h, λ h, h.ge⟩,
 end
 
 lemma Iic_singleton_of_bot {a : α} (h_bot : ∀ x, a ≤ x) : Iic a = {a} :=
@@ -576,16 +576,16 @@ lemma Ioo_eq_empty_iff [densely_ordered α] : Ioo a b = ∅ ↔ b ≤ a :=
 Ioo_eq_empty⟩
 
 lemma Ico_eq_empty_iff : Ico a b = ∅ ↔ b ≤ a :=
-⟨λ eq, le_of_not_lt $ λ h, eq_empty_iff_forall_not_mem.1 eq a ⟨le_refl _, h⟩,
+⟨λ eq, le_of_not_lt $ λ h, eq_empty_iff_forall_not_mem.1 eq a ⟨le_rfl, h⟩,
  Ico_eq_empty⟩
 
 lemma Icc_eq_empty_iff : Icc a b = ∅ ↔ b < a :=
-⟨λ eq, lt_of_not_ge $ λ h, eq_empty_iff_forall_not_mem.1 eq a ⟨le_refl _, h⟩,
+⟨λ eq, lt_of_not_ge $ λ h, eq_empty_iff_forall_not_mem.1 eq a ⟨le_rfl, h⟩,
  Icc_eq_empty⟩
 
 lemma Ico_subset_Ico_iff (h₁ : a₁ < b₁) :
   Ico a₁ b₁ ⊆ Ico a₂ b₂ ↔ a₂ ≤ a₁ ∧ b₁ ≤ b₂ :=
-⟨λ h, have a₂ ≤ a₁ ∧ a₁ < b₂ := h ⟨le_refl _, h₁⟩,
+⟨λ h, have a₂ ≤ a₁ ∧ a₁ < b₂ := h ⟨le_rfl, h₁⟩,
   ⟨this.1, le_of_not_lt $ λ h', lt_irrefl b₂ (h ⟨le_of_lt this.2, h'⟩).2⟩,
  λ ⟨h₁, h₂⟩, Ico_subset_Ico h₁ h₂⟩
 
@@ -594,9 +594,9 @@ lemma Ioo_subset_Ioo_iff [densely_ordered α] (h₁ : a₁ < b₁) :
 ⟨λ h, begin
   rcases exists_between h₁ with ⟨x, xa, xb⟩,
   split; refine le_of_not_lt (λ h', _),
-  { have ab := lt_trans (h ⟨xa, xb⟩).1 xb,
+  { have ab := (h ⟨xa, xb⟩).1.trans xb,
     exact lt_irrefl _ (h ⟨h', ab⟩).1 },
-  { have ab := lt_trans xa (h ⟨xa, xb⟩).2,
+  { have ab := xa.trans (h ⟨xa, xb⟩).2,
     exact lt_irrefl _ (h ⟨ab, h'⟩).2 }
 end, λ ⟨h₁, h₂⟩, Ioo_subset_Ioo h₁ h₂⟩
 
@@ -605,7 +605,7 @@ lemma Ico_eq_Ico_iff (h : a₁ < b₁ ∨ a₂ < b₂) : Ico a₁ b₁ = Ico a�
   simp [subset.antisymm_iff] at e, simp [le_antisymm_iff],
   cases h; simp [Ico_subset_Ico_iff h] at e;
     [ rcases e with ⟨⟨h₁, h₂⟩, e'⟩, rcases e with ⟨e', ⟨h₁, h₂⟩⟩ ];
-    have := (Ico_subset_Ico_iff (lt_of_le_of_lt h₁ $ lt_of_lt_of_le h h₂)).1 e';
+    have := (Ico_subset_Ico_iff $ h₁.trans_lt $ h.trans_le h₂).1 e';
     tauto
 end, λ ⟨h₁, h₂⟩, by rw [h₁, h₂]⟩
 
@@ -613,22 +613,22 @@ open_locale classical
 
 @[simp] lemma Ioi_subset_Ioi_iff : Ioi b ⊆ Ioi a ↔ a ≤ b :=
 begin
-  refine ⟨λh, _, λh, Ioi_subset_Ioi h⟩,
+  refine ⟨λ h, _, λ h, Ioi_subset_Ioi h⟩,
   by_contradiction ba,
   exact lt_irrefl _ (h (not_le.mp ba))
 end
 
 @[simp] lemma Ioi_subset_Ici_iff [densely_ordered α] : Ioi b ⊆ Ici a ↔ a ≤ b :=
 begin
-  refine ⟨λh, _, λh, Ioi_subset_Ici h⟩,
+  refine ⟨λ h, _, λ h, Ioi_subset_Ici h⟩,
   by_contradiction ba,
   obtain ⟨c, bc, ca⟩ : ∃c, b < c ∧ c < a := exists_between (not_le.mp ba),
-  exact lt_irrefl _ (lt_of_lt_of_le ca (h bc))
+  exact lt_irrefl _ (ca.trans_le (h bc))
 end
 
 @[simp] lemma Iio_subset_Iio_iff : Iio a ⊆ Iio b ↔ a ≤ b :=
 begin
-  refine ⟨λh, _, λh, Iio_subset_Iio h⟩,
+  refine ⟨λ h, _, λ h, Iio_subset_Iio h⟩,
   by_contradiction ab,
   exact lt_irrefl _ (h (not_le.mp ab))
 end
@@ -654,31 +654,31 @@ begin
   ext1 x,
   simp_rw [mem_union, mem_Ioo, mem_Ioi, min_lt_iff],
   by_cases hc : c < x,
-  { tauto, },
-  { have hxb : x < b, from lt_of_le_of_lt (le_of_not_gt hc) h₁,
-    tauto, },
+  { tauto },
+  { have hxb : x < b := (le_of_not_gt hc).trans_lt h₁,
+    tauto },
 end
 
 lemma Ioo_union_Ioi (h : c < max a b) :
   Ioo a b ∪ Ioi c = Ioi (min a c) :=
 begin
   cases le_total a b with hab hab; simp [hab] at h,
-  { exact Ioo_union_Ioi' h, },
+  { exact Ioo_union_Ioi' h },
   { rw min_comm,
-    simp [*, min_eq_left_of_lt], },
+    simp [*, min_eq_left_of_lt] },
 end
 
 lemma Ioi_subset_Ioo_union_Ici : Ioi a ⊆ Ioo a b ∪ Ici b :=
 λ x hx, (lt_or_le x b).elim (λ hxb, or.inl ⟨hx, hxb⟩) (λ hxb, or.inr hxb)
 
 @[simp] lemma Ioo_union_Ici_eq_Ioi (h : a < b) : Ioo a b ∪ Ici b = Ioi a :=
-subset.antisymm (λ x hx, hx.elim and.left (lt_of_lt_of_le h)) Ioi_subset_Ioo_union_Ici
+subset.antisymm (λ x hx, hx.elim and.left h.trans_le) Ioi_subset_Ioo_union_Ici
 
 lemma Ici_subset_Ico_union_Ici : Ici a ⊆ Ico a b ∪ Ici b :=
 λ x hx, (lt_or_le x b).elim (λ hxb, or.inl ⟨hx, hxb⟩) (λ hxb, or.inr hxb)
 
 @[simp] lemma Ico_union_Ici_eq_Ici (h : a ≤ b) : Ico a b ∪ Ici b = Ici a :=
-subset.antisymm (λ x hx, hx.elim and.left (le_trans h)) Ici_subset_Ico_union_Ici
+subset.antisymm (λ x hx, hx.elim and.left h.trans) Ici_subset_Ico_union_Ici
 
 lemma Ico_union_Ici' (h₁ : c ≤ b) :
   Ico a b ∪ Ici c = Ici (min a c) :=
@@ -686,16 +686,16 @@ begin
   ext1 x,
   simp_rw [mem_union, mem_Ico, mem_Ici, min_le_iff],
   by_cases hc : c ≤ x,
-  { tauto, },
-  { have hxb : x < b, from lt_of_lt_of_le (lt_of_not_ge hc) h₁,
-    tauto, },
+  { tauto },
+  { have hxb : x < b := (lt_of_not_ge hc).trans_le h₁,
+    tauto },
 end
 
 lemma Ico_union_Ici  (h : c ≤ max a b) :
   Ico a b ∪ Ici c = Ici (min a c) :=
 begin
   cases le_total a b with hab hab; simp [hab] at h,
-  { exact Ico_union_Ici' h, },
+  { exact Ico_union_Ici' h },
   { simp [*] },
 end
 
@@ -703,7 +703,7 @@ lemma Ioi_subset_Ioc_union_Ioi : Ioi a ⊆ Ioc a b ∪ Ioi b :=
 λ x hx, (le_or_lt x b).elim (λ hxb, or.inl ⟨hx, hxb⟩) (λ hxb, or.inr hxb)
 
 @[simp] lemma Ioc_union_Ioi_eq_Ioi (h : a ≤ b) : Ioc a b ∪ Ioi b = Ioi a :=
-subset.antisymm (λ x hx, hx.elim and.left (lt_of_le_of_lt h)) Ioi_subset_Ioc_union_Ioi
+subset.antisymm (λ x hx, hx.elim and.left h.trans_lt) Ioi_subset_Ioc_union_Ioi
 
 lemma Ioc_union_Ioi' (h₁ : c ≤ b) :
   Ioc a b ∪ Ioi c = Ioi (min a c) :=
@@ -711,16 +711,16 @@ begin
   ext1 x,
   simp_rw [mem_union, mem_Ioc, mem_Ioi, min_lt_iff],
   by_cases hc : c < x,
-  { tauto, },
-  { have hxb : x ≤ b, from le_trans (le_of_not_gt hc) h₁,
-    tauto, },
+  { tauto },
+  { have hxb : x ≤ b := (le_of_not_gt hc).trans h₁,
+    tauto },
 end
 
 lemma Ioc_union_Ioi (h : c ≤ max a b) :
   Ioc a b ∪ Ioi c = Ioi (min a c) :=
 begin
   cases le_total a b with hab hab; simp [hab] at h,
-  { exact Ioc_union_Ioi' h, },
+  { exact Ioc_union_Ioi' h },
   { simp [*] },
 end
 
@@ -728,19 +728,19 @@ lemma Ici_subset_Icc_union_Ioi : Ici a ⊆ Icc a b ∪ Ioi b :=
 λ x hx, (le_or_lt x b).elim (λ hxb, or.inl ⟨hx, hxb⟩) (λ hxb, or.inr hxb)
 
 @[simp] lemma Icc_union_Ioi_eq_Ici (h : a ≤ b) : Icc a b ∪ Ioi b = Ici a :=
-subset.antisymm (λ x hx, hx.elim and.left (λ hx, le_trans h (le_of_lt hx))) Ici_subset_Icc_union_Ioi
+subset.antisymm (λ x hx, hx.elim and.left $ λ hx', h.trans $ le_of_lt hx') Ici_subset_Icc_union_Ioi
 
 lemma Ioi_subset_Ioc_union_Ici : Ioi a ⊆ Ioc a b ∪ Ici b :=
 subset.trans Ioi_subset_Ioo_union_Ici (union_subset_union_left _ Ioo_subset_Ioc_self)
 
 @[simp] lemma Ioc_union_Ici_eq_Ioi (h : a < b) : Ioc a b ∪ Ici b = Ioi a :=
-subset.antisymm (λ x hx, hx.elim and.left (lt_of_lt_of_le h)) Ioi_subset_Ioc_union_Ici
+subset.antisymm (λ x hx, hx.elim and.left h.trans_le) Ioi_subset_Ioc_union_Ici
 
 lemma Ici_subset_Icc_union_Ici : Ici a ⊆ Icc a b ∪ Ici b :=
 subset.trans Ici_subset_Ico_union_Ici (union_subset_union_left _ Ico_subset_Icc_self)
 
 @[simp] lemma Icc_union_Ici_eq_Ici (h : a ≤ b) : Icc a b ∪ Ici b = Ici a :=
-subset.antisymm (λ x hx, hx.elim and.left (le_trans h)) Ici_subset_Icc_union_Ici
+subset.antisymm (λ x hx, hx.elim and.left h.trans) Ici_subset_Icc_union_Ici
 
 lemma Icc_union_Ici' (h₁ : c ≤ b) :
   Icc a b ∪ Ici c = Ici (min a c) :=
@@ -748,20 +748,20 @@ begin
   ext1 x,
   simp_rw [mem_union, mem_Icc, mem_Ici, min_le_iff],
   by_cases hc : c ≤ x,
-  { tauto, },
-  { have hxb : x ≤ b, from le_trans (le_of_not_ge hc) h₁,
-    tauto, },
+  { tauto },
+  { have hxb : x ≤ b := (le_of_not_ge hc).trans h₁,
+    tauto },
 end
 
 lemma Icc_union_Ici (h : c ≤ max a b) :
   Icc a b ∪ Ici c = Ici (min a c) :=
 begin
   cases le_or_lt a b with hab hab; simp [hab] at h,
-  { exact Icc_union_Ici' h, },
+  { exact Icc_union_Ici' h },
   { cases h,
-    { simp [*], },
-    { have hca : c ≤ a, from le_trans h (le_of_lt hab),
-      simp [*], }, },
+    { simp [*] },
+    { have hca : c ≤ a := h.trans hab.le,
+      simp [*] } },
 end
 
 /-! #### An infinite and a finite interval -/
@@ -770,14 +770,14 @@ lemma Iic_subset_Iio_union_Icc : Iic b ⊆ Iio a ∪ Icc a b :=
 λ x hx, (lt_or_le x a).elim (λ hxa, or.inl hxa) (λ hxa, or.inr ⟨hxa, hx⟩)
 
 @[simp] lemma Iio_union_Icc_eq_Iic (h : a ≤ b) : Iio a ∪ Icc a b = Iic b :=
-subset.antisymm (λ x hx, hx.elim (λ hx, le_trans (le_of_lt hx) h) and.right)
+subset.antisymm (λ x hx, hx.elim (λ hx, (le_of_lt hx).trans h) and.right)
   Iic_subset_Iio_union_Icc
 
 lemma Iio_subset_Iio_union_Ico : Iio b ⊆ Iio a ∪ Ico a b :=
 λ x hx, (lt_or_le x a).elim (λ hxa, or.inl hxa) (λ hxa, or.inr ⟨hxa, hx⟩)
 
 @[simp] lemma Iio_union_Ico_eq_Iio (h : a ≤ b) : Iio a ∪ Ico a b = Iio b :=
-subset.antisymm (λ x hx, hx.elim (λ hx, lt_of_lt_of_le hx h) and.right) Iio_subset_Iio_union_Ico
+subset.antisymm (λ x hx, hx.elim (λ hx', lt_of_lt_of_le hx' h) and.right) Iio_subset_Iio_union_Ico
 
 lemma Iio_union_Ico' (h₁ : c ≤ b) :
   Iio b ∪ Ico c d = Iio (max b d) :=
@@ -785,16 +785,16 @@ begin
   ext1 x,
   simp_rw [mem_union, mem_Iio, mem_Ico, lt_max_iff],
   by_cases hc : c ≤ x,
-  { tauto, },
-  { have hxb : x < b, from lt_of_lt_of_le (lt_of_not_ge hc) h₁,
-    tauto, },
+  { tauto },
+  { have hxb : x < b := (lt_of_not_ge hc).trans_le h₁,
+    tauto },
 end
 
 lemma Iio_union_Ico (h : min c d ≤ b) :
   Iio b ∪ Ico c d = Iio (max b d) :=
 begin
   cases le_total c d with hcd hcd; simp [hcd] at h,
-  { exact Iio_union_Ico' h, },
+  { exact Iio_union_Ico' h },
   { simp [*] },
 end
 
@@ -802,7 +802,7 @@ lemma Iic_subset_Iic_union_Ioc : Iic b ⊆ Iic a ∪ Ioc a b :=
 λ x hx, (le_or_lt x a).elim (λ hxa, or.inl hxa) (λ hxa, or.inr ⟨hxa, hx⟩)
 
 @[simp] lemma Iic_union_Ioc_eq_Iic (h : a ≤ b) : Iic a ∪ Ioc a b = Iic b :=
-subset.antisymm (λ x hx, hx.elim (λ hx, le_trans hx h) and.right) Iic_subset_Iic_union_Ioc
+subset.antisymm (λ x hx, hx.elim (λ hx', le_trans hx' h) and.right) Iic_subset_Iic_union_Ioc
 
 lemma Iic_union_Ioc' (h₁ : c < b) :
   Iic b ∪ Ioc c d = Iic (max b d) :=
@@ -810,25 +810,25 @@ begin
   ext1 x,
   simp_rw [mem_union, mem_Iic, mem_Ioc, le_max_iff],
   by_cases hc : c < x,
-  { tauto, },
-  { have hxb : x ≤ b, from le_trans (le_of_not_gt hc) (le_of_lt h₁),
-    tauto, },
+  { tauto },
+  { have hxb : x ≤ b := (le_of_not_gt hc).trans h₁.le,
+    tauto },
 end
 
 lemma Iic_union_Ioc (h : min c d < b) :
   Iic b ∪ Ioc c d = Iic (max b d) :=
 begin
   cases le_total c d with hcd hcd; simp [hcd] at h,
-  { exact Iic_union_Ioc' h, },
+  { exact Iic_union_Ioc' h },
   { rw max_comm,
-    simp [*, max_eq_right_of_lt h], },
+    simp [*, max_eq_right_of_lt h] },
 end
 
 lemma Iio_subset_Iic_union_Ioo : Iio b ⊆ Iic a ∪ Ioo a b :=
 λ x hx, (le_or_lt x a).elim (λ hxa, or.inl hxa) (λ hxa, or.inr ⟨hxa, hx⟩)
 
 @[simp] lemma Iic_union_Ioo_eq_Iio (h : a < b) : Iic a ∪ Ioo a b = Iio b :=
-subset.antisymm (λ x hx, hx.elim (λ hx, lt_of_le_of_lt hx h) and.right) Iio_subset_Iic_union_Ioo
+subset.antisymm (λ x hx, hx.elim (λ hx', lt_of_le_of_lt hx' h) and.right) Iio_subset_Iic_union_Ioo
 
 lemma Iio_union_Ioo' (h₁ : c < b) :
   Iio b ∪ Ioo c d = Iio (max b d) :=
@@ -845,16 +845,16 @@ lemma Iio_union_Ioo (h : min c d < b) :
   Iio b ∪ Ioo c d = Iio (max b d) :=
 begin
   cases le_total c d with hcd hcd; simp [hcd] at h,
-  { exact Iio_union_Ioo' h, },
+  { exact Iio_union_Ioo' h },
   { rw max_comm,
-    simp [*, max_eq_right_of_lt h], },
+    simp [*, max_eq_right_of_lt h] },
 end
 
 lemma Iic_subset_Iic_union_Icc : Iic b ⊆ Iic a ∪ Icc a b :=
 subset.trans Iic_subset_Iic_union_Ioc (union_subset_union_right _ Ioc_subset_Icc_self)
 
 @[simp] lemma Iic_union_Icc_eq_Iic (h : a ≤ b) : Iic a ∪ Icc a b = Iic b :=
-subset.antisymm (λ x hx, hx.elim (λ hx, le_trans hx h) and.right) Iic_subset_Iic_union_Icc
+subset.antisymm (λ x hx, hx.elim (λ hx', le_trans hx' h) and.right) Iic_subset_Iic_union_Icc
 
 lemma Iic_union_Icc' (h₁ : c ≤ b) :
   Iic b ∪ Icc c d = Iic (max b d) :=
@@ -862,27 +862,27 @@ begin
   ext1 x,
   simp_rw [mem_union, mem_Iic, mem_Icc, le_max_iff],
   by_cases hc : c ≤ x,
-  { tauto, },
-  { have hxb : x ≤ b, from le_trans (le_of_not_ge hc) h₁,
-    tauto, },
+  { tauto },
+  { have hxb : x ≤ b := (le_of_not_ge hc).trans h₁,
+    tauto },
 end
 
 lemma Iic_union_Icc (h : min c d ≤ b) :
   Iic b ∪ Icc c d = Iic (max b d) :=
 begin
   cases le_or_lt c d with hcd hcd; simp [hcd] at h,
-  { exact Iic_union_Icc' h, },
+  { exact Iic_union_Icc' h },
   { cases h,
-    { have hdb : d ≤ b, from le_trans (le_of_lt hcd) h,
-      simp [*], },
-    { simp [*], }, },
+    { have hdb : d ≤ b := hcd.le.trans h,
+      simp [*] },
+    { simp [*] } },
 end
 
 lemma Iio_subset_Iic_union_Ico : Iio b ⊆ Iic a ∪ Ico a b :=
 subset.trans Iio_subset_Iic_union_Ioo (union_subset_union_right _ Ioo_subset_Ico_self)
 
 @[simp] lemma Iic_union_Ico_eq_Iio (h : a < b) : Iic a ∪ Ico a b = Iio b :=
-subset.antisymm (λ x hx, hx.elim (λ hx, lt_of_le_of_lt hx h) and.right) Iio_subset_Iic_union_Ico
+subset.antisymm (λ x hx, hx.elim (λ hx', lt_of_le_of_lt hx' h) and.right) Iio_subset_Iic_union_Ico
 
 /-! #### Two finite intervals, `I?o` and `Ic?` -/
 
@@ -891,7 +891,7 @@ lemma Ioo_subset_Ioo_union_Ico : Ioo a c ⊆ Ioo a b ∪ Ico b c :=
 
 @[simp] lemma Ioo_union_Ico_eq_Ioo (h₁ : a < b) (h₂ : b ≤ c) : Ioo a b ∪ Ico b c = Ioo a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, lt_of_lt_of_le hx.2 h₂⟩) (λ hx, ⟨lt_of_lt_of_le h₁ hx.1, hx.2⟩))
+  (λ x hx, hx.elim (λ hx, ⟨hx.1, hx.2.trans_le h₂⟩) (λ hx, ⟨h₁.trans_le hx.1, hx.2⟩))
   Ioo_subset_Ioo_union_Ico
 
 lemma Ico_subset_Ico_union_Ico : Ico a c ⊆ Ico a b ∪ Ico b c :=
@@ -899,7 +899,7 @@ lemma Ico_subset_Ico_union_Ico : Ico a c ⊆ Ico a b ∪ Ico b c :=
 
 @[simp] lemma Ico_union_Ico_eq_Ico (h₁ : a ≤ b) (h₂ : b ≤ c) : Ico a b ∪ Ico b c = Ico a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, lt_of_lt_of_le hx.2 h₂⟩) (λ hx, ⟨le_trans h₁ hx.1, hx.2⟩))
+  (λ x hx, hx.elim (λ hx, ⟨hx.1, hx.2.trans_le h₂⟩) (λ hx, ⟨h₁.trans hx.1, hx.2⟩))
   Ico_subset_Ico_union_Ico
 
 lemma Ico_union_Ico' (h₁ : c ≤ b) (h₂ : a ≤ d) :
@@ -908,19 +908,19 @@ begin
   ext1 x,
   simp_rw [mem_union, mem_Ico, min_le_iff, lt_max_iff],
   by_cases hc : c ≤ x; by_cases hd : x < d,
-  { tauto, },
-  { have hax : a ≤ x, from le_trans h₂ (le_of_not_gt hd),
-    tauto, },
-  { have hxb : x < b, from lt_of_lt_of_le (lt_of_not_ge hc) h₁,
-    tauto, },
-  { tauto, },
+  { tauto },
+  { have hax : a ≤ x := h₂.trans (le_of_not_gt hd),
+    tauto },
+  { have hxb : x < b := (lt_of_not_ge hc).trans_le h₁,
+    tauto },
+  { tauto },
 end
 
 lemma Ico_union_Ico (h₁ : min a b ≤ max c d) (h₂ : min c d ≤ max a b) :
   Ico a b ∪ Ico c d = Ico (min a c) (max b d) :=
 begin
   cases le_total a b with hab hab; cases le_total c d with hcd hcd; simp [hab, hcd] at h₁ h₂,
-  { exact Ico_union_Ico' h₂ h₁, },
+  { exact Ico_union_Ico' h₂ h₁ },
   all_goals { simp [*] },
 end
 
@@ -929,7 +929,7 @@ lemma Icc_subset_Ico_union_Icc : Icc a c ⊆ Ico a b ∪ Icc b c :=
 
 @[simp] lemma Ico_union_Icc_eq_Icc (h₁ : a ≤ b) (h₂ : b ≤ c) : Ico a b ∪ Icc b c = Icc a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, le_trans (le_of_lt hx.2) h₂⟩) (λ hx, ⟨le_trans h₁ hx.1, hx.2⟩))
+  (λ x hx, hx.elim (λ hx, ⟨hx.1, hx.2.le.trans h₂⟩) (λ hx, ⟨h₁.trans hx.1, hx.2⟩))
   Icc_subset_Ico_union_Icc
 
 lemma Ioc_subset_Ioo_union_Icc : Ioc a c ⊆ Ioo a b ∪ Icc b c :=
@@ -937,8 +937,8 @@ lemma Ioc_subset_Ioo_union_Icc : Ioc a c ⊆ Ioo a b ∪ Icc b c :=
 
 @[simp] lemma Ioo_union_Icc_eq_Ioc (h₁ : a < b) (h₂ : b ≤ c) : Ioo a b ∪ Icc b c = Ioc a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, le_trans (le_of_lt hx.2) h₂⟩)
-    (λ hx, ⟨lt_of_lt_of_le h₁ hx.1, hx.2⟩))
+  (λ x hx, hx.elim (λ hx, ⟨hx.1, hx.2.le.trans h₂⟩)
+    (λ hx, ⟨h₁.trans_le hx.1, hx.2⟩))
   Ioc_subset_Ioo_union_Icc
 
 /-! #### Two finite intervals, `I?c` and `Io?` -/
@@ -948,7 +948,7 @@ lemma Ioo_subset_Ioc_union_Ioo : Ioo a c ⊆ Ioc a b ∪ Ioo b c :=
 
 @[simp] lemma Ioc_union_Ioo_eq_Ioo (h₁ : a ≤ b) (h₂ : b < c) : Ioc a b ∪ Ioo b c = Ioo a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, lt_of_le_of_lt hx.2 h₂⟩) (λ hx, ⟨lt_of_le_of_lt h₁ hx.1, hx.2⟩))
+  (λ x hx, hx.elim (λ hx, ⟨hx.1, hx.2.trans_lt h₂⟩) (λ hx, ⟨h₁.trans_lt hx.1, hx.2⟩))
   Ioo_subset_Ioc_union_Ioo
 
 lemma Ico_subset_Icc_union_Ioo : Ico a c ⊆ Icc a b ∪ Ioo b c :=
@@ -956,8 +956,8 @@ lemma Ico_subset_Icc_union_Ioo : Ico a c ⊆ Icc a b ∪ Ioo b c :=
 
 @[simp] lemma Icc_union_Ioo_eq_Ico (h₁ : a ≤ b) (h₂ : b < c) : Icc a b ∪ Ioo b c = Ico a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, lt_of_le_of_lt hx.2 h₂⟩)
-    (λ hx, ⟨le_trans h₁ (le_of_lt hx.1), hx.2⟩))
+  (λ x hx, hx.elim (λ hx, ⟨hx.1, hx.2.trans_lt h₂⟩)
+    (λ hx, ⟨h₁.trans hx.1.le, hx.2⟩))
   Ico_subset_Icc_union_Ioo
 
 lemma Icc_subset_Icc_union_Ioc : Icc a c ⊆ Icc a b ∪ Ioc b c :=
@@ -965,7 +965,7 @@ lemma Icc_subset_Icc_union_Ioc : Icc a c ⊆ Icc a b ∪ Ioc b c :=
 
 @[simp] lemma Icc_union_Ioc_eq_Icc (h₁ : a ≤ b) (h₂ : b ≤ c) : Icc a b ∪ Ioc b c = Icc a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, le_trans hx.2 h₂⟩) (λ hx, ⟨le_trans h₁ (le_of_lt hx.1), hx.2⟩))
+  (λ x hx, hx.elim (λ hx, ⟨hx.1, hx.2.trans h₂⟩) (λ hx, ⟨h₁.trans hx.1.le, hx.2⟩))
   Icc_subset_Icc_union_Ioc
 
 lemma Ioc_subset_Ioc_union_Ioc : Ioc a c ⊆ Ioc a b ∪ Ioc b c :=
@@ -973,7 +973,7 @@ lemma Ioc_subset_Ioc_union_Ioc : Ioc a c ⊆ Ioc a b ∪ Ioc b c :=
 
 @[simp] lemma Ioc_union_Ioc_eq_Ioc (h₁ : a ≤ b) (h₂ : b ≤ c) : Ioc a b ∪ Ioc b c = Ioc a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, le_trans hx.2 h₂⟩) (λ hx, ⟨lt_of_le_of_lt h₁ hx.1, hx.2⟩))
+  (λ x hx, hx.elim (λ hx, ⟨hx.1, hx.2.trans h₂⟩) (λ hx, ⟨h₁.trans_lt hx.1, hx.2⟩))
   Ioc_subset_Ioc_union_Ioc
 
 lemma Ioc_union_Ioc' (h₁ : c ≤ b) (h₂ : a ≤ d) :
@@ -982,19 +982,19 @@ begin
   ext1 x,
   simp_rw [mem_union, mem_Ioc, min_lt_iff, le_max_iff],
   by_cases hc : c < x; by_cases hd : x ≤ d,
-  { tauto, },
-  { have hax : a < x, from lt_of_le_of_lt h₂ (lt_of_not_ge hd),
-    tauto, },
-  { have hxb : x ≤ b, from le_trans (le_of_not_gt hc) h₁,
-    tauto, },
-  { tauto, },
+  { tauto },
+  { have hax : a < x := h₂.trans_lt (lt_of_not_ge hd),
+    tauto },
+  { have hxb : x ≤ b := (le_of_not_gt hc).trans h₁,
+    tauto },
+  { tauto },
 end
 
 lemma Ioc_union_Ioc (h₁ : min a b ≤ max c d) (h₂ : min c d ≤ max a b) :
   Ioc a b ∪ Ioc c d = Ioc (min a c) (max b d) :=
 begin
   cases le_total a b with hab hab; cases le_total c d with hcd hcd; simp [hab, hcd] at h₁ h₂,
-  { exact Ioc_union_Ioc' h₂ h₁, },
+  { exact Ioc_union_Ioc' h₂ h₁ },
   all_goals { simp [*] },
 end
 
@@ -1005,7 +1005,7 @@ subset.trans Ioo_subset_Ioc_union_Ioo (union_subset_union_right _ Ioo_subset_Ico
 
 @[simp] lemma Ioc_union_Ico_eq_Ioo (h₁ : a < b) (h₂ : b < c) : Ioc a b ∪ Ico b c = Ioo a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, lt_of_le_of_lt hx.2 h₂⟩) (λ hx, ⟨lt_of_lt_of_le h₁ hx.1, hx.2⟩))
+  (λ x hx, hx.elim (λ hx', ⟨hx'.1, hx'.2.trans_lt h₂⟩) (λ hx', ⟨h₁.trans_le hx'.1, hx'.2⟩))
   Ioo_subset_Ioc_union_Ico
 
 lemma Ico_subset_Icc_union_Ico : Ico a c ⊆ Icc a b ∪ Ico b c :=
@@ -1013,7 +1013,7 @@ subset.trans Ico_subset_Icc_union_Ioo (union_subset_union_right _ Ioo_subset_Ico
 
 @[simp] lemma Icc_union_Ico_eq_Ico (h₁ : a ≤ b) (h₂ : b < c) : Icc a b ∪ Ico b c = Ico a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, lt_of_le_of_lt hx.2 h₂⟩) (λ hx, ⟨le_trans h₁ hx.1, hx.2⟩))
+  (λ x hx, hx.elim (λ hx, ⟨hx.1, hx.2.trans_lt h₂⟩) (λ hx, ⟨h₁.trans hx.1, hx.2⟩))
   Ico_subset_Icc_union_Ico
 
 lemma Icc_subset_Icc_union_Icc : Icc a c ⊆ Icc a b ∪ Icc b c :=
@@ -1021,7 +1021,7 @@ subset.trans Icc_subset_Icc_union_Ioc (union_subset_union_right _ Ioc_subset_Icc
 
 @[simp] lemma Icc_union_Icc_eq_Icc (h₁ : a ≤ b) (h₂ : b ≤ c) : Icc a b ∪ Icc b c = Icc a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, le_trans hx.2 h₂⟩) (λ hx, ⟨le_trans h₁ hx.1, hx.2⟩))
+  (λ x hx, hx.elim (λ hx, ⟨hx.1, hx.2.trans h₂⟩) (λ hx, ⟨h₁.trans hx.1, hx.2⟩))
   Icc_subset_Icc_union_Icc
 
 lemma Icc_union_Icc' (h₁ : c ≤ b) (h₂ : a ≤ d) :
@@ -1030,12 +1030,12 @@ begin
   ext1 x,
   simp_rw [mem_union, mem_Icc, min_le_iff, le_max_iff],
   by_cases hc : c ≤ x; by_cases hd : x ≤ d,
-  { tauto, },
-  { have hax : a ≤ x, from le_trans h₂ (le_of_not_ge hd),
-    tauto, },
-  { have hxb : x ≤ b, from le_trans (le_of_not_ge hc) h₁,
-    tauto, },
-  { tauto, },
+  { tauto },
+  { have hax : a ≤ x :=.trans h₂ (le_of_not_ge hd),
+    tauto },
+  { have hxb : x ≤ b :=.trans (le_of_not_ge hc) h₁,
+    tauto },
+  { tauto },
 end
 
 /--
@@ -1048,9 +1048,9 @@ begin
   cases le_or_lt a b with hab hab; cases le_or_lt c d with hcd hcd;
     simp only [min_eq_left, min_eq_right, max_eq_left, max_eq_right, min_eq_left_of_lt,
     min_eq_right_of_lt, max_eq_left_of_lt, max_eq_right_of_lt, hab, hcd] at h₁ h₂,
-  { exact Icc_union_Icc' (le_of_lt h₂) (le_of_lt h₁), },
+  { exact Icc_union_Icc' (le_of_lt h₂) (le_of_lt h₁) },
   all_goals { simp [*, min_eq_left_of_lt, max_eq_left_of_lt, min_eq_right_of_lt,
-    max_eq_right_of_lt], },
+    max_eq_right_of_lt] },
 end
 
 lemma Ioc_subset_Ioc_union_Icc : Ioc a c ⊆ Ioc a b ∪ Icc b c :=
@@ -1058,7 +1058,7 @@ subset.trans Ioc_subset_Ioc_union_Ioc (union_subset_union_right _ Ioc_subset_Icc
 
 @[simp] lemma Ioc_union_Icc_eq_Ioc (h₁ : a < b) (h₂ : b ≤ c) : Ioc a b ∪ Icc b c = Ioc a c :=
 subset.antisymm
-  (λ x hx, hx.elim (λ hx, ⟨hx.1, le_trans hx.2 h₂⟩) (λ hx, ⟨lt_of_lt_of_le h₁ hx.1, hx.2⟩))
+  (λ x hx, hx.elim (λ hx, ⟨hx.1, hx.2.trans h₂⟩) (λ hx, ⟨h₁.trans_le hx.1, hx.2⟩))
   Ioc_subset_Ioc_union_Icc
 
 lemma Ioo_union_Ioo' (h₁ : c < b) (h₂ : a < d) :
@@ -1066,13 +1066,13 @@ lemma Ioo_union_Ioo' (h₁ : c < b) (h₂ : a < d) :
 begin
   ext1 x,
   simp_rw [mem_union, mem_Ioo, min_lt_iff, lt_max_iff],
-  by_cases hc : c < x; by_cases hd : x < d,
-  { tauto, },
-  { have hax : a < x, from lt_of_lt_of_le h₂ (le_of_not_gt hd),
-    tauto, },
-  { have hxb : x < b, from lt_of_le_of_lt (le_of_not_gt hc) h₁,
-    tauto, },
-  { tauto, },
+  obtain hc | hc := le_or_lt x c; obtain hd | hd := le_or_lt x d,
+  { have hax : a < x := h₂.trans_le hd,
+    tauto },
+  { tauto },
+  { have hxb : x < b := hc.trans_lt h₁,
+    tauto },
+  { tauto },
 end
 
 lemma Ioo_union_Ioo (h₁ : min a b < max c d) (h₂ : min c d < max a b) :
@@ -1080,10 +1080,10 @@ lemma Ioo_union_Ioo (h₁ : min a b < max c d) (h₂ : min c d < max a b) :
 begin
   cases le_total a b with hab hab; cases le_total c d with hcd hcd;
     simp only [min_eq_left, min_eq_right, max_eq_left, max_eq_right, hab, hcd] at h₁ h₂,
-  { exact Ioo_union_Ioo' h₂ h₁, },
+  { exact Ioo_union_Ioo' h₂ h₁ },
   all_goals {
     simp [*, min_eq_left_of_lt, min_eq_right_of_lt, max_eq_left_of_lt, max_eq_right_of_lt,
-      le_of_lt h₂, le_of_lt h₁], },
+      le_of_lt h₂, le_of_lt h₁] },
 end
 
 end linear_order
@@ -1147,11 +1147,11 @@ variables {α : Type u} [linear_order α] {a a₁ a₂ b b₁ b₂ c d : α}
 
 lemma Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ :=
 ext $ λ x, by simp [and_assoc, @and.left_comm (x ≤ _),
-  and_iff_left_iff_imp.2 (λ h', lt_of_le_of_lt h' h)]
+  and_iff_left_iff_imp.2 (λ h',.trans_lt h' h)]
 
 lemma Ioc_inter_Ioo_of_right_le (h : b₂ ≤ b₁) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (max a₁ a₂) b₂ :=
 ext $ λ x, by simp [and_assoc, @and.left_comm (x ≤ _),
-  and_iff_right_iff_imp.2 (λ h', (le_trans (le_of_lt h') h))]
+  and_iff_right_iff_imp.2 (λ h', (.trans (le_of_lt h') h))]
 
 lemma Ioo_inter_Ioc_of_left_le (h : b₁ ≤ b₂) : Ioo a₁ b₁ ∩ Ioc a₂ b₂ = Ioo (max a₁ a₂) b₁ :=
 by rw [inter_comm, Ioc_inter_Ioo_of_right_le h, max_comm]
@@ -1267,7 +1267,7 @@ lemma nonempty_Ico_sdiff {x dx y dy : α} (h : dy < dx) (hx : 0 < dx) :
   nonempty ↥(Ico x (x + dx) \ Ico y (y + dy)) :=
 begin
   cases lt_or_le x y with h' h',
-  { use x, simp [*, not_le.2 h'], },
+  { use x, simp [*, not_le.2 h'] },
   { use max x (x + dy), simp [*, le_refl] }
 end
 

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -586,7 +586,7 @@ lemma Icc_eq_empty_iff : Icc a b = ∅ ↔ b < a :=
 lemma Ico_subset_Ico_iff (h₁ : a₁ < b₁) :
   Ico a₁ b₁ ⊆ Ico a₂ b₂ ↔ a₂ ≤ a₁ ∧ b₁ ≤ b₂ :=
 ⟨λ h, have a₂ ≤ a₁ ∧ a₁ < b₂ := h ⟨le_rfl, h₁⟩,
-  ⟨this.1, le_of_not_lt $ λ h', lt_irrefl b₂ (h ⟨le_of_lt this.2, h'⟩).2⟩,
+  ⟨this.1, le_of_not_lt $ λ h', lt_irrefl b₂ (h ⟨this.2.le, h'⟩).2⟩,
  λ ⟨h₁, h₂⟩, Ico_subset_Ico h₁ h₂⟩
 
 lemma Ioo_subset_Ioo_iff [densely_ordered α] (h₁ : a₁ < b₁) :
@@ -1031,11 +1031,11 @@ begin
   simp_rw [mem_union, mem_Icc, min_le_iff, le_max_iff],
   by_cases hc : c ≤ x; by_cases hd : x ≤ d,
   { tauto },
-  { have hax : a ≤ x :=.trans h₂ (le_of_not_ge hd),
+  { have hax : a ≤ x := h₂.trans (le_of_not_ge hd),
     tauto },
-  { have hxb : x ≤ b :=.trans (le_of_not_ge hc) h₁,
+  { have hxb : x ≤ b := (le_of_not_ge hc).trans h₁,
     tauto },
-  { tauto },
+  { tauto }
 end
 
 /--
@@ -1066,13 +1066,13 @@ lemma Ioo_union_Ioo' (h₁ : c < b) (h₂ : a < d) :
 begin
   ext1 x,
   simp_rw [mem_union, mem_Ioo, min_lt_iff, lt_max_iff],
-  obtain hc | hc := le_or_lt x c; obtain hd | hd := le_or_lt x d,
-  { have hax : a < x := h₂.trans_le hd,
-    tauto },
+  by_cases hc : c < x; by_cases hd : x < d,
   { tauto },
-  { have hxb : x < b := hc.trans_lt h₁,
+  { have hax : a < x := h₂.trans_le (le_of_not_lt hd),
     tauto },
-  { tauto },
+  { have hxb : x < b := (le_of_not_lt hc).trans_lt h₁,
+    tauto },
+  { tauto }
 end
 
 lemma Ioo_union_Ioo (h₁ : min a b < max c d) (h₂ : min c d < max a b) :
@@ -1147,11 +1147,11 @@ variables {α : Type u} [linear_order α] {a a₁ a₂ b b₁ b₂ c d : α}
 
 lemma Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ :=
 ext $ λ x, by simp [and_assoc, @and.left_comm (x ≤ _),
-  and_iff_left_iff_imp.2 (λ h',.trans_lt h' h)]
+  and_iff_left_iff_imp.2 (λ h', lt_of_le_of_lt h' h)]
 
 lemma Ioc_inter_Ioo_of_right_le (h : b₂ ≤ b₁) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (max a₁ a₂) b₂ :=
 ext $ λ x, by simp [and_assoc, @and.left_comm (x ≤ _),
-  and_iff_right_iff_imp.2 (λ h', (.trans (le_of_lt h') h))]
+  and_iff_right_iff_imp.2 (λ h', ((le_of_lt h').trans h))]
 
 lemma Ioo_inter_Ioc_of_left_le (h : b₁ ≤ b₂) : Ioo a₁ b₁ ∩ Ioc a₂ b₂ = Ioo (max a₁ a₂) b₁ :=
 by rw [inter_comm, Ioc_inter_Ioo_of_right_le h, max_comm]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Don't mind me, I'm a bit obsessed with with cleanliness.

This is to declutter the diff of #8071.
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
