### PR TITLE
[Merged by Bors] - feat(measure_theory/function/l1_space): add integrability lemmas for composition with `to_real`

### DIFF
--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -568,10 +568,18 @@ begin
   simp [real.norm_eq_abs, ennreal.of_real_le_of_real, abs_le, abs_nonneg, le_abs_self],
 end
 
+lemma mem_ℒ1_to_real_of_lintegral_ne_top
+  {f : α → ℝ≥0∞} (hfm : ae_measurable f μ) (hfi : ∫⁻ x, f x ∂μ ≠ ∞) :
+  mem_ℒp (λ x, (f x).to_real) 1 μ :=
+begin
+  rw [mem_ℒp, snorm_one_eq_lintegral_nnnorm],
+  exact ⟨ae_measurable.ennreal_to_real hfm, has_finite_integral_to_real_of_lintegral_ne_top hfi⟩
+end
+
 lemma integrable_to_real_of_lintegral_ne_top
   {f : α → ℝ≥0∞} (hfm : ae_measurable f μ) (hfi : ∫⁻ x, f x ∂μ ≠ ∞) :
   integrable (λ x, (f x).to_real) μ :=
-⟨ae_measurable.ennreal_to_real hfm, has_finite_integral_to_real_of_lintegral_ne_top hfi⟩
+mem_ℒp_one_iff_integrable.1 $ mem_ℒ1_to_real_of_lintegral_ne_top hfm hfi
 
 section pos_part
 /-! ### Lemmas used for defining the positive part of a `L¹` function -/

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -224,6 +224,21 @@ lemma has_finite_integral_norm_iff (f : α → β) :
   has_finite_integral (λa, ∥f a∥) μ ↔ has_finite_integral f μ :=
 has_finite_integral_congr' $ eventually_of_forall $ λ x, norm_norm (f x)
 
+lemma has_finite_integral_to_real_of_lintegral_ne_top
+  {f : α → ℝ≥0∞} (hf : ∫⁻ x, f x ∂μ ≠ ∞) :
+  has_finite_integral (λ x, (f x).to_real) μ :=
+begin
+  have : ∀ x, (∥(f x).to_real∥₊ : ℝ≥0∞) =
+    @coe ℝ≥0 ℝ≥0∞ _ (⟨(f x).to_real, ennreal.to_real_nonneg⟩ : ℝ≥0),
+  { intro x, rw real.nnnorm_of_nonneg },
+  simp_rw [has_finite_integral, this],
+  refine lt_of_le_of_lt (lintegral_mono (λ x, _)) (lt_top_iff_ne_top.2 hf),
+  by_cases hfx : f x = ∞,
+  { simp [hfx] },
+  { lift f x to ℝ≥0 using hfx with fx,
+    simp [← h] }
+end
+
 section dominated_convergence
 
 variables {F : ℕ → α → β} {f : α → β} {bound : α → ℝ}
