### PR TITLE
[Merged by Bors] - chore(topology/order): relate Sup and Inf of topologies to `generate_from`

### DIFF
--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -690,8 +690,8 @@ section infi
 variables {α : Type u} {ι : Sort v}
 
 lemma generate_from_union (a₁ a₂ : set (set α)) :
-  topological_space.generate_from (a₁ ∪ a₂)
-  = topological_space.generate_from a₁ ⊓ topological_space.generate_from a₂ :=
+  topological_space.generate_from (a₁ ∪ a₂) =
+    topological_space.generate_from a₁ ⊓ topological_space.generate_from a₂ :=
 @galois_connection.l_sup _ (order_dual (topological_space α)) a₁ a₂ _ _ _ _
   (λ g t, generate_from_le_iff_subset_is_open)
 

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -166,14 +166,6 @@ lemma generate_from_mono {α} {g₁ g₂ : set (set α)} (h : g₁ ⊆ g₂) :
   topological_space.generate_from g₁ ≤ topological_space.generate_from g₂ :=
 (gi_generate_from _).gc.monotone_l h
 
-/-- The complete lattice of topological spaces, but built on the inclusion ordering. -/
-def tmp_complete_lattice {α : Type u} : complete_lattice (topological_space α) :=
-(gi_generate_from α).lift_complete_lattice
-
-section
-
-local attribute [instance] tmp_complete_lattice
-
 lemma generate_from_set_of_is_open (t : topological_space α) :
   topological_space.generate_from {s | t.is_open s} = t :=
 (gi_generate_from α).l_u_eq t
@@ -191,7 +183,11 @@ lemma set_of_is_open_injective :
   function.injective (λ t : topological_space α, {s | t.is_open s}) :=
 (gi_generate_from α).u_injective
 
-end
+/-- The "temporary" order `tmp_order` on `topological_space α`, i.e. the inclusion order, is a
+complete lattice.  (Note that later `topological_space α` will equipped with the dual order to
+`tmp_order`). -/
+def tmp_complete_lattice {α : Type u} : complete_lattice (topological_space α) :=
+(gi_generate_from α).lift_complete_lattice
 
 /-- The ordering on topologies on the type `α`.
   `t ≤ s` if every set open in `s` is also open in `t` (`t` is finer than `s`). -/

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -210,13 +210,7 @@ instance : complete_lattice (topological_space α) :=
 
 lemma is_open_implies_is_open_iff {a b : topological_space α} :
   (∀ s, a.is_open s → b.is_open s) ↔ b ≤ a :=
-@galois_insertion.u_le_u_iff _ _ _ _ _
-  (@partial_order.to_preorder _
-    (@semilattice_sup.to_partial_order _
-      (@lattice.to_semilattice_sup _
-        (@bounded_lattice.to_lattice _
-          (@complete_lattice.to_bounded_lattice _ tmp_complete_lattice)))))
-  (gi_generate_from α) a b
+@galois_insertion.u_le_u_iff _ (order_dual (topological_space α)) _ _ _ _ (gi_generate_from α) a b
 
 /-- A topological space is discrete if every set is open, that is,
   its topology equals the discrete topology `⊥`. -/
@@ -698,82 +692,56 @@ variables {α : Type u} {ι : Sort v}
 lemma generate_from_union (a₁ a₂ : set (set α)) :
   topological_space.generate_from (a₁ ∪ a₂)
   = topological_space.generate_from a₁ ⊓ topological_space.generate_from a₂ :=
-@galois_connection.l_sup _ _ a₁ a₂ _
-  (@lattice.to_semilattice_sup _
-    (@bounded_lattice.to_lattice _
-      (@complete_lattice.to_bounded_lattice _ tmp_complete_lattice)))
-  _ _
+@galois_connection.l_sup _ (order_dual (topological_space α)) a₁ a₂ _ _ _ _
   (λ g t, generate_from_le_iff_subset_is_open)
 
 lemma set_of_is_open_sup (t₁ t₂ : topological_space α) :
   {s | (t₁ ⊔ t₂).is_open s} = {s | t₁.is_open s} ∩ {s | t₂.is_open s} :=
-@galois_connection.u_inf _ _ t₁ t₂ _
-  (@lattice.to_semilattice_inf _
-    (@bounded_lattice.to_lattice _
-      (@complete_lattice.to_bounded_lattice _ tmp_complete_lattice)))
-  _ _
+@galois_connection.u_inf _ (order_dual (topological_space α)) t₁ t₂ _ _ _ _
   (λ g t, generate_from_le_iff_subset_is_open)
 
 lemma generate_from_Union {f : ι → set (set α)} :
   topological_space.generate_from (⋃ i, f i) = (⨅ i, topological_space.generate_from (f i)) :=
