### PR TITLE
[Merged by Bors] - refactor(tactic/tidy): use @[user_attribute]

### DIFF
--- a/src/tactic/tidy.lean
+++ b/src/tactic/tidy.lean
@@ -12,7 +12,7 @@ namespace tactic
 namespace tidy
 /-- Tag interactive tactics (locally) with `[tidy]` to add them to the list of default tactics
 called by `tidy`. -/
-meta def tidy_attribute : user_attribute := {
+@[user_attribute] meta def tidy_attribute : user_attribute := {
   name := `tidy,
   descr := "A tactic that should be called by `tidy`."
 }
@@ -22,8 +22,6 @@ add_tactic_doc
   category                 := doc_category.attr,
   decl_names               := [`tactic.tidy.tidy_attribute],
   tags                     := ["search"] }
-
-run_cmd attribute.register ``tidy_attribute
 
 meta def run_tactics : tactic string :=
 do names ← attribute.get_instances `tidy,


### PR DESCRIPTION
This is just a minor change to use the `@[user_attribute]` attribute like all other user attrs instead of calling `attribute.register`. (This came up during the census of mathlib user attrs.)