### PR TITLE
[Merged by Bors] - feat(group_theory/nilpotent): add def lemmas, basic lemmas on central series

### DIFF
--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -260,9 +260,9 @@ variable {G}
 
 @[simp] lemma lower_central_series_zero : lower_central_series G 0 = ⊤ := rfl
 
-lemma mem_lower_central_series_succ_iff (n : ℕ) (x : G) :
-  x ∈ lower_central_series G (n + 1) ↔
-  x ∈ closure {x | ∃ (p ∈ lower_central_series G n) (q ∈ (⊤ : subgroup G)), p * q * p⁻¹ * q⁻¹ = x}
+lemma mem_lower_central_series_succ_iff (n : ℕ) (q : G) :
+  q ∈ lower_central_series G (n + 1) ↔
+  q ∈ closure {x | ∃ (p ∈ lower_central_series G n) (q ∈ (⊤ : subgroup G)), p * q * p⁻¹ * q⁻¹ = x}
 := iff.rfl
 
 instance (n : ℕ) : normal (lower_central_series G n) :=

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -122,7 +122,7 @@ def upper_central_series (n : ℕ) : subgroup G := (upper_central_series_aux G n
 
 instance (n : ℕ) : normal (upper_central_series G n) := (upper_central_series_aux G n).2
 
-@[simp] lemma upper_central_series_zero_def : upper_central_series G 0 = ⊥ := rfl
+@[simp] lemma upper_central_series_zero : upper_central_series G 0 = ⊥ := rfl
 
 /-- The `n+1`st term of the upper central series `H i` has underlying set equal to the `x` such
 that `⁅x,G⁆ ⊆ H n`-/
@@ -258,7 +258,7 @@ def lower_central_series (G : Type*) [group G] : ℕ → subgroup G
 
 variable {G}
 
-@[simp] lemma lower_central_series_zero_def : lower_central_series G 0 = ⊤ := rfl
+@[simp] lemma lower_central_series_zero : lower_central_series G 0 = ⊤ := rfl
 
 lemma mem_lower_central_series_succ_iff (n : ℕ) (x : G) :
   x ∈ lower_central_series G (n + 1) ↔

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -260,9 +260,10 @@ variable {G}
 
 @[simp] lemma lower_central_series_zero_def : lower_central_series G 0 = ⊤ := rfl
 
-lemma mem_lower_central_series_succ_iff (n : ℕ) (x : G) : x ∈ lower_central_series G (n + 1) ↔
-  x ∈ closure {x | ∃ (p ∈ lower_central_series G n) (q ∈ (⊤ : subgroup G)), p * q * p⁻¹ * q⁻¹ = x}
-:= iff.rfl
+lemma mem_lower_central_series_succ_iff (n : ℕ) (x : G) :
+  x ∈ lower_central_series G (n + 1) ↔
+    x ∈ closure {x | ∃ (p ∈ lower_central_series G n) (q ∈ (⊤ : subgroup G)), p * q * p⁻¹ * q⁻¹ = x} :=
+iff.rfl
 
 instance (n : ℕ) : normal (lower_central_series G n) :=
 begin

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -311,8 +311,8 @@ lemma subsingleton_is_nilpotent (hG : subsingleton G) : is_nilpotent G :=
  nilpotent_iff_lower_central_series.2 ⟨0, subsingleton.elim ⊤ ⊥⟩
 
 lemma upper_central_series.map {H : Type*} [group H] (f : G →* H)
-(h : function.surjective f) (n : ℕ)
-: subgroup.map f (upper_central_series G n) ≤ upper_central_series H n :=
+  (h : function.surjective f) (n : ℕ) :
+  subgroup.map f (upper_central_series G n) ≤ upper_central_series H n :=
 begin
   induction n with d hd,
   { simp },

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -181,8 +181,8 @@ lemma upper_central_series_is_ascending_central_series :
   is_ascending_central_series (upper_central_series G) :=
 ⟨rfl, λ x n h, h⟩
 
-lemma upper_central_series_mono (n : ℕ)
-: upper_central_series G n ≤ upper_central_series G n.succ :=
+lemma upper_central_series_mono : monotone (upper_central_series G) :=
+monotone_nat_of_le_succ $ λ n,
 begin
   intros x hx y,
   rw [mul_assoc, mul_assoc, ← mul_assoc y x⁻¹ y⁻¹],
@@ -307,7 +307,7 @@ begin
     use [lower_central_series G, lower_central_series_is_descending_central_series, h] },
 end
 
