### PR TITLE
[Merged by Bors] - fix(computability/DFA): tighten regular pumping lemma to match standard textbooks

### DIFF
--- a/src/computability/DFA.lean
+++ b/src/computability/DFA.lean
@@ -50,19 +50,22 @@ lemma eval_from_of_append (start : σ) (x y : list α) :
   M.eval_from start (x ++ y) = M.eval_from (M.eval_from start x) y :=
 x.foldl_append _ _ y
 
-lemma eval_from_split [fintype σ] {x : list α} {s t : σ} (hlen : fintype.card σ + 1 ≤ x.length)
+lemma eval_from_split [fintype σ] {x : list α} {s t : σ} (hlen : fintype.card σ ≤ x.length)
   (hx : M.eval_from s x = t) :
   ∃ q a b c,
   x = a ++ b ++ c ∧
-  a.length + b.length ≤ fintype.card σ + 1 ∧
+  a.length + b.length ≤ fintype.card σ ∧
   b ≠ [] ∧
   M.eval_from s a = q ∧
   M.eval_from q b = q ∧
   M.eval_from q c = t :=
 begin
-  obtain ⟨⟨n, hn⟩, ⟨m, hm⟩, hneq, heq⟩ := fintype.exists_ne_map_eq_of_card_lt
+  obtain ⟨n, m, hneq, heq⟩ := fintype.exists_ne_map_eq_of_card_lt
     (λ n : fin (fintype.card σ + 1), M.eval_from s (x.take n)) (by norm_num),
-  wlog hle : n ≤ m := le_total n m using [n m, m n],
+  wlog hle : (n : ℕ) ≤ m using n m,
+  have hlt : (n : ℕ) < m := (ne.le_iff_lt hneq).mp hle,
+  have hm : (m : ℕ) ≤ fintype.card σ := fin.is_le m,
+  dsimp at heq,
 
   refine ⟨M.eval_from s ((x.take m).take n), (x.take m).take n, (x.take m).drop n, x.drop m,
     _, _, _, by refl, _⟩,
@@ -70,23 +73,22 @@ begin
   { rw [list.take_append_drop, list.take_append_drop] },
 
   { simp only [list.length_drop, list.length_take],
-    rw [min_eq_left (hm.le.trans hlen), min_eq_left hle, add_sub_cancel_of_le hle],
-    exact hm.le },
+    rw [min_eq_left (hm.trans hlen), min_eq_left hle, add_sub_cancel_of_le hle],
+    exact hm },
 
   { intro h,
     have hlen' := congr_arg list.length h,
     simp only [list.length_drop, list.length, list.length_take] at hlen',
-    rw [min_eq_left_of_lt, nat.sub_eq_zero_iff_le] at hlen',
+    rw [min_eq_left, nat.sub_eq_zero_iff_le] at hlen',
     { apply hneq,
       apply le_antisymm,
       assumption' },
-    exact hm.trans_le hlen, },
+    exact hm.trans hlen, },
 
   have hq :
     M.eval_from (M.eval_from s ((x.take m).take n)) ((x.take m).drop n) =
       M.eval_from s ((x.take m).take n),
-  { simp only [fin.coe_mk] at heq,
-    rw [list.take_take, min_eq_left hle, ←eval_from_of_append, heq, ←min_eq_left hle,
+  { rw [list.take_take, min_eq_left hle, ←eval_from_of_append, heq, ←min_eq_left hle,
         ←list.take_take, min_eq_left hle, list.take_append_drop] },
 
   use hq,
@@ -110,8 +112,8 @@ begin
 end
 
 lemma pumping_lemma [fintype σ] {x : list α} (hx : x ∈ M.accepts)
-  (hlen : fintype.card σ + 1 ≤ list.length x) :
-  ∃ a b c, x = a ++ b ++ c ∧ a.length + b.length ≤ fintype.card σ + 1 ∧ b ≠ [] ∧
+  (hlen : fintype.card σ ≤ list.length x) :
+  ∃ a b c, x = a ++ b ++ c ∧ a.length + b.length ≤ fintype.card σ ∧ b ≠ [] ∧
   {a} * language.star {b} * {c} ≤ M.accepts :=
 begin
   obtain ⟨_, a, b, c, hx, hlen, hnil, rfl, hb, hc⟩ := M.eval_from_split hlen rfl,

--- a/src/computability/NFA.lean
+++ b/src/computability/NFA.lean
@@ -72,8 +72,8 @@ begin
 end
 
 lemma pumping_lemma [fintype σ] {x : list α} (hx : x ∈ M.accepts)
-  (hlen : fintype.card (set σ) + 1 ≤ list.length x) :
-  ∃ a b c, x = a ++ b ++ c ∧ a.length + b.length ≤ fintype.card (set σ) + 1 ∧ b ≠ [] ∧
+  (hlen : fintype.card (set σ) ≤ list.length x) :
+  ∃ a b c, x = a ++ b ++ c ∧ a.length + b.length ≤ fintype.card (set σ) ∧ b ≠ [] ∧
   {a} * language.star {b} * {c} ≤ M.accepts :=
 begin
   rw ←to_DFA_correct at hx ⊢,

--- a/src/computability/epsilon_NFA.lean
+++ b/src/computability/epsilon_NFA.lean
@@ -76,8 +76,8 @@ begin
 end
 
 lemma pumping_lemma [fintype σ] {x : list α} (hx : x ∈ M.accepts)
-  (hlen : fintype.card (set σ) + 1 ≤ list.length x) :
-  ∃ a b c, x = a ++ b ++ c ∧ a.length + b.length ≤ fintype.card (set σ) + 1 ∧ b ≠ [] ∧
+  (hlen : fintype.card (set σ) ≤ list.length x) :
+  ∃ a b c, x = a ++ b ++ c ∧ a.length + b.length ≤ fintype.card (set σ) ∧ b ≠ [] ∧
   {a} * language.star {b} * {c} ≤ M.accepts :=
 begin
   rw ←to_NFA_correct at hx ⊢,


### PR DESCRIPTION
This PR slightly tightens the regular pumping lemma: the current version applies only to words that are of length at least the number of states in the DFA plus one. Here we remove the plus one.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
