### PR TITLE
[Merged by Bors] - feat(data/matrix/kronecker): add two lemmas

### DIFF
--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -301,7 +301,7 @@ lemma diagonal_kronecker_tmul_diagonal
   (diagonal a) ⊗ₖₜ[R] (diagonal b) = diagonal (λ mn, a mn.1 ⊗ₜ b mn.2) :=
 kronecker_map_diagonal_diagonal _ (zero_tmul _) (tmul_zero _) _ _
 
-lemma kronecker_tmul_assoc (A : matrix l m α) (B : matrix n p β) (C : matrix q r γ) :
+@[simp] lemma kronecker_tmul_assoc (A : matrix l m α) (B : matrix n p β) (C : matrix q r γ) :
 reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)
   (((A ⊗ₖₜ[R] B) ⊗ₖₜ[R] C).map (tensor_product.assoc _ _ _ _)) = A ⊗ₖₜ[R] (B ⊗ₖₜ[R] C) :=
 ext $ λ i j, assoc_tmul _ _ _

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -153,6 +153,23 @@ begin
   simp_rw [f.map_sum, linear_map.sum_apply, linear_map.map_sum, h_comm],
 end
 
+lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω')
+  (g' : β → δ → ξ) {q r : Type*} [fintype q] [fintype r] (A : matrix l m α) (B : matrix n p β)
+  (D : matrix q r δ) (φ : ω ≃ ω') :
+  (reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)).trans (equiv.map_matrix φ)
+    (kronecker_map g (kronecker_map f A B) D) = kronecker_map f' A (kronecker_map g' B D) :=
+begin
+  ext i j,
+  simp only [equiv.prod_assoc_symm_apply, function.comp_app, minor_apply, equiv.map_matrix_apply,
+    map_apply, reindex_apply, equiv.coe_trans, kronecker_map],
+  -- simp only [matrix.linear_equiv_index_assoc, kronecker_biprod_apply_apply, linear_map.coe_mk,
+  --   id.map_eq_self,
+  --   reindex_apply, linear_equiv.coe_mk],
+  -- ext i j,
+  -- simp only [equiv.prod_assoc_symm_apply, reindex_linear_equiv_apply, minor_apply, reindex_apply,
+  --   mul_assoc, kronecker_map, algebra.biprod_apply, id.map_eq_self],
+end
+
 end kronecker_map
 
 /-! ### Specialization to `matrix.kronecker_map (*)` -/
@@ -221,7 +238,10 @@ lemma mul_kronecker_mul [comm_semiring α]
   (A ⬝ B) ⊗ₖ (A' ⬝ B') = (A ⊗ₖ A') ⬝ (B ⊗ₖ B') :=
 kronecker_map_linear_mul_mul (algebra.lmul ℕ α).to_linear_map mul_mul_mul_comm A B A' B'
 
--- insert lemmas specific to `kronecker` below this line
+lemma kronecker_assoc [comm_semiring α] {q r : Type*} [fintype q] [fintype r]
+  (A : matrix l m α) (B : matrix n p α) (C : matrix q r α) :
+  reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r) ((A ⊗ₖ B) ⊗ₖ C) = A ⊗ₖ (B ⊗ₖ C):=
+kronecker_map_assoc _ _ _ _ A B C (equiv.cast rfl)
 
 end kronecker
 

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -230,7 +230,7 @@ lemma mul_kronecker_mul [comm_semiring α]
 kronecker_map_linear_mul_mul (algebra.lmul ℕ α).to_linear_map mul_mul_mul_comm A B A' B'
 
 @[simp] lemma kronecker_assoc [semigroup α] (A : matrix l m α) (B : matrix n p α) (C : matrix q r α) :