-lemma subsingleton_is_nilpotent (hG : subsingleton G) : is_nilpotent G :=
+lemma subsingleton.is_nilpotent (hG : subsingleton G) : is_nilpotent G :=
  nilpotent_iff_lower_central_series.2 ⟨0, subsingleton.elim ⊤ ⊥⟩
 
 lemma upper_central_series.map {H : Type*} [group H] (f : G →* H)

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -126,7 +126,7 @@ instance (n : ℕ) : normal (upper_central_series G n) := (upper_central_series_
 
 /-- The `n+1`st term of the upper central series `H i` has underlying set equal to the `x` such
 that `⁅x,G⁆ ⊆ H n`-/
-lemma mem_upper_central_series_succ_iff {G : Type*} [group G] (n : ℕ) (x : G) :
+lemma mem_upper_central_series_succ_iff (n : ℕ) (x : G) :
   x ∈ upper_central_series G (n + 1) ↔
   ∀ y : G, x * y * x⁻¹ * y⁻¹ ∈ upper_central_series G n := iff.rfl
 
@@ -181,7 +181,7 @@ lemma upper_central_series_is_ascending_central_series :
   is_ascending_central_series (upper_central_series G) :=
 ⟨rfl, λ x n h, h⟩
 
-lemma upper_central_series_le_succ (G : Type*) [group G] (n : ℕ)
+lemma upper_central_series_le_succ (n : ℕ)
 : upper_central_series G n ≤ upper_central_series G n.succ :=
 begin
   intros x hx y,
@@ -309,12 +309,12 @@ begin
     use [lower_central_series G, lower_central_series_is_descending_central_series, h] },
 end
 
-lemma subsingleton_is_nilpotent (G : Type*) [group G] (hG : subsingleton G) : is_nilpotent G :=
+lemma subsingleton_is_nilpotent (hG : subsingleton G) : is_nilpotent G :=
 begin
   exact nilpotent_iff_lower_central_series.2 ⟨0, subsingleton.elim ⊤ ⊥⟩,
 end
 
-lemma ucs_functorial_wrt_surjection (G : Type*) [group G] (H : Type*) [group H] (f : G →* H)
+lemma ucs_functorial_wrt_surjection {H : Type*} [group H] (f : G →* H)
 (h : function.surjective f) (n : ℕ)
 : subgroup.map f (upper_central_series G n) ≤ upper_central_series H n :=
 begin

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -312,9 +312,8 @@ end
 instance is_nilpotent_of_subsingleton [subsingleton G] : is_nilpotent G :=
 nilpotent_iff_lower_central_series.2 ⟨0, subsingleton.elim ⊤ ⊥⟩
 
-lemma upper_central_series.map {H : Type*} [group H] (f : G →* H)
-  (h : function.surjective f) (n : ℕ) :
-  subgroup.map f (upper_central_series G n) ≤ upper_central_series H n :=
+lemma upper_central_series.map {H : Type*} [group H] {f : G →* H} (h : function.surjective f)
+  (n : ℕ) : subgroup.map f (upper_central_series G n) ≤ upper_central_series H n :=
 begin
   induction n with d hd,
   { simp },

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -308,6 +308,7 @@ begin
     use [lower_central_series G, lower_central_series_is_descending_central_series, h] },
 end
 
