### PR TITLE
[Merged by Bors] - doc(ring_theory/subring): fix docstring of `subring.center`

### DIFF
--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -487,7 +487,7 @@ section
 
 variables (R)
 
-/-- The center of a semiring `R` is the set of elements that commute with everything in `R` -/
+/-- The center of a ring `R` is the set of elements that commute with everything in `R` -/
 def center : subring R :=
 { carrier := set.center R,
   neg_mem' := λ a, set.neg_mem_center,


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
