### PR TITLE
[Merged by Bors] - doc({topology.algebra.weak_dual_topology, analysis.normed_space.weak_dual}): fix docstrings

### DIFF
--- a/src/analysis/normed_space/weak_dual.lean
+++ b/src/analysis/normed_space/weak_dual.lean
@@ -10,11 +10,14 @@ import analysis.normed_space.operator_norm
 /-!
 # Weak dual of normed space
 
-This file proves properties of the weak-* topology on the dual of a normed space `E`.
+Let `E` be a normed space over a field `𝕜`. This file is concerned with properties of the weak-*
+topology on the dual of `E`. By the dual, we mean either of the type synonyms
+`normed_space.dual 𝕜 E` or `weak_dual 𝕜 E`, depending on whether it is viewed as equipped with its
+usual operator norm topology or the weak-* topology.
 
-It is shown that the canonical mapping `dual 𝕜 E → weak_dual 𝕜 E` is continuous, and as a
-consequence the weak-* topology is coarser than the topology obtained from the dual norm (operator
-norm).
+It is shown that the canonical mapping `normed_space.dual 𝕜 E → weak_dual 𝕜 E` is continuous, and
+as a consequence the weak-* topology is coarser than the topology obtained from the operator norm
+(dual norm).
 
 The file is a stub, some TODOs below.
 

--- a/src/analysis/normed_space/weak_dual.lean
+++ b/src/analysis/normed_space/weak_dual.lean
@@ -10,31 +10,36 @@ import analysis.normed_space.operator_norm
 /-!
 # Weak dual of normed space
 
-This file proves properties of the weak-* topology on the dual of a normed space.
+This file proves properties of the weak-* topology on the dual of a normed space `E`.
 
-It is shown that the canconical mapping `dual 𝕜 E → weak_dual 𝕜 E` is continuous, and as a
-consequence the weak-* topology is coarser than the topology induced by the dual norm (operator
+It is shown that the canonical mapping `dual 𝕜 E → weak_dual 𝕜 E` is continuous, and as a
+consequence the weak-* topology is coarser than the topology obtained from the dual norm (operator
 norm).
+
+The file is a stub, some TODOs below.
 
 ## Main definitions
 
 The main definitions concern the canonical mapping `dual 𝕜 E → weak_dual 𝕜 E`.
 
-* `to_weak_dual` is a linear equivalence from `dual 𝕜 E`to `weak_dual 𝕜 E`.
-* `continuous_linear_map_to_weak_dual` is a continuous linear mapping from
-  `dual 𝕜 E` to `weak_dual 𝕜 E`.
+* `normed_space.dual.to_weak_dual` and `weak_dual.to_normed_dual`: Linear equivalences from
+  `dual 𝕜 E` to `weak_dual 𝕜 E` and in the converse direction.
+* `normed_space.dual.continuous_linear_map_to_weak_dual`: A continuous linear mapping from
+  `dual 𝕜 E` to `weak_dual 𝕜 E` (same as `normed_space.dual.to_weak_dual` but different bundled
+  data).
 
 ## Main results
 
-The file is a stub.
-
-The first main results concern the comparison of the operator norm topology on `dual 𝕜 E` and the
+The first main result concerns the comparison of the operator norm topology on `dual 𝕜 E` and the
 weak-* topology on (its type synonym) `weak_dual 𝕜 E`:
-* `dual_norm_topology_le_weak_dual_topology` is the statement that the weak-* topology on the dual
-  of a normed space is coarser (not necessarily strictly) than the operator norm topology.
+* `dual_norm_topology_le_weak_dual_topology`: The weak-* topology on the dual of a normed space is
+  coarser (not necessarily strictly) than the operator norm topology.
 
 TODOs:
-* Add Banach-Alaoglu theorem.
+* Add that in finite dimensions, the weak-* topology and the dual norm topology coincide.
+* Add that in infinite dimensions, the weak-* topology is strictly coarser than the dual norm
+  topology.
+* Add Banach-Alaoglu theorem (general version maybe in `topology.algebra.weak_dual_topology`).
 * Add metrizability of the dual unit ball (more generally bounded subsets) of `weak_dual 𝕜 E`
   under the assumption of separability of `E`. Sequential Banach-Alaoglu theorem would then follow
   from the general one.
@@ -45,7 +50,7 @@ No new notation is introduced.
 
 ## Implementation notes
 
-Weak-* topology is defined generally in the file <topology.algebra.weak_dual_topology>.
+Weak-* topology is defined generally in the file `topology.algebra.weak_dual_topology`.
 
 When `E` is a normed space, the duals `dual 𝕜 E` and `weak_dual 𝕜 E` are type synonyms with
 different topology instances.
@@ -79,13 +84,13 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
 
 /-- For normed spaces `E`, there is a canonical map `dual 𝕜 E → weak_dual 𝕜 E` (the "identity"
-    mapping). It is a linear equivalence. -/
+mapping). It is a linear equivalence. -/
 def normed_space.dual.to_weak_dual : dual 𝕜 E ≃ₗ[𝕜] weak_dual 𝕜 E :=
 linear_equiv.refl 𝕜 (E →L[𝕜] 𝕜)
 
 /-- For normed spaces `E`, there is a canonical map `weak_dual 𝕜 E → dual 𝕜 E` (the "identity"
-    mapping). It is a linear equivalence. Here it is implemented as the inverse of the linear
-    equivalence `normed_space.dual.to_weak_dual` in the other direction. -/
+mapping). It is a linear equivalence. Here it is implemented as the inverse of the linear
+equivalence `normed_space.dual.to_weak_dual` in the other direction. -/
 def weak_dual.to_normed_dual : weak_dual 𝕜 E ≃ₗ[𝕜] dual 𝕜 E :=
 normed_space.dual.to_weak_dual.symm
 
