### PR TITLE
[Merged by Bors] - feat(data/matrix/kronecker): add two reindex lemmas

### DIFF
--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -122,12 +122,11 @@ end
   kronecker_map f (1 : matrix m m α) (1 : matrix n n β) = 1 :=
 (kronecker_map_diagonal_diagonal _ hf₁ hf₂ _ _).trans $ by simp only [hf₃, diagonal_one]
 
-@[simp]
 lemma kronecker_map_reindex (f : α → β → γ) (el : l ≃ l') (em : m ≃ m') (en : n ≃ n')
   (ep : p ≃ p') (M : matrix l m α) (N : matrix n p β) :
   kronecker_map f (reindex el em M) (reindex en ep N) =
-  reindex (el.prod_congr en) (em.prod_congr ep)
-    (kronecker_map f M N) := by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
+    reindex (el.prod_congr en) (em.prod_congr ep) (kronecker_map f M N) :=
+by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
 
 lemma kronecker_map_reindex_left (f : α → β → γ) (el : l ≃ l') (em : m ≃ m') (M : matrix l m α)
   (N : matrix n n' β) : kronecker_map f (matrix.reindex el em M) N =

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -131,14 +131,12 @@ by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
 lemma kronecker_map_reindex_left (f : α → β → γ) (el : l ≃ l') (em : m ≃ m') (M : matrix l m α)
   (N : matrix n n' β) : kronecker_map f (matrix.reindex el em M) N =
   reindex (el.prod_congr (equiv.refl _)) (em.prod_congr (equiv.refl _)) (kronecker_map f M N) :=
--- by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
 kronecker_map_reindex _ _ _ (equiv.refl _) (equiv.refl _) _ _
 
 lemma kronecker_map_reindex_right (f : α → β → γ) (em : m ≃ m') (en : n ≃ n') (M : matrix l l' α)
   (N : matrix m n β) : kronecker_map f M (reindex em en N) =
   reindex ((equiv.refl _).prod_congr em) ((equiv.refl _).prod_congr en) (kronecker_map f M N) :=
-by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
--- kronecker_map_reindex _ (equiv.refl _) (equiv.refl _) _ _ _ _
+kronecker_map_reindex _ (equiv.refl _) (equiv.refl _) _ _ _ _
 
 lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω')
   (g' : β → δ → ξ) (A : matrix l m α) (B : matrix n p β) (D : matrix q r δ) (φ : ω ≃ ω')

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -123,14 +123,14 @@ end
 (kronecker_map_diagonal_diagonal _ hf₁ hf₂ _ _).trans $ by simp only [hf₃, diagonal_one]
 
 lemma kronecker_map_reindex_left (f : α → β → γ) (el : l ≃ l') (em : m ≃ m') (M : matrix l m α)
-  (N : matrix n n' β) : matrix.kronecker_map f (matrix.reindex el em M) N =
-  matrix.reindex (el.prod_congr (equiv.refl _)) (em.prod_congr (equiv.refl _))
-  (matrix.kronecker_map f M N) := by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
+  (N : matrix n n' β) : kronecker_map f (matrix.reindex el em M) N =
+  reindex (el.prod_congr (equiv.refl _)) (em.prod_congr (equiv.refl _)) (kronecker_map f M N)
+:= by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
 
 lemma kronecker_map_reindex_right (f : α → β → γ) (em : m ≃ m') (en : n ≃ n') (M : matrix l l' α)
-  (N : matrix m n β) : matrix.kronecker_map f M (matrix.reindex em en N) =
-  matrix.reindex ((equiv.refl _).prod_congr em) ((equiv.refl _).prod_congr en)
-    (matrix.kronecker_map f M N) := by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
+  (N : matrix m n β) : kronecker_map f M (reindex em en N) =
+  reindex ((equiv.refl _).prod_congr em) ((equiv.refl _).prod_congr en) (kronecker_map f M N) :=
+by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
 
 lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω')
   (g' : β → δ → ξ) (A : matrix l m α) (B : matrix n p β) (D : matrix q r δ) (φ : ω ≃ ω')

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -123,7 +123,7 @@ end
 (kronecker_map_diagonal_diagonal _ hf₁ hf₂ _ _).trans $ by simp only [hf₃, diagonal_one]
 
 @[simp]
-lemma kronecker_map_reindex (f : α → β → γ)  (el : l ≃ l') (em : m ≃ m') (en : n ≃ n')
+lemma kronecker_map_reindex (f : α → β → γ) (el : l ≃ l') (em : m ≃ m') (en : n ≃ n')
   (ep : p ≃ p') (M : matrix l m α) (N : matrix n p β) :
   kronecker_map f (reindex el em M) (reindex en ep N) =
   reindex (el.prod_congr en) (em.prod_congr ep)

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -122,15 +122,24 @@ end
   kronecker_map f (1 : matrix m m α) (1 : matrix n n β) = 1 :=
 (kronecker_map_diagonal_diagonal _ hf₁ hf₂ _ _).trans $ by simp only [hf₃, diagonal_one]
 
+@[simp]
+lemma kronecker_map_reindex (f : α → β → γ)  (el : l ≃ l') (em : m ≃ m') (en : n ≃ n')
+  (ep : p ≃ p') (M : matrix l m α) (N : matrix n p β) :
+  kronecker_map f (reindex el em M) (reindex en ep N) =
+  reindex (el.prod_congr en) (em.prod_congr ep)
+    (kronecker_map f M N) := by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
+
 lemma kronecker_map_reindex_left (f : α → β → γ) (el : l ≃ l') (em : m ≃ m') (M : matrix l m α)
   (N : matrix n n' β) : kronecker_map f (matrix.reindex el em M) N =
-  reindex (el.prod_congr (equiv.refl _)) (em.prod_congr (equiv.refl _)) (kronecker_map f M N)
-:= by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
+  reindex (el.prod_congr (equiv.refl _)) (em.prod_congr (equiv.refl _)) (kronecker_map f M N) :=
+-- by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
+kronecker_map_reindex _ _ _ (equiv.refl _) (equiv.refl _) _ _
 
 lemma kronecker_map_reindex_right (f : α → β → γ) (em : m ≃ m') (en : n ≃ n') (M : matrix l l' α)
   (N : matrix m n β) : kronecker_map f M (reindex em en N) =
   reindex ((equiv.refl _).prod_congr em) ((equiv.refl _).prod_congr en) (kronecker_map f M N) :=
 by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
+-- kronecker_map_reindex _ (equiv.refl _) (equiv.refl _) _ _ _ _
 
 lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω')
   (g' : β → δ → ξ) (A : matrix l m α) (B : matrix n p β) (D : matrix q r δ) (φ : ω ≃ ω')

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -122,6 +122,30 @@ end
   kronecker_map f (1 : matrix m m α) (1 : matrix n n β) = 1 :=
 (kronecker_map_diagonal_diagonal _ hf₁ hf₂ _ _).trans $ by simp only [hf₃, diagonal_one]
 
+lemma kronecker_map_reindex_left (f : α → β → γ) (el : l ≃ l') (em : m ≃ m') (M : matrix l m α)
+  (N : matrix n n' β) : matrix.kronecker_map f (matrix.reindex el em M) N =
+  matrix.reindex (el.prod_congr (equiv.refl _)) (em.prod_congr (equiv.refl _))
+  (matrix.kronecker_map f M N) := by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
+
+lemma kronecker_map_reindex_right (f : α → β → γ) (em : m ≃ m') (en : n ≃ n') (M : matrix l l' α)
+  (N : matrix m₁ n₁ β) : matrix.kronecker_map f M (matrix.reindex em en N) =
+  matrix.reindex ((equiv.refl _).prod_congr em) ((equiv.refl _).prod_congr en)
+    (matrix.kronecker_map f M N) := by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
+
+lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω')
+  (g' : β → δ → ξ) (A : matrix l m α) (B : matrix n p β) (D : matrix q r δ) (φ : ω ≃ ω')
+  (hφ : ∀ a b d, φ (g (f a b) d) = f' a (g' b d)) :
+  (reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)).trans (equiv.map_matrix φ)
+    (kronecker_map g (kronecker_map f A B) D) = kronecker_map f' A (kronecker_map g' B D) :=
+ext $ λ i j, hφ _ _ _
+
+lemma kronecker_map_assoc₁ {δ ξ ω : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω)
+  (g' : β → δ → ξ) (A : matrix l m α) (B : matrix n p β) (D : matrix q r δ)
+  (h : ∀ a b d, (g (f a b) d) = f' a (g' b d)) :
+  reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)
+    (kronecker_map g (kronecker_map f A B) D) = kronecker_map f' A (kronecker_map g' B D) :=
+ext $ λ i j, h _ _ _
+
 /-- When `f` is bilinear then `matrix.kronecker_map f` is also bilinear. -/
 @[simps]
 def kronecker_map_bilinear [comm_semiring R]
@@ -153,20 +177,6 @@ begin
     finset.sum_product, kronecker_map],
   simp_rw [f.map_sum, linear_map.sum_apply, linear_map.map_sum, h_comm],
 end
-
-lemma kronecker_map_assoc {δ ξ ω ω' : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω')
-  (g' : β → δ → ξ) (A : matrix l m α) (B : matrix n p β) (D : matrix q r δ) (φ : ω ≃ ω')
-  (hφ : ∀ a b d, φ (g (f a b) d) = f' a (g' b d)) :
-  (reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)).trans (equiv.map_matrix φ)
-    (kronecker_map g (kronecker_map f A B) D) = kronecker_map f' A (kronecker_map g' B D) :=
-ext $ λ i j, hφ _ _ _
-
-lemma kronecker_map_assoc₁ {δ ξ ω : Type*} (f : α → β → γ) (g : γ → δ → ω) (f' : α → ξ → ω)
-  (g' : β → δ → ξ) (A : matrix l m α) (B : matrix n p β) (D : matrix q r δ)
-  (h : ∀ a b d, (g (f a b) d) = f' a (g' b d)) :
-  reindex (equiv.prod_assoc l n q) (equiv.prod_assoc m p r)
-    (kronecker_map g (kronecker_map f A B) D) = kronecker_map f' A (kronecker_map g' B D) :=
-ext $ λ i j, h _ _ _
 
 end kronecker_map
 

--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -128,7 +128,7 @@ lemma kronecker_map_reindex_left (f : α → β → γ) (el : l ≃ l') (em : m 
   (matrix.kronecker_map f M N) := by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
 
 lemma kronecker_map_reindex_right (f : α → β → γ) (em : m ≃ m') (en : n ≃ n') (M : matrix l l' α)
-  (N : matrix m₁ n₁ β) : matrix.kronecker_map f M (matrix.reindex em en N) =
+  (N : matrix m n β) : matrix.kronecker_map f M (matrix.reindex em en N) =
   matrix.reindex ((equiv.refl _).prod_congr em) ((equiv.refl _).prod_congr en)
     (matrix.kronecker_map f M N) := by { ext ⟨i, i'⟩ ⟨j, j'⟩, refl }
 


### PR DESCRIPTION
Added two lemmas `kronecker_map_reindex_right` and `kronecker_map_reindex_left` (used in LTE) and moved the two `assoc` lemmas some lines up, before the `linear` section, because they are unrelated to any linearity business.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
