### PR TITLE
[Merged by Bors] - chore(topology/algebra): bundled homs in group and ring completion

### DIFF
--- a/src/topology/algebra/group_completion.lean
+++ b/src/topology/algebra/group_completion.lean
@@ -5,6 +5,7 @@ Authors: Patrick Massot, Johannes Hölzl
 
 Completion of topological groups:
 -/
+import algebra.group.hom_instances
 import topology.uniform_space.completion
 import topology.algebra.uniform_group
 
@@ -21,7 +22,6 @@ instance [has_neg α] : has_neg (completion α) := ⟨completion.map (λa, -a : 
 instance [has_add α] : has_add (completion α) := ⟨completion.map₂ (+)⟩
 instance [has_sub α] : has_sub (completion α) := ⟨completion.map₂ has_sub.sub⟩
 
--- TODO: switch sides once #1103 is fixed
 @[norm_cast]
 lemma uniform_space.completion.coe_zero [has_zero α] : ((0 : α) : completion α) = 0 := rfl
 end group
@@ -79,26 +79,16 @@ instance : add_group (completion α) :=
 instance : uniform_add_group (completion α) :=
 ⟨uniform_continuous_map₂ has_sub.sub⟩
 
-lemma is_add_group_hom_coe : is_add_group_hom (coe : α → completion α) :=
-{ map_add := coe_add }
+/-- The map from a group to its completion as a group hom. -/
+@[simps] def to_compl : α →+ completion α :=
+{ to_fun := coe,
+  map_add' := coe_add,
+  map_zero' := coe_zero }
+
+lemma continuous_to_compl : continuous (to_compl : α → completion α) :=
+continuous_coe α
 
 variables {β : Type v} [uniform_space β] [add_group β] [uniform_add_group β]
-
-lemma is_add_group_hom_extension  [complete_space β] [separated_space β] {f : α → β}
-  (hfg : is_add_group_hom f) (hf : continuous f) : is_add_group_hom (completion.extension f) :=
-have hf : uniform_continuous f, from uniform_continuous_of_continuous hfg hf,
-{ map_add := assume a b, completion.induction_on₂ a b
-  (is_closed_eq
-    (continuous_extension.comp continuous_add)
-    ((continuous_extension.comp continuous_fst).add (continuous_extension.comp continuous_snd)))
-  (λ a b, by rw_mod_cast [extension_coe hf, extension_coe hf, extension_coe hf,
-    hfg.map_add]) }
-
-lemma is_add_group_hom_map
-  {f : α → β} (hfa : is_add_group_hom f) (hf : continuous f) :
-  is_add_group_hom (completion.map f) :=
-@is_add_group_hom_extension _ _ _ _ _ _ _ _ _ _ _ (is_add_group_hom.comp hfa is_add_group_hom_coe)
-  ((continuous_coe _).comp hf)
 
 instance {α : Type u} [uniform_space α] [add_comm_group α] [uniform_add_group α] :
   add_comm_group (completion α) :=
@@ -107,7 +97,73 @@ instance {α : Type u} [uniform_space α] [add_comm_group α] [uniform_add_group
       (continuous_map₂ continuous_snd continuous_fst))
     (assume x y, by { change ↑x + ↑y = ↑y + ↑x, rw [← coe_add, ← coe_add, add_comm]}),
   .. completion.add_group }
+
 end uniform_add_group
 
-
 end uniform_space.completion
+
+section add_monoid_hom
+variables {α β : Type*} [uniform_space α] [add_group α] [uniform_add_group α]
+                        [uniform_space β] [add_group β] [uniform_add_group β]
+
+open uniform_space uniform_space.completion
+
+/-- Extension to the completion of a continuous group hom. -/
+def add_monoid_hom.extension [complete_space β] [separated_space β] (f : α →+ β)
+  (hf : continuous f) : completion α →+ β :=
+have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
+{ to_fun := completion.extension f,
+  map_zero' := by rw [← coe_zero, extension_coe hf, f.map_zero],
+  map_add' := assume a b, completion.induction_on₂ a b
+  (is_closed_eq
+    (continuous_extension.comp continuous_add)
+    ((continuous_extension.comp continuous_fst).add (continuous_extension.comp continuous_snd)))
+  (λ a b, by rw_mod_cast [extension_coe hf, extension_coe hf, extension_coe hf,
+    f.map_add]) }
+
+lemma add_monoid_hom.extension_coe [complete_space β] [separated_space β] (f : α →+ β)
+  (hf : continuous f) (a : α) : f.extension hf a = f a :=
+extension_coe (uniform_continuous_of_continuous hf) a
+
+@[continuity]
+lemma add_monoid_hom.continuous_extension [complete_space β] [separated_space β] (f : α →+ β)
+  (hf : continuous f) : continuous (f.extension hf) :=
+continuous_extension
+
+/-- Completion of a continuous group hom, as a group hom. -/
+def add_monoid_hom.completion (f : α →+ β) (hf : continuous f) : completion α →+ completion β :=
+(to_compl.comp f).extension (continuous_to_compl.comp hf)
+
+@[continuity]
+lemma add_monoid_hom.continuous_completion (f : α →+ β)
+  (hf : continuous f) : continuous (f.completion hf : completion α → completion β) :=
+continuous_map
+
+lemma add_monoid_hom.completion_coe (f : α →+ β)
+  (hf : continuous f) (a : α) : f.completion hf a = f a :=
+map_coe (uniform_continuous_of_continuous hf) a
+
+lemma add_monoid_hom.completion_zero : (0 : α →+ β).completion continuous_const = 0 :=
+begin
+  ext x,
+  apply completion.induction_on x,
+  { apply is_closed_eq ((0 : α →+ β).continuous_completion continuous_const),
+    simp [continuous_const] },
+  { intro a,
+    simp [(0 : α →+ β).completion_coe continuous_const, coe_zero] }
+end
+
+lemma add_monoid_hom.completion_add {γ : Type*} [add_comm_group γ] [uniform_space γ]
+  [uniform_add_group γ] (f g : α →+ γ) (hf : continuous f) (hg : continuous g) :
+  (f + g).completion (hf.add hg) = f.completion hf + g.completion hg :=
+begin
+  have hfg := hf.add hg,
+  ext x,
+  apply completion.induction_on x,
+  { exact is_closed_eq ((f+g).continuous_completion hfg)
+    ((f.continuous_completion hf).add (g.continuous_completion hg)) },
+  { intro a,
+    simp [(f+g).completion_coe hfg, coe_add, f.completion_coe hf, g.completion_coe hg] }
+end
+
+end add_monoid_hom

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -137,7 +137,7 @@ lemma add_monoid_hom.uniform_continuous_of_continuous_at_zero
   [uniform_space β] [add_group β] [uniform_add_group β]
   (f : α →+ β) (hf : continuous_at f 0) :
   uniform_continuous f :=
-uniform_continuous_of_tendsto_zero f.is_add_group_hom (by simpa using hf.tendsto)
+uniform_continuous_of_tendsto_zero (by simpa using hf.tendsto)
 
 lemma uniform_continuous_of_continuous [uniform_space β] [add_group β] [uniform_add_group β]
   {f : α →+ β} (h : continuous f) : uniform_continuous f :=
@@ -288,7 +288,7 @@ begin
   let ee := λ u : β × β, (e u.1, e u.2),
 
   have lim1 : tendsto (λ a : β × β, (a.2 - a.1, y₁)) (comap e Nx ×ᶠ comap e Nx) (𝓝 (0, y₁)),
-  { have := tendsto.prod_mk (tendsto_sub_comap_self he de x₀)
+  { have := tendsto.prod_mk (tendsto_sub_comap_self de x₀)
       (tendsto_const_nhds : tendsto (λ (p : β × β), y₁) (comap ee $ 𝓝 (x₀, x₀)) (𝓝 y₁)),
     rw [nhds_prod_eq, prod_comap_comap_eq, ←nhds_prod_eq],
     exact (this : _) },
@@ -315,7 +315,7 @@ begin
     ((comap ee $ 𝓝 (x₀, x₀)) ×ᶠ (comap ff $ 𝓝 (y₀, y₀))) (𝓝 0),
   { have lim_sub_sub :  tendsto (λ (p : (β × β) × δ × δ), (p.1.2 - p.1.1, p.2.2 - p.2.1))
       ((comap ee (𝓝 (x₀, x₀))) ×ᶠ (comap ff (𝓝 (y₀, y₀)))) (𝓝 0 ×ᶠ 𝓝 0),
-    { have := filter.prod_mono (tendsto_sub_comap_self he de x₀) (tendsto_sub_comap_self hf df y₀),
+    { have := filter.prod_mono (tendsto_sub_comap_self de x₀) (tendsto_sub_comap_self df y₀),
       rwa prod_map_map_eq at this },
     rw ← nhds_prod_eq at lim_sub_sub,
     exact tendsto.comp lim_φ lim_sub_sub },
@@ -387,7 +387,7 @@ begin
 
     intros W' W'_nhd,
 
-    have key := extend_Z_bilin_key he de hf df hφ W'_nhd x₀ y₀,
+    have key := extend_Z_bilin_key de df hφ W'_nhd x₀ y₀,
     rcases key with ⟨U, U_nhd, V, V_nhd, h⟩,
     rw mem_comap_sets at U_nhd,
     rcases U_nhd with ⟨U', U'_nhd, U'_sub⟩,

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -123,11 +123,11 @@ begin
 end
 
 lemma uniform_continuous_of_tendsto_zero [uniform_space β] [add_group β] [uniform_add_group β]
-  {f : α → β} (hf : is_add_group_hom f) (h : tendsto f (𝓝 0) (𝓝 0)) :
+  {f : α →+ β} (h : tendsto f (𝓝 0) (𝓝 0)) :
   uniform_continuous f :=
 begin
   have : ((λx:β×β, x.2 - x.1) ∘ (λx:α×α, (f x.1, f x.2))) = (λx:α×α, f (x.2 - x.1)),
-  { simp only [hf.map_sub] },
+  { simp only [f.map_sub] },
   rw [uniform_continuous, uniformity_eq_comap_nhds_zero α, uniformity_eq_comap_nhds_zero β,
     tendsto_comap_iff, this],
   exact tendsto.comp h tendsto_comap
@@ -140,10 +140,9 @@ lemma add_monoid_hom.uniform_continuous_of_continuous_at_zero
 uniform_continuous_of_tendsto_zero f.is_add_group_hom (by simpa using hf.tendsto)
 
 lemma uniform_continuous_of_continuous [uniform_space β] [add_group β] [uniform_add_group β]
-  {f : α → β} (hf : is_add_group_hom f) (h : continuous f) :
-  uniform_continuous f :=
-uniform_continuous_of_tendsto_zero hf $
-  suffices tendsto f (𝓝 0) (𝓝 (f 0)), by rwa [hf.map_zero] at this,
+  {f : α →+ β} (h : continuous f) : uniform_continuous f :=
+uniform_continuous_of_tendsto_zero $
+  suffices tendsto f (𝓝 0) (𝓝 (f 0)), by rwa f.map_zero at this,
   h.tendsto 0
 
 end uniform_add_group
@@ -233,90 +232,7 @@ end
 
 end topological_add_comm_group
 
-namespace add_comm_group
-section Z_bilin
-
-variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
-variables [add_comm_group α] [add_comm_group β] [add_comm_group γ]
-
-/- TODO: when modules are changed to have more explicit base ring, then change replace `is_Z_bilin`
-by using `is_bilinear_map ℤ` from `tensor_product`. -/
-/-- `ℤ`-bilinearity for maps between additive commutative groups. -/
-class is_Z_bilin (f : α × β → γ) : Prop :=
-(add_left []  : ∀ a a' b, f (a + a', b) = f (a, b) + f (a', b))
-(add_right [] : ∀ a b b', f (a, b + b') = f (a, b) + f (a, b'))
-
-variables (f : α × β → γ) [is_Z_bilin f]
-
-lemma is_Z_bilin.comp_hom {g : γ → δ} [add_comm_group δ] (hg : is_add_group_hom g) :
-  is_Z_bilin (g ∘ f) :=
-by constructor; simp [(∘), is_Z_bilin.add_left f, is_Z_bilin.add_right f, hg.map_add]
-
-instance is_Z_bilin.comp_swap : is_Z_bilin (f ∘ prod.swap) :=
-⟨λ a a' b, is_Z_bilin.add_right f b a a',
- λ a b b', is_Z_bilin.add_left f b b' a⟩
-
-lemma is_Z_bilin.zero_left : ∀ b, f (0, b) = 0 :=
-begin
-  intro b,
-  apply add_right_eq_self.1,
-  rw [ ←is_Z_bilin.add_left f, zero_add]
-end
-
-lemma is_Z_bilin.zero_right : ∀ a, f (a, 0) = 0 :=
-is_Z_bilin.zero_left (f ∘ prod.swap)
-
-lemma is_Z_bilin.zero : f (0, 0) = 0 :=
-is_Z_bilin.zero_left f 0
-
-lemma is_Z_bilin.neg_left  : ∀ a b, f (-a, b) = -f (a, b) :=
-begin
-  intros a b,
-  apply eq_of_sub_eq_zero,
-  rw [sub_eq_add_neg, neg_neg, ←is_Z_bilin.add_left f, neg_add_self, is_Z_bilin.zero_left f]
-end
-
-lemma is_Z_bilin.neg_right  : ∀ a b, f (a, -b) = -f (a, b) :=
-assume a b, is_Z_bilin.neg_left (f ∘ prod.swap) b a
-
-lemma is_Z_bilin.sub_left : ∀ a a' b, f (a - a', b) = f (a, b) - f (a', b) :=
-begin
-  intros,
-  simp [sub_eq_add_neg],
-  rw [is_Z_bilin.add_left f, is_Z_bilin.neg_left f]
-end
-
-lemma is_Z_bilin.sub_right : ∀ a b b', f (a, b - b') = f (a, b) - f (a,b') :=
-assume a b b', is_Z_bilin.sub_left (f ∘ prod.swap) b b' a
-end Z_bilin
-end add_comm_group
-
 open add_comm_group filter set function
-
-section
-variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
-
--- α, β and G are abelian topological groups, G is a uniform space
-variables [topological_space α] [add_comm_group α]
-variables [topological_space β] [add_comm_group β]
-variables {G : Type*} [uniform_space G] [add_comm_group G]
-
-variables {ψ : α × β → G} (hψ : continuous ψ) [ψbilin : is_Z_bilin ψ]
-
-include hψ ψbilin
-
-lemma is_Z_bilin.tendsto_zero_left (x₁ : α) : tendsto ψ (𝓝 (x₁, 0)) (𝓝 0) :=
-begin
-  have := hψ.tendsto (x₁, 0),
-  rwa [is_Z_bilin.zero_right ψ] at this
-end
-
-lemma is_Z_bilin.tendsto_zero_right (y₁ : β) : tendsto ψ (𝓝 (0, y₁)) (𝓝 0) :=
-begin
-  have := hψ.tendsto (0, y₁),
-  rwa [is_Z_bilin.zero_left ψ] at this
-end
-end
 
 section
 variables {α : Type*} {β : Type*}
@@ -324,8 +240,8 @@ variables [topological_space α] [add_comm_group α] [topological_add_group α]
 
 -- β is a dense subgroup of α, inclusion is denoted by e
 variables [topological_space β] [add_comm_group β]
-variables {e : β → α} (he : is_add_group_hom e) (de : dense_inducing e)
-include he de
+variables {e : β →+ α} (de : dense_inducing e)
+include de
 
 lemma tendsto_sub_comap_self (x₀ : α) :
   tendsto (λt:β×β, t.2 - t.1) (comap (λp:β×β, (e p.1, e p.2)) $ 𝓝 (x₀, x₀)) (𝓝 0) :=
@@ -333,12 +249,10 @@ begin
   have comm : (λx:α×α, x.2-x.1) ∘ (λt:β×β, (e t.1, e t.2)) = e ∘ (λt:β×β, t.2 - t.1),
   { ext t,
     change e t.2 - e t.1 = e (t.2 - t.1),
-    rwa ← he.map_sub t.2 t.1 },
+    rwa ← e.map_sub t.2 t.1 },
   have lim : tendsto (λ x : α × α, x.2-x.1) (𝓝 (x₀, x₀)) (𝓝 (e 0)),
-    { have := (continuous_sub.comp (@continuous_swap α α _ _)).tendsto (x₀, x₀),
-      simpa [-sub_eq_add_neg, sub_self, eq.symm (he.map_zero)] using this },
-  have := de.tendsto_comap_nhds_nhds lim comm,
-  simp [-sub_eq_add_neg, this]
+  { simpa using (continuous_sub.comp (@continuous_swap α α _ _)).tendsto (x₀, x₀) },
+  simpa using de.tendsto_comap_nhds_nhds lim comm
 end
 end
 
@@ -354,17 +268,21 @@ variables [topological_space γ] [add_comm_group γ] [topological_add_group γ]
 variables [topological_space δ] [add_comm_group δ] [topological_add_group δ]
 variables [uniform_space G] [add_comm_group G] [uniform_add_group G] [separated_space G]
   [complete_space G]
-variables {e : β → α} (he : is_add_group_hom e) (de : dense_inducing e)
-variables {f : δ → γ} (hf : is_add_group_hom f) (df : dense_inducing f)
-variables {φ : β × δ → G} (hφ : continuous φ) [bilin : is_Z_bilin φ]
+variables {e : β →+ α} (de : dense_inducing e)
+variables {f : δ →+ γ} (df : dense_inducing f)
 
-include he de hf df hφ bilin
+variables {φ : β →+ δ →+ G}
+local notation `Φ` := λ p : β × δ, φ p.1 p.2
+
+variables  (hφ : continuous Φ)
+
+include de df hφ
 
 variables {W' : set G} (W'_nhd : W' ∈ 𝓝 (0 : G))
 include W'_nhd
 
 private lemma extend_Z_bilin_aux (x₀ : α) (y₁ : δ) :
-  ∃ U₂ ∈ comap e (𝓝 x₀), ∀ x x' ∈ U₂, φ (x' - x, y₁) ∈ W' :=
+  ∃ U₂ ∈ comap e (𝓝 x₀), ∀ x x' ∈ U₂, Φ (x' - x, y₁) ∈ W' :=
 begin
   let Nx := 𝓝 x₀,
   let ee := λ u : β × β, (e u.1, e u.2),
@@ -374,15 +292,15 @@ begin
       (tendsto_const_nhds : tendsto (λ (p : β × β), y₁) (comap ee $ 𝓝 (x₀, x₀)) (𝓝 y₁)),
     rw [nhds_prod_eq, prod_comap_comap_eq, ←nhds_prod_eq],
     exact (this : _) },
-
-  have lim := tendsto.comp (is_Z_bilin.tendsto_zero_right hφ y₁) lim1,
+  have lim2 : tendsto Φ (𝓝 (0, y₁)) (𝓝 0), by simpa using hφ.tendsto (0, y₁),
+  have lim := lim2.comp lim1,
   rw tendsto_prod_self_iff at lim,
-  exact lim W' W'_nhd,
+  exact lim W' W'_nhd
 end
 
 private lemma extend_Z_bilin_key (x₀ : α) (y₀ : γ) :
   ∃ U ∈ comap e (𝓝 x₀), ∃ V ∈ comap f (𝓝 y₀),
-    ∀ x x' ∈ U, ∀ y y' ∈ V, φ (x', y') - φ (x, y) ∈ W' :=
+    ∀ x x' ∈ U, ∀ y y' ∈ V, Φ (x', y') - Φ (x, y) ∈ W' :=
 begin
   let Nx := 𝓝 x₀,
   let Ny := 𝓝 y₀,
@@ -390,11 +308,10 @@ begin
   let ee := λ u : β × β, (e u.1, e u.2),
   let ff := λ u : δ × δ, (f u.1, f u.2),
 
-  have lim_φ : filter.tendsto φ (𝓝 (0, 0)) (𝓝 0),
-  { have := hφ.tendsto (0, 0),
-    rwa [is_Z_bilin.zero φ] at this },
+  have lim_φ : filter.tendsto Φ (𝓝 (0, 0)) (𝓝 0),
+  { simpa using hφ.tendsto (0, 0) },
 
-  have lim_φ_sub_sub : tendsto (λ (p : (β × β) × (δ × δ)), φ (p.1.2 - p.1.1, p.2.2 - p.2.1))
+  have lim_φ_sub_sub : tendsto (λ (p : (β × β) × (δ × δ)), Φ (p.1.2 - p.1.1, p.2.2 - p.2.1))
     ((comap ee $ 𝓝 (x₀, x₀)) ×ᶠ (comap ff $ 𝓝 (y₀, y₀))) (𝓝 0),
   { have lim_sub_sub :  tendsto (λ (p : (β × β) × δ × δ), (p.1.2 - p.1.1, p.2.2 - p.2.1))
       ((comap ee (𝓝 (x₀, x₀))) ×ᶠ (comap ff (𝓝 (y₀, y₀)))) (𝓝 0 ×ᶠ 𝓝 0),
@@ -406,7 +323,7 @@ begin
   rcases exists_nhds_zero_quarter W'_nhd with ⟨W, W_nhd, W4⟩,
 
   have : ∃ U₁ ∈ comap e (𝓝 x₀), ∃ V₁ ∈ comap f (𝓝 y₀),
-    ∀ x x' ∈ U₁, ∀ y y' ∈ V₁,  φ (x'-x, y'-y) ∈ W,
+    ∀ x x' ∈ U₁, ∀ y y' ∈ V₁,  Φ (x'-x, y'-y) ∈ W,
   { have := tendsto_prod_iff.1 lim_φ_sub_sub W W_nhd,
     repeat { rw [nhds_prod_eq, ←prod_comap_comap_eq] at this },
     rcases this with ⟨U, U_in, V, V_in, H⟩,
@@ -423,26 +340,23 @@ begin
   obtain ⟨y₁, y₁_in⟩ : V₁.nonempty :=
     ((df.comap_nhds_ne_bot _).nonempty_of_mem V₁_nhd),
 
-  rcases (extend_Z_bilin_aux he de hf df hφ W_nhd x₀ y₁) with ⟨U₂, U₂_nhd, HU⟩,
-  rcases (extend_Z_bilin_aux hf df he de (hφ.comp continuous_swap) W_nhd y₀ x₁)
-    with ⟨V₂, V₂_nhd, HV⟩,
+  have cont_flip : continuous (λ p : δ × β, φ.flip p.1 p.2),
+  { show continuous (Φ ∘ prod.swap), from hφ.comp continuous_swap },
+  rcases (extend_Z_bilin_aux de df hφ W_nhd x₀ y₁) with ⟨U₂, U₂_nhd, HU⟩,
+  rcases (extend_Z_bilin_aux df de cont_flip W_nhd y₀ x₁) with ⟨V₂, V₂_nhd, HV⟩,
 
   existsi [U₁ ∩ U₂, inter_mem_sets U₁_nhd U₂_nhd,
             V₁ ∩ V₂, inter_mem_sets V₁_nhd V₂_nhd],
 
   rintros x x' ⟨xU₁, xU₂⟩ ⟨x'U₁, x'U₂⟩ y y' ⟨yV₁, yV₂⟩ ⟨y'V₁, y'V₂⟩,
-  have key_formula : φ(x', y') - φ(x, y) =
-    φ(x' - x, y₁) + φ(x' - x, y' - y₁) + φ(x₁, y' - y) + φ(x - x₁, y' - y),
-  { repeat { rw is_Z_bilin.sub_left φ },
-    repeat { rw is_Z_bilin.sub_right φ },
-    apply eq_of_sub_eq_zero,
-    simp [sub_eq_add_neg], abel },
+  have key_formula : φ x' y' - φ x y =
+    φ(x' - x) y₁ + φ (x' - x) (y' - y₁) + φ x₁ (y' - y) + φ (x - x₁) (y' - y),
+  { simp, abel },
   rw key_formula,
   have h₁ := HU x x' xU₂ x'U₂,
   have h₂ := H x x' xU₁ x'U₁ y₁ y' y₁_in y'V₁,
   have h₃ := HV y y' yV₂ y'V₂,
   have h₄ := H x₁ x x₁_in xU₁ y y' yV₁ y'V₁,
-
   exact W4 h₁ h₂ h₃ h₄
 end
 
@@ -453,7 +367,7 @@ open dense_inducing
 /-- Bourbaki GT III.6.5 Theorem I:
 ℤ-bilinear continuous maps from dense images into a complete Hausdorff group extend by continuity.
 Note: Bourbaki assumes that α and β are also complete Hausdorff, but this is not necessary. -/
-theorem extend_Z_bilin  : continuous (extend (de.prod df) φ) :=
+theorem extend_Z_bilin  : continuous (extend (de.prod df) Φ) :=
 begin
   refine continuous_extend_of_cauchy _ _,
   rintro ⟨x₀, y₀⟩,
@@ -465,7 +379,7 @@ begin
     rcases mem_closure_iff_nhds.1 ((de.prod df).dense (x₀, y₀)) U h with ⟨x, x_in, ⟨z, z_x⟩⟩,
     existsi z,
     cc },
-  { suffices : map (λ (p : (β × δ) × (β × δ)), φ p.2 - φ p.1)
+  { suffices : map (λ (p : (β × δ) × (β × δ)), Φ p.2 - Φ p.1)
       (comap (λ (p : (β × δ) × β × δ), ((e p.1.1, f p.1.2), (e p.2.1, f p.2.2)))
          (𝓝 (x₀, y₀) ×ᶠ 𝓝 (x₀, y₀))) ≤ 𝓝 0,
     by rwa [uniformity_eq_comap_nhds_zero G, prod_map_map_eq, ←map_le_iff_le_comap, filter.map_map,

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -34,7 +34,7 @@ variables [uniform_add_group α]
 
 lemma continuous_mul : continuous (λ p : completion α × completion α, p.1 * p.2) :=
 begin
-let m := (add_monoid_hom.mul : α →+ α →+ α).compr₂ to_compl,
+  let m := (add_monoid_hom.mul : α →+ α →+ α).compr₂ to_compl,
   have : continuous (λ p : α × α, m p.1 p.2),
   from (continuous_coe α).comp continuous_mul,
   have di : dense_inducing (to_compl : α → completion α),

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -34,13 +34,7 @@ variables [uniform_add_group α]
 
 lemma continuous_mul : continuous (λ p : completion α × completion α, p.1 * p.2) :=
 begin
-  let m : α →+ α →+ completion α :=
-  { to_fun := λ a,
-    { to_fun := λ b, ((a*b : α) : completion α),
-      map_zero' := by rw [mul_zero, coe_zero],
-      map_add' := λ x y, by rw_mod_cast [mul_add] },
-  map_zero' := by {ext x, dsimp, rw_mod_cast [zero_mul], refl },
-  map_add' := λ x y, by {ext z, dsimp, rw_mod_cast [add_mul] } },
+let m := (add_monoid_hom.mul : α →+ α →+ α).compr₂ to_compl,
   have : continuous (λ p : α × α, m p.1 p.2),
   from (continuous_coe α).comp continuous_mul,
   have di : dense_inducing (to_compl : α → completion α),

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -19,7 +19,7 @@ variables (α : Type*) [ring α] [uniform_space α]
 instance : has_one (completion α) := ⟨(1:α)⟩
 
 instance : has_mul (completion α) :=
-  ⟨curry $ (dense_inducing_coe.prod dense_inducing_coe).extend (coe ∘ uncurry (*))⟩
+⟨curry $ (dense_inducing_coe.prod dense_inducing_coe).extend (coe ∘ uncurry (*))⟩
 
 @[norm_cast] lemma coe_one : ((1 : α) : completion α) = 1 := rfl
 
@@ -34,23 +34,20 @@ variables [uniform_add_group α]
 
 lemma continuous_mul : continuous (λ p : completion α × completion α, p.1 * p.2) :=
 begin
-  haveI : is_Z_bilin ((coe ∘ uncurry (*)) : α × α → completion α) :=
-  { add_left := begin
-      introv,
-      change coe ((a + a')*b) = coe (a*b) + coe (a'*b),
-      rw_mod_cast add_mul
-    end,
-    add_right := begin
-      introv,
-      change coe (a*(b + b')) = coe (a*b) + coe (a*b'),
-      rw_mod_cast mul_add
-    end },
-  have : continuous ((coe ∘ uncurry (*)) : α × α → completion α),
-    from (continuous_coe α).comp continuous_mul,
-  convert dense_inducing_coe.extend_Z_bilin _ _ dense_inducing_coe this,
-  { simp only [(*), curry, prod.mk.eta] },
-  { exact completion.is_add_group_hom_coe },
-  { exact completion.is_add_group_hom_coe },
+  let m : α →+ α →+ completion α :=
+  { to_fun := λ a,
+    { to_fun := λ b, ((a*b : α) : completion α),
+      map_zero' := by rw [mul_zero, coe_zero],
+      map_add' := λ x y, by rw_mod_cast [mul_add] },
+  map_zero' := by {ext x, dsimp, rw_mod_cast [zero_mul], refl },
+  map_add' := λ x y, by {ext z, dsimp, rw_mod_cast [add_mul] } },
+  have : continuous (λ p : α × α, m p.1 p.2),
+  from (continuous_coe α).comp continuous_mul,
+  have di : dense_inducing (to_compl : α → completion α),
+  from dense_inducing_coe,
+  convert di.extend_Z_bilin di this,
+  ext ⟨x, y⟩,
+  refl
 end
 
 lemma continuous.mul {β : Type*} [topological_space β] {f g : β → completion α}
@@ -94,6 +91,9 @@ instance : ring (completion α) :=
 def coe_ring_hom : α →+* completion α :=
 ⟨coe, coe_one α, assume a b, coe_mul a b, coe_zero, assume a b, coe_add a b⟩
 
+lemma continuous_coe_ring_hom : continuous (coe_ring_hom : α → completion α) :=
+continuous_coe α
+
 universes u
 variables {β : Type u} [uniform_space β] [ring β] [uniform_add_group β] [topological_ring β]
           (f : α →+* β) (hf : continuous f)
@@ -101,7 +101,8 @@ variables {β : Type u} [uniform_space β] [ring β] [uniform_add_group β] [top
 /-- The completion extension as a ring morphism. -/
 def extension_hom [complete_space β] [separated_space β] :
   completion α →+* β :=
-have hf : uniform_continuous f, from uniform_continuous_of_continuous f.to_is_add_group_hom hf,
+have hf' : continuous (f : α →+ β), from hf, -- helping the elaborator
+have hf : uniform_continuous f, from uniform_continuous_of_continuous hf',
 { to_fun := completion.extension f,
   map_zero' := by rw [← coe_zero, extension_coe hf, f.map_zero],
   map_add' := assume a b, completion.induction_on₂ a b
@@ -126,8 +127,8 @@ instance top_ring_compl : topological_ring (completion α) :=
   continuous_neg := continuous_neg }
 
 /-- The completion map as a ring morphism. -/
-def map_ring_hom : completion α →+* completion β :=
-  extension_hom (coe_ring_hom.comp f) ((continuous_coe β).comp hf)
+def map_ring_hom (hf : continuous f) : completion α →+* completion β :=
+extension_hom (coe_ring_hom.comp f) (continuous_coe_ring_hom.comp  hf)
 
 variables (R : Type*) [comm_ring R] [uniform_space R] [uniform_add_group R] [topological_ring R]
 


### PR DESCRIPTION
Also take the opportunity to remove is_Z_bilin (who was scheduled for
removal from the beginning).


---

This is the refactor that was started as part of the review of #8317. It also meshed with @kbuzzard's recent effort about unbundled homs.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
