### PR TITLE
[Merged by Bors] - refactor(data/real/nnreal): use `has_ordered_sub`

### DIFF
--- a/src/algebra/ordered_ring.lean
+++ b/src/algebra/ordered_ring.lean
@@ -5,6 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
 -/
 import algebra.invertible
 import algebra.ordered_group
+import algebra.ordered_sub
 import data.set.intervals.basic
 
 /-!
@@ -1435,6 +1436,19 @@ lemma zero_lt_one [nontrivial α] : (0:α) < 1 := (zero_le 1).lt_of_ne zero_ne_o
 
 lemma mul_pos : 0 < a * b ↔ (0 < a) ∧ (0 < b) :=
 by simp only [pos_iff_ne_zero, ne.def, mul_eq_zero, not_or_distrib]
+
+variables [has_sub α] [has_ordered_sub α] [contravariant_class α α (+) (≤)] [is_total α (≤)]
+
+lemma _root_.mul_sub' (a b c : α) : a * (b - c) = a * b - a * c :=
+begin
+  cases total_of (≤) b c with hbc hcb,
+  { rw [sub_eq_zero_iff_le.2 hbc, mul_zero, sub_eq_zero_iff_le.2 (mul_le_mul_left' hbc a)] },
+  { apply eq_sub_of_add_eq'',
+    rw [← mul_add, sub_add_cancel_of_le hcb] }
+end
+
+lemma _root_.sub_mul' (a b c : α) : (a - b) * c = a * c - b * c :=
+by simp only [← mul_comm c, mul_sub']
 
 end canonically_ordered_comm_semiring
 

--- a/src/algebra/ordered_sub.lean
+++ b/src/algebra/ordered_sub.lean
@@ -133,7 +133,7 @@ end
 
 end cov
 
-/-! Lemmas that assume that an element is `add_le_cancellable`. -/
+/-! ### Lemmas that assume that an element is `add_le_cancellable`. -/
 namespace add_le_cancellable
 
 protected lemma le_add_sub_swap (hb : add_le_cancellable b) : a ≤ b + a - b :=
@@ -181,7 +181,7 @@ end
 
 end add_le_cancellable
 
-/-! Lemmas where addition is order-reflecting. -/
+/-! ### Lemmas where addition is order-reflecting. -/
 
 section contra
 variable [contravariant_class α α (+) (≤)]
@@ -240,7 +240,7 @@ end both
 
 end ordered_add_comm_monoid
 
-/-! Lemmas in a linearly ordered monoid. -/
+/-! ### Lemmas in a linearly ordered monoid. -/
 section linear_order
 variables {a b c d : α} [linear_order α] [add_comm_monoid α] [has_sub α] [has_ordered_sub α]
 
@@ -259,7 +259,7 @@ end cov
 
 end linear_order
 
-/-! Lemmas in a canonically ordered monoid. -/
+/-! ### Lemmas in a canonically ordered monoid. -/
 
 section canonically_ordered_add_monoid
 variables [canonically_ordered_add_monoid α] [has_sub α] [has_ordered_sub α] {a b c d : α}
@@ -332,7 +332,7 @@ end
 lemma sub_sub_sub_cancel_right' (h : c ≤ b) : (a - c) - (b - c) = a - b :=
 by rw [sub_sub', add_sub_cancel_of_le h]
 
-/-! Lemmas that assume that an element is `add_le_cancellable`. -/
+/-! ### Lemmas that assume that an element is `add_le_cancellable`. -/
 
 namespace add_le_cancellable
 protected lemma eq_sub_iff_add_eq_of_le (hc : add_le_cancellable c) (h : c ≤ b) :
@@ -462,7 +462,7 @@ by rw [hba.sub_eq_iff_eq_add_of_le sub_le_self', add_sub_cancel_of_le h]
 end add_le_cancellable
 
 section contra
-/-! Lemmas where addition is order-reflecting. -/
+/-! ### Lemmas where addition is order-reflecting. -/
 variable [contravariant_class α α (+) (≤)]
 
 lemma eq_sub_iff_add_eq_of_le (h : c ≤ b) : a = b - c ↔ a + c = b :=
@@ -551,7 +551,7 @@ end contra
 
 end canonically_ordered_add_monoid
 
-/-! Lemmas in a linearly canonically ordered monoid. -/
+/-! ### Lemmas in a linearly canonically ordered monoid. -/
 
 section canonically_linear_ordered_add_monoid
 variables [canonically_linear_ordered_add_monoid α] [has_sub α] [has_ordered_sub α] {a b c d : α}
@@ -643,7 +643,7 @@ contravariant.add_le_cancellable.sub_lt_sub_iff_left_of_le contravariant.add_le_
 
 end contra
 
-/-! Lemmas about `max` and `min`. -/
+/-! ### Lemmas about `max` and `min`. -/
 
 lemma sub_add_eq_max : a - b + b = max a b :=
 begin

--- a/src/algebra/ordered_sub.lean
+++ b/src/algebra/ordered_sub.lean
@@ -35,7 +35,7 @@ lemmas about subtraction/division in `ordered_[add_]comm_group` with these.
 
 -/
 
-variables {α : Type*}
+variables {α β : Type*}
 
 /-- `has_ordered_sub α` means that `α` has a subtraction characterized by `a - b ≤ c ↔ a ≤ c + b`.
 In other words, `a - b` is the least `c` such that `a ≤ b + c`.
@@ -46,11 +46,55 @@ in canonically ordered monoids on many specific types.
 class has_ordered_sub (α : Type*) [preorder α] [has_add α] [has_sub α] :=
 (sub_le_iff_right : ∀ a b c : α, a - b ≤ c ↔ a ≤ c + b)
 
-section ordered_add_comm_monoid
-variables {a b c d : α} [partial_order α] [add_comm_monoid α] [has_sub α] [has_ordered_sub α]
+section has_add
+
+variables [preorder α] [has_add α] [has_sub α] [has_ordered_sub α] {a b c d : α}
 
 @[simp] lemma sub_le_iff_right : a - b ≤ c ↔ a ≤ c + b :=
 has_ordered_sub.sub_le_iff_right a b c
+
+/-- See `add_sub_cancel_right` for the equality if `contravariant_class α α (+) (≤)`. -/
+lemma add_sub_le_right : a + b - b ≤ a :=
+sub_le_iff_right.mpr le_rfl
+
+lemma le_sub_add : b ≤ (b - a) + a :=
+sub_le_iff_right.mp le_rfl
+
+lemma add_hom.le_map_sub [preorder β] [has_add β] [has_sub β] [has_ordered_sub β]
+  (f : add_hom α β) (hf : monotone f) (a b : α) :
+  f a - f b ≤ f (a - b) :=
+by { rw [sub_le_iff_right, ← f.map_add], exact hf le_sub_add }
+
+lemma le_mul_sub {R : Type*} [distrib R] [preorder R] [has_sub R] [has_ordered_sub R]
+  [covariant_class R R (*) (≤)] (a b c : R) :
+  a * b - a * c ≤ a * (b - c) :=
+(add_hom.mul_left a).le_map_sub (monotone_id.const_mul' a) _ _
+
+lemma le_sub_mul {R : Type*} [comm_semiring R] [preorder R] [has_sub R] [has_ordered_sub R]
+  [covariant_class R R (*) (≤)] (a b c : R) :
+  a * c - b * c ≤ (a - b) * c :=
+by simpa only [mul_comm c] using le_mul_sub c a b
+
+end has_add
+
+/-- An order isomorphism between types with ordered subtraction preserves subtraction provided that
+it preserves addition. -/
+lemma order_iso.map_sub {M N : Type*} [preorder M] [has_add M] [has_sub M] [has_ordered_sub M]
+  [partial_order N] [has_add N] [has_sub N] [has_ordered_sub N] (e : M ≃o N)
+  (h_add : ∀ a b, e (a + b) = e a + e b) (a b : M) :
+  e (a - b) = e a - e b :=
+begin
+  set e_add : M ≃+ N := { map_add' := h_add, .. e },
+  refine le_antisymm _ (e_add.to_add_hom.le_map_sub e.monotone a b),
+  suffices : e (e.symm (e a) - e.symm (e b)) ≤ e (e.symm (e a - e b)), by simpa,
+  exact e.monotone (e_add.symm.to_add_hom.le_map_sub e.symm.monotone _ _)
+end
+
+section ordered_add_comm_monoid
+
+section preorder
+
+variables [preorder α] [add_comm_monoid α] [has_sub α] [has_ordered_sub α] {a b c d : α}
 
 lemma sub_le_iff_left : a - b ≤ c ↔ a ≤ b + c :=
 by rw [sub_le_iff_right, add_comm]
@@ -62,18 +106,24 @@ sub_le_iff_left.mp le_rfl
 lemma add_sub_le_left : a + b - a ≤ b :=
 sub_le_iff_left.mpr le_rfl
 
-/-- See `add_sub_cancel_right` for the equality if `contravariant_class α α (+) (≤)`. -/
-lemma add_sub_le_right : a + b - b ≤ a :=
-sub_le_iff_right.mpr le_rfl
-
-lemma le_sub_add : b ≤ (b - a) + a :=
-sub_le_iff_right.mp le_rfl
-
 lemma sub_le_sub_right' (h : a ≤ b) (c : α) : a - c ≤ b - c :=
 sub_le_iff_left.mpr $ h.trans le_add_sub
 
 lemma sub_le_iff_sub_le : a - b ≤ c ↔ a - c ≤ b :=
 by rw [sub_le_iff_left, sub_le_iff_right]
+
+/-- See `sub_sub_cancel_of_le` for the equality. -/
+lemma sub_sub_le : b - (b - a) ≤ a :=
+sub_le_iff_right.mpr le_add_sub
+
+lemma add_monoid_hom.le_map_sub [preorder β] [add_comm_monoid β] [has_sub β]
+  [has_ordered_sub β] (f : α →+ β) (hf : monotone f) (a b : α) :
+  f a - f b ≤ f (a - b) :=
+f.to_add_hom.le_map_sub hf a b
+
+end preorder
+
+variables [partial_order α] [add_comm_monoid α] [has_sub α] [has_ordered_sub α] {a b c d : α}
 
 lemma sub_sub' (b a c : α) : b - a - c = b - (a + c) :=
 begin
@@ -81,10 +131,6 @@ begin
   { rw [sub_le_iff_left, sub_le_iff_left, ← add_assoc, ← sub_le_iff_left] },
   { rw [sub_le_iff_left, add_assoc, ← sub_le_iff_left, ← sub_le_iff_left] }
 end
-
-/-- See `sub_sub_cancel_of_le` for the equality. -/
-lemma sub_sub_le : b - (b - a) ≤ a :=
-sub_le_iff_right.mpr le_add_sub
 
 section cov
 variable [covariant_class α α (+) (≤)]

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -285,6 +285,18 @@ dvd.elim h₁ (λ d hd, dvd.elim h₂ (λ e he, dvd.intro (d + e) (by simp [left
 
 end semiring
 
+namespace add_hom
+
+/-- Left multiplication by an element of a type with distributive multiplication is an `add_hom`. -/
+@[simps { fully_applied := ff}] def mul_left {R : Type*} [distrib R] (r : R) : add_hom R R :=
+⟨(*) r, mul_add r⟩
+
+/-- Left multiplication by an element of a type with distributive multiplication is an `add_hom`. -/
+@[simps { fully_applied := ff}] def mul_right {R : Type*} [distrib R] (r : R) : add_hom R R :=
+⟨λ a, a * r, λ _ _, add_mul _ _ r⟩
+
+end add_hom
+
 namespace add_monoid_hom
 
 /-- Left multiplication by an element of a (semi)ring is an `add_monoid_hom` -/

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -594,7 +594,7 @@ lemma antilipschitz_with.add_lipschitz_with {α : Type*} [pseudo_metric_space α
 begin
   refine antilipschitz_with.of_le_mul_dist (λ x y, _),
   rw [nnreal.coe_inv, ← div_eq_inv_mul],
-  rw le_div_iff (nnreal.coe_pos.2 $ nnreal.sub_pos.2 hK),
+  rw le_div_iff (nnreal.coe_pos.2 $ sub_pos_iff_lt.2 hK),
   rw [mul_comm, nnreal.coe_sub (le_of_lt hK), sub_mul],
   calc ↑Kf⁻¹ * dist x y - Kg * dist x y ≤ dist (f x) (f y) - dist (g x) (g y) :
     sub_le_sub (hf.mul_le_dist x y) (hg.dist_le_mul x y)

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -595,7 +595,7 @@ begin
   refine antilipschitz_with.of_le_mul_dist (λ x y, _),
   rw [nnreal.coe_inv, ← div_eq_inv_mul],
   rw le_div_iff (nnreal.coe_pos.2 $ sub_pos_iff_lt.2 hK),
-  rw [mul_comm, nnreal.coe_sub (le_of_lt hK), sub_mul],
+  rw [mul_comm, nnreal.coe_sub hK.le, sub_mul],
   calc ↑Kf⁻¹ * dist x y - Kg * dist x y ≤ dist (f x) (f y) - dist (g x) (g y) :
     sub_le_sub (hf.mul_le_dist x y) (hg.dist_le_mul x y)
   ... ≤ _ : le_trans (le_abs_self _) (abs_dist_sub_le_dist_add_add _ _ _ _)

--- a/src/analysis/specific_limits.lean
+++ b/src/analysis/specific_limits.lean
@@ -400,7 +400,7 @@ begin
   { rcases ennreal.lt_iff_exists_coe.1 hr with ⟨r, rfl, hr'⟩,
     norm_cast at *,
     convert ennreal.tsum_coe_eq (nnreal.has_sum_geometric hr),
-    rw [ennreal.coe_inv $ ne_of_gt $ nnreal.sub_pos.2 hr] },
+    rw [ennreal.coe_inv $ ne_of_gt $ sub_pos_iff_lt.2 hr] },
   { rw [ennreal.sub_eq_zero_of_le hr, ennreal.inv_zero, ennreal.tsum_eq_supr_nat, supr_eq_top],
     refine λ a ha, (ennreal.exists_nat_gt (lt_top_iff_ne_top.1 ha)).imp
       (λ n hn, lt_of_lt_of_le hn _),

--- a/src/data/bool.lean
+++ b/src/data/bool.lean
@@ -95,6 +95,9 @@ decidable_of_decidable_of_iff or.decidable exists_bool.symm
   cond (to_bool p) t e = if p then t else e :=
 by by_cases p; simp *
 
+@[simp] theorem cond_bnot {α} (b : bool) (t e : α) : cond (!b) t e = cond b e t :=
+by cases b; refl
+
 theorem coe_bool_iff : ∀ {a b : bool}, (a ↔ b) ↔ a = b := dec_trivial
 
 theorem eq_tt_of_ne_ff : ∀ {a : bool}, a ≠ ff → a = tt := dec_trivial

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -523,13 +523,13 @@ begin
   have ad : a < d,
   { rw of_real_eq_coe_nnreal c_nonneg at ac,
     exact coe_lt_coe.1 ac },
-  refine ⟨d-a, nnreal.sub_pos.2 ad, _⟩,
+  refine ⟨d-a, sub_pos_iff_lt.2 ad, _⟩,
   rw [some_eq_coe, ← coe_add],
   convert cb,
   have : real.to_nnreal c = d,
     by { rw [← nnreal.coe_eq, real.coe_to_nnreal _ c_nonneg], refl },
   rw [add_comm, this],
-  exact nnreal.sub_add_cancel_of_le (le_of_lt ad)
+  exact sub_add_cancel_of_le ad.le
 end
 
 lemma coe_nat_lt_coe {n : ℕ} : (n : ℝ≥0∞) < r ↔ ↑n < r := ennreal.coe_nat n ▸ coe_lt_coe
@@ -657,9 +657,9 @@ instance : has_sub ℝ≥0∞ := ⟨λa b, Inf {d | a ≤ d + b}⟩
 @[norm_cast] lemma coe_sub : ↑(p - r) = (↑p:ℝ≥0∞) - r :=
 le_antisymm
   (le_Inf $ assume b (hb : ↑p ≤ b + r), coe_le_iff.2 $
-    by rintros d rfl; rwa [← coe_add, coe_le_coe, ← nnreal.sub_le_iff_le_add] at hb)
+    by rintros d rfl; rwa [← coe_add, coe_le_coe, ← sub_le_iff_right] at hb)
   (Inf_le $ show (↑p : ℝ≥0∞) ≤ ↑(p - r) + ↑r,
-    by rw [← coe_add, coe_le_coe, ← nnreal.sub_le_iff_le_add])
+    by rw [← coe_add, coe_le_coe, ← sub_le_iff_right])
 
 @[simp] lemma top_sub_coe : ∞ - ↑r = ∞ :=
 top_unique $ le_Inf $ by simp [add_eq_top]
@@ -685,7 +685,7 @@ Inf_le_Inf $ assume e (h : b ≤ e + d),
 | a        none     := by simp [none_eq_top]
 | none     (some b) := by simp [none_eq_top, some_eq_coe]
 | (some a) (some b) :=
-  by simp [some_eq_coe]; rw [← coe_add, ← coe_sub, coe_eq_coe, nnreal.add_sub_cancel]
+  by simp [some_eq_coe]; rw [← coe_add, ← coe_sub, coe_eq_coe, add_sub_cancel_right]
 
 @[simp] lemma add_sub_self' (h : a < ∞) : (a + b) - a = b :=
 by rw [add_comm, add_sub_self h]
@@ -700,7 +700,7 @@ by rw [add_comm, add_comm c, add_right_inj h]
 begin
   simp [forall_ennreal, le_coe_iff, -add_comm] {contextual := tt},
   rintros r p x rfl h,
-  rw [← coe_sub, ← coe_add, nnreal.sub_add_cancel_of_le h]
+  rw [← coe_sub, ← coe_add, sub_add_cancel_of_le h]
 end
 
 @[simp] lemma add_sub_cancel_of_le (h : b ≤ a) : b + (a - b) = a :=
@@ -738,7 +738,7 @@ match a, b with
 | (some a), (some b) :=
   begin
     simp only [some_eq_coe, coe_sub.symm, coe_pos, coe_eq_zero, coe_lt_coe, ne.def],
-    assume h₁ h₂, apply nnreal.sub_lt_self, exact pos_iff_ne_zero.2 h₂
+    assume h₁ h₂, apply sub_lt_self', exact pos_iff_ne_zero.2 h₂
   end
 end
 
@@ -755,7 +755,7 @@ begin
   cases c, { simp },
   cases b, { simp only [true_iff, coe_lt_top, some_eq_coe, top_sub_coe, none_eq_top, ← coe_add] },
   simp only [some_eq_coe],
-  rw [← coe_add, ← coe_sub, coe_lt_coe, coe_lt_coe, nnreal.lt_sub_iff_add_lt],
+  rw [← coe_add, ← coe_sub, coe_lt_coe, coe_lt_coe, lt_sub_iff_right],
 end
 
 lemma sub_le_self (a b : ℝ≥0∞) : a - b ≤ a :=

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -534,83 +534,20 @@ end
 end pow
 
 section sub
+/-!
+### Lemmas about subtraction
+
+In this section we provide a few lemmas about definition, the instance `nnreal.has_ordered_sub`, and
+a few lemmas about subtraction, multiplication, and division. For lemmas about subtraction and
+addition see lemmas about `has_ordered_sub` in the file `algebra/ordered_sub`. -/
 
 lemma sub_def {r p : ℝ≥0} : r - p = real.to_nnreal (r - p) := rfl
 
 lemma coe_sub_def {r p : ℝ≥0} : ↑(r - p) = max (r - p : ℝ) 0 := rfl
 
-lemma sub_eq_zero {r p : ℝ≥0} (h : r ≤ p) : r - p = 0 :=
-nnreal.eq $ max_eq_right $ sub_le_iff_le_add.2 $ by simpa [nnreal.coe_le_coe] using h
-
-@[simp] lemma sub_self {r : ℝ≥0} : r - r = 0 := sub_eq_zero $ le_refl r
-
-@[simp] lemma sub_zero {r : ℝ≥0} : r - 0 = r :=
-by rw [sub_def, nnreal.coe_zero, sub_zero, real.to_nnreal_coe]
-
-lemma sub_pos {r p : ℝ≥0} : 0 < r - p ↔ p < r :=
-to_nnreal_pos.trans $ sub_pos.trans $ nnreal.coe_lt_coe
-
-protected lemma sub_lt_self {r p : ℝ≥0} : 0 < r → 0 < p → r - p < r :=
-assume hr hp,
-begin
-  cases le_total r p,
-  { rwa [sub_eq_zero h] },
-  { rw [← nnreal.coe_lt_coe, nnreal.coe_sub h], exact sub_lt_self _ hp }
-end
-
-@[simp] lemma sub_le_iff_le_add {r p q : ℝ≥0} : r - p ≤ q ↔ r ≤ q + p :=
-match le_total p r with
-| or.inl h := by rw [← nnreal.coe_le_coe, ← nnreal.coe_le_coe, nnreal.coe_sub h, nnreal.coe_add,
-    sub_le_iff_le_add]
-| or.inr h :=
-  have r ≤ p + q, from le_add_right h,
-  by simpa [nnreal.coe_le_coe, nnreal.coe_le_coe, sub_eq_zero h, add_comm]
-end
-
-@[simp] lemma sub_le_self {r p : ℝ≥0} : r - p ≤ r :=
-sub_le_iff_le_add.2 $ le_add_right $ le_refl r
-
-lemma add_sub_cancel {r p : ℝ≥0} : (p + r) - r = p :=
-nnreal.eq $ by rw [nnreal.coe_sub, nnreal.coe_add, add_sub_cancel]; exact le_add_self
-
-lemma add_sub_cancel' {r p : ℝ≥0} : (r + p) - r = p :=
-by rw [add_comm, add_sub_cancel]
-
-@[mono] lemma sub_le_sub {p₁ p₂ r₁ r₂ : ℝ≥0} (hp : p₁ ≤ p₂) (hr : r₁ ≤ r₂) :
-  p₁ - r₂ ≤ p₂ - r₁ :=
-real.to_nnreal_mono $ sub_le_sub hp hr
-
-lemma sub_add_eq_max {r p : ℝ≥0} : (r - p) + p = max r p :=
-nnreal.eq $ by rw [sub_def, nnreal.coe_add, coe_max, real.to_nnreal, coe_mk,
-  ← max_add_add_right, zero_add, sub_add_cancel]
-
-lemma add_sub_eq_max {r p : ℝ≥0} : p + (r - p) = max p r :=
-by rw [add_comm, sub_add_eq_max, max_comm]
-
-@[simp] lemma sub_add_cancel_of_le {a b : ℝ≥0} (h : b ≤ a) : (a - b) + b = a :=
-by rw [sub_add_eq_max, max_eq_left h]
-
-lemma sub_sub_cancel_of_le {r p : ℝ≥0} (h : r ≤ p) : p - (p - r) = r :=
-by rw [nnreal.sub_def, nnreal.sub_def, real.coe_to_nnreal _ $ sub_nonneg.2 h,
-  sub_sub_cancel, real.to_nnreal_coe]
-
-lemma lt_sub_iff_add_lt {p q r : ℝ≥0} : p < q - r ↔ p + r < q :=
-begin
-  split,
-  { assume H,
-    have : (((q - r) : ℝ≥0) : ℝ) = (q : ℝ) - (r : ℝ) :=
-      nnreal.coe_sub (le_of_lt (sub_pos.1 (lt_of_le_of_lt (zero_le _) H))),
-    rwa [← nnreal.coe_lt_coe, this, lt_sub_iff_add_lt, ← nnreal.coe_add] at H },
-  { assume H,
-    have : r ≤ q := le_trans (le_add_self) (le_of_lt H),
-    rwa [← nnreal.coe_lt_coe, nnreal.coe_sub this, lt_sub_iff_add_lt, ← nnreal.coe_add] }
-end
-
-lemma sub_lt_iff_lt_add {a b c : ℝ≥0} (h : b ≤ a) : a - b < c ↔ a < b + c :=
-by simp only [←nnreal.coe_lt_coe, nnreal.coe_sub h, nnreal.coe_add, sub_lt_iff_lt_add']
-
-lemma sub_eq_iff_eq_add {a b c : ℝ≥0} (h : b ≤ a) : a - b = c ↔ a = c + b :=
-by rw [←nnreal.eq_iff, nnreal.coe_sub h, ←nnreal.eq_iff, nnreal.coe_add, sub_eq_iff_eq_add]
+instance : has_ordered_sub ℝ≥0 :=
+⟨λ a b c, by simp only [← nnreal.coe_le_coe, nnreal.coe_add, coe_sub_def, max_le_iff, c.coe_nonneg,
+  and_true, sub_le_iff_le_add]⟩
 
 lemma mul_sub (a b c : ℝ≥0) : a * (b - c) = a * b - a * c :=
 nnreal.eq $ by simp only [coe_sub_def, nnreal.coe_mul, mul_max_of_nonneg _ _ a.coe_nonneg,
@@ -619,13 +556,8 @@ nnreal.eq $ by simp only [coe_sub_def, nnreal.coe_mul, mul_max_of_nonneg _ _ a.c
 lemma sub_mul (a b c : ℝ≥0) : (a - b) * c = a * c - b * c :=
 by simp only [← mul_comm c, mul_sub]
 
-lemma sub_add_sub_cancel {a b c : ℝ≥0} (h₁ : b ≤ a) (h₂ : c ≤ b) :
-  (a - b) + (b - c) = a - c :=
-nnreal.eq $ by simp [*, h₂.trans h₁, sub_add_sub_cancel]
-
-lemma sub_add_sub_cancel' {a b c : ℝ≥0} (h₁ : b ≤ a) (h₂ : a ≤ c) :
-  (a - b) + (c - a) = c - b :=
-by rw [add_comm, sub_add_sub_cancel h₂ h₁]
+lemma sub_div (a b c : ℝ≥0) : (a - b) / c = a / c - b / c :=
+by simp only [div_eq_mul_inv, sub_mul]
 
 end sub
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -537,9 +537,9 @@ section sub
 /-!
 ### Lemmas about subtraction
 
-In this section we provide a few lemmas about definition, the instance `nnreal.has_ordered_sub`, and
-a few lemmas about subtraction, multiplication, and division. For lemmas about subtraction and
-addition see lemmas about `has_ordered_sub` in the file `algebra/ordered_sub`. -/
+In this section we provide the instance `nnreal.has_ordered_sub` and a few lemmas about subtraction
+that do not fit well into any other typeclass. For lemmas about subtraction and addition see lemmas
+about `has_ordered_sub` in the file `algebra/ordered_sub`. See also `mul_sub'` and `sub_mul'`. -/
 
 lemma sub_def {r p : ℝ≥0} : r - p = real.to_nnreal (r - p) := rfl
 
@@ -549,15 +549,8 @@ instance : has_ordered_sub ℝ≥0 :=
 ⟨λ a b c, by simp only [← nnreal.coe_le_coe, nnreal.coe_add, coe_sub_def, max_le_iff, c.coe_nonneg,
   and_true, sub_le_iff_le_add]⟩
 
-lemma mul_sub (a b c : ℝ≥0) : a * (b - c) = a * b - a * c :=
-nnreal.eq $ by simp only [coe_sub_def, nnreal.coe_mul, mul_max_of_nonneg _ _ a.coe_nonneg,
-  mul_sub, mul_zero]
-
-lemma sub_mul (a b c : ℝ≥0) : (a - b) * c = a * c - b * c :=
-by simp only [← mul_comm c, mul_sub]
-
 lemma sub_div (a b c : ℝ≥0) : (a - b) / c = a / c - b / c :=
-by simp only [div_eq_mul_inv, sub_mul]
+by simp only [div_eq_mul_inv, sub_mul']
 
 end sub
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -537,6 +537,8 @@ section sub
 
 lemma sub_def {r p : ℝ≥0} : r - p = real.to_nnreal (r - p) := rfl
 
+lemma coe_sub_def {r p : ℝ≥0} : ↑(r - p) = max (r - p : ℝ) 0 := rfl
+
 lemma sub_eq_zero {r p : ℝ≥0} (h : r ≤ p) : r - p = 0 :=
 nnreal.eq $ max_eq_right $ sub_le_iff_le_add.2 $ by simpa [nnreal.coe_le_coe] using h
 
@@ -574,6 +576,10 @@ nnreal.eq $ by rw [nnreal.coe_sub, nnreal.coe_add, add_sub_cancel]; exact le_add
 lemma add_sub_cancel' {r p : ℝ≥0} : (r + p) - r = p :=
 by rw [add_comm, add_sub_cancel]
 
+@[mono] lemma sub_le_sub {p₁ p₂ r₁ r₂ : ℝ≥0} (hp : p₁ ≤ p₂) (hr : r₁ ≤ r₂) :
+  p₁ - r₂ ≤ p₂ - r₁ :=
+real.to_nnreal_mono $ sub_le_sub hp hr
+
 lemma sub_add_eq_max {r p : ℝ≥0} : (r - p) + p = max r p :=
 nnreal.eq $ by rw [sub_def, nnreal.coe_add, coe_max, real.to_nnreal, coe_mk,
   ← max_add_add_right, zero_add, sub_add_cancel]
@@ -605,6 +611,21 @@ by simp only [←nnreal.coe_lt_coe, nnreal.coe_sub h, nnreal.coe_add, sub_lt_iff
 
 lemma sub_eq_iff_eq_add {a b c : ℝ≥0} (h : b ≤ a) : a - b = c ↔ a = c + b :=
 by rw [←nnreal.eq_iff, nnreal.coe_sub h, ←nnreal.eq_iff, nnreal.coe_add, sub_eq_iff_eq_add]
+
+lemma mul_sub (a b c : ℝ≥0) : a * (b - c) = a * b - a * c :=
+nnreal.eq $ by simp only [coe_sub_def, nnreal.coe_mul, mul_max_of_nonneg _ _ a.coe_nonneg,
+  mul_sub, mul_zero]
+
+lemma sub_mul (a b c : ℝ≥0) : (a - b) * c = a * c - b * c :=
+by simp only [← mul_comm c, mul_sub]
+
+lemma sub_add_sub_cancel {a b c : ℝ≥0} (h₁ : b ≤ a) (h₂ : c ≤ b) :
+  (a - b) + (b - c) = a - c :=
+nnreal.eq $ by simp [*, h₂.trans h₁, sub_add_sub_cancel]
+
+lemma sub_add_sub_cancel' {a b c : ℝ≥0} (h₁ : b ≤ a) (h₂ : a ≤ c) :
+  (a - b) + (c - a) = c - b :=
+by rw [add_comm, sub_add_sub_cancel h₂ h₁]
 
 end sub
 

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -1031,7 +1031,7 @@ begin
   rw [← add_lt_add_iff_left this.ne, ← add_lintegral, ← map_add @ennreal.coe_add],
   refine (hb _ (λ x, le_trans _ (max_le (hle x) (hψ x)))).trans_lt hbφ,
   norm_cast,
-  simp only [add_apply, sub_apply, nnreal.add_sub_eq_max]
+  simp only [add_apply, sub_apply, add_sub_eq_max]
 end
 
 theorem supr_lintegral_le {ι : Sort*} (f : ι → α → ℝ≥0∞) :
@@ -1233,7 +1233,7 @@ begin
     begin
       rw [← simple_func.add_lintegral, ← simple_func.map_add @ennreal.coe_add],
       refine simple_func.lintegral_mono (λ x, _) le_rfl,
-      simp [-ennreal.coe_add, nnreal.add_sub_eq_max, le_max_right]
+      simp [-ennreal.coe_add, add_sub_eq_max, le_max_right]
     end
   ... ≤ (map coe φ).lintegral (μ.restrict s) + ε₁ :
     begin

--- a/src/tactic/monotonicity/lemmas.lean
+++ b/src/tactic/monotonicity/lemmas.lean
@@ -81,7 +81,7 @@ attribute [mono] upper_bounds_mono_set lower_bounds_mono_set
 attribute [mono] add_le_add mul_le_mul neg_le_neg
          mul_lt_mul_of_pos_left mul_lt_mul_of_pos_right
          imp_imp_imp le_implies_le_of_le_of_le
-         sub_le_sub abs_le_abs sup_le_sup
+         sub_le_sub sub_le_sub' sub_le_sub_right' abs_le_abs sup_le_sup
          inf_le_inf
 attribute [mono left] add_lt_add_of_le_of_lt mul_lt_mul'
 attribute [mono right] add_lt_add_of_lt_of_le mul_lt_mul

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -1178,11 +1178,10 @@ begin
   refine (metric.cauchy_seq_iff'.1 hd ε (nnreal.coe_pos.2 εpos)).imp (λ N hN n hn, _),
   have hsum := hN n hn,
   -- We simplify the known inequality
-  rw [dist_nndist, nnreal.nndist_eq, ← sum_range_add_sum_Ico _ hn, nnreal.add_sub_cancel'] at hsum,
+  rw [dist_nndist, nnreal.nndist_eq, ← sum_range_add_sum_Ico _ hn, add_sub_cancel_left] at hsum,
   norm_cast at hsum,
   replace hsum := lt_of_le_of_lt (le_max_left _ _) hsum,
   rw edist_comm,
-
   -- Then use `hf` to simplify the goal to the same form
   apply lt_of_le_of_lt (edist_le_Ico_sum_of_edist_le hn (λ k _ _, hf k)),
   assumption_mod_cast

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1149,7 +1149,7 @@ lemma nnreal.nndist_eq (a b : ℝ≥0) :
 begin
   wlog h : a ≤ b,
   { apply nnreal.coe_eq.1,
-    rw [nnreal.sub_eq_zero h, max_eq_right (zero_le $ b - a), ← dist_nndist, nnreal.dist_eq,
+    rw [sub_eq_zero_iff_le.2 h, max_eq_right (zero_le $ b - a), ← dist_nndist, nnreal.dist_eq,
       nnreal.coe_sub h, abs_eq_max_neg, neg_sub],
     apply max_eq_right,
     linarith [nnreal.coe_le_coe.2 h] },


### PR DESCRIPTION
* provide a `has_ordered_sub` instance for `nnreal`;
* drop most lemmas about subtraction in favor of lemmas from `algebra/ordered_sub`;
* add `mul_sub'` and `sub_mul'`;
* generalize some lemmas about `has_ordered_sub` to `has_add`;
* add `add_hom.mul_left` and `add_hom.mul_right`.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)