### PR TITLE
feat(data/list/nodup_permutations): nodup_permutations

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -827,7 +827,10 @@ section sum_compl
 
 /-- For any predicate `p` on `α`,
 the sum of the two subtypes `{a // p a}` and its complement `{a // ¬ p a}`
-is naturally equivalent to `α`. -/
+is naturally equivalent to `α`.
+
+See `subtype_or_equiv` for sum types over subtypes `{x // p x}` and `{x // q x}`
+that are not necessarily `is_compl p q`.  -/
 def sum_compl {α : Type*} (p : α → Prop) [decidable_pred p] :
   {a // p a} ⊕ {a // ¬ p a} ≃ α :=
 { to_fun := sum.elim coe coe,

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1205,7 +1205,7 @@ lemma fintype.card_subtype_or (p q : α → Prop) [decidable_pred p]
   [fintype {x // p x}] [fintype {x // q x}] [fintype {x // p x ∨ q x}] :
   fintype.card {x // p x ∨ q x} ≤ fintype.card {x // p x} + fintype.card {x // q x} :=
 begin
-  convert fintype.card_le_of_embedding (subtype_or_embedding p q),
+  convert fintype.card_le_of_embedding (subtype_or_left_embedding p q),
   rw fintype.card_sum
 end
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1201,7 +1201,7 @@ begin
   simp
 end
 
-lemma fintype.card_subtype_or (p q : α → Prop) [decidable_pred p] [decidable_pred q]
+lemma fintype.card_subtype_or (p q : α → Prop) [decidable_pred p]
   [fintype {x // p x}] [fintype {x // q x}] [fintype {x // p x ∨ q x}] :
   fintype.card {x // p x ∨ q x} ≤ fintype.card {x // p x} + fintype.card {x // q x} :=
 begin
@@ -1209,10 +1209,8 @@ begin
   rw fintype.card_sum
 end
 
-lemma fintype.card_subtype_or_disjoint (p q : α → Prop)
-  (h : disjoint p q)
-  [decidable_pred p] [decidable_pred q]
-  [fintype {x // p x}] [fintype {x // q x}] [fintype {x // p x ∨ q x}] :
+lemma fintype.card_subtype_or_disjoint (p q : α → Prop) (h : disjoint p q)
+  [decidable_pred p] [fintype {x // p x}] [fintype {x // q x}] [fintype {x // p x ∨ q x}] :
   fintype.card {x // p x ∨ q x} = fintype.card {x // p x} + fintype.card {x // q x} :=
 begin
   convert fintype.card_congr (subtype_or_equiv p q h),

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -534,6 +534,13 @@ arbitrary `fintype` instances, use either `fintype.card_le_one_iff_subsingleton`
   fintype.card α = 1 :=
 subsingleton.elim (of_subsingleton $ default α) h ▸ card_of_subsingleton _
 
+@[simp] lemma fintype.card_subtype_eq (y : α) [fintype {x // x = y}] :
+  fintype.card {x // x = y} = 1 :=
+begin
+  convert fintype.card_unique,
+  exact unique.subtype_eq _
+end
+
 @[priority 100] -- see Note [lower instance priority]
 instance of_is_empty [is_empty α] : fintype α := ⟨∅, is_empty_elim⟩
 
@@ -709,6 +716,11 @@ end
 
 @[instance, priority 10] def unique.fintype {α : Type*} [unique α] : fintype α :=
 fintype.of_subsingleton (default α)
+
+/-- Short-circuit instance to decrease search for `unique.fintype`,
+since that relies on a subsingleton elimination for `unique`. -/
+instance fintype.subtype_eq (y : α) : fintype {x // x = y} :=
+fintype.subtype {y} (by simp)
 
 @[simp] lemma univ_unique {α : Type*} [unique α] [f : fintype α] : @finset.univ α _ = {default α} :=
 by rw [subsingleton.elim f (@unique.fintype α _)]; refl

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -836,6 +836,21 @@ that `sum.inr` is an injection, but there's no clear inverse if `β` is empty. -
 noncomputable def fintype.sum_right {α β} [fintype (α ⊕ β)] : fintype β :=
 fintype.of_injective (sum.inr : β → α ⊕ β) sum.inr_injective
 
+@[simp] theorem fintype.card_sum (α β : Type*) [fintype α] [fintype β] [fintype (α ⊕ β)] :
+  fintype.card (α ⊕ β) = fintype.card α + fintype.card β :=
+begin
+  classical,
+  rw ←finset.card_univ,
+  rw univ_sum_type,
+  rw finset.card_union_eq,
+  { simp [finset.card_univ] },
+  { intros x hx,
+    suffices : (∃ (a : α), sum.inl a = x) ∧ ∃ (b : β), sum.inr b = x,
+    { obtain ⟨⟨a, rfl⟩, ⟨b, hb⟩⟩ := this,
+      simpa using hb },
+    simpa using hx }
+end
+
 section finset
 
 /-! ### `fintype (s : finset α)` -/
@@ -1180,6 +1195,31 @@ fintype.card_le_of_embedding (function.embedding.subtype _)
 theorem fintype.card_subtype_lt [fintype α] {p : α → Prop} [decidable_pred p]
   {x : α} (hx : ¬ p x) : fintype.card {x // p x} < fintype.card α :=
 fintype.card_lt_of_injective_of_not_mem coe subtype.coe_injective $ by rwa subtype.range_coe_subtype
+
+lemma fintype.card_subtype [fintype α] (p : α → Prop) [decidable_pred p] :
+  fintype.card {x // p x} = ((finset.univ : finset α).filter p).card :=
+begin
+  refine fintype.card_of_subtype _ _,
+  simp
+end
+
+lemma fintype.card_subtype_or (p q : α → Prop) [decidable_pred p] [decidable_pred q]
+  [fintype {x // p x}] [fintype {x // q x}] [fintype {x // p x ∨ q x}] :
+  fintype.card {x // p x ∨ q x} ≤ fintype.card {x // p x} + fintype.card {x // q x} :=
+begin
+  convert fintype.card_le_of_embedding (subtype_or_embedding p q),
+  rw fintype.card_sum
+end
+
+lemma fintype.card_subtype_or_disjoint (p q : α → Prop)
+  (h : disjoint p q)
+  [decidable_pred p] [decidable_pred q]
+  [fintype {x // p x}] [fintype {x // q x}] [fintype {x // p x ∨ q x}] :
+  fintype.card {x // p x ∨ q x} = fintype.card {x // p x} + fintype.card {x // q x} :=
+begin
+  convert fintype.card_congr (subtype_or_equiv p q h),
+  simp
+end
 
 theorem fintype.card_quotient_le [fintype α] (s : setoid α) [decidable_rel ((≈) : α → α → Prop)] :
   fintype.card (quotient s) ≤ fintype.card α :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1201,18 +1201,20 @@ begin
   simp
 end
 
-lemma fintype.card_subtype_or (p q : α → Prop) [decidable_pred p]
+lemma fintype.card_subtype_or (p q : α → Prop)
   [fintype {x // p x}] [fintype {x // q x}] [fintype {x // p x ∨ q x}] :
   fintype.card {x // p x ∨ q x} ≤ fintype.card {x // p x} + fintype.card {x // q x} :=
 begin
+  classical,
   convert fintype.card_le_of_embedding (subtype_or_left_embedding p q),
   rw fintype.card_sum
 end
 
 lemma fintype.card_subtype_or_disjoint (p q : α → Prop) (h : disjoint p q)
-  [decidable_pred p] [fintype {x // p x}] [fintype {x // q x}] [fintype {x // p x ∨ q x}] :
+  [fintype {x // p x}] [fintype {x // q x}] [fintype {x // p x ∨ q x}] :
   fintype.card {x // p x ∨ q x} = fintype.card {x // p x} + fintype.card {x // q x} :=
 begin
+  classical,
   convert fintype.card_congr (subtype_or_equiv p q h),
   simp
 end

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -534,7 +534,7 @@ arbitrary `fintype` instances, use either `fintype.card_le_one_iff_subsingleton`
   fintype.card α = 1 :=
 subsingleton.elim (of_subsingleton $ default α) h ▸ card_of_subsingleton _
 
-@[simp] lemma fintype.card_subtype_eq (y : α) [fintype {x // x = y}] :
+@[simp] lemma card_subtype_eq (y : α) [fintype {x // x = y}] :
   fintype.card {x // x = y} = 1 :=
 begin
   convert fintype.card_unique,

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -836,13 +836,11 @@ that `sum.inr` is an injection, but there's no clear inverse if `β` is empty. -
 noncomputable def fintype.sum_right {α β} [fintype (α ⊕ β)] : fintype β :=
 fintype.of_injective (sum.inr : β → α ⊕ β) sum.inr_injective
 
-@[simp] theorem fintype.card_sum (α β : Type*) [fintype α] [fintype β] [fintype (α ⊕ β)] :
+@[simp] theorem fintype.card_sum [fintype α] [fintype β] [fintype (α ⊕ β)] :
   fintype.card (α ⊕ β) = fintype.card α + fintype.card β :=
 begin
   classical,
-  rw ←finset.card_univ,
-  rw univ_sum_type,
-  rw finset.card_union_eq,
+  rw [←finset.card_univ, univ_sum_type, finset.card_union_eq],
   { simp [finset.card_univ] },
   { intros x hx,
     suffices : (∃ (a : α), sum.inl a = x) ∧ ∃ (b : β), sum.inr b = x,

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -836,7 +836,7 @@ that `sum.inr` is an injection, but there's no clear inverse if `β` is empty. -
 noncomputable def fintype.sum_right {α β} [fintype (α ⊕ β)] : fintype β :=
 fintype.of_injective (sum.inr : β → α ⊕ β) sum.inr_injective
 
-@[simp] theorem fintype.card_sum [fintype α] [fintype β] [fintype (α ⊕ β)] :
+@[simp] theorem fintype.card_sum [fintype α] [fintype β] :
   fintype.card (α ⊕ β) = fintype.card α + fintype.card β :=
 begin
   classical,

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -183,11 +183,6 @@ open finset
   fintype.card (sigma β) = ∑ a, fintype.card (β a) :=
 card_sigma _ _
 
--- FIXME ouch, this should be in the main file.
-@[simp] theorem fintype.card_sum (α β : Type*) [fintype α] [fintype β] :
-  fintype.card (α ⊕ β) = fintype.card α + fintype.card β :=
-by simp [sum.fintype, fintype.of_equiv_card]
-
 @[simp] lemma finset.card_pi [decidable_eq α] {δ : α → Type*}
   (s : finset α) (t : Π a, finset (δ a)) :
   (s.pi t).card = ∏ a in s, card (t a) :=

--- a/src/data/list/nodup.lean
+++ b/src/data/list/nodup.lean
@@ -107,6 +107,17 @@ end
 nodup_iff_nth_le_inj.1 H _ _ _ h $
 index_of_nth_le $ index_of_lt_length.2 $ nth_le_mem _ _ _
 
+@[simp] lemma index_of_eq_iff [decidable_eq α] {l : list α} {x : α} (hn : nodup l) {n : ℕ} :
+  index_of x l = n ↔ (x ∉ l ∧ n = l.length) ∨ ∃ (h : n < l.length), l.nth_le n h = x :=
+begin
+  split,
+  { rintro rfl,
+    by_cases hx : x ∈ l;
+    simp [hx, index_of_lt_length] },
+  { rintro (⟨hx, rfl⟩|⟨hx, rfl⟩);
+    simp [hx, hn] }
+end
+
 theorem nodup_iff_count_le_one [decidable_eq α] {l : list α} : nodup l ↔ ∀ a, count a l ≤ 1 :=
 nodup_iff_sublist.trans $ forall_congr $ λ a,
 have [a, a] <+ l ↔ 1 < count a l, from (@le_count_iff_repeat_sublist _ _ a l 2).symm,

--- a/src/data/list/nodup_permutations.lean
+++ b/src/data/list/nodup_permutations.lean
@@ -1,0 +1,112 @@
+import data.list.nodup_equiv_fin
+import data.fintype.basic
+
+namespace list
+
+variable {α : Type*}
+
+@[simp] lemma card_attach [decidable_eq α] (l : list α) :
+  fintype.card {x // x ∈ l} = finset.card l.to_finset :=
+begin
+  rw fintype.card_of_subtype,
+  simp
+end
+
+lemma card_attach_le [decidable_eq α] (l : list α) :
+  fintype.card {x // x ∈ l} ≤ l.length :=
+by simpa using to_finset_card_le l
+
+lemma nodup_iff_card_eq_length [decidable_eq α] {l : list α} :
+  nodup l ↔ fintype.card {x // x ∈ l} = l.length :=
+begin
+  classical,
+  induction l with hd tl IH,
+  { simp },
+  { simp only [mem_cons_iff, length, nodup_cons],
+    by_cases h : hd ∈ tl,
+    { simp only [h, false_iff, not_true, false_and],
+      refine (((eq.le _).trans tl.card_attach_le).trans_lt (nat.lt_succ_self _)).ne,
+      convert fintype.card_congr _,
+      refine (equiv.subtype_equiv_right (λ x, _)).symm,
+      refine (or_iff_right_of_imp _).symm,
+      rintro rfl,
+      exact h },
+    { rw [fintype.card_subtype_or_disjoint, add_comm, IH],
+      { simp only [h, true_and, add_left_inj, fintype.card_subtype_eq, list.card_attach,
+                   not_false_iff],
+        convert iff.rfl },
+      { rintros x ⟨hx, hx'⟩,
+        apply h,
+        simpa [hx] using hx' } } }
+end
+
+lemma nodup_of_embedding (l : list α) (f : fin l.length ↪ {x // x ∈ l}) :
+  nodup l :=
+begin
+  classical,
+  rw list.nodup_iff_card_eq_length,
+  refine le_antisymm l.card_attach_le _,
+  { rw ←fintype.card_fin l.length,
+    exact fintype.card_le_of_embedding f }
+end
+
+def perm_perm [decidable_eq α] (l : list α) (hn : nodup l) :
+  {l' : list α // l ~ l'} ≃ equiv.perm (fin l.length) :=
+{ to_fun := λ l',
+    (nodup.nth_le_equiv l hn).trans $
+    equiv.trans (equiv.subtype_equiv_right (λ x, l'.prop.mem_iff)) $
+    (nodup.nth_le_equiv (l' : list α) (l'.prop.nodup_iff.mp hn)).symm.trans
+    (fin.cast l'.prop.length_eq.symm).to_equiv,
+  inv_fun := λ f,
+    ⟨l.pmap (λ x hx, l.nth_le (f.symm ⟨index_of x l, index_of_lt_length.mpr hx⟩) (fin.is_lt _))
+      (λ x hx, hx),
+      by { refine (perm_ext hn _).mpr _,
+        { refine nodup_pmap (λ x hx y hy h, _) hn,
+          rw nodup_iff_nth_le_inj at hn,
+          simpa [←fin.ext_iff, ←index_of_inj hx hy] using hn _ _ _ _ h },
+        { simp only [mem_pmap],
+          intro x,
+          split,
+          { intro hx,
+            refine ⟨l.nth_le (f ⟨index_of x l, index_of_lt_length.mpr hx⟩) (fin.is_lt _),
+              nth_le_mem _ _ _, _⟩,
+            simp [nth_le_index_of hn] },
+          { rintro ⟨x, hx, rfl⟩,
+            exact nth_le_mem _ _ _ } } }⟩,
+  left_inv := λ l', by {
+    cases l' with l' hl,
+    simp only [index_of_nth_le, equiv.coe_fn_mk, subtype.coe_mk, fin.coe_mk, mem_pmap,
+               subtype.val_eq_coe, nth_le, nth_le_index_of],
+    apply ext_le,
+    { simpa using hl.length_eq },
+    { simp [nth_le_pmap, nth_le_index_of hn] } },
+  right_inv := λ f, by {
+    ext ⟨n, h⟩,
+    have : (pmap (λ (x : α) (hx : x ∈ l), l.nth_le ((equiv.symm f)
+      ⟨index_of x l, index_of_lt_length.mpr hx⟩) (fin.is_lt _)) l (λ x hx, hx)).nodup,
+    { refine nodup_pmap (λ x hx y hy hxy, _) hn,
+      rw nodup_iff_nth_le_inj at hn,
+      simpa [←fin.ext_iff, ←index_of_inj hx hy] using hn _ _ _ _ hxy },
+    simp [this, fin.is_lt, nth_le_pmap, nth_le_index_of hn] } }
+
+@[simp] lemma perm_perm_self [decidable_eq α] (l : list α) (h : nodup l) :
+  perm_perm l h ⟨l, perm.refl _⟩ = equiv.refl _ :=
+begin
+  ext,
+  simp [perm_perm, nth_le_index_of h]
+end
+
+lemma nodup_permutations (l : list α) (h : nodup l) :
+  nodup (permutations l) :=
+begin
+  classical,
+  refine list.nodup_of_embedding _ _,
+  refine (equiv.trans _ ((equiv.subtype_equiv_right _).trans (perm_perm l h)).symm).to_embedding,
+  { refine fintype.equiv_of_card_eq _,
+    simpa [fintype.card_perm] using length_permutations _ },
+  { intro l',
+    rw mem_permutations,
+    exact ⟨perm.symm, perm.symm⟩ }
+end
+
+end list

--- a/src/data/list/nodup_permutations.lean
+++ b/src/data/list/nodup_permutations.lean
@@ -1,5 +1,24 @@
+/-
+Copyright (c) 2021 Yakov Pechersky. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yakov Pechersky
+-/
 import data.list.nodup_equiv_fin
 import data.fintype.basic
+
+/-!
+# Isomorphism between `{l' // l ~ l'}` and `equiv.perm (fin l.length)`
+
+Given a list `l : list α`,
+
+* if `l` has no duplicates, then `list.perm_perm` is the bijection between
+  lists `l' : list α` such that `l ~ l'`, that is, they are permutations of each other,
+  and `equiv.perm (fin l.length)`, the permutation of indices of `l` such that
+  permuting them gives `l'`.
+
+* if `l` has no duplicates then neither does `l.permutations`.
+
+-/
 
 namespace list
 
@@ -50,6 +69,10 @@ begin
     exact fintype.card_le_of_embedding f }
 end
 
+/-- Given `l : list α` and `nodup l`, `list.perm_perm` is the bijection between
+lists `l' : list α` such that `l ~ l'`, that is, they are permutations of each other,
+and `equiv.perm (fin l.length)`, the permutation of indices of `l` such that
+permuting them gives `l'`. -/
 def perm_perm [decidable_eq α] (l : list α) (hn : nodup l) :
   {l' : list α // l ~ l'} ≃ equiv.perm (fin l.length) :=
 { to_fun := λ l',

--- a/src/group_theory/specific_groups/dihedral.lean
+++ b/src/group_theory/specific_groups/dihedral.lean
@@ -113,7 +113,10 @@ instance : nontrivial (dihedral_group n) := ⟨⟨r 0, sr 0, dec_trivial⟩⟩
 If `0 < n`, then `dihedral_group n` has `2n` elements.
 -/
 lemma card [fact (0 < n)] : fintype.card (dihedral_group n) = 2 * n :=
-by rw [← fintype.card_eq.mpr ⟨fintype_helper⟩, fintype.card_sum, zmod.card, two_mul]
+begin
+  rw [← fintype.card_eq.mpr ⟨fintype_helper⟩, fintype.card_sum, zmod.card, two_mul],
+  apply_instance
+end
 
 @[simp] lemma r_one_pow (k : ℕ) : (r 1 : dihedral_group n) ^ k = r k :=
 begin

--- a/src/group_theory/specific_groups/dihedral.lean
+++ b/src/group_theory/specific_groups/dihedral.lean
@@ -113,10 +113,7 @@ instance : nontrivial (dihedral_group n) := ⟨⟨r 0, sr 0, dec_trivial⟩⟩
 If `0 < n`, then `dihedral_group n` has `2n` elements.
 -/
 lemma card [fact (0 < n)] : fintype.card (dihedral_group n) = 2 * n :=
-begin
-  rw [← fintype.card_eq.mpr ⟨fintype_helper⟩, fintype.card_sum, zmod.card, two_mul],
-  apply_instance
-end
+by rw [← fintype.card_eq.mpr ⟨fintype_helper⟩, fintype.card_sum, zmod.card, two_mul]
 
 @[simp] lemma r_one_pow (k : ℕ) : (r 1 : dihedral_group n) ^ k = r k :=
 begin

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -327,7 +327,7 @@ variable {α : Type*}
 
 /-- A subtype `{x // p x ∨ q x}` over a disjunction of `p q : α → Prop` can be injectively split
 into a sum of subtypes `{x // p x} ⊕ {x // q x}` such that `¬ p x` is sent to the right. -/
-def subtype_or_embedding (p q : α → Prop) [decidable_pred p] :
+def subtype_or_left_embedding (p q : α → Prop) [decidable_pred p] :
   {x // p x ∨ q x} ↪ {x // p x} ⊕ {x // q x} :=
 ⟨λ x, if h : p x then sum.inl ⟨x, h⟩ else sum.inr ⟨x, x.prop.resolve_left h⟩,
   begin
@@ -337,11 +337,11 @@ def subtype_or_embedding (p q : α → Prop) [decidable_pred p] :
     simp [subtype.ext_iff]
   end⟩
 
-lemma subtype_or_embedding_apply_left {p q : α → Prop} [decidable_pred p] (x : {x // p x ∨ q x})
-  (hx : p x) : subtype_or_embedding p q x = sum.inl ⟨x, hx⟩ := dif_pos hx
+lemma subtype_or_left_embedding_apply_left {p q : α → Prop} [decidable_pred p] (x : {x // p x ∨ q x})
+  (hx : p x) : subtype_or_left_embedding p q x = sum.inl ⟨x, hx⟩ := dif_pos hx
 
-lemma subtype_or_embedding_apply_right {p q : α → Prop} [decidable_pred p] (x : {x // p x ∨ q x})
-  (hx : ¬ p x) : subtype_or_embedding p q x = sum.inr ⟨x, x.prop.resolve_left hx⟩ := dif_neg hx
+lemma subtype_or_left_embedding_apply_right {p q : α → Prop} [decidable_pred p] (x : {x // p x ∨ q x})
+  (hx : ¬ p x) : subtype_or_left_embedding p q x = sum.inr ⟨x, x.prop.resolve_left hx⟩ := dif_neg hx
 
 /-- A subtype `{x // p x}` can be injectively sent to into a subtype `{x // q x}`,
 if `p x → q x` for all `x : α`. -/
@@ -351,28 +351,30 @@ if `p x → q x` for all `x : α`. -/
 
 /-- A subtype `{x // p x ∨ q x}` over a disjunction of `p q : α → Prop` is equivalent to a sum of
 subtypes `{x // p x} ⊕ {x // q x}` such that `¬ p x` is sent to the right, when
-`disjoint p q`. -/
-def subtype_or_equiv (p q : α → Prop) [decidable_pred p] (h : disjoint p q) :
+`disjoint p q`.
+
+See also `equiv.sum_compl`, for when `is_compl p q`.  -/
+@[simps] def subtype_or_equiv (p q : α → Prop) [decidable_pred p] (h : disjoint p q) :
   {x // p x ∨ q x} ≃ {x // p x} ⊕ {x // q x} :=
-{ to_fun := subtype_or_embedding p q,
+{ to_fun := subtype_or_left_embedding p q,
   inv_fun := sum.elim
     (subtype.imp_embedding _ _ (λ x hx, (or.inl hx : p x ∨ q x)))
     (subtype.imp_embedding _ _ (λ x hx, (or.inr hx : p x ∨ q x))),
   left_inv := λ x, begin
     by_cases hx : p x,
-    { rw subtype_or_embedding_apply_left _ hx,
+    { rw subtype_or_left_embedding_apply_left _ hx,
       simp [subtype.ext_iff] },
-    { rw subtype_or_embedding_apply_right _ hx,
+    { rw subtype_or_left_embedding_apply_right _ hx,
       simp [subtype.ext_iff] },
   end,
   right_inv := λ x, begin
     cases x,
     { simp only [sum.elim_inl],
-      rw subtype_or_embedding_apply_left,
+      rw subtype_or_left_embedding_apply_left,
       { simp },
       { simpa using x.prop } },
     { simp only [sum.elim_inr],
-      rw subtype_or_embedding_apply_right,
+      rw subtype_or_left_embedding_apply_right,
       { simp },
       { suffices : ¬ p x,
         { simpa },

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -337,11 +337,14 @@ def subtype_or_left_embedding (p q : α → Prop) [decidable_pred p] :
     simp [subtype.ext_iff]
   end⟩
 
-lemma subtype_or_left_embedding_apply_left {p q : α → Prop} [decidable_pred p] (x : {x // p x ∨ q x})
-  (hx : p x) : subtype_or_left_embedding p q x = sum.inl ⟨x, hx⟩ := dif_pos hx
+lemma subtype_or_left_embedding_apply_left {p q : α → Prop} [decidable_pred p]
+  (x : {x // p x ∨ q x}) (hx : p x) : subtype_or_left_embedding p q x = sum.inl ⟨x, hx⟩ :=
+dif_pos hx
 
-lemma subtype_or_left_embedding_apply_right {p q : α → Prop} [decidable_pred p] (x : {x // p x ∨ q x})
-  (hx : ¬ p x) : subtype_or_left_embedding p q x = sum.inr ⟨x, x.prop.resolve_left hx⟩ := dif_neg hx
+lemma subtype_or_left_embedding_apply_right {p q : α → Prop} [decidable_pred p]
+  (x : {x // p x ∨ q x}) (hx : ¬ p x) :
+  subtype_or_left_embedding p q x = sum.inr ⟨x, x.prop.resolve_left hx⟩ :=
+dif_neg hx
 
 /-- A subtype `{x // p x}` can be injectively sent to into a subtype `{x // q x}`,
 if `p x → q x` for all `x : α`. -/
@@ -354,7 +357,7 @@ subtypes `{x // p x} ⊕ {x // q x}` such that `¬ p x` is sent to the right, wh
 `disjoint p q`.
 
 See also `equiv.sum_compl`, for when `is_compl p q`.  -/
-@[simps] def subtype_or_equiv (p q : α → Prop) [decidable_pred p] (h : disjoint p q) :
+@[simps?] def subtype_or_equiv (p q : α → Prop) [decidable_pred p] (h : disjoint p q) :
   {x // p x ∨ q x} ≃ {x // p x} ⊕ {x // q x} :=
 { to_fun := subtype_or_left_embedding p q,
   inv_fun := sum.elim

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -320,3 +320,57 @@ namespace set
 ⟨λ x, ⟨x.1, h x.2⟩, λ ⟨x, hx⟩ ⟨y, hy⟩ h, by { congr, injection h }⟩
 
 end set
+
+section subtype
+
+variable {α : Type*}
+
+def subtype_or_embedding (p q : α → Prop) [decidable_pred p] :
+  {x // p x ∨ q x} ↪ {x // p x} ⊕ {x // q x} :=
+⟨λ x, if h : p x then sum.inl ⟨x, h⟩ else sum.inr ⟨x, x.prop.resolve_left h⟩,
+  begin
+    intros x y,
+    dsimp only,
+    split_ifs;
+    simp [subtype.ext_iff]
+  end⟩
+
+lemma subtype_or_embedding_apply_left {p q : α → Prop} [decidable_pred p] (x : {x // p x ∨ q x})
+  (hx : p x) : subtype_or_embedding p q x = sum.inl ⟨x, hx⟩ := dif_pos hx
+
+lemma subtype_or_embedding_apply_right {p q : α → Prop} [decidable_pred p] (x : {x // p x ∨ q x})
+  (hx : ¬ p x) : subtype_or_embedding p q x = sum.inr ⟨x, x.prop.resolve_left hx⟩ := dif_neg hx
+
+@[simps] def subtype.imp_embedding (p q : α → Prop) (h : p ≤ q) :
+  {x // p x} ↪ {x // q x} :=
+⟨λ x, ⟨x, h x x.prop⟩, λ x y, by simp [subtype.ext_iff]⟩
+
+def subtype_or_equiv (p q : α → Prop) [decidable_pred p] (h : disjoint p q) :
+  {x // p x ∨ q x} ≃ {x // p x} ⊕ {x // q x} :=
+{ to_fun := subtype_or_embedding p q,
+  inv_fun := sum.elim
+    (subtype.imp_embedding _ _ (λ x hx, (or.inl hx : p x ∨ q x)))
+    (subtype.imp_embedding _ _ (λ x hx, (or.inr hx : p x ∨ q x))),
+  left_inv := λ x, begin
+    by_cases hx : p x,
+    { rw subtype_or_embedding_apply_left _ hx,
+      simp [subtype.ext_iff] },
+    { rw subtype_or_embedding_apply_right _ hx,
+      simp [subtype.ext_iff] },
+  end,
+  right_inv := λ x, begin
+    cases x,
+    { simp only [sum.elim_inl],
+      rw subtype_or_embedding_apply_left,
+      { simp },
+      { simpa using x.prop } },
+    { simp only [sum.elim_inr],
+      rw subtype_or_embedding_apply_right,
+      { simp },
+      { suffices : ¬ p x,
+        { simpa },
+        intro hp,
+        simpa using h x ⟨hp, x.prop⟩ } }
+  end }
+
+end subtype

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -357,7 +357,7 @@ subtypes `{x // p x} ⊕ {x // q x}` such that `¬ p x` is sent to the right, wh
 `disjoint p q`.
 
 See also `equiv.sum_compl`, for when `is_compl p q`.  -/
-@[simps?] def subtype_or_equiv (p q : α → Prop) [decidable_pred p] (h : disjoint p q) :
+@[simps] def subtype_or_equiv (p q : α → Prop) [decidable_pred p] (h : disjoint p q) :
   {x // p x ∨ q x} ≃ {x // p x} ⊕ {x // q x} :=
 { to_fun := subtype_or_left_embedding p q,
   inv_fun := sum.elim

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -325,6 +325,8 @@ section subtype
 
 variable {α : Type*}
 
+/-- A subtype `{x // p x ∨ q x}` over a disjunction of `p q : α → Prop` can be injectively split
+into a sum of subtypes `{x // p x} ⊕ {x // q x}` such that `¬ p x` is sent to the right. -/
 def subtype_or_embedding (p q : α → Prop) [decidable_pred p] :
   {x // p x ∨ q x} ↪ {x // p x} ⊕ {x // q x} :=
 ⟨λ x, if h : p x then sum.inl ⟨x, h⟩ else sum.inr ⟨x, x.prop.resolve_left h⟩,
@@ -341,10 +343,15 @@ lemma subtype_or_embedding_apply_left {p q : α → Prop} [decidable_pred p] (x 
 lemma subtype_or_embedding_apply_right {p q : α → Prop} [decidable_pred p] (x : {x // p x ∨ q x})
   (hx : ¬ p x) : subtype_or_embedding p q x = sum.inr ⟨x, x.prop.resolve_left hx⟩ := dif_neg hx
 
+/-- A subtype `{x // p x}` can be injectively sent to into a subtype `{x // q x}`,
+if `p x → q x` for all `x : α`. -/
 @[simps] def subtype.imp_embedding (p q : α → Prop) (h : p ≤ q) :
   {x // p x} ↪ {x // q x} :=
 ⟨λ x, ⟨x, h x x.prop⟩, λ x y, by simp [subtype.ext_iff]⟩
 
+/-- A subtype `{x // p x ∨ q x}` over a disjunction of `p q : α → Prop` is equivalent to a sum of
+subtypes `{x // p x} ⊕ {x // q x}` such that `¬ p x` is sent to the right, when
+`disjoint p q`. -/
 def subtype_or_equiv (p q : α → Prop) [decidable_pred p] (h : disjoint p q) :
   {x // p x ∨ q x} ≃ {x // p x} ⊕ {x // q x} :=
 { to_fun := subtype_or_embedding p q,

--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -161,3 +161,11 @@ protected def injective.unique [inhabited α] [subsingleton β] (hf : injective 
 @unique.mk' _ _ hf.subsingleton
 
 end function
+
+section subtype
+
+instance unique.subtype_eq (y : α) : unique {x // x = y} :=
+{ default := ⟨y, rfl⟩,
+  uniq := λ ⟨x, hx⟩, by simpa using hx }
+
+end subtype


### PR DESCRIPTION
Using a cardinality argument, prove that the list of permutations of a list
is nodup if the list is nodup.
TODO: prove the reverse implication.
Implementation: provide an explicit equiv between
the perm Prop and the equiv over indices.
TODO: prove that this equiv moves indices as expected
TODO: generalize to sublists/embeddings

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

- [x] depends on: #8490
- [x] depends on: #8491