### PR TITLE
[Merged by Bors] - feat(data/fintype/basic): induction principle for finite types

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1639,24 +1639,6 @@ end multiset
 
 namespace fintype
 
-/-- An induction principle for finite types, analogous to `nat.rec`. It effectively says
-that every `fintype` is either `empty` or `option α`, up to an `equiv`. -/
-lemma induction_empty_option {P : Type u → Prop}
-  (of_equiv : ∀ {α β}, α ≃ β → P α → P β)
-  (h_empty : P pempty)
-  (h_option : ∀ {α} [fintype α], P α → P (option α))
-  (α : Type u) [fintype α] : P α :=
-begin
-  suffices : ∀ n : ℕ, P (ulift $ fin n),
-  { exact of_equiv (equiv.ulift.trans (equiv_fin α).symm) (this (fintype.card α)), },
-  intro n,
-  induction n with n ih,
-  { refine of_equiv (equiv_of_card_eq _) h_empty,
-    simp only [card_fin, card_pempty, card_ulift], },
-  { refine of_equiv (equiv_of_card_eq _) (h_option ih),
-    simp only [card_fin, card_option, card_ulift], },
-end
-
 /-- A recursor principle for finite types, analogous to `nat.rec`. It effectively says
 that every `fintype` is either `empty` or `option α`, up to an `equiv`. -/
 def trunc_rec_empty_option {P : Type u → Sort v}
@@ -1686,6 +1668,19 @@ begin
     apply trunc.map _ ih,
     intro ih,
     refine of_equiv e (h_option ih), },
+end
+
+/-- An induction principle for finite types, analogous to `nat.rec`. It effectively says
+that every `fintype` is either `empty` or `option α`, up to an `equiv`. -/
+lemma induction_empty_option {P : Type u → Prop}
+  (of_equiv : ∀ {α β}, α ≃ β → P α → P β)
+  (h_empty : P pempty)
+  (h_option : ∀ {α} [fintype α], P α → P (option α))
+  (α : Type u) [fintype α] : P α :=
+begin
+  haveI := classical.dec_eq α,
+  obtain ⟨p⟩ := trunc_rec_empty_option @of_equiv h_empty (λ _ _ _, by exactI h_option) α,
+  exact p,
 end
 
 end fintype

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1641,7 +1641,7 @@ namespace fintype
 
 /-- An induction principle for finite types, analogous to `nat.rec`. It effectively says
 that every `fintype` is either `empty` or `option α`, up to an `equiv`. -/
-noncomputable def induction_empty_option {P : Type u → Sort v}
+lemma induction_empty_option {P : Type u → Prop}
   (of_equiv : ∀ {α β}, α ≃ β → P α → P β)
   (h_empty : P pempty)
   (h_option : ∀ {α}, P α → P (option α))

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1644,7 +1644,7 @@ that every `fintype` is either `empty` or `option α`, up to an `equiv`. -/
 lemma induction_empty_option {P : Type u → Prop}
   (of_equiv : ∀ {α β}, α ≃ β → P α → P β)
   (h_empty : P pempty)
-  (h_option : ∀ {α}, P α → P (option α))
+  (h_option : ∀ {α} [fintype α], P α → P (option α))
   (α : Type u) [fintype α] : P α :=
 begin
   suffices : ∀ n : ℕ, P (ulift $ fin n),
@@ -1655,6 +1655,37 @@ begin
     simp only [card_fin, card_pempty, card_ulift], },
   { refine of_equiv (equiv_of_card_eq _) (h_option ih),
     simp only [card_fin, card_option, card_ulift], },
+end
+
+/-- A recursor principle for finite types, analogous to `nat.rec`. It effectively says
+that every `fintype` is either `empty` or `option α`, up to an `equiv`. -/
+def trunc_rec_empty_option {P : Type u → Sort v}
+  (of_equiv : ∀ {α β}, α ≃ β → P α → P β)
+  (h_empty : P pempty)
+  (h_option : ∀ {α} [fintype α] [decidable_eq α], P α → P (option α))
+  (α : Type u) [fintype α] [decidable_eq α] : trunc (P α) :=
+begin
+  suffices : ∀ n : ℕ, trunc (P (ulift $ fin n)),
+  { apply trunc.bind (this (fintype.card α)),
+    intro h,
+    apply trunc.map _ (fintype.trunc_equiv_fin α),
+    intro e,
+    exact of_equiv (equiv.ulift.trans e.symm) h },
+  intro n,
+  induction n with n ih,
+  { have : card pempty = card (ulift (fin 0)),
+    { simp only [card_fin, card_pempty, card_ulift] },
+    apply trunc.bind (trunc_equiv_of_card_eq this),
+    intro e,
+    apply trunc.mk,
+    refine of_equiv e h_empty, },
+  { have : card (option (ulift (fin n))) = card (ulift (fin n.succ)),
+    { simp only [card_fin, card_option, card_ulift] },
+    apply trunc.bind (trunc_equiv_of_card_eq this),
+    intro e,
+    apply trunc.map _ ih,
+    intro ih,
+    refine of_equiv e (h_option ih), },
 end
 
 end fintype

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1636,3 +1636,25 @@ variables [fintype α] [decidable_eq α]
 count_eq_one_of_mem finset.univ.nodup (finset.mem_univ _)
 
 end multiset
+
+namespace fintype
+
+/-- An induction principle for finite types, analogous to `nat.rec`. It effectively says
+that every `fintype` is either `empty` or `option α`, up to an `equiv`. -/
+noncomputable def induction_empty_option {P : Type u → Sort v}
+  (of_equiv : ∀ {α β}, α ≃ β → P α → P β)
+  (h_empty : P pempty)
+  (h_option : ∀ {α}, P α → P (option α))
+  (α : Type u) [fintype α] : P α :=
+begin
+  suffices : ∀ n : ℕ, P (ulift $ fin n),
+  { exact of_equiv (equiv.ulift.trans (equiv_fin α).symm) (this (fintype.card α)), },
+  intro n,
+  induction n with n ih,
+  { refine of_equiv (equiv_of_card_eq _) h_empty,
+    simp only [card_fin, card_pempty, card_ulift], },
+  { refine of_equiv (equiv_of_card_eq _) (h_option ih),
+    simp only [card_fin, card_option, card_ulift], },
+end
+
+end fintype


### PR DESCRIPTION
This lets us prove things about finite types by induction, analogously to proving things about natural numbers by induction. Here `pempty` plays the role of `0` and `option` plays the role of `nat.succ`. We need an extra hypothesis that our statement is invariant under equivalence of types. Used in #8019.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
