### PR TITLE
[Merged by Bors] - refactor(linear_algebra/charpoly): split in two files

### DIFF
--- a/src/linear_algebra/charpoly/basic.lean
+++ b/src/linear_algebra/charpoly/basic.lean
@@ -12,7 +12,8 @@ import linear_algebra.matrix.charpoly.coeff
 # Characteristic polynomial
 
 We define the characteristic polynomial of `f : M →ₗ[R] M`, where `M` is a finite and
-free `R`-module.
+free `R`-module. The proof that `f.charpoly` is the characteristic polynomial of the matrix of `f`
+in any basis is in `linear_algebra/charpoly/to_matrix`.
 
 ## Main definition
 

--- a/src/linear_algebra/charpoly/basic.lean
+++ b/src/linear_algebra/charpoly/basic.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2021 Riccardo Brasca. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Riccardo Brasca
+-/
+
+import linear_algebra.free_module.finite
+import linear_algebra.matrix.charpoly.coeff
+
+/-!
+
+# Characteristic polynomial
+
+We define the characteristic polynomial of `f : M →ₗ[R] M`, where `M` is a finite and
+free `R`-module.
+
+## Main definition
+
+* `linear_map.charpoly f` : the characteristic polynomial of `f : M →ₗ[R] M`.
+
+-/
+
+universes u v w
+
+variables {R : Type u} {M : Type v} [comm_ring R] [nontrivial R]
+variables [add_comm_group M] [module R M] [module.free R M] [module.finite R M] (f : M →ₗ[R] M)
+
+open_locale classical matrix
+
+noncomputable theory
+
+open module.free polynomial matrix
+
+namespace linear_map
+
+section basic
+
+/-- The characteristic polynomial of `f : M →ₗ[R] M`. -/
+def charpoly : polynomial R :=
+(to_matrix (choose_basis R M) (choose_basis R M) f).charpoly
+
+lemma charpoly_def :
+  f.charpoly = (to_matrix (choose_basis R M) (choose_basis R M) f).charpoly := rfl
+
+end basic
+
+section coeff
+
+lemma charpoly_monic : f.charpoly.monic := charpoly_monic _
+
+end coeff
+
+section cayley_hamilton
+
+/-- The Cayley-Hamilton Theorem, that the characteristic polynomial of a linear map, applied to
+the linear map itself, is zero. -/
+lemma aeval_self_charpoly : aeval f f.charpoly = 0 :=
+begin
+  apply (linear_equiv.map_eq_zero_iff (alg_equiv_matrix _).to_linear_equiv).1,
+  rw [alg_equiv.to_linear_equiv_apply, ← alg_equiv.coe_alg_hom,
+    ← polynomial.aeval_alg_hom_apply _ _ _, charpoly_def],
+  exact aeval_self_charpoly _,
+end
+
+lemma is_integral : is_integral R f := ⟨f.charpoly, ⟨charpoly_monic f, aeval_self_charpoly f⟩⟩
+
+lemma minpoly_dvd_charpoly {K : Type u} {M : Type v} [field K] [add_comm_group M] [module K M]
+  [finite_dimensional K M] (f : M →ₗ[K] M) : minpoly K f ∣ f.charpoly :=
+minpoly.dvd _ _ (aeval_self_charpoly f)
+
+variable {f}
+
+lemma charpoly_coeff_zero_of_injective (hf : function.injective f) : (minpoly R f).coeff 0 ≠ 0 :=
+begin
+  intro h,
+  obtain ⟨P, hP⟩ := X_dvd_iff.2 h,
+  have hdegP : P.degree < (minpoly R f).degree,
+  { rw [hP, mul_comm],
+    refine degree_lt_degree_mul_X (λ h, _),
+    rw [h, mul_zero] at hP,
+    exact minpoly.ne_zero (is_integral f) hP },
+  have hPmonic : P.monic,
+  { suffices : (minpoly R f).monic,
+    { rwa [monic.def, hP, mul_comm, leading_coeff_mul_X, ← monic.def] at this },
+    exact minpoly.monic (is_integral f) },
+  have hzero : aeval f (minpoly R f) = 0 := minpoly.aeval _ _,
+  simp only [hP, mul_eq_comp, ext_iff, hf, aeval_X, map_eq_zero_iff, coe_comp, alg_hom.map_mul,
+    zero_apply] at hzero,
+  exact not_le.2 hdegP (minpoly.min _ _ hPmonic (ext hzero)),
+end
+
+end cayley_hamilton
+
+end linear_map

--- a/src/linear_algebra/charpoly/to_matrix.lean
+++ b/src/linear_algebra/charpoly/to_matrix.lean
@@ -4,22 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
 
-import linear_algebra.free_module.finite
-import linear_algebra.matrix.charpoly.coeff
+import linear_algebra.charpoly.basic
 import linear_algebra.matrix.basis
-
-/-!
-
-# Characteristic polynomial
-
-We define the characteristic polynomial of `f : M →ₗ[R] M`, where `M` is a finite and
-free `R`-module.
-
-## Main definition
-
-* `linear_map.charpoly f` : the characteristic polynomial of `f : M →ₗ[R] M`.
-
--/
 
 universes u v w
 
