### PR TITLE
[Merged by Bors] - feat(data/nat/enat): refactor coe from nat to enat

### DIFF
--- a/src/algebra/squarefree.lean
+++ b/src/algebra/squarefree.lean
@@ -79,7 +79,7 @@ begin
   refine forall_congr (λ a, _),
   rw [← sq, pow_dvd_iff_le_multiplicity, or_iff_not_imp_left, not_le, imp_congr],
   swap, { refl },
-  convert enat.add_one_le_iff_lt (enat.coe_ne_top _),
+  convert enat.add_one_le_iff_lt (enat.coe_ne_top 1),
   norm_cast,
 end
 

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -45,23 +45,38 @@ followed by `@[simp] lemma to_with_top_zero'` whose proof uses `convert`.
 
 enat, with_top ℕ
 -/
-open part
+open part (hiding some)
 
 /-- Type of natural numbers with infinity (`⊤`) -/
 def enat : Type := part ℕ
 
 namespace enat
 
+/-- The computable embedding `ℕ → enat` -/
+def some : ℕ → enat := part.some
+
 instance : has_zero enat := ⟨some 0⟩
 instance : inhabited enat := ⟨0⟩
 instance : has_one enat := ⟨some 1⟩
 instance : has_add enat := ⟨λ x y, ⟨x.dom ∧ y.dom, λ h, get x h.1 + get y h.2⟩⟩
-instance : has_coe ℕ enat := ⟨some⟩
-instance (n : ℕ) : decidable (n : enat).dom := is_true trivial
 
-@[simp] lemma coe_inj {x y : ℕ} : (x : enat) = y ↔ x = y := part.some_inj
+instance (n : ℕ) : decidable (some n).dom := is_true trivial
 
