### PR TITLE
[Merged by Bors] - feat(data/real/irrational): exists irrational between any two distinct rationals and reals

### DIFF
--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -300,7 +300,7 @@ theorem exists_irrational_btwn_rats {x y : ℚ} (h : x < y) :
 theorem exists_irrational_btwn {x y : ℝ} (h : x < y) :
   ∃ r, irrational r ∧ x < r ∧ r < y:=
 begin
-  obtain ⟨q₁, ⟨x_lt_q₁,  q₁_lt_y⟩⟩ := exists_rat_btwn h,
+  obtain ⟨q₁, ⟨x_lt_q₁, q₁_lt_y⟩⟩ := exists_rat_btwn h,
   obtain ⟨q₂, ⟨q₁_lt_q₂, q₂_lt_y⟩⟩ := exists_rat_btwn q₁_lt_y ,
   obtain ⟨r, ⟨irrat_r, q₁_lt_r, r_lt_q₂⟩⟩ := exists_irrational_btwn_rats (cast_lt.mp q₁_lt_q₂),
   exact ⟨r, irrat_r, lt_trans x_lt_q₁ q₁_lt_r, lt_trans r_lt_q₂ q₂_lt_y⟩,

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -263,10 +263,8 @@ open irrational
 
 theorem exists_irrational_btwn {x y : ℝ} (h : x < y) :
   ∃ r, irrational r ∧ x < r ∧ r < y :=
-begin
-  obtain ⟨q, ⟨hq1, hq2⟩⟩ := exists_rat_btwn ((sub_lt_sub_iff_right (real.sqrt 2)).mpr h),
-  refine ⟨q + real.sqrt 2, irrational_sqrt_two.rat_add _,
-    sub_lt_iff_lt_add.mp hq1,  lt_sub_iff_add_lt.mp hq2⟩,
-end
+let ⟨q, ⟨hq1, hq2⟩⟩ := (exists_rat_btwn ((sub_lt_sub_iff_right (real.sqrt 2)).mpr h)) in
+  ⟨q + real.sqrt 2, irrational_sqrt_two.rat_add _,
+    sub_lt_iff_lt_add.mp hq1,  lt_sub_iff_add_lt.mp hq2⟩
 
 end

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -262,46 +262,47 @@ open irrational
 -/
 
 /-- An irrational number between any two distinct rational numbers.-/
