### PR TITLE
[Merged by Bors] - feat(topology/homotopy): add `homotopy_with`

### DIFF
--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -238,6 +238,9 @@ def refl (f : C(X, Y)) (A : set X) : homotopy_rel f f A :=
   eq_snd' := λ  _ _ _, rfl,
   ..homotopy.refl f }
 
+instance : inhabited (homotopy_rel (continuous_map.id : C(X, X)) continuous_map.id set.univ) :=
+⟨homotopy_rel.refl continuous_map.id set.univ⟩
+
 /--
 Given continuous functions `f₀ f₁ : C(X, Y)`, and `F : homotopy_rel f g A`, we can reverse the
 homotopy to get a `homotopy_rel g f A`.

--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -286,7 +286,7 @@ homotopy_with.symm_trans F G
 end homotopy
 
 /--
-A `homotopy_rel f₀ f₁ S` is a homotopy bewteen `f₀` and `f₁` which is fixed on the points in `S`.
+A `homotopy_rel f₀ f₁ S` is a homotopy between `f₀` and `f₁` which is fixed on the points in `S`.
 -/
 abbreviation homotopy_rel (f₀ f₁ : C(X, Y)) (S : set X) :=
 homotopy_with f₀ f₁ (λ f, ∀ x ∈ S, f x = f₀ x ∧ f x = f₁ x)

--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -12,18 +12,24 @@ import topology.compact_open
 /-!
 # Homotopy between functions
 
-In this file, we define a `homotopy` between two functions `f₀` and `f₁`. We also refine the related
-notion of `homotopy` relative to a subset of the domain.
+In this file, we define a homotopy between two functions `f₀` and `f₁`. For this, we use a more
+general `homotopy_with`, which is inspired by the formalisation of homotopy between functions in
+HOL-Analysis. With this, we get `homotopy` as a special case of `homotopy_with`.
 
 ## Definitions
 
-* `homotopy f₀ f₁` is the type of homotopies between `f₀` and `f₁`
-* `homotopy.refl f₀` is the constant homotopy between `f₀` and `f₀`
-* `homotopy.symm f₀ f₁` is the `homotopy f₁ f₀` defined by reversing the homotopy
-* `homotopy.trans F G`, where `F : homotopy f₀ f₁`, `G : homotopy f₁ f₂` is a
-  `homotopy f₀ f₂` defined by putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
-* `homotopy_rel f₀ f₁ A` is the type of homotopies between `f₀` and `f₁` which fix all the points in
-  `A : set X`.
+* `homotopy_with f₀ f₁ P` is the type of homotoies between `f₀` and `f₁`, where the intermediate
+  maps satisfy the predicate `P : C(X, Y) → Prop`.
+* `homotopy_with.refl` is the homotopy between `f₀` and `f₀`.
+* `homotopy_with.symm F` is a defined by reversing the homotopy `F`
+* `homotopy_with.trans F G`, where `F : homotopy f₀ f₁`, `G : homotopy f₁ f₂` is a `homotopy f₀ f₂`
+  defined by putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
+* `homotopy f₀ f₁` is defined to be `homotopy_with f₀ f₁ (λ f, true)`.
+* `homotopy.refl` is a variant of `homotopy_with.refl` with the proof of `P f` filled in.
+* `homotopy_rel f₀ f₁ S` is defined to be
+  `homotopy_with f₀ f₁ (λ f, ∀ x ∈ S, f x = f₀ x ∧ f x = f₁ x)`. That is, a homotopy between `f₀`
+  and `f₁` which is fixed on the points in `S`.
+* `homotopy_rel.refl` is a variant of `homotopy_with.refl` with the proof of `P f` filled in.
 -/
 
 noncomputable theory
@@ -37,86 +43,135 @@ open_locale unit_interval
 namespace continuous_map
 
 /--
-The type of homotopies between two functions.
+The type of homotopies between two functions, where the intermediate maps satisfy the predicate
+`P : C(X, Y) → Prop`.
 -/
-structure homotopy (f₀ f₁ : C(X, Y)) extends C(I × X, Y) :=
+structure homotopy_with (f₀ f₁ : C(X, Y)) (P : C(X, Y) → Prop) extends C(I × X, Y) :=
 (to_fun_zero : ∀ x, to_fun (0, x) = f₀ x)
 (to_fun_one : ∀ x, to_fun (1, x) = f₁ x)
