### PR TITLE
[Merged by Bors] - feat(group_theory/sylow): Sylow's theorems for infinite groups

### DIFF
--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -143,6 +143,9 @@ begin
   exact set.eq_singleton_iff_unique_mem.mpr ⟨H.mpr rfl, λ R h, subtype.ext (sylow.ext (H.mp h))⟩,
 end
 
+instance [hp : fact p.prime] [fintype (sylow p G)] : is_pretransitive G (sylow p G) :=
+⟨sylow.conjugate⟩
+
 variables (p) (G)
 
 /-- A generalization of **Sylow's third theorem**.

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -78,7 +78,8 @@ classical.inhabited_of_nonempty sylow.nonempty
 
 open_locale pointwise
 
-instance sylow.mul_action' {α : Type*} [group α] [mul_distrib_mul_action α G] :
+/-- `subgroup.pointwise_mul_action` preserves Sylow subgroups. -/
+instance sylow.pointwise_mul_action {α : Type*} [group α] [mul_distrib_mul_action α G] :
   mul_action α (sylow p G) :=
 { smul := λ g P, ⟨g • P, P.2.map _, λ Q hQ hS, inv_smul_eq_iff.mp (P.3 (hQ.map _)
     (λ s hs, (congr_arg (∈ g⁻¹ • Q) (inv_smul_smul g s)).mp

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -70,11 +70,11 @@ exists.elim (zorn.zorn_nonempty_partial_order₀ {Q : subgroup G | is_p_group p 
     rwa [subtype.ext_iff, coe_pow] at hk ⊢ },
   λ M hM g hg, ⟨M, ⟨⟨M, hM⟩, rfl⟩, hg⟩⟩) P hP) (λ Q ⟨hQ1, hQ2, hQ3⟩, ⟨⟨Q, hQ1, hQ3⟩, hQ2⟩)
 
-instance sylow_nonempty : nonempty (sylow p G) :=
+instance sylow.nonempty : nonempty (sylow p G) :=
 nonempty_of_exists is_p_group.of_bot.exists_le_sylow
 
-noncomputable instance sylow_inhabited : inhabited (sylow p G) :=
-classical.inhabited_of_nonempty sylow_nonempty
+noncomputable instance sylow.inhabited : inhabited (sylow p G) :=
+classical.inhabited_of_nonempty sylow.nonempty
 
 instance sylow.mul_aut_mul_action : mul_action (mul_aut G) (sylow p G) :=
 { smul := λ ϕ P, ⟨P.1.comap ϕ⁻¹.to_monoid_hom, P.2.comap_injective _ ϕ⁻¹.injective, λ Q hQ hP,
@@ -84,22 +84,22 @@ instance sylow.mul_aut_mul_action : mul_action (mul_aut G) (sylow p G) :=
   one_smul := λ P, sylow.ext (ext (λ g, iff.rfl)),
   mul_smul := λ ϕ ψ P, sylow.ext (P.1.comap_comap ψ⁻¹.to_monoid_hom ϕ⁻¹.to_monoid_hom).symm }
 
-lemma mul_aut_coe_smul_sylow {ϕ : mul_aut G} {P : sylow p G} :
+lemma sylow.coe_mul_aut_smul {ϕ : mul_aut G} {P : sylow p G} :
   ↑(ϕ • P) = P.1.comap ϕ⁻¹.to_monoid_hom := rfl
 
 instance sylow.mul_action : mul_action G (sylow p G) :=
 of_End_hom (to_End_hom.comp mul_aut.conj)
 
-lemma coe_smul_sylow {g : G} {P : sylow p G} :
+lemma sylow.coe_smul {g : G} {P : sylow p G} :
   ↑(g • P) = P.1.comap (mul_aut.conj g)⁻¹.to_monoid_hom := rfl
 
-lemma smul_eq_iff_mem_normalizer {g : G} {P : sylow p G} :
+lemma sylow.smul_eq_iff_mem_normalizer {g : G} {P : sylow p G} :
   g • P = P ↔ g ∈ P.1.normalizer :=
 by rw [eq_comm, sylow.ext_iff, set_like.ext_iff, ←inv_mem_iff, mem_normalizer_iff, inv_inv]; refl
 
 lemma subgroup.sylow_mem_fixed_points_iff (H : subgroup G) {P : sylow p G} :
   P ∈ fixed_points H (sylow p G) ↔ H ≤ P.1.normalizer :=
-by simp_rw [set_like.le_def, ←smul_eq_iff_mem_normalizer]; exact subtype.forall
+by simp_rw [set_like.le_def, ←sylow.smul_eq_iff_mem_normalizer]; exact subtype.forall
 
 lemma is_p_group.inf_normalizer_sylow {P : subgroup G} (hP : is_p_group p P) (Q : sylow p G) :
   P ⊓ Q.1.normalizer = P ⊓ Q :=
@@ -113,7 +113,7 @@ by rw [P.sylow_mem_fixed_points_iff, ←inf_eq_left, hP.inf_normalizer_sylow, in
 
 /-- A generalization of **Sylow's second theorem**.
   If the number of Sylow `p`-subgroups is finite, then all Sylow `p`-subgroups are conjugate. -/
-lemma sylow_conjugate [hp : fact p.prime] [fintype (sylow p G)] (P Q : sylow p G) :
+lemma sylow.conjugate [hp : fact p.prime] [fintype (sylow p G)] (P Q : sylow p G) :
   ∃ g : G, g • P = Q :=
 begin
   classical,
@@ -139,7 +139,7 @@ variables (p) (G)
   If the number of Sylow `p`-subgroups is finite, then it is congruent to `1` modulo `p`. -/
 lemma card_sylow_modeq_one [fact p.prime] [fintype (sylow p G)] : card (sylow p G) ≡ 1 [MOD p] :=
 begin
-  refine sylow_nonempty.elim (λ P : sylow p G, _),
+  refine sylow.nonempty.elim (λ P : sylow p G, _),
   have := set.ext (λ Q : sylow p G, calc Q ∈ fixed_points P (sylow p G)
       ↔ P.1 ≤ Q : P.2.sylow_mem_fixed_points_iff
   ... ↔ Q.1 = P.1 : ⟨P.3 Q.2, ge_of_eq⟩

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -123,10 +123,9 @@ by rw [P.sylow_mem_fixed_points_iff, ←inf_eq_left, hP.inf_normalizer_sylow, in
 
 /-- A generalization of **Sylow's second theorem**.
   If the number of Sylow `p`-subgroups is finite, then all Sylow `p`-subgroups are conjugate. -/
-lemma sylow.conjugate [hp : fact p.prime] [fintype (sylow p G)] (P Q : sylow p G) :
-  ∃ g : G, g • P = Q :=
-begin
-  classical,
+instance [hp : fact p.prime] [fintype (sylow p G)] : is_pretransitive G (sylow p G) :=
+⟨λ P Q, by
+{ classical,
   have H := λ {R : sylow p G} {S : orbit G P},
   calc S ∈ fixed_points R (orbit G P)
       ↔ S.1 ∈ fixed_points R (sylow p G) : forall_congr (λ a, subtype.ext_iff)
@@ -140,11 +139,7 @@ begin
      ... ≡ card (orbit G P) [MOD p] : (P.2.card_modeq_card_fixed_points (orbit G P)).symm
      ... ≡ 0 [MOD p] : nat.modeq_zero_iff_dvd.mpr h,
   convert (set.card_singleton (⟨P, mem_orbit_self P⟩ : orbit G P)).symm,
-  exact set.eq_singleton_iff_unique_mem.mpr ⟨H.mpr rfl, λ R h, subtype.ext (sylow.ext (H.mp h))⟩,
-end
-
-instance [hp : fact p.prime] [fintype (sylow p G)] : is_pretransitive G (sylow p G) :=
-⟨sylow.conjugate⟩
+  exact set.eq_singleton_iff_unique_mem.mpr ⟨H.mpr rfl, λ R h, subtype.ext (sylow.ext (H.mp h))⟩ }⟩
 
 variables (p) (G)
 

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -22,7 +22,7 @@ In this file, currently only the first of these results is proven.
 ## Main statements
 
 * `exists_subgroup_card_pow_prime`: A generalization of Sylow's first theorem:
-  For every prime power `pⁿ` dividing `G`, there exists a subgroup of `G` of order `pⁿ`.
+  For every prime power `pⁿ` dividing the cardinality of `G`, there exists a subgroup of `G` of order `pⁿ`.
 * `is_p_group.exists_le_sylow`: A generalization of Sylow's first theorem:
   Every `p`-subgroup is contained in a Sylow `p`-subgroup.
 * `sylow_conjugate`: A generalization of Sylow's second theorem:

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -17,7 +17,9 @@ The Sylow theorems are the following results for every finite group `G` and ever
   `p`-subgroup, `nₚ ≡ 1 [MOD p]`, and `nₚ` is equal to the index of the normalizer of the Sylow
   `p`-subgroup in `G`.
 
-In this file, currently only the first of these results is proven.
+## Main definitions
+
+* `sylow p G` : The type of Sylow `p`-subgroups of `G`.
 
 ## Main statements
 

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -76,26 +76,30 @@ nonempty_of_exists is_p_group.of_bot.exists_le_sylow
 noncomputable instance sylow.inhabited : inhabited (sylow p G) :=
 classical.inhabited_of_nonempty sylow.nonempty
 
-instance sylow.mul_aut_mul_action : mul_action (mul_aut G) (sylow p G) :=
-{ smul := λ ϕ P, ⟨P.1.comap ϕ⁻¹.to_monoid_hom, P.2.comap_injective _ ϕ⁻¹.injective, λ Q hQ hP,
-    le_antisymm (λ g hg, by { rw ← P.3 (hQ.comap_injective ϕ.to_monoid_hom ϕ.injective)
-      (ge_trans (comap_mono hP) (λ g h, (congr_arg _ (ϕ.inv_apply_self G g)).mpr h)),
-      simpa only [mem_comap, mul_equiv.coe_to_monoid_hom, mul_aut.apply_inv_self] }) hP⟩,
-  one_smul := λ P, sylow.ext (ext (λ g, iff.rfl)),
-  mul_smul := λ ϕ ψ P, sylow.ext (P.1.comap_comap ψ⁻¹.to_monoid_hom ϕ⁻¹.to_monoid_hom).symm }
+open_locale pointwise
 
-lemma sylow.coe_mul_aut_smul {ϕ : mul_aut G} {P : sylow p G} :
-  ↑(ϕ • P) = P.1.comap ϕ⁻¹.to_monoid_hom := rfl
+instance sylow.mul_action' {α : Type*} [group α] [mul_distrib_mul_action α G] :
+  mul_action α (sylow p G) :=
+{ smul := λ g P, ⟨g • P, P.2.map _, λ Q hQ hS, inv_smul_eq_iff.mp (P.3 (hQ.map _)
+    (λ s hs, (congr_arg (∈ g⁻¹ • Q) (inv_smul_smul g s)).mp
+      (smul_mem_pointwise_smul (g • s) g⁻¹ Q (hS (smul_mem_pointwise_smul s g P hs)))))⟩,
+  one_smul := λ P, sylow.ext (one_smul α P),
+  mul_smul := λ g h P, sylow.ext (mul_smul g h P) }
 
 instance sylow.mul_action : mul_action G (sylow p G) :=
 of_End_hom (to_End_hom.comp mul_aut.conj)
 
 lemma sylow.coe_smul {g : G} {P : sylow p G} :
-  ↑(g • P) = P.1.comap (mul_aut.conj g)⁻¹.to_monoid_hom := rfl
+  ↑(g • P) = P.1.map (mul_aut.conj g).to_monoid_hom := rfl
 
 lemma sylow.smul_eq_iff_mem_normalizer {g : G} {P : sylow p G} :
   g • P = P ↔ g ∈ P.1.normalizer :=
-by rw [eq_comm, sylow.ext_iff, set_like.ext_iff, ←inv_mem_iff, mem_normalizer_iff, inv_inv]; refl
+begin
+  rw [eq_comm, sylow.ext_iff, set_like.ext_iff, ←inv_mem_iff, mem_normalizer_iff, inv_inv],
+  exact forall_congr (λ h, iff_congr iff.rfl ⟨λ ⟨a, b, c⟩, (congr_arg _ c).mp
+    ((congr_arg (∈ P.1) (mul_aut.inv_apply_self G (mul_aut.conj g) a)).mpr b),
+    λ hh, ⟨(mul_aut.conj g)⁻¹ h, hh, mul_aut.apply_inv_self G (mul_aut.conj g) h⟩⟩),
+end
 
 lemma subgroup.sylow_mem_fixed_points_iff (H : subgroup G) {P : sylow p G} :
   P ∈ fixed_points H (sylow p G) ↔ H ≤ P.1.normalizer :=

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -92,8 +92,11 @@ instance sylow.pointwise_mul_action {α : Type*} [group α] [mul_distrib_mul_act
 instance sylow.mul_action : mul_action G (sylow p G) :=
 mul_action.comp_hom _ mul_aut.conj
 
+lemma sylow.coe_subgroup_smul {g : G} {P : sylow p G} :
+  ↑(g • P) = mul_aut.conj g • (P : subgroup G) := rfl
+
 lemma sylow.coe_smul {g : G} {P : sylow p G} :
-  ↑(g • P) = P.1.map (mul_aut.conj g).to_monoid_hom := rfl
+  ↑(g • P) = mul_aut.conj g • (P : set G) := rfl
 
 lemma sylow.smul_eq_iff_mem_normalizer {g : G} {P : sylow p G} :
   g • P = P ↔ g ∈ P.1.normalizer :=

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -88,7 +88,7 @@ instance sylow.pointwise_mul_action {α : Type*} [group α] [mul_distrib_mul_act
   mul_smul := λ g h P, sylow.ext (mul_smul g h P) }
 
 instance sylow.mul_action : mul_action G (sylow p G) :=
-of_End_hom (to_End_hom.comp mul_aut.conj)
+mul_action.comp_hom _ mul_aut.conj
 
 lemma sylow.coe_smul {g : G} {P : sylow p G} :
   ↑(g • P) = P.1.map (mul_aut.conj g).to_monoid_hom := rfl

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -49,10 +49,10 @@ variables {p} {G}
 
 instance : has_coe (sylow p G) (subgroup G) := ⟨sylow.to_subgroup⟩
 
-@[ext] lemma sylow.ext {P Q : sylow p G} (h : ↑P = (↑Q : subgroup G)) : P = Q :=
+@[ext] lemma sylow.ext {P Q : sylow p G} (h : (P : subgroup G) = Q) : P = Q :=
 by cases P; cases Q; congr'
 
-lemma sylow.ext_iff {P Q : sylow p G} : P = Q ↔ ↑P = (↑Q : subgroup G) :=
+lemma sylow.ext_iff {P Q : sylow p G} : P = Q ↔ (P : subgroup G) = Q :=
 ⟨congr_arg coe, sylow.ext⟩
 
 /-- A generalization of **Sylow's first theorem**.
@@ -75,8 +75,6 @@ nonempty_of_exists is_p_group.of_bot.exists_le_sylow
 
 noncomputable instance sylow_inhabited : inhabited (sylow p G) :=
 classical.inhabited_of_nonempty sylow_nonempty
-
---subtype.ext (ext (λ g, iff.rfl))
 
 instance sylow.mul_aut_mul_action : mul_action (mul_aut G) (sylow p G) :=
 { smul := λ ϕ P, ⟨P.1.comap ϕ⁻¹.to_monoid_hom, P.2.comap_injective _ ϕ⁻¹.injective, λ Q hQ hP,

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -24,7 +24,8 @@ The Sylow theorems are the following results for every finite group `G` and ever
 ## Main statements
 
 * `exists_subgroup_card_pow_prime`: A generalization of Sylow's first theorem:
-  For every prime power `pⁿ` dividing the cardinality of `G`, there exists a subgroup of `G` of order `pⁿ`.
+  For every prime power `pⁿ` dividing the cardinality of `G`,
+  there exists a subgroup of `G` of order `pⁿ`.
 * `is_p_group.exists_le_sylow`: A generalization of Sylow's first theorem:
   Every `p`-subgroup is contained in a Sylow `p`-subgroup.
 * `sylow_conjugate`: A generalization of Sylow's second theorem:
@@ -40,10 +41,11 @@ section infinite_sylow
 variables (p : ℕ) (G : Type*) [group G]
 
 /-- A Sylow `p`-subgroup is a maximal `p`-subgroup. -/
-def sylow :=
-{P : subgroup G // is_p_group p P ∧ ∀ {Q : subgroup G}, is_p_group p Q → P ≤ Q → Q = P}
+structure sylow extends subgroup G :=
+(is_p_group' : is_p_group p to_subgroup)
+(is_maximal' : ∀ {Q : subgroup G}, is_p_group p Q → to_subgroup ≤ Q → Q = to_subgroup)
 
-instance : has_coe (sylow p G) (subgroup G) := ⟨subtype.val⟩
+instance : has_coe (sylow p G) (subgroup G) := ⟨sylow.to_subgroup⟩
 
 variables {p} {G}
 

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -49,6 +49,8 @@ variables {p} {G}
 
 instance : has_coe (sylow p G) (subgroup G) := ⟨sylow.to_subgroup⟩
 
+@[simp] lemma sylow.to_subgroup_eq_coe {P : sylow p G} : P.to_subgroup = ↑P := rfl
+
 @[ext] lemma sylow.ext {P Q : sylow p G} (h : (P : subgroup G) = Q) : P = Q :=
 by cases P; cases Q; congr'
 


### PR DESCRIPTION
This PR contains all three of Sylow's theorems for infinite groups, building off the work of @ChrisHughes24 in the `ch_sylow2` branch of mathlib.

Later, I'll PR some consequences (e.g., index of normalizer stuff, maybe a golf of the original sylow stuff using the new results, Frattini's argument, ...).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
