### PR TITLE
[Merged by Bors] - feat(linear_algebra/{bilinear,quadratic}_form): remove non-degeneracy requirement from `exists_orthogonal_basis` and Sylvester's law of inertia

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -206,7 +206,7 @@ Bilinear and Quadratic Forms Over a Vector Space:
   Orthogonality:
     orthogonal elements: 'bilin_form.is_ortho'
     adjoint endomorphism: 'bilin_form.left_adjoint_of_nondegenerate'
-    Sylvester's law of inertia: 'quadratic_form.equivalent_one_neg_one_weighted_sum_squared'
+    Sylvester's law of inertia: 'quadratic_form.equivalent_one_zero_neg_one_weighted_sum_squared'
     real classification:
     complex classification:
     Gram-Schmidt orthogonalisation:

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -597,18 +597,12 @@ begin
   intros s w hs i hi,
   have : B (s.sum $ λ (i : n), w i • v i) (v i) = 0,
   { rw [hs, zero_left] },
-  have hsum : s.sum (λ (j : n), w j * B (v j) (v i)) =
-    s.sum (λ (j : n), if i = j then w j * B (v j) (v i) else 0),
-  { refine finset.sum_congr rfl (λ j hj, _),
-    by_cases (i = j),
-    { rw [if_pos h] },
-    { rw [if_neg h, is_Ortho_def.1 hv₁ _ _ h, mul_zero] } },
-  simp_rw [sum_left, smul_left, hsum, finset.sum_ite_eq] at this,
-  rw [if_pos, mul_eq_zero] at this,
-  cases this,
-  { assumption },
-  { exact false.elim (hv₂ i $ this) },
-  { assumption }
+  have hsum : s.sum (λ (j : n), w j * B (v j) (v i)) = w i * B (v i) (v i),
+  { apply finset.sum_eq_single_of_mem i hi,
+    intros j hj hij,
+    rw [is_Ortho_def.1 hv₁ _ _ hij.symm, mul_zero], },
+  simp_rw [sum_left, smul_left, hsum] at this,
+  exact eq_zero_of_ne_zero_of_mul_right_eq_zero (hv₂ i) this,
 end
 
 end
@@ -1414,6 +1408,45 @@ begin
   refine hW ⟨hx, λ y hy, _⟩,
   specialize b₁ ⟨y, hy⟩,
   rwa [restrict_apply, submodule.coe_mk, submodule.coe_mk, b] at b₁
+end
+
+/-- An orthogonal basis with respect to a nondegenerate bilinear form has no self-orthogonal
+elements. -/
+lemma is_Ortho.not_is_ortho_basis_self_of_nondegenerate
+  {n : Type w} [nontrivial R] {B : bilin_form R M} {v : basis n R M}
+  (h : B.is_Ortho v) (hB : B.nondegenerate) (i : n) :
+  ¬B.is_ortho (v i) (v i) :=
+begin
+  intro ho,
+  refine v.ne_zero i (hB (v i) $ λ m, _),
+  obtain ⟨vi, rfl⟩ := v.repr.symm.surjective m,
+  rw [basis.repr_symm_apply, finsupp.total_apply, finsupp.sum, sum_right],
+  apply finset.sum_eq_zero,
+  rintros j -,
+  rw smul_right,
+  convert mul_zero _ using 2,
+  obtain rfl | hij := eq_or_ne i j,
+  { exact ho },
+  { exact h j i hij.symm },
+end
+
+/-- Given an orthogonal basis with respect to a bilinear form, the bilinear form is nondegenerate
+iff the basis has no elements which are self-orthogonal. -/
+lemma is_Ortho.nondegenerate_iff_not_is_ortho_basis_self {n : Type w} [nontrivial R]
+  [no_zero_divisors R] (B : bilin_form R M) (v : basis n R M) (hO : B.is_Ortho v) :
+  B.nondegenerate ↔ ∀ i, ¬B.is_ortho (v i) (v i) :=
+begin
+  refine ⟨hO.not_is_ortho_basis_self_of_nondegenerate, λ ho m hB, _⟩,
+  obtain ⟨vi, rfl⟩ := v.repr.symm.surjective m,
+  rw linear_equiv.map_eq_zero_iff,
+  ext i,
+  rw [finsupp.zero_apply],
+  specialize hB (v i),
+  simp_rw [basis.repr_symm_apply, finsupp.total_apply, finsupp.sum, sum_left, smul_left] at hB,
+  rw finset.sum_eq_single i at hB,
+  { exact eq_zero_of_ne_zero_of_mul_right_eq_zero (ho i) hB, },
+  { intros j hj hij, convert mul_zero _ using 2, exact hO i j hij.symm, },
+  { intros hi, convert zero_mul _ using 2, exact finsupp.not_mem_support_iff.mp hi }
 end
 
 section

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -550,10 +550,10 @@ lemma ne_zero_of_not_is_ortho_self {B : bilin_form K V}
 if for all `i ≠ j`, `B (v i) (v j) = 0`. For orthogonality between two elements, use
 `bilin_form.is_ortho` -/
 def is_Ortho {n : Type w} (B : bilin_form R M) (v : n → M) : Prop :=
