### PR TITLE
[Merged by Bors] - feat(order): if `f x ≤ f y → x ≤ y`, then `f` is injective

### DIFF
--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -388,7 +388,7 @@ end
 
 lemma injective_of_le_imp_le [partial_order α] [preorder β] (f : α → β)
   (h : ∀ {x y}, f x ≤ f y → x ≤ y) : function.injective f :=
-λ x y hxy, le_antisymm (h hxy.le) (h hxy.ge)
+λ x y hxy, (h hxy.le).antisymm (h hxy.ge)
 
 lemma strict_mono_of_monotone_of_injective [partial_order α] [partial_order β] {f : α → β}
   (h₁ : monotone f) (h₂ : injective f) : strict_mono f :=

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -386,6 +386,10 @@ begin
     apply h _ _ k }
 end
 
+lemma injective_of_le_imp_le [partial_order α] [preorder β] (f : α → β)
+  (h : ∀ {x y}, f x ≤ f y → x ≤ y) : function.injective f :=
+λ x y hxy, le_antisymm (h hxy.le) (h hxy.ge)
+
 lemma strict_mono_of_monotone_of_injective [partial_order α] [partial_order β] {f : α → β}
   (h₁ : monotone f) (h₂ : injective f) : strict_mono f :=
 λ a b h,

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -387,7 +387,7 @@ begin
 end
 
 lemma injective_of_le_imp_le [partial_order α] [preorder β] (f : α → β)
-  (h : ∀ {x y}, f x ≤ f y → x ≤ y) : function.injective f :=
+  (h : ∀ {x y}, f x ≤ f y → x ≤ y) : injective f :=
 λ x y hxy, (h hxy.le).antisymm (h hxy.ge)
 
 lemma strict_mono_of_monotone_of_injective [partial_order α] [partial_order β] {f : α → β}


### PR DESCRIPTION
I couldn't find this specific result, not assuming linear orders, anywhere and [the Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/If.20.60f.20x.20.E2.89.A4.20f.20y.20.E2.86.92.20x.20.E2.89.A4.20y.60.2C.20then.20.60f.60.20is.20injective) didn't get any responses, so I decided to PR the result.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
