### PR TITLE
[Merged by Bors] - feat(measure_theory/measure/measure_space): obtain pairwise disjoint spanning sets wrt. two measures

### DIFF
--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1816,24 +1816,6 @@ begin
   exact eq_univ_of_subset (Union_subset_Union $ λ n, subset_to_measurable μ (s n)) hs
 end
 
-/-- Given two σ-finite measures `μ` and `ν`, `finite_spanning_setsin.add μ ν` is a sequence of
-pairwise disjoint, finite spanning sets in `{s | measurable_set s}` with respect to `μ + ν`. -/
-protected def finite_spanning_sets_in.add
-  (S : μ.finite_spanning_sets_in {s | measurable_set s})
-  (T : ν.finite_spanning_sets_in {s | measurable_set s}) :
-  (μ + ν).finite_spanning_sets_in {s | measurable_set s} :=
-{ set := λ n : ℕ, S.set n.unpair.1 ∩ T.set n.unpair.2,
-  set_mem := λ n, (S.set_mem n.unpair.1).inter (T.set_mem n.unpair.2),
-  finite :=
-    begin
-      intro n,
-      rw [add_apply, ennreal.add_lt_top],
-      exact ⟨lt_of_le_of_lt (measure_mono (set.inter_subset_left _ _)) (S.finite n.unpair.1),
-             lt_of_le_of_lt (measure_mono (set.inter_subset_right _ _)) (T.finite n.unpair.2)⟩,
-    end,
-  spanning := by simp_rw [set.Union_unpair (λ i j, S.set i ∩ T.set j), ← set.inter_Union,
-                          ← set.Union_inter, S.spanning, T.spanning, set.inter_univ] }
-
 /-- Given measures `μ`, `ν` where `ν ≤ μ`, `finite_spanning_sets_in.of_le` provides the induced
 `finite_spanning_set` with respect to `ν` from a `finite_spanning_set` with respect to `μ`. -/
 def finite_spanning_sets_in.of_le (h : ν ≤ μ) {C : set (set α)}
@@ -1846,36 +1828,6 @@ def finite_spanning_sets_in.of_le (h : ν ≤ μ) {C : set (set α)}
 lemma sigma_finite_of_le (μ : measure α) [hs : sigma_finite μ]
   (h : ν ≤ μ) : sigma_finite ν :=
 ⟨hs.out.map $ finite_spanning_sets_in.of_le h⟩
