### PR TITLE
[Merged by Bors] - chore(measure_theory/{bochner_integration, simple_func_dense}): Move construction of embedding of L1 simple funcs

### DIFF
--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -26,16 +26,14 @@ The Bochner integral is defined following these steps:
   (See `simple_func.bintegral` and section `bintegral` for details. Also see `simple_func.integral`
   for the integral on simple functions of the type `simple_func α ℝ≥0∞`.)
 
-2. Use `α →ₛ E` to cut out the simple functions from L1 functions, and define integral
-  on these. The type of simple functions in L1 space is written as `α →₁ₛ[μ] E`.
+2. Transfer this definition to define the integral on `L1.simple_func α E` (notation :
+  `α →₁ₛ[μ] E`), see `L1.simple_func.integral`. Show that this integral is a continuous linear
+  map from `α →₁ₛ[μ] E` to `E`.
 
-3. Show that the embedding of `α →₁ₛ[μ] E` into L1 is a dense and uniform one.
-
-4. Show that the integral defined on `α →₁ₛ[μ] E` is a continuous linear map.
-
-5. Define the Bochner integral on L1 functions by extending the integral on integrable simple
-  functions `α →₁ₛ[μ] E` using `continuous_linear_map.extend`. Define the Bochner integral on
-  functions as the Bochner integral of its equivalence class in L1 space.
+3. Define the Bochner integral on L1 functions by extending the integral on integrable simple
+  functions `α →₁ₛ[μ] E` using `continuous_linear_map.extend` and the fact that the embedding of
+  `α →₁ₛ[μ] E` into `α →₁[μ] E` is dense. Define the Bochner integral on functions as the Bochner
+  integral of its equivalence class in L1 space.
 
 ## Main statements
 
@@ -80,8 +78,8 @@ The Bochner integral is defined following these steps:
 Some tips on how to prove a proposition if the API for the Bochner integral is not enough so that
 you need to unfold the definition of the Bochner integral and go back to simple functions.
 
-One method is to use the theorem `integrable.induction` in the file `set_integral`, which allows
-you to prove something for an arbitrary measurable + integrable function.
+One method is to use the theorem `integrable.induction` in the file `simple_func_dense`, which
+allows you to prove something for an arbitrary measurable + integrable function.
 
 Another method is using the following steps.
 See `integral_eq_lintegral_max_sub_lintegral_min` for a complicated example, which proves that
@@ -120,7 +118,7 @@ Use `is_closed_property` or `dense_range.induction_on` for this argument.
 * `α →₁[μ] E` : functions in L1 space, i.e., equivalence classes of integrable functions (defined in
                 `measure_theory/lp_space`)
 * `α →₁ₛ[μ] E` : simple functions in L1 space, i.e., equivalence classes of integrable simple
-                 functions
+                 functions (defined in `measure_theory/simple_func_dense`)
 * `∫ a, f a ∂μ` : integral of `f` with respect to a measure `μ`
 * `∫ a, f a` : integral of `f` with respect to `volume`, the default measure on the
                     ambient type
@@ -138,16 +136,18 @@ Bochner integral, simple function, function space, Lebesgue dominated convergenc
 
 noncomputable theory
 open_locale classical topological_space big_operators nnreal ennreal measure_theory
+open set filter topological_space ennreal emetric
 
 namespace measure_theory
 
-variables {α E : Type*} [measurable_space α] [linear_order E] [has_zero E]
-
 local infixr ` →ₛ `:25 := simple_func
+
+variables {α E F 𝕜 : Type*} [measurable_space α]
 
 namespace simple_func
 
 section pos_part
+variables [linear_order E] [has_zero E]
 
 /-- Positive part of a simple function. -/
 def pos_part (f : α →ₛ E) : α →ₛ E := f.map (λb, max b 0)
@@ -176,19 +176,6 @@ end
 
 end pos_part
 
-end simple_func
-
-end measure_theory
-
-namespace measure_theory
-open set filter topological_space ennreal emetric
-
-variables {α E F 𝕜 : Type*} [measurable_space α]
-
-local infixr ` →ₛ `:25 := simple_func
-
-namespace simple_func
-
 section integral
 /-!
 ### The Bochner integral of simple functions
@@ -198,117 +185,9 @@ and prove basic property of this integral.
 -/
 open finset
 
