### PR TITLE
[Merged by Bors] - chore(analysis/normed_space/finite_dimensional): restructure imports

### DIFF
--- a/src/analysis/normed_space/affine_isometry.lean
+++ b/src/analysis/normed_space/affine_isometry.lean
@@ -538,29 +538,6 @@ end constructions
 
 end affine_isometry_equiv
 
-namespace affine_isometry
-
-open finite_dimensional affine_map
-
-variables [finite_dimensional 𝕜 V₁] [finite_dimensional 𝕜 V₂]
-
-/-- A affine isometry between finite dimensional spaces of equal dimension can be upgraded
-    to an affine isometry equivalence. -/
-noncomputable def to_affine_isometry_equiv [inhabited P₁]
-  (li : P₁ →ᵃⁱ[𝕜] P₂) (h : finrank 𝕜 V₁ = finrank 𝕜 V₂) : P₁ ≃ᵃⁱ[𝕜] P₂ :=
-affine_isometry_equiv.mk' li (li.linear_isometry.to_linear_isometry_equiv h) (arbitrary P₁)
-  (λ p, by simp)
-
-@[simp] lemma coe_to_affine_isometry_equiv [inhabited P₁]
-  (li : P₁ →ᵃⁱ[𝕜] P₂) (h : finrank 𝕜 V₁ = finrank 𝕜 V₂) :
-  (li.to_affine_isometry_equiv h : P₁ → P₂) = li := rfl
-
-@[simp] lemma to_affine_isometry_equiv_apply [inhabited P₁]
-  (li : P₁ →ᵃⁱ[𝕜] P₂) (h : finrank 𝕜 V₁ = finrank 𝕜 V₂) (x : P₁) :
-  (li.to_affine_isometry_equiv h) x = li x := rfl
-
-end affine_isometry
-
 include V V₂
 /-- If `f` is an affine map, then its linear part is continuous iff `f` is continuous. -/
 lemma affine_map.continuous_linear_iff {f : P →ᵃ[𝕜] P₂} :

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -42,6 +42,8 @@ then the identities from `E` to `E'` and from `E'`to `E` are continuous thanks t
 
 universes u v w x
 
+noncomputable theory
+
 open set finite_dimensional topological_space filter asymptotics
 open_locale classical big_operators filter topological_space asymptotics
 
@@ -59,7 +61,7 @@ variables {R₁ : Type*} [field R₁] [module R₁ E₁] [module R₁ F]
 
 /-- A linear isometry between finite dimensional spaces of equal dimension can be upgraded
     to a linear isometry equivalence. -/