-
-section disjointed
-
-variable [measurable_space α]
-
-/-- Given `S : μ.finite_spanning_sets_in {s | measurable_set s}`,
-`finite_spanning_sets_in.disjointed` provides a `finite_spanning_sets_in {s | measurable_set s}`
-such that its underlying sets are pairwise disjoint. -/
-protected def finite_spanning_sets_in.disjointed {μ : measure α}
-  (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
-   μ.finite_spanning_sets_in {s | measurable_set s} :=
-⟨disjointed S.set, measurable_set.disjointed S.set_mem,
-  λ n, lt_of_le_of_lt (measure_mono (disjointed_subset S.set n)) (S.finite _),
-  S.spanning ▸ Union_disjointed⟩
-
-lemma finite_spanning_sets_in.disjointed_set_eq {μ : measure α}
-  (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
-  S.disjointed.set = disjointed S.set :=
-rfl
-
-lemma exists_eq_disjoint_finite_spanning_sets_in
-  (μ ν : measure α) [sigma_finite μ] [sigma_finite ν] :
-  ∃ (S : μ.finite_spanning_sets_in {s | measurable_set s})
-    (T : ν.finite_spanning_sets_in {s | measurable_set s}),
-    S.set = T.set ∧ pairwise (disjoint on S.set) :=
-let S := (μ.to_finite_spanning_sets_in.add ν.to_finite_spanning_sets_in).disjointed in
-⟨S.of_le (measure.le_add_right le_rfl), S.of_le (measure.le_add_left le_rfl),
- rfl, disjoint_disjointed _⟩
-
-end disjointed
 
 end measure
 
@@ -1995,6 +1947,36 @@ lemma ext_of_generate_finite (C : set (set α)) (hA : m0 = generate_from C)
 measure.ext (λ s hs, ext_on_measurable_space_of_generate_finite m0 C hμν le_rfl hA hC h_univ hs)
 
 namespace measure
+
+section disjointed
+
+variable [measurable_space α]
+
+/-- Given `S : μ.finite_spanning_sets_in {s | measurable_set s}`,
+`finite_spanning_sets_in.disjointed` provides a `finite_spanning_sets_in {s | measurable_set s}`
+such that its underlying sets are pairwise disjoint. -/
+protected def finite_spanning_sets_in.disjointed {μ : measure α}
+  (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
+   μ.finite_spanning_sets_in {s | measurable_set s} :=
+⟨disjointed S.set, measurable_set.disjointed S.set_mem,
+  λ n, lt_of_le_of_lt (measure_mono (disjointed_subset S.set n)) (S.finite _),
+  S.spanning ▸ Union_disjointed⟩
+
+lemma finite_spanning_sets_in.disjointed_set_eq {μ : measure α}
+  (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
+  S.disjointed.set = disjointed S.set :=
+rfl
+
+lemma exists_eq_disjoint_finite_spanning_sets_in
+  (μ ν : measure α) [sigma_finite μ] [sigma_finite ν] :
+  ∃ (S : μ.finite_spanning_sets_in {s | measurable_set s})
+    (T : ν.finite_spanning_sets_in {s | measurable_set s}),
+    S.set = T.set ∧ pairwise (disjoint on S.set) :=
+let S := (μ + ν).to_finite_spanning_sets_in.disjointed in
+⟨S.of_le (measure.le_add_right le_rfl), S.of_le (measure.le_add_left le_rfl),
+ rfl, disjoint_disjointed _⟩
+
+end disjointed
 
 namespace finite_at_filter
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1974,7 +1974,7 @@ lemma exists_eq_disjoint_finite_spanning_sets_in
     S.set = T.set ∧ pairwise (disjoint on S.set) :=
 let S := (μ + ν).to_finite_spanning_sets_in.disjointed in
 ⟨S.of_le (measure.le_add_right le_rfl), S.of_le (measure.le_add_left le_rfl),
- rfl, disjoint_disjointed _⟩
+  rfl, disjoint_disjointed _⟩
 
 end disjointed
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1950,7 +1950,7 @@ namespace measure
 
 section disjointed
 
-variable [measurable_space α]
+include m0
 
 /-- Given `S : μ.finite_spanning_sets_in {s | measurable_set s}`,
 `finite_spanning_sets_in.disjointed` provides a `finite_spanning_sets_in {s | measurable_set s}`

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1831,21 +1831,21 @@ variable [measurable_space α]
 /-- Given `S : μ.finite_spanning_sets_in {s | measurable_set s}`,
 `disjointed_finite_spanning_sets_in` provides a `finite_spanning_sets_in {s | measurable_set s}`
 such that its underlying sets are pairwise disjoint. -/
-def finite_spanning_sets_in.disjointed {μ : measure α}
+protected def finite_spanning_sets_in.disjointed {μ : measure α}
   (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
    μ.finite_spanning_sets_in {s | measurable_set s} :=
 ⟨disjointed S.set, measurable_set.disjointed S.set_mem,
   λ n, lt_of_le_of_lt (measure_mono (disjointed_subset S.set n)) (S.finite _),
   S.spanning ▸ Union_disjointed⟩
 
-lemma disjoint_disjointed_finite_spanning_sets_in {μ : measure α}
+lemma finite_spanning_sets_in.disjoint_disjointed {μ : measure α}
   (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
   pairwise (disjoint on S.disjointed.set) :=
 disjoint_disjointed _
 
 /-- Given two σ-finite measures `μ` and `ν`, `finite_spanning_sets.in_add μ ν` is a sequence of
 pairwise disjoint, finite spanning sets in `{s | measurable_set s}` with respect to `μ + ν`. -/
-def finite_spanning_sets_in.add {μ ν : measure α}
+protected def finite_spanning_sets_in.add {μ ν : measure α}
   (S : μ.finite_spanning_sets_in {s | measurable_set s})
   (T : ν.finite_spanning_sets_in {s | measurable_set s}) :
   (μ + ν).finite_spanning_sets_in {s | measurable_set s} :=
@@ -1877,7 +1877,7 @@ lemma exists_eq_disjoint_finite_spanning_sets_in
     S.set = T.set ∧ pairwise (disjoint on S.set) :=
 let S := (μ.to_finite_spanning_sets_in.add ν.to_finite_spanning_sets_in).disjointed in
 ⟨S.of_le (measure.le_add_right (le_refl _)), S.of_le (measure.le_add_left (le_refl _)),
- rfl, disjoint_disjointed_finite_spanning_sets_in _⟩
+ rfl, finite_spanning_sets_in.disjoint_disjointed _⟩
 
 end disjointed
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1843,13 +1843,13 @@ lemma disjoint_disjointed_finite_spanning_sets_in {μ : measure α}
   pairwise (disjoint on (disjointed_finite_spanning_sets_in μ S).set) :=
 disjoint_disjointed _
 
-/-- Given two σ-finite measures `μ` and `ν`, `finite_spanning_sets_in_add μ ν` is a sequence of
+/-- Given two σ-finite measures `μ` and `ν`, `finite_spanning_sets.in_add μ ν` is a sequence of
 pairwise disjoint, finite spanning sets in `{s | measurable_set s}` with respect to `μ + ν`. -/
-def finite_spanning_sets_in_add (μ ν : measure α) [sigma_finite μ] [sigma_finite ν] :
+def finite_spanning_sets_in.add {μ ν : measure α}
+  (S : μ.finite_spanning_sets_in {s | measurable_set s})
+  (T : ν.finite_spanning_sets_in {s | measurable_set s}) :
   (μ + ν).finite_spanning_sets_in {s | measurable_set s} :=
 (μ + ν).disjointed_finite_spanning_sets_in $
-let S := μ.to_finite_spanning_sets_in in
-let T := ν.to_finite_spanning_sets_in in
 { set := λ n : ℕ, S.set n.unpair.1 ∩ T.set n.unpair.2,
   set_mem := λ n, (S.set_mem n.unpair.1).inter (T.set_mem n.unpair.2),
   finite :=
@@ -1862,9 +1862,10 @@ let T := ν.to_finite_spanning_sets_in in
   spanning := by simp_rw [set.Union_unpair (λ i j, S.set i ∩ T.set j), ← set.inter_Union,
                           ← set.Union_inter, S.spanning, T.spanning, set.inter_univ] }
 
-lemma disjoint_finite_spanning_sets_in_add
-  {μ ν : measure α} [sigma_finite μ] [sigma_finite ν] :
-  pairwise (disjoint on (finite_spanning_sets_in_add μ ν).set) :=
+lemma finite_spanning_sets_in.add_disjoint {μ ν : measure α}
+  (S : μ.finite_spanning_sets_in {s | measurable_set s})
+  (T : ν.finite_spanning_sets_in {s | measurable_set s}):
+  pairwise (disjoint on (finite_spanning_sets_in.add S T).set) :=
 disjoint_disjointed_finite_spanning_sets_in _
 
 /-- Given measures `μ`, `ν` where `ν ≤ μ`, `finite_spanning_sets_in_of_le` provides the induced
@@ -1881,9 +1882,9 @@ lemma exists_eq_disjoint_finite_spanning_sets_in
   ∃ (S : μ.finite_spanning_sets_in {s | measurable_set s})
     (T : ν.finite_spanning_sets_in {s | measurable_set s}),
     S.set = T.set ∧ pairwise (disjoint on S.set) :=
-⟨(finite_spanning_sets_in_add μ ν).of_le (measure.le_add_right (le_refl _)),
- (finite_spanning_sets_in_add μ ν).of_le (measure.le_add_left (le_refl _)),
- rfl, disjoint_finite_spanning_sets_in_add⟩
+let S := μ.to_finite_spanning_sets_in.add ν.to_finite_spanning_sets_in in
+⟨S.of_le (measure.le_add_right (le_refl _)), S.of_le (measure.le_add_left (le_refl _)),
+ rfl, finite_spanning_sets_in.add_disjoint _ _⟩
 
 end disjointed
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1843,39 +1843,59 @@ lemma disjoint_disjointed_finite_spanning_sets_in {μ : measure α}
   pairwise (disjoint on (disjointed_finite_spanning_sets_in μ S).set) :=
 disjoint_disjointed _
 
-private lemma exists_eq_finite_spanning_sets_in
-  (μ ν : measure α) [sigma_finite μ] [sigma_finite ν] :
-  ∃ (S : μ.finite_spanning_sets_in {s | measurable_set s})
-    (T : ν.finite_spanning_sets_in {s | measurable_set s}), S.set = T.set :=
-begin
-  set S := μ.to_finite_spanning_sets_in,
-  set T := ν.to_finite_spanning_sets_in,
-  set W := λ n : ℕ, S.set n.unpair.1 ∩ T.set n.unpair.2 with hW,
-  have hW₁ : ∀ n, measurable_set (W n) :=
-    λ n, (S.set_mem n.unpair.1).inter (T.set_mem n.unpair.2),
-  have hW₂ : (⋃ i, W i) = set.univ,
-  { simp_rw [hW, set.Union_unpair (λ i j, S.set i ∩ T.set j), ← set.inter_Union,
-             ← set.Union_inter, S.spanning, T.spanning, set.inter_univ] },
-  refine ⟨⟨W, hW₁, _, hW₂⟩, ⟨W, hW₁, _, hW₂⟩, rfl⟩,
-  { intro i,
-    refine lt_of_le_of_lt (measure_mono _) (S.finite i.unpair.1),
-    exact set.inter_subset_left _ _ },
-  { intro i,
-    refine lt_of_le_of_lt (measure_mono _) (T.finite i.unpair.2),
-    exact set.inter_subset_right _ _ },
-end
+/-- Given a pair of σ-finite measure `μ`, `ν`, `unpair_finite_spanning_sets_in_left μ ν` provides
+an element of type `μ.finite_spanning_sets_in {s | measurable_set s}` such that its underlying
+sets is pairwise disjoint, finite with respect to both `μ` and `ν` and equal to the underlying
+sets of `unpair_finite_spanning_sets_in_right μ ν`.
 
-lemma exists_eq_disjoint_finite_spanning_sets_in
+Note: this definition is not commutative since `n.unpair.1` does not necessarily equal
+`n.unpair.2`. -/
+def unpair_finite_spanning_sets_in_left
   (μ ν : measure α) [sigma_finite μ] [sigma_finite ν] :
-  ∃ (S : μ.finite_spanning_sets_in {s | measurable_set s})
-    (T : ν.finite_spanning_sets_in {s | measurable_set s}),
-    S.set = T.set ∧ pairwise (disjoint on S.set) :=
-begin
-  obtain ⟨S, T, hST⟩ := exists_eq_finite_spanning_sets_in μ ν,
-  refine ⟨disjointed_finite_spanning_sets_in μ S, disjointed_finite_spanning_sets_in ν T, _, _⟩,
-  { simp [disjointed_finite_spanning_sets_in, hST] },
-  { exact disjoint_disjointed_finite_spanning_sets_in _ }
-end
+  μ.finite_spanning_sets_in {s | measurable_set s} :=
+μ.disjointed_finite_spanning_sets_in $
+let S := μ.to_finite_spanning_sets_in in
+let T := ν.to_finite_spanning_sets_in in
+{ set := λ n : ℕ, S.set n.unpair.1 ∩ T.set n.unpair.2,
+  set_mem := λ n, (S.set_mem n.unpair.1).inter (T.set_mem n.unpair.2),
+  finite := λ n, lt_of_le_of_lt (measure_mono (set.inter_subset_left _ _)) (S.finite n.unpair.1),
+  spanning := by simp_rw [set.Union_unpair (λ i j, S.set i ∩ T.set j), ← set.inter_Union,
+                          ← set.Union_inter, S.spanning, T.spanning, set.inter_univ] }
+
+/-- Given a pair of σ-finite measure `μ`, `ν`, `unpair_finite_spanning_sets_in_right μ ν` provides
+an element of type `ν.finite_spanning_sets_in {s | measurable_set s}` such that its underlying
+sets is pairwise disjoint, finite with respect to both `μ` and `ν`, and equal to the underlying
+sets of `unpair_finite_spanning_sets_in_left μ ν`.
+
+Note: this definition is not commutative since `n.unpair.1` does not necessarily equal
+`n.unpair.2`. -/
+def unpair_finite_spanning_sets_in_right
+  (μ ν : measure α) [sigma_finite μ] [sigma_finite ν] :
+  ν.finite_spanning_sets_in {s | measurable_set s} :=
+ν.disjointed_finite_spanning_sets_in $
+let S := μ.to_finite_spanning_sets_in in
+let T := ν.to_finite_spanning_sets_in in
+{ set := λ n : ℕ, S.set n.unpair.1 ∩ T.set n.unpair.2,
+  set_mem := λ n, (S.set_mem n.unpair.1).inter (T.set_mem n.unpair.2),
+  finite := λ n, lt_of_le_of_lt (measure_mono (set.inter_subset_right _ _)) (T.finite n.unpair.2),
+  spanning := by simp_rw [set.Union_unpair (λ i j, S.set i ∩ T.set j), ← set.inter_Union,
+                          ← set.Union_inter, S.spanning, T.spanning, set.inter_univ] }
+
+lemma unpair_finite_spanning_sets_in_eq
+  {μ ν : measure α} [sigma_finite μ] [sigma_finite ν] :
+  (unpair_finite_spanning_sets_in_left μ ν).set =
+  (unpair_finite_spanning_sets_in_right μ ν).set :=
+rfl
+
+lemma disjointed_unpair_finite_spanning_sets_in_left
+  {μ ν : measure α} [sigma_finite μ] [sigma_finite ν] :
+  pairwise (disjoint on (unpair_finite_spanning_sets_in_left μ ν).set) :=
+disjoint_disjointed_finite_spanning_sets_in _
+
+lemma disjointed_unpair_finite_spanning_sets_in_right
+  {μ ν : measure α} [sigma_finite μ] [sigma_finite ν] :
+  pairwise (disjoint on (unpair_finite_spanning_sets_in_right μ ν).set) :=
+disjoint_disjointed_finite_spanning_sets_in _
 
 end disjointed
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1829,7 +1829,7 @@ section disjointed
 variable [measurable_space α]
 
 /-- Given `S : μ.finite_spanning_sets_in {s | measurable_set s}`,
-`disjointed_finite_spanning_sets_in` provides a `finite_spanning_sets_in {s | measurable_set s}`
+`finite_spanning_sets_in.disjointed` provides a `finite_spanning_sets_in {s | measurable_set s}`
 such that its underlying sets are pairwise disjoint. -/
 protected def finite_spanning_sets_in.disjointed {μ : measure α}
   (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
@@ -1843,7 +1843,7 @@ lemma finite_spanning_sets_in.disjoint_disjointed {μ : measure α}
   pairwise (disjoint on S.disjointed.set) :=
 disjoint_disjointed _
 
-/-- Given two σ-finite measures `μ` and `ν`, `finite_spanning_sets.in_add μ ν` is a sequence of
+/-- Given two σ-finite measures `μ` and `ν`, `finite_spanning_setsin.add μ ν` is a sequence of
 pairwise disjoint, finite spanning sets in `{s | measurable_set s}` with respect to `μ + ν`. -/
 protected def finite_spanning_sets_in.add {μ ν : measure α}
   (S : μ.finite_spanning_sets_in {s | measurable_set s})
@@ -1861,7 +1861,7 @@ protected def finite_spanning_sets_in.add {μ ν : measure α}
   spanning := by simp_rw [set.Union_unpair (λ i j, S.set i ∩ T.set j), ← set.inter_Union,
                           ← set.Union_inter, S.spanning, T.spanning, set.inter_univ] }
 
-/-- Given measures `μ`, `ν` where `ν ≤ μ`, `finite_spanning_sets_in_of_le` provides the induced
+/-- Given measures `μ`, `ν` where `ν ≤ μ`, `finite_spanning_sets_in.of_le` provides the induced
 `finite_spanning_set` with respect to `ν` from a `finite_spanning_set` with respect to `μ`. -/
 def finite_spanning_sets_in.of_le {μ ν : measure α} (h : ν ≤ μ) {C : set (set α)}
   (S : μ.finite_spanning_sets_in C) : ν.finite_spanning_sets_in C :=

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1869,7 +1869,7 @@ disjoint_disjointed_finite_spanning_sets_in _
 
 /-- Given measures `μ`, `ν` where `ν ≤ μ`, `finite_spanning_sets_in_of_le` provides the induced
 `finite_spanning_set` with respect to `ν` from a `finite_spanning_set` with respect to `μ`. -/
-def finite_spanning_sets_in_of_le (μ ν : measure α) (h : ν ≤ μ) {C : set (set α)}
+def finite_spanning_sets_in.of_le {μ ν : measure α} (h : ν ≤ μ) {C : set (set α)}
   (S : μ.finite_spanning_sets_in C) : ν.finite_spanning_sets_in C :=
 { set := S.set,
   set_mem := S.set_mem,
@@ -1881,13 +1881,9 @@ lemma exists_eq_disjoint_finite_spanning_sets_in
   ∃ (S : μ.finite_spanning_sets_in {s | measurable_set s})
     (T : ν.finite_spanning_sets_in {s | measurable_set s}),
     S.set = T.set ∧ pairwise (disjoint on S.set) :=
-begin
-  refine ⟨finite_spanning_sets_in_of_le (μ + ν) μ _ (finite_spanning_sets_in_add μ ν),
-          finite_spanning_sets_in_of_le (μ + ν) ν _ (finite_spanning_sets_in_add μ ν),
-          rfl, disjoint_finite_spanning_sets_in_add⟩,
-  { exact measure.le_add_right (le_refl _) },
-  { exact measure.le_add_left (le_refl _) }
-end
+⟨(finite_spanning_sets_in_add μ ν).of_le (measure.le_add_right (le_refl _)),
+ (finite_spanning_sets_in_add μ ν).of_le (measure.le_add_left (le_refl _)),
+ rfl, disjoint_finite_spanning_sets_in_add⟩
 
 end disjointed
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1861,10 +1861,10 @@ protected def finite_spanning_sets_in.disjointed {μ : measure α}
   λ n, lt_of_le_of_lt (measure_mono (disjointed_subset S.set n)) (S.finite _),
   S.spanning ▸ Union_disjointed⟩
 
-lemma finite_spanning_sets_in.disjoint_disjointed {μ : measure α}
+lemma finite_spanning_sets_in.disjointed_set_eq {μ : measure α}
   (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
-  pairwise (disjoint on S.disjointed.set) :=
-disjoint_disjointed _
+  S.disjointed.set = disjointed S.set :=
+rfl
 
 lemma exists_eq_disjoint_finite_spanning_sets_in
   (μ ν : measure α) [sigma_finite μ] [sigma_finite ν] :
@@ -1873,7 +1873,7 @@ lemma exists_eq_disjoint_finite_spanning_sets_in
     S.set = T.set ∧ pairwise (disjoint on S.set) :=
 let S := (μ.to_finite_spanning_sets_in.add ν.to_finite_spanning_sets_in).disjointed in
 ⟨S.of_le (measure.le_add_right le_rfl), S.of_le (measure.le_add_left le_rfl),
- rfl, finite_spanning_sets_in.disjoint_disjointed _⟩
+ rfl, disjoint_disjointed _⟩
 
 end disjointed
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1843,14 +1843,6 @@ lemma disjoint_disjointed_finite_spanning_sets_in {μ : measure α}
   pairwise (disjoint on (disjointed_finite_spanning_sets_in μ S).set) :=
 disjoint_disjointed _
 
-lemma set.Union_unpair_inter (s t : ℕ → set α) :
-  (⋃ n : ℕ, s n.unpair.1 ∩ t n.unpair.2) = ⋃ i j : ℕ, s i ∩ t j :=
-begin
-  have : (⋃ i : ℕ × ℕ, s i.1 ∩ t i.2) = ⋃ i j : ℕ, s i ∩ t j,
-  { ext, simp only [set.mem_Union, prod.exists] },
-  rw [← this, ← nat.surjective_unpair.Union_comp],
-end
-
 private lemma exists_eq_finite_spanning_sets_in
   (μ ν : measure α) [sigma_finite μ] [sigma_finite ν] :
   ∃ (S : μ.finite_spanning_sets_in {s | measurable_set s})
@@ -1862,8 +1854,8 @@ begin
   have hW₁ : ∀ n, measurable_set (W n) :=
     λ n, (S.set_mem n.unpair.1).inter (T.set_mem n.unpair.2),
   have hW₂ : (⋃ i, W i) = set.univ,
-  { simp_rw [hW, set.Union_unpair_inter, ← set.inter_Union, ← set.Union_inter,
-             S.spanning, T.spanning, set.inter_univ] },
+  { simp_rw [hW, set.Union_unpair (λ i j, S.set i ∩ T.set j), ← set.inter_Union,
+             ← set.Union_inter, S.spanning, T.spanning, set.inter_univ] },
   refine ⟨⟨W, hW₁, _, hW₂⟩, ⟨W, hW₁, _, hW₂⟩, rfl⟩,
   { intro i,
     refine lt_of_le_of_lt (measure_mono _) (S.finite i.unpair.1),

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1831,7 +1831,7 @@ variable [measurable_space α]
 /-- Given `S : μ.finite_spanning_sets_in {s | measurable_set s}`,
 `disjointed_finite_spanning_sets_in` provides a `finite_spanning_sets_in {s | measurable_set s}`
 such that its underlying sets are pairwise disjoint. -/
-def disjointed_finite_spanning_sets_in (μ : measure α)
+def finite_spanning_sets_in.disjointed {μ : measure α}
   (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
    μ.finite_spanning_sets_in {s | measurable_set s} :=
 ⟨disjointed S.set, measurable_set.disjointed S.set_mem,
@@ -1840,7 +1840,7 @@ def disjointed_finite_spanning_sets_in (μ : measure α)
 
 lemma disjoint_disjointed_finite_spanning_sets_in {μ : measure α}
   (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
-  pairwise (disjoint on (disjointed_finite_spanning_sets_in μ S).set) :=
+  pairwise (disjoint on S.disjointed.set) :=
 disjoint_disjointed _
 
 /-- Given two σ-finite measures `μ` and `ν`, `finite_spanning_sets.in_add μ ν` is a sequence of
@@ -1849,7 +1849,6 @@ def finite_spanning_sets_in.add {μ ν : measure α}
   (S : μ.finite_spanning_sets_in {s | measurable_set s})
   (T : ν.finite_spanning_sets_in {s | measurable_set s}) :
   (μ + ν).finite_spanning_sets_in {s | measurable_set s} :=
-(μ + ν).disjointed_finite_spanning_sets_in $
 { set := λ n : ℕ, S.set n.unpair.1 ∩ T.set n.unpair.2,
   set_mem := λ n, (S.set_mem n.unpair.1).inter (T.set_mem n.unpair.2),
   finite :=
@@ -1861,12 +1860,6 @@ def finite_spanning_sets_in.add {μ ν : measure α}
     end,
   spanning := by simp_rw [set.Union_unpair (λ i j, S.set i ∩ T.set j), ← set.inter_Union,
                           ← set.Union_inter, S.spanning, T.spanning, set.inter_univ] }
-
-lemma finite_spanning_sets_in.add_disjoint {μ ν : measure α}
-  (S : μ.finite_spanning_sets_in {s | measurable_set s})
-  (T : ν.finite_spanning_sets_in {s | measurable_set s}):
-  pairwise (disjoint on (S.add T).set) :=
-disjoint_disjointed_finite_spanning_sets_in _
 
 /-- Given measures `μ`, `ν` where `ν ≤ μ`, `finite_spanning_sets_in_of_le` provides the induced
 `finite_spanning_set` with respect to `ν` from a `finite_spanning_set` with respect to `μ`. -/
@@ -1882,9 +1875,9 @@ lemma exists_eq_disjoint_finite_spanning_sets_in
   ∃ (S : μ.finite_spanning_sets_in {s | measurable_set s})
     (T : ν.finite_spanning_sets_in {s | measurable_set s}),
     S.set = T.set ∧ pairwise (disjoint on S.set) :=
-let S := μ.to_finite_spanning_sets_in.add ν.to_finite_spanning_sets_in in
+let S := (μ.to_finite_spanning_sets_in.add ν.to_finite_spanning_sets_in).disjointed in
 ⟨S.of_le (measure.le_add_right (le_refl _)), S.of_le (measure.le_add_left (le_refl _)),
- rfl, finite_spanning_sets_in.add_disjoint _ _⟩
+ rfl, disjoint_disjointed_finite_spanning_sets_in _⟩
 
 end disjointed
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1828,6 +1828,9 @@ section disjointed
 
 variable [measurable_space α]
 
+/-- Given `S : μ.finite_spanning_sets_in {s | measurable_set s}`,
+`disjointed_finite_spanning_sets_in` provides a `finite_spanning_sets_in {s | measurable_set s}`
+such that its underlying sets are pairwise disjoint. -/
 def disjointed_finite_spanning_sets_in (μ : measure α)
   (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
    μ.finite_spanning_sets_in {s | measurable_set s} :=
@@ -1848,7 +1851,7 @@ begin
   rw [← this, ← nat.surjective_unpair.Union_comp],
 end
 
-lemma exists_eq_finite_spanning_sets_in
+private lemma exists_eq_finite_spanning_sets_in
   (μ ν : measure α) [sigma_finite μ] [sigma_finite ν] :
   ∃ (S : μ.finite_spanning_sets_in {s | measurable_set s})
     (T : ν.finite_spanning_sets_in {s | measurable_set s}), S.set = T.set :=

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1865,7 +1865,7 @@ def finite_spanning_sets_in.add {μ ν : measure α}
 lemma finite_spanning_sets_in.add_disjoint {μ ν : measure α}
   (S : μ.finite_spanning_sets_in {s | measurable_set s})
   (T : ν.finite_spanning_sets_in {s | measurable_set s}):
-  pairwise (disjoint on (finite_spanning_sets_in.add S T).set) :=
+  pairwise (disjoint on (S.add T).set) :=
 disjoint_disjointed_finite_spanning_sets_in _
 
 /-- Given measures `μ`, `ν` where `ν ≤ μ`, `finite_spanning_sets_in_of_le` provides the induced

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1824,6 +1824,66 @@ begin
     (lt_of_le_of_lt (le_iff'.1 h _) (C.finite i)), C.spanning⟩⟩,
 end
 
+section disjointed
+
+variable [measurable_space α]
+
+def disjointed_finite_spanning_sets_in (μ : measure α)
+  (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
+   μ.finite_spanning_sets_in {s | measurable_set s} :=
+⟨disjointed S.set, measurable_set.disjointed S.set_mem,
+  λ n, lt_of_le_of_lt (measure_mono (disjointed_subset S.set n)) (S.finite _),
+  S.spanning ▸ Union_disjointed⟩
+
+lemma disjoint_disjointed_finite_spanning_sets_in {μ : measure α}
+  (S : μ.finite_spanning_sets_in {s | measurable_set s}) :
+  pairwise (disjoint on (disjointed_finite_spanning_sets_in μ S).set) :=
+disjoint_disjointed _
+
+lemma set.Union_unpair_inter (s t : ℕ → set α) :
+  (⋃ n : ℕ, s n.unpair.1 ∩ t n.unpair.2) = ⋃ i j : ℕ, s i ∩ t j :=
+begin
+  have : (⋃ i : ℕ × ℕ, s i.1 ∩ t i.2) = ⋃ i j : ℕ, s i ∩ t j,
+  { ext, simp only [set.mem_Union, prod.exists] },
+  rw [← this, ← nat.surjective_unpair.Union_comp],
+end
+
+lemma exists_eq_finite_spanning_sets_in
+  (μ ν : measure α) [sigma_finite μ] [sigma_finite ν] :
+  ∃ (S : μ.finite_spanning_sets_in {s | measurable_set s})
+    (T : ν.finite_spanning_sets_in {s | measurable_set s}), S.set = T.set :=
+begin
+  set S := μ.to_finite_spanning_sets_in,
+  set T := ν.to_finite_spanning_sets_in,
+  set W := λ n : ℕ, S.set n.unpair.1 ∩ T.set n.unpair.2 with hW,
+  have hW₁ : ∀ n, measurable_set (W n) :=
+    λ n, (S.set_mem n.unpair.1).inter (T.set_mem n.unpair.2),
+  have hW₂ : (⋃ i, W i) = set.univ,
+  { simp_rw [hW, set.Union_unpair_inter, ← set.inter_Union, ← set.Union_inter,
+             S.spanning, T.spanning, set.inter_univ] },
+  refine ⟨⟨W, hW₁, _, hW₂⟩, ⟨W, hW₁, _, hW₂⟩, rfl⟩,
+  { intro i,
+    refine lt_of_le_of_lt (measure_mono _) (S.finite i.unpair.1),
+    exact set.inter_subset_left _ _ },
+  { intro i,
+    refine lt_of_le_of_lt (measure_mono _) (T.finite i.unpair.2),
+    exact set.inter_subset_right _ _ },
+end
+
+lemma exists_eq_disjoint_finite_spanning_sets_in
+  (μ ν : measure α) [sigma_finite μ] [sigma_finite ν] :
+  ∃ (S : μ.finite_spanning_sets_in {s | measurable_set s})
+    (T : ν.finite_spanning_sets_in {s | measurable_set s}),
+    S.set = T.set ∧ pairwise (disjoint on S.set) :=
+begin
+  obtain ⟨S, T, hST⟩ := exists_eq_finite_spanning_sets_in μ ν,
+  refine ⟨disjointed_finite_spanning_sets_in μ S, disjointed_finite_spanning_sets_in ν T, _, _⟩,
+  { simp [disjointed_finite_spanning_sets_in, hST] },
+  { exact disjoint_disjointed_finite_spanning_sets_in _ }
+end
+
+end disjointed
+
 end measure
 
 include m0

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1845,7 +1845,7 @@ def finite_spanning_sets_in.of_le (h : ν ≤ μ) {C : set (set α)}
 
 lemma sigma_finite_of_le (μ : measure α) [hs : sigma_finite μ]
   (h : ν ≤ μ) : sigma_finite ν :=
-⟨nonempty.intro (hs.out.some.of_le h)⟩
+⟨hs.out.map $ finite_spanning_sets_in.of_le h⟩
 
 section disjointed
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1876,7 +1876,7 @@ lemma exists_eq_disjoint_finite_spanning_sets_in
     (T : ν.finite_spanning_sets_in {s | measurable_set s}),
     S.set = T.set ∧ pairwise (disjoint on S.set) :=
 let S := (μ.to_finite_spanning_sets_in.add ν.to_finite_spanning_sets_in).disjointed in
-⟨S.of_le (measure.le_add_right (le_refl _)), S.of_le (measure.le_add_left (le_refl _)),
+⟨S.of_le (measure.le_add_right le_rfl), S.of_le (measure.le_add_left le_rfl),
  rfl, finite_spanning_sets_in.disjoint_disjointed _⟩
 
 end disjointed


### PR DESCRIPTION
Given two sigma finite measures, there exists a sequence of pairwise disjoint spanning sets that are finite wrt. both measures

---

This is helpful in proving the Lebesgue decomposition for sigma finite measures

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