@@ -35,13 +21,6 @@ open module.free polynomial matrix
 namespace linear_map
 
 section basic
-
-/-- The characteristic polynomial of `f : M →ₗ[R] M`. -/
-def charpoly : polynomial R :=
-(to_matrix (choose_basis R M) (choose_basis R M) f).charpoly
-
-lemma charpoly_def :
-  f.charpoly = (to_matrix (choose_basis R M) (choose_basis R M) f).charpoly := rfl
 
 /-- `charpoly f` is the characteristic polynomial of the matrix of `f` in any basis. -/
 @[simp] lemma charpoly_to_matrix {ι : Type w} [fintype ι] (b : basis ι R M) :
@@ -87,52 +66,5 @@ begin
 end
 
 end basic
-
-section coeff
-
-lemma charpoly_monic : f.charpoly.monic := charpoly_monic _
-
-end coeff
-
-section cayley_hamilton
-
-/-- The Cayley-Hamilton Theorem, that the characteristic polynomial of a linear map, applied to
-the linear map itself, is zero. -/
-lemma aeval_self_charpoly : aeval f f.charpoly = 0 :=
-begin
-  apply (linear_equiv.map_eq_zero_iff (alg_equiv_matrix _).to_linear_equiv).1,
-  rw [alg_equiv.to_linear_equiv_apply, ← alg_equiv.coe_alg_hom,
-    ← polynomial.aeval_alg_hom_apply _ _ _, charpoly_def],
-  exact aeval_self_charpoly _,
-end
-
-lemma is_integral : is_integral R f := ⟨f.charpoly, ⟨charpoly_monic f, aeval_self_charpoly f⟩⟩
-
-lemma minpoly_dvd_charpoly {K : Type u} {M : Type v} [field K] [add_comm_group M] [module K M]
-  [finite_dimensional K M] (f : M →ₗ[K] M) : minpoly K f ∣ f.charpoly :=
-minpoly.dvd _ _ (aeval_self_charpoly f)
-
-variable {f}
-
-lemma charpoly_coeff_zero_of_injective (hf : function.injective f) : (minpoly R f).coeff 0 ≠ 0 :=
-begin
-  intro h,
-  obtain ⟨P, hP⟩ := X_dvd_iff.2 h,
-  have hdegP : P.degree < (minpoly R f).degree,
-  { rw [hP, mul_comm],
-    refine degree_lt_degree_mul_X (λ h, _),
-    rw [h, mul_zero] at hP,
-    exact minpoly.ne_zero (is_integral f) hP },
-  have hPmonic : P.monic,
-  { suffices : (minpoly R f).monic,
-    { rwa [monic.def, hP, mul_comm, leading_coeff_mul_X, ← monic.def] at this },
-    exact minpoly.monic (is_integral f) },
-  have hzero : aeval f (minpoly R f) = 0 := minpoly.aeval _ _,
-  simp only [hP, mul_eq_comp, ext_iff, hf, aeval_X, map_eq_zero_iff, coe_comp, alg_hom.map_mul,
-    zero_apply] at hzero,
-  exact not_le.2 hdegP (minpoly.min _ _ hPmonic (ext hzero)),
-end
-
-end cayley_hamilton
 
 end linear_map

--- a/src/linear_algebra/charpoly/to_matrix.lean
+++ b/src/linear_algebra/charpoly/to_matrix.lean
@@ -7,6 +7,17 @@ Authors: Riccardo Brasca
 import linear_algebra.charpoly.basic
 import linear_algebra.matrix.basis
 
+/-!
+
+# Characteristic polynomial
+
+## Main result
+
+* `linear_map.charpoly_to_matrix f` : `charpoly f` is the characteristic polynomial of the matrix
+of `f` in any basis.
+
+-/
+
 universes u v w
 
 variables {R : Type u} {M : Type v} [comm_ring R] [nontrivial R]

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -8,7 +8,7 @@ import field_theory.is_alg_closed.basic
 import linear_algebra.finsupp
 import linear_algebra.matrix.to_lin
 import order.preorder_hom
-import linear_algebra.charpoly
+import linear_algebra.charpoly.basic
 
 /-!
 # Eigenvectors and eigenvalues


### PR DESCRIPTION
We split `linear_algebra/charpoly` in `linear_algebra/charpoly/basic` and `linear_algebra/charpoly/to_matrix`.

Currently in `linear_algebra/charpoly/to_matrix` we only prove `linear_map.charpoly_to_matrix f` : `charpoly f` is the characteristic polynomial of the matrix of `f` in any basis. This needs to be in a separate file then the definition of `f.charpoly` since it needs the invariant basis number property for commutative rings and in a future PR I will prove this as a special case of the fact that any commutative ring satisfies the strong rank condition, but the proof of this uses the characteristic polynomial.

We plan to add ohter results regarding the characteristic polynomial in the future.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
