### PR TITLE
[Merged by Bors] - chore(linear_algebra): rename endomorphism multiplicative structures for consistency

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -18,7 +18,7 @@ Linear algebra:
     linear map: 'linear_map'
     range of a linear map: 'linear_map.range'
     kernel of a linear map: 'linear_map.ker'
-    algebra of endomorphisms of a vector space: 'module.endomorphism_algebra'
+    algebra of endomorphisms of a vector space: 'module.End.algebra'
     general linear group: 'linear_map.general_linear_group'
   Duality:
     dual vector space: 'module.dual'

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -395,7 +395,7 @@ end opposite
 namespace module
 variables (R : Type u) (M : Type v) [comm_semiring R] [add_comm_monoid M] [module R M]
 
-instance endomorphism_algebra : algebra R (M →ₗ[R] M) :=
+instance : algebra R (module.End R M) :=
 { to_fun    := λ r, r • linear_map.id,
   map_one' := one_smul _ _,
   map_zero' := zero_smul _ _,

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -370,7 +370,7 @@ end add_comm_group
 end is_linear_map
 
 /-- Linear endomorphisms of a module, with associated ring structure
-`linear_map.endomorphism_semiring` and algebra structure `module.endomorphism_algebra`. -/
+`module.End.semiring` and algebra structure `module.End.algebra`. -/
 abbreviation module.End (R : Type u) (M : Type v)
   [semiring R] [add_comm_monoid M] [module R M] := M →ₗ[R] M
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -289,7 +289,7 @@ rfl
   ⇑(∑ i in t, f i) = ∑ i in t, (f i : M → M₂) :=
 add_monoid_hom.map_sum ⟨@to_fun R M M₂ _ _ _ _ _, rfl, λ x y, rfl⟩ _ _
 
-instance : monoid (M →ₗ[R] M) :=
+instance _root_.module.End.monoid : monoid (module.End R M) :=
 by refine_struct { mul := (*), one := (1 : M →ₗ[R] M), npow := @npow_rec _ ⟨1⟩ ⟨(*)⟩ };
 intros; try { refl }; apply linear_map.ext; simp {proj := ff}
 
@@ -568,15 +568,18 @@ section semiring
 
 variables [semiring R] [add_comm_monoid M] [module R M]
 
-instance endomorphism_semiring : semiring (M →ₗ[R] M) :=
-by refine_struct
-  { mul := (*),
-    one := (1 : M →ₗ[R] M),
-    zero := 0,
-    add := (+),
-    npow := @npow_rec _ ⟨1⟩ ⟨(*)⟩,
-    .. linear_map.add_comm_monoid, .. };
-intros; try { refl }; apply linear_map.ext; simp {proj := ff}
+instance _root_.module.End.semiring : semiring (End R M) :=
+{ mul := (*),
+  one := (1 : M →ₗ[R] M),
+  zero := 0,
+  add := (+),
+  npow := @npow_rec _ ⟨1⟩ ⟨(*)⟩,
+  mul_zero := comp_zero,
+  zero_mul := zero_comp,
+  left_distrib := λ f g h, comp_add _ _ _,
+  right_distrib := λ f g h, add_comp _ _ _,
+  .. _root_.module.End.monoid,
+  .. linear_map.add_comm_monoid }
 
 /-- The tautological action by `M →ₗ[R] M` on `M`.
 
@@ -608,8 +611,8 @@ section ring
 
 variables [ring R] [add_comm_group M] [module R M]
 
-instance endomorphism_ring : ring (M →ₗ[R] M) :=
-{ ..linear_map.endomorphism_semiring, ..linear_map.add_comm_group }
+instance _root_.module.End.ring : ring (module.End R M) :=
+{ ..module.End.semiring, ..linear_map.add_comm_group }
 
 end ring
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -568,7 +568,7 @@ section semiring
 
 variables [semiring R] [add_comm_monoid M] [module R M]
 
-instance _root_.module.End.semiring : semiring (End R M) :=
+instance _root_.module.End.semiring : semiring (module.End R M) :=
 { mul := (*),
   one := (1 : M →ₗ[R] M),
   zero := 0,

--- a/src/ring_theory/simple_module.lean
+++ b/src/ring_theory/simple_module.lean
@@ -132,7 +132,8 @@ theorem bijective_of_ne_zero [is_simple_module R M] [is_simple_module R N]
 f.bijective_or_eq_zero.resolve_right h
 
 /-- Schur's Lemma makes the endomorphism ring of a simple module a division ring. -/
-noncomputable instance [decidable_eq (module.End R M)] [is_simple_module R M] :
+noncomputable instance _root_.module.End.division_ring
+  [decidable_eq (module.End R M)] [is_simple_module R M] :
   division_ring (module.End R M) :=
 { inv := λ f, if h : f = 0 then 0 else (linear_map.inverse f
     (equiv.of_bijective _ (bijective_of_ne_zero h)).inv_fun
@@ -154,6 +155,6 @@ noncomputable instance [decidable_eq (module.End R M)] [is_simple_module R M] :
     exact (equiv.of_bijective _ (bijective_of_ne_zero a0)).right_inv x,
   end,
   inv_zero := dif_pos rfl,
-.. (linear_map.endomorphism_ring : ring (module.End R M))}
+.. (module.End.ring : ring (module.End R M))}
 
 end linear_map


### PR DESCRIPTION
This renames:
* `module.endomorphism_semiring` → `module.End.semiring`
* `module.endomorphism_ring` → `module.End.ring`
* `module.endomorphism_algebra` → `module.End.algebra`
* `linear_map.module.End.division_ring` → `module.End.division_ring`

This brings the name in line with the names for `add_monoid.End`.

Since `module.End` is an abbreviation, it does not matter that the instances now use this instead of `M →ₗ[R] M`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
