### PR TITLE
[Merged by Bors] - feat(measure_theory): add lemmas of equality of measures under assumptions of null difference, in particular null frontier

### DIFF
--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -289,7 +289,7 @@ variables {α' : Type*} [topological_space α'] [measurable_space α']
 lemma meas_interior_of_null_bdry {μ : measure α'} {s : set α'}
   (h_nullbdry : μ (frontier s) = 0) : μ (interior s) = μ s :=
 meas_eq_meas_smaller_of_between_null_diff
-  (@interior_subset _ _ s) (@subset_closure _ _ s) h_nullbdry
+  interior_subset subset_closure h_nullbdry
 
 lemma meas_closure_of_null_bdry {μ : measure α'} {s : set α'}
   (h_nullbdry : μ (frontier s) = 0) : μ (closure s) = μ s :=

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -294,7 +294,7 @@ meas_eq_meas_smaller_of_between_null_diff
 lemma meas_closure_of_null_bdry {μ : measure α'} {s : set α'}
   (h_nullbdry : μ (frontier s) = 0) : μ (closure s) = μ s :=
 (meas_eq_meas_larger_of_between_null_diff
-  (@interior_subset _ _ s) (@subset_closure _ _ s) h_nullbdry).symm
+  interior_subset subset_closure h_nullbdry).symm
 
 section preorder
 variables [preorder α] [order_closed_topology α] {a b : α}

--- a/src/measure_theory/borel_space.lean
+++ b/src/measure_theory/borel_space.lean
@@ -284,6 +284,18 @@ begin
     (is_open_of_mem_countable_basis hv).measurable_set
 end
 
+variables {α' : Type*} [topological_space α'] [measurable_space α']
+
+lemma meas_interior_of_null_bdry {μ : measure α'} {s : set α'}
+  (h_nullbdry : μ (frontier s) = 0) : μ (interior s) = μ s :=
+meas_eq_meas_smaller_of_between_null_diff
+  (@interior_subset _ _ s) (@subset_closure _ _ s) h_nullbdry
+
+lemma meas_closure_of_null_bdry {μ : measure α'} {s : set α'}
+  (h_nullbdry : μ (frontier s) = 0) : μ (closure s) = μ s :=
+(meas_eq_meas_larger_of_between_null_diff
+  (@interior_subset _ _ s) (@subset_closure _ _ s) h_nullbdry).symm
+
 section preorder
 variables [preorder α] [order_closed_topology α] {a b : α}
 

--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -176,6 +176,31 @@ begin
   rw [← measure_union disjoint_diff h₂ (h₁.diff h₂), union_diff_cancel h]
 end
 
+lemma meas_eq_meas_of_null_diff {s t : set α}
+  (hst : s ⊆ t) (h_nulldiff : μ (t.diff s) = 0) : μ s = μ t :=
+by { rw [←diff_diff_cancel_left hst, ←@measure_diff_null _ _ _ t _ h_nulldiff], refl, }
+
+lemma meas_eq_meas_of_between_null_diff {s₁ s₂ s₃ : set α}
+  (h12 : s₁ ⊆ s₂) (h23 : s₂ ⊆ s₃) (h_nulldiff : μ (s₃ \ s₁) = 0) :
+  (μ s₁ = μ s₂) ∧ (μ s₂ = μ s₃) :=
+begin
+  have le12 : μ s₁ ≤ μ s₂ := measure_mono h12,
+  have le23 : μ s₂ ≤ μ s₃ := measure_mono h23,
+  have key : μ s₃ ≤ μ s₁ := calc
+    μ s₃ = μ ((s₃ \ s₁) ∪ s₁)  : by rw (diff_union_of_subset (h12.trans h23))
+     ... ≤ μ (s₃ \ s₁) + μ s₁  : measure_union_le _ _
+     ... = μ s₁                : by simp only [h_nulldiff, zero_add],
+  exact ⟨le12.antisymm (le23.trans key), le23.antisymm (key.trans le12)⟩,
+end
+
+lemma meas_eq_meas_smaller_of_between_null_diff {s₁ s₂ s₃ : set α}
+  (h12 : s₁ ⊆ s₂) (h23 : s₂ ⊆ s₃) (h_nulldiff : μ (s₃.diff s₁) = 0) : μ s₁ = μ s₂ :=
+(meas_eq_meas_of_between_null_diff h12 h23 h_nulldiff).1
+
+lemma meas_eq_meas_larger_of_between_null_diff {s₁ s₂ s₃ : set α}
+  (h12 : s₁ ⊆ s₂) (h23 : s₂ ⊆ s₃) (h_nulldiff : μ (s₃.diff s₁) = 0) : μ s₂ = μ s₃ :=
+(meas_eq_meas_of_between_null_diff h12 h23 h_nulldiff).2
+
 lemma measure_compl (h₁ : measurable_set s) (h_fin : μ s < ∞) : μ (sᶜ) = μ univ - μ s :=
 by { rw compl_eq_univ_diff, exact measure_diff (subset_univ s) measurable_set.univ h₁ h_fin }
 


### PR DESCRIPTION
Adding lemmas in `measure_theory/measure_space` and `measure_theory/borel_space` about equality of measures of sets under the assumption that the difference of the largest to the smallest has null measure.

---

Two lemmas in `measure_theory/borel_space` do not actually use the `borel_space` hypothesis, but they do require a `topological_space` instance, to talk about interior, closure, and frontier, so this seemed like the appropriate file. These lemmas will be used in the proof of Portmanteau theorem.

The lemmas to be used in portmanteau were discussed on Zulip <https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Portmanteau.20theorem/near/245870297>. I ended up modifying Patrick's suggestion there a bit, in that I now first state a slightly more general result (the argument had nothing to do with topological notions specifically). I tried to follow the advice of Mario and Patrick in avoiding lemmas whose conclusion is a conjunction (only one such lemma remains).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
