### PR TITLE
[Merged by Bors] - feat(topology/locally_constant): Adding a module structure to locally constant functions

### DIFF
--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -110,4 +110,29 @@ instance [ring Y] : ring (locally_constant X Y) :=
 instance [comm_ring Y] : comm_ring (locally_constant X Y) :=
 { .. locally_constant.comm_semiring, .. locally_constant.ring }
 
+variables (A : Type*) [semiring A]
+
+instance : has_scalar A (locally_constant X A) :=
+{ smul := λ a f,
+  { to_fun := λ x, a*f(x),
+    is_locally_constant := is_locally_constant.comp (is_locally_constant f)
+      (has_mul.mul a) } }
+
+instance : mul_action A (locally_constant X A) :=
+{ smul := (•),
+  one_smul := one_mul,
+  mul_smul := λ a b f, ext ( λ x, show a * b * f x = a * (b * f x), from mul_assoc _ _ _ ) }
+
+instance : distrib_mul_action A (locally_constant X A) :=
+{
+  smul_add := λ r f g, ext ( λ x, show  r * (f x + g x) = r * f x + r * g x, from mul_add _ _ _ ),
+  smul_zero := λ r, ext (λ x, mul_zero r),
+  ..locally_constant.mul_action A }
+
+instance : module A (locally_constant X A) :=
+{
+  add_smul := λ r s f, ext (λ x, show (r + s) * f x = r * f x + s * f x, from add_mul _ _ _),
+  zero_smul := zero_mul,
+  ..locally_constant.distrib_mul_action A }
+
 end locally_constant

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -35,7 +35,7 @@ variables {X Y : Type*} [topological_space X]
 @[to_additive] instance [has_mul Y] : has_mul (locally_constant X Y) :=
 { mul := λ f g, ⟨f * g, f.is_locally_constant.mul g.is_locally_constant⟩ }
 
-@[to_additive] lemma coe_mul [has_mul Y] (f g : locally_constant X Y) :
+@[simp, to_additive] lemma coe_mul [has_mul Y] (f g : locally_constant X Y) :
   ⇑(f * g) = f * g :=
 rfl
 

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -67,6 +67,9 @@ instance [mul_zero_one_class Y] : mul_zero_one_class (locally_constant X Y) :=
 @[to_additive] instance [has_div Y] : has_div (locally_constant X Y) :=
 { div := λ f g, ⟨f / g, f.is_locally_constant.div g.is_locally_constant⟩ }
 
+@[to_additive] lemma coe_div [has_div Y] (f g : locally_constant X Y) :
+  ⇑(f / g) = f / g := rfl
+
 @[to_additive] lemma div_apply [has_div Y] (f g : locally_constant X Y) (x : X) :
   (f / g) x = f x / g x := rfl
 

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -20,18 +20,26 @@ variables {X Y : Type*} [topological_space X]
 @[to_additive] instance [has_one Y] : has_one (locally_constant X Y) :=
 { one := const X 1 }
 
-@[simp, to_additive] lemma one_apply [has_one Y] (x : X) : (1 : locally_constant X Y) x = 1 := rfl
+@[simp, to_additive] lemma coe_one [has_one Y] : ⇑(1 : locally_constant X Y) = (1 : X → Y) := rfl
+
+@[to_additive] lemma one_apply [has_one Y] (x : X) : (1 : locally_constant X Y) x = 1 := rfl
 
 @[to_additive] instance [has_inv Y] : has_inv (locally_constant X Y) :=
 { inv := λ f, ⟨f⁻¹ , f.is_locally_constant.inv⟩ }
 
-@[simp, to_additive] lemma inv_apply [has_inv Y] (f : locally_constant X Y) (x : X) :
+@[simp, to_additive] lemma coe_inv [has_inv Y] (f : locally_constant X Y) : ⇑(f⁻¹) = f⁻¹ := rfl
+
+@[to_additive] lemma inv_apply [has_inv Y] (f : locally_constant X Y) (x : X) :
   f⁻¹ x = (f x)⁻¹ := rfl
 
 @[to_additive] instance [has_mul Y] : has_mul (locally_constant X Y) :=
 { mul := λ f g, ⟨f * g, f.is_locally_constant.mul g.is_locally_constant⟩ }
 
-@[simp, to_additive] lemma mul_apply [has_mul Y] (f g : locally_constant X Y) (x : X) :
+@[to_additive] lemma coe_mul [has_mul Y] (f g : locally_constant X Y) :
+  ⇑(f * g) = (f * g) :=
+rfl
+
+@[to_additive] lemma mul_apply [has_mul Y] (f g : locally_constant X Y) (x : X) :
   (f * g) x = f x * g x := rfl
 
 @[to_additive] instance [mul_one_class Y] : mul_one_class (locally_constant X Y) :=
