### PR TITLE
[Merged by Bors] - feat(topology/metric_space): add `uniform_embedding.comap_metric_space`

### DIFF
--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -17,7 +17,7 @@ import algebra.periodic
 noncomputable theory
 open classical set filter topological_space metric
 open_locale classical
-open_locale topological_space
+open_locale topological_space filter uniformity
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -31,22 +31,19 @@ theorem rat.dist_eq (x y : ℚ) : dist x y = abs (x - y) := rfl
 
 namespace int
 
-section low_prio
--- we want to ignore this instance for the next declaration
-local attribute [instance, priority 10] int.uniform_space
-instance : metric_space ℤ :=
-begin
-  letI M := metric_space.induced coe int.cast_injective real.metric_space,
-  refine @metric_space.replace_uniformity _ int.uniform_space M
-    (le_antisymm refl_le_uniformity $ λ r ru,
-      mem_uniformity_dist.2 ⟨1, zero_lt_one, λ a b h,
-      mem_principal.1 ru $ dist_le_zero.1 (_ : (abs (a - b) : ℝ) ≤ 0)⟩),
-  have : (abs (↑a - ↑b) : ℝ) < 1 := h,
-  have : abs (a - b) < 1, by norm_cast at this; assumption,
-  have : abs (a - b) ≤ 0 := (@int.lt_add_one_iff _ 0).mp this,
-  norm_cast, assumption
-end
-end low_prio
+lemma uniform_embedding_coe_real : uniform_embedding (coe : ℤ → ℝ) :=
+{ comap_uniformity :=
+    begin
+      refine le_antisymm (le_principal_iff.2 _) (@refl_le_uniformity ℤ $
+        uniform_space.comap coe (infer_instance : uniform_space ℝ)),
+      refine (uniformity_basis_dist.comap _).mem_iff.2 ⟨1, zero_lt_one, _⟩,
+      rintro ⟨a, b⟩ (h : abs (a - b : ℝ) < 1),
+      norm_cast at h,
+      erw [@int.lt_add_one_iff _ 0, abs_nonpos_iff, sub_eq_zero] at h, assumption
+    end,
+  inj := int.cast_injective }
+
+instance : metric_space ℤ := int.uniform_embedding_coe_real.comap_metric_space _
 
 theorem dist_eq (x y : ℤ) : dist x y = abs (x - y) := rfl
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1123,6 +1123,13 @@ def pseudo_metric_space.induced {α β} (f : α → β)
       exact ⟨_, dist_mem_uniformity ε0, λ ⟨a, b⟩, hε⟩ }
   end }
 
+/-- Pull back a pseudometric space structure by a uniform inducing map. This is a version of
+`pseudo_metric_space.induced` useful in case if the domain already has a `uniform_space`
+structure. -/
+def uniform_inducing.comap_pseudo_metric_space {α β} [uniform_space α] [pseudo_metric_space β]
+  (f : α → β) (h : uniform_inducing f) : pseudo_metric_space α :=
+(pseudo_metric_space.induced f ‹_›).replace_uniformity h.comap_uniformity.symm
+
 instance subtype.psudo_metric_space {α : Type*} {p : α → Prop} [t : pseudo_metric_space α] :
   pseudo_metric_space (subtype p) :=
 pseudo_metric_space.induced coe t
@@ -2002,6 +2009,12 @@ def metric_space.induced {γ β} (f : γ → β) (hf : function.injective f)
   (m : metric_space β) : metric_space γ :=
 { eq_of_dist_eq_zero := λ x y h, hf (dist_eq_zero.1 h),
   ..pseudo_metric_space.induced f m.to_pseudo_metric_space }
+
+/-- Pull back a metric space structure by a uniform embedding. This is a version of
+`metric_space.induced` useful in case if the domain already has a `uniform_space` structure. -/
+def uniform_embedding.comap_metric_space {α β} [uniform_space α] [metric_space β] (f : α → β)
+  (h : uniform_embedding f) : metric_space α :=
+(metric_space.induced f h.inj ‹_›).replace_uniformity h.comap_uniformity.symm
 
 instance subtype.metric_space {α : Type*} {p : α → Prop} [t : metric_space α] :
   metric_space (subtype p) :=

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -564,7 +564,10 @@ is_open_compl_iff.1 $ is_open_iff.2 $ λ y hy, ⟨⊤, ennreal.coe_lt_top, subse
   ball_disjoint $ by { rw ennreal.top_add, exact le_of_not_lt hy }⟩
 
 theorem ball_mem_nhds (x : α) {ε : ℝ≥0∞} (ε0 : 0 < ε) : ball x ε ∈ 𝓝 x :=
-is_open.mem_nhds is_open_ball (mem_ball_self ε0)
+is_open_ball.mem_nhds (mem_ball_self ε0)
+
+theorem closed_ball_mem_nhds (x : α) {ε : ℝ≥0∞} (ε0 : 0 < ε) : closed_ball x ε ∈ 𝓝 x :=
+mem_of_superset (ball_mem_nhds x ε0) ball_subset_closed_ball
 
 theorem ball_prod_same [pseudo_emetric_space β] (x : α) (y : β) (r : ℝ≥0∞) :
   (ball x r).prod (ball y r) = ball (x, y) r :=


### PR DESCRIPTION
* add `uniform_embedding.comap_metric_space` and
  `uniform_inducing.comap_pseudo_metric_space`;
* use the former for `int.metric_space`;
* also add `emetric.closed_ball_mem_nhds`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)