### PR TITLE
[Merged by Bors] - feat(linear_algebra/prod): add coprod_map_prod

### DIFF
--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -249,12 +249,15 @@ begin
   exact mul_le_mul' (hbA hxa) (hbB hxb),
 end
 
+section big_operators
 open_locale big_operators
+
+variables {ι : Type*} [comm_monoid α]
 
 /-- The n-ary version of `set.mem_mul`. -/
 @[to_additive /-" The n-ary version of `set.mem_add`. "-/]
-lemma mem_finset_prod {α ι : Type*} (t : finset ι) (f : ι → set α) [comm_monoid α] (a : α) :
-  a ∈ ∏ i in t, f i ↔ ∃ (g : ι → α) (hg : ∀ i ∈ t, g i ∈ f i), ∏ i in t, g i = a :=
+lemma mem_finset_prod (t : finset ι) (f : ι → set α) (a : α) :
+  a ∈ ∏ i in t, f i ↔ ∃ (g : ι → α) (hg : ∀ {i}, i ∈ t → g i ∈ f i), ∏ i in t, g i = a :=
 begin
   classical,
   induction t using finset.induction_on with i is hi ih generalizing a,
@@ -268,12 +271,41 @@ begin
     refine ⟨function.update g i x, λ j hj, _, _⟩,
     obtain rfl | hj := finset.mem_insert.mp hj,
     { rw function.update_same, exact hx },
-    { rw update_noteq (ne_of_mem_of_not_mem hj hi), exact hg j hj, },
+    { rw update_noteq (ne_of_mem_of_not_mem hj hi), exact hg hj, },
     rw [finset.prod_update_of_not_mem hi, function.update_same], },
   { rintros ⟨g, hg, rfl⟩,
-    exact ⟨g i, is.prod g, hg _ (is.mem_insert_self _),
-      ⟨g, λ i hi, hg i (finset.mem_insert_of_mem hi), rfl⟩, rfl⟩ },
+    exact ⟨g i, is.prod g, hg (is.mem_insert_self _),
+      ⟨g, λ i hi, hg (finset.mem_insert_of_mem hi), rfl⟩, rfl⟩ },
 end
+
+/-- A version of `set.mem_finset_prod` with a simpler RHS for products over a fintype. -/
+@[to_additive /-" A version of `set.mem_finset_sum` with a simpler RHS for sums over a fintype. "-/]
+lemma mem_fintype_prod [fintype ι] (f : ι → set α) (a : α) :
+  a ∈ ∏ i, f i ↔ ∃ (g : ι → α) (hg : ∀ i, g i ∈ f i), ∏ i, g i = a :=
+by { rw mem_finset_prod, simp }
+
+/-- The n-ary version of `set.mul_mem_mul`. -/
+@[to_additive /-" The n-ary version of `set.add_mem_add`. "-/]
+lemma finset_prod_mem_finset_prod (t : finset ι) (f : ι → set α)
+  (g : ι → α) (hg : ∀ i ∈ t, g i ∈ f i) :
+  ∏ i in t, g i ∈ ∏ i in t, f i :=
+by { rw mem_finset_prod, exact ⟨g, hg, rfl⟩ }
+
+/-- The n-ary version of `set.mul_subset_mul`. -/
+@[to_additive /-" The n-ary version of `set.add_subset_add`. "-/]
+lemma finset_prod_subset_finset_prod (t : finset ι) (f₁ f₂ : ι → set α)
+  (hf : ∀ {i}, i ∈ t → f₁ i ⊆ f₂ i) :
+  ∏ i in t, f₁ i ⊆ ∏ i in t, f₂ i :=
+begin
+  intro a,
+  rw [mem_finset_prod, mem_finset_prod],
+  rintro ⟨g, hg, rfl⟩,
+  exact ⟨g, λ i hi, hf hi $ hg hi, rfl⟩
+end
+
+/-! TODO: define `decidable_mem_finset_prod` and `decidable_mem_finset_sum`. -/
+
+end big_operators
 
 /-! ### Properties about inversion -/
 @[to_additive set.has_neg]

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -249,6 +249,32 @@ begin
   exact mul_le_mul' (hbA hxa) (hbB hxb),
 end
 