+(prop' : ∀ t, P ⟨λ x, to_fun (t, x),
+  continuous.comp continuous_to_fun (continuous_const.prod_mk continuous_id')⟩)
 
-namespace homotopy
+namespace homotopy_with
 
 section
 
-variables {f₀ f₁ : C(X, Y)}
+variables {f₀ f₁ : C(X, Y)} {P : C(X, Y) → Prop}
 
-instance : has_coe_to_fun (homotopy f₀ f₁) := ⟨_, λ F, F.to_fun⟩
+instance : has_coe_to_fun (homotopy_with f₀ f₁ P) := ⟨_, λ F, F.to_fun⟩
 
-lemma coe_fn_injective : @function.injective (homotopy f₀ f₁) (I × X → Y) coe_fn :=
+lemma coe_fn_injective : @function.injective (homotopy_with f₀ f₁ P) (I × X → Y) coe_fn :=
 begin
-  rintros ⟨⟨F, _⟩, _, _⟩ ⟨⟨G, _⟩, _, _⟩ h,
+  rintros ⟨⟨F, _⟩, _⟩ ⟨⟨G, _⟩, _⟩ h,
   congr' 2,
 end
 
 @[ext]
-lemma ext {F G : homotopy f₀ f₁} (h : ∀ x, F x = G x) : F = G := coe_fn_injective $ funext h
+lemma ext {F G : homotopy_with f₀ f₁ P} (h : ∀ x, F x = G x) : F = G :=
+coe_fn_injective $ funext h
 
 @[continuity]
-protected lemma continuous (F : homotopy f₀ f₁) : continuous F := F.continuous_to_fun
+protected lemma continuous (F : homotopy_with f₀ f₁ P) : continuous F := F.continuous_to_fun
 
 @[simp]
-lemma apply_zero (F : homotopy f₀ f₁) (x : X) : F (0, x) = f₀ x := F.to_fun_zero x
-@[simp]
-lemma apply_one (F : homotopy f₀ f₁) (x : X) : F (1, x) = f₁ x := F.to_fun_one x
+lemma apply_zero (F : homotopy_with f₀ f₁ P) (x : X) : F (0, x) = f₀ x := F.to_fun_zero x
 
 @[simp]
-lemma coe_to_continuous_map (F : homotopy f₀ f₁) : ⇑F.to_continuous_map = F := rfl
+lemma apply_one (F : homotopy_with f₀ f₁ P) (x : X) : F (1, x) = f₁ x := F.to_fun_one x
+
+@[simp]
+lemma coe_to_continuous_map (F : homotopy_with f₀ f₁ P) : ⇑F.to_continuous_map = F := rfl
 
 /--
 Currying a homotopy to a continuous function fron `I` to `C(X, Y)`.
 -/
-def curry (F : homotopy f₀ f₁) : C(I, C(X, Y)) := F.to_continuous_map.curry
+def curry (F : homotopy_with f₀ f₁ P) : C(I, C(X, Y)) := F.to_continuous_map.curry
+
+lemma prop (F : homotopy_with f₀ f₁ P) (t : I) : P (F.curry t) := F.prop' t
+
+@[simp]
+lemma curry_apply (F : homotopy_with f₀ f₁ P) (t : I) (x : X) : F.curry t x = F (t, x) := rfl
 
 /--
 Continuously extending a curried homotopy to a function from `ℝ` to `C(X, Y)`.
 -/
-def extend (F : homotopy f₀ f₁) : C(ℝ, C(X, Y)) := F.curry.Icc_extend zero_le_one
+def extend (F : homotopy_with f₀ f₁ P) : C(ℝ, C(X, Y)) := F.curry.Icc_extend zero_le_one
+
+lemma extend_apply_of_le_zero (F : homotopy_with f₀ f₁ P) {t : ℝ} (ht : t ≤ 0) (x : X) :
+  F.extend t x = f₀ x :=
+begin
+  rw [←F.apply_zero],
+  exact continuous_map.congr_fun (set.Icc_extend_of_le_left (@zero_le_one ℝ _) F.curry ht) x,
+end
+
+lemma extend_apply_of_one_le (F : homotopy_with f₀ f₁ P) {t : ℝ} (ht : 1 ≤ t) (x : X) :
+  F.extend t x = f₁ x :=
+begin
+  rw [←F.apply_one],
+  exact continuous_map.congr_fun (set.Icc_extend_of_right_le (@zero_le_one ℝ _) F.curry ht) x,
+end
 
 @[simp]
-lemma extend_apply_zero (F : homotopy f₀ f₁) (x : X) : F.extend 0 x = f₀ x :=
-by simp [extend, curry]
+lemma extend_apply_coe (F : homotopy_with f₀ f₁ P) (t : I) (x : X) : F.extend t x = F (t, x) :=
+continuous_map.congr_fun (set.Icc_extend_coe (@zero_le_one ℝ _) F.curry t) x
 
 @[simp]
-lemma extend_apply_one (F : homotopy f₀ f₁) (x : X) : F.extend 1 x = f₁ x := by simp [extend, curry]
+lemma extend_apply_of_mem_I (F : homotopy_with f₀ f₁ P) {t : ℝ} (ht : t ∈ I) (x : X) :
+  F.extend t x = F (⟨t, ht⟩, x) :=
+continuous_map.congr_fun (set.Icc_extend_of_mem (@zero_le_one ℝ _) F.curry ht) x
+
+lemma extend_prop (F : homotopy_with f₀ f₁ P) (t : ℝ) : P (F.extend t) :=
+begin
+  by_cases ht₀ : 0 ≤ t,
+  { by_cases ht₁ : t ≤ 1,
+    { convert F.prop ⟨t, ht₀, ht₁⟩,
+      ext,
+      rw [F.extend_apply_of_mem_I ⟨ht₀, ht₁⟩, F.curry_apply] },
+    { convert F.prop 1,
+      ext,
+      rw [F.extend_apply_of_one_le (le_of_not_le ht₁), F.curry_apply, F.apply_one] } },
+  { convert F.prop 0,
+    ext,
+    rw [F.extend_apply_of_le_zero (le_of_not_le ht₀), F.curry_apply, F.apply_zero] }
+end
 
 end
 
+variable {P : C(X, Y) → Prop}
+
 /--
-Given a continuous function `f`, we can define a `homotopy f f` by `F (t, x) = f x`
+Given a continuous function `f` and a proof `hP : P f`, we can define a `homotopy_with f f` by
+`F (t, x) = f x`
 -/
-def refl (f : C(X, Y)) : homotopy f f :=
+def refl (f : C(X, Y)) (hP : P f) : homotopy_with f f P :=
 { to_fun := λ x, f x.2,
   continuous_to_fun := by continuity,
   to_fun_zero := λ _, rfl,
-  to_fun_one := λ _, rfl }
+  to_fun_one := λ _, rfl,
+  prop' := λ t, begin
+    convert hP,
+    ext, refl,
+  end }
 
-instance : inhabited (homotopy (continuous_map.id : C(X, X)) continuous_map.id) :=
-  ⟨homotopy.refl continuous_map.id⟩
+instance : inhabited (homotopy_with (continuous_map.id : C(X, X)) continuous_map.id (λ f, true)) :=
+  ⟨homotopy_with.refl continuous_map.id trivial⟩
 
 /--
-Given a `homotopy f₀ f₁`, we can define a `homotopy f₁ f₀` by reversing the homotopy.
+Given a `homotopy_with f₀ f₁ P`, we can define a `homotopy_with f₁ f₀ P` by reversing the homotopy.
 -/
-def symm {f₀ f₁ : C(X, Y)} (F : homotopy f₀ f₁) : homotopy f₁ f₀ :=
+def symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : homotopy_with f₁ f₀ P :=
 { to_fun := λ x, F (σ x.1, x.2),
   continuous_to_fun := by continuity,
   to_fun_zero := by norm_num,
-  to_fun_one := by norm_num }
+  to_fun_one := by norm_num,
+  prop' := λ t, by simpa using F.prop' (σ t) }
 
 @[simp]
-lemma symm_apply {f₀ f₁ : C(X, Y)} (F : homotopy f₀ f₁) (x : X) (t : I) :
+lemma symm_apply {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (x : X) (t : I) :
   F.symm (t, x) = F (σ t, x) := rfl
 
 @[simp]
-lemma symm_symm {f₀ f₁ : C(X, Y)} (F : homotopy f₀ f₁) : F.symm.symm = F :=
+lemma symm_symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : F.symm.symm = F :=
 begin
   ext x,
   cases x,
@@ -124,10 +179,11 @@ begin
 end
 
 /--
-Given `homotopy f₀ f₁` and `homotopy f₁ f₂`, we can define a `homotopy f₀ f₂` by putting the first
-homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
+Given `homotopy_with f₀ f₁ P` and `homotopy_with f₁ f₂ P`, we can define a `homotopy_with f₀ f₂ P`
+by putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
 -/
-def trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂) : homotopy f₀ f₂ :=
+def trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P) :
+  homotopy_with f₀ f₂ P :=
 { to_fun := λ x, if (x.1 : ℝ) ≤ 1/2 then F.extend (2 * x.1) x.2 else G.extend (2 * x.1 - 1) x.2,
   continuous_to_fun := begin
     refine continuous_if_le _ _ (continuous.continuous_on _) (continuous.continuous_on _) _,
@@ -137,20 +193,27 @@ def trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁
     exact continuous_induced_dom.comp continuous_fst,
     exact continuous_const,
     -- TODO: Work out why `continuity` doesn't work here.
-    exact (homotopy.continuous F).comp
+    exact F.continuous.comp
       ((continuous_proj_Icc.comp (continuous_const.mul
         (continuous_induced_dom.comp continuous_fst))).prod_mk continuous_snd),
-    exact (homotopy.continuous G).comp
+    exact G.continuous.comp
       ((continuous_proj_Icc.comp
       ((continuous_const.mul
         (continuous_induced_dom.comp continuous_fst)).sub continuous_const)).prod_mk
           continuous_snd),
   end,
   to_fun_zero := λ x, by norm_num,
-  to_fun_one := λ x, by norm_num }
+  to_fun_one := λ x, by norm_num,
+  prop' := λ t, begin
+    simp only,
+    split_ifs,
+    { exact F.extend_prop _ },
+    { exact G.extend_prop _ },
+  end }
 
-lemma trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂) (x : I × X) :
-  (F.trans G) x = if h : (x.1 : ℝ) ≤ 1/2 then
+lemma trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P)
+  (x : I × X) : (F.trans G) x =
+  if h : (x.1 : ℝ) ≤ 1/2 then
     F (⟨2 * x.1, (unit_interval.mul_pos_mem_iff zero_lt_two).2 ⟨x.1.2.1, h⟩⟩, x.2)
   else
     G (⟨2 * x.1 - 1, unit_interval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, x.1.2.2⟩⟩, x.2) :=
@@ -163,7 +226,7 @@ begin
     refl }
 end
 
-lemma symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂) :
+lemma symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P) :
   (F.trans G).symm = G.symm.trans F.symm :=
 begin
   ext,
@@ -188,88 +251,53 @@ begin
     exfalso, linarith }
 end
 
