### PR TITLE
[Merged by Bors] - feat(group_theory/perm/concrete_cycle): perm.to_list

### DIFF
--- a/src/group_theory/perm/concrete_cycle.lean
+++ b/src/group_theory/perm/concrete_cycle.lean
@@ -379,12 +379,12 @@ begin
 end
 
 lemma is_cycle.exists_unique_cycle {f : perm α} (hf : is_cycle f) :
-  ∃! (s : {s : cycle α // s.nodup}), (s : cycle α).form_perm s.prop = f :=
+  ∃! (s : cycle α), ∃ (h : s.nodup), s.form_perm h = f :=
 begin
   obtain ⟨x, hx, hy⟩ := id hf,
-  refine ⟨⟨f.to_list x, nodup_to_list f x⟩, _, _⟩,
+  refine ⟨f.to_list x, ⟨nodup_to_list f x, _⟩, _⟩,
   { simp [form_perm_to_list, hf.cycle_of_eq hx] },
-  { rintro ⟨⟨l⟩, hn⟩ rfl,
+  { rintro ⟨l⟩ ⟨hn, rfl⟩,
     simp only [cycle.mk_eq_coe, cycle.coe_eq_coe, subtype.coe_mk, cycle.form_perm_coe],
     refine (to_list_form_perm_is_rotated_self _ _ hn _ _).symm,
     { contrapose! hx,
@@ -395,6 +395,15 @@ begin
     { rw ←mem_to_finset,
       refine support_form_perm_le l _,
       simpa using hx } }
+end
+
+lemma is_cycle.exists_unique_cycle_subtype {f : perm α} (hf : is_cycle f) :
+  ∃! (s : {s : cycle α // s.nodup}), (s : cycle α).form_perm s.prop = f :=
+begin
+  obtain ⟨s, ⟨hs, rfl⟩, hs'⟩ := hf.exists_unique_cycle,
+  refine ⟨⟨s, hs⟩, rfl, _⟩,
+  rintro ⟨t, ht⟩ ht',
+  simpa using hs' _ ⟨ht, ht'⟩
 end
 
 end equiv.perm

--- a/src/group_theory/perm/concrete_cycle.lean
+++ b/src/group_theory/perm/concrete_cycle.lean
@@ -16,6 +16,7 @@ In the following, `{α : Type*} [fintype α] [decidable_eq α]`.
 ## Main definitions
 
 * `cycle.form_perm`: the cyclic permutation created by looping over a `cycle α`
+* `equiv.perm.to_list`: the list formed by iterating application of a permutation
 
 ## Main results
 
@@ -185,3 +186,219 @@ begin
 end
 
 end cycle
+variables {α : Type*}
+
+namespace equiv.perm
+
+variables [fintype α] [decidable_eq α] (p : equiv.perm α) (x : α)
+
+/--
+`equiv.perm.to_list (f : perm α) (x : α)` generates the list `[x, f x, f (f x), ...]`
+until looping. That means when `f x = x`, `to_list f x = []`.
+-/
+def to_list : list α :=
+(list.range (cycle_of p x).support.card).map (λ k, (p ^ k) x)
+
+@[simp] lemma to_list_one : to_list (1 : perm α) x = [] :=
+by simp [to_list, cycle_of_one]
+
+@[simp] lemma to_list_eq_nil_iff {p : perm α} {x} : to_list p x = [] ↔ x ∉ p.support :=
+by simp [to_list]
+
+@[simp] lemma length_to_list : length (to_list p x) = (cycle_of p x).support.card :=
+by simp [to_list]
+
+lemma to_list_ne_singleton (y : α) : to_list p x ≠ [y] :=
+begin
+  intro H,
+  simpa [card_support_ne_one] using congr_arg length H
+end
+
+lemma two_le_length_to_list_iff_mem_support {p : perm α} {x : α} :
+  2 ≤ length (to_list p x) ↔ x ∈ p.support :=
+by simp
+
+lemma length_to_list_pos_of_mem_support (h : x ∈ p.support) : 0 < length (to_list p x) :=
+zero_lt_two.trans_le (two_le_length_to_list_iff_mem_support.mpr h)
+
+lemma nth_le_to_list (n : ℕ) (hn : n < length (to_list p x)) :
+  nth_le (to_list p x) n hn = (p ^ n) x :=
+by simp [to_list]
+
+lemma to_list_nth_le_zero (h : x ∈ p.support) :
+  (to_list p x).nth_le 0 (length_to_list_pos_of_mem_support _ _ h) = x :=
+by simp [to_list]
+
+variables {p} {x}
+
+lemma mem_to_list_iff {y : α} :
+  y ∈ to_list p x ↔ same_cycle p x y ∧ x ∈ p.support :=
+begin
+  simp only [to_list, mem_range, mem_map],
+  split,
+  { rintro ⟨n, hx, rfl⟩,
+    refine ⟨⟨n, rfl⟩, _⟩,
+    contrapose! hx,
+    rw ←support_cycle_of_eq_nil_iff at hx,
+    simp [hx] },
+  { rintro ⟨h, hx⟩,
+    simpa using same_cycle.nat_of_mem_support _ h hx }
+end
+
+lemma nodup_to_list (p : perm α) (x : α) :
+  nodup (to_list p x)  :=
+begin
+  by_cases hx : p x = x,
+  { rw [←not_mem_support, ←to_list_eq_nil_iff] at hx,
+    simp [hx] },
+  have hc : is_cycle (cycle_of p x) := is_cycle_cycle_of p hx,
+  rw nodup_iff_nth_le_inj,
+  rintros n m hn hm,
+  rw [length_to_list, ←order_of_is_cycle hc] at hm hn,
+  rw [←cycle_of_apply_self, ←ne.def, ←mem_support] at hx,
+  rw [nth_le_to_list, nth_le_to_list,
+      ←cycle_of_pow_apply_self p x n, ←cycle_of_pow_apply_self p x m],
+  cases n; cases m,
+  { simp },
+  { rw [←hc.mem_support_pos_pow_iff_of_lt_order_of m.zero_lt_succ hm,
+        mem_support, cycle_of_pow_apply_self] at hx,
+    simp [hx.symm] },
+  { rw [←hc.mem_support_pos_pow_iff_of_lt_order_of n.zero_lt_succ hn,
+        mem_support, cycle_of_pow_apply_self] at hx,
+    simp [hx] },
+  intro h,
+  have hn' : ¬ order_of (p.cycle_of x) ∣ n.succ := nat.not_dvd_of_pos_of_lt n.zero_lt_succ hn,
+  have hm' : ¬ order_of (p.cycle_of x) ∣ m.succ := nat.not_dvd_of_pos_of_lt m.zero_lt_succ hm,
+  rw ←hc.support_pow_eq_iff at hn' hm',
+  rw [←nat.mod_eq_of_lt hn, ←nat.mod_eq_of_lt hm, ←pow_inj_mod],
+  refine support_congr _ _,
+  { rw [hm', hn'],
+    exact finset.subset.refl _ },
+  { rw hm',
+    intros y hy,
+    obtain ⟨k, rfl⟩ := hc.exists_pow_eq (mem_support.mp hx) (mem_support.mp hy),
+    rw [←mul_apply, (commute.pow_pow_self _ _ _).eq, mul_apply, h, ←mul_apply, ←mul_apply,
+        (commute.pow_pow_self _ _ _).eq] }
+end
+
+lemma next_to_list_eq_apply (p : perm α) (x y : α) (hy : y ∈ to_list p x) :
+  next (to_list p x) y hy = p y :=
+begin
+  rw mem_to_list_iff at hy,
+  obtain ⟨k, hk, hk'⟩ := hy.left.nat_of_mem_support _ hy.right,
+  rw ←nth_le_to_list p x k (by simpa using hk) at hk',
+  simp_rw ←hk',
+  rw [next_nth_le _ (nodup_to_list _ _), nth_le_to_list, nth_le_to_list, ←mul_apply, ←pow_succ,
+      length_to_list, pow_apply_eq_pow_mod_order_of_cycle_of_apply p (k + 1), order_of_is_cycle],
+  exact is_cycle_cycle_of _ (mem_support.mp hy.right)
+end
+
+lemma to_list_pow_apply_eq_rotate (p : perm α) (x : α) (k : ℕ) :
+  p.to_list ((p ^ k) x) = (p.to_list x).rotate k :=
+begin
+  apply ext_le,
+  { simp },
+  { intros n hn hn',
+    rw [nth_le_to_list, nth_le_rotate, nth_le_to_list, length_to_list,
+        pow_mod_card_support_cycle_of_self_apply, pow_add, mul_apply] }
+end
+
+lemma same_cycle.to_list_is_rotated {f : perm α} {x y : α} (h : same_cycle f x y) :
+  to_list f x ~r to_list f y :=
+begin
+  by_cases hx : x ∈ f.support,
+  { obtain ⟨_ | k, hk, hy⟩ := h.nat_of_mem_support _ hx,
+    { simp only [coe_one, id.def, pow_zero] at hy,
+      simp [hy] },
+    use k.succ,
+    rw [←to_list_pow_apply_eq_rotate, hy] },
+  { rw [to_list_eq_nil_iff.mpr hx, is_rotated_nil_iff', eq_comm, to_list_eq_nil_iff],
+    rwa ←h.mem_support_iff }
+end
+
+lemma pow_apply_mem_to_list_iff_mem_support {n : ℕ} :
+  (p ^ n) x ∈ p.to_list x ↔ x ∈ p.support :=
+begin
+  rw [mem_to_list_iff, and_iff_right_iff_imp],
+  refine λ _, same_cycle.symm _,
+  rw same_cycle_pow_left_iff
+end
+
+lemma to_list_form_perm_nil (x : α) :
+  to_list (form_perm ([] : list α)) x = [] :=
+by simp
+
+lemma to_list_form_perm_singleton (x y : α) :
+  to_list (form_perm [x]) y = [] :=
+by simp
+
+lemma to_list_form_perm_nontrivial (l : list α) (hl : 2 ≤ l.length) (hn : nodup l) :
+  to_list (form_perm l) (l.nth_le 0 (zero_lt_two.trans_le hl)) = l :=
+begin
+  have hc : l.form_perm.is_cycle := list.is_cycle_form_perm hn hl,
+  have hs : l.form_perm.support = l.to_finset,
+  { refine support_form_perm_of_nodup _ hn _,
+    rintro _ rfl,
+    simpa [nat.succ_le_succ_iff] using hl },
+  rw [to_list, hc.cycle_of_eq (mem_support.mp _), hs, card_to_finset, erase_dup_eq_self.mpr hn],
+  { refine list.ext_le (by simp) (λ k hk hk', _),
+    simp [form_perm_pow_apply_nth_le _ hn, nat.mod_eq_of_lt hk'] },
+  { simpa [hs] using nth_le_mem _ _ _ }
+end
+
+lemma to_list_form_perm_is_rotated_self (l : list α) (hl : 2 ≤ l.length) (hn : nodup l)
+  (x : α) (hx : x ∈ l):
+  to_list (form_perm l) x ~r l :=
+begin
+  obtain ⟨k, hk, rfl⟩ := nth_le_of_mem hx,
+  have hr : l ~r l.rotate k := ⟨k, rfl⟩,
+  rw form_perm_eq_of_is_rotated hn hr,
+  rw ←nth_le_rotate' l k k,
+  simp only [nat.mod_eq_of_lt hk, nat.sub_add_cancel hk.le, nat.mod_self],
+  rw [to_list_form_perm_nontrivial],
+  { simp },
+  { simpa using hl },
+  { simpa using hn }
+end
+
+lemma form_perm_to_list (f : perm α) (x : α) :
+  form_perm (to_list f x) = f.cycle_of x :=
+begin
+  by_cases hx : f x = x,
+  { rw [(cycle_of_eq_one_iff f).mpr hx, to_list_eq_nil_iff.mpr (not_mem_support.mpr hx),
+        form_perm_nil] },
+  ext y,
+  by_cases hy : same_cycle f x y,
+  { obtain ⟨k, hk, rfl⟩ := hy.nat_of_mem_support _ (mem_support.mpr hx),
+    rw [cycle_of_apply_apply_pow_self, list.form_perm_apply_mem_eq_next (nodup_to_list f x),
+        next_to_list_eq_apply, pow_succ, mul_apply],
+    rw mem_to_list_iff,
+    exact ⟨⟨k, rfl⟩, mem_support.mpr hx⟩ },
+  { rw [cycle_of_apply_of_not_same_cycle hy, form_perm_apply_of_not_mem],
+    simp [mem_to_list_iff, hy] }
+end
+
+lemma is_cycle.exists_unique_cycle {f : perm α} (hf : is_cycle f) :
+  ∃! (s : {s : cycle α // s.nodup ∧ s.nontrivial}), (s : cycle α).form_perm s.prop.left = f :=
+begin
+  obtain ⟨x, hx, hy⟩ := id hf,
+  refine ⟨⟨(f.to_list x), nodup_to_list f x, _⟩, _, _⟩,
+  { refine ⟨f x, x, hx, _, _⟩,
+    { rw cycle.mem_coe_iff,
+      convert_to (f ^ 1) x ∈ f.to_list x,
+      rwa [pow_apply_mem_to_list_iff_mem_support, mem_support] },
+    { rw cycle.mem_coe_iff,
+      convert_to (f ^ 0) x ∈ f.to_list x,
+      rwa [pow_apply_mem_to_list_iff_mem_support, mem_support] } },
+  { simp [form_perm_to_list, hf.cycle_of_eq hx] },
+  { rintro ⟨⟨l⟩, hn, ht⟩ rfl,
+    simp only [subtype.coe_mk, cycle.mk_eq_coe, cycle.coe_eq_coe, cycle.form_perm_coe],
+    refine (to_list_form_perm_is_rotated_self _ _ _ _ _).symm,
+    { simpa using cycle.length_nontrivial ht },
+    { simpa using hn },
+    { rw ←mem_to_finset,
+      refine support_form_perm_le l _,
+      simpa using hx } }
+end
+
+end equiv.perm

--- a/src/group_theory/perm/concrete_cycle.lean
+++ b/src/group_theory/perm/concrete_cycle.lean
@@ -246,7 +246,7 @@ begin
 end
 
 lemma nodup_to_list (p : perm α) (x : α) :
-  nodup (to_list p x)  :=
+  nodup (to_list p x) :=
 begin
   by_cases hx : p x = x,
   { rw [←not_mem_support, ←to_list_eq_nil_iff] at hx,

--- a/src/group_theory/perm/concrete_cycle.lean
+++ b/src/group_theory/perm/concrete_cycle.lean
@@ -379,23 +379,19 @@ begin
 end
 
 lemma is_cycle.exists_unique_cycle {f : perm α} (hf : is_cycle f) :
-  ∃! (s : {s : cycle α // s.nodup ∧ s.nontrivial}), (s : cycle α).form_perm s.prop.left = f :=
+  ∃! (s : {s : cycle α // s.nodup}), (s : cycle α).form_perm s.prop = f :=
 begin
   obtain ⟨x, hx, hy⟩ := id hf,
-  refine ⟨⟨(f.to_list x), nodup_to_list f x, _⟩, _, _⟩,
-  { refine ⟨f x, x, hx, _, _⟩,
-    { rw cycle.mem_coe_iff,
-      convert_to (f ^ 1) x ∈ f.to_list x,
-      rwa [pow_apply_mem_to_list_iff_mem_support, mem_support] },
-    { rw cycle.mem_coe_iff,
-      convert_to (f ^ 0) x ∈ f.to_list x,
-      rwa [pow_apply_mem_to_list_iff_mem_support, mem_support] } },
+  refine ⟨⟨f.to_list x, nodup_to_list f x⟩, _, _⟩,
   { simp [form_perm_to_list, hf.cycle_of_eq hx] },
-  { rintro ⟨⟨l⟩, hn, ht⟩ rfl,
-    simp only [subtype.coe_mk, cycle.mk_eq_coe, cycle.coe_eq_coe, cycle.form_perm_coe],
-    refine (to_list_form_perm_is_rotated_self _ _ _ _ _).symm,
-    { simpa using cycle.length_nontrivial ht },
-    { simpa using hn },
+  { rintro ⟨⟨l⟩, hn⟩ rfl,
+    simp only [cycle.mk_eq_coe, cycle.coe_eq_coe, subtype.coe_mk, cycle.form_perm_coe],
+    refine (to_list_form_perm_is_rotated_self _ _ hn _ _).symm,
+    { contrapose! hx,
+      suffices : form_perm l = 1,
+      { simp [this] },
+      rw form_perm_eq_one_iff _ hn,
+      exact nat.le_of_lt_succ hx },
     { rw ←mem_to_finset,
       refine support_form_perm_le l _,
       simpa using hx } }


### PR DESCRIPTION
The conceptual inverse to `list.form_perm`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

A continuation of a piecewise re-PR of #8226. The suggestions from that PR have been incorporated.