### PR TITLE
[Merged by Bors] - fix(tactic/norm_cast): assumption_mod_cast should only work on one goal

### DIFF
--- a/src/tactic/norm_cast.lean
+++ b/src/tactic/norm_cast.lean
@@ -583,7 +583,7 @@ decorate_error "assumption_mod_cast failed:" $ do
   },
   replace_at derive [] tt,
   ctx ← local_context,
-  try_lst $ ctx.map (λ h, aux_mod_cast h ff >>= tactic.exact)
+  ctx.mfirst (λ h, aux_mod_cast h ff >>= tactic.exact)
 
 end tactic
 

--- a/test/norm_cast.lean
+++ b/test/norm_cast.lean
@@ -126,3 +126,10 @@ begin
 end
 
 end ennreal
+
+lemma b (h g : true) : true ∧ true :=
+begin
+ split,
+ assumption_mod_cast,
+ assumption_mod_cast,
+end


### PR DESCRIPTION
fixes #8438 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
