### PR TITLE
chore(gitpod): be slightly more intelligent about getting a PR cache

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,4 +6,5 @@ vscode:
     - jroesch.lean
 
 tasks:
-  - command: . /home/gitpod/.profile && leanproject get-mathlib-cache
+  # if getting the cache for the current commit fails, try the closest common ancestor between this branch and master
+  - command: . /home/gitpod/.profile && (leanproject get-mathlib-cache || leanproject get-cache --rev $(git merge-base origin/master HEAD))


### PR DESCRIPTION
Having any cache is much better than starting up gitpod and having no cache at all.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
