### PR TITLE
[Merged by Bors] - feat(group_theory/p_group): Intersection with p-subgroup is a p-subgroup

### DIFF
--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -58,6 +58,14 @@ begin
   exact λ h, hK ⟨h, hHK h.2⟩,
 end
 
+lemma to_inf_left {H : subgroup G} (hH : is_p_group p H) (K : subgroup G) :
+  is_p_group p (H ⊓ K : subgroup G) :=
+hH.to_le inf_le_left
+
+lemma to_inf_right {K : subgroup G} (hK : is_p_group p K) (H : subgroup G) :
+  is_p_group p (H ⊓ K : subgroup G) :=
+hK.to_le inf_le_right
+
 variables (hG : is_p_group p G)
 
 include hG


### PR DESCRIPTION
Two lemmas stating that the intersection with a p-subgroup is a p-subgroup.

Not sure which one should be called left and which one should be called right though :)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
