### PR TITLE
[Merged by Bors] - feat(algebra/graded_monoid): Split out graded monoids from graded rings

### DIFF
--- a/src/algebra/direct_sum/algebra.lean
+++ b/src/algebra/direct_sum/algebra.lean
@@ -40,21 +40,19 @@ open_locale direct_sum
 variables (R : Type uR) (A : ι → Type uA) {B : Type uB} [decidable_eq ι]
 
 variables [comm_semiring R] [Π i, add_comm_monoid (A i)] [Π i, module R (A i)]
-variables [add_monoid ι] [gmonoid A]
+variables [add_monoid ι] [gsemiring A]
 
 section
-
-local attribute [instance] ghas_one.to_sigma_has_one
-local attribute [instance] ghas_mul.to_sigma_has_mul
 
 /-- A graded version of `algebra`. An instance of `direct_sum.galgebra R A` endows `(⨁ i, A i)`
 with an `R`-algebra structure. -/
 class galgebra :=
 (to_fun : R →+ A 0)
-(map_one : to_fun 1 = ghas_one.one)
-(map_mul : ∀ r s, (⟨_, to_fun (r * s)⟩ : Σ i, A i) = ⟨_, ghas_mul.mul (to_fun r) (to_fun s)⟩)
-(commutes : ∀ r x, (⟨_, to_fun (r)⟩ : Σ i, A i) * x = x * ⟨_, to_fun (r)⟩)
-(smul_def : ∀ r (x : Σ i, A i), (⟨x.1, r • x.2⟩ : Σ i, A i) = ⟨_, to_fun (r)⟩ * x)
+(map_one : to_fun 1 = graded_monoid.ghas_one.one)
+(map_mul : ∀ r s,
+  graded_monoid.mk _ (to_fun (r * s)) = ⟨_, graded_monoid.ghas_mul.mul (to_fun r) (to_fun s)⟩)
+(commutes : ∀ r x, graded_monoid.mk _ (to_fun r) * x = x * ⟨_, to_fun r⟩)
+(smul_def : ∀ r (x : graded_monoid A), graded_monoid.mk x.1 (r • x.2) = ⟨_, to_fun (r)⟩ * x)
 
 end
 
@@ -106,7 +104,7 @@ instance galgebra.of_submodules
   (carriers : ι → submodule R B)
   (one_mem : (1 : B) ∈ carriers 0)
   (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : B) ∈ carriers (i + j)) :
