### PR TITLE
[Merged by Bors] - feat(group_theory/perm/basic): permutations of a subtype

### DIFF
--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -299,13 +299,13 @@ the rest. -/
   right_inv := λ f,
     subtype.ext (equiv.perm.of_subtype_subtype_perm _ $ λ a, not.decidable_imp_symm $ f.prop a) }
 
-@[simp] lemma perm.subtype_equiv_subtype_perm_apply_of_mem {α : Type*} (p : α → Prop)
-  [decidable_pred p] (f : perm (subtype p)) (a : α) (h : p a) :
+lemma perm.subtype_equiv_subtype_perm_apply_of_mem {α : Type*} {p : α → Prop}
+  [decidable_pred p] (f : perm (subtype p)) {a : α} (h : p a) :
   perm.subtype_equiv_subtype_perm p f a = f ⟨a, h⟩ :=
 f.of_subtype_apply_of_mem h
 
-@[simp] lemma perm.subtype_equiv_subtype_perm_apply_of_not_mem {α : Type*} (p : α → Prop)
-  [decidable_pred p] (f : perm (subtype p)) (a : α) (h : ¬ p a) :
+lemma perm.subtype_equiv_subtype_perm_apply_of_not_mem {α : Type*} {p : α → Prop}
+  [decidable_pred p] (f : perm (subtype p)) {a : α} (h : ¬ p a) :
   perm.subtype_equiv_subtype_perm p f a = a :=
 f.of_subtype_apply_of_not_mem h
 

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -299,6 +299,16 @@ the rest. -/
   right_inv := λ f,
     subtype.ext (equiv.perm.of_subtype_subtype_perm _ $ λ a, not.decidable_imp_symm $ f.prop a) }
 