-  reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r) ((A ⊗ₖ B) ⊗ₖ C) = A ⊗ₖ (B ⊗ₖ C):=
+  reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r) ((A ⊗ₖ B) ⊗ₖ C) = A ⊗ₖ (B ⊗ₖ C) :=
 kronecker_map_assoc _ _ _ _ A B C (equiv.cast rfl) mul_assoc
 
 end kronecker

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -24,10 +24,10 @@ This defines the [Kronecker product](https://en.wikipedia.org/wiki/Kronecker_pro
 ## Specializations
 
 * `matrix.kronecker`: An alias of `kronecker_map (*)`. Prefer using the notation.
-* `matrix.kronecker_linear`: `matrix.kronecker` is bilinear
+* `matrix.kronecker_bilinear`: `matrix.kronecker` is bilinear
 
 * `matrix.kronecker_tmul`: An alias of `kronecker_map (⊗ₜ)`. Prefer using the notation.
-* `matrix.kronecker_tmul_linear`: `matrix.tmul_kronecker` is bilinear
+* `matrix.kronecker_tmul_bilinear`: `matrix.tmul_kronecker` is bilinear
 
 ## Notations
 
@@ -153,23 +153,19 @@ begin
   simp_rw [f.map_sum, linear_map.sum_apply, linear_map.map_sum, h_comm],
 end
 
+variables {δ ξ ω ω' : Type*} (f : (α → β) → γ) (g : γ → δ → ω)
+#check function.comp g f
+
 lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω')
   (g' : β → δ → ξ) {q r : Type*} [fintype q] [fintype r] (A : matrix l m α) (B : matrix n p β)
-  (D : matrix q r δ) (φ : ω ≃ ω') :
+  (D : matrix q r δ) (φ : ω ≃ ω') (hφ : ∀ a b d, φ (g (f a b) d ) = f' a (g' b d )) :
   (reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)).trans (equiv.map_matrix φ)
     (kronecker_map g (kronecker_map f A B) D) = kronecker_map f' A (kronecker_map g' B D) :=
 begin
   ext i j,
   simp only [equiv.prod_assoc_symm_apply, function.comp_app, minor_apply, equiv.map_matrix_apply,
     map_apply, reindex_apply, equiv.coe_trans, kronecker_map],
-  sorry,
-
-  -- simp only [matrix.linear_equiv_index_assoc, kronecker_biprod_apply_apply, linear_map.coe_mk,
-  --   id.map_eq_self,
-  --   reindex_apply, linear_equiv.coe_mk],
-  -- ext i j,
-  -- simp only [equiv.prod_assoc_symm_apply, reindex_linear_equiv_apply, minor_apply, reindex_apply,
-  --   mul_assoc, kronecker_map, algebra.biprod_apply, id.map_eq_self],
+  apply hφ,
 end
 
 end kronecker_map
@@ -243,7 +239,7 @@ kronecker_map_linear_mul_mul (algebra.lmul ℕ α).to_linear_map mul_mul_mul_com
 lemma kronecker_assoc [comm_semiring α] {q r : Type*} [fintype q] [fintype r]
   (A : matrix l m α) (B : matrix n p α) (C : matrix q r α) :
   reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r) ((A ⊗ₖ B) ⊗ₖ C) = A ⊗ₖ (B ⊗ₖ C):=
-kronecker_map_assoc _ _ _ _ A B C (equiv.cast rfl)
+kronecker_map_assoc _ _ _ _ A B C (equiv.cast rfl) mul_assoc
 
 end kronecker
 

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -246,6 +246,7 @@ open_locale matrix tensor_product
 section module
 
 variables [comm_semiring R] [add_comm_monoid α] [add_comm_monoid β] [module R α] [module R β]
+variables [add_comm_monoid γ] [module R γ]
 
 /-- The Kronecker tensor product. This is just a shorthand for `kronecker_map (⊗ₜ)`.
 Prefer the notation `⊗ₖₜ` rather than this definition. -/
@@ -299,9 +300,6 @@ lemma diagonal_kronecker_tmul_diagonal
   (a : m → α) (b : n → α):
   (diagonal a) ⊗ₖₜ[R] (diagonal b) = diagonal (λ mn, a mn.1 ⊗ₜ b mn.2) :=
 kronecker_map_diagonal_diagonal _ (zero_tmul _) (tmul_zero _) _ _
-
-
-variables [add_comm_monoid γ] [module R γ]
 
 lemma kronecker_tmul_assoc (A : matrix l m α) (B : matrix n p β) (C : matrix q r γ) :
 reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -159,12 +159,7 @@ lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ 
   (hφ : ∀ a b d, φ (g (f a b) d ) = f' a (g' b d )) :
   (reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)).trans (equiv.map_matrix φ)
     (kronecker_map g (kronecker_map f A B) D) = kronecker_map f' A (kronecker_map g' B D) :=
