### PR TITLE
[Merged by Bors] - feat(group_theory/sylow): The number of Sylow subgroups equals the index of the normalizer

### DIFF
--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -90,7 +90,7 @@ instance sylow.pointwise_mul_action {α : Type*} [group α] [mul_distrib_mul_act
   mul_smul := λ g h P, sylow.ext (mul_smul g h P) }
 
 instance sylow.mul_action : mul_action G (sylow p G) :=
-mul_action.comp_hom _ mul_aut.conj
+comp_hom _ mul_aut.conj
 
 lemma sylow.coe_subgroup_smul {g : G} {P : sylow p G} :
   ↑(g • P) = mul_aut.conj g • (P : subgroup G) := rfl
@@ -179,7 +179,7 @@ of_equiv (sylow p G) (sylow_equiv_quotient_normalizer P)
 
 lemma card_sylow_eq_card_quotient_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   card (sylow p G) = card (quotient_group.quotient P.1.normalizer) :=
-fintype.card_congr (sylow_equiv_quotient_normalizer P)
+card_congr (sylow_equiv_quotient_normalizer P)
 
 lemma card_sylow_eq_index_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   card (sylow p G) = P.1.normalizer.index :=

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -159,27 +159,28 @@ end
 
 variables {p} {G}
 
-lemma orbit_sylow_eq_top [fact p.prime] [fintype (sylow p G)] (P : sylow p G) : orbit G P = ⊤ :=
+@[simp] lemma sylow.orbit_eq_top [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+  orbit G P = ⊤ :=
 top_le_iff.mp (λ Q hQ, exists_smul_eq G P Q)
 
-lemma stabilizer_sylow_eq_normalizer (P : sylow p G) : stabilizer G P = P.1.normalizer :=
+lemma sylow.stabilizer_eq_normalizer (P : sylow p G) : stabilizer G P = P.1.normalizer :=
 ext (λ g, sylow.smul_eq_iff_mem_normalizer)
 
 /-- Sylow `p`-subgroups are in bijection with cosets of the normalizer of a Sylow `p`-subgroup -/
-noncomputable def sylow_equiv_quotient_normalizer [fact p.prime] [fintype (sylow p G)]
+noncomputable def sylow.equiv_quotient_normalizer [fact p.prime] [fintype (sylow p G)]
   (P : sylow p G) : sylow p G ≃ quotient_group.quotient P.1.normalizer :=
 calc sylow p G ≃ (⊤ : set (sylow p G)) : (equiv.set.univ (sylow p G)).symm
-... ≃ orbit G P : by rw orbit_sylow_eq_top
+... ≃ orbit G P : by rw P.orbit_eq_top
 ... ≃ quotient_group.quotient (stabilizer G P) : orbit_equiv_quotient_stabilizer G P
-... ≃ quotient_group.quotient P.1.normalizer : by rw stabilizer_sylow_eq_normalizer
+... ≃ quotient_group.quotient P.1.normalizer : by rw P.stabilizer_eq_normalizer
 
 noncomputable instance [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   fintype (quotient_group.quotient P.1.normalizer) :=
-of_equiv (sylow p G) (sylow_equiv_quotient_normalizer P)
+of_equiv (sylow p G) P.equiv_quotient_normalizer
 
 lemma card_sylow_eq_card_quotient_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   card (sylow p G) = card (quotient_group.quotient P.1.normalizer) :=
-card_congr (sylow_equiv_quotient_normalizer P)
+card_congr P.equiv_quotient_normalizer
 
 lemma card_sylow_eq_index_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   card (sylow p G) = P.1.normalizer.index :=

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -178,17 +178,17 @@ noncomputable instance [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   fintype (quotient_group.quotient P.1.normalizer) :=
 of_equiv (sylow p G) P.equiv_quotient_normalizer
 
-lemma sylow.card_eq_card_quotient_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+lemma card_sylow_eq_card_quotient_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   card (sylow p G) = card (quotient_group.quotient P.1.normalizer) :=
 card_congr P.equiv_quotient_normalizer
 
-lemma sylow.card_eq_index_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+lemma card_sylow_eq_index_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   card (sylow p G) = P.1.normalizer.index :=
-P.card_eq_card_quotient_normalizer.trans P.1.normalizer.index_eq_card.symm
+(card_sylow_eq_card_quotient_normalizer P).trans P.1.normalizer.index_eq_card.symm
 
-lemma sylow.card_dvd_index [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+lemma card_sylow_dvd_index [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   card (sylow p G) ∣ P.1.index :=
-((congr_arg _ P.card_eq_index_normalizer).mp dvd_rfl).trans (index_dvd_of_le le_normalizer)
+((congr_arg _ (card_sylow_eq_index_normalizer P)).mp dvd_rfl).trans (index_dvd_of_le le_normalizer)
 
 end infinite_sylow
 

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -157,6 +157,36 @@ begin
   exact (P.2.card_modeq_card_fixed_points (sylow p G)).trans (by rw this),
 end
 
+variables {p} {G}
+
+lemma orbit_sylow_eq_top [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+  orbit G P = ⊤ :=
+top_le_iff.mp (λ Q hQ, exists_smul_eq G P Q)
+
+lemma stabilizer_sylow_eq_normalizer [fintype (sylow p G)] (P : sylow p G) :
+  stabilizer G P = normalizer P.1 :=
+ext (λ g, sylow.smul_eq_iff_mem_normalizer)
+
+/-- Sylow `p`-subgroups are in bijection with cosets of the normalizer of a Sylow `p`-subgroup -/
+noncomputable def sylow_equiv_quotient_normalizer [fact p.prime] [fintype (sylow p G)]
+  (P : sylow p G) : sylow p G ≃ quotient_group.quotient P.1.normalizer :=
+calc sylow p G ≃ (⊤ : set (sylow p G)) : (equiv.set.univ (sylow p G)).symm
+... ≃ orbit G P : by rw orbit_sylow_eq_top
+... ≃ quotient_group.quotient (stabilizer G P) : orbit_equiv_quotient_stabilizer G P
+... ≃ quotient_group.quotient P.1.normalizer : by rw stabilizer_sylow_eq_normalizer
+
+noncomputable instance [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+  fintype (quotient_group.quotient P.1.normalizer) :=
+fintype.of_equiv (sylow p G) (sylow_equiv_quotient_normalizer P)
+
+lemma card_sylow_eq_card_quotient_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+  fintype.card (sylow p G) = fintype.card (quotient_group.quotient P.1.normalizer) :=
+fintype.card_congr (sylow_equiv_quotient_normalizer P)
+
+lemma card_sylow_eq_index_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+  fintype.card (sylow p G) = P.1.normalizer.index :=
+(card_sylow_eq_card_quotient_normalizer P).trans P.1.normalizer.index_eq_card.symm
+
 end infinite_sylow
 
 open equiv equiv.perm finset function list quotient_group

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -178,17 +178,17 @@ noncomputable instance [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   fintype (quotient_group.quotient P.1.normalizer) :=
 of_equiv (sylow p G) P.equiv_quotient_normalizer
 
-lemma card_sylow_eq_card_quotient_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+lemma sylow.card_eq_card_quotient_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   card (sylow p G) = card (quotient_group.quotient P.1.normalizer) :=
 card_congr P.equiv_quotient_normalizer
 
-lemma card_sylow_eq_index_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+lemma sylow.card_eq_index_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   card (sylow p G) = P.1.normalizer.index :=
-(card_sylow_eq_card_quotient_normalizer P).trans P.1.normalizer.index_eq_card.symm
+P.card_eq_card_quotient_normalizer.trans P.1.normalizer.index_eq_card.symm
 
-lemma card_sylow_dvd_index [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+lemma sylow.card_dvd_index [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   card (sylow p G) ∣ P.1.index :=
-((congr_arg _ (card_sylow_eq_index_normalizer P)).mp dvd_rfl).trans (index_dvd_of_le le_normalizer)
+((congr_arg _ P.card_eq_index_normalizer).mp dvd_rfl).trans (index_dvd_of_le le_normalizer)
 
 end infinite_sylow
 

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -187,6 +187,10 @@ lemma card_sylow_eq_index_normalizer [fact p.prime] [fintype (sylow p G)] (P : s
   fintype.card (sylow p G) = P.1.normalizer.index :=
 (card_sylow_eq_card_quotient_normalizer P).trans P.1.normalizer.index_eq_card.symm
 
+lemma card_sylow_dvd_index [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
+  fintype.card (sylow p G) ∣ P.1.index :=
+((congr_arg _ (card_sylow_eq_index_normalizer P)).mp dvd_rfl).trans (index_dvd_of_le le_normalizer)
+
 end infinite_sylow
 
 open equiv equiv.perm finset function list quotient_group

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -159,12 +159,10 @@ end
 
 variables {p} {G}
 
-lemma orbit_sylow_eq_top [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
-  orbit G P = ⊤ :=
+lemma orbit_sylow_eq_top [fact p.prime] [fintype (sylow p G)] (P : sylow p G) : orbit G P = ⊤ :=
 top_le_iff.mp (λ Q hQ, exists_smul_eq G P Q)
 
-lemma stabilizer_sylow_eq_normalizer [fintype (sylow p G)] (P : sylow p G) :
-  stabilizer G P = normalizer P.1 :=
+lemma stabilizer_sylow_eq_normalizer (P : sylow p G) : stabilizer G P = P.1.normalizer :=
 ext (λ g, sylow.smul_eq_iff_mem_normalizer)
 
 /-- Sylow `p`-subgroups are in bijection with cosets of the normalizer of a Sylow `p`-subgroup -/
@@ -177,18 +175,18 @@ calc sylow p G ≃ (⊤ : set (sylow p G)) : (equiv.set.univ (sylow p G)).symm
 
 noncomputable instance [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   fintype (quotient_group.quotient P.1.normalizer) :=
-fintype.of_equiv (sylow p G) (sylow_equiv_quotient_normalizer P)
+of_equiv (sylow p G) (sylow_equiv_quotient_normalizer P)
 
 lemma card_sylow_eq_card_quotient_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
-  fintype.card (sylow p G) = fintype.card (quotient_group.quotient P.1.normalizer) :=
+  card (sylow p G) = card (quotient_group.quotient P.1.normalizer) :=
 fintype.card_congr (sylow_equiv_quotient_normalizer P)
 
 lemma card_sylow_eq_index_normalizer [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
-  fintype.card (sylow p G) = P.1.normalizer.index :=
+  card (sylow p G) = P.1.normalizer.index :=
 (card_sylow_eq_card_quotient_normalizer P).trans P.1.normalizer.index_eq_card.symm
 
 lemma card_sylow_dvd_index [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
-  fintype.card (sylow p G) ∣ P.1.index :=
+  card (sylow p G) ∣ P.1.index :=
 ((congr_arg _ (card_sylow_eq_index_normalizer P)).mp dvd_rfl).trans (index_dvd_of_le le_normalizer)
 
 end infinite_sylow


### PR DESCRIPTION
This PR adds further consequences of Sylow's theorems (still for infinite groups, more will be PRed later).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
