### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal/operations): add some theorems about taking the quotient of a ring by a sum of ideals 

### DIFF
--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -599,8 +599,7 @@ ideal.quotient.lift S (T^.quotient.mk) (λ x hx, eq_zero_iff_mem.2 (H hx))
 @[simp] lemma factor_mk (S T : ideal α) (H : S ≤ T) (x : α) :
   factor S T H (mk S x) = mk T x := rfl
 
-lemma factor_comp_mk (S T : ideal α) (H : S ≤ T) :
-  ring_hom.comp (factor S T H) (mk S) = mk T :=
+@[simp] lemma factor_comp_mk (S T : ideal α) (H : S ≤ T) : (factor S T H).comp (mk S) = mk T :=
 ring_hom.ext factor_mk
 
 end quotient

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -601,7 +601,7 @@ ideal.quotient.lift S (T^.quotient.mk) (λ x hx, eq_zero_iff_mem.2 (H hx))
 
 lemma factor_comp_mk (S T : ideal α) (H : S ≤ T) :
   ring_hom.comp (factor S T H) (mk S) = mk T :=
-by ext x; rw [ring_hom.comp_apply, quotient.factor_mk]
+ring_hom.ext factor_mk
 
 end quotient
 

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -600,7 +600,7 @@ ideal.quotient.lift S (T^.quotient.mk) (λ x hx, eq_zero_iff_mem.2 (H hx))
   factor S T H (mk S x) = mk T x := rfl
 
 @[simp] lemma factor_comp_mk (S T : ideal α) (H : S ≤ T) : (factor S T H).comp (mk S) = mk T :=
