### PR TITLE
[Merged by Bors] - feat(tactic/cache): allow optional := in haveI

### DIFF
--- a/archive/examples/prop_encodable.lean
+++ b/archive/examples/prop_encodable.lean
@@ -89,8 +89,8 @@ private def finv : W_type (λ i, fin (arity α i)) → prop_form α
 
 instance [encodable α] : encodable (prop_form α) :=
 begin
-  haveI : encodable (constructors α) :=
-    by { unfold constructors, apply_instance },
+  haveI : encodable (constructors α),
+  { unfold constructors, apply_instance },
   exact encodable.of_left_inverse f finv
     (by { intro p, induction p; simp [f, finv, *] })
 end

--- a/src/algebra/char_p/exp_char.lean
+++ b/src/algebra/char_p/exp_char.lean
@@ -116,7 +116,7 @@ begin
   casesI char_p.exists R with p hp,
   have p_ne_zero : p ≠ 0,
   { intro p_zero,
-    haveI : char_p R 0 := by { rwa ←p_zero },
+    haveI : char_p R 0, { rwa ←p_zero },
     have : q = 1 := exp_char_one_of_char_zero R q,
     contradiction, },
   have p_eq_q : p = q := (char_eq_exp_char_iff R p q).mpr (char_prime_of_ne_zero R p_ne_zero),

--- a/src/category_theory/abelian/non_preadditive.lean
+++ b/src/category_theory/abelian/non_preadditive.lean
@@ -298,8 +298,8 @@ lemma mono_of_zero_kernel {X Y : C} (f : X ⟶ Y) (Z : C)
   { rw [←hm, reassoc_of hw, zero_comp] },
   obtain ⟨n, hn⟩ := kernel_fork.is_limit.lift' l _ hwf,
   rw [fork.ι_of_ι, has_zero_morphisms.comp_zero] at hn,
-  haveI : is_iso (coequalizer.π u v) :=
-    by apply is_iso_colimit_cocone_parallel_pair_of_eq hn.symm hl,
+  haveI : is_iso (coequalizer.π u v),
+  { apply is_iso_colimit_cocone_parallel_pair_of_eq hn.symm hl },
   apply (cancel_mono (coequalizer.π u v)).1,
   exact coequalizer.condition _ _
  end⟩
@@ -315,8 +315,8 @@ lemma epi_of_zero_cokernel {X Y : C} (f : X ⟶ Y) (Z : C)
   { rw [←hm, category.assoc, hw, comp_zero] },
   obtain ⟨n, hn⟩ := cokernel_cofork.is_colimit.desc' l _ hwf,
   rw [cofork.π_of_π, zero_comp] at hn,
-  haveI : is_iso (equalizer.ι u v) :=
-    by apply is_iso_limit_cone_parallel_pair_of_eq hn.symm hl,
+  haveI : is_iso (equalizer.ι u v),
+  { apply is_iso_limit_cone_parallel_pair_of_eq hn.symm hl },
   apply (cancel_epi (equalizer.ι u v)).1,
   exact equalizer.condition _ _
  end⟩

--- a/src/category_theory/limits/cofinal.lean
+++ b/src/category_theory/limits/cofinal.lean
@@ -445,7 +445,7 @@ If `colimit (F ⋙ coyoneda.obj (op d)) ≅ punit` for all `d : D`, then `F` is 
 lemma cofinal_of_colimit_comp_coyoneda_iso_punit
   (I : Π d, colimit (F ⋙ coyoneda.obj (op d)) ≅ punit) : cofinal F :=
 ⟨λ d, begin
-  haveI : nonempty (structured_arrow d F) := by
+  haveI : nonempty (structured_arrow d F),
   { have := (I d).inv punit.star,
     obtain ⟨j, y, rfl⟩ := limits.types.jointly_surjective' this,
     exact ⟨structured_arrow.mk y⟩, },

--- a/src/combinatorics/simple_graph/degree_sum.lean
+++ b/src/combinatorics/simple_graph/degree_sum.lean
@@ -133,7 +133,7 @@ end
 
 lemma dart_card_eq_sum_degrees : fintype.card G.dart = ∑ v, G.degree v :=
 begin
-  haveI h : decidable_eq V := by { classical, apply_instance },
+  haveI h : decidable_eq V, { classical, apply_instance },
   simp only [←card_univ, ←dart_fst_fiber_card_eq_degree],
   exact card_eq_sum_card_fiberwise (by simp),
 end
