### PR TITLE
[Merged by Bors] - fix(data/complex/basic): better formulas for nsmul and gsmul on complex to fix a diamond

### DIFF
--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -133,10 +133,22 @@ ext_iff.2 $ by simp
 
 /-! ### Commutative ring instance and lemmas -/
 
+/- We use a nonstandard formula for the `ℕ` and `ℤ` actions to make sure there is no
+diamond from the other actions they inherit through the `ℝ`-action on `ℂ` and action transitivity
+defined in `data.complex.module.lean`. -/
 instance : comm_ring ℂ :=
-by refine_struct { zero := (0 : ℂ), add := (+), neg := has_neg.neg, sub := has_sub.sub, one := 1,
-  mul := (*), nsmul := @nsmul_rec _ ⟨(0)⟩ ⟨(+)⟩, npow := @npow_rec _ ⟨(1)⟩ ⟨(*)⟩,
-  gsmul := @gsmul_rec _ ⟨(0)⟩ ⟨(+)⟩ ⟨has_neg.neg⟩ };
+by refine_struct
+  { zero := (0 : ℂ),
+    add := (+),
+    neg := has_neg.neg,
+    sub := has_sub.sub,
+    one := 1,
+    mul := (*),
+    zero_add := λ z, by { apply ext_iff.2, simp },
+    add_zero := λ z, by { apply ext_iff.2, simp },
+    nsmul := λ n z, ⟨n • z.re - 0 * z.im, n • z.im + 0 * z.re⟩,
+    npow := @npow_rec _ ⟨(1)⟩ ⟨(*)⟩,
+    gsmul := λ n z, ⟨n • z.re - 0 * z.im, n • z.im + 0 * z.re⟩ };
 intros; try { refl }; apply ext_iff.2; split; simp; {ring1 <|> ring_nf}
 
 /-- This shortcut instance ensures we do not find `ring` via the noncomputable `complex.field`

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -42,7 +42,7 @@ section
 variables [has_scalar R ℝ]
 
 /- The useless `0` multiplication in `smul` is to make sure that
-`restrict_scalars.module ℝ ℂ ℂ  = complex.module` definitionally. -/
+`restrict_scalars.module ℝ ℂ ℂ = complex.module` definitionally. -/
 instance : has_scalar R ℂ :=
 { smul := λ r x, ⟨r • x.re - 0 * x.im, r • x.im + 0 * x.re⟩ }
 

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -8,11 +8,16 @@ import algebra.module.pi
 import data.polynomial.basic
 import group_theory.group_action.prod
 import group_theory.group_action.units
+import data.complex.module
 
 /-! # Tests that instances do not form diamonds -/
 
 /-! ## Scalar action instances -/
 section has_scalar
+
+example :
+  (sub_neg_monoid.has_scalar_int : has_scalar ℤ ℂ) = (complex.has_scalar : has_scalar ℤ ℂ) :=
+rfl
 
 section units
 


### PR DESCRIPTION
As diagnosed by @eric-wieser in https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/diamond.20in.20data.2Ecomplex.2Emodule/near/250318167

After the PR,
```lean
example :
  (sub_neg_monoid.has_scalar_int : has_scalar ℤ ℂ) = (complex.has_scalar : has_scalar ℤ ℂ) :=
rfl
```
works fine, while it fails on current master.
