### PR TITLE
[Merged by Bors] - feat(algebra/lie/semisimple): adjoint action is injective for semisimple Lie algebras

### DIFF
--- a/src/algebra/lie/abelian.lean
+++ b/src/algebra/lie/abelian.lean
@@ -213,7 +213,9 @@ abbreviation center : lie_ideal R L := lie_module.max_triv_submodule R L L
 
 instance : is_lie_abelian (center R L) := infer_instance
 
-lemma center_eq_adjoint_kernel : center R L = lie_module.ker R L L :=
+@[simp] lemma ad_ker_eq_self_module_ker : (ad R L).ker = lie_module.ker R L L := rfl
+
+@[simp] lemma self_module_ker_eq_center : lie_module.ker R L L = center R L :=
 begin
   ext y,
   simp only [lie_module.mem_max_triv_submodule, lie_module.mem_ker, ← lie_skew _ y, neg_eq_zero],

--- a/src/algebra/lie/semisimple.lean
+++ b/src/algebra/lie/semisimple.lean
@@ -110,4 +110,7 @@ begin
   { intros h, apply h, apply_instance, },
 end
 
+lemma ad_ker_eq_bot_of_semisimple [is_semisimple R L] : (ad R L).ker = ⊥ :=
+by simp
+
 end lie_algebra


### PR DESCRIPTION


---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
