### PR TITLE
[Merged by Bors] - feat(set_theory/cardinal,*): assorted lemmas

### DIFF
--- a/src/data/equiv/denumerable.lean
+++ b/src/data/equiv/denumerable.lean
@@ -62,6 +62,9 @@ of_nat_of_decode (encodek _)
 def eqv (α) [denumerable α] : α ≃ ℕ :=
 ⟨encode, of_nat α, of_nat_encode, encode_of_nat⟩
 
+@[priority 100] -- See Note [lower instance priority]
+instance : infinite α := infinite.of_surjective _ (eqv α).surjective
+
 /-- A type equivalent to `ℕ` is denumerable. -/
 def mk' {α} (e : α ≃ ℕ) : denumerable α :=
 { encode := e,

--- a/src/data/equiv/encodable/basic.lean
+++ b/src/data/equiv/encodable/basic.lean
@@ -210,6 +210,9 @@ begin
   simp [decode_sum]; cases bodd n; simp [decode_sum]; rw e; refl
 end
 
+noncomputable instance «Prop» : encodable Prop :=
+of_equiv bool equiv.Prop_equiv_bool
+
 section sigma
 variables {γ : α → Type*} [encodable α] [∀ a, encodable (γ a)]
 

--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -232,6 +232,14 @@ begin
   rw quotient.out_eq x,
 end
 
+@[simp] lemma quotient.out_equiv_out [s : setoid α] {x y : quotient s} :
+  x.out ≈ y.out ↔ x = y :=
+by rw [← quotient.eq_mk_iff_out, quotient.out_eq]
+
+@[simp] lemma quotient.out_inj [s : setoid α] {x y : quotient s} :
+  x.out = y.out ↔ x = y :=
+⟨λ h, quotient.out_equiv_out.1 $ h ▸ setoid.refl _, λ h, h ▸ rfl⟩
+
 instance pi_setoid {ι : Sort*} {α : ι → Sort*} [∀ i, setoid (α i)] : setoid (Π i, α i) :=
 { r := λ a b, ∀ i, a i ≈ b i,
   iseqv := ⟨

--- a/src/data/rat/denumerable.lean
+++ b/src/data/rat/denumerable.lean
@@ -39,7 +39,7 @@ end rat
 namespace cardinal
 
 open_locale cardinal
-lemma mk_rat : #ℚ = ω :=
-denumerable_iff.mp ⟨by apply_instance⟩
+
+lemma mk_rat : #ℚ = ω := mk_denumerable ℚ
 
 end cardinal

--- a/src/logic/nontrivial.lean
+++ b/src/logic/nontrivial.lean
@@ -62,6 +62,8 @@ lemma subtype.nontrivial_iff_exists_ne (p : α → Prop) (x : subtype p) :
   nontrivial (subtype p) ↔ ∃ (y : α) (hy : p y), y ≠ x :=
 by simp only [nontrivial_iff_exists_ne x, subtype.exists, ne.def, subtype.ext_iff, subtype.coe_mk]
 
+instance : nontrivial Prop := ⟨⟨true, false, true_ne_false⟩⟩
+
 /--
 See Note [lower instance priority]
 

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -699,7 +699,7 @@ def omega : cardinal.{u} := lift (#ℕ)
 
 localized "notation `ω` := cardinal.omega" in cardinal
 
-@[simp] lemma mk_nat : #ℕ = ω := (lift_id _).symm
+lemma mk_nat : #ℕ = ω := (lift_id _).symm
 
 theorem omega_ne_zero : ω ≠ 0 :=
 ne_zero_iff_nonempty.2 ⟨⟨0⟩⟩

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -91,6 +91,9 @@ def mk : Type u → cardinal := quotient.mk
 
 localized "notation `#` := cardinal.mk" in cardinal
 
+instance can_lift_cardinal_Type : can_lift cardinal.{u} (Type u) :=
+⟨mk, λ c, true, λ c _, quot.induction_on c $ λ α, ⟨α, rfl⟩⟩
+
 protected lemma eq : #α = #β ↔ nonempty (α ≃ β) := quotient.eq
 
 @[simp] theorem mk_def (α : Type u) : @eq cardinal ⟦α⟧ (#α) := rfl
@@ -563,8 +566,23 @@ quotient.sound ⟨equiv.ulift.trans (equiv.prod_congr equiv.ulift equiv.ulift).s
 quotient.induction_on₂ a b $ λ α β,
 quotient.sound ⟨equiv.ulift.trans (equiv.arrow_congr equiv.ulift equiv.ulift).symm⟩
 
-@[simp] theorem lift_two_power (a) : lift (2 ^ a) = 2 ^ lift a :=
-by simp [bit0]
+@[simp] theorem lift_bit0 (a : cardinal) : lift (bit0 a) = bit0 (lift a) :=
+lift_add a a
+
+@[simp] theorem lift_bit1 (a : cardinal) : lift (bit1 a) = bit1 (lift a) :=
+by simp [bit1]
+
+theorem lift_two : lift.{u v} 2 = 2 := by simp
+
+theorem lift_two_power (a) : lift (2 ^ a) = 2 ^ lift a := by simp
+
+@[simp] theorem lift_prod {ι : Type u} (c : ι → cardinal.{v}) :
+  lift.{w} (prod c) = prod (λ i, lift.{w} (c i)) :=
+begin
+  lift c to ι → Type v using λ _, trivial,
+  simp only [prod_mk, lift_mk],
+  exact cardinal.mk_congr (equiv.ulift.trans $ equiv.Pi_congr_right $ λ i, equiv.ulift.symm)
+end
 
 @[simp] theorem lift_min {ι I} (f : ι → cardinal) : lift (min I f) = min I (lift ∘ f) :=
 le_antisymm (le_min.2 $ λ a, lift_le.2 $ min_le _ a) $
@@ -690,6 +708,12 @@ theorem omega_pos : 0 < ω :=
 pos_iff_ne_zero.2 omega_ne_zero
 
 @[simp] theorem lift_omega : lift ω = ω := lift_lift _
+
+@[simp] theorem omega_le_lift {c : cardinal.{u}} : ω ≤ lift.{v} c ↔ ω ≤ c :=
+by rw [← lift_omega, lift_le]
+
+@[simp] theorem lift_le_omega {c : cardinal.{u}} : lift.{v} c ≤ ω ↔ c ≤ ω :=
+by rw [← lift_omega, lift_le]
 
 /- properties about the cast from nat -/
 
@@ -832,6 +856,9 @@ lemma add_lt_omega_iff {a b : cardinal} : a + b < ω ↔ a < ω ∧ b < ω :=
 ⟨λ h, ⟨lt_of_le_of_lt (self_le_add_right _ _) h, lt_of_le_of_lt (self_le_add_left _ _) h⟩,
   λ⟨h1, h2⟩, add_lt_omega h1 h2⟩
 
+lemma omega_le_add_iff {a b : cardinal} : ω ≤ a + b ↔ ω ≤ a ∨ ω ≤ b :=
+by simp only [← not_lt, add_lt_omega_iff, not_and_distrib]
+
 theorem mul_lt_omega {a b : cardinal} (ha : a < ω) (hb : b < ω) : a * b < ω :=
 match a, b, lt_omega.1 ha, lt_omega.1 hb with
 | _, _, ⟨m, rfl⟩, ⟨n, rfl⟩ := by rw [← nat.cast_mul]; apply nat_lt_omega
@@ -872,9 +899,20 @@ end
 theorem infinite_iff {α : Type u} : infinite α ↔ ω ≤ #α :=
 by rw [←not_lt, lt_omega_iff_fintype, not_nonempty_iff, is_empty_fintype]
 
+lemma omega_le_mk (α : Type u) [infinite α] : ω ≤ #α := infinite_iff.1 ‹_›
+
+lemma encodable_iff {α : Type u} : nonempty (encodable α) ↔ #α ≤ ω :=
+⟨λ ⟨h⟩, ⟨(@encodable.encode' α h).trans equiv.ulift.symm.to_embedding⟩,
+  λ ⟨h⟩, ⟨encodable.of_inj _ (h.trans equiv.ulift.to_embedding).injective⟩⟩
+
+@[simp] lemma mk_le_omega [encodable α] : #α ≤ ω := encodable_iff.1 ⟨‹_›⟩
+
 lemma denumerable_iff {α : Type u} : nonempty (denumerable α) ↔ #α = ω :=
 ⟨λ⟨h⟩, quotient.sound $ by exactI ⟨ (denumerable.eqv α).trans equiv.ulift.symm ⟩,
  λ h, by { cases quotient.exact h with f, exact ⟨denumerable.mk' $ f.trans equiv.ulift⟩ }⟩
+
+@[simp] lemma mk_denumerable (α : Type u) [denumerable α] : #α = ω :=
+denumerable_iff.1 ⟨‹_›⟩
 
 lemma countable_iff (s : set α) : countable s ↔ #s ≤ ω :=
 begin
@@ -1005,11 +1043,9 @@ end
 lemma mk_to_enat_eq_coe_card [fintype α] : (#α).to_enat = fintype.card α :=
 by simp [fintype_card]
 
-lemma mk_int : #ℤ = ω :=
-denumerable_iff.mp ⟨by apply_instance⟩
+lemma mk_int : #ℤ = ω := mk_denumerable ℤ
 
-lemma mk_pnat : #ℕ+ = ω :=
-denumerable_iff.mp ⟨by apply_instance⟩
+lemma mk_pnat : #ℕ+ = ω := mk_denumerable ℕ+
 
 lemma two_le_iff : (2 : cardinal) ≤ #α ↔ ∃x y : α, x ≠ y :=
 begin
@@ -1120,7 +1156,7 @@ begin
   { intro, convert mk_emptyc _ }
 end
 
-theorem mk_univ {α : Type u} : #(@univ α) = #α :=
+@[simp] theorem mk_univ {α : Type u} : #(@univ α) = #α :=
 quotient.sound ⟨equiv.set.univ α⟩
 
 theorem mk_image_le {α β : Type u} {f : α → β} {s : set α} : #(f '' s) ≤ #s :=
@@ -1207,6 +1243,10 @@ lemma mk_union_le {α : Type u} (S T : set α) : #(S ∪ T : set α) ≤ #S + #T
 theorem mk_union_of_disjoint {α : Type u} {S T : set α} (H : disjoint S T) :
   #(S ∪ T : set α) = #S + #T :=
 quot.sound ⟨equiv.set.union H⟩
+
+theorem mk_insert {α : Type u} {s : set α} {a : α} (h : a ∉ s) :
+  #(insert a s : set α) = #s + 1 :=
+by { rw [← union_singleton, mk_union_of_disjoint, mk_singleton], simpa }
 
 lemma mk_sum_compl {α} (s : set α) : #s + #(sᶜ : set α) = #α :=
 quotient.sound ⟨equiv.set.sum_compl s⟩

--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -459,7 +459,7 @@ by { rw [add_comm a b, add_comm c b] at h, exact cardinal.eq_of_add_eq_add_left 
 
 /-! ### Properties about power -/
 
-theorem pow_le {κ μ : cardinal.{u}} (H1 : omega ≤ κ) (H2 : μ < omega) : κ ^ μ ≤ κ :=
+theorem pow_le {κ μ : cardinal.{u}} (H1 : ω ≤ κ) (H2 : μ < ω) : κ ^ μ ≤ κ :=
 let ⟨n, H3⟩ := lt_omega.1 H2 in
 H3.symm ▸ (quotient.induction_on κ (λ α H1, nat.rec_on n
   (le_of_lt $ lt_of_lt_of_le (by rw [nat.cast_zero, power_zero];
@@ -469,19 +469,36 @@ H3.symm ▸ (quotient.induction_on κ (λ α H1, nat.rec_on n
       exact mul_le_mul_right' ih _ })
     (mul_eq_self H1))) H1)
 
-lemma power_self_eq {c : cardinal} (h : omega ≤ c) : c ^ c = 2 ^ c :=
+lemma power_self_eq {c : cardinal} (h : ω ≤ c) : c ^ c = 2 ^ c :=
 begin
   apply le_antisymm,
   { apply le_trans (power_le_power_right $ le_of_lt $ cantor c), rw [← power_mul, mul_eq_self h] },
   { convert power_le_power_right (le_trans (le_of_lt $ nat_lt_omega 2) h), apply nat.cast_two.symm }
 end
 
-lemma nat_power_eq {c : cardinal.{u}} (h : omega ≤ c) {n : ℕ} (hn : 2 ≤ n) :
-  (n : cardinal.{u}) ^ c = 2 ^ c :=
-le_antisymm (power_self_eq h ▸ power_le_power_right ((nat_lt_omega n).le.trans h))
-  (power_le_power_right $ by assumption_mod_cast)
+lemma prod_eq_two_power {ι : Type u} [infinite ι] {c : ι → cardinal.{v}} (h₁ : ∀ i, 2 ≤ c i)
+  (h₂ : ∀ i, lift.{u} (c i) ≤ lift.{v} (#ι)) :
+  prod c = 2 ^ lift.{v} (#ι) :=
+begin
+  rw [← lift_id' (prod c), lift_prod, ← lift_two_power],
+  apply le_antisymm,
+  { refine (prod_le_prod _ _ h₂).trans_eq _,
+    rw [← lift_prod, prod_const, power_self_eq (omega_le_mk ι)] },
+  { rw [← prod_const, lift_prod],
+    refine prod_le_prod _ _ (λ i, _),
+    rw [lift_two, ← lift_two.{u v}, lift_le],
+    exact h₁ i }
+end
 
-lemma power_nat_le {c : cardinal.{u}} {n : ℕ} (h  : omega ≤ c) : c ^ (n : cardinal.{u}) ≤ c :=
+lemma power_eq_two_power {c₁ c₂ : cardinal} (h₁ : ω ≤ c₁) (h₂ : 2 ≤ c₂) (h₂' : c₂ ≤ c₁) :
+  c₂ ^ c₁ = 2 ^ c₁ :=
+le_antisymm (power_self_eq h₁ ▸ power_le_power_right h₂') (power_le_power_right h₂)
+
+lemma nat_power_eq {c : cardinal.{u}} (h : ω ≤ c) {n : ℕ} (hn : 2 ≤ n) :
+  (n : cardinal.{u}) ^ c = 2 ^ c :=
+power_eq_two_power h (by assumption_mod_cast) ((nat_lt_omega n).le.trans h)
+
+lemma power_nat_le {c : cardinal.{u}} {n : ℕ} (h  : ω ≤ c) : c ^ (n : cardinal.{u}) ≤ c :=
 pow_le h (nat_lt_omega n)
 
 lemma power_nat_le_max {c : cardinal.{u}} {n : ℕ} : c ^ (n : cardinal.{u}) ≤ max c ω :=


### PR DESCRIPTION
### New instances

* a denumerable type is infinite;
* `Prop` is (noncomputably) enumerable;
* `Prop` is nontrivial;
* `cardinal.can_lift_cardinal_Type`: lift `cardinal.{u}` to `Type u`.

### New lemmas / attrs

* `quotient.out_equiv_out` : `x.out ≈ y.out ↔ x = y`;
* `quotient.out_inj` : `x.out = y.out ↔ x = y`;
* `cardinal.lift_bit0`, `cardinal.lift_bit1`, `cardinal.lift_two`, `cardinal.lift_prod` :
  new lemmas about `cardinal.lift`;
* `cardinal.omega_le_lift` and `cardinal.lift_le_omega` : simplify `ω ≤ lift c` and `lift c ≤ ω`;
* `cardinal.omega_le_add_iff`, `cardinal.encodable_iff`, `cardinal.mk_le_omega`,
  `cardinal.mk_denumerable`: new lemmas about `cardinal.omega`;
* add `@[simp]` attribute to `cardinal.mk_univ`, add `cardinal.mk_insert`;
* generalize `cardinal.nat_power_eq` to `cardinal.power_eq_two_power` and `cardinal.prod_eq_two_power`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)