### PR TITLE
[Merged by Bors] - refactor(analysis/convex/*): prove `convex_independent_iff_finset` without full Carathéodory

### DIFF
--- a/src/analysis/convex/extreme.lean
+++ b/src/analysis/convex/extreme.lean
@@ -46,7 +46,7 @@ open set
 variables (𝕜 : Type*) {E : Type*}
 
 section has_scalar
-variables [ordered_semiring 𝕜] [add_comm_group E] [has_scalar 𝕜 E]
+variables [ordered_semiring 𝕜] [add_comm_monoid E] [has_scalar 𝕜 E]
 
 /-- A set `B` is an extreme subset of `A` if `B ⊆ A` and all points of `B` only belong to open
 segments whose ends are in `B`. -/

--- a/src/analysis/convex/function.lean
+++ b/src/analysis/convex/function.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Alexander Bentkamp. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp, François Dupuis
 -/
-import algebra.module.ordered
 import analysis.convex.basic
 import tactic.field_simp
 import tactic.linarith
@@ -71,9 +70,9 @@ convex 𝕜 s ∧
 
 variables {𝕜 s f}
 
-lemma convex_on_id {s : set 𝕜} (hs : convex 𝕜 s) : convex_on 𝕜 s id := ⟨hs, by { intros, refl }⟩
+lemma convex_on_id {s : set β} (hs : convex 𝕜 s) : convex_on 𝕜 s id := ⟨hs, by { intros, refl }⟩
 
-lemma concave_on_id {s : set 𝕜} (hs : convex 𝕜 s) : concave_on 𝕜 s id := ⟨hs, by { intros, refl }⟩
+lemma concave_on_id {s : set β} (hs : convex 𝕜 s) : concave_on 𝕜 s id := ⟨hs, by { intros, refl }⟩
 
 lemma convex_on.subset {t : set E} (hf : convex_on 𝕜 t f) (hst : s ⊆ t) (hs : convex 𝕜 s) :
   convex_on 𝕜 s f :=

--- a/src/analysis/convex/independent.lean
+++ b/src/analysis/convex/independent.lean
@@ -3,9 +3,8 @@ Copyright (c) 2021 Yaël Dillies, Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
-import analysis.convex.caratheodory
+import analysis.convex.combination
 import analysis.convex.extreme
-import linear_algebra.affine_space.independent
 
 /-!
 # Convex independence
@@ -181,19 +180,16 @@ begin
     refine h {b} a _,
     rw [hab, image_singleton, coe_singleton, convex_hull_singleton],
     exact set.mem_singleton _ },
-  let s' : finset ι :=
-    (caratheodory.min_card_finset_of_mem_convex_hull hx).preimage p (hp.inj_on _),
-  suffices hs' : x ∈ s',
-  { rw ←hp.mem_set_image,
-    rw [finset.mem_preimage, ←mem_coe] at hs',
-    exact caratheodory.min_card_finset_of_mem_convex_hull_subseteq hx hs' },
-  refine h s' x _,
-  have : s'.image p = caratheodory.min_card_finset_of_mem_convex_hull hx,
-  { rw [image_preimage, filter_true_of_mem],
-    exact λ y hy, set.image_subset_range _ s
-      (caratheodory.min_card_finset_of_mem_convex_hull_subseteq hx $ mem_coe.2 hy) },
-  rw this,
-  exact caratheodory.mem_min_card_finset_of_mem_convex_hull hx,
+  rw convex_hull_eq_union_convex_hull_finite_subsets at hx,
+  simp_rw set.mem_Union at hx,
+  obtain ⟨t, ht, hx⟩ := hx,
+  rw ←hp.mem_set_image,
+  refine ht _,
+  suffices : x ∈ t.preimage p (hp.inj_on _),
+  { rwa [mem_preimage, ←mem_coe] at this },
+  refine h _ x _,
+  rwa [t.image_preimage p (hp.inj_on _), filter_true_of_mem],
+  { exact λ y hy, s.image_subset_range p (ht $ mem_coe.2 hy) }
 end
 
 /-! ### Extreme points -/


### PR DESCRIPTION
Also relax one `add_comm_group` to `add_comm_monoid` and two `𝕜` to `β` + `module 𝕜 β`, and simplify imports.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
