### PR TITLE
[Merged by Bors] - chore(analysis/convex/basic): instance cleanup

### DIFF
--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -145,8 +145,8 @@ open_locale convex
 section ordered_ring
 variables [ordered_ring 𝕜]
 
-section add_comm_monoid
-variables (𝕜) [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F]
+section add_comm_group
+variables (𝕜) [add_comm_group E] [add_comm_group F] [module 𝕜 E] [module 𝕜 F]
 
 section densely_ordered
 variables [nontrivial 𝕜] [densely_ordered 𝕜]
@@ -169,10 +169,6 @@ set.ext $ λ z,
     ⟨b, ⟨hb, hab ▸ le_add_of_nonneg_left ha⟩, hab ▸ hz ▸ by simp only [add_sub_cancel]⟩,
     λ ⟨θ, ⟨hθ₀, hθ₁⟩, hz⟩, ⟨1-θ, θ, sub_nonneg.2 hθ₁, hθ₀, sub_add_cancel _ _, hz⟩⟩
 
-lemma segment_eq_image₂ (x y : E) :
-  [x -[𝕜] y] = (λ p : 𝕜 × 𝕜, p.1 • x + p.2 • y) '' {p | 0 ≤ p.1 ∧ 0 ≤ p.2 ∧ p.1 + p.2 = 1} :=
-by simp only [segment, image, prod.exists, mem_set_of_eq, exists_prop, and_assoc]
-
 lemma open_segment_eq_image (x y : E) :
   open_segment 𝕜 x y = (λ (θ : 𝕜), (1 - θ) • x + θ • y) '' Ioo (0 : 𝕜) 1 :=
 set.ext $ λ z,
@@ -180,23 +176,14 @@ set.ext $ λ z,
     ⟨b, ⟨hb, hab ▸ lt_add_of_pos_left _ ha⟩, hab ▸ hz ▸ by simp only [add_sub_cancel]⟩,
     λ ⟨θ, ⟨hθ₀, hθ₁⟩, hz⟩, ⟨1 - θ, θ, sub_pos.2 hθ₁, hθ₀, sub_add_cancel _ _, hz⟩⟩
 
+lemma segment_eq_image₂ (x y : E) :
+  [x -[𝕜] y] = (λ p : 𝕜 × 𝕜, p.1 • x + p.2 • y) '' {p | 0 ≤ p.1 ∧ 0 ≤ p.2 ∧ p.1 + p.2 = 1} :=
+by simp only [segment, image, prod.exists, mem_set_of_eq, exists_prop, and_assoc]
+
 lemma open_segment_eq_image₂ (x y : E) :
   open_segment 𝕜 x y =
     (λ p : 𝕜 × 𝕜, p.1 • x + p.2 • y) '' {p | 0 < p.1 ∧ 0 < p.2 ∧ p.1 + p.2 = 1} :=
 by simp only [open_segment, image, prod.exists, mem_set_of_eq, exists_prop, and_assoc]
-
-lemma segment_image (f : E →ₗ[𝕜] F) (a b : E) : f '' [a -[𝕜] b] = [f a -[𝕜] f b] :=
-set.ext (λ x, by simp_rw [segment_eq_image, mem_image, exists_exists_and_eq_and, map_add, map_smul])
-
-@[simp] lemma open_segment_image (f : E →ₗ[𝕜] F) (a b : E) :
-  f '' open_segment 𝕜 a b = open_segment 𝕜 (f a) (f b) :=
-set.ext (λ x, by simp_rw [open_segment_eq_image, mem_image, exists_exists_and_eq_and, map_add,
-  map_smul])
-
-end add_comm_monoid
-
-section add_comm_group
-variables (𝕜) [add_comm_group E] [module 𝕜 E]
 
 lemma segment_eq_image' (x y : E) :
   [x -[𝕜] y] = (λ (θ : 𝕜), x + θ • (y - x)) '' Icc (0 : 𝕜) 1 :=
@@ -205,6 +192,14 @@ by { convert segment_eq_image 𝕜 x y, ext θ, simp only [smul_sub, sub_smul, o
 lemma open_segment_eq_image' (x y : E) :
   open_segment 𝕜 x y = (λ (θ : 𝕜), x + θ • (y - x)) '' Ioo (0 : 𝕜) 1 :=
 by { convert open_segment_eq_image 𝕜 x y, ext θ, simp only [smul_sub, sub_smul, one_smul], abel }
+
+lemma segment_image (f : E →ₗ[𝕜] F) (a b : E) : f '' [a -[𝕜] b] = [f a -[𝕜] f b] :=
+set.ext (λ x, by simp_rw [segment_eq_image, mem_image, exists_exists_and_eq_and, map_add, map_smul])
+
+@[simp] lemma open_segment_image (f : E →ₗ[𝕜] F) (a b : E) :
+  f '' open_segment 𝕜 a b = open_segment 𝕜 (f a) (f b) :=
+set.ext (λ x, by simp_rw [open_segment_eq_image, mem_image, exists_exists_and_eq_and, map_add,
+  map_smul])
 
 lemma mem_segment_translate (a : E) {x b c} : a + x ∈ [a + b -[𝕜] a + c] ↔ x ∈ [b -[𝕜] c] :=
 begin
@@ -242,7 +237,7 @@ section linear_ordered_field
 variables [linear_ordered_field 𝕜]
 
 section add_comm_group
-variables [add_comm_group E] [module 𝕜 E] [add_comm_group F] [module 𝕜 F]
+variables [add_comm_group E] [add_comm_group F] [module 𝕜 E] [module 𝕜 F]
 
 @[simp] lemma left_mem_open_segment_iff [no_zero_smul_divisors 𝕜 E] {x y : E} :
   x ∈ open_segment 𝕜 x y ↔ x = y :=
@@ -746,8 +741,8 @@ end ordered_comm_semiring
 section ordered_ring
 variables [ordered_ring 𝕜]
 
-section add_comm_monoid
-variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F] {s : set E}
+section add_comm_group
+variables [add_comm_group E] [add_comm_group F] [module 𝕜 E] [module 𝕜 F] {s : set E}
 
 lemma convex.add_smul_mem (hs : convex 𝕜 s) {x y : E} (hx : x ∈ s) (hy : x + y ∈ s)
   {t : 𝕜} (ht : t ∈ Icc (0 : 𝕜) 1) : x + t • y ∈ s :=
@@ -761,11 +756,6 @@ end
 lemma convex.smul_mem_of_zero_mem (hs : convex 𝕜 s) {x : E} (zero_mem : (0 : E) ∈ s) (hx : x ∈ s)
   {t : 𝕜} (ht : t ∈ Icc (0 : 𝕜) 1) : t • x ∈ s :=
 by simpa using hs.add_smul_mem zero_mem (by simpa using hx) ht
-
-end add_comm_monoid
-
-section add_comm_group
-variables [add_comm_group E] [module 𝕜 E] [add_comm_group F] [module 𝕜 F] {s : set E}
 
 lemma convex.add_smul_sub_mem (h : convex 𝕜 s) {x y : E} (hx : x ∈ s) (hy : y ∈ s)
   {t : 𝕜} (ht : t ∈ Icc (0 : 𝕜) 1) : x + t • (y - x) ∈ s :=
@@ -811,14 +801,13 @@ lemma convex.neg_preimage (hs : convex 𝕜 s) : convex 𝕜 ((λ z, -z) ⁻¹' 
 hs.is_linear_preimage is_linear_map.is_linear_map_neg
 
 end add_comm_group
-
 end ordered_ring
 
 section linear_ordered_field
 variables [linear_ordered_field 𝕜]
 
-section add_comm_monoid
-variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F] {s : set E}
+section add_comm_group
+variables [add_comm_group E] [add_comm_group F] [module 𝕜 E] [module 𝕜 F] {s : set E}
 
 /-- Alternative definition of set convexity, using division. -/
 lemma convex_iff_div :
@@ -867,7 +856,7 @@ begin
       by simp only [← mul_smul, smul_add, mul_div_cancel' _ hpq.ne']⟩ }
 end
 
