### PR TITLE
[Merged by Bors] - feat(ring_theory/derivation): helper lemma for custom `derivation_ext` lemmas

### DIFF
--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -5,6 +5,7 @@ Authors: Nicolò Cavalleri
 -/
 
 import algebra.lie.of_associative
+import ring_theory.adjoin.basic
 import ring_theory.algebra_tower
 
 /-!
@@ -89,6 +90,17 @@ end
 @[simp] lemma map_algebra_map : D (algebra_map R A r) = 0 :=
 by rw [←mul_one r, ring_hom.map_mul, ring_hom.map_one, ←smul_def, map_smul, map_one_eq_zero,
   smul_zero]
+
+lemma eq_on_adjoin {s : set A} (h : set.eq_on D1 D2 s) : set.eq_on D1 D2 (adjoin R s) :=
+λ x hx, algebra.adjoin_induction hx h
+  (λ r, (D1.map_algebra_map r).trans (D2.map_algebra_map r).symm)
+  (λ x y hx hy, by simp only [map_add, *])
+  (λ x y hx hy, by simp only [leibniz, *])
+
+/-- If adjoin of a set is the whole algebra, then any two derivations equal on this set are equal
+on the whole algebra. -/
+lemma ext_of_adjoin_eq_top (s : set A) (hs : adjoin R s = ⊤) (h : set.eq_on D1 D2 s) : D1 = D2 :=
+ext $ λ a, eq_on_adjoin h $ hs.symm ▸ trivial
 
 /- Data typeclasses -/
 


### PR DESCRIPTION
---

In order to actually use it for custom lemmas `polynomial.derivation_ext` and `mv_polynomial.derivation_ext` I need to fix some import loops first: currently, the file with `algebra.adjoin_induction` depends on `mv_polynomial`s.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
