### PR TITLE
[Merged by Bors] - refactor(group_theory/is_p_group): Generalize `is_p_group.comap_injective`

### DIFF
--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -189,7 +189,7 @@ begin
   exact ⟨j + k, by rwa [subtype.ext_iff, (H.comap ϕ).coe_pow]⟩,
 end
 
-lemma comap_injective {H : subgroup G} (hH : is_p_group p H) {K : Type*} [group K]
+lemma comap_of_injective {H : subgroup G} (hH : is_p_group p H) {K : Type*} [group K]
   (ϕ : K →* G) (hϕ : function.injective ϕ) : is_p_group p (H.comap ϕ) :=
 begin
   apply hH.comap_ker_is_p_group ϕ,

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -192,7 +192,7 @@ end
 lemma comap_of_injective {H : subgroup G} (hH : is_p_group p H) {K : Type*} [group K]
   (ϕ : K →* G) (hϕ : function.injective ϕ) : is_p_group p (H.comap ϕ) :=
 begin
-  apply hH.comap_ker_is_p_group ϕ,
+  apply hH.comap_of_ker_is_p_group ϕ,
   rw ϕ.ker_eq_bot_iff.mpr hϕ,
   exact is_p_group.of_bot,
 end
@@ -201,7 +201,7 @@ lemma to_sup_of_normal_right {H K : subgroup G} (hH : is_p_group p H) (hK : is_p
   [K.normal] : is_p_group p (H ⊔ K : subgroup G) :=
 begin
   rw [←quotient_group.ker_mk K, ←subgroup.comap_map_eq],
-  apply (hH.map (quotient_group.mk' K)).comap_ker_is_p_group,
+  apply (hH.map (quotient_group.mk' K)).comap_of_ker_is_p_group,
   rwa quotient_group.ker_mk,
 end
 

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -178,7 +178,7 @@ begin
   exact hH.of_surjective (ϕ.restrict H).range_restrict (ϕ.restrict H).range_restrict_surjective,
 end
 
-lemma comap_ker_is_p_group {H : subgroup G} (hH : is_p_group p H) {K : Type*} [group K]
+lemma comap_of_ker_is_p_group {H : subgroup G} (hH : is_p_group p H) {K : Type*} [group K]
   (ϕ : K →* G) (hϕ : is_p_group p ϕ.ker) : is_p_group p (H.comap ϕ) :=
 begin
   intro g,


### PR DESCRIPTION
`is_p_group.comap_injective` (comap along injective preserves p-groups) can be generalized to `is_p_group.comap_ker_is_p_group` (comap with p-group kernel preserves p-groups). This also simplifies the proof of `is_p_group.to_sup_of_normal_right`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
