### PR TITLE
[Merged by Bors] - feat(algebra/ordered_ring): `linear_ordered_semiring` extends `linear_ordered_add_comm_monoid`

### DIFF
--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -655,6 +655,10 @@ lemma neg_of_mul_pos_right (h : 0 < a * b) (ha : a ≤ 0) : b < 0 :=
 by haveI := @linear_order.decidable_le α _; exact
 lt_of_not_ge (λ hb, absurd h (decidable.mul_nonpos_of_nonpos_of_nonneg ha hb).not_lt)
 
+instance linear_ordered_semiring.to_linear_ordered_add_comm_monoid {α : Type*}
+  [h : linear_ordered_semiring α] : linear_ordered_add_comm_monoid R :=
+{ ..h }
+
 @[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_semiring.to_no_top_order {α : Type*} [linear_ordered_semiring α] :
   no_top_order α :=

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -655,6 +655,7 @@ lemma neg_of_mul_pos_right (h : 0 < a * b) (ha : a ≤ 0) : b < 0 :=
 by haveI := @linear_order.decidable_le α _; exact
 lt_of_not_ge (λ hb, absurd h (decidable.mul_nonpos_of_nonpos_of_nonneg ha hb).not_lt)
 
+@[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_semiring.to_linear_ordered_add_comm_monoid {α : Type*}
   [h : linear_ordered_semiring α] : linear_ordered_add_comm_monoid α :=
 { ..h }

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -414,7 +414,8 @@ such that multiplication with a positive number and addition are monotone.
 -- but be warned that the instances involving `domain` may cause
 -- typeclass search loops.
 @[protect_proj]
-class linear_ordered_semiring (α : Type u) extends ordered_semiring α, linear_order α, nontrivial α
+class linear_ordered_semiring (α : Type u)
+  extends ordered_semiring α, linear_ordered_add_comm_monoid α, nontrivial α
 
 section linear_ordered_semiring
 variables [linear_ordered_semiring α] {a b c d : α}
@@ -654,11 +655,6 @@ lt_of_not_ge (λ ha, absurd h (decidable.mul_nonpos_of_nonneg_of_nonpos ha hb).n
 lemma neg_of_mul_pos_right (h : 0 < a * b) (ha : a ≤ 0) : b < 0 :=
 by haveI := @linear_order.decidable_le α _; exact
 lt_of_not_ge (λ hb, absurd h (decidable.mul_nonpos_of_nonpos_of_nonneg ha hb).not_lt)
-
-@[priority 100] -- see Note [lower instance priority]
-instance linear_ordered_semiring.to_linear_ordered_add_comm_monoid {α : Type*}
-  [h : linear_ordered_semiring α] : linear_ordered_add_comm_monoid α :=
-{ ..h }
 
 @[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_semiring.to_no_top_order {α : Type*} [linear_ordered_semiring α] :

--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -656,7 +656,7 @@ by haveI := @linear_order.decidable_le α _; exact
 lt_of_not_ge (λ hb, absurd h (decidable.mul_nonpos_of_nonpos_of_nonneg ha hb).not_lt)
 
 instance linear_ordered_semiring.to_linear_ordered_add_comm_monoid {α : Type*}
-  [h : linear_ordered_semiring α] : linear_ordered_add_comm_monoid R :=
+  [h : linear_ordered_semiring α] : linear_ordered_add_comm_monoid α :=
 { ..h }
 
 @[priority 100] -- see Note [lower instance priority]


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
