### PR TITLE
[Merged by Bors] - feat(linear_algebra): introduce notation for `linear_map.comp` and `linear_equiv.trans`

### DIFF
--- a/src/algebra/category/Module/abelian.lean
+++ b/src/algebra/category/Module/abelian.lean
@@ -40,8 +40,8 @@ def normal_mono (hf : mono f) : normal_mono f :=
         ```
       -/
       (linear_equiv.to_Module_iso'
-        ((submodule.quot_equiv_of_eq_bot _ (ker_eq_bot_of_mono _)).symm ≫ₗ
-          ((linear_map.quot_ker_equiv_range f) ≫ₗ
+        ((submodule.quot_equiv_of_eq_bot _ (ker_eq_bot_of_mono _)).symm ≪≫ₗ
+          ((linear_map.quot_ker_equiv_range f) ≪≫ₗ
             (linear_equiv.of_eq _ _ (submodule.ker_mkq _).symm)))) $
       by { ext, refl } }
 
@@ -61,8 +61,8 @@ def normal_epi (hf : epi f) : normal_epi f :=
         ... ≃ₗ[R] N              : linear_equiv.of_top _ (range_eq_top_of_epi _)
         ```
       -/
-        (((submodule.quot_equiv_of_eq _ _ (submodule.range_subtype _)) ≫ₗ
-          (linear_map.quot_ker_equiv_range f)) ≫ₗ
+        (((submodule.quot_equiv_of_eq _ _ (submodule.range_subtype _)) ≪≫ₗ
+          (linear_map.quot_ker_equiv_range f)) ≪≫ₗ
           (linear_equiv.of_top _ (range_eq_top_of_epi _)))) $
       by { ext, refl } }
 

--- a/src/algebra/category/Module/abelian.lean
+++ b/src/algebra/category/Module/abelian.lean
@@ -40,8 +40,8 @@ def normal_mono (hf : mono f) : normal_mono f :=
         ```
       -/
       (linear_equiv.to_Module_iso'
-        (linear_equiv.trans (submodule.quot_equiv_of_eq_bot _ (ker_eq_bot_of_mono _)).symm
-          (linear_equiv.trans (linear_map.quot_ker_equiv_range f)
+        ((submodule.quot_equiv_of_eq_bot _ (ker_eq_bot_of_mono _)).symm ≫ₗ
+          ((linear_map.quot_ker_equiv_range f) ≫ₗ
             (linear_equiv.of_eq _ _ (submodule.ker_mkq _).symm)))) $
       by { ext, refl } }
 
@@ -61,9 +61,9 @@ def normal_epi (hf : epi f) : normal_epi f :=
         ... ≃ₗ[R] N              : linear_equiv.of_top _ (range_eq_top_of_epi _)
         ```
       -/
-        (linear_equiv.trans
-          (linear_equiv.trans (submodule.quot_equiv_of_eq _ _ (submodule.range_subtype _))
-            (linear_map.quot_ker_equiv_range f)) (linear_equiv.of_top _ (range_eq_top_of_epi _)))) $
+        (((submodule.quot_equiv_of_eq _ _ (submodule.range_subtype _)) ≫ₗ
+          (linear_map.quot_ker_equiv_range f)) ≫ₗ
+          (linear_equiv.of_top _ (range_eq_top_of_epi _)))) $
       by { ext, refl } }
 
 /-- The category of R-modules is abelian. -/

--- a/src/algebra/category/Module/monoidal.lean
+++ b/src/algebra/category/Module/monoidal.lean
@@ -69,8 +69,7 @@ private lemma associator_naturality_aux
   [add_comm_monoid Y₁] [add_comm_monoid Y₂] [add_comm_monoid Y₃]
   [module R Y₁] [module R Y₂] [module R Y₃]
   (f₁ : X₁ →ₗ[R] Y₁) (f₂ : X₂ →ₗ[R] Y₂) (f₃ : X₃ →ₗ[R] Y₃) :
-  linear_map.comp ↑(assoc R Y₁ Y₂ Y₃) (map (map f₁ f₂) f₃) =
-    (map f₁ (map f₂ f₃)).comp ↑(assoc R X₁ X₂ X₃) :=
+  (↑(assoc R Y₁ Y₂ Y₃) ∘ₗ (map (map f₁ f₂) f₃)) = ((map f₁ (map f₂ f₃)) ∘ₗ ↑(assoc R X₁ X₂ X₃)) :=
 begin
   apply tensor_product.ext_threefold,
   intros x y z,

--- a/src/algebra/lie/base_change.lean
+++ b/src/algebra/lie/base_change.lean
@@ -41,8 +41,8 @@ support in the tensor product library, it is far easier to bootstrap like this, 
 definition below. -/
 private def bracket' : (A ⊗[R] L) →ₗ[R] (A ⊗[R] L) →ₗ[R] A ⊗[R] L :=
 tensor_product.curry $
