### PR TITLE
[Merged by Bors] - fix(tactic/core): add subst'

### DIFF
--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -719,7 +719,7 @@ meta def subst' (h : expr) : tactic unit := do
     else return h },
   success_if_fail (is_local_def e) <|>
     fail format!("Cannot substitute variable {e.local_pp_name}, " ++
-      "it is a local definition. Hint: use `clear_value`."),
+      "it is a local definition. If you really want to do this, use `clear_value` first."),
   subst h
 
 /-- A variant of `simplify_bottom_up`. Given a tactic `post` for rewriting subexpressions,

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -1084,12 +1084,23 @@ add_tactic_doc
   tags       := ["context management"] }
 
 /--
+If the expression `q` is a local variable with type `x = t` or `t = x`, where `x` is a local
+constant, `tactic.interactive.subst' q` substitutes `x` by `t` everywhere in the main goal and
+then clears `q`.
+If `q` is another local variable, then we find a local constant with type `q = t` or `t = q` and
+substitute `t` for `q`.
+
 Like `tactic.interactive.subst`, but fails with a nicer error message if the substituted variable is
 a local definition. It is trickier to fix this in core, since `tactic.is_local_def` is in mathlib.
 -/
 meta def subst' (q : parse texpr) : tactic unit := do
 i_to_expr q >>= tactic.subst' >> try (tactic.reflexivity reducible)
 
+add_tactic_doc
+{ name       := "subst'",
+  category   := doc_category.tactic,
+  decl_names := [`tactic.interactive.subst'],
+  tags       := ["context management"] }
 
 end interactive
 end tactic

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -1083,5 +1083,13 @@ add_tactic_doc
   decl_names := [`tactic.interactive.generalize'],
   tags       := ["context management"] }
 
+/--
+Like `tactic.interactive.subst`, but fails with a nicer error message if the substituted variable is
+a local definition. It is trickier to fix this in core, since `tactic.is_local_def` is in mathlib.
+-/
+meta def subst' (q : parse texpr) : tactic unit := do
+i_to_expr q >>= tactic.subst' >> try (tactic.reflexivity reducible)
+
+
 end interactive
 end tactic

--- a/src/tactic/rcases.lean
+++ b/src/tactic/rcases.lean
@@ -299,7 +299,7 @@ meta mutual def rcases_core, rcases.continue
 with rcases_core : rcases_patt → expr → tactic (list uncleared_goal)
 | (rcases_patt.one `rfl) e := do
   (t, e) ← get_local_and_type e,
-  subst e,
+  subst' e,
   list.map (prod.mk []) <$> get_goals
 -- If the pattern is any other name, we already bound the name in the
 -- top-level `cases` tactic, so there is no more work to do for it.
@@ -478,7 +478,7 @@ with rcases_hint_core : ℕ → expr → tactic (rcases_patt × list expr)
   env ← get_env,
   let I := t.get_app_fn.const_name,
   (do guard (I = ``eq),
-    subst e,
+    subst' e,
     prod.mk (rcases_patt.one `rfl) <$> get_goals) <|>
   (do
     let c := env.constructors_of I,

--- a/test/lift.lean
+++ b/test/lift.lean
@@ -40,7 +40,8 @@ example : let n : ℤ := 3 in n = n :=
 begin
   intro n,
   success_if_fail_with_msg { lift n to ℕ }
-    "Cannot substitute variable n, it is a local definition. Hint: use `clear_value`.",
+    ("Cannot substitute variable n, it is a local definition. " ++
+    "If you really want to do this, use `clear_value` first."),
   refl
 end
 

--- a/test/lift.lean
+++ b/test/lift.lean
@@ -41,6 +41,7 @@ begin
   intro n,
   success_if_fail_with_msg { lift n to ℕ }
     "Cannot substitute variable n, it is a local definition. Hint: use `clear_value`.",
+  refl
 end
 
 instance can_lift_unit : can_lift unit unit :=

--- a/test/lift.lean
+++ b/test/lift.lean
@@ -35,6 +35,14 @@ begin
   exact int.coe_nat_nonneg _
 end
 
+-- fail gracefully when the lifted variable is a local definition
+example : let n : ℤ := 3 in n = n :=
+begin
+  intro n,
+  success_if_fail_with_msg { lift n to ℕ }
+    "Cannot substitute variable n, it is a local definition. Hint: use `clear_value`.",
+end
+
 instance can_lift_unit : can_lift unit unit :=
 ⟨id, λ x, true, λ x _, ⟨x, rfl⟩⟩
 


### PR DESCRIPTION
`tactic.subst'` gives a better error message when the substituted variable is a local definition.
It is hard to fix this in core (without touching C++ code), since `tactic.is_local_def` is in mathlib



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
