### PR TITLE
[Merged by Bors] - chore(data/pnat/basic): rename `bot_eq_zero` to `bot_eq_one`, generalize from `Prop` to `Sort*`

### DIFF
--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -213,9 +213,7 @@ begin
   { exact (lt_irrefl 0 kprop).elim },
   cases k with k,
   { exact hz },
-  refine hi ⟨k.succ, nat.succ_pos _⟩ (λ ⟨m, _⟩ hm, hk _ _),
-  rw lt_add_one_iff_le,
-  exact hm,
+  exact hi ⟨k.succ, nat.succ_pos _⟩ (λ m hm, hk _ (lt_succ_iff.2 hm)),
 end
 
 /-- An induction principle for `ℕ+`: it takes values in `Sort*`, so it applies also to Types,

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -131,7 +131,7 @@ instance : inhabited ℕ+ := ⟨1⟩
 @[simp] lemma mk_bit1 (n) {h} {k} : (⟨bit1 n, h⟩ : ℕ+) = (bit1 ⟨n, k⟩ : ℕ+) := rfl
 
 -- Some lemmas that rewrite inequalities between explicit numerals in `ℕ+`
--- into the corresponding inequalities in `nat`.
+-- into the corresponding inequalities in `ℕ`.
 -- TODO: perhaps this should not be attempted by `simp`,
 -- and instead we should expect `norm_num` to take care of these directly?
 -- TODO: these lemmas are perhaps incomplete:
@@ -204,6 +204,7 @@ lemma exists_eq_succ_of_ne_one : ∀ {n : ℕ+} (h1 : n ≠ 1), ∃ (k : ℕ+), 
 | ⟨1, _⟩ h1 := false.elim $ h1 rfl
 | ⟨n+2, _⟩ _ := ⟨⟨n+1, by simp⟩, rfl⟩
 
+/-- Strong induction on `ℕ+`, with `n = 1` treated separately. -/
 def case_strong_induction_on {p : ℕ+ → Sort*} (a : ℕ+) (hz : p 1)
   (hi : ∀ n, (∀ m, m ≤ n → p m) → p (n + 1)) : p a :=
 begin

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -195,7 +195,7 @@ theorem add_sub_of_lt {a b : ℕ+} : a < b → a + (b - a) = b :=
 instance : has_well_founded ℕ+ := ⟨(<), measure_wf coe⟩
 
 /-- Strong induction on `ℕ+`. -/
-lemma strong_induction_on {p : ℕ+ → Sort*} : ∀ (n : ℕ+) (h : ∀ k, (∀ m, m < k → p m) → p k), p n
+def strong_induction_on {p : ℕ+ → Sort*} : ∀ (n : ℕ+) (h : ∀ k, (∀ m, m < k → p m) → p k), p n
 | n := λ IH, IH _ (λ a h, strong_induction_on a IH)
 using_well_founded { dec_tac := `[assumption] }
 
@@ -204,7 +204,7 @@ lemma exists_eq_succ_of_ne_one : ∀ {n : ℕ+} (h1 : n ≠ 1), ∃ (k : ℕ+), 
 | ⟨1, _⟩ h1 := false.elim $ h1 rfl
 | ⟨n+2, _⟩ _ := ⟨⟨n+1, by simp⟩, rfl⟩
 
-lemma case_strong_induction_on {p : ℕ+ → Sort*} (a : ℕ+) (hz : p 1)
+def case_strong_induction_on {p : ℕ+ → Sort*} (a : ℕ+) (hz : p 1)
   (hi : ∀ n, (∀ m, m ≤ n → p m) → p (n + 1)) : p a :=
 begin
   apply strong_induction_on a,


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
`bot_eq_zero : (⊥ : ℕ+) = 1` sounded odd!
I also did some whitespace changes and generalized `strong_induction_on` from `ℕ+ → Prop` to `ℕ+ → Sort*`.
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
