### PR TITLE
[Merged by Bors] - chore(algebra/star/basic): provide automorphisms in commutative rings

### DIFF
--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -160,7 +160,7 @@ def star_ring_equiv [semiring R] [star_ring R] : R ≃+* Rᵒᵖ :=
   ..star_add_equiv.trans (opposite.op_add_equiv : R ≃+ Rᵒᵖ),
   ..star_mul_equiv}
 
-/-- `star` as an `ring_aut` for commutative `R` -/
+/-- `star` as a `ring_aut` for commutative `R`. -/
 @[simps apply]
 def star_ring_aut [comm_semiring R] [star_ring R] : ring_aut R :=
 { to_fun := star,

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -7,7 +7,8 @@ import tactic.apply_fun
 import algebra.order.ring
 import algebra.opposites
 import algebra.big_operators.basic
-import data.equiv.ring
+import data.equiv.ring_aut
+import data.equiv.mul_add_aut
 
 /-!
 # Star monoids and star rings
@@ -86,6 +87,13 @@ def star_mul_equiv [monoid R] [star_monoid R] : R ≃* Rᵒᵖ :=
   map_mul' := λ x y, (star_mul x y).symm ▸ (opposite.op_mul _ _),
   ..(has_involutive_star.star_involutive.to_equiv star).trans opposite.equiv_to_opposite}
 
+/-- `star` as a `mul_aut` for commutative `R`. -/
+@[simps apply]
+def star_mul_aut [comm_monoid R] [star_monoid R] : mul_aut R :=
+{ to_fun := star,
+  map_mul' := λ x y, (star_mul x y).trans (mul_comm _ _),
+  ..(has_involutive_star.star_involutive.to_equiv star) }
+
 variables (R)
 
 @[simp] lemma star_one [monoid R] [star_monoid R] : star (1 : R) = 1 :=
@@ -151,6 +159,13 @@ def star_ring_equiv [semiring R] [star_ring R] : R ≃+* Rᵒᵖ :=
 { to_fun := λ x, opposite.op (star x),
   ..star_add_equiv.trans (opposite.op_add_equiv : R ≃+ Rᵒᵖ),
   ..star_mul_equiv}
+
+/-- `star` as an `ring_aut` for commutative `R` -/
+@[simps apply]
+def star_ring_aut [comm_semiring R] [star_ring R] : ring_aut R :=
+{ to_fun := star,
+  ..star_add_equiv,
+  ..star_mul_aut}
 
 section
 open_locale big_operators

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -165,7 +165,7 @@ def star_ring_equiv [semiring R] [star_ring R] : R ≃+* Rᵒᵖ :=
 def star_ring_aut [comm_semiring R] [star_ring R] : ring_aut R :=
 { to_fun := star,
   ..star_add_equiv,
-  ..star_mul_aut}
+  ..star_mul_aut }
 
 section
 open_locale big_operators


### PR DESCRIPTION
This adds `star_mul_aut` and `star_ring_aut`, which are the versions of `star_mul_equiv` and `star_ring_equiv` which avoid needing `opposite` due to commutativity.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