@@ -227,7 +227,7 @@ lemma exists_ne_odd_degree_of_exists_odd_degree [fintype V] [decidable_rel G.adj
   (v : V) (h : odd (G.degree v)) :
   ∃ (w : V), w ≠ v ∧ odd (G.degree w) :=
 begin
-  haveI : decidable_eq V := by { classical, apply_instance },
+  haveI : decidable_eq V, { classical, apply_instance },
   rcases G.odd_card_odd_degree_vertices_ne v h with ⟨k, hg⟩,
   have hg' : (filter (λ (w : V), w ≠ v ∧ odd (G.degree w)) univ).card > 0,
   { rw hg,

--- a/src/data/set/countable.lean
+++ b/src/data/set/countable.lean
@@ -197,7 +197,7 @@ protected lemma countable.prod {s : set α} {t : set β} (hs : countable s) (ht 
 begin
   haveI : encodable s := hs.to_encodable,
   haveI : encodable t := ht.to_encodable,
-  haveI : encodable (s × t) := by apply_instance,
+  haveI : encodable (s × t), { apply_instance },
   have : range (prod.map coe coe : s × t → α × β) = set.prod s t,
     by rw [range_prod_map, subtype.range_coe, subtype.range_coe],
   rw ← this,

--- a/src/field_theory/abel_ruffini.lean
+++ b/src/field_theory/abel_ruffini.lean
@@ -378,7 +378,7 @@ lemma is_solvable' {α : E} {q : polynomial F} (q_irred : irreducible q)
   (q_aeval : aeval α q = 0) (hα : is_solvable_by_rad F α) :
   _root_.is_solvable q.gal :=
 begin
-  haveI : _root_.is_solvable (q * C q.leading_coeff⁻¹).gal := by
+  haveI : _root_.is_solvable (q * C q.leading_coeff⁻¹).gal,
   { rw [minpoly.unique'' q_irred q_aeval,
         ←show minpoly F (⟨α, hα⟩ : solvable_by_rad F E) = minpoly F α,
         from minpoly.eq_of_algebra_map_eq (ring_hom.injective _) (is_integral ⟨α, hα⟩) rfl],

--- a/src/field_theory/finite/basic.lean
+++ b/src/field_theory/finite/basic.lean
@@ -178,7 +178,7 @@ begin
   { to_fun   := λ x, x ^ i,
     map_one' := by rw [units.coe_one, one_pow],
     map_mul' := by { intros, rw [units.coe_mul, mul_pow] } },
-  haveI : decidable (φ = 1) := by { classical, apply_instance },
+  haveI : decidable (φ = 1), { classical, apply_instance },
   calc ∑ x : units K, φ x = if φ = 1 then fintype.card (units K) else 0 : sum_hom_units φ
                       ... = if (q - 1) ∣ i then -1 else 0 : _,
   suffices : (q - 1) ∣ i ↔ φ = 1,

--- a/src/field_theory/normal.lean
+++ b/src/field_theory/normal.lean
@@ -128,7 +128,7 @@ lemma normal.of_is_splitting_field (p : polynomial F) [hFEp : is_splitting_field
   normal F E :=
 begin
   by_cases hp : p = 0,
-  { haveI : is_splitting_field F F p := by { rw hp, exact ⟨splits_zero _, subsingleton.elim _ _⟩ },
+  { haveI : is_splitting_field F F p, { rw hp, exact ⟨splits_zero _, subsingleton.elim _ _⟩ },
     exactI (alg_equiv.transfer_normal ((is_splitting_field.alg_equiv F p).trans
       (is_splitting_field.alg_equiv E p).symm)).mp (normal_self F) },
   refine normal_iff.2 (λ x, _),

--- a/src/field_theory/polynomial_galois_group.lean
+++ b/src/field_theory/polynomial_galois_group.lean
@@ -222,7 +222,7 @@ monoid_hom.prod (restrict_dvd (dvd_mul_right p q)) (restrict_dvd (dvd_mul_left q
 lemma restrict_prod_injective : function.injective (restrict_prod p q) :=
 begin
   by_cases hpq : (p * q) = 0,
-  { haveI : unique (p * q).gal := by { rw hpq, apply_instance },
+  { haveI : unique (p * q).gal, { rw hpq, apply_instance },
     exact λ f g h, eq.trans (unique.eq_default f) (unique.eq_default g).symm },
   intros f g hfg,
   dsimp only [restrict_prod, restrict_dvd] at hfg,

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -728,7 +728,7 @@ lemma ae_measurable.is_lub {ι} {μ : measure δ} [encodable ι] {f : ι → δ 
   ae_measurable g μ :=
 begin
   by_cases hμ : μ = 0, { rw hμ, exact ae_measurable_zero_measure },
-  haveI : μ.ae.ne_bot := by simpa [ne_bot_iff],
+  haveI : μ.ae.ne_bot, { simpa [ne_bot_iff] },
   by_cases hι : nonempty ι, { exact ae_measurable.is_lub_of_nonempty hι hf hg, },
   suffices : ∃ x, g =ᵐ[μ] λ y, g x,
   by { exact ⟨(λ y, g this.some), measurable_const, this.some_spec⟩, },
@@ -785,7 +785,7 @@ lemma ae_measurable.is_glb {ι} {μ : measure δ} [encodable ι] {f : ι → δ 
   ae_measurable g μ :=
 begin
   by_cases hμ : μ = 0, { rw hμ, exact ae_measurable_zero_measure },
-  haveI : μ.ae.ne_bot := by simpa [ne_bot_iff],
+  haveI : μ.ae.ne_bot, { simpa [ne_bot_iff] },
   by_cases hι : nonempty ι, { exact ae_measurable.is_glb_of_nonempty hι hf hg, },
   suffices : ∃ x, g =ᵐ[μ] λ y, g x,
   by { exact ⟨(λ y, g this.some), measurable_const, this.some_spec⟩, },

--- a/src/measure_theory/function/ess_sup.lean
+++ b/src/measure_theory/function/ess_sup.lean
@@ -67,7 +67,7 @@ liminf_le_liminf hfg
 
 lemma ess_sup_const (c : β) (hμ : μ ≠ 0) : ess_sup (λ x : α, c) μ = c :=
 begin
-  haveI hμ_ne_bot : μ.ae.ne_bot := by rwa [ne_bot_iff, ne.def, ae_eq_bot],
+  haveI hμ_ne_bot : μ.ae.ne_bot, { rwa [ne_bot_iff, ne.def, ae_eq_bot] },
   exact limsup_const c,
 end
 

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -131,7 +131,7 @@ begin
       (comap (algebra_map R S) P) (comap_is_prime _ _)), comap_jacobson],
     refine Inf_le_Inf (λ J hJ, _),
     simp only [true_and, set.mem_image, bot_le, set.mem_set_of_eq],
-    haveI : J.is_maximal := by simpa using hJ,
+    haveI : J.is_maximal, { simpa using hJ },
     exact exists_ideal_over_maximal_of_is_integral (is_integral_quotient_of_is_integral hRS) J
       (comap_bot_le_of_injective _ algebra_map_quotient_injective) }
 end

--- a/src/ring_theory/polynomial/dickson.lean
+++ b/src/ring_theory/polynomial/dickson.lean
@@ -185,7 +185,7 @@ begin
   obtain ⟨K, _, _, H⟩ : ∃ (K : Type) [field K], by exactI ∃ [char_p K p], infinite K,
   { let K := fraction_ring (polynomial (zmod p)),
     let f : zmod p →+* K := (algebra_map _ (fraction_ring _)).comp C,
-    haveI : char_p K p := by { rw ← f.char_p_iff_char_p, apply_instance },
+    haveI : char_p K p, { rw ← f.char_p_iff_char_p, apply_instance },
     haveI : infinite K :=
     infinite.of_injective (algebra_map (polynomial (zmod p)) (fraction_ring (polynomial (zmod p))))
       (is_fraction_ring.injective _ _),

--- a/src/tactic/cache.lean
+++ b/src/tactic/cache.lean
@@ -70,14 +70,14 @@ intros p >> reset_instance_cache
 be used in typeclass inference. The syntax is the same as `have`,
 but the proof-omitted version is not supported. For
 this one must write `have : t, { <proof> }, resetI, <proof>`. -/
-meta def haveI (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse (tk ":=" *> texpr)) :
+meta def haveI (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse (tk ":=" *> texpr)?) :
   tactic unit :=
 do h ← match h with
   | none   := get_unused_name "_inst"
   | some a := return a
   end,
-  «have» (some h) q₁ (some q₂),
-  match q₁ with
+  «have» (some h) q₁ q₂,
+  match q₂ with
   | none    := swap >> reset_instance_cache >> swap
   | some p₂ := reset_instance_cache
   end

--- a/src/topology/uniform_space/compact_separated.lean
+++ b/src/topology/uniform_space/compact_separated.lean
@@ -70,10 +70,10 @@ lemma unique_uniformity_of_compact_t2 {α : Type*} [t : topological_space α] [c
 begin
   apply uniform_space_eq,
   change uniformity _ = uniformity _,
-  haveI : @compact_space α u.to_topological_space := by rw h ; assumption,
-  haveI : @compact_space α u'.to_topological_space := by rw h' ; assumption,
-  haveI : @separated_space α u := by rwa [separated_iff_t2, h],
-  haveI : @separated_space α u' :=  by rwa [separated_iff_t2, h'],
+  haveI : @compact_space α u.to_topological_space, { rw h ; assumption },
+  haveI : @compact_space α u'.to_topological_space, { rw h' ; assumption },
+  haveI : @separated_space α u, { rwa [separated_iff_t2, h] },
+  haveI : @separated_space α u', { rwa [separated_iff_t2, h'] },
   rw [compact_space_uniformity, compact_space_uniformity, h, h']
 end
 


### PR DESCRIPTION
This syntactic restriction was originally added because it was not possible to reset the instance cache only for a given goal. This limitation has since been lifted (a while ago, I think), and so the syntax can be made more like `have` now.