### PR TITLE
[Merged by Bors] - refactor(data/real/ereal): replace `.cases` with `.rec`

### DIFF
--- a/src/data/real/ereal.lean
+++ b/src/data/real/ereal.lean
@@ -83,12 +83,18 @@ instance has_coe_ennreal : has_coe ℝ≥0∞ ereal := ⟨ennreal.to_ereal⟩
 instance : has_zero ereal := ⟨(0 : ℝ)⟩
 instance : inhabited ereal := ⟨0⟩
 
-/-- A way to case on an element of `ereal`, separating the bot, real and top cases.
-A typical invocation looks like `rcases x.cases with rfl|⟨x, rfl⟩|rfl` -/
-protected lemma cases : ∀ (a : ereal), a = ⊥ ∨ (∃ (x : ℝ), a = x) ∨ a = ⊤
-| ⊤ := by simp
-| ⊥ := by simp
-| (a : ℝ) := by simp
+/-- A recursor for `ereal` in terms of the coercion.
+
+A typical invocation looks like `induction x using ereal.rec`. Note that using `induction`
+directly will unfold `ereal` to `option` which is undesirable.
+
+When working in term mode, note that pattern matching can be used directly. -/
+@[elab_as_eliminator]
+protected def rec {C : ereal → Sort*} (h_bot : C ⊥) (h_real : Π a : ℝ, C a) (h_top : C ⊤) :
+  ∀ a : ereal, C a
+| ⊥ := h_bot
+| (a : ℝ) := h_real a
+| ⊤ := h_top
 
 /-! ### Real coercion -/
 
@@ -97,7 +103,7 @@ instance : can_lift ereal ℝ :=
   cond := λ r, r ≠ ⊤ ∧ r ≠ ⊥,
   prf := λ x hx,
   begin
-    rcases x.cases with rfl|⟨x, rfl⟩|rfl,
+    induction x using ereal.rec,
     { simpa using hx },
     { simp },
     { simpa using hx }
