### PR TITLE
[Merged by Bors] - feat(algebra/lattice_ordered_group): add basic theory of lattice ordered groups

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -80,6 +80,13 @@
   publisher     = {Springer}
 }
 
+@Manual{          banasiak,
+  author        = {Banasiak},
+  title         = {Banach Lattices in Applications},
+  organization  = {University of Pretoria},
+  address       = {Pretoria, South Africa}
+}
+
 @Book{            beals2004,
   author        = {Richard Beals},
   title         = {Analysis. An introduction},
@@ -135,6 +142,22 @@
   mrnumber      = {1700749},
   doi           = {10.1002/9780470316962},
   url           = {https://doi.org/10.1002/9780470316962}
+}
+
+@Article{         birkhoff1942,
+  author        = {Birkhoff, Garrett},
+  title         = {Lattice, ordered groups},
+  journal       = {Ann. of Math. (2)},
+  fjournal      = {Annals of Mathematics. Second Series},
+  volume        = {43},
+  year          = {1942},
+  pages         = {298--331},
+  issn          = {0003-486X},
+  mrclass       = {20.0X},
+  mrnumber      = {6550},
+  mrreviewer    = {H. Wallman},
+  doi           = {10.2307/1968871},
+  url           = {https://doi.org/10.2307/1968871}
 }
 
 @Book{            borceux-vol1,
@@ -208,6 +231,19 @@
   isbn          = {3-540-43405-4},
   mrclass       = {17-01 (01A75 22-01)},
   mrnumber      = {2109105}
+}
+
+@Book{            bourbaki1981,
+  author        = {Bourbaki, N.},
+  title         = {Algebra. {II}. {C}hapters 4--7},
+  series        = {Elements of Mathematics (Berlin)},
+  note          = {Translated from the French by P. M. Cohn and J. Howie},
+  publisher     = {Springer-Verlag, Berlin},
+  year          = {1990},
+  pages         = {vii+461},
+  isbn          = {3-540-19375-8},
+  mrclass       = {00A05 (12-01 13-01)},
+  mrnumber      = {1080964}
 }
 
 @Article{         cadiou1972,
@@ -430,6 +466,19 @@
   annote        = {Keywords: Interactive theorem proving, formal
                   verification, set theory, forcing, independence proofs,
                   continuum hypothesis, Boolean-valued models, Lean}
+}
+
+@Book{            fuchs1963,
+  author        = {Fuchs, L.},
+  title         = {Partially ordered algebraic systems},
+  publisher     = {Pergamon Press, Oxford-London-New York-Paris;
+                  Addison-Wesley Publishing Co., Inc., Reading, Mass.-Palo
+                  Alto, Calif.-London},
+  year          = {1963},
+  pages         = {ix+229},
+  mrclass       = {06.00 (20.00)},
+  mrnumber      = {0171864},
+  mrreviewer    = {P. F. Conrad}
 }
 
 @InProceedings{   fuerer-lochbihler-schneider-traytel2020,
@@ -1188,6 +1237,14 @@
   title         = {Adic Spaces},
   year          = {2019},
   eprint        = {arXiv:1910.05934}
+}
+
+@TechReport{      zaanen1966,
+  author        = {Zaanen, A. C.},
+  title         = {Lectures on "Riesz Spaces"},
+  institution   = {Euratom},
+  year          = {1966},
+  number        = {EUR 3140.e}
 }
 
 @Article{         zbMATH06785026,

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -159,7 +159,7 @@ lemma fpow_even_abs (a : K) {p : ℤ} (hp : even p) :
   abs a ^ p = a ^ p :=
 begin
   cases le_or_lt a (-a) with h h;
-  simp [abs, h, max_eq_left_of_lt, fpow_even_neg _ hp]
+  simp [abs_eq_max_neg, h, max_eq_left_of_lt, fpow_even_neg _ hp]
 end
 
 @[simp] lemma fpow_bit0_abs (a : K) (p : ℤ) :

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -451,6 +451,11 @@ by rw [mul_inv_rev, mul_comm]
 lemma div_eq_of_eq_mul' {a b c : G} (h : a = b * c) : a / b = c :=
 by rw [h, div_eq_mul_inv, mul_comm, inv_mul_cancel_left]
 
+@[to_additive]
+lemma div_mul_comm (a b c d : G) : a / b * (c / d) = a * c / (b * d) :=
+by rw [div_eq_mul_inv, div_eq_mul_inv, div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_assoc,
+  mul_left_cancel_iff, mul_comm, mul_assoc]
+
 end comm_group
 
 section add_comm_group

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -141,23 +141,23 @@ namespace lattice_ordered_comm_group
 Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
 the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`.
 -/
-@[to_additive additive_pos "
+@[to_additive pos "
   Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
   the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`.
 "]
-def pos (a : α) : α :=  a ⊔ 1
-postfix `⁺`:1000 := pos
+def mpos (a : α) : α :=  a ⊔ 1
+postfix `⁺`:1000 := mpos
 
 /--
 Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
 the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`.
 -/
-@[to_additive additive_neg "
+@[to_additive neg "
   Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
   the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`.
 "]
-def neg (a : α) : α := a⁻¹ ⊔ 1
-postfix `⁻`:1000 := neg
+def mneg (a : α) : α := a⁻¹ ⊔ 1
+postfix `⁻`:1000 := mneg
 
 
 /--
@@ -214,8 +214,8 @@ component `a⁻` of `a` is equal to the positive component `(-a)⁺` of `-a`.
 @[to_additive]
 lemma neg_eq_pos_inv (a : α) : a⁻ = (a⁻¹)⁺ :=
 begin
-  unfold neg,
-  unfold pos,
+  unfold mneg,
+  unfold mpos,
 end
 
 /--
@@ -252,7 +252,7 @@ $$a⁻ = -(a ⊓ 0).$$
 @[to_additive]
 lemma neg_eq_inv_inf_one (a : α) : a⁻ = (a ⊓ 1)⁻¹ :=
 begin
-  unfold lattice_ordered_comm_group.neg,
+  unfold lattice_ordered_comm_group.mneg,
   rw ← inv_inj,
   rw inv_sup_eq_inv_inf_inv,
   rw [inv_inv, inv_inv, one_inv],
@@ -269,9 +269,9 @@ lemma pos_inv_neg (a : α) : a = a⁺ / a⁻ :=
 begin
   rw div_eq_mul_inv,
   apply eq_mul_inv_of_mul_eq,
-  unfold lattice_ordered_comm_group.neg,
+  unfold lattice_ordered_comm_group.mneg,
   rw [mul_sup_eq_mul_sup_mul, mul_one, mul_right_inv, sup_comm],
-  unfold lattice_ordered_comm_group.pos,
+  unfold lattice_ordered_comm_group.mpos,
 end
 
 -- Hack to work around rewrite not working if lhs is a variable
@@ -502,7 +502,7 @@ equal to its positive component `a⁺`.
 -/
 lemma pos_pos_id (a : α) (h : 1 ≤ a): a⁺ = a :=
 begin
-  unfold lattice_ordered_comm_group.pos,
+  unfold lattice_ordered_comm_group.mpos,
   apply sup_of_le_left h,
 end
 

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -441,8 +441,7 @@ Every lattice ordered commutative group is a distributive lattice
 -/
 @[to_additive, priority 100] -- see Note [lower instance priority]
 instance lattice_ordered_comm_group_to_distrib_lattice (α : Type u)
-  [s: lattice α] [comm_group α] [covariant_class α α (*) (≤)]
-  [covariant_class α α (function.swap (*)) (≤)] : distrib_lattice α :=
+  [s: lattice α] [comm_group α] [covariant_class α α (*) (≤)] : distrib_lattice α :=
 { le_sup_inf :=
   begin
     intros,

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -139,10 +139,9 @@ namespace lattice_ordered_comm_group
 Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
 the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`.
 -/
-@[to_additive pos "
-  Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
-  the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`.
-"]
+@[to_additive pos
+  "Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
+  the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`."]
 def mpos (a : α) : α :=  a ⊔ 1
 postfix `⁺`:1000 := mpos
 

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -38,7 +38,6 @@ A lattice ordered commutative group is a type `α` satisfying:
 * `[lattice α]`
 * `[comm_group α]`
 * `[covariant_class α α (*) (≤)]`
-*  `[covariant_class α α (function.swap (*)) (≤)]`
 
 The remainder of the file establishes basic properties of `lattice_ordered_comm_group`. A number
 of these results also hold in the non-commutative case ([Birkhoff][birkhoff1942],
@@ -68,8 +67,6 @@ instance linear_ordered_comm_group.to_covariant_class (α : Type u)
 
 
 variables {α : Type u} [lattice α] [comm_group α] [covariant_class α α (*) (≤)]
-  [covariant_class α α (function.swap (*)) (≤)]
-
 
 -- Special case of Bourbaki A.VI.9 (1)
 /--

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -107,7 +107,7 @@ end
 Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
 $$ -(a ⊓ b) = -a ⊔ -b.$$
 -/
-@[to_additive, simp]
+@[to_additive]
 lemma inv_inf_eq_sup_inv [covariant_class α α (*) (≤)] (a b : α) : (a ⊓ b)⁻¹ = a⁻¹ ⊔ b⁻¹ :=
 by rw [← inv_inv (a⁻¹ ⊔ b⁻¹), inv_sup_eq_inv_inf_inv a⁻¹ b⁻¹, inv_inv, inv_inv]
 

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -71,10 +71,10 @@ variables {α : Type u} [lattice α] [comm_group α] [covariant_class α α (*) 
 -- Special case of Bourbaki A.VI.9 (1)
 /--
 Let `α` be a lattice ordered commutative group. For all elements `a`, `b` and `c` in `α`,
-$$c + (a⊔b) = (c+a)⊔(c+b).$$
+$$c + (a ⊔ b) = (c + a) ⊔ (c + b).$$
 -/
 @[to_additive]
-lemma mul_sup_eq_mul_sup_mul (a b c : α) : c * (a⊔b) = (c*a)⊔(c*b) :=
+lemma mul_sup_eq_mul_sup_mul (a b c : α) : c * (a ⊔ b) = (c * a) ⊔ (c * b) :=
 begin
   refine le_antisymm _ (by simp),
   rw [← mul_le_mul_iff_left (c⁻¹), ← mul_assoc, inv_mul_self, one_mul],
@@ -86,10 +86,10 @@ end
 -- Special case of Bourbaki A.VI.9 (2)
 /--
 Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
-$$-(a⊔b)=(-a)⊓(-b).$$
+$$-(a ⊔ b)=(-a) ⊓ (-b).$$
 -/
 @[to_additive]
-lemma inv_sup_eq_inv_inf_inv (a b : α) : (a⊔b)⁻¹ =a⁻¹⊓b⁻¹ :=
+lemma inv_sup_eq_inv_inf_inv (a b : α) : (a ⊔ b)⁻¹ = a⁻¹ ⊓ b⁻¹ :=
 begin
   rw le_antisymm_iff,
   split,
@@ -105,24 +105,24 @@ end
 
 /--
 Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
-$$ -(a⊓b) = -a⊔-b.$$
+$$ -(a ⊓ b) = -a ⊔ -b.$$
 -/
 @[to_additive, simp]
-lemma inv_inf_eq_sup_inv (a b : α) : (a⊓b)⁻¹ = a⁻¹⊔b⁻¹ :=
+lemma inv_inf_eq_sup_inv (a b : α) : (a ⊓ b)⁻¹ = a⁻¹ ⊔ b⁻¹ :=
 begin
-  rw [← inv_inv (a⁻¹⊔b⁻¹), inv_sup_eq_inv_inf_inv a⁻¹ b⁻¹, inv_inv, inv_inv],
+  rw [← inv_inv (a⁻¹ ⊔ b⁻¹), inv_sup_eq_inv_inf_inv a⁻¹ b⁻¹, inv_inv, inv_inv],
 end
 
 -- Bourbaki A.VI.10 Prop 7
 /--
 Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
-$$a⊓b + (a⊔b) = a + b.$$
+$$a ⊓ b + (a ⊔ b) = a + b.$$
 -/
 @[to_additive]
-lemma inf_mul_sup (a b : α) : a⊓b * (a⊔b) = a * b :=
-calc a⊓b * (a⊔b) = a⊓b * ((a * b) * (b⁻¹⊔a⁻¹)) :
-  by {  rw mul_sup_eq_mul_sup_mul b⁻¹ a⁻¹ (a*b), simp,  }
-... = a⊓b * ((a * b) * (a⊓b)⁻¹) : by { rw [inv_inf_eq_sup_inv, sup_comm], }
+lemma inf_mul_sup (a b : α) : a ⊓ b * (a ⊔ b) = a * b :=
+calc a⊓b * (a ⊔ b) = a ⊓ b * ((a * b) * (b⁻¹ ⊔ a⁻¹)) :
+  by {  rw mul_sup_eq_mul_sup_mul b⁻¹ a⁻¹ (a * b), simp,  }
+... = a⊓b * ((a * b) * (a ⊓ b)⁻¹) : by { rw [inv_inf_eq_sup_inv, sup_comm], }
 ... = a * b                    : by { rw [mul_comm, inv_mul_cancel_right],  }
 
 
@@ -212,7 +212,7 @@ Let `α` be a lattice ordered commutative group and let `a` be an element in `α
 component `a⁻` of `a` is equal to the positive component `(-a)⁺` of `-a`.
 -/
 @[to_additive]
-lemma neg_eq_pos_inv (a : α) : a⁻ =(a⁻¹)⁺ :=
+lemma neg_eq_pos_inv (a : α) : a⁻ = (a⁻¹)⁺ :=
 begin
   unfold neg,
   unfold pos,
@@ -232,10 +232,10 @@ end
 -- We use this in Bourbaki A.VI.12  Prop 9 a)
 /--
 Let `α` be a lattice ordered commutative group. For all elements `a`, `b` and `c` in `α`,
-$$c + (a⊓b) = (c+a)⊓(c+b).$$
+$$c + (a ⊓ b) = (c + a) ⊓ (c + b).$$
 -/
 @[to_additive]
-lemma mul_inf_eq_mul_inf_mul (a b c : α) : c * (a⊓b) = (c*a)⊓(c*b) :=
+lemma mul_inf_eq_mul_inf_mul (a b c : α) : c * (a ⊓ b) = (c * a) ⊓ (c * b) :=
 begin
   rw le_antisymm_iff,
   split,
@@ -247,10 +247,10 @@ end
 /--
 Let `α` be a lattice ordered commutative group with identity `0` and let `a` be an element in `α`
 with negative component `a⁻`. Then
-$$a⁻ = -(a⊓0).$$
+$$a⁻ = -(a ⊓ 0).$$
 -/
 @[to_additive]
-lemma neg_eq_inv_inf_one (a : α) : a⁻ = (a⊓1)⁻¹ :=
+lemma neg_eq_inv_inf_one (a : α) : a⁻ = (a ⊓ 1)⁻¹ :=
 begin
   unfold lattice_ordered_comm_group.neg,
   rw ← inv_inj,
@@ -285,7 +285,7 @@ component `a⁺` and negative component `a⁻`. Then `a⁺` and `a⁻` are co-pr
 positive, disjoint).
 -/
 @[to_additive]
-lemma pos_inf_neg_eq_one (a : α) : a⁺⊓a⁻=1 :=
+lemma pos_inf_neg_eq_one (a : α) : a⁺ ⊓ a⁻=1 :=
 begin
   rw [←mul_right_inj (a⁻)⁻¹, mul_inf_eq_mul_inf_mul, mul_one, mul_left_inv, mul_comm,
     ←div_eq_mul_inv, pos_div_neg', neg_eq_inv_inf_one, inv_inv],
@@ -294,31 +294,31 @@ end
 -- Bourbaki A.VI.12 (with a and b swapped)
 /--
 Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α`, and let
-`(a - b)⁺` be the positive componet of `a-b`. Then
+`(a - b)⁺` be the positive componet of `a - b`. Then
 $$a⊔b = b + (a - b)⁺.$$
 -/
 @[to_additive]
-lemma sup_eq_mul_pos_div (a b : α) : a⊔b = b * (a / b)⁺ :=
-  calc  a⊔b = (b*(a/b))⊔(b*1) : by {rw [mul_one b, div_eq_mul_inv, mul_comm a,
+lemma sup_eq_mul_pos_div (a b : α) : a ⊔ b = b * (a / b)⁺ :=
+  calc  a ⊔ b = (b * (a / b)) ⊔ (b * 1) : by {rw [mul_one b, div_eq_mul_inv, mul_comm a,
     mul_inv_cancel_left], }
-  ... = b * ((a/b)⊔1) : by { rw ← mul_sup_eq_mul_sup_mul (a/b) 1 b}
+  ... = b * ((a / b) ⊔ 1) : by { rw ← mul_sup_eq_mul_sup_mul (a / b) 1 b}
 
 -- Bourbaki A.VI.12 (with a and b swapped)
 /--
 Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α`, and let
-`(a - b)⁺` be the positive componet of `a-b`. Then
+`(a - b)⁺` be the positive componet of `a - b`. Then
 $$a⊓b = a - (a - b)⁺.$$
 -/
 @[to_additive]
-lemma inf_eq_div_pos_div (a b : α) : a⊓b = a / (a / b)⁺ :=
-  calc a⊓b = (a*1)⊓(a*(b/a)) : by { rw [mul_one a, div_eq_mul_inv, mul_comm b,
+lemma inf_eq_div_pos_div (a b : α) : a ⊓ b = a / (a / b)⁺ :=
+  calc a ⊓ b = (a * 1) ⊓ (a * (b / a)) : by { rw [mul_one a, div_eq_mul_inv, mul_comm b,
     mul_inv_cancel_left], }
-  ... = a * (1⊓(b/a))        : by {rw ← mul_inf_eq_mul_inf_mul 1 (b/a) a}
-  ... = a * ((b/a)⊓1)        : by { rw inf_comm }
-  ... = a * ((a/b)⁻¹⊓1) : by { rw div_eq_mul_inv,  nth_rewrite 0 ← inv_inv b,
+  ... = a * (1 ⊓ (b / a))        : by {rw ← mul_inf_eq_mul_inf_mul 1 (b / a) a}
+  ... = a * ((b / a) ⊓ 1)        : by { rw inf_comm }
+  ... = a * ((a / b)⁻¹ ⊓ 1) : by { rw div_eq_mul_inv,  nth_rewrite 0 ← inv_inv b,
     rw [← mul_inv, mul_comm b⁻¹, ← div_eq_mul_inv], }
-  ... = a * ((a/b)⁻¹⊓1⁻¹) : by { rw one_inv, }
-  ... = a / ((a/b)⊔1)        : by  { rw ← inv_sup_eq_inv_inf_inv, rw ← div_eq_mul_inv, }
+  ... = a * ((a / b)⁻¹ ⊓ 1⁻¹) : by { rw one_inv, }
+  ... = a / ((a / b) ⊔ 1)        : by  { rw ← inv_sup_eq_inv_inf_inv, rw ← div_eq_mul_inv, }
 
 -- Bourbaki A.VI.12 Prop 9 c)
 /--
@@ -398,27 +398,27 @@ begin
 end
 
 /--
-Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b-a|`
-be the absolute value of `b-a`. Then,
-$$a⊔b - (a⊓b) = |b-a|.$$
+Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b - a|`
+be the absolute value of `b - a`. Then,
+$$a ⊔ b - (a ⊓ b) = |b - a|.$$
 -/
 @[to_additive]
-lemma sup_div_inf_eq_abs_div (a b : α) : (a⊔b) / (a⊓b) = |b/a| :=
+lemma sup_div_inf_eq_abs_div (a b : α) : (a ⊔ b) / (a ⊓ b) = |b / a| :=
 begin
   rw [sup_eq_mul_pos_div, inf_comm, inf_eq_div_pos_div, div_eq_mul_inv],
   nth_rewrite 1 div_eq_mul_inv,
-  rw [mul_inv_rev, inv_inv, mul_comm, ← mul_assoc, inv_mul_cancel_right, pos_eq_neg_inv (a/b)],
+  rw [mul_inv_rev, inv_inv, mul_comm, ← mul_assoc, inv_mul_cancel_right, pos_eq_neg_inv (a / b)],
   nth_rewrite 1 div_eq_mul_inv,
   rw [mul_inv_rev, ← div_eq_mul_inv, inv_inv, ← pos_mul_neg],
 end
 
 /--
-Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b-a|`
-be the absolute value of `b-a`. Then,
-$$2•(a⊔b) = a + b + |b - a|.$$
+Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b - a|`
+be the absolute value of `b - a`. Then,
+$$2•(a ⊔ b) = a + b + |b - a|.$$
 -/
 @[to_additive]
-lemma sup_sq_eq_mul_mul_abs_div (a b : α) : (a⊔b)^2 = a * b * |b / a| :=
+lemma sup_sq_eq_mul_mul_abs_div (a b : α) : (a ⊔ b)^2 = a * b * |b / a| :=
 begin
   rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, ← mul_assoc, mul_comm,
     mul_assoc, ← pow_two, inv_mul_cancel_left],
@@ -427,10 +427,10 @@ end
 /--
 Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b-a|`
 be the absolute value of `b-a`. Then,
-$$2•(a⊓b) = a + b - |b - a|.$$
+$$2•(a ⊓ b) = a + b - |b - a|.$$
 -/
 @[to_additive]
-lemma two_inf_eq_mul_div_abs_div (a b : α) : (a⊓b)^2 = a * b / |b / a| :=
+lemma two_inf_eq_mul_div_abs_div (a b : α) : (a ⊓ b)^2 = a * b / |b / a| :=
 begin
   rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, div_eq_mul_inv,
     mul_inv_rev, inv_inv, mul_assoc, mul_inv_cancel_comm_assoc, ← pow_two],
@@ -446,7 +446,7 @@ instance lattice_ordered_comm_group_to_distrib_lattice (α : Type u)
 { le_sup_inf :=
   begin
     intros,
-    rw [← mul_le_mul_iff_left (x⊓(y⊓z)),  inf_mul_sup x (y⊓z),
+    rw [← mul_le_mul_iff_left (x ⊓ (y ⊓ z)),  inf_mul_sup x (y ⊓ z),
       ← inv_mul_le_iff_le_mul, le_inf_iff ],
     split,
     { rw [inv_mul_le_iff_le_mul, ← inf_mul_sup x y ],
@@ -462,7 +462,7 @@ instance lattice_ordered_comm_group_to_distrib_lattice (α : Type u)
 }
 
 @[to_additive]
-lemma div_mul_div_eq_mul_div_mul (x y w z : α) : x/y*(w/z) = x*w/(y*z) :=
+lemma div_mul_div_eq_mul_div_mul (x y w z : α) : x / y * (w / z) = x * w / (y * z) :=
 begin
   rw [div_eq_mul_inv, div_eq_mul_inv, div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_assoc,
     mul_left_cancel_iff, mul_comm, mul_assoc],
@@ -472,35 +472,36 @@ end
 -- 3rd lecture
 /--
 Let `α` be a lattice ordered commutative group and let `a`, `b` and `c` be elements in `α`. Let
-`|a⊔c-(b⊔c)|`, `|a⊓c-b⊓c|` and `|a-b|` denote the absolute values of `a⊔c-(b⊔c)`, `a⊓c-b⊓c` and
-`a-b` respectively. Then,
-$$|a⊔c-(b⊔c)| + |a⊓c-b⊓c| = |a-b|.$$
+`|a ⊔ c - (b ⊔ c)|`, `|a ⊓ c - b ⊓ c|` and `|a - b|` denote the absolute values of
+`a ⊔ c - (b ⊔ c)`, `a ⊓ c - b ⊓ c` and `a - b` respectively. Then,
+$$|a ⊔ c - (b ⊔ c)| + |a ⊓ c-b ⊓ c| = |a - b|.$$
 -/
 @[to_additive]
 theorem abs_div_sup_mul_abs_div_inf (a b c : α) :
-|(a⊔c)/(b⊔c)| * |(a⊓c)/(b⊓c)| = |a/b| :=
-  calc |(a⊔c)/(b⊔c)| * |a⊓c/(b⊓c)| =
-    ((b⊔c⊔(a⊔c)) / ((b⊔c)⊓(a⊔c))) * |a⊓c/(b⊓c)|       : by {rw sup_div_inf_eq_abs_div, }
-    ... = (b⊔c⊔(a⊔c))/((b⊔c)⊓(a⊔c)) * (((b⊓c)⊔(a⊓c)) / ((b⊓c)⊓(a⊓c))) : by
-      {rw sup_div_inf_eq_abs_div (b⊓c) (a⊓c), }
-    ... = (b⊔a⊔c) / ((b⊓a)⊔c) * (((b⊔a)⊓c) / (b⊓a⊓c)) : by {
+|(a ⊔ c)/(b ⊔ c)| * |(a ⊓ c)/(b ⊓ c)| = |a / b| :=
+  calc |(a ⊔ c) / (b ⊔ c)| * |a ⊓ c / (b ⊓ c)| =
+    ((b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c))) * |a ⊓ c / (b ⊓ c)| : by {rw sup_div_inf_eq_abs_div, }
+    ... = (b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c)) * (((b ⊓ c) ⊔ (a ⊓ c)) / ((b ⊓ c) ⊓ (a ⊓ c))) : by
+      {rw sup_div_inf_eq_abs_div (b ⊓ c) (a ⊓ c), }
+    ... = (b ⊔ a ⊔ c) / ((b ⊓ a) ⊔ c) * (((b ⊔ a) ⊓ c) / (b ⊓ a ⊓ c)) : by {
       rw [← sup_inf_right, ← inf_sup_right, sup_assoc ],
       nth_rewrite 1 sup_comm,
       rw [sup_right_idem, sup_assoc, inf_assoc ],
       nth_rewrite 3 inf_comm,
       rw [inf_right_idem, inf_assoc], }
-    ... = (b⊔a⊔c) * ((b⊔a)⊓c) /(((b⊓a)⊔c)*(b⊓a⊓c))    : by { rw div_mul_div_eq_mul_div_mul,}
-    ... = (b⊔a) * c /(b⊓a*c)                      :
+    ... = (b ⊔ a ⊔ c) * ((b ⊔ a) ⊓ c) /(((b ⊓ a) ⊔ c) * (b ⊓ a ⊓ c)) : by
+      { rw div_mul_div_eq_mul_div_mul,}
+    ... = (b ⊔ a) * c / (b ⊓ a * c)                      :
       by {rw [mul_comm, inf_mul_sup, mul_comm (b ⊓ a ⊔ c), inf_mul_sup] }
-    ... = (b⊔a) / (b⊓a) : by { rw [div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_inv_cancel_left,
+    ... = (b ⊔ a) / (b ⊓ a) : by { rw [div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_inv_cancel_left,
        ← div_eq_mul_inv], }
-    ... = |a/b|         : by { rw sup_div_inf_eq_abs_div,  }
+    ... = |a / b|           : by { rw sup_div_inf_eq_abs_div,  }
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
 equal to its positive component `a⁺`.
 -/
-lemma pos_pos_id (a : α) (h : 1≤ a): a⁺ = a :=
+lemma pos_pos_id (a : α) (h : 1 ≤ a): a⁺ = a :=
 begin
   unfold lattice_ordered_comm_group.pos,
   apply sup_of_le_left h,
@@ -510,7 +511,7 @@ end
 Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
 equal to its absolute value `|a|`.
 -/
-lemma abs_pos_eq (a : α) (h: 1≤a) : |a| = a :=
+lemma abs_pos_eq (a : α) (h: 1 ≤ a) : |a| = a :=
 begin
   unfold has_abs.abs,
   rw [sup_eq_mul_pos_div, div_eq_mul_inv, inv_inv, ← pow_two, inv_mul_eq_iff_eq_mul,
@@ -546,12 +547,13 @@ end
 -- For the non-commutative case, see Birkhoff Theorem 19 (27)
 /--
 Let `α` be a lattice ordered commutative group and let `a`, `b` and `c` be elements in `α`. Let
-`|a⊔c-(b⊔c)|`, `|a⊓c-b⊓c|` and `|a-b|` denote the absolute values of `a⊔c-(b⊔c)`, `a⊓c-b⊓c` and
-`a-b` respectively. Then `|a-b|` dominates `|a⊔c-(b⊔c)|` and `|a⊓c-b⊓c|`.
+`|a ⊔ c - (b ⊔ c)|`, `|a ⊓ c - b ⊓ c|` and `|a - b|` denote the absolute values of
+`a ⊔ c - (b ⊔ c)`, `a ⊓ c - b ⊓ c` and`a - b` respectively. Then `|a - b|` dominates
+`|a ⊔ c - (b ⊔ c)|` and `|a ⊓ c - b ⊓ c|`.
 -/
 @[to_additive additive_Birkhoff_inequalities]
 theorem Birkhoff_inequalities (a b c : α) :
-|(a⊔c)/(b⊔c)| ⊔ |(a⊓c)/(b⊓c)| ≤ |a/b| :=
+|(a ⊔ c) / (b ⊔ c)| ⊔ |(a ⊓ c) / (b ⊓ c)| ≤ |a / b| :=
 begin
   rw sup_le_iff,
   split,
@@ -569,7 +571,7 @@ Let `α` be a lattice ordered commutative group. Then the absolute value satisfi
 inequality.
 -/
 @[to_additive additive_abs_triangle]
-lemma abs_triangle  (a b : α) : |a*b| ≤ |a|*|b| :=
+lemma abs_triangle  (a b : α) : |a * b| ≤ |a| * |b| :=
 begin
   apply sup_le,
   { apply mul_le_mul'

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -211,16 +211,14 @@ Let `α` be a lattice ordered commutative group with identity `0`. For an elemen
 the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`.
 -/
 def lattice_ordered_add_comm_group.pos (a : α) : α :=  a ⊔ 0
-reserve postfix `⁺`:100
-postfix `⁺` := lattice_ordered_add_comm_group.pos
+postfix `⁺`:1000 := lattice_ordered_add_comm_group.pos
 
 /--
 Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
 the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`.
 -/
 def lattice_ordered_add_comm_group.neg (a : α) : α :=  (-a) ⊔ 0
-reserve postfix `⁻`:100
-postfix `⁻` := lattice_ordered_add_comm_group.neg
+postfix `⁻`:1000 := lattice_ordered_add_comm_group.neg
 
 /--
 Absolute value is a unary operator with properties similar to the absolute value of a real number.

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -345,8 +345,7 @@ begin
     { nth_rewrite 0 ← one_mul (a⁻¹),
       apply mul_le_mul'
         (lattice_ordered_comm_group.pos_pos a)
-        (lattice_ordered_comm_group.le_neg a) }
-  },
+        (lattice_ordered_comm_group.le_neg a) } },
   { have mod_eq_pos: |a|⁺ = |a| :=
     begin
       nth_rewrite 1 ← pos_div_neg' (|a|),

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -127,21 +127,14 @@ instance lattice_ordered_comm_group.to_lattice_ordered_group (α : Type u)
     nth_rewrite 1 mul_comm,
     apply s.mul_le_mul_left,
     exact h,
-  end
-}
+  end }
 
 
 -- A linearly ordered additive commutative group is a lattice ordered commutative group
 @[priority 100, to_additive] -- see Note [lower instance priority]
 instance linear_ordered_comm_group.to_lattice_ordered_comm_group (α : Type u)
  [s : linear_ordered_comm_group α] : lattice_ordered_comm_group α :=
-{ mul_le_mul_left :=
-  begin
-    rintros a b h c,
-    apply s.mul_le_mul_left,
-    exact h,
-  end
-}
+{ mul_le_mul_left := s.mul_le_mul_left, }
 
 variables {α : Type u} [lattice_ordered_add_comm_group α]
 
@@ -157,8 +150,7 @@ begin
   { rw [← add_le_add_iff_left (-c), ← add_assoc, neg_add_self, zero_add, sup_le_iff],
     split,
     { simp, },
-    { simp, }
-  },
+    { simp, } },
   { rw ← add_le_add_iff_left (-c), simp,  }
 end
 
@@ -174,13 +166,11 @@ begin
   { rw le_inf_iff,
     split,
     { rw neg_le_neg_iff, apply le_sup_left, },
-    { rw neg_le_neg_iff, apply le_sup_right, }
-  },
+    { rw neg_le_neg_iff, apply le_sup_right, } },
   { rw ← neg_le_neg_iff, simp,
     split,
     { rw ← neg_le_neg_iff, simp, },
-    { rw ← neg_le_neg_iff, simp, }
-  }
+    { rw ← neg_le_neg_iff, simp, } }
 end
 
 /--
@@ -198,12 +188,10 @@ Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in
 $$a⊓b + (a⊔b) = a + b.$$
 -/
 lemma add_eq_meet_add_join (a b : α) : a⊓b + (a⊔b) = a + b :=
-begin
 calc a⊓b + (a⊔b) = a⊓b + ((a + b) + ((-b)⊔(-a))) :
   by {  rw add_join_eq_add_join_add (-b) (-a) (a+b), simp,  }
 ... = a⊓b + ((a + b) + -(a⊓b)) : by { rw [← join_neg_eq_neg_meet, sup_comm], }
 ... = a + b                    : by { simp, },
-end
 
 -- Bourbaki A.VI.12 Definition 4
 /--
@@ -332,11 +320,7 @@ begin
 end
 
 -- Hack to work around rewrite not working if lhs is a variable
-@[nolint doc_blame_thm] lemma pos_sub_neg' (a : α) :  a⁺ - a⁻ = a :=
-begin
-  symmetry,
-  apply pos_sub_neg,
-end
+@[nolint doc_blame_thm] lemma pos_sub_neg' (a : α) :  a⁺ - a⁻ = a := (pos_sub_neg _).symm
 
 -- Bourbaki A.VI.12  Prop 9 a)
 /--
@@ -349,7 +333,7 @@ begin
   rw ←add_right_inj (-a⁻),
   rw add_meet_eq_add_meet_add,
   rw neg_add_eq_sub,
-  simp,
+  simp only [add_zero, add_left_neg],
   rw pos_sub_neg',
   rw neg_eq_neg_inf_zero,
   simp,
@@ -362,10 +346,8 @@ Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in 
 $$a⊔b = b + (a - b)⁺.$$
 -/
 lemma join_eq_add_pos_sub (a b : α) : a⊔b = b + (a - b)⁺ :=
-begin
   calc  a⊔b = (b+(a-b))⊔(b+0) : by {rw add_zero b, rw add_sub_cancel'_right, }
   ... = b + ((a-b)⊔0) : by { rw ← add_join_eq_add_join_add (a-b) 0 b},
-end
 
 -- Bourbaki A.VI.12 (with a and b swapped)
 /--
@@ -374,13 +356,11 @@ Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in 
 $$a⊓b = a - (a - b)⁺.$$
 -/
 lemma meet_eq_sub_pos_sub (a b : α) : a⊓b = a - (a - b)⁺ :=
-begin
   calc a⊓b = (a+0)⊓(a+(b-a)) : by { rw add_zero a, rw add_sub_cancel'_right, }
   ... = a + (0⊓(b-a))        : by {rw ← add_meet_eq_add_meet_add 0 (b-a) a}
   ... = a + ((b-a)⊓0)        : by { rw inf_comm }
   ... = a + (-(a-b)⊓-0 )     : by { rw neg_zero, rw neg_sub }
   ... = a - ((a-b)⊔0)        : by  { rw ← neg_join_eq_neg_meet_neg, rw ← sub_eq_add_neg, }
-end
 
 -- Bourbaki A.VI.12 Prop 9 c)
 -- Can we rewrite `lattice_ordered_add_comm_group.le_pos b` as `b.le_pos`?
@@ -396,19 +376,15 @@ begin
     split,
     { apply sup_le
       (le_trans h (lattice_ordered_add_comm_group.le_pos b))
-      (lattice_ordered_add_comm_group.pos_pos b),
-    },
+      (lattice_ordered_add_comm_group.pos_pos b), },
     { rw ← neg_le_neg_iff at h,
       apply sup_le
       (le_trans h (lattice_ordered_add_comm_group.le_neg a))
-      (lattice_ordered_add_comm_group.neg_pos a),
-    }
+      (lattice_ordered_add_comm_group.neg_pos a), }
   },
   { intro h,
-    rw ← pos_sub_neg' a,
-    rw ← pos_sub_neg' b,
-    apply sub_le_sub h.1 h.2,
-  }
+    rw [← pos_sub_neg' a, ← pos_sub_neg' b ],
+    apply sub_le_sub h.1 h.2, }
 end
 
 -- The proof from Bourbaki A.VI.12 Prop 9 d)
@@ -427,44 +403,31 @@ begin
     { nth_rewrite 0 ← add_zero a,
       apply add_le_add
         (lattice_ordered_add_comm_group.le_pos a)
-        (lattice_ordered_add_comm_group.neg_pos a)
-    },
-    {
-      nth_rewrite 0 ← zero_add (-a),
+        (lattice_ordered_add_comm_group.neg_pos a) },
+    { nth_rewrite 0 ← zero_add (-a),
       apply add_le_add
         (lattice_ordered_add_comm_group.pos_pos a)
-        (lattice_ordered_add_comm_group.le_neg a)
-    }
+        (lattice_ordered_add_comm_group.le_neg a) }
   },
-  {
-    have mod_eq_pos: |a|⁺ = |a| :=
+  { have mod_eq_pos: |a|⁺ = |a| :=
     begin
       nth_rewrite 1 ← pos_sub_neg' (|a|),
       rw sub_eq_add_neg,
       symmetry,
-      rw add_right_eq_self,
-      rw neg_eq_zero,
-      rw le_antisymm_iff,
+      rw [add_right_eq_self, neg_eq_zero, le_antisymm_iff ],
       split,
       { rw ← pos_meet_neg_eq_zero a,
         apply le_inf,
         { rw pos_eq_neg_neg,
           apply and.right
             (iff.elim_left (le_iff_pos_le_neg_ge _ _)
-            (lattice_ordered_add_comm_group.neg_le_abs a)),
-        },
+            (lattice_ordered_add_comm_group.neg_le_abs a)), },
         { apply and.right
             (iff.elim_left (le_iff_pos_le_neg_ge _ _)
-            (lattice_ordered_add_comm_group.le_abs a)),
-        }
-      },
+            (lattice_ordered_add_comm_group.le_abs a)), } },
       { apply lattice_ordered_add_comm_group.neg_pos, }
-
     end,
-    rw ← add_eq_meet_add_join,
-    rw pos_meet_neg_eq_zero,
-    rw zero_add,
-    rw ← mod_eq_pos,
+    rw [← add_eq_meet_add_join, pos_meet_neg_eq_zero, zero_add, ← mod_eq_pos ],
     apply sup_le,
     apply and.left
       (iff.elim_left (le_iff_pos_le_neg_ge _ _)
@@ -472,8 +435,7 @@ begin
     rw neg_eq_pos_neg,
     apply and.left
       (iff.elim_left (le_iff_pos_le_neg_ge _ _)
-      (lattice_ordered_add_comm_group.neg_le_abs a)),
-  }
+      (lattice_ordered_add_comm_group.neg_le_abs a)), }
 end
 
 /--
@@ -484,7 +446,7 @@ $$a⊔b - (a⊓b) = |b-a|.$$
 lemma join_sub_meet_eq_abs_sub (a b : α) : a⊔b - (a⊓b) = |b-a| :=
 begin
   rw [join_eq_add_pos_sub, inf_comm, meet_eq_sub_pos_sub],
-  simp,
+  simp only [add_sub_sub_cancel],
   rw [pos_eq_neg_neg, add_comm, neg_sub, pos_add_neg],
 end
 
@@ -520,30 +482,20 @@ Every lattice ordered commutative group is a distributive lattice
 @[priority 100] -- see Note [lower instance priority]
 instance lattice_ordered_add_comm_group.to_distrib_lattice (α : Type u)
   [s : lattice_ordered_add_comm_group α] : distrib_lattice α :=
-{
-  le_sup_inf :=
+{ le_sup_inf :=
   begin
     intros,
-    rw ← add_le_add_iff_left (x⊓y⊓z),
-    rw inf_assoc,
-    rw add_eq_meet_add_join x (y⊓z),
-    rw ← neg_add_le_iff_le_add,
-    rw le_inf_iff,
+    rw [← add_le_add_iff_left (x⊓y⊓z), inf_assoc, add_eq_meet_add_join x (y⊓z),
+      ← neg_add_le_iff_le_add, le_inf_iff ],
     split,
-    {
-      rw neg_add_le_iff_le_add,
-      rw ← add_eq_meet_add_join x y,
+    { rw [neg_add_le_iff_le_add, ← add_eq_meet_add_join x y ],
       apply add_le_add,
       { apply inf_le_inf_left, apply inf_le_left, },
-      { apply inf_le_left, }
-    },
-    {
-      rw neg_add_le_iff_le_add,
-      rw ← add_eq_meet_add_join x z,
+      { apply inf_le_left, } },
+    { rw [neg_add_le_iff_le_add, ← add_eq_meet_add_join x z ],
       apply add_le_add,
       { apply inf_le_inf_left, apply inf_le_right, },
-      { apply inf_le_right, },
-    }
+      { apply inf_le_right, }, }
   end,
   ..s
 }
@@ -558,22 +510,20 @@ $$|a⊔c-(b⊔c)| + |a⊓c-b⊓c| = |a-b|.$$
 -/
 theorem abs_diff_sup_add_abs_diff_inf (a b c : α) :
 |a⊔c-(b⊔c)| + |a⊓c-b⊓c| = |a-b| :=
-begin
   calc |a⊔c-(b⊔c)| + |a⊓c-b⊓c| =
     (b⊔c)⊔(a⊔c) - (b⊔c)⊓(a⊔c) + |a⊓c-b⊓c|       : by {rw ← join_sub_meet_eq_abs_sub, }
     ... = (b⊔c)⊔(a⊔c) - (b⊔c)⊓(a⊔c) + (b⊓c⊔a⊓c - b⊓c⊓(a⊓c)) : by {rw ←join_sub_meet_eq_abs_sub, }
     ... = b⊔a⊔c - ((b⊓a)⊔c) + ((b⊔a)⊓c - b⊓a⊓c) : by {
-      rw ← sup_inf_right,
-      rw ← inf_sup_right,
-      rw sup_assoc, nth_rewrite 1 sup_comm, rw sup_right_idem, rw sup_assoc,
-      rw inf_assoc, nth_rewrite 3 inf_comm, rw inf_right_idem, rw inf_assoc,
-    }
+      rw [← sup_inf_right, ← inf_sup_right, sup_assoc ],
+      nth_rewrite 1 sup_comm,
+      rw [sup_right_idem, sup_assoc, inf_assoc ],
+      nth_rewrite 3 inf_comm,
+      rw [inf_right_idem, inf_assoc], }
     ... = b⊔a⊔c + (b⊔a)⊓c -(((b⊓a)⊔c)+b⊓a⊓c)    : by {abel,}
     ... = b⊔a + c -(b⊓a+c)                      :
       by {rw [add_comm, add_eq_meet_add_join, add_comm (b ⊓ a ⊔ c), add_eq_meet_add_join] }
     ... = b⊔a - b⊓a                             : by { simp, }
     ... = |a-b|                                 : by { rw join_sub_meet_eq_abs_sub, },
-end
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
@@ -592,21 +542,9 @@ equal to its absolute value `|a|`.
 lemma abs_pos_eq (a : α) (h: 0≤a) : |a| = a :=
 begin
   unfold has_abs.abs,
-  rw join_eq_add_pos_sub,
-  rw sub_neg_eq_add,
-  rw neg_add_eq_sub,
-  rw ←add_left_inj a,
-  rw sub_add_cancel,
-  rw ← two_smul ℕ,
-  rw pos_pos_id,
-  -- I feel there ought to be a simpler way of finishing from here?
-  have t: a+0 ≤ 2•a :=
-  begin
-    rw two_smul,
-    apply add_le_add_left h a,
-  end,
-  rw add_zero at t,
-  apply le_trans h t,
+  rw [join_eq_add_pos_sub, sub_neg_eq_add, neg_add_eq_sub, ←add_left_inj a, sub_add_cancel,
+    ← two_smul ℕ, pos_pos_id ],
+  exact nsmul_nonneg h 2,
 end
 
 /--
@@ -615,8 +553,7 @@ value `|a|` of `a` is positive.
 -/
 lemma lattice_ordered_add_comm_group.abs_pos (a : α) : 0 ≤ |a| :=
 begin
-  rw pos_add_neg,
-  rw ← add_zero (0:α),
+  rw [pos_add_neg, ← add_zero (0:α)],
   apply add_le_add
     (lattice_ordered_add_comm_group.pos_pos a)
     (lattice_ordered_add_comm_group.neg_pos a),
@@ -644,16 +581,12 @@ theorem Birkhoff_inequalities (a b c : α) :
 begin
   rw sup_le_iff,
   split,
-  {
-    apply le_of_add_le_of_nonneg_left,
+  { apply le_of_add_le_of_nonneg_left,
     rw abs_diff_sup_add_abs_diff_inf,
-    apply lattice_ordered_add_comm_group.abs_pos,
-  },
-  {
-    apply le_of_add_le_of_nonneg_right,
+    apply lattice_ordered_add_comm_group.abs_pos, },
+  { apply le_of_add_le_of_nonneg_right,
     rw abs_diff_sup_add_abs_diff_inf,
-    apply lattice_ordered_add_comm_group.abs_pos,
-  }
+    apply lattice_ordered_add_comm_group.abs_pos, }
 end
 
 -- Banasiak Proposition 2.12, Zaanen 2nd lecture
@@ -667,10 +600,8 @@ begin
   { apply add_le_add,
     apply lattice_ordered_add_comm_group.le_abs,
     apply lattice_ordered_add_comm_group.le_abs, },
-  {
-    rw neg_add,
+  { rw neg_add,
     apply add_le_add,
     apply lattice_ordered_add_comm_group.neg_le_abs,
-    apply lattice_ordered_add_comm_group.neg_le_abs,
-  }
+    apply lattice_ordered_add_comm_group.neg_le_abs, }
 end

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -65,7 +65,6 @@ instance linear_ordered_comm_group.to_covariant_class (α : Type u)
   [linear_ordered_comm_group α] :  covariant_class α α (*) (≤) :=
 { elim := λ a b c bc, linear_ordered_comm_group.mul_le_mul_left _ _ bc a }
 
-
 variables {α : Type u} [lattice α] [comm_group α] [covariant_class α α (*) (≤)]
 
 -- Special case of Bourbaki A.VI.9 (1)
@@ -125,7 +124,6 @@ calc a⊓b * (a ⊔ b) = a ⊓ b * ((a * b) * (b⁻¹ ⊔ a⁻¹)) :
 ... = a⊓b * ((a * b) * (a ⊓ b)⁻¹) : by { rw [inv_inf_eq_sup_inv, sup_comm], }
 ... = a * b                    : by { rw [mul_comm, inv_mul_cancel_right],  }
 
-
 /--
 Absolute value is a unary operator with properties similar to the absolute value of a real number.
 -/
@@ -152,13 +150,11 @@ postfix `⁺`:1000 := mpos
 Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
 the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`.
 -/
-@[to_additive neg "
-  Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
-  the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`.
-"]
+@[to_additive neg
+  "Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
+  the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`."]
 def mneg (a : α) : α := a⁻¹ ⊔ 1
 postfix `⁻`:1000 := mneg
-
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with absolute value
@@ -203,8 +199,6 @@ component `a⁻`. Then `a⁻` dominates `-a`.
 -/
 @[to_additive additive_le_neg]
 lemma le_neg (a : α) : a⁻¹ ≤ a⁻ := le_sup_left
-
-
 
 -- Bourbaki A.VI.12
 /--

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -26,7 +26,7 @@ This file develops the basic theory, concentrating on the commutative case writt
 
 ## Main statements
 
-- `pos_sub_neg`: Every element a of a `lattice_ordered_add_comm_group` has a decomposition a⁺-a⁻
+- `pos_sub_neg`: Every element `a` of a `lattice_ordered_add_comm_group` has a decomposition `a⁺-a⁻`
    into the difference of the positive and negative component.
 - `pos_meet_neg_eq_zero`: The positive and negative components are coprime.
 - `abs_triangle`: The absolute value operation satisfies the triangle inequality.
@@ -36,9 +36,9 @@ number of equations and inequalities.
 
 ## Notations
 
-- `a⁺ = a ⊔ 0`: The *positive component* of an element a of a `lattice_ordered_add_comm_group`
-- `a⁻ = (-a) ⊔ 0`: The *negative component* of an element a of a `lattice_ordered_add_comm_group`
-* `|a| = a⊔(-a)`: The *absolute value* of an element a of a `lattice_ordered_add_comm_group`
+- `a⁺ = a ⊔ 0`: The *positive component* of an element `a` of a `lattice_ordered_add_comm_group`
+- `a⁻ = (-a) ⊔ 0`: The *negative component* of an element `a` of a `lattice_ordered_add_comm_group`
+* `|a| = a⊔(-a)`: The *absolute value* of an element `a` of a `lattice_ordered_add_comm_group`
 
 ## Implementation notes
 
@@ -68,8 +68,8 @@ lattice, ordered, group
 universe u
 
 /--
-A group (α,*), equipped with a partial order ≤, making α into a lattice, such that, given elements
-a and b of type α satisfying a ≤ b, for all elements c and d of type α,
+A group `(α,*)`, equipped with a partial order `≤`, making `α` into a lattice, such that, given
+elements `a` and `b` of type `α` satisfying `a ≤ b`, for all elements `c` and `d` of `type α`,
 $$c * a * d ≤ c * b * d,$$
 is said to be a *lattice ordered group*.
 -/
@@ -86,8 +86,8 @@ class lattice_ordered_comm_group (α : Type u)
 (mul_le_mul_left : ∀ a b : α, a ≤ b → ∀ c : α, c * a ≤ c * b)
 
 /--
-A group (α,+), equipped with a partial order ≤, making α into a lattice, such that, given elements
-a and b of type α satisfying a ≤ b, for all elements c and d of type α,
+A group `(α,+)`, equipped with a partial order `≤`, making `α` into a lattice, such that, given
+elements `a` and `b` of type `α` satisfying `a ≤ b`, for all elements `c` and `d` of type `α`,
 $$c + a + d ≤ c + b + d,$$
 is said to be a *lattice ordered (additive) group*.
 -/
@@ -147,7 +147,7 @@ variables {α : Type u} [lattice_ordered_add_comm_group α]
 
 -- Special case of Bourbaki A.VI.9 (1)
 /--
-Let α be a lattice ordered commutative group. For all elements a, b and c in α,
+Let `α` be a lattice ordered commutative group. For all elements `a`, `b` and `c` in `α`,
 $$c + (a⊔b) = (c+a)⊔(c+b).$$
 -/
 lemma add_join_eq_add_join_add (a b c : α) : c + (a⊔b) = (c+a)⊔(c+b) :=
@@ -164,7 +164,7 @@ end
 
 -- Special case of Bourbaki A.VI.9 (2)
 /--
-Let α be a lattice ordered commutative group. For all elements a and b in α,
+Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
 $$-(a⊔b)=(-a)⊓(-b).$$
 -/
 lemma neg_join_eq_neg_meet_neg (a b : α) : -(a⊔b)=(-a)⊓(-b) :=
@@ -184,7 +184,7 @@ begin
 end
 
 /--
-Let α be a lattice ordered commutative group. For all elements a and b in α,
+Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
 $$-a⊔-b = -(a⊓b).$$
 -/
 @[simp] lemma join_neg_eq_neg_meet (a b : α) : -a⊔-b = -(a⊓b) :=
@@ -194,7 +194,7 @@ end
 
 -- Bourbaki A.VI.10 Prop 7
 /--
-Let α be a lattice ordered commutative group. For all elements a and b in α,
+Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
 $$a⊓b + (a⊔b) = a + b.$$
 -/
 lemma add_eq_meet_add_join (a b : α) : a⊓b + (a⊔b) = a + b :=
@@ -207,16 +207,16 @@ end
 
 -- Bourbaki A.VI.12 Definition 4
 /--
-Let α be a lattice ordered commutative group with identity 0. For an element a of type α, the
-element a ⊔ 0 is said to be the *positive component* of a, denoted a⁺.
+Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
+the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`.
 -/
 def lattice_ordered_add_comm_group.pos (a : α) : α :=  a ⊔ 0
 reserve postfix `⁺`:100
 postfix `⁺` := lattice_ordered_add_comm_group.pos
 
 /--
-Let α be a lattice ordered commutative group with identity 0. For an element a of type α, the
-element (-a) ⊔ 0 is said to be the *negative component* of a, denoted a⁻.
+Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
+the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`.
 -/
 def lattice_ordered_add_comm_group.neg (a : α) : α :=  (-a) ⊔ 0
 reserve postfix `⁻`:100
@@ -233,40 +233,40 @@ instance lattice_ordered_add_comm_group_has_abs : has_abs (α)  := ⟨λa, a⊔-
 namespace lattice_ordered_add_comm_group
 
 /--
-Let α be a lattice ordered commutative group and let a be an element in α with absolute value |a|.
-Then,
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with absolute value
+`|a|`. Then,
 $$a ≤ |a|.$$
 -/
 lemma le_abs (a : α) : a ≤ |a| := le_sup_left
 
 /--
-Let α be a lattice ordered commutative group and let a be an element in α with absolute value |a|.
-Then,
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with absolute value
+`|a|`. Then,
 $$-a ≤ |a|.$$
 -/
 lemma neg_le_abs (a : α) : -a ≤ |a| := le_sup_right
 
 /--
-Let α be a lattice ordered commutative group and let a be an element in α with positive component
-a⁺. Then a⁺ is positive.
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
+ component `a⁺`. Then `a⁺` is positive.
 -/
 lemma pos_pos (a : α) : 0 ≤ a⁺ := le_sup_right
 
 /--
-Let α be a lattice ordered commutative group and let a be an element in α withnegative component a⁻.
-Then a⁻ is positive.
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α` withnegative
+component `a⁻`. Then `a⁻` is positive.
 -/
 lemma neg_pos (a : α) : 0 ≤ a⁻ := le_sup_right
 
 /--
-Let α be a lattice ordered commutative group and let a be an element in α with positive component
-a⁺. Then a⁺ dominates a.
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
+component `a⁺`. Then `a⁺` dominates `a`.
 -/
 lemma le_pos (a : α) : a ≤ a⁺ := le_sup_left
 
 /--
-Let α be a lattice ordered commutative group and let a be an element in α with negative component
-a⁻. Then a⁻ dominates -a.
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with negative
+component `a⁻`. Then `a⁻` dominates `-a`.
 -/
 lemma le_neg (a : α) : -a ≤ a⁻ := le_sup_left
 
@@ -274,8 +274,8 @@ end lattice_ordered_add_comm_group
 
 -- Bourbaki A.VI.12
 /--
-Let α be a lattice ordered commutative group and let a be an element in α. Then the negative
-component a⁻ of a is equal to the positive component (-a)⁺ of -a.
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α`. Then the negative
+component `a⁻` of `a` is equal to the positive component `(-a)⁺` of `-a`.
 -/
 lemma neg_eq_pos_neg (a : α) : a⁻ =(-a)⁺ :=
 begin
@@ -284,8 +284,8 @@ begin
 end
 
 /--
-Let α be a lattice ordered commutative group and let a be an element in α. Then the positive
-component a⁺ of a is equal to the negative component (-a)⁻ of -a.
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α`. Then the positive
+component `a⁺` of `a` is equal to the negative component `(-a)⁻` of `-a`.
 -/
 lemma pos_eq_neg_neg (a : α) : a⁺ =(-a)⁻ :=
 begin
@@ -295,7 +295,7 @@ end
 
 -- We use this in Bourbaki A.VI.12  Prop 9 a)
 /--
-Let α be a lattice ordered commutative group. For all elements a, b and c in α,
+Let `α` be a lattice ordered commutative group. For all elements `a`, `b` and `c` in `α`,
 $$c + (a⊓b) = (c+a)⊓(c+b).$$
 -/
 lemma add_meet_eq_add_meet_add (a b c : α) : c + (a⊓b) = (c+a)⊓(c+b) :=
@@ -308,8 +308,8 @@ end
 
 -- We use this in Bourbaki A.VI.12  Prop 9 a)
 /--
-Let α be a lattice ordered commutative group with identity 0 and let a be an element in α with
-negative component a⁻. Then
+Let `α` be a lattice ordered commutative group with identity `0` and let `a` be an element in `α`
+with negative component `a⁻`. Then
 $$a⁻ = -(a⊓0).$$
 -/
 lemma neg_eq_neg_inf_zero (a : α) : a⁻ = -(a⊓0) :=
@@ -322,8 +322,9 @@ end
 
 -- Bourbaki A.VI.12  Prop 9 a)
 /--
-Let α be a lattice ordered commutative group and let a be an element in α with positive component a⁺
-and negative component a⁻. Then a can be decomposed as the difference of a⁺ and a⁻.
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
+component `a⁺` and negative component `a⁻`. Then `a` can be decomposed as the difference of `a⁺` and
+`a⁻`.
 -/
 lemma pos_sub_neg (a : α) : a = a⁺ - a⁻ :=
 begin
@@ -341,8 +342,9 @@ end
 
 -- Bourbaki A.VI.12  Prop 9 a)
 /--
-Let α be a lattice ordered commutative group and let a be an element in α with positive component a⁺
-and negative component a⁻. Then a⁺ and a⁻ are co-prime (and, since they are positive, disjoint).
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
+component `a⁺` and negative component `a⁻`. Then `a⁺` and `a⁻` are co-prime (and, since they are
+positive, disjoint).
 -/
 lemma pos_meet_neg_eq_zero (a : α) : a⁺⊓a⁻=0 :=
 begin
@@ -357,8 +359,8 @@ end
 
 -- Bourbaki A.VI.12 (with a and b swapped)
 /--
-Let α be a lattice ordered commutative group, let a and b be elements in α, and let (a - b)⁺ be the
-positive componet of a-b. Then
+Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α`, and let
+`(a - b)⁺` be the positive componet of `a-b`. Then
 $$a⊔b = b + (a - b)⁺.$$
 -/
 lemma join_eq_add_pos_sub (a b : α) : a⊔b = b + (a - b)⁺ :=
@@ -369,8 +371,8 @@ end
 
 -- Bourbaki A.VI.12 (with a and b swapped)
 /--
-Let α be a lattice ordered commutative group, let a and b be elements in α, and let (a - b)⁺ be the
-positive componet of a-b. Then
+Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α`, and let
+`(a - b)⁺` be the positive componet of `a-b`. Then
 $$a⊓b = a - (a - b)⁺.$$
 -/
 lemma meet_eq_sub_pos_sub (a b : α) : a⊓b = a - (a - b)⁺ :=
@@ -385,9 +387,9 @@ end
 -- Bourbaki A.VI.12 Prop 9 c)
 -- Can we rewrite `lattice_ordered_add_comm_group.le_pos b` as `b.le_pos`?
 /--
-Let α be a lattice ordered commutative group and let a and b be elements in α with positive
-components a⁺ and b⁺ and negative components a⁻ and b⁻ respectively. Then b dominates a if
-and only if b⁺ dominates a⁺ and b⁻ dominates a⁺.
+Let `α` be a lattice ordered commutative group and let `a` and `b` be elements in `α` with positive
+components `a⁺` and `b⁺` and negative components `a⁻` and `b⁻` respectively. Then `b` dominates `a`
+if and only if `b⁺` dominates `a⁺` and `a⁻` dominates `b⁻`.
 -/
 lemma le_iff_pos_le_neg_ge (a b : α) : a ≤ b ↔ a⁺ ≤ b⁺ ∧ b⁻ ≤ a⁻ :=
 begin
@@ -413,8 +415,9 @@ end
 
 -- The proof from Bourbaki A.VI.12 Prop 9 d)
 /--
-Let α be a lattice ordered commutative group and let a be an element in α with absolute value |a|,
-positive component a⁺ and negative component a⁻. Then |a| decomposes as the sum of a⁺ and a⁻.
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with absolute value
+`|a|`, positive component `a⁺` and negative component `a⁻`. Then `|a|` decomposes as the sum of `a⁺`
+and `a⁻`.
 -/
 lemma pos_add_neg (a : α) : |a| = a⁺ + a⁻ :=
 begin
@@ -470,8 +473,8 @@ begin
 end
 
 /--
-Let α be a lattice ordered commutative group, let a and b be elements in α and let |b-a| be the
-absolute value of b-a. Then,
+Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b-a|`
+be the absolute value of `b-a`. Then,
 $$a⊔b - (a⊓b) = |b-a|.$$
 -/
 lemma join_sub_meet_eq_abs_sub (a b : α) : a⊔b - (a⊓b) = |b-a| :=
@@ -482,8 +485,8 @@ begin
 end
 
 /--
-Let α be a lattice ordered commutative group, let a and b be elements in α and let |b-a| be the
-absolute value of b-a. Then,
+Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b-a|`
+be the absolute value of `b-a`. Then,
 $$2•(a⊔b) = a + b + |b - a|.$$
 -/
 lemma two_join_eq_add_add_abs_sub (a b : α) : 2•(a⊔b) = a + b + |b - a| :=
@@ -495,8 +498,8 @@ begin
 end
 
 /--
-Let α be a lattice ordered commutative group, let a and b be elements in α and let |b-a| be the
-absolute value of b-a. Then,
+Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b-a|`
+be the absolute value of `b-a`. Then,
 $$2•(a⊓b) = a + b - |b - a|.$$
 -/
 lemma two_meet_eq_add_sub_abs_sub (a b : α) : 2•(a⊓b) = a + b - |b - a| :=
@@ -544,8 +547,9 @@ instance lattice_ordered_add_comm_group.to_distrib_lattice (α : Type u)
 -- See, e.g. Zaanen, Lectures on Riesz Spaces
 -- 3rd lecture
 /--
-Let α be a lattice ordered commutative group and let a, b and c be elements in α. Let |a⊔c-(b⊔c)|,
-|a⊓c-b⊓c| and |a-b| denote the absolute values of a⊔c-(b⊔c), a⊓c-b⊓c and a-b respectively. Then,
+Let `α` be a lattice ordered commutative group and let `a`, `b` and `c` be elements in `α`. Let
+`|a⊔c-(b⊔c)|`, `|a⊓c-b⊓c|` and `|a-b|` denote the absolute values of `a⊔c-(b⊔c)`, `a⊓c-b⊓c` and
+`a-b` respectively. Then,
 $$|a⊔c-(b⊔c)| + |a⊓c-b⊓c| = |a-b|.$$
 -/
 theorem abs_diff_sup_add_abs_diff_inf (a b c : α) :
@@ -568,8 +572,8 @@ begin
 end
 
 /--
-Let α be a lattice ordered commutative group and let a be a positive element in α. Then a is equal
-to its positive component a⁺.
+Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is equal
+to its positive component `a⁺`.
 -/
 lemma pos_pos_id (a : α) (h : 0≤ a): a⁺ = a :=
 begin
@@ -578,8 +582,8 @@ begin
 end
 
 /--
-Let α be a lattice ordered commutative group and let a be a positive element in α. Then a is equal
-to its absolute value |a|.
+Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
+equal to its absolute value `|a|`.
 -/
 lemma abs_pos_eq (a : α) (h: 0≤a) : |a| = a :=
 begin
@@ -602,8 +606,8 @@ begin
 end
 
 /--
-Let α be a lattice ordered commutative group and let a be an element in α. Then the absolute value
-|a| of a is positive.
+Let `α` be a lattice ordered commutative group and let `a` be an element in `α`. Then the absolute
+value `|a|` of `a` is positive.
 -/
 lemma lattice_ordered_add_comm_group.abs_pos (a : α) : 0 ≤ |a| :=
 begin
@@ -613,7 +617,7 @@ begin
 end
 
 /--
-Let α be a lattice ordered commutative group. The unary operation of taking the absolute value is
+Let `α` be a lattice ordered commutative group. The unary operation of taking the absolute value is
 idempotent.
 -/
 lemma abs_idempotent (a : α) : |a| = | |a| | :=
@@ -625,9 +629,9 @@ end
 -- Commutative case, Zaanen, 3rd lecture
 -- For the non-commutative case, see Birkhoff Theorem 19 (27)
 /--
-Let α be a lattice ordered commutative group and let a, b and c be elements in α. Let |a⊔c-(b⊔c)|,
-|a⊓c-b⊓c| and |a-b| denote the absolute values of a⊔c-(b⊔c), a⊓c-b⊓c and a-b respectively. Then
-|a-b| dominates |a⊔c-(b⊔c)| and |a⊓c-b⊓c|.
+Let `α` be a lattice ordered commutative group and let `a`, `b` and `c` be elements in `α`. Let
+`|a⊔c-(b⊔c)|`, `|a⊓c-b⊓c|` and `|a-b|` denote the absolute values of `a⊔c-(b⊔c)`, `a⊓c-b⊓c` and
+`a-b` respectively. Then `|a-b|` dominates `|a⊔c-(b⊔c)|` and `|a⊓c-b⊓c|`.
 -/
 theorem Birkhoff_inequalities (a b c : α) :
 |a⊔c-(b⊔c)| ⊔ |a⊓c-b⊓c| ≤ |a-b| :=
@@ -648,7 +652,7 @@ end
 
 -- Banasiak Proposition 2.12, Zaanen 2nd lecture
 /--
-Let α be a lattice ordered commutative group. Then the absolute value satisfies the triangle
+Let `α` be a lattice ordered commutative group. Then the absolute value satisfies the triangle
 inequality.
 -/
 lemma abs_triangle  (a b : α) : |a+b| ≤ |a|+|b| :=

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -65,7 +65,7 @@ instance linear_ordered_comm_group.to_covariant_class (α : Type u)
   [linear_ordered_comm_group α] :  covariant_class α α (*) (≤) :=
 { elim := λ a b c bc, linear_ordered_comm_group.mul_le_mul_left _ _ bc a }
 
-variables {α : Type u} [lattice α] [comm_group α] [covariant_class α α (*) (≤)]
+variables {α : Type u} [lattice α] [comm_group α]
 
 -- Special case of Bourbaki A.VI.9 (1)
 /--
@@ -73,7 +73,8 @@ Let `α` be a lattice ordered commutative group. For all elements `a`, `b` and `
 $$c + (a ⊔ b) = (c + a) ⊔ (c + b).$$
 -/
 @[to_additive]
-lemma mul_sup_eq_mul_sup_mul (a b c : α) : c * (a ⊔ b) = (c * a) ⊔ (c * b) :=
+lemma mul_sup_eq_mul_sup_mul [covariant_class α α (*) (≤)]
+  (a b c : α) : c * (a ⊔ b) = (c * a) ⊔ (c * b) :=
 begin
   refine le_antisymm _ (by simp),
   rw [← mul_le_mul_iff_left (c⁻¹), ← mul_assoc, inv_mul_self, one_mul],
@@ -88,7 +89,7 @@ Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in
 $$-(a ⊔ b)=(-a) ⊓ (-b).$$
 -/
 @[to_additive]
-lemma inv_sup_eq_inv_inf_inv (a b : α) : (a ⊔ b)⁻¹ = a⁻¹ ⊓ b⁻¹ :=
+lemma inv_sup_eq_inv_inf_inv [covariant_class α α (*) (≤)] (a b : α) : (a ⊔ b)⁻¹ = a⁻¹ ⊓ b⁻¹ :=
 begin
   rw le_antisymm_iff,
   split,
@@ -107,7 +108,7 @@ Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in
 $$ -(a ⊓ b) = -a ⊔ -b.$$
 -/
 @[to_additive, simp]
-lemma inv_inf_eq_sup_inv (a b : α) : (a ⊓ b)⁻¹ = a⁻¹ ⊔ b⁻¹ :=
+lemma inv_inf_eq_sup_inv [covariant_class α α (*) (≤)] (a b : α) : (a ⊓ b)⁻¹ = a⁻¹ ⊔ b⁻¹ :=
 by rw [← inv_inv (a⁻¹ ⊔ b⁻¹), inv_sup_eq_inv_inf_inv a⁻¹ b⁻¹, inv_inv, inv_inv]
 
 -- Bourbaki A.VI.10 Prop 7
@@ -116,7 +117,7 @@ Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in
 $$a ⊓ b + (a ⊔ b) = a + b.$$
 -/
 @[to_additive]
-lemma inf_mul_sup (a b : α) : a ⊓ b * (a ⊔ b) = a * b :=
+lemma inf_mul_sup [covariant_class α α (*) (≤)] (a b : α) : a ⊓ b * (a ⊔ b) = a * b :=
 calc a⊓b * (a ⊔ b) = a ⊓ b * ((a * b) * (b⁻¹ ⊔ a⁻¹)) :
   by {  rw mul_sup_eq_mul_sup_mul b⁻¹ a⁻¹ (a * b), simp,  }
 ... = a⊓b * ((a * b) * (a ⊓ b)⁻¹) : by rw [inv_inf_eq_sup_inv, sup_comm]
@@ -218,7 +219,8 @@ Let `α` be a lattice ordered commutative group. For all elements `a`, `b` and `
 $$c + (a ⊓ b) = (c + a) ⊓ (c + b).$$
 -/
 @[to_additive]
-lemma mul_inf_eq_mul_inf_mul (a b c : α) : c * (a ⊓ b) = (c * a) ⊓ (c * b) :=
+lemma mul_inf_eq_mul_inf_mul [covariant_class α α (*) (≤)]
+  (a b c : α) : c * (a ⊓ b) = (c * a) ⊓ (c * b) :=
 begin
   rw le_antisymm_iff,
   split,
@@ -233,7 +235,7 @@ with negative component `a⁻`. Then
 $$a⁻ = -(a ⊓ 0).$$
 -/
 @[to_additive]
-lemma neg_eq_inv_inf_one (a : α) : a⁻ = (a ⊓ 1)⁻¹ :=
+lemma neg_eq_inv_inf_one [covariant_class α α (*) (≤)] (a : α) : a⁻ = (a ⊓ 1)⁻¹ :=
 begin
   unfold lattice_ordered_comm_group.mneg,
   rw [← inv_inj, inv_sup_eq_inv_inf_inv, inv_inv, inv_inv, one_inv],
@@ -246,7 +248,7 @@ component `a⁺` and negative component `a⁻`. Then `a` can be decomposed as th
 `a⁻`.
 -/
 @[to_additive]
-lemma pos_inv_neg (a : α) : a = a⁺ / a⁻ :=
+lemma pos_inv_neg [covariant_class α α (*) (≤)] (a : α) : a = a⁺ / a⁻ :=
 begin
   rw div_eq_mul_inv,
   apply eq_mul_inv_of_mul_eq,
@@ -257,7 +259,7 @@ end
 
 -- Hack to work around rewrite not working if lhs is a variable
 @[to_additive, nolint doc_blame_thm]
-lemma pos_div_neg' (a : α) :  a⁺ / a⁻ = a := (pos_inv_neg _).symm
+lemma pos_div_neg' [covariant_class α α (*) (≤)] (a : α) :  a⁺ / a⁻ = a := (pos_inv_neg _).symm
 
 -- Bourbaki A.VI.12  Prop 9 a)
 /--
@@ -266,7 +268,7 @@ component `a⁺` and negative component `a⁻`. Then `a⁺` and `a⁻` are co-pr
 positive, disjoint).
 -/
 @[to_additive]
-lemma pos_inf_neg_eq_one (a : α) : a⁺ ⊓ a⁻=1 :=
+lemma pos_inf_neg_eq_one [covariant_class α α (*) (≤)] (a : α) : a⁺ ⊓ a⁻=1 :=
 by rw [←mul_right_inj (a⁻)⁻¹, mul_inf_eq_mul_inf_mul, mul_one, mul_left_inv, mul_comm,
   ←div_eq_mul_inv, pos_div_neg', neg_eq_inv_inf_one, inv_inv]
 
@@ -277,7 +279,7 @@ Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in 
 $$a⊔b = b + (a - b)⁺.$$
 -/
 @[to_additive]
-lemma sup_eq_mul_pos_div (a b : α) : a ⊔ b = b * (a / b)⁺ :=
+lemma sup_eq_mul_pos_div [covariant_class α α (*) (≤)] (a b : α) : a ⊔ b = b * (a / b)⁺ :=
 calc  a ⊔ b = (b * (a / b)) ⊔ (b * 1) : by {rw [mul_one b, div_eq_mul_inv, mul_comm a,
   mul_inv_cancel_left], }
 ... = b * ((a / b) ⊔ 1) : by { rw ← mul_sup_eq_mul_sup_mul (a / b) 1 b}
@@ -289,7 +291,7 @@ Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in 
 $$a⊓b = a - (a - b)⁺.$$
 -/
 @[to_additive]
-lemma inf_eq_div_pos_div (a b : α) : a ⊓ b = a / (a / b)⁺ :=
+lemma inf_eq_div_pos_div [covariant_class α α (*) (≤)] (a b : α) : a ⊓ b = a / (a / b)⁺ :=
 calc a ⊓ b = (a * 1) ⊓ (a * (b / a)) : by { rw [mul_one a, div_eq_mul_inv, mul_comm b,
   mul_inv_cancel_left], }
 ... = a * (1 ⊓ (b / a))     : by rw ← mul_inf_eq_mul_inf_mul 1 (b / a) a
@@ -306,7 +308,7 @@ components `a⁺` and `b⁺` and negative components `a⁻` and `b⁻` respectiv
 if and only if `b⁺` dominates `a⁺` and `a⁻` dominates `b⁻`.
 -/
 @[to_additive additive_le_iff_pos_le_neg_ge]
-lemma le_iff_pos_le_neg_ge (a b : α) : a ≤ b ↔ a⁺ ≤ b⁺ ∧ b⁻ ≤ a⁻ :=
+lemma le_iff_pos_le_neg_ge [covariant_class α α (*) (≤)] (a b : α) : a ≤ b ↔ a⁺ ≤ b⁺ ∧ b⁻ ≤ a⁻ :=
 begin
   split,
   { intro h,
@@ -331,7 +333,7 @@ Let `α` be a lattice ordered commutative group and let `a` be an element in `α
 and `a⁻`.
 -/
 @[to_additive]
-lemma pos_mul_neg (a : α) : |a| = a⁺ * a⁻ :=
+lemma pos_mul_neg [covariant_class α α (*) (≤)] (a : α) : |a| = a⁺ * a⁻ :=
 begin
   rw le_antisymm_iff,
   split,
@@ -379,7 +381,8 @@ be the absolute value of `b - a`. Then,
 $$a ⊔ b - (a ⊓ b) = |b - a|.$$
 -/
 @[to_additive]
-lemma sup_div_inf_eq_abs_div (a b : α) : (a ⊔ b) / (a ⊓ b) = |b / a| :=
+lemma sup_div_inf_eq_abs_div [covariant_class α α (*) (≤)] (a b : α) : (a ⊔ b) / (a ⊓ b) = |b / a|
+  :=
 begin
   rw [sup_eq_mul_pos_div, inf_comm, inf_eq_div_pos_div, div_eq_mul_inv],
   nth_rewrite 1 div_eq_mul_inv,
@@ -394,7 +397,8 @@ be the absolute value of `b - a`. Then,
 $$2•(a ⊔ b) = a + b + |b - a|.$$
 -/
 @[to_additive]
-lemma sup_sq_eq_mul_mul_abs_div (a b : α) : (a ⊔ b)^2 = a * b * |b / a| :=
+lemma sup_sq_eq_mul_mul_abs_div [covariant_class α α (*) (≤)] (a b : α) :
+  (a ⊔ b)^2 = a * b * |b / a| :=
 by rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, ← mul_assoc, mul_comm,
     mul_assoc, ← pow_two, inv_mul_cancel_left]
 
@@ -404,7 +408,8 @@ be the absolute value of `b-a`. Then,
 $$2•(a ⊓ b) = a + b - |b - a|.$$
 -/
 @[to_additive]
-lemma two_inf_eq_mul_div_abs_div (a b : α) : (a ⊓ b)^2 = a * b / |b / a| :=
+lemma two_inf_eq_mul_div_abs_div [covariant_class α α (*) (≤)] (a b : α) :
+  (a ⊓ b)^2 = a * b / |b / a| :=
 by rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, div_eq_mul_inv,
     mul_inv_rev, inv_inv, mul_assoc, mul_inv_cancel_comm_assoc, ← pow_two]
 
@@ -440,7 +445,7 @@ Let `α` be a lattice ordered commutative group and let `a`, `b` and `c` be elem
 $$|a ⊔ c - (b ⊔ c)| + |a ⊓ c-b ⊓ c| = |a - b|.$$
 -/
 @[to_additive]
-theorem abs_div_sup_mul_abs_div_inf (a b c : α) :
+theorem abs_div_sup_mul_abs_div_inf [covariant_class α α (*) (≤)] (a b c : α) :
 |(a ⊔ c)/(b ⊔ c)| * |(a ⊓ c)/(b ⊓ c)| = |a / b| :=
 calc |(a ⊔ c) / (b ⊔ c)| * |a ⊓ c / (b ⊓ c)| =
   ((b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c))) * |a ⊓ c / (b ⊓ c)| : by rw sup_div_inf_eq_abs_div
@@ -473,7 +478,7 @@ end
 Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
 equal to its absolute value `|a|`.
 -/
-lemma abs_pos_eq (a : α) (h: 1 ≤ a) : |a| = a :=
+lemma abs_pos_eq [covariant_class α α (*) (≤)] (a : α) (h: 1 ≤ a) : |a| = a :=
 begin
   unfold has_abs.abs,
   rw [sup_eq_mul_pos_div, div_eq_mul_inv, inv_inv, ← pow_two, inv_mul_eq_iff_eq_mul,
@@ -487,7 +492,7 @@ Let `α` be a lattice ordered commutative group and let `a` be an element in `α
 value `|a|` of `a` is positive.
 -/
 @[to_additive additive_abs_pos]
-lemma abs_pos (a : α) : 1 ≤ |a| :=
+lemma abs_pos [covariant_class α α (*) (≤)] (a : α) : 1 ≤ |a| :=
 begin
   rw pos_mul_neg,
   apply one_le_mul
@@ -499,7 +504,7 @@ end
 Let `α` be a lattice ordered commutative group. The unary operation of taking the absolute value is
 idempotent.
 -/
-lemma abs_idempotent (a : α) : |a| = | |a| | :=
+lemma abs_idempotent [covariant_class α α (*) (≤)] (a : α) : |a| = | |a| | :=
 begin
   rw abs_pos_eq (|a|),
   apply lattice_ordered_comm_group.abs_pos,
@@ -514,7 +519,7 @@ Let `α` be a lattice ordered commutative group and let `a`, `b` and `c` be elem
 `|a ⊔ c - (b ⊔ c)|` and `|a ⊓ c - b ⊓ c|`.
 -/
 @[to_additive additive_Birkhoff_inequalities]
-theorem Birkhoff_inequalities (a b c : α) :
+theorem Birkhoff_inequalities [covariant_class α α (*) (≤)] (a b c : α) :
 |(a ⊔ c) / (b ⊔ c)| ⊔ |(a ⊓ c) / (b ⊓ c)| ≤ |a / b| :=
 begin
   rw sup_le_iff,
@@ -533,7 +538,7 @@ Let `α` be a lattice ordered commutative group. Then the absolute value satisfi
 inequality.
 -/
 @[to_additive additive_abs_triangle]
-lemma abs_triangle  (a b : α) : |a * b| ≤ |a| * |b| :=
+lemma abs_triangle [covariant_class α α (*) (≤)] (a b : α) : |a * b| ≤ |a| * |b| :=
 begin
   apply sup_le,
   { apply mul_le_mul'

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -39,8 +39,8 @@ A lattice ordered commutative group is a type `α` satisfying:
 * `[comm_group α]`
 * `[covariant_class α α (*) (≤)]`
 
-The remainder of the file establishes basic properties of `lattice_ordered_comm_group`. A number
-of these results also hold in the non-commutative case ([Birkhoff][birkhoff1942],
+The remainder of the file establishes basic properties of lattice ordered commutative groups. A
+number of these results also hold in the non-commutative case ([Birkhoff][birkhoff1942],
 [Fuchs][fuchs1963]) but we have not developed that here, since we are primarily interested in vector
 lattices.
 

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -352,7 +352,6 @@ lemma inf_eq_sub_pos_sub (a b : α) : a⊓b = a - (a - b)⁺ :=
   ... = a - ((a-b)⊔0)        : by  { rw ← neg_sup_eq_neg_inf_neg, rw ← sub_eq_add_neg, }
 
 -- Bourbaki A.VI.12 Prop 9 c)
--- Can we rewrite `lattice_ordered_add_comm_group.le_pos b` as `b.le_pos`?
 /--
 Let `α` be a lattice ordered commutative group and let `a` and `b` be elements in `α` with positive
 components `a⁺` and `b⁺` and negative components `a⁻` and `b⁻` respectively. Then `b` dominates `a`

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -191,7 +191,7 @@ lemma add_eq_meet_add_join (a b : α) : a⊓b + (a⊔b) = a + b :=
 calc a⊓b + (a⊔b) = a⊓b + ((a + b) + ((-b)⊔(-a))) :
   by {  rw add_join_eq_add_join_add (-b) (-a) (a+b), simp,  }
 ... = a⊓b + ((a + b) + -(a⊓b)) : by { rw [← join_neg_eq_neg_meet, sup_comm], }
-... = a + b                    : by { simp, },
+... = a + b                    : by { simp, }
 
 -- Bourbaki A.VI.12 Definition 4
 /--
@@ -347,7 +347,7 @@ $$a⊔b = b + (a - b)⁺.$$
 -/
 lemma join_eq_add_pos_sub (a b : α) : a⊔b = b + (a - b)⁺ :=
   calc  a⊔b = (b+(a-b))⊔(b+0) : by {rw add_zero b, rw add_sub_cancel'_right, }
-  ... = b + ((a-b)⊔0) : by { rw ← add_join_eq_add_join_add (a-b) 0 b},
+  ... = b + ((a-b)⊔0) : by { rw ← add_join_eq_add_join_add (a-b) 0 b}
 
 -- Bourbaki A.VI.12 (with a and b swapped)
 /--
@@ -523,7 +523,7 @@ theorem abs_diff_sup_add_abs_diff_inf (a b c : α) :
     ... = b⊔a + c -(b⊓a+c)                      :
       by {rw [add_comm, add_eq_meet_add_join, add_comm (b ⊓ a ⊔ c), add_eq_meet_add_join] }
     ... = b⊔a - b⊓a                             : by { simp, }
-    ... = |a-b|                                 : by { rw join_sub_meet_eq_abs_sub, },
+    ... = |a-b|                                 : by { rw join_sub_meet_eq_abs_sub, }
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -416,7 +416,9 @@ by rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, div_eq_m
 /--
 Every lattice ordered commutative group is a distributive lattice
 -/
-@[to_additive, priority 100] -- see Note [lower instance priority]
+@[to_additive
+  "Every lattice ordered commutative additive group is a distributive lattice"
+]
 def lattice_ordered_comm_group_to_distrib_lattice (α : Type u)
   [s: lattice α] [comm_group α] [covariant_class α α (*) (≤)] : distrib_lattice α :=
 { le_sup_inf :=

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -346,9 +346,8 @@ begin
       apply mul_le_mul'
         (lattice_ordered_comm_group.pos_pos a)
         (lattice_ordered_comm_group.le_neg a) } },
-  { have mod_eq_pos: |a|⁺ = |a| :=
-    begin
-      nth_rewrite 1 ← pos_div_neg' (|a|),
+  { have mod_eq_pos: |a|⁺ = |a|,
+    { nth_rewrite 1 ← pos_div_neg' (|a|),
       rw div_eq_mul_inv,
       symmetry,
       rw [mul_right_eq_self], symmetry, rw [one_eq_inv, le_antisymm_iff],
@@ -362,8 +361,7 @@ begin
         { apply and.right
             (iff.elim_left (le_iff_pos_le_neg_ge _ _)
             (lattice_ordered_comm_group.le_abs a)), } },
-      { apply lattice_ordered_comm_group.neg_pos, }
-    end,
+      { apply lattice_ordered_comm_group.neg_pos, } },
     rw [← inf_mul_sup, pos_inf_neg_eq_one, one_mul, ← mod_eq_pos ],
     apply sup_le,
     apply and.left

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -442,22 +442,22 @@ $$|a ⊔ c - (b ⊔ c)| + |a ⊓ c-b ⊓ c| = |a - b|.$$
 @[to_additive]
 theorem abs_div_sup_mul_abs_div_inf (a b c : α) :
 |(a ⊔ c)/(b ⊔ c)| * |(a ⊓ c)/(b ⊓ c)| = |a / b| :=
-  calc |(a ⊔ c) / (b ⊔ c)| * |a ⊓ c / (b ⊓ c)| =
-    ((b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c))) * |a ⊓ c / (b ⊓ c)| : by rw sup_div_inf_eq_abs_div
-    ... = (b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c)) * (((b ⊓ c) ⊔ (a ⊓ c)) / ((b ⊓ c) ⊓ (a ⊓ c))) :
-      by rw sup_div_inf_eq_abs_div (b ⊓ c) (a ⊓ c)
-    ... = (b ⊔ a ⊔ c) / ((b ⊓ a) ⊔ c) * (((b ⊔ a) ⊓ c) / (b ⊓ a ⊓ c)) : by {
-      rw [← sup_inf_right, ← inf_sup_right, sup_assoc ],
-      nth_rewrite 1 sup_comm,
-      rw [sup_right_idem, sup_assoc, inf_assoc ],
-      nth_rewrite 3 inf_comm,
-      rw [inf_right_idem, inf_assoc], }
-    ... = (b ⊔ a ⊔ c) * ((b ⊔ a) ⊓ c) /(((b ⊓ a) ⊔ c) * (b ⊓ a ⊓ c)) : by rw div_mul_comm
-    ... = (b ⊔ a) * c / (b ⊓ a * c) :
-      by rw [mul_comm, inf_mul_sup, mul_comm (b ⊓ a ⊔ c), inf_mul_sup]
-    ... = (b ⊔ a) / (b ⊓ a) : by rw [div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_inv_cancel_left,
-       ← div_eq_mul_inv]
-    ... = |a / b|           : by rw sup_div_inf_eq_abs_div
+calc |(a ⊔ c) / (b ⊔ c)| * |a ⊓ c / (b ⊓ c)| =
+  ((b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c))) * |a ⊓ c / (b ⊓ c)| : by rw sup_div_inf_eq_abs_div
+... = (b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c)) * (((b ⊓ c) ⊔ (a ⊓ c)) / ((b ⊓ c) ⊓ (a ⊓ c))) :
+  by rw sup_div_inf_eq_abs_div (b ⊓ c) (a ⊓ c)
+... = (b ⊔ a ⊔ c) / ((b ⊓ a) ⊔ c) * (((b ⊔ a) ⊓ c) / (b ⊓ a ⊓ c)) : by {
+  rw [← sup_inf_right, ← inf_sup_right, sup_assoc ],
+  nth_rewrite 1 sup_comm,
+  rw [sup_right_idem, sup_assoc, inf_assoc ],
+  nth_rewrite 3 inf_comm,
+  rw [inf_right_idem, inf_assoc], }
+... = (b ⊔ a ⊔ c) * ((b ⊔ a) ⊓ c) /(((b ⊓ a) ⊔ c) * (b ⊓ a ⊓ c)) : by rw div_mul_comm
+... = (b ⊔ a) * c / (b ⊓ a * c) :
+  by rw [mul_comm, inf_mul_sup, mul_comm (b ⊓ a ⊔ c), inf_mul_sup]
+... = (b ⊔ a) / (b ⊓ a) : by rw [div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_inv_cancel_left,
+    ← div_eq_mul_inv]
+... = |a / b|           : by rw sup_div_inf_eq_abs_div
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -1,0 +1,666 @@
+/-
+Copyright (c) 2021 Christopher Hoskin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christopher Hoskin
+-/
+import algebra.ordered_group
+import algebra.module.basic -- Needed for scalar multiplication
+import tactic.ring
+
+/-!
+# Lattice ordered groups
+
+Lattice ordered groups were introduced by [Birkhoff][birkhoff1942].
+They form the algebraic underpinnings of vector lattices, Banach lattices, AL-space, AM-space etc.
+
+This file develops the basic theory, concentrating on the commutative case written additively.
+
+## Main definitions
+
+* `lattice_ordered_group` - a (non-commutative) partially ordered (multiplicative) group which forms
+  a lattice with respect to the partial order.
+* `lattice_ordered_add_group` - the additive form of a `lattice_ordered_group`
+* `lattice_ordered_comm_group` - a lattice ordered (multiplicative) group with commutative group
+  operation
+* `lattice_ordered_add_comm_group` - the additice form of a `lattice_ordered_comm_group`
+
+## Main statements
+
+- `pos_sub_neg`: Every element a of a `lattice_ordered_add_comm_group` has a decomposition a⁺-a⁻
+   into the difference of the positive and negative component.
+- `pos_meet_neg_eq_zero`: The positive and negative components are coprime.
+- `abs_triangle`: The absolute value operation satisfies the triangle inequality.
+
+It is shown that the meet and join operations are related to the absolute value operation by a
+number of equations and inequalities.
+
+## Notations
+
+- `a⁺ = a ⊔ 0`: The *positive component* of an element a of a `lattice_ordered_add_comm_group`
+- `a⁻ = (-a) ⊔ 0`: The *negative component* of an element a of a `lattice_ordered_add_comm_group`
+* `|a| = a⊔(-a)`: The *absolute value* of an element a of a `lattice_ordered_add_comm_group`
+
+## Implementation notes
+
+We define `lattice_ordered_group` as extending `group` and `lattice` and
+`lattice_ordered_comm_group` as extending `comm_group` and `lattice`. Equivalent additive classes
+are defined. We then show that a `lattice_ordered_comm_group` is a `lattice_ordered_group` and an
+`ordered_comm_group`.
+
+The remainder of the file establishes basic properties of `lattice_ordered_add_comm_group`. A number
+of these results also hold in the non-commutative case ([Birkhoff][birkhoff1942],
+[Fuchs][fuchs1963]) but we have not developed that here. We have concentrated on groups written
+additively, since we are primarily interested in vector lattices.
+
+## References
+
+* [Birkhoff, Lattice-ordered Groups][birkhoff1942]
+* [Bourbaki, Algebra II][bourbaki1981]
+* [Fuchs, Partially Ordered Algebraic Systems][fuchs1963]
+* [Zaanen, Lectures on "Riesz Spaces"][zaanen1966]
+* [Banasiak, Banach Lattices in Applications][banasiak]
+
+## Tags
+
+lattice, ordered, group
+-/
+
+universe u
+
+/--
+A group (α,*), equipped with a partial order ≤, making α into a lattice, such that, given elements
+a and b of type α satisfying a ≤ b, for all elements c and d of type α,
+$$c * a * d ≤ c * b * d,$$
+is said to be a *lattice ordered group*.
+-/
+class lattice_ordered_group (α : Type u)
+  extends group α, lattice α :=
+(mul_le_mul : ∀ a b : α, a ≤ b → ∀ c d : α, c * a * d ≤ c * b * d)
+
+/--
+A lattice ordered group with Abelian group multiplication is said to be a *lattice ordered
+commutative group*.
+-/
+class lattice_ordered_comm_group (α : Type u)
+  extends comm_group α, lattice α :=
+(mul_le_mul_left : ∀ a b : α, a ≤ b → ∀ c : α, c * a ≤ c * b)
+
+/--
+A group (α,+), equipped with a partial order ≤, making α into a lattice, such that, given elements
+a and b of type α satisfying a ≤ b, for all elements c and d of type α,
+$$c + a + d ≤ c + b + d,$$
+is said to be a *lattice ordered (additive) group*.
+-/
+class lattice_ordered_add_group (α : Type u)
+  extends add_group α, lattice α :=
+(add_le_add : ∀ a b : α, a ≤ b → ∀ c d : α, c + a + d ≤ c + b + d)
+
+/--
+A lattice ordered additive group with Abelian group addition is said to be a *lattice ordered
+(additative) commutative group*.
+-/
+class lattice_ordered_add_comm_group (α : Type u)
+  extends add_comm_group α, lattice α :=
+(add_le_add_left : ∀ a b : α, a ≤ b → ∀ c : α, c + a ≤ c + b)
+
+-- Tells to_additive that lattice_ordered_add_group is the additive form of lattice_ordered_group
+-- and lattice_ordered_add_comm_group is the additive form of lattice_ordered_comm_group
+attribute [to_additive] lattice_ordered_group
+attribute [to_additive] lattice_ordered_comm_group
+
+-- Every lattice ordered commutative group is also an ordered additive commutative group
+@[priority 100, to_additive] -- see Note [lower instance priority]
+instance lattice_ordered_comm_group.to_ordered_comm_group (α : Type u)
+  [s : lattice_ordered_comm_group α] : ordered_comm_group α :=
+{ mul := s.mul, ..s }
+
+-- A lattice ordered commutative group is a lattice ordered group
+@[priority 100, to_additive] -- see Note [lower instance priority]
+instance lattice_ordered_comm_group.to_lattice_ordered_group (α : Type u)
+  [s : lattice_ordered_comm_group α] : lattice_ordered_group α :=
+{ mul_le_mul :=
+  begin
+    rintros a b h c d,
+    rw [mul_assoc, mul_assoc],
+    apply s.mul_le_mul_left,
+    rw mul_comm,
+    nth_rewrite 1 mul_comm,
+    apply s.mul_le_mul_left,
+    exact h,
+  end
+}
+
+
+-- A linearly ordered additive commutative group is a lattice ordered commutative group
+@[priority 100, to_additive] -- see Note [lower instance priority]
+instance linear_ordered_comm_group.to_lattice_ordered_comm_group (α : Type u)
+ [s : linear_ordered_comm_group α] : lattice_ordered_comm_group α :=
+{ mul_le_mul_left :=
+  begin
+    rintros a b h c,
+    apply s.mul_le_mul_left,
+    exact h,
+  end
+}
+
+variables {α : Type u} [lattice_ordered_add_comm_group α]
+
+-- Special case of Bourbaki A.VI.9 (1)
+/--
+Let α be a lattice ordered commutative group. For all elements a, b and c in α,
+$$c + (a⊔b) = (c+a)⊔(c+b).$$
+-/
+lemma add_join_eq_add_join_add (a b c : α) : c + (a⊔b) = (c+a)⊔(c+b) :=
+begin
+  rw le_antisymm_iff,
+  split,
+  { rw [← add_le_add_iff_left (-c), ← add_assoc, neg_add_self, zero_add, sup_le_iff],
+    split,
+    { simp, },
+    { simp, }
+  },
+  { rw ← add_le_add_iff_left (-c), simp,  }
+end
+
+-- Special case of Bourbaki A.VI.9 (2)
+/--
+Let α be a lattice ordered commutative group. For all elements a and b in α,
+$$-(a⊔b)=(-a)⊓(-b).$$
+-/
+lemma neg_join_eq_neg_meet_neg (a b : α) : -(a⊔b)=(-a)⊓(-b) :=
+begin
+  rw le_antisymm_iff,
+  split,
+  { rw le_inf_iff,
+    split,
+    { rw neg_le_neg_iff, apply le_sup_left, },
+    { rw neg_le_neg_iff, apply le_sup_right, }
+  },
+  { rw ← neg_le_neg_iff, simp,
+    split,
+    { rw ← neg_le_neg_iff, simp, },
+    { rw ← neg_le_neg_iff, simp, }
+  }
+end
+
+/--
+Let α be a lattice ordered commutative group. For all elements a and b in α,
+$$-a⊔-b = -(a⊓b).$$
+-/
+@[simp] lemma join_neg_eq_neg_meet (a b : α) : -a⊔-b = -(a⊓b) :=
+begin
+  rw [← neg_neg (-a⊔-b), neg_join_eq_neg_meet_neg (-a) (-b), neg_neg, neg_neg],
+end
+
+-- Bourbaki A.VI.10 Prop 7
+/--
+Let α be a lattice ordered commutative group. For all elements a and b in α,
+$$a⊓b + (a⊔b) = a + b.$$
+-/
+lemma add_eq_meet_add_join (a b : α) : a⊓b + (a⊔b) = a + b :=
+begin
+calc a⊓b + (a⊔b) = a⊓b + ((a + b) + ((-b)⊔(-a))) :
+  by {  rw add_join_eq_add_join_add (-b) (-a) (a+b), simp,  }
+... = a⊓b + ((a + b) + -(a⊓b)) : by { rw [← join_neg_eq_neg_meet, sup_comm], }
+... = a + b                    : by { simp, },
+end
+
+-- Bourbaki A.VI.12 Definition 4
+/--
+Let α be a lattice ordered commutative group with identity 0. For an element a of type α, the
+element a ⊔ 0 is said to be the *positive component* of a, denoted a⁺.
+-/
+def lattice_ordered_add_comm_group.pos (a : α) : α :=  a ⊔ 0
+reserve postfix `⁺`:100
+postfix `⁺` := lattice_ordered_add_comm_group.pos
+
+/--
+Let α be a lattice ordered commutative group with identity 0. For an element a of type α, the
+element (-a) ⊔ 0 is said to be the *negative component* of a, denoted a⁻.
+-/
+def lattice_ordered_add_comm_group.neg (a : α) : α :=  (-a) ⊔ 0
+reserve postfix `⁻`:100
+postfix `⁻` := lattice_ordered_add_comm_group.neg
+
+/--
+Absolute value is a unary operator with properties similar to the absolute value of a real number.
+-/
+class has_abs (α : Type u) := (abs : α → α)
+local notation `|`a`|` := has_abs.abs a
+@[priority 100] -- see Note [lower instance priority]
+instance lattice_ordered_add_comm_group_has_abs : has_abs (α)  := ⟨λa, a⊔-a⟩
+
+namespace lattice_ordered_add_comm_group
+
+/--
+Let α be a lattice ordered commutative group and let a be an element in α with absolute value |a|.
+Then,
+$$a ≤ |a|.$$
+-/
+lemma le_abs (a : α) : a ≤ |a| := le_sup_left
+
+/--
+Let α be a lattice ordered commutative group and let a be an element in α with absolute value |a|.
+Then,
+$$-a ≤ |a|.$$
+-/
+lemma neg_le_abs (a : α) : -a ≤ |a| := le_sup_right
+
+/--
+Let α be a lattice ordered commutative group and let a be an element in α with positive component
+a⁺. Then a⁺ is positive.
+-/
+lemma pos_pos (a : α) : 0 ≤ a⁺ := le_sup_right
+
+/--
+Let α be a lattice ordered commutative group and let a be an element in α withnegative component a⁻.
+Then a⁻ is positive.
+-/
+lemma neg_pos (a : α) : 0 ≤ a⁻ := le_sup_right
+
+/--
+Let α be a lattice ordered commutative group and let a be an element in α with positive component
+a⁺. Then a⁺ dominates a.
+-/
+lemma le_pos (a : α) : a ≤ a⁺ := le_sup_left
+
+/--
+Let α be a lattice ordered commutative group and let a be an element in α with negative component
+a⁻. Then a⁻ dominates -a.
+-/
+lemma le_neg (a : α) : -a ≤ a⁻ := le_sup_left
+
+end lattice_ordered_add_comm_group
+
+-- Bourbaki A.VI.12
+/--
+Let α be a lattice ordered commutative group and let a be an element in α. Then the negative
+component a⁻ of a is equal to the positive component (-a)⁺ of -a.
+-/
+lemma neg_eq_pos_neg (a : α) : a⁻ =(-a)⁺ :=
+begin
+  unfold lattice_ordered_add_comm_group.neg,
+  unfold lattice_ordered_add_comm_group.pos,
+end
+
+/--
+Let α be a lattice ordered commutative group and let a be an element in α. Then the positive
+component a⁺ of a is equal to the negative component (-a)⁻ of -a.
+-/
+lemma pos_eq_neg_neg (a : α) : a⁺ =(-a)⁻ :=
+begin
+  rw neg_eq_pos_neg,
+  simp,
+end
+
+-- We use this in Bourbaki A.VI.12  Prop 9 a)
+/--
+Let α be a lattice ordered commutative group. For all elements a, b and c in α,
+$$c + (a⊓b) = (c+a)⊓(c+b).$$
+-/
+lemma add_meet_eq_add_meet_add (a b c : α) : c + (a⊓b) = (c+a)⊓(c+b) :=
+begin
+  rw le_antisymm_iff,
+  split,
+  { simp, },
+  { rw ← add_le_add_iff_left (-c), abel, rw le_inf_iff, simp, }
+end
+
+-- We use this in Bourbaki A.VI.12  Prop 9 a)
+/--
+Let α be a lattice ordered commutative group with identity 0 and let a be an element in α with
+negative component a⁻. Then
+$$a⁻ = -(a⊓0).$$
+-/
+lemma neg_eq_neg_inf_zero (a : α) : a⁻ = -(a⊓0) :=
+begin
+  unfold lattice_ordered_add_comm_group.neg,
+  rw ← neg_inj,
+  rw neg_join_eq_neg_meet_neg,
+  simp,
+end
+
+-- Bourbaki A.VI.12  Prop 9 a)
+/--
+Let α be a lattice ordered commutative group and let a be an element in α with positive component a⁺
+and negative component a⁻. Then a can be decomposed as the difference of a⁺ and a⁻.
+-/
+lemma pos_sub_neg (a : α) : a = a⁺ - a⁻ :=
+begin
+  unfold lattice_ordered_add_comm_group.neg,
+  rw [eq_sub_iff_add_eq, add_join_eq_add_join_add, add_zero, add_right_neg, sup_comm],
+  unfold lattice_ordered_add_comm_group.pos,
+end
+
+-- Hack to work around rewrite not working if lhs is a variable
+@[nolint doc_blame_thm] lemma pos_sub_neg' (a : α) :  a⁺ - a⁻ = a :=
+begin
+  symmetry,
+  apply pos_sub_neg,
+end
+
+-- Bourbaki A.VI.12  Prop 9 a)
+/--
+Let α be a lattice ordered commutative group and let a be an element in α with positive component a⁺
+and negative component a⁻. Then a⁺ and a⁻ are co-prime (and, since they are positive, disjoint).
+-/
+lemma pos_meet_neg_eq_zero (a : α) : a⁺⊓a⁻=0 :=
+begin
+  rw ←add_right_inj (-a⁻),
+  rw add_meet_eq_add_meet_add,
+  rw neg_add_eq_sub,
+  simp,
+  rw pos_sub_neg',
+  rw neg_eq_neg_inf_zero,
+  simp,
+end
+
+-- Bourbaki A.VI.12 (with a and b swapped)
+/--
+Let α be a lattice ordered commutative group, let a and b be elements in α, and let (a - b)⁺ be the
+positive componet of a-b. Then
+$$a⊔b = b + (a - b)⁺.$$
+-/
+lemma join_eq_add_pos_sub (a b : α) : a⊔b = b + (a - b)⁺ :=
+begin
+  calc  a⊔b = (b+(a-b))⊔(b+0) : by {rw add_zero b, rw add_sub_cancel'_right, }
+  ... = b + ((a-b)⊔0) : by { rw ← add_join_eq_add_join_add (a-b) 0 b},
+end
+
+-- Bourbaki A.VI.12 (with a and b swapped)
+/--
+Let α be a lattice ordered commutative group, let a and b be elements in α, and let (a - b)⁺ be the
+positive componet of a-b. Then
+$$a⊓b = a - (a - b)⁺.$$
+-/
+lemma meet_eq_sub_pos_sub (a b : α) : a⊓b = a - (a - b)⁺ :=
+begin
+  calc a⊓b = (a+0)⊓(a+(b-a)) : by { rw add_zero a, rw add_sub_cancel'_right, }
+  ... = a + (0⊓(b-a))        : by {rw ← add_meet_eq_add_meet_add 0 (b-a) a}
+  ... = a + ((b-a)⊓0)        : by { rw inf_comm }
+  ... = a + (-(a-b)⊓-0 )     : by { rw neg_zero, rw neg_sub }
+  ... = a - ((a-b)⊔0)        : by  { rw ← neg_join_eq_neg_meet_neg, rw ← sub_eq_add_neg, }
+end
+
+-- Bourbaki A.VI.12 Prop 9 c)
+-- Can we rewrite `lattice_ordered_add_comm_group.le_pos b` as `b.le_pos`?
+/--
+Let α be a lattice ordered commutative group and let a and b be elements in α with positive
+components a⁺ and b⁺ and negative components a⁻ and b⁻ respectively. Then b dominates a if
+and only if b⁺ dominates a⁺ and b⁻ dominates a⁺.
+-/
+lemma le_iff_pos_le_neg_ge (a b : α) : a ≤ b ↔ a⁺ ≤ b⁺ ∧ b⁻ ≤ a⁻ :=
+begin
+  split,
+  { intro h,
+    split,
+    { apply sup_le
+      (le_trans h (lattice_ordered_add_comm_group.le_pos b))
+      (lattice_ordered_add_comm_group.pos_pos b),
+    },
+    { rw ← neg_le_neg_iff at h,
+      apply sup_le
+      (le_trans h (lattice_ordered_add_comm_group.le_neg a))
+      (lattice_ordered_add_comm_group.neg_pos a),
+    }
+  },
+  { intro h,
+    rw ← pos_sub_neg' a,
+    rw ← pos_sub_neg' b,
+    apply sub_le_sub h.1 h.2,
+  }
+end
+
+-- The proof from Bourbaki A.VI.12 Prop 9 d)
+/--
+Let α be a lattice ordered commutative group and let a be an element in α with absolute value |a|,
+positive component a⁺ and negative component a⁻. Then |a| decomposes as the sum of a⁺ and a⁻.
+-/
+lemma pos_add_neg (a : α) : |a| = a⁺ + a⁻ :=
+begin
+  rw le_antisymm_iff,
+  split,
+  { unfold has_abs.abs,
+    rw sup_le_iff,
+    split,
+    { nth_rewrite 0 ← add_zero a,
+      apply add_le_add  (lattice_ordered_add_comm_group.le_pos a) (lattice_ordered_add_comm_group.neg_pos a)
+    },
+    {
+      nth_rewrite 0 ← zero_add (-a),
+      apply add_le_add  (lattice_ordered_add_comm_group.pos_pos a) (lattice_ordered_add_comm_group.le_neg a)
+    }
+  },
+  {
+    have mod_eq_pos: |a|⁺ = |a| :=
+    begin
+      nth_rewrite 1 ← pos_sub_neg' (|a|),
+      rw sub_eq_add_neg,
+      symmetry,
+      rw add_right_eq_self,
+      rw neg_eq_zero,
+      rw le_antisymm_iff,
+      split,
+      { rw ← pos_meet_neg_eq_zero a,
+        apply le_inf,
+        { rw pos_eq_neg_neg,
+          apply and.right
+            (iff.elim_left (le_iff_pos_le_neg_ge _ _)
+            (lattice_ordered_add_comm_group.neg_le_abs a)),
+        },
+        { apply and.right
+            (iff.elim_left (le_iff_pos_le_neg_ge _ _)
+            (lattice_ordered_add_comm_group.le_abs a)),
+        }
+      },
+      { apply lattice_ordered_add_comm_group.neg_pos, }
+
+    end,
+    rw ← add_eq_meet_add_join,
+    rw pos_meet_neg_eq_zero,
+    rw zero_add,
+    rw ← mod_eq_pos,
+    apply sup_le,
+    apply and.left (iff.elim_left (le_iff_pos_le_neg_ge _ _) (lattice_ordered_add_comm_group.le_abs a)),
+    rw neg_eq_pos_neg,
+    apply and.left
+      (iff.elim_left (le_iff_pos_le_neg_ge _ _)
+      (lattice_ordered_add_comm_group.neg_le_abs a)),
+  }
+end
+
+/--
+Let α be a lattice ordered commutative group, let a and b be elements in α and let |b-a| be the
+absolute value of b-a. Then,
+$$a⊔b - (a⊓b) = |b-a|.$$
+-/
+lemma join_sub_meet_eq_abs_sub (a b : α) : a⊔b - (a⊓b) = |b-a| :=
+begin
+  rw [join_eq_add_pos_sub, inf_comm, meet_eq_sub_pos_sub],
+  simp,
+  rw [pos_eq_neg_neg, add_comm, neg_sub, pos_add_neg],
+end
+
+/--
+Let α be a lattice ordered commutative group, let a and b be elements in α and let |b-a| be the
+absolute value of b-a. Then,
+$$2•(a⊔b) = a + b + |b - a|.$$
+-/
+lemma two_join_eq_add_add_abs_sub (a b : α) : 2•(a⊔b) = a + b + |b - a| :=
+begin
+  rw [← add_eq_meet_add_join a b, ← join_sub_meet_eq_abs_sub],
+  abel,
+  simp only [← gsmul_coe_nat],
+  norm_cast,
+end
+
+/--
+Let α be a lattice ordered commutative group, let a and b be elements in α and let |b-a| be the
+absolute value of b-a. Then,
+$$2•(a⊓b) = a + b - |b - a|.$$
+-/
+lemma two_meet_eq_add_sub_abs_sub (a b : α) : 2•(a⊓b) = a + b - |b - a| :=
+begin
+  rw [← add_eq_meet_add_join a b, ← join_sub_meet_eq_abs_sub],
+  abel,
+  simp only [← gsmul_coe_nat],
+  norm_cast,
+end
+
+/--
+Every lattice ordered commutative group is a distributive lattice
+-/
+@[priority 100] -- see Note [lower instance priority]
+instance lattice_ordered_add_comm_group.to_distrib_lattice (α : Type u)
+  [s : lattice_ordered_add_comm_group α] : distrib_lattice α :=
+{
+  le_sup_inf :=
+  begin
+    intros,
+    rw ← add_le_add_iff_left (x⊓y⊓z),
+    rw inf_assoc,
+    rw add_eq_meet_add_join x (y⊓z),
+    rw ← neg_add_le_iff_le_add,
+    rw le_inf_iff,
+    split,
+    {
+      rw neg_add_le_iff_le_add,
+      rw ← add_eq_meet_add_join x y,
+      apply add_le_add,
+      { apply inf_le_inf_left, apply inf_le_left, },
+      { apply inf_le_left, }
+    },
+    {
+      rw neg_add_le_iff_le_add,
+      rw ← add_eq_meet_add_join x z,
+      apply add_le_add,
+      { apply inf_le_inf_left, apply inf_le_right, },
+      { apply inf_le_right, },
+    }
+  end,
+  ..s
+}
+
+-- See, e.g. Zaanen, Lectures on Riesz Spaces
+-- 3rd lecture
+/--
+Let α be a lattice ordered commutative group and let a, b and c be elements in α. Let |a⊔c-(b⊔c)|,
+|a⊓c-b⊓c| and |a-b| denote the absolute values of a⊔c-(b⊔c), a⊓c-b⊓c and a-b respectively. Then,
+$$|a⊔c-(b⊔c)| + |a⊓c-b⊓c| = |a-b|.$$
+-/
+theorem abs_diff_sup_add_abs_diff_inf (a b c : α) :
+|a⊔c-(b⊔c)| + |a⊓c-b⊓c| = |a-b| :=
+begin
+  calc |a⊔c-(b⊔c)| + |a⊓c-b⊓c| =
+    (b⊔c)⊔(a⊔c) - (b⊔c)⊓(a⊔c) + |a⊓c-b⊓c|       : by {rw ← join_sub_meet_eq_abs_sub, }
+    ... = (b⊔c)⊔(a⊔c) - (b⊔c)⊓(a⊔c) + (b⊓c⊔a⊓c - b⊓c⊓(a⊓c)) : by {rw ←join_sub_meet_eq_abs_sub, }
+    ... = b⊔a⊔c - ((b⊓a)⊔c) + ((b⊔a)⊓c - b⊓a⊓c) : by {
+      rw ← sup_inf_right,
+      rw ← inf_sup_right,
+      rw sup_assoc, nth_rewrite 1 sup_comm, rw sup_right_idem, rw sup_assoc,
+      rw inf_assoc, nth_rewrite 3 inf_comm, rw inf_right_idem, rw inf_assoc,
+    }
+    ... = b⊔a⊔c + (b⊔a)⊓c -(((b⊓a)⊔c)+b⊓a⊓c)    : by {abel,}
+    ... = b⊔a + c -(b⊓a+c)                      :
+      by {rw [add_comm, add_eq_meet_add_join, add_comm (b ⊓ a ⊔ c), add_eq_meet_add_join] }
+    ... = b⊔a - b⊓a                             : by { simp, }
+    ... = |a-b|                                 : by { rw join_sub_meet_eq_abs_sub, },
+end
+
+/--
+Let α be a lattice ordered commutative group and let a be a positive element in α. Then a is equal
+to its positive component a⁺.
+-/
+lemma pos_pos_id (a : α) (h : 0≤ a): a⁺ = a :=
+begin
+  unfold lattice_ordered_add_comm_group.pos,
+  apply sup_of_le_left h,
+end
+
+/--
+Let α be a lattice ordered commutative group and let a be a positive element in α. Then a is equal
+to its absolute value |a|.
+-/
+lemma abs_pos_eq (a : α) (h: 0≤a) : |a| = a :=
+begin
+  unfold has_abs.abs,
+  rw join_eq_add_pos_sub,
+  rw sub_neg_eq_add,
+  rw neg_add_eq_sub,
+  rw ←add_left_inj a,
+  rw sub_add_cancel,
+  rw ← two_smul ℕ,
+  rw pos_pos_id,
+  -- I feel there ought to be a simpler way of finishing from here?
+  have t: a+0 ≤ 2•a :=
+  begin
+    rw two_smul,
+    apply add_le_add_left h a,
+  end,
+  rw add_zero at t,
+  apply le_trans h t,
+end
+
+/--
+Let α be a lattice ordered commutative group and let a be an element in α. Then the absolute value
+|a| of a is positive.
+-/
+lemma lattice_ordered_add_comm_group.abs_pos (a : α) : 0 ≤ |a| :=
+begin
+  rw pos_add_neg,
+  rw ← add_zero (0:α),
+  apply add_le_add (lattice_ordered_add_comm_group.pos_pos a) (lattice_ordered_add_comm_group.neg_pos a),
+end
+
+/--
+Let α be a lattice ordered commutative group. The unary operation of taking the absolute value is
+idempotent.
+-/
+lemma abs_idempotent (a : α) : |a| = | |a| | :=
+begin
+  rw abs_pos_eq (|a|),
+  apply lattice_ordered_add_comm_group.abs_pos,
+end
+
+-- Commutative case, Zaanen, 3rd lecture
+-- For the non-commutative case, see Birkhoff Theorem 19 (27)
+/--
+Let α be a lattice ordered commutative group and let a, b and c be elements in α. Let |a⊔c-(b⊔c)|,
+|a⊓c-b⊓c| and |a-b| denote the absolute values of a⊔c-(b⊔c), a⊓c-b⊓c and a-b respectively. Then
+|a-b| dominates |a⊔c-(b⊔c)| and |a⊓c-b⊓c|.
+-/
+theorem Birkhoff_inequalities (a b c : α) :
+|a⊔c-(b⊔c)| ⊔ |a⊓c-b⊓c| ≤ |a-b| :=
+begin
+  rw sup_le_iff,
+  split,
+  {
+    apply le_of_add_le_of_nonneg_left,
+    rw abs_diff_sup_add_abs_diff_inf,
+    apply lattice_ordered_add_comm_group.abs_pos,
+  },
+  {
+    apply le_of_add_le_of_nonneg_right,
+    rw abs_diff_sup_add_abs_diff_inf,
+    apply lattice_ordered_add_comm_group.abs_pos,
+  }
+end
+
+-- Banasiak Proposition 2.12, Zaanen 2nd lecture
+/--
+Let α be a lattice ordered commutative group. Then the absolute value satisfies the triangle
+inequality.
+-/
+lemma abs_triangle  (a b : α) : |a+b| ≤ |a|+|b| :=
+begin
+  apply sup_le,
+  { apply add_le_add, apply lattice_ordered_add_comm_group.le_abs, apply lattice_ordered_add_comm_group.le_abs, },
+  {
+    rw neg_add,
+    apply add_le_add,
+    apply lattice_ordered_add_comm_group.neg_le_abs,
+    apply lattice_ordered_add_comm_group.neg_le_abs,
+  }
+end
+
+#lint doc_blame_thm

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -417,7 +417,7 @@ by rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, div_eq_m
 Every lattice ordered commutative group is a distributive lattice
 -/
 @[to_additive, priority 100] -- see Note [lower instance priority]
