### PR TITLE
[Merged by Bors] - chore(measure_theory/measure_space): untangle `probability_measure`, `finite_measure`, and `has_no_atoms`

### DIFF
--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -1384,11 +1384,7 @@ end
 lemma restrict_congr_set (H : s =ᵐ[μ] t) : μ.restrict s = μ.restrict t :=
 le_antisymm (restrict_mono_ae H.le) (restrict_mono_ae H.symm.le)
 
-/-- A measure `μ` is called a probability measure if `μ univ = 1`. -/
-class probability_measure (μ : measure α) : Prop := (measure_univ : μ univ = 1)
-
-instance measure.dirac.probability_measure {x : α} : probability_measure (dirac x) :=
-⟨dirac_apply_of_mem $ mem_univ x⟩
+section finite_measure
 
 /-- A measure `μ` is called finite if `μ univ < ∞`. -/
 class finite_measure (μ : measure α) : Prop := (measure_univ_lt_top : μ univ < ∞)
@@ -1396,22 +1392,6 @@ class finite_measure (μ : measure α) : Prop := (measure_univ_lt_top : μ univ 
 instance restrict.finite_measure (μ : measure α) [hs : fact (μ s < ∞)] :
   finite_measure (μ.restrict s) :=
 ⟨by simp [hs.elim]⟩
-
-/-- Measure `μ` *has no atoms* if the measure of each singleton is zero.
-
-NB: Wikipedia assumes that for any measurable set `s` with positive `μ`-measure,
-there exists a measurable `t ⊆ s` such that `0 < μ t < μ s`. While this implies `μ {x} = 0`,
-the converse is not true. -/
-class has_no_atoms (μ : measure α) : Prop :=
-(measure_singleton : ∀ x, μ {x} = 0)
-
-export probability_measure (measure_univ) has_no_atoms (measure_singleton)
-
-attribute [simp] measure_singleton
-
-@[simp] lemma measure.restrict_singleton' [has_no_atoms μ] {a : α} :
-  μ.restrict {a} = 0 :=
-by simp only [measure_singleton, measure.restrict_eq_zero]
 
 lemma measure_lt_top (μ : measure α) [finite_measure μ] (s : set α) : μ s < ∞ :=
 (measure_mono (subset_univ s)).trans_lt finite_measure.measure_univ_lt_top
@@ -1448,6 +1428,18 @@ lemma measure.le_of_add_le_add_left {μ ν₁ ν₂ : measure α} [finite_measur
   (A2 : μ + ν₁ ≤ μ + ν₂) : ν₁ ≤ ν₂ :=
 λ S B1, ennreal.le_of_add_le_add_left (measure_theory.measure_lt_top μ S) (A2 S B1)
 
+end finite_measure
+
+section probability_measure
+
+/-- A measure `μ` is called a probability measure if `μ univ = 1`. -/
+class probability_measure (μ : measure α) : Prop := (measure_univ : μ univ = 1)
+
+export probability_measure (measure_univ)
+
+instance measure.dirac.probability_measure {x : α} : probability_measure (dirac x) :=
+⟨dirac_apply_of_mem $ mem_univ x⟩
+
 @[priority 100]
 instance probability_measure.to_finite_measure (μ : measure α) [probability_measure μ] :
   finite_measure μ :=
@@ -1456,9 +1448,26 @@ instance probability_measure.to_finite_measure (μ : measure α) [probability_me
 lemma probability_measure.ne_zero (μ : measure α) [probability_measure μ] : μ ≠ 0 :=
 mt measure_univ_eq_zero.2 $ by simp [measure_univ]
 
+end probability_measure
+
 section no_atoms
 
+/-- Measure `μ` *has no atoms* if the measure of each singleton is zero.
+
+NB: Wikipedia assumes that for any measurable set `s` with positive `μ`-measure,
+there exists a measurable `t ⊆ s` such that `0 < μ t < μ s`. While this implies `μ {x} = 0`,
+the converse is not true. -/
+class has_no_atoms (μ : measure α) : Prop :=
+(measure_singleton : ∀ x, μ {x} = 0)
+
+export has_no_atoms (measure_singleton)
+attribute [simp] measure_singleton
+
 variables [has_no_atoms μ]
+
+@[simp] lemma measure.restrict_singleton' {a : α} :
+  μ.restrict {a} = 0 :=
+by simp only [measure_singleton, measure.restrict_eq_zero]
 
 instance (s : set α) : has_no_atoms (μ.restrict s) :=
 begin


### PR DESCRIPTION
This only moves existing lemmas around. Putting all the instance together up front seems to result in lemmas being added in adhoc places - by adding `section`s, this should guide future contributions.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
