### PR TITLE
[Merged by Bors] - chore(set_theory/cardinal): use notation `#`, add notation `ω`

### DIFF
--- a/archive/100-theorems-list/82_cubing_a_cube.lean
+++ b/archive/100-theorems-list/82_cubing_a_cube.lean
@@ -518,7 +518,7 @@ end
 theorem cannot_cube_a_cube :
   ∀{n : ℕ}, n ≥ 3 →                              -- In ℝ^n for n ≥ 3
   ∀{ι : Type} [fintype ι] {cs : ι → cube n},     -- given a finite collection of (hyper)cubes
-  2 ≤ #ι            →                            -- containing at least two elements
+  2 ≤ #ι →                                       -- containing at least two elements
   pairwise (disjoint on (cube.to_set ∘ cs)) →    -- which is pairwise disjoint
   (⋃(i : ι), (cs i).to_set) = unit_cube.to_set → -- whose union is the unit cube
   injective (cube.w ∘ cs) →                      -- such that the widths of all cubes are different

--- a/archive/100-theorems-list/82_cubing_a_cube.lean
+++ b/archive/100-theorems-list/82_cubing_a_cube.lean
@@ -18,6 +18,7 @@ http://www.alaricstephen.com/main-featured/2017/9/28/cubing-a-cube-proof
 
 
 open real set function fin
+open_locale cardinal
 
 noncomputable theory
 
@@ -125,7 +126,7 @@ def correct (cs : ι → cube n) : Prop :=
 pairwise (disjoint on (cube.to_set ∘ cs)) ∧
 (⋃(i : ι), (cs i).to_set) = unit_cube.to_set ∧
 injective (cube.w ∘ cs) ∧
-2 ≤ cardinal.mk ι ∧
+2 ≤ #ι ∧
 3 ≤ n
 
 variable (h : correct cs)
@@ -261,7 +262,7 @@ end
 
 open cardinal
 /-- There are at least two cubes in a valley -/
-lemma two_le_mk_bcubes : 2 ≤ cardinal.mk (bcubes cs c) :=
+lemma two_le_mk_bcubes : 2 ≤ #(bcubes cs c) :=
 begin
   rw [two_le_iff],
   rcases v.1 c.b_mem_bottom with ⟨_, ⟨i, rfl⟩, hi⟩,
@@ -517,7 +518,7 @@ end
 theorem cannot_cube_a_cube :
   ∀{n : ℕ}, n ≥ 3 →                              -- In ℝ^n for n ≥ 3
   ∀{ι : Type} [fintype ι] {cs : ι → cube n},     -- given a finite collection of (hyper)cubes
-  2 ≤ cardinal.mk ι →                            -- containing at least two elements
+  2 ≤ #ι            →                            -- containing at least two elements
   pairwise (disjoint on (cube.to_set ∘ cs)) →    -- which is pairwise disjoint
   (⋃(i : ι), (cs i).to_set) = unit_cube.to_set → -- whose union is the unit cube
   injective (cube.w ∘ cs) →                      -- such that the widths of all cubes are different

--- a/src/category_theory/limits/small_complete.lean
+++ b/src/category_theory/limits/small_complete.lean
@@ -28,6 +28,7 @@ small complete, preorder, Freyd
 namespace category_theory
 
 open category limits
+open_locale cardinal
 
 universe u
 
@@ -45,14 +46,14 @@ instance {X Y : C} : subsingleton (X ⟶ Y) :=
 begin
   classical,
   by_contra r_ne_s,
-  have z : (2 : cardinal) ≤ cardinal.mk (X ⟶ Y),
+  have z : (2 : cardinal) ≤ #(X ⟶ Y),
   { rw cardinal.two_le_iff,
     exact ⟨_, _, r_ne_s⟩ },
   let md := Σ (Z W : C), Z ⟶ W,
-  let α := cardinal.mk md,
+  let α := #md,
   apply not_le_of_lt (cardinal.cantor α),
   let yp : C := ∏ (λ (f : md), Y),
