### PR TITLE
[Merged by Bors] - refactor(analysis/convex/{extreme, exposed}): generalize `is_extreme` and `is_exposed` to semimodules

### DIFF
--- a/src/analysis/convex/exposed.lean
+++ b/src/analysis/convex/exposed.lean
@@ -5,7 +5,7 @@ Authors: Yaël Dillies, Bhavik Mehta
 -/
 import analysis.convex.extreme
 import analysis.convex.function
-import analysis.normed_space.basic
+import analysis.normed_space.ordered
 
 /-!
 # Exposed sets
@@ -13,7 +13,7 @@ import analysis.normed_space.basic
 This file defines exposed sets and exposed points for sets in a real vector space.
 
 An exposed subset of `A` is a subset of `A` that is the set of all maximal points of a functional
-(a continuous linear map `E → ℝ`) over `A`. By convention, `∅` is an exposed subset of all sets.
+(a continuous linear map `E → 𝕜`) over `A`. By convention, `∅` is an exposed subset of all sets.
 This allows for better functioriality of the definition (the intersection of two exposed subsets is
 exposed, faces of a polytope form a bounded lattice).
 This is an analytic notion of "being on the side of". It is stronger than being extreme (see
@@ -25,7 +25,7 @@ on mathlib!).
 
 ## Main declarations
 
-* `is_exposed A B`: States that `B` is an exposed set of `A` (in the literature, `A` is often
+* `is_exposed 𝕜 A B`: States that `B` is an exposed set of `A` (in the literature, `A` is often
   implicit).
 * `is_exposed.is_extreme`: An exposed set is also extreme.
 
@@ -35,9 +35,9 @@ See chapter 8 of [Barry Simon, *Convexity*][simon2011]
 
 ## TODO
 
-* define convex independence, intrinsic frontier/interior and prove the lemmas related to exposed
-  sets and points.
-* generalise to Locally Convex Topological Vector Spaces™
+Define intrinsic frontier/interior and prove the lemmas related to exposed sets and points.
+
+Generalise to Locally Convex Topological Vector Spaces™
 
 More not-yet-PRed stuff is available on the branch `sperner_again`.
 -/
@@ -45,38 +45,39 @@ More not-yet-PRed stuff is available on the branch `sperner_again`.
 open_locale classical affine big_operators
 open set
 
-variables {E : Type*} [normed_group E] [normed_space ℝ E] {x : E} {A B C : set E}
-  {X : finset E} {l : E →L[ℝ] ℝ}
+variables (𝕜 : Type*) {E : Type*} [normed_linear_ordered_field 𝕜] [normed_group E]
+  [normed_space 𝕜 E] {l : E →L[𝕜] 𝕜} {A B C : set E} {X : finset E} {x : E}
 
 /-- A set `B` is exposed with respect to `A` iff it maximizes some functional over `A` (and contains
-all points maximizing it). Written `is_exposed A B`. -/
+all points maximizing it). Written `is_exposed 𝕜 A B`. -/
 def is_exposed (A B : set E) : Prop :=
-B.nonempty → ∃ l : E →L[ℝ] ℝ, B = {x ∈ A | ∀ y ∈ A, l y ≤ l x}
+B.nonempty → ∃ l : E →L[𝕜] 𝕜, B = {x ∈ A | ∀ y ∈ A, l y ≤ l x}
 
+variables {𝕜}
 
 /-- A useful way to build exposed sets from intersecting `A` with halfspaces (modelled by an
 inequality with a functional). -/
-def continuous_linear_map.to_exposed (l : E →L[ℝ] ℝ) (A : set E) : set E :=
+def continuous_linear_map.to_exposed (l : E →L[𝕜] 𝕜) (A : set E) : set E :=
 {x ∈ A | ∀ y ∈ A, l y ≤ l x}
 
-lemma continuous_linear_map.to_exposed.is_exposed : is_exposed A (l.to_exposed A) := λ h, ⟨l, rfl⟩
+lemma continuous_linear_map.to_exposed.is_exposed : is_exposed 𝕜 A (l.to_exposed A) := λ h, ⟨l, rfl⟩
 
-lemma is_exposed_empty : is_exposed A ∅ :=
+lemma is_exposed_empty : is_exposed 𝕜 A ∅ :=
 λ ⟨x, hx⟩, by { exfalso, exact hx }
 
 namespace is_exposed
 
-protected lemma subset (hAB : is_exposed A B) : B ⊆ A :=
+protected lemma subset (hAB : is_exposed 𝕜 A B) : B ⊆ A :=
 begin
   rintro x hx,
   obtain ⟨_, rfl⟩ := hAB ⟨x, hx⟩,
   exact hx.1,
 end
 
