### PR TITLE
[Merged by Bors] - ci(bors.toml): add merge-conflict to block_labels

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -4,6 +4,6 @@ status = ["Build mathlib", "Lint mathlib", "Run tests", "Lint style"]
 # status = ["Build mathlib (fork)", "Lint mathlib (fork)", "Run tests (fork)", "Lint style (fork)"]
 use_squash_merge = true
 timeout_sec = 28800
-block_labels = ["not-ready-to-merge", "WIP", "blocked-by-other-PR"]
+block_labels = ["not-ready-to-merge", "WIP", "blocked-by-other-PR", "merge-conflict"]
 delete_merged_branches = true
 cut_body_after = "---"


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I was surprised that `bors r+` put #7891 on the queue when it had the `merge-conflict` tag. This change should prevent that from happening in the future.