### PR TITLE
[Merged by Bors] - docs(measure_theory/integral/lebesgue): Add "Markov's inequality" to the doc string of `mul_meas_ge_le_lintegral`

### DIFF
--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -1504,7 +1504,7 @@ begin
   exact hf (measurable_set_singleton r)
 end
 
-/-- **Chebyshev's inequality** -/
+/-- **Markov's inequality** also known as **Chebyshev's first inequality**. -/
 lemma mul_meas_ge_le_lintegral {f : α → ℝ≥0∞} (hf : measurable f) (ε : ℝ≥0∞) :
   ε * μ {x | ε ≤ f x} ≤ ∫⁻ a, f a ∂μ :=
 begin


### PR DESCRIPTION

---

`mul_meas_ge_le_lintegral` is what I would call [Markov's inequality](https://en.wikipedia.org/wiki/Markov%27s_inequality) so I've added it to the doc string.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
