### PR TITLE
[Merged by Bors] - chore(linear_algebra/matrix/determinant): squeeze some simps for speed up

### DIFF
--- a/src/linear_algebra/matrix/determinant.lean
+++ b/src/linear_algebra/matrix/determinant.lean
@@ -135,7 +135,7 @@ begin
     (λ _ _, mem_univ _)
     (λ σ _, mul_swap_involutive i j σ)
 end
-set_option profiler true
+
 @[simp] lemma det_mul (M N : matrix n n R) : det (M ⬝ N) = det M * det N :=
 calc det (M ⬝ N) = ∑ p : n → n, ∑ σ : perm n, ε σ * ∏ i, (M (σ i) (p i) * N (p i) i) :
   by simp only [det_apply', mul_apply, prod_univ_sum, mul_sum,
@@ -492,7 +492,8 @@ begin
     simp only [prod_congr_left_apply] },
   { intros σ _,
     rw [finset.prod_mul_distrib, ←finset.univ_product_univ, finset.prod_product, finset.prod_comm],
-    simp only [sign_prod_congr_left, units.coe_prod, int.coe_prod, block_diagonal_apply_eq, prod_congr_left_apply] },
+    simp only [sign_prod_congr_left, units.coe_prod, int.coe_prod, block_diagonal_apply_eq,
+      prod_congr_left_apply] },
   { intros σ σ' _ _ eq,
     ext x hx k,
     simp only at eq,

--- a/src/linear_algebra/matrix/determinant.lean
+++ b/src/linear_algebra/matrix/determinant.lean
@@ -157,7 +157,7 @@ calc det (M ⬝ N) = ∑ p : n → n, ∑ σ : perm n, ε σ * ∏ i, (M (σ i) 
         by { rw ← σ⁻¹.prod_comp, simp only [equiv.perm.coe_mul, apply_inv_self] },
       have h : ε σ * ε (τ * σ⁻¹) = ε τ :=
         calc ε σ * ε (τ * σ⁻¹) = ε ((τ * σ⁻¹) * σ) :
-          by { rw [mul_comm, sign_mul (τ * σ⁻¹)], simp }
+          by { rw [mul_comm, sign_mul (τ * σ⁻¹)], simp only [int.cast_mul, units.coe_mul] }
         ... = ε τ : by simp only [inv_mul_cancel_right],
       by { simp_rw [equiv.coe_mul_right, h], simp only [this] }))
 ... = det M * det N : by simp only [det_apply', finset.mul_sum, mul_comm, mul_left_comm]
@@ -552,7 +552,7 @@ begin
     simp only [],
     erw [set.mem_to_finset, monoid_hom.mem_range],
     use σ₁₂,
-    simp },
+    simp only [sum_congr_hom_apply] },
   { simp only [forall_prop_of_true, prod.forall, mem_univ],
     intros σ₁ σ₂,
     rw fintype.prod_sum_type,
@@ -561,8 +561,7 @@ begin
     have hr : ∀ (a b c d : R), (a * b) * (c * d) = a * c * (b * d), { intros, ac_refl },
     rw hr,
     congr,
-    norm_cast,
-    rw sign_sum_congr },
+    rw [sign_sum_congr, units.coe_mul, int.cast_mul] },
   { intros σ₁ σ₂ h₁ h₂,
     dsimp only [],
     intro h,


### PR DESCRIPTION
I simply squeezed some simps in `linear_algebra/matrix/determinant` to obtain two much faster proofs.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