-begin
-  ext i j,
-  simp only [equiv.prod_assoc_symm_apply, function.comp_app, minor_apply, equiv.map_matrix_apply,
-    map_apply, reindex_apply, equiv.coe_trans, kronecker_map],
-  apply hφ,
-end
+ext $ λ i j, hφ _ _ _
 
 end kronecker_map
 

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -162,6 +162,8 @@ begin
   ext i j,
   simp only [equiv.prod_assoc_symm_apply, function.comp_app, minor_apply, equiv.map_matrix_apply,
     map_apply, reindex_apply, equiv.coe_trans, kronecker_map],
+  sorry,
+
   -- simp only [matrix.linear_equiv_index_assoc, kronecker_biprod_apply_apply, linear_map.coe_mk,
   --   id.map_eq_self,
   --   reindex_apply, linear_equiv.coe_mk],

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -156,7 +156,7 @@ end
 
 lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω')
   (g' : β → δ → ξ) (A : matrix l m α) (B : matrix n p β) (D : matrix q r δ) (φ : ω ≃ ω')
-  (hφ : ∀ a b d, φ (g (f a b) d ) = f' a (g' b d )) :
+  (hφ : ∀ a b d, φ (g (f a b) d) = f' a (g' b d)) :
   (reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)).trans (equiv.map_matrix φ)
     (kronecker_map g (kronecker_map f A B) D) = kronecker_map f' A (kronecker_map g' B D) :=
 ext $ λ i j, hφ _ _ _
@@ -303,8 +303,8 @@ lemma diagonal_kronecker_tmul_diagonal
 kronecker_map_diagonal_diagonal _ (zero_tmul _) (tmul_zero _) _ _
 
 @[simp] lemma kronecker_tmul_assoc (A : matrix l m α) (B : matrix n p β) (C : matrix q r γ) :
-reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)
-  (((A ⊗ₖₜ[R] B) ⊗ₖₜ[R] C).map (tensor_product.assoc _ _ _ _)) = A ⊗ₖₜ[R] (B ⊗ₖₜ[R] C) :=
+  reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)
+    (((A ⊗ₖₜ[R] B) ⊗ₖₜ[R] C).map (tensor_product.assoc _ _ _ _)) = A ⊗ₖₜ[R] (B ⊗ₖₜ[R] C) :=
 ext $ λ i j, assoc_tmul _ _ _
 
 end module

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -153,9 +153,6 @@ begin
   simp_rw [f.map_sum, linear_map.sum_apply, linear_map.map_sum, h_comm],
 end
 
-variables {δ ξ ω ω' : Type*} (f : (α → β) → γ) (g : γ → δ → ω)
-#check function.comp g f
-
 lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω')
   (g' : β → δ → ξ) {q r : Type*} [fintype q] [fintype r] (A : matrix l m α) (B : matrix n p β)
   (D : matrix q r δ) (φ : ω ≃ ω') (hφ : ∀ a b d, φ (g (f a b) d ) = f' a (g' b d )) :

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -161,6 +161,13 @@ lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ 
     (kronecker_map g (kronecker_map f A B) D) = kronecker_map f' A (kronecker_map g' B D) :=
 ext $ λ i j, hφ _ _ _
 
+lemma kronecker_map_assoc₁ {δ ξ ω : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω)
+  (g' : β → δ → ξ) (A : matrix l m α) (B : matrix n p β) (D : matrix q r δ)
+  (h : ∀ a b d, (g (f a b) d) = f' a (g' b d)) :
+  reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)
+    (kronecker_map g (kronecker_map f A B) D) = kronecker_map f' A (kronecker_map g' B D) :=
+ext $ λ i j, h _ _ _
+
 end kronecker_map
 
 /-! ### Specialization to `matrix.kronecker_map (*)` -/

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -229,8 +229,9 @@ lemma mul_kronecker_mul [comm_semiring α]
   (A ⬝ B) ⊗ₖ (A' ⬝ B') = (A ⊗ₖ A') ⬝ (B ⊗ₖ B') :=
 kronecker_map_linear_mul_mul (algebra.lmul ℕ α).to_linear_map mul_mul_mul_comm A B A' B'
 
-@[simp] lemma kronecker_assoc [semigroup α] (A : matrix l m α) (B : matrix n p α) (C : matrix q r α) :
-  reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r) ((A ⊗ₖ B) ⊗ₖ C) = A ⊗ₖ (B ⊗ₖ C) :=
+@[simp] lemma kronecker_assoc [semigroup α] (A : matrix l m α) (B : matrix n p α)
+  (C : matrix q r α) : reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r) ((A ⊗ₖ B) ⊗ₖ C) =
+  A ⊗ₖ (B ⊗ₖ C) :=
 kronecker_map_assoc _ _ _ _ A B C (equiv.cast rfl) mul_assoc
 
 end kronecker

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -234,7 +234,7 @@ lemma mul_kronecker_mul [comm_semiring α]
   (A ⬝ B) ⊗ₖ (A' ⬝ B') = (A ⊗ₖ A') ⬝ (B ⊗ₖ B') :=
 kronecker_map_linear_mul_mul (algebra.lmul ℕ α).to_linear_map mul_mul_mul_comm A B A' B'
 
