### PR TITLE
[Merged by Bors] - refactor(measure_theory/measure_space): use `covariant_class` instead of `add_le_add`

### DIFF
--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -461,17 +461,8 @@ lt_iff_le_not_le.trans $ and_congr iff.rfl $ by simp only [le_iff, not_forall, n
 theorem lt_iff' : μ < ν ↔ μ ≤ ν ∧ ∃ s, μ s < ν s :=
 lt_iff_le_not_le.trans $ and_congr iff.rfl $ by simp only [le_iff', not_forall, not_le]
 
--- TODO: add typeclasses for `∀ c, monotone ((*) c)` and `∀ c, monotone ((+) c)`
-
-protected lemma add_le_add_left (ν : measure α) (hμ : μ₁ ≤ μ₂) : ν + μ₁ ≤ ν + μ₂ :=
-λ s hs, add_le_add_left (hμ s hs) _
-
-protected lemma add_le_add_right (hμ : μ₁ ≤ μ₂) (ν : measure α) : μ₁ + ν ≤ μ₂ + ν :=
-λ s hs, add_le_add_right (hμ s hs) _
-
-protected lemma add_le_add (hμ : μ₁ ≤ μ₂) (hν : ν₁ ≤ ν₂) :
-  μ₁ + ν₁ ≤ μ₂ + ν₂ :=
-λ s hs, add_le_add (hμ s hs) (hν s hs)
+instance covariant_add_le : covariant_class (measure α) (measure α) (+) (≤) :=
+⟨λ ν μ₁ μ₂ hμ s hs, add_le_add_left (hμ s hs) _⟩
 
 protected lemma le_add_left (h : μ ≤ ν) : μ ≤ ν' + ν :=
 λ s hs, le_add_left (h s hs)


### PR DESCRIPTION
---
- [x] depends on: #8287 fix a timeout

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
