### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal): lemmas on `ideal.span {x} * I`

### DIFF
--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -321,6 +321,45 @@ begin
   simp only [pow_succ, ih, span_singleton_mul_span_singleton],
 end
 
+lemma mem_mul_span_singleton {x y : R} {I : ideal R} :
+  x ∈ I * span {y} ↔ ∃ z ∈ I, z * y = x :=
+submodule.mem_smul_span_singleton
+
+lemma mem_span_singleton_mul {x y : R} {I : ideal R} :
+  x ∈ span {y} * I ↔ ∃ z ∈ I, y * z = x :=
+by simp only [mul_comm, mem_mul_span_singleton]
+
+lemma le_span_singleton_mul_iff {x : R} {I J : ideal R} :
+  I ≤ span {x} * J ↔ ∀ zI ∈ I, ∃ zJ ∈ J, x * zJ = zI :=
+show (∀ {zI} (hzI : zI ∈ I), zI ∈ span {x} * J) ↔ ∀ zI ∈ I, ∃ zJ ∈ J, x * zJ = zI,
+by simp only [mem_span_singleton_mul]
+
+lemma span_singleton_mul_le_iff {x : R} {I J : ideal R} :
+  span {x} * I ≤ J ↔ ∀ z ∈ I, x * z ∈ J :=
+begin
+  simp only [mul_le, mem_span_singleton_mul, mem_span_singleton],
+  split,
+  { intros h zI hzI,
+    exact h x (dvd_refl x) zI hzI },
+  { rintros h _ ⟨z, rfl⟩ zI hzI,
+    rw [mul_comm x z, mul_assoc],
+    exact J.mul_mem_left _ (h zI hzI) },
+end
+
+lemma span_singleton_mul_le_span_singleton_mul {x y : R} {I J : ideal R} :
+  span {x} * I ≤ span {y} * J ↔ ∀ zI ∈ I, ∃ zJ ∈ J, x * zI = y * zJ :=
+by simp only [span_singleton_mul_le_iff, mem_span_singleton_mul, eq_comm]
+
+lemma eq_span_singleton_mul {x : R} (I J : ideal R) :
+  I = span {x} * J ↔ ((∀ zI ∈ I, ∃ zJ ∈ J, x * zJ = zI) ∧ (∀ z ∈ J, x * z ∈ I)) :=
+by simp only [le_antisymm_iff, le_span_singleton_mul_iff, span_singleton_mul_le_iff]
+
+lemma span_singleton_mul_eq_span_singleton_mul {x y : R} (I J : ideal R) :
+  span {x} * I = span {y} * J ↔
+    ((∀ zI ∈ I, ∃ zJ ∈ J, x * zI = y * zJ) ∧
+     (∀ zJ ∈ J, ∃ zI ∈ I, x * zI = y * zJ)) :=
+by simp only [le_antisymm_iff, span_singleton_mul_le_span_singleton_mul, eq_comm]
+
 theorem mul_le_inf : I * J ≤ I ⊓ J :=
 mul_le.2 $ λ r hri s hsj, ⟨I.mul_mem_right s hri, J.mul_mem_left r hsj⟩
 


### PR DESCRIPTION
Originally created for being used in the context of the ideal class group, but didn't end up being used. Hopefully they are still useful for others.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