-ring_hom.ext factor_mk
+by { ext x, rw [ring_hom.comp_apply, factor_mk] }
 
 end quotient
 

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -590,7 +590,7 @@ def lift (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0
 @[simp] lemma lift_mk (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0) :
   lift S f H (mk S a) = f a := rfl
 
-/-- Weaken the relation of a quotient.
+/-- The ring homomorphism from the quotient by a smaller ideal to the quotient by a larger ideal.
 
 This is the `ideal.quotient` version of `quot.factor` -/
 def factor (S T : ideal α) (H : S ≤ T) : S.quotient →+* T.quotient :=

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -594,7 +594,7 @@ def lift (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0
 
 This is the `ideal.quotient` version of `quot.factor` -/
 def factor (S T : ideal α) (H : S ≤ T) : S.quotient →+* T.quotient :=
-  ideal.quotient.lift S (T^.quotient.mk) (λ x hx, eq_zero_iff_mem.2 (H hx))
+ideal.quotient.lift S (T^.quotient.mk) (λ x hx, eq_zero_iff_mem.2 (H hx))
 
 @[simp] lemma factor_mk (S T : ideal α) (H : S ≤ T) (x : α) :
   factor S T H (mk S x) = mk T x := rfl

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -599,6 +599,10 @@ ideal.quotient.lift S (T^.quotient.mk) (λ x hx, eq_zero_iff_mem.2 (H hx))
 @[simp] lemma factor_mk (S T : ideal α) (H : S ≤ T) (x : α) :
   factor S T H (mk S x) = mk T x := rfl
 
+lemma factor_comp_mk (S T : ideal α) (H : S ≤ T) :
+  ring_hom.comp (factor S T H) (mk S) = mk T :=
+by ext x; rw [ring_hom.comp_apply, quotient.factor_mk]
+
 end quotient
 
 /-- Quotienting by equal ideals gives equivalent rings.

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -593,8 +593,11 @@ def lift (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0
 /-- Weaken the relation of a quotient.
 
 This is the `ideal.quotient` version of `quot.factor` -/
-def inclusion (S T : ideal α) (H : S ≤ T) : S.quotient →+* T.quotient :=
+def factor (S T : ideal α) (H : S ≤ T) : S.quotient →+* T.quotient :=
   ideal.quotient.lift S (T^.quotient.mk) (λ x hx, eq_zero_iff_mem.2 (H hx))
+
+@[simp] lemma factor_mk (S T : ideal α) (H : S ≤ T) (x : α) :
+  factor S T H (mk S x) = mk T x := rfl
 
 end quotient
 

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -590,7 +590,10 @@ def lift (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0
 @[simp] lemma lift_mk (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0) :
   lift S f H (mk S a) = f a := rfl
 
-def lift_mk_of_le (S T : ideal α) (H : S ≤ T) : S.quotient →+* T.quotient :=
+/-- Weaken the relation of a quotient.
+
+This is the `ideal.quotient` version of `quot.factor` -/
+def inclusion (S T : ideal α) (H : S ≤ T) : S.quotient →+* T.quotient :=
   ideal.quotient.lift S (T^.quotient.mk) (λ x hx, eq_zero_iff_mem.2 (H hx))
 
 end quotient

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -590,6 +590,9 @@ def lift (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0
 @[simp] lemma lift_mk (S : ideal α) (f : α →+* β) (H : ∀ (a : α), a ∈ S → f a = 0) :
   lift S f H (mk S a) = f a := rfl
 
+def lift_mk_of_le (S T : ideal α) (H : S ≤ T) : S.quotient →+* T.quotient :=
+  ideal.quotient.lift S (T^.quotient.mk) (λ x hx, eq_zero_iff_mem.2 (H hx))
+
 end quotient
 
 /-- Quotienting by equal ideals gives equivalent rings.

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1628,40 +1628,23 @@ begin
   split,
     {intro hx,
     obtain ⟨y, hy⟩ := quotient.mk_surjective x,
-    rw [ring_hom.mem_ker, ← hy,quot_left_to_quot_sup, ideal.quotient.factor_mk, ← ring_hom.mem_ker,
+    rw [ring_hom.mem_ker, ← hy, quot_left_to_quot_sup, ideal.quotient.factor_mk, ← ring_hom.mem_ker,
      mk_ker] at hx,
     replace hx := (mem_map_of_mem (I^.quotient.mk)) hx,
-    have :  I.map I^.quotient.mk = ⊥ := by rw [map_eq_bot_iff_le_ker, mk_ker] ; exact le_refl I,
+    have : I.map I^.quotient.mk = ⊥ := by rw [map_eq_bot_iff_le_ker, mk_ker] ; exact le_refl I,
     rw [map_sup, this, bot_sup_eq, hy] at hx,
     exact hx},
    {intro hx,
-    have hIJmap: ((quot_left_to_quot_sup I J).comp(ideal.quotient.mk I) '' J) =
-    (ideal.quotient.mk (I ⊔ J) '' J),
-      {apply set.ext,
-      intro y,
-      split,
-      {intro hy,
-        obtain ⟨z, hz⟩ := (set.mem_image ((quot_left_to_quot_sup I J).comp(ideal.quotient.mk I))
-          J y).1 hy,
-        rw quot_left_to_quot_sup at hz,
-        rw [ring_hom.comp_apply, ideal.quotient.factor_mk] at hz,
-        rw ← hz.right,
-        exact set.mem_image_of_mem (ideal.quotient.mk (I ⊔ J)) hz.left},
-       {intro hy,
-        obtain ⟨z, hz⟩ := (set.mem_image (ideal.quotient.mk (I ⊔ J)) J y).1 hy,
-        rw [quot_left_to_quot_sup, set.mem_image_eq],
-        use z,
-        rwa [ring_hom.comp_apply, ideal.quotient.factor_mk]}},
-    have hJ: (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sup I J) = J.map
-      (ideal.quotient.mk (I ⊔ J))
-      := by rw [ideal.map_map, ideal.map,hIJmap, ← ideal.map],
-    have hmapx : quot_left_to_quot_sup I J x ∈ (J.map (ideal.quotient.mk I)).map
-      (quot_left_to_quot_sup I J),
-        {rw ideal.map,
-        apply set.mem_of_subset_of_mem (ideal.subset_span),
-        exact (set.mem_image_of_mem (quot_left_to_quot_sup I J) hx)},
-    have : J.map(ideal.quotient.mk(I ⊔ J)) = ⊥ :=  map_mk_eq_bot_of_le le_sup_right,
-    rwa [hJ,this] at hmapx},
+    have hJ: comap (I ⊔ J)^.quotient.mk ((J.map (ideal.quotient.mk I)).map
+      (quot_left_to_quot_sup I J)) ≤ I ⊔ J,
+     {rw [map_map, quot_left_to_quot_sup, ideal.quotient.factor_comp_mk, comap_map_of_surjective
+      (I ⊔ J)^.quotient.mk (quotient.mk_surjective), ← ring_hom.ker_eq_comap_bot, mk_ker, sup_comm,
+      sup_assoc, sup_idem],
+      exact le_refl (I ⊔ J)},
+    replace hJ := map_mk_eq_bot_of_le hJ,
+    rw map_comap_of_surjective (I ⊔ J)^.quotient.mk quotient.mk_surjective at hJ,
+    rw [ring_hom.mem_ker,← mem_bot, ← hJ],
+    exact mem_map_of_mem (quot_left_to_quot_sup I J) hx},
 end
 
 /-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I ⊔ J)`,

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1622,50 +1622,53 @@ ideal.quotient.factor I (I ⊔ J) (le_sup_left)
 
 /-- This will be used to lift `quot_left_to_quot_sup` to a map `(R/I)/J' → R/(I ⊔ J)`-/
 lemma map_mk_le_ker_quot_left_to_quot_sup :
-  J.map (ideal.quotient.mk I) ≤ (quot_left_to_quot_sup I J).ker :=
+  J.map (ideal.quotient.mk I) = (quot_left_to_quot_sup I J).ker :=
 begin
-  intros x hx,
-  have hIJmap: ((quot_left_to_quot_sup I J).comp(ideal.quotient.mk I) '' J) =
+  ext x,
+  split,
+   {intro hx,
+    have hIJmap: ((quot_left_to_quot_sup I J).comp(ideal.quotient.mk I) '' J) =
     (ideal.quotient.mk (I ⊔ J) '' J),
-   {apply set.ext,
-    intro y,
-    split,
-
-     {intro hy,
-      obtain ⟨z, hz⟩ := (set.mem_image ((quot_left_to_quot_sup I J).comp(ideal.quotient.mk I))
-        J y).1 hy,
-      unfold quot_left_to_quot_sup at hz,
-      rw [ring_hom.comp_apply, ideal.quotient.factor_mk] at hz,
-      rw ← hz.right,
-      exact set.mem_image_of_mem (ideal.quotient.mk (I ⊔ J)) hz.left},
-
-     {intro hy,
-      obtain ⟨z, hz⟩ := (set.mem_image (ideal.quotient.mk (I ⊔ J)) J y).1 hy,
-      rw [quot_left_to_quot_sup, set.mem_image_eq],
-      use z,
-      rwa [ring_hom.comp_apply, ideal.quotient.factor_mk]},
-    },
-
-  have hJ: (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sup I J) = J.map
-    (ideal.quotient.mk (I ⊔ J))
-    := by rw [ideal.map_map, ideal.map,hIJmap, ← ideal.map],
-
-  have hmapx : quot_left_to_quot_sup I J x ∈ (J.map (ideal.quotient.mk I)).map
-    (quot_left_to_quot_sup I J),
-    {rw ideal.map,
-    apply set.mem_of_subset_of_mem (ideal.subset_span),
-    exact (set.mem_image_of_mem (quot_left_to_quot_sup I J) hx)},
-
-  have : J.map(ideal.quotient.mk(I ⊔ J)) = ⊥ :=  map_mk_eq_bot_of_le le_sup_right,
-  rwa [hJ,this] at hmapx,
+      {apply set.ext,
+      intro y,
+      split,
+      {intro hy,
+        obtain ⟨z, hz⟩ := (set.mem_image ((quot_left_to_quot_sup I J).comp(ideal.quotient.mk I))
+          J y).1 hy,
+        rw quot_left_to_quot_sup at hz,
+        rw [ring_hom.comp_apply, ideal.quotient.factor_mk] at hz,
+        rw ← hz.right,
+        exact set.mem_image_of_mem (ideal.quotient.mk (I ⊔ J)) hz.left},
+       {intro hy,
+        obtain ⟨z, hz⟩ := (set.mem_image (ideal.quotient.mk (I ⊔ J)) J y).1 hy,
+        rw [quot_left_to_quot_sup, set.mem_image_eq],
+        use z,
+        rwa [ring_hom.comp_apply, ideal.quotient.factor_mk]}},
+    have hJ: (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sup I J) = J.map
+      (ideal.quotient.mk (I ⊔ J))
+      := by rw [ideal.map_map, ideal.map,hIJmap, ← ideal.map],
+    have hmapx : quot_left_to_quot_sup I J x ∈ (J.map (ideal.quotient.mk I)).map
+      (quot_left_to_quot_sup I J),
+        {rw ideal.map,
+        apply set.mem_of_subset_of_mem (ideal.subset_span),
+        exact (set.mem_image_of_mem (quot_left_to_quot_sup I J) hx)},
+    have : J.map(ideal.quotient.mk(I ⊔ J)) = ⊥ :=  map_mk_eq_bot_of_le le_sup_right,
+    rwa [hJ,this] at hmapx},
+    {intro hx,
+    obtain ⟨y, hy⟩ := quotient.mk_surjective x,
+    rw [ring_hom.mem_ker, ← hy,quot_left_to_quot_sup, ideal.quotient.factor_mk, ← ring_hom.mem_ker,
+     mk_ker] at hx,
+    replace hx := (mem_map_of_mem (I^.quotient.mk)) hx,
+    have :  I.map I^.quotient.mk = ⊥ := by rw [map_eq_bot_iff_le_ker, mk_ker] ; exact le_refl I,
+    rw [map_sup, this, bot_sup_eq, hy] at hx,
+    exact hx},
 end
 
 /-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I ⊔ J)`,
   where `J'` is the image of `J` in `R/I` -/
 def double_quot_to_quot_sup : (J.map (ideal.quotient.mk I)).quotient →+* (I ⊔ J).quotient :=
 ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sup I J)
- (λ x hx, (ring_hom.mem_ker (quot_left_to_quot_sup I J)).2
-  (map_mk_le_ker_quot_left_to_quot_sup I J hx))
+  (map_mk_le_ker_quot_left_to_quot_sup I J).le
 
 /-- define `double_quot_mk` to be the composite of the maps `R → (R/I) and (R/I) → (R/I)/J'` -/
 def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=
@@ -1696,7 +1699,7 @@ end
 
 /-- define `lift_add_double_quot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/
 def lift_sup_double_quot_mk (I J : ideal R) := ideal.quotient.lift (I ⊔ J) (double_quot_mk I J)
-  ker_double_quot_mk.le
+  ((ker_double_quot_mk I J).symm).le
 
 /-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/
 def double_quot_equiv_quot_sup : (J.map (ideal.quotient.mk I)).quotient ≃+* (I ⊔ J).quotient :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1644,13 +1644,13 @@ lemma ker_quot_left_to_quot_sup :
 by simp only [mk_ker, sup_idem, sup_comm, quot_left_to_quot_sup, quotient.factor, ker_quotient_lift,
     map_eq_iff_sup_ker_eq_of_surjective I^.quotient.mk quotient.mk_surjective, ← sup_assoc]
 
-/-- The ring homomorphism `(R/I)/J' ->R/(I ⊔ J)` induced by `quot_left_to_quot_sup` where `J'`
+/-- The ring homomorphism `(R/I)/J' -> R/(I ⊔ J)` induced by `quot_left_to_quot_sup` where `J'`
   is the image of `J` in `R/I`-/
 def quot_quot_to_quot_sup : (J.map (ideal.quotient.mk I)).quotient →+* (I ⊔ J).quotient :=
 ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sup I J)
   (ker_quot_left_to_quot_sup I J).symm.le
 
-/-- The composite of the maps `R → (R/I) and (R/I) → (R/I)/J'` -/
+/-- The composite of the maps `R → (R/I)` and `(R/I) → (R/I)/J'` -/
 def quot_quot_mk : R →+* (J.map I^.quotient.mk).quotient :=
 ((J.map I^.quotient.mk)^.quotient.mk).comp I^.quotient.mk
 

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1288,7 +1288,7 @@ lemma ker_quotient_lift {S : Type v} [comm_ring S] {I : ideal R} (f : R →+* S)
 begin
   ext x,
   split,
- {intro hx,
+  { intro hx,
   obtain ⟨y, hy⟩ := quotient.mk_surjective x,
   rw [ring_hom.mem_ker, ← hy, ideal.quotient.lift_mk, ← ring_hom.mem_ker] at hx,
   rw [← hy, mem_map_iff_of_surjective I^.quotient.mk quotient.mk_surjective],

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1676,26 +1676,9 @@ def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=
 
 -- Another short result for lifting map `ring_to_double_quot` to a map `R/(I ⊔ J) → (R/I)/J'`
 lemma ker_double_quot_mk : (double_quot_mk I J).ker = I ⊔ J :=
-begin
-  ext,
-  rw [sup_comm, submodule.mem_sup, ring_hom.mem_ker, double_quot_mk, ring_hom.comp_apply,
-    quotient.eq_zero_iff_mem, mem_map_iff_of_surjective _ (quotient.mk_surjective)],
-  simp_rw [ideal.quotient.eq, exists_prop],
-  refine exists_congr (λ a, and_congr_right $ λ ha, _),
-  split,
-  {intro ha,
-    use - (a - x),
-    split,
-    exact submodule.neg_mem _ ha,
-    ring},
-  intro hz,
-  obtain ⟨z, hz'⟩ := hz,
-  suffices hax : a - x = - z, {
-    rw hax,
-    exact submodule.neg_mem _ hz'.left},
-  rw ← hz'.right,
-  ring,
-end
+by rw [ring_hom.ker_eq_comap_bot, double_quot_mk, ← comap_comap, ← ring_hom.ker, mk_ker,
+  comap_map_of_surjective (ideal.quotient.mk I) (quotient.mk_surjective), ← ring_hom.ker, mk_ker,
+  sup_comm]
 
 /-- define `lift_add_double_quot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/
 def lift_sup_double_quot_mk (I J : ideal R) := ideal.quotient.lift (I ⊔ J) (double_quot_mk I J)

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1302,9 +1302,8 @@ end
 
 theorem map_eq_iff_sup_ker_eq_of_surjective {I J : ideal R} (f : R →+* S)
   (hf : function.surjective f) : map f I = map f J ↔ I ⊔ f.ker = J ⊔ f.ker :=
-by rw [← (comap_injective_of_surjective f hf).eq_iff,
-  comap_map_of_surjective f hf, comap_map_of_surjective f hf,
-  ring_hom.ker_eq_comap_bot]
+by rw [← (comap_injective_of_surjective f hf).eq_iff, comap_map_of_surjective f hf,
+  comap_map_of_surjective f hf, ring_hom.ker_eq_comap_bot]
 
 
 theorem map_radical_of_surjective {f : R →+* S} (hf : function.surjective f) {I : ideal R}

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1634,40 +1634,40 @@ namespace double_quot
 open ideal
 variables {R : Type u} [comm_ring R] (I J : ideal R)
 
-/-- define `quot_left_to_quot_sup` to be the obvious ring hom `R/I → R/(I ⊔ J)` -/
+/-- The obvious ring hom `R/I → R/(I ⊔ J)` -/
 def quot_left_to_quot_sup : I.quotient →+* (I ⊔ J).quotient :=
 ideal.quotient.factor I (I ⊔ J) le_sup_left
 
-/-- This will be used to lift `quot_left_to_quot_sup` to a map `(R/I)/J' → R/(I ⊔ J)`-/
+/-- The kernel of `quot_left_to_quot_sup` -/
 lemma ker_quot_left_to_quot_sup :
   (quot_left_to_quot_sup I J).ker = J.map (ideal.quotient.mk I) :=
 by simp only [mk_ker, sup_idem, sup_comm, quot_left_to_quot_sup, quotient.factor, ker_quotient_lift,
     map_eq_iff_sup_ker_eq_of_surjective I^.quotient.mk quotient.mk_surjective, ← sup_assoc]
 
-/-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I ⊔ J)`,
-  where `J'` is the image of `J` in `R/I` -/
-def double_quot_to_quot_sup : (J.map (ideal.quotient.mk I)).quotient →+* (I ⊔ J).quotient :=
+/-- The ring homomorphism `(R/I)/J' ->R/(I ⊔ J)` induced by `quot_left_to_quot_sup` where `J'`
+  is the image of `J` in `R/I`-/
+def quot_quot_to_quot_sup : (J.map (ideal.quotient.mk I)).quotient →+* (I ⊔ J).quotient :=
 ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sup I J)
   (ker_quot_left_to_quot_sup I J).symm.le
 
-/-- define `double_quot_mk` to be the composite of the maps `R → (R/I) and (R/I) → (R/I)/J'` -/
-def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient :=
+/-- The composite of the maps `R → (R/I) and (R/I) → (R/I)/J'` -/
+def quot_quot_mk : R →+* (J.map I^.quotient.mk).quotient :=
 ((J.map I^.quotient.mk)^.quotient.mk).comp I^.quotient.mk
 
--- Another short result for lifting map `ring_to_double_quot` to a map `R/(I ⊔ J) → (R/I)/J'`
-lemma ker_double_quot_mk : (double_quot_mk I J).ker = I ⊔ J :=
-by rw [ring_hom.ker_eq_comap_bot, double_quot_mk, ← comap_comap, ← ring_hom.ker, mk_ker,
+/-- The kernel of `quot_quot_mk` -/
+lemma ker_quot_quot_mk : (quot_quot_mk I J).ker = I ⊔ J :=
+by rw [ring_hom.ker_eq_comap_bot, quot_quot_mk, ← comap_comap, ← ring_hom.ker, mk_ker,
   comap_map_of_surjective (ideal.quotient.mk I) (quotient.mk_surjective), ← ring_hom.ker, mk_ker,
   sup_comm]
 
-/-- define `lift_add_double_quot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/
-def lift_sup_double_quot_mk (I J : ideal R) : (I ⊔ J).quotient →+*
+/-- The ring homomorphism `R/(I ⊔ J) → (R/I)/J' `induced by `quot_quot_mk` -/
+def lift_sup_quot_quot_mk (I J : ideal R) : (I ⊔ J).quotient →+*
   (J.map (ideal.quotient.mk I)).quotient :=
-ideal.quotient.lift (I ⊔ J) (double_quot_mk I J) (ker_double_quot_mk I J).symm.le
+ideal.quotient.lift (I ⊔ J) (quot_quot_mk I J) (ker_quot_quot_mk I J).symm.le
 
-/-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/
-def double_quot_equiv_quot_sup : (J.map (ideal.quotient.mk I)).quotient ≃+* (I ⊔ J).quotient :=
-ring_equiv.of_hom_inv (double_quot_to_quot_sup I J) (lift_sup_double_quot_mk I J)
+/-- `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/
+def quot_quot_equiv_quot_sup : (J.map (ideal.quotient.mk I)).quotient ≃+* (I ⊔ J).quotient :=
+ring_equiv.of_hom_inv (quot_quot_to_quot_sup I J) (lift_sup_quot_quot_mk I J)
   (by { ext z, refl }) (by { ext z, refl })
 
 end double_quot

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1664,7 +1664,7 @@ ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sup I
   (ker_quot_left_to_quot_sup I J).symm.le
 
 /-- define `double_quot_mk` to be the composite of the maps `R → (R/I) and (R/I) → (R/I)/J'` -/
-def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=
+def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient :=
 ((J.map I^.quotient.mk)^.quotient.mk).comp I^.quotient.mk
 
 -- Another short result for lifting map `ring_to_double_quot` to a map `R/(I ⊔ J) → (R/I)/J'`

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1674,8 +1674,8 @@ by rw [ring_hom.ker_eq_comap_bot, double_quot_mk, ← comap_comap, ← ring_hom.
   sup_comm]
 
 /-- define `lift_add_double_quot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/
-def lift_sup_double_quot_mk (I J : ideal R) := ideal.quotient.lift (I ⊔ J) (double_quot_mk I J)
-  (ker_double_quot_mk I J).symm.le
+def lift_sup_double_quot_mk (I J : ideal R) :=
+ideal.quotient.lift (I ⊔ J) (double_quot_mk I J) (ker_double_quot_mk I J).symm.le
 
 /-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/
 def double_quot_equiv_quot_sup : (J.map (ideal.quotient.mk I)).quotient ≃+* (I ⊔ J).quotient :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1671,7 +1671,8 @@ by rw [ring_hom.ker_eq_comap_bot, double_quot_mk, ← comap_comap, ← ring_hom.
   sup_comm]
 
 /-- define `lift_add_double_quot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/
-def lift_sup_double_quot_mk (I J : ideal R) :=
+def lift_sup_double_quot_mk (I J : ideal R) : (I ⊔ J).quotient →+*
+  (J.map (ideal.quotient.mk I)).quotient :=
 ideal.quotient.lift (I ⊔ J) (double_quot_mk I J) (ker_double_quot_mk I J).symm.le
 
 /-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1699,7 +1699,7 @@ end
 
 /-- define `lift_add_double_quot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/
 def lift_sup_double_quot_mk (I J : ideal R) := ideal.quotient.lift (I ⊔ J) (double_quot_mk I J)
-  ((ker_double_quot_mk I J).symm).le
+  (ker_double_quot_mk I J).symm.le
 
 /-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/
 def double_quot_equiv_quot_sup : (J.map (ideal.quotient.mk I)).quotient ≃+* (I ⊔ J).quotient :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1302,18 +1302,10 @@ end
 
 theorem map_eq_iff_sup_ker_eq_of_surjective {I J : ideal R} (f : R →+* S)
   (hf : function.surjective f) : map f I = map f J ↔ I ⊔ f.ker = J ⊔ f.ker :=
-begin
-  split,
-  { intro h,
-    apply_fun comap f at h,
-    rw [comap_map_of_surjective f hf, comap_map_of_surjective f hf,
-      ← ring_hom.ker_eq_comap_bot] at h,
-    exact h },
-  { intro h,
-    apply_fun map f at h,
-    rw [map_sup, map_sup, (map_eq_bot_iff_le_ker f).2 (le_refl f.ker), sup_bot_eq, sup_bot_eq] at h,
-    exact h },
-end
+by rw [← (comap_injective_of_surjective f hf).eq_iff,
+  comap_map_of_surjective f hf, comap_map_of_surjective f hf,
+  ring_hom.ker_eq_comap_bot]
+
 
 theorem map_radical_of_surjective {f : R →+* S} (hf : function.surjective f) {I : ideal R}
   (h : ring_hom.ker f ≤ I) : map f (I.radical) = (map f I).radical :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1665,7 +1665,7 @@ def lift_sup_quot_quot_mk (I J : ideal R) : (I ⊔ J).quotient →+*
   (J.map (ideal.quotient.mk I)).quotient :=
 ideal.quotient.lift (I ⊔ J) (quot_quot_mk I J) (ker_quot_quot_mk I J).symm.le
 
-/-- `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/
+/-- `quot_quot_to_quot_add` and `lift_sup_double_qot_mk` are inverse isomorphisms -/
 def quot_quot_equiv_quot_sup : (J.map (ideal.quotient.mk I)).quotient ≃+* (I ⊔ J).quotient :=
 ring_equiv.of_hom_inv (quot_quot_to_quot_sup I J) (lift_sup_quot_quot_mk I J)
   (by { ext z, refl }) (by { ext z, refl })

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1618,7 +1618,7 @@ variables {R : Type u} [comm_ring R] (I J : ideal R)
 
 /-- define `quot_left_to_quot_sup` to be the obvious ring hom `R/I → R/(I ⊔ J)` -/
 def quot_left_to_quot_sup : I.quotient →+* (I ⊔ J).quotient :=
-  ideal.quotient.factor I (I ⊔ J) (le_sup_left)
+ideal.quotient.factor I (I ⊔ J) (le_sup_left)
 
 /-- This will be used to lift `quot_left_to_quot_sup` to a map `(R/I)/J' → R/(I ⊔ J)`-/
 lemma map_mk_le_ker_quot_left_to_quot_sup :

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1696,8 +1696,7 @@ end
 
 /-- define `lift_add_double_quot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/
 def lift_sup_double_quot_mk (I J : ideal R) := ideal.quotient.lift (I ⊔ J) (double_quot_mk I J)
-  (λ x hx, (ring_hom.mem_ker (double_quot_mk I J)).1 ((set_like.ext_iff.1
-    (ker_double_quot_mk I J)  x).2 hx))
+  ker_double_quot_mk.le
 
 /-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/
 def double_quot_equiv_quot_sup : (J.map (ideal.quotient.mk I)).quotient ≃+* (I ⊔ J).quotient :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1621,7 +1621,7 @@ def quot_left_to_quot_sup : I.quotient →+* (I ⊔ J).quotient :=
 ideal.quotient.factor I (I ⊔ J) (le_sup_left)
 
 /-- This will be used to lift `quot_left_to_quot_sup` to a map `(R/I)/J' → R/(I ⊔ J)`-/
-lemma map_mk_le_ker_quot_left_to_quot_sup :
+lemma ker_quot_left_to_quot_sup :
   (quot_left_to_quot_sup I J).ker = J.map (ideal.quotient.mk I) :=
 begin
   ext x,

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1626,6 +1626,14 @@ lemma ker_quot_left_to_quot_sup :
 begin
   ext x,
   split,
+    {intro hx,
+    obtain ⟨y, hy⟩ := quotient.mk_surjective x,
+    rw [ring_hom.mem_ker, ← hy,quot_left_to_quot_sup, ideal.quotient.factor_mk, ← ring_hom.mem_ker,
+     mk_ker] at hx,
+    replace hx := (mem_map_of_mem (I^.quotient.mk)) hx,
+    have :  I.map I^.quotient.mk = ⊥ := by rw [map_eq_bot_iff_le_ker, mk_ker] ; exact le_refl I,
+    rw [map_sup, this, bot_sup_eq, hy] at hx,
+    exact hx},
    {intro hx,
     have hIJmap: ((quot_left_to_quot_sup I J).comp(ideal.quotient.mk I) '' J) =
     (ideal.quotient.mk (I ⊔ J) '' J),
@@ -1654,21 +1662,13 @@ begin
         exact (set.mem_image_of_mem (quot_left_to_quot_sup I J) hx)},
     have : J.map(ideal.quotient.mk(I ⊔ J)) = ⊥ :=  map_mk_eq_bot_of_le le_sup_right,
     rwa [hJ,this] at hmapx},
-    {intro hx,
-    obtain ⟨y, hy⟩ := quotient.mk_surjective x,
-    rw [ring_hom.mem_ker, ← hy,quot_left_to_quot_sup, ideal.quotient.factor_mk, ← ring_hom.mem_ker,
-     mk_ker] at hx,
-    replace hx := (mem_map_of_mem (I^.quotient.mk)) hx,
-    have :  I.map I^.quotient.mk = ⊥ := by rw [map_eq_bot_iff_le_ker, mk_ker] ; exact le_refl I,
-    rw [map_sup, this, bot_sup_eq, hy] at hx,
-    exact hx},
 end
 
 /-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I ⊔ J)`,
   where `J'` is the image of `J` in `R/I` -/
 def double_quot_to_quot_sup : (J.map (ideal.quotient.mk I)).quotient →+* (I ⊔ J).quotient :=
 ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sup I J)
-  (map_mk_le_ker_quot_left_to_quot_sup I J).le
+  (ker_quot_left_to_quot_sup I J).symm.le
 
 /-- define `double_quot_mk` to be the composite of the maps `R → (R/I) and (R/I) → (R/I)/J'` -/
 def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1281,7 +1281,7 @@ variables [comm_ring R] [comm_ring S]
 by ext; rw [ring_hom.ker, mem_comap, submodule.mem_bot, quotient.eq_zero_iff_mem]
 
 lemma map_mk_eq_bot_of_le {I J : ideal R} (h : I ≤ J) : I.map (J^.quotient.mk) = ⊥ :=
-by {rw [map_eq_bot_iff_le_ker, mk_ker], exact h}
+by { rw [map_eq_bot_iff_le_ker, mk_ker], exact h }
 
 lemma ker_quotient_lift {S : Type v} [comm_ring S] {I : ideal R} (f : R →+* S) (H : I ≤ f.ker) :
   (ideal.quotient.lift I f H).ker = (f.ker).map I^.quotient.mk :=
@@ -1289,33 +1289,30 @@ begin
   ext x,
   split,
   { intro hx,
-  obtain ⟨y, hy⟩ := quotient.mk_surjective x,
-  rw [ring_hom.mem_ker, ← hy, ideal.quotient.lift_mk, ← ring_hom.mem_ker] at hx,
-  rw [← hy, mem_map_iff_of_surjective I^.quotient.mk quotient.mk_surjective],
-  use y,
-  split,
-  exact hx,
-  refl},
- {intro hx,
-  rw mem_map_iff_of_surjective I^.quotient.mk quotient.mk_surjective at hx,
-  obtain ⟨y, hy⟩ := hx,
-  rw [ring_hom.mem_ker, ← hy.right, ideal.quotient.lift_mk, ← (ring_hom.mem_ker f)],
-    exact hy.left},
+    obtain ⟨y, hy⟩ := quotient.mk_surjective x,
+    rw [ring_hom.mem_ker, ← hy, ideal.quotient.lift_mk, ← ring_hom.mem_ker] at hx,
+    rw [← hy, mem_map_iff_of_surjective I^.quotient.mk quotient.mk_surjective],
+    exact ⟨y, hx, rfl⟩ },
+ { intro hx,
+    rw mem_map_iff_of_surjective I^.quotient.mk quotient.mk_surjective at hx,
+    obtain ⟨y, hy⟩ := hx,
+    rw [ring_hom.mem_ker, ← hy.right, ideal.quotient.lift_mk, ← (ring_hom.mem_ker f)],
+    exact hy.left },
 end
 
 theorem map_eq_iff_sup_ker_eq_of_surjective {I J : ideal R} (f : R →+* S)
   (hf : function.surjective f) : map f I = map f J ↔ I ⊔ f.ker = J ⊔ f.ker :=
 begin
   split,
