### PR TITLE
[Merged by Bors] - chore(order): globally replace "antimono" with "antitone"

### DIFF
--- a/src/algebra/lie/solvable.lean
+++ b/src/algebra/lie/solvable.lean
@@ -95,7 +95,7 @@ derived_series_of_ideal_le (le_refl I) (zero_le k)
 lemma derived_series_of_ideal_mono {I J : lie_ideal R L} (h : I ≤ J) (k : ℕ) : D k I ≤ D k J :=
 derived_series_of_ideal_le h (le_refl k)
 
-lemma derived_series_of_ideal_antimono {k l : ℕ} (h : l ≤ k) : D k I ≤ D l I :=
+lemma derived_series_of_ideal_antitone {k l : ℕ} (h : l ≤ k) : D k I ≤ D l I :=
 derived_series_of_ideal_le (le_refl I) h
 
 lemma derived_series_of_ideal_add_le_add (J : lie_ideal R L) (k l : ℕ) :
@@ -300,7 +300,7 @@ begin
   { intros k₁ k₂ h₁₂ h₁,
     suffices : derived_series_of_ideal R L k₂ I ≤ ⊥, { exact eq_bot_iff.mpr this, },
     change derived_series_of_ideal R L k₁ I = ⊥ at h₁, rw ← h₁,
-    exact derived_series_of_ideal_antimono I h₁₂, },
+    exact derived_series_of_ideal_antitone I h₁₂, },
   exact nat.Inf_upward_closed_eq_succ_iff hs k,
 end
 

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -49,8 +49,8 @@ In this file we prove the following facts:
   `convex.image_sub_le_mul_sub_of_deriv_le`, `convex.mul_sub_le_image_sub_of_le_deriv`,
   if `∀ x, C (</≤/>/≥) (f' x)`, then `C * (y - x) (</≤/>/≥) (f y - f x)` whenever `x < y`.
 
-* `convex.mono_of_deriv_nonneg`, `convex.antimono_of_deriv_nonpos`,
-  `convex.strict_mono_of_deriv_pos`, `convex.strict_antimono_of_deriv_neg` :
+* `convex.mono_of_deriv_nonneg`, `convex.antitone_of_deriv_nonpos`,
+  `convex.strict_mono_of_deriv_pos`, `convex.strict_antitone_of_deriv_neg` :
   if the derivative of a function is non-negative/non-positive/positive/negative, then
   the function is monotone/monotonically decreasing/strictly monotone/strictly monotonically
   decreasing.
