### PR TITLE
[Merged by Bors] - chore(algebra/ordered_smul): reduce instance assumptions & delete duplicated instances

### DIFF
--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -250,6 +250,7 @@ instance semiring.to_module [semiring R] : module R R :=
   zero_smul := zero_mul,
   smul_zero := mul_zero }
 
+/-- Like `semiring.to_module`, but multiplies on the right. -/
 @[priority 910] -- see Note [lower instance priority]
 instance semiring.to_opposite_module [semiring R] : module Rᵒᵖ R :=
 { smul_add := λ r x y, add_mul _ _ _,

--- a/src/algebra/module/opposites.lean
+++ b/src/algebra/module/opposites.lean
@@ -16,28 +16,7 @@ cycles.
 namespace opposite
 universes u v
 
-variables (R : Type u) {M : Type v}
-
-/-- Like `mul_zero_class.to_smul_with_zero`, but multiplies on the right. -/
-instance mul_zero_class.to_opposite_smul_with_zero [mul_zero_class R] :
-  smul_with_zero (opposite R) R :=
-{ smul := λ c x, x * c.unop,
-  smul_zero := λ x, zero_mul _,
-  zero_smul := mul_zero }
-
-/-- Like `monoid_with_zero.to_mul_action_with_zero`, but multiplies on the right. -/
-instance monoid_with_zero.to_opposite_mul_action_with_zero [monoid_with_zero R] :
-  mul_action_with_zero (opposite R) R :=
-{ ..mul_zero_class.to_opposite_smul_with_zero R,
-  ..monoid.to_opposite_mul_action R }
-
-/-- Like `semiring.to_module`, but multiplies on the right. -/
-instance semiring.to_opposite_module [semiring R] : module (opposite R) R :=
-{ smul_add := λ r x y, add_mul _ _ _,
-  add_smul := λ r s x, mul_add _ _ _,
-  ..mul_zero_class.to_opposite_smul_with_zero R }
-
-variables [semiring R] [add_comm_monoid M] [module R M]
+variables (R : Type u) {M : Type v} [semiring R] [add_comm_monoid M] [module R M]
 
 /-- `opposite.distrib_mul_action` extends to a `module` -/
 instance : module R (opposite M) :=

--- a/src/algebra/ordered_smul.lean
+++ b/src/algebra/ordered_smul.lean
@@ -150,22 +150,22 @@ variables {R M : Type*}
 instance [has_scalar R M] : has_scalar R (order_dual M) :=
 { smul := λ k x, order_dual.rec (λ x', (k • x' : M)) x }
 
-instance [semiring R] [ordered_add_comm_monoid M] [h : smul_with_zero R M] :
+instance [has_zero R] [add_zero_class M] [h : smul_with_zero R M] :
   smul_with_zero R (order_dual M) :=
 { zero_smul := λ m, order_dual.rec (zero_smul _) m,
   smul_zero := λ r, order_dual.rec (smul_zero' _) r,
   ..order_dual.has_scalar }
 
-instance [semiring R] [mul_action R M] : mul_action R (order_dual M) :=
+instance [monoid R] [mul_action R M] : mul_action R (order_dual M) :=
 { one_smul := λ m, order_dual.rec (one_smul _) m,
   mul_smul := λ r, order_dual.rec mul_smul r,
   ..order_dual.has_scalar }
 
-instance [semiring R] [ordered_add_comm_monoid M] [mul_action_with_zero R M] :
+instance [monoid_with_zero R] [add_monoid M] [mul_action_with_zero R M] :
   mul_action_with_zero R (order_dual M) :=
 { ..order_dual.mul_action, ..order_dual.smul_with_zero }
 
-instance [semiring R] [ordered_add_comm_monoid M] [distrib_mul_action R M] :
+instance [monoid_with_zero R] [add_monoid M] [distrib_mul_action R M] :
   distrib_mul_action R (order_dual M) :=
 { smul_add := λ k a, order_dual.rec (λ a' b, order_dual.rec (smul_add _ _) b) a,
   smul_zero := λ r, order_dual.rec smul_zero r }

--- a/src/algebra/smul_with_zero.lean
+++ b/src/algebra/smul_with_zero.lean
@@ -45,6 +45,7 @@ instance mul_zero_class.to_smul_with_zero [mul_zero_class R] : smul_with_zero R 
   smul_zero := mul_zero,
   zero_smul := zero_mul }
 
+/-- Like `mul_zero_class.to_smul_with_zero`, but multiplies on the right. -/
 instance mul_zero_class.to_opposite_smul_with_zero [mul_zero_class R] : smul_with_zero Rᵒᵖ R :=
 { smul := (•),
   smul_zero := λ r, zero_mul _,
@@ -117,7 +118,8 @@ instance monoid_with_zero.to_mul_action_with_zero : mul_action_with_zero R R :=
 { ..mul_zero_class.to_smul_with_zero R,
   ..monoid.to_mul_action R }
 
-/-- See also `semiring.to_opposite_module` -/
+/-- Like `monoid_with_zero.to_mul_action_with_zero`, but multiplies on the right. See also
+`semiring.to_opposite_module` -/
 instance monoid_with_zero.to_opposite_mul_action_with_zero : mul_action_with_zero Rᵒᵖ R :=
 { ..mul_zero_class.to_opposite_smul_with_zero R,
   ..monoid.to_opposite_mul_action R }


### PR DESCRIPTION
These instances all assumed `semiring R` superfluously:
* `order_dual.smul_with_zero`
* `order_dual.mul_action`
* `order_dual.mul_action_with_zero`
* `order_dual.distrib_mul_action`

and these instances were duplicates (with their `opposite.`-less counterparts):
* `opposite.mul_zero_class.to_opposite_smul_with_zero`
* `opposite.monoid_with_zero.to_opposite_mul_action_with_zero`
* `opposite.semiring.to_opposite_module`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