-   {intro h,
+  { intro h,
     apply_fun comap f at h,
     rw [comap_map_of_surjective f hf, comap_map_of_surjective f hf,
       ← ring_hom.ker_eq_comap_bot] at h,
-    exact h},
-   {intro h,
+    exact h },
+  { intro h,
     apply_fun map f at h,
     rw [map_sup, map_sup, (map_eq_bot_iff_le_ker f).2 (le_refl f.ker), sup_bot_eq, sup_bot_eq] at h,
-    exact h},
+    exact h },
 end
 
 theorem map_radical_of_surjective {f : R →+* S} (hf : function.surjective f) {I : ideal R}

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1646,7 +1646,7 @@ variables {R : Type u} [comm_ring R] (I J : ideal R)
 
 /-- define `quot_left_to_quot_sup` to be the obvious ring hom `R/I → R/(I ⊔ J)` -/
 def quot_left_to_quot_sup : I.quotient →+* (I ⊔ J).quotient :=
-ideal.quotient.factor I (I ⊔ J) (le_sup_left)
+ideal.quotient.factor I (I ⊔ J) le_sup_left
 
 /-- This will be used to lift `quot_left_to_quot_sup` to a map `(R/I)/J' → R/(I ⊔ J)`-/
 lemma ker_quot_left_to_quot_sup :

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1305,7 +1305,6 @@ theorem map_eq_iff_sup_ker_eq_of_surjective {I J : ideal R} (f : R →+* S)
 by rw [← (comap_injective_of_surjective f hf).eq_iff, comap_map_of_surjective f hf,
   comap_map_of_surjective f hf, ring_hom.ker_eq_comap_bot]
 
