### PR TITLE
[Merged by Bors] - feat(data/complex/module): add `complex.lift` to match `zsqrtd.lift`

### DIFF
--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -247,12 +247,12 @@ alg_hom.mk'
     map_mul' := λ ⟨x₁, y₁⟩ ⟨x₂, y₂⟩, by {
       change algebra_map ℝ A (x₁ * x₂ - y₁ * y₂) + (x₁ * y₂ + y₁ * x₂) • I' =
              (algebra_map ℝ A x₁ + y₁ • I') * (algebra_map ℝ A x₂ + y₂ • I'),
-      rw [add_mul, mul_add, mul_add, smul_mul_smul, hf, smul_neg, ←algebra.algebra_map_eq_smul_one,
-        ←sub_eq_add_neg],
-      simp only [algebra.smul_def],
-      rw [←algebra.right_comm _ x₂, ←mul_assoc, ←ring_hom.map_mul, ←ring_hom.map_mul,
-        ←ring_hom.map_mul, add_sub, add_assoc, ←add_mul, ←ring_hom.map_add,
-        ←sub_add_eq_add_sub, ring_hom.map_sub], },
+      rw [add_mul, mul_add, mul_add, add_comm _ (y₁ • I' * y₂ • I'), add_add_add_comm],
+      congr' 1, -- equate "real" and "imaginary" parts
+      { rw [smul_mul_smul, hf, smul_neg, ←algebra.algebra_map_eq_smul_one, ←sub_eq_add_neg,
+          ←ring_hom.map_mul, ←ring_hom.map_sub], },
+      { rw [algebra.smul_def, algebra.smul_def, algebra.smul_def, ←algebra.right_comm _ x₂,
+          ←mul_assoc, ←add_mul, ←ring_hom.map_mul, ←ring_hom.map_mul, ←ring_hom.map_add], } },
     map_one' := show algebra_map ℝ A 1 + (0 : ℝ) • I' = 1,
       by rw [ring_hom.map_one, zero_smul, add_zero], }
   (linear_map.map_smul _)

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -238,8 +238,7 @@ variables {A : Type*} [ring A] [algebra ℝ A]
 /-- There is an alg_hom from `ℂ` to any `ℝ`-algebra with an element that squares to `-1`.
 
 See `complex.lift` for this as an equiv. -/
