### PR TITLE
[Merged by Bors] - chore(data/real/pi/*): correct authorship data

### DIFF
--- a/src/data/real/pi/bounds.lean
+++ b/src/data/real/pi/bounds.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Floris van Doorn
+Authors: Floris van Doorn, Mario Carneiro
 -/
 import analysis.special_functions.trigonometric
 

--- a/src/data/real/pi/bounds.lean
+++ b/src/data/real/pi/bounds.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Floris van Doorn, Benjamin Davidson
+Authors: Floris van Doorn
 -/
 import analysis.special_functions.trigonometric
 

--- a/src/data/real/pi/leibniz.lean
+++ b/src/data/real/pi/leibniz.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2019 Floris van Doorn. All rights reserved.
+Copyright (c) 2020 Benjamin Davidson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Floris van Doorn, Benjamin Davidson
+Authors: Benjamin Davidson
 -/
 import analysis.special_functions.pow
 

--- a/src/data/real/pi/wallis.lean
+++ b/src/data/real/pi/wallis.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2019 Floris van Doorn. All rights reserved.
+Copyright (c) 2021 Hanting Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Floris van Doorn, Benjamin Davidson
+Authors: Hanting Zhang
 -/
 import analysis.special_functions.integrals
 


### PR DESCRIPTION
#9295 split `data.real.pi` into three files with the naive transferral of authorship and copyright data, this updates it to the actual authorship.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
