### PR TITLE
[Merged by Bors] - feat(algebra/*): Tensor product is the fibered coproduct in CommRing

### DIFF
--- a/src/algebra/category/CommRing/pushout.lean
+++ b/src/algebra/category/CommRing/pushout.lean
@@ -10,7 +10,7 @@ import algebra.category.CommRing.basic
 /-!
 # Explicit pushout cocone for CommRing
 
-In this file we prove that tensor products is indeed the fibered coproduct in `CommRing`, and
+In this file we prove that tensor product is indeed the fibered coproduct in `CommRing`, and
 provide the explicit pushout cocone.
 
 -/

--- a/src/algebra/category/CommRing/pushout.lean
+++ b/src/algebra/category/CommRing/pushout.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2020 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang
+-/
 import category_theory.limits.shapes.pullbacks
 import ring_theory.tensor_product
 import algebra.category.CommRing.basic

--- a/src/algebra/category/CommRing/pushout.lean
+++ b/src/algebra/category/CommRing/pushout.lean
@@ -1,0 +1,89 @@
+import category_theory.limits.shapes.pullbacks
+import ring_theory.tensor_product
+import algebra.category.CommRing.basic
+
+/-!
+# Explicit pushout cocone for CommRing
+
+In this file we prove that tensor products is indeed the fibered coproduct in `CommRing`, and
+provide the explicit pushout cocone.
+
+-/
+
+universe u
+
+open category_theory
+open_locale tensor_product
+
+variables {R A B : CommRing.{u}} (f : R ⟶ A) (g : R ⟶ B)
+
+namespace CommRing
+
+/-- The explicit cocone with tensor products as the fibred product in `CommRing` -/
+def pushout_cocone : limits.pushout_cocone f g :=
+begin
+  letI := ring_hom.to_algebra f,
+  letI := ring_hom.to_algebra g,
+  apply limits.pushout_cocone.mk,
+  show CommRing, from CommRing.of (A ⊗[R] B),
+  show A ⟶ _,  from algebra.tensor_product.include_left.to_ring_hom,
+  show B ⟶ _,  from algebra.tensor_product.include_right.to_ring_hom,
+  ext r,
+  transitivity algebra_map R (A ⊗[R] B) r,
+  exact algebra.tensor_product.include_left.commutes r,
+  exact (algebra.tensor_product.include_right.commutes r).symm,
+end
+
+@[simp]
+lemma pushout_cocone_inl : (pushout_cocone f g).inl = (by {
+  letI := f.to_algebra, letI := g.to_algebra,
+  exactI algebra.tensor_product.include_left.to_ring_hom
+}) := rfl
+
+@[simp]
+lemma pushout_cocone_inr : (pushout_cocone f g).inr = (by {
+  letI := f.to_algebra, letI := g.to_algebra,
+  exactI algebra.tensor_product.include_right.to_ring_hom
+}) := rfl
+
+@[simp]
+lemma pushout_cocone_X : (pushout_cocone f g).X = (by {
+  letI := f.to_algebra, letI := g.to_algebra,
+  exactI CommRing.of (A ⊗[R] B)
+}) := rfl
+
+lemma pushout_cocone_is_pushout : limits.is_colimit (pushout_cocone f g) :=
+limits.pushout_cocone.is_colimit_aux' _ (λ s,
+begin
+  letI := ring_hom.to_algebra f,
+  letI := ring_hom.to_algebra g,
+  letI := ring_hom.to_algebra (f ≫ s.inl),
+  let f' : A →ₐ[R] s.X := { commutes' := λ r, by {
+        change s.inl.to_fun (f r) = (f ≫ s.inl) r, refl
+      }, ..s.inl},
+  let g' : B →ₐ[R] s.X := { commutes' := λ r, by {
+        change (g ≫ s.inr) r = (f ≫ s.inl) r,
+        congr' 1,
+        exact (s.ι.naturality limits.walking_span.hom.snd).trans
+          (s.ι.naturality limits.walking_span.hom.fst).symm
+      }, ..s.inr},
+  /- The factor map is a ⊗ b ↦ f(a) * g(b) -/
+  use alg_hom.to_ring_hom (algebra.tensor_product.product_map f' g'),
+  simp only [pushout_cocone_inl, pushout_cocone_inr],
+  split, { ext x, exact algebra.tensor_product.product_map_left_apply _ _ x, },
+  split, { ext x, exact algebra.tensor_product.product_map_right_apply _ _ x, },
+  intros h eq1 eq2,
+  let h' : (A ⊗[R] B) →ₐ[R] s.X :=
+    { commutes' := λ r, by {
+      change h ((f r) ⊗ₜ[R] 1) = s.inl (f r),
+      rw ← eq1, simp }, ..h },
+  suffices : h' = algebra.tensor_product.product_map f' g',
+    { ext x,
+      change h' x = algebra.tensor_product.product_map f' g' x,
+      rw this },
+  apply algebra.tensor_product.ext,
+  intros a b,
+  simp [← eq1, ← eq2, ← h.map_mul],
+end)
+
+end CommRing

--- a/src/algebra/category/CommRing/pushout.lean
+++ b/src/algebra/category/CommRing/pushout.lean
@@ -24,7 +24,7 @@ variables {R A B : CommRing.{u}} (f : R ⟶ A) (g : R ⟶ B)
 
 namespace CommRing
 
-/-- The explicit cocone with tensor products as the fibred product in `CommRing`. -/
+/-- The explicit cocone with tensor products as the fibered product in `CommRing`. -/
 def pushout_cocone : limits.pushout_cocone f g :=
 begin
   letI := ring_hom.to_algebra f,

--- a/src/algebra/category/CommRing/pushout.lean
+++ b/src/algebra/category/CommRing/pushout.lean
@@ -19,7 +19,7 @@ variables {R A B : CommRing.{u}} (f : R ⟶ A) (g : R ⟶ B)
 
 namespace CommRing
 
-/-- The explicit cocone with tensor products as the fibred product in `CommRing` -/
+/-- The explicit cocone with tensor products as the fibred product in `CommRing`. -/
 def pushout_cocone : limits.pushout_cocone f g :=
 begin
   letI := ring_hom.to_algebra f,
@@ -52,7 +52,8 @@ lemma pushout_cocone_X : (pushout_cocone f g).X = (by {
   exactI CommRing.of (A ⊗[R] B)
 }) := rfl
 
-lemma pushout_cocone_is_pushout : limits.is_colimit (pushout_cocone f g) :=
+/-- Verify that the `pushout_cocone` is indeed the colimit. -/
+def pushout_cocone_is_colimit : limits.is_colimit (pushout_cocone f g) :=
 limits.pushout_cocone.is_colimit_aux' _ (λ s,
 begin
   letI := ring_hom.to_algebra f,
@@ -60,17 +61,17 @@ begin
   letI := ring_hom.to_algebra (f ≫ s.inl),
   let f' : A →ₐ[R] s.X := { commutes' := λ r, by {
         change s.inl.to_fun (f r) = (f ≫ s.inl) r, refl
-      }, ..s.inl},
+      }, ..s.inl },
   let g' : B →ₐ[R] s.X := { commutes' := λ r, by {
         change (g ≫ s.inr) r = (f ≫ s.inl) r,
         congr' 1,
         exact (s.ι.naturality limits.walking_span.hom.snd).trans
           (s.ι.naturality limits.walking_span.hom.fst).symm
-      }, ..s.inr},
-  /- The factor map is a ⊗ b ↦ f(a) * g(b) -/
+      }, ..s.inr },
+  /- The factor map is a ⊗ b ↦ f(a) * g(b). -/
   use alg_hom.to_ring_hom (algebra.tensor_product.product_map f' g'),
   simp only [pushout_cocone_inl, pushout_cocone_inr],
-  split, { ext x, exact algebra.tensor_product.product_map_left_apply _ _ x, },
+  split, { ext x, exact algebra.tensor_product.product_map_left_apply  _ _ x, },
   split, { ext x, exact algebra.tensor_product.product_map_right_apply _ _ x, },
   intros h eq1 eq2,
   let h' : (A ⊗[R] B) →ₐ[R] s.X :=

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -776,11 +776,11 @@ end
   product_map f g (a ⊗ₜ b) = f a * g b :=
 tensor_product.product_map_apply_tmul f.to_linear_map g.to_linear_map a b
 
-@[simp] lemma product_map_left_apply (a : A) : product_map f g (include_left a) = f a := by simp
+lemma product_map_left_apply (a : A) : product_map f g (include_left a) = f a := by simp
 
 @[simp] lemma product_map_left : (product_map f g).comp include_left = f := alg_hom.ext (by simp)
 
-@[simp] lemma product_map_right_apply (b : B) : product_map f g (include_right b) = g b := by simp
+lemma product_map_right_apply (b : B) : product_map f g (include_right b) = g b := by simp
 
 @[simp] lemma product_map_right : (product_map f g).comp include_right = g := alg_hom.ext (by simp)
 

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -730,6 +730,8 @@ alg_hom_of_linear_map_tensor_product (algebra.lmul' R)
 
 variables {S}
 
+lemma lmul'_to_linear_map : (lmul' S).to_linear_map = algebra.lmul' R := rfl
+
 @[simp] lemma lmul'_apply_tmul (a b : S) : lmul' S (a ⊗ₜ[R] b) = a * b := lmul'_apply
 
 include f g

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -720,31 +720,30 @@ variables {R A B S: Type*} [comm_semiring R] [semiring A] [semiring B] [comm_sem
 variables [algebra R A] [algebra R B] [algebra R S]
 variables (f : A →ₐ[R] S) (g : B →ₐ[R] S)
 
-variables (S)
+variables (R)
 
-/-- The multiplication map on an algebra is a morphism of algebras. -/
+/-- `algebra.lmul'` is an alg_hom on commutative rings. -/
 def lmul' : S ⊗[R] S →ₐ[R] S :=
 alg_hom_of_linear_map_tensor_product (algebra.lmul' R)
   (λ a₁ a₂ b₁ b₂, by simp only [algebra.lmul'_apply, mul_mul_mul_comm])
   (λ r, by simp only [algebra.lmul'_apply, _root_.mul_one])
 
-variables {S}
+variables {R}
 
-lemma lmul'_to_linear_map : (lmul' S).to_linear_map = algebra.lmul' R := rfl
+lemma lmul'_to_linear_map : (lmul' R : _ →ₐ[R] S).to_linear_map = algebra.lmul' R := rfl
 
-@[simp] lemma lmul'_apply_tmul (a b : S) : lmul' S (a ⊗ₜ[R] b) = a * b := lmul'_apply
+@[simp] lemma lmul'_apply_tmul (a b : S) : lmul' R (a ⊗ₜ[R] b) = a * b := lmul'_apply
 
-include f g
 
 /--
 If `S` is commutative, for a pair of morphisms `f : A →ₐ[R] S`, `g : B →ₐ[R] S`,
 We obtain a map `A ⊗[R] B →ₐ[R] S` that commutes with `f`, `g` via `a ⊗ b ↦ f(a) * g(b)`.
 -/
-def product_map : A ⊗[R] B →ₐ[R] S := (lmul' S).comp (tensor_product.map f g)
+def product_map : A ⊗[R] B →ₐ[R] S := (lmul' R).comp (tensor_product.map f g)
 
 
 @[simp] lemma product_map_apply_tmul (a : A) (b : B) : product_map f g (a ⊗ₜ b) = f a * g b :=
-by { unfold product_map, simp }
+by { unfold product_map lmul', simp }
 
 lemma product_map_left_apply (a : A) : product_map f g (include_left a) = f a := by simp
 
@@ -757,3 +756,5 @@ lemma product_map_right_apply (b : B) : product_map f g (include_right b) = g b 
 end
 end tensor_product
 end algebra
+
+#lint

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -693,10 +693,10 @@ alg_hom_of_linear_map_tensor_product
   map f g (a ⊗ₜ c) = f a ⊗ₜ g c :=
 rfl
 
-lemma map_comp_include_left (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
+@[simp] lemma map_comp_include_left (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
   (map f g).comp include_left = include_left.comp f := alg_hom.ext $ by simp
 
-lemma map_comp_include_right (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
+@[simp] lemma map_comp_include_right (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
   (map f g).comp include_right = include_right.comp g := alg_hom.ext $ by simp
 
 /--
@@ -740,9 +740,11 @@ lemma lmul'_to_linear_map : (lmul' R : _ →ₐ[R] S).to_linear_map = algebra.lm
 
 @[simp] lemma lmul'_apply_tmul (a b : S) : lmul' R (a ⊗ₜ[R] b) = a * b := lmul'_apply
 
+@[simp]
 lemma lmul'_comp_include_left : (lmul' R : _ →ₐ[R] S).comp include_left = alg_hom.id R S :=
 alg_hom.ext $ λ _, (lmul'_apply_tmul _ _).trans (_root_.mul_one _)
 
+@[simp]
 lemma lmul'_comp_include_right : (lmul' R : _ →ₐ[R] S).comp include_right = alg_hom.id R S :=
 alg_hom.ext $ λ _, (lmul'_apply_tmul _ _).trans (_root_.one_mul _)
 
@@ -757,11 +759,11 @@ by { unfold product_map lmul', simp }
 
 lemma product_map_left_apply (a : A) : product_map f g (include_left a) = f a := by simp
 
-lemma product_map_comp_left : (product_map f g).comp include_left = f := alg_hom.ext $ by simp
+@[simp] lemma product_map_left : (product_map f g).comp include_left = f := alg_hom.ext $ by simp
 
 lemma product_map_right_apply (b : B) : product_map f g (include_right b) = g b := by simp
 
-lemma product_map_right : (product_map f g).comp include_right = g := alg_hom.ext $ by simp
+@[simp] lemma product_map_right : (product_map f g).comp include_right = g := alg_hom.ext $ by simp
 
 end
 end tensor_product

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -693,6 +693,12 @@ alg_hom_of_linear_map_tensor_product
   map f g (a ⊗ₜ c) = f a ⊗ₜ g c :=
 rfl
 
+lemma map_comp_include_left (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
+  (map f g).comp include_left = include_left.comp f := alg_hom.ext $ by simp
+
+lemma map_comp_include_right (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
+  (map f g).comp include_right = include_right.comp g := alg_hom.ext $ by simp
+
 /--
 Construct an isomorphism between tensor products of R-algebras
 from isomorphisms between the tensor factors.
@@ -716,7 +722,7 @@ end monoidal
 
 section
 
-variables {R A B S: Type*} [comm_semiring R] [semiring A] [semiring B] [comm_semiring S]
+variables {R A B S : Type*} [comm_semiring R] [semiring A] [semiring B] [comm_semiring S]
 variables [algebra R A] [algebra R B] [algebra R S]
 variables (f : A →ₐ[R] S) (g : B →ₐ[R] S)
 
@@ -734,6 +740,11 @@ lemma lmul'_to_linear_map : (lmul' R : _ →ₐ[R] S).to_linear_map = algebra.lm
 
 @[simp] lemma lmul'_apply_tmul (a b : S) : lmul' R (a ⊗ₜ[R] b) = a * b := lmul'_apply
 
+lemma lmul'_comp_include_left : (lmul' R : _ →ₐ[R] S).comp include_left = alg_hom.id R S :=
+alg_hom.ext $ λ _, (lmul'_apply_tmul _ _).trans (_root_.mul_one _)
+
+lemma lmul'_comp_include_right : (lmul' R : _ →ₐ[R] S).comp include_right = alg_hom.id R S :=
+alg_hom.ext $ λ _, (lmul'_apply_tmul _ _).trans (_root_.one_mul _)
 
 /--
 If `S` is commutative, for a pair of morphisms `f : A →ₐ[R] S`, `g : B →ₐ[R] S`,
@@ -741,20 +752,17 @@ We obtain a map `A ⊗[R] B →ₐ[R] S` that commutes with `f`, `g` via `a ⊗ 
 -/
 def product_map : A ⊗[R] B →ₐ[R] S := (lmul' R).comp (tensor_product.map f g)
 
-
 @[simp] lemma product_map_apply_tmul (a : A) (b : B) : product_map f g (a ⊗ₜ b) = f a * g b :=
 by { unfold product_map lmul', simp }
 
 lemma product_map_left_apply (a : A) : product_map f g (include_left a) = f a := by simp
 
-@[simp] lemma product_map_left : (product_map f g).comp include_left = f := alg_hom.ext (by simp)
+lemma product_map_comp_left : (product_map f g).comp include_left = f := alg_hom.ext $ by simp
 
 lemma product_map_right_apply (b : B) : product_map f g (include_right b) = g b := by simp
 
-@[simp] lemma product_map_right : (product_map f g).comp include_right = g := alg_hom.ext (by simp)
+lemma product_map_right : (product_map f g).comp include_right = g := alg_hom.ext $ by simp
 
 end
 end tensor_product
 end algebra
-
-#lint

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -714,66 +714,35 @@ end
 
 end monoidal
 
-end tensor_product
-
-end algebra
-
-namespace tensor_product
-
-variables {R M N S: Type*} [comm_semiring R] [add_comm_monoid M] [add_comm_monoid N] [semiring S]
-variables [module R M] [module R N] [algebra R S]
-
-/--
-If `S` is an `R`-algebra, for a pair of morphisms `f : M →ₗ[R] S`, `g : N →ₗ[R] S`,
-We may obtain a map `M ⊗[R] N →ₗ[R] S` via `a ⊗ b ↦ f(a) * g(b)`.
-This may not be that useful in module-sense, but is useful when `M`, `N` are both algebras.
--/
-def product_map (f : M →ₗ[R] S) (g : N →ₗ[R] S) : M ⊗[R] N →ₗ[R] S :=
-lift {
-  to_fun := λ m, {
-    to_fun := λ n, f m * g n,
-    map_add' := λ n₁ n₂, by rw [g.map_add, mul_add],
-    map_smul' := λ r n, by rw [g.map_smul, mul_smul_comm]
-  },
-  map_add' := λ m₁ m₂, by
-    { ext n, simp only [linear_map.coe_mk, linear_map.add_apply, f.map_add, add_mul] },
-  map_smul' := λ r m, by
-    { ext n, simp only [linear_map.coe_mk, linear_map.smul_apply,
-      f.map_smul, algebra.smul_mul_assoc] }
-}
-
-@[simp] lemma product_map_apply_tmul (f : M →ₗ[R] S) (g : N →ₗ[R] S) (m : M) (n : N) :
-  product_map f g (m ⊗ₜ n) = f m * g n :=
-by apply tensor_product.lift.tmul
-
-end tensor_product
-
-namespace algebra.tensor_product
+section
 
 variables {R A B S: Type*} [comm_semiring R] [semiring A] [semiring B] [comm_semiring S]
 variables [algebra R A] [algebra R B] [algebra R S]
 variables (f : A →ₐ[R] S) (g : B →ₐ[R] S)
+
+variables (S)
+
+/-- The multiplication map on an algebra is a morphism of algebras. -/
+def lmul' : S ⊗[R] S →ₐ[R] S :=
+alg_hom_of_linear_map_tensor_product (algebra.lmul' R)
+  (λ a₁ a₂ b₁ b₂, by simp only [algebra.lmul'_apply, mul_mul_mul_comm])
+  (λ r, by simp only [algebra.lmul'_apply, _root_.mul_one])
+
+variables {S}
+
+@[simp] lemma lmul'_apply_tmul (a b : S) : lmul' S (a ⊗ₜ[R] b) = a * b := lmul'_apply
+
 include f g
 
 /--
 If `S` is commutative, for a pair of morphisms `f : A →ₐ[R] S`, `g : B →ₐ[R] S`,
 We obtain a map `A ⊗[R] B →ₐ[R] S` that commutes with `f`, `g` via `a ⊗ b ↦ f(a) * g(b)`.
 -/
-def product_map : A ⊗[R] B →ₐ[R] S :=
-begin
-  apply alg_hom_of_linear_map_tensor_product
-    (tensor_product.product_map f.to_linear_map g.to_linear_map),
-  { intros a₁ a₂ b₁ b₂,
-    unfold alg_hom.to_linear_map,
-    simp only [linear_map.coe_mk, tensor_product.product_map_apply_tmul, alg_hom.map_mul],
-    rw [semiring.mul_assoc, semiring.mul_assoc,
-      ← semiring.mul_assoc (f a₂), ← semiring.mul_assoc (g b₁), mul_comm (f a₂)],
-    refl },
-  { intros r, simp }
-end
+def product_map : A ⊗[R] B →ₐ[R] S := (lmul' S).comp (tensor_product.map f g)
+
 
 @[simp] lemma product_map_apply_tmul (a : A) (b : B) : product_map f g (a ⊗ₜ b) = f a * g b :=
-tensor_product.product_map_apply_tmul f.to_linear_map g.to_linear_map a b
+by { unfold product_map, simp }
 
 lemma product_map_left_apply (a : A) : product_map f g (include_left a) = f a := by simp
 
@@ -783,4 +752,6 @@ lemma product_map_right_apply (b : B) : product_map f g (include_right b) = g b 
 
 @[simp] lemma product_map_right : (product_map f g).comp include_right = g := alg_hom.ext (by simp)
 
-end algebra.tensor_product
+end
+end tensor_product
+end algebra

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -716,7 +716,7 @@ end monoidal
 
 section
 
-variables {R A B S: Type*} [comm_semiring R] [semiring A] [semiring B] [comm_semiring S]
+variables {R A B S : Type*} [comm_semiring R] [semiring A] [semiring B] [comm_semiring S]
 variables [algebra R A] [algebra R B] [algebra R S]
 variables (f : A →ₐ[R] S) (g : B →ₐ[R] S)
 

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -719,12 +719,13 @@ end tensor_product
 end algebra
 
 namespace tensor_product
+
 variables {R M N S: Type*} [comm_semiring R] [add_comm_monoid M] [add_comm_monoid N] [semiring S]
 variables [module R M] [module R N] [algebra R S]
 
 /--
 If `S` is an `R`-algebra, for a pair of morphisms `f : M →ₗ[R] S`, `g : N →ₗ[R] S`,
-We obtain a map `M ⊗[R] N →ₗ[R] S` via `a ⊗ b ↦ f(a) * g(b)`.
+We may obtain a map `M ⊗[R] N →ₗ[R] S` via `a ⊗ b ↦ f(a) * g(b)`.
 This may not be that useful in module-sense, but is useful when `M`, `N` are both algebras.
 -/
 def product_map (f : M →ₗ[R] S) (g : N →ₗ[R] S) : M ⊗[R] N →ₗ[R] S :=
@@ -742,16 +743,15 @@ lift {
 }
 
 @[simp] lemma product_map_apply_tmul (f : M →ₗ[R] S) (g : N →ₗ[R] S) (m : M) (n : N) :
-  product_map f g (m ⊗ₜ n) = f m * g n := by apply tensor_product.lift.tmul
+  product_map f g (m ⊗ₜ n) = f m * g n :=
+by apply tensor_product.lift.tmul
 
 end tensor_product
 
 namespace algebra.tensor_product
 
-variables {R : Type u} [comm_semiring R]
-variables {A : Type v₁} [semiring A] [algebra R A]
-variables {B : Type v₂} [semiring B] [algebra R B]
-variables {S : Type v₂} [comm_semiring S] [algebra R S]
+variables {R A B S: Type*} [comm_semiring R] [semiring A] [semiring B] [comm_semiring S]
+variables [algebra R A] [algebra R B] [algebra R S]
 variables (f : A →ₐ[R] S) (g : B →ₐ[R] S)
 include f g
 
@@ -772,8 +772,7 @@ begin
   { intros r, simp }
 end
 
-@[simp] lemma product_map_apply_tmul (a : A) (b : B) :
-  product_map f g (a ⊗ₜ b) = f a * g b :=
+@[simp] lemma product_map_apply_tmul (a : A) (b : B) : product_map f g (a ⊗ₜ b) = f a * g b :=
 tensor_product.product_map_apply_tmul f.to_linear_map g.to_linear_map a b
 
 lemma product_map_left_apply (a : A) : product_map f g (include_left a) = f a := by simp


### PR DESCRIPTION

---

It seems that either the algebra type class or the tensor product is getting a major refactor.
But if that will take a while, the additions in `tensor_product.lean` might still be useful for the time being.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
