### PR TITLE
[Merged by Bors] - chore(measure_theory/function/simple_func_dense): distance to `approx_on` is antitone

### DIFF
--- a/src/measure_theory/function/simple_func_dense.lean
+++ b/src/measure_theory/function/simple_func_dense.lean
@@ -163,13 +163,18 @@ begin
     (subset_union_right _ _)
 end
 
+lemma edist_approx_on_mono {f : β → α} (hf : measurable f) {s : set α} {y₀ : α} (h₀ : y₀ ∈ s)
+  [separable_space s] (x : β) {m n : ℕ} (h : m ≤ n) :
+  edist (approx_on f hf s y₀ h₀ n x) (f x) ≤ edist (approx_on f hf s y₀ h₀ m x) (f x) :=
+begin
+  dsimp only [approx_on, coe_comp, (∘)],
+  exact edist_nearest_pt_le _ _ ((nearest_pt_ind_le _ _ _).trans h)
+end
+
 lemma edist_approx_on_le {f : β → α} (hf : measurable f) {s : set α} {y₀ : α} (h₀ : y₀ ∈ s)
   [separable_space s] (x : β) (n : ℕ) :
   edist (approx_on f hf s y₀ h₀ n x) (f x) ≤ edist y₀ (f x) :=
-begin
-  dsimp only [approx_on, coe_comp, (∘)],
-  exact edist_nearest_pt_le _ _ (zero_le _)
-end
+edist_approx_on_mono hf h₀ x (zero_le n)
 
 lemma edist_approx_on_y0_le {f : β → α} (hf : measurable f) {s : set α} {y₀ : α} (h₀ : y₀ ∈ s)
   [separable_space s] (x : β) (n : ℕ) :


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