@@ -368,6 +383,7 @@ lemma has_finite_integral.const_mul {f : α → ℝ} (h : has_finite_integral f 
 lemma has_finite_integral.mul_const {f : α → ℝ} (h : has_finite_integral f μ) (c : ℝ) :
   has_finite_integral (λ x, f x * c) μ :=
 by simp_rw [mul_comm, h.const_mul _]
+
 end normed_space
 
 /-! ### The predicate `integrable` -/
@@ -551,6 +567,11 @@ begin
   assume x,
   simp [real.norm_eq_abs, ennreal.of_real_le_of_real, abs_le, abs_nonneg, le_abs_self],
 end
+
+lemma integrable_to_real_of_lintegral_ne_top
+  {f : α → ℝ≥0∞} (hfm : ae_measurable f μ) (hfi : ∫⁻ x, f x ∂μ ≠ ∞) :
+  integrable (λ x, (f x).to_real) μ :=
+⟨ae_measurable.ennreal_to_real hfm, has_finite_integral_to_real_of_lintegral_ne_top hfi⟩
 
 section pos_part
 /-! ### Lemmas used for defining the positive part of a `L¹` function -/

--- a/src/measure_theory/measure/with_density_vector_measure.lean
+++ b/src/measure_theory/measure/with_density_vector_measure.lean
@@ -174,21 +174,6 @@ begin
   exact lintegral_mono_set (set.subset_univ _),
 end
 
-lemma with_densityᵥ_sub_eq_with_density {f g : α → ℝ≥0∞}
-  (hfm : ae_measurable f μ) (hgm : ae_measurable g μ)
-  (hf : ∫⁻ x, f x ∂μ ≠ ∞) (hg : ∫⁻ x, g x ∂μ ≠ ∞) :
-  μ.with_densityᵥ (λ x, (f x).to_real - (g x).to_real) =
-  @to_signed_measure α _ (μ.with_density f)
-    (is_finite_measure_with_density (lt_top_iff_ne_top.2 hf)) -
-  @to_signed_measure α _ (μ.with_density g)
-    (is_finite_measure_with_density (lt_top_iff_ne_top.2 hg)) :=
-begin
-  have hfi := integrable_to_real_of_lintegral_ne_top hfm hf,
-  have hgi := integrable_to_real_of_lintegral_ne_top hgm hg,
-  ext i hi,
-  rw [with_densityᵥ_sub' hfi hgi, with_densityᵥ_to_real hfm hf, with_densityᵥ_to_real hgm hg],
-end
-
 end signed_measure
 
 end measure_theory

--- a/src/measure_theory/measure/with_density_vector_measure.lean
+++ b/src/measure_theory/measure/with_density_vector_measure.lean
@@ -74,6 +74,9 @@ begin
     rwa integrable_neg_iff }
 end
 
+lemma with_densityᵥ_neg' : μ.with_densityᵥ (λ x, -f x) = -μ.with_densityᵥ f :=
+with_densityᵥ_neg
+
 @[simp] lemma with_densityᵥ_add (hf : integrable f μ) (hg : integrable g μ) :
   μ.with_densityᵥ (f + g) = μ.with_densityᵥ f + μ.with_densityᵥ g :=
 begin
@@ -86,9 +89,17 @@ begin
   { exact hg.integrable_on.restrict measurable_set.univ }
 end
 
+lemma with_densityᵥ_add' (hf : integrable f μ) (hg : integrable g μ) :
+  μ.with_densityᵥ (λ x, f x + g x) = μ.with_densityᵥ f + μ.with_densityᵥ g :=
+with_densityᵥ_add hf hg
+
 @[simp] lemma with_densityᵥ_sub (hf : integrable f μ) (hg : integrable g μ) :
   μ.with_densityᵥ (f - g) = μ.with_densityᵥ f - μ.with_densityᵥ g :=
 by rw [sub_eq_add_neg, sub_eq_add_neg, with_densityᵥ_add hf hg.neg, with_densityᵥ_neg]
+
+lemma with_densityᵥ_sub' (hf : integrable f μ) (hg : integrable g μ) :
+  μ.with_densityᵥ (λ x, f x - g x) = μ.with_densityᵥ f - μ.with_densityᵥ g :=
+with_densityᵥ_sub hf hg
 
 @[simp] lemma with_densityᵥ_smul {𝕜 : Type*} [nondiscrete_normed_field 𝕜] [normed_space 𝕜 E]
   [smul_comm_class ℝ 𝕜 E] [measurable_space 𝕜] [opens_measurable_space 𝕜] (r : 𝕜) :
@@ -104,6 +115,11 @@ begin
     { rw [with_densityᵥ, with_densityᵥ, dif_neg hf, dif_neg, smul_zero],
       rwa integrable_smul_iff hr f } }
 end
+
+lemma with_densityᵥ_smul' {𝕜 : Type*} [nondiscrete_normed_field 𝕜] [normed_space 𝕜 E]
+  [smul_comm_class ℝ 𝕜 E] [measurable_space 𝕜] [opens_measurable_space 𝕜] (r : 𝕜) :
+  μ.with_densityᵥ (λ x, r • f x) = r • μ.with_densityᵥ f :=
+with_densityᵥ_smul r
 
 lemma measure.with_densityᵥ_absolutely_continuous (μ : measure α) (f : α → ℝ) :
   μ.with_densityᵥ f ≪ μ.to_ennreal_vector_measure :=
@@ -144,6 +160,20 @@ lemma integrable.with_densityᵥ_eq_iff {f g : α → E}
 
 section signed_measure
 
+lemma with_densityᵥ_to_real {f : α → ℝ≥0∞} (hfm : ae_measurable f μ) (hf : ∫⁻ x, f x ∂μ ≠ ∞) :
+  μ.with_densityᵥ (λ x, (f x).to_real) =
+  @to_signed_measure α _ (μ.with_density f)
+    (is_finite_measure_with_density (lt_top_iff_ne_top.2 hf)) :=
+begin
+  have hfi := integrable_to_real_of_lintegral_ne_top hfm hf,
+  ext i hi,
+  rw [with_densityᵥ_apply hfi hi, to_signed_measure_apply_measurable hi,
+      with_density_apply _ hi, integral_to_real hfm.restrict],
+  refine ae_lt_top' hfm.restrict (lt_of_le_of_lt _ (lt_top_iff_ne_top.2 hf)),
+  conv_rhs { rw ← set_lintegral_univ },
+  exact lintegral_mono_set (set.subset_univ _),
+end
+
 lemma with_densityᵥ_sub_eq_with_density {f g : α → ℝ≥0∞}
   (hfm : ae_measurable f μ) (hgm : ae_measurable g μ)
   (hf : ∫⁻ x, f x ∂μ ≠ ∞) (hg : ∫⁻ x, g x ∂μ ≠ ∞) :