-@[simp] lemma dom_coe (x : ℕ) : (x : enat).dom := trivial
+lemma some_eq_coe (n : ℕ) : some n = n :=
+begin
+  induction n with n ih, { refl },
+  apply part.ext',
+  { show true ↔ ((n : enat).dom ∧ true), rw [← ih, and_true], exact iff.rfl },
+  { intros h H, show n.succ = (n : enat).get H.1 + 1,
+    rw [nat.cast_succ] at H, revert H, simp only [← ih], intro, refl },
+end
+
+@[simp] lemma coe_inj {x y : ℕ} : (x : enat) = y ↔ x = y :=
+by simpa only [← some_eq_coe] using part.some_inj
+
+@[simp] lemma dom_some (x : ℕ) : (some x).dom := trivial
+
+@[simp] lemma dom_coe (x : ℕ) : (x : enat).dom := by rw [← some_eq_coe]; trivial
 
 instance : add_comm_monoid enat :=
 { add       := (+),
@@ -79,9 +94,13 @@ instance : has_sup enat := ⟨λ x y, ⟨x.dom ∧ y.dom, λ h, x.get h.1 ⊔ y.
 lemma le_def (x y : enat) : x ≤ y ↔ ∃ h : y.dom → x.dom, ∀ hy : y.dom, x.get (h hy) ≤ y.get hy :=
 iff.rfl
 
-@[elab_as_eliminator] protected lemma cases_on {P : enat → Prop} : ∀ a : enat,
-  P ⊤ → (∀ n : ℕ, P n) → P a :=
+@[elab_as_eliminator] protected lemma cases_on' {P : enat → Prop} :
+  ∀ a : enat, P ⊤ → (∀ n : ℕ, P (some n)) → P a :=
 part.induction_on
+
+@[elab_as_eliminator] protected lemma cases_on {P : enat → Prop} :
+  ∀ a : enat, P ⊤ → (∀ n : ℕ, P n) → P a :=
+by { simp only [← some_eq_coe], exact enat.cases_on' }
 
 @[simp] lemma top_add (x : enat) : ⊤ + x = ⊤ :=
 part.ext' (false_and _) (λ h, h.left.elim)
@@ -91,23 +110,24 @@ by rw [add_comm, top_add]
 
 @[simp, norm_cast] lemma coe_zero : ((0 : ℕ) : enat) = 0 := rfl
 
-@[simp, norm_cast] lemma coe_one : ((1 : ℕ) : enat) = 1 := rfl
+@[simp, norm_cast] lemma coe_one : ((1 : ℕ) : enat) = 1 := nat.cast_one
 
-@[simp, norm_cast] lemma coe_add (x y : ℕ) : ((x + y : ℕ) : enat) = x + y :=
-part.ext' (and_true _).symm (λ _ _, rfl)
+@[simp, norm_cast] lemma coe_add (x y : ℕ) : ((x + y : ℕ) : enat) = x + y := nat.cast_add _ _
 
-lemma get_coe {x : ℕ} : get (x : enat) true.intro = x := rfl
+@[simp] lemma coe_get {x : enat} (h : x.dom) : (x.get h : enat) = x :=
+by { rw [← some_eq_coe], exact part.ext' (iff_of_true trivial h) (λ _ _, rfl) }
 
-@[simp, norm_cast] lemma get_coe' (x : ℕ) (h : (x : enat).dom) : get (x : enat) h = x := rfl
+@[simp, norm_cast] lemma get_coe' (x : ℕ) (h : (x : enat).dom) : get (x : enat) h = x :=
+by rw [← coe_inj, coe_get]
+
+lemma get_coe {x : ℕ} : get (x : enat) (dom_coe x) = x := get_coe' _ _
 
 lemma coe_add_get {x : ℕ} {y : enat} (h : ((x : enat) + y).dom) :
-  get ((x : enat) + y) h = x + get y h.2 := rfl
+  get ((x : enat) + y) h = x + get y h.2 :=
+by { simp only [← some_eq_coe] at h ⊢, refl }
 
 @[simp] lemma get_add {x y : enat} (h : (x + y).dom) :
   get (x + y) h = x.get h.1 + y.get h.2 := rfl
-
-@[simp] lemma coe_get {x : enat} (h : x.dom) : (x.get h : enat) = x :=
-part.ext' (iff_of_true trivial h) (λ _ _, rfl)
 
 @[simp] lemma get_zero (h : (0 : enat).dom) : (0 : enat).get h = 0 := rfl
 
@@ -115,7 +135,10 @@ part.ext' (iff_of_true trivial h) (λ _ _, rfl)
 
 lemma dom_of_le_of_dom {x y : enat} : x ≤ y → y.dom → x.dom := λ ⟨h, _⟩, h
 
-lemma dom_of_le_some {x : enat} {y : ℕ} (h : x ≤ y) : x.dom := dom_of_le_of_dom h trivial
+lemma dom_of_le_some {x : enat} {y : ℕ} (h : x ≤ some y) : x.dom := dom_of_le_of_dom h trivial
+
+lemma dom_of_le_coe {x : enat} {y : ℕ} (h : x ≤ y) : x.dom :=
+by { rw [← some_eq_coe] at h, exact dom_of_le_some h }
 
 instance decidable_le (x y : enat) [decidable x.dom] [decidable y.dom] : decidable (x ≤ y) :=
 if hx : x.dom
@@ -155,7 +178,7 @@ begin
 end
 
 @[simp, norm_cast] lemma coe_le_coe {x y : ℕ} : (x : enat) ≤ y ↔ x ≤ y :=
-⟨λ ⟨_, h⟩, h trivial, λ h, ⟨λ _, trivial, λ _, h⟩⟩
+by { rw [← some_eq_coe, ← some_eq_coe], exact ⟨λ ⟨_, h⟩, h trivial, λ h, ⟨λ _, trivial, λ _, h⟩⟩ }
 
 @[simp, norm_cast] lemma coe_lt_coe {x y : ℕ} : (x : enat) < y ↔ x < y :=
 by rw [lt_iff_le_not_le, lt_iff_le_not_le, coe_le_coe, coe_le_coe]
@@ -166,8 +189,9 @@ by conv { to_lhs, rw [← coe_le_coe, coe_get, coe_get]}
 
 lemma le_coe_iff (x : enat) (n : ℕ) : x ≤ n ↔ ∃ h : x.dom, x.get h ≤ n :=
 begin
+  rw [← some_eq_coe],
   show (∃ (h : true → x.dom), _) ↔ ∃ h : x.dom, x.get h ≤ n,
-  simp only [forall_prop_of_true, dom_coe, get_coe'],
+  simp only [forall_prop_of_true, some_eq_coe, dom_coe, get_coe'],
   split; rintro ⟨_, _⟩; refine ⟨_, _⟩; intros; try { assumption }
 end
 
@@ -175,10 +199,18 @@ lemma lt_coe_iff (x : enat) (n : ℕ) : x < n ↔ ∃ h : x.dom, x.get h < n :=
 by simp only [lt_def, forall_prop_of_true, get_coe', dom_coe]
 
 lemma coe_le_iff (n : ℕ) (x : enat) : (n : enat) ≤ x ↔ ∀ h : x.dom, n ≤ x.get h :=
-by simpa only [le_def, exists_prop_of_true, dom_coe, forall_true_iff] using iff.rfl
+begin
+  rw [← some_eq_coe],
+  simp only [le_def, exists_prop_of_true, dom_some, forall_true_iff],
+  refl,
+end
 
 lemma coe_lt_iff (n : ℕ) (x : enat) : (n : enat) < x ↔ ∀ h : x.dom, n < x.get h :=
-by simpa only [lt_def, exists_prop_of_true, dom_coe] using iff.rfl
+begin
+  rw [← some_eq_coe],
+  simp only [lt_def, exists_prop_of_true, dom_some, forall_true_iff],
+  refl,
+end
 
 protected lemma zero_lt_one : (0 : enat) < 1 :=
 by { norm_cast, norm_num }
@@ -199,16 +231,17 @@ instance order_top : order_top enat :=
   ..enat.semilattice_sup_bot }
 
 lemma dom_of_lt {x y : enat} : x < y → x.dom :=
-enat.cases_on x not_top_lt $ λ _ _, trivial
+enat.cases_on x not_top_lt $ λ _ _, dom_coe _
 
 lemma top_eq_none : (⊤ : enat) = none := rfl
 
 @[simp] lemma coe_lt_top (x : ℕ) : (x : enat) < ⊤ :=
-lt_of_le_of_ne le_top (λ h, absurd (congr_arg dom h) true_ne_false)
+lt_of_le_of_ne le_top (λ h, absurd (congr_arg dom h) $ by simpa only [dom_coe] using true_ne_false)
 
 @[simp] lemma coe_ne_top (x : ℕ) : (x : enat) ≠ ⊤ := ne_of_lt (coe_lt_top x)
 
-lemma ne_top_iff {x : enat} : x ≠ ⊤ ↔ ∃(n : ℕ), x = n := part.ne_none_iff
+lemma ne_top_iff {x : enat} : x ≠ ⊤ ↔ ∃(n : ℕ), x = n :=
+by simpa only [← some_eq_coe] using part.ne_none_iff
 
 lemma ne_top_iff_dom {x : enat} : x ≠ ⊤ ↔ x.dom :=
 by classical; exact not_iff_comm.1 part.eq_none_iff'.symm
@@ -228,9 +261,8 @@ lemma eq_top_iff_forall_le (x : enat) : x = ⊤ ↔ ∀ n : ℕ, (n : enat) ≤ 
 ⟨λ h n, (h n).le, λ h n, lt_of_lt_of_le (coe_lt_coe.mpr n.lt_succ_self) (h (n + 1))⟩
 
 lemma pos_iff_one_le {x : enat} : 0 < x ↔ 1 ≤ x :=
-enat.cases_on x ⟨λ _, le_top, λ _, coe_lt_top _⟩
-  (λ n, ⟨λ h, enat.coe_le_coe.2 (enat.coe_lt_coe.1 h),
-    λ h, enat.coe_lt_coe.2 (enat.coe_le_coe.1 h)⟩)
+enat.cases_on x (by simp only [iff_true, le_top, coe_lt_top, ← enat.coe_zero]) $
+  λ n, by { rw [← enat.coe_zero, ← enat.coe_one, enat.coe_lt_coe, enat.coe_le_coe], refl }
 
 noncomputable instance : linear_order enat :=
 { le_total := λ x y, enat.cases_on x
@@ -257,8 +289,8 @@ lemma inf_eq_min {a b : enat} : a ⊓ b = min a b := rfl
 instance : ordered_add_comm_monoid enat :=
 { add_le_add_left := λ a b ⟨h₁, h₂⟩ c,
     enat.cases_on c (by simp)
-      (λ c, ⟨λ h, and.intro trivial (h₁ h.2),
-        λ _, add_le_add_left (h₂ _) c⟩),
+      (λ c, ⟨λ h, and.intro (dom_coe _) (h₁ h.2),
+        λ h, by simpa only [coe_add_get] using add_le_add_left (h₂ _) c⟩),
   lt_of_add_lt_add_left := λ a b c, enat.cases_on a
     (λ h, by simpa [lt_irrefl] using h)
     (λ a, enat.cases_on b
@@ -368,7 +400,10 @@ lemma to_with_top_zero : to_with_top 0 = 0 := rfl
 @[simp] lemma to_with_top_zero' {h : decidable (0 : enat).dom} : to_with_top 0 = 0 :=
 by convert to_with_top_zero
 
-lemma to_with_top_coe (n : ℕ) : to_with_top n = n := rfl
+lemma to_with_top_some (n : ℕ) : to_with_top (some n) = n := rfl
+
+lemma to_with_top_coe (n : ℕ) {_ : decidable (n : enat).dom} : to_with_top n = n :=
+by { simp only [← some_eq_coe, ← to_with_top_some], congr }
 
 @[simp] lemma to_with_top_coe' (n : ℕ) {h : decidable (n : enat).dom} :
   to_with_top (n : enat) = n :=
@@ -401,7 +436,7 @@ end
 /-- `equiv` between `enat` and `with_top ℕ` (for the order isomorphism see `with_top_order_iso`). -/
 noncomputable def with_top_equiv : enat ≃ with_top ℕ :=
 { to_fun := λ x, to_with_top x,
-  inv_fun := λ x, match x with (some n) := coe n | none := ⊤ end,
+  inv_fun := λ x, match x with (option.some n) := coe n | none := ⊤ end,
   left_inv := λ x, by apply enat.cases_on x; intros; simp; refl,
   right_inv := λ x, by cases x; simp [with_top_equiv._match_1]; refl }
 
@@ -412,7 +447,7 @@ to_with_top_top'
 to_with_top_coe' _
 
 @[simp] lemma with_top_equiv_zero : with_top_equiv 0 = 0 :=
-with_top_equiv_coe _
+enat.coe_zero ▸ with_top_equiv_coe _
 
 @[simp] lemma with_top_equiv_le {x y : enat} : with_top_equiv x ≤ with_top_equiv y ↔ x ≤ y :=
 to_with_top_le

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -108,12 +108,6 @@ part.ext' (false_and _) (λ h, h.left.elim)
 @[simp] lemma add_top (x : enat) : x + ⊤ = ⊤ :=
 by rw [add_comm, top_add]
 
-@[simp, norm_cast] lemma coe_zero : ((0 : ℕ) : enat) = 0 := rfl
-
-@[simp, norm_cast] lemma coe_one : ((1 : ℕ) : enat) = 1 := nat.cast_one
-
-@[simp, norm_cast] lemma coe_add (x y : ℕ) : ((x + y : ℕ) : enat) = x + y := nat.cast_add _ _
-
 @[simp] lemma coe_get {x : enat} (h : x.dom) : (x.get h : enat) = x :=
 by { rw [← some_eq_coe], exact part.ext' (iff_of_true trivial h) (λ _ _, rfl) }
 
@@ -157,7 +151,7 @@ then is_false $ λ h, hx $ dom_of_le_of_dom h hy
 else is_true ⟨λ h, (hy h).elim, λ h, (hy h).elim⟩
 
 /-- The coercion `ℕ → enat` preserves `0` and addition. -/
-def coe_hom : ℕ →+ enat := ⟨coe, enat.coe_zero, enat.coe_add⟩
+def coe_hom : ℕ →+ enat := ⟨coe, nat.cast_zero, nat.cast_add⟩
 
 instance : partial_order enat :=
 { le          := (≤),
@@ -267,8 +261,8 @@ lemma eq_top_iff_forall_le (x : enat) : x = ⊤ ↔ ∀ n : ℕ, (n : enat) ≤ 
 ⟨λ h n, (h n).le, λ h n, lt_of_lt_of_le (coe_lt_coe.mpr n.lt_succ_self) (h (n + 1))⟩
 
 lemma pos_iff_one_le {x : enat} : 0 < x ↔ 1 ≤ x :=
-enat.cases_on x (by simp only [iff_true, le_top, coe_lt_top, ← enat.coe_zero]) $
-  λ n, by { rw [← enat.coe_zero, ← enat.coe_one, enat.coe_lt_coe, enat.coe_le_coe], refl }
+enat.cases_on x (by simp only [iff_true, le_top, coe_lt_top, ← @nat.cast_zero enat]) $
+  λ n, by { rw [← nat.cast_zero, ← nat.cast_one, enat.coe_lt_coe, enat.coe_le_coe], refl }
 
 noncomputable instance : linear_order enat :=
 { le_total := λ x y, enat.cases_on x
@@ -303,7 +297,7 @@ instance : ordered_add_comm_monoid enat :=
       (λ h, absurd h (not_lt_of_ge (by rw add_top; exact le_top)))
       (λ b, enat.cases_on c
         (λ _, coe_lt_top _)
-        (λ c h,  coe_lt_coe.2 (by rw [← coe_add, ← coe_add, coe_lt_coe] at h;
+        (λ c h,  coe_lt_coe.2 (by rw [← nat.cast_add, ← nat.cast_add, coe_lt_coe] at h;
             exact lt_of_add_lt_add_left h)))),
   ..enat.linear_order,
   ..enat.add_comm_monoid }
@@ -315,11 +309,11 @@ instance : canonically_ordered_add_monoid enat :=
       (iff_of_false (not_le_of_gt (coe_lt_top _))
         (not_exists.2 (λ x, ne_of_lt (by rw [top_add]; exact coe_lt_top _))))
       (λ a, ⟨λ h, ⟨(b - a : ℕ),
-          by rw [← coe_add, coe_inj, add_comm, nat.sub_add_cancel (coe_le_coe.1 h)]⟩,
+          by rw [← nat.cast_add, coe_inj, add_comm, nat.sub_add_cancel (coe_le_coe.1 h)]⟩,
         (λ ⟨c, hc⟩, enat.cases_on c
           (λ hc, hc.symm ▸ show (a : enat) ≤ a + ⊤, by rw [add_top]; exact le_top)
           (λ c (hc : (b : enat) = a + c),
-            coe_le_coe.2 (by rw [← coe_add, coe_inj] at hc;
+            coe_le_coe.2 (by rw [← nat.cast_add, coe_inj] at hc;
               rw hc; exact nat.le_add_right _ _)) hc)⟩)),
   ..enat.semilattice_sup_bot,
   ..enat.ordered_add_comm_monoid }
@@ -377,14 +371,14 @@ end
 
 lemma add_eq_top_iff {a b : enat} : a + b = ⊤ ↔ a = ⊤ ∨ b = ⊤ :=
 by apply enat.cases_on a; apply enat.cases_on b;
-  simp; simp only [(enat.coe_add _ _).symm, enat.coe_ne_top]; simp
+  simp; simp only [(nat.cast_add _ _).symm, enat.coe_ne_top]; simp
 
 protected lemma add_right_cancel_iff {a b c : enat} (hc : c ≠ ⊤) : a + c = b + c ↔ a = b :=
 begin
   rcases ne_top_iff.1 hc with ⟨c, rfl⟩,
   apply enat.cases_on a; apply enat.cases_on b;
   simp [add_eq_top_iff, coe_ne_top, @eq_comm _ (⊤ : enat)];
-  simp only [(enat.coe_add _ _).symm, add_left_cancel_iff, enat.coe_inj, add_comm];
+  simp only [(nat.cast_add _ _).symm, add_left_cancel_iff, enat.coe_inj, add_comm];
   tauto
 end
 
@@ -453,7 +447,7 @@ to_with_top_top'
 to_with_top_coe' _
 
 @[simp] lemma with_top_equiv_zero : with_top_equiv 0 = 0 :=
-enat.coe_zero ▸ with_top_equiv_coe _
+by simpa only [nat.cast_zero] using with_top_equiv_coe 0
 
 @[simp] lemma with_top_equiv_le {x y : enat} : with_top_equiv x ≤ with_top_equiv y ↔ x ≤ y :=
 to_with_top_le

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -133,6 +133,12 @@ by { simp only [← some_eq_coe] at h ⊢, refl }
 
 @[simp] lemma get_one (h : (1 : enat).dom) : (1 : enat).get h = 1 := rfl
 
+lemma get_eq_iff_eq_some {a : enat} {ha : a.dom} {b : ℕ} :
+  a.get ha = b ↔ a = some b := get_eq_iff_eq_some
+
+lemma get_eq_iff_eq_coe {a : enat} {ha : a.dom} {b : ℕ} :
+  a.get ha = b ↔ a = b := by rw [get_eq_iff_eq_some, some_eq_coe]
+
 lemma dom_of_le_of_dom {x y : enat} : x ≤ y → y.dom → x.dom := λ ⟨h, _⟩, h
 
 lemma dom_of_le_some {x : enat} {y : ℕ} (h : x ≤ some y) : x.dom := dom_of_le_of_dom h trivial

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -242,11 +242,11 @@ enat.cases_on x not_top_lt $ λ _ _, dom_coe _
 lemma top_eq_none : (⊤ : enat) = none := rfl
 
 @[simp] lemma coe_lt_top (x : ℕ) : (x : enat) < ⊤ :=
-lt_of_le_of_ne le_top (λ h, absurd (congr_arg dom h) $ by simpa only [dom_coe] using true_ne_false)
+ne.lt_top (λ h, absurd (congr_arg dom h) $ by simpa only [dom_coe] using true_ne_false)
 
 @[simp] lemma coe_ne_top (x : ℕ) : (x : enat) ≠ ⊤ := ne_of_lt (coe_lt_top x)
 
-lemma ne_top_iff {x : enat} : x ≠ ⊤ ↔ ∃(n : ℕ), x = n :=
+lemma ne_top_iff {x : enat} : x ≠ ⊤ ↔ ∃ (n : ℕ), x = n :=
 by simpa only [← some_eq_coe] using part.ne_none_iff
 
 lemma ne_top_iff_dom {x : enat} : x ≠ ⊤ ↔ x.dom :=

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -154,10 +154,9 @@ then is_false $ λ h, hx $ dom_of_le_of_dom h hy
 else is_true ⟨λ h, (hy h).elim, λ h, (hy h).elim⟩
 
 /-- The coercion `ℕ → enat` preserves `0` and addition. -/
-def coe_hom : ℕ →+ enat :=
-⟨some, nat.cast_zero, λ m n, by { simp only [some_eq_coe], apply nat.cast_add }⟩
+def coe_hom : ℕ →+ enat := ⟨coe, nat.cast_zero, nat.cast_add⟩
 
-@[simp] lemma coe_coe_hom : ⇑coe_hom = coe := funext $ λ n, some_eq_coe n
+@[simp] lemma coe_coe_hom : ⇑coe_hom = coe := rfl
 
 instance : partial_order enat :=
 { le          := (≤),

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -52,7 +52,10 @@ def enat : Type := part ℕ
 
 namespace enat
 
-/-- The computable embedding `ℕ → enat` -/
+/-- The computable embedding `ℕ → enat`.
+
+This coincides with the coercion `coe : ℕ → enat`, see `enat.some_eq_coe`.
+However, `coe` is noncomputable so `some` is preferable when computability is a concern. -/
 def some : ℕ → enat := part.some
 
 instance : has_zero enat := ⟨some 0⟩
@@ -151,7 +154,10 @@ then is_false $ λ h, hx $ dom_of_le_of_dom h hy
 else is_true ⟨λ h, (hy h).elim, λ h, (hy h).elim⟩
 
 /-- The coercion `ℕ → enat` preserves `0` and addition. -/
-def coe_hom : ℕ →+ enat := ⟨coe, nat.cast_zero, nat.cast_add⟩
+def coe_hom : ℕ →+ enat :=
+⟨some, nat.cast_zero, λ m n, by { simp only [some_eq_coe], apply nat.cast_add }⟩
+
+@[simp] lemma coe_coe_hom : ⇑coe_hom = coe := funext $ λ n, some_eq_coe n
 
 instance : partial_order enat :=
 { le          := (≤),

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -289,8 +289,8 @@ lemma inf_eq_min {a b : enat} : a ⊓ b = min a b := rfl
 instance : ordered_add_comm_monoid enat :=
 { add_le_add_left := λ a b ⟨h₁, h₂⟩ c,
     enat.cases_on c (by simp)
-      (λ c, ⟨λ h, and.intro trivial (h₁ h.2),
-        λ _, add_le_add_left (h₂ _) c⟩),
+      (λ c, ⟨λ h, and.intro (dom_coe _) (h₁ h.2),
+        λ h, by simpa only [coe_add_get] using add_le_add_left (h₂ _) c⟩),
   ..enat.linear_order,
   ..enat.add_comm_monoid }
 

--- a/src/data/nat/multiplicity.lean
+++ b/src/data/nat/multiplicity.lean
@@ -135,7 +135,7 @@ begin
   induction n with n ih,
   { simp },
   { simp only [succ_eq_add_one, multiplicity.mul, hp, prime_iff.mp hp, ih,
-      multiplicity_factorial_mul_succ, ←add_assoc, enat.coe_one, enat.coe_add, factorial_succ],
+      multiplicity_factorial_mul_succ, ←add_assoc, nat.cast_one, nat.cast_add, factorial_succ],
     congr' 1,
     rw [add_comm, add_assoc] }
 end
@@ -199,7 +199,7 @@ else begin
     multiplicity_eq_card_pow_dvd (ne_of_gt hp.one_lt) (nat.pos_of_ne_zero hk0)
       (lt_succ_of_le (log_le_log_of_le (le_of_not_gt hkn))),
     multiplicity_eq_card_pow_dvd (ne_of_gt hp.one_lt) (nat.pos_of_ne_zero hn0) (lt_succ_self _),
-    ← enat.coe_add, enat.coe_le_coe],
+    ← nat.cast_add, enat.coe_le_coe],
   calc ((Ico 1 (log p n).succ).filter (λ i, p ^ i ∣ n)).card
       ≤ ((Ico 1 (log p n).succ).filter (λ i, p ^ i ≤ k % p ^ i + (n - k) % p ^ i) ∪
         (Ico 1 (log p n).succ).filter (λ i, p ^ i ∣ k) ).card :
@@ -226,7 +226,7 @@ le_antisymm
     rw [multiplicity_choose hp hkn (lt_succ_self _),
       multiplicity_eq_card_pow_dvd (ne_of_gt hp.one_lt) hk0
         (lt_succ_of_le (log_le_log_of_le hkn)),
-      ← enat.coe_add, enat.coe_le_coe, log_pow hp.one_lt,
+      ← nat.cast_add, enat.coe_le_coe, log_pow hp.one_lt,
       ← card_disjoint_union hdisj, filter_union_right],
     have filter_le_Ico := (Ico 1 n.succ).card_filter_le _,
     rwa Ico.card 1 n.succ at filter_le_Ico,

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -167,7 +167,7 @@ lemma root_multiplicity_eq_zero {p : polynomial R} {x : R} (h : ¬ is_root p x) 
 begin
   rw root_multiplicity_eq_multiplicity,
   split_ifs, { refl },
-  rw [← enat.coe_inj, enat.coe_get, multiplicity.multiplicity_eq_zero_of_not_dvd, enat.coe_zero],
+  rw [← enat.coe_inj, enat.coe_get, multiplicity.multiplicity_eq_zero_of_not_dvd, nat.cast_zero],
   intro hdvd,
   exact h (dvd_iff_is_root.mp hdvd)
 end

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -473,7 +473,7 @@ begin
   apply is_unit_of_self_mul_dvd_separable hsep,
   rw ← sq,
   apply multiplicity.pow_dvd_of_le_multiplicity,
-  exact_mod_cast (enat.add_one_le_of_lt hq)
+  simpa only [enat.coe_one, nat.cast_bit0] using enat.add_one_le_of_lt hq
 end
 
 lemma separable.squarefree {p : polynomial F}  (hsep : separable p) : squarefree p :=
@@ -521,7 +521,7 @@ lemma squarefree_X_pow_sub_C {n : ℕ} (a : F) (hn : (n : F) ≠ 0) (ha : a ≠ 
 lemma root_multiplicity_le_one_of_separable {p : polynomial F} (hp : p ≠ 0)
   (hsep : separable p) (x : F) : root_multiplicity x p ≤ 1 :=
 begin
-  rw [root_multiplicity_eq_multiplicity, dif_neg hp, ← enat.coe_le_coe, enat.coe_get],
+  rw [root_multiplicity_eq_multiplicity, dif_neg hp, ← enat.coe_le_coe, enat.coe_get, enat.coe_one],
   exact multiplicity_le_one_of_separable (not_unit_X_sub_C _) hsep
 end
 

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -473,7 +473,7 @@ begin
   apply is_unit_of_self_mul_dvd_separable hsep,
   rw ← sq,
   apply multiplicity.pow_dvd_of_le_multiplicity,
-  simpa only [enat.coe_one, nat.cast_bit0] using enat.add_one_le_of_lt hq
+  simpa only [nat.cast_one, nat.cast_bit0] using enat.add_one_le_of_lt hq
 end
 
 lemma separable.squarefree {p : polynomial F}  (hsep : separable p) : squarefree p :=
@@ -521,7 +521,7 @@ lemma squarefree_X_pow_sub_C {n : ℕ} (a : F) (hn : (n : F) ≠ 0) (ha : a ≠ 
 lemma root_multiplicity_le_one_of_separable {p : polynomial F} (hp : p ≠ 0)
   (hsep : separable p) (x : F) : root_multiplicity x p ≤ 1 :=
 begin
-  rw [root_multiplicity_eq_multiplicity, dif_neg hp, ← enat.coe_le_coe, enat.coe_get, enat.coe_one],
+  rw [root_multiplicity_eq_multiplicity, dif_neg hp, ← enat.coe_le_coe, enat.coe_get, nat.cast_one],
   exact multiplicity_le_one_of_separable (not_unit_X_sub_C _) hsep
 end
 

--- a/src/number_theory/padics/padic_norm.lean
+++ b/src/number_theory/padics/padic_norm.lean
@@ -169,7 +169,7 @@ begin
   rw @padic_val_nat_def _ prime _ nonzero,
   let one_le_mul : _ ≤ multiplicity p n :=
     @multiplicity.le_multiplicity_of_pow_dvd _ _ _ p n 1 (begin norm_num, exact div end),
-  simp only [enat.coe_one] at one_le_mul,
+  simp only [nat.cast_one] at one_le_mul,
   rcases one_le_mul with ⟨_, q⟩,
   dsimp at q,
   solve_by_elim,
@@ -422,8 +422,8 @@ lemma pow_succ_padic_val_nat_not_dvd {p n : ℕ} [hp : fact (nat.prime p)] (hn :
 begin
   { rw multiplicity.pow_dvd_iff_le_multiplicity,
     rw padic_val_nat_def (ne_of_gt hn),
-    { rw [enat.coe_add, enat.coe_get],
-      simp only [enat.coe_one, not_le],
+    { rw [nat.cast_add, enat.coe_get],
+      simp only [nat.cast_one, not_le],
       apply enat.lt_add_one (ne_top_iff_finite.2 (finite_nat_iff.2 ⟨hp.elim.ne_one, hn⟩)) },
     { apply_instance } }
 end

--- a/src/number_theory/padics/padic_numbers.lean
+++ b/src/number_theory/padics/padic_numbers.lean
@@ -907,7 +907,7 @@ begin
       simp only [neg_eq_zero],
       rw padic_val_rat.padic_val_rat_of_int _ hp.1.ne_one H,
       norm_cast,
-      rw [← enat.coe_inj, enat.coe_get, enat.coe_zero],
+      rw [← enat.coe_inj, enat.coe_get, nat.cast_zero],
       apply multiplicity.multiplicity_eq_zero_of_not_dvd h } },
   { rintro ⟨x, rfl⟩,
     push_cast,

--- a/src/ring_theory/discrete_valuation_ring.lean
+++ b/src/ring_theory/discrete_valuation_ring.lean
@@ -414,7 +414,7 @@ add_val_def _ u hϖ n rfl
 (add_val R).map_one
 
 @[simp] lemma add_val_uniformizer {ϖ : R} (hϖ : irreducible ϖ) : add_val R ϖ = 1 :=
-add_val_def ϖ 1 hϖ 1 (by simp)
+enat.coe_one ▸ add_val_def ϖ 1 hϖ 1 (by simp)
 
 @[simp] lemma add_val_mul {a b : R} :
   add_val R (a * b) = add_val R a + add_val R b :=

--- a/src/ring_theory/discrete_valuation_ring.lean
+++ b/src/ring_theory/discrete_valuation_ring.lean
@@ -414,7 +414,7 @@ add_val_def _ u hϖ n rfl
 (add_val R).map_one
 
 @[simp] lemma add_val_uniformizer {ϖ : R} (hϖ : irreducible ϖ) : add_val R ϖ = 1 :=
-enat.coe_one ▸ add_val_def ϖ 1 hϖ 1 (by simp)
+nat.cast_one ▸ add_val_def ϖ 1 hϖ 1 (by simp)
 
 @[simp] lemma add_val_mul {a b : R} :
   add_val R (a * b) = add_val R a + add_val R b :=

--- a/src/ring_theory/discrete_valuation_ring.lean
+++ b/src/ring_theory/discrete_valuation_ring.lean
@@ -414,7 +414,8 @@ add_val_def _ u hϖ n rfl
 (add_val R).map_one
 
 @[simp] lemma add_val_uniformizer {ϖ : R} (hϖ : irreducible ϖ) : add_val R ϖ = 1 :=
-nat.cast_one ▸ add_val_def ϖ 1 hϖ 1 (by simp)
+by simpa only [one_mul, eq_self_iff_true, units.coe_one, pow_one, forall_true_left, nat.cast_one]
+  using add_val_def ϖ 1 hϖ 1
 
 @[simp] lemma add_val_mul {a b : R} :
   add_val R (a * b) = add_val R a + add_val R b :=

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -150,7 +150,7 @@ lemma unit_right {a : α} (ha : ¬is_unit a) (u : units α) : multiplicity a u =
 is_unit_right ha u.is_unit
 
 lemma multiplicity_eq_zero_of_not_dvd {a b : α} (ha : ¬a ∣ b) : multiplicity a b = 0 :=
-enat.coe_zero ▸ eq_coe_iff.2 $ show a ^ 0 ∣ b ∧ ¬a ^ (0 + 1) ∣ b, by simpa
+nat.cast_zero ▸ eq_coe_iff.2 $ show a ^ 0 ∣ b ∧ ¬a ^ (0 + 1) ∣ b, by simpa
 
 lemma eq_top_iff_not_finite {a b : α} : multiplicity a b = ⊤ ↔ ¬ finite a b :=
 part.eq_none_iff'
@@ -193,13 +193,13 @@ le_antisymm (multiplicity_le_multiplicity_of_dvd_right h.dvd)
   (multiplicity_le_multiplicity_of_dvd_right h.symm.dvd)
 
 lemma dvd_of_multiplicity_pos {a b : α} (h : (0 : enat) < multiplicity a b) : a ∣ b :=
-by { rw ← pow_one a, exact pow_dvd_of_le_multiplicity (enat.coe_one.symm ▸ enat.pos_iff_one_le.1 h) }
+by { rw ← pow_one a, exact pow_dvd_of_le_multiplicity (nat.cast_one.symm ▸ enat.pos_iff_one_le.1 h) }
 
 lemma dvd_iff_multiplicity_pos {a b : α} : (0 : enat) < multiplicity a b ↔ a ∣ b :=
 ⟨dvd_of_multiplicity_pos,
   λ hdvd, lt_of_le_of_ne (zero_le _) (λ heq, is_greatest
     (show multiplicity a b < ↑1,
-      by simpa only [heq, enat.coe_zero] using enat.coe_lt_coe.mpr zero_lt_one)
+      by simpa only [heq, nat.cast_zero] using enat.coe_lt_coe.mpr zero_lt_one)
     (by rwa pow_one a))⟩
 
 lemma finite_nat_iff {a b : ℕ} : finite a b ↔ (a ≠ 1 ∧ 0 < b) :=
@@ -274,7 +274,7 @@ begin
     rw [hk], rw_mod_cast [multiplicity_lt_iff_neg_dvd], intro h_dvd,
     rw [← dvd_add_iff_right] at h_dvd,
     apply multiplicity.is_greatest _ h_dvd, rw [hk], apply_mod_cast nat.lt_succ_self,
-    rw [pow_dvd_iff_le_multiplicity, enat.coe_add, ← hk, enat.coe_one],
+    rw [pow_dvd_iff_le_multiplicity, nat.cast_add, ← hk, nat.cast_one],
     exact enat.add_one_le_of_lt h },
   { convert min_le_multiplicity_add, rw [min_eq_right (le_of_lt h)] }
 end
@@ -390,7 +390,7 @@ protected lemma mul {p a b : α} (hp : prime p) :
 if h : finite p a ∧ finite p b then
 by rw [← enat.coe_get (finite_iff_dom.1 h.1), ← enat.coe_get (finite_iff_dom.1 h.2),
   ← enat.coe_get (finite_iff_dom.1 (finite_mul hp h.1 h.2)),
-    ← enat.coe_add, enat.coe_inj, multiplicity.mul' hp]; refl
+    ← nat.cast_add, enat.coe_inj, multiplicity.mul' hp]; refl
 else begin
   rw [eq_top_iff_not_finite.2 (mt (finite_mul_iff hp).1 h)],
   cases not_and_distrib.1 h with h h;
@@ -454,7 +454,7 @@ lemma multiplicity_eq_zero_of_coprime {p a b : ℕ} (hp : p ≠ 1)
   (hab : nat.coprime a b) : multiplicity p a = 0 :=
 begin
   rw [multiplicity_le_multiplicity_iff] at hle,
-  rw [← nonpos_iff_eq_zero, ← not_lt, enat.pos_iff_one_le, ← enat.coe_one,
+  rw [← nonpos_iff_eq_zero, ← not_lt, enat.pos_iff_one_le, ← nat.cast_one,
     ← pow_dvd_iff_le_multiplicity],
   assume h,
   have := nat.dvd_gcd h (hle _ h),

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -150,7 +150,7 @@ lemma unit_right {a : α} (ha : ¬is_unit a) (u : units α) : multiplicity a u =
 is_unit_right ha u.is_unit
 
 lemma multiplicity_eq_zero_of_not_dvd {a b : α} (ha : ¬a ∣ b) : multiplicity a b = 0 :=
-nat.cast_zero ▸ eq_coe_iff.2 $ show a ^ 0 ∣ b ∧ ¬a ^ (0 + 1) ∣ b, by simpa
+by { rw [← nat.cast_zero, eq_coe_iff], simpa }
 
 lemma eq_top_iff_not_finite {a b : α} : multiplicity a b = ⊤ ↔ ¬ finite a b :=
 part.eq_none_iff'
@@ -193,7 +193,11 @@ le_antisymm (multiplicity_le_multiplicity_of_dvd_right h.dvd)
   (multiplicity_le_multiplicity_of_dvd_right h.symm.dvd)
 
 lemma dvd_of_multiplicity_pos {a b : α} (h : (0 : enat) < multiplicity a b) : a ∣ b :=
-by { rw ← pow_one a, exact pow_dvd_of_le_multiplicity (nat.cast_one.symm ▸ enat.pos_iff_one_le.1 h) }
+begin
+  rw ← pow_one a,
+  apply pow_dvd_of_le_multiplicity,
+  simpa only [nat.cast_one, enat.pos_iff_one_le] using h
+end
 
 lemma dvd_iff_multiplicity_pos {a b : α} : (0 : enat) < multiplicity a b ↔ a ∣ b :=
 ⟨dvd_of_multiplicity_pos,

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -111,11 +111,13 @@ by { rw [pow_dvd_iff_le_multiplicity, not_le] }
 
 lemma eq_coe_iff {a b : α} {n : ℕ} :
   multiplicity a b = (n : enat) ↔ a ^ n ∣ b ∧ ¬a ^ (n + 1) ∣ b :=
-by rw [← enat.some_eq_coe]; exact
-⟨λ h, let ⟨h₁, h₂⟩ := eq_some_iff.1 h in
-    h₂ ▸ ⟨pow_multiplicity_dvd _, is_greatest
-      (by { rw [enat.lt_coe_iff], exact ⟨h₁, lt_succ_self _⟩ })⟩,
-  λ h, eq_some_iff.2 ⟨⟨n, h.2⟩, eq.symm $ unique' h.1 h.2⟩⟩
+begin
+  rw [← enat.some_eq_coe],
+  exact ⟨λ h, let ⟨h₁, h₂⟩ := eq_some_iff.1 h in
+      h₂ ▸ ⟨pow_multiplicity_dvd _, is_greatest
+        (by { rw [enat.lt_coe_iff], exact ⟨h₁, lt_succ_self _⟩ })⟩,
+    λ h, eq_some_iff.2 ⟨⟨n, h.2⟩, eq.symm $ unique' h.1 h.2⟩⟩
+end
 
 lemma eq_top_iff {a b : α} :
   multiplicity a b = ⊤ ↔ ∀ n : ℕ, a ^ n ∣ b :=

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -73,6 +73,7 @@ by rw mul_comm; exact finite_of_finite_mul_left
 variable [decidable_rel ((∣) : α → α → Prop)]
 
 lemma pow_dvd_of_le_multiplicity {a b : α} {k : ℕ} : (k : enat) ≤ multiplicity a b → a ^ k ∣ b :=
+by rw [← enat.some_eq_coe]; exact
 nat.cases_on k (λ _, by { rw pow_zero, exact one_dvd _ })
   (λ k ⟨h₁, h₂⟩, by_contradiction (λ hk, (nat.find_min _ (lt_of_succ_le (h₂ ⟨k, hk⟩)) hk)))
 
@@ -108,8 +109,9 @@ lemma multiplicity_lt_iff_neg_dvd {a b : α} {k : ℕ} :
   multiplicity a b < (k : enat) ↔ ¬ a ^ k ∣ b :=
 by { rw [pow_dvd_iff_le_multiplicity, not_le] }
 
-lemma eq_some_iff {a b : α} {n : ℕ} :
+lemma eq_coe_iff {a b : α} {n : ℕ} :
   multiplicity a b = (n : enat) ↔ a ^ n ∣ b ∧ ¬a ^ (n + 1) ∣ b :=
+by rw [← enat.some_eq_coe]; exact
 ⟨λ h, let ⟨h₁, h₂⟩ := eq_some_iff.1 h in
     h₂ ▸ ⟨pow_multiplicity_dvd _, is_greatest
       (by { rw [enat.lt_coe_iff], exact ⟨h₁, lt_succ_self _⟩ })⟩,
@@ -126,15 +128,18 @@ eq_top_iff.2 (λ _, is_unit_iff_forall_dvd.1 (ha.pow _) _)
 
 lemma is_unit_right {a b : α} (ha : ¬is_unit a) (hb : is_unit b) :
   multiplicity a b = 0 :=
-eq_some_iff.2 ⟨by simp, by { rw pow_one, exact λ h, mt (is_unit_of_dvd_unit h) ha hb, }⟩
+eq_coe_iff.2 ⟨show a ^ 0 ∣ b, by simp only [pow_zero, one_dvd],
+  by { rw pow_one, exact λ h, mt (is_unit_of_dvd_unit h) ha hb, }⟩
 
 @[simp] lemma one_left (b : α) : multiplicity 1 b = ⊤ := is_unit_left b is_unit_one
 
 lemma one_right {a : α} (ha : ¬is_unit a) : multiplicity a 1 = 0 := is_unit_right ha is_unit_one
 
 @[simp] lemma get_one_right {a : α} (ha : finite a 1) : get (multiplicity a 1) ha = 0 :=
-get_eq_iff_eq_some.2 (eq_some_iff.2 ⟨by rw pow_zero,
-  by simpa [is_unit_iff_dvd_one.symm] using not_unit_of_finite ha⟩)
+begin
+  rw [enat.get_eq_iff_eq_coe, eq_coe_iff, pow_zero],
+  simpa [is_unit_iff_dvd_one.symm] using not_unit_of_finite ha,
+end
 
 @[simp] lemma unit_left (a : α) (u : units α) : multiplicity (u : α) a = ⊤ :=
 is_unit_left a u.is_unit
@@ -143,7 +148,7 @@ lemma unit_right {a : α} (ha : ¬is_unit a) (u : units α) : multiplicity a u =
 is_unit_right ha u.is_unit
 
 lemma multiplicity_eq_zero_of_not_dvd {a b : α} (ha : ¬a ∣ b) : multiplicity a b = 0 :=
-eq_some_iff.2 (by simpa)
+enat.coe_zero ▸ eq_coe_iff.2 $ show a ^ 0 ∣ b ∧ ¬a ^ (0 + 1) ∣ b, by simpa
 
 lemma eq_top_iff_not_finite {a b : α} : multiplicity a b = ⊤ ↔ ¬ finite a b :=
 part.eq_none_iff'
@@ -186,12 +191,13 @@ le_antisymm (multiplicity_le_multiplicity_of_dvd_right h.dvd)
   (multiplicity_le_multiplicity_of_dvd_right h.symm.dvd)
 
 lemma dvd_of_multiplicity_pos {a b : α} (h : (0 : enat) < multiplicity a b) : a ∣ b :=
-by rw [← pow_one a]; exact pow_dvd_of_le_multiplicity (enat.pos_iff_one_le.1 h)
+by rw [← pow_one a]; exact pow_dvd_of_le_multiplicity (enat.coe_one.symm ▸ enat.pos_iff_one_le.1 h)
 
 lemma dvd_iff_multiplicity_pos {a b : α} : (0 : enat) < multiplicity a b ↔ a ∣ b :=
 ⟨dvd_of_multiplicity_pos,
   λ hdvd, lt_of_le_of_ne (zero_le _) (λ heq, is_greatest
-    (show multiplicity a b < 1, from heq ▸ enat.coe_lt_coe.mpr zero_lt_one)
+    (show multiplicity a b < ↑1,
+      by simpa only [heq, enat.coe_zero] using enat.coe_lt_coe.mpr zero_lt_one)
     (by rwa pow_one a))⟩
 
 lemma finite_nat_iff {a b : ℕ} : finite a b ↔ (a ≠ 1 ∧ 0 < b) :=
@@ -266,7 +272,8 @@ begin
     rw [hk], rw_mod_cast [multiplicity_lt_iff_neg_dvd], intro h_dvd,
     rw [← dvd_add_iff_right] at h_dvd,
     apply multiplicity.is_greatest _ h_dvd, rw [hk], apply_mod_cast nat.lt_succ_self,
-    rw [pow_dvd_iff_le_multiplicity, enat.coe_add, ← hk], exact enat.add_one_le_of_lt h },
+    rw [pow_dvd_iff_le_multiplicity, enat.coe_add, ← hk, enat.coe_one],
+    exact enat.add_one_le_of_lt h },
   { convert min_le_multiplicity_add, rw [min_eq_right (le_of_lt h)] }
 end
 
@@ -336,13 +343,14 @@ variable [decidable_rel ((∣) : α → α → Prop)]
 
 @[simp] lemma multiplicity_self {a : α} (ha : ¬is_unit a) (ha0 : a ≠ 0) :
   multiplicity a a = 1 :=
-eq_some_iff.2 ⟨by simp, λ ⟨b, hb⟩, ha (is_unit_iff_dvd_one.2
+by rw [← enat.coe_one]; exact
+eq_coe_iff.2 ⟨by simp, λ ⟨b, hb⟩, ha (is_unit_iff_dvd_one.2
   ⟨b, mul_left_cancel' ha0 $ by clear _fun_match;
     simpa [pow_succ, mul_assoc] using hb⟩)⟩
 
 @[simp] lemma get_multiplicity_self {a : α} (ha : finite a a) :
   get (multiplicity a a) ha = 1 :=
-part.get_eq_iff_eq_some.2 (eq_some_iff.2
+enat.get_eq_iff_eq_coe.2 (eq_coe_iff.2
   ⟨by simp, λ ⟨b, hb⟩,
     by rw [← mul_one a, pow_add, pow_one, mul_assoc, mul_assoc,
         mul_right_inj' (ne_zero_of_finite ha)] at hb;
@@ -370,7 +378,7 @@ have hsucc : ¬p ^ ((get (multiplicity p a) ((finite_mul_iff hp).1 h).1 +
     get (multiplicity p b) ((finite_mul_iff hp).1 h).2) + 1) ∣ a * b,
   from λ h, not_or (is_greatest' _ (lt_succ_self _)) (is_greatest' _ (lt_succ_self _))
     (by exact succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul hp hdiva hdivb h),
-by rw [← enat.coe_inj, enat.coe_get, eq_some_iff];
+by rw [← enat.coe_inj, enat.coe_get, eq_coe_iff];
   exact ⟨hdiv, hsucc⟩
 
 open_locale classical
@@ -411,7 +419,7 @@ lemma pow {p a : α} (hp : prime p) : ∀ {k : ℕ},
 
 lemma multiplicity_pow_self {p : α} (h0 : p ≠ 0) (hu : ¬ is_unit p) (n : ℕ) :
   multiplicity p (p ^ n) = n :=
-by { rw [eq_some_iff], use dvd_rfl, rw [pow_dvd_pow_iff h0 hu], apply nat.not_succ_le_self }
+by { rw [eq_coe_iff], use dvd_rfl, rw [pow_dvd_pow_iff h0 hu], apply nat.not_succ_le_self }
 
 lemma multiplicity_pow_self_of_prime {p : α} (hp : prime p) (n : ℕ) :
   multiplicity p (p ^ n) = n :=

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -73,9 +73,9 @@ by rw mul_comm; exact finite_of_finite_mul_left
 variable [decidable_rel ((∣) : α → α → Prop)]
 
 lemma pow_dvd_of_le_multiplicity {a b : α} {k : ℕ} : (k : enat) ≤ multiplicity a b → a ^ k ∣ b :=
-by rw [← enat.some_eq_coe]; exact
+by { rw ← enat.some_eq_coe, exact
 nat.cases_on k (λ _, by { rw pow_zero, exact one_dvd _ })
-  (λ k ⟨h₁, h₂⟩, by_contradiction (λ hk, (nat.find_min _ (lt_of_succ_le (h₂ ⟨k, hk⟩)) hk)))
+  (λ k ⟨h₁, h₂⟩, by_contradiction (λ hk, (nat.find_min _ (lt_of_succ_le (h₂ ⟨k, hk⟩)) hk))) }
 
 lemma pow_multiplicity_dvd {a b : α} (h : finite a b) : a ^ get (multiplicity a b) h ∣ b :=
 pow_dvd_of_le_multiplicity (by rw enat.coe_get)
@@ -129,7 +129,7 @@ eq_top_iff.2 (λ _, is_unit_iff_forall_dvd.1 (ha.pow _) _)
 lemma is_unit_right {a b : α} (ha : ¬is_unit a) (hb : is_unit b) :
   multiplicity a b = 0 :=
 eq_coe_iff.2 ⟨show a ^ 0 ∣ b, by simp only [pow_zero, one_dvd],
-  by { rw pow_one, exact λ h, mt (is_unit_of_dvd_unit h) ha hb, }⟩
+  by { rw pow_one, exact λ h, mt (is_unit_of_dvd_unit h) ha hb }⟩
 
 @[simp] lemma one_left (b : α) : multiplicity 1 b = ⊤ := is_unit_left b is_unit_one
 
@@ -191,7 +191,7 @@ le_antisymm (multiplicity_le_multiplicity_of_dvd_right h.dvd)
   (multiplicity_le_multiplicity_of_dvd_right h.symm.dvd)
 
 lemma dvd_of_multiplicity_pos {a b : α} (h : (0 : enat) < multiplicity a b) : a ∣ b :=
-by rw [← pow_one a]; exact pow_dvd_of_le_multiplicity (enat.coe_one.symm ▸ enat.pos_iff_one_le.1 h)
+by { rw ← pow_one a, exact pow_dvd_of_le_multiplicity (enat.coe_one.symm ▸ enat.pos_iff_one_le.1 h) }
 
 lemma dvd_iff_multiplicity_pos {a b : α} : (0 : enat) < multiplicity a b ↔ a ∣ b :=
 ⟨dvd_of_multiplicity_pos,
@@ -343,10 +343,10 @@ variable [decidable_rel ((∣) : α → α → Prop)]
 
 @[simp] lemma multiplicity_self {a : α} (ha : ¬is_unit a) (ha0 : a ≠ 0) :
   multiplicity a a = 1 :=
-by rw [← enat.coe_one]; exact
+by { rw ← nat.cast_one, exact
 eq_coe_iff.2 ⟨by simp, λ ⟨b, hb⟩, ha (is_unit_iff_dvd_one.2
-  ⟨b, mul_left_cancel' ha0 $ by clear _fun_match;
-    simpa [pow_succ, mul_assoc] using hb⟩)⟩
+  ⟨b, mul_left_cancel' ha0 $ by { clear _fun_match,
+    simpa [pow_succ, mul_assoc] using hb }⟩)⟩ }
 
 @[simp] lemma get_multiplicity_self {a : α} (ha : finite a a) :
   get (multiplicity a a) ha = 1 :=

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1557,7 +1557,7 @@ begin
   rw not_lt at hi hj, rw finset.nat.mem_antidiagonal at hij,
   exfalso,
   apply ne_of_lt (lt_of_lt_of_le hn $ add_le_add hi hj),
-  rw [← enat.coe_add, hij]
+  rw [← nat.cast_add, hij]
 end
 
 /-- The order of the monomial `a*X^n` is infinite if `a = 0` and `n` otherwise.-/
@@ -1619,7 +1619,7 @@ by simpa using order_monomial_of_ne_zero 0 (1:R) one_ne_zero
 
 /-- The order of the formal power series `X` is `1`.-/
 @[simp] lemma order_X : order (X : power_series R) = 1 :=
-enat.coe_one ▸ order_monomial_of_ne_zero 1 (1:R) one_ne_zero
+nat.cast_one ▸ order_monomial_of_ne_zero 1 (1:R) one_ne_zero
 
 /-- The order of the formal power series `X^n` is `n`.-/
 @[simp] lemma order_X_pow (n : ℕ) : order ((X : power_series R)^n) = n :=

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1619,7 +1619,7 @@ by simpa using order_monomial_of_ne_zero 0 (1:R) one_ne_zero
 
 /-- The order of the formal power series `X` is `1`.-/
 @[simp] lemma order_X : order (X : power_series R) = 1 :=
-nat.cast_one ▸ order_monomial_of_ne_zero 1 (1:R) one_ne_zero
+by simpa only [nat.cast_one] using order_monomial_of_ne_zero 1 (1:R) one_ne_zero
 
 /-- The order of the formal power series `X^n` is `n`.-/
 @[simp] lemma order_X_pow (n : ℕ) : order ((X : power_series R)^n) = n :=

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1465,7 +1465,7 @@ lemma nat_le_order (φ : power_series R) (n : ℕ) (h : ∀ i < n, coeff R i φ 
   ↑n ≤ order φ :=
 begin
   by_contra H, rw not_le at H,
-  have : (order φ).dom := enat.dom_of_le_coe (le_of_lt H),
+  have : (order φ).dom := enat.dom_of_le_coe H.le,
   rw [← enat.coe_get this, enat.coe_lt_coe] at H,
   exact coeff_order _ this (h _ H)
 end

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -1465,7 +1465,7 @@ lemma nat_le_order (φ : power_series R) (n : ℕ) (h : ∀ i < n, coeff R i φ 
   ↑n ≤ order φ :=
 begin
   by_contra H, rw not_le at H,
-  have : (order φ).dom := enat.dom_of_le_some (le_of_lt H),
+  have : (order φ).dom := enat.dom_of_le_coe (le_of_lt H),
   rw [← enat.coe_get this, enat.coe_lt_coe] at H,
   exact coeff_order _ this (h _ H)
 end
@@ -1486,7 +1486,7 @@ and the `i`th coefficient is `0` for all `i < n`.-/
 lemma order_eq_nat {φ : power_series R} {n : ℕ} :
   order φ = n ↔ (coeff R n φ ≠ 0) ∧ (∀ i, i < n → coeff R i φ = 0) :=
 begin
-  simp only [eq_some_iff, X_pow_dvd_iff], push_neg,
+  simp only [eq_coe_iff, X_pow_dvd_iff], push_neg,
   split,
   { rintros ⟨h₁, m, hm₁, hm₂⟩, refine ⟨_, h₁⟩,
     suffices : n = m, { rwa this },
@@ -1619,7 +1619,7 @@ by simpa using order_monomial_of_ne_zero 0 (1:R) one_ne_zero
 
 /-- The order of the formal power series `X` is `1`.-/
 @[simp] lemma order_X : order (X : power_series R) = 1 :=
-order_monomial_of_ne_zero 1 (1:R) one_ne_zero
+enat.coe_one ▸ order_monomial_of_ne_zero 1 (1:R) one_ne_zero
 
 /-- The order of the formal power series `X^n` is `n`.-/
 @[simp] lemma order_X_pow (n : ℕ) : order ((X : power_series R)^n) = n :=

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -901,7 +901,7 @@ begin
     exact hdiv ((zmod.nat_coe_zmod_eq_zero_iff_dvd n p).1 (not_not.1 hzero)) },
   cases (multiplicity.squarefree_iff_multiplicity_le_one (X ^ n - 1)).1 hfree
     (map (int.cast_ring_hom (zmod p)) P) with hle hunit,
-  { rw enat.coe_one at habs, exact not_lt_of_le hle habs },
+  { rw enat.coe_one at habs, exact hle.not_lt habs },
   { replace hunit := degree_eq_zero_of_is_unit hunit,
     rw degree_map_eq_of_leading_coeff_ne_zero (int.cast_ring_hom (zmod p)) _ at hunit,
     { exact (minpoly.degree_pos (is_integral h hpos)).ne' hunit },

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -901,7 +901,7 @@ begin
     exact hdiv ((zmod.nat_coe_zmod_eq_zero_iff_dvd n p).1 (not_not.1 hzero)) },
   cases (multiplicity.squarefree_iff_multiplicity_le_one (X ^ n - 1)).1 hfree
     (map (int.cast_ring_hom (zmod p)) P) with hle hunit,
-  { rw enat.coe_one at habs, exact hle.not_lt habs },
+  { rw nat.cast_one at habs, exact hle.not_lt habs },
   { replace hunit := degree_eq_zero_of_is_unit hunit,
     rw degree_map_eq_of_leading_coeff_ne_zero (int.cast_ring_hom (zmod p)) _ at hunit,
     { exact (minpoly.degree_pos (is_integral h hpos)).ne' hunit },

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -901,7 +901,7 @@ begin
     exact hdiv ((zmod.nat_coe_zmod_eq_zero_iff_dvd n p).1 (not_not.1 hzero)) },
   cases (multiplicity.squarefree_iff_multiplicity_le_one (X ^ n - 1)).1 hfree
     (map (int.cast_ring_hom (zmod p)) P) with hle hunit,
-  { exact not_lt_of_le hle habs },
+  { rw enat.coe_one at habs, exact not_lt_of_le hle habs },
   { replace hunit := degree_eq_zero_of_is_unit hunit,
     rw degree_map_eq_of_leading_coeff_ne_zero (int.cast_ring_hom (zmod p)) _ at hunit,
     { exact (minpoly.degree_pos (is_integral h hpos)).ne' hunit },

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -623,7 +623,7 @@ lemma multiplicity_eq_count_factors {a b : R} (ha : irreducible a) (hb : b ≠ 0
 begin
   apply le_antisymm,
   { apply enat.le_of_lt_add_one,
-    rw [← enat.coe_one, ← enat.coe_add, lt_iff_not_ge, ge_iff_le,
+    rw [← nat.cast_one, ← nat.cast_add, lt_iff_not_ge, ge_iff_le,
       le_multiplicity_iff_repeat_le_factors ha hb, ← le_count_iff_repeat_le],
     simp },
   rw [le_multiplicity_iff_repeat_le_factors ha hb, ← le_count_iff_repeat_le],

--- a/src/ring_theory/witt_vector/frobenius.lean
+++ b/src/ring_theory/witt_vector/frobenius.lean
@@ -123,7 +123,7 @@ begin
   { rw [← multiplicity.finite_iff_dom, multiplicity.finite_nat_iff],
     exact ⟨hp.1.ne_one, nat.choose_pos hj⟩, },
   rw [← enat.coe_get aux, enat.coe_le_coe, nat.sub_le_left_iff_le_add,
-      ← enat.coe_le_coe, enat.coe_add, pnat_multiplicity, enat.coe_get, enat.coe_get, add_comm],
+      ← enat.coe_le_coe, nat.cast_add, pnat_multiplicity, enat.coe_get, enat.coe_get, add_comm],
   exact (hp.1.multiplicity_choose_prime_pow hj j.succ_pos).ge,
 end
 

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -940,7 +940,7 @@ noncomputable def to_enat : cardinal →+ enat :=
       by_cases hy : y < omega,
       { obtain ⟨y0, rfl⟩ := lt_omega.1 hy,
         simp only [add_lt_omega hx hy, hx, hy, to_nat_cast, if_true],
-        rw [← nat.cast_add, to_nat_cast, enat.coe_add] },
+        rw [← nat.cast_add, to_nat_cast, nat.cast_add] },
       { rw [if_neg hy, if_neg, enat.add_top],
         contrapose! hy,
         apply lt_of_le_of_lt le_add_self hy } },


### PR DESCRIPTION
The coercion from nat to enat was defined to be enat.some. But another
coercion could be inferred from the additive structure on enat, leading to
confusing goals of the form
`↑n = ↑n` where the two sides were not defeq.

We now make the coercion inferred from the additive structure the default, 
even though it is not computable.

A dedicated function `enat.some` is introduced, to be used whenever
computability is important.




---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)