-lemma kronecker_assoc [comm_semiring α] (A : matrix l m α) (B : matrix n p α) (C : matrix q r α) :
+lemma kronecker_assoc [semigroup α] (A : matrix l m α) (B : matrix n p α) (C : matrix q r α) :
   reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r) ((A ⊗ₖ B) ⊗ₖ C) = A ⊗ₖ (B ⊗ₖ C):=
 kronecker_map_assoc _ _ _ _ A B C (equiv.cast rfl) mul_assoc
 

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -239,7 +239,7 @@ kronecker_map_linear_mul_mul (algebra.lmul ℕ α).to_linear_map mul_mul_mul_com
 @[simp] lemma kronecker_assoc [semigroup α] (A : matrix l m α) (B : matrix n p α)
   (C : matrix q r α) : reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r) ((A ⊗ₖ B) ⊗ₖ C) =
   A ⊗ₖ (B ⊗ₖ C) :=
-kronecker_map_assoc _ _ _ _ A B C (equiv.cast rfl) mul_assoc
+kronecker_map_assoc₁ _ _ _ _ A B C mul_assoc
 
 end kronecker
 

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -300,6 +300,14 @@ lemma diagonal_kronecker_tmul_diagonal
   (diagonal a) ⊗ₖₜ[R] (diagonal b) = diagonal (λ mn, a mn.1 ⊗ₜ b mn.2) :=
 kronecker_map_diagonal_diagonal _ (zero_tmul _) (tmul_zero _) _ _
 
+
+variables [add_comm_monoid γ] [module R γ]
+
+lemma kronecker_tmul_assoc (A : matrix l m α) (B : matrix n p β) (C : matrix q r γ) :
+reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)
+  (((A ⊗ₖₜ[R] B) ⊗ₖₜ[R] C).map (tensor_product.assoc _ _ _ _)) = A ⊗ₖₜ[R] (B ⊗ₖₜ[R] C) :=
+ext $ λ i j, assoc_tmul _ _ _
+
 end module
 
 section algebra

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -246,8 +246,8 @@ open_locale matrix tensor_product
 
 section module
 
-variables [comm_semiring R] [add_comm_monoid α] [add_comm_monoid β] [module R α] [module R β]
-variables [add_comm_monoid γ] [module R γ]
+variables [comm_semiring R] [add_comm_monoid α] [add_comm_monoid β] [add_comm_monoid γ]
+variables [module R α] [module R β] [module R γ]
 
 /-- The Kronecker tensor product. This is just a shorthand for `kronecker_map (⊗ₜ)`.
 Prefer the notation `⊗ₖₜ` rather than this definition. -/

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -229,7 +229,7 @@ lemma mul_kronecker_mul [comm_semiring α]
   (A ⬝ B) ⊗ₖ (A' ⬝ B') = (A ⊗ₖ A') ⬝ (B ⊗ₖ B') :=
 kronecker_map_linear_mul_mul (algebra.lmul ℕ α).to_linear_map mul_mul_mul_comm A B A' B'
 
