### PR TITLE
[Merged by Bors] - feat(set/basic): range_splitting f : range f → α

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1823,7 +1823,7 @@ subset.antisymm (range_diff_image_subset f s) $ λ y ⟨x, hx, hy⟩, hy ▸
 /-- We can use the axiom of choice to pick a preimage for every element of `range f`. -/
 noncomputable def range_splitting (f : α → β) : range f → α := λ x, x.2.some
 
-@[simp] lemma apply_range_splitting (f : α → β) (x : range f) : f (range_splitting f x) = x :=
+lemma apply_range_splitting (f : α → β) (x : range f) : f (range_splitting f x) = x :=
 x.2.some_spec
 
 attribute [irreducible] range_splitting

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1823,6 +1823,7 @@ subset.antisymm (range_diff_image_subset f s) $ λ y ⟨x, hx, hy⟩, hy ▸
 /-- We can use the axiom of choice to pick a preimage for every element of `range f`. -/
 noncomputable def range_splitting (f : α → β) : range f → α := λ x, x.2.some
 
+-- This can not be a `@[simp]` lemma because the head of the left hand side is a variable.
 lemma apply_range_splitting (f : α → β) (x : range f) : f (range_splitting f x) = x :=
 x.2.some_spec
 
@@ -1831,6 +1832,7 @@ attribute [irreducible] range_splitting
 @[simp] lemma comp_range_splitting (f : α → β) : f ∘ range_splitting f = coe :=
 by { ext, simp only [function.comp_app], apply apply_range_splitting, }
 
+-- When `f` is injective, see also `equiv.of_injective`.
 lemma left_inverse_range_splitting (f : α → β) :
   left_inverse (range_factorization f) (range_splitting f) :=
 λ x, by { ext, simp only [range_factorization_coe], apply apply_range_splitting, }

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1767,6 +1767,9 @@ lemma range_factorization_eq {f : ι → β} :
   subtype.val ∘ range_factorization f = f :=
 funext $ λ i, rfl
 
+@[simp] lemma range_factorization_coe (f : ι → β) (a : ι) :
+  (range_factorization f a : β) = f a := rfl
+
 lemma surjective_onto_range : surjective (range_factorization f) :=
 λ ⟨_, ⟨i, rfl⟩⟩, ⟨i, rfl⟩
 
@@ -1816,6 +1819,24 @@ lemma range_diff_image {f : α → β} (H : injective f) (s : set α) :
   range f \ f '' s = f '' sᶜ :=
 subset.antisymm (range_diff_image_subset f s) $ λ y ⟨x, hx, hy⟩, hy ▸
   ⟨mem_range_self _, λ ⟨x', hx', eq⟩, hx $ H eq ▸ hx'⟩
+
+/-- We can use the axiom of choice to pick a preimage for every element of `range f`. -/
+noncomputable def range_splitting (f : α → β) : range f → α := λ x, x.2.some
+
+@[simp] lemma apply_range_splitting (f : α → β) (x : range f) : f (range_splitting f x) = x :=
+x.2.some_spec
+
+attribute [irreducible] range_splitting
+
+@[simp] lemma comp_range_splitting (f : α → β) : f ∘ range_splitting f = coe :=
+by { ext, simp only [function.comp_app], apply apply_range_splitting, }
+
+lemma left_inverse_range_splitting (f : α → β) :
+  left_inverse (range_factorization f) (range_splitting f) :=
+λ x, by { ext, simp only [range_factorization_coe], apply apply_range_splitting, }
+
+lemma range_splitting_injective (f : α → β) : injective (range_splitting f) :=
+(left_inverse_range_splitting f).injective
 
 end range
 


### PR DESCRIPTION
We use choice to provide an arbitrary injective splitting `range f → α` for any `f : α → β`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
