### PR TITLE
[Merged by Bors] - fix(docs/references.bib): add missing comma

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1008,7 +1008,7 @@ MRREVIEWER = {B. J. Pettis},
   mrreviewer    = {R. E. Block}
 }
 
-@book{            serre1965
+@book{            serre1965,
   author        = {Serre, Jean-Pierre},
   title         = {Complex semisimple {L}ie algebras},
   note          = {Translated from the French by G. A. Jones},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -120,10 +120,11 @@
   isbn          = "978-3-540-70722-6"
 }
 
-@Book {           billingsley1999,
+@Book{            billingsley1999,
   author        = {Billingsley, Patrick},
   title         = {Convergence of probability measures},
-  series        = {Wiley Series in Probability and Statistics: Probability and Statistics},
+  series        = {Wiley Series in Probability and Statistics: Probability
+                  and Statistics},
   edition       = {Second},
   note          = {A Wiley-Interscience Publication},
   publisher     = {John Wiley \& Sons, Inc., New York},
@@ -133,7 +134,7 @@
   mrclass       = {60B10 (28A33 60F17)},
   mrnumber      = {1700749},
   doi           = {10.1002/9780470316962},
-  url           = {https://doi.org/10.1002/9780470316962},
+  url           = {https://doi.org/10.1002/9780470316962}
 }
 
 @Book{            borceux-vol1,
@@ -167,6 +168,20 @@
   mrnumber      = {0205210}
 }
 
+@Book{            bourbaki1968,
+  author        = {Bourbaki, Nicolas},
+  title         = {Lie groups and {L}ie algebras. {C}hapters 4--6},
+  series        = {Elements of Mathematics (Berlin)},
+  note          = {Translated from the 1968 French original by Andrew
+                  Pressley},
+  publisher     = {Springer-Verlag, Berlin},
+  year          = {2002},
+  pages         = {xii+300},
+  isbn          = {3-540-42650-7},
+  mrclass       = {17-01 (00A05 20E42 20F55 22-01)},
+  mrnumber      = {1890629}
+}
+
 @Book{            bourbaki1975,
   author        = {Bourbaki, Nicolas},
   title         = {Lie groups and {L}ie algebras. {C}hapters 1--3},
@@ -181,26 +196,12 @@
   mrnumber      = {1728312}
 }
 
-@Book{            bourbaki1968,
-  author        = {Bourbaki, Nicolas},
-  title         = {Lie groups and {L}ie algebras. {C}hapters 4--6},
-  series        = {Elements of Mathematics (Berlin)},
-  note          = {Translated from the 1968 French original by Andrew
-                   Pressley},
-  publisher     = {Springer-Verlag, Berlin},
-  year          = {2002},
-  pages         = {xii+300},
-  isbn          = {3-540-42650-7},
-  mrclass       = {17-01 (00A05 20E42 20F55 22-01)},
-  mrnumber      = {1890629}
-}
-
 @Book{            bourbaki1975b,
   author        = {Bourbaki, Nicolas},
   title         = {Lie groups and {L}ie algebras. {C}hapters 7--9},
   series        = {Elements of Mathematics (Berlin)},
-  note          = {Translated from the 1975 and 1982 French originals by Andrew
-                  Pressley},
+  note          = {Translated from the 1975 and 1982 French originals by
+                  Andrew Pressley},
   publisher     = {Springer-Verlag, Berlin},
   year          = {2005},
   pages         = {xii+434},
@@ -210,7 +211,8 @@
 }
 
 @Article{         cadiou1972,
-  title         = {Recursive definitions of partial functions and their computations},
+  title         = {Recursive definitions of partial functions and their
+                  computations},
   doi           = {10.1145/942580.807072},
   number        = {14},
   journal       = {ACM SIGACT News},
@@ -219,7 +221,6 @@
   month         = {Jan},
   pages         = {58–65}
 }
-
 
 @Book{            calugareanu,
   author        = {C\v{a}lug\v{a}reanu, Grigore},
@@ -381,36 +382,41 @@
   mrnumber      = {1194995}
 }
 
-@InProceedings{   flypitch_itp,
-  author        = {Jesse Michael Han and Floris van Doorn},
-  title         = {{A Formalization of Forcing and the Unprovability of the Continuum Hypothesis}},
-  booktitle     = {10th International Conference on Interactive Theorem Proving (ITP 2019)},
-  pages         = {19:1--19:19},
-  series        = {Leibniz International Proceedings in Informatics (LIPIcs)},
-  ISBN          = {978-3-95977-122-1},
-  ISSN          = {1868-8969},
-  year          = {2019},
-  volume        = {141},
-  editor        = {John Harrison and John O'Leary and Andrew Tolmach},
-  publisher     = {Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik},
-  address       = {Dagstuhl, Germany},
-  URL           = {http://drops.dagstuhl.de/opus/volltexte/2019/11074},
-  URN           = {urn:nbn:de:0030-drops-110742},
-  doi           = {10.4230/LIPIcs.ITP.2019.19},
-  annote        = {Keywords: Interactive theorem proving, formal verification, set theory, forcing,
-    independence proofs, continuum hypothesis, Boolean-valued models, Lean}
-}
-
-@inproceedings{   flypitch_cpp,
+@InProceedings{   flypitch_cpp,
   doi           = {10.1145/3372885.3373826},
   url           = {https://doi.org/10.1145/3372885.3373826},
   year          = {2020},
   month         = jan,
   publisher     = {{ACM}},
   author        = {Jesse Michael Han and Floris van Doorn},
-  title         = {A formal proof of the independence of the continuum hypothesis},
-  booktitle     = {Proceedings of the 9th {ACM} {SIGPLAN} International Conference on Certified
-    Programs and Proofs}
+  title         = {A formal proof of the independence of the continuum
+                  hypothesis},
+  booktitle     = {Proceedings of the 9th {ACM} {SIGPLAN} International
+                  Conference on Certified Programs and Proofs}
+}
+
+@InProceedings{   flypitch_itp,
+  author        = {Jesse Michael Han and Floris van Doorn},
+  title         = {{A Formalization of Forcing and the Unprovability of the
+                  Continuum Hypothesis}},
+  booktitle     = {10th International Conference on Interactive Theorem
+                  Proving (ITP 2019)},
+  pages         = {19:1--19:19},
+  series        = {Leibniz International Proceedings in Informatics
+                  (LIPIcs)},
+  isbn          = {978-3-95977-122-1},
+  issn          = {1868-8969},
+  year          = {2019},
+  volume        = {141},
+  editor        = {John Harrison and John O'Leary and Andrew Tolmach},
+  publisher     = {Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik},
+  address       = {Dagstuhl, Germany},
+  url           = {http://drops.dagstuhl.de/opus/volltexte/2019/11074},
+  urn           = {urn:nbn:de:0030-drops-110742},
+  doi           = {10.4230/LIPIcs.ITP.2019.19},
+  annote        = {Keywords: Interactive theorem proving, formal
+                  verification, set theory, forcing, independence proofs,
+                  continuum hypothesis, Boolean-valued models, Lean}
 }
 
 @InProceedings{   fuerer-lochbihler-schneider-traytel2020,
@@ -442,7 +448,8 @@
 
 @Article{         ghys87:groupes,
   author        = {Étienne Ghys},
-  title         = {Groupes d'homéomorphismes du cercle et cohomologie bornée},
+  title         = {Groupes d'homéomorphismes du cercle et cohomologie
+                  bornée},
   journal       = {Contemporary Mathematics},
   year          = 1987,
   volume        = 58,
@@ -480,13 +487,13 @@
 }
 
 @Book{            gunter1992,
-  title         = {Semantics of Programming Languages: Structures and Techniques},
+  title         = {Semantics of Programming Languages: Structures and
+                  Techniques},
   isbn          = {0262570955},
   publisher     = {MIT Press},
   author        = {Gunter, Carl A.},
   year          = {1992}
 }
-
 
 @Article{         Gusakov2021,
   author        = {Alena Gusakov and Bhavik Mehta and Kyle A. Miller},
@@ -528,7 +535,7 @@
   isbn          = {0-387-90088-8}
 }
 
-@Book {           har77,
+@Book{            har77,
   author        = {Hartshorne, Robin},
   title         = {Algebraic geometry},
   note          = {Graduate Texts in Mathematics, No. 52},
@@ -538,7 +545,7 @@
   isbn          = {0-387-90244-9},
   mrclass       = {14-01},
   mrnumber      = {0463157},
-  mrreviewer    = {Robert Speiser},
+  mrreviewer    = {Robert Speiser}
 }
 
 @Book{            hardy2008introduction,
@@ -686,10 +693,11 @@
   publisher     = {Springer}
 }
 
-@article{         markowsky1976,
-  title         = {Chain-complete posets and directed sets with applications},
+@Article{         markowsky1976,
+  title         = {Chain-complete posets and directed sets with
+                  applications},
   volume        = {6},
-  DOI           = {10.1007/bf02485815},
+  doi           = {10.1007/bf02485815},
   number        = {1},
   journal       = {Algebra Universalis},
   author        = {Markowsky, George},
@@ -697,7 +705,6 @@
   month         = {Dec},
   pages         = {53–68}
 }
-
 
 @InProceedings{   mcbride1996,
   title         = {Inverting inductively defined relations in {LEGO}},
@@ -876,9 +883,10 @@
 @Article{         Nash-Williams63,
   title         = {On well-quasi-ordering finite trees},
   volume        = {59},
-  DOI           = {10.1017/S0305004100003844},
+  doi           = {10.1017/S0305004100003844},
   number        = {4},
-  journal       = {Mathematical Proceedings of the Cambridge Philosophical Society},
+  journal       = {Mathematical Proceedings of the Cambridge Philosophical
+                  Society},
   publisher     = {Cambridge University Press},
   author        = {Nash-Williams, C. St. J. A.},
   year          = {1963},
@@ -914,20 +922,20 @@
   zbl           = {1411.41023}
 }
 
-@article{phillips1940,
-    AUTHOR = {Phillips, Ralph S.},
-     TITLE = {Integration in a convex linear topological space},
-   JOURNAL = {Trans. Amer. Math. Soc.},
-  FJOURNAL = {Transactions of the American Mathematical Society},
-    VOLUME = {47},
-      YEAR = {1940},
-     PAGES = {114--145},
-      ISSN = {0002-9947},
-   MRCLASS = {46.3X},
-  MRNUMBER = {2707},
-MRREVIEWER = {B. J. Pettis},
-       DOI = {10.2307/1990004},
-       URL = {https://doi.org/10.2307/1990004},
+@Article{         phillips1940,
+  author        = {Phillips, Ralph S.},
+  title         = {Integration in a convex linear topological space},
+  journal       = {Trans. Amer. Math. Soc.},
+  fjournal      = {Transactions of the American Mathematical Society},
+  volume        = {47},
+  year          = {1940},
+  pages         = {114--145},
+  issn          = {0002-9947},
+  mrclass       = {46.3X},
+  mrnumber      = {2707},
+  mrreviewer    = {B. J. Pettis},
+  doi           = {10.2307/1990004},
+  url           = {https://doi.org/10.2307/1990004}
 }
 
 @Misc{            ponton2020chebyshev,
@@ -1008,7 +1016,7 @@ MRREVIEWER = {B. J. Pettis},
   mrreviewer    = {R. E. Block}
 }
 
-@book{            serre1965,
+@Book{            serre1965,
   author        = {Serre, Jean-Pierre},
   title         = {Complex semisimple {L}ie algebras},
   note          = {Translated from the French by G. A. Jones},
@@ -1019,7 +1027,7 @@ MRREVIEWER = {B. J. Pettis},
   mrclass       = {17-01 (17B20)},
   mrnumber      = {914496},
   doi           = {10.1007/978-1-4757-3910-7},
-  url           = {https://doi.org/10.1007/978-1-4757-3910-7},
+  url           = {https://doi.org/10.1007/978-1-4757-3910-7}
 }
 
 @Book{            simon2011,


### PR DESCRIPTION
* Adds a missing comma to docs/references.bib. Without this the file cannot be parsed by bibtool.
* Normalises docs/references.bib as described in [Citing other works](https://leanprover-community.github.io/contribute/doc.html#citing-other-works).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