-@galois_connection.l_supr
-  (set (set α)) _ _ _
-  tmp_complete_lattice _ _
-  (λ g t, generate_from_le_iff_subset_is_open)
-  f
+@galois_connection.l_supr _ (order_dual (topological_space α)) _ _ _ _ _
+  (λ g t, generate_from_le_iff_subset_is_open) f
 
 lemma set_of_is_open_supr {t : ι → topological_space α} :
   {s | (⨆ i, t i).is_open s} = ⋂ i, {s | (t i).is_open s} :=
-@galois_connection.u_infi
-  (set (set α)) _ _ _
-  tmp_complete_lattice _ _
-  (λ g t, generate_from_le_iff_subset_is_open)
-  t
+@galois_connection.u_infi _ (order_dual (topological_space α)) _ _ _ _ _
+  (λ g t, generate_from_le_iff_subset_is_open) t
 
 lemma generate_from_sUnion {S : set (set (set α))} :
   topological_space.generate_from (⋃₀ S) = (⨅ s ∈ S, topological_space.generate_from s) :=
-@galois_connection.l_Sup
-  (set (set α)) _ _
-  tmp_complete_lattice _ _
-  (λ g t, generate_from_le_iff_subset_is_open)
-  S
+@galois_connection.l_Sup _ (order_dual (topological_space α)) _ _ _ _
+  (λ g t, generate_from_le_iff_subset_is_open) S
 
 lemma set_of_is_open_Sup {T : set (topological_space α)} :
   {s | (Sup T).is_open s} = ⋂ t ∈ T, {s | (t : topological_space α).is_open s} :=
-@galois_connection.u_Inf
-  (set (set α)) _ _
-  tmp_complete_lattice _ _
-  (λ g t, generate_from_le_iff_subset_is_open)
-  T
+@galois_connection.u_Inf _ (order_dual (topological_space α)) _ _ _ _
+  (λ g t, generate_from_le_iff_subset_is_open) T
 
 lemma generate_from_union_is_open (a b : topological_space α) :
   topological_space.generate_from ({s | a.is_open s} ∪ {s | b.is_open s}) = a ⊓ b :=
-@galois_insertion.l_sup_u _ _ _ _ _
-  (@lattice.to_semilattice_sup _
-    (@bounded_lattice.to_lattice _
-      (@complete_lattice.to_bounded_lattice _ tmp_complete_lattice)))
-  (gi_generate_from α) a b
+@galois_insertion.l_sup_u _ (order_dual (topological_space α)) _ _ _ _ (gi_generate_from α) a b
 
 lemma generate_from_Union_is_open (f : ι → topological_space α) :
   topological_space.generate_from (⋃ i, {s | (f i).is_open s}) = ⨅ i, (f i) :=
-@galois_insertion.l_supr_u _ _ _ _ _ tmp_complete_lattice (gi_generate_from α) _ f
+@galois_insertion.l_supr_u _ (order_dual (topological_space α)) _ _ _ _ (gi_generate_from α) _ f
 
 lemma generate_from_inter (a b : topological_space α) :
   topological_space.generate_from ({s | a.is_open s} ∩ {s | b.is_open s}) = a ⊔ b :=
-@galois_insertion.l_inf_u _ _ _ _ _
-  (@lattice.to_semilattice_inf _
-    (@bounded_lattice.to_lattice _
-      (@complete_lattice.to_bounded_lattice _ tmp_complete_lattice)))
+@galois_insertion.l_inf_u _ (order_dual (topological_space α)) _ _ _ _
   (gi_generate_from α) a b
 
 lemma generate_from_Inter (f : ι → topological_space α) :
   topological_space.generate_from (⋂ i, {s | (f i).is_open s}) = ⨆ i, (f i) :=
-@galois_insertion.l_infi_u _ _ _ _ _ tmp_complete_lattice (gi_generate_from α) _ f
+@galois_insertion.l_infi_u _ (order_dual (topological_space α)) _ _ _ _ (gi_generate_from α) _ f
 
 lemma generate_from_Inter_of_generate_from_eq_self (f : ι → set (set α))
   (hf : ∀ i, {s | (topological_space.generate_from (f i)).is_open s} = f i) :
   topological_space.generate_from (⋂ i, (f i)) = ⨆ i, topological_space.generate_from (f i) :=
