### PR TITLE
[Merged by Bors] - chore(.gitignore): ignore lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ all.lean
 /src/.noisy_files
 *~
 .DS_Store
+*.lock


### PR DESCRIPTION
Two reasons:
1. Sometimes these accidentally make it into PRs  (e.g. #8344)
2. Some editor plugins (like the git in vscode) update very frequently causing these files to appear and disappear quickly in the sidebar whenever lean compiles which is annoying

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
