### PR TITLE
[Merged by Bors] - feat(algebra/group_with_zero): pullback a `comm_cancel_monoid_with_zero` instance across an injective hom

### DIFF
--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -387,6 +387,23 @@ classical.by_contradiction $ λ ha, h₁ $ mul_right_cancel' ha $ h₂.symm ▸ 
 
 end cancel_monoid_with_zero
 
+section comm_cancel_monoid_with_zero
+
+variables [comm_cancel_monoid_with_zero M₀] {a b c : M₀}
+
+/-- Pullback a `comm_cancel_monoid_with_zero` class along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.comm_cancel_monoid_with_zero
+  [has_zero M₀'] [has_mul M₀'] [has_one M₀']
+  (f : M₀' → M₀) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (mul : ∀ x y, f (x * y) = f x * f y) :
+  comm_cancel_monoid_with_zero M₀' :=
+{ .. hf.comm_monoid_with_zero f zero one mul,
+  .. hf.cancel_monoid_with_zero f zero one mul }
+
+end comm_cancel_monoid_with_zero
+
 section group_with_zero
 variables [group_with_zero G₀] {a b c g h x : G₀}
 


### PR DESCRIPTION
This generalizes `function.injective.cancel_monoid_with_zero` to the commutative case.

See also: https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/A.20submonoid.20of.20a.20.60cancel_monoid_with_zero.60.20also.20cancels



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
