### PR TITLE
[Merged by Bors] - chore(data/set/basic): remove set.decidable_mem

### DIFF
--- a/src/data/equiv/fintype.lean
+++ b/src/data/equiv/fintype.lean
@@ -100,9 +100,7 @@ lemma extend_subtype_apply_of_mem (e : {x // p x} ≃ {x // q x}) (x) (hx : p x)
   e.extend_subtype x = e ⟨x, hx⟩ :=
 by { dunfold extend_subtype,
      simp only [subtype_congr, equiv.trans_apply, equiv.sum_congr_apply],
-     -- `p` gets turned into `λ x, p x` which `rw` doesn't like, so we have to use `erw`
-     erw [equiv.set.sum_compl_symm_apply_of_mem hx, sum.map_inl,
-          equiv.set.sum_compl_apply_inl q] }
+     rw [sum_compl_apply_symm_of_pos _ _ hx, sum.map_inl, sum_compl_apply_inl] }
 
 lemma extend_subtype_mem (e : {x // p x} ≃ {x // q x}) (x) (hx : p x) :
   q (e.extend_subtype x) :=
@@ -112,10 +110,8 @@ by { convert (e ⟨x, hx⟩).2,
 lemma extend_subtype_apply_of_not_mem (e : {x // p x} ≃ {x // q x}) (x) (hx : ¬ p x) :
   e.extend_subtype x = e.to_compl ⟨x, hx⟩ :=
 by { dunfold extend_subtype,
-    simp only [subtype_congr, equiv.trans_apply, equiv.sum_congr_apply],
-    -- `p` gets turned into `λ x, p x` which `rw` doesn't like, so we have to use `erw`
-    erw [equiv.set.sum_compl_symm_apply_of_not_mem hx, sum.map_inr,
-         equiv.set.sum_compl_apply_inr q] }
+     simp only [subtype_congr, equiv.trans_apply, equiv.sum_congr_apply],
+     rw [sum_compl_apply_symm_of_neg _ _ hx, sum.map_inr, sum_compl_apply_inr] }
 
 lemma extend_subtype_not_mem (e : {x // p x} ≃ {x // q x}) (x) (hx : ¬ p x) :
   ¬ q (e.extend_subtype x) :=

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -210,10 +210,6 @@ lemma set_of_app_iff {p : α → Prop} {x : α} : { x | p x } x ↔ p x := iff.r
 
 theorem mem_def {a : α} {s : set α} : a ∈ s ↔ s a := iff.rfl
 
-/-- Note: `decidable_pred s` should be avoided in favor of `decidable_pred (∈ s)`, this instance
-acts as a compatibility layer. -/
-instance decidable_mem (s : set α) [H : decidable_pred s] : ∀ a, decidable (a ∈ s) := H
-
 instance decidable_set_of (p : α → Prop) [H : decidable_pred p] : decidable_pred (∈ {a | p a}) := H
 
 @[simp] theorem set_of_subset_set_of {p q : α → Prop} :


### PR DESCRIPTION
The only purpose of this instance was to enable the spelling `[decidable_pred s]` when what is actually needed is `decidable_pred (∈ s)`, which is a bad idea.

This is a follow-up to #8211.
Only two proofs needed this instance, and both were using completely the wrong lemmas anyway.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
