### PR TITLE
[Merged by Bors] - feat(measure_theory/hausdorff_measure): dimH and Hölder/Lipschitz maps

### DIFF
--- a/src/measure_theory/measure/hausdorff.lean
+++ b/src/measure_theory/measure/hausdorff.lean
@@ -110,7 +110,7 @@ measures.
   with nonempty interior, then the Hausdorff dimension of `s` is equal to the dimension of `E`.
 * `dense_compl_of_dimH_lt_finrank`: if `s` is a set in a finite dimensional real vector space `E`
   with Hausdorff dimension strictly less than the dimension of `E`, the `s` has a dense complement.
-* `times_cont_diff.dense_compl_range_of_finrank_finrank_lt`: the complement to the range of a `C¹`
+* `times_cont_diff.dense_compl_range_of_finrank_lt_finrank`: the complement to the range of a `C¹`
   smooth map is dense provided that the dimension of the domain is strictly less than the dimension
   of the codomain.
 
@@ -147,7 +147,7 @@ Hausdorff measure, Hausdorff dimension, dimension, measure, metric measure
 
 open_locale nnreal ennreal topological_space big_operators
 
-open emetric set function filter encodable finite_dimensional
+open emetric set function filter encodable finite_dimensional topological_space
 
 noncomputable theory
 
@@ -736,13 +736,13 @@ lemma measure_zero_of_dimH_lt {μ : measure X} {d : ℝ≥0}
   μ s = 0 :=
 h $ hausdorff_measure_of_dimH_lt hd
 