-end add_comm_monoid
+end add_comm_group
 end linear_ordered_field
 
 /-!
@@ -877,7 +866,7 @@ Relates `convex` and `ord_connected`.
 
 section
 
-lemma set.ord_connected.convex_of_chain [ordered_add_comm_monoid E] [ordered_semiring 𝕜]
+lemma set.ord_connected.convex_of_chain [ordered_semiring 𝕜] [ordered_add_comm_monoid E]
   [module 𝕜 E] [ordered_smul 𝕜 E] {s : set E} (hs : s.ord_connected) (h : zorn.chain (≤) s) :
   convex 𝕜 s :=
 begin
@@ -901,8 +890,8 @@ begin
       ... = x : convex.combo_self hab _ }
 end
 
-lemma set.ord_connected.convex [linear_ordered_add_comm_monoid E] [ordered_semiring 𝕜]
-  [module 𝕜 E] [ordered_smul 𝕜 E] {s : set E} (hs : s.ord_connected) :
+lemma set.ord_connected.convex [ordered_semiring 𝕜] [linear_ordered_add_comm_monoid E] [module 𝕜 E]
+  [ordered_smul 𝕜 E] {s : set E} (hs : s.ord_connected) :
   convex 𝕜 s :=
 hs.convex_of_chain (zorn.chain_of_trichotomous s)
 
@@ -1044,8 +1033,8 @@ end ordered_semiring
 section ordered_ring
 variables [ordered_ring 𝕜]
 
-section add_comm_monoid
-variables [add_comm_group E] [module 𝕜 E] [add_comm_group F] [module 𝕜 F] {s : set E}
+section add_comm_group
+variables [add_comm_group E] [add_comm_group F] [module 𝕜 E] [module 𝕜 F] {s : set E}
 
 lemma affine_map.image_convex_hull (f : E →ᵃ[𝕜] F) :
   f '' (convex_hull 𝕜 s) = convex_hull 𝕜 (f '' s) :=
@@ -1059,7 +1048,7 @@ begin
     ((convex_convex_hull 𝕜 s).affine_image f) }
 end
 
-end add_comm_monoid
+end add_comm_group
 end ordered_ring
 end convex_hull
 
@@ -1067,21 +1056,18 @@ end convex_hull
 
 section simplex
 
-variables (ι : Type*) [fintype ι]
+variables (𝕜) (ι : Type*) [ordered_semiring 𝕜] [fintype ι]
 
-/-- The standard simplex in the space of functions `ι → ℝ` is the set
-of vectors with non-negative coordinates with total sum `1`. -/
-def std_simplex (ι : Type*) [fintype ι] (R : Type*) [ordered_semiring R] :
-  set (ι → R) :=
+/-- The standard simplex in the space of functions `ι → 𝕜` is the set of vectors with non-negative
+coordinates with total sum `1`. This is the free object in the category of convex spaces. -/
+def std_simplex : set (ι → 𝕜) :=
 {f | (∀ x, 0 ≤ f x) ∧ ∑ x, f x = 1}
 
-variables (R : Type*) [ordered_semiring R] {f : ι → R}
-
 lemma std_simplex_eq_inter :
-  std_simplex ι R = (⋂ x, {f | 0 ≤ f x}) ∩ {f | ∑ x, f x = 1} :=
+  std_simplex 𝕜 ι = (⋂ x, {f | 0 ≤ f x}) ∩ {f | ∑ x, f x = 1} :=
 by { ext f, simp only [std_simplex, set.mem_inter_eq, set.mem_Inter, set.mem_set_of_eq] }
 
-lemma convex_std_simplex : convex R (std_simplex ι R) :=
+lemma convex_std_simplex : convex 𝕜 (std_simplex 𝕜 ι) :=
 begin
   refine λ f g hf hg a b ha hb hab, ⟨λ x, _, _⟩,
   { apply_rules [add_nonneg, mul_nonneg, hf.1, hg.1] },
@@ -1092,7 +1078,7 @@ end
 
 variable {ι}
 
-lemma ite_eq_mem_std_simplex (i : ι) : (λ j, ite (i = j) (1:R) 0) ∈ std_simplex ι R :=
+lemma ite_eq_mem_std_simplex (i : ι) : (λ j, ite (i = j) (1:𝕜) 0) ∈ std_simplex 𝕜 ι :=
 ⟨λ j, by simp only; split_ifs; norm_num, by rw [finset.sum_ite_eq, if_pos (finset.mem_univ _)]⟩
 
 end simplex

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -721,7 +721,7 @@ section ordered_comm_semiring
 variables [ordered_comm_semiring 𝕜]
 
 section add_comm_monoid
-variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F] {s : set E}
+variables [add_comm_monoid E] [add_comm_monoid F] [module 𝕜 E] [module 𝕜 F] {s : set E}
 
 lemma convex.smul (hs : convex 𝕜 s) (c : 𝕜) : convex 𝕜 (c • s) :=
 hs.linear_image (linear_map.lsmul _ _ c)
@@ -928,7 +928,7 @@ section ordered_semiring
 variables [ordered_semiring 𝕜]
 
 section add_comm_monoid
-variables (𝕜) [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F]
+variables (𝕜) [add_comm_monoid E] [add_comm_monoid F] [module 𝕜 E] [module 𝕜 F]
 
 /-- The convex hull of a set `s` is the minimal convex set that includes `s`. -/
 def convex_hull : closure_operator (set E) :=

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Alexander Bentkamp. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp, Yury Kudriashov, Yaël Dillies
 -/
-import algebra.order.smul
+import algebra.module.ordered
 import data.set.intervals.image_preimage
 import linear_algebra.affine_space.affine_map
 import order.closure