-instance lattice_ordered_comm_group_to_distrib_lattice (α : Type u)
+def lattice_ordered_comm_group_to_distrib_lattice (α : Type u)
   [s: lattice α] [comm_group α] [covariant_class α α (*) (≤)] : distrib_lattice α :=
 { le_sup_inf :=
   begin
@@ -446,23 +446,26 @@ $$|a ⊔ c - (b ⊔ c)| + |a ⊓ c-b ⊓ c| = |a - b|.$$
 -/
 @[to_additive]
 theorem abs_div_sup_mul_abs_div_inf [covariant_class α α (*) (≤)] (a b c : α) :
-|(a ⊔ c)/(b ⊔ c)| * |(a ⊓ c)/(b ⊓ c)| = |a / b| :=
-calc |(a ⊔ c) / (b ⊔ c)| * |a ⊓ c / (b ⊓ c)| =
-  ((b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c))) * |a ⊓ c / (b ⊓ c)| : by rw sup_div_inf_eq_abs_div
-... = (b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c)) * (((b ⊓ c) ⊔ (a ⊓ c)) / ((b ⊓ c) ⊓ (a ⊓ c))) :
-  by rw sup_div_inf_eq_abs_div (b ⊓ c) (a ⊓ c)
-... = (b ⊔ a ⊔ c) / ((b ⊓ a) ⊔ c) * (((b ⊔ a) ⊓ c) / (b ⊓ a ⊓ c)) : by {
-  rw [← sup_inf_right, ← inf_sup_right, sup_assoc ],
-  nth_rewrite 1 sup_comm,
-  rw [sup_right_idem, sup_assoc, inf_assoc ],
-  nth_rewrite 3 inf_comm,
-  rw [inf_right_idem, inf_assoc], }
-... = (b ⊔ a ⊔ c) * ((b ⊔ a) ⊓ c) /(((b ⊓ a) ⊔ c) * (b ⊓ a ⊓ c)) : by rw div_mul_comm
-... = (b ⊔ a) * c / (b ⊓ a * c) :
-  by rw [mul_comm, inf_mul_sup, mul_comm (b ⊓ a ⊔ c), inf_mul_sup]
-... = (b ⊔ a) / (b ⊓ a) : by rw [div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_inv_cancel_left,
-    ← div_eq_mul_inv]
-... = |a / b|           : by rw sup_div_inf_eq_abs_div
+  |(a ⊔ c)/(b ⊔ c)| * |(a ⊓ c)/(b ⊓ c)| = |a / b| :=
+begin
+  letI : distrib_lattice α := lattice_ordered_comm_group_to_distrib_lattice α,
+  calc |(a ⊔ c) / (b ⊔ c)| * |a ⊓ c / (b ⊓ c)| =
+    ((b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c))) * |a ⊓ c / (b ⊓ c)| : by rw sup_div_inf_eq_abs_div
+  ... = (b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c)) * (((b ⊓ c) ⊔ (a ⊓ c)) / ((b ⊓ c) ⊓ (a ⊓ c))) :
+    by rw sup_div_inf_eq_abs_div (b ⊓ c) (a ⊓ c)
+  ... = (b ⊔ a ⊔ c) / ((b ⊓ a) ⊔ c) * (((b ⊔ a) ⊓ c) / (b ⊓ a ⊓ c)) : by {
+    rw [← sup_inf_right, ← inf_sup_right, sup_assoc ],
+    nth_rewrite 1 sup_comm,
+    rw [sup_right_idem, sup_assoc, inf_assoc ],
+    nth_rewrite 3 inf_comm,
+    rw [inf_right_idem, inf_assoc], }
+  ... = (b ⊔ a ⊔ c) * ((b ⊔ a) ⊓ c) /(((b ⊓ a) ⊔ c) * (b ⊓ a ⊓ c)) : by rw div_mul_comm
+  ... = (b ⊔ a) * c / (b ⊓ a * c) :
+    by rw [mul_comm, inf_mul_sup, mul_comm (b ⊓ a ⊔ c), inf_mul_sup]
+  ... = (b ⊔ a) / (b ⊓ a) : by rw [div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_inv_cancel_left,
+      ← div_eq_mul_inv]
+  ... = |a / b|           : by rw sup_div_inf_eq_abs_div
+end
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -378,8 +378,8 @@ be the absolute value of `b - a`. Then,
 $$a ⊔ b - (a ⊓ b) = |b - a|.$$
 -/
 @[to_additive]