-
 theorem map_radical_of_surjective {f : R →+* S} (hf : function.surjective f) {I : ideal R}
   (h : ring_hom.ker f ≤ I) : map f (I.radical) = (map f I).radical :=
 begin

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1622,7 +1622,7 @@ ideal.quotient.factor I (I ⊔ J) (le_sup_left)
 
 /-- This will be used to lift `quot_left_to_quot_sup` to a map `(R/I)/J' → R/(I ⊔ J)`-/
 lemma map_mk_le_ker_quot_left_to_quot_sup :
-  J.map (ideal.quotient.mk I) = (quot_left_to_quot_sup I J).ker :=
+  (quot_left_to_quot_sup I J).ker = J.map (ideal.quotient.mk I) :=
 begin
   ext x,
   split,

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1671,8 +1671,9 @@ def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=
 ((J.map I^.quotient.mk)^.quotient.mk).comp I^.quotient.mk
 
 -- Another short result for lifting map `ring_to_double_quot` to a map `R/(I ⊔ J) → (R/I)/J'`
-lemma mem_add_double_quot_mk (x : R) (hx : x ∈ I ⊔ J) : double_quot_mk I J x = 0 :=
+lemma sup_le_ker_double_quot_mk : I ⊔ J ≤ (double_quot_mk I J).ker :=
 begin
+  intros x hx,
   have hIJtoJ : (I ⊔ J).map(ideal.quotient.mk I) = J.map(ideal.quotient.mk I) := by {
     rw [ ideal.map_sup, ideal.map_quotient_self],
     simp},

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1609,13 +1609,13 @@ namespace double_quot
 variables {R : Type u} [comm_ring R] (I J : ideal R)
 
 -- a few lemmas to help shorten the proofs later
-lemma left_proj_quot_add_mk (x :R) (hx : x ∈ I) : ideal.quotient.mk (I+J) x = 0 :=
+lemma left_proj_quot_add_mk (x :R) (hx : x ∈ I) : ideal.quotient.mk (I ⊔ J) x = 0 :=
 ideal.quotient.eq_zero_iff_mem.2 (ideal.mem_sup_left hx)
 
-lemma right_proj_quot_add_mk (x : R) (hx : x ∈ J) :  ideal.quotient.mk (I+J) x = 0 :=
+lemma right_proj_quot_add_mk (x : R) (hx : x ∈ J) :  ideal.quotient.mk (I ⊔ J) x = 0 :=
 ideal.quotient.eq_zero_iff_mem.2 (ideal.mem_sup_right hx)
 
-lemma in_ker_proj_to_add_left : I.map(ideal.quotient.mk(I+J)) = ⊥ :=
+lemma in_ker_proj_to_add_left : I.map(ideal.quotient.mk(I ⊔ J)) = ⊥ :=
 begin
   simp_rw [ideal.map, ideal.span_eq_bot, set.mem_image],
   rintros y ⟨x, hx, rfl⟩,
@@ -1623,40 +1623,40 @@ begin
 end
 
 
-lemma in_ker_proj_to_add_right : J.map(ideal.quotient.mk(I+J)) = ⊥ :=
-by {rw add_comm, apply in_ker_proj_to_add_left}
+lemma in_ker_proj_to_add_right : J.map(ideal.quotient.mk(I ⊔ J)) = ⊥ :=
+by {rw sup_comm, apply in_ker_proj_to_add_left}
 
-/-- define `quot_left_to_quot_sum` to be the obvious ring hom `R/I → R/(I+J)` -/
-def quot_left_to_quot_sum : I.quotient →+* (I+J).quotient :=
-ideal.quotient.lift I (ideal.quotient.mk (I+J)) (left_proj_quot_add_mk I J)
+/-- define `quot_left_to_quot_sum` to be the obvious ring hom `R/I → R/(I ⊔ J)` -/
+def quot_left_to_quot_sum : I.quotient →+* (I ⊔ J).quotient :=
+ideal.quotient.lift I (ideal.quotient.mk (I ⊔ J)) (left_proj_quot_add_mk I J)
 
