### PR TITLE
[Merged by Bors] - chore(algebra/ordered_group): fix/add `order_dual` instances, add lemmas

### DIFF
--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -73,7 +73,7 @@ instance ordered_comm_group.to_covariant_class_left_le (α : Type u) [ordered_co
 instance units.ordered_comm_group [ordered_comm_monoid α] : ordered_comm_group (units α) :=
 { mul_le_mul_left := λ a b h c, (mul_le_mul_left' (h : (a : α) ≤ b) _ :  (c : α) * a ≤ c * b),
   .. units.partial_order,
-  .. (infer_instance : comm_group (units α)) }
+  .. units.comm_group }
 
 @[priority 100, to_additive]    -- see Note [lower instance priority]
 instance ordered_comm_group.to_ordered_cancel_comm_monoid (α : Type u)
@@ -88,6 +88,13 @@ instance ordered_comm_group.has_exists_mul_of_le (α : Type u)
   [ordered_comm_group α] :
   has_exists_mul_of_le α :=
 ⟨λ a b hab, ⟨b * a⁻¹, (mul_inv_cancel_comm_assoc a b).symm⟩⟩
+
+@[to_additive] instance [has_inv α] : has_inv (order_dual α) := ‹has_inv α›
+@[to_additive] instance [group α] : group (order_dual α) := ‹group α›
+@[to_additive] instance [comm_group α] : comm_group (order_dual α) := ‹comm_group α›
+
+@[to_additive] instance [ordered_comm_group α] : ordered_comm_group (order_dual α) :=
+{ .. order_dual.ordered_comm_monoid, .. order_dual.group }
 
 section group
 variables [group α]
@@ -824,11 +831,24 @@ variables [densely_ordered α] {a b c : α}
 lemma le_of_forall_one_lt_le_mul (h : ∀ ε : α, 1 < ε → a ≤ b * ε) : a ≤ b :=
 le_of_forall_le_of_dense $ λ c hc,
 calc a ≤ b * (b⁻¹ * c) : h _ (lt_inv_mul_iff_lt.mpr hc)
-   ... = c            : mul_inv_cancel_left b c
+   ... = c             : mul_inv_cancel_left b c
+
+@[to_additive]
+lemma le_of_forall_lt_one_mul_le (h : ∀ ε < 1, a * ε ≤ b) : a ≤ b :=
+@le_of_forall_one_lt_le_mul (order_dual α) _ _ _ _ _ _ h
+
+@[to_additive]
+lemma le_of_forall_one_lt_div_le (h : ∀ ε : α, 1 < ε → a / ε ≤ b) : a ≤ b :=
+le_of_forall_lt_one_mul_le $ λ ε ε1,
+  by simpa only [div_eq_mul_inv, inv_inv]  using h ε⁻¹ (left.one_lt_inv_iff.2 ε1)
 
 @[to_additive]
 lemma le_iff_forall_one_lt_le_mul : a ≤ b ↔ ∀ ε, 1 < ε → a ≤ b * ε :=
 ⟨λ h ε ε_pos, le_mul_of_le_of_one_le h ε_pos.le, le_of_forall_one_lt_le_mul⟩
+
+@[to_additive]
+lemma le_iff_forall_lt_one_mul_le : a ≤ b ↔ ∀ ε < 1, a * ε ≤ b :=
+@le_iff_forall_one_lt_le_mul (order_dual α) _ _ _ _ _ _
 
 end densely_ordered
 
@@ -857,6 +877,10 @@ commutative group with a linear order in which
 multiplication is monotone. -/
 @[protect_proj, ancestor ordered_comm_group linear_order, to_additive]
 class linear_ordered_comm_group (α : Type u) extends ordered_comm_group α, linear_order α
+
+@[to_additive] instance [linear_ordered_comm_group α] :
+  linear_ordered_comm_group (order_dual α) :=
+{ .. order_dual.ordered_comm_group, .. order_dual.linear_order α }
 
 section linear_ordered_comm_group
 variables [linear_ordered_comm_group α] {a b c : α}
@@ -1237,22 +1261,6 @@ def to_linear_ordered_add_comm_group
   ..@nonneg_add_comm_group.to_ordered_add_comm_group _ s }
 
 end nonneg_add_comm_group
-
-namespace order_dual
-
-instance [ordered_add_comm_group α] : ordered_add_comm_group (order_dual α) :=
-{ add_left_neg := λ a : α, add_left_neg a,
-  sub := λ a b, (a - b : α),
-  ..order_dual.ordered_add_comm_monoid,
-  ..show add_comm_group α, by apply_instance }
-
-instance [linear_ordered_add_comm_group α] :
-  linear_ordered_add_comm_group (order_dual α) :=
-{ add_le_add_left := λ a b h c, by exact add_le_add_left h _,
-  ..order_dual.linear_order α,
-  ..show add_comm_group α, by apply_instance }
-
-end order_dual
 
 namespace prod
 

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -89,9 +89,11 @@ instance ordered_comm_group.has_exists_mul_of_le (α : Type u)
   has_exists_mul_of_le α :=
 ⟨λ a b hab, ⟨b * a⁻¹, (mul_inv_cancel_comm_assoc a b).symm⟩⟩
 
