### PR TITLE
[Merged by Bors] - feat(combinatorics/derangements/*): add lemmas about counting derangements

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -328,6 +328,10 @@
   title  : Desargues’s Theorem
 88:
   title  : Derangements Formula
+  decls  :
+    - card_derangements_eq_num_derangements
+    - num_derangements_sum
+  author : Henry Swanson
 89:
   title  : The Factor and Remainder Theorems
   decls  :

--- a/src/combinatorics/derangements/exponential.lean
+++ b/src/combinatorics/derangements/exponential.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2021 Henry Swanson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henry Swanson, Patrick Massot
+-/
+import combinatorics.derangements.finite
+import analysis.complex.basic
+import data.complex.exponential
+import topology.metric_space.cau_seq_filter
+
+/-!
+# Derangement exponential series
+
+This file proves that the probability of a permutation on n elements being a derangement is 1/e.
+The specific lemma is `num_derangements_tendsto_inv_e`.
+-/
+open filter
+open finset
+
+open_locale big_operators
+open_locale topological_space
+
+lemma complex.tendsto_iff_real (u : ℕ → ℝ) (x : ℝ) :
+  tendsto (λ n, u n) at_top (𝓝 x) ↔
+  tendsto (λ n, (u n : ℂ)) at_top (𝓝 (x : ℂ)) :=
+  ⟨(complex.continuous_of_real.tendsto x).comp, (complex.continuous_re.tendsto x).comp⟩
+
+lemma complex.tendsto_exp_series (z : ℂ) :
+  tendsto (λ n, ∑ k in range n, z^k / k.factorial) at_top (𝓝 z.exp) :=
+begin
+  convert z.exp'.tendsto_limit,
+  unfold complex.exp,
+end
+
+lemma real.tendsto_exp_series (x : ℝ) :
+  tendsto (λ n, ∑ k in range n, x^k / k.factorial) at_top (𝓝 x.exp) :=
+begin
+  rw complex.tendsto_iff_real,
+  convert complex.tendsto_exp_series x; simp,
+end
+
+theorem num_derangements_tendsto_inv_e :
+  tendsto (λ n, (num_derangements n : ℝ) / n.factorial) at_top
+  (𝓝 (real.exp (-1))) :=
+begin
+  -- we show that d(n)/n! is the partial sum of exp(-1), but offset by 1.
+  -- this isn't entirely obvious, since we have to ensure that asc_factorial and
+  -- factorial interact in the right way, e.g., that k ≤ n always
+  let s : ℕ → ℝ := λ n, ∑ k in finset.range n, (-1 : ℝ)^k / k.factorial,
+  suffices : ∀ n : ℕ, (num_derangements n : ℝ) / n.factorial = s(n+1),
+  { simp_rw this,
+    -- shift the function by 1, and use the power series lemma
+    rw tendsto_add_at_top_iff_nat 1,
+    exact real.tendsto_exp_series (-1) },
+  intro n,
+  rw [← int.cast_coe_nat, num_derangements_sum],
+  push_cast,
+  rw finset.sum_div,
+  -- get down to individual terms
+  refine finset.sum_congr (refl _) _,
+  intros k hk,
+  have h_le : k ≤ n := finset.mem_range_succ_iff.mp hk,
+  rw [nat.asc_factorial_eq_div, nat.add_sub_cancel' h_le],
+  push_cast [nat.factorial_dvd_factorial h_le],
+  field_simp [nat.factorial_ne_zero],
+  ring,
+end

--- a/src/combinatorics/derangements/exponential.lean
+++ b/src/combinatorics/derangements/exponential.lean
@@ -3,10 +3,9 @@ Copyright (c) 2021 Henry Swanson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henry Swanson, Patrick Massot
 -/
+import analysis.normed_space.exponential
 import combinatorics.derangements.finite
-import analysis.complex.basic
-import data.complex.exponential
-import topology.metric_space.cau_seq_filter
+import order.filter.basic
 
 /-!
 # Derangement exponential series
@@ -15,29 +14,9 @@ This file proves that the probability of a permutation on n elements being a der
 The specific lemma is `num_derangements_tendsto_inv_e`.
 -/
 open filter
-open finset
 
 open_locale big_operators
 open_locale topological_space
-
-lemma complex.tendsto_iff_real (u : ℕ → ℝ) (x : ℝ) :
-  tendsto (λ n, u n) at_top (𝓝 x) ↔
-  tendsto (λ n, (u n : ℂ)) at_top (𝓝 (x : ℂ)) :=
-  ⟨(complex.continuous_of_real.tendsto x).comp, (complex.continuous_re.tendsto x).comp⟩
-
-lemma complex.tendsto_exp_series (z : ℂ) :
-  tendsto (λ n, ∑ k in range n, z^k / k.factorial) at_top (𝓝 z.exp) :=
-begin
-  convert z.exp'.tendsto_limit,
-  unfold complex.exp,
-end
-
-lemma real.tendsto_exp_series (x : ℝ) :
-  tendsto (λ n, ∑ k in range n, x^k / k.factorial) at_top (𝓝 x.exp) :=
-begin
-  rw complex.tendsto_iff_real,
-  convert complex.tendsto_exp_series x; simp,
-end
 
 theorem num_derangements_tendsto_inv_e :
   tendsto (λ n, (num_derangements n : ℝ) / n.factorial) at_top
@@ -49,9 +28,14 @@ begin
   let s : ℕ → ℝ := λ n, ∑ k in finset.range n, (-1 : ℝ)^k / k.factorial,
   suffices : ∀ n : ℕ, (num_derangements n : ℝ) / n.factorial = s(n+1),
   { simp_rw this,
-    -- shift the function by 1, and use the power series lemma
+    -- shift the function by 1, and then use the fact that the partial sums
+    -- converge to the infinite sum
     rw tendsto_add_at_top_iff_nat 1,
-    exact real.tendsto_exp_series (-1) },
+    apply has_sum.tendsto_sum_nat,
+    -- there's no specific lemma for ℝ that ∑ x^k/k! sums to exp(x), but it's
+    -- true in more general fields, so use that lemma
+    rw real.exp_eq_exp_ℝ_ℝ,
+    exact exp_series_field_has_sum_exp (-1 : ℝ) },
   intro n,
   rw [← int.cast_coe_nat, num_derangements_sum],
   push_cast,

--- a/src/combinatorics/derangements/finite.lean
+++ b/src/combinatorics/derangements/finite.lean
@@ -87,12 +87,12 @@ end
 lemma card_derangements_fin_eq_num_derangements {n : ℕ} :
   card (derangements (fin n)) = num_derangements n :=
 begin
-  apply nat.strong_induction_on n, clear n, -- to avoid confusion with the n in the hypothesis
-  rintros (_|_|n) hyp, { refl }, { refl },  -- knock out cases 0 and 1
+  induction n using nat.strong_induction_on with n hyp,
+  obtain (_|_|n) := n, { refl }, { refl },  -- knock out cases 0 and 1
   -- now we have n ≥ 2. rewrite everything in terms of card_derangements, so that we can use
   -- `card_derangements_fin_add_two`
-  rw [num_derangements_add_two, card_derangements_fin_add_two, mul_add, hyp, hyp _ (lt_add_one _)],
-  exact nat.lt_add_of_pos_right zero_lt_two,
+  rw [num_derangements_add_two, card_derangements_fin_add_two, mul_add,
+    hyp _ (nat.lt_add_of_pos_right zero_lt_two), hyp _ (lt_add_one _)],
 end
 
 lemma card_derangements_eq_num_derangements (α : Type*) [fintype α] [decidable_eq α] :

--- a/src/combinatorics/derangements/finite.lean
+++ b/src/combinatorics/derangements/finite.lean
@@ -42,27 +42,23 @@ lemma card_derangements_invariant {α β : Type*} [fintype α] [decidable_eq α]
   card (derangements α) = card (derangements β) :=
 fintype.card_congr (equiv.derangements_congr $ equiv_of_card_eq h)
 
-lemma card_derangements_fin_succ_succ (n : ℕ) :
+lemma card_derangements_fin_add_two (n : ℕ) :
   card (derangements (fin (n+2))) = (n+1) * card (derangements (fin n)) +
   (n+1) * card (derangements (fin (n+1))) :=
 begin
   -- get some basic results about the size of fin (n+1) plus or minus an element
-  have card_n' : ∀ a : fin (n+1), card ({a}ᶜ : set (fin (n+1))) = n,
+  have h1 : ∀ a : fin (n+1), card ({a}ᶜ : set (fin (n+1))) = card (fin n),
   { intro a,
-    simp only [fintype.card_of_finset, set.mem_compl_singleton_iff],
-    rw [finset.filter_ne' _ a, finset.card_erase_of_mem (finset.mem_univ a)],
-    simp },
-  have card_n : ∀ a : fin (n+1), card ({a}ᶜ : set (fin (n+1))) = card (fin n),
-  { intro a, rw card_n' a, simp },
-  have card_n2 : card (fin (n+2)) = card (option (fin (n+1))) := by simp,
+    simp only [fintype.card_fin, finset.card_fin, fintype.card_of_finset, finset.filter_ne' _ a,
+      set.mem_compl_singleton_iff, finset.card_erase_of_mem (finset.mem_univ a), nat.pred_succ] },
+  have h2 : card (fin (n+2)) = card (option (fin (n+1))),
+  { simp only [card_fin, card_option] },
   -- rewrite the LHS and substitute in our fintype-level equivalence
-  rw [card_derangements_invariant card_n2,
-    card_congr (@derangements_recursion_equiv (fin (n+1)) _)],
+  simp only [card_derangements_invariant h2,
+    card_congr (@derangements_recursion_equiv (fin (n+1)) _),
   -- push the cardinality through the Σ and ⊕ so that we can use `card_n`
-  rw card_sigma,
-  simp_rw [card_sum, card_derangements_invariant (card_n _)],
-  rw [finset.sum_const, nsmul_eq_mul, finset.card_fin, mul_add],
-  norm_cast,
+    card_sigma, card_sum, card_derangements_invariant (h1 _), finset.sum_const, nsmul_eq_mul,
+    finset.card_fin, mul_add, nat.cast_id],
 end
 
 /-- The number of derangements on an `n`-element set. -/
@@ -71,35 +67,32 @@ def num_derangements : ℕ → ℕ
 | 1 := 0
 | (n + 2) := (n + 1) * (num_derangements n + num_derangements (n+1))
 
-lemma num_derangements_succ {n : ℕ} :
+@[simp] lemma num_derangements_zero : num_derangements 0 = 1 := rfl
+
+@[simp] lemma num_derangements_one : num_derangements 1 = 0 := rfl
+
+lemma num_derangements_add_two (n : ℕ) :
+  num_derangements (n+2) = (n+1) * (num_derangements n + num_derangements (n+1)) := rfl
+
+lemma num_derangements_succ (n : ℕ) :
   (num_derangements (n+1) : ℤ) = (n + 1) * (num_derangements n : ℤ) - (-1)^n :=
 begin
   induction n with n hn,
   { refl },
-  { rw num_derangements,
-    push_cast,
-    rw hn,
-    rw pow_succ,
+  { simp only [num_derangements_add_two, hn, pow_succ,
+      int.coe_nat_mul, int.coe_nat_add, int.coe_nat_succ],
     ring }
 end
 
 lemma card_derangements_fin_eq_num_derangements {n : ℕ} :
   card (derangements (fin n)) = num_derangements n :=
 begin
-  apply nat.strong_induction_on n,
-  clear n, -- to avoid confusion with the n in the hypothesis
-  intros n hyp,
-  -- knock out cases 0 and 1
-  cases n, { refl },
-  cases n, { refl },
+  apply nat.strong_induction_on n, clear n, -- to avoid confusion with the n in the hypothesis
+  rintros (_|_|n) hyp, { refl }, { refl },  -- knock out cases 0 and 1
   -- now we have n ≥ 2. rewrite everything in terms of card_derangements, so that we can use
-  -- `card_derangements_fin_succ_succ`
-  rw num_derangements,
-  have n_le : n < n + 2 := nat.lt_succ_of_le (nat.le_succ _),
-  have n_succ_le : n + 1 < n + 2 := lt_add_one _,
-  rw [← hyp n n_le, ← hyp n.succ n_succ_le],
-  rw card_derangements_fin_succ_succ,
-  rw mul_add,
+  -- `card_derangements_fin_add_two`
+  rw [num_derangements_add_two, card_derangements_fin_add_two, mul_add, hyp, hyp _ (lt_add_one _)],
+  exact nat.lt_add_of_pos_right zero_lt_two,
 end
 
 lemma card_derangements_eq_num_derangements (α : Type*) [fintype α] [decidable_eq α] :
@@ -110,20 +103,15 @@ begin
 end
 
 theorem num_derangements_sum (n : ℕ) :
-  (num_derangements n : ℤ) = ∑ k in finset.range (n + 1),
-  (-1 : ℤ)^k * nat.asc_factorial k (n - k) :=
+  (num_derangements n : ℤ) = ∑ k in finset.range (n + 1), (-1:ℤ)^k * nat.asc_factorial k (n - k) :=
 begin
-  induction n with n hn,
-  { refl },
-  { rw [finset.sum_range_succ, num_derangements_succ, hn, finset.mul_sum, sub_eq_add_neg],
-    congr' 1,
-    -- show that (n + 1) * (-1)^x * desc_fac x (n - x) = (-1)^x * desc_fac x (n.succ - x)
-    { refine finset.sum_congr (refl _) _,
-      intros x hx,
-      have h_le : x ≤ n := finset.mem_range_succ_iff.mp hx,
-      rw [nat.succ_sub h_le, nat.asc_factorial_succ, nat.add_sub_cancel' h_le],
-      push_cast,
-      ring },
-    -- show that -(-1)^n = (-1)^n.succ * desc_fac n.succ (n.succ - n.succ)
-    { simp [pow_succ] } }
+  induction n with n hn, { refl },
+  rw [finset.sum_range_succ, num_derangements_succ, hn, finset.mul_sum, nat.sub_self,
+    nat.asc_factorial_zero, int.coe_nat_one, mul_one, pow_succ, neg_one_mul, sub_eq_add_neg,
+    add_left_inj, finset.sum_congr rfl],
+  -- show that (n + 1) * (-1)^x * asc_fac x (n - x) = (-1)^x * asc_fac x (n.succ - x)
+  intros x hx,
+  have h_le : x ≤ n := finset.mem_range_succ_iff.mp hx,
+  rw [nat.succ_sub h_le, nat.asc_factorial_succ, nat.add_sub_cancel' h_le,
+    int.coe_nat_mul, int.coe_nat_succ, mul_left_comm],
 end

--- a/src/combinatorics/derangements/finite.lean
+++ b/src/combinatorics/derangements/finite.lean
@@ -5,6 +5,7 @@ Authors: Henry Swanson
 -/
 import combinatorics.derangements.basic
 import data.fintype.card
+import tactic.delta_instance
 import tactic.ring
 
 /-!
@@ -34,11 +35,7 @@ variables {α : Type*} [decidable_eq α] [fintype α]
 
 instance : decidable_pred (derangements α) := λ _, fintype.decidable_forall_fintype
 
-instance : fintype (derangements α) :=
-begin
-  rw [derangements],
-  apply_instance
-end
+instance : fintype (derangements α) := by delta_instance derangements
 
 lemma card_derangements_invariant {α β : Type*} [fintype α] [decidable_eq α]
   [fintype β] [decidable_eq β] (h : card α = card β) :

--- a/src/combinatorics/derangements/finite.lean
+++ b/src/combinatorics/derangements/finite.lean
@@ -15,16 +15,13 @@ This file contains lemmas that describe the cardinality of `derangements α` whe
 
 # Main definitions
 
-  - `card_derangements_invariant`: A lemma stating that the number of derangements on a type `α`
+* `card_derangements_invariant`: A lemma stating that the number of derangements on a type `α`
     depends only on the cardinality of `α`.
-
-  - `num_derangements n`: The number of derangements on an n-element set, defined in a computation-
+* `num_derangements n`: The number of derangements on an n-element set, defined in a computation-
     friendly way.
-
-  - `card_derangements_eq_num_derangements`: Proof that `num_derangements` really does compute the
+* `card_derangements_eq_num_derangements`: Proof that `num_derangements` really does compute the
     number of derangements.
-
-  - `num_derangements_sum`: A lemma giving an expression for `num_derangements n` in terms of
+* `num_derangements_sum`: A lemma giving an expression for `num_derangements n` in terms of
     factorials.
 -/
 
@@ -61,7 +58,7 @@ begin
     finset.card_fin, mul_add, nat.cast_id],
 end
 
-/-- The number of derangements on an `n`-element set. -/
+/-- The number of derangements of an `n`-element set. -/
 def num_derangements : ℕ → ℕ
 | 0 := 1
 | 1 := 0

--- a/src/combinatorics/derangements/finite.lean
+++ b/src/combinatorics/derangements/finite.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2021 Henry Swanson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henry Swanson
+-/
+import combinatorics.derangements.basic
+import data.fintype.card
+import tactic.ring
+
+/-!
+# Derangements on fintypes
+
+This file contains lemmas that describe the cardinality of `derangements α` when `α` is a fintype.
+
+# Main definitions
+
+  - `card_derangements_invariant`: A lemma stating that the number of derangements on a type `α`
+    depends only on the cardinality of `α`.
+
+  - `num_derangements n`: The number of derangements on an n-element set, defined in a computation-
+    friendly way.
+
+  - `card_derangements_eq_num_derangements`: Proof that `num_derangements` really does compute the
+    number of derangements.
+
+  - `num_derangements_sum`: A lemma giving an expression for `num_derangements n` in terms of
+    factorials.
+-/
+
+open derangements equiv fintype
+open_locale big_operators
+
+variables {α : Type*} [decidable_eq α] [fintype α]
+
+instance : decidable_pred (derangements α) := λ _, fintype.decidable_forall_fintype
+
+instance : fintype (derangements α) :=
+begin
+  rw [derangements],
+  apply_instance
+end
+
+lemma card_derangements_invariant {α β : Type*} [fintype α] [decidable_eq α]
+  [fintype β] [decidable_eq β] (h : card α = card β) :
+  card (derangements α) = card (derangements β) :=
+fintype.card_congr (equiv.derangements_congr $ equiv_of_card_eq h)
+
+lemma card_derangements_fin_succ_succ (n : ℕ) :
+  card (derangements (fin (n+2))) = (n+1) * card (derangements (fin n)) +
+  (n+1) * card (derangements (fin (n+1))) :=
+begin
+  -- get some basic results about the size of fin (n+1) plus or minus an element
+  have card_n' : ∀ a : fin (n+1), card ({a}ᶜ : set (fin (n+1))) = n,
+  { intro a,
+    simp only [fintype.card_of_finset, set.mem_compl_singleton_iff],
+    rw [finset.filter_ne' _ a, finset.card_erase_of_mem (finset.mem_univ a)],
+    simp },
+  have card_n : ∀ a : fin (n+1), card ({a}ᶜ : set (fin (n+1))) = card (fin n),
+  { intro a, rw card_n' a, simp },
+  have card_n2 : card (fin (n+2)) = card (option (fin (n+1))) := by simp,
+  -- rewrite the LHS and substitute in our fintype-level equivalence
+  rw [card_derangements_invariant card_n2,
+    card_congr (@derangements_recursion_equiv (fin (n+1)) _)],
+  -- push the cardinality through the Σ and ⊕ so that we can use `card_n`
+  rw card_sigma,
+  simp_rw [card_sum, card_derangements_invariant (card_n _)],
+  rw [finset.sum_const, nsmul_eq_mul, finset.card_fin, mul_add],
+  norm_cast,
+end
+
+/-- The number of derangements on an `n`-element set. -/
+def num_derangements : ℕ → ℕ
+| 0 := 1
+| 1 := 0
+| (n + 2) := (n + 1) * (num_derangements n + num_derangements (n+1))
+
+lemma num_derangements_succ {n : ℕ} :
+  (num_derangements (n+1) : ℤ) = (n + 1) * (num_derangements n : ℤ) - (-1)^n :=
+begin
+  induction n with n hn,
+  { refl },
+  { rw num_derangements,
+    push_cast,
+    rw hn,
+    rw pow_succ,
+    ring }
+end
+
+lemma card_derangements_fin_eq_num_derangements {n : ℕ} :
+  card (derangements (fin n)) = num_derangements n :=
+begin
+  apply nat.strong_induction_on n,
+  clear n, -- to avoid confusion with the n in the hypothesis
+  intros n hyp,
+  -- knock out cases 0 and 1
+  cases n, { refl },
+  cases n, { refl },
+  -- now we have n ≥ 2. rewrite everything in terms of card_derangements, so that we can use
+  -- `card_derangements_fin_succ_succ`
+  rw num_derangements,
+  have n_le : n < n + 2 := nat.lt_succ_of_le (nat.le_succ _),
+  have n_succ_le : n + 1 < n + 2 := lt_add_one _,
+  rw [← hyp n n_le, ← hyp n.succ n_succ_le],
+  rw card_derangements_fin_succ_succ,
+  rw mul_add,
+end
+
+lemma card_derangements_eq_num_derangements (α : Type*) [fintype α] [decidable_eq α] :
+  card (derangements α) = num_derangements (card α) :=
+begin
+  rw ←card_derangements_invariant (card_fin _),
+  exact card_derangements_fin_eq_num_derangements,
+end
+
+theorem num_derangements_sum (n : ℕ) :
+  (num_derangements n : ℤ) = ∑ k in finset.range (n + 1),
+  (-1 : ℤ)^k * nat.asc_factorial k (n - k) :=
+begin
+  induction n with n hn,
+  { refl },
+  { rw [finset.sum_range_succ, num_derangements_succ, hn, finset.mul_sum, sub_eq_add_neg],
+    congr' 1,
+    -- show that (n + 1) * (-1)^x * desc_fac x (n - x) = (-1)^x * desc_fac x (n.succ - x)
+    { refine finset.sum_congr (refl _) _,
+      intros x hx,
+      have h_le : x ≤ n := finset.mem_range_succ_iff.mp hx,
+      rw [nat.succ_sub h_le, nat.asc_factorial_succ, nat.add_sub_cancel' h_le],
+      push_cast,
+      ring },
+    -- show that -(-1)^n = (-1)^n.succ * desc_fac n.succ (n.succ - n.succ)
+    { simp [pow_succ] } }
+end


### PR DESCRIPTION
This defines `card_derangements` as the cardinality of the set of derangements of a fintype, and `num_derangements` as a function from N to N, and proves their equality, along with some other lemmas.

Context: PR #7526 grew too large and had to be split in half. The first half retained the original PR ID, and this is the second half. This adds back the finite.lean and exponential.lean files. Also, added entries back to 100.yaml.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
