### PR TITLE
[Merged by Bors] - feat(linear_algebra/determinant): `det (M ⬝ N) = det (N ⬝ M)` if `M` is invertible

### DIFF
--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -94,7 +94,7 @@ lemma det_conj [decidable_eq m] [decidable_eq n]
   {M : matrix m n A} {M' : matrix n m A} {N : matrix n n A}
   (hMM' : M ⬝ M' = 1) (hM'M : M' ⬝ M = 1) :
   det (M ⬝ N ⬝ M') = det N :=
-by rw [← det_comm hM'M hMM', ← matrix.mul_assoc, hM'M, matrix.one_mul]
+by rw [← det_comm' hM'M hMM', ← matrix.mul_assoc, hM'M, matrix.one_mul]
 
 end matrix
 

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -94,19 +94,16 @@ begin
 end
 
 /-- If there exists a two-sided inverse `M'` for `M` (indexed differently),
-then `det (Mᵀ ⬝ N ⬝ M) = det (M ⬝ Mᵀ) * det N`.
-Compare `matrix.det_conj`, where we use `M'` instead of `Mᵀ`.
--/
-lemma det_transpose_conj [decidable_eq m] [decidable_eq n]
-  {N : matrix n n A} {M : matrix n m A} {M' : matrix m n A}
+then `det (N ⬝ M) = det (M ⬝ N)`. -/
+lemma det_comm [decidable_eq m] [decidable_eq n]
+  {M : matrix n m A} {N : matrix m n A} {M' : matrix m n A}
   (hMM' : M ⬝ M' = 1) (hM'M : M' ⬝ M = 1) :
-  det (Mᵀ ⬝ N ⬝ M) = det (M ⬝ Mᵀ) * det N :=
+  det (M ⬝ N) = det (N ⬝ M) :=
 begin
-  rw ← det_conj hMM' hM'M,
-  calc (M ⬝ (Mᵀ ⬝ N ⬝ M) ⬝ M').det
-      = ((M ⬝ Mᵀ) ⬝ (N ⬝ (M ⬝ M'))).det : by simp only [matrix.mul_assoc]
-  ... = ((M ⬝ Mᵀ) ⬝ N).det : by rw [hMM', matrix.mul_one]
-  ... = det (M ⬝ Mᵀ) * det N : det_mul _ _
+  rw ← det_conj hM'M hMM',
+  calc det (M' ⬝ (M ⬝ N) ⬝ M)
+      = det ((M' ⬝ M) ⬝ (N ⬝ M)) : by simp only [matrix.mul_assoc]
+  ... = det (N ⬝ M) : by rw [hM'M, matrix.one_mul]
 end
 
 end matrix

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -74,37 +74,24 @@ def index_equiv_of_inv [decidable_eq m] [decidable_eq n]
   m ≃ n :=
 equiv_of_pi_lequiv_pi (to_lin'_of_inv hMM' hM'M)
 
-/-- If `M'` is a two-sided inverse for `M` (indexed differently), `det (M ⬝ N ⬝ M') = det N`. -/
-lemma det_conj [decidable_eq m] [decidable_eq n]
-  {M : matrix m n A} {M' : matrix n m A} {N : matrix n n A}
-  (hMM' : M ⬝ M' = 1) (hM'M : M' ⬝ M = 1) :
-  det (M ⬝ N ⬝ M') = det N :=
-begin
-  -- Although `m` and `n` are different a priori, we will show they have the same cardinality.
-  -- This turns the problem into one for square matrices (`matrix.det_units_conj`), which is easy.
-  let e : m ≃ n := index_equiv_of_inv hMM' hM'M,
-  let U : units (matrix n n A) :=
-    ⟨M.minor e.symm (equiv.refl _),
-     M'.minor (equiv.refl _) e.symm,
-     by rw [mul_eq_mul, ←minor_mul_equiv, hMM', minor_one_equiv],
-     by rw [mul_eq_mul, ←minor_mul_equiv, hM'M, minor_one_equiv]⟩,
-  rw [← det_units_conj U N, ← det_minor_equiv_self e.symm],
-  simp only [minor_mul_equiv _ _ _ (equiv.refl n) _, equiv.coe_refl, minor_id_id,
-             units.coe_mk, units.inv_mk]
-end
-
 /-- If there exists a two-sided inverse `M'` for `M` (indexed differently),
 then `det (N ⬝ M) = det (M ⬝ N)`. -/
 lemma det_comm [decidable_eq m] [decidable_eq n]
   {M : matrix n m A} {N : matrix m n A} {M' : matrix m n A}
   (hMM' : M ⬝ M' = 1) (hM'M : M' ⬝ M = 1) :
   det (M ⬝ N) = det (N ⬝ M) :=
-begin
-  rw ← det_conj hM'M hMM',
-  calc det (M' ⬝ (M ⬝ N) ⬝ M)
-      = det ((M' ⬝ M) ⬝ (N ⬝ M)) : by simp only [matrix.mul_assoc]
-  ... = det (N ⬝ M) : by rw [hM'M, matrix.one_mul]
-end
+-- Although `m` and `n` are different a priori, we will show they have the same cardinality.
+-- This turns the problem into one for square matrices, which is easy.
+by rw [← det_minor_equiv_self (index_equiv_of_inv hMM' hM'M),
+       minor_mul_equiv _ _ _ (equiv.refl n) _, det_mul, mul_comm, ← det_mul, ← minor_mul_equiv,
+       equiv.coe_refl, minor_id_id]
+
+/-- If `M'` is a two-sided inverse for `M` (indexed differently), `det (M ⬝ N ⬝ M') = det N`. -/
+lemma det_conj [decidable_eq m] [decidable_eq n]
+  {M : matrix m n A} {M' : matrix n m A} {N : matrix n n A}
+  (hMM' : M ⬝ M' = 1) (hM'M : M' ⬝ M = 1) :
+  det (M ⬝ N ⬝ M') = det N :=
+by rw [← det_comm hM'M hMM', ← matrix.mul_assoc, hM'M, matrix.one_mul]
 
 end matrix
 

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -74,17 +74,20 @@ def index_equiv_of_inv [decidable_eq m] [decidable_eq n]
   m ≃ n :=
 equiv_of_pi_lequiv_pi (to_lin'_of_inv hMM' hM'M)
 
+lemma det_comm [decidable_eq n] (M N : matrix n n A) : det (M ⬝ N) = det (N ⬝ M) :=
+by rw [det_mul, det_mul, mul_comm]
+
 /-- If there exists a two-sided inverse `M'` for `M` (indexed differently),
 then `det (N ⬝ M) = det (M ⬝ N)`. -/
-lemma det_comm [decidable_eq m] [decidable_eq n]
+lemma det_comm' [decidable_eq m] [decidable_eq n]
   {M : matrix n m A} {N : matrix m n A} {M' : matrix m n A}
   (hMM' : M ⬝ M' = 1) (hM'M : M' ⬝ M = 1) :
   det (M ⬝ N) = det (N ⬝ M) :=
 -- Although `m` and `n` are different a priori, we will show they have the same cardinality.
 -- This turns the problem into one for square matrices, which is easy.
-by rw [← det_minor_equiv_self (index_equiv_of_inv hMM' hM'M),
-       minor_mul_equiv _ _ _ (equiv.refl n) _, det_mul, mul_comm, ← det_mul, ← minor_mul_equiv,
-       equiv.coe_refl, minor_id_id]
+let e := index_equiv_of_inv hMM' hM'M in
+by rw [← det_minor_equiv_self e, minor_mul_equiv _ _ _ (equiv.refl n) _, det_comm,
+  ← minor_mul_equiv, equiv.coe_refl, minor_id_id]
 
 /-- If `M'` is a two-sided inverse for `M` (indexed differently), `det (M ⬝ N ⬝ M') = det N`. -/
 lemma det_conj [decidable_eq m] [decidable_eq n]

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -98,7 +98,8 @@ end
 Compare `det_conj`, where we use `M⁻¹` instead of `Mᵀ`.
 -/
 lemma det_transpose_conj [decidable_eq m] [decidable_eq n]
-  {N : matrix n n A} {M : matrix n m A} {M' : matrix m n A} (hMM' : M ⬝ M' = 1) (hM'M : M' ⬝ M = 1) :
+  {N : matrix n n A} {M : matrix n m A} {M' : matrix m n A}
+  (hMM' : M ⬝ M' = 1) (hM'M : M' ⬝ M = 1) :
   det (Mᵀ ⬝ N ⬝ M) = det (M ⬝ Mᵀ) * det N :=
 begin
   rw ← det_conj hMM' hM'M,

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -93,9 +93,9 @@ begin
              units.coe_mk, units.inv_mk]
 end
 
-/-- If `M'` is a two-sided inverse for `M` (indexed differently),
-`det (Mᵀ ⬝ N ⬝ M) = det (M ⬝ Mᵀ) * det N`.
-Compare `det_conj`, where we use `M⁻¹` instead of `Mᵀ`.
+/-- If there exists a two-sided inverse `M'` for `M` (indexed differently),
+then `det (Mᵀ ⬝ N ⬝ M) = det (M ⬝ Mᵀ) * det N`.
+Compare `matrix.det_conj`, where we use `M'` instead of `Mᵀ`.
 -/
 lemma det_transpose_conj [decidable_eq m] [decidable_eq n]
   {N : matrix n n A} {M : matrix n m A} {M' : matrix m n A}


### PR DESCRIPTION
If `M` is a square or invertible matrix, then `det (M ⬝ N) = det (N ⬝ M)`. This is basically just using `mul_comm` on `det M * det N`, except for some tricky rewriting to handle the invertible case.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
