### PR TITLE
[Merged by Bors] - feat(data/matrix/{basic, block}): missing lemmas on conj_transpose

### DIFF
--- a/src/algebra/star/algebra.lean
+++ b/src/algebra/star/algebra.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import algebra.algebra.basic
 import algebra.star.basic
+import algebra.star.pi
 
 /-!
 # Star algebras
@@ -12,7 +13,7 @@ import algebra.star.basic
 Introduces the notion of a star algebra over a star ring.
 -/
 
-universes u v
+universes u v w
 
 /--
 A star algebra `A` over a star ring `R` is an algebra which is a star ring,
@@ -30,3 +31,16 @@ class star_algebra (R : Type u) (A : Type v)
   (r : R) (a : A) :
   star (r • a) = star r • star a :=
 star_algebra.star_smul r a
+
+namespace pi
+
+variable {I : Type u}     -- The indexing type
+variable {f : I → Type v} -- The family of types already equipped with instances
+
+instance {R : Type w}
+  [comm_semiring R] [Π i, semiring (f i)] [Π i, algebra R (f i)]
+  [star_ring R] [Π i, star_ring (f i)] [Π i, star_algebra R (f i)] :
+  star_algebra R (Π i, f i) :=
+{ star_smul := λ r x, funext $ λ _, star_smul _ _ }
+
+end pi

--- a/src/algebra/star/pi.lean
+++ b/src/algebra/star/pi.lean
@@ -3,13 +3,17 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import algebra.star.algebra
+import algebra.star.basic
+import algebra.ring.pi
 
 /-!
 # `star` on pi types
 
 We put a `has_star` structure on pi types that operates elementwise, such that it describes the
 complex conjugation of vectors.
+
+Note that `pi.star_algebra` is in a different file to avoid pulling in everything from
+`algebra/algebra/basic`.
 -/
 
 universes u v w
