### PR TITLE
[Merged by Bors] - feat(ring_theory): shortcut lemmas for `coe : ideal R → fractional_ideal R⁰ K`

### DIFF
--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -715,6 +715,23 @@ end
 ⟨imp_of_not_imp_not _ _ (map_ne_zero _),
  λ hI, hI.symm ▸ map_zero h⟩
 
+lemma coe_ideal_injective :
+  function.injective (coe : ideal R → fractional_ideal R⁰ K) :=
+injective_of_le_imp_le _ (λ _ _, (coe_ideal_le_coe_ideal _).mp)
+
+@[simp]
+lemma coe_ideal_eq_zero_iff
+  {I : ideal R} : (I : fractional_ideal R⁰ K) = 0 ↔ I = ⊥ :=
+by { rw ← coe_to_fractional_ideal_bot, exact coe_ideal_injective.eq_iff }
+
+lemma coe_ideal_ne_zero_iff
+  {I : ideal R} : (I : fractional_ideal R⁰ K) ≠ 0 ↔ I ≠ ⊥ :=
+not_iff_not.mpr coe_ideal_eq_zero_iff
+
+lemma coe_ideal_ne_zero
+  {I : ideal R} (hI : I ≠ ⊥) : (I : fractional_ideal R⁰ K) ≠ 0 :=
+coe_ideal_ne_zero_iff.mpr hI
+
 end is_fraction_ring
 
 section quotient

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -178,6 +178,14 @@ variables (S)
   x ∈ (I : fractional_ideal S P) ↔ ∃ x', x' ∈ I ∧ algebra_map R P x' = x :=
 mem_coe_submodule _ _
 
+lemma coe_ideal_le_coe_ideal' [is_localization S P] (h : S ≤ non_zero_divisors R)
+  {I J : ideal R} : (I : fractional_ideal S P) ≤ J ↔ I ≤ J :=
+coe_submodule_le_coe_submodule h
+
+@[simp] lemma coe_ideal_le_coe_ideal (K : Type*) [comm_ring K] [algebra R K] [is_fraction_ring R K]
+  {I J : ideal R} : (I : fractional_ideal R⁰ K) ≤ J ↔ I ≤ J :=
+is_fraction_ring.coe_submodule_le_coe_submodule
+
 instance : has_zero (fractional_ideal S P) := ⟨(0 : ideal R)⟩
 
 @[simp] lemma mem_zero_iff {x : P} : x ∈ (0 : fractional_ideal S P) ↔ x = 0 :=


### PR DESCRIPTION
These results were already available, but in a less convenient form that e.g. asked you to prove an inclusion of submonoids `S ≤ R⁰`. Specializing them to the common case where the fractional ideal is in the field of fractions should save a bit of headache in the common cases.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

 - [x] depends on: #8275 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
