### PR TITLE
[Merged by Bors] - feat(category_theory/adjunction/fully_faithful): Converses to `unit_is_iso_of_L_fully_faithful` and `counit_is_iso_of_R_fully_faithful`

### DIFF
--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -6,7 +6,7 @@ Authors: Scott Morrison
 import category_theory.adjunction.basic
 import category_theory.conj
 import category_theory.yoneda
-import tactic
+import tactic.apply_fun
 
 open category_theory
 

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -117,7 +117,7 @@ lemma R_faithful_of_counit_is_iso [is_iso (h.counit)] : faithful R :=
   begin
     rw ←(h.hom_equiv (R.obj X) Y).symm.apply_eq_iff_eq at H,
     simpa using ((inv h.counit).app X) ≫= H,
-  end}
+  end }
 
 -- TODO also do the statements from Riehl 4.5.13 for full and faithful separately?
 

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -75,8 +75,7 @@ by L whiskered with the counit. -/
 @[simps]
 noncomputable def whisker_left_L_counit_iso_of_is_iso_unit [is_iso h.unit] :
   L ⋙ R ⋙ L ≅ L :=
-(functor.associator _ _ _).symm ≪≫
-  iso_whisker_right (as_iso h.unit).symm L ≪≫ functor.left_unitor _
+(L.associator R L).symm ≪≫ iso_whisker_right (as_iso h.unit).symm L ≪≫ functor.left_unitor _
 
 /-- If the counit of an adjunction is an isomorphism, then its inverse on the image of R is given
 by R whiskered with the unit. -/
@@ -88,8 +87,7 @@ is_iso.inv_eq_of_inv_hom_id h.right_triangle_components
 @[simps]
 noncomputable def whisker_left_R_unit_iso_of_is_iso_counit [is_iso h.counit] :
   (R ⋙ L ⋙ R) ≅ R :=
-(functor.associator _ _ _ ).symm ≪≫
-  (iso_whisker_right (as_iso h.counit) R) ≪≫ functor.left_unitor _
+(R.associator L R).symm ≪≫ iso_whisker_right (as_iso h.counit) R ≪≫ functor.left_unitor _
 
 /-- If the unit is an isomorphism, then the left adjoint is full-/
 noncomputable

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -70,8 +70,7 @@ lemma inv_map_unit {X : C} [is_iso (h.unit.app X)] :
   inv (L.map (h.unit.app X)) = h.counit.app (L.obj X) :=
 is_iso.inv_eq_of_hom_inv_id h.left_triangle_components
 
-/-- If the unit of an adjunction is an isomorphism, then its inverse on the image of L is given
-by L whiskered with the counit. -/
+/-- If the unit is an isomorphism, bundle one has an isomorphism `L ⋙ R ⋙ L ≅ L`. -/
 @[simps]
 noncomputable def whisker_left_L_counit_iso_of_is_iso_unit [is_iso h.unit] :
   L ⋙ R ⋙ L ≅ L :=
@@ -84,8 +83,7 @@ lemma inv_counit_map {X : D} [is_iso (h.counit.app X)] :
   inv (R.map (h.counit.app X)) = h.unit.app (R.obj X) :=
 is_iso.inv_eq_of_inv_hom_id h.right_triangle_components
 
-/-- If the counit of an adjunction is an isomorphism, then its inverse on the image of R is given
-by R whiskered with the unit. -/
+/-- If the counit of an is an isomorphism, one has an isomorphism `(R ⋙ L ⋙ R) ≅ R`. -/
 @[simps]
 noncomputable def whisker_left_R_unit_iso_of_is_iso_counit [is_iso h.counit] :
   (R ⋙ L ⋙ R) ≅ R :=

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -68,12 +68,12 @@ by L whiskered with the counit. -/
 @[simp]
 lemma inv_map_unit {X : C} [is_iso (h.unit.app X)] :
   inv (L.map (h.unit.app X)) = h.counit.app (L.obj X) :=
