### PR TITLE
[Merged by Bors] - feat(linear_algebra/clifford_algebra/equivs): there is a clifford algebra isomorphic to every quaternion algebra

### DIFF
--- a/src/linear_algebra/clifford_algebra/basic.lean
+++ b/src/linear_algebra/clifford_algebra/basic.lean
@@ -201,6 +201,18 @@ alg_equiv.of_alg_hom
   (by { ext, simp, })
   (by { ext, simp, })
 
+/-- The symmetric product of vectors is a scalar -/
+lemma ι_mul_ι_add_swap (a b : M) :
+  ι Q a * ι Q b + ι Q b * ι Q a = algebra_map R _ (quadratic_form.polar Q a b) :=
+calc  ι Q a * ι Q b + ι Q b * ι Q a
+    = ι Q (a + b) * ι Q (a + b) - ι Q a * ι Q a - ι Q b * ι Q b :
+        by { rw [(ι Q).map_add, mul_add, add_mul, add_mul], abel, }
+... = algebra_map R _ (Q (a + b)) - algebra_map R _ (Q a) - algebra_map R _ (Q b) :
+        by rw [ι_sq_scalar, ι_sq_scalar, ι_sq_scalar]
+... = algebra_map R _ (Q (a + b) - Q a - Q b) :
+        by rw [←ring_hom.map_sub, ←ring_hom.map_sub]
+... = algebra_map R _ (quadratic_form.polar Q a b) : rfl
+
 section map
 
 variables {M₁ M₂ M₃ : Type*}

