### PR TITLE
[Merged by Bors] - fix(ring_theory/ideal/basic): ideal.module_pi speedup

### DIFF
--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -638,12 +638,9 @@ variables (ι : Type v)
 instance module_pi : module (I.quotient) (I.pi ι).quotient :=
 { smul := λ c m, quotient.lift_on₂' c m (λ r m, submodule.quotient.mk $ r • m) begin
     intros c₁ m₁ c₂ m₂ hc hm,
-    change c₁ - c₂ ∈ I at hc,
     apply ideal.quotient.eq.2,
     intro i,
-    change c₁ * (m₁ i) - c₂ * (m₂ i) ∈ I,
-    have hm : m₁ i - m₂ i ∈ I := hm i,
-    exact mul_sub_mul_mem hc hm,
+    exact mul_sub_mul_mem hc (hm i),
   end,
   one_smul := begin
     rintro ⟨a⟩,

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -429,6 +429,13 @@ section comm_ring
 
 namespace ideal
 
+theorem mul_sub_mul_mem {R : Type*} [comm_ring R] {I : ideal R} {a b c d : R}
+  (h1 : a - b ∈ I) (h2 : c - d ∈ I) : a * c - b * d ∈ I :=
+begin
+  rw (show a * c - b * d = (a - b) * c + b * (c - d), by {rw [sub_mul, mul_sub], abel}),
+  exact I.add_mem (I.mul_mem_right _ h1) (I.mul_mem_left _ h2),
+end
+
 variables [comm_ring α] (I : ideal α) {a b : α}
 
 /-- The quotient `R/I` of a ring `R` by an ideal `I`.
@@ -629,27 +636,46 @@ variables (ι : Type v)
 
 /-- `R^n/I^n` is a `R/I`-module. -/
 instance module_pi : module (I.quotient) (I.pi ι).quotient :=
-begin
-  refine { smul := λ c m, quotient.lift_on₂' c m (λ r m, submodule.quotient.mk $ r • m) _, .. },
-  { intros c₁ m₁ c₂ m₂ hc hm,
+{ smul := λ c m, quotient.lift_on₂' c m (λ r m, submodule.quotient.mk $ r • m) begin
+    intros c₁ m₁ c₂ m₂ hc hm,
     change c₁ - c₂ ∈ I at hc,
-    change m₁ - m₂ ∈ (I.pi ι) at hm,
     apply ideal.quotient.eq.2,
-    have : c₁ • (m₂ - m₁) ∈ I.pi ι,
-    { rw ideal.mem_pi,
-      intro i,
-      simp only [smul_eq_mul, pi.smul_apply, pi.sub_apply],
-      apply ideal.mul_mem_left,
-      rw ←ideal.neg_mem_iff,
-      simpa only [neg_sub] using hm i },
-    rw [←ideal.add_mem_iff_left (I.pi ι) this, sub_eq_add_neg, add_comm, ←add_assoc, ←smul_add,
-      sub_add_cancel, ←sub_eq_add_neg, ←sub_smul, ideal.mem_pi],
-    exact λ i, I.mul_mem_right _ hc },
-  all_goals { rintro ⟨a⟩ ⟨b⟩ ⟨c⟩ <|> rintro ⟨a⟩,
-    simp only [(•), submodule.quotient.quot_mk_eq_mk, ideal.quotient.mk_eq_mk],
+    intro i,
+    change c₁ * (m₁ i) - c₂ * (m₂ i) ∈ I,
+    have hm : m₁ i - m₂ i ∈ I := hm i,
+    exact mul_sub_mul_mem hc hm,
+  end,
+  one_smul := begin
+    rintro ⟨a⟩,
     change ideal.quotient.mk _ _ = ideal.quotient.mk _ _,
-    congr' with i, simp [mul_assoc, mul_add, add_mul] }
-end
+    congr' with i, exact one_mul (a i),
+  end,
+  mul_smul := begin
+    rintro ⟨a⟩ ⟨b⟩ ⟨c⟩,
+    change ideal.quotient.mk _ _ = ideal.quotient.mk _ _,
+    simp only [(•)],
+    congr' with i, exact mul_assoc a b (c i),
+  end,
+  smul_add := begin
+    rintro ⟨a⟩ ⟨b⟩ ⟨c⟩,
+    change ideal.quotient.mk _ _ = ideal.quotient.mk _ _,
+    congr' with i, exact mul_add a (b i) (c i),
+  end,
+  smul_zero := begin
+    rintro ⟨a⟩,
+    change ideal.quotient.mk _ _ = ideal.quotient.mk _ _,
+    congr' with i, exact mul_zero a,
+  end,
+  add_smul := begin
+    rintro ⟨a⟩ ⟨b⟩ ⟨c⟩,
+    change ideal.quotient.mk _ _ = ideal.quotient.mk _ _,
+    congr' with i, exact add_mul a b (c i),
+  end,
+  zero_smul := begin
+    rintro ⟨a⟩,
+    change ideal.quotient.mk _ _ = ideal.quotient.mk _ _,
+    congr' with i, exact zero_mul (a i),
+  end, }
 
 /-- `R^n/I^n` is isomorphic to `(R/I)^n` as an `R/I`-module. -/
 noncomputable def pi_quot_equiv : (I.pi ι).quotient ≃ₗ[I.quotient] (ι → I.quotient) :=

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -429,7 +429,7 @@ section comm_ring
 
 namespace ideal
 
-theorem mul_sub_mul_mem {R : Type*} [comm_ring R] {I : ideal R} {a b c d : R}
+theorem mul_sub_mul_mem {R : Type*} [comm_ring R] (I : ideal R) {a b c d : R}
   (h1 : a - b ∈ I) (h2 : c - d ∈ I) : a * c - b * d ∈ I :=
 begin
   rw (show a * c - b * d = (a - b) * c + b * (c - d), by {rw [sub_mul, mul_sub], abel}),
@@ -640,7 +640,7 @@ instance module_pi : module (I.quotient) (I.pi ι).quotient :=
     intros c₁ m₁ c₂ m₂ hc hm,
     apply ideal.quotient.eq.2,
     intro i,
-    exact mul_sub_mul_mem hc (hm i),
+    exact I.mul_sub_mul_mem hc (hm i),
   end,
   one_smul := begin
     rintro ⟨a⟩,


### PR DESCRIPTION
Eric and Yael were both complaining that `ideal.module_pi` would occasionally cause random timeouts on unrelated PRs. This PR (a) makes the `smul` proof obligation much tidier (factoring out a sublemma) and (b) replaces the `all_goals` trick by 6 slightly more refined proofs (making the new proof longer, but quicker). On my machine the profiler stats are:

```
ORIG

parsing took 74.1ms
elaboration of module_pi took 3.83s
type checking of module_pi took 424ms
decl post-processing of module_pi took 402ms

NEW

parsing took 136ms
elaboration of module_pi took 1.19s
type checking of module_pi took 82.8ms
decl post-processing of module_pi took 82.5ms
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Eric/Yael conversation is here: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/distrib_mul_action_with_zero/near/252816196

I'm sorry the proof is now longer, but if this is one of these proofs which occasionally tips CI over the edge then it's probably best to have it much quicker and a bit longer. To orientate you around the diff: the smul proof is now a third the size and much less gnarly; it now finishes on line 644 not 647 even though we have some new lemma `mul_sub_mul_mem` before that, so this is a win. Github diff gets a bit confused about what happens next -- the main point is that I removed `all_goals {generic proof}` on line 648 and replaced it with six similar bespoke proofs for the remaining obligations. Just refactoring the smul proof and leaving the `all_goals` technique in there makes elaboration on my machine go back up to 1.6 seconds; this would be an alternative approach, and if we did this instead then the proof would be both shorter and quicker, but not as quick as this version.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
