### PR TITLE
[Merged by Bors] - feat(algebra/module/ordered): simple `smul` lemmas

### DIFF
--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -216,7 +216,7 @@ variables [ring R] [add_comm_group M] [module R M] (r s : R) (x y : M)
 @[simp] theorem neg_smul : -r • x = - (r • x) :=
 eq_neg_of_add_eq_zero (by rw [← add_smul, add_left_neg, zero_smul])
 
-lemma neg_smul_neg : -r • -x = r • x :=
+@[simp] lemma neg_smul_neg : -r • -x = r • x :=
 by rw [neg_smul, smul_neg, neg_neg]
 
 @[simp] theorem units.neg_smul (u : units R) (x : M) : -u • x = - (u • x) :=

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -216,6 +216,9 @@ variables [ring R] [add_comm_group M] [module R M] (r s : R) (x y : M)
 @[simp] theorem neg_smul : -r • x = - (r • x) :=
 eq_neg_of_add_eq_zero (by rw [← add_smul, add_left_neg, zero_smul])
 
+lemma neg_smul_neg : -r • -x = r • x :=
+by rw [neg_smul, smul_neg, neg_neg]
+
 @[simp] theorem units.neg_smul (u : units R) (x : M) : -u • x = - (u • x) :=
 by rw [units.smul_def, units.coe_neg, neg_smul, units.smul_def]
 

--- a/src/algebra/module/ordered.lean
+++ b/src/algebra/module/ordered.lean
@@ -1,13 +1,13 @@
 /-
 Copyright (c) 2020 Frédéric Dupuis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Frédéric Dupuis
+Authors: Frédéric Dupuis, Yaël Dillies
 -/
 
 import algebra.module.pi
-import algebra.ordered_smul
 import algebra.module.prod
 import algebra.ordered_field
+import algebra.ordered_smul
 
 /-!
 # Ordered module
@@ -25,17 +25,100 @@ ordered module, ordered scalar, ordered smul, ordered action, ordered vector spa
 
 variables {k M N : Type*}
 
-section field
+section semiring
+variables [ordered_semiring k] [ordered_add_comm_group M] [module k M] [ordered_smul k M]
+  {a b : M} {c : k}
 
-variables [linear_ordered_field k] [ordered_add_comm_group M] [module k M] [ordered_smul k M]
-  [ordered_add_comm_group N] [module k N] [ordered_smul k N]
-
-lemma smul_le_smul_iff_of_neg
-  {a b : M} {c : k} (hc : c < 0) : c • a ≤ c • b ↔ b ≤ a :=
+/- can be generalized from `module k M` to `distrib_mul_action_with_zero k M` once it exists.
+where `distrib_mul_action_with_zero k M`is the conjunction of `distrib_mul_action k M` and
+`smul_with_zero k M`.-/
+lemma smul_neg_iff_of_pos (hc : 0 < c) :
+  c • a < 0 ↔ a < 0 :=
 begin
-  rw [← neg_neg c, neg_smul, neg_smul (-c), neg_le_neg_iff, smul_le_smul_iff_of_pos (neg_pos.2 hc)],
-  apply_instance,
+  rw [←neg_neg a, smul_neg, neg_neg_iff_pos, neg_neg_iff_pos],
+  exact smul_pos_iff_of_pos hc,
 end
