### PR TITLE
[Merged by Bors] - feat(analysis/special_functions): limit of (1+1/x)^x

### DIFF
--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -753,6 +753,44 @@ begin
     { exact neg_zero.symm } },
 end
 
+/-- The function `x * log (1 + t / x)` tends to `t` at `+∞`. -/
+lemma tendsto_mul_log_one_plus_div_at_top (t : ℝ) :
+  tendsto (λ x, x * log (1 + t / x)) at_top (𝓝 t) :=
+begin
+  rcases eq_or_ne t 0 with rfl | ht,
+  { simpa using tendsto_const_nhds },
+  suffices h : tendsto (λ x, real.log (1 + t * x) / x) (𝓝[{0}ᶜ] 0) (𝓝 t),
+  { apply (h.comp (tendsto_inv_at_top_zero'.mono_right _)).congr' _,
+    { refine eventually_at_top.2 ⟨1, λ x hx, _⟩,
+      dsimp,
+      have : x ≠ 0 := ne_of_gt (lt_of_lt_of_le zero_lt_one hx),
+      rw [←div_eq_mul_inv, div_eq_mul_inv, inv_inv', mul_comm] },
+    refine inf_le_inf_left _ _,
+    rw principal_mono,
+    intros x,
+    apply ne_of_gt },
+  suffices h : tendsto (λ x, real.log (1 + x) / x) (𝓝[{0}ᶜ] 0) (𝓝 1),
+  { have : tendsto (λ (x : ℝ), real.log (1 + t * x) / (t * x)) (𝓝[{0}ᶜ] 0) (𝓝 1),
+    { apply h.comp (tendsto.inf (by simpa using (continuous_mul_left t).tendsto 0) _),
+      simp [ht, not_or_distrib] },
+    replace := filter.tendsto.mul_const t this,
+    simp_rw [one_mul, div_mul_eq_mul_div, mul_comm _ t, mul_div_mul_left _ _ ht] at this,
+    exact this },
+  suffices h : tendsto (λ x, (real.log (1 + x) - x) / x) (𝓝[{0}ᶜ] 0) (𝓝 0),
+  { simp_rw [sub_div] at h,
+    have : tendsto (λ (x : ℝ), real.log (1 + x) / x - 1) (𝓝[{0}ᶜ] 0) (𝓝 0),
+    { apply h.congr' (eventually_inf_principal.2 _),
+      rw _root_.eventually_nhds_iff,
+      exact ⟨set.univ, λ x _ (hx : x ≠ 0), by simp [div_self hx], is_open_univ, ⟨⟩⟩ },
+    simpa using this.add_const 1 },
+  apply asymptotics.is_o.tendsto_0,
+  have : has_deriv_at real.log 1 1,
+    by simpa using real.has_deriv_at_log (show (1 : ℝ) ≠ 0, by norm_num),
+  rw has_deriv_at_iff_is_o_nhds_zero at this,
+  simp only [mul_one, algebra.id.smul_eq_mul, real.log_one, sub_zero] at this,
+  apply this.mono inf_le_left,
+end
+
 open_locale big_operators
 
 /-- A crude lemma estimating the difference between `log (1-x)` and its Taylor series at `0`,

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -757,38 +757,14 @@ end
 lemma tendsto_mul_log_one_plus_div_at_top (t : ℝ) :
   tendsto (λ x, x * log (1 + t / x)) at_top (𝓝 t) :=
 begin
-  rcases eq_or_ne t 0 with rfl | ht,
-  { simpa using tendsto_const_nhds },
-  suffices h : tendsto (λ x, real.log (1 + t * x) / x) (𝓝[{0}ᶜ] 0) (𝓝 t),
-  { apply (h.comp (tendsto_inv_at_top_zero'.mono_right _)).congr' _,
-    { refine eventually_at_top.2 ⟨1, λ x hx, _⟩,
-      dsimp,
-      have : x ≠ 0 := ne_of_gt (lt_of_lt_of_le zero_lt_one hx),
-      rw [←div_eq_mul_inv, div_eq_mul_inv, inv_inv', mul_comm] },
-    refine inf_le_inf_left _ _,
-    rw principal_mono,
-    intros x,
-    apply ne_of_gt },
-  suffices h : tendsto (λ x, real.log (1 + x) / x) (𝓝[{0}ᶜ] 0) (𝓝 1),
-  { have : tendsto (λ (x : ℝ), real.log (1 + t * x) / (t * x)) (𝓝[{0}ᶜ] 0) (𝓝 1),
-    { apply h.comp (tendsto.inf (by simpa using (continuous_mul_left t).tendsto 0) _),
-      simp [ht, not_or_distrib] },
-    replace := filter.tendsto.mul_const t this,
-    simp_rw [one_mul, div_mul_eq_mul_div, mul_comm _ t, mul_div_mul_left _ _ ht] at this,
-    exact this },
-  suffices h : tendsto (λ x, (real.log (1 + x) - x) / x) (𝓝[{0}ᶜ] 0) (𝓝 0),
-  { simp_rw [sub_div] at h,
-    have : tendsto (λ (x : ℝ), real.log (1 + x) / x - 1) (𝓝[{0}ᶜ] 0) (𝓝 0),
-    { apply h.congr' (eventually_inf_principal.2 _),
-      rw _root_.eventually_nhds_iff,
-      exact ⟨set.univ, λ x _ (hx : x ≠ 0), by simp [div_self hx], is_open_univ, ⟨⟩⟩ },
-    simpa using this.add_const 1 },
-  apply asymptotics.is_o.tendsto_0,
-  have : has_deriv_at real.log 1 1,
-    by simpa using real.has_deriv_at_log (show (1 : ℝ) ≠ 0, by norm_num),
-  rw has_deriv_at_iff_is_o_nhds_zero at this,
-  simp only [mul_one, algebra.id.smul_eq_mul, real.log_one, sub_zero] at this,
-  apply this.mono inf_le_left,
+  have h₁ : tendsto (λ h, h⁻¹ * log (1 + t * h)) (𝓝[{0}ᶜ] 0) (𝓝 t),
+  { simpa [has_deriv_at_iff_tendsto_slope] using
+      ((has_deriv_at_const _ 1).add ((has_deriv_at_id 0).const_mul t)).log (by simp) },
+  have h₂ : tendsto (λ x : ℝ, x⁻¹) at_top (𝓝[{0}ᶜ] 0) :=
+    tendsto_inv_at_top_zero'.mono_right (nhds_within_mono _ (λ x hx, (set.mem_Ioi.mp hx).ne')),
+  convert h₁.comp h₂,
+  ext,
+  field_simp [mul_comm],
 end
 
 open_locale big_operators

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -991,6 +991,28 @@ by { convert tendsto_rpow_div_mul_add (1:ℝ) _ (0:ℝ) zero_ne_one, ring_nf }
 lemma tendsto_rpow_neg_div : tendsto (λ x, x ^ (-(1:ℝ) / x)) at_top (𝓝 1) :=
 by { convert tendsto_rpow_div_mul_add (-(1:ℝ)) _ (0:ℝ) zero_ne_one, ring_nf }
 
+/-- The function `(1 + t/x) ^ x` tends to `exp t` at `+∞`. -/
+lemma tendsto_one_plus_div_rpow_tendsto_exp (t : ℝ) :
+  tendsto (λ (x : ℝ), (1 + t / x) ^ x) at_top (𝓝 (exp t)) :=
+begin
+  apply ((real.continuous_exp.tendsto _).comp (tendsto_mul_log_one_plus_div_at_top t)).congr' _,
+  refine eventually_at_top.2 ⟨max 1 (1 - t), λ x hx, _⟩,
+  have : 0 < x := zero_lt_one.trans_le ((le_max_left _ _).trans hx),
+  have : x ≠ 0 := ‹0 < x›.ne',
+  have : 0 < 1 + t / x,
+  { rw [add_div' _ _ _ ‹x ≠ 0›, one_mul],
+    apply div_pos _ ‹0 < x›,
+    linarith [(le_max_right _ _).trans hx]},
+  dsimp only [function.comp_apply],
+  rw [←real.log_rpow ‹0 < 1 + t / x›, real.exp_log],
+  apply real.rpow_pos_of_pos ‹0 < 1 + t / x›,
+end
+
+/-- The function `(1 + t/x) ^ x` tends to `exp t` at `+∞` for naturals `x`. -/
+lemma tendsto_one_plus_div_pow_tendsto_e (t : ℝ) :
+  tendsto (λ (x : ℕ), (1 + t / (x:ℝ)) ^ x) at_top (𝓝 (real.exp t)) :=
+((tendsto_one_plus_div_rpow_tendsto_exp t).comp tendsto_coe_nat_at_top_at_top).congr (by simp)
+
 end limits
 
 namespace nnreal

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -992,7 +992,7 @@ lemma tendsto_rpow_neg_div : tendsto (λ x, x ^ (-(1:ℝ) / x)) at_top (𝓝 1) 
 by { convert tendsto_rpow_div_mul_add (-(1:ℝ)) _ (0:ℝ) zero_ne_one, ring_nf }
 
 /-- The function `(1 + t/x) ^ x` tends to `exp t` at `+∞`. -/
-lemma tendsto_one_plus_div_rpow_tendsto_exp (t : ℝ) :
+lemma tendsto_one_plus_div_rpow_exp (t : ℝ) :
   tendsto (λ (x : ℝ), (1 + t / x) ^ x) at_top (𝓝 (exp t)) :=
 begin
   apply ((real.continuous_exp.tendsto _).comp (tendsto_mul_log_one_plus_div_at_top t)).congr' _,
@@ -1005,7 +1005,7 @@ begin
 end
 
 /-- The function `(1 + t/x) ^ x` tends to `exp t` at `+∞` for naturals `x`. -/
-lemma tendsto_one_plus_div_pow_tendsto_e (t : ℝ) :
+lemma tendsto_one_plus_div_pow_e (t : ℝ) :
   tendsto (λ (x : ℕ), (1 + t / (x:ℝ)) ^ x) at_top (𝓝 (real.exp t)) :=
 ((tendsto_one_plus_div_rpow_tendsto_exp t).comp tendsto_coe_nat_at_top_at_top).congr (by simp)
 

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -997,7 +997,7 @@ lemma tendsto_one_plus_div_rpow_exp (t : ℝ) :
 begin
   apply ((real.continuous_exp.tendsto _).comp (tendsto_mul_log_one_plus_div_at_top t)).congr' _,
   have h₁ : (1:ℝ)/2 < 1 := by linarith,
-  have h₂ : tendsto (λ x : ℝ, 1 + t / x) at_top (𝓝 1) := 
+  have h₂ : tendsto (λ x : ℝ, 1 + t / x) at_top (𝓝 1) :=
     by simpa using (tendsto_inv_at_top_zero.const_mul t).const_add 1,
   refine (eventually_ge_of_tendsto_gt h₁ h₂).mono (λ x hx, _),
   have hx' : 0 < 1 + t / x := by linarith,
@@ -1005,9 +1005,9 @@ begin
 end
 
 /-- The function `(1 + t/x) ^ x` tends to `exp t` at `+∞` for naturals `x`. -/
-lemma tendsto_one_plus_div_pow_e (t : ℝ) :
+lemma tendsto_one_plus_div_pow_exp (t : ℝ) :
   tendsto (λ (x : ℕ), (1 + t / (x:ℝ)) ^ x) at_top (𝓝 (real.exp t)) :=
-((tendsto_one_plus_div_rpow_tendsto_exp t).comp tendsto_coe_nat_at_top_at_top).congr (by simp)
+((tendsto_one_plus_div_rpow_exp t).comp tendsto_coe_nat_at_top_at_top).congr (by simp)
 
 end limits
 

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -996,16 +996,12 @@ lemma tendsto_one_plus_div_rpow_tendsto_exp (t : ℝ) :
   tendsto (λ (x : ℝ), (1 + t / x) ^ x) at_top (𝓝 (exp t)) :=
 begin
   apply ((real.continuous_exp.tendsto _).comp (tendsto_mul_log_one_plus_div_at_top t)).congr' _,
-  refine eventually_at_top.2 ⟨max 1 (1 - t), λ x hx, _⟩,
-  have : 0 < x := zero_lt_one.trans_le ((le_max_left _ _).trans hx),
-  have : x ≠ 0 := ‹0 < x›.ne',
-  have : 0 < 1 + t / x,
-  { rw [add_div' _ _ _ ‹x ≠ 0›, one_mul],
-    apply div_pos _ ‹0 < x›,
-    linarith [(le_max_right _ _).trans hx]},
-  dsimp only [function.comp_apply],
-  rw [←real.log_rpow ‹0 < 1 + t / x›, real.exp_log],
-  apply real.rpow_pos_of_pos ‹0 < 1 + t / x›,
+  have h₁ : (1:ℝ)/2 < 1 := by linarith,
+  have h₂ : tendsto (λ x : ℝ, 1 + t / x) at_top (𝓝 1) := 
+    by simpa using (tendsto_inv_at_top_zero.const_mul t).const_add 1,
+  refine (eventually_ge_of_tendsto_gt h₁ h₂).mono (λ x hx, _),
+  have hx' : 0 < 1 + t / x := by linarith,
+  simp [mul_comm x, exp_mul, exp_log hx'],
 end
 
 /-- The function `(1 + t/x) ^ x` tends to `exp t` at `+∞` for naturals `x`. -/


### PR DESCRIPTION
Resolves https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/e.20as.20limit.20of.20.281.2B1.2Fn.29.5En. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
