### PR TITLE
[Merged by Bors] - doc(linear_algebra/trace): fix error in title

### DIFF
--- a/src/linear_algebra/trace.lean
+++ b/src/linear_algebra/trace.lean
@@ -8,7 +8,7 @@ import linear_algebra.matrix.trace
 
 
 /-!
-# Trace of a matrix
+# Trace of a linear map
 
 This file defines the trace of a linear map.
 


### PR DESCRIPTION
the first two lines of this were super contradictory



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
