### PR TITLE
[Merged by Bors] - feat(ring_theory/dedekind_domain): the integral closure of a DD is a DD

### DIFF
--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -719,13 +719,12 @@ variables [algebra C L] [is_integral_closure C A L] [algebra A C] [is_scalar_tow
 lemma is_integral_closure.range_le_span_dual_basis [is_separable K L]
   {ι : Type*} [fintype ι] [decidable_eq ι] (b : basis ι K L)
   (hb_int : ∀ i, is_integral A (b i)) [is_integrally_closed A] :
-  ((algebra.of_id C L).to_linear_map.restrict_scalars A).range ≤
+  ((algebra.linear_map C L).restrict_scalars A).range ≤
     submodule.span A (set.range $ (trace_form K L).dual_basis (trace_form_nondegenerate K L) b) :=
 begin
   let db := (trace_form K L).dual_basis (trace_form_nondegenerate K L) b,
   rintros _ ⟨x, rfl⟩,
-  simp only [alg_hom.to_linear_map_apply, linear_map.coe_restrict_scalars_eq_coe,
-    algebra.of_id_apply],
+  simp only [linear_map.coe_restrict_scalars_eq_coe, algebra.linear_map_apply],
   have hx : is_integral A (algebra_map C L x) :=
     (is_integral_closure.is_integral A L x).algebra_map,
   suffices : ∃ (c : ι → A), algebra_map C L x = ∑ i, c i • db i,
@@ -831,7 +830,7 @@ begin
   letI := is_noetherian_span_of_finite A (set.finite_range b'),
   let f : C →ₗ[A] submodule.span A (set.range b') :=
     (submodule.of_le (is_integral_closure.range_le_span_dual_basis C b hb_int)).comp
-    ((algebra.of_id C L).to_linear_map.restrict_scalars A).range_restrict,
+    ((algebra.linear_map C L).restrict_scalars A).range_restrict,
   refine is_noetherian_of_tower A (is_noetherian_of_injective f _),
   rw [linear_map.ker_comp, submodule.ker_of_le, submodule.comap_bot, linear_map.ker_cod_restrict],
   exact linear_map.ker_eq_bot_of_injective (is_integral_closure.algebra_map_injective C A L)

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -61,11 +61,17 @@ lemma dimension_le_one.principal_ideal_ring
   [is_principal_ideal_ring A] : dimension_le_one A :=
 λ p nonzero prime, by { haveI := prime, exact is_prime.to_maximal_ideal nonzero }
 
+lemma dimension_le_one.is_integral_closure (B : Type*) [integral_domain B]
+  [nontrivial R] [algebra R A] [algebra R B] [algebra B A] [is_scalar_tower R B A]
+  [is_integral_closure B R A] (h : dimension_le_one R) :
+  dimension_le_one B :=
+λ p ne_bot prime, by exactI
+  is_integral_closure.is_maximal_of_is_maximal_comap A p
+    (h _ (is_integral_closure.comap_ne_bot A ne_bot) infer_instance)
+
 lemma dimension_le_one.integral_closure [nontrivial R] [algebra R A]
   (h : dimension_le_one R) : dimension_le_one (integral_closure R A) :=
-λ p ne_bot prime, by exactI
-  integral_closure.is_maximal_of_is_maximal_comap p
-    (h _ (integral_closure.comap_ne_bot ne_bot) infer_instance)
+h.is_integral_closure R A (integral_closure R A)
 
 end ring
 

--- a/src/ring_theory/ideal/over.lean
+++ b/src/ring_theory/ideal/over.lean
@@ -225,25 +225,50 @@ lemma is_maximal_comap_of_is_integral_of_is_maximal' {R S : Type*} [comm_ring R]
   (f : R →+* S) (hf : f.is_integral) (I : ideal S) (hI : I.is_maximal) : is_maximal (I.comap f) :=
 @is_maximal_comap_of_is_integral_of_is_maximal R _ S _ f.to_algebra hf I hI
 
+section is_integral_closure
+
+variables (S) {A : Type*} [integral_domain A]
+variables [algebra R A] [algebra A S] [is_scalar_tower R A S] [is_integral_closure A R S]
+
+lemma is_integral_closure.comap_ne_bot [nontrivial R] {I : ideal A}
+  (I_ne_bot : I ≠ ⊥) : I.comap (algebra_map R A) ≠ ⊥ :=
+let ⟨x, x_mem, x_ne_zero⟩ := I.ne_bot_iff.mp I_ne_bot in
+comap_ne_bot_of_integral_mem x_ne_zero x_mem (is_integral_closure.is_integral R S x)
+
+lemma is_integral_closure.eq_bot_of_comap_eq_bot [nontrivial R] {I : ideal A} :
+  I.comap (algebra_map R A) = ⊥ → I = ⊥ :=
+imp_of_not_imp_not _ _ (is_integral_closure.comap_ne_bot S)
+
+lemma is_integral_closure.comap_lt_comap {I J : ideal A} [I.is_prime]
+  (I_lt_J : I < J) :
+  I.comap (algebra_map R A) < J.comap (algebra_map _ _) :=
+let ⟨I_le_J, x, hxJ, hxI⟩ := set_like.lt_iff_le_and_exists.mp I_lt_J in
+comap_lt_comap_of_integral_mem_sdiff I_le_J ⟨hxJ, hxI⟩ (is_integral_closure.is_integral R S x)
+
+lemma is_integral_closure.is_maximal_of_is_maximal_comap
+  (I : ideal A) [I.is_prime]
+  (hI : is_maximal (I.comap (algebra_map R A))) : is_maximal I :=
+is_maximal_of_is_integral_of_is_maximal_comap (λ x, is_integral_closure.is_integral R S x) I hI
+
+end is_integral_closure
+
 lemma integral_closure.comap_ne_bot [nontrivial R] {I : ideal (integral_closure R S)}
   (I_ne_bot : I ≠ ⊥) : I.comap (algebra_map R (integral_closure R S)) ≠ ⊥ :=
-let ⟨x, x_mem, x_ne_zero⟩ := I.ne_bot_iff.mp I_ne_bot in
-comap_ne_bot_of_integral_mem x_ne_zero x_mem (integral_closure.is_integral x)
+is_integral_closure.comap_ne_bot S I_ne_bot
 
 lemma integral_closure.eq_bot_of_comap_eq_bot [nontrivial R] {I : ideal (integral_closure R S)} :
   I.comap (algebra_map R (integral_closure R S)) = ⊥ → I = ⊥ :=
-imp_of_not_imp_not _ _ integral_closure.comap_ne_bot
+is_integral_closure.eq_bot_of_comap_eq_bot S
 
 lemma integral_closure.comap_lt_comap {I J : ideal (integral_closure R S)} [I.is_prime]
   (I_lt_J : I < J) :
   I.comap (algebra_map R (integral_closure R S)) < J.comap (algebra_map _ _) :=
-let ⟨I_le_J, x, hxJ, hxI⟩ := set_like.lt_iff_le_and_exists.mp I_lt_J in
-comap_lt_comap_of_integral_mem_sdiff I_le_J ⟨hxJ, hxI⟩ (integral_closure.is_integral x)
+is_integral_closure.comap_lt_comap S I_lt_J
 
 lemma integral_closure.is_maximal_of_is_maximal_comap
   (I : ideal (integral_closure R S)) [I.is_prime]
   (hI : is_maximal (I.comap (algebra_map R (integral_closure R S)))) : is_maximal I :=
-is_maximal_of_is_integral_of_is_maximal_comap (λ x, integral_closure.is_integral x) I hI
+is_integral_closure.is_maximal_of_is_maximal_comap S I hI
 
 /-- `comap (algebra_map R S)` is a surjection from the prime spec of `R` to prime spec of `S`.
 `hP : (algebra_map R S).ker ≤ P` is a slight generalization of the extension being injective -/

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1797,6 +1797,43 @@ lemma is_integral_localization' {R S : Type*} [comm_ring R] [comm_ring S]
 
 end is_integral
 
+namespace is_integral_closure
+
+variables (A) {L : Type*} [field K] [field L] [algebra A K] [algebra A L] [is_fraction_ring A K]
+variables (C : Type*) [integral_domain C] [algebra C L] [is_integral_closure C A L]
+variables [algebra A C] [is_scalar_tower A C L]
+
+open algebra
+
+/-- If the field `L` is an algebraic extension of the integral domain `A`,
+the integral closure `C` of `A` in `L` has fraction field `L`. -/
+lemma is_fraction_ring_of_algebraic (alg : is_algebraic A L)
+  (inj : ∀ x, algebra_map A L x = 0 → x = 0) :
+  is_fraction_ring C L :=
+{ map_units := λ ⟨y, hy⟩,
+    is_unit.mk0 _ (show algebra_map C L y ≠ 0, from λ h, mem_non_zero_divisors_iff_ne_zero.mp hy
+      ((algebra_map C L).injective_iff.mp (algebra_map_injective C A L) _ h)),
+  surj := λ z, let ⟨x, y, hy, hxy⟩ := exists_integral_multiple (alg z) inj in
+    ⟨⟨mk' C (x : L) x.2, algebra_map _ _ y,
+        mem_non_zero_divisors_iff_ne_zero.mpr (λ h, hy (inj _
+          (by rw [is_scalar_tower.algebra_map_apply A C L, h, ring_hom.map_zero])))⟩,
+     by rw [set_like.coe_mk, algebra_map_mk', ← is_scalar_tower.algebra_map_apply A C L, hxy]⟩,
+  eq_iff_exists := λ x y, ⟨λ h, ⟨1, by simpa using algebra_map_injective C A L h⟩, λ ⟨c, hc⟩,
+    congr_arg (algebra_map _ L) (mul_right_cancel' (mem_non_zero_divisors_iff_ne_zero.mp c.2) hc)⟩ }
+
+variables (K L)
+
+/-- If the field `L` is a finite extension of the fraction field of the integral domain `A`,
+the integral closure `C` of `A` in `L` has fraction field `L`. -/
+lemma is_fraction_ring_of_finite_extension [algebra K L] [is_scalar_tower A K L]
+  [finite_dimensional K L] : is_fraction_ring C L :=
+is_fraction_ring_of_algebraic A C
+  (is_fraction_ring.comap_is_algebraic_iff.mpr (is_algebraic_of_finite : is_algebraic K L))
+  (λ x hx, is_fraction_ring.to_map_eq_zero_iff.mp ((algebra_map K L).map_eq_zero.mp $
+    (is_scalar_tower.algebra_map_apply _ _ _ _).symm.trans hx))
+
+end is_integral_closure
+
 namespace integral_closure
 
 variables {L : Type*} [field K] [field L] [algebra A K] [is_fraction_ring A K]
@@ -1808,15 +1845,7 @@ the integral closure of `A` in `L` has fraction field `L`. -/
 lemma is_fraction_ring_of_algebraic [algebra A L] (alg : is_algebraic A L)
   (inj : ∀ x, algebra_map A L x = 0 → x = 0) :
   is_fraction_ring (integral_closure A L) L :=
-⟨(λ ⟨⟨y, integral⟩, nonzero⟩,
-   have y ≠ 0 := λ h, mem_non_zero_divisors_iff_ne_zero.mp nonzero (subtype.ext_iff_val.mpr h),
-   show is_unit y, from ⟨⟨y, y⁻¹, mul_inv_cancel this, inv_mul_cancel this⟩, rfl⟩),
- (λ z, let ⟨x, y, hy, hxy⟩ := exists_integral_multiple (alg z) inj in
-   ⟨⟨x, ⟨algebra_map _ _ y, mem_non_zero_divisors_iff_ne_zero.mpr
-      (λ h, hy (inj _ ((congr_arg coe h).trans (subalgebra.coe_zero _))))⟩⟩, hxy⟩),
- (λ x y, ⟨λ (h : x.1 = y.1), ⟨1, by simpa using subtype.ext_iff_val.mpr h⟩,
-          λ ⟨c, hc⟩, congr_arg (algebra_map _ L)
-            (mul_right_cancel' (mem_non_zero_divisors_iff_ne_zero.mp c.2) hc)⟩)⟩
+is_integral_closure.is_fraction_ring_of_algebraic A (integral_closure A L) alg inj
 
 variables (K L)
 
@@ -1825,10 +1854,7 @@ the integral closure of `A` in `L` has fraction field `L`. -/
 lemma is_fraction_ring_of_finite_extension [algebra A L] [algebra K L]
   [is_scalar_tower A K L] [finite_dimensional K L] :
   is_fraction_ring (integral_closure A L) L :=
-is_fraction_ring_of_algebraic
-  (is_fraction_ring.comap_is_algebraic_iff.mpr (is_algebraic_of_finite : is_algebraic K L))
-  (λ x hx, is_fraction_ring.to_map_eq_zero_iff.mp ((algebra_map K L).map_eq_zero.mp $
-    (is_scalar_tower.algebra_map_apply _ _ _ _).symm.trans hx))
+is_integral_closure.is_fraction_ring_of_finite_extension A K L (integral_closure A L)
 
 end integral_closure
 

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -376,7 +376,7 @@ begin
   { rw [alg_hom.card, pb.finrank] }
 end
 
-lemma det_trace_form_ne_zero  [is_separable K L] [decidable_eq ι] (b : basis ι K L) :
+lemma det_trace_form_ne_zero [is_separable K L] [decidable_eq ι] (b : basis ι K L) :
   det (bilin_form.to_matrix b (trace_form K L)) ≠ 0 :=
 begin
   haveI : finite_dimensional K L := finite_dimensional.of_fintype_basis b,
@@ -396,5 +396,12 @@ begin
   ... = 1 : by simp only [basis.to_matrix_mul_to_matrix_flip, matrix.transpose_one,
                           matrix.mul_one, matrix.det_one]
 end
+
+variables (K L)
+
+theorem trace_form_nondegenerate [finite_dimensional K L] [is_separable K L] :
+  (trace_form K L).nondegenerate :=
+bilin_form.nondegenerate_of_det_ne_zero (trace_form K L) _
+  (det_trace_form_ne_zero (finite_dimensional.fin_basis K L))
 
 end det_ne_zero


### PR DESCRIPTION
Let `L` be a finite separable extension of `K = Frac(A)`, where `A` is a Dedekind domain. Then any `is_integral_closure C A L` is also a Dedekind domain, in particular for `C := integral_closure A L`.

In combination with the definitions of #8701, we can conclude that rings of integers are Dedekind domains.

---

 - [x] depends on: #8777 
 - [x] depends on: #8823
 - [x] depends on: #8824
 - [x] depends on: #8846

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
