### PR TITLE
[Merged by Bors] - doc(*): remove docstrings from copyright headers

### DIFF
--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2019 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
-
 -/
 import data.dfinsupp
 import group_theory.submonoid.operations

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
-
-Direct sum of modules over commutative rings, indexed by a discrete type.
 -/
 import algebra.direct_sum.basic
 import linear_algebra.dfinsupp

--- a/src/category_theory/category/Kleisli.lean
+++ b/src/category_theory/category/Kleisli.lean
@@ -2,10 +2,6 @@
 Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
-
-The Kleisli construction on the Type category
-
-TODO: generalise this to work with category_theory.monad
 -/
 import category_theory.category
 
@@ -15,6 +11,10 @@ import category_theory.category
 Define the Kleisli category for (control) monads.
 `category_theory/monad/kleisli` defines the general version for a monad on `C`, and demonstrates
 the equivalence between the two.
+
+## TODO
+
+Generalise this to work with category_theory.monad
 -/
 
 universes u v

--- a/src/data/lazy_list/basic.lean
+++ b/src/data/lazy_list/basic.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
-
-Traversable instance for lazy_lists.
 -/
 import control.traversable.equiv
 import control.traversable.instances

--- a/src/data/list/sigma.lean
+++ b/src/data/list/sigma.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Sean Leather
-
-Functions on lists of sigma types.
 -/
 import data.list.perm
 import data.list.range

--- a/src/data/matrix/notation.lean
+++ b/src/data/matrix/notation.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
-
-Notation for vectors and matrices
 -/
 
 import data.fintype.card

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -2,14 +2,13 @@
 Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
-
 -/
-import data.nat.sqrt
-import data.nat.gcd
-import data.list.sort
 import algebra.group_power
-import tactic.wlog
+import data.list.sort
+import data.nat.gcd
+import data.nat.sqrt
 import tactic.norm_num
+import tactic.wlog
 
 /-!
 # Prime numbers

--- a/src/linear_algebra/special_linear_group.lean
+++ b/src/linear_algebra/special_linear_group.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
-
-The Special Linear group $SL(n, R)$
 -/
 import linear_algebra.matrix.nonsingular_inverse
 import linear_algebra.matrix.to_lin

--- a/src/number_theory/padics/padic_numbers.lean
+++ b/src/number_theory/padics/padic_numbers.lean
@@ -2,10 +2,9 @@
 Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
-
 -/
-import number_theory.padics.padic_norm
 import analysis.normed_space.basic
+import number_theory.padics.padic_norm
 
 /-!
 # p-adic numbers

--- a/src/order/preorder_hom.lean
+++ b/src/order/preorder_hom.lean
@@ -2,18 +2,18 @@
 Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
-
-# Preorder homomorphisms
-
-Bundled monotone functions, `x ≤ y → f x ≤ f y`.
 -/
 import logic.function.iterate
-import order.basic
 import order.bounded_lattice
 import order.complete_lattice
 import tactic.monotonicity
 
-/-! # Category of preorders -/
+/-!
+# Preorder homomorphisms
+
+This file defines preorder homomorphisms, which are bundled monotone functions. A preorder
+homomorphism `f : α →ₘ β` is a function `α → β` along with a proof that `∀ x y, x ≤ y → f x ≤ f y`.
+-/
 
 /-- Bundled monotone (aka, increasing) function -/
 structure preorder_hom (α β : Type*) [preorder α] [preorder β] :=

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Chris Hughes
-
-Adjoining roots of polynomials
 -/
 import data.polynomial.field_division
 import linear_algebra.finite_dimensional

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -2,13 +2,18 @@
 Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
-
-Case bashing:
-* on `x ∈ A`, for `A : finset α` or `A : list α`, or
-* on `x : A`, with `[fintype A]`.
 -/
 import data.fintype.basic
 import tactic.norm_num
+
+/-!
+# Case bash
+
+This file provides the tactic `fin_cases`. `fin_cases x` performs case analysis on `x`, that is
+creates one goal for each possible value of `x`, where either:
+* `x : α`, where `[fintype α]`
+* `x ∈ A`, where `A : finset α`, `A : multiset α` or `A : list α`.
+-/
 
 namespace tactic
 open lean.parser

--- a/src/tactic/interval_cases.lean
+++ b/src/tactic/interval_cases.lean
@@ -2,32 +2,33 @@
 Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
+-/
+import data.fintype.intervals
+import tactic.fin_cases
 
-Case bashing on variables in finite intervals.
+/-!
+# Case bash on variables in finite intervals
 
