### PR TITLE
[Merged by Bors] - feat(data/list/rotate): is_rotated_append

### DIFF
--- a/src/data/list/rotate.lean
+++ b/src/data/list/rotate.lean
@@ -111,6 +111,14 @@ begin
   rw [←rotate_eq_drop_append_take (n.mod_lt hl).le, rotate_mod]
 end
 
+@[simp] lemma rotate_append_length_eq (l l' : list α) : (l ++ l').rotate l.length = l' ++ l :=
+begin
+  rw rotate_eq_rotate',
+  induction l generalizing l',
+  { simp, },
+  { simp [rotate', l_ih] },
+end
+
 lemma rotate_rotate (l : list α) (n m : ℕ) : (l.rotate n).rotate m = l.rotate (n + m) :=
 by rw [rotate_eq_rotate', rotate_eq_rotate', rotate_eq_rotate', rotate'_rotate']
 
@@ -400,6 +408,9 @@ by rw [is_rotated_comm, is_rotated_singleton_iff, eq_comm]
 lemma is_rotated_concat (hd : α) (tl : list α) :
   (tl ++ [hd]) ~r (hd :: tl) :=
 is_rotated.symm ⟨1, by simp⟩
+
+lemma is_rotated_append : (l ++ l') ~r (l' ++ l) :=
+⟨l.length, by simp⟩
 
 lemma is_rotated.reverse (h : l ~r l') : l.reverse ~r l'.reverse :=
 begin


### PR DESCRIPTION
`list.append` is commutative with respect to `~r`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
