### PR TITLE
[Merged by Bors] - chore(linear_algebra/quadratic_form): speed up quadratic_form.lin_mul_lin

### DIFF
--- a/src/linear_algebra/quadratic_form.lean
+++ b/src/linear_algebra/quadratic_form.lean
@@ -382,12 +382,13 @@ def mk_left (f : M → R₁)
 /-- The product of linear forms is a quadratic form. -/
 def lin_mul_lin (f g : M →ₗ[R₁] R₁) : quadratic_form R₁ M :=
 mk_left (f * g)
-  (λ a x, by { simp, ring })
-  (λ x x' y, by { simp [polar], ring })
+  (λ a x,
+    by { simp only [smul_eq_mul, ring_hom.id_apply, pi.mul_apply, linear_map.map_smulₛₗ], ring })
+  (λ x x' y, by { simp only [polar, pi.mul_apply, linear_map.map_add], ring })
   (λ a x y,
     begin
-      dsimp [polar],
-      simp only [linear_map.map_add, linear_map.map_smul, smul_eq_mul],
+      simp only [polar, ring_hom.id_apply, pi.mul_apply, linear_map.map_smulₛₗ, linear_map.map_add,
+        linear_map.map_add, linear_map.map_smul, smul_eq_mul],
       ring,
     end)
 


### PR DESCRIPTION
In my single profiler run, this reduced elaboration time from 20s to 1.5s.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
