### PR TITLE
[Merged by Bors] - feat(linear_algebra/quotient): `S.restrict_scalars.quotient` is `S.quotient`

### DIFF
--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -101,17 +101,19 @@ instance : add_comm_group (quotient p) :=
     refl },
   gsmul_neg' := by { rintros n ⟨x⟩, simp_rw [gsmul_neg_succ_of_nat, gsmul_coe_nat], refl }, }
 
-variables {S : Type*} [ring S] [mul_action S R] (P : submodule R M)
-
 section has_scalar
 
-variables [has_scalar S M] [is_scalar_tower S R M]
+variables {S : Type*} [has_scalar S R] [has_scalar S M] [is_scalar_tower S R M] (P : submodule R M)
 
 instance : has_scalar S (quotient P) :=
 ⟨λ a x, quotient.lift_on' x (λ x, mk (a • x)) $
  λ x y h, (quotient.eq P).2 $ by simpa [smul_sub] using P.smul_mem (a • 1 : R) h⟩
 
-@[simp] theorem mk_smul (r : S) : (mk (r • x) : quotient P) = r • mk x := rfl
+instance : has_scalar S (quotient P) :=
+⟨λ a x, quotient.lift_on' x (λ x, mk (a • x)) $
+ λ x y h, (quotient.eq P).2 $ by simpa [smul_sub] using P.smul_mem (a • 1 : R) h⟩
+
+@[simp] theorem mk_smul (r : S) (x : M) : (mk (r • x) : quotient P) = r • mk x := rfl
 
 @[simp] theorem mk_nsmul (n : ℕ) : (mk (n • x) : quotient P) = n • mk x := rfl
 

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -105,11 +105,11 @@ section has_scalar
 
 variables {S : Type*} [has_scalar S R] [has_scalar S M] [is_scalar_tower S R M] (P : submodule R M)
 
-instance : has_scalar S (quotient P) :=
+instance has_scalar' : has_scalar S (quotient P) :=
 ⟨λ a, quotient.map' ((•) a) $ λ x y h, by simpa [smul_sub] using P.smul_mem (a • 1 : R) h⟩
 
 /-- Shortcut to help the elaborator in the common case. -/
-instance has_scalar': has_scalar R (quotient P) :=
+instance has_scalar : has_scalar R (quotient P) :=
 quotient.has_scalar P
 
 @[simp] theorem mk_smul (r : S) (x : M) : (mk (r • x) : quotient P) = r • mk x := rfl
@@ -124,27 +124,28 @@ section module
 
 variables {S : Type*}
 
-instance [monoid S] [has_scalar S R] [mul_action S M] [is_scalar_tower S R M]
+instance mul_action' [monoid S] [has_scalar S R] [mul_action S M] [is_scalar_tower S R M]
   (P : submodule R M) : mul_action S (quotient P) :=
 function.surjective.mul_action mk (surjective_quot_mk _) P^.quotient.mk_smul
 
-instance mul_action' (P : submodule R M) : mul_action R (quotient P) :=
+instance mul_action (P : submodule R M) : mul_action R (quotient P) :=
 quotient.mul_action P
 
-instance [monoid S] [has_scalar S R] [distrib_mul_action S M] [is_scalar_tower S R M]
+instance distrib_mul_action' [monoid S] [has_scalar S R] [distrib_mul_action S M]
+  [is_scalar_tower S R M]
   (P : submodule R M) : distrib_mul_action S (quotient P) :=
 function.surjective.distrib_mul_action
   ⟨mk, rfl, λ _ _, rfl⟩ (surjective_quot_mk _) P^.quotient.mk_smul
 
-instance distrib_mul_action' (P : submodule R M) : distrib_mul_action R (quotient P) :=
+instance distrib_mul_action (P : submodule R M) : distrib_mul_action R (quotient P) :=
 quotient.distrib_mul_action P
 
-instance [semiring S] [has_scalar S R] [module S M] [is_scalar_tower S R M]
+instance module' [semiring S] [has_scalar S R] [module S M] [is_scalar_tower S R M]
   (P : submodule R M) : module S (quotient P) :=
 function.surjective.module _
   ⟨mk, rfl, λ _ _, rfl⟩ (surjective_quot_mk _) P^.quotient.mk_smul
 
