### PR TITLE
[Merged by Bors] - feat(category_theory/limits/concrete_category): Some lemmas about limits in concrete categories

### DIFF
--- a/src/category_theory/limits/concrete_category.lean
+++ b/src/category_theory/limits/concrete_category.lean
@@ -41,9 +41,8 @@ begin
     suffices : T.inv (T.hom a) = T.inv (T.hom b), by simpa,
     rw h },
   suffices : function.injective (λ (x : G.X) j, G.π.app j x),
-    by exact function.injective.comp this h,
-  intros a b hh,
-  exact subtype.ext hh,
+    by exact this.comp h,
+  apply subtype.ext,
 end
 
 lemma concrete.is_limit_ext {D : cone F} (hD : is_limit D) (x y : D.X) :

--- a/src/category_theory/limits/concrete_category.lean
+++ b/src/category_theory/limits/concrete_category.lean
@@ -1,10 +1,11 @@
 /-
 Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott Morrison
+Authors: Scott Morrison, Adam Topaz
 -/
-import category_theory.limits.has_limits
-import category_theory.concrete_category.basic
+import category_theory.limits.preserves.basic
+import category_theory.limits.types
+import category_theory.limits.shapes.wide_pullbacks
 import tactic.elementwise
 
 /-!
@@ -18,5 +19,67 @@ open category_theory
 namespace category_theory.limits
 
 attribute [elementwise] cone.w limit.lift_π limit.w cocone.w colimit.ι_desc colimit.w
+
+set_option pp.universes true
+
+local attribute [instance] concrete_category.has_coe_to_fun concrete_category.has_coe_to_sort
+
+section limits
+
+variables {C : Type u} [category.{v} C] [concrete_category.{v} C]
+  {J : Type v} [small_category J] (F : J ⥤ C) [preserves_limit F (forget C)]
+
+lemma concrete.is_limit_to_product_injective {D : cone F} (hD : is_limit D) :
+  function.injective (λ (x : D.X) (j : J), D.π.app j x) :=
+begin
+  let E := (forget C).map_cone D,
+  let hE : is_limit E := is_limit_of_preserves _ hD,
+  let G := types.limit_cone (F ⋙ forget C),
+  let hG := types.limit_cone_is_limit (F ⋙ forget C),
+  let T : E.X ≅ G.X := hE.cone_point_unique_up_to_iso hG,
+  change function.injective (T.hom ≫ (λ x j, G.π.app j x)),
+  have h : function.injective T.hom,
+  { intros a b h,
+    suffices : T.inv (T.hom a) = T.inv (T.hom b), by simpa,
+    rw h },
+  suffices : function.injective (λ (x : G.X) j, G.π.app j x),
+    by exact function.injective.comp this h,
+  intros a b hh,
+  exact subtype.ext hh,
+end
+
+lemma concrete.is_limit_ext {D : cone F} (hD : is_limit D) (x y : D.X) :
+  (∀ j, D.π.app j x = D.π.app j y) → x = y :=
+λ h, concrete.is_limit_to_product_injective _ hD (funext h)
+
+lemma concrete.limit_ext [has_limit F] (x y : limit F) :
+  (∀ j, limit.π F j x = limit.π F j y) → x = y :=
+concrete.is_limit_ext F (limit.is_limit _) _ _
+
+open wide_pullback
+open wide_pullback_shape
+
+lemma concrete.wide_pullback_ext {B : C} {ι : Type*} {X : ι → C} (f : Π j : ι, X j ⟶ B)
+  [has_wide_pullback B X f] [preserves_limit (wide_cospan B X f) (forget C)]
+  (x y : wide_pullback B X f) (h₀ : base f x = base f y)
+  (h : ∀ j, π f j x = π f j y) : x = y :=
+begin
+  apply concrete.limit_ext,
+  rintro (_|j),
+  { exact h₀ },
+  { apply h }
+end
+
+lemma concrete.wide_pullback_ext' {B : C} {ι : Type*} [nonempty ι]
+  {X : ι → C} (f : Π j : ι, X j ⟶ B) [has_wide_pullback B X f]
+  [preserves_limit (wide_cospan B X f) (forget C)]
+  (x y : wide_pullback B X f) (h : ∀ j, π f j x = π f j y) : x = y :=
+begin
+  apply concrete.wide_pullback_ext _ _ _ _ h,
+  inhabit ι,
+  simp only [← π_arrow f (arbitrary _), comp_apply, h],
+end
+
+end limits
 
 end category_theory.limits

