### PR TITLE
[Merged by Bors] - fix(order/rel_classes): remove looping instance

### DIFF
--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -65,7 +65,6 @@ instance [preorder α] : is_antisymm α (<) := is_asymm.is_antisymm _
 instance [preorder α] : is_antisymm α (>) := is_asymm.is_antisymm _
 instance [preorder α] : is_strict_order α (<) := {}
 instance [preorder α] : is_strict_order α (>) := {}
-instance preorder.is_total_preorder [preorder α] [is_total α (≤)] : is_total_preorder α (≤) := {}
 instance [partial_order α] : is_antisymm α (≤) := ⟨@le_antisymm _ _⟩
 instance [partial_order α] : is_antisymm α (≥) := is_antisymm.swap _
 instance [partial_order α] : is_partial_order α (≤) := {}


### PR DESCRIPTION
This instance causes loop with `is_total_preorder.to_is_total`, and was unused in the library.

Caught by the new linter (#8932).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
