### PR TITLE
[Merged by Bors] - feat(ring_theory): define integrally closed domains

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -603,6 +603,10 @@ def snd : A × B →ₐ[R] B :=
 
 end prod
 
+lemma algebra_map_eq_apply (f : A →ₐ[R] B) {y : R} {x : A} (h : algebra_map R A y = x) :
+  algebra_map R B y = f x :=
+h ▸ (f.commutes _).symm
+
 end semiring
 
 section comm_semiring
@@ -1030,6 +1034,11 @@ instance apply_smul_comm_class : smul_comm_class R (A₁ ≃ₐ[R] A₁) A₁ :=
 
 instance apply_smul_comm_class' : smul_comm_class (A₁ ≃ₐ[R] A₁) R A₁ :=
 { smul_comm := λ e r a, (e.to_linear_equiv.map_smul r a) }
+
+@[simp] lemma algebra_map_eq_apply (e : A₁ ≃ₐ[R] A₂) {y : R} {x : A₁} :
+  (algebra_map R A₂ y = e x) ↔ (algebra_map R A₁ y = x) :=
+⟨λ h, by simpa using e.symm.to_alg_hom.algebra_map_eq_apply h,
+ λ h, e.to_alg_hom.algebra_map_eq_apply h⟩
 
 end semiring
 

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -434,7 +434,8 @@ end
 section is_integral_closure
 
 /-- `is_integral_closure A R B` is the characteristic predicate stating `A` is
-the integral closure of `R` in `B`.
+the integral closure of `R` in `B`,
+i.e. that an element of `B` is integral over `R` iff it is an element of (the image of) `A`.
 -/
 class is_integral_closure (A R B : Type*) [comm_ring R] [comm_semiring A] [comm_ring B]
   [algebra R B] [algebra A B] : Prop :=

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -124,13 +124,23 @@ theorem is_integral_of_subring {x : A} (T : subring R)
   (hx : is_integral T x) : is_integral R x :=
 is_integral_of_is_scalar_tower x hx
 
+lemma is_integral.algebra_map [algebra A B] [is_scalar_tower R A B]
+  {x : A} (h : is_integral R x) :
+  is_integral R (algebra_map A B x) :=
+begin
+  rcases h with ⟨f, hf, hx⟩,
+  use [f, hf],
+  rw [is_scalar_tower.algebra_map_eq R A B, ← hom_eval₂, hx, ring_hom.map_zero]
+end
+
 lemma is_integral_algebra_map_iff [algebra A B] [is_scalar_tower R A B]
   {x : A} (hAB : function.injective (algebra_map A B)) :
   is_integral R (algebra_map A B x) ↔ is_integral R x :=
 begin
-  split; rintros ⟨f, hf, hx⟩; use [f, hf],
-  { exact is_scalar_tower.aeval_eq_zero_of_aeval_algebra_map_eq_zero R A B hAB hx },
-  { rw [is_scalar_tower.algebra_map_eq R A B, ← hom_eval₂, hx, ring_hom.map_zero] }
+  refine ⟨_, λ h, h.algebra_map⟩,
+  rintros ⟨f, hf, hx⟩,
+  use [f, hf],
+  exact is_scalar_tower.aeval_eq_zero_of_aeval_algebra_map_eq_zero R A B hAB hx,
 end
 
 theorem is_integral_iff_is_integral_closure_finite {r : A} :
