### PR TITLE
[Merged by Bors] - feat(data/nat/log): Ceil log

### DIFF
--- a/src/data/nat/log.lean
+++ b/src/data/nat/log.lean
@@ -8,11 +8,11 @@ import data.nat.pow
 /-!
 # Natural number logarithms
 
-This file defines two `ℕ`-valued ana**log**s of the logarithm of `n` with base `b`:
+This file defines two `ℕ`-valued analogs of the logarithm of `n` with base `b`:
 * `log b n`: Lower logarithm, or floor **log**. Greatest `k` such that `b^k ≤ n`.
 * `clog b n`: Upper logarithm, or **c**eil **log**. Least `k` such that `n ≤ b^k`.
 
-These are interesting because, for `2 ≤ b`, `nat.log b` and `nat.clog b` are respectively right and
+These are interesting because, for `1 < b`, `nat.log b` and `nat.clog b` are respectively right and
 left adjoints of `nat.pow b`. See `pow_le_iff_le_log` and `le_pow_iff_clog_le`.
 -/
 
@@ -104,7 +104,7 @@ end
 lemma log_mono {b : ℕ} : monotone (λ n : ℕ, log b n) :=
 λ x y, log_le_log_of_le
 
-private lemma add_pred_div_lt {b n : ℕ} (hb : 2 ≤ b) (hn : 2 ≤ n) : (n + b - 1)/b < n :=
+private lemma add_pred_div_lt {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) : (n + b - 1)/b < n :=
 begin
   rw [div_lt_iff_lt_mul _ _ (zero_lt_one.trans hb), ←succ_le_iff, ←pred_eq_sub_one,
     succ_pred_eq_of_pos (add_pos (zero_lt_one.trans hn) (zero_lt_one.trans hb))],
@@ -140,11 +140,11 @@ clog_of_left_le_one le_rfl _
 lemma clog_one_right (b : ℕ) : clog b 1 = 0 :=
 clog_of_right_le_one le_rfl _
 
-lemma clog_of_two_le {b n : ℕ} (hb : 2 ≤ b) (hn : 2 ≤ n) :
+lemma clog_of_two_le {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) :
   clog b n = clog b ((n + b - 1)/b) + 1 :=
 by rw [clog, if_pos (⟨hb, hn⟩ : 1 < b ∧ 1 < n)]
 
-lemma clog_pos {b n : ℕ} (hb : 2 ≤ b) (hn : 2 ≤ n) : 0 < clog b n :=
+lemma clog_pos {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) : 0 < clog b n :=
 by { rw clog_of_two_le hb hn, exact zero_lt_succ _ }
 
 lemma clog_eq_one {b n : ℕ} (hn : 2 ≤ n) (h : n ≤ b) : clog b n = 1 :=
@@ -157,7 +157,7 @@ begin
 end
 
 /--`clog b` and `pow b` form a Galois connection. -/
-lemma le_pow_iff_clog_le {b : ℕ} (hb : 2 ≤ b) {x y : ℕ} :
+lemma le_pow_iff_clog_le {b : ℕ} (hb : 1 < b) {x y : ℕ} :
   x ≤ b^y ↔ clog b x ≤ y :=
 begin
   induction x using nat.strong_induction_on with x ih generalizing y,
@@ -187,7 +187,7 @@ begin
   exact pred_lt (clog_pos hb hx).ne',
 end
 
-lemma le_pow_clog {b : ℕ} (hb : 2 ≤ b) (x : ℕ) : x ≤ b ^ clog b x :=
+lemma le_pow_clog {b : ℕ} (hb : 1 < b) (x : ℕ) : x ≤ b ^ clog b x :=
 (le_pow_iff_clog_le hb).2 le_rfl
 
 lemma clog_le_clog_of_le (b : ℕ) {n m : ℕ} (h : n ≤ m) : clog b n ≤ clog b m :=

--- a/src/data/nat/log.lean
+++ b/src/data/nat/log.lean
@@ -42,16 +42,16 @@ by rw [log, if_neg (λ h : b ≤ n ∧ 1 < b, h.1.not_lt hnb)]
 lemma log_of_left_le_one {b n : ℕ} (hb : b ≤ 1) : log b n = 0 :=
 by rw [log, if_neg (λ h : b ≤ n ∧ 1 < b, h.2.not_le hb)]
 
-lemma log_zero_left (n : ℕ) : log 0 n = 0 :=
+@[simp] lemma log_zero_left (n : ℕ) : log 0 n = 0 :=
 log_of_left_le_one zero_le_one
 
-lemma log_zero_right (b : ℕ) : log b 0 = 0 :=
+@[simp] lemma log_zero_right (b : ℕ) : log b 0 = 0 :=
 by { rw log, cases b; refl }
 
-lemma log_one_left (n : ℕ) : log 1 n = 0 :=
+@[simp] lemma log_one_left (n : ℕ) : log 1 n = 0 :=
 log_of_left_le_one le_rfl
 
