### PR TITLE
[Merged by Bors] - feat(group_theory/sylow): Generalize proof of first Sylow theorem

### DIFF
--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -406,13 +406,8 @@ end
 @[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
 by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
-@[simp] lemma _root_.add_subgroup.card_bot {h : fintype.{v} (⊥ : add_subgroup A)} :
-  @fintype.card (⊥ : add_subgroup A) h = 1 :=
-(@fintype.card_eq_one_iff (⊥ : add_subgroup A) h).2
-  ⟨⟨(0 : A), set.mem_singleton 0⟩, λ ⟨y, hy⟩, subtype.eq $ add_subgroup.mem_bot.1 hy⟩
-
 -- `@[to_additive]` doesn't work, because it converts the `1 : ℕ` to `0`.
-@[simp] lemma card_bot {h : fintype.{u} (⊥ : subgroup G)} :
+@[to_additive, simp] lemma card_bot {h : fintype.{u} (⊥ : subgroup G)} :
   @fintype.card (⊥ : subgroup G) h = 1 :=
 (@fintype.card_eq_one_iff (↥(⊥ : subgroup G)) h).2
   ⟨⟨(1 : G), set.mem_singleton 1⟩, λ ⟨y, hy⟩, subtype.eq $ subgroup.mem_bot.1 hy⟩

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -83,8 +83,10 @@ subgroup, subgroups
 
 open_locale big_operators
 
-variables {G : Type*} [group G]
-variables {A : Type*} [add_group A]
+universes u v
+
+variables {G : Type u} [group G]
+variables {A : Type v} [add_group A]
 
 set_option old_structure_cmd true
 
@@ -404,13 +406,15 @@ end
 @[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
 by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
-@[simp] lemma _root_.add_subgroup.card_bot : fintype.card (⊥ : add_subgroup A) = 1 :=
-fintype.card_eq_one_iff.2
+@[simp] lemma _root_.add_subgroup.card_bot {h : fintype.{v} (⊥ : add_subgroup A)} :
+  @fintype.card (⊥ : add_subgroup A) h = 1 :=
+(@fintype.card_eq_one_iff (⊥ : add_subgroup A) h).2
   ⟨⟨(0 : A), set.mem_singleton 0⟩, λ ⟨y, hy⟩, subtype.eq $ add_subgroup.mem_bot.1 hy⟩
 
 -- `@[to_additive]` doesn't work, because it converts the `1 : ℕ` to `0`.
-@[simp] lemma card_bot : fintype.card (⊥ : subgroup G) = 1 :=
-fintype.card_eq_one_iff.2
+@[simp] lemma card_bot {h : fintype.{u} (⊥ : subgroup G)} :
+  @fintype.card (⊥ : subgroup G) h = 1 :=
+(@fintype.card_eq_one_iff (↥(⊥ : subgroup G)) h).2
   ⟨⟨(1 : G), set.mem_singleton 1⟩, λ ⟨y, hy⟩, subtype.eq $ subgroup.mem_bot.1 hy⟩
 
 @[to_additive] lemma eq_top_of_card_eq [fintype H] [fintype G]
@@ -444,6 +448,11 @@ begin
   convert H.bot_or_nontrivial,
   rw nontrivial_iff_exists_ne_one
 end
+
+@[to_additive] lemma card_le_one_iff_eq_bot [fintype H] : fintype.card H ≤ 1 ↔ H = ⊥ :=
+⟨λ h, (eq_bot_iff_forall _).2
+    (λ x hx, by simpa [subtype.ext_iff] using fintype.card_le_one_iff.1 h ⟨x, hx⟩ 1),
+  λ h, by simp [h]⟩
 
 /-- The inf of two subgroups is their intersection. -/
 @[to_additive "The inf of two `add_subgroups`s is their intersection."]

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -406,7 +406,7 @@ by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
 /-! curly brackets `{}` are used here instead of instance brackets `[]` because
   the instance in a goal is often not the same as the one inferred by type class inference.  -/
-@[simp, to_additive] lemma card_bot {h : fintype ↥(⊥ : subgroup G)} :
+@[simp, to_additive] lemma card_bot {_ : fintype ↥(⊥ : subgroup G)} :
   fintype.card (⊥ : subgroup G)  = 1 :=
 fintype.card_eq_one_iff.2
   ⟨⟨(1 : G), set.mem_singleton 1⟩, λ ⟨y, hy⟩, subtype.eq $ subgroup.mem_bot.1 hy⟩

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -406,7 +406,7 @@ end
 @[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
 by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
-/- curly brackets `{}` are used here instead of instance brackets `[]` because
+/-! curly brackets `{}` are used here instead of instance brackets `[]` because
   the instance in a goal is often not the same as the one inferred by type class inference.  -/
 @[simp, to_additive] lemma card_bot {h : fintype.{u} (⊥ : subgroup G)} :
   fintype.card (⊥ : subgroup G)  = 1 :=

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -406,6 +406,8 @@ end
 @[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
 by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
+/- curly brackets `{}` are used here instead of instance brackets `[]` because
+  the instance in a goal is often not the same as the one inferred by type class inference.  -/
 @[simp, to_additive] lemma card_bot {h : fintype.{u} (⊥ : subgroup G)} :
   fintype.card (⊥ : subgroup G)  = 1 :=
 (@fintype.card_eq_one_iff (↥(⊥ : subgroup G)) h).2

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -406,7 +406,7 @@ end
 @[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
 by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
-@[to_additive, simp] lemma card_bot {h : fintype.{u} (⊥ : subgroup G)} :
+@[simp, to_additive] lemma card_bot [h : fintype.{u} (⊥ : subgroup G)] :
   @fintype.card (⊥ : subgroup G) h = 1 :=
 (@fintype.card_eq_one_iff (↥(⊥ : subgroup G)) h).2
   ⟨⟨(1 : G), set.mem_singleton 1⟩, λ ⟨y, hy⟩, subtype.eq $ subgroup.mem_bot.1 hy⟩

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -83,10 +83,8 @@ subgroup, subgroups
 
 open_locale big_operators
 
-universes u v
-
-variables {G : Type u} [group G]
-variables {A : Type v} [add_group A]
+variables {G : Type*} [group G]
+variables {A : Type*} [add_group A]
 
 set_option old_structure_cmd true
 
@@ -408,7 +406,7 @@ by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
 /- curly brackets `{}` are used here instead of instance brackets `[]` because
   the instance in a goal is often not the same as the one inferred by type class inference.  -/
-@[simp, to_additive] lemma card_bot {h : fintype.{u} (⊥ : subgroup G)} :
+@[simp, to_additive] lemma card_bot {h : fintype ↥(⊥ : subgroup G)} :
   fintype.card (⊥ : subgroup G)  = 1 :=
 fintype.card_eq_one_iff.2
   ⟨⟨(1 : G), set.mem_singleton 1⟩, λ ⟨y, hy⟩, subtype.eq $ subgroup.mem_bot.1 hy⟩

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -406,8 +406,8 @@ end
 @[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
 by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
-@[simp, to_additive] lemma card_bot [h : fintype.{u} (⊥ : subgroup G)] :
-  @fintype.card (⊥ : subgroup G) h = 1 :=
+@[simp, to_additive] lemma card_bot {h : fintype.{u} (⊥ : subgroup G)} :
+  fintype.card (⊥ : subgroup G)  = 1 :=
 (@fintype.card_eq_one_iff (↥(⊥ : subgroup G)) h).2
   ⟨⟨(1 : G), set.mem_singleton 1⟩, λ ⟨y, hy⟩, subtype.eq $ subgroup.mem_bot.1 hy⟩
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -410,7 +410,7 @@ by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
   the instance in a goal is often not the same as the one inferred by type class inference.  -/
 @[simp, to_additive] lemma card_bot {h : fintype.{u} (⊥ : subgroup G)} :
   fintype.card (⊥ : subgroup G)  = 1 :=
-(@fintype.card_eq_one_iff (↥(⊥ : subgroup G)) h).2
+fintype.card_eq_one_iff.2
   ⟨⟨(1 : G), set.mem_singleton 1⟩, λ ⟨y, hy⟩, subtype.eq $ subgroup.mem_bot.1 hy⟩
 
 @[to_additive] lemma eq_top_of_card_eq [fintype H] [fintype G]

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -404,7 +404,7 @@ end
 @[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
 by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
-/-! curly brackets `{}` are used here instead of instance brackets `[]` because
+/- curly brackets `{}` are used here instead of instance brackets `[]` because
   the instance in a goal is often not the same as the one inferred by type class inference.  -/
 @[simp, to_additive] lemma card_bot {_ : fintype ↥(⊥ : subgroup G)} :
   fintype.card (⊥ : subgroup G)  = 1 :=

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -406,7 +406,6 @@ end
 @[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
 by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 
--- `@[to_additive]` doesn't work, because it converts the `1 : ℕ` to `0`.
 @[to_additive, simp] lemma card_bot {h : fintype.{u} (⊥ : subgroup G)} :
   @fintype.card (⊥ : subgroup G) h = 1 :=
 (@fintype.card_eq_one_iff (↥(⊥ : subgroup G)) h).2

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -223,7 +223,7 @@ def fixed_points_mul_left_cosets_equiv_quotient (H : subgroup G) [fintype (H : s
   (λ a, (@mem_fixed_points_mul_left_cosets_iff_mem_normalizer _ _ _ _inst_2 _).symm)
   (by intros; refl)
 
-/-- If `H` is a subgroup of `G` of cardinality `p ^ n`, then
+/-- If `H` is a subgroup of `G` of cardinality `p ^ n`,
   then `H` is contained in a subgroup of cardinality `p ^ (n + 1)`
   if `p ^ (n + 1)` divides the cardinality of `G` -/
 theorem exists_subgroup_card_pow_succ [fintype G] {p : ℕ} {n : ℕ} [hp : fact p.prime]

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -290,7 +290,7 @@ theorem exists_subgroup_card_pow_prime_le [fintype G] (p : ℕ) : ∀ {n m : ℕ
 
 /-- A generalisation of **Sylow's first theorem**. If `p ^ n` divides
   the cardinality of `G`, then there is a subgroup of cardinality `p ^ n` -/
-theorem exists_subgroup_card_pow_prime [fintype G] (p : ℕ) {n : ℕ} [hp : fact p.prime]
+theorem exists_subgroup_card_pow_prime [fintype G] (p : ℕ) {n : ℕ} [fact p.prime]
   (hdvd : p ^ n ∣ card G) : ∃ K : subgroup G, fintype.card K = p ^ n :=
 let ⟨K, hK⟩ := exists_subgroup_card_pow_prime_le p hdvd ⊥ (by simp) n.zero_le in
 ⟨K, hK.1⟩

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -269,7 +269,7 @@ begin
   simpa using hy
 end⟩
 
-/-- If `H` is a subgroup of `G` of cardinality `p ^ n`, then
+/-- If `H` is a subgroup of `G` of cardinality `p ^ n`,
   then `H` is contained in a subgroup of cardinality `p ^ m`
   if `n ≤ m` and `p ^ m` divides the cardinality of `G` -/
 theorem exists_subgroup_card_pow_prime_le [fintype G] (p : ℕ) : ∀ {n m : ℕ} [hp : fact p.prime]


### PR DESCRIPTION
Generalize the first proof. There is now a proof that every p-subgroup is contained in a Sylow subgroup.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