+end homotopy_with
+
+/--
+A `homotopy f₀ f₁` is defined to be a `homotopy_with` where the predicate is always `true`.
+-/
+abbreviation homotopy (f₀ f₁ : C(X, Y)) := homotopy_with f₀ f₁ (λ f, true)
+
+namespace homotopy
+
+/--
+Given a map `f : C(X, Y)`, we can define a `homotopy f f` by setting `F (t, x) = f x` for all `t`.
+This is defined using `homotopy_with.refl`, but with the proof filled in.
+-/
+def refl (f : C(X, Y)) : homotopy f f := homotopy_with.refl f trivial
+
 end homotopy
 
 /--
-The type of homotopies between two functions, fixing all points in `A : set X`.
+A `homotopy_rel f₀ f₁ S` is a homotopy bewteen `f₀` and `f₁` which is fixed on the points in `S`.
 -/
-structure homotopy_rel (f g : C(X, Y)) (A : set X) extends homotopy f g :=
-(eq_fst' : ∀ t (x ∈ A), to_fun (t, x) = f x)
-(eq_snd' : ∀ t (x ∈ A), to_fun (t, x) = g x)
+abbreviation homotopy_rel (f₀ f₁ : C(X, Y)) (S : set X) :=
+homotopy_with f₀ f₁ (λ f, ∀ x ∈ S, f x = f₀ x ∧ f x = f₁ x)
 
 namespace homotopy_rel
 
 section
 
-variables {f₀ f₁ : C(X, Y)} {A : set X}
+variables {f₀ f₁ : C(X, Y)} {S : set X}
 
-instance : has_coe_to_fun (homotopy_rel f₀ f₁ A) := ⟨_, λ F, F.to_fun⟩
+lemma eq_fst (F : homotopy_rel f₀ f₁ S) (t : I) {x : X} (hx : x ∈ S) :
+  F (t, x) = f₀ x := (F.prop t x hx).1
 
-@[simp]
-lemma coe_to_homotopy {F : homotopy_rel f₀ f₁ A} : ⇑F.to_homotopy = F := rfl
+lemma eq_snd (F : homotopy_rel f₀ f₁ S) (t : I) {x : X} (hx : x ∈ S) :
+  F (t, x) = f₁ x := (F.prop t x hx).2
 
-lemma coe_fn_injective : @function.injective (homotopy_rel f₀ f₁ A) (I × X → Y) coe_fn :=
-begin
-  rintros ⟨⟨⟨F, _⟩, _⟩, _⟩ ⟨⟨⟨G, _⟩, _⟩, _⟩ h,
-  congr' 3,
+lemma fst_eq_snd (F : homotopy_rel f₀ f₁ S) {x : X} (hx : x ∈ S) :
+  f₀ x = f₁ x := F.eq_fst 0 hx ▸ F.eq_snd 0 hx
 end
-
-@[ext]
-lemma ext {F G : homotopy_rel f₀ f₁ A} (h : ∀ t, F t = G t) : F = G :=
-coe_fn_injective $ funext h
-
-lemma eq_fst (F : homotopy_rel f₀ f₁ A) (t : I) {x : X} (hx : x ∈ A) : F (t, x) = f₀ x :=
-eq_fst' _ _ _ hx
-
-lemma eq_snd (F : homotopy_rel f₀ f₁ A) (t : I) {x : X} (hx : x ∈ A) : F (t, x) = f₁ x :=
-eq_snd' _ _ _ hx
-
-lemma fst_eq_snd (F : homotopy_rel f₀ f₁ A) {x : X} (hx : x ∈ A) : f₀ x = f₁ x :=
-eq_fst' F 1 _ hx ▸ eq_snd' F _ _ hx
-
-end
-
-/--
-Given a continuous function `f : C(X, Y)` and any `A : set X`, we can define the constant homotopy
-relative to `A`.
--/
-def refl (f : C(X, Y)) (A : set X) : homotopy_rel f f A :=
-{ eq_fst' := λ _ _ _, rfl,
-  eq_snd' := λ  _ _ _, rfl,
-  ..homotopy.refl f }
-
-instance : inhabited (homotopy_rel (continuous_map.id : C(X, X)) continuous_map.id set.univ) :=
-⟨homotopy_rel.refl continuous_map.id set.univ⟩
-
-/--
-Given continuous functions `f₀ f₁ : C(X, Y)`, and `F : homotopy_rel f g A`, we can reverse the
-homotopy to get a `homotopy_rel g f A`.
--/
-def symm {f₀ f₁ : C(X, Y)} {A : set X} (F : homotopy_rel f₀ f₁ A) : homotopy_rel f₁ f₀ A :=
-{ eq_fst' := λ t x hx, by simp [F.eq_snd, hx],
-  eq_snd' := λ t x hx, by simp [F.eq_fst, hx],
-  ..F.to_homotopy.symm }
-
-/--
-Given `homotopy_rel f₀ f₁ A` and `homotopy_rel f₁ f₂ A`, we can define a `homotopy_rel f₀ f₂ A` by
-putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
--/
-def trans {f₀ f₁ f₂ : C(X, Y)} {A : set X} (F : homotopy_rel f₀ f₁ A) (G : homotopy_rel f₁ f₂ A) :
-  homotopy_rel f₀ f₂ A :=
-{ eq_fst' := λ t x hx, begin
-    simp_rw [to_fun_eq_coe, homotopy.coe_to_continuous_map, homotopy.trans_apply],
-    split_ifs,
-    { rw [coe_to_homotopy, F.eq_fst _ hx] },
-    { rw [coe_to_homotopy, G.eq_fst _ hx, F.fst_eq_snd hx] }
-  end,
-  eq_snd' := λ t x hx, begin
-    simp_rw [to_fun_eq_coe, homotopy.coe_to_continuous_map, homotopy.trans_apply],
-    split_ifs,
-    { rw [coe_to_homotopy, F.eq_snd _ hx, G.fst_eq_snd hx] },
-    { rw [coe_to_homotopy, G.eq_snd _ hx] }
-  end,
-  ..F.to_homotopy.trans G.to_homotopy }
 
 end homotopy_rel
+
+/--
+Given a map `f : C(X, Y)` and a set `S`, we can define a `homotopy_rel f f S` by setting
+`F (t, x) = f x` for all `t`. This is defined using `homotopy_with.refl`, but with the proof
+filled in.
+-/
+def refl (f : C(X, Y)) (S : set X) : homotopy_rel f f S :=
+homotopy_with.refl f (λ x hx, ⟨rfl, rfl⟩)
 
 end continuous_map

--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -18,10 +18,10 @@ HOL-Analysis. With this, we get `homotopy` as a special case of `homotopy_with`.
 
 ## Definitions
 
-* `homotopy_with f₀ f₁ P` is the type of homotoies between `f₀` and `f₁`, where the intermediate
+* `homotopy_with f₀ f₁ P` is the type of homotopies between `f₀` and `f₁`, where the intermediate
   maps satisfy the predicate `P : C(X, Y) → Prop`.
 * `homotopy_with.refl` is the homotopy between `f₀` and `f₀`.
-* `homotopy_with.symm F` is a defined by reversing the homotopy `F`
+* `homotopy_with.symm F` is defined by reversing the homotopy `F`
 * `homotopy_with.trans F G`, where `F : homotopy f₀ f₁`, `G : homotopy f₁ f₂` is a `homotopy f₀ f₂`
   defined by putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
 * `homotopy f₀ f₁` is defined to be `homotopy_with f₀ f₁ (λ f, true)`.
@@ -73,6 +73,12 @@ end
 @[ext]
 lemma ext {F G : homotopy_with f₀ f₁ P} (h : ∀ x, F x = G x) : F = G :=
 coe_fn_injective $ funext h
+
+/-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
+because it is a composition of multiple projections. -/
+def simps.apply (F : homotopy_with f₀ f₁ P) : I × X → Y := F
+
+initialize_simps_projections homotopy_with (to_continuous_map_to_fun -> apply, -to_continuous_map)
 
 @[continuity]
 protected lemma continuous (F : homotopy_with f₀ f₁ P) : continuous F := F.continuous_to_fun
@@ -147,6 +153,7 @@ variable {P : C(X, Y) → Prop}
 Given a continuous function `f` and a proof `hP : P f`, we can define a `homotopy_with f f` by
 `F (t, x) = f x`
 -/
+@[simps]
 def refl (f : C(X, Y)) (hP : P f) : homotopy_with f f P :=
 { to_fun := λ x, f x.2,
   continuous_to_fun := by continuity,
@@ -157,25 +164,19 @@ def refl (f : C(X, Y)) (hP : P f) : homotopy_with f f P :=
     ext, refl,
   end }
 
-@[simp]
-lemma refl_apply {f : C(X, Y)} (hP : P f) (x : I × X) : refl f hP x = f x.2 := rfl
-
 instance : inhabited (homotopy_with (continuous_map.id : C(X, X)) continuous_map.id (λ f, true)) :=
 ⟨homotopy_with.refl continuous_map.id trivial⟩
 
 /--
 Given a `homotopy_with f₀ f₁ P`, we can define a `homotopy_with f₁ f₀ P` by reversing the homotopy.
 -/
+@[simps]
 def symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : homotopy_with f₁ f₀ P :=
 { to_fun := λ x, F (σ x.1, x.2),
   continuous_to_fun := by continuity,
   to_fun_zero := by norm_num,
   to_fun_one := by norm_num,
   prop' := λ t, by simpa using F.prop' (σ t) }
-
-@[simp]
-lemma symm_apply {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (x : I × X) :
-  F.symm x = F (σ x.1, x.2) := rfl
 
 @[simp]
 lemma symm_symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : F.symm.symm = F :=
@@ -189,21 +190,11 @@ def trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homoto
   homotopy_with f₀ f₂ P :=
 { to_fun := λ x, if (x.1 : ℝ) ≤ 1/2 then F.extend (2 * x.1) x.2 else G.extend (2 * x.1 - 1) x.2,
   continuous_to_fun := begin
-    refine continuous_if_le _ _ (continuous.continuous_on _) (continuous.continuous_on _) _,
-    swap 5,
-    { rintros x hx,
-      norm_num [hx] },
-    exact continuous_induced_dom.comp continuous_fst,
-    exact continuous_const,
-    -- TODO: Work out why `continuity` doesn't work here.
-    exact F.continuous.comp
-      ((continuous_proj_Icc.comp (continuous_const.mul
-        (continuous_induced_dom.comp continuous_fst))).prod_mk continuous_snd),
-    exact G.continuous.comp
-      ((continuous_proj_Icc.comp
-      ((continuous_const.mul
-        (continuous_induced_dom.comp continuous_fst)).sub continuous_const)).prod_mk
-          continuous_snd),
+    refine continuous_if_le (continuous_induced_dom.comp continuous_fst) continuous_const
+      (F.continuous.comp (by continuity)).continuous_on
+      (G.continuous.comp (by continuity)).continuous_on _,
+    rintros x hx,
+    norm_num [hx],
   end,
   to_fun_zero := λ x, by norm_num,
   to_fun_one := λ x, by norm_num,
@@ -260,7 +251,37 @@ namespace homotopy
 Given a map `f : C(X, Y)`, we can define a `homotopy f f` by setting `F (t, x) = f x` for all `t`.
 This is defined using `homotopy_with.refl`, but with the proof filled in.
 -/
+@[simps]
 def refl (f : C(X, Y)) : homotopy f f := homotopy_with.refl f trivial
+
+/--
+Given a `homotopy f₀ f₁`, we can define a `homotopy f₁ f₀` by reversing the homotopy.
+-/
+@[simps]
+def symm {f₀ f₁ : C(X, Y)} (F : homotopy f₀ f₁) : homotopy f₁ f₀ := homotopy_with.symm F
+
+@[simp]
+lemma symm_symm {f₀ f₁ : C(X, Y)} (F : homotopy f₀ f₁) : F.symm.symm = F :=
+homotopy_with.symm_symm F
+
+/--
+Given `homotopy f₀ f₁` and `homotopy f₁ f₂`, we can define a `homotopy f₀ f₂`
+by putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
+-/
+def trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂) : homotopy f₀ f₂ :=
+homotopy_with.trans F G
+
+lemma trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂)
+  (x : I × X) : (F.trans G) x =
+  if h : (x.1 : ℝ) ≤ 1/2 then
+    F (⟨2 * x.1, (unit_interval.mul_pos_mem_iff zero_lt_two).2 ⟨x.1.2.1, h⟩⟩, x.2)
+  else
+    G (⟨2 * x.1 - 1, unit_interval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, x.1.2.2⟩⟩, x.2) :=
+homotopy_with.trans_apply F G x
+
+lemma symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂) :
+  (F.trans G).symm = G.symm.trans F.symm :=
+homotopy_with.symm_trans F G
 
 end homotopy
 
@@ -284,16 +305,92 @@ lemma eq_snd (F : homotopy_rel f₀ f₁ S) (t : I) {x : X} (hx : x ∈ S) :
 
 lemma fst_eq_snd (F : homotopy_rel f₀ f₁ S) {x : X} (hx : x ∈ S) :
   f₀ x = f₁ x := F.eq_fst 0 hx ▸ F.eq_snd 0 hx
+
 end
 
-end homotopy_rel
+variables {f₀ f₁ f₂ : C(X, Y)} {S : set X}
 
 /--
 Given a map `f : C(X, Y)` and a set `S`, we can define a `homotopy_rel f f S` by setting
 `F (t, x) = f x` for all `t`. This is defined using `homotopy_with.refl`, but with the proof
 filled in.
 -/
+@[simps]
 def refl (f : C(X, Y)) (S : set X) : homotopy_rel f f S :=
 homotopy_with.refl f (λ x hx, ⟨rfl, rfl⟩)
 
+/--
+Given a `homotopy_rel f₀ f₁ S`, we can define a `homotopy_rel f₁ f₀ S` by reversing the homotopy.
+-/
+@[simps]
+def symm (F : homotopy_rel f₀ f₁ S) : homotopy_rel f₁ f₀ S :=
+{ prop' := λ t x hx, by simp [F.eq_snd _ hx, F.fst_eq_snd hx],
+  ..homotopy_with.symm F }
+
+@[simp]
+lemma symm_symm (F : homotopy_rel f₀ f₁ S) : F.symm.symm = F :=
+homotopy_with.symm_symm F
+
+/--
+Given `homotopy_rel f₀ f₁ S` and `homotopy_rel f₁ f₂ S`, we can define a `homotopy_rel f₀ f₂ S`
+by putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
+-/
+def trans (F : homotopy_rel f₀ f₁ S) (G : homotopy_rel f₁ f₂ S) : homotopy_rel f₀ f₂ S :=
+{ to_fun := λ x, if (x.1 : ℝ) ≤ 1/2 then F.extend (2 * x.1) x.2 else G.extend (2 * x.1 - 1) x.2,
+  continuous_to_fun := begin
+    refine continuous_if_le (continuous_induced_dom.comp continuous_fst) continuous_const
+      (F.continuous.comp (by continuity)).continuous_on
+      (G.continuous.comp (by continuity)).continuous_on _,
+    rintros x hx,
+    norm_num [hx],
+  end,
+  to_fun_zero := λ x, by norm_num,
+  to_fun_one := λ x, by norm_num,
+  prop' := λ t, begin
+    simp only,
+    split_ifs,
+    { intros x hx,
+      simp [(homotopy_with.extend_prop F (2 * t) x hx).1, F.fst_eq_snd hx, G.fst_eq_snd hx] },
+    { intros x hx,
+      simp [(homotopy_with.extend_prop G (2 * t - 1) x hx).1, F.fst_eq_snd hx, G.fst_eq_snd hx] },
+  end }
+
+lemma trans_apply (F : homotopy_rel f₀ f₁ S) (G : homotopy_rel f₁ f₂ S)
+  (x : I × X) : (F.trans G) x =
+  if h : (x.1 : ℝ) ≤ 1/2 then
+    F (⟨2 * x.1, (unit_interval.mul_pos_mem_iff zero_lt_two).2 ⟨x.1.2.1, h⟩⟩, x.2)
+  else
+    G (⟨2 * x.1 - 1, unit_interval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, x.1.2.2⟩⟩, x.2) :=
+show ite _ _ _ = _,
+by split_ifs;
+  { rw [homotopy_with.extend, continuous_map.coe_Icc_extend, set.Icc_extend_of_mem], refl }
+
+lemma symm_trans (F : homotopy_rel f₀ f₁ S) (G : homotopy_rel f₁ f₂ S) :
+  (F.trans G).symm = G.symm.trans F.symm :=
+begin
+  ext x,
+  simp only [symm_apply, trans_apply],
+  split_ifs with h₁ h₂,
+  { change (x.1 : ℝ) ≤ _ at h₂,
+    change (1 : ℝ) - x.1 ≤ _ at h₁,
+    have ht : (x.1 : ℝ) = 1/2,
+    { linarith },
+    norm_num [ht] },
+  { congr' 2,
+    apply subtype.ext,
+    simp only [unit_interval.coe_symm_eq, subtype.coe_mk],
+    linarith },
+  { congr' 2,
+    apply subtype.ext,
+    simp only [unit_interval.coe_symm_eq, subtype.coe_mk],
+    linarith },
+  { change ¬ (x.1 : ℝ) ≤ _ at h,
+    change ¬ (1 : ℝ) - x.1 ≤ _ at h₁,
+    exfalso, linarith }
+end
+
+end homotopy_rel
+
 end continuous_map
+
+#lint

--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -392,5 +392,3 @@ end
 end homotopy_rel
 
 end continuous_map
-
-#lint

--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -179,10 +179,7 @@ lemma symm_apply {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (x : I ×
 
 @[simp]
 lemma symm_symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : F.symm.symm = F :=
-begin
-  ext x,
-  simp,
-end
+by { ext, simp }
 
 /--
 Given `homotopy_with f₀ f₁ P` and `homotopy_with f₁ f₂ P`, we can define a `homotopy_with f₀ f₂ P`
@@ -223,14 +220,8 @@ lemma trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G 
     F (⟨2 * x.1, (unit_interval.mul_pos_mem_iff zero_lt_two).2 ⟨x.1.2.1, h⟩⟩, x.2)
   else
     G (⟨2 * x.1 - 1, unit_interval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, x.1.2.2⟩⟩, x.2) :=
-begin
-  change ite _ _ _ = _,
-  split_ifs,
-  { rw [extend, continuous_map.coe_Icc_extend, set.Icc_extend_of_mem],
-    refl },
-  { rw [extend, continuous_map.coe_Icc_extend, set.Icc_extend_of_mem],
-    refl }
-end
+show ite _ _ _ = _,
+by split_ifs; { rw [extend, continuous_map.coe_Icc_extend, set.Icc_extend_of_mem], refl }
 
 lemma symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P) :
   (F.trans G).symm = G.symm.trans F.symm :=

--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -233,8 +233,7 @@ end
 lemma symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P) :
   (F.trans G).symm = G.symm.trans F.symm :=
 begin
-  ext,
-  cases x with t x,
+  ext ⟨t, x⟩,
   simp only [symm_apply, trans_apply],
   split_ifs with h₁ h₂,
   { change (t : ℝ) ≤ _ at h₂,

--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -30,6 +30,10 @@ HOL-Analysis. With this, we get `homotopy` as a special case of `homotopy_with`.
   `homotopy_with f₀ f₁ (λ f, ∀ x ∈ S, f x = f₀ x ∧ f x = f₁ x)`. That is, a homotopy between `f₀`
   and `f₁` which is fixed on the points in `S`.
 * `homotopy_rel.refl` is a variant of `homotopy_with.refl` with the proof of `P f` filled in.
+
+## References
+
+- [HOL-Analysis formalisation](https://isabelle.in.tum.de/library/HOL/HOL-Analysis/Homotopy.html)
 -/
 
 noncomputable theory
@@ -154,11 +158,12 @@ def refl (f : C(X, Y)) (hP : P f) : homotopy_with f f P :=
   end }
 
 instance : inhabited (homotopy_with (continuous_map.id : C(X, X)) continuous_map.id (λ f, true)) :=
-  ⟨homotopy_with.refl continuous_map.id trivial⟩
+⟨homotopy_with.refl continuous_map.id trivial⟩
 
 /--
 Given a `homotopy_with f₀ f₁ P`, we can define a `homotopy_with f₁ f₀ P` by reversing the homotopy.
 -/
+@[simps?]
 def symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : homotopy_with f₁ f₀ P :=
 { to_fun := λ x, F (σ x.1, x.2),
   continuous_to_fun := by continuity,
@@ -173,8 +178,7 @@ lemma symm_apply {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (x : X) (
 @[simp]
 lemma symm_symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : F.symm.symm = F :=
 begin
-  ext x,
-  cases x,
+  ext ⟨t, x⟩,
   simp,
 end
 

--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -50,71 +50,71 @@ namespace continuous_map
 The type of homotopies between two functions, where the intermediate maps satisfy the predicate
 `P : C(X, Y) → Prop`.
 -/
-structure homotopy_with (f₀ f₁ : C(X, Y)) (P : C(X, Y) → Prop) extends C(I × X, Y) :=
+structure homotopy (f₀ f₁ : C(X, Y)) extends C(I × X, Y) :=
 (to_fun_zero : ∀ x, to_fun (0, x) = f₀ x)
 (to_fun_one : ∀ x, to_fun (1, x) = f₁ x)
-(prop' : ∀ t, P ⟨λ x, to_fun (t, x),
-  continuous.comp continuous_to_fun (continuous_const.prod_mk continuous_id')⟩)
+-- (prop' : ∀ t, P ⟨λ x, to_fun (t, x),
+--   continuous.comp continuous_to_fun (continuous_const.prod_mk continuous_id')⟩)
 
-namespace homotopy_with
+namespace homotopy
 
 section
 
-variables {f₀ f₁ : C(X, Y)} {P : C(X, Y) → Prop}
+variables {f₀ f₁ : C(X, Y)}
 
-instance : has_coe_to_fun (homotopy_with f₀ f₁ P) := ⟨_, λ F, F.to_fun⟩
+instance : has_coe_to_fun (homotopy f₀ f₁) := ⟨_, λ F, F.to_fun⟩
 
-lemma coe_fn_injective : @function.injective (homotopy_with f₀ f₁ P) (I × X → Y) coe_fn :=
+lemma coe_fn_injective : @function.injective (homotopy f₀ f₁) (I × X → Y) coe_fn :=
 begin
   rintros ⟨⟨F, _⟩, _⟩ ⟨⟨G, _⟩, _⟩ h,
   congr' 2,
 end
 
 @[ext]
-lemma ext {F G : homotopy_with f₀ f₁ P} (h : ∀ x, F x = G x) : F = G :=
+lemma ext {F G : homotopy f₀ f₁} (h : ∀ x, F x = G x) : F = G :=
 coe_fn_injective $ funext h
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
 because it is a composition of multiple projections. -/
-def simps.apply (F : homotopy_with f₀ f₁ P) : I × X → Y := F
+def simps.apply (F : homotopy f₀ f₁) : I × X → Y := F
 
-initialize_simps_projections homotopy_with (to_continuous_map_to_fun -> apply, -to_continuous_map)
+initialize_simps_projections homotopy (to_continuous_map_to_fun -> apply, -to_continuous_map)
 
 @[continuity]
-protected lemma continuous (F : homotopy_with f₀ f₁ P) : continuous F := F.continuous_to_fun
+protected lemma continuous (F : homotopy f₀ f₁) : continuous F := F.continuous_to_fun
 
 @[simp]
-lemma apply_zero (F : homotopy_with f₀ f₁ P) (x : X) : F (0, x) = f₀ x := F.to_fun_zero x
+lemma apply_zero (F : homotopy f₀ f₁) (x : X) : F (0, x) = f₀ x := F.to_fun_zero x
 
 @[simp]
-lemma apply_one (F : homotopy_with f₀ f₁ P) (x : X) : F (1, x) = f₁ x := F.to_fun_one x
+lemma apply_one (F : homotopy f₀ f₁) (x : X) : F (1, x) = f₁ x := F.to_fun_one x
 
 @[simp]
-lemma coe_to_continuous_map (F : homotopy_with f₀ f₁ P) : ⇑F.to_continuous_map = F := rfl
+lemma coe_to_continuous_map (F : homotopy f₀ f₁) : ⇑F.to_continuous_map = F := rfl
 
 /--
 Currying a homotopy to a continuous function fron `I` to `C(X, Y)`.
 -/
-def curry (F : homotopy_with f₀ f₁ P) : C(I, C(X, Y)) := F.to_continuous_map.curry
+def curry (F : homotopy f₀ f₁) : C(I, C(X, Y)) := F.to_continuous_map.curry
 
-lemma prop (F : homotopy_with f₀ f₁ P) (t : I) : P (F.curry t) := F.prop' t
+-- lemma prop (F : homotopy f₀ f₁) (t : I) : P (F.curry t) := F.prop' t
 
 @[simp]
-lemma curry_apply (F : homotopy_with f₀ f₁ P) (t : I) (x : X) : F.curry t x = F (t, x) := rfl
+lemma curry_apply (F : homotopy f₀ f₁) (t : I) (x : X) : F.curry t x = F (t, x) := rfl
 
 /--
 Continuously extending a curried homotopy to a function from `ℝ` to `C(X, Y)`.
 -/
-def extend (F : homotopy_with f₀ f₁ P) : C(ℝ, C(X, Y)) := F.curry.Icc_extend zero_le_one
+def extend (F : homotopy f₀ f₁) : C(ℝ, C(X, Y)) := F.curry.Icc_extend zero_le_one
 
-lemma extend_apply_of_le_zero (F : homotopy_with f₀ f₁ P) {t : ℝ} (ht : t ≤ 0) (x : X) :
+lemma extend_apply_of_le_zero (F : homotopy f₀ f₁) {t : ℝ} (ht : t ≤ 0) (x : X) :
   F.extend t x = f₀ x :=
 begin
   rw [←F.apply_zero],
   exact continuous_map.congr_fun (set.Icc_extend_of_le_left (@zero_le_one ℝ _) F.curry ht) x,
 end
 
-lemma extend_apply_of_one_le (F : homotopy_with f₀ f₁ P) {t : ℝ} (ht : 1 ≤ t) (x : X) :
+lemma extend_apply_of_one_le (F : homotopy f₀ f₁) {t : ℝ} (ht : 1 ≤ t) (x : X) :
   F.extend t x = f₁ x :=
 begin
   rw [←F.apply_one],
@@ -122,72 +122,60 @@ begin
 end
 
 @[simp]
-lemma extend_apply_coe (F : homotopy_with f₀ f₁ P) (t : I) (x : X) : F.extend t x = F (t, x) :=
+lemma extend_apply_coe (F : homotopy f₀ f₁) (t : I) (x : X) : F.extend t x = F (t, x) :=
 continuous_map.congr_fun (set.Icc_extend_coe (@zero_le_one ℝ _) F.curry t) x
 
 @[simp]
-lemma extend_apply_of_mem_I (F : homotopy_with f₀ f₁ P) {t : ℝ} (ht : t ∈ I) (x : X) :
+lemma extend_apply_of_mem_I (F : homotopy f₀ f₁) {t : ℝ} (ht : t ∈ I) (x : X) :
   F.extend t x = F (⟨t, ht⟩, x) :=
 continuous_map.congr_fun (set.Icc_extend_of_mem (@zero_le_one ℝ _) F.curry ht) x
 
-lemma extend_prop (F : homotopy_with f₀ f₁ P) (t : ℝ) : P (F.extend t) :=
-begin
-  by_cases ht₀ : 0 ≤ t,
-  { by_cases ht₁ : t ≤ 1,
-    { convert F.prop ⟨t, ht₀, ht₁⟩,
-      ext,
-      rw [F.extend_apply_of_mem_I ⟨ht₀, ht₁⟩, F.curry_apply] },
-    { convert F.prop 1,
-      ext,
-      rw [F.extend_apply_of_one_le (le_of_not_le ht₁), F.curry_apply, F.apply_one] } },
-  { convert F.prop 0,
-    ext,
-    rw [F.extend_apply_of_le_zero (le_of_not_le ht₀), F.curry_apply, F.apply_zero] }
-end
+lemma congr_fun {F G : homotopy f₀ f₁} (h : F = G) (x : I × X) : F x = G x :=
+continuous_map.congr_fun (congr_arg _ h) x
+
+lemma congr_arg (F : homotopy f₀ f₁) {x y : I × X} (h : x = y) : F x = F y :=
+F.to_continuous_map.congr_arg h
 
 end
 
-variable {P : C(X, Y) → Prop}
+-- variable {P : C(X, Y) → Prop}
 
 /--
-Given a continuous function `f` and a proof `hP : P f`, we can define a `homotopy_with f f` by
+Given a continuous function `f`, we can define a `homotopy f f` by
 `F (t, x) = f x`
 -/
 @[simps]
-def refl (f : C(X, Y)) (hP : P f) : homotopy_with f f P :=
+def refl (f : C(X, Y)) : homotopy f f :=
 { to_fun := λ x, f x.2,
   continuous_to_fun := by continuity,
   to_fun_zero := λ _, rfl,
-  to_fun_one := λ _, rfl,
-  prop' := λ t, begin
-    convert hP,
-    ext, refl,
-  end }
+  to_fun_one := λ _, rfl }
 
-instance : inhabited (homotopy_with (continuous_map.id : C(X, X)) continuous_map.id (λ f, true)) :=
-⟨homotopy_with.refl continuous_map.id trivial⟩
+instance : inhabited (homotopy (continuous_map.id : C(X, X)) continuous_map.id) :=
+⟨homotopy.refl continuous_map.id⟩
 
 /--
 Given a `homotopy_with f₀ f₁ P`, we can define a `homotopy_with f₁ f₀ P` by reversing the homotopy.
 -/
 @[simps]
-def symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : homotopy_with f₁ f₀ P :=
+def symm {f₀ f₁ : C(X, Y)} (F : homotopy f₀ f₁) : homotopy f₁ f₀ :=
 { to_fun := λ x, F (σ x.1, x.2),
   continuous_to_fun := by continuity,
   to_fun_zero := by norm_num,
   to_fun_one := by norm_num,
-  prop' := λ t, by simpa using F.prop' (σ t) }
+  -- prop' := λ t, by simpa using F.prop' (σ t)
+   }
 
 @[simp]
-lemma symm_symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : F.symm.symm = F :=
+lemma symm_symm {f₀ f₁ : C(X, Y)} (F : homotopy f₀ f₁) : F.symm.symm = F :=
 by { ext, simp }
 
 /--
 Given `homotopy_with f₀ f₁ P` and `homotopy_with f₁ f₂ P`, we can define a `homotopy_with f₀ f₂ P`
 by putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
 -/
-def trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P) :
-  homotopy_with f₀ f₂ P :=
+def trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂) :
+  homotopy f₀ f₂ :=
 { to_fun := λ x, if (x.1 : ℝ) ≤ 1/2 then F.extend (2 * x.1) x.2 else G.extend (2 * x.1 - 1) x.2,
   continuous_to_fun := begin
     refine continuous_if_le (continuous_induced_dom.comp continuous_fst) continuous_const
@@ -198,14 +186,15 @@ def trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homoto
   end,
   to_fun_zero := λ x, by norm_num,
   to_fun_one := λ x, by norm_num,
-  prop' := λ t, begin
-    simp only,
-    split_ifs,
-    { exact F.extend_prop _ },
-    { exact G.extend_prop _ },
-  end }
+  -- prop' := λ t, begin
+  --   simp only,
+  --   split_ifs,
+  --   { exact F.extend_prop _ },
+  --   { exact G.extend_prop _ },
+  -- end
+   }
 
-lemma trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P)
+lemma trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂)
   (x : I × X) : (F.trans G) x =
   if h : (x.1 : ℝ) ≤ 1/2 then
     F (⟨2 * x.1, (unit_interval.mul_pos_mem_iff zero_lt_two).2 ⟨x.1.2.1, h⟩⟩, x.2)
@@ -214,7 +203,7 @@ lemma trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G 
 show ite _ _ _ = _,
 by split_ifs; { rw [extend, continuous_map.coe_Icc_extend, set.Icc_extend_of_mem], refl }
 
-lemma symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P) :
+lemma symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂) :
   (F.trans G).symm = G.symm.trans F.symm :=
 begin
   ext x,