-variables [normed_group E] [measurable_space E] [normed_group F]
-variables {μ : measure α} {p : ℝ≥0∞}
-
-/-!
-#### Properties of simple functions
-
-A simple function `f : α →ₛ E` into a normed group `E` verifies, for a measure `μ`:
-- `mem_ℒp f 0 μ` and `mem_ℒp f ∞ μ`, since `f` is a.e.-measurable and bounded,
-- for `0 < p < ∞`, `mem_ℒp f p μ ↔ integrable f μ ↔ f.fin_meas_supp μ ↔ ∀ y ≠ 0, μ (f ⁻¹' {y}) < ∞`.
--/
-
-lemma exists_forall_norm_le (f : α →ₛ F) : ∃ C, ∀ x, ∥f x∥ ≤ C :=
-exists_forall_le (f.map (λ x, ∥x∥))
-
-lemma mem_ℒp_zero (f : α →ₛ E) (μ : measure α) : mem_ℒp f 0 μ :=
-mem_ℒp_zero_iff_ae_measurable.mpr f.ae_measurable
-
-lemma mem_ℒp_top (f : α →ₛ E) (μ : measure α) : mem_ℒp f ∞ μ :=
-let ⟨C, hfC⟩ := f.exists_forall_norm_le in
-mem_ℒp_top_of_bound f.ae_measurable C $ eventually_of_forall hfC
-
-protected lemma snorm'_eq {p : ℝ} (f : α →ₛ F) (μ : measure α) :
-  snorm' f p μ = (∑ y in f.range, (nnnorm y : ℝ≥0∞) ^ p * μ (f ⁻¹' {y})) ^ (1/p) :=
-have h_map : (λ a, (nnnorm (f a) : ℝ≥0∞) ^ p) = f.map (λ a : F, (nnnorm a : ℝ≥0∞) ^ p), by simp,
-by rw [snorm', h_map, lintegral_eq_lintegral, map_lintegral]
-
-lemma measure_preimage_lt_top_of_mem_ℒp  (hp_pos : 0 < p) (hp_ne_top : p ≠ ∞) (f : α →ₛ E)
-  (hf : mem_ℒp f p μ) (y : E) (hy_ne : y ≠ 0) :
-  μ (f ⁻¹' {y}) < ∞ :=
-begin
-  have hp_pos_real : 0 < p.to_real, from ennreal.to_real_pos_iff.mpr ⟨hp_pos, hp_ne_top⟩,
-  have hf_snorm := mem_ℒp.snorm_lt_top hf,
-  rw [snorm_eq_snorm' hp_pos.ne.symm hp_ne_top, f.snorm'_eq,
-    ← @ennreal.lt_rpow_one_div_iff _ _ (1 / p.to_real) (by simp [hp_pos_real]),
-    @ennreal.top_rpow_of_pos (1 / (1 / p.to_real)) (by simp [hp_pos_real]),
-    ennreal.sum_lt_top_iff] at hf_snorm,
-  by_cases hyf : y ∈ f.range,
-  swap,
-  { suffices h_empty : f ⁻¹' {y} = ∅,
-      by { rw [h_empty, measure_empty], exact ennreal.coe_lt_top, },
-    ext1 x,
-    rw [set.mem_preimage, set.mem_singleton_iff, mem_empty_eq, iff_false],
-    refine λ hxy, hyf _,
-    rw [mem_range, set.mem_range],
-    exact ⟨x, hxy⟩, },
-  specialize hf_snorm y hyf,
-  rw ennreal.mul_lt_top_iff at hf_snorm,
-  cases hf_snorm,
-  { exact hf_snorm.2, },
-  cases hf_snorm,
-  { refine absurd _ hy_ne,
-    simpa [hp_pos_real] using hf_snorm, },
-  { simp [hf_snorm], },
-end
-
-lemma mem_ℒp_of_finite_measure_preimage (p : ℝ≥0∞) {f : α →ₛ E} (hf : ∀ y ≠ 0, μ (f ⁻¹' {y}) < ∞) :
-  mem_ℒp f p μ :=
-begin
-  by_cases hp0 : p = 0,
-  { rw [hp0, mem_ℒp_zero_iff_ae_measurable], exact f.ae_measurable, },
-  by_cases hp_top : p = ∞,
-  { rw hp_top, exact mem_ℒp_top f μ, },
-  refine ⟨f.ae_measurable, _⟩,
-  rw [snorm_eq_snorm' hp0 hp_top, f.snorm'_eq],
-  refine ennreal.rpow_lt_top_of_nonneg (by simp) (ennreal.sum_lt_top_iff.mpr (λ y hy, _)).ne,
-  by_cases hy0 : y = 0,
-  { simp [hy0, ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) (ne.symm hp0), hp_top⟩], },
-  { refine ennreal.mul_lt_top _ (hf y hy0),
-    exact ennreal.rpow_lt_top_of_nonneg ennreal.to_real_nonneg ennreal.coe_ne_top, },
-end
-
-lemma mem_ℒp_iff {f : α →ₛ E} (hp_pos : 0 < p) (hp_ne_top : p ≠ ∞) :
-  mem_ℒp f p μ ↔ ∀ y ≠ 0, μ (f ⁻¹' {y}) < ∞ :=
-⟨λ h, measure_preimage_lt_top_of_mem_ℒp hp_pos hp_ne_top f h,
-  λ h, mem_ℒp_of_finite_measure_preimage p h⟩
-
-lemma integrable_iff {f : α →ₛ E} : integrable f μ ↔ ∀ y ≠ 0, μ (f ⁻¹' {y}) < ∞ :=
-mem_ℒp_one_iff_integrable.symm.trans $ mem_ℒp_iff ennreal.zero_lt_one ennreal.coe_ne_top
-
-lemma mem_ℒp_iff_integrable {f : α →ₛ E} (hp_pos : 0 < p) (hp_ne_top : p ≠ ∞) :
-  mem_ℒp f p μ ↔ integrable f μ :=
-(mem_ℒp_iff hp_pos hp_ne_top).trans integrable_iff.symm
-
-lemma mem_ℒp_iff_fin_meas_supp {f : α →ₛ E} (hp_pos : 0 < p) (hp_ne_top : p ≠ ∞) :
-  mem_ℒp f p μ ↔ f.fin_meas_supp μ :=
-(mem_ℒp_iff hp_pos hp_ne_top).trans fin_meas_supp_iff.symm
-
-lemma integrable_iff_fin_meas_supp {f : α →ₛ E} : integrable f μ ↔ f.fin_meas_supp μ :=
-integrable_iff.trans fin_meas_supp_iff.symm
-
-lemma fin_meas_supp.integrable {f : α →ₛ E} (h : f.fin_meas_supp μ) : integrable f μ :=
-integrable_iff_fin_meas_supp.2 h
-
-lemma integrable_pair [measurable_space F] {f : α →ₛ E} {g : α →ₛ F} :
-  integrable f μ → integrable g μ → integrable (pair f g) μ :=
-by simpa only [integrable_iff_fin_meas_supp] using fin_meas_supp.pair
-
-lemma mem_ℒp_of_finite_measure (f : α →ₛ E) (p : ℝ≥0∞) (μ : measure α) [finite_measure μ] :
-  mem_ℒp f p μ :=
-let ⟨C, hfC⟩ := f.exists_forall_norm_le in
-mem_ℒp.of_bound f.ae_measurable C $ eventually_of_forall hfC
-
-lemma integrable_of_finite_measure [finite_measure μ] (f : α →ₛ E) : integrable f μ :=
-mem_ℒp_one_iff_integrable.mp (f.mem_ℒp_of_finite_measure 1 μ)
-
-lemma measure_preimage_lt_top_of_integrable (f : α →ₛ E) (hf : integrable f μ) {x : E}
-  (hx : x ≠ 0) :
-  μ (f ⁻¹' {x}) < ∞ :=
-integrable_iff.mp hf x hx
-
-variables [normed_space ℝ F]
+variables [normed_group E] [measurable_space E]
+variables [normed_group F] [normed_space ℝ F]
+variables {μ : measure α}
 
 /-- Bochner integral of simple functions whose codomain is a real `normed_space`. -/
 def integral (μ : measure α) (f : α →ₛ F) : F :=
@@ -496,263 +375,9 @@ variables
   [normed_group F] [second_countable_topology F] [measurable_space F] [borel_space F]
   {μ : measure α}
 
-variables (α E μ)
-
-/-- `L1.simple_func` is a subspace of L1 consisting of equivalence classes of an integrable simple
-    function. -/
-def simple_func : add_subgroup (Lp E 1 μ) :=
-{ carrier := {f : α →₁[μ] E | ∃ (s : α →ₛ E), (ae_eq_fun.mk s s.ae_measurable : α →ₘ[μ] E) = f},
-  zero_mem' := ⟨0, rfl⟩,
-  add_mem' := λ f g ⟨s, hs⟩ ⟨t, ht⟩, ⟨s + t,
-      by simp only [←hs, ←ht, mk_add_mk, add_subgroup.coe_add, mk_eq_mk, simple_func.coe_add]⟩,
-  neg_mem' := λ f ⟨s, hs⟩, ⟨-s,
-      by simp only [←hs, neg_mk, simple_func.coe_neg, mk_eq_mk, add_subgroup.coe_neg]⟩ }
-
 variables {α E μ}
 
-notation α ` →₁ₛ[`:25 μ `] ` E := measure_theory.L1.simple_func α E μ
-
 namespace simple_func
-
-section instances
-/-! Simple functions in L1 space form a `normed_space`. -/
-
-instance : has_coe (α →₁ₛ[μ] E) (α →₁[μ] E) := coe_subtype
-instance : has_coe_to_fun (α →₁ₛ[μ] E) := ⟨λ f, α → E, λ f, ⇑(f : α →₁[μ] E)⟩
-
-@[simp, norm_cast] lemma coe_coe (f : α →₁ₛ[μ] E) : ⇑(f : α →₁[μ] E) = f := rfl
-protected lemma eq {f g : α →₁ₛ[μ] E} : (f : α →₁[μ] E) = (g : α →₁[μ] E) → f = g := subtype.eq
-protected lemma eq' {f g : α →₁ₛ[μ] E} : (f : α →ₘ[μ] E) = (g : α →ₘ[μ] E) → f = g :=
-subtype.eq ∘ subtype.eq
-
-@[norm_cast] protected lemma eq_iff {f g : α →₁ₛ[μ] E} : (f : α →₁[μ] E) = g ↔ f = g :=
-subtype.ext_iff.symm
-
-@[norm_cast] protected lemma eq_iff' {f g : α →₁ₛ[μ] E} : (f : α →ₘ[μ] E) = g ↔ f = g :=
-iff.intro (simple_func.eq') (congr_arg _)
-
-/-- L1 simple functions forms a `normed_group`, with the metric being inherited from L1 space,
-  i.e., `dist f g = ennreal.to_real (∫⁻ a, edist (f a) (g a)`).
-  Not declared as an instance as `α →₁ₛ[μ] β` will only be useful in the construction of the Bochner
-  integral. -/
-protected def normed_group : normed_group (α →₁ₛ[μ] E) := by apply_instance
-
-local attribute [instance] simple_func.normed_group
-
-/-- Functions `α →₁ₛ[μ] E` form an additive commutative group. -/
-instance : inhabited (α →₁ₛ[μ] E) := ⟨0⟩
-
-@[simp, norm_cast]
-lemma coe_zero : ((0 : α →₁ₛ[μ] E) : α →₁[μ] E) = 0 := rfl
-@[simp, norm_cast]
-lemma coe_add (f g : α →₁ₛ[μ] E) : ((f + g : α →₁ₛ[μ] E) : α →₁[μ] E) = f + g := rfl
-@[simp, norm_cast]
-lemma coe_neg (f : α →₁ₛ[μ] E) : ((-f : α →₁ₛ[μ] E) : α →₁[μ] E) = -f := rfl
-@[simp, norm_cast]
-lemma coe_sub (f g : α →₁ₛ[μ] E) : ((f - g : α →₁ₛ[μ] E) : α →₁[μ] E) = f - g := rfl
-
-@[simp] lemma edist_eq (f g : α →₁ₛ[μ] E) : edist f g = edist (f : α →₁[μ] E) (g : α →₁[μ] E) := rfl
-@[simp] lemma dist_eq (f g : α →₁ₛ[μ] E) : dist f g = dist (f : α →₁[μ] E) (g : α →₁[μ] E) := rfl
-
-lemma norm_eq (f : α →₁ₛ[μ] E) : ∥f∥ = ∥(f : α →₁[μ] E)∥ := rfl
-
-variables [normed_field 𝕜] [normed_space 𝕜 E] [measurable_space 𝕜] [opens_measurable_space 𝕜]
-
-/-- Not declared as an instance as `α →₁ₛ[μ] E` will only be useful in the construction of the
-Bochner integral. -/
-protected def has_scalar : has_scalar 𝕜 (α →₁ₛ[μ] E) := ⟨λk f, ⟨k • f,
-begin
-  rcases f with ⟨f, ⟨s, hs⟩⟩,
-  use k • s,
-  apply eq.trans (smul_mk k s s.ae_measurable).symm _,
-  rw hs,
-  refl,
-end ⟩⟩
-
-local attribute [instance, priority 10000] simple_func.has_scalar
-
-@[simp, norm_cast] lemma coe_smul (c : 𝕜) (f : α →₁ₛ[μ] E) :
-  ((c • f : α →₁ₛ[μ] E) : α →₁[μ] E) = c • (f : α →₁[μ] E) := rfl
-
-/-- Not declared as an instance as `α →₁ₛ[μ] E` will only be useful in the construction of the
-  Bochner integral. -/
-protected def module : module 𝕜 (α →₁ₛ[μ] E) :=
-{ one_smul  := λf, simple_func.eq (by { simp only [coe_smul], exact one_smul _ _ }),
-  mul_smul  := λx y f, simple_func.eq (by { simp only [coe_smul], exact mul_smul _ _ _ }),
-  smul_add  := λx f g, simple_func.eq (by { simp only [coe_smul], exact smul_add _ _ _ }),
-  smul_zero := λx, simple_func.eq (by { simp only [coe_smul], exact smul_zero _ }),
-  add_smul  := λx y f, simple_func.eq (by { simp only [coe_smul], exact add_smul _ _ _ }),
-  zero_smul := λf, simple_func.eq (by { simp only [coe_smul], exact zero_smul _ _ }) }
-
-local attribute [instance] simple_func.normed_group simple_func.module
-
-/-- Not declared as an instance as `α →₁ₛ[μ] E` will only be useful in the construction of the
-Bochner integral. -/
-protected def normed_space : normed_space 𝕜 (α →₁ₛ[μ] E) :=
-⟨ λc f, by { rw [norm_eq, norm_eq, coe_smul, norm_smul] } ⟩
-
-end instances
-
-local attribute [instance] simple_func.normed_group simple_func.normed_space
-
-section to_L1
-
-/-- Construct the equivalence class `[f]` of an integrable simple function `f`. -/
-@[reducible] def to_L1 (f : α →ₛ E) (hf : integrable f μ) : (α →₁ₛ[μ] E) :=
-⟨hf.to_L1 f, ⟨f, rfl⟩⟩
-
-lemma to_L1_eq_to_L1 (f : α →ₛ E) (hf : integrable f μ) :
-  (to_L1 f hf : α →₁[μ] E) = hf.to_L1 f := rfl
-
-lemma to_L1_eq_mk (f : α →ₛ E) (hf : integrable f μ) :
-  (to_L1 f hf : α →ₘ[μ] E) = ae_eq_fun.mk f f.ae_measurable := rfl
-
-lemma to_L1_zero : to_L1 (0 : α →ₛ E) (integrable_zero α E μ) = 0 := rfl
-
-lemma to_L1_add (f g : α →ₛ E) (hf : integrable f μ) (hg : integrable g μ) :
-  to_L1 (f + g) (hf.add hg) = to_L1 f hf + to_L1 g hg := rfl
-
-lemma to_L1_neg (f : α →ₛ E) (hf : integrable f μ) :
-  to_L1 (-f) hf.neg = -to_L1 f hf := rfl
-
-lemma to_L1_sub (f g : α →ₛ E) (hf : integrable f μ) (hg : integrable g μ) :
-  to_L1 (f - g) (hf.sub hg) = to_L1 f hf - to_L1 g hg :=
-by { simp only [sub_eq_add_neg, ← to_L1_neg, ← to_L1_add], refl }
-
-variables [normed_field 𝕜] [normed_space 𝕜 E] [measurable_space 𝕜] [opens_measurable_space 𝕜]
-
-lemma to_L1_smul (f : α →ₛ E) (hf : integrable f μ) (c : 𝕜) :
-  to_L1 (c • f) (hf.smul c) = c • to_L1 f hf := rfl
-
-lemma norm_to_L1 (f : α →ₛ E) (hf : integrable f μ) :
-  ∥to_L1 f hf∥ = ennreal.to_real (∫⁻ a, edist (f a) 0 ∂μ) :=
-by simp [to_L1, integrable.norm_to_L1]
-
-end to_L1
-
-section to_simple_func
-
-/-- Find a representative of a `L1.simple_func`. -/
-def to_simple_func (f : α →₁ₛ[μ] E) : α →ₛ E := classical.some f.2
-
-/-- `(to_simple_func f)` is measurable. -/
-@[measurability]
-protected lemma measurable (f : α →₁ₛ[μ] E) : measurable (to_simple_func f) :=
-(to_simple_func f).measurable
-
-@[measurability]
-protected lemma ae_measurable (f : α →₁ₛ[μ] E) : ae_measurable (to_simple_func f) μ :=
-(simple_func.measurable f).ae_measurable
-
-/-- `to_simple_func f` is integrable. -/
-protected lemma integrable (f : α →₁ₛ[μ] E) : integrable (to_simple_func f) μ :=
-begin
-  apply (integrable_mk (simple_func.ae_measurable f)).1,
-  convert integrable_coe_fn f.val,
-  exact classical.some_spec f.2
-end
-
-lemma to_L1_to_simple_func (f : α →₁ₛ[μ] E) :
-  to_L1 (to_simple_func f) (simple_func.integrable f) = f :=
-by { rw ← simple_func.eq_iff', exact classical.some_spec f.2 }
-
-lemma to_simple_func_to_L1 (f : α →ₛ E) (hfi : integrable f μ) :
-  to_simple_func (to_L1 f hfi) =ᵐ[μ] f :=
-by { rw ← mk_eq_mk, exact classical.some_spec (to_L1 f hfi).2 }
-
-lemma to_simple_func_eq_to_fun (f : α →₁ₛ[μ] E) : to_simple_func f =ᵐ[μ] f :=
-begin
-  simp_rw [← integrable.to_L1_eq_to_L1_iff (to_simple_func f) f (simple_func.integrable f)
-    (integrable_coe_fn ↑f), subtype.ext_iff],
-  convert classical.some_spec f.coe_prop,
-  exact integrable.to_L1_coe_fn _ _,
-end
-
-variables (E μ)
-lemma zero_to_simple_func : to_simple_func (0 : α →₁ₛ[μ] E) =ᵐ[μ] 0 :=
-begin
-  filter_upwards [to_simple_func_eq_to_fun (0 : α →₁ₛ[μ] E), Lp.coe_fn_zero E 1 μ],
-  assume a h₁ h₂,
-  rwa h₁,
-end
-variables {E μ}
-
-lemma add_to_simple_func (f g : α →₁ₛ[μ] E) :
-  to_simple_func (f + g) =ᵐ[μ] to_simple_func f + to_simple_func g :=
-begin
-  filter_upwards [to_simple_func_eq_to_fun (f + g), to_simple_func_eq_to_fun f,
-    to_simple_func_eq_to_fun g, Lp.coe_fn_add (f :  α →₁[μ] E) g],
-  assume a,
-  simp only [← coe_coe, coe_add, pi.add_apply],
-  iterate 4 { assume h, rw h }
-end
-
-lemma neg_to_simple_func (f : α →₁ₛ[μ] E) : to_simple_func (-f) =ᵐ[μ] - to_simple_func f :=
-begin
-  filter_upwards [to_simple_func_eq_to_fun (-f), to_simple_func_eq_to_fun f,
-    Lp.coe_fn_neg (f : α →₁[μ] E)],
-  assume a,
-  simp only [pi.neg_apply, coe_neg, ← coe_coe],
-  repeat { assume h, rw h }
-end
-
-lemma sub_to_simple_func (f g : α →₁ₛ[μ] E) :
-  to_simple_func (f - g) =ᵐ[μ] to_simple_func f - to_simple_func g :=
-begin
-  filter_upwards [to_simple_func_eq_to_fun (f - g), to_simple_func_eq_to_fun f,
-    to_simple_func_eq_to_fun g, Lp.coe_fn_sub (f : α →₁[μ] E) g],
-  assume a,
-  simp only [coe_sub, pi.sub_apply, ← coe_coe],
-  repeat { assume h, rw h }
-end
-
-variables [normed_field 𝕜] [normed_space 𝕜 E] [measurable_space 𝕜] [opens_measurable_space 𝕜]
-
-lemma smul_to_simple_func (k : 𝕜) (f : α →₁ₛ[μ] E) :
-  to_simple_func (k • f) =ᵐ[μ] k • to_simple_func f :=
-begin
-  filter_upwards [to_simple_func_eq_to_fun (k • f), to_simple_func_eq_to_fun f,
-    Lp.coe_fn_smul k (f : α →₁[μ] E)],
-  assume a,
-  simp only [pi.smul_apply, coe_smul, ← coe_coe],
-  repeat { assume h, rw h }
-end
-
-lemma lintegral_edist_to_simple_func_lt_top (f g : α →₁ₛ[μ] E) :
-  ∫⁻ (x : α), edist (to_simple_func f x) (to_simple_func g x) ∂μ < ∞ :=
-begin
-  rw lintegral_rw₂ (to_simple_func_eq_to_fun f) (to_simple_func_eq_to_fun g),
-  exact lintegral_edist_lt_top (integrable_coe_fn _) (integrable_coe_fn _)
-end
-
-lemma dist_to_simple_func (f g : α →₁ₛ[μ] E) : dist f g =
-  ennreal.to_real (∫⁻ x, edist (to_simple_func f x) (to_simple_func g x) ∂μ) :=
-begin
-  rw [dist_eq, L1.dist_def, ennreal.to_real_eq_to_real],
-  { rw lintegral_rw₂, repeat { exact ae_eq_symm (to_simple_func_eq_to_fun _) } },
-  { exact lintegral_edist_lt_top (integrable_coe_fn _) (integrable_coe_fn _) },
-  { exact lintegral_edist_to_simple_func_lt_top _ _ }
-end
-
-lemma norm_to_simple_func (f : α →₁ₛ[μ] E) :
-  ∥f∥ = ennreal.to_real (∫⁻ (a : α), nnnorm ((to_simple_func f) a) ∂μ) :=
-calc ∥f∥ =
-  ennreal.to_real (∫⁻x, edist ((to_simple_func f) x) (to_simple_func (0 : α →₁ₛ[μ] E) x) ∂μ) :
-begin
-  rw [← dist_zero_right, dist_to_simple_func]
-end
-... = ennreal.to_real (∫⁻ (x : α), (coe ∘ nnnorm) ((to_simple_func f) x) ∂μ) :
-begin
-  rw lintegral_nnnorm_eq_lintegral_edist,
-  have : ∫⁻ x, edist ((to_simple_func f) x) ((to_simple_func (0 : α →₁ₛ[μ] E)) x) ∂μ =
-    ∫⁻ x, edist ((to_simple_func f) x) 0 ∂μ,
-  { refine lintegral_congr_ae ((zero_to_simple_func E μ).mono (λ a h, _)),
-    rw [h, pi.zero_apply] },
-  rw [ennreal.to_real_eq_to_real],
-  { exact this },
-  { exact lintegral_edist_to_simple_func_lt_top _ _ },
-  { rw ← this, exact lintegral_edist_to_simple_func_lt_top _ _ }
-end
 
 lemma norm_eq_integral (f : α →₁ₛ[μ] E) : ∥f∥ = ((to_simple_func f).map norm).integral μ :=
 begin
@@ -761,52 +386,6 @@ begin
   { exact (simple_func.integrable f).norm },
   { exact eventually_of_forall (λ x, norm_nonneg _) }
 end
-
-end to_simple_func
-
-section coe_to_L1
-
-protected lemma uniform_continuous : uniform_continuous (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
-uniform_continuous_comap
-
-protected lemma uniform_embedding : uniform_embedding (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
-uniform_embedding_comap subtype.val_injective
-
-protected lemma uniform_inducing : uniform_inducing (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
-simple_func.uniform_embedding.to_uniform_inducing
-
-protected lemma dense_embedding : dense_embedding (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
-begin
-  apply simple_func.uniform_embedding.dense_embedding,
-  assume f,
-  rw mem_closure_iff_seq_limit,
-  have hfi' : integrable f μ := integrable_coe_fn f,
-  refine ⟨λ n, ↑(to_L1 (simple_func.approx_on f (Lp.measurable f) univ 0 trivial n)
-    (simple_func.integrable_approx_on_univ (Lp.measurable f) hfi' n)), λ n, mem_range_self _, _⟩,
-  convert simple_func.tendsto_approx_on_univ_L1 (Lp.measurable f) hfi',
-  rw integrable.to_L1_coe_fn
-end
-
-protected lemma dense_inducing : dense_inducing (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
-simple_func.dense_embedding.to_dense_inducing
-
-protected lemma dense_range : dense_range (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
-simple_func.dense_inducing.dense
-
-variables [normed_field 𝕜] [normed_space 𝕜 E] [measurable_space 𝕜] [opens_measurable_space 𝕜]
-
-variables (α E 𝕜)
-
-/-- The uniform and dense embedding of L1 simple functions into L1 functions. -/
-def coe_to_L1 : (α →₁ₛ[μ] E) →L[𝕜] (α →₁[μ] E) :=
-{ to_fun := (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)),
-  map_add' := λf g, rfl,
-  map_smul' := λk f, rfl,
-  cont := L1.simple_func.uniform_continuous.continuous, }
-
-variables {α E 𝕜}
-
-end coe_to_L1
 
 section pos_part
 
@@ -831,9 +410,15 @@ lemma coe_neg_part (f : α →₁ₛ[μ] ℝ) : (neg_part f : α →₁[μ] ℝ)
 end pos_part
 
 section simple_func_integral
-/-! Define the Bochner integral on `α →₁ₛ[μ] E` and prove basic properties of this integral. -/
+/-!
+### The Bochner integral of `L1`
+
+Define the Bochner integral on `α →₁ₛ[μ] E` by extension from the simple functions `α →₁ₛ[μ] E`,
+and prove basic properties of this integral. -/
 
 variables [normed_field 𝕜] [normed_space 𝕜 E] [normed_space ℝ E] [smul_comm_class ℝ 𝕜 E]
+
+local attribute [instance] simple_func.normed_group simple_func.normed_space
 
 /-- The Bochner integral over simple functions in L1 space. -/
 def integral (f : α →₁ₛ[μ] E) : E := ((to_simple_func f)).integral μ
@@ -1055,6 +640,14 @@ end pos_part
 end integration_in_L1
 
 end L1
+
+/-!
+### The Bochner integral on functions
+
+Define the Bochner integral on functions generally to be the `L1` Bochner integral, for integrable
+functions, and 0 otherwise; prove its basic properties.
+
+-/
 
 variables [normed_group E] [second_countable_topology E] [normed_space ℝ E] [complete_space E]
   [measurable_space E] [borel_space E]

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -32,8 +32,10 @@ The Bochner integral is defined following these steps:
 
 3. Define the Bochner integral on L1 functions by extending the integral on integrable simple
   functions `α →₁ₛ[μ] E` using `continuous_linear_map.extend` and the fact that the embedding of
-  `α →₁ₛ[μ] E` into `α →₁[μ] E` is dense. Define the Bochner integral on functions as the Bochner
-  integral of its equivalence class in L1 space.
+  `α →₁ₛ[μ] E` into `α →₁[μ] E` is dense.
+
+4. Define the Bochner integral on functions as the Bochner integral of its equivalence class in L1
+  space, if it is in L1, and 0 otherwise.
 
 ## Main statements
 

--- a/src/measure_theory/bochner_integration.lean
+++ b/src/measure_theory/bochner_integration.lean
@@ -140,9 +140,9 @@ open set filter topological_space ennreal emetric
 
 namespace measure_theory
 
-local infixr ` →ₛ `:25 := simple_func
-
 variables {α E F 𝕜 : Type*} [measurable_space α]
+
+local infixr ` →ₛ `:25 := simple_func
 
 namespace simple_func
 

--- a/src/measure_theory/simple_func_dense.lean
+++ b/src/measure_theory/simple_func_dense.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Zhouhang Zhou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou, Yury Kudryashov, Heather Macbeth
 -/
-import measure_theory.l1_space
+import measure_theory.integrable_on
 
 /-!
 # Density of simple functions
@@ -18,6 +18,8 @@ both pointwise and in `Lᵖ` norm, by a sequence of simple functions.
 * `measure_theory.simple_func.approx_on (f : β → α) (hf : measurable f) (s : set α) (y₀ : α)
   (h₀ : y₀ ∈ s) [separable_space s] (n : ℕ) : β →ₛ α` : a simple function that takes values in `s`
   and approximates `f`.
+* `measure_theory.L1.simple_func`, the type of `L1` simple functions (notation: `α →₁ₛ[μ] E`)
+* `coe_to_L1`, the embedding of `α →₁ₛ[μ] E` into `α →₁[μ] E`
 
 ## Main results
 
@@ -30,6 +32,10 @@ both pointwise and in `Lᵖ` norm, by a sequence of simple functions.
 * `tendsto_approx_on_univ_L1` (L¹ convergence): If `E` is a `normed_group` and `f` is measurable
   and integrable, then the simple functions `simple_func.approx_on f hf s 0 h₀ n` may be considered
   as elements of `Lp E 1 μ`, and they tend in L¹ to `f`.
+* `L1.simple_func.dense_embedding`: the embedding `coe_to_L1` of the `L1` simple functions into
+  `L1` is dense.
+* `integrable.induction`: to prove a predicate for all elements of `L1`, it suffices to check that
+  it behaves correctly on simple functions in `L1`.
 
 ## TODO
 
@@ -38,14 +44,16 @@ For `E` finite-dimensional, simple functions `α →ₛ E` are dense in L^∞ --
 ## Notations
 
 * `α →ₛ β` (local notation): the type of simple functions `α → β`.
+* `α →₁ₛ[μ] E`: the type of `L1` simple functions `α → β`.
 -/
 
-open set filter topological_space
-open_locale classical topological_space ennreal
-variables {α β ι E : Type*}
+open set function filter topological_space ennreal emetric finset
+open_locale classical topological_space ennreal measure_theory big_operators
+variables {α β ι E F 𝕜 : Type*}
+
+noncomputable theory
 
 namespace measure_theory
-open ennreal emetric
 
 local infixr ` →ₛ `:25 := simple_func
 
@@ -346,6 +354,489 @@ tendsto_approx_on_univ_Lp one_ne_top fmeas _
 
 end integrable
 
+section simple_func_properties
+
+variables [measurable_space α]
+variables [normed_group E] [measurable_space E] [normed_group F]
+variables {μ : measure α} {p : ℝ≥0∞}
+
+/-!
+### Properties of simple functions in `Lp` spaces
+
+A simple function `f : α →ₛ E` into a normed group `E` verifies, for a measure `μ`:
+- `mem_ℒp f 0 μ` and `mem_ℒp f ∞ μ`, since `f` is a.e.-measurable and bounded,
+- for `0 < p < ∞`, `mem_ℒp f p μ ↔ integrable f μ ↔ f.fin_meas_supp μ ↔ ∀ y ≠ 0, μ (f ⁻¹' {y}) < ∞`.
+-/
+
+lemma exists_forall_norm_le (f : α →ₛ F) : ∃ C, ∀ x, ∥f x∥ ≤ C :=
+exists_forall_le (f.map (λ x, ∥x∥))
+
+lemma mem_ℒp_zero (f : α →ₛ E) (μ : measure α) : mem_ℒp f 0 μ :=
+mem_ℒp_zero_iff_ae_measurable.mpr f.ae_measurable
+
+lemma mem_ℒp_top (f : α →ₛ E) (μ : measure α) : mem_ℒp f ∞ μ :=
+let ⟨C, hfC⟩ := f.exists_forall_norm_le in
+mem_ℒp_top_of_bound f.ae_measurable C $ eventually_of_forall hfC
+
+protected lemma snorm'_eq {p : ℝ} (f : α →ₛ F) (μ : measure α) :
+  snorm' f p μ = (∑ y in f.range, (nnnorm y : ℝ≥0∞) ^ p * μ (f ⁻¹' {y})) ^ (1/p) :=
+have h_map : (λ a, (nnnorm (f a) : ℝ≥0∞) ^ p) = f.map (λ a : F, (nnnorm a : ℝ≥0∞) ^ p), by simp,
+by rw [snorm', h_map, lintegral_eq_lintegral, map_lintegral]
+
+lemma measure_preimage_lt_top_of_mem_ℒp  (hp_pos : 0 < p) (hp_ne_top : p ≠ ∞) (f : α →ₛ E)
+  (hf : mem_ℒp f p μ) (y : E) (hy_ne : y ≠ 0) :
+  μ (f ⁻¹' {y}) < ∞ :=
+begin
+  have hp_pos_real : 0 < p.to_real, from ennreal.to_real_pos_iff.mpr ⟨hp_pos, hp_ne_top⟩,
+  have hf_snorm := mem_ℒp.snorm_lt_top hf,
+  rw [snorm_eq_snorm' hp_pos.ne.symm hp_ne_top, f.snorm'_eq,
+    ← @ennreal.lt_rpow_one_div_iff _ _ (1 / p.to_real) (by simp [hp_pos_real]),
+    @ennreal.top_rpow_of_pos (1 / (1 / p.to_real)) (by simp [hp_pos_real]),
+    ennreal.sum_lt_top_iff] at hf_snorm,
+  by_cases hyf : y ∈ f.range,
+  swap,
+  { suffices h_empty : f ⁻¹' {y} = ∅,
+      by { rw [h_empty, measure_empty], exact ennreal.coe_lt_top, },
+    ext1 x,
+    rw [set.mem_preimage, set.mem_singleton_iff, mem_empty_eq, iff_false],
+    refine λ hxy, hyf _,
+    rw [mem_range, set.mem_range],
+    exact ⟨x, hxy⟩, },
+  specialize hf_snorm y hyf,
+  rw ennreal.mul_lt_top_iff at hf_snorm,
+  cases hf_snorm,
+  { exact hf_snorm.2, },
+  cases hf_snorm,
+  { refine absurd _ hy_ne,
+    simpa [hp_pos_real] using hf_snorm, },
+  { simp [hf_snorm], },
+end
+
+lemma mem_ℒp_of_finite_measure_preimage (p : ℝ≥0∞) {f : α →ₛ E} (hf : ∀ y ≠ 0, μ (f ⁻¹' {y}) < ∞) :
+  mem_ℒp f p μ :=
+begin
+  by_cases hp0 : p = 0,
+  { rw [hp0, mem_ℒp_zero_iff_ae_measurable], exact f.ae_measurable, },
+  by_cases hp_top : p = ∞,
+  { rw hp_top, exact mem_ℒp_top f μ, },
+  refine ⟨f.ae_measurable, _⟩,
+  rw [snorm_eq_snorm' hp0 hp_top, f.snorm'_eq],
+  refine ennreal.rpow_lt_top_of_nonneg (by simp) (ennreal.sum_lt_top_iff.mpr (λ y hy, _)).ne,
+  by_cases hy0 : y = 0,
+  { simp [hy0, ennreal.to_real_pos_iff.mpr ⟨lt_of_le_of_ne (zero_le _) (ne.symm hp0), hp_top⟩], },
+  { refine ennreal.mul_lt_top _ (hf y hy0),
+    exact ennreal.rpow_lt_top_of_nonneg ennreal.to_real_nonneg ennreal.coe_ne_top, },
+end
+
+lemma mem_ℒp_iff {f : α →ₛ E} (hp_pos : 0 < p) (hp_ne_top : p ≠ ∞) :
+  mem_ℒp f p μ ↔ ∀ y ≠ 0, μ (f ⁻¹' {y}) < ∞ :=
+⟨λ h, measure_preimage_lt_top_of_mem_ℒp hp_pos hp_ne_top f h,
+  λ h, mem_ℒp_of_finite_measure_preimage p h⟩
+
+lemma integrable_iff {f : α →ₛ E} : integrable f μ ↔ ∀ y ≠ 0, μ (f ⁻¹' {y}) < ∞ :=
+mem_ℒp_one_iff_integrable.symm.trans $ mem_ℒp_iff ennreal.zero_lt_one ennreal.coe_ne_top
+
+lemma mem_ℒp_iff_integrable {f : α →ₛ E} (hp_pos : 0 < p) (hp_ne_top : p ≠ ∞) :
+  mem_ℒp f p μ ↔ integrable f μ :=
+(mem_ℒp_iff hp_pos hp_ne_top).trans integrable_iff.symm
+
+lemma mem_ℒp_iff_fin_meas_supp {f : α →ₛ E} (hp_pos : 0 < p) (hp_ne_top : p ≠ ∞) :
+  mem_ℒp f p μ ↔ f.fin_meas_supp μ :=
+(mem_ℒp_iff hp_pos hp_ne_top).trans fin_meas_supp_iff.symm
+
+lemma integrable_iff_fin_meas_supp {f : α →ₛ E} : integrable f μ ↔ f.fin_meas_supp μ :=
+integrable_iff.trans fin_meas_supp_iff.symm
+
+lemma fin_meas_supp.integrable {f : α →ₛ E} (h : f.fin_meas_supp μ) : integrable f μ :=
+integrable_iff_fin_meas_supp.2 h
+
+lemma integrable_pair [measurable_space F] {f : α →ₛ E} {g : α →ₛ F} :
+  integrable f μ → integrable g μ → integrable (pair f g) μ :=
+by simpa only [integrable_iff_fin_meas_supp] using fin_meas_supp.pair
+
+lemma mem_ℒp_of_finite_measure (f : α →ₛ E) (p : ℝ≥0∞) (μ : measure α) [finite_measure μ] :
+  mem_ℒp f p μ :=
+let ⟨C, hfC⟩ := f.exists_forall_norm_le in
+mem_ℒp.of_bound f.ae_measurable C $ eventually_of_forall hfC
+
+lemma integrable_of_finite_measure [finite_measure μ] (f : α →ₛ E) : integrable f μ :=
+mem_ℒp_one_iff_integrable.mp (f.mem_ℒp_of_finite_measure 1 μ)
+
+lemma measure_preimage_lt_top_of_integrable (f : α →ₛ E) (hf : integrable f μ) {x : E}
+  (hx : x ≠ 0) :
+  μ (f ⁻¹' {x}) < ∞ :=
+integrable_iff.mp hf x hx
+
+end simple_func_properties
+
 end simple_func
+
+/-! Construction of the space of `L1` simple functions, and its dense embedding into `L1`. -/
+namespace L1
+
+open ae_eq_fun
+
+variables
+  [measurable_space α]
+  [normed_group E] [second_countable_topology E] [measurable_space E] [borel_space E]
+  [normed_group F] [second_countable_topology F] [measurable_space F] [borel_space F]
+  {μ : measure α}
+
+variables (α E μ)
+
+/-- `L1.simple_func` is a subspace of L1 consisting of equivalence classes of an integrable simple
+    function. -/
+def simple_func : add_subgroup (Lp E 1 μ) :=
+{ carrier := {f : α →₁[μ] E | ∃ (s : α →ₛ E), (ae_eq_fun.mk s s.ae_measurable : α →ₘ[μ] E) = f},
+  zero_mem' := ⟨0, rfl⟩,
+  add_mem' := λ f g ⟨s, hs⟩ ⟨t, ht⟩, ⟨s + t,
+      by simp only [←hs, ←ht, mk_add_mk, add_subgroup.coe_add, mk_eq_mk, simple_func.coe_add]⟩,
+  neg_mem' := λ f ⟨s, hs⟩, ⟨-s,
+      by simp only [←hs, neg_mk, simple_func.coe_neg, mk_eq_mk, add_subgroup.coe_neg]⟩ }
+
+variables {α E μ}
+
+notation α ` →₁ₛ[`:25 μ `] ` E := measure_theory.L1.simple_func α E μ
+
+namespace simple_func
+
+section instances
+/-! Simple functions in L1 space form a `normed_space`. -/
+
+instance : has_coe (α →₁ₛ[μ] E) (α →₁[μ] E) := coe_subtype
+instance : has_coe_to_fun (α →₁ₛ[μ] E) := ⟨λ f, α → E, λ f, ⇑(f : α →₁[μ] E)⟩
+
+@[simp, norm_cast] lemma coe_coe (f : α →₁ₛ[μ] E) : ⇑(f : α →₁[μ] E) = f := rfl
+protected lemma eq {f g : α →₁ₛ[μ] E} : (f : α →₁[μ] E) = (g : α →₁[μ] E) → f = g := subtype.eq
+protected lemma eq' {f g : α →₁ₛ[μ] E} : (f : α →ₘ[μ] E) = (g : α →ₘ[μ] E) → f = g :=
+subtype.eq ∘ subtype.eq
+
+@[norm_cast] protected lemma eq_iff {f g : α →₁ₛ[μ] E} : (f : α →₁[μ] E) = g ↔ f = g :=
+subtype.ext_iff.symm
+
+@[norm_cast] protected lemma eq_iff' {f g : α →₁ₛ[μ] E} : (f : α →ₘ[μ] E) = g ↔ f = g :=
+iff.intro (simple_func.eq') (congr_arg _)
+
+/-- L1 simple functions forms a `normed_group`, with the metric being inherited from L1 space,
+  i.e., `dist f g = ennreal.to_real (∫⁻ a, edist (f a) (g a)`).
+  Not declared as an instance as `α →₁ₛ[μ] β` will only be useful in the construction of the Bochner
+  integral. -/
+protected def normed_group : normed_group (α →₁ₛ[μ] E) := by apply_instance
+
+local attribute [instance] simple_func.normed_group
+
+/-- Functions `α →₁ₛ[μ] E` form an additive commutative group. -/
+instance : inhabited (α →₁ₛ[μ] E) := ⟨0⟩
+
+@[simp, norm_cast]
+lemma coe_zero : ((0 : α →₁ₛ[μ] E) : α →₁[μ] E) = 0 := rfl
+@[simp, norm_cast]
+lemma coe_add (f g : α →₁ₛ[μ] E) : ((f + g : α →₁ₛ[μ] E) : α →₁[μ] E) = f + g := rfl
+@[simp, norm_cast]
+lemma coe_neg (f : α →₁ₛ[μ] E) : ((-f : α →₁ₛ[μ] E) : α →₁[μ] E) = -f := rfl
+@[simp, norm_cast]
+lemma coe_sub (f g : α →₁ₛ[μ] E) : ((f - g : α →₁ₛ[μ] E) : α →₁[μ] E) = f - g := rfl
+
+@[simp] lemma edist_eq (f g : α →₁ₛ[μ] E) : edist f g = edist (f : α →₁[μ] E) (g : α →₁[μ] E) := rfl
+@[simp] lemma dist_eq (f g : α →₁ₛ[μ] E) : dist f g = dist (f : α →₁[μ] E) (g : α →₁[μ] E) := rfl
+
+lemma norm_eq (f : α →₁ₛ[μ] E) : ∥f∥ = ∥(f : α →₁[μ] E)∥ := rfl
+
+variables [normed_field 𝕜] [normed_space 𝕜 E] [measurable_space 𝕜] [opens_measurable_space 𝕜]
+
+/-- Not declared as an instance as `α →₁ₛ[μ] E` will only be useful in the construction of the
+Bochner integral. -/
+protected def has_scalar : has_scalar 𝕜 (α →₁ₛ[μ] E) := ⟨λk f, ⟨k • f,
+begin
+  rcases f with ⟨f, ⟨s, hs⟩⟩,
+  use k • s,
+  apply eq.trans (smul_mk k s s.ae_measurable).symm _,
+  rw hs,
+  refl,
+end ⟩⟩
+
+local attribute [instance, priority 10000] simple_func.has_scalar
+
+@[simp, norm_cast] lemma coe_smul (c : 𝕜) (f : α →₁ₛ[μ] E) :
+  ((c • f : α →₁ₛ[μ] E) : α →₁[μ] E) = c • (f : α →₁[μ] E) := rfl
+
+/-- Not declared as an instance as `α →₁ₛ[μ] E` will only be useful in the construction of the
+  Bochner integral. -/
+protected def module : module 𝕜 (α →₁ₛ[μ] E) :=
+{ one_smul  := λf, simple_func.eq (by { simp only [coe_smul], exact one_smul _ _ }),
+  mul_smul  := λx y f, simple_func.eq (by { simp only [coe_smul], exact mul_smul _ _ _ }),
+  smul_add  := λx f g, simple_func.eq (by { simp only [coe_smul], exact smul_add _ _ _ }),
+  smul_zero := λx, simple_func.eq (by { simp only [coe_smul], exact smul_zero _ }),
+  add_smul  := λx y f, simple_func.eq (by { simp only [coe_smul], exact add_smul _ _ _ }),
+  zero_smul := λf, simple_func.eq (by { simp only [coe_smul], exact zero_smul _ _ }) }
+
+local attribute [instance] simple_func.normed_group simple_func.module
+
+/-- Not declared as an instance as `α →₁ₛ[μ] E` will only be useful in the construction of the
+Bochner integral. -/
+protected def normed_space : normed_space 𝕜 (α →₁ₛ[μ] E) :=
+⟨ λc f, by { rw [norm_eq, norm_eq, coe_smul, norm_smul] } ⟩
+
+end instances
+
+local attribute [instance] simple_func.normed_group simple_func.normed_space
+
+section to_L1
+
+/-- Construct the equivalence class `[f]` of an integrable simple function `f`. -/
+@[reducible] def to_L1 (f : α →ₛ E) (hf : integrable f μ) : (α →₁ₛ[μ] E) :=
+⟨hf.to_L1 f, ⟨f, rfl⟩⟩
+
+lemma to_L1_eq_to_L1 (f : α →ₛ E) (hf : integrable f μ) :
+  (to_L1 f hf : α →₁[μ] E) = hf.to_L1 f := rfl
+
+lemma to_L1_eq_mk (f : α →ₛ E) (hf : integrable f μ) :
+  (to_L1 f hf : α →ₘ[μ] E) = ae_eq_fun.mk f f.ae_measurable := rfl
+
+lemma to_L1_zero : to_L1 (0 : α →ₛ E) (integrable_zero α E μ) = 0 := rfl
+
+lemma to_L1_add (f g : α →ₛ E) (hf : integrable f μ) (hg : integrable g μ) :
+  to_L1 (f + g) (hf.add hg) = to_L1 f hf + to_L1 g hg := rfl
+
+lemma to_L1_neg (f : α →ₛ E) (hf : integrable f μ) :
+  to_L1 (-f) hf.neg = -to_L1 f hf := rfl
+
+lemma to_L1_sub (f g : α →ₛ E) (hf : integrable f μ) (hg : integrable g μ) :
+  to_L1 (f - g) (hf.sub hg) = to_L1 f hf - to_L1 g hg :=
+by { simp only [sub_eq_add_neg, ← to_L1_neg, ← to_L1_add], refl }
+
+variables [normed_field 𝕜] [normed_space 𝕜 E] [measurable_space 𝕜] [opens_measurable_space 𝕜]
+
+lemma to_L1_smul (f : α →ₛ E) (hf : integrable f μ) (c : 𝕜) :
+  to_L1 (c • f) (hf.smul c) = c • to_L1 f hf := rfl
+
+lemma norm_to_L1 (f : α →ₛ E) (hf : integrable f μ) :
+  ∥to_L1 f hf∥ = ennreal.to_real (∫⁻ a, edist (f a) 0 ∂μ) :=
+by simp [to_L1, integrable.norm_to_L1]
+
+end to_L1
+
+section to_simple_func
+
+/-- Find a representative of a `L1.simple_func`. -/
+def to_simple_func (f : α →₁ₛ[μ] E) : α →ₛ E := classical.some f.2
+
+/-- `(to_simple_func f)` is measurable. -/
+@[measurability]
+protected lemma measurable (f : α →₁ₛ[μ] E) : measurable (to_simple_func f) :=
+(to_simple_func f).measurable
+
+@[measurability]
+protected lemma ae_measurable (f : α →₁ₛ[μ] E) : ae_measurable (to_simple_func f) μ :=
+(simple_func.measurable f).ae_measurable
+
+/-- `to_simple_func f` is integrable. -/
+protected lemma integrable (f : α →₁ₛ[μ] E) : integrable (to_simple_func f) μ :=
+begin
+  apply (integrable_mk (simple_func.ae_measurable f)).1,
+  convert integrable_coe_fn f.val,
+  exact classical.some_spec f.2
+end
+
+lemma to_L1_to_simple_func (f : α →₁ₛ[μ] E) :
+  to_L1 (to_simple_func f) (simple_func.integrable f) = f :=
+by { rw ← simple_func.eq_iff', exact classical.some_spec f.2 }
+
+lemma to_simple_func_to_L1 (f : α →ₛ E) (hfi : integrable f μ) :
+  to_simple_func (to_L1 f hfi) =ᵐ[μ] f :=
+by { rw ← mk_eq_mk, exact classical.some_spec (to_L1 f hfi).2 }
+
+lemma to_simple_func_eq_to_fun (f : α →₁ₛ[μ] E) : to_simple_func f =ᵐ[μ] f :=
+begin
+  simp_rw [← integrable.to_L1_eq_to_L1_iff (to_simple_func f) f (simple_func.integrable f)
+    (integrable_coe_fn ↑f), subtype.ext_iff],
+  convert classical.some_spec f.coe_prop,
+  exact integrable.to_L1_coe_fn _ _,
+end
+
+variables (E μ)
+lemma zero_to_simple_func : to_simple_func (0 : α →₁ₛ[μ] E) =ᵐ[μ] 0 :=
+begin
+  filter_upwards [to_simple_func_eq_to_fun (0 : α →₁ₛ[μ] E), Lp.coe_fn_zero E 1 μ],
+  assume a h₁ h₂,
+  rwa h₁,
+end
+variables {E μ}
+
+lemma add_to_simple_func (f g : α →₁ₛ[μ] E) :
+  to_simple_func (f + g) =ᵐ[μ] to_simple_func f + to_simple_func g :=
+begin
+  filter_upwards [to_simple_func_eq_to_fun (f + g), to_simple_func_eq_to_fun f,
+    to_simple_func_eq_to_fun g, Lp.coe_fn_add (f :  α →₁[μ] E) g],
+  assume a,
+  simp only [← coe_coe, coe_add, pi.add_apply],
+  iterate 4 { assume h, rw h }
+end
+
+lemma neg_to_simple_func (f : α →₁ₛ[μ] E) : to_simple_func (-f) =ᵐ[μ] - to_simple_func f :=
+begin
+  filter_upwards [to_simple_func_eq_to_fun (-f), to_simple_func_eq_to_fun f,
+    Lp.coe_fn_neg (f : α →₁[μ] E)],
+  assume a,
+  simp only [pi.neg_apply, coe_neg, ← coe_coe],
+  repeat { assume h, rw h }
+end
+
+lemma sub_to_simple_func (f g : α →₁ₛ[μ] E) :
+  to_simple_func (f - g) =ᵐ[μ] to_simple_func f - to_simple_func g :=
+begin
+  filter_upwards [to_simple_func_eq_to_fun (f - g), to_simple_func_eq_to_fun f,
+    to_simple_func_eq_to_fun g, Lp.coe_fn_sub (f : α →₁[μ] E) g],
+  assume a,
+  simp only [coe_sub, pi.sub_apply, ← coe_coe],
+  repeat { assume h, rw h }
+end
+
+variables [normed_field 𝕜] [normed_space 𝕜 E] [measurable_space 𝕜] [opens_measurable_space 𝕜]
+
+lemma smul_to_simple_func (k : 𝕜) (f : α →₁ₛ[μ] E) :
+  to_simple_func (k • f) =ᵐ[μ] k • to_simple_func f :=
+begin
+  filter_upwards [to_simple_func_eq_to_fun (k • f), to_simple_func_eq_to_fun f,
+    Lp.coe_fn_smul k (f : α →₁[μ] E)],
+  assume a,
+  simp only [pi.smul_apply, coe_smul, ← coe_coe],
+  repeat { assume h, rw h }
+end
+
+lemma lintegral_edist_to_simple_func_lt_top (f g : α →₁ₛ[μ] E) :
+  ∫⁻ (x : α), edist (to_simple_func f x) (to_simple_func g x) ∂μ < ∞ :=
+begin
+  rw lintegral_rw₂ (to_simple_func_eq_to_fun f) (to_simple_func_eq_to_fun g),
+  exact lintegral_edist_lt_top (integrable_coe_fn _) (integrable_coe_fn _)
+end
+
+lemma dist_to_simple_func (f g : α →₁ₛ[μ] E) : dist f g =
+  ennreal.to_real (∫⁻ x, edist (to_simple_func f x) (to_simple_func g x) ∂μ) :=
+begin
+  rw [dist_eq, L1.dist_def, ennreal.to_real_eq_to_real],
+  { rw lintegral_rw₂, repeat { exact ae_eq_symm (to_simple_func_eq_to_fun _) } },
+  { exact lintegral_edist_lt_top (integrable_coe_fn _) (integrable_coe_fn _) },
+  { exact lintegral_edist_to_simple_func_lt_top _ _ }
+end
+
+lemma norm_to_simple_func (f : α →₁ₛ[μ] E) :
+  ∥f∥ = ennreal.to_real (∫⁻ (a : α), nnnorm ((to_simple_func f) a) ∂μ) :=
+calc ∥f∥ =
+  ennreal.to_real (∫⁻x, edist ((to_simple_func f) x) (to_simple_func (0 : α →₁ₛ[μ] E) x) ∂μ) :
+begin
+  rw [← dist_zero_right, dist_to_simple_func]
+end
+... = ennreal.to_real (∫⁻ (x : α), (coe ∘ nnnorm) ((to_simple_func f) x) ∂μ) :
+begin
+  rw lintegral_nnnorm_eq_lintegral_edist,
+  have : ∫⁻ x, edist ((to_simple_func f) x) ((to_simple_func (0 : α →₁ₛ[μ] E)) x) ∂μ =
+    ∫⁻ x, edist ((to_simple_func f) x) 0 ∂μ,
+  { refine lintegral_congr_ae ((zero_to_simple_func E μ).mono (λ a h, _)),
+    rw [h, pi.zero_apply] },
+  rw [ennreal.to_real_eq_to_real],
+  { exact this },
+  { exact lintegral_edist_to_simple_func_lt_top _ _ },
+  { rw ← this, exact lintegral_edist_to_simple_func_lt_top _ _ }
+end
+
+end to_simple_func
+
+section coe_to_L1
+
+protected lemma uniform_continuous : uniform_continuous (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
+uniform_continuous_comap
+
+protected lemma uniform_embedding : uniform_embedding (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
+uniform_embedding_comap subtype.val_injective
+
+protected lemma uniform_inducing : uniform_inducing (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
+simple_func.uniform_embedding.to_uniform_inducing
+
+protected lemma dense_embedding : dense_embedding (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
+begin
+  apply simple_func.uniform_embedding.dense_embedding,
+  assume f,
+  rw mem_closure_iff_seq_limit,
+  have hfi' : integrable f μ := integrable_coe_fn f,
+  refine ⟨λ n, ↑(to_L1 (simple_func.approx_on f (Lp.measurable f) univ 0 trivial n)
+    (simple_func.integrable_approx_on_univ (Lp.measurable f) hfi' n)), λ n, mem_range_self _, _⟩,
+  convert simple_func.tendsto_approx_on_univ_L1 (Lp.measurable f) hfi',
+  rw integrable.to_L1_coe_fn
+end
+
+protected lemma dense_inducing : dense_inducing (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
+simple_func.dense_embedding.to_dense_inducing
+
+protected lemma dense_range : dense_range (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)) :=
+simple_func.dense_inducing.dense
+
+variables [normed_field 𝕜] [normed_space 𝕜 E] [measurable_space 𝕜] [opens_measurable_space 𝕜]
+
+variables (α E 𝕜)
+
+/-- The uniform and dense embedding of L1 simple functions into L1 functions. -/
+def coe_to_L1 : (α →₁ₛ[μ] E) →L[𝕜] (α →₁[μ] E) :=
+{ to_fun := (coe : (α →₁ₛ[μ] E) → (α →₁[μ] E)),
+  map_add' := λf g, rfl,
+  map_smul' := λk f, rfl,
+  cont := L1.simple_func.uniform_continuous.continuous, }
+
+variables {α E 𝕜}
+
+end coe_to_L1
+
+end simple_func
+
+end L1
+
+variables [measurable_space α] [normed_group E] [measurable_space E] {f g : α → E} {s t : set α}
+  {μ ν : measure α} {l l' : filter α} [borel_space E] [second_countable_topology E]
+
+/-- To prove something for an arbitrary integrable function in a second countable
+Borel normed group, it suffices to show that
+* the property holds for (multiples of) characteristic functions;
+* is closed under addition;
+* the set of functions in the `L¹` space for which the property holds is closed.
+* the property is closed under the almost-everywhere equal relation.
+
+It is possible to make the hypotheses in the induction steps a bit stronger, and such conditions
+can be added once we need them (for example in `h_add` it is only necessary to consider the sum of
+a simple function with a multiple of a characteristic function and that the intersection
+of their images is a subset of `{0}`).
+-/
+@[elab_as_eliminator]
+lemma integrable.induction (P : (α → E) → Prop)
+  (h_ind : ∀ (c : E) ⦃s⦄, measurable_set s → μ s < ∞ → P (s.indicator (λ _, c)))
+  (h_add : ∀ ⦃f g : α → E⦄, disjoint (support f) (support g) → integrable f μ → integrable g μ →
+    P f → P g → P (f + g))
+  (h_closed : is_closed {f : α →₁[μ] E | P f} )
+  (h_ae : ∀ ⦃f g⦄, f =ᵐ[μ] g → integrable f μ → P f → P g) :
+  ∀ ⦃f : α → E⦄ (hf : integrable f μ), P f :=
+begin
+  have : ∀ (f : simple_func α E), integrable f μ → P f,
+  { refine simple_func.induction _ _,
+    { intros c s hs h, dsimp only [simple_func.coe_const, simple_func.const_zero,
+        piecewise_eq_indicator, simple_func.coe_zero, simple_func.coe_piecewise] at h ⊢,
+      by_cases hc : c = 0,
+      { subst hc, convert h_ind 0 measurable_set.empty (by simp) using 1, simp [const] },
+      apply h_ind c hs,
+      have : (nnnorm c : ℝ≥0∞) * μ s < ∞,
+      { have := @comp_indicator _ _ _ _ (λ x : E, (nnnorm x : ℝ≥0∞)) (const α c) s,
+        dsimp only at this,
+        have h' := h.has_finite_integral,
+        simpa [has_finite_integral, this, lintegral_indicator, hs] using h' },
+      exact ennreal.lt_top_of_mul_lt_top_right this (by simp [hc]) },
+    { intros f g hfg hf hg int_fg,
+      rw [simple_func.coe_add, integrable_add hfg f.measurable g.measurable] at int_fg,
+      refine h_add hfg int_fg.1 int_fg.2 (hf int_fg.1) (hg int_fg.2) } },
+  have : ∀ (f : α →₁ₛ[μ] E), P f,
+  { intro f,
+    exact h_ae (L1.simple_func.to_simple_func_eq_to_fun f) (L1.simple_func.integrable f)
+      (this (L1.simple_func.to_simple_func f) (L1.simple_func.integrable f)) },
+  have : ∀ (f : α →₁[μ] E), P f :=
+    λ f, L1.simple_func.dense_range.induction_on f h_closed this,
+  exact λ f hf, h_ae hf.coe_fn_to_L1 (L1.integrable_coe_fn _) (this (hf.to_L1 f)),
+end
 
 end measure_theory


### PR DESCRIPTION
At the moment, there is a low-level construction in `measure_theory/simple_func_dense` for the approximation of an element of L1 by simple functions, and this is generalized to a more abstract version (with a normed space `L1.simple_func` and a dense linear embedding of this into `L1`) in `measure_theory/bochner_integration`.  #8114 generalized the low-level construction, and I am thinking of rewriting the more abstract version to apply to `Lp`, too.

But since this will all be more generally useful than in the construction of the Bochner integral, and since the Bochner integral file is very long, I propose moving all this material into `measure_theory/simple_func_dense`.  This PR shows what it would look like.  There are no mathematical changes.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
