### PR TITLE
[Merged by Bors] - feat(data/sym2): add the universal property, and make `sym2.is_diag ⟦(x, y)⟧ ↔ x = y` true definitionally

### DIFF
--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -218,7 +218,6 @@ A predicate for testing whether an element of `sym2 α` is on the diagonal.
 def is_diag : sym2 α → Prop :=
 lift ⟨eq, λ _ _, propext eq_comm⟩
 
-@[simp]
 lemma is_diag_iff_eq {x y : α} : is_diag ⟦(x, y)⟧ ↔ x = y :=
 iff.rfl
 

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -95,19 +95,17 @@ begin
 end
 
 /-- The universal property of `sym2`; symmetric functions of two arguments are equivalent to
-functions from `sym2`. Note that this applies to both `Prop` and `Type`, although frequently
-`sym2.from_rel` is a more convenient spelling when working with `Prop`. -/
-def lift {β : Sort*} :
-  {f : α → α → β // ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁} ≃ (sym2 α → β) :=
-{ to_fun := λ f, quotient.lift (λ a : α × α, (f : α → α → β) a.1 a.2) $
-    by { rintro ⟨_, _⟩ ⟨_, _⟩ (_ | _), refl, exact f.prop _ _ },
+functions from `sym2`. Note that when `β` is `Prop`, it can sometimes be more convenient to use
+`sym2.from_rel` instead. -/
+def lift {β : Type*} : {f : α → α → β // ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁} ≃ (sym2 α → β) :=
+{ to_fun := λ f, quotient.lift (uncurry ↑f) $ by { rintro _ _ ⟨⟩, exacts [rfl, f.prop _ _] },
   inv_fun := λ F, ⟨λ a₁ a₂, F ⟦(a₁, a₂)⟧, λ a₁ a₂, congr_arg F eq_swap⟩,
   left_inv := λ f, subtype.ext rfl,
   right_inv := λ F, funext $ quotient.ind $ prod.rec $ by exact λ _ _, rfl }
 
 @[simp]
-lemma lift_mk {β : Sort*} (f : {f : α → α → β // ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁})
-  (a₁ a₂ : α) : lift f ⟦(a₁, a₂)⟧ = (f : α → α → β) a₁ a₂ := rfl
+lemma lift_mk {β : Type*} (f : {f : α → α → β // ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁}) (a₁ a₂ : α) :
+  lift f ⟦(a₁, a₂)⟧ = (f : α → α → β) a₁ a₂ := rfl
 
 /--
 The functor `sym2` is functorial, and this function constructs the induced maps.

--- a/src/data/sym2.lean
+++ b/src/data/sym2.lean
@@ -227,8 +227,8 @@ lemma is_diag_iff_proj_eq (z : α × α) : is_diag ⟦z⟧ ↔ z.1 = z.2 :=
 prod.rec_on z $ λ _ _, is_diag_iff_eq
 
 @[simp]
-lemma diag_is_diag (a : α) : is_diag (diag a) :=
-is_diag_iff_eq.mpr rfl
+lemma is_diag_diag (a : α) : is_diag (diag a) :=
+eq.refl a
 
 lemma is_diag.mem_range_diag {z : sym2 α} : is_diag z → z ∈ set.range (@diag α) :=
 begin
@@ -239,7 +239,7 @@ begin
 end
 
 lemma is_diag_iff_mem_range_diag (z : sym2 α) : is_diag z ↔ z ∈ set.range (@diag α) :=
-⟨is_diag.mem_range_diag, λ ⟨i, hi⟩, hi ▸ diag_is_diag i⟩
+⟨is_diag.mem_range_diag, λ ⟨i, hi⟩, hi ▸ is_diag_diag i⟩
 
 instance is_diag.decidable_pred (α : Type u) [decidable_eq α] : decidable_pred (@is_diag α) :=
 by { refine λ z, quotient.rec_on_subsingleton z (λ a, _), erw is_diag_iff_proj_eq, apply_instance }


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
