### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/add_torsor_bases): barycentric coordinates are open maps (in finite dimensions over a complete field)

### DIFF
--- a/src/analysis/normed_space/add_torsor_bases.lean
+++ b/src/analysis/normed_space/add_torsor_bases.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Oliver Nash. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
-import analysis.normed_space.add_torsor
+import analysis.normed_space.banach
 import analysis.normed_space.finite_dimension
 import linear_algebra.affine_space.barycentric_coords
 
@@ -15,12 +15,8 @@ This file contains results about bases in normed affine spaces.
 ## Main definitions:
 
  * `continuous_barycentric_coord`
+ * `is_open_map_barycentric_coord`
  * `exists_subset_affine_independent_affine_span_eq_top_of_open`
-
-## TODO
-
-Prove `barycentric_coord h_ind h_tot i` is an open map in finite (non-zero) dimensions.
-
 -/
 
 section barycentric
@@ -33,6 +29,14 @@ variables {p : ι → P} (h_ind : affine_independent 𝕜 p) (h_tot : affine_spa
 @[continuity]
 lemma continuous_barycentric_coord (i : ι) : continuous (barycentric_coord h_ind h_tot i) :=
 affine_map.continuous_of_finite_dimensional _
+
+local attribute [instance] finite_dimensional.complete
+
+lemma is_open_map_barycentric_coord [nontrivial ι] (i : ι) :
+  is_open_map (barycentric_coord h_ind h_tot i) :=
+open_mapping_affine
+  (continuous_barycentric_coord h_ind h_tot i)
+  (surjective_barycentric_coord h_ind h_tot i)
 
 end barycentric
 

--- a/src/linear_algebra/affine_space/barycentric_coords.lean
+++ b/src/linear_algebra/affine_space/barycentric_coords.lean
@@ -123,3 +123,19 @@ begin
   have hq : q = s.affine_combination p (function.const ι (1 : k)), { simp, },
   rw [pi.one_apply, hq, barycentric_coord_apply_combination_of_mem h_ind h_tot hi hw],
 end
+
+lemma surjective_barycentric_coord [nontrivial ι] (i : ι) :
+  function.surjective $ barycentric_coord h_ind h_tot i :=
+begin
+  classical,
+  intros x,
+  obtain ⟨j, hij⟩ := exists_ne i,
+  let s : finset ι := {i, j},
+  have hi : i ∈ s, { simp, },
+  have hj : j ∈ s, { simp, },
+  let w : ι → k := λ j', if j' = i then x else 1-x,
+  have hw : s.sum w = 1, { simp [hij, finset.sum_ite, finset.filter_insert, finset.filter_eq'], },
+  use s.affine_combination p w,
+  simp only [barycentric_coord_apply_combination_of_mem h_ind h_tot hi hw, ite_eq_left_iff,
+    eq_self_iff_true, not_true, forall_false_left],
+end

--- a/src/linear_algebra/affine_space/barycentric_coords.lean
+++ b/src/linear_algebra/affine_space/barycentric_coords.lean
@@ -137,5 +137,4 @@ begin
   have hw : s.sum w = 1, { simp [hij, finset.sum_ite, finset.filter_insert, finset.filter_eq'], },
   use s.affine_combination p w,
   simp [barycentric_coord_apply_combination_of_mem h_ind h_tot hi hw],
-    eq_self_iff_true, not_true, forall_false_left],
 end

--- a/src/linear_algebra/affine_space/barycentric_coords.lean
+++ b/src/linear_algebra/affine_space/barycentric_coords.lean
@@ -136,6 +136,6 @@ begin
   let w : ι → k := λ j', if j' = i then x else 1-x,
   have hw : s.sum w = 1, { simp [hij, finset.sum_ite, finset.filter_insert, finset.filter_eq'], },
   use s.affine_combination p w,
-  simp only [barycentric_coord_apply_combination_of_mem h_ind h_tot hi hw, ite_eq_left_iff,
+  simp [barycentric_coord_apply_combination_of_mem h_ind h_tot hi hw],
     eq_self_iff_true, not_true, forall_false_left],
 end


### PR DESCRIPTION
Using the open mapping theorem with a one-dimensional codomain feels a bit ridiculous but I see no reason not to do so.

Formalized as part of the Sphere Eversion project.

---

- [x] depends on: #9538
- [x] depends on: #9540


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