@@ -43,26 +43,29 @@ define `clopen_segment`/`convex.Ico`/`convex.Ioc`?
 -/
 
 universes u u'
-variables (𝕜 : Type*) {E F : Type*}
+variables {𝕜 E F β : Type*}
 
 open linear_map set
 open_locale big_operators classical pointwise
 
 /-! ### Segment -/
 
+section ordered_semiring
+variables [ordered_semiring 𝕜] [add_comm_monoid E]
+
+section has_scalar
+variables (𝕜) [has_scalar 𝕜 E]
+
 /-- Segments in a vector space. -/
-def segment [add_comm_monoid E] [ordered_semiring 𝕜] [has_scalar 𝕜 E] (x y : E) : set E :=
+def segment (x y : E) : set E :=
 {z : E | ∃ (a b : 𝕜) (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1), a • x + b • y = z}
 
 /-- Open segment in a vector space. Note that `open_segment 𝕜 x x = {x}` instead of being `∅` when
 the base semiring has some element between `0` and `1`. -/
-def open_segment [add_comm_monoid E] [ordered_semiring 𝕜] [has_scalar 𝕜 E] (x y : E) : set E :=
+def open_segment (x y : E) : set E :=
 {z : E | ∃ (a b : 𝕜) (ha : 0 < a) (hb : 0 < b) (hab : a + b = 1), a • x + b • y = z}
 
 localized "notation `[` x ` -[` 𝕜 `] ` y `]` := segment 𝕜 x y" in convex
-
-section ordered_semiring
-variables [add_comm_monoid E] [ordered_semiring 𝕜] [module 𝕜 E]
 
 lemma segment_symm (x y : E) : [x -[𝕜] y] = [y -[𝕜] x] :=
 set.ext $ λ z,
@@ -75,20 +78,32 @@ set.ext $ λ z,
 ⟨λ ⟨a, b, ha, hb, hab, H⟩, ⟨b, a, hb, ha, (add_comm _ _).trans hab, (add_comm _ _).trans H⟩,
   λ ⟨a, b, ha, hb, hab, H⟩, ⟨b, a, hb, ha, (add_comm _ _).trans hab, (add_comm _ _).trans H⟩⟩
 
+lemma open_segment_subset_segment (x y : E) :
+  open_segment 𝕜 x y ⊆ [x -[𝕜] y] :=
+λ z ⟨a, b, ha, hb, hab, hz⟩, ⟨a, b, ha.le, hb.le, hab, hz⟩
+
+end has_scalar
+
+open_locale convex
+
+section mul_action_with_zero
+variables (𝕜) [mul_action_with_zero 𝕜 E]
+
 lemma left_mem_segment (x y : E) : x ∈ [x -[𝕜] y] :=
 ⟨1, 0, zero_le_one, le_refl 0, add_zero 1, by rw [zero_smul, one_smul, add_zero]⟩
 
 lemma right_mem_segment (x y : E) : y ∈ [x -[𝕜] y] :=
 segment_symm 𝕜 y x ▸ left_mem_segment 𝕜 y x
 
+end mul_action_with_zero
+
+section module
+variables (𝕜) [module 𝕜 E]
+
 lemma segment_same (x : E) : [x -[𝕜] x] = {x} :=
 set.ext $ λ z, ⟨λ ⟨a, b, ha, hb, hab, hz⟩,
   by simpa only [(add_smul _ _ _).symm, mem_singleton_iff, hab, one_smul, eq_comm] using hz,
   λ h, mem_singleton_iff.1 h ▸ left_mem_segment 𝕜 z z⟩
-
-lemma open_segment_subset_segment (x y : E) :
-  open_segment 𝕜 x y ⊆ [x -[𝕜] y] :=
-λ z ⟨a, b, ha, hb, hab, hz⟩, ⟨a, b, ha.le, hb.le, hab, hz⟩
 
 lemma mem_open_segment_of_ne_left_right {x y z : E} (hx : x ≠ z) (hy : y ≠ z)
   (hz : z ∈ [x -[𝕜] y]) :
@@ -119,16 +134,19 @@ begin
   exact h (mem_open_segment_of_ne_left_right 𝕜 hxz hyz hz),
 end
 
-lemma convex.combo_self {x y : 𝕜} (h : x + y = 1) (a : E) : x • a + y • a = a :=
+lemma convex.combo_self {a b : 𝕜} (h : a + b = 1) (x : E) : a • x + b • x = x :=
 by rw [←add_smul, h, one_smul]
 
+end module
 end ordered_semiring
+
+open_locale convex
 
 section ordered_ring
 variables [ordered_ring 𝕜]
 
 section add_comm_monoid
-variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F]
+variables (𝕜) [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F]
 
 section densely_ordered
 variables [nontrivial 𝕜] [densely_ordered 𝕜]
