### PR TITLE
[Merged by Bors] - fix(ci): always use python3 executable

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -80,8 +80,8 @@ jobs:
         run: |
           leanpkg configure
           echo "::set-output name=started::true"
-          lean --json -T100000 --make src | python scripts/detect_errors.py
-          lean --json -T100000 --make src | python scripts/detect_errors.py
+          lean --json -T100000 --make src | python3 scripts/detect_errors.py
+          lean --json -T100000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'
@@ -177,12 +177,12 @@ jobs:
 
       - name: install Python dependencies
         if: ${{ ! 1 }}
-        run: python -m pip install --upgrade pip pyyaml
+        run: python3 -m pip install --upgrade pip pyyaml
 
       - name: tests
         run: |
           set -o pipefail
-          lean --json -T100000 --make docs archive roadmap test counterexamples | python scripts/detect_errors.py
+          lean --json -T100000 --make docs archive roadmap test counterexamples | python3 scripts/detect_errors.py
 
       - uses: actions/setup-java@v2
         if: ${{ ! 1 }}
@@ -205,6 +205,6 @@ jobs:
 
       - name: check declarations in db files
         run: |
-          python scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
           bash scripts/mk_all.sh
           lean --run scripts/yaml_check.lean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,8 @@ jobs:
         run: |
           leanpkg configure
           echo "::set-output name=started::true"
-          lean --json -T100000 --make src | python scripts/detect_errors.py
-          lean --json -T100000 --make src | python scripts/detect_errors.py
+          lean --json -T100000 --make src | python3 scripts/detect_errors.py
+          lean --json -T100000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'
@@ -185,12 +185,12 @@ jobs:
 
       - name: install Python dependencies
         if: ${{ ! 1 }}
-        run: python -m pip install --upgrade pip pyyaml
+        run: python3 -m pip install --upgrade pip pyyaml
 
       - name: tests
         run: |
           set -o pipefail
-          lean --json -T100000 --make docs archive roadmap test counterexamples | python scripts/detect_errors.py
+          lean --json -T100000 --make docs archive roadmap test counterexamples | python3 scripts/detect_errors.py
 
       - uses: actions/setup-java@v2
         if: ${{ ! 1 }}
@@ -213,6 +213,6 @@ jobs:
 
       - name: check declarations in db files
         run: |
-          python scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
           bash scripts/mk_all.sh
           lean --run scripts/yaml_check.lean

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -66,8 +66,8 @@ jobs:
         run: |
           leanpkg configure
           echo "::set-output name=started::true"
-          lean --json -T100000 --make src | python scripts/detect_errors.py
-          lean --json -T100000 --make src | python scripts/detect_errors.py
+          lean --json -T100000 --make src | python3 scripts/detect_errors.py
+          lean --json -T100000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'
@@ -163,12 +163,12 @@ jobs:
 
       - name: install Python dependencies
         if: ${{ ! IS_SELF_HOSTED }}
-        run: python -m pip install --upgrade pip pyyaml
+        run: python3 -m pip install --upgrade pip pyyaml
 
       - name: tests
         run: |
           set -o pipefail
-          lean --json -T100000 --make docs archive roadmap test counterexamples | python scripts/detect_errors.py
+          lean --json -T100000 --make docs archive roadmap test counterexamples | python3 scripts/detect_errors.py
 
       - uses: actions/setup-java@v2
         if: ${{ ! IS_SELF_HOSTED }}
@@ -191,6 +191,6 @@ jobs:
 
       - name: check declarations in db files
         run: |
-          python scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
           bash scripts/mk_all.sh
           lean --run scripts/yaml_check.lean

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -86,8 +86,8 @@ jobs:
         run: |
           leanpkg configure
           echo "::set-output name=started::true"
-          lean --json -T100000 --make src | python scripts/detect_errors.py
-          lean --json -T100000 --make src | python scripts/detect_errors.py
+          lean --json -T100000 --make src | python3 scripts/detect_errors.py
+          lean --json -T100000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'
@@ -183,12 +183,12 @@ jobs:
 
       - name: install Python dependencies
         if: ${{ ! 0 }}
-        run: python -m pip install --upgrade pip pyyaml
+        run: python3 -m pip install --upgrade pip pyyaml
 
       - name: tests
         run: |
           set -o pipefail
-          lean --json -T100000 --make docs archive roadmap test counterexamples | python scripts/detect_errors.py
+          lean --json -T100000 --make docs archive roadmap test counterexamples | python3 scripts/detect_errors.py
 
       - uses: actions/setup-java@v2
         if: ${{ ! 0 }}
@@ -211,6 +211,6 @@ jobs:
 
       - name: check declarations in db files
         run: |
-          python scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
           bash scripts/mk_all.sh
           lean --run scripts/yaml_check.lean


### PR DESCRIPTION
On many (particularly older) systems, the `python` command can refer to `python2` instead of `python3`.  Therefore we change all `python` calls to `python3` to prevent failures on some self-hosted runners.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
