### PR TITLE
[Merged by Bors] - fix(tactic/core): mk_simp_attribute: remove superfluous disjunct

### DIFF
--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -2313,7 +2313,7 @@ do n ← ident,
    d ← parser.pexpr,
    d ← to_expr ``(%%d : option string),
    descr ← eval_expr (option string) d,
-   with_list ← types.with_ident_list <|> return [],
+   with_list ← types.with_ident_list,
    mk_simp_attr n with_list,
    add_doc_string (name.append `simp_attr n) $ descr.get_or_else $ "simp set for " ++ to_string n
 


### PR DESCRIPTION
`with_ident_list` already returns `[]` if `with` is not present.