### PR TITLE
[Merged by Bors] - feat(algebra/big_operators): absolute values and big operators 

### DIFF
--- a/src/algebra/absolute_value.lean
+++ b/src/algebra/absolute_value.lean
@@ -90,21 +90,13 @@ protected def abs : absolute_value S S :=
 
 instance : inhabited (absolute_value S S) := ⟨absolute_value.abs⟩
 
-end linear_ordered_ring
-
-section linear_ordered_field
-
-section semiring
-
-variables {R S : Type*} [semiring R] [linear_ordered_field S] (abv : absolute_value R S)
-
 variables [nontrivial R]
 
 @[simp] protected theorem map_one : abv 1 = 1 :=
-(mul_right_inj' $ mt abv.eq_zero.1 one_ne_zero).1 $
+(mul_right_inj' $ abv.ne_zero one_ne_zero).1 $
 by rw [← abv.map_mul, mul_one, mul_one]
 
-/-- Absolute values from a nontrivial `R` to a linear ordered field preserve `*`, `0` and `1`. -/
+/-- Absolute values from a nontrivial `R` to a linear ordered ring preserve `*`, `0` and `1`. -/
 def to_monoid_with_zero_hom : monoid_with_zero_hom R S :=
 { to_fun := abv,
   map_zero' := abv.map_zero,
@@ -113,7 +105,7 @@ def to_monoid_with_zero_hom : monoid_with_zero_hom R S :=
 
 @[simp] lemma coe_to_monoid_with_zero_hom : ⇑abv.to_monoid_with_zero_hom = abv := rfl
 
-/-- Absolute values from a nontrivial `R` to a linear ordered field preserve `*` and `1`. -/
+/-- Absolute values from a nontrivial `R` to a linear ordered ring preserve `*` and `1`. -/
 def to_monoid_hom : monoid_hom R S :=
 { to_fun := abv,
   map_one' := abv.map_one,
@@ -124,15 +116,21 @@ def to_monoid_hom : monoid_hom R S :=
 @[simp] protected lemma map_pow (a : R) (n : ℕ) : abv (a ^ n) = abv a ^ n :=
 abv.to_monoid_hom.map_pow a n
 
-end semiring
+end linear_ordered_ring
+
+section linear_ordered_comm_ring
 
 section ring
 
-variables {R S : Type*} [ring R] [linear_ordered_field S] (abv : absolute_value R S)
+variables {R S : Type*} [ring R] [linear_ordered_comm_ring S] (abv : absolute_value R S)
 
 @[simp] protected theorem map_neg (a : R) : abv (-a) = abv a :=
-by rw [← mul_self_inj_of_nonneg (abv.nonneg _) (abv.nonneg _),
-       ← abv.map_mul]; simp
+begin
+  by_cases ha : a = 0, { simp [ha] },
+  refine (mul_self_eq_mul_self_iff.mp
+    (by rw [← abv.map_mul, neg_mul_neg, abv.map_mul])).resolve_right _,
+  exact ((neg_lt_zero.mpr (abv.pos ha)).trans (abv.pos (neg_ne_zero.mpr ha))).ne'
+end
 
 protected theorem map_sub (a b : R) : abv (a - b) = abv (b - a) :=
 by rw [← neg_sub, abv.map_neg]
@@ -142,6 +140,10 @@ lemma abs_abv_sub_le_abv_sub (a b : R) :
 abs_sub_le_iff.2 ⟨abv.le_sub _ _, by rw abv.map_sub; apply abv.le_sub⟩
 
 end ring
+
+end linear_ordered_comm_ring
+
+section linear_ordered_field
 
 section field
 

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 
+import algebra.absolute_value
 import algebra.big_operators.basic
 
 /-!
@@ -485,3 +486,25 @@ lemma sum_lt_top_iff [ordered_add_comm_monoid M] {s : finset ι} {f : ι → wit
 by simp only [lt_top_iff_ne_top, ne.def, sum_eq_top_iff, not_exists]
 
 end with_top
+
+section absolute_value
+
+variables {S : Type*}
+
+lemma absolute_value.sum_le [semiring R] [ordered_semiring S]
+  (abv : absolute_value R S) (s : finset ι) (f : ι → R) :
+  abv (∑ i in s, f i) ≤ ∑ i in s, abv (f i) :=
+begin
+  letI := classical.dec_eq ι,
+  refine finset.induction_on s _ (λ i s hi ih, _),
+  { simp },
+  { simp only [finset.sum_insert hi],
+  exact (abv.add_le _ _).trans (add_le_add (le_refl _) ih) },
+end
+
+lemma absolute_value.map_prod [comm_semiring R] [nontrivial R] [linear_ordered_comm_ring S]
+  (abv : absolute_value R S) (f : ι → R) (s : finset ι) :
+  abv (∏ i in s, f i) = ∏ i in s, abv (f i) :=
+abv.to_monoid_hom.map_prod f s
+
+end absolute_value


### PR DESCRIPTION
This PR extends `absolute_value.add_le` and `absolute_value.map_mul` to `finset.sum` and `finset.prod` respectively.

---

- [x] depends on: #9026

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
