### PR TITLE
[Merged by Bors] - refactor(order/atoms): reorder arguments of `is_simple_lattice.fintype`

### DIFF
--- a/src/order/atoms.lean
+++ b/src/order/atoms.lean
@@ -299,6 +299,8 @@ end is_simple_lattice
 
 namespace is_simple_lattice
 
+section bounded_lattice
+
 variables [bounded_lattice α] [is_simple_lattice α]
 
 /-- A simple `bounded_lattice` is also distributive. -/
@@ -314,8 +316,12 @@ instance : is_atomic α :=
 @[priority 100]
 instance : is_coatomic α := is_atomic_dual_iff_is_coatomic.1 is_simple_lattice.is_atomic
 
+end bounded_lattice
+
+/- It is important that in this section `is_simple_lattice` is the last type-class argument. -/
 section decidable_eq
-variable [decidable_eq α]
+
+variables [decidable_eq α] [bounded_lattice α] [is_simple_lattice α]
 
 /-- Every simple lattice is order-isomorphic to `bool`. -/
 def order_iso_bool : α ≃o bool :=
@@ -331,6 +337,8 @@ def order_iso_bool : α ≃o bool :=
       { simp [bot_ne_top] } }
   end }
 
+/- It is important that `is_simple_lattice` is the last type-class argument of this instance,
+so that type-class inference fails quickly if it doesn't apply. -/
 @[priority 200]
 instance : fintype α := fintype.of_equiv bool (order_iso_bool.to_equiv).symm
 
@@ -350,6 +358,7 @@ protected def boolean_algebra : boolean_algebra α :=
 
 end decidable_eq
 
+variables [bounded_lattice α] [is_simple_lattice α]
 open_locale classical
 
 /-- A simple `bounded_lattice` is also complete. -/


### PR DESCRIPTION
Previously, this instance would first look for `decidable_eq` instances and after that for `is_simple_lattice` instances. The latter has only 4 instances, while the former takes hundreds of steps. Reordering the arguments makes a lot of type-class searches fail a lot quicker.

Caught by the new linter (#8932).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
