### PR TITLE
[Merged by Bors] - fix(ring_theory/polynomial/homogeneous): spelling mistake in `homogeneous`

### DIFF
--- a/src/ring_theory/polynomial/homogeneous.lean
+++ b/src/ring_theory/polynomial/homogeneous.lean
@@ -72,7 +72,7 @@ variables {σ R}
 variables (σ R)
 
 /-- While equal, the former has a convenient definitional reduction. -/
-lemma homogenous_submodule_eq_finsupp_supported [comm_semiring R] (n : ℕ) :
+lemma homogeneous_submodule_eq_finsupp_supported [comm_semiring R] (n : ℕ) :
   homogeneous_submodule σ R n = finsupp.supported _ R {d | ∑ i in d.support, d i = n} :=
 begin
   ext,
@@ -83,7 +83,7 @@ end
 
 variables {σ R}
 
-lemma homogenous_submodule_mul [comm_semiring R] (m n : ℕ) :
+lemma homogeneous_submodule_mul [comm_semiring R] (m n : ℕ) :
   homogeneous_submodule σ R m * homogeneous_submodule σ R n ≤ homogeneous_submodule σ R (m + n) :=
 begin
   rw submodule.mul_le,
@@ -174,7 +174,7 @@ lemma sum {ι : Type*} (s : finset ι) (φ : ι → mv_polynomial σ R) (n : ℕ
 
 lemma mul (hφ : is_homogeneous φ m) (hψ : is_homogeneous ψ n) :
   is_homogeneous (φ * ψ) (m + n) :=
-homogenous_submodule_mul m n $ submodule.mul_mem_mul hφ hψ
+homogeneous_submodule_mul m n $ submodule.mul_mem_mul hφ hψ
 
 lemma prod {ι : Type*} (s : finset ι) (φ : ι → mv_polynomial σ R) (n : ι → ℕ)
   (h : ∀ i ∈ s, is_homogeneous (φ i) (n i)) :
@@ -207,7 +207,7 @@ begin
 end
 
 /--
-The homogenous submodules form a graded ring. This instance is used by `direct_sum.comm_semiring`.
+The homogeneous submodules form a graded ring. This instance is used by `direct_sum.comm_semiring`.
 -/
 noncomputable instance homogeneous_submodule.gcomm_monoid :
   direct_sum.gcomm_monoid (λ i, homogeneous_submodule σ R i) :=


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
