### PR TITLE
[Merged by Bors] - fix(algebra/algebra/restrict_scalars): Remove a bad instance

### DIFF
--- a/src/algebra/algebra/restrict_scalars.lean
+++ b/src/algebra/algebra/restrict_scalars.lean
@@ -107,14 +107,6 @@ rfl
 instance : is_scalar_tower R S (restrict_scalars R S M) :=
 ⟨λ r S M, by { rw [algebra.smul_def, mul_smul], refl }⟩
 
-instance submodule.restricted_module (V : submodule S M) :
-  module R V :=
-restrict_scalars.module R S V
-
-instance submodule.restricted_module_is_scalar_tower (V : submodule S M) :
-  is_scalar_tower R S V :=
-restrict_scalars.is_scalar_tower R S V
-
 end module
 
 section algebra


### PR DESCRIPTION
This instance forms a non-defeq diamond with the following one
```lean
instance submodule.restricted_module' [module R M] [is_scalar_tower R S M] (V : submodule S M) :
  module R V :=
by apply_instance
```

The `submodule.restricted_module_is_scalar_tower` instance is harmless, but it can't exist without the first one so we remove it too.

Based on the CI result, this instance wasn't used anyway.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