@@ -178,7 +196,7 @@ set.ext (λ x, by simp_rw [open_segment_eq_image, mem_image, exists_exists_and_e
 end add_comm_monoid
 
 section add_comm_group
-variables [add_comm_group E] [module 𝕜 E]
+variables (𝕜) [add_comm_group E] [module 𝕜 E]
 
 lemma segment_eq_image' (x y : E) :
   [x -[𝕜] y] = (λ (θ : 𝕜), x + θ • (y - x)) '' Icc (0 : 𝕜) 1 :=
@@ -224,7 +242,7 @@ section linear_ordered_field
 variables [linear_ordered_field 𝕜]
 
 section add_comm_group
-variables [add_comm_group E] [module 𝕜 E] [add_comm_group F] [module 𝕜 F] {𝕜}
+variables [add_comm_group E] [module 𝕜 E] [add_comm_group F] [module 𝕜 F]
 
 @[simp] lemma left_mem_open_segment_iff [no_zero_smul_divisors 𝕜 E] {x y : E} :
   x ∈ open_segment 𝕜 x y ↔ x = y :=
@@ -253,44 +271,44 @@ section ordered_semiring
 variables [ordered_semiring 𝕜]
 
 section ordered_add_comm_monoid
-variables [ordered_add_comm_monoid E] [module 𝕜 E] [ordered_smul 𝕜 E] {𝕜}
+variables [ordered_add_comm_monoid E] [module 𝕜 E] [ordered_smul 𝕜 E]
 
 lemma segment_subset_Icc {x y : E} (h : x ≤ y) : [x -[𝕜] y] ⊆ Icc x y :=
 begin
   rintro z ⟨a, b, ha, hb, hab, rfl⟩,
   split,
   calc
-    x   = a • x + b • x : by rw [←add_smul, hab, one_smul]
+    x   = a • x + b • x :(convex.combo_self hab _).symm
     ... ≤ a • x + b • y : add_le_add_left (smul_le_smul_of_nonneg h hb) _,
   calc
     a • x + b • y
         ≤ a • y + b • y : add_le_add_right (smul_le_smul_of_nonneg h ha) _
-    ... = y : by rw [←add_smul, hab, one_smul],
+    ... = y : convex.combo_self hab _,
 end
 
 end ordered_add_comm_monoid
 
 section ordered_cancel_add_comm_monoid
-variables [ordered_cancel_add_comm_monoid E] [module 𝕜 E] [ordered_smul 𝕜 E] {𝕜}
+variables [ordered_cancel_add_comm_monoid E] [module 𝕜 E] [ordered_smul 𝕜 E]
 
 lemma open_segment_subset_Ioo {x y : E} (h : x < y) : open_segment 𝕜 x y ⊆ Ioo x y :=
 begin
   rintro z ⟨a, b, ha, hb, hab, rfl⟩,
   split,
   calc
-    x   = a • x + b • x : by rw [←add_smul, hab, one_smul]
+    x   = a • x + b • x : (convex.combo_self hab _).symm
     ... < a • x + b • y : add_lt_add_left (smul_lt_smul_of_pos h hb) _,
   calc
     a • x + b • y
         < a • y + b • y : add_lt_add_right (smul_lt_smul_of_pos h ha) _
-    ... = y : by rw [←add_smul, hab, one_smul],
+    ... = y : convex.combo_self hab _,
 end
 
 end ordered_cancel_add_comm_monoid
 end ordered_semiring
 
 section linear_ordered_field
-variables [linear_ordered_field 𝕜] {𝕜}
+variables [linear_ordered_field 𝕜]
 
 lemma Icc_subset_segment {x y : 𝕜} : Icc x y ⊆ [x -[𝕜] y] :=
 begin
@@ -401,27 +419,17 @@ section ordered_semiring
 variables [ordered_semiring 𝕜]
 
 section add_comm_monoid
-variables [add_comm_monoid E]
+variables [add_comm_monoid E] [add_comm_monoid F]
+
+section has_scalar
+variables (𝕜) [has_scalar 𝕜 E] [has_scalar 𝕜 F] (s : set E)
 
 /-- Convexity of sets. -/
-def convex [has_scalar 𝕜 E] (s : set E) :=
+def convex : Prop :=
 ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1 →
   a • x + b • y ∈ s
 
-variables {𝕜} [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F] {s : set E}
-
-lemma convex_iff_forall_pos :
-  convex 𝕜 s ↔ ∀ ⦃x y⦄, x ∈ s → y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1
-  → a • x + b • y ∈ s :=
-begin
-  refine ⟨λ h x y hx hy a b ha hb hab, h hx hy ha.le hb.le hab, _⟩,
-  intros h x y hx hy a b ha hb hab,
-  cases ha.eq_or_lt with ha ha,
-  { subst a, rw [zero_add] at hab, simp [hab, hy] },
-  cases hb.eq_or_lt with hb hb,
-  { subst b, rw [add_zero] at hab, simp [hab, hx] },
-  exact h hx hy ha hb hab
-end
+variables {𝕜 s}
 
 lemma convex_iff_segment_subset :
   convex 𝕜 s ↔ ∀ ⦃x y⦄, x ∈ s → y ∈ s → [x -[𝕜] y] ⊆ s :=
@@ -433,21 +441,13 @@ begin
     exact h hx hy ⟨a, b, ha, hb, hab, rfl⟩ }
 end
 
-lemma convex_iff_open_segment_subset :
-  convex 𝕜 s ↔ ∀ ⦃x y⦄, x ∈ s → y ∈ s → open_segment 𝕜 x y ⊆ s :=
-begin
-  rw convex_iff_segment_subset,
-  exact forall₂_congr (λ x y, forall₂_congr $ λ hx hy,
-    (open_segment_subset_iff_segment_subset hx hy).symm),
-end
-
 lemma convex.segment_subset (h : convex 𝕜 s) {x y : E} (hx : x ∈ s) (hy : y ∈ s) :
   [x -[𝕜] y] ⊆ s :=
 convex_iff_segment_subset.1 h hx hy
 
 lemma convex.open_segment_subset (h : convex 𝕜 s) {x y : E} (hx : x ∈ s) (hy : y ∈ s) :
   open_segment 𝕜 x y ⊆ s :=
-convex_iff_open_segment_subset.1 h hx hy
+(open_segment_subset_segment 𝕜 x y).trans (h.segment_subset hx hy)
 
 /-- Alternative definition of set convexity, in terms of pointwise set operations. -/
 lemma convex_iff_pointwise_add_subset :
@@ -461,13 +461,6 @@ iff.intro
     (h ha hb hab) (set.add_mem_add ⟨_, hx, rfl⟩ ⟨_, hy, rfl⟩))
 
 lemma convex_empty : convex 𝕜 (∅ : set E) := by finish
-
-lemma convex_singleton (c : E) : convex 𝕜 ({c} : set E) :=
-begin
-  intros x y hx hy a b ha hb hab,
-  rw [set.eq_of_mem_singleton hx, set.eq_of_mem_singleton hy, ←add_smul, hab, one_smul],
-  exact mem_singleton c
-end
 
 lemma convex_univ : convex 𝕜 (set.univ : set E) := λ _ _ _ _ _ _ _ _ _, trivial
 
@@ -492,7 +485,7 @@ begin
         ht (mem_prod.1 hx).2 (mem_prod.1 hy).2 ha hb hab⟩
 end
 
-lemma directed.convex_Union {ι : Sort*} {s : ι → set E} (hdir : directed has_subset.subset s)
+lemma directed.convex_Union {ι : Sort*} {s : ι → set E} (hdir : directed (⊆) s)
   (hc : ∀ ⦃i : ι⦄, convex 𝕜 (s i)) :
   convex 𝕜 (⋃ i, s i) :=
 begin
@@ -504,7 +497,7 @@ begin
   exact ⟨k, hc (hik hx) (hjk hy) ha hb hab⟩,
 end
 
-lemma directed_on.convex_sUnion {c : set (set E)} (hdir : directed_on has_subset.subset c)
+lemma directed_on.convex_sUnion {c : set (set E)} (hdir : directed_on (⊆) c)
   (hc : ∀ ⦃A : set E⦄, A ∈ c → convex 𝕜 A) :
   convex 𝕜 (⋃₀c) :=
 begin
@@ -512,7 +505,54 @@ begin
   exact (directed_on_iff_directed.1 hdir).convex_Union (λ A, hc A.2),
 end
 
