### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/affine_isometry): affine maps are open iff their underlying linear maps are

### DIFF
--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -230,6 +230,7 @@ lemma continuous_within_at.vsub {f g : α → P} {x : α} {s : set α}
   continuous_within_at (f -ᵥ g) s x :=
 hf.vsub hg
 
+/-- `v ↦ v +ᵥ p` as a homeomorphism. -/
 @[simps] def homeomorph.vadd_const (p : P) : V ≃ₜ P :=
 { to_fun := equiv.vadd_const p,
   continuous_to_fun  := continuous_uncurry_right p continuous_vadd,

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -230,6 +230,12 @@ lemma continuous_within_at.vsub {f g : α → P} {x : α} {s : set α}
   continuous_within_at (f -ᵥ g) s x :=
 hf.vsub hg
 
+@[simps] def homeomorph.vadd_const (p : P) : V ≃ₜ P :=
+{ to_fun := equiv.vadd_const p,
+  continuous_to_fun  := continuous_uncurry_right p continuous_vadd,
+  continuous_inv_fun := continuous_uncurry_right p continuous_vsub,
+  .. equiv.vadd_const p }
+
 end
 
 section
@@ -300,6 +306,30 @@ begin
 end
 
 end normed_space
+
+namespace affine_map
+
+variables {𝕜 V₂ P₂ : Type*} [normed_field 𝕜] [semi_normed_space 𝕜 V] [semi_normed_group V₂]
+variables [semi_normed_space 𝕜 V₂] [pseudo_metric_space P₂] [semi_normed_add_torsor V₂ P₂]
+include V₂
+
+lemma continuous_of_normed_iff (f : P →ᵃ[𝕜] P₂) : continuous f ↔ continuous f.linear :=
+begin
+  obtain ⟨q⟩ := (infer_instance : nonempty P),
+  have h : ⇑f.linear = (homeomorph.vadd_const (f q)).symm ∘ f ∘ (homeomorph.vadd_const q),
+  { ext v, simp [f.map_vadd, vadd_vsub_assoc], },
+  rw [h, homeomorph.comp_continuous_iff, homeomorph.comp_continuous_iff'],
+end
+
+lemma is_open_map_of_normed_iff (f : P →ᵃ[𝕜] P₂) : is_open_map f ↔ is_open_map f.linear :=
+begin
+  obtain ⟨q⟩ := (infer_instance : nonempty P),
+  have h : ⇑f.linear = (homeomorph.vadd_const (f q)).symm ∘ f ∘ (homeomorph.vadd_const q),
+  { ext v, simp [f.map_vadd, vadd_vsub_assoc], },
+  rw [h, homeomorph.comp_is_open_map_iff, homeomorph.comp_is_open_map_iff'],
+end
+
+end affine_map
 
 variables [semi_normed_space ℝ V] [normed_space ℝ W]
 

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -230,13 +230,6 @@ lemma continuous_within_at.vsub {f g : α → P} {x : α} {s : set α}
   continuous_within_at (f -ᵥ g) s x :=
 hf.vsub hg
 
-/-- `v ↦ v +ᵥ p` as a homeomorphism. -/
-@[simps] def homeomorph.vadd_const (p : P) : V ≃ₜ P :=
-{ to_fun := equiv.vadd_const p,
-  continuous_to_fun  := continuous_uncurry_right p continuous_vadd,
-  continuous_inv_fun := continuous_uncurry_right p continuous_vsub,
-  .. equiv.vadd_const p }
-
 end
 
 section
@@ -307,30 +300,6 @@ begin
 end
 
 end normed_space
-
-namespace affine_map
-
-variables {𝕜 V₂ P₂ : Type*} [normed_field 𝕜] [semi_normed_space 𝕜 V] [semi_normed_group V₂]
-variables [semi_normed_space 𝕜 V₂] [pseudo_metric_space P₂] [semi_normed_add_torsor V₂ P₂]
-include V₂
-
-lemma continuous_of_normed_iff (f : P →ᵃ[𝕜] P₂) : continuous f ↔ continuous f.linear :=
-begin
-  obtain ⟨q⟩ := (infer_instance : nonempty P),
-  have h : ⇑f.linear = (homeomorph.vadd_const (f q)).symm ∘ f ∘ (homeomorph.vadd_const q),
-  { ext v, simp [f.map_vadd, vadd_vsub_assoc], },
-  rw [h, homeomorph.comp_continuous_iff, homeomorph.comp_continuous_iff'],
-end
-
-lemma is_open_map_of_normed_iff (f : P →ᵃ[𝕜] P₂) : is_open_map f ↔ is_open_map f.linear :=
-begin
-  obtain ⟨q⟩ := (infer_instance : nonempty P),
-  have h : ⇑f.linear = (homeomorph.vadd_const (f q)).symm ∘ f ∘ (homeomorph.vadd_const q),
-  { ext v, simp [f.map_vadd, vadd_vsub_assoc], },
-  rw [h, homeomorph.comp_is_open_map_iff, homeomorph.comp_is_open_map_iff'],
-end
-
-end affine_map
 
 variables [semi_normed_space ℝ V] [normed_space ℝ W]
 

--- a/src/analysis/normed_space/affine_isometry.lean
+++ b/src/analysis/normed_space/affine_isometry.lean
@@ -555,7 +555,7 @@ end
 
 /-- If `f` is an affine map, then its linear part is an open map iff `f` is an open map. -/
 lemma affine_map.is_open_map_linear_iff {f : P →ᵃ[𝕜] P₂} :
-  is_open_map f ↔ is_open_map f.linear :=
+  is_open_map f.linear ↔ is_open_map f :=
 begin
   inhabit P,
   have : (f.linear : V → V₂) =

--- a/src/analysis/normed_space/affine_isometry.lean
+++ b/src/analysis/normed_space/affine_isometry.lean
@@ -539,6 +539,7 @@ end constructions
 end affine_isometry_equiv
 
 include V V₂
+
 /-- If `f` is an affine map, then its linear part is continuous iff `f` is continuous. -/
 lemma affine_map.continuous_linear_iff {f : P →ᵃ[𝕜] P₂} :
   continuous f.linear ↔ continuous f :=
@@ -550,4 +551,17 @@ begin
   { ext v, simp },
   rw this,
   simp only [homeomorph.comp_continuous_iff, homeomorph.comp_continuous_iff'],
+end
+
+/-- If `f` is an affine map, then its linear part is an open map iff `f` is an open map. -/
+lemma affine_map.is_open_map_linear_iff {f : P →ᵃ[𝕜] P₂} :
+  is_open_map f ↔ is_open_map f.linear :=
+begin
+  inhabit P,
+  have : (f.linear : V → V₂) =
+    (affine_isometry_equiv.vadd_const 𝕜 $ f $ default P).to_homeomorph.symm ∘ f ∘
+      (affine_isometry_equiv.vadd_const 𝕜 $ default P).to_homeomorph,
+  { ext v, simp },
+  rw this,
+  simp only [homeomorph.comp_is_open_map_iff, homeomorph.comp_is_open_map_iff'],
 end

--- a/src/topology/algebra/affine.lean
+++ b/src/topology/algebra/affine.lean
@@ -28,7 +28,7 @@ section ring
 variables [ring R] [module R E] [module R F]
 
 /-- An affine map is continuous iff its underlying linear map is continuous. See also
-`affine_map.continuous_of_normed_iff`. -/
+`affine_map.continuous_linear_iff`. -/
 lemma continuous_iff {f : E →ᵃ[R] F} :
   continuous f ↔ continuous f.linear :=
 begin

--- a/src/topology/algebra/affine.lean
+++ b/src/topology/algebra/affine.lean
@@ -12,7 +12,9 @@ import linear_algebra.affine_space.affine_map
 For now, this contains only a few facts regarding the continuity of affine maps in the special
 case when the point space and vector space are the same.
 
-TODO: Deal with the case where the point spaces are different from the vector spaces.
+TODO: Deal with the case where the point spaces are different from the vector spaces. Note that
+we do have some results in this direction under the assumption that the topologies are induced by
+(semi)norms.
 -/
 
 namespace affine_map
@@ -25,7 +27,8 @@ section ring
 
 variables [ring R] [module R E] [module R F]
 
-/-- An affine map is continuous iff its underlying linear map is continuous. -/
+/-- An affine map is continuous iff its underlying linear map is continuous. See also
+`affine_map.continuous_of_normed_iff`. -/
 lemma continuous_iff {f : E →ᵃ[R] F} :
   continuous f ↔ continuous f.linear :=
 begin

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -251,6 +251,24 @@ h.inducing.continuous_iff.symm
   continuous (f ∘ h) ↔ continuous f :=
 h.quotient_map.continuous_iff.symm
 
+@[simp] lemma comp_is_open_map_iff (h : α ≃ₜ β) {f : γ → α} :
+  is_open_map (h ∘ f) ↔ is_open_map f :=
+begin
+  refine ⟨_, λ hf, h.is_open_map.comp hf⟩,
+  intros hf,
+  rw [← function.comp.left_id f, ← h.symm_comp_self, function.comp.assoc],
+  exact h.symm.is_open_map.comp hf,
+end
+
+@[simp] lemma comp_is_open_map_iff' (h : α ≃ₜ β) {f : β → γ} :
+  is_open_map (f ∘ h) ↔ is_open_map f :=
+begin
+  refine ⟨_, λ hf, hf.comp h.is_open_map⟩,
+  intros hf,
+  rw [← function.comp.right_id f, ← h.self_comp_symm, ← function.comp.assoc],
+  exact hf.comp h.symm.is_open_map,
+end
+
 /-- If two sets are equal, then they are homeomorphic. -/
 def set_congr {s t : set α} (h : s = t) : s ≃ₜ t :=
 { continuous_to_fun := continuous_subtype_mk _ continuous_subtype_val,


### PR DESCRIPTION
Formalized as part of the Sphere Eversion project.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
