### PR TITLE
[Merged by Bors] - feat(order/bounded_lattice): add some disjoint lemmas

### DIFF
--- a/src/data/set/disjointed.lean
+++ b/src/data/set/disjointed.lean
@@ -57,6 +57,14 @@ theorem pairwise_disjoint_on_nat [semilattice_inf_bot α] (f : ℕ → α) :
   pairwise (disjoint on f) ↔ ∀ (m n) (h : m < n), disjoint (f m) (f n) :=
 pairwise_on_nat disjoint.symm f
 
+lemma pairwise_disjoint_on_inter_right {f : β → set α} {a : set α}
+  (hf : pairwise (disjoint on f)) : pairwise (disjoint on (λ n, a ∩ f n)) :=
+hf.mono $ λ i j, disjoint.mono inf_le_right inf_le_right
+
+lemma pairwise_disjoint_on_inter_left {f : β → set α} {a : set α}
+  (hf : pairwise (disjoint on f)) : pairwise (disjoint on (λ n, f n ∩ a)) :=
+hf.mono $ λ i j, disjoint.mono inf_le_left inf_le_left
+
 theorem pairwise.pairwise_on {p : α → α → Prop} (h : pairwise p) (s : set α) : s.pairwise_on p :=
 λ x hx y hy, h x y
 
@@ -131,5 +139,21 @@ lemma Union_disjointed_of_mono (hf : monotone f) (n : ℕ) :
   (⋃ i < n.succ, disjointed f i) = f n :=
 subset.antisymm (bUnion_subset $ λ k hk, subset.trans disjointed_subset $ hf $ nat.lt_succ_iff.1 hk)
   subset_Union_disjointed
+
+lemma Union_inter_disjointed_eq {f : ℕ → set α} {a : set α} (ha : a ⊆ ⋃ n, f n) :
+  (⋃ n, a ∩ disjointed f n) = a :=
+by rwa [← inter_Union, set.Union_disjointed, inter_eq_left_iff_subset]
+
+lemma Union_disjoint_inter_eq {f : ℕ → set α} {a : set α} (ha : a ⊆ ⋃ n, f n) :
+  (⋃ n, disjointed f n ∩ a) = a :=
+by rwa [← Union_inter, set.Union_disjointed, inter_eq_right_iff_subset]
+
+lemma pairwise_disjoint_on_inter_disjointed {f : ℕ → set α} {a : set α} :
+  pairwise $ disjoint on (λ n, a ∩ disjointed f n) :=
+pairwise_disjoint_on_inter_right disjoint_disjointed
+
+lemma pairwise_disjoint_on_disjointed_inter {f : ℕ → set α} {a : set α} :
+  pairwise $ disjoint on (λ n, disjointed f n ∩ a) :=
+pairwise_disjoint_on_inter_left disjoint_disjointed
 
 end set

--- a/src/data/set/disjointed.lean
+++ b/src/data/set/disjointed.lean
@@ -57,14 +57,6 @@ theorem pairwise_disjoint_on_nat [semilattice_inf_bot α] (f : ℕ → α) :
   pairwise (disjoint on f) ↔ ∀ (m n) (h : m < n), disjoint (f m) (f n) :=
 pairwise_on_nat disjoint.symm f
 
-lemma pairwise_disjoint_on_inter_right {f : β → set α} {a : set α}
-  (hf : pairwise (disjoint on f)) : pairwise (disjoint on (λ n, a ∩ f n)) :=
-hf.mono $ λ i j, disjoint.mono inf_le_right inf_le_right
-
-lemma pairwise_disjoint_on_inter_left {f : β → set α} {a : set α}
-  (hf : pairwise (disjoint on f)) : pairwise (disjoint on (λ n, f n ∩ a)) :=
-hf.mono $ λ i j, disjoint.mono inf_le_left inf_le_left
-
 theorem pairwise.pairwise_on {p : α → α → Prop} (h : pairwise p) (s : set α) : s.pairwise_on p :=
 λ x hx y hy, h x y
 
