### PR TITLE
[Merged by Bors] - chore(category_theory): homogenise usage of notation for terminal objects

### DIFF
--- a/src/category_theory/closed/cartesian.lean
+++ b/src/category_theory/closed/cartesian.lean
@@ -67,7 +67,7 @@ This isn't an instance because most of the time we'll prove cartesian closed for
 at once, rather than just for this one.
 -/
 def terminal_exponentiable {C : Type u} [category.{v} C] [has_finite_products C] :
-  exponentiable ⊤_C :=
+  exponentiable ⊤_ C :=
 unit_closed
 
 /--
@@ -211,7 +211,7 @@ Show that the exponential of the terminal object is isomorphic to itself, i.e. `
 
 The typeclass argument is explicit: any instance can be used.
 -/
-def exp_terminal_iso_self [exponentiable ⊤_C] : (⊤_C ⟹ X) ≅ X :=
+def exp_terminal_iso_self [exponentiable ⊤_ C] : (⊤_ C ⟹ X) ≅ X :=
 yoneda.ext (⊤_ C ⟹ X) X
   (λ Y f, (prod.left_unitor Y).inv ≫ uncurry f)
   (λ Y f, curry ((prod.left_unitor Y).hom ≫ f))
@@ -220,7 +220,7 @@ yoneda.ext (⊤_ C ⟹ X) X
   (λ Z W f g, by rw [uncurry_natural_left, prod.left_unitor_inv_naturality_assoc f] )
 
 /-- The internal element which points at the given morphism. -/
-def internalize_hom (f : A ⟶ Y) : ⊤_C ⟶ (A ⟹ Y) :=
+def internalize_hom (f : A ⟶ Y) : ⊤_ C ⟶ (A ⟹ Y) :=
 curry (limits.prod.fst ≫ f)
 
 section pre

--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -126,8 +126,8 @@ This object is characterized by having a unique morphism to any object.
 -/
 abbreviation initial [has_initial C] : C := colimit (functor.empty C)
 
-notation `⊤_` C:20 := terminal C
-notation `⊥_` C:20 := initial C
+notation `⊤_ ` C:20 := terminal C
+notation `⊥_ ` C:20 := initial C
 
 section
 variables {C}


### PR DESCRIPTION
I went with the option that is used more frequently, but I'm also happy to switch to the space-less option if people prefer it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