-lemma sup_div_inf_eq_abs_div [covariant_class α α (*) (≤)] (a b : α) : (a ⊔ b) / (a ⊓ b) = |b / a|
-  :=
+lemma sup_div_inf_eq_abs_div [covariant_class α α (*) (≤)] (a b : α) :
+  (a ⊔ b) / (a ⊓ b) = |b / a| :=
 begin
   rw [sup_eq_mul_pos_div, inf_comm, inf_eq_div_pos_div, div_eq_mul_inv],
   nth_rewrite 1 div_eq_mul_inv,

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -118,16 +118,7 @@ instance lattice_ordered_comm_group.to_ordered_comm_group (α : Type u)
 @[priority 100, to_additive] -- see Note [lower instance priority]
 instance lattice_ordered_comm_group.to_lattice_ordered_group (α : Type u)
   [s : lattice_ordered_comm_group α] : lattice_ordered_group α :=
-{ mul_le_mul :=
-  begin
-    rintros a b h c d,
-    rw [mul_assoc, mul_assoc],
-    apply s.mul_le_mul_left,
-    rw mul_comm,
-    nth_rewrite 1 mul_comm,
-    apply s.mul_le_mul_left,
-    exact h,
-  end }
+{ mul_le_mul := λ a b hab c d, mul_le_mul' (mul_le_mul' le_rfl hab) le_rfl }
 
 
 -- A linearly ordered additive commutative group is a lattice ordered commutative group

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -136,13 +136,11 @@ $$c + (a⊔b) = (c+a)⊔(c+b).$$
 -/
 lemma add_join_eq_add_join_add (a b c : α) : c + (a⊔b) = (c+a)⊔(c+b) :=
 begin
