### PR TITLE
[Merged by Bors] - feat(linear_algebra/matrix/basis): add matrix basis change formula

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -42,7 +42,7 @@ Linear algebra:
     commutative-ring-valued matrices: 'matrix'
     field-valued matrices: 'matrix'
     matrix representation of a linear map: 'linear_map.to_matrix'
-    change of basis: 'basis_to_matrix_mul_linear_map_to_matrix'
+    change of basis: 'basis_to_matrix_mul_linear_map_to_matrix_mul_basis_to_matrix'
     rank of a matrix: ''
     determinant: 'matrix.det'
     invertibility: 'matrix.nonsing_inv'

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -42,7 +42,7 @@ Linear algebra:
     commutative-ring-valued matrices: 'matrix'
     field-valued matrices: 'matrix'
     matrix representation of a linear map: 'linear_map.to_matrix'
-    change of basis: 'basis_to_matrix_mul_linear_map_to_matrix' 'linear_map_to_matrix_mul_basis_to_matrix'
+    change of basis: 'basis_to_matrix_mul_linear_map_to_matrix'
     rank of a matrix: ''
     determinant: 'matrix.det'
     invertibility: 'matrix.nonsing_inv'

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -42,7 +42,7 @@ Linear algebra:
     commutative-ring-valued matrices: 'matrix'
     field-valued matrices: 'matrix'
     matrix representation of a linear map: 'linear_map.to_matrix'
-    change of basis: ''
+    change of basis: 'basis_to_matrix_mul_linear_map_to_matrix' 'linear_map_to_matrix_mul_basis_to_matrix'
     rank of a matrix: ''
     determinant: 'matrix.det'
     invertibility: 'matrix.nonsing_inv'

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -141,7 +141,7 @@ variable [fintype ι]
 (matrix.to_lin b c').injective
   (by rw [to_lin_to_matrix, to_lin_mul b b' c', to_lin_to_matrix, b'.to_lin_to_matrix, comp_id])
 
-@[simp] lemma basis_to_matrix_mul_linear_map_to_matrix_mul_basis_to_matrix
+lemma basis_to_matrix_mul_linear_map_to_matrix_mul_basis_to_matrix
   [decidable_eq ι] [decidable_eq ι'] :
   c.to_matrix c' ⬝ linear_map.to_matrix b' c' f ⬝ b'.to_matrix b = linear_map.to_matrix b c f :=
 by { rw [basis_to_matrix_mul_linear_map_to_matrix, linear_map_to_matrix_mul_basis_to_matrix] }

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -141,6 +141,11 @@ variable [fintype ι]
 (matrix.to_lin b c').injective
   (by rw [to_lin_to_matrix, to_lin_mul b b' c', to_lin_to_matrix, b'.to_lin_to_matrix, comp_id])
 
+@[simp] lemma basis_to_matrix_mul_linear_map_to_matrix_mul_basis_to_matrix
+  [decidable_eq ι] [decidable_eq ι'] :
+  c.to_matrix c' ⬝ linear_map.to_matrix b' c' f ⬝ b'.to_matrix b = linear_map.to_matrix b c f :=
+by { rw [basis_to_matrix_mul_linear_map_to_matrix, linear_map_to_matrix_mul_basis_to_matrix] }
+
 /-- A generalization of `linear_map.to_matrix_id`. -/
 @[simp] lemma linear_map.to_matrix_id_eq_basis_to_matrix [decidable_eq ι] :
   linear_map.to_matrix b b' id = b'.to_matrix b :=

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -144,7 +144,7 @@ variable [fintype ι]
 @[simp] lemma basis_to_matrix_mul_linear_map_to_matrix_mul_basis_to_matrix
   [decidable_eq ι] [decidable_eq ι'] :
   c.to_matrix c' ⬝ linear_map.to_matrix b' c' f ⬝ b'.to_matrix b = linear_map.to_matrix b c f :=
-by { rw [basis_to_matrix_mul_linear_map_to_matrix, linear_map_to_matrix_mul_basis_to_matrix] }
+by rw [basis_to_matrix_mul_linear_map_to_matrix, linear_map_to_matrix_mul_basis_to_matrix]
 
 /-- A generalization of `linear_map.to_matrix_id`. -/
 @[simp] lemma linear_map.to_matrix_id_eq_basis_to_matrix [decidable_eq ι] :


### PR DESCRIPTION
We add `basis_to_matrix_mul_linear_map_to_matrix_mul_basis_to_matrix`, the formula for the change of basis.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