+@[priority 100]
 instance is_nilpotent_of_subsingleton [subsingleton G] : is_nilpotent G :=
 nilpotent_iff_lower_central_series.2 ⟨0, subsingleton.elim ⊤ ⊥⟩
 

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -183,7 +183,7 @@ lemma upper_central_series_is_ascending_central_series :
 
 lemma upper_central_series_mono : monotone (upper_central_series G) :=
 begin
-  apply monotone_nat_of_le_succ ,
+  refine monotone_nat_of_le_succ _,
   intros n x hx y,
   rw [mul_assoc, mul_assoc, ← mul_assoc y x⁻¹ y⁻¹],
   exact mul_mem (upper_central_series G n) hx

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -122,7 +122,7 @@ def upper_central_series (n : ℕ) : subgroup G := (upper_central_series_aux G n
 
 instance (n : ℕ) : normal (upper_central_series G n) := (upper_central_series_aux G n).2
 
-lemma upper_central_series_zero_def : upper_central_series G 0 = ⊥ := rfl
+@[simp] lemma upper_central_series_zero_def : upper_central_series G 0 = ⊥ := rfl
 
 /-- The `n+1`st term of the upper central series `H i` has underlying set equal to the `x` such
 that `⁅x,G⁆ ⊆ H n`-/
@@ -269,7 +269,7 @@ end
 instance (n : ℕ) : normal (lower_central_series G n) :=
 begin
   induction n,
-  { simp [lower_central_series_zero_def, subgroup.top_normal] },
+  { simp [subgroup.top_normal] },
   { haveI := n_ih,
     exact general_commutator_normal (lower_central_series G n_n) ⊤ },
 end
@@ -319,7 +319,7 @@ lemma ucs_functorial_wrt_surjection (G : Type*) [group G] (H : Type*) [group H] 
 : subgroup.map f (upper_central_series G n) ≤ upper_central_series H n :=
 begin
   induction n with d hd,
-  { simp [upper_central_series_zero_def] },
+  { simp },
   { rintros _ ⟨x, hx : x ∈ upper_central_series G d.succ, rfl⟩ y',
     rcases (h y') with ⟨y, rfl⟩,
     simpa using hd (mem_map_of_mem f (hx y)) }

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -262,8 +262,8 @@ variable {G}
 
 lemma mem_lower_central_series_succ_iff (n : ℕ) (x : G) :
   x ∈ lower_central_series G (n + 1) ↔
-    x ∈ closure {x | ∃ (p ∈ lower_central_series G n) (q ∈ (⊤ : subgroup G)), p * q * p⁻¹ * q⁻¹ = x} :=
-iff.rfl
+  x ∈ closure {x | ∃ (p ∈ lower_central_series G n) (q ∈ (⊤ : subgroup G)), p * q * p⁻¹ * q⁻¹ = x}
+:= iff.rfl
 
 instance (n : ℕ) : normal (lower_central_series G n) :=
 begin

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -308,7 +308,7 @@ begin
     use [lower_central_series G, lower_central_series_is_descending_central_series, h] },
 end
 
-lemma subsingleton.is_nilpotent (hG : subsingleton G) : is_nilpotent G :=
+instance is_nilpotent_of_subsingleton [subsingleton G] : is_nilpotent G :=
 nilpotent_iff_lower_central_series.2 ⟨0, subsingleton.elim ⊤ ⊥⟩
 
 lemma upper_central_series.map {H : Type*} [group H] (f : G →* H)

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -182,9 +182,9 @@ lemma upper_central_series_is_ascending_central_series :
 ⟨rfl, λ x n h, h⟩
 
 lemma upper_central_series_mono : monotone (upper_central_series G) :=
-monotone_nat_of_le_succ $ λ n,
 begin
-  intros x hx y,
+  apply monotone_nat_of_le_succ ,
+  intros n x hx y,
   rw [mul_assoc, mul_assoc, ← mul_assoc y x⁻¹ y⁻¹],
   exact mul_mem (upper_central_series G n) hx
     (normal.conj_mem (upper_central_series.subgroup.normal G n) x⁻¹ (inv_mem _ hx) y),

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -182,7 +182,7 @@ lemma upper_central_series_is_ascending_central_series :
 ⟨rfl, λ x n h, h⟩
 
 lemma upper_central_series_mono : monotone (upper_central_series G) :=
-  monotone_nat_of_le_succ $ λ n,
+monotone_nat_of_le_succ $ λ n,
 begin
   intros x hx y,
   rw [mul_assoc, mul_assoc, ← mul_assoc y x⁻¹ y⁻¹],

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -182,7 +182,7 @@ lemma upper_central_series_is_ascending_central_series :
 ⟨rfl, λ x n h, h⟩
 
 lemma upper_central_series_mono : monotone (upper_central_series G) :=
-monotone_nat_of_le_succ $ λ n,
+  monotone_nat_of_le_succ $ λ n,
 begin
   intros x hx y,
   rw [mul_assoc, mul_assoc, ← mul_assoc y x⁻¹ y⁻¹],

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -181,7 +181,7 @@ lemma upper_central_series_is_ascending_central_series :
   is_ascending_central_series (upper_central_series G) :=
 ⟨rfl, λ x n h, h⟩
 
-lemma upper_central_series_le_succ (n : ℕ)
+lemma upper_central_series_mono (n : ℕ)
 : upper_central_series G n ≤ upper_central_series G n.succ :=
 begin
   intros x hx y,
@@ -262,9 +262,7 @@ variable {G}
 
 lemma mem_lower_central_series_succ_iff (n : ℕ) (x : G) : x ∈ lower_central_series G (n + 1) ↔
   x ∈ closure {x | ∃ (p ∈ lower_central_series G n) (q ∈ (⊤ : subgroup G)), p * q * p⁻¹ * q⁻¹ = x}
-:= begin
-  refl,
-end
+:= iff.rfl
 
 instance (n : ℕ) : normal (lower_central_series G n) :=
 begin
@@ -310,11 +308,9 @@ begin
 end
 
 lemma subsingleton_is_nilpotent (hG : subsingleton G) : is_nilpotent G :=
-begin
-  exact nilpotent_iff_lower_central_series.2 ⟨0, subsingleton.elim ⊤ ⊥⟩,
-end
+ nilpotent_iff_lower_central_series.2 ⟨0, subsingleton.elim ⊤ ⊥⟩
 
-lemma ucs_functorial_wrt_surjection {H : Type*} [group H] (f : G →* H)
+lemma upper_central_series.map {H : Type*} [group H] (f : G →* H)
 (h : function.surjective f) (n : ℕ)
 : subgroup.map f (upper_central_series G n) ≤ upper_central_series H n :=
 begin

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -266,10 +266,10 @@ lemma mem_lower_central_series_succ_iff (n : ℕ) (x : G) : x ∈ lower_central_
 
 instance (n : ℕ) : normal (lower_central_series G n) :=
 begin
-  induction n,
+  induction n with d hd,
   { simp [subgroup.top_normal] },
-  { haveI := n_ih,
-    exact general_commutator_normal (lower_central_series G n_n) ⊤ },
+  { haveI := hd,
+    exact general_commutator_normal (lower_central_series G d) ⊤ },
 end
 
 /-- The lower central series of a group is a descending central series. -/

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -308,7 +308,7 @@ begin
 end
 
 lemma subsingleton_is_nilpotent (hG : subsingleton G) : is_nilpotent G :=
- nilpotent_iff_lower_central_series.2 ⟨0, subsingleton.elim ⊤ ⊥⟩
+nilpotent_iff_lower_central_series.2 ⟨0, subsingleton.elim ⊤ ⊥⟩
 
 lemma upper_central_series.map {H : Type*} [group H] (f : G →* H)
   (h : function.surjective f) (n : ℕ) :


### PR DESCRIPTION

Add to API for nilpotent groups with simp def lemmas and other basic properties of central series.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
