### PR TITLE
[Merged by Bors] - chore(combinatorics/simple_graph): rename sym to symm

### DIFF
--- a/archive/100-theorems-list/83_friendship_graphs.lean
+++ b/archive/100-theorems-list/83_friendship_graphs.lean
@@ -106,7 +106,7 @@ lemma degree_eq_of_not_adj {v w : V} (hvw : ¬ G.adj v w) :
 begin
   rw [← nat.cast_id (G.degree v), ← nat.cast_id (G.degree w),
       ← adj_matrix_pow_three_of_not_adj ℕ hG hvw,
-      ← adj_matrix_pow_three_of_not_adj ℕ hG (λ h, hvw (G.sym h))],
+      ← adj_matrix_pow_three_of_not_adj ℕ hG (λ h, hvw (G.symm h))],
   conv_lhs {rw ← transpose_adj_matrix},
   simp only [pow_succ, sq, mul_eq_mul, ← transpose_mul, transpose_apply],
   simp only [← mul_eq_mul, mul_assoc],
@@ -163,8 +163,8 @@ begin
     rw [h, mem_singleton] at h',
     injection h', },
   apply hxy',
-  rw [key ((mem_common_neighbors G).mpr ⟨hvx, G.sym hxw⟩),
-      key ((mem_common_neighbors G).mpr ⟨hvy, G.sym hcontra⟩)],
+  rw [key ((mem_common_neighbors G).mpr ⟨hvx, G.symm hxw⟩),
+      key ((mem_common_neighbors G).mpr ⟨hvy, G.symm hcontra⟩)],
 end
 
 /-- Let `A` be the adjacency matrix of a `d`-regular friendship graph, and let `v` be a vector

--- a/src/combinatorics/simple_graph/adj_matrix.lean
+++ b/src/combinatorics/simple_graph/adj_matrix.lean
@@ -72,7 +72,7 @@ by rw [←apply_ne_one_iff h, not_not]
 def to_graph [mul_zero_one_class α] [nontrivial α] (h : is_adj_matrix A) :
   simple_graph V :=
 { adj := λ i j, A i j = 1,
-  sym := λ i j hij, by rwa h.symm.apply i j,
+  symm := λ i j hij, by rwa h.symm.apply i j,
   loopless := λ i, by simp [h] }
 
 instance [mul_zero_one_class α] [nontrivial α] [decidable_eq α] (h : is_adj_matrix A) :

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -81,7 +81,7 @@ see `simple_graph.edge_set` for the corresponding edge set.
 @[ext]
 structure simple_graph (V : Type u) :=
 (adj : V → V → Prop)
-(sym : symmetric adj . obviously)
+(symm : symmetric adj . obviously)
 (loopless : irreflexive adj . obviously)
 
 /--
@@ -90,7 +90,7 @@ symmetrizes the relation and makes it irreflexive.
 -/
 def simple_graph.from_rel {V : Type u} (r : V → V → Prop) : simple_graph V :=
 { adj := λ a b, (a ≠ b) ∧ (r a b ∨ r b a),
-  sym := λ a b ⟨hn, hr⟩, ⟨hn.symm, hr.symm⟩,
+  symm := λ a b ⟨hn, hr⟩, ⟨hn.symm, hr.symm⟩,
   loopless := λ a ⟨hn, _⟩, hn rfl }
 
 noncomputable instance {V : Type u} [fintype V] : fintype (simple_graph V) :=
@@ -114,9 +114,9 @@ variables {V : Type u} {W : Type v} {X : Type w} (G : simple_graph V) (G' : simp
 
 @[simp] lemma irrefl {v : V} : ¬G.adj v v := G.loopless v
 
-lemma adj_comm (u v : V) : G.adj u v ↔ G.adj v u := ⟨λ x, G.sym x, λ x, G.sym x⟩
+lemma adj_comm (u v : V) : G.adj u v ↔ G.adj v u := ⟨λ x, G.symm x, λ x, G.symm x⟩
 
-@[symm] lemma adj_symm {u v : V} (h : G.adj u v) : G.adj v u := G.sym h
+@[symm] lemma adj_symm {u v : V} (h : G.adj u v) : G.adj v u := G.symm h
 
 lemma ne_of_adj {a b : V} (hab : G.adj a b) : a ≠ b :=
 by { rintro rfl, exact G.irrefl hab }
@@ -135,7 +135,7 @@ rfl
 /-- The supremum of two graphs `x ⊔ y` has edges where either `x` or `y` have edges. -/
 instance : has_sup (simple_graph V) := ⟨λ x y,
   { adj := x.adj ⊔ y.adj,
-    sym := λ v w h, by rwa [sup_apply, sup_apply, x.adj_comm, y.adj_comm] }⟩
+    symm := λ v w h, by rwa [sup_apply, sup_apply, x.adj_comm, y.adj_comm] }⟩
 
 @[simp] lemma sup_adj (x y : simple_graph V) (v w : V) : (x ⊔ y).adj v w ↔ x.adj v w ∨ y.adj v w :=
 iff.rfl