-lemma convex.linear_image (hs : convex 𝕜 s) (f : E →ₗ[𝕜]  F) : convex 𝕜 (s.image f) :=
+end has_scalar
+
+section module
+variables [module 𝕜 E] [module 𝕜 F] {s : set E}
+
+lemma convex_iff_forall_pos :
+  convex 𝕜 s ↔ ∀ ⦃x y⦄, x ∈ s → y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1
+  → a • x + b • y ∈ s :=
+begin
+  refine ⟨λ h x y hx hy a b ha hb hab, h hx hy ha.le hb.le hab, _⟩,
+  intros h x y hx hy a b ha hb hab,
+  cases ha.eq_or_lt with ha ha,
+  { subst a, rw [zero_add] at hab, simp [hab, hy] },
+  cases hb.eq_or_lt with hb hb,
+  { subst b, rw [add_zero] at hab, simp [hab, hx] },
+  exact h hx hy ha hb hab
+end
+
+lemma convex_iff_pairwise_on_pos :
+  convex 𝕜 s ↔ s.pairwise_on (λ x y, ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1 → a • x + b • y ∈ s) :=
+begin
+  refine ⟨λ h x hx y hy _ a b ha hb hab, h hx hy ha.le hb.le hab, _⟩,
+  intros h x y hx hy a b ha hb hab,
+  obtain rfl | ha' := ha.eq_or_lt,
+  { rw [zero_add] at hab, simp [hab, hy] },
+  obtain rfl | hb' := hb.eq_or_lt,
+  { rw [add_zero] at hab, simp [hab, hx] },
+  obtain rfl | hxy := eq_or_ne x y,
+  { rwa convex.combo_self hab },
+  exact h _ hx _ hy hxy ha' hb' hab,
+end
+
+lemma convex_iff_open_segment_subset :
+  convex 𝕜 s ↔ ∀ ⦃x y⦄, x ∈ s → y ∈ s → open_segment 𝕜 x y ⊆ s :=
+begin
+  rw convex_iff_segment_subset,
+  exact forall₂_congr (λ x y, forall₂_congr $ λ hx hy,
+    (open_segment_subset_iff_segment_subset hx hy).symm),
+end
+
+lemma convex_singleton (c : E) : convex 𝕜 ({c} : set E) :=
+begin
+  intros x y hx hy a b ha hb hab,
+  rw [set.eq_of_mem_singleton hx, set.eq_of_mem_singleton hy, ←add_smul, hab, one_smul],
+  exact mem_singleton c
+end
+
+lemma convex.linear_image (hs : convex 𝕜 s) (f : E →ₗ[𝕜] F) : convex 𝕜 (s.image f) :=
 begin
   intros x y hx hy a b ha hb hab,
   obtain ⟨x', hx', rfl⟩ := mem_image_iff_bex.1 hx,