@@ -156,23 +186,7 @@ begin
   have hfi := integrable_to_real_of_lintegral_ne_top hfm hf,
   have hgi := integrable_to_real_of_lintegral_ne_top hgm hg,
   ext i hi,
-  rw [with_densityᵥ_apply _ hi, vector_measure.sub_apply,
-      to_signed_measure_apply_measurable hi, to_signed_measure_apply_measurable hi,
-      with_density_apply _ hi, with_density_apply _ hi, integral_sub,
-      integral_to_real hfm.restrict, integral_to_real hgm.restrict],
-  { refine ae_lt_top' hgm.restrict (lt_of_le_of_lt _ (lt_top_iff_ne_top.2 hg)),
-    conv_rhs { rw ← set_lintegral_univ },
-    exact lintegral_mono_set (set.subset_univ _) },
-  { refine ae_lt_top' hfm.restrict (lt_of_le_of_lt _ (lt_top_iff_ne_top.2 hf)),
-    conv_rhs { rw ← set_lintegral_univ },
-    exact lintegral_mono_set (set.subset_univ _) },
-  { rw ← integrable_on,
-    rw ← integrable_on_univ at hfi,
-    exact integrable_on.mono hfi (set.subset_univ _) (le_refl _) },
-  { rw ← integrable_on,
-    rw ← integrable_on_univ at hgi,
-    exact integrable_on.mono hgi (set.subset_univ _) (le_refl _) },
-  { exact hfi.sub hgi }
+  rw [with_densityᵥ_sub' hfi hgi, with_densityᵥ_to_real hfm hf, with_densityᵥ_to_real hgm hg],
 end
 
 end signed_measure

--- a/src/measure_theory/measure/with_density_vector_measure.lean
+++ b/src/measure_theory/measure/with_density_vector_measure.lean
@@ -142,4 +142,39 @@ lemma integrable.with_densityᵥ_eq_iff {f g : α → E}
   μ.with_densityᵥ f = μ.with_densityᵥ g ↔ f =ᵐ[μ] g :=
 ⟨λ hfg, hf.ae_eq_of_with_densityᵥ_eq hg hfg, λ h, with_densityᵥ_eq.congr_ae h⟩
 
+section signed_measure
+
+lemma with_densityᵥ_sub_eq_with_density {f g : α → ℝ≥0∞}
+  (hfm : ae_measurable f μ) (hgm : ae_measurable g μ)
+  (hf : ∫⁻ x, f x ∂μ ≠ ∞) (hg : ∫⁻ x, g x ∂μ ≠ ∞) :
+  μ.with_densityᵥ (λ x, (f x).to_real - (g x).to_real) =
+  @to_signed_measure α _ (μ.with_density f)
+    (is_finite_measure_with_density (lt_top_iff_ne_top.2 hf)) -
+  @to_signed_measure α _ (μ.with_density g)
+    (is_finite_measure_with_density (lt_top_iff_ne_top.2 hg)) :=
+begin
+  have hfi := integrable_to_real_of_lintegral_ne_top hfm hf,
+  have hgi := integrable_to_real_of_lintegral_ne_top hgm hg,
+  ext i hi,
+  rw [with_densityᵥ_apply _ hi, vector_measure.sub_apply,
+      to_signed_measure_apply_measurable hi, to_signed_measure_apply_measurable hi,
+      with_density_apply _ hi, with_density_apply _ hi, integral_sub,
+      integral_to_real hfm.restrict, integral_to_real hgm.restrict],
+  { refine ae_lt_top' hgm.restrict (lt_of_le_of_lt _ (lt_top_iff_ne_top.2 hg)),
+    conv_rhs { rw ← set_lintegral_univ },
+    exact lintegral_mono_set (set.subset_univ _) },
+  { refine ae_lt_top' hfm.restrict (lt_of_le_of_lt _ (lt_top_iff_ne_top.2 hf)),
+    conv_rhs { rw ← set_lintegral_univ },
+    exact lintegral_mono_set (set.subset_univ _) },
+  { rw ← integrable_on,
+    rw ← integrable_on_univ at hfi,
+    exact integrable_on.mono hfi (set.subset_univ _) (le_refl _) },
+  { rw ← integrable_on,
+    rw ← integrable_on_univ at hgi,
+    exact integrable_on.mono hgi (set.subset_univ _) (le_refl _) },
+  { exact hfi.sub hgi }
+end
+
+end signed_measure
+
 end measure_theory


### PR DESCRIPTION

---

These lemmas are useful for #9065 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
