### PR TITLE
[Merged by Bors] -  feat(topology/compact_open): express the compact-open topology as an Inf of topologies

### DIFF
--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -103,6 +103,45 @@ continuous_iff_continuous_at.mpr $ assume ⟨f, x⟩ n hn,
 
 end ev
 
+section Inf_induced
+
+-- not a very conceptual proof!
+lemma compact_open_eq_Inf_induced :
+  (continuous_map.compact_open : topological_space C(α, β))
+  = ⨅ (s : set α) (hs : is_compact s),
+    topological_space.induced (continuous_map.restrict s) continuous_map.compact_open :=
+begin
+  simp only [← generate_from_Union, induced_generate_from_eq, continuous_map.compact_open],
+  congr' 1,
+  ext m,
+  rw mem_bUnion_iff',
+  split,
+  { rintros ⟨s, hs, u, hu, rfl⟩,
+    refine ⟨s, hs, compact_open.gen univ u, _⟩,
+    refine ⟨⟨univ, is_compact_iff_is_compact_univ.mp hs, u, hu, rfl⟩, _⟩,
+    ext f,
+    simp only [compact_open.gen, mem_set_of_eq, mem_preimage, continuous_map.coe_restrict],
+    rw image_comp f (coe : s → α),
+    simp },
+  { rintros ⟨s, hs, sb, ⟨s', hs', u, hu, rfl⟩, rfl⟩,
+    refine ⟨coe '' s', hs'.image continuous_subtype_coe, u, hu, _⟩,
+    ext f,
+    simp only [compact_open.gen, coe_restrict, mem_set_of_eq, preimage_set_of_eq,
+      image_subset_iff],
+    rw preimage_comp },
+end
+
+lemma nhds_compact_open_eq_Inf_nhds_induced (f : C(α, β)) :
+  𝓝 f = ⨅ s (hs : is_compact s), (𝓝 (f.restrict s)).comap (continuous_map.restrict s) :=
+by { rw [compact_open_eq_Inf_induced], simp [nhds_infi, nhds_induced] }
+
+lemma tendsto_compact_open_iff_forall {ι : Type*} {l : filter ι} (F : ι → C(α, β)) (f : C(α, β)) :
+  filter.tendsto F l (nhds f)
+  ↔ ∀ s (hs : is_compact s), filter.tendsto (λ i, (F i).restrict s) l (𝓝 (f.restrict s)) :=
+by { rw [compact_open_eq_Inf_induced], simp [nhds_infi, nhds_induced, filter.tendsto_comap_iff] }
+
+end Inf_induced
+
 section coev
 
 variables (α β)

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -105,7 +105,9 @@ end ev
 
 section Inf_induced
 
--- not a very conceptual proof!
+/-- The compact-open topology on `C(α, β)` is equal to the infimum of the compact-open topologies
+on `C(s, β)` for `s` a compact subset of `α`.  The key point of the proof is that the union of the
+compact subsets of `α` is equal to the union of compact subsets of the compact subsets of `α`. -/
 lemma compact_open_eq_Inf_induced :
   (continuous_map.compact_open : topological_space C(α, β))
   = ⨅ (s : set α) (hs : is_compact s),

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -207,6 +207,17 @@ end inf'
 
 end lattice
 
+section restrict
+
+variables (s : set α)
+
+/-- The restriction of a continuous function `α → β` to a subset `s` of `α`. -/
+def restrict (f : C(α, β)) : C(s, β) := ⟨f ∘ coe⟩
+
+@[simp] lemma coe_restrict (f : C(α, β)) : ⇑(f.restrict s) = f ∘ coe := rfl
+
+end restrict
+
 section extend
 
 variables [linear_order α] [order_topology α] {a b : α} (h : a ≤ b)


### PR DESCRIPTION
For `f : C(α, β)` and a set `s` in `α`, define `f.restrict s` to be the restriction of `f` as an element of `C(s, β)`.  This PR then proves that the compact-open topology on `C(α, β)` is equal to the infimum of the induced compact-open topologies from the restrictions to compact sets.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
