### PR TITLE
[Merged by Bors] - feat(ring_theory/dedekind_domain): ideals in a DD are cancellative 

### DIFF
--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -249,9 +249,10 @@ fractional_ideal.div_one
 /--
 A Dedekind domain is an integral domain such that every fractional ideal has an inverse.
 
-This is equivalent to `is_dedekind_domain`, and in particular we provide a `comm_group_with_zero`
-instance on `fractional_ideal A⁰ (fraction_ring A)`, assuming `is_dedekind_domain A`,
-which implies `is_dedekind_domain_inv`.
+This is equivalent to `is_dedekind_domain`.
+In particular we provide a `fractional_ideal.comm_group_with_zero` instance,
+assuming `is_dedekind_domain A`, which implies `is_dedekind_domain_inv`. For **integral** ideals,
+`is_dedekind_domain`(`_inv`) implies only `ideal.comm_cancel_monoid_with_zero`.
 -/
 def is_dedekind_domain_inv : Prop :=
 ∀ I ≠ (⊥ : fractional_ideal A⁰ (fraction_ring A)), I * I⁻¹ = 1

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -595,8 +595,7 @@ noncomputable instance fractional_ideal.comm_group_with_zero
 
 noncomputable instance ideal.comm_cancel_monoid_with_zero
   [is_dedekind_domain A] : comm_cancel_monoid_with_zero (ideal A) :=
-{ .. function.injective.cancel_monoid_with_zero (coe_ideal_hom A⁰ (fraction_ring A))
-       coe_ideal_injective (ring_hom.map_zero _) (ring_hom.map_one _) (ring_hom.map_mul _),
-  .. (infer_instance : comm_monoid_with_zero (ideal A)) }
+function.injective.comm_cancel_monoid_with_zero (coe_ideal_hom A⁰ (fraction_ring A))
+  coe_ideal_injective (ring_hom.map_zero _) (ring_hom.map_one _) (ring_hom.map_mul _)
 
 end inverse

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -249,8 +249,9 @@ fractional_ideal.div_one
 /--
 A Dedekind domain is an integral domain such that every fractional ideal has an inverse.
 
-This is equivalent to `is_dedekind_domain`.
-TODO: prove the equivalence.
+This is equivalent to `is_dedekind_domain`, and in particular we provide a `comm_group_with_zero`
+instance on `fractional_ideal A⁰ (fraction_ring A)`, assuming `is_dedekind_domain A`,
+which implies `is_dedekind_domain_inv`.
 -/
 def is_dedekind_domain_inv : Prop :=
 ∀ I ≠ (⊥ : fractional_ideal A⁰ (fraction_ring A)), I * I⁻¹ = 1
@@ -591,5 +592,11 @@ noncomputable instance fractional_ideal.comm_group_with_zero
     (by simpa using @zero_ne_one (ideal A) _ _)⟩,
   mul_inv_cancel := λ I, fractional_ideal.mul_inv_cancel,
   .. fractional_ideal.comm_semiring }
+
+noncomputable instance ideal.comm_cancel_monoid_with_zero
+  [is_dedekind_domain A] : comm_cancel_monoid_with_zero (ideal A) :=
+{ .. function.injective.cancel_monoid_with_zero (coe_ideal_hom A⁰ (fraction_ring A))
+       coe_ideal_injective (ring_hom.map_zero _) (ring_hom.map_one _) (ring_hom.map_mul _),
+  .. (infer_instance : comm_monoid_with_zero (ideal A)) }
 
 end inverse


### PR DESCRIPTION
This PR provides a `comm_cancel_monoid_with_zero` instance on integral ideals in a Dedekind domain.

As a bonus, it deletes an out of date TODO comment.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #8511
- [x] depends on: #8515

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