-∀ i j : n, i ≠ j → B.is_ortho (v j) (v i)
+pairwise (B.is_ortho on v)
 
 lemma is_Ortho_def {n : Type w} {B : bilin_form R M} {v : n → M} :
-  B.is_Ortho v ↔ ∀ i j : n, i ≠ j → B (v j) (v i) = 0 := iff.rfl
+  B.is_Ortho v ↔ ∀ i j : n, i ≠ j → B (v i) (v j) = 0 := iff.rfl
 
 section
 
@@ -600,7 +600,7 @@ begin
   have hsum : s.sum (λ (j : n), w j * B (v j) (v i)) = w i * B (v i) (v i),
   { apply finset.sum_eq_single_of_mem i hi,
     intros j hj hij,
-    rw [is_Ortho_def.1 hv₁ _ _ hij.symm, mul_zero], },
+    rw [is_Ortho_def.1 hv₁ _ _ hij, mul_zero], },
   simp_rw [sum_left, smul_left, hsum] at this,
   exact eq_zero_of_ne_zero_of_mul_right_eq_zero (hv₂ i) this,
 end
@@ -1427,7 +1427,7 @@ begin
   convert mul_zero _ using 2,
   obtain rfl | hij := eq_or_ne i j,
   { exact ho },
-  { exact h j i hij.symm },
+  { exact h i j hij },
 end
 
 /-- Given an orthogonal basis with respect to a bilinear form, the bilinear form is nondegenerate
@@ -1445,7 +1445,7 @@ begin
   simp_rw [basis.repr_symm_apply, finsupp.total_apply, finsupp.sum, sum_left, smul_left] at hB,
   rw finset.sum_eq_single i at hB,
   { exact eq_zero_of_ne_zero_of_mul_right_eq_zero (ho i) hB, },