-/-- This will be used to lift `quot_left_to_quot_sum` to a map `(R/I)/J' → R/(I+J)`-/
+/-- This will be used to lift `quot_left_to_quot_sum` to a map `(R/I)/J' → R/(I ⊔ J)`-/
 lemma img_left_in_ker (x : I.quotient) (hx : x ∈ J.map(ideal.quotient.mk I)) :
   quot_left_to_quot_sum I J x = 0 :=
 begin
   have hIJmap: ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I) '' J) =
-    (ideal.quotient.mk (I+J) '' J),
+    (ideal.quotient.mk (I ⊔ J) '' J),
    {apply set.ext,
     intro y,
     split,
 
      {intro hy,
-      obtain ⟨z,hz⟩ := (set.mem_image ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I))
+      obtain ⟨z, hz⟩ := (set.mem_image ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I))
         J y).1 hy,
       unfold quot_left_to_quot_sum at hz,
-      rw [ring_hom.comp_apply,ideal.quotient.lift_mk] at hz,
+      rw [ring_hom.comp_apply, ideal.quotient.lift_mk] at hz,
       rw ← hz.right,
-      exact set.mem_image_of_mem (ideal.quotient.mk (I+J)) hz.left},
+      exact set.mem_image_of_mem (ideal.quotient.mk (I ⊔ J)) hz.left},
 
      {intro hy,
-      obtain ⟨z,hz⟩ := (set.mem_image (ideal.quotient.mk (I+J)) J y).1 hy,
+      obtain ⟨z, hz⟩ := (set.mem_image (ideal.quotient.mk (I ⊔ J)) J y).1 hy,
       rw [quot_left_to_quot_sum, set.mem_image_eq],
       use z,
       rwa [ring_hom.comp_apply, ideal.quotient.lift_mk]},
     },
 
   have hJ: (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sum I J) = J.map
-    (ideal.quotient.mk (I+J))
+    (ideal.quotient.mk (I ⊔ J))
     := by rw [ideal.map_map, ideal.map,hIJmap, ← ideal.map],
 
   have hmapx : quot_left_to_quot_sum I J x ∈ (J.map (ideal.quotient.mk I)).map
@@ -1668,9 +1668,9 @@ begin
   rwa [hJ, in_ker_proj_to_add_right I J] at hmapx,
 end
 
-/-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I+J)`,
+/-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I ⊔ J)`,
   where `J'` is the image of `J` in `R/I` -/
-def double_quot_to_quot_add : (J.map (ideal.quotient.mk I)).quotient →+* (I + J).quotient :=
+def double_quot_to_quot_add : (J.map (ideal.quotient.mk I)).quotient →+* (I ⊔ J).quotient :=
 ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sum I J)
  (img_left_in_ker I J)
 
@@ -1678,14 +1678,14 @@ ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sum I
 def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=
 ((J.map I^.quotient.mk)^.quotient.mk).comp I^.quotient.mk
 
--- Another short result for lifting map `ring_to_double_quot` to a map `R/(I+J) → (R/I)/J'`
+-- Another short result for lifting map `ring_to_double_quot` to a map `R/(I ⊔ J) → (R/I)/J'`
 --shorter and easier proof using ker_g₁ from
-lemma mem_add_double_quot_mk (x : R) (hx : x ∈ I+J) : double_quot_mk I J x = 0 :=
+lemma mem_add_double_quot_mk (x : R) (hx : x ∈ I ⊔ J) : double_quot_mk I J x = 0 :=
 begin
-  have hIJtoJ : (I+J).map(ideal.quotient.mk I) = J.map(ideal.quotient.mk I) := by {
-    rw [ideal.add_eq_sup, ideal.map_sup, ideal.map_quotient_self],
+  have hIJtoJ : (I ⊔ J).map(ideal.quotient.mk I) = J.map(ideal.quotient.mk I) := by {
+    rw [ ideal.map_sup, ideal.map_quotient_self],
     simp},
-  have : ((I+J).map(ideal.quotient.mk I)).map(ideal.quotient.mk
+  have : ((I ⊔ J).map(ideal.quotient.mk I)).map(ideal.quotient.mk
     (J.map(ideal.quotient.mk I))) = ⊥ := by rw [hIJtoJ, ideal.map_quotient_self
       (J.map(ideal.quotient.mk I))],
   rw [double_quot_mk, ← ideal.mem_bot, ← this, ring_hom.comp_apply],
@@ -1694,12 +1694,12 @@ begin
   exact hx,
 end
 
-/-- define `lift_add_double_qot_mk` to be the induced map `R/(I+J) → (R/I)/J' ` -/
-def lift_add_double_qot_mk (I J : ideal R) := ideal.quotient.lift (I+J) (double_quot_mk I J)
+/-- define `lift_add_double_qot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/
+def lift_add_double_qot_mk (I J : ideal R) := ideal.quotient.lift (I ⊔ J) (double_quot_mk I J)
   (mem_add_double_quot_mk I J)
 
 /-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/
-def double_quot_equiv_quot_add : (J.map (ideal.quotient.mk I)).quotient ≃+* (I + J).quotient :=
+def double_quot_equiv_quot_add : (J.map (ideal.quotient.mk I)).quotient ≃+* (I ⊔ J).quotient :=
 ring_equiv.of_hom_inv (double_quot_to_quot_add I J) (lift_add_double_qot_mk I J)
   (by { ext z, refl }) (by { ext z, refl })
 

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1619,14 +1619,11 @@ ideal.quotient.eq_zero_iff_mem.2 (ideal.mem_sup_right hx)
 
 lemma in_ker_proj_to_add_left : I.map(ideal.quotient.mk(I+J)) = ⊥ :=
 begin
-  rw [ideal.map,ideal.span_eq_bot],
-  intro y,
-  rw set.mem_image,
-  intro hy,
-  cases hy with x hx,
-  rw ← hx.2,
-  exact left_proj_quot_add_mk I J x hx.1,
+  simp_rw [ideal.map, ideal.span_eq_bot, set.mem_image],
+  rintros y ⟨x, hx, rfl⟩,
+  exact left_proj_quot_add_mk I J x hx,
 end
+
 
 lemma in_ker_proj_to_add_right : J.map(ideal.quotient.mk(I+J)) = ⊥ :=
 by {rw add_comm, apply in_ker_proj_to_add_left}
@@ -1678,5 +1675,34 @@ end
 def double_quot_to_quot_add : (J.map (ideal.quotient.mk I)).quotient →+* (I + J).quotient :=
 ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sum I J)
  (img_left_in_ker I J)
+
+/-- define `double_quot_mk` to be the composite of the maps `R → (R/I) and (R/I) → (R/I)/J'` -/
+def double_quot_mk := ring_hom.comp (ideal.quotient.mk (J.map (ideal.quotient.mk I)))
+ (ideal.quotient.mk I)
+
+-- Another short result for lifting map `ring_to_double_quot` to a map `R/(I+J) → (R/I)/J'`
+--shorter and easier proof using ker_g₁ from
+def mem_add_double_quot_mk (x : R) (hx : x ∈ I+J) : double_quot_mk I J x = 0 :=
+begin
+  have hIJtoJ : (I+J).map(ideal.quotient.mk I) = J.map(ideal.quotient.mk I) := by {
+    rw [ideal.add_eq_sup, ideal.map_sup, ideal.map_quotient_self],
+    simp},
+  have : ((I+J).map(ideal.quotient.mk I)).map(ideal.quotient.mk
+    (J.map(ideal.quotient.mk I))) = ⊥ := by rw [hIJtoJ, ideal.map_quotient_self
+      (J.map(ideal.quotient.mk I))],
+  rw [double_quot_mk, ← ideal.mem_bot, ← this, ring_hom.comp_apply],
+  apply ideal.mem_map_of_mem,
+  apply ideal.mem_map_of_mem,
+  exact hx,
+end
+
+-- define `lift_add_double_qot_mk` to be the induced map `R/(I+J) → (R/I)/J' `
+def lift_add_double_qot_mk (I J : ideal R) := ideal.quotient.lift (I+J) (double_quot_mk I J)
+  (mem_add_double_quot_mk I J)
+
+-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms
+theorem double_quot_equiv_quot_add : (J.map (ideal.quotient.mk I)).quotient ≃+* (I + J).quotient :=
+ring_equiv.of_hom_inv (double_quot_to_quot_add I J) (lift_add_double_qot_mk I J)
+  (by { ext z, refl }) (by { ext z, refl })
 
 end double_quot

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1609,7 +1609,6 @@ namespace double_quot
 variables {R : Type u} [comm_ring R] (I J : ideal R)
 
 lemma add_comm : I+J = J+I := _root_.add_comm I J
-  --rw [ideal.add_eq_sup, sup_comm, ← ideal.add_eq_sup]}
 
 -- a few lemmas to help shorten the proofs later
 def left_proj_quot_add_mk (x :R) (hx : x ∈ I) : ideal.quotient.mk (I+J) x = 0 :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1677,8 +1677,8 @@ ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sum I
  (img_left_in_ker I J)
 
 /-- define `double_quot_mk` to be the composite of the maps `R → (R/I) and (R/I) → (R/I)/J'` -/
-def double_quot_mk := ring_hom.comp (ideal.quotient.mk (J.map (ideal.quotient.mk I)))
- (ideal.quotient.mk I)
+def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=
+((J.map I^.quotient.mk)^.quotient.mk).comp I^.quotient.mk
 
 -- Another short result for lifting map `ring_to_double_quot` to a map `R/(I+J) → (R/I)/J'`
 --shorter and easier proof using ker_g₁ from

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1618,7 +1618,7 @@ variables {R : Type u} [comm_ring R] (I J : ideal R)
 
 /-- define `quot_left_to_quot_sum` to be the obvious ring hom `R/I → R/(I ⊔ J)` -/
 def quot_left_to_quot_sum : I.quotient →+* (I ⊔ J).quotient :=
-  ideal.quotient.lift_mk_of_le I (I ⊔ J) (le_sup_left)
+  ideal.quotient.inclusion I (I ⊔ J) (le_sup_left)
 
 /-- This will be used to lift `quot_left_to_quot_sum` to a map `(R/I)/J' → R/(I ⊔ J)`-/
 lemma img_left_in_ker (x : I.quotient) (hx : x ∈ J.map(ideal.quotient.mk I)) :
@@ -1634,7 +1634,7 @@ begin
       obtain ⟨z, hz⟩ := (set.mem_image ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I))
         J y).1 hy,
       unfold quot_left_to_quot_sum at hz,
