### PR TITLE
[Merged by Bors] - feat(data/fintype/basic): provide a `fintype` instance for `sym α n`

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1118,7 +1118,7 @@ instance finset.fintype [fintype α] : fintype (finset α) :=
 fintype.of_equiv _ (equiv.subtype_injective_equiv_embedding α β)
 
 instance [decidable_eq α] [fintype α] {n : ℕ} : fintype (sym.sym' α n) :=
-by { unfold sym.sym' vector.perm.is_setoid, exact quotient.fintype _ }
+quotient.fintype _
 
 instance [decidable_eq α] [fintype α] {n : ℕ} : fintype (sym α n) :=
 fintype.of_equiv _ sym.sym_equiv_sym'.symm

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro
 import data.array.lemmas
 import data.finset.pi
 import data.finset.powerset
+import data.sym
 import group_theory.perm.basic
 import order.well_founded
 import tactic.wlog
@@ -1115,6 +1116,15 @@ instance finset.fintype [fintype α] : fintype (finset α) :=
 @[irreducible] instance function.embedding.fintype {α β} [fintype α] [fintype β]
   [decidable_eq α] [decidable_eq β] : fintype (α ↪ β) :=
 fintype.of_equiv _ (equiv.subtype_injective_equiv_embedding α β)
+
+instance [decidable_eq α] [fintype α] {n : ℕ} : fintype (sym.sym' α n) :=
+begin
+  unfold sym.sym' vector.perm.is_setoid,
+  exact quotient.fintype _,
+end
+
+instance [decidable_eq α] [fintype α] {n : ℕ} : fintype (sym α n) :=
+fintype.of_equiv _ sym.sym_equiv_sym'.symm
 
 @[simp] lemma fintype.card_finset [fintype α] :
   fintype.card (finset α) = 2 ^ (fintype.card α) :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1118,10 +1118,7 @@ instance finset.fintype [fintype α] : fintype (finset α) :=
 fintype.of_equiv _ (equiv.subtype_injective_equiv_embedding α β)
 
 instance [decidable_eq α] [fintype α] {n : ℕ} : fintype (sym.sym' α n) :=
-begin
-  unfold sym.sym' vector.perm.is_setoid,
-  exact quotient.fintype _,
-end
+by { unfold sym.sym' vector.perm.is_setoid, exact quotient.fintype _ }
 
 instance [decidable_eq α] [fintype α] {n : ℕ} : fintype (sym α n) :=
 fintype.of_equiv _ sym.sym_equiv_sym'.symm

--- a/src/data/sym.lean
+++ b/src/data/sym.lean
@@ -39,7 +39,10 @@ def sym (α : Type u) (n : ℕ) := {s : multiset α // s.card = n}
 
 /--
 This is the `list.perm` setoid lifted to `vector`.
+
+See note [reducible non-instances].
 -/
+@[reducible]
 def vector.perm.is_setoid (α : Type u) (n : ℕ) : setoid (vector α n) :=
 { r := λ a b, list.perm a.1 b.1,
   iseqv := by { rcases list.perm.eqv α with ⟨hr, hs, ht⟩, tidy, } }


### PR DESCRIPTION
This also provides `fintype (sym.sym' α n)` as an intermediate step.

Note we make `vector.perm.is_setoid` reducible as `quotient.fintype _` requires either this or `local attribute [instance] vector.perm.is_setoid` to be accepted by the elaborator.
The referenced library note suggests making it reducible is fine.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