+open_locale big_operators
+
+/-- The n-ary version of `set.mem_mul`. -/
+@[to_additive /-" The n-ary version of `set.mem_add`. "-/]
+lemma mem_finset_prod {α ι : Type*} (t : finset ι) (f : ι → set α) [comm_monoid α] (a : α) :
+  a ∈ ∏ i in t, f i ↔ ∃ (g : ι → α) (hg : ∀ i ∈ t, g i ∈ f i), ∏ i in t, g i = a :=
+begin
+  classical,
+  induction t using finset.induction_on with i is hi ih generalizing a,
+  { simp_rw [finset.prod_empty, set.mem_one],
+    exact ⟨λ h, ⟨λ i, a, λ i, false.elim, h.symm⟩, λ ⟨f, _, hf⟩, hf.symm⟩ },
+  rw [finset.prod_insert hi, set.mem_mul],
+  simp_rw [finset.prod_insert hi],
+  simp_rw ih,
+  split,
+  { rintros ⟨x, y, hx, ⟨g, hg, rfl⟩, rfl⟩,
+    refine ⟨function.update g i x, λ j hj, _, _⟩,
+    obtain rfl | hj := finset.mem_insert.mp hj,
+    { rw function.update_same, exact hx },
+    { rw update_noteq (ne_of_mem_of_not_mem hj hi), exact hg j hj, },
+    rw [finset.prod_update_of_not_mem hi, function.update_same], },
+  { rintros ⟨g, hg, rfl⟩,
+    exact ⟨g i, is.prod g, hg _ (is.mem_insert_self _),
+      ⟨g, λ i hi, hg i (finset.mem_insert_of_mem hi), rfl⟩, rfl⟩ },
+end
+
 /-! ### Properties about inversion -/
 @[to_additive set.has_neg]
 instance [has_inv α] : has_inv (set α) :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1044,6 +1044,13 @@ by rintro ⟨y, hy, z, hz, rfl⟩; exact add_mem _
 lemma mem_sup' : x ∈ p ⊔ p' ↔ ∃ (y : p) (z : p'), (y:M) + z = x :=
 mem_sup.trans $ by simp only [set_like.exists, coe_mk]
 
+lemma coe_sup : ↑(p ⊔ p') = (p + p' : set M) :=
+begin
+  ext,
+  rw [set_like.mem_coe, mem_sup, set.mem_add],
+  simp,
+end
+
 end
 
 /- This is the character `∙`, with escape sequence `\.`, and is thus different from the scalar

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1045,11 +1045,7 @@ lemma mem_sup' : x ∈ p ⊔ p' ↔ ∃ (y : p) (z : p'), (y:M) + z = x :=
 mem_sup.trans $ by simp only [set_like.exists, coe_mk]
 
 lemma coe_sup : ↑(p ⊔ p') = (p + p' : set M) :=
-begin
-  ext,
-  rw [set_like.mem_coe, mem_sup, set.mem_add],
-  simp,
-end
+by { ext, rw [set_like.mem_coe, mem_sup, set.mem_add], simp, }
 
 end
 

--- a/src/linear_algebra/prod.lean
+++ b/src/linear_algebra/prod.lean
@@ -143,6 +143,16 @@ theorem snd_eq_coprod : snd R M M₂ = coprod 0 linear_map.id := by ext; simp
   (f.coprod g).comp (f'.prod g') = f.comp f' + g.comp g' :=
 rfl
 
+@[simp]
+lemma coprod_map_prod (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₃) (S : submodule R M)
+  (S' : submodule R M₂) :
+  (submodule.prod S S').map (linear_map.coprod f g) = S.map f ⊔ S'.map g :=
+set_like.coe_injective $ begin
+  simp only [linear_map.coprod_apply, submodule.coe_sup, submodule.map_coe],
+  rw [←set.image2_add, set.image2_image_left, set.image2_image_right],
+  exact set.image_prod (λ m m₂, f m + g m₂),
+end
+
 /-- Taking the product of two maps with the same codomain is equivalent to taking the product of
 their domains.
 


### PR DESCRIPTION
This also adds `submodule.coe_sup` and `set.mem_finset_prod`. The latter was intended to be used to show `submodule.coe_supr`, but I didn't really need that and it was hard to prove.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
