### PR TITLE
[Merged by Bors] - chore(.docker): add missing library

### DIFF
--- a/.docker/debian/lean/Dockerfile
+++ b/.docker/debian/lean/Dockerfile
@@ -11,7 +11,7 @@ FROM debian as leanproject-builder
 
 USER root
 # install prerequisites
-RUN apt-get update && apt-get install curl git python3 python3-pip python3-venv -y && apt-get clean
+RUN apt-get update && apt-get install curl git python3 python3-pip python3-venv zlib1g-dev -y && apt-get clean
 # create a non-root user
 RUN useradd -m lean
 


### PR DESCRIPTION
Something must have changed that now needs this library. It's only installed in an intemediate build, anyway.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
