### PR TITLE
[Merged by Bors] - feat(linear_algebra/basis): a nontrivial module has nonempty bases

### DIFF
--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -418,6 +418,13 @@ by { rw [← b.total_repr x, finsupp.total_apply, finsupp.sum],
 protected lemma span_eq : span R (range b) = ⊤ :=
 eq_top_iff.mpr $ λ x _, b.mem_span x
 
+lemma index_nonempty (b : basis ι R M) [nontrivial M] : nonempty ι :=
+begin
+  obtain ⟨x, y, ne⟩ : ∃ (x y : M), x ≠ y := nontrivial.exists_pair_ne,
+  obtain ⟨i, _⟩ := not_forall.mp (mt b.ext_elem ne),
+  exact ⟨i⟩
+end
+
 section constr
 
 variables (S : Type*) [semiring S] [module S M']

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -104,15 +104,8 @@ begin
     simpa only [degree_eq_nat_degree hf, with_bot.coe_lt_coe] using h },
 end
 
-lemma dim_ne_zero [nontrivial S] (pb : power_basis R S) : pb.dim ≠ 0 :=
-λ h, one_ne_zero $
-show (1 : S) = 0,
-by { rw [← pb.basis.total_repr 1, finsupp.total_apply, finsupp.sum_fintype],
-     { refine finset.sum_eq_zero (λ x hx, _),
-       cases x with x x_lt,
-       rw h at x_lt,
-       cases x_lt },
-     { simp } }
+lemma dim_ne_zero [h : nontrivial S] (pb : power_basis R S) : pb.dim ≠ 0 :=
+λ h, not_nonempty_iff.mpr (h.symm ▸ fin.is_empty : is_empty (fin pb.dim)) pb.basis.index_nonempty
 
 lemma dim_pos [nontrivial S] (pb : power_basis R S) : 0 < pb.dim :=
 nat.pos_of_ne_zero pb.dim_ne_zero


### PR DESCRIPTION
A tiny little lemma that guarantees the dimension of a nontrivial module is nonzero. Noticeably simplifies the proof that the dimension of a power basis is positive in this case.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