-  by haveI : gmonoid (λ i, carriers i) := gmonoid.of_submodules carriers one_mem mul_mem; exact
+  by haveI : gsemiring (λ i, carriers i) := gsemiring.of_submodules carriers one_mem mul_mem; exact
   galgebra R (λ i, carriers i) :=
 by exact {
   to_fun := begin
@@ -130,8 +128,8 @@ coercions such as `submodule.subtype (A i)`, and the `[gmonoid A]` structure ori
 can be discharged by `rfl`. -/
 @[simps]
 def to_algebra
-  (f : Π i, A i →ₗ[R] B) (hone : f _ (ghas_one.one) = 1)
-  (hmul : ∀ {i j} (ai : A i) (aj : A j), f _ (ghas_mul.mul ai aj) = f _ ai * f _ aj)
+  (f : Π i, A i →ₗ[R] B) (hone : f _ (graded_monoid.ghas_one.one) = 1)
+  (hmul : ∀ {i j} (ai : A i) (aj : A j), f _ (graded_monoid.ghas_mul.mul ai aj) = f _ ai * f _ aj)
   (hcommutes : ∀ r, (f 0) (galgebra.to_fun r) = (algebra_map R B) r) :
   (⨁ i, A i) →ₐ[R] B :=
 { to_fun := to_semiring (λ i, (f i).to_add_monoid_hom) hone @hmul,

--- a/src/algebra/direct_sum/ring.lean
+++ b/src/algebra/direct_sum/ring.lean
@@ -7,6 +7,7 @@ import algebra.algebra.basic
 import algebra.algebra.operations
 import algebra.direct_sum.basic
 import group_theory.subgroup.basic
+import algebra.graded_monoid
 
 /-!
 # Additively-graded multiplicative structures on `⨁ i, A i`
@@ -15,28 +16,24 @@ This module provides a set of heterogeneous typeclasses for defining a multiplic
 over `⨁ i, A i` such that `(*) : A i → A j → A (i + j)`; that is to say, `A` forms an
 additively-graded ring. The typeclasses are:
 
-* `direct_sum.ghas_one A`
-* `direct_sum.ghas_mul A`
-* `direct_sum.gmonoid A`
-* `direct_sum.gcomm_monoid A`
+* `direct_sum.gnon_unital_non_assoc_semiring A`
+* `direct_sum.gsemiring A`
+* `direct_sum.gcomm_semiring A`
 
 Respectively, these imbue the direct sum `⨁ i, A i` with:
 
-* `direct_sum.has_one`
 * `direct_sum.non_unital_non_assoc_semiring`
 * `direct_sum.semiring`, `direct_sum.ring`
 * `direct_sum.comm_semiring`, `direct_sum.comm_ring`
 
 the base ring `A 0` with:
 
-* `direct_sum.grade_zero.has_one`
 * `direct_sum.grade_zero.non_unital_non_assoc_semiring`
 * `direct_sum.grade_zero.semiring`, `direct_sum.grade_zero.ring`
 * `direct_sum.grade_zero.comm_semiring`, `direct_sum.grade_zero.comm_ring`
 
 and the `i`th grade `A i` with `A 0`-actions (`•`) defined as left-multiplication:
 
-* (nothing)
 * `direct_sum.grade_zero.has_scalar (A 0)`, `direct_sum.grade_zero.smul_with_zero (A 0)`
 * `direct_sum.grade_zero.module (A 0)`
 * (nothing)
@@ -50,18 +47,15 @@ homomorphism.
 
 ## Direct sums of subobjects
 
-Additionally, this module provides helper functions to construct `gmonoid` and `gcomm_monoid`
+Additionally, this module provides helper functions to construct `gsemiring` and `gcomm_semiring`
 instances for:
 
 * `A : ι → submonoid S`:
-  `direct_sum.ghas_one.of_add_submonoids`, `direct_sum.ghas_mul.of_add_submonoids`,
-  `direct_sum.gmonoid.of_add_submonoids`, `direct_sum.gcomm_monoid.of_add_submonoids`.
+  `direct_sum.gsemiring.of_add_submonoids`, `direct_sum.gcomm_semiring.of_add_submonoids`.
 * `A : ι → subgroup S`:
-  `direct_sum.ghas_one.of_add_subgroups`, `direct_sum.ghas_mul.of_add_subgroups`,
-  `direct_sum.gmonoid.of_add_subgroups`, `direct_sum.gcomm_monoid.of_add_subgroups`.
+  `direct_sum.gsemiring.of_add_subgroups`, `direct_sum.gcomm_semiring.of_add_subgroups`.
 * `A : ι → submodule S`:
-  `direct_sum.ghas_one.of_submodules`, `direct_sum.ghas_mul.of_submodules`,
-  `direct_sum.gmonoid.of_submodules`, `direct_sum.gcomm_monoid.of_submodules`.
+  `direct_sum.gsemiring.of_submodules`, `direct_sum.gcomm_semiring.of_submodules`.
 
 If `complete_lattice.independent (set.range A)`, these provide a gradation of `⨆ i, A i`, and the
 mapping `⨁ i, A i →+ ⨆ i, A i` can be obtained as
@@ -71,6 +65,9 @@ mapping `⨁ i, A i →+ ⨆ i, A i` can be obtained as
 
 graded ring, filtered ring, direct sum, add_submonoid
 -/
+
+set_option old_structure_cmd true
+
 variables {ι : Type*} [decidable_eq ι]
 
 namespace direct_sum
@@ -82,27 +79,13 @@ section defs
 
 variables (A : ι → Type*)
 
-/-- A graded version of `has_one`, which must be of grade 0. -/
-class ghas_one [has_zero ι] :=
-(one : A 0)
-
-/-- A graded version of `has_mul` that also subsumes `non_unital_non_assoc_semiring` by requiring
-the multiplication be an `add_monoid_hom`. Multiplication combines grades additively, like
-`add_monoid_algebra`. -/
-class ghas_mul [has_add ι] [Π i, add_comm_monoid (A i)] :=
-(mul {i j} : A i →+ A j →+ A (i + j))
-
-variables {A}
-
-/-- `direct_sum.ghas_one` implies a `has_one (Σ i, A i)`, although this is only used as an instance
-locally to define notation in `direct_sum.gmonoid` and similar typeclasses. -/
-def ghas_one.to_sigma_has_one [has_zero ι] [ghas_one A] : has_one (Σ i, A i) := ⟨⟨_, ghas_one.one⟩⟩
-
-/-- `direct_sum.ghas_mul` implies a `has_mul (Σ i, A i)`, although this is only used as an instance
-locally to define notation in `direct_sum.gmonoid` and similar typeclasses. -/
-def ghas_mul.to_sigma_has_mul [has_add ι] [Π i, add_comm_monoid (A i)] [ghas_mul A] :
-  has_mul (Σ i, A i) :=
-⟨λ (x y : Σ i, A i), ⟨_, ghas_mul.mul x.snd y.snd⟩⟩
+/-- A graded version of `non_unital_non_assoc_semiring`. -/
+class gnon_unital_non_assoc_semiring [has_add ι] [Π i, add_comm_monoid (A i)] extends
+  graded_monoid.ghas_mul A :=
+(mul_zero : ∀ {i j} (a : A i), mul a (0 : A j) = 0)
+(zero_mul : ∀ {i j} (b : A j), mul (0 : A i) b = 0)
+(mul_add : ∀ {i j} (a : A i) (b c : A j), mul a (b + c) = mul a b + mul a c)
+(add_mul : ∀ {i j} (a b : A i) (c : A j), mul (a + b) c = mul a c + mul b c)
 
 end defs
 
@@ -110,18 +93,13 @@ section defs
 
 variables (A : ι → Type*)
 
-local attribute [instance] ghas_one.to_sigma_has_one
-local attribute [instance] ghas_mul.to_sigma_has_mul
+/-- A graded version of `semiring`. -/
+class gsemiring [add_monoid ι] [Π i, add_comm_monoid (A i)] extends
+  gnon_unital_non_assoc_semiring A, graded_monoid.gmonoid A
 
-/-- A graded version of `monoid`. -/
-class gmonoid [add_monoid ι] [Π i, add_comm_monoid (A i)] extends ghas_mul A, ghas_one A :=
-(one_mul (a : Σ i, A i) : 1 * a = a)
-(mul_one (a : Σ i, A i) : a * 1 = a)
-(mul_assoc (a : Σ i, A i) (b : Σ i, A i) (c : Σ i, A i) : a * b * c = a * (b * c))
-
-/-- A graded version of `comm_monoid`. -/
-class gcomm_monoid [add_comm_monoid ι] [Π i, add_comm_monoid (A i)] extends gmonoid A :=
-(mul_comm (a : Σ i, A i) (b : Σ i, A i) : a * b = b * a)
+/-- A graded version of `comm_semiring`. -/
+class gcomm_semiring [add_comm_monoid ι] [Π i, add_comm_monoid (A i)] extends
+  gsemiring A, graded_monoid.gcomm_monoid A
 
 end defs
 
@@ -133,148 +111,68 @@ variables {R : Type*}
 
 /-! #### From `add_submonoid`s -/
 
-/-- Build a `ghas_one` instance for a collection of `add_submonoid`s. -/
-@[simps one]
-def ghas_one.of_add_submonoids [semiring R] [has_zero ι]
-  (carriers : ι → add_submonoid R)
-  (one_mem : (1 : R) ∈ carriers 0) :
-  ghas_one (λ i, carriers i) :=
-{ one := ⟨1, one_mem⟩ }
-
--- `@[simps]` doesn't generate a useful lemma, so we state one manually below.
-/-- Build a `ghas_mul` instance for a collection of `add_submonoids`. -/
-def ghas_mul.of_add_submonoids [semiring R] [has_add ι]
-  (carriers : ι → add_submonoid R)
-  (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : R) ∈ carriers (i + j)) :
-  ghas_mul (λ i, carriers i) :=
-{ mul := λ i j,
-  { to_fun := λ a,
-    { to_fun := λ b, ⟨(a * b : R), mul_mem a b⟩,
-      map_add' := λ _ _, subtype.ext (mul_add _ _ _),
-      map_zero' := subtype.ext (mul_zero _), },
-    map_add' := λ _ _, add_monoid_hom.ext $ λ _, subtype.ext (add_mul _ _ _),
-    map_zero' := add_monoid_hom.ext $ λ _, subtype.ext (zero_mul _) }, }
-
--- `@[simps]` doesn't generate this well
-@[simp] lemma ghas_mul.of_add_submonoids_mul [semiring R] [has_add ι]
-  (carriers : ι → add_submonoid R) (mul_mem) {i j} (a : carriers i) (b : carriers j) :
-  @ghas_mul.mul _ _ _ _ _ (ghas_mul.of_add_submonoids carriers mul_mem) i j a b =
-    ⟨a * b, mul_mem a b⟩ := rfl
-
-/-- Build a `gmonoid` instance for a collection of `add_submonoid`s. -/
-@[simps to_ghas_one to_ghas_mul]
-def gmonoid.of_add_submonoids [semiring R] [add_monoid ι]
+/-- Build a `gsemiring` instance for a collection of `add_submonoid`s. -/
+def gsemiring.of_add_submonoids [semiring R] [add_monoid ι]
   (carriers : ι → add_submonoid R)
   (one_mem : (1 : R) ∈ carriers 0)
   (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : R) ∈ carriers (i + j)) :
-  gmonoid (λ i, carriers i) :=
-{ one_mul := λ ⟨i, a, h⟩, sigma.subtype_ext (zero_add _) (one_mul _),
-  mul_one := λ ⟨i, a, h⟩, sigma.subtype_ext (add_zero _) (mul_one _),
-  mul_assoc := λ ⟨i, a, ha⟩ ⟨j, b, hb⟩ ⟨k, c, hc⟩,
-    sigma.subtype_ext (add_assoc _ _ _) (mul_assoc _ _ _),
-  ..ghas_one.of_add_submonoids carriers one_mem,
-  ..ghas_mul.of_add_submonoids carriers mul_mem }
+  gsemiring (λ i, carriers i) :=
+{ mul_zero := λ i j _, subtype.ext (mul_zero _),
+  zero_mul := λ i j _, subtype.ext (zero_mul _),
+  mul_add := λ i j _ _ _, subtype.ext (mul_add _ _ _),
+  add_mul := λ i j _ _ _, subtype.ext (add_mul _ _ _),
+  ..graded_monoid.gmonoid.of_subobjects carriers one_mem mul_mem }
 
-/-- Build a `gcomm_monoid` instance for a collection of `add_submonoid`s. -/
-@[simps to_gmonoid]
-def gcomm_monoid.of_add_submonoids [comm_semiring R] [add_comm_monoid ι]
+/-- Build a `gcomm_semiring` instance for a collection of `add_submonoid`s. -/
+def gcomm_semiring.of_add_submonoids [comm_semiring R] [add_comm_monoid ι]
   (carriers : ι → add_submonoid R)
   (one_mem : (1 : R) ∈ carriers 0)
   (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : R) ∈ carriers (i + j)) :
-  gcomm_monoid (λ i, carriers i) :=
-{ mul_comm := λ ⟨i, a, ha⟩ ⟨j, b, hb⟩, sigma.subtype_ext (add_comm _ _) (mul_comm _ _),
-  ..gmonoid.of_add_submonoids carriers one_mem mul_mem}
+  gcomm_semiring (λ i, carriers i) :=
+{ ..graded_monoid.gcomm_monoid.of_subobjects carriers one_mem mul_mem,
+  ..gsemiring.of_add_submonoids carriers one_mem mul_mem}
 
 /-! #### From `add_subgroup`s -/
 
-/-- Build a `ghas_one` instance for a collection of `add_subgroup`s. -/
-@[simps one]
-def ghas_one.of_add_subgroups [ring R] [has_zero ι]
-  (carriers : ι → add_subgroup R)
-  (one_mem : (1 : R) ∈ carriers 0) :
-  ghas_one (λ i, carriers i) :=
-ghas_one.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem
-
--- `@[simps]` doesn't generate a useful lemma, so we state one manually below.
-/-- Build a `ghas_mul` instance for a collection of `add_subgroup`s. -/
-def ghas_mul.of_add_subgroups [ring R] [has_add ι]
-  (carriers : ι → add_subgroup R)
-  (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : R) ∈ carriers (i + j)) :
-  ghas_mul (λ i, carriers i) :=
-ghas_mul.of_add_submonoids (λ i, (carriers i).to_add_submonoid) mul_mem
-
--- `@[simps]` doesn't generate this well
-@[simp] lemma ghas_mul.of_add_subgroups_mul [ring R] [has_add ι]
-  (carriers : ι → add_subgroup R) (mul_mem) {i j} (a : carriers i) (b : carriers j) :
-  @ghas_mul.mul _ _ _ _ _ (ghas_mul.of_add_subgroups carriers mul_mem) i j a b =
-    ⟨a * b, mul_mem a b⟩ := rfl
-
-/-- Build a `gmonoid` instance for a collection of `add_subgroup`s. -/
-@[simps to_ghas_one to_ghas_mul]
-def gmonoid.of_add_subgroups [ring R] [add_monoid ι]
+/-- Build a `gsemiring` instance for a collection of `add_subgroup`s. -/
+def gsemiring.of_add_subgroups [ring R] [add_monoid ι]
   (carriers : ι → add_subgroup R)
   (one_mem : (1 : R) ∈ carriers 0)
   (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : R) ∈ carriers (i + j)) :
