### PR TITLE
chore(*): Cleanup a bunch of duplicate and misstated lemmas

### DIFF
--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -495,10 +495,10 @@ lemma one_hom.cancel_left [has_one M] [has_one N] [has_one P]
 ⟨λ h, one_hom.ext $ λ x, hg $ by rw [← one_hom.comp_apply, h, one_hom.comp_apply],
  λ h, h ▸ rfl⟩
 @[to_additive]
-lemma mul_hom.cancel_left [has_one M] [has_one N] [has_one P]
-  {g : one_hom N P} {f₁ f₂ : one_hom M N} (hg : function.injective g) :
+lemma mul_hom.cancel_left [has_mul M] [has_mul N] [has_mul P]
+  {g : mul_hom N P} {f₁ f₂ : mul_hom M N} (hg : function.injective g) :
   g.comp f₁ = g.comp f₂ ↔ f₁ = f₂ :=
-⟨λ h, one_hom.ext $ λ x, hg $ by rw [← one_hom.comp_apply, h, one_hom.comp_apply],
+⟨λ h, mul_hom.ext $ λ x, hg $ by rw [← mul_hom.comp_apply, h, mul_hom.comp_apply],
  λ h, h ▸ rfl⟩
 @[to_additive]
 lemma monoid_hom.cancel_left [mul_one_class M] [mul_one_class N] [mul_one_class P]

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -46,7 +46,7 @@ instance [nonempty α] : nontrivial (with_one α) := option.nontrivial
 instance : has_coe_t α (with_one α) := ⟨some⟩
 
 @[to_additive]
-lemma some_eq_coe {a : α} : (some a : with_one α) = ↑a := rfl
+lemma some_eq_coe {a : α} : @eq (with_one α) (some a) ↑a := rfl
 
 @[simp, to_additive]
 lemma coe_ne_one {a : α} : (a : with_one α) ≠ (1 : with_one α) :=

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -45,9 +45,6 @@ instance [nonempty α] : nontrivial (with_one α) := option.nontrivial
 @[to_additive]
 instance : has_coe_t α (with_one α) := ⟨some⟩
 
-@[to_additive]
-lemma some_eq_coe {a : α} : @eq (with_one α) (some a) ↑a := rfl
-
 @[simp, to_additive]
 lemma coe_ne_one {a : α} : (a : with_one α) ≠ (1 : with_one α) :=
 option.some_ne_none a

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -440,7 +440,7 @@ begin
   { refine ⟨univ, is_open.mem_nhds is_open_univ trivial, λ x hx y hy, _⟩,
     simp [@subsingleton.elim E hE x y] },
   have := hf.def hc,
-  rw [nhds_prod_eq, filter.eventually, mem_prod_same_iff] at this,
+  rw [nhds_prod_eq, filter.eventually, mem_prod_self_iff] at this,
   rcases this with ⟨s, has, hs⟩,
   exact ⟨s, has, λ x hx y hy, hs (mk_mem_prod hx hy)⟩
 end

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -64,7 +64,7 @@ lemma dist_eq (z w : ℂ) : dist z w = abs (z - w) := rfl
 suffices ∥((r : ℝ) : ℂ)∥ = _root_.abs r, by simpa,
 by rw [norm_real, real.norm_eq_abs]
 
-@[simp] lemma norm_nat (n : ℕ) : ∥(n : ℂ)∥ = n := abs_of_nat _
+@[simp] lemma norm_nat (n : ℕ) : ∥(n : ℂ)∥ = n := abs_cast_nat _
 
 @[simp] lemma norm_int {n : ℤ} : ∥(n : ℂ)∥ = _root_.abs n :=
 suffices ∥((n : ℝ) : ℂ)∥ = _root_.abs n, by simpa,

--- a/src/analysis/special_functions/trigonometric.lean
+++ b/src/analysis/special_functions/trigonometric.lean
@@ -160,8 +160,8 @@ lemma times_cont_diff_cosh {n} : times_cont_diff ℂ n cosh :=
 lemma differentiable_cosh : differentiable ℂ cosh :=
 λx, (has_deriv_at_cosh x).differentiable_at
 
-lemma differentiable_at_cosh {x : ℂ} : differentiable_at ℂ cos x :=
-differentiable_cos x
+lemma differentiable_at_cosh {x : ℂ} : differentiable_at ℂ cosh x :=
+differentiable_cosh x
 
 @[simp] lemma deriv_cosh : deriv cosh = sinh :=
 funext $ λ x, (has_deriv_at_cosh x).deriv

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -68,15 +68,12 @@ lemma nat.tendsto_pow_at_top_at_top_of_one_lt {m : ℕ} (h : 1 < m) :
 nat.sub_add_cancel (le_of_lt h) ▸
   tendsto_add_one_pow_at_top_at_top_of_pos (nat.sub_pos_of_lt h)
 
-lemma tendsto_norm_zero' {𝕜 : Type*} [normed_group 𝕜] :
-  tendsto (norm : 𝕜 → ℝ) (𝓝[{0}ᶜ] 0) (𝓝[set.Ioi 0] 0) :=
-tendsto_norm_zero.inf $ tendsto_principal_principal.2 $ λ x hx, norm_pos_iff.2 hx
-
 namespace normed_field
 
 lemma tendsto_norm_inverse_nhds_within_0_at_top {𝕜 : Type*} [normed_field 𝕜] :
   tendsto (λ x:𝕜, ∥x⁻¹∥) (𝓝[{0}ᶜ] 0) at_top :=
