### PR TITLE
[Merged by Bors] - doc(data/list/*): Add missing documentation

### DIFF
--- a/src/data/list/alist.lean
+++ b/src/data/list/alist.lean
@@ -8,7 +8,7 @@ import data.list.sigma
 /-!
 # Association Lists
 
-This file makes use of the contents of the `list.sigma` file to define association lists. These
+This file makes use of the contents of the `data.list.sigma` file to define association lists. These
 association lists are represented by the `alist` structure, which comprises a list of sigmas as a
 key-value store, as well as a proof that this has no duplicate keys.
 

--- a/src/data/list/alist.lean
+++ b/src/data/list/alist.lean
@@ -6,7 +6,13 @@ Authors: Sean Leather, Mario Carneiro
 import data.list.sigma
 
 /-!
-# Association lists
+# Association Lists
+
+This file makes use of the contents of the `list.sigma` file to define association lists. These
+association lists are represented by the `alist` structure, which comprises a list of sigmas as a
+key-value store, as well as a proof that this has no duplicate keys.
+
+The file provides ways to access, modify, and combine `alist`s.
 -/
 
 universes u v w

--- a/src/data/list/func.lean
+++ b/src/data/list/func.lean
@@ -58,22 +58,25 @@ localized "notation as ` {` m ` ↦ ` a `}` := list.func.set a as m" in list.fun
 | 0 (a::as)     := a
 | (n+1) (a::as) := get n as
 
-/-- Pointwise equality of lists -/
+/--
+Pointwise equality of lists. If lists are different lengths, compare with the default
+element.
+-/
 def equiv (as1 as2 : list α) : Prop :=
 ∀ (m : nat), get m as1 = get m as2
 
-/-- Pointwise operations on lists -/
+/-- Pointwise operations on lists. If lists are different lengths, use the default element. -/
 @[simp] def pointwise (f : α → β → γ) : list α → list β → list γ
 | []      []      := []
 | []      (b::bs) := map (f $ default α) (b::bs)
 | (a::as) []      := map (λ x, f x $ default β) (a::as)
 | (a::as) (b::bs) := (f a b)::(pointwise as bs)
 
-/-- Pointwise addition on lists -/
+/-- Pointwise addition on lists. If lists are different lengths, use zero. -/
 def add {α : Type u} [has_zero α] [has_add α] : list α → list α → list α :=
 @pointwise α α α ⟨0⟩ ⟨0⟩ (+)
 
-/-- Pointwise subtraction on lists -/
+/-- Pointwise subtraction on lists. If lists are different lengths, use zero. -/
 def sub {α : Type u} [has_zero α] [has_sub α] : list α → list α → list α :=
 @pointwise α α α ⟨0⟩ ⟨0⟩ (@has_sub.sub α _)
 

--- a/src/data/list/func.lean
+++ b/src/data/list/func.lean
@@ -8,7 +8,18 @@ import data.nat.basic
 /-!
 # Lists as Functions
 
-Definitions for using lists as finite representations of functions with domain ℕ.
+Definitions for using lists as finite representations of finitely-supported functions with domain
+ℕ.
+
+These include pointwise operations on lists, as well as get and set operations.
+
+## Notations
+
+An index notation is introduced in this file for setting a particular element of a list. With `as`
+as a list `m` as an index, and `a` as a new element, the notation is `as {m ↦ a}`.
+
+So, for example
+`[1, 3, 5] {1 ↦ 9}` would result in `[1, 9, 5]`
 -/
 
 open list
@@ -27,7 +38,10 @@ def neg [has_neg α] (as : list α) := as.map (λ a, -a)
 
 variables [inhabited α] [inhabited β]
 
-/-- Update element of a list by index -/
+/--
+Update element of a list by index. If the index is out of range, extend the list with default
+elements
+-/
 @[simp] def set (a : α) : list α → ℕ → list α
 | (_::as) 0     := a::as
 | []      0     := [a]
@@ -36,7 +50,7 @@ variables [inhabited α] [inhabited β]
 
 localized "notation as ` {` m ` ↦ ` a `}` := list.func.set a as m" in list.func
 
-/-- Get element of a list by index -/
+/-- Get element of a list by index. If the index is out of range, return the default element -/
 @[simp] def get : ℕ → list α → α
 | _ []          := default α
 | 0 (a::as)     := a

--- a/src/data/list/func.lean
+++ b/src/data/list/func.lean
@@ -5,6 +5,12 @@ Authors: Seul Baek
 -/
 import data.nat.basic
 
+/-!
+# Lists as Functions
+
+Definitions for using lists as finite representations of functions with domain ℕ.
+-/
+
 open list
 
 universes u v w
@@ -16,12 +22,12 @@ namespace func
 variables {a : α}
 variables {as as1 as2 as3 : list α}
 
-/- Definitions for using lists as finite
-   representations of functions with domain ℕ. -/
+/-- Elementwise negation of a list -/
 def neg [has_neg α] (as : list α) := as.map (λ a, -a)
 
 variables [inhabited α] [inhabited β]
 
+/-- Update element of a list by index -/
 @[simp] def set (a : α) : list α → ℕ → list α
 | (_::as) 0     := a::as
 | []      0     := [a]
@@ -30,23 +36,28 @@ variables [inhabited α] [inhabited β]
 
 localized "notation as ` {` m ` ↦ ` a `}` := list.func.set a as m" in list.func
 
+/-- Get element of a list by index -/
 @[simp] def get : ℕ → list α → α
 | _ []          := default α
 | 0 (a::as)     := a
 | (n+1) (a::as) := get n as
 
+/-- Pointwise equality of lists -/
 def equiv (as1 as2 : list α) : Prop :=
 ∀ (m : nat), get m as1 = get m as2
 
+/-- Pointwise operations on lists -/
 @[simp] def pointwise (f : α → β → γ) : list α → list β → list γ
 | []      []      := []
 | []      (b::bs) := map (f $ default α) (b::bs)
 | (a::as) []      := map (λ x, f x $ default β) (a::as)
 | (a::as) (b::bs) := (f a b)::(pointwise as bs)
 
+/-- Pointwise addition on lists -/
 def add {α : Type u} [has_zero α] [has_add α] : list α → list α → list α :=
 @pointwise α α α ⟨0⟩ ⟨0⟩ (+)
 
+/-- Pointwise subtraction on lists -/
 def sub {α : Type u} [has_zero α] [has_sub α] : list α → list α → list α :=
 @pointwise α α α ⟨0⟩ ⟨0⟩ (@has_sub.sub α _)
 

--- a/src/data/list/func.lean
+++ b/src/data/list/func.lean
@@ -20,6 +20,8 @@ as a list `m` as an index, and `a` as a new element, the notation is `as {m ↦ 
 
 So, for example
 `[1, 3, 5] {1 ↦ 9}` would result in `[1, 9, 5]`
+
+This notation is in the locale `list.func`.
 -/
 
 open list

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -16,7 +16,7 @@ of length n.
 
 The main definitions pertain to lists generated using `of_fn`
 
-- `length_of_fn`, which tells us the length of such a list
+- `list.length_of_fn`, which tells us the length of such a list
 - `nth_of_fn`, which tells us the nth element of such a list
 - `array_eq_of_fn`, which interprets the list form of an array as such a list.
 -/

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -11,6 +11,14 @@ import data.fin
 
 Theorems and lemmas for dealing with `list.of_fn`, which converts a function on `fin n` to a list
 of length n.
+
+## Main Definitions
+
+The main definitions pertain to lists generated using `of_fn`
+
+- `length_of_fn`, which tells us the length of such a list
+- `nth_of_fn`, which tells us the nth element of such a list
+- `array_eq_of_fn`, which interprets the list form of an array as such a list.
 -/
 
 universes u

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -17,8 +17,8 @@ of length n.
 The main definitions pertain to lists generated using `of_fn`
 
 - `list.length_of_fn`, which tells us the length of such a list
-- `nth_of_fn`, which tells us the nth element of such a list
-- `array_eq_of_fn`, which interprets the list form of an array as such a list.
+- `list.nth_of_fn`, which tells us the nth element of such a list
+- `list.array_eq_of_fn`, which interprets the list form of an array as such a list.
 -/
 
 universes u

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -6,6 +6,12 @@ Authors: Mario Carneiro
 import data.list.basic
 import data.fin
 
+/-!
+# Lists from functions
+
+Theorems and lemmas for dealing with `list.of_fn`, which converts a function on `fin n` to a list of length n.
+-/
+
 universes u
 
 variables {α : Type u}
@@ -13,17 +19,16 @@ variables {α : Type u}
 open nat
 namespace list
 
-/- of_fn -/
-
-theorem length_of_fn_aux {n} (f : fin n → α) :
+lemma length_of_fn_aux {n} (f : fin n → α) :
   ∀ m h l, length (of_fn_aux f m h l) = length l + m
 | 0        h l := rfl
 | (succ m) h l := (length_of_fn_aux m _ _).trans (succ_add _ _)
 
+/-- The length of a list converted from a function is the size of the domain. -/
 @[simp] theorem length_of_fn {n} (f : fin n → α) : length (of_fn f) = n :=
 (length_of_fn_aux f _ _ _).trans (zero_add _)
 
-theorem nth_of_fn_aux {n} (f : fin n → α) (i) :
+lemma nth_of_fn_aux {n} (f : fin n → α) (i) :
   ∀ m h l,
     (∀ i, nth l i = of_fn_nth_val f (i + m)) →
      nth (of_fn_aux f m h l) i = of_fn_nth_val f i
@@ -34,6 +39,7 @@ theorem nth_of_fn_aux {n} (f : fin n → α) (i) :
   { simp only [nth, H, add_succ, succ_add] }
 end
 
+/-- The `n`th element of a list -/
 @[simp] theorem nth_of_fn {n} (f : fin n → α) (i) :
   nth (of_fn f) i = of_fn_nth_val f i :=
 nth_of_fn_aux f _ _ _ _ $ λ i,
@@ -52,6 +58,7 @@ nth_le_of_fn f ⟨i, ((length_of_fn f) ▸ h)⟩
   map g (of_fn f) = of_fn (g ∘ f) :=
 ext_le (by simp) (λ i h h', by simp)
 
+/-- Arrays converted to lists are the same as `of_fn` on the indexing function of the array. -/
 theorem array_eq_of_fn {n} (a : array n α) : a.to_list = of_fn a.read :=
 suffices ∀ {m h l}, d_array.rev_iterate_aux a
   (λ i, cons) m h l = of_fn_aux (d_array.read a) m h l, from this,
@@ -60,6 +67,7 @@ begin
   simp only [d_array.rev_iterate_aux, of_fn_aux, IH]
 end
 
+/-- `of_fn` on an empty domain is the empty list. -/
 @[simp] theorem of_fn_zero (f : fin 0 → α) : of_fn f = [] := rfl
 
 @[simp] theorem of_fn_succ {n} (f : fin (succ n) → α) :

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -9,7 +9,8 @@ import data.fin
 /-!
 # Lists from functions
 
-Theorems and lemmas for dealing with `list.of_fn`, which converts a function on `fin n` to a list of length n.
+Theorems and lemmas for dealing with `list.of_fn`, which converts a function on `fin n` to a list
+of length n.
 -/
 
 universes u

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -9,7 +9,14 @@ import data.list.zip
 import logic.relation
 
 /-!
-# List permutations
+# List Permutations
+
+This file introduces the `list.perm` relation, which is true if two lists are permutations of one
+another.
+
+## Notation
+
+The notation `~` is used for permutation equivalence.
 -/
 
 open_locale nat

--- a/src/data/list/sigma.lean
+++ b/src/data/list/sigma.lean
@@ -17,12 +17,12 @@ This file includes several ways of interacting with `list (sigma β)`, treated a
 ## Main Definitions
 
 - `list.keys` extracts the list of keys.
-- `nodupkeys` determines if the store has duplicate keys.
-- `lookup`/`lookup_all` accesses the value(s) of a particular key.
-- `kreplace` modifies a value.
-- `kerase` removes a value.
-- `kinsert` inserts a value.
-- `kunion` computes the union of two stores.
+- `list.nodupkeys` determines if the store has duplicate keys.
+- `list.lookup`/`lookup_all` accesses the value(s) of a particular key.
+- `list.kreplace` modifies a value.
+- `list.kerase` removes a value.
+- `list.kinsert` inserts a value.
+- `list.kunion` computes the union of two stores.
 -/
 
 universes u v

--- a/src/data/list/sigma.lean
+++ b/src/data/list/sigma.lean
@@ -14,7 +14,7 @@ import data.sigma
 
 This file includes several ways of interacting with `list (sigma β)`, treated as a key-value store.
 
-## Important Definitions
+## Main Definitions
 
 - `keys` extracts the list of keys.
 - `nodupkeys` determines if the store has duplicate keys.

--- a/src/data/list/sigma.lean
+++ b/src/data/list/sigma.lean
@@ -16,7 +16,7 @@ This file includes several ways of interacting with `list (sigma β)`, treated a
 
 ## Main Definitions
 
-- `keys` extracts the list of keys.
+- `list.keys` extracts the list of keys.
 - `nodupkeys` determines if the store has duplicate keys.
 - `lookup`/`lookup_all` accesses the value(s) of a particular key.
 - `kreplace` modifies a value.

--- a/src/data/list/sigma.lean
+++ b/src/data/list/sigma.lean
@@ -9,6 +9,22 @@ import data.list.perm
 import data.list.range
 import data.sigma
 
+/-!
+# Utilities for lists of sigmas
+
+This file includes several ways of interacting with `list (sigma β)`, treated as a key-value store.
+
+## Important Definitions
+
+- `keys` extracts the list of keys.
+- `nodupkeys` determines if the store has duplicate keys.
+- `lookup`/`lookup_all` accesses the value(s) of a particular key.
+- `kreplace` modifies a value.
+- `kerase` removes a value.
+- `kinsert` inserts a value.
+- `kunion` computes the union of two stores.
+-/
+
 universes u v
 
 namespace list


### PR DESCRIPTION

Fixing the missing module docstrings in `data/list`, as well as documenting some `def`s and `theorem`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