-  transitivity (cardinal.mk (X ⟶ yp)),
+  transitivity (#(X ⟶ yp)),
   { apply le_trans (cardinal.power_le_power_right z),
     rw cardinal.power_def,
     apply le_of_eq,

--- a/src/data/rat/denumerable.lean
+++ b/src/data/rat/denumerable.lean
@@ -37,7 +37,9 @@ end
 end rat
 
 namespace cardinal
-lemma mk_rat : cardinal.mk ℚ = omega :=
+
+open_locale cardinal
+lemma mk_rat : #ℚ = ω :=
 denumerable_iff.mp ⟨by apply_instance⟩
 
 end cardinal

--- a/src/field_theory/finite/polynomial.lean
+++ b/src/field_theory/finite/polynomial.lean
@@ -140,7 +140,7 @@ end mv_polynomial
 
 namespace mv_polynomial
 
-open_locale classical
+open_locale classical cardinal
 open linear_map submodule
 
 universe u
@@ -158,20 +158,20 @@ calc module.rank K (R σ K) =
   module.rank K (↥{s : σ →₀ ℕ | ∀ (n : σ), s n ≤ fintype.card K - 1} →₀ K) :
     linear_equiv.dim_eq
       (finsupp.supported_equiv_finsupp {s : σ →₀ ℕ | ∀n:σ, s n ≤ fintype.card K - 1 })
-  ... = cardinal.mk {s : σ →₀ ℕ | ∀ (n : σ), s n ≤ fintype.card K - 1} :
+  ... = #{s : σ →₀ ℕ | ∀ (n : σ), s n ≤ fintype.card K - 1} :
     by rw [finsupp.dim_eq, dim_self, mul_one]
-  ... = cardinal.mk {s : σ → ℕ | ∀ (n : σ), s n < fintype.card K } :
+  ... = #{s : σ → ℕ | ∀ (n : σ), s n < fintype.card K } :
   begin
     refine quotient.sound ⟨equiv.subtype_equiv finsupp.equiv_fun_on_fintype $ assume f, _⟩,
     refine forall_congr (assume n, nat.le_sub_right_iff_add_le _),
     exact fintype.card_pos_iff.2 ⟨0⟩
   end
-  ... = cardinal.mk (σ → {n // n < fintype.card K}) :
-    quotient.sound ⟨@equiv.subtype_pi_equiv_pi σ (λ_, ℕ) (λs n, n < fintype.card K)⟩
-  ... = cardinal.mk (σ → fin (fintype.card K)) :
-    quotient.sound ⟨equiv.arrow_congr (equiv.refl σ) (equiv.fin_equiv_subtype _).symm⟩
-  ... = cardinal.mk (σ → K) :
-    quotient.sound ⟨equiv.arrow_congr (equiv.refl σ) (fintype.equiv_fin K).symm⟩
+  ... = #(σ → {n // n < fintype.card K}) :
+    (@equiv.subtype_pi_equiv_pi σ (λ_, ℕ) (λs n, n < fintype.card K)).cardinal_eq
+  ... = #(σ → fin (fintype.card K)) :
+    (equiv.arrow_congr (equiv.refl σ) (equiv.fin_equiv_subtype _).symm).cardinal_eq
+  ... = #(σ → K) :
+    (equiv.arrow_congr (equiv.refl σ) (fintype.equiv_fin K).symm).cardinal_eq
   ... = fintype.card (σ → K) : cardinal.fintype_card _
 
 instance : finite_dimensional K (R σ K) :=

--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -58,7 +58,7 @@ variables {H} {K : subgroup G}
 
 @[to_additive] lemma index_eq_mul_of_le (h : H ≤ K) :
   H.index = K.index * (H.subgroup_of K).index :=
-(congr_arg cardinal.to_nat (by exact cardinal.eq_congr (quotient_equiv_prod_of_le h))).trans
+(congr_arg cardinal.to_nat (by exact (quotient_equiv_prod_of_le h).cardinal_eq)).trans
   (cardinal.to_nat_mul _ _)
 
 @[to_additive] lemma index_dvd_of_le (h : H ≤ K) : K.index ∣ H.index :=

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -78,7 +78,7 @@ universes u v v' v'' u₁' w w'
 variables {K : Type u} {V V₁ V₂ V₃ : Type v} {V' V'₁ : Type v'} {V'' : Type v''}
 variables {ι : Type w} {ι' : Type w'} {η : Type u₁'} {φ : η → Type*}
 
-open_locale classical big_operators
+open_locale classical big_operators cardinal
 
 open basis submodule function set
 
@@ -104,8 +104,7 @@ The definition is marked as protected to avoid conflicts with `_root_.rank`,
 the rank of a linear map.
 -/
 protected def module.rank : cardinal :=
-cardinal.sup.{v v}
-  (λ ι : {s : set V // linear_independent K (coe : s → V)}, cardinal.mk ι.1)
+cardinal.sup.{v v} (λ ι : {s : set V // linear_independent K (coe : s → V)}, #ι.1)
 
 end
 
@@ -235,7 +234,7 @@ variables [nontrivial R]
 
 lemma {m} cardinal_lift_le_dim_of_linear_independent
   {ι : Type w} {v : ι → M} (hv : linear_independent R v) :
-  cardinal.lift.{w (max v m)} (cardinal.mk ι) ≤ cardinal.lift.{v (max w m)} (module.rank R M) :=
+  cardinal.lift.{w (max v m)} (#ι) ≤ cardinal.lift.{v (max w m)} (module.rank R M) :=
 begin
   apply le_trans,
   { exact cardinal.lift_mk_le.mpr
@@ -249,12 +248,12 @@ end
 
 lemma cardinal_le_dim_of_linear_independent
   {ι : Type v} {v : ι → M} (hv : linear_independent R v) :
-  cardinal.mk ι ≤ module.rank R M :=
+  #ι ≤ module.rank R M :=
 by simpa using cardinal_lift_le_dim_of_linear_independent hv
 
 lemma cardinal_le_dim_of_linear_independent'
   {s : set M} (hs : linear_independent R (λ x, x : s → M)) :
-  cardinal.mk s ≤ module.rank R M :=
+  #s ≤ module.rank R M :=
 cardinal_le_dim_of_linear_independent hs
 
 variables (R M)
@@ -395,14 +394,14 @@ then the cardinality of `b` is bounded by the cardinality of `s`.
 lemma infinite_basis_le_maximal_linear_independent'
   {ι : Type w} (b : basis ι R M) [infinite ι]
   {κ : Type w'} (v : κ → M) (i : linear_independent R v) (m : i.maximal) :
-  cardinal.lift.{w w'} (cardinal.mk ι) ≤ cardinal.lift.{w' w} (cardinal.mk κ) :=
+  cardinal.lift.{w w'} (#ι) ≤ cardinal.lift.{w' w} (#κ) :=
 begin
   let Φ := λ k : κ, (b.repr (v k)).support,
-  have w₁ : cardinal.mk ι ≤ cardinal.mk (set.range Φ),
+  have w₁ : #ι ≤ #(set.range Φ),
   { apply cardinal.le_range_of_union_finset_eq_top,
     exact union_support_maximal_linear_independent_eq_range_basis b v i m, },
   have w₂ :
-    cardinal.lift.{w w'} (cardinal.mk (set.range Φ)) ≤ cardinal.lift.{w' w} (cardinal.mk κ) :=
+    cardinal.lift.{w w'} (#(set.range Φ)) ≤ cardinal.lift.{w' w} (#κ) :=
     cardinal.mk_range_le_lift,
   exact (cardinal.lift_le.mpr w₁).trans w₂,
 end
@@ -417,7 +416,7 @@ then the cardinality of `b` is bounded by the cardinality of `s`.
 lemma infinite_basis_le_maximal_linear_independent
   {ι : Type w} (b : basis ι R M) [infinite ι]
   {κ : Type w} (v : κ → M) (i : linear_independent R v) (m : i.maximal) :
-  cardinal.mk ι ≤ cardinal.mk κ :=
+  #ι ≤ #κ :=
 cardinal.lift_le.mp (infinite_basis_le_maximal_linear_independent' b v i m)
 
 end
@@ -430,9 +429,9 @@ variables {M : Type v} [add_comm_group M] [module R M]
 /-- The dimension theorem: if `v` and `v'` are two bases, their index types
 have the same cardinalities. -/
 theorem mk_eq_mk_of_basis (v : basis ι R M) (v' : basis ι' R M) :
-  cardinal.lift.{w w'} (cardinal.mk ι) = cardinal.lift.{w' w} (cardinal.mk ι') :=
+  cardinal.lift.{w w'} (#ι) = cardinal.lift.{w' w} (#ι') :=
 begin
-  by_cases h : cardinal.mk ι < cardinal.omega,
+  by_cases h : #ι < ω,
   { -- `v` is a finite basis, so by `basis_fintype_of_finite_spans` so is `v'`.
     haveI : fintype ι := (cardinal.lt_omega_iff_fintype.mp h).some,
     haveI : fintype (range v) := set.fintype_range ⇑v,
@@ -464,7 +463,7 @@ begin
 end
 
 theorem mk_eq_mk_of_basis' {ι' : Type w} (v : basis ι R M) (v' : basis ι' R M) :
-  cardinal.mk ι = cardinal.mk ι' :=
+  #ι = #ι' :=
 cardinal.lift_inj.1 $ mk_eq_mk_of_basis v v'
 
 end invariant_basis_number
@@ -504,7 +503,7 @@ but still assumes we have a finite spanning set.
 -/
 lemma basis_le_span' {ι : Type*} (b : basis ι R M)
   {w : set M} [fintype w] (s : span R w = ⊤) :
-  cardinal.mk ι ≤ fintype.card w :=
+  #ι ≤ fintype.card w :=
 begin
   haveI := basis_fintype_of_finite_spans w s b,
   rw cardinal.fintype_card ι,
@@ -519,9 +518,9 @@ then the cardinality of any basis is bounded by the cardinality of any spanning 
 -- Note that if `R` satisfies the strong rank condition,
 -- this also follows from `linear_independent_le_span` below.
 theorem basis.le_span {J : set M} (v : basis ι R M)
-   (hJ : span R J = ⊤) : cardinal.mk (range v) ≤ cardinal.mk J :=
+   (hJ : span R J = ⊤) : #(range v) ≤ #J :=
 begin
-  cases le_or_lt cardinal.omega (cardinal.mk J) with oJ oJ,
+  cases le_or_lt ω (#J) with oJ oJ,
   { have := cardinal.mk_range_eq_of_injective v.injective,
     let S : J → set ι := λ j, ↑(v.repr j).support,
     let S' : J → set M := λ j, v '' S j,
@@ -539,7 +538,7 @@ begin
         exact mem_Union.2 ⟨j, (mem_image _ _ _).2 ⟨i, hj, rfl⟩⟩ },
       { apply_instance } },
     refine le_of_not_lt (λ IJ, _),
-    suffices : cardinal.mk (⋃ j, S' j) < cardinal.mk (range v),
+    suffices : #(⋃ j, S' j) < #(range v),
     { exact not_le_of_lt this ⟨set.embedding_of_subset _ _ hs⟩ },
     refine lt_of_le_of_lt (le_trans cardinal.mk_Union_le_sum_mk
       (cardinal.sum_le_sum _ (λ _, cardinal.omega) _)) _,
@@ -605,7 +604,7 @@ the cardinality of `ι` is bounded by the cardinality of `w`.
 -/
 lemma linear_independent_le_span' {ι : Type*} (v : ι → M) (i : linear_independent R v)
   (w : set M) [fintype w] (s : range v ≤ span R w) :
-  cardinal.mk ι ≤ fintype.card w :=
+  #ι ≤ fintype.card w :=
 begin
   haveI : fintype ι := linear_independent_fintype_of_le_span_fintype v i w s,
   rw cardinal.fintype_card,
@@ -621,7 +620,7 @@ the cardinality of `ι` is bounded by the cardinality of `w`.
 -/
 lemma linear_independent_le_span {ι : Type*} (v : ι → M) (i : linear_independent R v)
   (w : set M) [fintype w] (s : span R w = ⊤) :
-  cardinal.mk ι ≤ fintype.card w :=
+  #ι ≤ fintype.card w :=
 begin
   apply linear_independent_le_span' v i w,
   rw s,
@@ -635,11 +634,11 @@ we handle the case where the basis `b` is infinite.
 lemma linear_independent_le_infinite_basis
   {ι : Type*} (b : basis ι R M) [infinite ι]
   {κ : Type*} (v : κ → M) (i : linear_independent R v) :
-  cardinal.mk κ ≤ cardinal.mk ι :=
+  #κ ≤ #ι :=
 begin
   by_contradiction,
   simp only [not_le] at h,
-  have w : cardinal.mk (finset ι) = cardinal.mk ι :=
+  have w : #(finset ι) = #ι :=
     cardinal.mk_finset_eq_mk (cardinal.infinite_iff.mp ‹infinite ι›),
   rw ←w at h,
   let Φ := λ k : κ, (b.repr (v k)).support,
@@ -664,7 +663,7 @@ then the cardinality of `s` is bounded by the cardinality of `b`.
 lemma linear_independent_le_basis
   {ι : Type*} (b : basis ι R M)
   {κ : Type*} (v : κ → M) (i : linear_independent R v) :
-  cardinal.mk κ ≤ cardinal.mk ι :=
+  #κ ≤ #ι :=
 begin
   -- We split into cases depending on whether `ι` is infinite.
   cases fintype_or_infinite ι; resetI,
@@ -689,7 +688,7 @@ This proof (along with some of the lemmas above) comes from
 lemma maximal_linear_independent_eq_infinite_basis
   {ι : Type*} (b : basis ι R M) [infinite ι]
   {κ : Type*} (v : κ → M) (i : linear_independent R v) (m : i.maximal) :
-  cardinal.mk κ = cardinal.mk ι :=
+  #κ = #ι :=
 begin
   apply le_antisymm,
   { exact linear_independent_le_basis b v i, },
@@ -700,14 +699,14 @@ end
 variables [nontrivial R]
 
 theorem basis.mk_eq_dim'' {ι : Type v} (v : basis ι R M) :
-  cardinal.mk ι = module.rank R M :=
+  #ι = module.rank R M :=
 begin
   apply le_antisymm,
   { transitivity,
     swap,
     apply cardinal.le_sup,
     exact ⟨set.range v, by { convert v.reindex_range.linear_independent, ext, simp }⟩,
-    exact (cardinal.eq_congr (equiv.of_injective v v.injective)).le, },
+    exact (cardinal.mk_range_eq v v.injective).ge, },
   { apply cardinal.sup_le.mpr,
     rintro ⟨s, li⟩,
     apply linear_independent_le_basis v _ li, },
@@ -718,7 +717,7 @@ end
 attribute [irreducible] module.rank
 
 theorem basis.mk_range_eq_dim (v : basis ι R M) :
-  cardinal.mk (range v) = module.rank R M :=
+  #(range v) = module.rank R M :=
 v.reindex_range.mk_eq_dim''
 
 /-- If a vector space has a finite basis, then its dimension (seen as a cardinal) is equal to the
@@ -729,11 +728,11 @@ by rw [←h.mk_range_eq_dim, cardinal.fintype_card,
        set.card_range_of_injective h.injective]
 
 theorem basis.mk_eq_dim (v : basis ι R M) :
-  cardinal.lift.{w v} (cardinal.mk ι) = cardinal.lift.{v w} (module.rank R M) :=
+  cardinal.lift.{w v} (#ι) = cardinal.lift.{v w} (module.rank R M) :=
 by rw [←v.mk_range_eq_dim, cardinal.mk_range_eq_of_injective v.injective]
 
 theorem {m} basis.mk_eq_dim' (v : basis ι R M) :
-  cardinal.lift.{w (max v m)} (cardinal.mk ι) = cardinal.lift.{v (max w m)} (module.rank R M) :=
+  cardinal.lift.{w (max v m)} (#ι) = cardinal.lift.{v (max w m)} (module.rank R M) :=
 by simpa using v.mk_eq_dim
 
 /-- If a module has a finite dimension, all bases are indexed by a finite type. -/
@@ -758,12 +757,12 @@ lemma basis.finite_index_of_dim_lt_omega {ι : Type*} {s : set ι}
 b.nonempty_fintype_index_of_dim_lt_omega h
 
 lemma dim_span {v : ι → M} (hv : linear_independent R v) :
-  module.rank R ↥(span R (range v)) = cardinal.mk (range v) :=
+  module.rank R ↥(span R (range v)) = #(range v) :=
 by rw [←cardinal.lift_inj, ← (basis.span hv).mk_eq_dim,
     cardinal.mk_range_eq_of_injective (@linear_independent.injective ι R M v _ _ _ _ hv)]
 
 lemma dim_span_set {s : set M} (hs : linear_independent R (λ x, x : s → M)) :
-  module.rank R ↥(span R s) = cardinal.mk s :=
+  module.rank R ↥(span R s) = #s :=
 by { rw [← @set_of_mem_eq _ s, ← subtype.range_coe_subtype], exact dim_span hs }
 
 variables (R)
@@ -791,7 +790,7 @@ theorem nonempty_linear_equiv_of_lift_dim_eq
 begin
   let B := basis.of_vector_space K V,
   let B' := basis.of_vector_space K V',
-  have : cardinal.lift.{v v'} (cardinal.mk _) = cardinal.lift.{v' v} (cardinal.mk _),
+  have : cardinal.lift.{v v'} (#_) = cardinal.lift.{v' v} (#_),
     by rw [B.mk_eq_dim'', cond, B'.mk_eq_dim''],
   exact (cardinal.lift_mk_eq.{v v' 0}.1 this).map (B.equiv B')
 end
@@ -831,7 +830,7 @@ theorem linear_equiv.nonempty_equiv_iff_dim_eq :
 -- TODO how far can we generalise this?
 -- When `s` is finite, we could prove this for any ring satisfying the strong rank condition
 -- using `linear_independent_le_span'`
-lemma dim_span_le (s : set V) : module.rank K (span K s) ≤ cardinal.mk s :=
+lemma dim_span_le (s : set V) : module.rank K (span K s) ≤ #s :=
 begin
   classical,
   rcases
@@ -845,7 +844,7 @@ end
 
 lemma dim_span_of_finset (s : finset V) :
   module.rank K (span K (↑s : set V)) < cardinal.omega :=
-calc module.rank K (span K (↑s : set V)) ≤ cardinal.mk (↑s : set V) : dim_span_le ↑s
+calc module.rank K (span K (↑s : set V)) ≤ #(↑s : set V) : dim_span_le ↑s
                              ... = s.card : by rw [cardinal.finset_card, finset.coe_sort_coe]
                              ... < cardinal.omega : cardinal.nat_lt_omega _
 
@@ -1092,7 +1091,7 @@ end
 rfl
 
 lemma le_dim_iff_exists_linear_independent {c : cardinal} :
-  c ≤ module.rank K V ↔ ∃ s : set V, cardinal.mk s = c ∧ linear_independent K (coe : s → V) :=
+  c ≤ module.rank K V ↔ ∃ s : set V, #s = c ∧ linear_independent K (coe : s → V) :=
 begin
   split,
   { intro h,
@@ -1118,7 +1117,7 @@ end
 
 lemma le_rank_iff_exists_linear_independent {c : cardinal} {f : V →ₗ[K] V'} :
   c ≤ rank f ↔
-  ∃ s : set V, cardinal.lift.{v v'} (cardinal.mk s) = cardinal.lift.{v' v} c ∧
+  ∃ s : set V, cardinal.lift.{v v'} (#s) = cardinal.lift.{v' v} c ∧
     linear_independent K (λ x : s, f x) :=
 begin
   rcases f.range_restrict.exists_right_inverse_of_surjective f.range_range_restrict with ⟨g, hg⟩,

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -79,7 +79,7 @@ equivalence is proved in `submodule.fg_iff_finite_dimensional`.
 -/
 
 universes u v v' w
-open_locale classical
+open_locale classical cardinal
 
 open cardinal submodule module function
 
@@ -196,7 +196,7 @@ end
 /-- If a vector space is finite-dimensional, then the cardinality of any basis is equal to its
 `finrank`. -/
 lemma finrank_eq_card_basis' [finite_dimensional K V] {ι : Type w} (h : basis ι K V) :
-  (finrank K V : cardinal.{w}) = cardinal.mk ι :=
+  (finrank K V : cardinal.{w}) = #ι :=
 begin
   haveI : fintype ι := fintype_basis_index h,
   rw [cardinal.fintype_card, finrank_eq_card_basis h]
@@ -240,7 +240,7 @@ lemma basis_unique.repr_eq_zero_iff {ι : Type*} [unique ι] {h : finrank K V = 
 
 lemma cardinal_mk_le_finrank_of_linear_independent
   [finite_dimensional K V] {ι : Type w} {b : ι → V} (h : linear_independent K b) :
-  cardinal.mk ι ≤ finrank K V :=
+  #ι ≤ finrank K V :=
 begin
   rw ← lift_le.{_ (max v w)},
   simpa [← finrank_eq_dim K V] using
@@ -262,7 +262,7 @@ end
 
 lemma lt_omega_of_linear_independent {ι : Type w} [finite_dimensional K V]
   {v : ι → V} (h : linear_independent K v) :
-  cardinal.mk ι < cardinal.omega :=
+  #ι < cardinal.omega :=
 begin
   apply cardinal.lift_lt.1,
   apply lt_of_le_of_lt,
@@ -275,8 +275,8 @@ lemma not_linear_independent_of_infinite {ι : Type w} [inf : infinite ι] [fini
   (v : ι → V) : ¬ linear_independent K v :=
 begin
   intro h_lin_indep,
-  have : ¬ omega ≤ mk ι := not_le.mpr (lt_omega_of_linear_independent h_lin_indep),
-  have : omega ≤ mk ι := infinite_iff.mp inf,
+  have : ¬ omega ≤ #ι := not_le.mpr (lt_omega_of_linear_independent h_lin_indep),
+  have : omega ≤ #ι := infinite_iff.mp inf,
   contradiction
 end
 
@@ -1075,7 +1075,7 @@ lemma finrank_span_le_card (s : set V) [fin : fintype s] :
   finrank K (span K s) ≤ s.to_finset.card :=
 begin
   haveI := span_of_finite K ⟨fin⟩,
-  have : module.rank K (span K s) ≤ (mk s : cardinal) := dim_span_le s,
+  have : module.rank K (span K s) ≤ #s := dim_span_le s,
   rw [←finrank_eq_dim, cardinal.fintype_card, ←set.to_finset_card] at this,
   exact_mod_cast this
 end
@@ -1090,7 +1090,7 @@ lemma finrank_span_eq_card {ι : Type*} [fintype ι] {b : ι → V}
   finrank K (span K (set.range b)) = fintype.card ι :=
 begin
   haveI : finite_dimensional K (span K (set.range b)) := span_of_finite K (set.finite_range b),
-  have : module.rank K (span K (set.range b)) = (mk (set.range b) : cardinal) := dim_span hb,
+  have : module.rank K (span K (set.range b)) = #(set.range b) := dim_span hb,
   rwa [←finrank_eq_dim, ←lift_inj, mk_range_eq_of_injective hb.injective,
     cardinal.fintype_card, lift_nat_cast, lift_nat_cast, nat_cast_inj] at this,
 end
@@ -1100,7 +1100,7 @@ lemma finrank_span_set_eq_card (s : set V) [fin : fintype s]
   finrank K (span K s) = s.to_finset.card :=
 begin
   haveI := span_of_finite K ⟨fin⟩,
-  have : module.rank K (span K s) = (mk s : cardinal) := dim_span_set hs,
+  have : module.rank K (span K s) = #s := dim_span_set hs,
   rw [←finrank_eq_dim, cardinal.fintype_card, ←set.to_finset_card] at this,
   exact_mod_cast this
 end

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -262,7 +262,7 @@ end
 
 lemma lt_omega_of_linear_independent {ι : Type w} [finite_dimensional K V]
   {v : ι → V} (h : linear_independent K v) :
-  #ι < cardinal.omega :=
+  #ι < ω :=
 begin
   apply cardinal.lift_lt.1,
   apply lt_of_le_of_lt,
@@ -275,8 +275,8 @@ lemma not_linear_independent_of_infinite {ι : Type w} [inf : infinite ι] [fini
   (v : ι → V) : ¬ linear_independent K v :=
 begin
   intro h_lin_indep,
-  have : ¬ omega ≤ #ι := not_le.mpr (lt_omega_of_linear_independent h_lin_indep),
-  have : omega ≤ #ι := infinite_iff.mp inf,
+  have : ¬ ω ≤ #ι := not_le.mpr (lt_omega_of_linear_independent h_lin_indep),
+  have : ω ≤ #ι := infinite_iff.mp inf,
   contradiction
 end
 

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -28,6 +28,7 @@ noncomputable theory
 local attribute [instance, priority 100] classical.prop_decidable
 
 open set linear_map submodule
+open_locale cardinal
 
 namespace finsupp
 
@@ -123,7 +124,7 @@ universes u v
 variables {K : Type u} {V : Type v} {ι : Type v}
 variables [field K] [add_comm_group V] [module K V]
 
-lemma dim_eq : module.rank K (ι →₀ V) = cardinal.mk ι * module.rank K V :=
+lemma dim_eq : module.rank K (ι →₀ V) = #ι * module.rank K V :=
 begin
   let bs := basis.of_vector_space K V,
   rw [← cardinal.lift_inj, cardinal.lift_mul, ← bs.mk_eq_dim,
@@ -195,17 +196,17 @@ open module
 variables (K V : Type u) [field K] [add_comm_group V] [module K V]
 
 lemma cardinal_mk_eq_cardinal_mk_field_pow_dim [finite_dimensional K V] :
-  cardinal.mk V = cardinal.mk K ^ module.rank K V :=
+  #V = #K ^ module.rank K V :=
 begin
   let s := basis.of_vector_space_index K V,
   let hs := basis.of_vector_space K V,
-  calc cardinal.mk V = cardinal.mk (s →₀ K) : quotient.sound ⟨hs.repr.to_equiv⟩
-    ... = cardinal.mk (s → K) : quotient.sound ⟨finsupp.equiv_fun_on_fintype⟩
+  calc #V = #(s →₀ K) : quotient.sound ⟨hs.repr.to_equiv⟩
+    ... = #(s → K) : quotient.sound ⟨finsupp.equiv_fun_on_fintype⟩
     ... = _ : by rw [← cardinal.lift_inj.1 hs.mk_eq_dim, cardinal.power_def]
 end
 
 lemma cardinal_lt_omega_of_finite_dimensional [fintype K] [finite_dimensional K V] :
-  cardinal.mk V < cardinal.omega :=
+  #V < ω :=
 begin
   rw cardinal_mk_eq_cardinal_mk_field_pow_dim K V,
   exact cardinal.power_lt_omega (cardinal.lt_omega_iff_fintype.2 ⟨infer_instance⟩)

--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -73,7 +73,7 @@ linearly dependent, linear dependence, linearly independent, linear independence
 noncomputable theory
 
 open function set submodule
-open_locale classical big_operators
+open_locale classical big_operators cardinal
 
 universes u
 
@@ -305,7 +305,7 @@ then the same is true for arbitrary sets of linearly independent vectors.
 -/
 lemma linear_independent_bounded_of_finset_linear_independent_bounded {n : ℕ}
   (H : ∀ s : finset M, linear_independent R (λ i : s, (i : M)) → s.card ≤ n) :
-  ∀ s : set M, linear_independent R (coe : s → M) → cardinal.mk s ≤ n :=
+  ∀ s : set M, linear_independent R (coe : s → M) → #s ≤ n :=
 begin
   intros s li,
   apply cardinal.card_le_of,

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -23,7 +23,7 @@ We define cardinal numbers as a quotient of types under the equivalence relation
 * Multiplication `c₁ * c₂` is defined by `cardinal.mul_def : #α * #β = #(α * β)`.
 * The order `c₁ ≤ c₂` is defined by `cardinal.le_def α β : #α ≤ #β ↔ nonempty (α ↪ β)`.
 * Exponentiation `c₁ ^ c₂` is defined by `cardinal.power_def α β : #α ^ #β = #(β → α)`.
-* `cardinal.omega` the cardinality of `ℕ`. This definition is universe polymorphic:
+* `cardinal.omega` or `ω` the cardinality of `ℕ`. This definition is universe polymorphic:
   `cardinal.omega.{u} : cardinal.{u}`
   (contrast with `ℕ : Type`, which lives in a specific universe).
   In some cases the universe level has to be given explicitly.
@@ -91,65 +91,67 @@ def mk : Type u → cardinal := quotient.mk
 
 localized "notation `#` := cardinal.mk" in cardinal
 
-protected lemma eq : mk α = mk β ↔ nonempty (α ≃ β) := quotient.eq
+protected lemma eq : #α = #β ↔ nonempty (α ≃ β) := quotient.eq
 
-@[simp] theorem mk_def (α : Type u) : @eq cardinal ⟦α⟧ (mk α) := rfl
+@[simp] theorem mk_def (α : Type u) : @eq cardinal ⟦α⟧ (#α) := rfl
 
-@[simp] theorem mk_out (c : cardinal) : mk (c.out) = c := quotient.out_eq _
+@[simp] theorem mk_out (c : cardinal) : #(c.out) = c := quotient.out_eq _
 
-/-- We define the order on cardinal numbers by `mk α ≤ mk β` if and only if
+protected lemma mk_congr (e : α ≃ β) : # α = # β :=
+quot.sound ⟨e⟩
+
+alias cardinal.mk_congr ← equiv.cardinal_eq
+
+/-- We define the order on cardinal numbers by `#α ≤ #β` if and only if
   there exists an embedding (injective function) from α to β. -/
 instance : has_le cardinal.{u} :=
 ⟨λq₁ q₂, quotient.lift_on₂ q₁ q₂ (λα β, nonempty $ α ↪ β) $
   assume α β γ δ ⟨e₁⟩ ⟨e₂⟩,
     propext ⟨assume ⟨e⟩, ⟨e.congr e₁ e₂⟩, assume ⟨e⟩, ⟨e.congr e₁.symm e₂.symm⟩⟩⟩
 
-theorem le_def (α β : Type u) : mk α ≤ mk β ↔ nonempty (α ↪ β) :=
+theorem le_def (α β : Type u) : #α ≤ #β ↔ nonempty (α ↪ β) :=
 iff.rfl
 
-theorem mk_le_of_injective {α β : Type u} {f : α → β} (hf : injective f) : mk α ≤ mk β :=
+theorem mk_le_of_injective {α β : Type u} {f : α → β} (hf : injective f) : #α ≤ #β :=
 ⟨⟨f, hf⟩⟩
 
-theorem mk_le_of_surjective {α β : Type u} {f : α → β} (hf : surjective f) : mk β ≤ mk α :=
+theorem mk_le_of_surjective {α β : Type u} {f : α → β} (hf : surjective f) : #β ≤ #α :=
 ⟨embedding.of_surjective f hf⟩
 
 theorem le_mk_iff_exists_set {c : cardinal} {α : Type u} :
-  c ≤ mk α ↔ ∃ p : set α, mk p = c :=
+  c ≤ #α ↔ ∃ p : set α, #p = c :=
 ⟨quotient.induction_on c $ λ β ⟨⟨f, hf⟩⟩,
-  ⟨set.range f, eq.symm $ quot.sound ⟨equiv.of_injective f hf⟩⟩,
+  ⟨set.range f, (equiv.of_injective f hf).cardinal_eq.symm⟩,
 λ ⟨p, e⟩, e ▸ ⟨⟨subtype.val, λ a b, subtype.eq⟩⟩⟩
 
 theorem out_embedding {c c' : cardinal} : c ≤ c' ↔ nonempty (c.out ↪ c'.out) :=
 by { transitivity _, rw [←quotient.out_eq c, ←quotient.out_eq c'], refl }
 
-protected lemma eq_congr : α ≃ β → # α = # β :=
-λ h, quot.sound ⟨h⟩
-
 noncomputable instance : linear_order cardinal.{u} :=
 { le          := (≤),
   le_refl     := by rintros ⟨α⟩; exact ⟨embedding.refl _⟩,
   le_trans    := by rintros ⟨α⟩ ⟨β⟩ ⟨γ⟩ ⟨e₁⟩ ⟨e₂⟩; exact ⟨e₁.trans e₂⟩,
-  le_antisymm := by rintros ⟨α⟩ ⟨β⟩ ⟨e₁⟩ ⟨e₂⟩; exact quotient.sound (e₁.antisymm e₂),
+  le_antisymm := by { rintros ⟨α⟩ ⟨β⟩ ⟨e₁⟩ ⟨e₂⟩, exact quotient.sound (e₁.antisymm e₂) },
   le_total    := by rintros ⟨α⟩ ⟨β⟩; exact embedding.total,
   decidable_le := classical.dec_rel _ }
 
 -- short-circuit type class inference
 noncomputable instance : distrib_lattice cardinal.{u} := by apply_instance
 
-instance : has_zero cardinal.{u} := ⟨⟦pempty⟧⟩
+instance : has_zero cardinal.{u} := ⟨#pempty⟩
 
 instance : inhabited cardinal.{u} := ⟨0⟩
 
 @[simp]
-lemma eq_zero_of_is_empty {α : Type u} [is_empty α] : mk α = 0 :=
-quotient.sound ⟨equiv.equiv_pempty α⟩
+lemma eq_zero_of_is_empty {α : Type u} [is_empty α] : #α = 0 :=
+(equiv.equiv_pempty α).cardinal_eq
 
-lemma eq_zero_iff_is_empty {α : Type u} : mk α = 0 ↔ is_empty α :=
+lemma eq_zero_iff_is_empty {α : Type u} : #α = 0 ↔ is_empty α :=
 ⟨λ e, let ⟨h⟩ := quotient.exact e in
   equiv.equiv_empty_equiv α $ h.trans equiv.empty_equiv_pempty.symm,
   @eq_zero_of_is_empty _⟩
 
-theorem ne_zero_iff_nonempty {α : Type u} : mk α ≠ 0 ↔ nonempty α :=
+theorem ne_zero_iff_nonempty {α : Type u} : #α ≠ 0 ↔ nonempty α :=
 (not_iff_not.2 eq_zero_iff_is_empty).trans not_is_empty_iff
 
 instance : has_one cardinal.{u} := ⟨⟦punit⟧⟩
@@ -157,24 +159,24 @@ instance : has_one cardinal.{u} := ⟨⟦punit⟧⟩
 instance : nontrivial cardinal.{u} :=
 ⟨⟨1, 0, ne_zero_iff_nonempty.2 ⟨punit.star⟩⟩⟩
 
-theorem le_one_iff_subsingleton {α : Type u} : mk α ≤ 1 ↔ subsingleton α :=
+theorem le_one_iff_subsingleton {α : Type u} : #α ≤ 1 ↔ subsingleton α :=
 ⟨λ ⟨f⟩, ⟨λ a b, f.injective (subsingleton.elim _ _)⟩,
  λ ⟨h⟩, ⟨⟨λ a, punit.star, λ a b _, h _ _⟩⟩⟩
 
-theorem one_lt_iff_nontrivial {α : Type u} : 1 < mk α ↔ nontrivial α :=
+theorem one_lt_iff_nontrivial {α : Type u} : 1 < #α ↔ nontrivial α :=
 by { rw [← not_iff_not, not_nontrivial_iff_subsingleton, ← le_one_iff_subsingleton], simp }
 
 instance : has_add cardinal.{u} :=
-⟨λq₁ q₂, quotient.lift_on₂ q₁ q₂ (λα β, mk (α ⊕ β)) $ assume α β γ δ ⟨e₁⟩ ⟨e₂⟩,
+⟨λq₁ q₂, quotient.lift_on₂ q₁ q₂ (λα β, #(α ⊕ β)) $ assume α β γ δ ⟨e₁⟩ ⟨e₂⟩,
   quotient.sound ⟨equiv.sum_congr e₁ e₂⟩⟩
 
-@[simp] theorem add_def (α β : Type u) : mk α + mk β = mk (α ⊕ β) := rfl
+@[simp] theorem add_def (α β : Type u) : #α + #β = #(α ⊕ β) := rfl
 
 instance : has_mul cardinal.{u} :=
-⟨λq₁ q₂, quotient.lift_on₂ q₁ q₂ (λα β, mk (α × β)) $ assume α β γ δ ⟨e₁⟩ ⟨e₂⟩,
+⟨λq₁ q₂, quotient.lift_on₂ q₁ q₂ (λα β, #(α × β)) $ assume α β γ δ ⟨e₁⟩ ⟨e₂⟩,
   quotient.sound ⟨equiv.prod_congr e₁ e₂⟩⟩
 
-@[simp] theorem mul_def (α β : Type u) : mk α * mk β = mk (α × β) := rfl
+@[simp] theorem mul_def (α β : Type u) : #α * #β = #(α × β) := rfl
 
 private theorem add_comm (a b : cardinal.{u}) : a + b = b + a :=
 quotient.induction_on₂ a b $ assume α β, quotient.sound ⟨equiv.sum_comm α β⟩
@@ -227,15 +229,15 @@ instance : comm_semiring cardinal.{u} :=
   right_distrib := assume a b c,
     by rw [mul_comm (a + b) c, left_distrib c a b, mul_comm c a, mul_comm c b] }
 
-/-- The cardinal exponential. `mk α ^ mk β` is the cardinal of `β → α`. -/
+/-- The cardinal exponential. `#α ^ #β` is the cardinal of `β → α`. -/
 protected def power (a b : cardinal.{u}) : cardinal.{u} :=
-quotient.lift_on₂ a b (λα β, mk (β → α)) $ assume α₁ α₂ β₁ β₂ ⟨e₁⟩ ⟨e₂⟩,
+quotient.lift_on₂ a b (λα β, #(β → α)) $ assume α₁ α₂ β₁ β₂ ⟨e₁⟩ ⟨e₂⟩,
   quotient.sound ⟨equiv.arrow_congr e₂ e₁⟩
 
 instance : has_pow cardinal cardinal := ⟨cardinal.power⟩
 local infixr ^ := @has_pow.pow cardinal cardinal cardinal.has_pow
 
-@[simp] theorem power_def (α β) : mk α ^ mk β = mk (β → α) := rfl
+@[simp] theorem power_def (α β) : #α ^ #β = #(β → α) := rfl
 
 @[simp] theorem power_zero {a : cardinal} : a ^ 0 = 1 :=
 quotient.induction_on a $ assume α, quotient.sound
@@ -249,7 +251,7 @@ quotient.induction_on a $ assume α, quotient.sound
 quotient.induction_on a $ assume α, quotient.sound
 ⟨equiv.arrow_punit_equiv_punit α⟩
 
-@[simp] theorem prop_eq_two : mk (ulift Prop) = 2 :=
+@[simp] theorem prop_eq_two : #(ulift Prop) = 2 :=
 quot.sound ⟨equiv.ulift.trans $ equiv.Prop_equiv_bool.trans equiv.bool_equiv_punit_sum_punit⟩
 
 @[simp] theorem zero_power {a : cardinal} : a ≠ 0 → 0 ^ a = 0 :=
@@ -423,11 +425,11 @@ theorem le_sum {ι} (f : ι → cardinal) (i) : f i ≤ sum f :=
 by rw ← quotient.out_eq (f i); exact
 ⟨⟨λ a, ⟨i, a⟩, λ a b h, eq_of_heq $ by injection h⟩⟩
 
-@[simp] theorem sum_mk {ι} (f : ι → Type*) : sum (λ i, mk (f i)) = mk (Σ i, f i) :=
+@[simp] theorem sum_mk {ι} (f : ι → Type*) : sum (λ i, #(f i)) = #(Σ i, f i) :=
 quot.sound ⟨equiv.sigma_congr_right $ λ i,
-  classical.choice $ quotient.exact $ quot.out_eq $ mk (f i)⟩
+  classical.choice $ quotient.exact $ quot.out_eq $ #(f i)⟩
 
-theorem sum_const (ι : Type u) (a : cardinal.{u}) : sum (λ _:ι, a) = mk ι * a :=
+theorem sum_const (ι : Type u) (a : cardinal.{u}) : sum (λ _:ι, a) = #ι * a :=
 quotient.induction_on a $ λ α, by simp; exact
   quotient.sound ⟨equiv.sigma_equiv_prod _ _⟩
 
@@ -453,7 +455,7 @@ sup_le.2 $ λ i, le_trans (H i) (le_sup _ _)
 theorem sup_le_sum {ι} (f : ι → cardinal) : sup f ≤ sum f :=
 sup_le.2 $ le_sum _
 
-theorem sum_le_sup {ι : Type u} (f : ι → cardinal.{u}) : sum f ≤ mk ι * sup.{u u} f :=
+theorem sum_le_sup {ι : Type u} (f : ι → cardinal.{u}) : sum f ≤ #ι * sup.{u u} f :=
 by rw ← sum_const; exact sum_le_sum _ _ (le_sup _)
 
 theorem sup_eq_zero {ι} {f : ι → cardinal} [is_empty ι] : sup f = 0 :=
@@ -461,13 +463,13 @@ by { rw [← nonpos_iff_eq_zero, sup_le], exact is_empty_elim }
 
 /-- The indexed product of cardinals is the cardinality of the Pi type
   (dependent product). -/
-def prod {ι : Type u} (f : ι → cardinal) : cardinal := mk (Π i, (f i).out)
+def prod {ι : Type u} (f : ι → cardinal) : cardinal := #(Π i, (f i).out)
 
-@[simp] theorem prod_mk {ι} (f : ι → Type*) : prod (λ i, mk (f i)) = mk (Π i, f i) :=
+@[simp] theorem prod_mk {ι} (f : ι → Type*) : prod (λ i, #(f i)) = #(Π i, f i) :=
 quot.sound ⟨equiv.Pi_congr_right $ λ i,
-  classical.choice $ quotient.exact $ mk_out $ mk (f i)⟩
+  classical.choice $ quotient.exact $ mk_out $ #(f i)⟩
 
-theorem prod_const (ι : Type u) (a : cardinal.{u}) : prod (λ _:ι, a) = a ^ mk ι :=
+theorem prod_const (ι : Type u) (a : cardinal.{u}) : prod (λ _:ι, a) = a ^ #ι :=
 quotient.induction_on a $ by simp
 
 theorem prod_le_prod {ι} (f g : ι → cardinal) (H : ∀ i, f i ≤ g i) : prod f ≤ prod g :=
@@ -490,7 +492,7 @@ def lift (c : cardinal.{u}) : cardinal.{max u v} :=
 quotient.lift_on c (λ α, ⟦ulift α⟧) $ λ α β ⟨e⟩,
 quotient.sound ⟨equiv.ulift.trans $ e.trans equiv.ulift.symm⟩
 
-theorem lift_mk (α) : lift.{u v} (mk α) = mk (ulift.{v u} α) := rfl
+theorem lift_mk (α) : lift.{u v} (#α) = #(ulift.{v u} α) := rfl
 
 theorem lift_umax : lift.{u (max u v)} = lift.{u v} :=
 funext $ λ a, quot.induction_on a $ λ α,
@@ -507,7 +509,7 @@ quot.induction_on a $ λ α,
 quotient.sound ⟨equiv.ulift.trans $ equiv.ulift.trans equiv.ulift.symm⟩
 
 theorem lift_mk_le {α : Type u} {β : Type v} :
-  lift.{u (max v w)} (mk α) ≤ lift.{v (max u w)} (mk β) ↔ nonempty (α ↪ β) :=
+  lift.{u (max v w)} (#α) ≤ lift.{v (max u w)} (#β) ↔ nonempty (α ↪ β) :=
 ⟨λ ⟨f⟩, ⟨embedding.congr equiv.ulift equiv.ulift f⟩,
  λ ⟨f⟩, ⟨embedding.congr equiv.ulift.symm equiv.ulift.symm f⟩⟩
 
@@ -516,11 +518,11 @@ Because Lean often can not realize it should use this specialization itself,
 we provide this statement separately so you don't have to solve the specialization problem either.
 -/
 theorem lift_mk_le' {α : Type u} {β : Type v} :
-  lift.{u v} (mk α) ≤ lift.{v u} (mk β) ↔ nonempty (α ↪ β) :=
+  lift.{u v} (#α) ≤ lift.{v u} (#β) ↔ nonempty (α ↪ β) :=
 lift_mk_le.{u v 0}
 
 theorem lift_mk_eq {α : Type u} {β : Type v} :
-  lift.{u (max v w)} (mk α) = lift.{v (max u w)} (mk β) ↔ nonempty (α ≃ β) :=
+  lift.{u (max v w)} (#α) = lift.{v (max u w)} (#β) ↔ nonempty (α ≃ β) :=
 quotient.eq.trans
 ⟨λ ⟨f⟩, ⟨equiv.ulift.symm.trans $ f.trans equiv.ulift⟩,
  λ ⟨f⟩, ⟨equiv.ulift.trans $ f.trans equiv.ulift.symm⟩⟩
@@ -530,7 +532,7 @@ Because Lean often can not realize it should use this specialization itself,
 we provide this statement separately so you don't have to solve the specialization problem either.
 -/
 theorem lift_mk_eq' {α : Type u} {β : Type v} :
-  lift.{u v} (mk α) = lift.{v u} (mk β) ↔ nonempty (α ≃ β) :=
+  lift.{u v} (#α) = lift.{v u} (#β) ↔ nonempty (α ≃ β) :=
 lift_mk_eq.{u v 0}
 
 @[simp] theorem lift_le {a b : cardinal} : lift a ≤ lift b ↔ a ≤ b :=
@@ -573,8 +575,8 @@ by have := min_le (lift ∘ f) j; rwa e at this)
 theorem lift_down {a : cardinal.{u}} {b : cardinal.{max u v}} :
   b ≤ lift a → ∃ a', lift a' = b :=
 quotient.induction_on₂ a b $ λ α β,
-by dsimp; rw [← lift_id (mk β), ← lift_umax, ← lift_umax.{u v}, lift_mk_le]; exact
-λ ⟨f⟩, ⟨mk (set.range f), eq.symm $ lift_mk_eq.2
+by dsimp; rw [← lift_id (#β), ← lift_umax, ← lift_umax.{u v}, lift_mk_le]; exact
+λ ⟨f⟩, ⟨#(set.range f), eq.symm $ lift_mk_eq.2
   ⟨embedding.equiv_of_surjective
     (embedding.cod_restrict _ f set.mem_range_self)
     $ λ ⟨a, ⟨b, e⟩⟩, ⟨b, subtype.eq e⟩⟩⟩
@@ -607,11 +609,11 @@ calc lift.{u (max v w)} a = lift.{v (max u w)} b
   ... ↔ lift.{u v} a = lift.{v u} b : lift_inj
 
 theorem mk_prod {α : Type u} {β : Type v} :
-  mk (α × β) = lift.{u v} (mk α) * lift.{v u} (mk β) :=
+  #(α × β) = lift.{u v} (#α) * lift.{v u} (#β) :=
 quotient.sound ⟨equiv.prod_congr (equiv.ulift).symm (equiv.ulift).symm⟩
 
 theorem sum_const_eq_lift_mul (ι : Type u) (a : cardinal.{v}) :
-  sum (λ _:ι, a) = lift.{u v} (mk ι) * lift.{v u} a :=
+  sum (λ _:ι, a) = lift.{u v} (#ι) * lift.{v u} a :=
 begin
   apply quotient.induction_on a,
   intro α,
@@ -677,21 +679,23 @@ lemma lift_sup_le_lift_sup'
 lift_sup_le_lift_sup f f' g h
 
 /-- `ω` is the smallest infinite cardinal, also known as ℵ₀. -/
-def omega : cardinal.{u} := lift (mk ℕ)
+def omega : cardinal.{u} := lift (#ℕ)
 
-lemma mk_nat : mk nat = omega := (lift_id _).symm
+localized "notation `ω` := cardinal.omega" in cardinal
 
-theorem omega_ne_zero : omega ≠ 0 :=
+lemma mk_nat : #ℕ = ω := (lift_id _).symm
+
+theorem omega_ne_zero : ω ≠ 0 :=
 ne_zero_iff_nonempty.2 ⟨⟨0⟩⟩
 
-theorem omega_pos : 0 < omega :=
+theorem omega_pos : 0 < ω :=
 pos_iff_ne_zero.2 omega_ne_zero
 
-@[simp] theorem lift_omega : lift omega = omega := lift_lift _
+@[simp] theorem lift_omega : lift ω = ω := lift_lift _
 
 /- properties about the cast from nat -/
 
-@[simp] theorem mk_fin : ∀ (n : ℕ), mk (fin n) = n
+@[simp] theorem mk_fin : ∀ (n : ℕ), #(fin n) = n
 | 0     := quotient.sound ⟨equiv.equiv_pempty _⟩
 | (n+1) := by rw [nat.cast_succ, ← mk_fin]; exact
   quotient.sound (fintype.card_eq.1 $ by simp)
@@ -706,16 +710,16 @@ lemma nat_eq_lift_eq_iff {n : ℕ} {a : cardinal.{u}} :
   (n : cardinal) = lift.{u v} a ↔ (n : cardinal) = a :=
 by rw [← lift_nat_cast.{u v} n, lift_inj]
 
-theorem lift_mk_fin (n : ℕ) : lift (mk (fin n)) = n := by simp
+theorem lift_mk_fin (n : ℕ) : lift (#(fin n)) = n := by simp
 
-theorem fintype_card (α : Type u) [fintype α] : mk α = fintype.card α :=
-by rw [← lift_mk_fin.{u}, ← lift_id (mk α), lift_mk_eq.{u 0 u}];
+theorem fintype_card (α : Type u) [fintype α] : #α = fintype.card α :=
+by rw [← lift_mk_fin.{u}, ← lift_id (#α), lift_mk_eq.{u 0 u}];
    exact fintype.card_eq.1 (by simp)
 
 theorem card_le_of_finset {α} (s : finset α) :
-  (s.card : cardinal) ≤ cardinal.mk α :=
+  (s.card : cardinal) ≤ #α :=
 begin
-  rw (_ : (s.card : cardinal) = cardinal.mk s),
+  rw (_ : (s.card : cardinal) = #s),
   { exact ⟨function.embedding.subtype _⟩ },
   rw [cardinal.fintype_card, fintype.card_coe]
 end
@@ -761,14 +765,14 @@ by rw [← succ_zero, succ_le]
 theorem one_le_iff_ne_zero {c : cardinal} : 1 ≤ c ↔ c ≠ 0 :=
 by rw [one_le_iff_pos, pos_iff_ne_zero]
 
-theorem nat_lt_omega (n : ℕ) : (n : cardinal.{u}) < omega :=
+theorem nat_lt_omega (n : ℕ) : (n : cardinal.{u}) < ω :=
 succ_le.1 $ by rw [← nat_succ, ← lift_mk_fin, omega, lift_mk_le.{0 0 u}]; exact
 ⟨⟨coe, λ a b, fin.ext⟩⟩
 
-@[simp] theorem one_lt_omega : 1 < omega :=
+@[simp] theorem one_lt_omega : 1 < ω :=
 by simpa using nat_lt_omega 1
 
-theorem lt_omega {c : cardinal.{u}} : c < omega ↔ ∃ n : ℕ, c = n :=
+theorem lt_omega {c : cardinal.{u}} : c < ω ↔ ∃ n : ℕ, c = n :=
 ⟨λ h, begin
   rcases lt_lift_iff.1 h with ⟨c, rfl, h'⟩,
   rcases le_mk_iff_exists_set.1 h'.1 with ⟨S, rfl⟩,
@@ -797,41 +801,41 @@ theorem lt_omega {c : cardinal.{u}} : c < omega ↔ ∃ n : ℕ, c = n :=
   exact λ e, this ⟨m, h, e⟩,
 end, λ ⟨n, e⟩, e.symm ▸ nat_lt_omega _⟩
 
-theorem omega_le {c : cardinal.{u}} : omega ≤ c ↔ ∀ n : ℕ, (n:cardinal) ≤ c :=
+theorem omega_le {c : cardinal.{u}} : ω ≤ c ↔ ∀ n : ℕ, (n:cardinal) ≤ c :=
 ⟨λ h n, le_trans (le_of_lt (nat_lt_omega _)) h,
  λ h, le_of_not_lt $ λ hn, begin
   rcases lt_omega.1 hn with ⟨n, rfl⟩,
   exact not_le_of_lt (nat.lt_succ_self _) (nat_cast_le.1 (h (n+1)))
 end⟩
 
-theorem lt_omega_iff_fintype {α : Type u} : mk α < omega ↔ nonempty (fintype α) :=
+theorem lt_omega_iff_fintype {α : Type u} : #α < ω ↔ nonempty (fintype α) :=
 lt_omega.trans ⟨λ ⟨n, e⟩, begin
   rw [← lift_mk_fin n] at e,
   cases quotient.exact e with f,
   exact ⟨fintype.of_equiv _ f.symm⟩
 end, λ ⟨_⟩, by exactI ⟨_, fintype_card _⟩⟩
 
-theorem lt_omega_iff_finite {α} {S : set α} : mk S < omega ↔ finite S :=
+theorem lt_omega_iff_finite {α} {S : set α} : #S < ω ↔ finite S :=
 lt_omega_iff_fintype
 
 instance can_lift_cardinal_nat : can_lift cardinal ℕ :=
-⟨ coe, λ x, x < omega, λ x hx, let ⟨n, hn⟩ := lt_omega.mp hx in ⟨n, hn.symm⟩⟩
+⟨ coe, λ x, x < ω, λ x hx, let ⟨n, hn⟩ := lt_omega.mp hx in ⟨n, hn.symm⟩⟩
 
-theorem add_lt_omega {a b : cardinal} (ha : a < omega) (hb : b < omega) : a + b < omega :=
+theorem add_lt_omega {a b : cardinal} (ha : a < ω) (hb : b < ω) : a + b < ω :=
 match a, b, lt_omega.1 ha, lt_omega.1 hb with
 | _, _, ⟨m, rfl⟩, ⟨n, rfl⟩ := by rw [← nat.cast_add]; apply nat_lt_omega
 end
 
-lemma add_lt_omega_iff {a b : cardinal} : a + b < omega ↔ a < omega ∧ b < omega :=
+lemma add_lt_omega_iff {a b : cardinal} : a + b < ω ↔ a < ω ∧ b < ω :=
 ⟨λ h, ⟨lt_of_le_of_lt (self_le_add_right _ _) h, lt_of_le_of_lt (self_le_add_left _ _) h⟩,
   λ⟨h1, h2⟩, add_lt_omega h1 h2⟩
 
-theorem mul_lt_omega {a b : cardinal} (ha : a < omega) (hb : b < omega) : a * b < omega :=
+theorem mul_lt_omega {a b : cardinal} (ha : a < ω) (hb : b < ω) : a * b < ω :=
 match a, b, lt_omega.1 ha, lt_omega.1 hb with
 | _, _, ⟨m, rfl⟩, ⟨n, rfl⟩ := by rw [← nat.cast_mul]; apply nat_lt_omega
 end
 
-lemma mul_lt_omega_iff {a b : cardinal} : a * b < omega ↔ a = 0 ∨ b = 0 ∨ a < omega ∧ b < omega :=
+lemma mul_lt_omega_iff {a b : cardinal} : a * b < ω ↔ a = 0 ∨ b = 0 ∨ a < ω ∧ b < ω :=
 begin
   split,
   { intro h, by_cases ha : a = 0, { left, exact ha },
@@ -845,32 +849,32 @@ begin
 end
 
 lemma mul_lt_omega_iff_of_ne_zero {a b : cardinal} (ha : a ≠ 0) (hb : b ≠ 0) :
-  a * b < omega ↔ a < omega ∧ b < omega :=
+  a * b < ω ↔ a < ω ∧ b < ω :=
 by simp [mul_lt_omega_iff, ha, hb]
 
-theorem power_lt_omega {a b : cardinal} (ha : a < omega) (hb : b < omega) : a ^ b < omega :=
+theorem power_lt_omega {a b : cardinal} (ha : a < ω) (hb : b < ω) : a ^ b < ω :=
 match a, b, lt_omega.1 ha, lt_omega.1 hb with
 | _, _, ⟨m, rfl⟩, ⟨n, rfl⟩ := by rw [← nat_cast_pow]; apply nat_lt_omega
 end
 
 lemma eq_one_iff_unique {α : Type*} :
-  mk α = 1 ↔ subsingleton α ∧ nonempty α :=
-calc mk α = 1 ↔ mk α ≤ 1 ∧ ¬mk α < 1 : eq_iff_le_not_lt
-          ... ↔ subsingleton α ∧ nonempty α :
+  #α = 1 ↔ subsingleton α ∧ nonempty α :=
+calc #α = 1 ↔ #α ≤ 1 ∧ ¬#α < 1 : eq_iff_le_not_lt
+        ... ↔ subsingleton α ∧ nonempty α :
 begin
   apply and_congr le_one_iff_subsingleton,
   push_neg,
   rw [one_le_iff_ne_zero, ne_zero_iff_nonempty]
 end
 
-theorem infinite_iff {α : Type u} : infinite α ↔ omega ≤ mk α :=
+theorem infinite_iff {α : Type u} : infinite α ↔ ω ≤ #α :=
 by rw [←not_lt, lt_omega_iff_fintype, not_nonempty_iff, is_empty_fintype]
 
-lemma denumerable_iff {α : Type u} : nonempty (denumerable α) ↔ mk α = omega :=
+lemma denumerable_iff {α : Type u} : nonempty (denumerable α) ↔ #α = ω :=
 ⟨λ⟨h⟩, quotient.sound $ by exactI ⟨ (denumerable.eqv α).trans equiv.ulift.symm ⟩,
  λ h, by { cases quotient.exact h with f, exact ⟨denumerable.mk' $ f.trans equiv.ulift⟩ }⟩
 
-lemma countable_iff (s : set α) : countable s ↔ mk s ≤ omega :=
+lemma countable_iff (s : set α) : countable s ↔ #s ≤ ω :=
 begin
   rw [countable_iff_exists_injective], split,
   rintro ⟨f, hf⟩, exact ⟨embedding.trans ⟨f, hf⟩ equiv.ulift.symm.to_embedding⟩,
@@ -882,26 +886,26 @@ end
 noncomputable def to_nat : zero_hom cardinal ℕ :=
 ⟨λ c, if h : c < omega.{v} then classical.some (lt_omega.1 h) else 0,
   begin
-    have h : 0 < omega := nat_lt_omega 0,
+    have h : 0 < ω := nat_lt_omega 0,
     rw [dif_pos h, ← cardinal.nat_cast_inj, ← classical.some_spec (lt_omega.1 h), nat.cast_zero],
   end⟩
 
-lemma to_nat_apply_of_lt_omega {c : cardinal} (h : c < omega) :
+lemma to_nat_apply_of_lt_omega {c : cardinal} (h : c < ω) :
   c.to_nat = classical.some (lt_omega.1 h) :=
 dif_pos h
 
 @[simp]
-lemma to_nat_apply_of_omega_le {c : cardinal} (h : omega ≤ c) :
+lemma to_nat_apply_of_omega_le {c : cardinal} (h : ω ≤ c) :
   c.to_nat = 0 :=
 dif_neg (not_lt_of_le h)
 
 @[simp]
-lemma cast_to_nat_of_lt_omega {c : cardinal} (h : c < omega) :
+lemma cast_to_nat_of_lt_omega {c : cardinal} (h : c < ω) :
   ↑c.to_nat = c :=
 by rw [to_nat_apply_of_lt_omega h, ← classical.some_spec (lt_omega.1 h)]
 
 @[simp]
-lemma cast_to_nat_of_omega_le {c : cardinal} (h : omega ≤ c) :
+lemma cast_to_nat_of_omega_le {c : cardinal} (h : ω ≤ c) :
   ↑c.to_nat = (0 : cardinal) :=
 by rw [to_nat_apply_of_omega_le h, nat.cast_zero]
 
@@ -921,11 +925,11 @@ lemma nat_cast_injective : injective (coe : ℕ → cardinal) :=
 to_nat_right_inverse.left_inverse.injective
 
 @[simp]
-lemma mk_to_nat_of_infinite [h : infinite α] : (mk α).to_nat = 0 :=
+lemma mk_to_nat_of_infinite [h : infinite α] : (#α).to_nat = 0 :=
 dif_neg (not_lt_of_le (infinite_iff.1 h))
 
 @[simp]
-lemma mk_to_nat_eq_card [fintype α] : (mk α).to_nat = fintype.card α :=
+lemma mk_to_nat_eq_card [fintype α] : (#α).to_nat = fintype.card α :=
 by simp [fintype_card]
 
 @[simp]
@@ -943,8 +947,8 @@ begin
   by_cases hy1 : y = 0,
   { rw [hy1, zero_to_nat, mul_zero, mul_zero, zero_to_nat] },
   refine nat_cast_injective (eq.trans _ (nat.cast_mul _ _).symm),
-  cases lt_or_ge x omega with hx2 hx2,
-  { cases lt_or_ge y omega with hy2 hy2,
+  cases lt_or_ge x ω with hx2 hx2,
+  { cases lt_or_ge y ω with hy2 hy2,
     { rw [cast_to_nat_of_lt_omega, cast_to_nat_of_lt_omega hx2, cast_to_nat_of_lt_omega hy2],
       exact mul_lt_omega hx2 hy2 },
     { rw [cast_to_nat_of_omega_le hy2, mul_zero, cast_to_nat_of_omega_le],
@@ -959,9 +963,9 @@ noncomputable def to_enat : cardinal →+ enat :=
 { to_fun := λ c, if c < omega.{v} then c.to_nat else ⊤,
   map_zero' := by simp [if_pos (lt_trans zero_lt_one one_lt_omega)],
   map_add' := λ x y, begin
-    by_cases hx : x < omega,
+    by_cases hx : x < ω,
     { obtain ⟨x0, rfl⟩ := lt_omega.1 hx,
-      by_cases hy : y < omega,
+      by_cases hy : y < ω,
       { obtain ⟨y0, rfl⟩ := lt_omega.1 hy,
         simp only [add_lt_omega hx hy, hx, hy, to_nat_cast, if_true],
         rw [← nat.cast_add, to_nat_cast, nat.cast_add] },
@@ -974,12 +978,12 @@ noncomputable def to_enat : cardinal →+ enat :=
   end }
 
 @[simp]
-lemma to_enat_apply_of_lt_omega {c : cardinal} (h : c < omega) :
+lemma to_enat_apply_of_lt_omega {c : cardinal} (h : c < ω) :
   c.to_enat = c.to_nat :=
 if_pos h
 
 @[simp]
-lemma to_enat_apply_of_omega_le {c : cardinal} (h : omega ≤ c) :
+lemma to_enat_apply_of_omega_le {c : cardinal} (h : ω ≤ c) :
   c.to_enat = ⊤ :=
 if_neg (not_lt_of_le h)
 
@@ -988,27 +992,27 @@ lemma to_enat_cast (n : ℕ) : cardinal.to_enat n = n :=
 by rw [to_enat_apply_of_lt_omega (nat_lt_omega n), to_nat_cast]
 
 @[simp]
-lemma mk_to_enat_of_infinite [h : infinite α] : (mk α).to_enat = ⊤ :=
+lemma mk_to_enat_of_infinite [h : infinite α] : (#α).to_enat = ⊤ :=
 to_enat_apply_of_omega_le (infinite_iff.1 h)
 
 lemma to_enat_surjective : surjective to_enat :=
 begin
   intro x,
-  exact enat.cases_on x ⟨omega, to_enat_apply_of_omega_le (le_refl omega)⟩
+  exact enat.cases_on x ⟨ω, to_enat_apply_of_omega_le (le_refl ω)⟩
     (λ n, ⟨n, to_enat_cast n⟩),
 end
 
 @[simp]
-lemma mk_to_enat_eq_coe_card [fintype α] : (mk α).to_enat = fintype.card α :=
+lemma mk_to_enat_eq_coe_card [fintype α] : (#α).to_enat = fintype.card α :=
 by simp [fintype_card]
 
-lemma mk_int : mk ℤ = omega :=
+lemma mk_int : #ℤ = ω :=
 denumerable_iff.mp ⟨by apply_instance⟩
 
-lemma mk_pnat : mk ℕ+ = omega :=
+lemma mk_pnat : #ℕ+ = ω :=
 denumerable_iff.mp ⟨by apply_instance⟩
 
-lemma two_le_iff : (2 : cardinal) ≤ mk α ↔ ∃x y : α, x ≠ y :=
+lemma two_le_iff : (2 : cardinal) ≤ #α ↔ ∃x y : α, x ≠ y :=
 begin
   split,
   { rintro ⟨f⟩, refine ⟨f $ sum.inl ⟨⟩, f $ sum.inr ⟨⟩, _⟩, intro h, cases f.2 h },
@@ -1017,7 +1021,7 @@ begin
     apply h, exactI subsingleton.elim _ _ }
 end
 
-lemma two_le_iff' (x : α) : (2 : cardinal) ≤ mk α ↔ ∃y : α, x ≠ y :=
+lemma two_le_iff' (x : α) : (2 : cardinal) ≤ #α ↔ ∃y : α, x ≠ y :=
 begin
   rw [two_le_iff],
   split,
@@ -1044,101 +1048,101 @@ lt_of_not_ge $ λ ⟨F⟩, begin
   exact (let ⟨⟨i, a⟩, h⟩ := sG C in hc i a (congr_fun h _))
 end
 
-@[simp] theorem mk_empty : mk empty = 0 :=
+@[simp] theorem mk_empty : #empty = 0 :=
 fintype_card empty
 
-@[simp] theorem mk_pempty : mk pempty = 0 :=
+@[simp] theorem mk_pempty : #pempty = 0 :=
 fintype_card pempty
 
-@[simp] theorem mk_plift_of_false {p : Prop} (h : ¬ p) : mk (plift p) = 0 :=
+@[simp] theorem mk_plift_of_false {p : Prop} (h : ¬ p) : #(plift p) = 0 :=
 by { haveI : is_empty p := ⟨h⟩, exact quotient.sound ⟨equiv.plift.trans $ equiv.equiv_pempty _⟩ }
 
-theorem mk_unit : mk unit = 1 :=
+theorem mk_unit : #unit = 1 :=
 (fintype_card unit).trans nat.cast_one
 
-@[simp] theorem mk_punit : mk punit = 1 :=
+@[simp] theorem mk_punit : #punit = 1 :=
 (fintype_card punit).trans nat.cast_one
 
-@[simp] theorem mk_singleton {α : Type u} (x : α) : mk ({x} : set α) = 1 :=
+@[simp] theorem mk_singleton {α : Type u} (x : α) : #({x} : set α) = 1 :=
 quotient.sound ⟨equiv.set.singleton x⟩
 
-@[simp] theorem mk_plift_of_true {p : Prop} (h : p) : mk (plift p) = 1 :=
+@[simp] theorem mk_plift_of_true {p : Prop} (h : p) : #(plift p) = 1 :=
 quotient.sound ⟨equiv.plift.trans $ equiv.prop_equiv_punit h⟩
 
-@[simp] theorem mk_bool : mk bool = 2 :=
+@[simp] theorem mk_bool : #bool = 2 :=
 quotient.sound ⟨equiv.bool_equiv_punit_sum_punit⟩
 
-@[simp] theorem mk_Prop : mk Prop = 2 :=
-(quotient.sound ⟨equiv.Prop_equiv_bool⟩ : mk Prop = mk bool).trans mk_bool
+@[simp] theorem mk_Prop : #Prop = 2 :=
+(quotient.sound ⟨equiv.Prop_equiv_bool⟩ : #Prop = #bool).trans mk_bool
 
-@[simp] theorem mk_set {α : Type u} : mk (set α) = 2 ^ mk α :=
+@[simp] theorem mk_set {α : Type u} : #(set α) = 2 ^ #α :=
 begin
   rw [← prop_eq_two, cardinal.power_def (ulift Prop) α, cardinal.eq],
   exact ⟨equiv.arrow_congr (equiv.refl _) equiv.ulift.symm⟩,
 end
 
-@[simp] theorem mk_option {α : Type u} : mk (option α) = mk α + 1 :=
+@[simp] theorem mk_option {α : Type u} : #(option α) = #α + 1 :=
 quotient.sound ⟨equiv.option_equiv_sum_punit α⟩
 
-theorem mk_list_eq_sum_pow (α : Type u) : mk (list α) = sum (λ n : ℕ, (mk α)^(n:cardinal.{u})) :=
-calc  mk (list α)
-    = mk (Σ n, vector α n) : quotient.sound ⟨(equiv.sigma_preimage_equiv list.length).symm⟩
-... = mk (Σ n, fin n → α) : quotient.sound ⟨equiv.sigma_congr_right $ λ n,
+theorem mk_list_eq_sum_pow (α : Type u) : #(list α) = sum (λ n : ℕ, (#α)^(n:cardinal.{u})) :=
+calc  #(list α)
+    = #(Σ n, vector α n) : quotient.sound ⟨(equiv.sigma_preimage_equiv list.length).symm⟩
+... = #(Σ n, fin n → α) : quotient.sound ⟨equiv.sigma_congr_right $ λ n,
   ⟨vector.nth, vector.of_fn, vector.of_fn_nth, λ f, funext $ vector.nth_of_fn f⟩⟩
-... = mk (Σ n : ℕ, ulift.{u} (fin n) → α) : quotient.sound ⟨equiv.sigma_congr_right $ λ n,
+... = #(Σ n : ℕ, ulift.{u} (fin n) → α) : quotient.sound ⟨equiv.sigma_congr_right $ λ n,
   equiv.arrow_congr equiv.ulift.symm (equiv.refl α)⟩
-... = sum (λ n : ℕ, (mk α)^(n:cardinal.{u})) :
+... = sum (λ n : ℕ, (#α)^(n:cardinal.{u})) :
   by simp only [(lift_mk_fin _).symm, lift_mk, power_def, sum_mk]
 
-theorem mk_quot_le {α : Type u} {r : α → α → Prop} : mk (quot r) ≤ mk α :=
+theorem mk_quot_le {α : Type u} {r : α → α → Prop} : #(quot r) ≤ #α :=
 mk_le_of_surjective quot.exists_rep
 
-theorem mk_quotient_le {α : Type u} {s : setoid α} : mk (quotient s) ≤ mk α :=
+theorem mk_quotient_le {α : Type u} {s : setoid α} : #(quotient s) ≤ #α :=
 mk_quot_le
 
-theorem mk_subtype_le {α : Type u} (p : α → Prop) : mk (subtype p) ≤ mk α :=
+theorem mk_subtype_le {α : Type u} (p : α → Prop) : #(subtype p) ≤ #α :=
 ⟨embedding.subtype p⟩
 
 theorem mk_subtype_le_of_subset {α : Type u} {p q : α → Prop} (h : ∀ ⦃x⦄, p x → q x) :
-  mk (subtype p) ≤ mk (subtype q) :=
+  #(subtype p) ≤ #(subtype q) :=
 ⟨embedding.subtype_map (embedding.refl α) h⟩
 
-@[simp] theorem mk_emptyc (α : Type u) : mk (∅ : set α) = 0 :=
+@[simp] theorem mk_emptyc (α : Type u) : #(∅ : set α) = 0 :=
 quotient.sound ⟨equiv.set.pempty α⟩
 
-lemma mk_emptyc_iff {α : Type u} {s : set α} : mk s = 0 ↔ s = ∅ :=
+lemma mk_emptyc_iff {α : Type u} {s : set α} : #s = 0 ↔ s = ∅ :=
 begin
   split,
   { intro h,
-    have h2 : cardinal.mk s = cardinal.mk pempty, by simp [h],
+    have h2 : #s = #pempty, by simp [h],
     refine set.eq_empty_iff_forall_not_mem.mpr (λ _ hx, _),
     rcases cardinal.eq.mp h2 with ⟨f, _⟩,
     cases f ⟨_, hx⟩ },
   { intro, convert mk_emptyc _ }
 end
 
-theorem mk_univ {α : Type u} : mk (@univ α) = mk α :=
+theorem mk_univ {α : Type u} : #(@univ α) = #α :=
 quotient.sound ⟨equiv.set.univ α⟩
 
-theorem mk_image_le {α β : Type u} {f : α → β} {s : set α} : mk (f '' s) ≤ mk s :=
+theorem mk_image_le {α β : Type u} {f : α → β} {s : set α} : #(f '' s) ≤ #s :=
 mk_le_of_surjective surjective_onto_image
 
 theorem mk_image_le_lift {α : Type u} {β : Type v} {f : α → β} {s : set α} :
-  lift.{v u} (mk (f '' s)) ≤ lift.{u v} (mk s) :=
+  lift.{v u} (#(f '' s)) ≤ lift.{u v} (#s) :=
 lift_mk_le.{v u 0}.mpr ⟨embedding.of_surjective _ surjective_onto_image⟩
 
-theorem mk_range_le {α β : Type u} {f : α → β} : mk (range f) ≤ mk α :=
+theorem mk_range_le {α β : Type u} {f : α → β} : #(range f) ≤ #α :=
 mk_le_of_surjective surjective_onto_range
 
 theorem mk_range_le_lift {α : Type u} {β : Type v} {f : α → β} :
-  lift.{v u} (mk (range f)) ≤ lift.{u v} (mk α) :=
+  lift.{v u} (#(range f)) ≤ lift.{u v} (#α) :=
 lift_mk_le.{v u 0}.mpr ⟨embedding.of_surjective _ surjective_onto_range⟩
 
-lemma mk_range_eq (f : α → β) (h : injective f) : mk (range f) = mk α :=
+lemma mk_range_eq (f : α → β) (h : injective f) : #(range f) = #α :=
 quotient.sound ⟨(equiv.of_injective f h).symm⟩
 
 lemma mk_range_eq_of_injective {α : Type u} {β : Type v} {f : α → β} (hf : injective f) :
-  lift.{v u} (mk (range f)) = lift.{u v} (mk α) :=
+  lift.{v u} (#(range f)) = lift.{u v} (#α) :=
 begin
   have := (@lift_mk_eq.{v u max u v} (range f) α).2 ⟨(equiv.of_injective f hf).symm⟩,
   simp only [lift_umax.{u v}, lift_umax.{v u}] at this,
@@ -1150,38 +1154,38 @@ lemma mk_range_eq_lift {α : Type u} {β : Type v} {f : α → β} (hf : injecti
 lift_mk_eq.mpr ⟨(equiv.of_injective f hf).symm⟩
 
 theorem mk_image_eq {α β : Type u} {f : α → β} {s : set α} (hf : injective f) :
-  mk (f '' s) = mk s :=
+  #(f '' s) = #s :=
 quotient.sound ⟨(equiv.set.image f s hf).symm⟩
 
-theorem mk_Union_le_sum_mk {α ι : Type u} {f : ι → set α} : mk (⋃ i, f i) ≤ sum (λ i, mk (f i)) :=
-calc mk (⋃ i, f i) ≤ mk (Σ i, f i) : mk_le_of_surjective (set.sigma_to_Union_surjective f)
-  ... = sum (λ i, mk (f i)) : (sum_mk _).symm
+theorem mk_Union_le_sum_mk {α ι : Type u} {f : ι → set α} : #(⋃ i, f i) ≤ sum (λ i, #(f i)) :=
+calc #(⋃ i, f i) ≤ #(Σ i, f i)        : mk_le_of_surjective (set.sigma_to_Union_surjective f)
+              ... = sum (λ i, #(f i)) : (sum_mk _).symm
 
 theorem mk_Union_eq_sum_mk {α ι : Type u} {f : ι → set α} (h : ∀i j, i ≠ j → disjoint (f i) (f j)) :
-  mk (⋃ i, f i) = sum (λ i, mk (f i)) :=
-calc mk (⋃ i, f i) = mk (Σi, f i) : quot.sound ⟨set.Union_eq_sigma_of_disjoint h⟩
-  ... = sum (λi, mk (f i)) : (sum_mk _).symm
+  #(⋃ i, f i) = sum (λ i, #(f i)) :=
+calc #(⋃ i, f i) = #(Σ i, f i)       : quot.sound ⟨set.Union_eq_sigma_of_disjoint h⟩
+              ... = sum (λi, #(f i)) : (sum_mk _).symm
 
 lemma mk_Union_le {α ι : Type u} (f : ι → set α) :
-  mk (⋃ i, f i) ≤ mk ι * cardinal.sup.{u u} (λ i, mk (f i)) :=
+  #(⋃ i, f i) ≤ #ι * cardinal.sup.{u u} (λ i, #(f i)) :=
 le_trans mk_Union_le_sum_mk (sum_le_sup _)
 
 lemma mk_sUnion_le {α : Type u} (A : set (set α)) :
-  mk (⋃₀ A) ≤ mk A * cardinal.sup.{u u} (λ s : A, mk s) :=
+  #(⋃₀ A) ≤ #A * cardinal.sup.{u u} (λ s : A, #s) :=
 by { rw [sUnion_eq_Union], apply mk_Union_le }
 
 lemma mk_bUnion_le {ι α : Type u} (A : ι → set α) (s : set ι) :
-  mk (⋃(x ∈ s), A x) ≤ mk s * cardinal.sup.{u u} (λ x : s, mk (A x.1)) :=
+  #(⋃(x ∈ s), A x) ≤ #s * cardinal.sup.{u u} (λ x : s, #(A x.1)) :=
 by { rw [bUnion_eq_Union], apply mk_Union_le }
 
-@[simp] lemma finset_card {α : Type u} {s : finset α} : ↑(finset.card s) = mk s :=
+@[simp] lemma finset_card {α : Type u} {s : finset α} : ↑(finset.card s) = #s :=
 by rw [fintype_card, nat_cast_inj, fintype.card_coe]
 
-lemma finset_card_lt_omega (s : finset α) : mk (↑s : set α) < omega :=
+lemma finset_card_lt_omega (s : finset α) : #(↑s : set α) < ω :=
 by { rw [lt_omega_iff_fintype], exact ⟨finset.subtype.fintype s⟩ }
 
 theorem mk_eq_nat_iff_finset {α} {s : set α} {n : ℕ} :
-  mk s = n ↔ ∃ t : finset α, (t : set α) = s ∧ t.card = n :=
+  #s = n ↔ ∃ t : finset α, (t : set α) = s ∧ t.card = n :=
 begin
   split,
   { intro h,
@@ -1193,58 +1197,58 @@ begin
 end
 
 theorem mk_union_add_mk_inter {α : Type u} {S T : set α} :
-  mk (S ∪ T : set α) + mk (S ∩ T : set α) = mk S + mk T :=
+  #(S ∪ T : set α) + #(S ∩ T : set α) = #S + #T :=
 quot.sound ⟨equiv.set.union_sum_inter S T⟩
 
 /-- The cardinality of a union is at most the sum of the cardinalities
 of the two sets. -/
-lemma mk_union_le {α : Type u} (S T : set α) : mk (S ∪ T : set α) ≤ mk S + mk T :=
-@mk_union_add_mk_inter α S T ▸ self_le_add_right (mk (S ∪ T : set α)) (mk (S ∩ T : set α))
+lemma mk_union_le {α : Type u} (S T : set α) : #(S ∪ T : set α) ≤ #S + #T :=
+@mk_union_add_mk_inter α S T ▸ self_le_add_right (#(S ∪ T : set α)) (#(S ∩ T : set α))
 
 theorem mk_union_of_disjoint {α : Type u} {S T : set α} (H : disjoint S T) :
-  mk (S ∪ T : set α) = mk S + mk T :=
+  #(S ∪ T : set α) = #S + #T :=
 quot.sound ⟨equiv.set.union H⟩
 
 lemma mk_sum_compl {α} (s : set α) : #s + #(sᶜ : set α) = #α :=
 quotient.sound ⟨equiv.set.sum_compl s⟩
 
-lemma mk_le_mk_of_subset {α} {s t : set α} (h : s ⊆ t) : mk s ≤ mk t :=
+lemma mk_le_mk_of_subset {α} {s t : set α} (h : s ⊆ t) : #s ≤ #t :=
 ⟨set.embedding_of_subset s t h⟩
 
-lemma mk_subtype_mono {p q : α → Prop} (h : ∀x, p x → q x) : mk {x // p x} ≤ mk {x // q x} :=
+lemma mk_subtype_mono {p q : α → Prop} (h : ∀x, p x → q x) : #{x // p x} ≤ #{x // q x} :=
 ⟨embedding_of_subset _ _ h⟩
 
-lemma mk_set_le (s : set α) : mk s ≤ mk α :=
+lemma mk_set_le (s : set α) : #s ≤ #α :=
 mk_subtype_le s
 
 lemma mk_image_eq_lift {α : Type u} {β : Type v} (f : α → β) (s : set α) (h : injective f) :
-  lift.{v u} (mk (f '' s)) = lift.{u v} (mk s) :=
+  lift.{v u} (#(f '' s)) = lift.{u v} (#s) :=
 lift_mk_eq.{v u 0}.mpr ⟨(equiv.set.image f s h).symm⟩
 
 lemma mk_image_eq_of_inj_on_lift {α : Type u} {β : Type v} (f : α → β) (s : set α)
-  (h : inj_on f s) : lift.{v u} (mk (f '' s)) = lift.{u v} (mk s) :=
+  (h : inj_on f s) : lift.{v u} (#(f '' s)) = lift.{u v} (#s) :=
 lift_mk_eq.{v u 0}.mpr ⟨(equiv.set.image_of_inj_on f s h).symm⟩
 
 lemma mk_image_eq_of_inj_on {α β : Type u} (f : α → β) (s : set α) (h : inj_on f s) :
-  mk (f '' s) = mk s :=
+  #(f '' s) = #s :=
 quotient.sound ⟨(equiv.set.image_of_inj_on f s h).symm⟩
 
 lemma mk_subtype_of_equiv {α β : Type u} (p : β → Prop) (e : α ≃ β) :
-  mk {a : α // p (e a)} = mk {b : β // p b} :=
+  #{a : α // p (e a)} = #{b : β // p b} :=
 quotient.sound ⟨equiv.subtype_equiv_of_subtype e⟩
 
-lemma mk_sep (s : set α) (t : α → Prop) : mk ({ x ∈ s | t x } : set α) = mk { x : s | t x.1 } :=
+lemma mk_sep (s : set α) (t : α → Prop) : #({ x ∈ s | t x } : set α) = #{ x : s | t x.1 } :=
 quotient.sound ⟨equiv.set.sep s t⟩
 
 lemma mk_preimage_of_injective_lift {α : Type u} {β : Type v} (f : α → β) (s : set β)
-  (h : injective f) : lift.{u v} (mk (f ⁻¹' s)) ≤ lift.{v u} (mk s) :=
+  (h : injective f) : lift.{u v} (#(f ⁻¹' s)) ≤ lift.{v u} (#s) :=
 begin
   rw lift_mk_le.{u v 0}, use subtype.coind (λ x, f x.1) (λ x, x.2),
   apply subtype.coind_injective, exact h.comp subtype.val_injective
 end
 
 lemma mk_preimage_of_subset_range_lift {α : Type u} {β : Type v} (f : α → β) (s : set β)
-  (h : s ⊆ range f) : lift.{v u} (mk s) ≤ lift.{u v} (mk (f ⁻¹' s)) :=
+  (h : s ⊆ range f) : lift.{v u} (#s) ≤ lift.{u v} (#(f ⁻¹' s)) :=
 begin
   rw lift_mk_le.{v u 0},
   refine ⟨⟨_, _⟩⟩,
@@ -1256,52 +1260,52 @@ begin
 end
 
 lemma mk_preimage_of_injective_of_subset_range_lift {β : Type v} (f : α → β) (s : set β)
-  (h : injective f) (h2 : s ⊆ range f) : lift.{u v} (mk (f ⁻¹' s)) = lift.{v u} (mk s) :=
+  (h : injective f) (h2 : s ⊆ range f) : lift.{u v} (#(f ⁻¹' s)) = lift.{v u} (#s) :=
 le_antisymm (mk_preimage_of_injective_lift f s h) (mk_preimage_of_subset_range_lift f s h2)
 
 lemma mk_preimage_of_injective (f : α → β) (s : set β) (h : injective f) :
-  mk (f ⁻¹' s) ≤ mk s :=
+  #(f ⁻¹' s) ≤ #s :=
 by { convert mk_preimage_of_injective_lift.{u u} f s h using 1; rw [lift_id] }
 
 lemma mk_preimage_of_subset_range (f : α → β) (s : set β)
-  (h : s ⊆ range f) : mk s ≤ mk (f ⁻¹' s) :=
+  (h : s ⊆ range f) : #s ≤ #(f ⁻¹' s) :=
 by { convert mk_preimage_of_subset_range_lift.{u u} f s h using 1; rw [lift_id] }
 
 lemma mk_preimage_of_injective_of_subset_range (f : α → β) (s : set β)
-  (h : injective f) (h2 : s ⊆ range f) : mk (f ⁻¹' s) = mk s :=
+  (h : injective f) (h2 : s ⊆ range f) : #(f ⁻¹' s) = #s :=
 by { convert mk_preimage_of_injective_of_subset_range_lift.{u u} f s h h2 using 1; rw [lift_id] }
 
 lemma mk_subset_ge_of_subset_image_lift {α : Type u} {β : Type v} (f : α → β) {s : set α}
   {t : set β} (h : t ⊆ f '' s) :
-    lift.{v u} (mk t) ≤ lift.{u v} (mk ({ x ∈ s | f x ∈ t } : set α)) :=
+    lift.{v u} (#t) ≤ lift.{u v} (#({ x ∈ s | f x ∈ t } : set α)) :=
 by { rw [image_eq_range] at h, convert mk_preimage_of_subset_range_lift _ _ h using 1,
      rw [mk_sep], refl }
 
 lemma mk_subset_ge_of_subset_image (f : α → β) {s : set α} {t : set β} (h : t ⊆ f '' s) :
-  mk t ≤ mk ({ x ∈ s | f x ∈ t } : set α) :=
+  #t ≤ #({ x ∈ s | f x ∈ t } : set α) :=
 by { rw [image_eq_range] at h, convert mk_preimage_of_subset_range _ _ h using 1,
      rw [mk_sep], refl }
 
 theorem le_mk_iff_exists_subset {c : cardinal} {α : Type u} {s : set α} :
-  c ≤ mk s ↔ ∃ p : set α, p ⊆ s ∧ mk p = c :=
+  c ≤ #s ↔ ∃ p : set α, p ⊆ s ∧ #p = c :=
 begin
   rw [le_mk_iff_exists_set, ←subtype.exists_set_subtype],
   apply exists_congr, intro t, rw [mk_image_eq], apply subtype.val_injective
 end
 
 /-- The function α^{<β}, defined to be sup_{γ < β} α^γ.
-  We index over {s : set β.out // mk s < β } instead of {γ // γ < β}, because the latter lives in a
+  We index over {s : set β.out // #s < β } instead of {γ // γ < β}, because the latter lives in a
   higher universe -/
 noncomputable def powerlt (α β : cardinal.{u}) : cardinal.{u} :=
-sup.{u u} (λ(s : {s : set β.out // mk s < β}), α ^ mk.{u} s)
+sup.{u u} (λ(s : {s : set β.out // #s < β}), α ^ mk.{u} s)
 
 infix ` ^< `:80 := powerlt
 
 theorem powerlt_aux {c c' : cardinal} (h : c < c') :
-  ∃(s : {s : set c'.out // mk s < c'}), mk s = c :=
+  ∃(s : {s : set c'.out // #s < c'}), #s = c :=
 begin
   cases out_embedding.mp (le_of_lt h) with f,
-  have : mk ↥(range ⇑f) = c, { rwa [mk_range_eq, mk, quotient.out_eq c], exact f.2 },
+  have : #↥(range ⇑f) = c, { rwa [mk_range_eq, mk, quotient.out_eq c], exact f.2 },
   exact ⟨⟨range f, by convert h⟩, this⟩
 end
 
@@ -1343,6 +1347,3 @@ begin
 end
 
 end cardinal
-
-lemma equiv.cardinal_eq {α β} : α ≃ β → cardinal.mk α = cardinal.mk β :=
-cardinal.eq_congr

--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -116,7 +116,7 @@ end
 @[simp] theorem type_cardinal : @ordinal.type cardinal (<) _ = ordinal.univ.{u (u+1)} :=
 by rw ordinal.univ_id; exact quotient.sound ⟨aleph_idx.rel_iso⟩
 
-@[simp] theorem mk_cardinal : mk cardinal = univ.{u (u+1)} :=
+@[simp] theorem mk_cardinal : #cardinal = univ.{u (u+1)} :=
 by simpa only [card_type, card_univ] using congr_arg card type_cardinal
 
 /-- The `aleph'` function gives the cardinals listed by their ordinal
@@ -468,24 +468,24 @@ end
 
 /-! ### Computing cardinality of various types -/
 
-theorem mk_list_eq_mk {α : Type u} (H1 : omega ≤ mk α) : mk (list α) = mk α :=
+theorem mk_list_eq_mk {α : Type u} (H1 : ω ≤ #α) : #(list α) = #α :=
 eq.symm $ le_antisymm ⟨⟨λ x, [x], λ x y H, (list.cons.inj H).1⟩⟩ $
-calc  mk (list α)
-    = sum (λ n : ℕ, mk α ^ (n : cardinal.{u})) : mk_list_eq_sum_pow α
-... ≤ sum (λ n : ℕ, mk α) : sum_le_sum _ _ $ λ n, pow_le H1 $ nat_lt_omega n
-... = sum (λ n : ulift.{u} ℕ, mk α) : quotient.sound
-  ⟨@sigma_congr_left _ _ (λ _, quotient.out (mk α)) equiv.ulift.symm⟩
-... = omega * mk α : sum_const _ _
-... = max (omega) (mk α) : mul_eq_max (le_refl _) H1
-... = mk α : max_eq_right H1
+calc  #(list α)
+    = sum (λ n : ℕ, #α ^ (n : cardinal.{u})) : mk_list_eq_sum_pow α
+... ≤ sum (λ n : ℕ, #α) : sum_le_sum _ _ $ λ n, pow_le H1 $ nat_lt_omega n
+... = sum (λ n : ulift.{u} ℕ, #α) : quotient.sound
+  ⟨@sigma_congr_left _ _ (λ _, quotient.out (#α)) equiv.ulift.symm⟩
+... = omega * #α : sum_const _ _
+... = max ω (#α) : mul_eq_max (le_refl _) H1
+... = #α : max_eq_right H1
 
-theorem mk_finset_eq_mk {α : Type u} (h : omega ≤ mk α) : mk (finset α) = mk α :=
+theorem mk_finset_eq_mk {α : Type u} (h : omega ≤ #α) : #(finset α) = #α :=
 eq.symm $ le_antisymm (mk_le_of_injective (λ x y, finset.singleton_inj.1)) $
-calc mk (finset α) ≤ mk (list α) : mk_le_of_surjective list.to_finset_surjective
-... = mk α : mk_list_eq_mk h
+calc #(finset α) ≤ #(list α) : mk_le_of_surjective list.to_finset_surjective
+... = #α : mk_list_eq_mk h
 
-lemma mk_bounded_set_le_of_omega_le (α : Type u) (c : cardinal) (hα : omega ≤ mk α) :
-  mk {t : set α // mk t ≤ c} ≤ mk α ^ c :=
+lemma mk_bounded_set_le_of_omega_le (α : Type u) (c : cardinal) (hα : omega ≤ #α) :
+  #{t : set α // mk t ≤ c} ≤ #α ^ c :=
 begin
   refine le_trans _ (by rw [←add_one_eq hα]), refine quotient.induction_on c _, clear c, intro β,
   fapply mk_le_of_surjective,
@@ -506,18 +506,18 @@ begin
 end
 
 lemma mk_bounded_set_le (α : Type u) (c : cardinal) :
-  mk {t : set α // mk t ≤ c} ≤ max (mk α) omega ^ c :=
+  #{t : set α // #t ≤ c} ≤ max (#α) omega ^ c :=
 begin
-  transitivity mk {t : set (ulift.{u} nat ⊕ α) // mk t ≤ c},
+  transitivity #{t : set (ulift.{u} nat ⊕ α) // #t ≤ c},
   { refine ⟨embedding.subtype_map _ _⟩, apply embedding.image,
     use sum.inr, apply sum.inr.inj, intros s hs, exact le_trans mk_image_le hs },
   refine le_trans
-    (mk_bounded_set_le_of_omega_le (ulift.{u} nat ⊕ α) c (self_le_add_right omega (mk α))) _,
+    (mk_bounded_set_le_of_omega_le (ulift.{u} nat ⊕ α) c (self_le_add_right omega (#α))) _,
   rw [max_comm, ←add_eq_max]; refl
 end
 
 lemma mk_bounded_subset_le {α : Type u} (s : set α) (c : cardinal.{u}) :
-  mk {t : set α // t ⊆ s ∧ mk t ≤ c} ≤ max (mk s) omega ^ c :=
+  #{t : set α // t ⊆ s ∧ #t ≤ c} ≤ max (#s) omega ^ c :=
 begin
   refine le_trans _ (mk_bounded_set_le s c),
   refine ⟨embedding.cod_restrict _ _ _⟩,

--- a/src/set_theory/cofinality.lean
+++ b/src/set_theory/cofinality.lean
@@ -17,15 +17,15 @@ This file contains the definition of cofinality of a ordinal number and regular 
 * `cardinal.is_limit c` means that `c` is a (weak) limit cardinal: `c ≠ 0 ∧ ∀ x < c, succ x < c`.
 * `cardinal.is_strong_limit c` means that `c` is a strong limit cardinal:
   `c ≠ 0 ∧ ∀ x < c, 2 ^ x < c`.
-* `cardinal.is_regular c` means that `c` is a regular cardinal: `omega ≤ c ∧ c.ord.cof = c`.
+* `cardinal.is_regular c` means that `c` is a regular cardinal: `ω ≤ c ∧ c.ord.cof = c`.
 * `cardinal.is_inaccessible c` means that `c` is strongly inaccessible:
-  `omega < c ∧ is_regular c ∧ is_strong_limit c`.
+  `ω < c ∧ is_regular c ∧ is_strong_limit c`.
 
 ## Main Statements
 
 * `ordinal.infinite_pigeonhole_card`: the infinite pigeonhole principle
 * `cardinal.lt_power_cof`: A consequence of König's theorem stating that `c < c ^ c.ord.cof` for
-  `c ≥ cardinal.omega`
+  `c ≥ ω`
 * `cardinal.univ_inaccessible`: The type of ordinals in `Type u` form an inaccessible cardinal
   (in `Type v` with `v > u`). This shows (externally) that in `Type u` there are at least `u`
   inaccessible cardinals.
@@ -45,7 +45,7 @@ infinite pigeonhole principle
 noncomputable theory
 
 open function cardinal set
-open_locale classical
+open_locale classical cardinal
 
 universes u v w
 variables {α : Type*} {r : α → α → Prop}
@@ -56,14 +56,14 @@ namespace order
 def cof (r : α → α → Prop) [is_refl α r] : cardinal :=
 @cardinal.min {S : set α // ∀ a, ∃ b ∈ S, r a b}
   ⟨⟨set.univ, λ a, ⟨a, ⟨⟩, refl _⟩⟩⟩
-  (λ S, mk S)
+  (λ S, #S)
 
 lemma cof_le (r : α → α → Prop) [is_refl α r] {S : set α} (h : ∀a, ∃(b ∈ S), r a b) :
-  order.cof r ≤ mk S :=
+  order.cof r ≤ #S :=
 le_trans (cardinal.min_le _ ⟨S, h⟩) (le_refl _)
 
 lemma le_cof {r : α → α → Prop} [is_refl α r] (c : cardinal) :
-  c ≤ order.cof r ↔ ∀ {S : set α} (h : ∀a, ∃(b ∈ S), r a b) , c ≤ mk S :=
+  c ≤ order.cof r ↔ ∀ {S : set α} (h : ∀a, ∃(b ∈ S), r a b) , c ≤ #S :=
 by { rw [order.cof, cardinal.le_min], exact ⟨λ H S h, H ⟨S, h⟩, λ H ⟨S, h⟩, H h ⟩ }
 
 end order
@@ -112,20 +112,20 @@ end
 lemma cof_type (r : α → α → Prop) [is_well_order α r] : (type r).cof = strict_order.cof r := rfl
 
 theorem le_cof_type [is_well_order α r] {c} : c ≤ cof (type r) ↔
-  ∀ S : set α, (∀ a, ∃ b ∈ S, ¬ r b a) → c ≤ mk S :=
+  ∀ S : set α, (∀ a, ∃ b ∈ S, ¬ r b a) → c ≤ #S :=
 by dsimp [cof, strict_order.cof, order.cof, type, quotient.mk, quot.lift_on];
    rw [cardinal.le_min, subtype.forall]; refl
 
 theorem cof_type_le [is_well_order α r] (S : set α) (h : ∀ a, ∃ b ∈ S, ¬ r b a) :
-  cof (type r) ≤ mk S :=
+  cof (type r) ≤ #S :=
 le_cof_type.1 (le_refl _) S h
 
-theorem lt_cof_type [is_well_order α r] (S : set α) (hl : mk S < cof (type r)) :
+theorem lt_cof_type [is_well_order α r] (S : set α) (hl : #S < cof (type r)) :
   ∃ a, ∀ b ∈ S, r b a :=
 not_forall_not.1 $ λ h, not_le_of_lt hl $ cof_type_le S (λ a, not_ball.1 (h a))
 
 theorem cof_eq (r : α → α → Prop) [is_well_order α r] :
-  ∃ S : set α, (∀ a, ∃ b ∈ S, ¬ r b a) ∧ mk S = cof (type r) :=
+  ∃ S : set α, (∀ a, ∃ b ∈ S, ¬ r b a) ∧ #S = cof (type r) :=
 begin
   have : ∃ i, cof (type r) = _,
   { dsimp [cof, order.cof, type, quotient.mk, quot.lift_on],
@@ -165,13 +165,13 @@ induction_on o $ begin introsI α r _,
   cases lift_type r with _ e, rw e,
   apply le_antisymm,
   { unfreezingI { refine le_cof_type.2 (λ S H, _) },
-    have : (mk (ulift.up ⁻¹' S)).lift ≤ mk S :=
+    have : (#(ulift.up ⁻¹' S)).lift ≤ #S :=
      ⟨⟨λ ⟨⟨x, h⟩⟩, ⟨⟨x⟩, h⟩,
        λ ⟨⟨x, h₁⟩⟩ ⟨⟨y, h₂⟩⟩ e, by simp at e; congr; injection e⟩⟩,
     refine le_trans (cardinal.lift_le.2 $ cof_type_le _ _) this,
     exact λ a, let ⟨⟨b⟩, bs, br⟩ := H ⟨a⟩ in ⟨b, bs, br⟩ },
   { rcases cof_eq r with ⟨S, H, e'⟩,
-    have : mk (ulift.down ⁻¹' S) ≤ (mk S).lift :=
+    have : #(ulift.down ⁻¹' S) ≤ (#S).lift :=
      ⟨⟨λ ⟨⟨x⟩, h⟩, ⟨⟨x, h⟩⟩,
        λ ⟨⟨x⟩, h₁⟩ ⟨⟨y⟩, h₂⟩ e, by simp at e; congr; injections⟩⟩,
     rw e' at this,
@@ -182,7 +182,7 @@ end
 theorem cof_le_card (o) : cof o ≤ card o :=
 induction_on o $ λ α r _, begin
   resetI,
-  have : mk (@set.univ α) = card (type r) :=
+  have : #(@set.univ α) = card (type r) :=
     quotient.sound ⟨equiv.set.univ _⟩,
   rw ← this, exact cof_type_le set.univ (λ a, ⟨a, ⟨⟩, irrefl a⟩)
 end
@@ -205,7 +205,7 @@ begin
   apply le_antisymm,
   { refine induction_on o (λ α r _, _),
     change cof (type _) ≤ _,
-    rw [← (_ : mk _ = 1)], apply cof_type_le,
+    rw [← (_ : #_ = 1)], apply cof_type_le,
     { refine λ a, ⟨sum.inr punit.star, set.mem_singleton _, _⟩,
       rcases a with a|⟨⟨⟨⟩⟩⟩; simp [empty_relation] },
     { rw [cardinal.fintype_card, set.card_singleton], simp } },
@@ -278,7 +278,7 @@ let ⟨S, hS, e₁⟩ := ord_cof_eq r,
       by injection h with h; congr; injection h },
 end
 
-theorem omega_le_cof {o} : cardinal.omega ≤ cof o ↔ is_limit o :=
+theorem omega_le_cof {o} : ω ≤ cof o ↔ is_limit o :=
 begin
   rcases zero_or_succ_or_limit o with rfl|⟨o,rfl⟩|l,
   { simp [not_zero_is_limit, cardinal.omega_ne_zero] },
@@ -295,13 +295,13 @@ begin
       exact not_succ_is_limit _ l } }
 end
 
-@[simp] theorem cof_omega : cof omega = cardinal.omega :=
+@[simp] theorem cof_omega : cof omega = ω :=
 le_antisymm
   (by rw ← card_omega; apply cof_le_card)
   (omega_le_cof.2 omega_is_limit)
 
 theorem cof_eq' (r : α → α → Prop) [is_well_order α r] (h : is_limit (type r)) :
-  ∃ S : set α, (∀ a, ∃ b ∈ S, r a b) ∧ mk S = cof (type r) :=
+  ∃ S : set α, (∀ a, ∃ b ∈ S, r a b) ∧ #S = cof (type r) :=
 let ⟨S, H, e⟩ := cof_eq r in
 ⟨S, λ a,
   let a' := enum r _ (h.2 _ (typein_lt_type r a)) in
@@ -311,7 +311,7 @@ let ⟨S, H, e⟩ := cof_eq r in
 e⟩
 
 theorem cof_sup_le_lift {ι} (f : ι → ordinal) (H : ∀ i, f i < sup f) :
-  cof (sup f) ≤ (mk ι).lift :=
+  cof (sup f) ≤ (#ι).lift :=
 begin
   generalize e : sup f = o,
   refine ordinal.induction_on o _ e, introsI α r _ e',
@@ -329,7 +329,7 @@ begin
 end
 
 theorem cof_sup_le {ι} (f : ι → ordinal) (H : ∀ i, f i < sup.{u u} f) :
-  cof (sup.{u u} f) ≤ mk ι :=
+  cof (sup.{u u} f) ≤ #ι :=
 by simpa using cof_sup_le_lift.{u u} f H
 
 theorem cof_bsup_le_lift {o : ordinal} : ∀ (f : Π a < o, ordinal), (∀ i h, f i h < bsup o f) →
@@ -362,7 +362,7 @@ le_antisymm (cof_le_card _) begin
   apply le_sup
 end
 
-theorem sup_lt_ord {ι} (f : ι → ordinal) {c : ordinal} (H1 : cardinal.mk ι < c.cof)
+theorem sup_lt_ord {ι} (f : ι → ordinal) {c : ordinal} (H1 : #ι < c.cof)
   (H2 : ∀ i, f i < c) : sup.{u u} f < c :=
 begin
   apply lt_of_le_of_ne,
@@ -371,20 +371,20 @@ begin
   simpa [sup_ord, H2, h] using cof_sup_le.{u} f
 end
 
-theorem sup_lt {ι} (f : ι → cardinal) {c : cardinal} (H1 : cardinal.mk ι < c.ord.cof)
+theorem sup_lt {ι} (f : ι → cardinal) {c : cardinal} (H1 : #ι < c.ord.cof)
   (H2 : ∀ i, f i < c) : cardinal.sup.{u u} f < c :=
 by { rw [←ord_lt_ord, ←sup_ord], apply sup_lt_ord _ H1, intro i, rw ord_lt_ord, apply H2 }
 
 /-- If the union of s is unbounded and s is smaller than the cofinality,
   then s has an unbounded member -/
 theorem unbounded_of_unbounded_sUnion (r : α → α → Prop) [wo : is_well_order α r] {s : set (set α)}
-  (h₁ : unbounded r $ ⋃₀ s) (h₂ : mk s < strict_order.cof r) : ∃(x ∈ s), unbounded r x :=
+  (h₁ : unbounded r $ ⋃₀ s) (h₂ : #s < strict_order.cof r) : ∃(x ∈ s), unbounded r x :=
 begin
   by_contra h, simp only [not_exists, exists_prop, not_and, not_unbounded_iff] at h,
   apply not_le_of_lt h₂,
   let f : s → α := λ x : s, wo.wf.sup x (h x.1 x.2),
   let t : set α := range f,
-  have : mk t ≤ mk s, exact mk_range_le, refine le_trans _ this,
+  have : #t ≤ #s, exact mk_range_le, refine le_trans _ this,
   have : unbounded r t,
   { intro x, rcases h₁ x with ⟨y, ⟨c, hc, hy⟩, hxy⟩,
     refine ⟨f ⟨c, hc⟩, mem_range_self _, _⟩, intro hxz, apply hxy,
@@ -396,18 +396,18 @@ end
   then s has an unbounded member -/
 theorem unbounded_of_unbounded_Union {α β : Type u} (r : α → α → Prop) [wo : is_well_order α r]
   (s : β → set α)
-  (h₁ : unbounded r $ ⋃x, s x) (h₂ : mk β < strict_order.cof r) : ∃x : β, unbounded r (s x) :=
+  (h₁ : unbounded r $ ⋃x, s x) (h₂ : #β < strict_order.cof r) : ∃x : β, unbounded r (s x) :=
 begin
   rw [← sUnion_range] at h₁,
-  have : mk ↥(range (λ (i : β), s i)) < strict_order.cof r := lt_of_le_of_lt mk_range_le h₂,
+  have : #(range (λ (i : β), s i)) < strict_order.cof r := lt_of_le_of_lt mk_range_le h₂,
   rcases unbounded_of_unbounded_sUnion r h₁ this with ⟨_, ⟨x, rfl⟩, u⟩, exact ⟨x, u⟩
 end
 
 /-- The infinite pigeonhole principle -/
-theorem infinite_pigeonhole {β α : Type u} (f : β → α) (h₁ : cardinal.omega ≤ mk β)
-  (h₂ : mk α < (mk β).ord.cof) : ∃a : α, mk (f ⁻¹' {a}) = mk β :=
+theorem infinite_pigeonhole {β α : Type u} (f : β → α) (h₁ : ω ≤ #β)
+  (h₂ : #α < (#β).ord.cof) : ∃a : α, #(f ⁻¹' {a}) = #β :=
 begin
-  have : ¬∀a, mk (f ⁻¹' {a}) < mk β,
+  have : ¬∀a, #(f ⁻¹' {a}) < #β,
   { intro h,
     apply not_lt_of_ge (ge_of_eq $ mk_univ),
     rw [←@preimage_univ _ _ f, ←Union_of_singleton, preimage_Union],
@@ -421,8 +421,8 @@ begin
 end
 
 /-- pigeonhole principle for a cardinality below the cardinality of the domain -/
-theorem infinite_pigeonhole_card {β α : Type u} (f : β → α) (θ : cardinal) (hθ : θ ≤ mk β)
-  (h₁ : cardinal.omega ≤ θ) (h₂ : mk α < θ.ord.cof) : ∃a : α, θ ≤ mk (f ⁻¹' {a}) :=
+theorem infinite_pigeonhole_card {β α : Type u} (f : β → α) (θ : cardinal) (hθ : θ ≤ #β)
+  (h₁ : ω ≤ θ) (h₂ : #α < θ.ord.cof) : ∃a : α, θ ≤ #(f ⁻¹' {a}) :=
 begin
   rcases le_mk_iff_exists_set.1 hθ with ⟨s, rfl⟩,
   cases infinite_pigeonhole (f ∘ subtype.val : s → α) h₁ h₂ with a ha,
@@ -431,8 +431,8 @@ begin
 end
 
 theorem infinite_pigeonhole_set {β α : Type u} {s : set β} (f : s → α) (θ : cardinal)
-  (hθ : θ ≤ mk s) (h₁ : cardinal.omega ≤ θ) (h₂ : mk α < θ.ord.cof) :
-    ∃(a : α) (t : set β) (h : t ⊆ s), θ ≤ mk t ∧ ∀{{x}} (hx : x ∈ t), f ⟨x, h hx⟩ = a :=
+  (hθ : θ ≤ #s) (h₁ : ω ≤ θ) (h₂ : #α < θ.ord.cof) :
+    ∃(a : α) (t : set β) (h : t ⊆ s), θ ≤ #t ∧ ∀{{x}} (hx : x ∈ t), f ⟨x, h hx⟩ = a :=
 begin
   cases infinite_pigeonhole_card f θ hθ h₁ h₂ with a ha,
   refine ⟨a, {x | ∃(h : x ∈ s), f ⟨x, h⟩ = a}, _, _, _⟩,
@@ -465,15 +465,15 @@ theorem is_strong_limit.is_limit {c} (H : is_strong_limit c) : is_limit c :=
 
 /-- A cardinal is regular if it is infinite and it equals its own cofinality. -/
 def is_regular (c : cardinal) : Prop :=
-omega ≤ c ∧ c.ord.cof = c
+ω ≤ c ∧ c.ord.cof = c
 
 theorem cof_is_regular {o : ordinal} (h : o.is_limit) : is_regular o.cof :=
 ⟨omega_le_cof.2 h, cof_cof _⟩
 
-theorem omega_is_regular : is_regular omega :=
+theorem omega_is_regular : is_regular ω :=
 ⟨le_refl _, by simp⟩
 
-theorem succ_is_regular {c : cardinal.{u}} (h : omega ≤ c) : is_regular (succ c) :=
+theorem succ_is_regular {c : cardinal.{u}} (h : ω ≤ c) : is_regular (succ c) :=
 ⟨le_trans h (le_of_lt $ lt_succ_self _), begin
   refine le_antisymm (cof_ord_le _) (succ_le.2 _),
   cases quotient.exists_rep (succ c) with α αe, simp at αe,
@@ -483,7 +483,7 @@ theorem succ_is_regular {c : cardinal.{u}} (h : omega ≤ c) : is_regular (succ 
   rcases cof_eq' r this with ⟨S, H, Se⟩,
   rw [← Se],
   apply lt_imp_lt_of_le_imp_le
-    (λ (h : mk S ≤ c), mul_le_mul_right' h c),
+    (λ (h : #S ≤ c), mul_le_mul_right' h c),
   rw [mul_eq_self h, ← succ_le, ← αe, ← sum_const],
   refine le_trans _ (sum_le_sum (λ x:S, card (typein r x)) _ _),
   { simp [typein, sum_mk (λ x:S, {a//r a x})],
@@ -500,11 +500,11 @@ A function whose codomain's cardinality is infinite but strictly smaller than it
 has a fiber with cardinality strictly great than the codomain.
 -/
 theorem infinite_pigeonhole_card_lt {β α : Type u} (f : β → α)
-  (w : mk α < mk β) (w' : omega ≤ mk α) :
-  ∃ a : α, mk α < mk (f ⁻¹' {a}) :=
+  (w : #α < #β) (w' : ω ≤ #α) :
+  ∃ a : α, #α < #(f ⁻¹' {a}) :=
 begin
   simp_rw [← succ_le],
-  exact ordinal.infinite_pigeonhole_card f (mk α).succ (succ_le.mpr w)
+  exact ordinal.infinite_pigeonhole_card f (#α).succ (succ_le.mpr w)
     (w'.trans (lt_succ_self _).le)
     ((lt_succ_self _).trans_le (succ_is_regular w').2.ge),
 end
@@ -514,7 +514,7 @@ A function whose codomain's cardinality is infinite but strictly smaller than it
 has an infinite fiber.
 -/
 theorem exists_infinite_fiber {β α : Type*} (f : β → α)
-  (w : mk α < mk β) (w' : _root_.infinite α) :
+  (w : #α < #β) (w' : _root_.infinite α) :
   ∃ a : α, _root_.infinite (f ⁻¹' {a}) :=
 begin
   simp_rw [cardinal.infinite_iff] at ⊢ w',
@@ -529,7 +529,7 @@ must be at least the cardinality of `β`.
 -/
 lemma le_range_of_union_finset_eq_top
   {α β : Type*} [infinite β] (f : α → finset β) (w : (⋃ a, (f a : set β)) = ⊤) :
-  mk β ≤ mk (range f) :=
+  #β ≤ #(range f) :=
 begin
   have k : _root_.infinite (range f),
   { rw infinite_coe_iff,
@@ -550,27 +550,27 @@ begin
 end
 
 theorem sup_lt_ord_of_is_regular {ι} (f : ι → ordinal)
-  {c} (hc : is_regular c) (H1 : cardinal.mk ι < c)
+  {c} (hc : is_regular c) (H1 : #ι < c)
   (H2 : ∀ i, f i < c.ord) : ordinal.sup.{u u} f < c.ord :=
 by { apply sup_lt_ord _ _ H2, rw [hc.2], exact H1 }
 
 theorem sup_lt_of_is_regular {ι} (f : ι → cardinal)
-  {c} (hc : is_regular c) (H1 : cardinal.mk ι < c)
+  {c} (hc : is_regular c) (H1 : #ι < c)
   (H2 : ∀ i, f i < c) : sup.{u u} f < c :=
 by { apply sup_lt _ _ H2, rwa [hc.2] }
 
 theorem sum_lt_of_is_regular {ι} (f : ι → cardinal)
-  {c} (hc : is_regular c) (H1 : cardinal.mk ι < c)
+  {c} (hc : is_regular c) (H1 : #ι < c)
   (H2 : ∀ i, f i < c) : sum.{u u} f < c :=
 lt_of_le_of_lt (sum_le_sup _) $ mul_lt_of_lt hc.1 H1 $
 sup_lt_of_is_regular f hc H1 H2
 
 /-- A cardinal is inaccessible if it is an uncountable regular strong limit cardinal. -/
 def is_inaccessible (c : cardinal) :=
-omega < c ∧ is_regular c ∧ is_strong_limit c
+ω < c ∧ is_regular c ∧ is_strong_limit c
 
 theorem is_inaccessible.mk {c}
- (h₁ : omega < c) (h₂ : c ≤ c.ord.cof) (h₃ : ∀ x < c, 2 ^ x < c) :
+ (h₁ : ω < c) (h₂ : c ≤ c.ord.cof) (h₃ : ∀ x < c, 2 ^ x < c) :
  is_inaccessible c :=
 ⟨h₁, ⟨le_of_lt h₁, le_antisymm (cof_ord_le _) h₂⟩,
   ne_of_gt (lt_trans omega_pos h₁), h₃⟩
@@ -578,7 +578,7 @@ theorem is_inaccessible.mk {c}
 /- Lean's foundations prove the existence of ω many inaccessible cardinals -/
 theorem univ_inaccessible : is_inaccessible (univ.{u v}) :=
 is_inaccessible.mk
-  (by simpa using lift_lt_univ' omega)
+  (by simpa using lift_lt_univ' ω)
   (by simp)
   (λ c h, begin
     rcases lt_univ'.1 h with ⟨c, rfl⟩,
@@ -586,13 +586,13 @@ is_inaccessible.mk
     apply lift_lt_univ'
   end)
 
-theorem lt_power_cof {c : cardinal.{u}} : omega ≤ c → c < c ^ cof c.ord :=
+theorem lt_power_cof {c : cardinal.{u}} : ω ≤ c → c < c ^ cof c.ord :=
 quotient.induction_on c $ λ α h, begin
   rcases ord_eq α with ⟨r, wo, re⟩, resetI,
   have := ord_is_limit h,
   rw [mk_def, re] at this ⊢,
   rcases cof_eq' r this with ⟨S, H, Se⟩,
-  have := sum_lt_prod (λ a:S, mk {x // r x a}) (λ _, mk α) (λ i, _),
+  have := sum_lt_prod (λ a:S, #{x // r x a}) (λ _, #α) (λ i, _),
   { simp [Se.symm] at this ⊢,
     refine lt_of_le_of_lt _ this,
     refine ⟨embedding.of_surjective _ _⟩,
@@ -602,7 +602,7 @@ quotient.induction_on c $ λ α h, begin
     rwa [← re, lt_ord] at this }
 end
 
-theorem lt_cof_power {a b : cardinal} (ha : omega ≤ a) (b1 : 1 < b) :
+theorem lt_cof_power {a b : cardinal} (ha : ω ≤ a) (b1 : 1 < b) :
   a < cof (b ^ a).ord :=
 begin
   have b0 : b ≠ 0 := ne_of_gt (lt_trans zero_lt_one b1),

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -713,14 +713,14 @@ def typein.principal_seg {α : Type u} (r : α → α → Prop) [is_well_order �
 /-- The cardinal of an ordinal is the cardinal of any
   set with that order type. -/
 def card (o : ordinal) : cardinal :=
-quot.lift_on o (λ ⟨α, r, _⟩, mk α) $
+quot.lift_on o (λ ⟨α, r, _⟩, #α) $
 λ ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨e⟩, quotient.sound ⟨e.to_equiv⟩
 
 @[simp] theorem card_type (r : α → α → Prop) [is_well_order α r] :
-  card (type r) = mk α := rfl
+  card (type r) = #α := rfl
 
 lemma card_typein {r : α → α → Prop} [wo : is_well_order α r] (x : α) :
-  mk {y // r y x} = (typein r x).card := rfl
+  #{y // r y x} = (typein r x).card := rfl
 
 theorem card_le_card {o₁ o₂ : ordinal} : o₁ ≤ o₂ → card o₁ ≤ card o₂ :=
 induction_on o₁ $ λ α r _, induction_on o₂ $ λ β s _ ⟨⟨⟨f, _⟩, _⟩⟩, ⟨f⟩
@@ -843,7 +843,7 @@ theorem lift_down' {a : cardinal.{u}} {b : ordinal.{max u v}}
 let ⟨c, e⟩ := cardinal.lift_down h in
 quotient.induction_on c (λ α, induction_on b $ λ β s _ e', begin
   resetI,
-  rw [mk_def, card_type, ← cardinal.lift_id'.{(max u v) u} (mk β),
+  rw [mk_def, card_type, ← cardinal.lift_id'.{(max u v) u} (#β),
       ← cardinal.lift_umax.{u v}, lift_mk_eq.{u (max u v) (max u v)}] at e',
   cases e' with f,
   have g := rel_iso.preimage f s,
@@ -1127,18 +1127,18 @@ begin
   exact ordinal.min_le (λ i:ι α, ⟦⟨α, i.1, i.2⟩⟧) ⟨_, _⟩
 end
 
-lemma ord_eq_min (α : Type u) : ord (mk α) =
+lemma ord_eq_min (α : Type u) : ord (#α) =
   @ordinal.min {r // is_well_order α r} ⟨⟨well_ordering_rel, by apply_instance⟩⟩
     (λ i, ⟦⟨α, i.1, i.2⟩⟧) := rfl
 
 theorem ord_eq (α) : ∃ (r : α → α → Prop) [wo : is_well_order α r],
-  ord (mk α) = @type α r wo :=
+  ord (#α) = @type α r wo :=
 let ⟨⟨r, wo⟩, h⟩ := @ordinal.min_eq {r // is_well_order α r}
   ⟨⟨well_ordering_rel, by apply_instance⟩⟩
   (λ i:{r // is_well_order α r}, ⟦⟨α, i.1, i.2⟩⟧) in
 ⟨r, wo, h⟩
 
-theorem ord_le_type (r : α → α → Prop) [is_well_order α r] : ord (mk α) ≤ ordinal.type r :=
+theorem ord_le_type (r : α → α → Prop) [is_well_order α r] : ord (#α) ≤ ordinal.type r :=
 @ordinal.min_le {r // is_well_order α r}
   ⟨⟨well_ordering_rel, by apply_instance⟩⟩
   (λ i:{r // is_well_order α r}, ⟦⟨α, i.1, i.2⟩⟧) ⟨r, _⟩
@@ -1195,11 +1195,11 @@ eq_of_forall_ge_iff $ λ o, le_iff_le_iff_lt_iff_lt.2 $ begin
     rwa [ordinal.lift_lt, lt_ord] }
 end
 
-lemma mk_ord_out (c : cardinal) : mk c.ord.out.α = c :=
+lemma mk_ord_out (c : cardinal) : #c.ord.out.α = c :=
 by rw [←card_type c.ord.out.r, type_out, card_ord]
 
 lemma card_typein_lt (r : α → α → Prop) [is_well_order α r] (x : α)
-  (h : ord (mk α) = type r) : card (typein r x) < mk α :=
+  (h : ord (#α) = type r) : card (typein r x) < #α :=
 by { rw [←ord_lt_ord, h], refine lt_of_le_of_lt (ord_card_le _) (typein_lt_type r x) }
 
 lemma card_typein_out_lt (c : cardinal) (x : c.ord.out.α) : card (typein c.ord.out.r x) < c :=
@@ -1221,9 +1221,9 @@ rel_embedding.order_embedding_of_lt_embedding
 /-- The cardinal `univ` is the cardinality of ordinal `univ`, or
   equivalently the cardinal of `ordinal.{u}`, or `cardinal.{u}`,
   as an element of `cardinal.{v}` (when `u < v`). -/
-def univ := lift.{(u+1) v} (mk ordinal)
+def univ := lift.{(u+1) v} (#ordinal)
 
-theorem univ_id : univ.{u (u+1)} = mk ordinal := lift_id _
+theorem univ_id : univ.{u (u+1)} = #ordinal := lift_id _
 
 @[simp] theorem lift_univ : lift.{_ w} univ.{u v} = univ.{u (max v w)} := lift_lift _
 


### PR DESCRIPTION
The only API change: rename `cardinal.eq_congr` to `cardinal.mk_congr`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
