### PR TITLE
refactor(data/matrix/basic): Remove matrix.scalar

### DIFF
--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -742,41 +742,6 @@ instance semiring.smul_comm_class [monoid R] [distrib_mul_action R α] [smul_com
   (λ i j, a * M i j) ⬝ N = a • (M ⬝ N) :=
 smul_mul a M N
 
-/--
-The ring homomorphism `α →+* matrix n n α`
-sending `a` to the diagonal matrix with `a` on the diagonal.
--/
-def scalar (n : Type u) [decidable_eq n] [fintype n] : α →+* matrix n n α :=
-{ to_fun := λ a, a • 1,
-  map_one' := by simp,
-  map_mul' := by { intros, ext, simp [mul_assoc], },
-  .. (smul_add_hom α _).flip (1 : matrix n n α) }
-
-section scalar
-
-variable [decidable_eq n]
-
-@[simp] lemma coe_scalar : (scalar n : α → matrix n n α) = λ a, a • 1 := rfl
-
-lemma scalar_apply_eq (a : α) (i : n) :
-  scalar n a i i = a :=
-by simp only [coe_scalar, smul_eq_mul, mul_one, one_apply_eq, pi.smul_apply]
-
-lemma scalar_apply_ne (a : α) (i j : n) (h : i ≠ j) :
-  scalar n a i j = 0 :=
-by simp only [h, coe_scalar, one_apply_ne, ne.def, not_false_iff, pi.smul_apply, smul_zero]
-
-lemma scalar_inj [nonempty n] {r s : α} : scalar n r = scalar n s ↔ r = s :=
-begin
-  split,
-  { intro h,
-    inhabit n,
-    rw [← scalar_apply_eq r (arbitrary n), ← scalar_apply_eq s (arbitrary n), h] },
-  { rintro rfl, refl }
-end
-
-end scalar
-
 end semiring
 
 section comm_semiring
@@ -790,9 +755,6 @@ by { ext, simp [mul_comm] }
   M ⬝ (λ i j, a * N i j) = a • (M ⬝ N) :=
 mul_smul M a N
 
-lemma scalar.commute [decidable_eq n] (r : α) (M : matrix n n α) : commute (scalar n r) M :=
-by simp [commute, semiconj_by]
-
 end comm_semiring
 
 section algebra
@@ -800,19 +762,20 @@ variables [comm_semiring R] [semiring α] [algebra R α] [decidable_eq n]
 
 instance : algebra R (matrix n n α) :=
 { commutes' := λ r x, begin
-    ext, simp [matrix.scalar, matrix.mul_apply, matrix.one_apply, algebra.commutes, smul_ite], end,
-  smul_def' := λ r x, begin ext, simp [matrix.scalar, algebra.smul_def'' r], end,
-  ..((matrix.scalar n).comp (algebra_map R α)) }
+    dsimp,
+    ext i j,
+    rw [diagonal_mul, mul_diagonal, pi.algebra_map_apply, pi.algebra_map_apply, algebra.commutes],
+  end,
+  smul_def' := λ r x, begin ext, simp [algebra.smul_def'' r], end,
+  to_ring_hom := (diagonal_ring_hom n α).comp (algebra_map R _) }
 
-lemma algebra_map_matrix_apply {r : R} {i j : n} :
-  algebra_map R (matrix n n α) r i j = if i = j then algebra_map R α r else 0 :=
-begin
-  dsimp [algebra_map, algebra.to_ring_hom, matrix.scalar],
-  split_ifs with h; simp [h, matrix.one_apply_ne],
-end
+lemma algebra_map_eq_diagonal_ring_hom_comp :
+  algebra_map R (matrix n n α) = (diagonal_ring_hom n α).comp (algebra_map R _) :=
+rfl
 
-@[simp] lemma algebra_map_eq_smul (r : R) :
-  algebra_map R (matrix n n R) r = r • (1 : matrix n n R) := rfl
+lemma algebra_map_eq_diagonal (r : R) :
+  algebra_map R (matrix n n α) r = diagonal (λ _ : n, algebra_map R α r) :=
+rfl
 
 variables (R)
 
@@ -820,7 +783,7 @@ variables (R)
 @[simps]
 def diagonal_alg_hom : (n → α) →ₐ[R] matrix n n α :=
 { to_fun := diagonal,
-  commutes' := λ r, by { ext, rw [algebra_map_matrix_apply, diagonal, pi.algebra_map_apply] },
+  commutes' := λ r, rfl,
   .. diagonal_ring_hom n α }
 
 end algebra

