### PR TITLE
[Merged by Bors] - feat(tactic/abel): check for defeq of atoms instead of syntactic eq

### DIFF
--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -16,14 +16,20 @@ Evaluate expressions in the language of additive, commutative monoids and groups
 namespace tactic
 namespace abel
 
-meta structure cache :=
+/-- The `context` for a call to `abel`.
+
+Stores a few options for this call, and caches some common subexpressions
+such as typeclass instances and `0 : α`.
+-/
+meta structure context :=
+(red : transparency)
 (α : expr)
 (univ : level)
 (α0 : expr)
 (is_group : bool)
 (inst : expr)
 
-meta def mk_cache (e : expr) : tactic cache :=
+meta def mk_context (red : transparency) (e : expr) : tactic context :=
 do α ← infer_type e,
    c ← mk_app ``add_comm_monoid [α] >>= mk_instance,
    cg ← try_core (mk_app ``add_comm_group [α] >>= mk_instance),
@@ -32,29 +38,29 @@ do α ← infer_type e,
    u ← get_univ_assignment u,
    α0 ← expr.of_nat α 0,
    match cg with
-   | (some cg) := return ⟨α, u, α0, tt, cg⟩
-   | _ := return ⟨α, u, α0, ff, c⟩
+   | (some cg) := return ⟨red, α, u, α0, tt, cg⟩
+   | _ := return ⟨red, α, u, α0, ff, c⟩
    end
 
-meta def cache.app (c : cache) (n : name) (inst : expr) : list expr → expr :=
+meta def context.app (c : context) (n : name) (inst : expr) : list expr → expr :=
 (@expr.const tt n [c.univ] c.α inst).mk_app
 
-meta def cache.mk_app (c : cache) (n inst : name) (l : list expr) : tactic expr :=
+meta def context.mk_app (c : context) (n inst : name) (l : list expr) : tactic expr :=
 do m ← mk_instance ((expr.const inst [c.univ] : expr) c.α), return $ c.app n m l
 
 meta def add_g : name → name
 | (name.mk_string s p) := name.mk_string (s ++ "g") p
 | n := n
 
-meta def cache.iapp (c : cache) (n : name) : list expr → expr :=
+meta def context.iapp (c : context) (n : name) : list expr → expr :=
 c.app (if c.is_group then add_g n else n) c.inst
 
 def term {α} [add_comm_monoid α] (n : ℕ) (x a : α) : α := n • x + a
 def termg {α} [add_comm_group α] (n : ℤ) (x a : α) : α := n • x + a
 
-meta def cache.mk_term (c : cache) (n x a : expr) : expr := c.iapp ``term [n, x, a]
+meta def context.mk_term (c : context) (n x a : expr) : expr := c.iapp ``term [n, x, a]
 
-meta def cache.int_to_expr (c : cache) (n : ℤ) : tactic expr :=
+meta def context.int_to_expr (c : context) (n : ℤ) : tactic expr :=
 expr.of_int (if c.is_group then `(ℤ) else `(ℕ)) n
 
 meta inductive normal_expr : Type
@@ -68,10 +74,11 @@ meta def normal_expr.e : normal_expr → expr
 meta instance : has_coe normal_expr expr := ⟨normal_expr.e⟩
 meta instance : has_coe_to_fun normal_expr := ⟨_, λ e, ((e : expr) : expr → expr)⟩
 
-meta def normal_expr.term' (c : cache) (n : expr × ℤ) (x : expr) (a : normal_expr) : normal_expr :=
+meta def normal_expr.term' (c : context) (n : expr × ℤ) (x : expr) (a : normal_expr) :
+  normal_expr :=
 normal_expr.nterm (c.mk_term n.1 x a) n x a
 
-meta def normal_expr.zero' (c : cache) : normal_expr := normal_expr.zero c.α0
+meta def normal_expr.zero' (c : context) : normal_expr := normal_expr.zero c.α0
 
 meta def normal_expr.to_list : normal_expr → list (ℤ × expr)
 | (normal_expr.zero _) := []
