### PR TITLE
[Merged by Bors] - fix(tactic/tfae): remove unused arg in tfae_have

### DIFF
--- a/src/tactic/tfae.lean
+++ b/src/tactic/tfae.lean
@@ -57,8 +57,7 @@ meta def tfae_have
   (re : parse (((tk "→" <|> tk "->")  *> return arrow.right)      <|>
                ((tk "↔" <|> tk "<->") *> return arrow.left_right) <|>
                ((tk "←" <|> tk "<-")  *> return arrow.left)))
-  (i₂ : parse (with_desc "j" small_nat))
-  (discharger : tactic unit := tactic.solve_by_elim) :
+  (i₂ : parse (with_desc "j" small_nat)) :
   tactic unit := do
     `(tfae %%l) <- target,
     l ← parse_list l,


### PR DESCRIPTION
Since this "discharger" argument is not using the interactive tactic parser, you can only give names of tactics here, and in any case it's unused by the body, so there is no point in specifying the discharger in the first place.