@@ -536,7 +576,7 @@ lemma convex.is_linear_preimage {s : set F} (hs : convex 𝕜 s) {f : E → F} (
   convex 𝕜 (preimage f s) :=
 hs.linear_preimage $ hf.mk' f
 
-lemma convex.add {t : set E}  (hs : convex 𝕜 s) (ht : convex 𝕜 t) : convex 𝕜 (s + t) :=
+lemma convex.add {t : set E} (hs : convex 𝕜 s) (ht : convex 𝕜 t) : convex 𝕜 (s + t) :=
 by { rw ← add_image_prod, exact (hs.prod ht).is_linear_image is_linear_map.is_linear_map_add }
 
 lemma convex.translate (hs : convex 𝕜 s) (z : E) : convex 𝕜 ((λ x, z + x) '' s) :=
@@ -560,78 +600,103 @@ end
 lemma convex.translate_preimage_left (hs : convex 𝕜 s) (z : E) : convex 𝕜 ((λ x, x + z) ⁻¹' s) :=
 by simpa only [add_comm] using hs.translate_preimage_right z
 
-lemma convex_Iio (r : 𝕜) : convex 𝕜 (Iio r) :=
-begin
-  intros x y hx hy a b ha hb hab,
-  obtain rfl | ha' := ha.eq_or_lt,
-  { rw zero_add at hab,
-    rwa [zero_smul, zero_add, hab, one_smul] },
-  rw [smul_eq_mul, smul_eq_mul],
-  rw mem_Iio at hx hy,
-  calc
-    a * x + b * y
-        < a * r + b * r : add_lt_add_of_lt_of_le (mul_lt_mul_of_pos_left hx ha')
-          (mul_le_mul_of_nonneg_left hy.le hb)
-  ... = r : by rw [←add_mul, hab, one_mul]
-end
+section ordered_add_comm_monoid
+variables [ordered_add_comm_monoid β] [module 𝕜 β] [ordered_smul 𝕜 β]
 
-lemma convex_Ioi (r : 𝕜) : convex 𝕜 (Ioi r) :=
-begin
-  intros x y hx hy a b ha hb hab,
-  obtain rfl | ha' := ha.eq_or_lt,
-  { rw zero_add at hab,
-    rwa [zero_smul, zero_add, hab, one_smul] },
-  rw [smul_eq_mul, smul_eq_mul],
-  rw mem_Ioi at hx hy,
-  calc
-    r   = a * r + b * r : by rw [←add_mul, hab, one_mul]
-    ... < a * x + b * y : add_lt_add_of_lt_of_le (mul_lt_mul_of_pos_left hx ha')
-          (mul_le_mul_of_nonneg_left hy.le hb),
-end
-
-lemma convex_Iic (r : 𝕜) : convex 𝕜 (Iic r) :=
+lemma convex_Iic (r : β) : convex 𝕜 (Iic r) :=
 λ x y hx hy a b ha hb hab,
 calc
-  a * x + b * y
-      ≤ a * r + b * r
-      : add_le_add (mul_le_mul_of_nonneg_left hx ha) (mul_le_mul_of_nonneg_left hy hb)
-  ... = r : by rw [←add_mul, hab, one_mul]
+  a • x + b • y
+      ≤ a • r + b • r
+      : add_le_add (smul_le_smul_of_nonneg hx ha) (smul_le_smul_of_nonneg hy hb)
+  ... = r : convex.combo_self hab _
 
-lemma convex_Ici (r : 𝕜) : convex 𝕜 (Ici r) :=
-λ x y hx hy a b ha hb hab,
-calc
-  r   = a * r + b * r : by rw [←add_mul, hab, one_mul]
-  ... ≤ a * x + b * y
-      : add_le_add (mul_le_mul_of_nonneg_left hx ha) (mul_le_mul_of_nonneg_left hy hb)
+lemma convex_Ici (r : β) : convex 𝕜 (Ici r) :=
+@convex_Iic 𝕜 (order_dual β) _ _ _ _ r
 
-lemma convex_Ioo (r s : 𝕜) : convex 𝕜 (Ioo r s) :=
-Ioi_inter_Iio.subst ((convex_Ioi r).inter $ convex_Iio s)
-
-lemma convex_Ico (r s : 𝕜) : convex 𝕜 (Ico r s) :=
-Ici_inter_Iio.subst ((convex_Ici r).inter $ convex_Iio s)
-
-lemma convex_Ioc (r s : 𝕜) : convex 𝕜 (Ioc r s) :=
-Ioi_inter_Iic.subst ((convex_Ioi r).inter $ convex_Iic s)
-
-lemma convex_Icc (r s : 𝕜) : convex 𝕜 (Icc r s) :=
+lemma convex_Icc (r s : β) : convex 𝕜 (Icc r s) :=
 Ici_inter_Iic.subst ((convex_Ici r).inter $ convex_Iic s)
 
+lemma convex_halfspace_le {f : E → β} (h : is_linear_map 𝕜 f) (r : β) :
+  convex 𝕜 {w | f w ≤ r} :=
+(convex_Iic r).is_linear_preimage h
+
+lemma convex_halfspace_ge {f : E → β} (h : is_linear_map 𝕜 f) (r : β) :
+  convex 𝕜 {w | r ≤ f w} :=
+(convex_Ici r).is_linear_preimage h
+
+lemma convex_hyperplane {f : E → β} (h : is_linear_map 𝕜 f) (r : β) :
+  convex 𝕜 {w | f w = r} :=
+begin
+  simp_rw le_antisymm_iff,
+  exact (convex_halfspace_le h r).inter (convex_halfspace_ge h r),
+end
+
+end ordered_add_comm_monoid
+
+section ordered_cancel_add_comm_monoid
+variables [ordered_cancel_add_comm_monoid β] [module 𝕜 β] [ordered_smul 𝕜 β]
+
+lemma convex_Iio (r : β) : convex 𝕜 (Iio r) :=
+begin
+  intros x y hx hy a b ha hb hab,
+  obtain rfl | ha' := ha.eq_or_lt,
+  { rw zero_add at hab,
+    rwa [zero_smul, zero_add, hab, one_smul] },
+  rw mem_Iio at hx hy,
+  calc
+    a • x + b • y
+        < a • r + b • r
+        : add_lt_add_of_lt_of_le (smul_lt_smul_of_pos hx ha') (smul_le_smul_of_nonneg hy.le hb)
+    ... = r : convex.combo_self hab _
+end
+
+lemma convex_Ioi (r : β) : convex 𝕜 (Ioi r) :=
+@convex_Iio 𝕜 (order_dual β) _ _ _ _ r
+
+lemma convex_Ioo (r s : β) : convex 𝕜 (Ioo r s) :=
+Ioi_inter_Iio.subst ((convex_Ioi r).inter $ convex_Iio s)
+
+lemma convex_Ico (r s : β) : convex 𝕜 (Ico r s) :=
+Ici_inter_Iio.subst ((convex_Ici r).inter $ convex_Iio s)
+
+lemma convex_Ioc (r s : β) : convex 𝕜 (Ioc r s) :=
+Ioi_inter_Iic.subst ((convex_Ioi r).inter $ convex_Iic s)
+
+lemma convex_halfspace_lt {f : E → β} (h : is_linear_map 𝕜 f) (r : β) :
+  convex 𝕜 {w | f w < r} :=
+(convex_Iio r).is_linear_preimage h
+
+lemma convex_halfspace_gt {f : E → β} (h : is_linear_map 𝕜 f) (r : β) :
+  convex 𝕜 {w | r < f w} :=
+(convex_Ioi r).is_linear_preimage h
+
+end ordered_cancel_add_comm_monoid
+
+section linear_ordered_add_comm_monoid
+variables [linear_ordered_add_comm_monoid β] [module 𝕜 β] [ordered_smul 𝕜 β]
+
+lemma convex_interval (r s : β) : convex 𝕜 (interval r s) :=
+convex_Icc _ _
+
+end linear_ordered_add_comm_monoid
+end module
 end add_comm_monoid
 
 section add_comm_group
-variables [add_comm_group E] [module 𝕜 E] {𝕜} {s t : set E}
+variables [add_comm_group E] [module 𝕜 E] {s t : set E}
 
 lemma convex.combo_eq_vadd {a b : 𝕜} {x y : E} (h : a + b = 1) :
   a • x + b • y = b • (y - x) + x :=
 calc
   a • x + b • y = (b • y - b • x) + (a • x + b • x) : by abel
-            ... = b • (y - x) + x                   : by rw [smul_sub, ←add_smul, h, one_smul]
+            ... = b • (y - x) + x                   : by rw [smul_sub, convex.combo_self h]
 
 lemma convex.sub (hs : convex 𝕜 s) (ht : convex 𝕜 t) :
   convex 𝕜 ((λ x : E × E, x.1 - x.2) '' (s.prod t)) :=
 (hs.prod ht).is_linear_image is_linear_map.is_linear_map_sub
 
-lemma convex_segment (x y : E) : convex 𝕜 [x -[𝕜]  y] :=
+lemma convex_segment (x y : E) : convex 𝕜 [x -[𝕜] y] :=
 begin
   rintro p q ⟨ap, bp, hap, hbp, habp, rfl⟩ ⟨aq, bq, haq, hbq, habq, rfl⟩ a b ha hb hab,
   refine ⟨a * ap + b * aq, a * bp + b * bq,
@@ -654,45 +719,14 @@ begin
     exact add_add_add_comm _ _ _ _ }
 end
 
-lemma convex_halfspace_lt {f : E → 𝕜} (h : is_linear_map 𝕜 f) (r : 𝕜) :
-  convex 𝕜 {w | f w < r} :=
-(convex_Iio r).is_linear_preimage h
-
-lemma convex_halfspace_le {f : E → 𝕜} (h : is_linear_map 𝕜 f) (r : 𝕜) :
-  convex 𝕜 {w | f w ≤ r} :=
-(convex_Iic r).is_linear_preimage h
-
-lemma convex_halfspace_gt {f : E → 𝕜} (h : is_linear_map 𝕜 f) (r : 𝕜) :
-  convex 𝕜 {w | r < f w} :=
-(convex_Ioi r).is_linear_preimage h
-
-lemma convex_halfspace_ge {f : E → 𝕜} (h : is_linear_map 𝕜 f) (r : 𝕜) :
-  convex 𝕜 {w | r ≤ f w} :=
-(convex_Ici r).is_linear_preimage h
-
-lemma convex_hyperplane {f : E → 𝕜} (h : is_linear_map 𝕜 f) (r : 𝕜) :
-  convex 𝕜 {w | f w = r} :=
-begin
-  simp_rw le_antisymm_iff,
-  exact (convex_halfspace_le h r).inter (convex_halfspace_ge h r),
-end
-
 end add_comm_group
 end ordered_semiring
-
-section linear_ordered_semiring
-variables [linear_ordered_semiring 𝕜] {𝕜}
-
-lemma convex_interval (r s : 𝕜) : convex 𝕜 (interval r s) :=
-convex_Icc _ _
-
-end linear_ordered_semiring
 
 section ordered_comm_semiring
 variables [ordered_comm_semiring 𝕜]
 
 section add_comm_monoid
-variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F] {𝕜} {s : set E}
+variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F] {s : set E}
 
 lemma convex.smul (hs : convex 𝕜 s) (c : 𝕜) : convex 𝕜 (c • s) :=
 hs.linear_image (linear_map.lsmul _ _ c)
@@ -713,7 +747,7 @@ section ordered_ring
 variables [ordered_ring 𝕜]
 
 section add_comm_monoid
-variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F] {𝕜} {s : set E}
+variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F] {s : set E}
 
 lemma convex.add_smul_mem (hs : convex 𝕜 s) {x y : E} (hx : x ∈ s) (hy : x + y ∈ s)
   {t : 𝕜} (ht : t ∈ Icc (0 : 𝕜) 1) : x + t • y ∈ s :=
