### PR TITLE
[Merged by Bors] - feat(algebra/group/to_additive): customize the relevant argument

### DIFF
--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -78,6 +78,30 @@ meta def ignore_args_attr : user_attribute (name_map $ list ℕ) (list ℕ) :=
   parser    := (lean.parser.small_nat)* }
 
 /--
+An attribute that tells `@[to_additive]` which argument(s) are the type where this declaration uses
+the multiplicative structure. If any of these arguments contain a fixed type, this declaration will
+note be additivized. See the Heuristics section of `to_additive.attr`.
+By default, this is `[1]`, but `@[to_additive]` will usually add this attribute automatically, when
+needed.
+Warning: adding `@[to_additive_reorder]` with an equal or smaller number than any number in this
+attribute is currently not supported.
+-/
+@[user_attribute]
+meta def relevant_args_attr : user_attribute (name_map $ list ℕ) (list ℕ) :=
+{ name      := `to_additive_relevant_args,
+  descr     :=
+    "Auxiliary attribute for `to_additive` stating which arguments are the types with a " ++
+    "multiplicative structure.",
+  cache_cfg :=
+    ⟨λ ns, ns.mfoldl
+      (λ dict n, do
+        param ← relevant_args_attr.get_param_untyped n, -- see Note [user attribute parameters]
+        -- we subtract 1 from the values provided by the user.
+        return $ dict.insert n $ (param.to_list expr.to_nat).iget.map nat.pred)
+      mk_name_map, []⟩,
+  parser    := (lean.parser.small_nat)* }
+
+/--
 An attribute that stores all the declarations that needs their arguments reordered when
 applying `@[to_additive]`. Currently, we only support swapping consecutive arguments.
 The list of the natural numbers contains the positions of the first of the two arguments
@@ -103,6 +127,22 @@ meta def reorder_attr : user_attribute (name_map $ list ℕ) (list ℕ) :=
     return l }
 
 end extra_attributes
+
+/--
+Find the first argument of `nm` that has a multiplicative type-class on it.
+E.g. `prod.group` returns 1, and `pi.has_one` returns 2.
+-/
+meta def first_multiplicative_arg (nm : name) : tactic ℕ := do
+  d ← get_decl nm,
+  let (es, _) := d.type.pi_binders,
+  l ← es.mmap_with_index $ λ n bi, do {
+    let tgt := bi.type.pi_codomain,
+    let n_bi := bi.type.pi_binders.fst.length,
+    tt ← has_attribute' `to_additive tgt.get_app_fn.const_name | return none,
+    let n2 := tgt.get_app_args.head.get_app_fn.match_var.map $ λ m, n + n_bi - m,
+    return $ n2 },
+  let l := l.reduce_option,
+  return $ if l = [] then 1 else l.foldr min l.head
 
 /-- A command that can be used to have future uses of `to_additive` change the `src` namespace
 to the `tgt` namespace.
@@ -312,10 +352,14 @@ Examples:
 The reasoning behind the heuristic is that the first argument is the type which is "additivized",
 and this usually doesn't make sense if this is on a fixed type.
 
-There are two exceptions in this heuristic:
+There are some exceptions in this heuristic:
 
 * Identifiers that have the `@[to_additive]` attribute are ignored.
   For example, multiplication in `↥Semigroup` is replaced by addition in `↥AddSemigroup`.
+* If an identifier `d` is has attribute `@[to_additive_relevant_args n1 n2 ...]` then the arguments
+  in positions `n1`, `n2`, ... are checked for a fixed type, instead of checking the first argument.
+  `@[to_additive]` will automatically add the attribute `@[to_additive_relevant_args n]` to a
+  declaration when the first argument has no multiplicative type-class, but argument `n` does.
 * If an identifier has attribute `@[to_additive_ignore_args n1 n2 ...]` then all the arguments in
   positions `n1`, `n2`, ... will not be checked for unapplied identifiers (start counting from 1).
   For example, `times_cont_mdiff_map` has attribute `@[to_additive_ignore_args 21]`, which means
