### PR TITLE
[Merged by Bors] - feat(ring_theory/power_basis): extensionality for algebra homs

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -519,9 +519,7 @@ lemma map_finsupp_sum {α : Type*} [has_zero α] {ι : Type*} (f : ι →₀ α)
 φ.to_ring_hom.map_bit1 x
 
 -- TODO[gh-6025]: make this an instance once safe to do so
-def subsingleton {R A B} [comm_semiring R] [semiring A] [semiring B]
-  [algebra R A] [algebra R B] [subsingleton A] :
-  subsingleton (A →ₐ[R] B) :=
+lemma subsingleton [subsingleton A] : subsingleton (A →ₐ[R] B) :=
 ⟨λ f g, alg_hom.ext $ λ x, subsingleton.elim 0 x ▸ f.map_zero.trans g.map_zero.symm⟩
 
 /-- If a `ring_hom` is `R`-linear, then it is an `alg_hom`. -/

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -518,6 +518,12 @@ lemma map_finsupp_sum {α : Type*} [has_zero α] {ι : Type*} (f : ι →₀ α)
 @[simp] lemma map_bit1 (x) : φ (bit1 x) = bit1 (φ x) :=
 φ.to_ring_hom.map_bit1 x
 
+-- TODO[gh-6025]: make this an instance once safe to do so
+def subsingleton {R A B} [comm_semiring R] [semiring A] [semiring B]
+  [algebra R A] [algebra R B] [subsingleton A] :
+  subsingleton (A →ₐ[R] B) :=
+⟨λ f g, alg_hom.ext $ λ x, subsingleton.elim 0 x ▸ f.map_zero.trans g.map_zero.symm⟩
+
 /-- If a `ring_hom` is `R`-linear, then it is an `alg_hom`. -/
 def mk' (f : A →+* B) (h : ∀ (c : R) x, f (c • x) = c • f x) : A →ₐ[R] B :=
 { to_fun := f,

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -123,7 +123,7 @@ lemma exists_eq_aeval [nontrivial S] (pb : power_basis R S) (y : S) :
 
 lemma alg_hom_ext [nontrivial S] {S' : Type*} [semiring S'] [algebra R S']
   (pb : power_basis R S) ⦃f g : S →ₐ[R] S'⦄ (h : f pb.gen = g pb.gen) :
-f = g :=
+  f = g :=
 begin
   ext x,
   obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x,

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -265,7 +265,10 @@ begin
 end
 
 /-- `pb.lift y hy` is the algebra map sending `pb.gen` to `y`,
-where `hy` states the higher powers of `y` are the same as the higher powers of `pb.gen`. -/
+where `hy` states the higher powers of `y` are the same as the higher powers of `pb.gen`.
+
+See `power_basis.lift_equiv` for a bundled equiv sending `⟨y, hy⟩` to the algebra map.
+-/
 noncomputable def lift [nontrivial S] (pb : power_basis A S) (y : S')
   (hy : aeval y (minpoly A pb.gen) = 0) :
   S →ₐ[A] S' :=
@@ -284,6 +287,19 @@ pb.constr_pow_gen hy
   (hy : aeval y (minpoly A pb.gen) = 0) (f : polynomial A) :
   pb.lift y hy (aeval pb.gen f) = aeval y f :=
 pb.constr_pow_aeval hy f
+
+/-- `pb.lift_equiv` states that roots of the minimal polynomial of `pb.gen` correspond to
+maps sending `pb.gen` to that root.
+
+This is the bundled equiv version of `power_basis.lift`.
+-/
+@[simps]
+noncomputable def lift_equiv [nontrivial S] (pb : power_basis A S) :
+  {y : S' // aeval y (minpoly A pb.gen) = 0} ≃ (S →ₐ[A] S') :=
+{ to_fun := λ y, pb.lift y y.2,
+  inv_fun := λ f, ⟨f pb.gen, by rw [aeval_alg_hom_apply, minpoly.aeval, f.map_zero]⟩,
+  left_inv := λ y, by simp only [subtype.ext_iff, lift_gen, subtype.coe_mk],
+  right_inv := λ f, pb.alg_hom_ext (by simp only [lift_gen, subtype.coe_mk]) }
 
 /-- `pb.equiv pb' h` is an equivalence of algebras with the same power basis. -/
 noncomputable def equiv [nontrivial S] [nontrivial S']

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -121,6 +121,15 @@ lemma exists_eq_aeval [nontrivial S] (pb : power_basis R S) (y : S) :
   ∃ f : polynomial R, f.nat_degree < pb.dim ∧ y = aeval pb.gen f :=
 (mem_span_pow pb.dim_ne_zero).mp (by simpa using pb.basis.mem_span y)
 
+lemma alg_hom_ext [nontrivial S] {S' : Type*} [semiring S'] [algebra R S']
+  (pb : power_basis R S) ⦃f g : S →ₐ[R] S'⦄ (h : f pb.gen = g pb.gen) :
+f = g :=
+begin
+  ext x,
+  obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x,
+  rw [← polynomial.aeval_alg_hom_apply, ← polynomial.aeval_alg_hom_apply, h]
+end
+
 section minpoly
 
 open_locale big_operators

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -129,8 +129,6 @@ begin
   exact ⟨f, hf⟩
 end
 
-local attribute [instance] alg_hom.subsingleton
-
 lemma alg_hom_ext {S' : Type*} [semiring S'] [algebra R S']
   (pb : power_basis R S) ⦃f g : S →ₐ[R] S'⦄ (h : f pb.gen = g pb.gen) :
   f = g :=

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -121,10 +121,13 @@ lemma exists_eq_aeval [nontrivial S] (pb : power_basis R S) (y : S) :
   ∃ f : polynomial R, f.nat_degree < pb.dim ∧ y = aeval pb.gen f :=
 (mem_span_pow pb.dim_ne_zero).mp (by simpa using pb.basis.mem_span y)
 
-lemma alg_hom_ext [nontrivial S] {S' : Type*} [semiring S'] [algebra R S']
+local attribute [instance] alg_hom.subsingleton
+
+lemma alg_hom_ext {S' : Type*} [semiring S'] [algebra R S']
   (pb : power_basis R S) ⦃f g : S →ₐ[R] S'⦄ (h : f pb.gen = g pb.gen) :
   f = g :=
 begin
+  nontriviality S,
   ext x,
   obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x,
   rw [← polynomial.aeval_alg_hom_apply, ← polynomial.aeval_alg_hom_apply, h]

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -301,8 +301,8 @@ noncomputable def lift_equiv [nontrivial S] (pb : power_basis A S) :
   {y : S' // aeval y (minpoly A pb.gen) = 0} ≃ (S →ₐ[A] S') :=
 { to_fun := λ y, pb.lift y y.2,
   inv_fun := λ f, ⟨f pb.gen, by rw [aeval_alg_hom_apply, minpoly.aeval, f.map_zero]⟩,
-  left_inv := λ y, by simp only [subtype.ext_iff, lift_gen, subtype.coe_mk],
-  right_inv := λ f, pb.alg_hom_ext (by simp only [lift_gen, subtype.coe_mk]) }
+  left_inv := λ y, subtype.ext $ lift_gen _ _ y.prop,
+  right_inv := λ f, pb.alg_hom_ext $ lift_gen _ _ _  }
 
 /-- `pb.equiv pb' h` is an equivalence of algebras with the same power basis. -/
 noncomputable def equiv [nontrivial S] [nontrivial S']

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -122,7 +122,7 @@ lemma exists_eq_aeval [nontrivial S] (pb : power_basis R S) (y : S) :
 (mem_span_pow pb.dim_ne_zero).mp (by simpa using pb.basis.mem_span y)
 
 lemma exists_eq_aeval' (pb : power_basis R S) (y : S) :
-∃ f : polynomial R, y = aeval pb.gen f :=
+  ∃ f : polynomial R, y = aeval pb.gen f :=
 begin
   nontriviality S,
   obtain ⟨f, _, hf⟩ := exists_eq_aeval pb y,

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -121,15 +121,22 @@ lemma exists_eq_aeval [nontrivial S] (pb : power_basis R S) (y : S) :
   ∃ f : polynomial R, f.nat_degree < pb.dim ∧ y = aeval pb.gen f :=
 (mem_span_pow pb.dim_ne_zero).mp (by simpa using pb.basis.mem_span y)
 
+lemma exists_eq_aeval' (pb : power_basis R S) (y : S) :
+∃ f : polynomial R, y = aeval pb.gen f :=
+begin
+  nontriviality S,
+  obtain ⟨f, _, hf⟩ := exists_eq_aeval pb y,
+  exact ⟨f, hf⟩
+end
+
 local attribute [instance] alg_hom.subsingleton
 
 lemma alg_hom_ext {S' : Type*} [semiring S'] [algebra R S']
   (pb : power_basis R S) ⦃f g : S →ₐ[R] S'⦄ (h : f pb.gen = g pb.gen) :
   f = g :=
 begin
-  nontriviality S,
   ext x,
-  obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x,
+  obtain ⟨f, rfl⟩ := pb.exists_eq_aeval' x,
   rw [← polynomial.aeval_alg_hom_apply, ← polynomial.aeval_alg_hom_apply, h]
 end
 
@@ -257,13 +264,13 @@ lemma constr_pow_algebra_map (pb : power_basis A S) {y : S'}
   pb.basis.constr A (λ i, y ^ (i : ℕ)) (algebra_map A S x) = algebra_map A S' x :=
 by { convert pb.constr_pow_aeval hy (C x); rw aeval_C }
 
-lemma constr_pow_mul [nontrivial S] (pb : power_basis A S) {y : S'}
+lemma constr_pow_mul (pb : power_basis A S) {y : S'}
   (hy : aeval y (minpoly A pb.gen) = 0) (x x' : S) :
   pb.basis.constr A (λ i, y ^ (i : ℕ)) (x * x') =
     pb.basis.constr A (λ i, y ^ (i : ℕ)) x * pb.basis.constr A (λ i, y ^ (i : ℕ)) x' :=
 begin
-  obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x,
-  obtain ⟨g, hg, rfl⟩ := pb.exists_eq_aeval x',
+  obtain ⟨f, rfl⟩ := pb.exists_eq_aeval' x,
+  obtain ⟨g, rfl⟩ := pb.exists_eq_aeval' x',
   simp only [← aeval_mul, pb.constr_pow_aeval hy]
 end
 
@@ -272,7 +279,7 @@ where `hy` states the higher powers of `y` are the same as the higher powers of 
 
 See `power_basis.lift_equiv` for a bundled equiv sending `⟨y, hy⟩` to the algebra map.
 -/
-noncomputable def lift [nontrivial S] (pb : power_basis A S) (y : S')
+noncomputable def lift (pb : power_basis A S) (y : S')
   (hy : aeval y (minpoly A pb.gen) = 0) :
   S →ₐ[A] S' :=
 { map_one' := by { convert pb.constr_pow_algebra_map hy 1 using 2; rw ring_hom.map_one },
@@ -281,12 +288,12 @@ noncomputable def lift [nontrivial S] (pb : power_basis A S) (y : S')
   commutes' := pb.constr_pow_algebra_map hy,
   .. pb.basis.constr A (λ i, y ^ (i : ℕ)) }
 
-@[simp] lemma lift_gen [nontrivial S] (pb : power_basis A S) (y : S')
+@[simp] lemma lift_gen (pb : power_basis A S) (y : S')
   (hy : aeval y (minpoly A pb.gen) = 0) :
   pb.lift y hy pb.gen = y :=
 pb.constr_pow_gen hy
 
-@[simp] lemma lift_aeval [nontrivial S] (pb : power_basis A S) (y : S')
+@[simp] lemma lift_aeval (pb : power_basis A S) (y : S')
   (hy : aeval y (minpoly A pb.gen) = 0) (f : polynomial A) :
   pb.lift y hy (aeval pb.gen f) = aeval y f :=
 pb.constr_pow_aeval hy f
@@ -297,7 +304,7 @@ maps sending `pb.gen` to that root.
 This is the bundled equiv version of `power_basis.lift`.
 -/
 @[simps]
-noncomputable def lift_equiv [nontrivial S] (pb : power_basis A S) :
+noncomputable def lift_equiv (pb : power_basis A S) :
   {y : S' // aeval y (minpoly A pb.gen) = 0} ≃ (S →ₐ[A] S') :=
 { to_fun := λ y, pb.lift y y.2,
   inv_fun := λ f, ⟨f pb.gen, by rw [aeval_alg_hom_apply, minpoly.aeval, f.map_zero]⟩,
@@ -305,18 +312,18 @@ noncomputable def lift_equiv [nontrivial S] (pb : power_basis A S) :
   right_inv := λ f, pb.alg_hom_ext $ lift_gen _ _ _  }
 
 /-- `pb.equiv pb' h` is an equivalence of algebras with the same power basis. -/
-noncomputable def equiv [nontrivial S] [nontrivial S']
+noncomputable def equiv
   (pb : power_basis A S) (pb' : power_basis A S')
   (h : minpoly A pb.gen = minpoly A pb'.gen) :
   S ≃ₐ[A] S' :=
 alg_equiv.of_alg_hom
   (pb.lift pb'.gen (h.symm ▸ minpoly.aeval A pb'.gen))
   (pb'.lift pb.gen (h ▸ minpoly.aeval A pb.gen))
-  (by { ext x, obtain ⟨f, hf, rfl⟩ := pb'.exists_eq_aeval x, simp })
-  (by { ext x, obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x, simp })
+  (by { ext x, obtain ⟨f, hf, rfl⟩ := pb'.exists_eq_aeval' x, simp })
+  (by { ext x, obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval' x, simp })
 
 @[simp]
-lemma equiv_aeval [nontrivial S] [nontrivial S']
+lemma equiv_aeval
   (pb : power_basis A S) (pb' : power_basis A S')
   (h : minpoly A pb.gen = minpoly A pb'.gen)
   (f : polynomial A) :
@@ -324,7 +331,7 @@ lemma equiv_aeval [nontrivial S] [nontrivial S']
 pb.lift_aeval _ (h.symm ▸ minpoly.aeval A _) _
 
 @[simp]
-lemma equiv_gen [nontrivial S] [nontrivial S']
+lemma equiv_gen
   (pb : power_basis A S) (pb' : power_basis A S')
   (h : minpoly A pb.gen = minpoly A pb'.gen) :
   pb.equiv pb' h pb.gen = pb'.gen :=
@@ -333,7 +340,7 @@ pb.lift_gen _ (h.symm ▸ minpoly.aeval A _)
 local attribute [irreducible] power_basis.lift
 
 @[simp]
-lemma equiv_symm [nontrivial S] [nontrivial S']
+lemma equiv_symm
   (pb : power_basis A S) (pb' : power_basis A S')
   (h : minpoly A pb.gen = minpoly A pb'.gen) :
   (pb.equiv pb' h).symm = pb'.equiv pb h.symm :=
@@ -433,10 +440,10 @@ by { dsimp only [minpoly_gen, map_dim], -- Turn `fin (pb.map e).dim` into `fin p
         alg_equiv.symm_apply_apply, sub_right_inj] }
 
 @[simp]
-lemma equiv_map [nontrivial S] [nontrivial S'] (pb : power_basis A S) (e : S ≃ₐ[A] S')
+lemma equiv_map (pb : power_basis A S) (e : S ≃ₐ[A] S')
   (h : minpoly A pb.gen = minpoly A (pb.map e).gen) :
   pb.equiv (pb.map e) h = e :=
-by { ext x, obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x, simp [aeval_alg_equiv] }
+by { ext x, obtain ⟨f, rfl⟩ := pb.exists_eq_aeval' x, simp [aeval_alg_equiv] }
 
 end map
 


### PR DESCRIPTION
This PR shows two `alg_hom`s out of an algebra with a power basis are equal if the generator has the same image for both maps. It uses this result to bundle `power_basis.lift` into an equiv.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
