### PR TITLE
[Merged by Bors] - chore(order/complete_lattice): generalize `Sup_eq_supr'`, add lemmas

### DIFF
--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -473,6 +473,9 @@ le_antisymm
   (Sup_le $ assume b h, le_supr_of_le b $ le_supr _ h)
   (supr_le $ assume b, supr_le $ assume h, le_Sup h)
 
+lemma Sup_eq_supr' {α} [has_Sup α] (s : set α) : Sup s = ⨆ x : s, (x : α) :=
+by rw [supr, subtype.range_coe]
+
 lemma Sup_sUnion {s : set (set α)} :
   Sup (⋃₀ s) = ⨆ (t ∈ s), Sup t :=
 begin
@@ -575,6 +578,9 @@ le_infi $ infi_le _ ∘ h
 
 theorem Inf_eq_infi {s : set α} : Inf s = (⨅a ∈ s, a) :=
 @Sup_eq_supr (order_dual α) _ _
+
+theorem Inf_eq_infi' {α} [has_Inf α] (s : set α) : Inf s = ⨅ a : s, a :=
+@Sup_eq_supr' (order_dual α) _ _
 
 lemma monotone.map_infi_le [complete_lattice β] {f : α → β} (hf : monotone f) :
   f (infi s) ≤ (⨅ i, f (s i)) :=
@@ -842,16 +848,30 @@ lemma Sup_range {α : Type*} [has_Sup α] {f : ι → α} : Sup (range f) = supr
 
 lemma Inf_range {α : Type*} [has_Inf α] {f : ι → α} : Inf (range f) = infi f := rfl
 
-lemma supr_range {g : β → α} {f : ι → β} : (⨆b∈range f, g b) = (⨆i, g (f i)) :=
-le_antisymm
-  (supr_le $ assume b, supr_le $ assume ⟨i, (h : f i = b)⟩, h ▸ le_supr _ i)
-  (supr_le $ assume i, le_supr_of_le (f i) $ le_supr (λp, g (f i)) (mem_range_self _))
+lemma supr_range' {α} [has_Sup α] (g : β → α) (f : ι → β) :
+  (⨆ b : range f, g b) = ⨆ i, g (f i) :=
+by rw [supr, supr, ← image_eq_range, ← range_comp]
+
+lemma infi_range' {α} [has_Inf α] (g : β → α) (f : ι → β) :
+  (⨅ b : range f, g b) = ⨅ i, g (f i) :=
+@supr_range' _ _ (order_dual α) _ _ _
 
 lemma infi_range {g : β → α} {f : ι → β} : (⨅b∈range f, g b) = (⨅i, g (f i)) :=
-@supr_range (order_dual α) _ _ _ _ _
+by rw [← infi_subtype'', infi_range']
+
+lemma supr_range {g : β → α} {f : ι → β} : (⨆b∈range f, g b) = (⨆i, g (f i)) :=
+@infi_range (order_dual α) _ _ _ _ _
+
+theorem Inf_image' {α} [has_Inf α] {s : set β} {f : β → α} :
+  Inf (f '' s) = (⨅ a : s, f a) :=
+by rw [infi, image_eq_range]
+
+theorem Sup_image' {α} [has_Sup α] {s : set β} {f : β → α} :
+  Sup (f '' s) = (⨆ a : s, f a) :=
+@Inf_image' _ (order_dual α) _ _ _
 
 theorem Inf_image {s : set β} {f : β → α} : Inf (f '' s) = (⨅ a ∈ s, f a) :=
-by rw [← infi_subtype'', infi, range_comp, subtype.range_coe]
+by rw [← infi_subtype'', Inf_image']
 
 theorem Sup_image {s : set β} {f : β → α} : Sup (f '' s) = (⨆ a ∈ s, f a) :=
 @Inf_image (order_dual α) _ _ _ _
@@ -973,9 +993,6 @@ lemma supr_subtype' {p : ι → Prop} {f : ∀ i, p i → α} :
 lemma supr_subtype'' {ι} (s : set ι) (f : ι → α) :
   (⨆ i : s, f i) = ⨆ (t : ι) (H : t ∈ s), f t :=
 supr_subtype
-
-lemma Sup_eq_supr' {s : set α} : Sup s = ⨆ x : s, (x : α) :=
-by rw [Sup_eq_supr, supr_subtype']; refl
 
 lemma is_lub_bsupr {s : set β} {f : β → α} : is_lub (f '' s) (⨆ x ∈ s, f x) :=
 by simpa only [range_comp, subtype.range_coe, supr_subtype'] using @is_lub_supr α s _ (f ∘ coe)


### PR DESCRIPTION
* `Sup_eq_supr'` only needs `[has_Sup α]`, add `Inf_eq_infi'`;
* add `supr_range'`, `infi_range'`, `Sup_image'`, `Inf_image'`
  lemmas that use supremum/infimum over subtypes and only require
  `[has_Sup]`/`[has_Inf]`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