--- a/src/category_theory/limits/concrete_category.lean
+++ b/src/category_theory/limits/concrete_category.lean
@@ -20,8 +20,6 @@ namespace category_theory.limits
 
 attribute [elementwise] cone.w limit.lift_π limit.w cocone.w colimit.ι_desc colimit.w
 
-set_option pp.universes true
-
 local attribute [instance] concrete_category.has_coe_to_fun concrete_category.has_coe_to_sort
 
 section limits

--- a/src/category_theory/limits/concrete_category.lean
+++ b/src/category_theory/limits/concrete_category.lean
@@ -119,7 +119,7 @@ end
 lemma concrete.is_colimit_exists_rep {D : cocone F} (hD : is_colimit D) (x : D.X) :
   ∃ (j : J) (y : F.obj j), D.ι.app j y = x :=
 begin
-  obtain ⟨a,rfl⟩ := concrete.from_union_surjective_of_is_colimit F hD x,
+  obtain ⟨a, rfl⟩ := concrete.from_union_surjective_of_is_colimit F hD x,
   exact ⟨a.1, a.2, rfl⟩,
 end
 
@@ -136,8 +136,7 @@ lemma concrete.wide_pushout_exists_rep {B : C} {α : Type*} {X : α → C} (f : 
   [has_wide_pushout B X f] [preserves_colimit (wide_span B X f) (forget C)]
   (x : wide_pushout B X f) : (∃ y : B, head f y = x) ∨ (∃ (i : α) (y : X i), ι f i y = x) :=
 begin
-  obtain ⟨j,y,rfl⟩ := concrete.colimit_exists_rep _ x,
-  cases j,
+  obtain ⟨_ | j, y, rfl⟩ := concrete.colimit_exists_rep _ x,
   { use y },
   { right,
     use [j,y] }
@@ -148,7 +147,7 @@ lemma concrete.wide_pushout_exists_rep' {B : C} {α : Type*} [nonempty α] {X : 
   [preserves_colimit (wide_span B X f) (forget C)] (x : wide_pushout B X f) :
   ∃ (i : α) (y : X i), ι f i y = x :=
 begin
-  rcases concrete.wide_pushout_exists_rep f x with ⟨y,rfl⟩|⟨i,y,rfl⟩,
+  rcases concrete.wide_pushout_exists_rep f x with ⟨y, rfl⟩ | ⟨i, y, rfl⟩,
   { inhabit α,
     use [arbitrary _, f _ y],
     simp only [← arrow_ι _ (arbitrary α), comp_apply] },

--- a/src/category_theory/limits/concrete_category.lean
+++ b/src/category_theory/limits/concrete_category.lean
@@ -27,7 +27,7 @@ section limits
 variables {C : Type u} [category.{v} C] [concrete_category.{v} C]
   {J : Type v} [small_category J] (F : J ⥤ C) [preserves_limit F (forget C)]
 
-lemma concrete.is_limit_to_product_injective {D : cone F} (hD : is_limit D) :
+lemma concrete.to_product_injective_of_is_limit {D : cone F} (hD : is_limit D) :
   function.injective (λ (x : D.X) (j : J), D.π.app j x) :=
 begin
   let E := (forget C).map_cone D,
@@ -48,7 +48,7 @@ end
 
 lemma concrete.is_limit_ext {D : cone F} (hD : is_limit D) (x y : D.X) :
   (∀ j, D.π.app j x = D.π.app j y) → x = y :=
-λ h, concrete.is_limit_to_product_injective _ hD (funext h)
+λ h, concrete.to_product_injective_of_is_limit _ hD (funext h)
 
 lemma concrete.limit_ext [has_limit F] (x y : limit F) :
   (∀ j, limit.π F j x = limit.π F j y) → x = y :=

--- a/src/topology/category/Profinite/default.lean
+++ b/src/topology/category/Profinite/default.lean
@@ -203,6 +203,10 @@ has_limits_of_has_limits_creates_limits Profinite_to_Top
 instance has_colimits : limits.has_colimits Profinite :=
 has_colimits_of_reflective to_CompHaus
 
+noncomputable
+instance forget_preserves_limits : limits.preserves_limits (forget Profinite) :=
+by apply limits.comp_preserves_limits Profinite_to_Top (forget _)
+
 variables {X Y : Profinite.{u}} (f : X ⟶ Y)
 
 /-- Any morphism of profinite spaces is a closed map. -/


### PR DESCRIPTION
Generalizes some lemmas from LTE. 

See zulip discussion [here](https://leanprover.zulipchat.com/#narrow/stream/267928-condensed-mathematics/topic/for_mathlib.2Fwide_pullback/near/244298079).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
