### PR TITLE
[Merged by Bors] - feat(measure_theory/simple_func_dense): induction lemmas for Lp.simple_func and Lp

### DIFF
--- a/src/algebra/indicator_function.lean
+++ b/src/algebra/indicator_function.lean
@@ -117,6 +117,9 @@ mul_indicator_eq_self.2 $ subset_univ _
 @[simp, to_additive] lemma mul_indicator_empty (f : α → M) : mul_indicator (∅ : set α) f = λa, 1 :=
 mul_indicator_eq_one.2 $ disjoint_empty _
 
+@[to_additive] lemma mul_indicator_empty' (f : α → M) : mul_indicator (∅ : set α) f = 1 :=
+mul_indicator_empty f
+
 variable (M)
 
 @[simp, to_additive] lemma mul_indicator_one (s : set α) :

--- a/src/algebra/support.lean
+++ b/src/algebra/support.lean
@@ -62,6 +62,10 @@ mul_support_eq_empty_iff.2 rfl
 @[simp, to_additive] lemma mul_support_one : mul_support (λ x : α, (1 : M)) = ∅ :=
 mul_support_one'
 
+@[to_additive] lemma mul_support_const {c : M} (hc : c ≠ 1) :
+  mul_support (λ x : α, c) = set.univ :=
+by { ext x, simp [hc] }
+
 @[to_additive] lemma mul_support_binop_subset (op : M → N → P) (op1 : op 1 1 = 1)
   (f : α → M) (g : α → N) :
   mul_support (λ x, op (f x) (g x)) ⊆ mul_support f ∪ mul_support g :=

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -172,6 +172,10 @@ coe_injective $ by simp
 @[simp] lemma piecewise_empty (f g : α →ₛ β) : piecewise ∅ measurable_set.empty f g = g :=
 coe_injective $ by simp
 
+lemma support_indicator [has_zero β] {s : set α} (hs : measurable_set s) (f : α →ₛ β) :
+  function.support (f.piecewise s hs (simple_func.const α 0)) = s ∩ function.support f :=
+set.support_indicator
+
 lemma measurable_bind [measurable_space γ] (f : α →ₛ β) (g : β → α → γ)
   (hg : ∀ b, measurable (g b)) : measurable (λ a, g (f a) a) :=
 λ s hs, f.measurable_set_cut (λ a b, g b a ∈ s) $ λ b, hg b hs

--- a/src/measure_theory/lp_space.lean
+++ b/src/measure_theory/lp_space.lean
@@ -1449,6 +1449,14 @@ begin
   { exact norm_indicator_const_Lp hp_pos hp_top, },
 end
 
