### PR TITLE
[Merged by Bors] - feat(data/list/basic): add lemmas about list.take list.drop

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1716,40 +1716,24 @@ lemma map_take {α β : Type*} (f : α → β) :
 | L 0 := by simp
 | (h :: t) (n+1) := by { dsimp, rw [map_take], }
 
-lemma take_append_of_le_length : ∀ {l₁ l₂ : list α} {n : ℕ},
-  n ≤ l₁.length → (l₁ ++ l₂).take n = l₁.take n
-| l₁      l₂ 0     hn := by simp
-| []      l₂ (n+1) hn := absurd hn dec_trivial
-| (a::l₁) l₂ (n+1) hn :=
-by rw [list.take, list.cons_append, list.take, take_append_of_le_length (le_of_succ_le_succ hn)]
+/-- Taking the first `n` elements in `l₁ ++ l₂` is the same as appending the first `n` elements
+of `l₁` to the first `n - l₁.length` elements of `l₂`. -/
+lemma take_append_eq_append_take {l₁ l₂ : list α} {n : ℕ} :
+  take n (l₁ ++ l₂) = take n l₁ ++ take (n - l₁.length) l₂ :=
+begin
+  induction l₁ generalizing n, { simp },
+  cases n, { simp }, simp *
+end
+
+lemma take_append_of_le_length {l₁ l₂ : list α} {n : ℕ} (h : n ≤ l₁.length) :
+  (l₁ ++ l₂).take n = l₁.take n :=
+by simp [take_append_eq_append_take, sub_eq_zero_iff_le.mpr h]
 
 /-- Taking the first `l₁.length + i` elements in `l₁ ++ l₂` is the same as appending the first
 `i` elements of `l₂` to `l₁`. -/
 lemma take_append {l₁ l₂ : list α} (i : ℕ) :
   take (l₁.length + i) (l₁ ++ l₂) = l₁ ++ (take i l₂) :=
-begin
-  induction l₁, { simp },
-  have : length l₁_tl + 1 + i = (length l₁_tl + i).succ,
-    by { rw nat.succ_eq_add_one, exact succ_add _ _ },
-  simp only [cons_append, length, this, take_cons, l₁_ih, eq_self_iff_true, and_self]
-end
-
-/-- Taking the first `n` elements in `l₁ ++ l₂` is the same as appending the first `n` elements
-of `l₁` to the first `n - l₁.length` elements of `l₂`. -/
-lemma take_append_sub (l₁ l₂ : list α) (n : ℕ) :
-  take n (l₁ ++ l₂) = take n l₁ ++ take (n - l₁.length) l₂ :=
-begin
-  cases (le_total l₁.length n) with h,
-  { calc take n (l₁ ++ l₂)
-       = take (l₁.length + (n - l₁.length)) (l₁ ++ l₂) : by rw nat.add_sub_of_le h
-   ... = l₁ ++ take (n - l₁.length) l₂                 : by rw take_append
-   ... = take n l₁ ++ take (n - l₁.length) l₂          : by rw take_all_of_le h },
-
-  { calc take n (l₁ ++ l₂) = take n l₁        : take_append_of_le_length h
-   ... = take n l₁ ++ []                      : by rw append_nil
-   ... = take n l₁ ++ take 0 l₂               : rfl
-   ... = take n l₁ ++ take (n - l₁.length) l₂ : by rw nat.sub_eq_zero_of_le h }
-end
+by simp [take_append_eq_append_take, take_all_of_le le_self_add]
 
 /-- The `i`-th element of a list coincides with the `i`-th element of any of its prefixes of
 length `> i`. Version designed to rewrite from the big list to the small list. -/
@@ -1886,40 +1870,24 @@ theorem drop_eq_nth_le_cons : ∀ {n} {l : list α} h,
 calc l.drop l.length = (l ++ []).drop l.length : by simp
                  ... = [] : drop_left _ _
 
-lemma drop_append_of_le_length : ∀ {l₁ l₂ : list α} {n : ℕ}, n ≤ l₁.length →
-  (l₁ ++ l₂).drop n = l₁.drop n ++ l₂
-| l₁      l₂ 0     hn := by simp
-| []      l₂ (n+1) hn := absurd hn dec_trivial
-| (a::l₁) l₂ (n+1) hn :=
-by rw [drop, cons_append, drop, drop_append_of_le_length (le_of_succ_le_succ hn)]
+/-- Dropping the elements up to `n` in `l₁ ++ l₂` is the same as dropping the elements up to `n`
+in `l₁`, dropping the elements up to `n - l₁.length` in `l₂`, and appending them. -/
+lemma drop_append_eq_append_drop {l₁ l₂ : list α} {n : ℕ} :
+  drop n (l₁ ++ l₂) = drop n l₁ ++ drop (n - l₁.length) l₂ :=
+begin
+  induction l₁ generalizing n, { simp },
+  cases n, { simp }, simp *
+end
+
+lemma drop_append_of_le_length {l₁ l₂ : list α} {n : ℕ} (h : n ≤ l₁.length) :
+  (l₁ ++ l₂).drop n = l₁.drop n ++ l₂ :=
+by simp [drop_append_eq_append_drop, sub_eq_zero_iff_le.mpr h]
 
 /-- Dropping the elements up to `l₁.length + i` in `l₁ + l₂` is the same as dropping the elements
 up to `i` in `l₂`. -/
 lemma drop_append {l₁ l₂ : list α} (i : ℕ) :
   drop (l₁.length + i) (l₁ ++ l₂) = drop i l₂ :=
