### PR TITLE
[Merged by Bors] - refactor(linear_algebra/free_module): split in two files

### DIFF
--- a/src/algebra/module/projective.lean
+++ b/src/algebra/module/projective.lean
@@ -6,7 +6,7 @@ Authors: Kevin Buzzard
 
 import algebra.module.basic
 import linear_algebra.finsupp
-import linear_algebra.free_module
+import linear_algebra.free_module.basic
 
 /-!
 

--- a/src/linear_algebra/charpoly.lean
+++ b/src/linear_algebra/charpoly.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
 
-import linear_algebra.free_module.basic
+import linear_algebra.free_module.finite
 import linear_algebra.matrix.charpoly.coeff
 import linear_algebra.matrix.basis
 

--- a/src/linear_algebra/charpoly.lean
+++ b/src/linear_algebra/charpoly.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
 
-import linear_algebra.free_module
+import linear_algebra.free_module.basic
 import linear_algebra.matrix.charpoly.coeff
 import linear_algebra.matrix.basis
 

--- a/src/linear_algebra/free_module/basic.lean
+++ b/src/linear_algebra/free_module/basic.lean
@@ -5,11 +5,8 @@ Authors: Riccardo Brasca
 -/
 
 import linear_algebra.direct_sum.finsupp
-import linear_algebra.matrix.to_lin
-import linear_algebra.std_basis
 import logic.small
 import ring_theory.finiteness
-import linear_algebra.matrix.to_lin
 
 /-!
 
