### PR TITLE
[Merged by Bors] - feat(analysis/complex/isometry): Show that certain complex isometries are not equal

### DIFF
--- a/src/analysis/complex/isometry.lean
+++ b/src/analysis/complex/isometry.lean
@@ -71,6 +71,8 @@ begin
     simp [this], },
 end
 
+/-- Takes an element of `ℂ ≃ₗᵢ[ℝ] ℂ` and checks if it is a rotation, returns an element of the
+unit circle. -/
 @[simps]
 def rotation_of (e : ℂ ≃ₗᵢ[ℝ] ℂ) : circle :=
 ⟨(e 1) / complex.abs (e 1), by simp⟩

--- a/src/analysis/complex/isometry.lean
+++ b/src/analysis/complex/isometry.lean
@@ -56,19 +56,12 @@ congr_arg _ h
 
 lemma rotation_ne_conj_lie (a : circle) : rotation a ≠ conj_lie :=
 begin
-  intros h,
-  by_cases hu: (a:ℂ).re = -1,
-  { have := linear_isometry_equiv.congr_fun h 1,
-    simp only [rotation_apply, ne.def, conj_lie_apply, mul_one, ring_hom.map_one] at this,
-    rw [this, one_re] at hu,
-    linarith, },
-  { have : rotation a I = conj_lie I,
-    { rw h, },
-    apply hu,
-    have : (a : ℂ) * I = -1 * I,
-    { simpa using this, },
-    rw mul_left_inj' I_ne_zero at this,
-    simp [this], },
+  intro h,
+  have h1 : rotation a 1 = conj 1 := linear_isometry_equiv.congr_fun h 1,
+  have hI : rotation a I = conj I := linear_isometry_equiv.congr_fun h I,
+  rw [rotation_apply, ring_hom.map_one, mul_one] at h1,
+  rw [rotation_apply, conj_I, ← neg_one_mul, mul_left_inj' I_ne_zero, h1, eq_neg_self_iff] at hI,
+  exact one_ne_zero hI,
 end
 
 /-- Takes an element of `ℂ ≃ₗᵢ[ℝ] ℂ` and checks if it is a rotation, returns an element of the

--- a/src/analysis/complex/isometry.lean
+++ b/src/analysis/complex/isometry.lean
@@ -49,6 +49,32 @@ def rotation : circle →* (ℂ ≃ₗᵢ[ℝ] ℂ) :=
 
 @[simp] lemma rotation_apply (a : circle) (z : ℂ) : rotation a z = a * z := rfl
 
+lemma reflection_rotation (a : circle) : rotation a ≠ conj_lie :=
+begin
+  intros h,
+  by_cases hu: (a:ℂ).re = -1,
+  { have : rotation a 1 = conj_lie 1,
+    { rw h, },
+    simp only [rotation_apply, ne.def, conj_lie_apply, mul_one, ring_hom.map_one] at this,
+    rw [this, one_re] at hu,
+    linarith, },
+  { have : rotation a I = conj_lie I,
+    { rw h, },
+    apply hu,
+    have : (a : ℂ) * I = -1 * I,
+    { simpa using this, },
+    rw mul_left_inj' I_ne_zero at this,
+    simp [this], },
+end
+
+lemma rotation_injective : function.injective rotation :=
+begin
+  intros a b h,
+  suffices : rotation a 1 = rotation b 1,
+  { simpa using this, },
+  { rw h, },
+end
+
 lemma linear_isometry.re_apply_eq_re_of_add_conj_eq (f : ℂ →ₗᵢ[ℝ] ℂ)
   (h₃ : ∀ z, z + conj z = f z + conj (f z)) (z : ℂ) : (f z).re = z.re :=
 by simpa [ext_iff, add_re, add_im, conj_re, conj_im, ←two_mul,

--- a/src/analysis/complex/isometry.lean
+++ b/src/analysis/complex/isometry.lean
@@ -49,12 +49,16 @@ def rotation : circle →* (ℂ ≃ₗᵢ[ℝ] ℂ) :=
 
 @[simp] lemma rotation_apply (a : circle) (z : ℂ) : rotation a z = a * z := rfl
 
-lemma reflection_rotation (a : circle) : rotation a ≠ conj_lie :=
+lemma linear_isometry_equiv.congr_fun {R E F}
+  [semiring R] [semi_normed_group E] [semi_normed_group F] [module R E] [module R F]
+  {f g : E ≃ₗᵢ[R] F} (h : f = g) (x : E) : f x = g x :=
+congr_arg _ h
+
+lemma rotation_ne_conj_lie (a : circle) : rotation a ≠ conj_lie :=
 begin
   intros h,
   by_cases hu: (a:ℂ).re = -1,
-  { have : rotation a 1 = conj_lie 1,
-    { rw h, },
+  { have := linear_isometry_equiv.congr_fun h 1,
     simp only [rotation_apply, ne.def, conj_lie_apply, mul_one, ring_hom.map_one] at this,
     rw [this, one_re] at hu,
     linarith, },
@@ -67,13 +71,16 @@ begin
     simp [this], },
 end
 
+@[simps]
+def rotation_of (e : ℂ ≃ₗᵢ[ℝ] ℂ) : circle :=
+⟨(e 1) / complex.abs (e 1), by simp⟩
+
+@[simp]
+lemma rotation_of_rotation (a : circle) : rotation_of (rotation a) = a :=
+subtype.ext $ by simp
+
 lemma rotation_injective : function.injective rotation :=
-begin
-  intros a b h,
-  suffices : rotation a 1 = rotation b 1,
-  { simpa using this, },
-  { rw h, },
-end
+function.left_inverse.injective rotation_of_rotation
 
 lemma linear_isometry.re_apply_eq_re_of_add_conj_eq (f : ℂ →ₗᵢ[ℝ] ℂ)
   (h₃ : ∀ z, z + conj z = f z + conj (f z)) (z : ℂ) : (f z).re = z.re :=


### PR DESCRIPTION
1. Lemma `reflection_rotation` proves that rotation by `(a : circle)` is not equal to reflection over the x-axis (i.e, `conj_lie`).  
2. Lemma `rotation_injective` proves that rotation by different `(a b: circle)` are not the same,(i.e, `rotation` is injective).
Co-authored by Kyle Miller
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
