### PR TITLE
[Merged by Bors] - docs(set_theory/lists): add module docstring and def docstrings

### DIFF
--- a/src/set_theory/lists.lean
+++ b/src/set_theory/lists.lean
@@ -10,12 +10,30 @@ import data.list.basic
 
 In this file we define finite hereditary lists. This is useful for calculations in naive set theory.
 
-## Main declarations
-
-A ZFA list is inductively defined as
+We distinguish two kinds of ZFA lists:
+* Atoms. Directly correspond to an element of the original type.
+* Proper ZFA lists. Can thought of (but aren't implemented) as a list of ZFA lists (not necessarily
+  proper).
 
 For example, `lists ℕ` contains stuff like `23`, `[]`, `[37]`, `[1, [[2], 3], 4]`.
 
+## Implementation note
+
+As we want to be able to append both atoms and proper ZFA lists to proper ZFA lists, it's handy that
+atoms and proper ZFA lists belong to the same type, even though atoms of `α` could be modelled as
+`α` directly. But we don't want to be able to append anything to atoms.
+
+This calls for a two-steps definition of ZFA lists:
+* First, define ZFA prelists as atoms and proper ZFA prelists. Those proper ZFA prelists are defined
+  by inductive appending of (not necessarily proper) ZFA lists.
+* Second, define ZFA lists by rubbing out the distinction between atoms and proper lists.
+
+## Main declarations
+
+* `lists' α ff`: Atoms as ZFA prelists. Basically a copy of `α`.
+* `lists' α tt`: Proper ZFA prelists. Defined inductively from the empty ZFA prelist (`lists'.nil`)
+  and from appending a ZFA prelist to a proper ZFA prelist (`lists'.cons a l`).
+* `lists α`: ZFA lists. Sum of the atoms and proper ZFA prelists.
 
 ## TODO
 

--- a/src/set_theory/lists.lean
+++ b/src/set_theory/lists.lean
@@ -68,7 +68,7 @@ instance [inhabited α] : ∀ b, inhabited (lists' α b)
 def cons : lists α → lists' α tt → lists' α tt
 | ⟨b, a⟩ l := cons' a l
 
-/-- Converts a ZFA prelist to a `list` of ZFA lists. Atoms are yeeted onto `[]`. -/
+/-- Converts a ZFA prelist to a `list` of ZFA lists. Atoms are sent to `[]`. -/
 @[simp] def to_list : ∀ {b}, lists' α b → list (lists α)
 | _ (atom a)    := []
 | _ nil         := []
@@ -110,8 +110,11 @@ with lists'.subset : lists' α tt → lists' α tt → Prop
   lists'.subset l l' → lists'.subset (lists'.cons a l) l'
 local infix ` ~ `:50 := lists.equiv
 
-run_cmd tactic.add_doc_string `lists.equiv "Equivalence of ZFA lists. Defined inductively."
-run_cmd tactic.add_doc_string `lists'.subset "Subset relation for ZFA lists. Defined inductively."
+/-- Equivalence of ZFA lists. Defined inductively. -/
+add_decl_doc lists.equiv
+
+/-- Subset relation for ZFA lists. Defined inductively. -/
+add_decl_doc lists'.subset
 
 namespace lists'
 
@@ -184,7 +187,7 @@ namespace lists
 /-- Converts a proper ZFA prelist to a ZFA list. -/
 @[pattern] def of' (l : lists' α tt) : lists α := ⟨_, l⟩
 
-/-- Converts a ZFA list to a `list` of ZFA lists. Atoms are yeeted onto `[]`. -/
+/-- Converts a ZFA list to a `list` of ZFA lists. Atoms are sent to `[]`. -/
 @[simp] def to_list : lists α → list (lists α)
 | ⟨b, l⟩ := l.to_list
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
I didn't put docstrings on `equiv.decidable_meas` (this one is very obsucre to me. What does it do?) nor `equiv.decidable`, `subset.decidable`, `mem.decidable` but they don't even seem to pop up in `nolints.txt`.
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