-  gmonoid (λ i, carriers i) :=
-gmonoid.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem mul_mem
+  gsemiring (λ i, carriers i) :=
+gsemiring.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem mul_mem
 
-/-- Build a `gcomm_monoid` instance for a collection of `add_subgroup`s. -/
-@[simps to_gmonoid]
-def gcomm_monoid.of_add_subgroups [comm_ring R] [add_comm_monoid ι]
+/-- Build a `gcomm_semiring` instance for a collection of `add_subgroup`s. -/
+def gcomm_semiring.of_add_subgroups [comm_ring R] [add_comm_monoid ι]
   (carriers : ι → add_subgroup R)
   (one_mem : (1 : R) ∈ carriers 0)
   (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : R) ∈ carriers (i + j)) :
-  gcomm_monoid (λ i, carriers i) :=
-gcomm_monoid.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem mul_mem
+  gcomm_semiring (λ i, carriers i) :=
+gcomm_semiring.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem mul_mem
 
 /-! #### From `submodules`s -/
 
 variables {A : Type*}
 
-/-- Build a `ghas_one` instance for a collection of `submodule`s. -/
-@[simps one]
-def ghas_one.of_submodules
-  [comm_semiring R] [semiring A] [algebra R A] [has_zero ι]
-  (carriers : ι → submodule R A)
-  (one_mem : (1 : A) ∈ carriers 0) :
-  ghas_one (λ i, carriers i) :=
-ghas_one.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem
-
--- `@[simps]` doesn't generate a useful lemma, so we state one manually below.
-/-- Build a `ghas_mul` instance for a collection of `submodule`s. -/
-def ghas_mul.of_submodules
-  [comm_semiring R] [semiring A] [algebra R A] [has_add ι]
-  (carriers : ι → submodule R A)
-  (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : A) ∈ carriers (i + j)) :
-  ghas_mul (λ i, carriers i) :=
-ghas_mul.of_add_submonoids (λ i, (carriers i).to_add_submonoid) mul_mem
-
--- `@[simps]` doesn't generate this well
-@[simp] lemma ghas_mul.of_submodules_mul
-  [comm_semiring R] [semiring A] [algebra R A] [has_add ι]
-  (carriers : ι → submodule R A) (mul_mem) {i j} (a : carriers i) (b : carriers j) :
-  @ghas_mul.mul _ _ _ _ _ (ghas_mul.of_submodules carriers mul_mem) i j a b =
-    ⟨a * b, mul_mem a b⟩ := rfl
-
-/-- Build a `gmonoid` instance for a collection of `submodules`s. -/
-@[simps to_ghas_one to_ghas_mul]
-def gmonoid.of_submodules
+/-- Build a `gsemiring` instance for a collection of `submodules`s. -/
+@[simps one mul]
+def gsemiring.of_submodules
   [comm_semiring R] [semiring A] [algebra R A] [add_monoid ι]
   (carriers : ι → submodule R A)
   (one_mem : (1 : A) ∈ carriers 0)
   (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : A) ∈ carriers (i + j)) :
-  gmonoid (λ i, carriers i) :=
-gmonoid.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem mul_mem
+  gsemiring (λ i, carriers i) :=
+gsemiring.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem mul_mem
 
-/-- Build a `gcomm_monoid` instance for a collection of `submodules`s. -/
-@[simps to_gmonoid]
-def gcomm_monoid.of_submodules
+/-- Build a `gcomm_semiring` instance for a collection of `submodules`s. -/
+@[simps one mul]
+def gcomm_semiring.of_submodules
   [comm_semiring R] [comm_semiring A] [algebra R A] [add_comm_monoid ι]
   (carriers : ι → submodule R A)
   (one_mem : (1 : A) ∈ carriers 0)
   (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : A) ∈ carriers (i + j)) :
-  gcomm_monoid (λ i, carriers i) :=
-gcomm_monoid.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem mul_mem
+  gcomm_semiring (λ i, carriers i) :=
+gcomm_semiring.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem mul_mem
 
 end shorthands
 
@@ -284,23 +182,33 @@ variables (A : ι → Type*)
 
 
 section one
-variables [has_zero ι] [ghas_one A] [Π i, add_comm_monoid (A i)]
+variables [has_zero ι] [graded_monoid.ghas_one A] [Π i, add_comm_monoid (A i)]
 
 instance : has_one (⨁ i, A i) :=
-{ one := direct_sum.of (λ i, A i) 0 ghas_one.one}
+{ one := direct_sum.of (λ i, A i) 0 graded_monoid.ghas_one.one}
 
 end one
 
 section mul
-variables [has_add ι] [Π i, add_comm_monoid (A i)] [ghas_mul A]
+variables [has_add ι] [Π i, add_comm_monoid (A i)] [gnon_unital_non_assoc_semiring A]
 
 open add_monoid_hom (map_zero map_add flip_apply coe_comp comp_hom_apply_apply)
