### PR TITLE
[Merged by Bors] - refactor(algebra/regular): split out `is_regular`

### DIFF
--- a/src/algebra/regular/basic.lean
+++ b/src/algebra/regular/basic.lean
@@ -3,9 +3,9 @@ Copyright (c) 2021 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
-import algebra.group
-import algebra.group_power.basic
-import algebra.iterate_hom
+import algebra.group.basic
+import algebra.group_with_zero.basic
+import logic.embedding
 
 /-!
 # Regular elements
@@ -109,48 +109,6 @@ lemma is_regular.and_of_mul_of_mul (ab : is_regular (a * b)) (ba : is_regular (b
 is_regular_mul_and_mul_iff.mp ⟨ab, ba⟩
 
 end semigroup
-
-section monoid
-
-variable [monoid R]
-
-/--  Any power of a left-regular element is left-regular. -/
-lemma is_left_regular.pow (n : ℕ) (rla : is_left_regular a) : is_left_regular (a ^ n) :=
-by simp only [is_left_regular, ← mul_left_iterate, rla.iterate n]
-
-/--  Any power of a right-regular element is right-regular. -/
-lemma is_right_regular.pow (n : ℕ) (rra : is_right_regular a) : is_right_regular (a ^ n) :=
-by { rw [is_right_regular, ← mul_right_iterate], exact rra.iterate n }
-
-/--  Any power of a regular element is regular. -/
-lemma is_regular.pow (n : ℕ) (ra : is_regular a) : is_regular (a ^ n) :=
-⟨is_left_regular.pow n ra.left, is_right_regular.pow n ra.right⟩
-
-/--  An element `a` is left-regular if and only if a positive power of `a` is left-regular. -/
-lemma is_left_regular.pow_iff {n : ℕ} (n0 : 0 < n) :
-  is_left_regular (a ^ n) ↔ is_left_regular a :=
-begin
-  refine ⟨_, is_left_regular.pow n⟩,
-  rw [← nat.succ_pred_eq_of_pos n0, pow_succ'],
-  exact is_left_regular.of_mul,
-end
-
-/--  An element `a` is right-regular if and only if a positive power of `a` is right-regular. -/
-lemma is_right_regular.pow_iff {n : ℕ} (n0 : 0 < n) :
-  is_right_regular (a ^ n) ↔ is_right_regular a :=
-begin
-  refine ⟨_, is_right_regular.pow n⟩,
-  rw [← nat.succ_pred_eq_of_pos n0, pow_succ],
-  exact is_right_regular.of_mul,
-end
-
-/--  An element `a` is regular if and only if a positive power of `a` is regular. -/
-lemma is_regular.pow_iff {n : ℕ} (n0 : 0 < n) :
-  is_regular (a ^ n) ↔ is_regular a :=
-⟨λ h, ⟨(is_left_regular.pow_iff n0).mp h.left, (is_right_regular.pow_iff n0).mp h.right⟩,
-  λ h, ⟨is_left_regular.pow n h.left, is_right_regular.pow n h.right⟩⟩
-
-end monoid
 
 section mul_zero_class
 

--- a/src/algebra/regular/pow.lean
+++ b/src/algebra/regular/pow.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2021 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+import algebra.group_power.basic
+import algebra.regular.basic
+import algebra.iterate_hom
+
+/-!
+# Regular elements
+
+## Implementation details
+
+Group powers and other definitions import a lot of the algebra hierarchy.
+Lemmas about them are kept separate to be able to provide `is_regular` early in the
+algebra hierarchy.
+
+-/
+
+variables {R : Type*} {a b : R}
+
+section monoid
+
+variable [monoid R]
+
+/--  Any power of a left-regular element is left-regular. -/
+lemma is_left_regular.pow (n : ℕ) (rla : is_left_regular a) : is_left_regular (a ^ n) :=
+by simp only [is_left_regular, ← mul_left_iterate, rla.iterate n]
+
+/--  Any power of a right-regular element is right-regular. -/
+lemma is_right_regular.pow (n : ℕ) (rra : is_right_regular a) : is_right_regular (a ^ n) :=
+by { rw [is_right_regular, ← mul_right_iterate], exact rra.iterate n }
+
+/--  Any power of a regular element is regular. -/
+lemma is_regular.pow (n : ℕ) (ra : is_regular a) : is_regular (a ^ n) :=
+⟨is_left_regular.pow n ra.left, is_right_regular.pow n ra.right⟩
+
+/--  An element `a` is left-regular if and only if a positive power of `a` is left-regular. -/
+lemma is_left_regular.pow_iff {n : ℕ} (n0 : 0 < n) :
+  is_left_regular (a ^ n) ↔ is_left_regular a :=
+begin
+  refine ⟨_, is_left_regular.pow n⟩,
+  rw [← nat.succ_pred_eq_of_pos n0, pow_succ'],
+  exact is_left_regular.of_mul,
+end
+
+/--  An element `a` is right-regular if and only if a positive power of `a` is right-regular. -/
+lemma is_right_regular.pow_iff {n : ℕ} (n0 : 0 < n) :
+  is_right_regular (a ^ n) ↔ is_right_regular a :=
+begin
+  refine ⟨_, is_right_regular.pow n⟩,
+  rw [← nat.succ_pred_eq_of_pos n0, pow_succ],
+  exact is_right_regular.of_mul,
+end
+
+/--  An element `a` is regular if and only if a positive power of `a` is regular. -/
+lemma is_regular.pow_iff {n : ℕ} (n0 : 0 < n) :
+  is_regular (a ^ n) ↔ is_regular a :=
+⟨λ h, ⟨(is_left_regular.pow_iff n0).mp h.left, (is_right_regular.pow_iff n0).mp h.right⟩,
+  λ h, ⟨is_left_regular.pow n h.left, is_right_regular.pow n h.right⟩⟩
+
+end monoid

--- a/src/algebra/regular/smul.lean
+++ b/src/algebra/regular/smul.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import algebra.smul_with_zero
-import algebra.regular
+import algebra.regular.basic
 /-!
 # Action of regular elements on a module
 

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -5,7 +5,7 @@ Authors: Scott Morrison
 -/
 import algebra.monoid_algebra
 import algebra.char_p.invertible
-import algebra.regular
+import algebra.regular.basic
 import linear_algebra.basis
 
 /-!


### PR DESCRIPTION
One would like to import `is_regular` for rings. However, group powers
are too late in the algebra hierarchy,
so the proofs of powers of regular elements are factored
out to a separate file.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
