### PR TITLE
[Merged by Bors] - feat(linear_algebra/dimension): generalize dim_map_le to heterogeneous universes

### DIFF
--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -143,22 +143,33 @@ begin
   exact linear_independent_bounded_of_finset_linear_independent_bounded H _ li,
 end
 
-lemma dim_range_le (f : M →ₗ[R] M₁) : module.rank R f.range ≤ module.rank R M :=
+lemma lift_dim_range_le (f : M →ₗ[R] M') :
+  cardinal.lift.{v' v} (module.rank R f.range) ≤ cardinal.lift.{v v'} (module.rank R M) :=
 begin
   dsimp [module.rank],
-  apply cardinal.sup_le.mpr,
+  apply cardinal.lift_sup_le,
   rintro ⟨s, li⟩,
-  refine le_trans _ (cardinal.le_sup _ ⟨range_splitting f '' s, _⟩),
+  apply le_trans,
+  swap 2,
+  apply cardinal.lift_le.mpr,
+  refine (cardinal.le_sup _ ⟨range_splitting f '' s, _⟩),
   { apply linear_independent.of_comp f.range_restrict,
     convert li.comp (equiv.set.range_splitting_image_equiv f s) (equiv.injective _) using 1, },
-  { exact (cardinal.eq_congr (equiv.set.range_splitting_image_equiv f s)).ge, },
+  { exact (cardinal.lift_mk_eq'.mpr ⟨equiv.set.range_splitting_image_equiv f s⟩).ge, },
+end
+
+lemma dim_range_le (f : M →ₗ[R] M₁) : module.rank R f.range ≤ module.rank R M :=
+by simpa using lift_dim_range_le f
+
+lemma lift_dim_map_le (f : M →ₗ[R] M') (p : submodule R M) :
+  cardinal.lift.{v' v} (module.rank R (p.map f)) ≤ cardinal.lift.{v v'} (module.rank R p) :=
+begin
+  have h := lift_dim_range_le (f.comp (submodule.subtype p)),
+  rwa [linear_map.range_comp, range_subtype] at h,
 end
 
 lemma dim_map_le (f : M →ₗ[R] M₁) (p : submodule R M) : module.rank R (p.map f) ≤ module.rank R p :=
-begin
-  have h := dim_range_le (f.comp (submodule.subtype p)),
-  rwa [linear_map.range_comp, range_subtype] at h,
-end
+by simpa using lift_dim_map_le f p
 
 lemma dim_le_of_submodule (s t : submodule R M) (h : s ≤ t) :
   module.rank R s ≤ module.rank R t :=

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -525,6 +525,14 @@ quotient.eq.trans
 ⟨λ ⟨f⟩, ⟨equiv.ulift.symm.trans $ f.trans equiv.ulift⟩,
  λ ⟨f⟩, ⟨equiv.ulift.trans $ f.trans equiv.ulift.symm⟩⟩
 
+/-- A variant of `lift_mk_eq` with universes specialized as `w = max u v`.
+This is sometimes necessary to avoid universe unification issues. -/
+theorem lift_mk_eq' {α : Type u} {β : Type v} :
+  lift.{u v} (mk α) = lift.{v u} (mk β) ↔ nonempty (α ≃ β) :=
+quotient.eq.trans
+⟨λ ⟨f⟩, ⟨equiv.ulift.symm.trans $ f.trans equiv.ulift⟩,
+ λ ⟨f⟩, ⟨equiv.ulift.trans $ f.trans equiv.ulift.symm⟩⟩
+
 @[simp] theorem lift_le {a b : cardinal} : lift a ≤ lift b ↔ a ≤ b :=
 quotient.induction_on₂ a b $ λ α β,
 by rw ← lift_umax; exact lift_mk_le

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -512,12 +512,13 @@ theorem lift_mk_le {α : Type u} {β : Type v} :
 ⟨λ ⟨f⟩, ⟨embedding.congr equiv.ulift equiv.ulift f⟩,
  λ ⟨f⟩, ⟨embedding.congr equiv.ulift.symm equiv.ulift.symm f⟩⟩
 
-/-- A variant of `lift_mk_le` with slight different universe constraints.
-Unfortunately this is not a specialization of `lift_mk_le`. -/
+/-- A variant of `lift_mk_le` with specialized universes.
+Because Lean often can not realize it should use this specialization itself,
+we provide this statement separately so you don't have to solve the specialization problem either.
+-/
 theorem lift_mk_le' {α : Type u} {β : Type v} :
   lift.{u v} (mk α) ≤ lift.{v u} (mk β) ↔ nonempty (α ↪ β) :=
-⟨λ ⟨f⟩, ⟨embedding.congr equiv.ulift equiv.ulift f⟩,
- λ ⟨f⟩, ⟨embedding.congr equiv.ulift.symm equiv.ulift.symm f⟩⟩
+lift_mk_le.{u v 0}
 
 theorem lift_mk_eq {α : Type u} {β : Type v} :
   lift.{u (max v w)} (mk α) = lift.{v (max u w)} (mk β) ↔ nonempty (α ≃ β) :=
@@ -525,13 +526,13 @@ quotient.eq.trans
 ⟨λ ⟨f⟩, ⟨equiv.ulift.symm.trans $ f.trans equiv.ulift⟩,
  λ ⟨f⟩, ⟨equiv.ulift.trans $ f.trans equiv.ulift.symm⟩⟩
 
-/-- A variant of `lift_mk_eq` with slight different universe constraints.
-Unfortunately this is not a specialization of `lift_mk_eq`. -/
+/-- A variant of `lift_mk_eq` with specialized universes.
+Because Lean often can not realize it should use this specialization itself,
+we provide this statement separately so you don't have to solve the specialization problem either.
+-/
 theorem lift_mk_eq' {α : Type u} {β : Type v} :
   lift.{u v} (mk α) = lift.{v u} (mk β) ↔ nonempty (α ≃ β) :=
-quotient.eq.trans
-⟨λ ⟨f⟩, ⟨equiv.ulift.symm.trans $ f.trans equiv.ulift⟩,
- λ ⟨f⟩, ⟨equiv.ulift.trans $ f.trans equiv.ulift.symm⟩⟩
+lift_mk_eq.{u v 0}
 
 @[simp] theorem lift_le {a b : cardinal} : lift a ≤ lift b ↔ a ≤ b :=
 quotient.induction_on₂ a b $ λ α β,

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -512,8 +512,8 @@ theorem lift_mk_le {α : Type u} {β : Type v} :
 ⟨λ ⟨f⟩, ⟨embedding.congr equiv.ulift equiv.ulift f⟩,
  λ ⟨f⟩, ⟨embedding.congr equiv.ulift.symm equiv.ulift.symm f⟩⟩
 
-/-- A variant of `lift_mk_le` with universes specialized as `w = max u v`.
-This is sometimes necessary to avoid universe unification issues. -/
+/-- A variant of `lift_mk_le` with slight different universe constraints.
+Unfortunately this is not a specialization of `lift_mk_le`. -/
 theorem lift_mk_le' {α : Type u} {β : Type v} :
   lift.{u v} (mk α) ≤ lift.{v u} (mk β) ↔ nonempty (α ↪ β) :=
 ⟨λ ⟨f⟩, ⟨embedding.congr equiv.ulift equiv.ulift f⟩,
@@ -525,8 +525,8 @@ quotient.eq.trans
 ⟨λ ⟨f⟩, ⟨equiv.ulift.symm.trans $ f.trans equiv.ulift⟩,
  λ ⟨f⟩, ⟨equiv.ulift.trans $ f.trans equiv.ulift.symm⟩⟩
 
-/-- A variant of `lift_mk_eq` with universes specialized as `w = max u v`.
-This is sometimes necessary to avoid universe unification issues. -/
+/-- A variant of `lift_mk_eq` with slight different universe constraints.
+Unfortunately this is not a specialization of `lift_mk_eq`. -/
 theorem lift_mk_eq' {α : Type u} {β : Type v} :
   lift.{u v} (mk α) = lift.{v u} (mk β) ↔ nonempty (α ≃ β) :=
 quotient.eq.trans


### PR DESCRIPTION
Per @hrmacbeth's [request on zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Behaviour.20of.20finrank.20under.20morphisms).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
