### PR TITLE
[Merged by Bors] - feat(set_theory/cardinal_ordinal): there is no injective function from ordinals to types in the same universe

### DIFF
--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -168,10 +168,6 @@ lemma bijective.of_comp_iff' {f : α → β} (hf : bijective f) (g : γ → α) 
   function.bijective (f ∘ g) ↔ function.bijective g :=
 and_congr (injective.of_comp_iff hf.injective _) (surjective.of_comp_iff' hf _)
 
-lemma up_injective {α : Type u} :
-  function.injective (ulift.up.{v} : α → ulift α) :=
-by { intros x1 x2 h, cc }
-
 /-- **Cantor's diagonal argument** implies that there are no surjective functions from `α`
 to `set α`. -/
 theorem cantor_surjective {α} (f : α → set α) : ¬ function.surjective f | h :=

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -168,6 +168,10 @@ lemma bijective.of_comp_iff' {f : α → β} (hf : bijective f) (g : γ → α) 
   function.bijective (f ∘ g) ↔ function.bijective g :=
 and_congr (injective.of_comp_iff hf.injective _) (surjective.of_comp_iff' hf _)
 
+lemma up_injective {α : Type u} :
+  function.injective (ulift.up.{v} : α → ulift α) :=
+by { intros x1 x2 h, cc }
+
 /-- **Cantor's diagonal argument** implies that there are no surjective functions from `α`
 to `set α`. -/
 theorem cantor_surjective {α} (f : α → set α) : ¬ function.surjective f | h :=

--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -921,7 +921,7 @@ begin
   exact lt_irrefl _ this
 end
 
-lemma not_injective_of_ordinal' {α : Type v} [small.{u} α] (f : ordinal.{u} → α) :
+lemma not_injective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : ordinal.{u} → α) :
   ¬ function.injective f :=
 begin
   intro hf,

--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -911,11 +911,11 @@ lemma not_injective_of_ordinal {α : Type u} (f : ordinal.{u} → α) :
 begin
   let g : ordinal.{u} → ulift.{u+1} α := λ o, ulift.up (f o),
   suffices : ¬ function.injective g,
-  { intro hf, exact this (up_injective.comp hf) },
+  { intro hf, exact this (equiv.ulift.symm.injective.comp hf) },
   intro hg,
   replace hg := cardinal.mk_le_of_injective hg,
   rw ← cardinal.lift_mk at hg,
-  replace hg := lt_of_le_of_lt hg (cardinal.lift_lt_univ _),
-  contrapose! hg,
-  rw cardinal.univ_id
+  have := hg.trans_lt (cardinal.lift_lt_univ _),
+  rw cardinal.univ_id at this,
+  exact lt_irrefl _ this
 end

--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 
 import set_theory.ordinal_arithmetic
 import tactic.linarith
+import logic.small
 
 /-!
 # Cardinals and ordinals
@@ -918,4 +919,12 @@ begin
   have := hg.trans_lt (cardinal.lift_lt_univ _),
   rw cardinal.univ_id at this,
   exact lt_irrefl _ this
+end
+
+lemma not_injective_of_ordinal' {α : Type v} [small.{u} α] (f : ordinal.{u} → α) :
+  ¬ function.injective f :=
+begin
+  intro hf,
+  apply not_injective_of_ordinal (equiv_shrink α ∘ f),
+  exact (equiv_shrink _).injective.comp hf,
 end

--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -905,3 +905,17 @@ le_refl _
 end bit
 
 end cardinal
+
+lemma not_injective_of_ordinal {α : Type u} (f : ordinal.{u} → α) :
+  ¬ function.injective f :=
+begin
+  let g : ordinal.{u} → ulift.{u+1} α := λ o, ulift.up (f o),
+  suffices : ¬ function.injective g,
+  { intro hf, exact this (up_injective.comp hf) },
+  intro hg,
+  replace hg := cardinal.mk_le_of_injective hg,
+  rw ← cardinal.lift_mk at hg,
+  replace hg := lt_of_le_of_lt hg (cardinal.lift_lt_univ _),
+  contrapose! hg,
+  rw cardinal.univ_id
+end


### PR DESCRIPTION
Contributed by @rwbarton at https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Transfinite.20recursion/near/253614140

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
