### PR TITLE
[Merged by Bors] - feat(data/equiv/basic): add a small lemma for simplifying map between equivalent quotient spaces induced by equivalent relations

### DIFF
--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -2294,7 +2294,7 @@ quot.congr e eq
 lemma congr_mk {ra : setoid α} {rb : setoid β} (e : α ≃ β)
   (eq : ∀ (a₁ a₂ : α), setoid.r a₁ a₂ ↔ setoid.r (e a₁) (e a₂)) (a : α):
   quotient.congr e eq (quotient.mk a) = quotient.mk (e a) :=
-@quot.congr_mk _ _ (setoid.r) (setoid.r) e eq a
+rfl
 
 /-- Quotients are congruent on equivalences under equality of their relation.
 An alternative is just to use rewriting with `eq`, but then computational proofs get stuck. -/

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -2263,12 +2263,10 @@ protected def congr {ra : α → α → Prop} {rb : β → β → Prop} (e : α 
   left_inv := by { rintros ⟨a⟩, dunfold quot.map, simp only [equiv.symm_apply_apply] },
   right_inv := by { rintros ⟨a⟩, dunfold quot.map, simp only [equiv.apply_symm_apply] } }
 
-/-- A lemma for simplifying the equivalence between quotient spaces as stated just above -/
 @[simp]
-lemma congr_map_simp {α : Sort u} {β : Sort v} {ra : α → α → Prop} {rb : β → β → Prop} (e : α ≃ β)
+lemma congr_mk {ra : α → α → Prop} {rb : β → β → Prop} (e : α ≃ β)
   (eq : ∀ (a₁ a₂ : α), ra a₁ a₂ ↔ rb (e a₁) (e a₂)) (a : α) :
-  (quot.congr e eq).to_fun (quot.mk ra a) = quot.mk rb (e a)
-  := by unfold quot.congr quot.map
+  quot.congr e eq (quot.mk ra a) = quot.mk rb (e a) := rfl
 
 /-- Quotients are congruent on equivalences under equality of their relation.
 An alternative is just to use rewriting with `eq`, but then computational proofs get stuck. -/

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -2263,6 +2263,13 @@ protected def congr {ra : α → α → Prop} {rb : β → β → Prop} (e : α 
   left_inv := by { rintros ⟨a⟩, dunfold quot.map, simp only [equiv.symm_apply_apply] },
   right_inv := by { rintros ⟨a⟩, dunfold quot.map, simp only [equiv.apply_symm_apply] } }
 
+/-- A lemma for simplifying the equivalence between quotient spaces as stated just above -/
+@[simp]
+lemma congr_map_simp {α : Sort u} {β : Sort v} {ra : α → α → Prop} {rb : β → β → Prop} (e : α ≃ β)
+  (eq : ∀ (a₁ a₂ : α), ra a₁ a₂ ↔ rb (e a₁) (e a₂)) (a : α) :
+  (quot.congr e eq).to_fun (quot.mk ra a) = quot.mk rb (e a)
+  := by unfold quot.congr quot.map
+
 /-- Quotients are congruent on equivalences under equality of their relation.
 An alternative is just to use rewriting with `eq`, but then computational proofs get stuck. -/
 protected def congr_right {r r' : α → α → Prop} (eq : ∀a₁ a₂, r a₁ a₂ ↔ r' a₁ a₂) :

--- a/src/data/equiv/basic.lean
+++ b/src/data/equiv/basic.lean
@@ -2290,6 +2290,12 @@ protected def congr {ra : setoid α} {rb : setoid β} (e : α ≃ β)
   quotient ra ≃ quotient rb :=
 quot.congr e eq
 
+@[simp]
+lemma congr_mk {ra : setoid α} {rb : setoid β} (e : α ≃ β)
+  (eq : ∀ (a₁ a₂ : α), setoid.r a₁ a₂ ↔ setoid.r (e a₁) (e a₂)) (a : α):
+  quotient.congr e eq (quotient.mk a) = quotient.mk (e a) :=
+@quot.congr_mk _ _ (setoid.r) (setoid.r) e eq a
+
 /-- Quotients are congruent on equivalences under equality of their relation.
 An alternative is just to use rewriting with `eq`, but then computational proofs get stuck. -/
 protected def congr_right {r r' : setoid α}


### PR DESCRIPTION
Just adding a small lemma that allows us to compute the composition of the map given by `quot.congr` with `quot.mk`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
