### PR TITLE
[Merged by Bors] - chore(order/basic): rename monotone_of_monotone_nat and strict_mono.nat

### DIFF
--- a/archive/100-theorems-list/82_cubing_a_cube.lean
+++ b/archive/100-theorems-list/82_cubing_a_cube.lean
@@ -497,7 +497,7 @@ def decreasing_sequence (k : ℕ) : order_dual ℝ :=
 (cs (sequence_of_cubes h k).1).w
 
 lemma strict_mono_sequence_of_cubes : strict_mono $ decreasing_sequence h :=
-strict_mono.nat $
+strict_mono_nat_of_lt_succ $
 begin
   intro k, let v := (sequence_of_cubes h k).2, dsimp only [decreasing_sequence, sequence_of_cubes],
   apply w_lt_w h v (mi_mem_bcubes : mi h v ∈ _),

--- a/archive/imo/imo1977_q6.lean
+++ b/archive/imo/imo1977_q6.lean
@@ -28,7 +28,7 @@ begin
          ... < f n           : nat.sub_add_cancel
         (le_trans (nat.succ_le_succ (nat.zero_le _)) hk) ▸ h _ } },
   have hf : ∀ n, n ≤ f n := λ n, h' n n rfl.le,
-  have hf_mono : strict_mono f := strict_mono.nat (λ _, lt_of_le_of_lt (hf _) (h _)),
+  have hf_mono : strict_mono f := strict_mono_nat_of_lt_succ (λ _, lt_of_le_of_lt (hf _) (h _)),
   intro,
   exact nat.eq_of_le_of_lt_succ (hf _) (hf_mono.lt_iff_lt.mp (h _))
 end

--- a/src/algebra/group_power/order.lean
+++ b/src/algebra/group_power/order.lean
@@ -142,7 +142,7 @@ theorem one_le_pow_of_one_le {a : R} (H : 1 ≤ a) : ∀ (n : ℕ), 1 ≤ a ^ n
     zero_le_one (le_trans zero_le_one H) }
 
 lemma pow_mono {a : R} (h : 1 ≤ a) : monotone (λ n : ℕ, a ^ n) :=
-monotone_of_monotone_nat $ λ n,
+monotone_nat_of_le_succ $ λ n,
   by { rw pow_succ, exact le_mul_of_one_le_left (pow_nonneg (zero_le_one.trans h) _) h }
 
 theorem pow_le_pow {a : R} {n m : ℕ} (ha : 1 ≤ a) (h : n ≤ m) : a ^ n ≤ a ^ m :=
@@ -150,7 +150,7 @@ pow_mono ha h
 
 lemma strict_mono_pow {a : R} (h : 1 < a) : strict_mono (λ n : ℕ, a ^ n) :=
 have 0 < a := zero_le_one.trans_lt h,
-strict_mono.nat $ λ n, by simpa only [one_mul, pow_succ]
+strict_mono_nat_of_lt_succ $ λ n, by simpa only [one_mul, pow_succ]
   using mul_lt_mul h (le_refl (a ^ n)) (pow_pos this _) this.le
 
 lemma pow_lt_pow {a : R} {n m : ℕ} (h : 1 < a) (h2 : n < m) : a ^ n < a ^ m :=

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -678,7 +678,7 @@ begin
     rintros ⟨b, hb⟩ ⟨c, hc⟩ hbc,
     exact subtype.ext (mul_left_cancel (subtype.ext_iff.mp hbc)) },
   have mono : monotone (λ n, fintype.card ↥(S ^ n) : ℕ → ℕ) :=
-  monotone_of_monotone_nat (λ n, key a _ _ (λ b hb, set.mul_mem_mul ha hb)),
+  monotone_nat_of_le_succ (λ n, key a _ _ (λ b hb, set.mul_mem_mul ha hb)),
   convert card_pow_eq_card_pow_card_univ_aux mono (λ n, set_fintype_card_le_univ (S ^ n))
     (λ n h, le_antisymm (mono (n + 1).le_succ) (key a⁻¹ _ _ _)),
   { simp only [finset.filter_congr_decidable, fintype.card_of_finset] },

--- a/src/data/equiv/encodable/basic.lean
+++ b/src/data/equiv/encodable/basic.lean
@@ -447,7 +447,7 @@ end
 variables [preorder β] {f : α → β} (hf : directed (≤) f)
 
 lemma sequence_mono : monotone (f ∘ (hf.sequence f)) :=
