### PR TITLE
[Merged by Bors] - feat(algebra/opposites): {add,mul,ring}_equiv.op

### DIFF
--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -434,13 +434,13 @@ def mul_equiv.op {α β} [has_mul α] [has_mul β] :
   (α ≃* β) ≃ (αᵒᵖ ≃* βᵒᵖ) :=
 { to_fun    := λ f, { to_fun   := op ∘ f ∘ unop,
                       inv_fun  := op ∘ f.symm ∘ unop,
-                      left_inv := λ _, by simp,
-                      right_inv := λ _, by simp,
+                      left_inv := λ x, unop_injective (f.symm_apply_apply x.unop),
+                      right_inv := λ x, unop_injective (f.apply_symm_apply x.unop),
                       map_mul' := λ x y, unop_injective (f.map_mul y.unop x.unop) },
   inv_fun   := λ f, { to_fun   := unop ∘ f ∘ op,
                       inv_fun  := unop ∘ f.symm ∘ op,
-                      left_inv := λ _, by simp,
-                      right_inv := λ _, by simp,
+                      left_inv := λ x, op_injective (f.symm_apply_apply (op x)),
+                      right_inv := λ x, op_injective (f.apply_symm_apply (op x)),
                       map_mul' := λ x y, congr_arg unop (f.map_mul (op y) (op x)) },
   left_inv  := λ f, by { ext, refl },
   right_inv := λ f, by { ext, refl } }

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -414,3 +414,37 @@ def ring_hom.op {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
 /-- The 'unopposite' of a ring hom `αᵒᵖ →+* βᵒᵖ`. Inverse to `ring_hom.op`. -/
 @[simp] def ring_hom.unop {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
   (αᵒᵖ →+* βᵒᵖ) ≃ (α →+* β) := ring_hom.op.symm
+
+/-- A iso `α ≃+ β` can equivalently be viewed as an iso `αᵒᵖ ≃+ βᵒᵖ`. -/
+@[simps]
+def add_equiv.op {α β} [has_add α] [has_add β] :
+  (α ≃+ β) ≃ (αᵒᵖ ≃+ βᵒᵖ) :=
+{ to_fun    := λ f, op_add_equiv.symm.trans (f.trans op_add_equiv),
+  inv_fun   := λ f, op_add_equiv.trans (f.trans op_add_equiv.symm),
+  left_inv  := λ f, by { ext, refl },
+  right_inv := λ f, by { ext, refl } }
+
+/-- The 'unopposite' of an iso `αᵒᵖ ≃+ βᵒᵖ`. Inverse to `add_equiv.op`. -/
+@[simp] def add_equiv.unop {α β} [has_add α] [has_add β] :
+  (αᵒᵖ ≃+ βᵒᵖ) ≃ (α ≃+ β) := add_equiv.op.symm
+
+/-- A iso `α ≃* β` can equivalently be viewed as an iso `αᵒᵖ ≃+ βᵒᵖ`. -/
+@[simps]
+def mul_equiv.op {α β} [has_mul α] [has_mul β] :
+  (α ≃* β) ≃ (αᵒᵖ ≃* βᵒᵖ) :=
+{ to_fun    := λ f, { to_fun   := op ∘ f ∘ unop,
+                      inv_fun  := op ∘ f.symm ∘ unop,
+                      left_inv := λ _, by simp,
+                      right_inv := λ _, by simp,
+                      map_mul' := λ x y, unop_injective (f.map_mul y.unop x.unop) },
+  inv_fun   := λ f, { to_fun   := unop ∘ f ∘ op,
+                      inv_fun  := unop ∘ f.symm ∘ op,
+                      left_inv := λ _, by simp,
+                      right_inv := λ _, by simp,
+                      map_mul' := λ x y, congr_arg unop (f.map_mul (op y) (op x)) },
+  left_inv  := λ f, by { ext, refl },
+  right_inv := λ f, by { ext, refl } }
+
+/-- The 'unopposite' of an iso `αᵒᵖ ≃* βᵒᵖ`. Inverse to `mul_equiv.op`. -/
+@[simp] def mul_equiv.unop {α β} [has_mul α] [has_mul β] :
+  (αᵒᵖ ≃* βᵒᵖ) ≃ (α ≃* β) := mul_equiv.op.symm

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -178,7 +178,7 @@ open opposite
 
 /-- A ring iso `α ≃+* β` can equivalently be viewed as a ring iso `αᵒᵖ ≃+* βᵒᵖ`. -/
 @[simps]
-def ring_equiv.op {α β} [has_add α] [has_mul α] [has_add β] [has_mul β] :
+protected def op {α β} [has_add α] [has_mul α] [has_add β] [has_mul β] :
   (α ≃+* β) ≃ (αᵒᵖ ≃+* βᵒᵖ) :=
 { to_fun    := λ f, { ..f.to_add_equiv.op, ..f.to_mul_equiv.op},
   inv_fun   := λ f, { ..(add_equiv.op.symm f.to_add_equiv), ..(mul_equiv.op.symm f.to_mul_equiv) },
@@ -186,7 +186,7 @@ def ring_equiv.op {α β} [has_add α] [has_mul α] [has_add β] [has_mul β] :
   right_inv := λ f, by { ext, refl } }
 
 /-- The 'unopposite' of a ring iso `αᵒᵖ ≃+* βᵒᵖ`. Inverse to `ring_equiv.op`. -/
-@[simp] def ring_equiv.unop {α β} [has_add α] [has_mul α] [has_add β] [has_mul β] :
+@[simp] protected def unop {α β} [has_add α] [has_mul α] [has_add β] [has_mul β] :
   (αᵒᵖ ≃+* βᵒᵖ) ≃ (α ≃+* β) := ring_equiv.op.symm
 
 section comm_semiring

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -173,8 +173,23 @@ e.to_equiv.image_eq_preimage s
 
 end basic
 
-section comm_semiring
+section opposite
 open opposite
+
+/-- A ring iso `α ≃+* β` can equivalently be viewed as a ring iso `αᵒᵖ ≃+* βᵒᵖ`. -/
+@[simps]
+def ring_equiv.op {α β} [has_add α] [has_mul α] [has_add β] [has_mul β] :
+  (α ≃+* β) ≃ (αᵒᵖ ≃+* βᵒᵖ) :=
+{ to_fun    := λ f, { ..f.to_add_equiv.op, ..f.to_mul_equiv.op},
+  inv_fun   := λ f, { ..(add_equiv.op.symm f.to_add_equiv), ..(mul_equiv.op.symm f.to_mul_equiv) },
+  left_inv  := λ f, by { ext, refl },
+  right_inv := λ f, by { ext, refl } }
+
+/-- The 'unopposite' of a ring iso `αᵒᵖ ≃+* βᵒᵖ`. Inverse to `ring_equiv.op`. -/
+@[simp] def ring_equiv.unop {α β} [has_add α] [has_mul α] [has_add β] [has_mul β] :
+  (αᵒᵖ ≃+* βᵒᵖ) ≃ (α ≃+* β) := ring_equiv.op.symm
+
+section comm_semiring
 
 variables (R) [comm_semiring R]
 
@@ -191,6 +206,8 @@ lemma to_opposite_apply (r : R) : to_opposite R r = op r := rfl
 lemma to_opposite_symm_apply (r : Rᵒᵖ) : (to_opposite R).symm r = unop r := rfl
 
 end comm_semiring
+
+end opposite
 
 section non_unital_semiring
 


### PR DESCRIPTION
We had the equivalences of homs. Now we have equivalences of isos.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
