### PR TITLE
[Merged by Bors] - chore(order/*): replace `mono_incr` and `mono_decr` in lemma names wih `monotone` and `antitone`

### DIFF
--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -522,7 +522,7 @@ end mul
 
 section pow
 
-lemma pow_mono_decr_exp {a : ℝ≥0} (m n : ℕ) (mn : m ≤ n) (a1 : a ≤ 1) :
+lemma pow_antitone_exp {a : ℝ≥0} (m n : ℕ) (mn : m ≤ n) (a1 : a ≤ 1) :
   a ^ n ≤ a ^ m :=
 begin
   rcases le_iff_exists_add.mp mn with ⟨k, rfl⟩,

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -504,29 +504,29 @@ theorem cinfi_eq_of_forall_ge_of_forall_gt_exists_lt [nonempty ι] {f : ι → �
 
 /-- Nested intervals lemma: if `f` is a monotone sequence, `g` is an antitone sequence, and
 `f n ≤ g n` for all `n`, then `⨆ n, f n` belongs to all the intervals `[f n, g n]`. -/
-lemma csupr_mem_Inter_Icc_of_mono_incr_of_mono_decr [nonempty β] [semilattice_sup β]
+lemma csupr_mem_Inter_Icc_of_monotone_of_antitone [nonempty β] [semilattice_sup β]
   {f g : β → α} (hf : monotone f) (hg : ∀ ⦃m n⦄, m ≤ n → g n ≤ g m) (h : ∀ n, f n ≤ g n) :
   (⨆ n, f n) ∈ ⋂ n, Icc (f n) (g n) :=
 begin
   inhabit β,
   refine mem_Inter.2 (λ n, ⟨le_csupr ⟨g $ default β, forall_range_iff.2 $ λ m, _⟩ _,
-    csupr_le $ λ m, _⟩); exact forall_le_of_monotone_of_mono_decr hf hg h _ _
+    csupr_le $ λ m, _⟩); exact forall_le_of_monotone_of_antitone hf hg h _ _
 end
 
 /-- Nested intervals lemma: if `[f n, g n]` is an antitone sequence of nonempty
 closed intervals, then `⨆ n, f n` belongs to all the intervals `[f n, g n]`. -/
-lemma csupr_mem_Inter_Icc_of_mono_decr_Icc [nonempty β] [semilattice_sup β]
+lemma csupr_mem_Inter_Icc_of_antitone_Icc [nonempty β] [semilattice_sup β]
   {f g : β → α} (h : ∀ ⦃m n⦄, m ≤ n → Icc (f n) (g n) ⊆ Icc (f m) (g m)) (h' : ∀ n, f n ≤ g n) :
   (⨆ n, f n) ∈ ⋂ n, Icc (f n) (g n) :=
-csupr_mem_Inter_Icc_of_mono_incr_of_mono_decr (λ m n hmn, ((Icc_subset_Icc_iff (h' n)).1 (h hmn)).1)
+csupr_mem_Inter_Icc_of_monotone_of_antitone (λ m n hmn, ((Icc_subset_Icc_iff (h' n)).1 (h hmn)).1)
   (λ m n hmn, ((Icc_subset_Icc_iff (h' n)).1 (h hmn)).2) h'
 
 /-- Nested intervals lemma: if `[f n, g n]` is an antitone sequence of nonempty
 closed intervals, then `⨆ n, f n` belongs to all the intervals `[f n, g n]`. -/
-lemma csupr_mem_Inter_Icc_of_mono_decr_Icc_nat
+lemma csupr_mem_Inter_Icc_of_antitone_Icc_nat
   {f g : ℕ → α} (h : ∀ n, Icc (f (n + 1)) (g (n + 1)) ⊆ Icc (f n) (g n)) (h' : ∀ n, f n ≤ g n) :
   (⨆ n, f n) ∈ ⋂ n, Icc (f n) (g n) :=
-csupr_mem_Inter_Icc_of_mono_decr_Icc
+csupr_mem_Inter_Icc_of_antitone_Icc
   (@monotone_nat_of_le_succ (order_dual $ set α) _ (λ n, Icc (f n) (g n)) h) h'
 
 lemma finset.nonempty.sup'_eq_cSup_image {s : finset β} (hs : s.nonempty) (f : β → α) :

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -241,7 +241,7 @@ assume ⟨b, hb⟩,
 
 /-- If `f` is monotone, `g` is antitone, and `f a ≤ g a` for all `a`, then for all `a`, `b` we have
 `f a ≤ g b`. -/
-theorem forall_le_of_monotone_of_mono_decr {β : Type*} [preorder β]
+theorem forall_le_of_monotone_of_antitone {β : Type*} [preorder β]
   {f g : α → β} (hf : monotone f) (hg : ∀ ⦃m n⦄, m ≤ n → g n ≤ g m)
   (h : ∀ n, f n ≤ g n) (m n : α) : f m ≤ g n :=
 calc f m ≤ f (m ⊔ n) : hf le_sup_left

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -3586,7 +3586,7 @@ by rw [continuous_within_at_Ioi_iff_Ici, continuous_within_at_Iio_iff_Iic,
 
 In this section we prove the following fact: if `f` is a monotone function on a neighborhood of `a`
 and the image of this neighborhood is a neighborhood of `f a`, then `f` is continuous at `a`, see
-`continuous_at_of_mono_incr_on_of_image_mem_nhds`, as well as several similar facts.
+`continuous_at_of_monotone_on_of_image_mem_nhds`, as well as several similar facts.
 -/
 
 section linear_order
@@ -3624,7 +3624,7 @@ under `f` meets every interval `(f a, b)`, `b > f a`, then `f` is continuous at 
 The assumption `hfs : ∀ b > f a, ∃ c ∈ s, f c ∈ Ioo (f a) b` cannot be replaced by the weaker
 assumption `hfs : ∀ b > f a, ∃ c ∈ s, f c ∈ Ioc (f a) b` we use for strictly monotone functions
 because otherwise the function `ceil : ℝ → ℤ` would be a counter-example at `a = 0`. -/
-lemma continuous_at_right_of_mono_incr_on_of_exists_between {f : α → β} {s : set α} {a : α}
+lemma continuous_at_right_of_monotone_on_of_exists_between {f : α → β} {s : set α} {a : α}
   (h_mono : ∀ (x ∈ s) (y ∈ s), x ≤ y → f x ≤ f y) (hs : s ∈ 𝓝[Ici a] a)
   (hfs : ∀ b > f a, ∃ c ∈ s, f c ∈ Ioo (f a) b) :
   continuous_within_at f (Ici a) a :=
@@ -3645,12 +3645,12 @@ end
 /-- If a function `f` with a densely ordered codomain is monotone on a right neighborhood of `a` and
 the closure of the image of this neighborhood under `f` is a right neighborhood of `f a`, then `f`
 is continuous at `a` from the right. -/
-lemma continuous_at_right_of_mono_incr_on_of_closure_image_mem_nhds_within [densely_ordered β]
+lemma continuous_at_right_of_monotone_on_of_closure_image_mem_nhds_within [densely_ordered β]
   {f : α → β} {s : set α} {a : α} (h_mono : ∀ (x ∈ s) (y ∈ s), x ≤ y → f x ≤ f y)
   (hs : s ∈ 𝓝[Ici a] a) (hfs : closure (f '' s) ∈ 𝓝[Ici (f a)] (f a)) :
   continuous_within_at f (Ici a) a :=
 begin
-  refine continuous_at_right_of_mono_incr_on_of_exists_between h_mono hs (λ b hb, _),
+  refine continuous_at_right_of_monotone_on_of_exists_between h_mono hs (λ b hb, _),
   rcases (mem_nhds_within_Ici_iff_exists_mem_Ioc_Ico_subset hb).1 hfs with ⟨b', ⟨hab', hbb'⟩, hb'⟩,
   rcases exists_between hab' with ⟨c', hc'⟩,
   rcases mem_closure_iff.1 (hb' ⟨hc'.1.le, hc'.2⟩) (Ioo (f a) b') is_open_Ioo hc'
@@ -3661,11 +3661,11 @@ end
 /-- If a function `f` with a densely ordered codomain is monotone on a right neighborhood of `a` and
 the image of this neighborhood under `f` is a right neighborhood of `f a`, then `f` is continuous at
 `a` from the right. -/
-lemma continuous_at_right_of_mono_incr_on_of_image_mem_nhds_within [densely_ordered β] {f : α → β}
+lemma continuous_at_right_of_monotone_on_of_image_mem_nhds_within [densely_ordered β] {f : α → β}
   {s : set α} {a : α} (h_mono : ∀ (x ∈ s) (y ∈ s), x ≤ y → f x ≤ f y) (hs : s ∈ 𝓝[Ici a] a)
   (hfs : f '' s ∈ 𝓝[Ici (f a)] (f a)) :
   continuous_within_at f (Ici a) a :=
-continuous_at_right_of_mono_incr_on_of_closure_image_mem_nhds_within h_mono hs $
+continuous_at_right_of_monotone_on_of_closure_image_mem_nhds_within h_mono hs $
   mem_of_superset hfs subset_closure
 
 /-- If a function `f` with a densely ordered codomain is strictly monotone on a right neighborhood
@@ -3675,7 +3675,7 @@ lemma strict_mono_on.continuous_at_right_of_closure_image_mem_nhds_within [dense
   {f : α → β} {s : set α} {a : α} (h_mono : strict_mono_on f s) (hs : s ∈ 𝓝[Ici a] a)
   (hfs : closure (f '' s) ∈ 𝓝[Ici (f a)] (f a)) :
   continuous_within_at f (Ici a) a :=
-continuous_at_right_of_mono_incr_on_of_closure_image_mem_nhds_within
+continuous_at_right_of_monotone_on_of_closure_image_mem_nhds_within
   (λ x hx y hy, (h_mono.le_iff_le hx hy).2) hs hfs
 
 /-- If a function `f` with a densely ordered codomain is strictly monotone on a right neighborhood
@@ -3716,32 +3716,32 @@ under `f` meets every interval `(b, f a)`, `b < f a`, then `f` is continuous at 
 The assumption `hfs : ∀ b < f a, ∃ c ∈ s, f c ∈ Ioo b (f a)` cannot be replaced by the weaker
 assumption `hfs : ∀ b < f a, ∃ c ∈ s, f c ∈ Ico b (f a)` we use for strictly monotone functions
 because otherwise the function `floor : ℝ → ℤ` would be a counter-example at `a = 0`. -/
-lemma continuous_at_left_of_mono_incr_on_of_exists_between {f : α → β} {s : set α} {a : α}
+lemma continuous_at_left_of_monotone_on_of_exists_between {f : α → β} {s : set α} {a : α}
   (h_mono : ∀ (x ∈ s) (y ∈ s), x ≤ y → f x ≤ f y) (hs : s ∈ 𝓝[Iic a] a)
   (hfs : ∀ b < f a, ∃ c ∈ s, f c ∈ Ioo b (f a)) :
   continuous_within_at f (Iic a) a :=
-@continuous_at_right_of_mono_incr_on_of_exists_between (order_dual α) (order_dual β) _ _ _ _ _ _
+@continuous_at_right_of_monotone_on_of_exists_between (order_dual α) (order_dual β) _ _ _ _ _ _
   f s a (λ x hx y hy, h_mono y hy x hx) hs $
   λ b hb, let ⟨c, hcs, hcb, hca⟩ := hfs b hb in ⟨c, hcs, hca, hcb⟩
 
 /-- If a function `f` with a densely ordered codomain is monotone on a left neighborhood of `a` and
 the closure of the image of this neighborhood under `f` is a left neighborhood of `f a`, then `f` is
 continuous at `a` from the left -/
-lemma continuous_at_left_of_mono_incr_on_of_closure_image_mem_nhds_within [densely_ordered β]
+lemma continuous_at_left_of_monotone_on_of_closure_image_mem_nhds_within [densely_ordered β]
   {f : α → β} {s : set α} {a : α} (h_mono : ∀ (x ∈ s) (y ∈ s), x ≤ y → f x ≤ f y)
   (hs : s ∈ 𝓝[Iic a] a) (hfs : closure (f '' s) ∈ 𝓝[Iic (f a)] (f a)) :
   continuous_within_at f (Iic a) a :=
-@continuous_at_right_of_mono_incr_on_of_closure_image_mem_nhds_within (order_dual α) (order_dual β)
+@continuous_at_right_of_monotone_on_of_closure_image_mem_nhds_within (order_dual α) (order_dual β)
   _ _ _ _ _ _ _ f s a (λ x hx y hy, h_mono y hy x hx) hs hfs
 
 /-- If a function `f` with a densely ordered codomain is monotone on a left neighborhood of `a` and
 the image of this neighborhood under `f` is a left neighborhood of `f a`, then `f` is continuous at
 `a` from the left. -/
-lemma continuous_at_left_of_mono_incr_on_of_image_mem_nhds_within [densely_ordered β]
+lemma continuous_at_left_of_monotone_on_of_image_mem_nhds_within [densely_ordered β]
   {f : α → β} {s : set α} {a : α} (h_mono : ∀ (x ∈ s) (y ∈ s), x ≤ y → f x ≤ f y)
   (hs : s ∈ 𝓝[Iic a] a) (hfs : f '' s ∈ 𝓝[Iic (f a)] (f a)) :
   continuous_within_at f (Iic a) a :=
-continuous_at_left_of_mono_incr_on_of_closure_image_mem_nhds_within h_mono hs
+continuous_at_left_of_monotone_on_of_closure_image_mem_nhds_within h_mono hs
   (mem_of_superset hfs subset_closure)
 
 /-- If a function `f` with a densely ordered codomain is strictly monotone on a left neighborhood of
@@ -3803,36 +3803,36 @@ h_mono.continuous_at_of_closure_image_mem_nhds hs (mem_of_superset hfs subset_cl
 /-- If `f` is a monotone function on a neighborhood of `a` and the image of this neighborhood under
 `f` meets every interval `(b, f a)`, `b < f a`, and every interval `(f a, b)`, `b > f a`, then `f`
 is continuous at `a`. -/
-lemma continuous_at_of_mono_incr_on_of_exists_between {f : α → β} {s : set α} {a : α}
+lemma continuous_at_of_monotone_on_of_exists_between {f : α → β} {s : set α} {a : α}
   (h_mono : ∀ (x ∈ s) (y ∈ s), x ≤ y → f x ≤ f y) (hs : s ∈ 𝓝 a)
   (hfs_l : ∀ b < f a, ∃ c ∈ s, f c ∈ Ioo b (f a)) (hfs_r : ∀ b > f a, ∃ c ∈ s, f c ∈ Ioo (f a) b) :
   continuous_at f a :=
 continuous_at_iff_continuous_left_right.2
-  ⟨continuous_at_left_of_mono_incr_on_of_exists_between h_mono
+  ⟨continuous_at_left_of_monotone_on_of_exists_between h_mono
      (mem_nhds_within_of_mem_nhds hs) hfs_l,
-   continuous_at_right_of_mono_incr_on_of_exists_between h_mono
+   continuous_at_right_of_monotone_on_of_exists_between h_mono
      (mem_nhds_within_of_mem_nhds hs) hfs_r⟩
 
 /-- If a function `f` with a densely ordered codomain is monotone on a neighborhood of `a` and the
 closure of the image of this neighborhood under `f` is a neighborhood of `f a`, then `f` is
 continuous at `a`. -/
-lemma continuous_at_of_mono_incr_on_of_closure_image_mem_nhds [densely_ordered β] {f : α → β}
+lemma continuous_at_of_monotone_on_of_closure_image_mem_nhds [densely_ordered β] {f : α → β}
   {s : set α} {a : α} (h_mono : ∀ (x ∈ s) (y ∈ s), x ≤ y → f x ≤ f y) (hs : s ∈ 𝓝 a)
   (hfs : closure (f '' s) ∈ 𝓝 (f a)) :
   continuous_at f a :=
 continuous_at_iff_continuous_left_right.2
-  ⟨continuous_at_left_of_mono_incr_on_of_closure_image_mem_nhds_within h_mono
+  ⟨continuous_at_left_of_monotone_on_of_closure_image_mem_nhds_within h_mono
      (mem_nhds_within_of_mem_nhds hs) (mem_nhds_within_of_mem_nhds hfs),
-   continuous_at_right_of_mono_incr_on_of_closure_image_mem_nhds_within h_mono
+   continuous_at_right_of_monotone_on_of_closure_image_mem_nhds_within h_mono
      (mem_nhds_within_of_mem_nhds hs) (mem_nhds_within_of_mem_nhds hfs)⟩
 
 /-- If a function `f` with a densely ordered codomain is monotone on a neighborhood of `a` and the
 image of this neighborhood under `f` is a neighborhood of `f a`, then `f` is continuous at `a`. -/
-lemma continuous_at_of_mono_incr_on_of_image_mem_nhds [densely_ordered β] {f : α → β}
+lemma continuous_at_of_monotone_on_of_image_mem_nhds [densely_ordered β] {f : α → β}
   {s : set α} {a : α} (h_mono : ∀ (x ∈ s) (y ∈ s), x ≤ y → f x ≤ f y) (hs : s ∈ 𝓝 a)
   (hfs : f '' s ∈ 𝓝 (f a)) :
   continuous_at f a :=
-continuous_at_of_mono_incr_on_of_closure_image_mem_nhds h_mono hs
+continuous_at_of_monotone_on_of_closure_image_mem_nhds h_mono hs
   (mem_of_superset hfs subset_closure)
 
 /-- A monotone function with densely ordered codomain and a dense range is continuous. -/
@@ -3840,7 +3840,7 @@ lemma monotone.continuous_of_dense_range [densely_ordered β] {f : α → β}
   (h_mono : monotone f) (h_dense : dense_range f) :
   continuous f :=
 continuous_iff_continuous_at.mpr $ λ a,
-  continuous_at_of_mono_incr_on_of_closure_image_mem_nhds (λ x hx y hy hxy, h_mono hxy)
+  continuous_at_of_monotone_on_of_closure_image_mem_nhds (λ x hx y hy hxy, h_mono hxy)
     univ_mem $ by simp only [image_univ, h_dense.closure_eq, univ_mem]
 
 /-- A monotone surjective function with a densely ordered codomain is continuous. -/


### PR DESCRIPTION
This change was performed as a find-and-replace. No occurrences of `incr` or `decr` appear as tokens in lemma names after this change.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I meant to do this in #9401, but forgot.