### PR TITLE
[Merged by Bors] - feat(measure_theory/measure/with_density_vector_measure): `with_densityᵥ` of a real function equals the density of the pos part - density of the neg part

### DIFF
--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -1371,6 +1371,18 @@ module.punctured_nhds_ne_bot ℝ E x
 
 end real
 
+namespace ennreal
+
+lemma of_real_le_ennnorm (r : ℝ) : ennreal.of_real r ≤ ∥r∥₊ :=
+begin
+  by_cases hr : 0 ≤ r,
+  { rw real.ennnorm_eq_of_real hr, refl' },
+  { rw [ennreal.of_real_eq_zero.2 (le_of_lt (not_le.1 hr))],
+    exact bot_le }
+end
+
+end ennreal
+
 namespace nnreal
 
 open_locale nnreal

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -1369,19 +1369,15 @@ instance punctured_nhds_module_ne_bot
   ne_bot (𝓝[{x}ᶜ] x) :=
 module.punctured_nhds_ne_bot ℝ E x
 
-end real
-
-namespace ennreal
-
-lemma of_real_le_ennnorm (r : ℝ) : ennreal.of_real r ≤ ∥r∥₊ :=
+lemma of_real_le_ennnorm (x : ℝ) : ennreal.of_real x ≤ ∥x∥₊ :=
 begin
-  by_cases hr : 0 ≤ r,
-  { rw real.ennnorm_eq_of_real hr, refl' },
-  { rw [ennreal.of_real_eq_zero.2 (le_of_lt (not_le.1 hr))],
+  by_cases hx : 0 ≤ x,
+  { rw real.ennnorm_eq_of_real hx, refl' },
+  { rw [ennreal.of_real_eq_zero.2 (le_of_lt (not_le.1 hx))],
     exact bot_le }
 end
 
-end ennreal
+end real
 
 namespace nnreal
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -1361,14 +1361,6 @@ nnreal.eq $ norm_of_nonneg hx
 lemma ennnorm_eq_of_real {x : ℝ} (hx : 0 ≤ x) : (∥x∥₊ : ℝ≥0∞) = ennreal.of_real x :=
 by { rw [← of_real_norm_eq_coe_nnnorm, norm_of_nonneg hx] }
 
-/-- If `E` is a nontrivial topological module over `ℝ`, then `E` has no isolated points.
-This is a particular case of `module.punctured_nhds_ne_bot`. -/
-instance punctured_nhds_module_ne_bot
-  {E : Type*} [add_comm_group E] [topological_space E] [has_continuous_add E] [nontrivial E]
-  [module ℝ E] [has_continuous_smul ℝ E] (x : E) :
-  ne_bot (𝓝[{x}ᶜ] x) :=
-module.punctured_nhds_ne_bot ℝ E x
-
 lemma of_real_le_ennnorm (x : ℝ) : ennreal.of_real x ≤ ∥x∥₊ :=
 begin
   by_cases hx : 0 ≤ x,
@@ -1376,6 +1368,14 @@ begin
   { rw [ennreal.of_real_eq_zero.2 (le_of_lt (not_le.1 hx))],
     exact bot_le }
 end
+
+/-- If `E` is a nontrivial topological module over `ℝ`, then `E` has no isolated points.
+This is a particular case of `module.punctured_nhds_ne_bot`. -/
+instance punctured_nhds_module_ne_bot
+  {E : Type*} [add_comm_group E] [topological_space E] [has_continuous_add E] [nontrivial E]
+  [module ℝ E] [has_continuous_smul ℝ E] (x : E) :
+  ne_bot (𝓝[{x}ᶜ] x) :=
+module.punctured_nhds_ne_bot ℝ E x
 
 end real
 

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -227,7 +227,7 @@ has_finite_integral_congr' $ eventually_of_forall $ λ x, norm_norm (f x)
 lemma is_finite_measure_with_density_of_real {f : α → ℝ} (hfi : has_finite_integral f μ) :
   is_finite_measure (μ.with_density (λ x, ennreal.of_real $ f x)) :=
 is_finite_measure_with_density $
-  lt_of_le_of_lt (lintegral_mono $ λ x,ennreal.of_real_le_ennnorm _) hfi
+  lt_of_le_of_lt (lintegral_mono $ λ x,real.of_real_le_ennnorm _) hfi
 
 section dominated_convergence
 

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -224,6 +224,11 @@ lemma has_finite_integral_norm_iff (f : α → β) :
   has_finite_integral (λa, ∥f a∥) μ ↔ has_finite_integral f μ :=
 has_finite_integral_congr' $ eventually_of_forall $ λ x, norm_norm (f x)
 
+lemma is_finite_measure_with_density_of_real {f : α → ℝ} (hfi : has_finite_integral f μ) :
+  is_finite_measure (μ.with_density (λ x, ennreal.of_real $ f x)) :=
+is_finite_measure_with_density $
+  lt_of_le_of_lt (lintegral_mono $ λ x,ennreal.of_real_le_ennnorm _) hfi
+
 section dominated_convergence
 
 variables {F : ℕ → α → β} {f : α → β} {bound : α → ℝ}

--- a/src/measure_theory/measure/with_density_vector_measure.lean
+++ b/src/measure_theory/measure/with_density_vector_measure.lean
@@ -142,4 +142,24 @@ lemma integrable.with_densityᵥ_eq_iff {f g : α → E}
   μ.with_densityᵥ f = μ.with_densityᵥ g ↔ f =ᵐ[μ] g :=
 ⟨λ hfg, hf.ae_eq_of_with_densityᵥ_eq hg hfg, λ h, with_densityᵥ_eq.congr_ae h⟩
 
+section signed_measure
+
+lemma with_densityᵥ_eq_with_density_pos_part_sub_with_density_neg_part
+  {f : α → ℝ} (hfi : integrable f μ) :
+  μ.with_densityᵥ f =
+  @to_signed_measure α _ (μ.with_density (λ x, ennreal.of_real $ f x))
+    (is_finite_measure_with_density_of_real hfi.2) -
+  @to_signed_measure α _ (μ.with_density (λ x, ennreal.of_real $ -f x))
+    (is_finite_measure_with_density_of_real hfi.neg.2) :=
+begin
+  ext i hi,
+  rw [with_densityᵥ_apply hfi hi, integral_eq_lintegral_pos_part_sub_lintegral_neg_part,
+      vector_measure.sub_apply, to_signed_measure_apply_measurable hi,
+      to_signed_measure_apply_measurable hi, with_density_apply _ hi, with_density_apply _ hi],
+  rw ← integrable_on_univ at hfi ⊢,
+  exact hfi.restrict measurable_set.univ
+end
+
+end signed_measure
+
 end measure_theory

--- a/src/measure_theory/measure/with_density_vector_measure.lean
+++ b/src/measure_theory/measure/with_density_vector_measure.lean
@@ -153,11 +153,10 @@ lemma with_densityᵥ_eq_with_density_pos_part_sub_with_density_neg_part
     (is_finite_measure_with_density_of_real hfi.neg.2) :=
 begin
   ext i hi,
-  rw [with_densityᵥ_apply hfi hi, integral_eq_lintegral_pos_part_sub_lintegral_neg_part,
+  rw [with_densityᵥ_apply hfi hi,
+      integral_eq_lintegral_pos_part_sub_lintegral_neg_part hfi.integrable_on,
       vector_measure.sub_apply, to_signed_measure_apply_measurable hi,
       to_signed_measure_apply_measurable hi, with_density_apply _ hi, with_density_apply _ hi],
-  rw ← integrable_on_univ at hfi ⊢,
-  exact hfi.restrict measurable_set.univ
 end
 
 end signed_measure


### PR DESCRIPTION

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