@@ -330,16 +374,22 @@ various things you can try.
 The first thing to do is to figure out what `@[to_additive]` did wrong by looking at the type
 mismatch error.
 
-* Option 1: It additivized a declaration `d` that should remain multiplicative. Solutions:
+* Option 1: It additivized a declaration `d` that should remain multiplicative. Solution:
   * Make sure the first argument of `d` is a type with a multiplicative structure. If not, can you
     reorder the (implicit) arguments of `d` so that the first argument becomes a type with a
     multiplicative structure (and not some indexing type)?
     The reason is that `@[to_additive]` doesn't additivize declarations if their first argument
     contains fixed types like `ℕ` or `ℝ`. See section Heuristics.
-    This is not possible if `d` is something like `pi.has_one` or `prod.group`, where the second
-    argument (also) has a multiplicative structure.
-  * Sometimes only the proof of a lemma/theorem uses these problematic declarations.
-    In some cases you can rewrite the proof a little bit to work around these declarations.
+    If the first argument is not the argument with a multiplicative type-class, `@[to_additive]`
+    should have automatically added the attribute `@[to_additive_relevant_args]` to the declaration.
+    You can test this by running the following (where `d` is the full name of the declaration):
+    ```
+      run_cmd do to_additive.relevant_args_attr.get_param `d >>= trace
+    ```
+    The expected output is `[n]` where the `n`-th argument of `d` is a type (family) with a
+    multiplicative structure on it. If you get a different output (or a failure), you could add
+    the attribute `@[to_additive_relevant_args n]` manually, where `n` is an argument with a
+    multiplicative structure.
 * Option 2: It didn't additivize a declaration that should be additivized.
   This happened because the heuristic applied, and the first argument contains a fixed type,
   like `ℕ` or `ℝ`. Solutions:
@@ -435,14 +485,17 @@ protected meta def attr : user_attribute unit value_type :=
     val ← attr.get_param src,
     dict ← aux_attr.get_cache,
     ignore ← ignore_args_attr.get_cache,
+    relevant ← relevant_args_attr.get_cache,
     reorder ← reorder_attr.get_cache,
     tgt ← target_name src val.tgt dict val.allow_auto_name,
     aux_attr.set src tgt tt,
     let dict := dict.insert src tgt,
+    first_mult_arg ← first_multiplicative_arg src,
+    when (first_mult_arg ≠ 1) $ relevant_args_attr.set src [first_mult_arg] tt,
     if env.contains tgt
     then proceed_fields env src tgt prio
     else do
-      transform_decl_with_prefix_dict dict val.replace_all val.trace ignore reorder src tgt
+      transform_decl_with_prefix_dict dict val.replace_all val.trace ignore relevant reorder src tgt
         [`reducible, `_refl_lemma, `simp, `instance, `refl, `symm, `trans, `elab_as_eliminator,
          `no_rsimp, `measurability],
       mwhen (has_attribute' `simps src)

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -352,7 +352,7 @@ Examples:
 The reasoning behind the heuristic is that the first argument is the type which is "additivized",
 and this usually doesn't make sense if this is on a fixed type.
 
-There are some exceptions in this heuristic:
+There are some exceptions to this heuristic:
 
 * Identifiers that have the `@[to_additive]` attribute are ignored.
   For example, multiplication in `↥Semigroup` is replaced by addition in `↥AddSemigroup`.

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -356,7 +356,7 @@ There are some exceptions to this heuristic:
 
 * Identifiers that have the `@[to_additive]` attribute are ignored.
   For example, multiplication in `↥Semigroup` is replaced by addition in `↥AddSemigroup`.