@@ -238,56 +227,117 @@ begin
     exfalso, linarith }
 end
 
-end homotopy_with
+end homotopy
 
-/--
-A `homotopy f₀ f₁` is defined to be a `homotopy_with` where the predicate is always `true`.
--/
-abbreviation homotopy (f₀ f₁ : C(X, Y)) := homotopy_with f₀ f₁ (λ f, true)
+structure homotopy_with (f₀ f₁ : C(X, Y)) (P : C(X, Y) → Prop) extends homotopy f₀ f₁ :=
+(prop' : ∀ t, P ⟨λ x, to_fun (t, x),
+  continuous.comp continuous_to_fun (continuous_const.prod_mk continuous_id')⟩)
 
-namespace homotopy
+namespace homotopy_with
 
-/--
-Given a map `f : C(X, Y)`, we can define a `homotopy f f` by setting `F (t, x) = f x` for all `t`.
-This is defined using `homotopy_with.refl`, but with the proof filled in.
--/
-@[simps]
-def refl (f : C(X, Y)) : homotopy f f := homotopy_with.refl f trivial
+section
 
-/--
-Given a `homotopy f₀ f₁`, we can define a `homotopy f₁ f₀` by reversing the homotopy.
--/
-@[simps]
-def symm {f₀ f₁ : C(X, Y)} (F : homotopy f₀ f₁) : homotopy f₁ f₀ := homotopy_with.symm F
+variables {f₀ f₁ : C(X, Y)} {P : C(X, Y) → Prop}
+
+instance : has_coe_to_fun (homotopy_with f₀ f₁ P) := ⟨_, λ F, F.to_fun⟩
+
+lemma coe_fn_injective : @function.injective (homotopy_with f₀ f₁ P) (I × X → Y) coe_fn :=
+begin
+  rintros ⟨⟨⟨F, _⟩, _⟩, _⟩ ⟨⟨⟨G, _⟩, _⟩, _⟩ h,
+  congr' 3,
+end
+
+@[ext]
+lemma ext {F G : homotopy_with f₀ f₁ P} (h : ∀ x, F x = G x) : F = G :=
+coe_fn_injective $ funext h
+
+/-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
+because it is a composition of multiple projections. -/
+def simps.apply (F : homotopy_with f₀ f₁ P) : I × X → Y := F
+
+initialize_simps_projections homotopy_with
+  (to_homotopy_to_continuous_map_to_fun -> apply, -to_homotopy_to_continuous_map)
+
+@[continuity]
+protected lemma continuous (F : homotopy_with f₀ f₁ P) : continuous F := F.continuous_to_fun
 
 @[simp]
-lemma symm_symm {f₀ f₁ : C(X, Y)} (F : homotopy f₀ f₁) : F.symm.symm = F :=
-homotopy_with.symm_symm F
+lemma apply_zero (F : homotopy_with f₀ f₁ P) (x : X) : F (0, x) = f₀ x := F.to_fun_zero x
 
-/--
-Given `homotopy f₀ f₁` and `homotopy f₁ f₂`, we can define a `homotopy f₀ f₂`
-by putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
--/
-def trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂) : homotopy f₀ f₂ :=
-homotopy_with.trans F G
+@[simp]
+lemma apply_one (F : homotopy_with f₀ f₁ P) (x : X) : F (1, x) = f₁ x := F.to_fun_one x
 
-lemma trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂)
+@[simp]
+lemma coe_to_continuous_map (F : homotopy_with f₀ f₁ P) : ⇑F.to_continuous_map = F := rfl
+
+@[simp]
+lemma coe_to_homotopy (F : homotopy_with f₀ f₁ P) : ⇑F.to_homotopy = F := rfl
+
+lemma prop (F : homotopy_with f₀ f₁ P) (t : I) : P (F.to_homotopy.curry t) := F.prop' t
+
+lemma extend_prop (F : homotopy_with f₀ f₁ P) (t : ℝ) : P (F.to_homotopy.extend t) :=
+begin
+  by_cases ht₀ : 0 ≤ t,
+  { by_cases ht₁ : t ≤ 1,
+    { convert F.prop ⟨t, ht₀, ht₁⟩,
+      ext,
+      rw [F.to_homotopy.extend_apply_of_mem_I ⟨ht₀, ht₁⟩, F.to_homotopy.curry_apply] },
+    { convert F.prop 1,
+      ext,
+      rw [F.to_homotopy.extend_apply_of_one_le (le_of_not_le ht₁), F.to_homotopy.curry_apply,
+          F.to_homotopy.apply_one] } },
+  { convert F.prop 0,
+    ext,
+    rw [F.to_homotopy.extend_apply_of_le_zero (le_of_not_le ht₀), F.to_homotopy.curry_apply,
+        F.to_homotopy.apply_zero] }
+end
+
+end
+
+variable {P : C(X, Y) → Prop}
+
+@[simps]
+def refl (f : C(X, Y)) (hf : P f) : homotopy_with f f P :=
+{ prop' := λ t, by { convert hf, cases f, refl },
+  ..homotopy.refl f }
+
+@[simps]
+def symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : homotopy_with f₁ f₀ P :=
+{ prop' := λ t, by simpa using F.prop (σ t),
+  ..F.to_homotopy.symm }
+
+@[simp]
+lemma symm_symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : F.symm.symm = F :=
+ext $ homotopy.congr_fun $ homotopy.symm_symm _
+
+def trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P) :
+  homotopy_with f₀ f₂ P :=
+{ prop' := λ t, begin
+    simp only [homotopy.trans],
+    change P ⟨λ _, ite ((t : ℝ) ≤ _) _ _, _⟩,
+    split_ifs,
+    { exact F.extend_prop _ },
+    { exact G.extend_prop _ }
+  end,
+  ..F.to_homotopy.trans G.to_homotopy }
+
+lemma trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P)
   (x : I × X) : (F.trans G) x =
   if h : (x.1 : ℝ) ≤ 1/2 then
     F (⟨2 * x.1, (unit_interval.mul_pos_mem_iff zero_lt_two).2 ⟨x.1.2.1, h⟩⟩, x.2)
   else
     G (⟨2 * x.1 - 1, unit_interval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, x.1.2.2⟩⟩, x.2) :=