-  (tensor_product.map (algebra.lmul' R) (lie_module.to_module_hom R L L : L ⊗[R] L →ₗ[R] L)).comp $
-  tensor_product.tensor_tensor_tensor_comm R A L A L
+  (tensor_product.map (algebra.lmul' R) (lie_module.to_module_hom R L L : L ⊗[R] L →ₗ[R] L))
+  ∘ₗ ↑(tensor_product.tensor_tensor_tensor_comm R A L A L)
 
 @[simp] private lemma bracket'_tmul (s t : A) (x y : L) :
   bracket' R A L (s ⊗ₜ[R] x) (t ⊗ₜ[R] y) = (s*t) ⊗ₜ ⁅x, y⁆ :=

--- a/src/algebra/lie/tensor_product.lean
+++ b/src/algebra/lie/tensor_product.lean
@@ -93,8 +93,8 @@ lift.equiv_apply R M N P f m n
 Note that maps `f` of type `M →ₗ⁅R,L⁆ N →ₗ[R] P` are exactly those `R`-bilinear maps satisfying
 `⁅x, f m n⁆ = f ⁅x, m⁆ n + f m ⁅x, n⁆` for all `x, m, n` (see e.g, `lie_module_hom.map_lie₂`). -/
 def lift_lie : (M →ₗ⁅R,L⁆ N →ₗ[R] P) ≃ₗ[R] (M ⊗[R] N →ₗ⁅R,L⁆ P) :=
-(max_triv_linear_map_equiv_lie_module_hom.symm.trans
-↑(max_triv_equiv (lift R L M N P))).trans
+(max_triv_linear_map_equiv_lie_module_hom.symm ≫ₗ
+↑(max_triv_equiv (lift R L M N P))) ≫ₗ
 max_triv_linear_map_equiv_lie_module_hom
 
 @[simp] lemma coe_lift_lie_eq_lift_coe (f : M →ₗ⁅R,L⁆ N →ₗ[R] P) :

--- a/src/algebra/lie/tensor_product.lean
+++ b/src/algebra/lie/tensor_product.lean
@@ -93,8 +93,8 @@ lift.equiv_apply R M N P f m n
 Note that maps `f` of type `M →ₗ⁅R,L⁆ N →ₗ[R] P` are exactly those `R`-bilinear maps satisfying
 `⁅x, f m n⁆ = f ⁅x, m⁆ n + f m ⁅x, n⁆` for all `x, m, n` (see e.g, `lie_module_hom.map_lie₂`). -/
 def lift_lie : (M →ₗ⁅R,L⁆ N →ₗ[R] P) ≃ₗ[R] (M ⊗[R] N →ₗ⁅R,L⁆ P) :=
-(max_triv_linear_map_equiv_lie_module_hom.symm ≫ₗ
-↑(max_triv_equiv (lift R L M N P))) ≫ₗ
+(max_triv_linear_map_equiv_lie_module_hom.symm ≪≫ₗ
+↑(max_triv_equiv (lift R L M N P))) ≪≫ₗ
 max_triv_linear_map_equiv_lie_module_hom
 
 @[simp] lemma coe_lift_lie_eq_lift_coe (f : M →ₗ⁅R,L⁆ N →ₗ[R] P) :

--- a/src/algebra/lie/weights.lean
+++ b/src/algebra/lie/weights.lean
@@ -110,7 +110,7 @@ begin
   /- Eliminate `g` from the picture. -/
   let f₁ : module.End R (M₁ ⊗[R] M₂) := (to_endomorphism R L M₁ x - (χ₁ x) • 1).rtensor M₂,
   let f₂ : module.End R (M₁ ⊗[R] M₂) := (to_endomorphism R L M₂ x - (χ₂ x) • 1).ltensor M₁,
-  have h_comm_square : F.comp ↑g = (g : M₁ ⊗[R] M₂ →ₗ[R] M₃).comp (f₁ + f₂),
+  have h_comm_square : F ∘ₗ ↑g = (g : M₁ ⊗[R] M₂ →ₗ[R] M₃).comp (f₁ + f₂),
   { ext m₁ m₂, simp only [← g.map_lie x (m₁ ⊗ₜ m₂), add_smul, sub_tmul, tmul_sub, smul_tmul,
       lie_tmul_right, tmul_smul, to_endomorphism_apply_apply, lie_module_hom.map_smul,
       linear_map.one_apply, lie_module_hom.coe_to_linear_map, linear_map.smul_apply,

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -528,7 +528,7 @@ def trans : M ≃ₗ[R] M₃ :=
 { .. e₂.to_linear_map.comp e₁.to_linear_map,
   .. e₁.to_equiv.trans e₂.to_equiv }
 
-infixl ` ≫ₗ `:80 := linear_equiv.trans
+infixl ` ≪≫ₗ `:80 := linear_equiv.trans
 
 @[simp] lemma coe_to_add_equiv : ⇑(e.to_add_equiv) = e := rfl
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -528,7 +528,7 @@ def trans : M ≃ₗ[R] M₃ :=
 { .. e₂.to_linear_map.comp e₁.to_linear_map,
   .. e₁.to_equiv.trans e₂.to_equiv }
 
-infixl ` ≫ₗ `:80 := @linear_equiv.trans
+infixl ` ≫ₗ `:80 := linear_equiv.trans
 
 @[simp] lemma coe_to_add_equiv : ⇑(e.to_add_equiv) = e := rfl
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -224,6 +224,8 @@ variables (f : M₂ →ₗ[R] M₃) (g : M →ₗ[R] M₂)
 def comp : M →ₗ[R] M₃ :=
 { to_fun := f ∘ g, .. f.to_distrib_mul_action_hom.comp g.to_distrib_mul_action_hom }
 
+infixr ` ∘ₗ `:80 := linear_map.comp
+
 lemma comp_apply (x : M) : f.comp g x = f (g x) := rfl
 
 @[simp, norm_cast] lemma coe_comp : (f.comp g : M → M₃) = f ∘ g := rfl
@@ -525,6 +527,8 @@ variables {module_M₃ : module R M₃} (e₁ : M ≃ₗ[R] M₂) (e₂ : M₂ �
 def trans : M ≃ₗ[R] M₃ :=
 { .. e₂.to_linear_map.comp e₁.to_linear_map,
   .. e₁.to_equiv.trans e₂.to_equiv }
+
+infixl ` ≫ₗ `:80 := @linear_equiv.trans
 
 @[simp] lemma coe_to_add_equiv : ⇑(e.to_add_equiv) = e := rfl
 

--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -487,7 +487,7 @@ theorem riesz_extension (s : convex_cone E) (f : linear_pmap ℝ E ℝ)
 begin
   rcases riesz_extension.exists_top s f nonneg dense with ⟨⟨g_dom, g⟩, ⟨hpg, hfg⟩, htop, hgs⟩,
   clear hpg,
-  refine ⟨g.comp (linear_equiv.of_top _ htop).symm, _, _⟩;
+  refine ⟨g ∘ₗ ↑(linear_equiv.of_top _ htop).symm, _, _⟩;
     simp only [comp_apply, linear_equiv.coe_coe, linear_equiv.of_top_symm_apply],
   { exact λ x, (hfg (submodule.coe_mk _ _).symm).symm },
   { exact λ x hx, hgs ⟨x, _⟩ hx }

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -126,7 +126,7 @@ begin
     -- basis decomposition, deduce that all such coefficients are controlled in terms of the norm
     have : ∀i:ι, ∃C, 0 ≤ C ∧ ∀(x:E), ∥ξ.equiv_fun x i∥ ≤ C * ∥x∥,
     { assume i,
-      let f : E →ₗ[𝕜] 𝕜 := (linear_map.proj i).comp ξ.equiv_fun,
+      let f : E →ₗ[𝕜] 𝕜 := (linear_map.proj i) ∘ₗ ↑ξ.equiv_fun,
       let f' : E →L[𝕜] 𝕜 := { cont := H₂ f, ..f },
       exact ⟨∥f'∥, norm_nonneg _, λx, continuous_linear_map.le_op_norm f' x⟩ },
     -- fourth step: combine the bound on each coefficient to get a global bound and the continuity

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -157,8 +157,7 @@ with respect to the basis `b`.
 finite-dimensional spaces it is the `ι`th basis vector of the dual space.
 -/
 @[simps]
-def coord (i : ι) : M →ₗ[R] R :=
-(finsupp.lapply i).comp b.repr
+def coord (i : ι) : M →ₗ[R] R := (finsupp.lapply i) ∘ₗ ↑b.repr
 
 lemma forall_coord_eq_zero_iff {x : M} :
   (∀ i, b.coord i x = 0) ↔ x = 0 :=
@@ -213,8 +212,8 @@ begin
   let f_i : M →ₗ[R] R :=
   { to_fun := λ x, f x i,
     map_add' := λ _ _, by rw [hadd, pi.add_apply],
-    map_smul' := λ _ _, by rw [hsmul, pi.smul_apply] },
-  have : (finsupp.lapply i).comp ↑b.repr = f_i,
+    map_smul' := λ _ _, by { simp [hsmul, pi.smul_apply] } },
+  have : (finsupp.lapply i) ∘ₗ ↑b.repr = f_i,
   { refine b.ext (λ j, _),
     show b.repr (b j) i = f (b j) i,
     rw [b.repr_self, f_eq] },
@@ -403,7 +402,7 @@ you can recover an `add_equiv` by setting `S := ℕ`.
 See library note [bundled maps over different rings].
 -/
 def constr : (ι → M') ≃ₗ[S] (M →ₗ[R] M') :=
-{ to_fun := λ f, (finsupp.total M' M' R id).comp $ (finsupp.lmap_domain R R f).comp b.repr,
+{ to_fun := λ f, (finsupp.total M' M' R id).comp $ (finsupp.lmap_domain R R f) ∘ₗ ↑b.repr,
   inv_fun := λ f i, f (b i),
   left_inv := λ f, by { ext, simp },
   right_inv := λ f, by { refine b.ext (λ i, _), simp },
@@ -411,7 +410,7 @@ def constr : (ι → M') ≃ₗ[S] (M →ₗ[R] M') :=
   map_smul' := λ c f, by { refine b.ext (λ i, _), simp } }
 
 theorem constr_def (f : ι → M') :
-  b.constr S f = (finsupp.total M' M' R id).comp ((finsupp.lmap_domain R R f).comp b.repr) :=
+  b.constr S f = (finsupp.total M' M' R id) ∘ₗ ((finsupp.lmap_domain R R f) ∘ₗ ↑b.repr) :=
 rfl
 
 theorem constr_apply (f : ι → M') (x : M) :

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -433,8 +433,8 @@ begin
     simp only [cardinal.lift_nat_cast, cardinal.nat_cast_inj],
     -- Now we can use invariant basis number to show they have the same cardinality.
     apply card_eq_of_lequiv R,
-    exact (((finsupp.linear_equiv_fun_on_fintype R R ι).symm.trans v.repr.symm).trans
-      v'.repr).trans (finsupp.linear_equiv_fun_on_fintype R R ι'), },
+    exact (((finsupp.linear_equiv_fun_on_fintype R R ι).symm.trans v.repr.symm) ≫ₗ
+      v'.repr) ≫ₗ (finsupp.linear_equiv_fun_on_fintype R R ι'), },
   { -- `v` is an infinite basis,
     -- so by `infinite_basis_le_maximal_linear_independent`, `v'` is at least as big,
     -- and then applying `infinite_basis_le_maximal_linear_independent` again

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -433,8 +433,8 @@ begin
     simp only [cardinal.lift_nat_cast, cardinal.nat_cast_inj],
     -- Now we can use invariant basis number to show they have the same cardinality.
     apply card_eq_of_lequiv R,
-    exact (((finsupp.linear_equiv_fun_on_fintype R R ι).symm.trans v.repr.symm) ≫ₗ
-      v'.repr) ≫ₗ (finsupp.linear_equiv_fun_on_fintype R R ι'), },
+    exact (((finsupp.linear_equiv_fun_on_fintype R R ι).symm.trans v.repr.symm) ≪≫ₗ
+      v'.repr) ≪≫ₗ (finsupp.linear_equiv_fun_on_fintype R R ι'), },
   { -- `v` is an infinite basis,
     -- so by `infinite_basis_le_maximal_linear_independent`, `v'` is at least as big,
     -- and then applying `infinite_basis_le_maximal_linear_independent` again

--- a/src/linear_algebra/direct_sum/finsupp.lean
+++ b/src/linear_algebra/direct_sum/finsupp.lean
@@ -56,11 +56,9 @@ open_locale tensor_product classical
 def finsupp_tensor_finsupp (R M N ι κ : Sort*) [comm_ring R]
   [add_comm_group M] [module R M] [add_comm_group N] [module R N] :
   (ι →₀ M) ⊗[R] (κ →₀ N) ≃ₗ[R] (ι × κ) →₀ (M ⊗[R] N) :=
-linear_equiv.trans
-  (tensor_product.congr (finsupp_lequiv_direct_sum R M ι) (finsupp_lequiv_direct_sum R N κ)) $
-linear_equiv.trans
-  (tensor_product.direct_sum R ι κ (λ _, M) (λ _, N))
-  (finsupp_lequiv_direct_sum R (M ⊗[R] N) (ι × κ)).symm
+(tensor_product.congr (finsupp_lequiv_direct_sum R M ι) (finsupp_lequiv_direct_sum R N κ))
+  ≫ₗ ((tensor_product.direct_sum R ι κ (λ _, M) (λ _, N))
+  ≫ₗ (finsupp_lequiv_direct_sum R (M ⊗[R] N) (ι × κ)).symm)
 
 @[simp] theorem finsupp_tensor_finsupp_single (R M N ι κ : Sort*) [comm_ring R]
   [add_comm_group M] [module R M] [add_comm_group N] [module R N]

--- a/src/linear_algebra/direct_sum/finsupp.lean
+++ b/src/linear_algebra/direct_sum/finsupp.lean
@@ -57,8 +57,8 @@ def finsupp_tensor_finsupp (R M N ι κ : Sort*) [comm_ring R]
   [add_comm_group M] [module R M] [add_comm_group N] [module R N] :
   (ι →₀ M) ⊗[R] (κ →₀ N) ≃ₗ[R] (ι × κ) →₀ (M ⊗[R] N) :=
 (tensor_product.congr (finsupp_lequiv_direct_sum R M ι) (finsupp_lequiv_direct_sum R N κ))
-  ≫ₗ ((tensor_product.direct_sum R ι κ (λ _, M) (λ _, N))
-  ≫ₗ (finsupp_lequiv_direct_sum R (M ⊗[R] N) (ι × κ)).symm)
+  ≪≫ₗ ((tensor_product.direct_sum R ι κ (λ _, M) (λ _, N))
+  ≪≫ₗ (finsupp_lequiv_direct_sum R (M ⊗[R] N) (ι × κ)).symm)
 
 @[simp] theorem finsupp_tensor_finsupp_single (R M N ι κ : Sort*) [comm_ring R]
   [add_comm_group M] [module R M] [add_comm_group N] [module R N]

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -552,7 +552,7 @@ linear_equiv.quot_equiv_of_quot_equiv $
 noncomputable def quot_equiv_annihilator (W : subspace K V) :
   W.quotient ≃ₗ[K] W.dual_annihilator :=
 begin
-  refine _ ≫ₗ W.quot_dual_equiv_annihilator,
+  refine _ ≪≫ₗ W.quot_dual_equiv_annihilator,
   refine linear_equiv.quot_equiv_of_equiv _ (basis.of_vector_space K V).to_dual_equiv,
   exact (basis.of_vector_space K W).to_dual_equiv.trans W.dual_equiv_dual
 end

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -552,7 +552,7 @@ linear_equiv.quot_equiv_of_quot_equiv $
 noncomputable def quot_equiv_annihilator (W : subspace K V) :
   W.quotient ≃ₗ[K] W.dual_annihilator :=
 begin
-  refine linear_equiv.trans _ W.quot_dual_equiv_annihilator,
+  refine _ ≫ₗ W.quot_dual_equiv_annihilator,
   refine linear_equiv.quot_equiv_of_equiv _ (basis.of_vector_space K V).to_dual_equiv,
   exact (basis.of_vector_space K W).to_dual_equiv.trans W.dual_equiv_dual
 end

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -635,8 +635,8 @@ noncomputable def congr {α' : Type*} (s : set α) (t : set α') (e : s ≃ t) :
 begin
   haveI := classical.dec_pred (λ x, x ∈ s),
   haveI := classical.dec_pred (λ x, x ∈ t),
-  refine (finsupp.supported_equiv_finsupp s) ≫ₗ
-      (_ ≫ₗ (finsupp.supported_equiv_finsupp t).symm),
+  refine (finsupp.supported_equiv_finsupp s) ≪≫ₗ
+      (_ ≪≫ₗ (finsupp.supported_equiv_finsupp t).symm),
   exact finsupp.dom_lcongr e
 end
 

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -635,8 +635,8 @@ noncomputable def congr {α' : Type*} (s : set α) (t : set α') (e : s ≃ t) :
 begin
   haveI := classical.dec_pred (λ x, x ∈ s),
   haveI := classical.dec_pred (λ x, x ∈ t),
-  refine linear_equiv.trans (finsupp.supported_equiv_finsupp s)
-      (linear_equiv.trans _ (finsupp.supported_equiv_finsupp t).symm),
+  refine (finsupp.supported_equiv_finsupp s) ≫ₗ
+      (_ ≫ₗ (finsupp.supported_equiv_finsupp t).symm),
   exact finsupp.dom_lcongr e
 end
 

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -126,8 +126,8 @@ variables [comm_ring R] [add_comm_group M] [module R M] [add_comm_group N] [modu
 def basis.tensor_product (b : basis ι R M) (c : basis κ R N) :
   basis (ι × κ) R (tensor_product R M N) :=
 finsupp.basis_single_one.map
-  ((tensor_product.congr b.repr c.repr) ≫ₗ
-    (finsupp_tensor_finsupp _ _ _ _ _) ≫ₗ
+  ((tensor_product.congr b.repr c.repr) ≪≫ₗ
+    (finsupp_tensor_finsupp _ _ _ _ _) ≪≫ₗ
     (lcongr (equiv.refl _)) (tensor_product.lid R R)).symm
 
 end comm_ring
@@ -177,7 +177,7 @@ begin
   rw [←cardinal.lift_inj.1 m.mk_eq_dim, ←cardinal.lift_inj.1 m'.mk_eq_dim] at h,
   rcases quotient.exact h with ⟨e⟩,
   let e := (equiv.ulift.symm.trans e).trans equiv.ulift,
-  exact ⟨(m.repr ≫ₗ (finsupp.dom_lcongr e)) ≫ₗ m'.repr.symm⟩
+  exact ⟨(m.repr ≪≫ₗ (finsupp.dom_lcongr e)) ≪≫ₗ m'.repr.symm⟩
 end
 
 /-- Two `K`-vector spaces are equivalent if their dimension is the same. -/

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -126,9 +126,9 @@ variables [comm_ring R] [add_comm_group M] [module R M] [add_comm_group N] [modu
 def basis.tensor_product (b : basis ι R M) (c : basis κ R N) :
   basis (ι × κ) R (tensor_product R M N) :=
 finsupp.basis_single_one.map
-  ((tensor_product.congr b.repr c.repr).trans $
-    (finsupp_tensor_finsupp _ _ _ _ _).trans $
-    lcongr (equiv.refl _) (tensor_product.lid R R)).symm
+  ((tensor_product.congr b.repr c.repr) ≫ₗ
+    (finsupp_tensor_finsupp _ _ _ _ _) ≫ₗ
+    (lcongr (equiv.refl _)) (tensor_product.lid R R)).symm
 
 end comm_ring
 
@@ -177,7 +177,7 @@ begin
   rw [←cardinal.lift_inj.1 m.mk_eq_dim, ←cardinal.lift_inj.1 m'.mk_eq_dim] at h,
   rcases quotient.exact h with ⟨e⟩,
   let e := (equiv.ulift.symm.trans e).trans equiv.ulift,
-  exact ⟨(m.repr.trans (finsupp.dom_lcongr e)).trans m'.repr.symm⟩
+  exact ⟨(m.repr ≫ₗ (finsupp.dom_lcongr e)) ≫ₗ m'.repr.symm⟩
 end
 
 /-- Two `K`-vector spaces are equivalent if their dimension is the same. -/

--- a/src/linear_algebra/free_module_pid.lean
+++ b/src/linear_algebra/free_module_pid.lean
@@ -85,7 +85,7 @@ begin
   refine b.ext_elem (λ i, _),
   rw (eq_bot_iff_generator_eq_zero _).mpr hgen at hϕ,
   rw [linear_equiv.map_zero, finsupp.zero_apply],
-  exact (submodule.eq_bot_iff _).mp (hϕ ((finsupp.lapply i).comp b.repr) bot_le) _ ⟨x, hx, rfl⟩
+  exact (submodule.eq_bot_iff _).mp (hϕ ((finsupp.lapply i) ∘ₗ ↑b.repr) bot_le) _ ⟨x, hx, rfl⟩
 end
 
 /-- `(ϕ : O →ₗ M').submodule_image N` is `ϕ(N)` as a submodule of `M'` -/
@@ -132,7 +132,7 @@ begin
   refine congr_arg coe (show (⟨x, hNO hx⟩ : O) = 0, from b.ext_elem (λ i, _)),
   rw (eq_bot_iff_generator_eq_zero _).mpr hgen at hϕ,
   rw [linear_equiv.map_zero, finsupp.zero_apply],
-  refine (submodule.eq_bot_iff _).mp (hϕ ((finsupp.lapply i).comp b.repr) bot_le) _ _,
+  refine (submodule.eq_bot_iff _).mp (hϕ ((finsupp.lapply i) ∘ₗ ↑b.repr) bot_le) _ _,
   exact (linear_map.mem_submodule_image_of_le hNO).mpr ⟨x, hx, rfl⟩
 end
 

--- a/src/linear_algebra/invariant_basis_number.lean
+++ b/src/linear_algebra/invariant_basis_number.lean
@@ -155,7 +155,7 @@ invariant_basis_number.eq_of_fin_equiv
 
 lemma card_eq_of_lequiv {α β : Type*} [fintype α] [fintype β]
   (f : (α → R) ≃ₗ[R] (β → R)) : fintype.card α = fintype.card β :=
-eq_of_fin_equiv R (((linear_equiv.fun_congr_left R R (fintype.equiv_fin α)).trans f) ≫ₗ
+eq_of_fin_equiv R (((linear_equiv.fun_congr_left R R (fintype.equiv_fin α)).trans f) ≪≫ₗ
   ((linear_equiv.fun_congr_left R R (fintype.equiv_fin β)).symm))
 
 lemma nontrivial_of_invariant_basis_number : nontrivial R :=
@@ -258,6 +258,6 @@ instance invariant_basis_number_of_nontrivial_of_comm_ring {R : Type u} [comm_ri
   [nontrivial R] : invariant_basis_number R :=
 ⟨λ n m e, let ⟨I, hI⟩ := ideal.exists_maximal R in
   by exactI eq_of_fin_equiv I.quotient
-    ((ideal.pi_quot_equiv _ _).symm ≫ₗ ((induced_equiv _ e) ≫ₗ (ideal.pi_quot_equiv _ _)))⟩
+    ((ideal.pi_quot_equiv _ _).symm ≪≫ₗ ((induced_equiv _ e) ≪≫ₗ (ideal.pi_quot_equiv _ _)))⟩
 
 end

--- a/src/linear_algebra/invariant_basis_number.lean
+++ b/src/linear_algebra/invariant_basis_number.lean
@@ -155,7 +155,7 @@ invariant_basis_number.eq_of_fin_equiv
 
 lemma card_eq_of_lequiv {α β : Type*} [fintype α] [fintype β]
   (f : (α → R) ≃ₗ[R] (β → R)) : fintype.card α = fintype.card β :=
-eq_of_fin_equiv R (((linear_equiv.fun_congr_left R R (fintype.equiv_fin α)).trans f).trans
+eq_of_fin_equiv R (((linear_equiv.fun_congr_left R R (fintype.equiv_fin α)).trans f) ≫ₗ
   ((linear_equiv.fun_congr_left R R (fintype.equiv_fin β)).symm))
 
 lemma nontrivial_of_invariant_basis_number : nontrivial R :=
@@ -258,6 +258,6 @@ instance invariant_basis_number_of_nontrivial_of_comm_ring {R : Type u} [comm_ri
   [nontrivial R] : invariant_basis_number R :=
 ⟨λ n m e, let ⟨I, hI⟩ := ideal.exists_maximal R in
   by exactI eq_of_fin_equiv I.quotient
-    ((ideal.pi_quot_equiv _ _).symm.trans ((induced_equiv _ e).trans (ideal.pi_quot_equiv _ _)))⟩
+    ((ideal.pi_quot_equiv _ _).symm ≫ₗ ((induced_equiv _ e) ≫ₗ (ideal.pi_quot_equiv _ _)))⟩
 
 end

--- a/src/linear_algebra/pi_tensor_product.lean
+++ b/src/linear_algebra/pi_tensor_product.lean
@@ -376,12 +376,12 @@ For simplicity, this is defined only for homogeneously- (rather than dependently
 -/
 def reindex (e : ι ≃ ι₂) : ⨂[R] i : ι, M ≃ₗ[R] ⨂[R] i : ι₂, M :=
 linear_equiv.of_linear
-  ((lift.symm.trans $
-    multilinear_map.dom_dom_congr_linear_equiv M (⨂[R] i : ι₂, M) R R e.symm).trans
-      lift (linear_map.id))
-  ((lift.symm.trans $
-    multilinear_map.dom_dom_congr_linear_equiv M (⨂[R] i : ι, M) R R e).trans
-      lift (linear_map.id))
+  (((lift.symm ≫ₗ
+    (multilinear_map.dom_dom_congr_linear_equiv M (⨂[R] i : ι₂, M) R R e.symm)) ≫ₗ
+      lift) (linear_map.id))
+  (((lift.symm ≫ₗ
+    (multilinear_map.dom_dom_congr_linear_equiv M (⨂[R] i : ι, M) R R e)) ≫ₗ
+      lift) (linear_map.id))
   (by { ext, simp })
   (by { ext, simp })
 
@@ -397,7 +397,7 @@ lift.tprod f
 multilinear_map.ext $ reindex_tprod e
 
 @[simp] lemma lift_comp_reindex (e : ι ≃ ι₂) (φ : multilinear_map R (λ _ : ι₂, M) E) :
-  (lift φ).comp ↑(reindex R M e) = lift (φ.dom_dom_congr e.symm) :=
+  (lift φ) ∘ₗ ↑(reindex R M e) = lift (φ.dom_dom_congr e.symm) :=
 by { ext, simp, }
 
 @[simp]

--- a/src/linear_algebra/pi_tensor_product.lean
+++ b/src/linear_algebra/pi_tensor_product.lean
@@ -376,11 +376,11 @@ For simplicity, this is defined only for homogeneously- (rather than dependently
 -/
 def reindex (e : ι ≃ ι₂) : ⨂[R] i : ι, M ≃ₗ[R] ⨂[R] i : ι₂, M :=
 linear_equiv.of_linear
-  (((lift.symm ≫ₗ
-    (multilinear_map.dom_dom_congr_linear_equiv M (⨂[R] i : ι₂, M) R R e.symm)) ≫ₗ
+  (((lift.symm ≪≫ₗ
+    (multilinear_map.dom_dom_congr_linear_equiv M (⨂[R] i : ι₂, M) R R e.symm)) ≪≫ₗ
       lift) (linear_map.id))
-  (((lift.symm ≫ₗ
-    (multilinear_map.dom_dom_congr_linear_equiv M (⨂[R] i : ι, M) R R e)) ≫ₗ
+  (((lift.symm ≪≫ₗ
+    (multilinear_map.dom_dom_congr_linear_equiv M (⨂[R] i : ι, M) R R e)) ≪≫ₗ
       lift) (linear_map.id))
   (by { ext, simp })
   (by { ext, simp })

--- a/src/linear_algebra/projection.lean
+++ b/src/linear_algebra/projection.lean
@@ -131,7 +131,7 @@ end
 /-- Projection to a submodule along its complement. -/
 def linear_proj_of_is_compl (h : is_compl p q) :
   E →ₗ[R] p :=
-(linear_map.fst R p q).comp $ (prod_equiv_of_is_compl p q h).symm
+(linear_map.fst R p q) ∘ₗ ↑(prod_equiv_of_is_compl p q h).symm
 
 variables {p q}
 
@@ -188,7 +188,7 @@ open submodule
 the induced linear map over the entire module. -/
 def of_is_compl {p q : submodule R E} (h : is_compl p q)
   (φ : p →ₗ[R] F) (ψ : q →ₗ[R] F) : E →ₗ[R] F :=
-(linear_map.coprod φ ψ).comp (submodule.prod_equiv_of_is_compl _ _ h).symm
+(linear_map.coprod φ ψ) ∘ₗ ↑(submodule.prod_equiv_of_is_compl _ _ h).symm
 
 variables {p q}
 

--- a/src/linear_algebra/std_basis.lean
+++ b/src/linear_algebra/std_basis.lean
@@ -200,7 +200,7 @@ protected noncomputable def basis (s : ∀ j, basis (ιs j) R (Ms j)) :
   basis (Σ j, ιs j) R (Π j, Ms j) :=
 -- The `add_comm_monoid (Π j, Ms j)` instance was hard to find.
 -- Defining this in tactic mode seems to shake up instance search enough that it works by itself.
-by { refine basis.of_repr (linear_equiv.trans _ (finsupp.sigma_finsupp_lequiv_pi_finsupp R).symm),
+by { refine basis.of_repr (_ ≫ₗ (finsupp.sigma_finsupp_lequiv_pi_finsupp R).symm),
      exact linear_equiv.Pi_congr_right (λ j, (s j).repr) }
 
 @[simp] lemma basis_repr_std_basis [decidable_eq η] (s : ∀ j, basis (ιs j) R (Ms j)) (j i) :

--- a/src/linear_algebra/std_basis.lean
+++ b/src/linear_algebra/std_basis.lean
@@ -200,7 +200,7 @@ protected noncomputable def basis (s : ∀ j, basis (ιs j) R (Ms j)) :
   basis (Σ j, ιs j) R (Π j, Ms j) :=
 -- The `add_comm_monoid (Π j, Ms j)` instance was hard to find.
 -- Defining this in tactic mode seems to shake up instance search enough that it works by itself.
-by { refine basis.of_repr (_ ≫ₗ (finsupp.sigma_finsupp_lequiv_pi_finsupp R).symm),
+by { refine basis.of_repr (_ ≪≫ₗ (finsupp.sigma_finsupp_lequiv_pi_finsupp R).symm),
      exact linear_equiv.Pi_congr_right (λ j, (s j).repr) }
 
 @[simp] lemma basis_repr_std_basis [decidable_eq η] (s : ∀ j, basis (ιs j) R (Ms j)) (j i) :

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -850,7 +850,7 @@ def left_comm : M ⊗[R] (N ⊗[R] P) ≃ₗ[R] N ⊗[R] (M ⊗[R] P) :=
 let e₁ := (tensor_product.assoc R M N P).symm,
     e₂ := congr (tensor_product.comm R M N) (1 : P ≃ₗ[R] P),
     e₃ := (tensor_product.assoc R N M P) in
-e₁ ≫ₗ (e₂ ≫ₗ e₃)
+e₁ ≪≫ₗ (e₂ ≪≫ₗ e₃)
 
 variables {M N P Q}
 

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -878,7 +878,7 @@ def tensor_tensor_tensor_comm : (M ⊗[R] N) ⊗[R] (P ⊗[R] Q) ≃ₗ[R] (M �
 let e₁ := tensor_product.assoc R M N (P ⊗[R] Q),
     e₂ := congr (1 : M ≃ₗ[R] M) (left_comm R N P Q),
     e₃ := (tensor_product.assoc R M P (N ⊗[R] Q)).symm in
-e₁ ≫ₗ (e₂ ≫ₗ e₃)
+e₁ ≪≫ₗ (e₂ ≪≫ₗ e₃)
 
 variables {M N P Q}
 

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -850,7 +850,7 @@ def left_comm : M ⊗[R] (N ⊗[R] P) ≃ₗ[R] N ⊗[R] (M ⊗[R] P) :=
 let e₁ := (tensor_product.assoc R M N P).symm,
     e₂ := congr (tensor_product.comm R M N) (1 : P ≃ₗ[R] P),
     e₃ := (tensor_product.assoc R N M P) in
-e₁.trans $ e₂.trans e₃
+e₁ ≫ₗ (e₂ ≫ₗ e₃)
 
 variables {M N P Q}
 
@@ -878,7 +878,7 @@ def tensor_tensor_tensor_comm : (M ⊗[R] N) ⊗[R] (P ⊗[R] Q) ≃ₗ[R] (M �
 let e₁ := tensor_product.assoc R M N (P ⊗[R] Q),
     e₂ := congr (1 : M ≃ₗ[R] M) (left_comm R N P Q),
     e₃ := (tensor_product.assoc R M P (N ⊗[R] Q)).symm in
-e₁.trans $ e₂.trans e₃
+e₁ ≫ₗ (e₂ ≫ₗ e₃)
 
 variables {M N P Q}
 

--- a/src/linear_algebra/trace.lean
+++ b/src/linear_algebra/trace.lean
@@ -37,7 +37,7 @@ variables (b : basis ι R M) (c : basis κ R M)
 /-- The trace of an endomorphism given a basis. -/
 def trace_aux :
   (M →ₗ[R] M) →ₗ[R] R :=
-(matrix.trace ι R R).comp $ linear_map.to_matrix b b
+(matrix.trace ι R R) ∘ₗ ↑(linear_map.to_matrix b b)
 
 -- Can't be `simp` because it would cause a loop.
 lemma trace_aux_def (b : basis ι R M) (f : M →ₗ[R] M) :

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -150,10 +150,10 @@ end
 where the `(i, j)`th basis vector is `b i • c j`. -/
 noncomputable def basis.smul {ι : Type v₁} {ι' : Type w₁}
   (b : basis ι R S) (c : basis ι' S A) : basis (ι × ι') R A :=
-basis.of_repr ((c.repr.restrict_scalars R).trans $
-  (finsupp.lcongr (equiv.refl _) b.repr).trans $
-  (finsupp_prod_lequiv R).symm.trans $
-  (finsupp.lcongr (equiv.prod_comm ι' ι) (linear_equiv.refl _ _)))
+basis.of_repr ((c.repr.restrict_scalars R) ≫ₗ
+  ((finsupp.lcongr (equiv.refl _) b.repr) ≫ₗ
+  ((finsupp_prod_lequiv R).symm ≫ₗ
+  ((finsupp.lcongr (equiv.prod_comm ι' ι) (linear_equiv.refl _ _))))))
 
 @[simp] theorem basis.smul_repr {ι : Type v₁} {ι' : Type w₁}
   (b : basis ι R S) (c : basis ι' S A) (x ij):

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -150,9 +150,9 @@ end
 where the `(i, j)`th basis vector is `b i • c j`. -/
 noncomputable def basis.smul {ι : Type v₁} {ι' : Type w₁}
   (b : basis ι R S) (c : basis ι' S A) : basis (ι × ι') R A :=
-basis.of_repr ((c.repr.restrict_scalars R) ≫ₗ
-  ((finsupp.lcongr (equiv.refl _) b.repr) ≫ₗ
-  ((finsupp_prod_lequiv R).symm ≫ₗ
+basis.of_repr ((c.repr.restrict_scalars R) ≪≫ₗ
+  ((finsupp.lcongr (equiv.refl _) b.repr) ≪≫ₗ
+  ((finsupp_prod_lequiv R).symm ≪≫ₗ
   ((finsupp.lcongr (equiv.prod_comm ι' ι) (linear_equiv.refl _ _))))))
 
 @[simp] theorem basis.smul_repr {ι : Type v₁} {ι' : Type w₁}

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -570,7 +570,7 @@ begin
     (f.tailings_disjoint_tailing i),
   specialize w n (le_refl n),
   apply nonempty.intro,
-  refine (f.tailing_linear_equiv i n).symm ≫ₗ _,
+  refine (f.tailing_linear_equiv i n).symm ≪≫ₗ _,
   rw w,
   exact submodule.bot_equiv_punit,
 end

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -570,7 +570,7 @@ begin
     (f.tailings_disjoint_tailing i),
   specialize w n (le_refl n),
   apply nonempty.intro,
-  refine (f.tailing_linear_equiv i n).symm.trans _,
+  refine (f.tailing_linear_equiv i n).symm ≫ₗ _,
   rw w,
   exact submodule.bot_equiv_punit,
 end

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -381,9 +381,9 @@ end add
 
 /-- Composition of bounded linear maps. -/
 def comp (g : M₂ →L[R] M₃) (f : M →L[R] M₂) : M →L[R] M₃ :=
-⟨(g : M₂ →ₗ[R] M₃).comp f, g.2.comp f.2⟩
+⟨(g : M₂ →ₗ[R] M₃) ∘ₗ ↑f, g.2.comp f.2⟩
 
-@[simp, norm_cast] lemma coe_comp : ((h.comp f) : (M →ₗ[R] M₃)) = (h : M₂ →ₗ[R] M₃).comp f := rfl
+@[simp, norm_cast] lemma coe_comp : ((h.comp f) : (M →ₗ[R] M₃)) = (h : M₂ →ₗ[R] M₃) ∘ₗ ↑f := rfl
 @[simp, norm_cast] lemma coe_comp' : ((h.comp f) : (M → M₃)) = (h : M₂ → M₃) ∘ f := rfl
 
 @[simp] theorem comp_id : f.comp (id R M) = f :=


### PR DESCRIPTION
This PR introduces new notation for the composition of linear maps and linear equivalences: `∘ₗ` denotes `linear_map.comp` and `≫ₗ` denotes `linear_equiv.trans`. This will be needed by an upcoming PR generalizing linear maps to semilinear maps (see discussion [here](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Semilinear.20maps)): in some places, we need to help the elaborator a bit by telling it that we are composing plain linear maps/equivs as opposed to semilinear ones. We have not made the change systematically throughout the library, only in places where it is needed in our semilinear maps branch.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