-  rw le_antisymm_iff,
-  split,
-  { rw [← add_le_add_iff_left (-c), ← add_assoc, neg_add_self, zero_add, sup_le_iff],
-    split,
-    { simp, },
-    { simp, } },
-  { rw ← add_le_add_iff_left (-c), simp,  }
+  refine le_antisymm _ (by simp),
+  rw [← add_le_add_iff_left (-c), ← add_assoc, neg_add_self, zero_add],
+  apply sup_le,
+  { simp },
+  { simp },
 end
 
 -- Special case of Bourbaki A.VI.9 (2)

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -470,7 +470,8 @@ end
 Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
 equal to its positive component `a⁺`.
 -/
-lemma pos_pos_id (a : α) (h : 1 ≤ a): a⁺ = a :=
+@[to_additive pos_pos_id]
+lemma m_pos_pos_id (a : α) (h : 1 ≤ a): a⁺ = a :=
 begin
   unfold lattice_ordered_comm_group.mpos,
   apply sup_of_le_left h,
@@ -480,11 +481,12 @@ end
 Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
 equal to its absolute value `|a|`.
 -/
-lemma abs_pos_eq [covariant_class α α (*) (≤)] (a : α) (h: 1 ≤ a) : |a| = a :=
+@[to_additive abs_pos_eq]
+lemma mabs_pos_eq [covariant_class α α (*) (≤)] (a : α) (h: 1 ≤ a) : |a| = a :=
 begin
   unfold mabs,
   rw [sup_eq_mul_pos_div, div_eq_mul_inv, inv_inv, ← pow_two, inv_mul_eq_iff_eq_mul,
-    ← pow_two, pos_pos_id ],
+    ← pow_two, m_pos_pos_id ],
   rw pow_two,
   apply one_le_mul h h,
 end
