### PR TITLE
[Merged by Bors] - feat(data/nat/log): add antitonicity lemmas for first argument

### DIFF
--- a/src/data/nat/log.lean
+++ b/src/data/nat/log.lean
@@ -115,8 +115,8 @@ end
 lemma log_mono {b : ℕ} : monotone (λ n : ℕ, log b n) :=
 λ x y, log_le_log_of_le
 
-lemma log_left_gt_one_anti {n : ℕ} : antitone (subtype.restrict (λ b, log b n) (λ b, 1 < b)) :=
-λ c b hb, log_le_log_of_left_ge c.property (subtype.coe_le_coe.2 hb)
+lemma log_left_gt_one_anti {n : ℕ} : antitone_on (λ b, log b n) (set.Ioi 1) :=
+λ _ hc _ _ hb, log_le_log_of_left_ge (set.mem_Iio.1 hc) hb
 
 private lemma add_pred_div_lt {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) : (n + b - 1)/b < n :=
 begin
@@ -226,8 +226,8 @@ end
 lemma clog_mono (b : ℕ) : monotone (clog b) :=
 λ x y, clog_le_clog_of_le _
 
-lemma clog_left_gt_one_anti {n : ℕ} : antitone (subtype.restrict (λ b, clog b n) (λ b, 1 < b)) :=
-λ c b hb, clog_le_clog_of_left_ge c.property (subtype.coe_le_coe.2 hb)
+lemma clog_left_gt_one_anti {n : ℕ} : antitone_on (λ b : ℕ, clog b n) (set.Ioi 1) :=
+λ _ hc _ _ hb, clog_le_clog_of_left_ge (set.mem_Iio.1 hc) hb
 
 lemma log_le_clog (b n : ℕ) : log b n ≤ clog b n :=
 begin

--- a/src/data/nat/log.lean
+++ b/src/data/nat/log.lean
@@ -112,10 +112,10 @@ begin
                                             (zero_lt_succ n)
 end
 
-lemma log_mono {b : ℕ} : monotone (λ n : ℕ, log b n) :=
+lemma log_monotone {b : ℕ} : monotone (λ n : ℕ, log b n) :=
 λ x y, log_le_log_of_le
 
-lemma log_left_gt_one_anti {n : ℕ} : antitone_on (λ b, log b n) (set.Ioi 1) :=
+lemma log_antitone_left {n : ℕ} : antitone_on (λ b, log b n) (set.Ioi 1) :=
 λ _ hc _ _ hb, log_le_log_of_left_ge (set.mem_Iio.1 hc) hb
 
 private lemma add_pred_div_lt {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) : (n + b - 1)/b < n :=
@@ -223,10 +223,10 @@ begin
        ... ≤ b ^ clog c n.succ : pow_le_pow_of_le_left (le_of_lt $ zero_lt_one.trans hc) hb _
 end
 
-lemma clog_mono (b : ℕ) : monotone (clog b) :=
+lemma clog_monotone (b : ℕ) : monotone (clog b) :=
 λ x y, clog_le_clog_of_le _
 
-lemma clog_left_gt_one_anti {n : ℕ} : antitone_on (λ b : ℕ, clog b n) (set.Ioi 1) :=
+lemma clog_antitone_left {n : ℕ} : antitone_on (λ b : ℕ, clog b n) (set.Ioi 1) :=
 λ _ hc _ _ hb, clog_le_clog_of_left_ge (set.mem_Iio.1 hc) hb
 
 lemma log_le_clog (b n : ℕ) : log b n ≤ clog b n :=

--- a/src/data/nat/log.lean
+++ b/src/data/nat/log.lean
@@ -101,21 +101,21 @@ begin
       exact (pow_log_le_self hb hn).trans h } }
 end
 
-lemma log_le_log_of_left_ge {b c n : ℕ} (hc : c > 1) (hb : b ≥ c) : log b n ≤ log c n :=
+lemma log_le_log_of_left_ge {b c n : ℕ} (hc : 1 < c) (hb : c ≤ b) : log b n ≤ log c n :=
 begin
-  cases n, { simp, },
-  { rw ← pow_le_iff_le_log hc (zero_lt_succ n),
-    exact calc
-      c ^ log b n.succ ≤ b ^ log b n.succ : pow_le_pow_of_le_left
-                                              (le_of_lt $ zero_lt_one.trans hc) hb _
-                   ... ≤ n.succ           : pow_log_le_self (lt_of_lt_of_le hc hb)
-                                              (zero_lt_succ n), },
+  cases n, { simp },
+  rw ← pow_le_iff_le_log hc (zero_lt_succ n),
+  exact calc
+    c ^ log b n.succ ≤ b ^ log b n.succ : pow_le_pow_of_le_left
+                                            (le_of_lt $ zero_lt_one.trans hc) hb _
+                 ... ≤ n.succ           : pow_log_le_self (lt_of_lt_of_le hc hb)
+                                            (zero_lt_succ n)
 end
 
 lemma log_mono {b : ℕ} : monotone (λ n : ℕ, log b n) :=
 λ x y, log_le_log_of_le
 