-* If an identifier `d` is has attribute `@[to_additive_relevant_args n1 n2 ...]` then the arguments
+* If an identifier `d` has attribute `@[to_additive_relevant_args n1 n2 ...]` then the arguments
   in positions `n1`, `n2`, ... are checked for a fixed type, instead of checking the first argument.
   `@[to_additive]` will automatically add the attribute `@[to_additive_relevant_args n]` to a
   declaration when the first argument has no multiplicative type-class, but argument `n` does.

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -384,7 +384,7 @@ mismatch error.
     should have automatically added the attribute `@[to_additive_relevant_args]` to the declaration.
     You can test this by running the following (where `d` is the full name of the declaration):
     ```
-      run_cmd do to_additive.relevant_args_attr.get_param `d >>= trace
+      run_cmd to_additive.relevant_args_attr.get_param `d >>= tactic.trace
     ```
     The expected output is `[n]` where the `n`-th argument of `d` is a type (family) with a
     multiplicative structure on it. If you get a different output (or a failure), you could add

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -368,8 +368,8 @@ There are some exceptions to this heuristic:
 
 * Identifiers that have the `@[to_additive]` attribute are ignored.
   For example, multiplication in `↥Semigroup` is replaced by addition in `↥AddSemigroup`.
-* If an identifier `d` has attribute `@[to_additive_relevant_arg n]` then the arguments
-  in positions `n1`, `n2`, ... are checked for a fixed type, instead of checking the first argument.
+* If an identifier `d` has attribute `@[to_additive_relevant_arg n]` then the argument
+  in position `n` is checked for a fixed type, instead of checking the first argument.
   `@[to_additive]` will automatically add the attribute `@[to_additive_relevant_arg n]` to a
   declaration when the first argument has no multiplicative type-class, but argument `n` does.
 * If an identifier has attribute `@[to_additive_ignore_args n1 n2 ...]` then all the arguments in

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -142,6 +142,7 @@ end extra_attributes
 
 /--
 Find the first argument of `nm` that has a multiplicative type-class on it.
+Returns 1 if there are no types with a multiplicative class as arguments.
 E.g. `prod.group` returns 1, and `pi.has_one` returns 2.
 -/
 meta def first_multiplicative_arg (nm : name) : tactic ℕ := do

--- a/src/measure_theory/measure/haar.lean
+++ b/src/measure_theory/measure/haar.lean
@@ -506,17 +506,6 @@ scaled so that `add_haar_measure K₀ K₀ = 1`."]
 def haar_measure (K₀ : positive_compacts G) : measure G :=
 ((haar_content K₀).outer_measure K₀.1)⁻¹ • (haar_content K₀).measure
 
--- Unfortunately we have to manually give the additive version here
-lemma add_haar_measure_apply {G : Type*} [add_group G] [topological_space G] [t2_space G]
-  [topological_add_group G] [measurable_space G] [borel_space G] {K₀ : positive_compacts G}
-  {s : set G} (hs : measurable_set s) : add_haar_measure K₀ s =
-  (add_haar_content K₀).outer_measure s / (add_haar_content K₀).outer_measure K₀.1 :=
-begin
-  delta add_haar_measure,
-  simp only [hs, div_eq_mul_inv, mul_comm, content.measure_apply, algebra.id.smul_eq_mul,
-    coe_smul, pi.smul_apply],
-end
-
 @[to_additive]
 lemma haar_measure_apply {K₀ : positive_compacts G} {s : set G} (hs : measurable_set s) :
   haar_measure K₀ s = (haar_content K₀).outer_measure s / (haar_content K₀).outer_measure K₀.1 :=

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -871,25 +871,29 @@ protected meta def eta_expand (env : environment) (dict : name_map $ list ℕ) :
 (inductive type, defined function etc) in an expression, unless
 * The identifier occurs in an application with first argument `arg`; and
 * `test arg` is false.
-* Reorder contains the information about what arguments to reorder:
-  e.g. `g x₁ x₂ x₃ ... xₙ` becomes `g x₂ x₁ x₃ ... xₙ` if `reorder.find g = some [1]`.
-  We assume that all functions where we want to reorder arguments are fully applied.
-  This can be done by applying `expr.eta_expand` first.
+Reorder contains the information about what arguments to reorder:
+e.g. `g x₁ x₂ x₃ ... xₙ` becomes `g x₂ x₁ x₃ ... xₙ` if `reorder.find g = some [1]`.
+We assume that all functions where we want to reorder arguments are fully applied.
+This can be done by applying `expr.eta_expand` first.
 -/
 protected meta def apply_replacement_fun (f : name → name) (test : expr → bool)
