### PR TITLE
[Merged by Bors] - feat(linear_algebra/matrix/reindex): generalize reindex_linear_equiv to operate on an arbitrary ring

### DIFF
--- a/src/algebra/lie/classical.lean
+++ b/src/algebra/lie/classical.lean
@@ -360,7 +360,7 @@ begin
   symmetry,
   apply (skew_adjoint_matrices_lie_subalgebra_equiv_transpose
     (indefinite_diagonal (unit ⊕ l) l R)
-    (matrix.reindex_alg_equiv (equiv.sum_assoc punit l l)) (matrix.transpose_reindex _ _)).trans,
+    (matrix.reindex_alg_equiv _ (equiv.sum_assoc punit l l)) (matrix.transpose_reindex _ _)).trans,
   apply lie_equiv.of_eq,
   ext A,
   rw [JB_transform, ← unit_of_invertible_val (2 : R), ←units.smul_def, lie_subalgebra.mem_coe,

--- a/src/algebra/lie/matrix.lean
+++ b/src/algebra/lie/matrix.lean
@@ -73,7 +73,7 @@ def matrix.reindex_lie_equiv {m : Type w₁} [decidable_eq m] [fintype m]
 { to_fun := matrix.reindex e e,
   map_lie' := λ M N, by simp only [lie_ring.of_associative_ring_bracket, matrix.reindex_apply,
     ←matrix.minor_mul_equiv _ _ _ _, matrix.mul_eq_mul, matrix.minor_sub, pi.sub_apply],
-  ..(matrix.reindex_linear_equiv e e) }
+  ..(matrix.reindex_linear_equiv R R e e) }
 
 @[simp] lemma matrix.reindex_lie_equiv_apply {m : Type w₁} [decidable_eq m] [fintype m]
   (e : n ≃ m) (M : matrix n n R) :

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -162,7 +162,7 @@ by { ext, simp only [basis.to_matrix_apply, basis.reindex_repr, matrix.minor_app
 /-- See also `basis.to_matrix_reindex` which gives the `simp` normal form of this result. -/
 lemma basis.to_matrix_reindex' [decidable_eq ι] [decidable_eq ι']
   (b : basis ι R M) (v : ι' → M) (e : ι ≃ ι') :
-  (b.reindex e).to_matrix v = matrix.reindex_alg_equiv e (b.to_matrix (v ∘ e)) :=
+  (b.reindex e).to_matrix v = matrix.reindex_alg_equiv _ e (b.to_matrix (v ∘ e)) :=
 by { ext, simp only [basis.to_matrix_apply, basis.reindex_repr, matrix.reindex_alg_equiv_apply,
         matrix.reindex_apply, matrix.minor_apply, function.comp_app, e.apply_symm_apply] }
 

--- a/src/linear_algebra/matrix/reindex.lean
+++ b/src/linear_algebra/matrix/reindex.lean
@@ -14,8 +14,9 @@ to an `m'` by `n'` matrix, as long as `m ≃ m'` and `n ≃ n'`.
 
 ## Main definitions
 
-* `matrix.reindex_linear_equiv`: `matrix.reindex` is a linear equivalence
-* `matrix.reindex_alg_equiv`: `matrix.reindex` is a algebra equivalence
+* `matrix.reindex_linear_equiv R A`: `matrix.reindex` is an `R`-linear equivalence between
+  `A`-matrices.
+* `matrix.reindex_alg_equiv R`: `matrix.reindex` is an `R`-algebra equivalence between `R`-matrices.
 
 ## Tags
 
@@ -31,112 +32,120 @@ open_locale matrix
 
 
 
-variables {l m n : Type*} [fintype l] [fintype m] [fintype n]
-variables {l' m' n' : Type*} [fintype l'] [fintype m'] [fintype n']
+variables {l m n o : Type*} [fintype l] [fintype m] [fintype n] [fintype o]
+variables {l' m' n' o' : Type*} [fintype l'] [fintype m'] [fintype n'] [fintype o']
 variables {m'' n'' : Type*} [fintype m''] [fintype n'']
-variables {R : Type*}
+variables (R A : Type*)
+
+section add_comm_monoid
+variables [semiring R] [add_comm_monoid A] [module R A]
 
 /-- The natural map that reindexes a matrix's rows and columns with equivalent types,
 `matrix.reindex`, is a linear equivalence. -/
-def reindex_linear_equiv [semiring R] (eₘ : m ≃ m') (eₙ : n ≃ n') :
-  matrix m n R ≃ₗ[R] matrix m' n' R :=
-{ map_add'  := λ M N, rfl,
-  map_smul' := λ M N, rfl,
+def reindex_linear_equiv (eₘ : m ≃ m') (eₙ : n ≃ n') : matrix m n A ≃ₗ[R] matrix m' n' A :=
+{ map_add'  := λ _ _, rfl,
+  map_smul' := λ _ _, rfl,
   ..(reindex eₘ eₙ)}
 
-@[simp] lemma reindex_linear_equiv_apply [semiring R]
-  (eₘ : m ≃ m') (eₙ : n ≃ n') (M : matrix m n R) :
-  reindex_linear_equiv eₘ eₙ M = reindex eₘ eₙ M :=
+@[simp] lemma reindex_linear_equiv_apply
+  (eₘ : m ≃ m') (eₙ : n ≃ n') (M : matrix m n A) :
+  reindex_linear_equiv R A eₘ eₙ M = reindex eₘ eₙ M :=
 rfl
 
-@[simp] lemma reindex_linear_equiv_symm [semiring R] (eₘ : m ≃ m') (eₙ : n ≃ n') :
-  (reindex_linear_equiv eₘ eₙ : _ ≃ₗ[R] _).symm = reindex_linear_equiv eₘ.symm eₙ.symm :=
+@[simp] lemma reindex_linear_equiv_symm (eₘ : m ≃ m') (eₙ : n ≃ n') :
+  (reindex_linear_equiv R A eₘ eₙ).symm = reindex_linear_equiv R A eₘ.symm eₙ.symm :=
 rfl
 
-@[simp] lemma reindex_linear_equiv_refl_refl [semiring R] :
-  reindex_linear_equiv (equiv.refl m) (equiv.refl n) = linear_equiv.refl R _ :=
+@[simp] lemma reindex_linear_equiv_refl_refl :
+  reindex_linear_equiv R A (equiv.refl m) (equiv.refl n) = linear_equiv.refl R _ :=
 linear_equiv.ext $ λ _, rfl
 
-lemma reindex_linear_equiv_trans [semiring R] (e₁ : m ≃ m') (e₂ : n ≃ n') (e₁' : m' ≃ m'')
-  (e₂' : n' ≃ n'') : (reindex_linear_equiv e₁ e₂).trans (reindex_linear_equiv e₁' e₂') =
-   (reindex_linear_equiv (e₁.trans e₁') (e₂.trans e₂') : _ ≃ₗ[R] _) :=
+lemma reindex_linear_equiv_trans (e₁ : m ≃ m') (e₂ : n ≃ n') (e₁' : m' ≃ m'')
+  (e₂' : n' ≃ n'') : (reindex_linear_equiv R A e₁ e₂).trans (reindex_linear_equiv R A e₁' e₂') =
+   (reindex_linear_equiv R A (e₁.trans e₁') (e₂.trans e₂') : _ ≃ₗ[R] _) :=
 by { ext, refl }
 
-lemma reindex_linear_equiv_comp [semiring R] (e₁ : m ≃ m') (e₂ : n ≃ n') (e₁' : m' ≃ m'')
+lemma reindex_linear_equiv_comp (e₁ : m ≃ m') (e₂ : n ≃ n') (e₁' : m' ≃ m'')
   (e₂' : n' ≃ n'') :
-  (reindex_linear_equiv e₁' e₂' : _ ≃ₗ[R] _) ∘ (reindex_linear_equiv e₁ e₂ : _ ≃ₗ[R] _)
-  = reindex_linear_equiv (e₁.trans e₁') (e₂.trans e₂') :=
+  (reindex_linear_equiv R A e₁' e₂') ∘ (reindex_linear_equiv R A e₁ e₂)
+  = reindex_linear_equiv R A (e₁.trans e₁') (e₂.trans e₂') :=
 by { rw [← reindex_linear_equiv_trans], refl }
 
-lemma reindex_linear_equiv_comp_apply [semiring R] (e₁ : m ≃ m') (e₂ : n ≃ n') (e₁' : m' ≃ m'')
-  (e₂' : n' ≃ n'') (M : matrix m n R) :
-  (reindex_linear_equiv e₁' e₂') (reindex_linear_equiv e₁ e₂ M) =
-    reindex_linear_equiv (e₁.trans e₁') (e₂.trans e₂') M :=
+lemma reindex_linear_equiv_comp_apply (e₁ : m ≃ m') (e₂ : n ≃ n') (e₁' : m' ≃ m'')
+  (e₂' : n' ≃ n'') (M : matrix m n A) :
+  (reindex_linear_equiv R A e₁' e₂') (reindex_linear_equiv R A e₁ e₂ M) =
+    reindex_linear_equiv R A (e₁.trans e₁') (e₂.trans e₂') M :=
 minor_minor _ _ _ _ _
 
-lemma reindex_linear_equiv_one [semiring R] [decidable_eq m] [decidable_eq m']
-  (e : m ≃ m') : (reindex_linear_equiv e e (1 : matrix m m R)) = 1 :=
+lemma reindex_linear_equiv_one [decidable_eq m] [decidable_eq m'] [has_one A]
+  (e : m ≃ m') : (reindex_linear_equiv R A e e (1 : matrix m m A)) = 1 :=
 minor_one_equiv e.symm
 
-variables {o o' : Type*} [fintype o] [fintype o']
+end add_comm_monoid
 
-lemma reindex_linear_equiv_mul [semiring R]
-  (eₘ : m ≃ m') (eₙ : n ≃ n') (eₒ : o ≃ o') (M : matrix m n R) (N : matrix n o R) :
-  reindex_linear_equiv eₘ eₒ (M ⬝ N) =
-    reindex_linear_equiv eₘ eₙ M ⬝ reindex_linear_equiv eₙ eₒ N :=
+section semiring
+variables [semiring R] [semiring A] [module R A]
+
+lemma reindex_linear_equiv_mul
+  (eₘ : m ≃ m') (eₙ : n ≃ n') (eₒ : o ≃ o') (M : matrix m n A) (N : matrix n o A) :
+  reindex_linear_equiv R A eₘ eₒ (M ⬝ N) =
+    reindex_linear_equiv R A eₘ eₙ M ⬝ reindex_linear_equiv R A eₙ eₒ N :=
 minor_mul_equiv M N _ _ _
 
-lemma mul_reindex_linear_equiv_one [semiring R] [decidable_eq o] (e₁ : o ≃ n) (e₂ : o ≃ n')
-  (M : matrix m n R) : M.mul (reindex_linear_equiv e₁ e₂ 1) =
-    reindex_linear_equiv (equiv.refl m) (e₁.symm.trans e₂) M :=
+lemma mul_reindex_linear_equiv_one [decidable_eq o] (e₁ : o ≃ n) (e₂ : o ≃ n')
+  (M : matrix m n A) : M.mul (reindex_linear_equiv R A e₁ e₂ 1) =
+    reindex_linear_equiv R A (equiv.refl m) (e₁.symm.trans e₂) M :=
 mul_minor_one _ _ _
+
+end semiring
+
+section algebra
+
+variables [comm_semiring R] [decidable_eq m] [decidable_eq n]
 
 /--
 For square matrices with coefficients in commutative semirings, the natural map that reindexes
 a matrix's rows and columns with equivalent types, `matrix.reindex`, is an equivalence of algebras.
 -/
-def reindex_alg_equiv [comm_semiring R] [decidable_eq m] [decidable_eq n]
-  (e : m ≃ n) : matrix m m R ≃ₐ[R] matrix n n R :=
+def reindex_alg_equiv (e : m ≃ n) : matrix m m R ≃ₐ[R] matrix n n R :=
 { to_fun    := reindex e e,
-  map_mul'  := reindex_linear_equiv_mul e e e,
+  map_mul'  := reindex_linear_equiv_mul R R e e e,
   commutes' := λ r, by simp [algebra_map, algebra.to_ring_hom, minor_smul],
-  ..(reindex_linear_equiv e e) }
+  ..(reindex_linear_equiv R R e e) }
 
-@[simp] lemma reindex_alg_equiv_apply [comm_semiring R] [decidable_eq m] [decidable_eq n]
-  (e : m ≃ n) (M : matrix m m R) :
-  reindex_alg_equiv e M = reindex e e M :=
+@[simp] lemma reindex_alg_equiv_apply (e : m ≃ n) (M : matrix m m R) :
+  reindex_alg_equiv R e M = reindex e e M :=
 rfl
 
-@[simp] lemma reindex_alg_equiv_symm [comm_semiring R] [decidable_eq m] [decidable_eq n]
-  (e : m ≃ n) :
-  (reindex_alg_equiv e : _ ≃ₐ[R] _).symm = reindex_alg_equiv e.symm :=
+@[simp] lemma reindex_alg_equiv_symm (e : m ≃ n) :
+  (reindex_alg_equiv R e).symm = reindex_alg_equiv R e.symm :=
 rfl
 
-@[simp] lemma reindex_alg_equiv_refl [comm_semiring R] [decidable_eq m] :
-  reindex_alg_equiv (equiv.refl m) = (alg_equiv.refl : _ ≃ₐ[R] _) :=
+@[simp] lemma reindex_alg_equiv_refl : reindex_alg_equiv R (equiv.refl m) = alg_equiv.refl :=
 alg_equiv.ext $ λ _, rfl
 
-lemma reindex_alg_equiv_mul [comm_semiring R] [decidable_eq m] [decidable_eq n]
-  (e : m ≃ n) (M : matrix m m R) (N : matrix m m R) :
-  reindex_alg_equiv e (M ⬝ N) = reindex_alg_equiv e M ⬝ reindex_alg_equiv e N :=
-(reindex_alg_equiv e).map_mul M N
+lemma reindex_alg_equiv_mul (e : m ≃ n) (M : matrix m m R) (N : matrix m m R) :
+  reindex_alg_equiv R e (M ⬝ N) = reindex_alg_equiv R e M ⬝ reindex_alg_equiv R e N :=
+(reindex_alg_equiv R e).map_mul M N
+
+end algebra
 
 /-- Reindexing both indices along the same equivalence preserves the determinant.
 
 For the `simp` version of this lemma, see `det_minor_equiv_self`.
 -/
-lemma det_reindex_linear_equiv_self [decidable_eq m] [decidable_eq n] [comm_ring R]
-  (e : m ≃ n) (A : matrix m m R) :
-  det (reindex_linear_equiv e e A) = det A :=
-det_reindex_self e A
+lemma det_reindex_linear_equiv_self [comm_ring R] [decidable_eq m] [decidable_eq n]
+  (e : m ≃ n) (M : matrix m m R) :
+  det (reindex_linear_equiv R R e e M) = det M :=
+det_reindex_self e M
 
 /-- Reindexing both indices along the same equivalence preserves the determinant.
 
 For the `simp` version of this lemma, see `det_minor_equiv_self`.
 -/
-lemma det_reindex_alg_equiv [decidable_eq m] [decidable_eq n] [comm_ring R]
+lemma det_reindex_alg_equiv [comm_ring R] [decidable_eq m] [decidable_eq n]
   (e : m ≃ n) (A : matrix m m R) :
-  det (reindex_alg_equiv e A) = det A :=
+  det (reindex_alg_equiv R e A) = det A :=
 det_reindex_self e A
 
 end matrix


### PR DESCRIPTION
This changes `reindex_linear_equiv eₘ eₙ : matrix m m R ≃ₗ[R] matrix n n R` to `reindex_linear_equiv R A eₘ eₙ : matrix m m A ≃ₗ[R] matrix n n A`, which both works for a larger range of types, and eliminates the need for type ascriptions that was previously caused by the implicitness of `R`.

We cannot yet make the same generalization for `reindex_alg_equiv` as the `algebra R (matrix m m A)` structure implied by `algebra R A` is not in mathlib yet.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

cc @faenuccio, this addresses a comment in #8147.