### PR TITLE
[Merged by Bors] - chore(*): Fix syntactic tautologies

### DIFF
--- a/src/analysis/normed_space/affine_isometry.lean
+++ b/src/analysis/normed_space/affine_isometry.lean
@@ -157,7 +157,7 @@ include V
 /-- The identity affine isometry. -/
 def id : P →ᵃⁱ[𝕜] P := ⟨affine_map.id 𝕜 P, λ x, rfl⟩
 
-@[simp] lemma coe_id : ⇑(id : P →ᵃⁱ[𝕜] P) = id := rfl
+@[simp] lemma coe_id : ⇑(id : P →ᵃⁱ[𝕜] P) = _root_.id := rfl
 
 @[simp] lemma id_apply (x : P) : (affine_isometry.id : P →ᵃⁱ[𝕜] P) x = x := rfl
 

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -104,7 +104,7 @@ f.isometry.comp_continuous_iff
 /-- The identity linear isometry. -/
 def id : E →ₗᵢ[R] E := ⟨linear_map.id, λ x, rfl⟩
 
-@[simp] lemma coe_id : ⇑(id : E →ₗᵢ[R] E) = id := rfl
+@[simp] lemma coe_id : ⇑(id : E →ₗᵢ[R] E) = id := _root_.rfl
 
 @[simp] lemma id_apply (x : E) : (id : E →ₗᵢ[R] E) x = x := rfl
 

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -104,7 +104,7 @@ f.isometry.comp_continuous_iff
 /-- The identity linear isometry. -/
 def id : E →ₗᵢ[R] E := ⟨linear_map.id, λ x, rfl⟩
 
-@[simp] lemma coe_id : ⇑(id : E →ₗᵢ[R] E) = id := _root_.rfl
+@[simp] lemma coe_id : ⇑(id : E →ₗᵢ[R] E) = _root_.id := rfl
 
 @[simp] lemma id_apply (x : E) : (id : E →ₗᵢ[R] E) x = x := rfl
 

--- a/src/category_theory/sums/basic.lean
+++ b/src/category_theory/sums/basic.lean
@@ -51,9 +51,11 @@ instance sum : category.{v₁} (C ⊕ D) :=
     end }
 
 @[simp] lemma sum_comp_inl {P Q R : C} (f : (inl P : C ⊕ D) ⟶ inl Q) (g : inl Q ⟶ inl R) :
-  f ≫ g = (f : P ⟶ Q) ≫ (g : Q ⟶ R) := rfl
+  @category_struct.comp _ _ (inl P) (inl Q) (inl R) f g =
+  @category_struct.comp _ _ P Q R f g := rfl
 @[simp] lemma sum_comp_inr {P Q R : D} (f : (inr P : C ⊕ D) ⟶ inr Q) (g : inr Q ⟶ inr R) :
-  f ≫ g = (f : P ⟶ Q) ≫ (g : Q ⟶ R) := rfl
+  @category_struct.comp _ _ (inr P) (inr Q) (inr R) f g =
+  @category_struct.comp _ _ P Q R f g := rfl
 end
 
 namespace sum
@@ -70,6 +72,9 @@ variables (C : Type u₁) [category.{v₁} C] (D : Type u₁) [category.{v₁} D
 @[simps] def inr_ : D ⥤ C ⊕ D :=
 { obj := λ X, inr X,
   map := λ X Y f, f }
+
+@[simp] lemma id_inl (X : C) : 𝟙 (inl X : C ⊕ D) = (inl_ C D).map (𝟙 X) := rfl
+@[simp] lemma id_inr (Y : D) : 𝟙 (inr Y : C ⊕ D) = (inr_ C D).map (𝟙 Y) := rfl
 
 /-- The functor exchanging two direct summand categories. -/
 def swap : C ⊕ D ⥤ D ⊕ C :=

--- a/src/category_theory/sums/basic.lean
+++ b/src/category_theory/sums/basic.lean
@@ -52,10 +52,12 @@ instance sum : category.{v₁} (C ⊕ D) :=
 
 @[simp] lemma sum_comp_inl {P Q R : C} (f : (inl P : C ⊕ D) ⟶ inl Q)
   (g : (inl Q : C ⊕ D) ⟶ inl R) :
-  @category_struct.comp _ _ (inl P) (inl Q) (inl R) (f : P ⟶ Q) (g : Q ⟶ R) = f ≫ g := rfl
+  @category_struct.comp _ _ P Q R (f : P ⟶ Q) (g : Q ⟶ R) =
+  @category_struct.comp _ _ (inl P) (inl Q) (inl R) (f : P ⟶ Q) (g : Q ⟶ R) := rfl
 @[simp] lemma sum_comp_inr {P Q R : D} (f : (inr P : C ⊕ D) ⟶ inr Q)
   (g : (inr Q : C ⊕ D) ⟶ inr R) :
-  @category_struct.comp _ _ (inr P) (inr Q) (inr R) (f : P ⟶ Q) (g : Q ⟶ R) = f ≫ g := rfl
+  @category_struct.comp _ _ P Q R (f : P ⟶ Q) (g : Q ⟶ R) =
+  @category_struct.comp _ _ (inr P) (inr Q) (inr R) (f : P ⟶ Q) (g : Q ⟶ R) := rfl
 end
 
 namespace sum

--- a/src/category_theory/sums/basic.lean
+++ b/src/category_theory/sums/basic.lean
@@ -50,12 +50,12 @@ instance sum : category.{v₁} (C ⊕ D) :=
     | inr X, inr Y, inr Z, f, g := f ≫ g
     end }
 