-In particular, `interval_cases n`
-1) inspects hypotheses looking for lower and upper bounds of the form `a ≤ n` and `n < b`
-   (although in `ℕ`, `ℤ`, and `ℕ+` bounds of the form `a < n` and `n ≤ b` are also allowed),
+This file provides the tactic `interval_cases`. `interval_cases n` will:
+1. inspect hypotheses looking for lower and upper bounds of the form `a ≤ n` and `n < b`
+   (in `ℕ`, `ℤ`, `ℕ+`, bounds of the form `a < n` and `n ≤ b` are also allowed),
    and also makes use of lower and upper bounds found via `le_top` and `bot_le`
-   (so for example if `n : ℕ`, then the bound `0 ≤ n` is found automatically), then
-2) calls `fin_cases` on the synthesised hypothesis `n ∈ set.Ico a b`,
+   (so for example if `n : ℕ`, then the bound `0 ≤ n` is automatically found).
+2. call `fin_cases` on the synthesised hypothesis `n ∈ set.Ico a b`,
    assuming an appropriate `fintype` instance can be found for the type of `n`.
 
 The variable `n` can belong to any type `α`, with the following restrictions:
 * only bounds on which `expr.to_rat` succeeds will be considered "explicit" (TODO: generalise this?)
 * an instance of `decidable_eq α` is available,
-* an explicit lower bound can be found amongst the hypotheses, or from `bot_le n`,
-* an explicit upper bound can be found amongst the hypotheses, or from `le_top n`,
+* an explicit lower bound can be found among the hypotheses, or from `bot_le n`,
+* an explicit upper bound can be found among the hypotheses, or from `le_top n`,
 * if multiple bounds are located, an instance of `linear_order α` is available, and
 * an instance of `fintype set.Ico l u` is available for the relevant bounds.
 
-You can also explicitly specify a lower and upper bound to use, as `interval_cases using hl hu`.
-The hypotheses should be in the form `hl : a ≤ n` and `hu : n < b`,
-in which case `interval_cases` calls `fin_cases` on the resulting fact `n ∈ set.Ico a b`.
-
+You can also explicitly specify a lower and upper bound to use, as `interval_cases using hl hu`,
+where the hypotheses should be of the form `hl : a ≤ n` and `hu : n < b`. In that case,
+`interval_cases` calls `fin_cases` on the resulting hypothesis `h : n ∈ set.Ico a b`.
 -/
-import tactic.fin_cases
-import data.fintype.intervals
 
 open set
 

--- a/src/tactic/norm_cast.lean
+++ b/src/tactic/norm_cast.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2019 Paul-Nicolas Madelaine. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul-Nicolas Madelaine, Robert Y. Lewis
-
-Normalizing casts inside expressions.
 -/
 import tactic.converter.interactive
 import tactic.hint

--- a/src/tactic/ring_exp.lean
+++ b/src/tactic/ring_exp.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2019 Tim Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tim Baanen
-
-Solve equations in commutative (semi)rings with exponents.
 -/
 import tactic.norm_num
 import control.traversable.basic

--- a/src/tactic/scc.lean
+++ b/src/tactic/scc.lean
@@ -2,13 +2,6 @@
 Copyright (c) 2018 Simon Hudon All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
-
-Tactics based on the strongly connected components (SCC) of a graph where
-the vertices are propositions and the edges are implications found
-in the context.
-
-They are used for finding the sets of equivalent propositions in a set
-of implications.
 -/
 import tactic.tauto
 import data.sum

--- a/src/tactic/simp_rw.lean
+++ b/src/tactic/simp_rw.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
-
-The `simp_rw` tactic, a mix of `simp` and `rewrite`.
 -/
 import tactic.core
 

--- a/src/tactic/tfae.lean
+++ b/src/tactic/tfae.lean
@@ -7,7 +7,7 @@ import data.list.tfae
 import tactic.scc
 
 /-!
-# The Following Are Equivalent
+# The Following Are Equivalent (TFAE)
 
 This file provides the tactics `tfae_have` and `tfae_finish` for proving the pairwise equivalence of
 propositions in a set using various implications between them.

--- a/src/tactic/tfae.lean
+++ b/src/tactic/tfae.lean
@@ -2,13 +2,16 @@
 Copyright (c) 2018 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Reid Barton, Simon Hudon
-
-"The Following Are Equivalent" (tfae) :
-Tactic for proving the equivalence of a set of proposition
-using various implications between them.
 -/
 import data.list.tfae
 import tactic.scc
+
+/-!
+# The Following Are Equivalent
+
+This file provides the tactics `tfae_have` and `tfae_finish` for proving the pairwise equivalence of
+propositions in a set using various implications between them.
+-/
 
 open expr tactic lean lean.parser
 

--- a/src/topology/algebra/localization.lean
+++ b/src/topology/algebra/localization.lean
@@ -2,11 +2,9 @@
 Copyright (c) 2021 María Inés de Frutos-Fernández. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: María Inés de Frutos-Fernández
-
-Localization of topological rings.
 -/
-import topology.algebra.ring
 import ring_theory.localization
+import topology.algebra.ring
 
 /-!
 