@@ -731,7 +765,7 @@ by simpa using hs.add_smul_mem zero_mem (by simpa using hx) ht
 end add_comm_monoid
 
 section add_comm_group
-variables [add_comm_group E] [module 𝕜 E] [add_comm_group F] [module 𝕜 F] {𝕜} {s : set E}
+variables [add_comm_group E] [module 𝕜 E] [add_comm_group F] [module 𝕜 F] {s : set E}
 
 lemma convex.add_smul_sub_mem (h : convex 𝕜 s) {x y : E} (hx : x ∈ s) (hy : y ∈ s)
   {t : 𝕜} (ht : t ∈ Icc (0 : 𝕜) 1) : x + t • (y - x) ∈ s :=
@@ -745,7 +779,7 @@ end
 Applying an affine map to an affine combination of two points yields
 an affine combination of the images.
 -/
-lemma convex.combo_affine_apply {a b : 𝕜} {x y : E} {f : E →ᵃ[𝕜]  F} (h : a + b = 1) :
+lemma convex.combo_affine_apply {a b : 𝕜} {x y : E} {f : E →ᵃ[𝕜] F} (h : a + b = 1) :
   f (a • x + b • y) = a • f x + b • f y :=
 begin
   simp only [convex.combo_eq_vadd h, ← vsub_eq_sub],
@@ -753,7 +787,7 @@ begin
 end
 
 /-- The preimage of a convex set under an affine map is convex. -/
-lemma convex.affine_preimage (f : E →ᵃ[𝕜]  F) {s : set F} (hs : convex 𝕜 s) :
+lemma convex.affine_preimage (f : E →ᵃ[𝕜] F) {s : set F} (hs : convex 𝕜 s) :
   convex 𝕜 (f ⁻¹' s) :=
 begin
   intros x y xs ys a b ha hb hab,
@@ -762,7 +796,7 @@ begin
 end
 
 /-- The image of a convex set under an affine map is convex. -/
-lemma convex.affine_image (f : E →ᵃ[𝕜]  F) {s : set E} (hs : convex 𝕜 s) :
+lemma convex.affine_image (f : E →ᵃ[𝕜] F) {s : set E} (hs : convex 𝕜 s) :
   convex 𝕜 (f '' s) :=
 begin
   rintro x y ⟨x', ⟨hx', hx'f⟩⟩ ⟨y', ⟨hy', hy'f⟩⟩ a b ha hb hab,
@@ -784,7 +818,7 @@ section linear_ordered_field
 variables [linear_ordered_field 𝕜]
 
 section add_comm_monoid
-variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F] {𝕜} {s : set E}
+variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F] {s : set E}
 
 /-- Alternative definition of set convexity, using division. -/
 lemma convex_iff_div :
@@ -842,7 +876,6 @@ Relates `convex` and `ord_connected`.
 -/
 
 section
-variables {𝕜}
 
 lemma set.ord_connected.convex_of_chain [ordered_add_comm_monoid E] [ordered_semiring 𝕜]
   [module 𝕜 E] [ordered_smul 𝕜 E] {s : set E} (hs : s.ord_connected) (h : zorn.chain (≤) s) :
@@ -852,20 +885,20 @@ begin
   obtain hxy | hyx := h.total_of_refl hx hy,
   { refine hs.out hx hy (mem_Icc.2 ⟨_, _⟩),
     calc
-      x   = a • x + b • x : by rw [←add_smul, hab, one_smul]
+      x   = a • x + b • x : (convex.combo_self hab _).symm
       ... ≤ a • x + b • y : add_le_add_left (smul_le_smul_of_nonneg hxy hb) _,
     calc
       a • x + b • y
           ≤ a • y + b • y : add_le_add_right (smul_le_smul_of_nonneg hxy ha) _
-      ... = y : by rw [←add_smul, hab, one_smul] },
+      ... = y : convex.combo_self hab _ },
   { refine hs.out hy hx (mem_Icc.2 ⟨_, _⟩),
     calc
-      y   = a • y + b • y : by rw [←add_smul, hab, one_smul]
+      y   = a • y + b • y : (convex.combo_self hab _).symm
       ... ≤ a • x + b • y : add_le_add_right (smul_le_smul_of_nonneg hyx ha) _,
     calc
       a • x + b • y
           ≤ a • x + b • x : add_le_add_left (smul_le_smul_of_nonneg hyx hb) _
-      ... = x : by rw [←add_smul, hab, one_smul] }
+      ... = x : convex.combo_self hab _ }
 end
 
 lemma set.ord_connected.convex [linear_ordered_add_comm_monoid E] [ordered_semiring 𝕜]
@@ -887,7 +920,6 @@ end
 /-! #### Convexity of submodules/subspaces -/
 
 section submodule
-variables {𝕜}
 open submodule
 
 lemma submodule.convex [ordered_semiring 𝕜] [add_comm_monoid E] [module 𝕜 E] (K : submodule 𝕜 E) :
@@ -907,7 +939,7 @@ section ordered_semiring
 variables [ordered_semiring 𝕜]
 
 section add_comm_monoid
-variables [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F]
+variables (𝕜) [add_comm_monoid E] [module 𝕜 E] [add_comm_monoid F] [module 𝕜 F]
 
 /-- The convex hull of a set `s` is the minimal convex set that includes `s`. -/
 def convex_hull : closure_operator (set E) :=
@@ -1013,7 +1045,7 @@ section ordered_ring
 variables [ordered_ring 𝕜]
 
 section add_comm_monoid
-variables {𝕜} [add_comm_group E] [module 𝕜 E] [add_comm_group F] [module 𝕜 F] {s : set E}
+variables [add_comm_group E] [module 𝕜 E] [add_comm_group F] [module 𝕜 F] {s : set E}
 
 lemma affine_map.image_convex_hull (f : E →ᵃ[𝕜] F) :
   f '' (convex_hull 𝕜 s) = convex_hull 𝕜 (f '' s) :=

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -17,8 +17,8 @@ In a 𝕜-vector space, we define the following objects and properties.
 * `convex 𝕜 s`: A set `s` is convex if for any two points `x y ∈ s` it includes `segment 𝕜 x y`.
 * `convex_hull 𝕜 s`: The minimal convex set that includes `s`. In order theory speak, this is a
   closure operator.
