### PR TITLE
[Merged by Bors] - fix(category/preadditive/single_obj): remove superfluous instance

### DIFF
--- a/src/category_theory/preadditive/single_obj.lean
+++ b/src/category_theory/preadditive/single_obj.lean
@@ -15,9 +15,6 @@ namespace category_theory
 
 variables {α : Type*} [ring α]
 
-instance (X Y : single_obj α) : add_comm_group (X ⟶ Y) :=
-by { change add_comm_group α, apply_instance, }
-
 instance : preadditive (single_obj α) :=
 { add_comp' := λ _ _ _ f f' g, mul_add g f f',
   comp_add' := λ _ _ _ f g g', add_mul g g' f, }


### PR DESCRIPTION
Per @fpvandoorn's [new linter](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/type-class.20loops.20in.20category.20theory).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