-def lift_aux (I' : A) (hf : I' * I' = -1) :
-  ℂ →ₐ[ℝ] A :=
+def lift_aux (I' : A) (hf : I' * I' = -1) : ℂ →ₐ[ℝ] A :=
 alg_hom.mk'
   { to_fun := ⇑((algebra.of_id ℝ A).to_linear_map.comp re_lm +
                 (linear_map.to_span_singleton _ _ I').comp im_lm),
@@ -248,22 +247,21 @@ alg_hom.mk'
     map_mul' := λ ⟨x₁, y₁⟩ ⟨x₂, y₂⟩, by {
       change algebra_map ℝ A (x₁ * x₂ - y₁ * y₂) + (x₁ * y₂ + y₁ * x₂) • I' =
              (algebra_map ℝ A x₁ + y₁ • I') * (algebra_map ℝ A x₂ + y₂ • I'),
-      rw [mul_add, add_mul, add_mul],
-      rw [smul_mul_smul, hf, smul_neg, ←algebra.algebra_map_eq_smul_one, ←sub_eq_add_neg],
-      simp only [←algebra.commutes x₂, ←ring_hom.map_mul],
-      simp only [←algebra.smul_def],
-      simp only [add_smul, smul_smul, ring_hom.map_sub, mul_comm y₁ x₂],
-      abel, },
+      rw [add_mul, mul_add, mul_add, smul_mul_smul, hf, smul_neg, ←algebra.algebra_map_eq_smul_one,
+        ←sub_eq_add_neg],
+      simp only [algebra.smul_def],
+      rw [←algebra.right_comm _ x₂, ←mul_assoc, ←ring_hom.map_mul, ←ring_hom.map_mul,
+        ←ring_hom.map_mul, add_sub, add_assoc, ←add_mul, ←ring_hom.map_add,
+        ←sub_add_eq_add_sub, ring_hom.map_sub], },
     map_one' := show algebra_map ℝ A 1 + (0 : ℝ) • I' = 1,
       by rw [ring_hom.map_one, zero_smul, add_zero], }
   (linear_map.map_smul _)
 
 @[simp]
 lemma lift_aux_apply (I' : A) (hI') (z : ℂ) :
-  lift_aux I' hI' z = algebra_map ℝ A z.re + z.im • I' := rfl
+ lift_aux I' hI' z = algebra_map ℝ A z.re + z.im • I' := rfl
 
-lemma lift_aux_apply_I (I' : A) (hI') :
-  lift_aux I' hI' I = I' := by simp
+lemma lift_aux_apply_I (I' : A) (hI') : lift_aux I' hI' I = I' := by simp
 
 /-- A universal property of the complex numbers, providing a unique `ℂ →ₐ[ℝ] A` for every element
 of `A` which squares to `-1`.
@@ -272,8 +270,7 @@ This can be used to embed the complex numbers in the `quaternion`s.
 
 This isomorphism is named to match the very similar `zsqrtd.lift`. -/
 @[simps {simp_rhs := tt}]
-noncomputable def lift  :
-  {I' : A // I' * I' = -1} ≃ (ℂ →ₐ[ℝ] A) :=
+noncomputable def lift : {I' : A // I' * I' = -1} ≃ (ℂ →ₐ[ℝ] A) :=
 { to_fun := λ I', lift_aux I' I'.prop,
   inv_fun := λ F, ⟨F I, by rw [←F.map_mul, I_mul_I, alg_hom.map_neg, alg_hom.map_one]⟩,
   left_inv := λ I', subtype.ext $ lift_aux_apply_I I' I'.prop,

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Alexander Bentkamp, Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alexander Bentkamp, Sébastien Gouëzel
+Authors: Alexander Bentkamp, Sébastien Gouëzel, Eric Wieser
 -/
 import data.complex.basic
 import algebra.algebra.ordered
@@ -28,6 +28,9 @@ part, the embedding of `ℝ` in `ℂ`, and the complex conjugate):
 * `complex.im_lm` (`ℝ`-linear map);
 * `complex.of_real_am` (`ℝ`-algebra (homo)morphism);
 * `complex.conj_ae` (`ℝ`-algebra equivalence).
+
+It also provides a universal property of the complex numbers `complex.lift`, which constructs a
+`ℂ →ₐ[ℝ] A` into any `ℝ`-algebra `A` given a square root of `-1`.
 
 -/
 noncomputable theory
@@ -218,5 +221,65 @@ def conj_ae : ℂ ≃ₐ[ℝ] ℂ :=
   .. conj }
 
 @[simp] lemma conj_ae_coe : ⇑conj_ae = conj := rfl
+
+section lift
+
+variables {A : Type*} [ring A] [algebra ℝ A]
+
+/-- There is an alg_hom from `ℂ` to any `ℝ`-algebra with an element that squares to `-1`.
+
+See `complex.lift` for this as an equiv. -/
+def lift_aux (I' : A) (hf : I' * I' = -1) :
+  ℂ →ₐ[ℝ] A :=
+alg_hom.mk'
+  { to_fun := ⇑((algebra.of_id ℝ A).to_linear_map.comp re_lm +
+                (linear_map.to_span_singleton _ _ I').comp im_lm),
+    map_zero' := linear_map.map_zero _,
+    map_add' := linear_map.map_add _,
+    map_mul' := λ ⟨x₁, y₁⟩ ⟨x₂, y₂⟩, by {
+      change algebra_map ℝ A (x₁ * x₂ - y₁ * y₂) + (x₁ * y₂ + y₁ * x₂) • I' =
+             (algebra_map ℝ A x₁ + y₁ • I') * (algebra_map ℝ A x₂ + y₂ • I'),
+      rw [mul_add, add_mul, add_mul],
+      rw [smul_mul_smul, hf, smul_neg, ←algebra.algebra_map_eq_smul_one, ←sub_eq_add_neg],
+      simp only [←algebra.commutes x₂, ←ring_hom.map_mul],
+      simp only [←algebra.smul_def],
+      simp only [add_smul, smul_smul, ring_hom.map_sub, mul_comm y₁ x₂],
+      abel, },
+    map_one' := show algebra_map ℝ A 1 + (0 : ℝ) • I' = 1,
+      by rw [ring_hom.map_one, zero_smul, add_zero], }
+  (linear_map.map_smul _)
+
+@[simp]
+lemma lift_aux_apply (I' : A) (hI') (z : ℂ) :
+  lift_aux I' hI' z = algebra_map ℝ A z.re + z.im • I' := rfl
+
+lemma lift_aux_apply_I (I' : A) (hI') :
+  lift_aux I' hI' I = I' := by simp
+
+/-- A universal property of the complex numbers, providing a unique `ℂ →ₐ[ℝ] A` for every element
+of `A` which squares to `-1`.
+
+This can be used to embed the complex numbers in the `quaternion`s.
+
+This isomorphism is named to match the very similar `zsqrtd.lift`. -/
+@[simps {simp_rhs := tt}]
+noncomputable def lift  :
+  {I' : A // I' * I' = -1} ≃ (ℂ →ₐ[ℝ] A) :=
+{ to_fun := λ I', lift_aux I' I'.prop,
+  inv_fun := λ F, ⟨F I, by rw [←F.map_mul, I_mul_I, alg_hom.map_neg, alg_hom.map_one]⟩,
+  left_inv := λ I', subtype.ext $ lift_aux_apply_I I' I'.prop,
+  right_inv := λ F, alg_hom_ext $ lift_aux_apply_I _ _, }
+
+/- When applied to `complex.I` itself, `lift` is the identity. -/
+@[simp]
+lemma lift_aux_I : lift_aux I I_mul_I = alg_hom.id ℝ ℂ :=
+alg_hom_ext $ lift_aux_apply_I _ _
+
+/- When applied to `-complex.I`, `lift` is conjugation, `conj`. -/
+@[simp]
+lemma lift_aux_neg_I : lift_aux (-I) ((neg_mul_neg _ _).trans I_mul_I) = conj_ae :=
+alg_hom_ext $ (lift_aux_apply_I _ _).trans conj_I.symm
+
+end lift
 
 end complex

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -78,6 +78,17 @@ instance [comm_semiring R] [algebra R ℝ] : algebra R ℂ :=
   commutes' := λ r ⟨xr, xi⟩, by ext; simp [smul_re, smul_im, algebra.commutes],
   ..complex.of_real.comp (algebra_map R ℝ) }
 
+/-- Two algebra homomorphisms from ℂ are equal if they agree on `complex.I`. -/
+@[ext]
+lemma alg_hom_ext {A : Type*} [semiring A] [algebra ℝ A] ⦃f g : ℂ →ₐ[ℝ] A⦄ (h : f I = g I) :
+  f = g :=
+begin
+  ext ⟨x, y⟩,
+  have : (coe : ℝ → ℂ) = algebra_map ℝ ℂ := rfl,
+  rw [mk_eq_add_mul_I, ←smul_coe, this],
+  simp only [alg_hom.map_add, alg_hom.commutes, alg_hom.map_smul, h],
+end
+
 section
 open_locale complex_order
 


### PR DESCRIPTION
[Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/The.20unique.20.60.E2.84.82.20.E2.86.92.E2.82.90.5B.E2.84.9D.5D.20A.60.20given.20a.20square.20root.20of.20-1/near/244135262)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->

- [x] depends on: #8105

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