-@[refl] lemma refl (A : set E) : is_exposed A A :=
+@[refl] lemma refl (A : set E) : is_exposed 𝕜 A A :=
 λ ⟨w, hw⟩, ⟨0, subset.antisymm (λ x hx, ⟨hx, λ y hy, by exact le_refl 0⟩) (λ x hx, hx.1)⟩
 
-lemma antisymm (hB : is_exposed A B) (hA : is_exposed B A) :
+lemma antisymm (hB : is_exposed 𝕜 A B) (hA : is_exposed 𝕜 B A) :
   A = B :=
 hA.subset.antisymm hB.subset
 
@@ -85,8 +86,8 @@ hA.subset.antisymm hB.subset
 of `A₀₀₀A₀₀₁A₀₁₀` which is an exposed subset of the cube, but `A₀₀₁A₀₁₀` is not itself an exposed
 subset of the cube. -/
 
-protected lemma mono (hC : is_exposed A C) (hBA : B ⊆ A) (hCB : C ⊆ B) :
-  is_exposed B C :=
+protected lemma mono (hC : is_exposed 𝕜 A C) (hBA : B ⊆ A) (hCB : C ⊆ B) :
+  is_exposed 𝕜 B C :=
 begin
   rintro ⟨w, hw⟩,
   obtain ⟨l, rfl⟩ := hC ⟨w, hw⟩,
@@ -97,8 +98,8 @@ end
 /-- If `B` is an exposed subset of `A`, then `B` is the intersection of `A` with some closed
 halfspace. The converse is *not* true. It would require that the corresponding open halfspace
 doesn't intersect `A`. -/
-lemma eq_inter_halfspace (hAB : is_exposed A B) :
-  ∃ l : E →L[ℝ] ℝ, ∃ a, B = {x ∈ A | a ≤ l x} :=
+lemma eq_inter_halfspace (hAB : is_exposed 𝕜 A B) :
+  ∃ l : E →L[𝕜] 𝕜, ∃ a, B = {x ∈ A | a ≤ l x} :=
 begin
   obtain hB | hB := B.eq_empty_or_nonempty,
   { refine ⟨0, 1, _⟩,
@@ -112,8 +113,8 @@ begin
     (λ x hx, ⟨hx.1, λ y hy, (hw.2 y hy).trans hx.2⟩)⟩,
 end
 
-lemma inter (hB : is_exposed A B) (hC : is_exposed A C) :
-  is_exposed A (B ∩ C) :=
+lemma inter (hB : is_exposed 𝕜 A B) (hC : is_exposed 𝕜 A C) :
+  is_exposed 𝕜 A (B ∩ C) :=
 begin
   rintro ⟨w, hwB, hwC⟩,
   obtain ⟨l₁, rfl⟩ := hB ⟨w, hwB⟩,
@@ -130,8 +131,8 @@ begin
 end
 
 lemma sInter {F : finset (set E)} (hF : F.nonempty)
-  (hAF : ∀ B ∈ F, is_exposed A B) :
-  is_exposed A (⋂₀ F) :=
+  (hAF : ∀ B ∈ F, is_exposed 𝕜 A B) :
+  is_exposed 𝕜 A (⋂₀ F) :=
 begin
   revert hF F,
   refine finset.induction _ _,
@@ -147,8 +148,8 @@ begin
     hCF B(finset.mem_insert_of_mem hB))),
 end
 
-lemma inter_left (hC : is_exposed A C) (hCB : C ⊆ B) :
-  is_exposed (A ∩ B) C :=
+lemma inter_left (hC : is_exposed 𝕜 A C) (hCB : C ⊆ B) :
+  is_exposed 𝕜 (A ∩ B) C :=
 begin
   rintro ⟨w, hw⟩,
   obtain ⟨l, rfl⟩ := hC ⟨w, hw⟩,
@@ -156,15 +157,15 @@ begin
     (λ x ⟨⟨hxC, _⟩, hx⟩, ⟨hxC, λ y hy, (hw.2 y hy).trans (hx w ⟨hC.subset hw, hCB hw⟩)⟩)⟩,
 end
 
-lemma inter_right (hC : is_exposed B C) (hCA : C ⊆ A) :
-  is_exposed (A ∩ B) C :=
+lemma inter_right (hC : is_exposed 𝕜 B C) (hCA : C ⊆ A) :
+  is_exposed 𝕜 (A ∩ B) C :=
 begin
   rw inter_comm,
   exact hC.inter_left hCA,
 end
 
-protected lemma is_extreme (hAB : is_exposed A B) :
-  is_extreme A B :=
+protected lemma is_extreme [normed_space ℝ E]  (hAB : is_exposed ℝ A B) :
+  is_extreme ℝ A B :=
 begin
   refine ⟨hAB.subset, λ x₁ x₂ hx₁A hx₂A x hxB hx, _⟩,
   obtain ⟨l, rfl⟩ := hAB ⟨x, hxB⟩,
