### PR TITLE
[Merged by Bors] - chore(ring_theory/localization): speed up `localization` a bit

### DIFF
--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -688,6 +688,14 @@ instance : has_add (localization M) := ⟨localization.add⟩
 lemma add_mk (a b c d) : (mk a b : localization M) + mk c d = mk (b * c + d * a) (b * d) :=
 by { unfold has_add.add localization.add, apply lift_on₂_mk }
 
+lemma add_mk_self (a b c) : (mk a b : localization M) + mk c b = mk (a + c) b :=
+begin
+  rw [add_mk, mk_eq_mk_iff, r_eq_r'],
+  refine (r' M).symm ⟨1, _⟩,
+  simp only [submonoid.coe_one, submonoid.coe_mul],
+  ring
+end
+
 /-- Negation in a ring localization is defined as `-⟨a, b⟩ = ⟨-a, b⟩`. -/
 @[irreducible] protected def neg (z : localization M) : localization M :=
 localization.lift_on z (λ a b, mk (-a) b) $
@@ -717,6 +725,24 @@ lemma mk_zero (b) : (mk 0 b : localization M) = 0 :=
 calc mk 0 b = mk 0 1 : mk_eq_mk_iff.mpr (r_of_eq (by simp))
 ... = 0 : by  unfold has_zero.zero localization.zero
 
+/-- Scalar multiplication in a ring localization is defined as `c • ⟨a, b⟩ = ⟨c • a, c • b⟩`. -/
+@[irreducible] protected def smul {S : Type*} [has_scalar S R] [is_scalar_tower S R R]
+  (c : S) (z : localization M) : localization M :=
+localization.lift_on z (λ a b, mk (c • a) b) $
+  λ a a' b b' h, mk_eq_mk_iff.2
+begin
+  cases b with b hb,
+  cases b' with b' hb',
+  rw r_eq_r' at h ⊢,
+  cases h with t ht,
+  use t,
+  simp only [smul_mul_assoc, ht]
+end
+
+lemma smul_mk {S : Type*} [has_scalar S R] [is_scalar_tower S R R]
+  (c : S) (a b) : localization.smul c (mk a b : localization M) = mk (c • a) b :=
+by { unfold has_scalar.smul localization.smul, apply lift_on_mk }
+
 private meta def tac := `[{
   intros,
   simp only [add_mk, localization.mk_mul, neg_mk, ← mk_zero 1],
@@ -730,6 +756,18 @@ instance : comm_ring (localization M) :=
   add  := (+),
   mul  := (*),
   npow := localization.npow _,
+  nsmul := localization.smul,
+  nsmul_zero' := λ x, localization.induction_on x
+    (λ x, by simp only [smul_mk, zero_nsmul, mk_zero]),
+  nsmul_succ' := λ n x, localization.induction_on x
+    (λ x, by simp only [smul_mk, succ_nsmul, add_mk_self]),
+  gsmul := localization.smul,
+  gsmul_zero' := λ x, localization.induction_on x
+    (λ x, by simp only [smul_mk, zero_gsmul, mk_zero]),
+  gsmul_succ' := λ n x, localization.induction_on x
+    (λ x, by simp [smul_mk, add_mk_self, -mk_eq_monoid_of_mk', add_comm (n : ℤ) 1, add_smul]),
+  gsmul_neg' := λ n x, localization.induction_on x
+    (λ x, by { rw [smul_mk, smul_mk, neg_mk, ← neg_smul], refl }),
   add_assoc      := λ m n k, localization.induction_on₃ m n k (by tac),
   zero_add       := λ y, localization.induction_on y (by tac),
   add_zero       := λ y, localization.induction_on y (by tac),
@@ -1974,8 +2012,10 @@ noncomputable instance : field (fraction_ring A) :=
   sub := has_sub.sub,
   one := 1,
   zero := 0,
+  nsmul := nsmul,
   gsmul := gsmul,
   npow := localization.npow _,
+  .. localization.comm_ring,
   .. is_fraction_ring.to_field A }
 
 @[simp] lemma mk_eq_div {r s} : (localization.mk r s : fraction_ring A) =


### PR DESCRIPTION
Now `nsmul` and `gsmul` are irreducible on `localization`. This helps against [timeouts when combining `localization` and `polynomial`](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60variables.60.20doesn't.20time.20out.20but.20inline.20params.20do), although the full test case is still quite slow (going from >40sec to approx 11 sec).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