--- a/src/linear_algebra/clifford_algebra/equivs.lean
+++ b/src/linear_algebra/clifford_algebra/equivs.lean
@@ -109,20 +109,20 @@ lemma Q_apply (v : R × R) : Q c₁ c₂ v = c₁ * (v.1 * v.1) + c₂ * (v.2 * 
 /-- The quaternion basis vectors within the algebra. -/
 @[simps i j k]
 def quaternion_basis : quaternion_algebra.basis (clifford_algebra (Q c₁ c₂)) c₁ c₂ :=
-{ i := clifford_algebra.ι (Q c₁ c₂) (1, 0),
-  j := clifford_algebra.ι (Q c₁ c₂) (0, 1),
-  k := clifford_algebra.ι (Q c₁ c₂) (1, 0) * clifford_algebra.ι (Q c₁ c₂) (0, 1),
+{ i := ι (Q c₁ c₂) (1, 0),
+  j := ι (Q c₁ c₂) (0, 1),
+  k := ι (Q c₁ c₂) (1, 0) * ι (Q c₁ c₂) (0, 1),
   i_mul_i := begin
-    rw [clifford_algebra.ι_sq_scalar, Q_apply, ←algebra.algebra_map_eq_smul_one],
+    rw [ι_sq_scalar, Q_apply, ←algebra.algebra_map_eq_smul_one],
     simp,
   end,
   j_mul_j := begin
-    rw [clifford_algebra.ι_sq_scalar, Q_apply, ←algebra.algebra_map_eq_smul_one],
+    rw [ι_sq_scalar, Q_apply, ←algebra.algebra_map_eq_smul_one],
     simp,
   end,
   i_mul_j := rfl,
   j_mul_i := begin
-    rw [eq_neg_iff_add_eq_zero, clifford_algebra.ι_mul_ι_add_swap, quadratic_form.polar],
+    rw [eq_neg_iff_add_eq_zero, ι_mul_ι_add_swap, quadratic_form.polar],
     simp,
   end }
 
@@ -143,26 +143,31 @@ clifford_algebra.lift (Q c₁ c₂) ⟨
 
 @[simp]
 lemma to_quaternion_ι (v : R × R) :
-  to_quaternion (clifford_algebra.ι (Q c₁ c₂) v) = (⟨0, v.1, v.2, 0⟩ : ℍ[R,c₁,c₂]) :=
+  to_quaternion (ι (Q c₁ c₂) v) = (⟨0, v.1, v.2, 0⟩ : ℍ[R,c₁,c₂]) :=
 clifford_algebra.lift_ι_apply _ _ v
 
 /-- Map a quaternion into the clifford algebra. -/
-@[simp] def of_quaternion : ℍ[R,c₁,c₂] →ₐ[R] clifford_algebra (Q c₁ c₂) :=
+def of_quaternion : ℍ[R,c₁,c₂] →ₐ[R] clifford_algebra (Q c₁ c₂) :=
 (quaternion_basis c₁ c₂).lift_hom
+
+@[simp] lemma of_quaternion_apply (x : ℍ[R,c₁,c₂]) :
+  of_quaternion x = algebra_map R _ x.re
+                  + x.im_i • ι (Q c₁ c₂) (1, 0)
+                  + x.im_j • ι (Q c₁ c₂) (0, 1)
+                  + x.im_k • (ι (Q c₁ c₂) (1, 0) * ι (Q c₁ c₂) (0, 1)) := rfl
 
 @[simp]
 lemma of_quaternion_comp_to_quaternion :
   of_quaternion.comp to_quaternion = alg_hom.id R (clifford_algebra (Q c₁ c₂)) :=
 begin
-  ext1,
-  dsimp,
+  ext : 1,
+  dsimp, -- before we end up with two goals and have to do this twice
   ext,
   all_goals {
-    dsimp [quaternion_algebra.basis.lift],
+    dsimp,
     rw to_quaternion_ι,
     dsimp,
-    simp only [zero_smul, one_smul, zero_add, add_zero, ring_hom.map_zero],
-  },
+    simp only [to_quaternion_ι, zero_smul, one_smul, zero_add, add_zero, ring_hom.map_zero], },
 end
 
 @[simp]
@@ -176,7 +181,7 @@ end
 /-- The clifford algebra over `clifford_algebra_quaternion.Q` is isomorphic as an `R`-algebra
 to `ℍ[R,c₁,c₂]`. -/
 @[simps]
-def equiv_quaternion : clifford_algebra (Q c₁ c₂) ≃ₐ[R] ℍ[R,c₁,c₂] :=
+protected def equiv : clifford_algebra (Q c₁ c₂) ≃ₐ[R] ℍ[R,c₁,c₂] :=
 alg_equiv.of_alg_hom to_quaternion of_quaternion
   to_quaternion_comp_of_quaternion
   of_quaternion_comp_to_quaternion

--- a/src/linear_algebra/clifford_algebra/equivs.lean
+++ b/src/linear_algebra/clifford_algebra/equivs.lean
@@ -62,7 +62,7 @@ clifford_algebra.lift Q ⟨linear_map.to_span_singleton _ _ complex.I, λ r, beg
 end⟩
 
 @[simp]
-lemma to_complex_ι (r : ℝ) : to_complex (clifford_algebra.ι Q r) = r • complex.I :=
+lemma to_complex_ι (r : ℝ) : to_complex (ι Q r) = r • complex.I :=
 clifford_algebra.lift_ι_apply _ _ r
 
 /-- The clifford algebras over `clifford_algebra_complex.Q` is isomorphic as an `ℝ`-algebra to

--- a/src/linear_algebra/clifford_algebra/equivs.lean
+++ b/src/linear_algebra/clifford_algebra/equivs.lean
@@ -130,7 +130,7 @@ def quaternion_basis : quaternion_algebra.basis (clifford_algebra (Q c₁ c₂))
 variables {c₁ c₂}
 
 /-- Intermediate result of `clifford_algebra_quaternion.equiv`: clifford algebras over
-`clifford_algebra_quaternion.Q`  can be converted to `ℍ[R,c₁,c₂]`. -/
+`clifford_algebra_quaternion.Q` can be converted to `ℍ[R,c₁,c₂]`. -/
 def to_quaternion : clifford_algebra (Q c₁ c₂) →ₐ[R] ℍ[R,c₁,c₂] :=
 clifford_algebra.lift (Q c₁ c₂) ⟨
   { to_fun := λ v, (⟨0, v.1, v.2, 0⟩ : ℍ[R,c₁,c₂]),

--- a/src/linear_algebra/clifford_algebra/equivs.lean
+++ b/src/linear_algebra/clifford_algebra/equivs.lean
@@ -98,7 +98,8 @@ open quaternion_algebra
 
 variables {R : Type*} [comm_ring R] (c₁ c₂ : R)
 
-/-- The quadratic form. -/
+/-- `Q c₁ c₂` is a quadratic form over `R × R` such that `clifford_algebra (Q c₁ c₂)` is isomorphic
+as an `R`-algebra to `ℍ[R,c₁,c₂]`. -/
 def Q : quadratic_form R (R × R) :=
 c₁ • quadratic_form.lin_mul_lin (linear_map.fst _ _ _) (linear_map.fst _ _ _) +
 c₂ • quadratic_form.lin_mul_lin (linear_map.snd _ _ _) (linear_map.snd _ _ _)
@@ -128,8 +129,8 @@ def quaternion_basis : quaternion_algebra.basis (clifford_algebra (Q c₁ c₂))
 
 variables {c₁ c₂}
 
-/-- Intermediate result of `clifford_algebra_complex.equiv_quaternion`: clifford algebras over
-`clifford_algebra_quaternion.Q` above can be converted to `ℍ[R,c₁,c₂]`. -/
+/-- Intermediate result of `clifford_algebra_quaternion.equiv`: clifford algebras over
+`clifford_algebra_quaternion.Q`  can be converted to `ℍ[R,c₁,c₂]`. -/
 def to_quaternion : clifford_algebra (Q c₁ c₂) →ₐ[R] ℍ[R,c₁,c₂] :=
 clifford_algebra.lift (Q c₁ c₂) ⟨
   { to_fun := λ v, (⟨0, v.1, v.2, 0⟩ : ℍ[R,c₁,c₂]),
@@ -178,7 +179,7 @@ begin
   ext1; dsimp [quaternion_algebra.basis.lift]; simp,
 end
 
-/-- The clifford algebra over `clifford_algebra_quaternion.Q` is isomorphic as an `R`-algebra
+/-- The clifford algebra over `clifford_algebra_quaternion.Q c₁ c₂` is isomorphic as an `R`-algebra
 to `ℍ[R,c₁,c₂]`. -/
 @[simps]
 protected def equiv : clifford_algebra (Q c₁ c₂) ≃ₐ[R] ℍ[R,c₁,c₂] :=


### PR DESCRIPTION
The proofs are not particularly fast here unfortunately.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I'll follow up with a PR to show that this isomorphism and the existing complex one preserve conjugation too.
