### PR TITLE
[Merged by Bors] - feat(algebra,group_theory): smul_(g)pow

### DIFF
--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -83,13 +83,21 @@ begin
   exact is_unit_of_invertible x
 end
 
-lemma pow_smul [monoid A] [mul_action M A] [is_scalar_tower M A A] [smul_comm_class M A A]
-  (k : M) (x : A) (p : ℕ) :
+lemma smul_pow [monoid N] [mul_action M N] [is_scalar_tower M N N] [smul_comm_class M N N]
+  (k : M) (x : N) (p : ℕ) :
   (k • x) ^ p = k ^ p • x ^ p :=
 begin
   induction p with p IH,
   { simp },
   { rw [pow_succ', IH, smul_mul_smul, ←pow_succ', ←pow_succ'] }
+end
+
+@[simp] lemma smul_pow' [monoid N] [mul_distrib_mul_action M N] (x : M) (m : N) (n : ℕ) :
+  x • m ^ n = (x • m) ^ n :=
+begin
+  induction n with n ih,
+  { rw [pow_zero, pow_zero], exact smul_one x },
+  { rw [pow_succ, pow_succ], exact (smul_mul' x m (m ^ n)).trans (congr_arg _ ih) }
 end
 
 end monoid

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -83,6 +83,16 @@ begin
   exact is_unit_of_invertible x
 end
 
+lemma pow_smul [monoid A] [add_monoid A] [distrib_mul_action M A]
+  [is_scalar_tower M A A] [smul_comm_class M A A]
+  (k : M) (x : A) (p : ℕ) :
+  (k • x) ^ p = k ^ p • x ^ p :=
+begin
+  induction p with p IH,
+  { simp },
+  { rw [pow_succ', IH, smul_mul_smul, ←pow_succ', ←pow_succ'] }
+end
+
 end monoid
 
 section group

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -83,8 +83,7 @@ begin
   exact is_unit_of_invertible x
 end
 
-lemma pow_smul [monoid A] [add_monoid A] [distrib_mul_action M A]
-  [is_scalar_tower M A A] [smul_comm_class M A A]
+lemma pow_smul [monoid A] [mul_action M A] [is_scalar_tower M A A] [smul_comm_class M A A]
   (k : M) (x : A) (p : ℕ) :
   (k • x) ^ p = k ^ p • x ^ p :=
 begin

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -83,7 +83,7 @@ begin
   exact is_unit_of_invertible x
 end
 
-lemma smul_pow [monoid N] [mul_action M N] [is_scalar_tower M N N] [smul_comm_class M N N]
+lemma smul_pow [mul_action M N] [is_scalar_tower M N N] [smul_comm_class M N N]
   (k : M) (x : N) (p : ℕ) :
   (k • x) ^ p = k ^ p • x ^ p :=
 begin
@@ -92,7 +92,7 @@ begin
   { rw [pow_succ', IH, smul_mul_smul, ←pow_succ', ←pow_succ'] }
 end
 
-@[simp] lemma smul_pow' [monoid N] [mul_distrib_mul_action M N] (x : M) (m : N) (n : ℕ) :
+@[simp] lemma smul_pow' [mul_distrib_mul_action M N] (x : M) (m : N) (n : ℕ) :
   x • m ^ n = (x • m) ^ n :=
 begin
   induction n with n ih,

--- a/src/algebra/polynomial/group_ring_action.lean
+++ b/src/algebra/polynomial/group_ring_action.lean
@@ -57,8 +57,8 @@ theorem smul_eval_smul (m : M) (f : polynomial S) (x : S) :
 polynomial.induction_on f
   (λ r, by rw [smul_C, eval_C, eval_C])
   (λ f g ihf ihg, by rw [smul_add, eval_add, ihf, ihg, eval_add, smul_add])
-  (λ n r ih, by rw [smul_mul', smul_pow, smul_C, smul_X, eval_mul, eval_C, eval_pow, eval_X,
-      eval_mul, eval_C, eval_pow, eval_X, smul_mul', smul_pow])
+  (λ n r ih, by rw [smul_mul', smul_pow', smul_C, smul_X, eval_mul, eval_C, eval_pow, eval_X,
+      eval_mul, eval_C, eval_pow, eval_X, smul_mul', smul_pow'])
 
 variables (G : Type*) [group G]
 
@@ -117,9 +117,9 @@ protected noncomputable def polynomial (g : P →+*[M] Q) : polynomial P →+*[M
   map_smul' := λ m p, polynomial.induction_on p
     (λ b, by rw [smul_C, map_C, coe_fn_coe, g.map_smul, map_C, coe_fn_coe, smul_C])
     (λ p q ihp ihq, by rw [smul_add, polynomial.map_add, ihp, ihq, polynomial.map_add, smul_add])
-    (λ n b ih, by rw [smul_mul', smul_C, smul_pow, smul_X, polynomial.map_mul, map_C,
+    (λ n b ih, by rw [smul_mul', smul_C, smul_pow', smul_X, polynomial.map_mul, map_C,
         polynomial.map_pow, map_X, coe_fn_coe, g.map_smul, polynomial.map_mul, map_C,
-        polynomial.map_pow, map_X, smul_mul', smul_C, smul_pow, smul_X, coe_fn_coe]),
+        polynomial.map_pow, map_X, smul_mul', smul_C, smul_pow', smul_X, coe_fn_coe]),
   map_zero' := polynomial.map_zero g,
   map_add' := λ p q, polynomial.map_add g,
   map_one' := polynomial.map_one g,

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -607,16 +607,6 @@ instance semiring.smul_comm_class [fintype n] [monoid R] [distrib_mul_action R �
   (λ i j, a * M i j) ⬝ N = a • (M ⬝ N) :=
 smul_mul a M N
 
-lemma smul_pow [fintype n] [decidable_eq n] [monoid R] [distrib_mul_action R α]
-  [is_scalar_tower R α α] [smul_comm_class R α α]
-  (k : R) (A : matrix n n α) (p : ℕ) :
-  (k • A) ^ p = k ^ p • A ^ p :=
-begin
-  induction p with p IH,
-  { simp },
-  { rw [pow_succ', IH, smul_mul_smul, ←pow_succ', ←pow_succ'] }
-end
-
 /--
 The ring homomorphism `α →+* matrix n n α`
 sending `a` to the diagonal matrix with `a` on the diagonal.

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -607,6 +607,16 @@ instance semiring.smul_comm_class [fintype n] [monoid R] [distrib_mul_action R �
   (λ i j, a * M i j) ⬝ N = a • (M ⬝ N) :=
 smul_mul a M N
 
+lemma smul_pow [fintype n] [decidable_eq n] [monoid R] [distrib_mul_action R α]
+  [is_scalar_tower R α α] [smul_comm_class R α α]
+  (k : R) (A : matrix n n α) (p : ℕ) :
+  (k • A) ^ p = k ^ p • A ^ p :=
+begin
+  induction p with p IH,
+  { simp },
+  { rw [pow_succ', IH, smul_mul_smul, ←pow_succ', ←pow_succ'] }
+end
+
 /--
 The ring homomorphism `α →+* matrix n n α`
 sending `a` to the diagonal matrix with `a` on the diagonal.

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -98,7 +98,7 @@ subtype.eq $ x.2 m
 polynomial.induction_on p
   (λ x, by rw [polynomial.smul_C, smul])
   (λ p q ihp ihq, by rw [smul_add, ihp, ihq])
-  (λ n x ih, by rw [smul_mul', polynomial.smul_C, smul, smul_pow, polynomial.smul_X])
+  (λ n x ih, by rw [smul_mul', polynomial.smul_C, smul, smul_pow', polynomial.smul_X])
 
 instance : algebra (fixed_points.subfield M F) F :=
 algebra.of_subring (fixed_points.subfield M F).to_subring

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -465,14 +465,6 @@ end
 section
 variables [monoid α] [monoid β] [mul_distrib_mul_action α β]
 
-@[simp] lemma smul_pow (x : α) (m : β) (n : ℕ) :
-  x • m ^ n = (x • m) ^ n :=
-begin
-  induction n with n ih,
-  { rw [pow_zero, pow_zero], exact smul_one x },
-  { rw [pow_succ, pow_succ], exact (smul_mul' x m (m ^ n)).trans (congr_arg _ ih) }
-end
-
 lemma list.smul_prod {r : α} {l : list β} :
   r • l.prod = (l.map ((•) r)).prod :=
 (mul_distrib_mul_action.to_monoid_hom β r).map_list_prod l

--- a/src/group_theory/group_action/group.lean
+++ b/src/group_theory/group_action/group.lean
@@ -89,6 +89,11 @@ lemma smul_inv [group β] [smul_comm_class α β β] [is_scalar_tower α β β] 
   (c • x)⁻¹ = c⁻¹ • x⁻¹  :=
 by rw [inv_eq_iff_mul_eq_one, smul_mul_smul, mul_right_inv, mul_right_inv, one_smul]
 
+lemma smul_gpow [group β] [smul_comm_class α β β] [is_scalar_tower α β β]
+  (c : α) (x : β) (p : ℤ) :
+  (c • x) ^ p = c ^ p • x ^ p :=
+by { cases p; simp [smul_pow, smul_inv] }
+
 @[to_additive] protected lemma mul_action.bijective (g : α) : function.bijective (λ b : β, g • b) :=
 (mul_action.to_perm g).bijective
 


### PR DESCRIPTION
Rename `smul_pow` to `smul_pow'` to match `smul_mul'`. Instead provide the distributing lemma `smul_pow` where the power distributes onto the scalar as well. Provide the group action `smul_gpow` as well.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
