### PR TITLE
[Merged by Bors] - feat(data/nat/choose/cast): Cast of binomial coefficients equals a Pochhammer polynomial

### DIFF
--- a/src/data/nat/choose/basic.lean
+++ b/src/data/nat/choose/basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Bhavik Mehta
 -/
-import data.nat.factorial
+import data.nat.factorial.basic
 
 /-!
 # Binomial coefficients

--- a/src/data/nat/choose/cast.lean
+++ b/src/data/nat/choose/cast.lean
@@ -31,9 +31,9 @@ lemma cast_add_choose {a b : ℕ} :
   ((a + b).choose a : K) = (a + b)! / (a! * b!) :=
 by rw [cast_choose K (le_add_right le_rfl), nat.add_sub_cancel_left]
 
-lemma cast_choose' (a b : ℕ) :
-  (a.choose b : K) = (pochhammer K b).eval (a - (b - 1) : ℕ) / b.factorial :=
-by rw [eq_div_iff_mul_eq (nat.cast_ne_zero.2 b.factorial_ne_zero : (b.factorial : K) ≠ 0),
+lemma cast_choose_eq_pochhammer_div (a b : ℕ) :
+  (a.choose b : K) = (pochhammer K b).eval (a - (b - 1) : ℕ) / b! :=
+by rw [eq_div_iff_mul_eq (nat.cast_ne_zero.2 b.factorial_ne_zero : (b! : K) ≠ 0),
   ←nat.cast_mul, mul_comm, ←nat.desc_factorial_eq_factorial_mul_choose, ←cast_desc_factorial]
 
 lemma cast_choose_two (a : ℕ) :

--- a/src/data/nat/choose/cast.lean
+++ b/src/data/nat/choose/cast.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2021 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import data.nat.factorial.cast
+
+/-!
+# Cast of binomial coefficients
+
+This file allows calculating the binomial coefficient `a.choose b` as an element of a division ring
+of characteristic `0`.
+-/
+
+open nat
+open_locale nat
+
+variables (K : Type*) [division_ring K] [char_zero K]
+
+lemma cast_choose {a b : ℕ} (h : a ≤ b) :
+  (b.choose a : K) = b! / (a! * (b - a)!) :=
+begin
+  have : ∀ {n : ℕ}, (n! : K) ≠ 0 := λ n, nat.cast_ne_zero.2 (factorial_ne_zero _),
+  rw eq_div_iff_mul_eq (mul_ne_zero this this),
+  rw_mod_cast [← mul_assoc, choose_mul_factorial_mul_factorial h],
+end
+
+lemma cast_add_choose {a b : ℕ} :
+  ((a + b).choose a : K) = (a + b)! / (a! * b!) :=
+by rw [cast_choose K (le_add_right le_rfl), nat.add_sub_cancel_left]
+
+lemma cast_choose' (a b : ℕ) :
+  (a.choose b : K) = (pochhammer K b).eval (a - (b - 1) : ℕ) / b.factorial :=
+by rw [eq_div_iff_mul_eq (nat.cast_ne_zero.2 b.factorial_ne_zero : (b.factorial : K) ≠ 0),
+  ←nat.cast_mul, mul_comm, ←nat.desc_factorial_eq_factorial_mul_choose, ←cast_desc_factorial]
+
+lemma cast_choose_two (a : ℕ) :
+  (a.choose 2 : K) = a * (a - 1) / 2 :=
+begin
+  rw [cast_choose', factorial_two, cast_two],
+  cases a,
+  { rw [nat.zero_sub, cast_zero, pochhammer_ne_zero_eval_zero _ (two_ne_zero), zero_mul] },
+  { rw [succ_sub_succ, nat.sub_zero, cast_succ, add_sub_cancel, pochhammer_succ_right,
+      pochhammer_one, polynomial.X_mul, polynomial.eval_mul_X, polynomial.eval_add,
+      polynomial.eval_X, cast_one, polynomial.eval_one] }
+end

--- a/src/data/nat/choose/cast.lean
+++ b/src/data/nat/choose/cast.lean
@@ -37,11 +37,5 @@ by rw [eq_div_iff_mul_eq (nat.cast_ne_zero.2 b.factorial_ne_zero : (b.factorial 
 
 lemma cast_choose_two (a : ℕ) :
   (a.choose 2 : K) = a * (a - 1) / 2 :=
-begin
-  rw [cast_choose', factorial_two, cast_two],
-  cases a,
-  { rw [nat.zero_sub, cast_zero, pochhammer_ne_zero_eval_zero _ (two_ne_zero), zero_mul] },
-  { rw [succ_sub_succ, nat.sub_zero, cast_succ, add_sub_cancel, pochhammer_succ_right,
-      pochhammer_one, polynomial.X_mul, polynomial.eval_mul_X, polynomial.eval_add,
-      polynomial.eval_X, cast_one, polynomial.eval_one] }
-end
+by rw [←cast_desc_factorial_two, desc_factorial_eq_factorial_mul_choose, factorial_two, mul_comm,
+    cast_mul, cast_two, eq_div_iff_mul_eq (two_ne_zero' : (2 : K) ≠ 0)]

--- a/src/data/nat/choose/cast.lean
+++ b/src/data/nat/choose/cast.lean
@@ -13,10 +13,11 @@ This file allows calculating the binomial coefficient `a.choose b` as an element
 of characteristic `0`.
 -/
 
-open nat
 open_locale nat
 
 variables (K : Type*) [division_ring K] [char_zero K]
+
+namespace nat
 
 lemma cast_choose {a b : ℕ} (h : a ≤ b) :
   (b.choose a : K) = b! / (a! * (b - a)!) :=
@@ -39,3 +40,5 @@ lemma cast_choose_two (a : ℕ) :
   (a.choose 2 : K) = a * (a - 1) / 2 :=
 by rw [←cast_desc_factorial_two, desc_factorial_eq_factorial_mul_choose, factorial_two, mul_comm,
     cast_mul, cast_two, eq_div_iff_mul_eq (two_ne_zero' : (2 : K) ≠ 0)]
+
+end nat

--- a/src/data/nat/choose/cast.lean
+++ b/src/data/nat/choose/cast.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import data.nat.choose.basic
 import data.nat.factorial.cast
 
 /-!

--- a/src/data/nat/choose/default.lean
+++ b/src/data/nat/choose/default.lean
@@ -1,2 +1,3 @@
 import data.nat.choose.dvd
+import data.nat.choose.cast
 import data.nat.choose.sum

--- a/src/data/nat/choose/dvd.lean
+++ b/src/data/nat/choose/dvd.lean
@@ -38,16 +38,4 @@ end
 
 end prime
 
-lemma cast_choose (K : Type*) [division_ring K] [char_zero K] {a b : ℕ} (h : a ≤ b) :
-  (b.choose a : K) = b! / (a! * (b - a)!) :=
-begin
-  have : ∀ {n : ℕ}, (n! : K) ≠ 0 := λ n, nat.cast_ne_zero.2 (factorial_ne_zero _),
-  rw [eq_div_iff_mul_eq (mul_ne_zero this this)],
-  rw_mod_cast [← mul_assoc, choose_mul_factorial_mul_factorial h],
-end
-
-lemma cast_add_choose (K : Type*) [division_ring K] [char_zero K] {a b : ℕ} :
-  ((a + b).choose a : K) = (a + b)! / (a! * b!) :=
-by rw [cast_choose K (le_add_right le_rfl), nat.add_sub_cancel_left]
-
 end nat

--- a/src/data/nat/factorial/basic.lean
+++ b/src/data/nat/factorial/basic.lean
@@ -312,6 +312,8 @@ lemma desc_factorial_self : ∀ n : ℕ, n.desc_factorial n = n!
   exact λ h _, h,
 end
 
+alias nat.desc_factorial_eq_zero_iff_lt ↔ _ nat.desc_factorial_of_lt
+
 lemma add_desc_factorial_eq_asc_factorial (n : ℕ) :
   ∀ k : ℕ, (n + k).desc_factorial k = n.asc_factorial k
 | 0        := by rw [asc_factorial_zero, desc_factorial_zero]

--- a/src/data/nat/factorial/basic.lean
+++ b/src/data/nat/factorial/basic.lean
@@ -39,6 +39,8 @@ variables {m n : ℕ}
 
 @[simp] theorem factorial_one : 1! = 1 := rfl
 
+@[simp] theorem factorial_two : 2! = 2 := rfl
+
 theorem mul_factorial_pred (hn : 0 < n) : n * (n - 1)! = n! :=
 nat.sub_add_cancel hn ▸ rfl
 

--- a/src/data/nat/factorial/cast.lean
+++ b/src/data/nat/factorial/cast.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2021 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import data.nat.choose.basic
+import ring_theory.polynomial.pochhammer
+
+/-!
+# Cast of factorials
+
+This file allows calculating factorials (including ascending and descending ones) as elements of a semiring.
+-/
+
+open nat
+open_locale nat
+
+variables  (S : Type*) [semiring S] (a b : ℕ)
+
+lemma cast_asc_factorial :
+  (a.asc_factorial b : S) = (pochhammer S b).eval (a + 1) :=
+by rw [←pochhammer_nat_eq_asc_factorial, pochhammer_eval_cast, nat.cast_add, nat.cast_one]
+
+lemma cast_desc_factorial :
+  (a.desc_factorial b : S) = (pochhammer S b).eval (a - (b - 1) : ℕ) :=
+begin
+  rw [←pochhammer_eval_cast, pochhammer_nat_eq_desc_factorial],
+  cases b,
+  { simp_rw desc_factorial_zero },
+  simp_rw succ_sub_one,
+  obtain h | h := le_total a b,
+  { rw [desc_factorial_of_lt (lt_succ_of_le h), desc_factorial_of_lt (lt_succ_of_le _)],
+    rw [sub_eq_zero_of_le h, zero_add] },
+  { rw nat.sub_add_cancel h }
+end
+
+lemma cast_factorial :
+  (a! : S) = (pochhammer S b).eval 1 :=
+by rw [←zero_asc_factorial, cast_asc_factorial, zero_add]
+
+lemma cast_desc_factorial_two :
+  (a.desc_factorial 2 : S) = a * (a - 1) :=
+sorry

--- a/src/data/nat/factorial/cast.lean
+++ b/src/data/nat/factorial/cast.lean
@@ -12,10 +12,14 @@ This file allows calculating factorials (including ascending and descending ones
 semiring.
 -/
 
-open nat
 open_locale nat
 
-variables  (S : Type*) [semiring S] (a b : ℕ)
+variables (S : Type*)
+
+namespace nat
+
+section semiring
+variables [semiring S] (a b : ℕ)
 
 lemma cast_asc_factorial :
   (a.asc_factorial b : S) = (pochhammer S b).eval (a + 1) :=
@@ -27,17 +31,33 @@ begin
   rw [←pochhammer_eval_cast, pochhammer_nat_eq_desc_factorial],
   cases b,
   { simp_rw desc_factorial_zero },
-  simp_rw succ_sub_one,
+  simp_rw [add_succ, succ_sub_one],
   obtain h | h := le_total a b,
   { rw [desc_factorial_of_lt (lt_succ_of_le h), desc_factorial_of_lt (lt_succ_of_le _)],
-    rw [sub_eq_zero_of_le h, zero_add] },
+    rw [nat.sub_eq_zero_of_le h, zero_add] },
   { rw nat.sub_add_cancel h }
 end
 
 lemma cast_factorial :
-  (a! : S) = (pochhammer S b).eval 1 :=
-by rw [←zero_asc_factorial, cast_asc_factorial, zero_add]
+  (a! : S) = (pochhammer S a).eval 1 :=
+by rw [←zero_asc_factorial, cast_asc_factorial, cast_zero, zero_add]
+
+end semiring
+
+section ring
+variables [ring S] (a b : ℕ)
 
 lemma cast_desc_factorial_two :
   (a.desc_factorial 2 : S) = a * (a - 1) :=
-sorry
+begin
+  rw cast_desc_factorial,
+  cases a,
+  { rw [nat.zero_sub, cast_zero, pochhammer_ne_zero_eval_zero _ (two_ne_zero), zero_mul] },
+  { rw [succ_sub_succ, nat.sub_zero, cast_succ, add_sub_cancel, pochhammer_succ_right,
+      pochhammer_one, polynomial.X_mul, polynomial.eval_mul_X, polynomial.eval_add,
+      polynomial.eval_X, cast_one, polynomial.eval_one] }
+end
+
+end ring
+
+end nat

--- a/src/data/nat/factorial/cast.lean
+++ b/src/data/nat/factorial/cast.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import data.nat.choose.basic
 import ring_theory.polynomial.pochhammer
 
 /-!

--- a/src/data/nat/factorial/cast.lean
+++ b/src/data/nat/factorial/cast.lean
@@ -9,7 +9,8 @@ import ring_theory.polynomial.pochhammer
 /-!
 # Cast of factorials
 
-This file allows calculating factorials (including ascending and descending ones) as elements of a semiring.
+This file allows calculating factorials (including ascending and descending ones) as elements of a
+semiring.
 -/
 
 open nat

--- a/src/data/nat/factorial/cast.lean
+++ b/src/data/nat/factorial/cast.lean
@@ -10,6 +10,11 @@ import ring_theory.polynomial.pochhammer
 
 This file allows calculating factorials (including ascending and descending ones) as elements of a
 semiring.
+
+This is particularly crucial for `nat.desc_factorial` as substraction on `ℕ` does **not** correspond
+to substraction on a general semiring. For example, we can't rely on existing cast lemmas to prove
+`↑(a.desc_factorial 2) = ↑a * (↑a - 1)`. We must use the fact that, whenever `↑(a - 1)` is not equal
+to `↑a - 1`, the other factor is `0` anyway.
 -/
 
 open_locale nat

--- a/src/data/nat/factorial/cast.lean
+++ b/src/data/nat/factorial/cast.lean
@@ -52,6 +52,8 @@ end semiring
 section ring
 variables [ring S] (a b : ℕ)
 
+/-- Convenience lemma. The `a - 1` is not using truncated substraction, as opposed to the definition
+of `nat.desc_factorial` as a natural. -/
 lemma cast_desc_factorial_two :
   (a.desc_factorial 2 : S) = a * (a - 1) :=
 begin

--- a/src/data/polynomial/hasse_deriv.lean
+++ b/src/data/polynomial/hasse_deriv.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 
-import data.polynomial.derivative
+import data.nat.choose.cast
 import data.nat.choose.vandermonde
+import data.polynomial.derivative
 
 /-!
 # Hasse derivative of polynomials

--- a/src/number_theory/bernoulli_polynomials.lean
+++ b/src/number_theory/bernoulli_polynomials.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Ashvni Narayanan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ashvni Narayanan
 -/
-
+import data.nat.choose.cast
 import number_theory.bernoulli
 
 /-!

--- a/src/ring_theory/polynomial/pochhammer.lean
+++ b/src/ring_theory/polynomial/pochhammer.lean
@@ -10,7 +10,7 @@ import data.polynomial.eval
 # The Pochhammer polynomials
 
 We define and prove some basic relations about
-`pochhammer S n : polynomial S := X * (X+1) * ... * (X + n - 1)`
+`pochhammer S n : polynomial S := X * (X + 1) * ... * (X + n - 1)`
 which is also known as the rising factorial. A version of this definition
 that is focused on `nat` can be found in `data.nat.factorial` as `asc_factorial`.
 
@@ -117,7 +117,7 @@ lemma pochhammer_nat_eq_desc_factorial (a b : ℕ) :
 begin
   cases b,
   { rw [nat.desc_factorial_zero, pochhammer_zero, polynomial.eval_one] },
-  rw [nat.succ_sub_succ, nat.sub_zero],
+  rw [nat.add_succ, nat.succ_sub_succ, nat.sub_zero],
   cases a,
   { rw [pochhammer_ne_zero_eval_zero _ b.succ_ne_zero, zero_add,
     nat.desc_factorial_of_lt b.lt_succ_self] },

--- a/src/ring_theory/polynomial/pochhammer.lean
+++ b/src/ring_theory/polynomial/pochhammer.lean
@@ -10,7 +10,7 @@ import data.polynomial.eval
 # The Pochhammer polynomials
 
 We define and prove some basic relations about
-`pochhammer S n : polynomial S = X * (X+1) * ... * (X + n - 1)`
+`pochhammer S n : polynomial S := X * (X+1) * ... * (X + n - 1)`
 which is also known as the rising factorial. A version of this definition
 that is focused on `nat` can be found in `data.nat.factorial` as `asc_factorial`.
 
@@ -29,7 +29,7 @@ universes u v
 
 open polynomial
 
-section
+section semiring
 variables (S : Type u) [semiring S]
 
 /--
@@ -112,9 +112,32 @@ lemma pochhammer_nat_eq_asc_factorial (n : ℕ) :
   rw [nat.asc_factorial_succ, add_right_comm, mul_comm]
 end
 
+lemma pochhammer_nat_eq_desc_factorial (a b : ℕ) :
+  (pochhammer ℕ b).eval a = (a + b - 1).desc_factorial b :=
+begin
+  cases b,
+  { rw [nat.desc_factorial_zero, pochhammer_zero, polynomial.eval_one] },
+  rw [nat.succ_sub_succ, nat.sub_zero],
+  cases a,
+  { rw [pochhammer_ne_zero_eval_zero _ b.succ_ne_zero, zero_add,
+    nat.desc_factorial_of_lt b.lt_succ_self] },
+  { rw [nat.succ_add, ←nat.add_succ, nat.add_desc_factorial_eq_asc_factorial,
+      pochhammer_nat_eq_asc_factorial] }
 end
 
-section
+end semiring
+
+section comm_semiring
+variables {S : Type*} [comm_semiring S]
+
+lemma pochhammer_succ_eval (n : ℕ) (k : S) :
+  (pochhammer S n.succ).eval k = (pochhammer S n).eval k * (k + ↑n) :=
+by rw [pochhammer_succ_right, polynomial.eval_mul, polynomial.eval_add, polynomial.eval_X,
+    polynomial.eval_nat_cast]
+
+end comm_semiring
+
+section ordered_semiring
 variables {S : Type*} [ordered_semiring S] [nontrivial S]
 
 lemma pochhammer_pos (n : ℕ) (s : S) (h : 0 < s) : 0 < (pochhammer S n).eval s :=
@@ -127,7 +150,7 @@ begin
       (lt_of_lt_of_le h ((le_add_iff_nonneg_right _).mpr (nat.cast_nonneg n))), }
 end
 
-end
+end ordered_semiring
 
 section factorial
 


### PR DESCRIPTION
This adds some glue between `nat.factorial`/`nat.asc_factorial`/`nat.desc_factorial` and `pochhammer` to provide some API to calculate binomial coefficients in a semiring. For example, `n.choose 2` as a real is `n * (n - 1)/2`.

I also move files as such:
* create `data.nat.choose.cast`
* create `data.nat.factorial.cast`
* rename `data.nat.factorial` to `data.nat.factorial.basic`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