-@[simp] lemma sum_comp_inl {P Q R : C} (f : (inl P : C ⊕ D) ⟶ inl Q) (g : inl Q ⟶ inl R) :
-  @category_struct.comp _ _ (inl P) (inl Q) (inl R) f g =
-  @category_struct.comp _ _ P Q R f g := rfl
-@[simp] lemma sum_comp_inr {P Q R : D} (f : (inr P : C ⊕ D) ⟶ inr Q) (g : inr Q ⟶ inr R) :
-  @category_struct.comp _ _ (inr P) (inr Q) (inr R) f g =
-  @category_struct.comp _ _ P Q R f g := rfl
+@[simp] lemma sum_comp_inl {P Q R : C} (f : (inl P : C ⊕ D) ⟶ inl Q)
+  (g : (inl Q : C ⊕ D) ⟶ inl R) :
+  @category_struct.comp _ _ (inl P) (inl Q) (inl R) (f : P ⟶ Q) (g : Q ⟶ R) = f ≫ g := rfl
+@[simp] lemma sum_comp_inr {P Q R : D} (f : (inr P : C ⊕ D) ⟶ inr Q)
+  (g : (inr Q : C ⊕ D) ⟶ inr R) :
+  @category_struct.comp _ _ (inr P) (inr Q) (inr R) (f : P ⟶ Q) (g : Q ⟶ R) = f ≫ g := rfl
 end
 
 namespace sum
@@ -72,9 +72,6 @@ variables (C : Type u₁) [category.{v₁} C] (D : Type u₁) [category.{v₁} D
 @[simps] def inr_ : D ⥤ C ⊕ D :=
 { obj := λ X, inr X,
   map := λ X Y f, f }
-
-@[simp] lemma id_inl (X : C) : 𝟙 (inl X : C ⊕ D) = (inl_ C D).map (𝟙 X) := rfl
-@[simp] lemma id_inr (Y : D) : 𝟙 (inr Y : C ⊕ D) = (inr_ C D).map (𝟙 Y) := rfl
 
 /-- The functor exchanging two direct summand categories. -/
 def swap : C ⊕ D ⥤ D ⊕ C :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1330,7 +1330,8 @@ namespace quotient
 when `p` is a submodule of `M`. -/
 def mk {p : submodule R M} : M → quotient p := quotient.mk'
 
-@[simp] theorem mk_eq_mk {p : submodule R M} (x : M) : (quotient.mk x : quotient p) = mk x := rfl
+@[simp] theorem mk_eq_mk {p : submodule R M} (x : M) :
+  (@_root_.quotient.mk _ (quotient_rel p) x) = mk x := rfl
 @[simp] theorem mk'_eq_mk {p : submodule R M} (x : M) : (quotient.mk' x : quotient p) = mk x := rfl
 @[simp] theorem quot_mk_eq_mk {p : submodule R M} (x : M) : (quot.mk _ x : quotient p) = mk x := rfl
 


### PR DESCRIPTION
Fix a few lemmas that were accidentally tautological in the sense that they were equations with syntactically equal LHS and RHS.
A linter will be added in a second PR, for now we just fix the found issues.
It would be great if a category expert like @semorrison would check the category ones, as its unclear to me which direction they are meant to go.

As pointed out by @PatrickMassot on Zulip https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/syntactic.20tautology.20linter/near/250267477.

Thanks to @eric-wieser for helping figure out the corrected versions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