-lemma kronecker_assoc [semigroup α] (A : matrix l m α) (B : matrix n p α) (C : matrix q r α) :
+@[simp] lemma kronecker_assoc [semigroup α] (A : matrix l m α) (B : matrix n p α) (C : matrix q r α) :
   reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r) ((A ⊗ₖ B) ⊗ₖ C) = A ⊗ₖ (B ⊗ₖ C):=
 kronecker_map_assoc _ _ _ _ A B C (equiv.cast rfl) mul_assoc
 

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -44,7 +44,8 @@ namespace matrix
 open_locale matrix
 
 variables {R α α' β β' γ γ' : Type*}
-variables {l m n p : Type*} [fintype l] [fintype m] [fintype n] [fintype p]
+variables {l m n p q r : Type*} [fintype l] [fintype m] [fintype n] [fintype p] [fintype q]
+variables {q r : Type*} [fintype q] [fintype r]
 variables {l' m' n' p' : Type*} [fintype l'] [fintype m'] [fintype n'] [fintype p']
 
 section kronecker_map
@@ -233,8 +234,7 @@ lemma mul_kronecker_mul [comm_semiring α]
   (A ⬝ B) ⊗ₖ (A' ⬝ B') = (A ⊗ₖ A') ⬝ (B ⊗ₖ B') :=
 kronecker_map_linear_mul_mul (algebra.lmul ℕ α).to_linear_map mul_mul_mul_comm A B A' B'
 
-lemma kronecker_assoc [comm_semiring α] {q r : Type*} [fintype q] [fintype r]
-  (A : matrix l m α) (B : matrix n p α) (C : matrix q r α) :
+lemma kronecker_assoc [comm_semiring α] (A : matrix l m α) (B : matrix n p α) (C : matrix q r α) :
   reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r) ((A ⊗ₖ B) ⊗ₖ C) = A ⊗ₖ (B ⊗ₖ C):=
 kronecker_map_assoc _ _ _ _ A B C (equiv.cast rfl) mul_assoc
 

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -19,7 +19,7 @@ This defines the [Kronecker product](https://en.wikipedia.org/wiki/Kronecker_pro
   and matrices `A` and `B` with coefficients in `α` and `β`, respectively, it is defined as the
   matrix with coefficients in `γ` such that
   `kronecker_map f A B (i₁, i₂) (j₁, j₂) = f (A i₁ j₁) (B i₁ j₂)`.
-* `matrix.kronecker_map_linear`: when `f` is bilinear, so is `kronecker_map f`.
+* `matrix.kronecker_map_bilinear`: when `f` is bilinear, so is `kronecker_map f`.
 
 ## Specializations
 
@@ -124,7 +124,7 @@ end
 
 /-- When `f` is bilinear then `matrix.kronecker_map f` is also bilinear. -/
 @[simps]
-def kronecker_map_linear [comm_semiring R]
+def kronecker_map_bilinear [comm_semiring R]
   [add_comm_monoid α] [add_comm_monoid β] [add_comm_monoid γ]
   [module R α] [module R β] [module R γ]
   (f : α →ₗ[R] β →ₗ[R] γ) :
@@ -136,20 +136,20 @@ linear_map.mk₂ R
   (kronecker_map_add_right _ $ λ a, (f a).map_add)
   (λ r, kronecker_map_smul_right _ _ $ λ a, (f a).map_smul r)
 
-/-- `matrix.kronecker_map_linear` commutes with `⬝` if `f` commutes with `*`.
+/-- `matrix.kronecker_map_bilinear` commutes with `⬝` if `f` commutes with `*`.
 
 This is primarily used with `R = ℕ` to prove `matrix.mul_kronecker_mul`. -/
-lemma kronecker_map_linear_mul_mul [comm_semiring R]
+lemma kronecker_map_bilinear_mul_mul [comm_semiring R]
   [non_unital_non_assoc_semiring α] [non_unital_non_assoc_semiring β]
   [non_unital_non_assoc_semiring γ]
   [module R α] [module R β] [module R γ]
   (f : α →ₗ[R] β →ₗ[R] γ) (h_comm : ∀ a b a' b', f (a * b) (a' * b') = f a a' * f b b')
   (A : matrix l m α) (B : matrix m n α) (A' : matrix l' m' β) (B' : matrix m' n' β) :
-  kronecker_map_linear f (A ⬝ B) (A' ⬝ B') =
-    (kronecker_map_linear f A A') ⬝ (kronecker_map_linear f B B') :=
+  kronecker_map_bilinear f (A ⬝ B) (A' ⬝ B') =
+    (kronecker_map_bilinear f A A') ⬝ (kronecker_map_bilinear f B B') :=
 begin
   ext ⟨i, i'⟩ ⟨j, j'⟩,
-  simp only [kronecker_map_linear_apply_apply, mul_apply, ← finset.univ_product_univ,
+  simp only [kronecker_map_bilinear_apply_apply, mul_apply, ← finset.univ_product_univ,
     finset.sum_product, kronecker_map],
   simp_rw [f.map_sum, linear_map.sum_apply, linear_map.map_sum, h_comm],
 end
@@ -192,7 +192,7 @@ lemma kronecker_apply [has_mul α] (A : matrix l m α) (B : matrix n p α) (i₁
 /-- `matrix.kronecker` as a bilinear map. -/
 def kronecker_bilinear [comm_semiring R] [semiring α] [algebra R α] :
   matrix l m α →ₗ[R] matrix n p α →ₗ[R] matrix (l × n) (m × p) α :=
-kronecker_map_linear (algebra.lmul R α).to_linear_map
+kronecker_map_bilinear (algebra.lmul R α).to_linear_map
 
 /-! What follows is a copy, in order, of every `matrix.kronecker_map` lemma above that has
 hypotheses which can be filled by properties of `*`. -/
@@ -234,7 +234,7 @@ kronecker_map_one_one _ zero_mul mul_zero (one_mul _)
 lemma mul_kronecker_mul [comm_semiring α]
   (A : matrix l m α) (B : matrix m n α) (A' : matrix l' m' α) (B' : matrix m' n' α) :
   (A ⬝ B) ⊗ₖ (A' ⬝ B') = (A ⊗ₖ A') ⬝ (B ⊗ₖ B') :=
-kronecker_map_linear_mul_mul (algebra.lmul ℕ α).to_linear_map mul_mul_mul_comm A B A' B'
+kronecker_map_bilinear_mul_mul (algebra.lmul ℕ α).to_linear_map mul_mul_mul_comm A B A' B'
 
 @[simp] lemma kronecker_assoc [semigroup α] (A : matrix l m α) (B : matrix n p α)
   (C : matrix q r α) : reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r) ((A ⊗ₖ B) ⊗ₖ C) =
@@ -274,7 +274,7 @@ lemma kronecker_tmul_apply (A : matrix l m α) (B : matrix n p β) (i₁ i₂ j�
 /-- `matrix.kronecker` as a bilinear map. -/
 def kronecker_tmul_bilinear :
   matrix l m α →ₗ[R] matrix n p β →ₗ[R] matrix (l × n) (m × p) (α ⊗[R] β) :=
-kronecker_map_linear (tensor_product.mk R α β)
+kronecker_map_bilinear (tensor_product.mk R α β)
 
 /-! What follows is a copy, in order, of every `matrix.kronecker_map` lemma above that has
 hypotheses which can be filled by properties of `⊗ₜ`. -/
@@ -329,7 +329,7 @@ kronecker_map_one_one _ (zero_tmul _) (tmul_zero _) rfl
 lemma mul_kronecker_tmul_mul
   (A : matrix l m α) (B : matrix m n α) (A' : matrix l' m' β) (B' : matrix m' n' β) :
   (A ⬝ B) ⊗ₖₜ[R] (A' ⬝ B') = (A ⊗ₖₜ A') ⬝ (B ⊗ₖₜ B') :=
-kronecker_map_linear_mul_mul (tensor_product.mk R α β) tmul_mul_tmul A B A' B'
+kronecker_map_bilinear_mul_mul (tensor_product.mk R α β) tmul_mul_tmul A B A' B'
 
 end algebra
 

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -44,7 +44,7 @@ namespace matrix
 open_locale matrix
 
 variables {R α α' β β' γ γ' : Type*}
-variables {l m n p q r : Type*} [fintype l] [fintype m] [fintype n] [fintype p] [fintype q]
+variables {l m n p : Type*} [fintype l] [fintype m] [fintype n] [fintype p]
 variables {q r : Type*} [fintype q] [fintype r]
 variables {l' m' n' p' : Type*} [fintype l'] [fintype m'] [fintype n'] [fintype p']
 
@@ -155,8 +155,8 @@ begin
 end
 
 lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω')
-  (g' : β → δ → ξ) {q r : Type*} [fintype q] [fintype r] (A : matrix l m α) (B : matrix n p β)
-  (D : matrix q r δ) (φ : ω ≃ ω') (hφ : ∀ a b d, φ (g (f a b) d ) = f' a (g' b d )) :
+  (g' : β → δ → ξ) (A : matrix l m α) (B : matrix n p β) (D : matrix q r δ) (φ : ω ≃ ω')
+  (hφ : ∀ a b d, φ (g (f a b) d ) = f' a (g' b d )) :
   (reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)).trans (equiv.map_matrix φ)
     (kronecker_map g (kronecker_map f A B) D) = kronecker_map f' A (kronecker_map g' B D) :=
 begin


### PR DESCRIPTION
Added two lemmas `kronecker_map_assoc` and `kronecker_assoc` showing associativity of the Kronecker product

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
