### PR TITLE
[Merged by Bors] - chore(*): simplify `data.real.cau_seq` import

### DIFF
--- a/src/number_theory/padics/padic_norm.lean
+++ b/src/number_theory/padics/padic_norm.lean
@@ -3,12 +3,11 @@ Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
-import ring_theory.int.basic
+import algebra.absolute_value
 import algebra.field_power
-import ring_theory.multiplicity
-import data.real.cau_seq
-import tactic.ring_exp
+import ring_theory.int.basic
 import tactic.basic
+import tactic.ring_exp
 
 /-!
 # p-adic norm

--- a/src/topology/uniform_space/absolute_value.lean
+++ b/src/topology/uniform_space/absolute_value.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot
 -/
-import data.real.cau_seq
+import algebra.absolute_value
 import topology.uniform_space.basic
 
 /-!


### PR DESCRIPTION
Some files were still importing `data.real.cau_seq` when their dependency really was on `is_absolute_value`, which has been moved to `algebra.absolute_value`. Hopefully simplifying the dependency tree slightly reduces build complexity.



---

Marking this as WIP until everything builds.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
