### PR TITLE
[Merged by Bors] - chore({group,ring}_theory/sub{group,monoid,ring,semiring}): Add missing scalar action typeclasses

### DIFF
--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -82,6 +82,9 @@ def mul_semiring_action.to_semiring_equiv [mul_semiring_action G R] (x : G) : R 
 { .. distrib_mul_action.to_add_equiv G R x,
   .. mul_semiring_action.to_ring_hom G R x }
 
+section
+variables {M G R}
+
 /-- A stronger version of `submonoid.distrib_mul_action`. -/
 instance submonoid.mul_semiring_action [mul_semiring_action M R] (H : submonoid M) :
   mul_semiring_action H R :=
@@ -106,6 +109,8 @@ instance subring.mul_semiring_action {R'} [ring R'] [mul_semiring_action R' R]
   (H : subring R') :
   mul_semiring_action H R :=
 H.to_subsemiring.mul_semiring_action
+
+end
 
 section prod
 variables [mul_semiring_action M R] [mul_semiring_action M S]

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -82,6 +82,31 @@ def mul_semiring_action.to_semiring_equiv [mul_semiring_action G R] (x : G) : R 
 { .. distrib_mul_action.to_add_equiv G R x,
   .. mul_semiring_action.to_ring_hom G R x }
 
+/-- A stronger version of `submonoid.distrib_mul_action`. -/
+instance submonoid.mul_semiring_action [mul_semiring_action M R] (H : submonoid M) :
+  mul_semiring_action H R :=
+{ smul := (•),
+  smul_one := λ h, smul_one (h : M),
+  smul_mul := λ h, smul_mul' (h : M),
+  .. H.distrib_mul_action }
+
+/-- A stronger version of `subgroup.distrib_mul_action`. -/
+instance subgroup.mul_semiring_action [mul_semiring_action G R] (H : subgroup G) :
+  mul_semiring_action H R :=
+H.to_submonoid.mul_semiring_action
+
+/-- A stronger version of `subsemiring.distrib_mul_action`. -/
+instance subsemiring.mul_semiring_action {R'} [semiring R'] [mul_semiring_action R' R]
+  (H : subsemiring R') :
+  mul_semiring_action H R :=
+H.to_submonoid.mul_semiring_action
+
+/-- A stronger version of `subring.distrib_mul_action`. -/
+instance subring.mul_semiring_action {R'} [ring R'] [mul_semiring_action R' R]
+  (H : subring R') :
+  mul_semiring_action H R :=
+H.to_subsemiring.mul_semiring_action
+
 section prod
 variables [mul_semiring_action M R] [mul_semiring_action M S]
 

--- a/src/group_theory/subgroup.lean
+++ b/src/group_theory/subgroup.lean
@@ -2244,6 +2244,10 @@ instance
   is_scalar_tower S α β :=
 S.to_submonoid.is_scalar_tower
 
+instance [mul_action G α] [has_faithful_scalar G α] (S : subgroup G) :
+  has_faithful_scalar S α :=
+S.to_submonoid.has_faithful_scalar
+
 /-- The action by a subgroup is the action by the underlying group. -/
 instance [add_monoid α] [distrib_mul_action G α] (S : subgroup G) : distrib_mul_action S α :=
 S.to_submonoid.distrib_mul_action

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -822,6 +822,10 @@ instance
 
 example {S : submonoid M'} : is_scalar_tower S M' M' := by apply_instance
 
+instance [mul_action M' α] [has_faithful_scalar M' α] (S : submonoid M') :
+  has_faithful_scalar S α :=
+{ eq_of_smul_eq_smul := λ x y h, subtype.ext (eq_of_smul_eq_smul h) }
+
 end submonoid
 
 end actions

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -895,6 +895,10 @@ instance
   is_scalar_tower S α β :=
 S.to_subsemiring.is_scalar_tower
 
+instance [mul_action R α] [has_faithful_scalar R α] (S : subring R) :
+  has_faithful_scalar S α :=
+S.to_subsemiring.has_faithful_scalar
+
 /-- The action by a subring is the action by the underlying ring. -/
 instance [add_monoid α] [distrib_mul_action R α] (S : subring R) : distrib_mul_action S α :=
 S.to_subsemiring.distrib_mul_action

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -780,6 +780,10 @@ instance
   is_scalar_tower S α β :=
 S.to_submonoid.is_scalar_tower
 
+instance [mul_action R' α] [has_faithful_scalar R' α] (S : subsemiring R') :
+  has_faithful_scalar S α :=
+S.to_submonoid.has_faithful_scalar
+
 /-- The action by a subsemiring is the action by the underlying semiring. -/
 instance [add_monoid α] [distrib_mul_action R' α] (S : subsemiring R') : distrib_mul_action S α :=
 S.to_submonoid.distrib_mul_action


### PR DESCRIPTION
This adds `has_faithful_scalar` and `mul_semiring_action` instances for simple subtypes. 
Neither typeclass associates any new actions with these types; they just provide additionally properties of the existing actions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