-lemma log_one_right (b : ℕ) : log b 1 = 0 :=
+@[simp] lemma log_one_right (b : ℕ) : log b 1 = 0 :=
 if h : b ≤ 1 then
   log_of_left_le_one h
 else
@@ -128,16 +128,16 @@ by rw [clog, if_neg (λ h : 1 < b ∧ 1 < n, h.1.not_le hb)]
 lemma clog_of_right_le_one {n : ℕ} (hn : n ≤ 1) (b : ℕ) : clog b n = 0 :=
 by rw [clog, if_neg (λ h : 1 < b ∧ 1 < n, h.2.not_le hn)]
 
-lemma clog_zero_left (n : ℕ) : clog 0 n = 0 :=
+@[simp] lemma clog_zero_left (n : ℕ) : clog 0 n = 0 :=
 clog_of_left_le_one zero_le_one _
 
-lemma clog_zero_right (b : ℕ) : clog b 0 = 0 :=
+@[simp] lemma clog_zero_right (b : ℕ) : clog b 0 = 0 :=
 clog_of_right_le_one zero_le_one _
 
-lemma clog_one_left (n : ℕ) : clog 1 n = 0 :=
+@[simp] lemma clog_one_left (n : ℕ) : clog 1 n = 0 :=
 clog_of_left_le_one le_rfl _
 
-lemma clog_one_right (b : ℕ) : clog b 1 = 0 :=
+@[simp] lemma clog_one_right (b : ℕ) : clog b 1 = 0 :=
 clog_of_right_le_one le_rfl _
 
 lemma clog_of_two_le {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) :

--- a/src/data/nat/log.lean
+++ b/src/data/nat/log.lean
@@ -1,18 +1,24 @@
 /-
 Copyright (c) 2020 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Simon Hudon
+Authors: Simon Hudon, Yaël Dillies
 -/
 import data.nat.pow
 
 /-!
-# Natural number logarithm
+# Natural number logarithms
 
-This file defines `log b n`, the logarithm of `n` with base `b`, to be the largest `k` such that
-`b ^ k ≤ n`.
+This file defines two `ℕ`-valued ana**log**s of the logarithm of `n` with base `b`:
+* `log b n`: Lower logarithm, or floor **log**. Greatest `k` such that `b^k ≤ n`.
+* `clog b n`: Upper logarithm, or **c**eil **log**. Least `k` such that `n ≤ b^k`.
 
+These are of interest because, for `2 ≤ b`, `nat.log b` and `nat.clog b` are respectively right and
+left adjoints of `nat.pow b`. See `pow_le_iff_le_log` and `le_pow_iff_clog_le`.
 -/
+
 namespace nat
+
+/-! ### Floor logarithm -/
 
 /-- `log b n`, is the logarithm of natural number `n` in base `b`. It returns the largest `k : ℕ`
 such that `b^k ≤ n`, so if `b^k = n`, it returns exactly `k`. -/
@@ -20,8 +26,7 @@ such that `b^k ≤ n`, so if `b^k = n`, it returns exactly `k`. -/
 | n :=
   if h : b ≤ n ∧ 1 < b then
     have n / b < n,
-      from div_lt_self
-        (nat.lt_of_lt_of_le (lt_trans zero_lt_one h.2) h.1) h.2,
+      from div_lt_self ((zero_lt_one.trans h.2).trans_le h.1) h.2,
     log (n / b) + 1
   else 0
 
@@ -31,81 +36,169 @@ begin
   rw [log, ←ite_not, if_pos hnb],
 end
 
-lemma log_eq_zero_of_lt {b n : ℕ} (hn : n < b) : log b n = 0 :=
-log_eq_zero $ or.inl hn
+lemma log_of_lt {b n : ℕ} (hnb : n < b) : log b n = 0 :=
+by rw [log, if_neg (λ h : b ≤ n ∧ 1 < b, h.1.not_lt hnb)]
 
-lemma log_eq_zero_of_le {b n : ℕ} (hb : b ≤ 1) : log b n = 0 :=
-log_eq_zero $ or.inr hb
+lemma log_of_left_le_one {b n : ℕ} (hb : b ≤ 1) : log b n = 0 :=
+by rw [log, if_neg (λ h : b ≤ n ∧ 1 < b, h.2.not_le hb)]
 
-lemma log_zero_eq_zero {b : ℕ} : log b 0 = 0 :=
+lemma log_zero_left (n : ℕ) : log 0 n = 0 :=
+log_of_left_le_one zero_le_one
+
+lemma log_zero_right (b : ℕ) : log b 0 = 0 :=
 by { rw log, cases b; refl }
 
-lemma log_one_eq_zero {b : ℕ} : log b 1 = 0 :=
+lemma log_one_left (n : ℕ) : log 1 n = 0 :=
+log_of_left_le_one rfl.ge
+
+lemma log_one_right (b : ℕ) : log b 1 = 0 :=
 if h : b ≤ 1 then
-  log_eq_zero_of_le h
+  log_of_left_le_one h
 else
