### PR TITLE
[Merged by Bors] - feat(data/equiv/fin): fin_order_iso_subtype

### DIFF
--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -309,19 +309,13 @@ def fin_prod_fin_equiv : fin m × fin n ≃ fin (m * n) :=
 
 /-- Promote a `fin n` into a larger `fin m`, as a subtype where the underlying
 values are retained. This is the `order_iso` version of `fin.cast_le`. -/
+@[simps apply symm_apply]
 def fin.cast_le_order_iso {n m : ℕ} (h : n ≤ m) : fin n ≃o {i : fin m // (i : ℕ) < n} :=
 { to_fun := λ i, ⟨fin.cast_le h i, by simpa using i.is_lt⟩,
   inv_fun := λ i, ⟨i, i.prop⟩,
   left_inv := λ _, by simp,
   right_inv := λ _, by simp,
   map_rel_iff' := λ _ _, by simp }
-
-@[simp] lemma fin.cast_le_order_iso_apply {n m : ℕ} (h : n ≤ m) (i : fin n) :
-  fin.cast_le_order_iso h i = ⟨⟨i, i.is_lt.trans_le h⟩, i.is_lt⟩ := rfl
-
-@[simp] lemma fin.cast_le_order_iso_symm_apply {n m : ℕ} (h : n ≤ m)
-  (i : subtype (λ (i : fin m), (i : ℕ) < n)) :
-  (fin.cast_le_order_iso h).symm i = ⟨i, i.prop⟩ := rfl
 
 /-- `fin 0` is a subsingleton. -/
 instance subsingleton_fin_zero : subsingleton (fin 0) :=

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -309,7 +309,7 @@ def fin_prod_fin_equiv : fin m × fin n ≃ fin (m * n) :=
 
 /- Promote a `fin n` into a larger `fin m`, as a subtype where the underlying
 values are retained. This is the `order_iso` version of `fin.cast_le`. -/
-def fin_order_iso_subtype {n m : ℕ} (h : n ≤ m) : fin n ≃o subtype (λ (i : fin m), (i : ℕ) < n) :=
+def fin_order_iso_subtype {n m : ℕ} (h : n ≤ m) : fin n ≃o {i : fin m // (i : ℕ) < n} :=
 { to_fun := λ i, ⟨fin.cast_le h i, by simpa using i.is_lt⟩,
   inv_fun := λ i, ⟨i, i.prop⟩,
   left_inv := λ _, by simp,

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -309,19 +309,19 @@ def fin_prod_fin_equiv : fin m × fin n ≃ fin (m * n) :=
 
 /- Promote a `fin n` into a larger `fin m`, as a subtype where the underlying
 values are retained. This is the `order_iso` version of `fin.cast_le`. -/
-def fin_order_iso_subtype {n m : ℕ} (h : n ≤ m) : fin n ≃o {i : fin m // (i : ℕ) < n} :=
+def fin.cast_le_order_iso {n m : ℕ} (h : n ≤ m) : fin n ≃o {i : fin m // (i : ℕ) < n} :=
 { to_fun := λ i, ⟨fin.cast_le h i, by simpa using i.is_lt⟩,
   inv_fun := λ i, ⟨i, i.prop⟩,
   left_inv := λ _, by simp,
   right_inv := λ _, by simp,
   map_rel_iff' := λ _ _, by simp }
 
-@[simp] lemma fin_order_iso_subtype_apply {n m : ℕ} (h : n ≤ m) (i : fin n) :
-  fin_order_iso_subtype h i = ⟨⟨i, i.is_lt.trans_le h⟩, i.is_lt⟩ := rfl
+@[simp] lemma fin.cast_le_order_iso_apply {n m : ℕ} (h : n ≤ m) (i : fin n) :
+  fin.cast_le_order_iso h i = ⟨⟨i, i.is_lt.trans_le h⟩, i.is_lt⟩ := rfl
 
-@[simp] lemma fin_order_iso_subtype_symm_apply {n m : ℕ} (h : n ≤ m)
+@[simp] lemma fin.cast_le_order_iso_symm_apply {n m : ℕ} (h : n ≤ m)
   (i : subtype (λ (i : fin m), (i : ℕ) < n)) :
-  (fin_order_iso_subtype h).symm i = ⟨i, i.prop⟩ := rfl
+  (fin.cast_le_order_iso h).symm i = ⟨i, i.prop⟩ := rfl
 
 /-- `fin 0` is a subsingleton. -/
 instance subsingleton_fin_zero : subsingleton (fin 0) :=

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -307,6 +307,22 @@ def fin_prod_fin_equiv : fin m × fin n ≃ fin (m * n) :=
         ... = y.1 : nat.mod_eq_of_lt y.2),
   right_inv := λ x, fin.eq_of_veq $ nat.mod_add_div _ _ }
 
+/- Promote a `fin n` into a larger `fin m`, as a subtype where the underlying
+values are retained. This is the `order_iso` version of `fin.cast_le`. -/
+def fin_order_iso_subtype {n m : ℕ} (h : n ≤ m) : fin n ≃o subtype (λ (i : fin m), (i : ℕ) < n) :=
+{ to_fun := λ i, ⟨fin.cast_le h i, by simpa using i.is_lt⟩,
+  inv_fun := λ i, ⟨i, i.prop⟩,
+  left_inv := λ _, by simp,
+  right_inv := λ _, by simp,
+  map_rel_iff' := λ _ _, by simp }
+
+@[simp] lemma fin_order_iso_subtype_apply {n m : ℕ} (h : n ≤ m) (i : fin n) :
+  fin_as_subtype h i = ⟨i, i.is_lt.trans_le h⟩ := rfl
+
+@[simp] lemma fin_order_iso_subtype_symm_apply {n m : ℕ} (h : n ≤ m)
+  (i : subtype (λ (i : fin m), (i : ℕ) < n)) :
+  (fin_as_subtype h).symm i = ⟨i, i.prop⟩ := rfl
+
 /-- `fin 0` is a subsingleton. -/
 instance subsingleton_fin_zero : subsingleton (fin 0) :=
 fin_zero_equiv.subsingleton

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -317,7 +317,7 @@ def fin_order_iso_subtype {n m : ℕ} (h : n ≤ m) : fin n ≃o subtype (λ (i 
   map_rel_iff' := λ _ _, by simp }
 
 @[simp] lemma fin_order_iso_subtype_apply {n m : ℕ} (h : n ≤ m) (i : fin n) :
-  fin_order_iso_subtype h i = ⟨i, i.is_lt.trans_le h⟩ := rfl
+  fin_order_iso_subtype h i = ⟨⟨i, i.is_lt.trans_le h⟩, i.is_lt⟩ := rfl
 
 @[simp] lemma fin_order_iso_subtype_symm_apply {n m : ℕ} (h : n ≤ m)
   (i : subtype (λ (i : fin m), (i : ℕ) < n)) :

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -317,11 +317,11 @@ def fin_order_iso_subtype {n m : ℕ} (h : n ≤ m) : fin n ≃o subtype (λ (i 
   map_rel_iff' := λ _ _, by simp }
 
 @[simp] lemma fin_order_iso_subtype_apply {n m : ℕ} (h : n ≤ m) (i : fin n) :
-  fin_as_subtype h i = ⟨i, i.is_lt.trans_le h⟩ := rfl
+  fin_order_iso_subtype h i = ⟨i, i.is_lt.trans_le h⟩ := rfl
 
 @[simp] lemma fin_order_iso_subtype_symm_apply {n m : ℕ} (h : n ≤ m)
   (i : subtype (λ (i : fin m), (i : ℕ) < n)) :
-  (fin_as_subtype h).symm i = ⟨i, i.prop⟩ := rfl
+  (fin_order_iso_subtype h).symm i = ⟨i, i.prop⟩ := rfl
 
 /-- `fin 0` is a subsingleton. -/
 instance subsingleton_fin_zero : subsingleton (fin 0) :=

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -307,7 +307,7 @@ def fin_prod_fin_equiv : fin m × fin n ≃ fin (m * n) :=
         ... = y.1 : nat.mod_eq_of_lt y.2),
   right_inv := λ x, fin.eq_of_veq $ nat.mod_add_div _ _ }
 
-/- Promote a `fin n` into a larger `fin m`, as a subtype where the underlying
+/-- Promote a `fin n` into a larger `fin m`, as a subtype where the underlying
 values are retained. This is the `order_iso` version of `fin.cast_le`. -/
 def fin.cast_le_order_iso {n m : ℕ} (h : n ≤ m) : fin n ≃o {i : fin m // (i : ℕ) < n} :=
 { to_fun := λ i, ⟨fin.cast_le h i, by simpa using i.is_lt⟩,

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -320,7 +320,7 @@ def fin.cast_le_order_iso {n m : ℕ} (h : n ≤ m) : fin n ≃o {i : fin m // (
   fin.cast_le_order_iso h i = ⟨⟨i, i.is_lt.trans_le h⟩, i.is_lt⟩ := rfl
 
 @[simp] lemma fin.cast_le_order_iso_symm_apply {n m : ℕ} (h : n ≤ m)
-  (i : subtype (λ (i : fin m), (i : ℕ) < n)) :
+  (i : {i : fin m // (i : ℕ) < n}) :
   (fin.cast_le_order_iso h).symm i = ⟨i, i.prop⟩ := rfl
 
 /-- `fin 0` is a subsingleton. -/


### PR DESCRIPTION
Promote a `fin n` into a larger `fin m`, as a subtype where the underlying
values are retained. This is the `order_iso` version of `fin.cast_le`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
