### PR TITLE
[Merged by Bors] - chore(linear_algebra/matrix/trace): relax `comm_ring` to `comm_semiring` in `matrix.trace_mul_comm`

### DIFF
--- a/src/linear_algebra/matrix/trace.lean
+++ b/src/linear_algebra/matrix/trace.lean
@@ -74,7 +74,7 @@ by simp_rw [h, diag_one, finset.sum_const, nsmul_one]; refl
 @[simp] lemma trace_transpose_mul (A : matrix m n R) (B : matrix n m R) :
   trace n R R (Aᵀ ⬝ Bᵀ) = trace m R R (A ⬝ B) := finset.sum_comm
 
-lemma trace_mul_comm {S : Type v} [comm_ring S] (A : matrix m n S) (B : matrix n m S) :
+lemma trace_mul_comm {S : Type v} [comm_semiring S] (A : matrix m n S) (B : matrix n m S) :
   trace n S S (B ⬝ A) = trace m S S (A ⬝ B) :=
 by rw [←trace_transpose, ←trace_transpose_mul, transpose_mul]
 


### PR DESCRIPTION

---

The motivation is to avoid me having to tell a lie in an article I'm writing but I believe the change is worth making anyway.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
