### PR TITLE
[Merged by Bors] - chore({field,ring}_theory): generalize `fraction_ring` and `is_separable` to rings

### DIFF
--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -599,8 +599,12 @@ end
 -- See: https://en.wikipedia.org/wiki/Separable_extension#Separability_of_transcendental_extensions
 
 /-- Typeclass for separable field extension: `K` is a separable field extension of `F` iff
-the minimal polynomial of every `x : K` is separable. -/
-class is_separable (F K : Sort*) [field F] [field K] [algebra F K] : Prop :=
+the minimal polynomial of every `x : K` is separable.
+
+We define this for general (commutative) rings and only assume `F` and `K` are fields if this
+is needed for a proof.
+-/
+class is_separable (F K : Sort*) [comm_ring F] [ring K] [algebra F K] : Prop :=
 (is_integral' (x : K) : is_integral F x)
 (separable' (x : K) : (minpoly F x).separable)
 

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -595,6 +595,10 @@ begin
   intro hf2, rw [hf2, C_0] at hf1, exact absurd hf1 hf.ne_zero
 end
 
+section comm_ring
+
+variables (F K : Type*) [comm_ring F] [ring K] [algebra F K]
+
 -- TODO: refactor to allow transcendental extensions?
 -- See: https://en.wikipedia.org/wiki/Separable_extension#Separability_of_transcendental_extensions
 
@@ -604,20 +608,25 @@ the minimal polynomial of every `x : K` is separable.
 We define this for general (commutative) rings and only assume `F` and `K` are fields if this
 is needed for a proof.
 -/
-class is_separable (F K : Sort*) [comm_ring F] [ring K] [algebra F K] : Prop :=
+class is_separable : Prop :=
 (is_integral' (x : K) : is_integral F x)
 (separable' (x : K) : (minpoly F x).separable)
 
-theorem is_separable.is_integral (F) {K} [field F] [field K] [algebra F K] [is_separable F K] :
+variables (F) {K}
+
+theorem is_separable.is_integral [is_separable F K] :
   ∀ x : K, is_integral F x := is_separable.is_integral'
 
-theorem is_separable.separable (F) {K} [field F] [field K] [algebra F K] [is_separable F K] :
+theorem is_separable.separable [is_separable F K] :
   ∀ x : K, (minpoly F x).separable := is_separable.separable'
 
-theorem is_separable_iff {F K} [field F] [field K] [algebra F K] : is_separable F K ↔
-  ∀ x : K, is_integral F x ∧ (minpoly F x).separable :=
+variables {F K}
+
+theorem is_separable_iff : is_separable F K ↔ ∀ x : K, is_integral F x ∧ (minpoly F x).separable :=
 ⟨λ h x, ⟨@@is_separable.is_integral F _ _ _ h x, @@is_separable.separable F _ _ _ h x⟩,
  λ h, ⟨λ x, (h x).1, λ x, (h x).2⟩⟩
+
+end comm_ring
 
 instance is_separable_self (F : Type*) [field F] : is_separable F F :=
 ⟨λ x, is_integral_algebra_map, λ x, by { rw minpoly.eq_X_sub_C', exact separable_X_sub_C }⟩

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1958,10 +1958,14 @@ end integral_closure
 
 end algebra
 
-variables (A)
+variables (R A)
 
-/-- The fraction field of an integral domain as a quotient type. -/
-@[reducible] def fraction_ring := localization (non_zero_divisors A)
+/-- The fraction ring of a commutative ring `R` as a quotient type.
+
+We instantiate this definition as generally as possible, and assume that the
+commutative ring `R` is an integral domain only when this is needed for proving.
+-/
+@[reducible] def fraction_ring := localization (non_zero_divisors R)
 
 namespace fraction_ring
 


### PR DESCRIPTION
These used to be defined only for `integral_domain`s resp. `field`s, however the construction makes sense even for `comm_ring`s. So we can just do the generalization for free, and moreover it makes certain proof terms in their definition a lot smaller. Together with #9414, this helps against [timeouts when combining `localization` and `polynomial`](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60variables.60.20doesn't.20time.20out.20but.20inline.20params.20do), although the full test case is still quite slow (going from >40sec to approx 11 sec).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