@@ -111,8 +116,8 @@ begin
 end
 
 /-- For a normed space `E`, according to `to_weak_dual_continuous` the "identity mapping"
-`dual 𝕜 E → weak_dual 𝕜 E` is continuous. The following definition implements it as a continuous
-linear map. -/
+`dual 𝕜 E → weak_dual 𝕜 E` is continuous. This definition implements it as a continuous linear
+map. -/
 def continuous_linear_map_to_weak_dual : dual 𝕜 E →L[𝕜] weak_dual 𝕜 E :=
 { cont := to_weak_dual_continuous, .. to_weak_dual, }
 

--- a/src/topology/algebra/weak_dual_topology.lean
+++ b/src/topology/algebra/weak_dual_topology.lean
@@ -93,7 +93,8 @@ continuous_linear_map.add_comm_monoid
 namespace weak_dual
 
 /-- The weak-* topology instance `weak_dual.topological_space` on the dual of a topological module
-`E` over a topological semiring `𝕜` is defined as the induced topology under the mapping that associates to a dual element `x' : weak_dual 𝕜 E` the functional `E → 𝕜`, when the space `E → 𝕜`
+`E` over a topological semiring `𝕜` is defined as the induced topology under the mapping that
+associates to a dual element `x' : weak_dual 𝕜 E` the functional `E → 𝕜`, when the space `E → 𝕜`
 of functionals is equipped with the topology of pointwise convergence (product topology). -/
 instance : topological_space (weak_dual 𝕜 E) :=
 topological_space.induced (λ x' : weak_dual 𝕜 E, λ z : E, x' z) Pi.topological_space

--- a/src/topology/algebra/weak_dual_topology.lean
+++ b/src/topology/algebra/weak_dual_topology.lean
@@ -19,26 +19,27 @@ The weak dual is a module over `𝕜` if the semiring `𝕜` is commutative.
 
 The main definitions are the type `weak_dual 𝕜 E` and a topology instance on it.
 
-* `weak_dual 𝕜 E` is a type synonym for `dual 𝕜 E` (when the latter is defined), both are equal to
+* `weak_dual 𝕜 E` is a type synonym for `dual 𝕜 E` (when the latter is defined): both are equal to
   the type `E →L[𝕜] 𝕜` of continuous linear maps from a module `E` over `𝕜` to the ring `𝕜`.
-* the instance `topological_space (weak_dual 𝕜 E)` is the weak-* topology on `weak_dual 𝕜 E`, i.e.,
-  the coarsest topology making the evaluation maps at all `z : E` are continuous.
+* The instance `weak_dual.topological_space` is the weak-* topology on `weak_dual 𝕜 E`, i.e., the
+  coarsest topology making the evaluation maps at all `z : E` continuous.
 
 ## Main results
 
 We establish that `weak_dual 𝕜 E` has the following structure:
-* The addition in `weak_dual 𝕜 E` is continuous, i.e. we have `has_continuous_add (weak_dual 𝕜 E)`.
-* If the scalars `𝕜` are a commutative semiring, then `weak_dual 𝕜 E` is a module over `𝕜`.
-* If the scalars `𝕜` are a commutative semiring, then the scalar multiplication by `𝕜` in
-  `weak_dual 𝕜 E` is continuous, i.e. we have `has_continuous_smul 𝕜 (weak_dual 𝕜 E)`.
+* `weak_dual.has_continuous_add`: The addition in `weak_dual 𝕜 E` is continuous.
+* `weak_dual.module`: If the scalars `𝕜` are a commutative semiring, then `weak_dual 𝕜 E` is a
+  module over `𝕜`.
+* `weak_dual.has_continuous_smul`: If the scalars `𝕜` are a commutative semiring, then the scalar
+  multiplication by `𝕜` in `weak_dual 𝕜 E` is continuous.
 
 We prove the following results characterizing the weak-* topology:
