### PR TITLE
[Merged by Bors] - feat(category_theory/preadditive/opposite): Adds some instances and lemmas

### DIFF
--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -231,7 +231,7 @@ we can take the "unopposite" of each component obtaining a natural transformatio
 end
 
 section
-variables {F G : C ⥤ Dᵒᵖ}
+variables {F G H : C ⥤ Dᵒᵖ}
 
 /--
 Given a natural transformation `α : F ⟶ G`, for `F G : C ⥤ Dᵒᵖ`,
@@ -244,6 +244,11 @@ taking `unop` of each component gives a natural transformation `G.left_op ⟶ F.
     dsimp,
     simp_rw [← unop_comp, α.naturality]
   end }
+
+@[simp] lemma left_op_id : (𝟙 F : F ⟶ F).left_op = 𝟙 F.left_op := rfl
+
+@[simp] lemma left_op_comp (α : F ⟶ G) (β : G ⟶ H) :
+  (α ≫ β).left_op = β.left_op ≫ α.left_op := rfl
 
 /--
 Given a natural transformation `α : F.left_op ⟶ G.left_op`, for `F G : C ⥤ Dᵒᵖ`,
@@ -262,7 +267,7 @@ taking `op` of each component gives a natural transformation `G ⟶ F`.
 end
 
 section
-variables {F G : Cᵒᵖ ⥤ D}
+variables {F G H : Cᵒᵖ ⥤ D}
 
 /--
 Given a natural transformation `α : F ⟶ G`, for `F G : Cᵒᵖ ⥤ D`,
@@ -275,6 +280,11 @@ taking `op` of each component gives a natural transformation `G.right_op ⟶ F.r
     dsimp,
     simp_rw [← op_comp, α.naturality]
   end }
+
+@[simp] lemma right_op_id : (𝟙 F : F ⟶ F).right_op = 𝟙 F.right_op := rfl
+
+@[simp] lemma right_op_comp (α : F ⟶ G) (β : G ⟶ H) :
+  (α ≫ β).right_op = β.right_op ≫ α.right_op := rfl
 
 /--
 Given a natural transformation `α : F.right_op ⟶ G.right_op`, for `F G : Cᵒᵖ ⥤ D`,

--- a/src/category_theory/preadditive/opposite.lean
+++ b/src/category_theory/preadditive/opposite.lean
@@ -34,13 +34,13 @@ instance functor.op_additive (F : C ⥤ D) [F.additive] : F.op.additive := {}
 
 instance functor.right_op_additive (F : Cᵒᵖ ⥤ D) [F.additive] : F.right_op.additive :=
 { map_zero' := λ X Y, begin
-    change (F.map 0).op = 0,
-    rw functor.map_zero,
+    dsimp only [functor.right_op],
+    erw F.map_zero,
     refl,
   end,
   map_add' := λ X Y f g, begin
-    change (F.map (f.op + g.op)).op = _,
-    rw functor.map_add,
+    dsimp only [functor.right_op],
+    erw (F.map_add : F.map (f.op + g.op) = _),
     refl,
   end }
 
@@ -48,13 +48,13 @@ instance functor.left_op_additive (F : C ⥤ Dᵒᵖ) [F.additive] : F.left_op.a
 
 instance functor.unop_additive (F : Cᵒᵖ ⥤ Dᵒᵖ) [F.additive] : F.unop.additive :=
 { map_zero' := λ X Y, begin
-    change (F.map 0).unop = 0,
-    rw functor.map_zero,
+    dsimp only [functor.unop],
+    erw functor.map_zero,
     refl,
   end,
   map_add' := λ X Y f g, begin
-    change (F.map (f.op + g.op)).unop = _,
-    rw F.map_add,
+    dsimp only [functor.unop],
+    erw (F.map_add : F.map (f.op + g.op) = _),
     refl,
   end }
 

