### PR TITLE
[Merged by Bors] - feat(algebra/group/hom): monoid_hom.injective_iff in iff form

### DIFF
--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -695,7 +695,9 @@ theorem map_mul_inv {G H} [group G] [group H] (f : G →* H) (g h : G) :
 
 /-- A homomorphism from a group to a monoid is injective iff its kernel is trivial.
 For the iff statement on the triviality of the kernel, see `monoid_hom.injective_iff'`.  -/
-@[to_additive]
+@[to_additive /- A homomorphism from an additive group to an additive monoid is injective iff
+its kernel is trivial. For the iff statement on the triviality of the kernel,
+see `add_monoid_hom.injective_iff'`. -/]
 lemma injective_iff {G H} [group G] [mul_one_class H] (f : G →* H) :
   function.injective f ↔ (∀ a, f a = 1 → a = 1) :=
 ⟨λ h x hfx, h $ hfx.trans f.map_one.symm,
@@ -704,7 +706,9 @@ lemma injective_iff {G H} [group G] [mul_one_class H] (f : G →* H) :
 /-- A homomorphism from a group to a monoid is injective iff its kernel is trivial,
 stated as an iff on the triviality of the kernel.
 For the implication, see `monoid_hom.injective_iff`. -/
-@[to_additive]
+@[to_additive /- A homomorphism from an additive group to an additive monoid is injective iff
+its kernel is trivial, stated as an iff on the triviality of the kernel. For the implication, see
+`add_monoid_hom.injective_iff`. -/]
 lemma injective_iff' {G H} [group G] [mul_one_class H] (f : G →* H) :
   function.injective f ↔ (∀ a, f a = 1 ↔ a = 1) :=
 f.injective_iff.trans $ forall_congr $ λ a, ⟨λ h, ⟨h, λ H, H.symm ▸ f.map_one⟩, iff.mp⟩

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -693,12 +693,24 @@ eq_inv_of_mul_eq_one $ f.map_mul_eq_one $ inv_mul_self g
 theorem map_mul_inv {G H} [group G] [group H] (f : G →* H) (g h : G) :
   f (g * h⁻¹) = (f g) * (f h)⁻¹ := by rw [f.map_mul, f.map_inv]
 
-/-- A homomorphism from a group to a monoid is injective iff its kernel is trivial. -/
+/-- A homomorphism from a group to a monoid is injective iff its kernel is trivial.
+For the iff statement on the triviality of the kernel, see `monoid_hom.injective_iff'`.  -/
 @[to_additive]
 lemma injective_iff {G H} [group G] [mul_one_class H] (f : G →* H) :
   function.injective f ↔ (∀ a, f a = 1 → a = 1) :=
 ⟨λ h x hfx, h $ hfx.trans f.map_one.symm,
  λ h x y hxy, mul_inv_eq_one.1 $ h _ $ by rw [f.map_mul, hxy, ← f.map_mul, mul_inv_self, f.map_one]⟩
+
+/-- A homomorphism from a group to a monoid is injective iff its kernel is trivial,
+stated as an iff on the triviality of the kernel.
+For the implication, see `monoid_hom.injective_iff`. -/
+@[to_additive]
+lemma injective_iff' {G H} [group G] [mul_one_class H] (f : G →* H) :
+  function.injective f ↔ (∀ a, f a = 1 ↔ a = 1) :=
+begin
+  rw f.injective_iff,
+  exact ⟨λ h a, ⟨h a, λ H, H.symm ▸ f.map_one⟩, λ h a, (h a).mp⟩
+end
 
 include mM
 /-- Makes a group homomorphism from a proof that the map preserves multiplication. -/

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -695,9 +695,9 @@ theorem map_mul_inv {G H} [group G] [group H] (f : G →* H) (g h : G) :
 
 /-- A homomorphism from a group to a monoid is injective iff its kernel is trivial.
 For the iff statement on the triviality of the kernel, see `monoid_hom.injective_iff'`.  -/
