### PR TITLE
[Merged by Bors] - feat(linear_algebra/vandermonde): `vandermonde v` multiplied by its transpose

### DIFF
--- a/src/linear_algebra/vandermonde.lean
+++ b/src/linear_algebra/vandermonde.lean
@@ -62,8 +62,8 @@ begin
   simp only [fin.tail]
 end
 
-lemma vandermonde_mul_vandermonde_transpose {n : ℕ} (v : fin n → R) (i j) :
-  (vandermonde v ⬝ (vandermonde v)ᵀ) i j = ∑ (k : fin n), (v i * v j) ^ (k : ℕ) :=
+lemma vandermonde_mul_vandermonde_transpose {n : ℕ} (v w : fin n → R) (i j) :
+  (vandermonde v ⬝ (vandermonde w)ᵀ) i j = ∑ (k : fin n), (v i * w j) ^ (k : ℕ) :=
 by simp only [vandermonde_apply, matrix.mul_apply, matrix.transpose_apply, mul_pow]
 
 lemma vandermonde_transpose_mul_vandermonde {n : ℕ} (v : fin n → R) (i j) :

--- a/src/linear_algebra/vandermonde.lean
+++ b/src/linear_algebra/vandermonde.lean
@@ -62,6 +62,14 @@ begin
   simp only [fin.tail]
 end
 
+lemma vandermonde_mul_vandermonde_transpose {n : ℕ} (v : fin n → R) (i j) :
+  (vandermonde v ⬝ (vandermonde v)ᵀ) i j = ∑ (k : fin n), (v i * v j) ^ (k : ℕ) :=
+by simp only [vandermonde_apply, matrix.mul_apply, matrix.transpose_apply, mul_pow]
+
+lemma vandermonde_transpose_mul_vandermonde {n : ℕ} (v : fin n → R) (i j) :
+  ((vandermonde v)ᵀ ⬝ vandermonde v) i j = ∑ (k : fin n), v k ^ (i + j : ℕ) :=
+by simp only [vandermonde_apply, matrix.mul_apply, matrix.transpose_apply, pow_add]
+
 lemma det_vandermonde {n : ℕ} (v : fin n → R) :
   det (vandermonde v) = ∏ i : fin n, ∏ j in finset.univ.filter (λ j, i < j), (v j - v i) :=
 begin


### PR DESCRIPTION
Two not very exciting lemmas about multiplying a Vandermonde matrix by its transpose (one for each side). I don't know if they are really useful, so I could also just inline them in #8777.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