--- a/src/data/matrix/char_p.lean
+++ b/src/data/matrix/char_p.lean
@@ -16,6 +16,11 @@ instance matrix.char_p [decidable_eq n] [nonempty n] (p : ℕ) [char_p R p] :
   char_p (matrix n n R) p :=
 ⟨begin
   intro k,
-  rw [← char_p.cast_eq_zero_iff R p k, ← nat.cast_zero, ← (scalar n).map_nat_cast],
-  convert scalar_inj, {simp}, {assumption}
+  let scalar := (diagonal_ring_hom n R).comp (pi.ring_hom $ λ _, ring_hom.id _),
+  suffices : function.injective scalar,
+  { rw [← scalar.map_nat_cast k, ← scalar.map_zero, this.eq_iff, ←char_p.cast_eq_zero_iff R p k], },
+  refine diagonal_injective.comp _,
+  intros x y h,
+  obtain ⟨i⟩ := id ‹nonempty n›,
+  exact function.funext_iff.mp h i,
  end⟩

--- a/src/linear_algebra/char_poly/basic.lean
+++ b/src/linear_algebra/char_poly/basic.lean
@@ -41,16 +41,16 @@ The "characteristic matrix" of `M : matrix n n R` is the matrix of polynomials $
 The determinant of this matrix is the characteristic polynomial.
 -/
 def char_matrix (M : matrix n n R) : matrix n n (polynomial R) :=
-matrix.scalar n (X : polynomial R) - (C : R →+* polynomial R).map_matrix M
+diagonal (λ _, (X : polynomial R)) - (C : R →+* polynomial R).map_matrix M
 
 @[simp] lemma char_matrix_apply_eq (M : matrix n n R) (i : n) :
   char_matrix M i i = (X : polynomial R) - C (M i i) :=