-@[to_additive /- A homomorphism from an additive group to an additive monoid is injective iff
+@[to_additive /-" A homomorphism from an additive group to an additive monoid is injective iff
 its kernel is trivial. For the iff statement on the triviality of the kernel,
-see `add_monoid_hom.injective_iff'`. -/]
+see `add_monoid_hom.injective_iff'`. "-/]
 lemma injective_iff {G H} [group G] [mul_one_class H] (f : G →* H) :
   function.injective f ↔ (∀ a, f a = 1 → a = 1) :=
 ⟨λ h x hfx, h $ hfx.trans f.map_one.symm,
@@ -706,9 +706,9 @@ lemma injective_iff {G H} [group G] [mul_one_class H] (f : G →* H) :
 /-- A homomorphism from a group to a monoid is injective iff its kernel is trivial,
 stated as an iff on the triviality of the kernel.
 For the implication, see `monoid_hom.injective_iff`. -/
-@[to_additive /- A homomorphism from an additive group to an additive monoid is injective iff
+@[to_additive /-" A homomorphism from an additive group to an additive monoid is injective iff
 its kernel is trivial, stated as an iff on the triviality of the kernel. For the implication, see
-`add_monoid_hom.injective_iff`. -/]
+`add_monoid_hom.injective_iff`. "-/]
 lemma injective_iff' {G H} [group G] [mul_one_class H] (f : G →* H) :
   function.injective f ↔ (∀ a, f a = 1 ↔ a = 1) :=
 f.injective_iff.trans $ forall_congr $ λ a, ⟨λ h, ⟨h, λ H, H.symm ▸ f.map_one⟩, iff.mp⟩

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -707,10 +707,7 @@ For the implication, see `monoid_hom.injective_iff`. -/
 @[to_additive]
 lemma injective_iff' {G H} [group G] [mul_one_class H] (f : G →* H) :
   function.injective f ↔ (∀ a, f a = 1 ↔ a = 1) :=
-begin
-  rw f.injective_iff,
-  exact ⟨λ h a, ⟨h a, λ H, H.symm ▸ f.map_one⟩, λ h a, (h a).mp⟩
-end
+f.injective_iff.trans $ forall_congr $ λ a, ⟨λ h, ⟨h, λ H, H.symm ▸ f.map_one⟩, iff.mp⟩
 
 include mM
 /-- Makes a group homomorphism from a proof that the map preserves multiplication. -/

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -208,12 +208,7 @@ lemma extend_domain_hom_injective : function.injective (extend_domain_hom f) :=
 
 @[simp] lemma extend_domain_eq_one_iff {e : perm α} {f : α ≃ subtype p} :
   e.extend_domain f = 1 ↔ e = 1 :=
-begin
-  rw ←extend_domain_hom_apply,
-  revert e,
-  rw ←monoid_hom.injective_iff',
-  exact extend_domain_hom_injective f
-end
+(extend_domain_hom f).injective_iff'.mp (extend_domain_hom_injective f) e
 
 end extend_domain
 

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -206,6 +206,15 @@ lemma extend_domain_hom_injective : function.injective (extend_domain_hom f) :=
 ((extend_domain_hom f).injective_iff).mpr (λ e he, ext (λ x, f.injective (subtype.ext
   ((extend_domain_apply_image e f x).symm.trans (ext_iff.mp he (f x))))))
 
+@[simp] lemma extend_domain_eq_one_iff {e : perm α} {f : α ≃ subtype p} :
+  e.extend_domain f = 1 ↔ e = 1 :=
+begin
+  rw ←extend_domain_hom_apply,
+  revert e,
+  rw ←monoid_hom.injective_iff',
+  exact extend_domain_hom_injective f
+end
+
 end extend_domain
 
 /-- If the permutation `f` fixes the subtype `{x // p x}`, then this returns the permutation


### PR DESCRIPTION
Interpret the injectivity of a group hom as triviality of the kernel,
in iff form. This helps make explicit simp lemmas about
the application of such homs,
as in the added `extend_domain_eq_one_iff` lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