-  log_eq_zero_of_lt (not_le.mp h)
+  log_of_lt (not_le.mp h)
 
-lemma log_b_zero_eq_zero {n : ℕ} : log 0 n = 0 :=
-log_eq_zero_of_le zero_le_one
-
-lemma log_b_one_eq_zero {n : ℕ} : log 1 n = 0 :=
-log_eq_zero_of_le rfl.ge
-
-lemma pow_le_iff_le_log (x y : ℕ) {b} (hb : 1 < b) (hy : 1 ≤ y) :
+/-- `b^` and `log b` (almost) form a Galois connection. -/
+lemma pow_le_iff_le_log {b : ℕ} (hb : 1 < b) {x y : ℕ} (hy : 0 < y) :
   b^x ≤ y ↔ x ≤ log b y :=
 begin
-  induction y using nat.strong_induction_on with y ih
-    generalizing x,
-  rw [log], split_ifs,
-  { have h'' : 0 < b := lt_of_le_of_lt (zero_le _) hb,
-    cases h with h₀ h₁,
-    rw [← nat.sub_le_right_iff_le_add,← ih (y / b),
-          le_div_iff_mul_le _ _ h'',← pow_succ'],
-    { cases x; simp [h₀,hy] },
-    { apply div_lt_self; assumption },
-    { rwa [le_div_iff_mul_le _ _ h'',one_mul], } },
-  { replace h := lt_of_not_ge (not_and'.1 h hb),
-    split; intros h',
-    { have := lt_of_le_of_lt h' h,
-      apply le_of_succ_le_succ,
-      change x < 1, rw [← pow_lt_iff_lt_right hb,pow_one],
-      exact this },
-    { replace h' := le_antisymm h' (zero_le _),
-      rw [h',pow_zero], exact hy} },
+  induction y using nat.strong_induction_on with y ih generalizing x,
+  cases x,
+  { exact iff_of_true hy (zero_le _) },
+  rw log, split_ifs,
+  { have b_pos : 0 < b := zero_le_one.trans_lt hb,
+    rw [succ_eq_add_one, add_le_add_iff_right, ←ih (y / b) (div_lt_self hy hb)
+      (nat.div_pos h.1 b_pos), le_div_iff_mul_le _ _ b_pos, pow_succ'] },
+  { refine iff_of_false (λ hby, h ⟨le_trans _ hby, hb⟩) (not_succ_le_zero _),
+    convert pow_mono hb.le (zero_lt_succ x),
+    exact (pow_one b).symm }
 end
 
-lemma log_pow (b x : ℕ) (hb : 1 < b) : log b (b ^ x) = x :=
+lemma log_pow {b : ℕ} (hb : 1 < b) (x : ℕ) : log b (b ^ x) = x :=
 eq_of_forall_le_iff $ λ z,
-by { rwa [← pow_le_iff_le_log _ _ hb,pow_le_iff_le_right],
-     rw ← pow_zero b, apply pow_le_pow_of_le_right,
-     apply lt_of_le_of_lt (zero_le _) hb, apply zero_le }
+by { rw ←pow_le_iff_le_log hb (pow_pos (zero_lt_one.trans hb) _),
+    exact (pow_right_strict_mono hb).le_iff_le }
 
-lemma pow_succ_log_gt_self (b x : ℕ) (hb : 1 < b) (hy : 1 ≤ x) :
-  x < b ^ succ (log b x) :=
+lemma lt_pow_succ_log_self {b : ℕ} (hb : 1 < b) {x : ℕ} (hx : 0 < x) :
+  x < b ^ (log b x).succ :=
 begin
-  apply lt_of_not_ge,
-  rw [(≥),pow_le_iff_le_log _ _ hb hy],
-  apply not_le_of_lt, apply lt_succ_self,
+  rw [←not_le, pow_le_iff_le_log hb hx, not_le],
+  exact lt_succ_self _,
 end
 
-lemma pow_log_le_self (b x : ℕ) (hb : 1 < b) (hx : 1 ≤ x) : b ^ log b x ≤ x :=
-by rw [pow_le_iff_le_log _ _ hb hx]
+lemma pow_log_le_self {b : ℕ} (hb : 1 < b) {x : ℕ} (hx : 0 < x) : b ^ log b x ≤ x :=
+(pow_le_iff_le_log hb hx).2 le_rfl
 
 lemma log_le_log_of_le {b n m : ℕ} (h : n ≤ m) : log b n ≤ log b m :=
 begin
   cases le_or_lt b 1 with hb hb,
-  { rw log_eq_zero_of_le hb, exact zero_le _ },
+  { rw log_of_left_le_one hb, exact zero_le _ },
   { cases nat.eq_zero_or_pos n with hn hn,
-    { rw [hn, log_zero_eq_zero], exact zero_le _ },
-    { rw ←pow_le_iff_le_log _ _ hb (lt_of_lt_of_le hn h),
-      exact (pow_log_le_self b n hb hn).trans h } }
+    { rw [hn, log_zero_right], exact zero_le _ },
+    { rw ←pow_le_iff_le_log hb (hn.trans_le h),
+      exact (pow_log_le_self hb hn).trans h } }
 end
 
-lemma log_le_log_succ {b n : ℕ} : log b n ≤ log b n.succ :=
-log_le_log_of_le $ le_succ n
-
 lemma log_mono {b : ℕ} : monotone (λ n : ℕ, log b n) :=
-monotone_nat_of_le_succ $ λ n, log_le_log_succ
+λ x y, log_le_log_of_le
+
+private lemma add_pred_div_lt {b n : ℕ} (hb : 2 ≤ b) (hn : 2 ≤ n) : (n + b - 1)/b < n :=
+begin
+  rw [div_lt_iff_lt_mul _ _ (zero_lt_one.trans hb), ←succ_le_iff, ←pred_eq_sub_one,
+    succ_pred_eq_of_pos (add_pos (zero_lt_one.trans hn) (zero_lt_one.trans hb))],
+  exact add_le_mul hn hb,
+end
+
+/-! ### Ceil logarithm -/
+
+/-- `clog b n`, is the upper logarithm of natural number `n` in base `b`. It returns the smallest
+`k : ℕ` such that `n ≤ b^k`, so if `b^k = n`, it returns exactly `k`. -/
+@[pp_nodot] def clog (b : ℕ) : ℕ → ℕ
+| n :=
+  if h : 1 < b ∧ 1 < n then
+    have (n + b - 1)/b < n := add_pred_div_lt h.1 h.2,
+    clog ((n + b - 1)/b) + 1
+  else 0
+
+lemma clog_of_left_le_one {b : ℕ} (hb : b ≤ 1) (n : ℕ) : clog b n = 0 :=
+by rw [clog, if_neg (λ h : 1 < b ∧ 1 < n, h.1.not_le hb)]
+
+lemma clog_of_right_le_one {n : ℕ} (hn : n ≤ 1) (b : ℕ) : clog b n = 0 :=
+by rw [clog, if_neg (λ h : 1 < b ∧ 1 < n, h.2.not_le hn)]
+
+lemma clog_zero_left (n : ℕ) : clog 0 n = 0 :=
+clog_of_left_le_one zero_le_one _
+
+lemma clog_zero_right (b : ℕ) : clog b 0 = 0 :=
+clog_of_right_le_one zero_le_one _
+
+lemma clog_one_left (n : ℕ) : clog 1 n = 0 :=
+clog_of_left_le_one le_rfl _
+
+lemma clog_one_right (b : ℕ) : clog b 1 = 0 :=
+clog_of_right_le_one le_rfl _
+
+lemma clog_of_two_le {b n : ℕ} (hb : 2 ≤ b) (hn : 2 ≤ n) :
+  clog b n = clog b ((n + b - 1)/b) + 1 :=
+by rw [clog, if_pos (⟨hb, hn⟩ : 1 < b ∧ 1 < n)]
+
+lemma clog_pos {b n : ℕ} (hb : 2 ≤ b) (hn : 2 ≤ n) : 0 < clog b n :=
+by { rw clog_of_two_le hb hn, exact zero_lt_succ _ }
+
+lemma clog_eq_one {b n : ℕ} (hn : 2 ≤ n) (h : n ≤ b) : clog b n = 1 :=
+begin
+  rw [clog_of_two_le (hn.trans h) hn, clog_of_right_le_one],
+  have n_pos : 0 < n := zero_lt_two.trans_le hn,
+  rw [←lt_succ_iff, nat.div_lt_iff_lt_mul _ _ (n_pos.trans_le h), ←succ_le_iff,
+    ←pred_eq_sub_one, succ_pred_eq_of_pos (add_pos n_pos (n_pos.trans_le h)), succ_mul, one_mul],
+  exact add_le_add_right h _,
+end
+
+
+/--`clog b` and `b^` form a Galois connection. -/
+lemma le_pow_iff_clog_le {b : ℕ} (hb : 2 ≤ b) {x y : ℕ} :
+  x ≤ b^y ↔ clog b x ≤ y :=
+begin
+  induction x using nat.strong_induction_on with x ih generalizing y,
+  cases y,
+  { rw [pow_zero],
+    refine ⟨λ h, (clog_of_right_le_one h b).le, _⟩,
+    simp_rw ←not_lt,
+    contrapose!,
+    exact clog_pos hb },
+  have b_pos : 0 < b := zero_lt_two.trans_le hb,
+  rw clog, split_ifs,
+  { rw [succ_eq_add_one, add_le_add_iff_right, ←ih ((x + b - 1)/b) (add_pred_div_lt hb h.2),
+      nat.div_le_iff_le_mul_add_pred b_pos, ←pow_succ, nat.add_sub_assoc b_pos,
+      add_le_add_iff_right] },
+  { exact iff_of_true ((not_lt.1 (not_and.1 h hb)).trans $ succ_le_of_lt $ pow_pos b_pos _)
+    (zero_le _) }
+end
+
+lemma clog_pow (b x : ℕ) (hb : 1 < b) : clog b (b ^ x) = x :=
+eq_of_forall_ge_iff $ λ z,
+by { rw ←le_pow_iff_clog_le hb, exact (pow_right_strict_mono hb).le_iff_le }
+
+lemma pow_pred_clog_lt_self {b x : ℕ} (hb : 1 < b) {x : ℕ} (hx : 1 < x) :
+  b ^ (clog b x).pred < x :=
+begin
+  rw [←not_le, le_pow_iff_clog_le hb, not_le],
+  exact pred_lt (clog_pos hb hx).ne',
+end
+
+lemma le_pow_clog {b : ℕ} (hb : 2 ≤ b) {x : ℕ} (hx : 0 < x) : x ≤ b ^ clog b x :=
+(le_pow_iff_clog_le hb).2 le_rfl
+
+lemma clog_le_clog_of_le {b n m : ℕ} (h : n ≤ m) : clog b n ≤ clog b m :=
+begin
+  cases le_or_lt b 1 with hb hb,
+  { rw clog_of_left_le_one hb, exact zero_le _ },
+  { obtain rfl | hn := n.eq_zero_or_pos,
+    { rw [clog_zero_right], exact zero_le _ },
+    { rw ←le_pow_iff_clog_le hb,
+      exact h.trans (le_pow_clog hb $ hn.trans_le h) } }
+end
+
+lemma clog_mono {b : ℕ} : monotone (clog b) :=
+λ x y, clog_le_clog_of_le
 
 end nat

--- a/src/data/nat/log.lean
+++ b/src/data/nat/log.lean
@@ -12,7 +12,7 @@ This file defines two `ℕ`-valued ana**log**s of the logarithm of `n` with base
 * `log b n`: Lower logarithm, or floor **log**. Greatest `k` such that `b^k ≤ n`.
 * `clog b n`: Upper logarithm, or **c**eil **log**. Least `k` such that `n ≤ b^k`.
 
-These are of interest because, for `2 ≤ b`, `nat.log b` and `nat.clog b` are respectively right and
+These are interesting because, for `2 ≤ b`, `nat.log b` and `nat.clog b` are respectively right and
 left adjoints of `nat.pow b`. See `pow_le_iff_le_log` and `le_pow_iff_clog_le`.
 -/
 
@@ -49,7 +49,7 @@ lemma log_zero_right (b : ℕ) : log b 0 = 0 :=
 by { rw log, cases b; refl }
 
 lemma log_one_left (n : ℕ) : log 1 n = 0 :=
-log_of_left_le_one rfl.ge
+log_of_left_le_one le_rfl
 
 lemma log_one_right (b : ℕ) : log b 1 = 0 :=
 if h : b ≤ 1 then
@@ -57,7 +57,7 @@ if h : b ≤ 1 then
 else
   log_of_lt (not_le.mp h)
 
-/-- `b^` and `log b` (almost) form a Galois connection. -/
+/-- `pow b` and `log b` (almost) form a Galois connection. -/
 lemma pow_le_iff_le_log {b : ℕ} (hb : 1 < b) {x y : ℕ} (hy : 0 < y) :
   b^x ≤ y ↔ x ≤ log b y :=
 begin
@@ -153,8 +153,7 @@ begin
   exact add_le_add_right h _,
 end
 
-
-/--`clog b` and `b^` form a Galois connection. -/
+/--`clog b` and `pow b` form a Galois connection. -/
 lemma le_pow_iff_clog_le {b : ℕ} (hb : 2 ≤ b) {x y : ℕ} :
   x ≤ b^y ↔ clog b x ≤ y :=
 begin
@@ -200,5 +199,17 @@ end
 
 lemma clog_mono {b : ℕ} : monotone (clog b) :=
 λ x y, clog_le_clog_of_le
+
+lemma log_le_clog (b n : ℕ) : log b n ≤ clog b n :=
+begin
+  obtain hb | hb := le_or_lt b 1,
+  { rw log_of_left_le_one hb,
+    exact zero_le _},
+  cases n,
+  { rw log_zero_right,
+    exact zero_le _},
+  exact (pow_right_strict_mono hb).le_iff_le.1 ((pow_log_le_self hb $ succ_pos _).trans $
+    le_pow_clog hb $ succ_pos _),
+end
 
 end nat

--- a/src/data/nat/log.lean
+++ b/src/data/nat/log.lean
@@ -78,6 +78,9 @@ eq_of_forall_le_iff $ λ z,
 by { rw ←pow_le_iff_le_log hb (pow_pos (zero_lt_one.trans hb) _),
     exact (pow_right_strict_mono hb).le_iff_le }
 
+lemma log_pos {b n : ℕ} (hb : 1 < b) (hn : b ≤ n) : 0 < log b n :=
+by { rwa [←succ_le_iff, ←pow_le_iff_le_log hb (hb.le.trans hn), pow_one] }
+
 lemma lt_pow_succ_log_self {b : ℕ} (hb : 1 < b) {x : ℕ} (hx : 0 < x) :
   x < b ^ (log b x).succ :=
 begin
@@ -177,28 +180,28 @@ lemma clog_pow (b x : ℕ) (hb : 1 < b) : clog b (b ^ x) = x :=
 eq_of_forall_ge_iff $ λ z,
 by { rw ←le_pow_iff_clog_le hb, exact (pow_right_strict_mono hb).le_iff_le }
 
-lemma pow_pred_clog_lt_self {b x : ℕ} (hb : 1 < b) {x : ℕ} (hx : 1 < x) :
+lemma pow_pred_clog_lt_self {b : ℕ} (hb : 1 < b) {x : ℕ} (hx : 1 < x) :
   b ^ (clog b x).pred < x :=
 begin
   rw [←not_le, le_pow_iff_clog_le hb, not_le],
   exact pred_lt (clog_pos hb hx).ne',
 end
 
-lemma le_pow_clog {b : ℕ} (hb : 2 ≤ b) {x : ℕ} (hx : 0 < x) : x ≤ b ^ clog b x :=
+lemma le_pow_clog {b : ℕ} (hb : 2 ≤ b) (x : ℕ) : x ≤ b ^ clog b x :=
 (le_pow_iff_clog_le hb).2 le_rfl
 
-lemma clog_le_clog_of_le {b n m : ℕ} (h : n ≤ m) : clog b n ≤ clog b m :=
+lemma clog_le_clog_of_le (b : ℕ) {n m : ℕ} (h : n ≤ m) : clog b n ≤ clog b m :=
 begin
   cases le_or_lt b 1 with hb hb,
   { rw clog_of_left_le_one hb, exact zero_le _ },
   { obtain rfl | hn := n.eq_zero_or_pos,
     { rw [clog_zero_right], exact zero_le _ },
     { rw ←le_pow_iff_clog_le hb,
-      exact h.trans (le_pow_clog hb $ hn.trans_le h) } }
+      exact h.trans (le_pow_clog hb _) } }
 end
 
-lemma clog_mono {b : ℕ} : monotone (clog b) :=
-λ x y, clog_le_clog_of_le
+lemma clog_mono (b : ℕ) : monotone (clog b) :=
+λ x y, clog_le_clog_of_le _
 
 lemma log_le_clog (b n : ℕ) : log b n ≤ clog b n :=
 begin
@@ -209,7 +212,7 @@ begin
   { rw log_zero_right,
     exact zero_le _},
   exact (pow_right_strict_mono hb).le_iff_le.1 ((pow_log_le_self hb $ succ_pos _).trans $
-    le_pow_clog hb $ succ_pos _),
+    le_pow_clog hb _),
 end
 
 end nat

--- a/src/data/nat/multiplicity.lean
+++ b/src/data/nat/multiplicity.lean
@@ -12,8 +12,9 @@ import ring_theory.int.basic
 /-!
 # Natural number multiplicity
 
-This file contains lemmas about the multiplicity function (the maximum prime power divding a number)
-when applied to naturals, in particular calculating it for factorials and binomial coefficients.
+This file contains lemmas about the multiplicity function (the maximum prime power dividing a
+number) when applied to naturals, in particular calculating it for factorials and binomial
+coefficients.
 
 ## Multiplicity calculations
 
@@ -127,7 +128,7 @@ begin
     add_comm (1 : enat)]
 end
 
-/-- The multiplicity of `p` in `(pn)!` is `n` more than that of `n!`. -/
+/-- The multiplicity of `p` in `(p * n)!` is `n` more than that of `n!`. -/
 lemma multiplicity_factorial_mul {n p : ℕ} (hp : p.prime) :
   multiplicity p (p * n)! = multiplicity p n! + n :=
 begin

--- a/src/data/nat/multiplicity.lean
+++ b/src/data/nat/multiplicity.lean
@@ -3,24 +3,39 @@ Copyright (c) 2019 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+import algebra.big_operators.intervals
 import data.nat.bitwise
 import data.nat.log
 import data.nat.parity
 import ring_theory.int.basic
-import algebra.big_operators.intervals
 
 /-!
-
 # Natural number multiplicity
 
-This file contains lemmas about the multiplicity function
-(the maximum prime power divding a number).
+This file contains lemmas about the multiplicity function (the maximum prime power divding a number)
+when applied to naturals, in particular calculating it for factorials and binomial coefficients.
 
-# Main results
+## Multiplicity calculations
 
-There are natural number versions of some basic lemmas about multiplicity.
+* `nat.multiplicity_factorial`: Legendre's Theorem. The multiplicity of `p` in `n!` is
+  `n/p + ... + n/p^b` for any `b` such that `n/p^(b + 1) = 0`.
+* `nat.multiplicity_factorial_mul`: The multiplicity of `p` in `(p * n)!` is `n` more than that of
+  `n!`.
+* `nat.multiplicity_choose`: The multiplicity of `p` in `n.choose k` is the number of carries when
+  `k` and`n - k` are added in base `p`.
 
-There are also lemmas about the multiplicity of primes in factorials and in binomial coefficients.
+## Other declarations
+
+* `nat.multiplicity_eq_card_pow_dvd`: The multiplicity of `m` in `n` is the number of positive
+  natural numbers `i` such that `m ^ i` divides `n`.
+* `nat.multiplicity_two_factorial_lt`: The multiplicity of `2` in `n!` is strictly less than `n`.
+* `nat.prime.multiplicity_something`: Specialization of `multiplicity.something` to a prime in the
+  naturals. Avoids having to provide `p ≠ 1` and other trivialities, along with translating between
+  `prime` and `nat.prime`.
+
+## Tags
+
+Legendre, p-adic
 -/
 
 open finset nat multiplicity
@@ -28,7 +43,7 @@ open_locale big_operators nat
 
 namespace nat
 
-/-- The multiplicity of `m` in `n` is the number of positive natural numbers `i` such that `p ^ i`
+/-- The multiplicity of `m` in `n` is the number of positive natural numbers `i` such that `m ^ i`
 divides `n`. This set is expressed by filtering `Ico 1 b` where `b` is any bound greater than
 `log m n`. -/
 lemma multiplicity_eq_card_pow_dvd {m n b : ℕ} (hm : m ≠ 1) (hn : 0 < n) (hb : log m n < b):

--- a/src/data/nat/multiplicity.lean
+++ b/src/data/nat/multiplicity.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import data.nat.bitwise
-import data.nat.parity
 import data.nat.log
+import data.nat.parity
 import ring_theory.int.basic
 import algebra.big_operators.intervals
 
@@ -28,34 +28,27 @@ open_locale big_operators nat
 
 namespace nat
 
-/-- The multiplicity of a divisor `m` of `n`, is the cardinality of the set of
-  positive natural numbers `i` such that `p ^ i` divides `n`. The set is expressed
-  by filtering `Ico 1 b` where `b` is any bound greater than `log m n` -/
-lemma multiplicity_eq_card_pow_dvd {m n b : ℕ} (hm1 : m ≠ 1) (hn0 : 0 < n) (hb : log m n < b):
+/-- The multiplicity of `m` in `n` is the number of positive natural numbers `i` such that `p ^ i`
+divides `n`. This set is expressed by filtering `Ico 1 b` where `b` is any bound greater than
+`log m n`. -/
+lemma multiplicity_eq_card_pow_dvd {m n b : ℕ} (hm : m ≠ 1) (hn : 0 < n) (hb : log m n < b):
   multiplicity m n = ↑((finset.Ico 1 b).filter (λ i, m ^ i ∣ n)).card :=
-calc multiplicity m n = ↑(Ico 1 $ ((multiplicity m n).get (finite_nat_iff.2 ⟨hm1, hn0⟩) + 1)).card :
-  by simp
-... = ↑((finset.Ico 1 b).filter (λ i, m ^ i ∣ n)).card : congr_arg coe $ congr_arg card $
-  finset.ext $ λ i,
-  have hmn : ¬ m ^ (log m n).succ ∣ n,
-    from if hm0 : m = 0
-    then λ _, by cases n; simp [*, lt_irrefl, pow_succ'] at *
-    else mt (le_of_dvd hn0) (not_le_of_lt $ pow_succ_log_gt_self m n
-        (hm1.symm.le_iff_lt.mp (zero_lt_iff.mpr hm0.intro)) hn0),
-  ⟨λ hi, begin
-      simp only [Ico.mem, mem_filter, lt_succ_iff] at *,
-      exact ⟨⟨hi.1, lt_of_le_of_lt hi.2 $
-        lt_of_lt_of_le (by rw [← enat.coe_lt_coe, enat.coe_get,
-            multiplicity_lt_iff_neg_dvd]; exact hmn)
-          hb⟩,
-        by rw [pow_dvd_iff_le_multiplicity];
-          rw [← @enat.coe_le_coe i, enat.coe_get] at hi; exact hi.2⟩
-    end,
-  begin
-    simp only [Ico.mem, mem_filter, lt_succ_iff, and_imp, true_and] { contextual := tt },
-    assume h1i hib hmin,
-    rwa [← enat.coe_le_coe, enat.coe_get, ← pow_dvd_iff_le_multiplicity]
-  end⟩
+calc
+  multiplicity m n = ↑(Ico 1 $ ((multiplicity m n).get (finite_nat_iff.2 ⟨hm, hn⟩) + 1)).card
+    : by simp
+... = ↑((finset.Ico 1 b).filter (λ i, m ^ i ∣ n)).card
+    : congr_arg coe $ congr_arg card $ finset.ext $ λ i,
+      begin
+        rw [mem_filter, Ico.mem, Ico.mem, lt_succ_iff, ←@enat.coe_le_coe i, enat.coe_get,
+          ←pow_dvd_iff_le_multiplicity, and.right_comm],
+        refine (and_iff_left_of_imp (λ h, _)).symm,
+        cases m,
+        { rw [zero_pow, zero_dvd_iff] at h,
+          exact (hn.ne' h.2).elim,
+          { exact h.1 } },
+        exact ((pow_le_iff_le_log (succ_lt_succ $ nat.pos_of_ne_zero $ succ_ne_succ.1 hm) hn).1 $
+          le_of_dvd hn h.2).trans_lt hb,
+      end
 
 namespace prime
 
@@ -76,8 +69,10 @@ multiplicity_self (prime_iff.mp hp).not_unit hp.ne_zero
 lemma multiplicity_pow_self {p n : ℕ} (hp : p.prime) : multiplicity p (p ^ n) = n :=
 multiplicity_pow_self hp.ne_zero (prime_iff.mp hp).not_unit n
 
-/-- The multiplicity of a prime in `n!` is the sum of the quotients `n / p ^ i`.
-  This sum is expressed over the set `Ico 1 b` where `b` is any bound greater than `log p n` -/
+/-- **Legendre's Theorem**
+
+The multiplicity of a prime in `n!` is the sum of the quotients `n / p ^ i`. This sum is expressed
+over the finset `Ico 1 b` where `b` is any bound greater than `log p n`. -/
 lemma multiplicity_factorial {p : ℕ} (hp : p.prime) :
   ∀ {n b : ℕ}, log p n < b → multiplicity p n! = (∑ i in Ico 1 b, n / p ^ i : ℕ)
 | 0     b hb := by simp [Ico, hp.multiplicity_one]
@@ -85,14 +80,14 @@ lemma multiplicity_factorial {p : ℕ} (hp : p.prime) :
   calc multiplicity p (n+1)! = multiplicity p n! + multiplicity p (n+1) :
     by rw [factorial_succ, hp.multiplicity_mul, add_comm]
   ... = (∑ i in Ico 1 b, n / p ^ i : ℕ) + ((finset.Ico 1 b).filter (λ i, p ^ i ∣ n+1)).card :
-    by rw [multiplicity_factorial (lt_of_le_of_lt log_le_log_succ hb),
-      ← multiplicity_eq_card_pow_dvd (ne_of_gt hp.one_lt) (succ_pos _) hb]
+    by rw [multiplicity_factorial ((log_le_log_of_le $ le_succ _).trans_lt hb),
+      ← multiplicity_eq_card_pow_dvd hp.ne_one (succ_pos _) hb]
   ... = (∑ i in Ico 1 b, (n / p ^ i + if p^i ∣ n+1 then 1 else 0) : ℕ) :
-    by rw [sum_add_distrib, sum_boole]; simp
+    by { rw [sum_add_distrib, sum_boole], simp }
   ... = (∑ i in Ico 1 b, (n + 1) / p ^ i : ℕ) :
-    congr_arg coe $ finset.sum_congr rfl (by intros; simp [nat.succ_div]; congr)
+    congr_arg coe $ finset.sum_congr rfl $ λ _ _, (succ_div _ _).symm
 
-/-- The multiplicity of `p` in `(p(n+1))!` is one more than the sum
+/-- The multiplicity of `p` in `(p * (n + 1))!` is one more than the sum
   of the multiplicities of `p` in `(p * n)!` and `n + 1`. -/
 lemma multiplicity_factorial_mul_succ {n p : ℕ} (hp : p.prime) :
   multiplicity p (p * (n + 1))! = multiplicity p (p * n)! + multiplicity p (n + 1) + 1 :=
@@ -147,7 +142,7 @@ calc ∑ i in finset.Ico 1 b, n / p ^ i
     by simp only [nat.add_div (pow_pos hp.pos _)]
 ... = _ : by simp [sum_add_distrib, sum_boole]
 
-/-- The multiplity of `p` in `choose n k` is the number of carries when `k` and `n - k`
+/-- The multiplicity of `p` in `choose n k` is the number of carries when `k` and `n - k`
   are added in base `p`. The set is expressed by filtering `Ico 1 b` where `b`
   is any bound greater than `log p n`. -/
 lemma multiplicity_choose {p n k b : ℕ} (hp : p.prime) (hkn : k ≤ n) (hnb : log p n < b) :
@@ -208,7 +203,7 @@ le_antisymm
     rw [multiplicity_choose hp hkn (lt_succ_self _),
       multiplicity_eq_card_pow_dvd (ne_of_gt hp.one_lt) hk0
         (lt_succ_of_le (log_le_log_of_le hkn)),
-      ← enat.coe_add, enat.coe_le_coe, log_pow _ _ hp.one_lt,
+      ← enat.coe_add, enat.coe_le_coe, log_pow hp.one_lt,
       ← card_disjoint_union hdisj, filter_union_right],
     have filter_le_Ico := (Ico 1 n.succ).card_filter_le _,
     rwa Ico.card 1 n.succ at filter_le_Ico,


### PR DESCRIPTION
Defines the upper natural log, which is the least `k` such that `n ≤ b^k`.
Also expand greatly the docs of `data.nat.multiplicity`, in particular to underline that it proves Legendre's theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
