### PR TITLE
[Merged by Bors] - feat(category_theory/is_connected): constant functor is full

### DIFF
--- a/src/category_theory/is_connected.lean
+++ b/src/category_theory/is_connected.lean
@@ -40,7 +40,7 @@ connected limit. That is, any limit of shape `J` where `J` is a connected
 category is preserved by the functor `(X × -)`. This appears in `category_theory.limits.connected`.
 -/
 
-universes v₁ v₂ v₃ u₁ u₂
+universes v₁ v₂ u₁ u₂
 
 noncomputable theory
 

--- a/src/category_theory/is_connected.lean
+++ b/src/category_theory/is_connected.lean
@@ -40,7 +40,7 @@ connected limit. That is, any limit of shape `J` where `J` is a connected
 category is preserved by the functor `(X × -)`. This appears in `category_theory.limits.connected`.
 -/
 
-universes v₁ v₂ u₁ u₂
+universes v₁ v₂ v₃ u₁ u₂
 
 noncomputable theory
 
@@ -318,6 +318,14 @@ lemma nat_trans_from_is_connected [is_preconnected J] {X Y : C}
   (X ⟶ Y)
   (λ j, α.app j)
   (λ _ _ f, (by { have := α.naturality f, erw [id_comp, comp_id] at this, exact this.symm }))
+
+instance [is_connected J] : full (functor.const J : C ⥤ _) :=
+{ preimage := λ X Y f, f.app (classical.arbitrary J),
+  witness' := λ X Y f,
+  begin
+    ext j,
+    apply nat_trans_from_is_connected f (classical.arbitrary J) j,
+  end }
 
 instance nonempty_hom_of_connected_groupoid {G} [groupoid G] [is_connected G] (x y : G) :
   nonempty (x ⟶ y) :=

--- a/src/category_theory/is_connected.lean
+++ b/src/category_theory/is_connected.lean
@@ -319,7 +319,7 @@ lemma nat_trans_from_is_connected [is_preconnected J] {X Y : C}
   (λ j, α.app j)
   (λ _ _ f, (by { have := α.naturality f, erw [id_comp, comp_id] at this, exact this.symm }))
 
-instance [is_connected J] : full (functor.const J : C ⥤ _) :=
+instance [is_connected J] : full (functor.const J : C ⥤ J ⥤ C) :=
 { preimage := λ X Y f, f.app (classical.arbitrary J),
   witness' := λ X Y f,
   begin
@@ -327,16 +327,11 @@ instance [is_connected J] : full (functor.const J : C ⥤ _) :=
     apply nat_trans_from_is_connected f (classical.arbitrary J) j,
   end }
 
-instance nonempty_hom_of_connected_groupoid {G} [groupoid G] [is_connected G] (x y : G) :
-  nonempty (x ⟶ y) :=
+instance nonempty_hom_of_connected_groupoid {G} [groupoid G] [is_connected G] :
+  ∀ (x y : G), nonempty (x ⟶ y) :=
 begin
-  have h := is_connected_zigzag x y,
-  induction h with z w _ h ih,
-  { exact ⟨𝟙 x⟩ },
-  { refine nonempty.map (λ f, f ≫ classical.choice _) ih,
-    cases h,
-    { assumption },
-    { apply nonempty.map (λ f, inv f) h } }
+  refine equiv_relation _ _ (λ j₁ j₂, nonempty.intro),
+  exact ⟨λ j, ⟨𝟙 _⟩, λ j₁ j₂, nonempty.map (λ f, inv f), λ _ _ _, nonempty.map2 (≫)⟩,
 end
 
 end category_theory


### PR DESCRIPTION
Shows the constant functor on a connected category is full.

Also golfs a later proof slightly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
