### PR TITLE
[Merged by Bors] - chore(topology/topological_fiber_bundle): renaming

### DIFF
--- a/src/geometry/manifold/basic_smooth_bundle.lean
+++ b/src/geometry/manifold/basic_smooth_bundle.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import topology.topological_fiber_bundle
+import topology.fiber_bundle
 import geometry.manifold.smooth_manifold_with_corners
 
 /-!

--- a/src/topology/fiber_bundle.lean
+++ b/src/topology/fiber_bundle.lean
@@ -29,7 +29,7 @@ fiber bundle from trivializations given as local equivalences with minimum addit
 
 ### Basic definitions
 
-* `bundle_trivialization F p` : structure extending local homeomorphisms, defining a local
+* `trivialization F p` : structure extending local homeomorphisms, defining a local
                   trivialization of a topological space `Z` with projection `p` and fiber `F`.
 
 * `is_topological_fiber_bundle F p` : Prop saying that the map `p` between topological spaces is a
@@ -41,9 +41,9 @@ fiber bundle from trivializations given as local equivalences with minimum addit
 
 ### Operations on bundles
 
-We provide the following operations on `bundle_trivialization`s.
+We provide the following operations on `trivialization`s.
 
-* `bundle_trivialization.comap`: given a local trivialization `e` of a fiber bundle `p : Z → B`, a
+* `trivialization.comap`: given a local trivialization `e` of a fiber bundle `p : Z → B`, a
   continuous map `f : B' → B` and a point `b' : B'` such that `f b' ∈ e.base_set`,
   `e.comap f hf b' hb'` is a trivialization of the pullback bundle. The pullback bundle
   (a.k.a., the induced bundle) has total space `{(x, y) : B' × Z | f x = p y}`, and is given by
@@ -52,7 +52,7 @@ We provide the following operations on `bundle_trivialization`s.
 * `is_topological_fiber_bundle.comap`: if `p : Z → B` is a topological fiber bundle, then its
   pullback along a continuous map `f : B' → B` is a topological fiber bundle as well.
 
-* `bundle_trivialization.comp_homeomorph`: given a local trivialization `e` of a fiber bundle
+* `trivialization.comp_homeomorph`: given a local trivialization `e` of a fiber bundle
   `p : Z → B` and a homeomorphism `h : Z' ≃ₜ Z`, returns a local trivialization of the fiber bundle
   `p ∘ h`.
 
@@ -77,7 +77,7 @@ Let `Z : topological_fiber_bundle_core ι B F`. Then we define
 * `Z.local_triv i`: for `i : ι`, bundle trivialization above the set `Z.base_set i`, which is an
                     open set in `B`.
 
-* `prebundle_trivialization F proj` : trivialization as a local equivalence, mainly used when the
+* `pretrivialization F proj` : trivialization as a local equivalence, mainly used when the
                                       topology on the total space has not yet been defined.
 * `topological_fiber_prebundle F proj` : structure registering a cover of prebundle trivializations
   and requiring that the relative transition maps are local homeomorphisms.
@@ -160,12 +160,12 @@ section topological_fiber_bundle
 variables (F) {Z : Type*} [topological_space B] [topological_space F] {proj : Z → B}
 
 /-- This structure contains the information left for a local trivialization (which is implemented
-below as `bundle_trivialization F proj`) if the total space has not been given a topology, but we
+below as `trivialization F proj`) if the total space has not been given a topology, but we
 have a topology on both the fiber and the base space. Through the construction
 `topological_fiber_prebundle F proj` it will be possible to promote a
-`prebundle_trivialization F proj` to a `bundle_trivialization F proj`. -/
+`pretrivialization F proj` to a `trivialization F proj`. -/
 @[nolint has_inhabited_instance]
-structure prebundle_trivialization (proj : Z → B) extends local_equiv Z (B × F) :=
+structure topological_fiber_bundle.pretrivialization (proj : Z → B) extends local_equiv Z (B × F) :=
 (open_target   : is_open target)
 (base_set      : set B)
 (open_base_set : is_open base_set)
@@ -173,11 +173,13 @@ structure prebundle_trivialization (proj : Z → B) extends local_equiv Z (B × 
 (target_eq     : target = set.prod base_set univ)
 (proj_to_fun   : ∀ p ∈ source, (to_fun p).1 = proj p)
 
-namespace prebundle_trivialization
+open topological_fiber_bundle
 
-instance : has_coe_to_fun (prebundle_trivialization F proj) := ⟨_, λ e, e.to_fun⟩
+namespace topological_fiber_bundle.pretrivialization
 
-variables {F} (e : prebundle_trivialization F proj) {x : Z}
+instance : has_coe_to_fun (pretrivialization F proj) := ⟨_, λ e, e.to_fun⟩
+
+variables {F} (e : pretrivialization F proj) {x : Z}
 
 @[simp, mfld_simps] lemma coe_coe : ⇑e.to_local_equiv = e := rfl
 @[simp, mfld_simps] lemma coe_fst (ex : x ∈ e.source) : (e x).1 = proj x := e.proj_to_fun x ex
@@ -238,7 +240,7 @@ begin
     exact hx.2, }
 end
 
-end prebundle_trivialization
+end topological_fiber_bundle.pretrivialization
 
 variable [topological_space Z]
 
@@ -248,23 +250,26 @@ A structure extending local homeomorphisms, defining a local trivialization of a
 sets of the form `proj ⁻¹' base_set` and `base_set × F`, acting trivially on the first coordinate.
 -/
 @[nolint has_inhabited_instance]