@@ -506,9 +508,10 @@ end
 Let `α` be a lattice ordered commutative group. The unary operation of taking the absolute value is
 idempotent.
 -/
-lemma abs_idempotent [covariant_class α α (*) (≤)] (a : α) : |a| = | |a| | :=
+@[to_additive abs_idempotent]
+lemma mabs_idempotent [covariant_class α α (*) (≤)] (a : α) : |a| = | |a| | :=
 begin
-  rw abs_pos_eq (|a|),
+  rw mabs_pos_eq (|a|),
   apply lattice_ordered_comm_group.abs_pos,
 end
 

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -28,10 +28,10 @@ This file develops the basic theory, concentrating on the commutative case writt
 
 - `pos_sub_neg`: Every element `a` of a `lattice_ordered_add_comm_group` has a decomposition `a⁺-a⁻`
    into the difference of the positive and negative component.
-- `pos_meet_neg_eq_zero`: The positive and negative components are coprime.
+- `pos_inf_neg_eq_zero`: The positive and negative components are coprime.
 - `abs_triangle`: The absolute value operation satisfies the triangle inequality.
 
-It is shown that the meet and join operations are related to the absolute value operation by a
+It is shown that the inf and sup operations are related to the absolute value operation by a
 number of equations and inequalities.
 
 ## Notations
