### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/add_torsor_bases): the interior of the convex hull of a finite affine basis is the set of points with strictly positive barycentric coordinates

### DIFF
--- a/src/analysis/convex/hull.lean
+++ b/src/analysis/convex/hull.lean
@@ -57,6 +57,9 @@ lemma convex_hull_mono (hst : s ⊆ t) : convex_hull 𝕜 s ⊆ convex_hull 𝕜
 lemma convex.convex_hull_eq {s : set E} (hs : convex 𝕜 s) : convex_hull 𝕜 s = s :=
 closure_operator.mem_mk₃_closed hs
 
+@[simp] lemma convex_hull_univ : convex_hull 𝕜 (univ : set E) = univ :=
+closure_operator.closure_top (convex_hull 𝕜)
+
 @[simp] lemma convex_hull_empty : convex_hull 𝕜 (∅ : set E) = ∅ := convex_empty.convex_hull_eq
 
 @[simp] lemma convex_hull_empty_iff : convex_hull 𝕜 s = ∅ ↔ s = ∅ :=

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -710,6 +710,15 @@ begin
   exact subsingleton_of_univ_subsingleton h₂,
 end
 
+lemma eq_univ_of_subsingleton_span_eq_top {s : set P} (h₁ : s.subsingleton)
+  (h₂ : affine_span k s = ⊤) : s = (univ : set P) :=
+begin
+  obtain ⟨p, hp⟩ := affine_subspace.nonempty_of_affine_span_eq_top k V P h₂,
+  have : s = {p}, { exact subset.antisymm (λ q hq, h₁ hq hp) (by simp [hp]), },
+  rw [this, eq_comm, ← subsingleton_iff_singleton (mem_univ p), subsingleton_univ_iff],
+  exact subsingleton_of_subsingleton_span_eq_top h₁ h₂,
+end
+
 /-- A nonempty affine subspace is `⊤` if and only if its direction is
 `⊤`. -/
 @[simp] lemma direction_eq_top_iff_of_nonempty {s : affine_subspace k P}


### PR DESCRIPTION
Formalized as part of the Sphere Eversion project.

---

- [x] depends on: #9543
- [x] depends on: #9540


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
