### PR TITLE
[Merged by Bors] - doc(tactic/monotonicity): bad ac_mono syntax doc

### DIFF
--- a/src/tactic/monotonicity/interactive.lean
+++ b/src/tactic/monotonicity/interactive.lean
@@ -619,9 +619,9 @@ monotonic function `f` to `x ≺ y`.
 `ac_mono^k`, for some literal number `k` applies monotonicity `k`
 times.
 
-`ac_mono h`, with `h` a hypothesis, unwraps monotonic functions and
+`ac_mono := h`, with `h` a hypothesis, unwraps monotonic functions and
 uses `h` to solve the remaining goal. Can be combined with `*` or `^k`:
-`ac_mono* h`
+`ac_mono* := h`
 
 `ac_mono : p` asserts `p` and uses it to discharge the goal result
 unwrapping a series of monotonic functions. Can be combined with * or
@@ -651,7 +651,7 @@ end
 ```
 
 As with `mono*`, `ac_mono*` solves the goal in one go and so does
-`ac_mono* h₁`. The latter syntax becomes especially interesting in the
+`ac_mono* := h₁`. The latter syntax becomes especially interesting in the
 following example:
 
 ```lean
@@ -659,7 +659,7 @@ example (x y z k m n : ℕ)
   (h₀ : z ≥ 0)
   (h₁ : m + x + n ≤ y + n + m) :
   (m + x + n) * z + k ≤ z * (y + n + m) + k :=
-by ac_mono* h₁.
+by ac_mono* := h₁.
 ```
 
 By giving `ac_mono` the assumption `h₁`, we are asking `ac_refl` to
@@ -677,7 +677,7 @@ do h ← i_to_expr t >>= assert `h,
    tactic.swap,
    focus1 $ repeat_or_not rep (ac_mono_aux opt) (some $ done <|> ac_refine h)
 /-
-TODO(Simon): with `ac_mono h` and `ac_mono : p` split the remaining
+TODO(Simon): with `ac_mono := h` and `ac_mono : p` split the remaining
   gaol if the provided rule does not solve it completely.
 -/
 


### PR DESCRIPTION
The syntax `ac_mono h` was at some point changed to `ac_mono := h` but the documentation did not reflect the change.