### PR TITLE
[Merged by Bors] - refactor(algebra/ordered_ring): use `mul_le_mul'` for `canonically_ordered_comm_semiring`

### DIFF
--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -405,7 +405,7 @@ begin
   induction s using finset.induction with a s has ih h,
   { simp },
   { rw [finset.prod_insert has, finset.prod_insert has],
-    apply canonically_ordered_semiring.mul_le_mul,
+    apply mul_le_mul',
     { exact h _ (finset.mem_insert_self a s) },
     { exact ih (λ i hi, h _ (finset.mem_insert_of_mem hi)) } }
 end
@@ -418,9 +418,9 @@ lemma prod_add_prod_le' (hi : i ∈ s) (h2i : g i + h i ≤ f i)
   ∏ i in s, g i + ∏ i in s, h i ≤ ∏ i in s, f i :=
 begin
   classical, simp_rw [prod_eq_mul_prod_diff_singleton hi],
-  refine le_trans _ (canonically_ordered_semiring.mul_le_mul_right' h2i _),
+  refine le_trans _ (mul_le_mul_right' h2i _),
   rw [right_distrib],
-  apply add_le_add; apply canonically_ordered_semiring.mul_le_mul_left'; apply prod_le_prod';
+  apply add_le_add; apply mul_le_mul_left'; apply prod_le_prod';
   simp only [and_imp, mem_sdiff, mem_singleton]; intros; apply_assumption; assumption
 end
 

--- a/src/algebra/group_power/order.lean
+++ b/src/algebra/group_power/order.lean
@@ -72,17 +72,17 @@ end
 
 end cancel_add_monoid
 
-namespace canonically_ordered_semiring
+namespace canonically_ordered_comm_semiring
 variable [canonically_ordered_comm_semiring R]
 
 theorem pow_pos {a : R} (H : 0 < a) : ∀ n : ℕ, 0 < a ^ n
-| 0     := by { nontriviality, rw pow_zero, exact canonically_ordered_semiring.zero_lt_one }
-| (n+1) := by { rw pow_succ, exact canonically_ordered_semiring.mul_pos.2 ⟨H, pow_pos n⟩ }
+| 0     := by { nontriviality, rw pow_zero, exact zero_lt_one }
+| (n+1) := by { rw pow_succ, exact mul_pos.2 ⟨H, pow_pos n⟩ }
 
 @[mono] lemma pow_le_pow_of_le_left {a b : R} (hab : a ≤ b) : ∀ i : ℕ, a^i ≤ b^i
 | 0     := by simp
 | (k+1) := by { rw [pow_succ, pow_succ],
-    exact canonically_ordered_semiring.mul_le_mul hab (pow_le_pow_of_le_left k) }
+    exact mul_le_mul' hab (pow_le_pow_of_le_left k) }
 
 theorem one_le_pow_of_one_le {a : R} (H : 1 ≤ a) (n : ℕ) : 1 ≤ a ^ n :=
 by simpa only [one_pow] using pow_le_pow_of_le_left H n
@@ -90,7 +90,7 @@ by simpa only [one_pow] using pow_le_pow_of_le_left H n
 theorem pow_le_one {a : R} (H : a ≤ 1) (n : ℕ) : a ^ n ≤ 1:=
 by simpa only [one_pow] using pow_le_pow_of_le_left H n
 
-end canonically_ordered_semiring
+end canonically_ordered_comm_semiring
 
 section ordered_semiring
 variable [ordered_semiring R]

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -1333,29 +1333,21 @@ class canonically_ordered_comm_semiring (α : Type*) extends
   canonically_ordered_add_monoid α, comm_semiring α :=
 (eq_zero_or_eq_zero_of_mul_eq_zero : ∀ a b : α, a * b = 0 → a = 0 ∨ b = 0)
 
-namespace canonically_ordered_semiring
+namespace canonically_ordered_comm_semiring
 variables [canonically_ordered_comm_semiring α] {a b : α}
 
-open canonically_ordered_add_monoid (le_iff_exists_add)
-
 @[priority 100] -- see Note [lower instance priority]
-instance canonically_ordered_comm_semiring.to_no_zero_divisors :
-  no_zero_divisors α :=
+instance to_no_zero_divisors : no_zero_divisors α :=
 ⟨canonically_ordered_comm_semiring.eq_zero_or_eq_zero_of_mul_eq_zero⟩
 
-lemma mul_le_mul {a b c d : α} (hab : a ≤ b) (hcd : c ≤ d) : a * c ≤ b * d :=
+@[priority 100] -- see Note [lower instance priority]
+instance to_covariant_mul_le : covariant_class α α (*) (≤) :=
 begin
-  rcases (le_iff_exists_add _ _).1 hab with ⟨b, rfl⟩,
-  rcases (le_iff_exists_add _ _).1 hcd with ⟨d, rfl⟩,
-  suffices : a * c ≤ a * c + (a * d + b * c + b * d), by simpa [mul_add, add_mul, add_assoc],
-  exact (le_iff_exists_add _ _).2 ⟨_, rfl⟩
+  refine ⟨λ a b c h, _⟩,
+  rcases le_iff_exists_add.1 h with ⟨c, rfl⟩,
+  rw mul_add,
+  apply self_le_add_right
 end
-
-lemma mul_le_mul_left' {b c : α} (h : b ≤ c) (a : α) : a * b ≤ a * c :=
-mul_le_mul le_rfl h
-
-lemma mul_le_mul_right' {b c : α} (h : b ≤ c) (a : α) : b * a ≤ c * a :=
-mul_le_mul h le_rfl
 
 /-- A version of `zero_lt_one : 0 < 1` for a `canonically_ordered_comm_semiring`. -/
 lemma zero_lt_one [nontrivial α] : (0:α) < 1 := (zero_le 1).lt_of_ne zero_ne_one
@@ -1363,7 +1355,7 @@ lemma zero_lt_one [nontrivial α] : (0:α) < 1 := (zero_le 1).lt_of_ne zero_ne_o
 lemma mul_pos : 0 < a * b ↔ (0 < a) ∧ (0 < b) :=
 by simp only [pos_iff_ne_zero, ne.def, mul_eq_zero, not_or_distrib]
 
-end canonically_ordered_semiring
+end canonically_ordered_comm_semiring
 
 /-! ### Structures involving `*` and `0` on `with_top` and `with_bot`
 

--- a/src/algebra/squarefree.lean
+++ b/src/algebra/squarefree.lean
@@ -217,7 +217,7 @@ begin
   simp only [finset.sep_def, S, finset.mem_filter, finset.mem_range] at hs,
   obtain ⟨hsn1, ⟨a, hsa⟩, ⟨b, hsb⟩⟩ := hs,
   rw hsa at hn,
-  obtain ⟨hlts, hlta⟩ := canonically_ordered_semiring.mul_pos.mp hn,
+  obtain ⟨hlts, hlta⟩ := canonically_ordered_comm_semiring.mul_pos.mp hn,
   rw hsb at hsa hn hlts,
   refine ⟨a, b, hlta, (pow_pos_iff zero_lt_two).mp hlts, hsa.symm, _⟩,
   rintro x ⟨y, hy⟩,

--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -418,7 +418,7 @@ begin
         rw [mul_rpow, mul_left_comm, ← rpow_mul _ _ p, div_mul_cancel _ hpq.ne_zero, div_rpow,
           div_mul_div, mul_comm (G ^ q), mul_div_mul_right],
         { nth_rewrite 1 [← mul_one ((f i) ^ p)],
-          exact canonically_ordered_semiring.mul_le_mul (le_refl _) (div_self_le _) },
+          exact mul_le_mul_left' (div_self_le _) _ },
         { simpa [hpq.symm.ne_zero] using hG }
       end }
 end
@@ -444,8 +444,8 @@ begin
       simpa [hpq.symm.ne_zero] using hf } },
   { rintros _ ⟨g, hg, rfl⟩,
     apply le_trans (inner_le_Lp_mul_Lq s f g hpq),
-    simpa only [mul_one] using canonically_ordered_semiring.mul_le_mul (le_refl _)
-      (nnreal.rpow_le_one hg (le_of_lt hpq.symm.one_div_pos)) }
+    simpa only [mul_one] using mul_le_mul_left'
+      (nnreal.rpow_le_one hg (le_of_lt hpq.symm.one_div_pos)) _ }
 end
 
 /-- Minkowski inequality: the `L_p` seminorm of the sum of two vectors is less than or equal

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -378,7 +378,8 @@ begin
   { rw [ennreal.sub_eq_zero_of_le hr, ennreal.inv_zero, ennreal.tsum_eq_supr_nat, supr_eq_top],
     refine λ a ha, (ennreal.exists_nat_gt (lt_top_iff_ne_top.1 ha)).imp
       (λ n hn, lt_of_lt_of_le hn _),
-    have : ∀ k:ℕ, 1 ≤ r^k, by simpa using canonically_ordered_semiring.pow_le_pow_of_le_left hr,
+    have : ∀ k:ℕ, 1 ≤ r^k,
+      by simpa using canonically_ordered_comm_semiring.pow_le_pow_of_le_left hr,
     calc (n:ℝ≥0∞) = (∑ i in range n, 1) : by rw [sum_const, nsmul_one, card_range]
     ... ≤ ∑ i in range n, r ^ i : sum_le_sum (λ k _, this k) }
 end

