### PR TITLE
[Merged by Bors] - feat(probability_theory/notation): add notations for expected value, conditional expectation

### DIFF
--- a/src/probability_theory/notation.lean
+++ b/src/probability_theory/notation.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2021 Rémy Degenne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne
+-/
+import measure_theory.function.conditional_expectation
+
+/-! # Notations for probability theory -/
+
+open measure_theory topological_space
+
+-- The related notation `ℙ[ X | hm] := measure_theory.condexp hm ℙ X` is defined in
+-- measure_theory.function.conditional_expectation.
+localized "notation `𝔼[` X `|` hm `]` := measure_theory.condexp hm volume X" in probability_theory
+
+-- The usual expectation notation `𝔼[X]` does not carry information about the measure used, hence
+-- we reserve it for the `volume` measure, and use the similar `ℙ[X]` for the expectation under `ℙ`.
+localized "notation ℙ `[` X `]` := ∫ x, X x ∂ℙ" in probability_theory
+
+localized "notation `𝔼[` X `]` := ∫ a, X a" in probability_theory
+
+localized "notation X `=ₐₛ`:50 Y:50 := X =ᵐ[volume] Y" in probability_theory
+
+localized "notation X `≤ₐₛ`:50 Y:50 := X ≤ᵐ[volume] Y" in probability_theory
+
+section examples
+
+open_locale probability_theory
+
+variables {α E : Type*} [measure_space α] {ℙ : measure α} [measurable_space E] [normed_group E]
+  [normed_space ℝ E] [borel_space E] [second_countable_topology E] [complete_space E] {X Y : α → E}
+
+example : ℙ[X] = ∫ a, X a ∂ℙ := rfl
+
+example : 𝔼[X] = volume[X] := rfl
+
+example : X =ₐₛ Y ↔ X =ᵐ[volume] Y := iff.rfl
+
+end examples

--- a/src/probability_theory/notation.lean
+++ b/src/probability_theory/notation.lean
@@ -10,6 +10,8 @@ import measure_theory.decomposition.radon_nikodym
 
 open measure_theory measure_theory.measure topological_space
 
+localized "notation `ℙ` := volume" in probability_theory
+
 -- The related notation `P[ X | hm] := measure_theory.condexp hm P X` is defined in
 -- measure_theory.function.conditional_expectation.
 localized "notation `𝔼[` X `|` hm `]` := measure_theory.condexp hm volume X" in probability_theory