-(tendsto_inv_zero_at_top.comp tendsto_norm_zero').congr $ λ x, (normed_field.norm_inv x).symm
+(tendsto_inv_zero_at_top.comp tendsto_norm_nhds_within_zero).congr $
+  λ x, (normed_field.norm_inv x).symm
 
 lemma tendsto_norm_fpow_nhds_within_0_at_top {𝕜 : Type*} [normed_field 𝕜] {m : ℤ}
   (hm : m < 0) :

--- a/src/category_theory/limits/constructions/limits_of_products_and_equalizers.lean
+++ b/src/category_theory/limits/constructions/limits_of_products_and_equalizers.lean
@@ -269,9 +269,9 @@ Any category with coproducts and coequalizers has all colimits.
 See https://stacks.math.columbia.edu/tag/002P.
 -/
 lemma colimits_from_coequalizers_and_coproducts
-  [has_products C] [has_equalizers C] : has_limits C :=
-{ has_limits_of_shape := λ J 𝒥,
-  { has_limit := λ F, by exactI has_limit_of_equalizer_and_product F } }
+  [has_coproducts C] [has_coequalizers C] : has_colimits C :=
+{ has_colimits_of_shape := λ J 𝒥,
+  { has_colimit := λ F, by exactI has_colimit_of_coequalizer_and_coproduct F } }
 
 /--
 Any category with finite coproducts and coequalizers has all finite colimits.

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -413,10 +413,6 @@ by simp [abs, norm_sq_of_real, real.sqrt_mul_self_eq_abs]
 lemma abs_of_nonneg {r : ℝ} (h : 0 ≤ r) : abs r = r :=
 (abs_of_real _).trans (abs_of_nonneg h)
 
-lemma abs_of_nat (n : ℕ) : complex.abs n = n :=
-calc complex.abs n = complex.abs (n:ℝ) : by rw [of_real_nat_cast]
-  ... = _ : abs_of_nonneg (nat.cast_nonneg n)
-
 lemma mul_self_abs (z : ℂ) : abs z * abs z = norm_sq z :=
 real.mul_self_sqrt (norm_sq_nonneg _)
 

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -449,9 +449,6 @@ lemma norm_eq_abs (z : K) : ∥z∥ = absK z := by simp [abs, norm_sq_eq_def']
 lemma abs_of_nonneg {r : ℝ} (h : 0 ≤ r) : absK r = r :=
 (abs_of_real _).trans (abs_of_nonneg h)
 
-lemma abs_of_nat (n : ℕ) : absK n = n :=
-by { rw [← of_real_nat_cast], exact abs_of_nonneg (nat.cast_nonneg n) }
-
 lemma mul_self_abs (z : K) : abs z * abs z = norm_sq z :=
 real.mul_self_sqrt (norm_sq_nonneg _)
 

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -694,10 +694,10 @@ ext $ λ x, by simp only [mem_union, or_assoc]
 
 instance : is_associative (finset α) (∪) := ⟨union_assoc⟩
 
-@[simp] theorem union_idempotent (s : finset α) : s ∪ s = s :=
+@[simp] theorem union_self (s : finset α) : s ∪ s = s :=
 ext $ λ _, mem_union.trans $ or_self _
 
-instance : is_idempotent (finset α) (∪) := ⟨union_idempotent⟩
+instance : is_idempotent (finset α) (∪) := ⟨union_self⟩
 
 theorem union_left_comm (s₁ s₂ s₃ : finset α) : s₁ ∪ (s₂ ∪ s₃) = s₂ ∪ (s₁ ∪ s₃) :=
 ext $ λ _, by simp only [mem_union, or.left_comm]
@@ -705,7 +705,6 @@ ext $ λ _, by simp only [mem_union, or.left_comm]
 theorem union_right_comm (s₁ s₂ s₃ : finset α) : (s₁ ∪ s₂) ∪ s₃ = (s₁ ∪ s₃) ∪ s₂ :=
 ext $ λ x, by simp only [mem_union, or_assoc, or_comm (x ∈ s₂)]
 
-theorem union_self (s : finset α) : s ∪ s = s := union_idempotent s
 
 @[simp] theorem union_empty (s : finset α) : s ∪ ∅ = s :=
 ext $ λ x, mem_union.trans $ or_false _
@@ -1671,7 +1670,7 @@ finset.ext $ by simp
   begin
     by_cases n = 0,
     { rw [h, zero_add, one_nsmul] },
-    { rw [add_nsmul, to_finset_add, one_nsmul, to_finset_nsmul n h, finset.union_idempotent] }
+    { rw [add_nsmul, to_finset_add, one_nsmul, to_finset_nsmul n h, finset.union_self] }
   end
 
 @[simp] lemma to_finset_inter (s t : multiset α) :

--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -45,7 +45,7 @@ by rw [not_odd_iff, even_iff]
 @[simp] lemma odd_iff_not_even : odd n ↔ ¬ even n :=
 by rw [not_even_iff, odd_iff]
 
-lemma is_compl_even_odd : is_compl {n : ℕ | even n} {n | odd n} :=
+lemma is_compl_even_odd : is_compl {n : ℤ | even n} {n | odd n} :=
 by simp [← set.compl_set_of, is_compl_compl]
 
 lemma even_or_odd (n : ℤ) : even n ∨ odd n :=

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -35,6 +35,8 @@ variables {α : Type*} {β : Type*} {γ : Type*}
 
 lemma coe_def : (coe : α → option α) = some := rfl
 
+lemma some_eq_coe {a : α} : some a = ↑a := rfl
+
 lemma some_ne_none (x : α) : some x ≠ none := λ h, option.no_confusion h
 
 protected lemma «forall» {p : option α → Prop} : (∀ x, p x) ↔ p none ∧ ∀ x, p (some x) :=

--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -142,11 +142,8 @@ ext $ λ k, (coeff_mul_X_pow p n k).symm.trans $ ext_iff.1 H (k+n)
 lemma C_mul_X_pow_eq_monomial (c : R) (n : ℕ) : C c * X^n = monomial n c :=
 by { ext1, rw [monomial_eq_smul_X, coeff_smul, coeff_C_mul, smul_eq_mul] }
 
-lemma support_mul_X_pow (c : R) (n : ℕ) (H : c ≠ 0) : (C c * X^n).support = singleton n :=
+lemma support_C_mul_X_pow (c : R) (n : ℕ) (H : c ≠ 0) : (C c * X^n).support = singleton n :=
 by rw [C_mul_X_pow_eq_monomial, support_monomial n c H]
-
-lemma support_C_mul_X_pow' {c : R} {n : ℕ} : (C c * X^n).support ⊆ singleton n :=
-by { rw [C_mul_X_pow_eq_monomial], exact support_monomial' n c }
 
 lemma C_dvd_iff_dvd_coeff (r : R) (φ : polynomial R) :
   C r ∣ φ ↔ ∀ i, r ∣ φ.coeff i :=

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -329,13 +329,6 @@ le_degree_of_ne_zero ∘ mem_support_iff.mp
 lemma nonempty_support_iff : p.support.nonempty ↔ p ≠ 0 :=
 by rw [ne.def, nonempty_iff_ne_empty, ne.def, ← support_eq_empty]
 
-lemma support_C_mul_X_pow_nonzero {c : R} {n : ℕ} (h : c ≠ 0) :
-  (C c * X ^ n).support = singleton n :=
-begin
-  rw [C_mul_X_pow_eq_monomial],
-  exact support_monomial _ _ h
-end
-
 end semiring
 
 section nonzero_semiring

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -301,19 +301,19 @@ degree_monomial_le _ _
 lemma nat_degree_X_le : (X : polynomial R).nat_degree ≤ 1 :=
 nat_degree_le_of_degree_le degree_X_le
 
-lemma support_C_mul_X_pow (c : R) (n : ℕ) : (C c * X ^ n).support ⊆ singleton n :=
+lemma support_C_mul_X_pow' (c : R) (n : ℕ) : (C c * X ^ n).support ⊆ singleton n :=
 begin
   rw [C_mul_X_pow_eq_monomial],
   exact support_monomial' _ _
 end
 
 lemma mem_support_C_mul_X_pow {n a : ℕ} {c : R} (h : a ∈ (C c * X ^ n).support) : a = n :=
-mem_singleton.1 $ support_C_mul_X_pow _ _ h
+mem_singleton.1 $ support_C_mul_X_pow' _ _ h
 
 lemma card_support_C_mul_X_pow_le_one {c : R} {n : ℕ} : (C c * X ^ n).support.card ≤ 1 :=
 begin
   rw ← card_singleton n,
-  apply card_le_of_subset (support_C_mul_X_pow c n),
+  apply card_le_of_subset (support_C_mul_X_pow' c n),
 end
 
 lemma card_supp_le_succ_nat_degree (p : polynomial R) : p.support.card ≤ p.nat_degree + 1 :=

--- a/src/data/prod.lean
+++ b/src/data/prod.lean
@@ -127,9 +127,6 @@ lemma swap_bijective : function.bijective (@swap α β) :=
 
 @[simp] lemma swap_inj {p q : α × β} : swap p = swap q ↔ p = q := swap_injective.eq_iff
 
-lemma eq_iff_fst_eq_snd_eq : ∀{p q : α × β}, p = q ↔ (p.1 = q.1 ∧ p.2 = q.2)
-| ⟨p₁, p₂⟩ ⟨q₁, q₂⟩ := by simp
-
 lemma fst_eq_iff : ∀ {p : α × β} {x : α}, p.1 = x ↔ p = (x, p.2)
 | ⟨a, b⟩ x := by simp
 

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -533,7 +533,7 @@ lemma coe_nat_lt_coe {n : ℕ} : (n : ℝ≥0∞) < r ↔ ↑n < r := ennreal.co
 lemma coe_lt_coe_nat {n : ℕ} : (r : ℝ≥0∞) < n ↔ r < n := ennreal.coe_nat n ▸ coe_lt_coe
 @[simp, norm_cast] lemma coe_nat_lt_coe_nat {m n : ℕ} : (m : ℝ≥0∞) < n ↔ m < n :=
 ennreal.coe_nat n ▸ coe_nat_lt_coe.trans nat.cast_lt
-lemma coe_nat_ne_top {n : ℕ} : (n : ℝ≥0∞) ≠ ∞ := ennreal.coe_nat n ▸ coe_ne_top
+@[simp] lemma coe_nat_ne_top {n : ℕ} : (n : ℝ≥0∞) ≠ ∞ := ennreal.coe_nat n ▸ coe_ne_top
 lemma coe_nat_mono : strict_mono (coe : ℕ → ℝ≥0∞) := λ _ _, coe_nat_lt_coe_nat.2
 @[simp, norm_cast] lemma coe_nat_le_coe_nat {m n : ℕ} : (m : ℝ≥0∞) ≤ n ↔ m ≤ n :=
 coe_nat_mono.le_iff_le

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -533,7 +533,7 @@ lemma coe_nat_lt_coe {n : ℕ} : (n : ℝ≥0∞) < r ↔ ↑n < r := ennreal.co
 lemma coe_lt_coe_nat {n : ℕ} : (r : ℝ≥0∞) < n ↔ r < n := ennreal.coe_nat n ▸ coe_lt_coe
 @[simp, norm_cast] lemma coe_nat_lt_coe_nat {m n : ℕ} : (m : ℝ≥0∞) < n ↔ m < n :=
 ennreal.coe_nat n ▸ coe_nat_lt_coe.trans nat.cast_lt
-@[simp] lemma coe_nat_ne_top {n : ℕ} : (n : ℝ≥0∞) ≠ ∞ := ennreal.coe_nat n ▸ coe_ne_top
+lemma coe_nat_ne_top {n : ℕ} : (n : ℝ≥0∞) ≠ ∞ := ennreal.coe_nat n ▸ coe_ne_top
 lemma coe_nat_mono : strict_mono (coe : ℕ → ℝ≥0∞) := λ _ _, coe_nat_lt_coe_nat.2
 @[simp, norm_cast] lemma coe_nat_le_coe_nat {m n : ℕ} : (m : ℝ≥0∞) ≤ n ↔ m ≤ n :=
 coe_nat_mono.le_iff_le

--- a/src/data/real/ereal.lean
+++ b/src/data/real/ereal.lean
@@ -327,6 +327,8 @@ instance : has_neg ereal := ⟨ereal.neg⟩
 @[simp] lemma neg_bot : - (⊥ : ereal) = ⊤ := rfl
 @[simp] lemma neg_zero : - (0 : ereal) = 0 := by { change ((-0 : ℝ) : ereal) = 0, simp }
 
+@[simp, norm_cast] lemma coe_neg (x : ℝ) : ((- x : ℝ) : ereal) = - (x : ereal) := rfl
+
 /-- `- -a = a` on `ereal`. -/
 @[simp] protected theorem neg_neg : ∀ (a : ereal), - (- a) = a
 | ⊥ := rfl
@@ -376,8 +378,6 @@ by rwa [←ereal.neg_neg b, ereal.neg_le, ereal.neg_neg]
 
 @[simp] lemma neg_le_neg_iff {a b : ereal} : - a ≤ - b ↔ b ≤ a :=
 by conv_lhs { rw [ereal.neg_le, ereal.neg_neg] }
-
-@[simp, norm_cast] lemma coe_neg (x : ℝ) : ((- x : ℝ) : ereal) = - (x : ereal) := rfl
 
 /-- Negation as an order reversing isomorphism on `ereal`. -/
 def neg_order_iso : ereal ≃o (order_dual ereal) :=

--- a/src/data/real/ereal.lean
+++ b/src/data/real/ereal.lean
@@ -323,8 +323,6 @@ protected def neg : ereal → ereal
 
 instance : has_neg ereal := ⟨ereal.neg⟩
 
-@[norm_cast] protected lemma neg_def (x : ℝ) : ((-x : ℝ) : ereal) = -x := rfl
-
 @[simp] lemma neg_top : - (⊤ : ereal) = ⊥ := rfl
 @[simp] lemma neg_bot : - (⊥ : ereal) = ⊤ := rfl
 @[simp] lemma neg_zero : - (0 : ereal) = 0 := by { change ((-0 : ℝ) : ereal) = 0, simp }

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -649,17 +649,14 @@ if h0 : c = 0 then by simp [h0] else (div_le_iff h0).2 h
 lemma div_le_of_le_mul' {a b c : ℝ≥0} (h : a ≤ b * c) : a / b ≤ c :=
 div_le_of_le_mul $ mul_comm b c ▸ h
 
-lemma le_div_iff {a b r : ℝ≥0} (hr : r ≠ 0) : a ≤ b / r ↔ a * r ≤ b :=
-@le_div_iff ℝ _ a b r $ pos_iff_ne_zero.2 hr
-
-lemma le_div_iff' {a b r : ℝ≥0} (hr : r ≠ 0) : a ≤ b / r ↔ r * a ≤ b :=
+lemma le_div_iff_mul_le' {a b r : ℝ≥0} (hr : r ≠ 0) : a ≤ b / r ↔ r * a ≤ b :=
 @le_div_iff' ℝ _ a b r $ pos_iff_ne_zero.2 hr
 
 lemma div_lt_iff {a b r : ℝ≥0} (hr : r ≠ 0) : a / r < b ↔ a < b * r :=
-lt_iff_lt_of_le_iff_le (le_div_iff hr)
+lt_iff_lt_of_le_iff_le (le_div_iff_mul_le hr)
 
 lemma div_lt_iff' {a b r : ℝ≥0} (hr : r ≠ 0) : a / r < b ↔ a < r * b :=
-lt_iff_lt_of_le_iff_le (le_div_iff' hr)
+lt_iff_lt_of_le_iff_le (le_div_iff_mul_le' hr)
 
 lemma lt_div_iff {a b r : ℝ≥0} (hr : r ≠ 0) : a < b / r ↔ a * r < b :=
 lt_iff_lt_of_le_iff_le (div_le_iff hr)

--- a/src/data/set/accumulate.lean
+++ b/src/data/set/accumulate.lean
@@ -32,7 +32,7 @@ lemma bUnion_accumulate [preorder α] (x : α) : (⋃ y ≤ x, accumulate s y) =
 begin
   apply subset.antisymm,
   { exact bUnion_subset (λ x hx, (monotone_accumulate hx : _)) },
-  { exact bUnion_subset_bUnion_right (λ x hx, subset_accumulate) }
+  { exact bUnion_mono (λ x hx, subset_accumulate) }
 end
 
 lemma Union_accumulate [preorder α] : (⋃ x, accumulate s x) = ⋃ x, s x :=

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -349,8 +349,6 @@ nonempty_subtype.2 h
 
 instance [nonempty α] : nonempty (set.univ : set α) := set.univ_nonempty.to_subtype
 
-@[simp] lemma nonempty_insert (a : α) (s : set α) : (insert a s).nonempty := ⟨a, or.inl rfl⟩
-
 lemma nonempty_of_nonempty_subtype [nonempty s] : s.nonempty :=
 nonempty_subtype.mp ‹_›
 
@@ -677,7 +675,7 @@ theorem insert_union : insert a s ∪ t = insert a (s ∪ t) := ext $ λ x, or.a
 
 @[simp] theorem union_insert : s ∪ insert a t = insert a (s ∪ t) := ext $ λ x, or.left_comm
 
-theorem insert_nonempty (a : α) (s : set α) : (insert a s).nonempty := ⟨a, mem_insert a s⟩
+@[simp] theorem insert_nonempty (a : α) (s : set α) : (insert a s).nonempty := ⟨a, mem_insert a s⟩
 
 instance (a : α) (s : set α) : nonempty (insert a s : set α) := (insert_nonempty a s).to_subtype
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -707,8 +707,7 @@ theorem singleton_def (a : α) : ({a} : set α) = insert a ∅ := (insert_emptyc
 @[simp] theorem mem_singleton_iff {a b : α} : a ∈ ({b} : set α) ↔ a = b := iff.rfl
 
 @[simp]
-lemma set_of_eq_eq_singleton {a : α} : {n | n = a} = {a} :=
-ext $ λ n, (set.mem_singleton_iff).symm
+lemma set_of_eq_eq_singleton {a : α} : {n | n = a} = {a} := rfl
 
 -- TODO: again, annotation needed
 @[simp] theorem mem_singleton (a : α) : a ∈ ({a} : set α) := @rfl _ _
@@ -730,8 +729,6 @@ theorem pair_comm (a b : α) : ({a, b} : set α) = {b, a} := union_comm _ _
 ⟨a, rfl⟩
 
 @[simp] theorem singleton_subset_iff {a : α} {s : set α} : {a} ⊆ s ↔ a ∈ s := forall_eq
-
-theorem set_compr_eq_eq_singleton {a : α} : {b | b = a} = {a} := rfl
 
 @[simp] theorem singleton_union : {a} ∪ s = insert a s := rfl
 

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -543,7 +543,7 @@ omit Is I's
 /-! ### Deriving continuity from differentiability on manifolds -/
 
 theorem has_mfderiv_within_at.continuous_within_at
-  (h : mdifferentiable_within_at I I' f s x) : continuous_within_at f s x :=
+  (h : has_mfderiv_within_at I I' f s x f') : continuous_within_at f s x :=
 h.1
 
 theorem has_mfderiv_at.continuous_at (h : has_mfderiv_at I I' f x f') :

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -140,18 +140,15 @@ def to_dual_flip (m : M) : (M →ₗ[R] R) := b.to_dual.flip m
 
 lemma to_dual_flip_apply (m₁ m₂ : M) : b.to_dual_flip m₁ m₂ = b.to_dual m₂ m₁ := rfl
 
-lemma to_dual_eq_repr (m : M) (i : ι) : b.to_dual m (b i) = b.repr m i :=
-b.to_dual_apply_left m i
-
 lemma to_dual_eq_equiv_fun [fintype ι] (m : M) (i : ι) : b.to_dual m (b i) = b.equiv_fun m i :=
-by rw [b.equiv_fun_apply, to_dual_eq_repr]
+by rw [b.equiv_fun_apply, to_dual_apply_left]
 
 lemma to_dual_inj (m : M) (a : b.to_dual m = 0) : m = 0 :=
 begin
   rw [← mem_bot R, ← b.repr.ker, mem_ker, linear_equiv.coe_coe],
   apply finsupp.ext,
   intro b,
-  rw [← to_dual_eq_repr, a],
+  rw [← to_dual_apply_left, a],
   refl
 end
 
@@ -167,7 +164,7 @@ begin
   { use finsupp.total ι M R b lin_comb,
     apply b.ext,
     { intros i,
-      rw [b.to_dual_eq_repr _ i, repr_total b],
+      rw [b.to_dual_apply_left _ i, repr_total b],
       { refl } } },
   { intros a _,
     apply fin.complete }

--- a/src/linear_algebra/projection.lean
+++ b/src/linear_algebra/projection.lean
@@ -176,7 +176,7 @@ lemma exists_unique_add_of_is_compl (hc : is_compl p q) (x : E) :
   ∃ (u : p) (v : q), ((u : E) + v = x ∧ ∀ (r : p) (s : q),
     (r : E) + s = x → r = u ∧ s = v) :=
 let ⟨u, hu₁, hu₂⟩ := exists_unique_add_of_is_compl_prod hc x in
-  ⟨u.1, u.2, hu₁, λ r s hrs, prod.eq_iff_fst_eq_snd_eq.1 (hu₂ ⟨r, s⟩ hrs)⟩
+  ⟨u.1, u.2, hu₁, λ r s hrs, prod.ext_iff.1 (hu₂ ⟨r, s⟩ hrs)⟩
 
 end submodule
 

--- a/src/number_theory/l_series.lean
+++ b/src/number_theory/l_series.lean
@@ -112,7 +112,7 @@ begin
     ext n,
     cases n, { simp [h0] },
     simp only [n.succ_ne_zero, one_div, cast_one, nat_coe_apply, complex.abs_cpow_real, inv_inj',
-      complex.abs_inv, if_false, zeta_apply, complex.norm_eq_abs, complex.abs_of_nat] }
+      complex.abs_inv, if_false, zeta_apply, complex.norm_eq_abs, complex.abs_cast_nat] }
 end
 
 @[simp] theorem l_series_add {f g : arithmetic_function ℂ} {z : ℂ}

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -159,17 +159,8 @@ section
   | (n+1) := by simp [pow_succ']; exact le_trans
     (nat.mul_le_mul_right _ (xn_ge_a_pow n)) (nat.le_add_right _ _)
 
-  theorem n_lt_a_pow : ∀ (n : ℕ), n < a^n
-  | 0     := nat.le_refl 1
-  | (n+1) := begin have IH := n_lt_a_pow n,
-    have : a^n + a^n ≤ a^n * a,
-    { rw ← mul_two, exact nat.mul_le_mul_left _ a1 },
-    simp [pow_succ'], refine lt_of_lt_of_le _ this,
-    exact add_lt_add_of_lt_of_le IH (lt_of_le_of_lt (nat.zero_le _) IH)
-  end
-
   theorem n_lt_xn (n) : n < xn n :=
-  lt_of_lt_of_le (n_lt_a_pow n) (xn_ge_a_pow n)
+  lt_of_lt_of_le (n.lt_pow_self a1) (xn_ge_a_pow n)
 
   theorem x_pos (n) : 0 < xn n :=
   lt_of_le_of_lt (nat.zero_le n) (n_lt_xn n)

--- a/src/order/filter/lift.lean
+++ b/src/order/filter/lift.lean
@@ -439,14 +439,10 @@ from lift_lift'_same_eq_lift'
   (assume s, set.monotone_prod monotone_const monotone_id)
   (assume t, set.monotone_prod monotone_id monotone_const)
 
-lemma mem_prod_same_iff {s : set (α×α)} :
-  s ∈ f ×ᶠ f ↔ (∃t∈f, set.prod t t ⊆ s) :=
-by rw [prod_same_eq, mem_lift'_sets]; exact set.monotone_prod monotone_id monotone_id
-
 lemma tendsto_prod_self_iff {f : α × α → β} {x : filter α} {y : filter β} :
   filter.tendsto f (x ×ᶠ x) y ↔
   ∀ W ∈ y, ∃ U ∈ x, ∀ (x x' : α), x ∈ U → x' ∈ U → f (x, x') ∈ W :=
-by simp only [tendsto_def, mem_prod_same_iff, prod_sub_preimage_iff, exists_prop, iff_self]
+by simp only [tendsto_def, mem_prod_self_iff, prod_sub_preimage_iff, exists_prop, iff_self]
 
 variables {α₁ : Type*} {α₂ : Type*} {β₁ : Type*} {β₂ : Type*}
 

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -848,10 +848,6 @@ begin
   { exact ⟨L, HL', or.inl $ by rw [list.prod_cons, hhd, HP, neg_one_mul, neg_neg]⟩ }
 end
 
-lemma closure_preimage_le (f : R →+* S) (s : set S) :
-  closure (f ⁻¹' s) ≤ (closure s).comap f :=
-closure_le.2 $ λ x hx, set_like.mem_coe.2 $ mem_comap.2 $ subset_closure hx
-
 end subring
 
 lemma add_subgroup.int_mul_mem {G : add_subgroup R} (k : ℤ) {g : R} (h : g ∈ G) :

--- a/src/topology/algebra/group_with_zero.lean
+++ b/src/topology/algebra/group_with_zero.lean
@@ -42,7 +42,7 @@ operations on `filter.tendsto`, `continuous_at`, `continuous_within_at`, `contin
 `continuous`.
 -/
 
-variables {α G₀ : Type*}
+variables {α G₀ : Type*} {a : α}
 
 section div_const
 
@@ -55,8 +55,8 @@ by simpa only [div_eq_mul_inv] using hf.mul tendsto_const_nhds
 
 variables [topological_space α]
 
-lemma continuous_at.div_const (hf : continuous f) {y : G₀} : continuous (λ x, f x / y) :=
-by simpa only [div_eq_mul_inv] using hf.mul continuous_const
+lemma continuous_at.div_const (hf : continuous_at f a) {y : G₀} : continuous_at (λ x, f x / y) a :=
+by simpa only [div_eq_mul_inv] using hf.mul continuous_at_const
 
 lemma continuous_within_at.div_const {a} (hf : continuous_within_at f s a) {y : G₀} :
   continuous_within_at (λ x, f x / y) s a :=
@@ -81,7 +81,7 @@ export has_continuous_inv' (continuous_at_inv')
 section inv'
 
 variables [has_zero G₀] [has_inv G₀] [topological_space G₀] [has_continuous_inv' G₀]
-  {l : filter α} {f : α → G₀} {s : set α} {a : α}
+  {l : filter α} {f : α → G₀} {s : set α}
 
 /-!
 ### Continuity of `λ x, x⁻¹` at a non-zero point

--- a/src/topology/algebra/group_with_zero.lean
+++ b/src/topology/algebra/group_with_zero.lean
@@ -42,12 +42,12 @@ operations on `filter.tendsto`, `continuous_at`, `continuous_within_at`, `contin
 `continuous`.
 -/
 
-variables {α G₀ : Type*} {a : α}
+variables {α G₀ : Type*}
 
 section div_const
 
 variables [group_with_zero G₀] [topological_space G₀] [has_continuous_mul G₀]
-  {f : α → G₀} {s : set α} {l : filter α}
+  {f : α → G₀} {s : set α} {l : filter α} {a : α}
 
 lemma filter.tendsto.div_const {x y : G₀} (hf : tendsto f l (𝓝 x)) :
   tendsto (λa, f a / y) l (𝓝 (x / y)) :=
@@ -81,7 +81,7 @@ export has_continuous_inv' (continuous_at_inv')
 section inv'
 
 variables [has_zero G₀] [has_inv G₀] [topological_space G₀] [has_continuous_inv' G₀]
-  {l : filter α} {f : α → G₀} {s : set α}
+  {l : filter α} {f : α → G₀} {s : set α} {a : α}
 
 /-!
 ### Continuity of `λ x, x⁻¹` at a non-zero point

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -3178,7 +3178,7 @@ begin
   obtain ⟨s : set α, hsc : is_compact s, hsf : ∀ x ∉ s, f (default α) ≤ f x⟩ :=
     (has_basis_cocompact.tendsto_iff at_top_basis).1 hlim (f $ default α) trivial,
   obtain ⟨x, -, hx⟩ :=
-    (hsc.insert (default α)).exists_forall_le (nonempty_insert _ _) hf.continuous_on,
+    (hsc.insert (default α)).exists_forall_le (insert_nonempty _ _) hf.continuous_on,
   refine ⟨x, λ y, _⟩,
   by_cases hy : y ∈ s,
   exacts [hx y (or.inr hy), (hx _ (or.inl rfl)).trans (hsf y hy)]

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -90,7 +90,7 @@ lemma uniform_embedding_translate (a : α) : uniform_embedding (λx:α, x + a) :
 { comap_uniformity := begin
     rw [← uniformity_translate a, comap_map] {occs := occurrences.pos [1]},
     rintros ⟨p₁, p₂⟩ ⟨q₁, q₂⟩,
-    simp [prod.eq_iff_fst_eq_snd_eq] {contextual := tt}
+    simp [prod.ext_iff] {contextual := tt}
   end,
   inj := add_left_injective a }
 

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -327,7 +327,7 @@ begin
   { have := tendsto_prod_iff.1 lim_φ_sub_sub W W_nhd,
     repeat { rw [nhds_prod_eq, ←prod_comap_comap_eq] at this },
     rcases this with ⟨U, U_in, V, V_in, H⟩,
-    rw [mem_prod_same_iff] at U_in V_in,
+    rw [mem_prod_self_iff] at U_in V_in,
     rcases U_in with ⟨U₁, U₁_in, HU₁⟩,
     rcases V_in with ⟨V₁, V₁_in, HV₁⟩,
     existsi [U₁, U₁_in, V₁, V₁_in],
@@ -396,7 +396,7 @@ begin
 
     rw [mem_map, mem_comap, nhds_prod_eq],
     existsi set.prod (set.prod U' V') (set.prod U' V'),
-    rw mem_prod_same_iff,
+    rw mem_prod_self_iff,
 
     simp only [exists_prop],
     split,

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -172,7 +172,7 @@ lemma is_compact.elim_nhds_subcover' (hs : is_compact s) (U : Π x ∈ s, set α
   ∃ t : finset s, s ⊆ ⋃ x ∈ t, U (x : s) x.2 :=
 (hs.elim_finite_subcover (λ x : s, interior (U x x.2)) (λ x, is_open_interior)
   (λ x hx, mem_Union.2 ⟨⟨x, hx⟩, mem_interior_iff_mem_nhds.2 $ hU _ _⟩)).imp $ λ t ht,
-subset.trans ht $ bUnion_subset_bUnion_right $ λ _ _, interior_subset
+subset.trans ht $ bUnion_mono $ λ _ _, interior_subset
 
 lemma is_compact.elim_nhds_subcover (hs : is_compact s) (U : α → set α) (hU : ∀ x ∈ s, U x ∈ 𝓝 x) :
   ∃ t : finset α, (∀ x ∈ t, x ∈ s) ∧ s ⊆ ⋃ x ∈ t, U x :=

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -416,7 +416,7 @@ begin
         simpa [nonempty_diff] using hd_cover t t.finite_to_set } },
     have : f ≤ 𝓟 s, from infi_le_of_le ∅ (by simp),
     refine ⟨f, ‹_›, ‹_›, λ c hcf hc, _⟩,
-    rcases mem_prod_same_iff.1 (hc.2 hd) with ⟨m, hm, hmd⟩,
+    rcases mem_prod_self_iff.1 (hc.2 hd) with ⟨m, hm, hmd⟩,
     have : m ∩ s ∈ c, from inter_mem hm (le_principal_iff.mp (hcf.trans ‹_›)),
     rcases hc.1.nonempty_of_mem this with ⟨y, hym, hys⟩,
     set ys := ⋃ y' ∈ ({y} : finset α), {x | (x, y') ∈ d},

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -164,7 +164,7 @@ have h_ex : ∀ s ∈ 𝓤 (Cauchy α), ∃y:α, (f, pure_cauchy y) ∈ s, from
   let ⟨t', ht'₁, ht'₂⟩ := comp_mem_uniformity_sets ht''₁ in
   have t' ∈ f.val ×ᶠ f.val,
     from f.property.right ht'₁,
-  let ⟨t, ht, (h : set.prod t t ⊆ t')⟩ := mem_prod_same_iff.mp this in
+  let ⟨t, ht, (h : set.prod t t ⊆ t')⟩ := mem_prod_self_iff.mp this in
   let ⟨x, (hx : x ∈ t)⟩ := f.property.left.nonempty_of_mem ht in
   have t'' ∈ f.val ×ᶠ pure x,
     from mem_prod_iff.mpr ⟨t, ht, {y:α | (x, y) ∈ t'},
@@ -209,7 +209,7 @@ complete_space_extension
   have map pure_cauchy f ≤ (𝓤 $ Cauchy α).lift' (preimage (prod.mk f')),
     from le_lift' $ assume s hs,
     let ⟨t, ht₁, (ht₂ : gen t ⊆ s)⟩ := (mem_lift'_sets monotone_gen).mp hs in
-    let ⟨t', ht', (h : set.prod t' t' ⊆ t)⟩ := mem_prod_same_iff.mp (hf.right ht₁) in
+    let ⟨t', ht', (h : set.prod t' t' ⊆ t)⟩ := mem_prod_self_iff.mp (hf.right ht₁) in
     have t' ⊆ { y : α | (f', pure_cauchy y) ∈ gen t },
       from assume x hx, (f ×ᶠ pure x).sets_of_superset (prod_mem_prod ht' hx) h,
     f.sets_of_superset ht' $ subset.trans this (preimage_mono ht₂),

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -262,7 +262,7 @@ have cauchy g, from
   let
     ⟨s₁, hs₁, (comp_s₁ : comp_rel s₁ s₁ ⊆ s)⟩ := comp_mem_uniformity_sets hs,
     ⟨s₂, hs₂, (comp_s₂ : comp_rel s₂ s₂ ⊆ s₁)⟩ := comp_mem_uniformity_sets hs₁,
-    ⟨t, ht, (prod_t : set.prod t t ⊆ s₂)⟩ := mem_prod_same_iff.mp (hf.right hs₂)
+    ⟨t, ht, (prod_t : set.prod t t ⊆ s₂)⟩ := mem_prod_self_iff.mp (hf.right hs₂)
   in
   have hg₁ : p (preimage prod.swap s₁) t ∈ g,
     from mem_lift (symm_le_uniformity hs₁) $ @mem_lift' α α f _ t ht,


### PR DESCRIPTION
Sometimes lemmas get added to mathlib which are exact duplicates of each other, this can happen for a few reasons:
1. they are aliases, which is fine and normal, but they should be created with the alias command
2. the author didn't find the original lemma, in which case the better name and proof should be chosen
3. the author didn't prove the lemma they were intending to, due to copy paste errors or elaborator quirks.

Here we cleanup some duplicates in the library in categories 2. and 3. above, changing the names and proofs of some duplicated lemmas, and changing the statement and proof when there was a copy paste error and a different statement was intended.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