--- a/src/category_theory/preadditive/opposite.lean
+++ b/src/category_theory/preadditive/opposite.lean
@@ -27,35 +27,17 @@ instance : preadditive Cᵒᵖ :=
 
 @[simp] lemma unop_zero (X Y : Cᵒᵖ) : (0 : X ⟶ Y).unop = 0 := rfl
 @[simp] lemma unop_add {X Y : Cᵒᵖ} (f g : X ⟶ Y) : (f + g).unop = f.unop + g.unop := rfl
+@[simp] lemma op_zero (X Y : C) : (0 : X ⟶ Y).op = 0 := rfl
+@[simp] lemma op_add {X Y : C} (f g : X ⟶ Y) : (f + g).op = f.op + g.op := rfl
 
 variables {C} {D : Type*} [category D] [preadditive D]
 
 instance functor.op_additive (F : C ⥤ D) [F.additive] : F.op.additive := {}
 
-instance functor.right_op_additive (F : Cᵒᵖ ⥤ D) [F.additive] : F.right_op.additive :=
-{ map_zero' := λ X Y, begin
-    dsimp only [functor.right_op],
-    erw F.map_zero,
-    refl,
-  end,
-  map_add' := λ X Y f g, begin
-    dsimp only [functor.right_op],
-    erw (F.map_add : F.map (f.op + g.op) = _),
-    refl,
-  end }
+instance functor.right_op_additive (F : Cᵒᵖ ⥤ D) [F.additive] : F.right_op.additive := {}
 
 instance functor.left_op_additive (F : C ⥤ Dᵒᵖ) [F.additive] : F.left_op.additive := {}
 
-instance functor.unop_additive (F : Cᵒᵖ ⥤ Dᵒᵖ) [F.additive] : F.unop.additive :=
-{ map_zero' := λ X Y, begin
-    dsimp only [functor.unop],
-    erw functor.map_zero,
-    refl,
-  end,
-  map_add' := λ X Y f g, begin
-    dsimp only [functor.unop],
-    erw (F.map_add : F.map (f.op + g.op) = _),
-    refl,
-  end }
+instance functor.unop_additive (F : Cᵒᵖ ⥤ Dᵒᵖ) [F.additive] : F.unop.additive := {}
 
 end category_theory

--- a/src/category_theory/preadditive/opposite.lean
+++ b/src/category_theory/preadditive/opposite.lean
@@ -1,9 +1,10 @@
 /-
 Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott Morrison
+Authors: Scott Morrison, Adam Topaz
 -/
 import category_theory.preadditive
+import category_theory.preadditive.additive_functor
 import data.equiv.transfer_instance
 
 /-!
@@ -26,5 +27,35 @@ instance : preadditive Cᵒᵖ :=
 
 @[simp] lemma unop_zero (X Y : Cᵒᵖ) : (0 : X ⟶ Y).unop = 0 := rfl
 @[simp] lemma unop_add {X Y : Cᵒᵖ} (f g : X ⟶ Y) : (f + g).unop = f.unop + g.unop := rfl
+
+variables {C} {D : Type*} [category D] [preadditive D]
+
+instance functor.op_additive (F : C ⥤ D) [F.additive] : F.op.additive := {}
+
+instance functor.right_op_additive (F : Cᵒᵖ ⥤ D) [F.additive] : F.right_op.additive :=
+{ map_zero' := λ X Y, begin
+    change (F.map 0).op = 0,
+    rw functor.map_zero,
+    refl,
+  end,
+  map_add' := λ X Y f g, begin
+    change (F.map (f.op + g.op)).op = _,
+    rw functor.map_add,
+    refl,
+  end }
+
+instance functor.left_op_additive (F : C ⥤ Dᵒᵖ) [F.additive] : F.left_op.additive := {}
+
+instance functor.unop_additive (F : Cᵒᵖ ⥤ Dᵒᵖ) [F.additive] : F.unop.additive :=
+{ map_zero' := λ X Y, begin
+    change (F.map 0).unop = 0,
+    rw functor.map_zero,
+    refl,
+  end,
+  map_add' := λ X Y f g, begin
+    change (F.map (f.op + g.op)).unop = _,
+    rw F.map_add,
+    refl,
+  end }
 
 end category_theory


### PR DESCRIPTION
This PR adds some instances and lemmas related to opposites and additivity of functors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
