### PR TITLE
[Merged by Bors] - feat(tactic/lint/misc): unused haves and suffices linters

### DIFF
--- a/src/control/traversable/instances.lean
+++ b/src/control/traversable/instances.lean
@@ -109,12 +109,7 @@ lemma mem_traverse {f : α' → set β'} :
 | []      []      := by simp
 | (a::as) []      := by simp; exact assume h, match h with end
 | []      (b::bs) := by simp
-| (a::as) (b::bs) :=
-  suffices (b :: bs : list β') ∈ traverse f (a :: as) ↔ b ∈ f a ∧ bs ∈ traverse f as,
-    by simp [mem_traverse as bs],
-  iff.intro
-    (assume ⟨_, ⟨b, hb, rfl⟩, _, hl, rfl⟩, ⟨hb, hl⟩)
-    (assume ⟨hb, hl⟩, ⟨_, ⟨b, hb, rfl⟩, _, hl, rfl⟩)
+| (a::as) (b::bs) := by simp [mem_traverse as bs]
 
 end traverse
 

--- a/src/control/traversable/instances.lean
+++ b/src/control/traversable/instances.lean
@@ -107,7 +107,7 @@ variables [is_lawful_applicative F]
 lemma mem_traverse {f : α' → set β'} :
   ∀(l : list α') (n : list β'), n ∈ traverse f l ↔ forall₂ (λb a, b ∈ f a) n l
 | []      []      := by simp
-| (a::as) []      := by simp; exact assume h, match h with end
+| (a::as) []      := by simp
 | []      (b::bs) := by simp
 | (a::as) (b::bs) := by simp [mem_traverse as bs]
 

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -350,7 +350,6 @@ See `cSup_eq_of_forall_le_of_forall_lt_exists_gt` for a version in conditionally
 lattices. -/
 theorem Sup_eq_of_forall_le_of_forall_lt_exists_gt (_ : ∀a∈s, a ≤ b)
   (H : ∀w, w < b → (∃a∈s, w < a)) : Sup s = b :=
-have bdd_above s := ⟨b, by assumption⟩,
 have (Sup s < b) ∨ (Sup s = b) := lt_or_eq_of_le (Sup_le ‹∀a∈s, a ≤ b›),
 have ¬(Sup s < b) :=
   assume: Sup s < b,

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -300,6 +300,7 @@ is larger than all elements of `s`, and that this is not the case of any `w<b`.
 See `Sup_eq_of_forall_le_of_forall_lt_exists_gt` for a version in complete lattices. -/
 theorem cSup_eq_of_forall_le_of_forall_lt_exists_gt (_ : s.nonempty)
   (_ : ∀a∈s, a ≤ b) (H : ∀w, w < b → (∃a∈s, w < a)) : Sup s = b :=
+have bdd_above s := ⟨b, by assumption⟩,
 have (Sup s < b) ∨ (Sup s = b) := lt_or_eq_of_le (cSup_le ‹_› ‹∀a∈s, a ≤ b›),
 have ¬(Sup s < b) :=
   assume: Sup s < b,

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -300,7 +300,6 @@ is larger than all elements of `s`, and that this is not the case of any `w<b`.
 See `Sup_eq_of_forall_le_of_forall_lt_exists_gt` for a version in complete lattices. -/
 theorem cSup_eq_of_forall_le_of_forall_lt_exists_gt (_ : s.nonempty)
   (_ : ∀a∈s, a ≤ b) (H : ∀w, w < b → (∃a∈s, w < a)) : Sup s = b :=
-have bdd_above s := ⟨b, by assumption⟩,
 have (Sup s < b) ∨ (Sup s = b) := lt_or_eq_of_le (cSup_le ‹_› ‹∀a∈s, a ≤ b›),
 have ¬(Sup s < b) :=
   assume: Sup s < b,

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -372,9 +372,9 @@ meta def find_unused_have_macro : expr → tactic (list string)
 | (elet var_name type assignment body) := (++) <$> find_unused_have_macro type
                                           <*> ((++) <$> find_unused_have_macro assignment
                                                <*> find_unused_have_macro body)
-| (macro md [lam ppnm bi vt bd]) := do -- term mode have statements are tagged with a macro
+| m@(macro md [lam ppnm bi vt bd]) := do -- term mode have statements are tagged with a macro
   -- if the macro annotation is `have then this lambda came from a term mode have statement
-  if Π h : (macro md [lam ppnm bi vt bd]).is_annotation.is_some, (option.get h).fst = `have then
+  if m.is_annotation.iget.fst = `have then
     (++) (if bd.has_zero_var then [] else
       ["unnecessary have " ++ ppnm.to_string ++ " : " ++ vt.to_string]) <$>
     find_unused_have_macro (lam ppnm bi vt bd)

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -18,6 +18,7 @@ This file defines several small linters:
   - `check_type` checks that the statement of a declaration is well-typed.
   - `check_univs` checks that there are no bad `max u v` universe levels.
   - `syn_taut` checks that declarations are not syntactic tautologies.
+  - `` checks that declarations produced via term mode do not have ineffectual `have` or `suffices`
 -/
 
 open tactic expr
@@ -363,35 +364,43 @@ attribute [nolint syn_taut] rfl
 meta def expr.has_zero_var (e : expr) : bool :=
 e.fold ff $ λ e' d res, res || match e' with | var k := k = d | _ := ff end
 
-meta def find_unused_have_macro : expr → tactic (list string)
-| (app a b) := (++) <$> find_unused_have_macro a <*> find_unused_have_macro b
-| (lam var_name bi var_type body) := (++) <$> find_unused_have_macro var_type
-                                     <*> find_unused_have_macro body
-| (pi var_name bi var_type body) := (++) <$> find_unused_have_macro var_type
-                                    <*> find_unused_have_macro body
-| (elet var_name type assignment body) := (++) <$> find_unused_have_macro type
-                                          <*> ((++) <$> find_unused_have_macro assignment
-                                               <*> find_unused_have_macro body)
+meta def find_unused_have_suffices_macros : expr → tactic (list string)
+| (app a b) := (++) <$> find_unused_have_suffices_macros a <*> find_unused_have_suffices_macros b
+| (lam var_name bi var_type body) := (++) <$> find_unused_have_suffices_macros var_type
+                                     <*> find_unused_have_suffices_macros body
+| (pi var_name bi var_type body) := (++) <$> find_unused_have_suffices_macros var_type
+                                    <*> find_unused_have_suffices_macros body
+| (elet var_name type assignment body) := (++) <$> find_unused_have_suffices_macros type
+                                          <*> ((++) <$> find_unused_have_suffices_macros assignment
+                                               <*> find_unused_have_suffices_macros body)
 | m@(macro md [lam ppnm bi vt bd]) := do -- term mode have statements are tagged with a macro
   -- if the macro annotation is `have then this lambda came from a term mode have statement
   if m.is_annotation.iget.fst = `have then
     (++) (if bd.has_zero_var then [] else
       ["unnecessary have " ++ ppnm.to_string ++ " : " ++ vt.to_string]) <$>
-    find_unused_have_macro (lam ppnm bi vt bd)
-  else find_unused_have_macro (lam ppnm bi vt bd)
-| (macro md l) := do ls ← l.mmap find_unused_have_macro, return ls.join
+    find_unused_have_suffices_macros (lam ppnm bi vt bd)
+  else find_unused_have_suffices_macros (lam ppnm bi vt bd)
+| m@(macro md [app (lam ppnm bi vt bd) arg]) := do
+  -- term mode suffices statements are tagged with a macro
+  -- if the macro annotation is `suffices then this lambda came from a term mode suffices statement
+  if m.is_annotation.iget.fst = `suffices then
+       (++) (if bd.has_zero_var then [] else
+        ["unnecessary suffices " ++ ppnm.to_string ++ " : " ++ vt.to_string]) <$>
+       find_unused_have_suffices_macros (lam ppnm bi vt bd)
+  else find_unused_have_suffices_macros (lam ppnm bi vt bd)
+| (macro md l) := do ls ← l.mmap find_unused_have_suffices_macros, return ls.join
 | _ := return []
 
 meta def unused_have_of_decl : declaration → tactic (list string)
-| (declaration.defn _ _ _ bd _ _) := find_unused_have_macro bd
-| (declaration.thm _ _ _ bd) := find_unused_have_macro bd.get
+| (declaration.defn _ _ _ bd _ _) := find_unused_have_suffices_macros bd
+| (declaration.thm _ _ _ bd) := find_unused_have_suffices_macros bd.get
 | _ := return []
 
 /--
 Checks whether a declaration contains term mode have statements that have no effect on the resulting
 term.
 -/
-meta def has_unused_haves (d : declaration) : tactic (option string) := do
+meta def has_unused_haves_suffices (d : declaration) : tactic (option string) := do
   ns ← unused_have_of_decl d,
   if ns.length = 0 then
     return none
@@ -402,65 +411,17 @@ meta def has_unused_haves (d : declaration) : tactic (option string) := do
 tag this as `@[linter]` so that it is not in the default linter set as it is slow and an uncommon
 problem. -/
 @[linter] -- TODO remove
-meta def linter.unused_haves : linter :=
-{ test := has_unused_haves,
+meta def linter.unused_haves_suffices : linter :=
+{ test := has_unused_haves_suffices,
   auto_decls := ff,
   no_errors_found := "No declarations have unused term mode have statements.",
-  errors_found := "THE FOLLOWING DECLARATIONS HAVE INEFFECTUAL TERM MODE HAVE STATEMENTS. " ++
-"This is a term of the form `have h := foo, bar` where `bar` does not refer to `foo`. " ++
-"Such statements have no effect on the generated proof, and can just be replaced by `bar`, " ++
-"in addition to being ineffectual, they may make unnecessary assumptions in proofs appear as if " ++
-"they are used. ",
-  is_fast := ff }
-
-
-meta def find_unused_suffices_macro : expr → tactic (list string)
-| (app a b) := (++) <$> find_unused_suffices_macro a <*> find_unused_suffices_macro b
-| (lam var_name bi var_type body) := (++) <$> find_unused_suffices_macro var_type
-                                     <*> find_unused_suffices_macro body
-| (pi var_name bi var_type body) := (++) <$> find_unused_suffices_macro var_type
-                                    <*> find_unused_suffices_macro body
-| (elet var_name type assignment body) := (++) <$> find_unused_suffices_macro type
-                                          <*> ((++) <$> find_unused_suffices_macro assignment
-                                               <*> find_unused_suffices_macro body)
-| (macro md [app (lam ppnm bi vt bd) arg]) := do
-  -- term mode suffices statements are tagged with a macro
-  -- if the macro annotation is `suffices then this lambda came from a term mode suffices statement
-  if Π h : (macro md [lam ppnm bi vt bd]).is_annotation.is_some, (option.get h).fst = `suffices then
-       (++) (if bd.has_zero_var then [] else
-        ["unnecessary suffices " ++ ppnm.to_string ++ " : " ++ vt.to_string]) <$>
-       find_unused_suffices_macro (lam ppnm bi vt bd)
-  else find_unused_suffices_macro (lam ppnm bi vt bd)
-| (macro md l) := do ls ← l.mmap find_unused_suffices_macro, return ls.join
-| _ := return []
-
-meta def unused_suffices_of_decl : declaration → tactic (list string)
-| (declaration.defn _ _ _ bd _ _) := find_unused_suffices_macro bd
-| (declaration.thm _ _ _ bd) := find_unused_suffices_macro bd.get
-| _ := return []
-
-/--
-Checks whether a declaration contains term mode suffices statements that have no effect on the
-resulting term.
--/
-meta def has_unused_suffices (d : declaration) : tactic (option string) := do
-  ns ← unused_suffices_of_decl d,
-  if ns.length = 0 then
-    return none
-  else
-    return (", ".intercalate (ns.map to_string))
-
-/-- A linter for checking that declarations don't have unused term mode suffices statements.
-We do not tag this as `@[linter]` so that it is not in the default linter set as it is slow and an
-uncommon problem. -/
-@[linter] -- TODO remove
-meta def linter.unused_suffices : linter :=
-{ test := has_unused_suffices,
-  auto_decls := ff,
-  no_errors_found := "No declarations have unused term mode suffices statements.",
-  errors_found := "THE FOLLOWING DECLARATIONS HAVE INEFFECTUAL TERM MODE SUFFICES STATEMENTS. " ++
-"This is a term of the form `suffices h : foo, proof_of_goal, proof_of_foo` where " ++
-"`proof_of_goal` does not refer to `foo`. " ++
+  errors_found := "THE FOLLOWING DECLARATIONS HAVE INEFFECTUAL TERM MODE HAVE/SUFFICES BLOCKS. " ++
+"In the case of `have` this is a term of the form `have h := foo, bar` where `bar` does not " ++
+"refer to `foo`. Such statements have no effect on the generated proof, and can just be " ++
+"replaced by `bar`, in addition to being ineffectual, they may make unnecessary assumptions " ++
+"in proofs appear as if they are used. " ++
+"For `suffices` this is a term of the form `suffices h : foo, proof_of_goal, proof_of_foo` where" ++
+" `proof_of_goal` does not refer to `foo`. " ++
 "Such statements have no effect on the generated proof, and can just be replaced by " ++
 "`proof_of_goal`, in addition to being ineffectual, they may make unnecessary assumptions in " ++
 "proofs appear as if they are used. ",

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -361,9 +361,15 @@ attribute [nolint syn_taut] rfl
 ## Linters for ineffectual have and suffices statements in term mode
 -/
 
+/--
+Check if an expression contains `var 0` by folding over the expression and matching the binder depth
+-/
 meta def expr.has_zero_var (e : expr) : bool :=
 e.fold ff $ λ e' d res, res || match e' with | var k := k = d | _ := ff end
 
+/--
+Return a list of unused have and suffices terms in an expression
+-/
 meta def find_unused_have_suffices_macros : expr → tactic (list string)
 | (app a b) := (++) <$> find_unused_have_suffices_macros a <*> find_unused_have_suffices_macros b
 | (lam var_name bi var_type body) := find_unused_have_suffices_macros body
@@ -386,6 +392,9 @@ meta def find_unused_have_suffices_macros : expr → tactic (list string)
 | (macro md l) := do ls ← l.mmap find_unused_have_suffices_macros, return ls.join
 | _ := return []
 
+/--
+Return a list of unused have and suffices terms in a declaration
+-/
 meta def unused_have_of_decl : declaration → tactic (list string)
 | (declaration.defn _ _ _ bd _ _) := find_unused_have_suffices_macros bd
 | (declaration.thm _ _ _ bd) := find_unused_have_suffices_macros bd.get

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -18,7 +18,8 @@ This file defines several small linters:
   - `check_type` checks that the statement of a declaration is well-typed.
   - `check_univs` checks that there are no bad `max u v` universe levels.
   - `syn_taut` checks that declarations are not syntactic tautologies.
-  - `` checks that declarations produced via term mode do not have ineffectual `have` or `suffices`
+  - `unused_haves_suffices` checks that declarations produced via term mode do not have
+    ineffectual `have` or `suffices` statements
 -/
 
 open tactic expr
@@ -414,7 +415,6 @@ meta def has_unused_haves_suffices (d : declaration) : tactic (option string) :=
 /-- A linter for checking that declarations don't have unused term mode have statements. We do not
 tag this as `@[linter]` so that it is not in the default linter set as it is slow and an uncommon
 problem. -/
-@[linter] -- TODO remove
 meta def linter.unused_haves_suffices : linter :=
 { test := has_unused_haves_suffices,
   auto_decls := ff,

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -390,7 +390,7 @@ meta def find_unused_have_suffices_macros : expr → tactic (list string)
       ["unnecessary suffices " ++ ppnm.to_string ++ " : " ++ vt.to_string]
     else []) <$>
   ((++) <$> find_unused_have_suffices_macros l <*> find_unused_have_suffices_macros arg)
-| (macro md l) := do ls ← l.mmap find_unused_have_suffices_macros, return ls.join
+| (macro md l) := list.join <$> l.mmap find_unused_have_suffices_macros
 | _ := return []
 
 /--

--- a/test/lint_unused_haves_suffices.lean
+++ b/test/lint_unused_haves_suffices.lean
@@ -1,0 +1,98 @@
+import tactic.lint
+import data.list.basic
+open tactic
+
+lemma test_a : true :=
+have 1 = 1 := rfl,
+trivial
+
+run_cmd do
+  d ← get_decl ``test_a,
+  some t ← linter.unused_haves_suffices.test d,
+  guard $ "unnecessary have".is_prefix_of t
+
+lemma test_b : true :=
+have h : 1 = 1 := rfl,
+trivial
+
+run_cmd do
+  d ← get_decl ``test_b,
+  some t ← linter.unused_haves_suffices.test d,
+  guard $ "unnecessary have h".is_prefix_of t
+
+lemma test_c : true :=
+suffices h : 1 = 1, from trivial,
+rfl
+
+run_cmd do
+  d ← get_decl ``test_c,
+  some t ← linter.unused_haves_suffices.test d,
+  guard $ "unnecessary suffices h".is_prefix_of t
+
+-- test a non-trivial example obtained by printing the term for `list.map_reverse` and adding
+-- some unnecessary terms
+universes u v
+theorem test_map_reverse : ∀ {α : Type u} {β : Type v} (f : α → β) (l : list α),
+  list.map f l.reverse = (list.map f l).reverse :=
+λ {α : Type u} {β : Type v} (f : α → β) (l : list α),
+  list.rec (eq.refl (list.map f list.nil.reverse))
+    (λ (l_hd : α) (l_tl : list α) (l_ih : list.map f l_tl.reverse = (list.map f l_tl).reverse),
+       (id
+          ((λ (a a_1 : list β) (e_1 : a = a_1) (a a_1 : list β) (e_2 : a = a_1),
+              congr (congr_arg eq e_1) e_2)
+             (list.map f (l_hd :: l_tl).reverse)
+             ((list.map f l_tl).reverse ++ [f l_hd])
+             ((((λ (f f_1 : α → β) (e_1 : f = f_1) (a a_1 : list α) (e_2 : a = a_1),
+                   congr (congr_arg list.map e_1) e_2)
+                  f
+                  f
+                  (eq.refl f)
+                  (l_hd :: l_tl).reverse
+                  (l_tl.reverse ++ [l_hd])
+                  (list.reverse_cons l_hd l_tl)).trans
+                 (list.map_append f l_tl.reverse [l_hd])).trans
+                ((λ [self : has_append (list β)] (a a_1 : list β) (e_2 : a = a_1) (a_2 a_3 : list β)
+                  (e_3 : a_2 = a_3), congr (congr_arg append e_2) e_3)
+                   (list.map f l_tl.reverse)
+                   (list.map f l_tl).reverse
+                   l_ih
+                   (list.map f [l_hd])
+                   [f l_hd]
+                   ((list.map.equations._eqn_2 f l_hd list.nil).trans
+                      ((λ (hd hd_1 : β) (e_1 : hd = hd_1) (tl tl_1 : list β) (e_2 : tl = tl_1),
+                          congr (congr_arg list.cons e_1) e_2)
+                         (f l_hd)
+                         (have 1 = 1 := rfl, f l_hd)
+                         (eq.refl (f l_hd))
+                         (list.map f list.nil)
+                         list.nil
+                         (list.map.equations._eqn_1 f)))))
+             (list.map f (l_hd :: l_tl)).reverse
+             ((list.map f l_tl).reverse ++ [f l_hd])
+             (((λ (a a_1 : list β) (e_1 : a = a_1), congr_arg list.reverse e_1)
+              (list.map f (l_hd :: l_tl))
+                 (f l_hd :: list.map f l_tl)
+                 (list.map.equations._eqn_2 f l_hd l_tl)).trans
+                (list.reverse_cons (f l_hd) (list.map f l_tl))))).mpr
+         (eq.refl (suffices hh : true, from (list.map f l_tl).reverse ++ [f l_hd], trivial)))
+    l
+
+run_cmd do
+  d ← get_decl ``test_map_reverse,
+  some t ← linter.unused_haves_suffices.test d,
+  guard $ "unnecessary have".is_prefix_of t,
+  guard $ " unnecessary suffices hh".is_prefix_of (t.split_on ',').tail.head
+
+theorem test_d : ∃ (n : ℕ), n^2 + 1 = 37 :=
+have np : 2 ≤ 3, from le_of_not_ge $ λ h,
+  have f1 : 1 = 1 := rfl,
+  have f2 : 2 * 1 = 2 * 1 := congr_arg (has_mul.mul 2) f1,
+  suffices 1 = 1,
+  from (dec_trivial : ¬ 2 ≥ 3) h,
+  rfl,
+⟨6, dec_trivial⟩
+
+run_cmd do
+  d ← get_decl ``test_d,
+  some t ← linter.unused_haves_suffices.test d,
+  guard $ (t.split_on ',').length = 3


### PR DESCRIPTION
A linter for unused term mode have and suffices statements.
Based on initial work by @robertylewis https://leanprover.zulipchat.com/#narrow/stream/187764-Lean-for.20teaching/topic/linter.20for.20helping.20grading/near/209243601 but hopefully with less false positives now.


---


Doing suffices in addition to have made sense to me, and it would be interesting to do let statements as well, but there are too many false positives from tactics like `letI` right now.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