-instance module' (P : submodule R M) : module R (quotient P) :=
+instance module (P : submodule R M) : module R (quotient P) :=
 quotient.module P
 
 variables (S)

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -109,10 +109,6 @@ instance : has_scalar S (quotient P) :=
 ⟨λ a x, quotient.lift_on' x (λ x, mk (a • x)) $
  λ x y h, (quotient.eq P).2 $ by simpa [smul_sub] using P.smul_mem (a • 1 : R) h⟩
 
-instance : has_scalar S (quotient P) :=
-⟨λ a x, quotient.lift_on' x (λ x, mk (a • x)) $
- λ x y h, (quotient.eq P).2 $ by simpa [smul_sub] using P.smul_mem (a • 1 : R) h⟩
-
 @[simp] theorem mk_smul (r : S) (x : M) : (mk (r • x) : quotient P) = r • mk x := rfl
 
 @[simp] theorem mk_nsmul (n : ℕ) : (mk (n • x) : quotient P) = n • mk x := rfl
@@ -124,16 +120,29 @@ end has_scalar
 
 section module
 
-variables [module S M] [is_scalar_tower S R M]
+variables {S : Type*}
 
-instance : module S (quotient P) :=
-module.of_core $ by refine {smul := (•), ..}; repeat {rintro ⟨⟩ <|> intro};
-  simp only [quot_mk_eq_mk, ← mk_add, ← mk_smul, smul_add, add_smul, mul_smul, one_smul]
+instance [monoid S] [has_scalar S R] [mul_action S M] [is_scalar_tower S R M]
+  (P : submodule R M) : mul_action S (quotient P) :=
+function.surjective.mul_action mk (surjective_quot_mk _) P^.quotient.mk_smul
+
+instance [monoid S] [has_scalar S R] [distrib_mul_action S M] [is_scalar_tower S R M]
+  (P : submodule R M) : distrib_mul_action S (quotient P) :=
+function.surjective.distrib_mul_action
+  ⟨mk, rfl, λ _ _, rfl⟩ (surjective_quot_mk _) P^.quotient.mk_smul
+
+instance [semiring S] [has_scalar S R] [module S M] [is_scalar_tower S R M]
+  (P : submodule R M) : module S (quotient P) :=
+function.surjective.module _
+  ⟨mk, rfl, λ _ _, rfl⟩ (surjective_quot_mk _) P^.quotient.mk_smul
+
+variables (S)
 
 /-- The quotient of `P` as an `S`-submodule is the same as the quotient of `P` as an `R`-submodule,
 where `P : submodule R M`.
 -/
-def restrict_scalars_equiv :
+def restrict_scalars_equiv [ring S] [has_scalar S R] [module S M] [is_scalar_tower S R M]
+  (P : submodule R M) :
   (P.restrict_scalars S).quotient ≃ₗ[S] P.quotient :=
 { to_fun := quot.map id (λ x y, id),
   inv_fun := quot.map id (λ x y, id),

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -101,18 +101,23 @@ instance : add_comm_group (quotient p) :=
     refl },
   gsmul_neg' := by { rintros n ⟨x⟩, simp_rw [gsmul_neg_succ_of_nat, gsmul_coe_nat], refl }, }
 
-instance : has_scalar R (quotient p) :=
+variables {A : Type*} [ring A] [module A M] [mul_action R A] [is_scalar_tower R A M]
+variables (P : submodule A M)
+
+instance : has_scalar R (quotient P) :=
 ⟨λ a x, quotient.lift_on' x (λ x, mk (a • x)) $
- λ x y h, (quotient.eq p).2 $ by simpa [smul_sub] using smul_mem p a h⟩
+ λ x y h, (quotient.eq P).2 $ by simpa [smul_sub] using P.smul_mem (a • 1 : A) h⟩
 
-@[simp] theorem mk_smul : (mk (r • x) : quotient p) = r • mk x := rfl
+@[simp] theorem mk_smul (r : R) : (mk (r • x) : quotient P) = r • mk x := rfl
 
-@[simp] theorem mk_nsmul (n : ℕ) : (mk (n • x) : quotient p) = n • mk x := rfl
+@[simp] theorem mk_nsmul (n : ℕ) : (mk (n • x) : quotient P) = n • mk x := rfl
 
