### PR TITLE
[Merged by Bors] - refactor(ring_theory): turn `localization_map` into a typeclass

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -104,7 +104,7 @@ General algebra:
     algebraically closed field: 'is_alg_closed'
     existence of algebraic closure of a field: 'algebraic_closure'
     $\C$ is algebraically closed: 'complex.exists_root'
-    field of fractions of an integral domain: 'fraction_map'
+    field of fractions of an integral domain: 'is_fraction_ring'
     algebraic extension: 'algebra.is_algebraic'
     rupture field: 'adjoin_root'
     splitting field: 'polynomial.splitting_field'

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -178,7 +178,7 @@ Ring Theory:
     field $\R$ of real numbers: 'real.division_ring'
     field $\C$ of complex numbers: 'complex.field'
     $\C$ is algebraically closed: 'complex.exists_root'
-    field of fractions of an integral domain: 'fraction_map'
+    field of fractions of an integral domain: 'is_fraction_ring'
     algebraic elements: 'is_algebraic'
     transcendental elements: 'transcendental'
     algebraic extensions: 'algebra.is_algebraic'

--- a/src/algebra/char_p/algebra.lean
+++ b/src/algebra/char_p/algebra.lean
@@ -68,16 +68,25 @@ char_zero_of_injective_algebra_map free_algebra.algebra_map_left_inverse.injecti
 
 end free_algebra
 
-namespace fraction_ring
+namespace is_fraction_ring
 
-variables {R : Type*} [integral_domain R] (p : ℕ)
+variables (R : Type*) {K : Type*} [integral_domain R] [field K] [algebra R K] [is_fraction_ring R K]
+variables (p : ℕ)
+
+/-- If `R` has characteristic `p`, then so does Frac(R). -/
+lemma char_p_of_is_fraction_ring [char_p R p] : char_p K p :=
+char_p_of_injective_algebra_map (is_fraction_ring.injective R K) p
 
 /-- If `R` has characteristic `p`, then so does `fraction_ring R`. -/
 instance char_p [char_p R p] : char_p (fraction_ring R) p :=
-char_p_of_injective_algebra_map (fraction_map.injective (fraction_ring.of R)) p
+char_p_of_is_fraction_ring R p
+
+/-- If `R` has characteristic `0`, then so does Frac(R). -/
+lemma char_zero_of_is_fraction_ring [char_zero R] : char_zero K :=
+@char_p.char_p_to_char_zero K _ (char_p_of_is_fraction_ring R 0)
 
 /-- If `R` has characteristic `0`, then so does `fraction_ring R`. -/
 instance char_zero [char_zero R] : char_zero (fraction_ring R) :=
-char_p.char_p_to_char_zero (fraction_ring R)
+char_zero_of_is_fraction_ring R
 
-end fraction_ring
+end is_fraction_ring

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -444,7 +444,8 @@ is_localization.lift (is_unit_to_stalk R x)
   localization_to_stalk R x (algebra_map _ (localization _) f) = to_stalk R x f :=
 is_localization.lift_eq _ f
 
-@[simp] lemma localization_to_stalk_mk' (x : prime_spectrum.Top R) (f : R) (s : (as_ideal x).prime_compl) :
+@[simp] lemma localization_to_stalk_mk' (x : prime_spectrum.Top R) (f : R)
+  (s : (as_ideal x).prime_compl) :
   localization_to_stalk R x (is_localization.mk' _ f s : localization _) =
   (structure_sheaf R).presheaf.germ (⟨x, s.2⟩ : basic_open (s : R))
     (const R f s (basic_open s) (λ _, id)) :=
@@ -549,8 +550,9 @@ by rw [to_open_eq_const, to_open_eq_const, const_mul_cancel']
 ring_hom.ext $ λ g,
 by rw [to_basic_open, is_localization.away.lift, ring_hom.comp_apply, is_localization.lift_eq]
 
-@[simp] lemma to_basic_open_to_map (s f : R) : to_basic_open R s (algebra_map R (localization.away s) f) =
-  const R f 1 (basic_open s) (λ _ _, submonoid.one_mem _) :=
+@[simp] lemma to_basic_open_to_map (s f : R) :
+  to_basic_open R s (algebra_map R (localization.away s) f) =
+    const R f 1 (basic_open s) (λ _ _, submonoid.one_mem _) :=
 (is_localization.lift_eq _ _).trans $ to_open_eq_const _ _ _
 
 -- The proof here follows the argument in Hartshorne's Algebraic Geometry, Proposition II.2.2.

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -72,7 +72,18 @@ The type family over `prime_spectrum R` consisting of the localization over each
 def localizations (P : prime_spectrum.Top R) : Type u := localization.at_prime P.as_ideal
 
 instance (P : prime_spectrum.Top R) : inhabited (localizations R P) :=
-⟨(localization.of _).to_map 1⟩
+⟨1⟩
+
+instance (P : prime_spectrum.Top R) : is_localization.at_prime (localizations R P) P.as_ideal :=
+localization.is_localization
+
+instance (U : opens (prime_spectrum.Top R)) (x : U) :
+  algebra R (localizations R x) :=
+localization.algebra
+
+instance (U : opens (prime_spectrum.Top R)) (x : U) :
+  is_localization.at_prime (localizations R x) (x : prime_spectrum.Top R).as_ideal :=
+localization.is_localization
 
 variables {R}
 
@@ -82,14 +93,16 @@ The predicate saying that a dependent function on an open `U` is realised as a f
 -/
 def is_fraction {U : opens (prime_spectrum.Top R)} (f : Π x : U, localizations R x) : Prop :=
 ∃ (r s : R), ∀ x : U,
-  ¬ (s ∈ x.1.as_ideal) ∧ f x * (localization.of _).to_map s = (localization.of _).to_map r
+  ¬ (s ∈ x.1.as_ideal) ∧ f x * algebra_map _ _ s = algebra_map _ _ r
 
 lemma is_fraction.eq_mk' {U : opens (prime_spectrum.Top R)} {f : Π x : U, localizations R x}
   (hf : is_fraction f) :
-  ∃ (r s : R) , ∀ x : U, ∃ (hs : s ∉ x.1.as_ideal), f x = (localization.of _).mk' r ⟨s, hs⟩ :=
+  ∃ (r s : R) , ∀ x : U, ∃ (hs : s ∉ x.1.as_ideal), f x =
+    is_localization.mk' (localization.at_prime _) r
+      (⟨s, hs⟩ : (x : prime_spectrum.Top R).as_ideal.prime_compl) :=
 begin
   rcases hf with ⟨r, s, h⟩,
-  refine ⟨r, s, λ x, ⟨(h x).1, ((localization_map.mk'_eq_iff_eq_mul _).mpr _).symm⟩⟩,
+  refine ⟨r, s, λ x, ⟨(h x).1, (is_localization.mk'_eq_iff_eq_mul.mpr _).symm⟩⟩,
   exact (h x).2.symm,
 end
 
@@ -132,7 +145,7 @@ lemma is_locally_fraction_pred
   ∀ x : U, ∃ (V) (m : x.1 ∈ V) (i : V ⟶ U),
   ∃ (r s : R), ∀ y : V,
   ¬ (s ∈ y.1.as_ideal) ∧
-    f (i y : U) * (localization.of _).to_map s = (localization.of _).to_map r :=
+    f (i y : U) * algebra_map _ _ s = algebra_map _ _ r :=
 rfl
 
 /--
@@ -294,18 +307,18 @@ In the square brackets we list the dependencies of a construction on the previou
 def const (f g : R) (U : opens (prime_spectrum.Top R))
   (hu : ∀ x ∈ U, g ∈ (x : prime_spectrum.Top R).as_ideal.prime_compl) :
   (structure_sheaf R).presheaf.obj (op U) :=
-⟨λ x, (localization.of _).mk' f ⟨g, hu x x.2⟩,
- λ x, ⟨U, x.2, 𝟙 _, f, g, λ y, ⟨hu y y.2, localization_map.mk'_spec _ _ _⟩⟩⟩
+⟨λ x, is_localization.mk' _ f ⟨g, hu x x.2⟩,
+ λ x, ⟨U, x.2, 𝟙 _, f, g, λ y, ⟨hu y y.2, is_localization.mk'_spec _ _ _⟩⟩⟩
 
 @[simp] lemma const_apply (f g : R) (U : opens (prime_spectrum.Top R))
   (hu : ∀ x ∈ U, g ∈ (x : prime_spectrum.Top R).as_ideal.prime_compl) (x : U) :
-  (const R f g U hu).1 x = (localization.of _).mk' f ⟨g, hu x x.2⟩ :=
+  (const R f g U hu).1 x = is_localization.mk' _ f ⟨g, hu x x.2⟩ :=
 rfl
 
 lemma const_apply' (f g : R) (U : opens (prime_spectrum.Top R))
   (hu : ∀ x ∈ U, g ∈ (x : prime_spectrum.Top R).as_ideal.prime_compl) (x : U)
-  (hx : g ∈ (as_ideal x.1).prime_compl) :
-  (const R f g U hu).1 x = (localization.of _).mk' f ⟨g, hx⟩ :=
+  (hx : g ∈ (as_ideal (x : prime_spectrum.Top R)).prime_compl) :
+  (const R f g U hu).1 x = is_localization.mk' _ f ⟨g, hx⟩ :=
 rfl
 
 lemma exists_const (U) (s : (structure_sheaf R).presheaf.obj (op U)) (x : prime_spectrum.Top R)
@@ -314,7 +327,7 @@ lemma exists_const (U) (s : (structure_sheaf R).presheaf.obj (op U)) (x : prime_
   const R f g V hg = (structure_sheaf R).presheaf.map i.op s :=
 let ⟨V, hxV, iVU, f, g, hfg⟩ := s.2 ⟨x, hx⟩ in
 ⟨V, hxV, iVU, f, g, λ y hyV, (hfg ⟨y, hyV⟩).1, subtype.eq $ funext $ λ y,
-(localization.of _).mk'_eq_iff_eq_mul.2 $ eq.symm $ (hfg y).2⟩
+is_localization.mk'_eq_iff_eq_mul.2 $ eq.symm $ (hfg y).2⟩
 
 @[simp] lemma res_const (f g : R) (U hu V hv i) :
   (structure_sheaf R).presheaf.map i (const R f g U hu) = const R f g V hv :=
@@ -326,11 +339,11 @@ lemma res_const' (f g : R) (V hv) :
 rfl
 
 lemma const_zero (f : R) (U hu) : const R 0 f U hu = 0 :=
-subtype.eq $ funext $ λ x, (localization.of _).mk'_eq_iff_eq_mul.2 $
+subtype.eq $ funext $ λ x, is_localization.mk'_eq_iff_eq_mul.2 $
 by erw [ring_hom.map_zero, subtype.val_eq_coe, subring.coe_zero, pi.zero_apply, zero_mul]
 
 lemma const_self (f : R) (U hu) : const R f f U hu = 1 :=
-subtype.eq $ funext $ λ x, localization_map.mk'_self _ _
+subtype.eq $ funext $ λ x, is_localization.mk'_self _ _
 
 lemma const_one (U) : const R 1 1 U (λ p _, submonoid.one_mem _) = 1 :=
 const_self R 1 U _
@@ -339,17 +352,17 @@ lemma const_add (f₁ f₂ g₁ g₂ : R) (U hu₁ hu₂) :
   const R f₁ g₁ U hu₁ + const R f₂ g₂ U hu₂ =
   const R (f₁ * g₂ + f₂ * g₁) (g₁ * g₂) U (λ x hx, submonoid.mul_mem _ (hu₁ x hx) (hu₂ x hx)) :=
 subtype.eq $ funext $ λ x, eq.symm $
-by convert (localization.of _).mk'_add f₁ f₂ ⟨g₁, hu₁ x x.2⟩ ⟨g₂, hu₂ x x.2⟩
+by convert is_localization.mk'_add f₁ f₂ ⟨g₁, hu₁ x x.2⟩ ⟨g₂, hu₂ x x.2⟩
 
 lemma const_mul (f₁ f₂ g₁ g₂ : R) (U hu₁ hu₂) :
   const R f₁ g₁ U hu₁ * const R f₂ g₂ U hu₂ =
   const R (f₁ * f₂) (g₁ * g₂) U (λ x hx, submonoid.mul_mem _ (hu₁ x hx) (hu₂ x hx)) :=
 subtype.eq $ funext $ λ x, eq.symm $
-by convert (localization.of _).mk'_mul f₁ f₂ ⟨g₁, hu₁ x x.2⟩ ⟨g₂, hu₂ x x.2⟩
+by convert is_localization.mk'_mul _ f₁ f₂ ⟨g₁, hu₁ x x.2⟩ ⟨g₂, hu₂ x x.2⟩
 
 lemma const_ext {f₁ f₂ g₁ g₂ : R} {U hu₁ hu₂} (h : f₁ * g₂ = f₂ * g₁) :
   const R f₁ g₁ U hu₁ = const R f₂ g₂ U hu₂ :=
-subtype.eq $ funext $ λ x, (localization.of _).mk'_eq_of_eq h.symm
+subtype.eq $ funext $ λ x, is_localization.mk'_eq_of_eq h.symm
 
 lemma const_congr {f₁ f₂ g₁ g₂ : R} {U hu} (hf : f₁ = f₂) (hg : g₁ = g₂) :
   const R f₁ g₁ U hu = const R f₂ g₂ U (hg ▸ hu) :=
@@ -369,9 +382,9 @@ by rw [mul_comm, const_mul_cancel]
 
 /-- The canonical ring homomorphism interpreting an element of `R` as
 a section of the structure sheaf. -/
-@[simps] def to_open (U : opens (prime_spectrum.Top R)) :
+def to_open (U : opens (prime_spectrum.Top R)) :
   CommRing.of R ⟶ (structure_sheaf R).presheaf.obj (op U) :=
-{ to_fun := λ f, ⟨λ x, (localization.of _).to_map f,
+{ to_fun := λ f, ⟨λ x, algebra_map R _ f,
     λ x, ⟨U, x.2, 𝟙 _, f, 1, λ y, ⟨(ideal.ne_top_iff_one _).1 y.1.2.1,
       by { rw [ring_hom.map_one, mul_one], refl } ⟩⟩⟩,
   map_one' := subtype.eq $ funext $ λ x, ring_hom.map_one _,
@@ -383,9 +396,13 @@ a section of the structure sheaf. -/
   to_open R U ≫ (structure_sheaf R).presheaf.map i.op = to_open R V :=
 rfl
 
+@[simp] lemma to_open_apply (U : opens (prime_spectrum.Top R)) (f : R) (x : U) :
+  (to_open R U f).1 x = algebra_map _ _ f :=
+rfl
+
 lemma to_open_eq_const (U : opens (prime_spectrum.Top R)) (f : R) : to_open R U f =
   const R f 1 U (λ x _, (ideal.ne_top_iff_one _).1 x.2.1) :=
-subtype.eq $ funext $ λ x, eq.symm $ (localization.of _).mk'_one f
+subtype.eq $ funext $ λ x, eq.symm $ is_localization.mk'_one _ f
 
 /-- The canonical ring homomorphism interpreting an element of `R` as an element of
 the stalk of `structure_sheaf R` at `x`. -/
@@ -420,18 +437,18 @@ by { erw ← germ_to_open R (basic_open (f : R)) ⟨x, f.2⟩ (f : R),
 of the structure sheaf at the point `p`. -/
 def localization_to_stalk (x : prime_spectrum.Top R) :
   CommRing.of (localization.at_prime x.as_ideal) ⟶ (structure_sheaf R).presheaf.stalk x :=
-(localization.of _).lift (is_unit_to_stalk R x)
+show localization.at_prime x.as_ideal →+* _, from
+is_localization.lift (is_unit_to_stalk R x)
 
 @[simp] lemma localization_to_stalk_of (x : prime_spectrum.Top R) (f : R) :
-  localization_to_stalk R x ((localization.of _).to_map f) = to_stalk R x f :=
-(localization.of _).lift_eq _ f
+  localization_to_stalk R x (algebra_map _ (localization _) f) = to_stalk R x f :=
+is_localization.lift_eq _ f
 
-@[simp] lemma localization_to_stalk_mk' (x : prime_spectrum.Top R) (f : R)
-  (s : (as_ideal x).prime_compl) :
-  localization_to_stalk R x ((localization.of _).mk' f s) =
+@[simp] lemma localization_to_stalk_mk' (x : prime_spectrum.Top R) (f : R) (s : (as_ideal x).prime_compl) :
+  localization_to_stalk R x (is_localization.mk' _ f s : localization _) =
   (structure_sheaf R).presheaf.germ (⟨x, s.2⟩ : basic_open (s : R))
     (const R f s (basic_open s) (λ _, id)) :=
-((localization.of _).lift_mk'_spec _ _ _ _).2 $
+(is_localization.lift_mk'_spec _ _ _ _).2 $
 by erw [← germ_to_open R (basic_open s) ⟨x, s.2⟩, ← germ_to_open R (basic_open s) ⟨x, s.2⟩,
     ← ring_hom.map_mul, to_open_eq_const, to_open_eq_const, const_mul_cancel']
 
@@ -486,11 +503,11 @@ ring_hom.ext_iff.1 (germ_comp_stalk_to_fiber_ring_hom R U ⟨x, hx⟩ : _) s
 by { cases x, exact stalk_to_fiber_ring_hom_germ' R U _ _ _ }
 
 @[simp] lemma to_stalk_comp_stalk_to_fiber_ring_hom (x : prime_spectrum.Top R) :
-  to_stalk R x ≫ stalk_to_fiber_ring_hom R x = (localization.of _).to_map :=
+  to_stalk R x ≫ stalk_to_fiber_ring_hom R x = (algebra_map _ _ : R →+* localization _) :=
 by { erw [to_stalk, category.assoc, germ_comp_stalk_to_fiber_ring_hom], refl }
 
 @[simp] lemma stalk_to_fiber_ring_hom_to_stalk (x : prime_spectrum.Top R) (f : R) :
-  stalk_to_fiber_ring_hom R x (to_stalk R x f) = (localization.of _).to_map f :=
+  stalk_to_fiber_ring_hom R x (to_stalk R x f) = algebra_map _ (localization _) f :=
 ring_hom.ext_iff.1 (to_stalk_comp_stalk_to_fiber_ring_hom R x) _
 
 /-- The ring isomorphism between the stalk of the structure sheaf of `R` at a point `p`
@@ -507,41 +524,43 @@ corresponding to a prime ideal in `R` and the localization of `R` at `p`. -/
     refine (structure_sheaf R).presheaf.germ_ext V hxV (hom_of_le hg) iVU _,
     erw [← hs, res_const']
   end,
-  inv_hom_id' := (localization.of x.as_ideal.prime_compl).epic_of_localization_map $ λ f,
-    by simp only [ring_hom.comp_apply, comp_apply, id_apply, localization_to_stalk_of,
-        stalk_to_fiber_ring_hom_to_stalk] }
-
+  inv_hom_id' := is_localization.epic_of_localization_map x.as_ideal.prime_compl
+      (ring_hom.comp (stalk_to_fiber_ring_hom R x) (localization_to_stalk R x))
+      (ring_hom.id (localization.at_prime _)) $
+    λ f, by simp only [ring_hom.comp_apply, comp_apply, id_apply, localization_to_stalk_of,
+         algebra_map_of, stalk_to_fiber_ring_hom_to_stalk] }
 
 /-- The canonical ring homomorphism interpreting `s ∈ R_f` as a section of the structure sheaf
 on the basic open defined by `f ∈ R`. -/
 def to_basic_open (f : R) : CommRing.of (localization.away f) ⟶
   (structure_sheaf R).presheaf.obj (op $ basic_open f) :=
-localization_map.away_map.lift f (localization.away.of f) (is_unit_to_basic_open_self R f)
+is_localization.away.lift f (is_unit_to_basic_open_self R f)
 
 @[simp] lemma to_basic_open_mk' (s f : R) (g : submonoid.powers s) :
-  to_basic_open R s ((localization.of _).mk' f g) =
+  to_basic_open R s (is_localization.mk' (localization.away s) f g) =
   const R f g (basic_open s) (λ x hx, submonoid.powers_subset hx g.2) :=
-((localization.of _).lift_mk'_spec _ _ _ _).2 $
+(is_localization.lift_mk'_spec _ _ _ _).2 $
 by rw [to_open_eq_const, to_open_eq_const, const_mul_cancel']
 
 @[simp] lemma localization_to_basic_open (f : R) :
   @category_theory.category_struct.comp _ _ (CommRing.of R)
-      (CommRing.of (localization.away f)) _
-    (localization.away.of f).to_map
+    (CommRing.of (localization.away f)) _
+    (algebra_map R (localization.away.of f))
     (to_basic_open R f) =
   to_open R (basic_open f) :=
-ring_hom.ext $ λ g, (localization.of _).lift_eq _ _
+ring_hom.ext $ λ g,
+by erw [to_basic_open, is_localization.away.lift, comp_apply, is_localization.lift_eq]
 
-@[simp] lemma to_basic_open_to_map (s f : R) : to_basic_open R s ((localization.of _).to_map f) =
+@[simp] lemma to_basic_open_to_map (s f : R) : to_basic_open R s (algebra_map R (localization.away s) f) =
   const R f 1 (basic_open s) (λ _ _, submonoid.one_mem _) :=
-((localization.of _).lift_eq _ _).trans $ to_open_eq_const _ _ _
+(is_localization.lift_eq _ _).trans $ to_open_eq_const _ _ _
 
 -- The proof here follows the argument in Hartshorne's Algebraic Geometry, Proposition II.2.2.
 lemma to_basic_open_injective (f : R) : function.injective (to_basic_open R f) :=
 begin
   intros s t h_eq,
-  obtain ⟨a, ⟨b, hb⟩, rfl⟩ := (localization.of _).mk'_surjective s,
-  obtain ⟨c, ⟨d, hd⟩, rfl⟩ := (localization.of _).mk'_surjective t,
+  obtain ⟨a, ⟨b, hb⟩, rfl⟩ := is_localization.mk'_surjective (submonoid.powers f) s,
+  obtain ⟨c, ⟨d, hd⟩, rfl⟩ := is_localization.mk'_surjective (submonoid.powers f) t,
   simp only [to_basic_open_mk'] at h_eq,
   rw localization_map.eq,
   -- We know that the fractions `a/b` and `c/d` are equal as sections of the structure sheaf on

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -74,9 +74,6 @@ def localizations (P : prime_spectrum.Top R) : Type u := localization.at_prime P
 instance (P : prime_spectrum.Top R) : inhabited (localizations R P) :=
 ⟨1⟩
 
-instance (P : prime_spectrum.Top R) : is_localization.at_prime (localizations R P) P.as_ideal :=
-localization.is_localization
-
 instance (U : opens (prime_spectrum.Top R)) (x : U) :
   algebra R (localizations R x) :=
 localization.algebra

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -325,68 +325,48 @@ section gcd_domain
 
 /-- For GCD domains, the minimal polynomial over the ring is the same as the minimal polynomial
 over the fraction field. -/
-lemma gcd_domain_eq_field_fractions {A K R : Type*} [integral_domain A]
-  [gcd_monoid A] [field K] [integral_domain R] (f : fraction_map A K) [algebra f.codomain R]
-  [algebra A R] [is_scalar_tower A f.codomain R] {x : R} (hx : is_integral A x) :
-  minpoly f.codomain x = (minpoly A x).map (localization_map.to_ring_hom f) :=
+lemma gcd_domain_eq_field_fractions {A R : Type*} (K : Type*) [integral_domain A]
+  [gcd_monoid A] [field K] [integral_domain R] [algebra A K] [is_fraction_ring A K]
+  [algebra K R] [algebra A R] [is_scalar_tower A K R] {x : R} (hx : is_integral A x) :
+  minpoly K x = (minpoly A x).map (algebra_map A K) :=
 begin
   symmetry,
   refine unique' _ _ _,
-  { exact (polynomial.is_primitive.irreducible_iff_irreducible_map_fraction_map f
-  (polynomial.monic.is_primitive (monic hx))).1 (irreducible hx) },
-  { have htower := is_scalar_tower.aeval_apply A f.codomain R x (minpoly A x),
-    simp only [localization_map.algebra_map_eq, aeval] at htower,
-    exact htower.symm },
+  { exact (polynomial.is_primitive.irreducible_iff_irreducible_map_fraction_map
+      (polynomial.monic.is_primitive (monic hx))).1 (irreducible hx) },
+  { have htower := is_scalar_tower.aeval_apply A K R x (minpoly A x),
+    rwa [aeval, eq_comm] at htower },
   { exact monic_map _ (monic hx) }
 end
 
 /-- The minimal polynomial over `ℤ` is the same as the minimal polynomial over `ℚ`. -/
---TODO use `gcd_domain_eq_field_fractions` directly when localizations are defined
--- in terms of algebras instead of `ring_hom`s
 lemma over_int_eq_over_rat {A : Type*} [integral_domain A] {x : A} [hℚA : algebra ℚ A]
   (hx : is_integral ℤ x) :
   minpoly ℚ x = map (int.cast_ring_hom ℚ) (minpoly ℤ x) :=
-begin
-  symmetry,
-  refine unique' _ _ _,
-  { exact (is_primitive.int.irreducible_iff_irreducible_map_cast
-  (polynomial.monic.is_primitive (monic hx))).1 (irreducible hx) },
-  { have htower := is_scalar_tower.aeval_apply ℤ ℚ A x (minpoly ℤ x),
-    simp only [localization_map.algebra_map_eq, aeval] at htower,
-    exact htower.symm },
-  { exact monic_map _ (monic hx) }
-end
+gcd_domain_eq_field_fractions ℚ hx
 
 /-- For GCD domains, the minimal polynomial divides any primitive polynomial that has the integral
 element as root. -/
-lemma gcd_domain_dvd {A K R : Type*}
-  [integral_domain A] [gcd_monoid A] [field K] [integral_domain R]
-  (f : fraction_map A K) [algebra f.codomain R] [algebra A R] [is_scalar_tower A f.codomain R]
+lemma gcd_domain_dvd {A R : Type*} (K : Type*)
+  [integral_domain A] [gcd_monoid A] [field K] [integral_domain R] [algebra A K]
+  [is_fraction_ring A K] [algebra K R] [algebra A R] [is_scalar_tower A K R]
   {x : R} (hx : is_integral A x)
   {P : polynomial A} (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) :
   minpoly A x ∣ P :=
 begin
-  apply (is_primitive.dvd_iff_fraction_map_dvd_fraction_map f
-    (monic.is_primitive (monic hx)) hprim ).2,
-  rw [← gcd_domain_eq_field_fractions f hx],
+  apply (is_primitive.dvd_iff_fraction_map_dvd_fraction_map K
+    (monic.is_primitive (monic hx)) hprim).2,
+  rw ← gcd_domain_eq_field_fractions K hx,
   refine dvd _ _ _,
-  rwa [← localization_map.algebra_map_eq, ← is_scalar_tower.aeval_apply]
+  rwa ← is_scalar_tower.aeval_apply
 end
 
 /-- The minimal polynomial over `ℤ` divides any primitive polynomial that has the integral element
 as root. -/
--- TODO use `gcd_domain_dvd` directly when localizations are defined in terms of algebras
--- instead of `ring_hom`s
 lemma integer_dvd {A : Type*} [integral_domain A] [algebra ℚ A] {x : A} (hx : is_integral ℤ x)
   {P : polynomial ℤ} (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) :
   minpoly ℤ x ∣ P :=
-begin
-  apply (is_primitive.int.dvd_iff_map_cast_dvd_map_cast _ _
-    (monic.is_primitive (monic hx)) hprim ).2,
-  rw [← over_int_eq_over_rat hx],
-  refine dvd _ _ _,
-  rwa [(int.cast_ring_hom ℚ).ext_int (algebra_map ℤ ℚ), ← is_scalar_tower.aeval_apply]
-end
+gcd_domain_dvd ℚ hx hprim hroot
 
 end gcd_domain
 

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -339,12 +339,6 @@ begin
   { exact monic_map _ (monic hx) }
 end
 
-/-- The minimal polynomial over `ℤ` is the same as the minimal polynomial over `ℚ`. -/
-lemma over_int_eq_over_rat {A : Type*} [integral_domain A] {x : A} [hℚA : algebra ℚ A]
-  (hx : is_integral ℤ x) :
-  minpoly ℚ x = map (int.cast_ring_hom ℚ) (minpoly ℤ x) :=
-gcd_domain_eq_field_fractions ℚ hx
-
 /-- For GCD domains, the minimal polynomial divides any primitive polynomial that has the integral
 element as root. -/
 lemma gcd_domain_dvd {A R : Type*} (K : Type*)
@@ -360,13 +354,6 @@ begin
   refine dvd _ _ _,
   rwa ← is_scalar_tower.aeval_apply
 end
-
-/-- The minimal polynomial over `ℤ` divides any primitive polynomial that has the integral element
-as root. -/
-lemma integer_dvd {A : Type*} [integral_domain A] [algebra ℚ A] {x : A} (hx : is_integral ℤ x)
-  {P : polynomial ℤ} (hprim : is_primitive P) (hroot : polynomial.aeval x P = 0) :
-  minpoly ℤ x ∣ P :=
-gcd_domain_dvd ℚ hx hprim hroot
 
 end gcd_domain
 

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -42,6 +42,8 @@ dedekind domain, dedekind ring
 
 variables (R A K : Type*) [comm_ring R] [integral_domain A] [field K]
 
+local notation R`⁰`:9000 := non_zero_divisors R
+
 /-- A ring `R` has Krull dimension at most one if all nonzero prime ideals are maximal. -/
 def ring.dimension_le_one : Prop :=
 ∀ p ≠ (⊥ : ideal R), p.is_prime → p.is_maximal
@@ -82,16 +84,14 @@ class is_dedekind_domain : Prop :=
 /-- An integral domain is a Dedekind domain iff and only if it is not a field, is
 Noetherian, has dimension ≤ 1, and is integrally closed in a given fraction field.
 In particular, this definition does not depend on the choice of this fraction field. -/
-lemma is_dedekind_domain_iff (f : fraction_map A K) :
+lemma is_dedekind_domain_iff (K : Type*) [field K] [algebra A K] [is_fraction_ring A K] :
   is_dedekind_domain A ↔
     (¬ is_field A) ∧ is_noetherian_ring A ∧ dimension_le_one A ∧
-    integral_closure A f.codomain = ⊥ :=
+    integral_closure A K = ⊥ :=
 ⟨λ ⟨hf, hr, hd, hi⟩, ⟨hf, hr, hd,
-  by rw [←integral_closure_map_alg_equiv (fraction_ring.alg_equiv_of_quotient f),
-         hi, algebra.map_bot]⟩,
+  by rw [←integral_closure_map_alg_equiv (fraction_ring.alg_equiv A K), hi, algebra.map_bot]⟩,
  λ ⟨hf, hr, hd, hi⟩, ⟨hf, hr, hd,
-  by rw [←integral_closure_map_alg_equiv (fraction_ring.alg_equiv_of_quotient f).symm,
-         hi, algebra.map_bot]⟩⟩
+  by rw [←integral_closure_map_alg_equiv (fraction_ring.alg_equiv A K).symm, hi, algebra.map_bot]⟩⟩
 
 /--
 A Dedekind domain is an integral domain that is not a field, is Noetherian, and the
@@ -110,25 +110,25 @@ section inverse
 
 open_locale classical
 
-variables {R₁ : Type*} [integral_domain R₁] {g : fraction_map R₁ K}
-variables {I J : fractional_ideal g}
+variables {R₁ : Type*} [integral_domain R₁] [algebra R₁ K] [is_fraction_ring R₁ K]
+variables {I J : fractional_ideal R₁⁰ K}
 
-noncomputable instance : has_inv (fractional_ideal g) := ⟨λ I, 1 / I⟩
+noncomputable instance : has_inv (fractional_ideal R₁⁰ K) := ⟨λ I, 1 / I⟩
 
 lemma inv_eq : I⁻¹ = 1 / I := rfl
 
-lemma inv_zero' : (0 : fractional_ideal g)⁻¹ = 0 := fractional_ideal.div_zero
+lemma inv_zero' : (0 : fractional_ideal R₁⁰ K)⁻¹ = 0 := fractional_ideal.div_zero
 
-lemma inv_nonzero {J : fractional_ideal g} (h : J ≠ 0) :
-J⁻¹ = ⟨(1 : fractional_ideal g) / J, fractional_ideal.fractional_div_of_nonzero h⟩ :=
+lemma inv_nonzero {J : fractional_ideal R₁⁰ K} (h : J ≠ 0) :
+J⁻¹ = ⟨(1 : fractional_ideal R₁⁰ K) / J, fractional_ideal.fractional_div_of_nonzero h⟩ :=
 fractional_ideal.div_nonzero _
 
-lemma coe_inv_of_nonzero {J : fractional_ideal g} (h : J ≠ 0) :
-  (↑J⁻¹ : submodule R₁ g.codomain) = g.coe_submodule 1 / J :=
+lemma coe_inv_of_nonzero {J : fractional_ideal R₁⁰ K} (h : J ≠ 0) :
+  (↑J⁻¹ : submodule R₁ K) = is_localization.coe_submodule K 1 / J :=
 by { rwa inv_nonzero _, refl, assumption}
 
 /-- `I⁻¹` is the inverse of `I` if `I` has an inverse. -/
-theorem right_inverse_eq (I J : fractional_ideal g) (h : I * J = 1) :
+theorem right_inverse_eq (I J : fractional_ideal R₁⁰ K) (h : I * J = 1) :
   J = I⁻¹ :=
 begin
   have hI : I ≠ 0 := fractional_ideal.ne_zero_of_mul_eq_one I J h,
@@ -148,27 +148,27 @@ begin
   exact fractional_ideal.mul_mem_mul hx hy
 end
 
-theorem mul_inv_cancel_iff {I : fractional_ideal g} :
+theorem mul_inv_cancel_iff {I : fractional_ideal R₁⁰ K} :
   I * I⁻¹ = 1 ↔ ∃ J, I * J = 1 :=
-⟨λ h, ⟨I⁻¹, h⟩, λ ⟨J, hJ⟩, by rwa [← @right_inverse_eq _ _ _ _ _ I J hJ]⟩
+⟨λ h, ⟨I⁻¹, h⟩, λ ⟨J, hJ⟩, by rwa ← right_inverse_eq K I J hJ⟩
 
-variables {K' : Type*} [field K'] {g' : fraction_map R₁ K'}
+variables {K' : Type*} [field K'] [algebra R₁ K'] [is_fraction_ring R₁ K']
 
-@[simp] lemma map_inv (I : fractional_ideal g) (h : g.codomain ≃ₐ[R₁] g'.codomain) :
-  (I⁻¹).map (h : g.codomain →ₐ[R₁] g'.codomain) = (I.map h)⁻¹ :=
+@[simp] lemma map_inv (I : fractional_ideal R₁⁰ K) (h : K ≃ₐ[R₁] K') :
+  (I⁻¹).map (h : K →ₐ[R₁] K') = (I.map h)⁻¹ :=
 by rw [inv_eq, fractional_ideal.map_div, fractional_ideal.map_one, inv_eq]
 
 open_locale classical
 
 open submodule submodule.is_principal
 
-@[simp] lemma span_singleton_inv (x : g.codomain) :
-  (fractional_ideal.span_singleton x)⁻¹ = fractional_ideal.span_singleton (x⁻¹) :=
+@[simp] lemma span_singleton_inv (x : K) :
+  (fractional_ideal.span_singleton R₁⁰ x)⁻¹ = fractional_ideal.span_singleton _ (x⁻¹) :=
 fractional_ideal.one_div_span_singleton x
 
-lemma mul_generator_self_inv (I : fractional_ideal g)
-  [submodule.is_principal (I : submodule R₁ g.codomain)] (h : I ≠ 0) :
-  I * fractional_ideal.span_singleton (generator (I : submodule R₁ g.codomain))⁻¹ = 1 :=
+lemma mul_generator_self_inv (I : fractional_ideal R₁⁰ K)
+  [submodule.is_principal (I : submodule R₁ K)] (h : I ≠ 0) :
+  I * fractional_ideal.span_singleton _ (generator (I : submodule R₁ K))⁻¹ = 1 :=
 begin
   -- Rewrite only the `I` that appears alone.
   conv_lhs { congr, rw fractional_ideal.eq_span_singleton_of_principal I },
@@ -180,16 +180,16 @@ begin
     fractional_ideal.span_singleton_zero]
 end
 
-lemma invertible_of_principal (I : fractional_ideal g)
-  [submodule.is_principal (I : submodule R₁ g.codomain)] (h : I ≠ 0) :
+lemma invertible_of_principal (I : fractional_ideal R₁⁰ K)
+  [submodule.is_principal (I : submodule R₁ K)] (h : I ≠ 0) :
   I * I⁻¹ = 1 :=
 (fractional_ideal.mul_div_self_cancel_iff).mpr
-  ⟨fractional_ideal.span_singleton (generator (I : submodule R₁ g.codomain))⁻¹,
-    @mul_generator_self_inv _ _ _ _ _ I _ h⟩
+  ⟨fractional_ideal.span_singleton _ (generator (I : submodule R₁ K))⁻¹,
+    mul_generator_self_inv _ I h⟩
 
-lemma invertible_iff_generator_nonzero (I : fractional_ideal g)
-  [submodule.is_principal (I : submodule R₁ g.codomain)] :
-  I * I⁻¹ = 1 ↔ generator (I : submodule R₁ g.codomain) ≠ 0 :=
+lemma invertible_iff_generator_nonzero (I : fractional_ideal R₁⁰ K)
+  [submodule.is_principal (I : submodule R₁ K)] :
+  I * I⁻¹ = 1 ↔ generator (I : submodule R₁ K) ≠ 0 :=
 begin
   split,
   { intros hI hg,
@@ -200,21 +200,21 @@ begin
     apply invertible_of_principal,
     rw [fractional_ideal.eq_span_singleton_of_principal I],
     intro hI,
-    have := fractional_ideal.mem_span_singleton_self (generator (I : submodule R₁ g.codomain)),
+    have := fractional_ideal.mem_span_singleton_self _ (generator (I : submodule R₁ K)),
     rw [hI, fractional_ideal.mem_zero_iff] at this,
     contradiction }
 end
 
-lemma is_principal_inv (I : fractional_ideal g)
-  [submodule.is_principal (I : submodule R₁ g.codomain)] (h : I ≠ 0) :
+lemma is_principal_inv (I : fractional_ideal R₁⁰ K)
+  [submodule.is_principal (I : submodule R₁ K)] (h : I ≠ 0) :
   submodule.is_principal (I⁻¹).1 :=
 begin
   rw [fractional_ideal.val_eq_coe, fractional_ideal.is_principal_iff],
-  use (generator (I : submodule R₁ g.codomain))⁻¹,
-  have hI : I  * fractional_ideal.span_singleton ((generator (I : submodule R₁ g.codomain))⁻¹)  = 1,
-  apply @mul_generator_self_inv _ _ _ _ _ I _ h,
-  apply (@right_inverse_eq _ _ _ _ _ I (fractional_ideal.span_singleton
-    ( (generator (I : submodule R₁ g.codomain))⁻¹)) hI).symm,
+  use (generator (I : submodule R₁ K))⁻¹,
+  have hI : I  * fractional_ideal.span_singleton _ ((generator (I : submodule R₁ K))⁻¹)  = 1,
+  apply mul_generator_self_inv _ I h,
+  exact (right_inverse_eq _ I (fractional_ideal.span_singleton _
+    ((generator (I : submodule R₁ K))⁻¹)) hI).symm
 end
 
 /--
@@ -226,22 +226,22 @@ TODO: prove the equivalence.
 -/
 structure is_dedekind_domain_inv : Prop :=
 (not_is_field : ¬ is_field A)
-(mul_inv_cancel : ∀ I ≠ (⊥ : fractional_ideal (fraction_ring.of A)), I * (1 / I) = 1)
+(mul_inv_cancel : ∀ I ≠ (⊥ : fractional_ideal A⁰ (fraction_ring A)), I * (1 / I) = 1)
 
 open ring.fractional_ideal
 
-lemma is_dedekind_domain_inv_iff (f : fraction_map A K) :
+lemma is_dedekind_domain_inv_iff (K : Type*) [field K] [algebra A K] [is_fraction_ring A K] :
   is_dedekind_domain_inv A ↔
-    (¬ is_field A) ∧ (∀ I ≠ (⊥ : fractional_ideal f), I * I⁻¹ = 1) :=
+    (¬ is_field A) ∧ (∀ I ≠ (⊥ : fractional_ideal A⁰ K), I * I⁻¹ = 1) :=
 begin
-  set h : (fraction_ring.of A).codomain ≃ₐ[A] f.codomain := fraction_ring.alg_equiv_of_quotient f,
+  set h : fraction_ring A ≃ₐ[A] K := fraction_ring.alg_equiv A K,
   split; rintros ⟨hf, hi⟩; use hf; intros I hI,
   { have := hi (map ↑h.symm I) (map_ne_zero _ hI),
-    convert congr_arg (map (h : (fraction_ring.of A).codomain →ₐ[A] f.codomain)) this;
+    convert congr_arg (map (h : fraction_ring A →ₐ[A] K)) this;
       simp only [map_symm_map, map_one, fractional_ideal.map_mul, fractional_ideal.map_div,
                  inv_eq] },
   { have := hi (map ↑h I) (map_ne_zero _ hI),
-    convert congr_arg (map (h.symm : f.codomain →ₐ[A] (fraction_ring.of A).codomain)) this;
+    convert congr_arg (map (h.symm : K →ₐ[A] fraction_ring A)) this;
       simp only [map_map_symm, map_one, fractional_ideal.map_mul, fractional_ideal.map_div,
                  inv_eq] },
 end

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -737,11 +737,10 @@ begin
     intro y'_eq_zero,
     have : algebra_map R₁ K aJ * y = 0,
     { rw [← algebra.smul_def, ←hy', y'_eq_zero, ring_hom.map_zero] },
-    obtain aJ_zero | y_zero := mul_eq_zero.mp this,
-    { have : aJ = 0 := (algebra_map R₁ K).injective_iff.1 (is_fraction_ring.injective _ _) _ aJ_zero,
-      have : aJ ≠ 0 := mem_non_zero_divisors_iff_ne_zero.mp haJ,
-      contradiction },
-    { exact not_mem_zero ((mem_zero_iff R₁⁰).mpr y_zero) } },
+    have y_zero := (mul_eq_zero.mp this).resolve_left
+      (mt ((algebra_map R₁ K).injective_iff.1 (is_fraction_ring.injective _ _) _)
+          (mem_non_zero_divisors_iff_ne_zero.mp haJ)),
+    exact not_mem_zero ((mem_zero_iff R₁⁰).mpr y_zero) },
   intros b hb,
   convert hI _ (hb _ (submodule.smul_mem _ aJ mem_J)) using 1,
   rw [← hy', mul_comm b, ← algebra.smul_def, mul_smul]

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -17,15 +17,16 @@ This file defines fractional ideals of an integral domain and proves basic facts
 Let `S` be a submonoid of an integral domain `R`, `P` the localization of `R` at `S`, and `f` the
 natural ring hom from `R` to `P`.
  * `is_fractional` defines which `R`-submodules of `P` are fractional ideals
- * `fractional_ideal f` is the type of fractional ideals in `P`
- * `has_coe (ideal R) (fractional_ideal f)` instance
- * `comm_semiring (fractional_ideal f)` instance:
+ * `fractional_ideal S P` is the type of fractional ideals in `P`
+ * `has_coe (ideal R) (fractional_ideal S P)` instance
+ * `comm_semiring (fractional_ideal S P)` instance:
    the typical ideal operations generalized to fractional ideals
- * `lattice (fractional_ideal f)` instance
+ * `lattice (fractional_ideal S P)` instance
  * `map` is the pushforward of a fractional ideal along an algebra morphism
 
-Let `K` be the localization of `R` at `R \ {0}` and `g` the natural ring hom from `R` to `K`.
- * `has_div (fractional_ideal g)` instance:
+Let `K` be the localization of `R` at `R⁰ = R \ {0}` (i.e. the field of fractions).
+ * `fractional_ideal R⁰ K` is the type of fractional ideals in the field of fractions
+ * `has_div (fractional_ideal R⁰ K)` instance:
    the ideal quotient `I / J` (typically written $I : J$, but a `:` operator cannot be defined)
 
 ## Main statements
@@ -47,12 +48,8 @@ Exceptions to this rule are defining `(+) := (⊔)` and `⊥ := 0`,
 in order to re-use their respective proof terms.
 We can still use `simp` to show `I.1 + J.1 = (I + J).1` and `⊥.1 = 0.1`.
 
-In `ring_theory.localization`, we define a copy of the localization map `f`'s codomain `P`
-(`f.codomain`) so that the `R`-algebra instance on `P` can 'know' the map needed to induce
-the `R`-algebra structure.
-
 We don't assume that the localization is a field until we need it to define ideal quotients.
-When this assumption is needed, we replace `S` with `non_zero_divisors R`, making the localization
+When this assumption is needed, we replace `S` with `R⁰`, making the localization
 a field.
 
 ## References
@@ -64,18 +61,24 @@ a field.
 fractional ideal, fractional ideals, invertible ideal
 -/
 
-open localization_map
+open is_localization
+
+local notation R`⁰`:9000 := non_zero_divisors R
 
 namespace ring
 
 section defs
 
 variables {R : Type*} [comm_ring R] {S : submonoid R} {P : Type*} [comm_ring P]
-  (f : localization_map S P)
+variables [algebra R P] [is_localization S P]
+
+variables (S)
 
 /-- A submodule `I` is a fractional ideal if `a I ⊆ R` for some `a ≠ 0`. -/
-def is_fractional (I : submodule R f.codomain) :=
-∃ a ∈ S, ∀ b ∈ I, f.is_integer (f.to_map a * b)
+def is_fractional (I : submodule R P) :=
+∃ a ∈ S, ∀ b ∈ I, is_integer R (a • b)
+
+variables (S P)
 
 /-- The fractional ideals of a domain `R` are ideals of `R` divided by some `a ∈ R`.
 
@@ -84,7 +87,7 @@ def is_fractional (I : submodule R f.codomain) :=
   such that there is a nonzero `a : R` with `a I ⊆ R`.
 -/
 def fractional_ideal :=
-{I : submodule R f.codomain // is_fractional f I}
+{I : submodule R P // is_fractional S I}
 
 end defs
 
@@ -94,44 +97,45 @@ open set
 open submodule
 
 variables {R : Type*} [comm_ring R] {S : submonoid R} {P : Type*} [comm_ring P]
-  {f : localization_map S P}
+variables [algebra R P] [is_localization S P]
 
-instance : has_coe (fractional_ideal f) (submodule R f.codomain) := ⟨λ I, I.val⟩
+instance : has_coe (fractional_ideal S P) (submodule R P) := ⟨λ I, I.val⟩
 
-@[simp] lemma val_eq_coe (I : fractional_ideal f) : I.val = I := rfl
+@[simp] lemma val_eq_coe (I : fractional_ideal S P) : I.val = I := rfl
 
-@[simp, norm_cast] lemma coe_mk (I : submodule R f.codomain) (hI : is_fractional f I) :
-  (subtype.mk I hI : submodule R f.codomain) = I := rfl
+@[simp, norm_cast] lemma coe_mk (I : submodule R P) (hI : is_fractional S I) :
+  (subtype.mk I hI : submodule R P) = I := rfl
 
-instance : has_mem P (fractional_ideal f) := ⟨λ x I, x ∈ (I : submodule R f.codomain)⟩
+instance : has_mem P (fractional_ideal S P) := ⟨λ x I, x ∈ (I : submodule R P)⟩
 
 /-- Fractional ideals are equal if their submodules are equal.
 
   Combined with `submodule.ext` this gives that fractional ideals are equal if
   they have the same elements.
 -/
-@[ext]
-lemma ext {I J : fractional_ideal f} : (I : submodule R f.codomain) = J → I = J :=
+lemma coe_injective {I J : fractional_ideal S P} : (I : submodule R P) = J → I = J :=
 subtype.ext_iff_val.mpr
 
-lemma ext_iff {I J : fractional_ideal f} : (∀ x, (x ∈ I ↔ x ∈ J)) ↔ I = J :=
-⟨ λ h, ext (submodule.ext h), λ h x, h ▸ iff.rfl ⟩
+lemma ext_iff {I J : fractional_ideal S P} : (∀ x, (x ∈ I ↔ x ∈ J)) ↔ I = J :=
+⟨λ h, coe_injective (submodule.ext h), λ h x, h ▸ iff.rfl⟩
 
-lemma fractional_of_subset_one (I : submodule R f.codomain)
+@[ext] lemma ext {I J : fractional_ideal S P} : (∀ x, (x ∈ I ↔ x ∈ J)) → I = J :=
+ext_iff.mp
+
+lemma fractional_of_subset_one (I : submodule R P)
   (h : I ≤ (submodule.span R {1})) :
-  is_fractional f I :=
+  is_fractional S I :=
 begin
   use [1, S.one_mem],
   intros b hb,
-  rw [f.to_map.map_one, one_mul],
+  rw one_smul,
   rw ←submodule.one_eq_span at h,
-  obtain ⟨b', b'_mem, b'_eq_b⟩ := h hb,
-  rw (show b = f.to_map b', from b'_eq_b.symm),
+  obtain ⟨b', b'_mem, rfl⟩ := h hb,
   exact set.mem_range_self b',
 end
 
-lemma is_fractional_of_le {I : submodule R f.codomain} {J : fractional_ideal f}
-  (hIJ : I ≤ J) : is_fractional f I :=
+lemma is_fractional_of_le {I : submodule R P} {J : fractional_ideal S P}
+  (hIJ : I ≤ J) : is_fractional S I :=
 begin
   obtain ⟨a, a_mem, ha⟩ := J.2,
   use [a, a_mem],
@@ -139,85 +143,98 @@ begin
   exact ha b (hIJ b_mem)
 end
 
-instance coe_to_fractional_ideal : has_coe (ideal R) (fractional_ideal f) :=
-⟨ λ I, ⟨f.coe_submodule I, fractional_of_subset_one _ $ λ x ⟨y, hy, h⟩,
-  submodule.mem_span_singleton.2 ⟨y, by rw ←h; exact mul_one _⟩⟩ ⟩
+instance coe_to_fractional_ideal : has_coe (ideal R) (fractional_ideal S P) :=
+⟨λ I, ⟨coe_submodule P I, fractional_of_subset_one _ $ λ x ⟨y, hy, h⟩,
+ submodule.mem_span_singleton.2 ⟨y, by rw ← h; exact (algebra.algebra_map_eq_smul_one y).symm⟩⟩⟩
 
 @[simp, norm_cast] lemma coe_coe_ideal (I : ideal R) :
-  ((I : fractional_ideal f) : submodule R f.codomain) = f.coe_submodule I := rfl
+  ((I : fractional_ideal S P) : submodule R P) = coe_submodule P I := rfl
 
-@[simp] lemma mem_coe_ideal {x : f.codomain} {I : ideal R} :
-  x ∈ (I : fractional_ideal f) ↔ ∃ (x' ∈ I), f.to_map x' = x :=
+variables (S)
+
+@[simp] lemma mem_coe_ideal {x : P} {I : ideal R} :
+  x ∈ (I : fractional_ideal S P) ↔ ∃ (x' ∈ I), algebra_map R P x' = x :=
 ⟨ λ ⟨x', hx', hx⟩, ⟨x', hx', hx⟩,
   λ ⟨x', hx', hx⟩, ⟨x', hx', hx⟩ ⟩
 
-instance : has_zero (fractional_ideal f) := ⟨(0 : ideal R)⟩
+instance : has_zero (fractional_ideal S P) := ⟨(0 : ideal R)⟩
 
-@[simp] lemma mem_zero_iff {x : P} : x ∈ (0 : fractional_ideal f) ↔ x = 0 :=
+@[simp] lemma mem_zero_iff {x : P} : x ∈ (0 : fractional_ideal S P) ↔ x = 0 :=
 ⟨ (λ ⟨x', x'_mem_zero, x'_eq_x⟩,
     have x'_eq_zero : x' = 0 := x'_mem_zero,
     by simp [x'_eq_x.symm, x'_eq_zero]),
   (λ hx, ⟨0, rfl, by simp [hx]⟩) ⟩
 
-@[simp, norm_cast] lemma coe_zero : ↑(0 : fractional_ideal f) = (⊥ : submodule R f.codomain) :=
-submodule.ext $ λ _, mem_zero_iff
+variables {S}
 
-@[simp, norm_cast] lemma coe_to_fractional_ideal_bot : ((⊥ : ideal R) : fractional_ideal f) = 0 :=
+@[simp, norm_cast] lemma coe_zero : ↑(0 : fractional_ideal S P) = (⊥ : submodule R P) :=
+submodule.ext $ λ _, mem_zero_iff S
+
+@[simp, norm_cast] lemma coe_to_fractional_ideal_bot : ((⊥ : ideal R) : fractional_ideal S P) = 0 :=
 rfl
 
+variables (P)
+
 @[simp] lemma exists_mem_to_map_eq {x : R} {I : ideal R} (h : S ≤ non_zero_divisors R) :
-  (∃ x', x' ∈ I ∧ f.to_map x' = f.to_map x) ↔ x ∈ I :=
-⟨λ ⟨x', hx', eq⟩, f.injective h eq ▸ hx', λ h, ⟨x, h, rfl⟩⟩
+  (∃ x', x' ∈ I ∧ algebra_map R P x' = algebra_map R P x) ↔ x ∈ I :=
+⟨λ ⟨x', hx', eq⟩, is_localization.injective _ h eq ▸ hx', λ h, ⟨x, h, rfl⟩⟩
+
+variables {P}
 
 lemma coe_to_fractional_ideal_injective (h : S ≤ non_zero_divisors R) :
-  function.injective (coe : ideal R → fractional_ideal f) :=
+  function.injective (coe : ideal R → fractional_ideal S P) :=
 λ I J heq, have
-  ∀ (x : R), f.to_map x ∈ (I : fractional_ideal f) ↔ f.to_map x ∈ (J : fractional_ideal f) :=
+  ∀ (x : R), algebra_map R P x ∈ (I : fractional_ideal S P) ↔
+             algebra_map R P x ∈ (J : fractional_ideal S P) :=
 λ x, heq ▸ iff.rfl,
-ideal.ext (by { simpa only [mem_coe_ideal, exists_prop, exists_mem_to_map_eq h] using this })
+ideal.ext (by simpa only [mem_coe_ideal, exists_prop, exists_mem_to_map_eq P h] using this)
 
 lemma coe_to_fractional_ideal_eq_zero {I : ideal R} (hS : S ≤ non_zero_divisors R) :
-  (I : fractional_ideal f) = 0 ↔ I = (⊥ : ideal R) :=
+  (I : fractional_ideal S P) = 0 ↔ I = (⊥ : ideal R) :=
 ⟨λ h, coe_to_fractional_ideal_injective hS h,
  λ h, by rw [h, coe_to_fractional_ideal_bot]⟩
 
 lemma coe_to_fractional_ideal_ne_zero {I : ideal R} (hS : S ≤ non_zero_divisors R) :
-  (I : fractional_ideal f) ≠ 0 ↔ I ≠ (⊥ : ideal R) :=
+  (I : fractional_ideal S P) ≠ 0 ↔ I ≠ (⊥ : ideal R) :=
 not_iff_not.mpr (coe_to_fractional_ideal_eq_zero hS)
 
-lemma coe_to_submodule_eq_bot {I : fractional_ideal f} :
-  (I : submodule R f.codomain) = ⊥ ↔ I = 0 :=
-⟨λ h, ext (by simp [h]),
+lemma coe_to_submodule_eq_bot {I : fractional_ideal S P} :
+  (I : submodule R P) = ⊥ ↔ I = 0 :=
+⟨λ h, coe_injective (by simp [h]),
  λ h, by simp [h] ⟩
 
-lemma coe_to_submodule_ne_bot {I : fractional_ideal f} :
-  ↑I ≠ (⊥ : submodule R f.codomain) ↔ I ≠ 0 :=
+lemma coe_to_submodule_ne_bot {I : fractional_ideal S P} :
+  ↑I ≠ (⊥ : submodule R P) ↔ I ≠ 0 :=
 not_iff_not.mpr coe_to_submodule_eq_bot
 
-instance : inhabited (fractional_ideal f) := ⟨0⟩
+instance : inhabited (fractional_ideal S P) := ⟨0⟩
 
-instance : has_one (fractional_ideal f) :=
+instance : has_one (fractional_ideal S P) :=
 ⟨(1 : ideal R)⟩
 
-lemma mem_one_iff {x : P} : x ∈ (1 : fractional_ideal f) ↔ ∃ x' : R, f.to_map x' = x :=
+variables (S)
+
+lemma mem_one_iff {x : P} : x ∈ (1 : fractional_ideal S P) ↔ ∃ x' : R, algebra_map R P x' = x :=
 iff.intro (λ ⟨x', _, h⟩, ⟨x', h⟩) (λ ⟨x', h⟩, ⟨x', ⟨x', set.mem_univ _, rfl⟩, h⟩)
 
-lemma coe_mem_one (x : R) : f.to_map x ∈ (1 : fractional_ideal f) :=
-mem_one_iff.mpr ⟨x, rfl⟩
+lemma coe_mem_one (x : R) : algebra_map R P x ∈ (1 : fractional_ideal S P) :=
+(mem_one_iff S).mpr ⟨x, rfl⟩
 
-lemma one_mem_one : (1 : P) ∈ (1 : fractional_ideal f) :=
-mem_one_iff.mpr ⟨1, f.to_map.map_one⟩
+lemma one_mem_one : (1 : P) ∈ (1 : fractional_ideal S P) :=
+(mem_one_iff S).mpr ⟨1, ring_hom.map_one _⟩
 
-/-- `(1 : fractional_ideal f)` is defined as the R-submodule `f(R) ≤ K`.
+variables {S}
 
-However, this is not definitionally equal to `1 : submodule R K`,
+/-- `(1 : fractional_ideal S P)` is defined as the R-submodule `f(R) ≤ P`.
+
+However, this is not definitionally equal to `1 : submodule R P`,
 which is proved in the actual `simp` lemma `coe_one`. -/
 lemma coe_one_eq_coe_submodule_one :
-  ↑(1 : fractional_ideal f) = f.coe_submodule (1 : ideal R) :=
+  ↑(1 : fractional_ideal S P) = coe_submodule P (1 : ideal R) :=
 rfl
 
 @[simp, norm_cast] lemma coe_one :
-  (↑(1 : fractional_ideal f) : submodule R f.codomain) = 1 :=
+  (↑(1 : fractional_ideal S P) : submodule R P) = 1 :=
 begin
   simp only [coe_one_eq_coe_submodule_one, ideal.one_eq_top],
   convert (submodule.one_eq_map_top).symm,
@@ -232,69 +249,68 @@ Defines the order on fractional ideals as inclusion of their underlying sets,
 and ports the lattice structure on submodules to fractional ideals.
 -/
 
-instance : partial_order (fractional_ideal f) :=
+instance : partial_order (fractional_ideal S P) :=
 { le := λ I J, I.1 ≤ J.1,
   le_refl := λ I, le_refl I.1,
   le_antisymm := λ ⟨I, hI⟩ ⟨J, hJ⟩ hIJ hJI, by { congr, exact le_antisymm hIJ hJI },
   le_trans := λ _ _ _ hIJ hJK, le_trans hIJ hJK }
 
-lemma le_iff_mem {I J : fractional_ideal f} : I ≤ J ↔ (∀ x ∈ I, x ∈ J) :=
+lemma le_iff_mem {I J : fractional_ideal S P} : I ≤ J ↔ (∀ x ∈ I, x ∈ J) :=
 iff.rfl
 
-@[simp] lemma coe_le_coe {I J : fractional_ideal f} :
-  (I : submodule R f.codomain) ≤ (J : submodule R f.codomain) ↔ I ≤ J :=
+@[simp] lemma coe_le_coe {I J : fractional_ideal S P} :
+  (I : submodule R P) ≤ (J : submodule R P) ↔ I ≤ J :=
 iff.rfl
 
-lemma zero_le (I : fractional_ideal f) : 0 ≤ I :=
+lemma zero_le (I : fractional_ideal S P) : 0 ≤ I :=
 begin
   intros x hx,
   convert submodule.zero_mem _,
   simpa using hx
 end
 
-instance order_bot : order_bot (fractional_ideal f) :=
+instance order_bot : order_bot (fractional_ideal S P) :=
 { bot := 0,
   bot_le := zero_le,
   ..fractional_ideal.partial_order }
 
-@[simp] lemma bot_eq_zero : (⊥ : fractional_ideal f) = 0 :=
+@[simp] lemma bot_eq_zero : (⊥ : fractional_ideal S P) = 0 :=
 rfl
 
-@[simp] lemma le_zero_iff {I : fractional_ideal f} : I ≤ 0 ↔ I = 0 :=
+@[simp] lemma le_zero_iff {I : fractional_ideal S P} : I ≤ 0 ↔ I = 0 :=
 le_bot_iff
 
-lemma eq_zero_iff {I : fractional_ideal f} : I = 0 ↔ (∀ x ∈ I, x = (0 : P)) :=
+lemma eq_zero_iff {I : fractional_ideal S P} : I = 0 ↔ (∀ x ∈ I, x = (0 : P)) :=
 ⟨ (λ h x hx, by simpa [h, mem_zero_iff] using hx),
-  (λ h, le_bot_iff.mp (λ x hx, mem_zero_iff.mpr (h x hx))) ⟩
+  (λ h, le_bot_iff.mp (λ x hx, (mem_zero_iff S).mpr (h x hx))) ⟩
 
-lemma fractional_sup (I J : fractional_ideal f) : is_fractional f (I.1 ⊔ J.1) :=
+lemma fractional_sup (I J : fractional_ideal S P) : is_fractional S (I.1 ⊔ J.1) :=
 begin
   rcases I.2 with ⟨aI, haI, hI⟩,
   rcases J.2 with ⟨aJ, haJ, hJ⟩,
   use aI * aJ,
   use S.mul_mem haI haJ,
   intros b hb,
-  rcases mem_sup.mp hb with
-    ⟨bI, hbI, bJ, hbJ, hbIJ⟩,
-  rw [←hbIJ, mul_add],
+  rcases mem_sup.mp hb with ⟨bI, hbI, bJ, hbJ, rfl⟩,
+  rw smul_add,
   apply is_integer_add,
-  { rw [mul_comm aI, f.to_map.map_mul, mul_assoc],
-    apply is_integer_smul (hI bI hbI), },
-  { rw [f.to_map.map_mul, mul_assoc],
-    apply is_integer_smul (hJ bJ hbJ) }
+  { rw [mul_smul, smul_comm],
+    exact is_integer_smul (hI bI hbI), },
+  { rw mul_smul,
+    exact is_integer_smul (hJ bJ hbJ) }
 end
 
-lemma fractional_inf (I J : fractional_ideal f) : is_fractional f (I.1 ⊓ J.1) :=
+lemma fractional_inf (I J : fractional_ideal S P) : is_fractional S (I.1 ⊓ J.1) :=
 begin
   rcases I.2 with ⟨aI, haI, hI⟩,
   use aI,
   use haI,
   intros b hb,
   rcases mem_inf.mp hb with ⟨hbI, hbJ⟩,
-  exact (hI b hbI)
+  exact hI b hbI
 end
 
-instance lattice : lattice (fractional_ideal f) :=
+instance lattice : lattice (fractional_ideal S P) :=
 { inf := λ I J, ⟨I.1 ⊓ J.1, fractional_inf I J⟩,
   sup := λ I J, ⟨I.1 ⊔ J.1, fractional_sup I J⟩,
   inf_le_left := λ I J, show I.1 ⊓ J.1 ≤ I.1, from inf_le_left,
@@ -305,22 +321,22 @@ instance lattice : lattice (fractional_ideal f) :=
   sup_le := λ I J K hIK hJK, show (I.1 ⊔ J.1) ≤ K.1, from sup_le hIK hJK,
   ..fractional_ideal.partial_order }
 
-instance : semilattice_sup_bot (fractional_ideal f) :=
+instance : semilattice_sup_bot (fractional_ideal S P) :=
 { ..fractional_ideal.order_bot, ..fractional_ideal.lattice }
 
 end lattice
 
 section semiring
 
-instance : has_add (fractional_ideal f) := ⟨(⊔)⟩
+instance : has_add (fractional_ideal S P) := ⟨(⊔)⟩
 
 @[simp]
-lemma sup_eq_add (I J : fractional_ideal f) : I ⊔ J = I + J := rfl
+lemma sup_eq_add (I J : fractional_ideal S P) : I ⊔ J = I + J := rfl
 
 @[simp, norm_cast]
-lemma coe_add (I J : fractional_ideal f) : (↑(I + J) : submodule R f.codomain) = I + J := rfl
+lemma coe_add (I J : fractional_ideal S P) : (↑(I + J) : submodule R P) = I + J := rfl
 
-lemma fractional_mul (I J : fractional_ideal f) : is_fractional f (I.1 * J.1) :=
+lemma fractional_mul (I J : fractional_ideal S P) : is_fractional S (I.1 * J.1) :=
 begin
   rcases I with ⟨I, aI, haI, hI⟩,
   rcases J with ⟨J, aJ, haJ, hJ⟩,
@@ -330,19 +346,17 @@ begin
   apply submodule.mul_induction_on hb,
   { intros m hm n hn,
     obtain ⟨n', hn'⟩ := hJ n hn,
-    rw [f.to_map.map_mul, mul_comm m, ←mul_assoc, mul_assoc _ _ n],
-    erw ←hn', rw mul_assoc,
+    rw [mul_smul, mul_comm m, ← smul_mul_assoc, ← hn', ← algebra.smul_def],
     apply hI,
     exact submodule.smul_mem _ _ hm },
-  { rw [mul_zero],
-    exact ⟨0, f.to_map.map_zero⟩ },
+  { rw smul_zero,
+    exact ⟨0, ring_hom.map_zero _⟩ },
   { intros x y hx hy,
-    rw [mul_add],
+    rw smul_add,
     apply is_integer_add hx hy },
   { intros r x hx,
-    show f.is_integer (_ * (f.to_map r * x)),
-    rw [←mul_assoc, ←f.to_map.map_mul, mul_comm _ r, f.to_map.map_mul, mul_assoc],
-    apply is_integer_smul hx },
+    rw smul_comm,
+    exact is_integer_smul hx },
 end
 
 /-- `fractional_ideal.mul` is the product of two fractional ideals,
@@ -354,129 +368,131 @@ Elaborated terms involving `fractional_ideal` tend to grow quite large,
 so by making definitions irreducible, we hope to avoid deep unfolds.
 -/
 @[irreducible]
-def mul (I J : fractional_ideal f) : fractional_ideal f :=
+def mul (I J : fractional_ideal S P) : fractional_ideal S P :=
 ⟨I.1 * J.1, fractional_mul I J⟩
 
 local attribute [semireducible] mul
 
-instance : has_mul (fractional_ideal f) := ⟨λ I J, mul I J⟩
+instance : has_mul (fractional_ideal S P) := ⟨λ I J, mul I J⟩
 
-@[simp] lemma mul_eq_mul (I J : fractional_ideal f) : mul I J = I * J := rfl
+@[simp] lemma mul_eq_mul (I J : fractional_ideal S P) : mul I J = I * J := rfl
 
 @[simp, norm_cast]
-lemma coe_mul (I J : fractional_ideal f) : (↑(I * J) : submodule R f.codomain) = I * J := rfl
+lemma coe_mul (I J : fractional_ideal S P) : (↑(I * J) : submodule R P) = I * J := rfl
 
-lemma mul_left_mono (I : fractional_ideal f) : monotone ((*) I) :=
+lemma mul_left_mono (I : fractional_ideal S P) : monotone ((*) I) :=
 λ J J' h, mul_le.mpr (λ x hx y hy, mul_mem_mul hx (h hy))
 
-lemma mul_right_mono (I : fractional_ideal f) : monotone (λ J, J * I) :=
+lemma mul_right_mono (I : fractional_ideal S P) : monotone (λ J, J * I) :=
 λ J J' h, mul_le.mpr (λ x hx y hy, mul_mem_mul (h hx) hy)
 
-lemma mul_mem_mul {I J : fractional_ideal f} {i j : f.codomain} (hi : i ∈ I) (hj : j ∈ J) :
+lemma mul_mem_mul {I J : fractional_ideal S P} {i j : P} (hi : i ∈ I) (hj : j ∈ J) :
   i * j ∈ I * J := submodule.mul_mem_mul hi hj
 
-lemma mul_le {I J K : fractional_ideal f} :
+lemma mul_le {I J K : fractional_ideal S P} :
   I * J ≤ K ↔ (∀ (i ∈ I) (j ∈ J), i * j ∈ K) :=
 submodule.mul_le
 
 @[elab_as_eliminator] protected theorem mul_induction_on
-  {I J : fractional_ideal f}
-  {C : f.codomain → Prop} {r : f.codomain} (hr : r ∈ I * J)
+  {I J : fractional_ideal S P}
+  {C : P → Prop} {r : P} (hr : r ∈ I * J)
   (hm : ∀ (i ∈ I) (j ∈ J), C (i * j))
   (h0 : C 0) (ha : ∀ x y, C x → C y → C (x + y))
   (hs : ∀ (r : R) x, C x → C (r • x)) : C r :=
 submodule.mul_induction_on hr hm h0 ha hs
 
-instance comm_semiring : comm_semiring (fractional_ideal f) :=
+instance comm_semiring : comm_semiring (fractional_ideal S P) :=
 { add_assoc := λ I J K, sup_assoc,
   add_comm := λ I J, sup_comm,
   add_zero := λ I, sup_bot_eq,
   zero_add := λ I, bot_sup_eq,
-  mul_assoc := λ I J K, ext (submodule.mul_assoc _ _ _),
-  mul_comm := λ I J, ext (submodule.mul_comm _ _),
+  mul_assoc := λ I J K, coe_injective (submodule.mul_assoc _ _ _),
+  mul_comm := λ I J, coe_injective (submodule.mul_comm _ _),
   mul_one := λ I, begin
     ext,
     split; intro h,
     { apply mul_le.mpr _ h,
-      rintros x hx y ⟨y', y'_mem_R, y'_eq_y⟩,
-      rw [←y'_eq_y, mul_comm],
-      exact submodule.smul_mem _ _ hx },
-    { have : x * 1 ∈ (I * 1) := mul_mem_mul h one_mem_one,
+      rintros x hx y ⟨y', y'_mem_R, rfl⟩,
+      convert submodule.smul_mem _ y' hx,
+      rw [mul_comm, eq_comm],
+      exact algebra.smul_def y' x },
+    { have : x * 1 ∈ (I * 1) := mul_mem_mul h (one_mem_one _),
       rwa [mul_one] at this }
   end,
   one_mul := λ I, begin
     ext,
     split; intro h,
     { apply mul_le.mpr _ h,
-      rintros x ⟨x', x'_mem_R, x'_eq_x⟩ y hy,
-      rw ←x'_eq_x,
-      exact submodule.smul_mem _ _ hy },
-    { have : 1 * x ∈ (1 * I) := mul_mem_mul one_mem_one h,
-      rwa [one_mul] at this }
+      rintros x ⟨x', x'_mem_R, rfl⟩ y hy,
+      convert submodule.smul_mem _ x' hy,
+      rw eq_comm,
+      exact algebra.smul_def x' y },
+    { have : 1 * x ∈ (1 * I) := mul_mem_mul (one_mem_one _) h,
+      rwa one_mul at this }
   end,
   mul_zero := λ I, eq_zero_iff.mpr (λ x hx, submodule.mul_induction_on hx
-    (λ x hx y hy, by simp [mem_zero_iff.mp hy])
+    (λ x hx y hy, by simp [(mem_zero_iff S).mp hy])
     rfl
     (λ x y hx hy, by simp [hx, hy])
     (λ r x hx, by simp [hx])),
   zero_mul := λ I, eq_zero_iff.mpr (λ x hx, submodule.mul_induction_on hx
-    (λ x hx y hy, by simp [mem_zero_iff.mp hx])
+    (λ x hx y hy, by simp [(mem_zero_iff S).mp hx])
     rfl
     (λ x y hx hy, by simp [hx, hy])
     (λ r x hx, by simp [hx])),
-  left_distrib := λ I J K, ext (mul_add _ _ _),
-  right_distrib := λ I J K, ext (add_mul _ _ _),
-  ..fractional_ideal.has_zero,
+  left_distrib := λ I J K, coe_injective (mul_add _ _ _),
+  right_distrib := λ I J K, coe_injective (add_mul _ _ _),
+  ..fractional_ideal.has_zero S,
   ..fractional_ideal.has_add,
   ..fractional_ideal.has_one,
   ..fractional_ideal.has_mul }
 
 section order
 
-lemma add_le_add_left {I J : fractional_ideal f} (hIJ : I ≤ J) (J' : fractional_ideal f) :
+lemma add_le_add_left {I J : fractional_ideal S P} (hIJ : I ≤ J) (J' : fractional_ideal S P) :
   J' + I ≤ J' + J :=
 sup_le_sup_left hIJ J'
 
-lemma mul_le_mul_left {I J : fractional_ideal f} (hIJ : I ≤ J) (J' : fractional_ideal f) :
+lemma mul_le_mul_left {I J : fractional_ideal S P} (hIJ : I ≤ J) (J' : fractional_ideal S P) :
   J' * I ≤ J' * J :=
 mul_le.mpr (λ k hk j hj, mul_mem_mul hk (hIJ hj))
 
-lemma le_self_mul_self {I : fractional_ideal f} (hI: 1 ≤ I) : I ≤ I * I :=
+lemma le_self_mul_self {I : fractional_ideal S P} (hI: 1 ≤ I) : I ≤ I * I :=
 begin
   convert mul_left_mono I hI,
   exact (mul_one I).symm
 end
 
-lemma mul_self_le_self {I : fractional_ideal f} (hI: I ≤ 1) : I * I ≤ I :=
+lemma mul_self_le_self {I : fractional_ideal S P} (hI: I ≤ 1) : I * I ≤ I :=
 begin
   convert mul_left_mono I hI,
   exact (mul_one I).symm
 end
 
-lemma coe_ideal_le_one {I : ideal R} : (I : fractional_ideal f) ≤ 1 :=
-λ x hx, let ⟨y, _, hy⟩ := fractional_ideal.mem_coe_ideal.mp hx
-  in fractional_ideal.mem_one_iff.mpr ⟨y, hy⟩
+lemma coe_ideal_le_one {I : ideal R} : (I : fractional_ideal S P) ≤ 1 :=
+λ x hx, let ⟨y, _, hy⟩ := (fractional_ideal.mem_coe_ideal S).mp hx
+  in (fractional_ideal.mem_one_iff S).mpr ⟨y, hy⟩
 
-lemma le_one_iff_exists_coe_ideal {J : fractional_ideal f} :
-  J ≤ (1 : fractional_ideal f) ↔ ∃ (I : ideal R), ↑I = J :=
+lemma le_one_iff_exists_coe_ideal {J : fractional_ideal S P} :
+  J ≤ (1 : fractional_ideal S P) ↔ ∃ (I : ideal R), ↑I = J :=
 begin
   split,
   { intro hJ,
-    refine ⟨⟨{x : R | f.to_map x ∈ J}, _, _, _⟩, _⟩,
+    refine ⟨⟨{x : R | algebra_map R P x ∈ J}, _, _, _⟩, _⟩,
     { rw [mem_set_of_eq, ring_hom.map_zero],
       exact J.val.zero_mem },
     { intros a b ha hb,
       rw [mem_set_of_eq, ring_hom.map_add],
       exact J.val.add_mem ha hb },
     { intros c x hx,
-      rw [smul_eq_mul, mem_set_of_eq, ring_hom.map_mul],
+      rw [smul_eq_mul, mem_set_of_eq, ring_hom.map_mul, ← algebra.smul_def],
       exact J.val.smul_mem c hx },
     { ext x,
       split,
       { rintros ⟨y, hy, eq_y⟩,
         rwa ← eq_y },
       { intro hx,
-        obtain ⟨y, eq_x⟩ := fractional_ideal.mem_one_iff.mp (hJ hx),
+        obtain ⟨y, eq_x⟩ := (fractional_ideal.mem_one_iff S).mp (hJ hx),
         rw ← eq_x at *,
         exact ⟨y, hx, rfl⟩ } } },
   { rintro ⟨I, hI⟩,
@@ -486,11 +502,11 @@ end
 
 end order
 
-variables {P' : Type*} [comm_ring P'] {f' : localization_map S P'}
-variables {P'' : Type*} [comm_ring P''] {f'' : localization_map S P''}
+variables {P' : Type*} [comm_ring P'] [algebra R P'] [is_localization S P']
+variables {P'' : Type*} [comm_ring P''] [algebra R P''] [is_localization S P'']
 
-lemma fractional_map (g : f.codomain →ₐ[R] f'.codomain) (I : fractional_ideal f) :
-  is_fractional f' (submodule.map g.to_linear_map I.1) :=
+lemma fractional_map (g : P →ₐ[R] P') (I : fractional_ideal S P) :
+  is_fractional S (submodule.map g.to_linear_map I.1) :=
 begin
   rcases I with ⟨I, a, a_nonzero, hI⟩,
   use [a, a_nonzero],
@@ -498,36 +514,35 @@ begin
   obtain ⟨b', b'_mem, hb'⟩ := submodule.mem_map.mp hb,
   obtain ⟨x, hx⟩ := hI b' b'_mem,
   use x,
-  erw [←g.commutes, hx, g.map_smul, hb'],
-  refl
+  erw [←g.commutes, hx, g.map_smul, hb']
 end
 
 /-- `I.map g` is the pushforward of the fractional ideal `I` along the algebra morphism `g` -/
-def map (g : f.codomain →ₐ[R] f'.codomain) :
-  fractional_ideal f → fractional_ideal f' :=
+def map (g : P →ₐ[R] P') :
+  fractional_ideal S P → fractional_ideal S P' :=
 λ I, ⟨submodule.map g.to_linear_map I.1, fractional_map g I⟩
 
-@[simp, norm_cast] lemma coe_map (g : f.codomain →ₐ[R] f'.codomain) (I : fractional_ideal f) :
+@[simp, norm_cast] lemma coe_map (g : P →ₐ[R] P') (I : fractional_ideal S P) :
   ↑(map g I) = submodule.map g.to_linear_map I := rfl
 
-@[simp] lemma mem_map {I : fractional_ideal f} {g : f.codomain →ₐ[R] f'.codomain}
-  {y : f'.codomain} : y ∈ I.map g ↔ ∃ x, x ∈ I ∧ g x = y :=
+@[simp] lemma mem_map {I : fractional_ideal S P} {g : P →ₐ[R] P'}
+  {y : P'} : y ∈ I.map g ↔ ∃ x, x ∈ I ∧ g x = y :=
 submodule.mem_map
 
-variables (I J : fractional_ideal f) (g : f.codomain →ₐ[R] f'.codomain)
+variables (I J : fractional_ideal S P) (g : P →ₐ[R] P')
 
 @[simp] lemma map_id : I.map (alg_hom.id _ _) = I :=
-ext (submodule.map_id I.1)
+coe_injective (submodule.map_id I.1)
 
-@[simp] lemma map_comp (g' : f'.codomain →ₐ[R] f''.codomain) :
+@[simp] lemma map_comp (g' : P' →ₐ[R] P'') :
   I.map (g'.comp g) = (I.map g).map g' :=
-ext (submodule.map_comp g.to_linear_map g'.to_linear_map I.1)
+coe_injective (submodule.map_comp g.to_linear_map g'.to_linear_map I.1)
 
 @[simp, norm_cast] lemma map_coe_ideal (I : ideal R) :
-  (I : fractional_ideal f).map g = I :=
+  (I : fractional_ideal S P).map g = I :=
 begin
   ext x,
-  simp only [coe_coe_ideal, mem_coe_submodule],
+  simp only [mem_coe_ideal],
   split,
   { rintro ⟨_, ⟨y, hy, rfl⟩, rfl⟩,
     exact ⟨y, hy, (g.commutes y).symm⟩ },
@@ -536,30 +551,30 @@ begin
 end
 
 @[simp] lemma map_one :
-  (1 : fractional_ideal f).map g = 1 :=
+  (1 : fractional_ideal S P).map g = 1 :=
 map_coe_ideal g 1
 
 @[simp] lemma map_zero :
-  (0 : fractional_ideal f).map g = 0 :=
+  (0 : fractional_ideal S P).map g = 0 :=
 map_coe_ideal g 0
 
 @[simp] lemma map_add : (I + J).map g = I.map g + J.map g :=
-ext (submodule.map_sup _ _ _)
+coe_injective (submodule.map_sup _ _ _)
 
 @[simp] lemma map_mul : (I * J).map g = I.map g * J.map g :=
-ext (submodule.map_mul _ _ _)
+coe_injective (submodule.map_mul _ _ _)
 
-@[simp] lemma map_map_symm (g : f.codomain ≃ₐ[R] f'.codomain) :
-  (I.map (g : f.codomain →ₐ[R] f'.codomain)).map (g.symm : f'.codomain →ₐ[R] f.codomain) = I :=
+@[simp] lemma map_map_symm (g : P ≃ₐ[R] P') :
+  (I.map (g : P →ₐ[R] P')).map (g.symm : P' →ₐ[R] P) = I :=
 by rw [←map_comp, g.symm_comp, map_id]
 
-@[simp] lemma map_symm_map (I : fractional_ideal f') (g : f.codomain ≃ₐ[R] f'.codomain) :
-  (I.map (g.symm : f'.codomain →ₐ[R] f.codomain)).map (g : f.codomain →ₐ[R] f'.codomain) = I :=
+@[simp] lemma map_symm_map (I : fractional_ideal S P') (g : P ≃ₐ[R] P') :
+  (I.map (g.symm : P' →ₐ[R] P)).map (g : P →ₐ[R] P') = I :=
 by rw [←map_comp, g.comp_symm, map_id]
 
 /-- If `g` is an equivalence, `map g` is an isomorphism -/
-def map_equiv (g : f.codomain ≃ₐ[R] f'.codomain) :
-  fractional_ideal f ≃+* fractional_ideal f' :=
+def map_equiv (g : P ≃ₐ[R] P') :
+  fractional_ideal S P ≃+* fractional_ideal S P' :=
 { to_fun := map g,
   inv_fun := map g.symm,
   map_add' := λ I J, map_add I J _,
@@ -567,90 +582,94 @@ def map_equiv (g : f.codomain ≃ₐ[R] f'.codomain) :
   left_inv := λ I, by { rw [←map_comp, alg_equiv.symm_comp, map_id] },
   right_inv := λ I, by { rw [←map_comp, alg_equiv.comp_symm, map_id] } }
 
-@[simp] lemma coe_fun_map_equiv (g : f.codomain ≃ₐ[R] f'.codomain) :
-  ⇑(map_equiv g) = map g :=
+@[simp] lemma coe_fun_map_equiv (g : P ≃ₐ[R] P') :
+  (map_equiv g : fractional_ideal S P → fractional_ideal S P') = map g :=
 rfl
 
-@[simp] lemma map_equiv_apply (g : f.codomain ≃ₐ[R] f'.codomain) (I : fractional_ideal f) :
+@[simp] lemma map_equiv_apply (g : P ≃ₐ[R] P') (I : fractional_ideal S P) :
   map_equiv g I = map ↑g I := rfl
 
-@[simp] lemma map_equiv_symm (g : f.codomain ≃ₐ[R] f'.codomain) :
-  (map_equiv g).symm = map_equiv g.symm := rfl
+@[simp] lemma map_equiv_symm (g : P ≃ₐ[R] P') :
+  ((map_equiv g).symm : fractional_ideal S P' ≃+* _) = map_equiv g.symm := rfl
 
 @[simp] lemma map_equiv_refl :
-  map_equiv alg_equiv.refl = ring_equiv.refl (fractional_ideal f) :=
+  map_equiv alg_equiv.refl = ring_equiv.refl (fractional_ideal S P) :=
 ring_equiv.ext (λ x, by simp)
 
-lemma is_fractional_span_iff {s : set f.codomain} :
-is_fractional f (span R s) ↔ ∃ a ∈ S, ∀ (b : P), b ∈ s → f.is_integer (f.to_map a * b) :=
-⟨ λ ⟨a, a_mem, h⟩, ⟨a, a_mem, λ b hb, h b (subset_span hb)⟩,
-  λ ⟨a, a_mem, h⟩, ⟨a, a_mem, λ b hb, span_induction hb
-    h
-    (by { rw mul_zero, exact f.is_integer_zero })
-    (λ x y hx hy, by { rw mul_add, exact is_integer_add hx hy })
-    (λ s x hx, by { rw algebra.mul_smul_comm, exact is_integer_smul hx }) ⟩ ⟩
+lemma is_fractional_span_iff {s : set P} :
+  is_fractional S (span R s) ↔ ∃ a ∈ S, ∀ (b : P), b ∈ s → is_integer R (a • b) :=
+⟨λ ⟨a, a_mem, h⟩, ⟨a, a_mem, λ b hb, h b (subset_span hb)⟩,
+ λ ⟨a, a_mem, h⟩, ⟨a, a_mem, λ b hb, span_induction hb
+   h
+   (by { rw smul_zero, exact is_integer_zero })
+   (λ x y hx hy, by { rw smul_add, exact is_integer_add hx hy })
+   (λ s x hx, by { rw smul_comm, exact is_integer_smul hx })⟩⟩
 
-lemma is_fractional_of_fg {I : submodule R f.codomain} (hI : I.fg) :
-  is_fractional f I :=
+lemma is_fractional_of_fg {I : submodule R P} (hI : I.fg) :
+  is_fractional S I :=
 begin
   rcases hI with ⟨I, rfl⟩,
-  rcases localization_map.exist_integer_multiples_of_finset f I with ⟨⟨s, hs1⟩, hs⟩,
+  rcases exist_integer_multiples_of_finset S I with ⟨⟨s, hs1⟩, hs⟩,
   rw is_fractional_span_iff,
   exact ⟨s, hs1, hs⟩,
 end
 
-/-- `canonical_equiv f f'` is the canonical equivalence between the fractional
-ideals in `f.codomain` and in `f'.codomain` -/
-@[irreducible]
-noncomputable def canonical_equiv (f : localization_map S P) (f' : localization_map S P') :
-  fractional_ideal f ≃+* fractional_ideal f' :=
-map_equiv
-  { commutes' := λ r, ring_equiv_of_ring_equiv_eq _ _ _,
-    ..ring_equiv_of_ring_equiv f f' (ring_equiv.refl R)
-      (by rw [ring_equiv.to_monoid_hom_refl, submonoid.map_id]) }
+variables (S P P')
 
-@[simp] lemma mem_canonical_equiv_apply {I : fractional_ideal f} {x : f'.codomain} :
-  x ∈ canonical_equiv f f' I ↔
-    ∃ y ∈ I, @localization_map.map _ _ _ _ _ _ _ f (ring_hom.id _) _ (λ ⟨y, hy⟩, hy) _ _ f' y = x :=
+/-- `canonical_equiv f f'` is the canonical equivalence between the fractional
+ideals in `P` and in `P'` -/
+@[irreducible]
+noncomputable def canonical_equiv :
+  fractional_ideal S P ≃+* fractional_ideal S P' :=
+map_equiv
+  { commutes' := λ r, ring_equiv_of_ring_equiv_eq _ _,
+    ..ring_equiv_of_ring_equiv P P' (ring_equiv.refl R)
+      (show S.map _ = S, by rw [ring_equiv.to_monoid_hom_refl, submonoid.map_id]) }
+
+@[simp] lemma mem_canonical_equiv_apply {I : fractional_ideal S P} {x : P'} :
+  x ∈ canonical_equiv S P P' I ↔
+    ∃ y ∈ I, is_localization.map P' (ring_hom.id R)
+      (λ y (hy : y ∈ S), show ring_hom.id R y ∈ S, from hy) (y : P) = x :=
 begin
   rw [canonical_equiv, map_equiv_apply, mem_map],
   exact ⟨λ ⟨y, mem, eq⟩, ⟨y, mem, eq⟩, λ ⟨y, mem, eq⟩, ⟨y, mem, eq⟩⟩
 end
 
-@[simp] lemma canonical_equiv_symm (f : localization_map S P) (f' : localization_map S P') :
-  (canonical_equiv f f').symm = canonical_equiv f' f :=
+@[simp] lemma canonical_equiv_symm :
+  (canonical_equiv S P P').symm = canonical_equiv S P' P :=
 ring_equiv.ext $ λ I, fractional_ideal.ext_iff.mp $ λ x,
 by { erw [mem_canonical_equiv_apply, canonical_equiv, map_equiv_symm, map_equiv, mem_map],
     exact ⟨λ ⟨y, mem, eq⟩, ⟨y, mem, eq⟩, λ ⟨y, mem, eq⟩, ⟨y, mem, eq⟩⟩ }
 
-@[simp] lemma canonical_equiv_flip (f : localization_map S P) (f' : localization_map S P') (I) :
-  canonical_equiv f f' (canonical_equiv f' f I) = I :=
+@[simp] lemma canonical_equiv_flip (I) :
+  canonical_equiv S P P' (canonical_equiv S P' P I) = I :=
 by rw [←canonical_equiv_symm, ring_equiv.symm_apply_apply]
 
 end semiring
 
-section fraction_map
+section is_fraction_ring
 
 /-!
-### `fraction_map` section
+### `is_fraction_ring` section
 
 This section concerns fractional ideals in the field of fractions,
-i.e. the type `fractional_ideal g` when `g` is a `fraction_map R K`.
+i.e. the type `fractional_ideal R⁰ K` where `is_fraction_ring R K`.
 -/
 
-variables {K K' : Type*} [field K] [field K'] {g : fraction_map R K} {g' : fraction_map R K'}
-variables {I J : fractional_ideal g} (h : g.codomain →ₐ[R] g'.codomain)
+variables {K K' : Type*} [field K] [field K']
+variables [algebra R K] [is_fraction_ring R K] [algebra R K'] [is_fraction_ring R K']
+variables {I J : fractional_ideal R⁰ K} (h : K →ₐ[R] K')
 
 /-- Nonzero fractional ideals contain a nonzero integer. -/
 lemma exists_ne_zero_mem_is_integer [nontrivial R] (hI : I ≠ 0) :
-  ∃ x ≠ (0 : R), g.to_map x ∈ I :=
+  ∃ x ≠ (0 : R), algebra_map R K x ∈ I :=
 begin
   obtain ⟨y, y_mem, y_not_mem⟩ := set_like.exists_of_lt (bot_lt_iff_ne_bot.mpr hI),
   have y_ne_zero : y ≠ 0 := by simpa using y_not_mem,
-  obtain ⟨z, ⟨x, hx⟩⟩ := g.exists_integer_multiple y,
+  obtain ⟨z, ⟨x, hx⟩⟩ := exists_integer_multiple R⁰ y,
   refine ⟨x, _, _⟩,
-  { rw [ne.def, ← g.to_map_eq_zero_iff, hx],
-    exact mul_ne_zero (g.to_map_ne_zero_of_mem_non_zero_divisors z.2) y_ne_zero },
+  { rw [ne.def, ← @is_fraction_ring.to_map_eq_zero_iff R _ K, hx, algebra.smul_def],
+    exact mul_ne_zero (is_fraction_ring.to_map_ne_zero_of_mem_non_zero_divisors z.2) y_ne_zero },
   { rw hx,
     exact smul_mem _ _ y_mem }
 end
@@ -659,15 +678,15 @@ lemma map_ne_zero [nontrivial R] (hI : I ≠ 0) : I.map h ≠ 0 :=
 begin
   obtain ⟨x, x_ne_zero, hx⟩ := exists_ne_zero_mem_is_integer hI,
   contrapose! x_ne_zero with map_eq_zero,
-  refine g'.to_map_eq_zero_iff.mp (eq_zero_iff.mp map_eq_zero _ (mem_map.mpr _)),
-  exact ⟨g.to_map x, hx, h.commutes x⟩,
+  refine is_fraction_ring.to_map_eq_zero_iff.mp (eq_zero_iff.mp map_eq_zero _ (mem_map.mpr _)),
+  exact ⟨algebra_map R K x, hx, h.commutes x⟩,
 end
 
 @[simp] lemma map_eq_zero_iff [nontrivial R] : I.map h = 0 ↔ I = 0 :=
 ⟨imp_of_not_imp_not _ _ (map_ne_zero _),
  λ hI, hI.symm ▸ map_zero h⟩
 
-end fraction_map
+end is_fraction_ring
 
 section quotient
 
@@ -684,16 +703,17 @@ is a field because `R` is a domain.
 
 open_locale classical
 
-variables {R₁ : Type*} [integral_domain R₁] {K : Type*} [field K] {g : fraction_map R₁ K}
+variables {R₁ : Type*} [integral_domain R₁] {K : Type*} [field K]
+variables [algebra R₁ K] [is_fraction_ring R₁ K]
 
-instance : nontrivial (fractional_ideal g) :=
+instance : nontrivial (fractional_ideal R₁⁰ K) :=
 ⟨⟨0, 1, λ h,
-  have this : (1 : K) ∈ (0 : fractional_ideal g) :=
-    by rw ←g.to_map.map_one; convert coe_mem_one _,
-  one_ne_zero (mem_zero_iff.mp this) ⟩⟩
+  have this : (1 : K) ∈ (0 : fractional_ideal R₁⁰ K) :=
+    by { rw ← (algebra_map R₁ K).map_one, simpa only [h] using coe_mem_one R₁⁰ 1 },
+  one_ne_zero ((mem_zero_iff _).mp this)⟩⟩
 
-lemma fractional_div_of_nonzero {I J : fractional_ideal g} (h : J ≠ 0) :
-  is_fractional g (I.1 / J.1) :=
+lemma fractional_div_of_nonzero {I J : fractional_ideal R₁⁰ K} (h : J ≠ 0) :
+  is_fractional R₁⁰ (I.1 / J.1) :=
 begin
   rcases I with ⟨I, aI, haI, hI⟩,
   rcases J with ⟨J, aJ, haJ, hJ⟩,
@@ -703,43 +723,44 @@ begin
   split,
   { apply (non_zero_divisors R₁).mul_mem haI (mem_non_zero_divisors_iff_ne_zero.mpr _),
     intro y'_eq_zero,
-    have : g.to_map aJ * y = 0 := by rw [←hy', y'_eq_zero, g.to_map.map_zero],
+    have : algebra_map R₁ K aJ * y = 0,
+    { rw [← algebra.smul_def, ←hy', y'_eq_zero, ring_hom.map_zero] },
     obtain aJ_zero | y_zero := mul_eq_zero.mp this,
-    { have : aJ = 0 := g.to_map.injective_iff.1 g.injective _ aJ_zero,
+    { have : aJ = 0 := (algebra_map R₁ K).injective_iff.1 is_fraction_ring.injective _ aJ_zero,
       have : aJ ≠ 0 := mem_non_zero_divisors_iff_ne_zero.mp haJ,
       contradiction },
-    { exact not_mem_zero (mem_zero_iff.mpr y_zero) } },
+    { exact not_mem_zero ((mem_zero_iff R₁⁰).mpr y_zero) } },
   intros b hb,
-  rw [g.to_map.map_mul, mul_assoc, mul_comm _ b, hy'],
-  exact hI _ (hb _ (submodule.smul_mem _ aJ mem_J)),
+  convert hI _ (hb _ (submodule.smul_mem _ aJ mem_J)) using 1,
+  rw [← hy', mul_comm b, ← algebra.smul_def, mul_smul]
 end
 
 noncomputable instance fractional_ideal_has_div :
-  has_div (fractional_ideal g) :=
+  has_div (fractional_ideal R₁⁰ K) :=
 ⟨ λ I J, if h : J = 0 then 0 else ⟨I.1 / J.1, fractional_div_of_nonzero h⟩ ⟩
 
-variables {I J : fractional_ideal g} [ J ≠ 0 ]
+variables {I J : fractional_ideal R₁⁰ K} [ J ≠ 0 ]
 
-@[simp] lemma div_zero {I : fractional_ideal g} :
+@[simp] lemma div_zero {I : fractional_ideal R₁⁰ K} :
   I / 0 = 0 :=
 dif_pos rfl
 
-lemma div_nonzero {I J : fractional_ideal g} (h : J ≠ 0) :
+lemma div_nonzero {I J : fractional_ideal R₁⁰ K} (h : J ≠ 0) :
   (I / J) = ⟨I.1 / J.1, fractional_div_of_nonzero h⟩ :=
 dif_neg h
 
-@[simp] lemma coe_div {I J : fractional_ideal g} (hJ : J ≠ 0) :
-  (↑(I / J) : submodule R₁ g.codomain) = ↑I / (↑J : submodule R₁ g.codomain) :=
+@[simp] lemma coe_div {I J : fractional_ideal R₁⁰ K} (hJ : J ≠ 0) :
+  (↑(I / J) : submodule R₁ K) = ↑I / (↑J : submodule R₁ K) :=
 begin
   unfold has_div.div,
   simp only [dif_neg hJ, coe_mk, val_eq_coe],
 end
 
-lemma mem_div_iff_of_nonzero {I J : fractional_ideal g} (h : J ≠ 0) {x} :
+lemma mem_div_iff_of_nonzero {I J : fractional_ideal R₁⁰ K} (h : J ≠ 0) {x} :
   x ∈ I / J ↔ ∀ y ∈ J, x * y ∈ I :=
 by { rw div_nonzero h, exact submodule.mem_div_iff_forall_mul_mem }
 
-lemma mul_one_div_le_one {I : fractional_ideal g} : I * (1 / I) ≤ 1 :=
+lemma mul_one_div_le_one {I : fractional_ideal R₁⁰ K} : I * (1 / I) ≤ 1 :=
 begin
   by_cases hI : I = 0,
   { rw [hI, div_zero, mul_zero],
@@ -748,7 +769,7 @@ begin
     apply submodule.mul_one_div_le_one },
 end
 
-lemma le_self_mul_one_div {I : fractional_ideal g} (hI : I ≤ (1 : fractional_ideal g)) :
+lemma le_self_mul_one_div {I : fractional_ideal R₁⁰ K} (hI : I ≤ (1 : fractional_ideal R₁⁰ K)) :
   I ≤ I * (1 / I) :=
 begin
   by_cases hI_nz : I = 0,
@@ -758,12 +779,13 @@ begin
     exact submodule.le_self_mul_one_div hI },
 end
 
-lemma le_div_iff_of_nonzero {I J J' : fractional_ideal g} (hJ' : J' ≠ 0) :
+lemma le_div_iff_of_nonzero {I J J' : fractional_ideal R₁⁰ K} (hJ' : J' ≠ 0) :
   I ≤ J / J' ↔ ∀ (x ∈ I) (y ∈ J'), x * y ∈ J :=
 ⟨ λ h x hx, (mem_div_iff_of_nonzero hJ').mp (h hx),
   λ h x hx, (mem_div_iff_of_nonzero hJ').mpr (h x hx) ⟩
 
-lemma le_div_iff_mul_le {I J J' : fractional_ideal g} (hJ' : J' ≠ 0) : I ≤ J / J' ↔ I * J' ≤ J :=
+lemma le_div_iff_mul_le {I J J' : fractional_ideal R₁⁰ K} (hJ' : J' ≠ 0) :
+  I ≤ J / J' ↔ I * J' ≤ J :=
 begin
   rw div_nonzero hJ',
   convert submodule.le_div_iff_mul_le using 1,
@@ -771,26 +793,25 @@ begin
   refl,
 end
 
-@[simp] lemma div_one {I : fractional_ideal g} : I / 1 = I :=
+@[simp] lemma div_one {I : fractional_ideal R₁⁰ K} : I / 1 = I :=
 begin
-  rw [div_nonzero (@one_ne_zero (fractional_ideal g) _ _)],
+  rw [div_nonzero (@one_ne_zero (fractional_ideal R₁⁰ K) _ _)],
   ext,
   split; intro h,
-  { convert mem_div_iff_forall_mul_mem.mp h 1
-      (g.to_map.map_one ▸ coe_mem_one 1), simp },
+  { simpa using mem_div_iff_forall_mul_mem.mp h 1
+      ((algebra_map R₁ K).map_one ▸ coe_mem_one R₁⁰ 1) },
   { apply mem_div_iff_forall_mul_mem.mpr,
-    rintros y ⟨y', _, y_eq_y'⟩,
+    rintros y ⟨y', _, rfl⟩,
     rw mul_comm,
     convert submodule.smul_mem _ y' h,
-    rw ←y_eq_y',
-    refl }
+    exact (algebra.smul_def _ _).symm }
 end
 
-lemma ne_zero_of_mul_eq_one (I J : fractional_ideal g) (h : I * J = 1) : I ≠ 0 :=
-λ hI, @zero_ne_one (fractional_ideal g) _ _ (by { convert h, simp [hI], })
+lemma ne_zero_of_mul_eq_one (I J : fractional_ideal R₁⁰ K) (h : I * J = 1) : I ≠ 0 :=
+λ hI, @zero_ne_one (fractional_ideal R₁⁰ K) _ _ (by { convert h, simp [hI], })
 
 
-theorem eq_one_div_of_mul_eq_one (I J : fractional_ideal g) (h : I * J = 1) :
+theorem eq_one_div_of_mul_eq_one (I J : fractional_ideal R₁⁰ K) (h : I * J = 1) :
   J = 1 / I :=
 begin
   have hI : I ≠ 0 := ne_zero_of_mul_eq_one I J h,
@@ -810,140 +831,145 @@ begin
   exact mul_mem_mul hx hy,
 end
 
-theorem mul_div_self_cancel_iff {I : fractional_ideal g} :
+theorem mul_div_self_cancel_iff {I : fractional_ideal R₁⁰ K} :
   I * (1 / I) = 1 ↔ ∃ J, I * J = 1 :=
 ⟨λ h, ⟨(1 / I), h⟩, λ ⟨J, hJ⟩, by rwa [← eq_one_div_of_mul_eq_one I J hJ]⟩
 
-variables {K' : Type*} [field K'] {g' : fraction_map R₁ K'}
+variables {K' : Type*} [field K'] [algebra R₁ K'] [is_fraction_ring R₁ K']
 
-@[simp] lemma map_div (I J : fractional_ideal g) (h : g.codomain ≃ₐ[R₁] g'.codomain) :
-  (I / J).map (h : g.codomain →ₐ[R₁] g'.codomain) = I.map h / J.map h :=
+@[simp] lemma map_div (I J : fractional_ideal R₁⁰ K) (h : K ≃ₐ[R₁] K') :
+  (I / J).map (h : K →ₐ[R₁] K') = I.map h / J.map h :=
 begin
   by_cases H : J = 0,
   { rw [H, div_zero, map_zero, div_zero] },
-  { ext x,
+  { apply coe_injective,
     simp [div_nonzero H, div_nonzero (map_ne_zero _ H), submodule.map_div] }
 end
 
-@[simp] lemma map_one_div (I : fractional_ideal g) (h : g.codomain ≃ₐ[R₁] g'.codomain) :
-  (1 / I).map (h : g.codomain →ₐ[R₁] g'.codomain) = 1 / I.map h :=
+@[simp] lemma map_one_div (I : fractional_ideal R₁⁰ K) (h : K ≃ₐ[R₁] K') :
+  (1 / I).map (h : K →ₐ[R₁] K') = 1 / I.map h :=
 by rw [map_div, map_one]
 
 end quotient
 
 section principal_ideal_ring
 
-variables {R₁ : Type*} [integral_domain R₁] {K : Type*} [field K] {g : fraction_map R₁ K}
+variables {R₁ : Type*} [integral_domain R₁] {K : Type*} [field K]
+variables [algebra R₁ K] [is_fraction_ring R₁ K]
 
 open_locale classical
 
 open submodule submodule.is_principal
 
-lemma is_fractional_span_singleton (x : f.codomain) : is_fractional f (span R {x}) :=
-let ⟨a, ha⟩ := f.exists_integer_multiple x in
-is_fractional_span_iff.mpr ⟨ a.1, a.2, λ x hx, (mem_singleton_iff.mp hx).symm ▸ ha⟩
+lemma is_fractional_span_singleton (x : P) : is_fractional S (span R {x} : submodule R P) :=
+let ⟨a, ha⟩ := exists_integer_multiple S x in
+is_fractional_span_iff.mpr ⟨a, a.2, λ x' hx', (set.mem_singleton_iff.mp hx').symm ▸ ha⟩
+
+variables (S)
 
 /-- `span_singleton x` is the fractional ideal generated by `x` if `0 ∉ S` -/
 @[irreducible]
-def span_singleton (x : f.codomain) : fractional_ideal f :=
+def span_singleton (x : P) : fractional_ideal S P :=
 ⟨span R {x}, is_fractional_span_singleton x⟩
 
 local attribute [semireducible] span_singleton
 
-@[simp] lemma coe_span_singleton (x : f.codomain) :
-  (span_singleton x : submodule R f.codomain) = span R {x} := rfl
+@[simp] lemma coe_span_singleton (x : P) :
+  (span_singleton S x : submodule R P) = span R {x} := rfl
 
-@[simp] lemma mem_span_singleton {x y : f.codomain} :
-  x ∈ span_singleton y ↔ ∃ (z : R), z • y = x :=
+@[simp] lemma mem_span_singleton {x y : P} :
+  x ∈ span_singleton S y ↔ ∃ (z : R), z • y = x :=
 submodule.mem_span_singleton
 
-lemma mem_span_singleton_self (x : f.codomain) :
-  x ∈ span_singleton x :=
-mem_span_singleton.mpr ⟨1, one_smul _ _⟩
+lemma mem_span_singleton_self (x : P) :
+  x ∈ span_singleton S x :=
+(mem_span_singleton S).mpr ⟨1, one_smul _ _⟩
 
-lemma eq_span_singleton_of_principal (I : fractional_ideal f)
-  [is_principal (I : submodule R f.codomain)] :
-  I = span_singleton (generator (I : submodule R f.codomain)) :=
-ext (span_singleton_generator I.1).symm
+variables {S}
 
-lemma is_principal_iff (I : fractional_ideal f) :
-  is_principal (I : submodule R f.codomain) ↔ ∃ x, I = span_singleton x :=
-⟨λ h, ⟨@generator _ _ _ _ _ I.1 h, @eq_span_singleton_of_principal _ _ _ _ _ _ I h⟩,
- λ ⟨x, hx⟩, { principal := ⟨x, trans (congr_arg _ hx) (coe_span_singleton x)⟩ } ⟩
+lemma eq_span_singleton_of_principal (I : fractional_ideal S P)
+  [is_principal (I : submodule R P)] :
+  I = span_singleton S (generator (I : submodule R P)) :=
+coe_injective (span_singleton_generator I.1).symm
 
-@[simp] lemma span_singleton_zero : span_singleton (0 : f.codomain) = 0 :=
+lemma is_principal_iff (I : fractional_ideal S P) :
+  is_principal (I : submodule R P) ↔ ∃ x, I = span_singleton S x :=
+⟨λ h, ⟨@generator _ _ _ _ _ I.1 h, @eq_span_singleton_of_principal _ _ _ _ _ _ _ I h⟩,
+ λ ⟨x, hx⟩, { principal := ⟨x, trans (congr_arg _ hx) (coe_span_singleton _ x)⟩ } ⟩
+
+@[simp] lemma span_singleton_zero : span_singleton S (0 : P) = 0 :=
 by { ext, simp [submodule.mem_span_singleton, eq_comm] }
 
-lemma span_singleton_eq_zero_iff {y : f.codomain} : span_singleton y = 0 ↔ y = 0 :=
+lemma span_singleton_eq_zero_iff {y : P} : span_singleton S y = 0 ↔ y = 0 :=
 ⟨λ h, span_eq_bot.mp (by simpa using congr_arg subtype.val h : span R {y} = ⊥) y (mem_singleton y),
  λ h, by simp [h] ⟩
 
-lemma span_singleton_ne_zero_iff {y : f.codomain} : span_singleton y ≠ 0 ↔ y ≠ 0 :=
+lemma span_singleton_ne_zero_iff {y : P} : span_singleton S y ≠ 0 ↔ y ≠ 0 :=
 not_congr span_singleton_eq_zero_iff
 
-@[simp] lemma span_singleton_one : span_singleton (1 : f.codomain) = 1 :=
+@[simp] lemma span_singleton_one : span_singleton S (1 : P) = 1 :=
 begin
   ext,
-  refine mem_span_singleton.trans ((exists_congr _).trans mem_one_iff.symm),
+  refine (mem_span_singleton S).trans ((exists_congr _).trans (mem_one_iff S).symm),
   intro x',
-  refine eq.congr (mul_one _) rfl,
+  rw [algebra.smul_def, mul_one]
 end
 
 @[simp]
-lemma span_singleton_mul_span_singleton (x y : f.codomain) :
-  span_singleton x * span_singleton y = span_singleton (x * y) :=
+lemma span_singleton_mul_span_singleton (x y : P) :
+  span_singleton S x * span_singleton S y = span_singleton S (x * y) :=
 begin
-  ext,
+  apply coe_injective,
   simp_rw [coe_mul, coe_span_singleton, span_mul_span, singleton.is_mul_hom.map_mul]
 end
 
 @[simp]
 lemma coe_ideal_span_singleton (x : R) :
-  (↑(span R {x} : ideal R) : fractional_ideal f) = span_singleton (f.to_map x) :=
+  (↑(span R {x} : ideal R) : fractional_ideal S P) = span_singleton S (algebra_map R P x) :=
 begin
   ext y,
-  refine mem_coe_ideal.trans (iff.trans _ mem_span_singleton.symm),
+  refine (mem_coe_ideal S).trans (iff.trans _ (mem_span_singleton S).symm),
   split,
   { rintros ⟨y', hy', rfl⟩,
     obtain ⟨x', rfl⟩ := submodule.mem_span_singleton.mp hy',
     use x',
-    rw [smul_eq_mul, f.to_map.map_mul],
-    refl },
+    rw [smul_eq_mul, ring_hom.map_mul, algebra.smul_def] },
   { rintros ⟨y', rfl⟩,
-    exact ⟨y' * x, submodule.mem_span_singleton.mpr ⟨y', rfl⟩, f.to_map.map_mul _ _⟩ }
+    refine ⟨y' * x, submodule.mem_span_singleton.mpr ⟨y', rfl⟩, _⟩,
+    rw [ring_hom.map_mul, algebra.smul_def] }
 end
 
 @[simp]
-lemma canonical_equiv_span_singleton (f : localization_map S P) {P'} [comm_ring P']
-  (f' : localization_map S P') (x : f.codomain) :
-  canonical_equiv f f' (span_singleton x) =
-    span_singleton (f.map (show ∀ (y : S), ring_hom.id _ y.1 ∈ S, from λ y, y.2) f' x) :=
+lemma canonical_equiv_span_singleton {P'} [comm_ring P'] [algebra R P'] [is_localization S P']
+  (x : P) :
+  canonical_equiv S P P' (span_singleton S x) =
+    span_singleton S (is_localization.map P' (ring_hom.id R)
+      (λ y (hy : y ∈ S), show ring_hom.id R y ∈ S, from hy) x) :=
 begin
   apply ext_iff.mp,
   intro y,
   split; intro h,
-  { apply mem_span_singleton.mpr,
-    obtain ⟨x', hx', rfl⟩ := mem_canonical_equiv_apply.mp h,
-    obtain ⟨z, rfl⟩ := mem_span_singleton.mp hx',
+  { rw mem_span_singleton,
+    obtain ⟨x', hx', rfl⟩ := (mem_canonical_equiv_apply _ _ _).mp h,
+    obtain ⟨z, rfl⟩ := (mem_span_singleton _).mp hx',
     use z,
-    rw localization_map.map_smul,
+    rw is_localization.map_smul,
     refl },
-  { apply mem_canonical_equiv_apply.mpr,
-    obtain ⟨z, rfl⟩ := mem_span_singleton.mp h,
-    use f.to_map z * x,
-    use mem_span_singleton.mpr ⟨z, rfl⟩,
-    rw [ring_hom.map_mul, localization_map.map_eq],
-    refl }
+  { rw mem_canonical_equiv_apply,
+    obtain ⟨z, rfl⟩ := (mem_span_singleton _).mp h,
+    use z • x,
+    use (mem_span_singleton _).mpr ⟨z, rfl⟩,
+    simp [is_localization.map_smul] }
 end
 
-lemma mem_singleton_mul {x y : f.codomain} {I : fractional_ideal f} :
-  y ∈ span_singleton x * I ↔ ∃ y' ∈ I, y = x * y' :=
+lemma mem_singleton_mul {x y : P} {I : fractional_ideal S P} :
+  y ∈ span_singleton S x * I ↔ ∃ y' ∈ I, y = x * y' :=
 begin
   split,
   { intro h,
     apply fractional_ideal.mul_induction_on h,
     { intros x' hx' y' hy',
-      obtain ⟨a, ha⟩ := mem_span_singleton.mp hx',
+      obtain ⟨a, ha⟩ := (mem_span_singleton S).mp hx',
       use [a • y', I.1.smul_mem a hy'],
       rw [←ha, algebra.mul_smul_comm, algebra.smul_mul_assoc] },
     { exact ⟨0, I.1.zero_mem, (mul_zero x).symm⟩ },
@@ -952,62 +978,63 @@ begin
     { rintros r _ ⟨y', hy', rfl⟩,
       exact ⟨r • y', I.1.smul_mem r hy', (algebra.mul_smul_comm _ _ _).symm ⟩ } },
   { rintros ⟨y', hy', rfl⟩,
-    exact mul_mem_mul (mem_span_singleton.mpr ⟨1, one_smul _ _⟩) hy' }
+    exact mul_mem_mul ((mem_span_singleton S).mpr ⟨1, one_smul _ _⟩) hy' }
 end
 
-lemma one_div_span_singleton (x : g.codomain) :
-  1 / span_singleton x = span_singleton (x⁻¹) :=
+lemma one_div_span_singleton (x : K) :
+  1 / span_singleton R₁⁰ x = span_singleton R₁⁰ (x⁻¹) :=
 if h : x = 0 then by simp [h] else (eq_one_div_of_mul_eq_one _ _ (by simp [h])).symm
 
-@[simp] lemma div_span_singleton (J : fractional_ideal g) (d : g.codomain) :
-  J / span_singleton d = span_singleton (d⁻¹) * J :=
+@[simp] lemma div_span_singleton (J : fractional_ideal R₁⁰ K) (d : K) :
+  J / span_singleton R₁⁰ d = span_singleton R₁⁰ (d⁻¹) * J :=
 begin
   rw ← one_div_span_singleton,
   by_cases hd : d = 0,
   { simp only [hd, span_singleton_zero, div_zero, zero_mul] },
-  have h_spand : span_singleton d ≠ 0 := mt span_singleton_eq_zero_iff.mp hd,
+  have h_spand : span_singleton R₁⁰ d ≠ 0 := mt span_singleton_eq_zero_iff.mp hd,
   apply le_antisymm,
   { intros x hx,
     rw [val_eq_coe, coe_div h_spand, submodule.mem_div_iff_forall_mul_mem] at hx,
-    specialize hx d (mem_span_singleton_self d),
+    specialize hx d (mem_span_singleton_self R₁⁰ d),
     have h_xd : x = d⁻¹ * (x * d), { field_simp },
     rw [val_eq_coe, coe_mul, one_div_span_singleton, h_xd],
-    exact submodule.mul_mem_mul (mem_span_singleton_self _) hx },
+    exact submodule.mul_mem_mul (mem_span_singleton_self R₁⁰ _) hx },
   { rw [le_div_iff_mul_le h_spand, mul_assoc, mul_left_comm, one_div_span_singleton,
     span_singleton_mul_span_singleton, inv_mul_cancel hd, span_singleton_one, mul_one],
     exact le_refl J },
 end
 
-lemma exists_eq_span_singleton_mul (I : fractional_ideal g) :
-  ∃ (a : R₁) (aI : ideal R₁), a ≠ 0 ∧ I = span_singleton (g.to_map a)⁻¹ * aI :=
+lemma exists_eq_span_singleton_mul (I : fractional_ideal R₁⁰ K) :
+  ∃ (a : R₁) (aI : ideal R₁), a ≠ 0 ∧ I = span_singleton R₁⁰ (algebra_map R₁ K a)⁻¹ * aI :=
 begin
   obtain ⟨a_inv, nonzero, ha⟩ := I.2,
   have nonzero := mem_non_zero_divisors_iff_ne_zero.mp nonzero,
-  have map_a_nonzero := mt g.to_map_eq_zero_iff.mp nonzero,
-  use a_inv,
-  use (span_singleton (g.to_map a_inv) * I).1.comap g.lin_coe,
-  split, exact nonzero,
-  ext,
-  refine iff.trans _ mem_singleton_mul.symm,
-  split,
+  have map_a_nonzero : algebra_map R₁ K a_inv ≠ 0 :=
+    mt is_fraction_ring.to_map_eq_zero_iff.mp nonzero,
+  refine ⟨a_inv,
+          (span_singleton R₁⁰ (algebra_map R₁ K a_inv) * I).1.comap (algebra.linear_map R₁ K),
+          nonzero,
+          ext (λ x, iff.trans ⟨_, _⟩ mem_singleton_mul.symm)⟩,
   { intro hx,
     obtain ⟨x', hx'⟩ := ha x hx,
-    refine ⟨g.to_map x', mem_coe_ideal.mpr ⟨x', (mem_singleton_mul.mpr ⟨x, hx, hx'⟩), rfl⟩, _⟩,
-    erw [hx', ←mul_assoc, inv_mul_cancel map_a_nonzero, one_mul] },
+    rw algebra.smul_def at hx',
+    refine ⟨algebra_map R₁ K x', (mem_coe_ideal _).mpr ⟨x', mem_singleton_mul.mpr _, rfl⟩, _⟩,
+    { exact ⟨x, hx, hx'⟩ },
+    { rw [hx', ← mul_assoc, inv_mul_cancel map_a_nonzero, one_mul] } },
   { rintros ⟨y, hy, rfl⟩,
-    obtain ⟨x', hx', rfl⟩ := mem_coe_ideal.mp hy,
+    obtain ⟨x', hx', rfl⟩ := (mem_coe_ideal _).mp hy,
     obtain ⟨y', hy', hx'⟩ := mem_singleton_mul.mp hx',
-    rw lin_coe_apply at hx',
-    erw [hx', ←mul_assoc, inv_mul_cancel map_a_nonzero, one_mul],
-    exact hy' }
+    rw algebra.linear_map_apply at hx',
+    rwa [hx', ←mul_assoc, inv_mul_cancel map_a_nonzero, one_mul] }
 end
 
-instance is_principal {R} [integral_domain R] [is_principal_ideal_ring R] {f : fraction_map R K}
-  (I : fractional_ideal f) : (I : submodule R f.codomain).is_principal :=
+instance is_principal {R} [integral_domain R] [is_principal_ideal_ring R]
+  [algebra R K] [is_fraction_ring R K]
+  (I : fractional_ideal R⁰ K) : (I : submodule R K).is_principal :=
 begin
   obtain ⟨a, aI, -, ha⟩ := exists_eq_span_singleton_mul I,
-  use (f.to_map a)⁻¹ * f.to_map (generator aI),
-  suffices : I = span_singleton ((f.to_map a)⁻¹ * f.to_map (generator aI)),
+  use (algebra_map R K a)⁻¹ * algebra_map R K (generator aI),
+  suffices : I = span_singleton R⁰ ((algebra_map R K a)⁻¹ * algebra_map R K (generator aI)),
   { exact congr_arg subtype.val this },
   conv_lhs { rw [ha, ←span_singleton_generator aI] },
   rw [coe_ideal_span_singleton (generator aI), span_singleton_mul_span_singleton]
@@ -1016,20 +1043,20 @@ end
 end principal_ideal_ring
 
 variables {R₁ : Type*} [integral_domain R₁]
-variables {K : Type*} [field K] {g : fraction_map R₁ K}
+variables {K : Type*} [field K] [algebra R₁ K] [is_fraction_ring R₁ K]
 
 local attribute [instance] classical.prop_decidable
 
-lemma is_noetherian_zero : is_noetherian R₁ (0 : fractional_ideal g) :=
-is_noetherian_submodule.mpr (λ I (hI : I ≤ (0 : fractional_ideal g)),
+lemma is_noetherian_zero : is_noetherian R₁ (0 : fractional_ideal R₁⁰ K) :=
+is_noetherian_submodule.mpr (λ I (hI : I ≤ (0 : fractional_ideal R₁⁰ K)),
   by { rw coe_zero at hI, rw le_bot_iff.mp hI, exact fg_bot })
 
-lemma is_noetherian_iff {I : fractional_ideal g} :
-  is_noetherian R₁ I ↔ ∀ J ≤ I, (J : submodule R₁ g.codomain).fg :=
+lemma is_noetherian_iff {I : fractional_ideal R₁⁰ K} :
+  is_noetherian R₁ I ↔ ∀ J ≤ I, (J : submodule R₁ K).fg :=
 is_noetherian_submodule.trans ⟨λ h J hJ, h _ hJ, λ h J hJ, h ⟨J, is_fractional_of_le hJ⟩ hJ⟩
 
-lemma is_noetherian_coe_to_fractional_ideal [is_noetherian_ring R₁] (I : ideal R₁) :
-  is_noetherian R₁ (I : fractional_ideal g) :=
+lemma is_noetherian_coe_to_fractional_ideal [_root_.is_noetherian_ring R₁] (I : ideal R₁) :
+  is_noetherian R₁ (I : fractional_ideal R₁⁰ K) :=
 begin
   rw is_noetherian_iff,
   intros J hJ,
@@ -1037,30 +1064,31 @@ begin
   exact fg_map (is_noetherian.noetherian J),
 end
 
-lemma is_noetherian_span_singleton_inv_to_map_mul (x : R₁) {I : fractional_ideal g}
+lemma is_noetherian_span_singleton_inv_to_map_mul (x : R₁) {I : fractional_ideal R₁⁰ K}
   (hI : is_noetherian R₁ I) :
-  is_noetherian R₁ (span_singleton (g.to_map x)⁻¹ * I : fractional_ideal g) :=
+  is_noetherian R₁ (span_singleton R₁⁰ (algebra_map R₁ K x)⁻¹ * I : fractional_ideal R₁⁰ K) :=
 begin
   by_cases hx : x = 0,
-  { rw [hx, g.to_map.map_zero, _root_.inv_zero, span_singleton_zero, zero_mul],
+  { rw [hx, ring_hom.map_zero, _root_.inv_zero, span_singleton_zero, zero_mul],
     exact is_noetherian_zero },
-  have h_gx : g.to_map x ≠ 0,
-    from mt (g.to_map.injective_iff.mp (fraction_map.injective g) x) hx,
-  have h_spanx : span_singleton (g.to_map x) ≠ (0 : fractional_ideal g),
+  have h_gx : algebra_map R₁ K x ≠ 0,
+    from mt ((algebra_map R₁ K).injective_iff.mp (is_fraction_ring.injective _ _) x) hx,
+  have h_spanx : span_singleton R₁⁰ (algebra_map R₁ K x) ≠ 0,
     from span_singleton_ne_zero_iff.mpr h_gx,
 
   rw is_noetherian_iff at ⊢ hI,
   intros J hJ,
   rw [← div_span_singleton, le_div_iff_mul_le h_spanx] at hJ,
   obtain ⟨s, hs⟩ := hI _ hJ,
-  use s * {(g.to_map x)⁻¹},
-  rw [finset.coe_mul, finset.coe_singleton, ← span_mul_span, hs, ← coe_span_singleton, ← coe_mul,
-      mul_assoc, span_singleton_mul_span_singleton, mul_inv_cancel h_gx,
+  use s * {(algebra_map R₁ K x)⁻¹},
+  rw [finset.coe_mul, finset.coe_singleton, ← span_mul_span, hs, ← coe_span_singleton R₁⁰,
+      ← coe_mul, mul_assoc, span_singleton_mul_span_singleton, mul_inv_cancel h_gx,
       span_singleton_one, mul_one],
 end
 
 /-- Every fractional ideal of a noetherian integral domain is noetherian. -/
-theorem is_noetherian [is_noetherian_ring R₁] (I : fractional_ideal g) : is_noetherian R₁ I :=
+theorem is_noetherian [_root_.is_noetherian_ring R₁] (I : fractional_ideal R₁⁰ K) :
+  is_noetherian R₁ I :=
 begin
   obtain ⟨d, J, h_nzd, rfl⟩ := exists_eq_span_singleton_mul I,
   apply is_noetherian_span_singleton_inv_to_map_mul,

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -726,7 +726,7 @@ begin
     have : algebra_map R₁ K aJ * y = 0,
     { rw [← algebra.smul_def, ←hy', y'_eq_zero, ring_hom.map_zero] },
     obtain aJ_zero | y_zero := mul_eq_zero.mp this,
-    { have : aJ = 0 := (algebra_map R₁ K).injective_iff.1 is_fraction_ring.injective _ aJ_zero,
+    { have : aJ = 0 := (algebra_map R₁ K).injective_iff.1 (is_fraction_ring.injective _ _) _ aJ_zero,
       have : aJ ≠ 0 := mem_non_zero_divisors_iff_ne_zero.mp haJ,
       contradiction },
     { exact not_mem_zero ((mem_zero_iff R₁⁰).mpr y_zero) } },

--- a/src/ring_theory/ideal/over.lean
+++ b/src/ring_theory/ideal/over.lean
@@ -255,18 +255,16 @@ begin
   { rintro ⟨x, ⟨hx, x0⟩⟩,
     exact absurd (hP x0) hx },
   let Rₚ := localization P.prime_compl,
-  let f := localization.of P.prime_compl,
   let Sₚ := localization (algebra.algebra_map_submonoid S P.prime_compl),
-  let g := localization.of (algebra.algebra_map_submonoid S P.prime_compl),
   letI : integral_domain (localization (algebra.algebra_map_submonoid S P.prime_compl)) :=
-    localization_map.integral_domain_localization (le_non_zero_divisors_of_domain hP0),
+    is_localization.integral_domain_localization (le_non_zero_divisors_of_domain hP0),
   obtain ⟨Qₚ : ideal Sₚ, Qₚ_maximal⟩ := exists_maximal Sₚ,
   haveI Qₚ_max : is_maximal (comap _ Qₚ) := @is_maximal_comap_of_is_integral_of_is_maximal Rₚ _ Sₚ _
-    (localization_algebra P.prime_compl f g)
-    (is_integral_localization f g H) _ Qₚ_maximal,
-  refine ⟨comap g.to_map Qₚ, ⟨comap_is_prime g.to_map Qₚ, _⟩⟩,
+    (localization_algebra P.prime_compl S)
+    (is_integral_localization H) _ Qₚ_maximal,
+  refine ⟨comap (algebra_map S Sₚ) Qₚ, ⟨comap_is_prime _ Qₚ, _⟩⟩,
   convert localization.at_prime.comap_maximal_ideal,
-  rw [comap_comap, ← local_ring.eq_maximal_ideal Qₚ_max, ← f.map_comp _],
+  rw [comap_comap, ← local_ring.eq_maximal_ideal Qₚ_max, ← is_localization.map_comp _],
   refl
 end
 

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -144,9 +144,9 @@ end is_jacobson
 
 
 section localization
-open localization_map submonoid
+open is_localization submonoid
 variables {R S : Type*} [comm_ring R] [comm_ring S] {I : ideal R}
-variables {y : R} (f : away_map y S)
+variables (y : R) [algebra R S] [is_localization.away y S]
 
 lemma disjoint_powers_iff_not_mem (hI : I.radical = I) :
   disjoint ((submonoid.powers y) : set R) ↑I ↔ y ∉ I.1 :=
@@ -157,51 +157,56 @@ begin
   exact absurd (hI ▸ mem_radical_of_pow_mem hx' : y ∈ I.carrier) h
 end
 
+variables (S)
+
 /-- If `R` is a Jacobson ring, then maximal ideals in the localization at `y`
 correspond to maximal ideals in the original ring `R` that don't contain `y`.
 This lemma gives the correspondence in the particular case of an ideal and its comap.
 See `le_rel_iso_of_maximal` for the more general relation isomorphism -/
 lemma is_maximal_iff_is_maximal_disjoint [H : is_jacobson R] (J : ideal S) :
-  J.is_maximal ↔ (comap f.to_map J).is_maximal ∧ y ∉ ideal.comap f.to_map J :=
+  J.is_maximal ↔ (comap (algebra_map R S) J).is_maximal ∧ y ∉ ideal.comap (algebra_map R S) J :=
 begin
   split,
   { refine λ h, ⟨_, λ hy, h.ne_top (ideal.eq_top_of_is_unit_mem _ hy
-      (map_units f ⟨y, submonoid.mem_powers _⟩))⟩,
+      (map_units _ ⟨y, submonoid.mem_powers _⟩))⟩,
     have hJ : J.is_prime := is_maximal.is_prime h,
-    rw is_prime_iff_is_prime_disjoint f at hJ,
-    have : y ∉ (comap f.to_map J).1 :=
+    rw is_prime_iff_is_prime_disjoint (submonoid.powers y) at hJ,
+    have : y ∉ (comap (algebra_map R S) J).1 :=
       set.disjoint_left.1 hJ.right (submonoid.mem_powers _),
     erw [← H.out (is_prime.radical hJ.left), mem_Inf] at this,
     push_neg at this,
     rcases this with ⟨I, hI, hI'⟩,
     convert hI.right,
-    by_cases hJ : J = map f.to_map I,
-    { rw [hJ, comap_map_of_is_prime_disjoint f I (is_maximal.is_prime hI.right)],
-      rwa disjoint_powers_iff_not_mem (is_maximal.is_prime hI.right).radical},
-    { have hI_p : (map f.to_map I).is_prime,
-      { refine is_prime_of_is_prime_disjoint f I hI.right.is_prime _,
-        rwa disjoint_powers_iff_not_mem (is_maximal.is_prime hI.right).radical },
-      have : J ≤ map f.to_map I := (map_comap f J) ▸ (map_mono hI.left),
+    by_cases hJ : J = map (algebra_map R S) I,
+    { rw [hJ, comap_map_of_is_prime_disjoint (powers y) S I (is_maximal.is_prime hI.right)],
+      rwa disjoint_powers_iff_not_mem y (is_maximal.is_prime hI.right).radical },
+    { have hI_p : (map (algebra_map R S) I).is_prime,
+      { refine is_prime_of_is_prime_disjoint (powers y) _ I hI.right.is_prime _,
+        rwa disjoint_powers_iff_not_mem y (is_maximal.is_prime hI.right).radical },
+      have : J ≤ map (algebra_map R S) I :=
+        (map_comap (submonoid.powers y) S J) ▸ (map_mono hI.left),
       exact absurd (h.1.2 _ (lt_of_le_of_ne this hJ)) hI_p.1 } },
   { refine λ h, ⟨⟨λ hJ, h.1.ne_top (eq_top_iff.2 _), λ I hI, _⟩⟩,
-    { rwa [eq_top_iff, ← f.order_embedding.le_iff_le] at hJ },
-    { have := congr_arg (map f.to_map) (h.1.1.2 _ ⟨comap_mono (le_of_lt hI), _⟩),
-      rwa [map_comap f I, map_top f.to_map] at this,
+    { rwa [eq_top_iff, ← (is_localization.order_embedding (powers y) S).le_iff_le] at hJ },
+    { have := congr_arg (map (algebra_map R S)) (h.1.1.2 _ ⟨comap_mono (le_of_lt hI), _⟩),
+      rwa [map_comap (powers y) S I, map_top] at this,
       refine λ hI', hI.right _,
-      rw [← map_comap f I, ← map_comap f J],
+      rw [← map_comap (powers y) S I, ← map_comap (powers y) S J],
       exact map_mono hI' } }
 end
+
+variables {S}
 
 /-- If `R` is a Jacobson ring, then maximal ideals in the localization at `y`
 correspond to maximal ideals in the original ring `R` that don't contain `y`.
 This lemma gives the correspondence in the particular case of an ideal and its map.
 See `le_rel_iso_of_maximal` for the more general statement, and the reverse of this implication -/
 lemma is_maximal_of_is_maximal_disjoint [is_jacobson R] (I : ideal R) (hI : I.is_maximal)
-  (hy : y ∉ I) : (map f.to_map I).is_maximal :=
+  (hy : y ∉ I) : (map (algebra_map R S) I).is_maximal :=
 begin
-  rw [is_maximal_iff_is_maximal_disjoint f,
-    comap_map_of_is_prime_disjoint f I (is_maximal.is_prime hI)
-    ((disjoint_powers_iff_not_mem (is_maximal.is_prime hI).radical).2 hy)],
+  rw [is_maximal_iff_is_maximal_disjoint S y,
+    comap_map_of_is_prime_disjoint (powers y) S I (is_maximal.is_prime hI)
+    ((disjoint_powers_iff_not_mem y (is_maximal.is_prime hI).radical).2 hy)],
   exact ⟨hI, hy⟩
 end
 
@@ -209,28 +214,33 @@ end
 correspond to maximal ideals in the original ring `R` that don't contain `y` -/
 def order_iso_of_maximal [is_jacobson R] :
   {p : ideal S // p.is_maximal} ≃o {p : ideal R // p.is_maximal ∧ y ∉ p} :=
-{ to_fun := λ p, ⟨ideal.comap f.to_map p.1, (is_maximal_iff_is_maximal_disjoint f p.1).1 p.2⟩,
-  inv_fun := λ p, ⟨ideal.map f.to_map p.1, is_maximal_of_is_maximal_disjoint f p.1 p.2.1 p.2.2⟩,
-  left_inv := λ J, subtype.eq (map_comap f J),
-  right_inv := λ I, subtype.eq (comap_map_of_is_prime_disjoint f I.1 (is_maximal.is_prime I.2.1)
-    ((disjoint_powers_iff_not_mem I.2.1.is_prime.radical).2 I.2.2)),
+{ to_fun := λ p,
+    ⟨ideal.comap (algebra_map R S) p.1, (is_maximal_iff_is_maximal_disjoint S y p.1).1 p.2⟩,
+  inv_fun := λ p,
+    ⟨ideal.map (algebra_map R S) p.1, is_maximal_of_is_maximal_disjoint y p.1 p.2.1 p.2.2⟩,
+  left_inv := λ J, subtype.eq (map_comap (powers y) S J),
+  right_inv := λ I, subtype.eq (comap_map_of_is_prime_disjoint _ _ I.1 (is_maximal.is_prime I.2.1)
+    ((disjoint_powers_iff_not_mem y I.2.1.is_prime.radical).2 I.2.2)),
   map_rel_iff' := λ I I', ⟨λ h, (show I.val ≤ I'.val,
-    from (map_comap f I.val) ▸ (map_comap f I'.val) ▸ (ideal.map_mono h)), λ h x hx, h hx⟩ }
+    from (map_comap (powers y) S I.val) ▸ (map_comap (powers y) S I'.val) ▸ (ideal.map_mono h)),
+    λ h x hx, h hx⟩ }
+
+include y
 
 /-- If `S` is the localization of the Jacobson ring `R` at the submonoid generated by `y : R`, then
 `S` is Jacobson. -/
-lemma is_jacobson_localization [H : is_jacobson R]
-  (f : away_map y S) : is_jacobson S :=
+lemma is_jacobson_localization [H : is_jacobson R] : is_jacobson S :=
 begin
   rw is_jacobson_iff_prime_eq,
   refine λ P' hP', le_antisymm _ le_jacobson,
-  obtain ⟨hP', hPM⟩ := (localization_map.is_prime_iff_is_prime_disjoint f P').mp hP',
+  obtain ⟨hP', hPM⟩ := (is_localization.is_prime_iff_is_prime_disjoint (powers y) S P').mp hP',
   have hP := H.out (is_prime.radical hP'),
-  refine le_trans (le_trans (le_of_eq (localization_map.map_comap f P'.jacobson).symm) (map_mono _))
-    (le_of_eq (localization_map.map_comap f P')),
-  have : Inf { I : ideal R | comap f.to_map P' ≤ I ∧ I.is_maximal ∧ y ∉ I } ≤ comap f.to_map P',
+  refine (le_of_eq (is_localization.map_comap (powers y) S P'.jacobson).symm).trans
+    ((map_mono _).trans (le_of_eq (is_localization.map_comap (powers y) S P'))),
+  have : Inf { I : ideal R | comap (algebra_map R S) P' ≤ I ∧ I.is_maximal ∧ y ∉ I } ≤
+    comap (algebra_map R S) P',
   { intros x hx,
-    have hxy : x * y ∈ (comap f.to_map P').jacobson,
+    have hxy : x * y ∈ (comap (algebra_map R S) P').jacobson,
     { rw [ideal.jacobson, mem_Inf],
       intros J hJ,
       by_cases y ∈ J,
@@ -242,11 +252,11 @@ begin
     { exact (hPM ⟨submonoid.mem_powers _, hxy⟩).elim } },
   refine le_trans _ this,
   rw [ideal.jacobson, comap_Inf', Inf_eq_infi],
-  refine infi_le_infi_of_subset (λ I hI, ⟨map f.to_map I, ⟨_, _⟩⟩),
-  { exact ⟨le_trans (le_of_eq ((localization_map.map_comap f P').symm)) (map_mono hI.1),
-    is_maximal_of_is_maximal_disjoint f _ hI.2.1 hI.2.2⟩ },
-  { exact localization_map.comap_map_of_is_prime_disjoint f I (is_maximal.is_prime hI.2.1)
-    ((disjoint_powers_iff_not_mem hI.2.1.is_prime.radical).2 hI.2.2) }
+  refine infi_le_infi_of_subset (λ I hI, ⟨map (algebra_map R S) I, ⟨_, _⟩⟩),
+  { exact ⟨le_trans (le_of_eq ((is_localization.map_comap (powers y) S P').symm)) (map_mono hI.1),
+    is_maximal_of_is_maximal_disjoint y _ hI.2.1 hI.2.2⟩ },
+  { exact is_localization.comap_map_of_is_prime_disjoint _ S I (is_maximal.is_prime hI.2.1)
+    ((disjoint_powers_iff_not_mem y hI.2.1.is_prime.radical).2 hI.2.2) }
 end
 
 end localization
@@ -262,40 +272,44 @@ variables {Rₘ Sₘ : Type*} [comm_ring Rₘ] [comm_ring Sₘ]
   then the map `R →+* R[x]/I` descends to an integral map when localizing at `pX.leading_coeff`.
   In particular `X` is integral because it satisfies `pX`, and constants are trivially integral,
   so integrality of the entire extension follows by closure under addition and multiplication. -/
-lemma is_integral_localization_map_polynomial_quotient
+lemma is_integral_is_localization_polynomial_quotient
   (P : ideal (polynomial R)) [P.is_prime] (pX : polynomial R) (hpX : pX ∈ P)
-  (ϕ : localization_map (submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff) Rₘ)
-  (ϕ' : localization_map ((submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff).map
-    (quotient_map P C le_rfl) : submonoid P.quotient) Sₘ) :
-  (ϕ.map ((submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff).apply_coe_mem_map
-      (quotient_map P C le_rfl :
-  (P.comap C : ideal R).quotient →* P.quotient)) ϕ').is_integral :=
+  [algebra (P.comap (C : R →+* _)).quotient Rₘ]
+  [is_localization.away (pX.map (quotient.mk (P.comap C))).leading_coeff Rₘ]
+  [algebra P.quotient Sₘ]
+  [is_localization ((submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff).map
+    (quotient_map P C le_rfl) : submonoid P.quotient) Sₘ] :
+  (is_localization.map Sₘ (quotient_map P C le_rfl)
+    ((submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff).le_comap_map) : Rₘ →+* _)
+    .is_integral :=
 begin
   let P' : ideal R := P.comap C,
   let M : submonoid P'.quotient :=
   submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff,
+  let M' : submonoid P.quotient :=
+  (submonoid.powers (pX.map (quotient.mk (P.comap C))).leading_coeff).map (quotient_map P C le_rfl),
   let φ : P'.quotient →+* P.quotient := quotient_map P C le_rfl,
-  let φ' := (ϕ.map (M.apply_coe_mem_map (φ : P'.quotient →* P.quotient)) ϕ'),
+  let φ' := is_localization.map Sₘ φ M.le_comap_map,
   have hφ' : φ.comp (quotient.mk P') = (quotient.mk P).comp C := rfl,
   intro p,
-  obtain ⟨⟨p', ⟨q, hq⟩⟩, hp⟩ := ϕ'.surj p,
-  suffices : φ'.is_integral_elem (ϕ'.to_map p'),
+  obtain ⟨⟨p', ⟨q, hq⟩⟩, hp⟩ := is_localization.surj M' p,
+  suffices : φ'.is_integral_elem (algebra_map _ _ p'),
   { obtain ⟨q', hq', rfl⟩ := hq,
-    obtain ⟨q'', hq''⟩ := is_unit_iff_exists_inv'.1 (ϕ.map_units ⟨q', hq'⟩),
-    refine φ'.is_integral_of_is_integral_mul_unit p (ϕ'.to_map (φ q')) q'' _ (hp.symm ▸ this),
+    obtain ⟨q'', hq''⟩ := is_unit_iff_exists_inv'.1 (is_localization.map_units Rₘ (⟨q', hq'⟩ : M)),
+    refine φ'.is_integral_of_is_integral_mul_unit p (algebra_map _ _ (φ q')) q'' _ (hp.symm ▸ this),
     convert trans (trans (φ'.map_mul _ _).symm (congr_arg φ' hq'')) φ'.map_one using 2,
-    rw [← φ'.comp_apply, localization_map.map_comp, ϕ'.to_map.comp_apply, subtype.coe_mk] },
+    rw [← φ'.comp_apply, is_localization.map_comp, ring_hom.comp_apply, subtype.coe_mk] },
   refine is_integral_of_mem_closure''
-    ((ϕ'.to_map.comp (quotient.mk P)) '' (insert X {p | p.degree ≤ 0})) _ _ _,
+    (((algebra_map _ Sₘ).comp (quotient.mk P)) '' (insert X {p | p.degree ≤ 0})) _ _ _,
   { rintros x ⟨p, hp, rfl⟩,
     refine hp.rec_on (λ hy, _) (λ hy, _),
     { refine hy.symm ▸ (φ.is_integral_elem_localization_at_leading_coeff ((quotient.mk P) X)
-        (pX.map (quotient.mk P')) _ M ⟨1, pow_one _⟩ _ _),
+        (pX.map (quotient.mk P')) _ M ⟨1, pow_one _⟩),
       rwa [eval₂_map, hφ', ← hom_eval₂, quotient.eq_zero_iff_mem, eval₂_C_X] },
     { rw [set.mem_set_of_eq, degree_le_zero_iff] at hy,
-      refine hy.symm ▸ ⟨X - C (ϕ.to_map ((quotient.mk P') (p.coeff 0))), monic_X_sub_C _, _⟩,
+      refine hy.symm ▸ ⟨X - C (algebra_map _ _ ((quotient.mk P') (p.coeff 0))), monic_X_sub_C _, _⟩,
       simp only [eval₂_sub, eval₂_C, eval₂_X],
-      rw [sub_eq_zero, ← φ'.comp_apply, localization_map.map_comp, ring_hom.comp_apply],
+      rw [sub_eq_zero, ← φ'.comp_apply, is_localization.map_comp],
       refl } },
   { obtain ⟨p, rfl⟩ := quotient.mk_surjective p',
     refine polynomial.induction_on p
@@ -303,42 +317,45 @@ begin
       (λ _ _ h1 h2, _) (λ n _ hr, _),
     { convert subring.add_mem _ h1 h2,
       rw [ring_hom.map_add, ring_hom.map_add] },
-    { rw [pow_succ X n, mul_comm X, ← mul_assoc, ring_hom.map_mul, ϕ'.to_map.map_mul],
+    { rw [pow_succ X n, mul_comm X, ← mul_assoc, ring_hom.map_mul, ring_hom.map_mul],
       exact subring.mul_mem _ hr (subring.subset_closure (set.mem_image_of_mem _ (or.inl rfl))) } },
 end
 
 /-- If `f : R → S` descends to an integral map in the localization at `x`,
   and `R` is a Jacobson ring, then the intersection of all maximal ideals in `S` is trivial -/
 lemma jacobson_bot_of_integral_localization {R : Type*} [integral_domain R] [is_jacobson R]
+  (Rₘ Sₘ : Type*) [comm_ring Rₘ] [comm_ring Sₘ]
   (φ : R →+* S) (hφ : function.injective φ) (x : R) (hx : x ≠ 0)
-  (ϕ : localization_map (submonoid.powers x) Rₘ)
-  (ϕ' : localization_map ((submonoid.powers x).map φ : submonoid S) Sₘ)
-  (hφ' : (ϕ.map ((submonoid.powers x).apply_coe_mem_map (φ : R →* S)) ϕ').is_integral) :
-  (⊥ : ideal S).jacobson = ⊥ :=
+  [algebra R Rₘ] [is_localization.away x Rₘ]
+  [algebra S Sₘ] [is_localization ((submonoid.powers x).map φ : submonoid S) Sₘ]
+  (hφ' : ring_hom.is_integral
+    (is_localization.map Sₘ φ (submonoid.powers x).le_comap_map : Rₘ →+* Sₘ)) :
+  (⊥ : ideal S).jacobson = (⊥ : ideal S) :=
 begin
   have hM : ((submonoid.powers x).map φ : submonoid S) ≤ non_zero_divisors S :=
     map_le_non_zero_divisors_of_injective hφ (powers_le_non_zero_divisors_of_domain hx),
-  letI : integral_domain Sₘ := localization_map.integral_domain_of_le_non_zero_divisors ϕ' hM,
-  let φ' : Rₘ →+* Sₘ := ϕ.map ((submonoid.powers x).apply_coe_mem_map (φ : R →* S)) ϕ',
-  suffices : ∀ I : ideal Sₘ, I.is_maximal → (I.comap ϕ'.to_map).is_maximal,
-  { have hϕ' : comap ϕ'.to_map ⊥ = ⊥,
-    { simpa [ring_hom.injective_iff_ker_eq_bot, ring_hom.ker_eq_comap_bot] using ϕ'.injective hM },
-    refine eq_bot_iff.2 (le_trans _ (le_of_eq hϕ')),
-    have hSₘ : is_jacobson Sₘ := is_jacobson_of_is_integral' φ' hφ' (is_jacobson_localization ϕ),
+  letI : integral_domain Sₘ := is_localization.integral_domain_of_le_non_zero_divisors _ hM,
+  let φ' : Rₘ →+* Sₘ := is_localization.map _ φ (submonoid.powers x).le_comap_map,
+  suffices : ∀ I : ideal Sₘ, I.is_maximal → (I.comap (algebra_map S Sₘ)).is_maximal,
+  { have hϕ' : comap (algebra_map S Sₘ) (⊥ : ideal Sₘ) = (⊥ : ideal S),
+    { simpa [ring_hom.injective_iff_ker_eq_bot, ring_hom.ker_eq_comap_bot]
+        using is_localization.injective _ hM },
+    have hSₘ : is_jacobson Sₘ := is_jacobson_of_is_integral' φ' hφ' (is_jacobson_localization x),
+    refine eq_bot_iff.mpr (le_trans _ (le_of_eq hϕ')),
     rw [← hSₘ.out radical_bot_of_integral_domain, comap_jacobson],
     exact Inf_le_Inf (λ j hj, ⟨bot_le, let ⟨J, hJ⟩ := hj in hJ.2 ▸ this J hJ.1.2⟩) },
   introsI I hI,
   -- Remainder of the proof is pulling and pushing ideals around the square and the quotient square
-  haveI : (I.comap ϕ'.to_map).is_prime := comap_is_prime ϕ'.to_map I,
+  haveI : (I.comap (algebra_map S Sₘ)).is_prime := comap_is_prime _ I,
   haveI : (I.comap φ').is_prime := comap_is_prime φ' I,
-  haveI : (⊥ : ideal (I.comap ϕ'.to_map).quotient).is_prime := bot_prime,
-  have hcomm: φ'.comp ϕ.to_map = ϕ'.to_map.comp φ := ϕ.map_comp _,
-  let f := quotient_map (I.comap ϕ'.to_map) φ le_rfl,
-  let g := quotient_map I ϕ'.to_map le_rfl,
+  haveI : (⊥ : ideal (I.comap (algebra_map S Sₘ)).quotient).is_prime := bot_prime,
+  have hcomm: φ'.comp (algebra_map R Rₘ) = (algebra_map S Sₘ).comp φ := is_localization.map_comp _,
+  let f := quotient_map (I.comap (algebra_map S Sₘ)) φ le_rfl,
+  let g := quotient_map I (algebra_map S Sₘ) le_rfl,
   have := is_maximal_comap_of_is_integral_of_is_maximal' φ' hφ' I
     (by convert hI; casesI _inst_4; refl),
-  have := ((is_maximal_iff_is_maximal_disjoint ϕ _).1 this).left,
-  have : ((I.comap ϕ'.to_map).comap φ).is_maximal,
+  have := ((is_maximal_iff_is_maximal_disjoint Rₘ x _).1 this).left,
+  have : ((I.comap (algebra_map S Sₘ)).comap φ).is_maximal,
   { rwa [comap_comap, hcomm, ← comap_comap] at this },
   rw ← bot_quotient_is_maximal_iff at this ⊢,
   refine is_maximal_of_is_integral_of_is_maximal_comap' f _ ⊥
@@ -346,7 +363,7 @@ begin
   exact f.is_integral_tower_bot_of_is_integral g quotient_map_injective
     ((comp_quotient_map_eq_of_comp_eq hcomm I).symm ▸
     (ring_hom.is_integral_trans _ _ (ring_hom.is_integral_of_surjective _
-      (localization_map.surjective_quotient_map_of_maximal_of_localization
+      (is_localization.surjective_quotient_map_of_maximal_of_localization (submonoid.powers x) Rₘ
       (by rwa [comap_comap, hcomm, ← bot_quotient_is_maximal_iff])))
       (ring_hom.is_integral_quotient_of_is_integral _ hφ'))),
 end
@@ -363,11 +380,14 @@ begin
   { refine jacobson_eq_iff_jacobson_quotient_eq_bot.mpr _,
     haveI : (P.comap (C : R →+* polynomial R)).is_prime := comap_is_prime C P,
     obtain ⟨p, pP, p0⟩ := exists_nonzero_mem_of_ne_bot Pb hP,
-    refine jacobson_bot_of_integral_localization (quotient_map P C le_rfl) quotient_map_injective
-      _ _ (localization.of (submonoid.powers (p.map (quotient.mk (P.comap C))).leading_coeff))
-      (localization.of _)
-      (by apply (is_integral_localization_map_polynomial_quotient P _ pP _ _)),
-    rwa [ne.def, leading_coeff_eq_zero] }
+    let x := (polynomial.map (quotient.mk (comap (C : R →+* _) P)) p).leading_coeff,
+    have hx : x ≠ 0 := by rwa [ne.def, leading_coeff_eq_zero],
+    exact jacobson_bot_of_integral_localization
+      (localization.away x)
+      (localization ((submonoid.powers x).map (P.quotient_map C le_rfl) : submonoid P.quotient))
+      (quotient_map P C le_rfl) quotient_map_injective
+      x hx
+      (is_integral_is_localization_polynomial_quotient P _ pP) }
 end
 
 lemma is_jacobson_polynomial_of_is_jacobson (hR : is_jacobson R) :
@@ -432,25 +452,26 @@ begin
       ((quotient.mk (P.comap C : ideal R)).injective_iff.2 (λ x hx,
       by rwa [quotient.eq_zero_iff_mem, (by rwa eq_bot_iff : (P.comap C : ideal R) = ⊥)] at hx))
       (by simpa only [leading_coeff_eq_zero, map_zero] using hp0'),
-  let ϕ : localization_map M (localization M) := localization.of M,
   have hM : (0 : ((P.comap C : ideal R)).quotient) ∉ M := λ ⟨n, hn⟩, hp0 (pow_eq_zero hn),
   suffices : (⊥ : ideal (localization M)).is_maximal,
-  { rw ← ϕ.comap_map_of_is_prime_disjoint ⊥ bot_prime (λ x hx, hM (hx.2 ▸ hx.1)),
-    refine ((is_maximal_iff_is_maximal_disjoint ϕ _).mp _).1,
-    rwa map_bot },
+  { rw ← is_localization.comap_map_of_is_prime_disjoint M (localization M) ⊥ bot_prime
+        (λ x hx, hM (hx.2 ▸ hx.1)),
+    refine ((is_maximal_iff_is_maximal_disjoint (localization M) _ _).mp (by rwa map_bot)).1,
+    swap, exact localization.is_localization },
   let M' : submonoid P.quotient := M.map φ,
   have hM' : (0 : P.quotient) ∉ M' :=
     λ ⟨z, hz⟩, hM (quotient_map_injective (trans hz.2 φ.map_zero.symm) ▸ hz.1),
   letI : integral_domain (localization M') :=
-    localization_map.integral_domain_localization (le_non_zero_divisors_of_domain hM'),
-  let ϕ' : localization_map (M.map ↑φ) (localization (M.map ↑φ)) := localization.of (M.map ↑φ),
+    is_localization.integral_domain_localization (le_non_zero_divisors_of_domain hM'),
   suffices : (⊥ : ideal (localization M')).is_maximal,
-  { rw le_antisymm bot_le (comap_bot_le_of_injective _ (map_injective_of_injective _
-      quotient_map_injective M ϕ ϕ' (le_non_zero_divisors_of_domain hM'))),
+  { rw le_antisymm bot_le (comap_bot_le_of_injective _ (is_localization.map_injective_of_injective
+      M (localization M) (localization M')
+      quotient_map_injective (le_non_zero_divisors_of_domain hM'))),
     refine is_maximal_comap_of_is_integral_of_is_maximal' _ _ ⊥ this,
-    apply is_integral_localization_map_polynomial_quotient P _ (submodule.coe_mem m) ϕ (ϕ' : _) },
-  rw (map_bot.symm : (⊥ : ideal (localization M')) = map ϕ'.to_map ⊥),
-  refine map.is_maximal ϕ'.to_map (localization_map_bijective_of_field hM' _ ϕ') hP,
+    apply is_integral_is_localization_polynomial_quotient P _ (submodule.coe_mem m) },
+  rw (map_bot.symm : (⊥ : ideal (localization M')) =
+                     map (algebra_map P.quotient (localization M')) ⊥),
+  refine map.is_maximal (algebra_map _ _) (localization_map_bijective_of_field hM' _) hP,
   rwa [← quotient.maximal_ideal_iff_is_field_quotient, ← bot_quotient_is_maximal_iff],
 end
 
@@ -465,22 +486,23 @@ begin
     exists_nonzero_mem_of_ne_bot (ne_of_lt (bot_lt_of_maximal P polynomial_not_is_field)).symm hP',
   let M : submonoid P'.quotient := submonoid.powers (pX.map (quotient.mk P')).leading_coeff,
   let φ : P'.quotient →+* P.quotient := quotient_map P C le_rfl,
-  let ϕ' : localization_map (M.map ↑φ) (localization (M.map ↑φ)) := localization.of (M.map ↑φ),
   haveI hp'_prime : P'.is_prime := comap_is_prime C P,
   have hM : (0 : P'.quotient) ∉ M := λ ⟨n, hn⟩, hp0 $ leading_coeff_eq_zero.mp (pow_eq_zero hn),
+  let M' : submonoid P.quotient := M.map (quotient_map P C le_rfl),
   refine ((quotient_map P C le_rfl).is_integral_tower_bot_of_is_integral
-    (localization.of (M.map ↑(quotient_map P C le_rfl))).to_map _ _),
-  { refine ϕ'.injective (le_non_zero_divisors_of_domain (λ hM', hM _)),
+    (algebra_map _ (localization M')) _ _),
+  { refine is_localization.injective (localization M')
+      (show M' ≤ _, from le_non_zero_divisors_of_domain (λ hM', hM _)),
     exact (let ⟨z, zM, z0⟩ := hM' in (quotient_map_injective (trans z0 φ.map_zero.symm)) ▸ zM) },
-  { let ϕ : localization_map M (localization M) := localization.of M,
-    rw ← (ϕ.map_comp _),
-    refine ring_hom.is_integral_trans ϕ.to_map
-      (ϕ.map (M.apply_coe_mem_map (φ : P'.quotient →* P.quotient)) ϕ') _ _,
-    { exact ϕ.to_map.is_integral_of_surjective (localization_map_bijective_of_field hM
-        ((quotient.maximal_ideal_iff_is_field_quotient _).mp
-        (is_maximal_comap_C_of_is_maximal P hP')) _).2 },
+  { rw ← is_localization.map_comp M.le_comap_map,
+    refine ring_hom.is_integral_trans (algebra_map P'.quotient (localization M))
+      (is_localization.map _ _ M.le_comap_map) _ _,
+    { exact (algebra_map P'.quotient (localization M)).is_integral_of_surjective
+        (localization_map_bijective_of_field hM
+          ((quotient.maximal_ideal_iff_is_field_quotient _).mp
+          (is_maximal_comap_C_of_is_maximal P hP'))).2 },
     { -- `convert` here is faster than `exact`, and this proof is near the time limit.
-      convert is_integral_localization_map_polynomial_quotient P pX hpX _ _ } }
+      convert is_integral_is_localization_polynomial_quotient P pX hpX } }
 end
 
 /-- If `R` is a Jacobson ring, and `P` is a maximal ideal of `polynomial R`,

--- a/src/ring_theory/laurent_series.lean
+++ b/src/ring_theory/laurent_series.lean
@@ -131,30 +131,34 @@ end
 instance [comm_semiring R] : algebra (power_series R) (laurent_series R) :=
 (hahn_series.of_power_series ℤ R).to_algebra
 
+@[simp] lemma coe_algebra_map [comm_semiring R] :
+  ⇑(algebra_map (power_series R) (laurent_series R)) = hahn_series.of_power_series ℤ R :=
+rfl
+
 /-- The localization map from power series to Laurent series. -/
 @[simps] instance of_power_series_localization [comm_ring R] :
   is_localization (submonoid.powers (power_series.X : power_series R)) (laurent_series R) :=
-{ surj := (begin rintro ⟨_, n, rfl⟩,
+{ map_units := (begin rintro ⟨_, n, rfl⟩,
     refine ⟨⟨single (n : ℤ) 1, single (-n : ℤ) 1, _, _⟩, _⟩,
     { simp only [single_mul_single, mul_one, add_right_neg],
       refl },
     { simp only [single_mul_single, mul_one, add_left_neg],
       refl },
     { simp } end),
- bar := (begin intro z,
+ surj := (begin intro z,
     by_cases h : 0 ≤ z.order,
     { refine ⟨⟨power_series.X ^ (int.nat_abs z.order) * power_series_part z, 1⟩, _⟩,
-      simp only [ring_hom.map_one, mul_one, ring_hom.map_mul,
+      simp only [ring_hom.map_one, mul_one, ring_hom.map_mul, coe_algebra_map,
         of_power_series_X_pow, submonoid.coe_one],
       rw [int.nat_abs_of_nonneg h, ← coe_power_series, single_order_mul_power_series_part] },
     { refine ⟨⟨power_series_part z, power_series.X ^ (int.nat_abs z.order), ⟨_, rfl⟩⟩, _⟩,
-      simp only [of_power_series_power_series_part],
+      simp only [coe_algebra_map, of_power_series_power_series_part],
       rw [mul_comm _ z],
       refine congr rfl _,
       rw [subtype.coe_mk, of_power_series_X_pow, int.of_nat_nat_abs_of_nonpos],
       exact le_of_not_ge h } end),
-  baz := (begin intros x y,
-    rw of_power_series_injective.eq_iff,
+  eq_iff_exists := (begin intros x y,
+    rw [coe_algebra_map, of_power_series_injective.eq_iff],
     split,
     { rintro rfl,
       exact ⟨1, rfl⟩ },

--- a/src/ring_theory/laurent_series.lean
+++ b/src/ring_theory/laurent_series.lean
@@ -128,18 +128,20 @@ begin
   rw [pow_succ, int.coe_nat_succ, ih, of_power_series_X, mul_comm, single_mul_single, one_mul],
 end
 
+instance [comm_semiring R] : algebra (power_series R) (laurent_series R) :=
+(hahn_series.of_power_series ℤ R).to_algebra
+
 /-- The localization map from power series to Laurent series. -/
-@[simps] def of_power_series_localization [comm_ring R] :
-  localization_map (submonoid.powers (power_series.X : power_series R)) (laurent_series R) :=
-ring_hom.to_localization_map (hahn_series.of_power_series ℤ R)
-  (begin rintro ⟨_, n, rfl⟩,
+@[simps] instance of_power_series_localization [comm_ring R] :
+  is_localization (submonoid.powers (power_series.X : power_series R)) (laurent_series R) :=
+{ surj := (begin rintro ⟨_, n, rfl⟩,
     refine ⟨⟨single (n : ℤ) 1, single (-n : ℤ) 1, _, _⟩, _⟩,
     { simp only [single_mul_single, mul_one, add_right_neg],
       refl },
     { simp only [single_mul_single, mul_one, add_left_neg],
       refl },
-    { simp } end)
-  (begin intro z,
+    { simp } end),
+ bar := (begin intro z,
     by_cases h : 0 ≤ z.order,
     { refine ⟨⟨power_series.X ^ (int.nat_abs z.order) * power_series_part z, 1⟩, _⟩,
       simp only [ring_hom.map_one, mul_one, ring_hom.map_mul,
@@ -150,8 +152,8 @@ ring_hom.to_localization_map (hahn_series.of_power_series ℤ R)
       rw [mul_comm _ z],
       refine congr rfl _,
       rw [subtype.coe_mk, of_power_series_X_pow, int.of_nat_nat_abs_of_nonpos],
-      exact le_of_not_ge h } end)
-  (begin intros x y,
+      exact le_of_not_ge h } end),
+  baz := (begin intros x y,
     rw of_power_series_injective.eq_iff,
     split,
     { rintro rfl,
@@ -164,6 +166,6 @@ ring_hom.to_localization_map (hahn_series.of_power_series ℤ R)
       rw [linear_map.map_zero, subtype.coe_mk, power_series.X_pow_eq, power_series.monomial,
         power_series.coeff, finsupp.single_add, mv_power_series.coeff_add_mul_monomial,
         mul_one] at h,
-      exact h } end)
+      exact h } end) }
 
 end laurent_series

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -75,7 +75,7 @@ then used a type synonym `f.codomain` for `f : localization_map M S` to instanti
 defined on `S`. By making `is_localization` a predicate on the `algebra_map R S`,
 we can ensure the localization map commutes nicely with other `algebra_map`s.
 
-o prove most lemmas about a localization map `algebra_map R S` in this file we invoke the
+To prove most lemmas about a localization map `algebra_map R S` in this file we invoke the
 corresponding proof for the underlying `comm_monoid` localization map
 `is_localization.to_localization_map M S`, which can be found in `group_theory.monoid_localization`
 and the namespace `submonoid.localization_map`.

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -21,29 +21,47 @@ ring homomorphism `f : R →+* S` satisfying 3 properties:
 2. For all `z : S`, there exists `(x, y) : R × M` such that `z * f y = f x`;
 3. For all `x, y : R`, `f x = f y` iff there exists `c ∈ M` such that `x * c = y * c`.
 
-Given such a localization map `f : R →+* S`, we can define the surjection
-`localization_map.mk'` sending `(x, y) : R × M` to `f x * (f y)⁻¹`, and
-`localization_map.lift`, the homomorphism from `S` induced by a homomorphism from `R` which maps
-elements of `M` to invertible elements of the codomain. Similarly, given commutative rings
-`P, Q`, a submonoid `T` of `P` and a localization map for `T` from `P` to `Q`, then a homomorphism
-`g : R →+* P` such that `g(M) ⊆ T` induces a homomorphism of localizations,
-`localization_map.map`, from `S` to `Q`.
-We treat the special case of localizing away from an element in the sections `away_map` and `away`.
+In the following, let `R, P` be commutative rings, `S, Q` be `R`- and `P`-algebras
+and `M, T` be submonoids of `R` and `P` respectively, e.g.:
+```
+variables (R S P Q : Type*) [comm_ring R] [comm_ring S] [comm_ring P] [comm_ring Q]
+variables [algebra R S] [algebra P Q] (M : submonoid R) (T : submonoid P)
+```
 
-We show the localization as a quotient type, defined in `group_theory.monoid_localization` as
-`submonoid.localization`, is a `comm_ring` and that the natural ring hom
-`of : R →+* localization M` is a localization map.
+## Main definitions
 
-We show that a localization at the complement of a prime ideal is a local ring.
+ * `is_localization (M : submonoid R) (S : Type*)` is a typeclass expressing that `S` is a
+   localization of `R` at `M`, i.e. the canonical map `algebra_map R S : R →+* S` is a
+   localization map (satisfying the above properties).
+ * `is_localization.mk' S` is a surjection sending `(x, y) : R × M` to `f x * (f y)⁻¹`
+ * `is_localization.lift` is the ring homomorphism from `S` induced by a homomorphism from `R`
+   which maps elements of `M` to invertible elements of the codomain.
+ * `is_localization.map S Q` is the ring homomorphism from `S` to `Q` which maps elements
+   of `M` to elements of `T`
+ * `is_localization.ring_equiv_of_ring_equiv`: if `R` and `P` are isomorphic by an isomorphism
+   sending `M` to `T`, then `S` and `Q` are isomorphic
+ * `is_localization.alg_equiv`: if `Q` is another localization of `R` at `M`, then `S` and `Q`
+   are isomorphic as `R`-algebras
+ * `is_localization.is_integer` is a predicate stating that `x : S` is in the image of `R`
+ * `is_localization.away (x : R) S` expresses that `S` is a localization away from `x`, as an
+   abbreviation of `is_localization (submonoid.powers x) S`
+ * `is_localization.at_prime (I : ideal R) [is_prime I] (S : Type*)` expresses that `S` is a
+   localization at (the complement of) a prime ideal `I`, as an abbreviation of
+   `is_localization I.prime_compl S`
+ * `is_fraction_ring R K` expresses that `K` is a field of fractions of `R`, as an abbreviation of
+   `is_localization (non_zero_divisors R) K`
 
-We prove some lemmas about the `R`-algebra structure of `S`.
+## Main results
 
-When `R` is an integral domain, we define `fraction_map R K` as an abbreviation for
-`localization (non_zero_divisors R) K`, the natural map to `R`'s field of fractions.
-
-We show that a `comm_ring` `K` which is the localization of an integral domain `R` at `R \ {0}`
-is a field. We use this to show the field of fractions as a quotient type, `fraction_ring`, is
-a field.
+ * `localization M S`, a construction of the localization as a quotient type, defined in
+   `group_theory.monoid_localization`, has `comm_ring`, `algebra R` and `is_localization M`
+   instances if `R` is a ring. `localization.away`, `localization.at_prime` and `fraction_ring`
+   are abbreviations for `localization`s and have their corresponding `is_localization` instances
+ * `is_localization.at_prime.local_ring`: a theorem (not an instance) stating a localization at the
+   complement of a prime ideal is a local ring
+ * `is_fraction_ring.field`: a definition (not an instance) stating the localization of an integral
+   domain `R` at `R \ {0}` is a field
+ * `rat.is_fraction_ring_int` is an instance stating `ℚ` is the field of fractions of `ℤ`
 
 ## Implementation notes
 
@@ -51,24 +69,22 @@ In maths it is natural to reason up to isomorphism, but in Lean we cannot natura
 structure with an isomorphic one; one way around this is to isolate a predicate characterizing
 a structure up to isomorphism, and reason about things that satisfy the predicate.
 
-A ring localization map is defined to be a localization map of the underlying `comm_monoid` (a
-`submonoid.localization_map`) which is also a ring hom. To prove most lemmas about a
-`localization_map` `f` in this file we invoke the corresponding proof for the underlying
-`comm_monoid` localization map `f.to_localization_map`, which can be found in
-`group_theory.monoid_localization` and the namespace `submonoid.localization_map`.
+A previous version of this file used a fully bundled type of ring localization maps,
+then used a type synonym `f.codomain` for `f : localization_map M S` to instantiate the
+`R`-algebra structure on `S`. This results in defining ad-hoc copies for everything already
+defined on `S`. By making `is_localization` a predicate on the `algebra_map R S`,
+we can ensure the localization map commutes nicely with other `algebra_map`s.
 
-To apply a localization map `f` as a function, we use `f.to_map`, as coercions don't work well for
-this structure.
+o prove most lemmas about a localization map `algebra_map R S` in this file we invoke the
+corresponding proof for the underlying `comm_monoid` localization map
+`is_localization.to_localization_map M S`, which can be found in `group_theory.monoid_localization`
+and the namespace `submonoid.localization_map`.
 
 To reason about the localization as a quotient type, use `mk_eq_of_mk'` and associated lemmas.
 These show the quotient map `mk : R → M → localization M` equals the surjection
-`localization_map.mk'` induced by the map `of : localization_map M (localization M)`
-(where `of` establishes the localization as a quotient type satisfies the characteristic
-predicate). The lemma `mk_eq_of_mk'` hence gives you access to the results in the rest of the file,
+`localization_map.mk'` induced by the map `algebra_map : R →+* localization M`.
+The lemma `mk_eq_of_mk'` hence gives you access to the results in the rest of the file,
 which are about the `localization_map.mk'` induced by any localization map.
-
-We define a copy of the localization map `f`'s codomain `S` carrying the data of `f` so that
-instances on `S` induced by `f` can 'know' the map needed to induce the instance.
 
 The proof that "a `comm_ring` `K` which is the localization of an integral domain `R` at `R \ {0}`
 is a field" is a `def` rather than an `instance`, so if you want to reason about a field of
@@ -79,302 +95,279 @@ localization, ring localization, commutative ring localization, characteristic p
 commutative ring, field of fractions
 -/
 variables {R : Type*} [comm_ring R] (M : submonoid R) (S : Type*) [comm_ring S]
-          {P : Type*} [comm_ring P]
+variables [algebra R S] {P : Type*} [comm_ring P]
 
 open function
 open_locale big_operators
 
-set_option old_structure_cmd true
-
-/-- The type of ring homomorphisms satisfying the characteristic predicate: if `f : R →+* S`
-satisfies this predicate, then `S` is isomorphic to the localization of `R` at `M`.
-We later define an instance coercing a localization map `f` to its codomain `S` so
-that instances on `S` induced by `f` can 'know' the map needed to induce the instance. -/
-@[nolint has_inhabited_instance] structure localization_map
-extends ring_hom R S, submonoid.localization_map M S
-
-/-- The ring hom underlying a `localization_map`. -/
-add_decl_doc localization_map.to_ring_hom
-
-/-- The `comm_monoid` `localization_map` underlying a `comm_ring` `localization_map`.
-See `group_theory.monoid_localization` for its definition. -/
-add_decl_doc localization_map.to_localization_map
+/-- The typeclass `is_localization (M : submodule R) S` where `S` is an `R`-algebra
+expresses that `S` is isomorphic to the localization of `R` at `M`. -/
+class is_localization : Prop :=
+(map_units [] : ∀ y : M, is_unit (algebra_map R S y))
+(surj [] : ∀ z : S, ∃ x : R × M, z * algebra_map R S x.2 = algebra_map R S x.1)
+(eq_iff_exists [] : ∀ {x y}, algebra_map R S x = algebra_map R S y ↔ ∃ c : M, x * c = y * c)
 
 variables {M S}
 
-namespace ring_hom
+namespace is_localization
 
-/-- Makes a localization map from a `comm_ring` hom satisfying the characteristic predicate. -/
-def to_localization_map (f : R →+* S) (H1 : ∀ y : M, is_unit (f y))
-  (H2 : ∀ z, ∃ x : R × M, z * f x.2 = f x.1) (H3 : ∀ x y, f x = f y ↔ ∃ c : M, x * c = y * c) :
-  localization_map M S :=
-{ map_units' := H1,
-  surj' := H2,
-  eq_iff_exists' := H3,
-  .. f }
+section is_localization
 
-end ring_hom
+variables [is_localization M S]
 
-/-- Makes a `comm_ring` localization map from an additive `comm_monoid` localization map of
-`comm_ring`s. -/
-def submonoid.localization_map.to_ring_localization
-  (f : submonoid.localization_map M S)
-  (h : ∀ x y, f.to_map (x + y) = f.to_map x + f.to_map y) :
-  localization_map M S :=
-{ ..ring_hom.mk' f.to_monoid_hom h, ..f }
+section
 
-namespace localization_map
+variables (M S)
 
-variables (f : localization_map M S)
+/-- `is_localization.to_localization_map M S` shows `S` is the monoid localization of `R` at `M`. -/
+@[simps]
+def to_localization_map : submonoid.localization_map M S :=
+{ to_fun := algebra_map R S,
+  map_units' := is_localization.map_units _,
+  surj' := is_localization.surj _,
+  eq_iff_exists' := λ _ _, is_localization.eq_iff_exists _ _,
+  .. algebra_map R S }
 
-/-- We define a copy of the localization map `f`'s codomain `S` carrying the data of `f` so that
-instances on `S` induced by `f` can 'know` the map needed to induce the instance. -/
-@[nolint unused_arguments has_inhabited_instance]
-def codomain (f : localization_map M S) := S
-
-instance : comm_ring f.codomain := by assumption
-instance {K : Type*} [field K] (f : localization_map M K) : field f.codomain := by assumption
-
-/-- Short for `to_ring_hom`; used for applying a localization map as a function. -/
-abbreviation to_map := f.to_ring_hom
-
-lemma map_units (y : M) : is_unit (f.to_map y) := f.6 y
-
-lemma surj (z) : ∃ x : R × M, z * f.to_map x.2 = f.to_map x.1 := f.7 z
-
-lemma eq_iff_exists {x y} : f.to_map x = f.to_map y ↔ ∃ c : M, x * c = y * c := f.8 x y
-
-@[ext] lemma ext {f g : localization_map M S}
-  (h : ∀ x, f.to_map x = g.to_map x) : f = g :=
-begin
-  cases f, cases g,
-  simp only at *,
-  exact funext h
 end
 
-lemma ext_iff {f g : localization_map M S} : f = g ↔ ∀ x, f.to_map x = g.to_map x :=
-⟨λ h x, h ▸ rfl, ext⟩
+section
 
-lemma to_map_injective : injective (@localization_map.to_map _ _ M S _) :=
-λ _ _ h, ext $ ring_hom.ext_iff.1 h
-
-/-- Given `a : S`, `S` a localization of `R`, `is_integer a` iff `a` is in the image of
-the localization map from `R` to `S`. -/
-def is_integer (a : S) : Prop := a ∈ set.range f.to_map
+variables (R)
 
 -- TODO: define a subalgebra of `is_integer`s
-lemma is_integer_zero : f.is_integer 0 := ⟨0, f.to_map.map_zero⟩
+/-- Given `a : S`, `S` a localization of `R`, `is_integer R a` iff `a` is in the image of
+the localization map from `R` to `S`. -/
+def is_integer (a : S) : Prop := a ∈ (algebra_map R S).range
 
-lemma is_integer_one : f.is_integer 1 := ⟨1, f.to_map.map_one⟩
-
-variables {f}
-
-lemma is_integer_add {a b} (ha : f.is_integer a) (hb : f.is_integer b) :
-  f.is_integer (a + b) :=
-begin
-  rcases ha with ⟨a', ha⟩,
-  rcases hb with ⟨b', hb⟩,
-  use a' + b',
-  rw [f.to_map.map_add, ha, hb]
 end
 
-lemma is_integer_mul {a b} (ha : f.is_integer a) (hb : f.is_integer b) :
-  f.is_integer (a * b) :=
-begin
-  rcases ha with ⟨a', ha⟩,
-  rcases hb with ⟨b', hb⟩,
-  use a' * b',
-  rw [f.to_map.map_mul, ha, hb]
-end
+lemma is_integer_zero : is_integer R (0 : S) := subring.zero_mem _
+lemma is_integer_one : is_integer R (1 : S) := subring.one_mem _
 
-lemma is_integer_smul {a : R} {b} (hb : f.is_integer b) :
-  f.is_integer (f.to_map a * b) :=
+lemma is_integer_add {a b : S} (ha : is_integer R a) (hb : is_integer R b) :
+  is_integer R (a + b) :=
+subring.add_mem _ ha hb
+
+lemma is_integer_mul {a b : S} (ha : is_integer R a) (hb : is_integer R b) :
+  is_integer R (a * b) :=
+subring.mul_mem _ ha hb
+
+lemma is_integer_smul {a : R} {b} (hb : is_integer R b) :
+  is_integer R ((algebra_map R S) a * b) :=
 begin
   rcases hb with ⟨b', hb⟩,
   use a * b',
-  rw [←hb, f.to_map.map_mul]
+  rw [←hb, (algebra_map R S).map_mul]
 end
 
-variables (f)
+variables (M)
 
 /-- Each element `a : S` has an `M`-multiple which is an integer.
 
 This version multiplies `a` on the right, matching the argument order in `localization_map.surj`.
 -/
 lemma exists_integer_multiple' (a : S) :
-  ∃ (b : M), is_integer f (a * f.to_map b) :=
-let ⟨⟨num, denom⟩, h⟩ := f.surj a in ⟨denom, set.mem_range.mpr ⟨num, h.symm⟩⟩
+  ∃ (b : M), is_integer R (a * algebra_map R S b) :=
+let ⟨⟨num, denom⟩, h⟩ := is_localization.surj _ a in ⟨denom, set.mem_range.mpr ⟨num, h.symm⟩⟩
 
 /-- Each element `a : S` has an `M`-multiple which is an integer.
 
 This version multiplies `a` on the left, matching the argument order in the `has_scalar` instance.
 -/
 lemma exists_integer_multiple (a : S) :
-  ∃ (b : M), is_integer f (f.to_map b * a) :=
+  ∃ (b : M), is_integer R (algebra_map R S b * a) :=
 by { simp_rw mul_comm _ a, apply exists_integer_multiple' }
 
-/-- Given `z : S`, `f.to_localization_map.sec z` is defined to be a pair `(x, y) : R × M` such
+/-- Given `z : S`, `is_localization.sec z` is defined to be a pair `(x, y) : R × M` such
 that `z * f y = f x` (so this lemma is true by definition). -/
-lemma sec_spec {f : localization_map M S} (z : S) :
-  z * f.to_map (f.to_localization_map.sec z).2 = f.to_map (f.to_localization_map.sec z).1 :=
-classical.some_spec $ f.surj z
+lemma sec_spec (z : S) :
+  z * algebra_map R S ((to_localization_map M S).sec z).2 =
+    algebra_map R S ((to_localization_map M S).sec z).1 :=
+classical.some_spec $ is_localization.surj _ z
 
-/-- Given `z : S`, `f.to_localization_map.sec z` is defined to be a pair `(x, y) : R × M` such
+/-- Given `z : S`, `(to_localization_map M S).sec z` is defined to be a pair `(x, y) : R × M` such
 that `z * f y = f x`, so this lemma is just an application of `S`'s commutativity. -/
-lemma sec_spec' {f : localization_map M S} (z : S) :
-  f.to_map (f.to_localization_map.sec z).1 = f.to_map (f.to_localization_map.sec z).2 * z :=
+lemma sec_spec' (z : S) :
+  algebra_map R S ((to_localization_map M S).sec z).1 =
+    algebra_map R S ((to_localization_map M S).sec z).2 * z :=
 by rw [mul_comm, sec_spec]
 
 open_locale big_operators
 
 /-- We can clear the denominators of a finite set of fractions. -/
 lemma exist_integer_multiples_of_finset (s : finset S) :
-  ∃ (b : M), ∀ a ∈ s, is_integer f (f.to_map b * a) :=
+  ∃ (b : M), ∀ a ∈ s, is_integer R (algebra_map R S b * a) :=
 begin
   haveI := classical.prop_decidable,
-  use ∏ a in s, (f.to_localization_map.sec a).2,
+  use ∏ a in s, ((to_localization_map M S).sec a).2,
   intros a ha,
-  use (∏ x in s.erase a, (f.to_localization_map.sec x).2) * (f.to_localization_map.sec a).1,
-  rw [ring_hom.map_mul, sec_spec', ←mul_assoc, ←f.to_map.map_mul],
+  use (∏ x in s.erase a, ((to_localization_map M S).sec x).2) * ((to_localization_map M S).sec a).1,
+  rw [ring_hom.map_mul, sec_spec', ←mul_assoc, ←(algebra_map R S).map_mul],
   congr' 2,
   refine trans _ ((submonoid.subtype M).map_prod _ _).symm,
   rw [mul_comm, ←finset.prod_insert (s.not_mem_erase a), finset.insert_erase ha],
   refl,
 end
 
-lemma map_right_cancel {x y} {c : M} (h : f.to_map (c * x) = f.to_map (c * y)) :
-  f.to_map x = f.to_map y :=
-f.to_localization_map.map_right_cancel h
+variables {R M}
 
-lemma map_left_cancel {x y} {c : M} (h : f.to_map (x * c) = f.to_map (y * c)) :
-  f.to_map x = f.to_map y :=
-f.to_localization_map.map_left_cancel h
+lemma map_right_cancel {x y} {c : M} (h : algebra_map R S (c * x) = algebra_map R S (c * y)) :
+  algebra_map R S x = algebra_map R S y :=
+(to_localization_map M S).map_right_cancel h
+
+lemma map_left_cancel {x y} {c : M} (h : algebra_map R S (x * c) = algebra_map R S (y * c)) :
+  algebra_map R S x = algebra_map R S y :=
+(to_localization_map M S).map_left_cancel h
 
 lemma eq_zero_of_fst_eq_zero {z x} {y : M}
-  (h : z * f.to_map y = f.to_map x) (hx : x = 0) : z = 0 :=
-by rw [hx, f.to_map.map_zero] at h; exact (f.map_units y).mul_left_eq_zero.1 h
+  (h : z * algebra_map R S y = algebra_map R S x) (hx : x = 0) : z = 0 :=
+by { rw [hx, (algebra_map R S).map_zero] at h,
+     exact (is_unit.mul_left_eq_zero (is_localization.map_units S y)).1 h}
 
-/-- Given a localization map `f : R →+* S`, the surjection sending `(x, y) : R × M` to
+variables (S)
+
+/-- `is_localization.mk' S` is the surjection sending `(x, y) : R × M` to
 `f x * (f y)⁻¹`. -/
-noncomputable def mk' (f : localization_map M S) (x : R) (y : M) : S :=
-f.to_localization_map.mk' x y
+noncomputable def mk' (x : R) (y : M) : S :=
+(to_localization_map M S).mk' x y
 
 @[simp] lemma mk'_sec (z : S) :
-  f.mk' (f.to_localization_map.sec z).1 (f.to_localization_map.sec z).2 = z :=
-f.to_localization_map.mk'_sec _
+  mk' S ((to_localization_map M S).sec z).1 ((to_localization_map M S).sec z).2 = z :=
+(to_localization_map M S).mk'_sec _
 
 lemma mk'_mul (x₁ x₂ : R) (y₁ y₂ : M) :
-  f.mk' (x₁ * x₂) (y₁ * y₂) = f.mk' x₁ y₁ * f.mk' x₂ y₂ :=
-f.to_localization_map.mk'_mul _ _ _ _
+  mk' S (x₁ * x₂) (y₁ * y₂) = mk' S x₁ y₁ * mk' S x₂ y₂ :=
+(to_localization_map M S).mk'_mul _ _ _ _
 
-lemma mk'_one (x) : f.mk' x (1 : M) = f.to_map x :=
-f.to_localization_map.mk'_one _
+lemma mk'_one (x) : mk' S x (1 : M) = algebra_map R S x :=
+(to_localization_map M S).mk'_one _
 
 @[simp]
 lemma mk'_spec (x) (y : M) :
-  f.mk' x y * f.to_map y = f.to_map x :=
-f.to_localization_map.mk'_spec _ _
+  mk' S x y * algebra_map R S y = algebra_map R S x :=
+(to_localization_map M S).mk'_spec _ _
 
 @[simp]
 lemma mk'_spec' (x) (y : M) :
-  f.to_map y * f.mk' x y = f.to_map x :=
-f.to_localization_map.mk'_spec' _ _
+  algebra_map R S y * mk' S x y = algebra_map R S x :=
+(to_localization_map M S).mk'_spec' _ _
+
+variables {S}
 
 theorem eq_mk'_iff_mul_eq {x} {y : M} {z} :
-  z = f.mk' x y ↔ z * f.to_map y = f.to_map x :=
-f.to_localization_map.eq_mk'_iff_mul_eq
+  z = mk' S x y ↔ z * algebra_map R S y = algebra_map R S x :=
+(to_localization_map M S).eq_mk'_iff_mul_eq
 
 theorem mk'_eq_iff_eq_mul {x} {y : M} {z} :
-  f.mk' x y = z ↔ f.to_map x = z * f.to_map y :=
-f.to_localization_map.mk'_eq_iff_eq_mul
+  mk' S x y = z ↔ algebra_map R S x = z * algebra_map R S y :=
+(to_localization_map M S).mk'_eq_iff_eq_mul
 
-lemma mk'_surjective (z : S) : ∃ x (y : M), f.mk' x y = z :=
-let ⟨r, hr⟩ := f.surj z in ⟨r.1, r.2, (f.eq_mk'_iff_mul_eq.2 hr).symm⟩
+variables (M)
+
+lemma mk'_surjective (z : S) : ∃ x (y : M), mk' S x y = z :=
+let ⟨r, hr⟩ := is_localization.surj _ z in ⟨r.1, r.2, (eq_mk'_iff_mul_eq.2 hr).symm⟩
+
+variables {M}
 
 lemma mk'_eq_iff_eq {x₁ x₂} {y₁ y₂ : M} :
-  f.mk' x₁ y₁ = f.mk' x₂ y₂ ↔ f.to_map (x₁ * y₂) = f.to_map (x₂ * y₁) :=
-f.to_localization_map.mk'_eq_iff_eq
+  mk' S x₁ y₁ = mk' S x₂ y₂ ↔ algebra_map R S (x₁ * y₂) = algebra_map R S (x₂ * y₁) :=
+(to_localization_map M S).mk'_eq_iff_eq
 
-lemma mk'_mem_iff {x} {y : M} {I : ideal S} : f.mk' x y ∈ I ↔ f.to_map x ∈ I :=
+lemma mk'_mem_iff {x} {y : M} {I : ideal S} : mk' S x y ∈ I ↔ algebra_map R S x ∈ I :=
 begin
   split;
   intro h,
-  { rw [← mk'_spec f x y, mul_comm],
-    exact I.mul_mem_left (f.to_map y) h },
-  { rw ← mk'_spec f x y at h,
-    obtain ⟨b, hb⟩ := is_unit_iff_exists_inv.1 (map_units f y),
+  { rw [← mk'_spec S x y, mul_comm],
+    exact I.mul_mem_left ((algebra_map R S) y) h },
+  { rw ← mk'_spec S x y at h,
+    obtain ⟨b, hb⟩ := is_unit_iff_exists_inv.1 (map_units S y),
     have := I.mul_mem_left b h,
     rwa [mul_comm, mul_assoc, hb, mul_one] at this }
 end
 
 protected lemma eq {a₁ b₁} {a₂ b₂ : M} :
-  f.mk' a₁ a₂ = f.mk' b₁ b₂ ↔ ∃ c : M, a₁ * b₂ * c = b₁ * a₂ * c :=
-f.to_localization_map.eq
+  mk' S a₁ a₂ = mk' S b₁ b₂ ↔ ∃ c : M, a₁ * b₂ * c = b₁ * a₂ * c :=
+(to_localization_map M S).eq
 
-lemma eq_iff_eq (g : localization_map M P) {x y} :
-  f.to_map x = f.to_map y ↔ g.to_map x = g.to_map y :=
-f.to_localization_map.eq_iff_eq g.to_localization_map
+section ext
 
-lemma mk'_eq_iff_mk'_eq (g : localization_map M P) {x₁ x₂}
-  {y₁ y₂ : M} : f.mk' x₁ y₁ = f.mk' x₂ y₂ ↔ g.mk' x₁ y₁ = g.mk' x₂ y₂ :=
-f.to_localization_map.mk'_eq_iff_mk'_eq g.to_localization_map
+variables [algebra R P] [is_localization M P]
+
+lemma eq_iff_eq {x y} :
+  algebra_map R S x = algebra_map R S y ↔ algebra_map R P x = algebra_map R P y :=
+(to_localization_map M S).eq_iff_eq (to_localization_map M P)
+
+lemma mk'_eq_iff_mk'_eq {x₁ x₂}
+  {y₁ y₂ : M} : mk' S x₁ y₁ = mk' S x₂ y₂ ↔ mk' P x₁ y₁ = mk' P x₂ y₂ :=
+(to_localization_map M S).mk'_eq_iff_mk'_eq (to_localization_map M P)
 
 lemma mk'_eq_of_eq {a₁ b₁ : R} {a₂ b₂ : M} (H : b₁ * a₂ = a₁ * b₂) :
-  f.mk' a₁ a₂ = f.mk' b₁ b₂ :=
-f.to_localization_map.mk'_eq_of_eq H
+  mk' S a₁ a₂ = mk' S b₁ b₂ :=
+(to_localization_map M S).mk'_eq_of_eq H
 
-@[simp] lemma mk'_self {x : R} (hx : x ∈ M) : f.mk' x ⟨x, hx⟩ = 1 :=
-f.to_localization_map.mk'_self _ hx
+variables (S)
 
-@[simp] lemma mk'_self' {x : M} : f.mk' x x = 1 :=
-f.to_localization_map.mk'_self' _
+@[simp] lemma mk'_self {x : R} (hx : x ∈ M) : mk' S x ⟨x, hx⟩ = 1 :=
+(to_localization_map M S).mk'_self _ hx
 
-lemma mk'_self'' {x : M} : f.mk' x.1 x = 1 :=
-f.mk'_self'
+@[simp] lemma mk'_self' {x : M} : mk' S (x : R) x = 1 :=
+(to_localization_map M S).mk'_self' _
+
+lemma mk'_self'' {x : M} : mk' S x.1 x = 1 :=
+mk'_self' _
+
+end ext
 
 lemma mul_mk'_eq_mk'_of_mul (x y : R) (z : M) :
-  f.to_map x * f.mk' y z = f.mk' (x * y) z :=
-f.to_localization_map.mul_mk'_eq_mk'_of_mul _ _ _
+  (algebra_map R S) x * mk' S y z = mk' S (x * y) z :=
+(to_localization_map M S).mul_mk'_eq_mk'_of_mul _ _ _
 
 lemma mk'_eq_mul_mk'_one (x : R) (y : M) :
-  f.mk' x y = f.to_map x * f.mk' 1 y :=
-(f.to_localization_map.mul_mk'_one_eq_mk' _ _).symm
+  mk' S x y = (algebra_map R S) x * mk' S 1 y :=
+((to_localization_map M S).mul_mk'_one_eq_mk' _ _).symm
 
 @[simp] lemma mk'_mul_cancel_left (x : R) (y : M) :
-  f.mk' (y * x) y = f.to_map x :=
-f.to_localization_map.mk'_mul_cancel_left _ _
+  mk' S (y * x : R) y = (algebra_map R S) x :=
+(to_localization_map M S).mk'_mul_cancel_left _ _
 
 lemma mk'_mul_cancel_right (x : R) (y : M) :
-  f.mk' (x * y) y = f.to_map x :=
-f.to_localization_map.mk'_mul_cancel_right _ _
+  mk' S (x * y) y = (algebra_map R S) x :=
+(to_localization_map M S).mk'_mul_cancel_right _ _
 
 @[simp] lemma mk'_mul_mk'_eq_one (x y : M) :
-  f.mk' x y * f.mk' y x = 1 :=
-by rw [←f.mk'_mul, mul_comm]; exact f.mk'_self _
+  mk' S (x : R) y * mk' S (y : R) x = 1 :=
+by rw [←mk'_mul, mul_comm]; exact mk'_self _ _
 
 lemma mk'_mul_mk'_eq_one' (x : R) (y : M) (h : x ∈ M) :
-  f.mk' x y * f.mk' y ⟨x, h⟩ = 1 :=
-f.mk'_mul_mk'_eq_one ⟨x, h⟩ _
+  mk' S x y * mk' S (y : R) ⟨x, h⟩ = 1 :=
+mk'_mul_mk'_eq_one ⟨x, h⟩ _
+
+section
+
+variables (M)
 
 lemma is_unit_comp (j : S →+* P) (y : M) :
-  is_unit (j.comp f.to_map y) :=
-f.to_localization_map.is_unit_comp j.to_monoid_hom _
+  is_unit (j.comp (algebra_map R S) y) :=
+(to_localization_map M S).is_unit_comp j.to_monoid_hom _
+
+end
 
 /-- Given a localization map `f : R →+* S` for a submonoid `M ⊆ R` and a map of `comm_ring`s
 `g : R →+* P` such that `g(M) ⊆ units P`, `f x = f y → g x = g y` for all `x y : R`. -/
-lemma eq_of_eq {g : R →+* P} (hg : ∀ y : M, is_unit (g y)) {x y} (h : f.to_map x = f.to_map y) :
+lemma eq_of_eq {g : R →+* P} (hg : ∀ y : M, is_unit (g y)) {x y}
+  (h : (algebra_map R S) x = (algebra_map R S) y) :
   g x = g y :=
 @submonoid.localization_map.eq_of_eq _ _ _ _ _ _ _
-  f.to_localization_map g.to_monoid_hom hg _ _ h
+  (to_localization_map M S) g.to_monoid_hom hg _ _ h
 
 lemma mk'_add (x₁ x₂ : R) (y₁ y₂ : M) :
-  f.mk' (x₁ * y₂ + x₂ * y₁) (y₁ * y₂) = f.mk' x₁ y₁ + f.mk' x₂ y₂ :=
-f.mk'_eq_iff_eq_mul.2 $ eq.symm
+  mk' S (x₁ * y₂ + x₂ * y₁) (y₁ * y₂) = mk' S x₁ y₁ + mk' S x₂ y₂ :=
+mk'_eq_iff_eq_mul.2 $ eq.symm
 begin
   rw [mul_comm (_ + _), mul_add, mul_mk'_eq_mk'_of_mul, ←eq_sub_iff_add_eq, mk'_eq_iff_eq_mul,
-      mul_comm _ (f.to_map _), mul_sub, eq_sub_iff_add_eq, ←eq_sub_iff_add_eq', ←mul_assoc,
-      ←f.to_map.map_mul, mul_mk'_eq_mk'_of_mul, mk'_eq_iff_eq_mul],
-  simp only [f.to_map.map_add, submonoid.coe_mul, f.to_map.map_mul],
+      mul_comm _ ((algebra_map R S) _), mul_sub, eq_sub_iff_add_eq, ←eq_sub_iff_add_eq', ←mul_assoc,
+      ←(algebra_map R S).map_mul, mul_mk'_eq_mk'_of_mul, mk'_eq_iff_eq_mul],
+  simp only [(algebra_map R S).map_add, submonoid.coe_mul, (algebra_map R S).map_mul],
   ring_exp,
 end
 
@@ -384,19 +377,20 @@ end
 `z = f x * (f y)⁻¹`. -/
 noncomputable def lift {g : R →+* P} (hg : ∀ y : M, is_unit (g y)) : S →+* P :=
 ring_hom.mk' (@submonoid.localization_map.lift _ _ _ _ _ _ _
-  f.to_localization_map g.to_monoid_hom hg) $
+  (to_localization_map M S) g.to_monoid_hom hg) $
 begin
   intros x y,
-  rw [f.to_localization_map.lift_spec, mul_comm, add_mul, ←sub_eq_iff_eq_add, eq_comm,
-      f.to_localization_map.lift_spec_mul, mul_comm _ (_ - _), sub_mul, eq_sub_iff_add_eq',
-      ←eq_sub_iff_add_eq, mul_assoc, f.to_localization_map.lift_spec_mul],
+  rw [(to_localization_map M S).lift_spec, mul_comm, add_mul, ←sub_eq_iff_eq_add, eq_comm,
+      (to_localization_map M S).lift_spec_mul, mul_comm _ (_ - _), sub_mul, eq_sub_iff_add_eq',
+      ←eq_sub_iff_add_eq, mul_assoc, (to_localization_map M S).lift_spec_mul],
   show g _ * (g _ * g _) = g _ * (g _ * g _ - g _ * g _),
   repeat {rw ←g.map_mul},
   rw [←g.map_sub, ←g.map_mul],
-  apply f.eq_of_eq hg,
-  erw [f.to_map.map_mul, sec_spec', mul_sub, f.to_map.map_sub],
-  simp only [f.to_map.map_mul, sec_spec'],
+  apply eq_of_eq hg,
+  erw [(algebra_map R S).map_mul, sec_spec', mul_sub, (algebra_map R S).map_sub],
+  simp only [(algebra_map R S).map_mul, sec_spec'],
   ring_exp,
+  assumption
 end
 
 variables {g : R →+* P} (hg : ∀ y : M, is_unit (g y))
@@ -405,154 +399,195 @@ variables {g : R →+* P} (hg : ∀ y : M, is_unit (g y))
 `g : R →* P` such that `g y` is invertible for all `y : M`, the homomorphism induced from
 `S` to `P` maps `f x * (f y)⁻¹` to `g x * (g y)⁻¹` for all `x : R, y ∈ M`. -/
 lemma lift_mk' (x y) :
-  f.lift hg (f.mk' x y) = g x * ↑(is_unit.lift_right (g.to_monoid_hom.mrestrict M) hg y)⁻¹ :=
-f.to_localization_map.lift_mk' _ _ _
+  lift hg (mk' S x y) = g x * ↑(is_unit.lift_right (g.to_monoid_hom.mrestrict M) hg y)⁻¹ :=
+(to_localization_map M S).lift_mk' _ _ _
 
 lemma lift_mk'_spec (x v) (y : M) :
-  f.lift hg (f.mk' x y) = v ↔ g x = g y * v :=
-f.to_localization_map.lift_mk'_spec _ _ _ _
+  lift hg (mk' S x y) = v ↔ g x = g y * v :=
+(to_localization_map M S).lift_mk'_spec _ _ _ _
 
 @[simp] lemma lift_eq (x : R) :
-  f.lift hg (f.to_map x) = g x :=
-f.to_localization_map.lift_eq _ _
+  lift hg ((algebra_map R S) x) = g x :=
+(to_localization_map M S).lift_eq _ _
 
 lemma lift_eq_iff {x y : R × M} :
-  f.lift hg (f.mk' x.1 x.2) = f.lift hg (f.mk' y.1 y.2) ↔ g (x.1 * y.2) = g (y.1 * x.2) :=
-f.to_localization_map.lift_eq_iff _
+  lift hg (mk' S x.1 x.2) = lift hg (mk' S y.1 y.2) ↔ g (x.1 * y.2) = g (y.1 * x.2) :=
+(to_localization_map M S).lift_eq_iff _
 
-@[simp] lemma lift_comp : (f.lift hg).comp f.to_map = g :=
-ring_hom.ext $ monoid_hom.ext_iff.1 $ f.to_localization_map.lift_comp _
+@[simp] lemma lift_comp : (lift hg).comp (algebra_map R S) = g :=
+ring_hom.ext $ monoid_hom.ext_iff.1 $ (to_localization_map M S).lift_comp _
 
 @[simp] lemma lift_of_comp (j : S →+* P) :
-  f.lift (f.is_unit_comp j) = j :=
-ring_hom.ext $ monoid_hom.ext_iff.1 $ f.to_localization_map.lift_of_comp j.to_monoid_hom
+  lift (is_unit_comp M j) = j :=
+ring_hom.ext $ monoid_hom.ext_iff.1 $ (to_localization_map M S).lift_of_comp j.to_monoid_hom
 
 lemma epic_of_localization_map {j k : S →+* P}
-  (h : ∀ a, j.comp f.to_map a = k.comp f.to_map a) : j = k :=
+  (h : ∀ a, j.comp (algebra_map R S) a = k.comp (algebra_map R S) a) : j = k :=
 ring_hom.ext $ monoid_hom.ext_iff.1 $ @submonoid.localization_map.epic_of_localization_map
-  _ _ _ _ _ _ _ f.to_localization_map j.to_monoid_hom k.to_monoid_hom h
+  _ _ _ _ _ _ _ (to_localization_map M S) j.to_monoid_hom k.to_monoid_hom h
 
 lemma lift_unique {j : S →+* P}
-  (hj : ∀ x, j (f.to_map x) = g x) : f.lift hg = j :=
+  (hj : ∀ x, j ((algebra_map R S) x) = g x) : lift hg = j :=
 ring_hom.ext $ monoid_hom.ext_iff.1 $ @submonoid.localization_map.lift_unique
-  _ _ _ _ _ _ _ f.to_localization_map g.to_monoid_hom hg j.to_monoid_hom hj
+  _ _ _ _ _ _ _ (to_localization_map M S) g.to_monoid_hom hg j.to_monoid_hom hj
 
-@[simp] lemma lift_id (x) : f.lift f.map_units x = x :=
-f.to_localization_map.lift_id _
-
-/-- Given two localization maps `f : R →+* S, k : R →+* P` for a submonoid `M ⊆ R`,
-the hom from `P` to `S` induced by `f` is left inverse to the hom from `S` to `P`
-induced by `k`. -/
-@[simp] lemma lift_left_inverse {k : localization_map M S} (z : S) :
-  k.lift f.map_units (f.lift k.map_units z) = z :=
-f.to_localization_map.lift_left_inverse _
+@[simp] lemma lift_id (x) : lift (map_units S : ∀ y : M, is_unit _) x = x :=
+(to_localization_map M S).lift_id _
 
 lemma lift_surjective_iff :
-  surjective (f.lift hg) ↔ ∀ v : P, ∃ x : R × M, v * g x.2 = g x.1 :=
-f.to_localization_map.lift_surjective_iff hg
+  surjective (lift hg : S → P) ↔ ∀ v : P, ∃ x : R × M, v * g x.2 = g x.1 :=
+(to_localization_map M S).lift_surjective_iff hg
 
 lemma lift_injective_iff :
-  injective (f.lift hg) ↔ ∀ x y, f.to_map x = f.to_map y ↔ g x = g y :=
-f.to_localization_map.lift_injective_iff hg
+  injective (lift hg : S → P) ↔ ∀ x y, algebra_map R S x = algebra_map R S y ↔ g x = g y :=
+(to_localization_map M S).lift_injective_iff hg
 
-variables {T : submonoid P} (hy : ∀ y : M, g y ∈ T) {Q : Type*} [comm_ring Q]
-          (k : localization_map T Q)
+section map
 
-/-- Given a `comm_ring` homomorphism `g : R →+* P` where for submonoids `M ⊆ R, T ⊆ P` we have
-`g(M) ⊆ T`, the induced ring homomorphism from the localization of `R` at `M` to the
-localization of `P` at `T`: if `f : R →+* S` and `k : P →+* Q` are localization maps for `M`
-and `T` respectively, we send `z : S` to `k (g x) * (k (g y))⁻¹`, where `(x, y) : R × M` are
-such that `z = f x * (f y)⁻¹`. -/
+variables {T : submonoid P} {Q : Type*} [comm_ring Q] (hy : ∀ y : M, g y ∈ T)
+variables [algebra P Q] [is_localization T Q]
+
+section
+
+variables (S Q)
+
+/-- Map a homomorphism `g : R →+* P` to `S →+* Q`, where `S` and `Q` are
+localizations of `R` and `P` at `M` and `T` respectively,
+such that `g(M) ⊆ T`.
+
+We send `z : S` to `algebra_map P Q (g x) * (algebra_map P Q (g y))⁻¹`, where
+`(x, y) : R × M` are such that `z = f x * (f y)⁻¹`. -/
 noncomputable def map : S →+* Q :=
-@lift _ _ _ _ _ _ _ f (k.to_map.comp g) $ λ y, k.map_units ⟨g y, hy y⟩
+@lift R _ M _ _ _ _ _ _ ((algebra_map P Q).comp g) (λ y, map_units _ ⟨g y, hy y⟩)
 
-variables {k}
+end
 
 lemma map_eq (x) :
-  f.map hy k (f.to_map x) = k.to_map (g x) :=
-f.lift_eq (λ y, k.map_units ⟨g y, hy y⟩) x
+  map S Q hy ((algebra_map R S) x) = algebra_map P Q (g x) :=
+lift_eq (λ y, map_units _ ⟨g y, hy y⟩) x
 
 @[simp] lemma map_comp :
-  (f.map hy k).comp f.to_map = k.to_map.comp g :=
-f.lift_comp $ λ y, k.map_units ⟨g y, hy y⟩
+  (map S Q hy).comp (algebra_map R S) = (algebra_map P Q).comp g :=
+lift_comp $ λ y, map_units _ ⟨g y, hy y⟩
 
 lemma map_mk' (x) (y : M) :
-  f.map hy k (f.mk' x y) = k.mk' (g x) ⟨g y, hy y⟩ :=
-@submonoid.localization_map.map_mk' _ _ _ _ _ _ _ f.to_localization_map
-g.to_monoid_hom _ hy _ _ k.to_localization_map _ _
+  map S Q hy (mk' S x y) = mk' Q (g x) ⟨g y, hy y⟩ :=
+@submonoid.localization_map.map_mk' _ _ _ _ _ _ _ (to_localization_map M S)
+g.to_monoid_hom _ hy _ _ (to_localization_map T Q) _ _
 
-@[simp] lemma map_id (z : S) :
-  f.map (λ y, show ring_hom.id R y ∈ M, from y.2) f z = z :=
-f.lift_id _
+@[simp] lemma map_id (z : S) (h : ∀ y : M, ring_hom.id R ↑y ∈ M := λ y, y.2) :
+  map S S h z = z :=
+lift_id _
 
-lemma map_unique {j : S →+* Q}
-  (hj : ∀ x : R, j (f.to_map x) = k.to_map (g x)) : f.map hy k = j :=
-f.lift_unique (λ y, k.map_units ⟨g y, hy y⟩) hj
+lemma map_unique (j : S →+* Q)
+  (hj : ∀ x : R, j (algebra_map R S x) = algebra_map P Q (g x)) : map S Q hy = j :=
+lift_unique (λ y, map_units _ ⟨g y, hy y⟩) hj
 
 /-- If `comm_ring` homs `g : R →+* P, l : P →+* A` induce maps of localizations, the composition
 of the induced maps equals the map of localizations induced by `l ∘ g`. -/
 lemma map_comp_map {A : Type*} [comm_ring A] {U : submonoid A} {W} [comm_ring W]
-  (j : localization_map U W) {l : P →+* A} (hl : ∀ w : T, l w ∈ U) :
-  (k.map hl j).comp (f.map hy k) = f.map (λ x, show l.comp g x ∈ U, from hl ⟨g x, hy x⟩) j :=
-ring_hom.ext $ monoid_hom.ext_iff.1 $ @submonoid.localization_map.map_comp_map _ _ _ _ _ _ _
-  f.to_localization_map g.to_monoid_hom _ hy _ _ k.to_localization_map
-    _ _ _ _ _ j.to_localization_map l.to_monoid_hom hl
+  [algebra A W] [is_localization U W] {l : P →+* A} (hl : ∀ w : T, l w ∈ U) :
+  (map Q W hl).comp (map S Q hy) = map S W (λ x, show l.comp g ↑x ∈ U, from hl ⟨g ↑x, hy x⟩) :=
+ring_hom.ext $ λ x, @submonoid.localization_map.map_map _ _ _ _ _ P _ (to_localization_map M S) g _
+hy _ _ _ _ _ _ _ _ (to_localization_map U W) l hl x
 
 /-- If `comm_ring` homs `g : R →+* P, l : P →+* A` induce maps of localizations, the composition
 of the induced maps equals the map of localizations induced by `l ∘ g`. -/
 lemma map_map {A : Type*} [comm_ring A] {U : submonoid A} {W} [comm_ring W]
-  (j : localization_map U W) {l : P →+* A} (hl : ∀ w : T, l w ∈ U) (x) :
-  k.map hl j (f.map hy k x) = f.map (λ x, show l.comp g x ∈ U, from hl ⟨g x, hy x⟩) j x :=
-by rw ←f.map_comp_map hy j hl; refl
+  [algebra A W] [is_localization U W] {l : P →+* A} (hl : ∀ w : T, l w ∈ U) (x) :
+  map Q W hl (map S Q hy x) = map S W (λ x, show l.comp g ↑x ∈ U, from hl ⟨g ↑x, hy x⟩) x :=
+by rw ←map_comp_map hy hl; refl
 
-/-- Given localization maps `f : R →+* S, k : P →+* Q` for submonoids `M, T` respectively, an
+section
+
+variables (S Q)
+
+/-- If `S`, `Q` are localizations of `R` and `P` at submonoids `M, T` respectively, an
 isomorphism `j : R ≃+* P` such that `j(M) = T` induces an isomorphism of localizations
 `S ≃+* Q`. -/
-noncomputable def ring_equiv_of_ring_equiv (k : localization_map T Q) (h : R ≃+* P)
-  (H : M.map h.to_monoid_hom = T) :
+@[simps]
+noncomputable def ring_equiv_of_ring_equiv (h : R ≃+* P) (H : M.map h.to_monoid_hom = T) :
   S ≃+* Q :=
-(f.to_localization_map.mul_equiv_of_mul_equiv k.to_localization_map H).to_ring_equiv $
-(@lift _ _ _ _ _ _ _ f (k.to_map.comp h.to_ring_hom)
-  (λ y, k.map_units ⟨(h y), H ▸ set.mem_image_of_mem h y.2⟩)).map_add
+have H' : T.map h.symm.to_monoid_hom = M,
+by { rw [← M.map_id, ← H, submonoid.map_map], congr, ext, apply h.symm_apply_apply },
+{ to_fun := map S Q (λ y : M, show (h : R →+* P) y ∈ T, from H ▸ ⟨y, y.2, rfl⟩),
+  inv_fun := map Q S (λ y : T, show (h.symm : P →+* R) y ∈ M, from H' ▸ ⟨y, y.2, rfl⟩),
+  left_inv := λ x, by { rw [map_map, map_unique _ (ring_hom.id _), ring_hom.id_apply],
+                        intro x, convert congr_arg (algebra_map R S) (h.symm_apply_apply x).symm },
+  right_inv := λ x, by { rw [map_map, map_unique _ (ring_hom.id _), ring_hom.id_apply],
+                         intro x, convert congr_arg (algebra_map P Q) (h.apply_symm_apply x).symm },
+  .. map S Q _ }
 
-@[simp] lemma ring_equiv_of_ring_equiv_eq_map_apply {j : R ≃+* P}
-  (H : M.map j.to_monoid_hom = T) (x) :
-  f.ring_equiv_of_ring_equiv k j H x =
-    f.map (λ y : M, show j.to_monoid_hom y ∈ T, from H ▸ set.mem_image_of_mem j y.2) k x := rfl
+end
 
 lemma ring_equiv_of_ring_equiv_eq_map {j : R ≃+* P} (H : M.map j.to_monoid_hom = T) :
-  (f.ring_equiv_of_ring_equiv k j H).to_monoid_hom =
-    f.map (λ y : M, show j.to_monoid_hom y ∈ T, from H ▸ set.mem_image_of_mem j y.2) k := rfl
+  (ring_equiv_of_ring_equiv S Q j H).to_monoid_hom =
+    map S Q (λ y : M, show j.to_monoid_hom y ∈ T, from H ▸ set.mem_image_of_mem j y.2) := rfl
 
 @[simp] lemma ring_equiv_of_ring_equiv_eq {j : R ≃+* P} (H : M.map j.to_monoid_hom = T) (x) :
-  f.ring_equiv_of_ring_equiv k j H (f.to_map x) = k.to_map (j x) :=
-f.to_localization_map.mul_equiv_of_mul_equiv_eq H _
+  ring_equiv_of_ring_equiv S Q j H ((algebra_map R S) x) = algebra_map P Q (j x) :=
+map_eq _ _
 
-lemma ring_equiv_of_ring_equiv_mk' {j : R ≃+* P} (H : M.map j.to_monoid_hom = T) (x y) :
-  f.ring_equiv_of_ring_equiv k j H (f.mk' x y) =
-    k.mk' (j x) ⟨j y, H ▸ set.mem_image_of_mem j y.2⟩ :=
-f.to_localization_map.mul_equiv_of_mul_equiv_mk' H _ _
+lemma ring_equiv_of_ring_equiv_mk' {j : R ≃+* P} (H : M.map j.to_monoid_hom = T) (x : R) (y : M) :
+  ring_equiv_of_ring_equiv S Q j H (mk' S x y) =
+    mk' Q (j x) ⟨j y, show j y ∈ T, from H ▸ set.mem_image_of_mem j y.2⟩ :=
+map_mk' _ _ _
 
-section away_map
+end map
+
+section alg_equiv
+
+variables {Q : Type*} [comm_ring Q] [algebra R Q] [is_localization M Q]
+
+section
+
+variables (M S Q)
+
+/-- If `S`, `Q` are localizations of `R` at the submonoid `M` respectively,
+there is an isomorphism of localizations `S ≃ₐ[R] Q`. -/
+@[simps]
+noncomputable def alg_equiv : S ≃ₐ[R] Q :=
+{ commutes' := ring_equiv_of_ring_equiv_eq _,
+  .. ring_equiv_of_ring_equiv S Q (ring_equiv.refl R) M.map_id }
+
+end
+
+@[simp]
+lemma alg_equiv_mk' (x : R) (y : M) : alg_equiv M S Q (mk' S x y) = mk' Q x y:=
+map_mk' _ _ _
+
+@[simp]
+lemma alg_equiv_symm_mk' (x : R) (y : M) : (alg_equiv M S Q).symm (mk' Q x y) = mk' S x y:=
+map_mk' _ _ _
+
+end alg_equiv
+
+end is_localization
+
+section away
 
 variables (x : R)
-/-- Given `x : R`, the type of homomorphisms `f : R →* S` such that `S`
-is isomorphic to the localization of `R` at the submonoid generated by `x`. -/
-@[reducible]
-def away_map (S' : Type*) [comm_ring S'] :=
-localization_map (submonoid.powers x) S'
 
-variables (F : away_map x S)
+/-- Given `x : R`, the typeclass `is_localization.away x S` states that `S` is
+isomorphic to the localization of `R` at the submonoid generated by `x`. -/
+abbreviation away (S : Type*) [comm_ring S] [algebra R S] :=
+is_localization (submonoid.powers x) S
+
+namespace away
+
+variables [is_localization.away x S]
 
 /-- Given `x : R` and a localization map `F : R →+* S` away from `x`, `inv_self` is `(F x)⁻¹`. -/
-noncomputable def away_map.inv_self : S :=
-F.mk' 1 ⟨x, submonoid.mem_powers _⟩
+noncomputable def inv_self : S :=
+mk' S 1 ⟨x, submonoid.mem_powers _⟩
+
+variables {g : R →+* P}
 
 /-- Given `x : R`, a localization map `F : R →+* S` away from `x`, and a map of `comm_ring`s
 `g : R →+* P` such that `g x` is invertible, the homomorphism induced from `S` to `P` sending
 `z : S` to `g y * (g x)⁻ⁿ`, where `y : R, n : ℕ` are such that `z = F y * (F x)⁻ⁿ`. -/
-noncomputable def away_map.lift (hg : is_unit (g x)) : S →+* P :=
-localization_map.lift F $ λ y, show is_unit (g y.1),
+noncomputable def lift (hg : is_unit (g x)) : S →+* P :=
+is_localization.lift $ λ (y : submonoid.powers x), show is_unit (g y.1),
 begin
   obtain ⟨n, hn⟩ := y.2,
   rw [←hn, g.map_pow],
@@ -560,22 +595,30 @@ begin
 end
 
 @[simp] lemma away_map.lift_eq (hg : is_unit (g x)) (a : R) :
-  F.lift x hg (F.to_map a) = g a := lift_eq _ _ _
+  lift x hg ((algebra_map R S) a) = g a := lift_eq _ _
 
 @[simp] lemma away_map.lift_comp (hg : is_unit (g x)) :
-  (F.lift x hg).comp F.to_map = g := lift_comp _ _
+  (lift x hg).comp (algebra_map R S) = g := lift_comp _
 
-/-- Given `x y : R` and localization maps `F : R →+* S, G : R →+* P` away from `x` and `x * y`
+/-- Given `x y : R` and localizations `S`, `P` away from `x` and `x * y`
 respectively, the homomorphism induced from `S` to `P`. -/
-noncomputable def away_to_away_right (y : R) (G : away_map (x * y) P) : S →* P :=
-F.lift x $ show is_unit (G.to_map x), from
-is_unit_of_mul_eq_one (G.to_map x) (G.mk' y ⟨x * y, submonoid.mem_powers _⟩) $
+noncomputable def away_to_away_right (y : R) [algebra R P] [is_localization.away (x * y) P] :
+  S →+* P :=
+lift x $ show is_unit ((algebra_map R P) x), from
+is_unit_of_mul_eq_one ((algebra_map R P) x) (mk' P y ⟨x * y, submonoid.mem_powers _⟩) $
 by rw [mul_mk'_eq_mk'_of_mul, mk'_self]
 
-end away_map
-end localization_map
+end away
+
+end away
+
+end is_localization
 
 namespace localization
+
+open is_localization
+
+/-! ### Constructing a localization at a given submonoid -/
 
 variables {M}
 
@@ -630,81 +673,60 @@ instance : comm_ring (localization M) :=
   right_distrib  := λ m n k, quotient.induction_on₃' m n k (by tac),
    ..localization.comm_monoid M }
 
-variables (M)
-/-- Natural hom sending `x : R`, `R` a `comm_ring`, to the equivalence class of
-`(x, 1)` in the localization of `R` at a submonoid. -/
-def of : localization_map M (localization M) :=
-(localization.monoid_of M).to_ring_localization $
-  λ x y, (con.eq _).2 $ r_of_eq $ by simp [add_comm]
+instance : algebra R (localization M) :=
+ring_hom.to_algebra $
+{ map_zero' := rfl,
+  map_add' := λ x y, (con.eq _).2 $ r_of_eq $ by simp [add_comm],
+  .. localization.monoid_of M }
 
-variables {M}
+instance : is_localization M (localization M) :=
+{ map_units := (localization.monoid_of M).map_units,
+  surj := (localization.monoid_of M).surj,
+  eq_iff_exists := λ _ _, (localization.monoid_of M).eq_iff_exists }
 
-lemma monoid_of_eq_of (x) : (monoid_of M).to_map x = (of M).to_map x := rfl
+lemma monoid_of_eq_algebra_map (x) :
+  (monoid_of M).to_map x = algebra_map R (localization M) x :=
+rfl
 
-lemma mk_one_eq_of (x) : mk x 1 = (of M).to_map x := rfl
+lemma mk_one_eq_algebra_map (x) : mk x 1 = algebra_map R (localization M) x := rfl
 
-lemma mk_eq_mk'_apply (x y) : mk x y = (of M).mk' x y :=
+lemma mk_eq_mk'_apply (x y) : mk x y = is_localization.mk' (localization M) x y :=
 mk_eq_monoid_of_mk'_apply _ _
 
-@[simp] lemma mk_eq_mk' : mk = (of M).mk' :=
+@[simp] lemma mk_eq_mk' : (mk : R → M → (localization M)) = is_localization.mk' (localization M) :=
 mk_eq_monoid_of_mk'
 
-variables (f : localization_map M S)
-/-- Given a localization map `f : R →+* S` for a submonoid `M`, we get an isomorphism
-between the localization of `R` at `M` as a quotient type and `S`. -/
-noncomputable def ring_equiv_of_quotient :
-  localization M ≃+* S :=
-(mul_equiv_of_quotient f.to_localization_map).to_ring_equiv $
-((of M).lift f.map_units).map_add
+variables [is_localization M S]
 
-variables {f}
+section
 
-@[simp] lemma ring_equiv_of_quotient_apply (x) :
-  ring_equiv_of_quotient f x = (of M).lift f.map_units x := rfl
+variables (M S)
 
-@[simp] lemma ring_equiv_of_quotient_mk' (x y) :
-  ring_equiv_of_quotient f ((of M).mk' x y) = f.mk' x y :=
-mul_equiv_of_quotient_mk' _ _
+/-- The localization of `R` at `M` as a quotient type is isomorphic to any other localization. -/
+@[simps]
+noncomputable def alg_equiv : localization M ≃ₐ[R] S :=
+is_localization.alg_equiv M _ _
 
-lemma ring_equiv_of_quotient_mk (x y) :
-  ring_equiv_of_quotient f (mk x y) = f.mk' x y :=
-mul_equiv_of_quotient_mk _ _
+end
 
-@[simp] lemma ring_equiv_of_quotient_of (x) :
-  ring_equiv_of_quotient f ((of M).to_map x) = f.to_map x :=
-mul_equiv_of_quotient_monoid_of _
+@[simp] lemma alg_equiv_mk' (x : R) (y : M) :
+  alg_equiv M S (mk' (localization M) x y) = mk' S x y :=
+alg_equiv_mk' _ _
 
-@[simp] lemma ring_equiv_of_quotient_symm_mk' (x y) :
-  (ring_equiv_of_quotient f).symm (f.mk' x y) = (of M).mk' x y :=
-mul_equiv_of_quotient_symm_mk' _ _
+@[simp] lemma alg_equiv_symm_mk' (x : R) (y : M) :
+  (alg_equiv M S).symm (mk' S x y) = mk' (localization M) x y :=
+alg_equiv_symm_mk' _ _
 
-lemma ring_equiv_of_quotient_symm_mk (x y) :
-  (ring_equiv_of_quotient f).symm (f.mk' x y) = mk x y :=
-mul_equiv_of_quotient_symm_mk _ _
+lemma alg_equiv_mk (x y) :
+  alg_equiv M S (mk x y) = mk' S x y :=
+by rw [mk_eq_mk', alg_equiv_mk']
 
-@[simp] lemma ring_equiv_of_quotient_symm_of (x) :
-  (ring_equiv_of_quotient f).symm (f.to_map x) = (of M).to_map x :=
-mul_equiv_of_quotient_symm_monoid_of _
+lemma alg_equiv_symm_mk (x : R) (y : M) :
+  (alg_equiv M S).symm (mk' S x y) = mk x y :=
+by rw [mk_eq_mk', alg_equiv_symm_mk']
 
-section away
-
-variables (x : R)
-
-/-- Given `x : R`, the natural hom sending `y : R`, `R` a `comm_ring`, to the equivalence class
-of `(y, 1)` in the localization of `R` at the submonoid generated by `x`. -/
-@[reducible] def away.of : localization_map.away_map x (away x) := of (submonoid.powers x)
-
-@[simp] lemma away.mk_eq_mk' : mk = (away.of x).mk' :=
-mk_eq_mk'
-
-/-- Given `x : R` and a localization map `f : R →+* S` away from `x`, we get an isomorphism between
-the localization of `R` at the submonoid generated by `x` as a quotient type and `S`. -/
-noncomputable def away.ring_equiv_of_quotient (f : localization_map.away_map x S) :
-  away x ≃+* S :=
-ring_equiv_of_quotient f
-
-end away
 end localization
+
 variables {M}
 
 section at_prime
@@ -722,50 +744,40 @@ def prime_compl :
 
 end ideal
 
-namespace localization_map
 variables (S)
 
-/-- A localization map from `R` to `S` where the submonoid is the complement of a prime
-ideal of `R`. -/
-@[reducible] def at_prime :=
-localization_map I.prime_compl S
+/-- Given a prime ideal `P`, the typeclass `is_localization.at_prime S P` states that `S` is
+isomorphic to the localization of `R` at the complement of `P`. -/
+protected abbreviation is_localization.at_prime := is_localization I.prime_compl S
 
-end localization_map
-namespace localization
+/-- Given a prime ideal `P`, `localization.at_prime S P` is a localization of
+`R` at the complement of `P`, as a quotient type. -/
+protected abbreviation localization.at_prime := localization I.prime_compl
 
-/-- The localization of `R` at the complement of a prime ideal, as a quotient type. -/
-@[reducible] def at_prime :=
-localization I.prime_compl
+namespace is_localization
 
-end localization
-namespace localization_map
-
-variables {I}
-
-/-- When `f` is a localization map from `R` at the complement of a prime ideal `I`, we use a
-copy of the localization map `f`'s codomain `S` carrying the data of `f` so that the `local_ring`
-instance on `S` can 'know' the map needed to induce the instance. -/
-instance at_prime.local_ring (f : at_prime S I) : local_ring f.codomain :=
+theorem at_prime.local_ring [is_localization.at_prime S I] : local_ring S :=
 local_of_nonunits_ideal
   (λ hze, begin
-    rw [←f.to_map.map_one, ←f.to_map.map_zero] at hze,
-    obtain ⟨t, ht⟩ := f.eq_iff_exists.1 hze,
-    exact ((show (t : R) ∉ I, from t.2) (have htz : (t : R) = 0, by simpa using ht.symm,
-      htz.symm ▸ I.zero_mem))
+      rw [←(algebra_map R S).map_one, ←(algebra_map R S).map_zero] at hze,
+      obtain ⟨t, ht⟩ := (eq_iff_exists I.prime_compl S).1 hze,
+      exact ((show (t : R) ∉ I, from t.2) (have htz : (t : R) = 0, by simpa using ht.symm,
+        htz.symm ▸ I.zero_mem))
     end)
   (begin
     intros x y hx hy hu,
     cases is_unit_iff_exists_inv.1 hu with z hxyz,
-    have : ∀ {r s}, f.mk' r s ∈ nonunits S → r ∈ I, from
-      λ r s, not_imp_comm.1
-        (λ nr, is_unit_iff_exists_inv.2 ⟨f.mk' s ⟨r, nr⟩, f.mk'_mul_mk'_eq_one' _ _ nr⟩),
-    rcases f.mk'_surjective x with ⟨rx, sx, hrx⟩,
-    rcases f.mk'_surjective y with ⟨ry, sy, hry⟩,
-    rcases f.mk'_surjective z with ⟨rz, sz, hrz⟩,
-    rw [←hrx, ←hry, ←hrz, ←f.mk'_add, ←f.mk'_mul,
-        ←f.mk'_self I.prime_compl.one_mem] at hxyz,
+    have : ∀ {r : R} {s : I.prime_compl}, mk' S r s ∈ nonunits S → r ∈ I, from
+      λ (r : R) (s : I.prime_compl), not_imp_comm.1
+        (λ nr, is_unit_iff_exists_inv.2 ⟨mk' S ↑s (⟨r, nr⟩ : I.prime_compl),
+          mk'_mul_mk'_eq_one' _ _ nr⟩),
+    rcases mk'_surjective I.prime_compl x with ⟨rx, sx, hrx⟩,
+    rcases mk'_surjective I.prime_compl y with ⟨ry, sy, hry⟩,
+    rcases mk'_surjective I.prime_compl z with ⟨rz, sz, hrz⟩,
+    rw [←hrx, ←hry, ←hrz, ←mk'_add, ←mk'_mul,
+        ←mk'_self S I.prime_compl.one_mem] at hxyz,
     rw ←hrx at hx, rw ←hry at hy,
-    cases f.eq.1 hxyz with t ht,
+    obtain ⟨t, ht⟩ := is_localization.eq.1 hxyz,
     simp only [mul_one, one_mul, submonoid.coe_mul, subtype.coe_mk] at ht,
     rw [←sub_eq_zero, ←sub_mul] at ht,
     have hr := (hp.mem_or_mem_of_mul_eq_zero ht).resolve_right t.2,
@@ -776,75 +788,83 @@ local_of_nonunits_ideal
                                          (I.mul_mem_right _ (this hy)))}
   end)
 
-end localization_map
+end is_localization
+
 namespace localization
 
 /-- The localization of `R` at the complement of a prime ideal is a local ring. -/
 instance at_prime.local_ring : local_ring (localization I.prime_compl) :=
-localization_map.at_prime.local_ring (of I.prime_compl)
+is_localization.at_prime.local_ring (localization I.prime_compl) I
 
 end localization
+
 end at_prime
-namespace localization_map
-variables (f : localization_map M S)
+
+namespace is_localization
+variables [is_localization M S]
 
 section ideals
 
-/-- Explicit characterization of the ideal given by `ideal.map f.to_map I`.
+variables (M) (S)
+include M
+
+/-- Explicit characterization of the ideal given by `ideal.map (algebra_map R S) I`.
 In practice, this ideal differs only in that the carrier set is defined explicitly.
 This definition is only meant to be used in proving `mem_map_to_map_iff`,
 and any proof that needs to refer to the explicit carrier set should use that theorem. -/
-private def to_map_ideal (I : ideal R) : ideal S :=
-{ carrier := { z : S | ∃ x : I × M, z * (f.to_map x.2) = f.to_map x.1},
+private def map_ideal (I : ideal R) : ideal S :=
+{ carrier := { z : S | ∃ x : I × M, z * algebra_map R S x.2 = algebra_map R S x.1},
   zero_mem' := ⟨⟨0, 1⟩, by simp⟩,
   add_mem' := begin
     rintros a b ⟨a', ha⟩ ⟨b', hb⟩,
     use ⟨a'.2 * b'.1 + b'.2 * a'.1, I.add_mem (I.mul_mem_left _ b'.1.2) (I.mul_mem_left _ a'.1.2)⟩,
     use a'.2 * b'.2,
     simp only [ring_hom.map_add, submodule.coe_mk, submonoid.coe_mul, ring_hom.map_mul],
-    rw [add_mul, ← mul_assoc a, ha, mul_comm (f.to_map a'.2) (f.to_map b'.2), ← mul_assoc b, hb],
+    rw [add_mul, ← mul_assoc a, ha, mul_comm (algebra_map R S a'.2) (algebra_map R S b'.2),
+        ← mul_assoc b, hb],
     ring
   end,
   smul_mem' := begin
     rintros c x ⟨x', hx⟩,
-    obtain ⟨c', hc⟩ := localization_map.surj f c,
+    obtain ⟨c', hc⟩ := is_localization.surj M c,
     use ⟨c'.1 * x'.1, I.mul_mem_left c'.1 x'.1.2⟩,
     use c'.2 * x'.2,
     simp only [←hx, ←hc, smul_eq_mul, submodule.coe_mk, submonoid.coe_mul, ring_hom.map_mul],
     ring
   end }
 
-theorem mem_map_to_map_iff {I : ideal R} {z} :
-  z ∈ ideal.map f.to_map I ↔ ∃ x : I × M, z * (f.to_map x.2) = f.to_map x.1 :=
+theorem mem_map_algebra_map_iff {I : ideal R} {z} :
+  z ∈ ideal.map (algebra_map R S) I ↔ ∃ x : I × M, z * algebra_map R S x.2 = algebra_map R S x.1 :=
 begin
   split,
-  { show _ → z ∈ to_map_ideal f I,
+  { change _ → z ∈ map_ideal M S I,
     refine λ h, ideal.mem_Inf.1 h (λ z hz, _),
     obtain ⟨y, hy⟩ := hz,
     use ⟨⟨⟨y, hy.left⟩, 1⟩, by simp [hy.right]⟩ },
   { rintros ⟨⟨a, s⟩, h⟩,
-    rw [← ideal.unit_mul_mem_iff_mem _ (map_units f s), mul_comm],
+    rw [← ideal.unit_mul_mem_iff_mem _ (map_units S s), mul_comm],
     exact h.symm ▸ ideal.mem_map_of_mem _ a.2 }
 end
 
 theorem map_comap (J : ideal S) :
-  ideal.map f.to_map (ideal.comap f.to_map J) = J :=
+  ideal.map (algebra_map R S) (ideal.comap (algebra_map R S) J) = J :=
 le_antisymm (ideal.map_le_iff_le_comap.2 (le_refl _)) $ λ x hJ,
 begin
-  obtain ⟨r, s, hx⟩ := f.mk'_surjective x,
+  obtain ⟨r, s, hx⟩ := mk'_surjective M x,
   rw ←hx at ⊢ hJ,
-  exact ideal.mul_mem_right _ _ (ideal.mem_map_of_mem _ (show f.to_map r ∈ J, from
-    f.mk'_spec r s ▸ J.mul_mem_right (f.to_map s) hJ)),
+  exact ideal.mul_mem_right _ _ (ideal.mem_map_of_mem _ (show (algebra_map R S) r ∈ J, from
+    mk'_spec S r s ▸ J.mul_mem_right ((algebra_map R S) s) hJ)),
 end
 
 theorem comap_map_of_is_prime_disjoint (I : ideal R) (hI : I.is_prime)
-  (hM : disjoint (M : set R) I) : ideal.comap f.to_map (ideal.map f.to_map I) = I :=
+  (hM : disjoint (M : set R) I) :
+  ideal.comap (algebra_map R S) (ideal.map (algebra_map R S) I) = I :=
 begin
   refine le_antisymm (λ a ha, _) ideal.le_comap_map,
-  rw [ideal.mem_comap, mem_map_to_map_iff] at ha,
+  rw [ideal.mem_comap, mem_map_algebra_map_iff M S] at ha,
   obtain ⟨⟨b, s⟩, h⟩ := ha,
-  have : f.to_map (a * ↑s - b) = 0 := by simpa [sub_eq_zero] using h,
-  rw [← f.to_map.map_zero, eq_iff_exists] at this,
+  have : (algebra_map R S) (a * ↑s - b) = 0 := by simpa [sub_eq_zero] using h,
+  rw [← (algebra_map R S).map_zero, eq_iff_exists M S] at this,
   obtain ⟨c, hc⟩ := this,
   have : a * s ∈ I,
   { rw zero_mul at hc,
@@ -862,9 +882,9 @@ end
 /-- If `S` is the localization of `R` at a submonoid, the ordering of ideals of `S` is
 embedded in the ordering of ideals of `R`. -/
 def order_embedding : ideal S ↪o ideal R :=
-{ to_fun := λ J, ideal.comap f.to_map J,
-  inj'   := function.left_inverse.injective f.map_comap,
-  map_rel_iff'   := λ J₁ J₂, ⟨λ hJ, f.map_comap J₁ ▸ f.map_comap J₂ ▸ ideal.map_mono hJ,
+{ to_fun := λ J, ideal.comap (algebra_map R S) J,
+  inj'   := function.left_inverse.injective (map_comap M S),
+  map_rel_iff'   := λ J₁ J₂, ⟨λ hJ, (map_comap M S) J₁ ▸ (map_comap M S) J₂ ▸ ideal.map_mono hJ,
     ideal.comap_mono⟩ }
 
 /-- If `R` is a ring, then prime ideals in the localization at `M`
@@ -872,23 +892,24 @@ correspond to prime ideals in the original ring `R` that are disjoint from `M`.
 This lemma gives the particular case for an ideal and its comap,
 see `le_rel_iso_of_prime` for the more general relation isomorphism -/
 lemma is_prime_iff_is_prime_disjoint (J : ideal S) :
-  J.is_prime ↔ (ideal.comap f.to_map J).is_prime ∧ disjoint (M : set R) ↑(ideal.comap f.to_map J) :=
+  J.is_prime ↔ (ideal.comap (algebra_map R S) J).is_prime ∧
+    disjoint (M : set R) ↑(ideal.comap (algebra_map R S) J) :=
 begin
   split,
   { refine λ h, ⟨⟨_, _⟩, λ m hm,
-      h.ne_top (ideal.eq_top_of_is_unit_mem _ hm.2 (map_units f ⟨m, hm.left⟩))⟩,
+      h.ne_top (ideal.eq_top_of_is_unit_mem _ hm.2 (map_units S ⟨m, hm.left⟩))⟩,
     { refine λ hJ, h.ne_top _,
-      rw [eq_top_iff, ← f.order_embedding.le_iff_le],
+      rw [eq_top_iff, ← (order_embedding M S).le_iff_le],
       exact le_of_eq hJ.symm },
     { intros x y hxy,
       rw [ideal.mem_comap, ring_hom.map_mul] at hxy,
       exact h.mem_or_mem hxy } },
   { refine λ h, ⟨λ hJ, h.left.ne_top (eq_top_iff.2 _), _⟩,
-    { rwa [eq_top_iff, ← f.order_embedding.le_iff_le] at hJ },
+    { rwa [eq_top_iff, ← (order_embedding M S).le_iff_le] at hJ },
     { intros x y hxy,
-      obtain ⟨a, s, ha⟩ := mk'_surjective f x,
-      obtain ⟨b, t, hb⟩ := mk'_surjective f y,
-      have : f.mk' (a * b) (s * t) ∈ J := by rwa [mk'_mul, ha, hb],
+      obtain ⟨a, s, ha⟩ := mk'_surjective M x,
+      obtain ⟨b, t, hb⟩ := mk'_surjective M y,
+      have : mk' S (a * b) (s * t) ∈ J := by rwa [mk'_mul, ha, hb],
       rw [mk'_mem_iff, ← ideal.mem_comap] at this,
       replace this := h.left.mem_or_mem this,
       rw [ideal.mem_comap, ideal.mem_comap] at this,
@@ -900,39 +921,41 @@ correspond to prime ideals in the original ring `R` that are disjoint from `M`.
 This lemma gives the particular case for an ideal and its map,
 see `le_rel_iso_of_prime` for the more general relation isomorphism, and the reverse implication -/
 lemma is_prime_of_is_prime_disjoint (I : ideal R) (hp : I.is_prime)
-  (hd : disjoint (M : set R) ↑I) : (ideal.map f.to_map I).is_prime :=
+  (hd : disjoint (M : set R) ↑I) : (ideal.map (algebra_map R S) I).is_prime :=
 begin
-  rw [is_prime_iff_is_prime_disjoint f, comap_map_of_is_prime_disjoint f I hp hd],
+  rw [is_prime_iff_is_prime_disjoint M S, comap_map_of_is_prime_disjoint M S I hp hd],
   exact ⟨hp, hd⟩
 end
 
 /-- If `R` is a ring, then prime ideals in the localization at `M`
 correspond to prime ideals in the original ring `R` that are disjoint from `M` -/
-def order_iso_of_prime (f : localization_map M S) :
+def order_iso_of_prime :
   {p : ideal S // p.is_prime} ≃o {p : ideal R // p.is_prime ∧ disjoint (M : set R) ↑p} :=
-{ to_fun := λ p, ⟨ideal.comap f.to_map p.1, (is_prime_iff_is_prime_disjoint f p.1).1 p.2⟩,
-  inv_fun := λ p, ⟨ideal.map f.to_map p.1, is_prime_of_is_prime_disjoint f p.1 p.2.1 p.2.2⟩,
-  left_inv := λ J, subtype.eq (map_comap f J),
-  right_inv := λ I, subtype.eq (comap_map_of_is_prime_disjoint f I.1 I.2.1 I.2.2),
+{ to_fun := λ p, ⟨ideal.comap (algebra_map R S) p.1,
+                  (is_prime_iff_is_prime_disjoint M S p.1).1 p.2⟩,
+  inv_fun := λ p, ⟨ideal.map (algebra_map R S) p.1,
+                   is_prime_of_is_prime_disjoint M S p.1 p.2.1 p.2.2⟩,
+  left_inv := λ J, subtype.eq (map_comap M S J),
+  right_inv := λ I, subtype.eq (comap_map_of_is_prime_disjoint M S I.1 I.2.1 I.2.2),
   map_rel_iff' := λ I I', ⟨λ h, (show I.val ≤ I'.val,
-    from (map_comap f I.val) ▸ (map_comap f I'.val) ▸ (ideal.map_mono h)), λ h x hx, h hx⟩ }
+    from (map_comap M S I.val) ▸ (map_comap M S I'.val) ▸ (ideal.map_mono h)), λ h x hx, h hx⟩ }
 
 /-- `quotient_map` applied to maximal ideals of a localization is `surjective`.
   The quotient by a maximal ideal is a field, so inverses to elements already exist,
   and the localization necessarily maps the equivalence class of the inverse in the localization -/
-lemma surjective_quotient_map_of_maximal_of_localization {f : localization_map M S} {I : ideal S}
-  [I.is_prime] {J : ideal R} {H : J ≤ I.comap f.to_map} (hI : (I.comap f.to_map).is_maximal) :
-  function.surjective (I.quotient_map f.to_map H) :=
+lemma surjective_quotient_map_of_maximal_of_localization {I : ideal S} [I.is_prime] {J : ideal R}
+  {H : J ≤ I.comap (algebra_map R S)} (hI : (I.comap (algebra_map R S)).is_maximal) :
+  function.surjective (I.quotient_map (algebra_map R S) H) :=
 begin
   intro s,
   obtain ⟨s, rfl⟩ := ideal.quotient.mk_surjective s,
-  obtain ⟨r, ⟨m, hm⟩, rfl⟩ := f.mk'_surjective s,
-  by_cases hM : (ideal.quotient.mk (I.comap f.to_map)) m = 0,
+  obtain ⟨r, ⟨m, hm⟩, rfl⟩ := mk'_surjective M s,
+  by_cases hM : (ideal.quotient.mk (I.comap (algebra_map R S))) m = 0,
   { have : I = ⊤,
     { rw ideal.eq_top_iff_one,
       rw [ideal.quotient.eq_zero_iff_mem, ideal.mem_comap] at hM,
-      convert I.mul_mem_right (f.mk' 1 ⟨m, hm⟩) hM,
-      rw [← f.mk'_eq_mul_mk'_one, f.mk'_self] },
+      convert I.mul_mem_right (mk' S 1 ⟨m, hm⟩) hM,
+      rw [← mk'_eq_mul_mk'_one, mk'_self] },
     exact ⟨0, eq_comm.1 (by simp [ideal.quotient.eq_zero_iff_mem, this])⟩ },
   { rw ideal.quotient.maximal_ideal_iff_is_field_quotient at hI,
     obtain ⟨n, hn⟩ := hI.3 hM,
@@ -940,126 +963,75 @@ begin
     refine ⟨(ideal.quotient.mk J) (r * rn), _⟩,
     -- The rest of the proof is essentially just algebraic manipulations to prove the equality
     rw ← ring_hom.map_mul at hn,
-    replace hn := congr_arg (ideal.quotient_map I f.to_map le_rfl) hn,
+    replace hn := congr_arg (ideal.quotient_map I (algebra_map R S) le_rfl) hn,
     simp only [ring_hom.map_one, ideal.quotient_map_mk, ring_hom.map_mul] at hn,
     rw [ideal.quotient_map_mk, ← sub_eq_zero, ← ring_hom.map_sub,
       ideal.quotient.eq_zero_iff_mem, ← ideal.quotient.eq_zero_iff_mem, ring_hom.map_sub,
-      sub_eq_zero, localization_map.mk'_eq_mul_mk'_one],
+      sub_eq_zero, mk'_eq_mul_mk'_one],
     simp only [mul_eq_mul_left_iff, ring_hom.map_mul],
     exact or.inl (mul_left_cancel' (λ hn, hM (ideal.quotient.eq_zero_iff_mem.2
       (ideal.mem_comap.2 (ideal.quotient.eq_zero_iff_mem.1 hn)))) (trans hn
-      (by rw [← ring_hom.map_mul, ← f.mk'_eq_mul_mk'_one, f.mk'_self, ring_hom.map_one]))) }
+      (by rw [← ring_hom.map_mul, ← mk'_eq_mul_mk'_one, mk'_self, ring_hom.map_one]))) }
 end
 
 end ideals
 
-/-!
-### `algebra` section
-
-Defines the `R`-algebra instance on a copy of `S` carrying the data of the localization map
-`f` needed to induce the `R`-algebra structure. -/
-
-/-- We use a copy of the localization map `f`'s codomain `S` carrying the data of `f` so that the
-`R`-algebra instance on `S` can 'know' the map needed to induce the `R`-algebra structure. -/
-instance algebra : algebra R f.codomain := f.to_map.to_algebra
-
-end localization_map
-namespace localization
-
-instance : algebra R (localization M) := localization_map.algebra (of M)
-
-end localization
-namespace localization_map
-variables (f : localization_map M S)
-
-@[simp] lemma of_id (a : R) :
-  (algebra.of_id R f.codomain) a = f.to_map a :=
-rfl
-
-@[simp] lemma algebra_map_eq : algebra_map R f.codomain = f.to_map := rfl
-
-variables (f)
-/-- Localization map `f` from `R` to `S` as an `R`-linear map. -/
-def lin_coe : R →ₗ[R] f.codomain :=
-{ to_fun    := f.to_map,
-  map_add'  := f.to_map.map_add,
-  map_smul' := f.to_map.map_mul }
+variables (S)
 
 /-- Map from ideals of `R` to submodules of `S` induced by `f`. -/
--- This was previously a `has_coe` instance, but if `f.codomain = R` then this will loop.
+-- This was previously a `has_coe` instance, but if `S = R` then this will loop.
 -- It could be a `has_coe_t` instance, but we keep it explicit here to avoid slowing down
 -- the rest of the library.
-def coe_submodule (I : ideal R) : submodule R f.codomain := submodule.map f.lin_coe I
-
-variables {f}
+def coe_submodule (I : ideal R) : submodule R S := submodule.map (algebra.linear_map R S) I
 
 lemma mem_coe_submodule (I : ideal R) {x : S} :
-  x ∈ f.coe_submodule I ↔ ∃ y : R, y ∈ I ∧ f.to_map y = x :=
+  x ∈ coe_submodule S I ↔ ∃ y : R, y ∈ I ∧ algebra_map R S y = x :=
 iff.rfl
-
-@[simp] lemma lin_coe_apply {x} : f.lin_coe x = f.to_map x := rfl
 
 variables {g : R →+* P}
 variables {T : submonoid P} (hy : ∀ y : M, g y ∈ T) {Q : Type*} [comm_ring Q]
-(k : localization_map T Q)
+variables [algebra P Q] [is_localization T Q]
 
-lemma map_smul (x : f.codomain) (z : R) :
-  f.map hy k (z • x : f.codomain) = @has_scalar.smul P k.codomain _ (g z) (f.map hy k x) :=
-show f.map hy k (f.to_map z * x) = k.to_map (g z) * f.map hy k x,
-by rw [ring_hom.map_mul, map_eq]
+lemma map_smul (x : S) (z : R) :
+  map S Q hy (z • x : S) = g z • map S Q hy x :=
+by rw [algebra.smul_def, algebra.smul_def, ring_hom.map_mul, map_eq]
 
-lemma is_noetherian_ring (h : is_noetherian_ring R) : is_noetherian_ring f.codomain :=
+section
+
+include M
+
+lemma is_noetherian_ring (h : is_noetherian_ring R) : is_noetherian_ring S :=
 begin
   rw [is_noetherian_ring_iff, is_noetherian_iff_well_founded] at h ⊢,
-  exact order_embedding.well_founded (f.order_embedding.dual) h
+  exact order_embedding.well_founded ((is_localization.order_embedding M S).dual) h
 end
 
-end localization_map
-
-namespace localization
-
-variables (f : localization_map M S)
-
-/-- Given a localization map `f : R →+* S` for a submonoid `M`, we get an `R`-preserving
-isomorphism between the localization of `R` at `M` as a quotient type and `S`. -/
-noncomputable def alg_equiv_of_quotient : localization M ≃ₐ[R] f.codomain :=
-{ commutes' := ring_equiv_of_quotient_of,
-  ..ring_equiv_of_quotient f }
-
-lemma alg_equiv_of_quotient_apply (x : localization M) :
-alg_equiv_of_quotient f x = ring_equiv_of_quotient f x := rfl
-
-lemma alg_equiv_of_quotient_symm_apply (x : f.codomain) :
-  (alg_equiv_of_quotient f).symm x = (ring_equiv_of_quotient f).symm x := rfl
-
-end localization
-
-namespace localization_map
+end
 
 section integer_normalization
-
-variables {f : localization_map M S}
 
 open polynomial
 open_locale classical
 
+variables (M) {S}
+
 /-- `coeff_integer_normalization p` gives the coefficients of the polynomial
 `integer_normalization p` -/
-noncomputable def coeff_integer_normalization (p : polynomial f.codomain) (i : ℕ) : R :=
+noncomputable def coeff_integer_normalization (p : polynomial S) (i : ℕ) : R :=
 if hi : i ∈ p.support
 then classical.some (classical.some_spec
-      (f.exist_integer_multiples_of_finset (p.support.image p.coeff))
+      (exist_integer_multiples_of_finset M (p.support.image p.coeff))
       (p.coeff i)
       (finset.mem_image.mpr ⟨i, hi, rfl⟩))
 else 0
 
-lemma coeff_integer_normalization_of_not_mem_support (p : polynomial f.codomain) (i : ℕ)
-  (h : coeff p i = 0) : coeff_integer_normalization p i = 0 :=
+lemma coeff_integer_normalization_of_not_mem_support (p : polynomial S) (i : ℕ)
+  (h : coeff p i = 0) : coeff_integer_normalization M p i = 0 :=
 by simp only [coeff_integer_normalization, h, mem_support_iff, eq_self_iff_true, not_true,
   ne.def, dif_neg, not_false_iff]
 
-lemma coeff_integer_normalization_mem_support (p : polynomial f.codomain) (i : ℕ)
-  (h : coeff_integer_normalization p i ≠ 0) : i ∈ p.support :=
+lemma coeff_integer_normalization_mem_support (p : polynomial S) (i : ℕ)
+  (h : coeff_integer_normalization M p i ≠ 0) : i ∈ p.support :=
 begin
   contrapose h,
   rw [ne.def, not_not, coeff_integer_normalization, dif_neg h]
@@ -1067,103 +1039,105 @@ end
 
 /-- `integer_normalization g` normalizes `g` to have integer coefficients
 by clearing the denominators -/
-noncomputable def integer_normalization (f : localization_map M S) (p : polynomial f.codomain) :
+noncomputable def integer_normalization (p : polynomial S) :
   polynomial R :=
-∑ i in p.support, monomial i (coeff_integer_normalization p i)
+∑ i in p.support, monomial i (coeff_integer_normalization M p i)
 
 @[simp]
-lemma integer_normalization_coeff (p : polynomial f.codomain) (i : ℕ) :
-  (f.integer_normalization p).coeff i = coeff_integer_normalization p i :=
+lemma integer_normalization_coeff (p : polynomial S) (i : ℕ) :
+  (integer_normalization M p).coeff i = coeff_integer_normalization M p i :=
 by simp [integer_normalization, coeff_monomial, coeff_integer_normalization_of_not_mem_support]
   {contextual := tt}
 
-lemma integer_normalization_spec (p : polynomial f.codomain) :
-  ∃ (b : M), ∀ i, f.to_map ((f.integer_normalization p).coeff i) = f.to_map b * p.coeff i :=
+lemma integer_normalization_spec (p : polynomial S) :
+  ∃ (b : M), ∀ i,
+    algebra_map R S ((integer_normalization M p).coeff i) = algebra_map R S b * p.coeff i :=
 begin
-  use classical.some (f.exist_integer_multiples_of_finset (p.support.image p.coeff)),
+  use classical.some (exist_integer_multiples_of_finset M (p.support.image p.coeff)),
   intro i,
   rw [integer_normalization_coeff, coeff_integer_normalization],
   split_ifs with hi,
   { exact classical.some_spec (classical.some_spec
-      (f.exist_integer_multiples_of_finset (p.support.image p.coeff))
+      (exist_integer_multiples_of_finset M (p.support.image p.coeff))
       (p.coeff i)
       (finset.mem_image.mpr ⟨i, hi, rfl⟩)) },
-  { convert (_root_.mul_zero (f.to_map _)).symm,
-    { exact f.to_ring_hom.map_zero },
+  { convert (_root_.mul_zero ((algebra_map R S) _)).symm,
+    { apply ring_hom.map_zero },
     { exact not_mem_support_iff.mp hi } }
 end
 
-lemma integer_normalization_map_to_map (p : polynomial f.codomain) :
-  ∃ (b : M), (f.integer_normalization p).map f.to_map = f.to_map b • p :=
-let ⟨b, hb⟩ := integer_normalization_spec p in
+lemma integer_normalization_map_to_map (p : polynomial S) :
+  ∃ (b : M), (integer_normalization M p).map (algebra_map R S) = algebra_map R S b • p :=
+let ⟨b, hb⟩ := integer_normalization_spec M p in
 ⟨b, polynomial.ext (λ i, by { rw [coeff_map, coeff_smul], exact hb i })⟩
 
 variables {R' : Type*} [comm_ring R']
 
-lemma integer_normalization_eval₂_eq_zero (g : f.codomain →+* R') (p : polynomial f.codomain)
-  {x : R'} (hx : eval₂ g x p = 0) : eval₂ (g.comp f.to_map) x (f.integer_normalization p) = 0 :=
-let ⟨b, hb⟩ := integer_normalization_map_to_map p in
-trans (eval₂_map f.to_map g x).symm (by rw [hb, eval₂_smul, hx, mul_zero])
+lemma integer_normalization_eval₂_eq_zero (g : S →+* R') (p : polynomial S)
+  {x : R'} (hx : eval₂ g x p = 0) :
+  eval₂ (g.comp (algebra_map R S)) x (integer_normalization M p) = 0 :=
+let ⟨b, hb⟩ := integer_normalization_map_to_map M p in
+trans (eval₂_map (algebra_map R S) g x).symm (by rw [hb, eval₂_smul, hx, mul_zero])
 
-lemma integer_normalization_aeval_eq_zero [algebra R R'] [algebra f.codomain R']
-  [is_scalar_tower R f.codomain R'] (p : polynomial f.codomain)
-  {x : R'} (hx : aeval x p = 0) : aeval x (f.integer_normalization p) = 0 :=
-by rw [aeval_def, is_scalar_tower.algebra_map_eq R f.codomain R', algebra_map_eq,
-    integer_normalization_eval₂_eq_zero _ _ hx]
+lemma integer_normalization_aeval_eq_zero [algebra R R'] [algebra S R'] [is_scalar_tower R S R']
+  (p : polynomial S) {x : R'} (hx : aeval x p = 0) :
+  aeval x (integer_normalization M p) = 0 :=
+by rw [aeval_def, is_scalar_tower.algebra_map_eq R S R',
+       integer_normalization_eval₂_eq_zero _ _ _ hx]
 
 end integer_normalization
 
-variables {R} {A K : Type*} [integral_domain A]
+variables {R M} (S) {A K : Type*} [integral_domain A]
 
-lemma to_map_eq_zero_iff (f : localization_map M S) {x : R} (hM : M ≤ non_zero_divisors R) :
-  f.to_map x = 0 ↔ x = 0 :=
+lemma to_map_eq_zero_iff {x : R} (hM : M ≤ non_zero_divisors R) :
+  algebra_map R S x = 0 ↔ x = 0 :=
 begin
-  rw ← f.to_map.map_zero,
+  rw ← (algebra_map R S).map_zero,
   split; intro h,
-  { cases f.eq_iff_exists.mp h with c hc,
+  { cases (eq_iff_exists M S).mp h with c hc,
     rw zero_mul at hc,
     exact hM c.2 x hc },
   { rw h },
 end
 
-lemma injective (f : localization_map M S) (hM : M ≤ non_zero_divisors R) :
-  injective f.to_map :=
+protected lemma injective (hM : M ≤ non_zero_divisors R) :
+  injective (algebra_map R S) :=
 begin
-  rw ring_hom.injective_iff f.to_map,
+  rw ring_hom.injective_iff (algebra_map R S),
   intros a ha,
-  rw [← f.to_map.map_zero, f.eq_iff_exists] at ha,
-  cases ha with c hc,
-  rw zero_mul at hc,
-  exact hM c.2 a hc,
+  rwa to_map_eq_zero_iff S hM at ha
 end
 
-protected lemma to_map_ne_zero_of_mem_non_zero_divisors [nontrivial R] (f : localization_map M S)
-  (hM : M ≤ non_zero_divisors R) {x : R} (hx : x ∈ non_zero_divisors R) : f.to_map x ≠ 0 :=
-map_ne_zero_of_mem_non_zero_divisors (f.injective hM) hx
+protected lemma to_map_ne_zero_of_mem_non_zero_divisors [nontrivial R]
+  (hM : M ≤ non_zero_divisors R) {x} (hx : x ∈ non_zero_divisors R) :
+  algebra_map R S x ≠ 0 :=
+map_ne_zero_of_mem_non_zero_divisors (is_localization.injective S hM) hx
 
 /-- A `comm_ring` `S` which is the localization of an integral domain `R` at a subset of
 non-zero elements is an integral domain. -/
-def integral_domain_of_le_non_zero_divisors {M : submonoid A} (f : localization_map M S)
+def integral_domain_of_le_non_zero_divisors [algebra A S] {M : submonoid A} [is_localization M S]
   (hM : M ≤ non_zero_divisors A) : integral_domain S :=
 { eq_zero_or_eq_zero_of_mul_eq_zero :=
     begin
       intros z w h,
-      cases f.surj z with x hx,
-      cases f.surj w with y hy,
-      have : z * w * f.to_map y.2 * f.to_map x.2 = f.to_map x.1 * f.to_map y.1,
+      cases surj M z with x hx,
+      cases surj M w with y hy,
+      have : z * w * algebra_map A S y.2 * algebra_map A S x.2 =
+        algebra_map A S x.1 * algebra_map A S y.1,
       by rw [mul_assoc z, hy, ←hx]; ac_refl,
-      rw [h, zero_mul, zero_mul, ← f.to_map.map_mul] at this,
-      cases eq_zero_or_eq_zero_of_mul_eq_zero ((to_map_eq_zero_iff f hM).mp this.symm) with H H,
-      { exact or.inl (f.eq_zero_of_fst_eq_zero hx H) },
-      { exact or.inr (f.eq_zero_of_fst_eq_zero hy H) },
+      rw [h, zero_mul, zero_mul, ← (algebra_map A S).map_mul] at this,
+      cases eq_zero_or_eq_zero_of_mul_eq_zero ((to_map_eq_zero_iff S hM).mp this.symm) with H H,
+      { exact or.inl (eq_zero_of_fst_eq_zero hx H) },
+      { exact or.inr (eq_zero_of_fst_eq_zero hy H) },
     end,
-  exists_pair_ne := ⟨f.to_map 0, f.to_map 1, λ h, zero_ne_one (f.injective hM h)⟩,
-  ..(infer_instance : comm_ring S) }
+  exists_pair_ne := ⟨(algebra_map A S) 0, (algebra_map A S) 1,
+                     λ h, zero_ne_one (is_localization.injective S hM h)⟩,
+  .. ‹comm_ring S› }
 
 /-- The localization at of an integral domain to a set of non-zero elements is an integral domain -/
 def integral_domain_localization {M : submonoid A} (hM : M ≤ non_zero_divisors A) :
   integral_domain (localization M) :=
-(localization.of M).integral_domain_of_le_non_zero_divisors hM
+integral_domain_of_le_non_zero_divisors _ hM
 
 /--
 The localization of an integral domain at the complement of a prime ideal is an integral domain.
@@ -1172,42 +1146,43 @@ instance integral_domain_of_local_at_prime {P : ideal A} (hp : P.is_prime) :
   integral_domain (localization.at_prime P) :=
 integral_domain_localization (le_non_zero_divisors_of_domain (by simpa only [] using P.zero_mem))
 
-end localization_map
+namespace at_prime
 
-section at_prime
-
-namespace localization_map
-
-variables (I : ideal R) [hI : I.is_prime] (f : at_prime S I)
+variables (I : ideal R) [hI : I.is_prime] [is_localization.at_prime S I]
 include hI
 
-lemma at_prime.is_unit_to_map_iff (x : R) :
-  is_unit (f.to_map x) ↔ x ∈ I.prime_compl :=
-⟨λ h hx, (f.is_prime_of_is_prime_disjoint I hI disjoint_compl_left).ne_top $
-  (ideal.map f.to_map I).eq_top_of_is_unit_mem (ideal.mem_map_of_mem _ hx) h,
-λ h, f.map_units ⟨x, h⟩⟩
+lemma is_unit_to_map_iff (x : R) :
+  is_unit ((algebra_map R S) x) ↔ x ∈ I.prime_compl :=
+⟨λ h hx, (is_prime_of_is_prime_disjoint I.prime_compl S I hI disjoint_compl_left).ne_top $
+  (ideal.map (algebra_map R S) I).eq_top_of_is_unit_mem (ideal.mem_map_of_mem _ hx) h,
+λ h, map_units S ⟨x, h⟩⟩
 
-lemma at_prime.to_map_mem_maximal_iff (x : R) :
-  f.to_map x ∈ local_ring.maximal_ideal (f.codomain) ↔ x ∈ I :=
+-- Can't use typeclasses to infer the `local_ring` instance, so use an `opt_param` instead
+-- (since `local_ring` is a `Prop`, there should be no unification issues.)
+lemma to_map_mem_maximal_iff (x : R) (h : _root_.local_ring S := local_ring S I) :
+  algebra_map R S x ∈ local_ring.maximal_ideal S ↔ x ∈ I :=
 not_iff_not.mp $ by
-simpa only [@local_ring.mem_maximal_ideal (f.codomain), mem_nonunits_iff, not_not]
-  using f.is_unit_to_map_iff I x
+simpa only [@local_ring.mem_maximal_ideal S, mem_nonunits_iff, not_not]
+  using is_unit_to_map_iff S I x
 
-lemma at_prime.is_unit_mk'_iff (x : R) (y : I.prime_compl) :
-  is_unit (f.mk' x y) ↔ x ∈ I.prime_compl :=
-⟨λ h hx, (mk'_mem_iff f).mpr ((f.to_map_mem_maximal_iff I x).mpr hx) h,
-λ h, is_unit_iff_exists_inv.mpr ⟨f.mk' y ⟨x, h⟩, f.mk'_mul_mk'_eq_one ⟨x, h⟩ y⟩⟩
+lemma is_unit_mk'_iff (x : R) (y : I.prime_compl) :
+  is_unit (mk' S x y) ↔ x ∈ I.prime_compl :=
+⟨λ h hx, mk'_mem_iff.mpr ((to_map_mem_maximal_iff S I x).mpr hx) h,
+λ h, is_unit_iff_exists_inv.mpr ⟨mk' S ↑y ⟨x, h⟩, mk'_mul_mk'_eq_one ⟨x, h⟩ y⟩⟩
 
-lemma at_prime.mk'_mem_maximal_iff (x : R) (y : I.prime_compl) :
-  f.mk' x y ∈ local_ring.maximal_ideal (f.codomain) ↔ x ∈ I :=
+lemma mk'_mem_maximal_iff (x : R) (y : I.prime_compl) (h : _root_.local_ring S := local_ring S I) :
+  mk' S x y ∈ local_ring.maximal_ideal S ↔ x ∈ I :=
 not_iff_not.mp $ by
-simpa only [@local_ring.mem_maximal_ideal (f.codomain), mem_nonunits_iff, not_not]
-  using f.is_unit_mk'_iff I x y
+simpa only [@local_ring.mem_maximal_ideal S, mem_nonunits_iff, not_not]
+  using is_unit_mk'_iff S I x y
 
-end localization_map
+end at_prime
+
+end is_localization
 
 namespace localization
-open localization_map
+
+open is_localization
 
 local attribute [instance] classical.prop_decidable
 
@@ -1217,19 +1192,19 @@ include hI
 variables {I}
 /-- The unique maximal ideal of the localization at `I.prime_compl` lies over the ideal `I`. -/
 lemma at_prime.comap_maximal_ideal :
-  ideal.comap (localization.of I.prime_compl).to_map
-  (local_ring.maximal_ideal (localization I.prime_compl)) = I :=
+  ideal.comap (algebra_map R (localization.at_prime I))
+    (local_ring.maximal_ideal (localization I.prime_compl)) = I :=
 ideal.ext $ λ x, by
-simpa only [ideal.mem_comap] using at_prime.to_map_mem_maximal_iff I _ x
+simpa only [ideal.mem_comap] using at_prime.to_map_mem_maximal_iff _ I x
 
 /-- The image of `I` in the localization at `I.prime_compl` is a maximal ideal, and in particular
 it is the unique maximal ideal given by the local ring structure `at_prime.local_ring` -/
 lemma at_prime.map_eq_maximal_ideal :
-  ideal.map (localization.of I.prime_compl).to_map I =
+  ideal.map (algebra_map R (localization.at_prime I)) I =
     (local_ring.maximal_ideal (localization I.prime_compl)) :=
 begin
-  convert congr_arg (ideal.map (localization.of _).to_map) at_prime.comap_maximal_ideal.symm,
-  rw map_comap,
+  convert congr_arg (ideal.map _) at_prime.comap_maximal_ideal.symm,
+  rw map_comap I.prime_compl
 end
 
 variables (I)
@@ -1288,116 +1263,154 @@ local_ring_hom_unique _ _ _ _
   (λ r, by simp only [function.comp_app, ring_hom.coe_comp, local_ring_hom_to_map])
 
 end localization
-end at_prime
+
+open is_localization
 
 /-- If `R` is a field, then localizing at a submonoid not containing `0` adds no new elements. -/
 lemma localization_map_bijective_of_field {R Rₘ : Type*} [integral_domain R] [comm_ring Rₘ]
   {M : submonoid R} (hM : (0 : R) ∉ M) (hR : is_field R)
-  (f : localization_map M Rₘ) : function.bijective f.to_map :=
+  [algebra R Rₘ] [is_localization M Rₘ] : function.bijective (algebra_map R Rₘ) :=
 begin
-  refine ⟨f.injective (le_non_zero_divisors_of_domain hM), λ x, _⟩,
-  obtain ⟨r, ⟨m, hm⟩, rfl⟩ := f.mk'_surjective x,
+  refine ⟨is_localization.injective _ (le_non_zero_divisors_of_domain hM), λ x, _⟩,
+  obtain ⟨r, ⟨m, hm⟩, rfl⟩ := mk'_surjective M x,
   obtain ⟨n, hn⟩ := hR.mul_inv_cancel (λ hm0, hM (hm0 ▸ hm) : m ≠ 0),
   exact ⟨r * n,
-    by erw [f.eq_mk'_iff_mul_eq, ← f.to_map.map_mul, mul_assoc, mul_comm n, hn, mul_one]⟩
+    by erw [eq_mk'_iff_mul_eq, ← ring_hom.map_mul, mul_assoc, mul_comm n, hn, mul_one]⟩
 end
 
 variables (R) {A : Type*} [integral_domain A]
 variables (K : Type*)
 
-/-- Localization map from an integral domain `R` to its field of fractions. -/
-@[reducible] def fraction_map [comm_ring K] := localization_map (non_zero_divisors R) K
+/-- `is_fraction_ring R K` states `K` is the field of fractions of an integral domain `R`. -/
+-- TODO: should this extend `algebra` instead of assuming it?
+abbreviation is_fraction_ring [comm_ring K] [algebra R K] := is_localization (non_zero_divisors R) K
 
-namespace fraction_map
-open localization_map
+/-- The cast from `int` to `rat` as a `fraction_ring`. -/
+instance rat.is_fraction_ring : is_fraction_ring ℤ ℚ :=
+{ map_units :=
+  begin
+    rintro ⟨x, hx⟩,
+    rw mem_non_zero_divisors_iff_ne_zero at hx,
+    simpa only [ring_hom.eq_int_cast, is_unit_iff_ne_zero, int.cast_eq_zero,
+                ne.def, subtype.coe_mk] using hx,
+    end,
+  surj :=
+  begin
+    rintro ⟨n, d, hd, h⟩,
+    refine ⟨⟨n, ⟨d, _⟩⟩, rat.mul_denom_eq_num⟩,
+    rwa [mem_non_zero_divisors_iff_ne_zero, int.coe_nat_ne_zero_iff_pos]
+  end,
+  eq_iff_exists :=
+  begin
+    intros x y,
+    rw [ring_hom.eq_int_cast, ring_hom.eq_int_cast, int.cast_inj],
+    refine ⟨by { rintro rfl, use 1 }, _⟩,
+    rintro ⟨⟨c, hc⟩, h⟩,
+    apply int.eq_of_mul_eq_mul_right _ h,
+    rwa mem_non_zero_divisors_iff_ne_zero at hc,
+  end }
+
+namespace is_fraction_ring
+
 variables {R K}
 
-lemma to_map_eq_zero_iff [comm_ring K] (φ : fraction_map R K) {x : R} :
-  φ.to_map x = 0 ↔ x = 0 :=
-φ.to_map_eq_zero_iff (le_of_eq rfl)
+section comm_ring
 
-protected theorem injective [comm_ring K] (φ : fraction_map R K) :
-  function.injective φ.to_map :=
-φ.injective (le_of_eq rfl)
+variables [comm_ring K] [algebra R K] [is_fraction_ring R K] [algebra A K] [is_fraction_ring A K]
 
-protected lemma to_map_ne_zero_of_mem_non_zero_divisors [nontrivial R] [comm_ring K]
-  (φ : fraction_map R K) {x : R} (hx : x ∈ non_zero_divisors R) : φ.to_map x ≠ 0 :=
-φ.to_map_ne_zero_of_mem_non_zero_divisors (le_of_eq rfl) hx
+lemma to_map_eq_zero_iff {x : R} :
+  algebra_map R K x = 0 ↔ x = 0 :=
+to_map_eq_zero_iff _ (le_of_eq rfl)
+
+protected theorem injective : function.injective (algebra_map R K) :=
+is_localization.injective _ (le_of_eq rfl)
+
+protected lemma to_map_ne_zero_of_mem_non_zero_divisors [nontrivial R]
+  {x : R} (h : x ∈ non_zero_divisors R) : algebra_map R K x ≠ 0 :=
+is_localization.to_map_ne_zero_of_mem_non_zero_divisors _ (le_refl _) h
+
+variables (A)
 
 /-- A `comm_ring` `K` which is the localization of an integral domain `R` at `R - {0}` is an
 integral domain. -/
-def to_integral_domain [comm_ring K] (φ : fraction_map A K) : integral_domain K :=
-φ.integral_domain_of_le_non_zero_divisors (le_of_eq rfl)
+def to_integral_domain : integral_domain K :=
+integral_domain_of_le_non_zero_divisors K (le_refl (non_zero_divisors A))
 
 local attribute [instance] classical.dec_eq
 
 /-- The inverse of an element in the field of fractions of an integral domain. -/
-protected noncomputable def inv [comm_ring K] (φ : fraction_map A K) (z : K) : K :=
+protected noncomputable def inv (z : K) : K :=
 if h : z = 0 then 0 else
-φ.mk' (φ.to_localization_map.sec z).2 ⟨(φ.to_localization_map.sec z).1,
-  mem_non_zero_divisors_iff_ne_zero.2 $ λ h0, h $ φ.eq_zero_of_fst_eq_zero (sec_spec z) h0⟩
+mk' K ↑((to_localization_map (non_zero_divisors A) K).sec z).2
+  ⟨((to_localization_map _ K).sec z).1,
+   mem_non_zero_divisors_iff_ne_zero.2 $ λ h0, h $
+    eq_zero_of_fst_eq_zero (sec_spec (non_zero_divisors A) z) h0⟩
 
-protected lemma mul_inv_cancel [comm_ring K] (φ : fraction_map A K) (x : K) (hx : x ≠ 0) :
-  x * φ.inv x = 1 :=
+protected lemma mul_inv_cancel (x : K) (hx : x ≠ 0) :
+  x * is_fraction_ring.inv A x = 1 :=
 show x * dite _ _ _ = 1, by rw [dif_neg hx,
-  ←is_unit.mul_left_inj (φ.map_units ⟨(φ.to_localization_map.sec x).1,
-    mem_non_zero_divisors_iff_ne_zero.2 $ λ h0, hx $ φ.eq_zero_of_fst_eq_zero (sec_spec x) h0⟩),
-  one_mul, mul_assoc, mk'_spec, ←eq_mk'_iff_mul_eq]; exact (φ.mk'_sec x).symm
+  ←is_unit.mul_left_inj (map_units K ⟨((to_localization_map (non_zero_divisors A) K).sec x).1,
+    mem_non_zero_divisors_iff_ne_zero.2 $ λ h0, hx $ eq_zero_of_fst_eq_zero (sec_spec _ x) h0⟩),
+  one_mul, mul_assoc, mk'_spec, ←eq_mk'_iff_mul_eq]; exact (mk'_sec _ x).symm
 
 /-- A `comm_ring` `K` which is the localization of an integral domain `R` at `R - {0}` is a
 field. -/
-noncomputable def to_field [comm_ring K] (φ : fraction_map A K) : field K :=
-{ inv := φ.inv,
-  mul_inv_cancel := φ.mul_inv_cancel,
-  inv_zero := dif_pos rfl, ..φ.to_integral_domain }
+noncomputable def to_field : field K :=
+{ inv := is_fraction_ring.inv A,
+  mul_inv_cancel := is_fraction_ring.mul_inv_cancel A,
+  inv_zero := dif_pos rfl,
+  .. to_integral_domain A }
+
+end comm_ring
 
 variables {B : Type*} [integral_domain B] [field K] {L : Type*} [field L]
-  (f : fraction_map A K) {g : A →+* L}
+  [algebra A K] [is_fraction_ring A K] {g : A →+* L}
 
-lemma mk'_eq_div {r s} : f.mk' r s = f.to_map r / f.to_map s :=
-f.mk'_eq_iff_eq_mul.2 $ (div_mul_cancel _
-    (f.to_map_ne_zero_of_mem_non_zero_divisors s.2)).symm
+lemma mk'_eq_div {r s} :
+  mk' K r s = algebra_map A K r / algebra_map A K s :=
+mk'_eq_iff_eq_mul.2 $ (div_mul_cancel (algebra_map A K r)
+    (is_fraction_ring.to_map_ne_zero_of_mem_non_zero_divisors s.2)).symm
 
 lemma is_unit_map_of_injective (hg : function.injective g)
   {y : A} (hy : y ∈ non_zero_divisors A) : is_unit (g y) :=
 is_unit.mk0 (g y) $ map_ne_zero_of_mem_non_zero_divisors hg hy
 
-/-- Given an integral domain `A`, a localization map to its fields of fractions
-`f : A →+* K`, and an injective ring hom `g : A →+* L` where `L` is a field, we get a
+/-- Given an integral domain `A` with field of fractions `K`,
+and an injective ring hom `g : A →+* L` where `L` is a field, we get a
 field hom sending `z : K` to `g x * (g y)⁻¹`, where `(x, y) : A × (non_zero_divisors A)` are
 such that `z = f x * (f y)⁻¹`. -/
 noncomputable def lift (hg : injective g) : K →+* L :=
-f.lift $ λ y, is_unit_map_of_injective hg y.2
+lift $ λ y, is_unit_map_of_injective hg y.2
 
-/-- Given an integral domain `A`, a localization map to its fields of fractions
-`f : A →+* K`, and an injective ring hom `g : A →+* L` where `L` is a field,
+/-- Given an integral domain `A` with field of fractions `K`,
+and an injective ring hom `g : A →+* L` where `L` is a field,
 field hom induced from `K` to `L` maps `f x / f y` to `g x / g y` for all
 `x : A, y ∈ non_zero_divisors A`. -/
-@[simp] lemma lift_mk' (hg : injective g) (x y) :
-  f.lift hg (f.mk' x y) = g x / g y :=
+@[simp] lemma lift_mk' (hg : injective g) (x) (y : non_zero_divisors A) :
+  lift hg (mk' K x y) = g x / g y :=
 begin
-  erw f.lift_mk' (λ y, is_unit_map_of_injective hg y.2),
+  erw lift_mk' (is_unit_map_of_injective hg),
   erw submonoid.localization_map.mul_inv_left
   (λ y : non_zero_divisors A, show is_unit (g.to_monoid_hom y), from
     is_unit_map_of_injective hg y.2),
   exact (mul_div_cancel' _ (map_ne_zero_of_mem_non_zero_divisors hg y.2)).symm,
 end
 
-/-- Given integral domains `A, B` and localization maps to their fields of fractions
-`f : A →+* K, g : B →+* L` and an injective ring hom `j : A →+* B`, we get a field hom
+/-- Given integral domains `A, B` with fields of fractions `K`, `L`
+and an injective ring hom `j : A →+* B`, we get a field hom
 sending `z : K` to `g (j x) * (g (j y))⁻¹`, where `(x, y) : A × (non_zero_divisors A)` are
 such that `z = f x * (f y)⁻¹`. -/
-noncomputable def map (g : fraction_map B L) {j : A →+* B} (hj : injective j) :
+noncomputable def map [algebra B L] [is_fraction_ring B L] {j : A →+* B} (hj : injective j) :
   K →+* L :=
-f.map (λ y, mem_non_zero_divisors_iff_ne_zero.2 $
+map (λ y, mem_non_zero_divisors_iff_ne_zero.2 $
   map_ne_zero_of_mem_non_zero_divisors hj y.2) g
 
 /-- Given integral domains `A, B` and localization maps to their fields of fractions
 `f : A →+* K, g : B →+* L`, an isomorphism `j : A ≃+* B` induces an isomorphism of
 fields of fractions `K ≃+* L`. -/
-noncomputable def field_equiv_of_ring_equiv (g : fraction_map B L) (h : A ≃+* B) :
+noncomputable def field_equiv_of_ring_equiv [algebra B L] [is_fraction_ring B L] (h : A ≃+* B) :
   K ≃+* L :=
-f.ring_equiv_of_ring_equiv g h
+ring_equiv_of_ring_equiv K L h
 begin
   ext b,
   show b ∈ h.to_equiv '' _ ↔ _,
@@ -1405,178 +1418,160 @@ begin
        mem_non_zero_divisors_iff_ne_zero, mem_non_zero_divisors_iff_ne_zero],
   exact h.symm.map_ne_zero_iff
 end
-/-- The cast from `int` to `rat` as a `fraction_map`. -/
-def int.fraction_map : fraction_map ℤ ℚ :=
-{ to_fun := coe,
-  map_units' :=
-  begin
-    rintro ⟨x, hx⟩,
-    rw mem_non_zero_divisors_iff_ne_zero at hx,
-    simpa only [is_unit_iff_ne_zero, int.cast_eq_zero, ne.def, subtype.coe_mk] using hx,
-  end,
-  surj' :=
-  begin
-    rintro ⟨n, d, hd, h⟩,
-    refine ⟨⟨n, ⟨d, _⟩⟩, rat.mul_denom_eq_num⟩,
-    rwa [mem_non_zero_divisors_iff_ne_zero, int.coe_nat_ne_zero_iff_pos]
-  end,
-  eq_iff_exists' :=
-  begin
-    intros x y,
-    rw [int.cast_inj],
-    refine ⟨by { rintro rfl, use 1 }, _⟩,
-    rintro ⟨⟨c, hc⟩, h⟩,
-    apply int.eq_of_mul_eq_mul_right _ h,
-    rwa mem_non_zero_divisors_iff_ne_zero at hc,
-  end,
-  ..int.cast_ring_hom ℚ }
 
-lemma integer_normalization_eq_zero_iff {p : polynomial f.codomain} :
-  f.integer_normalization p = 0 ↔ p = 0 :=
+lemma integer_normalization_eq_zero_iff {p : polynomial K} :
+  integer_normalization (non_zero_divisors A) p = 0 ↔ p = 0 :=
 begin
   refine (polynomial.ext_iff.trans (polynomial.ext_iff.trans _).symm),
-  obtain ⟨⟨b, nonzero⟩, hb⟩ := integer_normalization_spec p,
+  obtain ⟨⟨b, nonzero⟩, hb⟩ := integer_normalization_spec _ p,
   split; intros h i,
-  { apply f.to_map_eq_zero_iff.mp,
+  { apply to_map_eq_zero_iff.mp,
     rw [hb i, h i],
-    exact _root_.mul_zero _ },
+    exact _root_.mul_zero _,
+    assumption },
   { have hi := h i,
-    rw [polynomial.coeff_zero, ← f.to_map_eq_zero_iff, hb i] at hi,
+    rw [polynomial.coeff_zero, ← @to_map_eq_zero_iff A _ K, hb i] at hi,
     apply or.resolve_left (eq_zero_or_eq_zero_of_mul_eq_zero hi),
     intro h,
     apply mem_non_zero_divisors_iff_ne_zero.mp nonzero,
-    exact f.to_map_eq_zero_iff.mp h }
+    exact to_map_eq_zero_iff.mp h }
 end
 
 /-- A field is algebraic over the ring `A` iff it is algebraic over the field of fractions of `A`.
 -/
-lemma comap_is_algebraic_iff [algebra A L] [algebra f.codomain L] [is_scalar_tower A f.codomain L] :
-  algebra.is_algebraic A L ↔ algebra.is_algebraic f.codomain L :=
+lemma comap_is_algebraic_iff [algebra A L] [algebra K L] [is_scalar_tower A K L] :
+  algebra.is_algebraic A L ↔ algebra.is_algebraic K L :=
 begin
   split; intros h x; obtain ⟨p, hp, px⟩ := h x,
-  { refine ⟨p.map f.to_map, λ h, hp (polynomial.ext (λ i, _)), _⟩,
-  { have : f.to_map (p.coeff i) = 0 := trans (polynomial.coeff_map _ _).symm (by simp [h]),
-    exact f.to_map_eq_zero_iff.mp this },
-  { rwa [is_scalar_tower.aeval_apply _ f.codomain, algebra_map_eq] at px } },
-  { exact ⟨f.integer_normalization p,
-           mt f.integer_normalization_eq_zero_iff.mp hp,
-           integer_normalization_aeval_eq_zero p px⟩ },
+  { refine ⟨p.map (algebra_map A K), λ h, hp (polynomial.ext (λ i, _)), _⟩,
+  { have : algebra_map A K (p.coeff i) = 0 := trans (polynomial.coeff_map _ _).symm (by simp [h]),
+    exact to_map_eq_zero_iff.mp this },
+  { rwa is_scalar_tower.aeval_apply _ K at px } },
+  { exact ⟨integer_normalization _ p,
+           mt integer_normalization_eq_zero_iff.mp hp,
+           integer_normalization_aeval_eq_zero _ p px⟩ },
 end
 
 section num_denom
 
-variables [unique_factorization_monoid A] (φ : fraction_map A K)
+variables (A) [unique_factorization_monoid A]
 
-lemma exists_reduced_fraction (x : φ.codomain) :
+lemma exists_reduced_fraction (x : K) :
   ∃ (a : A) (b : non_zero_divisors A),
-  (∀ {d}, d ∣ a → d ∣ b → is_unit d) ∧ φ.mk' a b = x :=
+  (∀ {d}, d ∣ a → d ∣ b → is_unit d) ∧ mk' K a b = x :=
 begin
-  obtain ⟨⟨b, b_nonzero⟩, a, hab⟩ := φ.exists_integer_multiple x,
+  obtain ⟨⟨b, b_nonzero⟩, a, hab⟩ := exists_integer_multiple (non_zero_divisors A) x,
   obtain ⟨a', b', c', no_factor, rfl, rfl⟩ :=
     unique_factorization_monoid.exists_reduced_factors' a b
       (mem_non_zero_divisors_iff_ne_zero.mp b_nonzero),
   obtain ⟨c'_nonzero, b'_nonzero⟩ := mul_mem_non_zero_divisors.mp b_nonzero,
   refine ⟨a', ⟨b', b'_nonzero⟩, @no_factor, _⟩,
-  apply mul_left_cancel' (φ.to_map_ne_zero_of_mem_non_zero_divisors b_nonzero),
-  simp only [subtype.coe_mk, φ.to_map.map_mul] at *,
-  erw [←hab, mul_assoc, φ.mk'_spec' a' ⟨b', b'_nonzero⟩],
+  refine mul_left_cancel'
+    (is_fraction_ring.to_map_ne_zero_of_mem_non_zero_divisors b_nonzero) _,
+  simp only [subtype.coe_mk, ring_hom.map_mul] at *,
+  erw [←hab, mul_assoc, mk'_spec' _ a' ⟨b', b'_nonzero⟩],
 end
 
 /-- `f.num x` is the numerator of `x : f.codomain` as a reduced fraction. -/
-noncomputable def num (x : φ.codomain) : A :=
-classical.some (φ.exists_reduced_fraction x)
+noncomputable def num (x : K) : A :=
+classical.some (exists_reduced_fraction A x)
 
 /-- `f.num x` is the denominator of `x : f.codomain` as a reduced fraction. -/
-noncomputable def denom (x : φ.codomain) : non_zero_divisors A :=
-classical.some (classical.some_spec (φ.exists_reduced_fraction x))
+noncomputable def denom (x : K) : non_zero_divisors A :=
+classical.some (classical.some_spec (exists_reduced_fraction A x))
 
-lemma num_denom_reduced (x : φ.codomain) :
-  ∀ {d}, d ∣ φ.num x → d ∣ φ.denom x → is_unit d :=
-(classical.some_spec (classical.some_spec (φ.exists_reduced_fraction x))).1
+lemma num_denom_reduced (x : K) :
+  ∀ {d}, d ∣ num A x → d ∣ denom A x → is_unit d :=
+(classical.some_spec (classical.some_spec (exists_reduced_fraction A x))).1
 
-@[simp] lemma mk'_num_denom (x : φ.codomain) : φ.mk' (φ.num x) (φ.denom x) = x :=
-(classical.some_spec (classical.some_spec (φ.exists_reduced_fraction x))).2
+@[simp] lemma mk'_num_denom (x : K) : mk' K (num A x) (denom A x) = x :=
+(classical.some_spec (classical.some_spec (exists_reduced_fraction A x))).2
 
-lemma num_mul_denom_eq_num_iff_eq {x y : φ.codomain} :
-  x * φ.to_map (φ.denom y) = φ.to_map (φ.num y) ↔ x = y :=
-⟨ λ h, by simpa only [mk'_num_denom] using φ.eq_mk'_iff_mul_eq.mpr h,
-  λ h, φ.eq_mk'_iff_mul_eq.mp (by rw [h, mk'_num_denom]) ⟩
+variables {A}
 
-lemma num_mul_denom_eq_num_iff_eq' {x y : φ.codomain} :
-  y * φ.to_map (φ.denom x) = φ.to_map (φ.num x) ↔ x = y :=
-⟨ λ h, by simpa only [eq_comm, mk'_num_denom] using φ.eq_mk'_iff_mul_eq.mpr h,
-  λ h, φ.eq_mk'_iff_mul_eq.mp (by rw [h, mk'_num_denom]) ⟩
+lemma num_mul_denom_eq_num_iff_eq {x y : K} :
+  x * algebra_map A K (denom A y) = algebra_map A K (num A y) ↔ x = y :=
+⟨λ h, by simpa only [mk'_num_denom] using eq_mk'_iff_mul_eq.mpr h,
+ λ h, eq_mk'_iff_mul_eq.mp (by rw [h, mk'_num_denom])⟩
 
-lemma num_mul_denom_eq_num_mul_denom_iff_eq {x y : φ.codomain} :
-  φ.num y * φ.denom x = φ.num x * φ.denom y ↔ x = y :=
-⟨ λ h, by simpa only [mk'_num_denom] using φ.mk'_eq_of_eq h,
-  λ h, by rw h ⟩
+lemma num_mul_denom_eq_num_iff_eq' {x y : K} :
+  y * algebra_map A K (denom A x) = algebra_map A K (num A x) ↔ x = y :=
+⟨λ h, by simpa only [eq_comm, mk'_num_denom] using eq_mk'_iff_mul_eq.mpr h,
+ λ h, eq_mk'_iff_mul_eq.mp (by rw [h, mk'_num_denom])⟩
 
-lemma eq_zero_of_num_eq_zero {x : φ.codomain} (h : φ.num x = 0) : x = 0 :=
-φ.num_mul_denom_eq_num_iff_eq'.mp (by rw [zero_mul, h, ring_hom.map_zero])
+lemma num_mul_denom_eq_num_mul_denom_iff_eq {x y : K} :
+  num A y * denom A x = num A x * denom A y ↔ x = y :=
+⟨λ h, by simpa only [mk'_num_denom] using mk'_eq_of_eq h,
+ λ h, by rw h⟩
 
-lemma is_integer_of_is_unit_denom {x : φ.codomain} (h : is_unit (φ.denom x : A)) : φ.is_integer x :=
+lemma eq_zero_of_num_eq_zero {x : K} (h : num A x = 0) : x = 0 :=
+num_mul_denom_eq_num_iff_eq'.mp (by rw [zero_mul, h, ring_hom.map_zero])
+
+lemma is_integer_of_is_unit_denom {x : K} (h : is_unit (denom A x : A)) : is_integer A x :=
 begin
   cases h with d hd,
-  have d_ne_zero : φ.to_map (φ.denom x) ≠ 0 :=
-    φ.to_map_ne_zero_of_mem_non_zero_divisors (φ.denom x).2,
-  use ↑d⁻¹ * φ.num x,
-  refine trans _ (φ.mk'_num_denom x),
-  rw [φ.to_map.map_mul, φ.to_map.map_units_inv, hd],
+  have d_ne_zero : algebra_map A K (denom A x) ≠ 0 :=
+    is_fraction_ring.to_map_ne_zero_of_mem_non_zero_divisors (denom A x).2,
+  use ↑d⁻¹ * num A x,
+  refine trans _ (mk'_num_denom A x),
+  rw [ring_hom.map_mul, ring_hom.map_units_inv, hd],
   apply mul_left_cancel' d_ne_zero,
-  rw [←mul_assoc, mul_inv_cancel d_ne_zero, one_mul, φ.mk'_spec']
+  rw [←mul_assoc, mul_inv_cancel d_ne_zero, one_mul, mk'_spec']
 end
 
-lemma is_unit_denom_of_num_eq_zero {x : φ.codomain} (h : φ.num x = 0) : is_unit (φ.denom x : A) :=
-φ.num_denom_reduced x (h.symm ▸ dvd_zero _) (dvd_refl _)
+lemma is_unit_denom_of_num_eq_zero {x : K} (h : num A x = 0) : is_unit (denom A x : A) :=
+num_denom_reduced A x (h.symm ▸ dvd_zero _) (dvd_refl _)
 
 end num_denom
 
-end fraction_map
+end is_fraction_ring
 
 section algebra
 
 section is_integral
-variables {R S} {Rₘ Sₘ : Type*} [comm_ring Rₘ] [comm_ring Sₘ] [algebra R S]
+variables {R S} {Rₘ Sₘ : Type*} [comm_ring Rₘ] [comm_ring Sₘ]
+variables [algebra R Rₘ] [is_localization M Rₘ]
+variables [algebra S Sₘ] [is_localization (algebra.algebra_map_submonoid S M) Sₘ]
+
+section
+
+variables (S M)
 
 /-- Definition of the natural algebra induced by the localization of an algebra.
 Given an algebra `R → S`, a submonoid `R` of `M`, and a localization `Rₘ` for `M`,
 let `Sₘ` be the localization of `S` to the image of `M` under `algebra_map R S`.
 Then this is the natural algebra structure on `Rₘ → Sₘ`, such that the entire square commutes,
 where `localization_map.map_comp` gives the commutativity of the underlying maps -/
-noncomputable def localization_algebra (M : submonoid R) (f : localization_map M Rₘ)
-  (g : localization_map (algebra.algebra_map_submonoid S M) Sₘ) : algebra Rₘ Sₘ :=
-(f.map (@algebra.mem_algebra_map_submonoid_of_mem R S _ _ _ _) g).to_algebra
+noncomputable def localization_algebra : algebra Rₘ Sₘ :=
+(map Rₘ Sₘ (@algebra.mem_algebra_map_submonoid_of_mem R S _ _ _ M)).to_algebra
 
-variables (f : localization_map M Rₘ)
-variables (g : localization_map (algebra.algebra_map_submonoid S M) Sₘ)
+end
 
 lemma algebra_map_mk' (r : R) (m : M) :
-  (@algebra_map Rₘ Sₘ _ _ (localization_algebra M f g)) (f.mk' r m) =
-    g.mk' (algebra_map R S r) ⟨algebra_map R S m, algebra.mem_algebra_map_submonoid_of_mem m⟩ :=
-localization_map.map_mk' f _ r m
+  (@algebra_map Rₘ Sₘ _ _ (localization_algebra M S)) (mk' Rₘ r m) =
+    mk' Sₘ (algebra_map R S r) ⟨algebra_map R S m, algebra.mem_algebra_map_submonoid_of_mem m⟩ :=
+map_mk' _ r m
 
 /-- Injectivity of a map descends to the map induced on localizations. -/
 lemma map_injective_of_injective {R S : Type*} [comm_ring R] [comm_ring S]
   (ϕ : R →+* S) (hϕ : function.injective ϕ) (M : submonoid R)
-  (f : localization_map M Rₘ) (g : localization_map (M.map ϕ : submonoid S) Sₘ)
+  [algebra R Rₘ] [is_localization M Rₘ] [algebra S Sₘ] [is_localization (M.map ϕ : submonoid S) Sₘ]
   (hM : (M.map ϕ : submonoid S) ≤ non_zero_divisors S) :
-  function.injective (f.map (M.apply_coe_mem_map (ϕ : R →* S)) g) :=
+  function.injective (map Rₘ Sₘ (M.apply_coe_mem_map (ϕ : R →* S))) :=
 begin
   rintros x y hxy,
-  obtain ⟨a, b, rfl⟩ := localization_map.mk'_surjective f x,
-  obtain ⟨c, d, rfl⟩ := localization_map.mk'_surjective f y,
-  rw [localization_map.map_mk' f _ a b, localization_map.map_mk' f _ c d,
-    localization_map.mk'_eq_iff_eq] at hxy,
-  refine (localization_map.mk'_eq_iff_eq f).2 (congr_arg f.to_map (hϕ _)),
-  convert g.injective hM hxy; simp,
+  obtain ⟨a, b, rfl⟩ := mk'_surjective M x,
+  obtain ⟨c, d, rfl⟩ := mk'_surjective M y,
+  rw [map_mk' _ a b, map_mk' _ c d, mk'_eq_iff_eq] at hxy,
+  refine mk'_eq_iff_eq.2 (congr_arg (algebra_map R Rₘ) (hϕ _)),
+  convert is_localization.injective _ hM hxy; simp,
 end
 
 /-- Injectivity of the underlying `algebra_map` descends to the algebra induced by localization. -/
 lemma localization_algebra_injective (hRS : function.injective (algebra_map R S))
   (hM : algebra.algebra_map_submonoid S M ≤ non_zero_divisors S) :
-  function.injective (@algebra_map Rₘ Sₘ _ _ (localization_algebra M f g)) :=
-map_injective_of_injective (algebra_map R S) hRS M f g hM
+  function.injective (@algebra_map Rₘ Sₘ _ _ (localization_algebra M S)) :=
+map_injective_of_injective (algebra_map R S) hRS M hM
 
 open polynomial
 
@@ -1584,21 +1579,21 @@ lemma ring_hom.is_integral_elem_localization_at_leading_coeff
   {R S : Type*} [comm_ring R] [comm_ring S] (f : R →+* S)
   (x : S) (p : polynomial R) (hf : p.eval₂ f x = 0) (M : submonoid R)
   (hM : p.leading_coeff ∈ M) {Rₘ Sₘ : Type*} [comm_ring Rₘ] [comm_ring Sₘ]
-  (ϕ : localization_map M Rₘ) (ϕ' : localization_map (M.map ↑f : submonoid S) Sₘ) :
-  (ϕ.map (M.apply_coe_mem_map (f : R →* S)) ϕ').is_integral_elem (ϕ'.to_map x) :=
+  [algebra R Rₘ] [is_localization M Rₘ] [algebra S Sₘ] [is_localization (M.map f : submonoid S) Sₘ] :
+  (map Rₘ Sₘ (M.apply_coe_mem_map (f : R →* S))).is_integral_elem (algebra_map S Sₘ x) :=
 begin
   by_cases triv : (1 : Rₘ) = 0,
   { exact ⟨0, ⟨trans leading_coeff_zero triv.symm, eval₂_zero _ _⟩⟩ },
   haveI : nontrivial Rₘ := nontrivial_of_ne 1 0 triv,
   obtain ⟨b, hb⟩ := is_unit_iff_exists_inv.mp
-    (localization_map.map_units ϕ ⟨p.leading_coeff, hM⟩),
-  refine ⟨(p.map ϕ.to_map) * C b, ⟨_, _⟩⟩,
+    (map_units Rₘ ⟨p.leading_coeff, hM⟩),
+  refine ⟨(p.map (algebra_map R Rₘ)) * C b, ⟨_, _⟩⟩,
   { refine monic_mul_C_of_leading_coeff_mul_eq_one _,
-    rwa leading_coeff_map_of_leading_coeff_ne_zero ϕ.to_map,
+    rwa leading_coeff_map_of_leading_coeff_ne_zero (algebra_map R Rₘ),
     refine λ hfp, zero_ne_one (trans (zero_mul b).symm (hfp ▸ hb) : (0 : Rₘ) = 1) },
   { refine eval₂_mul_eq_zero_of_left _ _ _ _,
-    erw [eval₂_map, localization_map.map_comp, ← hom_eval₂ _ f ϕ'.to_map x],
-    exact trans (congr_arg ϕ'.to_map hf) ϕ'.to_map.map_zero }
+    erw [eval₂_map, is_localization.map_comp, ← hom_eval₂ _ f (algebra_map S Sₘ) x],
+    exact trans (congr_arg (algebra_map S Sₘ) hf) (ring_hom.map_zero _) }
 end
 
 /-- Given a particular witness to an element being algebraic over an algebra `R → S`,
@@ -1606,74 +1601,73 @@ We can localize to a submonoid containing the leading coefficient to make it int
 Explicitly, the map between the localizations will be an integral ring morphism -/
 theorem is_integral_localization_at_leading_coeff {x : S} (p : polynomial R)
   (hp : aeval x p = 0) (hM : p.leading_coeff ∈ M) :
-  (f.map (@algebra.mem_algebra_map_submonoid_of_mem R S _ _ _ _) g).is_integral_elem (g.to_map x) :=
-(algebra_map R S).is_integral_elem_localization_at_leading_coeff x p hp M hM f g
+  (map Rₘ Sₘ (@algebra.mem_algebra_map_submonoid_of_mem R S _ _ _ M)).is_integral_elem
+    (algebra_map S Sₘ x) :=
+(algebra_map R S).is_integral_elem_localization_at_leading_coeff x p hp M hM
 
 /-- If `R → S` is an integral extension, `M` is a submonoid of `R`,
 `Rₘ` is the localization of `R` at `M`,
 and `Sₘ` is the localization of `S` at the image of `M` under the extension map,
 then the induced map `Rₘ → Sₘ` is also an integral extension -/
 theorem is_integral_localization (H : algebra.is_integral R S) :
-  (f.map (@algebra.mem_algebra_map_submonoid_of_mem R S _ _ _ _) g).is_integral :=
+  (map Rₘ Sₘ (@algebra.mem_algebra_map_submonoid_of_mem R S _ _ _ M)).is_integral :=
 begin
   intro x,
   by_cases triv : (1 : R) = 0,
-  { have : (1 : Rₘ) = 0 := by convert congr_arg f.to_map triv; simp,
+  { have : (1 : Rₘ) = 0 := by convert congr_arg (algebra_map R Rₘ) triv; simp,
     exact ⟨0, ⟨trans leading_coeff_zero this.symm, eval₂_zero _ _⟩⟩ },
   { haveI : nontrivial R := nontrivial_of_ne 1 0 triv,
-    obtain ⟨⟨s, ⟨u, hu⟩⟩, hx⟩ := g.surj x,
+    obtain ⟨⟨s, ⟨u, hu⟩⟩, hx⟩ := surj (algebra.algebra_map_submonoid S M) x,
     obtain ⟨v, hv⟩ := hu,
-    obtain ⟨v', hv'⟩ := is_unit_iff_exists_inv'.1 (f.map_units ⟨v, hv.1⟩),
+    obtain ⟨v', hv'⟩ := is_unit_iff_exists_inv'.1 (map_units Rₘ ⟨v, hv.1⟩),
     refine @is_integral_of_is_integral_mul_unit Rₘ _ _ _
-      (localization_algebra M f g) x (g.to_map u) v' _ _,
-    { replace hv' := congr_arg (@algebra_map Rₘ Sₘ _ _ (localization_algebra M f g)) hv',
-      rw [ring_hom.map_mul, ring_hom.map_one, ← ring_hom.comp_apply _ f.to_map] at hv',
-      erw localization_map.map_comp at hv',
+      (localization_algebra M S) x (algebra_map S Sₘ u) v' _ _,
+    { replace hv' := congr_arg (@algebra_map Rₘ Sₘ _ _ (localization_algebra M S)) hv',
+      rw [ring_hom.map_mul, ring_hom.map_one, ← ring_hom.comp_apply _ (algebra_map R Rₘ)] at hv',
+      erw is_localization.map_comp at hv',
       exact hv.2 ▸ hv' },
     { obtain ⟨p, hp⟩ := H s,
-      exact hx.symm ▸ is_integral_localization_at_leading_coeff
-        f g p hp.2 (hp.1.symm ▸ M.one_mem) } }
+      exact hx.symm ▸ is_integral_localization_at_leading_coeff p hp.2 (hp.1.symm ▸ M.one_mem) } }
 end
 
 lemma is_integral_localization' {R S : Type*} [comm_ring R] [comm_ring S]
   {f : R →+* S} (hf : f.is_integral) (M : submonoid R) :
-  ((localization.of M).map (M.apply_coe_mem_map (f : R →* S))
-  (localization.of (M.map ↑f))).is_integral :=
-@is_integral_localization R _ M S _ _ _ _ _ f.to_algebra _ _ hf
+  (map (localization M) (localization (M.map (f : R →* S)))
+    (M.apply_coe_mem_map (f : R →* S))).is_integral :=
+@is_integral_localization R _ M S _ f.to_algebra _ _ _ _ _ _ _ _ hf
 
 end is_integral
 
 namespace integral_closure
 
-variables {L : Type*} [field K] [field L] (f : fraction_map A K)
+variables {L : Type*} [field K] [field L] [algebra A K] [is_fraction_ring A K]
 
 open algebra
 
 /-- If the field `L` is an algebraic extension of the integral domain `A`,
 the integral closure of `A` in `L` has fraction field `L`. -/
-def fraction_map_of_algebraic [algebra A L] (alg : is_algebraic A L)
+def is_fraction_ring_of_algebraic [algebra A L] (alg : is_algebraic A L)
   (inj : ∀ x, algebra_map A L x = 0 → x = 0) :
-  fraction_map (integral_closure A L) L :=
-(algebra_map (integral_closure A L) L).to_localization_map
-  (λ ⟨⟨y, integral⟩, nonzero⟩,
-    have y ≠ 0 := λ h, mem_non_zero_divisors_iff_ne_zero.mp nonzero (subtype.ext_iff_val.mpr h),
-    show is_unit y, from ⟨⟨y, y⁻¹, mul_inv_cancel this, inv_mul_cancel this⟩, rfl⟩)
-  (λ z, let ⟨x, y, hy, hxy⟩ := exists_integral_multiple (alg z) inj in
-    ⟨⟨x, ⟨y, mem_non_zero_divisors_iff_ne_zero.mpr hy⟩⟩, hxy⟩)
-  (λ x y, ⟨ λ (h : x.1 = y.1), ⟨1, by simpa using subtype.ext_iff_val.mpr h⟩,
-            λ ⟨c, hc⟩, congr_arg (algebra_map _ L)
-              (mul_right_cancel' (mem_non_zero_divisors_iff_ne_zero.mp c.2) hc) ⟩)
+  is_fraction_ring (integral_closure A L) L :=
+⟨(λ ⟨⟨y, integral⟩, nonzero⟩,
+   have y ≠ 0 := λ h, mem_non_zero_divisors_iff_ne_zero.mp nonzero (subtype.ext_iff_val.mpr h),
+   show is_unit y, from ⟨⟨y, y⁻¹, mul_inv_cancel this, inv_mul_cancel this⟩, rfl⟩),
+ (λ z, let ⟨x, y, hy, hxy⟩ := exists_integral_multiple (alg z) inj in
+   ⟨⟨x, ⟨y, mem_non_zero_divisors_iff_ne_zero.mpr hy⟩⟩, hxy⟩),
+ (λ x y, ⟨λ (h : x.1 = y.1), ⟨1, by simpa using subtype.ext_iff_val.mpr h⟩,
+          λ ⟨c, hc⟩, congr_arg (algebra_map _ L)
+            (mul_right_cancel' (mem_non_zero_divisors_iff_ne_zero.mp c.2) hc)⟩)⟩
 
 variables {K} (L)
 
 /-- If the field `L` is a finite extension of the fraction field of the integral domain `A`,
 the integral closure of `A` in `L` has fraction field `L`. -/
-def fraction_map_of_finite_extension [algebra A L] [algebra f.codomain L]
-  [is_scalar_tower A f.codomain L] [finite_dimensional f.codomain L] :
-  fraction_map (integral_closure A L) L :=
-fraction_map_of_algebraic
-  (f.comap_is_algebraic_iff.mpr is_algebraic_of_finite)
-  (λ x hx, f.to_map_eq_zero_iff.mp ((algebra_map f.codomain L).map_eq_zero.mp $
+instance is_fraction_ring_of_finite_extension [algebra A L] [algebra K L]
+  [is_scalar_tower A K L] [finite_dimensional K L] :
+  is_fraction_ring (integral_closure A L) L :=
+is_fraction_ring_of_algebraic
+  (is_fraction_ring.comap_is_algebraic_iff.mpr (is_algebraic_of_finite : is_algebraic K L))
+  (λ x hx, is_fraction_ring.to_map_eq_zero_iff.mp ((algebra_map K L).map_eq_zero.mp $
     (is_scalar_tower.algebra_map_apply _ _ _ _).symm.trans hx))
 
 end integral_closure
@@ -1687,28 +1681,20 @@ variables (A)
 
 namespace fraction_ring
 
-/-- Natural hom sending `x : A`, `A` an integral domain, to the equivalence class of
-`(x, 1)` in the field of fractions of `A`. -/
-def of : fraction_map A (localization (non_zero_divisors A)) :=
-localization.of (non_zero_divisors A)
-
 variables {A}
 
 noncomputable instance : field (fraction_ring A) :=
-(of A).to_field
+is_fraction_ring.to_field A
 
 @[simp] lemma mk_eq_div {r s} : (localization.mk r s : fraction_ring A) =
-  ((of A).to_map r / (of A).to_map s : fraction_ring A) :=
-by erw [localization.mk_eq_mk', (of A).mk'_eq_div]
+  (algebra_map _ _ r / algebra_map A _ s : fraction_ring A) :=
+by erw [localization.mk_eq_mk', is_fraction_ring.mk'_eq_div]
 
 /-- Given an integral domain `A` and a localization map to a field of fractions
 `f : A →+* K`, we get an `A`-isomorphism between the field of fractions of `A` as a quotient
 type and `K`. -/
-noncomputable def alg_equiv_of_quotient {K : Type*} [field K] (f : fraction_map A K) :
-  fraction_ring A ≃ₐ[A] f.codomain :=
-localization.alg_equiv_of_quotient f
-
-instance : algebra A (fraction_ring A) :=
-(of A).to_map.to_algebra
+noncomputable def alg_equiv (K : Type*) [field K] [algebra A K] [is_fraction_ring A K] :
+  fraction_ring A ≃ₐ[A] K :=
+localization.alg_equiv (non_zero_divisors A) K
 
 end fraction_ring

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1349,8 +1349,12 @@ lemma to_map_eq_zero_iff {x : R} :
   algebra_map R K x = 0 ↔ x = 0 :=
 to_map_eq_zero_iff _ (le_of_eq rfl)
 
+variables (R K)
+
 protected theorem injective : function.injective (algebra_map R K) :=
 is_localization.injective _ (le_of_eq rfl)
+
+variables {R K}
 
 protected lemma to_map_ne_zero_of_mem_non_zero_divisors [nontrivial R]
   {x : R} (hx : x ∈ non_zero_divisors R) : algebra_map R K x ≠ 0 :=

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -421,10 +421,14 @@ ring_hom.ext $ monoid_hom.ext_iff.1 $ (to_localization_map M S).lift_comp _
   lift (is_unit_comp M j) = j :=
 ring_hom.ext $ monoid_hom.ext_iff.1 $ (to_localization_map M S).lift_of_comp j.to_monoid_hom
 
-lemma epic_of_localization_map {j k : S →+* P}
+variables (M)
+
+lemma epic_of_localization_map (j k : S →+* P)
   (h : ∀ a, j.comp (algebra_map R S) a = k.comp (algebra_map R S) a) : j = k :=
 ring_hom.ext $ monoid_hom.ext_iff.1 $ @submonoid.localization_map.epic_of_localization_map
   _ _ _ _ _ _ _ (to_localization_map M S) j.to_monoid_hom k.to_monoid_hom h
+
+variables {M}
 
 lemma lift_unique {j : S →+* P}
   (hj : ∀ x, j ((algebra_map R S) x) = g x) : lift hg = j :=
@@ -1113,6 +1117,24 @@ protected lemma to_map_ne_zero_of_mem_non_zero_divisors [nontrivial R]
   (hM : M ≤ non_zero_divisors R) {x : R} (hx : x ∈ non_zero_divisors R) : algebra_map R S x ≠ 0 :=
 map_ne_zero_of_mem_non_zero_divisors (is_localization.injective S hM) hx
 
+variables (S Q M)
+
+/-- Injectivity of a map descends to the map induced on localizations. -/
+lemma map_injective_of_injective
+  (hg : function.injective g) [is_localization (M.map g : submonoid P) Q]
+  (hM : (M.map g : submonoid P) ≤ non_zero_divisors P) :
+  function.injective (map Q g M.le_comap_map : S → Q) :=
+begin
+  rintros x y hxy,
+  obtain ⟨a, b, rfl⟩ := mk'_surjective M x,
+  obtain ⟨c, d, rfl⟩ := mk'_surjective M y,
+  rw [map_mk' _ a b, map_mk' _ c d, mk'_eq_iff_eq] at hxy,
+  refine mk'_eq_iff_eq.2 (congr_arg (algebra_map _ _) (hg _)),
+  convert is_localization.injective _ hM hxy; simp,
+end
+
+variables (S) {Q M}
+
 /-- A `comm_ring` `S` which is the localization of an integral domain `R` at a subset of
 non-zero elements is an integral domain. -/
 def integral_domain_of_le_non_zero_divisors [algebra A S] {M : submonoid A} [is_localization M S]
@@ -1563,26 +1585,15 @@ lemma algebra_map_mk' (r : R) (m : M) :
     mk' Sₘ (algebra_map R S r) ⟨algebra_map R S m, algebra.mem_algebra_map_submonoid_of_mem m⟩ :=
 map_mk' _ _ _
 
-/-- Injectivity of a map descends to the map induced on localizations. -/
-lemma map_injective_of_injective {R S : Type*} [comm_ring R] [comm_ring S]
-  (ϕ : R →+* S) (hϕ : function.injective ϕ) (M : submonoid R)
-  [algebra R Rₘ] [is_localization M Rₘ] [algebra S Sₘ] [is_localization (M.map ϕ : submonoid S) Sₘ]
-  (hM : (M.map ϕ : submonoid S) ≤ non_zero_divisors S) :
-  function.injective (map Sₘ ϕ M.le_comap_map : Rₘ → Sₘ) :=
-begin
-  rintros x y hxy,
-  obtain ⟨a, b, rfl⟩ := mk'_surjective M x,
-  obtain ⟨c, d, rfl⟩ := mk'_surjective M y,
-  rw [map_mk' _ a b, map_mk' _ c d, mk'_eq_iff_eq] at hxy,
-  refine mk'_eq_iff_eq.2 (congr_arg (algebra_map R Rₘ) (hϕ _)),
-  convert is_localization.injective _ hM hxy; simp,
-end
+variables (Rₘ Sₘ)
 
 /-- Injectivity of the underlying `algebra_map` descends to the algebra induced by localization. -/
 lemma localization_algebra_injective (hRS : function.injective (algebra_map R S))
   (hM : algebra.algebra_map_submonoid S M ≤ non_zero_divisors S) :
   function.injective (@algebra_map Rₘ Sₘ _ _ (localization_algebra M S)) :=
-map_injective_of_injective (algebra_map R S) hRS M hM
+is_localization.map_injective_of_injective M Rₘ Sₘ hRS hM
+
+variables {Rₘ Sₘ}
 
 open polynomial
 

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1715,6 +1715,8 @@ is_fraction_ring.to_field A
   (algebra_map _ _ r / algebra_map A _ s : fraction_ring A) :=
 by rw [localization.mk_eq_mk', is_fraction_ring.mk'_eq_div]
 
+variables (A)
+
 /-- Given an integral domain `A` and a localization map to a field of fractions
 `f : A →+* K`, we get an `A`-isomorphism between the field of fractions of `A` as a quotient
 type and `K`. -/

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -178,7 +178,7 @@ lemma exists_integer_multiple (a : S) :
   ∃ (b : M), is_integer R ((b : R) • a) :=
 by { simp_rw [algebra.smul_def, mul_comm _ a], apply exists_integer_multiple' }
 
-/-- Given `z : S`, `is_localization.sec z` is defined to be a pair `(x, y) : R × M` such
+/-- Given `z : S`, `(to_localization_map M S).sec z` is defined to be a pair `(x, y) : R × M` such
 that `z * f y = f x` (so this lemma is true by definition). -/
 lemma sec_spec (z : S) :
   z * algebra_map R S ((to_localization_map M S).sec z).2 =

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1675,7 +1675,7 @@ open algebra
 
 /-- If the field `L` is an algebraic extension of the integral domain `A`,
 the integral closure of `A` in `L` has fraction field `L`. -/
-def is_fraction_ring_of_algebraic [algebra A L] (alg : is_algebraic A L)
+lemma is_fraction_ring_of_algebraic [algebra A L] (alg : is_algebraic A L)
   (inj : ∀ x, algebra_map A L x = 0 → x = 0) :
   is_fraction_ring (integral_closure A L) L :=
 ⟨(λ ⟨⟨y, integral⟩, nonzero⟩,
@@ -1687,11 +1687,11 @@ def is_fraction_ring_of_algebraic [algebra A L] (alg : is_algebraic A L)
           λ ⟨c, hc⟩, congr_arg (algebra_map _ L)
             (mul_right_cancel' (mem_non_zero_divisors_iff_ne_zero.mp c.2) hc)⟩)⟩
 
-variables {K} (L)
+variables (K L)
 
 /-- If the field `L` is a finite extension of the fraction field of the integral domain `A`,
 the integral closure of `A` in `L` has fraction field `L`. -/
-instance is_fraction_ring_of_finite_extension [algebra A L] [algebra K L]
+lemma is_fraction_ring_of_finite_extension [algebra A L] [algebra K L]
   [is_scalar_tower A K L] [finite_dimensional K L] :
   is_fraction_ring (integral_closure A L) L :=
 is_fraction_ring_of_algebraic

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -424,8 +424,9 @@ open_locale arithmetic_function
 
 /-- `cyclotomic n R` can be expressed as a product in a fraction field of `polynomial R`
   using Möbius inversion. -/
-lemma cyclotomic_eq_prod_X_pow_sub_one_pow_moebius {n : ℕ} (hpos : 0 < n) (R : Type*) [comm_ring R]
-  [nontrivial R] {K : Type*} [field K] [algebra (polynomial R) K] [is_fraction_ring (polynomial R) K] :
+lemma cyclotomic_eq_prod_X_pow_sub_one_pow_moebius {n : ℕ} (hpos : 0 < n)
+  (R : Type*) [comm_ring R] [nontrivial R]
+  {K : Type*} [field K] [algebra (polynomial R) K] [is_fraction_ring (polynomial R) K] :
   algebra_map _ K (cyclotomic n R) =
     ∏ i in n.divisors_antidiagonal, (algebra_map (polynomial R) K (X ^ i.snd - 1)) ^ μ i.fst :=
 begin

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -668,7 +668,7 @@ lemma minpoly_primitive_root_dvd_cyclotomic {n : ℕ} {K : Type*} [field K] {μ 
   (h : is_primitive_root μ n) (hpos : 0 < n) [char_zero K] :
   minpoly ℤ μ ∣ cyclotomic n ℤ :=
 begin
-  apply minpoly.integer_dvd (is_integral h hpos) (cyclotomic.monic n ℤ).is_primitive,
+  apply minpoly.gcd_domain_dvd ℚ (is_integral h hpos) (cyclotomic.monic n ℤ).is_primitive,
   simpa [aeval_def, eval₂_eq_eval_map, is_root.def] using is_root_cyclotomic hpos h
 end
 

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -425,16 +425,16 @@ open_locale arithmetic_function
 /-- `cyclotomic n R` can be expressed as a product in a fraction field of `polynomial R`
   using Möbius inversion. -/
 lemma cyclotomic_eq_prod_X_pow_sub_one_pow_moebius {n : ℕ} (hpos : 0 < n) (R : Type*) [comm_ring R]
-  [nontrivial R] {K : Type*} [field K] (f : fraction_map (polynomial R) K) :
-  f.to_map (cyclotomic n R) =
-    ∏ i in n.divisors_antidiagonal, (f.to_map (X ^ i.snd - 1)) ^ μ i.fst :=
+  [nontrivial R] {K : Type*} [field K] [algebra (polynomial R) K] [is_fraction_ring (polynomial R) K] :
+  algebra_map _ K (cyclotomic n R) =
+    ∏ i in n.divisors_antidiagonal, (algebra_map (polynomial R) K (X ^ i.snd - 1)) ^ μ i.fst :=
 begin
   have h : ∀ (n : ℕ), 0 < n →
-    ∏ i in nat.divisors n, f.to_map (cyclotomic i R) = f.to_map (X ^ n - 1),
+    ∏ i in nat.divisors n, algebra_map _ K (cyclotomic i R) = algebra_map _ _ (X ^ n - 1),
   { intros n hn,
     rw [← prod_cyclotomic_eq_X_pow_sub_one hn R, ring_hom.map_prod] },
   rw (prod_eq_iff_prod_pow_moebius_eq_of_nonzero (λ n hn, _) (λ n hn, _)).1 h n hpos;
-  rw [ne.def, fraction_map.to_map_eq_zero_iff],
+  rw [ne.def, is_fraction_ring.to_map_eq_zero_iff],
   { apply cyclotomic_ne_zero },
   { apply monic.ne_zero,
     apply monic_X_pow_sub_C _ (ne_of_gt hn) }

--- a/src/ring_theory/polynomial/dickson.lean
+++ b/src/ring_theory/polynomial/dickson.lean
@@ -188,7 +188,7 @@ begin
     haveI : char_p K p := by { rw ← f.char_p_iff_char_p, apply_instance },
     haveI : infinite K :=
     infinite.of_injective (algebra_map (polynomial (zmod p)) (fraction_ring (polynomial (zmod p))))
-      is_fraction_ring.injective,
+      (is_fraction_ring.injective _ _),
     refine ⟨K, _, _, _⟩; apply_instance },
   resetI,
   apply map_injective (zmod.cast_hom (dvd_refl p) K) (ring_hom.injective _),

--- a/src/ring_theory/polynomial/dickson.lean
+++ b/src/ring_theory/polynomial/dickson.lean
@@ -184,10 +184,11 @@ begin
   -- For this argument, we need an arbitrary infinite field of characteristic `p`.
   obtain ⟨K, _, _, H⟩ : ∃ (K : Type) [field K], by exactI ∃ [char_p K p], infinite K,
   { let K := fraction_ring (polynomial (zmod p)),
-    let f : zmod p →+* K := (fraction_ring.of _).to_map.comp C,
+    let f : zmod p →+* K := (algebra_map _ (fraction_ring _)).comp C,
     haveI : char_p K p := by { rw ← f.char_p_iff_char_p, apply_instance },
     haveI : infinite K :=
-    by { apply infinite.of_injective _ (fraction_ring.of _).injective, apply_instance },
+    infinite.of_injective (algebra_map (polynomial (zmod p)) (fraction_ring (polynomial (zmod p))))
+      is_fraction_ring.injective,
     refine ⟨K, _, _, _⟩; apply_instance },
   resetI,
   apply map_injective (zmod.cast_hom (dvd_refl p) K) (ring_hom.injective _),

--- a/src/ring_theory/polynomial/gauss_lemma.lean
+++ b/src/ring_theory/polynomial/gauss_lemma.lean
@@ -77,7 +77,7 @@ lemma is_unit_or_eq_zero_of_is_unit_integer_normalization_prim_part
 begin
   rcases is_unit_iff.1 h with ⟨_, ⟨u, rfl⟩, hu⟩,
   obtain ⟨⟨c, c0⟩, hc⟩ := integer_normalization_map_to_map R⁰ p,
-  rw [algebra.smul_def, ← C_eq_algebra_map, subtype.coe_mk] at hc,
+  rw [subtype.coe_mk, algebra.smul_def, algebra_map_apply] at hc,
   apply is_unit_of_mul_is_unit_right,
   rw [← hc, (integer_normalization R⁰ p).eq_C_content_mul_prim_part, ← hu,
     ← ring_hom.map_mul, is_unit_iff],
@@ -100,7 +100,7 @@ begin
     hp.irreducible_of_irreducible_map_of_injective (is_fraction_ring.injective _ _)⟩,
   obtain ⟨⟨c, c0⟩, hc⟩ := integer_normalization_map_to_map R⁰ a,
   obtain ⟨⟨d, d0⟩, hd⟩ := integer_normalization_map_to_map R⁰ b,
-  rw [algebra.smul_def, ← C_eq_algebra_map, subtype.coe_mk] at hc hd,
+  rw [algebra.smul_def, algebra_map_apply, subtype.coe_mk] at hc hd,
   rw mem_non_zero_divisors_iff_ne_zero at c0 d0,
   have hcd0 : c * d ≠ 0 := mul_ne_zero c0 d0,
   rw [ne.def, ← C_eq_zero] at hcd0,
@@ -139,7 +139,7 @@ lemma is_primitive.dvd_of_fraction_map_dvd_fraction_map {p q : polynomial R}
 begin
   rcases h_dvd with ⟨r, hr⟩,
   obtain ⟨⟨s, s0⟩, hs⟩ := integer_normalization_map_to_map R⁰ r,
-  rw [algebra.smul_def, ← C_eq_algebra_map, subtype.coe_mk] at hs,
+  rw [subtype.coe_mk, algebra.smul_def, algebra_map_apply] at hs,
   have h : p ∣ q * C s,
   { use (integer_normalization R⁰ r),
     apply map_injective (algebra_map R K) (is_fraction_ring.injective _ _),

--- a/src/ring_theory/polynomial/gauss_lemma.lean
+++ b/src/ring_theory/polynomial/gauss_lemma.lean
@@ -157,6 +157,8 @@ begin
     simp [s0, mem_non_zero_divisors_iff_ne_zero] }
 end
 
+variables (K)
+
 lemma is_primitive.dvd_iff_fraction_map_dvd_fraction_map {p q : polynomial R}
   (hp : p.is_primitive) (hq : q.is_primitive) :
   (p ∣ q) ↔ (p.map (algebra_map R K) ∣ q.map (algebra_map R K)) :=
@@ -175,7 +177,7 @@ hp.irreducible_iff_irreducible_map_fraction_map
 lemma is_primitive.int.dvd_iff_map_cast_dvd_map_cast (p q : polynomial ℤ)
   (hp : p.is_primitive) (hq : q.is_primitive) :
   (p ∣ q) ↔ (p.map (int.cast_ring_hom ℚ) ∣ q.map (int.cast_ring_hom ℚ)) :=
-hp.dvd_iff_fraction_map_dvd_fraction_map hq
+hp.dvd_iff_fraction_map_dvd_fraction_map ℚ hq
 
 end gcd_monoid
 end polynomial

--- a/src/ring_theory/polynomial/gauss_lemma.lean
+++ b/src/ring_theory/polynomial/gauss_lemma.lean
@@ -23,6 +23,8 @@ Gauss's Lemma is one of a few results pertaining to irreducibility of primitive 
 
 -/
 
+local notation R`⁰`:9000 := non_zero_divisors R
+
 variables {R : Type*} [integral_domain R]
 
 namespace polynomial
@@ -61,28 +63,28 @@ end
 end
 
 section fraction_map
-variables {K : Type*} [field K] (f : fraction_map R K)
+variables {K : Type*} [field K] [algebra R K] [is_fraction_ring R K]
 
 lemma is_primitive.is_unit_iff_is_unit_map {p : polynomial R} (hp : p.is_primitive) :
-  is_unit p ↔ is_unit (p.map f.to_map) :=
-hp.is_unit_iff_is_unit_map_of_injective f.injective
+  is_unit p ↔ is_unit (p.map (algebra_map R K)) :=
+hp.is_unit_iff_is_unit_map_of_injective (is_fraction_ring.injective _ _)
 
-open localization_map
+open is_localization
 
 lemma is_unit_or_eq_zero_of_is_unit_integer_normalization_prim_part
-  {p : polynomial K} (h0 : p ≠ 0) (h : is_unit (f.integer_normalization p).prim_part) :
+  {p : polynomial K} (h0 : p ≠ 0) (h : is_unit (integer_normalization R⁰ p).prim_part) :
   is_unit p :=
 begin
   rcases is_unit_iff.1 h with ⟨_, ⟨u, rfl⟩, hu⟩,
-  obtain ⟨⟨c, c0⟩, hc⟩ := @integer_normalization_map_to_map _ _ _ _ _ f p,
+  obtain ⟨⟨c, c0⟩, hc⟩ := integer_normalization_map_to_map R⁰ p,
   rw [algebra.smul_def, ← C_eq_algebra_map, subtype.coe_mk] at hc,
   apply is_unit_of_mul_is_unit_right,
-  rw [← hc, (f.integer_normalization p).eq_C_content_mul_prim_part, ← hu,
+  rw [← hc, (integer_normalization R⁰ p).eq_C_content_mul_prim_part, ← hu,
     ← ring_hom.map_mul, is_unit_iff],
-  refine ⟨f.to_map ((f.integer_normalization p).content * ↑u),
+  refine ⟨algebra_map R K ((integer_normalization R⁰ p).content * ↑u),
     is_unit_iff_ne_zero.2 (λ con, _), by simp⟩,
-  replace con := (ring_hom.injective_iff f.to_map).1 f.injective _ con,
-  rw [mul_eq_zero, content_eq_zero_iff, fraction_map.integer_normalization_eq_zero_iff] at con,
+  replace con := (algebra_map R K).injective_iff.1 (is_fraction_ring.injective _ _) _ con,
+  rw [mul_eq_zero, content_eq_zero_iff, is_fraction_ring.integer_normalization_eq_zero_iff] at con,
   rcases con with con | con,
   { apply h0 con },
   { apply units.ne_zero _ con },
@@ -92,55 +94,55 @@ end
   fraction field. -/
 theorem is_primitive.irreducible_iff_irreducible_map_fraction_map
   {p : polynomial R} (hp : p.is_primitive) :
-  irreducible p ↔ irreducible (p.map f.to_map) :=
+  irreducible p ↔ irreducible (p.map (algebra_map R K)) :=
 begin
-  refine ⟨λ hi, ⟨λ h, hi.not_unit ((hp.is_unit_iff_is_unit_map f).2 h), λ a b hab, _⟩,
-    hp.irreducible_of_irreducible_map_of_injective f.injective⟩,
-  obtain ⟨⟨c, c0⟩, hc⟩ := @integer_normalization_map_to_map _ _ _ _ _ f a,
-  obtain ⟨⟨d, d0⟩, hd⟩ := @integer_normalization_map_to_map _ _ _ _ _ f b,
+  refine ⟨λ hi, ⟨λ h, hi.not_unit (hp.is_unit_iff_is_unit_map.2 h), λ a b hab, _⟩,
+    hp.irreducible_of_irreducible_map_of_injective (is_fraction_ring.injective _ _)⟩,
+  obtain ⟨⟨c, c0⟩, hc⟩ := integer_normalization_map_to_map R⁰ a,
+  obtain ⟨⟨d, d0⟩, hd⟩ := integer_normalization_map_to_map R⁰ b,
   rw [algebra.smul_def, ← C_eq_algebra_map, subtype.coe_mk] at hc hd,
   rw mem_non_zero_divisors_iff_ne_zero at c0 d0,
   have hcd0 : c * d ≠ 0 := mul_ne_zero c0 d0,
   rw [ne.def, ← C_eq_zero] at hcd0,
-  have h1 : C c * C d * p = f.integer_normalization a * f.integer_normalization b,
-  { apply (map_injective _ f.injective _),
+  have h1 : C c * C d * p = integer_normalization R⁰ a * integer_normalization R⁰ b,
+  { apply map_injective (algebra_map R K) (is_fraction_ring.injective _ _) _,
     rw [map_mul, map_mul, map_mul, hc, hd, map_C, map_C, hab],
     ring },
-  obtain ⟨u, hu⟩ : associated (c * d) (content (f.integer_normalization a) *
-            content (f.integer_normalization b)),
+  obtain ⟨u, hu⟩ : associated (c * d) (content (integer_normalization R⁰ a) *
+            content (integer_normalization R⁰ b)),
   { rw [← dvd_dvd_iff_associated, ← normalize_eq_normalize_iff, normalize.map_mul,
         normalize.map_mul, normalize_content, normalize_content,
         ← mul_one (normalize c * normalize d), ← hp.content_eq_one, ← content_C, ← content_C,
         ← content_mul, ← content_mul, ← content_mul, h1] },
   rw [← ring_hom.map_mul, eq_comm,
-    (f.integer_normalization a).eq_C_content_mul_prim_part,
-    (f.integer_normalization b).eq_C_content_mul_prim_part, mul_assoc,
+    (integer_normalization R⁰ a).eq_C_content_mul_prim_part,
+    (integer_normalization R⁰ b).eq_C_content_mul_prim_part, mul_assoc,
     mul_comm _ (C _ * _), ← mul_assoc, ← mul_assoc, ← ring_hom.map_mul, ← hu, ring_hom.map_mul,
     mul_assoc, mul_assoc, ← mul_assoc (C ↑u)] at h1,
   have h0 : (a ≠ 0) ∧ (b ≠ 0),
   { classical,
     rw [ne.def, ne.def, ← decidable.not_or_iff_and_not, ← mul_eq_zero, ← hab],
     intro con,
-    apply hp.ne_zero (map_injective _ f.injective _),
+    apply hp.ne_zero (map_injective (algebra_map R K) (is_fraction_ring.injective _ _) _),
     simp [con] },
   rcases hi.is_unit_or_is_unit (mul_left_cancel' hcd0 h1).symm with h | h,
   { right,
-    apply is_unit_or_eq_zero_of_is_unit_integer_normalization_prim_part f h0.2
+    apply is_unit_or_eq_zero_of_is_unit_integer_normalization_prim_part h0.2
       (is_unit_of_mul_is_unit_right h) },
   { left,
-    apply is_unit_or_eq_zero_of_is_unit_integer_normalization_prim_part f h0.1 h },
+    apply is_unit_or_eq_zero_of_is_unit_integer_normalization_prim_part h0.1 h },
 end
 
 lemma is_primitive.dvd_of_fraction_map_dvd_fraction_map {p q : polynomial R}
-  (hp : p.is_primitive) (hq : q.is_primitive) (h_dvd : p.map f.to_map ∣ q.map f.to_map) :
-  (p ∣ q) :=
+  (hp : p.is_primitive) (hq : q.is_primitive)
+  (h_dvd : p.map (algebra_map R K) ∣ q.map (algebra_map R K)) : p ∣ q :=
 begin
   rcases h_dvd with ⟨r, hr⟩,
-  obtain ⟨⟨s, s0⟩, hs⟩ := @integer_normalization_map_to_map _ _ _ _ _ f r,
+  obtain ⟨⟨s, s0⟩, hs⟩ := integer_normalization_map_to_map R⁰ r,
   rw [algebra.smul_def, ← C_eq_algebra_map, subtype.coe_mk] at hs,
   have h : p ∣ q * C s,
-  { use (f.integer_normalization r),
-    apply map_injective _ f.injective,
+  { use (integer_normalization R⁰ r),
+    apply map_injective (algebra_map R K) (is_fraction_ring.injective _ _),
     rw [map_mul, map_mul, hs, hr, mul_assoc, mul_comm r],
     simp },
   rw [← hp.dvd_prim_part_iff_dvd, prim_part_mul, hq.prim_part_eq, dvd_iff_dvd_of_rel_right] at h,
@@ -157,9 +159,9 @@ end
 
 lemma is_primitive.dvd_iff_fraction_map_dvd_fraction_map {p q : polynomial R}
   (hp : p.is_primitive) (hq : q.is_primitive) :
-  (p ∣ q) ↔ (p.map f.to_map ∣ q.map f.to_map) :=
-⟨λ ⟨a,b⟩, ⟨a.map f.to_map, b.symm ▸ (map_mul f.to_map)⟩,
-  λ h, hp.dvd_of_fraction_map_dvd_fraction_map f hq h⟩
+  (p ∣ q) ↔ (p.map (algebra_map R K) ∣ q.map (algebra_map R K)) :=
+⟨λ ⟨a,b⟩, ⟨a.map (algebra_map R K), b.symm ▸ map_mul (algebra_map R K)⟩,
+  λ h, hp.dvd_of_fraction_map_dvd_fraction_map hq h⟩
 
 end fraction_map
 
@@ -168,12 +170,12 @@ end fraction_map
 theorem is_primitive.int.irreducible_iff_irreducible_map_cast
   {p : polynomial ℤ} (hp : p.is_primitive) :
   irreducible p ↔ irreducible (p.map (int.cast_ring_hom ℚ)) :=
-hp.irreducible_iff_irreducible_map_fraction_map fraction_map.int.fraction_map
+hp.irreducible_iff_irreducible_map_fraction_map
 
 lemma is_primitive.int.dvd_iff_map_cast_dvd_map_cast (p q : polynomial ℤ)
   (hp : p.is_primitive) (hq : q.is_primitive) :
   (p ∣ q) ↔ (p.map (int.cast_ring_hom ℚ) ∣ q.map (int.cast_ring_hom ℚ)) :=
-hp.dvd_iff_fraction_map_dvd_fraction_map fraction_map.int.fraction_map hq
+hp.dvd_iff_fraction_map_dvd_fraction_map hq
 
 end gcd_monoid
 end polynomial

--- a/src/ring_theory/polynomial/rational_root.lean
+++ b/src/ring_theory/polynomial/rational_root.lean
@@ -27,28 +27,25 @@ Finally, we use this to show unique factorization domains are integrally closed.
 section scale_roots
 
 variables {A K R S : Type*} [integral_domain A] [field K] [comm_ring R] [comm_ring S]
-variables {M : submonoid A} {f : localization_map M S} {g : fraction_map A K}
+variables {M : submonoid A} [algebra A S] [is_localization M S] [algebra A K] [is_fraction_ring A K]
 
-open finsupp polynomial
+open finsupp is_fraction_ring is_localization polynomial
 
 lemma scale_roots_aeval_eq_zero_of_aeval_mk'_eq_zero {p : polynomial A} {r : A} {s : M}
-  (hr : @aeval A f.codomain _ _ _ (f.mk' r s) p = 0) :
-  @aeval A f.codomain _ _ _ (f.to_map r) (scale_roots p s) = 0 :=
+  (hr : aeval (mk' S r s) p = 0) :
+  aeval (algebra_map A S r) (scale_roots p s) = 0 :=
 begin
-  convert scale_roots_eval₂_eq_zero f.to_map hr,
-  rw aeval_def,
-  congr,
-  apply (f.mk'_spec' r s).symm
+  convert scale_roots_eval₂_eq_zero (algebra_map A S) hr,
+  rw [aeval_def, mk'_spec' _ r s]
 end
 
 lemma num_is_root_scale_roots_of_aeval_eq_zero
-  [unique_factorization_monoid A] (g : fraction_map A K)
-  {p : polynomial A} {x : g.codomain} (hr : aeval x p = 0) :
-  is_root (scale_roots p (g.denom x)) (g.num x) :=
+  [unique_factorization_monoid A] {p : polynomial A} {x : K} (hr : aeval x p = 0) :
+  is_root (scale_roots p (denom A x)) (num A x) :=
 begin
-  apply is_root_of_eval₂_map_eq_zero g.injective,
+  apply is_root_of_eval₂_map_eq_zero (is_fraction_ring.injective A K),
   refine scale_roots_aeval_eq_zero_of_aeval_mk'_eq_zero _,
-  rw g.mk'_num_denom,
+  rw mk'_num_denom,
   exact hr
 end
 
@@ -57,49 +54,49 @@ end scale_roots
 section rational_root_theorem
 
 variables {A K : Type*} [integral_domain A] [unique_factorization_monoid A] [field K]
-variables {f : fraction_map A K}
+variables [algebra A K] [is_fraction_ring A K]
 
-open polynomial unique_factorization_monoid
+open is_fraction_ring is_localization polynomial unique_factorization_monoid
 
 /-- Rational root theorem part 1:
 if `r : f.codomain` is a root of a polynomial over the ufd `A`,
 then the numerator of `r` divides the constant coefficient -/
-theorem num_dvd_of_is_root {p : polynomial A} {r : f.codomain} (hr : aeval r p = 0) :
-  f.num r ∣ p.coeff 0 :=
+theorem num_dvd_of_is_root {p : polynomial A} {r : K} (hr : aeval r p = 0) :
+  num A r ∣ p.coeff 0 :=
 begin
-  suffices : f.num r ∣ (scale_roots p (f.denom r)).coeff 0,
+  suffices : num A r ∣ (scale_roots p (denom A r)).coeff 0,
   { simp only [coeff_scale_roots, nat.sub_zero] at this,
     haveI := classical.prop_decidable,
-    by_cases hr : f.num r = 0,
-    { obtain ⟨u, hu⟩ := (f.is_unit_denom_of_num_eq_zero hr).pow p.nat_degree,
+    by_cases hr : num A r = 0,
+    { obtain ⟨u, hu⟩ := (is_unit_denom_of_num_eq_zero hr).pow p.nat_degree,
       rw ←hu at this,
       exact units.dvd_mul_right.mp this },
     { refine dvd_of_dvd_mul_left_of_no_prime_factors hr _ this,
       intros q dvd_num dvd_denom_pow hq,
       apply hq.not_unit,
-      exact f.num_denom_reduced r dvd_num (hq.dvd_of_dvd_pow dvd_denom_pow) } },
-  convert dvd_term_of_is_root_of_dvd_terms 0 (num_is_root_scale_roots_of_aeval_eq_zero f hr) _,
+      exact num_denom_reduced A r dvd_num (hq.dvd_of_dvd_pow dvd_denom_pow) } },
+  convert dvd_term_of_is_root_of_dvd_terms 0 (num_is_root_scale_roots_of_aeval_eq_zero hr) _,
   { rw [pow_zero, mul_one] },
   intros j hj,
   apply dvd_mul_of_dvd_right,
-  convert pow_dvd_pow (f.num r) (nat.succ_le_of_lt (bot_lt_iff_ne_bot.mpr hj)),
+  convert pow_dvd_pow (num A r) (nat.succ_le_of_lt (bot_lt_iff_ne_bot.mpr hj)),
   exact (pow_one _).symm
 end
 
 /-- Rational root theorem part 2:
 if `r : f.codomain` is a root of a polynomial over the ufd `A`,
 then the denominator of `r` divides the leading coefficient -/
-theorem denom_dvd_of_is_root {p : polynomial A} {r : f.codomain} (hr : aeval r p = 0) :
-  (f.denom r : A) ∣ p.leading_coeff :=
+theorem denom_dvd_of_is_root {p : polynomial A} {r : K} (hr : aeval r p = 0) :
+  (denom A r : A) ∣ p.leading_coeff :=
 begin
-  suffices : (f.denom r : A) ∣ p.leading_coeff * f.num r ^ p.nat_degree,
+  suffices : (denom A r : A) ∣ p.leading_coeff * num A r ^ p.nat_degree,
   { refine dvd_of_dvd_mul_left_of_no_prime_factors
-      (mem_non_zero_divisors_iff_ne_zero.mp (f.denom r).2) _ this,
+      (mem_non_zero_divisors_iff_ne_zero.mp (denom A r).2) _ this,
     intros q dvd_denom dvd_num_pow hq,
     apply hq.not_unit,
-    exact f.num_denom_reduced r (hq.dvd_of_dvd_pow dvd_num_pow) dvd_denom },
+    exact num_denom_reduced A r (hq.dvd_of_dvd_pow dvd_num_pow) dvd_denom },
   rw ←coeff_scale_roots_nat_degree,
-  apply dvd_term_of_is_root_of_dvd_terms _ (num_is_root_scale_roots_of_aeval_eq_zero f hr),
+  apply dvd_term_of_is_root_of_dvd_terms _ (num_is_root_scale_roots_of_aeval_eq_zero hr),
   intros j hj,
   by_cases h : j < p.nat_degree,
   { rw coeff_scale_roots,
@@ -107,7 +104,7 @@ begin
     convert pow_dvd_pow _ (nat.succ_le_iff.mpr (nat.lt_sub_left_of_add_lt _)),
     { exact (pow_one _).symm },
     simpa using h },
-  rw [←nat_degree_scale_roots p (f.denom r)] at *,
+  rw [←nat_degree_scale_roots p (denom A r)] at *,
   rw [coeff_eq_zero_of_nat_degree_lt (lt_of_le_of_ne (le_of_not_gt h) hj.symm), zero_mul],
   exact dvd_zero _
 end
@@ -115,17 +112,17 @@ end
 /-- Integral root theorem:
 if `r : f.codomain` is a root of a monic polynomial over the ufd `A`,
 then `r` is an integer -/
-theorem is_integer_of_is_root_of_monic {p : polynomial A} (hp : monic p) {r : f.codomain}
-  (hr : aeval r p = 0) : f.is_integer r :=
-f.is_integer_of_is_unit_denom (is_unit_of_dvd_one _ (hp ▸ denom_dvd_of_is_root hr))
+theorem is_integer_of_is_root_of_monic {p : polynomial A} (hp : monic p) {r : K}
+  (hr : aeval r p = 0) : is_integer A r :=
+is_integer_of_is_unit_denom (is_unit_of_dvd_one _ (hp ▸ denom_dvd_of_is_root hr))
 
 namespace unique_factorization_monoid
 
-lemma integer_of_integral {x : f.codomain} :
-  is_integral A x → f.is_integer x :=
+lemma integer_of_integral {x : K} :
+  is_integral A x → is_integer A x :=
 λ ⟨p, hp, hx⟩, is_integer_of_is_root_of_monic hp hx
 
-lemma integrally_closed : integral_closure A f.codomain = ⊥ :=
+lemma integrally_closed : integral_closure A K = ⊥ :=
 eq_bot_iff.mpr (λ x hx, algebra.mem_bot.mpr (integer_of_integral hx))
 
 end unique_factorization_monoid

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -794,8 +794,8 @@ variables [char_zero K]
 /--The minimal polynomial of a root of unity `μ` divides `X ^ n - 1`. -/
 lemma minpoly_dvd_X_pow_sub_one : minpoly ℤ μ ∣ X ^ n - 1 :=
 begin
-  apply integer_dvd (is_integral h hpos) (polynomial.monic.is_primitive
-  (monic_X_pow_sub_C 1 (ne_of_lt hpos).symm)),
+  apply minpoly.gcd_domain_dvd ℚ (is_integral h hpos) (polynomial.monic.is_primitive
+    (monic_X_pow_sub_C 1 (ne_of_lt hpos).symm)),
   simp only [((is_primitive_root.iff_def μ n).mp h).left, aeval_X_pow, ring_hom.eq_int_cast,
   int.cast_one, aeval_one, alg_hom.map_sub, sub_self]
 end
@@ -825,7 +825,7 @@ lemma minpoly_dvd_expand {p : ℕ} (hprime : nat.prime p) (hdiv : ¬ p ∣ n) :
   minpoly ℤ μ ∣
   expand ℤ p (minpoly ℤ (μ ^ p)) :=
 begin
-  apply minpoly.integer_dvd (h.is_integral hpos),
+  apply minpoly.gcd_domain_dvd ℚ (h.is_integral hpos),
   { apply monic.is_primitive,
     rw [polynomial.monic, leading_coeff, nat_degree_expand, mul_comm, coeff_expand_mul'
         (nat.prime.pos hprime), ← leading_coeff, ← polynomial.monic],


### PR DESCRIPTION
This PR replaces the previous `localization_map (M : submodule R) Rₘ` definition (a ring hom `R →+* Rₘ` that presents `Rₘ` as the localization of `R` at `M`) with a new `is_localization M Rₘ` typeclass that puts these requirements on `algebra_map R Rₘ` instead. An important benefit is that we no longer need to mess with `localization_map.codomain` to put an `R`-algebra structure on `Rₘ`, we can just work with `Rₘ` directly.

The important API changes are in commit 0de78dc, all other commits are simply fixes to the dependent files.

Main changes:
 * `localization_map` has been replaced with `is_localization`, similarly `away_map` -> `is_localization.away`, `localization_map.at_prime` -> `is_localization.at_prime` and `fraction_map` -> `is_fraction_ring`
 * many declarations taking the `localization_map` as a parameter now take `R` and/or `M` and/or `Rₘ`, depending on what can be inferred easily
 * `localization_map.to_map` has been replaced with `algebra_map R Rₘ`
 * `localization_map.codomain` and its instances have been removed (you can now directly use `Rₘ`)
 * `is_localization.alg_equiv` generalizes `fraction_map.alg_equiv_of_quotient` (which has been renamed to `is_fraction_ring.alg_equiv`)
 * `is_localization.sec` has been introduced to replace `(to_localization_map _ _).sec`
 * `localization.of` have been replaced with `algebra` and `is_localization` instances on `localization`, similarly for `localization.away.of`, `localization.at_prime.of` and `fraction_ring.of`.
 * `int.fraction_map` is now an instance `rat.is_fraction_ring`
 * All files depending on the above definitions have had fixes. These were mostly straightforward, except:
 * [Some category-theory arrows in `algebraic_geometry/structure.sheaf` are now plain `ring_hom`s. This change was suggested by @justus-springer in order to help the elaborator figure out the arguments to  `is_localization`.](https://github.com/leanprover-community/mathlib/commit/cf3acc925467cc06237a13dbe4264529f9a58850)
 * Deleted `minpoly.over_int_eq_over_rat` and `minpoly.integer_dvd`, now you can just use `gcd_domain_eq_field_fractions` or `gcd_domain_dvd` respectively. [This removes code duplication in `minpoly.lean`](https://github.com/leanprover-community/mathlib/commit/5695924d85710f98ac60a7df91d7dbf27408ca26)
 * `fractional_ideal` does not need to assume `is_localization` everywhere, only for certain specific definitions

Things that stay the same:
 * `localization`, `localization.away`, `localization.at_prime` and `fraction_ring` are still a construction of localizations (although see above for `{localization,localization.away,localization.at_prime,fraction_ring}.of`)

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Refactoring.20.60localization_map.60

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