-begin
-  induction l₁, { simp },
-  have : length l₁_tl + 1 + i = (length l₁_tl + i).succ,
-    by { rw nat.succ_eq_add_one, exact succ_add _ _ },
-  simp only [cons_append, length, this, drop, l₁_ih]
-end
-
-/-- Dropping the elements up to `n` in `l₁ ++ l₂` is the same as dropping the elements up to `n`
-in `l₁`, dropping the elements up to `n - l₁.length` in `l₂`, and appending them. -/
-lemma drop_append_sub (l₁ l₂ : list α) (n : ℕ) :
-  drop n (l₁ ++ l₂) = drop n l₁ ++ drop (n - l₁.length) l₂ :=
-begin
-  cases (le_total l₁.length n) with h,
-  { calc drop n (l₁ ++ l₂)
-       = drop (l₁.length + (n - l₁.length)) (l₁ ++ l₂) : by rw nat.add_sub_of_le h
-   ... = drop (n - l₁.length) l₂                       : by rw drop_append
-   ... = [] ++ drop (n - l₁.length) l₂                 : rfl
-   ... = drop n l₁ ++ drop (n - l₁.length) l₂          : by rw drop_eq_nil_of_le h },
-  { calc drop n (l₁ ++ l₂)
-       = drop n l₁ ++ l₂                      : drop_append_of_le_length h
-   ... = drop n l₁ ++ drop 0 l₂               : rfl
-   ... = drop n l₁ ++ drop (n - l₁.length) l₂ : by rw nat.sub_eq_zero_of_le h }
-end
+by simp [drop_append_eq_append_drop, take_all_of_le le_self_add]
 
 /-- The `i + j`-th element of a list coincides with the `j`-th element of the list obtained by
 dropping the first `i` elements. Version designed to rewrite from the big list to the small list. -/

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1734,6 +1734,23 @@ begin
   simp only [cons_append, length, this, take_cons, l₁_ih, eq_self_iff_true, and_self]
 end
 
+/-- Taking the first `n` elements in `l₁ ++ l₂` is the same as appending the first `n` elements
+of `l₁` to the first `n - l₁.length` elements of `l₂`. -/
+lemma take_append_sub (l₁ l₂ : list α) (n : ℕ) :
+  take n (l₁ ++ l₂) = take n l₁ ++ take (n - l₁.length) l₂ :=
+begin
+  cases (le_total l₁.length n) with h,
+  { calc take n (l₁ ++ l₂)
+       = take (l₁.length + (n - l₁.length)) (l₁ ++ l₂) : by rw nat.add_sub_of_le h
+   ... = l₁ ++ take (n - l₁.length) l₂                 : by rw take_append
+   ... = take n l₁ ++ take (n - l₁.length) l₂          : by rw take_all_of_le h },
+
+  { calc take n (l₁ ++ l₂) = take n l₁        : take_append_of_le_length h
+   ... = take n l₁ ++ []                      : by rw append_nil
+   ... = take n l₁ ++ take 0 l₂               : rfl
+   ... = take n l₁ ++ take (n - l₁.length) l₂ : by rw nat.sub_eq_zero_of_le h }
+end
+
 /-- The `i`-th element of a list coincides with the `i`-th element of any of its prefixes of
 length `> i`. Version designed to rewrite from the big list to the small list. -/
 lemma nth_le_take (L : list α) {i j : ℕ} (hi : i < L.length) (hj : i < j) :
@@ -1885,6 +1902,23 @@ begin
   have : length l₁_tl + 1 + i = (length l₁_tl + i).succ,
     by { rw nat.succ_eq_add_one, exact succ_add _ _ },
   simp only [cons_append, length, this, drop, l₁_ih]
+end
+
+/-- Dropping the elements up to `n` in `l₁ ++ l₂` is the same as dropping the elements up to `n`
+in `l₁`, dropping the elements up to `n - l₁.length` in `l₂`, and appending them. -/
+lemma drop_append_sub (l₁ l₂ : list α) (n : ℕ) :
+  drop n (l₁ ++ l₂) = drop n l₁ ++ drop (n - l₁.length) l₂ :=
+begin
+  cases (le_total l₁.length n) with h,
+  { calc drop n (l₁ ++ l₂)
+       = drop (l₁.length + (n - l₁.length)) (l₁ ++ l₂) : by rw nat.add_sub_of_le h
+   ... = drop (n - l₁.length) l₂                       : by rw drop_append
+   ... = [] ++ drop (n - l₁.length) l₂                 : rfl
+   ... = drop n l₁ ++ drop (n - l₁.length) l₂          : by rw drop_eq_nil_of_le h },
+  { calc drop n (l₁ ++ l₂)
+       = drop n l₁ ++ l₂                      : drop_append_of_le_length h
+   ... = drop n l₁ ++ drop 0 l₂               : rfl
+   ... = drop n l₁ ++ drop (n - l₁.length) l₂ : by rw nat.sub_eq_zero_of_le h }
 end
 
 /-- The `i + j`-th element of a list coincides with the `j`-th element of the list obtained by


### PR DESCRIPTION
I added these lemmas about list.take and list.drop, which are present in Coq for example. Note that they are not entirely equivalent to list.take_append and list.drop_append because they also handle the case when `n ≤ l₁.length`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