@@ -134,7 +134,7 @@ variables {α : Type u} [lattice_ordered_add_comm_group α]
 Let `α` be a lattice ordered commutative group. For all elements `a`, `b` and `c` in `α`,
 $$c + (a⊔b) = (c+a)⊔(c+b).$$
 -/
-lemma add_join_eq_add_join_add (a b c : α) : c + (a⊔b) = (c+a)⊔(c+b) :=
+lemma add_sup_eq_add_sup_add (a b c : α) : c + (a⊔b) = (c+a)⊔(c+b) :=
 begin
   refine le_antisymm _ (by simp),
   rw [← add_le_add_iff_left (-c), ← add_assoc, neg_add_self, zero_add],
@@ -148,7 +148,7 @@ end
 Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
 $$-(a⊔b)=(-a)⊓(-b).$$
 -/
-lemma neg_join_eq_neg_meet_neg (a b : α) : -(a⊔b)=(-a)⊓(-b) :=
+lemma neg_sup_eq_neg_inf_neg (a b : α) : -(a⊔b)=(-a)⊓(-b) :=
 begin
   rw le_antisymm_iff,
   split,
@@ -166,9 +166,9 @@ end
 Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
 $$-a⊔-b = -(a⊓b).$$
 -/
-@[simp] lemma join_neg_eq_neg_meet (a b : α) : -a⊔-b = -(a⊓b) :=
+@[simp] lemma sup_neg_eq_neg_inf (a b : α) : -a⊔-b = -(a⊓b) :=
 begin
-  rw [← neg_neg (-a⊔-b), neg_join_eq_neg_meet_neg (-a) (-b), neg_neg, neg_neg],
+  rw [← neg_neg (-a⊔-b), neg_sup_eq_neg_inf_neg (-a) (-b), neg_neg, neg_neg],
 end
 
 -- Bourbaki A.VI.10 Prop 7
@@ -176,10 +176,10 @@ end
 Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
 $$a⊓b + (a⊔b) = a + b.$$
 -/
-lemma add_eq_meet_add_join (a b : α) : a⊓b + (a⊔b) = a + b :=
+lemma add_eq_inf_add_sup (a b : α) : a⊓b + (a⊔b) = a + b :=
 calc a⊓b + (a⊔b) = a⊓b + ((a + b) + ((-b)⊔(-a))) :
-  by {  rw add_join_eq_add_join_add (-b) (-a) (a+b), simp,  }
-... = a⊓b + ((a + b) + -(a⊓b)) : by { rw [← join_neg_eq_neg_meet, sup_comm], }
+  by {  rw add_sup_eq_add_sup_add (-b) (-a) (a+b), simp,  }
+... = a⊓b + ((a + b) + -(a⊓b)) : by { rw [← sup_neg_eq_neg_inf, sup_comm], }
 ... = a + b                    : by { simp, }
 
 -- Bourbaki A.VI.12 Definition 4
@@ -273,7 +273,7 @@ end
 Let `α` be a lattice ordered commutative group. For all elements `a`, `b` and `c` in `α`,
 $$c + (a⊓b) = (c+a)⊓(c+b).$$
 -/
-lemma add_meet_eq_add_meet_add (a b c : α) : c + (a⊓b) = (c+a)⊓(c+b) :=
+lemma add_inf_eq_add_inf_add (a b c : α) : c + (a⊓b) = (c+a)⊓(c+b) :=
 begin
   rw le_antisymm_iff,
   split,
@@ -291,7 +291,7 @@ lemma neg_eq_neg_inf_zero (a : α) : a⁻ = -(a⊓0) :=
 begin
   unfold lattice_ordered_add_comm_group.neg,
   rw ← neg_inj,
-  rw neg_join_eq_neg_meet_neg,
+  rw neg_sup_eq_neg_inf_neg,
   simp,
 end
 
@@ -304,7 +304,7 @@ component `a⁺` and negative component `a⁻`. Then `a` can be decomposed as th
 lemma pos_sub_neg (a : α) : a = a⁺ - a⁻ :=
 begin
   unfold lattice_ordered_add_comm_group.neg,
-  rw [eq_sub_iff_add_eq, add_join_eq_add_join_add, add_zero, add_right_neg, sup_comm],
+  rw [eq_sub_iff_add_eq, add_sup_eq_add_sup_add, add_zero, add_right_neg, sup_comm],
   unfold lattice_ordered_add_comm_group.pos,
 end
 
@@ -317,10 +317,10 @@ Let `α` be a lattice ordered commutative group and let `a` be an element in `α
 component `a⁺` and negative component `a⁻`. Then `a⁺` and `a⁻` are co-prime (and, since they are
 positive, disjoint).
 -/
-lemma pos_meet_neg_eq_zero (a : α) : a⁺⊓a⁻=0 :=
+lemma pos_inf_neg_eq_zero (a : α) : a⁺⊓a⁻=0 :=
 begin
   rw ←add_right_inj (-a⁻),
-  rw add_meet_eq_add_meet_add,
+  rw add_inf_eq_add_inf_add,
   rw neg_add_eq_sub,
   simp only [add_zero, add_left_neg],
   rw pos_sub_neg',
@@ -334,9 +334,9 @@ Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in 
 `(a - b)⁺` be the positive componet of `a-b`. Then
 $$a⊔b = b + (a - b)⁺.$$
 -/
-lemma join_eq_add_pos_sub (a b : α) : a⊔b = b + (a - b)⁺ :=
+lemma sup_eq_add_pos_sub (a b : α) : a⊔b = b + (a - b)⁺ :=
   calc  a⊔b = (b+(a-b))⊔(b+0) : by {rw add_zero b, rw add_sub_cancel'_right, }
-  ... = b + ((a-b)⊔0) : by { rw ← add_join_eq_add_join_add (a-b) 0 b}
+  ... = b + ((a-b)⊔0) : by { rw ← add_sup_eq_add_sup_add (a-b) 0 b}
 
 -- Bourbaki A.VI.12 (with a and b swapped)
 /--
@@ -344,12 +344,12 @@ Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in 
 `(a - b)⁺` be the positive componet of `a-b`. Then
 $$a⊓b = a - (a - b)⁺.$$
 -/
-lemma meet_eq_sub_pos_sub (a b : α) : a⊓b = a - (a - b)⁺ :=
+lemma inf_eq_sub_pos_sub (a b : α) : a⊓b = a - (a - b)⁺ :=
   calc a⊓b = (a+0)⊓(a+(b-a)) : by { rw add_zero a, rw add_sub_cancel'_right, }
-  ... = a + (0⊓(b-a))        : by {rw ← add_meet_eq_add_meet_add 0 (b-a) a}
+  ... = a + (0⊓(b-a))        : by {rw ← add_inf_eq_add_inf_add 0 (b-a) a}
   ... = a + ((b-a)⊓0)        : by { rw inf_comm }
   ... = a + (-(a-b)⊓-0 )     : by { rw neg_zero, rw neg_sub }
-  ... = a - ((a-b)⊔0)        : by  { rw ← neg_join_eq_neg_meet_neg, rw ← sub_eq_add_neg, }
+  ... = a - ((a-b)⊔0)        : by  { rw ← neg_sup_eq_neg_inf_neg, rw ← sub_eq_add_neg, }
 
 -- Bourbaki A.VI.12 Prop 9 c)
 -- Can we rewrite `lattice_ordered_add_comm_group.le_pos b` as `b.le_pos`?
@@ -405,7 +405,7 @@ begin
       symmetry,
       rw [add_right_eq_self, neg_eq_zero, le_antisymm_iff ],
       split,
-      { rw ← pos_meet_neg_eq_zero a,
+      { rw ← pos_inf_neg_eq_zero a,
         apply le_inf,
         { rw pos_eq_neg_neg,
           apply and.right
@@ -416,7 +416,7 @@ begin
             (lattice_ordered_add_comm_group.le_abs a)), } },
       { apply lattice_ordered_add_comm_group.neg_pos, }
     end,
-    rw [← add_eq_meet_add_join, pos_meet_neg_eq_zero, zero_add, ← mod_eq_pos ],
+    rw [← add_eq_inf_add_sup, pos_inf_neg_eq_zero, zero_add, ← mod_eq_pos ],
     apply sup_le,
     apply and.left
       (iff.elim_left (le_iff_pos_le_neg_ge _ _)
@@ -432,9 +432,9 @@ Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in 
 be the absolute value of `b-a`. Then,
 $$a⊔b - (a⊓b) = |b-a|.$$
 -/
-lemma join_sub_meet_eq_abs_sub (a b : α) : a⊔b - (a⊓b) = |b-a| :=
+lemma sup_sub_inf_eq_abs_sub (a b : α) : a⊔b - (a⊓b) = |b-a| :=
 begin
-  rw [join_eq_add_pos_sub, inf_comm, meet_eq_sub_pos_sub],
+  rw [sup_eq_add_pos_sub, inf_comm, inf_eq_sub_pos_sub],
   simp only [add_sub_sub_cancel],
   rw [pos_eq_neg_neg, add_comm, neg_sub, pos_add_neg],
 end
@@ -444,9 +444,9 @@ Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in 
 be the absolute value of `b-a`. Then,
 $$2•(a⊔b) = a + b + |b - a|.$$
 -/
-lemma two_join_eq_add_add_abs_sub (a b : α) : 2•(a⊔b) = a + b + |b - a| :=
+lemma two_sup_eq_add_add_abs_sub (a b : α) : 2•(a⊔b) = a + b + |b - a| :=
 begin
-  rw [← add_eq_meet_add_join a b, ← join_sub_meet_eq_abs_sub],
+  rw [← add_eq_inf_add_sup a b, ← sup_sub_inf_eq_abs_sub],
   abel,
   simp only [← gsmul_coe_nat],
   norm_cast,
@@ -457,9 +457,9 @@ Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in 
 be the absolute value of `b-a`. Then,
 $$2•(a⊓b) = a + b - |b - a|.$$
 -/
-lemma two_meet_eq_add_sub_abs_sub (a b : α) : 2•(a⊓b) = a + b - |b - a| :=
+lemma two_inf_eq_add_sub_abs_sub (a b : α) : 2•(a⊓b) = a + b - |b - a| :=
 begin
-  rw [← add_eq_meet_add_join a b, ← join_sub_meet_eq_abs_sub],
+  rw [← add_eq_inf_add_sup a b, ← sup_sub_inf_eq_abs_sub],
   abel,
   simp only [← gsmul_coe_nat],
   norm_cast,
@@ -474,14 +474,14 @@ instance lattice_ordered_add_comm_group.to_distrib_lattice (α : Type u)
 { le_sup_inf :=
   begin
     intros,
-    rw [← add_le_add_iff_left (x⊓y⊓z), inf_assoc, add_eq_meet_add_join x (y⊓z),
+    rw [← add_le_add_iff_left (x⊓y⊓z), inf_assoc, add_eq_inf_add_sup x (y⊓z),
       ← neg_add_le_iff_le_add, le_inf_iff ],
     split,
-    { rw [neg_add_le_iff_le_add, ← add_eq_meet_add_join x y ],
+    { rw [neg_add_le_iff_le_add, ← add_eq_inf_add_sup x y ],
       apply add_le_add,
       { apply inf_le_inf_left, apply inf_le_left, },
       { apply inf_le_left, } },
-    { rw [neg_add_le_iff_le_add, ← add_eq_meet_add_join x z ],
+    { rw [neg_add_le_iff_le_add, ← add_eq_inf_add_sup x z ],
       apply add_le_add,
       { apply inf_le_inf_left, apply inf_le_right, },
       { apply inf_le_right, }, }
@@ -500,8 +500,8 @@ $$|a⊔c-(b⊔c)| + |a⊓c-b⊓c| = |a-b|.$$
 theorem abs_diff_sup_add_abs_diff_inf (a b c : α) :
 |a⊔c-(b⊔c)| + |a⊓c-b⊓c| = |a-b| :=
   calc |a⊔c-(b⊔c)| + |a⊓c-b⊓c| =
-    (b⊔c)⊔(a⊔c) - (b⊔c)⊓(a⊔c) + |a⊓c-b⊓c|       : by {rw ← join_sub_meet_eq_abs_sub, }
-    ... = (b⊔c)⊔(a⊔c) - (b⊔c)⊓(a⊔c) + (b⊓c⊔a⊓c - b⊓c⊓(a⊓c)) : by {rw ←join_sub_meet_eq_abs_sub, }
+    (b⊔c)⊔(a⊔c) - (b⊔c)⊓(a⊔c) + |a⊓c-b⊓c|       : by {rw ← sup_sub_inf_eq_abs_sub, }
+    ... = (b⊔c)⊔(a⊔c) - (b⊔c)⊓(a⊔c) + (b⊓c⊔a⊓c - b⊓c⊓(a⊓c)) : by {rw ←sup_sub_inf_eq_abs_sub, }
     ... = b⊔a⊔c - ((b⊓a)⊔c) + ((b⊔a)⊓c - b⊓a⊓c) : by {
       rw [← sup_inf_right, ← inf_sup_right, sup_assoc ],
       nth_rewrite 1 sup_comm,
@@ -510,9 +510,9 @@ theorem abs_diff_sup_add_abs_diff_inf (a b c : α) :
       rw [inf_right_idem, inf_assoc], }
     ... = b⊔a⊔c + (b⊔a)⊓c -(((b⊓a)⊔c)+b⊓a⊓c)    : by {abel,}
     ... = b⊔a + c -(b⊓a+c)                      :
-      by {rw [add_comm, add_eq_meet_add_join, add_comm (b ⊓ a ⊔ c), add_eq_meet_add_join] }
+      by {rw [add_comm, add_eq_inf_add_sup, add_comm (b ⊓ a ⊔ c), add_eq_inf_add_sup] }
     ... = b⊔a - b⊓a                             : by { simp, }
-    ... = |a-b|                                 : by { rw join_sub_meet_eq_abs_sub, }
+    ... = |a-b|                                 : by { rw sup_sub_inf_eq_abs_sub, }
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
@@ -531,7 +531,7 @@ equal to its absolute value `|a|`.
 lemma abs_pos_eq (a : α) (h: 0≤a) : |a| = a :=
 begin
   unfold has_abs.abs,
-  rw [join_eq_add_pos_sub, sub_neg_eq_add, neg_add_eq_sub, ←add_left_inj a, sub_add_cancel,
+  rw [sup_eq_add_pos_sub, sub_neg_eq_add, neg_add_eq_sub, ←add_left_inj a, sub_add_cancel,
     ← two_smul ℕ, pos_pos_id ],
   exact nsmul_nonneg h 2,
 end

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -105,10 +105,10 @@ end
 
 /--
 Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
-$$-a⊔-b = -(a⊓b).$$
+$$ -(a⊓b) = -a⊔-b.$$
 -/
 @[to_additive, simp]
-lemma sup_inv_eq_inv_inf (a b : α) : a⁻¹⊔b⁻¹ = (a⊓b)⁻¹ :=
+lemma inv_inf_eq_sup_inv (a b : α) : (a⊓b)⁻¹ = a⁻¹⊔b⁻¹ :=
 begin
   rw [← inv_inv (a⁻¹⊔b⁻¹), inv_sup_eq_inv_inf_inv a⁻¹ b⁻¹, inv_inv, inv_inv],
 end
@@ -122,8 +122,8 @@ $$a⊓b + (a⊔b) = a + b.$$
 lemma mul_eq_inf_mul_sup (a b : α) : a⊓b * (a⊔b) = a * b :=
 calc a⊓b * (a⊔b) = a⊓b * ((a * b) * (b⁻¹⊔a⁻¹)) :
   by {  rw mul_sup_eq_mul_sup_mul b⁻¹ a⁻¹ (a*b), simp,  }
-... = a⊓b * ((a * b) * (a⊓b)⁻¹) : by { rw [← sup_inv_eq_inv_inf, sup_comm], }
-... = a * b                    : by { simp, }
+... = a⊓b * ((a * b) * (a⊓b)⁻¹) : by { rw [inv_inf_eq_sup_inv, sup_comm], }
+... = a * b                    : by { rw [mul_comm, inv_mul_cancel_right],  }
 
 
 /--
@@ -255,7 +255,7 @@ begin
   unfold lattice_ordered_comm_group.neg,
   rw ← inv_inj,
   rw inv_sup_eq_inv_inf_inv,
-  simp,
+  rw [inv_inv, inv_inv, one_inv],
 end
 
 -- Bourbaki A.VI.12  Prop 9 a)
@@ -288,8 +288,7 @@ positive, disjoint).
 lemma pos_inf_neg_eq_one (a : α) : a⁺⊓a⁻=1 :=
 begin
   rw [←mul_right_inj (a⁻)⁻¹, mul_inf_eq_mul_inf_mul, mul_one, mul_left_inv, mul_comm,
-    ←div_eq_mul_inv, pos_div_neg', neg_eq_inv_inf_one],
-  simp,
+    ←div_eq_mul_inv, pos_div_neg', neg_eq_inv_inf_one, inv_inv],
 end
 
 -- Bourbaki A.VI.12 (with a and b swapped)

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -446,22 +446,21 @@ $$|a ⊔ c - (b ⊔ c)| + |a ⊓ c-b ⊓ c| = |a - b|.$$
 theorem abs_div_sup_mul_abs_div_inf (a b c : α) :
 |(a ⊔ c)/(b ⊔ c)| * |(a ⊓ c)/(b ⊓ c)| = |a / b| :=
   calc |(a ⊔ c) / (b ⊔ c)| * |a ⊓ c / (b ⊓ c)| =
-    ((b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c))) * |a ⊓ c / (b ⊓ c)| : by {rw sup_div_inf_eq_abs_div, }
-    ... = (b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c)) * (((b ⊓ c) ⊔ (a ⊓ c)) / ((b ⊓ c) ⊓ (a ⊓ c))) : by
-      {rw sup_div_inf_eq_abs_div (b ⊓ c) (a ⊓ c), }
+    ((b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c))) * |a ⊓ c / (b ⊓ c)| : by rw sup_div_inf_eq_abs_div
+    ... = (b ⊔ c ⊔ (a ⊔ c)) / ((b ⊔ c) ⊓ (a ⊔ c)) * (((b ⊓ c) ⊔ (a ⊓ c)) / ((b ⊓ c) ⊓ (a ⊓ c))) :
+      by rw sup_div_inf_eq_abs_div (b ⊓ c) (a ⊓ c)
     ... = (b ⊔ a ⊔ c) / ((b ⊓ a) ⊔ c) * (((b ⊔ a) ⊓ c) / (b ⊓ a ⊓ c)) : by {
       rw [← sup_inf_right, ← inf_sup_right, sup_assoc ],
       nth_rewrite 1 sup_comm,
       rw [sup_right_idem, sup_assoc, inf_assoc ],
       nth_rewrite 3 inf_comm,
       rw [inf_right_idem, inf_assoc], }
-    ... = (b ⊔ a ⊔ c) * ((b ⊔ a) ⊓ c) /(((b ⊓ a) ⊔ c) * (b ⊓ a ⊓ c)) : by
-      { rw div_mul_comm,}
-    ... = (b ⊔ a) * c / (b ⊓ a * c)                      :
-      by {rw [mul_comm, inf_mul_sup, mul_comm (b ⊓ a ⊔ c), inf_mul_sup] }
-    ... = (b ⊔ a) / (b ⊓ a) : by { rw [div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_inv_cancel_left,
-       ← div_eq_mul_inv], }
-    ... = |a / b|           : by { rw sup_div_inf_eq_abs_div,  }
+    ... = (b ⊔ a ⊔ c) * ((b ⊔ a) ⊓ c) /(((b ⊓ a) ⊔ c) * (b ⊓ a ⊓ c)) : by rw div_mul_comm
+    ... = (b ⊔ a) * c / (b ⊓ a * c) :
+      by rw [mul_comm, inf_mul_sup, mul_comm (b ⊓ a ⊔ c), inf_mul_sup]
+    ... = (b ⊔ a) / (b ⊓ a) : by rw [div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_inv_cancel_left,
+       ← div_eq_mul_inv]
+    ... = |a / b|           : by rw sup_div_inf_eq_abs_div
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -17,8 +17,8 @@ This file develops the basic theory, concentrating on the commutative case.
 
 ## Main statements
 
-- `pos_div_neg`: Every element `a` of a lattice ordered commutative group has a decomposition `a⁺-a⁻`
-   into the difference of the positive and negative component.
+- `pos_div_neg`: Every element `a` of a lattice ordered commutative group has a decomposition
+  `a⁺-a⁻` into the difference of the positive and negative component.
 - `pos_inf_neg_eq_one`: The positive and negative components are coprime.
 - `abs_triangle`: The absolute value operation satisfies the triangle inequality.
 

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -156,8 +156,8 @@ Let `α` be a lattice ordered commutative group and let `a` be an element in `α
 `|a|`. Then,
 $$a ≤ |a|.$$
 -/
-@[to_additive additive_le_abs]
-lemma le_abs (a : α) : a ≤ |a| := le_sup_left
+@[to_additive le_abs]
+lemma le_mabs (a : α) : a ≤ |a| := le_sup_left
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with absolute value
@@ -171,29 +171,29 @@ lemma inv_le_abs (a : α) : a⁻¹ ≤ |a| := le_sup_right
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
  component `a⁺`. Then `a⁺` is positive.
 -/
-@[to_additive additive_pos_pos]
-lemma pos_pos (a : α) : 1 ≤ a⁺ := le_sup_right
+@[to_additive pos_pos]
+lemma m_pos_pos (a : α) : 1 ≤ a⁺ := le_sup_right
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α` withnegative
 component `a⁻`. Then `a⁻` is positive.
 -/
-@[to_additive additive_neg_pos]
-lemma neg_pos (a : α) : 1 ≤ a⁻ := le_sup_right
+@[to_additive neg_pos]
+lemma m_neg_pos (a : α) : 1 ≤ a⁻ := le_sup_right
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
 component `a⁺`. Then `a⁺` dominates `a`.
 -/
-@[to_additive additive_le_pos]
-lemma le_pos (a : α) : a ≤ a⁺ := le_sup_left
+@[to_additive le_pos]
+lemma m_le_pos (a : α) : a ≤ a⁺ := le_sup_left
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with negative
 component `a⁻`. Then `a⁻` dominates `-a`.
 -/
-@[to_additive additive_le_neg]
-lemma le_neg (a : α) : a⁻¹ ≤ a⁻ := le_sup_left
+@[to_additive le_neg]
+lemma m_le_neg (a : α) : a⁻¹ ≤ a⁻ := le_sup_left
 
 -- Bourbaki A.VI.12
 /--
@@ -304,19 +304,19 @@ Let `α` be a lattice ordered commutative group and let `a` and `b` be elements 
 components `a⁺` and `b⁺` and negative components `a⁻` and `b⁻` respectively. Then `b` dominates `a`
 if and only if `b⁺` dominates `a⁺` and `a⁻` dominates `b⁻`.
 -/
-@[to_additive additive_le_iff_pos_le_neg_ge]
-lemma le_iff_pos_le_neg_ge [covariant_class α α (*) (≤)] (a b : α) : a ≤ b ↔ a⁺ ≤ b⁺ ∧ b⁻ ≤ a⁻ :=
+@[to_additive le_iff_pos_le_neg_ge]
+lemma m_le_iff_pos_le_neg_ge [covariant_class α α (*) (≤)] (a b : α) : a ≤ b ↔ a⁺ ≤ b⁺ ∧ b⁻ ≤ a⁻ :=
 begin
   split,
   { intro h,
     split,
     { apply sup_le
-      (le_trans h (lattice_ordered_comm_group.le_pos b))
-      (lattice_ordered_comm_group.pos_pos b), },
+      (le_trans h (lattice_ordered_comm_group.m_le_pos b))
+      (lattice_ordered_comm_group.m_pos_pos b), },
     { rw ← inv_le_inv_iff at h,
       apply sup_le
-      (le_trans h (lattice_ordered_comm_group.le_neg a))
-      (lattice_ordered_comm_group.neg_pos a), }
+      (le_trans h (lattice_ordered_comm_group.m_le_neg a))
+      (lattice_ordered_comm_group.m_neg_pos a), }
   },
   { intro h,
     rw [← pos_div_neg' a, ← pos_div_neg' b ],
@@ -339,12 +339,12 @@ begin
     split,
     { nth_rewrite 0 ← mul_one a,
       apply mul_le_mul'
-        (lattice_ordered_comm_group.le_pos a)
-        (lattice_ordered_comm_group.neg_pos a) },
+        (lattice_ordered_comm_group.m_le_pos a)
+        (lattice_ordered_comm_group.m_neg_pos a) },
     { nth_rewrite 0 ← one_mul (a⁻¹),
       apply mul_le_mul'
-        (lattice_ordered_comm_group.pos_pos a)
-        (lattice_ordered_comm_group.le_neg a) } },
+        (lattice_ordered_comm_group.m_pos_pos a)
+        (lattice_ordered_comm_group.m_le_neg a) } },
   { have mod_eq_pos: |a|⁺ = |a|,
     { nth_rewrite 1 ← pos_div_neg' (|a|),
       rw div_eq_mul_inv,
@@ -355,20 +355,20 @@ begin
         apply le_inf,
         { rw pos_eq_neg_inv,
           apply and.right
-            (iff.elim_left (le_iff_pos_le_neg_ge _ _)
+            (iff.elim_left (m_le_iff_pos_le_neg_ge _ _)
             (lattice_ordered_comm_group.inv_le_abs a)), },
         { apply and.right
-            (iff.elim_left (le_iff_pos_le_neg_ge _ _)
-            (lattice_ordered_comm_group.le_abs a)), } },
-      { apply lattice_ordered_comm_group.neg_pos, } },
+            (iff.elim_left (m_le_iff_pos_le_neg_ge _ _)
+            (lattice_ordered_comm_group.le_mabs a)), } },
+      { apply lattice_ordered_comm_group.m_neg_pos, } },
     rw [← inf_mul_sup, pos_inf_neg_eq_one, one_mul, ← mod_eq_pos ],
     apply sup_le,
     apply and.left
-      (iff.elim_left (le_iff_pos_le_neg_ge _ _)
-      (lattice_ordered_comm_group.le_abs a)),
+      (iff.elim_left (m_le_iff_pos_le_neg_ge _ _)
+      (lattice_ordered_comm_group.le_mabs a)),
     rw neg_eq_pos_inv,
     apply and.left
-      (iff.elim_left (le_iff_pos_le_neg_ge _ _)
+      (iff.elim_left (m_le_iff_pos_le_neg_ge _ _)
       (lattice_ordered_comm_group.inv_le_abs a)), }
 end
 
@@ -495,13 +495,13 @@ end
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α`. Then the absolute
 value `|a|` of `a` is positive.
 -/