--- a/src/data/nat/pow.lean
+++ b/src/data/nat/pow.lean
@@ -15,12 +15,12 @@ namespace nat
 
 /-! ### `pow` -/
 
--- This is redundant with `canonically_ordered_semiring.pow_le_pow_of_le_left`,
--- but `canonically_ordered_semiring` is not such an obvious abstraction, and also quite long.
+-- This is redundant with `canonically_ordered_comm_semiring.pow_le_pow_of_le_left`,
+-- but `canonically_ordered_comm_semiring` is not such an obvious abstraction, and also quite long.
 -- So, we leave a version in the `nat` namespace as well.
 -- (The global `pow_le_pow_of_le_left` needs an extra hypothesis `0 ≤ x`.)
 protected theorem pow_le_pow_of_le_left {x y : ℕ} (H : x ≤ y) : ∀ i : ℕ, x^i ≤ y^i :=
-canonically_ordered_semiring.pow_le_pow_of_le_left H
+canonically_ordered_comm_semiring.pow_le_pow_of_le_left H
 
 theorem pow_le_pow_of_le_right {x : ℕ} (H : x > 0) {i : ℕ} : ∀ {j}, i ≤ j → x^i ≤ x^j
 | 0        h := by rw eq_zero_of_le_zero h; apply le_refl

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -214,7 +214,7 @@ lemma coe_mono : monotone (coe : ℝ≥0 → ℝ≥0∞) := λ _ _, coe_le_coe.2
 lemma coe_two : ((2:ℝ≥0) : ℝ≥0∞) = 2 := by norm_cast
 
 protected lemma zero_lt_one : 0 < (1 : ℝ≥0∞) :=
