### PR TITLE
[Merged by Bors] - chore(order/lattice): tidy up pi instances

### DIFF
--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -135,7 +135,7 @@ rfl
 /-- The supremum of two graphs `x ⊔ y` has edges where either `x` or `y` have edges. -/
 instance : has_sup (simple_graph V) := ⟨λ x y,
   { adj := x.adj ⊔ y.adj,
-    symm := λ v w h, by rwa [sup_apply, sup_apply, x.adj_comm, y.adj_comm] }⟩
+    symm := λ v w h, by rwa [pi.sup_apply, pi.sup_apply, x.adj_comm, y.adj_comm] }⟩
 
 @[simp] lemma sup_adj (x y : simple_graph V) (v w : V) : (x ⊔ y).adj v w ↔ x.adj v w ∨ y.adj v w :=
 iff.rfl
@@ -143,7 +143,7 @@ iff.rfl
 /-- The infinum of two graphs `x ⊓ y` has edges where both `x` and `y` have edges. -/
 instance : has_inf (simple_graph V) := ⟨λ x y,
   { adj := x.adj ⊓ y.adj,
-    symm := λ v w h, by rwa [inf_apply, inf_apply, x.adj_comm, y.adj_comm] }⟩
+    symm := λ v w h, by rwa [pi.inf_apply, pi.inf_apply, x.adj_comm, y.adj_comm] }⟩
 
 @[simp] lemma inf_adj (x y : simple_graph V) (v w : V) : (x ⊓ y).adj v w ↔ x.adj v w ∧ y.adj v w :=
 iff.rfl

--- a/src/combinatorics/simple_graph/subgraph.lean
+++ b/src/combinatorics/simple_graph/subgraph.lean
@@ -184,7 +184,7 @@ def union (x y : subgraph G) : subgraph G :=
   adj := x.adj ⊔ y.adj,
   adj_sub := λ v w h, or.cases_on h (λ h, x.adj_sub h) (λ h, y.adj_sub h),
   edge_vert := λ v w h, or.cases_on h (λ h, or.inl (x.edge_vert h)) (λ h, or.inr (y.edge_vert h)),
-  symm := λ v w h, by rwa [sup_apply, sup_apply, x.adj_comm, y.adj_comm] }
+  symm := λ v w h, by rwa [pi.sup_apply, pi.sup_apply, x.adj_comm, y.adj_comm] }
 
 /-- The intersection of two subgraphs. -/
 def inter (x y : subgraph G) : subgraph G :=
@@ -192,7 +192,7 @@ def inter (x y : subgraph G) : subgraph G :=
   adj := x.adj ⊓ y.adj,
   adj_sub := λ v w h, x.adj_sub h.1,
   edge_vert := λ v w h, ⟨x.edge_vert h.1, y.edge_vert h.2⟩,
-  symm := λ v w h, by rwa [inf_apply, inf_apply, x.adj_comm, y.adj_comm] }
+  symm := λ v w h, by rwa [pi.inf_apply, pi.inf_apply, x.adj_comm, y.adj_comm] }
 
 /-- The `top` subgraph is `G` as a subgraph of itself. -/
 def top : subgraph G :=

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -369,77 +369,43 @@ instance pi.order_bot {α : Type*} {β : α → Type*} [∀ a, order_bot $ β a]
 
 /-! ### Function lattices -/
 
