### PR TITLE
[Merged by Bors] - chore(ring_theory/fractional_ideal): make `coe : ideal → fractional_ideal` a `coe_t`

### DIFF
--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -18,7 +18,7 @@ Let `S` be a submonoid of an integral domain `R`, `P` the localization of `R` at
 natural ring hom from `R` to `P`.
  * `is_fractional` defines which `R`-submodules of `P` are fractional ideals
  * `fractional_ideal S P` is the type of fractional ideals in `P`
- * `has_coe (ideal R) (fractional_ideal S P)` instance
+ * `has_coe_t (ideal R) (fractional_ideal S P)` instance
  * `comm_semiring (fractional_ideal S P)` instance:
    the typical ideal operations generalized to fractional ideals
  * `lattice (fractional_ideal S P)` instance
@@ -166,7 +166,8 @@ This is a bundled version of `is_localization.coe_submodule : ideal R → submod
 which is not to be confused with the `coe : fractional_ideal S P → submodule R P`,
 also called `coe_to_submodule` in theorem names.
 -/
-instance coe_to_fractional_ideal : has_coe (ideal R) (fractional_ideal S P) :=
+-- Is a `coe_t` rather than `coe` to speed up failing inference, see library note [use has_coe_t]
+instance coe_to_fractional_ideal : has_coe_t (ideal R) (fractional_ideal S P) :=
 ⟨λ I, ⟨coe_submodule P I, is_fractional_of_le_one _
   (by simpa using coe_submodule_mono P (le_top : I ≤ ⊤))⟩⟩
 


### PR DESCRIPTION
This noticeably speeds up elaboration of `dedekind_domain.lean`, since it discourages the elaborator from going down a (nearly?)-looping path.

See also this Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Priority.20of.20.60coe_sort_trans.60



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