-@[to_additive additive_abs_pos]
-lemma abs_pos [covariant_class α α (*) (≤)] (a : α) : 1 ≤ |a| :=
+@[to_additive abs_pos]
+lemma mabs_pos [covariant_class α α (*) (≤)] (a : α) : 1 ≤ |a| :=
 begin
   rw pos_mul_neg,
   apply one_le_mul
-    (lattice_ordered_comm_group.pos_pos a)
-    (lattice_ordered_comm_group.neg_pos a),
+    (lattice_ordered_comm_group.m_pos_pos a)
+    (lattice_ordered_comm_group.m_neg_pos a),
 end
 
 /--
@@ -512,7 +512,7 @@ idempotent.
 lemma mabs_idempotent [covariant_class α α (*) (≤)] (a : α) : |a| = | |a| | :=
 begin
   rw mabs_pos_eq (|a|),
-  apply lattice_ordered_comm_group.abs_pos,
+  apply lattice_ordered_comm_group.mabs_pos,
 end
 
 -- Commutative case, Zaanen, 3rd lecture
@@ -523,18 +523,18 @@ Let `α` be a lattice ordered commutative group and let `a`, `b` and `c` be elem
 `a ⊔ c - (b ⊔ c)`, `a ⊓ c - b ⊓ c` and`a - b` respectively. Then `|a - b|` dominates
 `|a ⊔ c - (b ⊔ c)|` and `|a ⊓ c - b ⊓ c|`.
 -/
-@[to_additive additive_Birkhoff_inequalities]
-theorem Birkhoff_inequalities [covariant_class α α (*) (≤)] (a b c : α) :
+@[to_additive Birkhoff_inequalities]
+theorem m_Birkhoff_inequalities [covariant_class α α (*) (≤)] (a b c : α) :
 |(a ⊔ c) / (b ⊔ c)| ⊔ |(a ⊓ c) / (b ⊓ c)| ≤ |a / b| :=
 begin
   rw sup_le_iff,
   split,
   { apply le_of_mul_le_of_one_le_left,
     rw abs_div_sup_mul_abs_div_inf,
-    apply lattice_ordered_comm_group.abs_pos, },
+    apply lattice_ordered_comm_group.mabs_pos, },
   { apply le_of_mul_le_of_one_le_right,
     rw abs_div_sup_mul_abs_div_inf,
-    apply lattice_ordered_comm_group.abs_pos, }
+    apply lattice_ordered_comm_group.mabs_pos, }
 end
 
 -- Banasiak Proposition 2.12, Zaanen 2nd lecture
@@ -542,13 +542,13 @@ end
 Let `α` be a lattice ordered commutative group. Then the absolute value satisfies the triangle
 inequality.
 -/
-@[to_additive additive_abs_triangle]
-lemma abs_triangle [covariant_class α α (*) (≤)] (a b : α) : |a * b| ≤ |a| * |b| :=
+@[to_additive abs_triangle]
+lemma mabs_triangle [covariant_class α α (*) (≤)] (a b : α) : |a * b| ≤ |a| * |b| :=
 begin
   apply sup_le,
   { apply mul_le_mul'
-    (lattice_ordered_comm_group.le_abs a)
-    (lattice_ordered_comm_group.le_abs b), },
+    (lattice_ordered_comm_group.le_mabs a)
+    (lattice_ordered_comm_group.le_mabs b), },
   { rw mul_inv,
     apply mul_le_mul',
     apply lattice_ordered_comm_group.inv_le_abs,

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -434,11 +434,6 @@ instance lattice_ordered_comm_group_to_distrib_lattice (α : Type u)
   end,
   ..s }
 
-@[to_additive]
-lemma div_mul_div_eq_mul_div_mul (x y w z : α) : x / y * (w / z) = x * w / (y * z) :=
-by rw [div_eq_mul_inv, div_eq_mul_inv, div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_assoc,
-    mul_left_cancel_iff, mul_comm, mul_assoc]
-
 -- See, e.g. Zaanen, Lectures on Riesz Spaces
 -- 3rd lecture
 /--
@@ -461,7 +456,7 @@ theorem abs_div_sup_mul_abs_div_inf (a b c : α) :
       nth_rewrite 3 inf_comm,
       rw [inf_right_idem, inf_assoc], }
     ... = (b ⊔ a ⊔ c) * ((b ⊔ a) ⊓ c) /(((b ⊓ a) ⊔ c) * (b ⊓ a ⊓ c)) : by