-homotopy_with.trans_apply F G x
+homotopy.trans_apply _ _ _
 
-lemma symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy f₀ f₁) (G : homotopy f₁ f₂) :
+lemma symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P) :
   (F.trans G).symm = G.symm.trans F.symm :=
-homotopy_with.symm_trans F G
+ext $ homotopy.congr_fun $ homotopy.symm_trans _ _
 
-end homotopy
+end homotopy_with
 
-/--
-A `homotopy_rel f₀ f₁ S` is a homotopy between `f₀` and `f₁` which is fixed on the points in `S`.
--/
+-- /--
+-- A `homotopy_rel f₀ f₁ S` is a homotopy between `f₀` and `f₁` which is fixed on the points in `S`.
+-- -/
 abbreviation homotopy_rel (f₀ f₁ : C(X, Y)) (S : set X) :=
 homotopy_with f₀ f₁ (λ f, ∀ x ∈ S, f x = f₀ x ∧ f x = f₁ x)
 
@@ -336,24 +386,15 @@ Given `homotopy_rel f₀ f₁ S` and `homotopy_rel f₁ f₂ S`, we can define a
 by putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
 -/
 def trans (F : homotopy_rel f₀ f₁ S) (G : homotopy_rel f₁ f₂ S) : homotopy_rel f₀ f₂ S :=