-is_iso.inv_eq_of_hom_inv_id (h.left_triangle_components)
+is_iso.inv_eq_of_hom_inv_id h.left_triangle_components
 
 /-- If the unit of an adjunction is an isomorphism, then its inverse on the image of L is given
 by L whiskered with the counit. -/
 @[simps]
-noncomputable def whisker_left_L_counit_iso_of_is_iso_unit [is_iso (adjunction.unit h)] :
+noncomputable def whisker_left_L_counit_iso_of_is_iso_unit [is_iso h.unit] :
   L ⋙ R ⋙ L ≅ L :=
 (functor.associator _ _ _).symm ≪≫
   iso_whisker_right (as_iso (adjunction.unit h)).symm L ≪≫ functor.left_unitor _
@@ -82,8 +82,8 @@ noncomputable def whisker_left_L_counit_iso_of_is_iso_unit [is_iso (adjunction.u
 by R whiskered with the unit. -/
 @[simp]
 lemma inv_counit_map {X : D} [is_iso (h.counit.app X)] :
-  inv (R.map (h.counit.app X)) = (h.unit.app (R.obj X)) :=
-is_iso.inv_eq_of_inv_hom_id (h.right_triangle_components)
+  inv (R.map (h.counit.app X)) = h.unit.app (R.obj X) :=
+is_iso.inv_eq_of_inv_hom_id h.right_triangle_components
 
 @[simps]
 noncomputable def whisker_left_R_unit_iso_of_is_iso_counit [is_iso (h.counit)] :
@@ -93,11 +93,11 @@ noncomputable def whisker_left_R_unit_iso_of_is_iso_counit [is_iso (h.counit)] :
 
 /-- If the unit is an isomorphism, then the left adjoint is full-/
 noncomputable
-def L_full_of_unit_is_iso [is_iso (h.unit)] : full L :=
-{ preimage := λ X Y f, ((h.hom_equiv X (L.obj Y)) f) ≫ inv ((h.unit).app Y) }
+def L_full_of_unit_is_iso [is_iso h.unit] : full L :=
+{ preimage := λ X Y f, (h.hom_equiv X (L.obj Y) f) ≫ inv (h.unit.app Y) }
 
 /-- If the unit is an isomorphism, then the left adjoint is faithful-/
-lemma L_faithful_of_unit_is_iso [is_iso (adjunction.unit h)] : faithful L :=
+lemma L_faithful_of_unit_is_iso [is_iso h.unit] : faithful L :=
 { map_injective' := λ X Y f g H,
   begin
     rw ←(h.hom_equiv X (L.obj Y)).apply_eq_iff_eq at H,
@@ -106,8 +106,8 @@ lemma L_faithful_of_unit_is_iso [is_iso (adjunction.unit h)] : faithful L :=
 
 /-- If the counit is an isomorphism, then the right adjoint is full-/
 noncomputable
-def R_full_of_counit_is_iso [is_iso (h.counit)] : full R :=
-{ preimage := λ X Y f, ((inv (adjunction.counit h)).app X) ≫ (h.hom_equiv (R.obj X) Y).symm f }
+def R_full_of_counit_is_iso [is_iso h.counit] : full R :=
+{ preimage := λ X Y f, ((inv h.counit).app X) ≫ (h.hom_equiv (R.obj X) Y).symm f }
 
 
 /-- If the counit is an isomorphism, then the right adjoint is faithful-/
@@ -115,7 +115,7 @@ lemma R_faithful_of_counit_is_iso [is_iso (h.counit)] : faithful R :=
 { map_injective' := λ X Y f g H,
   begin
     rw ←(h.hom_equiv (R.obj X) Y).symm.apply_eq_iff_eq at H,
-    simpa using ((inv h.counit).app X) ≫= H,
+    simpa using (inv h.counit).app X ≫= H,
   end }
 
 -- TODO also do the statements from Riehl 4.5.13 for full and faithful separately?

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -107,7 +107,7 @@ lemma L_faithful_of_unit_is_iso [is_iso h.unit] : faithful L :=
 /-- If the counit is an isomorphism, then the right adjoint is full-/
 noncomputable
 def R_full_of_counit_is_iso [is_iso h.counit] : full R :=
-{ preimage := λ X Y f, ((inv h.counit).app X) ≫ (h.hom_equiv (R.obj X) Y).symm f }
+{ preimage := λ X Y f, inv (h.counit.app X) ≫ (h.hom_equiv (R.obj X) Y).symm f }
 
 
 /-- If the counit is an isomorphism, then the right adjoint is faithful-/
@@ -115,7 +115,7 @@ lemma R_faithful_of_counit_is_iso [is_iso h.counit] : faithful R :=
 { map_injective' := λ X Y f g H,
   begin
     rw ←(h.hom_equiv (R.obj X) Y).symm.apply_eq_iff_eq at H,
-    simpa using (inv h.counit).app X ≫= H,
+    simpa using inv (h.counit.app X) ≫= H,
   end }
 
 -- TODO also do the statements from Riehl 4.5.13 for full and faithful separately?

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -76,7 +76,7 @@ by L whiskered with the counit. -/
 noncomputable def whisker_left_L_counit_iso_of_is_iso_unit [is_iso h.unit] :
   L ⋙ R ⋙ L ≅ L :=
 (functor.associator _ _ _).symm ≪≫
-  iso_whisker_right (as_iso (adjunction.unit h)).symm L ≪≫ functor.left_unitor _
+  iso_whisker_right (as_iso h.unit).symm L ≪≫ functor.left_unitor _
 
 /-- If the counit of an adjunction is an isomorphism, then its inverse on the image of R is given
 by R whiskered with the unit. -/
@@ -86,10 +86,10 @@ lemma inv_counit_map {X : D} [is_iso (h.counit.app X)] :
 is_iso.inv_eq_of_inv_hom_id h.right_triangle_components
 
 @[simps]
-noncomputable def whisker_left_R_unit_iso_of_is_iso_counit [is_iso (h.counit)] :
-  R ≅ (R ⋙ L ⋙ R) :=
-(functor.left_unitor _).symm ≪≫
-  (iso_whisker_right (as_iso (h.counit)).symm R) ≪≫  (functor.associator _ _ _)
+noncomputable def whisker_left_R_unit_iso_of_is_iso_counit [is_iso h.counit] :
+  (R ⋙ L ⋙ R) ≅ R :=
+(functor.associator _ _ _ ).symm ≪≫
+  (iso_whisker_right (as_iso h.counit) R) ≪≫ functor.left_unitor _
 
 /-- If the unit is an isomorphism, then the left adjoint is full-/
 noncomputable
@@ -111,7 +111,7 @@ def R_full_of_counit_is_iso [is_iso h.counit] : full R :=
 
 
 /-- If the counit is an isomorphism, then the right adjoint is faithful-/
-lemma R_faithful_of_counit_is_iso [is_iso (h.counit)] : faithful R :=
+lemma R_faithful_of_counit_is_iso [is_iso h.counit] : faithful R :=
 { map_injective' := λ X Y f g H,
   begin
     rw ←(h.hom_equiv (R.obj X) Y).symm.apply_eq_iff_eq at H,

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -98,13 +98,12 @@ def L_full_of_unit_is_iso [is_iso (h.unit)] : full L :=
 { preimage := λ X Y f, ((h.hom_equiv X (L.obj Y)) f) ≫ inv ((h.unit).app Y) }
 
 /-- If the unit is an isomorphism, then the left adjoint is faithful-/
-def L_faithful_of_unit_is_iso [is_iso (adjunction.unit h)] : faithful L :=
-⟨ λ X Y,
+lemma L_faithful_of_unit_is_iso [is_iso (adjunction.unit h)] : faithful L :=
+{ map_injective' := λ X Y f g H,
   begin
-    intros f g H,
-    apply_fun (λ k, ((h.hom_equiv X (L.obj Y)) k) ≫ (inv (adjunction.unit h)).app Y) at H,
-    simpa using H,
-  end⟩
+    rw ←(h.hom_equiv X (L.obj Y)).apply_eq_iff_eq at H,
+    simpa using H =≫ inv (h.unit.app Y),
+  end }
 
 /-- If the counit is an isomorphism, then the right adjoint is full-/
 noncomputable

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -66,6 +66,7 @@ instance counit_is_iso_of_R_fully_faithful [full R] [faithful R] : is_iso (adjun
 
 /-- If the unit of an adjunction is an isomorphism, then its inverse on the image of L is given
 by L whiskered with the counit. -/
+@[reducible]
 def iso_of_L_counit [is_iso (adjunction.unit h)] : (L ⋙ R ⋙ L) ≅ L :=
 ⟨ ⟨(whisker_left L h.counit).app, (whisker_left L h.counit).naturality⟩,
   ⟨(whisker_right h.unit L).app, (whisker_right h.unit L).naturality⟩,
@@ -80,6 +81,7 @@ def iso_of_L_counit [is_iso (adjunction.unit h)] : (L ⋙ R ⋙ L) ≅ L :=
 
 /-- If the counit of an adjunction is an isomorphism, then its inverse on the image of R is given
 by R whiskered with the unit. -/
+@[reducible]
 def iso_of_R_unit [is_iso (adjunction.counit h)] : R ≅ (R ⋙ L ⋙ R) :=
 ⟨ ⟨(whisker_left R h.unit).app, (whisker_left R h.unit).naturality⟩,
   ⟨(whisker_right h.counit R).app, (whisker_right h.counit R).naturality⟩,
@@ -91,22 +93,6 @@ def iso_of_R_unit [is_iso (adjunction.counit h)] : R ≅ (R ⋙ L ⋙ R) :=
       rw [hom_comp_eq_id, ←comp_hom_eq_id],
       simpa [adjunction.right_triangle, functor.id_obj],
   end⟩
-
-@[simp]
-lemma iso_of_L_counit_hom_app [is_iso (adjunction.unit h)] {X : C} :
-  ((iso_of_L_counit h).hom.app X) = (whisker_left L h.counit).app X := by {refl}
-
-@[simp]
-lemma iso_of_L_counit_inv_app [is_iso (adjunction.unit h)] {X : C} :
-  ((iso_of_L_counit h).inv.app X) = (whisker_right h.unit L).app X := by {refl}
-
-@[simp]
-lemma iso_of_R_unit_hom_app [is_iso (adjunction.counit h)] {X : D} :
-  ((iso_of_R_unit h).hom.app X) = (whisker_left R h.unit).app X := by {refl}
-
-@[simp]
-lemma iso_of_R_unit_inv_app [is_iso (adjunction.counit h)] {X : D} :
-  ((iso_of_R_unit h).inv.app X) = (whisker_right h.counit R).app X := by {refl}
 
 /-- If the unit is an isomorphism, then the left adjoint is full-/
 noncomputable

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -84,6 +84,8 @@ lemma inv_counit_map {X : D} [is_iso (h.counit.app X)] :
   inv (R.map (h.counit.app X)) = h.unit.app (R.obj X) :=
 is_iso.inv_eq_of_inv_hom_id h.right_triangle_components
 
+/-- If the counit of an adjunction is an isomorphism, then its inverse on the image of R is given
+by R whiskered with the unit. -/
 @[simps]
 noncomputable def whisker_left_R_unit_iso_of_is_iso_counit [is_iso h.counit] :
   (R ⋙ L ⋙ R) ≅ R :=

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -67,7 +67,7 @@ instance counit_is_iso_of_R_fully_faithful [full R] [faithful R] : is_iso (adjun
 /-- If the unit of an adjunction is an isomorphism, then its inverse on the image of L is given
 by L whiskered with the counit. -/
 @[reducible]
-def iso_of_L_counit [is_iso (adjunction.unit h)] : (L ⋙ R ⋙ L) ≅ L :=
+def whisker_left_L_counit_iso_of_is_iso_unit [is_iso (adjunction.unit h)] : (L ⋙ R ⋙ L) ≅ L :=
 ⟨ ⟨(whisker_left L h.counit).app, (whisker_left L h.counit).naturality⟩,
   ⟨(whisker_right h.unit L).app, (whisker_right h.unit L).naturality⟩,
   begin
@@ -82,7 +82,7 @@ def iso_of_L_counit [is_iso (adjunction.unit h)] : (L ⋙ R ⋙ L) ≅ L :=
 /-- If the counit of an adjunction is an isomorphism, then its inverse on the image of R is given
 by R whiskered with the unit. -/
 @[reducible]
-def iso_of_R_unit [is_iso (adjunction.counit h)] : R ≅ (R ⋙ L ⋙ R) :=
+def whisker_left_R_unit_iso_of_is_iso_counit [is_iso (adjunction.counit h)] : R ≅ (R ⋙ L ⋙ R) :=
 ⟨ ⟨(whisker_left R h.unit).app, (whisker_left R h.unit).naturality⟩,
   ⟨(whisker_right h.counit R).app, (whisker_right h.counit R).naturality⟩,
   begin
@@ -101,11 +101,12 @@ def L_full_of_unit_is_iso [is_iso (adjunction.unit h)] : full L :=
   λ X Y f,
   begin
     simp, symmetry,
-    suffices H : f ≫ L.map (h.unit.app Y) ≫ ((iso_of_L_counit h).hom.app Y)
-      = L.map (h.unit.app X) ≫ L.map (R.map f) ≫ ((iso_of_L_counit h).hom.app Y),
+    suffices H : f ≫ L.map (h.unit.app Y) ≫ ((whisker_left_L_counit_iso_of_is_iso_unit h).hom.app Y)
+      = L.map (h.unit.app X) ≫ L.map (R.map f)
+        ≫ ((whisker_left_L_counit_iso_of_is_iso_unit h).hom.app Y),
     { rw [←assoc, ←assoc] at H,
-      rw [(nat_iso.cancel_nat_iso_hom_right (iso_of_L_counit h) (f ≫ L.map (h.unit.app Y))
-        (L.map (h.unit.app X) ≫ L.map (R.map f)))] at H,
+      rw [(nat_iso.cancel_nat_iso_hom_right (whisker_left_L_counit_iso_of_is_iso_unit h)
+      (f ≫ L.map (h.unit.app Y)) (L.map (h.unit.app X) ≫ L.map (R.map f)))] at H,
       rw [←assoc, is_iso.eq_comp_inv],
       exact H},
     { simp }
@@ -127,9 +128,10 @@ def R_full_of_counit_is_iso [is_iso (adjunction.counit h)] : full R :=
   λ X Y f,
   begin
     simp,
-    suffices H : ((iso_of_R_unit h).hom.app X) ≫ R.map (L.map f) ≫ R.map (h.counit.app Y)
-      = ((iso_of_R_unit h).hom.app X) ≫ R.map (h.counit.app X) ≫ f,
-    { rw [nat_iso.cancel_nat_iso_hom_left (iso_of_R_unit h)
+    suffices H : ((whisker_left_R_unit_iso_of_is_iso_counit h).hom.app X) ≫
+      R.map (L.map f) ≫ R.map (h.counit.app Y)
+      = ((whisker_left_R_unit_iso_of_is_iso_counit h).hom.app X) ≫ R.map (h.counit.app X) ≫ f,
+    { rw [nat_iso.cancel_nat_iso_hom_left (whisker_left_R_unit_iso_of_is_iso_counit h)
       (R.map (L.map f) ≫ R.map (h.counit.app Y)) (R.map (h.counit.app X) ≫ f)] at H,
       exact H },
     { simp }

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -6,7 +6,6 @@ Authors: Scott Morrison
 import category_theory.adjunction.basic
 import category_theory.conj
 import category_theory.yoneda
-import tactic.apply_fun
 
 open category_theory
 

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -66,18 +66,18 @@ instance counit_is_iso_of_R_fully_faithful [full R] [faithful R] : is_iso (adjun
 
 /-- If the unit of an adjunction is an isomorphism, then its inverse on the image of L is given
 by L whiskered with the counit. -/
-@[reducible]
-def whisker_left_L_counit_iso_of_is_iso_unit [is_iso (adjunction.unit h)] : (L ⋙ R ⋙ L) ≅ L :=
-⟨ ⟨(whisker_left L h.counit).app, (whisker_left L h.counit).naturality⟩,
-  ⟨(whisker_right h.unit L).app, (whisker_right h.unit L).naturality⟩,
-  begin
-    ext x, dsimp,
-    rw [comp_hom_eq_id, ←hom_comp_eq_id],
-    simpa [adjunction.right_triangle, functor.id_obj],
-  end, begin
-    ext x, dsimp,
-    simp [adjunction.right_triangle, functor.id_obj],
-  end⟩
+@[simp]
+lemma inv_map_unit {X : C} [is_iso (h.unit.app X)] :
+  inv (L.map (h.unit.app X)) = h.counit.app (L.obj X) :=
+is_iso.inv_eq_of_hom_inv_id (h.left_triangle_components)
+
+/-- If the unit of an adjunction is an isomorphism, then its inverse on the image of L is given
+by L whiskered with the counit. -/
+@[simps]
+noncomputable def whisker_left_L_counit_iso_of_is_iso_unit [is_iso (adjunction.unit h)] :
+  L ⋙ R ⋙ L ≅ L :=
+(functor.associator _ _ _).symm ≪≫
+  iso_whisker_right (as_iso (adjunction.unit h)).symm L ≪≫ functor.left_unitor _
 
 /-- If the counit of an adjunction is an isomorphism, then its inverse on the image of R is given
 by R whiskered with the unit. -/

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -81,36 +81,21 @@ noncomputable def whisker_left_L_counit_iso_of_is_iso_unit [is_iso (adjunction.u
 
 /-- If the counit of an adjunction is an isomorphism, then its inverse on the image of R is given
 by R whiskered with the unit. -/
-@[reducible]
-def whisker_left_R_unit_iso_of_is_iso_counit [is_iso (adjunction.counit h)] : R ≅ (R ⋙ L ⋙ R) :=
-⟨ ⟨(whisker_left R h.unit).app, (whisker_left R h.unit).naturality⟩,
-  ⟨(whisker_right h.counit R).app, (whisker_right h.counit R).naturality⟩,
-  begin
-      ext x, dsimp,
-      simp [adjunction.left_triangle, functor.id_obj],
-  end, begin
-      ext x, dsimp,
-      rw [hom_comp_eq_id, ←comp_hom_eq_id],
-      simpa [adjunction.right_triangle, functor.id_obj],
-  end⟩
+@[simp]
+lemma inv_counit_map {X : D} [is_iso (h.counit.app X)] :
+  inv (R.map (h.counit.app X)) = (h.unit.app (R.obj X)) :=
+is_iso.inv_eq_of_inv_hom_id (h.right_triangle_components)
+
+@[simps]
+noncomputable def whisker_left_R_unit_iso_of_is_iso_counit [is_iso (h.counit)] :
+  R ≅ (R ⋙ L ⋙ R) :=
+(functor.left_unitor _).symm ≪≫
+  (iso_whisker_right (as_iso (h.counit)).symm R) ≪≫  (functor.associator _ _ _)
 
 /-- If the unit is an isomorphism, then the left adjoint is full-/
 noncomputable
-def L_full_of_unit_is_iso [is_iso (adjunction.unit h)] : full L :=
-⟨ λ X Y f, ((h.hom_equiv X (L.obj Y)) f) ≫ (inv (adjunction.unit h)).app Y,
-  λ X Y f,
-  begin
-    simp, symmetry,
-    suffices H : f ≫ L.map (h.unit.app Y) ≫ ((whisker_left_L_counit_iso_of_is_iso_unit h).hom.app Y)
-      = L.map (h.unit.app X) ≫ L.map (R.map f)
-        ≫ ((whisker_left_L_counit_iso_of_is_iso_unit h).hom.app Y),
-    { rw [←assoc, ←assoc] at H,
-      rw [(nat_iso.cancel_nat_iso_hom_right (whisker_left_L_counit_iso_of_is_iso_unit h)
-      (f ≫ L.map (h.unit.app Y)) (L.map (h.unit.app X) ≫ L.map (R.map f)))] at H,
-      rw [←assoc, is_iso.eq_comp_inv],
-      exact H},
-    { simp }
-  end⟩
+def L_full_of_unit_is_iso [is_iso (h.unit)] : full L :=
+{ preimage := λ X Y f, ((h.hom_equiv X (L.obj Y)) f) ≫ inv ((h.unit).app Y) }
 
 /-- If the unit is an isomorphism, then the left adjoint is faithful-/
 def L_faithful_of_unit_is_iso [is_iso (adjunction.unit h)] : faithful L :=
@@ -123,28 +108,17 @@ def L_faithful_of_unit_is_iso [is_iso (adjunction.unit h)] : faithful L :=
 
 /-- If the counit is an isomorphism, then the right adjoint is full-/
 noncomputable
-def R_full_of_counit_is_iso [is_iso (adjunction.counit h)] : full R :=
-⟨ λ X Y f, ((inv (adjunction.counit h)).app X) ≫ (h.hom_equiv (R.obj X) Y).symm f,
-  λ X Y f,
-  begin
-    simp,
-    suffices H : ((whisker_left_R_unit_iso_of_is_iso_counit h).hom.app X) ≫
-      R.map (L.map f) ≫ R.map (h.counit.app Y)
-      = ((whisker_left_R_unit_iso_of_is_iso_counit h).hom.app X) ≫ R.map (h.counit.app X) ≫ f,
-    { rw [nat_iso.cancel_nat_iso_hom_left (whisker_left_R_unit_iso_of_is_iso_counit h)
-      (R.map (L.map f) ≫ R.map (h.counit.app Y)) (R.map (h.counit.app X) ≫ f)] at H,
-      exact H },
-    { simp }
-  end⟩
+def R_full_of_counit_is_iso [is_iso (h.counit)] : full R :=
+{ preimage := λ X Y f, ((inv (adjunction.counit h)).app X) ≫ (h.hom_equiv (R.obj X) Y).symm f }
+
 
 /-- If the counit is an isomorphism, then the right adjoint is faithful-/
-def R_faithful_of_counit_is_iso [is_iso (adjunction.counit h)] : faithful R :=
-⟨ λ X Y,
+lemma R_faithful_of_counit_is_iso [is_iso (h.counit)] : faithful R :=
+{ map_injective' := λ X Y f g H,
   begin
-    intros f g H,
-    apply_fun (λ k, ((inv (adjunction.counit h)).app X) ≫ (h.hom_equiv (R.obj X) Y).symm k) at H,
-    simpa using H,
-  end⟩
+    rw ←(h.hom_equiv (R.obj X) Y).symm.apply_eq_iff_eq at H,
+    simpa using ((inv h.counit).app X) ≫= H,
+  end}
 
 -- TODO also do the statements from Riehl 4.5.13 for full and faithful separately?
 


### PR DESCRIPTION
Add a converse to `unit_is_iso_of_L_fully_faithful` and to `counit_is_iso_of_R_fully_faithful`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I'm not sure wether I went with the best design choice by adding `whisker_left_L_counit_iso_of_is_iso_unit` and `whisker_left_R_unit_iso_of_is_iso_counit`. I wanted the fact that the inverse is explicit and computable in those case to be bundled nicely. The definition of their `hom` and `inv` component could be phrased in term of whiskers of the unit/counits with the functors and with unitors, but somehow it simplifies more nicely as it is. 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
