### PR TITLE
[Merged by Bors] - feat(data/rat/basic): Add nat num and denom inv lemmas

### DIFF
--- a/src/data/rat/basic.lean
+++ b/src/data/rat/basic.lean
@@ -744,6 +744,26 @@ begin
     coe_nat_div_self]
 end
 
+lemma num_inv_nat {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.num = 1 :=
+begin
+  rw [rat.inv_def', rat.coe_nat_num, rat.coe_nat_denom],
+  suffices : (((1 : ℤ) : ℚ) / (a : ℤ)).num = 1,
+    exact_mod_cast this,
+  apply num_div_eq_of_coprime,
+  { assumption_mod_cast },
+  { simp only [nat.coprime_one_left_iff, int.nat_abs_one] }
+end
+
+lemma denom_inv_nat {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.denom = a :=
+begin
+  rw [rat.inv_def', rat.coe_nat_num, rat.coe_nat_denom],
+  suffices : ((((1 : ℤ) : ℚ) / (a : ℤ)).denom : ℤ) = a,
+    exact_mod_cast this,
+  apply denom_div_eq_of_coprime,
+  { assumption_mod_cast },
+  { simp only [nat.coprime_one_left_iff, int.nat_abs_one] },
+end
+
 protected lemma «forall» {p : ℚ → Prop} : (∀ r, p r) ↔ ∀ a b : ℤ, p (a / b) :=
 ⟨λ h _ _, h _,
   λ h q, (show q = q.num / q.denom, from by simp [rat.div_num_denom]).symm ▸ (h q.1 q.2)⟩

--- a/src/data/rat/basic.lean
+++ b/src/data/rat/basic.lean
@@ -744,25 +744,28 @@ begin
     coe_nat_div_self]
 end
 
-lemma inv_coe_nat_num {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.num = 1 :=
+lemma inv_coe_int_num {a : ℤ} (ha0 : 0 < a) : (a : ℚ)⁻¹.num = 1 :=
 begin
-  rw [rat.inv_def', rat.coe_nat_num, rat.coe_nat_denom],
-  suffices : (((1 : ℤ) : ℚ) / (a : ℤ)).num = 1,
-    exact_mod_cast this,
-  apply num_div_eq_of_coprime,
-  { assumption_mod_cast },
-  { simp only [nat.coprime_one_left_iff, int.nat_abs_one] }
+  rw [rat.inv_def', rat.coe_int_num, rat.coe_int_denom, nat.cast_one, ←int.cast_one],
+  apply num_div_eq_of_coprime ha0,
+  rw int.nat_abs_one,
+  exact nat.coprime_one_left _,
+end
+
+lemma inv_coe_nat_num {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.num = 1 :=
+inv_coe_int_num (by exact_mod_cast ha0 : 0 < (a : ℤ))
+
+
+lemma inv_coe_int_denom {a : ℤ} (ha0 : 0 < a) : ((a : ℚ)⁻¹.denom : ℤ) = a :=
+begin
+  rw [rat.inv_def', rat.coe_int_num, rat.coe_int_denom, nat.cast_one, ←int.cast_one],
+  apply denom_div_eq_of_coprime ha0,
+  rw int.nat_abs_one,
+  exact nat.coprime_one_left _,
 end
 
 lemma inv_coe_nat_denom {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.denom = a :=
-begin
-  rw [rat.inv_def', rat.coe_nat_num, rat.coe_nat_denom],
-  suffices : ((((1 : ℤ) : ℚ) / (a : ℤ)).denom : ℤ) = a,
-    exact_mod_cast this,
-  apply denom_div_eq_of_coprime,
-  { assumption_mod_cast },
-  { simp only [nat.coprime_one_left_iff, int.nat_abs_one] },
-end
+by exact_mod_cast inv_coe_int_denom (by exact_mod_cast ha0 : 0 < (a : ℤ))
 
 protected lemma «forall» {p : ℚ → Prop} : (∀ r, p r) ↔ ∀ a b : ℤ, p (a / b) :=
 ⟨λ h _ _, h _,

--- a/src/data/rat/basic.lean
+++ b/src/data/rat/basic.lean
@@ -755,7 +755,6 @@ end
 lemma inv_coe_nat_num {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.num = 1 :=
 inv_coe_int_num (by exact_mod_cast ha0 : 0 < (a : ℤ))
 
-
 lemma inv_coe_int_denom {a : ℤ} (ha0 : 0 < a) : ((a : ℚ)⁻¹.denom : ℤ) = a :=
 begin
   rw [rat.inv_def', rat.coe_int_num, rat.coe_int_denom, nat.cast_one, ←int.cast_one],

--- a/src/data/rat/basic.lean
+++ b/src/data/rat/basic.lean
@@ -744,7 +744,7 @@ begin
     coe_nat_div_self]
 end
 
-lemma num_inv_nat {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.num = 1 :=
+lemma inv_coe_nat_num {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.num = 1 :=
 begin
   rw [rat.inv_def', rat.coe_nat_num, rat.coe_nat_denom],
   suffices : (((1 : ℤ) : ℚ) / (a : ℤ)).num = 1,
@@ -754,7 +754,7 @@ begin
   { simp only [nat.coprime_one_left_iff, int.nat_abs_one] }
 end
 
-lemma denom_inv_nat {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.denom = a :=
+lemma inv_coe_nat_denom {a : ℕ} (ha0 : 0 < a) : (a : ℚ)⁻¹.denom = a :=
 begin
   rw [rat.inv_def', rat.coe_nat_num, rat.coe_nat_denom],
   suffices : ((((1 : ℤ) : ℚ) / (a : ℤ)).denom : ℤ) = a,


### PR DESCRIPTION
Add `inv_coe_nat_num`  and `inv_coe_nat_denom` lemmas.

These lemmas show that the denominator and numerator of `1/ n` given `0 < n`, are equal to `n` and `1` respectively.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Hello All👋, this is my first PR.  I am working a project where I formalized the results for  thomae's function.  This lemma was necessary  and seemed fundamental enough to rationals, to make a PR. 

The lemmas are the following, 0 < n,  1/n .denom = n and 1/n.num = 1

Was done with collaboration with Xena and in particular Kevin buzzard.
 
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

> 