### PR TITLE
[Merged by Bors] - feat(data/fin): eq_zero_or_eq_succ

### DIFF
--- a/src/data/fin.lean
+++ b/src/data/fin.lean
@@ -234,6 +234,13 @@ begin
     refl, },
 end
 
+lemma eq_zero_or_eq_succ {n : ℕ} (i : fin (n+1)) : i = 0 ∨ ∃ j : fin n, i = j.succ :=
+begin
+  rcases i with ⟨_|j, h⟩,
+  { left, refl, },
+  { right, exact ⟨⟨j, nat.lt_of_succ_lt_succ h⟩, rfl⟩, }
+end
+
 /-- The greatest value of `fin (n+1)` -/
 def last (n : ℕ) : fin (n+1) := ⟨_, n.lt_succ_self⟩
 


### PR DESCRIPTION
Particularly useful with `rcases i.eq_zero_or_eq_succ with rfl|⟨j,rfl⟩`.

Perhaps it not worth having as a separate lemma, but it seems to avoid breaking the flow of a proof I was writing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