@@ -178,7 +179,7 @@ begin
     exact hxB.2 y hy }
 end
 
-protected lemma is_convex (hAB : is_exposed A B) (hA : convex ℝ A) :
+protected lemma convex [normed_space ℝ E] (hAB : is_exposed ℝ A B) (hA : convex ℝ A) :
   convex ℝ B :=
 begin
   obtain rfl | hB := B.eq_empty_or_nonempty,
@@ -189,32 +190,44 @@ begin
     ⟨mem_univ _, hx₁.2 y hy⟩ ⟨mem_univ _, hx₂.2 y hy⟩ ha hb hab).2⟩,
 end
 
-lemma is_closed (hAB : is_exposed A B) (hA : is_closed A) :
+lemma is_closed [normed_space ℝ E] (hAB : is_exposed ℝ A B) (hA : is_closed A) :
   is_closed B :=
 begin
   obtain ⟨l, a, rfl⟩ := hAB.eq_inter_halfspace,
   exact hA.is_closed_le continuous_on_const l.continuous.continuous_on,
 end
 
-lemma is_compact (hAB : is_exposed A B) (hA : is_compact A) :
+lemma is_compact [normed_space ℝ E] (hAB : is_exposed ℝ A B) (hA : is_compact A) :
   is_compact B :=
 compact_of_is_closed_subset hA (hAB.is_closed hA.is_closed) hAB.subset
 
 end is_exposed
 
+variables (𝕜)
+
 /-- A point is exposed with respect to `A` iff there exists an hyperplane whose intersection with
 `A` is exactly that point. -/
 def set.exposed_points (A : set E) :
   set E :=
-{x ∈ A | ∃ l : E →L[ℝ] ℝ, ∀ y ∈ A, l y ≤ l x ∧ (l x ≤ l y → y = x)}
+{x ∈ A | ∃ l : E →L[𝕜] 𝕜, ∀ y ∈ A, l y ≤ l x ∧ (l x ≤ l y → y = x)}
+
+variables {𝕜}
 
 lemma exposed_point_def :
-  x ∈ A.exposed_points ↔ x ∈ A ∧ ∃ l : E →L[ℝ] ℝ, ∀ y ∈ A, l y ≤ l x ∧ (l x ≤ l y → y = x) :=
+  x ∈ A.exposed_points 𝕜 ↔ x ∈ A ∧ ∃ l : E →L[𝕜] 𝕜, ∀ y ∈ A, l y ≤ l x ∧ (l x ≤ l y → y = x) :=
 iff.rfl
+
+lemma exposed_points_subset :
+  A.exposed_points 𝕜 ⊆ A :=
+λ x hx, hx.1
+
+@[simp] lemma exposed_points_empty :
+  (∅ : set E).exposed_points 𝕜 = ∅ :=
+subset_empty_iff.1 exposed_points_subset
 
 /-- Exposed points exactly correspond to exposed singletons. -/
 lemma mem_exposed_points_iff_exposed_singleton :
-  x ∈ A.exposed_points ↔ is_exposed A {x} :=
+  x ∈ A.exposed_points 𝕜 ↔ is_exposed 𝕜 A {x} :=
 begin
   use λ ⟨hxA, l, hl⟩ h, ⟨l, eq.symm $ eq_singleton_iff_unique_mem.2 ⟨⟨hxA, λ y hy, (hl y hy).1⟩,
     λ z hz, (hl z hz.1).2 (hz.2 x hxA)⟩⟩,
@@ -224,15 +237,7 @@ begin
   exact ⟨hl.1.1, l, λ y hy, ⟨hl.1.2 y hy, λ hxy, hl.2 y ⟨hy, λ z hz, (hl.1.2 z hz).trans hxy⟩⟩⟩,
 end
 
-lemma exposed_points_subset :
-  A.exposed_points ⊆ A :=
-λ x hx, hx.1
-
-lemma exposed_points_subset_extreme_points :
-  A.exposed_points ⊆ A.extreme_points :=
+lemma exposed_points_subset_extreme_points [normed_space ℝ E] :
+  A.exposed_points ℝ ⊆ A.extreme_points ℝ :=
 λ x hx, mem_extreme_points_iff_extreme_singleton.2
   (mem_exposed_points_iff_exposed_singleton.1 hx).is_extreme
-
-@[simp] lemma exposed_points_empty :
-  (∅ : set E).exposed_points = ∅ :=
-subset_empty_iff.1 exposed_points_subset