-  (reorder : name_map $ list ℕ) : expr → expr
+  (relevant reorder : name_map $ list ℕ) : expr → expr
 | e := e.replace $ λ e _,
   match e with
   | const n ls := some $ const (f n) $
       -- if the first two arguments are reordered, we also reorder the first two universe parameters
       if 1 ∈ (reorder.find n).iget then ls.inth 1::ls.head::ls.drop 2 else ls
   | app g x :=
-    let l := (reorder.find g.get_app_fn.const_name).iget in -- this might be inefficient
-    if g.get_app_num_args ∈ l ∧ test g.get_app_args.head then
+    let f := g.get_app_fn,
+        nm := f.const_name,
+        n_args := g.get_app_num_args in -- this might be inefficient
+    if n_args ∈ (reorder.find nm).iget ∧ test g.get_app_args.head then
     -- interchange `x` and the last argument of `g`
     some $ apply_replacement_fun g.app_fn (apply_replacement_fun x) $
       apply_replacement_fun g.app_arg else
-    if g.is_constant ∧ ¬ test x then some $ g (apply_replacement_fun x) else none
+    if n_args ∈ (relevant.find nm).lhoare [0] ∧ ¬ test x then
+      some $ (f.mk_app $ g.get_app_args.map apply_replacement_fun) (apply_replacement_fun x) else
+      none
   | _ := none
   end
 
@@ -1053,11 +1057,12 @@ sets the name of the given `decl : declaration` to `tgt`, and applies both `expr
 `expr.apply_replacement_fun` to the value and type of `decl`.
 -/
 protected meta def update_with_fun (env : environment) (f : name → name) (test : expr → bool)
-  (reorder : name_map $ list ℕ) (tgt : name) (decl : declaration) : declaration :=
+  (relevant reorder : name_map $ list ℕ) (tgt : name) (decl : declaration) : declaration :=
 let decl := decl.update_name $ tgt in
 let decl := decl.update_type $
-  (decl.type.eta_expand env reorder).apply_replacement_fun f test reorder in
-decl.update_value $ (decl.value.eta_expand env reorder).apply_replacement_fun f test reorder
+  (decl.type.eta_expand env reorder).apply_replacement_fun f test relevant reorder in
+decl.update_value $
+  (decl.value.eta_expand env reorder).apply_replacement_fun f test relevant reorder
 
 /-- Checks whether the declaration is declared in the current file.
   This is a simple wrapper around `environment.in_current_file`

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -894,7 +894,7 @@ protected meta def apply_replacement_fun (f : name → name) (test : expr → bo
     -- interchange `x` and the last argument of `g`
     some $ apply_replacement_fun g.app_fn (apply_replacement_fun x) $
       apply_replacement_fun g.app_arg else
-    if n_args ∈ (relevant.find nm).lhoare [0] ∧ ¬ test x then
+    if n_args ∈ (relevant.find nm).lhoare [0] ∧ f.is_constant ∧ ¬ test x then
       some $ (f.mk_app $ g.get_app_args.map apply_replacement_fun) (apply_replacement_fun x) else
       none
   | _ := none

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -871,8 +871,8 @@ protected meta def eta_expand (env : environment) (dict : name_map $ list ℕ) :
 (inductive type, defined function etc) in an expression, unless
 * The identifier occurs in an application with first argument `arg`; and
 * `test arg` is false.
-However, if `f` is in the dictionary `relevant`, then the arguments in `relevant.find f`
-are tested, instead of the first argument.
+However, if `f` is in the dictionary `relevant`, then the argument `relevant.find f`
+is tested, instead of the first argument.
 
 Reorder contains the information about what arguments to reorder:
 e.g. `g x₁ x₂ x₃ ... xₙ` becomes `g x₂ x₁ x₃ ... xₙ` if `reorder.find g = some [1]`.
@@ -880,7 +880,7 @@ We assume that all functions where we want to reorder arguments are fully applie
 This can be done by applying `expr.eta_expand` first.
 -/
 protected meta def apply_replacement_fun (f : name → name) (test : expr → bool)
-  (relevant reorder : name_map $ list ℕ) : expr → expr
+  (relevant : name_map ℕ) (reorder : name_map $ list ℕ) : expr → expr
 | e := e.replace $ λ e _,
   match e with
   | const n ls := some $ const (f n) $
@@ -894,7 +894,7 @@ protected meta def apply_replacement_fun (f : name → name) (test : expr → bo
     -- interchange `x` and the last argument of `g`
     some $ apply_replacement_fun g.app_fn (apply_replacement_fun x) $
       apply_replacement_fun g.app_arg else
-    if n_args ∈ (relevant.find nm).lhoare [0] ∧ f.is_constant ∧ ¬ test x then
+    if n_args = (relevant.find nm).lhoare 0 ∧ f.is_constant ∧ ¬ test x then
       some $ (f.mk_app $ g.get_app_args.map apply_replacement_fun) (apply_replacement_fun x) else
       none
   | _ := none
@@ -1060,7 +1060,8 @@ sets the name of the given `decl : declaration` to `tgt`, and applies both `expr
 `expr.apply_replacement_fun` to the value and type of `decl`.
 -/
 protected meta def update_with_fun (env : environment) (f : name → name) (test : expr → bool)