@@ -130,31 +127,7 @@ instance direct_sum {ι : Type*} (M : ι → Type*) [Π (i : ι), add_comm_monoi
   [Π (i : ι), module R (M i)] [Π (i : ι), module.free R (M i)] : module.free R (⨁ i, M i) :=
 module.free.dfinsupp R M
 
-instance pi {ι : Type*} [fintype ι] {M : ι → Type*} [Π (i : ι), add_comm_group (M i)]
-[Π (i : ι), module R (M i)] [Π (i : ι), module.free R (M i)] : module.free R (Π i, M i) :=
-of_basis $ pi.basis $ λ i, choose_basis R (M i)
-
-instance matrix {n : Type*} [fintype n] {m : Type*} [fintype m] :
-  module.free R (matrix n m R) :=
-of_basis $ matrix.std_basis R n m
-
 end semiring
-
-section ring
-
-variables [ring R] [add_comm_group M] [module R M] [module.free R M]
-
-/-- If a free module is finite, then any basis is finite. -/
-noncomputable
-instance [nontrivial R] [module.finite R M] :
-  fintype (module.free.choose_basis_index R M) :=
-begin
-  obtain ⟨h⟩ := id ‹module.finite R M›,
-  choose s hs using h,
-  exact basis_fintype_of_finite_spans ↑s hs (choose_basis _ _),
-end
-
-end ring
 
 section comm_ring
 
@@ -165,13 +138,6 @@ instance tensor : module.free R (M ⊗[R] N) :=
 of_equiv' (of_equiv' (finsupp.free R) (finsupp_tensor_finsupp' R _ _).symm)
   (tensor_product.congr (choose_basis R M).repr (choose_basis R N).repr).symm
 
-instance [nontrivial R] [module.finite R M] [module.finite R N] : module.free R (M →ₗ[R] N) :=
-begin
-  classical,
-  exact of_equiv
-    (linear_map.to_matrix (module.free.choose_basis R M) (module.free.choose_basis R N)).symm,
-end
-
 variables {R M}
 
 lemma _root_.module.finite.of_basis {R : Type*} {M : Type*} {ι : Type*} [comm_ring R]
@@ -180,18 +146,6 @@ begin
   classical,
   refine ⟨⟨finset.univ.image b, _⟩⟩,
   simp only [set.image_univ, finset.coe_univ, finset.coe_image, basis.span_eq],
-end
-
-instance _root_.module.finite.matrix {ι₁ : Type*} [fintype ι₁] {ι₂ : Type*} [fintype ι₂] :
-  module.finite R (matrix ι₁ ι₂ R) :=
-module.finite.of_basis $ pi.basis $ λ i, pi.basis_fun R _
-
-instance [nontrivial R] [module.finite R M] [module.finite R N] :
-  module.finite R (M →ₗ[R] N) :=
-begin
-  classical,
-  have f := (linear_map.to_matrix (choose_basis R M) (choose_basis R N)).symm,
-  exact module.finite.of_surjective f.to_linear_map (linear_equiv.surjective f),
 end
 
 end comm_ring
@@ -205,18 +159,5 @@ instance of_division_ring : module.free R M :=
 of_basis (basis.of_vector_space R M)
 
 end division_ring
-
-section integer
-
-variables [add_comm_group M] [module.finite ℤ M] [module.free ℤ M]
-variables [add_comm_group N] [module.finite ℤ N] [module.free ℤ N]
-
-instance : module.finite ℤ (M →+ N) :=
-module.finite.equiv (add_monoid_hom_lequiv_int ℤ).symm
-
-instance : module.free ℤ (M →+ N) :=
-module.free.of_equiv (add_monoid_hom_lequiv_int ℤ).symm
-
-end integer
 
 end module.free

--- a/src/linear_algebra/free_module/basic.lean
+++ b/src/linear_algebra/free_module/basic.lean
@@ -6,7 +6,6 @@ Authors: Riccardo Brasca
 
 import linear_algebra.direct_sum.finsupp
 import logic.small
-import ring_theory.finiteness
 
 /-!
 
@@ -137,16 +136,6 @@ variables [add_comm_group N] [module R N] [module.free R N]
 instance tensor : module.free R (M ⊗[R] N) :=
 of_equiv' (of_equiv' (finsupp.free R) (finsupp_tensor_finsupp' R _ _).symm)
   (tensor_product.congr (choose_basis R M).repr (choose_basis R N).repr).symm
-
-variables {R M}
-
-lemma _root_.module.finite.of_basis {R : Type*} {M : Type*} {ι : Type*} [comm_ring R]
-  [add_comm_group M] [module R M] [fintype ι] (b : basis ι R M) : module.finite R M :=
-begin
-  classical,
-  refine ⟨⟨finset.univ.image b, _⟩⟩,
-  simp only [set.image_univ, finset.coe_univ, finset.coe_image, basis.span_eq],
-end
 
 end comm_ring
 

--- a/src/linear_algebra/free_module/finite.lean
+++ b/src/linear_algebra/free_module/finite.lean
@@ -12,7 +12,6 @@ import ring_theory.finiteness
 # Finite and free modules
 
 We provide some instances for finite and free modules.
-
 -/
 
 universes u v w

--- a/src/linear_algebra/free_module/finite.lean
+++ b/src/linear_algebra/free_module/finite.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2021 Riccardo Brasca. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Riccardo Brasca
+-/
+
+import linear_algebra.free_module.basic
+import linear_algebra.matrix.to_lin
+import linear_algebra.std_basis
+
+/-!
+
+# Finite and free modules
+
+We provide some instances for finite and free modules.
+
+-/
+
+universes u v w
+
+variables (R : Type u) (M : Type v) (N : Type w)
+
+namespace module.free
+
+section semiring
+
+variables [semiring R]
+
+instance pi {ι : Type*} [fintype ι] {M : ι → Type*} [Π (i : ι), add_comm_group (M i)]
+[Π (i : ι), module R (M i)] [Π (i : ι), module.free R (M i)] : module.free R (Π i, M i) :=
+of_basis $ pi.basis $ λ i, choose_basis R (M i)
+
+instance matrix {n : Type*} [fintype n] {m : Type*} [fintype m] :
+  module.free R (matrix n m R) :=
+of_basis $ matrix.std_basis R n m
+
+end semiring
+
+section ring
+
+variables [ring R] [add_comm_group M] [module R M] [module.free R M]
+
+/-- If a free module is finite, then any basis is finite. -/
+noncomputable
+instance [nontrivial R] [module.finite R M] :
+  fintype (module.free.choose_basis_index R M) :=
+begin
+  obtain ⟨h⟩ := id ‹module.finite R M›,
+  choose s hs using h,
+  exact basis_fintype_of_finite_spans ↑s hs (choose_basis _ _),
+end
+
+end ring
+
+section comm_ring
+
+variables [comm_ring R] [add_comm_group M] [module R M] [module.free R M]
+variables [add_comm_group N] [module R N] [module.free R N]
+
+instance [nontrivial R] [module.finite R M] [module.finite R N] : module.free R (M →ₗ[R] N) :=
+begin
+  classical,
+  exact of_equiv
+    (linear_map.to_matrix (module.free.choose_basis R M) (module.free.choose_basis R N)).symm,
+end
+
+instance _root_.module.finite.matrix {ι₁ : Type*} [fintype ι₁] {ι₂ : Type*} [fintype ι₂] :
+  module.finite R (matrix ι₁ ι₂ R) :=
+module.finite.of_basis $ pi.basis $ λ i, pi.basis_fun R _
+
+instance [nontrivial R] [module.finite R M] [module.finite R N] :
+  module.finite R (M →ₗ[R] N) :=
+begin
+  classical,
+  have f := (linear_map.to_matrix (choose_basis R M) (choose_basis R N)).symm,
+  exact module.finite.of_surjective f.to_linear_map (linear_equiv.surjective f),
+end
+
+end comm_ring
+
+section integer
+
+variables [add_comm_group M] [module.finite ℤ M] [module.free ℤ M]
+variables [add_comm_group N] [module.finite ℤ N] [module.free ℤ N]
+
+instance : module.finite ℤ (M →+ N) :=
+module.finite.equiv (add_monoid_hom_lequiv_int ℤ).symm
+
+instance : module.free ℤ (M →+ N) :=
+module.free.of_equiv (add_monoid_hom_lequiv_int ℤ).symm
+
+end integer
+
+end module.free

--- a/src/linear_algebra/free_module/finite.lean
+++ b/src/linear_algebra/free_module/finite.lean
@@ -7,6 +7,7 @@ Authors: Riccardo Brasca
 import linear_algebra.free_module.basic
 import linear_algebra.matrix.to_lin
 import linear_algebra.std_basis
+import ring_theory.finiteness
 
 /-!
 
@@ -62,6 +63,16 @@ begin
   classical,
   exact of_equiv
     (linear_map.to_matrix (module.free.choose_basis R M) (module.free.choose_basis R N)).symm,
+end
+
+variables {R M}
+
+lemma _root_.module.finite.of_basis {R : Type*} {M : Type*} {ι : Type*} [comm_ring R]
+  [add_comm_group M] [module R M] [fintype ι] (b : basis ι R M) : module.finite R M :=
+begin
+  classical,
+  refine ⟨⟨finset.univ.image b, _⟩⟩,
+  simp only [set.image_univ, finset.coe_univ, finset.coe_image, basis.span_eq],
 end
 
 instance _root_.module.finite.matrix {ι₁ : Type*} [fintype ι₁] {ι₂ : Type*} [fintype ι₂] :

--- a/src/linear_algebra/free_module/finite.lean
+++ b/src/linear_algebra/free_module/finite.lean
@@ -14,6 +14,16 @@ import ring_theory.finiteness
 
 We provide some instances for finite and free modules.
 
+## Main results
+
+* `module.free.pi` : the product of finitely many free modules is free.
+* `module.free.matrix` : the module of (finite) matrices is free.
+* `module.free.choose_basis_index.fintype` : If a free module is finite, then any basis is
+  finite.
+* `module.free.linear_map.free ` : if `M` and `N` are finite and free, then `M →ₗ[R] N` is free.
+* `module.finite.of_basis` : A free module with a basis indexed by a `fintype` is finite.
+* `module.free.linear_map.module.finite` : if `M` and `N` are finite and free, then `M →ₗ[R] N`
+  is finite.
 -/
 
 universes u v w
@@ -66,6 +76,7 @@ end
 
 variables {R M}
 
+/-- A free module with a basis indexed by a `fintype` is finite. -/
 lemma _root_.module.finite.of_basis {R : Type*} {M : Type*} {ι : Type*} [comm_ring R]
   [add_comm_group M] [module R M] [fintype ι] (b : basis ι R M) : module.finite R M :=
 begin

--- a/src/linear_algebra/free_module/finite.lean
+++ b/src/linear_algebra/free_module/finite.lean
@@ -9,7 +9,6 @@ import linear_algebra.matrix.to_lin
 import ring_theory.finiteness
 
 /-!
-
 # Finite and free modules
 
 We provide some instances for finite and free modules.

--- a/src/linear_algebra/free_module/finite.lean
+++ b/src/linear_algebra/free_module/finite.lean
@@ -6,7 +6,6 @@ Authors: Riccardo Brasca
 
 import linear_algebra.free_module.basic
 import linear_algebra.matrix.to_lin
-import linear_algebra.std_basis
 import ring_theory.finiteness
 
 /-!

--- a/src/linear_algebra/free_module/finite.lean
+++ b/src/linear_algebra/free_module/finite.lean
@@ -36,7 +36,7 @@ section semiring
 variables [semiring R]
 
 instance pi {ι : Type*} [fintype ι] {M : ι → Type*} [Π (i : ι), add_comm_group (M i)]
-[Π (i : ι), module R (M i)] [Π (i : ι), module.free R (M i)] : module.free R (Π i, M i) :=
+  [Π (i : ι), module R (M i)] [Π (i : ι), module.free R (M i)] : module.free R (Π i, M i) :=
 of_basis $ pi.basis $ λ i, choose_basis R (M i)
 
 instance matrix {n : Type*} [fintype n] {m : Type*} [fintype m] :


### PR DESCRIPTION
We split `linear_algebra/free_module` in `linear_algebra/free_module/basic` and `linear_algebra/free_module/finite`, so one can work with free modules without having to import all the theory of dimension.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
