### PR TITLE
[Merged by Bors] - feat(algebra): `submodule.restrict_scalars p R` is `S`-isomorphic to `p`

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1534,6 +1534,19 @@ lemma restrict_scalars_top : restrict_scalars R (⊤ : submodule S M) = ⊤ := r
 lemma span_le_restrict_scalars (X : set M) : span R (X : set M) ≤ restrict_scalars R (span S X) :=
 submodule.span_le.mpr submodule.subset_span
 
+/-- Even though `p.restrict_scalars R` has type `submodule R M`, it is still an `S`-module. -/
+instance submodule.restrict_scalars.orig_module (p : submodule S M) : module S (p.restrict_scalars R) :=
+(by apply_instance : module S p)
+
+instance (p : submodule S M) : is_scalar_tower R S (p.restrict_scalars R) :=
+{ smul_assoc := λ r s x, subtype.ext $ smul_assoc r s (x : M) }
+
+/-- Turning `p : submodule S M` into an `R`-submodule gives the same module structure
+as turning it into a type and adding a module structure. -/
+@[simps]
+def restrict_scalars_equiv (p : submodule S M) : p.restrict_scalars R ≃ₗ[S] p :=
+{ map_smul' := λ c x, rfl, .. linear_equiv.refl R p }
+
 end submodule
 
 @[simp]

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1535,7 +1535,8 @@ lemma span_le_restrict_scalars (X : set M) : span R (X : set M) ≤ restrict_sca
 submodule.span_le.mpr submodule.subset_span
 
 /-- Even though `p.restrict_scalars R` has type `submodule R M`, it is still an `S`-module. -/
-instance submodule.restrict_scalars.orig_module (p : submodule S M) : module S (p.restrict_scalars R) :=
+instance submodule.restrict_scalars.orig_module (p : submodule S M) :
+  module S (p.restrict_scalars R) :=
 (by apply_instance : module S p)
 
 instance (p : submodule S M) : is_scalar_tower R S (p.restrict_scalars R) :=

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1535,7 +1535,7 @@ lemma span_le_restrict_scalars (X : set M) : span R (X : set M) ≤ restrict_sca
 submodule.span_le.mpr submodule.subset_span
 
 /-- Even though `p.restrict_scalars R` has type `submodule R M`, it is still an `S`-module. -/
-instance submodule.restrict_scalars.orig_module (p : submodule S M) :
+instance restrict_scalars.orig_module (p : submodule S M) :
   module S (p.restrict_scalars R) :=
 (by apply_instance : module S p)
 

--- a/src/algebra/algebra/tower.lean
+++ b/src/algebra/algebra/tower.lean
@@ -298,18 +298,6 @@ le_antisymm (span_le.2 $ λ x hx, let ⟨p, q, hps, hqt, hpqx⟩ := set.mem_smul
   (λ _ _, add_mem _)
   (λ k x hx, smul_mem_span_smul' hs hx)
 
-/-- Turning `p : submodule S M` into an `R`-submodule gives the same module structure
-as turning it into a type and adding a module structure. -/
-@[simps]
-def restrict_scalars_equiv (p : submodule S A) : p.restrict_scalars R ≃ₗ[R] p :=
--- Everything is automatically defeq except scalar multiplication.
-{ to_fun := λ x, x,
-  inv_fun := λ x, x,
-  map_smul' := λ c ⟨x, hx⟩, subtype.coe_injective $
-    by rw [← is_scalar_tower.algebra_map_smul S c (⟨x, hx⟩ : p), coe_smul, coe_smul,
-           is_scalar_tower.algebra_map_smul] ,
-  .. add_equiv.refl p }
-
 end submodule
 
 end semiring

--- a/src/algebra/algebra/tower.lean
+++ b/src/algebra/algebra/tower.lean
@@ -298,6 +298,18 @@ le_antisymm (span_le.2 $ λ x hx, let ⟨p, q, hps, hqt, hpqx⟩ := set.mem_smul
   (λ _ _, add_mem _)
   (λ k x hx, smul_mem_span_smul' hs hx)
 
+/-- Turning `p : submodule S M` into an `R`-submodule gives the same module structure
+as turning it into a type and adding a module structure. -/
+@[simps]
+def restrict_scalars_equiv (p : submodule S A) : p.restrict_scalars R ≃ₗ[R] p :=
+-- Everything is automatically defeq except scalar multiplication.
+{ to_fun := λ x, x,
+  inv_fun := λ x, x,
+  map_smul' := λ c ⟨x, hx⟩, subtype.coe_injective $
+    by rw [← is_scalar_tower.algebra_map_smul S c (⟨x, hx⟩ : p), coe_smul, coe_smul,
+           is_scalar_tower.algebra_map_smul] ,
+  .. add_equiv.refl p }
+
 end submodule
 
 end semiring

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -289,7 +289,7 @@ begin
   letI : algebra R S := ring_hom.to_algebra f,
   letI : algebra R A := ring_hom.to_algebra (g.comp f),
   letI : algebra S A := ring_hom.to_algebra g,
-  letI : is_scalar_tower R S A := restrict_scalars.is_scalar_tower R S A,
+  letI : is_scalar_tower R S A := _root_.restrict_scalars.is_scalar_tower R S A,
   let f₁ := algebra.linear_map R S,
   let g₁ := (is_scalar_tower.to_alg_hom R S A).to_linear_map,
   exact fg_ker_comp f₁ g₁ hf (fg_restrict_scalars g.ker hg hsur) hsur


### PR DESCRIPTION
To be more precise, turning `p : submodule S M` into an `R`-submodule gives the same module structure as turning it into a type and adding a module structure.

---

(I thought I PR'd this a while ago. Apparently I pushed the branch but never created a PR.)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
