### PR TITLE
[Merged by Bors] - chore(analysis/normed_space/banach): speed up the proof

### DIFF
--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -314,6 +314,9 @@ noncomputable def of_bijective (f : E →L[𝕜] F) (hinj : f.ker = ⊥) (hsurj 
 @[simp] lemma coe_fn_of_bijective (f : E →L[𝕜] F) (hinj : f.ker = ⊥) (hsurj : f.range = ⊤) :
   ⇑(of_bijective f hinj hsurj) = f := rfl
 
+lemma coe_of_bijective (f : E →L[𝕜] F) (hinj : f.ker = ⊥) (hsurj : f.range = ⊤) :
+  ↑(of_bijective f hinj hsurj) = f := by { ext, refl }
+
 @[simp] lemma of_bijective_symm_apply_apply (f : E →L[𝕜] F) (hinj : f.ker = ⊥)
   (hsurj : f.range = ⊤) (x : E) :
   (of_bijective f hinj hsurj).symm (f x) = x :=
@@ -328,25 +331,42 @@ end continuous_linear_equiv
 
 namespace continuous_linear_map
 
+/-- Intermediate definition used to show
+`continuous_linear_map.closed_complemented_range_of_is_compl_of_ker_eq_bot`.
+
+This is `f.coprod G.subtypeL` as an `continuous_linear_equiv`.
+-/
+noncomputable def coprod_subtypeL_equiv_of_is_compl
+  (f : E →L[𝕜] F) {G : submodule 𝕜 F}
+  (h : is_compl f.range G) [complete_space G] (hker : f.ker = ⊥) : (E × G) ≃L[𝕜] F :=
+continuous_linear_equiv.of_bijective (f.coprod G.subtypeL)
+  (begin
+    rw ker_coprod_of_disjoint_range,
+    { rw [hker, submodule.ker_subtypeL, submodule.prod_bot] },
+    { rw submodule.range_subtypeL,
+      exact h.disjoint }
+  end)
+  (by simp only [range_coprod, h.sup_eq_top, submodule.range_subtypeL])
+
+lemma range_eq_map_coprod_subtypeL_equiv_of_is_compl
+  (f : E →L[𝕜] F) {G : submodule 𝕜 F}
+  (h : is_compl f.range G) [complete_space G] (hker : f.ker = ⊥) :
+    f.range = ((⊤ : submodule 𝕜 E).prod (⊥ : submodule 𝕜 G)).map
+      (coprod_subtypeL_equiv_of_is_compl f h hker) :=
+by rw [coprod_subtypeL_equiv_of_is_compl, _root_.coe_coe, continuous_linear_equiv.coe_of_bijective,
+    coe_coprod, linear_map.coprod_map_prod, submodule.map_bot, sup_bot_eq, submodule.map_top,
+    range]
+
 /- TODO: remove the assumption `f.ker = ⊥` in the next lemma, by using the map induced by `f` on
 `E / f.ker`, once we have quotient normed spaces. -/
 lemma closed_complemented_range_of_is_compl_of_ker_eq_bot (f : E →L[𝕜] F) (G : submodule 𝕜 F)
   (h : is_compl f.range G) (hG : is_closed (G : set F)) (hker : f.ker = ⊥) :
   is_closed (f.range : set F) :=
 begin
-  let g : (E × G) →L[𝕜] F := f.coprod G.subtypeL,
-  have : (f.range : set F) = g '' ((⊤ : submodule 𝕜 E).prod (⊥ : submodule 𝕜 G)),
-    by { ext x, simp [continuous_linear_map.mem_range] },
-  rw this,
   haveI : complete_space G := complete_space_coe_iff_is_complete.2 hG.is_complete,
-  have grange : g.range = ⊤,
-    by simp only [range_coprod, h.sup_eq_top, submodule.range_subtypeL],
-  have gker : g.ker = ⊥,
-  { rw [ker_coprod_of_disjoint_range, hker],
-    { simp only [submodule.ker_subtypeL, submodule.prod_bot] },
-    { convert h.disjoint,
-      exact submodule.range_subtypeL _ } },
-  apply (continuous_linear_equiv.of_bijective g gker grange).to_homeomorph.is_closed_image.2,
+  let g := coprod_subtypeL_equiv_of_is_compl f h hker,
+  rw congr_arg coe (range_eq_map_coprod_subtypeL_equiv_of_is_compl f h hker ),
+  apply g.to_homeomorph.is_closed_image.2,
   exact is_closed_univ.prod is_closed_singleton,
 end
 

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -334,8 +334,7 @@ namespace continuous_linear_map
 /-- Intermediate definition used to show
 `continuous_linear_map.closed_complemented_range_of_is_compl_of_ker_eq_bot`.
 
-This is `f.coprod G.subtypeL` as an `continuous_linear_equiv`.
--/
+This is `f.coprod G.subtypeL` as an `continuous_linear_equiv`. -/
 noncomputable def coprod_subtypeL_equiv_of_is_compl
   (f : E →L[𝕜] F) {G : submodule 𝕜 F}
   (h : is_compl f.range G) [complete_space G] (hker : f.ker = ⊥) : (E × G) ≃L[𝕜] F :=


### PR DESCRIPTION
This proof has timed out in multiple refactor PRs I've made. This splits out an auxiliary definition.

The new definition takes about 3.5s to elaborate, and the two lemmas are <500ms each.
The old lemma took 45s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
 [optional extra text]
-->
- [ ] depends on: #8220 (all changes but to banach.lean are from this PR)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