@@ -35,7 +37,11 @@ variables {α E : Type*} [measure_space α] {P P' : measure α} [measurable_spac
 
 example : P[X] = ∫ a, X a ∂P := rfl
 
+example : ℙ[X] = ∫ a, X a := rfl
+
 example : 𝔼[X] = volume[X] := rfl
+
+example : 𝔼[X] = ℙ[X] := rfl
 
 example : X =ₐₛ Y ↔ X =ᵐ[volume] Y := iff.rfl
 

--- a/src/probability_theory/notation.lean
+++ b/src/probability_theory/notation.lean
@@ -8,7 +8,7 @@ import measure_theory.decomposition.radon_nikodym
 
 /-! # Notations for probability theory -/
 
-open measure_theory topological_space
+open measure_theory measure_theory.measure topological_space
 
 -- The related notation `ℙ[ X | hm] := measure_theory.condexp hm ℙ X` is defined in
 -- measure_theory.function.conditional_expectation.
@@ -40,5 +40,13 @@ example : 𝔼[X] = volume[X] := rfl
 example : X =ₐₛ Y ↔ X =ᵐ[volume] Y := iff.rfl
 
 example : ∂ℙ/∂ℙ' = ℙ.rn_deriv ℙ' := rfl
+
+/-- TODO: how may I remove the parentheses? -/
+example [have_lebesgue_decomposition ℙ ℙ'] (h : ℙ ≪ ℙ') : ∫⁻ a, (∂ℙ/∂ℙ') a ∂ℙ' = ℙ set.univ :=
+begin
+  obtain ⟨-, -, hadd⟩ := have_lebesgue_decomposition_spec ℙ ℙ',
+  rw [← set_lintegral_univ, ← with_density_apply _ measurable_set.univ],
+  rw with_density_rn_deriv_eq _ _ h,
+end
 
 end examples

--- a/src/probability_theory/notation.lean
+++ b/src/probability_theory/notation.lean
@@ -10,8 +10,6 @@ import measure_theory.decomposition.radon_nikodym
 
 open measure_theory measure_theory.measure topological_space
 
-localized "notation `ℙ` := volume" in probability_theory
-
 -- The related notation `P[ X | hm] := measure_theory.condexp hm P X` is defined in
 -- measure_theory.function.conditional_expectation.
 localized "notation `𝔼[` X `|` hm `]` := measure_theory.condexp hm volume X" in probability_theory
@@ -37,11 +35,7 @@ variables {α E : Type*} [measure_space α] {P P' : measure α} [measurable_spac
 
 example : P[X] = ∫ a, X a ∂P := rfl
 
-example : ℙ[X] = ∫ a, X a := rfl
-
 example : 𝔼[X] = volume[X] := rfl
-
-example : 𝔼[X] = ℙ[X] := rfl
 
 example : X =ₐₛ Y ↔ X =ᵐ[volume] Y := iff.rfl
 

--- a/src/probability_theory/notation.lean
+++ b/src/probability_theory/notation.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
 import measure_theory.function.conditional_expectation
+import measure_theory.decomposition.radon_nikodym
 
 /-! # Notations for probability theory -/
 
@@ -23,11 +24,13 @@ localized "notation X `=ₐₛ`:50 Y:50 := X =ᵐ[volume] Y" in probability_theo
 
 localized "notation X `≤ₐₛ`:50 Y:50 := X ≤ᵐ[volume] Y" in probability_theory
 
+localized "notation `∂` ℙ `/∂`:50 ℙ':50 := ℙ.rn_deriv ℙ'" in probability_theory
+
 section examples
 
 open_locale probability_theory
 
-variables {α E : Type*} [measure_space α] {ℙ : measure α} [measurable_space E] [normed_group E]
+variables {α E : Type*} [measure_space α] {ℙ ℙ' : measure α} [measurable_space E] [normed_group E]
   [normed_space ℝ E] [borel_space E] [second_countable_topology E] [complete_space E] {X Y : α → E}
 
 example : ℙ[X] = ∫ a, X a ∂ℙ := rfl
@@ -35,5 +38,7 @@ example : ℙ[X] = ∫ a, X a ∂ℙ := rfl
 example : 𝔼[X] = volume[X] := rfl
 
 example : X =ₐₛ Y ↔ X =ᵐ[volume] Y := iff.rfl
+
+example : ∂ℙ/∂ℙ' = ℙ.rn_deriv ℙ' := rfl
 
 end examples

--- a/src/probability_theory/notation.lean
+++ b/src/probability_theory/notation.lean
@@ -6,16 +6,27 @@ Authors: Rémy Degenne
 import measure_theory.function.conditional_expectation
 import measure_theory.decomposition.radon_nikodym
 
-/-! # Notations for probability theory -/
+/-! # Notations for probability theory
 
-open measure_theory measure_theory.measure topological_space
+This file defines the following notations, for functions `X,Y`, measures `P, Q` defined on a
+measurable space `m0`, and another measurable space structure `m` with `hm : m ≤ m0`,
+- `P[X] = ∫ a, X a ∂P`
+- `𝔼[X] = ∫ a, X a`
+- `𝔼[X|hm]`: conditional expectation of `X` with respect to the measure `volume` and the
+  measurable space `m`. The similar `P[X|hm]` for a measure `P` is defined in
+  measure_theory.function.conditional_expectation.
+- `X =ₐₛ Y`: `X =ᵐ[volume] Y`
+- `X ≤ₐₛ Y`: `X ≤ᵐ[volume] Y`
+- `∂P/∂Q = P.rn_deriv Q`
 
--- The related notation `P[ X | hm] := measure_theory.condexp hm P X` is defined in
--- measure_theory.function.conditional_expectation.
+TODO: define the notation `ℙ s` for the probability of a set `s`, and decide whether it should be a
+value in `ℝ`, `ℝ≥0` or `ℝ≥0∞`.
+-/
+
+open measure_theory
+
 localized "notation `𝔼[` X `|` hm `]` := measure_theory.condexp hm volume X" in probability_theory
 
--- The usual expectation notation `𝔼[X]` does not carry information about the measure used, hence
--- we reserve it for the `volume` measure, and use the similar `P[X]` for the expectation under `P`.
 localized "notation P `[` X `]` := ∫ x, X x ∂P" in probability_theory
 
 localized "notation `𝔼[` X `]` := ∫ a, X a" in probability_theory
@@ -24,26 +35,4 @@ localized "notation X `=ₐₛ`:50 Y:50 := X =ᵐ[volume] Y" in probability_theo
 
 localized "notation X `≤ₐₛ`:50 Y:50 := X ≤ᵐ[volume] Y" in probability_theory
 
-localized "notation `∂` P `/∂`:50 P':50 := P.rn_deriv P'" in probability_theory
-
-section examples
-
-open_locale probability_theory
-
-variables {α E : Type*} [measure_space α] {P P' : measure α} [measurable_space E] [normed_group E]
-  [normed_space ℝ E] [borel_space E] [second_countable_topology E] [complete_space E] {X Y : α → E}
-
-example : P[X] = ∫ a, X a ∂P := rfl
-
-example : 𝔼[X] = volume[X] := rfl
-
-example : X =ₐₛ Y ↔ X =ᵐ[volume] Y := iff.rfl
-
-example : ∂P/∂P' = P.rn_deriv P' := rfl
-
-/-- TODO: how may I remove the parentheses? Also: is this an existing lemma? -/
-example [have_lebesgue_decomposition P P'] (h : P ≪ P') : ∫⁻ a, (∂P/∂P') a ∂P' = P set.univ :=
-by rw [← set_lintegral_univ, ← with_density_apply _ measurable_set.univ,
-  with_density_rn_deriv_eq _ _ h]
-
-end examples
+localized "notation `∂` P `/∂`:50 Q:50 := P.rn_deriv Q" in probability_theory

--- a/src/probability_theory/notation.lean
+++ b/src/probability_theory/notation.lean
@@ -10,13 +10,13 @@ import measure_theory.decomposition.radon_nikodym
 
 open measure_theory measure_theory.measure topological_space
 
--- The related notation `ℙ[ X | hm] := measure_theory.condexp hm ℙ X` is defined in
+-- The related notation `P[ X | hm] := measure_theory.condexp hm P X` is defined in
 -- measure_theory.function.conditional_expectation.
 localized "notation `𝔼[` X `|` hm `]` := measure_theory.condexp hm volume X" in probability_theory
 
 -- The usual expectation notation `𝔼[X]` does not carry information about the measure used, hence
--- we reserve it for the `volume` measure, and use the similar `ℙ[X]` for the expectation under `ℙ`.
-localized "notation ℙ `[` X `]` := ∫ x, X x ∂ℙ" in probability_theory
+-- we reserve it for the `volume` measure, and use the similar `P[X]` for the expectation under `P`.
+localized "notation P `[` X `]` := ∫ x, X x ∂P" in probability_theory
 
 localized "notation `𝔼[` X `]` := ∫ a, X a" in probability_theory
 
@@ -24,28 +24,26 @@ localized "notation X `=ₐₛ`:50 Y:50 := X =ᵐ[volume] Y" in probability_theo
 
 localized "notation X `≤ₐₛ`:50 Y:50 := X ≤ᵐ[volume] Y" in probability_theory
 
-localized "notation `∂` ℙ `/∂`:50 ℙ':50 := ℙ.rn_deriv ℙ'" in probability_theory
+localized "notation `∂` P `/∂`:50 P':50 := P.rn_deriv P'" in probability_theory
 
 section examples
 
 open_locale probability_theory
 
-variables {α E : Type*} [measure_space α] {ℙ ℙ' : measure α} [measurable_space E] [normed_group E]
+variables {α E : Type*} [measure_space α] {P P' : measure α} [measurable_space E] [normed_group E]
   [normed_space ℝ E] [borel_space E] [second_countable_topology E] [complete_space E] {X Y : α → E}
 
-example : ℙ[X] = ∫ a, X a ∂ℙ := rfl
+example : P[X] = ∫ a, X a ∂P := rfl
 
 example : 𝔼[X] = volume[X] := rfl
 
 example : X =ₐₛ Y ↔ X =ᵐ[volume] Y := iff.rfl
 
-example : ∂ℙ/∂ℙ' = ℙ.rn_deriv ℙ' := rfl
+example : ∂P/∂P' = P.rn_deriv P' := rfl
 
 /-- TODO: how may I remove the parentheses? -/
-example [have_lebesgue_decomposition ℙ ℙ'] (h : ℙ ≪ ℙ') : ∫⁻ a, (∂ℙ/∂ℙ') a ∂ℙ' = ℙ set.univ :=
-begin
-  rw [← set_lintegral_univ, ← with_density_apply _ measurable_set.univ],
-  rw with_density_rn_deriv_eq _ _ h,
-end
+example [have_lebesgue_decomposition P P'] (h : P ≪ P') : ∫⁻ a, (∂P/∂P') a ∂P' = P set.univ :=
+by rw [← set_lintegral_univ, ← with_density_apply _ measurable_set.univ,
+  with_density_rn_deriv_eq _ _ h]
 
 end examples

--- a/src/probability_theory/notation.lean
+++ b/src/probability_theory/notation.lean
@@ -41,7 +41,7 @@ example : X =ₐₛ Y ↔ X =ᵐ[volume] Y := iff.rfl
 
 example : ∂P/∂P' = P.rn_deriv P' := rfl
 
-/-- TODO: how may I remove the parentheses? -/
+/-- TODO: how may I remove the parentheses? Also: is this an existing lemma? -/
 example [have_lebesgue_decomposition P P'] (h : P ≪ P') : ∫⁻ a, (∂P/∂P') a ∂P' = P set.univ :=
 by rw [← set_lintegral_univ, ← with_density_apply _ measurable_set.univ,
   with_density_rn_deriv_eq _ _ h]

--- a/src/probability_theory/notation.lean
+++ b/src/probability_theory/notation.lean
@@ -44,7 +44,6 @@ example : ∂ℙ/∂ℙ' = ℙ.rn_deriv ℙ' := rfl
 /-- TODO: how may I remove the parentheses? -/
 example [have_lebesgue_decomposition ℙ ℙ'] (h : ℙ ≪ ℙ') : ∫⁻ a, (∂ℙ/∂ℙ') a ∂ℙ' = ℙ set.univ :=
 begin
-  obtain ⟨-, -, hadd⟩ := have_lebesgue_decomposition_spec ℙ ℙ',
   rw [← set_lintegral_univ, ← with_density_apply _ measurable_set.univ],
   rw with_density_rn_deriv_eq _ _ h,
 end


### PR DESCRIPTION
When working in probability theory, the measure on the space is most often implicit. With our current notations for measure spaces, that means writing `volume` in a lot of places. To avoid that and introduce notations closer to the usual practice, this PR defines
- `𝔼[X]` for the expected value (integral) of a function `X` over the volume measure,
- `P[X]` for the expected value over the measure `P`,
- `𝔼[X | hm]` for the conditional expectation with respect to the volume,
- `X =ₐₛ Y` for `X =ᵐ[volume] Y` and similarly for `X ≤ᵐ[volume] Y`,
- `∂P/∂Q` for `P.rn_deriv Q`

All notations are localized to the `probability_theory` namespace.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I'd like to hear opinions about the notations and since I have no idea of how to set binding powers, I'd like some comments on that as well.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
