### PR TITLE
feat(tactic/lint/simp): `simp_var_head` uses `whnf reducible`

### DIFF
--- a/src/tactic/lint/simp.lean
+++ b/src/tactic/lint/simp.lean
@@ -17,7 +17,7 @@ This files defines several linters that prevent common mistakes when declaring s
 
 open tactic expr
 
-/-- `simp_lhs_rhs reduce_tac ty` returns the left-hand and right-hand side of a simp lemma with
+/-- `simp_lhs_rhs_aux reduce_tac ty` returns the left-hand and right-hand side of a simp lemma with
   type `ty`. `reduce_tac` is the tactic that is used to reduce the type. -/
 private meta def simp_lhs_rhs_aux (reduce_tac : expr → tactic expr) :
   expr → tactic (expr × expr) | ty := do
@@ -35,10 +35,13 @@ match ty with
 | ty := pure (ty, `(true))
 end
 
+/-- `simp_lhs_rhs ty` returns the left-hand and right-hand side of a simp lemma with
+  type `ty`, using `head_beta` to reduce the type. -/
 private meta def simp_lhs_rhs : expr → tactic (expr × expr) :=
 simp_lhs_rhs_aux head_beta
 
-/-- `simp_lhs ty` returns the left-hand side of a simp lemma with type `ty`. -/
+/-- `simp_lhs ty` returns the left-hand side of a simp lemma with type `ty`, using `whnf reducible`
+  to reduce the expression. -/
 private meta def simp_lhs (ty : expr): tactic expr :=
 prod.fst <$> simp_lhs_rhs_aux (λ e, whnf e reducible) ty
 

--- a/test/lint.lean
+++ b/test/lint.lean
@@ -127,3 +127,21 @@ run_cmd do
   d ← get_decl `my_exists_intro,
   t ← linter.def_lemma.test d,
   guard $ t = none
+
+/- test that `simp_var_head` applies `whnf reducible`. -/
+section
+
+variables {α β : Type*}
+/-- Two functions `f₁ f₂ : α → β` are equal on `s`
+  if `f₁ x = f₂ x` for all `x ∈ a`. -/
+@[reducible] def my_eq_on (f₁ f₂ : α → β) (s : set α) : Prop :=
+∀ ⦃x⦄, x ∈ s → f₁ x = f₂ x
+
+lemma my_eq_on_empty (f₁ f₂ : α → β) : my_eq_on f₁ f₂ ∅ := λ x, false.elim
+
+run_cmd do
+  d ← get_decl `my_eq_on_empty,
+  t ← linter.simp_var_head.test d,
+  guard t.is_some
+
+end


### PR DESCRIPTION
Changes the `simp_var_head` linter so that it unfolds reducible definitions. 

---

@gebner Do we also want this for the other simp linters? I'm not sure, so I currently kept their behavior as before.

Related Zulip: https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/bad.20simp.20lemmas

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