@@ -143,7 +143,7 @@ iff.rfl
 /-- The infinum of two graphs `x ⊓ y` has edges where both `x` and `y` have edges. -/
 instance : has_inf (simple_graph V) := ⟨λ x y,
   { adj := x.adj ⊓ y.adj,
-    sym := λ v w h, by rwa [inf_apply, inf_apply, x.adj_comm, y.adj_comm] }⟩
+    symm := λ v w h, by rwa [inf_apply, inf_apply, x.adj_comm, y.adj_comm] }⟩
 
 @[simp] lemma inf_adj (x y : simple_graph V) (v w : V) : (x ⊓ y).adj v w ↔ x.adj v w ∧ y.adj v w :=
 iff.rfl
@@ -155,7 +155,7 @@ are adjacent in the complement, and every nonadjacent pair of vertices is adjace
 -/
 instance : has_compl (simple_graph V) := ⟨λ G,
   { adj := λ v w, v ≠ w ∧ ¬G.adj v w,
-    sym := λ v w ⟨hne, _⟩, ⟨hne.symm, by rwa adj_comm⟩,
+    symm := λ v w ⟨hne, _⟩, ⟨hne.symm, by rwa adj_comm⟩,
     loopless := λ v ⟨hne, _⟩, (hne rfl).elim }⟩
 
 @[simp] lemma compl_adj (G : simple_graph V) (v w : V) : Gᶜ.adj v w ↔ v ≠ w ∧ ¬G.adj v w := iff.rfl
@@ -163,7 +163,7 @@ instance : has_compl (simple_graph V) := ⟨λ G,
 /-- The difference of two graphs `x / y` has the edges of `x` with the edges of `y` removed. -/
 instance : has_sdiff (simple_graph V) := ⟨λ x y,
   { adj := x.adj \ y.adj,
-    sym := λ v w h, by change x.adj w v ∧ ¬ y.adj w v; rwa [x.adj_comm, y.adj_comm] }⟩
+    symm := λ v w h, by change x.adj w v ∧ ¬ y.adj w v; rwa [x.adj_comm, y.adj_comm] }⟩
 
 @[simp] lemma sdiff_adj (x y : simple_graph V) (v w : V) :
   (x \ y).adj v w ↔ (x.adj v w ∧ ¬ y.adj v w) := iff.rfl
@@ -241,7 +241,7 @@ The edges of G consist of the unordered pairs of vertices related by
 The way `edge_set` is defined is such that `mem_edge_set` is proved by `refl`.
 (That is, `⟦(v, w)⟧ ∈ G.edge_set` is definitionally equal to `G.adj v w`.)
 -/
-def edge_set : set (sym2 V) := sym2.from_rel G.sym
+def edge_set : set (sym2 V) := sym2.from_rel G.symm
 
 /--
 The `incidence_set` is the set of edges incident to a given vertex.

--- a/src/combinatorics/simple_graph/degree_sum.lean
+++ b/src/combinatorics/simple_graph/degree_sum.lean
@@ -67,7 +67,7 @@ d.is_adj
 
 /-- The dart with reversed orientation from a given dart. -/
 def dart.rev (d : G.dart) : G.dart :=
-⟨d.snd, d.fst, G.sym d.is_adj⟩
+⟨d.snd, d.fst, G.symm d.is_adj⟩
 
 @[simp] lemma dart.rev_edge (d : G.dart) : d.rev.edge = d.edge :=
 sym2.eq_swap

--- a/src/combinatorics/simple_graph/subgraph.lean
+++ b/src/combinatorics/simple_graph/subgraph.lean
@@ -59,21 +59,21 @@ structure subgraph {V : Type u} (G : simple_graph V) :=
 (adj : V → V → Prop)
 (adj_sub : ∀ {v w : V}, adj v w → G.adj v w)
 (edge_vert : ∀ {v w : V}, adj v w → v ∈ verts)