-instance : module R (quotient p) :=
-module.of_core $ by refine {smul := (•), ..};
-  repeat {rintro ⟨⟩ <|> intro}; simp [smul_add, add_smul, smul_smul,
-    -mk_add, (mk_add p).symm, -mk_smul, (mk_smul p).symm]
+instance : is_scalar_tower R A P.quotient :=
+{ smul_assoc := by rintros x y ⟨z⟩; rw [quot_mk_eq_mk, ← mk_smul, smul_assoc, mk_smul, mk_smul] }
+
+instance : module R (quotient P) :=
+module.of_core $ by refine {smul := (•), ..}; repeat {rintro ⟨⟩ <|> intro};
+  simp only [quot_mk_eq_mk, ← mk_add, ← mk_smul, smul_add, add_smul, mul_smul, one_smul]
 
 lemma mk_surjective : function.surjective (@mk _ _ _ _ _ p) :=
 by { rintros ⟨x⟩, exact ⟨x, rfl⟩ }
@@ -124,46 +129,19 @@ begin
   simpa using not_mem_s
 end
 
-/-- More general, but harder to infer, instance than `submodule.quotient.module`. -/
-instance submodule.quotient.module' (R : Type*) {A : Type*} [ring A] [comm_ring R]
-  [algebra R A] [module A M] (P : submodule A M) :
-  module R P.quotient :=
-module.of_core
-{ smul := λ c x, algebra_map R A c • x, -- Note that this has to be defeq to `c • x` if `A = R`
-  smul_add := λ c x y, smul_add _ _ _,
-  add_smul := λ c c' x, by simp only [ring_hom.map_add, add_smul],
-  mul_smul := λ c c' x, by simp only [ring_hom.map_mul, mul_action.mul_smul],
-  one_smul := λ x, by simp only [ring_hom.map_one, one_smul] }
-
-@[simp] lemma smul_mk {R A : Type*} [comm_ring R] [ring A]
-  [algebra R A] [module R M] [module A M] [is_scalar_tower R A M]
-  (P : submodule A M) (c : R) (x : M) :
-  (c • submodule.quotient.mk x : P.quotient) = submodule.quotient.mk (c • x) :=
-show submodule.quotient.mk (algebra_map R A c • x) = submodule.quotient.mk (c • x),
-by rw algebra_map_smul
-
-instance {R A : Type*} [comm_ring R] [ring A] [algebra R A] [module A M]
-  (P : submodule A M) : is_scalar_tower R A P.quotient :=
-{ smul_assoc := λ x y z, show (x • y) • z = algebra_map R A x • y • z,
-    by rw [← smul_assoc, algebra_map_smul] }
-
 /-- The quotient of `S` as an `R`-submodule is the same as the quotient of `S` as an `A`-submodule,
 where `S : submodule A M`.
 -/
-def restrict_scalars_equiv (R : Type*) {A : Type*} [comm_ring R] [ring A] [algebra R A]
-  [module R M] [module A M] [is_scalar_tower R A M]
-  (S : submodule A M) [module R S.quotient] [is_scalar_tower R A S.quotient] :
-  (S.restrict_scalars R).quotient ≃ₗ[R] S.quotient :=
+def restrict_scalars_equiv (P : submodule A M) :
+  (P.restrict_scalars R).quotient ≃ₗ[R] P.quotient :=
 { to_fun := quot.map id (λ x y, id),
   inv_fun := quot.map id (λ x y, id),
   left_inv := λ x, quot.induction_on x (λ x', rfl),
   right_inv := λ x, quot.induction_on x (λ x', rfl),
   map_add' := λ x y, quot.induction_on₂ x y (λ x' y', rfl),
   map_smul' := λ c x, quot.induction_on x (λ x',
-    by { rw [submodule.quotient.quot_mk_eq_mk, submodule.quotient.smul_mk, ring_hom.id_apply,
-             ← algebra_map_smul A c x', ← algebra_map_smul A c],
-         exact submodule.quotient.mk_smul _,
-         { apply_instance } }) }
+    by { rw [quot_mk_eq_mk, ← mk_smul, ring_hom.id_apply],
+         exact submodule.quotient.mk_smul _ _ }) }
 
 end quotient
 

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -106,14 +106,14 @@ section has_scalar
 variables {S : Type*} [has_scalar S R] [has_scalar S M] [is_scalar_tower S R M] (P : submodule R M)
 
 instance : has_scalar S (quotient P) :=
-⟨λ a x, quotient.lift_on' x (λ x, mk (a • x)) $
- λ x y h, (quotient.eq P).2 $ by simpa [smul_sub] using P.smul_mem (a • 1 : R) h⟩
+⟨λ a, quotient.map' ((•) a) $ λ x y h, by simpa [smul_sub] using P.smul_mem (a • 1 : R) h⟩
 
 @[simp] theorem mk_smul (r : S) (x : M) : (mk (r • x) : quotient P) = r • mk x := rfl
 
