### PR TITLE
[Merged by Bors] - chore(analysis/convex/function): change `add_comm_monoid` to `add_comm_group` when carrier type is module of scalars containing -1

### DIFF
--- a/src/analysis/convex/combination.lean
+++ b/src/analysis/convex/combination.lean
@@ -26,7 +26,7 @@ open set
 open_locale big_operators classical
 
 universes u u'
-variables {R E ι ι' : Type*} [linear_ordered_field R] [add_comm_monoid E] [module R E] {s : set E}
+variables {R E ι ι' : Type*} [linear_ordered_field R] [add_comm_group E] [module R E] {s : set E}
 
 /-- Center of mass of a finite collection of points with prescribed weights.
 Note that we require neither `0 ≤ w i` nor `∑ w = 1`. -/

--- a/src/analysis/convex/function.lean
+++ b/src/analysis/convex/function.lean
@@ -602,7 +602,7 @@ end linear_ordered_field
 /-! ### Jensen's inequality -/
 
 section jensen
-variables [linear_ordered_field 𝕜] [add_comm_monoid E] [ordered_add_comm_monoid β] [module 𝕜 E]
+variables [linear_ordered_field 𝕜] [add_comm_group E] [ordered_add_comm_group β] [module 𝕜 E]
   [module 𝕜 β] [ordered_smul 𝕜 β] {s : set E} {f : E → β} {t : finset ι} {w : ι → 𝕜} {p : ι → E}
 
 /-- Convex **Jensen's inequality**, `finset.center_mass` version. -/
@@ -641,7 +641,7 @@ end jensen
 /-! ### Maximum principle -/
 
 section maximum_principle
-variables [linear_ordered_field 𝕜] [add_comm_monoid E] [linear_ordered_add_comm_group β]
+variables [linear_ordered_field 𝕜] [add_comm_group E] [linear_ordered_add_comm_group β]
   [module 𝕜 E] [module 𝕜 β] [ordered_smul 𝕜 β] {s : set E} {f : E → β} {t : finset ι} {w : ι → 𝕜}
   {p : ι → E}
 


### PR DESCRIPTION
Related [Zulip conversation](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Convexity.20refactor/near/255268131)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
