### PR TITLE
[Merged by Bors] - feat(ring_theory/dedekind_domain): prime elements of `ideal A` are the prime ideals

### DIFF
--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -677,7 +677,7 @@ begin
     rw ← ideal.one_eq_top at h,
     exact h.not_unit is_unit_one },
   { simp only [← ideal.dvd_span_singleton, ← ideal.span_singleton_mul_span_singleton] at ⊢ hxy,
-    exact h.div_or_div hxy }
+    exact h.dvd_or_dvd hxy }
 end
 
 theorem ideal.prime_of_is_prime {P : ideal A} (hP : P ≠ ⊥) (h : is_prime P) : prime P :=

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -666,4 +666,30 @@ instance ideal.unique_factorization_monoid :
 noncomputable instance ideal.normalization_monoid : normalization_monoid (ideal A) :=
 normalization_monoid_of_unique_units
 
+@[simp] lemma ideal.dvd_span_singleton {I : ideal A} {x : A} :
+  I ∣ ideal.span {x} ↔ x ∈ I :=
+ideal.dvd_iff_le.trans (ideal.span_le.trans set.singleton_subset_iff)
+
+lemma ideal.is_prime_of_prime {P : ideal A} (h : prime P) : is_prime P :=
+begin
+  refine ⟨_, λ x y hxy, _⟩,
+  { unfreezingI { rintro rfl },
+    rw ← ideal.one_eq_top at h,
+    exact h.not_unit is_unit_one },
+  { simp only [← ideal.dvd_span_singleton, ← ideal.span_singleton_mul_span_singleton] at ⊢ hxy,
+    exact h.div_or_div hxy }
+end
+
+theorem ideal.prime_of_is_prime {P : ideal A} (hP : P ≠ ⊥) (h : is_prime P) : prime P :=
+begin
+  refine ⟨hP, mt ideal.is_unit_iff.mp h.ne_top, λ I J hIJ, _⟩,
+  simpa only [ideal.dvd_iff_le] using (h.mul_le.mp (ideal.le_of_dvd hIJ)),
+end
+
+/-- In a Dedekind domain, the (nonzero) prime elements of the monoid with zero `ideal A`
+are exactly the prime ideals. -/
+theorem ideal.prime_iff_is_prime {P : ideal A} (hP : P ≠ ⊥) :
+  prime P ↔ is_prime P :=
+⟨ideal.is_prime_of_prime, ideal.prime_of_is_prime hP⟩
+
 end is_dedekind_domain


### PR DESCRIPTION
This shows that Dedekind domains have unique factorization into prime *ideals*, not just prime *elements* of the monoid `ideal A`.

After some thinking, I believe Dedekind domains are the most common setting in which this equality hold. If anyone has a reference showing how to generalize this, that would be much appreciated.

---

- [x] depends on: #8556 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