-@galois_insertion.l_infi_of_ul_eq_self _ _ _ _ _ tmp_complete_lattice (gi_generate_from α) _ f hf
+@galois_insertion.l_infi_of_ul_eq_self _ (order_dual (topological_space α)) _ _ _ _
+  (gi_generate_from α) _ f hf
 
 variables {t : ι → topological_space α}
 

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -170,6 +170,29 @@ lemma generate_from_mono {α} {g₁ g₂ : set (set α)} (h : g₁ ⊆ g₂) :
 def tmp_complete_lattice {α : Type u} : complete_lattice (topological_space α) :=
 (gi_generate_from α).lift_complete_lattice
 
+section
+
+local attribute [instance] tmp_complete_lattice
+
+lemma generate_from_set_of_is_open (t : topological_space α) :
+  topological_space.generate_from {s | t.is_open s} = t :=
+(gi_generate_from α).l_u_eq t
+
+lemma left_inverse_generate_from :
+  function.left_inverse topological_space.generate_from
+    (λ t : topological_space α, {s | t.is_open s}) :=
+(gi_generate_from α).left_inverse_l_u
+
+lemma generate_from_surjective :
+  function.surjective (topological_space.generate_from : set (set α) → topological_space α) :=
+(gi_generate_from α).l_surjective
+
+lemma set_of_is_open_injective :
+  function.injective (λ t : topological_space α, {s | t.is_open s}) :=
+(gi_generate_from α).u_injective
+
+end
+
 /-- The ordering on topologies on the type `α`.
   `t ≤ s` if every set open in `s` is also open in `t` (`t` is finer than `s`). -/
 instance : partial_order (topological_space α) :=
@@ -188,6 +211,16 @@ generate_from_le_iff_subset_is_open
   topology whose open sets are those sets open in every member of the collection. -/
 instance : complete_lattice (topological_space α) :=
 @order_dual.complete_lattice _ tmp_complete_lattice
+
+lemma is_open_implies_is_open_iff {a b : topological_space α} :
+  (∀ s, a.is_open s → b.is_open s) ↔ b ≤ a :=
+@galois_insertion.u_le_u_iff _ _ _ _ _
+  (@partial_order.to_preorder _
+    (@semilattice_sup.to_partial_order _
+      (@lattice.to_semilattice_sup _
+        (@bounded_lattice.to_lattice _
+          (@complete_lattice.to_bounded_lattice _ tmp_complete_lattice)))))
+  (gi_generate_from α) a b
 
 /-- A topological space is discrete if every set is open, that is,
   its topology equals the discrete topology `⊥`. -/
@@ -664,15 +697,93 @@ continuous_Prop.symm
 end sierpinski
 
 section infi