-  canonically_ordered_semiring.zero_lt_one
+  canonically_ordered_comm_semiring.zero_lt_one
 
 @[simp] lemma one_lt_two : (1 : ℝ≥0∞) < 2 :=
 coe_one ▸ coe_two ▸ by exact_mod_cast (@one_lt_two ℕ _ _)
@@ -455,7 +455,7 @@ by simp only [nonpos_iff_eq_zero.symm, max_le_iff]
 eq_of_forall_ge_iff $ λ c, sup_le_iff.trans max_le_iff.symm
 
 protected lemma pow_pos : 0 < a → ∀ n : ℕ, 0 < a^n :=
-  canonically_ordered_semiring.pow_pos
+  canonically_ordered_comm_semiring.pow_pos
 
 protected lemma pow_ne_zero : a ≠ 0 → ∀ n : ℕ, a^n ≠ 0 :=
 by simpa only [pos_iff_ne_zero] using ennreal.pow_pos
@@ -586,7 +586,7 @@ end complete_lattice
 section mul
 
 @[mono] lemma mul_le_mul : a ≤ b → c ≤ d → a * c ≤ b * d :=
-canonically_ordered_semiring.mul_le_mul
+mul_le_mul'
 
 @[mono] lemma mul_lt_mul (ac : a < c) (bd : b < d) : a * b < c * d :=
 begin

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -295,7 +295,10 @@ instance : linear_ordered_semiring ℝ≥0 :=
   zero_le_one                := @zero_le_one ℝ _,
   exists_pair_ne             := ⟨0, 1, ne_of_lt (@zero_lt_one ℝ _ _)⟩,
   .. nnreal.canonically_linear_ordered_add_monoid,