-(sym : symmetric adj . obviously)
+(symm : symmetric adj . obviously)
 
 namespace subgraph
 
 variables {V : Type u} {G : simple_graph V}
 
 lemma adj_comm (G' : subgraph G) (v w : V) : G'.adj v w ↔ G'.adj w v :=
-⟨λ x, G'.sym x, λ x, G'.sym x⟩
+⟨λ x, G'.symm x, λ x, G'.symm x⟩
 
-@[symm] lemma adj_symm (G' : subgraph G) {u v : V} (h : G'.adj u v) : G'.adj v u := G'.sym h
+@[symm] lemma adj_symm (G' : subgraph G) {u v : V} (h : G'.adj u v) : G'.adj v u := G'.symm h
 
 /-- Coercion from `G' : subgraph G` to a `simple_graph ↥G'.verts`. -/
 @[simps] def coe (G' : subgraph G) : simple_graph G'.verts :=
 { adj := λ v w, G'.adj v w,
-  sym := λ v w h, G'.sym h,
+  symm := λ v w h, G'.symm h,
   loopless := λ v h, loopless G v (G'.adj_sub h) }
 
 @[simp] lemma coe_adj_sub (G' : subgraph G) (u v : G'.verts) (h : G'.coe.adj u v) : G.adj u v :=
@@ -87,7 +87,7 @@ subgraph, then `G'.spanning_coe` yields an isomorphic graph.
 In general, this adds in all vertices from `V` as isolated vertices. -/
 @[simps] def spanning_coe (G' : subgraph G) : simple_graph V :=
 { adj := G'.adj,
-  sym := G'.sym,
+  symm := G'.symm,
   loopless := λ v hv, G.loopless v (G'.adj_sub hv) }
 
 @[simp] lemma spanning_coe_adj_sub (H : subgraph G) (u v : H.verts) (h : H.spanning_coe.adj u v) :
@@ -125,7 +125,7 @@ def coe_neighbor_set_equiv {G' : subgraph G} (v : G'.verts) :
   right_inv := λ w, by simp }
 
 /-- The edge set of `G'` consists of a subset of edges of `G`. -/
-def edge_set (G' : subgraph G) : set (sym2 V) := sym2.from_rel G'.sym
+def edge_set (G' : subgraph G) : set (sym2 V) := sym2.from_rel G'.symm
 
 lemma edge_set_subset (G' : subgraph G) : G'.edge_set ⊆ G.edge_set :=
 λ e, quotient.ind (λ e h, G'.adj_sub h) e
@@ -141,7 +141,7 @@ begin
   simp only [mem_edge_set] at he,
   cases sym2.mem_iff.mp hv with h h; subst h,
   { exact G'.edge_vert he, },
-  { exact G'.edge_vert (G'.sym he), },
+  { exact G'.edge_vert (G'.symm he), },
 end
 
 /-- The `incidence_set` is the set of edges incident to a given vertex. -/
@@ -170,7 +170,7 @@ def copy (G' : subgraph G)
   adj := adj',
   adj_sub := hadj.symm ▸ G'.adj_sub,
   edge_vert := hV.symm ▸ hadj.symm ▸ G'.edge_vert,
-  sym := hadj.symm ▸ G'.sym }
+  symm := hadj.symm ▸ G'.symm }
 
 lemma copy_eq (G' : subgraph G)
   (V'' : set V) (hV : V'' = G'.verts)
@@ -184,7 +184,7 @@ def union (x y : subgraph G) : subgraph G :=
   adj := x.adj ⊔ y.adj,
   adj_sub := λ v w h, or.cases_on h (λ h, x.adj_sub h) (λ h, y.adj_sub h),
   edge_vert := λ v w h, or.cases_on h (λ h, or.inl (x.edge_vert h)) (λ h, or.inr (y.edge_vert h)),
-  sym := λ v w h, by rwa [sup_apply, sup_apply, x.adj_comm, y.adj_comm] }
+  symm := λ v w h, by rwa [sup_apply, sup_apply, x.adj_comm, y.adj_comm] }
 
 /-- The intersection of two subgraphs. -/
 def inter (x y : subgraph G) : subgraph G :=
@@ -192,7 +192,7 @@ def inter (x y : subgraph G) : subgraph G :=
   adj := x.adj ⊓ y.adj,
   adj_sub := λ v w h, x.adj_sub h.1,
   edge_vert := λ v w h, ⟨x.edge_vert h.1, y.edge_vert h.2⟩,
-  sym := λ v w h, by rwa [inf_apply, inf_apply, x.adj_comm, y.adj_comm] }
+  symm := λ v w h, by rwa [inf_apply, inf_apply, x.adj_comm, y.adj_comm] }
 
 /-- The `top` subgraph is `G` as a subgraph of itself. -/
 def top : subgraph G :=
@@ -200,7 +200,7 @@ def top : subgraph G :=
   adj := G.adj,
   adj_sub := λ v w h, h,
   edge_vert := λ v w h, set.mem_univ v,
-  sym := G.sym }
+  symm := G.symm }
 
 /-- The `bot` subgraph is the subgraph with no vertices or edges. -/
 def bot : subgraph G :=
@@ -208,7 +208,7 @@ def bot : subgraph G :=
   adj := λ v w, false,
   adj_sub := λ v w h, false.rec _ h,
   edge_vert := λ v w h, false.rec _ h,
-  sym := λ u v h, h }
+  symm := λ u v h, h }
 
 instance subgraph_inhabited : inhabited (subgraph G) := ⟨bot⟩
 
@@ -248,7 +248,7 @@ instance : bounded_lattice (subgraph G) :=
   adj := H.adj,
   adj_sub := h,
   edge_vert := λ v w h, set.mem_univ v,
-  sym := H.sym }
+  symm := H.symm }
 
 lemma _root_.simple_graph.to_subgraph.is_spanning (H : simple_graph V) (h : H ≤ G) :
   (H.to_subgraph h).is_spanning := set.mem_univ


### PR DESCRIPTION
The naming convention for symmetry of a relation in mathlib seems to be symm, so this commit renames the axiom for the symmetry of the adjacency relation of a simple graph to this.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
