### PR TITLE
[Merged by Bors] - chore(ring_theory/dedekind_domain): speed up `dedekind_domain.lean`

### DIFF
--- a/src/group_theory/monoid_localization.lean
+++ b/src/group_theory/monoid_localization.lean
@@ -175,7 +175,7 @@ namespace localization
   inhabited (localization S) :=
 con.quotient.inhabited
 
-@[to_additive] instance : comm_monoid (localization S) :=
+@[to_additive, irreducible] instance : comm_monoid (localization S) :=
 (r S).comm_monoid
 
 variables {S}
@@ -1013,6 +1013,10 @@ end submonoid
 namespace localization
 variables (S)
 
+section
+
+local attribute [semireducible] localization.comm_monoid
+
 /-- Natural hom sending `x : M`, `M` a `comm_monoid`, to the equivalence class of
 `(x, 1)` in the localization of `M` at a submonoid. -/
 @[to_additive "Natural homomorphism sending `x : M`, `M` an `add_comm_monoid`, to the equivalence
@@ -1045,7 +1049,9 @@ end
 @[simp, to_additive] lemma mk_eq_monoid_of_mk' : mk = (monoid_of S).mk' :=
 funext $ λ _, funext $ λ _, mk_eq_monoid_of_mk'_apply _ _
 
-variables (f : submonoid.localization_map S N)
+end
+
+variables {S} (f : submonoid.localization_map S N)
 /-- Given a localization map `f : M →* N` for a submonoid `S`, we get an isomorphism between
 the localization of `M` at `S` as a quotient type and `N`. -/
 @[to_additive "Given a localization map `f : M →+ N` for a submonoid `S`, we get an isomorphism

--- a/src/group_theory/monoid_localization.lean
+++ b/src/group_theory/monoid_localization.lean
@@ -273,7 +273,7 @@ def lift_on {p : Sort u} (x : localization S) (f : M → S → p)
   (H : ∀ {a c : M} {b d : S} (h : r S (a, b) (c, d)), f a b = f c d) : p :=
 rec f (λ a c b d h, by rw [eq_rec_constant, H h]) x
 
-@[simp, to_additive] lemma lift_on_mk {p : Sort u}
+@[to_additive] lemma lift_on_mk {p : Sort u}
   (f : ∀ (a : M) (b : S), p) (H) (a : M) (b : S) :
   lift_on (mk a b) f H = f a b :=
 rfl
@@ -301,7 +301,7 @@ def lift_on₂ {p : Sort u} (x y : localization S) (f : M → S → M → S → 
 lift_on x (λ a b, lift_on y (f a b) (λ c c' d d' hy, H ((r S).refl _) hy))
   (λ a a' b b' hx, induction_on y (λ ⟨c, d⟩, H hx ((r S).refl _)))
 
-@[simp, to_additive] lemma lift_on₂_mk {p : Sort*}
+@[to_additive] lemma lift_on₂_mk {p : Sort*}
   (f : M → S → M → S → p) (H) (a c : M) (b d : S) :
   lift_on₂ (mk a b) (mk c d) f H = f a b c d :=
 rfl
@@ -1158,6 +1158,18 @@ end
 
 @[simp, to_additive] lemma mk_eq_monoid_of_mk' : mk = (monoid_of S).mk' :=
 funext $ λ _, funext $ λ _, mk_eq_monoid_of_mk'_apply _ _
+
+universes u
+
+@[simp, to_additive] lemma lift_on_mk' {p : Sort u}
+  (f : ∀ (a : M) (b : S), p) (H) (a : M) (b : S) :
+  lift_on ((monoid_of S).mk' a b) f H = f a b :=
+by rw [← mk_eq_monoid_of_mk', lift_on_mk]
+
+@[simp, to_additive] lemma lift_on₂_mk' {p : Sort*}
+  (f : M → S → M → S → p) (H) (a c : M) (b d : S) :
+  lift_on₂ ((monoid_of S).mk' a b) ((monoid_of S).mk' c d) f H = f a b c d :=
+by rw [← mk_eq_monoid_of_mk', lift_on₂_mk]
 
 variables (f : submonoid.localization_map S N)
 /-- Given a localization map `f : M →* N` for a submonoid `S`, we get an isomorphism between

--- a/src/group_theory/monoid_localization.lean
+++ b/src/group_theory/monoid_localization.lean
@@ -175,19 +175,37 @@ namespace localization
   inhabited (localization S) :=
 con.quotient.inhabited
 
-@[to_additive, irreducible] protected def mul : localization S → localization S → localization S :=
+/-- Multiplication in a localization is defined as `⟨a, b⟩ * ⟨c, d⟩ = ⟨a * c, b * d⟩`. -/
+@[to_additive "Addition in an `add_localization` is defined as `⟨a, b⟩ + ⟨c, d⟩ = ⟨a + c, b + d⟩`.
+
+Should not be confused with the ring localization counterpart `localization.add`, which maps
+`⟨a, b⟩ + ⟨c, d⟩` to `⟨d * a + b * c, b * d⟩`.", irreducible]
+protected def mul : localization S → localization S → localization S :=
 (r S).comm_monoid.mul
 
 @[to_additive] instance : has_mul (localization S) :=
 ⟨localization.mul S⟩
 
-@[to_additive, irreducible] protected def one : localization S :=
+/-- The identity element of a localization is defined as `⟨1, 1⟩`. -/
+@[to_additive "The identity element of an `add_localization` is defined as `⟨0, 0⟩`.
+
+Should not be confused with the ring localization counterpart `localization.zero`,
+which is defined as `⟨0, 1⟩`.", irreducible] protected def one : localization S :=
 (r S).comm_monoid.one
 
 @[to_additive] instance : has_one (localization S) :=
 ⟨localization.one S⟩
 
-@[to_additive, irreducible] protected def npow : ℕ → localization S → localization S :=
+/-- Exponentiation in a localization is defined as `⟨a, b⟩ ^ n = ⟨a ^ n, b ^ n⟩`.
+
+This is a separate `irreducible` def to ensure the elaborator doesn't waste its time
+trying to unify some huge recursive definition with itself, but unfolded one step less.
+-/
+@[to_additive "Multiplication with a natural in an `add_localization` is defined as `n • ⟨a, b⟩ = ⟨n • a, n • b⟩`.
+
+This is a separate `irreducible` def to ensure the elaborator doesn't waste its time
+trying to unify some huge recursive definition with itself, but unfolded one step less.", irreducible]
+protected def npow : ℕ → localization S → localization S :=
 (r S).comm_monoid.npow
 
 local attribute [semireducible] localization.mul localization.one localization.npow
@@ -222,7 +240,10 @@ universes u
 /-- Dependent recursion principle for localizations: given elements `f a b : p (mk a b)`
 for all `a b`, such that `r S (a, b) (c, d)` implies `f a b = f c d` (wih the correct coercions),
 then `f` is defined on the whole `localization S`. -/
-@[elab_as_eliminator, to_additive]
+@[elab_as_eliminator, to_additive
+"Dependent recursion principle for `add_localizations`: given elements `f a b : p (mk a b)`
+for all `a b`, such that `r S (a, b) (c, d)` implies `f a b = f c d` (wih the correct coercions),
+then `f` is defined on the whole `add_localization S`."]
 def rec {p : localization S → Sort u}
   (f : ∀ (a : M) (b : S), p (mk a b))
   (H : ∀ {a c : M} {b d : S} (h : r S (a, b) (c, d)),
@@ -244,7 +265,10 @@ rfl
 /-- Non-dependent recursion principle for localizations: given elements `f a b : p`
 for all `a b`, such that `r S (a, b) (c, d)` implies `f a b = f c d`,
 then `f` is defined on the whole `localization S`. -/
-@[elab_as_eliminator, to_additive]
+@[elab_as_eliminator, to_additive
+"Non-dependent recursion principle for `add_localizations`: given elements `f a b : p`
+for all `a b`, such that `r S (a, b) (c, d)` implies `f a b = f c d`,
+then `f` is defined on the whole `localization S`."]
 def lift_on {p : Sort u} (x : localization S) (f : M → S → p)
   (H : ∀ {a c : M} {b d : S} (h : r S (a, b) (c, d)), f a b = f c d) : p :=
 rec f (λ a c b d h, by rw [eq_rec_constant, H h]) x
@@ -266,7 +290,10 @@ theorem induction_on {p : localization S → Prop} (x)
 /-- Non-dependent recursion principle for localizations: given elements `f x y : p`
 for all `x` and `y`, such that `r S x x'` and `r S y y'` implies `f x y = f x' y'`,
 then `f` is defined on the whole `localization S`. -/
-@[elab_as_eliminator, to_additive]
+@[elab_as_eliminator, to_additive
+"Non-dependent recursion principle for localizations: given elements `f x y : p`
+for all `x` and `y`, such that `r S x x'` and `r S y y'` implies `f x y = f x' y'`,
+then `f` is defined on the whole `localization S`."]
 def lift_on₂ {p : Sort u} (x y : localization S) (f : M → S → M → S → p)
   (H : ∀ {a a' b b' c c' d d'} (hx : r S (a, b) (a', b')) (hy : r S (c, d) (c', d')),
     f a b c d = f a' b' c' d') :

--- a/src/group_theory/monoid_localization.lean
+++ b/src/group_theory/monoid_localization.lean
@@ -175,19 +175,22 @@ namespace localization
   inhabited (localization S) :=
 con.quotient.inhabited
 
-@[to_additive, irreducible] protected def mul :=
+@[to_additive, irreducible] protected def mul : localization S → localization S → localization S :=
 (r S).comm_monoid.mul
 
 @[to_additive] instance : has_mul (localization S) :=
 ⟨localization.mul S⟩
 
-@[to_additive, irreducible] protected def one :=
+@[to_additive, irreducible] protected def one : localization S :=
 (r S).comm_monoid.one
 
 @[to_additive] instance : has_one (localization S) :=
 ⟨localization.one S⟩
 
-local attribute [semireducible] localization.mul localization.one
+@[to_additive, irreducible] protected def npow : ℕ → localization S → localization S :=
+(r S).comm_monoid.npow
+
+local attribute [semireducible] localization.mul localization.one localization.npow
 
 @[to_additive] instance : comm_monoid (localization S) :=
 { mul := (*),
@@ -196,7 +199,11 @@ local attribute [semireducible] localization.mul localization.one
     show ∀ (x y z : localization S), x * y * z = x * (y * z), from (r S).comm_monoid.mul_assoc,
   mul_comm := show ∀ (x y : localization S), x * y = y * x, from (r S).comm_monoid.mul_comm,
   mul_one := show ∀ (x : localization S), x * 1 = x, from (r S).comm_monoid.mul_one,
-  one_mul := show ∀ (x : localization S), 1 * x = x, from (r S).comm_monoid.one_mul }
+  one_mul := show ∀ (x : localization S), 1 * x = x, from (r S).comm_monoid.one_mul,
+  npow := localization.npow S,
+  npow_zero' := show ∀ (x : localization S), localization.npow S 0 x = 1, from pow_zero,
+  npow_succ' := show ∀ (n : ℕ) (x : localization S),
+    localization.npow S n.succ x = x * localization.npow S n x, from λ n x, pow_succ x n }
 
 variables {S}
 

--- a/src/group_theory/monoid_localization.lean
+++ b/src/group_theory/monoid_localization.lean
@@ -201,10 +201,12 @@ which is defined as `⟨0, 1⟩`.", irreducible] protected def one : localizatio
 This is a separate `irreducible` def to ensure the elaborator doesn't waste its time
 trying to unify some huge recursive definition with itself, but unfolded one step less.
 -/
-@[to_additive "Multiplication with a natural in an `add_localization` is defined as `n • ⟨a, b⟩ = ⟨n • a, n • b⟩`.
+@[to_additive
+"Multiplication with a natural in an `add_localization` is defined as `n • ⟨a, b⟩ = ⟨n • a, n • b⟩`.
 
 This is a separate `irreducible` def to ensure the elaborator doesn't waste its time
-trying to unify some huge recursive definition with itself, but unfolded one step less.", irreducible]
+trying to unify some huge recursive definition with itself, but unfolded one step less.",
+irreducible]
 protected def npow : ℕ → localization S → localization S :=
 (r S).comm_monoid.npow
 

--- a/src/linear_algebra/matrix/to_linear_equiv.lean
+++ b/src/linear_algebra/matrix/to_linear_equiv.lean
@@ -122,11 +122,12 @@ begin
     exact matrix.det_ne_zero_of_right_inverse this }
 end
 
-lemma exists_mul_vec_eq_zero_iff {A : Type*} [decidable_eq n] [integral_domain A]
+lemma exists_mul_vec_eq_zero_iff' {A : Type*} (K : Type*) [decidable_eq n] [integral_domain A]
+  [field K] [algebra A K] [is_fraction_ring A K]
   {M : matrix n n A} :
   (∃ (v ≠ 0), M.mul_vec v = 0) ↔ M.det = 0 :=
 begin
-  have : (∃ (v ≠ 0), mul_vec ((algebra_map A (fraction_ring A)).map_matrix M) v = 0) ↔ _ :=
+  have : (∃ (v ≠ 0), mul_vec ((algebra_map A K).map_matrix M) v = 0) ↔ _ :=
     exists_mul_vec_eq_zero_iff_aux,
   rw [← ring_hom.map_det, is_fraction_ring.to_map_eq_zero_iff] at this,
   refine iff.trans _ this, split; rintro ⟨v, hv, mul_eq⟩,
@@ -135,29 +136,33 @@ begin
     { ext i,
       refine (ring_hom.map_mul_vec _ _ _ i).symm.trans _,
       rw [mul_eq, pi.zero_apply, ring_hom.map_zero, pi.zero_apply] } },
-  { letI := classical.dec_eq (fraction_ring A),
+  { letI := classical.dec_eq K,
     obtain ⟨⟨b, hb⟩, ba_eq⟩ := is_localization.exist_integer_multiples_of_finset
       (non_zero_divisors A) (finset.univ.image v),
     choose f hf using ba_eq,
     refine ⟨λ i, f _ (finset.mem_image.mpr ⟨i, finset.mem_univ i, rfl⟩),
             mt (λ h, funext $ λ i, _) hv, _⟩,
-    { have := congr_arg (algebra_map A (fraction_ring A)) (congr_fun h i),
+    { have := congr_arg (algebra_map A K) (congr_fun h i),
       rw [hf, subtype.coe_mk, pi.zero_apply, ring_hom.map_zero, algebra.smul_def,
           mul_eq_zero, is_fraction_ring.to_map_eq_zero_iff] at this,
       exact this.resolve_left (mem_non_zero_divisors_iff_ne_zero.mp hb), },
     { ext i,
-      refine is_fraction_ring.injective A (fraction_ring A) _,
-      calc algebra_map A (fraction_ring A) (M.mul_vec (λ (i : n), f (v i) _) i)
-          = ((algebra_map A (fraction_ring A)).map_matrix M).mul_vec
-              (algebra_map _ (fraction_ring A) b • v) i : _
+      refine is_fraction_ring.injective A K _,
+      calc algebra_map A K (M.mul_vec (λ (i : n), f (v i) _) i)
+          = ((algebra_map A K).map_matrix M).mul_vec
+              (algebra_map _ K b • v) i : _
       ... = 0 : _
-      ... = algebra_map A (fraction_ring A) 0 : (ring_hom.map_zero _).symm,
+      ... = algebra_map A K 0 : (ring_hom.map_zero _).symm,
       { simp_rw [ring_hom.map_mul_vec, mul_vec, dot_product, function.comp_app, hf,
           subtype.coe_mk, ring_hom.map_matrix_apply, pi.smul_apply, smul_eq_mul,
           algebra.smul_def] },
-      { rw [mul_vec_smul, mul_eq, pi.smul_apply, pi.zero_apply, smul_zero],
-        refl } } },
+      { rw [mul_vec_smul, mul_eq, pi.smul_apply, pi.zero_apply, smul_zero] } } },
 end
+
+lemma exists_mul_vec_eq_zero_iff {A : Type*} [decidable_eq n] [integral_domain A]
+  {M : matrix n n A} :
+  (∃ (v ≠ 0), M.mul_vec v = 0) ↔ M.det = 0 :=
+exists_mul_vec_eq_zero_iff' (fraction_ring A)
 
 lemma exists_vec_mul_eq_zero_iff {A : Type*} [decidable_eq n] [integral_domain A]
   {M : matrix n n A} :

--- a/src/linear_algebra/matrix/to_linear_equiv.lean
+++ b/src/linear_algebra/matrix/to_linear_equiv.lean
@@ -131,7 +131,7 @@ begin
   rw [← ring_hom.map_det, is_fraction_ring.to_map_eq_zero_iff] at this,
   refine iff.trans _ this, split; rintro ⟨v, hv, mul_eq⟩,
   { refine ⟨λ i, algebra_map _ _ (v i), mt (λ h, funext $ λ i, _) hv, _⟩,
-    { exact is_fraction_ring.injective A (fraction_ring A) (congr_fun h i) },
+    { exact is_fraction_ring.to_map_eq_zero_iff.mp (congr_fun h i) },
     { ext i,
       refine (ring_hom.map_mul_vec _ _ _ i).symm.trans _,
       rw [mul_eq, pi.zero_apply, ring_hom.map_zero, pi.zero_apply] } },
@@ -150,11 +150,13 @@ begin
       calc algebra_map A (fraction_ring A) (M.mul_vec (λ (i : n), f (v i) _) i)
           = ((algebra_map A (fraction_ring A)).map_matrix M).mul_vec
               (algebra_map _ (fraction_ring A) b • v) i : _
-      ... = 0 : _,
+      ... = 0 : _
+      ... = algebra_map A (fraction_ring A) 0 : (ring_hom.map_zero _).symm,
       { simp_rw [ring_hom.map_mul_vec, mul_vec, dot_product, function.comp_app, hf,
           subtype.coe_mk, ring_hom.map_matrix_apply, pi.smul_apply, smul_eq_mul,
           algebra.smul_def] },
-      { rw [mul_vec_smul, mul_eq, pi.smul_apply, pi.zero_apply, smul_zero] } } },
+      { rw [mul_vec_smul, mul_eq, pi.smul_apply, pi.zero_apply, smul_zero],
+        refl } } },
 end
 
 lemma exists_vec_mul_eq_zero_iff {A : Type*} [decidable_eq n] [integral_domain A]

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -282,18 +282,16 @@ lemma is_dedekind_domain_inv_iff [algebra A K] [is_fraction_ring A K] :
   is_dedekind_domain_inv A ↔
     (∀ I ≠ (⊥ : fractional_ideal A⁰ K), I * I⁻¹ = 1) :=
 begin
-  set h : fraction_ring A ≃ₐ[A] K := fraction_ring.alg_equiv A K,
+  set h := fraction_ring.alg_equiv A K,
   split; rintros hi I hI,
-  { have := hi (fractional_ideal.map h.symm.to_alg_hom I)
-               (fractional_ideal.map_ne_zero h.symm.to_alg_hom hI),
-    convert congr_arg (fractional_ideal.map h.to_alg_hom) this;
-      simp only [alg_equiv.to_alg_hom_eq_coe, map_symm_map, map_one,
-                 fractional_ideal.map_mul, fractional_ideal.map_div, inv_eq] },
-  { have := hi (fractional_ideal.map h.to_alg_hom I)
-               (fractional_ideal.map_ne_zero h.to_alg_hom hI),
-    convert congr_arg (fractional_ideal.map h.symm.to_alg_hom) this;
-      simp only [alg_equiv.to_alg_hom_eq_coe, map_map_symm, map_one,
-                 fractional_ideal.map_mul, fractional_ideal.map_div, inv_eq] },
+  { refine fractional_ideal.map_injective h.symm.to_alg_hom h.symm.injective _,
+    rw [alg_equiv.to_alg_hom_eq_coe, inv_eq, fractional_ideal.map_mul,
+        fractional_ideal.map_one_div, fractional_ideal.map_one, ← inv_eq, hi],
+    exact fractional_ideal.map_ne_zero _ hI },
+  { refine fractional_ideal.map_injective h.to_alg_hom h.injective _,
+    rw [alg_equiv.to_alg_hom_eq_coe, inv_eq, fractional_ideal.map_mul,
+        fractional_ideal.map_one_div, fractional_ideal.map_one, ← inv_eq, hi],
+    exact fractional_ideal.map_ne_zero _ hI },
 end
 
 lemma fractional_ideal.adjoin_integral_eq_one_of_is_unit [algebra A K] [is_fraction_ring A K]

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -510,24 +510,22 @@ begin
   { letI := hNF.to_field A, rcases hI1 (I.eq_bot_or_top.resolve_left hI0) },
   -- We'll show a contradiction with `exists_not_mem_one_of_ne_bot`:
   -- `J⁻¹ = (I * I⁻¹)⁻¹` cannot have an element `x ∉ 1`, so it must equal `1`.
-  by_contradiction h_abs,
   obtain ⟨J, hJ⟩ : ∃ (J : ideal A), (J : fractional_ideal A⁰ K) = I * I⁻¹ :=
     le_one_iff_exists_coe_ideal.mp mul_one_div_le_one,
   by_cases hJ0 : J = ⊥,
   { subst hJ0,
-    apply hI0,
+    refine absurd _ hI0,
     rw [eq_bot_iff, ← coe_ideal_le_coe_ideal K, hJ],
     exact coe_ideal_le_self_mul_inv K I,
     apply_instance },
-  have hJ1 : J ≠ ⊤,
-  { rintro rfl,
-    rw [← hJ, coe_ideal_top] at h_abs,
-    exact h_abs rfl },
+  by_cases hJ1 : J = ⊤,
+  { rw [← hJ, hJ1, coe_ideal_top] },
   obtain ⟨x, hx, hx1⟩ : ∃ (x : K),
     x ∈ (J : fractional_ideal A⁰ K)⁻¹ ∧ x ∉ (1 : fractional_ideal A⁰ K) :=
     exists_not_mem_one_of_ne_bot hNF hJ0 hJ1,
+  contrapose! hx1 with h_abs,
   rw hJ at hx,
-  exact hx1 (hI hx)
+  exact hI hx,
 end
 
 /-- Nonzero integral ideals in a Dedekind domain are invertible.

--- a/src/ring_theory/dedekind_domain.lean
+++ b/src/ring_theory/dedekind_domain.lean
@@ -11,7 +11,6 @@ import ring_theory.polynomial.rational_root
 import ring_theory.trace
 import algebra.associated
 
-
 /-!
 # Dedekind domains
 
@@ -660,19 +659,20 @@ instance : wf_dvd_monoid (ideal A) :=
 instance ideal.unique_factorization_monoid :
   unique_factorization_monoid (ideal A) :=
 { irreducible_iff_prime := λ P,
-    ⟨λ hirr, ⟨hirr.ne_zero, hirr.not_unit, λ I J, begin
-      have : P.is_maximal,
-      { use mt ideal.is_unit_iff.mpr hirr.not_unit,
-        intros J hJ,
-        obtain ⟨J_ne, H, hunit, P_eq⟩ := ideal.dvd_not_unit_iff_lt.mpr hJ,
-        exact ideal.is_unit_iff.mp ((hirr.is_unit_or_is_unit P_eq).resolve_right hunit) },
-      simp only [ideal.dvd_iff_le, has_le.le, preorder.le, partial_order.le],
-      contrapose!,
-      rintros ⟨⟨x, x_mem, x_not_mem⟩, ⟨y, y_mem, y_not_mem⟩⟩,
-      exact ⟨x * y, ideal.mul_mem_mul x_mem y_mem,
-             mt this.is_prime.mem_or_mem (not_or x_not_mem y_not_mem)⟩,
-    end⟩,
-    prime.irreducible⟩,
+  ⟨λ hirr, ⟨hirr.ne_zero, hirr.not_unit, λ I J, begin
+    have : P.is_maximal,
+    { refine ⟨⟨mt ideal.is_unit_iff.mpr hirr.not_unit, _⟩⟩,
+      intros J hJ,
+      obtain ⟨J_ne, H, hunit, P_eq⟩ := ideal.dvd_not_unit_iff_lt.mpr hJ,
+      exact ideal.is_unit_iff.mp ((hirr.is_unit_or_is_unit P_eq).resolve_right hunit) },
+    rw [ideal.dvd_iff_le, ideal.dvd_iff_le, ideal.dvd_iff_le,
+        set_like.le_def, set_like.le_def, set_like.le_def],
+    contrapose!,
+    rintros ⟨⟨x, x_mem, x_not_mem⟩, ⟨y, y_mem, y_not_mem⟩⟩,
+    exact ⟨x * y, ideal.mul_mem_mul x_mem y_mem,
+           mt this.is_prime.mem_or_mem (not_or x_not_mem y_not_mem)⟩,
+   end⟩,
+   prime.irreducible⟩,
   .. ideal.wf_dvd_monoid }
 
 noncomputable instance ideal.normalization_monoid : normalization_monoid (ideal A) :=

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -624,6 +624,15 @@ by rw [←map_comp, g.symm_comp, map_id]
   (I.map (g.symm : P' →ₐ[R] P)).map (g : P →ₐ[R] P') = I :=
 by rw [←map_comp, g.comp_symm, map_id]
 
+lemma map_mem_map {f : P →ₐ[R] P'} (h : function.injective f) {x : P} {I : fractional_ideal S P} :
+  f x ∈ map f I ↔ x ∈ I :=
+mem_map.trans ⟨λ ⟨x', hx', x'_eq⟩, h x'_eq ▸ hx', λ h, ⟨x, h, rfl⟩⟩
+
+lemma map_injective (f : P →ₐ[R] P') (h : function.injective f) :
+  function.injective (map f : fractional_ideal S P → fractional_ideal S P') :=
+λ I J hIJ, fractional_ideal.ext (λ x, (fractional_ideal.map_mem_map h).symm.trans
+  (hIJ.symm ▸ fractional_ideal.map_mem_map h))
+
 /-- If `g` is an equivalence, `map g` is an isomorphism -/
 def map_equiv (g : P ≃ₐ[R] P') :
   fractional_ideal S P ≃+* fractional_ideal S P' :=

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -664,8 +664,8 @@ variables {M}
 
 section
 
-@[irreducible] instance : has_add (localization M) :=
-⟨λ z w, con.lift_on₂ z w
+@[irreducible] protected def add (z w : localization M) : localization M :=
+con.lift_on₂ z w
   (λ x y : R × M, mk ((x.2 : R) * y.1 + y.2 * x.1) (x.2 * y.2)) $
 λ r1 r2 r3 r4 h1 h2, (con.eq _).2
 begin
@@ -676,10 +676,12 @@ begin
   calc ((r1.2 : R) * r2.1 + r2.2 * r1.1) * (r3.2 * r4.2) * (t₆ * t₅) =
       (r2.1 * r4.2 * t₆) * (r1.2 * r3.2 * t₅) + (r1.1 * r3.2 * t₅) * (r2.2 * r4.2 * t₆) : by ring
       ... = (r3.2 * r4.1 + r4.2 * r3.1) * (r1.2 * r2.2) * (t₆ * t₅) : by rw [ht₆, ht₅]; ring
-end⟩
+end
 
-@[irreducible] instance : has_neg (localization M) :=
-⟨λ z, con.lift_on z (λ x : R × M, mk (-x.1) x.2) $
+instance : has_add (localization M) := ⟨localization.add⟩
+
+@[irreducible] protected def neg (z : localization M) : localization M :=
+con.lift_on z (λ x : R × M, mk (-x.1) x.2) $
   λ r1 r2 h, (con.eq _).2
 begin
   rw r_eq_r' at h ⊢,
@@ -687,13 +689,17 @@ begin
   use t,
   rw [neg_mul_eq_neg_mul_symm, neg_mul_eq_neg_mul_symm, ht],
   ring_nf,
-end⟩
+end
 
-@[irreducible] instance : has_zero (localization M) :=
-⟨mk 0 1⟩
+instance : has_neg (localization M) := ⟨localization.neg⟩
 
-local attribute [semireducible] localization.has_add localization.has_neg localization.has_zero
-  localization.comm_monoid
+@[irreducible] protected def zero : localization M :=
+mk 0 1
+
+instance : has_zero (localization M) := ⟨localization.zero⟩
+
+local attribute [semireducible] localization.add localization.neg localization.zero
+  localization.mul localization.one
 
 private meta def tac := `[{
   intros,

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -720,6 +720,7 @@ instance : comm_ring (localization M) :=
   one  := 1,
   add  := (+),
   mul  := (*),
+  npow := localization.npow _,
   add_assoc      := λ m n k, localization.induction_on₃ m n k (by tac),
   zero_add       := λ y, localization.induction_on y (by tac),
   add_zero       := λ y, localization.induction_on y (by tac),
@@ -1925,7 +1926,7 @@ noncomputable instance : field (fraction_ring A) :=
   one := 1,
   zero := 0,
   gsmul := gsmul,
-  npow := npow,
+  npow := localization.npow _,
   .. is_fraction_ring.to_field A }
 
 @[simp] lemma mk_eq_div {r s} : (localization.mk r s : fraction_ring A) =

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -664,6 +664,11 @@ variables {M}
 
 section
 
+/-- Addition in a ring localization is defined as `⟨a, b⟩ + ⟨c, d⟩ = ⟨b * c + d * a, b * d⟩`.
+
+Should not be confused with `add_localization.add`, which is defined as
+`⟨a, b⟩ + ⟨c, d⟩ = ⟨a + c, b + d⟩`.
+-/
 @[irreducible] protected def add (z w : localization M) : localization M :=
 localization.lift_on₂ z w
   (λ a b c d, mk ((b : R) * c + d * a) (b * d)) $
@@ -683,6 +688,7 @@ instance : has_add (localization M) := ⟨localization.add⟩
 lemma add_mk (a b c d) : (mk a b : localization M) + mk c d = mk (b * c + d * a) (b * d) :=
 by { unfold has_add.add localization.add, apply lift_on₂_mk }
 
+/-- Negation in a ring localization is defined as `-⟨a, b⟩ = ⟨-a, b⟩`. -/
 @[irreducible] protected def neg (z : localization M) : localization M :=
 localization.lift_on z (λ a b, mk (-a) b) $
   λ a b c d h, mk_eq_mk_iff.2
@@ -699,6 +705,9 @@ instance : has_neg (localization M) := ⟨localization.neg⟩
 lemma neg_mk (a b) : -(mk a b : localization M) = mk (-a) b :=
 by { unfold has_neg.neg localization.neg, apply lift_on_mk }
 
+/-- The zero element in a ring localization is defined as `⟨0, 1⟩`.
+
+Should not be confused with `add_localization.zero` which is `⟨0, 0⟩`. -/
 @[irreducible] protected def zero : localization M :=
 mk 0 1
 

--- a/src/set_theory/surreal/dyadic.lean
+++ b/src/set_theory/surreal/dyadic.lean
@@ -179,9 +179,9 @@ end
 
 /-- The map `dyadic_map` sends ⟦⟨m, 2^n⟩⟧ to m • half ^ n. -/
 def dyadic_map (x : localization (submonoid.powers (2 : ℤ))) : surreal :=
-quotient.lift_on' x (λ x : _ × _, x.1 • pow_half (submonoid.log x.2)) $
+localization.lift_on x (λ x y, x • pow_half (submonoid.log y)) $
 begin
-  rintros ⟨m₁, n₁⟩ ⟨m₂, n₂⟩ h₁,
+  intros m₁ m₂ n₁ n₂ h₁,
   obtain ⟨⟨n₃, y₃, hn₃⟩, h₂⟩ := localization.r_iff_exists.mp h₁,
   simp only [subtype.coe_mk, mul_eq_mul_right_iff] at h₂,
   cases h₂,


### PR DESCRIPTION
@eric-wieser [noticed that `dedekind_domain.lean`](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Timeouts.20in.20ring_theory.2Fdedekind_domain.2Elean.3A664.3A9) was compiling slowly and on the verge of a timeout. @kbuzzard, @sgouezel and I reworked some definitions to make everything elaborate much faster: `is_dedekind_domain_inv_iff`, `mul_inv_cancel_of_le_one` and `ideal.unique_factorization_monoid` went from over 10 seconds on my machine to less than 3 seconds. No other declaration in that file now takes over 2 seconds on my machine.

Apart from the three declarations getting new proofs, I also made the following changes:
 * The operations on `localization` (`has_add`, `has_mul`, `has_one`, `has_zero`, `has_neg`, `npow` and `localization.inv`) are now `@[irreducible]`
 * `fraction_ring.field` copies its field from `localization.comm_ring` for faster unification (less relevant after the previous change)
 * Added `fractional_ideal.map_mem_map` and `fractional_ideal.map_injective` to simplify the proof of `is_dedekind_domain_inv_iff`.
 * Split the proof of `matrix.exists_mul_vec_eq_zero_iff` into two parts to speed it up

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