@@ -159,7 +165,7 @@ end
 
 lemma coe_to_real {x : ereal} (hx : x ≠ ⊤) (h'x : x ≠ ⊥) : (x.to_real : ereal) = x :=
 begin
-  rcases x.cases with rfl|⟨x, rfl⟩|rfl,
+  induction x using ereal.rec,
   { simpa using h'x },
   { refl },
   { simpa using hx },
@@ -270,7 +276,7 @@ lemma to_real_add : ∀ {x y : ereal} (hx : x ≠ ⊤) (h'x : x ≠ ⊥) (hy : y
 
 lemma add_lt_add_right_coe {x y : ereal} (h : x < y) (z : ℝ) : x + z < y + z :=
 begin
-  rcases x.cases with rfl|⟨x, rfl⟩|rfl; rcases y.cases with rfl|⟨y, rfl⟩|rfl,
+  induction x using ereal.rec; induction y using ereal.rec,
   { exact (lt_irrefl _ h).elim },
   { simp only [bot_lt_coe, bot_add_coe, ← coe_add] },
   { simp },
@@ -285,7 +291,7 @@ end
 lemma add_lt_add_of_lt_of_le {x y z t : ereal} (h : x < y) (h' : z ≤ t) (hz : z ≠ ⊥) (ht : t ≠ ⊤) :
   x + z < y + t :=
 begin
-  rcases z.cases with rfl|⟨z, rfl⟩|rfl,
+  induction z using ereal.rec,
   { simpa only using hz },
   { calc x + z < y + z : add_lt_add_right_coe h _
            ... ≤ y + t : add_le_add (le_refl _) h' },
@@ -297,7 +303,7 @@ by simpa [add_comm] using add_lt_add_right_coe h z
 
 lemma add_lt_add {x y z t : ereal} (h1 : x < y) (h2 : z < t) : x + z < y + t :=
 begin
-  rcases y.cases with rfl|⟨y, rfl⟩|rfl,
+  induction y using ereal.rec,
   { exact (lt_irrefl _ (bot_le.trans_lt h1)).elim },
   { calc x + z ≤ y + z : add_le_add h1.le (le_refl _)
     ... < y + t : add_lt_add_left_coe h2 _ },
@@ -306,7 +312,7 @@ end
 
 @[simp] lemma add_eq_top_iff {x y : ereal} : x + y = ⊤ ↔ x = ⊤ ∨ y = ⊤ :=
 begin
-  rcases x.cases with rfl|⟨x, rfl⟩|rfl; rcases y.cases with rfl|⟨x, rfl⟩|rfl;
+  induction x using ereal.rec; induction y using ereal.rec;
   simp [← ereal.coe_add],
 end
 

--- a/src/topology/instances/ereal.lean
+++ b/src/topology/instances/ereal.lean
@@ -67,12 +67,12 @@ lemma embedding_coe : embedding (coe : ℝ → ereal) :=
     refine le_generate_from (assume s ha, _),
     rcases ha with ⟨a, rfl | rfl⟩,
     show is_open {b : ℝ | a < ↑b},
-    { rcases a.cases with rfl|⟨x, rfl⟩|rfl,
+    { induction a using ereal.rec,
       { simp only [is_open_univ, bot_lt_coe, set_of_true] },
       { simp only [ereal.coe_lt_coe_iff], exact is_open_Ioi },
       { simp only [set_of_false, is_open_empty, not_top_lt] } },
     show is_open {b : ℝ | ↑b < a},
-    { rcases a.cases with rfl|⟨x, rfl⟩|rfl,
+    { induction a using ereal.rec,
       { simp only [not_lt_bot, set_of_false, is_open_empty] },
       { simp only [ereal.coe_lt_coe_iff], exact is_open_Iio },
       { simp only [is_open_univ, coe_lt_top, set_of_true] } } },
@@ -89,7 +89,7 @@ lemma open_embedding_coe : open_embedding (coe : ℝ → ereal) :=
 begin
   convert @is_open_Ioo ereal _ _ _ ⊥ ⊤,
   ext x,
-  rcases x.cases with rfl|⟨y, rfl⟩|rfl,
+  induction x using ereal.rec,
   { simp only [left_mem_Ioo, mem_range, coe_ne_bot, exists_false, not_false_iff] },
   { simp only [mem_range_self, mem_Ioo, bot_lt_coe, coe_lt_top, and_self] },
   { simp only [mem_range, right_mem_Ioo, exists_false, coe_ne_top] }
@@ -142,7 +142,7 @@ lemma embedding_coe_ennreal : embedding (coe : ℝ≥0∞ → ereal) :=
     refine le_generate_from (assume s ha, _),
     rcases ha with ⟨a, rfl | rfl⟩,
     show is_open {b : ℝ≥0∞ | a < ↑b},
-    { rcases a.cases with rfl|⟨x, rfl⟩|rfl,
+    { induction a using ereal.rec with x,
       { simp only [is_open_univ, bot_lt_coe_ennreal, set_of_true] },
       { rcases le_or_lt 0 x with h|h,
         { have : (x : ereal) = ((id ⟨x, h⟩ : ℝ≥0) : ℝ≥0∞) := rfl,
@@ -154,7 +154,7 @@ lemma embedding_coe_ennreal : embedding (coe : ℝ≥0∞ → ereal) :=
           simp only [this, is_open_univ, set_of_true] } },
       { simp only [set_of_false, is_open_empty, not_top_lt] } },
     show is_open {b : ℝ≥0∞ | ↑b < a},
-    { rcases a.cases with rfl|⟨x, rfl⟩|rfl,
+    { induction a using ereal.rec with x,
       { simp only [not_lt_bot, set_of_false, is_open_empty] },
       { rcases le_or_lt 0 x with h|h,
         { have : (x : ereal) = ((id ⟨x, h⟩ : ℝ≥0) : ℝ≥0∞) := rfl,
@@ -197,7 +197,7 @@ begin
   apply le_antisymm,
   { exact infi_le_infi2 (λ x, ⟨x, by simp⟩) },
   { refine le_infi (λ r, le_infi (λ hr, _)),
-    rcases r.cases with rfl|⟨x, rfl⟩|rfl,
+    induction r using ereal.rec,
     { exact (infi_le _ 0).trans (by simp) },
     { exact infi_le _ _ },
     { simpa using hr, } }
@@ -224,7 +224,7 @@ begin
   apply le_antisymm,
   { exact infi_le_infi2 (λ x, ⟨x, by simp⟩) },
   { refine le_infi (λ r, le_infi (λ hr, _)),
-    rcases r.cases with rfl|⟨x, rfl⟩|rfl,
+    induction r using ereal.rec,
     { simpa using hr },
     { exact infi_le _ _ },
     { exact (infi_le _ 0).trans (by simp) } }
@@ -331,7 +331,7 @@ lemma continuous_at_add {p : ereal × ereal} (h : p.1 ≠ ⊤ ∨ p.2 ≠ ⊥) (
   continuous_at (λ (p : ereal × ereal), p.1 + p.2) p :=
 begin
   rcases p with ⟨x, y⟩,
-  rcases x.cases with rfl|⟨x, rfl⟩|rfl; rcases y.cases with rfl|⟨y, rfl⟩|rfl,
+  induction x using ereal.rec; induction y using ereal.rec,
   { exact continuous_at_add_bot_bot },
   { exact continuous_at_add_bot_coe _ },
   { simpa using h' },


### PR DESCRIPTION
This provides a nicer spelling than the pile of `rfl`s we use with the old `ereal.cases`, as follows:
```diff
-rcases x.cases with rfl|⟨y, rfl⟩|rfl,
+induction x using ereal.rec with y,
```
As a bonus, the subgoals now end up with names matching the hypotheses.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