-  (relevant reorder : name_map $ list ℕ) (tgt : name) (decl : declaration) : declaration :=
+  (relevant : name_map ℕ) (reorder : name_map $ list ℕ) (tgt : name) (decl : declaration) :
+  declaration :=
 let decl := decl.update_name $ tgt in
 let decl := decl.update_type $
   (decl.type.eta_expand env reorder).apply_replacement_fun f test relevant reorder in

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -871,6 +871,9 @@ protected meta def eta_expand (env : environment) (dict : name_map $ list ℕ) :
 (inductive type, defined function etc) in an expression, unless
 * The identifier occurs in an application with first argument `arg`; and
 * `test arg` is false.
+However, if `f` is in the dictionary `relevant`, then the arguments in `relevant.find f`
+are tested, instead of the first argument.
+
 Reorder contains the information about what arguments to reorder:
 e.g. `g x₁ x₂ x₃ ... xₙ` becomes `g x₂ x₁ x₃ ... xₙ` if `reorder.find g = some [1]`.
 We assume that all functions where we want to reorder arguments are fully applied.

--- a/src/tactic/transform_decl.lean
+++ b/src/tactic/transform_decl.lean
@@ -50,8 +50,8 @@ using the dictionary `f`.
 `pre` is the declaration that got the `@[to_additive]` attribute and `tgt_pre` is the target of this
 declaration. -/
 meta def transform_decl_with_prefix_fun_aux (f : name → option name)
-  (replace_all trace : bool) (ignore relevant reorder : name_map $ list ℕ) (pre tgt_pre : name)
-  (attrs : list name) : name → command :=
+  (replace_all trace : bool) (relevant : name_map ℕ) (ignore reorder : name_map $ list ℕ)
+  (pre tgt_pre : name) (attrs : list name) : name → command :=
 λ src,
 do
   -- if this declaration is not `pre` or an internal declaration, we do nothing.
@@ -93,11 +93,12 @@ replacing fragments of the names of identifiers in the type and the body using t
 This is used to implement `@[to_additive]`.
 -/
 meta def transform_decl_with_prefix_fun (f : name → option name) (replace_all trace : bool)
