### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/linear_isometry): add an upgrade from linear isometries between finite dimensional spaces of eq finrank to linear isometry equivs

### DIFF
--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -353,33 +353,23 @@ namespace linear_isometry
 
 open finite_dimensional linear_map
 
+variables {R₁ : Type*} [field R₁] [module R₁ E₁] [module R₁ F]
+  [finite_dimensional R₁ E₁] [finite_dimensional R₁ F]
+
 /-- A linear isometry between finite dimensional spaces of equal dimension can be upgraded
     to a linear isometry equivalence. -/
-noncomputable def linear_isometry_equiv_of_finrank_eq_finrank {R X Y : Type*}
-  [field R] [normed_group X] [semi_normed_group Y]
-  [module R X] [module R Y] [finite_dimensional R X] [finite_dimensional R Y]
-  (li : X →ₗᵢ[R] Y) (h : finrank R X = finrank R Y) : X ≃ₗᵢ[R] Y :=
+noncomputable def to_linear_isometry_equiv
+  (li : E₁ →ₗᵢ[R₁] F) (h : finrank R₁ E₁ = finrank R₁ F) : E₁ ≃ₗᵢ[R₁] F :=
 { to_linear_equiv := li.to_linear_map.linear_equiv_of_ker_eq_bot
     (ker_eq_bot_of_injective li.injective) h,
   norm_map' := li.norm_map' }
 
-lemma coe_linear_isometry_equiv_of_finrank_eq_finrank
-  {R X Y : Type*} [field R] [normed_group X] [semi_normed_group Y]
-  [module R X] [module R Y] [finite_dimensional R X] [finite_dimensional R Y]
-  (li : X →ₗᵢ[R] Y) (h : finrank R X = finrank R Y) :
-  (li.linear_isometry_equiv_of_finrank_eq_finrank h : X → Y) = li :=
-begin
-  rw ← linear_isometry_equiv.coe_to_linear_equiv,
-  funext,
-  simp only [linear_isometry_equiv_of_finrank_eq_finrank, linear_equiv_of_ker_eq_bot_apply],
-  rw li.coe_to_linear_map,
-end
+@[simp] lemma coe_to_linear_isometry_equiv
+  (li : E₁ →ₗᵢ[R₁] F) (h : finrank R₁ E₁ = finrank R₁ F) :
+  (li.to_linear_isometry_equiv h : E₁ → F) = li := rfl
 
-lemma linear_isometry_equiv_of_finrank_eq_finrank_apply
-  {R X Y : Type*} [field R] [normed_group X] [semi_normed_group Y]
-  [module R X] [module R Y] [finite_dimensional R X] [finite_dimensional R Y]
-  (li : X →ₗᵢ[R] Y) (h : finrank R X = finrank R Y) (x : X) :
-  (li.linear_isometry_equiv_of_finrank_eq_finrank h) x = li x :=
-by rw li.coe_linear_isometry_equiv_of_finrank_eq_finrank
+@[simp] lemma to_linear_isometry_equiv_apply
+  (li : E₁ →ₗᵢ[R₁] F) (h : finrank R₁ E₁ = finrank R₁ F) (x : E₁) :
+  (li.to_linear_isometry_equiv h) x = li x := rfl
 
 end linear_isometry

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import analysis.normed_space.basic
+import linear_algebra.finite_dimensional
 
 /-!
 # Linear isometries
@@ -347,3 +348,36 @@ lemma linear_isometry.id_to_linear_map :
   (linear_isometry.id.to_linear_map : E →ₗ[R] E) = linear_map.id := rfl
 
 end linear_isometry_equiv
+
+namespace linear_isometry
+
+open finite_dimensional linear_map
+
+noncomputable def linear_isometry_equiv_of_finrank_eq_finrank {R X Y : Type*}
+  [field R] [normed_group X] [semi_normed_group Y]
+  [module R X] [module R Y] [finite_dimensional R X] [finite_dimensional R Y]
+  (li : X →ₗᵢ[R] Y) (h : finrank R X = finrank R Y) : X ≃ₗᵢ[R] Y :=
+{ to_linear_equiv := li.to_linear_map.linear_equiv_of_ker_eq_bot
+    (ker_eq_bot_of_injective li.injective) h,
+  norm_map' := li.norm_map' }
+
+lemma coe_linear_isometry_equiv_of_finrank_eq_finrank
+  {R X Y : Type*} [field R] [normed_group X] [semi_normed_group Y]
+  [module R X] [module R Y] [finite_dimensional R X] [finite_dimensional R Y]
+  (li : X →ₗᵢ[R] Y) (h : finrank R X = finrank R Y) :
+  (li.linear_isometry_equiv_of_finrank_eq_finrank h : X → Y) = li :=
+begin
+  rw ← linear_isometry_equiv.coe_to_linear_equiv,
+  funext,
+  simp only [linear_isometry_equiv_of_finrank_eq_finrank, linear_equiv_of_ker_eq_bot_apply],
+  rw li.coe_to_linear_map,
+end
+
+lemma linear_isometry_equiv_of_finrank_eq_finrank_apply
+  {R X Y : Type*} [field R] [normed_group X] [semi_normed_group Y]
+  [module R X] [module R Y] [finite_dimensional R X] [finite_dimensional R Y]
+  (li : X →ₗᵢ[R] Y) (h : finrank R X = finrank R Y) (x : X) :
+  (li.linear_isometry_equiv_of_finrank_eq_finrank h) x = li x :=
+by rw li.coe_linear_isometry_equiv_of_finrank_eq_finrank
+
+end linear_isometry

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -353,6 +353,8 @@ namespace linear_isometry
 
 open finite_dimensional linear_map
 
+/-- A linear isometry between finite dimensional spaces of equal dimension can be upgraded
+    to a linear isometry equivalence. -/
 noncomputable def linear_isometry_equiv_of_finrank_eq_finrank {R X Y : Type*}
   [field R] [normed_group X] [semi_normed_group Y]
   [module R X] [module R Y] [finite_dimensional R X] [finite_dimensional R Y]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
This feature was previously discussed [here](https://github.com/leanprover-community/mathlib/pull/8367#issuecomment-882847953).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