--- a/src/analysis/convex/extreme.lean
+++ b/src/analysis/convex/extreme.lean
@@ -17,16 +17,17 @@ This is an analytic notion of "being on the side of". It is weaker than being ex
 
 ## Main declarations
 
-* `is_extreme A B`: States that `B` is an extreme set of `A` (in the literature, `A` is often
+* `is_extreme 𝕜 A B`: States that `B` is an extreme set of `A` (in the literature, `A` is often
   implicit).
-* `set.extreme_points A`: Set of extreme points of `A` (corresponding to extreme singletons).
-* `convex.mem_extreme_points_iff_convex_remove`: A useful equivalent condition to being an extreme
+* `set.extreme_points 𝕜 A`: Set of extreme points of `A` (corresponding to extreme singletons).
+* `convex.mem_extreme_points_iff_convex_diff`: A useful equivalent condition to being an extreme
   point: `x` is an extreme point iff `A \ {x}` is convex.
 
 ## Implementation notes
 
 The exact definition of extremeness has been carefully chosen so as to make as many lemmas
-unconditional. In practice, `A` is often assumed to be a convex set.
+unconditional (in particular, the Krein-Milman theorem doesn't need the set to be convex!).
+In practice, `A` is often assumed to be a convex set.
 
 ## References
 
@@ -34,9 +35,7 @@ See chapter 8 of [Barry Simon, *Convexity*][simon2011]
 
 ## TODO
 
-* define convex independence, intrinsic frontier and prove lemmas related to extreme sets and
-  points.
-* generalise to Locally Convex Topological Vector Spaces™
+Define intrinsic frontier and prove lemmas related to extreme sets and points.
 
 More not-yet-PRed stuff is available on the branch `sperner_again`.
 -/
@@ -44,21 +43,33 @@ More not-yet-PRed stuff is available on the branch `sperner_again`.
 open_locale classical affine
 open set
 
-variables {E : Type*} [add_comm_group E] [module ℝ E] {x : E} {A B C : set E}
+variables (𝕜 : Type*) {E : Type*}
+
+section has_scalar
+variables [ordered_semiring 𝕜] [add_comm_group E] [has_scalar 𝕜 E]
 
 /-- A set `B` is an extreme subset of `A` if `B ⊆ A` and all points of `B` only belong to open
 segments whose ends are in `B`. -/
 def is_extreme (A B : set E) : Prop :=
-B ⊆ A ∧ ∀ x₁ x₂ ∈ A, ∀ x ∈ B, x ∈ open_segment ℝ x₁ x₂ → x₁ ∈ B ∧ x₂ ∈ B
+B ⊆ A ∧ ∀ x₁ x₂ ∈ A, ∀ x ∈ B, x ∈ open_segment 𝕜 x₁ x₂ → x₁ ∈ B ∧ x₂ ∈ B
 
-namespace is_extreme
+/-- A point `x` is an extreme point of a set `A` if `x` belongs to no open segment with ends in
+`A`, except for the obvious `open_segment x x`. -/
+def set.extreme_points (A : set E) : set E :=
+{x ∈ A | ∀ (x₁ x₂ ∈ A), x ∈ open_segment 𝕜 x₁ x₂ → x₁ = x ∧ x₂ = x}
 
-@[refl] lemma refl (A : set E) :
-  is_extreme A A :=
-⟨subset.refl _, λ x₁ x₂ hx₁A hx₂A x hxA hx, ⟨hx₁A, hx₂A⟩⟩
+@[refl] protected lemma is_extreme.refl (A : set E) :
+  is_extreme 𝕜 A A :=
+⟨subset.rfl, λ x₁ x₂ hx₁A hx₂A x hxA hx, ⟨hx₁A, hx₂A⟩⟩
 
-@[trans] lemma trans (hAB : is_extreme A B) (hBC : is_extreme B C) :
-  is_extreme A C :=
+variables {𝕜} {A B C : set E} {x : E}
+
+protected lemma is_extreme.rfl :
+  is_extreme 𝕜 A A :=
+is_extreme.refl 𝕜 A
+
+@[trans] protected lemma is_extreme.trans (hAB : is_extreme 𝕜 A B) (hBC : is_extreme 𝕜 B C) :
+  is_extreme 𝕜 A C :=
 begin
   use subset.trans hBC.1 hAB.1,
   rintro x₁ x₂ hx₁A hx₂A x hxC hx,
@@ -66,22 +77,17 @@ begin
   exact hBC.2 x₁ x₂ hx₁B hx₂B x hxC hx,
 end
 
-lemma antisymm :
-  anti_symmetric (is_extreme : set E → set E → Prop) :=
+protected lemma is_extreme.antisymm :
+  anti_symmetric (is_extreme 𝕜 : set E → set E → Prop) :=
 λ A B hAB hBA, subset.antisymm hBA.1 hAB.1
 
-instance : is_partial_order (set E) is_extreme :=
-{ refl := refl,
-  trans := λ A B C, trans,
-  antisymm := antisymm }
+instance : is_partial_order (set E) (is_extreme 𝕜) :=
+{ refl := is_extreme.refl 𝕜,
+  trans := λ A B C, is_extreme.trans,
+  antisymm := is_extreme.antisymm }
 
-lemma convex_diff (hA : convex ℝ A) (hAB : is_extreme A B) :
-  convex ℝ (A \ B) :=
-convex_iff_open_segment_subset.2 (λ x₁ x₂ ⟨hx₁A, hx₁B⟩ ⟨hx₂A, hx₂B⟩ x hx,
-    ⟨hA.open_segment_subset hx₁A hx₂A hx, λ hxB, hx₁B (hAB.2 x₁ x₂ hx₁A hx₂A x hxB hx).1⟩)
-
-lemma inter (hAB : is_extreme A B) (hAC : is_extreme A C) :
-  is_extreme A (B ∩ C) :=
+lemma is_extreme.inter (hAB : is_extreme 𝕜 A B) (hAC : is_extreme 𝕜 A C) :
+  is_extreme 𝕜 A (B ∩ C) :=
 begin
   use subset.trans (inter_subset_left _ _) hAB.1,
   rintro x₁ x₂ hx₁A hx₂A x ⟨hxB, hxC⟩ hx,
@@ -90,9 +96,13 @@ begin
   exact ⟨⟨hx₁B, hx₁C⟩, hx₂B, hx₂C⟩,
 end
 
-lemma Inter {ι : Type*} [nonempty ι] {F : ι → set E}
-  (hAF : ∀ i : ι, is_extreme A (F i)) :
-  is_extreme A (⋂ i : ι, F i) :=
+protected lemma is_extreme.mono (hAC : is_extreme 𝕜 A C) (hBA : B ⊆ A) (hCB : C ⊆ B) :
+  is_extreme 𝕜 B C :=
+⟨hCB, λ x₁ x₂ hx₁B hx₂B x hxC hx, hAC.2 x₁ x₂ (hBA hx₁B) (hBA hx₂B) x hxC hx⟩
+
+lemma is_extreme_Inter {ι : Type*} [nonempty ι] {F : ι → set E}
+  (hAF : ∀ i : ι, is_extreme 𝕜 A (F i)) :
+  is_extreme 𝕜 A (⋂ i : ι, F i) :=
 begin
   obtain i := classical.arbitrary ι,
   use Inter_subset_of_subset i (hAF i).1,
@@ -102,50 +112,87 @@ begin
   exact ⟨λ i, (h i).1, λ i, (h i).2⟩,
 end
 
-lemma bInter {F : set (set E)} (hF : F.nonempty)
-  (hAF : ∀ B ∈ F, is_extreme A B) :
-  is_extreme A (⋂ B ∈ F, B) :=
+lemma is_extreme_bInter {F : set (set E)} (hF : F.nonempty)
+  (hAF : ∀ B ∈ F, is_extreme 𝕜 A B) :
+  is_extreme 𝕜 A (⋂ B ∈ F, B) :=
 begin
   obtain ⟨B, hB⟩ := hF,
-  use subset.trans (bInter_subset_of_mem hB) (hAF B hB).1,
-  rintro x₁ x₂ hx₁A hx₂A x hxF hx,
-  rw mem_bInter_iff at ⊢ hxF,
-  rw mem_bInter_iff,
+  refine ⟨(bInter_subset_of_mem hB).trans (hAF B hB).1, λ x₁ x₂ hx₁A hx₂A x hxF hx, _⟩,
+  simp_rw mem_bInter_iff at ⊢ hxF,
   have h := λ B hB, (hAF B hB).2 x₁ x₂ hx₁A hx₂A x (hxF B hB) hx,
   exact ⟨λ B hB, (h B hB).1, λ B hB, (h B hB).2⟩,
 end
 
-lemma sInter {F : set (set E)} (hF : F.nonempty)
-  (hAF : ∀ B ∈ F, is_extreme A B) :
-  is_extreme A (⋂₀ F) :=
+lemma is_extreme_sInter {F : set (set E)} (hF : F.nonempty)
+  (hAF : ∀ B ∈ F, is_extreme 𝕜 A B) :
+  is_extreme 𝕜 A (⋂₀ F) :=
 begin
   obtain ⟨B, hB⟩ := hF,
-  use subset.trans (sInter_subset_of_mem hB) (hAF B hB).1,
-  rintro x₁ x₂ hx₁A hx₂A x hxF hx,
+  refine ⟨(sInter_subset_of_mem hB).trans (hAF B hB).1, λ x₁ x₂ hx₁A hx₂A x hxF hx, _⟩,
   simp_rw mem_sInter at ⊢ hxF,
   have h := λ B hB, (hAF B hB).2 x₁ x₂ hx₁A hx₂A x (hxF B hB) hx,
   exact ⟨λ B hB, (h B hB).1, λ B hB, (h B hB).2⟩,
 end
 
-lemma mono (hAC : is_extreme A C) (hBA : B ⊆ A) (hCB : C ⊆ B) :
-  is_extreme B C :=
-⟨hCB, λ x₁ x₂ hx₁B hx₂B x hxC hx, hAC.2 x₁ x₂ (hBA hx₁B) (hBA hx₂B) x hxC hx⟩
-
-end is_extreme
-
-/-- A point `x` is an extreme point of a set `A` if `x` belongs to no open segment with ends in
-`A`, except for the obvious `open_segment x x`. -/
-def set.extreme_points (A : set E) : set E :=
-{x ∈ A | ∀ (x₁ x₂ ∈ A), x ∈ open_segment ℝ x₁ x₂ → x₁ = x ∧ x₂ = x}
-
 lemma extreme_points_def :
-  x ∈ A.extreme_points ↔ x ∈ A ∧ ∀ (x₁ x₂ ∈ A), x ∈ open_segment ℝ x₁ x₂ → x₁ = x ∧ x₂ = x :=
+  x ∈ A.extreme_points 𝕜 ↔ x ∈ A ∧ ∀ (x₁ x₂ ∈ A), x ∈ open_segment 𝕜 x₁ x₂ → x₁ = x ∧ x₂ = x :=
 iff.rfl
+
+/-- x is an extreme point to A iff {x} is an extreme set of A. -/
+lemma mem_extreme_points_iff_extreme_singleton :
+  x ∈ A.extreme_points 𝕜 ↔ is_extreme 𝕜 A {x} :=
+begin
+  refine ⟨_, λ hx, ⟨singleton_subset_iff.1 hx.1, λ x₁ x₂ hx₁ hx₂, hx.2 x₁ x₂ hx₁ hx₂ x rfl⟩⟩,
+  rintro ⟨hxA, hAx⟩,
+  use singleton_subset_iff.2 hxA,
+  rintro x₁ x₂ hx₁A hx₂A y (rfl : y = x),
+  exact hAx x₁ x₂ hx₁A hx₂A,
+end
+
+lemma extreme_points_subset : A.extreme_points 𝕜 ⊆ A := λ x hx, hx.1
+
+@[simp] lemma extreme_points_empty :
+  (∅ : set E).extreme_points 𝕜 = ∅ :=
+subset_empty_iff.1 extreme_points_subset
+
+@[simp] lemma extreme_points_singleton :
+  ({x} : set E).extreme_points 𝕜 = {x} :=
+extreme_points_subset.antisymm $ singleton_subset_iff.2
+  ⟨mem_singleton x, λ x₁ x₂ hx₁ hx₂ _, ⟨hx₁, hx₂⟩⟩
+
+lemma inter_extreme_points_subset_extreme_points_of_subset (hBA : B ⊆ A) :
+  B ∩ A.extreme_points 𝕜 ⊆ B.extreme_points 𝕜 :=
+λ x ⟨hxB, hxA⟩, ⟨hxB, λ x₁ x₂ hx₁ hx₂ hx, hxA.2 x₁ x₂ (hBA hx₁) (hBA hx₂) hx⟩
+
+lemma is_extreme.extreme_points_subset_extreme_points (hAB : is_extreme 𝕜 A B) :
+  B.extreme_points 𝕜 ⊆ A.extreme_points 𝕜 :=
+λ x hx, mem_extreme_points_iff_extreme_singleton.2 (hAB.trans
+  (mem_extreme_points_iff_extreme_singleton.1 hx))
+
+lemma is_extreme.extreme_points_eq (hAB : is_extreme 𝕜 A B) :
+  B.extreme_points 𝕜 = B ∩ A.extreme_points 𝕜 :=
+subset.antisymm (λ x hx, ⟨hx.1, hAB.extreme_points_subset_extreme_points hx⟩)
+  (inter_extreme_points_subset_extreme_points_of_subset hAB.1)
+
+end has_scalar
+
+section ordered_semiring
+variables {𝕜} [ordered_semiring 𝕜] [add_comm_group E] [module 𝕜 E] {A B : set E} {x : E}
+
+lemma is_extreme.convex_diff (hA : convex 𝕜 A) (hAB : is_extreme 𝕜 A B) :
+  convex 𝕜 (A \ B) :=
+convex_iff_open_segment_subset.2 (λ x₁ x₂ ⟨hx₁A, hx₁B⟩ ⟨hx₂A, hx₂B⟩ x hx,
+    ⟨hA.open_segment_subset hx₁A hx₂A hx, λ hxB, hx₁B (hAB.2 x₁ x₂ hx₁A hx₂A x hxB hx).1⟩)
+
+end ordered_semiring
+
+section linear_ordered_field
+variables {𝕜} [linear_ordered_field 𝕜] [add_comm_group E] [module 𝕜 E] {A B : set E} {x : E}
 
 /-- A useful restatement using `segment`: `x` is an extreme point iff the only (closed) segments
 that contain it are those with `x` as one of their endpoints. -/
-lemma mem_extreme_points_iff_forall_segment :
-  x ∈ A.extreme_points ↔ x ∈ A ∧ ∀ (x₁ x₂ ∈ A), x ∈ segment ℝ x₁ x₂ → x₁ = x ∨ x₂ = x :=
+lemma mem_extreme_points_iff_forall_segment [no_zero_smul_divisors 𝕜 E] :
+  x ∈ A.extreme_points 𝕜 ↔ x ∈ A ∧ ∀ (x₁ x₂ ∈ A), x ∈ segment 𝕜 x₁ x₂ → x₁ = x ∨ x₂ = x :=
 begin
   split,
   { rintro ⟨hxA, hAx⟩,
@@ -153,40 +200,17 @@ begin
     rintro x₁ x₂ hx₁ hx₂ hx,
     by_contra,
     push_neg at h,
-    exact h.1 (hAx _ _ hx₁ hx₂ (mem_open_segment_of_ne_left_right ℝ h.1 h.2 hx)).1 },
+    exact h.1 (hAx _ _ hx₁ hx₂ (mem_open_segment_of_ne_left_right 𝕜 h.1 h.2 hx)).1 },
   rintro ⟨hxA, hAx⟩,
   use hxA,
   rintro x₁ x₂ hx₁ hx₂ hx,
-  obtain rfl | rfl := hAx x₁ x₂ hx₁ hx₂ (open_segment_subset_segment ℝ _ _ hx),
+  obtain rfl | rfl := hAx x₁ x₂ hx₁ hx₂ (open_segment_subset_segment 𝕜 _ _ hx),
   { exact ⟨rfl, (left_mem_open_segment_iff.1 hx).symm⟩ },
   exact ⟨right_mem_open_segment_iff.1 hx, rfl⟩,
 end
 
-/-- x is an extreme point to A iff {x} is an extreme set of A. -/
-lemma mem_extreme_points_iff_extreme_singleton :
-  x ∈ A.extreme_points ↔ is_extreme A {x} :=
-begin
-  split,
-  { rintro ⟨hxA, hAx⟩,
-    use singleton_subset_iff.2 hxA,
-    rintro x₁ x₂ hx₁A hx₂A y (rfl : y = x),
-    exact hAx x₁ x₂ hx₁A hx₂A },
-  exact λ hx, ⟨singleton_subset_iff.1 hx.1, λ x₁ x₂ hx₁ hx₂, hx.2 x₁ x₂ hx₁ hx₂ x rfl⟩,
-end
-
-lemma extreme_points_subset : A.extreme_points ⊆ A := λ x hx, hx.1
-
-@[simp] lemma extreme_points_empty :
-  (∅ : set E).extreme_points = ∅ :=
-subset_empty_iff.1 extreme_points_subset
-
-@[simp] lemma extreme_points_singleton :
-  ({x} : set E).extreme_points = {x} :=
-extreme_points_subset.antisymm $ singleton_subset_iff.2
-  ⟨mem_singleton x, λ x₁ x₂ hx₁ hx₂ _, ⟨hx₁, hx₂⟩⟩
-
-lemma convex.mem_extreme_points_iff_convex_remove (hA : convex ℝ A) :
-  x ∈ A.extreme_points ↔ x ∈ A ∧ convex ℝ (A \ {x}) :=
+lemma convex.mem_extreme_points_iff_convex_diff (hA : convex 𝕜 A) :
+  x ∈ A.extreme_points 𝕜 ↔ x ∈ A ∧ convex 𝕜 (A \ {x}) :=
 begin
   use λ hx, ⟨hx.1, (mem_extreme_points_iff_extreme_singleton.1 hx).convex_diff hA⟩,
   rintro ⟨hxA, hAx⟩,
@@ -198,35 +222,19 @@ begin
     ⟨hx₂, λ hx₂, h.2 (mem_singleton_iff.2 hx₂)⟩ hx).2 rfl,
 end
 
