### PR TITLE
[Merged by Bors] - feat(algebra/big_operators/finprod): a few more lemmas

### DIFF
--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -211,6 +211,44 @@ end
   f (∏ᶠ x, g x) = ∏ᶠ x, f (g x) :=
 f.map_finprod_plift g (finite.of_fintype _)
 
+@[to_additive] lemma monoid_hom.map_finprod_of_preimage_one (f : M →* N)
+  (hf : ∀ x, f x = 1 → x = 1) (g : α → M) :
+  f (∏ᶠ i, g i) = ∏ᶠ i, f (g i) :=
+begin
+  by_cases hg : (mul_support $ g ∘ plift.down).finite, { exact f.map_finprod_plift g hg },
+  rw [finprod, dif_neg, f.map_one, finprod, dif_neg],
+  exacts [infinite_mono (λ x hx, mt (hf (g x.down)) hx) hg, hg]
+end
+
+@[to_additive] lemma monoid_hom.map_finprod_of_injective (g : M →* N) (hg : injective g)
+  (f : α → M) :
+  g (∏ᶠ i, f i) = ∏ᶠ i, g (f i) :=
+g.map_finprod_of_preimage_one (λ x, (hg.eq_iff' g.map_one).mp) f
+
+@[to_additive] lemma mul_equiv.map_finprod (g : M ≃* N) (f : α → M) :
+  g (∏ᶠ i, f i) = ∏ᶠ i, g (f i) :=
+g.to_monoid_hom.map_finprod_of_injective g.injective f
+
+lemma finsum_smul {R M : Type*} [ring R] [add_comm_group M] [module R M]
+  [no_zero_smul_divisors R M] (f : ι → R) (x : M) :
+  (∑ᶠ i, f i) • x = (∑ᶠ i, (f i) • x) :=
+begin
+  rcases eq_or_ne x 0 with rfl|hx, { simp },
+  exact ((smul_add_hom R M).flip x).map_finsum_of_injective (smul_left_injective R hx) _
+end
+
+lemma smul_finsum {R M : Type*} [ring R] [add_comm_group M] [module R M]
+  [no_zero_smul_divisors R M] (c : R) (f : ι → M) :
+  c • (∑ᶠ i, f i) = (∑ᶠ i, c • f i) :=
+begin
+  rcases eq_or_ne c 0 with rfl|hc, { simp },
+  exact (smul_add_hom R M c).map_finsum_of_injective (smul_right_injective M hc) _
+end
+
+@[to_additive] lemma finprod_inv_distrib {G : Type*} [comm_group G] (f : α → G) :
+  ∏ᶠ x, (f x)⁻¹ = (∏ᶠ x, f x)⁻¹ :=
+((mul_equiv.inv G).map_finprod f).symm
+
 end sort
 
 section type


### PR DESCRIPTION
* versions of `monoid_hom.map_finprod` that assume properties of
  `f : M →* N` instead of finiteness of the support;
* `finsum_smul`, `smul_finsum`, `finprod_inv_distrib`: missing
  analogues of lemmas from `finset.prod`/`finset.sum` API.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)