### PR TITLE
[Merged by Bors] - feat(category_theory/limits): monomorphisms from initial

### DIFF
--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -226,7 +226,7 @@ instance initial.mono_from [has_initial C] [zero_le_category C] (X : C) (f : ⊥
 initial_is_initial.mono_from f
 
 section comparison
-variables {C} {D : Type u₂} [category.{v} D] (G : C ⥤ D)
+variables {D : Type u₂} [category.{v} D] (G : C ⥤ D)
 
 /--
 The comparison morphism from the image of a terminal object to the terminal object in the target
@@ -250,7 +250,7 @@ initial.to _
 
 end comparison
 
-variables {C} {J : Type v} [small_category J]
+variables {J : Type v} [small_category J]
 
 /-- From a functor `F : J ⥤ C`, given an initial object of `J`, construct a cone for `J`.
 In `limit_of_diagram_initial` we show it is a limit cone. -/

--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -100,11 +100,13 @@ by haveI := t.split_mono_from f; apply_instance
 lemma is_initial.epi_to {X Y : C} (t : is_initial X) (f : Y ⟶ X) : epi f :=
 by haveI := t.split_epi_to f; apply_instance
 
+/-- If `T` and `T'` are terminal, they are isomorphic. -/
 @[simps]
 def is_terminal.unique_up_to_iso {T T' : C} (hT : is_terminal T) (hT' : is_terminal T') : T ≅ T' :=
 { hom := hT'.from _,
   inv := hT.from _ }
 
+/-- If `I` and `I'` are initial, they are isomorphic. -/
 @[simps]
 def is_initial.unique_up_to_iso {I I' : C} (hI : is_initial I) (hI' : is_initial I') : I ≅ I' :=
 { hom := hI.to _,

--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -100,6 +100,16 @@ by haveI := t.split_mono_from f; apply_instance
 lemma is_initial.epi_to {X Y : C} (t : is_initial X) (f : Y ⟶ X) : epi f :=
 by haveI := t.split_epi_to f; apply_instance
 
+@[simps]
+def is_terminal.unique_up_to_iso {T T' : C} (hT : is_terminal T) (hT' : is_terminal T') : T ≅ T' :=
+{ hom := hT'.from _,
+  inv := hT.from _ }
+
+@[simps]
+def is_initial.unique_up_to_iso {I I' : C} (hI : is_initial I) (hI' : is_initial I') : I ≅ I' :=
+{ hom := hI.to _,
+  inv := hI'.to _ }
+
 variable (C)
 
 /--
@@ -224,6 +234,39 @@ end
 
 instance initial.mono_from [has_initial C] [zero_le_category C] (X : C) (f : ⊥_ C ⟶ X) : mono f :=
 initial_is_initial.mono_from f
+
+/-- To show a category is a `zero_le_category` it suffices to give an initial object such that
+every morphism out of it is a monomorphism. -/
+lemma zero_le_category.of_is_initial {I : C} (hI : is_initial I) (h : ∀ X, mono (hI.to X)) :
+  zero_le_category C :=
+{ is_initial_mono_from := λ I' X hI',
+  begin
+    rw hI'.hom_ext (hI'.to X) ((hI'.unique_up_to_iso hI).hom ≫ hI.to X),
+    apply mono_comp,
+  end }
+
+/-- To show a category is a `zero_le_category` it suffices to show every morphism out of the
+initial object is a monomorphism. -/
+lemma zero_le_category.of_initial [has_initial C] (h : ∀ X : C, mono (initial.to X)) :
+  zero_le_category C :=
+zero_le_category.of_is_initial initial_is_initial h
+
+/-- To show a category is a `zero_le_category` it suffices to show the unique morphism from an
+initial object to a terminal object is a monomorphism. -/
+lemma zero_le_category.of_is_terminal {I T : C} (hI : is_initial I) (hT : is_terminal T)
+  (f : mono (hI.to T)) :
+  zero_le_category C :=
+begin
+  apply zero_le_category.of_is_initial hI,
+  intros X,
+  apply mono_of_mono_fac (hI.hom_ext (hI.to X ≫ hT.from X) (hI.to T)),
+end
+
+/-- To show a category is a `zero_le_category` it suffices to show the unique morphism from the
+initial object to a terminal object is a monomorphism. -/
+lemma zero_le_category.of_terminal [has_initial C] [has_terminal C] (h : mono (initial.to (⊤_ C))) :
+  zero_le_category C :=
+zero_le_category.of_is_terminal initial_is_initial terminal_is_terminal h
 
 section comparison
 variables {D : Type u₂} [category.{v} D] (G : C ⥤ D)

--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -222,7 +222,7 @@ begin
   apply zero_le_category.is_initial_mono_from,
 end
 
-instance initial.mono_from [has_initial C] [zero_le_category C] (X : C) (f : ⊥_C ⟶ X) : mono f :=
+instance initial.mono_from [has_initial C] [zero_le_category C] (X : C) (f : ⊥_ C ⟶ X) : mono f :=
 initial_is_initial.mono_from f
 
 section comparison

--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -234,7 +234,6 @@ category.
 This is an isomorphism iff `G` preserves terminal objects, see
 `category_theory.limits.preserves_terminal.of_iso_comparison`.
 -/
--- TODO: Show this is an isomorphism if and only if `G` preserves terminal objects.
 def terminal_comparison [has_terminal C] [has_terminal D] :
   G.obj (⊤_ C) ⟶ ⊤_ D :=
 terminal.from _

--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -216,7 +216,7 @@ def initial_unop_of_terminal {X : Cᵒᵖ} (t : is_terminal X) : is_initial X.un
 { desc := λ s, (t.from (opposite.op s.X)).unop,
   uniq' := λ s m w, quiver.hom.op_inj (t.hom_ext _ _) }
 
-/-- A category is a `zero_le_category` if the canonical morphism of an initial object is a
+/-- A category is a `initial_mono_class` if the canonical morphism of an initial object is a
 monomorphism.
 In practice, this is most useful when given an arbitrary morphism out of the chosen initial object,
 see `initial.mono_from`.
@@ -224,51 +224,50 @@ see `initial.mono_from`.
 TODO: This is a condition satisfied by categories with zero objects and morphisms, as well as
 categories with a strict initial object; though these conditions are essentially mutually exclusive.
 -/
-class zero_le_category (C : Type u) [category.{v} C] : Prop :=
+class initial_mono_class (C : Type u) [category.{v} C] : Prop :=
 (is_initial_mono_from : ∀ {I} (X : C) (hI : is_initial I), mono (hI.to X))
 
-lemma is_initial.mono_from [zero_le_category C] {I} {X : C} (hI : is_initial I) (f : I ⟶ X) :
+lemma is_initial.mono_from [initial_mono_class C] {I} {X : C} (hI : is_initial I) (f : I ⟶ X) :
   mono f :=
 begin
   rw hI.hom_ext f (hI.to X),
-  apply zero_le_category.is_initial_mono_from,
+  apply initial_mono_class.is_initial_mono_from,
 end
 
-instance initial.mono_from [has_initial C] [zero_le_category C] (X : C) (f : ⊥_ C ⟶ X) : mono f :=
+@[priority 100]
+instance initial.mono_from [has_initial C] [initial_mono_class C] (X : C) (f : ⊥_ C ⟶ X) :
+  mono f :=
 initial_is_initial.mono_from f
 
-/-- To show a category is a `zero_le_category` it suffices to give an initial object such that
+/-- To show a category is a `initial_mono_class` it suffices to give an initial object such that
 every morphism out of it is a monomorphism. -/
-lemma zero_le_category.of_is_initial {I : C} (hI : is_initial I) (h : ∀ X, mono (hI.to X)) :
-  zero_le_category C :=
+lemma initial_mono_class.of_is_initial {I : C} (hI : is_initial I) (h : ∀ X, mono (hI.to X)) :
+  initial_mono_class C :=
 { is_initial_mono_from := λ I' X hI',
   begin
     rw hI'.hom_ext (hI'.to X) ((hI'.unique_up_to_iso hI).hom ≫ hI.to X),
     apply mono_comp,
   end }
 
-/-- To show a category is a `zero_le_category` it suffices to show every morphism out of the
+/-- To show a category is a `initial_mono_class` it suffices to show every morphism out of the
 initial object is a monomorphism. -/
-lemma zero_le_category.of_initial [has_initial C] (h : ∀ X : C, mono (initial.to X)) :
-  zero_le_category C :=
-zero_le_category.of_is_initial initial_is_initial h
+lemma initial_mono_class.of_initial [has_initial C] (h : ∀ X : C, mono (initial.to X)) :
+  initial_mono_class C :=
+initial_mono_class.of_is_initial initial_is_initial h
 
-/-- To show a category is a `zero_le_category` it suffices to show the unique morphism from an
+/-- To show a category is a `initial_mono_class` it suffices to show the unique morphism from an
 initial object to a terminal object is a monomorphism. -/
-lemma zero_le_category.of_is_terminal {I T : C} (hI : is_initial I) (hT : is_terminal T)
+lemma initial_mono_class.of_is_terminal {I T : C} (hI : is_initial I) (hT : is_terminal T)
   (f : mono (hI.to T)) :
-  zero_le_category C :=
-begin
-  apply zero_le_category.of_is_initial hI,
-  intros X,
-  apply mono_of_mono_fac (hI.hom_ext (hI.to X ≫ hT.from X) (hI.to T)),
-end
+  initial_mono_class C :=
+initial_mono_class.of_is_initial hI (λ X, mono_of_mono_fac (hI.hom_ext (_ ≫ hT.from X) (hI.to T)))
 
-/-- To show a category is a `zero_le_category` it suffices to show the unique morphism from the
+/-- To show a category is a `initial_mono_class` it suffices to show the unique morphism from the
 initial object to a terminal object is a monomorphism. -/
-lemma zero_le_category.of_terminal [has_initial C] [has_terminal C] (h : mono (initial.to (⊤_ C))) :
-  zero_le_category C :=
-zero_le_category.of_is_terminal initial_is_initial terminal_is_terminal h
+lemma initial_mono_class.of_terminal [has_initial C] [has_terminal C]
+  (h : mono (initial.to (⊤_ C))) :
+  initial_mono_class C :=
+initial_mono_class.of_is_terminal initial_is_initial terminal_is_terminal h
 
 section comparison
 variables {D : Type u₂} [category.{v} D] (G : C ⥤ D)

--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -217,9 +217,10 @@ def initial_unop_of_terminal {X : Cᵒᵖ} (t : is_terminal X) : is_initial X.un
   uniq' := λ s m w, quiver.hom.op_inj (t.hom_ext _ _) }
 
 /-- A category is a `initial_mono_class` if the canonical morphism of an initial object is a
-monomorphism.
-In practice, this is most useful when given an arbitrary morphism out of the chosen initial object,
-see `initial.mono_from`.
+monomorphism.  In practice, this is most useful when given an arbitrary morphism out of the chosen
+initial object, see `initial.mono_from`.
+Given a terminal object, this is equivalent to the assumption that the unique morphism from initial
+to terminal is a monomorphism, which is the second of Freyd's axioms for an AT category.
 
 TODO: This is a condition satisfied by categories with zero objects and morphisms, as well as
 categories with a strict initial object; though these conditions are essentially mutually exclusive.

--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -204,78 +204,26 @@ def initial_unop_of_terminal {X : Cᵒᵖ} (t : is_terminal X) : is_initial X.un
 { desc := λ s, (t.from (opposite.op s.X)).unop,
   uniq' := λ s m w, quiver.hom.op_inj (t.hom_ext _ _) }
 
-/-- From a functor `F : J ⥤ C`, given an initial object of `J`, construct a cone for `J`.
-In `limit_of_diagram_initial` we show it is a limit cone. -/
-@[simps]
-def cone_of_diagram_initial {J : Type v} [small_category J]
-  {X : J} (tX : is_initial X) (F : J ⥤ C) : cone F :=
-{ X := F.obj X,
-  π :=
-  { app := λ j, F.map (tX.to j),
-    naturality' := λ j j' k,
-    begin
-      dsimp,
-      rw [← F.map_comp, category.id_comp, tX.hom_ext (tX.to j ≫ k) (tX.to j')],
-    end } }
+/-- A category is a `zero_le_category` if the canonical morphism of an initial object is a
+monomorphism.
+In practice, this is most useful when given an arbitrary morphism out of the chosen initial object,
+see `initial.mono_from`.
 
-/-- From a functor `F : J ⥤ C`, given an initial object of `J`, show the cone
-`cone_of_diagram_initial` is a limit. -/
-def limit_of_diagram_initial {J : Type v} [small_category J]
-  {X : J} (tX : is_initial X) (F : J ⥤ C) :
-is_limit (cone_of_diagram_initial tX F) :=
-{ lift := λ s, s.π.app X,
-  uniq' := λ s m w,
-    begin
-      rw [← w X, cone_of_diagram_initial_π_app, tX.hom_ext (tX.to X) (𝟙 _)],
-      dsimp, simp -- See note [dsimp, simp]
-    end}
+TODO: This is a condition satisfied by categories with zero objects and morphisms, as well as
+categories with a strict initial object; though these conditions are essentially mutually exclusive.
+-/
+class zero_le_category (C : Type u) [category.{v} C] : Prop :=
+(is_initial_mono_from : ∀ {I} (X : C) (hI : is_initial I), mono (hI.to X))
 
--- This is reducible to allow usage of lemmas about `cone_point_unique_up_to_iso`.
-/-- For a functor `F : J ⥤ C`, if `J` has an initial object then the image of it is isomorphic
-to the limit of `F`. -/
-@[reducible]
-def limit_of_initial {J : Type v} [small_category J] (F : J ⥤ C)
-  [has_initial J] [has_limit F] :
-limit F ≅ F.obj (⊥_ J) :=
-is_limit.cone_point_unique_up_to_iso
-  (limit.is_limit _)
-  (limit_of_diagram_initial initial_is_initial F)
-
-/-- From a functor `F : J ⥤ C`, given a terminal object of `J`, construct a cocone for `J`.
-In `colimit_of_diagram_terminal` we show it is a colimit cocone. -/
-@[simps]
-def cocone_of_diagram_terminal {J : Type v} [small_category J]
-  {X : J} (tX : is_terminal X) (F : J ⥤ C) : cocone F :=
-{ X := F.obj X,
-  ι :=
-  { app := λ j, F.map (tX.from j),
-    naturality' := λ j j' k,
-    begin
-      dsimp,
-      rw [← F.map_comp, category.comp_id, tX.hom_ext (k ≫ tX.from j') (tX.from j)],
-    end } }
-
-/-- From a functor `F : J ⥤ C`, given a terminal object of `J`, show the cocone
-`cocone_of_diagram_terminal` is a colimit. -/
-def colimit_of_diagram_terminal {J : Type v} [small_category J]
-  {X : J} (tX : is_terminal X) (F : J ⥤ C) :
-is_colimit (cocone_of_diagram_terminal tX F) :=
-{ desc := λ s, s.ι.app X,
-  uniq' := λ s m w,
-    by { rw [← w X, cocone_of_diagram_terminal_ι_app, tX.hom_ext (tX.from X) (𝟙 _)], simp } }
-
--- This is reducible to allow usage of lemmas about `cocone_point_unique_up_to_iso`.
-/-- For a functor `F : J ⥤ C`, if `J` has a terminal object then the image of it is isomorphic
-to the colimit of `F`. -/
-@[reducible]
-def colimit_of_terminal {J : Type v} [small_category J] (F : J ⥤ C)
-  [has_terminal J] [has_colimit F] :
-colimit F ≅ F.obj (⊤_ J) :=
-is_colimit.cocone_point_unique_up_to_iso
-  (colimit.is_colimit _)
-  (colimit_of_diagram_terminal terminal_is_terminal F)
-
+lemma is_initial.mono_from [zero_le_category C] {I} {X : C} (hI : is_initial I) (f : I ⟶ X) :
+  mono f :=
+begin
+  rw hI.hom_ext f (hI.to X),
+  apply zero_le_category.is_initial_mono_from,
 end
+
+instance initial.mono_from [has_initial C] [zero_le_category C] (X : C) (f : ⊥_C ⟶ X) : mono f :=
+initial_is_initial.mono_from f
 
 section comparison
 variables {C} {D : Type u₂} [category.{v} D] (G : C ⥤ D)
@@ -283,6 +231,8 @@ variables {C} {D : Type u₂} [category.{v} D] (G : C ⥤ D)
 /--
 The comparison morphism from the image of a terminal object to the terminal object in the target
 category.
+This is an isomorphism iff `G` preserves terminal objects, see
+`category_theory.limits.preserves_terminal.of_iso_comparison`.
 -/
 -- TODO: Show this is an isomorphism if and only if `G` preserves terminal objects.
 def terminal_comparison [has_terminal C] [has_terminal D] :
@@ -301,6 +251,77 @@ initial.to _
 end comparison
 
 variables {C} {J : Type v} [small_category J]
+
+/-- From a functor `F : J ⥤ C`, given an initial object of `J`, construct a cone for `J`.
+In `limit_of_diagram_initial` we show it is a limit cone. -/
+@[simps]
+def cone_of_diagram_initial
+  {X : J} (tX : is_initial X) (F : J ⥤ C) : cone F :=
+{ X := F.obj X,
+  π :=
+  { app := λ j, F.map (tX.to j),
+    naturality' := λ j j' k,
+    begin
+      dsimp,
+      rw [← F.map_comp, category.id_comp, tX.hom_ext (tX.to j ≫ k) (tX.to j')],
+    end } }
+
+/-- From a functor `F : J ⥤ C`, given an initial object of `J`, show the cone
+`cone_of_diagram_initial` is a limit. -/
+def limit_of_diagram_initial
+  {X : J} (tX : is_initial X) (F : J ⥤ C) :
+is_limit (cone_of_diagram_initial tX F) :=
+{ lift := λ s, s.π.app X,
+  uniq' := λ s m w,
+    begin
+      rw [← w X, cone_of_diagram_initial_π_app, tX.hom_ext (tX.to X) (𝟙 _)],
+      dsimp, simp -- See note [dsimp, simp]
+    end}
+
+-- This is reducible to allow usage of lemmas about `cone_point_unique_up_to_iso`.
+/-- For a functor `F : J ⥤ C`, if `J` has an initial object then the image of it is isomorphic
+to the limit of `F`. -/
+@[reducible]
+def limit_of_initial (F : J ⥤ C)
+  [has_initial J] [has_limit F] :
+limit F ≅ F.obj (⊥_ J) :=
+is_limit.cone_point_unique_up_to_iso
+  (limit.is_limit _)
+  (limit_of_diagram_initial initial_is_initial F)
+
+/-- From a functor `F : J ⥤ C`, given a terminal object of `J`, construct a cocone for `J`.
+In `colimit_of_diagram_terminal` we show it is a colimit cocone. -/
+@[simps]
+def cocone_of_diagram_terminal
+  {X : J} (tX : is_terminal X) (F : J ⥤ C) : cocone F :=
+{ X := F.obj X,
+  ι :=
+  { app := λ j, F.map (tX.from j),
+    naturality' := λ j j' k,
+    begin
+      dsimp,
+      rw [← F.map_comp, category.comp_id, tX.hom_ext (k ≫ tX.from j') (tX.from j)],
+    end } }
+
+/-- From a functor `F : J ⥤ C`, given a terminal object of `J`, show the cocone
+`cocone_of_diagram_terminal` is a colimit. -/
+def colimit_of_diagram_terminal
+  {X : J} (tX : is_terminal X) (F : J ⥤ C) :
+is_colimit (cocone_of_diagram_terminal tX F) :=
+{ desc := λ s, s.ι.app X,
+  uniq' := λ s m w,
+    by { rw [← w X, cocone_of_diagram_terminal_ι_app, tX.hom_ext (tX.from X) (𝟙 _)], simp } }
+
+-- This is reducible to allow usage of lemmas about `cocone_point_unique_up_to_iso`.
+/-- For a functor `F : J ⥤ C`, if `J` has a terminal object then the image of it is isomorphic
+to the colimit of `F`. -/
+@[reducible]
+def colimit_of_terminal (F : J ⥤ C)
+  [has_terminal J] [has_colimit F] :
+colimit F ≅ F.obj (⊤_ J) :=
+is_colimit.cocone_point_unique_up_to_iso
+  (colimit.is_colimit _)
+  (colimit_of_diagram_terminal terminal_is_terminal F)
 
 /--
 If `j` is initial in the index category, then the map `limit.π F j` is an isomorphism.
@@ -323,5 +344,7 @@ lemma is_iso_ι_of_is_terminal {j : J} (I : is_terminal j) (F : J ⥤ C) [has_co
 instance is_iso_ι_terminal [has_terminal J] (F : J ⥤ C) [has_colimit F] :
   is_iso (colimit.ι F (⊤_ J)) :=
 is_iso_ι_of_is_terminal (terminal_is_terminal) F
+
+end
 
 end category_theory.limits


### PR DESCRIPTION
Defines a class for categories where every morphism from initial is a monomorphism. If the category has a terminal object, this is equivalent to saying the unique morphism from initial to terminal is a monomorphism, so this is essentially a "zero_le_one" for categories. I'm happy to change the name of this class!

This axiom does not appear to have a common name, though it is (equivalent to) the second of Freyd's AT axioms: specifically it is a property shared by abelian categories and pretoposes. The main advantage to this class is that it is the precise condition required for the subobject lattice to have a bottom element, resolving the discussion here: https://github.com/leanprover-community/mathlib/pull/6278#discussion_r577702542

I've also made some minor changes to later parts of this file, essentially de-duplicating arguments, and moving the `comparison` section up so that all the results about terminal objects in index categories of limits are together rather than split in two.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