+
+end semiring
+
+section ring
+variables [ordered_ring k] [ordered_add_comm_group M] [module k M] [ordered_smul k M]
+  {a b : M} {c : k}
+
+lemma smul_lt_smul_of_neg (h : a < b) (hc : c < 0) :
+  c • b < c • a :=
+begin
+  rw [←neg_neg c, neg_smul, neg_smul (-c), neg_lt_neg_iff],
+  exact smul_lt_smul_of_pos h (neg_pos_of_neg hc),
+end
+
+lemma smul_le_smul_of_nonpos (h : a ≤ b) (hc : c ≤ 0) :
+  c • b ≤ c • a :=
+begin
+  rw [←neg_neg c, neg_smul, neg_smul (-c), neg_le_neg_iff],
+  exact smul_le_smul_of_nonneg h (neg_nonneg_of_nonpos hc),
+end
+
+lemma eq_of_smul_eq_smul_of_neg_of_le (hab : c • a = c • b) (hc : c < 0) (h : a ≤ b) :
+  a = b :=
+begin
+  rw [←neg_neg c, neg_smul, neg_smul (-c), neg_inj] at hab,
+  exact eq_of_smul_eq_smul_of_pos_of_le hab (neg_pos_of_neg hc) h,
+end
+
+lemma lt_of_smul_lt_smul_of_nonpos (h : c • a < c • b) (hc : c ≤ 0) :
+  b < a :=
+begin
+  rw [←neg_neg c, neg_smul, neg_smul (-c), neg_lt_neg_iff] at h,
+  exact lt_of_smul_lt_smul_of_nonneg h (neg_nonneg_of_nonpos hc),
+end
+
+lemma smul_lt_smul_iff_of_neg (hc : c < 0) :
+  c • a < c • b ↔ b < a :=
+begin
+  rw [←neg_neg c, neg_smul, neg_smul (-c), neg_lt_neg_iff],
+  exact smul_lt_smul_iff_of_pos (neg_pos_of_neg hc),
+end
+
+lemma smul_neg_iff_of_neg (hc : c < 0) :
+  c • a < 0 ↔ 0 < a :=
+begin
+  rw [←neg_neg c, neg_smul, neg_neg_iff_pos],
+  exact smul_pos_iff_of_pos (neg_pos_of_neg hc),
+end
+
+lemma smul_pos_iff_of_neg (hc : c < 0) :
+  0 < c • a ↔ a < 0 :=
+begin
+  rw [←neg_neg c, neg_smul, neg_pos],
+  exact smul_neg_iff_of_pos (neg_pos_of_neg hc),
+end
+
+end ring
+
+section field
+variables [linear_ordered_field k] [ordered_add_comm_group M] [module k M] [ordered_smul k M]
+  {a b : M} {c : k}
+
+lemma smul_le_smul_iff_of_neg (hc : c < 0) : c • a ≤ c • b ↔ b ≤ a :=
+begin
+  rw [←neg_neg c, neg_smul, neg_smul (-c), neg_le_neg_iff],
+  exact smul_le_smul_iff_of_pos (neg_pos_of_neg hc),
+end
+
+lemma smul_lt_iff_of_neg (hc : c < 0) : c • a < b ↔ c⁻¹ • b < a :=
+begin
+  rw [←neg_neg c, ←neg_neg a, neg_smul_neg, inv_neg, neg_smul _ b, neg_lt_neg_iff],
+  exact smul_lt_iff_of_pos (neg_pos_of_neg hc),
+end
+
+lemma lt_smul_iff_of_neg (hc : c < 0) : a < c • b ↔ b < c⁻¹ • a :=
+begin
+  rw [←neg_neg c, ←neg_neg b, neg_smul_neg, inv_neg, neg_smul _ a, neg_lt_neg_iff],
+  exact lt_smul_iff_of_pos (neg_pos_of_neg hc),
+end
+
+variables [ordered_add_comm_group N] [module k N] [ordered_smul k N]
 
 -- TODO: solve `prod.has_lt` and `prod.has_le` misalignment issue
 instance prod.ordered_smul : ordered_smul k (M × N) :=

--- a/src/algebra/ordered_smul.lean
+++ b/src/algebra/ordered_smul.lean
@@ -116,9 +116,8 @@ instance linear_ordered_semiring.to_ordered_smul {R : Type*} [linear_ordered_sem
 
 section field
 
-variables {k M N : Type*} [linear_ordered_field k]
+variables {k M : Type*} [linear_ordered_field k]
   [ordered_add_comm_group M] [mul_action_with_zero k M] [ordered_smul k M]
-  [ordered_add_comm_group N] [smul_with_zero k N] [ordered_smul k N]
   {a b : M} {c : k}
 
 lemma smul_le_smul_iff_of_pos (hc : 0 < c) : c • a ≤ c • b ↔ a ≤ b :=
@@ -129,6 +128,10 @@ lemma smul_le_smul_iff_of_pos (hc : 0 < c) : c • a ≤ c • b ↔ a ≤ b :=
 lemma smul_lt_iff_of_pos (hc : 0 < c) : c • a < b ↔ a < c⁻¹ • b :=
 calc c • a < b ↔ c • a < c • c⁻¹ • b : by rw [smul_inv_smul' hc.ne']
 ... ↔ a < c⁻¹ • b : smul_lt_smul_iff_of_pos hc
+
+lemma lt_smul_iff_of_pos (hc : 0 < c) : a < c • b ↔ c⁻¹ • a < b :=
+calc a < c • b ↔ c • c⁻¹ • a < c • b : by rw [smul_inv_smul' hc.ne']
+... ↔ c⁻¹ • a < b : smul_lt_smul_iff_of_pos hc
 
 lemma smul_le_iff_of_pos (hc : 0 < c) : c • a ≤ b ↔ a ≤ c⁻¹ • b :=
 calc c • a ≤ b ↔ c • a ≤ c • c⁻¹ • b : by rw [smul_inv_smul' hc.ne']


### PR DESCRIPTION
These are the negative versions of the lemmas in `ordered_smul`, which suggests that both files should be merged.
Note however that, contrary to those, they need `module k M` instead of merely `smul_with_zero k M`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
So, Yakov, you said only a few lemmas required `ordered_module`? 😀
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
