### PR TITLE
[Merged by Bors] - feat(category_theory/limits/*): Filtered colimits preserves finite limits

### DIFF
--- a/src/category_theory/limits/colimit_limit.lean
+++ b/src/category_theory/limits/colimit_limit.lean
@@ -93,35 +93,8 @@ by { dsimp [colimit_limit_to_limit_colimit], simp, }
      colimit.ι ((curry.obj F).obj j) k (limit.π ((curry.obj (swap K J ⋙ F)).obj k) j f) :=
 by { dsimp [colimit_limit_to_limit_colimit], simp, }
 
-noncomputable theory
-variables (G : J ⥤ K ⥤ C) [has_limit G]
-
-/--
-For a functor `G : J ⥤ K ⥤ C`, its limit `K ⥤ C` is given by `(G' : K ⥤ J ⥤ C) ⋙ lim`.
-Note that this does not require `K` to be small.
--/
-@[simps] def limit_iso_swap_comp_lim {K : Type v} [category.{v₂} K] (G : J ⥤ K ⥤ C) [has_limit G] :
-  limit G ≅ curry.obj (swap K J ⋙ uncurry.obj G) ⋙ lim :=
-nat_iso.of_components (λ Y, limit_obj_iso_limit_comp_evaluation G Y ≪≫
-  (lim.map_iso (eq_to_iso (by
-  { apply functor.hext,
-    { intro X, simp },
-    { intros X₁ X₂ f, dsimp only [swap], simp }}))))
-  (λ Y₁ Y₂ f,
-    begin
-      ext1 x,
-      dsimp only [swap],
-      simp only [limit_obj_iso_limit_comp_evaluation_hom_π_assoc, category.comp_id,
-        limit_obj_iso_limit_comp_evaluation_hom_π, eq_to_iso.hom, curry.obj_map_app,
-        nat_trans.naturality, category.id_comp, eq_to_hom_refl, functor.comp_map,
-        eq_to_hom_app, lim_map_π_assoc, lim_map_π, category.assoc,
-        uncurry.obj_map, lim_map_eq_lim_map, iso.trans_hom,
-        nat_trans.id_app, category_theory.functor.map_id, functor.map_iso_hom],
-      erw category.id_comp,
-    end)
-
 /-- The map `colimit_limit_to_limit_colimit` realized as a map of cones. -/
-@[simps] def colimit_limit_to_limit_colimit_cone :
+@[simps] noncomputable def colimit_limit_to_limit_colimit_cone (G : J ⥤ K ⥤ C) [has_limit G] :
   colim.map_cone (limit.cone G) ⟶ limit.cone (G ⋙ colim) :=
 { hom := colim.map (limit_iso_swap_comp_lim G).hom ≫
     colimit_limit_to_limit_colimit (uncurry.obj G : _) ≫

--- a/src/category_theory/limits/colimit_limit.lean
+++ b/src/category_theory/limits/colimit_limit.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import category_theory.limits.types
 import category_theory.currying
+import category_theory.limits.functor_category
 
 /-!
 # The morphism comparing a colimit of limits with the corresponding limit of colimits.
@@ -81,7 +82,7 @@ limit.lift ((curry.obj F) ⋙ colim)
 Since `colimit_limit_to_limit_colimit` is a morphism from a colimit to a limit,
 this lemma characterises it.
 -/
-@[simp] lemma ι_colimit_limit_to_limit_colimit_π (j) (k) :
+@[simp, reassoc] lemma ι_colimit_limit_to_limit_colimit_π (j) (k) :
   colimit.ι _ k ≫ colimit_limit_to_limit_colimit F ≫ limit.π _ j =
     limit.π ((curry.obj (swap K J ⋙ F)).obj k) j ≫ colimit.ι ((curry.obj F).obj j) k :=
 by { dsimp [colimit_limit_to_limit_colimit], simp, }
@@ -91,5 +92,49 @@ by { dsimp [colimit_limit_to_limit_colimit], simp, }
      (colimit_limit_to_limit_colimit F (colimit.ι ((curry.obj (swap K J ⋙ F)) ⋙ lim) k f)) =
      colimit.ι ((curry.obj F).obj j) k (limit.π ((curry.obj (swap K J ⋙ F)).obj k) j f) :=
 by { dsimp [colimit_limit_to_limit_colimit], simp, }
+
+noncomputable theory
+variables (G : J ⥤ K ⥤ C) [has_limit G]
+
+/--
+For a functor `G : J ⥤ K ⥤ C`, its limit `K ⥤ C` is given by `(G' : K ⥤ J ⥤ C) ⋙ lim`.
+Note that this does not require `K` to be small.
+-/
+@[simps] def limit_iso_swap_comp_lim : limit G ≅ curry.obj (swap K J ⋙ uncurry.obj G) ⋙ lim :=
+nat_iso.of_components (λ Y, limit_obj_iso_limit_comp_evaluation G Y ≪≫
+  (lim.map_iso (eq_to_iso (by
+  { apply functor.hext,
+    { intro X, simp },
+    { intros X₁ X₂ f, dsimp only [swap], simp }}))))
+  (λ Y₁ Y₂ f,
+    begin
+      ext1 x,
+      dsimp only [swap],
+      simp only [limit_obj_iso_limit_comp_evaluation_hom_π_assoc, category.comp_id,
+        limit_obj_iso_limit_comp_evaluation_hom_π, eq_to_iso.hom, curry.obj_map_app,
+        nat_trans.naturality, category.id_comp, eq_to_hom_refl, functor.comp_map,
+        eq_to_hom_app, lim_map_π_assoc, lim_map_π, category.assoc,
+        uncurry.obj_map, lim_map_eq_lim_map, iso.trans_hom,
+        nat_trans.id_app, category_theory.functor.map_id, functor.map_iso_hom],
+      erw category.id_comp,
+    end)
+
+/-- The map `colimit_limit_to_limit_colimit` realized as a map of cones. -/
+@[simps] def colimit_limit_to_limit_colimit_cone :
+  colim.map_cone (limit.cone G) ⟶ limit.cone (G ⋙ colim) :=
+{ hom := colim.map (limit_iso_swap_comp_lim G).hom ≫
+    colimit_limit_to_limit_colimit (uncurry.obj G : _) ≫
+    lim.map (whisker_right (currying.unit_iso.app G).inv colim),
+  w' := λ j,
+  begin
+    ext1 k,
+    simp only [limit_obj_iso_limit_comp_evaluation_hom_π_assoc, iso.app_inv,
+      ι_colimit_limit_to_limit_colimit_π_assoc, whisker_right_app,
+      colimit.ι_map, functor.map_cone_π_app, category.id_comp,
+      eq_to_hom_refl, eq_to_hom_app, colimit.ι_map_assoc, limit.cone_π,
+      lim_map_π_assoc, lim_map_π, category.assoc, currying_unit_iso_inv_app_app_app,
+      limit_iso_swap_comp_lim_hom_app, lim_map_eq_lim_map],
+    erw category.id_comp,
+  end }
 
 end category_theory.limits

--- a/src/category_theory/limits/colimit_limit.lean
+++ b/src/category_theory/limits/colimit_limit.lean
@@ -22,7 +22,7 @@ is that when `C = Type`, filtered colimits commute with finite limits.
 * [Stacks: Filtered colimits](https://stacks.math.columbia.edu/tag/002W)
 -/
 
-universes v u
+universes v₂ v u
 
 open category_theory
 
@@ -100,7 +100,8 @@ variables (G : J ⥤ K ⥤ C) [has_limit G]
 For a functor `G : J ⥤ K ⥤ C`, its limit `K ⥤ C` is given by `(G' : K ⥤ J ⥤ C) ⋙ lim`.
 Note that this does not require `K` to be small.
 -/
-@[simps] def limit_iso_swap_comp_lim : limit G ≅ curry.obj (swap K J ⋙ uncurry.obj G) ⋙ lim :=
+@[simps] def limit_iso_swap_comp_lim {K : Type v} [category.{v₂} K] (G : J ⥤ K ⥤ C) [has_limit G] :
+  limit G ≅ curry.obj (swap K J ⋙ uncurry.obj G) ⋙ lim :=
 nat_iso.of_components (λ Y, limit_obj_iso_limit_comp_evaluation G Y ≪≫
   (lim.map_iso (eq_to_iso (by
   { apply functor.hext,

--- a/src/category_theory/limits/filtered_colimit_commutes_finite_limit.lean
+++ b/src/category_theory/limits/filtered_colimit_commutes_finite_limit.lean
@@ -300,4 +300,23 @@ instance colimit_limit_to_limit_colimit_is_iso :
 (is_iso_iff_bijective _).mpr
   ⟨colimit_limit_to_limit_colimit_injective F, colimit_limit_to_limit_colimit_surjective F⟩
 
+instance colimit_limit_to_limit_colimit_cone_iso (F : J ⥤ K ⥤ Type v) :
+  is_iso (colimit_limit_to_limit_colimit_cone F) :=
+begin
+  haveI : is_iso (colimit_limit_to_limit_colimit_cone F).hom,
+  { dsimp only [colimit_limit_to_limit_colimit_cone], apply_instance },
+  apply cones.cone_iso_of_hom_iso,
+end
+
+noncomputable
+instance filtered_colim_preserves_finite_limit :
+  preserves_limits_of_shape J (colim : (K ⥤ Type v) ⥤ _) := ⟨λ F, ⟨λ c hc,
+begin
+  apply is_limit.of_iso_limit (limit.is_limit _),
+  symmetry,
+  transitivity (colim.map_cone (limit.cone F)),
+  exact functor.map_iso _ (hc.unique_up_to_iso (limit.is_limit F)),
+  exact as_iso (colimit_limit_to_limit_colimit_cone F),
+end ⟩⟩
+
 end category_theory.limits

--- a/src/category_theory/limits/functor_category.lean
+++ b/src/category_theory/limits/functor_category.lean
@@ -257,18 +257,18 @@ nat_iso.of_components (λ Y, limit_obj_iso_limit_comp_evaluation G Y ≪≫
   { apply functor.hext,
     { intro X, simp },
     { intros X₁ X₂ f, dsimp only [swap], simp }}))))
-  (λ Y₁ Y₂ f,
-    begin
-      ext1 x,
-      dsimp only [swap],
-      simp only [limit_obj_iso_limit_comp_evaluation_hom_π_assoc, category.comp_id,
-        limit_obj_iso_limit_comp_evaluation_hom_π, eq_to_iso.hom, curry.obj_map_app,
-        nat_trans.naturality, category.id_comp, eq_to_hom_refl, functor.comp_map,
-        eq_to_hom_app, lim_map_π_assoc, lim_map_π, category.assoc,
-        uncurry.obj_map, lim_map_eq_lim_map, iso.trans_hom,
-        nat_trans.id_app, category_theory.functor.map_id, functor.map_iso_hom],
-      erw category.id_comp,
-    end)
+  begin
+    intros Y₁ Y₂ f,
+    ext1 x,
+    dsimp only [swap],
+    simp only [limit_obj_iso_limit_comp_evaluation_hom_π_assoc, category.comp_id,
+      limit_obj_iso_limit_comp_evaluation_hom_π, eq_to_iso.hom, curry.obj_map_app,
+      nat_trans.naturality, category.id_comp, eq_to_hom_refl, functor.comp_map,
+      eq_to_hom_app, lim_map_π_assoc, lim_map_π, category.assoc,
+      uncurry.obj_map, lim_map_eq_lim_map, iso.trans_hom,
+      nat_trans.id_app, category_theory.functor.map_id, functor.map_iso_hom],
+    erw category.id_comp,
+  end
 
 /--
 For a functor `G : J ⥤ K ⥤ C`, its colimit `K ⥤ C` is given by `(G' : K ⥤ J ⥤ C) ⋙ colim`.
@@ -277,22 +277,21 @@ Note that this does not require `K` to be small.
 @[simps]
 def colimit_iso_swap_comp_colim [has_colimits_of_shape J C] (G : J ⥤ K ⥤ C) [has_colimit G] :
   colimit G ≅ curry.obj (swap K J ⋙ uncurry.obj G) ⋙ colim :=
-begin
-  fapply nat_iso.of_components,
-  intro Y,
-  refine colimit_obj_iso_colimit_comp_evaluation G Y ≪≫ (colim.map_iso (eq_to_iso _)),
-  apply functor.hext,
-  { intro X, simp },
-  { intros X Y f, dsimp only [swap], simp, },
-  intros Y₁ Y₂ f,
-  ext1 x,
-  rw ← (colimit.ι G x).naturality_assoc f,
-  dsimp only [swap],
-  simp only [eq_to_iso.hom, colimit_obj_iso_colimit_comp_evaluation_ι_app_hom_assoc,
-    curry.obj_map_app, colimit.ι_map, category.id_comp, eq_to_hom_refl, iso.trans_hom,
-    functor.comp_map, eq_to_hom_app, colimit.ι_map_assoc, functor.map_iso_hom,
-    category.assoc, uncurry.obj_map, nat_trans.id_app, category_theory.functor.map_id],
-  erw category.id_comp,
-end
+nat_iso.of_components (λ Y, colimit_obj_iso_colimit_comp_evaluation G Y ≪≫
+  (colim.map_iso (eq_to_iso (by
+  { apply functor.hext,
+    { intro X, simp },
+    { intros X Y f, dsimp only [swap], simp, } }))))
+  begin
+    intros Y₁ Y₂ f,
+    ext1 x,
+    rw ← (colimit.ι G x).naturality_assoc f,
+    dsimp only [swap],
+    simp only [eq_to_iso.hom, colimit_obj_iso_colimit_comp_evaluation_ι_app_hom_assoc,
+      curry.obj_map_app, colimit.ι_map, category.id_comp, eq_to_hom_refl, iso.trans_hom,
+      functor.comp_map, eq_to_hom_app, colimit.ι_map_assoc, functor.map_iso_hom,
+      category.assoc, uncurry.obj_map, nat_trans.id_app, category_theory.functor.map_id],
+    erw category.id_comp,
+  end
 
 end category_theory.limits

--- a/src/category_theory/limits/functor_category.lean
+++ b/src/category_theory/limits/functor_category.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.limits.preserves.limits
+import category_theory.currying
+import category_theory.products
 
 open category_theory category_theory.category
 
@@ -241,5 +243,56 @@ instance evaluation_preserves_limits [has_limits C] (k : K) :
 instance evaluation_preserves_colimits [has_colimits C] (k : K) :
   preserves_colimits ((evaluation K C).obj k) :=
 { preserves_colimits_of_shape := λ J 𝒥, by resetI; apply_instance }
+
+open category_theory.prod
+
+/--
+For a functor `G : J ⥤ K ⥤ C`, its limit `K ⥤ C` is given by `(G' : K ⥤ J ⥤ C) ⋙ lim`.
+Note that this does not require `K` to be small.
+-/
+@[simps] def limit_iso_swap_comp_lim [has_limits_of_shape J C] (G : J ⥤ K ⥤ C) [has_limit G] :
+  limit G ≅ curry.obj (swap K J ⋙ uncurry.obj G) ⋙ lim :=
+nat_iso.of_components (λ Y, limit_obj_iso_limit_comp_evaluation G Y ≪≫
+  (lim.map_iso (eq_to_iso (by
+  { apply functor.hext,
+    { intro X, simp },
+    { intros X₁ X₂ f, dsimp only [swap], simp }}))))
+  (λ Y₁ Y₂ f,
+    begin
+      ext1 x,
+      dsimp only [swap],
+      simp only [limit_obj_iso_limit_comp_evaluation_hom_π_assoc, category.comp_id,
+        limit_obj_iso_limit_comp_evaluation_hom_π, eq_to_iso.hom, curry.obj_map_app,
+        nat_trans.naturality, category.id_comp, eq_to_hom_refl, functor.comp_map,
+        eq_to_hom_app, lim_map_π_assoc, lim_map_π, category.assoc,
+        uncurry.obj_map, lim_map_eq_lim_map, iso.trans_hom,
+        nat_trans.id_app, category_theory.functor.map_id, functor.map_iso_hom],
+      erw category.id_comp,
+    end)
+
+/--
+For a functor `G : J ⥤ K ⥤ C`, its colimit `K ⥤ C` is given by `(G' : K ⥤ J ⥤ C) ⋙ colim`.
+Note that this does not require `K` to be small.
+-/
+@[simps]
+def colimit_iso_swap_comp_colim [has_colimits_of_shape J C] (G : J ⥤ K ⥤ C) [has_colimit G] :
+  colimit G ≅ curry.obj (swap K J ⋙ uncurry.obj G) ⋙ colim :=
+begin
+  fapply nat_iso.of_components,
+  intro Y,
+  refine colimit_obj_iso_colimit_comp_evaluation G Y ≪≫ (colim.map_iso (eq_to_iso _)),
+  apply functor.hext,
+  { intro X, simp },
+  { intros X Y f, dsimp only [swap], simp, },
+  intros Y₁ Y₂ f,
+  ext1 x,
+  rw ← (colimit.ι G x).naturality_assoc f,
+  dsimp only [swap],
+  simp only [eq_to_iso.hom, colimit_obj_iso_colimit_comp_evaluation_ι_app_hom_assoc,
+    curry.obj_map_app, colimit.ι_map, category.id_comp, eq_to_hom_refl, iso.trans_hom,
+    functor.comp_map, eq_to_hom_app, colimit.ι_map_assoc, functor.map_iso_hom,
+    category.assoc, uncurry.obj_map, nat_trans.id_app, category_theory.functor.map_id],
+  erw category.id_comp,
+end
 
 end category_theory.limits


### PR DESCRIPTION
Restated `category_theory.limits.colimit_limit_to_limit_colimit_is_iso` in terms of limit preserving.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
