### PR TITLE
[Merged by Bors] - fix(tactic/core): fix incorrect uses of with_ident_list

### DIFF
--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -2313,7 +2313,7 @@ do n ← ident,
    d ← parser.pexpr,
    d ← to_expr ``(%%d : option string),
    descr ← eval_expr (option string) d,
-   with_list ← types.with_ident_list,
+   with_list ← (tk "with" *> many ident) <|> return [],
    mk_simp_attr n with_list,
    add_doc_string (name.append `simp_attr n) $ descr.get_or_else $ "simp set for " ++ to_string n
 

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -931,12 +931,12 @@ end
 
 -/
 meta def extract_goal (print_use : parse $ tt <$ tk "!" <|> pure ff)
-  (n : parse ident?) (vs : parse with_ident_list)
+  (n : parse ident?) (vs : parse (tk "with" *> ident*)?)
   : tactic unit :=
 do tgt ← target,
    solve_aux tgt $ do {
      ((cxt₀,cxt₁,ls,tgt),_) ← solve_aux tgt $ do {
-         when (¬ vs.empty) (clear_except vs),
+         vs.mmap clear_except,
          ls ← local_context,
          ls ← ls.mfilter $ succeeds ∘ is_local_def,
          n ← revert_lst ls,


### PR DESCRIPTION
`with_ident_list` uses `tk "with" >> ident_*`, which is incorrect for some tactics, where `_` doesn't mean anything. (It is good for tactics that name hypotheses like `cases`, but not tactics that use the list to reference hypotheses like `revert_deps`.)