### PR TITLE
[Merged by Bors] - fix(algebra/ordered_group): add missing `to_additive`, fix `simps`

### DIFF
--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -565,8 +565,8 @@ alias le_sub_iff_add_le ↔ add_le_of_le_sub_right le_sub_right_of_add_le
 lemma div_le_iff_le_mul : a / c ≤ b ↔ a ≤ b * c :=
 by rw [← mul_le_mul_iff_right c, div_eq_mul_inv, inv_mul_cancel_right]
 
-/-- `equiv.mul_right` as an order_iso. -/
-@[to_additive, simps to_equiv apply {simp_rhs := tt}]
+/-- `equiv.mul_right` as an `order_iso`. -/
+@[to_additive "`equiv.add_right` as an `order_iso`.", simps to_equiv apply {simp_rhs := tt}]
 def order_iso.mul_right (a : α) : α ≃o α :=
 { map_rel_iff' := λ _ _, mul_le_mul_iff_right a, to_equiv := equiv.mul_right a }
 
@@ -579,8 +579,8 @@ end right
 section left
 variables [covariant_class α α (*) (≤)]
 
-/-- `equiv.mul_left` as an order_iso. -/
-@[to_additive, simps to_equiv apply  {simp_rhs := tt}]
+/-- `equiv.mul_left` as an `order_iso`. -/
+@[to_additive "`equiv.add_left` as an `order_iso`.", simps to_equiv apply  {simp_rhs := tt}]
 def order_iso.mul_left (a : α) : α ≃o α :=
 { map_rel_iff' := λ _ _, mul_le_mul_iff_left a, to_equiv := equiv.mul_left a }
 

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -566,9 +566,13 @@ lemma div_le_iff_le_mul : a / c ≤ b ↔ a ≤ b * c :=
 by rw [← mul_le_mul_iff_right c, div_eq_mul_inv, inv_mul_cancel_right]
 
 /-- `equiv.mul_right` as an order_iso. -/
-@[simps {simp_rhs := tt}]
+@[to_additive, simps to_equiv apply {simp_rhs := tt}]
 def order_iso.mul_right (a : α) : α ≃o α :=
-{ map_rel_iff' := λ _ _, mul_le_mul_iff_right a, ..equiv.mul_right a }
+{ map_rel_iff' := λ _ _, mul_le_mul_iff_right a, to_equiv := equiv.mul_right a }
+
+@[simp, to_additive] lemma order_iso.mul_right_symm (a : α) :
+  (order_iso.mul_right a).symm = order_iso.mul_right a⁻¹ :=
+by { ext x, refl }
 
 end right
 
@@ -576,9 +580,13 @@ section left
 variables [covariant_class α α (*) (≤)]
 
 /-- `equiv.mul_left` as an order_iso. -/
-@[simps {simp_rhs := tt}]
+@[to_additive, simps to_equiv apply  {simp_rhs := tt}]
 def order_iso.mul_left (a : α) : α ≃o α :=
-{ map_rel_iff' := λ _ _, mul_le_mul_iff_left a, ..equiv.mul_left a }
+{ map_rel_iff' := λ _ _, mul_le_mul_iff_left a, to_equiv := equiv.mul_left a }
+
+@[simp, to_additive] lemma order_iso.mul_left_symm (a : α) :
+  (order_iso.mul_left a).symm = order_iso.mul_left a⁻¹ :=
+by { ext x, refl }
 
 variables [covariant_class α α (function.swap (*)) (≤)] {a b c : α}
 


### PR DESCRIPTION
* Add `order_iso.add_left` and `order_iso.add_right`.
* Use `to_equiv :=` instead of `..` to ensure
  `rfl : (order_iso.mul_right a).to_equiv = equiv.mul_right a`.
* Simplify unapplied `(order_iso.mul_left a).symm` etc.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
