### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/basic): define inclusion `locally_constant X G → C(X, G)` as various types of bundled morphism

### DIFF
--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -1997,11 +1997,11 @@ end uniform_space
 
 namespace locally_constant
 
-variables {X Y : Type*} [topological_space X] (f : locally_constant X Y)
+variables {X Y : Type*} [topological_space X] [topological_space Y] (f : locally_constant X Y)
 
 section monoid_hom
 
-variables [monoid Y] [topological_space Y] [has_continuous_mul Y]
+variables [monoid Y] [has_continuous_mul Y]
 
 /-- The inclusion of locally-constant functions into continuous functions as a multiplicative
 monoid hom. -/
@@ -2021,8 +2021,7 @@ end monoid_hom
 section linear_map
 
 variables (R : Type*) [semiring R] [topological_space R]
-variables [add_comm_monoid Y] [module R Y]
-variables [topological_space Y] [has_continuous_add Y] [has_continuous_smul R Y]
+variables [add_comm_monoid Y] [module R Y] [has_continuous_add Y] [has_continuous_smul R Y]
 
 /-- The inclusion of locally-constant functions into continuous functions as a linear map. -/
 def to_continuous_map_linear_map : locally_constant X Y →ₗ[R] C(X, Y) :=
@@ -2039,8 +2038,7 @@ end linear_map
 section alg_hom
 
 variables (R : Type*) [comm_semiring R] [topological_space R]
-variables [semiring Y] [algebra R Y]
-variables [topological_space Y] [topological_semiring Y] [has_continuous_smul R Y]
+variables [semiring Y] [algebra R Y] [topological_semiring Y] [has_continuous_smul R Y]
 
 /-- The inclusion of locally-constant functions into continuous functions as an algebra map. -/
 def to_continuous_map_alg_hom : locally_constant X Y →ₐ[R] C(X, Y) :=

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -1997,38 +1997,64 @@ end uniform_space
 
 namespace locally_constant
 
-variables {X G R : Type*} [topological_space X] [normed_group G] [normed_ring R]
+variables {X Y : Type*} [topological_space X] (f : locally_constant X Y)
 