+@[simp] lemma indicator_const_empty :
+  indicator_const_Lp p measurable_set.empty (by simp : μ ∅ ≠ ∞) c = 0 :=
+begin
+  rw Lp.eq_zero_iff_ae_eq_zero,
+  convert indicator_const_Lp_coe_fn,
+  simp [set.indicator_empty'],
+end
+
 lemma mem_ℒp_add_of_disjoint {f g : α → E}
   (h : disjoint (support f) (support g)) (hf : measurable f) (hg : measurable g) :
   mem_ℒp (f + g) p μ ↔ mem_ℒp f p μ ∧ mem_ℒp g p μ :=

--- a/src/measure_theory/simple_func_dense.lean
+++ b/src/measure_theory/simple_func_dense.lean
@@ -458,6 +458,16 @@ lemma measure_preimage_lt_top_of_integrable (f : α →ₛ E) (hf : integrable f
   μ (f ⁻¹' {x}) < ∞ :=
 integrable_iff.mp hf x hx
 
+lemma measure_lt_top_of_mem_ℒp_indicator (hp_pos : 0 < p) (hp_ne_top : p ≠ ∞) {c : E} (hc : c ≠ 0)
+  {s : set α} (hs : measurable_set s)
+  (hcs : mem_ℒp ((const α c).piecewise s hs (const α 0)) p μ) :
+  μ s < ⊤ :=
+begin
+  have : function.support (const α c) = set.univ := function.support_const hc,
+  simpa only [mem_ℒp_iff_fin_meas_supp hp_pos hp_ne_top, fin_meas_supp_iff_support,
+    support_indicator, set.inter_univ, this] using hcs
+end
+
 end simple_func_properties
 
 end simple_func
@@ -667,6 +677,58 @@ by simpa [to_Lp_to_simple_func] using norm_to_Lp (to_simple_func f) (simple_func
 
 end to_simple_func
 
+section induction
+
+variables (p)
+
+/-- The characteristic function of a finite-measure measurable set `s`, as an `Lp` simple function.
+-/
+def indicator_const {s : set α} (hs : measurable_set s) (hμs : μ s ≠ ∞) (c : E) :
+  Lp.simple_func E p μ :=
+to_Lp ((simple_func.const _ c).piecewise s hs (simple_func.const _ 0))
+  (mem_ℒp_indicator_const p hs c (or.inr hμs))
+
+variables {p}
+
+@[simp] lemma coe_indicator_const {s : set α} (hs : measurable_set s) (hμs : μ s ≠ ∞) (c : E) :
+  (↑(indicator_const p hs hμs c) : Lp E p μ) = indicator_const_Lp p hs hμs c :=
+rfl
+
+lemma to_simple_func_indicator_const {s : set α} (hs : measurable_set s) (hμs : μ s ≠ ∞) (c : E) :
+  to_simple_func (indicator_const p hs hμs c)
+    =ᵐ[μ] (simple_func.const _ c).piecewise s hs (simple_func.const _ 0) :=
+Lp.simple_func.to_simple_func_to_Lp _ _
+
+/-- To prove something for an arbitrary `Lp` simple function, with `0 < p < ∞`, it suffices to show
+that the property holds for (multiples of) characteristic functions of finite-measure measurable
+sets and is closed under addition (of functions with disjoint support). -/
+@[elab_as_eliminator]
+protected lemma induction (hp_pos : 0 < p) (hp_ne_top : p ≠ ∞) {P : Lp.simple_func E p μ → Prop}
+  (h_ind : ∀ (c : E) {s : set α} (hs : measurable_set s) (hμs : μ s < ∞),
+    P (Lp.simple_func.indicator_const p hs hμs.ne c))
+  (h_add : ∀ ⦃f g : α →ₛ E⦄, ∀ hf : mem_ℒp f p μ, ∀ hg : mem_ℒp g p μ,
+    disjoint (support f) (support g) → P (Lp.simple_func.to_Lp f hf) → P (Lp.simple_func.to_Lp g hg)
+    → P ((Lp.simple_func.to_Lp f hf) + (Lp.simple_func.to_Lp g hg)))
+  (f : Lp.simple_func E p μ) : P f :=
+begin
+  suffices : ∀ f : α →ₛ E, ∀ hf : mem_ℒp f p μ, P (to_Lp f hf),
+  { rw ← to_Lp_to_simple_func f,
+    apply this }, clear f,
+  refine simple_func.induction _ _,
+  { intros c s hs hf,
+    by_cases hc : c = 0,
+    { convert h_ind 0 measurable_set.empty (by simp) using 1,
+      ext1,
+      simp [hc] },
+    exact h_ind c hs (simple_func.measure_lt_top_of_mem_ℒp_indicator hp_pos hp_ne_top hc hs hf) },
+  { intros f g hfg hf hg hfg',
+    obtain ⟨hf', hg'⟩ : mem_ℒp f p μ ∧ mem_ℒp g p μ,
+    { exact (mem_ℒp_add_of_disjoint hfg f.measurable g.measurable).mp hfg' },
+    exact h_add hf' hg' hfg (hf hf') (hg hg') },
+end
+
+end induction
+
 section coe_to_Lp
 
 variables [fact (1 ≤ p)]
@@ -724,6 +786,27 @@ end Lp
 variables [measurable_space α] [normed_group E] [measurable_space E] [borel_space E]
   [second_countable_topology E] {f : α → E} {p : ℝ≥0∞} {μ : measure α}
 
+/-- To prove something for an arbitrary `Lp` function in a second countable Borel normed group, it
+suffices to show that
+* the property holds for (multiples of) characteristic functions;
+* is closed under addition;
+* the set of functions in `Lp` for which the property holds is closed.
+-/
+@[elab_as_eliminator]
+lemma Lp.induction [_i : fact (1 ≤ p)] (hp_ne_top : p ≠ ∞) (P : Lp E p μ → Prop)
+  (h_ind : ∀ (c : E) {s : set α} (hs : measurable_set s) (hμs : μ s < ∞),
+      P (Lp.simple_func.indicator_const p hs hμs.ne c))
+  (h_add : ∀ ⦃f g⦄, ∀ hf : mem_ℒp f p μ, ∀ hg : mem_ℒp g p μ, disjoint (support f) (support g) →
+    P (hf.to_Lp f) → P (hg.to_Lp g) → P ((hf.to_Lp f) + (hg.to_Lp g)))
+  (h_closed : is_closed {f : Lp E p μ | P f}) :
+  ∀ f : Lp E p μ, P f :=
+begin
+  refine λ f, (Lp.simple_func.dense_range hp_ne_top).induction_on f h_closed _,
+  refine Lp.simple_func.induction (lt_of_lt_of_le ennreal.zero_lt_one _i.elim) hp_ne_top _ _,
+  { exact λ c s, h_ind c },
+  { exact λ f g hf hg, h_add hf hg },
+end
+
 /-- To prove something for an arbitrary `mem_ℒp` function in a second countable
 Borel normed group, it suffices to show that
 * the property holds for (multiples of) characteristic functions;
@@ -750,15 +833,8 @@ begin
     { intros c s hs h,
       by_cases hc : c = 0,
       { subst hc, convert h_ind 0 measurable_set.empty (by simp) using 1, ext, simp [const] },
-      apply h_ind c hs,
       have hp_pos : 0 < p := lt_of_lt_of_le ennreal.zero_lt_one _i.elim,
-      rw simple_func.mem_ℒp_iff hp_pos hp_ne_top at h,
-      convert h c hc,
-      ext x,
-      simp only [simple_func.coe_const, set.mem_preimage, mem_singleton_iff, simple_func.coe_zero,
-        indicator_apply_eq_self, piecewise_eq_indicator, simple_func.const_zero,
-        simple_func.coe_piecewise, const_apply, hc],
-      exact not_not.symm },
+      exact h_ind c hs (simple_func.measure_lt_top_of_mem_ℒp_indicator hp_pos hp_ne_top hc hs h) },
     { intros f g hfg hf hg int_fg,
       rw [simple_func.coe_add, mem_ℒp_add_of_disjoint hfg f.measurable g.measurable] at int_fg,
       refine h_add hfg int_fg.1 int_fg.2 (hf int_fg.1) (hg int_fg.2) } },

--- a/src/measure_theory/simple_func_dense.lean
+++ b/src/measure_theory/simple_func_dense.lean
@@ -31,10 +31,9 @@ measurable function can be approximated in `Lᵖ` norm, by a sequence of simple 
   be considered as elements of `Lp E p μ`, and they tend in Lᵖ to `f`.
 * `Lp.simple_func.dense_embedding`: the embedding `coe_to_Lp` of the `Lp` simple functions into
   `Lp` is dense.
-* `mem_ℒp.induction`: to prove a predicate for all elements of `Lp`, it suffices to check that
-  it behaves correctly on simple functions in `Lp`.
-* `integrable.induction`: to prove a predicate for all elements of `L1`, it suffices to check that
-  it behaves correctly on simple functions in `L1`.
+* `Lp.simple_func.induction`, `Lp.induction`, `mem_ℒp.induction`, `integrable.induction`: to prove
+  a predicate for all elements of one of these classes of functions, it suffices to check that it
+  behaves correctly on simple functions.
 
 ## TODO
 

--- a/src/measure_theory/simple_func_dense.lean
+++ b/src/measure_theory/simple_func_dense.lean
@@ -707,7 +707,7 @@ protected lemma induction (hp_pos : 0 < p) (hp_ne_top : p ≠ ∞) {P : Lp.simpl
     P (Lp.simple_func.indicator_const p hs hμs.ne c))
   (h_add : ∀ ⦃f g : α →ₛ E⦄, ∀ hf : mem_ℒp f p μ, ∀ hg : mem_ℒp g p μ,
     disjoint (support f) (support g) → P (Lp.simple_func.to_Lp f hf) → P (Lp.simple_func.to_Lp g hg)
-    → P ((Lp.simple_func.to_Lp f hf) + (Lp.simple_func.to_Lp g hg)))
+    → P (Lp.simple_func.to_Lp f hf + Lp.simple_func.to_Lp g hg))
   (f : Lp.simple_func E p μ) : P f :=
 begin
   suffices : ∀ f : α →ₛ E, ∀ hf : mem_ℒp f p μ, P (to_Lp f hf),


### PR DESCRIPTION
The new lemmas, `Lp.simple_func.induction`, `Lp.induction`, allow one to prove a predicate for all elements of `Lp.simple_func` / `Lp` (here p < ∞), by proving it for characteristic functions and then checking it behaves appropriately under addition, and, in the second case, taking limits.  They are modelled on existing lemmas such as `simple_func.induction`, `mem_ℒp.induction`, `integrable.induction`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