-      rw [ring_hom.comp_apply, ideal.quotient.lift_mk_of_le, ideal.quotient.lift_mk] at hz,
+      rw [ring_hom.comp_apply, ideal.quotient.inclusion, ideal.quotient.lift_mk] at hz,
       rw ← hz.right,
       exact set.mem_image_of_mem (ideal.quotient.mk (I ⊔ J)) hz.left},
 
@@ -1642,7 +1642,7 @@ begin
       obtain ⟨z, hz⟩ := (set.mem_image (ideal.quotient.mk (I ⊔ J)) J y).1 hy,
       rw [quot_left_to_quot_sum, set.mem_image_eq],
       use z,
-      rwa [ring_hom.comp_apply, ideal.quotient.lift_mk_of_le, ideal.quotient.lift_mk]},
+      rwa [ring_hom.comp_apply, ideal.quotient.inclusion, ideal.quotient.lift_mk]},
     },
 
   have hJ: (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sum I J) = J.map

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1684,8 +1684,8 @@ begin
   exact hx,
 end
 
-/-- define `lift_add_double_qot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/
-def lift_add_double_qot_mk (I J : ideal R) := ideal.quotient.lift (I ⊔ J) (double_quot_mk I J)
+/-- define `lift_add_double_quot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/
+def lift_add_double_quot_mk (I J : ideal R) := ideal.quotient.lift (I ⊔ J) (double_quot_mk I J)
   (mem_add_double_quot_mk I J)
 
 /-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1671,19 +1671,14 @@ def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=
 ((J.map I^.quotient.mk)^.quotient.mk).comp I^.quotient.mk
 
 -- Another short result for lifting map `ring_to_double_quot` to a map `R/(I ⊔ J) → (R/I)/J'`
-lemma sup_le_ker_double_quot_mk : I ⊔ J ≤ (double_quot_mk I J).ker :=
+lemma ker_double_quot_mk : (double_quot_mk I J).ker = I ⊔ J :=
 begin
-  intros x hx,
-  have hIJtoJ : (I ⊔ J).map(ideal.quotient.mk I) = J.map(ideal.quotient.mk I) := by {
-    rw [ ideal.map_sup, ideal.map_quotient_self],
-    simp},
-  have : ((I ⊔ J).map(ideal.quotient.mk I)).map(ideal.quotient.mk
-    (J.map(ideal.quotient.mk I))) = ⊥ := by rw [hIJtoJ, ideal.map_quotient_self
-      (J.map(ideal.quotient.mk I))],
-  rw [double_quot_mk, ← ideal.mem_bot, ← this, ring_hom.comp_apply],
-  apply ideal.mem_map_of_mem,
-  apply ideal.mem_map_of_mem,
-  exact hx,
+  ext,
+  rw [sup_comm, submodule.mem_sup, ring_hom.mem_ker, double_quot_mk, ring_hom.comp_apply,
+    quotient.eq_zero_iff_mem, mem_map_iff_of_surjective _ (quotient.mk_surjective)],
+  simp_rw [ideal.quotient.eq, exists_prop],
+  refine exists_congr (λ a, and_congr_right $ λ ha, _),
+  sorry,
 end
 
 /-- define `lift_add_double_quot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1621,9 +1621,10 @@ def quot_left_to_quot_sum : I.quotient →+* (I ⊔ J).quotient :=
   ideal.quotient.inclusion I (I ⊔ J) (le_sup_left)
 
 /-- This will be used to lift `quot_left_to_quot_sum` to a map `(R/I)/J' → R/(I ⊔ J)`-/
-lemma img_left_in_ker (x : I.quotient) (hx : x ∈ J.map(ideal.quotient.mk I)) :
-  quot_left_to_quot_sum I J x = 0 :=
+lemma map_mk_le_ker_quot_left_to_quot_sum :
+  J.map (ideal.quotient.mk I) ≤ (quot_left_to_quot_sum I J).ker :=
 begin
+  intros x hx,
   have hIJmap: ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I) '' J) =
     (ideal.quotient.mk (I ⊔ J) '' J),
    {apply set.ext,

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1611,10 +1611,10 @@ variables {R : Type u} [comm_ring R] (I J : ideal R)
 lemma add_comm : I+J = J+I := _root_.add_comm I J
 
 -- a few lemmas to help shorten the proofs later
-def left_proj_quot_add_mk (x :R) (hx : x ∈ I) : ideal.quotient.mk (I+J) x = 0 :=
+lemma left_proj_quot_add_mk (x :R) (hx : x ∈ I) : ideal.quotient.mk (I+J) x = 0 :=
 ideal.quotient.eq_zero_iff_mem.2 (ideal.mem_sup_left hx)
 
-def right_proj_quot_add_mk (x : R) (hx : x ∈ J) :  ideal.quotient.mk (I+J) x = 0 :=
+lemma right_proj_quot_add_mk (x : R) (hx : x ∈ J) :  ideal.quotient.mk (I+J) x = 0 :=
 ideal.quotient.eq_zero_iff_mem.2 (ideal.mem_sup_right hx)
 
 lemma in_ker_proj_to_add_left : I.map(ideal.quotient.mk(I+J)) = ⊥ :=
@@ -1633,7 +1633,7 @@ def quot_left_to_quot_sum : I.quotient →+* (I+J).quotient :=
 ideal.quotient.lift I (ideal.quotient.mk (I+J)) (left_proj_quot_add_mk I J)
 
 /-- This will be used to lift `quot_left_to_quot_sum` to a map `(R/I)/J' → R/(I+J)`-/
-def img_left_in_ker (x : I.quotient) (hx : x ∈ J.map(ideal.quotient.mk I)) :
+lemma img_left_in_ker (x : I.quotient) (hx : x ∈ J.map(ideal.quotient.mk I)) :
   quot_left_to_quot_sum I J x = 0 :=
 begin
   have hIJmap: ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I) '' J) =
@@ -1682,7 +1682,7 @@ def double_quot_mk := ring_hom.comp (ideal.quotient.mk (J.map (ideal.quotient.mk
 
 -- Another short result for lifting map `ring_to_double_quot` to a map `R/(I+J) → (R/I)/J'`
 --shorter and easier proof using ker_g₁ from
-def mem_add_double_quot_mk (x : R) (hx : x ∈ I+J) : double_quot_mk I J x = 0 :=
+lemma mem_add_double_quot_mk (x : R) (hx : x ∈ I+J) : double_quot_mk I J x = 0 :=
 begin
   have hIJtoJ : (I+J).map(ideal.quotient.mk I) = J.map(ideal.quotient.mk I) := by {
     rw [ideal.add_eq_sup, ideal.map_sup, ideal.map_quotient_self],
@@ -1696,12 +1696,12 @@ begin
   exact hx,
 end
 
--- define `lift_add_double_qot_mk` to be the induced map `R/(I+J) → (R/I)/J' `
+/-- define `lift_add_double_qot_mk` to be the induced map `R/(I+J) → (R/I)/J' ` -/
 def lift_add_double_qot_mk (I J : ideal R) := ideal.quotient.lift (I+J) (double_quot_mk I J)
   (mem_add_double_quot_mk I J)
 
--- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms
-theorem double_quot_equiv_quot_add : (J.map (ideal.quotient.mk I)).quotient ≃+* (I + J).quotient :=
+/-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/
+def double_quot_equiv_quot_add : (J.map (ideal.quotient.mk I)).quotient ≃+* (I + J).quotient :=
 ring_equiv.of_hom_inv (double_quot_to_quot_add I J) (lift_add_double_qot_mk I J)
   (by { ext z, refl }) (by { ext z, refl })
 

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1608,8 +1608,6 @@ end ring_hom
 namespace double_quot
 variables {R : Type u} [comm_ring R] (I J : ideal R)
 
-lemma add_comm : I+J = J+I := _root_.add_comm I J
-
 -- a few lemmas to help shorten the proofs later
 lemma left_proj_quot_add_mk (x :R) (hx : x ∈ I) : ideal.quotient.mk (I+J) x = 0 :=
 ideal.quotient.eq_zero_iff_mem.2 (ideal.mem_sup_left hx)

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1618,7 +1618,7 @@ variables {R : Type u} [comm_ring R] (I J : ideal R)
 
 /-- define `quot_left_to_quot_sup` to be the obvious ring hom `R/I → R/(I ⊔ J)` -/
 def quot_left_to_quot_sup : I.quotient →+* (I ⊔ J).quotient :=
-  ideal.quotient.inclusion I (I ⊔ J) (le_sup_left)
+  ideal.quotient.factor I (I ⊔ J) (le_sup_left)
 
 /-- This will be used to lift `quot_left_to_quot_sup` to a map `(R/I)/J' → R/(I ⊔ J)`-/
 lemma map_mk_le_ker_quot_left_to_quot_sum :
@@ -1635,7 +1635,7 @@ begin
       obtain ⟨z, hz⟩ := (set.mem_image ((quot_left_to_quot_sup I J).comp(ideal.quotient.mk I))
         J y).1 hy,
       unfold quot_left_to_quot_sup at hz,
-      rw [ring_hom.comp_apply, ideal.quotient.inclusion, ideal.quotient.lift_mk] at hz,
+      rw [ring_hom.comp_apply, ideal.quotient.factor_mk] at hz,
       rw ← hz.right,
       exact set.mem_image_of_mem (ideal.quotient.mk (I ⊔ J)) hz.left},
 
@@ -1643,7 +1643,7 @@ begin
       obtain ⟨z, hz⟩ := (set.mem_image (ideal.quotient.mk (I ⊔ J)) J y).1 hy,
       rw [quot_left_to_quot_sup, set.mem_image_eq],
       use z,
-      rwa [ring_hom.comp_apply, ideal.quotient.inclusion, ideal.quotient.lift_mk]},
+      rwa [ring_hom.comp_apply, ideal.quotient.factor_mk]},
     },
 
   have hJ: (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sup I J) = J.map

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1608,7 +1608,8 @@ end ring_hom
 namespace double_quot
 variables {R : Type u} [comm_ring R] (I J : ideal R)
 