-  (ignore relevant reorder : name_map $ list ℕ) (src tgt : name) (attrs : list name) : command :=
-do transform_decl_with_prefix_fun_aux f replace_all trace ignore relevant reorder src tgt attrs src,
+  (relevant : name_map ℕ) (ignore reorder : name_map $ list ℕ) (src tgt : name) (attrs : list name)
+  : command :=
+do transform_decl_with_prefix_fun_aux f replace_all trace relevant ignore reorder src tgt attrs src,
    ls ← get_eqn_lemmas_for tt src,
    ls.mmap' $
-    transform_decl_with_prefix_fun_aux f replace_all trace ignore relevant reorder src tgt attrs
+    transform_decl_with_prefix_fun_aux f replace_all trace relevant ignore reorder src tgt attrs
 
 /--
 Make a new copy of a declaration, replacing fragments of the names of identifiers in the type and
@@ -105,7 +106,8 @@ the body using the dictionary `dict`.
 This is used to implement `@[to_additive]`.
 -/
 meta def transform_decl_with_prefix_dict (dict : name_map name) (replace_all trace : bool)
-  (ignore relevant reorder : name_map $ list ℕ) (src tgt : name) (attrs : list name) : command :=
-transform_decl_with_prefix_fun dict.find replace_all trace ignore relevant reorder src tgt attrs
+  (relevant : name_map ℕ) (ignore reorder : name_map $ list ℕ) (src tgt : name) (attrs : list name)
+  : command :=
+transform_decl_with_prefix_fun dict.find replace_all trace relevant ignore reorder src tgt attrs
 
 end tactic

--- a/src/tactic/transform_decl.lean
+++ b/src/tactic/transform_decl.lean
@@ -50,7 +50,7 @@ using the dictionary `f`.
 `pre` is the declaration that got the `@[to_additive]` attribute and `tgt_pre` is the target of this
 declaration. -/
 meta def transform_decl_with_prefix_fun_aux (f : name → option name)
-  (replace_all trace : bool) (ignore reorder : name_map $ list ℕ) (pre tgt_pre : name)
+  (replace_all trace : bool) (ignore relevant reorder : name_map $ list ℕ) (pre tgt_pre : name)
   (attrs : list name) : name → command :=
 λ src,
 do
@@ -71,7 +71,8 @@ The declaration {pre} depends on the declaration {src} which is in the namespace
   (decl.value.list_names_with_prefix pre).mfold () (λ n _, transform_decl_with_prefix_fun_aux n),
   -- we transform `decl` using `f` and the configuration options.
   let decl :=