+
+/-- The piecewise multiplication from the `has_mul` instance, as a bundled homomorphism. -/
+@[simps]
+def gmul_hom {i j} : A i →+ A j →+ A (i + j) :=
+{ to_fun := λ a,
+  { to_fun := λ b, graded_monoid.ghas_mul.mul a b,
+    map_zero' := gnon_unital_non_assoc_semiring.mul_zero _,
+    map_add' := gnon_unital_non_assoc_semiring.mul_add _ },
+  map_zero' := add_monoid_hom.ext $ λ a, gnon_unital_non_assoc_semiring.zero_mul a,
+  map_add' := λ a₁ a₂, add_monoid_hom.ext $ λ b, gnon_unital_non_assoc_semiring.add_mul _ _ _}
 
 /-- The multiplication from the `has_mul` instance, as a bundled homomorphism. -/
 def mul_hom : (⨁ i, A i) →+ (⨁ i, A i) →+ ⨁ i, A i :=
 direct_sum.to_add_monoid $ λ i,
   add_monoid_hom.flip $ direct_sum.to_add_monoid $ λ j, add_monoid_hom.flip $
-    (direct_sum.of A _).comp_hom.comp ghas_mul.mul
+    (direct_sum.of A _).comp_hom.comp $ gmul_hom A
 
 instance : non_unital_non_assoc_semiring (⨁ i, A i) :=
 { mul := λ a b, mul_hom A a b,
@@ -315,21 +223,21 @@ instance : non_unital_non_assoc_semiring (⨁ i, A i) :=
 variables {A}
 
 lemma mul_hom_of_of {i j} (a : A i) (b : A j) :
-  mul_hom A (of _ i a) (of _ j b) = of _ (i + j) (ghas_mul.mul a b) :=
+  mul_hom A (of _ i a) (of _ j b) = of _ (i + j) (graded_monoid.ghas_mul.mul a b) :=
 begin
   unfold mul_hom,
   rw [to_add_monoid_of, flip_apply, to_add_monoid_of, flip_apply, coe_comp, function.comp_app,
-      comp_hom_apply_apply, coe_comp, function.comp_app],
+      comp_hom_apply_apply, coe_comp, function.comp_app, gmul_hom_apply_apply],
 end
 
 lemma of_mul_of {i j} (a : A i) (b : A j) :
-  of _ i a * of _ j b = of _ (i + j) (ghas_mul.mul a b) :=
+  of _ i a * of _ j b = of _ (i + j) (graded_monoid.ghas_mul.mul a b) :=
 mul_hom_of_of a b
 
 end mul
 
 section semiring
-variables [Π i, add_comm_monoid (A i)] [add_monoid ι] [gmonoid A]
+variables [Π i, add_comm_monoid (A i)] [add_monoid ι] [gsemiring A]
 
 open add_monoid_hom (flip_hom coe_comp comp_hom_apply_apply flip_apply flip_hom_apply)
 
@@ -340,7 +248,7 @@ begin
   apply add_hom_ext, intros i xi,
   unfold has_one.one,
   rw mul_hom_of_of,
-  exact dfinsupp.single_eq_of_sigma_eq (gmonoid.one_mul ⟨i, xi⟩),
+  exact dfinsupp.single_eq_of_sigma_eq (gsemiring.one_mul ⟨i, xi⟩),
 end
 
 private lemma mul_one (x : ⨁ i, A i) : x * 1 = x :=
@@ -350,7 +258,7 @@ begin
   apply add_hom_ext, intros i xi,
   unfold has_one.one,
   rw [flip_apply, mul_hom_of_of],
-  exact dfinsupp.single_eq_of_sigma_eq (gmonoid.mul_one ⟨i, xi⟩),
+  exact dfinsupp.single_eq_of_sigma_eq (gsemiring.mul_one ⟨i, xi⟩),
 end
 
 private lemma mul_assoc (a b c : ⨁ i, A i) : a * b * c = a * (b * c) :=
@@ -362,10 +270,10 @@ begin
   ext ai ax bi bx ci cx : 6,
   dsimp only [coe_comp, function.comp_app, comp_hom_apply_apply, flip_apply, flip_hom_apply],
   rw [mul_hom_of_of, mul_hom_of_of, mul_hom_of_of, mul_hom_of_of],
-  exact dfinsupp.single_eq_of_sigma_eq (gmonoid.mul_assoc ⟨ai, ax⟩ ⟨bi, bx⟩ ⟨ci, cx⟩),
+  exact dfinsupp.single_eq_of_sigma_eq (gsemiring.mul_assoc ⟨ai, ax⟩ ⟨bi, bx⟩ ⟨ci, cx⟩),
 end
 
-/-- The `semiring` structure derived from `gmonoid A`. -/
+/-- The `semiring` structure derived from `gsemiring A`. -/
 instance semiring : semiring (⨁ i, A i) := {
   one := 1,
   mul := (*),
@@ -380,7 +288,7 @@ end semiring
 
 section comm_semiring
 
-variables [Π i, add_comm_monoid (A i)] [add_comm_monoid ι] [gcomm_monoid A]
+variables [Π i, add_comm_monoid (A i)] [add_comm_monoid ι] [gcomm_semiring A]
 
 private lemma mul_comm (a b : ⨁ i, A i) : a * b = b * a :=
 suffices mul_hom A = (mul_hom A).flip,
@@ -388,10 +296,10 @@ suffices mul_hom A = (mul_hom A).flip,
 begin
   apply add_hom_ext, intros ai ax, apply add_hom_ext, intros bi bx,
   rw [add_monoid_hom.flip_apply, mul_hom_of_of, mul_hom_of_of],
-  exact dfinsupp.single_eq_of_sigma_eq (gcomm_monoid.mul_comm ⟨ai, ax⟩ ⟨bi, bx⟩),
+  exact dfinsupp.single_eq_of_sigma_eq (gcomm_semiring.mul_comm ⟨ai, ax⟩ ⟨bi, bx⟩),
 end
 
-/-- The `comm_semiring` structure derived from `gcomm_monoid A`. -/
+/-- The `comm_semiring` structure derived from `gcomm_semiring A`. -/
 instance comm_semiring : comm_semiring (⨁ i, A i) := {
   one := 1,
   mul := (*),
@@ -403,9 +311,9 @@ instance comm_semiring : comm_semiring (⨁ i, A i) := {
 end comm_semiring
 
 section ring
-variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gmonoid A]
+variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gsemiring A]
 
-/-- The `ring` derived from `gmonoid A`. -/
+/-- The `ring` derived from `gsemiring A`. -/
 instance ring : ring (⨁ i, A i) := {
   one := 1,
   mul := (*),
@@ -419,9 +327,9 @@ instance ring : ring (⨁ i, A i) := {
 end ring
 
 section comm_ring
-variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gcomm_monoid A]
+variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gcomm_semiring A]
 
-/-- The `comm_ring` derived from `gcomm_monoid A`. -/
+/-- The `comm_ring` derived from `gcomm_semiring A`. -/
 instance comm_ring : comm_ring (⨁ i, A i) := {
   one := 1,
   mul := (*),
@@ -443,42 +351,17 @@ types of multiplicative structure.
 section grade_zero
 
 section one
-variables [has_zero ι] [ghas_one A] [Π i, add_comm_monoid (A i)]
-
-/-- `1 : A 0` is the value provided in `direct_sum.ghas_one.one`. -/
-@[nolint unused_arguments]
-instance grade_zero.has_one : has_one (A 0) :=
-⟨ghas_one.one⟩
+variables [has_zero ι] [graded_monoid.ghas_one A] [Π i, add_comm_monoid (A i)]
 
 @[simp] lemma of_zero_one : of _ 0 (1 : A 0) = 1 := rfl
 
 end one
 
 section mul
-variables [add_monoid ι] [Π i, add_comm_monoid (A i)] [ghas_mul A]
-
-/-- `(•) : A 0 → A i → A i` is the value provided in `direct_sum.ghas_mul.mul`, composed with
-an `eq.rec` to turn `A (0 + i)` into `A i`.
--/
-instance grade_zero.has_scalar (i : ι) : has_scalar (A 0) (A i) :=
-{ smul := λ x y, (zero_add i).rec (ghas_mul.mul x y) }
-
-/-- `(*) : A 0 → A 0 → A 0` is the value provided in `direct_sum.ghas_mul.mul`, composed with
-an `eq.rec` to turn `A (0 + 0)` into `A 0`.
--/
-instance grade_zero.has_mul : has_mul (A 0) :=
-{ mul := (•) }
-
-@[simp]lemma grade_zero.smul_eq_mul (a b : A 0) : a • b = a * b := rfl
+variables [add_monoid ι] [Π i, add_comm_monoid (A i)] [gnon_unital_non_assoc_semiring A]
 
 @[simp] lemma of_zero_smul {i} (a : A 0) (b : A i) : of _ _ (a • b) = of _ _ a * of _ _ b :=
-begin
-  rw of_mul_of,
-  dsimp [has_mul.mul, direct_sum.of, dfinsupp.single_add_hom_apply],
-  congr' 1,
-  rw zero_add,
-  apply eq_rec_heq,
-end
+(dfinsupp.single_eq_of_sigma_eq (graded_monoid.mk_zero_smul a b)).trans (of_mul_of _ _).symm
 
 @[simp] lemma of_zero_mul (a b : A 0) : of _ 0 (a * b) = of _ 0 a * of _ 0 b:=
 of_zero_smul A a b
@@ -496,9 +379,9 @@ end
 end mul
 
 section semiring
-variables [Π i, add_comm_monoid (A i)] [add_monoid ι] [gmonoid A]
+variables [Π i, add_comm_monoid (A i)] [add_monoid ι] [gsemiring A]
 
-/-- The `semiring` structure derived from `gmonoid A`. -/
+/-- The `semiring` structure derived from `gsemiring A`. -/
 instance grade_zero.semiring : semiring (A 0) :=
 function.injective.semiring (of A 0) dfinsupp.single_injective
   (of A 0).map_zero (of_zero_one A) (of A 0).map_add (of_zero_mul A)
@@ -507,7 +390,7 @@ function.injective.semiring (of A 0) dfinsupp.single_injective
 def of_zero_ring_hom : A 0 →+* (⨁ i, A i) :=
 { map_one' := of_zero_one A, map_mul' := of_zero_mul A, ..(of _ 0) }
 
-/-- Each grade `A i` derives a `A 0`-module structure from `gmonoid A`. Note that this results
+/-- Each grade `A i` derives a `A 0`-module structure from `gsemiring A`. Note that this results
 in an overall `module (A 0) (⨁ i, A i)` structure via `direct_sum.module`.
 -/
 instance grade_zero.module {i} : module (A 0) (A i) :=
@@ -520,9 +403,9 @@ end semiring
 
 section comm_semiring
 
-variables [Π i, add_comm_monoid (A i)] [add_comm_monoid ι] [gcomm_monoid A]
+variables [Π i, add_comm_monoid (A i)] [add_comm_monoid ι] [gcomm_semiring A]
 
-/-- The `comm_semiring` structure derived from `gcomm_monoid A`. -/
+/-- The `comm_semiring` structure derived from `gcomm_semiring A`. -/
 instance grade_zero.comm_semiring : comm_semiring (A 0) :=
 function.injective.comm_semiring (of A 0) dfinsupp.single_injective
   (of A 0).map_zero (of_zero_one A) (of A 0).map_add (of_zero_mul A)
@@ -530,9 +413,9 @@ function.injective.comm_semiring (of A 0) dfinsupp.single_injective
 end comm_semiring
 
 section ring
-variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gmonoid A]
+variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gsemiring A]
 
-/-- The `ring` derived from `gmonoid A`. -/
+/-- The `ring` derived from `gsemiring A`. -/
 instance grade_zero.ring : ring (A 0) :=
 function.injective.ring (of A 0) dfinsupp.single_injective
   (of A 0).map_zero (of_zero_one A) (of A 0).map_add (of_zero_mul A)
@@ -541,9 +424,9 @@ function.injective.ring (of A 0) dfinsupp.single_injective
 end ring
 
 section comm_ring
-variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gcomm_monoid A]
+variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gcomm_semiring A]
 