-lemma add_comm : I+J = J+I := by {rw [ideal.add_eq_sup, sup_comm, ← ideal.add_eq_sup]}
+lemma add_comm : I+J = J+I := _root_.add_comm I J
+  --rw [ideal.add_eq_sup, sup_comm, ← ideal.add_eq_sup]}
 
 -- a few lemmas to help shorten the proofs later
 def left_proj_quot_add_mk (x :R) (hx : x ∈ I) : ideal.quotient.mk (I+J) x = 0 :=
@@ -1673,7 +1674,8 @@ begin
   rwa [hJ, in_ker_proj_to_add_right I J] at hmapx,
 end
 
-/-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I+J)`, where `J'` is the image of `J` in `R/I` -/
+/-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I+J)`,
+  where `J'` is the image of `J` in `R/I` -/
 def double_quot_to_quot_add : (J.map (ideal.quotient.mk I)).quotient →+* (I + J).quotient :=
 ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sum I J)
  (img_left_in_ker I J)

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1078,6 +1078,13 @@ eq_bot_iff.2 $ ideal.map_le_iff_le_comap.2 $ λ x hx,
 
 variables {I J K L}
 
+lemma map_mk_eq_bot_of_le (h : I ≤ J) : I.map (J^.quotient.mk) = ⊥ :=
+begin
+  simp_rw [ideal.map, ideal.span_eq_bot, set.mem_image],
+  rintros y ⟨x, hx, rfl⟩,
+  exact ideal.quotient.eq_zero_iff_mem.2 (h hx),
+end
+
 theorem map_radical_le : map f (radical I) ≤ radical (map f I) :=
 map_le_iff_le_comap.2 $ λ r ⟨n, hrni⟩, ⟨n, f.map_pow r n ▸ mem_map_of_mem f hrni⟩
 
@@ -1606,25 +1613,12 @@ end
 end ring_hom
 
 namespace double_quot
+open ideal
 variables {R : Type u} [comm_ring R] (I J : ideal R)
 
 -- a few lemmas to help shorten the proofs later
 lemma left_proj_quot_add_mk (x :R) (hx : x ∈ I) : ideal.quotient.mk (I ⊔ J) x = 0 :=
 ideal.quotient.eq_zero_iff_mem.2 (ideal.mem_sup_left hx)
-
-lemma right_proj_quot_add_mk (x : R) (hx : x ∈ J) :  ideal.quotient.mk (I ⊔ J) x = 0 :=
-ideal.quotient.eq_zero_iff_mem.2 (ideal.mem_sup_right hx)
-
-lemma in_ker_proj_to_add_left : I.map(ideal.quotient.mk(I ⊔ J)) = ⊥ :=
-begin
-  simp_rw [ideal.map, ideal.span_eq_bot, set.mem_image],
-  rintros y ⟨x, hx, rfl⟩,
-  exact left_proj_quot_add_mk I J x hx,
-end
-
-
-lemma in_ker_proj_to_add_right : J.map(ideal.quotient.mk(I ⊔ J)) = ⊥ :=
-by {rw sup_comm, apply in_ker_proj_to_add_left}
 
 /-- define `quot_left_to_quot_sum` to be the obvious ring hom `R/I → R/(I ⊔ J)` -/
 def quot_left_to_quot_sum : I.quotient →+* (I ⊔ J).quotient :=
@@ -1665,7 +1659,8 @@ begin
     apply set.mem_of_subset_of_mem (ideal.subset_span),
     exact (set.mem_image_of_mem (quot_left_to_quot_sum I J) hx)},
 
-  rwa [hJ, in_ker_proj_to_add_right I J] at hmapx,
+  have : J.map(ideal.quotient.mk(I ⊔ J)) = ⊥ :=  map_mk_eq_bot_of_le le_sup_right,
+  rwa [hJ,this] at hmapx,
 end
 
 /-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I ⊔ J)`,

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1661,7 +1661,7 @@ end
 
 /-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I ⊔ J)`,
   where `J'` is the image of `J` in `R/I` -/
-def double_quot_to_quot_add : (J.map (ideal.quotient.mk I)).quotient →+* (I ⊔ J).quotient :=
+def double_quot_to_quot_sup : (J.map (ideal.quotient.mk I)).quotient →+* (I ⊔ J).quotient :=
 ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sum I J)
  (img_left_in_ker I J)
 

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1616,13 +1616,9 @@ namespace double_quot
 open ideal
 variables {R : Type u} [comm_ring R] (I J : ideal R)
 
--- a few lemmas to help shorten the proofs later
-lemma left_proj_quot_add_mk (x :R) (hx : x ∈ I) : ideal.quotient.mk (I ⊔ J) x = 0 :=
-ideal.quotient.eq_zero_iff_mem.2 (ideal.mem_sup_left hx)
-
 /-- define `quot_left_to_quot_sum` to be the obvious ring hom `R/I → R/(I ⊔ J)` -/
 def quot_left_to_quot_sum : I.quotient →+* (I ⊔ J).quotient :=
-ideal.quotient.lift I (ideal.quotient.mk (I ⊔ J)) (left_proj_quot_add_mk I J)
+  ideal.quotient.lift_mk_of_le I (I ⊔ J) (le_sup_left)
 
 /-- This will be used to lift `quot_left_to_quot_sum` to a map `(R/I)/J' → R/(I ⊔ J)`-/
 lemma img_left_in_ker (x : I.quotient) (hx : x ∈ J.map(ideal.quotient.mk I)) :
@@ -1638,7 +1634,7 @@ begin
       obtain ⟨z, hz⟩ := (set.mem_image ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I))
         J y).1 hy,
       unfold quot_left_to_quot_sum at hz,
-      rw [ring_hom.comp_apply, ideal.quotient.lift_mk] at hz,
+      rw [ring_hom.comp_apply, ideal.quotient.lift_mk_of_le, ideal.quotient.lift_mk] at hz,
       rw ← hz.right,
       exact set.mem_image_of_mem (ideal.quotient.mk (I ⊔ J)) hz.left},
 
@@ -1646,7 +1642,7 @@ begin
       obtain ⟨z, hz⟩ := (set.mem_image (ideal.quotient.mk (I ⊔ J)) J y).1 hy,
       rw [quot_left_to_quot_sum, set.mem_image_eq],
       use z,
-      rwa [ring_hom.comp_apply, ideal.quotient.lift_mk]},
+      rwa [ring_hom.comp_apply, ideal.quotient.lift_mk_of_le, ideal.quotient.lift_mk]},
     },
 
   have hJ: (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sum I J) = J.map
@@ -1674,7 +1670,6 @@ def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=
 ((J.map I^.quotient.mk)^.quotient.mk).comp I^.quotient.mk
 
 -- Another short result for lifting map `ring_to_double_quot` to a map `R/(I ⊔ J) → (R/I)/J'`
---shorter and easier proof using ker_g₁ from
 lemma mem_add_double_quot_mk (x : R) (hx : x ∈ I ⊔ J) : double_quot_mk I J x = 0 :=
 begin
   have hIJtoJ : (I ⊔ J).map(ideal.quotient.mk I) = J.map(ideal.quotient.mk I) := by {

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1621,7 +1621,7 @@ def quot_left_to_quot_sup : I.quotient →+* (I ⊔ J).quotient :=
   ideal.quotient.factor I (I ⊔ J) (le_sup_left)
 
 /-- This will be used to lift `quot_left_to_quot_sup` to a map `(R/I)/J' → R/(I ⊔ J)`-/
-lemma map_mk_le_ker_quot_left_to_quot_sum :
+lemma map_mk_le_ker_quot_left_to_quot_sup :
   J.map (ideal.quotient.mk I) ≤ (quot_left_to_quot_sup I J).ker :=
 begin
   intros x hx,
@@ -1665,7 +1665,7 @@ end
 def double_quot_to_quot_sup : (J.map (ideal.quotient.mk I)).quotient →+* (I ⊔ J).quotient :=
 ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sup I J)
  (λ x hx, (ring_hom.mem_ker (quot_left_to_quot_sup I J)).2
-  (map_mk_le_ker_quot_left_to_quot_sum I J hx))
+  (map_mk_le_ker_quot_left_to_quot_sup I J hx))
 
 /-- define `double_quot_mk` to be the composite of the maps `R → (R/I) and (R/I) → (R/I)/J'` -/
 def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=
@@ -1700,7 +1700,7 @@ def lift_sup_double_quot_mk (I J : ideal R) := ideal.quotient.lift (I ⊔ J) (do
     (ker_double_quot_mk I J)  x).2 hx))
 
 /-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/
-def double_quot_equiv_quot_add : (J.map (ideal.quotient.mk I)).quotient ≃+* (I ⊔ J).quotient :=
+def double_quot_equiv_quot_sup : (J.map (ideal.quotient.mk I)).quotient ≃+* (I ⊔ J).quotient :=
 ring_equiv.of_hom_inv (double_quot_to_quot_sup I J) (lift_sup_double_quot_mk I J)
   (by { ext z, refl }) (by { ext z, refl })
 

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1616,45 +1616,45 @@ namespace double_quot
 open ideal
 variables {R : Type u} [comm_ring R] (I J : ideal R)
 
-/-- define `quot_left_to_quot_sum` to be the obvious ring hom `R/I → R/(I ⊔ J)` -/
-def quot_left_to_quot_sum : I.quotient →+* (I ⊔ J).quotient :=
+/-- define `quot_left_to_quot_sup` to be the obvious ring hom `R/I → R/(I ⊔ J)` -/
+def quot_left_to_quot_sup : I.quotient →+* (I ⊔ J).quotient :=
   ideal.quotient.inclusion I (I ⊔ J) (le_sup_left)
 
