### PR TITLE
[Merged by Bors] - chore(data/vector): rename vector2

### DIFF
--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -364,7 +364,7 @@ apply_nolint wseq.mem doc_blame
 apply_nolint wseq.tail.aux doc_blame
 apply_nolint wseq.think_congr unused_arguments
 
--- data/vector2.lean
+-- data/vector/basic.lean
 apply_nolint vector.insert_nth doc_blame
 apply_nolint vector.m_of_fn doc_blame
 apply_nolint vector.mmap doc_blame

--- a/src/data/array/lemmas.lean
+++ b/src/data/array/lemmas.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
 import control.traversable.equiv
-import data.vector2
+import data.vector.basic
 
 universes u v w
 

--- a/src/data/bitvec/core.lean
+++ b/src/data/bitvec/core.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joe Hendrix, Sebastian Ullrich
 -/
 
-import data.vector.lemmas
+import data.vector.basic
 import data.nat.basic
 
 /-!

--- a/src/data/bitvec/core.lean
+++ b/src/data/bitvec/core.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joe Hendrix, Sebastian Ullrich
 -/
 
-import data.vector2
+import data.vector.lemmas
 import data.nat.basic
 
 /-!

--- a/src/data/sym/basic.lean
+++ b/src/data/sym/basic.lean
@@ -5,7 +5,7 @@ Authors: Kyle Miller
 -/
 
 import data.multiset.basic
-import data.vector2
+import data.vector.basic
 
 /-!
 # Symmetric powers

--- a/src/data/vector/basic.lean
+++ b/src/data/vector/basic.lean
@@ -8,7 +8,7 @@ import data.list.nodup
 import data.list.of_fn
 import control.applicative
 /-!
-# Additional theorems about the `vector` type
+# Additional theorems and definitions about the `vector` type
 
 This file introduces the infix notation `::ᵥ` for `vector.cons`.
 -/


### PR DESCRIPTION
This file was named this way to avoid clashing with `data/vector.lean` in core.
This renames it to `data/vector/basic.lean` which avoids the problem.

There was never a `vector2` definition, this was only ever a filename.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
