### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal): generalize from `integral_closure` to `is_integral_closure`

### DIFF
--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -61,11 +61,17 @@ lemma dimension_le_one.principal_ideal_ring
   [is_principal_ideal_ring A] : dimension_le_one A :=
 λ p nonzero prime, by { haveI := prime, exact is_prime.to_maximal_ideal nonzero }
 
+lemma dimension_le_one.is_integral_closure (B : Type*) [integral_domain B]
+  [nontrivial R] [algebra R A] [algebra R B] [algebra B A] [is_scalar_tower R B A]
+  [is_integral_closure B R A] (h : dimension_le_one R) :
+  dimension_le_one B :=
+λ p ne_bot prime, by exactI
+  is_integral_closure.is_maximal_of_is_maximal_comap A p
+    (h _ (is_integral_closure.comap_ne_bot A ne_bot) infer_instance)
+
 lemma dimension_le_one.integral_closure [nontrivial R] [algebra R A]
   (h : dimension_le_one R) : dimension_le_one (integral_closure R A) :=
-λ p ne_bot prime, by exactI
-  integral_closure.is_maximal_of_is_maximal_comap p
-    (h _ (integral_closure.comap_ne_bot ne_bot) infer_instance)
+h.is_integral_closure R A (integral_closure R A)
 
 end ring
 

--- a/src/ring_theory/ideal/over.lean
+++ b/src/ring_theory/ideal/over.lean
@@ -225,25 +225,50 @@ lemma is_maximal_comap_of_is_integral_of_is_maximal' {R S : Type*} [comm_ring R]
   (f : R →+* S) (hf : f.is_integral) (I : ideal S) (hI : I.is_maximal) : is_maximal (I.comap f) :=
 @is_maximal_comap_of_is_integral_of_is_maximal R _ S _ f.to_algebra hf I hI
 
+section is_integral_closure
+
+variables (S) {A : Type*} [integral_domain A]
+variables [algebra R A] [algebra A S] [is_scalar_tower R A S] [is_integral_closure A R S]
+
+lemma is_integral_closure.comap_ne_bot [nontrivial R] {I : ideal A}
+  (I_ne_bot : I ≠ ⊥) : I.comap (algebra_map R A) ≠ ⊥ :=
+let ⟨x, x_mem, x_ne_zero⟩ := I.ne_bot_iff.mp I_ne_bot in
+comap_ne_bot_of_integral_mem x_ne_zero x_mem (is_integral_closure.is_integral R S x)
+
+lemma is_integral_closure.eq_bot_of_comap_eq_bot [nontrivial R] {I : ideal A} :
+  I.comap (algebra_map R A) = ⊥ → I = ⊥ :=
+imp_of_not_imp_not _ _ (is_integral_closure.comap_ne_bot S)
+
+lemma is_integral_closure.comap_lt_comap {I J : ideal A} [I.is_prime]
+  (I_lt_J : I < J) :
+  I.comap (algebra_map R A) < J.comap (algebra_map _ _) :=
+let ⟨I_le_J, x, hxJ, hxI⟩ := set_like.lt_iff_le_and_exists.mp I_lt_J in
+comap_lt_comap_of_integral_mem_sdiff I_le_J ⟨hxJ, hxI⟩ (is_integral_closure.is_integral R S x)
+
+lemma is_integral_closure.is_maximal_of_is_maximal_comap
+  (I : ideal A) [I.is_prime]
+  (hI : is_maximal (I.comap (algebra_map R A))) : is_maximal I :=
+is_maximal_of_is_integral_of_is_maximal_comap (λ x, is_integral_closure.is_integral R S x) I hI
+
+end is_integral_closure
+
 lemma integral_closure.comap_ne_bot [nontrivial R] {I : ideal (integral_closure R S)}
   (I_ne_bot : I ≠ ⊥) : I.comap (algebra_map R (integral_closure R S)) ≠ ⊥ :=
-let ⟨x, x_mem, x_ne_zero⟩ := I.ne_bot_iff.mp I_ne_bot in
-comap_ne_bot_of_integral_mem x_ne_zero x_mem (integral_closure.is_integral x)
+is_integral_closure.comap_ne_bot S I_ne_bot
 
 lemma integral_closure.eq_bot_of_comap_eq_bot [nontrivial R] {I : ideal (integral_closure R S)} :
   I.comap (algebra_map R (integral_closure R S)) = ⊥ → I = ⊥ :=
-imp_of_not_imp_not _ _ integral_closure.comap_ne_bot
+is_integral_closure.eq_bot_of_comap_eq_bot S
 
 lemma integral_closure.comap_lt_comap {I J : ideal (integral_closure R S)} [I.is_prime]
   (I_lt_J : I < J) :
   I.comap (algebra_map R (integral_closure R S)) < J.comap (algebra_map _ _) :=
-let ⟨I_le_J, x, hxJ, hxI⟩ := set_like.lt_iff_le_and_exists.mp I_lt_J in
-comap_lt_comap_of_integral_mem_sdiff I_le_J ⟨hxJ, hxI⟩ (integral_closure.is_integral x)
+is_integral_closure.comap_lt_comap S I_lt_J
 
 lemma integral_closure.is_maximal_of_is_maximal_comap
   (I : ideal (integral_closure R S)) [I.is_prime]
   (hI : is_maximal (I.comap (algebra_map R (integral_closure R S)))) : is_maximal I :=
-is_maximal_of_is_integral_of_is_maximal_comap (λ x, integral_closure.is_integral x) I hI
+is_integral_closure.is_maximal_of_is_maximal_comap S I hI
 
 /-- `comap (algebra_map R S)` is a surjection from the prime spec of `R` to prime spec of `S`.
 `hP : (algebra_map R S).ker ≤ P` is a slight generalization of the extension being injective -/


### PR DESCRIPTION
This PR restates a couple of lemmas about ideals the integral closure to use an instance of `is_integral_closure` instead. The originals are still available, but their proofs are now oneliners shelling out to `is_integral_closure`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