-* Standard simplex `std_simplex ι [fintype ι]` is the intersection of the positive quadrant with
-  the hyperplane `s.sum = 1` in the space `ι → 𝕜`.
+* `std_simplex 𝕜 ι`: The standard simplex in `ι → 𝕜` (currently requires `fintype ι`). It is the
+  intersection of the positive quadrant with the hyperplane `s.sum = 1`.
 
 We also provide various equivalent versions of the definitions above, prove that some specific sets
 are convex.

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -518,20 +518,6 @@ begin
   exact h hx hy ha hb hab
 end
 
-lemma convex_iff_pairwise_on_pos :
-  convex 𝕜 s ↔ s.pairwise_on (λ x y, ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1 → a • x + b • y ∈ s) :=
-begin
-  refine ⟨λ h x hx y hy _ a b ha hb hab, h hx hy ha.le hb.le hab, _⟩,
-  intros h x y hx hy a b ha hb hab,
-  obtain rfl | ha' := ha.eq_or_lt,
-  { rw [zero_add] at hab, simp [hab, hy] },
-  obtain rfl | hb' := hb.eq_or_lt,
-  { rw [add_zero] at hab, simp [hab, hx] },
-  obtain rfl | hxy := eq_or_ne x y,
-  { rwa convex.combo_self hab },
-  exact h _ hx _ hy hxy ha' hb' hab,
-end
-
 lemma convex_iff_open_segment_subset :
   convex 𝕜 s ↔ ∀ ⦃x y⦄, x ∈ s → y ∈ s → open_segment 𝕜 x y ⊆ s :=
 begin

--- a/src/analysis/convex/combination.lean
+++ b/src/analysis/convex/combination.lean
@@ -287,11 +287,11 @@ end
 
 variables (ι) [fintype ι] {f : ι → R}
 
-/-- `std_simplex ι` is the convex hull of the canonical basis in `ι → ℝ`. -/
+/-- `std_simplex 𝕜 ι` is the convex hull of the canonical basis in `ι → 𝕜`. -/
 lemma convex_hull_basis_eq_std_simplex :
-  convex_hull R (range $ λ(i j:ι), if i = j then (1:R) else 0) = std_simplex ι R :=
+  convex_hull R (range $ λ(i j:ι), if i = j then (1:R) else 0) = std_simplex R ι :=
 begin
-  refine subset.antisymm (convex_hull_min _ (convex_std_simplex ι R)) _,
+  refine subset.antisymm (convex_hull_min _ (convex_std_simplex R ι)) _,
   { rintros _ ⟨i, rfl⟩,
     exact ite_eq_mem_std_simplex R i },
   { rintros w ⟨hw₀, hw₁⟩,
@@ -310,7 +310,7 @@ The map is defined in terms of operations on `(s → ℝ) →ₗ[ℝ] ℝ` so th
 to prove that this map is linear. -/
 lemma set.finite.convex_hull_eq_image {s : set E} (hs : finite s) :
   convex_hull R s = by haveI := hs.fintype; exact
-    (⇑(∑ x : s, (@linear_map.proj R s _ (λ i, R) _ _ x).smul_right x.1)) '' (std_simplex s R) :=
+    (⇑(∑ x : s, (@linear_map.proj R s _ (λ i, R) _ _ x).smul_right x.1)) '' (std_simplex R s) :=
 begin
   rw [← convex_hull_basis_eq_std_simplex, ← linear_map.convex_hull_image, ← set.range_comp, (∘)],
   apply congr_arg,
@@ -319,7 +319,7 @@ begin
   simp [linear_map.sum_apply, ite_smul, finset.filter_eq]
 end
 
-/-- All values of a function `f ∈ std_simplex ι` belong to `[0, 1]`. -/
-lemma mem_Icc_of_mem_std_simplex (hf : f ∈ std_simplex ι R) (x) :
+/-- All values of a function `f ∈ std_simplex 𝕜 ι` belong to `[0, 1]`. -/
+lemma mem_Icc_of_mem_std_simplex (hf : f ∈ std_simplex R ι) (x) :
   f x ∈ Icc (0 : R) 1 :=
 ⟨hf.1 x, hf.2 ▸ finset.single_le_sum (λ y hy, hf.1 y) (finset.mem_univ x)⟩

--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -42,9 +42,9 @@ section std_simplex
 
 variables [fintype ι]
 
-/-- Every vector in `std_simplex ι` has `max`-norm at most `1`. -/
+/-- Every vector in `std_simplex 𝕜 ι` has `max`-norm at most `1`. -/
 lemma std_simplex_subset_closed_ball :
-  std_simplex ι ℝ ⊆ metric.closed_ball 0 1 :=
+  std_simplex ℝ ι ⊆ metric.closed_ball 0 1 :=
 begin
   assume f hf,
   rw [metric.mem_closed_ball, dist_zero_right],
@@ -56,18 +56,18 @@ end
 
 variable (ι)
 
-/-- `std_simplex ι` is bounded. -/
-lemma bounded_std_simplex : metric.bounded (std_simplex ι ℝ) :=
+/-- `std_simplex ℝ ι` is bounded. -/
+lemma bounded_std_simplex : metric.bounded (std_simplex ℝ ι) :=
 (metric.bounded_iff_subset_ball 0).2 ⟨1, std_simplex_subset_closed_ball⟩
 
-/-- `std_simplex ι` is closed. -/
-lemma is_closed_std_simplex : is_closed (std_simplex ι ℝ) :=
-(std_simplex_eq_inter ι ℝ).symm ▸ is_closed.inter
+/-- `std_simplex ℝ ι` is closed. -/
+lemma is_closed_std_simplex : is_closed (std_simplex ℝ ι) :=
+(std_simplex_eq_inter ℝ ι).symm ▸ is_closed.inter
   (is_closed_Inter $ λ i, is_closed_le continuous_const (continuous_apply i))
   (is_closed_eq (continuous_finset_sum _ $ λ x _, continuous_apply x) continuous_const)
 
-/-- `std_simplex ι` is compact. -/
-lemma compact_std_simplex : is_compact (std_simplex ι ℝ) :=
+/-- `std_simplex ℝ ι` is compact. -/
+lemma compact_std_simplex : is_compact (std_simplex ℝ ι) :=
 metric.compact_iff_closed_bounded.2 ⟨is_closed_std_simplex ι, bounded_std_simplex ι⟩
 
 end std_simplex


### PR DESCRIPTION
Some lemmas were about `f : whatever → 𝕜`. They are now about `f : whatever → β` + a scalar instance between `𝕜` and `β`.
Some `add_comm_monoid` assumptions are actually promotable to `add_comm_group` directly thanks to [`module.add_comm_monoid_to_add_comm_group`](https://leanprover-community.github.io/mathlib_docs/algebra/module/basic.html#module.add_comm_monoid_to_add_comm_group). [Related Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Convexity.20refactor/near/255268131).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
