### PR TITLE
[Merged by Bors] - feat(algebra/ordered_monoid): generalize {min,max}_mul_mul_{left,right}

### DIFF
--- a/src/algebra/ordered_monoid.lean
+++ b/src/algebra/ordered_monoid.lean
@@ -788,11 +788,9 @@ section covariant_class_mul_le
 variables [linear_order α]
 
 section has_mul
-
 variable [has_mul α]
 
 section left
-
 variable [covariant_class α α (*) (≤)]
 
 @[to_additive] lemma min_mul_mul_left (a b c : α) : min (a * b) (a * c) = a * min b c :=
@@ -805,7 +803,6 @@ lemma max_mul_mul_left (a b c : α) : max (a * b) (a * c) = a * max b c :=
 end left
 
 section right
-
 variable [covariant_class α α (function.swap (*)) (≤)]
 
 @[to_additive]

--- a/src/algebra/ordered_monoid.lean
+++ b/src/algebra/ordered_monoid.lean
@@ -785,33 +785,57 @@ class linear_ordered_cancel_comm_monoid (α : Type u)
   extends ordered_cancel_comm_monoid α, linear_ordered_comm_monoid α
 
 section covariant_class_mul_le
-variables [cancel_comm_monoid α] [linear_order α] [covariant_class α α (*) (≤)]
+variables [linear_order α]
+
+section has_mul
+
+variable [has_mul α]
+
+section left
+
+variable [covariant_class α α (*) (≤)]
 
 @[to_additive] lemma min_mul_mul_left (a b c : α) : min (a * b) (a * c) = a * min b c :=
 (monotone_id.const_mul' a).map_min.symm
+
+@[to_additive]
+lemma max_mul_mul_left (a b c : α) : max (a * b) (a * c) = a * max b c :=
+(monotone_id.const_mul' a).map_max.symm
+
+end left
+
+section right
+
+variable [covariant_class α α (function.swap (*)) (≤)]
 
 @[to_additive]
 lemma min_mul_mul_right (a b c : α) : min (a * c) (b * c) = min a b * c :=
 (monotone_id.mul_const' c).map_min.symm
 
 @[to_additive]
-lemma max_mul_mul_left (a b c : α) : max (a * b) (a * c) = a * max b c :=
-(monotone_id.const_mul' a).map_max.symm
-
-@[to_additive]
 lemma max_mul_mul_right (a b c : α) : max (a * c) (b * c) = max a b * c :=
 (monotone_id.mul_const' c).map_max.symm
 
+end right
+
+end has_mul
+
+variable [monoid α]
+
 @[to_additive]
-lemma min_le_mul_of_one_le_right {a b : α} (hb : 1 ≤ b) : min a b ≤ a * b :=
+lemma min_le_mul_of_one_le_right [covariant_class α α (*) (≤)] {a b : α} (hb : 1 ≤ b) :
+  min a b ≤ a * b :=
 min_le_iff.2 $ or.inl $ le_mul_of_one_le_right' hb
 
 @[to_additive]
-lemma min_le_mul_of_one_le_left {a b : α} (ha : 1 ≤ a) : min a b ≤ a * b :=
+lemma min_le_mul_of_one_le_left [covariant_class α α (function.swap (*)) (≤)] {a b : α}
+  (ha : 1 ≤ a) : min a b ≤ a * b :=
 min_le_iff.2 $ or.inr $ le_mul_of_one_le_left' ha
 
 @[to_additive]
-lemma max_le_mul_of_one_le {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) : max a b ≤ a * b :=
+lemma max_le_mul_of_one_le [covariant_class α α (*) (≤)]
+  [covariant_class α α (function.swap (*)) (≤)] {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) :
+  max a b ≤ a * b :=
 max_le_iff.2 ⟨le_mul_of_one_le_right' hb, le_mul_of_one_le_left' ha⟩
 
 end covariant_class_mul_le


### PR DESCRIPTION
Before, it has assumptions about `cancel_comm_monoid` for all the lemmas.
In fact, they hold under much weaker `has_mul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