-{ to_fun := λ x, if (x.1 : ℝ) ≤ 1/2 then F.extend (2 * x.1) x.2 else G.extend (2 * x.1 - 1) x.2,
-  continuous_to_fun := begin
-    refine continuous_if_le (continuous_induced_dom.comp continuous_fst) continuous_const
-      (F.continuous.comp (by continuity)).continuous_on
-      (G.continuous.comp (by continuity)).continuous_on _,
-    rintros x hx,
-    norm_num [hx],
-  end,
-  to_fun_zero := λ x, by norm_num,
-  to_fun_one := λ x, by norm_num,
-  prop' := λ t, begin
-    simp only,
+{ prop' := λ t, begin
+    intros x hx,
+    simp only [homotopy.trans],
+    change (⟨λ _, ite ((t : ℝ) ≤ _) _ _, _⟩ : C(X, Y)) _ = _ ∧ _ = _,
     split_ifs,
-    { intros x hx,
-      simp [(homotopy_with.extend_prop F (2 * t) x hx).1, F.fst_eq_snd hx, G.fst_eq_snd hx] },
-    { intros x hx,
-      simp [(homotopy_with.extend_prop G (2 * t - 1) x hx).1, F.fst_eq_snd hx, G.fst_eq_snd hx] },
-  end }
+    { simp [(homotopy_with.extend_prop F (2 * t) x hx).1, F.fst_eq_snd hx, G.fst_eq_snd hx] },
+    { simp [(homotopy_with.extend_prop G (2 * t - 1) x hx).1, F.fst_eq_snd hx, G.fst_eq_snd hx] },
+  end,
+  ..homotopy.trans F.to_homotopy G.to_homotopy }
 
 lemma trans_apply (F : homotopy_rel f₀ f₁ S) (G : homotopy_rel f₁ f₂ S)
   (x : I × X) : (F.trans G) x =
