### PR TITLE
[Merged by Bors] - chore(data/option,data/set): a few lemmas, golf

### DIFF
--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -415,13 +415,6 @@ by cases o; refl
   get_or_else (o.map f) (f x) = f (get_or_else o x) :=
 by cases o; refl
 
-/-- `option α` is a `subsingleton` if and only if `α` is empty. -/
-lemma subsingleton_iff_is_empty : subsingleton (option α) ↔ is_empty α :=
-⟨λ h, ⟨λ x, some_ne_none x $ @subsingleton.elim _ h _ _⟩,
-  λ h, ⟨λ x y, option.cases_on x (option.cases_on y rfl (λ x, h.elim x)) (λ x, h.elim x)⟩⟩
-
-instance [is_empty α] : subsingleton (option α) := subsingleton_iff_is_empty.2 ‹_›
-
 section
 open_locale classical
 

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -415,6 +415,13 @@ by cases o; refl
   get_or_else (o.map f) (f x) = f (get_or_else o x) :=
 by cases o; refl
 
+/-- `option α` is a `subsingleton` if and only if `α` is empty. -/
+lemma subsingleton_iff_is_empty : subsingleton (option α) ↔ is_empty α :=
+⟨λ h, ⟨λ x, some_ne_none x $ @subsingleton.elim _ h _ _⟩,
+  λ h, ⟨λ x y, option.cases_on x (option.cases_on y rfl (λ x, h.elim x)) (λ x, h.elim x)⟩⟩
+
+instance [is_empty α] : subsingleton (option α) := subsingleton_iff_is_empty.2 ‹_›
+
 section
 open_locale classical
 
@@ -439,11 +446,10 @@ lemma choice_is_some_iff_nonempty {α : Type*} : (choice α).is_some ↔ nonempt
 begin
   fsplit,
   { intro h, exact ⟨option.get h⟩, },
-  { rintro ⟨a⟩,
-    dsimp [choice],
-    rw dif_pos,
-    fsplit,
-    exact ⟨a⟩, },
+  { intro h,
+    dsimp only [choice],
+    rw dif_pos h,
+    exact is_some_some },
 end
 
 end

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1854,6 +1854,21 @@ lemma left_inverse_range_splitting (f : α → β) :
 lemma range_splitting_injective (f : α → β) : injective (range_splitting f) :=
 (left_inverse_range_splitting f).injective
 
+lemma is_compl_range_some_none (α : Type*) :
+  is_compl (range (some : α → option α)) {none} :=
+⟨λ x ⟨⟨a, ha⟩, (hn : x = none)⟩, option.some_ne_none _ (ha.trans hn),
+  λ x hx, option.cases_on x (or.inr rfl) (λ x, or.inl $ mem_range_self _)⟩
+
+@[simp] lemma compl_range_some (α : Type*) :
+  (range (some : α → option α))ᶜ = {none} :=
+(is_compl_range_some_none α).compl_eq
+
+@[simp] lemma range_some_inter_none (α : Type*) : range (some : α → option α) ∩ {none} = ∅ :=
+(is_compl_range_some_none α).inf_eq_bot
+
+@[simp] lemma range_some_union_none (α : Type*) : range (some : α → option α) ∪ {none} = univ :=
+(is_compl_range_some_none α).sup_eq_top
+
 end range
 
 /-- The set `s` is pairwise `r` if `r x y` for all *distinct* `x y ∈ s`. -/
