### PR TITLE
[Merged by Bors] - fix(order/lattice, tactic.simps): add missing `notation_class` attributes to `has_(bot,top,inf,sup,compl)`

### DIFF
--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -520,7 +520,7 @@ end generalized_boolean_algebra
 
 
 /-- Set / lattice complement -/
-class has_compl (α : Type*) := (compl : α → α)
+@[notation_class] class has_compl (α : Type*) := (compl : α → α)
 
 export has_compl (compl)
 

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -39,9 +39,9 @@ universes u v
 variables {α : Type u} {β : Type v}
 
 /-- Typeclass for the `⊤` (`\top`) notation -/
-class has_top (α : Type u) := (top : α)
+@[notation_class] class has_top (α : Type u) := (top : α)
 /-- Typeclass for the `⊥` (`\bot`) notation -/
-class has_bot (α : Type u) := (bot : α)
+@[notation_class] class has_bot (α : Type u) := (bot : α)
 
 notation `⊤` := has_top.top
 notation `⊥` := has_bot.bot

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import order.rel_classes
+import tactic.simps
 
 /-!
 # (Semi-)lattices
@@ -66,9 +67,9 @@ end
 /- TODO: automatic construction of dual definitions / theorems -/
 
 /-- Typeclass for the `⊔` (`\lub`) notation -/
-class has_sup (α : Type u) := (sup : α → α → α)
+@[notation_class] class has_sup (α : Type u) := (sup : α → α → α)
 /-- Typeclass for the `⊓` (`\glb`) notation -/
-class has_inf (α : Type u) := (inf : α → α → α)
+@[notation_class] class has_inf (α : Type u) := (inf : α → α → α)
 
 infix ⊔ := has_sup.sup
 infix ⊓ := has_inf.inf


### PR DESCRIPTION

From the docs for `simps`:

> `@[notation_class]` should be added to all classes that define notation, like `has_mul` and
> `has_zero`. This specifies that the projections that `@[simps]` used are the projections from
> these notation classes instead of the projections of the superclasses.
> Example: if `has_mul` is tagged with `@[notation_class]` then the projection used for `semigroup`
> will be `λ α hα, @has_mul.mul α (@semigroup.to_has_mul α hα)` instead of `@semigroup.mul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
