### PR TITLE
[Merged by Bors] - refactor(tactic/*): mark internal attrs as `parser := failed`

### DIFF
--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -42,6 +42,7 @@ that have been processed by `to_additive`. -/
 meta def aux_attr : user_attribute (name_map name) name :=
 { name      := `to_additive_aux,
   descr     := "Auxiliary attribute for `to_additive`. DON'T USE IT",
+  parser    := failed,
   cache_cfg := ⟨λ ns,
                 ns.mfoldl
                   (λ dict n', do
@@ -51,8 +52,7 @@ meta def aux_attr : user_attribute (name_map name) name :=
                             end,
                     param ← aux_attr.get_param_untyped n',
                     pure $ dict.insert n param.app_arg.const_name)
-                  mk_name_map, []⟩,
-  parser    := lean.parser.ident }
+                  mk_name_map, []⟩ }
 
 end performance_hack
 

--- a/src/tactic/alias.lean
+++ b/src/tactic/alias.lean
@@ -48,7 +48,7 @@ open lean.parser tactic interactive parser
 namespace tactic.alias
 
 @[user_attribute] meta def alias_attr : user_attribute :=
-{ name := `alias, descr := "This definition is an alias of another." }
+{ name := `alias, descr := "This definition is an alias of another.", parser := failed }
 
 meta def alias_direct (d : declaration) (doc : string) (al : name) : tactic unit :=
 do updateex_env $ λ env,

--- a/src/tactic/doc_commands.lean
+++ b/src/tactic/doc_commands.lean
@@ -68,7 +68,8 @@ do fr ← parser.ident,
 output. -/
 @[user_attribute] meta def library_note_attr : user_attribute :=
 { name := `library_note,
-  descr := "Notes about library features to be included in documentation" }
+  descr := "Notes about library features to be included in documentation",
+  parser := failed }
 
 /--
 `mk_reflected_definition name val` constructs a definition declaration by reflection.
@@ -176,7 +177,8 @@ end
 for use in doc output -/
 @[user_attribute] meta def tactic_doc_entry_attr : user_attribute :=
 { name := `tactic_doc,
-  descr := "Information about a tactic to be included in documentation" }
+  descr := "Information about a tactic to be included in documentation",
+  parser := failed }
 
 /-- Collects everything in the environment tagged with the attribute `tactic_doc`. -/
 meta def tactic.get_tactic_doc_entries : tactic (list tactic_doc_entry) :=

--- a/src/tactic/lift.lean
+++ b/src/tactic/lift.lean
@@ -33,12 +33,14 @@ This should not be applied by hand.
 meta def can_lift_attr : user_attribute (list name) :=
 { name := "_can_lift",
   descr := "internal attribute used by the lift tactic",
-  cache_cfg := { mk_cache := λ _,
-    do { ls ← attribute.get_instances `instance,
-        ls.mfilter $ λ l,
-        do { (_,t) ← mk_const l >>= infer_type >>= open_pis,
-         return $ t.is_app_of `can_lift } },
-  dependencies := [`instance] } }
+  parser := failed,
+  cache_cfg := {
+    mk_cache := λ _,
+      do { ls ← attribute.get_instances `instance,
+          ls.mfilter $ λ l,
+          do { (_,t) ← mk_const l >>= infer_type >>= open_pis,
+          return $ t.is_app_of `can_lift } },
+    dependencies := [`instance] } }
 
 instance : can_lift ℤ ℕ :=
 ⟨coe, λ n, 0 ≤ n, λ n hn, ⟨n.nat_abs, int.nat_abs_of_nonneg hn⟩⟩

--- a/src/tactic/localized.lean
+++ b/src/tactic/localized.lean
@@ -23,9 +23,9 @@ open lean lean.parser interactive tactic native
 meta def localized_attr : user_attribute (rb_lmap name string) unit := {
   name := "_localized",
   descr := "(interal) attribute that flags localized commands",
+  parser := failed,
   cache_cfg := ⟨λ ns, (do dcls ← ns.mmap (λ n, mk_const n >>= eval_expr (name × string)),
-                          return $ rb_lmap.of_list dcls), []⟩
-}
+                          return $ rb_lmap.of_list dcls), []⟩ }
 
 /-- Get all commands in the given locale and return them as a list of strings -/
 meta def get_localized (ns : list name) : tactic (list string) :=

--- a/src/tactic/simps.lean
+++ b/src/tactic/simps.lean
@@ -102,7 +102,7 @@ used by the `@[simps]` attribute.
   user_attribute unit (list name × list projection_data) :=
 { name := `_simps_str,
   descr := "An attribute specifying the projection of the given structure.",
-  parser := do e ← texpr, eval_pexpr _ e }
+  parser := failed }
 
 /--
   The `@[notation_class]` attribute specifies that this is a notation class,


### PR DESCRIPTION
I saw this trick in some of the other user attributes, and it seems like a good idea to apply generally. Any attribute that is "internal use only" should have its `parser` field set to `failed`, so that it is impossible for the user to write the attribute. It is still possible for meta code to set the attributes programmatically, which is generally what's happening anyway.