### PR TITLE
[Merged by Bors] - feat(linear_algebra/{multilinear,alternating): add of_subsingleton

### DIFF
--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -266,6 +266,19 @@ instance : module S (alternating_map R M N ι) :=
 
 end module
 
+section
+variables (R N)
+
+/-- The evaluation map from `ι → N` to `N` at a given `i` is alternating when `ι` is subsingleton.
+-/
+@[simps]
+def of_subsingleton [subsingleton ι] (i : ι) : alternating_map R N N ι :=
+{ to_fun := function.eval i,
+  map_eq_zero_of_eq' := λ v i j hv hij, (hij $ subsingleton.elim _ _).elim,
+  ..multilinear_map.of_subsingleton R N i }
+
+end
+
 end alternating_map
 
 /-!

--- a/src/linear_algebra/multilinear.lean
+++ b/src/linear_algebra/multilinear.lean
@@ -184,6 +184,21 @@ multilinear map taking values in the space of functions `Π i, M' i`. -/
   map_add' := λ m i x y, funext $ λ j, (f j).map_add _ _ _ _,
   map_smul' := λ m i c x, funext $ λ j, (f j).map_smul _ _ _ _ }
 
+section
+variables (R M₂)
+
+/-- The evaluation map from `ι → M₂` to `M₂` is multilinear at a given `i` when `ι` is subsingleton.
+-/
+@[simps]
+def of_subsingleton [subsingleton ι] (i' : ι) : multilinear_map R (λ _ : ι, M₂) M₂ :=
+{ to_fun := function.eval i',
+  map_add' := λ m i x y, by {
+    rw subsingleton.elim i i', simp only [function.eval, function.update_same], },
+  map_smul' := λ m i r x, by {
+    rw subsingleton.elim i i', simp only [function.eval, function.update_same], } }
+
+end
+
 /-- Given a multilinear map `f` on `n` variables (parameterized by `fin n`) and a subset `s` of `k`
 of these variables, one gets a new multilinear map on `fin k` by varying these variables, and fixing
 the other ones equal to a given value `z`. It is denoted by `f.restr s hk z`, where `hk` is a


### PR DESCRIPTION
This was refactored from the `koszul_cx` branch, something I mentioned doing in [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/two.20decidable_eq.20instances.20on.20.28fin.201.29.20in.20mathlib.20.3A-.28/near/225596630).

The original version was:
```lean
def multilinear_map.of_subsingleton (ι : Type v) [subsingleton ι] [inhabited ι] {N : Type u}
  [add_comm_group N] [module R N] (f : M →ₗ[R] N) : multilinear_map R (λ (i : ι), M) N :=
{ to_fun := λ x, f (x $ default ι),
  map_add' := λ m i x y, by rw subsingleton.elim i (default ι); simp only
    [function.update_same, f.map_add],
  map_smul' := λ m i r x, by rw subsingleton.elim i (default ι); simp only
    [function.update_same, f.map_smul], }
```
but I decided to remove the `f : M →ₗ[R] N` argument as it can be added later with `(of_subsingleton R M i).comp_linear_map f`.

Co-authored-by: Amelia Livingston <al3717@ic.ac.uk>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Link to the original:

https://github.com/leanprover-community/mathlib/blob/df4221e47e1245c1a1d716e1c02f1f957953a1e6/src/m4r/Koszul_eq_free_Koszul.lean#L80-L86