-instance pi.has_sup {ι : Type*} {α : ι → Type*} [Π i, has_sup (α i)] : has_sup (Π i, α i) :=
-⟨λ f g i, f i ⊔ g i⟩
+namespace pi
+variables {ι : Type*} {α' : ι → Type*}
 
-@[simp] lemma sup_apply {ι : Type*} {α : ι → Type*} [Π i, has_sup (α i)] (f g : Π i, α i) (i : ι) :
-  (f ⊔ g) i = f i ⊔ g i :=
-rfl
+instance [Π i, has_bot (α' i)] : has_bot (Π i, α' i) := ⟨λ i, ⊥⟩
 
-instance pi.has_inf {ι : Type*} {α : ι → Type*} [Π i, has_inf (α i)] : has_inf (Π i, α i) :=
-⟨λ f g i, f i ⊓ g i⟩
+@[simp] lemma bot_apply [Π i, has_bot (α' i)] (i : ι) : (⊥ : Π i, α' i) i = ⊥ := rfl
 
-@[simp] lemma inf_apply {ι : Type*} {α : ι → Type*} [Π i, has_inf (α i)] (f g : Π i, α i) (i : ι) :
-  (f ⊓ g) i = f i ⊓ g i :=
-rfl
+lemma bot_def [Π i, has_bot (α' i)] : (⊥ : Π i, α' i) = λ i, ⊥ := rfl
 
-instance pi.has_bot {ι : Type*} {α : ι → Type*} [Π i, has_bot (α i)] : has_bot (Π i, α i) :=
-⟨λ i, ⊥⟩
+instance [Π i, has_top (α' i)] : has_top (Π i, α' i) := ⟨λ i, ⊤⟩
 
-@[simp] lemma bot_apply {ι : Type*} {α : ι → Type*} [Π i, has_bot (α i)] (i : ι) :
-  (⊥ : Π i, α i) i = ⊥ :=
-rfl
+@[simp] lemma top_apply [Π i, has_top (α' i)] (i : ι) : (⊤ : Π i, α' i) i = ⊤ := rfl
 
-instance pi.has_top {ι : Type*} {α : ι → Type*} [Π i, has_top (α i)] : has_top (Π i, α i) :=
-⟨λ i, ⊤⟩
+lemma top_def [Π i, has_top (α' i)] : (⊤ : Π i, α' i) = λ i, ⊤ := rfl
 
-@[simp] lemma top_apply {ι : Type*} {α : ι → Type*} [Π i, has_top (α i)] (i : ι) :
-  (⊤ : Π i, α i) i = ⊤ :=
-rfl
-
-instance pi.semilattice_sup {ι : Type*} {α : ι → Type*} [Π i, semilattice_sup (α i)] :
-  semilattice_sup (Π i, α i) :=
-by refine_struct { sup := (⊔), .. pi.partial_order }; tactic.pi_instance_derive_field
-
-instance pi.semilattice_inf {ι : Type*} {α : ι → Type*} [Π i, semilattice_inf (α i)] :
-  semilattice_inf (Π i, α i) :=
-by refine_struct { inf := (⊓), .. pi.partial_order }; tactic.pi_instance_derive_field
-
-instance pi.semilattice_inf_bot {ι : Type*} {α : ι → Type*} [Π i, semilattice_inf_bot (α i)] :
-  semilattice_inf_bot (Π i, α i) :=
+instance [Π i, semilattice_inf_bot (α' i)] : semilattice_inf_bot (Π i, α' i) :=
 by refine_struct { inf := (⊓), bot := ⊥, .. pi.partial_order }; tactic.pi_instance_derive_field
 
-instance pi.semilattice_inf_top {ι : Type*} {α : ι → Type*} [Π i, semilattice_inf_top (α i)] :
-  semilattice_inf_top (Π i, α i) :=
+instance [Π i, semilattice_inf_top (α' i)] : semilattice_inf_top (Π i, α' i) :=
 by refine_struct { inf := (⊓), top := ⊤, .. pi.partial_order }; tactic.pi_instance_derive_field
 
-instance pi.semilattice_sup_bot {ι : Type*} {α : ι → Type*} [Π i, semilattice_sup_bot (α i)] :
-  semilattice_sup_bot (Π i, α i) :=
+instance [Π i, semilattice_sup_bot (α' i)] : semilattice_sup_bot (Π i, α' i) :=
 by refine_struct { sup := (⊔), bot := ⊥, .. pi.partial_order }; tactic.pi_instance_derive_field
 
-instance pi.semilattice_sup_top {ι : Type*} {α : ι → Type*} [Π i, semilattice_sup_top (α i)] :
-  semilattice_sup_top (Π i, α i) :=
+instance [Π i, semilattice_sup_top (α' i)] : semilattice_sup_top (Π i, α' i) :=
 by refine_struct { sup := (⊔), top := ⊤, .. pi.partial_order }; tactic.pi_instance_derive_field
 
-instance pi.lattice {ι : Type*} {α : ι → Type*} [Π i, lattice (α i)] : lattice (Π i, α i) :=
-{ .. pi.semilattice_sup, .. pi.semilattice_inf }
-
-instance pi.distrib_lattice {ι : Type*} {α : ι → Type*} [Π i, distrib_lattice (α i)] :
-  distrib_lattice (Π i, α i) :=
-by refine_struct { .. pi.lattice }; tactic.pi_instance_derive_field
-
-instance pi.bounded_lattice {ι : Type*} {α : ι → Type*} [Π i, bounded_lattice (α i)] :
-  bounded_lattice (Π i, α i) :=
+instance [Π i, bounded_lattice (α' i)] : bounded_lattice (Π i, α' i) :=
 { .. pi.semilattice_sup_top, .. pi.semilattice_inf_bot }
 
-instance pi.distrib_lattice_bot {ι : Type*} {α : ι → Type*} [Π i, distrib_lattice_bot (α i)] :
-  distrib_lattice_bot (Π i, α i) :=
+instance [Π i, distrib_lattice_bot (α' i)] : distrib_lattice_bot (Π i, α' i) :=
 { .. pi.distrib_lattice, .. pi.order_bot }
 
-instance pi.bounded_distrib_lattice {ι : Type*} {α : ι → Type*}
-  [Π i, bounded_distrib_lattice (α i)] :
-  bounded_distrib_lattice (Π i, α i) :=
+instance [Π i, bounded_distrib_lattice (α' i)] : bounded_distrib_lattice (Π i, α' i) :=
 { .. pi.bounded_lattice, .. pi.distrib_lattice }
+
+end pi
 
 lemma eq_bot_of_bot_eq_top {α : Type*} [bounded_lattice α] (hα : (⊥ : α) = ⊤) (x : α) :
   x = (⊥ : α) :=

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -68,9 +68,9 @@ instance pi.complete_distrib_lattice {ι : Type*} {π : ι → Type*}
   [∀ i, complete_distrib_lattice (π i)] : complete_distrib_lattice (Π i, π i) :=
 { infi_sup_le_sup_Inf := λ a s i,
     by simp only [← sup_infi_eq, complete_lattice.Inf, Inf_apply, ←infi_subtype'', infi_apply,
-      sup_apply],
+      pi.sup_apply],
   inf_Sup_le_supr_inf := λ a s i,
-    by simp only [complete_lattice.Sup, Sup_apply, supr_apply, inf_apply, inf_supr_eq,
+    by simp only [complete_lattice.Sup, Sup_apply, supr_apply, pi.inf_apply, inf_supr_eq,
       ← supr_subtype''],
   .. pi.complete_lattice }
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -642,7 +642,6 @@ instance distrib_lattice_of_linear_order {α : Type u} [o : linear_order α] :
 instance nat.distrib_lattice : distrib_lattice ℕ :=
 by apply_instance
 
-
 /-! ### Function lattices -/
 
 namespace pi

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 import order.rel_classes
 import tactic.simps
+import tactic.pi_instances
 
 /-!
 # (Semi-)lattices
@@ -641,6 +642,40 @@ instance distrib_lattice_of_linear_order {α : Type u} [o : linear_order α] :
 instance nat.distrib_lattice : distrib_lattice ℕ :=
 by apply_instance
 
+
+/-! ### Function lattices -/
+
+namespace pi
+variables {ι : Type*} {α' : ι → Type*}
+
+instance [Π i, has_sup (α' i)] : has_sup (Π i, α' i) := ⟨λ f g i, f i ⊔ g i⟩
+
+@[simp] lemma sup_apply [Π i, has_sup (α' i)] (f g : Π i, α' i) (i : ι) : (f ⊔ g) i = f i ⊔ g i :=
+rfl
+
+lemma sup_def [Π i, has_sup (α' i)] (f g : Π i, α' i) : f ⊔ g = λ i, f i ⊔ g i := rfl
+
+instance [Π i, has_inf (α' i)] : has_inf (Π i, α' i) := ⟨λ f g i, f i ⊓ g i⟩
+
+@[simp] lemma inf_apply [Π i, has_inf (α' i)] (f g : Π i, α' i) (i : ι) : (f ⊓ g) i = f i ⊓ g i :=
+rfl
+
+lemma inf_def [Π i, has_inf (α' i)] (f g : Π i, α' i) : f ⊓ g = λ i, f i ⊓ g i := rfl
+
+instance [Π i, semilattice_sup (α' i)] : semilattice_sup (Π i, α' i) :=
+by refine_struct { sup := (⊔), .. pi.partial_order }; tactic.pi_instance_derive_field
+
+instance [Π i, semilattice_inf (α' i)] : semilattice_inf (Π i, α' i) :=
+by refine_struct { inf := (⊓), .. pi.partial_order }; tactic.pi_instance_derive_field
+
+instance [Π i, lattice (α' i)] : lattice (Π i, α' i) :=
+{ .. pi.semilattice_sup, .. pi.semilattice_inf }
+
+instance [Π i, distrib_lattice (α' i)] : distrib_lattice (Π i, α' i) :=
+by refine_struct { .. pi.lattice }; tactic.pi_instance_derive_field
+
+end pi
+
 /-!
 ### Monotone functions and lattices
 -/
@@ -648,12 +683,12 @@ namespace monotone
 
 /-- Pointwise supremum of two monotone functions is a monotone function. -/
 protected lemma sup [preorder α] [semilattice_sup β] {f g : α → β} (hf : monotone f)
-  (hg : monotone g) : monotone (λ x, f x ⊔ g x) :=
+  (hg : monotone g) : monotone (f ⊔ g) :=
 λ x y h, sup_le_sup (hf h) (hg h)
 
 /-- Pointwise infimum of two monotone functions is a monotone function. -/
 protected lemma inf [preorder α] [semilattice_inf β] {f g : α → β} (hf : monotone f)
-  (hg : monotone g) : monotone (λ x, f x ⊓ g x) :=
+  (hg : monotone g) : monotone (f ⊓ g) :=
 λ x y h, inf_le_inf (hf h) (hg h)
 
 /-- Pointwise maximum of two monotone functions is a monotone function. -/


### PR DESCRIPTION
These were previously defined in the wrong file, and the lemmas were missing the `pi` prefix that is present on `pi.add_apply` etc.

This also removes the instance names as they are autogenerated correctly.

Finally, this adds new `top_def`, `bot_def`, `sup_def`, and `inf_def` lemmas, which are useful for when wanting to rewrite under the lambda. We already have `zero_def`, `add_def`, etc.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