-variables {α : Type u} {ι : Type v} {t : ι → topological_space α}
+variables {α : Type u} {ι : Sort v}
+
+lemma generate_from_union (a₁ a₂ : set (set α)) :
+  topological_space.generate_from (a₁ ∪ a₂)
+  = topological_space.generate_from a₁ ⊓ topological_space.generate_from a₂ :=
+@galois_connection.l_sup _ _ a₁ a₂ _
+  (@lattice.to_semilattice_sup _
+    (@bounded_lattice.to_lattice _
+      (@complete_lattice.to_bounded_lattice _ tmp_complete_lattice)))
+  _ _
+  (λ g t, generate_from_le_iff_subset_is_open)
+
+lemma set_of_is_open_sup (t₁ t₂ : topological_space α) :
+  {s | (t₁ ⊔ t₂).is_open s} = {s | t₁.is_open s} ∩ {s | t₂.is_open s} :=
+@galois_connection.u_inf _ _ t₁ t₂ _
+  (@lattice.to_semilattice_inf _
+    (@bounded_lattice.to_lattice _
+      (@complete_lattice.to_bounded_lattice _ tmp_complete_lattice)))
+  _ _
+  (λ g t, generate_from_le_iff_subset_is_open)
+
+lemma generate_from_Union {f : ι → set (set α)} :
+  topological_space.generate_from (⋃ i, f i) = (⨅ i, topological_space.generate_from (f i)) :=
+@galois_connection.l_supr
+  (set (set α)) _ _ _
+  tmp_complete_lattice _ _
+  (λ g t, generate_from_le_iff_subset_is_open)
+  f
+
+lemma set_of_is_open_supr {t : ι → topological_space α} :
+  {s | (⨆ i, t i).is_open s} = ⋂ i, {s | (t i).is_open s} :=
+@galois_connection.u_infi
+  (set (set α)) _ _ _
+  tmp_complete_lattice _ _
+  (λ g t, generate_from_le_iff_subset_is_open)
+  t
+
+lemma generate_from_sUnion {S : set (set (set α))} :
+  topological_space.generate_from (⋃₀ S) = (⨅ s ∈ S, topological_space.generate_from s) :=
+@galois_connection.l_Sup
+  (set (set α)) _ _
+  tmp_complete_lattice _ _
+  (λ g t, generate_from_le_iff_subset_is_open)
+  S
+
+lemma set_of_is_open_Sup {T : set (topological_space α)} :
+  {s | (Sup T).is_open s} = ⋂ t ∈ T, {s | (t : topological_space α).is_open s} :=
+@galois_connection.u_Inf
+  (set (set α)) _ _
+  tmp_complete_lattice _ _
+  (λ g t, generate_from_le_iff_subset_is_open)
+  T
+
+lemma generate_from_union_is_open (a b : topological_space α) :
+  topological_space.generate_from ({s | a.is_open s} ∪ {s | b.is_open s}) = a ⊓ b :=
+@galois_insertion.l_sup_u _ _ _ _ _
+  (@lattice.to_semilattice_sup _
+    (@bounded_lattice.to_lattice _
+      (@complete_lattice.to_bounded_lattice _ tmp_complete_lattice)))
+  (gi_generate_from α) a b
+
+lemma generate_from_Union_is_open (f : ι → topological_space α) :
+  topological_space.generate_from (⋃ i, {s | (f i).is_open s}) = ⨅ i, (f i) :=
+@galois_insertion.l_supr_u _ _ _ _ _ tmp_complete_lattice (gi_generate_from α) _ f
+
+lemma generate_from_inter (a b : topological_space α) :
+  topological_space.generate_from ({s | a.is_open s} ∩ {s | b.is_open s}) = a ⊔ b :=
+@galois_insertion.l_inf_u _ _ _ _ _
+  (@lattice.to_semilattice_inf _
+    (@bounded_lattice.to_lattice _
+      (@complete_lattice.to_bounded_lattice _ tmp_complete_lattice)))
+  (gi_generate_from α) a b
+
+lemma generate_from_Inter (f : ι → topological_space α) :
+  topological_space.generate_from (⋂ i, {s | (f i).is_open s}) = ⨆ i, (f i) :=
+@galois_insertion.l_infi_u _ _ _ _ _ tmp_complete_lattice (gi_generate_from α) _ f
+
+lemma generate_from_Inter_of_generate_from_eq_self (f : ι → set (set α))
+  (hf : ∀ i, {s | (topological_space.generate_from (f i)).is_open s} = f i) :
+  topological_space.generate_from (⋂ i, (f i)) = ⨆ i, topological_space.generate_from (f i) :=
+@galois_insertion.l_infi_of_ul_eq_self _ _ _ _ _ tmp_complete_lattice (gi_generate_from α) _ f hf
+
+variables {t : ι → topological_space α}
 
 lemma is_open_supr_iff {s : set α} : @is_open _ (⨆ i, t i) s ↔ ∀ i, @is_open _ (t i) s :=
-begin
-  -- s defines a map from α to Prop, which is continuous iff s is open.
-  suffices : @continuous _ _ (⨆ i, t i) _ s ↔ ∀ i, @continuous _ _ (t i) _ s,
-  { simpa only [continuous_Prop] using this },
-  simp only [continuous_iff_le_induced, supr_le_iff]
-end
+show s ∈ set_of (supr t).is_open ↔ s ∈ {x : set α | ∀ (i : ι), (t i).is_open x},
+by simp [set_of_is_open_supr]
 
 lemma is_closed_infi_iff {s : set α} : @is_closed _ (⨆ i, t i) s ↔ ∀ i, @is_closed _ (t i) s :=
 by simp [← is_open_compl_iff, is_open_supr_iff]


### PR DESCRIPTION
Since there is a Galois insertion between `generate_from : set (set α) → topological_space α` and the "forgetful functor" `topological_space α → set (set α)`, all kinds of lemmas about the interaction of `generate_from` and the ordering on topologies automatically follow.  But it is hard to use the Galois insertion lemmas directly, because the Galois insertion is actually provided for the dual order on topologies, which confuses Lean.  Here we re-state most of the Galois insertion API in this special case.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
