### PR TITLE
[Merged by Bors] - refactor(data/nat/lattice): move code, add lemmas

### DIFF
--- a/src/data/nat/lattice.lean
+++ b/src/data/nat/lattice.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Floris van Doorn, Gabriel Ebner, Yury Kudryashov
+-/
+import data.nat.enat
+import order.conditionally_complete_lattice
+
+/-!
+# Conditionally complete linear order structure on `ℕ`
+
+In this file we
+
+* define a `conditionally_complete_linear_order_bot` structure on `ℕ`;
+* define a `complete_linear_order` structure on `enat`;
+* prove a few lemmas about `supr`/`infi`/`set.Union`/`set.Inter` and natural numbers.
+-/
+
+open set
+
+namespace nat
+
+open_locale classical
+
+noncomputable instance : has_Inf ℕ :=
+⟨λs, if h : ∃n, n ∈ s then @nat.find (λn, n ∈ s) _ h else 0⟩
+
+noncomputable instance : has_Sup ℕ :=
+⟨λs, if h : ∃n, ∀a∈s, a ≤ n then @nat.find (λn, ∀a∈s, a ≤ n) _ h else 0⟩
+
+lemma Inf_def {s : set ℕ} (h : s.nonempty) : Inf s = @nat.find (λn, n ∈ s) _ h :=
+dif_pos _
+
+lemma Sup_def {s : set ℕ} (h : ∃n, ∀a∈s, a ≤ n) :
+  Sup s = @nat.find (λn, ∀a∈s, a ≤ n) _ h :=
+dif_pos _
+
+@[simp] lemma Inf_eq_zero {s : set ℕ} : Inf s = 0 ↔ 0 ∈ s ∨ s = ∅ :=
+begin
+  cases eq_empty_or_nonempty s,
+  { subst h, simp only [or_true, eq_self_iff_true, iff_true, Inf, has_Inf.Inf,
+      mem_empty_eq, exists_false, dif_neg, not_false_iff] },
+  { have := ne_empty_iff_nonempty.mpr h,
+    simp only [this, or_false, nat.Inf_def, h, nat.find_eq_zero] }
+end
+
+lemma Inf_mem {s : set ℕ} (h : s.nonempty) : Inf s ∈ s :=
+by { rw [nat.Inf_def h], exact nat.find_spec h }
+
+lemma not_mem_of_lt_Inf {s : set ℕ} {m : ℕ} (hm : m < Inf s) : m ∉ s :=
+begin
+  cases eq_empty_or_nonempty s,
+  { subst h, apply not_mem_empty },
+  { rw [nat.Inf_def h] at hm, exact nat.find_min h hm }
+end
+
+protected lemma Inf_le {s : set ℕ} {m : ℕ} (hm : m ∈ s) : Inf s ≤ m :=
+by { rw [nat.Inf_def ⟨m, hm⟩], exact nat.find_min' ⟨m, hm⟩ hm }
+
+lemma nonempty_of_pos_Inf {s : set ℕ} (h : 0 < Inf s) : s.nonempty :=
+begin
+  by_contradiction contra, rw set.not_nonempty_iff_eq_empty at contra,
+  have h' : Inf s ≠ 0, { exact ne_of_gt h, }, apply h',
+  rw nat.Inf_eq_zero, right, assumption,
+end
+
+lemma nonempty_of_Inf_eq_succ {s : set ℕ} {k : ℕ} (h : Inf s = k + 1) : s.nonempty :=
+nonempty_of_pos_Inf (h.symm ▸ (succ_pos k) : Inf s > 0)
+
+lemma eq_Ici_of_nonempty_of_upward_closed {s : set ℕ} (hs : s.nonempty)
+  (hs' : ∀ (k₁ k₂ : ℕ), k₁ ≤ k₂ → k₁ ∈ s → k₂ ∈ s) : s = Ici (Inf s) :=
+ext (λ n, ⟨λ H, nat.Inf_le H, λ H, hs' (Inf s) n H (Inf_mem hs)⟩)
+
+lemma Inf_upward_closed_eq_succ_iff {s : set ℕ}
+  (hs : ∀ (k₁ k₂ : ℕ), k₁ ≤ k₂ → k₁ ∈ s → k₂ ∈ s) (k : ℕ) :
+  Inf s = k + 1 ↔ k + 1 ∈ s ∧ k ∉ s :=
+begin
+  split,
+  { intro H,
+    rw [eq_Ici_of_nonempty_of_upward_closed (nonempty_of_Inf_eq_succ H) hs, H, mem_Ici, mem_Ici],
+    exact ⟨le_refl _, k.not_succ_le_self⟩, },
+  { rintro ⟨H, H'⟩,
+    rw [Inf_def (⟨_, H⟩ : s.nonempty), find_eq_iff],
+    exact ⟨H, λ n hnk hns, H' $ hs n k (lt_succ_iff.mp hnk) hns⟩, },
+end
+
+/-- This instance is necessary, otherwise the lattice operations would be derived via
+conditionally_complete_linear_order_bot and marked as noncomputable. -/
+instance : lattice ℕ := lattice_of_linear_order
+
+noncomputable instance : conditionally_complete_linear_order_bot ℕ :=
+{ Sup := Sup, Inf := Inf,
+  le_cSup    := assume s a hb ha, by rw [Sup_def hb]; revert a ha; exact @nat.find_spec _ _ hb,
+  cSup_le    := assume s a hs ha, by rw [Sup_def ⟨a, ha⟩]; exact nat.find_min' _ ha,
+  le_cInf    := assume s a hs hb,
+    by rw [Inf_def hs]; exact hb (@nat.find_spec (λn, n ∈ s) _ _),
+  cInf_le    := assume s a hb ha, by rw [Inf_def ⟨a, ha⟩]; exact nat.find_min' _ ha,
+  cSup_empty :=
+  begin
+    simp only [Sup_def, set.mem_empty_eq, forall_const, forall_prop_of_false, not_false_iff,
+      exists_const],
+    apply bot_unique (nat.find_min' _ _),
+    trivial
+  end,
+  .. (infer_instance : order_bot ℕ), .. (lattice_of_linear_order : lattice ℕ),
+  .. (infer_instance : linear_order ℕ) }
+
+section
+
+variables {α : Type*} [complete_lattice α]
+
+lemma supr_lt_succ (u : ℕ → α) (n : ℕ) : (⨆ k < n + 1, u k) = (⨆ k < n, u k) ⊔ u n :=
+by simp [nat.lt_succ_iff_lt_or_eq, supr_or, supr_sup_eq]
+
+lemma supr_lt_succ' (u : ℕ → α) (n : ℕ) : (⨆ k < n + 1, u k) = u 0 ⊔ (⨆ k < n, u (k + 1)) :=
+by { rw ← sup_supr_nat_succ, simp }
+
+lemma infi_lt_succ (u : ℕ → α) (n : ℕ) : (⨅ k < n + 1, u k) = (⨅ k < n, u k) ⊓ u n :=
+@supr_lt_succ (order_dual α) _ _ _
+
+lemma infi_lt_succ' (u : ℕ → α) (n : ℕ) : (⨅ k < n + 1, u k) = u 0 ⊓ (⨅ k < n, u (k + 1)) :=
+@supr_lt_succ' (order_dual α) _ _ _
+
+end
+
+end nat
+
+namespace set
+
+variable {α : Type*}
+
+lemma bUnion_lt_succ (u : ℕ → set α) (n : ℕ) : (⋃ k < n + 1, u k) = (⋃ k < n, u k) ∪ u n :=
+nat.supr_lt_succ u n
+
+lemma bUnion_lt_succ' (u : ℕ → set α) (n : ℕ) : (⋃ k < n + 1, u k) = u 0 ∪ (⋃ k < n, u (k + 1)) :=
+nat.supr_lt_succ' u n
+
+lemma bInter_lt_succ (u : ℕ → set α) (n : ℕ) : (⋂ k < n + 1, u k) = (⋂ k < n, u k) ∩ u n :=
+nat.infi_lt_succ u n
+
+lemma bInter_lt_succ' (u : ℕ → set α) (n : ℕ) : (⋂ k < n + 1, u k) = u 0 ∩ (⋂ k < n, u (k + 1)) :=
+nat.infi_lt_succ' u n
+
+end set
+
+namespace enat
+open_locale classical
+
+noncomputable instance : complete_linear_order enat :=
+{ .. enat.linear_order,
+  .. with_top_order_iso.symm.to_galois_insertion.lift_complete_lattice }
+
+end enat

--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -544,13 +544,6 @@ theorem bInter_insert (a : α) (s : set α) (t : α → set β) :
   (⋂ x ∈ insert a s, t x) = t a ∩ (⋂ x ∈ s, t x) :=
 by simp
 
-lemma bInter_lt_succ (f : ℕ → set α) (n : ℕ) : (⋂ i < n.succ, f i) = f n ∩ (⋂ i < n, f i) :=
-ext $ λ a, begin
-  rw mem_inter_iff,
-  simp_rw [mem_Inter, nat.lt_succ_iff_lt_or_eq, or_imp_distrib],
-  rw [forall_and_distrib, forall_eq, and_comm],
-end
-
 -- TODO(Jeremy): another example of where an annotation is needed
 
 theorem bInter_pair (a b : α) (s : α → set β) :
@@ -596,13 +589,6 @@ supr_union
 theorem bUnion_insert (a : α) (s : set α) (t : α → set β) :
   (⋃ x ∈ insert a s, t x) = t a ∪ (⋃ x ∈ s, t x) :=
 by simp
-
-lemma bUnion_lt_succ (f : ℕ → set α) (n : ℕ) : (⋃ i < n.succ, f i) = f n ∪ (⋃ i < n, f i) :=
-ext $ λ a, begin
-  rw mem_union,
-  simp_rw [mem_Union, exists_prop, nat.lt_succ_iff_lt_or_eq, or_and_distrib_right],
-  rw [exists_or_distrib, exists_eq_left, or_comm],
-end
 
 theorem bUnion_pair (a b : α) (s : α → set β) :
   (⋃ x ∈ ({a, b} : set α), s x) = s a ∪ s b :=

--- a/src/measure_theory/measure/outer_measure.lean
+++ b/src/measure_theory/measure/outer_measure.lean
@@ -690,8 +690,8 @@ lemma is_caratheodory_Union_lt {s : ℕ → set α} :
   ∀{n:ℕ}, (∀i<n, is_caratheodory (s i)) → is_caratheodory (⋃i<n, s i)
 | 0       h := by simp [nat.not_lt_zero]
 | (n + 1) h := by rw bUnion_lt_succ; exact is_caratheodory_union m
-  (h n (le_refl (n + 1)))
-      (is_caratheodory_Union_lt $ assume i hi, h i $ lt_of_lt_of_le hi $ nat.le_succ _)
+    (is_caratheodory_Union_lt $ assume i hi, h i $ lt_of_lt_of_le hi $ nat.le_succ _)
+    (h n (le_refl (n + 1)))
 
 lemma is_caratheodory_inter (h₁ : is_caratheodory s₁) (h₂ : is_caratheodory s₂) :
   is_caratheodory (s₁ ∩ s₂) :=
@@ -703,10 +703,10 @@ lemma is_caratheodory_sum {s : ℕ → set α} (h : ∀i, is_caratheodory (s i))
   ∀ {n}, ∑ i in finset.range n, m (t ∩ s i) = m (t ∩ ⋃i<n, s i)
 | 0            := by simp [nat.not_lt_zero, m.empty]
 | (nat.succ n) := begin
-  simp [bUnion_lt_succ, range_succ],
-  rw [measure_inter_union m _ (h n), is_caratheodory_sum],
+  rw [bUnion_lt_succ, finset.sum_range_succ, set.union_comm, is_caratheodory_sum,
+    m.measure_inter_union _ (h n), add_comm],
   intro a,
-  simpa [range_succ] using λ (h₁ : a ∈ s n) i (hi : i < n) h₂, hd _ _ (ne_of_gt hi) ⟨h₁, h₂⟩
+  simpa using λ (h₁ : a ∈ s n) i (hi : i < n) h₂, hd _ _ (ne_of_gt hi) ⟨h₁, h₂⟩
 end
 
 lemma is_caratheodory_Union_nat {s : ℕ → set α} (h : ∀i, is_caratheodory (s i))

--- a/src/order/filter/partial.lean
+++ b/src/order/filter/partial.lean
@@ -6,6 +6,7 @@ Authors: Jeremy Avigad
 Extends `tendsto` to relations and partial functions.
 -/
 import order.filter.basic
+import data.pfun
 
 universes u v w
 namespace filter

--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro
 -/
 import data.equiv.denumerable
 import order.preorder_hom
-import order.conditionally_complete_lattice
+import data.nat.lattice
 
 /-!
 # Relation embeddings from the naturals


### PR DESCRIPTION
* move `nat.conditionally_complete_linear_order_with_bot` and `enat.complete_linear_order` to a new file `data.nat.lattice`;
* add a few lemmas (`nat.supr_lt_succ` etc), move `set.bUnion_lt_succ` to the same file;
* use `galois_insertion.lift_complete_lattice` to define `enat.complete_linear_order`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
