### PR TITLE
[Merged by Bors] - feat(topology/continuous_function/bounded): prove `norm_eq_supr_norm`

### DIFF
--- a/src/topology/continuous_function/bounded.lean
+++ b/src/topology/continuous_function/bounded.lean
@@ -532,12 +532,7 @@ of_normed_group (norm ∘ f) (by continuity) ∥f∥ (λ x, by simp only [f.norm
 by simp only [norm_eq, coe_norm_comp, norm_norm]
 
 lemma bdd_above_range_norm_comp : bdd_above $ set.range $ norm ∘ f :=
-begin
-  rw ← coe_norm_comp,
-  suffices : metric.bounded (set.range f.norm_comp),
-  { rw real.bounded_iff_bdd_below_bdd_above at this, exact this.2, },
-  apply bounded_range,
-end
+(real.bounded_iff_bdd_below_bdd_above.mp $ @bounded_range _ _ _ _ f.norm_comp).2
 
 /-- When the domain is non-empty, we do not need the `0 ≤ C` condition in the formula for ∥f∥ as an
 `Inf`. -/

--- a/src/topology/continuous_function/bounded.lean
+++ b/src/topology/continuous_function/bounded.lean
@@ -443,6 +443,25 @@ lemma norm_eq (f : α →ᵇ β) :
   ∥f∥ = Inf {C : ℝ | 0 ≤ C ∧ ∀ (x : α), ∥f x∥ ≤ C} :=
 by simp [norm_def, bounded_continuous_function.dist_eq]
 
+/-- When the domain is non-empty, we do not need the `0 ≤ C` condition in the formula for ∥f∥ as an
+`Inf`. -/
+lemma norm_eq_of_non_empty [h : nonempty α] : ∥f∥ = Inf {C : ℝ | ∀ (x : α), ∥f x∥ ≤ C} :=
+begin
+  unfreezingI { obtain ⟨a⟩ := h, },
+  rw norm_eq,
+  congr,
+  ext,
+  simp only [and_iff_right_iff_imp],
+  exact λ h', le_trans (norm_nonneg (f a)) (h' a),
+end
+
+@[simp] lemma norm_eq_zero_of_empty [h : is_empty α] : ∥f∥ = 0 :=
+begin
+  have h' : ∀ (C : ℝ) (x : α), ∥f x∥ ≤ C, { intros, exfalso, apply h.false, use x, },
+  simp only [norm_eq, h', and_true, implies_true_iff],
+  exact cInf_Ici,
+end
+
 lemma norm_coe_le_norm (x : α) : ∥f x∥ ≤ ∥f∥ := calc
   ∥f x∥ = dist (f x) ((0 : α →ᵇ β) x) : by simp [dist_zero_right]
   ... ≤ ∥f∥ : dist_coe_le_dist _
@@ -533,25 +552,6 @@ by simp only [norm_eq, coe_norm_comp, norm_norm]
 
 lemma bdd_above_range_norm_comp : bdd_above $ set.range $ norm ∘ f :=
 (real.bounded_iff_bdd_below_bdd_above.mp $ @bounded_range _ _ _ _ f.norm_comp).2
-
-/-- When the domain is non-empty, we do not need the `0 ≤ C` condition in the formula for ∥f∥ as an
-`Inf`. -/
-lemma norm_eq_of_non_empty [h : nonempty α] : ∥f∥ = Inf {C : ℝ | ∀ (x : α), ∥f x∥ ≤ C} :=
-begin
-  unfreezingI { obtain ⟨a⟩ := h, },
-  rw norm_eq,
-  congr,
-  ext,
-  simp only [and_iff_right_iff_imp],
-  exact λ h', le_trans (norm_nonneg (f a)) (h' a),
-end
-
-@[simp] lemma norm_eq_zero_of_empty [h : is_empty α] : ∥f∥ = 0 :=
-begin
-  have h' : ∀ (C : ℝ) (x : α), ∥f x∥ ≤ C, { intros, exfalso, apply h.false, use x, },
-  simp only [norm_eq, h', and_true, implies_true_iff],
-  exact cInf_Ici,
-end
 
 lemma norm_eq_supr_norm : ∥f∥ = ⨆ x : α, ∥f x∥ :=
 begin

--- a/src/topology/continuous_function/bounded.lean
+++ b/src/topology/continuous_function/bounded.lean
@@ -541,7 +541,7 @@ end
 
 /-- When the domain is non-empty, we do not need the `0 ≤ C` condition in the formula for ∥f∥ as an
 `Inf`. -/
-lemma norm_of_non_empty_eq [h : nonempty α] : ∥f∥ = Inf {C : ℝ | ∀ (x : α), ∥f x∥ ≤ C} :=
+lemma norm_eq_of_non_empty [h : nonempty α] : ∥f∥ = Inf {C : ℝ | ∀ (x : α), ∥f x∥ ≤ C} :=
 begin
   unfreezingI { obtain ⟨a⟩ := h, },
   rw norm_eq,
@@ -551,7 +551,7 @@ begin
   exact λ h', le_trans (norm_nonneg (f a)) (h' a),
 end
 
-@[simp] lemma norm_of_empty_eq_zero (h : ¬ nonempty α) : ∥f∥ = 0 :=
+@[simp] lemma norm_eq_zero_of_empty (h : ¬ nonempty α) : ∥f∥ = 0 :=
 begin
   have h' : ∀ (C : ℝ) (x : α), ∥f x∥ ≤ C, { intros, exfalso, apply h, use x, },
   simp only [norm_eq, h', and_true, implies_true_iff],
@@ -562,13 +562,13 @@ lemma norm_eq_supr_norm : ∥f∥ = ⨆ x : α, ∥f x∥ :=
 begin
   by_cases hα : nonempty α,
   { haveI := hα,
-    rw [norm_of_non_empty_eq, supr,
+    rw [norm_eq_of_non_empty, supr,
       ← cInf_upper_bounds_eq_cSup f.bdd_above_range_norm_comp (set.range_nonempty _)],
     congr,
     ext,
     simp only [forall_apply_eq_imp_iff', set.mem_range, exists_imp_distrib], },
   { suffices : set.range (norm ∘ f) = ∅,
-    { rw [f.norm_of_empty_eq_zero hα, supr, this, real.Sup_empty], },
+    { rw [f.norm_eq_zero_of_empty hα, supr, this, real.Sup_empty], },
     exact set.range_eq_empty.mpr hα, },
 end
 

--- a/src/topology/continuous_function/bounded.lean
+++ b/src/topology/continuous_function/bounded.lean
@@ -551,25 +551,23 @@ begin
   exact λ h', le_trans (norm_nonneg (f a)) (h' a),
 end
 
-@[simp] lemma norm_eq_zero_of_empty (h : ¬ nonempty α) : ∥f∥ = 0 :=
+@[simp] lemma norm_eq_zero_of_empty [h : is_empty α] : ∥f∥ = 0 :=
 begin
-  have h' : ∀ (C : ℝ) (x : α), ∥f x∥ ≤ C, { intros, exfalso, apply h, use x, },
+  have h' : ∀ (C : ℝ) (x : α), ∥f x∥ ≤ C, { intros, exfalso, apply h.false, use x, },
   simp only [norm_eq, h', and_true, implies_true_iff],
   exact cInf_Ici,
 end
 
 lemma norm_eq_supr_norm : ∥f∥ = ⨆ x : α, ∥f x∥ :=
 begin
-  by_cases hα : nonempty α,
-  { haveI := hα,
-    rw [norm_eq_of_non_empty, supr,
-      ← cInf_upper_bounds_eq_cSup f.bdd_above_range_norm_comp (set.range_nonempty _)],
+  casesI is_empty_or_nonempty α with hα _,
+  { suffices : range (norm ∘ f) = ∅, { rw [f.norm_eq_zero_of_empty, supr, this, real.Sup_empty], },
+    simp only [hα, range_eq_empty, not_nonempty_iff], },
+  { rw [norm_eq_of_non_empty, supr,
+      ← cInf_upper_bounds_eq_cSup f.bdd_above_range_norm_comp (range_nonempty _)],
     congr,
     ext,
-    simp only [forall_apply_eq_imp_iff', set.mem_range, exists_imp_distrib], },
-  { suffices : set.range (norm ∘ f) = ∅,
-    { rw [f.norm_eq_zero_of_empty hα, supr, this, real.Sup_empty], },
-    exact set.range_eq_empty.mpr hα, },
+    simp only [forall_apply_eq_imp_iff', mem_range, exists_imp_distrib], },
 end
 
 /-- The pointwise sum of two bounded continuous functions is again bounded continuous. -/

--- a/src/topology/continuous_function/bounded.lean
+++ b/src/topology/continuous_function/bounded.lean
@@ -445,7 +445,7 @@ by simp [norm_def, bounded_continuous_function.dist_eq]
 
 /-- When the domain is non-empty, we do not need the `0 ≤ C` condition in the formula for ∥f∥ as an
 `Inf`. -/
-lemma norm_eq_of_non_empty [h : nonempty α] : ∥f∥ = Inf {C : ℝ | ∀ (x : α), ∥f x∥ ≤ C} :=
+lemma norm_eq_of_nonempty [h : nonempty α] : ∥f∥ = Inf {C : ℝ | ∀ (x : α), ∥f x∥ ≤ C} :=
 begin
   unfreezingI { obtain ⟨a⟩ := h, },
   rw norm_eq,
@@ -558,7 +558,7 @@ begin
   casesI is_empty_or_nonempty α with hα _,
   { suffices : range (norm ∘ f) = ∅, { rw [f.norm_eq_zero_of_empty, supr, this, real.Sup_empty], },
     simp only [hα, range_eq_empty, not_nonempty_iff], },
-  { rw [norm_eq_of_non_empty, supr,
+  { rw [norm_eq_of_nonempty, supr,
       ← cInf_upper_bounds_eq_cSup f.bdd_above_range_norm_comp (range_nonempty _)],
     congr,
     ext,

--- a/src/topology/continuous_function/compact.lean
+++ b/src/topology/continuous_function/compact.lean
@@ -163,6 +163,17 @@ le_trans (le_abs.mpr (or.inl (le_refl (f x)))) (f.norm_coe_le_norm x)
 lemma neg_norm_le_apply (f : C(α, ℝ)) (x : α) : -∥f∥ ≤ f x :=
 le_trans (neg_le_neg (f.norm_coe_le_norm x)) (neg_le.mp (neg_le_abs_self (f x)))
 
+@[simp] lemma _root_.bounded_continuous_function.norm_forget_boundedness_eq (f : α →ᵇ β) :
+∥forget_boundedness α β f∥ = ∥f∥ :=
+rfl
+
+lemma norm_eq_supr_norm : ∥f∥ = ⨆ x : α, ∥f x∥ :=
+begin
+  equiv_rw equiv_bounded_of_compact α β at f,
+  rw [equiv_bounded_of_compact_symm_apply, forget_boundedness_coe, f.norm_forget_boundedness_eq,
+    f.norm_eq_supr_norm],
+end
+
 end
 
 section

--- a/src/topology/continuous_function/compact.lean
+++ b/src/topology/continuous_function/compact.lean
@@ -164,7 +164,7 @@ lemma neg_norm_le_apply (f : C(α, ℝ)) (x : α) : -∥f∥ ≤ f x :=
 le_trans (neg_le_neg (f.norm_coe_le_norm x)) (neg_le.mp (neg_le_abs_self (f x)))
 
 @[simp] lemma _root_.bounded_continuous_function.norm_forget_boundedness_eq (f : α →ᵇ β) :
-∥forget_boundedness α β f∥ = ∥f∥ :=
+  ∥forget_boundedness α β f∥ = ∥f∥ :=
 rfl
 
 lemma norm_eq_supr_norm : ∥f∥ = ⨆ x : α, ∥f x∥ :=


### PR DESCRIPTION
More precisely we prove both:
 * `bounded_continuous_function.norm_eq_supr_norm`
 * `continuous_map.norm_eq_supr_norm`

We also introduce one new definition: `bounded_continuous_function.norm_comp`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
