### PR TITLE
[Merged by Bors] - fix(data/dfinsupp): fix nat- and int- module diamonds

### DIFF
--- a/src/data/finsupp/to_dfinsupp.lean
+++ b/src/data/finsupp/to_dfinsupp.lean
@@ -123,7 +123,7 @@ namespace finsupp
 
 @[simp] lemma to_dfinsupp_sub [add_group M] (f g : ι →₀ M) :
   (f - g).to_dfinsupp = f.to_dfinsupp - g.to_dfinsupp :=
-dfinsupp.coe_fn_injective (sub_eq_add_neg _ _)
+dfinsupp.coe_fn_injective rfl
 
 @[simp] lemma to_dfinsupp_smul [monoid R] [add_monoid M] [distrib_mul_action R M]
   (r : R) (f : ι →₀ M) : (r • f).to_dfinsupp = r • f.to_dfinsupp :=


### PR DESCRIPTION
This also defines `has_sub` separately in case it turns out to help with unification



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