-structure bundle_trivialization (proj : Z → B) extends local_homeomorph Z (B × F) :=
+structure topological_fiber_bundle.trivialization (proj : Z → B)
+  extends local_homeomorph Z (B × F) :=
 (base_set      : set B)
 (open_base_set : is_open base_set)
 (source_eq     : source = proj ⁻¹' base_set)
 (target_eq     : target = set.prod base_set univ)
 (proj_to_fun   : ∀ p ∈ source, (to_local_homeomorph p).1 = proj p)
 
-namespace bundle_trivialization
+open topological_fiber_bundle
 
-variables {F} (e : bundle_trivialization F proj) {x : Z}
+namespace topological_fiber_bundle.trivialization
 
-/-- Natural identification as `prebundle_trivialization`. -/
-def to_prebundle_trivialization : prebundle_trivialization F proj := { ..e }
+variables {F} (e : trivialization F proj) {x : Z}
 
-instance : has_coe_to_fun (bundle_trivialization F proj) := ⟨_, λ e, e.to_fun⟩
-instance : has_coe (bundle_trivialization F proj) (prebundle_trivialization F proj) :=
-⟨to_prebundle_trivialization⟩
+/-- Natural identification as a `pretrivialization`. -/
+def to_pretrivialization : topological_fiber_bundle.pretrivialization F proj := { ..e }
+
+instance : has_coe_to_fun (trivialization F proj) := ⟨_, λ e, e.to_fun⟩
+instance : has_coe (trivialization F proj) (pretrivialization F proj) :=
+⟨to_pretrivialization⟩
 
 @[simp, mfld_simps] lemma coe_coe : ⇑e.to_local_homeomorph = e := rfl
 @[simp, mfld_simps] lemma coe_fst (ex : x ∈ e.source) : (e x).1 = proj x := e.proj_to_fun x ex
@@ -280,31 +285,31 @@ lemma source_inter_preimage_target_inter (s : set (B × F)) :
 e.to_local_homeomorph.source_inter_preimage_target_inter s
 
 @[simp, mfld_simps] lemma coe_mk (e : local_homeomorph Z (B × F)) (i j k l m) (x : Z) :
-  (bundle_trivialization.mk e i j k l m : bundle_trivialization F proj) x = e x := rfl
+  (trivialization.mk e i j k l m : trivialization F proj) x = e x := rfl
 
 lemma mem_target {x : B × F} : x ∈ e.target ↔ x.1 ∈ e.base_set :=
-e.to_prebundle_trivialization.mem_target
+e.to_pretrivialization.mem_target
 
 lemma map_target {x : B × F} (hx : x ∈ e.target) : e.to_local_homeomorph.symm x ∈ e.source :=
 e.to_local_homeomorph.map_target hx
 
 lemma proj_symm_apply {x : B × F} (hx : x ∈ e.target) : proj (e.to_local_homeomorph.symm x) = x.1 :=
-e.to_prebundle_trivialization.proj_symm_apply hx
+e.to_pretrivialization.proj_symm_apply hx
 
 lemma proj_symm_apply' {b : B} {x : F}
   (hx : b ∈ e.base_set) : proj (e.to_local_homeomorph.symm (b, x)) = b :=
-e.to_prebundle_trivialization.proj_symm_apply' hx
+e.to_pretrivialization.proj_symm_apply' hx
 
 lemma apply_symm_apply {x : B × F} (hx : x ∈ e.target) : e (e.to_local_homeomorph.symm x) = x :=
 e.to_local_homeomorph.right_inv hx
 
 lemma apply_symm_apply'
   {b : B} {x : F} (hx : b ∈ e.base_set) : e (e.to_local_homeomorph.symm (b, x)) = (b, x) :=
-e.to_prebundle_trivialization.apply_symm_apply' hx
+e.to_pretrivialization.apply_symm_apply' hx
 
 @[simp, mfld_simps] lemma symm_apply_mk_proj (ex : x ∈ e.source) :
   e.to_local_homeomorph.symm (proj x, (e x).2) = x :=
-e.to_prebundle_trivialization.symm_apply_mk_proj ex
+e.to_pretrivialization.symm_apply_mk_proj ex
 
 lemma coe_fst_eventually_eq_proj (ex : x ∈ e.source) : prod.fst ∘ e =ᶠ[𝓝 x] proj  :=
 mem_nhds_iff.2 ⟨e.source, λ y hy, e.coe_fst hy, e.open_source, ex⟩
@@ -320,9 +325,9 @@ by rw [← e.coe_fst ex, ← map_congr (e.coe_fst_eventually_eq_proj ex), ← ma
 lemma continuous_at_proj (ex : x ∈ e.source) : continuous_at proj x :=
 (e.map_proj_nhds ex).le
 
-/-- Composition of a `bundle_trivialization` and a `homeomorph`. -/
+/-- Composition of a `trivialization` and a `homeomorph`. -/
 def comp_homeomorph {Z' : Type*} [topological_space Z'] (h : Z' ≃ₜ Z) :
-  bundle_trivialization F (proj ∘ h) :=
+  trivialization F (proj ∘ h) :=
 { to_local_homeomorph := h.to_local_homeomorph.trans e.to_local_homeomorph,
   base_set := e.base_set,
   open_base_set := e.open_base_set,
@@ -332,13 +337,13 @@ def comp_homeomorph {Z' : Type*} [topological_space Z'] (h : Z' ≃ₜ Z) :
     have hp : h p ∈ e.source, by simpa using hp,
     by simp [hp] }
 
-end bundle_trivialization
+end topological_fiber_bundle.trivialization
 
 /-- A topological fiber bundle with fiber `F` over a base `B` is a space projecting on `B`
 for which the fibers are all homeomorphic to `F`, such that the local situation around each point
 is a direct product. -/
 def is_topological_fiber_bundle (proj : Z → B) : Prop :=
-∀ x : B, ∃e : bundle_trivialization F proj, x ∈ e.base_set
+∀ x : B, ∃e : trivialization F proj, x ∈ e.base_set
 
 /-- A trivial topological fiber bundle with fiber `F` over a base `B` is a space `Z`
 projecting on `B` for which there exists a homeomorphism to `B × F` that sends `proj`
@@ -397,15 +402,15 @@ lemma is_topological_fiber_bundle.comp_homeomorph {Z' : Type*} [topological_spac
   (e : is_topological_fiber_bundle F proj) (h : Z' ≃ₜ Z) :
   is_topological_fiber_bundle F (proj ∘ h) :=
 λ x, let ⟨e, he⟩ := e x in
-⟨e.comp_homeomorph h, by simpa [bundle_trivialization.comp_homeomorph] using he⟩
+⟨e.comp_homeomorph h, by simpa [topological_fiber_bundle.trivialization.comp_homeomorph] using he⟩
 
-namespace bundle_trivialization
+namespace topological_fiber_bundle.trivialization
 
-/-- If `e` is a `bundle_trivialization` of `proj : Z → B` with fiber `F` and `h` is a homeomorphism
+/-- If `e` is a `trivialization` of `proj : Z → B` with fiber `F` and `h` is a homeomorphism
 `F ≃ₜ F'`, then `e.trans_fiber_homeomorph h` is the trivialization of `proj` with the fiber `F'`
 that sends `p : Z` to `((e p).1, h (e p).2)`. -/
 def trans_fiber_homeomorph {F' : Type*} [topological_space F']
-  (e : bundle_trivialization F proj) (h : F ≃ₜ F') : bundle_trivialization F' proj :=
+  (e : trivialization F proj) (h : F ≃ₜ F') : trivialization F' proj :=
 { to_local_homeomorph := e.to_local_homeomorph.trans
     ((homeomorph.refl _).prod_congr h).to_local_homeomorph,
   base_set := e.base_set,
@@ -415,17 +420,17 @@ def trans_fiber_homeomorph {F' : Type*} [topological_space F']
   proj_to_fun := λ p hp, have p ∈ e.source, by simpa using hp, by simp [this] }
 
 @[simp] lemma trans_fiber_homeomorph_apply {F' : Type*} [topological_space F']
-  (e : bundle_trivialization F proj) (h : F ≃ₜ F') (x : Z) :
+  (e : trivialization F proj) (h : F ≃ₜ F') (x : Z) :
   e.trans_fiber_homeomorph h x = ((e x).1, h (e x).2) :=
 rfl
 
 /-- Coordinate transformation in the fiber induced by a pair of bundle trivializations. See also
-`bundle_trivialization.coord_change_homeomorph` for a version bundled as `F ≃ₜ F`. -/
-def coord_change (e₁ e₂ : bundle_trivialization F proj) (b : B) (x : F) : F :=
+`trivialization.coord_change_homeomorph` for a version bundled as `F ≃ₜ F`. -/
+def coord_change (e₁ e₂ : trivialization F proj) (b : B) (x : F) : F :=
 (e₂ $ e₁.to_local_homeomorph.symm (b, x)).2
 
 lemma mk_coord_change
-  (e₁ e₂ : bundle_trivialization F proj) {b : B}
+  (e₁ e₂ : trivialization F proj) {b : B}
   (h₁ : b ∈ e₁.base_set) (h₂ : b ∈ e₂.base_set) (x : F) :
   (b, e₁.coord_change e₂ b x) = e₂ (e₁.to_local_homeomorph.symm (b, x)) :=
 begin
@@ -436,32 +441,32 @@ begin
 end
 
 lemma coord_change_apply_snd
-  (e₁ e₂ : bundle_trivialization F proj) {p : Z}
+  (e₁ e₂ : trivialization F proj) {p : Z}
   (h : proj p ∈ e₁.base_set) :
   e₁.coord_change e₂ (proj p) (e₁ p).snd = (e₂ p).snd :=
 by rw [coord_change, e₁.symm_apply_mk_proj (e₁.mem_source.2 h)]
 
 lemma coord_change_same_apply
-  (e : bundle_trivialization F proj) {b : B} (h : b ∈ e.base_set) (x : F) :
+  (e : trivialization F proj) {b : B} (h : b ∈ e.base_set) (x : F) :
   e.coord_change e b x = x :=
-by rw [bundle_trivialization.coord_change, e.apply_symm_apply' h]
+by rw [coord_change, e.apply_symm_apply' h]
 
 lemma coord_change_same
-  (e : bundle_trivialization F proj) {b : B} (h : b ∈ e.base_set) :
+  (e : trivialization F proj) {b : B} (h : b ∈ e.base_set) :
   e.coord_change e b = id :=
 funext $ e.coord_change_same_apply h
 
 lemma coord_change_coord_change
-  (e₁ e₂ e₃ : bundle_trivialization F proj) {b : B}
+  (e₁ e₂ e₃ : trivialization F proj) {b : B}
   (h₁ : b ∈ e₁.base_set) (h₂ : b ∈ e₂.base_set) (x : F) :
   e₂.coord_change e₃ b (e₁.coord_change e₂ b x) = e₁.coord_change e₃ b x :=
 begin
-  rw [bundle_trivialization.coord_change, e₁.mk_coord_change _ h₁ h₂, ← e₂.coe_coe,
-    e₂.to_local_homeomorph.left_inv, bundle_trivialization.coord_change],
+  rw [coord_change, e₁.mk_coord_change _ h₁ h₂, ← e₂.coe_coe,
+    e₂.to_local_homeomorph.left_inv, coord_change],
   rwa [e₂.mem_source, e₁.proj_symm_apply' h₁]
 end
 
-lemma continuous_coord_change (e₁ e₂ : bundle_trivialization F proj) {b : B}
+lemma continuous_coord_change (e₁ e₂ : trivialization F proj) {b : B}
   (h₁ : b ∈ e₁.base_set) (h₂ : b ∈ e₂.base_set) :
   continuous (e₁.coord_change e₂ b) :=
 begin
@@ -476,7 +481,7 @@ end
 /-- Coordinate transformation in the fiber induced by a pair of bundle trivializations,
 as a homeomorphism. -/
 def coord_change_homeomorph
-  (e₁ e₂ : bundle_trivialization F proj) {b : B} (h₁ : b ∈ e₁.base_set) (h₂ : b ∈ e₂.base_set) :
+  (e₁ e₂ : trivialization F proj) {b : B} (h₁ : b ∈ e₁.base_set) (h₂ : b ∈ e₂.base_set) :
   F ≃ₜ F :=
 { to_fun := e₁.coord_change e₂ b,
   inv_fun := e₂.coord_change e₁ b,
@@ -486,11 +491,11 @@ def coord_change_homeomorph
   continuous_inv_fun := e₂.continuous_coord_change e₁ h₂ h₁ }
 
 @[simp] lemma coord_change_homeomorph_coe
-  (e₁ e₂ : bundle_trivialization F proj) {b : B} (h₁ : b ∈ e₁.base_set) (h₂ : b ∈ e₂.base_set) :
+  (e₁ e₂ : trivialization F proj) {b : B} (h₁ : b ∈ e₁.base_set) (h₂ : b ∈ e₂.base_set) :
   ⇑(e₁.coord_change_homeomorph e₂ h₁ h₂) = e₁.coord_change e₂ b :=
 rfl
 
-end bundle_trivialization
+end topological_fiber_bundle.trivialization
 
 section comap
 
@@ -501,10 +506,10 @@ variables {B' : Type*} [topological_space B']
 /-- Given a bundle trivialization of `proj : Z → B` and a continuous map `f : B' → B`,
 construct a bundle trivialization of `φ : {p : B' × Z | f p.1 = proj p.2} → B'`
 given by `φ x = (x : B' × Z).1`. -/
-noncomputable def bundle_trivialization.comap
-  (e : bundle_trivialization F proj) (f : B' → B) (hf : continuous f)
+noncomputable def topological_fiber_bundle.trivialization.comap
+  (e : trivialization F proj) (f : B' → B) (hf : continuous f)
   (b' : B') (hb' : f b' ∈ e.base_set) :
-  bundle_trivialization F (λ x : {p : B' × Z | f p.1 = proj p.2}, (x : B' × Z).1) :=
+  trivialization F (λ x : {p : B' × Z | f p.1 = proj p.2}, (x : B' × Z).1) :=
 { to_fun := λ p, ((p : B' × Z).1, (e (p : B' × Z).2).2),
   inv_fun := λ p, if h : f p.1 ∈ e.base_set
     then ⟨⟨p.1, e.to_local_homeomorph.symm (f p.1, p.2)⟩, by simp [e.proj_symm_apply' h]⟩
@@ -556,14 +561,15 @@ lemma is_topological_fiber_bundle.comap (h : is_topological_fiber_bundle F proj)
 
 end comap
 
-lemma bundle_trivialization.is_image_preimage_prod (e : bundle_trivialization F proj) (s : set B) :
+namespace topological_fiber_bundle.trivialization
+
+lemma is_image_preimage_prod (e : trivialization F proj) (s : set B) :
   e.to_local_homeomorph.is_image (proj ⁻¹' s) (s.prod univ) :=
 λ x hx, by simp [e.coe_fst', hx]
 
-/-- Restrict a `bundle_trivialization` to an open set in the base. `-/
-def bundle_trivialization.restr_open (e : bundle_trivialization F proj) (s : set B)
-  (hs : is_open s) :
-  bundle_trivialization F proj :=
+/-- Restrict a `trivialization` to an open set in the base. `-/
+def restr_open (e : trivialization F proj) (s : set B)
+  (hs : is_open s) : trivialization F proj :=
 { to_local_homeomorph := ((e.is_image_preimage_prod s).symm.restr
     (is_open.inter e.open_target (hs.prod is_open_univ))).symm,
   base_set := e.base_set ∩ s,
@@ -574,7 +580,7 @@ def bundle_trivialization.restr_open (e : bundle_trivialization F proj) (s : set
 
 section piecewise
 
-lemma bundle_trivialization.frontier_preimage (e : bundle_trivialization F proj) (s : set B) :
+lemma frontier_preimage (e : trivialization F proj) (s : set B) :
   e.source ∩ frontier (proj ⁻¹' s) = proj ⁻¹' (e.base_set ∩ frontier s) :=
 by rw [← (e.is_image_preimage_prod s).frontier.preimage_eq, frontier_prod_univ_eq,
   (e.is_image_preimage_prod _).preimage_eq, e.source_eq, preimage_inter]
@@ -584,10 +590,10 @@ the base sets of `e` and `e'` intersect `frontier s` on the same set and `e p = 
 `proj p ∈ e.base_set ∩ frontier s`, `e.piecewise e' s Hs Heq` is the bundle trivialization over
 `set.ite s e.base_set e'.base_set` that is equal to `e` on `proj ⁻¹ s` and is equal to `e'`
 otherwise. -/
-noncomputable def bundle_trivialization.piecewise (e e' : bundle_trivialization F proj) (s : set B)
+noncomputable def piecewise (e e' : trivialization F proj) (s : set B)
   (Hs : e.base_set ∩ frontier s = e'.base_set ∩ frontier s)
   (Heq : eq_on e e' $ proj ⁻¹' (e.base_set ∩ frontier s)) :
-  bundle_trivialization F proj :=
+  trivialization F proj :=
 { to_local_homeomorph := e.to_local_homeomorph.piecewise e'.to_local_homeomorph
     (proj ⁻¹' s) (s.prod univ) (e.is_image_preimage_prod s) (e'.is_image_preimage_prod s)
     (by rw [e.frontier_preimage, e'.frontier_preimage, Hs])
@@ -603,10 +609,10 @@ over a linearly ordered base `B` and a point `a ∈ e.base_set ∩ e'.base_set` 
 `e` equals `e'` on `proj ⁻¹' {a}`, `e.piecewise_le_of_eq e' a He He' Heq` is the bundle
 trivialization over `set.ite (Iic a) e.base_set e'.base_set` that is equal to `e` on points `p`
 such that `proj p ≤ a` and is equal to `e'` otherwise. -/
-noncomputable def bundle_trivialization.piecewise_le_of_eq [linear_order B] [order_topology B]
-  (e e' : bundle_trivialization F proj) (a : B) (He : a ∈ e.base_set) (He' : a ∈ e'.base_set)
+noncomputable def piecewise_le_of_eq [linear_order B] [order_topology B]
+  (e e' : trivialization F proj) (a : B) (He : a ∈ e.base_set) (He' : a ∈ e'.base_set)
   (Heq : ∀ p, proj p = a → e p = e' p) :
-  bundle_trivialization F proj :=
+  trivialization F proj :=
 e.piecewise e' (Iic a)
   (set.ext $ λ x, and.congr_left_iff.2 $ λ hx,
     by simp [He, He', mem_singleton_iff.1 (frontier_Iic_subset _ hx)])
@@ -618,9 +624,9 @@ is the bundle trivialization over `set.ite (Iic a) e.base_set e'.base_set` that 
 points `p` such that `proj p ≤ a` and is equal to `((e' p).1, h (e' p).2)` otherwise, where
 `h = `e'.coord_change_homeomorph e _ _` is the homeomorphism of the fiber such that
 `h (e' p).2 = (e p).2` whenever `e p = a`. -/
-noncomputable def bundle_trivialization.piecewise_le [linear_order B] [order_topology B]
-  (e e' : bundle_trivialization F proj) (a : B) (He : a ∈ e.base_set) (He' : a ∈ e'.base_set) :
-  bundle_trivialization F proj :=
+noncomputable def piecewise_le [linear_order B] [order_topology B]
+  (e e' : trivialization F proj) (a : B) (He : a ∈ e.base_set) (He' : a ∈ e'.base_set) :
+  trivialization F proj :=
 e.piecewise_le_of_eq (e'.trans_fiber_homeomorph (e'.coord_change_homeomorph e He' He))
   a He He' $ by { unfreezingI {rintro p rfl },
     ext1,
@@ -630,9 +636,9 @@ e.piecewise_le_of_eq (e'.trans_fiber_homeomorph (e'.coord_change_homeomorph e He
 /-- Given two bundle trivializations `e`, `e'` over disjoint sets, `e.disjoint_union e' H` is the
 bundle trivialization over the union of the base sets that agrees with `e` and `e'` over their
 base sets. -/
-noncomputable def bundle_trivialization.disjoint_union (e e' : bundle_trivialization F proj)
+noncomputable def disjoint_union (e e' : trivialization F proj)
   (H : disjoint e.base_set e'.base_set) :
-  bundle_trivialization F proj :=
+  trivialization F proj :=
 { to_local_homeomorph := e.to_local_homeomorph.disjoint_union e'.to_local_homeomorph
     (λ x hx, by { rw [e.source_eq, e'.source_eq] at hx, exact H hx })
     (λ x hx, by { rw [e.target_eq, e'.target_eq] at hx, exact H ⟨hx.1.1, hx.2.1⟩ }),
@@ -653,18 +659,18 @@ noncomputable def bundle_trivialization.disjoint_union (e e' : bundle_trivializa
 
 /-- If `h` is a topological fiber bundle over a conditionally complete linear order,
 then it is trivial over any closed interval. -/
-lemma is_topological_fiber_bundle.exists_trivialization_Icc_subset
+lemma _root_.is_topological_fiber_bundle.exists_trivialization_Icc_subset
   [conditionally_complete_linear_order B] [order_topology B]
   (h : is_topological_fiber_bundle F proj) (a b : B) :
-  ∃ e : bundle_trivialization F proj, Icc a b ⊆ e.base_set :=
+  ∃ e : trivialization F proj, Icc a b ⊆ e.base_set :=
 begin
   classical,
-  obtain ⟨ea, hea⟩ : ∃ ea : bundle_trivialization F proj, a ∈ ea.base_set := h a,
+  obtain ⟨ea, hea⟩ : ∃ ea : trivialization F proj, a ∈ ea.base_set := h a,
   -- If `a < b`, then `[a, b] = ∅`, and the statement is trivial
   cases le_or_lt a b with hab hab; [skip, exact ⟨ea, by simp *⟩],
   /- Let `s` be the set of points `x ∈ [a, b]` such that `proj` is trivializable over `[a, x]`.
   We need to show that `b ∈ s`. Let `c = Sup s`. We will show that `c ∈ s` and `c = b`. -/
-  set s : set B := {x ∈ Icc a b | ∃ e : bundle_trivialization F proj, Icc a x ⊆ e.base_set},
+  set s : set B := {x ∈ Icc a b | ∃ e : trivialization F proj, Icc a x ⊆ e.base_set},
   have ha : a ∈ s, from ⟨left_mem_Icc.2 hab, ea, by simp [hea]⟩,
   have sne : s.nonempty := ⟨a, ha⟩,
   have hsb : b ∈ upper_bounds s, from λ x hx, hx.1.2,
@@ -672,7 +678,7 @@ begin
   set c := Sup s,
   have hsc : is_lub s c, from is_lub_cSup sne sbd,
   have hc : c ∈ Icc a b, from ⟨hsc.1 ha, hsc.2 hsb⟩,
-  obtain ⟨-, ec : bundle_trivialization F proj, hec : Icc a c ⊆ ec.base_set⟩ : c ∈ s,
+  obtain ⟨-, ec : trivialization F proj, hec : Icc a c ⊆ ec.base_set⟩ : c ∈ s,
   { cases hc.1.eq_or_lt with heq hlt, { rwa ← heq },
     refine ⟨hc, _⟩,
     /- In order to show that `c ∈ s`, consider a trivialization `ec` of `proj` over a neighborhood
@@ -690,7 +696,7 @@ begin
   done. Otherwise we show that `proj` can be trivialized over a larger interval `[a, d]`,
   `d ∈ (c, b]`, hence `c` is not an upper bound of `s`. -/
   cases hc.2.eq_or_lt with heq hlt, { exact ⟨ec, heq ▸ hec⟩ },
-  suffices : ∃ (d ∈ Ioc c b) (e : bundle_trivialization F proj), Icc a d ⊆ e.base_set,
+  suffices : ∃ (d ∈ Ioc c b) (e : trivialization F proj), Icc a d ⊆ e.base_set,
   { rcases this with ⟨d, hdcb, hd⟩,
     exact ((hsc.1 ⟨⟨hc.1.trans hdcb.1.le, hdcb.2⟩, hd⟩).not_lt hdcb.1).elim },
   /- Since the base set of `ec` is open, it includes `[c, d)` (hence, `[a, d)`) for some
@@ -717,6 +723,8 @@ begin
 end
 
 end piecewise
+
+end topological_fiber_bundle.trivialization
 
 end topological_fiber_bundle
 
@@ -909,9 +917,11 @@ begin
     mem_local_triv_as_local_equiv_source, and_true, mem_univ, mem_preimage],
 end
 
+open topological_fiber_bundle
+
 /-- Extended version of the local trivialization of a fiber bundle constructed from core,
 registering additionally in its type that it is a local bundle trivialization. -/
-def local_triv (i : ι) : bundle_trivialization F Z.proj :=
+def local_triv (i : ι) : trivialization F Z.proj :=
 { base_set      := Z.base_set i,
   open_base_set := Z.is_open_base_set i,
   source_eq     := rfl,
@@ -962,7 +972,7 @@ Z.is_topological_fiber_bundle.is_open_map_proj
 
 /-- Preferred local trivialization of a fiber bundle constructed from core, at a given point, as
 a bundle trivialization -/
-def local_triv_at (b : B) : bundle_trivialization F Z.proj :=
+def local_triv_at (b : B) : trivialization F Z.proj :=
 Z.local_triv (Z.index_at b)
 
 @[simp, mfld_simps] lemma local_triv_at_def (b : B) :
@@ -1011,7 +1021,7 @@ end
 
 @[simp, mfld_simps] lemma mem_local_triv_target (p : B × F) :
   p ∈ (Z.local_triv i).target ↔ p.1 ∈ (Z.local_triv i).base_set :=
-bundle_trivialization.mem_target _
+trivialization.mem_target _
 
 @[simp, mfld_simps] lemma local_triv_symm_fst (p : B × F) :
   (Z.local_triv i).to_local_homeomorph.symm p =
@@ -1036,7 +1046,7 @@ begin
     local_triv_as_local_equiv_coe],
   rintros s ⟨i, t, ht, rfl⟩,
   rw [←((Z.local_triv i).source_inter_preimage_target_inter t), preimage_inter, ←preimage_comp,
-    bundle_trivialization.source_eq],
+    trivialization.source_eq],
   apply is_open.inter,
   { simp only [bundle.proj, proj, ←preimage_comp],
     by_cases (b ∈ (Z.local_triv i).base_set),
@@ -1061,17 +1071,19 @@ end topological_fiber_bundle_core
 
 variables (F) {Z : Type*} [topological_space B] [topological_space F] {proj : Z → B}
 
+open topological_fiber_bundle
+
 /-- This structure permits to define a fiber bundle when trivializations are given as local
 equivalences but there is not yet a topology on the total space. The total space is hence given a
 topology in such a way that there is a fiber bundle structure for which the local equivalences
 are also local homeomorphism and hence local trivializations. -/
 @[nolint has_inhabited_instance]
 structure topological_fiber_prebundle (proj : Z → B) :=
-(trivialization_at : B → prebundle_trivialization F proj)
-(mem_base_trivialization_at : ∀ x : B, x ∈ (trivialization_at x).base_set)
-(continuous_triv_change : ∀ x y : B, continuous_on ((trivialization_at x) ∘
-  (trivialization_at y).to_local_equiv.symm) ((trivialization_at y).target ∩
-  ((trivialization_at y).to_local_equiv.symm ⁻¹' (trivialization_at x).source)))
+(pretrivialization_at : B → pretrivialization F proj)
+(mem_base_pretrivialization_at : ∀ x : B, x ∈ (pretrivialization_at x).base_set)
+(continuous_triv_change : ∀ x y : B, continuous_on ((pretrivialization_at x) ∘
+  (pretrivialization_at y).to_local_equiv.symm) ((pretrivialization_at y).target ∩
+  ((pretrivialization_at y).to_local_equiv.symm ⁻¹' (pretrivialization_at x).source)))
 
 namespace topological_fiber_prebundle
 
@@ -1079,64 +1091,64 @@ variables {F} (a : topological_fiber_prebundle F proj) (x : B)
 
 /-- Topology on the total space that will make the prebundle into a bundle. -/
 def total_space_topology (a : topological_fiber_prebundle F proj) : topological_space Z :=
-⨆ x : B, coinduced (a.trivialization_at x).set_symm (subtype.topological_space)
+⨆ x : B, coinduced (a.pretrivialization_at x).set_symm (subtype.topological_space)
 
-lemma continuous_symm_trivialization_at : @continuous_on _ _ _ a.total_space_topology
-  (a.trivialization_at x).to_local_equiv.symm (a.trivialization_at x).target :=
+lemma continuous_symm_pretrivialization_at : @continuous_on _ _ _ a.total_space_topology
+  (a.pretrivialization_at x).to_local_equiv.symm (a.pretrivialization_at x).target :=
 begin
-  refine id (λ z H, id (λ U h, preimage_nhds_within_coinduced' H (a.trivialization_at x).open_target
-  (le_def.1 (nhds_mono _) U h))),
+  refine id (λ z H, id (λ U h, preimage_nhds_within_coinduced' H
+    (a.pretrivialization_at x).open_target (le_def.1 (nhds_mono _) U h))),
   exact le_supr _ x,
 end
 
-lemma is_open_source_trivialization_at :
-  @is_open _ a.total_space_topology (a.trivialization_at x).source :=
+lemma is_open_source_pretrivialization_at :
+  @is_open _ a.total_space_topology (a.pretrivialization_at x).source :=
 begin
   letI := a.total_space_topology,
   refine is_open_supr_iff.mpr (λ y, is_open_coinduced.mpr (is_open_induced_iff.mpr
-    ⟨(a.trivialization_at x).target, (a.trivialization_at x).open_target, _⟩)),
-  rw [prebundle_trivialization.set_symm, restrict, (a.trivialization_at x).target_eq,
-    (a.trivialization_at x).source_eq, preimage_comp, subtype.preimage_coe_eq_preimage_coe_iff,
-    (a.trivialization_at y).target_eq, prod_inter_prod, inter_univ,
-    prebundle_trivialization.preimage_symm_proj_inter],
+    ⟨(a.pretrivialization_at x).target, (a.pretrivialization_at x).open_target, _⟩)),
+  rw [pretrivialization.set_symm, restrict, (a.pretrivialization_at x).target_eq,
+    (a.pretrivialization_at x).source_eq, preimage_comp, subtype.preimage_coe_eq_preimage_coe_iff,
+    (a.pretrivialization_at y).target_eq, prod_inter_prod, inter_univ,
+    pretrivialization.preimage_symm_proj_inter],
 end
 
-lemma is_open_target_trivialization_at_inter (x y : B) :
-  is_open ((a.trivialization_at y).to_local_equiv.target ∩
-  (a.trivialization_at y).to_local_equiv.symm ⁻¹' (a.trivialization_at x).source) :=
+lemma is_open_target_pretrivialization_at_inter (x y : B) :
+  is_open ((a.pretrivialization_at y).to_local_equiv.target ∩
+  (a.pretrivialization_at y).to_local_equiv.symm ⁻¹' (a.pretrivialization_at x).source) :=
 begin
   letI := a.total_space_topology,
-  obtain ⟨u, hu1, hu2⟩ := continuous_on_iff'.mp (a.continuous_symm_trivialization_at y)
-    (a.trivialization_at x).source (a.is_open_source_trivialization_at x),
+  obtain ⟨u, hu1, hu2⟩ := continuous_on_iff'.mp (a.continuous_symm_pretrivialization_at y)
+    (a.pretrivialization_at x).source (a.is_open_source_pretrivialization_at x),
   rw [inter_comm, hu2],
-  exact hu1.inter (a.trivialization_at y).open_target,
+  exact hu1.inter (a.pretrivialization_at y).open_target,
 end
 
-/-- Promotion from a `prebundle_trivialization` to a `bundle_trivialization`. -/
-def bundle_trivialization_at (a : topological_fiber_prebundle F proj) (x : B) :
-  @bundle_trivialization B F Z _ _ a.total_space_topology proj :=
-{ open_source := a.is_open_source_trivialization_at x,
+/-- Promotion from a `pretrivialization` to a `trivialization`. -/
+def trivialization_at (a : topological_fiber_prebundle F proj) (x : B) :
+  @trivialization B F Z _ _ a.total_space_topology proj :=
+{ open_source := a.is_open_source_pretrivialization_at x,
   continuous_to_fun := begin
     letI := a.total_space_topology,
-    refine continuous_on_iff'.mpr (λ s hs, ⟨(a.trivialization_at x) ⁻¹' s ∩
-      (a.trivialization_at x).source, (is_open_supr_iff.mpr (λ y, _)),
+    refine continuous_on_iff'.mpr (λ s hs, ⟨(a.pretrivialization_at x) ⁻¹' s ∩
+      (a.pretrivialization_at x).source, (is_open_supr_iff.mpr (λ y, _)),
       by { rw [inter_assoc, inter_self], refl }⟩),
     rw [is_open_coinduced, is_open_induced_iff],
     obtain ⟨u, hu1, hu2⟩ := continuous_on_iff'.mp (a.continuous_triv_change x y) s hs,
-    have hu3 := congr_arg (λ s, (λ x : (a.trivialization_at y).target, (x : B × F)) ⁻¹' s) hu2,
+    have hu3 := congr_arg (λ s, (λ x : (a.pretrivialization_at y).target, (x : B × F)) ⁻¹' s) hu2,
     simp only [subtype.coe_preimage_self, preimage_inter, univ_inter] at hu3,
-    refine ⟨u ∩ (a.trivialization_at y).to_local_equiv.target ∩
-      ((a.trivialization_at y).to_local_equiv.symm ⁻¹' (a.trivialization_at x).source), _, by
+    refine ⟨u ∩ (a.pretrivialization_at y).to_local_equiv.target ∩
+      ((a.pretrivialization_at y).to_local_equiv.symm ⁻¹' (a.pretrivialization_at x).source), _, by
       { simp only [preimage_inter, inter_univ, subtype.coe_preimage_self, hu3.symm], refl }⟩,
     rw inter_assoc,
-    exact hu1.inter (a.is_open_target_trivialization_at_inter x y),
+    exact hu1.inter (a.is_open_target_pretrivialization_at_inter x y),
   end,
-  continuous_inv_fun := a.continuous_symm_trivialization_at x,
-  ..(a.trivialization_at x) }
+  continuous_inv_fun := a.continuous_symm_pretrivialization_at x,
+  ..(a.pretrivialization_at x) }
 
 lemma is_topological_fiber_bundle :
   @is_topological_fiber_bundle B F Z _ _ a.total_space_topology proj :=
-λ x, ⟨a.bundle_trivialization_at x, a.mem_base_trivialization_at x ⟩
+λ x, ⟨a.trivialization_at x, a.mem_base_pretrivialization_at x ⟩
 
 lemma continuous_proj : @continuous _ _ a.total_space_topology _ proj :=
 by { letI := a.total_space_topology, exact a.is_topological_fiber_bundle.continuous_proj, }

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -67,14 +67,16 @@ section
 
 /-- Local trivialization for vector bundles. -/
 @[nolint has_inhabited_instance]
-structure topological_vector_bundle.trivialization
-  extends topological_fiber_bundle.trivialization F (proj E) :=
+structure topological_vector_bundle.trivialization extends to_fiber_bundle_trivialization :
+  topological_fiber_bundle.trivialization F (proj E) :=
 (linear : ∀ x ∈ base_set, is_linear_map R (λ y : (E x), (to_fun y).2))
 
 open topological_vector_bundle
 
+instance : has_coe_to_fun (trivialization R F E) := ⟨_, λ e, e.to_fun⟩
+
 instance : has_coe (trivialization R F E) (topological_fiber_bundle.trivialization F (proj E)) :=
-⟨topological_vector_bundle.trivialization.to_trivialization⟩
+⟨topological_vector_bundle.trivialization.to_fiber_bundle_trivialization⟩
 
 namespace topological_vector_bundle
 
@@ -176,7 +178,7 @@ def continuous_linear_equiv_at (e : trivialization R F E) (b : B)
   continuous_inv_fun := begin
     rw (topological_vector_bundle.inducing R F E b).continuous_iff,
     dsimp,
-    have : continuous (λ (z : F), (e.to_trivialization.to_local_homeomorph.symm) (b, z)),
+    have : continuous (λ (z : F), e.to_fiber_bundle_trivialization.to_local_homeomorph.symm (b, z)),
     { apply e.to_local_homeomorph.symm.continuous_on.comp_continuous
         (continuous_const.prod_mk continuous_id') (λ z, _),
       simp only [topological_fiber_bundle.trivialization.mem_target, hb, local_equiv.symm_source,
@@ -250,7 +252,8 @@ variables {R B F}
 /- Not registered as an instance because of a metavariable. -/
 lemma is_topological_vector_bundle_is_topological_fiber_bundle :
   is_topological_fiber_bundle F (proj E) :=
-λ x, ⟨(trivialization_at R F E x).to_trivialization, mem_base_set_trivialization_at R F E x⟩
+λ x, ⟨(trivialization_at R F E x).to_fiber_bundle_trivialization,
+  mem_base_set_trivialization_at R F E x⟩
 
 end topological_vector_bundle
 

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nicolò Cavalleri, Sebastien Gouezel
 -/
 
-import topology.topological_fiber_bundle
+import topology.fiber_bundle
 import topology.algebra.module
 
 /-!
@@ -67,30 +67,28 @@ section
 
 /-- Local trivialization for vector bundles. -/
 @[nolint has_inhabited_instance]
-structure topological_vector_bundle.trivialization extends bundle_trivialization F (proj E) :=
+structure topological_vector_bundle.trivialization
+  extends topological_fiber_bundle.trivialization F (proj E) :=
 (linear : ∀ x ∈ base_set, is_linear_map R (λ y : (E x), (to_fun y).2))
 
-instance : has_coe_to_fun (topological_vector_bundle.trivialization R F E) :=
-⟨λ _, (total_space E → B × F), λ e, e.to_bundle_trivialization⟩
+open topological_vector_bundle
 
-instance : has_coe (topological_vector_bundle.trivialization R F E)
-  (bundle_trivialization F (proj E)) :=
-⟨topological_vector_bundle.trivialization.to_bundle_trivialization⟩
+instance : has_coe (trivialization R F E) (topological_fiber_bundle.trivialization F (proj E)) :=
+⟨topological_vector_bundle.trivialization.to_trivialization⟩
 
 namespace topological_vector_bundle
 
 variables {R F E}
 
 lemma trivialization.mem_source (e : trivialization R F E)
-  {x : total_space E} : x ∈ e.source ↔ proj E x ∈ e.base_set := bundle_trivialization.mem_source e
+  {x : total_space E} : x ∈ e.source ↔ proj E x ∈ e.base_set :=
+topological_fiber_bundle.trivialization.mem_source e
 
 @[simp, mfld_simps] lemma trivialization.coe_coe (e : trivialization R F E) :
   ⇑e.to_local_homeomorph = e := rfl
 
-@[simp, mfld_simps] lemma trivialization.coe_fst
-  (e : trivialization R F E) {x : total_space E} (ex : x ∈ e.source) :
-  (e x).1 = (proj E) x :=
-e.proj_to_fun x ex
+@[simp, mfld_simps] lemma trivialization.coe_fst (e : trivialization R F E) {x : total_space E}
+  (ex : x ∈ e.source) : (e x).1 = (proj E) x := e.proj_to_fun x ex
 
 end topological_vector_bundle
 
@@ -113,26 +111,28 @@ namespace topological_vector_bundle
 /-- `trivialization_at R F E b` is some choice of trivialization of a vector bundle whose base set
 contains a given point `b`. -/
 def trivialization_at : Π b : B, trivialization R F E :=
-λ b, classical.some (topological_vector_bundle.locally_trivial R F E b)
+λ b, classical.some (locally_trivial R F E b)
 
 @[simp, mfld_simps] lemma mem_base_set_trivialization_at (b : B) :
   b ∈ (trivialization_at R F E b).base_set :=
-classical.some_spec (topological_vector_bundle.locally_trivial R F E b)
+classical.some_spec (locally_trivial R F E b)
 
 @[simp, mfld_simps] lemma mem_source_trivialization_at (z : total_space E) :
   z ∈ (trivialization_at R F E z.1).source :=
-by { rw bundle_trivialization.mem_source, apply mem_base_set_trivialization_at }
+by { rw topological_fiber_bundle.trivialization.mem_source, apply mem_base_set_trivialization_at }
 
 variables {R F E}
 
+namespace trivialization
+
 /-- In a topological vector bundle, a trivialization in the fiber (which is a priori only linear)
 is in fact a continuous linear equiv between the fibers and the model fiber. -/
-def trivialization.continuous_linear_equiv_at (e : trivialization R F E) (b : B)
+def continuous_linear_equiv_at (e : trivialization R F E) (b : B)
   (hb : b ∈ e.base_set) : E b ≃L[R] F :=
 { to_fun := λ y, (e ⟨b, y⟩).2,
   inv_fun := λ z, begin
     have : ((e.to_local_homeomorph.symm) (b, z)).fst = b :=
-      bundle_trivialization.proj_symm_apply' _ hb,
+      topological_fiber_bundle.trivialization.proj_symm_apply' _ hb,
     have C : E ((e.to_local_homeomorph.symm) (b, z)).fst = E b, by rw this,
     exact cast C (e.to_local_homeomorph.symm (b, z)).2
   end,
@@ -143,10 +143,10 @@ def trivialization.continuous_linear_equiv_at (e : trivialization R F E) (b : B)
     have A : (b, (e ⟨b, v⟩).snd) = e ⟨b, v⟩,
     { refine prod.ext _ rfl,
       symmetry,
-      exact bundle_trivialization.coe_fst' _ hb },
+      exact topological_fiber_bundle.trivialization.coe_fst' _ hb },
     have B : e.to_local_homeomorph.symm (e ⟨b, v⟩) = ⟨b, v⟩,
     { apply local_homeomorph.left_inv_on,
-      rw bundle_trivialization.mem_source,
+      rw topological_fiber_bundle.trivialization.mem_source,
       exact hb },
     rw [A, B],
   end,
@@ -154,14 +154,14 @@ def trivialization.continuous_linear_equiv_at (e : trivialization R F E) (b : B)
     assume v,
     have B : e (e.to_local_homeomorph.symm (b, v)) = (b, v),
     { apply local_homeomorph.right_inv_on,
-      rw bundle_trivialization.mem_target,
+      rw topological_fiber_bundle.trivialization.mem_target,
       exact hb },
     have C : (e (e.to_local_homeomorph.symm (b, v))).2 = v, by rw [B],
     conv_rhs { rw ← C },
     dsimp,
     congr,
     ext,
-    { exact (bundle_trivialization.proj_symm_apply' _ hb).symm },
+    { exact (topological_fiber_bundle.trivialization.proj_symm_apply' _ hb).symm },
     { exact (cast_heq _ _).trans (by refl) },
   end,
   map_add' := λ v w, (e.linear _ hb).map_add v w,
@@ -170,30 +170,31 @@ def trivialization.continuous_linear_equiv_at (e : trivialization R F E) (b : B)
     refine continuous_snd.comp _,
     apply continuous_on.comp_continuous e.to_local_homeomorph.continuous_on
       (topological_vector_bundle.inducing R F E b).continuous (λ x, _),
-    rw bundle_trivialization.mem_source,
+    rw topological_fiber_bundle.trivialization.mem_source,
     exact hb,
   end,
   continuous_inv_fun := begin
     rw (topological_vector_bundle.inducing R F E b).continuous_iff,
     dsimp,
-    have : continuous (λ (z : F), (e.to_bundle_trivialization.to_local_homeomorph.symm) (b, z)),
+    have : continuous (λ (z : F), (e.to_trivialization.to_local_homeomorph.symm) (b, z)),
     { apply e.to_local_homeomorph.symm.continuous_on.comp_continuous
         (continuous_const.prod_mk continuous_id') (λ z, _),
-      simp only [bundle_trivialization.mem_target, hb, local_equiv.symm_source,
+      simp only [topological_fiber_bundle.trivialization.mem_target, hb, local_equiv.symm_source,
         local_homeomorph.symm_to_local_equiv] },
     convert this,
     ext z,
-    { exact (bundle_trivialization.proj_symm_apply' _ hb).symm },
+    { exact (topological_fiber_bundle.trivialization.proj_symm_apply' _ hb).symm },
     { exact cast_heq _ _ },
   end }
 
-@[simp] lemma trivialization.continuous_linear_equiv_at_apply (e : trivialization R F E) (b : B)
+@[simp] lemma continuous_linear_equiv_at_apply (e : trivialization R F E) (b : B)
   (hb : b ∈ e.base_set) (y : E b) : e.continuous_linear_equiv_at b hb y = (e ⟨b, y⟩).2 := rfl
 
-@[simp] lemma trivialization.continuous_linear_equiv_at_apply' (e : trivialization R F E)
+@[simp] lemma continuous_linear_equiv_at_apply' (e : trivialization R F E)
   (x : total_space E) (hx : x ∈ e.source) :
-  e.continuous_linear_equiv_at (proj E x) (e.mem_source.1 hx) x.2 = (e x).2 :=
-by { cases x, refl }
+  e.continuous_linear_equiv_at (proj E x) (e.mem_source.1 hx) x.2 = (e x).2 := by { cases x, refl }
+
+end trivialization
 
 section
 local attribute [reducible] bundle.trivial
@@ -211,7 +212,7 @@ end
 
 variables (R B F)
 /-- Local trivialization for trivial bundle. -/
-def trivial_bundle_trivialization : trivialization R F (bundle.trivial B F) :=
+def trivial_topological_vector_bundle.trivialization : trivialization R F (bundle.trivial B F) :=
 { to_fun := λ x, (x.fst, x.snd),
   inv_fun := λ y, ⟨y.fst, y.snd⟩,
   source := univ,
@@ -236,7 +237,7 @@ def trivial_bundle_trivialization : trivialization R F (bundle.trivial B F) :=
 
 instance trivial_bundle.topological_vector_bundle :
   topological_vector_bundle R F (bundle.trivial B F) :=
-{ locally_trivial := λ x, ⟨trivial_bundle_trivialization R B F, mem_univ x⟩,
+{ locally_trivial := λ x, ⟨trivial_topological_vector_bundle.trivialization R B F, mem_univ x⟩,
   inducing := λ b, ⟨begin
     have : (λ (x : trivial B F b), x) = @id F, by { ext x, refl },
     simp only [total_space.topological_space, induced_inf, induced_compose, function.comp, proj,
@@ -249,7 +250,7 @@ variables {R B F}
 /- Not registered as an instance because of a metavariable. -/
 lemma is_topological_vector_bundle_is_topological_fiber_bundle :
   is_topological_fiber_bundle F (proj E) :=
-λ x, ⟨(trivialization_at R F E x).to_bundle_trivialization, mem_base_set_trivialization_at R F E x⟩
+λ x, ⟨(trivialization_at R F E x).to_trivialization, mem_base_set_trivialization_at R F E x⟩
 
 end topological_vector_bundle
 


### PR DESCRIPTION
In this PR I changed
- `prebundle_trivialization` to `topological_fiber_bundle.pretrivialization`
- `bundle_trivialization` to `topological_fiber_bundle.trivialization`

so to make names consistent with `vector_bundle`. I also changed the name of the file for consistency.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
