### PR TITLE
[Merged by Bors] - feat(algebra/opposites): functoriality of the opposite monoid

### DIFF
--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -375,8 +375,8 @@ def monoid_hom.op {α β} [mul_one_class α] [mul_one_class β] :
   left_inv  := λ f, by { ext, simp },
   right_inv := λ f, by { ext, simp } }
 
-@[simp]
-def monoid_hom.unop {α β} [mul_one_class α] [mul_one_class β] :
+/-- The 'unopposite' of a monoid hom `αᵒᵖ →* βᵒᵖ`. Inverse to `monoid_hom.op`. -/
+@[simp] def monoid_hom.unop {α β} [mul_one_class α] [mul_one_class β] :
   (αᵒᵖ →* βᵒᵖ) ≃ (α →* β) := monoid_hom.op.symm
 
 /-- A ring hom `α →+* β` can equivalently be viewed as a ring hom `αᵒᵖ →+* βᵒᵖ`. This is the action
@@ -389,6 +389,6 @@ def ring_hom.op {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
   left_inv  := λ f, by { ext, simp },
   right_inv := λ f, by { ext, simp } }
 
-@[simp]
-def ring_hom.unop {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
+/-- The 'unopposite' of a ring hom `αᵒᵖ →+* βᵒᵖ`. Inverse to `ring_hom.op`. -/
+@[simp] def ring_hom.unop {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
   (αᵒᵖ →+* βᵒᵖ) ≃ (α →+* β) := ring_hom.op.symm

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -364,3 +364,11 @@ rfl
 lemma units.coe_op_equiv_symm {R} [monoid R] (u : (units R)ᵒᵖ) :
   (units.op_equiv.symm u : Rᵒᵖ) = op (u.unop : R) :=
 rfl
+
+/-- A hom `α →* β` can equivalently be viewed as a hom `αᵒᵖ →* βᵒᵖ`. This is the action
+of the `ᵒᵖ`-functor on morphisms. -/
+@[simps]
+def monoid_hom.op {α β} [monoid α] [monoid β] (f : α →* β) : αᵒᵖ →* βᵒᵖ :=
+{ to_fun := op ∘ f ∘ unop,
+  map_one' := by simp only [unop_one, function.comp_app, op_one, monoid_hom.map_one],
+  map_mul' := λ x y, by simp only [monoid_hom.map_mul, function.comp_app, op_mul, unop_mul] }

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -365,66 +365,23 @@ lemma units.coe_op_equiv_symm {R} [monoid R] (u : (units R)ᵒᵖ) :
   (units.op_equiv.symm u : Rᵒᵖ) = op (u.unop : R) :=
 rfl
 
-namespace monoid_hom
-
-variables {α β : Type*} [mul_one_class α] [mul_one_class β]
-
-/-- A hom `α →* β` viewed as a hom `αᵒᵖ →* βᵒᵖ`. This is the action of the `ᵒᵖ`-functor
-on morphisms. -/
+/-- A hom `α →* β` can equivalently be viewed as a hom `αᵒᵖ →* βᵒᵖ`. This is the action of the
+(fully faithful) `ᵒᵖ`-functor on morphisms. -/
 @[simps]
-def op (f : α →* β) : αᵒᵖ →* βᵒᵖ :=
-{ to_fun := opposite.op ∘ f ∘ opposite.unop,
-  map_one' := by simp only [unop_one, function.comp_app, op_one, map_one],
-  map_mul' := λ x y, by simp only [map_mul, function.comp_app, op_mul, unop_mul] }
+def monoid_hom.op {α β} [mul_one_class α] [mul_one_class β] :
+  (α →* β) ≃ (αᵒᵖ →* βᵒᵖ) :=
+{ to_fun    := λ f, { to_fun := op ∘ f ∘ unop, map_one' := by simp, map_mul' := λ x y, by simp },
+  inv_fun   := λ f, { to_fun := unop ∘ f ∘ op, map_one' := by simp, map_mul' := λ x y, by simp },
+  left_inv  := λ f, by { ext, simp },
+  right_inv := λ f, by { ext, simp } }
 
-/-- A hom `αᵒᵖ →* βᵒᵖ` viewed as a hom `α →* β`. -/
+/-- A ring hom `α →+* β` can equivalently be viewed as a ring hom `αᵒᵖ →+* βᵒᵖ`. This is the action
+of the (fully faithful) `ᵒᵖ`-functor on morphisms. -/
 @[simps]
-def unop (f : αᵒᵖ →* βᵒᵖ) : α →* β :=
-{ to_fun := opposite.unop ∘ f ∘ opposite.op,
-  map_one' := by simp only [unop_one, function.comp_app, op_one, map_one],
-  map_mul' := λ x y, by simp only [map_mul, function.comp_app, op_mul, unop_mul] }
-
-/-- A hom `α →* β` can equivalently be viewed as a hom `αᵒᵖ →* βᵒᵖ`. This expresses that the
-`op`-functor is fully faithful. -/
-@[simps]
-def hom_equiv_op_hom_op : (α →* β) ≃ (αᵒᵖ →* βᵒᵖ) :=
-{ to_fun := op,
-  inv_fun := unop,
-  left_inv := λ f, by { ext, simp only [unop_op, function.comp_app, unop_apply, op_apply] },
-  right_inv := λ f, by { ext, simp only [op_unop, function.comp_app, unop_apply, op_apply] } }
-
-end monoid_hom
-
-namespace ring_hom
-
-variables {α β : Type*} [non_assoc_semiring α] [non_assoc_semiring β]
-
-/-- A ring hom `α →+* β` viewed as a ring hom `αᵒᵖ →+* βᵒᵖ`. This is the action of the `ᵒᵖ`-functor
-on morphisms. -/
-@[simps]
-def op (f : α →+* β) : αᵒᵖ →+* βᵒᵖ :=
-{ to_fun := opposite.op ∘ f ∘ opposite.unop,
-  map_one' := by simp only [unop_one, function.comp_app, map_one, op_one],
-  map_mul' := λ x y, by simp only [unop_mul, op_mul, function.comp_app, map_mul],
-  map_zero' := by simp only [unop_zero, function.comp_app, map_zero, op_zero],
-  map_add' := λ x y, by simp only [map_add, function.comp_app, unop_add, op_add] }
-
-/-- A ring hom `αᵒᵖ →+* βᵒᵖ` viewed as a ring hom `α →+* β`. -/
-@[simps]
-def unop (f : αᵒᵖ →+* βᵒᵖ) : α →+* β :=
-{ to_fun := opposite.unop ∘ f ∘ opposite.op,
-  map_one' := by simp only [unop_one, function.comp_app, map_one, op_one],
-  map_mul' := λ x y, by simp only [unop_mul, op_mul, function.comp_app, map_mul],
-  map_zero' := by simp only [unop_zero, function.comp_app, map_zero, op_zero],
-  map_add' := λ x y, by simp only [map_add, function.comp_app, unop_add, op_add] }
-
-/-- A ring hom `α →+* β` can equivalently be viewed as a ring hom `αᵒᵖ →+* βᵒᵖ`. This expresses that
-the `op`-functor is fully faithful. -/
-@[simps]
-def hom_equiv_op_hom_op : (α →+* β) ≃ (αᵒᵖ →+* βᵒᵖ) :=
-{ to_fun := op,
-  inv_fun := unop,
-  left_inv := λ f, by { ext, simp only [unop_op, function.comp_app, unop_apply, op_apply] },
-  right_inv := λ f, by { ext, simp only [op_unop, function.comp_app, unop_apply, op_apply] } }
-
-end ring_hom
+def ring_hom.op {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
+  (α →+* β) ≃ (αᵒᵖ →+* βᵒᵖ) :=
+{ to_fun    := λ f, { map_zero' := by simp, map_add' := by simp, ..f.to_monoid_hom.op },
+  inv_fun   := λ f, { map_zero' := by simp, map_add' := by simp,
+    ..(monoid_hom.op.symm f.to_monoid_hom) },
+  left_inv  := λ f, by { ext, simp },
+  right_inv := λ f, by {ext, simp } }

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -370,24 +370,46 @@ rfl
 @[simps]
 def monoid_hom.op {α β} [mul_one_class α] [mul_one_class β] :
   (α →* β) ≃ (αᵒᵖ →* βᵒᵖ) :=
-{ to_fun    := λ f, { to_fun := op ∘ f ∘ unop, map_one' := by simp, map_mul' := λ x y, by simp },
-  inv_fun   := λ f, { to_fun := unop ∘ f ∘ op, map_one' := by simp, map_mul' := λ x y, by simp },
-  left_inv  := λ f, by { ext, simp },
-  right_inv := λ f, by { ext, simp } }
+{ to_fun    := λ f, { to_fun   := op ∘ f ∘ unop,
+                      map_one' := unop_injective f.map_one,
+                      map_mul' := λ x y, unop_injective (f.map_mul y.unop x.unop) },
+  inv_fun   := λ f, { to_fun   := unop ∘ f ∘ op,
+                      map_one' := congr_arg unop f.map_one,
+                      map_mul' := λ x y, congr_arg unop (f.map_mul (op y) (op x)) },
+  left_inv  := λ f, by { ext, refl },
+  right_inv := λ f, by { ext, refl } }
 
 /-- The 'unopposite' of a monoid hom `αᵒᵖ →* βᵒᵖ`. Inverse to `monoid_hom.op`. -/
 @[simp] def monoid_hom.unop {α β} [mul_one_class α] [mul_one_class β] :
   (αᵒᵖ →* βᵒᵖ) ≃ (α →* β) := monoid_hom.op.symm
+
+/-- A hom `α →+ β` can equivalently be viewed as a hom `αᵒᵖ →+ βᵒᵖ`. This is the action of the
+(fully faithful) `ᵒᵖ`-functor on morphisms. -/
+@[simps]
+def add_monoid_hom.op {α β} [add_zero_class α] [add_zero_class β] :
+  (α →+ β) ≃ (αᵒᵖ →+ βᵒᵖ) :=
+{ to_fun    := λ f, { to_fun    := op ∘ f ∘ unop,
+                      map_zero' := unop_injective f.map_zero,
+                      map_add'  := λ x y, unop_injective (f.map_add x.unop y.unop) },
+  inv_fun   := λ f, { to_fun    := unop ∘ f ∘ op,
+                      map_zero' := congr_arg unop f.map_zero,
+                      map_add'  := λ x y, congr_arg unop (f.map_add (op x) (op y)) },
+  left_inv  := λ f, by { ext, refl },
+  right_inv := λ f, by { ext, refl } }
+
+/-- The 'unopposite' of an additive monoid hom `αᵒᵖ →+ βᵒᵖ`. Inverse to `add_monoid_hom.op`. -/
+@[simp] def add_monoid_hom.unop {α β} [add_zero_class α] [add_zero_class β] :
+  (αᵒᵖ →+ βᵒᵖ) ≃ (α →+ β) := add_monoid_hom.op.symm
 
 /-- A ring hom `α →+* β` can equivalently be viewed as a ring hom `αᵒᵖ →+* βᵒᵖ`. This is the action
 of the (fully faithful) `ᵒᵖ`-functor on morphisms. -/
 @[simps]
 def ring_hom.op {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
   (α →+* β) ≃ (αᵒᵖ →+* βᵒᵖ) :=
-{ to_fun    := λ f, { map_zero' := by simp, map_add' := by simp, ..f.to_monoid_hom.op },
-  inv_fun   := λ f, { map_zero' := by simp, map_add' := by simp, ..f.to_monoid_hom.unop },
-  left_inv  := λ f, by { ext, simp },
-  right_inv := λ f, by { ext, simp } }
+{ to_fun    := λ f, { ..f.to_add_monoid_hom.op, ..f.to_monoid_hom.op },
+  inv_fun   := λ f, { ..f.to_add_monoid_hom.unop, ..f.to_monoid_hom.unop },
+  left_inv  := λ f, by { ext, refl },
+  right_inv := λ f, by { ext, refl } }
 
 /-- The 'unopposite' of a ring hom `αᵒᵖ →+* βᵒᵖ`. Inverse to `ring_hom.op`. -/
 @[simp] def ring_hom.unop {α β} [non_assoc_semiring α] [non_assoc_semiring β] :

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -375,13 +375,20 @@ def monoid_hom.op {α β} [mul_one_class α] [mul_one_class β] :
   left_inv  := λ f, by { ext, simp },
   right_inv := λ f, by { ext, simp } }
 
+@[simp]
+def monoid_hom.unop {α β} [mul_one_class α] [mul_one_class β] :
+  (αᵒᵖ →* βᵒᵖ) ≃ (α →* β) := monoid_hom.op.symm
+
 /-- A ring hom `α →+* β` can equivalently be viewed as a ring hom `αᵒᵖ →+* βᵒᵖ`. This is the action
 of the (fully faithful) `ᵒᵖ`-functor on morphisms. -/
 @[simps]
 def ring_hom.op {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
   (α →+* β) ≃ (αᵒᵖ →+* βᵒᵖ) :=
 { to_fun    := λ f, { map_zero' := by simp, map_add' := by simp, ..f.to_monoid_hom.op },
-  inv_fun   := λ f, { map_zero' := by simp, map_add' := by simp,
-    ..(monoid_hom.op.symm f.to_monoid_hom) },
+  inv_fun   := λ f, { map_zero' := by simp, map_add' := by simp, ..f.to_monoid_hom.unop },
   left_inv  := λ f, by { ext, simp },
-  right_inv := λ f, by {ext, simp } }
+  right_inv := λ f, by { ext, simp } }
+
+@[simp]
+def ring_hom.unop {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
+  (αᵒᵖ →+* βᵒᵖ) ≃ (α →+* β) := ring_hom.op.symm

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -365,10 +365,66 @@ lemma units.coe_op_equiv_symm {R} [monoid R] (u : (units R)ᵒᵖ) :
   (units.op_equiv.symm u : Rᵒᵖ) = op (u.unop : R) :=
 rfl
 
-/-- A hom `α →* β` can equivalently be viewed as a hom `αᵒᵖ →* βᵒᵖ`. This is the action
-of the `ᵒᵖ`-functor on morphisms. -/
+namespace monoid_hom
+
+variables {α β : Type*} [mul_one_class α] [mul_one_class β]
+
+/-- A hom `α →* β` viewed as a hom `αᵒᵖ →* βᵒᵖ`. This is the action of the `ᵒᵖ`-functor
+on morphisms. -/
 @[simps]
-def monoid_hom.op {α β} [monoid α] [monoid β] (f : α →* β) : αᵒᵖ →* βᵒᵖ :=
-{ to_fun := op ∘ f ∘ unop,
-  map_one' := by simp only [unop_one, function.comp_app, op_one, monoid_hom.map_one],
-  map_mul' := λ x y, by simp only [monoid_hom.map_mul, function.comp_app, op_mul, unop_mul] }
+def op (f : α →* β) : αᵒᵖ →* βᵒᵖ :=
+{ to_fun := opposite.op ∘ f ∘ opposite.unop,
+  map_one' := by simp only [unop_one, function.comp_app, op_one, map_one],
+  map_mul' := λ x y, by simp only [map_mul, function.comp_app, op_mul, unop_mul] }
+
+/-- A hom `αᵒᵖ →* βᵒᵖ` viewed as a hom `α →* β`. -/
+@[simps]
+def unop (f : αᵒᵖ →* βᵒᵖ) : α →* β :=
+{ to_fun := opposite.unop ∘ f ∘ opposite.op,
+  map_one' := by simp only [unop_one, function.comp_app, op_one, map_one],
+  map_mul' := λ x y, by simp only [map_mul, function.comp_app, op_mul, unop_mul] }
+
+/-- A hom `α →* β` can equivalently be viewed as a hom `αᵒᵖ →* βᵒᵖ`. This expresses that the
+`op`-functor is fully faithful. -/
+@[simps]
+def hom_equiv_op_hom_op : (α →* β) ≃ (αᵒᵖ →* βᵒᵖ) :=
+{ to_fun := op,
+  inv_fun := unop,
+  left_inv := λ f, by { ext, simp only [unop_op, function.comp_app, unop_apply, op_apply] },
+  right_inv := λ f, by { ext, simp only [op_unop, function.comp_app, unop_apply, op_apply] } }
+
+end monoid_hom
+
+namespace ring_hom
+
+variables {α β : Type*} [non_assoc_semiring α] [non_assoc_semiring β]
+
+/-- A ring hom `α →+* β` viewed as a ring hom `αᵒᵖ →+* βᵒᵖ`. This is the action of the `ᵒᵖ`-functor
+on morphisms. -/
+@[simps]
+def op (f : α →+* β) : αᵒᵖ →+* βᵒᵖ :=
+{ to_fun := opposite.op ∘ f ∘ opposite.unop,
+  map_one' := by simp only [unop_one, function.comp_app, map_one, op_one],
+  map_mul' := λ x y, by simp only [unop_mul, op_mul, function.comp_app, map_mul],
+  map_zero' := by simp only [unop_zero, function.comp_app, map_zero, op_zero],
+  map_add' := λ x y, by simp only [map_add, function.comp_app, unop_add, op_add] }
+
+/-- A ring hom `αᵒᵖ →+* βᵒᵖ` viewed as a ring hom `α →+* β`. -/
+@[simps]
+def unop (f : αᵒᵖ →+* βᵒᵖ) : α →+* β :=
+{ to_fun := opposite.unop ∘ f ∘ opposite.op,
+  map_one' := by simp only [unop_one, function.comp_app, map_one, op_one],
+  map_mul' := λ x y, by simp only [unop_mul, op_mul, function.comp_app, map_mul],
+  map_zero' := by simp only [unop_zero, function.comp_app, map_zero, op_zero],
+  map_add' := λ x y, by simp only [map_add, function.comp_app, unop_add, op_add] }
+
+/-- A ring hom `α →+* β` can equivalently be viewed as a ring hom `αᵒᵖ →+* βᵒᵖ`. This expresses that
+the `op`-functor is fully faithful. -/
+@[simps]
+def hom_equiv_op_hom_op : (α →+* β) ≃ (αᵒᵖ →+* βᵒᵖ) :=
+{ to_fun := op,
+  inv_fun := unop,
+  left_inv := λ f, by { ext, simp only [unop_op, function.comp_app, unop_apply, op_apply] },
+  right_inv := λ f, by { ext, simp only [op_unop, function.comp_app, unop_apply, op_apply] } }
+
+end ring_hom


### PR DESCRIPTION
A hom `α →* β` can equivalently be viewed as a hom `αᵒᵖ →* βᵒᵖ`.

Split off from #7395 

---
I'm surprised this doesn't seem to exist yet? There is lots of this stuff for category theory (`category_theory.functor.op` etc).
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
