### PR TITLE
[Merged by Bors] - feat(interval_integral): generalize change of variables

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -270,6 +270,13 @@ lemma has_deriv_at_iff_tendsto_slope :
     tendsto (λ y, (y - x)⁻¹ • (f y - f x)) (𝓝[{x}ᶜ] x) (𝓝 f') :=
 has_deriv_at_filter_iff_tendsto_slope
 
+theorem has_deriv_within_at_congr_set {s t u : set 𝕜}
+  (hu : u ∈ 𝓝 x) (h : s ∩ u = t ∩ u) :
+    has_deriv_within_at f f' s x ↔ has_deriv_within_at f f' t x :=
+by simp_rw [has_deriv_within_at, nhds_within_eq_nhds_within' hu h]
+
+alias has_deriv_within_at_congr_set ↔ has_deriv_within_at.congr_set _
+
 @[simp] lemma has_deriv_within_at_diff_singleton :
   has_deriv_within_at f f' (s \ {x}) x ↔ has_deriv_within_at f f' s x :=
 by simp only [has_deriv_within_at_iff_tendsto_slope, sdiff_idem]
@@ -287,6 +294,15 @@ by rw [← Iic_diff_right, has_deriv_within_at_diff_singleton]
 
 alias has_deriv_within_at_Iio_iff_Iic ↔
   has_deriv_within_at.Iic_of_Iio has_deriv_within_at.Iio_of_Iic
+
+theorem has_deriv_within_at.Ioi_iff_Ioo [linear_order 𝕜] [order_closed_topology 𝕜] {x y : 𝕜}
+  (h : x < y) :
+  has_deriv_within_at f f' (Ioo x y) x ↔ has_deriv_within_at f f' (Ioi x) x :=
+has_deriv_within_at_congr_set (is_open_Iio.mem_nhds h) $
+  by { rw [Ioi_inter_Iio, inter_eq_left_iff_subset], exact Ioo_subset_Iio_self }
+
+alias has_deriv_within_at.Ioi_iff_Ioo ↔
+  has_deriv_within_at.Ioi_of_Ioo has_deriv_within_at.Ioo_of_Ioi
 
 theorem has_deriv_at_iff_is_o_nhds_zero : has_deriv_at f f' x ↔
   is_o (λh, f (x + h) - f x - h • f') (λh, h) (𝓝 0) :=

--- a/src/data/set/intervals/unordered_interval.lean
+++ b/src/data/set/intervals/unordered_interval.lean
@@ -37,7 +37,7 @@ variables {α : Type u} [linear_order α] {a a₁ a₂ b b₁ b₂ x : α}
 /-- `interval a b` is the set of elements lying between `a` and `b`, with `a` and `b` included. -/
 def interval (a b : α) := Icc (min a b) (max a b)
 
-localized "notation `[`a `, ` b `]` := interval a b" in interval
+localized "notation `[`a `, ` b `]` := set.interval a b" in interval
 
 @[simp] lemma interval_of_le (h : a ≤ b) : [a, b] = Icc a b :=
 by rw [interval, min_eq_left h, max_eq_right h]
@@ -119,7 +119,7 @@ end
 def interval_oc : α → α → set α := λ a b, Ioc (min a b) (max a b)
 
 -- Below is a capital iota
-localized "notation `Ι` := interval_oc" in interval
+localized "notation `Ι` := set.interval_oc" in interval
 
 lemma interval_oc_of_le (h : a ≤ b) : Ι a b = Ioc a b :=
 by simp [interval_oc, h]

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -336,10 +336,6 @@ instance nhds_within_Icc_is_measurably_generated :
   is_measurably_generated (𝓝[Icc a b] x) :=
 by { rw [← Ici_inter_Iic, nhds_within_inter], apply_instance }
 
-instance nhds_within_interval_is_measurably_generated :
-  is_measurably_generated (𝓝[[a, b]] x) :=
-nhds_within_Icc_is_measurably_generated
-
 instance at_top_is_measurably_generated : (filter.at_top : filter α).is_measurably_generated :=
 @filter.infi_is_measurably_generated _ _ _ _ $
   λ a, (measurable_set_Ici : measurable_set (Ici a)).principal_is_measurably_generated
@@ -366,7 +362,7 @@ hf.prod_mk hg measurable_set_le'
 end partial_order
 
 section linear_order
-variables [linear_order α] [order_closed_topology α] {a b : α}
+variables [linear_order α] [order_closed_topology α] {a b x : α}
 
 @[simp, measurability]
 lemma measurable_set_Iio : measurable_set (Iio a) := is_open_Iio.measurable_set
@@ -388,6 +384,10 @@ measurable_set_Ioi.nhds_within_is_measurably_generated _
 instance nhds_within_Iio_is_measurably_generated :
   (𝓝[Iio b] a).is_measurably_generated :=
 measurable_set_Iio.nhds_within_is_measurably_generated _
+
+instance nhds_within_interval_is_measurably_generated :
+  is_measurably_generated (𝓝[[a, b]] x) :=
+nhds_within_Icc_is_measurably_generated
 
 @[measurability]
 lemma measurable_set_lt' [second_countable_topology α] : measurable_set {p : α × α | p.1 < p.2} :=

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -315,7 +315,7 @@ lemma meas_closure_of_null_bdry {μ : measure α'} {s : set α'}
   interior_subset subset_closure h_nullbdry).symm
 
 section preorder
-variables [preorder α] [order_closed_topology α] {a b : α}
+variables [preorder α] [order_closed_topology α] {a b x : α}
 
 @[simp, measurability]
 lemma measurable_set_Ici : measurable_set (Ici a) := is_closed_Ici.measurable_set
@@ -331,6 +331,14 @@ measurable_set_Ici.nhds_within_is_measurably_generated _
 instance nhds_within_Iic_is_measurably_generated :
   (𝓝[Iic b] a).is_measurably_generated :=
 measurable_set_Iic.nhds_within_is_measurably_generated _
+
+instance nhds_within_Icc_is_measurably_generated :
+  is_measurably_generated (𝓝[Icc a b] x) :=
+by { rw [← Ici_inter_Iic, nhds_within_inter], apply_instance }
+
+instance nhds_within_interval_is_measurably_generated :
+  is_measurably_generated (𝓝[Icc a b] x) :=
+is_measurably_generated.Icc
 
 instance at_top_is_measurably_generated : (filter.at_top : filter α).is_measurably_generated :=
 @filter.infi_is_measurably_generated _ _ _ _ $

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -39,7 +39,7 @@ import topology.instances.ereal
 noncomputable theory
 
 open classical set filter measure_theory
-open_locale classical big_operators topological_space nnreal ennreal
+open_locale classical big_operators topological_space nnreal ennreal interval
 
 universes u v w x y
 variables {α β γ γ₂ δ : Type*} {ι : Sort y} {s t u : set α}
@@ -337,8 +337,8 @@ instance nhds_within_Icc_is_measurably_generated :
 by { rw [← Ici_inter_Iic, nhds_within_inter], apply_instance }
 
 instance nhds_within_interval_is_measurably_generated :
-  is_measurably_generated (𝓝[Icc a b] x) :=
-is_measurably_generated.Icc
+  is_measurably_generated (𝓝[[a, b]] x) :=
+nhds_within_Icc_is_measurably_generated
 
 instance at_top_is_measurably_generated : (filter.at_top : filter α).is_measurably_generated :=
 @filter.infi_is_measurably_generated _ _ _ _ $

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -140,8 +140,8 @@ assumptions:
   in `s`.
 
 This typeclass has the following “real” instances: `(a, pure a, ⊥)`, `(a, 𝓝[Ici a] a, 𝓝[Ioi a] a)`,
-`(a, 𝓝[Iic a] a, 𝓝[Iic a] a)`, `(a, 𝓝 a, 𝓝 a)`. F
-urthermore, we have the following instances that are equal to the previously mentioned instances:
+`(a, 𝓝[Iic a] a, 𝓝[Iic a] a)`, `(a, 𝓝 a, 𝓝 a)`.
+Furthermore, we have the following instances that are equal to the previously mentioned instances:
 `(a, 𝓝[{a}] a, ⊥)` and `(a, 𝓝[univ] a, 𝓝[univ] a)`.
 While the difference between `Ici a` and `Ioi a` doesn't matter for theorems about Lebesgue measure,
 it becomes important in the versions of FTC about any locally finite measure if this measure has an

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -91,7 +91,7 @@ scheme as for the versions of FTC-1. They include:
 
 We then derive additional integration techniques from FTC-2:
 * `interval_integral.integral_mul_deriv_eq_deriv_mul` - integration by parts
-* `interval_integral.integral_comp_mul_deriv'` - integration by substitution
+* `interval_integral.integral_comp_mul_deriv''` - integration by substitution
 
 Many applications of these theorems can be found in the file `analysis.special_functions.integrals`.
 
@@ -2244,14 +2244,14 @@ end
 
 /--
 Change of variables, general form. If `f` is continuous on `[a, b]` and has
-continuous derivative `f'` in `(a, b)`, and `g` is continuous on `f '' [a, b]` then we can
+continuous right-derivative `f'` in `(a, b)`, and `g` is continuous on `f '' [a, b]` then we can
 substitute `u = f x` to get `∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
 
 We could potentially slightly weaken the conditions, by not requiring that `f'` and `g` are
 continuous on the endpoints of these intervals, but in that case we need to additionally assume that
 the functions are integrable on that interval.
 -/
-theorem integral_comp_mul_deriv' {f f' g : ℝ → ℝ}
+theorem integral_comp_mul_deriv'' {f f' g : ℝ → ℝ}
   (hf : continuous_on f [a, b])
   (hff' : ∀ x ∈ Ioo (min a b) (max a b), has_deriv_within_at f (f' x) (Ioi x) x)
   (hf' : continuous_on f' [a, b])
@@ -2287,7 +2287,19 @@ begin
 end
 
 /--
-Change of variables, most common . If `f` is has continuous derivative `f'` on `[a, b]`,
+Change of variables. If `f` is has continuous derivative `f'` on `[a, b]`,
+and `g` is continuous on `f '' [a, b]`, then we can substitute `u = f x` to get
+`∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
+-/
+theorem integral_comp_mul_deriv' {f f' g : ℝ → ℝ}
+  (h : ∀ x ∈ interval a b, has_deriv_at f (f' x) x)
+  (h' : continuous_on f' (interval a b)) (hg : continuous_on g (f '' [a, b])) :
+  ∫ x in a..b, (g ∘ f) x * f' x = ∫ x in f a..f b, g x :=
+integral_comp_mul_deriv'' (λ x hx, (h x hx).continuous_at.continuous_within_at)
+  (λ x hx, (h x $ Ioo_subset_Icc_self hx).has_deriv_within_at) h' hg
+
+/--
+Change of variables, most common version. If `f` is has continuous derivative `f'` on `[a, b]`,
 and `g` is continuous, then we can substitute `u = f x` to get
 `∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
 -/
@@ -2295,8 +2307,7 @@ theorem integral_comp_mul_deriv {f f' g : ℝ → ℝ}
   (h : ∀ x ∈ interval a b, has_deriv_at f (f' x) x)
   (h' : continuous_on f' (interval a b)) (hg : continuous g) :
   ∫ x in a..b, (g ∘ f) x * f' x = ∫ x in f a..f b, g x :=
-integral_comp_mul_deriv' (λ x hx, (h x hx).continuous_at.continuous_within_at)
-  (λ x hx, (h x $ Ioo_subset_Icc_self hx).has_deriv_within_at) h' hg.continuous_on
+integral_comp_mul_deriv' h h' hg.continuous_on
 
 theorem integral_deriv_comp_mul_deriv' {f f' g g' : ℝ → ℝ}
   (hf : continuous_on f [a, b])
@@ -2307,7 +2318,7 @@ theorem integral_deriv_comp_mul_deriv' {f f' g g' : ℝ → ℝ}
   (hg' : continuous_on g' (f '' [a, b])) :
   ∫ x in a..b, (g' ∘ f) x * f' x = (g ∘ f) b - (g ∘ f) a :=
 begin
-  rw [integral_comp_mul_deriv' hf hff' hf' hg',
+  rw [integral_comp_mul_deriv'' hf hff' hf' hg',
   integral_eq_sub_of_has_deriv_right hg hgg' (hg'.mono _).interval_integrable],
   exact real.interval_subset_image_interval hf left_mem_interval right_mem_interval,
 end

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -2290,6 +2290,8 @@ end
 Change of variables. If `f` is has continuous derivative `f'` on `[a, b]`,
 and `g` is continuous on `f '' [a, b]`, then we can substitute `u = f x` to get
 `∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
+Compared to `interval_integral.integral_comp_mul_deriv` we only require that `g` is continuous on
+`f '' [a, b]`.
 -/
 theorem integral_comp_mul_deriv' {f f' g : ℝ → ℝ}
   (h : ∀ x ∈ interval a b, has_deriv_at f (f' x) x)

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -139,17 +139,28 @@ assumptions:
 - if `u n` and `v n` tend to `l`, then for any `s ∈ l'`, `Ioc (u n) (v n)` is eventually included
   in `s`.
 
-This typeclass has exactly four “real” instances: `(a, pure a, ⊥)`, `(a, 𝓝[Ici a] a, 𝓝[Ioi a] a)`,
-`(a, 𝓝[Iic a] a, 𝓝[Iic a] a)`, `(a, 𝓝 a, 𝓝 a)`, and two instances that are equal to the first and
-last “real” instances: `(a, 𝓝[{a}] a, ⊥)` and `(a, 𝓝[univ] a, 𝓝[univ] a)`. While the difference
-between `Ici a` and `Ioi a` doesn't matter for theorems about Lebesgue measure, it becomes important
-in the versions of FTC about any locally finite measure if this measure has an atom at one of the
-endpoints.
+This typeclass has the following “real” instances: `(a, pure a, ⊥)`, `(a, 𝓝[Ici a] a, 𝓝[Ioi a] a)`,
+`(a, 𝓝[Iic a] a, 𝓝[Iic a] a)`, `(a, 𝓝 a, 𝓝 a)`. F
+urthermore, we have the following instances that are equal to the previously mentioned instances:
+`(a, 𝓝[{a}] a, ⊥)` and `(a, 𝓝[univ] a, 𝓝[univ] a)`.
+While the difference between `Ici a` and `Ioi a` doesn't matter for theorems about Lebesgue measure,
+it becomes important in the versions of FTC about any locally finite measure if this measure has an
+atom at one of the endpoints.
+
+### Combining one-sided and two-sided derivatives
+
+There are some `FTC_filter` instances where the fact that it is one-sided or
+two-sided depends on the point, namely `(x, 𝓝[Icc a b] x, 𝓝[Icc a b] x)`
+(resp. `(x, 𝓝[[a, b]] x, 𝓝[[a, b]] x)`, where `[a, b] = set.interval a b`),
+with `x ∈ Icc a b` (resp. `x ∈ [a, b]`).
+This results in a two-sided derivatives for `x ∈ Ioo a b` and one-sided derivatives for
+`x ∈ {a, b}`. Other instances could be added when needed (in that case, one also needs to add
+instances for `filter.is_measurably_generated` and `filter.tendsto_Ixx_class`).
 
 ## Tags
 
-integral, fundamental theorem of calculus
- -/
+integral, fundamental theorem of calculus, FTC-1, FTC-2, change of variables in integrals
+-/
 
 noncomputable theory
 open topological_space (second_countable_topology)
@@ -1221,9 +1232,7 @@ In the next subsection we apply this theorem to prove various theorems about dif
 of the integral w.r.t. Lebesgue measure. -/
 
 /-- An auxiliary typeclass for the Fundamental theorem of calculus, part 1. It is used to formulate
-theorems that work simultaneously for left and right one-sided derivatives of `∫ x in u..v, f x`.
-There are four instances: `(a, pure a, ⊥)`, `(a, 𝓝[Ici a], 𝓝[Ioi a])`,
-`(a, 𝓝[Iic a], 𝓝[Iic a])`, and `(a, 𝓝 a, 𝓝 a)`. -/
+theorems that work simultaneously for left and right one-sided derivatives of `∫ x in u..v, f x`. -/
 class FTC_filter {β : Type*} [linear_order β] [measurable_space β] [topological_space β]
   (a : out_param β) (outer : filter β) (inner : out_param $ filter β)
   extends tendsto_Ixx_class Ioc outer inner : Prop :=

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -2272,25 +2272,29 @@ theorem integral_comp_mul_deriv {f f' g : ℝ → ℝ}
   (h : ∀ x ∈ interval a b, has_deriv_at f (f' x) x)
   (h' : continuous_on f' (interval a b)) (hg : continuous g) :
   ∫ x in a..b, (g ∘ f) x * f' x = ∫ x in f a..f b, g x :=
-integral_comp_mul_deriv' h h' (λ x h, hg.continuous_at) (λ x h, hg.measurable.measurable_at_filter)
+integral_comp_mul_deriv' (λ x hx, (h x hx).continuous_at.continuous_within_at)
+  (λ x hx, (h x $ Ioo_subset_Icc_self hx).has_deriv_within_at) h' hg.continuous_on
 
 theorem integral_deriv_comp_mul_deriv' {f f' g g' : ℝ → ℝ}
-  (hf : ∀ x ∈ interval a b, has_deriv_at f (f' x) x)
-  (hg : ∀ x ∈ interval (f a) (f b), has_deriv_at g (g' x) x)
-  (hf' : continuous_on f' (interval a b))
-  (hg1 : continuous_on g' (interval (f a) (f b)))
-  (hg2 : ∀ x ∈ f '' (interval a b), continuous_at g' x)
-  (hgm : ∀ x ∈ f '' (interval a b), measurable_at_filter g' (𝓝 x)) :
+  (hf : continuous_on f [a, b])
+  (hff' : ∀ x ∈ Ioo (min a b) (max a b), has_deriv_within_at f (f' x) (Ioi x) x)
+  (hf' : continuous_on f' [a, b])
+  (hg : continuous_on g [f a, f b])
+  (hgg' : ∀ x ∈ Ioo (min (f a) (f b)) (max (f a) (f b)), has_deriv_within_at g (g' x) (Ioi x) x)
+  (hg' : continuous_on g' (f '' [a, b])) :
   ∫ x in a..b, (g' ∘ f) x * f' x = (g ∘ f) b - (g ∘ f) a :=
-by rw [integral_comp_mul_deriv' hf hf' hg2 hgm,
-  integral_eq_sub_of_has_deriv_at hg hg1.interval_integrable]
+begin
+  rw [integral_comp_mul_deriv' hf hff' hf' hg',
+  integral_eq_sub_of_has_deriv_right hg hgg' (hg'.mono _).interval_integrable],
+  exact real.interval_subset_image_interval hf left_mem_interval right_mem_interval,
+end
 
 theorem integral_deriv_comp_mul_deriv {f f' g g' : ℝ → ℝ}
   (hf : ∀ x ∈ interval a b, has_deriv_at f (f' x) x)
   (hg : ∀ x ∈ interval a b, has_deriv_at g (g' (f x)) (f x))
   (hf' : continuous_on f' (interval a b)) (hg' : continuous g') :
   ∫ x in a..b, (g' ∘ f) x * f' x = (g ∘ f) b - (g ∘ f) a :=
-integral_eq_sub_of_has_deriv_at (λ x hx, (hg x hx).comp x $ hf x hx) $
+integral_eq_sub_of_has_deriv_at (λ x hx, (hg x hx).comp x $ hf x hx)
   ((hg'.comp_continuous_on $ has_deriv_at.continuous_on hf).mul hf').interval_integrable
 
 end interval_integral

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -2242,12 +2242,21 @@ end
 ### Integration by substitution / Change of variables
 -/
 
+/--
+Change of variables, general form. If `f` is continuous on `[a, b]` and has
+continuous derivative `f'` in `(a, b)`, and `g` is continuous on `f '' [a, b]` then we can
+substitute `u = f x` to get `∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
+
+We could potentially slightly weaken the conditions, by not requiring that `f'` and `g` are
+continuous on the endpoints of these intervals, but in that case we need to additionally assume that
+the functions are integrable on that interval.
+-/
 theorem integral_comp_mul_deriv' {f f' g : ℝ → ℝ}
   (hf : continuous_on f [a, b])
   (hff' : ∀ x ∈ Ioo (min a b) (max a b), has_deriv_within_at f (f' x) (Ioi x) x)
   (hf' : continuous_on f' [a, b])
   (hg : continuous_on g (f '' [a, b])) :
-  ∫ x in a..b, (g ∘ f) x * f' x = ∫ x in f a..f b, g x :=
+  ∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u :=
 begin
   have h_cont : continuous_on (λ u, ∫ t in f a..f u, g t) [a, b],
   { rw [real.image_interval hf] at hg,
@@ -2277,6 +2286,11 @@ begin
   simp_rw [integral_eq_sub_of_has_deriv_right h_cont h_der h_int, integral_same, sub_zero],
 end
 
+/--
+Change of variables, most common . If `f` is has continuous derivative `f'` on `[a, b]`,
+and `g` is continuous, then we can substitute `u = f x` to get
+`∫ x in a..b, (g ∘ f) x * f' x = ∫ u in f a..f b, g u`.
+-/
 theorem integral_comp_mul_deriv {f f' g : ℝ → ℝ}
   (h : ∀ x ∈ interval a b, has_deriv_at f (f' x) x)
   (h' : continuous_on f' (interval a b)) (hg : continuous g) :

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -434,6 +434,15 @@ lemma continuous_at.measurable_at_filter
   ∀ x ∈ s, measurable_at_filter f (𝓝 x) μ :=
 continuous_on.measurable_at_filter hs $ continuous_at.continuous_on hf
 
+/-- If a function is continuous on a measurable set `s`, then it is measurable at the filter
+  `𝓝[s] x` for all `x`. -/
+lemma continuous_on.measurable_at_filter_nhds_within {α E : Type*} [measurable_space α]
+  [measurable_space E] [normed_group E] [topological_space α] [opens_measurable_space α]
+  [borel_space E] {f : α → E} {s : set α} {μ : measure α}
+  (hf : continuous_on f s) (hs : measurable_set s) (x : α) :
+  measurable_at_filter f (𝓝[s] x) μ :=
+⟨s, self_mem_nhds_within, hf.ae_measurable hs⟩
+
 /-- Fundamental theorem of calculus for set integrals, `nhds_within` version: if `μ` is a locally
 finite measure, `f` is continuous on a measurable set `t`, and `a ∈ t`, then `∫ x in (s i), f x ∂μ =
 μ (s i) • f a + o(μ (s i))` at `li` provided that `s i` tends to `(𝓝[t] a).lift' powerset` along

--- a/src/order/filter/interval.lean
+++ b/src/order/filter/interval.lean
@@ -42,13 +42,15 @@ that need topology are defined in `topology/algebra/ordered`.
 
 variables {α β : Type*}
 
-open_locale classical filter
+open_locale classical filter interval
 
 open set function
 
-variables [preorder α]
-
 namespace filter
+
+section preorder
+
+variables [preorder α]
 
 /-- A pair of filters `l₁`, `l₂` has `tendsto_Ixx_class Ixx` property if `Ixx a b` tends to
 `l₂.lift' powerset` as `a` and `b` tend to `l₁`. In all instances `Ixx` is one of `Icc`, `Ico`,
@@ -172,18 +174,43 @@ tendsto_Ixx_class_of_subset (λ _ _, Ioo_subset_Ioc_self)
 instance tendsto_Ioo_Iio_Iio {a : α} : tendsto_Ixx_class Ioo (𝓟 (Iio a)) (𝓟 (Iio a)) :=
 tendsto_Ixx_class_of_subset (λ _ _, Ioo_subset_Ioc_self)
 
-variable [partial_order β]
+instance tendsto_Icc_Icc_icc {a b : α} :
+  tendsto_Ixx_class Icc (𝓟 (Icc a b)) (𝓟 (Icc a b)) :=
+tendsto_Ixx_class_principal.mpr $ λ x hx y hy, Icc_subset_Icc hx.1 hy.2
 
-instance tendsto_Icc_pure_pure {a : β} : tendsto_Ixx_class Icc (pure a) (pure a : filter β) :=
+instance tendsto_Ioc_Icc_Icc {a b : α} : tendsto_Ixx_class Ioc (𝓟 (Icc a b)) (𝓟 (Icc a b)) :=
+tendsto_Ixx_class_of_subset $ λ _ _, Ioc_subset_Icc_self
+
+end preorder
+
+section partial_order
+
+variable [partial_order α]
+
+instance tendsto_Icc_pure_pure {a : α} : tendsto_Ixx_class Icc (pure a) (pure a : filter α) :=
 by { rw ← principal_singleton, exact tendsto_Ixx_class_principal.2 ord_connected_singleton.out }
 
-instance tendsto_Ico_pure_bot {a : β} : tendsto_Ixx_class Ico (pure a) ⊥ :=
+instance tendsto_Ico_pure_bot {a : α} : tendsto_Ixx_class Ico (pure a) ⊥ :=
 ⟨by simp [lift'_bot monotone_powerset]⟩
 
-instance tendsto_Ioc_pure_bot {a : β} : tendsto_Ixx_class Ioc (pure a) ⊥ :=
+instance tendsto_Ioc_pure_bot {a : α} : tendsto_Ixx_class Ioc (pure a) ⊥ :=
 ⟨by simp [lift'_bot monotone_powerset]⟩
 
-instance tendsto_Ioo_pure_bot {a : β} : tendsto_Ixx_class Ioo (pure a) ⊥ :=
+instance tendsto_Ioo_pure_bot {a : α} : tendsto_Ixx_class Ioo (pure a) ⊥ :=
 tendsto_Ixx_class_of_subset (λ _ _, Ioo_subset_Ioc_self)
+
+end partial_order
+
+section linear_order
+
+variables [linear_order α]
+
+instance tendsto_Icc_interval_interval {a b : α} : tendsto_Ixx_class Icc (𝓟 [a, b]) (𝓟 [a, b]) :=
+filter.tendsto_Icc_Icc_icc
+
+instance tendsto_Ioc_interval_interval {a b : α} : tendsto_Ixx_class Ioc (𝓟 [a, b]) (𝓟 [a, b]) :=
+tendsto_Ixx_class_of_subset $ λ _ _, Ioc_subset_Icc_self
+
+end linear_order
 
 end filter

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -158,6 +158,10 @@ end
 theorem nhds_within_le_nhds {a : α} {s : set α} : 𝓝[s] a ≤ 𝓝 a :=
 by { rw ← nhds_within_univ, apply nhds_within_le_of_mem, exact univ_mem }
 
+lemma nhds_within_eq_nhds_within' {a : α} {s t u : set α}
+  (hs : s ∈ 𝓝 a) (h₂ : t ∩ s = u ∩ s) : 𝓝[t] a = 𝓝[u] a :=
+by rw [nhds_within_restrict' t hs, nhds_within_restrict' u hs, h₂]
+
 theorem nhds_within_eq_nhds_within {a : α} {s t u : set α}
     (h₀ : a ∈ s) (h₁ : is_open s) (h₂ : t ∩ s = u ∩ s) :
   𝓝[t] a = 𝓝[u] a :=

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -297,23 +297,23 @@ lemma real.image_interval_eq_Icc {f : ℝ → ℝ} {a b : ℝ} (h : continuous_o
   f '' [a, b] = Icc (Inf (f '' [a, b])) (Sup (f '' [a, b])) :=
 begin
   cases le_total a b with h2 h2,
-  { simp_rw [interval_of_le h2] at h ⊢, exact image_Icc h2 h },
-  { simp_rw [interval_of_ge h2] at h ⊢, exact image_Icc h2 h },
+  { simp_rw [interval_of_le h2] at h ⊢, exact real.image_Icc h2 h },
+  { simp_rw [interval_of_ge h2] at h ⊢, exact real.image_Icc h2 h },
 end
 
 lemma real.image_interval {f : ℝ → ℝ} {a b : ℝ} (h : continuous_on f $ [a, b]) :
   f '' [a, b] = [Inf (f '' [a, b]), Sup (f '' [a, b])] :=
 begin
-  refine (image_interval_eq_Icc h).trans (interval_of_le _).symm,
-  rw [image_interval_eq_Icc h],
-  exact Inf_le_Sup _ bdd_below_Icc bdd_above_Icc
+  refine (real.image_interval_eq_Icc h).trans (interval_of_le _).symm,
+  rw [real.image_interval_eq_Icc h],
+  exact real.Inf_le_Sup _ bdd_below_Icc bdd_above_Icc
 end
 
 lemma real.interval_subset_image_interval {f : ℝ → ℝ} {a b x y : ℝ}
   (h : continuous_on f [a, b]) (hx : x ∈ [a, b]) (hy : y ∈ [a, b]) :
   [f x, f y] ⊆ f '' [a, b] :=
 begin
-  rw [image_interval h, interval_subset_interval_iff_mem, ← image_interval h],
+  rw [real.image_interval h, interval_subset_interval_iff_mem, ← real.image_interval h],
   exact ⟨mem_image_of_mem f hx, mem_image_of_mem f hy⟩
 end
 

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -16,8 +16,7 @@ import algebra.periodic
 
 noncomputable theory
 open classical set filter topological_space metric
-open_locale classical
-open_locale topological_space filter uniformity
+open_locale classical topological_space filter uniformity interval
 
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
@@ -293,6 +292,30 @@ lemma real.image_Icc {f : ℝ → ℝ} {a b : ℝ} (hab : a ≤ b) (h : continuo
   f '' Icc a b = Icc (Inf $ f '' Icc a b) (Sup $ f '' Icc a b) :=
 eq_Icc_of_connected_compact ⟨(nonempty_Icc.2 hab).image f, is_preconnected_Icc.image f h⟩
   (is_compact_Icc.image_of_continuous_on h)
+
+lemma real.image_interval_eq_Icc {f : ℝ → ℝ} {a b : ℝ} (h : continuous_on f $ [a, b]) :
+  f '' [a, b] = Icc (Inf (f '' [a, b])) (Sup (f '' [a, b])) :=
+begin
+  cases le_total a b with h2 h2,
+  { simp_rw [interval_of_le h2] at h ⊢, exact image_Icc h2 h },
+  { simp_rw [interval_of_ge h2] at h ⊢, exact image_Icc h2 h },
+end
+
+lemma real.image_interval {f : ℝ → ℝ} {a b : ℝ} (h : continuous_on f $ [a, b]) :
+  f '' [a, b] = [Inf (f '' [a, b]), Sup (f '' [a, b])] :=
+begin
+  refine (image_interval_eq_Icc h).trans (interval_of_le _).symm,
+  rw [image_interval_eq_Icc h],
+  exact Inf_le_Sup _ bdd_below_Icc bdd_above_Icc
+end
+
+lemma real.interval_subset_image_interval {f : ℝ → ℝ} {a b x y : ℝ}
+  (h : continuous_on f [a, b]) (hx : x ∈ [a, b]) (hy : y ∈ [a, b]) :
+  [f x, f y] ⊆ f '' [a, b] :=
+begin
+  rw [image_interval h, interval_subset_interval_iff_mem, ← image_interval h],
+  exact ⟨mem_image_of_mem f hx, mem_image_of_mem f hy⟩
+end
 
 end
 


### PR DESCRIPTION
* Generalizes `interval_integral.integral_comp_mul_deriv'`.
In this version:
(1) `f` need not be differentiable at the endpoints of `[a,b]`, only continuous,
(2) I removed the `measurable_at_filter` assumption
(3) I assumed that `g` was continuous on `f '' [a,b]`, instead of continuous at every point of `f '' [a,b]` (which differs in the endpoints).

This was possible after @sgouezel's PR #7978.

The proof was a lot longer/messier than expected. Under these assumptions we have to be careful to sometimes take one-sided derivatives. For example, we cannot take the 2-sided derivative of `λ u, ∫ x in f a..u, g x` when `u` is the maximum/minimum of `f` on `[a, b]`.

@urkud: I needed more `FTC_filter` classes, namely for closed intervals (to be precise: `FTC_filter x (𝓝[[a, b]] x) (𝓝[[a, b]] x)`). Was there a conscious reason to exclude these classes? (The documentation explicitly enumerates the existing instances.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Still to do in this PR:
- [x] fix errors and corollaries of `interval_integral.integral_comp_mul_deriv'`
- [x] update `ftc_filter` documentation