-@[simp] theorem mk_nsmul (n : ℕ) : (mk (n • x) : quotient P) = n • mk x := rfl
+@[simp] theorem mk_smul (r : S) (x : M) : (mk (r • x) : quotient P) = r • mk x := rfl
 
-instance : is_scalar_tower S R P.quotient :=
+instance (T : Type*) [has_scalar T R] [has_scalar T M] [is_scalar_tower T R M] [has_scalar S T]
+  [is_scalar_tower S T M] : is_scalar_tower S T P.quotient :=
 { smul_assoc := by rintros x y ⟨z⟩; rw [quot_mk_eq_mk, ← mk_smul, smul_assoc, mk_smul, mk_smul] }
 
 end has_scalar

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -164,6 +164,17 @@ def restrict_scalars_equiv [ring S] [has_scalar S R] [module S M] [is_scalar_tow
   map_smul' := λ c x, quotient.induction_on' x (λ x', rfl),
   ..quotient.congr_right $ λ _ _, iff.rfl }
 
+@[simp] lemma restrict_scalars_equiv_mk
+  [ring S] [has_scalar S R] [module S M] [is_scalar_tower S R M] (P : submodule R M)
+  (x : M) : restrict_scalars_equiv S P (mk x) = mk x :=
+rfl
+
+@[simp] lemma restrict_scalars_equiv_symm_mk
+  [ring S] [has_scalar S R] [module S M] [is_scalar_tower S R M] (P : submodule R M)
+  (x : M) : (restrict_scalars_equiv S P).symm (mk x) = mk x :=
+rfl
+
+
 end module
 
 lemma mk_surjective : function.surjective (@mk _ _ _ _ _ p) :=

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -155,12 +155,9 @@ where `P : submodule R M`.
 def restrict_scalars_equiv [ring S] [has_scalar S R] [module S M] [is_scalar_tower S R M]
   (P : submodule R M) :
   (P.restrict_scalars S).quotient ≃ₗ[S] P.quotient :=
-{ to_fun := quot.map id (λ x y, id),
-  inv_fun := quot.map id (λ x y, id),
-  left_inv := λ x, quot.induction_on x (λ x', rfl),
-  right_inv := λ x, quot.induction_on x (λ x', rfl),
-  map_add' := λ x y, quot.induction_on₂ x y (λ x' y', rfl),
-  map_smul' := λ c x, quot.induction_on x (λ x', rfl) }
+{ map_add' := λ x y, quotient.induction_on₂' x y (λ x' y', rfl),
+  map_smul' := λ c x, quotient.induction_on' x (λ x', rfl),
+  ..quotient.congr_right $ λ _ _, iff.rfl }
 
 end module
 

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -108,7 +108,9 @@ variables {S : Type*} [has_scalar S R] [has_scalar S M] [is_scalar_tower S R M] 
 instance : has_scalar S (quotient P) :=
 ⟨λ a, quotient.map' ((•) a) $ λ x y h, by simpa [smul_sub] using P.smul_mem (a • 1 : R) h⟩
 
-@[simp] theorem mk_smul (r : S) (x : M) : (mk (r • x) : quotient P) = r • mk x := rfl
+/-- Shortcut to help the elaborator in the common case. -/
+instance has_scalar': has_scalar R (quotient P) :=
+quotient.has_scalar P
 
 @[simp] theorem mk_smul (r : S) (x : M) : (mk (r • x) : quotient P) = r • mk x := rfl
 
@@ -126,15 +128,24 @@ instance [monoid S] [has_scalar S R] [mul_action S M] [is_scalar_tower S R M]
   (P : submodule R M) : mul_action S (quotient P) :=
 function.surjective.mul_action mk (surjective_quot_mk _) P^.quotient.mk_smul
 
+instance mul_action' (P : submodule R M) : mul_action R (quotient P) :=
+quotient.mul_action P
+
 instance [monoid S] [has_scalar S R] [distrib_mul_action S M] [is_scalar_tower S R M]
   (P : submodule R M) : distrib_mul_action S (quotient P) :=
 function.surjective.distrib_mul_action
   ⟨mk, rfl, λ _ _, rfl⟩ (surjective_quot_mk _) P^.quotient.mk_smul
 
+instance distrib_mul_action' (P : submodule R M) : distrib_mul_action R (quotient P) :=
+quotient.distrib_mul_action P
+
 instance [semiring S] [has_scalar S R] [module S M] [is_scalar_tower S R M]
   (P : submodule R M) : module S (quotient P) :=
 function.surjective.module _
   ⟨mk, rfl, λ _ _, rfl⟩ (surjective_quot_mk _) P^.quotient.mk_smul
+
+instance module' (P : submodule R M) : module R (quotient P) :=
+quotient.module P
 
 variables (S)
 

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -110,7 +110,7 @@ instance has_scalar' : has_scalar S (quotient P) :=
 
 /-- Shortcut to help the elaborator in the common case. -/
 instance has_scalar : has_scalar R (quotient P) :=
-quotient.has_scalar P
+quotient.has_scalar' P
 
 @[simp] theorem mk_smul (r : S) (x : M) : (mk (r • x) : quotient P) = r • mk x := rfl
 
@@ -129,7 +129,7 @@ instance mul_action' [monoid S] [has_scalar S R] [mul_action S M] [is_scalar_tow
 function.surjective.mul_action mk (surjective_quot_mk _) P^.quotient.mk_smul
 
 instance mul_action (P : submodule R M) : mul_action R (quotient P) :=
-quotient.mul_action P
+quotient.mul_action' P
 
 instance distrib_mul_action' [monoid S] [has_scalar S R] [distrib_mul_action S M]
   [is_scalar_tower S R M]
@@ -138,7 +138,7 @@ function.surjective.distrib_mul_action
   ⟨mk, rfl, λ _ _, rfl⟩ (surjective_quot_mk _) P^.quotient.mk_smul
 
 instance distrib_mul_action (P : submodule R M) : distrib_mul_action R (quotient P) :=
-quotient.distrib_mul_action P
+quotient.distrib_mul_action' P
 
 instance module' [semiring S] [has_scalar S R] [module S M] [is_scalar_tower S R M]
   (P : submodule R M) : module S (quotient P) :=
@@ -146,7 +146,7 @@ function.surjective.module _
   ⟨mk, rfl, λ _ _, rfl⟩ (surjective_quot_mk _) P^.quotient.mk_smul
 
 instance module (P : submodule R M) : module R (quotient P) :=
-quotient.module P
+quotient.module' P
 
 variables (S)
 

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -114,9 +114,13 @@ quotient.has_scalar' P
 
 @[simp] theorem mk_smul (r : S) (x : M) : (mk (r • x) : quotient P) = r • mk x := rfl
 
+instance (T : Type*) [has_scalar T R] [has_scalar T M] [is_scalar_tower T R M]
+  [smul_comm_class S T M] : smul_comm_class S T P.quotient :=
+{ smul_comm := λ x y, quotient.ind' $ by exact λ z, congr_arg mk (smul_comm _ _ _) }
+
 instance (T : Type*) [has_scalar T R] [has_scalar T M] [is_scalar_tower T R M] [has_scalar S T]
   [is_scalar_tower S T M] : is_scalar_tower S T P.quotient :=
-{ smul_assoc := by rintros x y ⟨z⟩; rw [quot_mk_eq_mk, ← mk_smul, smul_assoc, mk_smul, mk_smul] }
+{ smul_assoc := λ x y, quotient.ind' $ by exact λ z, congr_arg mk (smul_assoc _ _ _) }
 
 end has_scalar
 

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -73,7 +73,13 @@ quotient.induction_on' x ih
 /-- Embedding of the original ring `R` into `adjoin_root f`. -/
 def of : R →+* adjoin_root f := (mk f).comp C
 
-instance : algebra R (adjoin_root f) := (of f).to_algebra
+instance : algebra R (adjoin_root f) :=
+{ smul := @@has_scalar.smul (submodule.quotient.has_scalar' _),
+  smul_def' := λ r (x : submodule.quotient _),
+    show r • x = mk f (C r) * x,
+    by rw [C_eq_algebra_map, mk, ← ideal.quotient.mkₐ_eq_mk R,
+      alg_hom.commutes, ← algebra.smul_def],
+  .. (of f).to_algebra }
 
 @[simp] lemma algebra_map_eq : algebra_map R (adjoin_root f) = of f := rfl
 

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -319,10 +319,10 @@ equiv (quotient hker hfp) (ideal.quotient_ker_alg_equiv_of_surjective hf)
 lemma iff : finite_presentation R A ↔
   ∃ n (I : ideal (_root_.mv_polynomial (fin n) R)) (e : I.quotient ≃ₐ[R] A), I.fg :=
 begin
-  refine ⟨λ h,_, λ h, _⟩,
-  { obtain ⟨n, f, hf⟩ := h,
-    use [n, f.to_ring_hom.ker, ideal.quotient_ker_alg_equiv_of_surjective hf.1, hf.2] },
-  { obtain ⟨n, I, e, hfg⟩ := h,
+  split,
+  { rintros ⟨n, f, hf⟩,
+    exact ⟨n, f.to_ring_hom.ker, ideal.quotient_ker_alg_equiv_of_surjective hf.1, hf.2⟩ },
+  { rintros ⟨n, I, e, hfg⟩,
     exact equiv (quotient hfg (mv_polynomial R _)) e }
 end
 

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1414,7 +1414,7 @@ variables (R) {A : Type*} [comm_ring A] [algebra R A]
 instance {I : ideal A} : algebra R (ideal.quotient I) :=
 { to_fun := λ x, ideal.quotient.mk I (algebra_map R A x),
   smul := (•),
-   smul_def' := λ r x, quotient.induction_on' x $ λ x,
+  smul_def' := λ r x, quotient.induction_on' x $ λ x,
       ((quotient.mk I).congr_arg $ algebra.smul_def _ _).trans (ring_hom.map_mul _ _ _),
   commutes' := λ _ _, mul_comm _ _,
   .. ring_hom.comp (ideal.quotient.mk I) (algebra_map R A) }

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1412,7 +1412,13 @@ variables (R) {A : Type*} [comm_ring A] [algebra R A]
 
 /-- The `R`-algebra structure on `A/I` for an `R`-algebra `A` -/
 instance {I : ideal A} : algebra R (ideal.quotient I) :=
-(ring_hom.comp (ideal.quotient.mk I) (algebra_map R A)).to_algebra
+{ to_fun := λ x, ideal.quotient.mk I (algebra_map R A x),
+  smul := (•),
+  smul_def' := λ r x, quot.induction_on x $ λ x,
+    by simp_rw [submodule.quotient.quot_mk_eq_mk, ideal.quotient.mk_eq_mk, ← ring_hom.map_mul,
+      ← ideal.quotient.mk_eq_mk, ← algebra.smul_def, submodule.quotient.mk_smul],
+  commutes' := λ _ _, mul_comm _ _,
+  .. ring_hom.comp (ideal.quotient.mk I) (algebra_map R A) }
 
 /-- The canonical morphism `A →ₐ[R] I.quotient` as morphism of `R`-algebras, for `I` an ideal of
 `A`, where `A` is an `R`-algebra. -/
@@ -1421,7 +1427,7 @@ def quotient.mkₐ (I : ideal A) : A →ₐ[R] I.quotient :=
 
 lemma quotient.alg_map_eq (I : ideal A) :
   algebra_map R I.quotient = (algebra_map A I.quotient).comp (algebra_map R A) :=
-by simp only [ring_hom.algebra_map_to_algebra, ring_hom.comp_id]
+rfl
 
 instance [algebra S A] [algebra S R] [is_scalar_tower S R A]
   {I : ideal A} : is_scalar_tower S R (ideal.quotient I) :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1414,9 +1414,8 @@ variables (R) {A : Type*} [comm_ring A] [algebra R A]
 instance {I : ideal A} : algebra R (ideal.quotient I) :=
 { to_fun := λ x, ideal.quotient.mk I (algebra_map R A x),
   smul := (•),
-  smul_def' := λ r x, quot.induction_on x $ λ x,
-    by simp_rw [submodule.quotient.quot_mk_eq_mk, ideal.quotient.mk_eq_mk, ← ring_hom.map_mul,
-      ← ideal.quotient.mk_eq_mk, ← algebra.smul_def, submodule.quotient.mk_smul],
+   smul_def' := λ r x, quotient.induction_on' x $ λ x,
+      ((quotient.mk I).congr_arg $ algebra.smul_def _ _).trans (ring_hom.map_mul _ _ _),
   commutes' := λ _ _, mul_comm _ _,
   .. ring_hom.comp (ideal.quotient.mk I) (algebra_map R A) }
 


### PR DESCRIPTION
This PR adds a more general module instance on submodule quotients, in order to show that `(S.restrict_scalars R).quotient` is equivalent to `S.quotient`. If we decide this instance is not a good idea, I can write it instead as `S.quotient.restrict_scalars`, but that is a bit less convenient to work with.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #9656

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
