### PR TITLE
[Merged by Bors] - feat(field_theory): more general `algebra _ (algebraic_closure k)` instance

### DIFF
--- a/src/field_theory/algebraic_closure.lean
+++ b/src/field_theory/algebraic_closure.lean
@@ -323,8 +323,20 @@ end
 instance : is_alg_closed (algebraic_closure k) :=
 is_alg_closed.of_exists_root _ $ λ f, exists_root k
 
-instance : algebra k (algebraic_closure k) :=
-(of_step k 0).to_algebra
+instance {R : Type*} [comm_semiring R] [alg : algebra R k] :
+  algebra R (algebraic_closure k) :=
+((of_step k 0).comp (@algebra_map _ _ _ _ alg)).to_algebra
+
+lemma algebra_map_def {R : Type*} [comm_semiring R] [alg : algebra R k] :
+  algebra_map R (algebraic_closure k) = ((of_step k 0 : k →+* _).comp (@algebra_map _ _ _ _ alg)) :=
+rfl
+
+instance {R S : Type*} [comm_semiring R] [comm_semiring S]
+  [algebra R S] [algebra S k] [algebra R k] [is_scalar_tower R S k] :
+  is_scalar_tower R S (algebraic_closure k) :=
+is_scalar_tower.of_algebra_map_eq (λ x, by rw [algebra_map_def, algebra_map_def,
+  ring_hom.comp_apply, ring_hom.comp_apply,
+  is_scalar_tower.algebra_map_apply R S k])
 
 /-- Canonical algebra embedding from the `n`th step to the algebraic closure. -/
 def of_step_hom (n) : step k n →ₐ[k] algebraic_closure k :=

--- a/src/field_theory/algebraic_closure.lean
+++ b/src/field_theory/algebraic_closure.lean
@@ -334,9 +334,8 @@ rfl
 instance {R S : Type*} [comm_semiring R] [comm_semiring S]
   [algebra R S] [algebra S k] [algebra R k] [is_scalar_tower R S k] :
   is_scalar_tower R S (algebraic_closure k) :=
-is_scalar_tower.of_algebra_map_eq (λ x, by rw [algebra_map_def, algebra_map_def,
-  ring_hom.comp_apply, ring_hom.comp_apply,
-  is_scalar_tower.algebra_map_apply R S k])
+is_scalar_tower.of_algebra_map_eq (λ x,
+  ring_hom.congr_arg _ (is_scalar_tower.algebra_map_apply R S k x : _))
 
 /-- Canonical algebra embedding from the `n`th step to the algebraic closure. -/
 def of_step_hom (n) : step k n →ₐ[k] algebraic_closure k :=


### PR DESCRIPTION
For example, now we can take a field extension `L / K` and map `x : K` into the algebraic closure of `L`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
