### PR TITLE
[Merged by Bors] - feat(ring_theory): (fractional) ideals are finitely generated if they are invertible

### DIFF
--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -632,9 +632,50 @@ begin
   exact ⟨s, hs1, hs⟩,
 end
 
+omit loc
+
+lemma mem_span_mul_finite_of_mem_mul
+  {I J : fractional_ideal S P} {x : P} (hx : x ∈ I * J) :
+  ∃ (T T' : finset P), (T : set P) ⊆ I ∧ (T' : set P) ⊆ J ∧ x ∈ span R (T * T' : set P) :=
+submodule.mem_span_mul_finite_of_mem_mul (by simpa using mem_coe.mpr hx)
+
+variables (S)
+
+lemma coe_ideal_fg (inj : function.injective (algebra_map R P)) (I : ideal R) :
+  fg ((I : fractional_ideal S P) : submodule R P) ↔ fg I :=
+coe_submodule_fg _ inj _
+
+variables {S}
+
+lemma fg_unit (inj : function.injective (algebra_map R P))
+  (I : units (fractional_ideal S P)) :
+  fg (I : submodule R P) :=
+begin
+  have : (1 : P) ∈ (I * ↑I⁻¹ : fractional_ideal S P),
+  { rw units.mul_inv, exact one_mem_one _ },
+  obtain ⟨T, T', hT, hT', one_mem⟩ := mem_span_mul_finite_of_mem_mul this,
+  refine ⟨T, submodule.span_eq_of_le _ hT _⟩,
+  rw [← one_mul ↑I, ← mul_one (span R ↑T)],
+  conv_rhs { rw [← fractional_ideal.coe_one, ← units.mul_inv I, fractional_ideal.coe_mul,
+                 mul_comm ↑↑I, ← mul_assoc] },
+  refine submodule.mul_le_mul_left
+    (le_trans _ (submodule.mul_le_mul_right (submodule.span_le.mpr hT'))),
+  rwa [submodule.one_le, submodule.span_mul_span]
+end
+
+lemma fg_of_is_unit (inj : function.injective (algebra_map R P))
+  (I : fractional_ideal S P) (h : is_unit I) :
+  fg (I : submodule R P) :=
+by { rcases h with ⟨I, rfl⟩, exact fg_unit inj I }
+
+lemma _root_.ideal.fg_of_is_unit (inj : function.injective (algebra_map R P))
+  (I : ideal R) (h : is_unit (I : fractional_ideal S P)) :
+  I.fg :=
+by { rw ← coe_ideal_fg S inj I, exact fg_of_is_unit inj I h }
+
 variables (S P P')
 
-include loc'
+include loc loc'
 
 /-- `canonical_equiv f f'` is the canonical equivalence between the fractional
 ideals in `P` and in `P'` -/

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -647,7 +647,7 @@ coe_submodule_fg _ inj _
 
 variables {S}
 
-lemma fg_unit (inj : function.injective (algebra_map R P))
+lemma fg_unit
   (I : units (fractional_ideal S P)) :
   fg (I : submodule R P) :=
 begin
@@ -663,15 +663,15 @@ begin
   rwa [submodule.one_le, submodule.span_mul_span]
 end
 
-lemma fg_of_is_unit (inj : function.injective (algebra_map R P))
+lemma fg_of_is_unit
   (I : fractional_ideal S P) (h : is_unit I) :
   fg (I : submodule R P) :=
-by { rcases h with ⟨I, rfl⟩, exact fg_unit inj I }
+by { rcases h with ⟨I, rfl⟩, exact fg_unit I }
 
 lemma _root_.ideal.fg_of_is_unit (inj : function.injective (algebra_map R P))
   (I : ideal R) (h : is_unit (I : fractional_ideal S P)) :
   I.fg :=
-by { rw ← coe_ideal_fg S inj I, exact fg_of_is_unit inj I h }
+by { rw ← coe_ideal_fg S inj I, exact fg_of_is_unit I h }
 
 variables (S P P')
 

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -634,8 +634,7 @@ end
 
 omit loc
 
-lemma mem_span_mul_finite_of_mem_mul
-  {I J : fractional_ideal S P} {x : P} (hx : x ∈ I * J) :
+lemma mem_span_mul_finite_of_mem_mul {I J : fractional_ideal S P} {x : P} (hx : x ∈ I * J) :
   ∃ (T T' : finset P), (T : set P) ⊆ I ∧ (T' : set P) ⊆ J ∧ x ∈ span R (T * T' : set P) :=
 submodule.mem_span_mul_finite_of_mem_mul (by simpa using mem_coe.mpr hx)
 
@@ -647,8 +646,7 @@ coe_submodule_fg _ inj _
 
 variables {S}
 
-lemma fg_unit
-  (I : units (fractional_ideal S P)) :
+lemma fg_unit (I : units (fractional_ideal S P)) :
   fg (I : submodule R P) :=
 begin
   have : (1 : P) ∈ (I * ↑I⁻¹ : fractional_ideal S P),
@@ -663,8 +661,7 @@ begin
   rwa [submodule.one_le, submodule.span_mul_span]
 end
 
-lemma fg_of_is_unit
-  (I : fractional_ideal S P) (h : is_unit I) :
+lemma fg_of_is_unit (I : fractional_ideal S P) (h : is_unit I) :
   fg (I : submodule R P) :=
 by { rcases h with ⟨I, rfl⟩, exact fg_unit I }
 

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1012,6 +1012,11 @@ submodule.map_mono h
 @[simp] lemma coe_submodule_top : coe_submodule S (⊤ : ideal R) = 1 :=
 by rw [coe_submodule, submodule.map_top, submodule.one_eq_range]
 
+lemma coe_submodule_fg
+  (hS : function.injective (algebra_map R S)) (I : ideal R) :
+  submodule.fg (coe_submodule S I) ↔ submodule.fg I :=
+⟨submodule.fg_of_fg_map _ (linear_map.ker_eq_bot.mpr hS), submodule.fg_map⟩
+
 variables {g : R →+* P}
 variables {T : submonoid P} (hy : M ≤ T.comap g) {Q : Type*} [comm_ring Q]
 variables [algebra P Q] [is_localization T Q]


### PR DESCRIPTION
This is one of the three steps in showing `is_dedekind_domain_inv` implies `is_dedekind_domain`.

Co-Authored-By: Ashvni ashvni.n@gmail.com
Co-Authored-By: Filippo A. E. Nuccio filippo.nuccio@univ-st-etienne.fr



---

- [x] depends on: #8275

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