-/-- The `comm_ring` derived from `gcomm_monoid A`. -/
+/-- The `comm_ring` derived from `gcomm_semiring A`. -/
 instance grade_zero.comm_ring : comm_ring (A 0) :=
 function.injective.comm_ring (of A 0) dfinsupp.single_injective
   (of A 0).map_zero (of_zero_one A) (of A 0).map_add (of_zero_mul A)
@@ -555,7 +438,7 @@ end grade_zero
 
 section to_semiring
 
-variables {R : Type*} [Π i, add_comm_monoid (A i)] [add_monoid ι] [gmonoid A] [semiring R]
+variables {R : Type*} [Π i, add_comm_monoid (A i)] [add_monoid ι] [gsemiring A] [semiring R]
 variables {A}
 
 /-- If two ring homomorphisms from `⨁ i, A i` are equal on each `of A i y`,
@@ -571,13 +454,13 @@ ring_hom.coe_add_monoid_hom_injective $ direct_sum.add_hom_ext' h
 describes a `ring_hom`s on `⨁ i, A i`. This is a stronger version of `direct_sum.to_monoid`.
 
 Of particular interest is the case when `A i` are bundled subojects, `f` is the family of
-coercions such as `add_submonoid.subtype (A i)`, and the `[gmonoid A]` structure originates from
-`direct_sum.gmonoid.of_add_submonoids`, in which case the proofs about `ghas_one` and `ghas_mul`
+coercions such as `add_submonoid.subtype (A i)`, and the `[gsemiring A]` structure originates from
+`direct_sum.gsemiring.of_add_submonoids`, in which case the proofs about `ghas_one` and `ghas_mul`
 can be discharged by `rfl`. -/
 @[simps]
 def to_semiring