@@ -361,33 +402,11 @@ lemma trans_apply (F : homotopy_rel f₀ f₁ S) (G : homotopy_rel f₁ f₂ S)
     F (⟨2 * x.1, (unit_interval.mul_pos_mem_iff zero_lt_two).2 ⟨x.1.2.1, h⟩⟩, x.2)
   else
     G (⟨2 * x.1 - 1, unit_interval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, x.1.2.2⟩⟩, x.2) :=
-show ite _ _ _ = _,
-by split_ifs;
-  { rw [homotopy_with.extend, continuous_map.coe_Icc_extend, set.Icc_extend_of_mem], refl }
+homotopy.trans_apply _ _ _
 
 lemma symm_trans (F : homotopy_rel f₀ f₁ S) (G : homotopy_rel f₁ f₂ S) :
   (F.trans G).symm = G.symm.trans F.symm :=
-begin
-  ext x,
-  simp only [symm_apply, trans_apply],
-  split_ifs with h₁ h₂,
-  { change (x.1 : ℝ) ≤ _ at h₂,
-    change (1 : ℝ) - x.1 ≤ _ at h₁,
-    have ht : (x.1 : ℝ) = 1/2,
-    { linarith },
-    norm_num [ht] },
-  { congr' 2,
-    apply subtype.ext,
-    simp only [unit_interval.coe_symm_eq, subtype.coe_mk],
-    linarith },
-  { congr' 2,
-    apply subtype.ext,
-    simp only [unit_interval.coe_symm_eq, subtype.coe_mk],
-    linarith },
-  { change ¬ (x.1 : ℝ) ≤ _ at h,
-    change ¬ (1 : ℝ) - x.1 ≤ _ at h₁,
-    exfalso, linarith }
-end
+homotopy_with.ext $ homotopy.congr_fun $ homotopy.symm_trans _ _
 
 end homotopy_rel
 