-/-- This will be used to lift `quot_left_to_quot_sum` to a map `(R/I)/J' → R/(I ⊔ J)`-/
+/-- This will be used to lift `quot_left_to_quot_sup` to a map `(R/I)/J' → R/(I ⊔ J)`-/
 lemma map_mk_le_ker_quot_left_to_quot_sum :
-  J.map (ideal.quotient.mk I) ≤ (quot_left_to_quot_sum I J).ker :=
+  J.map (ideal.quotient.mk I) ≤ (quot_left_to_quot_sup I J).ker :=
 begin
   intros x hx,
-  have hIJmap: ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I) '' J) =
+  have hIJmap: ((quot_left_to_quot_sup I J).comp(ideal.quotient.mk I) '' J) =
     (ideal.quotient.mk (I ⊔ J) '' J),
    {apply set.ext,
     intro y,
     split,
 
      {intro hy,
-      obtain ⟨z, hz⟩ := (set.mem_image ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I))
+      obtain ⟨z, hz⟩ := (set.mem_image ((quot_left_to_quot_sup I J).comp(ideal.quotient.mk I))
         J y).1 hy,
-      unfold quot_left_to_quot_sum at hz,
+      unfold quot_left_to_quot_sup at hz,
       rw [ring_hom.comp_apply, ideal.quotient.inclusion, ideal.quotient.lift_mk] at hz,
       rw ← hz.right,
       exact set.mem_image_of_mem (ideal.quotient.mk (I ⊔ J)) hz.left},
 
      {intro hy,
       obtain ⟨z, hz⟩ := (set.mem_image (ideal.quotient.mk (I ⊔ J)) J y).1 hy,
-      rw [quot_left_to_quot_sum, set.mem_image_eq],
+      rw [quot_left_to_quot_sup, set.mem_image_eq],
       use z,
       rwa [ring_hom.comp_apply, ideal.quotient.inclusion, ideal.quotient.lift_mk]},
     },
 
-  have hJ: (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sum I J) = J.map
+  have hJ: (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sup I J) = J.map
     (ideal.quotient.mk (I ⊔ J))
     := by rw [ideal.map_map, ideal.map,hIJmap, ← ideal.map],
 
-  have hmapx : quot_left_to_quot_sum I J x ∈ (J.map (ideal.quotient.mk I)).map
-    (quot_left_to_quot_sum I J),
+  have hmapx : quot_left_to_quot_sup I J x ∈ (J.map (ideal.quotient.mk I)).map
+    (quot_left_to_quot_sup I J),
     {rw ideal.map,
     apply set.mem_of_subset_of_mem (ideal.subset_span),
-    exact (set.mem_image_of_mem (quot_left_to_quot_sum I J) hx)},
+    exact (set.mem_image_of_mem (quot_left_to_quot_sup I J) hx)},
 
   have : J.map(ideal.quotient.mk(I ⊔ J)) = ⊥ :=  map_mk_eq_bot_of_le le_sup_right,
   rwa [hJ,this] at hmapx,
@@ -1663,8 +1663,9 @@ end
 /-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I ⊔ J)`,
   where `J'` is the image of `J` in `R/I` -/
 def double_quot_to_quot_sup : (J.map (ideal.quotient.mk I)).quotient →+* (I ⊔ J).quotient :=
-ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sum I J)
- (img_left_in_ker I J)
+ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sup I J)
+ (λ x hx, (ring_hom.mem_ker (quot_left_to_quot_sup I J)).2
+  (map_mk_le_ker_quot_left_to_quot_sum I J hx))
 
 /-- define `double_quot_mk` to be the composite of the maps `R → (R/I) and (R/I) → (R/I)/J'` -/
 def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=
@@ -1673,26 +1674,23 @@ def double_quot_mk : R →+* (J.map I^.quotient.mk).quotient:=
 -- Another short result for lifting map `ring_to_double_quot` to a map `R/(I ⊔ J) → (R/I)/J'`
 lemma sup_le_ker_double_quot_mk : I ⊔ J ≤ (double_quot_mk I J).ker :=
 begin
-  intros x hx,
-  have hIJtoJ : (I ⊔ J).map(ideal.quotient.mk I) = J.map(ideal.quotient.mk I) := by {
-    rw [ ideal.map_sup, ideal.map_quotient_self],
-    simp},
-  have : ((I ⊔ J).map(ideal.quotient.mk I)).map(ideal.quotient.mk
-    (J.map(ideal.quotient.mk I))) = ⊥ := by rw [hIJtoJ, ideal.map_quotient_self
-      (J.map(ideal.quotient.mk I))],
-  rw [double_quot_mk, ← ideal.mem_bot, ← this, ring_hom.comp_apply],
-  apply ideal.mem_map_of_mem,
-  apply ideal.mem_map_of_mem,
-  exact hx,
+  apply sup_le _ _,
+  { intros x hx,
+    apply quotient.eq_zero_iff_mem.mpr,
+    rw quotient.eq_zero_iff_mem.mpr hx,
+    exact ideal.zero_mem _, },
+  { intros x hx,
+    apply quotient.eq_zero_iff_mem.mpr,
+    exact ideal.mem_map_of_mem _ hx, },
 end
 
 /-- define `lift_add_double_quot_mk` to be the induced map `R/(I ⊔ J) → (R/I)/J' ` -/
-def lift_add_double_quot_mk (I J : ideal R) := ideal.quotient.lift (I ⊔ J) (double_quot_mk I J)
-  (mem_add_double_quot_mk I J)
+def lift_sup_double_quot_mk (I J : ideal R) := ideal.quotient.lift (I ⊔ J) (double_quot_mk I J)
+  (sup_le_ker_double_quot_mk I J)
 
 /-- Then `double_quot_to_quot_add` and `lift_add_double_qot_mk` are inverse isomorphisms -/
 def double_quot_equiv_quot_add : (J.map (ideal.quotient.mk I)).quotient ≃+* (I ⊔ J).quotient :=
-ring_equiv.of_hom_inv (double_quot_to_quot_add I J) (lift_add_double_qot_mk I J)
+ring_equiv.of_hom_inv (double_quot_to_quot_sup I J) (lift_sup_double_quot_mk I J)
   (by { ext z, refl }) (by { ext z, refl })
 
 end double_quot

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1636,7 +1636,8 @@ def quot_left_to_quot_sum : I.quotient →+* (I+J).quotient :=
 ideal.quotient.lift I (ideal.quotient.mk (I+J)) (left_proj_quot_add_mk I J)
 
 /-- This will be used to lift `quot_left_to_quot_sum` to a map `(R/I)/J' → R/(I+J)`-/
-def img_left_in_ker (x : I.quotient) (hx : x ∈ J.map(ideal.quotient.mk I)) : quot_left_to_quot_sum I J x = 0 :=
+def img_left_in_ker (x : I.quotient) (hx : x ∈ J.map(ideal.quotient.mk I)) :
+  quot_left_to_quot_sum I J x = 0 :=
 begin
   have hIJmap: ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I) '' J) =
     (ideal.quotient.mk (I+J) '' J),
@@ -1645,7 +1646,8 @@ begin
     split,
 
      {intro hy,
-      obtain ⟨z,hz⟩ := (set.mem_image ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I)) J y).1 hy,
+      obtain ⟨z,hz⟩ := (set.mem_image ((quot_left_to_quot_sum I J).comp(ideal.quotient.mk I))
+        J y).1 hy,
       unfold quot_left_to_quot_sum at hz,
       rw [ring_hom.comp_apply,ideal.quotient.lift_mk] at hz,
       rw ← hz.right,
@@ -1658,11 +1660,13 @@ begin
       rwa [ring_hom.comp_apply, ideal.quotient.lift_mk]},
     },
 
-  have hJ: (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sum I J) = J.map (ideal.quotient.mk (I+J))
+  have hJ: (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sum I J) = J.map
+    (ideal.quotient.mk (I+J))
     := by rw [ideal.map_map, ideal.map,hIJmap, ← ideal.map],
 
-  have hmapx : quot_left_to_quot_sum I J x ∈ (J.map (ideal.quotient.mk I)).map (quot_left_to_quot_sum I J), {
-    rw ideal.map,
+  have hmapx : quot_left_to_quot_sum I J x ∈ (J.map (ideal.quotient.mk I)).map
+    (quot_left_to_quot_sum I J),
+    {rw ideal.map,
     apply set.mem_of_subset_of_mem (ideal.subset_span),
     exact (set.mem_image_of_mem (quot_left_to_quot_sum I J) hx)},
 
@@ -1671,6 +1675,7 @@ end
 
 /-- define `double_quot_to_quot_add` to be the induced ring hom `(R/I)/J' ->R/(I+J)`, where `J'` is the image of `J` in `R/I` -/
 def double_quot_to_quot_add : (J.map (ideal.quotient.mk I)).quotient →+* (I + J).quotient :=
-ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sum I J) (img_left_in_ker I J)
+ideal.quotient.lift (ideal.map (ideal.quotient.mk I) J) (quot_left_to_quot_sum I J)
+ (img_left_in_ker I J)
 
 end double_quot


### PR DESCRIPTION
The aim of this section is to prove that if `I, J` are ideals of the ring `R`, then the quotients `R/(I+J)` and `(R/I)/J'`are isomorphic, where `J'` is the image of `J` in `R/I`. 


Co-authored-by: Alex J. Best <alex.j.best@gmail.com>
Co-authored-by: Kevin Buzzard <k.buzzard@imperial.ac.uk>
Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

~~This is my first "big" PR so any advice on how to do this would be more than welcome. I have already written out all the proof and was thinking of uploading the different pieces of code in this PR little by little. Is this the right way to go about doing this ?~~ 

~~I also received some help from other users whilst writing this, is it possible to add them as co-authors ?~~

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Quotient.20of.20a.20ring.20by.20a.20sum.20of.20ideals/near/246947751)


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