-  (f : Π i, A i →+ R) (hone : f _ (ghas_one.one) = 1)
-  (hmul : ∀ {i j} (ai : A i) (aj : A j), f _ (ghas_mul.mul ai aj) = f _ ai * f _ aj) :
+  (f : Π i, A i →+ R) (hone : f _ (graded_monoid.ghas_one.one) = 1)
+  (hmul : ∀ {i j} (ai : A i) (aj : A j), f _ (graded_monoid.ghas_mul.mul ai aj) = f _ ai * f _ aj) :
   (⨁ i, A i) →+* R :=
 { to_fun := to_add_monoid f,
   map_one' := begin
@@ -608,8 +491,8 @@ are isomorphic to `ring_hom`s on `⨁ i, A i`. This is a stronger version of `df
 @[simps]
 def lift_ring_hom :
   {f : Π {i}, A i →+ R //
-    f (ghas_one.one) = 1 ∧
-    ∀ {i j} (ai : A i) (aj : A j), f (ghas_mul.mul ai aj) = f ai * f aj} ≃
+    f (graded_monoid.ghas_one.one) = 1 ∧
+    ∀ {i j} (ai : A i) (aj : A j), f (graded_monoid.ghas_mul.mul ai aj) = f ai * f aj} ≃
     ((⨁ i, A i) →+* R) :=
 { to_fun := λ f, to_semiring f.1 f.2.1 f.2.2,
   inv_fun := λ F,
@@ -649,48 +532,56 @@ end direct_sum
 
 /-! ### Concrete instances -/
 
-/-- A direct sum of copies of a `semiring` inherits the multiplication structure. -/
-instance semiring.direct_sum_gmonoid {R : Type*} [add_monoid ι] [semiring R] :
-  direct_sum.gmonoid (λ i : ι, R) :=
-{ mul := λ i j, add_monoid_hom.mul,
-  one_mul := λ a, sigma.ext (zero_add _) (heq_of_eq (one_mul _)),
-  mul_one := λ a, sigma.ext (add_zero _) (heq_of_eq (mul_one _)),
-  mul_assoc := λ a b c, sigma.ext (add_assoc _ _ _) (heq_of_eq (mul_assoc _ _ _)),
-  one := 1 }
+section uniform
 
-@[simp] lemma semiring.direct_sum_mul {R : Type*} [add_monoid ι] [semiring R] {i j} (x y : R) :
-  @direct_sum.ghas_mul.mul _ _ (λ _ : ι, R) _ _ _ i j x y = x * y := rfl
+variables (ι)
+
+/-- A direct sum of copies of a `semiring` inherits the multiplication structure. -/
+instance non_unital_non_assoc_semiring.direct_sum_gnon_unital_non_assoc_semiring
+  {R : Type*} [add_monoid ι] [non_unital_non_assoc_semiring R] :
+  direct_sum.gnon_unital_non_assoc_semiring (λ i : ι, R) :=
+{ mul_zero := λ i j, mul_zero,
+  zero_mul := λ i j, zero_mul,
+  mul_add := λ i j, mul_add,
+  add_mul := λ i j, add_mul,
+  ..has_mul.ghas_mul ι }
+
+/-- A direct sum of copies of a `semiring` inherits the multiplication structure. -/
+instance semiring.direct_sum_gsemiring {R : Type*} [add_monoid ι] [semiring R] :
+  direct_sum.gsemiring (λ i : ι, R) :=
+{ ..non_unital_non_assoc_semiring.direct_sum_gnon_unital_non_assoc_semiring ι, ..monoid.gmonoid ι }
 
 open_locale direct_sum
 
--- To check the lemma above does match
+-- To check `has_mul.ghas_mul_mul` matches
 example {R : Type*} [add_monoid ι] [semiring R] (i j : ι) (a b : R) :
   (direct_sum.of _ i a * direct_sum.of _ j b : ⨁ i, R) = direct_sum.of _ (i + j) (by exact a * b) :=
-by rw [direct_sum.of_mul_of, semiring.direct_sum_mul]
+by rw [direct_sum.of_mul_of, has_mul.ghas_mul_mul]
 
 /-- A direct sum of copies of a `comm_semiring` inherits the commutative multiplication structure.
 -/
-instance comm_semiring.direct_sum_gcomm_monoid {R : Type*} [add_comm_monoid ι] [comm_semiring R] :
-  direct_sum.gcomm_monoid (λ i : ι, R) :=
-{ mul_comm := λ a b, sigma.ext (add_comm _ _) (heq_of_eq (mul_comm _ _)),
-  .. semiring.direct_sum_gmonoid }
+instance comm_semiring.direct_sum_gcomm_semiring {R : Type*} [add_comm_monoid ι] [comm_semiring R] :
+  direct_sum.gcomm_semiring (λ i : ι, R) :=
+{ ..comm_monoid.gcomm_monoid ι, ..semiring.direct_sum_gsemiring ι }
+
+end uniform
 
 namespace submodule
 
 variables {R A : Type*} [comm_semiring R]
 
 /-- A direct sum of powers of a submodule of an algebra has a multiplicative structure. -/
-instance nat_power_direct_sum_gmonoid [semiring A] [algebra R A] (S : submodule R A) :
-  direct_sum.gmonoid (λ i : ℕ, ↥(S ^ i)) :=
-direct_sum.gmonoid.of_submodules _
+instance nat_power_direct_sum_gsemiring [semiring A] [algebra R A] (S : submodule R A) :
+  direct_sum.gsemiring (λ i : ℕ, ↥(S ^ i)) :=
+direct_sum.gsemiring.of_submodules _
   (by { rw [←one_le, pow_zero], exact le_rfl })
   (λ i j p q, by { rw pow_add, exact submodule.mul_mem_mul p.prop q.prop })
 
 /-- A direct sum of powers of a submodule of a commutative algebra has a commutative multiplicative
 structure. -/
-instance nat_power_direct_sum_gcomm_monoid [comm_semiring A] [algebra R A] (S : submodule R A) :
-  direct_sum.gcomm_monoid (λ i : ℕ, ↥(S ^ i)) :=
-direct_sum.gcomm_monoid.of_submodules _
+instance nat_power_direct_sum_gcomm_semiring [comm_semiring A] [algebra R A] (S : submodule R A) :
+  direct_sum.gcomm_semiring (λ i : ℕ, ↥(S ^ i)) :=
+direct_sum.gcomm_semiring.of_submodules _
   (by { rw [←one_le, pow_zero], exact le_rfl })
   (λ i j p q, by { rw pow_add, exact submodule.mul_mem_mul p.prop q.prop })
 

--- a/src/algebra/direct_sum/ring.lean
+++ b/src/algebra/direct_sum/ring.lean
@@ -111,7 +111,10 @@ variables {R : Type*}
 
 /-! #### From `add_submonoid`s -/
 
-/-- Build a `gsemiring` instance for a collection of `add_submonoid`s. -/
+/-- Build a `gsemiring` instance for a collection of `add_submonoid`s.
+
+See note [reducible non-instances]. -/
+@[reducible]
 def gsemiring.of_add_submonoids [semiring R] [add_monoid ι]
   (carriers : ι → add_submonoid R)
   (one_mem : (1 : R) ∈ carriers 0)
@@ -123,7 +126,10 @@ def gsemiring.of_add_submonoids [semiring R] [add_monoid ι]
   add_mul := λ i j _ _ _, subtype.ext (add_mul _ _ _),
   ..graded_monoid.gmonoid.of_subobjects carriers one_mem mul_mem }
 
-/-- Build a `gcomm_semiring` instance for a collection of `add_submonoid`s. -/
+/-- Build a `gcomm_semiring` instance for a collection of `add_submonoid`s.
+
+See note [reducible non-instances]. -/
+@[reducible]
 def gcomm_semiring.of_add_submonoids [comm_semiring R] [add_comm_monoid ι]
   (carriers : ι → add_submonoid R)
   (one_mem : (1 : R) ∈ carriers 0)
@@ -134,7 +140,10 @@ def gcomm_semiring.of_add_submonoids [comm_semiring R] [add_comm_monoid ι]
 
 /-! #### From `add_subgroup`s -/
 
-/-- Build a `gsemiring` instance for a collection of `add_subgroup`s. -/
+/-- Build a `gsemiring` instance for a collection of `add_subgroup`s.
+
+See note [reducible non-instances]. -/
+@[reducible]
 def gsemiring.of_add_subgroups [ring R] [add_monoid ι]
   (carriers : ι → add_subgroup R)
   (one_mem : (1 : R) ∈ carriers 0)
@@ -142,7 +151,10 @@ def gsemiring.of_add_subgroups [ring R] [add_monoid ι]
   gsemiring (λ i, carriers i) :=
 gsemiring.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem mul_mem
 
-/-- Build a `gcomm_semiring` instance for a collection of `add_subgroup`s. -/
+/-- Build a `gcomm_semiring` instance for a collection of `add_subgroup`s.
+
+See note [reducible non-instances]. -/
+@[reducible]
 def gcomm_semiring.of_add_subgroups [comm_ring R] [add_comm_monoid ι]
   (carriers : ι → add_subgroup R)
   (one_mem : (1 : R) ∈ carriers 0)
@@ -154,8 +166,10 @@ gcomm_semiring.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem m
 
 variables {A : Type*}
 
-/-- Build a `gsemiring` instance for a collection of `submodules`s. -/
-@[simps one mul]
+/-- Build a `gsemiring` instance for a collection of `submodules`s.
+
+See note [reducible non-instances]. -/
+@[reducible]
 def gsemiring.of_submodules
   [comm_semiring R] [semiring A] [algebra R A] [add_monoid ι]
   (carriers : ι → submodule R A)
@@ -164,8 +178,10 @@ def gsemiring.of_submodules
   gsemiring (λ i, carriers i) :=
 gsemiring.of_add_submonoids (λ i, (carriers i).to_add_submonoid) one_mem mul_mem
 
-/-- Build a `gcomm_semiring` instance for a collection of `submodules`s. -/
-@[simps one mul]
+/-- Build a `gcomm_semiring` instance for a collection of `submodules`s.
+
+See note [reducible non-instances]. -/
+@[reducible]
 def gcomm_semiring.of_submodules
   [comm_semiring R] [comm_semiring A] [algebra R A] [add_comm_monoid ι]
   (carriers : ι → submodule R A)

--- a/src/algebra/graded_monoid.lean
+++ b/src/algebra/graded_monoid.lean
@@ -1,0 +1,291 @@
+/-
+Copyright (c) 2021 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import algebra.group.inj_surj
+import data.set_like.basic
+import data.sigma.basic
+import group_theory.group_action.defs
+
+/-!
+# Additively-graded multiplicative structures
+
+This module provides a set of heterogeneous typeclasses for defining a multiplicative structure
+over the sigma type `graded_monoid A` such that `(*) : A i → A j → A (i + j)`; that is to say, `A`
+forms an additively-graded monoid. The typeclasses are:
+
+* `graded_monoid.ghas_one A`
+* `graded_monoid.ghas_mul A`
+* `graded_monoid.gmonoid A`
+* `graded_monoid.gcomm_monoid A`
+
+With the `sigma_graded` locale open, these respectively imbue:
+
+* `has_one (graded_monoid A)`
+* `has_mul (graded_monoid A)`
+* `monoid (graded_monoid A)`
+* `comm_monoid (graded_monoid A)`
+
+the base type `A 0` with:
+
+* `graded_monoid.grade_zero.has_one`
+* `graded_monoid.grade_zero.has_mul`
+* `graded_monoid.grade_zero.monoid`
+* `graded_monoid.grade_zero.comm_monoid`
+
+and the `i`th grade `A i` with `A 0`-actions (`•`) defined as left-multiplication:
+
+* (nothing)
+* `graded_monoid.grade_zero.has_scalar (A 0)`
+* `graded_monoid.grade_zero.mul_action (A 0)`
+* (nothing)
+
+For now, these typeclasses are primarily used in the construction of `direct_sum.ring` and the rest
+of that file.
+
+## Indexed subobjects
+
+Additionally, this module provides helper functions to construct `gmonoid` and `gcomm_monoid`
+instances for collections of subobjects:
+
+* `ghas_one.of_add_subobjects`
+* `ghas_mul.of_add_subobjects`
+* `gmonoid.of_add_subobjects`
+* `gcomm_monoid.of_add_subobjects`
+
+## tags
+
+graded monoid
+-/
+
+set_option old_structure_cmd true
+
+variables {ι : Type*}
+
+/-- A type alias of sigma types for graded monoids. -/
+def graded_monoid (A : ι → Type*) := sigma A
+
+namespace graded_monoid
+
+instance {A : ι → Type*} [inhabited ι] [inhabited (A (default ι))]: inhabited (graded_monoid A) :=
+sigma.inhabited
+
+/-- Construct an element of a graded monoid. -/
+def mk {A : ι → Type*} : Π i, A i → graded_monoid A := sigma.mk
+
+/-! ### Typeclasses -/
+section defs
+
+variables (A : ι → Type*)
+
+/-- A graded version of `has_one`, which must be of grade 0. -/
+class ghas_one [has_zero ι] :=
+(one : A 0)
+
+/-- `ghas_one` implies `has_one (graded_monoid A)` -/
+instance ghas_one.to_has_one [has_zero ι] [ghas_one A] : has_one (graded_monoid A) :=
+⟨⟨_, ghas_one.one⟩⟩
+
+/-- A graded version of `has_mul`. Multiplication combines grades additively, like
+`add_monoid_algebra`. -/
+class ghas_mul [has_add ι] :=
+(mul {i j} : A i → A j → A (i + j))
+
+/-- `ghas_mul` implies `has_mul (graded_monoid A)`. -/
+instance ghas_mul.to_has_mul [has_add ι] [ghas_mul A] :
+  has_mul (graded_monoid A) :=
+⟨λ (x y : graded_monoid A), ⟨_, ghas_mul.mul x.snd y.snd⟩⟩
+
+lemma mk_mul_mk [has_add ι] [ghas_mul A] {i j} (a : A i) (b : A j) :
+  mk i a * mk j b = mk (i + j) (ghas_mul.mul a b) :=
+rfl
+
+/-- A graded version of `monoid`. -/
+class gmonoid [add_monoid ι]  extends ghas_mul A, ghas_one A :=
+(one_mul (a : graded_monoid A) : 1 * a = a)
+(mul_one (a : graded_monoid A) : a * 1 = a)
+(mul_assoc (a b c : graded_monoid A) : a * b * c = a * (b * c))
+
+/-- `gmonoid` implies a `monoid (graded_monoid A)`. -/
+instance gmonoid.to_monoid [add_monoid ι] [gmonoid A] :
+  monoid (graded_monoid A) :=
+{ one := (1), mul := (*),
+  one_mul := gmonoid.one_mul, mul_one := gmonoid.mul_one, mul_assoc := gmonoid.mul_assoc }
+
+/-- A graded version of `comm_monoid`. -/
+class gcomm_monoid [add_comm_monoid ι] extends gmonoid A :=
+(mul_comm (a : graded_monoid A) (b : graded_monoid A) : a * b = b * a)
+
+/-- `gcomm_monoid` implies a `comm_monoid (graded_monoid A)`, although this is only used as an
+instance locally to define notation in `gmonoid` and similar typeclasses. -/
+instance gcomm_monoid.to_comm_monoid [add_comm_monoid ι] [gcomm_monoid A] :
+  comm_monoid (graded_monoid A) :=
+{ mul_comm := gcomm_monoid.mul_comm, ..gmonoid.to_monoid A }
+
+end defs
+
+
+/-! ### Instances for `A 0`
+
+The various `g*` instances are enough to promote the `add_comm_monoid (A 0)` structure to various
+types of multiplicative structure.
+-/
+
+section grade_zero
+
+variables (A : ι → Type*)
+
+section one
+variables [has_zero ι] [ghas_one A]
+
+/-- `1 : A 0` is the value provided in `ghas_one.one`. -/
+@[nolint unused_arguments]
+instance grade_zero.has_one : has_one (A 0) :=
+⟨ghas_one.one⟩
+
+end one
+
+section mul
+variables [add_monoid ι] [ghas_mul A]
+
+/-- `(•) : A 0 → A i → A i` is the value provided in `direct_sum.ghas_mul.mul`, composed with
+an `eq.rec` to turn `A (0 + i)` into `A i`.
+-/
+instance grade_zero.has_scalar (i : ι) : has_scalar (A 0) (A i) :=
+{ smul := λ x y, (zero_add i).rec (ghas_mul.mul x y) }
+
+/-- `(*) : A 0 → A 0 → A 0` is the value provided in `direct_sum.ghas_mul.mul`, composed with
+an `eq.rec` to turn `A (0 + 0)` into `A 0`.
+-/
+instance grade_zero.has_mul : has_mul (A 0) :=
+{ mul := (•) }
+
+variables {A}
+
+@[simp] lemma mk_zero_smul {i} (a : A 0) (b : A i) : mk _ (a • b) = mk _ a * mk _ b :=
+sigma.ext (zero_add _).symm $ eq_rec_heq _ _
+
+@[simp] lemma grade_zero.smul_eq_mul (a b : A 0) : a • b = a * b := rfl
+
+
+end mul
+
+section monoid
+variables [add_monoid ι] [gmonoid A]
+
+/-- The `monoid` structure derived from `gmonoid A`. -/
+instance grade_zero.monoid : monoid (A 0) :=
+function.injective.monoid (mk 0) sigma_mk_injective rfl mk_zero_smul
+
+end monoid
+
+section monoid
+variables [add_comm_monoid ι] [gcomm_monoid A]
+
+/-- The `comm_monoid` structure derived from `gcomm_monoid A`. -/
+instance grade_zero.comm_monoid : comm_monoid (A 0) :=
+function.injective.comm_monoid (mk 0) sigma_mk_injective rfl mk_zero_smul
+
+end monoid
+
+section mul_action
+variables [add_monoid ι] [gmonoid A]
+
+/-- `graded_monoid.mk 0` is a `monoid_hom`, using the `graded_monoid.grade_zero.monoid` structure.
+-/
+def mk_zero_monoid_hom : A 0 →* (graded_monoid A) :=
+{ to_fun := mk 0, map_one' := rfl, map_mul' := mk_zero_smul }
+
+/-- Each grade `A i` derives a `A 0`-action structure from `gmonoid A`. -/
+instance grade_zero.mul_action {i} : mul_action (A 0) (A i) :=
+begin
+  letI := mul_action.comp_hom (graded_monoid A) (mk_zero_monoid_hom A),
+  exact function.injective.mul_action (mk i) sigma_mk_injective mk_zero_smul,
+end
+
+end mul_action
+
+
+end grade_zero
+
+/-! ### Shorthands for creating instance of the above typeclasses for collections of subobjects -/
+
+section subobjects
+
+variables {R : Type*}
+
+/-- Build a `ghas_one` instance for a collection of subobjects. -/
+@[simps one]
+def ghas_one.of_subobjects {S : Type*} [set_like S R] [has_one R] [has_zero ι]
+  (carriers : ι → S)
+  (one_mem : (1 : R) ∈ carriers 0) :
+  ghas_one (λ i, carriers i) :=
+{ one := ⟨1, one_mem⟩ }
+
+/-- Build a `ghas_mul` instance for a collection of subobjects. -/
+@[simps mul]
+def ghas_mul.of_subobjects {S : Type*} [set_like S R] [has_mul R] [has_add ι]
+  (carriers : ι → S)
+  (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : R) ∈ carriers (i + j)) :
+  ghas_mul (λ i, carriers i) :=
+{ mul := λ i j a b, ⟨(a * b : R), mul_mem a b⟩ }
+
+/-- Build a `gmonoid` instance for a collection of `add_submonoid`s. -/
+def gmonoid.of_subobjects {S : Type*} [set_like S R] [monoid R] [add_monoid ι]
+  (carriers : ι → S)
+  (one_mem : (1 : R) ∈ carriers 0)
+  (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : R) ∈ carriers (i + j)) :
+  gmonoid (λ i, carriers i) :=
+{ one_mul := λ ⟨i, a, h⟩, sigma.subtype_ext (zero_add _) (one_mul _),
+  mul_one := λ ⟨i, a, h⟩, sigma.subtype_ext (add_zero _) (mul_one _),
+  mul_assoc := λ ⟨i, a, ha⟩ ⟨j, b, hb⟩ ⟨k, c, hc⟩,
+    sigma.subtype_ext (add_assoc _ _ _) (mul_assoc _ _ _),
+  ..ghas_one.of_subobjects carriers one_mem,
+  ..ghas_mul.of_subobjects carriers mul_mem }
+
+/-- Build a `gcomm_monoid` instance for a collection of `add_submonoid`s. -/
+def gcomm_monoid.of_subobjects {S : Type*} [set_like S R] [comm_monoid R] [add_comm_monoid ι]
+  (carriers : ι → S)
+  (one_mem : (1 : R) ∈ carriers 0)
+  (mul_mem : ∀ ⦃i j⦄ (gi : carriers i) (gj : carriers j), (gi * gj : R) ∈ carriers (i + j)) :
+  gcomm_monoid (λ i, carriers i) :=
+{ mul_comm := λ ⟨i, a, ha⟩ ⟨j, b, hb⟩, sigma.subtype_ext (add_comm _ _) (mul_comm _ _),
+  ..gmonoid.of_subobjects carriers one_mem mul_mem}
+
+end subobjects
+
+end graded_monoid
+
+/-! ### Concrete instances -/
+section
+
+variables (ι) {R : Type*}
+
+@[simps one]
+instance has_one.ghas_one [has_zero ι] [has_one R] : graded_monoid.ghas_one (λ i : ι, R) :=
+{ one := 1 }
+
+@[simps mul]
+instance has_mul.ghas_mul [has_add ι] [has_mul R] : graded_monoid.ghas_mul (λ i : ι, R) :=
+{ mul := λ i j, (*) }
+
+/-- If all grades are the same type and themselves form a monoid, then there is a trivial grading
+structure. -/
+@[simps one mul]
+instance monoid.gmonoid [add_monoid ι] [monoid R] : graded_monoid.gmonoid (λ i : ι, R) :=
+{ one_mul := λ a, sigma.ext (zero_add _) (heq_of_eq (one_mul _)),
+  mul_one := λ a, sigma.ext (add_zero _) (heq_of_eq (mul_one _)),
+  mul_assoc := λ a b c, sigma.ext (add_assoc _ _ _) (heq_of_eq (mul_assoc _ _ _)),
+  ..has_one.ghas_one ι,
+  ..has_mul.ghas_mul ι }
+
+/-- If all grades are the same type and themselves form a commutative monoid, then there is a
+trivial grading structure. -/
+@[simps one mul]
+instance comm_monoid.gcomm_monoid [add_comm_monoid ι] [comm_monoid R] :
+  graded_monoid.gcomm_monoid (λ i : ι, R) :=
+{ mul_comm := λ a b, sigma.ext (add_comm _ _) (heq_of_eq (mul_comm _ _)),
+  ..monoid.gmonoid ι }
+
+end

--- a/src/algebra/graded_monoid.lean
+++ b/src/algebra/graded_monoid.lean
@@ -231,7 +231,10 @@ def ghas_mul.of_subobjects {S : Type*} [set_like S R] [has_mul R] [has_add ι]
   ghas_mul (λ i, carriers i) :=
 { mul := λ i j a b, ⟨(a * b : R), mul_mem a b⟩ }
 
-/-- Build a `gmonoid` instance for a collection of `add_submonoid`s. -/
+/-- Build a `gmonoid` instance for a collection of subobjects.
+
+See note [reducible non-instances]. -/
+@[reducible]
 def gmonoid.of_subobjects {S : Type*} [set_like S R] [monoid R] [add_monoid ι]
   (carriers : ι → S)
   (one_mem : (1 : R) ∈ carriers 0)
@@ -244,7 +247,10 @@ def gmonoid.of_subobjects {S : Type*} [set_like S R] [monoid R] [add_monoid ι]
   ..ghas_one.of_subobjects carriers one_mem,
   ..ghas_mul.of_subobjects carriers mul_mem }
 
-/-- Build a `gcomm_monoid` instance for a collection of `add_submonoid`s. -/
+/-- Build a `gcomm_monoid` instance for a collection of subobjects.
+
+See note [reducible non-instances]. -/
+@[reducible]
 def gcomm_monoid.of_subobjects {S : Type*} [set_like S R] [comm_monoid R] [add_comm_monoid ι]
   (carriers : ι → S)
   (one_mem : (1 : R) ∈ carriers 0)
@@ -272,7 +278,6 @@ instance has_mul.ghas_mul [has_add ι] [has_mul R] : graded_monoid.ghas_mul (λ 
 
 /-- If all grades are the same type and themselves form a monoid, then there is a trivial grading
 structure. -/
-@[simps one mul]
 instance monoid.gmonoid [add_monoid ι] [monoid R] : graded_monoid.gmonoid (λ i : ι, R) :=
 { one_mul := λ a, sigma.ext (zero_add _) (heq_of_eq (one_mul _)),
   mul_one := λ a, sigma.ext (add_zero _) (heq_of_eq (mul_one _)),
@@ -282,7 +287,6 @@ instance monoid.gmonoid [add_monoid ι] [monoid R] : graded_monoid.gmonoid (λ i
 
 /-- If all grades are the same type and themselves form a commutative monoid, then there is a
 trivial grading structure. -/
-@[simps one mul]
 instance comm_monoid.gcomm_monoid [add_comm_monoid ι] [comm_monoid R] :
   graded_monoid.gcomm_monoid (λ i : ι, R) :=
 { mul_comm := λ a b, sigma.ext (add_comm _ _) (heq_of_eq (mul_comm _ _)),

--- a/src/algebra/monoid_algebra/grading.lean
+++ b/src/algebra/monoid_algebra/grading.lean
@@ -38,8 +38,8 @@ variables {R} [decidable_eq ι] [add_monoid ι] [comm_semiring R]
 
 open_locale direct_sum
 
-instance grade.gmonoid : direct_sum.gmonoid (λ i : ι, grade R i) :=
-direct_sum.gmonoid.of_submodules (grade R) ⟨1, rfl⟩ $ λ i j, begin
+instance grade.gsemiring : direct_sum.gsemiring (λ i : ι, grade R i) :=
+direct_sum.gsemiring.of_submodules (grade R) ⟨1, rfl⟩ $ λ i j, begin
   rintros ⟨-, a, rfl⟩ ⟨-, b, rfl⟩,
   exact ⟨_, single_mul_single.symm⟩,
 end

--- a/src/algebra/monoid_algebra/to_direct_sum.lean
+++ b/src/algebra/monoid_algebra/to_direct_sum.lean
@@ -121,7 +121,7 @@ begin
     add_monoid_hom.compr₂_apply, add_monoid_hom.mul_apply, add_equiv.coe_to_add_monoid_hom,
     finsupp.single_add_hom_apply],
   simp only [add_monoid_algebra.single_mul_single, this, add_monoid_algebra.to_direct_sum_single],
-  rw [direct_sum.of_mul_of, semiring.direct_sum_mul],
+  rw [direct_sum.of_mul_of, has_mul.ghas_mul_mul],
 end
 
 end add_monoid_algebra

--- a/src/ring_theory/polynomial/homogeneous.lean
+++ b/src/ring_theory/polynomial/homogeneous.lean
@@ -209,9 +209,9 @@ end
 /--
 The homogeneous submodules form a graded ring. This instance is used by `direct_sum.comm_semiring`
 and `direct_sum.algebra`. -/
-noncomputable instance homogeneous_submodule.gcomm_monoid :
-  direct_sum.gcomm_monoid (λ i, homogeneous_submodule σ R i) :=
-direct_sum.gcomm_monoid.of_submodules _
+noncomputable instance homogeneous_submodule.gcomm_semiring :
+  direct_sum.gcomm_semiring (λ i, homogeneous_submodule σ R i) :=
+direct_sum.gcomm_semiring.of_submodules _
   (is_homogeneous_one σ R)
   (λ i j hi hj, is_homogeneous.mul hi.prop hj.prop)
 


### PR DESCRIPTION
This cleans up the `direct_sum.gmonoid` typeclass to not contain a bundled morphism, which allows it to be used to describe graded monoids too, via the alias for `sigma` `graded_monoid`. Essentially, this:

* Renames:
  * `direct_sum.ghas_one` to `graded_monoid.has_one`
  * `direct_sum.ghas_mul` to `direct_sum.gnon_unital_non_assoc_semiring`
  * `direct_sum.gmonoid` to `direct_sum.gsemiring`
  * `direct_sum.gcomm_monoid` to `direct_sum.gcomm_semiring`
* Introduces new typeclasses which represent what the previous names should have been:
  * `graded_monoid.ghas_mul`
  * `graded_monoid.gmonoid`
  * `graded_monoid.gcomm_monoid` 

This doesn't do as much deduplication as I'd like, but it at least manages some.
There's not much in the way of new definitions here either, and most of the names are just copied from the graded ring case.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.239586.20Graded.20monoids/near/256583086)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