-by simp only [char_matrix, sub_left_inj, pi.sub_apply, scalar_apply_eq,
+by simp only [char_matrix, sub_left_inj, pi.sub_apply, diagonal_apply_eq,
   ring_hom.map_matrix_apply, map_apply, dmatrix.sub_apply]
 
 @[simp] lemma char_matrix_apply_ne (M : matrix n n R) (i j : n) (h : i ≠ j) :
   char_matrix M i j = - C (M i j) :=
-by simp only [char_matrix, pi.sub_apply, scalar_apply_ne _ _ _ h, zero_sub,
+by simp only [char_matrix, pi.sub_apply, diagonal_apply_ne h, zero_sub,
   ring_hom.map_matrix_apply, map_apply, dmatrix.sub_apply]
 
 lemma mat_poly_equiv_char_matrix (M : matrix n n R) :

--- a/src/linear_algebra/char_poly/coeff.lean
+++ b/src/linear_algebra/char_poly/coeff.lean
@@ -127,14 +127,14 @@ end
 
 -- I feel like this should use polynomial.alg_hom_eval₂_algebra_map
 lemma mat_poly_equiv_eval (M : matrix n n (polynomial R)) (r : R) (i j : n) :
-  (mat_poly_equiv M).eval ((scalar n) r) i j = (M i j).eval r :=
+  (mat_poly_equiv M).eval (algebra_map _ _ r) i j = (M i j).eval r :=
 begin
   unfold polynomial.eval, unfold eval₂,
   transitivity polynomial.sum (mat_poly_equiv M) (λ (e : ℕ) (a : matrix n n R),
-    (a * (scalar n) r ^ e) i j),
+    (a * algebra_map _ _ r ^ e) i j),
   { unfold polynomial.sum, rw matrix.sum_apply, dsimp, refl },
-  { simp_rw [←ring_hom.map_pow, ←(matrix.scalar.commute _ _).eq],
-    simp only [coe_scalar, matrix.one_mul, ring_hom.id_apply,
+  { simp_rw [←ring_hom.map_pow, ←algebra.commutes],
+    simp only [algebra.algebra_map_eq_smul_one, matrix.one_mul, ring_hom.id_apply,
       pi.smul_apply, smul_eq_mul, mul_eq_mul, algebra.smul_mul_assoc],
     have h : ∀ x : ℕ, (λ (e : ℕ) (a : R), r ^ e * a) x 0 = 0 := by simp,
     simp only [polynomial.sum, mat_poly_equiv_coeff_apply, mul_comm],
@@ -144,11 +144,16 @@ begin
     simp only [h'n, zero_mul] }
 end
 
+lemma mat_poly_equiv_eval_eq_map (M : matrix n n (polynomial R)) (r : R) :
+  (mat_poly_equiv M).eval (algebra_map _ _ r) = M.map (eval r) :=
+matrix.ext $ mat_poly_equiv_eval M r
+
 lemma eval_det (M : matrix n n (polynomial R)) (r : R) :
-  polynomial.eval r M.det = (polynomial.eval (matrix.scalar n r) (mat_poly_equiv M)).det :=
+  polynomial.eval r M.det = (polynomial.eval (algebra_map _ _ r) (mat_poly_equiv M)).det :=
 begin
   rw [polynomial.eval, ← coe_eval₂_ring_hom, ring_hom.map_det],
-  apply congr_arg det, ext, symmetry, convert mat_poly_equiv_eval _ _ _ _,
+  apply congr_arg det,
+  exact (mat_poly_equiv_eval_eq_map M r).symm,
 end
 
 theorem det_eq_sign_char_poly_coeff (M : matrix n n R) :

--- a/src/ring_theory/polynomial_algebra.lean
+++ b/src/ring_theory/polynomial_algebra.lean
@@ -218,8 +218,8 @@ variables {n : Type w} [decidable_eq n] [fintype n]
 The algebra isomorphism stating "matrices of polynomials are the same as polynomials of matrices".
 
 (You probably shouldn't attempt to use this underlying definition ---
-it's an algebra equivalence, and characterised extensionally by the lemma
-`mat_poly_equiv_coeff_apply` below.)
+it's an algebra equivalence, and characterised extensionally by the lemmas
+`mat_poly_equiv_coeff_apply` and `mat_poly_equiv_coeff_eq_map` below.)
 -/
 noncomputable def mat_poly_equiv :
   matrix n n (polynomial R) ≃ₐ[R] polynomial (matrix n n R) :=
@@ -259,7 +259,7 @@ begin
     split_ifs; { funext, simp, }, }
 end
 
-@[simp] lemma mat_poly_equiv_coeff_apply
+lemma mat_poly_equiv_coeff_apply
   (m : matrix n n (polynomial R)) (k : ℕ) (i j : n) :
   coeff (mat_poly_equiv m) k i j = coeff (m i j) k :=
 begin
@@ -274,6 +274,14 @@ begin
     { simp [std_basis_matrix, h], }, },
 end
 
+@[simp] lemma mat_poly_equiv_coeff_eq_map
+  (m : matrix n n (polynomial R)) (k : ℕ) :
+  coeff (mat_poly_equiv m) k = m.map (λ p, coeff p k) :=
+begin
+  ext i j,
+  exact mat_poly_equiv_coeff_apply _ _ _ _,
+end
+
 @[simp] lemma mat_poly_equiv_symm_apply_coeff
   (p : polynomial (matrix n n R)) (i j : n) (k : ℕ) :
   coeff (mat_poly_equiv.symm p i j) k = coeff p k i j :=
@@ -284,13 +292,20 @@ begin
   simp only [mat_poly_equiv_coeff_apply],
 end
 
+lemma mat_poly_equiv_algebra_map (p : polynomial R) :
+  mat_poly_equiv (algebra_map _ _ p) = p.map (algebra_map R (matrix n n R)) :=
+begin
+  ext m : 1,
+  rw mat_poly_equiv_coeff_eq_map,
+  simp only [matrix.algebra_map_eq_diagonal, polynomial.coeff_map, matrix.diagonal_map,
+    algebra.id.map_eq_self, coeff_zero],
+end
+
 lemma mat_poly_equiv_smul_one (p : polynomial R) :
   mat_poly_equiv (p • 1) = p.map (algebra_map R (matrix n n R)) :=
 begin
-  ext m i j,
-  simp only [coeff_map, one_apply, algebra_map_matrix_apply, mul_boole,
-    pi.smul_apply, mat_poly_equiv_coeff_apply],
-  split_ifs; simp,
+  rw ←algebra.algebra_map_eq_smul_one,
+  exact mat_poly_equiv_algebra_map p,
 end
 
 lemma support_subset_support_mat_poly_equiv


### PR DESCRIPTION
`matrix.scalar` was the same as `algebra_map R (matrix n n R)`. This replaces all uses with `algebra_map`, and also changes the definitional reduction of the algebra_map for matrices to be something simpler.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]

-->
- [x] depends on: #8510 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