-  { intros j hj hij, convert mul_zero _ using 2, exact hO i j hij.symm, },
+  { intros j hj hij, convert mul_zero _ using 2, exact hO j i hij, },
   { intros hi, convert zero_mul _ using 2, exact finsupp.not_mem_support_iff.mp hi }
 end
 

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -813,11 +813,11 @@ begin
   { rw basis.coe_mk_fin_cons,
     intros j i,
     refine fin.cases _ (λ i, _) i; refine fin.cases _ (λ j, _) j; intro hij;
-      simp only [fin.cons_zero, fin.cons_succ, function.comp_apply],
+      simp only [function.on_fun, fin.cons_zero, fin.cons_succ, function.comp_apply],
     { exact (hij rfl).elim },
-    { exact (v' j).prop _ (submodule.mem_span_singleton_self x) },
     { rw [is_ortho, hB₂],
-      exact (v' i).prop _ (submodule.mem_span_singleton_self x) },
+      exact (v' j).prop _ (submodule.mem_span_singleton_self x) },
+    { exact (v' i).prop _ (submodule.mem_span_singleton_self x) },
     { exact hv₁ _ _ (ne_of_apply_ne _ hij), }, }
 end
 
@@ -869,7 +869,7 @@ begin
   { rw [smul_left, smul_right], ring },
   { intros i _ hij,
     rw [smul_left, smul_right,
-        show (associated_hom R₁) Q (v j) (v i) = 0, by exact hv₂ i j hij,
+        show associated_hom R₁ Q (v j) (v i) = 0, from hv₂ j i hij.symm,
         mul_zero, mul_zero] },
   { contradiction }
 end

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -776,8 +776,8 @@ open finite_dimensional
 variables {V : Type u} {K : Type v} [field K] [add_comm_group V] [module K V]
 variable [finite_dimensional K V]
 
-/-- Given a symmetric bilinear form `B` on some vector space `V` over the
-field `K` with invertible `2`, there exists an orthogonal basis with respect to `B`. -/
+/-- Given a symmetric bilinear form `B` on some vector space `V` over a field `K`
+in which `2` is invertible, there exists an orthogonal basis with respect to `B`. -/
 lemma exists_orthogonal_basis [hK : invertible (2 : K)]
   {B : bilin_form K V} (hB₂ : sym_bilin_form.is_sym B) :
   ∃ (v : basis (fin (finrank K V)) K V), B.is_Ortho v :=

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -899,7 +899,7 @@ begin
 end
 
 variables {V : Type*} {K : Type*} [field K] [invertible (2 : K)]
-variables [add_comm_group V] [module K V] [finite_dimensional K V]
+variables [add_comm_group V] [module K V]
 
 /-- Given an orthogonal basis, a quadratic form is isometric with a weighted sum of squares. -/
 noncomputable def isometry_weighted_sum_squares (Q : quadratic_form K V)
@@ -912,6 +912,8 @@ begin
   convert iso.map_app m,
   rw basis_repr_eq_of_is_Ortho _ _ hv₁,
 end
+
+variables [finite_dimensional K V]
 
 lemma equivalent_weighted_sum_squares (Q : quadratic_form K V) :
   ∃ w : fin (finite_dimensional.finrank K V) → K, equivalent Q (weighted_sum_squares K w) :=

--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -932,14 +932,16 @@ end
 section complex
 
 /-- The isometry between a weighted sum of squares on the complex numbers and the
-sum of squares, i.e. `weighted_sum_squares` with weight `λ i : ι, 1`. -/
-noncomputable def isometry_sum_squares [decidable_eq ι] (w : ι → units ℂ) :
-  isometry (weighted_sum_squares ℂ w) (weighted_sum_squares ℂ (1 : ι → ℂ)) :=
+sum of squares, i.e. `weighted_sum_squares` with weights 1 or 0. -/
+noncomputable def isometry_sum_squares [decidable_eq ι] (w' : ι → ℂ) :
+  isometry (weighted_sum_squares ℂ w')
+    (weighted_sum_squares ℂ (λ i, if w' i = 0 then 0 else 1 : ι → ℂ)) :=
 begin
+  let w := λ i, if h : w' i = 0 then (1 : units ℂ) else units.mk0 (w' i) h,
   have hw' : ∀ i : ι, (w i : ℂ) ^ - (1 / 2 : ℂ) ≠ 0,
   { intros i hi,
     exact (w i).ne_zero ((complex.cpow_eq_zero_iff _ _).1 hi).1 },
-  convert (weighted_sum_squares ℂ w).isometry_basis_repr
+  convert (weighted_sum_squares ℂ w').isometry_basis_repr
     ((pi.basis_fun ℂ ι).units_smul (λ i, (is_unit_iff_ne_zero.2 $ hw' i).unit)),
   ext1 v,
   erw [basis_repr_apply, weighted_sum_squares_apply, weighted_sum_squares_apply],
@@ -956,10 +958,28 @@ begin
     intro hj', exact false.elim (hj' hj) },
   simp_rw basis.units_smul_apply,
   erw [hsum, smul_eq_mul],
-  suffices : 1 * v j * v j =  w j ^ - (1 / 2 : ℂ) * w j ^ - (1 / 2 : ℂ) * w j * v j * v j,
-  { erw [pi.one_apply, ← mul_assoc, this, smul_eq_mul, smul_eq_mul], ring },
+  split_ifs,
+  { simp only [h, zero_smul, zero_mul]},
+  have hww' : w' j = w j,
+  { simp only [w, dif_neg h, units.coe_mk0] },
+  simp only [hww', one_mul],
+  change v j * v j = ↑(w j) * ((v j * ↑(w j) ^ -(1 / 2 : ℂ)) * (v j * ↑(w j) ^ -(1 / 2 : ℂ))),
+  suffices : v j * v j = w j ^ - (1 / 2 : ℂ) * w j ^ - (1 / 2 : ℂ) * w j * v j * v j,
+  { rw [this], ring },
   rw [← complex.cpow_add _ _ (w j).ne_zero, show - (1 / 2 : ℂ) + - (1 / 2) = -1, by ring,
-      complex.cpow_neg_one, inv_mul_cancel (w j).ne_zero],
+      complex.cpow_neg_one, inv_mul_cancel (w j).ne_zero, one_mul],
+end
+
+/-- The isometry between a weighted sum of squares on the complex numbers and the
+sum of squares, i.e. `weighted_sum_squares` with weight `λ i : ι, 1`. -/
+noncomputable def isometry_sum_squares_units [decidable_eq ι] (w : ι → units ℂ) :
+  isometry (weighted_sum_squares ℂ w) (weighted_sum_squares ℂ (1 : ι → ℂ)) :=
+begin
+  have hw1 : (λ i, if (w i : ℂ) = 0 then 0 else 1 : ι → ℂ) = 1,
+  { ext i : 1, exact dif_neg (w i).ne_zero },
+  have := isometry_sum_squares (coe ∘ w),
+  rw hw1 at this,
+  exact this,
 end
 
 /-- A nondegenerate quadratic form on the complex numbers is equivalent to
@@ -968,7 +988,7 @@ theorem equivalent_sum_squares {M : Type*} [add_comm_group M] [module ℂ M]
   [finite_dimensional ℂ M] (Q : quadratic_form ℂ M) (hQ : (associated Q).nondegenerate) :
   equivalent Q (weighted_sum_squares ℂ (1 : fin (finite_dimensional.finrank ℂ M) → ℂ)) :=
 let ⟨w, ⟨hw₁⟩⟩ := Q.equivalent_weighted_sum_squares_units_of_nondegenerate' hQ in
-  ⟨hw₁.trans (isometry_sum_squares w)⟩
+  ⟨hw₁.trans (isometry_sum_squares_units w)⟩
 
 end complex
 
@@ -979,13 +999,14 @@ open real
 /-- The isometry between a weighted sum of squares with weights `u` on the
 (non-zero) real numbers and the weighted sum of squares with weights `sign ∘ u`. -/
 noncomputable def isometry_sign_weighted_sum_squares
-  [decidable_eq ι] (u : ι → units ℝ) :
-  isometry (weighted_sum_squares ℝ u) (weighted_sum_squares ℝ (sign ∘ coe ∘ u)) :=
+  [decidable_eq ι] (w : ι → ℝ) :
+  isometry (weighted_sum_squares ℝ w) (weighted_sum_squares ℝ (sign ∘ w)) :=
 begin
+  let u := λ i, if h : w i = 0 then (1 : units ℝ) else units.mk0 (w i) h,
   have hu' : ∀ i : ι, (sign (u i) * u i) ^ - (1 / 2 : ℝ) ≠ 0,
   { intro i, refine (ne_of_lt (real.rpow_pos_of_pos
       (sign_mul_pos_of_ne_zero _ $ units.ne_zero _) _)).symm},
-  convert ((weighted_sum_squares ℝ u).isometry_basis_repr
+  convert ((weighted_sum_squares ℝ w).isometry_basis_repr
     ((pi.basis_fun ℝ ι).units_smul (λ i, (is_unit_iff_ne_zero.2 $ hu' i).unit))),
   ext1 v,
   rw [basis_repr_apply, weighted_sum_squares_apply, weighted_sum_squares_apply],
@@ -1002,9 +1023,15 @@ begin
     intro hj', exact false.elim (hj' hj) },
   simp_rw basis.units_smul_apply,
   erw [hsum, smul_eq_mul],
-  suffices : (sign ∘ coe ∘ u) j * v j * v j = (sign (u j) * u j) ^ - (1 / 2 : ℝ) *
+  dsimp [u],
+  split_ifs,
+  { simp only [h, zero_smul, zero_mul, sign_zero]},
+  have hwu : w j = u j,
+  { simp only [u, dif_neg h, units.coe_mk0] },
+  simp only [hwu, units.coe_mk0],
+  suffices : (u j : ℝ).sign * v j * v j = (sign (u j) * u j) ^ - (1 / 2 : ℝ) *
     (sign (u j) * u j) ^ - (1 / 2 : ℝ) * u j * v j * v j,
-  { erw [← mul_assoc, this, smul_eq_mul, smul_eq_mul], ring },
+  { erw [← mul_assoc, this], ring },
   rw [← real.rpow_add (sign_mul_pos_of_ne_zero _ $ units.ne_zero _),
       show - (1 / 2 : ℝ) + - (1 / 2) = -1, by ring, real.rpow_neg_one, _root_.mul_inv',
       inv_sign, mul_assoc (sign (u j)) (u j)⁻¹,
@@ -1022,6 +1049,18 @@ theorem equivalent_one_neg_one_weighted_sum_squared
 let ⟨w, ⟨hw₁⟩⟩ := Q.equivalent_weighted_sum_squares_units_of_nondegenerate' hQ in
   ⟨sign ∘ coe ∘ w,
    λ i, sign_apply_eq_of_ne_zero (w i) (w i).ne_zero,
+   ⟨hw₁.trans (isometry_sign_weighted_sum_squares (coe ∘ w))⟩⟩
+
+/-- **Sylvester's law of inertia**: A real quadratic form is equivalent to a weighted
+sum of squares with the weights being ±1 or 0. -/
+theorem equivalent_one_zero_neg_one_weighted_sum_squared
+  {M : Type*} [add_comm_group M] [module ℝ M] [finite_dimensional ℝ M]
+  (Q : quadratic_form ℝ M) :
+  ∃ w : fin (finite_dimensional.finrank ℝ M) → ℝ,
+  (∀ i, w i = -1 ∨ w i = 0 ∨ w i = 1) ∧ equivalent Q (weighted_sum_squares ℝ w) :=
+let ⟨w, ⟨hw₁⟩⟩ := Q.equivalent_weighted_sum_squares in
+  ⟨sign ∘ coe ∘ w,
+   λ i, sign_apply_eq (w i),
    ⟨hw₁.trans (isometry_sign_weighted_sum_squares w)⟩⟩
 
 end real


### PR DESCRIPTION
This removes the `nondegenerate` hypothesis from `bilin_form.exists_orthogonal_basis`, and removes the `∀ i, B (v i) (v i) ≠ 0` statement from the goal. This property can be recovered in the case of a nondegenerate form with `is_Ortho.not_is_ortho_basis_self_of_nondegenerate`.

This also swaps the order of the binders in `is_Ortho` to make it expressible with `pairwise`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


It's quite likely there's some `basis` API that would make this easier that I don't know about