### PR TITLE
[Merged by Bors] - chore(linear_algebra/quadratic_form): add missing lemmas, lift instance, and tweak argument implicitness

### DIFF
--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -117,8 +117,13 @@ lemma sub_right (x y z : M₁) : B₁ x (y - z) = B₁ x y - B₁ x z :=
 by rw [sub_eq_add_neg, sub_eq_add_neg, add_right, neg_right]
 
 variable {D : bilin_form R M}
+
 @[ext] lemma ext (H : ∀ (x y : M), B x y = D x y) : B = D :=
 by { cases B, cases D, congr, funext, exact H _ _ }
+
+lemma congr_fun (h : B = D) (x y : M) : B x y = D x y := h ▸ rfl
+
+lemma ext_iff : B = D ↔ (∀ x y, B x y = D x y) := ⟨congr_fun, ext⟩
 
 instance : add_comm_monoid (bilin_form R M) :=
 { add := λ B D, { bilin := λ x y, B x y + D x y,

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1377,6 +1377,16 @@ not currently provided in mathlib. In finite dimension either definition implies
 def nondegenerate (B : bilin_form R M) : Prop :=
 ∀ m : M, (∀ n : M, B m n = 0) → m = 0
 
+section
+variables (R M)
+/-- In a non-trivial module, zero is not non-degenerate. -/
+lemma not_nondegenerate_zero [nontrivial M] : ¬(0 : bilin_form R M).nondegenerate :=
+let ⟨m, hm⟩ := exists_ne (0 : M) in λ h, hm (h m $ λ n, rfl)
+end
+
+lemma nondegenerate.ne_zero [nontrivial M] {B : bilin_form R M} (h : B.nondegenerate) : B ≠ 0 :=
+λ h0, not_nondegenerate_zero R M $ h0 ▸ h
+
 /-- A bilinear form is nondegenerate if and only if it has a trivial kernel. -/
 theorem nondegenerate_iff_ker_eq_bot {B : bilin_form R₂ M₂} :
   B.nondegenerate ↔ B.to_lin.ker = ⊥ :=

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -194,8 +194,13 @@ by rw [←is_scalar_tower.algebra_map_smul R a y, polar_smul_right, algebra.smul
 end of_tower
 
 variable {Q' : quadratic_form R M}
+
 @[ext] lemma ext (H : ∀ (x : M), Q x = Q' x) : Q = Q' :=
 by { cases Q, cases Q', congr, funext, apply H }
+
+lemma congr_fun (h : Q = Q') (x : M) : Q x = Q' x := h ▸ rfl
+
+lemma ext_iff : Q = Q' ↔ (∀ x, Q x = Q' x) := ⟨congr_fun, ext⟩
 
 instance : has_zero (quadratic_form R M) :=
 ⟨ { to_fun := λ x, 0,
@@ -471,17 +476,17 @@ def associated_hom : quadratic_form R M →ₗ[S] bilin_form R M :=
     bilin_add_left := λ x y z, by rw [← mul_add, polar_add_left],
     bilin_smul_left := λ x y z, begin
       have htwo : x * ⅟2 = ⅟2 * x := (commute.one_right x).bit0_right.inv_of_right,
-      simp [polar_smul_left, ← mul_assoc, htwo]
+      simp only [polar_smul_left, ← mul_assoc, htwo]
     end,
     bilin_add_right := λ x y z, by rw [← mul_add, polar_add_right],
     bilin_smul_right := λ x y z, begin
       have htwo : x * ⅟2 = ⅟2 * x := (commute.one_right x).bit0_right.inv_of_right,
-      simp [polar_smul_left, ← mul_assoc, htwo]
+      simp only [polar_smul_right, ← mul_assoc, htwo]
     end },
   map_add' := λ Q Q', by { ext, simp [bilin_form.add_apply, polar_add, mul_add] },
   map_smul' := λ s Q, by { ext, simp [polar_smul, algebra.mul_smul_comm] } }
 
-variables {Q : quadratic_form R M} {S}
+variables (Q : quadratic_form R M) (S)
 
 @[simp] lemma associated_apply (x y : M) :
   associated_hom S Q x y = ⅟2 * (Q (x + y) - Q x - Q y) := rfl
@@ -502,11 +507,18 @@ lemma associated_left_inverse (h : is_sym B₁) :
 bilin_form.ext $ λ x y,
 by rw [associated_to_quadratic_form, sym h x y, ←two_mul, ←mul_assoc, inv_of_mul_self, one_mul]
 
-lemma associated_right_inverse : (associated_hom S Q).to_quadratic_form = Q :=
+lemma to_quadratic_form_associated : (associated_hom S Q).to_quadratic_form = Q :=
 quadratic_form.ext $ λ x,
   calc (associated_hom S Q).to_quadratic_form x
       = ⅟2 * (Q x + Q x) : by simp [map_add_self, bit0, add_mul, add_assoc]
   ... = Q x : by rw [← two_mul (Q x), ←mul_assoc, inv_of_mul_self, one_mul]
+
+-- note: usually `right_inverse` lemmas are named the other way around, but this is consistent
+-- with historical naming in this file.
+lemma associated_right_inverse :
+  function.right_inverse (associated_hom S)
+    (bilin_form.to_quadratic_form : _ → quadratic_form R M) :=
+λ Q, to_quadratic_form_associated S Q
 
 lemma associated_eq_self_apply (x : M) : associated_hom S Q x x = Q x :=
 begin
@@ -522,6 +534,12 @@ end
 associated symmetric bilinear form. -/
 abbreviation associated' : quadratic_form R M →ₗ[ℤ] bilin_form R M :=
 associated_hom ℤ
+
+/-- Symmetric bilinear forms can be lifted to quadratic forms -/
+instance : can_lift (bilin_form R M) (quadratic_form R M) :=
+{ coe := associated_hom ℕ,
+  cond := is_sym,
+  prf := λ B hB, ⟨B.to_quadratic_form, associated_left_inverse _ hB⟩ }
 
 /-- There exists a non-null vector with respect to any quadratic form `Q` whose associated
 bilinear form is non-degenerate, i.e. there exists `x` such that `Q x ≠ 0`. -/
@@ -573,7 +591,7 @@ begin
   intros x hx,
   refine hB _ _,
   rw ← hx x,
-  exact (associated_eq_self_apply x).symm,
+  exact (associated_eq_self_apply _ _ x).symm,
 end
 
 end anisotropic
@@ -743,7 +761,7 @@ lemma exists_bilin_form_self_neq_zero [htwo : invertible (2 : R)] [nontrivial M]
   ∃ x, ¬ B.is_ortho x x :=
 begin
   have : B.to_quadratic_form.associated'.nondegenerate,
-  { simpa [quadratic_form.associated_left_inverse hB₂] using hB₁ },
+  { simpa [quadratic_form.associated_left_inverse _ hB₂] using hB₁ },
   obtain ⟨x, hx⟩ := quadratic_form.exists_quadratic_form_neq_zero this,
   refine ⟨x, λ h, hx (B.to_quadratic_form_apply x ▸ h)⟩,
 end
@@ -892,7 +910,7 @@ lemma equivalent_weighted_sum_squares_of_nondegenerate'
   ∃ w : fin (finite_dimensional.finrank K V) → units K,
     equivalent Q (weighted_sum_squares K w) :=
 begin
-  obtain ⟨v, hv₁, hv₂⟩ := exists_orthogonal_basis' hQ associated_is_sym,
+  obtain ⟨v, hv₁, hv₂⟩ := exists_orthogonal_basis' hQ (associated_is_sym _ _),
   refine ⟨λ i, units.mk0 _ (hv₂ i), nonempty.intro _⟩,
   convert Q.isometry_basis_repr v,
   ext w,

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -760,10 +760,9 @@ lemma exists_bilin_form_self_neq_zero [htwo : invertible (2 : R)] [nontrivial M]
   {B : bilin_form R M} (hB₁ : B.nondegenerate) (hB₂ : sym_bilin_form.is_sym B) :
   ∃ x, ¬ B.is_ortho x x :=
 begin
-  have : B.to_quadratic_form.associated'.nondegenerate,
-  { simpa [quadratic_form.associated_left_inverse _ hB₂] using hB₁ },
-  obtain ⟨x, hx⟩ := quadratic_form.exists_quadratic_form_neq_zero this,
-  refine ⟨x, λ h, hx (B.to_quadratic_form_apply x ▸ h)⟩,
+  lift B to quadratic_form R M using hB₂ with Q,
+  obtain ⟨x, hx⟩ := quadratic_form.exists_quadratic_form_neq_zero hB₁,
+  exact ⟨x, λ h, hx (Q.associated_eq_self_apply ℕ x ▸ h)⟩,
 end
 
 open finite_dimensional


### PR DESCRIPTION
This adds `{quadratic,bilin}_form.{ext_iff,congr_fun}`, and a `can_lift` instance to promote `bilin_form`s to `quadratic_form`s.

The `associated_*` lemmas should have `Q` and `S` explicit as they are not inferable from the arguments. In particular, with `S` implicit, rewriting any of them backwards introduces a lot of noisy subgoals.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