@@ -938,7 +938,7 @@ theorem mono_of_deriv_nonneg {f : ℝ → ℝ} (hf : differentiable ℝ f) (hf' 
 /-- Let `f` be a function continuous on a convex (or, equivalently, connected) subset `D`
 of the real line. If `f` is differentiable on the interior of `D` and `f'` is negative, then
 `f` is a strictly monotonically decreasing function on `D`. -/
-theorem convex.strict_antimono_of_deriv_neg {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
+theorem convex.strict_antitone_of_deriv_neg {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
   (hf : continuous_on f D) (hf' : differentiable_on ℝ f (interior D))
   (hf'_neg : ∀ x ∈ interior D, deriv f x < 0) :
   ∀ x y ∈ D, x < y → f y < f x :=
@@ -946,16 +946,16 @@ by simpa only [zero_mul, sub_lt_zero] using hD.image_sub_lt_mul_sub_of_deriv_lt 
 
 /-- Let `f : ℝ → ℝ` be a differentiable function. If `f'` is negative, then
 `f` is a strictly monotonically decreasing function. -/
-theorem strict_antimono_of_deriv_neg {f : ℝ → ℝ} (hf : differentiable ℝ f)
+theorem strict_antitone_of_deriv_neg {f : ℝ → ℝ} (hf : differentiable ℝ f)
   (hf' : ∀ x, deriv f x < 0) :
   ∀ ⦃x y⦄, x < y → f y < f x :=
-λ x y hxy, convex_univ.strict_antimono_of_deriv_neg hf.continuous.continuous_on hf.differentiable_on
+λ x y hxy, convex_univ.strict_antitone_of_deriv_neg hf.continuous.continuous_on hf.differentiable_on
   (λ x _, hf' x) x y trivial trivial hxy
 
 /-- Let `f` be a function continuous on a convex (or, equivalently, connected) subset `D`
 of the real line. If `f` is differentiable on the interior of `D` and `f'` is nonpositive, then
 `f` is a monotonically decreasing function on `D`. -/
-theorem convex.antimono_of_deriv_nonpos {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
+theorem convex.antitone_of_deriv_nonpos {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
   (hf : continuous_on f D) (hf' : differentiable_on ℝ f (interior D))
   (hf'_nonpos : ∀ x ∈ interior D, deriv f x ≤ 0) :
   ∀ x y ∈ D, x ≤ y → f y ≤ f x :=
@@ -963,9 +963,9 @@ by simpa only [zero_mul, sub_nonpos] using hD.image_sub_le_mul_sub_of_deriv_le h
 
 /-- Let `f : ℝ → ℝ` be a differentiable function. If `f'` is nonpositive, then
 `f` is a monotonically decreasing function. -/
-theorem antimono_of_deriv_nonpos {f : ℝ → ℝ} (hf : differentiable ℝ f) (hf' : ∀ x, deriv f x ≤ 0) :
+theorem antitone_of_deriv_nonpos {f : ℝ → ℝ} (hf : differentiable ℝ f) (hf' : ∀ x, deriv f x ≤ 0) :
   ∀ ⦃x y⦄, x ≤ y → f y ≤ f x :=
-λ x y hxy, convex_univ.antimono_of_deriv_nonpos hf.continuous.continuous_on hf.differentiable_on
+λ x y hxy, convex_univ.antitone_of_deriv_nonpos hf.continuous.continuous_on hf.differentiable_on
   (λ x _, hf' x) x y trivial trivial hxy
 
 /-- If a function `f` is continuous on a convex set `D ⊆ ℝ`, is differentiable on its interior,
@@ -996,7 +996,7 @@ end
 
 /-- If a function `f` is continuous on a convex set `D ⊆ ℝ`, is differentiable on its interior,
 and `f'` is antimonotone on the interior, then `f` is concave on `D`. -/
-theorem concave_on_of_deriv_antimono {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
+theorem concave_on_of_deriv_antitone {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
   (hf : continuous_on f D) (hf' : differentiable_on ℝ f (interior D))
   (hf'_mono : ∀ x y ∈ interior D, x ≤ y → deriv f y ≤ deriv f x) :
   concave_on ℝ D f :=
@@ -1016,10 +1016,10 @@ convex_on_of_deriv_mono convex_univ hf.continuous.continuous_on hf.differentiabl
   (λ x y _ _ h, hf'_mono h)
 
 /-- If a function `f` is differentiable and `f'` is antimonotone on `ℝ` then `f` is concave. -/
-theorem concave_on_univ_of_deriv_antimono {f : ℝ → ℝ} (hf : differentiable ℝ f)
-  (hf'_antimono : ∀⦃a b⦄, a ≤ b → (deriv f) b ≤ (deriv f) a) : concave_on ℝ univ f :=
-concave_on_of_deriv_antimono convex_univ hf.continuous.continuous_on hf.differentiable_on
-  (λ x y _ _ h, hf'_antimono h)
+theorem concave_on_univ_of_deriv_antitone {f : ℝ → ℝ} (hf : differentiable ℝ f)
+  (hf'_antitone : ∀⦃a b⦄, a ≤ b → (deriv f) b ≤ (deriv f) a) : concave_on ℝ univ f :=
+concave_on_of_deriv_antitone convex_univ hf.continuous.continuous_on hf.differentiable_on
+  (λ x y _ _ h, hf'_antitone h)
 
 /-- If a function `f` is continuous on a convex set `D ⊆ ℝ`, is twice differentiable on its
 interior, and `f''` is nonnegative on the interior, then `f` is convex on `D`. -/
@@ -1040,9 +1040,9 @@ theorem concave_on_of_deriv2_nonpos {D : set ℝ} (hD : convex ℝ D) {f : ℝ �
   (hf'' : differentiable_on ℝ (deriv f) (interior D))
   (hf''_nonpos : ∀ x ∈ interior D, (deriv^[2] f x) ≤ 0) :
   concave_on ℝ D f :=
-concave_on_of_deriv_antimono hD hf hf' $
+concave_on_of_deriv_antitone hD hf hf' $
 assume x y hx hy hxy,
-hD.interior.antimono_of_deriv_nonpos hf''.continuous_on (by rwa [interior_interior])
+hD.interior.antitone_of_deriv_nonpos hf''.continuous_on (by rwa [interior_interior])
   (by rwa [interior_interior]) _ _ hx hy hxy
 
 /-- If a function `f` is twice differentiable on a open convex set `D ⊆ ℝ` and

--- a/src/analysis/special_functions/integrals.lean
+++ b/src/analysis/special_functions/integrals.lean
@@ -341,7 +341,7 @@ begin
   linarith,
 end
 
-lemma integral_sin_pow_antimono : ∫ x in 0..π, sin x ^ (n + 1) ≤ ∫ x in 0..π, sin x ^ n :=
+lemma integral_sin_pow_antitone : ∫ x in 0..π, sin x ^ (n + 1) ≤ ∫ x in 0..π, sin x ^ n :=
 let H := λ x h, pow_le_pow_of_le_one (sin_nonneg_of_mem_Icc h) (sin_le_one x) (n.le_add_right 1) in
 by refine integral_mono_on pi_pos.le _ _ H; exact (continuous_sin.pow _).interval_integrable 0 π
 

--- a/src/data/real/pi/wallis.lean
+++ b/src/data/real/pi/wallis.lean
@@ -16,7 +16,7 @@ lemma integral_sin_pow_div_tendsto_one :
   tendsto (λ k, (∫ x in 0..π, sin x ^ (2 * k + 1)) / ∫ x in 0..π, sin x ^ (2 * k)) at_top (𝓝 1) :=
 begin
   have h₃ : ∀ n, (∫ x in 0..π, sin x ^ (2 * n + 1)) / ∫ x in 0..π, sin x ^ (2 * n) ≤ 1 :=
-    λ n, (div_le_one (integral_sin_pow_pos _)).mpr (integral_sin_pow_antimono _),
+    λ n, (div_le_one (integral_sin_pow_pos _)).mpr (integral_sin_pow_antitone _),
   have h₄ :
     ∀ n, (∫ x in 0..π, sin x ^ (2 * n + 1)) / ∫ x in 0..π, sin x ^ (2 * n) ≥ 2 * n / (2 * n + 1),
   { rintro ⟨n⟩,
@@ -25,7 +25,7 @@ begin
     calc (∫ x in 0..π, sin x ^ (2 * n.succ + 1)) / ∫ x in 0..π, sin x ^ (2 * n.succ) ≥
       (∫ x in 0..π, sin x ^ (2 * n.succ + 1)) / ∫ x in 0..π, sin x ^ (2 * n + 1) :
       by { refine div_le_div (integral_sin_pow_pos _).le (le_refl _) (integral_sin_pow_pos _) _,
-        convert integral_sin_pow_antimono (2 * n + 1) using 1 }
+        convert integral_sin_pow_antitone (2 * n + 1) using 1 }
     ... = 2 * ↑(n.succ) / (2 * ↑(n.succ) + 1) :
       by { rw div_eq_iff (integral_sin_pow_pos (2 * n + 1)).ne',
            convert integral_sin_pow (2 * n + 1), simp with field_simps, norm_cast } },

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -278,7 +278,7 @@ begin
     exact general_commutator_normal (lower_central_series G d) ⊤ },
 end
 
-lemma lower_central_series_antimono {m n : ℕ} (h : n ≤ m) :
+lemma lower_central_series_antitone {m n : ℕ} (h : n ≤ m) :
   lower_central_series G m ≤ lower_central_series G n :=
 begin
   refine @monotone_nat_of_le_succ (order_dual (subgroup G)) _ _ _ _ _ h,

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -826,12 +826,12 @@ lemma ae_measurable_restrict_of_monotone_on [linear_order β] [order_closed_topo
 have this : monotone (f ∘ coe : s → α), from λ ⟨x, hx⟩ ⟨y, hy⟩ (hxy : x ≤ y), hf hx hy hxy,
 ae_measurable_restrict_of_measurable_subtype hs this.measurable
 
-lemma measurable_of_antimono [linear_order β] [order_closed_topology β] {f : β → α}
+lemma measurable_of_antitone [linear_order β] [order_closed_topology β] {f : β → α}
   (hf : ∀ ⦃x y : β⦄, x ≤ y → f y ≤ f x) :
   measurable f :=
 @measurable_of_monotone (order_dual α) β _ _ ‹_› _ _ _ _ _ ‹_› _ _ _ hf
 
-lemma ae_measurable_restrict_of_antimono_on [linear_order β] [order_closed_topology β]
+lemma ae_measurable_restrict_of_antitone_on [linear_order β] [order_closed_topology β]
   {μ : measure β} {s : set β} (hs : measurable_set s) {f : β → α}
   (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → x ≤ y → f y ≤ f x) : ae_measurable f (μ.restrict s) :=
 @ae_measurable_restrict_of_monotone_on (order_dual α) β _ _ ‹_› _ _ _ _ _ ‹_› _ _ _ _ hs _ hf
@@ -1424,7 +1424,7 @@ variables [measurable_space β] [metric_space β] [borel_space β]
 open metric
 
 /-- A limit (over a general filter) of measurable `ℝ≥0` valued functions is measurable.
-The assumption `hs` can be dropped using `filter.is_countably_generated.has_antimono_basis`, but we
+The assumption `hs` can be dropped using `filter.is_countably_generated.has_antitone_basis`, but we
 don't need that case yet. -/
 lemma measurable_of_tendsto_nnreal' {ι ι'} {f : ι → α → ℝ≥0} {g : α → ℝ≥0} (u : filter ι)
   [ne_bot u] (hf : ∀ i, measurable (f i)) (lim : tendsto f u (𝓝 g)) {p : ι' → Prop}
@@ -1444,7 +1444,7 @@ lemma measurable_of_tendsto_nnreal {f : ℕ → α → ℝ≥0} {g : α → ℝ�
 measurable_of_tendsto_nnreal' at_top hf lim at_top_countable_basis (λ i, countable_encodable _)
 
 /-- A limit (over a general filter) of measurable functions valued in a metric space is measurable.
-The assumption `hs` can be dropped using `filter.is_countably_generated.has_antimono_basis`, but we
+The assumption `hs` can be dropped using `filter.is_countably_generated.has_antitone_basis`, but we
 don't need that case yet. -/
 lemma measurable_of_tendsto_metric' {ι ι'} {f : ι → α → β} {g : α → β}
   (u : filter ι) [ne_bot u] (hf : ∀ i, measurable (f i)) (lim : tendsto f u (𝓝 g)) {p : ι' → Prop}

--- a/src/measure_theory/function/ess_sup.lean
+++ b/src/measure_theory/function/ess_sup.lean
@@ -112,7 +112,7 @@ begin
   all_goals { is_bounded_default, },
 end
 
-lemma ess_inf_antimono_measure {f : α → β} (hμν : μ ≪ ν) : ess_inf f ν ≤ ess_inf f μ :=
+lemma ess_inf_antitone_measure {f : α → β} (hμν : μ ≪ ν) : ess_inf f ν ≤ ess_inf f μ :=
 begin
   refine liminf_le_liminf_of_le (measure.ae_le_iff_absolutely_continuous.mpr hμν) _ _,
   all_goals { is_bounded_default, },

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -1237,7 +1237,7 @@ lemma mem_Lp_iff_snorm_lt_top {f : α →ₘ[μ] E} : f ∈ Lp E p μ ↔ snorm 
 lemma mem_Lp_iff_mem_ℒp {f : α →ₘ[μ] E} : f ∈ Lp E p μ ↔ mem_ℒp f p μ :=
 by simp [mem_Lp_iff_snorm_lt_top, mem_ℒp, f.measurable.ae_measurable]
 
-lemma antimono [is_finite_measure μ] {p q : ℝ≥0∞} (hpq : p ≤ q) : Lp E q μ ≤ Lp E p μ :=
+lemma antitone [is_finite_measure μ] {p q : ℝ≥0∞} (hpq : p ≤ q) : Lp E q μ ≤ Lp E p μ :=
 λ f hf, (mem_ℒp.mem_ℒp_of_exponent_le ⟨f.ae_measurable, hf⟩ hpq).2
 
 @[simp] lemma coe_fn_mk {f : α →ₘ[μ] E} (hf : snorm f p μ < ∞) :

--- a/src/measure_theory/integral/integrable_on.lean
+++ b/src/measure_theory/integral/integrable_on.lean
@@ -459,7 +459,7 @@ begin
     exact integrable_on_empty }
 end
 
-lemma integrable_on_compact_of_antimono_on (hmono : ∀ ⦃x y⦄, x ∈ s → y ∈ s → x ≤ y → f y ≤ f x) :
+lemma integrable_on_compact_of_antitone_on (hmono : ∀ ⦃x y⦄, x ∈ s → y ∈ s → x ≤ y → f y ≤ f x) :
   integrable_on f s μ :=
 @integrable_on_compact_of_monotone_on α (order_dual E) _ _ ‹_› _ _ ‹_› _ _ _ _ ‹_› _ _ _ hs _
   hmono
@@ -470,7 +470,7 @@ integrable_on_compact_of_monotone_on hs (λ x y _ _ hxy, hmono hxy)
 
 alias integrable_on_compact_of_monotone ← monotone.integrable_on_compact
 
-lemma integrable_on_compact_of_antimono (hmono : ∀ ⦃x y⦄, x ≤ y → f y ≤ f x) :
+lemma integrable_on_compact_of_antitone (hmono : ∀ ⦃x y⦄, x ≤ y → f y ≤ f x) :
   integrable_on f s μ :=
 @integrable_on_compact_of_monotone α (order_dual E) _ _ ‹_› _ _ ‹_› _ _ _ _ ‹_› _ _ _ hs _
   hmono

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -389,7 +389,7 @@ begin
   exact (integrable_on_compact_of_monotone_on is_compact_interval hu).mono_set Ioc_subset_Icc_self,
 end
 
-lemma interval_integrable_of_antimono_on {u : ι → E} {a b : ι}
+lemma interval_integrable_of_antitone_on {u : ι → E} {a b : ι}
   (hu : ∀ ⦃x y⦄, x ∈ interval a b → y ∈ interval a b → x ≤ y → u y ≤ u x) :
   interval_integrable u μ a b :=
 @interval_integrable_of_monotone_on (order_dual E) _ ‹_› ι _ _ _ _ _ _ _ _ _ ‹_› ‹_› u a b hu
@@ -400,7 +400,7 @@ interval_integrable_of_monotone_on (λ x y _ _ hxy, hu hxy)
 
 alias interval_integrable_of_monotone ← monotone.interval_integrable
 
-lemma interval_integrable_of_antimono {u : ι → E} {a b : ι}
+lemma interval_integrable_of_antitone {u : ι → E} {a b : ι}
   (hu : ∀ ⦃x y⦄, x ≤ y → u y ≤ u x) :
   interval_integrable u μ a b :=
 @interval_integrable_of_monotone (order_dual E) _ ‹_› ι _ _ _ _ _ _ _ _ _ ‹_› ‹_› u a b hu

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -480,7 +480,7 @@ variables {μ : measure α}
   [measurable_space E] [normed_group E] [borel_space E] [complete_space E] [normed_space ℝ E]
   [second_countable_topology E] {s : ℕ → set α} {f : α → E}
 
-lemma tendsto_set_integral_of_antimono (hsm : ∀ i, measurable_set (s i))
+lemma tendsto_set_integral_of_antitone (hsm : ∀ i, measurable_set (s i))
   (h_mono : ∀ i j, i ≤ j → s j ⊆ s i) (hfi : integrable_on f (s 0) μ) :
   tendsto (λi, ∫ a in s i, f a ∂μ) at_top (𝓝 (∫ a in (⋂ n, s n), f a ∂μ)) :=
 begin
@@ -500,7 +500,7 @@ begin
   { simp_rw norm_indicator_eq_indicator_norm,
     refine λ n, eventually_of_forall (λ x, _),
     exact indicator_le_indicator_of_subset (h_mono 0 n (zero_le n)) (λ a, norm_nonneg _) _, },
-  { filter_upwards [] λa, le_trans (tendsto_indicator_of_antimono _ h_mono _ _) (pure_le_nhds _), },
+  { filter_upwards [] λa, le_trans (tendsto_indicator_of_antitone _ h_mono _ _) (pure_le_nhds _), },
 end
 
 end tendsto_mono

--- a/src/measure_theory/integral/vitali_caratheodory.lean
+++ b/src/measure_theory/integral/vitali_caratheodory.lean
@@ -493,7 +493,7 @@ begin
   { apply lower_semicontinuous.add',
     { exact continuous_coe_ennreal_ereal.comp_lower_semicontinuous gpcont
         (λ x y hxy, ereal.coe_ennreal_le_coe_ennreal_iff.2 hxy) },
-    { apply ereal.continuous_neg.comp_upper_semicontinuous_antimono _
+    { apply ereal.continuous_neg.comp_upper_semicontinuous_antitone _
         (λ x y hxy, ereal.neg_le_neg_iff.2 hxy),
       dsimp,
       apply continuous_coe_ennreal_ereal.comp_upper_semicontinuous _
@@ -517,7 +517,7 @@ begin
     with ⟨g, g_lt_f, gcont, g_integrable, g_lt_top, gint⟩,
   refine ⟨λ x, - g x, _, _, _, _, _⟩,
   { exact  λ x, ereal.neg_lt_iff_neg_lt.1 (by simpa only [ereal.coe_neg] using g_lt_f x) },
-  { exact ereal.continuous_neg.comp_lower_semicontinuous_antimono gcont
+  { exact ereal.continuous_neg.comp_lower_semicontinuous_antitone gcont
       (λ x y hxy, ereal.neg_le_neg_iff.2 hxy) },
   { convert g_integrable.neg,
     ext x,

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -330,7 +330,7 @@ begin
   rw [←h, inf_eq_right.mpr hx],
 end
 
--- cf. `is_compl.antimono`
+-- cf. `is_compl.antitone`
 lemma sdiff_le_sdiff_self (h : z ≤ x) : w \ x ≤ w \ z :=
 le_of_inf_le_sup_le
   (calc (w \ x) ⊓ (w ⊓ z) ≤ (w \ x) ⊓ (w ⊓ x) : inf_le_inf le_rfl (inf_le_inf le_rfl h)
@@ -611,7 +611,7 @@ is_compl_top_bot.compl_eq_iff
 (is_compl_compl.sup_inf is_compl_compl).compl_eq
 
 theorem compl_le_compl (h : y ≤ x) : xᶜ ≤ yᶜ :=
-is_compl_compl.antimono is_compl_compl h
+is_compl_compl.antitone is_compl_compl h
 
 @[simp] theorem compl_le_compl_iff_le : yᶜ ≤ xᶜ ↔ x ≤ y :=
 ⟨assume h, by have h := compl_le_compl h; simp at h; assumption,

--- a/src/order/bounded_lattice.lean
+++ b/src/order/bounded_lattice.lean
@@ -1186,13 +1186,13 @@ h.to_order_dual.le_left_iff
 lemma right_le_iff (h : is_compl x y) : y ≤ z ↔ ⊤ ≤ z ⊔ x :=
 h.symm.left_le_iff
 
-lemma antimono {x' y'} (h : is_compl x y) (h' : is_compl x' y') (hx : x ≤ x') :
+lemma antitone {x' y'} (h : is_compl x y) (h' : is_compl x' y') (hx : x ≤ x') :
   y' ≤ y :=
 h'.right_le_iff.2 $ le_trans h.symm.top_le_sup (sup_le_sup_left hx _)
 
 lemma right_unique (hxy : is_compl x y) (hxz : is_compl x z) :
   y = z :=
-le_antisymm (hxz.antimono hxy $ le_refl x) (hxy.antimono hxz $ le_refl x)
+le_antisymm (hxz.antitone hxy $ le_refl x) (hxy.antitone hxz $ le_refl x)
 
 lemma left_unique (hxz : is_compl x z) (hyz : is_compl y z) :
   x = y :=

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -1208,8 +1208,8 @@ by rw [map_at_top_eq, map_at_top_eq];
 from (le_infi $ assume b, let ⟨v, hv⟩ := h_eq b in infi_le_of_le v $
   by simp [set.image_subset_iff]; exact hv)
 
-lemma has_antimono_basis.tendsto [semilattice_sup ι] [nonempty ι] {l : filter α}
-  {p : ι → Prop} {s : ι → set α} (hl : l.has_antimono_basis p s) {φ : ι → α}
+lemma has_antitone_basis.tendsto [semilattice_sup ι] [nonempty ι] {l : filter α}
+  {p : ι → Prop} {s : ι → set α} (hl : l.has_antitone_basis p s) {φ : ι → α}
   (h : ∀ i : ι, φ i ∈ s i) : tendsto φ at_top l  :=
 (at_top_basis.tendsto_iff hl.to_has_basis).2 $ assume i hi,
   ⟨i, trivial, λ j hij, hl.decreasing hi (hl.mono hij hi) hij (h j)⟩
@@ -1225,7 +1225,7 @@ lemma tendsto_iff_seq_tendsto {f : α → β} {k : filter α} {l : filter β}
 suffices (∀ x : ℕ → α, tendsto x at_top k → tendsto (f ∘ x) at_top l) → tendsto f k l,
   from ⟨by intros; apply tendsto.comp; assumption, by assumption⟩,
 begin
-  rcases hcb.exists_antimono_basis with ⟨g, gbasis, gmon, -⟩,
+  rcases hcb.exists_antitone_basis with ⟨g, gbasis, gmon, -⟩,
   contrapose,
   simp only [not_forall, gbasis.tendsto_left_iff, exists_const, not_exists, not_imp],
   rintro ⟨B, hBl, hfBk⟩,
@@ -1249,7 +1249,7 @@ lemma subseq_tendsto {f : filter α} (hf : is_countably_generated f)
   (hx : ne_bot (f ⊓ map u at_top)) :
   ∃ (θ : ℕ → ℕ), (strict_mono θ) ∧ (tendsto (u ∘ θ) at_top f) :=
 begin
-  rcases hf.exists_antimono_basis with ⟨B, h⟩,
+  rcases hf.exists_antitone_basis with ⟨B, h⟩,
   have : ∀ N, ∃ n ≥ N, u n ∈ B N,
     from λ N, filter.inf_map_at_top_ne_bot_iff.mp hx _ (h.to_has_basis.mem_of_mem trivial) N,
   choose φ hφ using this,

--- a/src/order/filter/bases.lean
+++ b/src/order/filter/bases.lean
@@ -48,7 +48,7 @@ and consequences are derived.
   of bases.
 * `has_basis.tendsto_right_iff`, `has_basis.tendsto_left_iff`, `has_basis.tendsto_iff` : restate
   `tendsto f l l'` in terms of bases.
-* `is_countably_generated_iff_exists_antimono_basis` : proves a filter is
+* `is_countably_generated_iff_exists_antitone_basis` : proves a filter is
   countably generated if and only if it admis a basis parametrized by a
   decreasing sequence of sets indexed by `ℕ`.
 * `tendsto_iff_seq_tendsto ` : an abstract version of "sequentially continuous implies continuous".
@@ -591,16 +591,16 @@ end
 
 variables {ι'' : Type*} [preorder ι''] (l) (p'' : ι'' → Prop) (s'' : ι'' → set α)
 
-/-- `is_antimono_basis p s` means the image of `s` bounded by `p` is a filter basis
+/-- `is_antitone_basis p s` means the image of `s` bounded by `p` is a filter basis
 such that `s` is decreasing and `p` is increasing, ie `i ≤ j → p i → p j`. -/
-structure is_antimono_basis extends is_basis p'' s'' : Prop :=
+structure is_antitone_basis extends is_basis p'' s'' : Prop :=
 (decreasing : ∀ {i j}, p'' i → p'' j → i ≤ j → s'' j ⊆ s'' i)
 (mono : monotone p'')
 
-/-- We say that a filter `l` has a antimono basis `s : ι → set α` bounded by `p : ι → Prop`,
+/-- We say that a filter `l` has a antitone basis `s : ι → set α` bounded by `p : ι → Prop`,
 if `t ∈ l` if and only if `t` includes `s i` for some `i` such that `p i`,
 and `s` is decreasing and `p` is increasing, ie `i ≤ j → p i → p j`. -/
-structure has_antimono_basis (l : filter α) (p : ι'' → Prop) (s : ι'' → set α)
+structure has_antitone_basis (l : filter α) (p : ι'' → Prop) (s : ι'' → set α)
   extends has_basis l p s : Prop :=
 (decreasing : ∀ {i j}, p i → p j → i ≤ j → s j ⊆ s i)
 (mono : monotone p)
@@ -697,7 +697,7 @@ instance nat.inhabited_countable_filter_basis : inhabited (countable_filter_basi
 ⟨{ countable := countable_range (λ n, Ici n),
    ..(default $ filter_basis ℕ),}⟩
 
-lemma antimono_seq_of_seq (s : ℕ → set α) :
+lemma antitone_seq_of_seq (s : ℕ → set α) :
   ∃ t : ℕ → set α, (∀ i j, i ≤ j → t j ⊆ t i) ∧ (⨅ i, 𝓟 $ s i) = ⨅ i, 𝓟 (t i) :=
 begin
   use λ n, ⋂ m ≤ n, s m, split,
@@ -788,9 +788,9 @@ end
 enumerated by natural numbers such that all sets have the form `s i`. More precisely, there is a
 sequence `i n` such that `p (i n)` for all `n` and `s (i n)` is a decreasing sequence of sets which
 forms a basis of `f`-/
-lemma exists_antimono_subbasis {f : filter α} (cblb : f.is_countably_generated)
+lemma exists_antitone_subbasis {f : filter α} (cblb : f.is_countably_generated)
   {p : ι → Prop} {s : ι → set α} (hs : f.has_basis p s) :
-  ∃ x : ℕ → ι, (∀ i, p (x i)) ∧ f.has_antimono_basis (λ _, true) (λ i, s (x i)) :=
+  ∃ x : ℕ → ι, (∀ i, p (x i)) ∧ f.has_antitone_basis (λ _, true) (λ i, s (x i)) :=
 begin
   rcases cblb.exists_seq with ⟨x', hx'⟩,
   have : ∀ i, x' i ∈ f := λ i, hx'.symm ▸ (infi_le (λ i, 𝓟 (x' i)) i) (mem_principal_self _),
@@ -805,7 +805,7 @@ begin
   { rintro (_|i),
     exacts [hs.set_index_subset _, subset.trans (hs.set_index_subset _) (inter_subset_left _ _)] },
   refine ⟨λ i, x i, λ i, (x i).2, _⟩,
-  have : (⨅ i, 𝓟 (s (x i))).has_antimono_basis (λ _, true) (λ i, s (x i)) :=
+  have : (⨅ i, 𝓟 (s (x i))).has_antitone_basis (λ _, true) (λ i, s (x i)) :=
     ⟨has_basis_infi_principal (directed_of_sup x_mono), λ i j _ _ hij, x_mono hij, monotone_const⟩,
   convert this,
   exact le_antisymm (le_infi $ λ i, le_principal_iff.2 $ by cases i; apply hs.set_index_mem)
@@ -815,9 +815,9 @@ end
 
 /-- A countably generated filter admits a basis formed by a monotonically decreasing sequence of
 sets. -/
-lemma exists_antimono_basis {f : filter α} (cblb : f.is_countably_generated) :
-  ∃ x : ℕ → set α, f.has_antimono_basis (λ _, true) x :=
-let ⟨x, hxf, hx⟩ := cblb.exists_antimono_subbasis f.basis_sets in ⟨x, hx⟩
+lemma exists_antitone_basis {f : filter α} (cblb : f.is_countably_generated) :
+  ∃ x : ℕ → set α, f.has_antitone_basis (λ _, true) x :=
+let ⟨x, hxf, hx⟩ := cblb.exists_antitone_subbasis f.basis_sets in ⟨x, hx⟩
 
 end is_countably_generated
 
@@ -828,7 +828,7 @@ lemma has_countable_basis.is_countably_generated {f : filter α} {p : ι → Pro
 
 lemma is_countably_generated_seq (x : ℕ → set α) : is_countably_generated (⨅ i, 𝓟 $ x i) :=
 begin
-  rcases antimono_seq_of_seq x with ⟨y, am, h⟩,
+  rcases antitone_seq_of_seq x with ⟨y, am, h⟩,
   rw h,
   use [range y, countable_range _],
   rw (has_basis_infi_principal _).eq_generate,
@@ -845,11 +845,11 @@ lemma is_countably_generated_binfi_principal {B : set $ set α} (h : countable B
   is_countably_generated (⨅ (s ∈ B), 𝓟 s) :=
 is_countably_generated_of_seq (countable_binfi_principal_eq_seq_infi h)
 
-lemma is_countably_generated_iff_exists_antimono_basis {f : filter α} :
-  is_countably_generated f ↔ ∃ x : ℕ → set α, f.has_antimono_basis (λ _, true) x :=
+lemma is_countably_generated_iff_exists_antitone_basis {f : filter α} :
+  is_countably_generated f ↔ ∃ x : ℕ → set α, f.has_antitone_basis (λ _, true) x :=
 begin
   split,
-  { exact λ h, h.exists_antimono_basis },
+  { exact λ h, h.exists_antitone_basis },
   { rintros ⟨x, h⟩,
     rw h.to_has_basis.eq_infi,
     exact is_countably_generated_seq x },
@@ -866,7 +866,7 @@ namespace is_countably_generated
 lemma inf {f g : filter α} (hf : is_countably_generated f) (hg : is_countably_generated g) :
   is_countably_generated (f ⊓ g) :=
 begin
-  rw is_countably_generated_iff_exists_antimono_basis at hf hg,
+  rw is_countably_generated_iff_exists_antitone_basis at hf hg,
   rcases hf with ⟨s, hs⟩,
   rcases hg with ⟨t, ht⟩,
   exact has_countable_basis.is_countably_generated
@@ -877,14 +877,14 @@ lemma inf_principal {f : filter α} (h : is_countably_generated f) (s : set α) 
   is_countably_generated (f ⊓ 𝓟 s) :=
 h.inf (filter.is_countably_generated_principal s)
 
-lemma exists_antimono_seq' {f : filter α} (cblb : f.is_countably_generated) :
+lemma exists_antitone_seq' {f : filter α} (cblb : f.is_countably_generated) :
   ∃ x : ℕ → set α, (∀ i j, i ≤ j → x j ⊆ x i) ∧ ∀ {s}, (s ∈ f ↔ ∃ i, x i ⊆ s) :=
-let ⟨x, hx⟩ := is_countably_generated_iff_exists_antimono_basis.mp cblb in
+let ⟨x, hx⟩ := is_countably_generated_iff_exists_antitone_basis.mp cblb in
 ⟨x, λ i j, hx.decreasing trivial trivial, λ s, by simp [hx.to_has_basis.mem_iff]⟩
 
 protected lemma comap {l : filter β} (h : l.is_countably_generated) (f : α → β) :
   (comap f l).is_countably_generated :=
-let ⟨x, hx_mono⟩ := h.exists_antimono_basis in
+let ⟨x, hx_mono⟩ := h.exists_antitone_basis in
 is_countably_generated_of_seq ⟨_, (hx_mono.to_has_basis.comap _).eq_infi⟩
 
 end is_countably_generated

--- a/src/order/filter/extr.lean
+++ b/src/order/filter/extr.lean
@@ -32,7 +32,7 @@ Similar predicates with `_on` suffix are particular cases for `l = 𝓟 s`.
 
 * `is_*_*.comp_mono` : if `x` is an extremum for `f` and `g` is a monotone function,
   then `x` is an extremum for `g ∘ f`;
-* `is_*_*.comp_antimono` : similarly for the case of monotonically decreasing `g`;
+* `is_*_*.comp_antitone` : similarly for the case of monotonically decreasing `g`;
 * `is_*_*.bicomp_mono` : if `x` is an extremum of the same type for `f` and `g`
   and a binary operation `op` is monotone in both arguments, then `x` is an extremum
   of the same type for `λ x, op (f x) (g x)`.
@@ -230,17 +230,17 @@ lemma is_extr_filter.comp_mono (hf : is_extr_filter f l a) {g : β → γ} (hg :
   is_extr_filter (g ∘ f) l a :=
 hf.elim (λ hf, (hf.comp_mono hg).is_extr)  (λ hf, (hf.comp_mono hg).is_extr)
 
-lemma is_min_filter.comp_antimono (hf : is_min_filter f l a) {g : β → γ}
+lemma is_min_filter.comp_antitone (hf : is_min_filter f l a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_max_filter (g ∘ f) l a :=
 hf.dual.comp_mono (λ x y h, hg h)
 
-lemma is_max_filter.comp_antimono (hf : is_max_filter f l a) {g : β → γ}
+lemma is_max_filter.comp_antitone (hf : is_max_filter f l a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_min_filter (g ∘ f) l a :=
 hf.dual.comp_mono (λ x y h, hg h)
 
-lemma is_extr_filter.comp_antimono (hf : is_extr_filter f l a) {g : β → γ}
+lemma is_extr_filter.comp_antitone (hf : is_extr_filter f l a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_extr_filter (g ∘ f) l a :=
 hf.dual.comp_mono (λ x y h, hg h)
@@ -257,20 +257,20 @@ lemma is_extr_on.comp_mono (hf : is_extr_on f s a) {g : β → γ} (hg : monoton
   is_extr_on (g ∘ f) s a :=
 hf.comp_mono hg
 
-lemma is_min_on.comp_antimono (hf : is_min_on f s a) {g : β → γ}
+lemma is_min_on.comp_antitone (hf : is_min_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_max_on (g ∘ f) s a :=
-hf.comp_antimono hg
+hf.comp_antitone hg
 
-lemma is_max_on.comp_antimono (hf : is_max_on f s a) {g : β → γ}
+lemma is_max_on.comp_antitone (hf : is_max_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_min_on (g ∘ f) s a :=
-hf.comp_antimono hg
+hf.comp_antitone hg
 
-lemma is_extr_on.comp_antimono (hf : is_extr_on f s a) {g : β → γ}
+lemma is_extr_on.comp_antitone (hf : is_extr_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_extr_on (g ∘ f) s a :=
-hf.comp_antimono hg
+hf.comp_antitone hg
 
 lemma is_min_filter.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
   (hf : is_min_filter f l a) {g : α → γ} (hg : is_min_filter g l a) :
@@ -357,19 +357,19 @@ section ordered_add_comm_group
 variables [ordered_add_comm_group β] {f g : α → β} {a : α} {s : set α} {l : filter α}
 
 lemma is_min_filter.neg (hf : is_min_filter f l a) : is_max_filter (λ x, -f x) l a :=
-hf.comp_antimono (λ x y hx, neg_le_neg hx)
+hf.comp_antitone (λ x y hx, neg_le_neg hx)
 
 lemma is_max_filter.neg (hf : is_max_filter f l a) : is_min_filter (λ x, -f x) l a :=
-hf.comp_antimono (λ x y hx, neg_le_neg hx)
+hf.comp_antitone (λ x y hx, neg_le_neg hx)
 
 lemma is_extr_filter.neg (hf : is_extr_filter f l a) : is_extr_filter (λ x, -f x) l a :=
 hf.elim (λ hf, hf.neg.is_extr) (λ hf, hf.neg.is_extr)
 
 lemma is_min_on.neg (hf : is_min_on f s a) : is_max_on (λ x, -f x) s a :=
-hf.comp_antimono (λ x y hx, neg_le_neg hx)
+hf.comp_antitone (λ x y hx, neg_le_neg hx)
 
 lemma is_max_on.neg (hf : is_max_on f s a) : is_min_on (λ x, -f x) s a :=
-hf.comp_antimono (λ x y hx, neg_le_neg hx)
+hf.comp_antitone (λ x y hx, neg_le_neg hx)
 
 lemma is_extr_on.neg (hf : is_extr_on f s a) : is_extr_on (λ x, -f x) s a :=
 hf.elim (λ hf, hf.neg.is_extr) (λ hf, hf.neg.is_extr)

--- a/src/order/filter/indicator_function.lean
+++ b/src/order/filter/indicator_function.lean
@@ -65,7 +65,7 @@ begin
     apply indicator_of_not_mem, simpa only [not_exists, mem_Union] }
 end
 
-lemma tendsto_indicator_of_antimono {ι} [preorder ι] [has_zero β]
+lemma tendsto_indicator_of_antitone {ι} [preorder ι] [has_zero β]
   (s : ι → set α) (hs : ∀⦃i j⦄, i ≤ j → s j ⊆ s i) (f : α → β) (a : α) :
   tendsto (λi, indicator (s i) f a) at_top (pure $ indicator (⋂ i, s i) f a) :=
 begin

--- a/src/topology/G_delta.lean
+++ b/src/topology/G_delta.lean
@@ -108,7 +108,7 @@ lemma is_Gδ_set_of_continuous_at_of_countably_generated_uniformity
   [uniform_space β] (hU : is_countably_generated (𝓤 β)) (f : α → β) :
   is_Gδ {x | continuous_at f x} :=
 begin
-  rcases hU.exists_antimono_subbasis uniformity_has_basis_open_symmetric with ⟨U, hUo, hU⟩,
+  rcases hU.exists_antitone_subbasis uniformity_has_basis_open_symmetric with ⟨U, hUo, hU⟩,
   simp only [uniform.continuous_at_iff_prod, nhds_prod_eq],
   simp only [(nhds_basis_opens _).prod_self.tendsto_iff hU.to_has_basis, forall_prop_of_true,
     set_of_forall, id],

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -2166,7 +2166,7 @@ begin
     { exact h },
     { exact (not_mem hl).elim } },
   obtain ⟨s, hs⟩ : ∃ s : ℕ → set α, (𝓝 x).has_basis (λ (_x : ℕ), true) s :=
-    let ⟨s, hs⟩ := hx.exists_antimono_basis in ⟨s, hs.to_has_basis⟩,
+    let ⟨s, hs⟩ := hx.exists_antitone_basis in ⟨s, hs.to_has_basis⟩,
   have : ∀ n k, k < x → ∃ y, Icc y x ⊆ s n ∧ k < y ∧ y < x ∧ y ∈ t,
   { assume n k hk,
     obtain ⟨L, hL, h⟩ : ∃ (L : α) (hL : L ∈ Ico k x), Ioc L x ⊆ s n :=
@@ -2267,12 +2267,12 @@ lemma is_glb.exists_seq_monotone_tendsto [first_countable_topology α]
                         tendsto u at_top (𝓝 x) ∧ (∀ n, u n ∈ t) :=
 htx.exists_seq_monotone_tendsto' ht (is_countably_generated_nhds x)
 
-lemma exists_seq_strict_antimono_tendsto' [densely_ordered α]
+lemma exists_seq_strict_antitone_tendsto' [densely_ordered α]
   [first_countable_topology α] {x y : α} (hy : x < y) :
   ∃ u : ℕ → α, (∀ m n, m < n → u n < u m) ∧ (∀ n, x < u n) ∧ tendsto u at_top (𝓝 x) :=
 @exists_seq_strict_mono_tendsto' (order_dual α) _ _ _ _ _ x y hy
 
-lemma exists_seq_strict_antimono_tendsto [densely_ordered α] [no_top_order α]
+lemma exists_seq_strict_antitone_tendsto [densely_ordered α] [no_top_order α]
   [first_countable_topology α] (x : α) :
   ∃ u : ℕ → α, (∀ m n, m < n → u n < u m) ∧ (∀ n, x < u n) ∧ tendsto u at_top (𝓝 x) :=
 @exists_seq_strict_mono_tendsto (order_dual α) _ _ _ _ _ _ x

--- a/src/topology/local_extr.lean
+++ b/src/topology/local_extr.lean
@@ -174,20 +174,20 @@ lemma is_local_extr.comp_mono (hf : is_local_extr f a) {g : β → γ} (hg : mon
   is_local_extr (g ∘ f) a :=
 hf.comp_mono hg
 
-lemma is_local_min.comp_antimono (hf : is_local_min f a) {g : β → γ}
+lemma is_local_min.comp_antitone (hf : is_local_min f a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_local_max (g ∘ f) a :=
-hf.comp_antimono hg
+hf.comp_antitone hg
 
-lemma is_local_max.comp_antimono (hf : is_local_max f a) {g : β → γ}
+lemma is_local_max.comp_antitone (hf : is_local_max f a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_local_min (g ∘ f) a :=
-hf.comp_antimono hg
+hf.comp_antitone hg
 
-lemma is_local_extr.comp_antimono (hf : is_local_extr f a) {g : β → γ}
+lemma is_local_extr.comp_antitone (hf : is_local_extr f a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_local_extr (g ∘ f) a :=
-hf.comp_antimono hg
+hf.comp_antitone hg
 
 lemma is_local_min_on.comp_mono (hf : is_local_min_on f s a) {g : β → γ} (hg : monotone g) :
   is_local_min_on (g ∘ f) s a :=
@@ -201,20 +201,20 @@ lemma is_local_extr_on.comp_mono (hf : is_local_extr_on f s a) {g : β → γ} (
   is_local_extr_on (g ∘ f) s a :=
 hf.comp_mono hg
 
-lemma is_local_min_on.comp_antimono (hf : is_local_min_on f s a) {g : β → γ}
+lemma is_local_min_on.comp_antitone (hf : is_local_min_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_local_max_on (g ∘ f) s a :=
-hf.comp_antimono hg
+hf.comp_antitone hg
 
-lemma is_local_max_on.comp_antimono (hf : is_local_max_on f s a) {g : β → γ}
+lemma is_local_max_on.comp_antitone (hf : is_local_max_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_local_min_on (g ∘ f) s a :=
-hf.comp_antimono hg
+hf.comp_antitone hg
 
-lemma is_local_extr_on.comp_antimono (hf : is_local_extr_on f s a) {g : β → γ}
+lemma is_local_extr_on.comp_antitone (hf : is_local_extr_on f s a) {g : β → γ}
   (hg : ∀ ⦃x y⦄, x ≤ y → g y ≤ g x) :
   is_local_extr_on (g ∘ f) s a :=
-hf.comp_antimono hg
+hf.comp_antitone hg
 
 lemma is_local_min.bicomp_mono [preorder δ] {op : β → γ → δ} (hop : ((≤) ⇒ (≤) ⇒ (≤)) op op)
   (hf : is_local_min f a) {g : α → γ} (hg : is_local_min g a) :

--- a/src/topology/semicontinuous.lean
+++ b/src/topology/semicontinuous.lean
@@ -296,26 +296,26 @@ lemma continuous.comp_lower_semicontinuous
   (gmon : monotone g) : lower_semicontinuous (g ∘ f) :=
 λ x, (hg.continuous_at).comp_lower_semicontinuous_at (hf x) gmon
 
-lemma continuous_at.comp_lower_semicontinuous_within_at_antimono
+lemma continuous_at.comp_lower_semicontinuous_within_at_antitone
   {g : γ → δ} {f : α → γ} (hg : continuous_at g (f x)) (hf : lower_semicontinuous_within_at f s x)
   (gmon : ∀ x y, x ≤ y → g y ≤ g x) : upper_semicontinuous_within_at (g ∘ f) s x :=
 @continuous_at.comp_lower_semicontinuous_within_at α _ x s γ _ _ _ (order_dual δ) _ _ _
   g f hg hf gmon
 
-lemma continuous_at.comp_lower_semicontinuous_at_antimono
+lemma continuous_at.comp_lower_semicontinuous_at_antitone
   {g : γ → δ} {f : α → γ} (hg : continuous_at g (f x)) (hf : lower_semicontinuous_at f x)
   (gmon : ∀ x y, x ≤ y → g y ≤ g x) : upper_semicontinuous_at (g ∘ f) x :=
 @continuous_at.comp_lower_semicontinuous_at α _ x γ _ _ _ (order_dual δ) _ _ _ g f hg hf gmon
 
-lemma continuous.comp_lower_semicontinuous_on_antimono
+lemma continuous.comp_lower_semicontinuous_on_antitone
   {g : γ → δ} {f : α → γ} (hg : continuous g) (hf : lower_semicontinuous_on f s)
   (gmon : ∀ x y, x ≤ y → g y ≤ g x) : upper_semicontinuous_on (g ∘ f) s :=
-λ x hx, (hg.continuous_at).comp_lower_semicontinuous_within_at_antimono (hf x hx) gmon
+λ x hx, (hg.continuous_at).comp_lower_semicontinuous_within_at_antitone (hf x hx) gmon
 
-lemma continuous.comp_lower_semicontinuous_antimono
+lemma continuous.comp_lower_semicontinuous_antitone
   {g : γ → δ} {f : α → γ} (hg : continuous g) (hf : lower_semicontinuous f)
   (gmon : ∀ x y, x ≤ y → g y ≤ g x) : upper_semicontinuous (g ∘ f) :=
-λ x, (hg.continuous_at).comp_lower_semicontinuous_at_antimono (hf x) gmon
+λ x, (hg.continuous_at).comp_lower_semicontinuous_at_antitone (hf x) gmon
 
 end
 
@@ -730,26 +730,26 @@ lemma continuous.comp_upper_semicontinuous
   (gmon : monotone g) : upper_semicontinuous (g ∘ f) :=
 λ x, (hg.continuous_at).comp_upper_semicontinuous_at (hf x) gmon
 
-lemma continuous_at.comp_upper_semicontinuous_within_at_antimono
+lemma continuous_at.comp_upper_semicontinuous_within_at_antitone
   {g : γ → δ} {f : α → γ} (hg : continuous_at g (f x)) (hf : upper_semicontinuous_within_at f s x)
   (gmon : ∀ x y, x ≤ y → g y ≤ g x) : lower_semicontinuous_within_at (g ∘ f) s x :=
 @continuous_at.comp_upper_semicontinuous_within_at α _ x s γ _ _ _ (order_dual δ) _ _ _
   g f hg hf gmon
 
-lemma continuous_at.comp_upper_semicontinuous_at_antimono
+lemma continuous_at.comp_upper_semicontinuous_at_antitone
   {g : γ → δ} {f : α → γ} (hg : continuous_at g (f x)) (hf : upper_semicontinuous_at f x)
   (gmon : ∀ x y, x ≤ y → g y ≤ g x) : lower_semicontinuous_at (g ∘ f) x :=
 @continuous_at.comp_upper_semicontinuous_at α _ x γ _ _ _ (order_dual δ) _ _ _ g f hg hf gmon
 
-lemma continuous.comp_upper_semicontinuous_on_antimono
+lemma continuous.comp_upper_semicontinuous_on_antitone
   {g : γ → δ} {f : α → γ} (hg : continuous g) (hf : upper_semicontinuous_on f s)
   (gmon : ∀ x y, x ≤ y → g y ≤ g x) : lower_semicontinuous_on (g ∘ f) s :=
-λ x hx, (hg.continuous_at).comp_upper_semicontinuous_within_at_antimono (hf x hx) gmon
+λ x hx, (hg.continuous_at).comp_upper_semicontinuous_within_at_antitone (hf x hx) gmon
 
-lemma continuous.comp_upper_semicontinuous_antimono
+lemma continuous.comp_upper_semicontinuous_antitone
   {g : γ → δ} {f : α → γ} (hg : continuous g) (hf : upper_semicontinuous f)
   (gmon : ∀ x y, x ≤ y → g y ≤ g x) : lower_semicontinuous (g ∘ f) :=
-λ x, (hg.continuous_at).comp_upper_semicontinuous_at_antimono (hf x) gmon
+λ x, (hg.continuous_at).comp_upper_semicontinuous_at_antitone (hf x) gmon
 
 end
 

--- a/src/topology/sequences.lean
+++ b/src/topology/sequences.lean
@@ -153,7 +153,7 @@ instance : sequential_space α :=
   assume (p : α) (hp : p ∈ closure M),
   -- Since we are in a first-countable space, the neighborhood filter around `p` has a decreasing
   -- basis `U` indexed by `ℕ`.
-  let ⟨U, hU⟩ := (nhds_generated_countable p).exists_antimono_basis in
+  let ⟨U, hU⟩ := (nhds_generated_countable p).exists_antitone_basis in
   -- Since `p ∈ closure M`, there is an element in each `M ∩ U i`
   have hp : ∀ (i : ℕ), ∃ (y : α), y ∈ M ∧ y ∈ U i,
     by simpa using (mem_closure_iff_nhds_basis hU.1).mp hp,
@@ -241,7 +241,7 @@ lemma lebesgue_number_lemma_seq {ι : Type*} {c : ι → set β}
 begin
   classical,
   obtain ⟨V, hV, Vsymm⟩ :
-    ∃ V : ℕ → set (β × β), (𝓤 β).has_antimono_basis (λ _, true) V ∧  ∀ n, swap ⁻¹' V n = V n,
+    ∃ V : ℕ → set (β × β), (𝓤 β).has_antitone_basis (λ _, true) V ∧  ∀ n, swap ⁻¹' V n = V n,
       from uniform_space.has_seq_basis hU, clear hU,
   suffices : ∃ n, ∀ x ∈ s, ∃ i, ball x (V n) ⊆ c i,
   { cases this with n hn,

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -858,8 +858,8 @@ begin
 end
 
 lemma uniform_space.has_seq_basis (h : is_countably_generated $ 𝓤 α) :
-  ∃ V : ℕ → set (α × α), has_antimono_basis (𝓤 α) (λ _, true) V ∧ ∀ n, symmetric_rel (V n) :=
-let ⟨U, hsym, hbasis⟩ := h.exists_antimono_subbasis uniform_space.has_basis_symmetric
+  ∃ V : ℕ → set (α × α), has_antitone_basis (𝓤 α) (λ _, true) V ∧ ∀ n, symmetric_rel (V n) :=
+let ⟨U, hsym, hbasis⟩ := h.exists_antitone_subbasis uniform_space.has_basis_symmetric
 in ⟨U, hbasis, λ n, (hsym n).2⟩
 
 /-! ### Uniform continuity -/

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -556,7 +556,7 @@ theorem complete_of_convergent_controlled_sequences (U : ℕ → set (α × α))
   (HU : ∀ u : ℕ → α, (∀ N m n, N ≤ m → N ≤ n → (u m, u n) ∈ U N) → ∃ a, tendsto u at_top (𝓝 a)) :
   complete_space α :=
 begin
-  rcases H.exists_antimono_seq' with ⟨U', U'_mono, hU'⟩,
+  rcases H.exists_antitone_seq' with ⟨U', U'_mono, hU'⟩,
   have Hmem : ∀ n, U n ∩ U' n ∈ 𝓤 α,
     from λ n, inter_mem (U_mem n) (hU'.2 ⟨n, subset.refl _⟩),
   refine ⟨λ f hf, (HU (seq hf Hmem) (λ N m n hm hn, _)).imp $
@@ -571,7 +571,7 @@ complete. -/
 theorem complete_of_cauchy_seq_tendsto
   (H' : ∀ u : ℕ → α, cauchy_seq u → ∃a, tendsto u at_top (𝓝 a)) :
   complete_space α :=
-let ⟨U', U'_mono, hU'⟩ := H.exists_antimono_seq' in
+let ⟨U', U'_mono, hU'⟩ := H.exists_antitone_seq' in
 complete_of_convergent_controlled_sequences H U' (λ n, hU'.2 ⟨n, subset.refl _⟩)
   (λ u hu, H' u $ cauchy_seq_of_controlled U' (λ s hs, hU'.1 hs) hu)
 
@@ -580,7 +580,7 @@ protected lemma first_countable_topology : first_countable_topology α :=
 
 /-- A separable uniform space with countably generated uniformity filter is second countable:
 one obtains a countable basis by taking the balls centered at points in a dense subset,
-and with rational "radii" from a countable open symmetric antimono basis of `𝓤 α`. We do not
+and with rational "radii" from a countable open symmetric antitone basis of `𝓤 α`. We do not
 register this as an instance, as there is already an instance going in the other direction
 from second countable spaces to separable spaces, and we want to avoid loops. -/
 lemma second_countable_of_separable [separable_space α] : second_countable_topology α :=
@@ -588,8 +588,8 @@ begin
   rcases exists_countable_dense α with ⟨s, hsc, hsd⟩,
   obtain ⟨t : ℕ → set (α × α),
     hto : ∀ (i : ℕ), t i ∈ (𝓤 α).sets ∧ is_open (t i) ∧ symmetric_rel (t i),
-    h_basis : (𝓤 α).has_antimono_basis (λ _, true) t⟩ :=
-    H.exists_antimono_subbasis uniformity_has_basis_open_symmetric,
+    h_basis : (𝓤 α).has_antitone_basis (λ _, true) t⟩ :=
+    H.exists_antitone_subbasis uniformity_has_basis_open_symmetric,
   refine ⟨⟨⋃ (x ∈ s), range (λ k, ball x (t k)), hsc.bUnion (λ x hx, countable_range _), _⟩⟩,
   refine (is_topological_basis_of_open_of_nhds _ _).eq_generate_from,
   { simp only [mem_bUnion_iff, mem_range],


### PR DESCRIPTION
This was done with the regex `(?<=\b|_)antimono(?=\b|_)`



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Split from #9383 - it's easier to make a change procedurally and review the procedure than manually review a change made manually. I'll take ownership of any merge conflicts this creates with the original #9383, which is a superset of this change.