-monotone_of_monotone_nat $ hf.sequence_mono_nat
+monotone_nat_of_le_succ $ hf.sequence_mono_nat
 
 lemma le_sequence (a : α) : f a ≤ f (hf.sequence f (encode a + 1)) :=
 hf.rel_sequence a

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -2409,7 +2409,7 @@ end
 lemma monotone_sum_take [canonically_ordered_add_monoid α] (L : list α) :
   monotone (λ i, (L.take i).sum) :=
 begin
-  apply monotone_of_monotone_nat (λ n, _),
+  apply monotone_nat_of_le_succ (λ n, _),
   by_cases h : n < L.length,
   { rw sum_take_succ _ _ h,
     exact le_self_add },

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -420,7 +420,7 @@ begin
 end
 
 lemma le_digits_len_le (b n m : ℕ) (h : n ≤ m) : (digits b n).length ≤ (digits b m).length :=
-monotone_of_monotone_nat (digits_len_le_digits_len_succ b) h
+monotone_nat_of_le_succ (digits_len_le_digits_len_succ b) h
 
 lemma pow_length_le_mul_of_digits {b : ℕ} {l : list ℕ} (hl : l ≠ []) (hl2 : l.last hl ≠ 0):
   (b + 2) ^ l.length ≤ (b + 2) * of_digits (b+2) l :=

--- a/src/data/nat/fib.lean
+++ b/src/data/nat/fib.lean
@@ -81,11 +81,11 @@ end
 lemma fib_le_fib_succ {n : ℕ} : fib n ≤ fib (n + 1) := by { cases n; simp [fib_succ_succ] }
 
 @[mono] lemma fib_mono : monotone fib :=
-monotone_of_monotone_nat $ λ _, fib_le_fib_succ
+monotone_nat_of_le_succ $ λ _, fib_le_fib_succ
 
 /-- `fib (n + 2)` is strictly monotone. -/
 lemma fib_add_two_strict_mono : strict_mono (λ n, fib (n + 2)) :=
-strict_mono.nat $ λ n, lt_add_of_pos_left _ $ fib_pos succ_pos'
+strict_mono_nat_of_lt_succ $ λ n, lt_add_of_pos_left _ $ fib_pos succ_pos'
 
 lemma le_fib_self {n : ℕ} (five_le_n : 5 ≤ n) : n ≤ fib n :=
 begin

--- a/src/data/nat/log.lean
+++ b/src/data/nat/log.lean
@@ -106,6 +106,6 @@ lemma log_le_log_succ {b n : ℕ} : log b n ≤ log b n.succ :=
 log_le_log_of_le $ le_succ n
 
 lemma log_mono {b : ℕ} : monotone (λ n : ℕ, log b n) :=
-monotone_of_monotone_nat $ λ n, log_le_log_succ
+monotone_nat_of_le_succ $ λ n, log_le_log_succ
 
 end nat

--- a/src/data/nat/pow.lean
+++ b/src/data/nat/pow.lean
@@ -97,7 +97,7 @@ end
 
 end nat
 
-lemma strict_mono.nat_pow {n : ℕ} (hn : 1 ≤ n) {f : ℕ → ℕ} (hf : strict_mono f) :
+lemma strict_mono_nat_of_lt_succ_pow {n : ℕ} (hn : 1 ≤ n) {f : ℕ → ℕ} (hf : strict_mono f) :
   strict_mono (λ m, (f m) ^ n) :=
 (nat.pow_left_strict_mono hn).comp hf
 

--- a/src/data/nat/pow.lean
+++ b/src/data/nat/pow.lean
@@ -97,7 +97,7 @@ end
 
 end nat
 
-lemma strict_mono_nat_of_lt_succ_pow {n : ℕ} (hn : 1 ≤ n) {f : ℕ → ℕ} (hf : strict_mono f) :
+lemma strict_mono.nat_pow {n : ℕ} (hn : 1 ≤ n) {f : ℕ → ℕ} (hf : strict_mono f) :
   strict_mono (λ m, (f m) ^ n) :=
 (nat.pow_left_strict_mono hn).comp hf
 

--- a/src/linear_algebra/prod.lean
+++ b/src/linear_algebra/prod.lean
@@ -549,7 +549,7 @@ Give an injective map `f : M × N →ₗ[R] M` we can find a nested sequence of 
 all isomorphic to `M`.
 -/
 def tunnel (f : M × N →ₗ[R] M) (i : injective f) : ℕ →ₘ order_dual (submodule R M) :=
