### PR TITLE
[Merged by Bors] - feat(order/prime_ideal, order/boolean_algebra): small lemmas about prime ideals

### DIFF
--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -676,7 +676,7 @@ theorem sdiff_compl : x \ yᶜ = x ⊓ y := by rw [sdiff_eq, compl_compl]
 theorem top_sdiff : ⊤ \ x = xᶜ := by rw [sdiff_eq, top_inf_eq]
 @[simp] theorem sdiff_top : x \ ⊤ = ⊥ := by rw [sdiff_eq, compl_top, inf_bot_eq]
 
-lemma sup_inf_inf_compl : (x ⊓ y) ⊔ (x ⊓ yᶜ) = x :=
+@[simp] lemma sup_inf_inf_compl : (x ⊓ y) ⊔ (x ⊓ yᶜ) = x :=
 by rw [← sdiff_eq, sup_inf_sdiff _ _]
 
 end boolean_algebra

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -676,6 +676,9 @@ theorem sdiff_compl : x \ yᶜ = x ⊓ y := by rw [sdiff_eq, compl_compl]
 theorem top_sdiff : ⊤ \ x = xᶜ := by rw [sdiff_eq, top_inf_eq]
 @[simp] theorem sdiff_top : x \ ⊤ = ⊥ := by rw [sdiff_eq, compl_top, inf_bot_eq]
 
+lemma sup_inf_inf_compl : (x ⊓ y) ⊔ (x ⊓ yᶜ) = x :=
+by rw [← sdiff_eq, sup_inf_sdiff _ _]
+
 end boolean_algebra
 
 instance Prop.boolean_algebra : boolean_algebra Prop :=

--- a/src/order/prime_ideal.lean
+++ b/src/order/prime_ideal.lean
@@ -6,6 +6,7 @@ Authors: Noam Atar
 import order.basic
 import order.ideal
 import order.pfilter
+import order.boolean_algebra
 
 /-!
 # Prime ideals
@@ -147,6 +148,19 @@ begin
 end
 
 end distrib_lattice
+
+section boolean_algebra
+
+variables [boolean_algebra P] {x : P} {I : ideal P}
+
+lemma is_prime.mem_or_compl_mem (hI : is_prime I) : x ∈ I ∨ xᶜ ∈ I :=
+begin
+  apply is_prime.mem_or_mem hI,
+  rw inf_compl_eq_bot,
+  exact bot_mem,
+end
+
+end boolean_algebra
 
 end ideal
 

--- a/src/order/prime_ideal.lean
+++ b/src/order/prime_ideal.lean
@@ -160,6 +160,12 @@ begin
   exact bot_mem,
 end
 
+lemma is_prime.mem_compl_of_not_mem (hI : is_prime I) (hxnI : x ∉ I) : xᶜ ∈ I :=
+begin
+  have : x ∈ I ∨ xᶜ ∈ I := hI.mem_or_compl_mem,
+  tauto,
+end
+
 end boolean_algebra
 
 end ideal

--- a/src/order/prime_ideal.lean
+++ b/src/order/prime_ideal.lean
@@ -155,7 +155,7 @@ variables [boolean_algebra P] {x : P} {I : ideal P}
 
 lemma is_prime.mem_or_compl_mem (hI : is_prime I) : x ∈ I ∨ xᶜ ∈ I :=
 begin
-  apply is_prime.mem_or_mem hI,
+  apply hI.mem_or_mem,
   rw inf_compl_eq_bot,
   exact bot_mem,
 end

--- a/src/order/prime_ideal.lean
+++ b/src/order/prime_ideal.lean
@@ -161,10 +161,7 @@ begin
 end
 
 lemma is_prime.mem_compl_of_not_mem (hI : is_prime I) (hxnI : x ∉ I) : xᶜ ∈ I :=
-begin
-  have : x ∈ I ∨ xᶜ ∈ I := hI.mem_or_compl_mem,
-  tauto,
-end
+hI.mem_or_compl_mem.resolve_left hxnI
 
 end boolean_algebra
 


### PR DESCRIPTION
- Added is_prime.mem_or_compl_mem 
- Added is_prime.mem_compl_of_not_mem 
- Added sup_inf_inf_compl 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Started working on lemmas about primes in boolean algebras.
The other direction of these lemmas will be proved in the next PR.
It uses the lemma added to the boolean algebra file.
