### PR TITLE
[Merged by Bors] - feat(algebra/group_with_zero): `units.mk0` is a "monoid hom"

### DIFF
--- a/src/algebra/gcd_monoid.lean
+++ b/src/algebra/gcd_monoid.lean
@@ -162,7 +162,7 @@ variables [decidable_eq α] [comm_group_with_zero α]
 instance : normalization_monoid α :=
 { norm_unit := λ x, if h : x = 0 then 1 else (units.mk0 x h)⁻¹,
   norm_unit_zero := dif_pos rfl,
-  norm_unit_mul := λ x y x0 y0, units.eq_iff.1 (by simp [x0, y0, mul_inv']),
+  norm_unit_mul := λ x y x0 y0, units.eq_iff.1 (by simp [x0, y0, mul_comm]),
   norm_unit_coe_units := λ u, by { rw [dif_neg (units.ne_zero _), units.mk0_coe], apply_instance } }
 
 @[simp]

--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -589,6 +589,10 @@ variables {a b : G₀}
 def mk0 (a : G₀) (ha : a ≠ 0) : units G₀ :=
 ⟨a, a⁻¹, mul_inv_cancel ha, inv_mul_cancel ha⟩
 
+@[simp] lemma mk0_one (h := one_ne_zero) :
+  mk0 (1 : G₀) h = 1 :=
+by { ext, refl }
+
 @[simp] lemma coe_mk0 {a : G₀} (h : a ≠ 0) : (mk0 a h : G₀) = a := rfl
 
 @[simp] lemma mk0_coe (u : units G₀) (h : (u : G₀) ≠ 0) : mk0 (u : G₀) h = u :=
@@ -639,6 +643,13 @@ instance group_with_zero.cancel_monoid_with_zero : cancel_monoid_with_zero G₀ 
   mul_right_cancel_of_ne_zero := λ x y z hy h,
     by rw [← mul_inv_cancel_right' hy x, h, mul_inv_cancel_right' hy z],
   .. (‹_› : group_with_zero G₀) }
+
+-- Can't be put next to the other `mk0` lemmas becuase it depends on the
+-- `no_zero_divisors` instance, which depends on `mk0`.
+@[simp] lemma units.mk0_mul (x y : G₀) (hxy) :
+  units.mk0 (x * y) hxy =
+    units.mk0 x (mul_ne_zero_iff.mp hxy).1 * units.mk0 y (mul_ne_zero_iff.mp hxy).2 :=
+by { ext, refl }
 
 lemma mul_inv_rev' (x y : G₀) : (x * y)⁻¹ = y⁻¹ * x⁻¹ :=
 begin


### PR DESCRIPTION
This PR shows that `units.mk0` sends `1` to `1` and `x * y` to `mk0 x * mk0 y`. So it is a monoid hom, if we ignore the proof fields.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
