### PR TITLE
[Merged by Bors] - feat(category_theory/*): Yoneda extension is Kan

### DIFF
--- a/src/category_theory/elements.lean
+++ b/src/category_theory/elements.lean
@@ -121,5 +121,122 @@ equivalence.mk (to_structured_arrow F) (from_structured_arrow F)
     (λ X, { hom := { right := 𝟙 _ }, inv := { right := 𝟙 _ } })
     (by tidy))
 
+open opposite
+
+/--
+The forward direction of the equivalence `F.elementsᵒᵖ ≅ (yoneda, F)`,
+given by `category_theory.yoneda_sections`.
+-/
+@[simps]
+def to_costructured_arrow (F : Cᵒᵖ ⥤ Type v) : (F.elements)ᵒᵖ ⥤ costructured_arrow yoneda F :=
+{ obj := λ X, costructured_arrow.mk
+    ((yoneda_sections (unop (unop X).fst) F).inv (ulift.up (unop X).2)),
+  map := λ X Y f,
+  begin
+    fapply costructured_arrow.hom_mk,
+    exact f.unop.val.unop,
+    ext y,
+    simp only [costructured_arrow.mk_hom_eq_self, yoneda_map_app, functor_to_types.comp, op_comp,
+      yoneda_sections_inv_app, functor_to_types.map_comp_apply, quiver.hom.op_unop,
+      subtype.val_eq_coe],
+    congr,
+    exact f.unop.2,
+  end }
+
+/--
+The reverse direction of the equivalence `F.elementsᵒᵖ ≅ (yoneda, F)`,
+given by `category_theory.yoneda_equiv`.
+-/
+@[simps]
+def from_costructured_arrow (F : Cᵒᵖ ⥤ Type v) : (costructured_arrow yoneda F)ᵒᵖ ⥤ F.elements :=
+{ obj := λ X, ⟨op (unop X).1, yoneda_equiv.1 (unop X).3⟩,
+  map := λ X Y f, ⟨f.unop.1.op,
+  begin
+    convert (congr_fun ((unop X).hom.naturality f.unop.left.op) (𝟙 _)).symm,
+    simp only [equiv.to_fun_as_coe, quiver.hom.unop_op, yoneda_equiv_apply,
+      types_comp_apply, category.comp_id, yoneda_obj_map],
+    have : yoneda.map f.unop.left ≫ (unop X).hom = (unop Y).hom,
+    { convert f.unop.3, erw category.comp_id },
+    erw ← this,
+    simp only [yoneda_map_app, functor_to_types.comp],
+    erw category.id_comp
+  end ⟩}
+
+@[simp]
+lemma from_costructured_arrow_obj_mk (F : Cᵒᵖ ⥤ Type v) {X : C} (f : yoneda.obj X ⟶ F) :
+  (from_costructured_arrow F).obj (op (costructured_arrow.mk f)) = ⟨op X, yoneda_equiv.1 f⟩ := rfl
+
+/-- The unit of the equivalence `F.elementsᵒᵖ ≅ (yoneda, F)` is indeed iso. -/
+lemma from_to_costructured_arrow_eq (F : Cᵒᵖ ⥤ Type v) :
+ (to_costructured_arrow F).right_op ⋙ from_costructured_arrow F = 𝟭 _ :=
+begin
+  apply functor.ext,
+  intros X Y f,
+  have : ∀ {a b : F.elements} (H : a = b),
+    ↑(eq_to_hom H) = eq_to_hom (show a.fst = b.fst, by { cases H, refl }) :=
+    λ _ _ H, by { cases H, refl },
+  ext, simp[this],
+  tidy
+end
+
+/-- The counit of the equivalence `F.elementsᵒᵖ ≅ (yoneda, F)` is indeed iso. -/
+lemma to_from_costructured_arrow_eq (F : Cᵒᵖ ⥤ Type v) :
+  (from_costructured_arrow F).right_op ⋙ to_costructured_arrow F = 𝟭 _ :=
+begin
+  apply functor.hext,
+  { intro X, cases X, cases X_right,
+    simp only [functor.id_obj, functor.right_op_obj,
+      to_costructured_arrow_obj, functor.comp_obj, costructured_arrow.mk],
+    congr,
+    ext x f,
+    convert congr_fun (X_hom.naturality f.op).symm (𝟙 X_left),
+    simp only [quiver.hom.unop_op, yoneda_obj_map],
+    erw category.comp_id },
+  intros X Y f,
+  cases X, cases Y, cases f, cases X_right, cases Y_right,
+  simp[costructured_arrow.hom_mk],
+  delta costructured_arrow.mk,
+  congr,
+  { ext x f,
+    convert congr_fun (X_hom.naturality f.op).symm (𝟙 X_left),
+    simp only [quiver.hom.unop_op, category_theory.yoneda_obj_map],
+    erw category.comp_id },
+  { ext x f,
+    convert congr_fun (Y_hom.naturality f.op).symm (𝟙 Y_left),
+    simp only [quiver.hom.unop_op, category_theory.yoneda_obj_map],
+    erw category.comp_id },
+  simp,
+  exact proof_irrel_heq _ _,
+end
+
+
+/-- The equivalence `F.elementsᵒᵖ ≅ (yoneda, F)` given by yoneda lemma. -/
+@[simps] def costructured_arrow_yoneda_equivalence (F : Cᵒᵖ ⥤ Type v) :
+  (F.elements)ᵒᵖ ≌ costructured_arrow yoneda F :=
+equivalence.mk (to_costructured_arrow F) (from_costructured_arrow F).right_op
+  (nat_iso.op (eq_to_iso (from_to_costructured_arrow_eq F)))
+  (eq_to_iso $ to_from_costructured_arrow_eq F)
+
+/--
+The equivalence `(-.elements)ᵒᵖ ≅ (yoneda, -)` of is actually a natural isomorphism of functors.
+-/
+lemma costructured_arrow_yoneda_equivalence_naturality {F₁ F₂ : Cᵒᵖ ⥤ Type v}
+  (α : F₁ ⟶ F₂) : (map α).op ⋙ to_costructured_arrow F₂ =
+    to_costructured_arrow F₁ ⋙ costructured_arrow.map α :=
+begin
+  fapply functor.ext,
+  { intro X,
+    simp only [costructured_arrow.map_mk, to_costructured_arrow_obj,
+      functor.op_obj, functor.comp_obj],
+    congr,
+    ext x f,
+    simpa using congr_fun (α.naturality f.op).symm (unop X).snd },
+  { intros X Y f, ext,
+    have : ∀ {F : Cᵒᵖ ⥤ Type v} {a b : costructured_arrow yoneda F} (H : a = b),
+      comma_morphism.left (eq_to_hom H) = eq_to_hom (show a.left = b.left, by { cases H, refl }) :=
+      λ _ _ _ H, by { cases H, refl },
+    simp [this] }
+end
+
 end category_of_elements
 end category_theory

--- a/src/category_theory/limits/presheaf.lean
+++ b/src/category_theory/limits/presheaf.lean
@@ -23,7 +23,7 @@ This adjunction is used to show that every presheaf is a colimit of representabl
 Further, the left adjoint `colimit_adj.extend_along_yoneda : (Cᵒᵖ ⥤ Type u) ⥤ ℰ` satisfies
 `yoneda ⋙ L ≅ A`, that is, an extension of `A : C ⥤ ℰ` to `(Cᵒᵖ ⥤ Type u) ⥤ ℰ` through
 `yoneda : C ⥤ Cᵒᵖ ⥤ Type u`. It is the left Kan extension of `A` along the yoneda embedding,
-sometimes known as the Yoneda extension.
+sometimes known as the Yoneda extension, as proved in `extend_along_yoneda_iso_Kan`.
 
 `unique_extension_along_yoneda` shows `extend_along_yoneda` is unique amongst cocontinuous functors
 with this property, establishing the presheaf category as the free cocompletion of a small category.

--- a/src/category_theory/limits/presheaf.lean
+++ b/src/category_theory/limits/presheaf.lean
@@ -9,6 +9,7 @@ import category_theory.limits.functor_category
 import category_theory.limits.preserves.limits
 import category_theory.limits.shapes.terminal
 import category_theory.limits.types
+import category_theory.limits.kan_extension
 
 /-!
 # Colimit of representables
@@ -139,6 +140,18 @@ adjunction.left_adjoint_of_equiv
 lemma extend_along_yoneda_obj (P : Cᵒᵖ ⥤ Type u₁) : (extend_along_yoneda A).obj P =
 colimit ((category_of_elements.π P).left_op ⋙ A) := rfl
 
+lemma extend_along_yoneda_map {X Y : Cᵒᵖ ⥤ Type u₁} (f : X ⟶ Y) :
+  (extend_along_yoneda A).map f = colimit.pre ((category_of_elements.π Y).left_op ⋙ A)
+    (category_of_elements.map f).op :=
+begin
+  ext J,
+  erw colimit.ι_pre ((category_of_elements.π Y).left_op ⋙ A) (category_of_elements.map f).op,
+  dsimp only [extend_along_yoneda, restrict_yoneda_hom_equiv,
+    is_colimit.hom_iso', is_colimit.hom_iso],
+  simpa
+end
+
+
 /--
 Show `extend_along_yoneda` is left adjoint to `restricted_yoneda`.
 
@@ -194,6 +207,49 @@ end
 /-- See Property 2 of https://ncatlab.org/nlab/show/Yoneda+extension#properties. -/
 instance : preserves_colimits (extend_along_yoneda A) :=
 (yoneda_adjunction A).left_adjoint_preserves_colimits
+
+/--
+Show that the images of `X` after `extend_along_yoneda` and `Lan yoneda` are indeed isomorphic.
+This follows from `category_theory.category_of_elements.costructured_arrow_yoneda_equivalence`.
+-/
+@[simps] def extend_along_yoneda_iso_Kan_app (X) :
+  (extend_along_yoneda A).obj X ≅ ((Lan yoneda : (_ ⥤ ℰ) ⥤ _).obj A).obj X :=
+let eq := category_of_elements.costructured_arrow_yoneda_equivalence X in
+{ hom := colimit.pre (Lan.diagram (yoneda : C ⥤ _ ⥤ Type u₁) A X) eq.functor,
+  inv := colimit.pre ((category_of_elements.π X).left_op ⋙ A) eq.inverse,
+  hom_inv_id' :=
+  begin
+    erw colimit.pre_pre ((category_of_elements.π X).left_op ⋙ A) eq.inverse,
+    transitivity colimit.pre ((category_of_elements.π X).left_op ⋙ A) (𝟭 _),
+    congr,
+    { exact congr_arg functor.op (category_of_elements.from_to_costructured_arrow_eq X) },
+    { ext, simp only [colimit.ι_pre], erw category.comp_id, congr }
+  end,
+  inv_hom_id' :=
+  begin
+    erw colimit.pre_pre (Lan.diagram (yoneda : C ⥤ _ ⥤ Type u₁) A X) eq.functor,
+    transitivity colimit.pre (Lan.diagram (yoneda : C ⥤ _ ⥤ Type u₁) A X) (𝟭 _),
+    congr,
+    { exact category_of_elements.to_from_costructured_arrow_eq X },
+    { ext, simp only [colimit.ι_pre], erw category.comp_id, congr }
+  end }
+
+/--
+Verify that `extend_along_yoneda` is indeed the left Kan extension along the yoneda embedding.
+-/
+@[simps]
+def extend_along_yoneda_iso_Kan : extend_along_yoneda A ≅ (Lan yoneda : (_ ⥤ ℰ) ⥤ _).obj A :=
+nat_iso.of_components (extend_along_yoneda_iso_Kan_app A)
+begin
+  intros X Y f, simp,
+  rw extend_along_yoneda_map,
+  erw colimit.pre_pre (Lan.diagram (yoneda : C ⥤ _ ⥤ Type u₁) A Y) (costructured_arrow.map f),
+  erw colimit.pre_pre (Lan.diagram (yoneda : C ⥤ _ ⥤ Type u₁) A Y)
+    (category_of_elements.costructured_arrow_yoneda_equivalence Y).functor,
+  congr' 1,
+  apply category_of_elements.costructured_arrow_yoneda_equivalence_naturality,
+end
+
 
 end colimit_adj
 


### PR DESCRIPTION
- Proved that `(F.elements)ᵒᵖ ≌ costructured_arrow yoneda F`.
- Verified that the yoneda extension is indeed the left Kan extension along the yoneda embedding.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
