### PR TITLE
[Merged by Bors] - feat(group_theory): Add `monoid_hom.mker` and generalise the codomain for `monoid_hom.ker`

### DIFF
--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1374,7 +1374,7 @@ variables {M : Type*} [mul_one_class M]
 such that `f x = 0`"]
 def ker (f : G →* M) : subgroup G :=
 { inv_mem' := λ x (hx : f x = 1),
-  calc f x⁻¹ = f x * f x⁻¹ : by rw [hx, one_mul]
+    calc f x⁻¹ = f x * f x⁻¹ : by rw [hx, one_mul]
            ... = f (x * x⁻¹) : by rw [f.map_mul]
            ... = f 1 :         by rw [mul_right_inv]
            ... = 1 :           f.map_one,

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1373,8 +1373,8 @@ variables {M : Type*} [mul_one_class M]
 @[to_additive "The additive kernel of an `add_monoid` homomorphism is the `add_subgroup` of elements
 such that `f x = 0`"]
 def ker (f : G →* M) : subgroup G :=
-{ inv_mem' := λ x (hx : f x = 1), show f x⁻¹ = 1, from
-    calc f x⁻¹ = f x * f x⁻¹ : by rw [hx, one_mul]
+{ inv_mem' := λ x (hx : f x = 1),
+  calc f x⁻¹ = f x * f x⁻¹ : by rw [hx, one_mul]
            ... = f (x * x⁻¹) : by rw [f.map_mul]
            ... = f 1 :         by rw [mul_right_inv]
            ... = 1 :           f.map_one,

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1383,6 +1383,7 @@ def ker (f : G →* M) : subgroup G :=
            ... = f 1 :         by rw [mul_right_inv]
            ... = 1 :           f.map_one }
 
+@[to_additive]
 lemma ker_eq_comap (f : G →* N) : f.ker = (⊥ : subgroup N).comap f := rfl
 
 @[to_additive]
@@ -1434,7 +1435,7 @@ set_like.coe_injective $ set.preimage_prod_map_prod f g _ _
 @[to_additive]
 lemma ker_prod_map {G' : Type*} {N' : Type*} [group G'] [group N'] (f : G →* N) (g : G' →* N') :
   (prod_map f g).ker = f.ker.prod g.ker :=
-by rw [ker_eq_comap, ker_eq_comap, ker_eq_comap, ←prod_map_comap_prod, bot_prod_bot],
+by rw [ker_eq_comap, ker_eq_comap, ker_eq_comap, ←prod_map_comap_prod, bot_prod_bot]
 
 end ker
 
@@ -1536,7 +1537,11 @@ lemma map_le_range (H : subgroup G) : map f H ≤ f.range :=
 
 @[to_additive]
 lemma ker_le_comap (H : subgroup N) : f.ker ≤ comap f H :=
-comap_mono bot_le
+begin
+  rw ker_eq_comap,
+  exact comap_mono bot_le
+end
+
 
 @[to_additive]
 lemma map_comap_le (H : subgroup N) : map f (comap f H) ≤ H :=
@@ -1756,7 +1761,7 @@ instance subgroup.normal_comap {H : subgroup N}
 
 @[priority 100, to_additive]
 instance monoid_hom.normal_ker (f : G →* N) : f.ker.normal :=
-by rw [monoid_hom.ker]; apply_instance
+by rw [monoid_hom.ker_eq_comap]; apply_instance
 
 @[priority 100, to_additive]
 instance subgroup.normal_inf (H N : subgroup G) [hN : N.normal] :

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1375,7 +1375,8 @@ such that `f x = 0`"]
 def ker (f : G →* M) : subgroup G :=
 { carrier := {x | f x = 1},
   one_mem' := f.map_one,
-  mul_mem' := λ a b (ha : f a = 1) (hb : f b = 1), show f (a * b) = 1, by rw [f.map_mul, ha, hb, one_mul],
+  mul_mem' := λ a b (ha : f a = 1) (hb : f b = 1),
+    show f (a * b) = 1, by rw [f.map_mul, ha, hb, one_mul],
   inv_mem' := λ x (hx : f x = 1), show f x⁻¹ = 1, from
     calc f x⁻¹ = f x * f x⁻¹ : by rw [hx, one_mul]
            ... = f (x * x⁻¹) : by rw [f.map_mul]

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1364,24 +1364,38 @@ noncomputable def of_injective {f : G →* N} (hf : function.injective f) : G �
 lemma of_injective_apply {f : G →* N} (hf : function.injective f) {x : G} :
   ↑(of_injective hf x) = f x := rfl
 
+section ker
+
+variables {M : Type*} [monoid M]
+
 /-- The multiplicative kernel of a monoid homomorphism is the subgroup of elements `x : G` such that
 `f x = 1` -/
 @[to_additive "The additive kernel of an `add_monoid` homomorphism is the `add_subgroup` of elements
 such that `f x = 0`"]
-def ker (f : G →* N) := (⊥ : subgroup N).comap f
+def ker (f : G →* M) : subgroup G :=
+{ carrier := {x | f x = 1},
+  one_mem' := f.map_one,
+  mul_mem' := λ a b (ha : f a = 1) (hb : f b = 1), show f (a * b) = 1, by rw [f.map_mul, ha, hb, one_mul],
+  inv_mem' := λ x (hx : f x = 1), show f x⁻¹ = 1, from
+    calc f x⁻¹ = f x * f x⁻¹ : by rw [hx, one_mul]
+           ... = f (x * x⁻¹) : by rw [f.map_mul]
+           ... = f 1 :         by rw [mul_right_inv]
+           ... = 1 :           f.map_one }
+
+lemma ker_eq_comap (f : G →* N) : f.ker = (⊥ : subgroup N).comap f := rfl
 
 @[to_additive]
-lemma mem_ker (f : G →* N) {x : G} : x ∈ f.ker ↔ f x = 1 := iff.rfl
+lemma mem_ker (f : G →* M) {x : G} : x ∈ f.ker ↔ f x = 1 := iff.rfl
 
 @[to_additive]
-lemma coe_ker (f : G →* N) : (f.ker : set G) = (f : G → N) ⁻¹' {1} := rfl
+lemma coe_ker (f : G →* M) : (f.ker : set G) = (f : G → M) ⁻¹' {1} := rfl
 
 @[to_additive]
 lemma eq_iff (f : G →* N) {x y : G} : f x = f y ↔ y⁻¹ * x ∈ f.ker :=
 by rw [f.mem_ker, f.map_mul, f.map_inv, inv_mul_eq_one, eq_comm]
 
 @[to_additive]
-instance decidable_mem_ker [decidable_eq N] (f : G →* N) :
+instance decidable_mem_ker [decidable_eq M] (f : G →* M) :
   decidable_pred (∈ f.ker) :=
 λ x, decidable_of_iff (f x = 1) f.mem_ker
 
@@ -1399,7 +1413,7 @@ begin
 end
 
 @[simp, to_additive]
-lemma ker_one : (1 : G →* N).ker = ⊤ :=
+lemma ker_one : (1 : G →* M).ker = ⊤ :=
 by { ext, simp [mem_ker] }
 
 @[to_additive] lemma ker_eq_bot_iff (f : G →* N) : f.ker = ⊥ ↔ function.injective f :=
@@ -1419,10 +1433,9 @@ set_like.coe_injective $ set.preimage_prod_map_prod f g _ _
 @[to_additive]
 lemma ker_prod_map {G' : Type*} {N' : Type*} [group G'] [group N'] (f : G →* N) (g : G' →* N') :
   (prod_map f g).ker = f.ker.prod g.ker :=
-begin
-  dsimp only [ker],
-  rw [←prod_map_comap_prod, bot_prod_bot],
-end
+by rw [ker_eq_comap, ker_eq_comap, ker_eq_comap, ←prod_map_comap_prod, bot_prod_bot],
+
+end ker
 
 /-- The subgroup of elements `x : G` such that `f x = g x` -/
 @[to_additive "The additive subgroup of elements `x : G` such that `f x = g x`"]

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1373,18 +1373,12 @@ variables {M : Type*} [monoid M]
 @[to_additive "The additive kernel of an `add_monoid` homomorphism is the `add_subgroup` of elements
 such that `f x = 0`"]
 def ker (f : G →* M) : subgroup G :=
-{ carrier := {x | f x = 1},
-  one_mem' := f.map_one,
-  mul_mem' := λ a b (ha : f a = 1) (hb : f b = 1),
-    show f (a * b) = 1, by rw [f.map_mul, ha, hb, one_mul],
-  inv_mem' := λ x (hx : f x = 1), show f x⁻¹ = 1, from
+{ inv_mem' := λ x (hx : f x = 1), show f x⁻¹ = 1, from
     calc f x⁻¹ = f x * f x⁻¹ : by rw [hx, one_mul]
            ... = f (x * x⁻¹) : by rw [f.map_mul]
            ... = f 1 :         by rw [mul_right_inv]
-           ... = 1 :           f.map_one }
-
-@[to_additive]
-lemma ker_eq_comap (f : G →* N) : f.ker = (⊥ : subgroup N).comap f := rfl
+           ... = 1 :           f.map_one,
+  ..f.mker }
 
 @[to_additive]
 lemma mem_ker (f : G →* M) {x : G} : x ∈ f.ker ↔ f x = 1 := iff.rfl
@@ -1435,7 +1429,7 @@ set_like.coe_injective $ set.preimage_prod_map_prod f g _ _
 @[to_additive]
 lemma ker_prod_map {G' : Type*} {N' : Type*} [group G'] [group N'] (f : G →* N) (g : G' →* N') :
   (prod_map f g).ker = f.ker.prod g.ker :=
-by rw [ker_eq_comap, ker_eq_comap, ker_eq_comap, ←prod_map_comap_prod, bot_prod_bot]
+by rw [←comap_bot, ←comap_bot, ←comap_bot, ←prod_map_comap_prod, bot_prod_bot]
 
 end ker
 
@@ -1538,7 +1532,7 @@ lemma map_le_range (H : subgroup G) : map f H ≤ f.range :=
 @[to_additive]
 lemma ker_le_comap (H : subgroup N) : f.ker ≤ comap f H :=
 begin
-  rw ker_eq_comap,
+  rw ←comap_bot,
   exact comap_mono bot_le
 end
 
@@ -1761,7 +1755,7 @@ instance subgroup.normal_comap {H : subgroup N}
 
 @[priority 100, to_additive]
 instance monoid_hom.normal_ker (f : G →* N) : f.ker.normal :=
-by rw [monoid_hom.ker_eq_comap]; apply_instance
+by rw [←f.comap_bot]; apply_instance
 
 @[priority 100, to_additive]
 instance subgroup.normal_inf (H N : subgroup G) [hN : N.normal] :

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1531,11 +1531,7 @@ lemma map_le_range (H : subgroup G) : map f H ≤ f.range :=
 
 @[to_additive]
 lemma ker_le_comap (H : subgroup N) : f.ker ≤ comap f H :=
-begin
-  rw ←comap_bot,
-  exact comap_mono bot_le
-end
-
+(comap_bot f) ▸ comap_mono bot_le
 
 @[to_additive]
 lemma map_comap_le (H : subgroup N) : map f (comap f H) ≤ H :=
@@ -1755,7 +1751,7 @@ instance subgroup.normal_comap {H : subgroup N}
 
 @[priority 100, to_additive]
 instance monoid_hom.normal_ker (f : G →* N) : f.ker.normal :=
-by rw [←f.comap_bot]; apply_instance
+by { rw [←f.comap_bot], apply_instance }
 
 @[priority 100, to_additive]
 instance subgroup.normal_inf (H N : subgroup G) [hN : N.normal] :

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -1366,7 +1366,7 @@ lemma of_injective_apply {f : G →* N} (hf : function.injective f) {x : G} :
 
 section ker
 
-variables {M : Type*} [monoid M]
+variables {M : Type*} [mul_one_class M]
 
 /-- The multiplicative kernel of a monoid homomorphism is the subgroup of elements `x : G` such that
 `f x = 1` -/

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -53,6 +53,7 @@ In this file we define various operations on `submonoid`s and `monoid_hom`s.
 ### Operations on `monoid_hom`s
 
 * `monoid_hom.mrange`: range of a monoid homomorphism as a submonoid of the codomain;
+* `monoid_hom.mker`: kernel of a monoid homomorphism as a submonoid of the domain;
 * `monoid_hom.mrestrict`: restrict a monoid homomorphism to a submonoid;
 * `monoid_hom.cod_mrestrict`: restrict the codomain of a monoid homomorphism to a submonoid;
 * `monoid_hom.mrange_restrict`: restrict a monoid homomorphism to its range;
@@ -692,7 +693,7 @@ lemma prod_map_comap_prod' {M' : Type*} {N' : Type*} [mul_one_class M'] [mul_one
 set_like.coe_injective $ set.preimage_prod_map_prod f g _ _
 
 @[to_additive]
-lemma ker_prod_map' {M' : Type*} {N' : Type*} [mul_one_class M'] [mul_one_class N'] (f : M →* N)
+lemma mker_prod_map {M' : Type*} {N' : Type*} [mul_one_class M'] [mul_one_class N'] (f : M →* N)
   (g : M' →* N') : (prod_map f g).mker = f.mker.prod g.mker :=
 by rw [←comap_bot', ←comap_bot', ←comap_bot', ←prod_map_comap_prod', bot_prod_bot]
 

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -651,6 +651,61 @@ lemma coe_mrange_restrict {N} [mul_one_class N] (f : M →* N) (x : M) :
   (f.mrange_restrict x : N) = f x :=
 rfl
 
+/-- The multiplicative kernel of a monoid homomorphism is the submonoid of elements `x : G` such that
+`f x = 1` -/
+@[to_additive "The additive kernel of an `add_monoid` homomorphism is the `add_submonoid` of elements
+such that `f x = 0`"]
+def mker (f : M →* N) : submonoid M := (⊥ : submonoid N).comap f
+
+@[to_additive]
+lemma mem_mker (f : M →* N) {x : M} : x ∈ f.mker ↔ f x = 1 := iff.rfl
+
+@[to_additive]
+lemma coe_mker (f : M →* N) : (f.mker : set M) = (f : M → N) ⁻¹' {1} := rfl
+
+@[to_additive]
+instance decidable_mem_mker [decidable_eq N] (f : M →* N) :
+  decidable_pred (∈ f.mker) :=
+λ x, decidable_of_iff (f x = 1) f.mem_mker
+
+@[to_additive]
+lemma comap_mker (g : N →* P) (f : M →* N) : g.mker.comap f = (g.comp f).mker := rfl
+
+@[simp, to_additive] lemma comap_bot' (f : M →* N) :
+  (⊥ : submonoid N).comap f = f.mker := rfl
+
+@[to_additive] lemma range_restrict_mker  (f : M →* N) : mker (mrange_restrict f) = mker f :=
+begin
+  ext,
+  change (⟨f x, _⟩ : mrange f) = ⟨1, _⟩ ↔ f x = 1,
+  simp only [],
+end
+
+@[simp, to_additive]
+lemma mker_one : (1 : M →* N).mker = ⊤ :=
+by { ext, simp [mem_mker] }
+
+-- TODO: Is this true?
+-- @[to_additive] lemma mker_eq_bot_iff (f : M →* N) : f.mker = ⊥ ↔ function.injective f :=
+-- begin
+--   split,
+--   { intros h x y hxy,
+--     rwa [←mul_inv_eq_one, ←map_inv, ←map_mul, ←mem_ker, h, mem_bot, mul_inv_eq_one] at hxy },
+--   { exact λ h, le_bot_iff.mp (λ x hx, h (hx.trans f.map_one.symm)) },
+-- end
+
+@[to_additive]
+-- TODO: check naming
+lemma prod_map_comap_prod' {M' : Type*} {N' : Type*} [mul_one_class M'] [mul_one_class N']
+  (f : M →* N) (g : M' →* N') (S : submonoid N) (S' : submonoid N') :
+  (S.prod S').comap (prod_map f g) = (S.comap f).prod (S'.comap g) :=
+set_like.coe_injective $ set.preimage_prod_map_prod f g _ _
+
+@[to_additive]
+lemma ker_prod_map' {M' : Type*} {N' : Type*} [mul_one_class M'] [mul_one_class N'] (f : M →* N) (g : M' →* N') :
+  (prod_map f g).mker = f.mker.prod g.mker :=
+by rw [←comap_bot', ←comap_bot', ←comap_bot', ←prod_map_comap_prod', bot_prod_bot]
+
 end monoid_hom
 
 namespace submonoid

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -674,7 +674,7 @@ lemma comap_mker (g : N →* P) (f : M →* N) : g.mker.comap f = (g.comp f).mke
 @[simp, to_additive] lemma comap_bot' (f : M →* N) :
   (⊥ : submonoid N).comap f = f.mker := rfl
 
-@[to_additive] lemma range_restrict_mker  (f : M →* N) : mker (mrange_restrict f) = mker f :=
+@[to_additive] lemma range_restrict_mker (f : M →* N) : mker (mrange_restrict f) = mker f :=
 begin
   ext,
   change (⟨f x, _⟩ : mrange f) = ⟨1, _⟩ ↔ f x = 1,
@@ -685,17 +685,7 @@ end
 lemma mker_one : (1 : M →* N).mker = ⊤ :=
 by { ext, simp [mem_mker] }
 
--- TODO: Is this true?
--- @[to_additive] lemma mker_eq_bot_iff (f : M →* N) : f.mker = ⊥ ↔ function.injective f :=
--- begin
---   split,
---   { intros h x y hxy,
---     rwa [←mul_inv_eq_one, ←map_inv, ←map_mul, ←mem_ker, h, mem_bot, mul_inv_eq_one] at hxy },
---   { exact λ h, le_bot_iff.mp (λ x hx, h (hx.trans f.map_one.symm)) },
--- end
-
 @[to_additive]
--- TODO: check naming
 lemma prod_map_comap_prod' {M' : Type*} {N' : Type*} [mul_one_class M'] [mul_one_class N']
   (f : M →* N) (g : M' →* N') (S : submonoid N) (S' : submonoid N') :
   (S.prod S').comap (prod_map f g) = (S.comap f).prod (S'.comap g) :=

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -651,10 +651,10 @@ lemma coe_mrange_restrict {N} [mul_one_class N] (f : M →* N) (x : M) :
   (f.mrange_restrict x : N) = f x :=
 rfl
 
-/-- The multiplicative kernel of a monoid homomorphism is the submonoid of elements `x : G` such that
-`f x = 1` -/
-@[to_additive "The additive kernel of an `add_monoid` homomorphism is the `add_submonoid` of elements
-such that `f x = 0`"]
+/-- The multiplicative kernel of a monoid homomorphism is the submonoid of elements `x : G` such
+that `f x = 1` -/
+@[to_additive "The additive kernel of an `add_monoid` homomorphism is the `add_submonoid` of
+elements such that `f x = 0`"]
 def mker (f : M →* N) : submonoid M := (⊥ : submonoid N).comap f
 
 @[to_additive]
@@ -702,8 +702,8 @@ lemma prod_map_comap_prod' {M' : Type*} {N' : Type*} [mul_one_class M'] [mul_one
 set_like.coe_injective $ set.preimage_prod_map_prod f g _ _
 
 @[to_additive]
-lemma ker_prod_map' {M' : Type*} {N' : Type*} [mul_one_class M'] [mul_one_class N'] (f : M →* N) (g : M' →* N') :
-  (prod_map f g).mker = f.mker.prod g.mker :=
+lemma ker_prod_map' {M' : Type*} {N' : Type*} [mul_one_class M'] [mul_one_class N'] (f : M →* N)
+  (g : M' →* N') : (prod_map f g).mker = f.mker.prod g.mker :=
 by rw [←comap_bot', ←comap_bot', ←comap_bot', ←prod_map_comap_prod', bot_prod_bot]
 
 end monoid_hom


### PR DESCRIPTION
Add `monoid_hom.mker` for `f : M ->* N`, where `M` and `N` are `mul_one_class`es, and `monoid_hom.ker` is now defined for `f : G ->* H`, where `H` is a `mul_one_class`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
