### PR TITLE
[Merged by Bors] - chore(measure_theory/*): better names and notations, add easy lemmas

### DIFF
--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -1453,7 +1453,7 @@ begin
     rw [tendsto_pi], rw [tendsto_pi] at lim, intro x,
     exact ((continuous_inf_nndist_pt s).tendsto (g x)).comp (lim x) },
   have h4s : g ⁻¹' s = (λ x, inf_nndist (g x) s) ⁻¹' {0},
-  { ext x, simp [h1s, ← h1s.mem_iff_inf_dist_zero h2s, ← nnreal.coe_eq_zero] },
+  { ext x, simp [h1s, ← mem_iff_inf_dist_zero_of_closed h1s h2s, ← nnreal.coe_eq_zero] },
   rw [h4s], exact this (measurable_set_singleton 0),
 end
 

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -313,14 +313,14 @@ end
 
 variables {α' : Type*} [topological_space α'] [measurable_space α']
 
-lemma meas_interior_of_null_bdry {μ : measure α'} {s : set α'}
+lemma measure_interior_of_null_bdry {μ : measure α'} {s : set α'}
   (h_nullbdry : μ (frontier s) = 0) : μ (interior s) = μ s :=
-meas_eq_meas_smaller_of_between_null_diff
+measure_eq_measure_smaller_of_between_null_diff
   interior_subset subset_closure h_nullbdry
 
-lemma meas_closure_of_null_bdry {μ : measure α'} {s : set α'}
+lemma measure_closure_of_null_bdry {μ : measure α'} {s : set α'}
   (h_nullbdry : μ (frontier s) = 0) : μ (closure s) = μ s :=
-(meas_eq_meas_larger_of_between_null_diff
+(measure_eq_measure_larger_of_between_null_diff
   interior_subset subset_closure h_nullbdry).symm
 
 section preorder
@@ -1453,7 +1453,7 @@ begin
     rw [tendsto_pi], rw [tendsto_pi] at lim, intro x,
     exact ((continuous_inf_nndist_pt s).tendsto (g x)).comp (lim x) },
   have h4s : g ⁻¹' s = (λ x, inf_nndist (g x) s) ⁻¹' {0},
-  { ext x, simp [h1s, ← mem_iff_inf_dist_zero_of_closed h1s h2s, ← nnreal.coe_eq_zero] },
+  { ext x, simp [h1s, ← h1s.mem_iff_inf_dist_zero h2s, ← nnreal.coe_eq_zero] },
   rw [h4s], exact this (measurable_set_singleton 0),
 end
 

--- a/src/measure_theory/decomposition/jordan.lean
+++ b/src/measure_theory/decomposition/jordan.lean
@@ -483,7 +483,7 @@ begin
 end
 
 lemma absolutely_continuous_ennreal_iff (s : signed_measure α) (μ : vector_measure α ℝ≥0∞) :
-  s ≪ μ ↔ s.total_variation ≪ μ.ennreal_to_measure :=
+  s ≪ᵥ μ ↔ s.total_variation ≪ μ.ennreal_to_measure :=
 begin
   split; intro h,
   { refine measure.absolutely_continuous.mk (λ S hS₁ hS₂, _),

--- a/src/measure_theory/decomposition/radon_nikodym.lean
+++ b/src/measure_theory/decomposition/radon_nikodym.lean
@@ -93,7 +93,7 @@ open measure vector_measure
 
 theorem with_densityᵥ_rn_deriv_eq
   (s : signed_measure α) (μ : measure α) [sigma_finite μ]
-  (h : s ≪ μ.to_ennreal_vector_measure) :
+  (h : s ≪ᵥ μ.to_ennreal_vector_measure) :
   μ.with_densityᵥ (s.rn_deriv μ) = s :=
 begin
   rw [absolutely_continuous_ennreal_iff,
@@ -119,7 +119,7 @@ end
 /-- The Radon-Nikodym theorem for signed measures. -/
 theorem absolutely_continuous_iff_with_densityᵥ_rn_deriv_eq
   (s : signed_measure α) (μ : measure α) [sigma_finite μ] :
-  s ≪ μ.to_ennreal_vector_measure ↔
+  s ≪ᵥ μ.to_ennreal_vector_measure ↔
   μ.with_densityᵥ (s.rn_deriv μ) = s :=
 ⟨with_densityᵥ_rn_deriv_eq s μ,
  λ h, h ▸ with_densityᵥ_absolutely_continuous _ _⟩

--- a/src/measure_theory/function/ess_sup.lean
+++ b/src/measure_theory/function/ess_sup.lean
@@ -27,7 +27,7 @@ sense). We do not define that quantity here, which is simply the supremum of a m
 -/
 
 open measure_theory filter
-open_locale ennreal
+open_locale ennreal measure_theory
 
 variables {α β : Type*} {m : measurable_space α} {μ ν : measure α}
 

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -75,7 +75,7 @@ function coercion from the coercion to almost everywhere defined functions.
 
 noncomputable theory
 open topological_space measure_theory filter
-open_locale nnreal ennreal big_operators topological_space
+open_locale nnreal ennreal big_operators topological_space measure_theory
 
 lemma fact_one_le_one_ennreal : fact ((1 : ℝ≥0∞) ≤ 1) := ⟨le_refl _⟩
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -189,11 +189,15 @@ begin
   exact ennreal.sub_lt_of_lt_add (measure_mono hst) h
 end
 
-lemma meas_eq_meas_of_null_diff {s t : set α}
+lemma measure_diff_le_iff_le_add (hs : measurable_set s) (ht : measurable_set t) (hst : s ⊆ t)
+  (hs' : μ s ≠ ∞) {ε : ℝ≥0∞} : μ (t \ s) ≤ ε ↔ μ t ≤ μ s + ε :=
+by rwa [measure_diff hst ht hs hs', ennreal.sub_le_iff_le_add']
+
+lemma measure_eq_measure_of_null_diff {s t : set α}
   (hst : s ⊆ t) (h_nulldiff : μ (t.diff s) = 0) : μ s = μ t :=
 by { rw [←diff_diff_cancel_left hst, ←@measure_diff_null _ _ _ t _ h_nulldiff], refl, }
 
-lemma meas_eq_meas_of_between_null_diff {s₁ s₂ s₃ : set α}
+lemma measure_eq_measure_of_between_null_diff {s₁ s₂ s₃ : set α}
   (h12 : s₁ ⊆ s₂) (h23 : s₂ ⊆ s₃) (h_nulldiff : μ (s₃ \ s₁) = 0) :
   (μ s₁ = μ s₂) ∧ (μ s₂ = μ s₃) :=
 begin
@@ -206,13 +210,13 @@ begin
   exact ⟨le12.antisymm (le23.trans key), le23.antisymm (key.trans le12)⟩,
 end
 
-lemma meas_eq_meas_smaller_of_between_null_diff {s₁ s₂ s₃ : set α}
+lemma measure_eq_measure_smaller_of_between_null_diff {s₁ s₂ s₃ : set α}
   (h12 : s₁ ⊆ s₂) (h23 : s₂ ⊆ s₃) (h_nulldiff : μ (s₃.diff s₁) = 0) : μ s₁ = μ s₂ :=
-(meas_eq_meas_of_between_null_diff h12 h23 h_nulldiff).1
+(measure_eq_measure_of_between_null_diff h12 h23 h_nulldiff).1
 
-lemma meas_eq_meas_larger_of_between_null_diff {s₁ s₂ s₃ : set α}
+lemma measure_eq_measure_larger_of_between_null_diff {s₁ s₂ s₃ : set α}
   (h12 : s₁ ⊆ s₂) (h23 : s₂ ⊆ s₃) (h_nulldiff : μ (s₃.diff s₁) = 0) : μ s₂ = μ s₃ :=
-(meas_eq_meas_of_between_null_diff h12 h23 h_nulldiff).2
+(measure_eq_measure_of_between_null_diff h12 h23 h_nulldiff).2
 
 lemma measure_compl (h₁ : measurable_set s) (h_fin : μ s ≠ ∞) : μ (sᶜ) = μ univ - μ s :=
 by { rw compl_eq_univ_diff, exact measure_diff (subset_univ s) measurable_set.univ h₁ h_fin }
@@ -1240,7 +1244,7 @@ end count
 def absolutely_continuous {m0 : measurable_space α} (μ ν : measure α) : Prop :=
 ∀ ⦃s : set α⦄, ν s = 0 → μ s = 0
 
-infix ` ≪ `:50 := absolutely_continuous
+localized "infix ` ≪ `:50 := measure_theory.measure.absolutely_continuous" in measure_theory
 
 lemma absolutely_continuous_of_le (h : μ ≤ ν) : μ ≪ ν :=
 λ s hs, nonpos_iff_eq_zero.1 $ hs ▸ le_iff'.1 h s
@@ -1412,6 +1416,7 @@ end mutually_singular
 end measure
 
 open measure
+open_locale measure_theory
 
 @[simp] lemma ae_eq_bot : μ.ae = ⊥ ↔ μ = 0 :=
 by rw [← empty_mem_iff_bot, mem_ae_iff, compl_empty, measure_univ_eq_zero]
@@ -2685,6 +2690,8 @@ instance is_finite_measure_trim (hm : m ≤ m0) [is_finite_measure μ] :
 end trim
 
 end measure_theory
+
+open_locale measure_theory
 
 /-!
 # Almost everywhere measurable functions

--- a/src/measure_theory/measure/measure_space_def.lean
+++ b/src/measure_theory/measure/measure_space_def.lean
@@ -219,6 +219,10 @@ begin
   exact measure_bUnion_le s.countable_to_set f
 end
 
+lemma measure_Union_fintype_le [fintype β] (f : β → set α) :
+  μ (⋃ b, f b) ≤ ∑ p, μ (f p) :=
+by { convert measure_bUnion_finset_le finset.univ f, simp }
+
 lemma measure_bUnion_lt_top {s : set β} {f : β → set α} (hs : finite s)
   (hfin : ∀ i ∈ s, μ (f i) ≠ ∞) : μ (⋃ i ∈ s, f i) < ∞ :=
 begin

--- a/src/measure_theory/measure/vector_measure.lean
+++ b/src/measure_theory/measure/vector_measure.lean
@@ -942,13 +942,17 @@ include m
 def absolutely_continuous (v : vector_measure α M) (w : vector_measure α N) :=
 ∀ ⦃s : set α⦄, w s = 0 → v s = 0
 
-infix ` ≪ `:50 := absolutely_continuous
+
+localized "infix ` ≪ᵥ `:50 := measure_theory.vector_measure.absolutely_continuous"
+  in measure_theory
+
+open_locale measure_theory
 
 namespace absolutely_continuous
 
 variables {v : vector_measure α M} {w : vector_measure α N}
 
-lemma mk (h : ∀ ⦃s : set α⦄, measurable_set s → w s = 0 → v s = 0) : v ≪ w :=
+lemma mk (h : ∀ ⦃s : set α⦄, measurable_set s → w s = 0 → v s = 0) : v ≪ᵥ w :=
 begin
   intros s hs,
   by_cases hmeas : measurable_set s,
@@ -956,24 +960,24 @@ begin
   { exact not_measurable v hmeas }
 end
 
-lemma eq {w : vector_measure α M} (h : v = w) : v ≪ w :=
+lemma eq {w : vector_measure α M} (h : v = w) : v ≪ᵥ w :=
 λ s hs, h.symm ▸ hs
 
-@[refl] lemma refl (v : vector_measure α M) : v ≪ v :=
+@[refl] lemma refl (v : vector_measure α M) : v ≪ᵥ v :=
 eq rfl
 
-@[trans] lemma trans {u : vector_measure α L} (huv : u ≪ v) (hvw : v ≪ w) : u ≪ w :=
+@[trans] lemma trans {u : vector_measure α L} (huv : u ≪ᵥ v) (hvw : v ≪ᵥ w) : u ≪ᵥ w :=
 λ _ hs, huv $ hvw hs
 
-lemma zero (v : vector_measure α N) : (0 : vector_measure α M) ≪ v :=
+lemma zero (v : vector_measure α N) : (0 : vector_measure α M) ≪ᵥ v :=
 λ s _, vector_measure.zero_apply s
 
 lemma neg_left {M : Type*} [add_comm_group M] [topological_space M] [topological_add_group M]
-  {v : vector_measure α M} {w : vector_measure α N} (h : v ≪ w) : -v ≪ w :=
+  {v : vector_measure α M} {w : vector_measure α N} (h : v ≪ᵥ w) : -v ≪ᵥ w :=
 λ s hs, by { rw [neg_apply, h hs, neg_zero] }
 
 lemma neg_right {N : Type*} [add_comm_group N] [topological_space N] [topological_add_group N]
-  {v : vector_measure α M} {w : vector_measure α N} (h : v ≪ w) : v ≪ -w :=
+  {v : vector_measure α M} {w : vector_measure α N} (h : v ≪ᵥ w) : v ≪ᵥ -w :=
 begin
   intros s hs,
   rw [neg_apply, neg_eq_zero] at hs,
@@ -981,22 +985,22 @@ begin
 end
 
 lemma add [has_continuous_add M] {v₁ v₂ : vector_measure α M} {w : vector_measure α N}
-  (hv₁ : v₁ ≪ w) (hv₂ : v₂ ≪ w) : v₁ + v₂ ≪ w :=
+  (hv₁ : v₁ ≪ᵥ w) (hv₂ : v₂ ≪ᵥ w) : v₁ + v₂ ≪ᵥ w :=
 λ s hs, by { rw [add_apply, hv₁ hs, hv₂ hs, zero_add] }
 
 lemma sub {M : Type*} [add_comm_group M] [topological_space M] [topological_add_group M]
-  {v₁ v₂ : vector_measure α M} {w : vector_measure α N} (hv₁ : v₁ ≪ w) (hv₂ : v₂ ≪ w) :
-  v₁ - v₂ ≪ w :=
+  {v₁ v₂ : vector_measure α M} {w : vector_measure α N} (hv₁ : v₁ ≪ᵥ w) (hv₂ : v₂ ≪ᵥ w) :
+  v₁ - v₂ ≪ᵥ w :=
 λ s hs, by { rw [sub_apply, hv₁ hs, hv₂ hs, zero_sub, neg_zero] }
 
 lemma smul {R : Type*} [semiring R] [distrib_mul_action R M]
   [topological_space R] [has_continuous_smul R M]
-  {r : R} {v : vector_measure α M} {w : vector_measure α N} (h : v ≪ w) :
-  r • v ≪ w :=
+  {r : R} {v : vector_measure α M} {w : vector_measure α N} (h : v ≪ᵥ w) :
+  r • v ≪ᵥ w :=
 λ s hs, by { rw [smul_apply, h hs, smul_zero] }
 
-lemma map [measure_space β] (h : v ≪ w) (f : α → β) :
-  v.map f ≪ w.map f :=
+lemma map [measure_space β] (h : v ≪ᵥ w) (f : α → β) :
+  v.map f ≪ᵥ w.map f :=
 begin
   by_cases hf : measurable f,
   { refine mk (λ s hs hws, _),
@@ -1007,7 +1011,7 @@ begin
 end
 
 lemma ennreal_to_measure {μ : vector_measure α ℝ≥0∞} :
-  (∀ ⦃s : set α⦄, μ.ennreal_to_measure s = 0 → v s = 0) ↔ v ≪ μ :=
+  (∀ ⦃s : set α⦄, μ.ennreal_to_measure s = 0 → v s = 0) ↔ v ≪ᵥ μ :=
 begin
   split; intro h,
   { refine mk (λ s hmeas hs, h _),

--- a/src/measure_theory/measure/with_density_vector_measure.lean
+++ b/src/measure_theory/measure/with_density_vector_measure.lean
@@ -122,7 +122,7 @@ lemma with_densityᵥ_smul' {𝕜 : Type*} [nondiscrete_normed_field 𝕜] [norm
 with_densityᵥ_smul f r
 
 lemma measure.with_densityᵥ_absolutely_continuous (μ : measure α) (f : α → ℝ) :
-  μ.with_densityᵥ f ≪ μ.to_ennreal_vector_measure :=
+  μ.with_densityᵥ f ≪ᵥ μ.to_ennreal_vector_measure :=
 begin
   by_cases hf : integrable f μ,
   { refine vector_measure.absolutely_continuous.mk (λ i hi₁ hi₂, _),
@@ -196,7 +196,7 @@ by rw [vector_measure.trim_measurable_set_eq hm hi, with_densityᵥ_apply hf (hm
 
 lemma integrable.with_densityᵥ_trim_absolutely_continuous
   {m m0 : measurable_space α} {μ : measure α} (hm : m ≤ m0) (hfi : integrable f μ) :
-  (μ.with_densityᵥ f).trim hm ≪ (μ.trim hm).to_ennreal_vector_measure :=
+  (μ.with_densityᵥ f).trim hm ≪ᵥ (μ.trim hm).to_ennreal_vector_measure :=
 begin
   refine vector_measure.absolutely_continuous.mk (λ j hj₁ hj₂, _),
   rw [measure.to_ennreal_vector_measure_apply_measurable hj₁, trim_measurable_set_eq hm hj₁] at hj₂,


### PR DESCRIPTION
* Localize notation for absolutely continuous in the `measure_theory` namespace, and add separate notations for the case of measures and of vector measures.
* Standardize some names, using `measure` instead of `meas`.
* Add two lemmas on measures with density.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
