### PR TITLE
[Merged by Bors] - lint(tactic/*): break long lines

### DIFF
--- a/src/tactic/converter/interactive.lean
+++ b/src/tactic/converter/interactive.lean
@@ -50,16 +50,17 @@ meta def find (p : parse lean.parser.pexpr) (c : itactic) : old_conv unit :=
   pat ← tactic.pexpr_to_pattern p,
   s   ← simp_lemmas.mk_default, -- to be able to use congruence lemmas @[congr]
   (found, new_lhs, pr) ←
-     tactic.ext_simplify_core ff {zeta := ff, beta := ff, single_pass := tt, eta := ff, proj := ff} s
-       (λ u, return u)
-       (λ found s r p e, do
-         guard (not found),
-         matched ← (tactic.match_pattern pat e >> return tt) <|> return ff,
-         guard matched,
-         ⟨u, new_e, pr⟩ ← c r e,
-         return (tt, new_e, pr, ff))
-       (λ a s r p e, tactic.failed)
-       r lhs,
+    tactic.ext_simplify_core ff {zeta := ff, beta := ff, single_pass := tt, eta := ff, proj := ff}
+      s
+      (λ u, return u)
+      (λ found s r p e, do
+        guard (not found),
+        matched ← (tactic.match_pattern pat e >> return tt) <|> return ff,
+        guard matched,
+        ⟨u, new_e, pr⟩ ← c r e,
+        return (tt, new_e, pr, ff))
+      (λ a s r p e, tactic.failed)
+      r lhs,
   if not found then tactic.fail "find converter failed, pattern was not found"
   else return ⟨(), new_lhs, some pr⟩
 

--- a/src/tactic/converter/old_conv.lean
+++ b/src/tactic/converter/old_conv.lean
@@ -269,7 +269,8 @@ meta def findp : pexpr → old_conv unit → old_conv unit :=
   find_pattern pat c r e
 
 meta def conversion (c : old_conv unit) : tactic unit :=
-do (r, lhs, rhs) ← (target_lhs_rhs <|> fail "conversion failed, target is not of the form 'lhs R rhs'"),
+do (r, lhs, rhs) ←
+    (target_lhs_rhs <|> fail "conversion failed, target is not of the form 'lhs R rhs'"),
    (new_lhs, pr) ← to_tactic c r lhs,
    (unify new_lhs rhs <|>
      do new_lhs_fmt ← pp new_lhs,

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -2353,9 +2353,10 @@ then do
   user_attr_const ← mk_const user_attr_nm,
   tac ← eval_pexpr (tactic unit)
     ``(user_attribute.set %%user_attr_const %%c_name (default _) %%persistent) <|>
-    fail!("Cannot set attribute @[{attr_name}]. The corresponding user attribute {user_attr_nm}" ++
-    " has a parameter without a default value.
-Solution: provide an `inhabited` instance."),
+    fail! ("Cannot set attribute @[{attr_name}].\n" ++
+      "The corresponding user attribute {user_attr_nm} " ++
+      "has a parameter without a default value.\n" ++
+      "Solution: provide an `inhabited` instance."),
   tac
 else fail msg
 

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -2191,7 +2191,8 @@ do d ← get_decl n,
      (eval_expr (tactic unit) e) >>= (λ t, t >> (name.to_string <$> strip_prefix n))
    else if (t =ₐ `(tactic string)) then
      (eval_expr (tactic string) e) >>= (λ t, t)
-   else fail!"name_to_tactic cannot take `{n} as input: its type must be `tactic string` or `tactic unit`"
+   else fail!
+     "name_to_tactic cannot take `{n} as input: its type must be `tactic string` or `tactic unit`"
 
 /-- auxiliary function for `apply_under_n_pis` -/
 private meta def apply_under_n_pis_aux (func arg : pexpr) : ℕ → ℕ → expr → pexpr
@@ -2352,8 +2353,9 @@ then do
   user_attr_const ← mk_const user_attr_nm,
   tac ← eval_pexpr (tactic unit)
     ``(user_attribute.set %%user_attr_const %%c_name (default _) %%persistent) <|>
-    fail!"Cannot set attribute @[{attr_name}]. The corresponding user attribute {user_attr_nm} has a parameter without a default value.
-Solution: provide an `inhabited` instance.",
+    fail!("Cannot set attribute @[{attr_name}]. The corresponding user attribute {user_attr_nm}" ++
+    " has a parameter without a default value.
+Solution: provide an `inhabited` instance."),
   tac
 else fail msg
 

--- a/src/tactic/delta_instance.lean
+++ b/src/tactic/delta_instance.lean
@@ -64,7 +64,8 @@ if env.is_inductive new_decl_name then return ff else
 do new_decl ← get_decl new_decl_name,
    new_decl_pexpr ← resolve_name new_decl_name,
    arity ← get_pexpr_arg_arity_with_tgt cls new_decl.type,
-   tgt ← to_expr $ apply_under_n_pis cls new_decl_pexpr new_decl.type (new_decl.type.pi_arity - arity),
+   tgt ← to_expr $ apply_under_n_pis cls new_decl_pexpr new_decl.type
+     (new_decl.type.pi_arity - arity),
    (vs, tgt') ← open_pis tgt,
    tgt ← whnf tgt' transparency.none >>= pis vs,
    (_, inst) ← solve_aux tgt $ tactic.delta_instance [new_decl_name],
@@ -72,7 +73,8 @@ do new_decl ← get_decl new_decl_name,
    inst ← replace_univ_metas_with_univ_params inst,
    tgt ← instantiate_mvars tgt,
    nm ← get_unused_decl_name $ new_decl_name <.> (delta_instance_name cls),
-   add_protected_decl $ declaration.defn nm inst.collect_univ_params tgt inst new_decl.reducibility_hints new_decl.is_trusted,
+   add_protected_decl $ declaration.defn nm inst.collect_univ_params tgt inst
+     new_decl.reducibility_hints new_decl.is_trusted,
    set_basic_attribute `instance nm tt,
    return tt
 

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -118,7 +118,8 @@ meta def fin_cases : parse hyp → parse (tk "with" *> texpr)? → tactic unit
 | none none := focus1 $ do
     ctx ← local_context,
     ctx.mfirst (fin_cases_at none) <|>
-      fail "No hypothesis of the forms `x ∈ A`, where `A : finset X`, `A : list X`, or `A : multiset X`, or `x : A`, with `[fintype A]`."
+      fail ("No hypothesis of the forms `x ∈ A`, where `A : finset X`, `A : list X`, or" ++
+      " `A : multiset X`, or `x : A`, with `[fintype A]`.")
 | none (some _) := fail "Specify a single hypothesis when using a `with` argument."
 | (some n) with_list :=
   do

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -118,8 +118,8 @@ meta def fin_cases : parse hyp → parse (tk "with" *> texpr)? → tactic unit
 | none none := focus1 $ do
     ctx ← local_context,
     ctx.mfirst (fin_cases_at none) <|>
-      fail ("No hypothesis of the forms `x ∈ A`, where `A : finset X`, `A : list X`, or" ++
-      " `A : multiset X`, or `x : A`, with `[fintype A]`.")
+      fail ("No hypothesis of the forms `x ∈ A`, where " ++
+        "`A : finset X`, `A : list X`, or `A : multiset X`, or `x : A`, with `[fintype A]`.")
 | none (some _) := fail "Specify a single hypothesis when using a `with` argument."
 | (some n) with_list :=
   do

--- a/src/tactic/generalizes.lean
+++ b/src/tactic/generalizes.lean
@@ -115,8 +115,7 @@ focus1 $ do
   let new_target_type := (e.pis eqs).pis ks,
   type_check new_target_type <|> fail!
     ("generalizes': unable to generalize the target because the generalized target type does not" ++
-    " type check:
-{new_target_type}"),
+    " type check:\n{new_target_type}"),
   n ← mk_fresh_name,
   new_target ← assert n new_target_type,
   swap,

--- a/src/tactic/generalizes.lean
+++ b/src/tactic/generalizes.lean
@@ -114,7 +114,9 @@ meta def step3 (e : expr) (js ks eqs eq_proofs : list expr)
 focus1 $ do
   let new_target_type := (e.pis eqs).pis ks,
   type_check new_target_type <|> fail!
-    "generalizes': unable to generalize the target because the generalized target type does not type check:\n{new_target_type}",
+    ("generalizes': unable to generalize the target because the generalized target type does not" ++
+    " type check:
+{new_target_type}"),
   n ← mk_fresh_name,
   new_target ← assert n new_target_type,
   swap,

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -382,7 +382,8 @@ do h ← get_local n >>= infer_type >>= instantiate_mvars, guard_expr_eq h p
 `match_hyp h : t` fails if the hypothesis `h` does not match the type `t` (which may be a pattern).
 We use this tactic for writing tests.
 -/
-meta def match_hyp (n : parse ident) (p : parse $ tk ":" *> texpr) (m := reducible) : tactic (list expr) :=
+meta def match_hyp (n : parse ident) (p : parse $ tk ":" *> texpr) (m := reducible) :
+  tactic (list expr) :=
 do
   h ← get_local n >>= infer_type >>= instantiate_mvars,
   match_expr p h m
@@ -645,8 +646,8 @@ add_tactic_doc
   tags       := ["finishing"] }
 
 /--
-Similar to `existsi`. `use x` will instantiate the first term of an `∃` or `Σ` goal with `x`.
-It will then try to close the new goal using `triv`, or try to simplify it by applying `exists_prop`.
+Similar to `existsi`. `use x` will instantiate the first term of an `∃` or `Σ` goal with `x`. It
+will then try to close the new goal using `triv`, or try to simplify it by applying `exists_prop`.
 Unlike `existsi`, `x` is elaborated with respect to the expected type.
 `use` will alternatively take a list of terms `[x0, ..., xn]`.
 
@@ -849,7 +850,8 @@ private meta def format_binders : list name × binder_info × expr → tactic fo
 | (ns, binder_info.inst_implicit, t) := indent_bindents "[" "]" ns t
 | (ns, binder_info.aux_decl, t) := indent_bindents "(" ")" ns t
 
-private meta def partition_vars' (s : name_set) : list expr → list expr → list expr → tactic (list expr × list expr)
+private meta def partition_vars' (s : name_set) :
+  list expr → list expr → list expr → tactic (list expr × list expr)
 | [] as bs := pure (as.reverse, bs.reverse)
 | (x :: xs) as bs :=
 do t ← infer_type x,
@@ -1060,7 +1062,8 @@ the same type.
 succeeds when `e` does not occur in the goal. It is similar to `set`, but the resulting hypothesis
 `x` is not a local definition.
 -/
-meta def generalize' (h : parse ident?) (_ : parse $ tk ":") (p : parse generalize_arg_p) : tactic unit :=
+meta def generalize' (h : parse ident?) (_ : parse $ tk ":") (p : parse generalize_arg_p) :
+  tactic unit :=
 propagate_tags $
 do let (p, x) := p,
    e ← i_to_expr p,

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -73,7 +73,7 @@ meta def sf.flatten : sf → sf
   | (sf.of_string sx), (sf.compose (sf.of_string sy) z) := sf.compose (sf.of_string (sx ++ sy)) z
   | (sf.compose x (sf.of_string sy)), (sf.of_string sz) := sf.compose x (sf.of_string (sy ++ sz))
   | (sf.compose x (sf.of_string sy1)), (sf.compose (sf.of_string sy2) z) :=
-      sf.compose x (sf.compose (sf.of_string (sy1 ++ sy2)) z)
+    sf.compose x (sf.compose (sf.of_string (sy1 ++ sy2)) z)
   | x, y := sf.compose x y
   end
 | (sf.of_string s) := -- replace newline by space
@@ -235,7 +235,7 @@ $ tc.mk_simple
     | (action.on_mouse_enter ⟨e, ea⟩) := ((ca, some (e, ea)), none)
     | (action.on_mouse_leave_all)     := ((ca, none), none)
     | (action.on_click ⟨e, ea⟩)       :=
-        if some (e,ea) = ca then ((none, sa), none) else ((some (e, ea), sa), none)
+      if some (e,ea) = ca then ((none, sa), none) else ((some (e, ea), sa), none)
     | (action.on_tooltip_action g)    := ((none, sa), some $ sum.inl g)
     | (action.on_close_tooltip)       := ((none, sa), none)
     | (action.effect e)               := ((ca,sa), some $ sum.inr $ e)
@@ -245,8 +245,8 @@ $ tc.mk_simple
     m ← sf.of_eformat <$> tactic.pp_tagged e,
     let m := m.elim_part_apps,
     let m := m.flatten,
-    let m := m.tag_expr [] e, /- [hack] in pp.cpp I forgot to add an expr-boundary for the root
-      expression. -/
+    -- [hack] in pp.cpp I forgot to add an expr-boundary for the root expression.
+    let m := m.tag_expr [] e,
     v ← view tooltip_comp (prod.snd <$> ca) (prod.snd <$> sa) ⟨e, []⟩ m,
     pure $
     [ h "span" [
@@ -445,8 +445,8 @@ tc.mk_simple
           h "li" [className $ "lh-copy mt2", key i] [x])
         $ (goal_message :: hs),
     pure [
-      h "div" [className "fr"] [html.of_component ft $
-        component.map_action tactic_view_action.filter filter_component],
+      h "div" [className "fr"]
+        [html.of_component ft $ component.map_action tactic_view_action.filter filter_component],
       html.map_action tactic_view_action.out goals
     ])
 

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) 2020 E.W.Ayers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-
 Authors: E.W.Ayers
 -/
 
@@ -73,7 +72,8 @@ meta def sf.flatten : sf → sf
   | (sf.of_string sx), (sf.of_string sy) := sf.of_string (sx ++ sy)
   | (sf.of_string sx), (sf.compose (sf.of_string sy) z) := sf.compose (sf.of_string (sx ++ sy)) z
   | (sf.compose x (sf.of_string sy)), (sf.of_string sz) := sf.compose x (sf.of_string (sy ++ sz))
-  | (sf.compose x (sf.of_string sy1)), (sf.compose (sf.of_string sy2) z) := sf.compose x (sf.compose (sf.of_string (sy1 ++ sy2)) z)
+  | (sf.compose x (sf.of_string sy1)), (sf.compose (sf.of_string sy2) z) :=
+      sf.compose x (sf.compose (sf.of_string (sy1 ++ sy2)) z)
   | x, y := sf.compose x y
   end
 | (sf.of_string s) := -- replace newline by space
@@ -150,7 +150,8 @@ meta def goto_def_button {γ} : expr → tactic (list (html (action γ)))
   ) <|> pure []
 
 /-- Due to a bug in the webview browser, we have to reduce the number of spans in the expression.
-To do this, we collect the attributes from `sf.block` and `sf.highlight` after an expression boundary. -/
+To do this, we collect the attributes from `sf.block` and `sf.highlight` after an expression
+boundary. -/
 meta def get_block_attrs {γ}: sf → tactic (sf × list (attr γ))
 | (sf.block i a) := do
   let s : attr (γ) := style [
@@ -170,11 +171,13 @@ meta def get_block_attrs {γ}: sf → tactic (sf × list (attr γ))
 /--
 Renders a subexpression as a list of html elements.
 -/
-meta def view {γ} (tooltip_component : tc subexpr (action γ)) (click_address : option expr.address) (select_address : option expr.address) :
+meta def view {γ} (tooltip_component : tc subexpr (action γ)) (click_address : option expr.address)
+  (select_address : option expr.address) :
   subexpr → sf → tactic (list (html (action γ)))
 | ⟨ce, current_address⟩ (sf.tag_expr ea e m) := do
   let new_address := current_address ++ ea,
-  let select_attrs : list (attr (action γ)) := if some new_address = select_address then [className "highlight"] else [],
+  let select_attrs : list (attr (action γ)) :=
+    if some new_address = select_address then [className "highlight"] else [],
   click_attrs  : list (attr (action γ)) ←
     if some new_address = click_address then do
       content ← tc.to_html tooltip_component (e, new_address),
@@ -182,8 +185,10 @@ meta def view {γ} (tooltip_component : tc subexpr (action γ)) (click_address :
       gd_btn ← goto_def_button e,
       pure [tooltip $ h "div" [] [
           h "div" [cn "fr"] (gd_btn ++ [
-            h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.effect $ widget.effect.copy_text efmt), attr.val "title" "copy expression to clipboard"] ["📋"],
-            h "button" [cn "pointer ba br3", on_click (λ _, action.on_close_tooltip), attr.val "title" "close"] ["×"]
+            h "button" [cn "pointer ba br3 mr1", on_click (λ _, action.effect $
+              widget.effect.copy_text efmt), attr.val "title" "copy expression to clipboard"] ["📋"],
+            h "button" [cn "pointer ba br3", on_click (λ _, action.on_close_tooltip),
+              attr.val "title" "close"] ["×"]
           ]),
           content
       ]]
@@ -229,7 +234,8 @@ $ tc.mk_simple
     match act with
     | (action.on_mouse_enter ⟨e, ea⟩) := ((ca, some (e, ea)), none)
     | (action.on_mouse_leave_all)     := ((ca, none), none)
-    | (action.on_click ⟨e, ea⟩)       := if some (e,ea) = ca then ((none, sa), none) else ((some (e, ea), sa), none)
+    | (action.on_click ⟨e, ea⟩)       :=
+        if some (e,ea) = ca then ((none, sa), none) else ((some (e, ea), sa), none)
     | (action.on_tooltip_action g)    := ((none, sa), some $ sum.inl g)
     | (action.on_close_tooltip)       := ((none, sa), none)
     | (action.effect e)               := ((ca,sa), some $ sum.inr $ e)
@@ -239,7 +245,8 @@ $ tc.mk_simple
     m ← sf.of_eformat <$> tactic.pp_tagged e,
     let m := m.elim_part_apps,
     let m := m.flatten,
-    let m := m.tag_expr [] e, -- [hack] in pp.cpp I forgot to add an expr-boundary for the root expression.
+    let m := m.tag_expr [] e, /- [hack] in pp.cpp I forgot to add an expr-boundary for the root
+      expression. -/
     v ← view tooltip_comp (prod.snd <$> ca) (prod.snd <$> sa) ⟨e, []⟩ m,
     pure $
     [ h "span" [
@@ -365,7 +372,8 @@ meta def group_local_collection : list local_collection → list local_collectio
 | ls := ls
 
 /-- Component that displays the main (first) goal. -/
-meta def tactic_view_goal {γ} (local_c : tc local_collection γ) (target_c : tc expr γ) : tc filter_type γ :=
+meta def tactic_view_goal {γ} (local_c : tc local_collection γ) (target_c : tc expr γ) :
+  tc filter_type γ :=
 tc.stateless $ λ ft, do
   g@(expr.mvar u_n pp_n y) ← main_goal,
   t ← get_tag g,
@@ -410,7 +418,8 @@ meta def goals_accomplished_message {α} : html α :=
 h "div" [cn "f5"] ["goals accomplished 🎉"]
 
 /-- Component that displays all goals, together with the `$n goals` message. -/
-meta def tactic_view_component {γ} (local_c : tc local_collection γ) (target_c : tc expr γ) : tc unit γ :=
+meta def tactic_view_component {γ} (local_c : tc local_collection γ) (target_c : tc expr γ) :
+  tc unit γ :=
 tc.mk_simple
   (tactic_view_action γ)
   (filter_type)
@@ -436,12 +445,14 @@ tc.mk_simple
           h "li" [className $ "lh-copy mt2", key i] [x])
         $ (goal_message :: hs),
     pure [
-      h "div" [className "fr"] [html.of_component ft $ component.map_action tactic_view_action.filter filter_component],
+      h "div" [className "fr"] [html.of_component ft $
+        component.map_action tactic_view_action.filter filter_component],
       html.map_action tactic_view_action.out goals
     ])
 
 /-- Component that displays the term-mode goal. -/
-meta def tactic_view_term_goal {γ} (local_c : tc local_collection γ) (target_c : tc expr γ) : tc unit γ :=
+meta def tactic_view_term_goal {γ} (local_c : tc local_collection γ) (target_c : tc expr γ) :
+  tc unit γ :=
 tc.stateless $ λ _, do
   goal ← flip tc.to_html (filter_type.none) $ tactic_view_goal local_c target_c,
   pure [h "ul" [className "list pl0"] [

--- a/src/tactic/interval_cases.lean
+++ b/src/tactic/interval_cases.lean
@@ -243,7 +243,8 @@ do
     [hl, hu] ← [(option.get h').1, (option.get h').2].mmap get_local,
     tactic.interval_cases_using hl hu lname)
   else
-    fail "Call `interval_cases n` (specifying a variable), or `interval_cases lb ub` (specifying a lower bound and upper bound on the same variable)."
+    fail ("Call `interval_cases n` (specifying a variable), or `interval_cases lb ub` (specifying" ++
+      " a lower bound and upper bound on the same variable).")
 
 /--
 `interval_cases n` searches for upper and lower bounds on a variable `n`,

--- a/src/tactic/interval_cases.lean
+++ b/src/tactic/interval_cases.lean
@@ -243,8 +243,8 @@ do
     [hl, hu] ← [(option.get h').1, (option.get h').2].mmap get_local,
     tactic.interval_cases_using hl hu lname)
   else
-    fail ("Call `interval_cases n` (specifying a variable), or `interval_cases lb ub` (specifying" ++
-      " a lower bound and upper bound on the same variable).")
+    fail ("Call `interval_cases n` (specifying a variable), or `interval_cases lb ub`\n" ++
+      "(specifying a lower bound and upper bound on the same variable).")
 
 /--
 `interval_cases n` searches for upper and lower bounds on a variable `n`,

--- a/src/tactic/lean_core_docs.lean
+++ b/src/tactic/lean_core_docs.lean
@@ -730,7 +730,8 @@ add_tactic_doc
 Navigate into the contents of top-level `λ` binders.
 A target of `| λ a, a + b` will turn into the target `| a + b` and introduce `a` into the local
 context.
-If there are multiple binders, all of them will be entered, and if there are none, this tactic is a no-op.
+If there are multiple binders, all of them will be entered, and if there are none, this tactic is a
+no-op.
 -/
 add_tactic_doc
 { name       := "conv: funext",
@@ -763,7 +764,8 @@ add_tactic_doc
   tags       := ["conv"] }
 
 /--
-End conversion of the current goal. This is often what is needed when muscle memory would type `sorry`.
+End conversion of the current goal. This is often what is needed when muscle memory would type
+`sorry`.
 -/
 add_tactic_doc
 { name       := "conv: skip",

--- a/src/tactic/linarith/elimination.lean
+++ b/src/tactic/linarith/elimination.lean
@@ -118,8 +118,8 @@ Thus, if `c.maybe_minimal` is false, `c` is known not to be minimal and must be 
 See http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.51.493&rep=rep1&type=pdf p.13
 (Theorem 7).
 The condition described there considers only implicitly eliminated variables that have been
-officially eliminated from the system. This is not the case for every implicitly eliminated variable.
-Consider eliminating `z` from `{x + y + z < 0, x - y - z < 0}`. The result is the set
+officially eliminated from the system. This is not the case for every implicitly eliminated
+variable. Consider eliminating `z` from `{x + y + z < 0, x - y - z < 0}`. The result is the set
 `{2*x < 0}`; `y` is implicitly but not officially eliminated.
 
 This implementation of Fourier-Motzkin elimination processes variables in decreasing order of

--- a/src/tactic/linarith/parsing.lean
+++ b/src/tactic/linarith/parsing.lean
@@ -16,8 +16,8 @@ It identifies atoms up to ring-equivalence: that is, `(y*3)*x` will be identifie
 where the monomial `x*y` is the linear atom.
 
 * Variables are represented by natural numbers.
-* Monomials are represented by `monom := rb_map ℕ ℕ`. The monomial `1` is represented by the empty
-  map.
+* Monomials are represented by `monom := rb_map ℕ ℕ`.
+  The monomial `1` is represented by the empty map.
 * Linear combinations of monomials are represented by `sum := rb_map monom ℤ`.
 
 All input expressions are converted to `sum`s, preserving the map from expressions to variables.

--- a/src/tactic/linarith/parsing.lean
+++ b/src/tactic/linarith/parsing.lean
@@ -16,7 +16,8 @@ It identifies atoms up to ring-equivalence: that is, `(y*3)*x` will be identifie
 where the monomial `x*y` is the linear atom.
 
 * Variables are represented by natural numbers.
-* Monomials are represented by `monom := rb_map ℕ ℕ`. The monomial `1` is represented by the empty map.
+* Monomials are represented by `monom := rb_map ℕ ℕ`. The monomial `1` is represented by the empty
+  map.
 * Linear combinations of monomials are represented by `sum := rb_map monom ℤ`.
 
 All input expressions are converted to `sum`s, preserving the map from expressions to variables.

--- a/src/tactic/linarith/preprocessing.lean
+++ b/src/tactic/linarith/preprocessing.lean
@@ -225,7 +225,8 @@ A pair `(a, tt)` is added to `m` when `a^2` appears in `e`, and `(a, ff)` is add
 when `a*a` appears in `e`.  -/
 meta def find_squares : rb_set (expr × bool) → expr → tactic (rb_set (expr × bool))
 | s `(%%a ^ 2) := do s ← find_squares s a, return (s.insert (a, tt))
-| s e@`(%%e1 * %%e2) := if e1 = e2 then do s ← find_squares s e1, return (s.insert (e1, ff)) else e.mfoldl find_squares s
+| s e@`(%%e1 * %%e2) := if e1 = e2 then do s ← find_squares s e1, return (s.insert (e1, ff)) else
+    e.mfoldl find_squares s
 | s e := e.mfoldl find_squares s
 
 /--
@@ -256,8 +257,10 @@ do s ← ls.mfoldr (λ h s', infer_type h >>= find_squares s') mk_rb_set,
       | ineq.eq, _ := mk_app ``zero_mul_eq [a, b]
       | _, ineq.eq := mk_app ``mul_zero_eq [a, b]
       | ineq.lt, ineq.lt := mk_app ``mul_pos_of_neg_of_neg [a, b]
-      | ineq.lt, ineq.le := do a ← mk_app ``le_of_lt [a], mk_app ``mul_nonneg_of_nonpos_of_nonpos [a, b]
-      | ineq.le, ineq.lt := do b ← mk_app ``le_of_lt [b], mk_app ``mul_nonneg_of_nonpos_of_nonpos [a, b]
+      | ineq.lt, ineq.le := do a ← mk_app ``le_of_lt [a],
+          mk_app ``mul_nonneg_of_nonpos_of_nonpos [a, b]
+      | ineq.le, ineq.lt := do b ← mk_app ``le_of_lt [b],
+          mk_app ``mul_nonneg_of_nonpos_of_nonpos [a, b]
       | ineq.le, ineq.le := mk_app ``mul_nonneg_of_nonpos_of_nonpos [a, b]
       end <|> return none,
    products ← make_comp_with_zero.globalize.transform products.reduce_option,
@@ -302,7 +305,8 @@ The preprocessors are run sequentially: each recieves the output of the previous
 Note that a preprocessor may produce multiple or no expressions from each input expression,
 so the size of the list may change.
 -/
-meta def preprocess (pps : list global_branching_preprocessor) (l : list expr) : tactic (list branch) :=
+meta def preprocess (pps : list global_branching_preprocessor) (l : list expr) :
+  tactic (list branch) :=
 do g ← get_goal,
 pps.mfoldl (λ ls pp,
   list.join <$> (ls.mmap $ λ b, set_goals [b.1] >> pp.process b.2))

--- a/src/tactic/linarith/preprocessing.lean
+++ b/src/tactic/linarith/preprocessing.lean
@@ -226,7 +226,7 @@ when `a*a` appears in `e`.  -/
 meta def find_squares : rb_set (expr × bool) → expr → tactic (rb_set (expr × bool))
 | s `(%%a ^ 2) := do s ← find_squares s a, return (s.insert (a, tt))
 | s e@`(%%e1 * %%e2) := if e1 = e2 then do s ← find_squares s e1, return (s.insert (e1, ff)) else
-    e.mfoldl find_squares s
+  e.mfoldl find_squares s
 | s e := e.mfoldl find_squares s
 
 /--
@@ -258,9 +258,9 @@ do s ← ls.mfoldr (λ h s', infer_type h >>= find_squares s') mk_rb_set,
       | _, ineq.eq := mk_app ``mul_zero_eq [a, b]
       | ineq.lt, ineq.lt := mk_app ``mul_pos_of_neg_of_neg [a, b]
       | ineq.lt, ineq.le := do a ← mk_app ``le_of_lt [a],
-          mk_app ``mul_nonneg_of_nonpos_of_nonpos [a, b]
+        mk_app ``mul_nonneg_of_nonpos_of_nonpos [a, b]
       | ineq.le, ineq.lt := do b ← mk_app ``le_of_lt [b],
-          mk_app ``mul_nonneg_of_nonpos_of_nonpos [a, b]
+        mk_app ``mul_nonneg_of_nonpos_of_nonpos [a, b]
       | ineq.le, ineq.le := mk_app ``mul_nonneg_of_nonpos_of_nonpos [a, b]
       end <|> return none,
    products ← make_comp_with_zero.globalize.transform products.reduce_option,

--- a/src/tactic/monotonicity/interactive.lean
+++ b/src/tactic/monotonicity/interactive.lean
@@ -468,9 +468,8 @@ do t ← target,
              pure $ foldl compose "\n\n" $
                list.intersperse "\n" $ to_fmt l.get_app_fn.const_name :: msg),
         let msg := foldl compose "" lmms,
-        fail format!"ambiguous match: {msg}
-
-Tip: try asserting a side condition to distinguish between the lemmas"
+        fail format!("ambiguous match: {msg}\n\n" ++
+          "Tip: try asserting a side condition to distinguish between the lemmas")
    end
 
 meta def mono_aux (dir : parse side) :

--- a/src/tactic/monotonicity/interactive.lean
+++ b/src/tactic/monotonicity/interactive.lean
@@ -492,7 +492,7 @@ do t ← target >>= instantiate_mvars,
     - right: `x < w` and `y ≤ z`
 - `mono using [rule1,rule2]` calls `simp [rule1,rule2]` before applying mono.
 - The general syntax is
-  `mono '*'? ('with' hyp | 'with' [hyp1,hyp2])? ('using' [hyp1,hyp2])? mono_cfg?
+  `mono '*'? ('with' hyp | 'with' [hyp1,hyp2])? ('using' [hyp1,hyp2])? mono_cfg?`
 
 To use it, first import `tactic.monotonicity`.
 

--- a/src/tactic/monotonicity/interactive.lean
+++ b/src/tactic/monotonicity/interactive.lean
@@ -188,7 +188,8 @@ meta def parse_assoc_chain' (f : expr) : expr → tactic (dlist expr)
 meta def parse_assoc_chain (f : expr) : expr → tactic (list expr) :=
 map dlist.to_list ∘ parse_assoc_chain' f
 
-meta def fold_assoc (op : expr) : option (expr × expr × expr) → list expr → option (expr × list expr)
+meta def fold_assoc (op : expr) :
+  option (expr × expr × expr) → list expr → option (expr × list expr)
 | _ (x::xs) := some (foldl (expr.app ∘ expr.app op) x xs, [])
 | none []   := none
 | (some (l_id,r_id,x₀)) [] := some (x₀,[l_id,r_id])
@@ -464,9 +465,12 @@ do t ← target,
      do lmms ← r.mmap (λ ⟨l,gs,_⟩,
           do ts ← gs.mmap infer_type,
              msg ← ts.mmap pp,
-             pure $ foldl compose "\n\n" (list.intersperse "\n" $ to_fmt l.get_app_fn.const_name :: msg)),
+             pure $ foldl compose "\n\n" $
+               list.intersperse "\n" $ to_fmt l.get_app_fn.const_name :: msg),
         let msg := foldl compose "" lmms,
-        fail format!"ambiguous match: {msg}\n\nTip: try asserting a side condition to distinguish between the lemmas"
+        fail format!"ambiguous match: {msg}
+
+Tip: try asserting a side condition to distinguish between the lemmas"
    end
 
 meta def mono_aux (dir : parse side) :
@@ -487,7 +491,8 @@ do t ← target >>= instantiate_mvars,
     - left:  `x ≤ w` and `y < z` or
     - right: `x < w` and `y ≤ z`
 - `mono using [rule1,rule2]` calls `simp [rule1,rule2]` before applying mono.
-- The general syntax is `mono '*'? ('with' hyp | 'with' [hyp1,hyp2])? ('using' [hyp1,hyp2])? mono_cfg?
+- The general syntax is
+  `mono '*'? ('with' hyp | 'with' [hyp1,hyp2])? ('using' [hyp1,hyp2])? mono_cfg?
 
 To use it, first import `tactic.monotonicity`.
 

--- a/src/tactic/push_neg.lean
+++ b/src/tactic/push_neg.lean
@@ -185,8 +185,10 @@ meta def tactic.interactive.contrapose (push : parse (tk "!" )?) :
 | (some (h, h')) := get_local h >>= revert >> tactic.interactive.contrapose none >>
   intro (h'.get_or_else h) >> skip
 | none :=
-  do `(%%P → %%Q) ← target | fail "The goal is not an implication, and you didn't specify an assumption",
-  cp ← mk_mapp ``imp_of_not_imp_not [P, Q] <|> fail "contrapose only applies to nondependent arrows between props",
+  do `(%%P → %%Q) ← target | fail
+    "The goal is not an implication, and you didn't specify an assumption",
+  cp ← mk_mapp ``imp_of_not_imp_not [P, Q] <|> fail
+    "contrapose only applies to nondependent arrows between props",
   apply cp,
   when push.is_some $ try (tactic.interactive.push_neg (loc.ns [none]))
 

--- a/src/tactic/slim_check.lean
+++ b/src/tactic/slim_check.lean
@@ -177,9 +177,9 @@ For more information on writing your own `sampleable` and `testable`
 instances, see `testing.slim_check.testable`.
 
 Optional arguments given with `slim_check_cfg`
-* num_inst (default 100): number of examples to test properties with
-* max_size (default 100): final size argument
-* enable_tracing (default ff): enable the printing of discarded samples
+* `num_inst` (default 100): number of examples to test properties with
+* `max_size` (default 100): final size argument
+* `enable_tracing` (default `ff`): enable the printing of discarded samples
 
 Options:
 * `set_option trace.slim_check.decoration true`: print the proposition with quantifier annotations
@@ -207,11 +207,11 @@ meta def slim_check (cfg : slim_check_cfg := {}) : tactic unit := do
   inst ← mk_app ``testable [tgt'] >>= mk_instance <|>
     fail!("Failed to create a `testable` instance for `{tgt}`.
 What to do:
-1. make sure that the types you are using have `slim_check.sampleable` instances (you can use" ++
-" `#sample my_type` if you are unsure);
+1. make sure that the types you are using have `slim_check.sampleable` instances
+   (you can use `#sample my_type` if you are unsure);
 2. make sure that the relations and predicates that your proposition use are decidable;
-3. make sure that instances of `slim_check.testable` exist that, when combined, apply to your" ++
-" decorated proposition:
+3. make sure that instances of `slim_check.testable` exist that, when combined,
+   apply to your decorated proposition:
 ```
 {tgt'}
 ```

--- a/src/tactic/slim_check.lean
+++ b/src/tactic/slim_check.lean
@@ -177,32 +177,41 @@ For more information on writing your own `sampleable` and `testable`
 instances, see `testing.slim_check.testable`.
 
 Optional arguments given with `slim_check_cfg`
- * num_inst (default 100): number of examples to test properties with
- * max_size (default 100): final size argument
- * enable_tracing (default ff): enable the printing of discarded samples
+* num_inst (default 100): number of examples to test properties with
+* max_size (default 100): final size argument
+* enable_tracing (default ff): enable the printing of discarded samples
 
 Options:
-  * `set_option trace.slim_check.decoration true`: print the proposition with quantifier annotations
-  * `set_option trace.slim_check.discarded true`: print the examples discarded because they do not satisfy assumptions
-  * `set_option trace.slim_check.shrink.steps true`: trace the shrinking of counter-example
-  * `set_option trace.slim_check.shrink.candidates true`: print the lists of candidates considered when shrinking each variable
-  * `set_option trace.slim_check.instance true`: print the instances of `testable` being used to test the proposition
-  * `set_option trace.slim_check.success true`: print the tested samples that satisfy a property
+* `set_option trace.slim_check.decoration true`: print the proposition with quantifier annotations
+* `set_option trace.slim_check.discarded true`: print the examples discarded because they do not
+  satisfy assumptions
+* `set_option trace.slim_check.shrink.steps true`: trace the shrinking of counter-example
+* `set_option trace.slim_check.shrink.candidates true`: print the lists of candidates considered
+  when shrinking each variable
+* `set_option trace.slim_check.instance true`: print the instances of `testable` being used to test
+  the proposition
+* `set_option trace.slim_check.success true`: print the tested samples that satisfy a property
 -/
 meta def slim_check (cfg : slim_check_cfg := {}) : tactic unit := do
 { tgt ← retrieve $ tactic.revert_all >> target,
   let tgt' := tactic.add_decorations tgt,
   let cfg := { cfg with
-               trace_discarded         := cfg.trace_discarded         || is_trace_enabled_for `slim_check.discarded,
-               trace_shrink            := cfg.trace_shrink            || is_trace_enabled_for `slim_check.shrink.steps,
-               trace_shrink_candidates := cfg.trace_shrink_candidates || is_trace_enabled_for `slim_check.shrink.candidates,
-               trace_success           := cfg.trace_success           || is_trace_enabled_for `slim_check.success },
+               trace_discarded         := cfg.trace_discarded
+                || is_trace_enabled_for `slim_check.discarded,
+               trace_shrink            := cfg.trace_shrink
+                || is_trace_enabled_for `slim_check.shrink.steps,
+               trace_shrink_candidates := cfg.trace_shrink_candidates
+                || is_trace_enabled_for `slim_check.shrink.candidates,
+               trace_success           := cfg.trace_success
+                || is_trace_enabled_for `slim_check.success },
   inst ← mk_app ``testable [tgt'] >>= mk_instance <|>
     fail!"Failed to create a `testable` instance for `{tgt}`.
 What to do:
-1. make sure that the types you are using have `slim_check.sampleable` instances (you can use `#sample my_type` if you are unsure);
+1. make sure that the types you are using have `slim_check.sampleable` instances (you can use" ++
+" `#sample my_type` if you are unsure);
 2. make sure that the relations and predicates that your proposition use are decidable;
-3. make sure that instances of `slim_check.testable` exist that, when combined, apply to your decorated proposition:
+3. make sure that instances of `slim_check.testable` exist that, when combined, apply to your" ++
+" decorated proposition:
 ```
 {tgt'}
 ```

--- a/src/tactic/slim_check.lean
+++ b/src/tactic/slim_check.lean
@@ -205,7 +205,7 @@ meta def slim_check (cfg : slim_check_cfg := {}) : tactic unit := do
                trace_success           := cfg.trace_success
                 || is_trace_enabled_for `slim_check.success },
   inst ← mk_app ``testable [tgt'] >>= mk_instance <|>
-    fail!"Failed to create a `testable` instance for `{tgt}`.
+    fail!("Failed to create a `testable` instance for `{tgt}`.
 What to do:
 1. make sure that the types you are using have `slim_check.sampleable` instances (you can use" ++
 " `#sample my_type` if you are unsure);
@@ -220,7 +220,7 @@ Use `set_option trace.class_instances true` to understand what instances are mis
 
 Try this:
 set_option trace.class_instances true
-#check (by apply_instance : slim_check.testable ({tgt'}))",
+#check (by apply_instance : slim_check.testable ({tgt'}))"),
   e ← mk_mapp ``testable.check [tgt, `(cfg), tgt', inst],
   when_tracing `slim_check.decoration trace!"[testable decoration]\n  {tgt'}",
   when_tracing `slim_check.instance   $ do

--- a/src/tactic/solve_by_elim.lean
+++ b/src/tactic/solve_by_elim.lean
@@ -96,7 +96,8 @@ do
   else return [],
   -- Finally, run all of the tactics: any that return an expression without metavariables can safely
   -- be replaced by a `return` tactic.
-  hs ← hs.mmap (λ h : tactic expr, do e ← h, if e.has_meta_var then return h else return (return e)),
+  hs ← hs.mmap (λ h : tactic expr, do e ← h, if e.has_meta_var then return h else
+    return (return e)),
   return (hs, locals)
 
 /--
@@ -157,8 +158,9 @@ else
 /--
 The internal implementation of `solve_by_elim`, with a limiting counter.
 -/
-meta def solve_by_elim_aux (opt : basic_opt)
-  (original_goals : list expr) (lemmas : list (tactic expr)) (ctx : tactic (list expr)) : ℕ → tactic unit
+meta def solve_by_elim_aux (opt : basic_opt) (original_goals : list expr)
+  (lemmas : list (tactic expr)) (ctx : tactic (list expr)) :
+  ℕ → tactic unit
 | n := do
   -- First, check that progress so far is `accept`able.
   lock_tactic_state (original_goals.mmap instantiate_mvars >>= opt.accept),
@@ -172,7 +174,8 @@ meta def solve_by_elim_aux (opt : basic_opt)
     -- try either applying a lemma and recursing,
     (on_success, on_failure) ← trace_hooks (opt.max_depth - n),
     ctx_lemmas ← ctx,
-    (apply_any_thunk (lemmas ++ (ctx_lemmas.map return)) opt.to_apply_any_opt (solve_by_elim_aux (n-1))
+    (apply_any_thunk (lemmas ++ (ctx_lemmas.map return)) opt.to_apply_any_opt
+      (solve_by_elim_aux (n-1))
       on_success on_failure) <|>
     -- or if that doesn't work, run the discharger and recurse.
      (opt.discharger >> solve_by_elim_aux (n-1)))

--- a/src/tactic/solve_by_elim.lean
+++ b/src/tactic/solve_by_elim.lean
@@ -96,8 +96,9 @@ do
   else return [],
   -- Finally, run all of the tactics: any that return an expression without metavariables can safely
   -- be replaced by a `return` tactic.
-  hs ← hs.mmap (λ h : tactic expr, do e ← h, if e.has_meta_var then return h else
-    return (return e)),
+  hs ← hs.mmap (λ h : tactic expr, do
+    e ← h,
+    if e.has_meta_var then return h else return (return e)),
   return (hs, locals)
 
 /--

--- a/src/tactic/split_ifs.lean
+++ b/src/tactic/split_ifs.lean
@@ -53,7 +53,8 @@ private meta def value_known (c : expr) : tactic bool := do
 lctx ← local_context, lctx ← lctx.mmap infer_type,
 return $ c ∈ lctx ∨ `(¬%%c) ∈ lctx
 
-private meta def split_ifs_core (at_ : loc) (names : ref (list name)) : list expr → tactic unit | done := do
+private meta def split_ifs_core (at_ : loc) (names : ref (list name)) :
+  list expr → tactic unit | done := do
 some cond ← find_if_cond_at at_ | fail "no if-then-else expressions to split",
 let cond := match cond with `(¬%%p) := p | p := p end,
 if cond ∈ done then skip else do

--- a/src/tactic/squeeze.lean
+++ b/src/tactic/squeeze.lean
@@ -208,15 +208,17 @@ example {α β} (xs ys : list α) (f : α → β) :
 begin
   have : xs = ys, admit,
   squeeze_scope
-  { split; squeeze_simp, -- `squeeze_simp` is run twice, the first one requires
-                         -- `list.map_append` and the second one
-                         -- `[list.length_map, list.length_tail]`
-                         -- prints only one message and combine the suggestions:
-                         -- > Try this: simp only [list.length_map, list.length_tail, list.map_append]
-    squeeze_simp [this]  -- `squeeze_simp` is run only once
-                         -- prints:
-                         -- > Try this: simp only [this]
- },
+  { split; squeeze_simp,
+    -- `squeeze_simp` is run twice, the first one requires
+    -- `list.map_append` and the second one
+    -- `[list.length_map, list.length_tail]`
+    -- prints only one message and combine the suggestions:
+    -- > Try this: simp only [list.length_map, list.length_tail, list.map_append]
+    squeeze_simp [this]
+    -- `squeeze_simp` is run only once
+    -- prints:
+    -- > Try this: simp only [this]
+  },
 end
 ```
 

--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -32,7 +32,8 @@ do hs ← local_context,
          | `(¬ (_ → (_ : Prop))) := replace h.local_pp_name ``(decidable.not_imp.mp %%h)
          | `(¬ (_ ↔ _)) := replace h.local_pp_name ``(decidable.not_iff.mp %%h)
          | `(_ ↔ _) := replace h.local_pp_name ``(decidable.iff_iff_and_or_not_and_not.mp %%h) <|>
-                       replace h.local_pp_name ``(decidable.iff_iff_and_or_not_and_not.mp (%%h).symm) <|>
+                       replace h.local_pp_name
+                         ``(decidable.iff_iff_and_or_not_and_not.mp (%%h).symm) <|>
                        () <$ tactic.cases h
          | `(_ → _)     := replace h.local_pp_name ``(decidable.not_or_of_imp %%h)
          | _ := failed

--- a/src/tactic/tidy.lean
+++ b/src/tactic/tidy.lean
@@ -40,7 +40,8 @@ meta def default_tactics : list (tactic string) :=
 [ reflexivity                                 >> pure "refl",
   `[exact dec_trivial]                        >> pure "exact dec_trivial",
   propositional_goal >> assumption            >> pure "assumption",
-  intros1                                     >>= λ ns, pure ("intros " ++ (" ".intercalate (ns.map (λ e, e.to_string)))),
+  intros1                                     >>= λ ns, pure ("intros " ++ (" ".intercalate $
+                                                  ns.map $ λ e, e.to_string)),
   auto_cases,
   `[apply_auto_param]                         >> pure "apply_auto_param",
   `[dsimp at *]                               >> pure "dsimp at *",

--- a/src/tactic/transfer.lean
+++ b/src/tactic/transfer.lean
@@ -112,9 +112,9 @@ mmap (λn, do
 private meta def split_params_args :
   list (expr × bool) → list expr → list (expr × option expr) × list expr
 | ((lc, tt) :: ps) (e :: es) := let (ps', es') :=
-    split_params_args ps es in ((lc, some e) :: ps', es')
+  split_params_args ps es in ((lc, some e) :: ps', es')
 | ((lc, ff) :: ps) es        := let (ps', es') :=
-    split_params_args ps es in ((lc, none) :: ps', es')
+  split_params_args ps es in ((lc, none) :: ps', es')
 | _ es := ([], es)
 
 private meta def param_substitutions (ctxt : list expr) :

--- a/src/tactic/transfer.lean
+++ b/src/tactic/transfer.lean
@@ -98,7 +98,8 @@ private meta def analyse_rule (u' : list name) (pr : expr) : tactic rule_data :=
   p_data  ← return $ mark_occurences (app R p) params,
   p_vars  ← return $ list.map prod.fst (p_data.filter (λx, ↑x.2)),
   u       ← return $ collect_univ_params (app R p) ∩ u',
-  pat     ← mk_pattern (level.param <$> u) (p_vars ++ a_vars) (app R p) (level.param <$> u) (p_vars ++ a_vars),
+  pat     ← mk_pattern (level.param <$> u) (p_vars ++ a_vars) (app R p) (level.param <$> u)
+    (p_vars ++ a_vars),
   return $ rule_data.mk pr (u'.remove_all u) p_data u args pat g
 
 meta def analyse_decls : list name → tactic (list rule_data) :=
@@ -108,9 +109,12 @@ mmap (λn, do
   ls ← (repeat () c).mmap (λ_, mk_fresh_name),
   analyse_rule ls (const n (ls.map level.param)))
 
-private meta def split_params_args : list (expr × bool) → list expr → list (expr × option expr) × list expr
-| ((lc, tt) :: ps) (e :: es) := let (ps', es') := split_params_args ps es in ((lc, some e) :: ps', es')
-| ((lc, ff) :: ps) es        := let (ps', es') := split_params_args ps es in ((lc, none) :: ps', es')
+private meta def split_params_args :
+  list (expr × bool) → list expr → list (expr × option expr) × list expr
+| ((lc, tt) :: ps) (e :: es) := let (ps', es') :=
+    split_params_args ps es in ((lc, some e) :: ps', es')
+| ((lc, ff) :: ps) es        := let (ps', es') :=
+    split_params_args ps es in ((lc, none) :: ps', es')
 | _ es := ([], es)
 
 private meta def param_substitutions (ctxt : list expr) :

--- a/src/tactic/transform_decl.lean
+++ b/src/tactic/transform_decl.lean
@@ -94,8 +94,8 @@ do transform_decl_with_prefix_fun_aux f replace_all trace ignore reorder src tgt
    ls.mmap' $ transform_decl_with_prefix_fun_aux f replace_all trace ignore reorder src tgt attrs
 
 /--
-Make a new copy of a declaration,
-replacing fragments of the names of identifiers in the type and the body using the dictionary `dict`.
+Make a new copy of a declaration, replacing fragments of the names of identifiers in the type and
+the body using the dictionary `dict`.
 This is used to implement `@[to_additive]`.
 -/
 meta def transform_decl_with_prefix_dict (dict : name_map name) (replace_all trace : bool)

--- a/src/tactic/transport.lean
+++ b/src/tactic/transport.lean
@@ -42,7 +42,8 @@ and an equivalence `e : α ≃ β`,
 try to produce an `S β`,
 by transporting data and axioms across `e` using `equiv_rw`.
 -/
-@[nolint unused_arguments] -- At present we don't actually use `s`; it's inferred in the `mk_app` call.
+-- At present we don't actually use `s`; it's inferred in the `mk_app` call.
+@[nolint unused_arguments]
 meta def transport (s e : expr) : tactic unit :=
 do
   (_, α, β) ← infer_type e >>= relation_lhs_rhs <|>

--- a/src/tactic/wlog.lean
+++ b/src/tactic/wlog.lean
@@ -179,8 +179,8 @@ perms ← parse_permutations perms,
     fail "Cases contains variables not declared in `using x y z`",
   perms ← (if perms.length = 1
     then do
-      return (perms'.map $ λp, p ++ vars.filter (λ v, p.all (λ v',
-        v'.local_uniq_name ≠ v.local_uniq_name)))
+      return (perms'.map $ λ p,
+        p ++ vars.filter (λ v, p.all (λ v', v'.local_uniq_name ≠ v.local_uniq_name)))
     else do
       guard (perms.length = perms'.length) <|>
         fail "The provided permutation list has a different length then the provided cases.",
@@ -197,8 +197,8 @@ perms ← parse_permutations perms,
     | [l] := return l
     | _   := failed
     end,
-    let cases := mk_or_lst [pat, pat.instantiate_locals [(x.local_uniq_name, y),
-      (y.local_uniq_name, x)]],
+    let cases := mk_or_lst
+      [pat, pat.instantiate_locals [(x.local_uniq_name, y), (y.local_uniq_name, x)]],
     (do
       `(%%x' ≤ %%y') ← return pat,
       (cases_pr, []) ← local_proof name_h cases (exact ``(le_total %%x' %%y')),
@@ -217,8 +217,8 @@ perms ← parse_permutations perms,
     (cases_pr, [g]) ← local_proof name_h cases skip,
     return (pat, cases_pr, some g, vars, perms))
 end),
-let name_fn := (if perms.length = 2 then λ i, `invariant else λ i,
-  mk_simple_name ("invariant_" ++ to_string (i + 1))),
+let name_fn := if perms.length = 2 then λ _, `invariant else
+  λ i, mk_simple_name ("invariant_" ++ to_string (i + 1)),
 with_enable_tags $ tactic.focus1 $ do
   t ← get_main_tag,
   tactic.wlog vars cases_pr pat perms,

--- a/src/tactic/wlog.lean
+++ b/src/tactic/wlog.lean
@@ -91,10 +91,11 @@ private meta def parse_permutations : option (list (list name)) → tactic (list
 | none                    := return []
 | (some [])               := return []
 | (some perms@(p₀ :: ps)) := do
-  (guard p₀.nodup <|>
-    fail "No permutation `xs_i` in `using [xs_1, …, xs_n]` should contain the same variable twice."),
+  (guard p₀.nodup <|> fail
+    "No permutation `xs_i` in `using [xs_1, …, xs_n]` should contain the same variable twice."),
   (guard (perms.all $ λp, p.perm p₀) <|>
-    fail "The permutations `xs_i` in `using [xs_1, …, xs_n]` must be permutations of the same variables."),
+    fail ("The permutations `xs_i` in `using [xs_1, …, xs_n]` must be permutations of the same" ++
+      " variables.")),
   perms.mmap (λp, p.mmap get_local)
 
 /-- Without loss of generality: reduces to one goal under variables permutations.
@@ -178,7 +179,8 @@ perms ← parse_permutations perms,
     fail "Cases contains variables not declared in `using x y z`",
   perms ← (if perms.length = 1
     then do
-      return (perms'.map $ λp, p ++ vars.filter (λv, p.all (λv', v'.local_uniq_name ≠ v.local_uniq_name)))
+      return (perms'.map $ λp, p ++ vars.filter (λ v, p.all (λ v',
+        v'.local_uniq_name ≠ v.local_uniq_name)))
     else do
       guard (perms.length = perms'.length) <|>
         fail "The provided permutation list has a different length then the provided cases.",
@@ -195,7 +197,8 @@ perms ← parse_permutations perms,
     | [l] := return l
     | _   := failed
     end,
-    let cases := mk_or_lst [pat, pat.instantiate_locals [(x.local_uniq_name, y), (y.local_uniq_name, x)]],
+    let cases := mk_or_lst [pat, pat.instantiate_locals [(x.local_uniq_name, y),
+      (y.local_uniq_name, x)]],
     (do
       `(%%x' ≤ %%y') ← return pat,
       (cases_pr, []) ← local_proof name_h cases (exact ``(le_total %%x' %%y')),
@@ -214,8 +217,8 @@ perms ← parse_permutations perms,
     (cases_pr, [g]) ← local_proof name_h cases skip,
     return (pat, cases_pr, some g, vars, perms))
 end),
-let name_fn :=
-  (if perms.length = 2 then λi, `invariant else λi, mk_simple_name ("invariant_" ++ to_string (i + 1))),
+let name_fn := (if perms.length = 2 then λ i, `invariant else λ i,
+  mk_simple_name ("invariant_" ++ to_string (i + 1))),
 with_enable_tags $ tactic.focus1 $ do
   t ← get_main_tag,
   tactic.wlog vars cases_pr pat perms,


### PR DESCRIPTION
For code lines, the fix was often simple, just break that damn line.
For strings, you shouldn't break a line inside one as this will be a visible change to the tactic's output. When nothing else can be done, I used the trick of breaking the string into two appended strings. "A B" becomes "A" ++ " B", and that's line-breakable.
 
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