-lemma log_left_gt_one_anti {n : ℕ} : antitone (subtype.restrict (λ b, log b n) (λ b, b > 1)) :=
+lemma log_left_gt_one_anti {n : ℕ} : antitone (subtype.restrict (λ b, log b n) (λ b, 1 < b)) :=
 λ c b hb, log_le_log_of_left_ge c.property (subtype.coe_le_coe.2 hb)
 
 private lemma add_pred_div_lt {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) : (n + b - 1)/b < n :=
@@ -214,19 +214,19 @@ begin
       exact h.trans (le_pow_clog hb _) } }
 end
 
-lemma clog_le_clog_of_left_ge {b c n : ℕ} (hc : c > 1) (hb : b ≥ c) : clog b n ≤ clog c n :=
+lemma clog_le_clog_of_left_ge {b c n : ℕ} (hc : 1 < c) (hb : c ≤ b) : clog b n ≤ clog c n :=
 begin
-  cases n, { simp, },
-  { rw ← le_pow_iff_clog_le (lt_of_lt_of_le hc hb),
-    exact calc
-      n.succ ≤ c ^ clog c n.succ : le_pow_clog hc _
-         ... ≤ b ^ clog c n.succ : pow_le_pow_of_le_left (le_of_lt $ zero_lt_one.trans hc) hb _, },
+  cases n, { simp },
+  rw ← le_pow_iff_clog_le (lt_of_lt_of_le hc hb),
+  exact calc
+    n.succ ≤ c ^ clog c n.succ : le_pow_clog hc _
+       ... ≤ b ^ clog c n.succ : pow_le_pow_of_le_left (le_of_lt $ zero_lt_one.trans hc) hb _
 end
 
 lemma clog_mono (b : ℕ) : monotone (clog b) :=
 λ x y, clog_le_clog_of_le _
 
-lemma clog_left_gt_one_anti {n : ℕ} : antitone (subtype.restrict (λ b, clog b n) (λ b, b > 1)) :=
+lemma clog_left_gt_one_anti {n : ℕ} : antitone (subtype.restrict (λ b, clog b n) (λ b, 1 < b)) :=
 λ c b hb, clog_le_clog_of_left_ge c.property (subtype.coe_le_coe.2 hb)
 
 lemma log_le_clog (b n : ℕ) : log b n ≤ clog b n :=

--- a/src/data/nat/log.lean
+++ b/src/data/nat/log.lean
@@ -101,8 +101,22 @@ begin
       exact (pow_log_le_self hb hn).trans h } }
 end
 
+lemma log_le_log_of_left_ge {b c n : ℕ} (hc : c > 1) (hb : b ≥ c) : log b n ≤ log c n :=
+begin
+  cases n, { simp, },
+  { rw ← pow_le_iff_le_log hc (zero_lt_succ n),
+    exact calc
+      c ^ log b n.succ ≤ b ^ log b n.succ : pow_le_pow_of_le_left
+                                              (le_of_lt $ zero_lt_one.trans hc) hb _
+                   ... ≤ n.succ           : pow_log_le_self (lt_of_lt_of_le hc hb)
+                                              (zero_lt_succ n), },
+end
+
 lemma log_mono {b : ℕ} : monotone (λ n : ℕ, log b n) :=
 λ x y, log_le_log_of_le
+
+lemma log_left_gt_one_anti {n : ℕ} : antitone (subtype.restrict (λ b, log b n) (λ b, b > 1)) :=
+λ c b hb, log_le_log_of_left_ge c.property (subtype.coe_le_coe.2 hb)
 
 private lemma add_pred_div_lt {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) : (n + b - 1)/b < n :=
 begin
@@ -200,8 +214,20 @@ begin
       exact h.trans (le_pow_clog hb _) } }
 end
 
+lemma clog_le_clog_of_left_ge {b c n : ℕ} (hc : c > 1) (hb : b ≥ c) : clog b n ≤ clog c n :=
+begin
+  cases n, { simp, },
+  { rw ← le_pow_iff_clog_le (lt_of_lt_of_le hc hb),
+    exact calc
+      n.succ ≤ c ^ clog c n.succ : le_pow_clog hc _
+         ... ≤ b ^ clog c n.succ : pow_le_pow_of_le_left (le_of_lt $ zero_lt_one.trans hc) hb _, },
+end
+
 lemma clog_mono (b : ℕ) : monotone (clog b) :=
 λ x y, clog_le_clog_of_le _
+
+lemma clog_left_gt_one_anti {n : ℕ} : antitone (subtype.restrict (λ b, clog b n) (λ b, b > 1)) :=
+λ c b hb, clog_le_clog_of_left_ge c.property (subtype.coe_le_coe.2 hb)
 
 lemma log_le_clog (b n : ℕ) : log b n ≤ clog b n :=
 begin


### PR DESCRIPTION
`log` and `clog` are only antitone on bases >1, so we include this as an
assumption in `log_le_log_of_left_ge` (resp. `clog_le_...`) and as a
domain restriction in `log_left_gt_one_anti` (resp. `clog_left_...`).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
