### PR TITLE
[Merged by Bors] - refactor(topology/category/Top/open_nhds): remove open_nhds.is_filtered

### DIFF
--- a/src/topology/category/Top/open_nhds.lean
+++ b/src/topology/category/Top/open_nhds.lean
@@ -69,12 +69,6 @@ full_subcategory_inclusion _
 lemma open_embedding {x : X} (U : open_nhds x) : open_embedding (U.1.inclusion) :=
 U.1.open_embedding
 
-instance open_nhds_is_filtered (x : X) : is_filtered (open_nhds x)ᵒᵖ :=
-{ nonempty := ⟨op ⊤⟩,
-  cocone_objs := λ U V, ⟨op (unop U ⊓ unop V),
-    (inf_le_left (unop U) (unop V)).op, (inf_le_right (unop U) (unop V)).op, trivial⟩ ,
-  cocone_maps := λ U V i j, ⟨V, 𝟙 V, rfl⟩, }
-
 def map (x : X) : open_nhds (f x) ⥤ open_nhds x :=
 { obj := λ U, ⟨(opens.map f).obj U.1, by tidy⟩,
   map := λ U V i, (opens.map f).map i }


### PR DESCRIPTION
Remove instance that can be inferred automatically.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This can be inferred automatically, since we have:
- category_theory.is_filtered_op_of_is_cofiltered
- category_theory.is_cofiltered_of_semilattice_inf_nonempty 
- lattice.to_semilattice_inf
- open_nhds.lattice

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
