### PR TITLE
[Merged by Bors] - refactor(group_theory/*): Move Cauchy's theorem

### DIFF
--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -3,9 +3,9 @@ Copyright (c) 2018 . All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import group_theory.group_action.basic
-import data.fintype.card
-import data.zmod.basic
+
+import group_theory.perm.cycle_type
+
 /-!
 # p-groups
 

--- a/src/group_theory/perm/cycle_type.lean
+++ b/src/group_theory/perm/cycle_type.lean
@@ -407,7 +407,7 @@ by appending the inverse of the product of `v`. -/
   { rw [←list.prod_cons, ←vector.to_list_cons, v.1.cons_head_tail],
     exact v.2 })).symm rfl).trans v.1.cons_head_tail) }
 
-/-- Given a vector `v` of length `n` whose product is 1, make a vector of length `n - 1`
+/-- Given a vector `v` of length `n` whose product is 1, make a vector of length `n - 1`,
 by deleting the last entry of `v`. -/
 def equiv_vector : vectors_prod_eq_one G n ≃ vector G (n - 1) :=
 ((vector_equiv G (n - 1)).trans (if hn : n = 0 then (show vectors_prod_eq_one G (n - 1 + 1) ≃
@@ -423,6 +423,7 @@ lemma card [fintype G] :
 
 variables {G n} {g : G} (v : vectors_prod_eq_one G n) (j k : ℕ)
 
+/-- Rotate a vector whose product is 1. -/
 def rotate : vectors_prod_eq_one G n :=
 ⟨⟨_, (v.1.1.length_rotate k).trans v.1.2⟩, list.prod_rotate_eq_one_of_prod_eq_one v.2 k⟩
 


### PR DESCRIPTION
Moves Cauchy's theorem from `sylow.lean` to `perm/cycle_type.lean`. Now `perm/cycle_type.lean` no longer depends on `sylow.lean`, and `p_group.lean` can use Cauchy's theorem (e.g. for equivalent characterizations of p-groups).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