@@ -1878,27 +1893,10 @@ theorem pairwise_on.mono {s t : set α} {r}
 theorem pairwise_on.mono' {s : set α} {r r' : α → α → Prop}
   (H : r ≤ r') (hp : pairwise_on s r) : pairwise_on s r' :=
 hp.imp H
+
 theorem pairwise_on_top (s : set α) :
   pairwise_on s ⊤ :=
 pairwise_on_of_forall s _ (λ a b, trivial)
-
-/-- If and only if `f` takes pairwise equal values on `s`, there is
-some value it takes everywhere on `s`. -/
-lemma pairwise_on_eq_iff_exists_eq [nonempty β] (s : set α) (f : α → β) :
-  (pairwise_on s (λ x y, f x = f y)) ↔ ∃ z, ∀ x ∈ s, f x = z :=
-begin
-  split,
-  { intro h,
-    rcases eq_empty_or_nonempty s with rfl | ⟨x, hx⟩,
-    { exact ⟨classical.arbitrary β, λ x hx, false.elim hx⟩ },
-    { use f x,
-      intros y hy,
-      by_cases hyx : y = x,
-      { rw hyx },
-      { exact h y hy x hx hyx } } },
-  { rintros ⟨z, hz⟩ x hx y hy hne,
-    rw [hz x hx, hz y hy] }
-end
 
 protected lemma subsingleton.pairwise_on (h : s.subsingleton) (r : α → α → Prop) :
   pairwise_on s r :=
@@ -1911,6 +1909,35 @@ subsingleton_empty.pairwise_on r
 @[simp] lemma pairwise_on_singleton (a : α) (r : α → α → Prop) :
   pairwise_on {a} r :=
 subsingleton_singleton.pairwise_on r
+
+/-- For a nonempty set `s`, a function `f` takes pairwise equal values on `s` if and only if
+for some `z` in the codomain, `f` takes value `z` on all `x ∈ s`. See also
+`set.pairwise_on_eq_iff_exists_eq` for a version that assumes `[nonempty β]` instead of
+`set.nonempty s`. -/
+theorem nonempty.pairwise_on_eq_iff_exists_eq {s : set α} (hs : s.nonempty) {f : α → β} :
+  (pairwise_on s (λ x y, f x = f y)) ↔ ∃ z, ∀ x ∈ s, f x = z :=
+begin
+  fsplit,
+  { rcases hs with ⟨y, hy⟩,
+    refine λ H, ⟨f y, λ x hx, _⟩,
+    rcases eq_or_ne x y with rfl|hne,
+    { refl },
+    { exact H _ hx _ hy hne } },
+  { rintro ⟨z, hz⟩ x hx y hy hne,
+    exact (hz _ hx).trans (hz _ hy).symm }
+end
+
+/-- A function `f : α → β` with nonempty codomain takes pairwise equal values on a set `s` if and
+only if for some `z` in the codomain, `f` takes value `z` on all `x ∈ s`. See also
+`set.nonempty.pairwise_on_eq_iff_exists_eq` for a version that assumes `set.nonempty s` instead of
+`[nonempty β]`. -/
+lemma pairwise_on_eq_iff_exists_eq [nonempty β] (s : set α) (f : α → β) :
+  (pairwise_on s (λ x y, f x = f y)) ↔ ∃ z, ∀ x ∈ s, f x = z :=
+begin
+  rcases s.eq_empty_or_nonempty with rfl|hne,
+  { simp },
+  { exact hne.pairwise_on_eq_iff_exists_eq }
+end
 
 lemma pairwise_on_insert_of_symmetric {α} {s : set α} {a : α} {r : α → α → Prop}
   (hr : symmetric r) :

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -37,6 +37,8 @@ lemma reflexive_ne_imp_iff [is_refl α r] {x y : α} :
   (x ≠ y → r x y) ↔ r x y :=
 is_refl.reflexive.ne_imp_iff
 
+protected lemma symmetric.iff (H : symmetric r) (x y : α) : r x y ↔ r y x := ⟨λ h, H h, λ h, H h⟩
+
 end ne_imp
 
 section comap

--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -162,6 +162,17 @@ protected def injective.unique [inhabited α] [subsingleton β] (hf : injective 
 
 end function
 
+namespace option
+
+/-- `option α` is a `subsingleton` if and only if `α` is empty. -/
+lemma subsingleton_iff_is_empty {α} : subsingleton (option α) ↔ is_empty α :=
+⟨λ h, ⟨λ x, option.no_confusion $ @subsingleton.elim _ h x none⟩,
+  λ h, ⟨λ x y, option.cases_on x (option.cases_on y rfl (λ x, h.elim x)) (λ x, h.elim x)⟩⟩
+
+instance {α} [is_empty α] : unique (option α) := @unique.mk' _ _ (subsingleton_iff_is_empty.2 ‹_›)
+
+end option
+
 section subtype
 
 instance unique.subtype_eq (y : α) : unique {x // x = y} :=


### PR DESCRIPTION
* add `option.subsingleton_iff_is_empty` and an instance
  `option.unique`;
* add `set.is_compl_range_some_none`, `set.compl_range_some`,
  `set.range_some_inter_none`, `set.range_some_union_none`;
* split the proof of `set.pairwise_on_eq_iff_exists_eq` into
  `set.nonempty.pairwise_on_eq_iff_exists_eq` and
  `set.pairwise_on_eq_iff_exists_eq`.

Inspired by #8579

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
