### PR TITLE
[Merged by Bors] -  feat(algebra/opposites): more scalar action instances

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -195,6 +195,9 @@ search (and was here first). -/
   (r • x) * y = r • (x * y) :=
 smul_mul_assoc r x y
 
+instance _root_.is_scalar_tower.opposite_right : is_scalar_tower R Aᵒᵖ A :=
+⟨λ x y z, algebra.mul_smul_comm _ _ _⟩
+
 section
 variables {r : R} {a : A}
 

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -241,6 +241,12 @@ instance semiring.to_module [semiring R] : module R R :=
   zero_smul := zero_mul,
   smul_zero := mul_zero }
 
+@[priority 910] -- see Note [lower instance priority]
+instance semiring.to_opposite_module [semiring R] : module Rᵒᵖ R :=
+{ smul_add := λ r x y, add_mul _ _ _,
+  add_smul := λ r x y, mul_add _ _ _,
+  ..monoid_with_zero.to_opposite_mul_action_with_zero R}
+
 /-- A ring homomorphism `f : R →+* M` defines a module structure by `r • x = f r * x`. -/
 def ring_hom.to_module [semiring R] [semiring S] (f : R →+* S) : module R S :=
 { smul := λ r x, f r * x,

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -222,9 +222,25 @@ instance (R : Type*) [monoid R] [add_monoid α] [distrib_mul_action R α] :
   smul_zero := λ r, unop_injective $ smul_zero r,
   ..opposite.mul_action α R }
 
+/-- Like `has_mul.to_has_scalar`, but multiplies on the right.
+
+See also `monoid.to_opposite_mul_action` and `monoid_with_zero.to_opposite_mul_action`. -/
+instance _root_.has_mul.to_has_opposite_scalar [has_mul α] : has_scalar (opposite α) α :=
+{ smul := λ c x, x * c.unop }
+
+lemma op_smul_eq_mul [has_mul α] {a a' : α} : op a • a' = a' * a := rfl
+
+instance _root_.semigroup.opposite_smul_comm_class [semigroup α] :
+  smul_comm_class (opposite α) α α :=
+{ smul_comm := λ x y z, (mul_assoc _ _ _) }
+
+instance _root_.semigroup.opposite_smul_comm_class' [semigroup α] :
+  smul_comm_class α (opposite α) α :=
+{ smul_comm := λ x y z, (mul_assoc _ _ _).symm }
+
 /-- Like `monoid.to_mul_action`, but multiplies on the right. -/
 instance _root_.monoid.to_opposite_mul_action [monoid α] : mul_action (opposite α) α :=
-{ smul := λ c x, x * c.unop,
+{ smul := (•),
   one_smul := mul_one,
   mul_smul := λ x y r, (mul_assoc _ _ _).symm }
 
@@ -232,15 +248,13 @@ instance _root_.monoid.to_opposite_mul_action [monoid α] : mul_action (opposite
 -- `mul_action (opposite α) (opposite α)` are defeq.
 example [monoid α] : monoid.to_mul_action (opposite α) = opposite.mul_action α (opposite α) := rfl
 
-lemma op_smul_eq_mul [monoid α] {a a' : α} : op a • a' = a' * a := rfl
-
 /-- `monoid.to_opposite_mul_action` is faithful on cancellative monoids. -/
-instance left_cancel_monoid.to_has_faithful_scalar [left_cancel_monoid α] :
+instance _root_.left_cancel_monoid.to_has_faithful_opposite_scalar [left_cancel_monoid α] :
   has_faithful_scalar (opposite α) α :=
 ⟨λ x y h, unop_injective $ mul_left_cancel (h 1)⟩
 
 /-- `monoid.to_opposite_mul_action` is faithful on nontrivial cancellative monoids with zero. -/
-instance cancel_monoid_with_zero.to_has_faithful_opposite_scalar
+instance _root_.cancel_monoid_with_zero.to_has_faithful_opposite_scalar
   [cancel_monoid_with_zero α] [nontrivial α] : has_faithful_scalar (opposite α) α :=
 ⟨λ x y h, unop_injective $ mul_left_cancel' one_ne_zero (h 1)⟩
 

--- a/src/algebra/smul_with_zero.lean
+++ b/src/algebra/smul_with_zero.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import algebra.group_power.basic
+import algebra.opposites
 
 /-!
 # Introduce `smul_with_zero`
@@ -43,6 +44,11 @@ instance mul_zero_class.to_smul_with_zero [mul_zero_class R] : smul_with_zero R 
 { smul := (*),
   smul_zero := mul_zero,
   zero_smul := zero_mul }
+
+instance mul_zero_class.to_opposite_smul_with_zero [mul_zero_class R] : smul_with_zero Rᵒᵖ R :=
+{ smul := (•),
+  smul_zero := λ r, zero_mul _,
+  zero_smul := mul_zero }
 
 instance add_monoid.to_smul_with_zero [add_monoid M] : smul_with_zero ℕ M :=
 { smul_zero := nsmul_zero,
@@ -106,9 +112,15 @@ instance mul_action_with_zero.to_smul_with_zero [m : mul_action_with_zero R M] :
   smul_with_zero R M :=
 {..m}
 
+/-- See also `semiring.to_module` -/
 instance monoid_with_zero.to_mul_action_with_zero : mul_action_with_zero R R :=
 { ..mul_zero_class.to_smul_with_zero R,
   ..monoid.to_mul_action R }
+
+/-- See also `semiring.to_opposite_module` -/
+instance monoid_with_zero.to_opposite_mul_action_with_zero : mul_action_with_zero Rᵒᵖ R :=
+{ ..mul_zero_class.to_opposite_smul_with_zero R,
+  ..monoid.to_opposite_mul_action R }
 
 variables {R M} [mul_action_with_zero R M] [has_zero M'] [has_scalar R M']
 


### PR DESCRIPTION
This adds weaker and stronger versions of `monoid.to_opposite_mul_action` for `has_mul`, `monoid_with_zero`, and `semiring`. It also adds an `smul_comm_class` instance.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The motivation here was to help provide the instance in [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Lost.20instance/near/249468775)