--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -157,6 +157,9 @@ def refl (f : C(X, Y)) (hP : P f) : homotopy_with f f P :=
     ext, refl,
   end }
 
+@[simp]
+lemma refl_apply {f : C(X, Y)} (hP : P f) (x : I × X) : refl f hP x = f x.2 := rfl
+
 instance : inhabited (homotopy_with (continuous_map.id : C(X, X)) continuous_map.id (λ f, true)) :=
 ⟨homotopy_with.refl continuous_map.id trivial⟩
 
@@ -171,13 +174,13 @@ def symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : homotopy_with f
   prop' := λ t, by simpa using F.prop' (σ t) }
 
 @[simp]
-lemma symm_apply {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (x : X) (t : I) :
-  F.symm (t, x) = F (σ t, x) := rfl
+lemma symm_apply {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (x : I × X) :
+  F.symm x = F (σ x.1, x.2) := rfl
 
 @[simp]
 lemma symm_symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : F.symm.symm = F :=
 begin
-  ext ⟨t, x⟩,
+  ext x,
   simp,
 end
 
@@ -232,12 +235,12 @@ end
 lemma symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : homotopy_with f₀ f₁ P) (G : homotopy_with f₁ f₂ P) :
   (F.trans G).symm = G.symm.trans F.symm :=
 begin
-  ext ⟨t, x⟩,
+  ext x,
   simp only [symm_apply, trans_apply],
   split_ifs with h₁ h₂,
-  { change (t : ℝ) ≤ _ at h₂,
-    change (1 : ℝ) - t ≤ _ at h₁,
-    have ht : (t : ℝ) = 1/2,
+  { change (x.1 : ℝ) ≤ _ at h₂,
+    change (1 : ℝ) - x.1 ≤ _ at h₁,
+    have ht : (x.1 : ℝ) = 1/2,
     { linarith },
     norm_num [ht] },
   { congr' 2,
@@ -248,8 +251,8 @@ begin
     apply subtype.ext,
     simp only [unit_interval.coe_symm_eq, subtype.coe_mk],
     linarith },
-  { change ¬ (t : ℝ) ≤ _ at h,
-    change ¬ (1 : ℝ) - t ≤ _ at h₁,
+  { change ¬ (x.1 : ℝ) ≤ _ at h,
+    change ¬ (1 : ℝ) - x.1 ≤ _ at h₁,
     exfalso, linarith }
 end
 

--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -163,7 +163,6 @@ instance : inhabited (homotopy_with (continuous_map.id : C(X, X)) continuous_map
 /--
 Given a `homotopy_with f₀ f₁ P`, we can define a `homotopy_with f₁ f₀ P` by reversing the homotopy.
 -/
-@[simps?]
 def symm {f₀ f₁ : C(X, Y)} (F : homotopy_with f₀ f₁ P) : homotopy_with f₁ f₀ P :=
 { to_fun := λ x, F (σ x.1, x.2),
   continuous_to_fun := by continuity,


### PR DESCRIPTION
Added `homotopy_with` as in [`HOL-Analysis`](https://isabelle.in.tum.de/library/HOL/HOL-Analysis/Homotopy.html) extending `homotopy`. Furthermore, I've added `homotopy_rel`.

Also rename/moved the file. There is also some refactoring which is part of the suggestions from #9141 .


---

Edit; Done

~~I'll also copy over my question from #9141, which is that Isabelle has a `homotopy_with`, which instead of restricting the intermediate maps on a set, it takes in arbitrary `P : C(X, Y) -> Prop`. That is strictly more general than this, but I'm not really sure where/what that would be useful for?~~

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