@@ -420,6 +430,105 @@ lemma is_integral.sum {α : Type*} {s : finset α} (f : α → A) (h : ∀ x ∈
 (integral_closure R A).sum_mem h
 
 end
+
+section is_integral_closure
+
+/-- `is_integral_closure A R B` is the characteristic predicate stating `A` is
+the integral closure of `R` in `B`.
+-/
+class is_integral_closure (A R B : Type*) [comm_ring R] [comm_semiring A] [comm_ring B]
+  [algebra R B] [algebra A B] : Prop :=
+(algebra_map_injective [] : function.injective (algebra_map A B))
+(is_integral_iff : ∀ {x : B}, is_integral R x ↔ ∃ y, algebra_map A B y = x)
+
+instance integral_closure.is_integral_closure (R A : Type*) [comm_ring R] [comm_ring A]
+  [algebra R A] : is_integral_closure (integral_closure R A) R A :=
+⟨subtype.coe_injective, λ x, ⟨λ h, ⟨⟨x, h⟩, rfl⟩, by { rintro ⟨⟨_, h⟩, rfl⟩, exact h }⟩⟩
+
+namespace is_integral_closure
+
+variables {R A B : Type*} [comm_ring R] [comm_ring A] [comm_ring B]
+variables [algebra R B] [algebra A B] [is_integral_closure A R B]
+
+variables (R) {A} (B)
+protected theorem is_integral [algebra R A] [is_scalar_tower R A B] (x : A) : is_integral R x :=
+(is_integral_algebra_map_iff (algebra_map_injective A R B)).mp $
+show is_integral R (algebra_map A B x), from is_integral_iff.mpr ⟨x, rfl⟩
+
+theorem is_integral_algebra [algebra R A] [is_scalar_tower R A B] :
+  algebra.is_integral R A :=
+λ x, is_integral_closure.is_integral R B x
+
+variables {R} (A) {B}
+
+/-- If `x : B` is integral over `R`, then it is an element of the integral closure of `R` in `B`. -/
+noncomputable def mk' (x : B) (hx : is_integral R x) : A :=
+classical.some (is_integral_iff.mp hx)
+
+@[simp] lemma algebra_map_mk' (x : B) (hx : is_integral R x) :
+  algebra_map A B (mk' A x hx) = x :=
+classical.some_spec (is_integral_iff.mp hx)
+
+@[simp] lemma mk'_one (h : is_integral R (1 : B) := is_integral_one) :
+  mk' A 1 h = 1 :=
+algebra_map_injective A R B $ by rw [algebra_map_mk', ring_hom.map_one]
+
+@[simp] lemma mk'_zero (h : is_integral R (0 : B) := is_integral_zero) :
+  mk' A 0 h = 0 :=
+algebra_map_injective A R B $ by rw [algebra_map_mk', ring_hom.map_zero]
+
+@[simp] lemma mk'_add (x y : B) (hx : is_integral R x) (hy : is_integral R y) :
+  mk' A (x + y) (is_integral_add hx hy) = mk' A x hx + mk' A y hy :=
+algebra_map_injective A R B $ by simp only [algebra_map_mk', ring_hom.map_add]
+
+@[simp] lemma mk'_mul (x y : B) (hx : is_integral R x) (hy : is_integral R y) :
+  mk' A (x * y) (is_integral_mul hx hy) = mk' A x hx * mk' A y hy :=
+algebra_map_injective A R B $ by simp only [algebra_map_mk', ring_hom.map_mul]
+
+@[simp] lemma mk'_algebra_map [algebra R A] [is_scalar_tower R A B] (x : R)
+  (h : is_integral R (algebra_map R B x) := is_integral_algebra_map) :
+  is_integral_closure.mk' A (algebra_map R B x) h = algebra_map R A x :=
+algebra_map_injective A R B $ by rw [algebra_map_mk', ← is_scalar_tower.algebra_map_apply]
+
+section lift
+
+variables {R} (A B) {S : Type*} [comm_ring S] [algebra R S] [algebra S B] [is_scalar_tower R S B]
+variables [algebra R A] [is_scalar_tower R A B] (h : algebra.is_integral R S)
+
+/-- If `B / S / R` is a tower of ring extensions where `S` is integral over `R`,
+then `S` maps (uniquely) into an integral closure `B / A / R`. -/
+noncomputable def lift : S →ₐ[R] A :=
+{ to_fun := λ x, mk' A (algebra_map S B x) (is_integral.algebra_map (h x)),
+  map_one' := by simp only [ring_hom.map_one, mk'_one],
+  map_zero' := by simp only [ring_hom.map_zero, mk'_zero],
+  map_add' := λ x y, by simp_rw [← mk'_add, ring_hom.map_add],
+  map_mul' := λ x y, by simp_rw [← mk'_mul, ring_hom.map_mul],
+  commutes' := λ x, by simp_rw [← is_scalar_tower.algebra_map_apply, mk'_algebra_map] }
+
+@[simp] lemma algebra_map_lift (x : S) : algebra_map A B (lift A B h x) = algebra_map S B x :=
+algebra_map_mk' _ _ _
+
+end lift
+
+section equiv
+
+variables (R A B) (A' : Type*) [comm_ring A'] [algebra A' B] [is_integral_closure A' R B]
+variables [algebra R A] [algebra R A'] [is_scalar_tower R A B] [is_scalar_tower R A' B]
+
+/-- Integral closures are all isomorphic to each other. -/
+noncomputable def equiv : A ≃ₐ[R] A' :=
+alg_equiv.of_alg_hom (lift _ B (is_integral_algebra R B)) (lift _ B (is_integral_algebra R B))
+  (by { ext x, apply algebra_map_injective A' R B, simp })
+  (by { ext x, apply algebra_map_injective A R B, simp })
+
+@[simp] lemma algebra_map_equiv (x : A) : algebra_map A' B (equiv R A B A' x) = algebra_map A B x :=
+algebra_map_lift _ _ _ _
+
+end equiv
+
+end is_integral_closure
+
+end is_integral_closure
 
 section algebra
 open algebra

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -114,6 +114,10 @@ theorem is_integral_alg_hom (f : A →ₐ[R] B) {x : A} (hx : is_integral R x) :
 let ⟨p, hp, hpx⟩ :=
 hx in ⟨p, hp, by rw [← aeval_def, aeval_alg_hom_apply, aeval_def, hpx, f.map_zero]⟩
 
+@[simp]
+theorem is_integral_alg_equiv (f : A ≃ₐ[R] B) {x : A} : is_integral R (f x) ↔ is_integral R x :=
+⟨λ h, by simpa using is_integral_alg_hom f.symm.to_alg_hom h, is_integral_alg_hom f.to_alg_hom⟩
+
 theorem is_integral_of_is_scalar_tower [algebra A B] [is_scalar_tower R A B]
   (x : B) (hx : is_integral R x) : is_integral A x :=
 let ⟨p, hp, hpx⟩ := hx in

--- a/src/ring_theory/integrally_closed.lean
+++ b/src/ring_theory/integrally_closed.lean
@@ -33,17 +33,6 @@ class is_integrally_closed (R : Type*) [integral_domain R] : Prop :=
 (algebra_map_eq_of_integral :
   ∀ {x : fraction_ring R}, is_integral R x → ∃ y, algebra_map R (fraction_ring R) y = x)
 
-lemma alg_hom.algebra_map_eq_apply {R A B : Type*} [comm_semiring R] [semiring A] [semiring B]
-  [algebra R A] [algebra R B] (f : A →ₐ[R] B) {y : R} {x : A} (h : algebra_map R A y = x) :
-  algebra_map R B y = f x :=
-h ▸ (f.commutes _).symm
-
-@[simp] lemma alg_equiv.algebra_map_eq_apply {R A B : Type*} [comm_semiring R] [semiring A] [semiring B]
-  [algebra R A] [algebra R B] (e : A ≃ₐ[R] B) {y : R} {x : A} :
-  (algebra_map R B y = e x) ↔ (algebra_map R A y = x) :=
-⟨λ h, by simpa using e.symm.to_alg_hom.algebra_map_eq_apply h,
- λ h, e.to_alg_hom.algebra_map_eq_apply h⟩
-
 section iff
 
 variables {R : Type*} [integral_domain R] (K : Type*) [field K] [algebra R K] [is_fraction_ring R K]

--- a/src/ring_theory/integrally_closed.lean
+++ b/src/ring_theory/integrally_closed.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2021 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+import ring_theory.integral_closure
+import ring_theory.localization
+
+/-!
+# Integrally closed rings
+
+An integrally closed domain `R` contains all the elements of `Frac(R)` that are
+integral over `R`. A special case of integrally closed domains are the Dedekind domains.
+
+## Main definitions
+
+* `is_integrally_closed R` states `R` contains all integral elements of `Frac(R)`
+
+## Main results
+
+* `is_integrally_closed_iff K`, where `K` is a fraction field of `R`, states `R`
+  is integrally closed iff it is the integral closure of `R` in `K`
+-/
+
+open_locale non_zero_divisors
+
+/-- `R` is integrally closed if all integral elements of `Frac(R)` are also elements of `R`.
+
+This definition uses `fraction_ring R` to denote `Frac(R)`. See `is_integrally_closed_iff`
+if you want to choose another field of fractions for `R`.
+-/
+class is_integrally_closed (R : Type*) [integral_domain R] : Prop :=
+(algebra_map_eq_of_integral :
+  ∀ {x : fraction_ring R}, is_integral R x → ∃ y, algebra_map R (fraction_ring R) y = x)
+
+lemma alg_hom.algebra_map_eq_apply {R A B : Type*} [comm_semiring R] [semiring A] [semiring B]
+  [algebra R A] [algebra R B] (f : A →ₐ[R] B) {y : R} {x : A} (h : algebra_map R A y = x) :
+  algebra_map R B y = f x :=
+h ▸ (f.commutes _).symm
+
+@[simp] lemma alg_equiv.algebra_map_eq_apply {R A B : Type*} [comm_semiring R] [semiring A] [semiring B]
+  [algebra R A] [algebra R B] (e : A ≃ₐ[R] B) {y : R} {x : A} :
+  (algebra_map R B y = e x) ↔ (algebra_map R A y = x) :=
+⟨λ h, by simpa using e.symm.to_alg_hom.algebra_map_eq_apply h,
+ λ h, e.to_alg_hom.algebra_map_eq_apply h⟩
+
+section iff
+
+variables {R : Type*} [integral_domain R] (K : Type*) [field K] [algebra R K] [is_fraction_ring R K]
+
+/-- `R` is integrally closed iff all integral elements of its fraction field `K`
+are also elements of `R`. -/
+theorem is_integrally_closed_iff :
+  is_integrally_closed R ↔ ∀ {x : K}, is_integral R x → ∃ y, algebra_map R K y = x :=
+begin
+  let e : K ≃ₐ[R] fraction_ring R := is_localization.alg_equiv R⁰_ _,
+  split,
+  { rintros ⟨cl⟩,
+    refine λ x hx, _,
+    obtain ⟨y, hy⟩ := cl ((is_integral_alg_equiv e).mpr hx),
+    exact ⟨y, e.algebra_map_eq_apply.mp hy⟩ },
+  { rintros cl,
+    refine ⟨λ x hx, _⟩,
+    obtain ⟨y, hy⟩ := cl ((is_integral_alg_equiv e.symm).mpr hx),
+    exact ⟨y, e.symm.algebra_map_eq_apply.mp hy⟩ },
+end
+
+/-- `R` is integrally closed iff it is the integral closure of itself in its field of fractions. -/
+theorem is_integrally_closed_iff_is_integral_closure :
+  is_integrally_closed R ↔ is_integral_closure R R K :=
+(is_integrally_closed_iff K).trans $
+begin
+  let e : K ≃ₐ[R] fraction_ring R := is_localization.alg_equiv R⁰_ _,
+  split,
+  { intros cl,
+    refine ⟨is_fraction_ring.injective _ _, λ x, ⟨cl, _⟩⟩,
+    rintros ⟨y, y_eq⟩,
+    rw ← y_eq,
+    exact is_integral_algebra_map },
+  { rintros ⟨-, cl⟩ x hx,
+    exact cl.mp hx }
+end
+
+end iff
+
+namespace is_integrally_closed
+
+variables {R : Type*} [integral_domain R] [iic : is_integrally_closed R]
+variables {K : Type*} [field K] [algebra R K] [is_fraction_ring R K]
+
+instance : is_integral_closure R R K :=
+(is_integrally_closed_iff_is_integral_closure K).mp iic
+
+include iic
+
+lemma is_integral_iff {x : K} : is_integral R x ↔ ∃ y, algebra_map R K y = x :=
+is_integral_closure.is_integral_iff
+
+omit iic
+variables {R} (K)
+lemma integral_closure_eq_bot_iff :
+  integral_closure R K = ⊥ ↔ is_integrally_closed R :=
+begin
+  refine eq_bot_iff.trans _,
+  split,
+  { rw is_integrally_closed_iff K,
+    intros h x hx,
+    exact set.mem_range.mp (algebra.mem_bot.mp (h hx)),
+    assumption },
+  { intros h x hx,
+    rw [algebra.mem_bot, set.mem_range],
+    exactI is_integral_iff.mp hx },
+end
+
+include iic
+variables (R K)
+@[simp] lemma integral_closure_eq_bot : integral_closure R K = ⊥ :=
+(integral_closure_eq_bot_iff K).mpr ‹_›
+
+end is_integrally_closed

--- a/src/ring_theory/polynomial/rational_root.lean
+++ b/src/ring_theory/polynomial/rational_root.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 
+import ring_theory.integrally_closed
 import ring_theory.polynomial.scale_roots
-import ring_theory.localization
 
 /-!
 # Rational root theorem and integral root theorem
@@ -122,8 +122,8 @@ lemma integer_of_integral {x : K} :
   is_integral A x → is_integer A x :=
 λ ⟨p, hp, hx⟩, is_integer_of_is_root_of_monic hp hx
 
-lemma integrally_closed : integral_closure A K = ⊥ :=
-eq_bot_iff.mpr (λ x hx, algebra.mem_bot.mpr (integer_of_integral hx))
+instance : is_integrally_closed A :=
+⟨λ x, integer_of_integral⟩
 
 end unique_factorization_monoid
 

--- a/src/ring_theory/polynomial/rational_root.lean
+++ b/src/ring_theory/polynomial/rational_root.lean
@@ -122,6 +122,7 @@ lemma integer_of_integral {x : K} :
   is_integral A x → is_integer A x :=
 λ ⟨p, hp, hx⟩, is_integer_of_is_root_of_monic hp hx
 
+@[priority 100] -- See library note [lower instance priority]
 instance : is_integrally_closed A :=
 ⟨λ x, integer_of_integral⟩
 

--- a/src/ring_theory/valuation/integral.lean
+++ b/src/ring_theory/valuation/integral.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 
-import ring_theory.integral_closure
+import ring_theory.integrally_closed
 import ring_theory.valuation.integers
 
 /-!
@@ -45,6 +45,17 @@ protected lemma integral_closure : integral_closure O R = ⊥ :=
 bot_unique $ λ r hr, let ⟨x, hx⟩ := hv.3 (hv.mem_of_integral hr) in algebra.mem_bot.2 ⟨x, hx⟩
 
 end comm_ring
+
+section fraction_field
+
+variables {K : Type u} {Γ₀ : Type v} [field K] [linear_ordered_comm_group_with_zero Γ₀]
+variables {v : valuation K Γ₀} {O : Type w} [integral_domain O] [algebra O K] [is_fraction_ring O K]
+variables (hv : integers v O)
+
+lemma integrally_closed : is_integrally_closed O :=
+(is_integrally_closed.integral_closure_eq_bot_iff K).mp (valuation.integers.integral_closure hv)
+
+end fraction_field
 
 end integers
 


### PR DESCRIPTION
In this follow-up to #8882, we define the notion of an integrally closed domain `R`, which contains all integral elements of `Frac(R)`.
We show the equivalence to `is_integral_closure R R K` for a field of fractions `K`.
We provide instances for `is_dedekind_domain`s, `unique_fractorization_monoid`s, and to the integers of a valuation. In particular, the rational root theorem provides a proof that `ℤ` is integrally closed.

---

 - [ ] depends on: #8882

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