@@ -117,16 +125,14 @@ instance [ring Y] : ring (locally_constant X Y) :=
 instance [comm_ring Y] : comm_ring (locally_constant X Y) :=
 { .. locally_constant.comm_semiring, .. locally_constant.ring }
 
-variables (R : Type*)
+variables {R : Type*}
 
 instance [has_scalar R Y] : has_scalar R (locally_constant X Y) :=
 { smul := λ r f,
   { to_fun := r • f,
     is_locally_constant := ((is_locally_constant f).comp ((•) r) : _), } }
 
-@[simp] lemma coe_smul [has_scalar R Y] (r : R) (f : locally_constant X Y) :
-  ⇑(r • f) = r • (f : X → Y) :=
-rfl
+@[simp] lemma coe_smul [has_scalar R Y] (r : R) (f : locally_constant X Y) : ⇑(r • f) = r • f := rfl
 
 lemma smul_apply [has_scalar R Y] (r : R) (f : locally_constant X Y) (x : X) :
   (r • f) x = r • (f x) :=

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -124,14 +124,12 @@ instance : mul_action M (locally_constant X M) :=
   mul_smul := λ a b f, ext ( λ x, mul_assoc _ _ _ ) }
 
 instance : distrib_mul_action A (locally_constant X A) :=
-{
-  smul_add := λ r f g, ext ( λ x, mul_add _ _ _ ),
+{ smul_add := λ r f g, ext ( λ x, mul_add _ _ _ ),
   smul_zero := λ r, ext (λ x, mul_zero r),
   ..locally_constant.mul_action A }
 
 instance : module A (locally_constant X A) :=
-{
-  add_smul := λ r s f, ext (λ x, add_mul _ _ _),
+{ add_smul := λ r s f, ext (λ x, add_mul _ _ _),
   zero_smul := zero_mul,
   ..locally_constant.distrib_mul_action A }
 

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -36,7 +36,7 @@ variables {X Y : Type*} [topological_space X]
 { mul := λ f g, ⟨f * g, f.is_locally_constant.mul g.is_locally_constant⟩ }
 
 @[to_additive] lemma coe_mul [has_mul Y] (f g : locally_constant X Y) :
-  ⇑(f * g) = (f * g) :=
+  ⇑(f * g) = f * g :=
 rfl
 
 @[to_additive] lemma mul_apply [has_mul Y] (f g : locally_constant X Y) (x : X) :

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -110,28 +110,28 @@ instance [ring Y] : ring (locally_constant X Y) :=
 instance [comm_ring Y] : comm_ring (locally_constant X Y) :=
 { .. locally_constant.comm_semiring, .. locally_constant.ring }
 
-variables (A : Type*) [semiring A]
+variables (M : Type*) [monoid M] (A : Type*) [semiring A]
 
-instance : has_scalar A (locally_constant X A) :=
+instance : has_scalar M (locally_constant X M) :=
 { smul := λ a f,
   { to_fun := λ x, a*f(x),
     is_locally_constant := is_locally_constant.comp (is_locally_constant f)
       (has_mul.mul a) } }
 
-instance : mul_action A (locally_constant X A) :=
+instance : mul_action M (locally_constant X M) :=
 { smul := (•),
   one_smul := one_mul,
-  mul_smul := λ a b f, ext ( λ x, show a * b * f x = a * (b * f x), from mul_assoc _ _ _ ) }
+  mul_smul := λ a b f, ext ( λ x, mul_assoc _ _ _ ) }
 
 instance : distrib_mul_action A (locally_constant X A) :=
 {
-  smul_add := λ r f g, ext ( λ x, show  r * (f x + g x) = r * f x + r * g x, from mul_add _ _ _ ),
+  smul_add := λ r f g, ext ( λ x, mul_add _ _ _ ),
   smul_zero := λ r, ext (λ x, mul_zero r),
   ..locally_constant.mul_action A }
 
 instance : module A (locally_constant X A) :=
 {
-  add_smul := λ r s f, ext (λ x, show (r + s) * f x = r * f x + s * f x, from add_mul _ _ _),
+  add_smul := λ r s f, ext (λ x, add_mul _ _ _),
   zero_smul := zero_mul,
   ..locally_constant.distrib_mul_action A }
 


### PR DESCRIPTION
We add an A-module structure to locally constant functions from a topological space to a semiring A.

This also adds the lemmas `coe_zero`, `coe_add`, `coe_neg`, `coe_sub`, `coe_one`, `coe_mul`, `coe_div`, `coe_inv` to match the new `coe_smul` lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
