### PR TITLE
[Merged by Bors] - refactor(analysis/convex/function): generalize definition of `convex_on`/`concave_on` to allow any (ordered) scalars

### DIFF
--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -973,7 +973,7 @@ and `f'` is monotone on the interior, then `f` is convex on `D`. -/
 theorem convex_on_of_deriv_mono {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
   (hf : continuous_on f D) (hf' : differentiable_on ℝ f (interior D))
   (hf'_mono : ∀ x y ∈ interior D, x ≤ y → deriv f x ≤ deriv f y) :
-  convex_on D f :=
+  convex_on ℝ D f :=
 convex_on_real_of_slope_mono_adjacent hD
 begin
   intros x y z hx hz hxy hyz,
@@ -999,7 +999,7 @@ and `f'` is antimonotone on the interior, then `f` is concave on `D`. -/
 theorem concave_on_of_deriv_antimono {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
   (hf : continuous_on f D) (hf' : differentiable_on ℝ f (interior D))
   (hf'_mono : ∀ x y ∈ interior D, x ≤ y → deriv f y ≤ deriv f x) :
-  concave_on D f :=
+  concave_on ℝ D f :=
 begin
   have : ∀ x y ∈ interior D, x ≤ y → deriv (-f) x ≤ deriv (-f) y,
   { intros x y hx hy hxy,
@@ -1011,13 +1011,13 @@ end
 
 /-- If a function `f` is differentiable and `f'` is monotone on `ℝ` then `f` is convex. -/
 theorem convex_on_univ_of_deriv_mono {f : ℝ → ℝ} (hf : differentiable ℝ f)
-  (hf'_mono : monotone (deriv f)) : convex_on univ f :=
+  (hf'_mono : monotone (deriv f)) : convex_on ℝ univ f :=
 convex_on_of_deriv_mono convex_univ hf.continuous.continuous_on hf.differentiable_on
   (λ x y _ _ h, hf'_mono h)
 
 /-- If a function `f` is differentiable and `f'` is antimonotone on `ℝ` then `f` is concave. -/
 theorem concave_on_univ_of_deriv_antimono {f : ℝ → ℝ} (hf : differentiable ℝ f)
-  (hf'_antimono : ∀⦃a b⦄, a ≤ b → (deriv f) b ≤ (deriv f) a) : concave_on univ f :=
+  (hf'_antimono : ∀⦃a b⦄, a ≤ b → (deriv f) b ≤ (deriv f) a) : concave_on ℝ univ f :=
 concave_on_of_deriv_antimono convex_univ hf.continuous.continuous_on hf.differentiable_on
   (λ x y _ _ h, hf'_antimono h)
 
@@ -1027,7 +1027,7 @@ theorem convex_on_of_deriv2_nonneg {D : set ℝ} (hD : convex ℝ D) {f : ℝ �
   (hf : continuous_on f D) (hf' : differentiable_on ℝ f (interior D))
   (hf'' : differentiable_on ℝ (deriv f) (interior D))
   (hf''_nonneg : ∀ x ∈ interior D, 0 ≤ (deriv^[2] f x)) :
-  convex_on D f :=
+  convex_on ℝ D f :=
 convex_on_of_deriv_mono hD hf hf' $
 assume x y hx hy hxy,
 hD.interior.mono_of_deriv_nonneg hf''.continuous_on (by rwa [interior_interior])
@@ -1039,7 +1039,7 @@ theorem concave_on_of_deriv2_nonpos {D : set ℝ} (hD : convex ℝ D) {f : ℝ �
   (hf : continuous_on f D) (hf' : differentiable_on ℝ f (interior D))
   (hf'' : differentiable_on ℝ (deriv f) (interior D))
   (hf''_nonpos : ∀ x ∈ interior D, (deriv^[2] f x) ≤ 0) :
-  concave_on D f :=
+  concave_on ℝ D f :=
 concave_on_of_deriv_antimono hD hf hf' $
 assume x y hx hy hxy,
 hD.interior.antimono_of_deriv_nonpos hf''.continuous_on (by rwa [interior_interior])
@@ -1049,7 +1049,7 @@ hD.interior.antimono_of_deriv_nonpos hf''.continuous_on (by rwa [interior_interi
 `f''` is nonnegative on `D`, then `f` is convex on `D`. -/
 theorem convex_on_open_of_deriv2_nonneg {D : set ℝ} (hD : convex ℝ D) (hD₂ : is_open D) {f : ℝ → ℝ}
   (hf' : differentiable_on ℝ f D) (hf'' : differentiable_on ℝ (deriv f) D)
-  (hf''_nonneg : ∀ x ∈ D, 0 ≤ (deriv^[2] f x)) : convex_on D f :=
+  (hf''_nonneg : ∀ x ∈ D, 0 ≤ (deriv^[2] f x)) : convex_on ℝ D f :=
 convex_on_of_deriv2_nonneg hD hf'.continuous_on (by simpa [hD₂.interior_eq] using hf')
   (by simpa [hD₂.interior_eq] using hf'') (by simpa [hD₂.interior_eq] using hf''_nonneg)
 
@@ -1057,7 +1057,7 @@ convex_on_of_deriv2_nonneg hD hf'.continuous_on (by simpa [hD₂.interior_eq] us
 `f''` is nonpositive on `D`, then `f` is concave on `D`. -/
 theorem concave_on_open_of_deriv2_nonpos {D : set ℝ} (hD : convex ℝ D) (hD₂ : is_open D) {f : ℝ → ℝ}
   (hf' : differentiable_on ℝ f D) (hf'' : differentiable_on ℝ (deriv f) D)
-  (hf''_nonpos : ∀ x ∈ D, (deriv^[2] f x) ≤ 0) : concave_on D f :=
+  (hf''_nonpos : ∀ x ∈ D, (deriv^[2] f x) ≤ 0) : concave_on ℝ D f :=
 concave_on_of_deriv2_nonpos hD hf'.continuous_on (by simpa [hD₂.interior_eq] using hf')
   (by simpa [hD₂.interior_eq] using hf'') (by simpa [hD₂.interior_eq] using hf''_nonpos)
 
@@ -1073,7 +1073,7 @@ convex_on_open_of_deriv2_nonneg convex_univ is_open_univ hf'.differentiable_on
 then `f` is concave on `ℝ`. -/
 theorem concave_on_univ_of_deriv2_nonpos {f : ℝ → ℝ} (hf' : differentiable ℝ f)
   (hf'' : differentiable ℝ (deriv f)) (hf''_nonpos : ∀ x, (deriv^[2] f x) ≤ 0) :
-  concave_on univ f :=
+  concave_on ℝ univ f :=
 concave_on_open_of_deriv2_nonpos convex_univ is_open_univ hf'.differentiable_on
   hf''.differentiable_on (λ x _, hf''_nonpos x)
 

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -1065,7 +1065,7 @@ concave_on_of_deriv2_nonpos hD hf'.continuous_on (by simpa [hD₂.interior_eq] u
 then `f` is convex on `ℝ`. -/
 theorem convex_on_univ_of_deriv2_nonneg {f : ℝ → ℝ} (hf' : differentiable ℝ f)
   (hf'' : differentiable ℝ (deriv f)) (hf''_nonneg : ∀ x, 0 ≤ (deriv^[2] f x)) :
-  convex_on univ f :=
+  convex_on ℝ univ f :=
 convex_on_open_of_deriv2_nonneg convex_univ is_open_univ hf'.differentiable_on
   hf''.differentiable_on (λ x _, hf''_nonneg x)
 

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -401,14 +401,14 @@ section ordered_semiring
 variables [ordered_semiring 𝕜]
 
 section add_comm_monoid
-variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F]
+variables [add_comm_monoid E]
 
 /-- Convexity of sets. -/
-def convex (s : set E) :=
+def convex [has_scalar 𝕜 E] (s : set E) :=
 ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1 →
   a • x + b • y ∈ s
 
-variables {𝕜} {s : set E}
+variables {𝕜} [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F] {s : set E}
 
 lemma convex_iff_forall_pos :
   convex 𝕜 s ↔ ∀ ⦃x y⦄, x ∈ s → y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1

--- a/src/analysis/convex/exposed.lean
+++ b/src/analysis/convex/exposed.lean
@@ -169,7 +169,7 @@ protected lemma is_extreme [normed_space ℝ E]  (hAB : is_exposed ℝ A B) :
 begin
   refine ⟨hAB.subset, λ x₁ x₂ hx₁A hx₂A x hxB hx, _⟩,
   obtain ⟨l, rfl⟩ := hAB ⟨x, hxB⟩,
-  have hl : convex_on ℝ univ l := l.to_linear_map.convex_on ℝ convex_univ,
+  have hl : convex_on ℝ univ l := l.to_linear_map.convex_on convex_univ,
   have hlx₁ := hxB.2 x₁ hx₁A,
   have hlx₂ := hxB.2 x₂ hx₂A,
   refine ⟨⟨hx₁A, λ y hy, _⟩, ⟨hx₂A, λ y hy, _⟩⟩,
@@ -186,7 +186,7 @@ begin
   { exact convex_empty },
   obtain ⟨l, rfl⟩ := hAB hB,
   exact λ x₁ x₂ hx₁ hx₂ a b ha hb hab, ⟨hA hx₁.1 hx₂.1 ha hb hab, λ y hy,
-    ((l.to_linear_map.concave_on ℝ convex_univ).concave_le _
+    ((l.to_linear_map.concave_on convex_univ).concave_le _
     ⟨mem_univ _, hx₁.2 y hy⟩ ⟨mem_univ _, hx₂.2 y hy⟩ ha hb hab).2⟩,
 end
 

--- a/src/analysis/convex/exposed.lean
+++ b/src/analysis/convex/exposed.lean
@@ -169,7 +169,7 @@ protected lemma is_extreme [normed_space ℝ E]  (hAB : is_exposed ℝ A B) :
 begin
   refine ⟨hAB.subset, λ x₁ x₂ hx₁A hx₂A x hxB hx, _⟩,
   obtain ⟨l, rfl⟩ := hAB ⟨x, hxB⟩,
-  have hl : convex_on univ l := l.to_linear_map.convex_on convex_univ,
+  have hl : convex_on ℝ univ l := l.to_linear_map.convex_on ℝ convex_univ,
   have hlx₁ := hxB.2 x₁ hx₁A,
   have hlx₂ := hxB.2 x₂ hx₂A,
   refine ⟨⟨hx₁A, λ y hy, _⟩, ⟨hx₂A, λ y hy, _⟩⟩,
@@ -186,7 +186,7 @@ begin
   { exact convex_empty },
   obtain ⟨l, rfl⟩ := hAB hB,
   exact λ x₁ x₂ hx₁ hx₂ a b ha hb hab, ⟨hA hx₁.1 hx₂.1 ha hb hab, λ y hy,
-    ((l.to_linear_map.concave_on convex_univ).concave_le _
+    ((l.to_linear_map.concave_on ℝ convex_univ).concave_le _
     ⟨mem_univ _, hx₁.2 y hy⟩ ⟨mem_univ _, hx₂.2 y hy⟩ ha hb hab).2⟩,
 end
 

--- a/src/analysis/convex/extrema.lean
+++ b/src/analysis/convex/extrema.lean
@@ -27,7 +27,7 @@ open_locale classical
 Helper lemma for the more general case: `is_min_on.of_is_local_min_on_of_convex_on`.
 -/
 lemma is_min_on.of_is_local_min_on_of_convex_on_Icc {f : ℝ → β} {a b : ℝ} (a_lt_b : a < b)
-  (h_local_min : is_local_min_on f (Icc a b) a) (h_conv : convex_on (Icc a b) f) :
+  (h_local_min : is_local_min_on f (Icc a b) a) (h_conv : convex_on ℝ (Icc a b) f) :
   ∀ x ∈ Icc a b, f a ≤ f x :=
 begin
   by_contradiction H_cont,
@@ -61,7 +61,7 @@ end
 A local minimum of a convex function is a global minimum, restricted to a set `s`.
 -/
 lemma is_min_on.of_is_local_min_on_of_convex_on {f : E → β} {a : E}
-  (a_in_s : a ∈ s) (h_localmin : is_local_min_on f s a) (h_conv : convex_on s f) :
+  (a_in_s : a ∈ s) (h_localmin : is_local_min_on f s a) (h_conv : convex_on ℝ s f) :
   ∀ x ∈ s, f a ≤ f x :=
 begin
   by_contradiction H_cont,
@@ -92,18 +92,18 @@ end
 
 /-- A local maximum of a concave function is a global maximum, restricted to a set `s`. -/
 lemma is_max_on.of_is_local_max_on_of_concave_on {f : E → β} {a : E}
-  (a_in_s : a ∈ s) (h_localmax: is_local_max_on f s a) (h_conc : concave_on s f) :
+  (a_in_s : a ∈ s) (h_localmax: is_local_max_on f s a) (h_conc : concave_on ℝ s f) :
   ∀ x ∈ s, f x ≤ f a :=
 @is_min_on.of_is_local_min_on_of_convex_on
   _ (order_dual β) _ _ _ _ _ _ _ _ s f a a_in_s h_localmax h_conc
 
 /-- A local minimum of a convex function is a global minimum. -/
 lemma is_min_on.of_is_local_min_of_convex_univ {f : E → β} {a : E}
-  (h_local_min : is_local_min f a) (h_conv : convex_on univ f) : ∀ x, f a ≤ f x :=
+  (h_local_min : is_local_min f a) (h_conv : convex_on ℝ univ f) : ∀ x, f a ≤ f x :=
 λ x, (is_min_on.of_is_local_min_on_of_convex_on (mem_univ a)
         (is_local_min.on h_local_min univ) h_conv) x (mem_univ x)
 
 /-- A local maximum of a concave function is a global maximum. -/
 lemma is_max_on.of_is_local_max_of_convex_univ {f : E → β} {a : E}
-  (h_local_max : is_local_max f a) (h_conc : concave_on univ f) : ∀ x, f x ≤ f a :=
+  (h_local_max : is_local_max f a) (h_conc : concave_on ℝ univ f) : ∀ x, f x ≤ f a :=
 @is_min_on.of_is_local_min_of_convex_univ _ (order_dual β) _ _ _ _ _ _ _ _ f a h_local_max h_conc

--- a/src/analysis/convex/function.lean
+++ b/src/analysis/convex/function.lean
@@ -97,8 +97,8 @@ begin
 end⟩
 
 lemma concave_on_iff_div {f : E → β} :
-  concave_on ℝ s f ↔ convex ℝ s ∧ ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : ℝ⦄, 0 ≤ a → 0 ≤ b → 0 < a + b
-  → (a/(a+b)) • f x + (b/(a+b)) • f y ≤ f ((a/(a+b)) • x + (b/(a+b)) • y) :=
+  concave_on ℝ s f ↔ convex ℝ s ∧ ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : ℝ⦄, 0 ≤ a → 0 ≤ b
+  → 0 < a + b → (a/(a+b)) • f x + (b/(a+b)) • f y ≤ f ((a/(a+b)) • x + (b/(a+b)) • y) :=
 @convex_on_iff_div _ (order_dual β) _ _ _ _ _ _
 
 /-- For a function on a convex set in a linear ordered space, in order to prove that it is convex

--- a/src/analysis/convex/function.lean
+++ b/src/analysis/convex/function.lean
@@ -29,19 +29,16 @@ open finset linear_map set
 open_locale big_operators classical convex pointwise
 
 /-- Convexity of functions -/
-def convex_on (𝕜 : Type*) {E β : Type*} [ordered_semiring 𝕜] [add_comm_monoid E] [add_comm_monoid F]
+def convex_on (𝕜 : Type*) {E β : Type*} [ordered_semiring 𝕜] [add_comm_monoid E]
   [ordered_add_comm_monoid β] [has_scalar 𝕜 E] [has_scalar 𝕜 β] (s : set E) (f : E → β) : Prop :=
-  convex ℝ s ∧
-  ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : ℝ⦄, 0 ≤ a → 0 ≤ b → a + b = 1 →
-    f (a • x + b • y) ≤ a • f x + b • f y
+  convex 𝕜 s ∧ ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1
+    → f (a • x + b • y) ≤ a • f x + b • f y
 
 /-- Concavity of functions -/
 def concave_on (𝕜 : Type*) {E β : Type*} [ordered_semiring 𝕜] [add_comm_monoid E]
-  [add_comm_monoid F] [ordered_add_comm_monoid β] [has_scalar 𝕜 E] [has_scalar 𝕜 β] (s : set E)
-  (f : E → β) : Prop :=
-  convex ℝ s ∧
-  ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : ℝ⦄, 0 ≤ a → 0 ≤ b → a + b = 1 →
-    a • f x + b • f y ≤ f (a • x + b • y)
+  [ordered_add_comm_monoid β] [has_scalar 𝕜 E] [has_scalar 𝕜 β] (s : set E) (f : E → β) : Prop :=
+  convex 𝕜 s ∧ ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1
+    → a • f x + b • f y ≤ f (a • x + b • y)
 
 variables {𝕜 E F ι ι' β : Type*} [add_comm_group E] [module ℝ E] [add_comm_group F] [module ℝ F]
   [ordered_add_comm_monoid β] [module ℝ β] {s : set E}

--- a/src/analysis/convex/function.lean
+++ b/src/analysis/convex/function.lean
@@ -28,27 +28,30 @@ a convex set.
 open finset linear_map set
 open_locale big_operators classical convex pointwise
 
-variables {𝕜 E F ι ι' β : Type*} [add_comm_group E] [module ℝ E] [add_comm_group F] [module ℝ F]
-  [ordered_add_comm_monoid β] [module ℝ β] {s : set E}
-
 /-- Convexity of functions -/
-def convex_on (s : set E) (f : E → β) : Prop :=
+def convex_on (𝕜 : Type*) {E β : Type*} [ordered_semiring 𝕜] [add_comm_monoid E] [add_comm_monoid F]
+  [ordered_add_comm_monoid β] [has_scalar 𝕜 E] [has_scalar 𝕜 β] (s : set E) (f : E → β) : Prop :=
   convex ℝ s ∧
   ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : ℝ⦄, 0 ≤ a → 0 ≤ b → a + b = 1 →
     f (a • x + b • y) ≤ a • f x + b • f y
 
 /-- Concavity of functions -/
-def concave_on (s : set E) (f : E → β) : Prop :=
+def concave_on (𝕜 : Type*) {E β : Type*} [ordered_semiring 𝕜] [add_comm_monoid E]
+  [add_comm_monoid F] [ordered_add_comm_monoid β] [has_scalar 𝕜 E] [has_scalar 𝕜 β] (s : set E)
+  (f : E → β) : Prop :=
   convex ℝ s ∧
   ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : ℝ⦄, 0 ≤ a → 0 ≤ b → a + b = 1 →
     a • f x + b • f y ≤ f (a • x + b • y)
+
+variables {𝕜 E F ι ι' β : Type*} [add_comm_group E] [module ℝ E] [add_comm_group F] [module ℝ F]
+  [ordered_add_comm_monoid β] [module ℝ β] {s : set E}
 
 section
 variables [ordered_smul ℝ β]
 
 /-- A function `f` is concave iff `-f` is convex. -/
 @[simp] lemma neg_convex_on_iff {γ : Type*} [ordered_add_comm_group γ] [module ℝ γ]
-  (s : set E) (f : E → γ) : convex_on s (-f) ↔ concave_on s f :=
+  (s : set E) (f : E → γ) : convex_on ℝ s (-f) ↔ concave_on ℝ s f :=
 begin
   split,
   { rintros ⟨hconv, h⟩,
@@ -66,23 +69,23 @@ end
 
 /-- A function `f` is concave iff `-f` is convex. -/
 @[simp] lemma neg_concave_on_iff {γ : Type*} [ordered_add_comm_group γ] [module ℝ γ]
-  (s : set E) (f : E → γ) : concave_on s (-f) ↔ convex_on s f:=
+  (s : set E) (f : E → γ) : concave_on ℝ s (-f) ↔ convex_on ℝ s f:=
 by rw [← neg_convex_on_iff s (-f), neg_neg f]
 
 end
 
-lemma convex_on_id {s : set ℝ} (hs : convex ℝ s) : convex_on s id := ⟨hs, by { intros, refl }⟩
+lemma convex_on_id {s : set ℝ} (hs : convex ℝ s) : convex_on ℝ s id := ⟨hs, by { intros, refl }⟩
 
-lemma concave_on_id {s : set ℝ} (hs : convex ℝ s) : concave_on s id := ⟨hs, by { intros, refl }⟩
+lemma concave_on_id {s : set ℝ} (hs : convex ℝ s) : concave_on ℝ s id := ⟨hs, by { intros, refl }⟩
 
-lemma convex_on_const (c : β) (hs : convex ℝ s) : convex_on s (λ x:E, c) :=
+lemma convex_on_const (c : β) (hs : convex ℝ s) : convex_on ℝ s (λ x:E, c) :=
 ⟨hs, by { intros, simp only [← add_smul, *, one_smul] }⟩
 
-lemma concave_on_const (c : β) (hs : convex ℝ s) : concave_on s (λ x:E, c) :=
+lemma concave_on_const (c : β) (hs : convex ℝ s) : concave_on ℝ s (λ x:E, c) :=
 @convex_on_const _ (order_dual β) _ _ _ _ _ c hs
 
 lemma convex_on_iff_div {f : E → β} :
-  convex_on s f ↔ convex ℝ s ∧ ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : ℝ⦄, 0 ≤ a → 0 ≤ b → 0 < a + b
+  convex_on ℝ s f ↔ convex ℝ s ∧ ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : ℝ⦄, 0 ≤ a → 0 ≤ b → 0 < a + b
   → f ((a/(a+b)) • x + (b/(a+b)) • y) ≤ (a/(a+b)) • f x + (b/(a+b)) • f y :=
 and_congr iff.rfl
 ⟨begin
@@ -97,7 +100,7 @@ begin
 end⟩
 
 lemma concave_on_iff_div {f : E → β} :
-  concave_on s f ↔ convex ℝ s ∧ ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : ℝ⦄, 0 ≤ a → 0 ≤ b → 0 < a + b
+  concave_on ℝ s f ↔ convex ℝ s ∧ ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : ℝ⦄, 0 ≤ a → 0 ≤ b → 0 < a + b
   → (a/(a+b)) • f x + (b/(a+b)) • f y ≤ f ((a/(a+b)) • x + (b/(a+b)) • y) :=
 @convex_on_iff_div _ (order_dual β) _ _ _ _ _ _
 
@@ -107,7 +110,7 @@ and positive `a`, `b`. The main use case is `E = ℝ` however one can apply it, 
 lexicographic order. -/
 lemma linear_order.convex_on_of_lt {f : E → β} [linear_order E] (hs : convex ℝ s)
   (hf : ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → x < y → ∀ ⦃a b : ℝ⦄, 0 < a → 0 < b → a + b = 1 →
-    f (a • x + b • y) ≤ a • f x + b • f y) : convex_on s f :=
+    f (a • x + b • y) ≤ a • f x + b • f y) : convex_on ℝ s f :=
 begin
   use hs,
   intros x y hx hy a b ha hb hab,
@@ -128,7 +131,7 @@ and positive `a`, `b`. The main use case is `E = ℝ` however one can apply it, 
 lexicographic order. -/
 lemma linear_order.concave_on_of_lt {f : E → β} [linear_order E] (hs : convex ℝ s)
   (hf : ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → x < y → ∀ ⦃a b : ℝ⦄, 0 < a → 0 < b → a + b = 1 →
-     a • f x + b • f y ≤ f (a • x + b • y)) : concave_on s f :=
+     a • f x + b • f y ≤ f (a • x + b • y)) : concave_on ℝ s f :=
 @linear_order.convex_on_of_lt _ (order_dual β) _ _ _ _ _ f _ hs hf
 
 /-- For a function `f` defined on a convex subset `D` of `ℝ`, if for any three points `x < y < z`
@@ -138,7 +141,7 @@ of a function is used in the proof of convexity of a function with a monotone de
 lemma convex_on_real_of_slope_mono_adjacent {s : set ℝ} (hs : convex ℝ s) {f : ℝ → ℝ}
   (hf : ∀ {x y z : ℝ}, x ∈ s → z ∈ s → x < y → y < z →
     (f y - f x) / (y - x) ≤ (f z - f y) / (z - y)) :
-  convex_on s f :=
+  convex_on ℝ s f :=
 linear_order.convex_on_of_lt hs
 begin
   assume x z hx hz hxz a b ha hb hab,
@@ -163,7 +166,7 @@ end
 /-- For a function `f` defined on a subset `D` of `ℝ`, if `f` is convex on `D`, then for any three
 points `x < y < z`, the slope of the secant line of `f` on `[x, y]` is less than or equal to the
 slope of the secant line of `f` on `[x, z]`. -/
-lemma convex_on.slope_mono_adjacent {s : set ℝ} {f : ℝ → ℝ} (hf : convex_on s f)
+lemma convex_on.slope_mono_adjacent {s : set ℝ} {f : ℝ → ℝ} (hf : convex_on ℝ s f)
   {x y z : ℝ} (hx : x ∈ s) (hz : z ∈ s) (hxy : x < y) (hyz : y < z) :
   (f y - f x) / (y - x) ≤ (f z - f y) / (z - y) :=
 begin
@@ -192,7 +195,7 @@ end
 three points `x < y < z` the slope of the secant line of `f` on `[x, y]` is less than or equal to
 the slope,of the secant line of `f` on `[x, z]`. -/
 lemma convex_on_real_iff_slope_mono_adjacent {s : set ℝ} (hs : convex ℝ s) {f : ℝ → ℝ} :
-  convex_on s f ↔
+  convex_on ℝ s f ↔
   (∀ {x y z : ℝ}, x ∈ s → z ∈ s → x < y → y < z →
     (f y - f x) / (y - x) ≤ (f z - f y) / (z - y)) :=
 ⟨convex_on.slope_mono_adjacent, convex_on_real_of_slope_mono_adjacent hs⟩
@@ -202,7 +205,7 @@ the slope of the secant line of `f` on `[x, y]` is greater than or equal to the 
 of the secant line of `f` on `[x, z]`, then `f` is concave on `D`. -/
 lemma concave_on_real_of_slope_mono_adjacent {s : set ℝ} (hs : convex ℝ s) {f : ℝ → ℝ}
   (hf : ∀ {x y z : ℝ}, x ∈ s → z ∈ s → x < y → y < z →
-    (f z - f y) / (z - y) ≤ (f y - f x) / (y - x)) : concave_on s f :=
+    (f z - f y) / (z - y) ≤ (f y - f x) / (y - x)) : concave_on ℝ s f :=
 begin
   rw [←neg_convex_on_iff],
   apply convex_on_real_of_slope_mono_adjacent hs,
@@ -214,7 +217,7 @@ end
 /-- For a function `f` defined on a subset `D` of `ℝ`, if `f` is concave on `D`, then for any three
 points `x < y < z`, the slope of the secant line of `f` on `[x, y]` is greater than or equal to the
 slope of the secant line of `f` on `[x, z]`. -/
-lemma concave_on.slope_mono_adjacent {s : set ℝ} {f : ℝ → ℝ} (hf : concave_on s f)
+lemma concave_on.slope_mono_adjacent {s : set ℝ} {f : ℝ → ℝ} (hf : concave_on ℝ s f)
   {x y z : ℝ} (hx : x ∈ s) (hz : z ∈ s) (hxy : x < y) (hyz : y < z) :
   (f z - f y) / (z - y) ≤ (f y - f x) / (y - x) :=
 begin
@@ -229,25 +232,25 @@ end
 three points `x < y < z` the slope of the secant line of `f` on `[x, y]` is greater than or equal to
 the slope of the secant line of `f` on `[x, z]`. -/
 lemma concave_on_real_iff_slope_mono_adjacent {s : set ℝ} (hs : convex ℝ s) {f : ℝ → ℝ} :
-  concave_on s f ↔
+  concave_on ℝ s f ↔
   (∀ {x y z : ℝ}, x ∈ s → z ∈ s → x < y → y < z →
     (f z - f y) / (z - y) ≤ (f y - f x) / (y - x)) :=
 ⟨concave_on.slope_mono_adjacent, concave_on_real_of_slope_mono_adjacent hs⟩
 
-lemma convex_on.subset {f : E → β} {t : set E} (h_convex_on : convex_on t f)
-  (h_subset : s ⊆ t) (h_convex : convex ℝ s) : convex_on s f :=
+lemma convex_on.subset {f : E → β} {t : set E} (h_convex_on : convex_on ℝ t f)
+  (h_subset : s ⊆ t) (h_convex : convex ℝ s) : convex_on ℝ s f :=
 begin
   apply and.intro h_convex,
   intros x y hx hy,
   exact h_convex_on.2 (h_subset hx) (h_subset hy),
 end
 
-lemma concave_on.subset {f : E → β} {t : set E} (h_concave_on : concave_on t f)
-  (h_subset : s ⊆ t) (h_convex : convex ℝ s) : concave_on s f :=
+lemma concave_on.subset {f : E → β} {t : set E} (h_concave_on : concave_on ℝ t f)
+  (h_subset : s ⊆ t) (h_convex : convex ℝ s) : concave_on ℝ s f :=
 @convex_on.subset _ (order_dual β) _ _ _ _ _ f t h_concave_on h_subset h_convex
 
-lemma convex_on.add {f g : E → β} (hf : convex_on s f) (hg : convex_on s g) :
-  convex_on s (λx, f x + g x) :=
+lemma convex_on.add {f g : E → β} (hf : convex_on ℝ s f) (hg : convex_on ℝ s g) :
+  convex_on ℝ s (λx, f x + g x) :=
 begin
   apply and.intro hf.1,
   intros x y hx hy a b ha hb hab,
@@ -258,12 +261,12 @@ begin
     ... = a • (f x + g x) + b • (f y + g y) : by simp [smul_add, add_assoc]
 end
 
-lemma concave_on.add {f g : E → β} (hf : concave_on s f) (hg : concave_on s g) :
-  concave_on s (λx, f x + g x) :=
+lemma concave_on.add {f g : E → β} (hf : concave_on ℝ s f) (hg : concave_on ℝ s g) :
+  concave_on ℝ s (λx, f x + g x) :=
 @convex_on.add _ (order_dual β) _ _ _ _ _ f g hf hg
 
 lemma convex_on.smul [ordered_smul ℝ β] {f : E → β} {c : ℝ} (hc : 0 ≤ c)
-  (hf : convex_on s f) : convex_on s (λx, c • f x) :=
+  (hf : convex_on ℝ s f) : convex_on ℝ s (λx, c • f x) :=
 begin
   apply and.intro hf.1,
   intros x y hx hy a b ha hb hab,
@@ -274,7 +277,7 @@ begin
 end
 
 lemma concave_on.smul [ordered_smul ℝ β] {f : E → β} {c : ℝ} (hc : 0 ≤ c)
-  (hf : concave_on s f) : concave_on s (λx, c • f x) :=
+  (hf : concave_on ℝ s f) : concave_on ℝ s (λx, c • f x) :=
 @convex_on.smul _ (order_dual β) _ _ _ _ _ _ f c hc hf
 
 section linear_order
@@ -284,8 +287,8 @@ variables {γ : Type*} [linear_ordered_add_comm_monoid γ] [module ℝ γ] [orde
   {f g : E → γ}
 
 /-- The pointwise maximum of convex functions is convex. -/
-lemma convex_on.sup (hf : convex_on s f) (hg : convex_on s g) :
-  convex_on s (f ⊔ g) :=
+lemma convex_on.sup (hf : convex_on ℝ s f) (hg : convex_on ℝ s g) :
+  convex_on ℝ s (f ⊔ g) :=
 begin
    refine ⟨hf.left, λ x y hx hy a b ha hb hab, sup_le _ _⟩,
    { calc f (a • x + b • y) ≤ a • f x + b • f y : hf.right hx hy ha hb hab
@@ -299,12 +302,12 @@ begin
 end
 
 /-- The pointwise minimum of concave functions is concave. -/
-lemma concave_on.inf (hf : concave_on s f) (hg : concave_on s g) :
-  concave_on s (f ⊓ g) :=
+lemma concave_on.inf (hf : concave_on ℝ s f) (hg : concave_on ℝ s g) :
+  concave_on ℝ s (f ⊓ g) :=
 @convex_on.sup _ _ _ _ (order_dual γ) _ _ _ _ _ hf hg
 
 /-- A convex function on a segment is upper-bounded by the max of its endpoints. -/
-lemma convex_on.le_on_segment' (hf : convex_on s f) {x y : E} {a b : ℝ}
+lemma convex_on.le_on_segment' (hf : convex_on ℝ s f) {x y : E} {a b : ℝ}
   (hx : x ∈ s) (hy : y ∈ s) (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1) :
   f (a • x + b • y) ≤ max (f x) (f y) :=
 calc
@@ -315,19 +318,19 @@ calc
   ... = max (f x) (f y) : by rw [←add_smul, hab, one_smul]
 
 /-- A concave function on a segment is lower-bounded by the min of its endpoints. -/
-lemma concave_on.le_on_segment' (hf : concave_on s f) {x y : E} {a b : ℝ}
+lemma concave_on.le_on_segment' (hf : concave_on ℝ s f) {x y : E} {a b : ℝ}
   (hx : x ∈ s) (hy : y ∈ s) (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1) :
   min (f x) (f y) ≤ f (a • x + b • y) :=
 @convex_on.le_on_segment' _ _ _ _ (order_dual γ) _ _ _ f hf x y a b hx hy ha hb hab
 
 /-- A convex function on a segment is upper-bounded by the max of its endpoints. -/
-lemma convex_on.le_on_segment (hf : convex_on s f) {x y z : E}
+lemma convex_on.le_on_segment (hf : convex_on ℝ s f) {x y z : E}
   (hx : x ∈ s) (hy : y ∈ s) (hz : z ∈ [x -[ℝ] y]) :
   f z ≤ max (f x) (f y) :=
 let ⟨a, b, ha, hb, hab, hz⟩ := hz in hz ▸ hf.le_on_segment' hx hy ha hb hab
 
 /-- A concave function on a segment is lower-bounded by the min of its endpoints. -/
-lemma concave_on.le_on_segment {f : E → γ} (hf : concave_on s f) {x y z : E}
+lemma concave_on.le_on_segment {f : E → γ} (hf : concave_on ℝ s f) {x y z : E}
   (hx : x ∈ s) (hy : y ∈ s) (hz : z ∈ [x -[ℝ] y]) :
     min (f x) (f y) ≤ f z :=
 @convex_on.le_on_segment _ _ _ _ (order_dual γ) _ _ _ f hf x y z hx hy hz
@@ -338,7 +341,7 @@ variables {γ : Type*} [linear_ordered_cancel_add_comm_monoid γ] [module ℝ γ
   {f : E → γ}
 
 -- could be shown without contradiction but yeah
-lemma convex_on.le_left_of_right_le' (hf : convex_on s f) {x y : E} {a b : ℝ}
+lemma convex_on.le_left_of_right_le' (hf : convex_on ℝ s f) {x y : E} {a b : ℝ}
   (hx : x ∈ s) (hy : y ∈ s) (ha : 0 < a) (hb : 0 ≤ b) (hab : a + b = 1)
   (hxy : f y ≤ f (a • x + b • y)) :
   f (a • x + b • y) ≤ f x :=
@@ -352,13 +355,13 @@ begin
     ... = f (a • x + b • y) : by rw [←add_smul, hab, one_smul],
 end
 
-lemma concave_on.left_le_of_le_right' (hf : concave_on s f) {x y : E} {a b : ℝ}
+lemma concave_on.left_le_of_le_right' (hf : concave_on ℝ s f) {x y : E} {a b : ℝ}
   (hx : x ∈ s) (hy : y ∈ s) (ha : 0 < a) (hb : 0 ≤ b) (hab : a + b = 1)
   (hxy : f (a • x + b • y) ≤ f y) :
   f x ≤ f (a • x + b • y) :=
 @convex_on.le_left_of_right_le' _ _ _ _ (order_dual γ) _ _ _ f hf x y a b hx hy ha hb hab hxy
 
-lemma convex_on.le_right_of_left_le' (hf : convex_on s f) {x y : E} {a b : ℝ}
+lemma convex_on.le_right_of_left_le' (hf : convex_on ℝ s f) {x y : E} {a b : ℝ}
   (hx : x ∈ s) (hy : y ∈ s) (ha : 0 ≤ a) (hb : 0 < b) (hab : a + b = 1)
   (hxy : f x ≤ f (a • x + b • y)) :
   f (a • x + b • y) ≤ f y :=
@@ -367,13 +370,13 @@ begin
   exact hf.le_left_of_right_le' hy hx hb ha hab hxy,
 end
 
-lemma concave_on.le_right_of_left_le' (hf : concave_on s f) {x y : E} {a b : ℝ}
+lemma concave_on.le_right_of_left_le' (hf : concave_on ℝ s f) {x y : E} {a b : ℝ}
   (hx : x ∈ s) (hy : y ∈ s) (ha : 0 ≤ a) (hb : 0 < b) (hab : a + b = 1)
   (hxy : f (a • x + b • y) ≤ f x) :
   f y ≤ f (a • x + b • y) :=
 @convex_on.le_right_of_left_le' _ _ _ _ (order_dual γ) _ _ _ f hf x y a b hx hy ha hb hab hxy
 
-lemma convex_on.le_left_of_right_le (hf : convex_on s f) {x y z : E} (hx : x ∈ s)
+lemma convex_on.le_left_of_right_le (hf : convex_on ℝ s f) {x y z : E} (hx : x ∈ s)
   (hy : y ∈ s) (hz : z ∈ open_segment ℝ x y) (hyz : f y ≤ f z) :
   f z ≤ f x :=
 begin
@@ -381,12 +384,12 @@ begin
   exact hf.le_left_of_right_le' hx hy ha hb.le hab hyz,
 end
 
-lemma concave_on.left_le_of_le_right (hf : concave_on s f) {x y z : E} (hx : x ∈ s)
+lemma concave_on.left_le_of_le_right (hf : concave_on ℝ s f) {x y z : E} (hx : x ∈ s)
   (hy : y ∈ s) (hz : z ∈ open_segment ℝ x y) (hyz : f z ≤ f y) :
   f x ≤ f z :=
 @convex_on.le_left_of_right_le _ _ _ _ (order_dual γ) _ _ _ f hf x y z hx hy hz hyz
 
-lemma convex_on.le_right_of_left_le (hf : convex_on s f) {x y z : E} (hx : x ∈ s)
+lemma convex_on.le_right_of_left_le (hf : convex_on ℝ s f) {x y z : E} (hx : x ∈ s)
   (hy : y ∈ s) (hz : z ∈ open_segment ℝ x y) (hxz : f x ≤ f z) :
   f z ≤ f y :=
 begin
@@ -394,14 +397,14 @@ begin
   exact hf.le_right_of_left_le' hx hy ha.le hb hab hxz,
 end
 
-lemma concave_on.le_right_of_left_le (hf : concave_on s f) {x y z : E} (hx : x ∈ s)
+lemma concave_on.le_right_of_left_le (hf : concave_on ℝ s f) {x y z : E} (hx : x ∈ s)
   (hy : y ∈ s) (hz : z ∈ open_segment ℝ x y) (hxz : f z ≤ f x) :
   f y ≤ f z :=
 @convex_on.le_right_of_left_le _ _ _ _ (order_dual γ) _ _ _ f hf x y z hx hy hz hxz
 
 end linear_order
 
-lemma convex_on.convex_le [ordered_smul ℝ β] {f : E → β} (hf : convex_on s f) (r : β) :
+lemma convex_on.convex_le [ordered_smul ℝ β] {f : E → β} (hf : convex_on ℝ s f) (r : β) :
   convex ℝ {x ∈ s | f x ≤ r} :=
 λ x y hx hy a b ha hb hab,
 begin
@@ -413,13 +416,13 @@ begin
                   ... ≤ r                     : by simp [←add_smul, hab]
 end
 
-lemma concave_on.concave_le [ordered_smul ℝ β] {f : E → β} (hf : concave_on s f) (r : β) :
+lemma concave_on.concave_le [ordered_smul ℝ β] {f : E → β} (hf : concave_on ℝ s f) (r : β) :
   convex ℝ {x ∈ s | r ≤ f x} :=
 @convex_on.convex_le _ (order_dual β) _ _ _ _ _ _ f hf r
 
 lemma convex_on.convex_lt {γ : Type*} [ordered_cancel_add_comm_monoid γ]
   [module ℝ γ] [ordered_smul ℝ γ]
-  {f : E → γ} (hf : convex_on s f) (r : γ) : convex ℝ {x ∈ s | f x < r} :=
+  {f : E → γ} (hf : convex_on ℝ s f) (r : γ) : convex ℝ {x ∈ s | f x < r} :=
 begin
   intros a b as bs xa xb hxa hxb hxaxb,
   refine ⟨hf.1 as.1 bs.1 hxa hxb hxaxb, _⟩,
@@ -439,12 +442,12 @@ end
 
 lemma concave_on.convex_lt {γ : Type*} [ordered_cancel_add_comm_monoid γ]
   [module ℝ γ] [ordered_smul ℝ γ]
-  {f : E → γ} (hf : concave_on s f) (r : γ) : convex ℝ {x ∈ s | r < f x} :=
+  {f : E → γ} (hf : concave_on ℝ s f) (r : γ) : convex ℝ {x ∈ s | r < f x} :=
 @convex_on.convex_lt _ _ _ _ (order_dual γ) _ _ _ f hf r
 
 lemma convex_on.convex_epigraph {γ : Type*} [ordered_add_comm_group γ]
   [module ℝ γ] [ordered_smul ℝ γ]
-  {f : E → γ} (hf : convex_on s f) :
+  {f : E → γ} (hf : convex_on ℝ s f) :
   convex ℝ {p : E × γ | p.1 ∈ s ∧ f p.1 ≤ p.2} :=
 begin
   rintros ⟨x, r⟩ ⟨y, t⟩ ⟨hx, hr⟩ ⟨hy, ht⟩ a b ha hb hab,
@@ -456,14 +459,14 @@ end
 
 lemma concave_on.convex_hypograph {γ : Type*} [ordered_add_comm_group γ]
   [module ℝ γ] [ordered_smul ℝ γ]
-  {f : E → γ} (hf : concave_on s f) :
+  {f : E → γ} (hf : concave_on ℝ s f) :
   convex ℝ {p : E × γ | p.1 ∈ s ∧ p.2 ≤ f p.1} :=
 @convex_on.convex_epigraph _ _ _ _ (order_dual γ) _ _ _ f hf
 
 lemma convex_on_iff_convex_epigraph {γ : Type*} [ordered_add_comm_group γ]
   [module ℝ γ] [ordered_smul ℝ γ]
   {f : E → γ} :
-  convex_on s f ↔ convex ℝ {p : E × γ | p.1 ∈ s ∧ f p.1 ≤ p.2} :=
+  convex_on ℝ s f ↔ convex ℝ {p : E × γ | p.1 ∈ s ∧ f p.1 ≤ p.2} :=
 begin
   refine ⟨convex_on.convex_epigraph, λ h, ⟨_, _⟩⟩,
   { assume x y hx hy a b ha hb hab,
@@ -475,20 +478,20 @@ end
 lemma concave_on_iff_convex_hypograph {γ : Type*} [ordered_add_comm_group γ]
   [module ℝ γ] [ordered_smul ℝ γ]
   {f : E → γ} :
-  concave_on s f ↔ convex ℝ {p : E × γ | p.1 ∈ s ∧ p.2 ≤ f p.1} :=
+  concave_on ℝ s f ↔ convex ℝ {p : E × γ | p.1 ∈ s ∧ p.2 ≤ f p.1} :=
 @convex_on_iff_convex_epigraph _ _ _ _ (order_dual γ) _ _ _ f
 
 /- A linear map is convex. -/
-lemma linear_map.convex_on (f : E →ₗ[ℝ] β) {s : set E} (hs : convex ℝ s) : convex_on s f :=
+lemma linear_map.convex_on (f : E →ₗ[ℝ] β) {s : set E} (hs : convex ℝ s) : convex_on ℝ s f :=
 ⟨hs, λ _ _ _ _ _ _ _ _ _, by rw [f.map_add, f.map_smul, f.map_smul]⟩
 
 /- A linear map is concave. -/
-lemma linear_map.concave_on (f : E →ₗ[ℝ] β) {s : set E} (hs : convex ℝ s) : concave_on s f :=
+lemma linear_map.concave_on (f : E →ₗ[ℝ] β) {s : set E} (hs : convex ℝ s) : concave_on ℝ s f :=
 ⟨hs, λ _ _ _ _ _ _ _ _ _, by rw [f.map_add, f.map_smul, f.map_smul]⟩
 
 /-- If a function is convex on `s`, it remains convex when precomposed by an affine map. -/
 lemma convex_on.comp_affine_map {f : F → β} (g : E →ᵃ[ℝ] F) {s : set F}
-  (hf : convex_on s f) : convex_on (g ⁻¹' s) (f ∘ g) :=
+  (hf : convex_on ℝ s f) : convex_on ℝ (g ⁻¹' s) (f ∘ g) :=
 begin
   refine ⟨hf.1.affine_preimage  _,_⟩,
   intros x y xs ys a b ha hb hab,
@@ -501,37 +504,37 @@ end
 
 /-- If a function is concave on `s`, it remains concave when precomposed by an affine map. -/
 lemma concave_on.comp_affine_map {f : F → β} (g : E →ᵃ[ℝ] F) {s : set F}
-  (hf : concave_on s f) : concave_on (g ⁻¹' s) (f ∘ g) :=
+  (hf : concave_on ℝ s f) : concave_on ℝ (g ⁻¹' s) (f ∘ g) :=
 @convex_on.comp_affine_map _ _ (order_dual β) _ _ _ _ _ _ f g s hf
 
 /-- If `g` is convex on `s`, so is `(g ∘ f)` on `f ⁻¹' s` for a linear `f`. -/
-lemma convex_on.comp_linear_map {g : F → β} {s : set F} (hg : convex_on s g) (f : E →ₗ[ℝ] F) :
-  convex_on (f ⁻¹' s) (g ∘ f) :=
+lemma convex_on.comp_linear_map {g : F → β} {s : set F} (hg : convex_on ℝ s g) (f : E →ₗ[ℝ] F) :
+  convex_on ℝ (f ⁻¹' s) (g ∘ f) :=
 hg.comp_affine_map f.to_affine_map
 
 /-- If `g` is concave on `s`, so is `(g ∘ f)` on `f ⁻¹' s` for a linear `f`. -/
-lemma concave_on.comp_linear_map {g : F → β} {s : set F} (hg : concave_on s g) (f : E →ₗ[ℝ] F) :
-  concave_on (f ⁻¹' s) (g ∘ f) :=
+lemma concave_on.comp_linear_map {g : F → β} {s : set F} (hg : concave_on ℝ s g) (f : E →ₗ[ℝ] F) :
+  concave_on ℝ (f ⁻¹' s) (g ∘ f) :=
 hg.comp_affine_map f.to_affine_map
 
 /-- If a function is convex on `s`, it remains convex after a translation. -/
-lemma convex_on.translate_right {f : E → β} {s : set E} {a : E} (hf : convex_on s f) :
-  convex_on ((λ z, a + z) ⁻¹' s) (f ∘ (λ z, a + z)) :=
+lemma convex_on.translate_right {f : E → β} {s : set E} {a : E} (hf : convex_on ℝ s f) :
+  convex_on ℝ ((λ z, a + z) ⁻¹' s) (f ∘ (λ z, a + z)) :=
 hf.comp_affine_map $ affine_map.const ℝ E a +ᵥ affine_map.id ℝ E
 
 /-- If a function is concave on `s`, it remains concave after a translation. -/
-lemma concave_on.translate_right {f : E → β} {s : set E} {a : E} (hf : concave_on s f) :
-  concave_on ((λ z, a + z) ⁻¹' s) (f ∘ (λ z, a + z)) :=
+lemma concave_on.translate_right {f : E → β} {s : set E} {a : E} (hf : concave_on ℝ s f) :
+  concave_on ℝ ((λ z, a + z) ⁻¹' s) (f ∘ (λ z, a + z)) :=
 hf.comp_affine_map $ affine_map.const ℝ E a +ᵥ affine_map.id ℝ E
 
 /-- If a function is convex on `s`, it remains convex after a translation. -/
-lemma convex_on.translate_left {f : E → β} {s : set E} {a : E} (hf : convex_on s f) :
-  convex_on ((λ z, a + z) ⁻¹' s) (f ∘ (λ z, z + a)) :=
+lemma convex_on.translate_left {f : E → β} {s : set E} {a : E} (hf : convex_on ℝ s f) :
+  convex_on ℝ ((λ z, a + z) ⁻¹' s) (f ∘ (λ z, z + a)) :=
 by simpa only [add_comm] using hf.translate_right
 
 /-- If a function is concave on `s`, it remains concave after a translation. -/
-lemma concave_on.translate_left {f : E → β} {s : set E} {a : E} (hf : concave_on s f) :
-  concave_on ((λ z, a + z) ⁻¹' s) (f ∘ (λ z, z + a)) :=
+lemma concave_on.translate_left {f : E → β} {s : set E} {a : E} (hf : concave_on ℝ s f) :
+  concave_on ℝ ((λ z, a + z) ⁻¹' s) (f ∘ (λ z, z + a)) :=
 by simpa only [add_comm] using hf.translate_right
 
 /-! ### Jensen's inequality -/
@@ -539,7 +542,7 @@ by simpa only [add_comm] using hf.translate_right
 variables {i j : ι} {c : ℝ} {t : finset ι} {w : ι → ℝ} {z : ι → E}
 
 /-- Convex **Jensen's inequality**, `finset.center_mass` version. -/
-lemma convex_on.map_center_mass_le {f : E → ℝ} (hf : convex_on s f)
+lemma convex_on.map_center_mass_le {f : E → ℝ} (hf : convex_on ℝ s f)
   (h₀ : ∀ i ∈ t, 0 ≤ w i) (hpos : 0 < ∑ i in t, w i)
   (hmem : ∀ i ∈ t, z i ∈ s) : f (t.center_mass w z) ≤ t.center_mass w (f ∘ z) :=
 begin
@@ -550,7 +553,7 @@ begin
 end
 
 /-- Convex **Jensen's inequality**, `finset.sum` version. -/
-lemma convex_on.map_sum_le {f : E → ℝ} (hf : convex_on s f)
+lemma convex_on.map_sum_le {f : E → ℝ} (hf : convex_on ℝ s f)
   (h₀ : ∀ i ∈ t, 0 ≤ w i) (h₁ : ∑ i in t, w i = 1)
   (hmem : ∀ i ∈ t, z i ∈ s) : f (∑ i in t, w i • z i) ≤ ∑ i in t, w i * (f (z i)) :=
 by simpa only [center_mass, h₁, inv_one, one_smul]
@@ -560,7 +563,7 @@ by simpa only [center_mass, h₁, inv_one, one_smul]
 
 /-- If a function `f` is convex on `s` takes value `y` at the center of mass of some points
 `z i ∈ s`, then for some `i` we have `y ≤ f (z i)`. -/
-lemma convex_on.exists_ge_of_center_mass {f : E → ℝ} (h : convex_on s f)
+lemma convex_on.exists_ge_of_center_mass {f : E → ℝ} (h : convex_on ℝ s f)
   (hw₀ : ∀ i ∈ t, 0 ≤ w i) (hws : 0 < ∑ i in t, w i) (hz : ∀ i ∈ t, z i ∈ s) :
   ∃ i ∈ t, f (t.center_mass w z) ≤ f (z i) :=
 begin
@@ -581,7 +584,7 @@ end
 
 /-- Maximum principle for convex functions. If a function `f` is convex on the convex hull of `s`,
 then `f` can't have a maximum on `convex_hull s` outside of `s`. -/
-lemma convex_on.exists_ge_of_mem_convex_hull {f : E → ℝ} (hf : convex_on (convex_hull ℝ s) f)
+lemma convex_on.exists_ge_of_mem_convex_hull {f : E → ℝ} (hf : convex_on ℝ (convex_hull ℝ s) f)
   {x} (hx : x ∈ convex_hull ℝ s) : ∃ y ∈ s, f x ≤ f y :=
 begin
   rw _root_.convex_hull_eq at hx,

--- a/src/analysis/convex/integral.lean
+++ b/src/analysis/convex/integral.lean
@@ -107,7 +107,7 @@ to `s`, then the value of `g` at the average value of `f` is less than or equal 
 of `g ∘ f` provided that both `f` and `g ∘ f` are integrable. See also `convex.map_center_mass_le`
 for a finite sum version of this lemma. -/
 lemma convex_on.map_smul_integral_le [is_finite_measure μ] {s : set E} {g : E → ℝ}
-  (hg : convex_on s g) (hgc : continuous_on g s) (hsc : is_closed s) (hμ : μ ≠ 0) {f : α → E}
+  (hg : convex_on ℝ s g) (hgc : continuous_on g s) (hsc : is_closed s) (hμ : μ ≠ 0) {f : α → E}
   (hfs : ∀ᵐ x ∂μ, f x ∈ s) (hfi : integrable f μ) (hgi : integrable (g ∘ f) μ) :
   g ((μ univ).to_real⁻¹ • ∫ x, f x ∂μ) ≤ (μ univ).to_real⁻¹ • ∫ x, g (f x) ∂μ :=
 begin
@@ -127,7 +127,7 @@ end
 of `g ∘ f` provided that both `f` and `g ∘ f` are integrable. See also `convex.map_sum_le` for a
 finite sum version of this lemma. -/
 lemma convex_on.map_integral_le [is_probability_measure μ] {s : set E} {g : E → ℝ}
-  (hg : convex_on s g) (hgc : continuous_on g s) (hsc : is_closed s) {f : α → E}
+  (hg : convex_on ℝ s g) (hgc : continuous_on g s) (hsc : is_closed s) {f : α → E}
   (hfs : ∀ᵐ x ∂μ, f x ∈ s) (hfi : integrable f μ) (hgi : integrable (g ∘ f) μ) :
   g (∫ x, f x ∂μ) ≤ ∫ x, g (f x) ∂μ :=
 by simpa [measure_univ]

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -108,7 +108,7 @@ begin
     exact mul_nonneg (sub_nonneg_of_le hp) (rpow_nonneg_of_nonneg (le_of_lt hx) _) }
 end
 
-lemma concave_on_log_Ioi : concave_on (Ioi 0) log :=
+lemma concave_on_log_Ioi : concave_on ℝ (Ioi 0) log :=
 begin
   have h₁ : Ioi 0 ⊆ ({0} : set ℝ)ᶜ,
   { intros x hx hx',
@@ -126,7 +126,7 @@ begin
     exact neg_nonpos.mpr (inv_nonneg.mpr (sq_nonneg x)) }
 end
 
-lemma concave_on_log_Iio : concave_on (Iio 0) log :=
+lemma concave_on_log_Iio : concave_on ℝ (Iio 0) log :=
 begin
   have h₁ : Iio 0 ⊆ ({0} : set ℝ)ᶜ,
   { intros x hx hx',

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -16,7 +16,7 @@ In this file we prove that the following functions are convex:
   is convex on $(-∞, +∞)$;
 * `convex_on_pow` : for a natural $n$, the function $f(x)=x^n$ is convex on $[0, +∞)$;
 * `convex_on_fpow` : for an integer $m$, the function $f(x)=x^m$ is convex on $(0, +∞)$.
-* `convex_on_rpow : ∀ p : ℝ, 1 ≤ p → convex_on (Ici 0) (λ x, x ^ p)`
+* `convex_on_rpow : ∀ p : ℝ, 1 ≤ p → convex_on ℝ (Ici 0) (λ x, x ^ p)`
 * `concave_on_log_Ioi` and `concave_on_log_Iio`: log is concave on `Ioi 0` and `Iio 0` respectively.
 -/
 
@@ -24,12 +24,12 @@ open real set
 open_locale big_operators
 
 /-- `exp` is convex on the whole real line -/
-lemma convex_on_exp : convex_on univ exp :=
+lemma convex_on_exp : convex_on ℝ univ exp :=
 convex_on_univ_of_deriv2_nonneg differentiable_exp (by simp)
   (assume x, (iter_deriv_exp 2).symm ▸ le_of_lt (exp_pos x))
 
 /-- `x^n`, `n : ℕ` is convex on the whole real line whenever `n` is even -/
-lemma convex_on_pow_of_even {n : ℕ} (hn : even n) : convex_on set.univ (λ x : ℝ, x^n) :=
+lemma convex_on_pow_of_even {n : ℕ} (hn : even n) : convex_on ℝ set.univ (λ x : ℝ, x^n) :=
 begin
   apply convex_on_univ_of_deriv2_nonneg differentiable_pow,
   { simp only [deriv_pow', differentiable.mul, differentiable_const, differentiable_pow] },
@@ -40,7 +40,7 @@ begin
 end
 
 /-- `x^n`, `n : ℕ` is convex on `[0, +∞)` for all `n` -/
-lemma convex_on_pow (n : ℕ) : convex_on (Ici 0) (λ x : ℝ, x^n) :=
+lemma convex_on_pow (n : ℕ) : convex_on ℝ (Ici 0) (λ x : ℝ, x^n) :=
 begin
   apply convex_on_of_deriv2_nonneg (convex_Ici _) (continuous_pow n).continuous_on
     differentiable_on_pow,
@@ -76,7 +76,7 @@ begin
 end
 
 /-- `x^m`, `m : ℤ` is convex on `(0, +∞)` for all `m` -/
-lemma convex_on_fpow (m : ℤ) : convex_on (Ioi 0) (λ x : ℝ, x^m) :=
+lemma convex_on_fpow (m : ℤ) : convex_on ℝ (Ioi 0) (λ x : ℝ, x^m) :=
 begin
   have : ∀ n : ℤ, differentiable_on ℝ (λ x, x ^ n) (Ioi (0 : ℝ)),
     from λ n, differentiable_on_fpow _ _ (or.inl $ lt_irrefl _),
@@ -91,7 +91,7 @@ begin
     exact int_prod_range_nonneg _ _ (nat.even_bit0 1) }
 end
 
-lemma convex_on_rpow {p : ℝ} (hp : 1 ≤ p) : convex_on (Ici 0) (λ x : ℝ, x^p) :=
+lemma convex_on_rpow {p : ℝ} (hp : 1 ≤ p) : convex_on ℝ (Ici 0) (λ x : ℝ, x^p) :=
 begin
   have A : deriv (λ (x : ℝ), x ^ p) = λ x, p * x^(p-1), by { ext x, simp [hp] },
   apply convex_on_of_deriv2_nonneg (convex_Ici 0),

--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -181,7 +181,7 @@ section normed_space
 variables [normed_group E] [normed_space ℝ E]
 
 lemma convex_on_dist (z : E) (s : set E) (hs : convex ℝ s) :
-  convex_on s (λz', dist z' z) :=
+  convex_on ℝ s (λz', dist z' z) :=
 and.intro hs $
 assume x y hx hy a b ha hb hab,
 calc


### PR DESCRIPTION
`convex_on` and `concave_on` are currently only defined for real vector spaces. This generalizes ℝ to an arbitrary `ordered_semiring` in the definition.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Parent PR is #9356

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
