### PR TITLE
[Merged by Bors] - feat(data/nat/choose/vandermonde): Vandermonde's identity for binomial coefficients

### DIFF
--- a/src/data/nat/choose/vandermonde.lean
+++ b/src/data/nat/choose/vandermonde.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2021 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin
+-/
+
+import data.nat.choose.basic
+import ring_theory.polynomial.basic
+
+/-!
+
+# Vandermonde's identity
+
+In this file we prove Vandermonde's identity (`nat.add_choose_eq`):
+`(m + n).choose k = ∑ (ij : ℕ × ℕ) in antidiagonal k, m.choose ij.1 * n.choose ij.2`
+
+We follow the algebraic proof from
+https://en.wikipedia.org/wiki/Vandermonde%27s_identity#Algebraic_proof .
+
+-/
+
+open_locale big_operators
+
+open polynomial finset.nat
+
+/-- Vandermonde's identity -/
+lemma nat.add_choose_eq (m n k : ℕ) :
+  (m + n).choose k = ∑ (ij : ℕ × ℕ) in antidiagonal k, m.choose ij.1 * n.choose ij.2 :=
+begin
+  calc (m + n).choose k
+      = ((X + 1) ^ (m + n)).coeff k : _
+  ... = ((X + 1) ^ m * (X + 1) ^ n).coeff k : by rw pow_add
+  ... = ∑ (ij : ℕ × ℕ) in antidiagonal k, m.choose ij.1 * n.choose ij.2 : _,
+  { rw [coeff_X_add_one_pow, nat.cast_id], },
+  { rw [coeff_mul, finset.sum_congr rfl],
+    simp only [coeff_X_add_one_pow, nat.cast_id, eq_self_iff_true, imp_true_iff], }
+end

--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -3,8 +3,10 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
 -/
-import data.finset.nat_antidiagonal
+
 import data.polynomial.basic
+import data.finset.nat_antidiagonal
+import data.nat.choose.sum
 
 /-!
 # Theory of univariate polynomials
@@ -147,6 +149,23 @@ by rw [C_mul_X_pow_eq_monomial, support_monomial n c H]
 
 lemma support_C_mul_X_pow' {c : R} {n : ℕ} : (C c * X^n).support ⊆ singleton n :=
 by { rw [C_mul_X_pow_eq_monomial], exact support_monomial' n c }
+
+lemma coeff_X_add_one_pow (R : Type*) [semiring R] (n k : ℕ) :
+  ((X + 1) ^ n).coeff k = (n.choose k : R) :=
+begin
+  rw [(commute_X (1 : polynomial R)).add_pow, ← lcoeff_apply, linear_map.map_sum],
+  simp only [one_pow, mul_one, lcoeff_apply, ← C_eq_nat_cast, coeff_mul_C, nat.cast_id],
+  rw [finset.sum_eq_single k, coeff_X_pow_self, one_mul],
+  { intros _ _,
+    simp only [coeff_X_pow, boole_mul, ite_eq_right_iff, ne.def] {contextual := tt},
+    rintro h rfl, contradiction },
+  { simp only [coeff_X_pow_self, one_mul, not_lt, finset.mem_range],
+    intro h, rw [nat.choose_eq_zero_of_lt h, nat.cast_zero], }
+end
+
+lemma coeff_one_add_X_pow (R : Type*) [semiring R] (n k : ℕ) :
+  ((1 + X) ^ n).coeff k = (n.choose k : R) :=
+by rw [add_comm _ X, coeff_X_add_one_pow]
 
 lemma C_dvd_iff_dvd_coeff (r : R) (φ : polynomial R) :
   C r ∣ φ ↔ ∀ i, r ∣ φ.coeff i :=


### PR DESCRIPTION
I place this identity in a new file because the current proof depends on `polynomial`.




---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)