@@ -139,21 +131,5 @@ lemma Union_disjointed_of_mono (hf : monotone f) (n : ℕ) :
   (⋃ i < n.succ, disjointed f i) = f n :=
 subset.antisymm (bUnion_subset $ λ k hk, subset.trans disjointed_subset $ hf $ nat.lt_succ_iff.1 hk)
   subset_Union_disjointed
-
-lemma Union_inter_disjointed_eq {f : ℕ → set α} {a : set α} (ha : a ⊆ ⋃ n, f n) :
-  (⋃ n, a ∩ disjointed f n) = a :=
-by rwa [← inter_Union, set.Union_disjointed, inter_eq_left_iff_subset]
-
-lemma Union_disjoint_inter_eq {f : ℕ → set α} {a : set α} (ha : a ⊆ ⋃ n, f n) :
-  (⋃ n, disjointed f n ∩ a) = a :=
-by rwa [← Union_inter, set.Union_disjointed, inter_eq_right_iff_subset]
-
-lemma pairwise_disjoint_on_inter_disjointed {f : ℕ → set α} {a : set α} :
-  pairwise $ disjoint on (λ n, a ∩ disjointed f n) :=
-pairwise_disjoint_on_inter_right disjoint_disjointed
-
-lemma pairwise_disjoint_on_disjointed_inter {f : ℕ → set α} {a : set α} :
-  pairwise $ disjoint on (λ n, disjointed f n ∩ a) :=
-pairwise_disjoint_on_inter_left disjoint_disjointed
 
 end set

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -1223,6 +1223,18 @@ hs.sup_left ht
 theorem union_right (ht : disjoint s t) (hu : disjoint s u) : disjoint s (t ∪ u) :=
 ht.sup_right hu
 
+lemma inter_left (u : set α) (h : disjoint s t) : disjoint (s ∩ u) t :=
+inf_left _ h
+
+lemma inter_left' (u : set α) (h : disjoint s t) : disjoint (u ∩ s) t :=
+inf_left' _ h
+
+lemma inter_right (u : set α) (h : disjoint s t) : disjoint s (t ∩ u) :=
+inf_right _ h
+
+lemma inter_right' (u : set α) (h : disjoint s t) : disjoint s (u ∩ t) :=
+inf_right' _ h
+
 lemma preimage {α β} (f : α → β) {s t : set β} (h : disjoint s t) : disjoint (f ⁻¹' s) (f ⁻¹' t) :=
 λ x hx, h hx
 

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -1093,6 +1093,24 @@ lemma disjoint.left_le_of_le_sup_left {a b c : α} (h : a ≤ c ⊔ b) (hd : dis
 
 end bounded_distrib_lattice
 
+section semilattice_inf_bot
+
+variables [semilattice_inf_bot α] {a b : α} (c : α)
+
+lemma disjoint.inf_left (h : disjoint a b) : disjoint (a ⊓ c) b :=
+h.mono_left inf_le_left
+
+lemma disjoint.inf_left' (h : disjoint a b) : disjoint (c ⊓ a) b :=
+h.mono_left inf_le_right
+
+lemma disjoint.inf_right (h : disjoint a b) : disjoint a (b ⊓ c) :=
+h.mono_right inf_le_left
+
+lemma disjoint.inf_right' (h : disjoint a b) : disjoint a (c ⊓ b) :=
+h.mono_right inf_le_right
+
+end semilattice_inf_bot
+
 end disjoint
 
 section is_compl


### PR DESCRIPTION
This adds `disjoint.inf_left` and `disjoint.inf_right` (and primed variants) to match the existing `disjoint.sup_left` and `disjoint.sup_right`.

This also duplicates these lemmas to use set notation with `inter` instead of `inf`, matching the existing `disjoint.union_left` and `disjoint.union_right`.

---
This was written by @eric-wieser, from [here](https://github.com/leanprover-community/mathlib/pull/8388#discussion_r675484348).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