-    decl.update_with_fun env (name.map_prefix f) (additive_test f replace_all ignore) reorder tgt,
+    decl.update_with_fun env (name.map_prefix f) (additive_test f replace_all ignore)
+      relevant reorder tgt,
   pp_decl ← pp decl,
   when trace $ trace!"[to_additive] > generating\n{pp_decl}",
   decorate_error (format!"@[to_additive] failed. Type mismatch in additive declaration.
@@ -88,10 +89,11 @@ replacing fragments of the names of identifiers in the type and the body using t
 This is used to implement `@[to_additive]`.
 -/
 meta def transform_decl_with_prefix_fun (f : name → option name) (replace_all trace : bool)
-  (ignore reorder : name_map $ list ℕ) (src tgt : name) (attrs : list name) : command :=
-do transform_decl_with_prefix_fun_aux f replace_all trace ignore reorder src tgt attrs src,
+  (ignore relevant reorder : name_map $ list ℕ) (src tgt : name) (attrs : list name) : command :=
+do transform_decl_with_prefix_fun_aux f replace_all trace ignore relevant reorder src tgt attrs src,
    ls ← get_eqn_lemmas_for tt src,
-   ls.mmap' $ transform_decl_with_prefix_fun_aux f replace_all trace ignore reorder src tgt attrs
+   ls.mmap' $
+    transform_decl_with_prefix_fun_aux f replace_all trace ignore relevant reorder src tgt attrs
 
 /--
 Make a new copy of a declaration, replacing fragments of the names of identifiers in the type and
@@ -99,7 +101,7 @@ the body using the dictionary `dict`.
 This is used to implement `@[to_additive]`.
 -/
 meta def transform_decl_with_prefix_dict (dict : name_map name) (replace_all trace : bool)
-  (ignore reorder : name_map $ list ℕ) (src tgt : name) (attrs : list name) : command :=
-transform_decl_with_prefix_fun dict.find replace_all trace ignore reorder src tgt attrs
+  (ignore relevant reorder : name_map $ list ℕ) (src tgt : name) (attrs : list name) : command :=
+transform_decl_with_prefix_fun dict.find replace_all trace ignore relevant reorder src tgt attrs
 
 end tactic

--- a/src/tactic/transform_decl.lean
+++ b/src/tactic/transform_decl.lean
@@ -73,14 +73,18 @@ The declaration {pre} depends on the declaration {src} which is in the namespace
   let decl :=
     decl.update_with_fun env (name.map_prefix f) (additive_test f replace_all ignore)
       relevant reorder tgt,
+  -- o ← get_options, set_options $ o.set_bool `pp.all tt, -- print with pp.all (for debugging)
   pp_decl ← pp decl,
   when trace $ trace!"[to_additive] > generating\n{pp_decl}",
   decorate_error (format!"@[to_additive] failed. Type mismatch in additive declaration.
 For help, see the docstring of `to_additive.attr`, section `Troubleshooting`.
 Failed to add declaration\n{pp_decl}
 
-Nested error message:\n").to_string $ -- the empty line is intentional
+Nested error message:\n").to_string $ do {
     if env.is_protected src then add_protected_decl decl else add_decl decl,
+    -- we test that the declaration value type-checks, so that we get the decorated error message
+    -- without this line, the type-checking might fail outside the `decorate_error`.
+    decorate_error "proof doesn't type-check. " $ type_check decl.value },
   attrs.mmap' $ λ n, copy_attribute n src tgt
 
 /--

--- a/test/to_additive.lean
+++ b/test/to_additive.lean
@@ -70,10 +70,34 @@ if some_def.in_namespace then x * x else x
 run_cmd do
   dict ← to_additive.aux_attr.get_cache,
   success_if_fail
-    (transform_decl_with_prefix_dict dict ff tt mk_name_map mk_name_map `some_def `add_some_def []),
+    (transform_decl_with_prefix_dict dict ff tt mk_name_map mk_name_map mk_name_map
+      `some_def `add_some_def []),
   skip
 
 attribute [to_additive some_other_name] some_def.in_namespace
 attribute [to_additive add_some_def] some_def
 
 run_cmd success_if_fail (get_decl `add_some_def.in_namespace)
+
+-- test @[to_additive_relevant_args] and to_additive.first_multiplicative_arg
+
+-- first multiplicative argument: f
+def foo_mul {I J K : Type*} (n : ℕ) {f : I → Type*} (L : Type*) [∀ i (n : ℕ), bool → has_one (f i)]
+  [has_add I] [has_mul L] : true :=
+trivial
+
+@[to_additive]
+instance pi.has_one {I : Type*} {f : I → Type*} [∀ i, has_one $ f i] : has_one (Π i : I, f i) :=
+⟨λ _, 1⟩
+
+run_cmd do
+  n ← to_additive.first_multiplicative_arg `pi.has_one,
+  guard $ n = 2,
+  n ← to_additive.first_multiplicative_arg `foo_mul,
+  guard $ n = 5
+
+@[to_additive]
+def nat_pi_has_one {α : Type*} [has_one α] : has_one (Π x : ℕ, α) := by apply_instance
+
+@[to_additive]
+def pi_nat_has_one {I : Type*} : has_one (Π x : I, ℕ) := by apply_instance


### PR DESCRIPTION
`@[to_additive]` now automatically checks for each declaration what the first argument is with a multiplicative structure on it. 
This is now the argument that is tested when executing later occurrences of `@[to_additive]` for a fixed type to decide whether this declaration should be translated or not.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
