### PR TITLE
[Merged by Bors] - chore(category_theory/abelian/diagram_lemmas/four): Make the diagram into a code block

### DIFF
--- a/src/category_theory/abelian/diagram_lemmas/four.lean
+++ b/src/category_theory/abelian/diagram_lemmas/four.lean
@@ -10,12 +10,14 @@ import category_theory.abelian.pseudoelements
 
 Consider the following commutative diagram with exact rows in an abelian category:
 
+```
 A ---f--> B ---g--> C ---h--> D
 |         |         |         |
 α         β         γ         δ
 |         |         |         |
 v         v         v         v
 A' --f'-> B' --g'-> C' --h'-> D'
+```
 
 We prove the "mono" version of the four lemma: if α is an epimorphism and β and δ are monomorphisms,
 then γ is a monomorphism.


### PR DESCRIPTION
Currently on mathlib docs, it looks like this

![image](https://user-images.githubusercontent.com/15098580/124386872-4c869d00-dcd4-11eb-9c5c-ce6a29e4e607.png)

Making it into a code block should mean that it will render correctly on mathlib docs

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