-def to_continuous_map_monoid_hom : locally_constant X G →+ C(X, G) :=
+section monoid_hom
+
+variables [monoid Y] [topological_space Y] [has_continuous_mul Y]
+
+/-- The inclusion of locally-constant functions into continuous functions as a multiplicative
+monoid hom. -/
+@[to_additive "The inclusion of locally-constant functions into continuous functions as an
+additive monoid hom."]
+def to_continuous_map_monoid_hom : locally_constant X Y →* C(X, Y) :=
 { to_fun    := coe,
-  map_zero' := by { ext, simp, },
-  map_add'  := λ x y, by { ext, simp, }, }
+  map_one' := by { ext, simp, },
+  map_mul'  := λ x y, by { ext, simp, }, }
 
-@[simp] lemma coe_to_continuous_map_monoid_hom (f : locally_constant X G) :
-  (f.to_continuous_map_monoid_hom : X → G) = f :=
+@[simp, to_additive] lemma coe_to_continuous_map_monoid_hom :
+  (f.to_continuous_map_monoid_hom : X → Y) = f :=
 rfl
 
-def to_continuous_map_linear_map : locally_constant X R →ₗ[R] C(X, R) :=
+end monoid_hom
+
+section linear_map
+
+variables (R : Type*) [semiring R] [topological_space R]
+variables [add_comm_monoid Y] [module R Y]
+variables [topological_space Y] [has_continuous_add Y] [has_continuous_smul R Y]
+
+/-- The inclusion of locally-constant functions into continuous functions as a linear map. -/
+def to_continuous_map_linear_map : locally_constant X Y →ₗ[R] C(X, Y) :=
 { to_fun    := coe,
   map_add'  := λ x y, by { ext, simp, },
   map_smul' := λ x y, by { ext, simp, }, }
 
-@[simp] lemma coe_to_continuous_map_linear_map (f : locally_constant X R) :
-  (f.to_continuous_map_linear_map : X → R) = f :=
+@[simp] lemma coe_to_continuous_map_linear_map :
+  (to_continuous_map_linear_map R f : X → Y) = f :=
 rfl
 
-def to_continuous_map_alg_hom {R : Type*} [normed_comm_ring R] :
-  locally_constant X R →ₐ[R] C(X, R) :=
+end linear_map
+
+section alg_hom
+
+variables (R : Type*) [comm_semiring R] [topological_space R]
+variables [semiring Y] [algebra R Y]
+variables [topological_space Y] [topological_semiring Y] [has_continuous_smul R Y]
+
+/-- The inclusion of locally-constant functions into continuous functions as an algebra map. -/
+def to_continuous_map_alg_hom : locally_constant X Y →ₐ[R] C(X, Y) :=
 { to_fun    := coe,
   map_one'  := by { ext, simp, },
   map_mul'  := λ x y, by { ext, simp, },
   map_zero' := by { ext, simp, },
   map_add'  := λ x y, by { ext, simp, },
-  commutes' := λ x, by { ext y, simp, }, }
+  commutes' := λ r, by { ext x, simp [algebra.smul_def], }, }
 
-@[simp] lemma coe_to_continuous_map_alg_hom
-  {R : Type*} [normed_comm_ring R] (f : locally_constant X R) :
-  (f.to_continuous_map_alg_hom : X → R) = f :=
+@[simp] lemma coe_to_continuous_map_alg_hom :
+  (to_continuous_map_alg_hom R f : X → Y) = f :=
 rfl
+
+end alg_hom
 
 end locally_constant

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -1999,60 +1999,33 @@ namespace locally_constant
 
 variables {X Y : Type*} [topological_space X] [topological_space Y] (f : locally_constant X Y)
 
-section monoid_hom
-
-variables [monoid Y] [has_continuous_mul Y]
-
 /-- The inclusion of locally-constant functions into continuous functions as a multiplicative
 monoid hom. -/
 @[to_additive "The inclusion of locally-constant functions into continuous functions as an
-additive monoid hom."]
-def to_continuous_map_monoid_hom : locally_constant X Y →* C(X, Y) :=
+additive monoid hom.", simps]
+def to_continuous_map_monoid_hom [monoid Y] [has_continuous_mul Y] :
+  locally_constant X Y →* C(X, Y) :=
 { to_fun    := coe,
   map_one' := by { ext, simp, },
   map_mul'  := λ x y, by { ext, simp, }, }
 
-@[simp, to_additive] lemma coe_to_continuous_map_monoid_hom :
-  (f.to_continuous_map_monoid_hom : X → Y) = f :=
-rfl
-
-end monoid_hom
-
-section linear_map
-
-variables (R : Type*) [semiring R] [topological_space R]
-variables [add_comm_monoid Y] [module R Y] [has_continuous_add Y] [has_continuous_smul R Y]
-
 /-- The inclusion of locally-constant functions into continuous functions as a linear map. -/
-def to_continuous_map_linear_map : locally_constant X Y →ₗ[R] C(X, Y) :=
+@[simps] def to_continuous_map_linear_map (R : Type*) [semiring R] [topological_space R]
+  [add_comm_monoid Y] [module R Y] [has_continuous_add Y] [has_continuous_smul R Y] :
+  locally_constant X Y →ₗ[R] C(X, Y) :=
 { to_fun    := coe,
   map_add'  := λ x y, by { ext, simp, },
   map_smul' := λ x y, by { ext, simp, }, }
 
-@[simp] lemma coe_to_continuous_map_linear_map :
-  (to_continuous_map_linear_map R f : X → Y) = f :=
-rfl
-
-end linear_map
-
-section alg_hom
-
-variables (R : Type*) [comm_semiring R] [topological_space R]
-variables [semiring Y] [algebra R Y] [topological_semiring Y] [has_continuous_smul R Y]
-
 /-- The inclusion of locally-constant functions into continuous functions as an algebra map. -/
-def to_continuous_map_alg_hom : locally_constant X Y →ₐ[R] C(X, Y) :=
+@[simps] def to_continuous_map_alg_hom (R : Type*) [comm_semiring R] [topological_space R]
+  [semiring Y] [algebra R Y] [topological_semiring Y] [has_continuous_smul R Y] :
+  locally_constant X Y →ₐ[R] C(X, Y) :=
 { to_fun    := coe,
   map_one'  := by { ext, simp, },
   map_mul'  := λ x y, by { ext, simp, },
   map_zero' := by { ext, simp, },
   map_add'  := λ x y, by { ext, simp, },
   commutes' := λ r, by { ext x, simp [algebra.smul_def], }, }
-
-@[simp] lemma coe_to_continuous_map_alg_hom :
-  (to_continuous_map_alg_hom R f : X → Y) = f :=
-rfl
-
-end alg_hom
 
 end locally_constant

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -2019,9 +2019,12 @@ rfl
 
 def to_continuous_map_alg_hom {R : Type*} [normed_comm_ring R] :
   locally_constant X R →ₐ[R] C(X, R) :=
-alg_hom.of_linear_map to_continuous_map_linear_map
-  (by { ext, simp only [coe_to_continuous_map_linear_map, coe_one, continuous_map.coe_one], })
-  (λ f g, by { ext, simp only [coe_to_continuous_map_linear_map, coe_mul, continuous_map.coe_mul] })
+{ to_fun    := coe,
+  map_one'  := by { ext, simp, },
+  map_mul'  := λ x y, by { ext, simp, },
+  map_zero' := by { ext, simp, },
+  map_add'  := λ x y, by { ext, simp, },
+  commutes' := λ x, by { ext y, simp, }, }
 
 @[simp] lemma coe_to_continuous_map_alg_hom
   {R : Type*} [normed_comm_ring R] (f : locally_constant X R) :

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -9,6 +9,8 @@ import topology.algebra.group_completion
 import topology.instances.nnreal
 import topology.metric_space.completion
 import topology.sequences
+import topology.locally_constant.algebra
+import topology.continuous_function.algebra
 
 /-!
 # Normed spaces
@@ -1992,3 +1994,38 @@ instance [semi_normed_group V] : normed_group (completion V) :=
 
 end completion
 end uniform_space
+
+namespace locally_constant
+
+variables {X G R : Type*} [topological_space X] [normed_group G] [normed_ring R]
+
+def to_continuous_map_monoid_hom : locally_constant X G →+ C(X, G) :=
+{ to_fun    := to_continuous_map,
+  map_zero' := by { ext, simp, },
+  map_add'  := λ x y, by { ext, simp, }, }
+
+@[simp] lemma coe_to_continuous_map_monoid_hom (f : locally_constant X G) :
+  (f.to_continuous_map_monoid_hom : X → G) = f :=
+rfl
+
+def to_continuous_map_linear_map : locally_constant X R →ₗ[R] C(X, R) :=
+{ to_fun    := to_continuous_map,
+  map_add'  := λ x y, by { ext, simp, },
+  map_smul' := λ x y, by { ext, simp, }, }
+
+@[simp] lemma coe_to_continuous_map_linear_map (f : locally_constant X R) :
+  (f.to_continuous_map_linear_map : X → R) = f :=
+rfl
+
+def to_continuous_map_alg_hom {R : Type*} [normed_comm_ring R] :
+  locally_constant X R →ₐ[R] C(X, R) :=
+alg_hom.of_linear_map to_continuous_map_linear_map
+  (by { ext, simp only [coe_to_continuous_map_linear_map, coe_one, continuous_map.coe_one], })
+  (λ f g, by { ext, simp only [coe_to_continuous_map_linear_map, coe_mul, continuous_map.coe_mul] })
+
+@[simp] lemma coe_to_continuous_map_alg_hom
+  {R : Type*} [normed_comm_ring R] (f : locally_constant X R) :
+  (f.to_continuous_map_alg_hom : X → R) = f :=
+rfl
+
+end locally_constant

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -2000,7 +2000,7 @@ namespace locally_constant
 variables {X G R : Type*} [topological_space X] [normed_group G] [normed_ring R]
 
 def to_continuous_map_monoid_hom : locally_constant X G →+ C(X, G) :=
-{ to_fun    := to_continuous_map,
+{ to_fun    := coe,
   map_zero' := by { ext, simp, },
   map_add'  := λ x y, by { ext, simp, }, }
 
@@ -2009,7 +2009,7 @@ def to_continuous_map_monoid_hom : locally_constant X G →+ C(X, G) :=
 rfl
 
 def to_continuous_map_linear_map : locally_constant X R →ₗ[R] C(X, R) :=
-{ to_fun    := to_continuous_map,
+{ to_fun    := coe,
   map_add'  := λ x y, by { ext, simp, },
   map_smul' := λ x y, by { ext, simp, }, }
 

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -173,7 +173,7 @@ instance : algebra R (locally_constant X Y) :=
   smul_def'   := by { intros, ext, exact algebra.smul_def' _ _, }, }
 
 @[simp] lemma coe_algebra_map :
-  (algebra_map R (locally_constant X Y) : R → locally_constant X Y) = λ c, const X (algebra_map R Y c) :=
+  (algebra_map R _ : R → locally_constant X Y) = (const X) ∘ (algebra_map R Y) :=
 rfl
 
 @[simp] lemma coe_comp_C_eq_continuous_map_C [topological_space Y] [topological_semiring Y] :

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 import topology.locally_constant.basic
+import algebra.algebra.basic
 
 /-!
 # Algebraic structure on locally constant functions
@@ -150,5 +151,8 @@ function.injective.distrib_mul_action coe_fn_add_monoid_hom coe_injective (λ _ 
 
 instance [semiring R] [add_comm_monoid Y] [module R Y] : module R (locally_constant X Y) :=
 function.injective.module R coe_fn_add_monoid_hom coe_injective (λ _ _, rfl)
+
+instance [comm_semiring R] [semiring Y] [algebra R Y] : algebra R (locally_constant X Y) :=
+algebra.of_module' (by { intros, ext, simp, }) (by { intros, ext, simp, })
 
 end locally_constant

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -157,27 +157,21 @@ section algebra
 
 variables [comm_semiring R] [semiring Y] [algebra R Y]
 
-/-- Constant functions as a `ring_hom`.
-
-See also `continuous_map.C`. -/
-@[simps] def C : R →+* locally_constant X Y :=
-{ to_fun    := λ c, const X $ algebra_map R Y c,
-  map_one'  := by { ext, exact (algebra_map R Y).map_one, },
-  map_mul'  := by { intros, ext, exact (algebra_map R Y).map_mul _ _, },
-  map_zero' := by { ext, exact (algebra_map R Y).map_zero, },
-  map_add'  := by { intros, ext, exact (algebra_map R Y).map_add _ _, }, }
+/-- The constant-function embedding, as a ring hom.  -/
+@[simps] def const_ring_hom : Y →+* locally_constant X Y :=
+{ to_fun    := const X,
+  map_one'  := rfl,
+  map_mul'  := λ _ _, rfl,
+  map_zero' := rfl,
+  map_add'  := λ _ _, rfl, }
 
 instance : algebra R (locally_constant X Y) :=
-{ to_ring_hom := C,
+{ to_ring_hom := const_ring_hom.comp $ algebra_map R Y,
   commutes'   := by { intros, ext, exact algebra.commutes' _ _, },
   smul_def'   := by { intros, ext, exact algebra.smul_def' _ _, }, }
 
 @[simp] lemma coe_algebra_map :
   (algebra_map R _ : R → locally_constant X Y) = (const X) ∘ (algebra_map R Y) :=
-rfl
-
-@[simp] lemma coe_comp_C_eq_continuous_map_C [topological_space Y] [topological_semiring Y] :
-  (coe : locally_constant X Y → C(X, Y)) ∘ (C : R →+* locally_constant X Y) = continuous_map.C :=
 rfl
 
 end algebra

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -170,8 +170,8 @@ instance : algebra R (locally_constant X Y) :=
   commutes'   := by { intros, ext, exact algebra.commutes' _ _, },
   smul_def'   := by { intros, ext, exact algebra.smul_def' _ _, }, }
 
-@[simp] lemma coe_algebra_map :
-  (algebra_map R _ : R → locally_constant X Y) = (const X) ∘ (algebra_map R Y) :=
+@[simp] lemma coe_algebra_map (r : R) :
+  ⇑(algebra_map R (locally_constant X Y) r) = algebra_map R (X → Y) r :=
 rfl
 
 end algebra

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -57,6 +57,13 @@ def coe_fn_monoid_hom [mul_one_class Y] : locally_constant X Y →* (X → Y) :=
   map_one' := rfl,
   map_mul' := λ _ _, rfl }
 
+/-- The constant-function embedding, as a multiplicative monoid hom. -/
+@[to_additive "The constant-function embedding, as an additive monoid hom.", simps]
+def const_monoid_hom [mul_one_class Y] : Y →* locally_constant X Y :=
+{ to_fun   := const X,
+  map_one' := rfl,
+  map_mul' := λ _ _, rfl, }
+
 instance [mul_zero_class Y] : mul_zero_class (locally_constant X Y) :=
 { zero_mul := by { intros, ext, simp only [mul_apply, zero_apply, zero_mul] },
   mul_zero := by { intros, ext, simp only [mul_apply, zero_apply, mul_zero] },
@@ -120,10 +127,8 @@ instance [non_assoc_semiring Y] : non_assoc_semiring (locally_constant X Y) :=
 /-- The constant-function embedding, as a ring hom.  -/
 @[simps] def const_ring_hom [non_assoc_semiring Y] : Y →+* locally_constant X Y :=
 { to_fun    := const X,
-  map_one'  := rfl,
-  map_mul'  := λ _ _, rfl,
-  map_zero' := rfl,
-  map_add'  := λ _ _, rfl, }
+  .. const_monoid_hom,
+  .. const_add_monoid_hom, }
 
 instance [semiring Y] : semiring (locally_constant X Y) :=
 { .. locally_constant.add_comm_monoid, .. locally_constant.monoid,

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -117,6 +117,14 @@ instance [non_unital_semiring Y] : non_unital_semiring (locally_constant X Y) :=
 instance [non_assoc_semiring Y] : non_assoc_semiring (locally_constant X Y) :=
 { .. locally_constant.mul_one_class, .. locally_constant.non_unital_non_assoc_semiring }
 
+/-- The constant-function embedding, as a ring hom.  -/
+@[simps] def const_ring_hom [non_assoc_semiring Y] : Y →+* locally_constant X Y :=
+{ to_fun    := const X,
+  map_one'  := rfl,
+  map_mul'  := λ _ _, rfl,
+  map_zero' := rfl,
+  map_add'  := λ _ _, rfl, }
+
 instance [semiring Y] : semiring (locally_constant X Y) :=
 { .. locally_constant.add_comm_monoid, .. locally_constant.monoid,
   .. locally_constant.distrib, .. locally_constant.mul_zero_class }
@@ -156,14 +164,6 @@ function.injective.module R coe_fn_add_monoid_hom coe_injective (λ _ _, rfl)
 section algebra
 
 variables [comm_semiring R] [semiring Y] [algebra R Y]
-
-/-- The constant-function embedding, as a ring hom.  -/
-@[simps] def const_ring_hom : Y →+* locally_constant X Y :=
-{ to_fun    := const X,
-  map_one'  := rfl,
-  map_mul'  := λ _ _, rfl,
-  map_zero' := rfl,
-  map_add'  := λ _ _, rfl, }
 
 instance : algebra R (locally_constant X Y) :=
 { to_ring_hom := const_ring_hom.comp $ algebra_map R Y,

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 import topology.locally_constant.basic
+import topology.continuous_function.algebra
 import algebra.algebra.basic
 
 /-!
@@ -152,7 +153,33 @@ function.injective.distrib_mul_action coe_fn_add_monoid_hom coe_injective (λ _ 
 instance [semiring R] [add_comm_monoid Y] [module R Y] : module R (locally_constant X Y) :=
 function.injective.module R coe_fn_add_monoid_hom coe_injective (λ _ _, rfl)
 
-instance [comm_semiring R] [semiring Y] [algebra R Y] : algebra R (locally_constant X Y) :=
-algebra.of_module' (by { intros, ext, simp, }) (by { intros, ext, simp, })
+section algebra
+
+variables [comm_semiring R] [semiring Y] [algebra R Y]
+
+/-- Constant functions as a `ring_hom`.
+
+See also `continuous_map.C`. -/
+@[simps] def C : R →+* locally_constant X Y :=
+{ to_fun    := λ c, const X $ algebra_map R Y c,
+  map_one'  := by { ext, exact (algebra_map R Y).map_one, },
+  map_mul'  := by { intros, ext, exact (algebra_map R Y).map_mul _ _, },
+  map_zero' := by { ext, exact (algebra_map R Y).map_zero, },
+  map_add'  := by { intros, ext, exact (algebra_map R Y).map_add _ _, }, }
+
+instance : algebra R (locally_constant X Y) :=
+{ to_ring_hom := C,
+  commutes'   := by { intros, ext, exact algebra.commutes' _ _, },
+  smul_def'   := by { intros, ext, exact algebra.smul_def' _ _, }, }
+
+@[simp] lemma coe_algebra_map :
+  (algebra_map R (locally_constant X Y) : R → locally_constant X Y) = λ c, const X (algebra_map R Y c) :=
+rfl
+
+@[simp] lemma coe_comp_C_eq_continuous_map_C [topological_space Y] [topological_semiring Y] :
+  (coe : locally_constant X Y → C(X, Y)) ∘ (C : R →+* locally_constant X Y) = continuous_map.C :=
+rfl
+
+end algebra
 
 end locally_constant

--- a/src/topology/locally_constant/basic.lean
+++ b/src/topology/locally_constant/basic.lean
@@ -250,7 +250,7 @@ def const (X : Type*) {Y : Type*} [topological_space X] (y : Y) :
   locally_constant X Y :=
 ⟨function.const X y, is_locally_constant.const _⟩
 
-@[simp] lemma coe_const (y : Y) : (const X y : X → Y) = λ x, y := rfl
+@[simp] lemma coe_const (y : Y) : (const X y : X → Y) = function.const X y := rfl
 
 /-- The locally constant function to `fin 2` associated to a clopen set. -/
 def of_clopen {X : Type*} [topological_space X] {U : set X} [∀ x, decidable (x ∈ U)]

--- a/src/topology/locally_constant/basic.lean
+++ b/src/topology/locally_constant/basic.lean
@@ -250,6 +250,8 @@ def const (X : Type*) {Y : Type*} [topological_space X] (y : Y) :
   locally_constant X Y :=
 ⟨function.const X y, is_locally_constant.const _⟩
 
+@[simp] lemma coe_const (y : Y) : (const X y : X → Y) = λ x, y := rfl
+
 /-- The locally constant function to `fin 2` associated to a clopen set. -/
 def of_clopen {X : Type*} [topological_space X] {U : set X} [∀ x, decidable (x ∈ U)]
   (hU : is_clopen U) : locally_constant X (fin 2) :=


### PR DESCRIPTION


---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
