### PR TITLE
[Merged by Bors] - feat(ring_theory): `adjoin_root g ≃ S` if `S` has a power basis with the right minpoly

### DIFF
--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -454,10 +454,9 @@ end
 /-- algebra isomorphism between `adjoin_root` and `F⟮α⟯` -/
 noncomputable def adjoin_root_equiv_adjoin (h : is_integral F α) :
   adjoin_root (minpoly F α) ≃ₐ[F] F⟮α⟯ :=
-alg_equiv.of_bijective (alg_hom.mk (adjoin_root.lift (algebra_map F F⟮α⟯)
-  (adjoin_simple.gen F α) (aeval_gen_minpoly F α)) (ring_hom.map_one _)
-  (λ x y, ring_hom.map_mul _ x y) (ring_hom.map_zero _) (λ x y, ring_hom.map_add _ x y)
-  (by { exact λ _, adjoin_root.lift_of })) (begin
+alg_equiv.of_bijective
+  (adjoin_root.lift_hom (minpoly F α) (adjoin_simple.gen F α) (aeval_gen_minpoly F α))
+  (begin
     set f := adjoin_root.lift _ _ (aeval_gen_minpoly F α : _),
     haveI := minpoly.irreducible h,
     split,
@@ -472,11 +471,7 @@ alg_equiv.of_bijective (alg_hom.mk (adjoin_root.lift (algebra_map F F⟮α⟯)
 lemma adjoin_root_equiv_adjoin_apply_root (h : is_integral F α) :
   adjoin_root_equiv_adjoin F h (adjoin_root.root (minpoly F α)) =
     adjoin_simple.gen F α :=
-begin
-  refine adjoin_root.lift_root,
-  { exact minpoly F α },
-  { exact aeval_gen_minpoly F α }
-end
+adjoin_root.lift_root (aeval_gen_minpoly F α)
 
 section power_basis
 

--- a/src/field_theory/normal.lean
+++ b/src/field_theory/normal.lean
@@ -158,8 +158,8 @@ begin
       adjoin_root.algebra_map_eq, eval₂_mul, adjoin_root.eval₂_root, zero_mul])),
   letI : algebra C E := ring_hom.to_algebra (adjoin_root.lift
     (algebra_map F E) x (minpoly.aeval F x)),
-  haveI : is_scalar_tower F C D := of_algebra_map_eq (λ x, adjoin_root.lift_of.symm),
-  haveI : is_scalar_tower F C E := of_algebra_map_eq (λ x, adjoin_root.lift_of.symm),
+  haveI : is_scalar_tower F C D := of_algebra_map_eq (λ x, (adjoin_root.lift_of _).symm),
+  haveI : is_scalar_tower F C E := of_algebra_map_eq (λ x, (adjoin_root.lift_of _).symm),
   suffices : nonempty (D →ₐ[C] E),
   { exact nonempty.map (alg_hom.restrict_scalars F) this },
   let S : set D := ((p.map (algebra_map F E)).roots.map (algebra_map E D)).to_finset,

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -274,8 +274,10 @@ variables (g : polynomial R) (pb : _root_.power_basis R S)
 /-- If `S` is an extension of `R` with power basis `pb` and `g` is a monic polynomial over `R`
 such that `pb.gen` has a minimal polynomial `g`, then `S` is isomorphic to `adjoin_root g`.
 
-Compare `power_basis.equiv'`, which would require `h₂ : aeval pb.gen (minpoly R (root g)) = 0`;
-that minimal polynomial is not guaranteed to be identical to `g`. -/
+Compare `power_basis.equiv_of_root`, which would require
+`h₂ : aeval pb.gen (minpoly R (root g)) = 0`; that minimal polynomial is not
+guaranteed to be identical to `g`. -/
+@[simps]
 def equiv' (h₁ : aeval (root g) (minpoly R pb.gen) = 0) (h₂ : aeval pb.gen g = 0) :
   adjoin_root g ≃ₐ[R] S :=
 { to_fun := adjoin_root.lift_hom g pb.gen h₂,
@@ -286,6 +288,16 @@ def equiv' (h₁ : aeval (root g) (minpoly R pb.gen) = 0) (h₂ : aeval pb.gen g
     rw [pb.lift_aeval, aeval_eq, lift_hom_mk]
   end,
   .. adjoin_root.lift_hom g pb.gen h₂ }
+
+@[simp] lemma equiv'_to_alg_hom
+  (h₁ : aeval (root g) (minpoly R pb.gen) = 0) (h₂ : aeval pb.gen g = 0) :
+  (equiv' g pb h₁ h₂).to_alg_hom = adjoin_root.lift_hom g pb.gen h₂ :=
+rfl
+
+@[simp] lemma equiv'_symm_to_alg_hom
+  (h₁ : aeval (root g) (minpoly R pb.gen) = 0) (h₂ : aeval pb.gen g = 0) :
+  (equiv' g pb h₁ h₂).symm.to_alg_hom = pb.lift (root g) h₁ :=
+rfl
 
 end integral_domain
 

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -121,9 +121,9 @@ begin
   rw [hy, ring_hom.map_mul, coe_eval₂_ring_hom, h, zero_mul]
 end
 
-variables {i : R →+* S} {a : S} {h : f.eval₂ i a = 0}
+variables {i : R →+* S} {a : S} (h : f.eval₂ i a = 0)
 
-@[simp] lemma lift_mk {g : polynomial R} : lift i a h (mk f g) = g.eval₂ i a :=
+@[simp] lemma lift_mk (g : polynomial R) : lift i a h (mk f g) = g.eval₂ i a :=
 ideal.quotient.lift_mk _ _ _
 
 @[simp] lemma lift_root : lift i a h (root f) = a := by rw [root, lift_mk, eval₂_X]
@@ -139,7 +139,8 @@ variables (f) [algebra R S]
 /-- Produce an algebra homomorphism `adjoin_root f →ₐ[R] S` sending `root f` to
 a root of `f` in `S`. -/
 def lift_hom (x : S) (hfx : aeval x f = 0) : adjoin_root f →ₐ[R] S :=
-{ commutes' := λ r, show lift _ _ hfx r = _, from lift_of, .. lift (algebra_map R S) x hfx }
+{ commutes' := λ r, show lift _ _ hfx r = _, from lift_of hfx,
+  .. lift (algebra_map R S) x hfx }
 
 @[simp] lemma coe_lift_hom (x : S) (hfx : aeval x f = 0) :
   (lift_hom f x hfx : adjoin_root f →+* S) = lift (algebra_map R S) x hfx := rfl
@@ -159,6 +160,17 @@ begin
   rw [eq_top_iff, ←adjoin_root_eq_top, algebra.adjoin_le_iff, set.singleton_subset_iff],
   exact (@lift_root _ _ _ _ _ _ _ (aeval_alg_hom_eq_zero f ϕ)).symm,
 end
+
+variables (hfx : aeval a f = 0)
+
+@[simp] lemma lift_hom_mk {g : polynomial R} : lift_hom f a hfx (mk f g) = aeval a g :=
+lift_mk hfx g
+
+@[simp] lemma lift_hom_root : lift_hom f a hfx (root f) = a :=
+lift_root hfx
+
+@[simp] lemma lift_hom_of {x : R} : lift_hom f a hfx (of f x) = algebra_map _ _ x :=
+lift_of hfx
 
 end comm_ring
 
@@ -254,6 +266,31 @@ end power_basis
 
 section equiv
 
+section integral_domain
+
+variables [integral_domain R] [integral_domain S] [algebra R S]
+variables (g : polynomial R) (pb : _root_.power_basis R S)
+
+/-- If `S` is an extension of `R` with power basis `pb` and `g` is a monic polynomial over `R`
+such that `pb.gen` has a minimal polynomial `g`, then `S` is isomorphic to `adjoin_root g`.
+
+Compare `power_basis.equiv'`, which would require `h₂ : aeval pb.gen (minpoly R (root g)) = 0`;
+that minimal polynomial is not guaranteed to be identical to `g`. -/
+def equiv' (h₁ : aeval (root g) (minpoly R pb.gen) = 0) (h₂ : aeval pb.gen g = 0) :
+  adjoin_root g ≃ₐ[R] S :=
+{ to_fun := adjoin_root.lift_hom g pb.gen h₂,
+  inv_fun := pb.lift (root g) h₁,
+  left_inv := λ x, induction_on g x $ λ f, by rw [lift_hom_mk, pb.lift_aeval, aeval_eq],
+  right_inv := λ x, begin
+    obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x,
+    rw [pb.lift_aeval, aeval_eq, lift_hom_mk]
+  end,
+  .. adjoin_root.lift_hom g pb.gen h₂ }
+
+end integral_domain
+
+section field
+
 variables (K) (L F : Type*) [field F] [field K] [field L] [algebra F K] [algebra F L]
 variables (pb : _root_.power_basis F K)
 
@@ -267,6 +304,8 @@ def equiv (f : polynomial F) (hf : f ≠ 0) :
         polynomial.map_C, roots_C, add_zero, equiv.refl_apply],
     { rw ← polynomial.map_mul, exact map_monic_ne_zero (monic_mul_leading_coeff_inv hf) }
   end))
+
+end field
 
 end equiv
 

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -277,7 +277,7 @@ such that `pb.gen` has a minimal polynomial `g`, then `S` is isomorphic to `adjo
 Compare `power_basis.equiv_of_root`, which would require
 `h₂ : aeval pb.gen (minpoly R (root g)) = 0`; that minimal polynomial is not
 guaranteed to be identical to `g`. -/
-@[simps]
+@[simps {fully_applied := ff}]
 def equiv' (h₁ : aeval (root g) (minpoly R pb.gen) = 0) (h₂ : aeval pb.gen g = 0) :
   adjoin_root g ≃ₐ[R] S :=
 { to_fun := adjoin_root.lift_hom g pb.gen h₂,


### PR DESCRIPTION
This is basically `power_basis.equiv'` with slightly different hypotheses, specialised to `adjoin_root`. It guarantees that even over non-fields, a monogenic extension of `R` can be given by the polynomials over `R` modulo the relevant minimal polynomial.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
