### PR TITLE
[Merged by Bors] - chore(data/set/basic): use `decidable_pred (∈ s)` instead of `decidable_pred s`.

### DIFF
--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -1432,13 +1432,13 @@ end
 
 section
 
-variables (𝕜 G G') {k l : ℕ} {s : finset (fin n)} [decidable_pred (s : set (fin n))]
+variables (𝕜 G G') {k l : ℕ} {s : finset (fin n)}
 
 /-- If `s : finset (fin n)` is a finite set of cardinality `k` and its complement has cardinality
 `l`, then the space of continuous multilinear maps `G [×n]→L[𝕜] G'` of `n` variables is isomorphic
 to the space of continuous multilinear maps `G [×k]→L[𝕜] G [×l]→L[𝕜] G'` of `k` variables taking
 values in the space of continuous multilinear maps of `l` variables. -/
-def curry_fin_finset {k l n : ℕ} {s : finset (fin n)} [decidable_pred (s : set (fin n))]
+def curry_fin_finset {k l n : ℕ} {s : finset (fin n)}
   (hk : s.card = k) (hl : sᶜ.card = l) :
   (G [×n]→L[𝕜] G') ≃ₗᵢ[𝕜] (G [×k]→L[𝕜] G [×l]→L[𝕜] G') :=
 (dom_dom_congr 𝕜 G G' (fin_sum_equiv_of_finset hk hl).symm).trans

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -104,7 +104,7 @@ variables {V : Type u} (G : simple_graph V)
 def neighbor_set (v : V) : set V := set_of (G.adj v)
 
 instance neighbor_set.mem_decidable (v : V) [decidable_rel G.adj] :
-  decidable_pred (G.neighbor_set v) := by { unfold neighbor_set, apply_instance }
+  decidable_pred (∈ (G.neighbor_set v)) := by { unfold neighbor_set, apply_instance }
 
 lemma ne_of_adj {a b : V} (hab : G.adj a b) : a ≠ b :=
 by { rintro rfl, exact G.loopless a hab }
@@ -151,14 +151,14 @@ begin
   exact G.ne_of_adj he,
 end
 
-instance edge_set_decidable_pred [decidable_rel G.adj] :
-  decidable_pred G.edge_set := sym2.from_rel.decidable_pred _
+instance decidable_mem_edge_set [decidable_rel G.adj] :
+  decidable_pred (∈ G.edge_set) := sym2.from_rel.decidable_pred _
 
 instance edges_fintype [decidable_eq V] [fintype V] [decidable_rel G.adj] :
   fintype G.edge_set := subtype.fintype _
 
-instance incidence_set_decidable_pred [decidable_eq V] [decidable_rel G.adj] (v : V) :
-  decidable_pred (G.incidence_set v) := λ e, and.decidable
+instance decidable_mem_incidence_set [decidable_eq V] [decidable_rel G.adj] (v : V) :
+  decidable_pred (∈ G.incidence_set v) := λ e, and.decidable
 
 /--
 The `edge_set` of the graph as a `finset`.
@@ -224,7 +224,8 @@ lemma not_mem_common_neighbors_right (v w : V) : w ∉ G.common_neighbors v w :=
 lemma common_neighbors_subset_neighbor_set (v w : V) : G.common_neighbors v w ⊆ G.neighbor_set v :=
 by simp [common_neighbors]
 
-instance [decidable_rel G.adj] (v w : V) : decidable_pred (G.common_neighbors v w) :=
+instance decidable_mem_common_neighbors [decidable_rel G.adj] (v w : V) :
+  decidable_pred (∈ G.common_neighbors v w) :=
 λ a, and.decidable
 
 section incidence

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -1560,76 +1560,76 @@ protected def of_eq {α : Type u} {s t : set α} (h : s = t) : s ≃ t :=
   right_inv := λ _, subtype.eq rfl }
 
 /-- If `a ∉ s`, then `insert a s` is equivalent to `s ⊕ punit`. -/
-protected def insert {α} {s : set.{u} α} [decidable_pred s] {a : α} (H : a ∉ s) :
+protected def insert {α} {s : set.{u} α} [decidable_pred (∈ s)] {a : α} (H : a ∉ s) :
   (insert a s : set α) ≃ s ⊕ punit.{u+1} :=
 calc (insert a s : set α) ≃ ↥(s ∪ {a}) : equiv.set.of_eq (by simp)
 ... ≃ s ⊕ ({a} : set α) : equiv.set.union (by finish [set.subset_def])
 ... ≃ s ⊕ punit.{u+1} : sum_congr (equiv.refl _) (equiv.set.singleton _)
 
-@[simp] lemma insert_symm_apply_inl {α} {s : set.{u} α} [decidable_pred s] {a : α} (H : a ∉ s)
+@[simp] lemma insert_symm_apply_inl {α} {s : set.{u} α} [decidable_pred (∈ s)] {a : α} (H : a ∉ s)
   (b : s) : (equiv.set.insert H).symm (sum.inl b) = ⟨b, or.inr b.2⟩ :=
 rfl
 
-@[simp] lemma insert_symm_apply_inr {α} {s : set.{u} α} [decidable_pred s] {a : α} (H : a ∉ s)
+@[simp] lemma insert_symm_apply_inr {α} {s : set.{u} α} [decidable_pred (∈ s)] {a : α} (H : a ∉ s)
   (b : punit.{u+1}) : (equiv.set.insert H).symm (sum.inr b) = ⟨a, or.inl rfl⟩ :=
 rfl
 
-@[simp] lemma insert_apply_left {α} {s : set.{u} α} [decidable_pred s] {a : α} (H : a ∉ s) :
+@[simp] lemma insert_apply_left {α} {s : set.{u} α} [decidable_pred (∈ s)] {a : α} (H : a ∉ s) :
   equiv.set.insert H ⟨a, or.inl rfl⟩ = sum.inr punit.star :=
 (equiv.set.insert H).apply_eq_iff_eq_symm_apply.2 rfl
 
-@[simp] lemma insert_apply_right {α} {s : set.{u} α} [decidable_pred s] {a : α} (H : a ∉ s)
+@[simp] lemma insert_apply_right {α} {s : set.{u} α} [decidable_pred (∈ s)] {a : α} (H : a ∉ s)
   (b : s) : equiv.set.insert H ⟨b, or.inr b.2⟩ = sum.inl b :=
 (equiv.set.insert H).apply_eq_iff_eq_symm_apply.2 rfl
 
 /-- If `s : set α` is a set with decidable membership, then `s ⊕ sᶜ` is equivalent to `α`. -/
-protected def sum_compl {α} (s : set α) [decidable_pred s] : s ⊕ (sᶜ : set α) ≃ α :=
+protected def sum_compl {α} (s : set α) [decidable_pred (∈ s)] : s ⊕ (sᶜ : set α) ≃ α :=
 calc s ⊕ (sᶜ : set α) ≃ ↥(s ∪ sᶜ) : (equiv.set.union (by simp [set.ext_iff])).symm
 ... ≃ @univ α : equiv.set.of_eq (by simp)
 ... ≃ α : equiv.set.univ _
 
-@[simp] lemma sum_compl_apply_inl {α : Type u} (s : set α) [decidable_pred s] (x : s) :
+@[simp] lemma sum_compl_apply_inl {α : Type u} (s : set α) [decidable_pred (∈ s)] (x : s) :
   equiv.set.sum_compl s (sum.inl x) = x := rfl
 
-@[simp] lemma sum_compl_apply_inr {α : Type u} (s : set α) [decidable_pred s] (x : sᶜ) :
+@[simp] lemma sum_compl_apply_inr {α : Type u} (s : set α) [decidable_pred (∈ s)] (x : sᶜ) :
   equiv.set.sum_compl s (sum.inr x) = x := rfl
 
-lemma sum_compl_symm_apply_of_mem {α : Type u} {s : set α} [decidable_pred s] {x : α}
+lemma sum_compl_symm_apply_of_mem {α : Type u} {s : set α} [decidable_pred (∈ s)] {x : α}
   (hx : x ∈ s) : (equiv.set.sum_compl s).symm x = sum.inl ⟨x, hx⟩ :=
 have ↑(⟨x, or.inl hx⟩ : (s ∪ sᶜ : set α)) ∈ s, from hx,
 by { rw [equiv.set.sum_compl], simpa using set.union_apply_left _ this }
 
-lemma sum_compl_symm_apply_of_not_mem {α : Type u} {s : set α} [decidable_pred s] {x : α}
+lemma sum_compl_symm_apply_of_not_mem {α : Type u} {s : set α} [decidable_pred (∈ s)] {x : α}
   (hx : x ∉ s) : (equiv.set.sum_compl s).symm x = sum.inr ⟨x, hx⟩ :=
 have ↑(⟨x, or.inr hx⟩ : (s ∪ sᶜ : set α)) ∈ sᶜ, from hx,
 by { rw [equiv.set.sum_compl], simpa using set.union_apply_right _ this }
 
-@[simp] lemma sum_compl_symm_apply {α : Type*} {s : set α} [decidable_pred s] {x : s} :
+@[simp] lemma sum_compl_symm_apply {α : Type*} {s : set α} [decidable_pred (∈ s)] {x : s} :
   (equiv.set.sum_compl s).symm x = sum.inl x :=
 by cases x with x hx; exact set.sum_compl_symm_apply_of_mem hx
 
 @[simp] lemma sum_compl_symm_apply_compl {α : Type*} {s : set α}
-  [decidable_pred s] {x : sᶜ} : (equiv.set.sum_compl s).symm x = sum.inr x :=
+  [decidable_pred (∈ s)] {x : sᶜ} : (equiv.set.sum_compl s).symm x = sum.inr x :=
 by cases x with x hx; exact set.sum_compl_symm_apply_of_not_mem hx
 
 /-- `sum_diff_subset s t` is the natural equivalence between
 `s ⊕ (t \ s)` and `t`, where `s` and `t` are two sets. -/
-protected def sum_diff_subset {α} {s t : set α} (h : s ⊆ t) [decidable_pred s] :
+protected def sum_diff_subset {α} {s t : set α} (h : s ⊆ t) [decidable_pred (∈ s)] :
   s ⊕ (t \ s : set α) ≃ t :=
 calc s ⊕ (t \ s : set α) ≃ (s ∪ (t \ s) : set α) :
   (equiv.set.union (by simp [inter_diff_self])).symm
 ... ≃ t : equiv.set.of_eq (by { simp [union_diff_self, union_eq_self_of_subset_left h] })
 
 @[simp] lemma sum_diff_subset_apply_inl
-  {α} {s t : set α} (h : s ⊆ t) [decidable_pred s] (x : s) :
+  {α} {s t : set α} (h : s ⊆ t) [decidable_pred (∈ s)] (x : s) :
   equiv.set.sum_diff_subset h (sum.inl x) = inclusion h x := rfl
 
 @[simp] lemma sum_diff_subset_apply_inr
-  {α} {s t : set α} (h : s ⊆ t) [decidable_pred s] (x : t \ s) :
+  {α} {s t : set α} (h : s ⊆ t) [decidable_pred (∈ s)] (x : t \ s) :
   equiv.set.sum_diff_subset h (sum.inr x) = inclusion (diff_subset t s) x := rfl
 
 lemma sum_diff_subset_symm_apply_of_mem
-  {α} {s t : set α} (h : s ⊆ t) [decidable_pred s] {x : t} (hx : x.1 ∈ s) :
+  {α} {s t : set α} (h : s ⊆ t) [decidable_pred (∈ s)] {x : t} (hx : x.1 ∈ s) :
   (equiv.set.sum_diff_subset h).symm x = sum.inl ⟨x, hx⟩ :=
 begin
   apply (equiv.set.sum_diff_subset h).injective,
@@ -1638,7 +1638,7 @@ begin
 end
 
 lemma sum_diff_subset_symm_apply_of_not_mem
-  {α} {s t : set α} (h : s ⊆ t) [decidable_pred s] {x : t} (hx : x.1 ∉ s) :
+  {α} {s t : set α} (h : s ⊆ t) [decidable_pred (∈ s)] {x : t} (hx : x.1 ∉ s) :
   (equiv.set.sum_diff_subset h).symm x = sum.inr ⟨x, ⟨x.2, hx⟩⟩  :=
 begin
   apply (equiv.set.sum_diff_subset h).injective,
@@ -1648,7 +1648,7 @@ end
 
 /-- If `s` is a set with decidable membership, then the sum of `s ∪ t` and `s ∩ t` is equivalent
 to `s ⊕ t`. -/
-protected def union_sum_inter {α : Type u} (s t : set α) [decidable_pred s] :
+protected def union_sum_inter {α : Type u} (s t : set α) [decidable_pred (∈ s)] :
   (s ∪ t : set α) ⊕ (s ∩ t : set α) ≃ s ⊕ t :=
 calc  (s ∪ t : set α) ⊕ (s ∩ t : set α)
     ≃ (s ∪ t \ s : set α) ⊕ (s ∩ t : set α) : by rw [union_diff_self]
@@ -1664,8 +1664,8 @@ calc  (s ∪ t : set α) ⊕ (s ∩ t : set α)
 /-- Given an equivalence `e₀` between sets `s : set α` and `t : set β`, the set of equivalences
 `e : α ≃ β` such that `e ↑x = ↑(e₀ x)` for each `x : s` is equivalent to the set of equivalences
 between `sᶜ` and `tᶜ`. -/
-protected def compl {α : Type u} {β : Type v} {s : set α} {t : set β} [decidable_pred s]
-  [decidable_pred t] (e₀ : s ≃ t) :
+protected def compl {α : Type u} {β : Type v} {s : set α} {t : set β} [decidable_pred (∈ s)]
+  [decidable_pred (∈ t)] (e₀ : s ≃ t) :
   {e : α ≃ β // ∀ x : s, e x = e₀ x} ≃ ((sᶜ : set α) ≃ (tᶜ : set β)) :=
 { to_fun := λ e, subtype_equiv e
     (λ a, not_congr $ iff.symm $ maps_to.mem_iff

--- a/src/data/equiv/denumerable.lean
+++ b/src/data/equiv/denumerable.lean
@@ -168,7 +168,7 @@ fintype.false
 
 end classical
 
-variable [decidable_pred s]
+variable [decidable_pred (∈ s)]
 
 /-- Returns the next natural in a set, according to the usual ordering of `ℕ`. -/
 def succ (x : s) : s :=
@@ -199,7 +199,7 @@ lemma lt_succ_iff_le {x y : s} : x < succ y ↔ x ≤ y :=
   λ h, lt_of_le_of_lt h (lt_succ_self _)⟩
 
 /-- Returns the `n`-th element of a set, according to the usual ordering of `ℕ`. -/
-def of_nat (s : set ℕ) [decidable_pred s] [infinite s] : ℕ → s
+def of_nat (s : set ℕ) [decidable_pred (∈ s)] [infinite s] : ℕ → s
 | 0     := ⊥
 | (n+1) := succ (of_nat n)
 
@@ -259,7 +259,7 @@ begin
 end
 
 /-- Any infinite set of naturals is denumerable. -/
-def denumerable (s : set ℕ) [decidable_pred s] [infinite s] : denumerable s :=
+def denumerable (s : set ℕ) [decidable_pred (∈ s)] [infinite s] : denumerable s :=
 denumerable.of_equiv ℕ
 { to_fun := to_fun_aux,
   inv_fun := of_nat s,

--- a/src/data/equiv/denumerable.lean
+++ b/src/data/equiv/denumerable.lean
@@ -227,10 +227,10 @@ lemma of_nat_surjective : surjective (of_nat s) :=
 λ ⟨x, hx⟩, of_nat_surjective_aux hx
 
 private def to_fun_aux (x : s) : ℕ :=
-(list.range x).countp s
+(list.range x).countp (∈ s)
 
 private lemma to_fun_aux_eq (x : s) :
-  to_fun_aux x = ((finset.range x).filter s).card :=
+  to_fun_aux x = ((finset.range x).filter (∈ s)).card :=
 by rw [to_fun_aux, list.countp_eq_length_filter]; refl
 
 open finset
@@ -243,14 +243,14 @@ private lemma right_inverse_aux : ∀ n, to_fun_aux (of_nat s n) = n
   exact bot_le.not_lt (show (⟨n, hn.2⟩ : s) < ⊥, from hn.1),
 end
 | (n+1) := have ih : to_fun_aux (of_nat s n) = n, from right_inverse_aux n,
-have h₁ : (of_nat s n : ℕ) ∉ (range (of_nat s n)).filter s, by simp,
-have h₂ : (range (succ (of_nat s n))).filter s =
-  insert (of_nat s n) ((range (of_nat s n)).filter s),
+have h₁ : (of_nat s n : ℕ) ∉ (range (of_nat s n)).filter (∈ s), by simp,
+have h₂ : (range (succ (of_nat s n))).filter (∈ s) =
+  insert (of_nat s n) ((range (of_nat s n)).filter (∈ s)),
   begin
     simp only [finset.ext_iff, mem_insert, mem_range, mem_filter],
     exact λ m, ⟨λ h, by simp only [h.2, and_true]; exact or.symm
         (lt_or_eq_of_le ((@lt_succ_iff_le _ _ _ ⟨m, h.2⟩ _).1 h.1)),
-      λ h, h.elim (λ h, h.symm ▸ ⟨lt_succ_self _, subtype.property _⟩)
+      λ h, h.elim (λ h, h.symm ▸ ⟨lt_succ_self _, (of_nat s n).prop⟩)
         (λ h, ⟨h.1.trans (lt_succ_self _), h.2⟩)⟩,
   end,
 begin

--- a/src/data/equiv/encodable/basic.lean
+++ b/src/data/equiv/encodable/basic.lean
@@ -142,7 +142,7 @@ theorem encodek₂ [encodable α] (a : α) : decode₂ α (encode a) = some a :=
 mem_decode₂.2 rfl
 
 /-- The encoding function has decidable range. -/
-def decidable_range_encode (α : Type*) [encodable α] : decidable_pred (set.range (@encode α _)) :=
+def decidable_range_encode (α : Type*) [encodable α] : decidable_pred (∈ set.range (@encode α _)) :=
 λ x, decidable_of_iff (option.is_some (decode₂ α x))
   ⟨λ h, ⟨option.get h, by rw [← decode₂_is_partial_inv (option.get h), option.some_get]⟩,
   λ ⟨n, hn⟩, by rw [← hn, encodek₂]; exact rfl⟩

--- a/src/data/fintype/sort.lean
+++ b/src/data/fintype/sort.lean
@@ -18,8 +18,7 @@ def mono_equiv_of_fin (α) [fintype α] [linear_order α] {k : ℕ}
   (h : fintype.card α = k) : fin k ≃o α :=
 (univ.order_iso_of_fin h).trans $ (order_iso.set_congr _ _ coe_univ).trans order_iso.set.univ
 
-variables [decidable_eq α] [fintype α] [linear_order α] {m n : ℕ}
-  {s : finset α} [decidable_pred (s : set α)]
+variables [decidable_eq α] [fintype α] [linear_order α] {m n : ℕ} {s : finset α}
 
 /-- If `α` is a linearly ordered type, `s : finset α` has cardinality `m` and its complement has
 cardinality `n`, then `fin m ⊕ fin n ≃ α`. The equivalence sends elements of `fin m` to

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -98,7 +98,7 @@ instance : canonically_linear_ordered_add_monoid ℕ :=
 { .. (infer_instance : canonically_ordered_add_monoid ℕ),
   .. nat.linear_order }
 
-instance nat.subtype.semilattice_sup_bot (s : set ℕ) [decidable_pred s] [h : nonempty s] :
+instance nat.subtype.semilattice_sup_bot (s : set ℕ) [decidable_pred (∈ s)] [h : nonempty s] :
   semilattice_sup_bot s :=
 { bot := ⟨nat.find (nonempty_subtype.1 h), nat.find_spec (nonempty_subtype.1 h)⟩,
   bot_le := λ x, nat.find_min' _ x.2,

--- a/src/data/pequiv.lean
+++ b/src/data/pequiv.lean
@@ -158,13 +158,27 @@ variables (s : set α) [decidable_pred (∈ s)]
 def of_set (s : set α) [decidable_pred (∈ s)] : α ≃. α :=
 { to_fun := λ a, if a ∈ s then some a else none,
   inv_fun := λ a, if a ∈ s then some a else none,
-  inv := λ a b, by split_ifs; finish [eq_comm] }
+  inv := λ a b, by {
+    split_ifs with hb ha ha,
+    { simp [eq_comm] },
+    { simp [ne_of_mem_of_not_mem hb ha] },
+    { simp [ne_of_mem_of_not_mem ha hb] },
+    { simp } } }
 
 lemma mem_of_set_self_iff {s : set α} [decidable_pred (∈ s)] {a : α} : a ∈ of_set s a ↔ a ∈ s :=
 by dsimp [of_set]; split_ifs; simp *
 
 lemma mem_of_set_iff {s : set α} [decidable_pred (∈ s)] {a b : α} : a ∈ of_set s b ↔ a = b ∧ a ∈ s :=
-by dsimp [of_set]; split_ifs; split; finish
+begin
+  dsimp [of_set],
+  split_ifs,
+  { simp only [iff_self_and, option.mem_def, eq_comm],
+    rintro rfl,
+    exact h, },
+  { simp only [false_iff, not_and, option.not_mem_none],
+    rintro rfl,
+    exact h, }
+end
 
 @[simp] lemma of_set_eq_some_iff {s : set α} {h : decidable_pred (∈ s)} {a b : α} :
   of_set s b = some a ↔ a = b ∧ a ∈ s := mem_of_set_iff

--- a/src/data/pequiv.lean
+++ b/src/data/pequiv.lean
@@ -152,31 +152,31 @@ lemma injective_of_forall_is_some {f : α ≃. β}
   (λ hn x, (hn ⟨x⟩).elim)
 
 section of_set
-variables (s : set α) [decidable_pred s]
+variables (s : set α) [decidable_pred (∈ s)]
 
 /-- Creates a `pequiv` that is the identity on `s`, and `none` outside of it. -/
-def of_set (s : set α) [decidable_pred s] : α ≃. α :=
+def of_set (s : set α) [decidable_pred (∈ s)] : α ≃. α :=
 { to_fun := λ a, if a ∈ s then some a else none,
   inv_fun := λ a, if a ∈ s then some a else none,
   inv := λ a b, by split_ifs; finish [eq_comm] }
 
-lemma mem_of_set_self_iff {s : set α} [decidable_pred s] {a : α} : a ∈ of_set s a ↔ a ∈ s :=
+lemma mem_of_set_self_iff {s : set α} [decidable_pred (∈ s)] {a : α} : a ∈ of_set s a ↔ a ∈ s :=
 by dsimp [of_set]; split_ifs; simp *
 
-lemma mem_of_set_iff {s : set α} [decidable_pred s] {a b : α} : a ∈ of_set s b ↔ a = b ∧ a ∈ s :=
+lemma mem_of_set_iff {s : set α} [decidable_pred (∈ s)] {a b : α} : a ∈ of_set s b ↔ a = b ∧ a ∈ s :=
 by dsimp [of_set]; split_ifs; split; finish
 
-@[simp] lemma of_set_eq_some_iff {s : set α} {h : decidable_pred s} {a b : α} :
+@[simp] lemma of_set_eq_some_iff {s : set α} {h : decidable_pred (∈ s)} {a b : α} :
   of_set s b = some a ↔ a = b ∧ a ∈ s := mem_of_set_iff
 
-@[simp] lemma of_set_eq_some_self_iff {s : set α} {h : decidable_pred s} {a : α} :
+@[simp] lemma of_set_eq_some_self_iff {s : set α} {h : decidable_pred (∈ s)} {a : α} :
   of_set s a = some a ↔ a ∈ s := mem_of_set_self_iff
 
 @[simp] lemma of_set_symm : (of_set s).symm = of_set s := rfl
 
 @[simp] lemma of_set_univ : of_set set.univ = pequiv.refl α := rfl
 
-@[simp] lemma of_set_eq_refl {s : set α} [decidable_pred s] :
+@[simp] lemma of_set_eq_refl {s : set α} [decidable_pred (∈ s)] :
   of_set s = pequiv.refl α ↔ s = set.univ :=
 ⟨λ h, begin
   rw [set.eq_univ_iff_forall],

--- a/src/data/pequiv.lean
+++ b/src/data/pequiv.lean
@@ -168,7 +168,8 @@ def of_set (s : set α) [decidable_pred (∈ s)] : α ≃. α :=
 lemma mem_of_set_self_iff {s : set α} [decidable_pred (∈ s)] {a : α} : a ∈ of_set s a ↔ a ∈ s :=
 by dsimp [of_set]; split_ifs; simp *
 
-lemma mem_of_set_iff {s : set α} [decidable_pred (∈ s)] {a b : α} : a ∈ of_set s b ↔ a = b ∧ a ∈ s :=
+lemma mem_of_set_iff {s : set α} [decidable_pred (∈ s)] {a b : α} :
+  a ∈ of_set s b ↔ a = b ∧ a ∈ s :=
 begin
   dsimp [of_set],
   split_ifs,

--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -403,7 +403,7 @@ set.ext (mem_dom f)
 def fn (f : α →. β) (x) (h : dom f x) : β := (f x).get h
 
 /-- Evaluate a partial function to return an `option` -/
-def eval_opt (f : α →. β) [D : decidable_pred (dom f)] (x : α) : option β :=
+def eval_opt (f : α →. β) [D : decidable_pred (∈ dom f)] (x : α) : option β :=
 @roption.to_option _ _ (D x)
 
 /-- Partial function extensionality -/

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -214,7 +214,7 @@ theorem mem_def {a : α} {s : set α} : a ∈ s ↔ s a := iff.rfl
 acts as a compatibility layer. -/
 instance decidable_mem (s : set α) [H : decidable_pred s] : ∀ a, decidable (a ∈ s) := H
 
-instance decidable_set_of (p : α → Prop) [H : decidable_pred p] : decidable_pred {a | p a} := H
+instance decidable_set_of (p : α → Prop) [H : decidable_pred p] : decidable_pred (∈ {a | p a}) := H
 
 @[simp] theorem set_of_subset_set_of {p q : α → Prop} :
   {a | p a} ⊆ {a | q a} ↔ (∀a, p a → q a) := iff.rfl

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -441,7 +441,7 @@ eq_univ_of_univ_subset $ hs ▸ h
 lemma exists_mem_of_nonempty (α) : ∀ [nonempty α], ∃x:α, x ∈ (univ : set α)
 | ⟨x⟩ := ⟨x, trivial⟩
 
-instance univ_decidable : decidable_pred (@set.univ α) :=
+instance univ_decidable : decidable_pred (∈ @set.univ α) :=
 λ x, is_true trivial
 
 /-- `diagonal α` is the subset of `α × α` consisting of all pairs of the form `(a, a)`. -/

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -210,6 +210,8 @@ lemma set_of_app_iff {p : α → Prop} {x : α} : { x | p x } x ↔ p x := iff.r
 
 theorem mem_def {a : α} {s : set α} : a ∈ s ↔ s a := iff.rfl
 
+/-- Note: `decidable_pred s` should be avoided in favor of `decidable_pred (∈ s)`, this instance
+acts as a compatibility layer. -/
 instance decidable_mem (s : set α) [H : decidable_pred s] : ∀ a, decidable (a ∈ s) := H
 
 instance decidable_set_of (p : α → Prop) [H : decidable_pred p] : decidable_pred {a | p a} := H

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -273,11 +273,12 @@ instance fintype_sep (s : set α) (p : α → Prop) [fintype s] [decidable_pred 
   fintype ({a ∈ s | p a} : set α) :=
 fintype.of_finset (s.to_finset.filter p) $ by simp
 
-instance fintype_inter (s t : set α) [fintype s] [decidable_pred t] : fintype (s ∩ t : set α) :=
+instance fintype_inter (s t : set α) [fintype s] [decidable_pred (∈ t)] : fintype (s ∩ t : set α) :=
 set.fintype_sep s t
 
 /-- A `fintype` structure on a set defines a `fintype` structure on its subset. -/
-def fintype_subset (s : set α) {t : set α} [fintype s] [decidable_pred t] (h : t ⊆ s) : fintype t :=
+def fintype_subset (s : set α) {t : set α} [fintype s] [decidable_pred (∈ t)] (h : t ⊆ s) :
+  fintype t :=
 by rw ← inter_eq_self_of_subset_right h; apply_instance
 
 theorem finite.subset {s : set α} : finite s → ∀ {t : set α}, t ⊆ s → finite t

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -246,7 +246,7 @@ lemma mem_from_rel_irrefl_other_ne {sym : symmetric r} (irrefl : irreflexive r)
 mem_other_ne (from_rel_irreflexive.mp irrefl hz) h
 
 instance from_rel.decidable_pred (sym : symmetric r) [h : decidable_rel r] :
-  decidable_pred (sym2.from_rel sym) :=
+  decidable_pred (∈ sym2.from_rel sym) :=
 λ z, quotient.rec_on_subsingleton z (λ x, h _ _)
 
 end relations

--- a/src/field_theory/finite/polynomial.lean
+++ b/src/field_theory/finite/polynomial.lean
@@ -151,7 +151,7 @@ variables (σ : Type u) (K : Type u) [fintype σ] [field K] [fintype K]
 def R : Type u := restrict_degree σ K (fintype.card K - 1)
 
 noncomputable instance decidable_restrict_degree (m : ℕ) :
-  decidable_pred (λn, n ∈ {n : σ →₀ ℕ | ∀i, n i ≤ m }) :=
+  decidable_pred (∈ {n : σ →₀ ℕ | ∀i, n i ≤ m }) :=
 by simp only [set.mem_set_of_eq]; apply_instance
 
 lemma dim_R : module.rank K (R σ K) = fintype.card (σ → K) :=

--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -202,7 +202,7 @@ def left_rel [group α] (s : subgroup α) : setoid α :=
     by simpa [mul_assoc] using this⟩
 
 @[to_additive]
-instance left_rel_decidable [group α] (s : subgroup α) [d : decidable_pred (λ a, a ∈ s)] :
+instance left_rel_decidable [group α] (s : subgroup α) [d : decidable_pred (∈ s)] :
   decidable_rel (left_rel s).r := λ _ _, d _
 
 /-- `quotient s` is the quotient type representing the left cosets of `s`.
@@ -224,7 +224,7 @@ def right_rel [group α] (s : subgroup α) : setoid α :=
     by simpa [mul_assoc] using this⟩
 
 @[to_additive]
-instance right_rel_decidable [group α] (s : subgroup α) [d : decidable_pred (λ a, a ∈ s)] :
+instance right_rel_decidable [group α] (s : subgroup α) [d : decidable_pred (∈ s)] :
   decidable_rel (left_rel s).r := λ _ _, d _
 
 end quotient_group

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -485,7 +485,7 @@ finset.mem_range_iff_mem_finset_range_of_mod_eq' (order_of_pos x)
   (assume i, pow_eq_mod_order_of.symm)
 
 noncomputable instance decidable_multiples [decidable_eq A] :
-  decidable_pred (add_submonoid.multiples a : set A) :=
+  decidable_pred (∈ add_submonoid.multiples a : set A) :=
 begin
   assume b,
   apply decidable_of_iff' (b ∈ (finset.range (add_order_of a)).image (• a)),
@@ -494,7 +494,7 @@ end
 
 @[to_additive decidable_multiples]
 noncomputable instance decidable_powers [decidable_eq G] :
-  decidable_pred (submonoid.powers x : set G) :=
+  decidable_pred (∈ submonoid.powers x : set G) :=
 begin
   assume y,
   apply decidable_of_iff'
@@ -634,7 +634,7 @@ lemma mem_gpowers_iff_mem_range_order_of [decidable_eq G] :
 by rw [← mem_powers_iff_mem_gpowers, mem_powers_iff_mem_range_order_of]
 
 noncomputable instance decidable_gmultiples [decidable_eq A] :
-  decidable_pred (add_subgroup.gmultiples a : set A) :=
+  decidable_pred (∈ add_subgroup.gmultiples a : set A) :=
 begin
   rw ← multiples_eq_gmultiples,
   exact decidable_multiples,
@@ -642,7 +642,7 @@ end
 
 @[to_additive decidable_gmultiples]
 noncomputable instance decidable_gpowers [decidable_eq G] :
-  decidable_pred (subgroup.gpowers x : set G) :=
+  decidable_pred (∈ subgroup.gpowers x : set G) :=
 begin
   rw ← powers_eq_gpowers,
   exact decidable_powers,

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -485,7 +485,7 @@ finset.mem_range_iff_mem_finset_range_of_mod_eq' (order_of_pos x)
   (assume i, pow_eq_mod_order_of.symm)
 
 noncomputable instance decidable_multiples [decidable_eq A] :
-  decidable_pred (∈ add_submonoid.multiples a : set A) :=
+  decidable_pred (∈ add_submonoid.multiples a) :=
 begin
   assume b,
   apply decidable_of_iff' (b ∈ (finset.range (add_order_of a)).image (• a)),
@@ -494,7 +494,7 @@ end
 
 @[to_additive decidable_multiples]
 noncomputable instance decidable_powers [decidable_eq G] :
-  decidable_pred (∈ submonoid.powers x : set G) :=
+  decidable_pred (∈ submonoid.powers x) :=
 begin
   assume y,
   apply decidable_of_iff'
@@ -634,16 +634,18 @@ lemma mem_gpowers_iff_mem_range_order_of [decidable_eq G] :
 by rw [← mem_powers_iff_mem_gpowers, mem_powers_iff_mem_range_order_of]
 
 noncomputable instance decidable_gmultiples [decidable_eq A] :
-  decidable_pred (∈ add_subgroup.gmultiples a : set A) :=
+  decidable_pred (∈ add_subgroup.gmultiples a) :=
 begin
+  simp_rw ←set_like.mem_coe,
   rw ← multiples_eq_gmultiples,
   exact decidable_multiples,
 end
 
 @[to_additive decidable_gmultiples]
 noncomputable instance decidable_gpowers [decidable_eq G] :
-  decidable_pred (∈ subgroup.gpowers x : set G) :=
+  decidable_pred (∈ subgroup.gpowers x) :=
 begin
+  simp_rw ←set_like.mem_coe,
   rw ← powers_eq_gpowers,
   exact decidable_powers,
 end

--- a/src/group_theory/perm/subgroup.lean
+++ b/src/group_theory/perm/subgroup.lean
@@ -26,7 +26,7 @@ universes u
 
 instance sum_congr_hom.decidable_mem_range {α β : Type*}
   [decidable_eq α] [decidable_eq β] [fintype α] [fintype β] :
-  decidable_pred (λ x, x ∈ (sum_congr_hom α β).range) :=
+  decidable_pred (∈ (sum_congr_hom α β).range) :=
 λ x, infer_instance
 
 @[simp]
@@ -37,7 +37,7 @@ fintype.card_eq.mpr ⟨(of_injective (sum_congr_hom α β) sum_congr_hom_injecti
 
 instance sigma_congr_right_hom.decidable_mem_range {α : Type*} {β : α → Type*}
   [decidable_eq α] [∀ a, decidable_eq (β a)] [fintype α] [∀ a, fintype (β a)] :
-  decidable_pred (λ x, x ∈ (sigma_congr_right_hom β).range) :=
+  decidable_pred (∈ (sigma_congr_right_hom β).range) :=
 λ x, infer_instance
 
 @[simp]
@@ -48,7 +48,7 @@ fintype.card_eq.mpr ⟨(of_injective (sigma_congr_right_hom β) sigma_congr_righ
 
 instance subtype_congr_hom.decidable_mem_range {α : Type*} (p : α → Prop) [decidable_pred p]
   [fintype (perm {a // p a} × perm {a // ¬ p a})] [decidable_eq (perm α)] :
-  decidable_pred (λ x, x ∈ (subtype_congr_hom p).range) :=
+  decidable_pred (∈ (subtype_congr_hom p).range) :=
 λ x, infer_instance
 
 @[simp]

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1218,7 +1218,7 @@ subgroup.copy ((⊤ : subgroup G).map f) (set.range f) (by simp [set.ext_iff])
 
 @[to_additive]
 instance decidable_mem_range (f : G →* N) [fintype G] [decidable_eq N] :
-  decidable_pred (λ x, x ∈ f.range) :=
+  decidable_pred (∈ f.range) :=
 λ x, fintype.decidable_exists_fintype
 
 @[simp, to_additive] lemma coe_range (f : G →* N) :

--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -1116,7 +1116,7 @@ variables (R M₂ M')
 `l`, then the space of multilinear maps on `λ i : fin n, M'` is isomorphic to the space of
 multilinear maps on `λ i : fin k, M'` taking values in the space of multilinear maps
 on `λ i : fin l, M'`. -/
-def curry_fin_finset {k l n : ℕ} {s : finset (fin n)} [decidable_pred (s : set (fin n))]
+def curry_fin_finset {k l n : ℕ} {s : finset (fin n)}
   (hk : s.card = k) (hl : sᶜ.card = l) :
   multilinear_map R (λ x : fin n, M') M₂ ≃ₗ[R]
     multilinear_map R (λ x : fin k, M') (multilinear_map R (λ x : fin l, M') M₂) :=
@@ -1126,7 +1126,7 @@ def curry_fin_finset {k l n : ℕ} {s : finset (fin n)} [decidable_pred (s : set
 variables {R M₂ M'}
 
 @[simp]
-lemma curry_fin_finset_apply {k l n : ℕ} {s : finset (fin n)} [decidable_pred (s : set (fin n))]
+lemma curry_fin_finset_apply {k l n : ℕ} {s : finset (fin n)}
   (hk : s.card = k) (hl : sᶜ.card = l) (f : multilinear_map R (λ x : fin n, M') M₂)
   (mk : fin k → M') (ml : fin l → M') :
   curry_fin_finset R M₂ M' hk hl f mk ml =
@@ -1134,7 +1134,7 @@ lemma curry_fin_finset_apply {k l n : ℕ} {s : finset (fin n)} [decidable_pred 
 rfl
 
 @[simp] lemma curry_fin_finset_symm_apply {k l n : ℕ} {s : finset (fin n)}
-  [decidable_pred (s : set (fin n))] (hk : s.card = k) (hl : sᶜ.card = l)
+  (hk : s.card = k) (hl : sᶜ.card = l)
   (f : multilinear_map R (λ x : fin k, M') (multilinear_map R (λ x : fin l, M') M₂))
   (m : fin n → M') :
   (curry_fin_finset R M₂ M' hk hl).symm f m =
@@ -1143,7 +1143,7 @@ rfl
 rfl
 
 @[simp] lemma curry_fin_finset_symm_apply_piecewise_const {k l n : ℕ} {s : finset (fin n)}
-  [decidable_pred (s : set (fin n))] (hk : s.card = k) (hl : sᶜ.card = l)
+  (hk : s.card = k) (hl : sᶜ.card = l)
   (f : multilinear_map R (λ x : fin k, M') (multilinear_map R (λ x : fin l, M') M₂)) (x y : M') :
   (curry_fin_finset R M₂ M' hk hl).symm f (s.piecewise (λ _, x) (λ _, y)) = f (λ _, x) (λ _, y) :=
 begin
@@ -1155,13 +1155,12 @@ begin
 end
 
 @[simp] lemma curry_fin_finset_symm_apply_const {k l n : ℕ} {s : finset (fin n)}
-  [decidable_pred (s : set (fin n))] (hk : s.card = k) (hl : sᶜ.card = l)
+  (hk : s.card = k) (hl : sᶜ.card = l)
   (f : multilinear_map R (λ x : fin k, M') (multilinear_map R (λ x : fin l, M') M₂)) (x : M') :
   (curry_fin_finset R M₂ M' hk hl).symm f (λ _, x) = f (λ _, x) (λ _, x) :=
 rfl
 
 @[simp] lemma curry_fin_finset_apply_const {k l n : ℕ} {s : finset (fin n)}
-  [decidable_pred (s : set (fin n))]
   (hk : s.card = k) (hl : sᶜ.card = l) (f : multilinear_map R (λ x : fin n, M') M₂) (x y : M') :
   curry_fin_finset R M₂ M' hk hl f (λ _, x) (λ _, y) = f (s.piecewise (λ _, x) (λ _, y)) :=
 begin

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -186,7 +186,7 @@ lemma subsingleton.measurable [subsingleton α] {f : α → β} : measurable f :
 λ s hs, @subsingleton.measurable_set α _ _ _
 
 @[measurability]
-lemma measurable.piecewise {s : set α} {_ : decidable_pred s} {f g : α → β}
+lemma measurable.piecewise {s : set α} {_ : decidable_pred (∈ s)} {f g : α → β}
   (hs : measurable_set s) (hf : measurable f) (hg : measurable g) :
   measurable (piecewise s f g) :=
 begin

--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -63,7 +63,7 @@ theorem well_founded_iff_no_descending_seq :
 end rel_embedding
 
 namespace nat
-variables (s : set ℕ) [decidable_pred s] [infinite s]
+variables (s : set ℕ) [decidable_pred (∈ s)] [infinite s]
 
 /-- An order embedding from `ℕ` to itself with a specified range -/
 def order_embedding_of_set : ℕ ↪o ℕ :=

--- a/src/ring_theory/free_comm_ring.lean
+++ b/src/ring_theory/free_comm_ring.lean
@@ -178,11 +178,11 @@ end is_supported
 
 /-- The restriction map from `free_comm_ring α` to `free_comm_ring s` where `s : set α`, defined
   by sending all variables not in `s` to zero. -/
-def restriction (s : set α) [decidable_pred s] : free_comm_ring α →+* free_comm_ring s :=
+def restriction (s : set α) [decidable_pred (∈ s)] : free_comm_ring α →+* free_comm_ring s :=
 lift (λ p, if H : p ∈ s then of (⟨p, H⟩ : s) else 0)
 
 section restriction
-variables (s : set α) [decidable_pred s] (x y : free_comm_ring α)
+variables (s : set α) [decidable_pred (∈ s)] (x y : free_comm_ring α)
 @[simp] lemma restriction_of (p) :
   restriction s (of p) = if H : p ∈ s then of ⟨p, H⟩ else 0 := lift_of _ _
 
@@ -207,7 +207,8 @@ assume hps : is_supported (of p) s, begin
   rwa [polynomial.coeff_C, if_neg (one_ne_zero : 1 ≠ 0), polynomial.coeff_X, if_pos rfl] at this
 end
 
-theorem map_subtype_val_restriction {x} (s : set α) [decidable_pred s] (hxs : is_supported x s) :
+theorem map_subtype_val_restriction {x} (s : set α) [decidable_pred (∈ s)]
+  (hxs : is_supported x s) :
   map (subtype.val : s → α) (restriction s x) = x :=
 begin
   refine ring.in_closure.rec_on hxs _ _ _ _,


### PR DESCRIPTION
The latter exploits the fact that sets are functions to Prop, and is an annoying form as lemmas are never stated about it.

In future we should consider removing the `set.decidable_mem` instance which encourages this misuse.

Making this change reveals a collection of pointless decidable arguments requiring that finset membership be decidable; something which is always true anyway.

Two proofs in `data/pequiv` caused a crash inside the C++ portion of the `finish` tactic; it was easier to just write the simple proofs manually than to debug the C++ code.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