-lemma le_dimH_of_haussorff_measure_ne_zero {s : set X} {d : ℝ≥0} (h : μH[d] s ≠ 0) :
+lemma le_dimH_of_hausdorff_measure_ne_zero {s : set X} {d : ℝ≥0} (h : μH[d] s ≠ 0) :
   ↑d ≤ dimH s :=
 le_of_not_lt $ mt hausdorff_measure_of_dimH_lt h
 
 lemma dimH_of_hausdorff_measure_ne_zero_ne_top {d : ℝ≥0} {s : set X} (h : μH[d] s ≠ 0)
   (h' : μH[d] s ≠ ∞) : dimH s = d :=
-le_antisymm (dimH_le_of_hausdorff_measure_ne_top h') (le_dimH_of_haussorff_measure_ne_zero h)
+le_antisymm (dimH_le_of_hausdorff_measure_ne_top h') (le_dimH_of_hausdorff_measure_ne_zero h)
 
 @[mono] lemma dimH_mono {s t : set X} (h : s ⊆ t) : dimH s ≤ dimH t :=
 bsupr_le $ λ d hd, le_dimH_of_hausdorff_measure_eq_top $
@@ -922,9 +922,7 @@ begin
       exact ennreal.rpow_le_rpow (h.ediam_image_inter_le _) hd } }
 end
 
-/-- If `f` is a Hölder continuous map with exponent `r > 0`, then for any set `s` in the domain of
-`f`, the Hausdorff dimension of its image `f '' s` is at most the Hausdorff dimension of `s` divided
-by `r`. -/
+/-- If `f` is a Hölder continuous map with exponent `r > 0`, then `dimH (f '' s) ≤ dimH s / r`. -/
 lemma dimH_image_le (h : holder_on_with C r f s) (hr : 0 < r) :
   dimH (f '' s) ≤ dimH s / r :=
 begin
@@ -958,30 +956,30 @@ lemma dimH_range_le (h : holder_with C r f) (hr : 0 < r) :
 
 end holder_with
 
-/-- If `s` is a closed set in a `σ`-compact space `X` and `f : X → Y` is Hölder continuous in a
-neighborhood within `s` of every point `x ∈ s` with the same positive exponent `` but possibly
-different coefficients, then the Hausdorff dimension of the image `f '' s` is at most the Hausdorff
-dimension of `s` divided by `r`. -/
-lemma dimH_image_le_of_locally_holder_on [sigma_compact_space X] {r : ℝ≥0} {f : X → Y} (hr : 0 < r)
-  {s : set X} (hs : is_closed s) (hf : ∀ x ∈ s, ∃ (C : ℝ≥0) (t ∈ 𝓝[s] x), holder_on_with C r f t) :
+/-- If `s` is a set in a space `X` with second countable topology and `f : X → Y` is Hölder
+continuous in a neighborhood within `s` of every point `x ∈ s` with the same positive exponent `r`
+but possibly different coefficients, then the Hausdorff dimension of the image `f '' s` is at most
+the Hausdorff dimension of `s` divided by `r`. -/
+lemma dimH_image_le_of_locally_holder_on [second_countable_topology X] {r : ℝ≥0} {f : X → Y}
+  (hr : 0 < r) {s : set X} (hf : ∀ x ∈ s, ∃ (C : ℝ≥0) (t ∈ 𝓝[s] x), holder_on_with C r f t) :
   dimH (f '' s) ≤ dimH s / r :=
 begin
   choose! C t htn hC using hf,
-  rcases countable_cover_nhds_within_of_sigma_compact hs htn with ⟨u, hus, huc, huU⟩,
+  rcases countable_cover_nhds_within htn with ⟨u, hus, huc, huU⟩,
   replace huU := inter_eq_self_of_subset_left huU, rw inter_bUnion at huU,
   rw [← huU, image_bUnion, dimH_bUnion huc, dimH_bUnion huc], simp only [ennreal.supr_div],
   exact bsupr_le_bsupr (λ x hx, ((hC x (hus hx)).mono (inter_subset_right _ _)).dimH_image_le hr)
 end
 
 /-- If `f : X → Y` is Hölder continuous in a neighborhood of every point `x : X` with the same
-positive exponent `` but possibly different coefficients, then the Hausdorff dimension of the range
+positive exponent `r` but possibly different coefficients, then the Hausdorff dimension of the range
 of `f` is at most the Hausdorff dimension of `X` divided by `r`. -/
-lemma dimH_range_le_of_locally_holder_on [sigma_compact_space X] {r : ℝ≥0} {f : X → Y} (hr : 0 < r)
-  (hf : ∀ x : X, ∃ (C : ℝ≥0) (s ∈ 𝓝 x), holder_on_with C r f s) :
+lemma dimH_range_le_of_locally_holder_on [second_countable_topology X] {r : ℝ≥0} {f : X → Y}
+  (hr : 0 < r) (hf : ∀ x : X, ∃ (C : ℝ≥0) (s ∈ 𝓝 x), holder_on_with C r f s) :
   dimH (range f) ≤ dimH (univ : set X) / r :=
 begin
   rw ← image_univ,
-  refine dimH_image_le_of_locally_holder_on hr is_closed_univ (λ x _, _),
+  refine dimH_image_le_of_locally_holder_on hr (λ x _, _),
   simpa only [exists_prop, nhds_within_univ] using hf x
 end
 
@@ -995,8 +993,7 @@ lemma hausdorff_measure_image_le (h : lipschitz_on_with K f s) {d : ℝ} (hd : 0
 by simpa only [nnreal.coe_one, one_mul]
   using h.holder_on_with.hausdorff_measure_image_le zero_lt_one hd
 
-/-- If `f` is a Lipschitz continuous map, then for any set `s` in the domain of `f`, the Hausdorff
-dimension of its image `f '' s` is at most the Hausdorff dimension of `s`. -/
+/-- If `f : X → Y` is Lipschitz continuous on `s`, then `dimH (f '' s) ≤ dimH s`. -/
 lemma dimH_image_le (h : lipschitz_on_with K f s) : dimH (f '' s) ≤ dimH s :=
 by simpa using h.holder_on_with.dimH_image_le zero_lt_one
 
@@ -1012,8 +1009,7 @@ lemma hausdorff_measure_image_le (h : lipschitz_with K f) {d : ℝ} (hd : 0 ≤ 
   μH[d] (f '' s) ≤ K ^ d * μH[d] s :=
 (h.lipschitz_on_with s).hausdorff_measure_image_le hd
 
-/-- If `f` is a Lipschitz continuous map, then for any set `s` in the domain of `f`, the Hausdorff
-dimension of its image `f '' s` is at most the Hausdorff dimension of `s`. -/
+/-- If `f` is a Lipschitz continuous map, then `dimH (f '' s) ≤ dimH s`. -/
 lemma dimH_image_le (h : lipschitz_with K f) (s : set X) : dimH (f '' s) ≤ dimH s :=
 (h.lipschitz_on_with s).dimH_image_le
 
@@ -1024,24 +1020,27 @@ lemma dimH_range_le (h : lipschitz_with K f) : dimH (range f) ≤ dimH (univ : s
 
 end lipschitz_with
 
-/-- If `s` is a closed set and `f : X → Y` is Lipschitz in a neighborhood within `s` of every point
-`x ∈ s`, then the Hausdorff dimension of the image `f '' s` is at most the Hausdorff dimension of
-`s`. -/
-lemma dimH_image_le_of_locally_lipschitz_on [sigma_compact_space X] {f : X → Y}
-  {s : set X} (hs : is_closed s) (hf : ∀ x ∈ s, ∃ (C : ℝ≥0) (t ∈ 𝓝[s] x), lipschitz_on_with C f t) :
+/-- If `s` is a set in an extended metric space `X` with second countable topology and `f : X → Y`
+is Lipschitz in a neighborhood within `s` of every point `x ∈ s`, then the Hausdorff dimension of
+the image `f '' s` is at most the Hausdorff dimension of `s`. -/
+lemma dimH_image_le_of_locally_lipschitz_on [second_countable_topology X] {f : X → Y}
+  {s : set X} (hf : ∀ x ∈ s, ∃ (C : ℝ≥0) (t ∈ 𝓝[s] x), lipschitz_on_with C f t) :
   dimH (f '' s) ≤ dimH s :=
-by simpa only [ennreal.coe_one, ennreal.div_one]
-  using dimH_image_le_of_locally_holder_on zero_lt_one hs
-    (by simpa only [holder_on_with_one] using hf)
+begin
+  have : ∀ x ∈ s, ∃ (C : ℝ≥0) (t ∈ 𝓝[s] x), holder_on_with C 1 f t,
+    by simpa only [holder_on_with_one] using hf,
+  simpa only [ennreal.coe_one, ennreal.div_one]
+    using dimH_image_le_of_locally_holder_on zero_lt_one this
+end
 
 /-- If `f : X → Y` is Lipschitz in a neighborhood of each point `x : X`, then the Hausdorff
 dimension of `range f` is at most the Hausdorff dimension of `X`. -/
-lemma dimH_range_le_of_locally_lipschitz_on [sigma_compact_space X] {f : X → Y}
+lemma dimH_range_le_of_locally_lipschitz_on [second_countable_topology X] {f : X → Y}
   (hf : ∀ x : X, ∃ (C : ℝ≥0) (s ∈ 𝓝 x), lipschitz_on_with C f s) :
   dimH (range f) ≤ dimH (univ : set X) :=
 begin
   rw ← image_univ,
-  refine dimH_image_le_of_locally_lipschitz_on is_closed_univ (λ x _, _),
+  refine dimH_image_le_of_locally_lipschitz_on (λ x _, _),
   simpa only [exists_prop, nhds_within_univ] using hf x
 end
 
@@ -1252,37 +1251,38 @@ dimension of sets.
 -/
 
 /-- Let `f` be a function defined on a finite dimensional real normed space. If `f` is `C¹`-smooth
-on a closed convex set `s`, then the Hausdorff dimension of `f '' s` is less than or equal to the
-Hausdorff dimension of `s`.
+on a convex set `s`, then the Hausdorff dimension of `f '' s` is less than or equal to the Hausdorff
+dimension of `s`.
 
-TODO: do we actually need both `is_closed s` and `convex s`? -/
-lemma times_cont_diff_on.dimH_image_le {f : E → F} {s : set E}
-  (hf : times_cont_diff_on ℝ 1 f s) (h₁ : is_closed s) (h₂ : convex s) :
-  dimH (f '' s) ≤ dimH s :=
-dimH_image_le_of_locally_lipschitz_on h₁ $ λ x hx, ((hf x hx).exists_lipschitz_on_with h₂)
+TODO: do we actually need `convex s`? -/
+lemma times_cont_diff_on.dimH_image_le {f : E → F} {s t : set E} (hf : times_cont_diff_on ℝ 1 f s)
+  (hc : convex s) (ht : t ⊆ s) :
+  dimH (f '' t) ≤ dimH t :=
+dimH_image_le_of_locally_lipschitz_on $ λ x hx,
+  let ⟨C, u, hu, hf⟩ := (hf x (ht hx)).exists_lipschitz_on_with hc
+  in ⟨C, u, nhds_within_mono _ ht hu, hf⟩
 
 /-- The Hausdorff dimension of the range of a `C¹`-smooth function defined on a finite dimensional
 real normed space is at most the dimension of its domain as a vector space over `ℝ`. -/
 lemma times_cont_diff.dimH_range_le {f : E → F} (h : times_cont_diff ℝ 1 f) :
   dimH (range f) ≤ finrank ℝ E :=
-calc dimH (range f) ≤ dimH (univ : set E) :
-  dimH_range_le_of_locally_lipschitz_on $ λ x, h.times_cont_diff_at.exists_lipschitz_on_with
+calc dimH (range f) = dimH (f '' univ) : by rw image_univ
+... ≤ dimH (univ : set E) : h.times_cont_diff_on.dimH_image_le convex_univ subset.rfl
 ... = finrank ℝ E : real.dimH_univ_eq_finrank E
 
 /-- A particular case of Sard's Theorem. Let `f : E → F` be a map between finite dimensional real
-vector spaces. Suppose that `f` is `C¹` smooth on a closed convex set `s` of Hausdorff dimension
-strictly less than the dimension of `F`. Then the complement of the image `f '' s` is dense in
-`F`. -/
+vector spaces. Suppose that `f` is `C¹` smooth on a convex set `s` of Hausdorff dimension strictly
+less than the dimension of `F`. Then the complement of the image `f '' s` is dense in `F`. -/
 lemma times_cont_diff_on.dense_compl_image_of_dimH_lt_finrank [finite_dimensional ℝ F] {f : E → F}
-  {s : set E} (h : times_cont_diff_on ℝ 1 f s) (h₁ : is_closed s) (h₂ : convex s)
-  (hsF : dimH s < finrank ℝ F) :
-  dense (f '' s)ᶜ :=
-dense_compl_of_dimH_lt_finrank $ (h.dimH_image_le h₁ h₂).trans_lt hsF
+  {s t : set E} (h : times_cont_diff_on ℝ 1 f s) (hc : convex s) (ht : t ⊆ s)
+  (htF : dimH t < finrank ℝ F) :
+  dense (f '' t)ᶜ :=
+dense_compl_of_dimH_lt_finrank $ (h.dimH_image_le hc ht).trans_lt htF
 
 /-- A particular case of Sard's Theorem. If `f` is a `C¹` smooth map from a real vector space to a
 real vector space `F` of strictly larger dimension, then the complement of the range of `f` is dense
 in `F`. -/
-lemma times_cont_diff.dense_compl_range_of_finrank_finrank_lt [finite_dimensional ℝ F] {f : E → F}
+lemma times_cont_diff.dense_compl_range_of_finrank_lt_finrank [finite_dimensional ℝ F] {f : E → F}
   (h : times_cont_diff ℝ 1 f) (hEF : finrank ℝ E < finrank ℝ F) :
   dense (range f)ᶜ :=
 dense_compl_of_dimH_lt_finrank $ h.dimH_range_le.trans_lt $ ennreal.coe_nat_lt_coe_nat.2 hEF

--- a/src/measure_theory/measure/hausdorff.lean
+++ b/src/measure_theory/measure/hausdorff.lean
@@ -5,8 +5,9 @@ Authors: Yury Kudryashov
 -/
 import topology.metric_space.metric_separated
 import measure_theory.constructions.borel_space
-import analysis.special_functions.pow
 import measure_theory.measure.lebesgue
+import analysis.special_functions.pow
+import topology.metric_space.holder
 import data.equiv.list
 
 /-!
@@ -43,6 +44,57 @@ is additive on metric separated pairs of sets: `μ (s ∪ t) = μ s + μ t` prov
 metric outer measure, then prove that outer measures constructed using `mk_metric'` are metric outer
 measures.
 
+## Main definitions
+
+* `msaure_theory.outer_measure.is_metric`: an outer measure `μ` is called *metric* if
+  `μ (s ∪ t) = μ s + μ t` for any two metric separated sets `s` and `t`. A metric outer measure in a
+  Borel extended metric space is guaranteed to satisfy the Caratheodory condition, see
+  `measure_theory.outer_measure.is_metric.borel_le_caratheodory`.
+* `measure_theory.outer_measure.mk_metric'` and its particular case
+  `measure_theory.outer_measure.mk_metric`: a construction of an outer measure that is guaranteed to
+  be metric. Both constructions are generalizations of the Hausdorff measure. The same measures
+  interpreted as Borel measures are called `measure_theory.measure.mk_metric'` and
+  `measure_theory.measure.mk_metric`.
+* `measure_theory.measure.hausdorff_measure` a.k.a. `μH[d]`: the `d`-dimensional Hausdorff measure.
+  There are many definitions of the Hausdorff measure that differ from each other by a
+  multiplicative constant. We put
+  `μH[d] s = ⨆ r > 0, ⨅ (t : ℕ → set X) (hts : s ⊆ ⋃ n, t n) (ht : ∀ n, emetric.diam (t n) ≤ r),
+    ∑' n, ⨆ (ht : ¬set.subsingleton (t n)), (emetric.diam (t n)) ^ d`,
+  see `measure_theory.measure.hausdorff_measure_apply'`. In the most interesting case `0 < d` one
+  can omit the `⨆ (ht : ¬set.subsingleton (t n))` part.
+* `measure_theory.dimH`: the Hausdorff dimension of a set. For the Hausdorff dimension of the whole
+  space we use `measure_theory.dimH (set.univ : set X)`.
+
+## Main statements
+
+* `measure_theory.outer_measure.is_metric.borel_le_caratheodory`: if `μ` is a metric outer measure
+  on an extended metric space `X` (that is, it is additive on pairs of metric separated sets), then
+  every Borel set is Caratheodory measurable (hence, `μ` defines an actual
+  `measure_theory.measure`). See also `measure_theory.measure.mk_metric`.
+* `measure_theory.measure.hausdorff_measure_mono`: `μH[d] s` is a monotonically decreasing function
+  of `d`.
+* `measure_theory.measure.hausdorff_measure_zero_or_top`: if `d₁ < d₂`, then for any `s`, either
+  `μH[d₂] s = 0` or `μH[d₁] s = ∞`. Together with the previous lemma, this means that `μH[d] s` is
+  equal to infinity on some ray `(-∞, D)` and is equal to zero on `(D, +∞)`, where `D` is a possibly
+  infinite number called the *Hausdorff dimension* of `s`; `μH[D] s` can be zero, infinity, or
+  anything in between.
+* `measure_theory.measure.hausdorff_measure_of_lt_dimH`,
+  `measure_theory.measure.hausdorff_measure_of_dimH_lt`: if `d < dimH s`
+  (resp., `dimH s < d`), then `μH[d] s = ∞` (resp., `μH[d] s = 0`).
+* `measure_theory.measure.dimH_union`: the Hausdorff dimension of the union of two sets is the
+  maximum of their Hausdorff dimensions.
+* `measure_theory.measure.dimH_Union`, `measure_theory.measure.dimH_bUnion`,
+  `measure_theory.measure.dimH_sUnion`: the Hausdorff dimension of a countable union of sets is the
+  supremum of their Hausdorff dimensions.
+* `measure_theory.measure.no_atoms_hausdorff`, `measure_theory.measure.dimH_empty`,
+  `measure_theory.measure.dimH_singleton`, `set.subsingleton.dimH_zero`, `set.countable.dimH_zero`:
+  Hausdorff measure has no atoms and `dimH s = 0` whenever `s` is countable.
+* `holder_with.dimH_image_le` etc: if `f : X → Y` is Hölder continuous with exponent `r > 0`, then
+  for any `s`, `dimH (f '' s) ≤ dimH s / r`. We prove versions of this statement for `holder_with`,
+  `holder_on_with`, and locally Hölder maps, as well as for `set.image` and `set.range`.
+* `lipschitz_with.dimH_image_le` etc: Lipschitz continuous maps do not increase the Hausdorff
+  dimension of sets.
+
 ## Notations
 
 We use the following notation localized in `measure_theory`.
@@ -56,6 +108,10 @@ sources only allow coverings by balls and use `r ^ d` instead of `(diam s) ^ d`.
 construction lead to different Hausdorff measures, they lead to the same notion of the Hausdorff
 dimension.
 
+Some sources define the `0`-dimensional Hausdorff measure to be the counting measure. We define it
+to be zero on subsingletons because this way we can have a
+`measure.has_no_atoms (measure.hausdorff_measure d)` instance.
+
 ## References
 
 * [Herbert Federer, Geometric Measure Theory, Chapter 2.10][Federer1996]
@@ -67,7 +123,7 @@ Hausdorff measure, Hausdorff dimension, dimension, measure, metric measure
 
 open_locale nnreal ennreal topological_space big_operators
 
-open emetric set function filter encodable
+open emetric set function filter encodable finite_dimensional
 
 noncomputable theory
 
@@ -260,6 +316,8 @@ begin
     (tendsto_at_top_supr $ λ k l hkl, mk_metric'.mono_pre_nat m hkl s)
 end
 
+/-- `measure_theory.outer_measure.mk_metric'.pre m r` is a trimmed measure provided that
+`m (closure s) = m s` for any set `s`. -/
 lemma trim_pre [measurable_space X] [opens_measurable_space X]
   (m : set X → ℝ≥0∞) (hcl : ∀ s, m (closure s) = m s) (r : ℝ≥0∞) :
   (pre m r).trim = pre m r :=
@@ -632,6 +690,10 @@ begin
   exact (ennreal.zero_ne_top $ h.symm.trans hsd').elim
 end
 
+lemma dimH_le_of_hausdorff_measure_ne_top {s : set X} {d : ℝ≥0} (h : μH[d] s ≠ ∞) :
+  dimH s ≤ d :=
+le_of_not_lt $ mt hausdorff_measure_of_lt_dimH h
+
 lemma le_dimH_of_hausdorff_measure_eq_top {s : set X} {d : ℝ≥0} (h : μH[d] s = ∞) :
   ↑d ≤ dimH s :=
 le_bsupr d h
@@ -649,6 +711,14 @@ lemma measure_zero_of_dimH_lt {μ : measure X} {d : ℝ≥0}
   (h : μ ≪ μH[d]) {s : set X} (hd : dimH s < d) :
   μ s = 0 :=
 h $ hausdorff_measure_of_dimH_lt hd
+
+lemma le_dimH_of_haussorff_measure_ne_zero {s : set X} {d : ℝ≥0} (h : μH[d] s ≠ 0) :
+  ↑d ≤ dimH s :=
+le_of_not_lt $ mt hausdorff_measure_of_dimH_lt h
+
+lemma dimH_of_hausdorff_measure_ne_zero_ne_top {d : ℝ≥0} {s : set X} (h : μH[d] s ≠ 0)
+  (h' : μH[d] s ≠ ∞) : dimH s = d :=
+le_antisymm (dimH_le_of_hausdorff_measure_ne_top h') (le_dimH_of_haussorff_measure_ne_zero h)
 
 @[mono] lemma dimH_mono {s t : set X} (h : s ⊆ t) : dimH s ≤ dimH t :=
 bsupr_le $ λ d hd, le_dimH_of_hausdorff_measure_eq_top $
@@ -688,7 +758,7 @@ alias dimH_countable ← set.countable.dimH_zero
 -/
 
 /-- In the space `ι → ℝ`, Hausdorff measure coincides exactly with Lebesgue measure. -/
-theorem hausdorff_measure_pi_real {ι : Type*} [fintype ι] [nonempty ι] :
+@[simp] theorem hausdorff_measure_pi_real {ι : Type*} [fintype ι] [nonempty ι] :
   (μH[fintype.card ι] : measure (ι → ℝ)) = volume :=
 begin
   classical,
@@ -784,3 +854,406 @@ begin
 end
 
 end measure_theory
+
+/-!
+### Hausdorff measure, Hausdorff dimension, and Hölder or Lipschitz continuous maps
+-/
+
+open_locale measure_theory
+open measure_theory measure_theory.measure
+
+variables [measurable_space X] [borel_space X] [measurable_space Y] [borel_space Y]
+
+namespace holder_on_with
+
+variables {C r : ℝ≥0} {f : X → Y} {s t : set X}
+
+/-- If `f : X → Y` is Hölder continuous on `s` with a positive exponent `r`, then
+`μH[d] (f '' s) ≤ C ^ d * μH[r * d] s`. -/
+lemma hausdorff_measure_image_le (h : holder_on_with C r f s) (hr : 0 < r) {d : ℝ} (hd : 0 ≤ d) :
+  μH[d] (f '' s) ≤ C ^ d * μH[r * d] s :=
+begin
+  -- We start with the trivial case `C = 0`
+  rcases (zero_le C).eq_or_lt with rfl|hC0,
+  { have : (f '' s).subsingleton, by simpa [diam_eq_zero_iff] using h.ediam_image_le,
+    rw this.measure_zero,
+    exact zero_le _ },
+  { have hCd0 : (C : ℝ≥0∞) ^ d ≠ 0, by simp [hC0.ne'],
+    have hCd : (C : ℝ≥0∞) ^ d ≠ ∞, by simp [hd],
+    simp only [hausdorff_measure_apply', ennreal.mul_supr, ennreal.mul_infi_of_ne hCd0 hCd,
+      ← ennreal.tsum_mul_left],
+    refine supr_le (λ R, supr_le $ λ hR, _),
+    have : tendsto (λ d : ℝ≥0∞, (C : ℝ≥0∞) * d ^ (r : ℝ)) (𝓝 0) (𝓝 0),
+      from ennreal.tendsto_const_mul_rpow_nhds_zero_of_pos ennreal.coe_ne_top hr,
+    rcases ennreal.nhds_zero_basis_Iic.eventually_iff.1 (this.eventually (gt_mem_nhds hR))
+      with ⟨δ, δ0, H⟩,
+    refine le_supr_of_le δ (le_supr_of_le δ0 $ le_binfi $ λ t hst, le_infi $ λ htδ, _),
+    refine binfi_le_of_le (λ n, f '' (t n ∩ s)) _ (infi_le_of_le (λ n, _) _),
+    { rw [← image_Union, ← Union_inter],
+      exact image_subset _ (subset_inter hst subset.rfl) },
+    { exact (h.ediam_image_inter_le (t n)).trans (H (htδ n)).le },
+    { refine ennreal.tsum_le_tsum (λ n, supr_le $ λ hft,
+        le_supr_of_le (λ ht, hft $ (ht.mono (inter_subset_left _ _)).image f) _),
+      rw [ennreal.rpow_mul, ← ennreal.mul_rpow_of_nonneg _ _ hd],
+      exact ennreal.rpow_le_rpow (h.ediam_image_inter_le _) hd } }
+end
+
+/-- If `f` is a Hölder continuous map with exponent `r > 0`, then for any set `s` in the domain of
+`f`, the Hausdorff dimension of its image `f '' s` is at most the Hausdorff dimension of `s` divided
+by `r`. -/
+lemma dimH_image_le (h : holder_on_with C r f s) (hr : 0 < r) :
+  dimH (f '' s) ≤ dimH s / r :=
+begin
+  refine bsupr_le (λ d hd, _),
+  have := h.hausdorff_measure_image_le hr d.coe_nonneg,
+  rw [hd, ennreal.coe_rpow_of_nonneg _ d.coe_nonneg, top_le_iff] at this,
+  have Hrd : μH[(r * d : ℝ≥0)] s = ⊤,
+  { contrapose this, exact ennreal.mul_ne_top ennreal.coe_ne_top this },
+  rw [ennreal.le_div_iff_mul_le, mul_comm, ← ennreal.coe_mul],
+  exacts [le_dimH_of_hausdorff_measure_eq_top Hrd, or.inl (mt ennreal.coe_eq_zero.1 hr.ne'),
+    or.inl ennreal.coe_ne_top]
+end
+
+end holder_on_with
+
+namespace holder_with
+
+variables {C r : ℝ≥0} {f : X → Y} {s : set X}
+
+/-- If `f : X → Y` is Hölder continuous with a positive exponent `r`, then the Hausdorff dimension
+of the image of a set `s` is at most `dimH s / r`. -/
+lemma dimH_image_le (h : holder_with C r f) (hr : 0 < r) (s : set X) :
+  dimH (f '' s) ≤ dimH s / r :=
+(h.holder_on_with s).dimH_image_le hr
+
+/-- If `f` is a Hölder continuous map with exponent `r > 0`, then the Hausdorff dimension of its
+range is at most the Hausdorff dimension of its domain divided by `r`. -/
+lemma dimH_range_le (h : holder_with C r f) (hr : 0 < r) :
+  dimH (range f) ≤ dimH (univ : set X) / r :=
+@image_univ _ _ f ▸ h.dimH_image_le hr univ
+
+end holder_with
+
+/-- If `s` is a closed set in a `σ`-compact space `X` and `f : X → Y` is Hölder continuous in a
+neighborhood within `s` of every point `x ∈ s` with the same positive exponent `` but possibly
+different coefficients, then the Hausdorff dimension of the image `f '' s` is at most the Hausdorff
+dimension of `s` divided by `r`. -/
+lemma dimH_image_le_of_locally_holder_on [sigma_compact_space X] {r : ℝ≥0} {f : X → Y} (hr : 0 < r)
+  {s : set X} (hs : is_closed s) (hf : ∀ x ∈ s, ∃ (C : ℝ≥0) (t ∈ 𝓝[s] x), holder_on_with C r f t) :
+  dimH (f '' s) ≤ dimH s / r :=
+begin
+  choose! C t htn hC using hf,
+  rcases countable_cover_nhds_within_of_sigma_compact hs htn with ⟨u, hus, huc, huU⟩,
+  replace huU := inter_eq_self_of_subset_left huU, rw inter_bUnion at huU,
+  rw [← huU, image_bUnion, dimH_bUnion huc, dimH_bUnion huc], simp only [ennreal.supr_div],
+  exact bsupr_le_bsupr (λ x hx, ((hC x (hus hx)).mono (inter_subset_right _ _)).dimH_image_le hr)
+end
+
+/-- If `f : X → Y` is Hölder continuous in a neighborhood of every point `x : X` with the same
+positive exponent `` but possibly different coefficients, then the Hausdorff dimension of the range
+of `f` is at most the Hausdorff dimension of `X` divided by `r`. -/
+lemma dimH_range_le_of_locally_holder_on [sigma_compact_space X] {r : ℝ≥0} {f : X → Y} (hr : 0 < r)
+  (hf : ∀ x : X, ∃ (C : ℝ≥0) (s ∈ 𝓝 x), holder_on_with C r f s) :
+  dimH (range f) ≤ dimH (univ : set X) / r :=
+begin
+  rw ← image_univ,
+  refine dimH_image_le_of_locally_holder_on hr is_closed_univ (λ x _, _),
+  simpa only [exists_prop, nhds_within_univ] using hf x
+end
+
+namespace lipschitz_on_with
+
+variables {K : ℝ≥0} {f : X → Y} {s t : set X}
+
+/-- If `f : X → Y` is `K`-Lipschitz on `s`, then `μH[d] (f '' s) ≤ K ^ d * μH[d] s`. -/
+lemma hausdorff_measure_image_le (h : lipschitz_on_with K f s) {d : ℝ} (hd : 0 ≤ d) :
+  μH[d] (f '' s) ≤ K ^ d * μH[d] s :=
+by simpa only [nnreal.coe_one, one_mul]
+  using h.holder_on_with.hausdorff_measure_image_le zero_lt_one hd
+
+/-- If `f` is a Lipschitz continuous map, then for any set `s` in the domain of `f`, the Hausdorff
+dimension of its image `f '' s` is at most the Hausdorff dimension of `s`. -/
+lemma dimH_image_le (h : lipschitz_on_with K f s) : dimH (f '' s) ≤ dimH s :=
+by simpa using h.holder_on_with.dimH_image_le zero_lt_one
+
+end lipschitz_on_with
+
+namespace lipschitz_with
+
+variables {K : ℝ≥0} {f : X → Y}
+
+/-- If `f` is a `K`-Lipschitz map, then it increases the Hausdorff `d`-measures of sets at most
+by the factor of `K ^ d`.-/
+lemma hausdorff_measure_image_le (h : lipschitz_with K f) {d : ℝ} (hd : 0 ≤ d) (s : set X) :
+  μH[d] (f '' s) ≤ K ^ d * μH[d] s :=
+(h.lipschitz_on_with s).hausdorff_measure_image_le hd
+
+/-- If `f` is a Lipschitz continuous map, then for any set `s` in the domain of `f`, the Hausdorff
+dimension of its image `f '' s` is at most the Hausdorff dimension of `s`. -/
+lemma dimH_image_le (h : lipschitz_with K f) (s : set X) : dimH (f '' s) ≤ dimH s :=
+(h.lipschitz_on_with s).dimH_image_le
+
+/-- If `f` is a Lipschitz continuous map, then the Hausdorff dimension of its range is at most the
+Hausdorff dimension of its domain. -/
+lemma dimH_range_le (h : lipschitz_with K f) : dimH (range f) ≤ dimH (univ : set X) :=
+@image_univ _ _ f ▸ h.dimH_image_le univ
+
+end lipschitz_with
+
+/-- If `s` is a closed set and `f : X → Y` is Lipschitz in a neighborhood within `s` of every point
+`x ∈ s`, then the Hausdorff dimension of the image `f '' s` is at most the Hausdorff dimension of
+`s`. -/
+lemma dimH_image_le_of_locally_lipschitz_on [sigma_compact_space X] {f : X → Y}
+  {s : set X} (hs : is_closed s) (hf : ∀ x ∈ s, ∃ (C : ℝ≥0) (t ∈ 𝓝[s] x), lipschitz_on_with C f t) :
+  dimH (f '' s) ≤ dimH s :=
+by simpa only [ennreal.coe_one, ennreal.div_one]
+  using dimH_image_le_of_locally_holder_on zero_lt_one hs
+    (by simpa only [holder_on_with_one] using hf)
+
+/-- If `f : X → Y` is Lipschitz in a neighborhood of each point `x : X`, then the Hausdorff
+dimension of `range f` is at most the Hausdorff dimension of `X`. -/
+lemma dimH_range_le_of_locally_lipschitz_on [sigma_compact_space X] {f : X → Y}
+  (hf : ∀ x : X, ∃ (C : ℝ≥0) (s ∈ 𝓝 x), lipschitz_on_with C f s) :
+  dimH (range f) ≤ dimH (univ : set X) :=
+begin
+  rw ← image_univ,
+  refine dimH_image_le_of_locally_lipschitz_on is_closed_univ (λ x _, _),
+  simpa only [exists_prop, nhds_within_univ] using hf x
+end
+
+/-!
+### Antilipschitz maps do not decrease Hausdorff measures and dimension
+-/
+
+namespace antilipschitz_with
+
+variables {f : X → Y} {K : ℝ≥0} {d : ℝ}
+
+lemma hausdorff_measure_preimage_le (hf : antilipschitz_with K f) (hd : 0 ≤ d) (s : set Y) :
+  μH[d] (f ⁻¹' s) ≤ K ^ d * μH[d] s :=
+begin
+  rcases eq_or_ne K 0 with rfl|h0,
+  { haveI : subsingleton X := hf.subsingleton,
+    have : (f ⁻¹' s).subsingleton, from subsingleton_univ.mono (subset_univ _),
+    rw this.measure_zero,
+    exact zero_le _ },
+  have hKd0 : (K : ℝ≥0∞) ^ d ≠ 0, by simp [h0],
+  have hKd : (K : ℝ≥0∞) ^ d ≠ ∞, by simp [hd],
+  simp only [hausdorff_measure_apply', ennreal.mul_supr, ennreal.mul_infi_of_ne hKd0 hKd,
+    ← ennreal.tsum_mul_left],
+  refine bsupr_le (λ ε ε0, _),
+  refine le_bsupr_of_le (ε / K) (by simp [ε0.ne']) _,
+  refine le_binfi (λ t hst, le_infi $ λ htε, _),
+  replace hst : f ⁻¹' s ⊆ _ := preimage_mono hst, rw preimage_Union at hst,
+  refine binfi_le_of_le _ hst (infi_le_of_le (λ n, _) _),
+  { exact (hf.ediam_preimage_le _).trans (ennreal.mul_le_of_le_div' $ htε n) },
+  { refine ennreal.tsum_le_tsum (λ n, supr_le $
+      λ H, le_supr_of_le (λ h, H $ h.preimage hf.injective) _),
+    rw [← ennreal.mul_rpow_of_nonneg _ _ hd],
+    exact ennreal.rpow_le_rpow (hf.ediam_preimage_le _) hd }
+end
+
+lemma le_hausdorff_measure_image (hf : antilipschitz_with K f) (hd : 0 ≤ d) (s : set X) :
+  μH[d] s ≤ K ^ d * μH[d] (f '' s) :=
+calc μH[d] s ≤ μH[d] (f ⁻¹' (f '' s)) : measure_mono (subset_preimage_image _ _)
+         ... ≤ K ^ d * μH[d] (f '' s) : hf.hausdorff_measure_preimage_le hd (f '' s)
+
+lemma dimH_preimage_le (hf : antilipschitz_with K f) (s : set Y) :
+  dimH (f ⁻¹' s) ≤ dimH s :=
+begin
+  refine bsupr_le (λ d hd, le_dimH_of_hausdorff_measure_eq_top _),
+  have := hf.hausdorff_measure_preimage_le d.coe_nonneg s,
+  rw [hd, top_le_iff] at this,
+  contrapose! this,
+  exact ennreal.mul_ne_top (by simp) this
+end
+
+lemma le_dimH_image (hf : antilipschitz_with K f) (s : set X) :
+  dimH s ≤ dimH (f '' s) :=
+calc dimH s ≤ dimH (f ⁻¹' (f '' s)) : dimH_mono (subset_preimage_image _ _)
+        ... ≤ dimH (f '' s)         : hf.dimH_preimage_le _
+
+end antilipschitz_with
+
+/-!
+### Isometries preserve the Hausdorff measure and Hausdorff dimension
+-/
+
+namespace isometry
+
+variables {f : X → Y} {d : ℝ}
+
+lemma hausdorff_measure_image (hf : isometry f) (hd : 0 ≤ d ∨ surjective f) (s : set X) :
+  μH[d] (f '' s) = μH[d] s :=
+begin
+  simp only [hausdorff_measure, ← outer_measure.coe_mk_metric, ← outer_measure.comap_apply],
+  rw [outer_measure.isometry_comap_mk_metric _ hf (hd.imp_left _)],
+  exact λ hd x y hxy, ennreal.rpow_le_rpow hxy hd
+end
+
+lemma hausdorff_measure_preimage (hf : isometry f) (hd : 0 ≤ d ∨ surjective f) (s : set Y) :
+  μH[d] (f ⁻¹' s) = μH[d] (s ∩ range f) :=
+by rw [← hf.hausdorff_measure_image hd, image_preimage_eq_inter_range]
+
+lemma map_hausdorff_measure (hf : isometry f) (hd : 0 ≤ d ∨ surjective f) :
+  measure.map f μH[d] = (μH[d]).restrict (range f) :=
+begin
+  ext1 s hs,
+  rw [map_apply hf.continuous.measurable hs, restrict_apply hs, hf.hausdorff_measure_preimage hd]
+end
+
+lemma dimH_image (hf : isometry f) (s : set X) : dimH (f '' s) = dimH s :=
+le_antisymm (hf.lipschitz.dimH_image_le _) (hf.antilipschitz.le_dimH_image _)
+
+end isometry
+
+namespace isometric
+
+@[simp] lemma hausdorff_measure_image (e : X ≃ᵢ Y) (d : ℝ) (s : set X) :
+  μH[d] (e '' s) = μH[d] s :=
+e.isometry.hausdorff_measure_image (or.inr e.surjective) s
+
+@[simp] lemma hausdorff_measure_preimage (e : X ≃ᵢ Y) (d : ℝ) (s : set Y) :
+  μH[d] (e ⁻¹' s) = μH[d] s :=
+by rw [← e.image_symm, e.symm.hausdorff_measure_image]
+
+@[simp] lemma dimH_image (e : X ≃ᵢ Y) (s : set X) : dimH (e '' s) = dimH s :=
+e.isometry.dimH_image s
+
+@[simp] lemma dimH_preimage (e : X ≃ᵢ Y) (s : set Y) : dimH (e ⁻¹' s) = dimH s :=
+by rw [← e.image_symm, e.symm.dimH_image]
+
+lemma dimH_univ (e : X ≃ᵢ Y) : dimH (univ : set X) = dimH (univ : set Y) :=
+by rw [← e.dimH_preimage univ, preimage_univ]
+
+end isometric
+
+namespace continuous_linear_equiv
+
+variables {𝕜 E F : Type*} [nondiscrete_normed_field 𝕜]
+  [normed_group E] [normed_space 𝕜 E] [measurable_space E] [borel_space E]
+  [normed_group F] [normed_space 𝕜 F] [measurable_space F] [borel_space F]
+
+@[simp] lemma dimH_image (e : E ≃L[𝕜] F) (s : set E) : dimH (e '' s) = dimH s :=
+le_antisymm (e.lipschitz.dimH_image_le s) $
+  by simpa only [e.symm_image_image] using e.symm.lipschitz.dimH_image_le (e '' s)
+
+@[simp] lemma dimH_preimage (e : E ≃L[𝕜] F) (s : set F) : dimH (e ⁻¹' s) = dimH s :=
+by rw [← e.image_symm_eq_preimage, e.symm.dimH_image]
+
+lemma dimH_univ (e : E ≃L[𝕜] F) : dimH (univ : set E) = dimH (univ : set F) :=
+by rw [← e.dimH_preimage, preimage_univ]
+
+end continuous_linear_equiv
+
+namespace real
+
+variables {E : Type*} [fintype ι] [normed_group E] [normed_space ℝ E] [finite_dimensional ℝ E]
+  [measurable_space E] [borel_space E]
+
+open measure_theory
+
+open_locale measure_theory
+
+theorem dimH_ball_pi (x : ι → ℝ) {r : ℝ} (hr : 0 < r) :
+  dimH (metric.ball x r) = fintype.card ι :=
+begin
+  casesI is_empty_or_nonempty ι,
+  { rwa [dimH_subsingleton, eq_comm, nat.cast_eq_zero, fintype.card_eq_zero_iff],
+    exact λ x _ y _, subsingleton.elim x y },
+  { rw ← ennreal.coe_nat,
+    have : μH[fintype.card ι] (metric.ball x r) = ennreal.of_real ((2 * r) ^ fintype.card ι),
+      by rw [hausdorff_measure_pi_real, real.volume_pi_ball _ hr],
+    refine dimH_of_hausdorff_measure_ne_zero_ne_top _ _; rw [nnreal.coe_nat_cast, this],
+    { simp [pow_pos (mul_pos zero_lt_two hr)] },
+    { exact ennreal.of_real_ne_top } }
+end
+
+theorem dimH_ball_pi_fin {n : ℕ} (x : fin n → ℝ) {r : ℝ} (hr : 0 < r) :
+  dimH (metric.ball x r) = n :=
+by rw [dimH_ball_pi x hr, fintype.card_fin]
+
+theorem dimH_univ_pi (ι : Type*) [fintype ι] : dimH (univ : set (ι → ℝ)) = fintype.card ι :=
+by simp only [← metric.Union_ball_nat_succ (0 : ι → ℝ), dimH_Union,
+  dimH_ball_pi _ (nat.cast_add_one_pos _), supr_const]
+
+theorem dimH_univ_pi_fin (n : ℕ) : dimH (univ : set (fin n → ℝ)) = n :=
+by rw [dimH_univ_pi, fintype.card_fin]
+
+theorem dimH_of_mem_nhds {x : E} {s : set E} (h : s ∈ 𝓝 x) :
+  dimH s = finrank ℝ E :=
+begin
+  haveI : finite_dimensional ℝ (fin (finrank ℝ E) → ℝ), from is_noetherian_pi',
+  have e : E ≃L[ℝ] (fin (finrank ℝ E) → ℝ),
+    from continuous_linear_equiv.of_finrank_eq (finite_dimensional.finrank_fin_fun ℝ).symm,
+  rw ← e.dimH_image,
+  refine le_antisymm _ _,
+  { exact (dimH_mono (subset_univ _)).trans_eq (dimH_univ_pi_fin _) },
+  { have : e '' s ∈ 𝓝 (e x), by { rw ← e.map_nhds_eq, exact image_mem_map h },
+    rcases metric.nhds_basis_ball.mem_iff.1 this with ⟨r, hr0, hr⟩,
+    simpa only [dimH_ball_pi_fin (e x) hr0] using dimH_mono hr }
+end
+
+variable (E)
+
+theorem dimH_univ_eq_finrank : dimH (univ : set E) = finrank ℝ E :=
+dimH_of_mem_nhds (@univ_mem _ (𝓝 0))
+
+theorem dimH_univ : dimH (univ : set ℝ) = 1 :=
+by rw [dimH_univ_eq_finrank ℝ, finite_dimensional.finrank_of_field, nat.cast_one]
+
+end real
+
+variables {E F : Type*}
+  [normed_group E] [normed_space ℝ E] [finite_dimensional ℝ E] [measurable_space E] [borel_space E]
+  [normed_group F] [normed_space ℝ F] [measurable_space F] [borel_space F]
+
+theorem dense_compl_of_dimH_lt_finrank {s : set E} (hs : dimH s < finrank ℝ E) : dense sᶜ :=
+begin
+  refine λ x, mem_closure_iff_nhds.2 (λ t ht, ne_empty_iff_nonempty.1 $ λ he, hs.not_le _),
+  rw [← diff_eq, diff_eq_empty] at he,
+  rw [← real.dimH_of_mem_nhds ht],
+  exact dimH_mono he
+end
+
+/-!
+### Hausdorff dimension and `C¹`-smooth maps
+
+`C¹`-smooth maps are locally Lipschitz continuous, hence they do not increase the Hausdorff
+dimension of sets.
+-/
+
+/-- Let `f` be a function defined on a finite dimensional real normed space. If `f` is `C¹`-smooth
+on a closed convex set `s`, then the Hausdorff dimension of `f '' s` is less than or equal to the
+Hausdorff dimension of `s`.
+
+TODO: do we actually need both `is_closed s` and `convex s`? -/
+lemma times_cont_diff_on.dimH_image_le {f : E → F} {s : set E}
+  (hf : times_cont_diff_on ℝ 1 f s) (h₁ : is_closed s) (h₂ : convex s) :
+  dimH (f '' s) ≤ dimH s :=
+dimH_image_le_of_locally_lipschitz_on h₁ $ λ x hx, ((hf x hx).exists_lipschitz_on_with h₂)
+
+/-- The Hausdorff dimension of the range of a `C¹`-smooth function defined on a finite dimensional
+real normed space is at most the dimension of its domain as a vector space over `ℝ`. -/
+lemma times_cont_diff.dimH_range_le {f : E → F} (h : times_cont_diff ℝ 1 f) :
+  dimH (range f) ≤ finrank ℝ E :=
+calc dimH (range f) ≤ dimH (univ : set E) :
+  dimH_range_le_of_locally_lipschitz_on $ λ x, h.times_cont_diff_at.exists_lipschitz_on_with
+... = finrank ℝ E : real.dimH_univ_eq_finrank E
+
+/-- A particular of Sard's Theorem. Let `f : E → F` be a map between finite dimensional real vector
+spaces. Suppose that `f` is `C¹` smooth on a closed convex set `s` of Hausdorff dimension strictly
+less than the dimension of `F`. Then the complement of the image `f '' s` is dense in `F`. -/
+lemma times_cont_diff_on.dense_compl_image_of_dimH_lt_finrank [finite_dimensional ℝ F] {f : E → F}
+  {s : set E} (h : times_cont_diff_on ℝ 1 f s) (h₁ : is_closed s) (h₂ : convex s)
+  (hsF : dimH s < finrank ℝ F) :
+  dense (f '' s)ᶜ :=
+dense_compl_of_dimH_lt_finrank $ (h.dimH_image_le h₁ h₂).trans_lt hsF
+
+/-- A particular of Sard's Theorem. If `f` is a `C¹` smooth map from a real vector space to a real
+vector space `F` of strictly larger dimension, then the complement of the range of `f` is dense in
+`F`. -/
+lemma times_cont_diff.dense_compl_range_of_finrank_finrank_lt [finite_dimensional ℝ F] {f : E → F}
+  (h : times_cont_diff ℝ 1 f) (hEF : finrank ℝ E < finrank ℝ F) :
+  dense (range f)ᶜ :=
+dense_compl_of_dimH_lt_finrank $ h.dimH_range_le.trans_lt $ ennreal.coe_nat_lt_coe_nat.2 hEF

--- a/src/measure_theory/measure/hausdorff.lean
+++ b/src/measure_theory/measure/hausdorff.lean
@@ -131,6 +131,11 @@ Some sources define the `0`-dimensional Hausdorff measure to be the counting mea
 to be zero on subsingletons because this way we can have a
 `measure.has_no_atoms (measure.hausdorff_measure d)` instance.
 
+## TODO
+
+* prove that `1`-dimensional Hausdorff measure on `ℝ` equals `volume`;
+* prove a similar statement for `ℝ × ℝ`.
+
 ## References
 
 * [Herbert Federer, Geometric Measure Theory, Chapter 2.10][Federer1996]

--- a/src/measure_theory/measure/hausdorff.lean
+++ b/src/measure_theory/measure/hausdorff.lean
@@ -1269,18 +1269,19 @@ calc dimH (range f) ≤ dimH (univ : set E) :
   dimH_range_le_of_locally_lipschitz_on $ λ x, h.times_cont_diff_at.exists_lipschitz_on_with
 ... = finrank ℝ E : real.dimH_univ_eq_finrank E
 
-/-- A particular of Sard's Theorem. Let `f : E → F` be a map between finite dimensional real vector
-spaces. Suppose that `f` is `C¹` smooth on a closed convex set `s` of Hausdorff dimension strictly
-less than the dimension of `F`. Then the complement of the image `f '' s` is dense in `F`. -/
+/-- A particular case of Sard's Theorem. Let `f : E → F` be a map between finite dimensional real
+vector spaces. Suppose that `f` is `C¹` smooth on a closed convex set `s` of Hausdorff dimension
+strictly less than the dimension of `F`. Then the complement of the image `f '' s` is dense in
+`F`. -/
 lemma times_cont_diff_on.dense_compl_image_of_dimH_lt_finrank [finite_dimensional ℝ F] {f : E → F}
   {s : set E} (h : times_cont_diff_on ℝ 1 f s) (h₁ : is_closed s) (h₂ : convex s)
   (hsF : dimH s < finrank ℝ F) :
   dense (f '' s)ᶜ :=
 dense_compl_of_dimH_lt_finrank $ (h.dimH_image_le h₁ h₂).trans_lt hsF
 
-/-- A particular of Sard's Theorem. If `f` is a `C¹` smooth map from a real vector space to a real
-vector space `F` of strictly larger dimension, then the complement of the range of `f` is dense in
-`F`. -/
+/-- A particular case of Sard's Theorem. If `f` is a `C¹` smooth map from a real vector space to a
+real vector space `F` of strictly larger dimension, then the complement of the range of `f` is dense
+in `F`. -/
 lemma times_cont_diff.dense_compl_range_of_finrank_finrank_lt [finite_dimensional ℝ F] {f : E → F}
   (h : times_cont_diff ℝ 1 f) (hEF : finrank ℝ E < finrank ℝ F) :
   dense (range f)ᶜ :=

--- a/src/measure_theory/measure/hausdorff.lean
+++ b/src/measure_theory/measure/hausdorff.lean
@@ -46,7 +46,7 @@ measures.
 
 ## Main definitions
 
-* `msaure_theory.outer_measure.is_metric`: an outer measure `μ` is called *metric* if
+* `measure_theory.outer_measure.is_metric`: an outer measure `μ` is called *metric* if
   `μ (s ∪ t) = μ s + μ t` for any two metric separated sets `s` and `t`. A metric outer measure in a
   Borel extended metric space is guaranteed to satisfy the Caratheodory condition, see
   `measure_theory.outer_measure.is_metric.borel_le_caratheodory`.
@@ -66,6 +66,8 @@ measures.
   space we use `measure_theory.dimH (set.univ : set X)`.
 
 ## Main statements
+
+### Basic properties
 
 * `measure_theory.outer_measure.is_metric.borel_le_caratheodory`: if `μ` is a metric outer measure
   on an extended metric space `X` (that is, it is additive on pairs of metric separated sets), then
@@ -89,11 +91,28 @@ measures.
 * `measure_theory.measure.no_atoms_hausdorff`, `measure_theory.measure.dimH_empty`,
   `measure_theory.measure.dimH_singleton`, `set.subsingleton.dimH_zero`, `set.countable.dimH_zero`:
   Hausdorff measure has no atoms and `dimH s = 0` whenever `s` is countable.
+
+### (Pre)images under (anti)lipschitz and Hölder continuous maps
+
 * `holder_with.dimH_image_le` etc: if `f : X → Y` is Hölder continuous with exponent `r > 0`, then
   for any `s`, `dimH (f '' s) ≤ dimH s / r`. We prove versions of this statement for `holder_with`,
   `holder_on_with`, and locally Hölder maps, as well as for `set.image` and `set.range`.
 * `lipschitz_with.dimH_image_le` etc: Lipschitz continuous maps do not increase the Hausdorff
   dimension of sets.
+* for a map that is known to be both Lipschitz and antilipschitz (e.g., for an `isometry` or
+  a `continuous_linear_equiv`) we also prove `dimH (f '' s) = dimH s`.
+
+### Hausdorff measure in `ℝⁿ`
+
+* `measure_theory.hausdorff_measure_pi_real`: for a nonempty `ι`, `μH[card ι]` on `ι → ℝ` equals
+  Lebesgue measure.
+* `real.dimH_of_nonempty_interior`: if `s` is a set in a finite dimensional real vector space `E`
+  with nonempty interior, then the Hausdorff dimension of `s` is equal to the dimension of `E`.
+* `dense_compl_of_dimH_lt_finrank`: if `s` is a set in a finite dimensional real vector space `E`
+  with Hausdorff dimension strictly less than the dimension of `E`, the `s` has a dense complement.
+* `times_cont_diff.dense_compl_range_of_finrank_finrank_lt`: the complement to the range of a `C¹`
+  smooth map is dense provided that the dimension of the domain is strictly less than the dimension
+  of the codomain.
 
 ## Notations
 
@@ -1193,6 +1212,10 @@ begin
     rcases metric.nhds_basis_ball.mem_iff.1 this with ⟨r, hr0, hr⟩,
     simpa only [dimH_ball_pi_fin (e x) hr0] using dimH_mono hr }
 end
+
+theorem dimH_of_nonempty_interior {s : set E} (h : (interior s).nonempty) :
+  dimH s = finrank ℝ E :=
+let ⟨x, hx⟩ := h in dimH_of_mem_nhds (mem_interior_iff_mem_nhds.1 hx)
 
 variable (E)
 

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -436,6 +436,10 @@ begin
       simp only [or.by_cases, dif_neg this, dif_pos h], } }
 end
 
+instance is_noetherian_pi' {R ι M : Type*} [ring R] [add_comm_group M] [module R M] [fintype ι]
+  [is_noetherian R M] : is_noetherian R (ι → M) :=
+is_noetherian_pi
+
 end
 
 open is_noetherian submodule function

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -436,6 +436,9 @@ begin
       simp only [or.by_cases, dif_neg this, dif_pos h], } }
 end
 
+/-- A version of `is_noetherian_pi` for non-dependent functions. We need this instance because
+sometimes Lean fails to apply the dependent version in non-dependent settings (e.g., it fails to
+prove that `ι → ℝ` is finite dimensional over `ℝ`). -/
 instance is_noetherian_pi' {R ι M : Type*} [ring R] [add_comm_group M] [module R M] [fintype ι]
   [is_noetherian R M] : is_noetherian R (ι → M) :=
 is_noetherian_pi

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -539,6 +539,16 @@ begin
   exact λ x, ⟨x, mem_interior_iff_mem_nhds.2 (hf x)⟩
 end
 
+lemma countable_cover_nhds_within [second_countable_topology α] {f : α → set α} {s : set α}
+  (hf : ∀ x ∈ s, f x ∈ 𝓝[s] x) : ∃ t ⊆ s, countable t ∧ s ⊆ (⋃ x ∈ t, f x) :=
+begin
+  have : ∀ x : s, coe ⁻¹' (f x) ∈ 𝓝 x, from λ x, preimage_coe_mem_nhds_subtype.2 (hf x x.2),
+  rcases countable_cover_nhds this with ⟨t, htc, htU⟩,
+  refine ⟨coe '' t, subtype.coe_image_subset _ _, htc.image _, λ x hx, _⟩,
+  simp only [bUnion_image, eq_univ_iff_forall, ← preimage_Union, mem_preimage] at htU ⊢,
+  exact htU ⟨x, hx⟩
+end
+
 end topological_space
 
 open topological_space

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -400,6 +400,16 @@ theorem nhds_within_eq_map_subtype_coe {s : set α} {a : α} (h : a ∈ s) :
   𝓝[s] a = map (coe : s → α) (𝓝 ⟨a, h⟩) :=
 by simpa only [subtype.range_coe] using (embedding_subtype_coe.map_nhds_eq ⟨a, h⟩).symm
 
+theorem mem_nhds_subtype_iff_nhds_within {s : set α} {a : s} {t : set s} :
+  t ∈ 𝓝 a ↔ coe '' t ∈ 𝓝[s] (a : α) :=
+by rw [nhds_within_eq_map_subtype_coe a.coe_prop, mem_map,
+  preimage_image_eq _ subtype.coe_injective, subtype.coe_eta]
+
+theorem preimage_coe_mem_nhds_subtype {s t : set α} {a : s} :
+  coe ⁻¹' t ∈ 𝓝 a ↔ t ∈ 𝓝[s] ↑a :=
+by simp only [mem_nhds_subtype_iff_nhds_within, subtype.image_preimage_coe, inter_mem_iff,
+  self_mem_nhds_within, and_true]
+
 theorem tendsto_nhds_within_iff_subtype {s : set α} {a : α} (h : a ∈ s) (f : α → β) (l : filter β) :
   tendsto f (𝓝[s] a) l ↔ tendsto (s.restrict f) (𝓝 ⟨a, h⟩) l :=
 by simp only [tendsto, nhds_within_eq_map_subtype_coe h, filter.map_map, restrict]


### PR DESCRIPTION
* expand module docs;
* prove that a Lipschitz continuous map does not increase Hausdorff measure and Hausdorff dimension of sets;
* prove similar lemmas about Hölder continuous and antilipschitz maps;
* add convenience lemmas for some bundled types and for `Cⁿ` smooth maps;
* Hausdorff dimension of `ℝⁿ` equals `n`;
* prove a baby version of Sard's theorem: if `f : E → F` is a `C¹` smooth map between normed vector spaces such that `finrank ℝ E < finrank ℝ F`, then `(range f)ᶜ` is dense.

---
- [x] depends on: #8362 
- [x] depends on: #8554

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
