### PR TITLE
[Merged by Bors] - feat(group_theory/p_group): p-groups are preserved by isomorphisms

### DIFF
--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -94,7 +94,7 @@ end
 
 lemma to_quotient (H : subgroup G) [H.normal] :
   is_p_group p (quotient_group.quotient H) :=
-hG.to_surjective (quotient_group.mk' H) quotient.surjective_quotient_mk'
+hG.of_surjective (quotient_group.mk' H) quotient.surjective_quotient_mk'
 
 lemma of_equiv {H : Type*} [group H] (ϕ : G ≃* H) : is_p_group p H :=
 hG.to_surjective ϕ.to_monoid_hom ϕ.surjective

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -85,7 +85,7 @@ end
 lemma to_subgroup (H : subgroup G) : is_p_group p H :=
 hG.to_injective H.subtype subtype.coe_injective
 
-lemma to_surjective {H : Type*} [group H] (ϕ : G →* H) (hϕ : function.surjective ϕ) :
+lemma of_surjective {H : Type*} [group H] (ϕ : G →* H) (hϕ : function.surjective ϕ) :
   is_p_group p H :=
 begin
   refine λ h, exists.elim (hϕ h) (λ g hg, exists_imp_exists (λ k hk, _) (hG g)),

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -83,7 +83,7 @@ begin
 end
 
 lemma to_subgroup (H : subgroup G) : is_p_group p H :=
-hG.to_injective H.subtype subtype.coe_injective
+hG.of_injective H.subtype subtype.coe_injective
 
 lemma of_surjective {H : Type*} [group H] (ϕ : G →* H) (hϕ : function.surjective ϕ) :
   is_p_group p H :=

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -75,18 +75,29 @@ variables (hG : is_p_group p G)
 
 include hG
 
-lemma to_subgroup (H : subgroup G) : is_p_group p H :=
+lemma to_injective {H : Type*} [group H] (ϕ : H →* G) (hϕ : function.injective ϕ) :
+  is_p_group p H :=
 begin
-  simp_rw [is_p_group, subtype.ext_iff, subgroup.coe_pow],
-  exact λ h, hG h,
+  simp_rw [is_p_group, ←hϕ.eq_iff, ϕ.map_pow, ϕ.map_one],
+  exact λ h, hG (ϕ h),
+end
+
+lemma to_subgroup (H : subgroup G) : is_p_group p H :=
+hG.to_injective H.subtype subtype.coe_injective
+
+lemma to_surjective {H : Type*} [group H] (ϕ : G →* H) (hϕ : function.surjective ϕ) :
+  is_p_group p H :=
+begin
+  refine λ h, exists.elim (hϕ h) (λ g hg, exists_imp_exists (λ k hk, _) (hG g)),
+  rw [←hg, ←ϕ.map_pow, hk, ϕ.map_one],
 end
 
 lemma to_quotient (H : subgroup G) [H.normal] :
   is_p_group p (quotient_group.quotient H) :=
-begin
-  refine quotient.ind' (forall_imp (λ g, _) hG),
-  exact exists_imp_exists (λ k h, (quotient_group.coe_pow H g _).symm.trans (congr_arg coe h)),
-end
+hG.to_surjective (quotient_group.mk' H) quotient.surjective_quotient_mk'
+
+lemma to_equiv {H : Type*} [group H] (ϕ : G ≃* H) : is_p_group p H :=
+hG.to_surjective ϕ.to_monoid_hom ϕ.surjective
 
 variables [hp : fact p.prime]
 

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -75,7 +75,7 @@ variables (hG : is_p_group p G)
 
 include hG
 
-lemma to_injective {H : Type*} [group H] (ϕ : H →* G) (hϕ : function.injective ϕ) :
+lemma of_injective {H : Type*} [group H] (ϕ : H →* G) (hϕ : function.injective ϕ) :
   is_p_group p H :=
 begin
   simp_rw [is_p_group, ←hϕ.eq_iff, ϕ.map_pow, ϕ.map_one],

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -96,7 +96,7 @@ lemma to_quotient (H : subgroup G) [H.normal] :
   is_p_group p (quotient_group.quotient H) :=
 hG.to_surjective (quotient_group.mk' H) quotient.surjective_quotient_mk'
 
-lemma to_equiv {H : Type*} [group H] (ϕ : G ≃* H) : is_p_group p H :=
+lemma of_equiv {H : Type*} [group H] (ϕ : G ≃* H) : is_p_group p H :=
 hG.to_surjective ϕ.to_monoid_hom ϕ.surjective
 
 variables [hp : fact p.prime]

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -97,7 +97,7 @@ lemma to_quotient (H : subgroup G) [H.normal] :
 hG.of_surjective (quotient_group.mk' H) quotient.surjective_quotient_mk'
 
 lemma of_equiv {H : Type*} [group H] (ϕ : G ≃* H) : is_p_group p H :=
-hG.to_surjective ϕ.to_monoid_hom ϕ.surjective
+hG.of_surjective ϕ.to_monoid_hom ϕ.surjective
 
 variables [hp : fact p.prime]
 

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -118,7 +118,7 @@ lemma card_orbit (a : α) [fintype (orbit G a)] :
   ∃ n : ℕ, card (orbit G a) = p ^ n :=
 begin
   let ϕ := orbit_equiv_quotient_stabilizer G a,
-  haveI := of_equiv (orbit G a) ϕ,
+  haveI := fintype.of_equiv (orbit G a) ϕ,
   rw [card_congr ϕ, ←subgroup.index_eq_card],
   exact hG.index (stabilizer G a),
 end


### PR DESCRIPTION
Adds three lemmas about transporting `is_p_group` across injective, surjective, and bijective homomorphisms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
