### PR TITLE
[Merged by Bors] -  feat(linear_algebra/matrix): some bounds on the determinant of matrices

### DIFF
--- a/src/linear_algebra/matrix/absolute_value.lean
+++ b/src/linear_algebra/matrix/absolute_value.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2021 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+import data.int.absolute_value
+import linear_algebra.matrix.determinant
+
+/-!
+# Absolute values and matrices
+
+This file proves some bounds on matrices involving absolute values.
+
+## Main results
+
+ * `matrix.det_le`: if the entries of an `n × n` matrix are bounded by `x`,
+   then the determinant is bounded by `n! x^n`
+ * `matrix.det_sum_le`: if we have `s` `n × n` matrices and the entries of each
+   matrix are bounded by `x`, then the determinant is bounded by `n! (s * x)^n`
+ * `matrix.det_sum_smul_le`: if we have `s` `n × n` matrices each multiplied by
+   a constant bounded by `y`, and the entries of each matrix are bounded by `x`,
+   then the determinant is bounded by `n! (s * y * x)^n`
+-/
+
+open_locale big_operators
+open_locale matrix
+
+namespace matrix
+
+open equiv finset
+
+variables {R S : Type*} [comm_ring R] [nontrivial R] [linear_ordered_comm_ring S]
+variables {n : Type*} [fintype n] [decidable_eq n]
+
+lemma det_le {A : matrix n n R} {abv : absolute_value R S}
+  {x : S} (hx : ∀ i j, abv (A i j) ≤ x) :
+  abv A.det ≤ nat.factorial (fintype.card n) • x ^ (fintype.card n) :=
+calc  abv A.det
+    = abv (∑ σ : perm n, _) : congr_arg abv (det_apply _)
+... ≤ ∑ σ : perm n, abv _ : abv.sum_le _ _
+... = ∑ σ : perm n, (∏ i, abv (A (σ i) i)) : sum_congr rfl (λ σ hσ,
+  by rw [abv.map_units_int_smul, abv.map_prod])
+... ≤ ∑ σ : perm n, (∏ (i : n), x) :
+  sum_le_sum (λ _ _, prod_le_prod (λ _ _, abv.nonneg _) (λ _ _, hx _ _))
+... = ∑ σ : perm n, x ^ (fintype.card n) : sum_congr rfl (λ _ _,
+  by rw [prod_const, finset.card_univ])
+... = nat.factorial (fintype.card n) • x ^ (fintype.card n) :
+  by rw [sum_const, finset.card_univ, fintype.card_perm]
+
+lemma det_sum_le {ι : Type*} (s : finset ι) {A : ι → matrix n n R}
+  {abv : absolute_value R S} {x : S} (hx : ∀ k i j, abv (A k i j) ≤ x) :
+  abv (det (∑ k in s, A k)) ≤
+    nat.factorial (fintype.card n) • (finset.card s • x) ^ (fintype.card n) :=
+det_le $ λ i j,
+calc  abv ((∑ k in s, A k) i j)
+    = abv (∑ k in s, A k i j) : by simp only [sum_apply]
+... ≤ ∑ k in s, abv (A k i j) : abv.sum_le _ _
+... ≤ ∑ k in s, x : sum_le_sum (λ k _, hx k i j)
+... = s.card • x : sum_const _
+
+lemma det_sum_smul_le {ι : Type*} (s : finset ι) {c : ι → R} {A : ι → matrix n n R}
+  {abv : absolute_value R S}
+  {x : S} (hx : ∀ k i j, abv (A k i j) ≤ x) {y : S} (hy : ∀ k, abv (c k) ≤ y) :
+  abv (det (∑ k in s, c k • A k)) ≤
+    nat.factorial (fintype.card n) • (finset.card s • y * x) ^ (fintype.card n) :=
+by simpa only [smul_mul_assoc] using
+det_sum_le s (λ k i j,
+calc  abv (c k * A k i j)
+    = abv (c k) * abv (A k i j) : abv.map_mul _ _
+... ≤ y * x : mul_le_mul (hy k) (hx k i j) (abv.nonneg _) ((abv.nonneg _).trans (hy k)))
+
+end matrix

--- a/src/linear_algebra/matrix/absolute_value.lean
+++ b/src/linear_algebra/matrix/absolute_value.lean
@@ -16,10 +16,10 @@ This file proves some bounds on matrices involving absolute values.
  * `matrix.det_le`: if the entries of an `n × n` matrix are bounded by `x`,
    then the determinant is bounded by `n! x^n`
  * `matrix.det_sum_le`: if we have `s` `n × n` matrices and the entries of each
-   matrix are bounded by `x`, then the determinant is bounded by `n! (s * x)^n`
+   matrix are bounded by `x`, then the determinant of their sum is bounded by `n! (s * x)^n`
  * `matrix.det_sum_smul_le`: if we have `s` `n × n` matrices each multiplied by
    a constant bounded by `y`, and the entries of each matrix are bounded by `x`,
-   then the determinant is bounded by `n! (s * y * x)^n`
+   then the determinant of the linear combination is bounded by `n! (s * y * x)^n`
 -/
 
 open_locale big_operators


### PR DESCRIPTION
This PR shows that matrices with bounded entries also have bounded determinants.

`matrix.det_le` is the most generic version of these results, which we specialise in two steps to `matrix.det_sum_smul_le`. In a follow-up PR we will connect this to `algebra.left_mul_matrix` to provide an upper bound on `algebra.norm`.

---

- [x] depends on: #9027 
- [x] depends on: #9028 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
