### PR TITLE
[Merged by Bors] - chore(algebra/module/pi): add `pi.smul_def`

### DIFF
--- a/src/algebra/module/pi.lean
+++ b/src/algebra/module/pi.lean
@@ -22,6 +22,7 @@ instance has_scalar {α : Type*} [Π i, has_scalar α $ f i] :
   has_scalar α (Π i : I, f i) :=
 ⟨λ s x, λ i, s • (x i)⟩
 
+lemma smul_def {α : Type*} [Π i, has_scalar α $ f i] (s : α) : s • x = λ i, s • x i := rfl
 @[simp] lemma smul_apply {α : Type*} [Π i, has_scalar α $ f i] (s : α) : (s • x) i = s • x i := rfl
 
 instance has_scalar' {g : I → Type*} [Π i, has_scalar (f i) (g i)] :


### PR DESCRIPTION
Sometimes it is useful to rewrite unapplied `s • x` (I need it in a branch that is not yet ready for review).

We already have `pi.zero_def`, `pi.add_def`, etc.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
