### PR TITLE
[Merged by Bors] - ci(.github/workflows/*): lint PR style on GitHub runners

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install Python
-        if: ${{ ! 1 }}
+        if: ${{ 'self-hosted' == 'ubuntu-latest' }}
         uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,12 +38,12 @@ jobs:
   style_lint:
     if: github.repository == 'leanprover-community/mathlib'
     name: Lint style
-    runs-on: pr
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
       - name: install Python
-        if: ${{ ! 1 }}
+        if: ${{ 'ubuntu-latest' == 'ubuntu-latest' }}
         uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -16,12 +16,12 @@ jobs:
   style_lint:
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib'
     name: Lint styleJOB_NAME
-    runs-on: RUNS_ON
+    runs-on: STYLE_LINT_RUNNER
     steps:
       - uses: actions/checkout@v2
 
       - name: install Python
-        if: ${{ ! IS_SELF_HOSTED }}
+        if: ${{ 'STYLE_LINT_RUNNER' == 'ubuntu-latest' }}
         uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install Python
-        if: ${{ ! 0 }}
+        if: ${{ 'ubuntu-latest' == 'ubuntu-latest' }}
         uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/mk_build_yml.sh
+++ b/.github/workflows/mk_build_yml.sh
@@ -33,7 +33,7 @@ on:
 
 name: continuous integration
 EOF
-  include 1 pr == ""
+  include 1 pr == "" ubuntu-latest
 }
 
 bors_yml() {
@@ -48,7 +48,7 @@ on:
 
 name: continuous integration (staging)
 EOF
-  include 1 self-hosted == ""
+  include 1 self-hosted == "" self-hosted
 }
 
 build_fork_yml() {
@@ -69,7 +69,7 @@ on:
 
 name: continuous integration (mathlib forks)
 EOF
-  include 0 ubuntu-latest != " (fork)"
+  include 0 ubuntu-latest != " (fork)" ubuntu-latest
 }
 
 include() {
@@ -78,6 +78,7 @@ include() {
     s/RUNS_ON/$2/g;
     s/MAIN_OR_FORK/$3/g;
     s/JOB_NAME/$4/g;
+    s/STYLE_LINT_RUNNER/$5/g;
   " build.yml.in
 }
 


### PR DESCRIPTION
Since the style linter usually finishes in just a few seconds, we can move it off our self-hosted runners to give PR authors quicker feedback when the build queue is long.

We do this only for PR runs, so that `bors` won't be held up in case the GitHub runners are backed up for whatever reason.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