-      { rw div_mul_div_eq_mul_div_mul,}
+      { rw div_mul_comm,}
     ... = (b ⊔ a) * c / (b ⊓ a * c)                      :
       by {rw [mul_comm, inf_mul_sup, mul_comm (b ⊓ a ⊔ c), inf_mul_sup] }
     ... = (b ⊔ a) / (b ⊓ a) : by { rw [div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_inv_cancel_left,

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -427,11 +427,15 @@ begin
     rw sup_le_iff,
     split,
     { nth_rewrite 0 ← add_zero a,
-      apply add_le_add  (lattice_ordered_add_comm_group.le_pos a) (lattice_ordered_add_comm_group.neg_pos a)
+      apply add_le_add
+        (lattice_ordered_add_comm_group.le_pos a)
+        (lattice_ordered_add_comm_group.neg_pos a)
     },
     {
       nth_rewrite 0 ← zero_add (-a),
-      apply add_le_add  (lattice_ordered_add_comm_group.pos_pos a) (lattice_ordered_add_comm_group.le_neg a)
+      apply add_le_add
+        (lattice_ordered_add_comm_group.pos_pos a)
+        (lattice_ordered_add_comm_group.le_neg a)
     }
   },
   {
@@ -464,7 +468,9 @@ begin
     rw zero_add,
     rw ← mod_eq_pos,
     apply sup_le,
-    apply and.left (iff.elim_left (le_iff_pos_le_neg_ge _ _) (lattice_ordered_add_comm_group.le_abs a)),
+    apply and.left
+      (iff.elim_left (le_iff_pos_le_neg_ge _ _)
+      (lattice_ordered_add_comm_group.le_abs a)),
     rw neg_eq_pos_neg,
     apply and.left
       (iff.elim_left (le_iff_pos_le_neg_ge _ _)
@@ -572,8 +578,8 @@ begin
 end
 
 /--
-Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is equal
-to its positive component `a⁺`.
+Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
+equal to its positive component `a⁺`.
 -/
 lemma pos_pos_id (a : α) (h : 0≤ a): a⁺ = a :=
 begin
@@ -613,7 +619,9 @@ lemma lattice_ordered_add_comm_group.abs_pos (a : α) : 0 ≤ |a| :=
 begin
   rw pos_add_neg,
   rw ← add_zero (0:α),
-  apply add_le_add (lattice_ordered_add_comm_group.pos_pos a) (lattice_ordered_add_comm_group.neg_pos a),
+  apply add_le_add
+    (lattice_ordered_add_comm_group.pos_pos a)
+    (lattice_ordered_add_comm_group.neg_pos a),
 end
 
 /--
@@ -658,7 +666,9 @@ inequality.
 lemma abs_triangle  (a b : α) : |a+b| ≤ |a|+|b| :=
 begin
   apply sup_le,
-  { apply add_le_add, apply lattice_ordered_add_comm_group.le_abs, apply lattice_ordered_add_comm_group.le_abs, },
+  { apply add_le_add,
+    apply lattice_ordered_add_comm_group.le_abs,
+    apply lattice_ordered_add_comm_group.le_abs, },
   {
     rw neg_add,
     apply add_le_add,

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -15,37 +15,30 @@ They form the algebraic underpinnings of vector lattices, Banach lattices, AL-sp
 
 This file develops the basic theory, concentrating on the commutative case.
 
-## Main definitions
-
-* `lattice_ordered_group` - a (non-commutative) partially ordered (multiplicative) group which forms
-  a lattice with respect to the partial order.
-* `lattice_ordered_add_group` - the additive form of a `lattice_ordered_group`
-* `lattice_ordered_comm_group` - a lattice ordered (multiplicative) group with commutative group
-  operation
-* `lattice_ordered_add_comm_group` - the additive form of a `lattice_ordered_comm_group`
-
 ## Main statements
 
-- `pos_div_neg`: Every element `a` of a `lattice_ordered_add_comm_group` has a decomposition `a⁺-a⁻`
+- `pos_div_neg`: Every element `a` of a lattice ordered commutative group has a decomposition `a⁺-a⁻`
    into the difference of the positive and negative component.
 - `pos_inf_neg_eq_one`: The positive and negative components are coprime.
-- `mul_abs_triangle`: The absolute value operation satisfies the triangle inequality.
+- `abs_triangle`: The absolute value operation satisfies the triangle inequality.
 
 It is shown that the inf and sup operations are related to the absolute value operation by a
 number of equations and inequalities.
 
 ## Notations
 
-- `a⁺ = a ⊔ 0`: The *positive component* of an element `a` of a `lattice_ordered_add_comm_group`
-- `a⁻ = (-a) ⊔ 0`: The *negative component* of an element `a` of a `lattice_ordered_add_comm_group`
-* `|a| = a⊔(-a)`: The *absolute value* of an element `a` of a `lattice_ordered_add_comm_group`
+- `a⁺ = a ⊔ 0`: The *positive component* of an element `a` of a lattice ordered commutative group
+- `a⁻ = (-a) ⊔ 0`: The *negative component* of an element `a` of a lattice ordered commutative group
+* `|a| = a⊔(-a)`: The *absolute value* of an element `a` of a lattice ordered commutative group
 
 ## Implementation notes
 
-We define `lattice_ordered_group` as extending `group` and `lattice` and
-`lattice_ordered_comm_group` as extending `comm_group` and `lattice`. Equivalent additive classes
-are defined. We then show that a `lattice_ordered_comm_group` is a `lattice_ordered_group` and an
-`ordered_comm_group`.
+A lattice ordered commutative group is a type `α` satisfying:
+
+* `[lattice α]`
+* `[comm_group α]`
+* `[covariant_class α α (*) (≤)]`
+*  `[covariant_class α α (function.swap (*)) (≤)]`
 
 The remainder of the file establishes basic properties of `lattice_ordered_comm_group`. A number
 of these results also hold in the non-commutative case ([Birkhoff][birkhoff1942],
@@ -67,67 +60,16 @@ lattice, ordered, group
 
 universe u
 
-/--
-A group `(α,*)`, equipped with a partial order `≤`, making `α` into a lattice, such that, given
-elements `a` and `b` of type `α` satisfying `a ≤ b`, for all elements `c` and `d` of `type α`,
-$$c * a * d ≤ c * b * d,$$
-is said to be a *lattice ordered group*.
--/
-class lattice_ordered_group (α : Type u)
-  extends group α, lattice α :=
-(mul_le_mul : ∀ a b : α, a ≤ b → ∀ c d : α, c * a * d ≤ c * b * d)
-
-/--
-A lattice ordered group with Abelian group multiplication is said to be a *lattice ordered
-commutative group*.
--/
-class lattice_ordered_comm_group (α : Type u)
-  extends comm_group α, lattice α :=
-(mul_le_mul_left : ∀ a b : α, a ≤ b → ∀ c : α, c * a ≤ c * b)
-
-/--
-A group `(α,+)`, equipped with a partial order `≤`, making `α` into a lattice, such that, given
-elements `a` and `b` of type `α` satisfying `a ≤ b`, for all elements `c` and `d` of type `α`,
-$$c + a + d ≤ c + b + d,$$
-is said to be a *lattice ordered (additive) group*.
--/
-class lattice_ordered_add_group (α : Type u)
-  extends add_group α, lattice α :=
-(add_le_add : ∀ a b : α, a ≤ b → ∀ c d : α, c + a + d ≤ c + b + d)
-
-/--
-A lattice ordered additive group with Abelian group addition is said to be a *lattice ordered
-(additative) commutative group*.
--/
-class lattice_ordered_add_comm_group (α : Type u)
-  extends add_comm_group α, lattice α :=
-(add_le_add_left : ∀ a b : α, a ≤ b → ∀ c : α, c + a ≤ c + b)
-
--- Tells to_additive that lattice_ordered_add_group is the additive form of lattice_ordered_group
--- and lattice_ordered_add_comm_group is the additive form of lattice_ordered_comm_group
-attribute [to_additive] lattice_ordered_group
-attribute [to_additive] lattice_ordered_comm_group
-
--- Every lattice ordered commutative group is also an ordered additive commutative group
-@[priority 100, to_additive] -- see Note [lower instance priority]
-instance lattice_ordered_comm_group.to_ordered_comm_group (α : Type u)
-  [s : lattice_ordered_comm_group α] : ordered_comm_group α :=
-{ mul := s.mul, ..s }
-
--- A lattice ordered commutative group is a lattice ordered group
-@[priority 100, to_additive] -- see Note [lower instance priority]
-instance lattice_ordered_comm_group.to_lattice_ordered_group (α : Type u)
-  [s : lattice_ordered_comm_group α] : lattice_ordered_group α :=
-{ mul_le_mul := λ a b hab c d, mul_le_mul' (mul_le_mul' le_rfl hab) le_rfl }
-
-
 -- A linearly ordered additive commutative group is a lattice ordered commutative group
 @[priority 100, to_additive] -- see Note [lower instance priority]
-instance linear_ordered_comm_group.to_lattice_ordered_comm_group (α : Type u)
- [s : linear_ordered_comm_group α] : lattice_ordered_comm_group α :=
-{ mul_le_mul_left := s.mul_le_mul_left, }
+instance linear_ordered_comm_group.to_covariant_class (α : Type u)
+  [linear_ordered_comm_group α] :  covariant_class α α (*) (≤) :=
+{ elim := λ a b c bc, linear_ordered_comm_group.mul_le_mul_left _ _ bc a }
 
-variables {α : Type u} [lattice_ordered_comm_group α]
+
+variables {α : Type u} [lattice α] [comm_group α] [covariant_class α α (*) (≤)]
+  [covariant_class α α (function.swap (*)) (≤)]
+
 
 -- Special case of Bourbaki A.VI.9 (1)
 /--
@@ -186,22 +128,6 @@ calc a⊓b * (a⊔b) = a⊓b * ((a * b) * (b⁻¹⊔a⁻¹)) :
 ... = a⊓b * ((a * b) * (a⊓b)⁻¹) : by { rw [← sup_inv_eq_inv_inf, sup_comm], }
 ... = a * b                    : by { simp, }
 
--- Bourbaki A.VI.12 Definition 4
-/--
-Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
-the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`.
--/
-@[to_additive]
-def lattice_ordered_comm_group.pos (a : α) : α :=  a ⊔ 1
-postfix `⁺`:1000 := lattice_ordered_comm_group.pos
-
-/--
-Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
-the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`.
--/
-@[to_additive]
-def lattice_ordered_comm_group.neg (a : α) : α := a⁻¹ ⊔ 1
-postfix `⁻`:1000 := lattice_ordered_comm_group.neg
 
 /--
 Absolute value is a unary operator with properties similar to the absolute value of a real number.
@@ -213,12 +139,36 @@ instance lattice_ordered_comm_group_has_abs : has_abs (α)  := ⟨λa, a⊔a⁻�
 
 namespace lattice_ordered_comm_group
 
+-- Bourbaki A.VI.12 Definition 4
+/--
+Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
+the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`.
+-/
+@[to_additive additive_pos "
+  Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
+  the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`.
+"]
+def pos (a : α) : α :=  a ⊔ 1
+postfix `⁺`:1000 := pos
+
+/--
+Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
+the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`.
+-/
+@[to_additive additive_neg "
+  Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type `α`,
+  the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`.
+"]
+def neg (a : α) : α := a⁻¹ ⊔ 1
+postfix `⁻`:1000 := neg
+
+
 /--
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with absolute value
 `|a|`. Then,
 $$a ≤ |a|.$$
 -/
-@[to_additive]
+@[to_additive additive_le_abs]
 lemma le_abs (a : α) : a ≤ |a| := le_sup_left
 
 /--
@@ -233,31 +183,31 @@ lemma inv_le_abs (a : α) : a⁻¹ ≤ |a| := le_sup_right
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
  component `a⁺`. Then `a⁺` is positive.
 -/
-@[to_additive]
+@[to_additive additive_pos_pos]
 lemma pos_pos (a : α) : 1 ≤ a⁺ := le_sup_right
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α` withnegative
 component `a⁻`. Then `a⁻` is positive.
 -/
-@[to_additive]
+@[to_additive additive_neg_pos]
 lemma neg_pos (a : α) : 1 ≤ a⁻ := le_sup_right
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
 component `a⁺`. Then `a⁺` dominates `a`.
 -/
-@[to_additive]
+@[to_additive additive_le_pos]
 lemma le_pos (a : α) : a ≤ a⁺ := le_sup_left
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with negative
 component `a⁻`. Then `a⁻` dominates `-a`.
 -/
-@[to_additive]
+@[to_additive additive_le_neg]
 lemma le_neg (a : α) : a⁻¹ ≤ a⁻ := le_sup_left
 
-end lattice_ordered_comm_group
+
 
 -- Bourbaki A.VI.12
 /--
@@ -267,8 +217,8 @@ component `a⁻` of `a` is equal to the positive component `(-a)⁺` of `-a`.
 @[to_additive]
 lemma neg_eq_pos_inv (a : α) : a⁻ =(a⁻¹)⁺ :=
 begin
-  unfold lattice_ordered_comm_group.neg,
-  unfold lattice_ordered_comm_group.pos,
+  unfold neg,
+  unfold pos,
 end
 
 /--
@@ -380,8 +330,8 @@ Let `α` be a lattice ordered commutative group and let `a` and `b` be elements 
 components `a⁺` and `b⁺` and negative components `a⁻` and `b⁻` respectively. Then `b` dominates `a`
 if and only if `b⁺` dominates `a⁺` and `a⁻` dominates `b⁻`.
 -/
-@[to_additive]
-lemma mul_le_iff_pos_le_neg_ge (a b : α) : a ≤ b ↔ a⁺ ≤ b⁺ ∧ b⁻ ≤ a⁻ :=
+@[to_additive additive_le_iff_pos_le_neg_ge]
+lemma le_iff_pos_le_neg_ge (a b : α) : a ≤ b ↔ a⁺ ≤ b⁺ ∧ b⁻ ≤ a⁻ :=
 begin
   split,
   { intro h,
@@ -433,21 +383,21 @@ begin
         apply le_inf,
         { rw pos_eq_neg_inv,
           apply and.right
-            (iff.elim_left (mul_le_iff_pos_le_neg_ge _ _)
+            (iff.elim_left (le_iff_pos_le_neg_ge _ _)
             (lattice_ordered_comm_group.inv_le_abs a)), },
         { apply and.right
-            (iff.elim_left (mul_le_iff_pos_le_neg_ge _ _)
+            (iff.elim_left (le_iff_pos_le_neg_ge _ _)
             (lattice_ordered_comm_group.le_abs a)), } },
       { apply lattice_ordered_comm_group.neg_pos, }
     end,
     rw [← mul_eq_inf_mul_sup, pos_inf_neg_eq_one, one_mul, ← mod_eq_pos ],
     apply sup_le,
     apply and.left
-      (iff.elim_left (mul_le_iff_pos_le_neg_ge _ _)
+      (iff.elim_left (le_iff_pos_le_neg_ge _ _)
       (lattice_ordered_comm_group.le_abs a)),
     rw neg_eq_pos_inv,
     apply and.left
-      (iff.elim_left (mul_le_iff_pos_le_neg_ge _ _)
+      (iff.elim_left (le_iff_pos_le_neg_ge _ _)
       (lattice_ordered_comm_group.inv_le_abs a)), }
 end
 
@@ -494,8 +444,9 @@ end
 Every lattice ordered commutative group is a distributive lattice
 -/
 @[to_additive, priority 100] -- see Note [lower instance priority]
-instance lattice_ordered_comm_group.to_distrib_lattice (α : Type u)
-  [s : lattice_ordered_comm_group α] : distrib_lattice α :=
+instance lattice_ordered_comm_group_to_distrib_lattice (α : Type u)
+  [s: lattice α] [comm_group α] [covariant_class α α (*) (≤)]
+  [covariant_class α α (function.swap (*)) (≤)] : distrib_lattice α :=
 { le_sup_inf :=
   begin
     intros,
@@ -576,8 +527,8 @@ end
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α`. Then the absolute
 value `|a|` of `a` is positive.
 -/
-@[to_additive]
-lemma lattice_ordered_comm_group.abs_pos (a : α) : 1 ≤ |a| :=
+@[to_additive additive_abs_pos]
+lemma abs_pos (a : α) : 1 ≤ |a| :=
 begin
   rw pos_mul_neg,
   apply one_le_mul
@@ -602,8 +553,8 @@ Let `α` be a lattice ordered commutative group and let `a`, `b` and `c` be elem
 `|a⊔c-(b⊔c)|`, `|a⊓c-b⊓c|` and `|a-b|` denote the absolute values of `a⊔c-(b⊔c)`, `a⊓c-b⊓c` and
 `a-b` respectively. Then `|a-b|` dominates `|a⊔c-(b⊔c)|` and `|a⊓c-b⊓c|`.
 -/
-@[to_additive]
-theorem mul_Birkhoff_inequalities (a b c : α) :
+@[to_additive additive_Birkhoff_inequalities]
+theorem Birkhoff_inequalities (a b c : α) :
 |(a⊔c)/(b⊔c)| ⊔ |(a⊓c)/(b⊓c)| ≤ |a/b| :=
 begin
   rw sup_le_iff,
@@ -621,8 +572,8 @@ end
 Let `α` be a lattice ordered commutative group. Then the absolute value satisfies the triangle
 inequality.
 -/
-@[to_additive]
-lemma mul_abs_triangle  (a b : α) : |a*b| ≤ |a|*|b| :=
+@[to_additive additive_abs_triangle]
+lemma abs_triangle  (a b : α) : |a*b| ≤ |a|*|b| :=
 begin
   apply sup_le,
   { apply mul_le_mul'
@@ -633,3 +584,5 @@ begin
     apply lattice_ordered_comm_group.inv_le_abs,
     apply lattice_ordered_comm_group.inv_le_abs, }
 end
+
+end lattice_ordered_comm_group

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -676,5 +676,3 @@ begin
     apply lattice_ordered_add_comm_group.neg_le_abs,
   }
 end
-
-#lint doc_blame_thm

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -126,10 +126,7 @@ calc a⊓b * (a ⊔ b) = a ⊓ b * ((a * b) * (b⁻¹ ⊔ a⁻¹)) :
 /--
 Absolute value is a unary operator with properties similar to the absolute value of a real number.
 -/
-class has_abs (α : Type u) := (abs : α → α)
-local notation `|`a`|` := has_abs.abs a
-@[priority 100, to_additive] -- see Note [lower instance priority]
-instance lattice_ordered_comm_group_has_abs : has_abs (α)  := ⟨λa, a⊔a⁻¹⟩
+local notation `|`a`|` := mabs a
 
 namespace lattice_ordered_comm_group
 
@@ -337,7 +334,7 @@ lemma pos_mul_neg [covariant_class α α (*) (≤)] (a : α) : |a| = a⁺ * a⁻
 begin
   rw le_antisymm_iff,
   split,
-  { unfold has_abs.abs,
+  { unfold mabs,
     rw sup_le_iff,
     split,
     { nth_rewrite 0 ← mul_one a,
@@ -485,7 +482,7 @@ equal to its absolute value `|a|`.
 -/
 lemma abs_pos_eq [covariant_class α α (*) (≤)] (a : α) (h: 1 ≤ a) : |a| = a :=
 begin
-  unfold has_abs.abs,
+  unfold mabs,
   rw [sup_eq_mul_pos_div, div_eq_mul_inv, inv_inv, ← pow_two, inv_mul_eq_iff_eq_mul,
     ← pow_two, pos_pos_id ],
   rw pow_two,

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -119,7 +119,7 @@ Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in
 $$a⊓b + (a⊔b) = a + b.$$
 -/
 @[to_additive]
-lemma mul_eq_inf_mul_sup (a b : α) : a⊓b * (a⊔b) = a * b :=
+lemma inf_mul_sup (a b : α) : a⊓b * (a⊔b) = a * b :=
 calc a⊓b * (a⊔b) = a⊓b * ((a * b) * (b⁻¹⊔a⁻¹)) :
   by {  rw mul_sup_eq_mul_sup_mul b⁻¹ a⁻¹ (a*b), simp,  }
 ... = a⊓b * ((a * b) * (a⊓b)⁻¹) : by { rw [inv_inf_eq_sup_inv, sup_comm], }
@@ -386,7 +386,7 @@ begin
             (lattice_ordered_comm_group.le_abs a)), } },
       { apply lattice_ordered_comm_group.neg_pos, }
     end,
-    rw [← mul_eq_inf_mul_sup, pos_inf_neg_eq_one, one_mul, ← mod_eq_pos ],
+    rw [← inf_mul_sup, pos_inf_neg_eq_one, one_mul, ← mod_eq_pos ],
     apply sup_le,
     apply and.left
       (iff.elim_left (le_iff_pos_le_neg_ge _ _)
@@ -420,7 +420,7 @@ $$2•(a⊔b) = a + b + |b - a|.$$
 @[to_additive]
 lemma sup_sq_eq_mul_mul_abs_div (a b : α) : (a⊔b)^2 = a * b * |b / a| :=
 begin
-  rw [← mul_eq_inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, ← mul_assoc, mul_comm,
+  rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, ← mul_assoc, mul_comm,
     mul_assoc, ← pow_two, inv_mul_cancel_left],
 end
 
@@ -432,7 +432,7 @@ $$2•(a⊓b) = a + b - |b - a|.$$
 @[to_additive]
 lemma two_inf_eq_mul_div_abs_div (a b : α) : (a⊓b)^2 = a * b / |b / a| :=
 begin
-  rw [← mul_eq_inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, div_eq_mul_inv,
+  rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, div_eq_mul_inv,
     mul_inv_rev, inv_inv, mul_assoc, mul_inv_cancel_comm_assoc, ← pow_two],
 end
 
@@ -446,14 +446,14 @@ instance lattice_ordered_comm_group_to_distrib_lattice (α : Type u)
 { le_sup_inf :=
   begin
     intros,
-    rw [← mul_le_mul_iff_left (x⊓(y⊓z)),  mul_eq_inf_mul_sup x (y⊓z),
+    rw [← mul_le_mul_iff_left (x⊓(y⊓z)),  inf_mul_sup x (y⊓z),
       ← inv_mul_le_iff_le_mul, le_inf_iff ],
     split,
-    { rw [inv_mul_le_iff_le_mul, ← mul_eq_inf_mul_sup x y ],
+    { rw [inv_mul_le_iff_le_mul, ← inf_mul_sup x y ],
       apply mul_le_mul',
       { apply inf_le_inf_left, apply inf_le_left, },
       { apply inf_le_left, } },
-    { rw [inv_mul_le_iff_le_mul, ← mul_eq_inf_mul_sup x z ],
+    { rw [inv_mul_le_iff_le_mul, ← inf_mul_sup x z ],
       apply mul_le_mul',
       { apply inf_le_inf_left, apply inf_le_right, },
       { apply inf_le_right, }, }
@@ -491,7 +491,7 @@ theorem abs_div_sup_mul_abs_div_inf (a b c : α) :
       rw [inf_right_idem, inf_assoc], }
     ... = (b⊔a⊔c) * ((b⊔a)⊓c) /(((b⊓a)⊔c)*(b⊓a⊓c))    : by { rw div_mul_div_eq_mul_div_mul,}
     ... = (b⊔a) * c /(b⊓a*c)                      :
-      by {rw [mul_comm, mul_eq_inf_mul_sup, mul_comm (b ⊓ a ⊔ c), mul_eq_inf_mul_sup] }
+      by {rw [mul_comm, inf_mul_sup, mul_comm (b ⊓ a ⊔ c), inf_mul_sup] }
     ... = (b⊔a) / (b⊓a) : by { rw [div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_inv_cancel_left,
        ← div_eq_mul_inv], }
     ... = |a/b|         : by { rw sup_div_inf_eq_abs_div,  }

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -108,9 +108,7 @@ $$ -(a ⊓ b) = -a ⊔ -b.$$
 -/
 @[to_additive, simp]
 lemma inv_inf_eq_sup_inv (a b : α) : (a ⊓ b)⁻¹ = a⁻¹ ⊔ b⁻¹ :=
-begin
-  rw [← inv_inv (a⁻¹ ⊔ b⁻¹), inv_sup_eq_inv_inf_inv a⁻¹ b⁻¹, inv_inv, inv_inv],
-end
+by rw [← inv_inv (a⁻¹ ⊔ b⁻¹), inv_sup_eq_inv_inf_inv a⁻¹ b⁻¹, inv_inv, inv_inv]
 
 -- Bourbaki A.VI.10 Prop 7
 /--
@@ -121,8 +119,8 @@ $$a ⊓ b + (a ⊔ b) = a + b.$$
 lemma inf_mul_sup (a b : α) : a ⊓ b * (a ⊔ b) = a * b :=
 calc a⊓b * (a ⊔ b) = a ⊓ b * ((a * b) * (b⁻¹ ⊔ a⁻¹)) :
   by {  rw mul_sup_eq_mul_sup_mul b⁻¹ a⁻¹ (a * b), simp,  }
-... = a⊓b * ((a * b) * (a ⊓ b)⁻¹) : by { rw [inv_inf_eq_sup_inv, sup_comm], }
-... = a * b                    : by { rw [mul_comm, inv_mul_cancel_right],  }
+... = a⊓b * ((a * b) * (a ⊓ b)⁻¹) : by rw [inv_inf_eq_sup_inv, sup_comm]
+... = a * b                       : by rw [mul_comm, inv_mul_cancel_right]
 
 /--
 Absolute value is a unary operator with properties similar to the absolute value of a real number.
@@ -205,22 +203,14 @@ Let `α` be a lattice ordered commutative group and let `a` be an element in `α
 component `a⁻` of `a` is equal to the positive component `(-a)⁺` of `-a`.
 -/
 @[to_additive]
-lemma neg_eq_pos_inv (a : α) : a⁻ = (a⁻¹)⁺ :=
-begin
-  unfold mneg,
-  unfold mpos,
-end
+lemma neg_eq_pos_inv (a : α) : a⁻ = (a⁻¹)⁺ := by { unfold mneg, unfold mpos}
 
 /--
 Let `α` be a lattice ordered commutative group and let `a` be an element in `α`. Then the positive
 component `a⁺` of `a` is equal to the negative component `(-a)⁻` of `-a`.
 -/
 @[to_additive]
-lemma pos_eq_neg_inv (a : α) : a⁺ =(a⁻¹)⁻ :=
-begin
-  rw neg_eq_pos_inv,
-  simp,
-end
+lemma pos_eq_neg_inv (a : α) : a⁺ = (a⁻¹)⁻ := by simp [neg_eq_pos_inv]
 
 -- We use this in Bourbaki A.VI.12  Prop 9 a)
 /--
@@ -246,9 +236,7 @@ $$a⁻ = -(a ⊓ 0).$$
 lemma neg_eq_inv_inf_one (a : α) : a⁻ = (a ⊓ 1)⁻¹ :=
 begin
   unfold lattice_ordered_comm_group.mneg,
-  rw ← inv_inj,
-  rw inv_sup_eq_inv_inf_inv,
-  rw [inv_inv, inv_inv, one_inv],
+  rw [← inv_inj, inv_sup_eq_inv_inf_inv, inv_inv, inv_inv, one_inv],
 end
 
 -- Bourbaki A.VI.12  Prop 9 a)
@@ -279,10 +267,8 @@ positive, disjoint).
 -/
 @[to_additive]
 lemma pos_inf_neg_eq_one (a : α) : a⁺ ⊓ a⁻=1 :=
-begin
-  rw [←mul_right_inj (a⁻)⁻¹, mul_inf_eq_mul_inf_mul, mul_one, mul_left_inv, mul_comm,
-    ←div_eq_mul_inv, pos_div_neg', neg_eq_inv_inf_one, inv_inv],
-end
+by rw [←mul_right_inj (a⁻)⁻¹, mul_inf_eq_mul_inf_mul, mul_one, mul_left_inv, mul_comm,
+  ←div_eq_mul_inv, pos_div_neg', neg_eq_inv_inf_one, inv_inv]
 
 -- Bourbaki A.VI.12 (with a and b swapped)
 /--
@@ -292,9 +278,9 @@ $$a⊔b = b + (a - b)⁺.$$
 -/
 @[to_additive]
 lemma sup_eq_mul_pos_div (a b : α) : a ⊔ b = b * (a / b)⁺ :=
-  calc  a ⊔ b = (b * (a / b)) ⊔ (b * 1) : by {rw [mul_one b, div_eq_mul_inv, mul_comm a,
-    mul_inv_cancel_left], }
-  ... = b * ((a / b) ⊔ 1) : by { rw ← mul_sup_eq_mul_sup_mul (a / b) 1 b}
+calc  a ⊔ b = (b * (a / b)) ⊔ (b * 1) : by {rw [mul_one b, div_eq_mul_inv, mul_comm a,
+  mul_inv_cancel_left], }
+... = b * ((a / b) ⊔ 1) : by { rw ← mul_sup_eq_mul_sup_mul (a / b) 1 b}
 
 -- Bourbaki A.VI.12 (with a and b swapped)
 /--
@@ -304,14 +290,14 @@ $$a⊓b = a - (a - b)⁺.$$
 -/
 @[to_additive]
 lemma inf_eq_div_pos_div (a b : α) : a ⊓ b = a / (a / b)⁺ :=
-  calc a ⊓ b = (a * 1) ⊓ (a * (b / a)) : by { rw [mul_one a, div_eq_mul_inv, mul_comm b,
-    mul_inv_cancel_left], }
-  ... = a * (1 ⊓ (b / a))        : by {rw ← mul_inf_eq_mul_inf_mul 1 (b / a) a}
-  ... = a * ((b / a) ⊓ 1)        : by { rw inf_comm }
-  ... = a * ((a / b)⁻¹ ⊓ 1) : by { rw div_eq_mul_inv,  nth_rewrite 0 ← inv_inv b,
-    rw [← mul_inv, mul_comm b⁻¹, ← div_eq_mul_inv], }
-  ... = a * ((a / b)⁻¹ ⊓ 1⁻¹) : by { rw one_inv, }
-  ... = a / ((a / b) ⊔ 1)        : by  { rw ← inv_sup_eq_inv_inf_inv, rw ← div_eq_mul_inv, }
+calc a ⊓ b = (a * 1) ⊓ (a * (b / a)) : by { rw [mul_one a, div_eq_mul_inv, mul_comm b,
+  mul_inv_cancel_left], }
+... = a * (1 ⊓ (b / a))     : by rw ← mul_inf_eq_mul_inf_mul 1 (b / a) a
+... = a * ((b / a) ⊓ 1)     : by rw inf_comm
+... = a * ((a / b)⁻¹ ⊓ 1)   : by { rw div_eq_mul_inv,  nth_rewrite 0 ← inv_inv b,
+  rw [← mul_inv, mul_comm b⁻¹, ← div_eq_mul_inv], }
+... = a * ((a / b)⁻¹ ⊓ 1⁻¹) : by rw one_inv
+... = a / ((a / b) ⊔ 1)     : by rw [← inv_sup_eq_inv_inf_inv, ← div_eq_mul_inv]
 
 -- Bourbaki A.VI.12 Prop 9 c)
 /--
@@ -412,10 +398,8 @@ $$2•(a ⊔ b) = a + b + |b - a|.$$
 -/
 @[to_additive]
 lemma sup_sq_eq_mul_mul_abs_div (a b : α) : (a ⊔ b)^2 = a * b * |b / a| :=
-begin
-  rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, ← mul_assoc, mul_comm,
-    mul_assoc, ← pow_two, inv_mul_cancel_left],
-end
+by rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, ← mul_assoc, mul_comm,
+    mul_assoc, ← pow_two, inv_mul_cancel_left]
 
 /--
 Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b-a|`
@@ -424,10 +408,8 @@ $$2•(a ⊓ b) = a + b - |b - a|.$$
 -/
 @[to_additive]
 lemma two_inf_eq_mul_div_abs_div (a b : α) : (a ⊓ b)^2 = a * b / |b / a| :=
-begin
-  rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, div_eq_mul_inv,
-    mul_inv_rev, inv_inv, mul_assoc, mul_inv_cancel_comm_assoc, ← pow_two],
-end
+by rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, div_eq_mul_inv,
+    mul_inv_rev, inv_inv, mul_assoc, mul_inv_cancel_comm_assoc, ← pow_two]
 
 /--
 Every lattice ordered commutative group is a distributive lattice
@@ -450,15 +432,12 @@ instance lattice_ordered_comm_group_to_distrib_lattice (α : Type u)
       { apply inf_le_inf_left, apply inf_le_right, },
       { apply inf_le_right, }, }
   end,
-  ..s
-}
+  ..s }
 
 @[to_additive]
 lemma div_mul_div_eq_mul_div_mul (x y w z : α) : x / y * (w / z) = x * w / (y * z) :=
-begin
-  rw [div_eq_mul_inv, div_eq_mul_inv, div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_assoc,
-    mul_left_cancel_iff, mul_comm, mul_assoc],
-end
+by rw [div_eq_mul_inv, div_eq_mul_inv, div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_assoc,
+    mul_left_cancel_iff, mul_comm, mul_assoc]
 
 -- See, e.g. Zaanen, Lectures on Riesz Spaces
 -- 3rd lecture

--- a/src/algebra/ordered_group.lean
+++ b/src/algebra/ordered_group.lean
@@ -980,8 +980,16 @@ section covariant_add_le
 section has_neg
 variables [has_neg α] [linear_order α] {a b: α}
 
-/-- `abs a` is the absolute value of `a`. -/
-def abs {α : Type*} [has_neg α] [linear_order α] (a : α) : α := max a (-a)
+/-- `mabs a` is the multiplicative absolute value of `a`. -/
+@[to_additive abs
+"`abs a` is the additive absolute value of `a`."
+]
+def mabs {α : Type*} [has_inv α] [lattice α] (a : α) : α := a ⊔ (a⁻¹)
+
+lemma abs_eq_max_neg {α : Type*} [has_neg α] [linear_order α] (a : α) : abs a = max a (-a) :=
+begin
+  exact rfl,
+end
 
 lemma abs_choice (x : α) : abs x = x ∨ abs x = -x := max_choice _ _
 
@@ -1007,7 +1015,9 @@ section add_group
 variables [add_group α] [linear_order α]
 
 @[simp] lemma abs_neg (a : α) : abs (-a) = abs a :=
-begin unfold abs, rw [max_comm, neg_neg] end
+begin
+  rw [abs_eq_max_neg, max_comm, neg_neg, abs_eq_max_neg]
+end
 
 lemma eq_or_eq_neg_of_abs_eq {a b : α} (h : abs a = b) : a = b ∨ a = -b :=
 by simpa only [← h, eq_comm, eq_neg_iff_eq_neg] using abs_choice a

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -996,9 +996,9 @@ calc a < -a ↔ -(-a) < -a : by rw neg_neg
 ... ↔ 0 < -a : neg_lt_self_iff
 ... ↔ a < 0 : neg_pos
 
-@[simp] lemma abs_eq_self : abs a = a ↔ 0 ≤ a := by simp [abs]
+@[simp] lemma abs_eq_self : abs a = a ↔ 0 ≤ a := by simp [abs_eq_max_neg]
 
-@[simp] lemma abs_eq_neg_self : abs a = -a ↔ a ≤ 0 := by simp [abs]
+@[simp] lemma abs_eq_neg_self : abs a = -a ↔ a ≤ 0 := by simp [abs_eq_max_neg]
 
 /-- For an element `a` of a linear ordered ring, either `abs a = a` and `0 ≤ a`,
     or `abs a = -a` and `a < 0`.

--- a/src/data/int/cast.lean
+++ b/src/data/int/cast.lean
@@ -187,7 +187,7 @@ monotone.map_max cast_mono
 
 @[simp, norm_cast] theorem cast_abs [linear_ordered_ring α] {q : ℤ} :
   ((abs q : ℤ) : α) = abs q :=
-by simp [abs]
+by simp [abs_eq_max_neg]
 
 lemma cast_nat_abs {R : Type*} [linear_ordered_ring R] : ∀ (n : ℤ), (n.nat_abs : R) = abs n
 | (n : ℕ) := by simp only [int.nat_abs_of_nat, int.cast_coe_nat, nat.abs_cast]

--- a/src/data/rat/cast.lean
+++ b/src/data/rat/cast.lean
@@ -238,7 +238,7 @@ by by_cases b ≤ a; simp [h, max]
 
 @[simp, norm_cast] theorem cast_abs [linear_ordered_field α] {q : ℚ} :
   ((abs q : ℚ) : α) = abs q :=
-by simp [abs]
+by simp [abs_eq_max_neg]
 
 end rat
 

--- a/src/data/real/hyperreal.lean
+++ b/src/data/real/hyperreal.lean
@@ -45,7 +45,12 @@ germ.const_inj
 @[simp, norm_cast] lemma coe_pos {x : ℝ} : 0 < (x : ℝ*) ↔ 0 < x :=
 coe_lt_coe
 @[simp, norm_cast] lemma coe_le_coe {x y : ℝ} : (x : ℝ*) ≤ y ↔ x ≤ y := germ.const_le_iff
-@[simp, norm_cast] lemma coe_abs (x : ℝ) : ((abs x : ℝ) : ℝ*) = abs x := germ.const_abs _
+
+@[simp, norm_cast] lemma coe_abs (x : ℝ) : ((abs x : ℝ) : ℝ*) = abs x :=
+begin
+  convert const_abs x,
+  apply lattice_of_linear_order_eq_filter_germ_lattice,
+end
 @[simp, norm_cast] lemma coe_max (x y : ℝ) : ((max x y : ℝ) : ℝ*) = max x y := germ.const_max _ _
 @[simp, norm_cast] lemma coe_min (x y : ℝ) : ((min x y : ℝ) : ℝ*) = min x y := germ.const_min _ _
 

--- a/src/order/filter/filter_product.lean
+++ b/src/order/filter/filter_product.lean
@@ -97,8 +97,15 @@ begin
   { rw [max_eq_left h, map₂_coe, coe_eq], exact h.mono (λ i hi, (max_eq_left hi).symm) }
 end
 
-lemma min_def [K : linear_order β] (x y : β*) : min x y = map₂ min x y :=
+lemma sup_def [linear_order β] (x y : β*) : x ⊔ y = map₂ has_sup.sup x y :=
+induction_on₂ x y $ λ a b,
+begin
+  cases le_total (a : β*) b,
+  { rw [sup_eq_right.2 h, map₂_coe, coe_eq], exact h.mono (λ i hi, (max_eq_right hi).symm) },
+  { rw [sup_eq_left.2 h, map₂_coe, coe_eq], exact h.mono (λ i hi, (max_eq_left hi).symm)}
+end
 
+lemma min_def [K : linear_order β] (x y : β*) : min x y = map₂ min x y :=
 induction_on₂ x y $ λ a b,
 begin
   cases le_total (a : β*) b,
@@ -106,8 +113,16 @@ begin
   { rw [min_eq_right h, map₂_coe, coe_eq], exact h.mono (λ i hi, (min_eq_right hi).symm) }
 end
 
+lemma inf_def [linear_order β] (x y : β*) : x ⊓ y = map₂ has_inf.inf x y :=
+induction_on₂ x y $ λ a b,
+begin
+  cases le_total (a : β*) b,
+  { rw [inf_eq_left.2 h, map₂_coe, coe_eq], exact h.mono (λ i hi, (min_eq_left hi).symm) },
+  { rw [inf_eq_right.2 h, map₂_coe, coe_eq], exact h.mono (λ i hi, (min_eq_right hi).symm) }
+end
+
 lemma abs_def [linear_ordered_add_comm_group β] (x : β*) : abs x = map abs x :=
-induction_on x $ λ a, by rw [abs, ← coe_neg, max_def, map₂_coe]; refl
+induction_on x $ λ a, by exact rfl
 
 @[simp] lemma const_max [linear_order β] (x y : β) : (↑(max x y : β) : β*) = max ↑x ↑y :=
 by rw [max_def, map₂_const]
@@ -117,7 +132,11 @@ by rw [min_def, map₂_const]
 
 @[simp] lemma const_abs [linear_ordered_add_comm_group β] (x : β) :
   (↑(abs x) : β*) = abs ↑x :=
-const_max x (-x)
+by rw [abs_def, map_const]
+
+lemma lattice_of_linear_order_eq_filter_germ_lattice [linear_order β] :
+  (@lattice_of_linear_order (filter.germ ↑φ β) filter.germ.linear_order) = filter.germ.lattice :=
+lattice.ext (λ x y, iff.rfl)
 
 end germ
 

--- a/src/order/filter/filter_product.lean
+++ b/src/order/filter/filter_product.lean
@@ -97,28 +97,12 @@ begin
   { rw [max_eq_left h, map₂_coe, coe_eq], exact h.mono (λ i hi, (max_eq_left hi).symm) }
 end
 
-lemma sup_def [linear_order β] (x y : β*) : x ⊔ y = map₂ has_sup.sup x y :=
-induction_on₂ x y $ λ a b,
-begin
-  cases le_total (a : β*) b,
-  { rw [sup_eq_right.2 h, map₂_coe, coe_eq], exact h.mono (λ i hi, (max_eq_right hi).symm) },
-  { rw [sup_eq_left.2 h, map₂_coe, coe_eq], exact h.mono (λ i hi, (max_eq_left hi).symm)}
-end
-
 lemma min_def [K : linear_order β] (x y : β*) : min x y = map₂ min x y :=
 induction_on₂ x y $ λ a b,
 begin
   cases le_total (a : β*) b,
   { rw [min_eq_left h, map₂_coe, coe_eq], exact h.mono (λ i hi, (min_eq_left hi).symm) },
   { rw [min_eq_right h, map₂_coe, coe_eq], exact h.mono (λ i hi, (min_eq_right hi).symm) }
-end
-
-lemma inf_def [linear_order β] (x y : β*) : x ⊓ y = map₂ has_inf.inf x y :=
-induction_on₂ x y $ λ a b,
-begin
-  cases le_total (a : β*) b,
-  { rw [inf_eq_left.2 h, map₂_coe, coe_eq], exact h.mono (λ i hi, (min_eq_left hi).symm) },
-  { rw [inf_eq_right.2 h, map₂_coe, coe_eq], exact h.mono (λ i hi, (min_eq_right hi).symm) }
 end
 
 lemma abs_def [linear_ordered_add_comm_group β] (x : β*) : abs x = map abs x :=

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -591,14 +591,16 @@ variables {R : Type*} [linear_ordered_field R]
 -- it's here, immediately prior to the point of use.
 lemma min_eq_half_add_sub_abs_sub {x y : R} : min x y = 2⁻¹ * (x + y - abs (x - y)) :=
 begin
-  dsimp [min, max, abs],
-  simp only [neg_le_self_iff, if_congr, sub_nonneg, neg_sub],
+  rw abs_eq_max_neg,
+  dsimp [min, max],
+  simp  [abs_eq_max_neg, neg_le_self_iff, if_congr, sub_nonneg, neg_sub],
   split_ifs; ring_nf; linarith,
 end
 
 lemma max_eq_half_add_add_abs_sub {x y : R} : max x y = 2⁻¹ * (x + y + abs (x - y)) :=
 begin
-  dsimp [min, max, abs],
+  rw abs_eq_max_neg,
+  dsimp [min, max],
   simp only [neg_le_self_iff, if_congr, sub_nonneg, neg_sub],
   split_ifs; ring_nf; linarith,
 end

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1152,7 +1152,7 @@ begin
   wlog h : a ≤ b,
   { apply nnreal.coe_eq.1,
     rw [nnreal.sub_eq_zero h, max_eq_right (zero_le $ b - a), ← dist_nndist, nnreal.dist_eq,
-      nnreal.coe_sub h, abs, neg_sub],
+      nnreal.coe_sub h, abs_eq_max_neg, neg_sub],
     apply max_eq_right,
     linarith [nnreal.coe_le_coe.2 h] },
   rwa [nndist_comm, max_comm]


### PR DESCRIPTION

---

This is my first non-trivial PR to mathlib. It adds the basic theory of lattice ordered groups, which is useful as the algebraic underpinnings of vector lattices, Banach lattices, AL-space, AM-space etc. I am still relatively new to lean/mathlib and have a lot to learn, so constructive criticism is very welcome. I imagine an expert could write more succinct proofs.

I have defined both the multiplicative and additive classes, but have mostly developed the theory with the additive classes as this notation seems more natural in this context, and I have not myself had an application for multiplicative lattice ordered groups. I'm happy to rewrite the file in the multiplicative form if required.

Many of the results are valid in the non-commutative case, but the proofs are more involved. I've only submitted the commutative case, as that's all I personally need. Should I be aiming for greater generality?

Thanks for your time,

Christopher Hoskin

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