-lemma convex.mem_extreme_points_iff_mem_diff_convex_hull_remove (hA : convex ℝ A) :
-  x ∈ A.extreme_points ↔ x ∈ A \ convex_hull ℝ (A \ {x}) :=
-by rw [hA.mem_extreme_points_iff_convex_remove, hA.convex_remove_iff_not_mem_convex_hull_remove,
+lemma convex.mem_extreme_points_iff_mem_diff_convex_hull_diff (hA : convex 𝕜 A) :
+  x ∈ A.extreme_points 𝕜 ↔ x ∈ A \ convex_hull 𝕜 (A \ {x}) :=
+by rw [hA.mem_extreme_points_iff_convex_diff, hA.convex_remove_iff_not_mem_convex_hull_remove,
   mem_diff]
 
-lemma inter_extreme_points_subset_extreme_points_of_subset (hBA : B ⊆ A) :
-  B ∩ A.extreme_points ⊆ B.extreme_points :=
-λ x ⟨hxB, hxA⟩, ⟨hxB, λ x₁ x₂ hx₁ hx₂ hx, hxA.2 x₁ x₂ (hBA hx₁) (hBA hx₂) hx⟩
-
-namespace is_extreme
-
-lemma extreme_points_subset_extreme_points (hAB : is_extreme A B) :
-  B.extreme_points ⊆ A.extreme_points :=
-λ x hx, mem_extreme_points_iff_extreme_singleton.2 (hAB.trans
-  (mem_extreme_points_iff_extreme_singleton.1 hx))
-
-lemma extreme_points_eq (hAB : is_extreme A B) :
-  B.extreme_points = B ∩ A.extreme_points :=
-subset.antisymm (λ x hx, ⟨hx.1, hAB.extreme_points_subset_extreme_points hx⟩)
-  (inter_extreme_points_subset_extreme_points_of_subset hAB.1)
-
-end is_extreme
-
 lemma extreme_points_convex_hull_subset :
-  (convex_hull ℝ A).extreme_points ⊆ A :=
+  (convex_hull 𝕜 A).extreme_points 𝕜 ⊆ A :=
 begin
   rintro x hx,
-  rw (convex_convex_hull ℝ _).mem_extreme_points_iff_convex_remove at hx,
+  rw (convex_convex_hull 𝕜 _).mem_extreme_points_iff_convex_diff at hx,
   by_contra,
-  exact (convex_hull_min (subset_diff.2 ⟨subset_convex_hull ℝ _, disjoint_singleton_right.2 h⟩) hx.2
+  exact (convex_hull_min (subset_diff.2 ⟨subset_convex_hull 𝕜 _, disjoint_singleton_right.2 h⟩) hx.2
     hx.1).2 rfl,
 end
+
+end linear_ordered_field

--- a/src/analysis/convex/independent.lean
+++ b/src/analysis/convex/independent.lean
@@ -42,8 +42,10 @@ independence, convex position
 
 open_locale affine big_operators classical
 open finset function
-variables (𝕜 : Type*) {E : Type*} [ordered_semiring 𝕜] [add_comm_group E] [module 𝕜 E]
-          {ι : Type*} {s t : set E}
+variables (𝕜 : Type*) {E : Type*}
+
+section ordered_semiring
+variables [ordered_semiring 𝕜] [add_comm_group E] [module 𝕜 E] {ι : Type*} {s t : set E}
 
 /-- An indexed family is said to be convex independent if every point only belongs to convex hulls
 of sets containing it. -/
@@ -189,11 +191,18 @@ begin
     exact hs _ hxs (convex_hull_mono (set.subset_diff_singleton ht h) hxt) }
 end
 
+end ordered_semiring
+
 /-! ### Extreme points -/
 
-lemma convex.extreme_points_convex_independent [module ℝ E] (hs : convex ℝ s) :
-  convex_independent ℝ (λ p, p : s.extreme_points → E) :=
+section linear_ordered_field
+variables [linear_ordered_field 𝕜] [add_comm_group E] [module 𝕜 E] {s : set E}
+
+lemma convex.convex_independent_extreme_points (hs : convex 𝕜 s) :
+  convex_independent 𝕜 (λ p, p : s.extreme_points 𝕜 → E) :=
 convex_independent_set_iff_not_mem_convex_hull_diff.2 $ λ x hx h,
   (extreme_points_convex_hull_subset
   (inter_extreme_points_subset_extreme_points_of_subset (convex_hull_min
   ((set.diff_subset _ _).trans extreme_points_subset) hs) ⟨h, hx⟩)).2 (set.mem_singleton _)
+
+end linear_ordered_field


### PR DESCRIPTION
`is_extreme` and `is_exposed` are currently only defined in real vector spaces. This generalizes ℝ to arbitrary `ordered_semiring`s in definitions and abstracts it away to the correct generality in lemmas. It also generalizes the space from `add_comm_group` to `add_comm_monoid`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
