### PR TITLE
[Merged by Bors] - feat(algebra/ordered_ring): abs_cases lemma

### DIFF
--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -998,6 +998,19 @@ calc a < -a ↔ -(-a) < -a : by rw neg_neg
 
 @[simp] lemma abs_eq_neg_self : abs a = -a ↔ a ≤ 0 := by simp [abs]
 
+/-- For an element `a` of a linear ordered ring, either `abs a = a` and `a≥0`,
+    or `abs a = -a` and `a<0`.
+    Use cases on this lemma to automate linarith in inequalities -/
+lemma abs_cases (a : α) : (abs a = a ∧ a ≥ 0) ∨ (abs a = -a ∧ a < 0) :=
+begin
+  by_cases a ≥ 0,
+  { left,
+    exact ⟨abs_eq_self.mpr h, h⟩ },
+  { right,
+    push_neg at h,
+    exact ⟨abs_eq_neg_self.mpr (le_of_lt h), h⟩ }
+end
+
 lemma gt_of_mul_lt_mul_neg_left (h : c * a < c * b) (hc : c ≤ 0) : b < a :=
 have nhc : 0 ≤ -c, from neg_nonneg_of_nonpos hc,
 have h2 : -(c * b) < -(c * a), from neg_lt_neg h,

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -998,12 +998,12 @@ calc a < -a ↔ -(-a) < -a : by rw neg_neg
 
 @[simp] lemma abs_eq_neg_self : abs a = -a ↔ a ≤ 0 := by simp [abs]
 
-/-- For an element `a` of a linear ordered ring, either `abs a = a` and `a≥0`,
-    or `abs a = -a` and `a<0`.
+/-- For an element `a` of a linear ordered ring, either `abs a = a` and `0 ≤ a`,
+    or `abs a = -a` and `a < 0`.
     Use cases on this lemma to automate linarith in inequalities -/
-lemma abs_cases (a : α) : (abs a = a ∧ a ≥ 0) ∨ (abs a = -a ∧ a < 0) :=
+lemma abs_cases (a : α) : (abs a = a ∧ 0 ≤ a) ∨ (abs a = -a ∧ a < 0) :=
 begin
-  by_cases a ≥ 0,
+  by_cases 0 ≤ a,
   { left,
     exact ⟨abs_eq_self.mpr h, h⟩ },
   { right,


### PR DESCRIPTION
This lemma makes the following type of argument work seamlessly:

```lean
example (h : x<-1/2) : |x + 1| < |x| := by cases abs_cases (x + 1); cases abs_cases x; linarith
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