-noncomputable def irrational_btwn_rats {x y : ℚ} (h : x < y) : { r : ℝ // irrational r } :=
-⟨x +((y - x) : ℚ) * (real.sqrt 2)⁻¹, begin
-  refine irrational.rat_add _
-    (irrational.rat_mul
-      (irrational_inv_iff.mpr irrational_sqrt_two) _),
-  exact_mod_cast (ne_of_gt (sub_pos_of_lt h)) end⟩
+noncomputable def irrational_btwn_rats {x y : ℚ} (h : x < y) : ℝ :=
+x + ((y - x) : ℚ) * (real.sqrt 2)⁻¹
+
+def irrational_btwn_rats_irrational {x y : ℚ} (h : x < y) : irrational (irrational_btwn_rats h) :=
+((irrational_inv_iff.mpr irrational_sqrt_two).rat_mul
+  (by exact_mod_cast (ne_of_gt (sub_pos_of_lt h)))).rat_add _
 
 lemma lt_irrational_btwn_rats {x y : ℚ} (h : x < y) : (x : ℝ) < (irrational_btwn_rats h : ℝ) :=
 begin
   suffices : 0 < ↑(y - x) * (real.sqrt 2)⁻¹,
-  { simpa [irrational_btwn_rats] using h, },
+  { simpa [irrational_btwn_rats] using h },
   refine (zero_lt_mul_right _).mpr _,
-  apply inv_pos.mpr,
-  norm_num,
-  exact_mod_cast (sub_pos_of_lt h)
+  { apply inv_pos.mpr,
+    norm_num },
+  { exact_mod_cast (sub_pos_of_lt h) }
 end
 
 lemma irrational_btwn_rats_lt {x y : ℚ} (h : x < y) : (irrational_btwn_rats h : ℝ) < y :=
 begin
-  apply (sub_lt_sub_iff_right (x :ℝ)).mp,
+  apply (sub_lt_sub_iff_right (x : ℝ)).mp,
   simp only [irrational_btwn_rats, add_sub_cancel', cast_sub, subtype.coe_mk],
   refine (mul_lt_iff_lt_one_right _).mpr (inv_lt_one _),
-  exact_mod_cast  (sub_pos_of_lt h),
-  refine (real.lt_sqrt zero_le_one (zero_le_bit0.mpr zero_le_one)).mpr _,
-  rw one_pow,
-  exact one_lt_two
+  { exact_mod_cast (sub_pos_of_lt h) },
+  { refine (real.lt_sqrt zero_le_one (zero_le_bit0.mpr zero_le_one)).mpr _,
+    rw one_pow,
+    exact one_lt_two }
 end
 
 /-- There exists an irrational number between any two distinct rational numbers.-/
 theorem exists_irrational_btwn_rats {x y : ℚ} (h : x < y) :
-∃ r, irrational r ∧ (x : ℝ) < r ∧ r < y :=
-⟨irrational_btwn_rats h, subtype.prop _, lt_irrational_btwn_rats h, irrational_btwn_rats_lt h⟩
+  ∃ r, irrational r ∧ (x : ℝ) < r ∧ r < y :=
+⟨irrational_btwn_rats h, irrational_btwn_rats_irrational _,
+  lt_irrational_btwn_rats _, irrational_btwn_rats_lt _⟩
 
 /-- There exists an irrational number between any two distinct real numbers.-/
 theorem exists_irrational_btwn {x y : ℝ} (h : x < y) :
-∃ r, irrational r ∧ x < r ∧ r < y:=
+  ∃ r, irrational r ∧ x < r ∧ r < y:=
 begin
-  rcases exists_rat_btwn h with ⟨q₁, ⟨x_lt_q₁,  q₁_lt_y⟩⟩,
-  rcases exists_rat_btwn q₁_lt_y with ⟨q₂, ⟨q₁_lt_q₂, q₂_lt_y⟩⟩,
-  rcases exists_irrational_btwn_rats (cast_lt.mp q₁_lt_q₂) with ⟨r, ⟨irrat_r, q₁_lt_r, r_lt_q₂⟩⟩,
+  obtain ⟨q₁, ⟨x_lt_q₁,  q₁_lt_y⟩⟩ := exists_rat_btwn h,
+  obtain ⟨q₂, ⟨q₁_lt_q₂, q₂_lt_y⟩⟩ := exists_rat_btwn q₁_lt_y ,
+  obtain ⟨r, ⟨irrat_r, q₁_lt_r, r_lt_q₂⟩⟩ := exists_irrational_btwn_rats (cast_lt.mp q₁_lt_q₂),
   exact ⟨r, irrat_r, lt_trans x_lt_q₁ q₁_lt_r, lt_trans r_lt_q₂ q₂_lt_y⟩,
 end
 

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -258,52 +258,15 @@ open irrational
 ⟨of_inv, irrational.inv⟩
 
 /-!
-### Lemmas about Irrationals between Reals
+### Theorem about Irrationals between Reals
 -/
 
-/-- An irrational number between any two distinct rational numbers.-/
-noncomputable def irrational_btwn_rats {x y : ℚ} (h : x < y) : ℝ :=
-x + ((y - x) : ℚ) * (real.sqrt 2)⁻¹
-
-def irrational_btwn_rats_irrational {x y : ℚ} (h : x < y) : irrational (irrational_btwn_rats h) :=
-((irrational_inv_iff.mpr irrational_sqrt_two).rat_mul
-  (by exact_mod_cast (ne_of_gt (sub_pos_of_lt h)))).rat_add _
-
-lemma lt_irrational_btwn_rats {x y : ℚ} (h : x < y) : (x : ℝ) < (irrational_btwn_rats h : ℝ) :=
-begin
-  suffices : 0 < ↑(y - x) * (real.sqrt 2)⁻¹,
-  { simpa [irrational_btwn_rats] using h },
-  refine (zero_lt_mul_right _).mpr _,
-  { apply inv_pos.mpr,
-    norm_num },
-  { exact_mod_cast (sub_pos_of_lt h) }
-end
-
-lemma irrational_btwn_rats_lt {x y : ℚ} (h : x < y) : (irrational_btwn_rats h : ℝ) < y :=
-begin
-  apply (sub_lt_sub_iff_right (x : ℝ)).mp,
-  simp only [irrational_btwn_rats, add_sub_cancel', cast_sub, subtype.coe_mk],
-  refine (mul_lt_iff_lt_one_right _).mpr (inv_lt_one _),
-  { exact_mod_cast (sub_pos_of_lt h) },
-  { refine (real.lt_sqrt zero_le_one (zero_le_bit0.mpr zero_le_one)).mpr _,
-    rw one_pow,
-    exact one_lt_two }
-end
-
-/-- There exists an irrational number between any two distinct rational numbers.-/
-theorem exists_irrational_btwn_rats {x y : ℚ} (h : x < y) :
-  ∃ r, irrational r ∧ (x : ℝ) < r ∧ r < y :=
-⟨irrational_btwn_rats h, irrational_btwn_rats_irrational _,
-  lt_irrational_btwn_rats _, irrational_btwn_rats_lt _⟩
-
-/-- There exists an irrational number between any two distinct real numbers.-/
 theorem exists_irrational_btwn {x y : ℝ} (h : x < y) :
-  ∃ r, irrational r ∧ x < r ∧ r < y:=
+  ∃ r, irrational r ∧ x < r ∧ r < y :=
 begin
-  obtain ⟨q₁, ⟨x_lt_q₁, q₁_lt_y⟩⟩ := exists_rat_btwn h,
-  obtain ⟨q₂, ⟨q₁_lt_q₂, q₂_lt_y⟩⟩ := exists_rat_btwn q₁_lt_y ,
-  obtain ⟨r, ⟨irrat_r, q₁_lt_r, r_lt_q₂⟩⟩ := exists_irrational_btwn_rats (cast_lt.mp q₁_lt_q₂),
-  exact ⟨r, irrat_r, lt_trans x_lt_q₁ q₁_lt_r, lt_trans r_lt_q₂ q₂_lt_y⟩,
+  obtain ⟨q, ⟨hq1, hq2⟩⟩ := exists_rat_btwn ((sub_lt_sub_iff_right (real.sqrt 2)).mpr h),
+  refine ⟨q + real.sqrt 2, irrational_sqrt_two.rat_add _,
+    sub_lt_iff_lt_add.mp hq1,  lt_sub_iff_add_lt.mp hq2⟩,
 end
 
 end

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -265,6 +265,6 @@ theorem exists_irrational_btwn {x y : ℝ} (h : x < y) :
   ∃ r, irrational r ∧ x < r ∧ r < y :=
 let ⟨q, ⟨hq1, hq2⟩⟩ := (exists_rat_btwn ((sub_lt_sub_iff_right (real.sqrt 2)).mpr h)) in
   ⟨q + real.sqrt 2, irrational_sqrt_two.rat_add _,
-    sub_lt_iff_lt_add.mp hq1,  lt_sub_iff_add_lt.mp hq2⟩
+    sub_lt_iff_lt_add.mp hq1, lt_sub_iff_add_lt.mp hq2⟩
 
 end

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -257,10 +257,7 @@ open irrational
 @[simp] theorem irrational_inv_iff : irrational x⁻¹ ↔ irrational x :=
 ⟨of_inv, irrational.inv⟩
 
-/-!
-### Theorem about Irrationals between Reals
--/
-
+/-- There is an irrational number `r` between any two reals `x < r < y`. -/
 theorem exists_irrational_btwn {x y : ℝ} (h : x < y) :
   ∃ r, irrational r ∧ x < r ∧ r < y :=
 let ⟨q, ⟨hq1, hq2⟩⟩ := (exists_rat_btwn ((sub_lt_sub_iff_right (real.sqrt 2)).mpr h)) in

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -262,22 +262,20 @@ open irrational
 -/
 
 /-- There exists an irrational number between any two distinct rational numbers.-/
-theorem exists_irrational_btwn_rats {x y :ℚ} (h : (x :ℝ) < y) :
-∃ (r : ℝ), irrational r ∧ (x : ℝ) < r ∧ r < y:=
+theorem exists_irrational_btwn_rats {x y : ℚ} (h : x < y) :
+∃ r, irrational r ∧ (x : ℝ) < r ∧ r < y:=
 begin
-  use x + ((y - x) : ℚ) * (real.sqrt 2)⁻¹,
-  split,
+  refine ⟨x +((y - x) : ℚ) * (real.sqrt 2)⁻¹, _, _, _⟩,
   { refine irrational.rat_add _
       (irrational.rat_mul
         (irrational_inv_iff.mpr irrational_sqrt_two) _),
     exact_mod_cast (ne_of_gt (sub_pos_of_lt h)) },
-  split,
   { suffices : 0 < ↑(y - x) * (real.sqrt 2)⁻¹,
     { simpa using h, },
     refine (zero_lt_mul_right _).mpr _,
     apply inv_pos.mpr,
     norm_num,
-    exact_mod_cast (sub_pos_of_lt h)},
+    exact_mod_cast (sub_pos_of_lt h) },
   { apply (sub_lt_sub_iff_right (x :ℝ)).mp,
     rw [add_sub_cancel', ←cast_sub],
     refine (mul_lt_iff_lt_one_right _).mpr
@@ -289,14 +287,13 @@ begin
 end
 
 /-- There exists an irrational number between any two distinct real numbers.-/
-theorem exists_irrational_btwn {x y :ℝ} (h : x < y) :
-∃ (r : ℝ), irrational r ∧ x < r ∧ r < y:=
+theorem exists_irrational_btwn {x y : ℝ} (h : x < y) :
+∃ r, irrational r ∧ x < r ∧ r < y:=
 begin
   rcases exists_rat_btwn h with ⟨q₁, ⟨x_lt_q₁,  q₁_lt_y⟩⟩,
   rcases exists_rat_btwn q₁_lt_y with ⟨q₂, ⟨q₁_lt_q₂, q₂_lt_y⟩⟩,
-  rcases exists_irrational_btwn_rats q₁_lt_q₂ with ⟨r, ⟨irrational_r, q₁_lt_r, r_lt_q₂⟩⟩,
-  use r,
-  exact ⟨irrational_r, lt_trans x_lt_q₁ q₁_lt_r, lt_trans r_lt_q₂ q₂_lt_y⟩,
+  rcases exists_irrational_btwn_rats (cast_lt.mp q₁_lt_q₂) with ⟨r, ⟨irrational_r, q₁_lt_r, r_lt_q₂⟩⟩,
+  exact ⟨r, irrational_r, lt_trans x_lt_q₁ q₁_lt_r, lt_trans r_lt_q₂ q₂_lt_y⟩,
 end
 
 end

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -257,4 +257,44 @@ open irrational
 @[simp] theorem irrational_inv_iff : irrational x⁻¹ ↔ irrational x :=
 ⟨of_inv, irrational.inv⟩
 
+/-!
+### Lemmas about Irrationals between Reals
+-/
+
+theorem exists_irrational_btwn_rats {x y :ℚ} (h : (x :ℝ) < y) :
+∃ (r : ℝ), irrational r ∧ (x : ℝ) < r ∧ r < y:=
+begin
+  use x + ((y - x) : ℚ) * (real.sqrt 2)⁻¹,
+  split,
+  { refine irrational.rat_add _
+      (irrational.rat_mul
+        (irrational_inv_iff.mpr irrational_sqrt_two) _),
+    exact_mod_cast (ne_of_gt (sub_pos_of_lt h)) },
+  split,
+  { suffices : 0 < ↑(y - x) * (real.sqrt 2)⁻¹,
+    { simpa using h, },
+    refine (zero_lt_mul_right _).mpr _,
+    apply inv_pos.mpr,
+    norm_num,
+    exact_mod_cast (sub_pos_of_lt h)},
+  { apply (sub_lt_sub_iff_right (x :ℝ)).mp,
+    rw [add_sub_cancel', ←cast_sub],
+    refine (mul_lt_iff_lt_one_right _).mpr
+      (inv_lt_one _),
+    exact_mod_cast  (sub_pos_of_lt h),
+    refine (real.lt_sqrt zero_le_one (zero_le_bit0.mpr zero_le_one)).mpr _,
+    rw one_pow,
+    exact one_lt_two }
+end
+
+theorem exists_irrational_btwn {x y :ℝ} (h : x < y) :
+∃ (r : ℝ), irrational r ∧ x < r ∧ r < y:=
+begin
+  rcases exists_rat_btwn h with ⟨q₁, ⟨x_lt_q₁,  q₁_lt_y⟩⟩,
+  rcases exists_rat_btwn q₁_lt_y with ⟨q₂, ⟨q₁_lt_q₂, q₂_lt_y⟩⟩,
+  rcases exists_irrational_btwn_rats q₁_lt_q₂ with ⟨r, ⟨irrational_r, q₁_lt_r, r_lt_q₂⟩⟩,
+  use r,
+  refine ⟨irrational_r, lt_trans x_lt_q₁ q₁_lt_r, lt_trans r_lt_q₂ q₂_lt_y⟩,
+end
+
 end

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -261,6 +261,7 @@ open irrational
 ### Lemmas about Irrationals between Reals
 -/
 
+/-- There exists an irrational number between any two distinct rational numbers.-/
 theorem exists_irrational_btwn_rats {x y :ℚ} (h : (x :ℝ) < y) :
 ∃ (r : ℝ), irrational r ∧ (x : ℝ) < r ∧ r < y:=
 begin
@@ -287,6 +288,7 @@ begin
     exact one_lt_two }
 end
 
+/-- There exists an irrational number between any two distinct real numbers.-/
 theorem exists_irrational_btwn {x y :ℝ} (h : x < y) :
 ∃ (r : ℝ), irrational r ∧ x < r ∧ r < y:=
 begin
@@ -294,7 +296,7 @@ begin
   rcases exists_rat_btwn q₁_lt_y with ⟨q₂, ⟨q₁_lt_q₂, q₂_lt_y⟩⟩,
   rcases exists_irrational_btwn_rats q₁_lt_q₂ with ⟨r, ⟨irrational_r, q₁_lt_r, r_lt_q₂⟩⟩,
   use r,
-  refine ⟨irrational_r, lt_trans x_lt_q₁ q₁_lt_r, lt_trans r_lt_q₂ q₂_lt_y⟩,
+  exact ⟨irrational_r, lt_trans x_lt_q₁ q₁_lt_r, lt_trans r_lt_q₂ q₂_lt_y⟩,
 end
 
 end

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -292,8 +292,8 @@ theorem exists_irrational_btwn {x y : ℝ} (h : x < y) :
 begin
   rcases exists_rat_btwn h with ⟨q₁, ⟨x_lt_q₁,  q₁_lt_y⟩⟩,
   rcases exists_rat_btwn q₁_lt_y with ⟨q₂, ⟨q₁_lt_q₂, q₂_lt_y⟩⟩,
-  rcases exists_irrational_btwn_rats (cast_lt.mp q₁_lt_q₂) with ⟨r, ⟨irrational_r, q₁_lt_r, r_lt_q₂⟩⟩,
-  exact ⟨r, irrational_r, lt_trans x_lt_q₁ q₁_lt_r, lt_trans r_lt_q₂ q₂_lt_y⟩,
+  rcases exists_irrational_btwn_rats (cast_lt.mp q₁_lt_q₂) with ⟨r, ⟨irrat_r, q₁_lt_r, r_lt_q₂⟩⟩,
+  exact ⟨r, irrat_r, lt_trans x_lt_q₁ q₁_lt_r, lt_trans r_lt_q₂ q₂_lt_y⟩,
 end
 
 end

--- a/src/data/real/irrational.lean
+++ b/src/data/real/irrational.lean
@@ -261,30 +261,39 @@ open irrational
 ### Lemmas about Irrationals between Reals
 -/
 
+/-- An irrational number between any two distinct rational numbers.-/
+noncomputable def irrational_btwn_rats {x y : ℚ} (h : x < y) : { r : ℝ // irrational r } :=
+⟨x +((y - x) : ℚ) * (real.sqrt 2)⁻¹, begin
+  refine irrational.rat_add _
+    (irrational.rat_mul
+      (irrational_inv_iff.mpr irrational_sqrt_two) _),
+  exact_mod_cast (ne_of_gt (sub_pos_of_lt h)) end⟩
+
+lemma lt_irrational_btwn_rats {x y : ℚ} (h : x < y) : (x : ℝ) < (irrational_btwn_rats h : ℝ) :=
+begin
+  suffices : 0 < ↑(y - x) * (real.sqrt 2)⁻¹,
+  { simpa [irrational_btwn_rats] using h, },
+  refine (zero_lt_mul_right _).mpr _,
+  apply inv_pos.mpr,
+  norm_num,
+  exact_mod_cast (sub_pos_of_lt h)
+end
+
+lemma irrational_btwn_rats_lt {x y : ℚ} (h : x < y) : (irrational_btwn_rats h : ℝ) < y :=
+begin
+  apply (sub_lt_sub_iff_right (x :ℝ)).mp,
+  simp only [irrational_btwn_rats, add_sub_cancel', cast_sub, subtype.coe_mk],
+  refine (mul_lt_iff_lt_one_right _).mpr (inv_lt_one _),
+  exact_mod_cast  (sub_pos_of_lt h),
+  refine (real.lt_sqrt zero_le_one (zero_le_bit0.mpr zero_le_one)).mpr _,
+  rw one_pow,
+  exact one_lt_two
+end
+
 /-- There exists an irrational number between any two distinct rational numbers.-/
 theorem exists_irrational_btwn_rats {x y : ℚ} (h : x < y) :
-∃ r, irrational r ∧ (x : ℝ) < r ∧ r < y:=
-begin
-  refine ⟨x +((y - x) : ℚ) * (real.sqrt 2)⁻¹, _, _, _⟩,
-  { refine irrational.rat_add _
-      (irrational.rat_mul
-        (irrational_inv_iff.mpr irrational_sqrt_two) _),
-    exact_mod_cast (ne_of_gt (sub_pos_of_lt h)) },
-  { suffices : 0 < ↑(y - x) * (real.sqrt 2)⁻¹,
-    { simpa using h, },
-    refine (zero_lt_mul_right _).mpr _,
-    apply inv_pos.mpr,
-    norm_num,
-    exact_mod_cast (sub_pos_of_lt h) },
-  { apply (sub_lt_sub_iff_right (x :ℝ)).mp,
-    rw [add_sub_cancel', ←cast_sub],
-    refine (mul_lt_iff_lt_one_right _).mpr
-      (inv_lt_one _),
-    exact_mod_cast  (sub_pos_of_lt h),
-    refine (real.lt_sqrt zero_le_one (zero_le_bit0.mpr zero_le_one)).mpr _,
-    rw one_pow,
-    exact one_lt_two }
-end
+∃ r, irrational r ∧ (x : ℝ) < r ∧ r < y :=
+⟨irrational_btwn_rats h, subtype.prop _, lt_irrational_btwn_rats h, irrational_btwn_rats_lt h⟩
 
 /-- There exists an irrational number between any two distinct real numbers.-/
 theorem exists_irrational_btwn {x y : ℝ} (h : x < y) :


### PR DESCRIPTION
Did not find these proofs in `data/real/irrational`, seemed like they belong here.  Just proving the standard facts about irrationals between rats and reals.  I am using these lemmas in a repo about the Thomae's function.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
