### PR TITLE
[Merged by Bors] - feat(data/fintype/basic): bijection preserves cardinality

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -992,11 +992,14 @@ have injective (e.symm ∘ f) ↔ surjective (e.symm ∘ f), from injective_iff_
 λ hsurj, by simpa [function.comp] using
   e.injective.comp (this.2 (e.symm.surjective.comp hsurj))⟩
 
+lemma card_of_bijective {f : α → β} (hf : bijective f) : card α = card β :=
+card_congr (equiv.of_bijective f hf)
+
 lemma bijective_iff_injective_and_card (f : α → β) :
   bijective f ↔ injective f ∧ card α = card β :=
 begin
   split,
-  { intro h, exact ⟨h.1, card_congr (equiv.of_bijective f h)⟩ },
+  { intro h, exact ⟨h.1, card_of_bijective h⟩ },
   { rintro ⟨hf, h⟩,
     refine ⟨hf, _⟩,
     rwa ←injective_iff_surjective_of_equiv (equiv_of_card_eq h) }
@@ -1006,7 +1009,7 @@ lemma bijective_iff_surjective_and_card (f : α → β) :
   bijective f ↔ surjective f ∧ card α = card β :=
 begin
   split,
-  { intro h, exact ⟨h.2, card_congr (equiv.of_bijective f h)⟩, },
+  { intro h, exact ⟨h.2, card_of_bijective h⟩ },
   { rintro ⟨hf, h⟩,
     refine ⟨_, hf⟩,
     rwa injective_iff_surjective_of_equiv (equiv_of_card_eq h) }


### PR DESCRIPTION
We don't seem to have this lemma yet, so I've added it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
