### PR TITLE
[Merged by Bors] - feat(combinatorics/colex): order is decidable

### DIFF
--- a/src/combinatorics/colex.lean
+++ b/src/combinatorics/colex.lean
@@ -362,7 +362,7 @@ instance [linear_order α] : semilattice_sup_bot (finset.colex α) :=
 { ..finset.colex.order_bot,
   ..(by apply_instance : semilattice_sup (finset.colex α)) }
 
-noncomputable instance [linear_order α] [fintype α] : bounded_lattice (finset.colex α) :=
+instance [linear_order α] [fintype α] : bounded_lattice (finset.colex α) :=
 { top := finset.univ.to_colex,
   le_top := λ x, colex_le_of_subset (subset_univ _),
   ..(by apply_instance : semilattice_sup (finset.colex α)),

--- a/src/combinatorics/colex.lean
+++ b/src/combinatorics/colex.lean
@@ -181,14 +181,26 @@ end
 
 instance [linear_order α] : is_trichotomous (finset.colex α) (<) := ⟨lt_trichotomy⟩
 
--- It should be possible to do this computably but it doesn't seem to make any difference for now.
-noncomputable instance [linear_order α] : linear_order (finset.colex α) :=
+/-- Show that `colex.lt` is decidable. This isn't an instance since it's re-inferred from the
+(computable) `decidable_le` instance below. -/
+def colex_decidable_lt [linear_order α] {A B : finset α} : decidable (A.to_colex < B.to_colex) :=
+decidable_of_iff' (∃ (k ∈ B), (∀ x ∈ A ∪ B, k < x → (x ∈ A ↔ x ∈ B)) ∧ k ∉ A)
+begin
+  rw colex.lt_def,
+  apply exists_congr,
+  simp only [mem_union, exists_prop, or_imp_distrib, and_comm (_ ∈ B), and_assoc],
+  intro k,
+  refine and_congr_left' (forall_congr _),
+  tauto,
+end
+
+instance [linear_order α] : linear_order (finset.colex α) :=
 { le_refl := λ A, or.inr rfl,
   le_trans := le_trans,
   le_antisymm := λ A B AB BA, AB.elim (λ k, BA.elim (λ t, (asymm k t).elim) (λ t, t.symm)) id,
   le_total := λ A B,
           (lt_trichotomy A B).elim3 (or.inl ∘ or.inl) (or.inl ∘ or.inr) (or.inr ∘ or.inl),
-  decidable_le := classical.dec_rel _,
+  decidable_le := λ A B, @or.decidable _ _ (colex_decidable_lt) _,
   lt_iff_le_not_le := λ A B,
   begin
     split,
@@ -340,11 +352,11 @@ instance [linear_order α] : order_bot (finset.colex α) :=
   bot_le := λ x, empty_to_colex_le,
   ..(by apply_instance : partial_order (finset.colex α)) }
 
-noncomputable instance [linear_order α] : semilattice_inf_bot (finset.colex α) :=
+instance [linear_order α] : semilattice_inf_bot (finset.colex α) :=
 { ..finset.colex.order_bot,
   ..(by apply_instance : semilattice_inf (finset.colex α)) }
 
-noncomputable instance [linear_order α] : semilattice_sup_bot (finset.colex α) :=
+instance [linear_order α] : semilattice_sup_bot (finset.colex α) :=
 { ..finset.colex.order_bot,
   ..(by apply_instance : semilattice_sup (finset.colex α)) }
 

--- a/src/combinatorics/colex.lean
+++ b/src/combinatorics/colex.lean
@@ -181,16 +181,18 @@ end
 
 instance [linear_order α] : is_trichotomous (finset.colex α) (<) := ⟨lt_trichotomy⟩
 
-instance decidable_lt [linear_order α] {A B : finset α} : decidable (A.to_colex < B.to_colex) :=
-decidable_of_iff' (∃ (k ∈ B), (∀ x ∈ A ∪ B, k < x → (x ∈ A ↔ x ∈ B)) ∧ k ∉ A)
-begin
-  rw colex.lt_def,
-  apply exists_congr,
-  simp only [mem_union, exists_prop, or_imp_distrib, and_comm (_ ∈ B), and_assoc],
-  intro k,
-  refine and_congr_left' (forall_congr _),
-  tauto,
-end
+instance decidable_lt [linear_order α] : ∀ {A B : finset.colex α}, decidable (A < B) :=
+show ∀ A B : finset α, decidable (A.to_colex < B.to_colex),
+from λ A B, decidable_of_iff'
+  (∃ (k ∈ B), (∀ x ∈ A ∪ B, k < x → (x ∈ A ↔ x ∈ B)) ∧ k ∉ A)
+  begin
+    rw colex.lt_def,
+    apply exists_congr,
+    simp only [mem_union, exists_prop, or_imp_distrib, and_comm (_ ∈ B), and_assoc],
+    intro k,
+    refine and_congr_left' (forall_congr _),
+    tauto,
+  end
 
 instance [linear_order α] : linear_order (finset.colex α) :=
 { le_refl := λ A, or.inr rfl,
@@ -198,9 +200,9 @@ instance [linear_order α] : linear_order (finset.colex α) :=
   le_antisymm := λ A B AB BA, AB.elim (λ k, BA.elim (λ t, (asymm k t).elim) (λ t, t.symm)) id,
   le_total := λ A B,
           (lt_trichotomy A B).elim3 (or.inl ∘ or.inl) (or.inl ∘ or.inr) (or.inr ∘ or.inl),
-  decidable_le := λ A B, @or.decidable _ _ colex.decidable_lt _,
-  decidable_lt := λ A B, colex.decidable_lt,
-  decidable_eq := λ A B, decidable_of_iff' (A.to_colex = B.to_colex) iff.rfl,
+  decidable_le := λ A B, by apply_instance,
+  decidable_lt := λ A B, by apply_instance,
+  decidable_eq := λ A B, by apply_instance,
   lt_iff_le_not_le := λ A B,
   begin
     split,

--- a/src/combinatorics/colex.lean
+++ b/src/combinatorics/colex.lean
@@ -181,9 +181,7 @@ end
 
 instance [linear_order α] : is_trichotomous (finset.colex α) (<) := ⟨lt_trichotomy⟩
 
-/-- Show that `colex.lt` is decidable. This isn't an instance since it's re-inferred from the
-(computable) `decidable_le` instance below. -/
-def colex_decidable_lt [linear_order α] {A B : finset α} : decidable (A.to_colex < B.to_colex) :=
+instance decidable_lt [linear_order α] {A B : finset α} : decidable (A.to_colex < B.to_colex) :=
 decidable_of_iff' (∃ (k ∈ B), (∀ x ∈ A ∪ B, k < x → (x ∈ A ↔ x ∈ B)) ∧ k ∉ A)
 begin
   rw colex.lt_def,
@@ -200,7 +198,9 @@ instance [linear_order α] : linear_order (finset.colex α) :=
   le_antisymm := λ A B AB BA, AB.elim (λ k, BA.elim (λ t, (asymm k t).elim) (λ t, t.symm)) id,
   le_total := λ A B,
           (lt_trichotomy A B).elim3 (or.inl ∘ or.inl) (or.inl ∘ or.inr) (or.inr ∘ or.inl),
-  decidable_le := λ A B, @or.decidable _ _ (colex_decidable_lt) _,
+  decidable_le := λ A B, @or.decidable _ _ colex.decidable_lt _,
+  decidable_lt := λ A B, colex.decidable_lt,
+  decidable_eq := λ A B, decidable_of_iff' (A.to_colex = B.to_colex) iff.rfl,
   lt_iff_le_not_le := λ A B,
   begin
     split,
@@ -209,7 +209,7 @@ instance [linear_order α] : linear_order (finset.colex α) :=
       rintro (i | rfl),
       { apply asymm_of _ t i },
       { apply irrefl _ t } },
-    rintro ⟨(h₁ | rfl), h₂⟩,
+    rintro ⟨h₁ | rfl, h₂⟩,
     { apply h₁ },
     apply h₂.elim (or.inr rfl),
   end,


### PR DESCRIPTION
Show that the colex ordering is decidable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
