### PR TITLE
[Merged by Bors] - feat(group_theory/order_of_element): order_of_dvd_iff_gpow_eq_one

### DIFF
--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -356,7 +356,7 @@ section group
 variables [group G] [add_group A] {x a} {i : ℤ}
 
 @[to_additive add_order_of_dvd_iff_gsmul_eq_zero]
-lemma order_of_dvd_iff_gpow_eq_one : x ^ i = 1 ↔ (order_of x : ℤ) ∣ i :=
+lemma order_of_dvd_iff_gpow_eq_one : (order_of x : ℤ) ∣ i ↔ x ^ i = 1 :=
 begin
   rcases int.eq_coe_or_neg i with ⟨i, rfl|rfl⟩,
   { rw [int.coe_nat_dvd, order_of_dvd_iff_pow_eq_one, gpow_coe_nat] },

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -355,6 +355,15 @@ end cancel_monoid
 section group
 variables [group G] [add_group A] {x a} {i : ℤ}
 
+@[to_additive add_order_of_dvd_iff_gsmul_eq_zero]
+lemma order_of_dvd_iff_gpow_eq_one : x ^ i = 1 ↔ (order_of x : ℤ) ∣ i :=
+begin
+  rcases int.eq_coe_or_neg i with ⟨i, rfl|rfl⟩,
+  { rw [int.coe_nat_dvd, order_of_dvd_iff_pow_eq_one, gpow_coe_nat] },
+  { rw [dvd_neg, int.coe_nat_dvd, gpow_neg, inv_eq_one, gpow_coe_nat,
+      order_of_dvd_iff_pow_eq_one] }
+end
+
 @[simp, norm_cast, to_additive] lemma order_of_subgroup {H : subgroup G}
   (y: H) : order_of (y : G) = order_of y :=
 order_of_injective H.subtype subtype.coe_injective y


### PR DESCRIPTION
Version of `order_of_dvd_iff_pow_eq_one` for integer powers



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