--- a/src/topology/algebra/ring.lean
+++ b/src/topology/algebra/ring.lean
@@ -2,13 +2,11 @@
 Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl
-
-Theory of topological rings.
 -/
-import topology.algebra.group
+import algebra.ring.prod
 import ring_theory.ideal.basic
 import ring_theory.subring
-import algebra.ring.prod
+import topology.algebra.group
 
 /-!
 

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -2,13 +2,11 @@
 Copyright (c) 2018 Reid Barton. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton
-
-Type of continuous maps and the compact-open topology on them.
 -/
-import topology.subset_properties
+import tactic.tidy
 import topology.continuous_function.basic
 import topology.homeomorph
-import tactic.tidy
+import topology.subset_properties
 
 /-!
 # The compact-open topology

--- a/test/conv/conv.lean
+++ b/test/conv/conv.lean
@@ -2,11 +2,12 @@
 Copyright (c) 2019 Lucas Allen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lucas Allen
-
-Tests for the `conv` tactic inside the inveractive `conv` monad
 -/
-
 import tactic.converter.interactive
+
+/-!
+# Tests for the `conv` tactic inside the interactive `conv` monad
+-/
 
 example (a b c d : ℕ) (h₁ : b = c) (h₂ : a + c = a + d) : a + b = a + d :=
 begin

--- a/test/finish1.lean
+++ b/test/finish1.lean
@@ -2,11 +2,14 @@
 Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
-
-Examples to test finish. (The designations "clarify," "safe," "iauto," etc. are
-from a previous tableau prover.)
 -/
 import tactic.finish
+
+/-!
+# Examples to test `finish`
+
+The designations "clarify," "safe," "iauto," etc. are from a previous tableau prover.
+-/
 open auto
 
 section

--- a/test/finish2.lean
+++ b/test/finish2.lean
@@ -2,10 +2,15 @@
 Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Nathaniel Thomas
-
-More examples to test automation, stolen shamelessly by Jeremy from Nathaniel's "tauto".
 -/
 import tactic.finish
+
+/-!
+# More examples to test `finish`
+
+Shamelessly stolen by Jeremy from Nathaniel's `tauto`.
+-/
+
 open nat
 
 section

--- a/test/finish3.lean
+++ b/test/finish3.lean
@@ -2,10 +2,15 @@
 Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
-
-Examples from the tutorial.
 -/
 import tactic.finish
+
+/-!
+# Examples for `finish`
+
+Those come from the tutorial.
+-/
+
 open auto
 
 section

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -2,11 +2,13 @@
 Copyright (c) 2017 Simon Hudon All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Mario Carneiro
-
-Tests for norm_num
 -/
 
 import tactic.norm_num
+
+/--
+# Tests for `norm_num` extensions
+-/
 
 constant real : Type
 notation `ℝ` := real

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -6,7 +6,7 @@ Authors: Simon Hudon, Mario Carneiro
 
 import tactic.norm_num
 
-/--
+/-!
 # Tests for `norm_num` extensions
 -/
 

--- a/test/norm_num_ext.lean
+++ b/test/norm_num_ext.lean
@@ -2,11 +2,13 @@
 Copyright (c) 2021 Mario Carneiro All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
-
-Tests for norm_num extensions
 -/
-import data.nat.prime
 import data.int.gcd
+import data.nat.prime
+
+/--
+# Tests for `norm_num` extensions
+-/
 
 -- coverage tests
 example : nat.coprime 1 2 := by norm_num

--- a/test/norm_num_ext.lean
+++ b/test/norm_num_ext.lean
@@ -6,7 +6,7 @@ Authors: Mario Carneiro
 import data.int.gcd
 import data.nat.prime
 
-/--
+/-!
 # Tests for `norm_num` extensions
 -/
 

--- a/test/simp_rw.lean
+++ b/test/simp_rw.lean
@@ -7,7 +7,7 @@ import data.nat.basic
 import data.set.basic
 import tactic.simp_rw
 
-/--
+/-!
 # Tests for `simp_rw` extensions
 -/
 

--- a/test/simp_rw.lean
+++ b/test/simp_rw.lean
@@ -2,12 +2,14 @@
 Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
-
-A set of test cases for the `simp_rw` tactic.
 -/
-import tactic.simp_rw
-import data.set.basic
 import data.nat.basic
+import data.set.basic
+import tactic.simp_rw
+
+/--
+# Tests for `simp_rw` extensions
+-/
 
 -- `simp_rw` can perform rewrites under binders:
 example : (λ (x y : ℕ), x + y) = (λ x y, y + x) := by simp_rw [add_comm]


### PR DESCRIPTION
This moves/removes the docs from the copyright header that are enough to make for the missing module docstring/redundant with the module docstring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Remain those that aren't quite enough to be a module docstring. Shing or I will take care of those by hand.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