-@[to_additive] instance [has_inv α] : has_inv (order_dual α) := ‹has_inv α›
-@[to_additive] instance [group α] : group (order_dual α) := ‹group α›
-@[to_additive] instance [comm_group α] : comm_group (order_dual α) := ‹comm_group α›
+@[to_additive] instance [h : has_inv α] : has_inv (order_dual α) := h
+@[to_additive] instance [h : has_div α] : has_div (order_dual α) := h
+@[to_additive] instance [h : div_inv_monoid α] : div_inv_monoid (order_dual α) := h
+@[to_additive] instance [h : group α] : group (order_dual α) := h
+@[to_additive] instance [h : comm_group α] : comm_group (order_dual α) := h
 
 @[to_additive] instance [ordered_comm_group α] : ordered_comm_group (order_dual α) :=
 { .. order_dual.ordered_comm_monoid, .. order_dual.group }

--- a/src/algebra/ordered_monoid.lean
+++ b/src/algebra/ordered_monoid.lean
@@ -835,8 +835,11 @@ end linear_ordered_cancel_comm_monoid
 
 namespace order_dual
 
-@[to_additive]
-instance [h : has_mul α] : has_mul (order_dual α) := h
+@[to_additive] instance [h : has_mul α] : has_mul (order_dual α) := h
+@[to_additive] instance [h : has_one α] : has_one (order_dual α) := h
+@[to_additive] instance [h : monoid α] : monoid (order_dual α) := h
+@[to_additive] instance [h : comm_monoid α] : comm_monoid (order_dual α) := h
+@[to_additive] instance [h : cancel_comm_monoid α] : cancel_comm_monoid (order_dual α) := h
 
 @[to_additive]
 instance contravariant_class_mul_le [has_le α] [has_mul α] [c : contravariant_class α α (*) (≤)] :
@@ -884,8 +887,8 @@ instance covariant_class_swap_mul_lt [has_lt α] [has_mul α]
 instance [ordered_comm_monoid α] : ordered_comm_monoid (order_dual α) :=
 { mul_le_mul_left := λ a b h c, mul_le_mul_left' h c,
   lt_of_mul_lt_mul_left := λ a b c, lt_of_mul_lt_mul_left',
-  ..order_dual.partial_order α,
-  ..(infer_instance : comm_monoid α) }
+  .. order_dual.partial_order α,
+  .. order_dual.comm_monoid }
 
 @[to_additive ordered_cancel_add_comm_monoid.to_contravariant_class]
 instance ordered_cancel_comm_monoid.to_contravariant_class [ordered_cancel_comm_monoid α] :
@@ -895,8 +898,7 @@ instance ordered_cancel_comm_monoid.to_contravariant_class [ordered_cancel_comm_
 @[to_additive]
 instance [ordered_cancel_comm_monoid α] : ordered_cancel_comm_monoid (order_dual α) :=
 { le_of_mul_le_mul_left := λ a b c : α, le_of_mul_le_mul_left',
-  mul_left_cancel := @mul_left_cancel α _,
-  ..order_dual.ordered_comm_monoid }
+  .. order_dual.ordered_comm_monoid, .. order_dual.cancel_comm_monoid }
 
 @[to_additive]
 instance [linear_ordered_cancel_comm_monoid α] :
@@ -963,11 +965,5 @@ instance [linear_ordered_add_comm_monoid α] : linear_ordered_comm_monoid (multi
 instance [linear_ordered_comm_monoid α] : linear_ordered_add_comm_monoid (additive α) :=
 { ..additive.linear_order,
   ..additive.ordered_add_comm_monoid }
-
-instance [sub_neg_monoid α] : sub_neg_monoid (order_dual α) :=
-{ ..show sub_neg_monoid α, from infer_instance }
-
-instance [div_inv_monoid α] : div_inv_monoid (order_dual α) :=
-{ ..show div_inv_monoid α, from infer_instance }
 
 end type_tags


### PR DESCRIPTION
* add `order_dual.has_inv`, `order_dual.group`, `order_dual.comm_group`;
* use new instances in `order_dual.ordered_comm_group` and
  `order_dual.linear_ordered_comm_group` (earlier we had only additive
  versions);
* add `le_of_forall_neg_add_le`, `le_of_forall_pos_sub_le`,
  `le_iff_forall_neg_add_le` and their multiplicative versions.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
