### PR TITLE
[Merged by Bors] - feat(data/list/nodup): nodup.nth_le_inj_iff

### DIFF
--- a/src/data/list/nodup.lean
+++ b/src/data/list/nodup.lean
@@ -76,6 +76,11 @@ pairwise_iff_nth_le.trans
   .resolve_right (λ h', H _ _ h₁ h' h.symm),
  λ H i j h₁ h₂ h, ne_of_lt h₂ (H _ _ _ _ h)⟩
 
+theorem nodup.nth_le_inj_iff {α : Type*} {l : list α} (h : nodup l)
+  {i j : ℕ} (hi : i < l.length) (hj : j < l.length) :
+  l.nth_le i hi = l.nth_le j hj ↔ i = j :=
+⟨nodup_iff_nth_le_inj.mp h _ _ _ _, by simp {contextual := tt}⟩
+
 lemma nodup.ne_singleton_iff {l : list α} (h : nodup l) (x : α) :
   l ≠ [x] ↔ l = [] ∨ ∃ y ∈ l, y ≠ x :=
 begin


### PR DESCRIPTION
This allows rewriting as an `inj_iff` lemma directly via proj notation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