@@ -121,7 +128,7 @@ by simp [term, zero_nsmul, one_nsmul]
 theorem zero_termg {α} [add_comm_group α] (x a) : @termg α _ 0 x a = a :=
 by simp [termg]
 
-meta def eval_add (c : cache) : normal_expr → normal_expr → tactic (normal_expr × expr)
+meta def eval_add (c : context) : normal_expr → normal_expr → tactic (normal_expr × expr)
 | (zero _) e₂ := do
   p ← mk_app ``zero_add [e₂],
   return (e₂, p)
@@ -130,7 +137,7 @@ meta def eval_add (c : cache) : normal_expr → normal_expr → tactic (normal_e
   return (e₁, p)
 | he₁@(nterm e₁ n₁ x₁ a₁) he₂@(nterm e₂ n₂ x₂ a₂) :=
   (do
-    is_def_eq x₁ x₂,
+    is_def_eq x₁ x₂ c.red,
     (n', h₁) ← mk_app ``has_add.add [n₁.1, n₂.1] >>= norm_num.eval_field,
     (a', h₂) ← eval_add a₁ a₂,
     let k := n₁.2 + n₂.2,
@@ -151,7 +158,7 @@ theorem term_neg {α} [add_comm_group α] (n x a n' a')
   -@termg α _ n x a = termg n' x a' :=
 by simp [h₂.symm, h₁.symm, termg]; ac_refl
 
-meta def eval_neg (c : cache) : normal_expr → tactic (normal_expr × expr)
+meta def eval_neg (c : context) : normal_expr → tactic (normal_expr × expr)
 | (zero e) := do
   p ← c.mk_app ``neg_zero ``add_group [],
   return (zero' c, p)
@@ -180,7 +187,7 @@ theorem term_smulg {α} [add_comm_group α] (c n x a n' a')
   smulg c (@termg α _ n x a) = termg n' x a' :=
 by simp [h₂.symm, h₁.symm, termg, smulg, gsmul_add, mul_gsmul]
 
-meta def eval_smul (c : cache) (k : expr × ℤ) :
+meta def eval_smul (c : context) (k : expr × ℤ) :
   normal_expr → tactic (normal_expr × expr)
 | (zero _) := return (zero' c, c.iapp ``zero_smul [k.1])
 | (nterm e n x a) := do
@@ -195,7 +202,7 @@ by simp [term]
 theorem term_atomg {α} [add_comm_group α] (x : α) : x = termg 1 x 0 :=
 by simp [termg]
 
-meta def eval_atom (c : cache) (e : expr) : tactic (normal_expr × expr) :=
+meta def eval_atom (c : context) (e : expr) : tactic (normal_expr × expr) :=
 do n1 ← c.int_to_expr 1,
    return (term' c (n1, 1) e (zero' c), c.iapp ``term_atom [e])
 
@@ -223,7 +230,7 @@ lemma subst_into_smulg {α} [add_comm_group α]
 by simp [prl, prr, prt]
 
 /-- Deal with a `smul` term of the form `e₁ • e₂`, handling both natural and integer `e₁`. -/
-meta def eval_smul' (c : cache) (eval : expr → tactic (normal_expr × expr))
+meta def eval_smul' (c : context) (eval : expr → tactic (normal_expr × expr))
   (e₁ e₂ : expr) : tactic (normal_expr × expr) :=
 do (e₁', p₁) ← norm_num.derive e₁ <|> refl_conv e₁,
   n ← if c.is_group then e₁'.to_int else coe <$> e₁'.to_nat,
@@ -231,7 +238,7 @@ do (e₁', p₁) ← norm_num.derive e₁ <|> refl_conv e₁,
   (e', p) ← eval_smul c (e₁', n) e₂',
   return (e', c.iapp ``subst_into_smul [e₁, e₂, e₁', e₂', e', p₁, p₂, p])
 
-meta def eval (c : cache) : expr → tactic (normal_expr × expr)
+meta def eval (c : context) : expr → tactic (normal_expr × expr)
 | `(%%e₁ + %%e₂) := do
   (e₁', p₁) ← eval e₁,
   (e₂', p₂) ← eval e₂,
@@ -263,7 +270,7 @@ meta def eval (c : cache) : expr → tactic (normal_expr × expr)
 | `(smulg %%e₁ %%e₂) := eval_smul' c eval e₁ e₂
 | e := eval_atom c e
 
-meta def eval' (c : cache) (e : expr) : tactic (expr × expr) :=
+meta def eval' (c : context) (e : expr) : tactic (expr × expr) :=
 do (e', p) ← eval c e, return (e', p)
 
 @[derive has_reflect]
@@ -271,7 +278,8 @@ inductive normalize_mode | raw | term
 
 instance : inhabited normalize_mode := ⟨normalize_mode.term⟩
 
-meta def normalize (mode := normalize_mode.term) (e : expr) : tactic (expr × expr) := do
+meta def normalize (red : transparency) (mode := normalize_mode.term) (e : expr) :
+  tactic (expr × expr) := do
 pow_lemma ← simp_lemmas.mk.add_simp ``pow_one,
 let lemmas := match mode with
 | normalize_mode.term :=
@@ -282,7 +290,7 @@ end,
 lemmas ← lemmas.mfoldl simp_lemmas.add_simp simp_lemmas.mk,
 (_, e', pr) ← ext_simplify_core () {}
   simp_lemmas.mk (λ _, failed) (λ _ _ _ _ e, do
-    c ← mk_cache e,
+    c ← mk_context red e,
     (new_e, pr) ← match mode with
     | normalize_mode.raw := eval' c
     | normalize_mode.term := trans_conv (eval' c)
@@ -304,10 +312,13 @@ local postfix `?`:9001 := optional
 /-- Tactic for solving equations in the language of
 *additive*, commutative monoids and groups.
 This version of `abel` fails if the target is not an equality
-that is provable by the axioms of commutative monoids/groups. -/
-meta def abel1 : tactic unit :=
+that is provable by the axioms of commutative monoids/groups.
+
+`abel1!` will use a more aggressive reducibility setting to identify atoms.
+-/
+meta def abel1 (red : parse (tk "!")?) : tactic unit :=
 do `(%%e₁ = %%e₂) ← target,
-  c ← mk_cache e₁,
+  c ← mk_context (if red.is_some then semireducible else reducible) e₁,
   (e₁', p₁) ← eval c e₁,
   (e₂', p₂) ← eval c e₂,
   is_def_eq e₁' e₂',
@@ -329,20 +340,24 @@ It attempts to prove the goal outright if there is no `at`
 specifier and the target is an equality, but if this
 fails, it falls back to rewriting all monoid expressions into a normal form.
 If there is an `at` specifier, it rewrites the given target into a normal form.
+`abel!` will use a more aggressive reducibility setting to identify atoms.
 ```lean
 example {α : Type*} {a b : α} [add_comm_monoid α] : a + (b + a) = a + a + b := by abel
 example {α : Type*} {a b : α} [add_comm_group α] : (a + b) - ((b + a) + a) = -a := by abel
 example {α : Type*} {a b : α} [add_comm_group α] (hyp : a + a - a = b - b) : a = 0 :=
 by { abel at hyp, exact hyp }
+example {α : Type*} {a b : α} [add_comm_group α] : (a + b) - (id a + b) = 0 := by abel!
 ```
 -/
-meta def abel (SOP : parse abel.mode) (loc : parse location) : tactic unit :=
+meta def abel (red : parse (tk "!")?) (SOP : parse abel.mode) (loc : parse location) :
+  tactic unit :=
 match loc with
-| interactive.loc.ns [none] := abel1
+| interactive.loc.ns [none] := abel1 red
 | _ := failed
 end <|>
 do ns ← loc.get_locals,
-   tt ← tactic.replace_at (normalize SOP) ns loc.include_goal
+   let red := if red.is_some then semireducible else reducible,
+   tt ← tactic.replace_at (normalize red SOP) ns loc.include_goal
       | fail "abel failed to simplify",
    when loc.include_goal $ try tactic.reflexivity
 

--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -66,7 +66,7 @@ meta def add_g : name → name
 | (name.mk_string s p) := name.mk_string (s ++ "g") p
 | n := n
 
-/-- Applyy the function `n : ∀ {α} [add_comm_{monoid,group} α]` to the given
+/-- Apply the function `n : ∀ {α} [add_comm_{monoid,group} α]` to the given
 list of arguments.
 
 Will use the `add_comm_{monoid,group}` instance that has been cached in the context.
@@ -336,6 +336,7 @@ This version of `abel` fails if the target is not an equality
 that is provable by the axioms of commutative monoids/groups.
 
 `abel1!` will use a more aggressive reducibility setting to identify atoms.
+This can prove goals that `abel` cannot, but is more expensive.
 -/
 meta def abel1 (red : parse (tk "!")?) : tactic unit :=
 do `(%%e₁ = %%e₂) ← target,
@@ -361,7 +362,9 @@ It attempts to prove the goal outright if there is no `at`
 specifier and the target is an equality, but if this
 fails, it falls back to rewriting all monoid expressions into a normal form.
 If there is an `at` specifier, it rewrites the given target into a normal form.
+
 `abel!` will use a more aggressive reducibility setting to identify atoms.
+This can prove goals that `abel` cannot, but is more expensive.
 ```lean
 example {α : Type*} {a b : α} [add_comm_monoid α] : a + (b + a) = a + a + b := by abel
 example {α : Type*} {a b : α} [add_comm_group α] : (a + b) - ((b + a) + a) = -a := by abel

--- a/test/abel.lean
+++ b/test/abel.lean
@@ -6,3 +6,7 @@ example [add_comm_group α] : (a + b) - ((b + a) + a) = -a := by abel
 example [add_comm_group α] (x : α) : x - 0 = x := by abel
 example [add_comm_monoid α] (x : α) : (3 : ℕ) • a = a + (2 : ℕ) • a := by abel
 example [add_comm_group α] : (3 : ℤ) • a = a + (2 : ℤ) • a := by abel
+
+-- `abel` should see through terms that are definitionally equal
+def id' (x : α) := x
+example [add_comm_group α] : a + b - b - id' a = 0 := by abel

--- a/test/abel.lean
+++ b/test/abel.lean
@@ -7,6 +7,10 @@ example [add_comm_group α] (x : α) : x - 0 = x := by abel
 example [add_comm_monoid α] (x : α) : (3 : ℕ) • a = a + (2 : ℕ) • a := by abel
 example [add_comm_group α] : (3 : ℤ) • a = a + (2 : ℤ) • a := by abel
 
--- `abel` should see through terms that are definitionally equal
+-- `abel!` should see through terms that are definitionally equal,
 def id' (x : α) := x
-example [add_comm_group α] : a + b - b - id' a = 0 := by abel
+example [add_comm_group α] : a + b - b - id' a = 0 :=
+begin
+  success_if_fail { abel; done },
+  abel!
+end


### PR DESCRIPTION
I had a call to `abel` break after adding a new typeclass instance, and it turns out this was because two terms became defeq-but-not-syntactically-eq. This PR modifies the equality check in `abel` to follow the implementation in e.g. `ring`.

By default, `abel` now unifies atoms up to `reducible`, which should not have a huge impact on build times. Use `abel!` for trying to unify up to `semireducible`.

I also renamed the `tactic.abel.cache` to `tactic.abel.context`, since we store more things in there than a few elaborated terms. To appease the docstring linter, I added docs for all of the renamed `def`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
