### PR TITLE
[Merged by Bors] - feat(ring_theory/noetherian): is_noetherian_of_range_eq_ker

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -676,9 +676,6 @@ p.subtype.cod_restrict p' $ λ ⟨x, hx⟩, h hx
 
 theorem of_le_apply (h : p ≤ p') (x : p) : of_le h x = ⟨x, h x.2⟩ := rfl
 
-theorem of_le_injective (h : p ≤ p') : function.injective (of_le h) :=
-λ x y h, subtype.val_injective (subtype.mk.inj h)
-
 variables (p p')
 
 lemma subtype_comp_of_le (p q : submodule R M) (h : p ≤ q) :

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -676,6 +676,9 @@ p.subtype.cod_restrict p' $ λ ⟨x, hx⟩, h hx
 
 theorem of_le_apply (h : p ≤ p') (x : p) : of_le h x = ⟨x, h x.2⟩ := rfl
 
+theorem of_le_injective (h : p ≤ p') : function.injective (of_le h) :=
+λ x y h, subtype.val_injective (subtype.mk.inj h)
+
 variables (p p')
 
 lemma subtype_comp_of_le (p q : submodule R M) (h : p ≤ q) :
@@ -841,6 +844,49 @@ lemma map_comap_le (f : M →ₗ[R] M₂) (q : submodule R M₂) : map f (comap 
 
 lemma le_comap_map (f : M →ₗ[R] M₂) (p : submodule R M) : p ≤ comap f (map f p) :=
 (gc_map_comap f).le_u_l _
+
+section galois_insertion
+variables {f : M →ₗ[R] M₂} (hf : surjective f)
+include hf
+
+/-- `map f` and `comap f` form a `galois_insertion` when `f` is surjective. -/
+def gi_map_comap : galois_insertion (map f) (comap f) :=
+(gc_map_comap f).to_galois_insertion
+  (λ S x hx, begin
+    rcases hf x with ⟨y, rfl⟩,
+    simp only [mem_map, mem_comap],
+    exact ⟨y, hx, rfl⟩
+  end)
+
+lemma map_comap_eq_of_surjective (p : submodule R M₂) : (p.comap f).map f = p :=
+(gi_map_comap hf).l_u_eq _
+
+lemma map_surjective_of_surjective : function.surjective (map f) :=
+(gi_map_comap hf).l_surjective
+
+lemma comap_injective_of_surjective : function.injective (comap f) :=
+(gi_map_comap hf).u_injective
+
+lemma map_sup_comap_of_surjective (p q : submodule R M₂) :
+  (p.comap f ⊔ q.comap f).map f = p ⊔ q :=
+(gi_map_comap hf).l_sup_u _ _
+
+lemma map_supr_comap_of_sujective (S : ι → submodule R M₂) : (⨆ i, (S i).comap f).map f = supr S :=
+(gi_map_comap hf).l_supr_u _
+
+lemma map_inf_comap_of_surjective (p q : submodule R M₂) : (p.comap f ⊓ q.comap f).map f = p ⊓ q :=
+(gi_map_comap hf).l_inf_u _ _
+
+lemma map_infi_comap_of_surjective (S : ι → submodule R M₂) : (⨅ i, (S i).comap f).map f = infi S :=
+(gi_map_comap hf).l_infi_u _
+
+lemma comap_le_comap_iff_of_surjective (p q : submodule R M₂) : p.comap f ≤ q.comap f ↔ p ≤ q :=
+(gi_map_comap hf).u_le_u_iff
+
+lemma comap_strict_mono_of_surjective : strict_mono (comap f) :=
+(gi_map_comap hf).strict_mono_u
+
+end galois_insertion
 
 section galois_coinsertion
 variables {f : M →ₗ[R] M₂} (hf : injective f)

--- a/src/order/modular_lattice.lean
+++ b/src/order/modular_lattice.lean
@@ -57,16 +57,13 @@ instance : is_modular_lattice (order_dual α) :=
 ⟨λ x y z xz, le_of_eq (by { rw [inf_comm, sup_comm, eq_comm, inf_comm, sup_comm],
   convert sup_inf_assoc_of_le (order_dual.of_dual y) (order_dual.dual_le.2 xz) })⟩
 
-theorem is_modular_lattice.sup_inf_sup_assoc {x y z : α} :
+variables {x y z : α}
+
+theorem is_modular_lattice.sup_inf_sup_assoc :
   (x ⊔ z) ⊓ (y ⊔ z) = ((x ⊔ z) ⊓ y) ⊔ z :=
 @is_modular_lattice.inf_sup_inf_assoc (order_dual α) _ _ _ _ _
 
-
-theorem eq_of_le_of_inf_le_of_sup_le
-  {x y z : α}
-  (hxy : x ≤ y)
-  (hinf : y ⊓ z ≤ x ⊓ z)
-  (hsup : y ⊔ z ≤ x ⊔ z) :
+theorem eq_of_le_of_inf_le_of_sup_le (hxy : x ≤ y) (hinf : y ⊓ z ≤ x ⊓ z) (hsup : y ⊔ z ≤ x ⊔ z) :
   x = y :=
 le_antisymm hxy $
   have h : y ≤ x ⊔ z,
@@ -78,21 +75,13 @@ le_antisymm hxy $
       (by rw [inf_comm, @inf_comm _ _ z]; exact hinf) _
     ... ≤ x : sup_le (le_refl _) inf_le_right
 
-theorem sup_lt_sup_of_lt_of_inf_le_inf
-  {x y z : α}
-  (hxy : x < y)
-  (hinf : y ⊓ z ≤ x ⊓ z) :
-  x ⊔ z < y ⊔ z :=
+theorem sup_lt_sup_of_lt_of_inf_le_inf (hxy : x < y) (hinf : y ⊓ z ≤ x ⊓ z) : x ⊔ z < y ⊔ z :=
 lt_of_le_of_ne
   (sup_le_sup_right (le_of_lt hxy) _)
   (λ hsup, ne_of_lt hxy $ eq_of_le_of_inf_le_of_sup_le (le_of_lt hxy) hinf
     (le_of_eq hsup.symm))
 
-theorem inf_lt_inf_of_lt_of_sup_le_sup
-  {x y z : α}
-  (hxy : x < y)
-  (hinf : y ⊔ z ≤ x ⊔ z) :
-  x ⊓ z < y ⊓ z :=
+theorem inf_lt_inf_of_lt_of_sup_le_sup (hxy : x < y) (hinf : y ⊔ z ≤ x ⊔ z) : x ⊓ z < y ⊓ z :=
 @sup_lt_sup_of_lt_of_inf_le_inf (order_dual α) _ _ _ _ _ hxy hinf
 
 /-- A generalization of the theorem that if `N` is a submodule of `M` and

--- a/src/order/modular_lattice.lean
+++ b/src/order/modular_lattice.lean
@@ -95,7 +95,8 @@ theorem inf_lt_inf_of_lt_of_sup_le_sup
   x ⊓ z < y ⊓ z :=
 @sup_lt_sup_of_lt_of_inf_le_inf (order_dual α) _ _ _ _ _ hxy hinf
 
-/-- A generalization of the theorem that  -/
+/-- A generalization of the theorem that if `N` is a submodule of `M` and
+  `N` and `M / N` are both Artinian, then `M` is Artinian. -/
 theorem well_founded_lt_exact_sequence
   {β γ : Type*} [partial_order β] [partial_order γ]
   (h₁ : well_founded ((<) : β → β → Prop))
@@ -118,6 +119,8 @@ subrelation.wf
     end)
   (inv_image.wf _ (prod.lex_wf h₁ h₂))
 
+/-- A generalization of the theorem that if `N` is a submodule of `M` and
+  `N` and `M / N` are both Noetherian, then `M` is Noetherian.  -/
 theorem well_founded_gt_exact_sequence
   {β γ : Type*} [partial_order β] [partial_order γ]
   (h₁ : well_founded ((>) : β → β → Prop))

--- a/src/order/modular_lattice.lean
+++ b/src/order/modular_lattice.lean
@@ -6,6 +6,7 @@ Authors: Aaron Anderson
 import order.rel_iso
 import order.lattice_intervals
 import order.order_dual
+import order.galois_connection
 
 /-!
 # Modular Lattices
@@ -59,6 +60,77 @@ instance : is_modular_lattice (order_dual α) :=
 theorem is_modular_lattice.sup_inf_sup_assoc {x y z : α} :
   (x ⊔ z) ⊓ (y ⊔ z) = ((x ⊔ z) ⊓ y) ⊔ z :=
 @is_modular_lattice.inf_sup_inf_assoc (order_dual α) _ _ _ _ _
+
+
+theorem eq_of_le_of_inf_le_of_sup_le
+  {x y z : α}
+  (hxy : x ≤ y)
+  (hinf : y ⊓ z ≤ x ⊓ z)
+  (hsup : y ⊔ z ≤ x ⊔ z) :
+  x = y :=
+le_antisymm hxy $
+  have h : y ≤ x ⊔ z,
+    from calc y ≤ y ⊔ z : le_sup_left
+      ... ≤ x ⊔ z : hsup,
+  calc y ≤ (x ⊔ z) ⊓ y : le_inf h (le_refl _)
+    ... = x ⊔ (z ⊓ y) : sup_inf_assoc_of_le _ hxy
+    ... ≤ x ⊔ (z ⊓ x) : sup_le_sup_left
+      (by rw [inf_comm, @inf_comm _ _ z]; exact hinf) _
+    ... ≤ x : sup_le (le_refl _) inf_le_right
+
+theorem sup_lt_sup_of_lt_of_inf_le_inf
+  {x y z : α}
+  (hxy : x < y)
+  (hinf : y ⊓ z ≤ x ⊓ z) :
+  x ⊔ z < y ⊔ z :=
+lt_of_le_of_ne
+  (sup_le_sup_right (le_of_lt hxy) _)
+  (λ hsup, ne_of_lt hxy $ eq_of_le_of_inf_le_of_sup_le (le_of_lt hxy) hinf
+    (le_of_eq hsup.symm))
+
+theorem inf_lt_inf_of_lt_of_sup_le_sup
+  {x y z : α}
+  (hxy : x < y)
+  (hinf : y ⊔ z ≤ x ⊔ z) :
+  x ⊓ z < y ⊓ z :=
+@sup_lt_sup_of_lt_of_inf_le_inf (order_dual α) _ _ _ _ _ hxy hinf
+
+/-- A generalization of the theorem that  -/
+theorem well_founded_lt_exact_sequence
+  {β γ : Type*} [partial_order β] [partial_order γ]
+  (h₁ : well_founded ((<) : β → β → Prop))
+  (h₂ : well_founded ((<) : γ → γ → Prop))
+  (K : α) (f₁ : β → α) (f₂ : α → β) (g₁ : γ → α) (g₂ : α → γ)
+  (gci : galois_coinsertion f₁ f₂)
+  (gi : galois_insertion g₂ g₁)
+  (hf : ∀ a, f₁ (f₂ a) = a ⊓ K)
+  (hg : ∀ a, g₁ (g₂ a) = a ⊔ K) :
+  well_founded ((<) : α → α → Prop) :=
+subrelation.wf
+  (λ A B hAB, show prod.lex (<) (<) (f₂ A, g₂ A) (f₂ B, g₂ B),
+    begin
+      simp only [prod.lex_def, lt_iff_le_not_le, ← gci.l_le_l_iff,
+        ← gi.u_le_u_iff, hf, hg, le_antisymm_iff],
+      simp only [gci.l_le_l_iff, gi.u_le_u_iff, ← lt_iff_le_not_le, ← le_antisymm_iff],
+      cases lt_or_eq_of_le (inf_le_inf_right K (le_of_lt hAB)) with h h,
+      { exact or.inl h },
+      { exact or.inr ⟨h, sup_lt_sup_of_lt_of_inf_le_inf hAB (le_of_eq h.symm)⟩ }
+    end)
+  (inv_image.wf _ (prod.lex_wf h₁ h₂))
+
+theorem well_founded_gt_exact_sequence
+  {β γ : Type*} [partial_order β] [partial_order γ]
+  (h₁ : well_founded ((>) : β → β → Prop))
+  (h₂ : well_founded ((>) : γ → γ → Prop))
+  (K : α) (f₁ : β → α) (f₂ : α → β) (g₁ : γ → α) (g₂ : α → γ)
+  (gci : galois_coinsertion f₁ f₂)
+  (gi : galois_insertion g₂ g₁)
+  (hf : ∀ a, f₁ (f₂ a) = a ⊓ K)
+  (hg : ∀ a, g₁ (g₂ a) = a ⊔ K) :
+  well_founded ((>) : α → α → Prop) :=
+@well_founded_lt_exact_sequence
+  (order_dual α) _ _ (order_dual γ) (order_dual β) _ _
+  h₂ h₁ K g₁ g₂ f₁ f₂ gi.dual gci.dual hg hf
 
 /-- The diamond isomorphism between the intervals `[a ⊓ b, a]` and `[b, a ⊔ b]` -/
 def inf_Icc_order_iso_Icc_sup (a b : α) : set.Icc (a ⊓ b) a ≃o set.Icc b (a ⊔ b) :=

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -448,7 +448,8 @@ end
 open is_noetherian submodule function
 
 section
-variables {R M N P : Type*} [ring R] [add_comm_group M] [module R M]
+universe w
+variables {R M P : Type*} {N : Type w} [ring R] [add_comm_group M] [module R M]
   [add_comm_group N] [module R N] [add_comm_group P] [module R P]
 
 theorem is_noetherian_iff_well_founded :
@@ -586,9 +587,6 @@ begin
   exact ⟨n, (λ m p,
     eq_bot_of_disjoint_absorbs (h m) ((eq.symm (w (m + 1) (le_add_right p))).trans (w m p)))⟩
 end
-
-universe w
-variables {N : Type w} [add_comm_group N] [module R N]
 
 /--
 If `M ⊕ N` embeds into `M`, for `M` noetherian over `R`, then `N` is trivial.

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -448,7 +448,8 @@ end
 open is_noetherian submodule function
 
 section
-variables {R M : Type*} [ring R] [add_comm_group M] [module R M]
+variables {R M N P : Type*} [ring R] [add_comm_group M] [module R M]
+  [add_comm_group N] [module R N] [add_comm_group P] [module R P]
 
 theorem is_noetherian_iff_well_founded :
   is_noetherian R M ↔ well_founded ((>) : submodule R M → submodule R M → Prop) :=
@@ -502,6 +503,29 @@ by rw [is_noetherian_iff_well_founded, well_founded.monotone_chain_condition]
 lemma is_noetherian.induction [is_noetherian R M] {P : submodule R M → Prop}
   (hgt : ∀ I, (∀ J > I, P J) → P I) (I : submodule R M) : P I :=
 well_founded.recursion (well_founded_submodule_gt R M) I hgt
+
+/-- If the first and final modules in a short exact sequence are noetherian,
+  then the middle module is also noetherian. -/
+theorem is_noetherian_of_range_eq_ker
+  [is_noetherian R M] [is_noetherian R P]
+  (f : M →ₗ[R] N) (g : N →ₗ[R] P)
+  (hf : function.injective f)
+  (hg : function.surjective g)
+  (h : f.range = g.ker) :
+  is_noetherian R N :=
+is_noetherian_iff_well_founded.2 $
+well_founded_gt_exact_sequence
+  (well_founded_submodule_gt R M)
+  (well_founded_submodule_gt R P)
+  f.range
+  (submodule.map f)
+  (submodule.comap f)
+  (submodule.comap g)
+  (submodule.map g)
+  (submodule.gci_map_comap hf)
+  (submodule.gi_map_comap hg)
+  (by simp [linear_map.map_comap_eq, inf_comm])
+  (by simp [linear_map.comap_map_eq, h])
 
 /--
 For any endomorphism of a Noetherian module, there is some nontrivial iterate


### PR DESCRIPTION
---
If `N` and `M / N` are noetherian, then `M` is noetherian. I proved a version of it for any modular lattice first, that way the same proof will apply for Artinian modules.

I'm kind of surprised this wasn't already there. Did I miss it?

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #8978

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