-* `eval_continuous` shows that for any `z : E`, the evaluation mapping `weak_dual 𝕜 E → 𝕜`
-  taking `x'`to `x' z` is continuous.
-* `continuous_of_continuous_eval` shows that for a mapping to `weak_dual 𝕜 E → 𝕜` to be continuous,
-  it is sufficient that its compositions with evaluations at all points `z : E` are continuous
-* `tendsto_iff_forall_eval_tendsto` is a characterization of convergence in `weak_dual 𝕜 E` in
-  terms of convergence of the evaluations at all points `z : E`
+* `weak_dual.eval_continuous`: For any `z : E`, the evaluation mapping `weak_dual 𝕜 E → 𝕜` taking
+  `x'`to `x' z` is continuous.
+* `weak_dual.continuous_of_continuous_eval`: For a mapping to `weak_dual 𝕜 E` to be continuous,
+  it suffices that its compositions with evaluations at all points `z : E` are continuous.
+* `weak_dual.tendsto_iff_forall_eval_tendsto`: Convergence in `weak_dual 𝕜 E` can be characterized
+  in terms of convergence of the evaluations at all points `z : E`.
 
 ## Notations
 
@@ -50,12 +51,12 @@ The weak-* topology is defined as the induced topology under the mapping that as
 element `x'` the functional `E → 𝕜`, when the space `E → 𝕜` of functionals is equipped with the
 topology of pointwise convergence (product topology).
 
-Typically one might assumes that `𝕜` is a topological semiring in the sense of the typeclasses
- `topological_space 𝕜`, `semiring 𝕜`, `has_continuous_add 𝕜`, `has_continuous_mul 𝕜`,
+Typically one might assume that `𝕜` is a topological semiring in the sense of the typeclasses
+`topological_space 𝕜`, `semiring 𝕜`, `has_continuous_add 𝕜`, `has_continuous_mul 𝕜`,
 and that the space `E` is a topological module over `𝕜` in the sense of the typeclasses
 `topological_space E`, `add_comm_monoid E`, `has_continuous_add E`, `module 𝕜 E`,
-`has_continuous_smul 𝕜 E`. The definitions and results are, however, given with suitable subsets
-of these assumptions.
+`has_continuous_smul 𝕜 E`. The definitions and results are, however, given with weaker assumptions
+when possible.
 
 ## References
 
@@ -74,22 +75,15 @@ open_locale topological_space
 section weak_star_topology
 /-!
 ### Weak star topology on duals of topological modules
-In this section, we define the weak-* topology on duals of suitable topological modules `E` over
-suitable topological semirings `𝕜`. The (weak) dual `weak_dual 𝕜 E` consists of continuous linear
-functionals `E →L[𝕜] 𝕜` from `E` to scalars `𝕜`. The weak-* topology is the coarsest topology on
-this dual `weak_dual 𝕜 E := (E →L[𝕜] 𝕜)` w.r.t. which the evaluation maps at all `z : E` are
-continuous.
-
-The weak dual is a module over `𝕜` if the semiring `𝕜` is commutative.
 -/
 
 universe variables u v
 variables (𝕜 : Type*) [topological_space 𝕜] [semiring 𝕜]
 variables (E : Type*) [topological_space E] [add_comm_monoid E] [module 𝕜 E]
 
-/-- The (weak) dual of a topological module `E` over a topological semiring `𝕜` consists of
-continuous linear functionals from `E` to scalars `𝕜`. It is a type synonym with the original
-dual, but will be equipped with a different topology. -/
+/-- The weak dual of a topological module `E` over a topological semiring `𝕜` consists of
+continuous linear functionals from `E` to scalars `𝕜`. It is a type synonym with the usual dual
+(when the latter is defined), but will be equipped with a different topology. -/
 @[derive [inhabited, has_coe_to_fun]]
 def weak_dual := E →L[𝕜] 𝕜
 
@@ -98,10 +92,9 @@ continuous_linear_map.add_comm_monoid
 
 namespace weak_dual
 
-/-- The weak-* topology instance `weak_dual_topology` on the dual of a topological module `E` over
-a topological semiring `𝕜` is defined as the induced topology under the mapping that associates to
-a dual element `x' : weak_dual 𝕜 E` the functional `E → 𝕜`, when the space `E → 𝕜` of functionals
-is equipped with the topology of pointwise convergence (product topology). -/
+/-- The weak-* topology instance `weak_dual.topological_space` on the dual of a topological module
+`E` over a topological semiring `𝕜` is defined as the induced topology under the mapping that associates to a dual element `x' : weak_dual 𝕜 E` the functional `E → 𝕜`, when the space `E → 𝕜`
+of functionals is equipped with the topology of pointwise convergence (product topology). -/
 instance : topological_space (weak_dual 𝕜 E) :=
 topological_space.induced (λ x' : weak_dual 𝕜 E, λ z : E, x' z) Pi.topological_space
 


### PR DESCRIPTION
Fixing docstrings from the recently merged PR #8598 on weak-* topology.

---

Some of my mistakes in the docstrings of #8598 were due to forgetting to rename defs and theorems in the docstrings when they were renamed in the code. These mistakes should be fixed in this PR. Other included corrections address misprints and clarity.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