+@[simp] lemma perm.subtype_equiv_subtype_perm_apply_of_mem {α : Type*} (p : α → Prop)
+  [decidable_pred p] (f : perm (subtype p)) (a : α) (h : p a) :
+  perm.subtype_equiv_subtype_perm p f a = f ⟨a, h⟩ :=
+f.of_subtype_apply_of_mem h
+
+@[simp] lemma perm.subtype_equiv_subtype_perm_apply_of_not_mem {α : Type*} (p : α → Prop)
+  [decidable_pred p] (f : perm (subtype p)) (a : α) (h : ¬ p a) :
+  perm.subtype_equiv_subtype_perm p f a = a :=
+f.of_subtype_apply_of_not_mem h
+
 variables (e : perm α) (ι : α ↪ β)
 
 open_locale classical

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -289,7 +289,7 @@ equiv.ext $ λ ⟨x, hx⟩, by { dsimp [subtype_perm, of_subtype],
 
 /-- Permutations on a subtype are equivalent to permutations on the original type that fix pointwise
 the rest. -/
-@[simps] protected def subtype_equiv (p : α → Prop) [decidable_pred p] :
+@[simps] protected def subtype_equiv_subtype_perm (p : α → Prop) [decidable_pred p] :
   perm (subtype p) ≃ {f : perm α // ∀ a, ¬p a → f a = a} :=
 { to_fun := λ f, ⟨f.of_subtype, λ a, f.of_subtype_apply_of_not_mem⟩,
   inv_fun := λ f, (f : perm α).subtype_perm

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -299,12 +299,12 @@ the rest. -/
   right_inv := λ f,
     subtype.ext (equiv.perm.of_subtype_subtype_perm _ $ λ a, not.decidable_imp_symm $ f.prop a) }
 
-lemma perm.subtype_equiv_subtype_perm_apply_of_mem {α : Type*} {p : α → Prop}
+lemma subtype_equiv_subtype_perm_apply_of_mem {α : Type*} {p : α → Prop}
   [decidable_pred p] (f : perm (subtype p)) {a : α} (h : p a) :
   perm.subtype_equiv_subtype_perm p f a = f ⟨a, h⟩ :=
 f.of_subtype_apply_of_mem h
 
-lemma perm.subtype_equiv_subtype_perm_apply_of_not_mem {α : Type*} {p : α → Prop}
+lemma subtype_equiv_subtype_perm_apply_of_not_mem {α : Type*} {p : α → Prop}
   [decidable_pred p] (f : perm (subtype p)) {a : α} (h : ¬ p a) :
   perm.subtype_equiv_subtype_perm p f a = a :=
 f.of_subtype_apply_of_not_mem h

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -289,17 +289,15 @@ equiv.ext $ λ ⟨x, hx⟩, by { dsimp [subtype_perm, of_subtype],
 
 /-- Permutations on a subtype are equivalent to permutations on the original type that fix pointwise
 the rest. -/
-protected def perm.subtype_equiv (p : α → Prop) [decidable_pred p] :
+protected def subtype_equiv (p : α → Prop) [decidable_pred p] :
   perm (subtype p) ≃ {f : perm α // ∀ a, ¬p a → f a = a} :=
 { to_fun := λ f, ⟨f.of_subtype, λ a, f.of_subtype_apply_of_not_mem⟩,
-  inv_fun := λ ⟨f, hf⟩, (f : perm α).subtype_perm
-    (λ a, ⟨decidable.not_imp_not.1 $ λ hfa, (f.injective (hf _ hfa) ▸ hfa),
-    decidable.not_imp_not.1 $ λ ha hfa, ha (hf a ha ▸ hfa)⟩),
+  inv_fun := λ f, (f : perm α).subtype_perm
+    (λ a, ⟨decidable.not_imp_not.1 $ λ hfa, (f.val.injective (f.prop _ hfa) ▸ hfa),
+    decidable.not_imp_not.1 $ λ ha hfa, ha $ f.prop a ha ▸ hfa⟩),
   left_inv := equiv.perm.subtype_perm_of_subtype,
-  right_inv := begin
-    rintro ⟨f, hf⟩,
-    exact subtype.ext (equiv.perm.of_subtype_subtype_perm _ $ λ a, not.decidable_imp_symm $ hf a),
-  end }
+  right_inv := λ f,
+    subtype.ext (equiv.perm.of_subtype_subtype_perm _ $ λ a, not.decidable_imp_symm $ f.prop a) }
 
 variables (e : perm α) (ι : α ↪ β)
 

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -289,7 +289,7 @@ equiv.ext $ λ ⟨x, hx⟩, by { dsimp [subtype_perm, of_subtype],
 
 /-- Permutations on a subtype are equivalent to permutations on the original type that fix pointwise
 the rest. -/
-protected def subtype_equiv (p : α → Prop) [decidable_pred p] :
+@[simps] protected def subtype_equiv (p : α → Prop) [decidable_pred p] :
   perm (subtype p) ≃ {f : perm α // ∀ a, ¬p a → f a = a} :=
 { to_fun := λ f, ⟨f.of_subtype, λ a, f.of_subtype_apply_of_not_mem⟩,
   inv_fun := λ f, (f : perm α).subtype_perm

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -287,6 +287,20 @@ equiv.ext $ λ ⟨x, hx⟩, by { dsimp [subtype_perm, of_subtype],
 
 @[simp] lemma default_perm {n : Type*} : default (equiv.perm n) = 1 := rfl
 
+/-- Permutations on a subtype are equivalent to permutations on the original type that fix pointwise
+the rest. -/
+protected def perm.subtype_equiv (p : α → Prop) [decidable_pred p] :
+  perm (subtype p) ≃ {f : perm α // ∀ a, ¬p a → f a = a} :=
+{ to_fun := λ f, ⟨f.of_subtype, λ a, f.of_subtype_apply_of_not_mem⟩,
+  inv_fun := λ ⟨f, hf⟩, (f : perm α).subtype_perm
+    (λ a, ⟨decidable.not_imp_not.1 $ λ hfa, (f.injective (hf _ hfa) ▸ hfa),
+    decidable.not_imp_not.1 $ λ ha hfa, ha (hf a ha ▸ hfa)⟩),
+  left_inv := equiv.perm.subtype_perm_of_subtype,
+  right_inv := begin
+    rintro ⟨f, hf⟩,
+    exact subtype.ext (equiv.perm.of_subtype_subtype_perm _ $ λ a, not.decidable_imp_symm $ hf a),
+  end }
+
 variables (e : perm α) (ι : α ↪ β)
 
 open_locale classical


### PR DESCRIPTION
This is the same as `(equiv.refl _)^.set.compl .symm.trans (subtype_equiv_right $ by simp)` (up to a `compl`) but with better unfolding.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