@@ -32,11 +36,5 @@ instance [Π i, monoid (f i)] [Π i, star_monoid (f i)] : star_monoid (Π i, f i
 instance [Π i, semiring (f i)] [Π i, star_ring (f i)] : star_ring (Π i, f i) :=
 { star_add := λ _ _, funext $ λ _, star_add _ _,
   ..(by apply_instance : star_monoid (Π i, f i)) }
-
-instance {R : Type w}
-  [comm_semiring R] [Π i, semiring (f i)] [Π i, algebra R (f i)]
-  [star_ring R] [Π i, star_ring (f i)] [Π i, star_algebra R (f i)] :
-  star_algebra R (Π i, f i) :=
-{ star_smul := λ r x, funext $ λ _, star_smul _ _ }
 
 end pi

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -7,7 +7,7 @@ import algebra.big_operators.pi
 import algebra.module.pi
 import algebra.module.linear_map
 import algebra.big_operators.ring
-import algebra.star.basic
+import algebra.star.pi
 import data.equiv.ring
 import data.fintype.card
 import data.matrix.dmatrix
@@ -1232,6 +1232,22 @@ begin
   { rwa [update_column_ne h, if_neg h] }
 end
 
+lemma map_update_row [decidable_eq n] (f : α → β) :
+  map (update_row M i b) f = update_row (M.map f) i (f ∘ b) :=
+begin
+  ext i' j',
+  rw [update_row_apply, map_apply, map_apply, update_row_apply],
+  exact apply_ite f _ _ _,
+end
+
+lemma map_update_column [decidable_eq m] (f : α → β) :
+  map (update_column M j c) f = update_column (M.map f) j (f ∘ c) :=
+begin
+  ext i' j',
+  rw [update_column_apply, map_apply, map_apply, update_column_apply],
+  exact apply_ite f _ _ _,
+end
+
 lemma update_row_transpose [decidable_eq m] : update_row Mᵀ j c = (update_column M j c)ᵀ :=
 begin
   ext i' j,
@@ -1244,6 +1260,22 @@ begin
   ext i' j,
   rw [transpose_apply, update_row_apply, update_column_apply],
   refl
+end
+
+lemma update_row_conj_transpose [decidable_eq m] [has_star α] :
+  update_row Mᴴ j (star c) = (update_column M j c)ᴴ :=
+begin
+  rw [conj_transpose, conj_transpose, transpose_map, transpose_map, update_row_transpose,
+    map_update_column],
+  refl,
+end
+
+lemma update_column_conj_transpose [decidable_eq n] [has_star α] :
+  update_column Mᴴ i (star b) = (update_row M i b)ᴴ :=
+begin
+  rw [conj_transpose, conj_transpose, transpose_map, transpose_map, update_column_transpose,
+    map_update_row],
+  refl,
 end
 
 @[simp] lemma update_row_eq_self [decidable_eq m]

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -1184,9 +1184,14 @@ by { ext, refl }
 @[simp] lemma row_apply (v : m → α) (i j) : matrix.row v i j = v j := rfl
 
 @[simp]
-lemma transpose_col (v : m → α) : (matrix.col v).transpose = matrix.row v := by {ext, refl}
+lemma transpose_col (v : m → α) : (matrix.col v)ᵀ = matrix.row v := by {ext, refl}
 @[simp]
-lemma transpose_row (v : m → α) : (matrix.row v).transpose = matrix.col v := by {ext, refl}
+lemma transpose_row (v : m → α) : (matrix.row v)ᵀ = matrix.col v := by {ext, refl}
+
+@[simp]
+lemma conj_transpose_col [has_star α] (v : m → α) : (col v)ᴴ = row (star v) := by {ext, refl}
+@[simp]
+lemma conj_transpose_row [has_star α] (v : m → α) : (row v)ᴴ = col (star v) := by {ext, refl}
 
 lemma row_vec_mul [semiring α] (M : matrix m n α) (v : m → α) :
   matrix.row (matrix.vec_mul v M) = matrix.row v ⬝ M := by {ext, refl}

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -315,6 +315,18 @@ by simp [dot_product, finset.smul_sum, smul_mul_assoc]
   dot_product v (x • w) = x • dot_product v w :=
 by simp [dot_product, finset.smul_sum, mul_smul_comm]
 
+lemma star_dot_product_star [semiring α] [star_ring α] (v w : m → α) :
+  dot_product (star v) (star w) = star (dot_product w v) :=
+by simp [dot_product]
+
+lemma star_dot_product [semiring α] [star_ring α] (v w : m → α) :
+  dot_product (star v) w = star (dot_product (star w) v) :=
+by simp [dot_product]
+
+lemma dot_product_star [semiring α] [star_ring α] (v w : m → α) :
+  dot_product v (star w) = star (dot_product w (star v)) :=
+by simp [dot_product]
+
 end dot_product
 
 /-- `M ⬝ N` is the usual product of matrices `M` and `N`, i.e. we have that

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -1184,14 +1184,14 @@ by { ext, refl }
 @[simp] lemma row_apply (v : m → α) (i j) : matrix.row v i j = v j := rfl
 
 @[simp]
-lemma transpose_col (v : m → α) : (matrix.col v)ᵀ = matrix.row v := by {ext, refl}
+lemma transpose_col (v : m → α) : (matrix.col v)ᵀ = matrix.row v := by { ext, refl }
 @[simp]
-lemma transpose_row (v : m → α) : (matrix.row v)ᵀ = matrix.col v := by {ext, refl}
+lemma transpose_row (v : m → α) : (matrix.row v)ᵀ = matrix.col v := by { ext, refl }
 
 @[simp]
-lemma conj_transpose_col [has_star α] (v : m → α) : (col v)ᴴ = row (star v) := by {ext, refl}
+lemma conj_transpose_col [has_star α] (v : m → α) : (col v)ᴴ = row (star v) := by { ext, refl }
 @[simp]
-lemma conj_transpose_row [has_star α] (v : m → α) : (row v)ᴴ = col (star v) := by {ext, refl}
+lemma conj_transpose_row [has_star α] (v : m → α) : (row v)ᴴ = col (star v) := by { ext, refl }
 
 lemma row_vec_mul [semiring α] (M : matrix m n α) (v : m → α) :
   matrix.row (matrix.vec_mul v M) = matrix.row v ⬝ M := by {ext, refl}


### PR DESCRIPTION
This also moves some imports around to make the star operator on vectors available in matrix/basic.lean

This is a follow up to #8291

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
