### PR TITLE
[Merged by Bors] - feat(data/polynomial,field_theory): `(minpoly A x).map f ≠ 1`

### DIFF
--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -165,6 +165,20 @@ begin
     simp [coeff_mul, nat.antidiagonal, hp.leading_coeff, hq.leading_coeff, add_comm]
 end
 
+lemma eq_one_of_map_eq_one {S : Type*} [semiring S] [nontrivial S]
+  (f : R →+* S) (hp : p.monic) (map_eq : p.map f = 1) : p = 1 :=
+begin
+  nontriviality R,
+  have hdeg : p.degree = 0,
+  { rw [← degree_map_eq_of_leading_coeff_ne_zero f _, map_eq, degree_one],
+    { rw [hp.leading_coeff, f.map_one],
+      exact one_ne_zero } },
+  have hndeg : p.nat_degree = 0 :=
+    with_bot.coe_eq_coe.mp ((degree_eq_nat_degree hp.ne_zero).symm.trans hdeg),
+  convert eq_C_of_degree_eq_zero hdeg,
+  rw [← hndeg, ← polynomial.leading_coeff, hp.leading_coeff, C.map_one]
+end
+
 end monic
 
 end semiring

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -69,6 +69,36 @@ begin
   { exact aeval_zero _ }
 end
 
+/-- A minimal polynomial is not `1`.
+
+See also `minpoly.not_is_unit` (which also assumes `A` is nontrivial).
+-/
+lemma ne_one [nontrivial B] : minpoly A x ≠ 1 :=
+begin
+  intro h,
+  refine (one_ne_zero : (1 : B) ≠ 0) _,
+  simpa using congr_arg (polynomial.aeval x) h
+end
+
+lemma map_ne_one [nontrivial B] {R : Type*} [semiring R] [nontrivial R] (f : A →+* R) :
+  (minpoly A x).map f ≠ 1 :=
+begin
+  by_cases hx : is_integral A x,
+  { exact mt ((monic hx).eq_one_of_map_eq_one f) (ne_one A x) },
+  { rw [eq_zero hx, polynomial.map_zero], exact zero_ne_one },
+end
+
+/-- A minimal polynomial is not a unit.
+
+See also `minpoly.ne_one` (which doesn't need to assume `A` is nontrivial).
+-/
+lemma not_is_unit [nontrivial A] [nontrivial B] : ¬ is_unit (minpoly A x) :=
+begin
+  by_cases hx : is_integral A x,
+  { exact mt (eq_one_of_is_unit_of_monic (monic hx)) (ne_one A x) },
+  { rw [eq_zero hx], exact not_is_unit_zero }
+end
+
 lemma mem_range_of_degree_eq_one (hx : (minpoly A x).degree = 1) : x ∈ (algebra_map A B).range :=
 begin
   have h : is_integral A x,
@@ -144,16 +174,6 @@ begin
     exact (hf hroot) },
   rw hrw,
   simp only [h0, ring_hom.map_neg, sub_eq_add_neg],
-end
-
-variables (A x)
-
-/-- A minimal polynomial is not a unit. -/
-lemma not_is_unit : ¬ is_unit (minpoly A x) :=
-begin
-  by_cases hx : is_integral A x,
-  { assume H, exact (ne_of_lt (degree_pos hx)).symm (degree_eq_zero_of_is_unit H) },
-  { delta minpoly, rw dif_neg hx, simp only [not_is_unit_zero, not_false_iff] }
 end
 
 end ring

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -69,10 +69,7 @@ begin
   { exact aeval_zero _ }
 end
 
-/-- A minimal polynomial is not `1`.
-
-See also `minpoly.not_is_unit` (which also assumes `A` is nontrivial).
--/
+/-- A minimal polynomial is not `1`. -/
 lemma ne_one [nontrivial B] : minpoly A x ≠ 1 :=
 begin
   intro h,
@@ -88,12 +85,10 @@ begin
   { rw [eq_zero hx, polynomial.map_zero], exact zero_ne_one },
 end
 
-/-- A minimal polynomial is not a unit.
-
-See also `minpoly.ne_one` (which doesn't need to assume `A` is nontrivial).
--/
-lemma not_is_unit [nontrivial A] [nontrivial B] : ¬ is_unit (minpoly A x) :=
+/-- A minimal polynomial is not a unit. -/
+lemma not_is_unit [nontrivial B] : ¬ is_unit (minpoly A x) :=
 begin
+  haveI : nontrivial A := (algebra_map A B).domain_nontrivial,
   by_cases hx : is_integral A x,
   { exact mt (eq_one_of_is_unit_of_monic (monic hx)) (ne_one A x) },
   { rw [eq_zero hx], exact not_is_unit_zero }


### PR DESCRIPTION
We use this result to generalize `minpoly.not_is_unit` from integral domains to nontrivial `comm_ring`s.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
