### PR TITLE
[Merged by Bors] - feat(data/complex/exponential): bound on exp for arbitrary arguments

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -781,11 +781,8 @@ lemma prod_range_add_div_prod_range {α : Type*} [comm_group α] (f : ℕ → α
   (n m : ℕ) : (∏ k in range (n + m), f k ) / (∏ k in range n, f k) =
   ∏ k in finset.range m, f (n + k) :=
 begin
-  rw (prod_range_add f n m),
-  rw div_eq_mul_inv,
-  rw mul_comm,
-  rw ←mul_assoc,
-  simp only [one_mul, eq_self_iff_true, mul_left_inv],
+  rw [prod_range_add f n m, div_eq_mul_inv],
+  simp,
 end
 
 

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -777,9 +777,8 @@ begin
 end
 
 @[to_additive]
-lemma prod_range_add_div_prod_range {α : Type*} [comm_group α] (f : ℕ → α)
-  (n m : ℕ) : (∏ k in range (n + m), f k ) / (∏ k in range n, f k) =
-  ∏ k in finset.range m, f (n + k) :=
+lemma prod_range_add_div_prod_range {α : Type*} [comm_group α] (f : ℕ → α) (n m : ℕ) :
+  (∏ k in range (n + m), f k) / (∏ k in range n, f k) = ∏ k in finset.range m, f (n + k) :=
 div_eq_of_eq_mul' (prod_range_add f n m)
 
 

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -777,6 +777,19 @@ begin
 end
 
 @[to_additive]
+lemma prod_range_add_div_prod_range {α : Type*} [comm_group α] (f : ℕ → α)
+  (n m : ℕ) : (∏ k in range (n + m), f k ) / (∏ k in range n, f k) =
+  ∏ k in finset.range m, f (n + k) :=
+begin
+  rw (prod_range_add f n m),
+  rw div_eq_mul_inv,
+  rw mul_comm,
+  rw ←mul_assoc,
+  simp only [one_mul, eq_self_iff_true, mul_left_inv],
+end
+
+
+@[to_additive]
 lemma prod_range_zero (f : ℕ → β) :
   ∏ k in range 0, f k = 1 :=
 by rw [range_zero, prod_empty]

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -780,7 +780,7 @@ end
 lemma prod_range_add_div_prod_range {α : Type*} [comm_group α] (f : ℕ → α)
   (n m : ℕ) : (∏ k in range (n + m), f k ) / (∏ k in range n, f k) =
   ∏ k in finset.range m, f (n + k) :=
-div_eq_of_eq_mul' (prod_range_add f n m)
+div_eq_of_eq_mul' _ _ _ (prod_range_add f n m)
 
 
 @[to_additive]

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -780,7 +780,7 @@ end
 lemma prod_range_add_div_prod_range {α : Type*} [comm_group α] (f : ℕ → α)
   (n m : ℕ) : (∏ k in range (n + m), f k ) / (∏ k in range n, f k) =
   ∏ k in finset.range m, f (n + k) :=
-div_eq_of_eq_mul' _ _ _ (prod_range_add f n m)
+div_eq_of_eq_mul' (prod_range_add f n m)
 
 
 @[to_additive]

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -780,10 +780,7 @@ end
 lemma prod_range_add_div_prod_range {α : Type*} [comm_group α] (f : ℕ → α)
   (n m : ℕ) : (∏ k in range (n + m), f k ) / (∏ k in range n, f k) =
   ∏ k in finset.range m, f (n + k) :=
-begin
-  rw [prod_range_add f n m, div_eq_mul_inv],
-  simp,
-end
+div_eq_of_eq_mul' (prod_range_add f n m)
 
 
 @[to_additive]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -445,7 +445,7 @@ by rw [mul_inv_rev, mul_comm]
 
 @[to_additive]
 lemma div_eq_of_eq_mul' {a b c : G} (h : a = b * c) : a / b = c :=
-begin simp only [h, mul_comm, div_eq_mul_inv, mul_left_comm], rw [mul_left_comm], simp end
+by rw [h, div_eq_mul_inv, mul_comm, inv_mul_cancel_left]
 
 end comm_group
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -444,7 +444,7 @@ lemma mul_inv (a b : G) : (a * b)⁻¹ = a⁻¹ * b⁻¹ :=
 by rw [mul_inv_rev, mul_comm]
 
 @[to_additive]
-lemma div_eq_of_eq_mul' (a b c : G) (h : a = b * c) : a / b = c :=
+lemma div_eq_of_eq_mul' {a b c : G} (h : a = b * c) : a / b = c :=
 begin simp only [h, mul_comm, div_eq_mul_inv, mul_left_comm], rw [mul_left_comm], simp end
 
 end comm_group

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -332,6 +332,8 @@ calc  a / 1 = a * 1⁻¹ : div_eq_mul_inv a 1
 end group
 
 section add_group
+-- TODO: Generalize the contents of this section with to_additive as per
+-- https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.238667
 variables {G : Type u} [add_group G] {a b c d : G}
 
 @[simp] lemma sub_self (a : G) : a - a = 0 :=
@@ -448,6 +450,8 @@ begin simp only [h, mul_comm, div_eq_mul_inv, mul_left_comm], rw [mul_left_comm]
 end comm_group
 
 section add_comm_group
+-- TODO: Generalize the contents of this section with to_additive as per
+-- https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.238667
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -441,6 +441,10 @@ variables {G : Type u} [comm_group G]
 lemma mul_inv (a b : G) : (a * b)⁻¹ = a⁻¹ * b⁻¹ :=
 by rw [mul_inv_rev, mul_comm]
 
+@[to_additive]
+lemma div_eq_of_eq_mul' (a b c : G) (h : a = b * c) : a / b = c :=
+begin simp only [h, mul_comm, div_eq_mul_inv, mul_left_comm], rw [mul_left_comm], simp end
+
 end comm_group
 
 section add_comm_group
@@ -468,9 +472,6 @@ by simp
 
 lemma eq_sub_of_add_eq' (h : c + a = b) : a = b - c :=
 by simp [h.symm]
-
-lemma sub_eq_of_eq_add' (h : a = b + c) : a - b = c :=
-begin simp [h], rw [add_left_comm], simp end
 
 lemma eq_add_of_sub_eq' (h : a - b = c) : a = b + c :=
 by simp [h.symm]

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -227,14 +227,8 @@ lemma sum_range_add_sub_sum_range {α : Type*} [add_comm_group α] {f : ℕ → 
   {n m : ℕ} : ∑ k in range (n + m), f k - ∑ k in range n, f k =
   ∑ k in finset.range m, f (n + k) :=
 begin
-  sorry,
-  -- rw [← sum_sdiff (@filter_subset _ (λ k, n ≤ k) _ (range m)),
-  --   sub_eq_iff_eq_add, ← eq_sub_iff_add_eq, add_sub_cancel'],
-  -- refine finset.sum_congr
-  --   (finset.ext $ λ a, ⟨λ h, by simp at *; finish,
-  --   λ h, have ham : a < m := lt_of_lt_of_le (mem_range.1 h) hnm,
-  --     by simp * at *⟩)
-  --   (λ _ _, rfl),
+  rw sum_range_add,
+  simp only [add_sub_cancel', eq_self_iff_true],
 end
 
 end

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1290,6 +1290,155 @@ begin
     mul_le_mul_of_nonneg_left (sum_div_factorial_le _ _ hn) (pow_nonneg (abs_nonneg _) _)
 end
 
+
+
+lemma sum_half_geometric (j : ℕ) : ∑ (x : ℕ) in (range j), ((1:ℝ) / 2) ^ (x) = 2 - 2 * ((1 : ℝ)/2)^(j) :=
+begin
+  induction j,
+    {simp,},
+    {
+      rw finset.sum_range_succ,
+      rw j_ih,
+      rw pow_succ,
+      simp only [one_div, inv_pow', mul_inv_cancel_left'],
+      rw <-mul_assoc,
+      simp only [one_mul, mul_inv_cancel],
+      ring_nf,
+      -- TODO why does sub_add_assoc not exist?
+
+    },
+end
+
+lemma sum_half_geometric' (j n : ℕ) (h : n ≤ j) : ∑ (x : ℕ) in filter (λ (k : ℕ), n ≤ k) (range j), ((1 : ℝ) / 2) ^ (x - n) ≤ (2 : ℝ) :=
+begin
+  calc ∑ (x : ℕ) in filter (λ (k : ℕ), n ≤ k) (range j), ((1 : ℝ)/ 2) ^ (x - n)
+      = ∑ (x : ℕ) in (range (j - n)), ((1 : ℝ)/ 2) ^ (x) :
+        begin
+          rw range_eq_Ico,
+          -- rw range_eq_Ico,
+          rw Ico.filter_le_of_le (nat.zero_le n),
+          rw finset.sum_Ico_eq_sum_range,
+          congr,
+          funext,
+          congr,
+          exact norm_num.sub_nat_pos (n + k) n k rfl,
+        end
+  ... = 2 - 2 * ((1 : ℝ)/2)^(j-n) :
+        begin
+          exact sum_half_geometric (j - n),
+        end
+  ... ≤ 2 :
+        begin
+          simp only [one_div, sub_le_self_iff, inv_nonneg, inv_pow', pow_nonneg],
+          apply mul_nonneg,
+          linarith,
+          apply inv_nonneg.2,
+          apply pow_nonneg,
+          linarith,
+        end
+end
+
+lemma exp_bound' {x : ℂ} {n : ℕ} (hn : 0 < n) (hx : abs x ≤ n / 2) :
+  abs (exp x - ∑ m in range n, x ^ m / m!) ≤ 2 * abs x ^ n * (n!)⁻¹ :=
+begin
+  rw [← lim_const (∑ m in range n, _), exp, sub_eq_add_neg, ← lim_neg, lim_add, ← lim_abs],
+  refine lim_le (cau_seq.le_of_exists ⟨n, λ j hj, _⟩),
+  simp_rw ← sub_eq_add_neg,
+  show abs (∑ m in range j, x ^ m / m! - ∑ m in range n, x ^ m / m!)
+    ≤ 2 * abs x ^ n * (n!)⁻¹,
+  rw sum_range_sub_sum_range hj,
+  exact calc abs (∑ m in (range j).filter (λ k, n ≤ k), (x ^ m / m! : ℂ))
+      = abs (∑ m in (range j).filter (λ k, n ≤ k), (x ^ n * (x ^ (m - n) / m!) : ℂ)) :
+    begin
+      refine congr_arg abs (sum_congr rfl (λ m hm, _)),
+      rw [mem_filter, mem_range] at hm,
+      rw [← mul_div_assoc, ← pow_add, nat.add_sub_cancel' hm.2]
+    end
+  ... ≤ ∑ m in filter (λ k, n ≤ k) (range j), abs (x ^ n * (_ / m!)) : abv_sum_le_sum_abv _ _
+  ... ≤ ∑ m in filter (λ k, n ≤ k) (range j), abs x ^ n * ((((1 : ℝ)/2) ^ (m - n)) / n!) :
+    begin
+      refine sum_le_sum (λ m hm, _),
+      rw [abs_mul, abv_pow abs, abs_div, abs_cast_nat],
+      apply mul_le_mul_of_nonneg_left,
+      apply (div_le_div_iff _ _).2,
+      rw abv_pow abs,
+      rw mem_filter at hm,
+      apply (div_le_iff' _).1,
+      rw mul_div_right_comm,
+      rw <-div_pow,
+      -- simp only [one_div, div_pow, inv_pow'],
+      rw div_eq_inv_mul,
+      -- rw field.inv_inv,
+      calc ((1 / 2)⁻¹ * abs x) ^ (m - n) * ↑n!
+          ≤ (n) ^ (m - n) * ↑n! :
+            begin
+              apply mul_le_mul,
+              apply pow_le_pow_of_le_left,
+              apply mul_nonneg,
+              simp only [one_div, zero_le_one, inv_inv', zero_le_bit0],
+              exact abs_nonneg x,
+              apply (inv_mul_le_iff' _).2,
+              rw mul_one_div,
+              exact hx,
+              simp only [one_div, zero_lt_bit0, zero_lt_one, inv_pos],
+              simp only [nat.cast_nonneg],
+              apply pow_nonneg,
+              simp only [nat.cast_nonneg],
+            end
+      ... ≤ ↑m! :
+            begin
+              rw <-nat.cast_pow,
+              rw <-nat.cast_mul,
+              apply nat.cast_le.2,
+              --   by library_search,
+              apply nat.pow_mul_factorial_le_factorial,
+              exact hm.right,
+              exact real.nontrivial,
+            end,
+
+      apply pow_pos,
+      simp only [one_div, zero_lt_bit0, zero_lt_one, inv_pos],
+
+
+      simp only [nat.cast_pos],
+      exact nat.factorial_pos m,
+      simp only [nat.cast_pos],
+      exact nat.factorial_pos n,
+      apply pow_nonneg,
+      exact abs_nonneg x,
+
+      -- refine mul_le_mul_of_nonneg_left ((div_le_div_right _).2 _) _,
+      -- exact nat.cast_pos.2 (nat.factorial_pos _),
+      -- rw abv_pow abs,
+      -- exact (pow_le_one _ (abs_nonneg _) hx),
+      -- exact pow_nonneg (abs_nonneg _) _
+    end
+  ... ≤ 2 * abs x ^ n * (↑n!)⁻¹ :
+    begin
+      rw <-mul_sum,
+      rw <-sum_div,
+      rw div_eq_mul_inv,
+      rw <-mul_assoc,
+      apply mul_le_mul,
+      rw mul_comm,
+      apply mul_le_mul,
+      apply sum_half_geometric',
+      exact hj,
+      exact le_refl (abs x ^ n),
+      apply pow_nonneg,
+      exact abs_nonneg x,
+      exact zero_le_two,
+      apply le_refl,
+      apply inv_nonneg.2,
+      exact n!.cast_nonneg,
+      apply mul_nonneg,
+      linarith,
+      apply pow_nonneg,
+      exact abs_nonneg x,
+
+    end,
+end
+
 lemma abs_exp_sub_one_le {x : ℂ} (hx : abs x ≤ 1) :
   abs (exp x - 1) ≤ 2 * abs x :=
 calc abs (exp x - 1) = abs (exp x - ∑ m in range 1, x ^ m / m!) :

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -223,8 +223,8 @@ begin
     (λ _ _, rfl),
 end
 
-lemma sum_range_add_sub_sum_range {α : Type*} [add_comm_group α] {f : ℕ → α}
-  {n m : ℕ} : ∑ k in range (n + m), f k - ∑ k in range n, f k =
+lemma sum_range_add_sub_sum_range {α : Type*} [add_comm_group α] (f : ℕ → α)
+  (n m : ℕ) : ∑ k in range (n + m), f k - ∑ k in range n, f k =
   ∑ k in finset.range m, f (n + k) :=
 begin
   rw sum_range_add,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -223,11 +223,6 @@ begin
     (λ _ _, rfl),
 end
 
-lemma sum_range_add_sub_sum_range {α : Type*} [add_comm_group α] (f : ℕ → α)
-  (n m : ℕ) : ∑ k in range (n + m), f k - ∑ k in range n, f k =
-  ∑ k in finset.range m, f (n + k) :=
-sub_eq_of_eq_add' (sum_range_add f n m)
-
 end
 
 section no_archimedean

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1287,10 +1287,10 @@ begin
       refine sum_le_sum (λ m hm, _),
       rw [abs_mul, abv_pow abs, abs_div, abs_cast_nat],
       refine mul_le_mul_of_nonneg_left ((div_le_div_right _).2 _) _,
-      exact nat.cast_pos.2 (nat.factorial_pos _),
-      rw abv_pow abs,
-      exact (pow_le_one _ (abs_nonneg _) hx),
-      exact pow_nonneg (abs_nonneg _) _
+      { exact nat.cast_pos.2 (nat.factorial_pos _),},
+      { rw abv_pow abs,
+        exact (pow_le_one _ (abs_nonneg _) hx),},
+      { exact pow_nonneg (abs_nonneg _) _},
     end
   ... = abs x ^ n * (∑ m in (range j).filter (λ k, n ≤ k), (1 / m! : ℝ)) :
     by simp [abs_mul, abv_pow abs, abs_div, mul_sum.symm]
@@ -1323,14 +1323,14 @@ begin
           begin
             refine sum_le_sum (λ m hm, _),
             apply div_le_div (pow_nonneg (abs_nonneg x) (n + m)) (le_refl _),
-            apply mul_pos,
-            rw nat.cast_pos,
-            exact nat.factorial_pos n,
-            apply pow_pos,
-            rw nat.cast_pos,
-            exact nat.succ_pos n,
-            rw [←nat.cast_pow, ←nat.cast_mul, nat.cast_le],
-            exact (nat.factorial_mul_pow_le_factorial),
+            { apply mul_pos,
+              { rw nat.cast_pos,
+                exact nat.factorial_pos n,},
+              { apply pow_pos,
+                rw nat.cast_pos,
+                exact nat.succ_pos n,},},
+            { rw [←nat.cast_pow, ←nat.cast_mul, nat.cast_le],
+              exact (nat.factorial_mul_pow_le_factorial),},
           end
   ... = ∑ (k : ℕ) in range k, (abs x) ^ (n) / (n!) * ((abs x)^k / n.succ ^ k) :
           begin
@@ -1343,15 +1343,17 @@ begin
           begin
             rw ←mul_sum,
             apply mul_le_mul_of_nonneg_left,
-            simp_rw [←div_pow],
-            rw [←geom_sum_def, geom_sum_eq, div_le_iff_of_neg],
-            transitivity (-1 : ℝ),
-            linarith,
-            simp only [neg_le_sub_iff_le_add, div_pow, nat.cast_succ, le_add_iff_nonneg_left],
-            apply div_nonneg (pow_nonneg (abs_nonneg x) k) (pow_nonneg (nat.cast_nonneg (n + 1)) k),
-            linarith,
-            linarith,
-            exact div_nonneg (pow_nonneg (abs_nonneg x) n) (nat.cast_nonneg (n!)),
+            { simp_rw [←div_pow],
+              rw [←geom_sum_def, geom_sum_eq, div_le_iff_of_neg],
+              { transitivity (-1 : ℝ),
+                { linarith,},
+                { simp only [neg_le_sub_iff_le_add, div_pow,
+                             nat.cast_succ, le_add_iff_nonneg_left],
+                  apply div_nonneg (pow_nonneg (abs_nonneg x) k)
+                                   (pow_nonneg (nat.cast_nonneg (n + 1)) k),},},
+              { linarith,},
+              { linarith,},},
+            { exact div_nonneg (pow_nonneg (abs_nonneg x) n) (nat.cast_nonneg (n!)),},
           end,
 end
 

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1322,6 +1322,7 @@ begin
 end
 
 
+
 lemma exp_bound' {x : ℂ} {n : ℕ} (hx : abs x ≤ n / 2) :
   abs (exp x - ∑ m in range n, x ^ m / m!) ≤ 2 * abs x ^ n * (n!)⁻¹ :=
 begin
@@ -1343,36 +1344,28 @@ begin
     begin
       refine sum_le_sum (λ m hm, _),
       rw [abs_mul, abv_pow abs, abs_div, abs_cast_nat],
-      apply mul_le_mul_of_nonneg_left,
+      apply mul_le_mul_of_nonneg_left _ (pow_nonneg (abs_nonneg x) n),
       rw [div_le_div_iff, abv_pow abs, <-div_le_iff',
-          mul_div_right_comm, <-div_pow, div_eq_inv_mul],
-      calc ((1 / 2)⁻¹ * abs x) ^ (m - n) * ↑n!
-          ≤ (n) ^ (m - n) * ↑n! :
-            begin
-              apply mul_le_mul_of_nonneg_right,
-              apply pow_le_pow_of_le_left,
-              apply mul_nonneg,
-              simp only [one_div, zero_le_one, inv_inv', zero_le_bit0],
-              exact abs_nonneg x,
-              rw [inv_mul_le_iff', mul_one_div],
-              exact hx,
-              linarith,
-              exact n!.cast_nonneg,
-            end
-      ... ≤ ↑m! :
-            begin
-              rw [<-nat.cast_pow, <-nat.cast_mul, nat.cast_le],
-              rw mem_filter at hm,
-              rw mul_comm,
-              exact nat.factorial_mul_pow_sub_le_factorial hm.right,
-            end,
+          mul_div_right_comm, <-div_pow, div_eq_inv_mul, one_div, inv_inv'],
+      rw mem_filter at hm,
+      rw mul_comm,
+      apply trans _ (nat.cast_le.2 (nat.factorial_mul_pow_sub_le_factorial hm.right)),
+      exact is_trans.swap (λ (x y : ℝ), y ≤ x),
+      simp only [nat.factorial, nat.cast_mul, nat.cast_pow],
+      apply mul_le_mul_of_nonneg_left,
+      apply pow_le_pow_of_le_left,
+      apply mul_nonneg,
+      linarith,
+      exact abs_nonneg x,
+      linarith,
+      exact n!.cast_nonneg,
+      exact real.nontrivial,
       apply pow_pos,
       linarith,
       rw nat.cast_pos,
       exact nat.factorial_pos m,
       rw nat.cast_pos,
       exact nat.factorial_pos n,
-      apply pow_nonneg (abs_nonneg x),
     end
   ... ≤ 2 * abs x ^ n * (↑n!)⁻¹ :
     begin

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1291,12 +1291,6 @@ begin
 end
 
 
--- TODO why does sub_add_assoc not exist?
--- TODO src/analysis/specific_limits sum_geometric_two_le accomplishes what we want here
--- Nevertheless, the more general algebra.geom_sum should be improved.
--- There exists a geom_sum_Ico there, why not an analogous geom_sum?
--- Perhaps because there is a definition by that name. I'm not sure why that exists.
-
 private lemma sum_geometric_half' (j n : ℕ) (h : n ≤ j) :
   ∑ (x : ℕ) in filter (λ (k : ℕ), n ≤ k) (range j), ((1 : ℝ) / 2) ^ (x - n) ≤ (2 : ℝ) :=
 begin
@@ -1350,43 +1344,34 @@ begin
       refine sum_le_sum (λ m hm, _),
       rw [abs_mul, abv_pow abs, abs_div, abs_cast_nat],
       apply mul_le_mul_of_nonneg_left,
-      apply (div_le_div_iff _ _).2,
-      rw abv_pow abs,
-      rw mem_filter at hm,
-      apply (div_le_iff' _).1,
-      rw [mul_div_right_comm, <-div_pow, div_eq_inv_mul],
+      rw [div_le_div_iff, abv_pow abs, <-div_le_iff',
+          mul_div_right_comm, <-div_pow, div_eq_inv_mul],
       calc ((1 / 2)⁻¹ * abs x) ^ (m - n) * ↑n!
           ≤ (n) ^ (m - n) * ↑n! :
             begin
-              apply mul_le_mul,
+              apply mul_le_mul_of_nonneg_right,
               apply pow_le_pow_of_le_left,
               apply mul_nonneg,
               simp only [one_div, zero_le_one, inv_inv', zero_le_bit0],
               exact abs_nonneg x,
-              apply (inv_mul_le_iff' _).2,
-              rw mul_one_div,
+              rw [inv_mul_le_iff', mul_one_div],
               exact hx,
-              simp only [one_div, zero_lt_bit0, zero_lt_one, inv_pos],
+              linarith,
               exact n!.cast_nonneg,
-              apply pow_nonneg (n.cast_nonneg),
             end
       ... ≤ ↑m! :
             begin
-              rw <-nat.cast_pow,
-              rw <-nat.cast_mul,
-              apply nat.cast_le.2,
-              apply nat.pow_mul_factorial_le_factorial,
-              exact hm.right,
-              exact real.nontrivial,
+              rw [<-nat.cast_pow, <-nat.cast_mul, nat.cast_le],
+              rw mem_filter at hm,
+              exact nat.pow_mul_factorial_le_factorial hm.right,
             end,
       apply pow_pos,
-      simp only [one_div, zero_lt_bit0, zero_lt_one, inv_pos],
-      simp only [nat.cast_pos],
+      linarith,
+      rw nat.cast_pos,
       exact nat.factorial_pos m,
-      simp only [nat.cast_pos],
+      rw nat.cast_pos,
       exact nat.factorial_pos n,
-      apply pow_nonneg,
-      exact abs_nonneg x,
+      apply pow_nonneg (abs_nonneg x),
     end
   ... ≤ 2 * abs x ^ n * (↑n!)⁻¹ :
     begin

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1280,10 +1280,10 @@ begin
       refine sum_le_sum (λ m hm, _),
       rw [abs_mul, abv_pow abs, abs_div, abs_cast_nat],
       refine mul_le_mul_of_nonneg_left ((div_le_div_right _).2 _) _,
-      { exact nat.cast_pos.2 (nat.factorial_pos _),},
+      { exact nat.cast_pos.2 (nat.factorial_pos _), },
       { rw abv_pow abs,
-        exact (pow_le_one _ (abs_nonneg _) hx),},
-      { exact pow_nonneg (abs_nonneg _) _},
+        exact (pow_le_one _ (abs_nonneg _) hx), },
+      { exact pow_nonneg (abs_nonneg _) _ },
     end
   ... = abs x ^ n * (∑ m in (range j).filter (λ k, n ≤ k), (1 / m! : ℝ)) :
     by simp [abs_mul, abv_pow abs, abs_div, mul_sum.symm]

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1291,42 +1291,30 @@ begin
 end
 
 
-
-lemma sum_half_geometric (j : ℕ) : ∑ (x : ℕ) in (range j), ((1:ℝ) / 2) ^ (x) = 2 - 2 * ((1 : ℝ)/2)^(j) :=
+-- TODO why does sub_add_assoc not exist?
+-- TODO move this lemma to another file
+lemma sum_geometric_half (j : ℕ) : ∑ (x : ℕ) in (range j), ((1:ℝ) / 2) ^ (x) = 2 - 2 * ((1 : ℝ)/2)^(j) :=
 begin
   induction j,
     {simp,},
-    {
-      rw finset.sum_range_succ,
-      rw j_ih,
-      rw pow_succ,
+    { rw [finset.sum_range_succ, j_ih, pow_succ],
       simp only [one_div, inv_pow', mul_inv_cancel_left'],
       rw <-mul_assoc,
       simp only [one_mul, mul_inv_cancel],
-      ring_nf,
-      -- TODO why does sub_add_assoc not exist?
-
-    },
+      ring_nf,},
 end
 
-lemma sum_half_geometric' (j n : ℕ) (h : n ≤ j) : ∑ (x : ℕ) in filter (λ (k : ℕ), n ≤ k) (range j), ((1 : ℝ) / 2) ^ (x - n) ≤ (2 : ℝ) :=
+private lemma sum_geometric_half' (j n : ℕ) (h : n ≤ j) : ∑ (x : ℕ) in filter (λ (k : ℕ), n ≤ k) (range j), ((1 : ℝ) / 2) ^ (x - n) ≤ (2 : ℝ) :=
 begin
   calc ∑ (x : ℕ) in filter (λ (k : ℕ), n ≤ k) (range j), ((1 : ℝ)/ 2) ^ (x - n)
       = ∑ (x : ℕ) in (range (j - n)), ((1 : ℝ)/ 2) ^ (x) :
         begin
-          rw range_eq_Ico,
-          -- rw range_eq_Ico,
-          rw Ico.filter_le_of_le (nat.zero_le n),
-          rw finset.sum_Ico_eq_sum_range,
-          congr,
-          funext,
-          congr,
+          rw [range_eq_Ico, Ico.filter_le_of_le (nat.zero_le n),
+              finset.sum_Ico_eq_sum_range],
+          congr, funext, congr,
           exact norm_num.sub_nat_pos (n + k) n k rfl,
         end
-  ... = 2 - 2 * ((1 : ℝ)/2)^(j-n) :
-        begin
-          exact sum_half_geometric (j - n),
-        end
+  ... = 2 - 2 * ((1 : ℝ)/2)^(j-n) : sum_geometric_half (j - n)
   ... ≤ 2 :
         begin
           simp only [one_div, sub_le_self_iff, inv_nonneg, inv_pow', pow_nonneg],
@@ -1364,11 +1352,7 @@ begin
       rw abv_pow abs,
       rw mem_filter at hm,
       apply (div_le_iff' _).1,
-      rw mul_div_right_comm,
-      rw <-div_pow,
-      -- simp only [one_div, div_pow, inv_pow'],
-      rw div_eq_inv_mul,
-      -- rw field.inv_inv,
+      rw [mul_div_right_comm, <-div_pow, div_eq_inv_mul],
       calc ((1 / 2)⁻¹ * abs x) ^ (m - n) * ↑n!
           ≤ (n) ^ (m - n) * ↑n! :
             begin
@@ -1390,16 +1374,12 @@ begin
               rw <-nat.cast_pow,
               rw <-nat.cast_mul,
               apply nat.cast_le.2,
-              --   by library_search,
               apply nat.pow_mul_factorial_le_factorial,
               exact hm.right,
               exact real.nontrivial,
             end,
-
       apply pow_pos,
       simp only [one_div, zero_lt_bit0, zero_lt_one, inv_pos],
-
-
       simp only [nat.cast_pos],
       exact nat.factorial_pos m,
       simp only [nat.cast_pos],
@@ -1422,7 +1402,7 @@ begin
       apply mul_le_mul,
       rw mul_comm,
       apply mul_le_mul,
-      apply sum_half_geometric',
+      apply sum_geometric_half',
       exact hj,
       exact le_refl (abs x ^ n),
       apply pow_nonneg,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1329,7 +1329,7 @@ begin
             apply pow_pos,
             rw nat.cast_pos,
             exact nat.succ_pos n,
-            rw [<-nat.cast_pow, <-nat.cast_mul, nat.cast_le],
+            rw [←nat.cast_pow, ←nat.cast_mul, nat.cast_le],
             exact (nat.factorial_mul_pow_le_factorial),
           end
   ... = ∑ (k : ℕ) in range k, (abs x) ^ (n) / (n!) * ((abs x)^k / n.succ ^ k) :
@@ -1341,10 +1341,10 @@ begin
           end
   ... ≤ abs x ^ n / (↑n!) * 2 :
           begin
-            rw <-mul_sum,
+            rw ←mul_sum,
             apply mul_le_mul_of_nonneg_left,
-            simp_rw [<-div_pow],
-            rw [<-geom_sum_def, geom_sum_eq, div_le_iff_of_neg],
+            simp_rw [←div_pow],
+            rw [←geom_sum_def, geom_sum_eq, div_le_iff_of_neg],
             transitivity (-1 : ℝ),
             linarith,
             simp only [neg_le_sub_iff_le_add, div_pow, nat.cast_succ, le_add_iff_nonneg_left],

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1304,15 +1304,15 @@ begin
     exact (nat.add_sub_of_le hj).symm,
   rw hj,
   rw sum_range_add_sub_sum_range,
-  calc abs (∑ (k : ℕ) in range k, x ^ (n + k) / ((n + k)! : ℂ))
-      ≤ ∑ (k : ℕ) in range k, abs (x ^ (n + k) / ((n + k)! : ℂ)) : abv_sum_le_sum_abv _ _
-  ... ≤ ∑ (k : ℕ) in range k, (abs x) ^ (n + k) / (n + k)! :
+  calc abs (∑ (i : ℕ) in range k, x ^ (n + i) / ((n + i)! : ℂ))
+      ≤ ∑ (i : ℕ) in range k, abs (x ^ (n + i) / ((n + i)! : ℂ)) : abv_sum_le_sum_abv _ _
+  ... ≤ ∑ (i : ℕ) in range k, (abs x) ^ (n + i) / (n + i)! :
           begin
             refine sum_le_sum (λ m hm, _),
             simp only [complex.abs_cast_nat, complex.abs_div],
             rw [abv_pow abs],
           end
-  ... ≤ ∑ (k : ℕ) in range k, (abs x) ^ (n + k) / (n! * n.succ ^ k) :
+  ... ≤ ∑ (i : ℕ) in range k, (abs x) ^ (n + i) / (n! * n.succ ^ i) :
           begin
             refine sum_le_sum (λ m hm, _),
             apply div_le_div (pow_nonneg (abs_nonneg x) (n + m)) (le_refl _),
@@ -1325,7 +1325,7 @@ begin
             { rw [←nat.cast_pow, ←nat.cast_mul, nat.cast_le],
               exact (nat.factorial_mul_pow_le_factorial),},
           end
-  ... = ∑ (k : ℕ) in range k, (abs x) ^ (n) / (n!) * ((abs x)^k / n.succ ^ k) :
+  ... = ∑ (i : ℕ) in range k, (abs x) ^ (n) / (n!) * ((abs x)^i / n.succ ^ i) :
           begin
             congr,
             funext,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -226,10 +226,7 @@ end
 lemma sum_range_add_sub_sum_range {α : Type*} [add_comm_group α] (f : ℕ → α)
   (n m : ℕ) : ∑ k in range (n + m), f k - ∑ k in range n, f k =
   ∑ k in finset.range m, f (n + k) :=
-begin
-  rw sum_range_add,
-  simp only [add_sub_cancel', eq_self_iff_true],
-end
+sub_eq_of_eq_add' (sum_range_add f n m)
 
 end
 

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1328,27 +1328,21 @@ begin
   ... ≤ ∑ (k : ℕ) in range k, (abs x) ^ (n + k) / (n! * n.succ ^ k) :
           begin
             refine sum_le_sum (λ m hm, _),
-            apply div_le_div,
-            apply pow_nonneg,
-            apply abs_nonneg,
-            apply le_refl,
+            apply div_le_div (pow_nonneg (abs_nonneg x) (n + m)) (le_refl _),
             apply mul_pos,
             rw nat.cast_pos,
             exact nat.factorial_pos n,
             apply pow_pos,
             rw nat.cast_pos,
             exact nat.succ_pos n,
-            rw [<-nat.cast_pow, <-nat.cast_mul],
-            rw nat.cast_le,
+            rw [<-nat.cast_pow, <-nat.cast_mul, nat.cast_le],
             exact (nat.factorial_mul_pow_le_factorial),
           end
   ... = ∑ (k : ℕ) in range k, (abs x) ^ (n) / (n!) * ((abs x)^k / n.succ ^ k) :
           begin
             congr,
             funext,
-            rw pow_add,
-            simp only [div_eq_inv_mul],
-            simp only [mul_inv'],
+            simp only [pow_add, div_eq_inv_mul, mul_inv'],
             ring,
           end
   ... ≤ abs x ^ n / (↑n!) * 2 :
@@ -1356,9 +1350,7 @@ begin
             rw <-mul_sum,
             apply mul_le_mul_of_nonneg_left,
             simp_rw [<-div_pow],
-            rw <-geom_sum_def,
-            rw geom_sum_eq,
-            rw div_le_iff_of_neg,
+            rw [<-geom_sum_def, geom_sum_eq, div_le_iff_of_neg],
             transitivity (-1 : ℝ),
             linarith,
             simp only [neg_le_sub_iff_le_add, div_pow, nat.cast_succ, le_add_iff_nonneg_left],

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1314,9 +1314,7 @@ begin
   ... ≤ 2 :
         begin
           rw sub_le_self_iff,
-          apply mul_nonneg,
-          linarith,
-          apply pow_nonneg,
+          apply mul_nonneg zero_le_two (pow_nonneg _ (j - n)),
           linarith,
         end
 end
@@ -1337,7 +1335,7 @@ begin
     begin
       refine congr_arg abs (sum_congr rfl (λ m hm, _)),
       rw [mem_filter, mem_range] at hm,
-      rw [← mul_div_assoc, ← pow_add, nat.add_sub_cancel' hm.2]
+      rw [← mul_div_assoc, ← pow_add, nat.add_sub_cancel' hm.2],
     end
   ... ≤ ∑ m in filter (λ k, n ≤ k) (range j), abs (x ^ n * (_ / m!)) : abv_sum_le_sum_abv _ _
   ... ≤ ∑ m in filter (λ k, n ≤ k) (range j), abs x ^ n * ((((1 : ℝ)/2) ^ (m - n)) / n!) :
@@ -1351,12 +1349,9 @@ begin
       rw mul_comm,
       apply trans _ (nat.cast_le.2 (nat.factorial_mul_pow_sub_le_factorial hm.right)),
       exact is_trans.swap (λ (x y : ℝ), y ≤ x),
-      simp only [nat.factorial, nat.cast_mul, nat.cast_pow],
+      rw [nat.cast_mul, nat.cast_pow],
       apply mul_le_mul_of_nonneg_left,
-      apply pow_le_pow_of_le_left,
-      apply mul_nonneg,
-      linarith,
-      exact abs_nonneg x,
+      apply pow_le_pow_of_le_left (mul_nonneg zero_le_two (abs_nonneg x)),
       linarith,
       exact n!.cast_nonneg,
       exact real.nontrivial,
@@ -1377,10 +1372,7 @@ begin
       apply pow_nonneg (abs_nonneg x),
       apply le_refl,
       exact inv_nonneg.2 (n!.cast_nonneg),
-      apply mul_nonneg,
-      linarith,
-      apply pow_nonneg,
-      exact abs_nonneg x,
+      apply mul_nonneg zero_le_two (pow_nonneg (abs_nonneg x) n),
     end,
 end
 

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1293,7 +1293,8 @@ end
 
 -- TODO why does sub_add_assoc not exist?
 -- TODO move this lemma to another file
-lemma sum_geometric_half (j : ℕ) : ∑ (x : ℕ) in (range j), ((1:ℝ) / 2) ^ (x) = 2 - 2 * ((1 : ℝ)/2)^(j) :=
+lemma sum_geometric_half (j : ℕ) :
+  ∑ (x : ℕ) in (range j), ((1:ℝ) / 2) ^ (x) = 2 - 2 * ((1 : ℝ)/2)^(j) :=
 begin
   induction j,
     {simp,},
@@ -1304,7 +1305,8 @@ begin
       ring_nf,},
 end
 
-private lemma sum_geometric_half' (j n : ℕ) (h : n ≤ j) : ∑ (x : ℕ) in filter (λ (k : ℕ), n ≤ k) (range j), ((1 : ℝ) / 2) ^ (x - n) ≤ (2 : ℝ) :=
+private lemma sum_geometric_half' (j n : ℕ) (h : n ≤ j) :
+  ∑ (x : ℕ) in filter (λ (k : ℕ), n ≤ k) (range j), ((1 : ℝ) / 2) ^ (x - n) ≤ (2 : ℝ) :=
 begin
   calc ∑ (x : ℕ) in filter (λ (k : ℕ), n ≤ k) (range j), ((1 : ℝ)/ 2) ^ (x - n)
       = ∑ (x : ℕ) in (range (j - n)), ((1 : ℝ)/ 2) ^ (x) :

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -210,6 +210,7 @@ by rw [sum_sigma', sum_sigma']; exact sum_bij
     mem_range.2 (nat.lt_succ_of_le (nat.le_add_left _ _))⟩,
   sigma.mk.inj_iff.2 ⟨rfl, heq_of_eq (nat.add_sub_cancel _ _).symm⟩⟩⟩)
 
+-- TODO move to src/algebra/big_operators/basic.lean, rewrite with comm_group, and make to_additive
 lemma sum_range_sub_sum_range {α : Type*} [add_comm_group α] {f : ℕ → α}
   {n m : ℕ} (hnm : n ≤ m) : ∑ k in range m, f k - ∑ k in range n, f k =
   ∑ k in (range m).filter (λ k, n ≤ k), f k :=

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1328,7 +1328,7 @@ begin
         end
 end
 
-lemma exp_bound' {x : ℂ} {n : ℕ} (hn : 0 < n) (hx : abs x ≤ n / 2) :
+lemma exp_bound' {x : ℂ} {n : ℕ} (hx : abs x ≤ n / 2) :
   abs (exp x - ∑ m in range n, x ^ m / m!) ≤ 2 * abs x ^ n * (n!)⁻¹ :=
 begin
   rw [← lim_const (∑ m in range n, _), exp, sub_eq_add_neg, ← lim_neg, lim_add, ← lim_abs],

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1363,7 +1363,7 @@ begin
             begin
               rw [<-nat.cast_pow, <-nat.cast_mul, nat.cast_le],
               rw mem_filter at hm,
-              exact nat.pow_mul_factorial_le_factorial hm.right,
+              exact nat.pow_sub_mul_factorial_le_factorial hm.right,
             end,
       apply pow_pos,
       linarith,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1296,58 +1296,34 @@ lemma exp_bound' {x : ℂ} {n : ℕ} (hx : abs x / (n.succ) ≤ 1 / 2) :
 begin
   rw [← lim_const (∑ m in range n, _), exp, sub_eq_add_neg, ← lim_neg, lim_add, ← lim_abs],
   refine lim_le (cau_seq.le_of_exists ⟨n, λ j hj, _⟩),
-  simp_rw ← sub_eq_add_neg,
-  show abs (∑ m in range j, x ^ m / m! - ∑ m in range n, x ^ m / m!)
-    ≤ abs x ^ n / (n!) * 2,
+  simp_rw [←sub_eq_add_neg],
+  show abs (∑ m in range j, x ^ m / m! - ∑ m in range n, x ^ m / m!) ≤ abs x ^ n / (n!) * 2,
   let k := j - n,
-  have hj : j = n + k,
-    exact (nat.add_sub_of_le hj).symm,
-  rw hj,
-  rw sum_range_add_sub_sum_range,
+  have hj : j = n + k := (nat.add_sub_of_le hj).symm,
+  rw [hj, sum_range_add_sub_sum_range],
   calc abs (∑ (i : ℕ) in range k, x ^ (n + i) / ((n + i)! : ℂ))
       ≤ ∑ (i : ℕ) in range k, abs (x ^ (n + i) / ((n + i)! : ℂ)) : abv_sum_le_sum_abv _ _
   ... ≤ ∑ (i : ℕ) in range k, (abs x) ^ (n + i) / (n + i)! :
-          begin
-            refine sum_le_sum (λ m hm, _),
-            simp only [complex.abs_cast_nat, complex.abs_div],
-            rw [abv_pow abs],
-          end
-  ... ≤ ∑ (i : ℕ) in range k, (abs x) ^ (n + i) / (n! * n.succ ^ i) :
-          begin
-            refine sum_le_sum (λ m hm, _),
-            apply div_le_div (pow_nonneg (abs_nonneg x) (n + m)) (le_refl _),
-            { apply mul_pos,
-              { rw nat.cast_pos,
-                exact nat.factorial_pos n,},
-              { apply pow_pos,
-                rw nat.cast_pos,
-                exact nat.succ_pos n,},},
-            { rw [←nat.cast_pow, ←nat.cast_mul, nat.cast_le],
-              exact (nat.factorial_mul_pow_le_factorial),},
-          end
-  ... = ∑ (i : ℕ) in range k, (abs x) ^ (n) / (n!) * ((abs x)^i / n.succ ^ i) :
-          begin
-            congr,
-            funext,
-            simp only [pow_add, div_eq_inv_mul, mul_inv'],
-            ring,
-          end
-  ... ≤ abs x ^ n / (↑n!) * 2 :
-          begin
-            rw ←mul_sum,
-            apply mul_le_mul_of_nonneg_left,
-            { simp_rw [←div_pow],
-              rw [←geom_sum_def, geom_sum_eq, div_le_iff_of_neg],
-              { transitivity (-1 : ℝ),
-                { linarith,},
-                { simp only [neg_le_sub_iff_le_add, div_pow,
-                             nat.cast_succ, le_add_iff_nonneg_left],
-                  apply div_nonneg (pow_nonneg (abs_nonneg x) k)
-                                   (pow_nonneg (nat.cast_nonneg (n + 1)) k),},},
-              { linarith,},
-              { linarith,},},
-            { exact div_nonneg (pow_nonneg (abs_nonneg x) n) (nat.cast_nonneg (n!)),},
-          end,
+        by simp only [complex.abs_cast_nat, complex.abs_div, abv_pow abs]
+  ... ≤ ∑ (i : ℕ) in range k, (abs x) ^ (n + i) / (n! * n.succ ^ i) : _
+  ... = ∑ (i : ℕ) in range k, (abs x) ^ (n) / (n!) * ((abs x)^i / n.succ ^ i) : _
+  ... ≤ abs x ^ n / (↑n!) * 2 : _,
+  { refine sum_le_sum (λ m hm, div_le_div (pow_nonneg (abs_nonneg x) (n + m)) (le_refl _) _ _),
+    { exact_mod_cast mul_pos n.factorial_pos (pow_pos n.succ_pos _), },
+    { exact_mod_cast (nat.factorial_mul_pow_le_factorial), }, },
+  { refine finset.sum_congr rfl (λ _ _, _),
+    simp only [pow_add, div_eq_inv_mul, mul_inv', mul_left_comm, mul_assoc], },
+  { rw [←mul_sum],
+    apply mul_le_mul_of_nonneg_left,
+    { simp_rw [←div_pow],
+      rw [←geom_sum_def, geom_sum_eq, div_le_iff_of_neg],
+      { transitivity (-1 : ℝ),
+        { linarith },
+        { simp only [neg_le_sub_iff_le_add, div_pow, nat.cast_succ, le_add_iff_nonneg_left],
+          exact div_nonneg (pow_nonneg (abs_nonneg x) k) (pow_nonneg (n+1).cast_nonneg k) } },
+      { linarith },
+      { linarith }, },
+    { exact div_nonneg (pow_nonneg (abs_nonneg x) n) (nat.cast_nonneg (n!)), }, },
 end
 
 lemma abs_exp_sub_one_le {x : ℂ} (hx : abs x ≤ 1) :

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1363,7 +1363,8 @@ begin
             begin
               rw [<-nat.cast_pow, <-nat.cast_mul, nat.cast_le],
               rw mem_filter at hm,
-              exact nat.pow_sub_mul_factorial_le_factorial hm.right,
+              rw mul_comm,
+              exact nat.factorial_mul_pow_sub_le_factorial hm.right,
             end,
       apply pow_pos,
       linarith,

--- a/src/data/nat/factorial.lean
+++ b/src/data/nat/factorial.lean
@@ -159,25 +159,13 @@ begin
   exact add_factorial_succ_le_factorial_add_succ i h,
 end
 
-lemma pow_sub_mul_factorial_le_factorial {n m : ℕ} (hnm : n ≤ m) : n ^ (m - n) * n! ≤ m! :=
+lemma pow_sub_mul_factorial_le_factorial {n m : ℕ} (hnm : n ≤ m) : n! * n ^ (m - n) ≤ m! :=
 begin
-  induction m,
-  have hn : n = 0, exact le_zero_iff.mp hnm,
-  rw hn,
-  simp only [le_refl, mul_one, nat.nat_zero_eq_zero, nat.factorial_zero, nat.sub_self, pow_zero],
-  by_cases n ≤ m_n,
-  rw [succ_sub, nat.factorial_succ, pow_succ, mul_assoc],
-  apply mul_le_mul hnm (m_ih h),
-  apply zero_le,
-  apply zero_le,
-  exact h,
-  rw not_le at h,
-  rw factorial_succ,
-  have hn : m_n.succ ≤ n, exact succ_le_iff.mpr h,
-  have hn' : n = m_n.succ, exact le_antisymm hnm hn,
-  rw <- hn',
-  rw [nat.sub_self, pow_zero, one_mul, hn'],
-  simp only [le_refl, mul_le_mul_left, nat.factorial_succ],
+  suffices : n! * (n + 1) ^ (m - n) ≤ m!,
+  { have := pow_le_pow_of_le_left (nat.zero_le _) (le_succ n) (m - n),
+    sorry },
+  convert nat.factorial_mul_pow_le_factorial,
+  exact (nat.add_sub_of_le hnm).symm
 end
 
 

--- a/src/data/nat/factorial.lean
+++ b/src/data/nat/factorial.lean
@@ -159,6 +159,32 @@ begin
   exact add_factorial_succ_le_factorial_add_succ i h,
 end
 
+lemma pow_mul_factorial_le_factorial {n m : ℕ} (hnm : n ≤ m) : n ^ (m - n) * n! ≤ m! :=
+begin
+  induction m,
+  have hn : n = 0, exact le_zero_iff.mp hnm,
+  rw hn,
+  simp only [le_refl, mul_one, nat.nat_zero_eq_zero, nat.factorial_zero, nat.sub_self, pow_zero],
+  by_cases n ≤ m_n,
+  rw succ_sub,
+  rw [nat.factorial_succ, pow_succ],
+  rw mul_assoc,
+  apply mul_le_mul,
+  exact hnm,
+  exact m_ih h,
+  apply zero_le,
+  apply zero_le,
+  exact h,
+  simp at *,
+  have hn : m_n.succ ≤ n, exact succ_le_iff.mpr h,
+  have hn' : n = m_n.succ, exact le_antisymm hnm hn,
+  rw <- hn',
+  simp only [one_mul, nat.sub_self, pow_zero],
+  rw hn',
+  simp only [le_refl, mul_le_mul_left, nat.factorial_succ],
+end
+
+
 end factorial
 
 /-! ### Ascending and descending factorials -/

--- a/src/data/nat/factorial.lean
+++ b/src/data/nat/factorial.lean
@@ -159,28 +159,24 @@ begin
   exact add_factorial_succ_le_factorial_add_succ i h,
 end
 
-lemma pow_mul_factorial_le_factorial {n m : ℕ} (hnm : n ≤ m) : n ^ (m - n) * n! ≤ m! :=
+lemma pow_sub_mul_factorial_le_factorial {n m : ℕ} (hnm : n ≤ m) : n ^ (m - n) * n! ≤ m! :=
 begin
   induction m,
   have hn : n = 0, exact le_zero_iff.mp hnm,
   rw hn,
   simp only [le_refl, mul_one, nat.nat_zero_eq_zero, nat.factorial_zero, nat.sub_self, pow_zero],
   by_cases n ≤ m_n,
-  rw succ_sub,
-  rw [nat.factorial_succ, pow_succ],
-  rw mul_assoc,
-  apply mul_le_mul,
-  exact hnm,
-  exact m_ih h,
+  rw [succ_sub, nat.factorial_succ, pow_succ, mul_assoc],
+  apply mul_le_mul hnm (m_ih h),
   apply zero_le,
   apply zero_le,
   exact h,
-  simp at *,
+  rw not_le at h,
+  rw factorial_succ,
   have hn : m_n.succ ≤ n, exact succ_le_iff.mpr h,
   have hn' : n = m_n.succ, exact le_antisymm hnm hn,
   rw <- hn',
-  simp only [one_mul, nat.sub_self, pow_zero],
-  rw hn',
+  rw [nat.sub_self, pow_zero, one_mul, hn'],
   simp only [le_refl, mul_le_mul_left, nat.factorial_succ],
 end
 

--- a/src/data/nat/factorial.lean
+++ b/src/data/nat/factorial.lean
@@ -162,8 +162,13 @@ end
 lemma pow_sub_mul_factorial_le_factorial {n m : ℕ} (hnm : n ≤ m) : n! * n ^ (m - n) ≤ m! :=
 begin
   suffices : n! * (n + 1) ^ (m - n) ≤ m!,
-  { have := pow_le_pow_of_le_left (nat.zero_le _) (le_succ n) (m - n),
-    sorry },
+  { have h1 := pow_le_pow_of_le_left (nat.zero_le _) (le_succ n) (m - n),
+      apply trans _ this,
+      rw mul_le_mul_left,
+      apply pow_le_pow_of_le_left,
+      apply zero_le,
+      exact le_succ n,
+      exact factorial_pos n,},
   convert nat.factorial_mul_pow_le_factorial,
   exact (nat.add_sub_of_le hnm).symm
 end

--- a/src/data/nat/factorial.lean
+++ b/src/data/nat/factorial.lean
@@ -162,15 +162,12 @@ end
 lemma factorial_mul_pow_sub_le_factorial {n m : ℕ} (hnm : n ≤ m) : n! * n ^ (m - n) ≤ m! :=
 begin
   suffices : n! * (n + 1) ^ (m - n) ≤ m!,
-  { have h1 := pow_le_pow_of_le_left (nat.zero_le _) (le_succ n) (m - n),
-      apply trans _ this,
-      rw mul_le_mul_left,
-      apply pow_le_pow_of_le_left,
-      apply zero_le,
-      exact le_succ n,
-      exact factorial_pos n,},
+  { apply trans _ this,
+    rw mul_le_mul_left,
+    apply pow_le_pow_of_le_left (zero_le n) (le_succ n),
+    exact factorial_pos n,},
   convert nat.factorial_mul_pow_le_factorial,
-  exact (nat.add_sub_of_le hnm).symm
+  exact (nat.add_sub_of_le hnm).symm,
 end
 
 

--- a/src/data/nat/factorial.lean
+++ b/src/data/nat/factorial.lean
@@ -159,7 +159,7 @@ begin
   exact add_factorial_succ_le_factorial_add_succ i h,
 end
 
-lemma pow_sub_mul_factorial_le_factorial {n m : ℕ} (hnm : n ≤ m) : n! * n ^ (m - n) ≤ m! :=
+lemma factorial_mul_pow_sub_le_factorial {n m : ℕ} (hnm : n ≤ m) : n! * n ^ (m - n) ≤ m! :=
 begin
   suffices : n! * (n + 1) ^ (m - n) ≤ m!,
   { have h1 := pow_le_pow_of_le_left (nat.zero_le _) (le_succ n) (m - n),


### PR DESCRIPTION
This PR is for a new lemma (currently called `exp_bound'`) which proves `exp x` is close to its `n`th degree taylor expansion for sufficiently large `n`. Unlike the previous bound, this lemma can be instantiated on any real `x` rather than just `x` with absolute value less than or equal to 1. I am separating this lemma out from #8002 because I think it stands on its own.

The last time I checked it was sorry free - but that was before I merged with master and moved it to a different branch. It may also benefit from a little golfing.

There are a few lemmas I proved as well to support this - one about the relative size of factorials and a few about sums of geometric sequences. The ~~geometric series ones should probably be generalized and moved to another file~~ this generalization sort of exists and is in the algebra.geom_sum file. I didn't find it initially since I was searching for "geometric" not "geom".

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
