### PR TITLE
[Merged by Bors] - feat(algebra/{pointwise,algebra/operations}): add `supr_mul` and `mul_supr`

### DIFF
--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -186,11 +186,11 @@ end
 
 end decidable_eq
 
-lemma submodule.mul_eq_span_mul_set {R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
+lemma mul_eq_span_mul_set {R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
   (s t : submodule R A) : s * t = span R ((s : set A) * (t : set A)) :=
 by rw [← span_mul_span, span_eq, span_eq]
 
-lemma submodule.supr_mul_right {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
+lemma supr_mul_right {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
   (s : ι → submodule R A) (t : submodule R A) : (⨆ i, s i) * t = ⨆ i, s i * t :=
 begin
   suffices : (⨆ i, span R (s i : set A)) * span R t = (⨆ i, span R (s i) * span R t),
@@ -198,7 +198,7 @@ begin
   simp_rw [span_mul_span, ← span_Union, span_mul_span, set.Union_mul_right],
 end
 
-lemma submodule.supr_mul_left {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
+lemma supr_mul_left {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
   (s : ι → submodule R A) (t : submodule R A) : t * (⨆ i, s i) = ⨆ i, t * s i :=
 begin
   suffices : span R (t : set A) * (⨆ i, span R (s i)) = (⨆ i, span R t * span R (s i)),

--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -201,10 +201,9 @@ end
 lemma submodule.supr_mul_left {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
   (s : ι → submodule R A) (t : submodule R A) : t * (⨆ i, s i) = ⨆ i, t * s i :=
 begin
-  conv_rhs { simp only [submodule.mul_eq_span_mul_set], },
-  rw [← (submodule.gi R A).gc.l_supr, set.supr_eq_Union, ← set.Union_mul_left, ← set.supr_eq_Union,
-    ← span_eq (span R (↑t * (⨆ (i : ι), ↑(s i)))), ← submodule.span_mul_span, span_eq, span_eq,
-    ← (submodule.gi R A).l_supr_u],
+  suffices : span R (t : set A) * (⨆ i, span R (s i)) = (⨆ i, span R t * span R (s i)),
+  { simpa only [span_eq] using this },
+  simp_rw [span_mul_span, ← span_Union, span_mul_span, set.Union_mul_left],
 end
 
 lemma mem_span_mul_finite_of_mem_mul {P Q : submodule R A} {x : A} (hx : x ∈ P * Q) :

--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -193,10 +193,9 @@ by rw [← span_mul_span, span_eq, span_eq]
 lemma submodule.supr_mul_right {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
   (s : ι → submodule R A) (t : submodule R A) : (⨆ i, s i) * t = ⨆ i, s i * t :=
 begin
-  conv_rhs { simp only [submodule.mul_eq_span_mul_set], },
-  rw [← (submodule.gi R A).gc.l_supr, set.supr_eq_Union, ← set.Union_mul_right, ← set.supr_eq_Union,
-    ← span_eq (span R ((⨆ (i : ι), ↑(s i)) * ↑t)), ← submodule.span_mul_span, span_eq, span_eq,
-    ← (submodule.gi R A).l_supr_u],
+  suffices : (⨆ i, span R (s i : set A)) * span R t = (⨆ i, span R (s i) * span R t),
+  { simpa only [span_eq] using this },
+  simp_rw [span_mul_span, ← span_Union, span_mul_span, set.Union_mul_right],
 end
 
 lemma submodule.supr_mul_left {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]

--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -198,7 +198,7 @@ begin
   simp_rw [span_mul_span, ← span_Union, span_mul_span, set.Union_mul],
 end
 
-lemma mul_supr_mul {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
+lemma mul_supr {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
   (s : ι → submodule R A) (t : submodule R A) : t * (⨆ i, s i) = ⨆ i, t * s i :=
 begin
   suffices : span R (t : set A) * (⨆ i, span R (s i)) = (⨆ i, span R t * span R (s i)),

--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -190,7 +190,7 @@ lemma mul_eq_span_mul_set {R A : Type*} [comm_semiring R] [semiring A] [algebra 
   (s t : submodule R A) : s * t = span R ((s : set A) * (t : set A)) :=
 by rw [← span_mul_span, span_eq, span_eq]
 
-lemma supr_mul_right {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
+lemma supr_mul {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
   (s : ι → submodule R A) (t : submodule R A) : (⨆ i, s i) * t = ⨆ i, s i * t :=
 begin
   suffices : (⨆ i, span R (s i : set A)) * span R t = (⨆ i, span R (s i) * span R t),
@@ -198,7 +198,7 @@ begin
   simp_rw [span_mul_span, ← span_Union, span_mul_span, set.Union_mul_right],
 end
 
-lemma supr_mul_left {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
+lemma mul_supr_mul {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
   (s : ι → submodule R A) (t : submodule R A) : t * (⨆ i, s i) = ⨆ i, t * s i :=
 begin
   suffices : span R (t : set A) * (⨆ i, span R (s i)) = (⨆ i, span R t * span R (s i)),

--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -27,13 +27,14 @@ It is proved that `submodule R A` is a semiring, and also an algebra over `set A
 multiplication of submodules, division of subodules, submodule semiring
 -/
 
-universes u v
+universes uι u v
 
 open algebra set
 open_locale pointwise
 
 namespace submodule
 
+variables {ι : Sort uι}
 variables {R : Type u} [comm_semiring R]
 
 section ring
@@ -186,20 +187,17 @@ end
 
 end decidable_eq
 
-lemma mul_eq_span_mul_set {R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
-  (s t : submodule R A) : s * t = span R ((s : set A) * (t : set A)) :=
+lemma mul_eq_span_mul_set (s t : submodule R A) : s * t = span R ((s : set A) * (t : set A)) :=
 by rw [← span_mul_span, span_eq, span_eq]
 
-lemma supr_mul {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
-  (s : ι → submodule R A) (t : submodule R A) : (⨆ i, s i) * t = ⨆ i, s i * t :=
+lemma supr_mul (s : ι → submodule R A) (t : submodule R A) : (⨆ i, s i) * t = ⨆ i, s i * t :=
 begin
   suffices : (⨆ i, span R (s i : set A)) * span R t = (⨆ i, span R (s i) * span R t),
   { simpa only [span_eq] using this },
   simp_rw [span_mul_span, ← span_Union, span_mul_span, set.Union_mul],
 end
 
-lemma mul_supr {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
-  (s : ι → submodule R A) (t : submodule R A) : t * (⨆ i, s i) = ⨆ i, t * s i :=
+lemma mul_supr (t : submodule R A) (s : ι → submodule R A) : t * (⨆ i, s i) = ⨆ i, t * s i :=
 begin
   suffices : span R (t : set A) * (⨆ i, span R (s i)) = (⨆ i, span R t * span R (s i)),
   { simpa only [span_eq] using this },

--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -207,6 +207,7 @@ begin
     ← span_eq (span R (↑t * (⨆ (i : ι), ↑(s i)))), ← submodule.span_mul_span, span_eq, span_eq,
     ← (submodule.gi R A).l_supr_u],
 end
+
 lemma mem_span_mul_finite_of_mem_mul {P Q : submodule R A} {x : A} (hx : x ∈ P * Q) :
   ∃ (T T' : finset A), (T : set A) ⊆ P ∧ (T' : set A) ⊆ Q ∧ x ∈ span R (T * T' : set A) :=
 submodule.mem_span_mul_finite_of_mem_span_mul

--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -186,6 +186,27 @@ end
 
 end decidable_eq
 
+lemma submodule.mul_eq_span_mul_set {R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
+  (s t : submodule R A) : s * t = span R ((s : set A) * (t : set A)) :=
+by rw [← span_mul_span, span_eq, span_eq]
+
+lemma submodule.supr_mul_right {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
+  (s : ι → submodule R A) (t : submodule R A) : (⨆ i, s i) * t = ⨆ i, s i * t :=
+begin
+  conv_rhs { simp only [submodule.mul_eq_span_mul_set], },
+  rw [← (submodule.gi R A).gc.l_supr, set.supr_eq_Union, ← set.Union_mul_right, ← set.supr_eq_Union,
+    ← span_eq (span R ((⨆ (i : ι), ↑(s i)) * ↑t)), ← submodule.span_mul_span, span_eq, span_eq,
+    ← (submodule.gi R A).l_supr_u],
+end
+
+lemma submodule.supr_mul_left {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
+  (s : ι → submodule R A) (t : submodule R A) : t * (⨆ i, s i) = ⨆ i, t * s i :=
+begin
+  conv_rhs { simp only [submodule.mul_eq_span_mul_set], },
+  rw [← (submodule.gi R A).gc.l_supr, set.supr_eq_Union, ← set.Union_mul_left, ← set.supr_eq_Union,
+    ← span_eq (span R (↑t * (⨆ (i : ι), ↑(s i)))), ← submodule.span_mul_span, span_eq, span_eq,
+    ← (submodule.gi R A).l_supr_u],
+end
 lemma mem_span_mul_finite_of_mem_mul {P Q : submodule R A} {x : A} (hx : x ∈ P * Q) :
   ∃ (T T' : finset A), (T : set A) ⊆ P ∧ (T' : set A) ⊆ Q ∧ x ∈ span R (T * T' : set A) :=
 submodule.mem_span_mul_finite_of_mem_span_mul

--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -195,7 +195,7 @@ lemma supr_mul {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
 begin
   suffices : (⨆ i, span R (s i : set A)) * span R t = (⨆ i, span R (s i) * span R t),
   { simpa only [span_eq] using this },
-  simp_rw [span_mul_span, ← span_Union, span_mul_span, set.Union_mul_right],
+  simp_rw [span_mul_span, ← span_Union, span_mul_span, set.Union_mul],
 end
 
 lemma mul_supr_mul {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
@@ -203,7 +203,7 @@ lemma mul_supr_mul {ι R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
 begin
   suffices : span R (t : set A) * (⨆ i, span R (s i)) = (⨆ i, span R t * span R (s i)),
   { simpa only [span_eq] using this },
-  simp_rw [span_mul_span, ← span_Union, span_mul_span, set.Union_mul_left],
+  simp_rw [span_mul_span, ← span_Union, span_mul_span, set.mul_Union],
 end
 
 lemma mem_span_mul_finite_of_mem_mul {P Q : submodule R A} {x : A} (hx : x ∈ P * Q) :

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -238,6 +238,16 @@ Union_image_left _
 lemma Union_mul_right_image [has_mul α] : (⋃ a ∈ t, (λ x, x * a) '' s) = s * t :=
 Union_image_right _
 
+@[to_additive]
+lemma Union_mul_right {α ι : Type*} [has_mul α] (s : ι → set α) (t : set α) :
+  (⋃ i, s i) * t = ⋃ i, (s i * t) :=
+image2_Union_left _ _ _
+
+@[to_additive]
+lemma Union_mul_left {α ι : Type*} [has_mul α] (s : ι → set α) (t : set α) :
+  t * (⋃ i, s i) = ⋃ i, (t * s i) :=
+image2_Union_right _ _ _
+
 @[simp, to_additive]
 lemma univ_mul_univ [monoid α] : (univ : set α) * univ = univ :=
 begin

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -239,12 +239,12 @@ lemma Union_mul_right_image [has_mul α] : (⋃ a ∈ t, (λ x, x * a) '' s) = s
 Union_image_right _
 
 @[to_additive]
-lemma Union_mul_right {α ι : Type*} [has_mul α] (s : ι → set α) (t : set α) :
+lemma Union_mul {α ι : Type*} [has_mul α] (s : ι → set α) (t : set α) :
   (⋃ i, s i) * t = ⋃ i, (s i * t) :=
 image2_Union_left _ _ _
 
 @[to_additive]
-lemma Union_mul_left {α ι : Type*} [has_mul α] (s : ι → set α) (t : set α) :
+lemma mul_Union {α ι : Type*} [has_mul α] (s : ι → set α) (t : set α) :
   t * (⋃ i, s i) = ⋃ i, (t * s i) :=
 image2_Union_right _ _ _
 

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -244,7 +244,7 @@ lemma Union_mul {ι : Sort*} [has_mul α] (s : ι → set α) (t : set α) :
 image2_Union_left _ _ _
 
 @[to_additive]
-lemma mul_Union {ι : Sort*} [has_mul α] (s : ι → set α) (t : set α) :
+lemma mul_Union {ι : Sort*} [has_mul α] (t : set α) (s : ι → set α) :
   t * (⋃ i, s i) = ⋃ i, (t * s i) :=
 image2_Union_right _ _ _
 

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -239,12 +239,12 @@ lemma Union_mul_right_image [has_mul α] : (⋃ a ∈ t, (λ x, x * a) '' s) = s
 Union_image_right _
 
 @[to_additive]
-lemma Union_mul {α ι : Type*} [has_mul α] (s : ι → set α) (t : set α) :
+lemma Union_mul {ι : Sort*} [has_mul α] (s : ι → set α) (t : set α) :
   (⋃ i, s i) * t = ⋃ i, (s i * t) :=
 image2_Union_left _ _ _
 
 @[to_additive]
-lemma mul_Union {α ι : Type*} [has_mul α] (s : ι → set α) (t : set α) :
+lemma mul_Union {ι : Sort*} [has_mul α] (s : ι → set α) (t : set α) :
   t * (⋃ i, s i) = ⋃ i, (t * s i) :=
 image2_Union_right _ _ _
 


### PR DESCRIPTION
Requested by @eric-wieser  on Zulip, https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/submodule.2Esupr_mul/near/250122435
and a couple of helper lemmas.

Co-authored-by: Eric Wieser wieser.eric@gmail.com



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