-  .. nnreal.comm_semiring, }
+  .. nnreal.comm_semiring }
+
+instance : ordered_comm_semiring ℝ≥0 :=
+{ .. nnreal.linear_ordered_semiring, .. nnreal.comm_semiring }
 
 instance : linear_ordered_comm_group_with_zero ℝ≥0 :=
 { mul_le_mul_left := assume a b h c, mul_le_mul (le_refl c) h (zero_le a) (zero_le c),

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -700,7 +700,7 @@ calc f.lintegral μ ⊔ g.lintegral μ =
   begin
     rw [map_lintegral, map_lintegral],
     refine sup_le _ _;
-      refine finset.sum_le_sum (λ a _, canonically_ordered_semiring.mul_le_mul _ (le_refl _)),
+      refine finset.sum_le_sum (λ a _, mul_le_mul_right' _ _),
     exact le_sup_left,
     exact le_sup_right
   end
@@ -1118,7 +1118,7 @@ begin
         refine le_of_eq _,
         rw [ennreal.finset_sum_supr_nat],
         assume p i j h,
-        exact canonically_ordered_semiring.mul_le_mul (le_refl _) (measure_mono $ mono p h)
+        exact mul_le_mul_left' (measure_mono $ mono p h) _
       end
     ... ≤ (⨆n:ℕ, ((rs.map c).restrict {a | (rs.map c) a ≤ f n a}).lintegral μ) :
     begin
@@ -1325,8 +1325,7 @@ calc (∫⁻ a, r * f a ∂μ) = (∫⁻ a, (⨆n, (const α r * eapprox f n) a)
     { congr, funext n,
       rw [← simple_func.const_mul_lintegral, ← simple_func.lintegral_eq_lintegral] },
     { assume n, exact simple_func.measurable _ },
-    { assume i j h a, exact canonically_ordered_semiring.mul_le_mul (le_refl _)
-        (monotone_eapprox _ h _) }
+    { assume i j h a, exact mul_le_mul_left' (monotone_eapprox _ h _) _ }
   end
   ... = r * (∫⁻ a, f a ∂μ) : by rw [← ennreal.mul_supr, lintegral_eq_supr_eapprox_lintegral hf]
 
@@ -1349,7 +1348,7 @@ begin
   assume hs,
   rw ← simple_func.const_mul_lintegral,
   refine le_supr_of_le (const α r * s) (le_supr_of_le (λx, _) (le_refl _)),
-  exact canonically_ordered_semiring.mul_le_mul (le_refl _) (hs x)
+  exact mul_le_mul_left' (hs x) _
 end
 
 lemma lintegral_const_mul' (r : ℝ≥0∞) (f : α → ℝ≥0∞) (hr : r ≠ ∞) :
@@ -1363,7 +1362,7 @@ begin
   have := lintegral_const_mul_le (r⁻¹) (λx, r * f x),
   simp [(mul_assoc _ _ _).symm, rinv'] at this,
   simpa [(mul_assoc _ _ _).symm, rinv]
-    using canonically_ordered_semiring.mul_le_mul (le_refl r) this
+    using mul_le_mul_left' this r
 end
 
 lemma lintegral_mul_const (r : ℝ≥0∞) {f : α → ℝ≥0∞} (hf : measurable f) :

--- a/src/ring_theory/perfection.lean
+++ b/src/ring_theory/perfection.lean
@@ -518,8 +518,8 @@ begin
   rw [val_aux_eq hm, val_aux_eq hn, val_aux_eq hk, ring_hom.map_add],
   cases le_max_iff.1
     (mod_p.pre_val_add (coeff _ _ (max (max m n) k) f) (coeff _ _ (max (max m n) k) g)) with h h,
-  { exact le_max_of_le_left (canonically_ordered_semiring.pow_le_pow_of_le_left h _) },
-  { exact le_max_of_le_right (canonically_ordered_semiring.pow_le_pow_of_le_left h _) }
+  { exact le_max_of_le_left (canonically_ordered_comm_semiring.pow_le_pow_of_le_left h _) },
+  { exact le_max_of_le_right (canonically_ordered_comm_semiring.pow_le_pow_of_le_left h _) }
 end
 
 variables (K v O hv p)

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -767,9 +767,9 @@ begin
     right, by_cases hb : b = 0, { left, exact hb },
     right, rw [← ne, ← one_le_iff_ne_zero] at ha hb, split,
     { rw [← mul_one a],
-      refine lt_of_le_of_lt (canonically_ordered_semiring.mul_le_mul (le_refl a) hb) h },
+      refine lt_of_le_of_lt (mul_le_mul' (le_refl a) hb) h },
     { rw [← _root_.one_mul b],
-      refine lt_of_le_of_lt (canonically_ordered_semiring.mul_le_mul ha (le_refl b)) h }},
+      refine lt_of_le_of_lt (mul_le_mul' ha (le_refl b)) h }},
   rintro (rfl|rfl|⟨ha,hb⟩); simp only [*, mul_lt_omega, omega_pos, _root_.zero_mul, mul_zero]
 end
 

--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -235,7 +235,7 @@ theorem mul_eq_self {c : cardinal} (h : omega ≤ c) : c * c = c :=
 begin
   refine le_antisymm _
     (by simpa only [mul_one] using
-      canonically_ordered_semiring.mul_le_mul_left' (one_lt_omega.le.trans h) c),
+      mul_le_mul_left' (one_lt_omega.le.trans h) c),
   -- the only nontrivial part is `c * c ≤ c`. We prove it inductively.
   refine acc.rec_on (cardinal.wf.apply c) (λ c _,
     quotient.induction_on c $ λ α IH ol, _) h,
@@ -286,23 +286,23 @@ of the cardinalities of `α` and `β`. -/
 theorem mul_eq_max {a b : cardinal} (ha : omega ≤ a) (hb : omega ≤ b) : a * b = max a b :=
 le_antisymm
   (mul_eq_self (le_trans ha (le_max_left a b)) ▸
-    canonically_ordered_semiring.mul_le_mul (le_max_left _ _) (le_max_right _ _)) $
+    mul_le_mul' (le_max_left _ _) (le_max_right _ _)) $
 max_le
   (by simpa only [mul_one] using
-    canonically_ordered_semiring.mul_le_mul_left' (one_lt_omega.le.trans hb) a)
+    mul_le_mul_left' (one_lt_omega.le.trans hb) a)
   (by simpa only [one_mul] using
-    canonically_ordered_semiring.mul_le_mul_right' (one_lt_omega.le.trans ha) b)
+    mul_le_mul_right' (one_lt_omega.le.trans ha) b)
 
 theorem mul_lt_of_lt {a b c : cardinal} (hc : omega ≤ c)
   (h1 : a < c) (h2 : b < c) : a * b < c :=
-lt_of_le_of_lt (canonically_ordered_semiring.mul_le_mul (le_max_left a b) (le_max_right a b)) $
+lt_of_le_of_lt (mul_le_mul' (le_max_left a b) (le_max_right a b)) $
 (lt_or_le (max a b) omega).elim
   (λ h, lt_of_lt_of_le (mul_lt_omega h h) hc)
   (λ h, by rw mul_eq_self h; exact max_lt h1 h2)
 
 lemma mul_le_max_of_omega_le_left {a b : cardinal} (h : omega ≤ a) : a * b ≤ max a b :=
 begin
-  convert canonically_ordered_semiring.mul_le_mul (le_max_left a b) (le_max_right a b),
+  convert mul_le_mul' (le_max_left a b) (le_max_right a b),
   rw [mul_eq_self],
   refine le_trans h (le_max_left a b)
 end
@@ -313,7 +313,7 @@ begin
   cases le_or_gt omega b with hb hb, rw [mul_eq_max h hb],
   have : b ≤ a, exact le_trans (le_of_lt hb) h,
   rw [max_eq_left this],
-  convert canonically_ordered_semiring.mul_le_mul_left' (one_le_iff_ne_zero.mpr h') _, rw [mul_one],
+  convert mul_le_mul_left' (one_le_iff_ne_zero.mpr h') _, rw [mul_one],
 end
 
 lemma mul_eq_left {a b : cardinal} (ha : omega ≤ a) (hb : b ≤ a) (hb' : b ≠ 0) : a * b = a :=
@@ -323,7 +323,7 @@ lemma mul_eq_right {a b : cardinal} (hb : omega ≤ b) (ha : a ≤ b) (ha' : a �
 by { rw [mul_comm, mul_eq_left hb ha ha'] }
 
 lemma le_mul_left {a b : cardinal} (h : b ≠ 0) : a ≤ b * a :=
-by { convert canonically_ordered_semiring.mul_le_mul_right' (one_le_iff_ne_zero.mpr h) _,
+by { convert mul_le_mul_right' (one_le_iff_ne_zero.mpr h) _,
   rw [one_mul] }
 
 lemma le_mul_right {a b : cardinal} (h : b ≠ 0) : a ≤ a * b :=
@@ -357,7 +357,7 @@ end
 theorem add_eq_self {c : cardinal} (h : omega ≤ c) : c + c = c :=
 le_antisymm
   (by simpa only [nat.cast_bit0, nat.cast_one, mul_eq_self h, two_mul] using
-     canonically_ordered_semiring.mul_le_mul_right' ((nat_lt_omega 2).le.trans h) c)
+     mul_le_mul_right' ((nat_lt_omega 2).le.trans h) c)
   (self_le_add_left c c)
 
 /-- If `α` is an infinite type, then the cardinality of `α ⊕ β` is the maximum
@@ -439,7 +439,7 @@ H3.symm ▸ (quotient.induction_on κ (λ α H1, nat.rec_on n
     from one_lt_omega) H1)
   (λ n ih, trans_rel_left _
     (by { rw [nat.cast_succ, power_add, power_one];
-      exact canonically_ordered_semiring.mul_le_mul_right' ih _ })
+      exact mul_le_mul_right' ih _ })
     (mul_eq_self H1))) H1)
 
 lemma power_self_eq {c : cardinal} (h : omega ≤ c) : c ^ c = 2 ^ c :=

--- a/src/set_theory/cofinality.lean
+++ b/src/set_theory/cofinality.lean
@@ -483,7 +483,7 @@ theorem succ_is_regular {c : cardinal.{u}} (h : omega ≤ c) : is_regular (succ 
   rcases cof_eq' r this with ⟨S, H, Se⟩,
   rw [← Se],
   apply lt_imp_lt_of_le_imp_le
-    (λ (h : mk S ≤ c), canonically_ordered_semiring.mul_le_mul_right' h c),
+    (λ (h : mk S ≤ c), mul_le_mul_right' h c),
   rw [mul_eq_self h, ← succ_le, ← αe, ← sum_const],
   refine le_trans _ (sum_le_sum (λ x:S, card (typein r x)) _ _),
   { simp [typein, sum_mk (λ x:S, {a//r a x})],

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -438,7 +438,7 @@ begin
       pos_iff_ne_zero.1 (lt_of_lt_of_le (pos_iff_ne_zero.2 hx0) (le_Sup hx)),
     have : Sup ((λb, a * b) '' s) = a * Sup s :=
       is_lub.Sup_eq ((is_lub_Sup s).is_lub_of_tendsto
-        (assume x _ y _ h, canonically_ordered_semiring.mul_le_mul (le_refl _) h)
+        (assume x _ y _ h, mul_le_mul_left' h _)
         ⟨x, hx⟩
         (ennreal.tendsto.const_mul (tendsto_id' inf_le_left) (or.inl s₁))),
     rw [this.symm, Sup_image] }
@@ -1011,7 +1011,7 @@ begin
           ... ≤ f y + C * edist x y : h x y
           ... = f y + C * edist y x : by simp [edist_comm]
           ... ≤ f y + C * (C⁻¹ * (ε/2)) :
-            add_le_add_left (canonically_ordered_semiring.mul_le_mul (le_refl _) (le_of_lt hy)) _
+            add_le_add_left (mul_le_mul_left' (le_of_lt hy) _) _
           ... < f y + ε : (ennreal.add_lt_add_iff_left (lt_top_iff_ne_top.2 htop)).2 I,
         show e < f y, from
           (ennreal.add_lt_add_iff_right ‹ε < ⊤›).1 this }},
@@ -1034,7 +1034,7 @@ begin
       show f y < e, from calc
         f y ≤ f x + C * edist y x : h y x
         ... ≤ f x + C * (C⁻¹ * (ε/2)) :
-            add_le_add_left (canonically_ordered_semiring.mul_le_mul (le_refl _) (le_of_lt hy)) _
+            add_le_add_left (mul_le_mul_left' (le_of_lt hy) _) _
         ... < f x + ε : (ennreal.add_lt_add_iff_left (lt_top_iff_ne_top.2 htop)).2 I
         ... ≤ f x + (e - f x) : add_le_add_left (min_le_left _ _) _
         ... = e : by simp [le_of_lt he] },

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -76,7 +76,7 @@ def candidates : set (prod_space_fun X Y) :=
 
 /-- Version of the set of candidates in bounded_continuous_functions, to apply
 Arzela-Ascoli -/
-private def candidates_b : set (Cb X Y) := {f : Cb X Y | f.to_fun ∈ candidates X Y}
+private def candidates_b : set (Cb X Y) := {f : Cb X Y | (f : _ → ℝ) ∈ candidates X Y}
 
 end definitions --section
 
@@ -244,10 +244,7 @@ begin
                ∩ (⋂x y z, {f : Cb X Y | f (x, z) ≤ f (x, y) + f (y, z)})
                ∩ (⋂x, {f : Cb X Y | f (x, x) = 0})
                ∩ (⋂x y, {f : Cb X Y | f (x, y) ≤ max_var X Y}),
-  { ext,
-    simp only [candidates_b, candidates, mem_inter_eq, mem_Inter, mem_set_of_eq,
-               continuous_map.to_fun_eq_coe],
-    refl },
+  { ext, simp only [candidates_b, candidates, mem_inter_eq, mem_Inter, mem_set_of_eq], refl },
   rw this,
   repeat { apply is_closed.inter _ _
        <|> apply is_closed_Inter _

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -243,8 +243,11 @@ begin
                ∩ (⋂x y, {f : Cb X Y | f (x, y) = f (y, x)})
                ∩ (⋂x y z, {f : Cb X Y | f (x, z) ≤ f (x, y) + f (y, z)})
                ∩ (⋂x, {f : Cb X Y | f (x, x) = 0})
-               ∩ (⋂x y, {f : Cb X Y | f (x, y) ≤ max_var X Y}) :=
-    begin ext, unfold candidates_b, unfold candidates, simp [-sum.forall], refl end,
+               ∩ (⋂x y, {f : Cb X Y | f (x, y) ≤ max_var X Y}),
+  { ext,
+    simp only [candidates_b, candidates, mem_inter_eq, mem_Inter, mem_set_of_eq,
+               continuous_map.to_fun_eq_coe],
+    refl },
   rw this,
   repeat { apply is_closed.inter _ _
        <|> apply is_closed_Inter _

--- a/src/topology/metric_space/lipschitz.lean
+++ b/src/topology/metric_space/lipschitz.lean
@@ -129,7 +129,7 @@ protected lemma uniform_continuous (hf : lipschitz_with K f) :
   uniform_continuous f :=
 begin
   refine emetric.uniform_continuous_iff.2 (λε εpos, _),
-  use [ε/K, canonically_ordered_semiring.mul_pos.2 ⟨εpos, ennreal.inv_pos.2 $ ennreal.coe_ne_top⟩],
+  use [ε / K, ennreal.div_pos_iff.2 ⟨ne_of_gt εpos, ennreal.coe_ne_top⟩],
   assume x y Dxy,
   apply lt_of_le_of_lt (hf.edist_le_mul x y),
   rw [mul_comm],


### PR DESCRIPTION
* use `canonically_ordered_comm_semiring`, not `canonically_ordered_semiring` as a namespace;
* add an instance `canonically_ordered_comm_semiring.to_covariant_mul_le`;
* drop `canonically_ordered_semiring.mul_le_mul` etc in favor of `mul_le_mul'` etc.

---
- [x] depends on: #8287 fix a timeout

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