-⟨λ n, (tunnel' f i n).1, monotone_of_monotone_nat (λ n, begin
+⟨λ n, (tunnel' f i n).1, monotone_nat_of_le_succ (λ n, begin
     dsimp [tunnel', tunnel_aux],
     rw [submodule.map_comp, submodule.map_comp],
     apply submodule.map_subtype_le,

--- a/src/measure_theory/integration.lean
+++ b/src/measure_theory/integration.lean
@@ -1490,7 +1490,7 @@ calc
   ... = ⨆n, (∫⁻ a, g n a ∂μ) :
   lintegral_supr
     (assume n, measurable_const.piecewise hs.2.1 (hf n))
-    (monotone_of_monotone_nat $ assume n a, classical.by_cases
+    (monotone_nat_of_le_succ $ assume n a, classical.by_cases
       (assume h : a ∈ s, by simp [g, if_pos h])
       (assume h : a ∉ s,
       begin

--- a/src/measure_theory/outer_measure.lean
+++ b/src/measure_theory/outer_measure.lean
@@ -125,7 +125,7 @@ begin
   refine tendsto_nhds_bot_mono' (ennreal.tendsto_sum_nat_add _ h0) (λ n, _),
   refine (m.mono _).trans (m.Union _),
   /- Current goal: `(⋃ k, s k) \ s n ⊆ ⋃ k, s (k + n + 1) \ s (k + n)` -/
-  have h' : monotone s := @monotone_of_monotone_nat (set α) _ _ h_mono,
+  have h' : monotone s := @monotone_nat_of_le_succ (set α) _ _ h_mono,
   simp only [diff_subset_iff, Union_subset_iff],
   intros i x hx,
   rcases nat.find_x ⟨i, hx⟩ with ⟨j, hj, hlt⟩, clear hx i,

--- a/src/measure_theory/regular.lean
+++ b/src/measure_theory/regular.lean
@@ -568,7 +568,7 @@ instance of_sigma_compact_space_of_locally_finite_measure {X : Type*}
       exact le_supr (λ K : {K // is_compact K ∧ K ⊆ U}, μ K)
         ⟨B n ∩ F, is_compact.inter_right (B.is_compact n) F_closed,
           subset.trans (inter_subset_right _ _) FU⟩ },
-    { apply (monotone_of_monotone_nat (λ n, _)).directed_le,
+    { apply (monotone_nat_of_le_succ (λ n, _)).directed_le,
       exact inter_subset_inter_left _ (B.subset_succ n) },
   end,
   outer_regular :=

--- a/src/number_theory/padics/ring_homs.lean
+++ b/src/number_theory/padics/ring_homs.lean
@@ -320,7 +320,7 @@ end
 
 lemma appr_mono (x : ℤ_[p]) : monotone x.appr :=
 begin
-  apply monotone_of_monotone_nat,
+  apply monotone_nat_of_le_succ,
   intro n,
   dsimp [appr],
   split_ifs, { refl, },

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -36,8 +36,8 @@ import data.prod
 
 - `monotone_nat_of_le_succ`: If `f : ℕ → α` and `f n ≤ f (n + 1)` for all `n`, then `f` is
   monotone.
-- `strict_mono_nat_of_lt_succ`: If `f : ℕ → α` and `f n < f (n + 1)` for all `n`, then `f` is strictly
-  monotone.
+- `strict_mono_nat_of_lt_succ`: If `f : ℕ → α` and `f n < f (n + 1)` for all `n`, then `f` is
+  strictly monotone.
 
 ## TODO
 

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -34,9 +34,9 @@ import data.prod
 
 ## Main theorems
 
-- `monotone_of_monotone_nat`: If `f : ℕ → α` and `f n ≤ f (n + 1)` for all `n`, then `f` is
+- `monotone_nat_of_le_succ`: If `f : ℕ → α` and `f n ≤ f (n + 1)` for all `n`, then `f` is
   monotone.
-- `strict_mono.nat`: If `f : ℕ → α` and `f n < f (n + 1)` for all `n`, then `f` is strictly
+- `strict_mono_nat_of_lt_succ`: If `f : ℕ → α` and `f n < f (n + 1)` for all `n`, then `f` is strictly
   monotone.
 
 ## TODO
@@ -128,7 +128,7 @@ protected theorem monotone.comp {g : β → γ} {f : α → β} (m_g : monotone 
 protected theorem monotone.iterate {f : α → α} (hf : monotone f) (n : ℕ) : monotone (f^[n]) :=
 nat.rec_on n monotone_id (λ n ihn, ihn.comp hf)
 
-lemma monotone_of_monotone_nat {f : ℕ → α} (hf : ∀ n, f n ≤ f (n + 1)) :
+lemma monotone_nat_of_le_succ {f : ℕ → α} (hf : ∀ n, f n ≤ f (n + 1)) :
   monotone f | n m h :=
 begin
   induction h,
@@ -361,15 +361,16 @@ H.le_iff_le.mp (h_bot (f x))
 
 end
 
-protected lemma nat {β} [preorder β] {f : ℕ → β} (h : ∀ n, f n < f (n + 1)) : strict_mono f :=
-by { intros n m hnm, induction hnm with m' hnm' ih, apply h, exact ih.trans (h _) }
-
 -- `preorder α` isn't strong enough: if the preorder on α is an equivalence relation,
 -- then `strict_mono f` is vacuously true.
 lemma monotone [partial_order α] [preorder β] {f : α → β} (H : strict_mono f) : monotone f :=
 λ a b h, (lt_or_eq_of_le h).rec (le_of_lt ∘ (@H _ _)) (by rintro rfl; refl)
 
 end strict_mono
+
+lemma strict_mono_nat_of_lt_succ {β} [preorder β] {f : ℕ → β} (h : ∀ n, f n < f (n + 1)) :
+  strict_mono f :=
+by { intros n m hnm, induction hnm with m' hnm' ih, apply h, exact ih.trans (h _) }
 
 section
 open function

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -442,7 +442,7 @@ lemma csupr_mem_Inter_Icc_of_mono_decr_Icc_nat
   {f g : ℕ → α} (h : ∀ n, Icc (f (n + 1)) (g (n + 1)) ⊆ Icc (f n) (g n)) (h' : ∀ n, f n ≤ g n) :
   (⨆ n, f n) ∈ ⋂ n, Icc (f n) (g n) :=
 csupr_mem_Inter_Icc_of_mono_decr_Icc
-  (@monotone_of_monotone_nat (order_dual $ set α) _ (λ n, Icc (f n) (g n)) h) h'
+  (@monotone_nat_of_le_succ (order_dual $ set α) _ (λ n, Icc (f n) (g n)) h) h'
 
 end conditionally_complete_lattice
 

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -238,7 +238,7 @@ lemma extraction_of_frequently_at_top' {P : ℕ → Prop} (h : ∀ N, ∃ n > N,
 begin
   choose u hu using h,
   cases forall_and_distrib.mp hu with hu hu',
-  exact ⟨u ∘ (nat.rec 0 (λ n v, u v)), strict_mono.nat (λ n, hu _), λ n, hu' _⟩,
+  exact ⟨u ∘ (nat.rec 0 (λ n v, u v)), strict_mono_nat_of_lt_succ (λ n, hu _), λ n, hu' _⟩,
 end
 
 lemma extraction_of_frequently_at_top {P : ℕ → Prop} (h : ∃ᶠ n in at_top, P n) :
@@ -259,7 +259,7 @@ begin
   choose u hu hu' using h,
   use (λ n, nat.rec_on n (u 0 0) (λ n v, u (n+1) v) : ℕ → ℕ),
   split,
-  { apply strict_mono.nat,
+  { apply strict_mono_nat_of_lt_succ,
     intro n,
     apply hu },
   { intros n,

--- a/src/order/filter/bases.lean
+++ b/src/order/filter/bases.lean
@@ -760,7 +760,7 @@ begin
   have x_mono : ∀ n : ℕ, s (x n.succ) ⊆ s (x n) :=
     λ n, subset.trans (hs.set_index_subset _) (inter_subset_right _ _),
   replace x_mono : ∀ ⦃i j⦄, i ≤ j → s (x j) ≤ s (x i),
-  { refine @monotone_of_monotone_nat (order_dual $ set α) _ _ _,
+  { refine @monotone_nat_of_le_succ (order_dual $ set α) _ _ _,
     exact x_mono },
   have x_subset : ∀ i, s (x i) ⊆ x' i,
   { rintro (_|i),

--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -387,7 +387,7 @@ noncomputable def sequence_of_cofinals : ℕ → P
            end
 
 lemma sequence_of_cofinals.monotone : monotone (sequence_of_cofinals p 𝒟) :=
-by { apply monotone_of_monotone_nat, intros n, dunfold sequence_of_cofinals,
+by { apply monotone_nat_of_le_succ, intros n, dunfold sequence_of_cofinals,
   cases encodable.decode ι n, { refl }, { apply cofinal.le_above }, }
 
 lemma sequence_of_cofinals.encode_mem (i : ι) :

--- a/src/order/partial_sups.lean
+++ b/src/order/partial_sups.lean
@@ -39,7 +39,7 @@ variables [semilattice_sup α]
 /-- The monotone sequence whose value at `n` is the supremum of the `f m` where `m ≤ n`. -/
 def partial_sups (f : ℕ → α) : ℕ →ₘ α :=
 ⟨@nat.rec (λ _, α) (f 0) (λ (n : ℕ) (a : α), a ⊔ f (n + 1)),
-  monotone_of_monotone_nat (λ n, le_sup_left)⟩
+  monotone_nat_of_le_succ (λ n, le_sup_left)⟩
 
 @[simp] lemma partial_sups_zero (f : ℕ → α) : partial_sups f 0 = f 0 := rfl
 @[simp] lemma partial_sups_succ (f : ℕ → α) (n : ℕ) :

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -2164,7 +2164,7 @@ begin
     induction n with n IH,
     { exact (hf 0 l hl).2.2.1 },
     { exact (hf n.succ _ IH).2.2.1 } },
-  have S : strict_mono u := strict_mono.nat (λ n, (hf n.succ _ (I n)).2.1),
+  have S : strict_mono u := strict_mono_nat_of_lt_succ (λ n, (hf n.succ _ (I n)).2.1),
   refine ⟨u, S, I, hs.tendsto_right_iff.2 (λ n _, _), (λ n, _)⟩,
   { simp only [ge_iff_le, eventually_at_top],
     refine ⟨n, λ p hp, _⟩,

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -251,7 +251,7 @@ lemma is_compact.nonempty_Inter_of_sequence_nonempty_compact_closed
   (Z : ℕ → set α) (hZd : ∀ i, Z (i+1) ⊆ Z i)
   (hZn : ∀ i, (Z i).nonempty) (hZ0 : is_compact (Z 0)) (hZcl : ∀ i, is_closed (Z i)) :
   (⋂ i, Z i).nonempty :=
-have Zmono : _, from @monotone_of_monotone_nat (order_dual _) _ Z hZd,
+have Zmono : _, from @monotone_nat_of_le_succ (order_dual _) _ Z hZd,
 have hZd : directed (⊇) Z, from directed_of_sup Zmono,
 have ∀ i, Z i ⊆ Z 0, from assume i, Zmono $ zero_le i,
 have hZc : ∀ i, is_compact (Z i), from assume i, compact_of_is_closed_subset hZ0 (hZcl i) (this i),
@@ -1051,7 +1051,7 @@ lemma subset_succ (n : ℕ) : K n ⊆ K (n + 1) :=
 subset.trans (K.subset_interior_succ n) interior_subset
 
 @[mono] protected lemma subset ⦃m n : ℕ⦄ (h : m ≤ n) : K m ⊆ K n :=
-show K m ≤ K n, from monotone_of_monotone_nat K.subset_succ h
+show K m ≤ K n, from monotone_nat_of_le_succ K.subset_succ h
 
 lemma subset_interior ⦃m n : ℕ⦄ (h : m < n) : K m ⊆ interior (K n) :=
 subset.trans (K.subset_interior_succ m) $ interior_mono $ K.subset h

--- a/src/topology/urysohns_lemma.lean
+++ b/src/topology/urysohns_lemma.lean
@@ -196,7 +196,7 @@ begin
 end
 
 lemma approx_mono (c : CU X) (x : X) : monotone (λ n, c.approx n x) :=
-monotone_of_monotone_nat $ λ n, c.approx_le_succ n x
+monotone_nat_of_le_succ $ λ n, c.approx_le_succ n x
 
 /-- A continuous function `f : X → ℝ` such that
 


### PR DESCRIPTION
For more coherence (and easier discoverability), rename `monotone_of_monotone_nat` to `monotone_nat_of_le_succ`, and `strict_mono.nat` to `strict_mono_nat_of_lt_succ`.