-noncomputable def to_linear_isometry_equiv
+def to_linear_isometry_equiv
   (li : E₁ →ₗᵢ[R₁] F) (h : finrank R₁ E₁ = finrank R₁ F) : E₁ ≃ₗᵢ[R₁] F :=
 { to_linear_equiv :=
     li.to_linear_map.linear_equiv_of_injective li.injective h,
@@ -90,7 +92,7 @@ variables [finite_dimensional 𝕜 V₁] [finite_dimensional 𝕜 V₂]
 
 /-- A affine isometry between finite dimensional spaces of equal dimension can be upgraded
     to an affine isometry equivalence. -/
-noncomputable def to_affine_isometry_equiv [inhabited P₁]
+def to_affine_isometry_equiv [inhabited P₁]
   (li : P₁ →ᵃⁱ[𝕜] P₂) (h : finrank 𝕜 V₁ = finrank 𝕜 V₂) : P₁ ≃ᵃⁱ[𝕜] P₂ :=
 affine_isometry_equiv.mk' li (li.linear_isometry.to_linear_isometry_equiv h) (arbitrary P₁)
   (λ p, by simp)
@@ -104,9 +106,6 @@ affine_isometry_equiv.mk' li (li.linear_isometry.to_linear_isometry_equiv h) (ar
   (li.to_affine_isometry_equiv h) x = li x := rfl
 
 end affine_isometry
-
-
-noncomputable theory
 
 /-- A linear map on `ι → 𝕜` (where `ι` is a fintype) is continuous -/
 lemma linear_map.continuous_on_pi {ι : Type w} [fintype ι] {𝕜 : Type u} [normed_field 𝕜]

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -45,6 +45,67 @@ universes u v w x
 open set finite_dimensional topological_space filter asymptotics
 open_locale classical big_operators filter topological_space asymptotics
 
+namespace linear_isometry
+
+open linear_map
+
+variables {R : Type*} [semiring R]
+
+variables {F E₁ : Type*} [semi_normed_group F]
+  [normed_group E₁] [module R E₁]
+
+variables {R₁ : Type*} [field R₁] [module R₁ E₁] [module R₁ F]
+  [finite_dimensional R₁ E₁] [finite_dimensional R₁ F]
+
+/-- A linear isometry between finite dimensional spaces of equal dimension can be upgraded
+    to a linear isometry equivalence. -/
+noncomputable def to_linear_isometry_equiv
+  (li : E₁ →ₗᵢ[R₁] F) (h : finrank R₁ E₁ = finrank R₁ F) : E₁ ≃ₗᵢ[R₁] F :=
+{ to_linear_equiv :=
+    li.to_linear_map.linear_equiv_of_injective li.injective h,
+  norm_map' := li.norm_map' }
+
+@[simp] lemma coe_to_linear_isometry_equiv
+  (li : E₁ →ₗᵢ[R₁] F) (h : finrank R₁ E₁ = finrank R₁ F) :
+  (li.to_linear_isometry_equiv h : E₁ → F) = li := rfl
+
+@[simp] lemma to_linear_isometry_equiv_apply
+  (li : E₁ →ₗᵢ[R₁] F) (h : finrank R₁ E₁ = finrank R₁ F) (x : E₁) :
+  (li.to_linear_isometry_equiv h) x = li x := rfl
+
+end linear_isometry
+
+namespace affine_isometry
+
+open affine_map
+
+variables {𝕜 : Type*} {V₁ V₂  : Type*} {P₁ P₂ : Type*}
+  [normed_field 𝕜]
+  [normed_group V₁] [semi_normed_group V₂]
+  [normed_space 𝕜 V₁] [semi_normed_space 𝕜 V₂]
+  [metric_space P₁] [pseudo_metric_space P₂]
+  [normed_add_torsor V₁ P₁] [semi_normed_add_torsor V₂ P₂]
+
+variables [finite_dimensional 𝕜 V₁] [finite_dimensional 𝕜 V₂]
+
+/-- A affine isometry between finite dimensional spaces of equal dimension can be upgraded
+    to an affine isometry equivalence. -/
+noncomputable def to_affine_isometry_equiv [inhabited P₁]
+  (li : P₁ →ᵃⁱ[𝕜] P₂) (h : finrank 𝕜 V₁ = finrank 𝕜 V₂) : P₁ ≃ᵃⁱ[𝕜] P₂ :=
+affine_isometry_equiv.mk' li (li.linear_isometry.to_linear_isometry_equiv h) (arbitrary P₁)
+  (λ p, by simp)
+
+@[simp] lemma coe_to_affine_isometry_equiv [inhabited P₁]
+  (li : P₁ →ᵃⁱ[𝕜] P₂) (h : finrank 𝕜 V₁ = finrank 𝕜 V₂) :
+  (li.to_affine_isometry_equiv h : P₁ → P₂) = li := rfl
+
+@[simp] lemma to_affine_isometry_equiv_apply [inhabited P₁]
+  (li : P₁ →ᵃⁱ[𝕜] P₂) (h : finrank 𝕜 V₁ = finrank 𝕜 V₂) (x : P₁) :
+  (li.to_affine_isometry_equiv h) x = li x := rfl
+
+end affine_isometry
+
+
 noncomputable theory
 
 /-- A linear map on `ι → 𝕜` (where `ι` is a fintype) is continuous -/

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -90,7 +90,7 @@ variables {𝕜 : Type*} {V₁ V₂  : Type*} {P₁ P₂ : Type*}
 
 variables [finite_dimensional 𝕜 V₁] [finite_dimensional 𝕜 V₂]
 
-/-- A affine isometry between finite dimensional spaces of equal dimension can be upgraded
+/-- An affine isometry between finite dimensional spaces of equal dimension can be upgraded
     to an affine isometry equivalence. -/
 def to_affine_isometry_equiv [inhabited P₁]
   (li : P₁ →ᵃⁱ[𝕜] P₂) (h : finrank 𝕜 V₁ = finrank 𝕜 V₂) : P₁ ≃ᵃⁱ[𝕜] P₂ :=

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import analysis.normed_space.basic
--- import linear_algebra.finite_dimensional
 
 /-!
 # Linear isometries

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import analysis.normed_space.basic
-import linear_algebra.finite_dimensional
+-- import linear_algebra.finite_dimensional
 
 /-!
 # Linear isometries
@@ -356,28 +356,3 @@ variables {R}
 @[simp] lemma symm_neg : (neg R : E ≃ₗᵢ[R] E).symm = neg R := rfl
 
 end linear_isometry_equiv
-
-namespace linear_isometry
-
-open finite_dimensional linear_map
-
-variables {R₁ : Type*} [field R₁] [module R₁ E₁] [module R₁ F]
-  [finite_dimensional R₁ E₁] [finite_dimensional R₁ F]
-
-/-- A linear isometry between finite dimensional spaces of equal dimension can be upgraded
-    to a linear isometry equivalence. -/
-noncomputable def to_linear_isometry_equiv
-  (li : E₁ →ₗᵢ[R₁] F) (h : finrank R₁ E₁ = finrank R₁ F) : E₁ ≃ₗᵢ[R₁] F :=
-{ to_linear_equiv :=
-    li.to_linear_map.linear_equiv_of_injective li.injective h,
-  norm_map' := li.norm_map' }
-
-@[simp] lemma coe_to_linear_isometry_equiv
-  (li : E₁ →ₗᵢ[R₁] F) (h : finrank R₁ E₁ = finrank R₁ F) :
-  (li.to_linear_isometry_equiv h : E₁ → F) = li := rfl
-
-@[simp] lemma to_linear_isometry_equiv_apply
-  (li : E₁ →ₗᵢ[R₁] F) (h : finrank R₁ E₁ = finrank R₁ F) (x : E₁) :
-  (li.to_linear_isometry_equiv h) x = li x := rfl
-
-end linear_isometry


### PR DESCRIPTION
Delays importing `linear_algebra.finite_dimensional` in the `analysis/normed_space/` directory until it is really needed.

This reduces the ["long pole"](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/The.20long.20pole.20in.20mathlib) of mathlib compilation by 3 minutes (out of 55).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
