### PR TITLE
[Merged by Bors] - feat(measure_theory/vector_measure): add partial order instance to vector measures

### DIFF
--- a/src/measure_theory/measure_space.lean
+++ b/src/measure_theory/measure_space.lean
@@ -465,6 +465,12 @@ rfl
 
 /-! ### The complete lattice of measures -/
 
+/-- Measures are partially ordered.
+
+The definition of less equal here is equivalent to the definition without the
+measurable set condition, and this is shown by `measure.le_iff'`. It is defined
+this way since, to prove `μ ≤ ν`, we may simply `intros s hs` instead of rewriting followed
+by `intros s hs`. -/
 instance : partial_order (measure α) :=
 { le          := λ m₁ m₂, ∀ s, measurable_set s → m₁ s ≤ m₂ s,
   le_refl     := assume m s hs, le_refl _,

--- a/src/measure_theory/vector_measure.lean
+++ b/src/measure_theory/vector_measure.lean
@@ -429,7 +429,9 @@ end measure
 
 namespace vector_measure
 
-variables {M : Type*} [topological_space M] [ordered_add_comm_monoid M]
+section
+
+variables {M : Type*} [topological_space M] [add_comm_monoid M] [partial_order M]
 
 instance : partial_order (vector_measure α M) :=
 { le          := λ v w, ∀ i, measurable_set i → v i ≤ w i,
@@ -450,9 +452,12 @@ begin
   { rw [v.not_measurable hi, w.not_measurable hi] }
 end
 
+end
+
 section
 
-variable [has_continuous_add M]
+variables {M : Type*} [topological_space M] [add_comm_monoid M] [partial_order M]
+  [covariant_class M M (+) (≤)] [has_continuous_add M]
 
 instance covariant_add_le :
   covariant_class (vector_measure α M) (vector_measure α M) (+) (≤) :=

--- a/src/measure_theory/vector_measure.lean
+++ b/src/measure_theory/vector_measure.lean
@@ -424,7 +424,41 @@ begin
   rw [sub_to_signed_measure, vector_measure.sub_apply, to_signed_measure_apply_measurable hi,
       measure.to_signed_measure_apply_measurable hi, sub_eq_add_neg]
 end
-
 end measure
+
+namespace vector_measure
+
+variables {M : Type*} [topological_space M] [ordered_add_comm_monoid M]
+
+instance : partial_order (vector_measure α M) :=
+{ le          := λ v w, ∀ i, measurable_set i → v i ≤ w i,
+  le_refl     := λ v i hi, le_refl _,
+  le_trans    := λ u v w h₁ h₂ i hi, le_trans (h₁ i hi) (h₂ i hi),
+  le_antisymm := λ v w h₁ h₂, ext (λ i hi, le_antisymm (h₁ i hi) (h₂ i hi)) }
+
+variables {u v w : vector_measure α M}
+
+lemma le_iff : v ≤ w ↔ ∀ i, measurable_set i → v i ≤ w i :=
+iff.rfl
+
+lemma le_iff' : v ≤ w ↔ ∀ i, v i ≤ w i :=
+begin
+  refine ⟨λ h i, _, λ h i hi, h i⟩,
+  by_cases hi : measurable_set i,
+  { exact h i hi },
+  { rw [v.not_measurable hi, w.not_measurable hi] }
+end
+
+section
+
+variable [has_continuous_add M]
+
+instance covariant_add_le :
+  covariant_class (vector_measure α M) (vector_measure α M) (+) (≤) :=
+⟨λ u v w h i hi, add_le_add_left (h i hi) _⟩
+
+end
+
+end vector_measure
 
 end measure_theory

--- a/src/measure_theory/vector_measure.lean
+++ b/src/measure_theory/vector_measure.lean
@@ -424,6 +424,7 @@ begin
   rw [sub_to_signed_measure, vector_measure.sub_apply, to_signed_measure_apply_measurable hi,
       measure.to_signed_measure_apply_measurable hi, sub_eq_add_neg]
 end
+
 end measure
 
 namespace vector_measure

--- a/src/measure_theory/vector_measure.lean
+++ b/src/measure_theory/vector_measure.lean
@@ -433,6 +433,9 @@ section
 
 variables {M : Type*} [topological_space M] [add_comm_monoid M] [partial_order M]
 
+/-- Vector measures over a partially ordered monoid is partially ordered.
+
+This definition is consistent with `measure.partial_order`. -/
 instance : partial_order (vector_measure α M) :=
 { le          := λ v w, ∀ i, measurable_set i → v i ≤ w i,
   le_refl     := λ v i hi, le_refl _,


### PR DESCRIPTION

---
I defined partial order on vector measures the same way as it was done for measures: requiring measurability in the definition and include a lemma without the condition `le_iff'`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
