### PR TITLE
[Merged by Bors] - feat(algebra/order/nonneg): properties about the nonnegative cone

### DIFF
--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -36,6 +36,16 @@ set.Ici.order_bot
 instance no_top_order [partial_order α] [no_top_order α] {a : α} : no_top_order {x : α // a ≤ x} :=
 set.Ici.no_top_order
 
+instance semilattice_inf_bot [semilattice_inf α] {a : α} : semilattice_inf_bot {x : α // a ≤ x} :=
+set.Ici.semilattice_inf_bot
+
+instance densely_ordered [preorder α] [densely_ordered α] {a : α} :
+  densely_ordered {x : α // a ≤ x} :=
+show densely_ordered (Ici a), from set.densely_ordered
+
+instance inhabited [preorder α] {a : α} : inhabited {x : α // a ≤ x} :=
+⟨⟨a, le_rfl⟩⟩
+
 instance has_zero [has_zero α] [preorder α] : has_zero {x : α // 0 ≤ x} :=
 ⟨⟨0, le_rfl⟩⟩
 

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -10,17 +10,29 @@ import order.lattice_intervals
 import order.conditionally_complete_lattice
 
 /-!
-## The type of nonnegative elements
+# The type of nonnegative elements
 
-This file proves properties about `{x : α // 0 ≤ x}`.
-Note that we could also use `set.Ici (0 : α)`.
+This file defines instances and prove some properties about the nonnegative elements
+`{x : α // 0 ≤ x}` of an arbitrary type `α`.
+
+Currently we only state instances and states some `simp`/`norm_cast` lemmas.
+
+When `α` is `ℝ`, this will give us some properties about `ℝ≥0`.
+
+## Main declarations
+
+* `{x : α // 0 ≤ x}` is a `canonically_linear_ordered_add_monoid` if `α` is a `linear_ordered_ring`.
+* `{x : α // 0 ≤ x}` is a `linear_ordered_comm_group_with_zero` if `α` is a `linear_ordered_field`.
+
+## Implementation Notes
+
+Instead of `{x : α // 0 ≤ x}` we could also use `set.Ici (0 : α)`, which is definitionally equal.
 However, using the explicit subtype has a big advantage: when writing and element explicitly
 with a proof of nonnegativity as `⟨x, hx⟩`, the `hx` is expected to have type `0 ≤ x`. If we would
 use `Ici 0`, then the type is expected to be `x ∈ Ici 0`. Although these types are definitionally
-equal, this often confused the elaborator.
-We prove that `{x : α // 0 ≤ x}` is a `canonically_linear_ordered_add_monoid` if `α` is a
-`linear_ordered_ring`.
-When `α` is `ℝ`, this will give us some properties about `ℝ≥0`.
+equal, this often confuses the elaborator. Similar problems arise when doing cases on an element.
+
+The disadvantage is that we have to duplicate some instances about `set.Ici` to this subtype.
 -/
 
 open set

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -188,7 +188,7 @@ rfl
 
 end linear_order
 
-end nonneg
-
-instance [linear_ordered_ring α] : has_ordered_sub {x : α // 0 ≤ x} :=
+instance has_ordered_sub [linear_ordered_ring α] : has_ordered_sub {x : α // 0 ≤ x} :=
 ⟨by { rintro ⟨a, ha⟩ ⟨b, hb⟩ ⟨c, hc⟩, simp [sub_le_iff_le_add] }⟩
+
+end nonneg

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -30,8 +30,7 @@ instance [partial_order α] [no_top_order α] {a : α} : no_top_order (Ici a) :=
 
 namespace nonneg
 
-/-- -/
-instance order_bot [order_bot α] {a : α} : order_bot {x : α // a ≤ x} :=
+instance order_bot [partial_order α] {a : α} : order_bot {x : α // a ≤ x} :=
 set.Ici.order_bot
 
 instance no_top_order [partial_order α] [no_top_order α] {a : α} : no_top_order {x : α // a ≤ x} :=
@@ -140,19 +139,19 @@ lemma le_iff_exists_nonneg_add [ordered_ring α] (a b : α) : a ≤ b ↔ ∃ c 
 instance canonically_ordered_add_monoid [ordered_ring α] :
   canonically_ordered_add_monoid {x : α // 0 ≤ x} :=
 { le_iff_exists_add     := λ ⟨a, ha⟩ ⟨b, hb⟩,
-    by simpa only [mk_add_mk, set_coe.exists, subtype.mk_eq_mk] using le_iff_exists_nonneg_add a b,
+    by simpa [mk_add_mk, subtype.exists, subtype.mk_eq_mk] using le_iff_exists_nonneg_add a b,
   ..nonneg.ordered_add_comm_monoid,
   ..nonneg.order_bot }
 
 instance canonically_ordered_comm_semiring [ordered_comm_ring α] [no_zero_divisors α] :
   canonically_ordered_comm_semiring {x : α // 0 ≤ x} :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := by { rintro ⟨a, ha⟩ ⟨b, hb⟩, simp },
-  .. set.Ici.canonically_ordered_add_monoid,
-  .. set.Ici.ordered_comm_semiring }
+  ..nonneg.canonically_ordered_add_monoid,
+  ..nonneg.ordered_comm_semiring }
 
 instance canonically_linear_ordered_add_monoid [linear_ordered_ring α] :
   canonically_linear_ordered_add_monoid {x : α // 0 ≤ x} :=
-{ ..subtype.linear_order _, ..set.Ici.canonically_ordered_add_monoid }
+{ ..subtype.linear_order _, ..nonneg.canonically_ordered_add_monoid }
 
 section linear_order
 

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -25,6 +25,13 @@ open set
 
 variables {α : Type*}
 
+instance [partial_order α] [no_top_order α] {a : α} : no_top_order (Ici a) :=
+⟨λ x, let ⟨y, hy⟩ := no_top x.1 in ⟨⟨y, le_trans x.2 hy.le⟩, hy⟩ ⟩
+
+lemma le_iff_exists_nonneg_add (a b : α) : a ≤ b ↔ ∃ c ≥ 0, b = a + c :=
+⟨λ h, ⟨b - a, sub_nonneg.mpr h, by simp⟩,
+  λ ⟨c, hc, h⟩, by { rw [h, le_add_iff_nonneg_right], exact hc }⟩
+
 namespace nonneg
 
 /-- -/

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -42,6 +42,7 @@ instance densely_ordered [preorder α] [densely_ordered α] {a : α} :
   densely_ordered {x : α // a ≤ x} :=
 show densely_ordered (Ici a), from set.densely_ordered
 
+/-- If `Sup ∅ ≤ a` then `{x : α // a ≤ x}` is a `conditionally_complete_linear_order_bot`. -/
 @[reducible]
 protected noncomputable def conditionally_complete_linear_order_bot
   [conditionally_complete_linear_order α] {a : α} (h : Sup ∅ ≤ a) :
@@ -206,6 +207,7 @@ section linear_order
 
 variables [has_zero α] [linear_order α]
 
+/-- The function `a ↦ max a 0` of type `α → {x : α // 0 ≤ x}`. -/
 def to_nonneg (a : α) : {x : α // 0 ≤ x} :=
 ⟨max a 0, le_max_right _ _⟩
 

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -10,10 +10,13 @@ import order.lattice_intervals
 /-!
 ## The type of nonnegative elements
 
-This file proves properties about `{x : α // 0 ≤ x}`, or equivalently, `{x : α // 0 ≤ x}` for various
-types `α`. We use `Ici 0`, since `Ici a` already has some convenient type classes associated to it
-(like `order_bot`).
-We prove that `Ici 0` is a `canonically_linear_ordered_add_monoid` if `α` is a
+This file proves properties about `{x : α // 0 ≤ x}`.
+Note that we could also use `set.Ici (0 : α)`.
+However, using the explicit subtype has a big advantage: when writing and element explicitly
+with a proof of nonnegativity as `⟨x, hx⟩`, the `hx` is expected to have type `0 ≤ x`. If we would
+use `Ici 0`, then the type is expected to be `x ∈ Ici 0`. Although these types are definitionally
+equal, this often confused the elaborator.
+We prove that `{x : α // 0 ≤ x}` is a `canonically_linear_ordered_add_monoid` if `α` is a
 `linear_ordered_ring`.
 When `α` is `ℝ`, this will give us some properties about `ℝ≥0`.
 -/
@@ -24,7 +27,14 @@ variables {α : Type*}
 
 namespace nonneg
 
-instance [has_zero α] [preorder α] : has_zero {x : α // 0 ≤ x} :=
+/-- -/
+instance order_bot [order_bot α] {a : α} : order_bot {x : α // a ≤ x} :=
+set.Ici.order_bot
+
+instance no_top_order [partial_order α] [no_top_order α] {a : α} : no_top_order {x : α // a ≤ x} :=
+set.Ici.no_top_order
+
+instance has_zero [has_zero α] [preorder α] : has_zero {x : α // 0 ≤ x} :=
 ⟨⟨0, le_rfl⟩⟩
 
 @[simp] protected lemma coe_zero [has_zero α] [preorder α] : ((0 : {x : α // 0 ≤ x}) : α) = 0 := rfl
@@ -33,7 +43,8 @@ instance [has_zero α] [preorder α] : has_zero {x : α // 0 ≤ x} :=
   (⟨x, hx⟩ : {x : α // 0 ≤ x}) = 0 ↔ x = 0 :=
 subtype.ext_iff
 
-instance [add_zero_class α] [preorder α] [covariant_class α α (+) (≤)] : has_add {x : α // 0 ≤ x} :=
+instance has_add [add_zero_class α] [preorder α] [covariant_class α α (+) (≤)] :
+  has_add {x : α // 0 ≤ x} :=
 ⟨λ x y, ⟨x + y, add_nonneg x.2 y.2⟩⟩
 
 @[simp] lemma mk_add_mk [add_zero_class α] [preorder α] [covariant_class α α (+) (≤)] {x y : α}
@@ -44,22 +55,24 @@ rfl
 protected lemma coe_add [add_zero_class α] [preorder α] [covariant_class α α (+) (≤)]
   (a b : {x : α // 0 ≤ x}) : ((a + b : {x : α // 0 ≤ x}) : α) = a + b := rfl
 
-instance [ordered_add_comm_monoid α] : ordered_add_comm_monoid {x : α // 0 ≤ x} :=
+instance ordered_add_comm_monoid [ordered_add_comm_monoid α] :
+  ordered_add_comm_monoid {x : α // 0 ≤ x} :=
 subtype.coe_injective.ordered_add_comm_monoid (coe : {x : α // 0 ≤ x} → α) rfl (λ x y, rfl)
 
-instance [linear_ordered_add_comm_monoid α] : linear_ordered_add_comm_monoid {x : α // 0 ≤ x} :=
+instance linear_ordered_add_comm_monoid [linear_ordered_add_comm_monoid α] :
+  linear_ordered_add_comm_monoid {x : α // 0 ≤ x} :=
 subtype.coe_injective.linear_ordered_add_comm_monoid (coe : {x : α // 0 ≤ x} → α) rfl (λ x y, rfl)
 
-instance [ordered_cancel_add_comm_monoid α] :
+instance ordered_cancel_add_comm_monoid [ordered_cancel_add_comm_monoid α] :
   ordered_cancel_add_comm_monoid {x : α // 0 ≤ x} :=
 subtype.coe_injective.ordered_cancel_add_comm_monoid (coe : {x : α // 0 ≤ x} → α) rfl (λ x y, rfl)
 
-instance [linear_ordered_cancel_add_comm_monoid α] :
+instance linear_ordered_cancel_add_comm_monoid [linear_ordered_cancel_add_comm_monoid α] :
   linear_ordered_cancel_add_comm_monoid {x : α // 0 ≤ x} :=
 subtype.coe_injective.linear_ordered_cancel_add_comm_monoid
   (coe : {x : α // 0 ≤ x} → α) rfl (λ x y, rfl)
 
-instance [ordered_semiring α] : has_one {x : α // 0 ≤ x} :=
+instance has_one [ordered_semiring α] : has_one {x : α // 0 ≤ x} :=
 { one := ⟨1, zero_le_one⟩ }
 
 @[simp] protected lemma coe_one [ordered_semiring α] : ((1 : {x : α // 0 ≤ x}) : α) = 1 := rfl
@@ -68,7 +81,7 @@ instance [ordered_semiring α] : has_one {x : α // 0 ≤ x} :=
   (⟨x, hx⟩ : {x : α // 0 ≤ x}) = 1 ↔ x = 1 :=
 subtype.ext_iff
 
-instance [ordered_semiring α] : has_mul {x : α // 0 ≤ x} :=
+instance has_mul [ordered_semiring α] : has_mul {x : α // 0 ≤ x} :=
 { mul := λ x y, ⟨x * y, mul_nonneg x.2 y.2⟩ }
 
 @[simp, norm_cast]
@@ -79,22 +92,23 @@ protected lemma coe_mul [ordered_semiring α] (a b : {x : α // 0 ≤ x}) :
   (⟨x, hx⟩ : {x : α // 0 ≤ x}) * ⟨y, hy⟩ = ⟨x * y, mul_nonneg hx hy⟩ :=
 rfl
 
-instance [ordered_semiring α] : ordered_semiring {x : α // 0 ≤ x} :=
+instance ordered_semiring [ordered_semiring α] : ordered_semiring {x : α // 0 ≤ x} :=
 subtype.coe_injective.ordered_semiring
   (coe : {x : α // 0 ≤ x} → α) rfl rfl (λ x y, rfl) (λ x y, rfl)
 
-instance [ordered_comm_semiring α] : ordered_comm_semiring {x : α // 0 ≤ x} :=
+instance ordered_comm_semiring [ordered_comm_semiring α] : ordered_comm_semiring {x : α // 0 ≤ x} :=
 subtype.coe_injective.ordered_comm_semiring
   (coe : {x : α // 0 ≤ x} → α) rfl rfl (λ x y, rfl) (λ x y, rfl)
 
-instance [linear_ordered_semiring α] : nontrivial {x : α // 0 ≤ x} :=
+instance nontrivial [linear_ordered_semiring α] : nontrivial {x : α // 0 ≤ x} :=
 ⟨ ⟨0, 1, λ h, zero_ne_one (congr_arg subtype.val h)⟩ ⟩
 
-instance [linear_ordered_semiring α] : linear_ordered_semiring {x : α // 0 ≤ x} :=
+instance linear_ordered_semiring [linear_ordered_semiring α] :
+  linear_ordered_semiring {x : α // 0 ≤ x} :=
 subtype.coe_injective.linear_ordered_semiring
   (coe : {x : α // 0 ≤ x} → α) rfl rfl (λ x y, rfl) (λ x y, rfl)
 
-instance [linear_ordered_field α] : has_inv {x : α // 0 ≤ x} :=
+instance has_inv [linear_ordered_field α] : has_inv {x : α // 0 ≤ x} :=
 { inv := λ x, ⟨x⁻¹, inv_nonneg.mpr x.2⟩ }
 
 @[simp, norm_cast]
@@ -105,7 +119,7 @@ protected lemma coe_inv [linear_ordered_field α] (a : {x : α // 0 ≤ x}) :
   (⟨x, hx⟩ : {x : α // 0 ≤ x})⁻¹ = ⟨x⁻¹, inv_nonneg.mpr hx⟩ :=
 rfl
 
-instance [linear_ordered_field α] : has_div {x : α // 0 ≤ x} :=
+instance has_div [linear_ordered_field α] : has_div {x : α // 0 ≤ x} :=
 { div := λ x y, ⟨x / y, div_nonneg x.2 y.2⟩ }
 
 @[simp, norm_cast]
@@ -116,19 +130,20 @@ protected lemma coe_div [linear_ordered_field α] (a b : {x : α // 0 ≤ x}) :
   (⟨x, hx⟩ : {x : α // 0 ≤ x}) / ⟨y, hy⟩ = ⟨x / y, div_nonneg hx hy⟩ :=
 rfl
 
-instance [ordered_ring α] : canonically_ordered_add_monoid {x : α // 0 ≤ x} :=
+instance canonically_ordered_add_monoid [ordered_ring α] :
+  canonically_ordered_add_monoid {x : α // 0 ≤ x} :=
 { le_iff_exists_add     := λ ⟨a, ha⟩ ⟨b, hb⟩,
     by simpa only [mk_add_mk, set_coe.exists, subtype.mk_eq_mk] using le_iff_exists_nonneg_add a b,
-  ..set.Ici.ordered_add_comm_monoid,
-  ..set.Ici.order_bot }
+  ..nonneg.ordered_add_comm_monoid,
+  ..nonneg.order_bot }
 
-instance [ordered_comm_ring α] [no_zero_divisors α] :
+instance canonically_ordered_comm_semiring [ordered_comm_ring α] [no_zero_divisors α] :
   canonically_ordered_comm_semiring {x : α // 0 ≤ x} :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := by { rintro ⟨a, ha⟩ ⟨b, hb⟩, simp },
   .. set.Ici.canonically_ordered_add_monoid,
   .. set.Ici.ordered_comm_semiring }
 
-instance [linear_ordered_ring α] :
+instance canonically_linear_ordered_add_monoid [linear_ordered_ring α] :
   canonically_linear_ordered_add_monoid {x : α // 0 ≤ x} :=
 { ..subtype.linear_order _, ..set.Ici.canonically_ordered_add_monoid }
 
@@ -152,11 +167,11 @@ by { cases a with a ha, exact to_nonneg_of_nonneg ha }
 
 @[simp]
 lemma to_nonneg_le {a : α} {b : {x : α // 0 ≤ x}} : to_nonneg a ≤ b ↔ a ≤ b :=
-by { cases b with b hb, simp [to_nonneg, mem_Ici.mp hb] }
+by { cases b with b hb, simp [to_nonneg, hb] }
 
 @[simp]
 lemma to_nonneg_lt {a : {x : α // 0 ≤ x}} {b : α} : a < to_nonneg b ↔ ↑a < b :=
-by { cases a with a ha, simp [to_nonneg, (mem_Ici.mp ha).not_lt] }
+by { cases a with a ha, simp [to_nonneg, ha.not_lt] }
 
 instance [has_sub α] : has_sub {x : α // 0 ≤ x} :=
 ⟨λ x y, to_nonneg (x - y)⟩

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -104,7 +104,7 @@ lemma nsmul_coe [ordered_add_comm_monoid α] (n : ℕ) (r : {x : α // 0 ≤ x})
   ↑(n • r) = n • (r : α) :=
 nonneg.coe_add_monoid_hom.map_nsmul _ _
 
-instance archimedian [ordered_add_comm_monoid α] [archimedean α] : archimedean {x : α // 0 ≤ x} :=
+instance archimedean [ordered_add_comm_monoid α] [archimedean α] : archimedean {x : α // 0 ≤ x} :=
 ⟨ assume x y pos_y,
   let ⟨n, hr⟩ := archimedean.arch (x : α) (pos_y : (0 : α) < y) in
   ⟨n, show (x : α) ≤ (n • y : {x : α // 0 ≤ x}), by simp [*, -nsmul_eq_mul, nsmul_coe]⟩ ⟩

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -27,9 +27,6 @@ open set
 
 variables {α : Type*}
 
-instance [partial_order α] [no_top_order α] {a : α} : no_top_order (Ici a) :=
-⟨λ x, let ⟨y, hy⟩ := no_top x.1 in ⟨⟨y, le_trans x.2 hy.le⟩, hy⟩ ⟩
-
 namespace nonneg
 
 instance order_bot [partial_order α] {a : α} : order_bot {x : α // a ≤ x} :=
@@ -187,10 +184,6 @@ protected lemma coe_div [linear_ordered_field α] (a b : {x : α // 0 ≤ x}) :
 @[simp] lemma mk_div_mk [linear_ordered_field α] {x y : α} (hx : 0 ≤ x) (hy : 0 ≤ y) :
   (⟨x, hx⟩ : {x : α // 0 ≤ x}) / ⟨y, hy⟩ = ⟨x / y, div_nonneg hx hy⟩ :=
 rfl
-
-lemma le_iff_exists_nonneg_add [ordered_ring α] (a b : α) : a ≤ b ↔ ∃ c ≥ 0, b = a + c :=
-⟨λ h, ⟨b - a, sub_nonneg.mpr h, by simp⟩,
-  λ ⟨c, hc, h⟩, by { rw [h, le_add_iff_nonneg_right], exact hc }⟩
 
 instance canonically_ordered_add_monoid [ordered_ring α] :
   canonically_ordered_add_monoid {x : α // 0 ≤ x} :=

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2021 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+-/
+import data.set.intervals.ord_connected
+import algebra.order.sub
+import order.lattice_intervals
+
+/-!
+## The type of nonnegative elements
+
+This file proves properties about `{x : α // 0 ≤ x}`, or equivalently, `{x : α // 0 ≤ x}` for various
+types `α`. We use `Ici 0`, since `Ici a` already has some convenient type classes associated to it
+(like `order_bot`).
+We prove that `Ici 0` is a `canonically_linear_ordered_add_monoid` if `α` is a
+`linear_ordered_ring`.
+When `α` is `ℝ`, this will give us some properties about `ℝ≥0`.
+-/
+
+open set
+
+variables {α : Type*}
+
+namespace nonneg
+
+instance [has_zero α] [preorder α] : has_zero {x : α // 0 ≤ x} :=
+⟨⟨0, le_rfl⟩⟩
+
+@[simp] protected lemma coe_zero [has_zero α] [preorder α] : ((0 : {x : α // 0 ≤ x}) : α) = 0 := rfl
+
+@[simp] lemma mk_eq_zero [has_zero α] [preorder α] {x : α} (hx : 0 ≤ x) :
+  (⟨x, hx⟩ : {x : α // 0 ≤ x}) = 0 ↔ x = 0 :=
+subtype.ext_iff
+
+instance [add_zero_class α] [preorder α] [covariant_class α α (+) (≤)] : has_add {x : α // 0 ≤ x} :=
+⟨λ x y, ⟨x + y, add_nonneg x.2 y.2⟩⟩
+
+@[simp] lemma mk_add_mk [add_zero_class α] [preorder α] [covariant_class α α (+) (≤)] {x y : α}
+  (hx : 0 ≤ x) (hy : 0 ≤ y) : (⟨x, hx⟩ : {x : α // 0 ≤ x}) + ⟨y, hy⟩ = ⟨x + y, add_nonneg hx hy⟩ :=
+rfl
+
+@[simp, norm_cast]
+protected lemma coe_add [add_zero_class α] [preorder α] [covariant_class α α (+) (≤)]
+  (a b : {x : α // 0 ≤ x}) : ((a + b : {x : α // 0 ≤ x}) : α) = a + b := rfl
+
+instance [ordered_add_comm_monoid α] : ordered_add_comm_monoid {x : α // 0 ≤ x} :=
+subtype.coe_injective.ordered_add_comm_monoid (coe : {x : α // 0 ≤ x} → α) rfl (λ x y, rfl)
+
+instance [linear_ordered_add_comm_monoid α] : linear_ordered_add_comm_monoid {x : α // 0 ≤ x} :=
+subtype.coe_injective.linear_ordered_add_comm_monoid (coe : {x : α // 0 ≤ x} → α) rfl (λ x y, rfl)
+
+instance [ordered_cancel_add_comm_monoid α] :
+  ordered_cancel_add_comm_monoid {x : α // 0 ≤ x} :=
+subtype.coe_injective.ordered_cancel_add_comm_monoid (coe : {x : α // 0 ≤ x} → α) rfl (λ x y, rfl)
+
+instance [linear_ordered_cancel_add_comm_monoid α] :
+  linear_ordered_cancel_add_comm_monoid {x : α // 0 ≤ x} :=
+subtype.coe_injective.linear_ordered_cancel_add_comm_monoid
+  (coe : {x : α // 0 ≤ x} → α) rfl (λ x y, rfl)
+
+instance [ordered_semiring α] : has_one {x : α // 0 ≤ x} :=
+{ one := ⟨1, zero_le_one⟩ }
+
+@[simp] protected lemma coe_one [ordered_semiring α] : ((1 : {x : α // 0 ≤ x}) : α) = 1 := rfl
+
+@[simp] lemma mk_eq_one [ordered_semiring α] {x : α} (hx : 0 ≤ x) :
+  (⟨x, hx⟩ : {x : α // 0 ≤ x}) = 1 ↔ x = 1 :=
+subtype.ext_iff
+
+instance [ordered_semiring α] : has_mul {x : α // 0 ≤ x} :=
+{ mul := λ x y, ⟨x * y, mul_nonneg x.2 y.2⟩ }
+
+@[simp, norm_cast]
+protected lemma coe_mul [ordered_semiring α] (a b : {x : α // 0 ≤ x}) :
+  ((a * b : {x : α // 0 ≤ x}) : α) = a * b := rfl
+
+@[simp] lemma mk_mul_mk [ordered_semiring α] {x y : α} (hx : 0 ≤ x) (hy : 0 ≤ y) :
+  (⟨x, hx⟩ : {x : α // 0 ≤ x}) * ⟨y, hy⟩ = ⟨x * y, mul_nonneg hx hy⟩ :=
+rfl
+
+instance [ordered_semiring α] : ordered_semiring {x : α // 0 ≤ x} :=
+subtype.coe_injective.ordered_semiring
+  (coe : {x : α // 0 ≤ x} → α) rfl rfl (λ x y, rfl) (λ x y, rfl)
+
+instance [ordered_comm_semiring α] : ordered_comm_semiring {x : α // 0 ≤ x} :=
+subtype.coe_injective.ordered_comm_semiring
+  (coe : {x : α // 0 ≤ x} → α) rfl rfl (λ x y, rfl) (λ x y, rfl)
+
+instance [linear_ordered_semiring α] : nontrivial {x : α // 0 ≤ x} :=
+⟨ ⟨0, 1, λ h, zero_ne_one (congr_arg subtype.val h)⟩ ⟩
+
+instance [linear_ordered_semiring α] : linear_ordered_semiring {x : α // 0 ≤ x} :=
+subtype.coe_injective.linear_ordered_semiring
+  (coe : {x : α // 0 ≤ x} → α) rfl rfl (λ x y, rfl) (λ x y, rfl)
+
+instance [linear_ordered_field α] : has_inv {x : α // 0 ≤ x} :=
+{ inv := λ x, ⟨x⁻¹, inv_nonneg.mpr x.2⟩ }
+
+@[simp, norm_cast]
+protected lemma coe_inv [linear_ordered_field α] (a : {x : α // 0 ≤ x}) :
+  ((a⁻¹ : {x : α // 0 ≤ x}) : α) = a⁻¹ := rfl
+
+@[simp] lemma inv_mk [linear_ordered_field α] {x : α} (hx : 0 ≤ x) :
+  (⟨x, hx⟩ : {x : α // 0 ≤ x})⁻¹ = ⟨x⁻¹, inv_nonneg.mpr hx⟩ :=
+rfl
+
+instance [linear_ordered_field α] : has_div {x : α // 0 ≤ x} :=
+{ div := λ x y, ⟨x / y, div_nonneg x.2 y.2⟩ }
+
+@[simp, norm_cast]
+protected lemma coe_div [linear_ordered_field α] (a b : {x : α // 0 ≤ x}) :
+  ((a / b : {x : α // 0 ≤ x}) : α) = a / b := rfl
+
+@[simp] lemma mk_div_mk [linear_ordered_field α] {x y : α} (hx : 0 ≤ x) (hy : 0 ≤ y) :
+  (⟨x, hx⟩ : {x : α // 0 ≤ x}) / ⟨y, hy⟩ = ⟨x / y, div_nonneg hx hy⟩ :=
+rfl
+
+instance [ordered_ring α] : canonically_ordered_add_monoid {x : α // 0 ≤ x} :=
+{ le_iff_exists_add     := λ ⟨a, ha⟩ ⟨b, hb⟩,
+    by simpa only [mk_add_mk, set_coe.exists, subtype.mk_eq_mk] using le_iff_exists_nonneg_add a b,
+  ..set.Ici.ordered_add_comm_monoid,
+  ..set.Ici.order_bot }
+
+instance [ordered_comm_ring α] [no_zero_divisors α] :
+  canonically_ordered_comm_semiring {x : α // 0 ≤ x} :=
+{ eq_zero_or_eq_zero_of_mul_eq_zero := by { rintro ⟨a, ha⟩ ⟨b, hb⟩, simp },
+  .. set.Ici.canonically_ordered_add_monoid,
+  .. set.Ici.ordered_comm_semiring }
+
+instance [linear_ordered_ring α] :
+  canonically_linear_ordered_add_monoid {x : α // 0 ≤ x} :=
+{ ..subtype.linear_order _, ..set.Ici.canonically_ordered_add_monoid }
+
+section linear_order
+
+variables [has_zero α] [linear_order α]
+
+def to_nonneg (a : α) : {x : α // 0 ≤ x} :=
+⟨max a 0, le_max_right _ _⟩
+
+@[simp]
+lemma coe_to_nonneg {a : α} : (to_nonneg a : α) = max a 0 := rfl
+
+@[simp]
+lemma to_nonneg_of_nonneg {a : α} (h : 0 ≤ a) : to_nonneg a = ⟨a, h⟩ :=
+by simp [to_nonneg, h]
+
+@[simp]
+lemma to_nonneg_coe {a : {x : α // 0 ≤ x}} : to_nonneg (a : α) = a :=
+by { cases a with a ha, exact to_nonneg_of_nonneg ha }
+
+@[simp]
+lemma to_nonneg_le {a : α} {b : {x : α // 0 ≤ x}} : to_nonneg a ≤ b ↔ a ≤ b :=
+by { cases b with b hb, simp [to_nonneg, mem_Ici.mp hb] }
+
+@[simp]
+lemma to_nonneg_lt {a : {x : α // 0 ≤ x}} {b : α} : a < to_nonneg b ↔ ↑a < b :=
+by { cases a with a ha, simp [to_nonneg, (mem_Ici.mp ha).not_lt] }
+
+instance [has_sub α] : has_sub {x : α // 0 ≤ x} :=
+⟨λ x y, to_nonneg (x - y)⟩
+
+@[simp] lemma mk_sub_mk [has_sub α] {x y : α}
+  (hx : 0 ≤ x) (hy : 0 ≤ y) : (⟨x, hx⟩ : {x : α // 0 ≤ x}) - ⟨y, hy⟩ = to_nonneg (x - y) :=
+rfl
+
+end linear_order
+
+end nonneg
+
+instance [linear_ordered_ring α] : has_ordered_sub {x : α // 0 ≤ x} :=
+⟨by { rintro ⟨a, ha⟩ ⟨b, hb⟩ ⟨c, hc⟩, simp [sub_le_iff_le_add] }⟩

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -28,10 +28,6 @@ variables {α : Type*}
 instance [partial_order α] [no_top_order α] {a : α} : no_top_order (Ici a) :=
 ⟨λ x, let ⟨y, hy⟩ := no_top x.1 in ⟨⟨y, le_trans x.2 hy.le⟩, hy⟩ ⟩
 
-lemma le_iff_exists_nonneg_add (a b : α) : a ≤ b ↔ ∃ c ≥ 0, b = a + c :=
-⟨λ h, ⟨b - a, sub_nonneg.mpr h, by simp⟩,
-  λ ⟨c, hc, h⟩, by { rw [h, le_add_iff_nonneg_right], exact hc }⟩
-
 namespace nonneg
 
 /-- -/
@@ -136,6 +132,10 @@ protected lemma coe_div [linear_ordered_field α] (a b : {x : α // 0 ≤ x}) :
 @[simp] lemma mk_div_mk [linear_ordered_field α] {x y : α} (hx : 0 ≤ x) (hy : 0 ≤ y) :
   (⟨x, hx⟩ : {x : α // 0 ≤ x}) / ⟨y, hy⟩ = ⟨x / y, div_nonneg hx hy⟩ :=
 rfl
+
+lemma le_iff_exists_nonneg_add [ordered_ring α] (a b : α) : a ≤ b ↔ ∃ c ≥ 0, b = a + c :=
+⟨λ h, ⟨b - a, sub_nonneg.mpr h, by simp⟩,
+  λ ⟨c, hc, h⟩, by { rw [h, le_add_iff_nonneg_right], exact hc }⟩
 
 instance canonically_ordered_add_monoid [ordered_ring α] :
   canonically_ordered_add_monoid {x : α // 0 ≤ x} :=

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -139,7 +139,7 @@ lemma le_iff_exists_nonneg_add [ordered_ring α] (a b : α) : a ≤ b ↔ ∃ c 
 instance canonically_ordered_add_monoid [ordered_ring α] :
   canonically_ordered_add_monoid {x : α // 0 ≤ x} :=
 { le_iff_exists_add     := λ ⟨a, ha⟩ ⟨b, hb⟩,
-    by simpa [mk_add_mk, subtype.exists, subtype.mk_eq_mk] using le_iff_exists_nonneg_add a b,
+    by simpa only [mk_add_mk, subtype.exists, subtype.mk_eq_mk] using le_iff_exists_nonneg_add a b,
   ..nonneg.ordered_add_comm_monoid,
   ..nonneg.order_bot }
 

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -3,9 +3,11 @@ Copyright (c) 2021 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
-import data.set.intervals.ord_connected
 import algebra.order.sub
+import algebra.order.with_zero
+import algebra.archimedean
 import order.lattice_intervals
+import order.conditionally_complete_lattice
 
 /-!
 ## The type of nonnegative elements
@@ -43,13 +45,24 @@ instance densely_ordered [preorder α] [densely_ordered α] {a : α} :
   densely_ordered {x : α // a ≤ x} :=
 show densely_ordered (Ici a), from set.densely_ordered
 
+@[reducible]
+protected noncomputable def conditionally_complete_linear_order_bot
+  [conditionally_complete_linear_order α] {a : α} (h : Sup ∅ ≤ a) :
+  conditionally_complete_linear_order_bot {x : α // a ≤ x} :=
+{ cSup_empty := (function.funext_iff.1
+    (@subset_Sup_def α (set.Ici a) _ ⟨⟨a, le_rfl⟩⟩) ∅).trans $ subtype.eq $
+      by { cases h.lt_or_eq with h2 h2, { simp [h2.not_le] }, simp [h2] },
+  ..nonneg.order_bot,
+  .. @ord_connected_subset_conditionally_complete_linear_order α (set.Ici a) _ ⟨⟨a, le_rfl⟩⟩ _ }
+
 instance inhabited [preorder α] {a : α} : inhabited {x : α // a ≤ x} :=
 ⟨⟨a, le_rfl⟩⟩
 
 instance has_zero [has_zero α] [preorder α] : has_zero {x : α // 0 ≤ x} :=
 ⟨⟨0, le_rfl⟩⟩
 
-@[simp] protected lemma coe_zero [has_zero α] [preorder α] : ((0 : {x : α // 0 ≤ x}) : α) = 0 := rfl
+@[simp, norm_cast]
+protected lemma coe_zero [has_zero α] [preorder α] : ((0 : {x : α // 0 ≤ x}) : α) = 0 := rfl
 
 @[simp] lemma mk_eq_zero [has_zero α] [preorder α] {x : α} (hx : 0 ≤ x) :
   (⟨x, hx⟩ : {x : α // 0 ≤ x}) = 0 ↔ x = 0 :=
@@ -84,10 +97,25 @@ instance linear_ordered_cancel_add_comm_monoid [linear_ordered_cancel_add_comm_m
 subtype.coe_injective.linear_ordered_cancel_add_comm_monoid
   (coe : {x : α // 0 ≤ x} → α) rfl (λ x y, rfl)
 
+/-- Coercion `{x : α // 0 ≤ x} → α` as a `add_monoid_hom`. -/
+def coe_add_monoid_hom [ordered_add_comm_monoid α] : {x : α // 0 ≤ x} →+ α :=
+⟨coe, nonneg.coe_zero, nonneg.coe_add⟩
+
+@[norm_cast]
+lemma nsmul_coe [ordered_add_comm_monoid α] (n : ℕ) (r : {x : α // 0 ≤ x}) :
+  ↑(n • r) = n • (r : α) :=
+nonneg.coe_add_monoid_hom.map_nsmul _ _
+
+instance archimedian [ordered_add_comm_monoid α] [archimedean α] : archimedean {x : α // 0 ≤ x} :=
+⟨ assume x y pos_y,
+  let ⟨n, hr⟩ := archimedean.arch (x : α) (pos_y : (0 : α) < y) in
+  ⟨n, show (x : α) ≤ (n • y : {x : α // 0 ≤ x}), by simp [*, -nsmul_eq_mul, nsmul_coe]⟩ ⟩
+
 instance has_one [ordered_semiring α] : has_one {x : α // 0 ≤ x} :=
 { one := ⟨1, zero_le_one⟩ }
 
-@[simp] protected lemma coe_one [ordered_semiring α] : ((1 : {x : α // 0 ≤ x}) : α) = 1 := rfl
+@[simp, norm_cast]
+protected lemma coe_one [ordered_semiring α] : ((1 : {x : α // 0 ≤ x}) : α) = 1 := rfl
 
 @[simp] lemma mk_eq_one [ordered_semiring α] {x : α} (hx : 0 ≤ x) :
   (⟨x, hx⟩ : {x : α // 0 ≤ x}) = 1 ↔ x = 1 :=
@@ -120,6 +148,16 @@ instance linear_ordered_semiring [linear_ordered_semiring α] :
 subtype.coe_injective.linear_ordered_semiring
   (coe : {x : α // 0 ≤ x} → α) rfl rfl (λ x y, rfl) (λ x y, rfl)
 
+instance linear_ordered_comm_monoid_with_zero [linear_ordered_comm_ring α] :
+  linear_ordered_comm_monoid_with_zero {x : α // 0 ≤ x} :=
+{ mul_le_mul_left := λ a b h c, mul_le_mul_of_nonneg_left h c.2,
+  ..nonneg.linear_ordered_semiring,
+  ..nonneg.ordered_comm_semiring }
+
+/-- Coercion `{x : α // 0 ≤ x} → α` as a `ring_hom`. -/
+def coe_ring_hom [ordered_semiring α] : {x : α // 0 ≤ x} →+* α :=
+⟨coe, nonneg.coe_one, nonneg.coe_mul, nonneg.coe_zero, nonneg.coe_add⟩
+
 instance has_inv [linear_ordered_field α] : has_inv {x : α // 0 ≤ x} :=
 { inv := λ x, ⟨x⁻¹, inv_nonneg.mpr x.2⟩ }
 
@@ -130,6 +168,14 @@ protected lemma coe_inv [linear_ordered_field α] (a : {x : α // 0 ≤ x}) :
 @[simp] lemma inv_mk [linear_ordered_field α] {x : α} (hx : 0 ≤ x) :
   (⟨x, hx⟩ : {x : α // 0 ≤ x})⁻¹ = ⟨x⁻¹, inv_nonneg.mpr hx⟩ :=
 rfl
+
+instance linear_ordered_comm_group_with_zero [linear_ordered_field α] :
+  linear_ordered_comm_group_with_zero {x : α // 0 ≤ x} :=
+{ inv_zero := by { ext, exact inv_zero },
+  mul_inv_cancel := by { intros a ha, ext, refine mul_inv_cancel (mt (λ h, _) ha), ext, exact h },
+  ..nonneg.nontrivial,
+  ..nonneg.has_inv,
+  ..nonneg.linear_ordered_comm_monoid_with_zero }
 
 instance has_div [linear_ordered_field α] : has_div {x : α // 0 ≤ x} :=
 { div := λ x y, ⟨x / y, div_nonneg x.2 y.2⟩ }
@@ -189,7 +235,7 @@ by { cases b with b hb, simp [to_nonneg, hb] }
 lemma to_nonneg_lt {a : {x : α // 0 ≤ x}} {b : α} : a < to_nonneg b ↔ ↑a < b :=
 by { cases a with a ha, simp [to_nonneg, ha.not_lt] }
 
-instance [has_sub α] : has_sub {x : α // 0 ≤ x} :=
+instance has_sub [has_sub α] : has_sub {x : α // 0 ≤ x} :=
 ⟨λ x y, to_nonneg (x - y)⟩
 
 @[simp] lemma mk_sub_mk [has_sub α] {x y : α}
@@ -199,6 +245,7 @@ rfl
 end linear_order
 
 instance has_ordered_sub [linear_ordered_ring α] : has_ordered_sub {x : α // 0 ≤ x} :=
-⟨by { rintro ⟨a, ha⟩ ⟨b, hb⟩ ⟨c, hc⟩, simp [sub_le_iff_le_add] }⟩
+⟨by { rintro ⟨a, ha⟩ ⟨b, hb⟩ ⟨c, hc⟩, simp only [sub_le_iff_le_add, subtype.mk_le_mk, mk_sub_mk,
+  mk_add_mk, to_nonneg_le, subtype.coe_mk]}⟩
 
 end nonneg

--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -955,6 +955,10 @@ def function.injective.ordered_ring {β : Type*}
   ..hf.ordered_semiring f zero one add mul,
   ..hf.ring f zero one add mul neg sub }
 
+lemma le_iff_exists_nonneg_add (a b : α) : a ≤ b ↔ ∃ c ≥ 0, b = a + c :=
+⟨λ h, ⟨b - a, sub_nonneg.mpr h, by simp⟩,
+  λ ⟨c, hc, h⟩, by { rw [h, le_add_iff_nonneg_right], exact hc }⟩
+
 end ordered_ring
 
 section ordered_comm_ring

--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -955,10 +955,6 @@ def function.injective.ordered_ring {β : Type*}
   ..hf.ordered_semiring f zero one add mul,
   ..hf.ring f zero one add mul neg sub }
 
-lemma le_iff_exists_nonneg_add (a b : α) : a ≤ b ↔ ∃ c ≥ 0, b = a + c :=
-⟨λ h, ⟨b - a, sub_nonneg.mpr h, by simp⟩,
-  λ ⟨c, hc, h⟩, by { rw [h, le_add_iff_nonneg_right], exact hc }⟩
-
 end ordered_ring
 
 section ordered_comm_ring

--- a/src/analysis/normed_space/enorm.lean
+++ b/src/analysis/normed_space/enorm.lean
@@ -30,6 +30,7 @@ We do not define extended normed groups. They can be added to the chain once som
 normed space, extended norm
 -/
 
+noncomputable theory
 local attribute [instance, priority 1001] classical.prop_decidable
 open_locale ennreal
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -8,6 +8,7 @@ import algebra.big_operators.ring
 import data.real.basic
 import algebra.indicator_function
 import algebra.algebra.basic
+import algebra.order.nonneg
 
 /-!
 # Nonnegative real numbers
@@ -47,6 +48,10 @@ noncomputable theory
 open_locale classical big_operators
 
 /-- Nonnegative real numbers. -/
+@[derive [semilattice_inf_bot, densely_ordered,
+  linear_ordered_add_comm_monoid, linear_ordered_semiring, ordered_comm_semiring,
+  canonically_linear_ordered_add_monoid, canonically_ordered_comm_semiring,
+  has_sub, has_ordered_sub, has_inv, has_div, inhabited]]
 def nnreal := {r : ℝ // 0 ≤ r}
 localized "notation ` ℝ≥0 ` := nnreal" in nnreal
 
@@ -83,16 +88,17 @@ lemma coe_nonneg (r : ℝ≥0) : (0 : ℝ) ≤ r := r.2
 @[norm_cast]
 theorem coe_mk (a : ℝ) (ha) : ((⟨a, ha⟩ : ℝ≥0) : ℝ) = a := rfl
 
-instance : has_zero ℝ≥0  := ⟨⟨0, le_refl 0⟩⟩
-instance : has_one ℝ≥0   := ⟨⟨1, zero_le_one⟩⟩
-instance : has_add ℝ≥0   := ⟨λa b, ⟨a + b, add_nonneg a.2 b.2⟩⟩
-instance : has_sub ℝ≥0   := ⟨λa b, real.to_nnreal (a - b)⟩
-instance : has_mul ℝ≥0   := ⟨λa b, ⟨a * b, mul_nonneg a.2 b.2⟩⟩
-instance : has_inv ℝ≥0   := ⟨λa, ⟨(a.1)⁻¹, inv_nonneg.2 a.2⟩⟩
-instance : has_div ℝ≥0   := ⟨λa b, ⟨a / b, div_nonneg a.2 b.2⟩⟩
-instance : has_le ℝ≥0    := ⟨λ r s, (r:ℝ) ≤ s⟩
-instance : has_bot ℝ≥0   := ⟨0⟩
-instance : inhabited ℝ≥0 := ⟨0⟩
+example : has_zero ℝ≥0  := by apply_instance
+example : has_one ℝ≥0   := by apply_instance
+example : has_add ℝ≥0   := by apply_instance
+example : has_sub ℝ≥0   := by apply_instance
+example : has_mul ℝ≥0   := by apply_instance
+example : has_inv ℝ≥0   := by apply_instance
+example : has_div ℝ≥0   := by apply_instance
+example : has_le ℝ≥0    := by apply_instance
+example : has_bot ℝ≥0   := by apply_instance
+example : inhabited ℝ≥0 := by apply_instance
+example : nontrivial ℝ≥0 := by apply_instance
 
 protected lemma coe_injective : function.injective (coe : ℝ≥0 → ℝ) := subtype.coe_injective
 @[simp, norm_cast] protected lemma coe_eq {r₁ r₂ : ℝ≥0} : (r₁ : ℝ) = r₂ ↔ r₁ = r₂ :=
@@ -119,12 +125,7 @@ by rw [← nnreal.coe_one, nnreal.coe_eq]
 
 lemma coe_ne_zero {r : ℝ≥0} : (r : ℝ) ≠ 0 ↔ r ≠ 0 := by norm_cast
 
-instance : comm_semiring ℝ≥0 :=
-{ zero := 0,
-  add := (+),
-  one := 1,
-  mul := (*),
-  .. nnreal.coe_injective.comm_semiring _ rfl rfl (λ _ _, rfl) (λ _ _, rfl) }
+example : comm_semiring ℝ≥0 := by apply_instance
 
 /-- Coercion `ℝ≥0 → ℝ` as a `ring_hom`. -/
 def to_real_hom : ℝ≥0 →+* ℝ :=
@@ -235,8 +236,7 @@ to_real_hom.to_add_monoid_hom.map_nsmul _ _
 @[simp, norm_cast] protected lemma coe_nat_cast (n : ℕ) : (↑(↑n : ℝ≥0) : ℝ) = n :=
 to_real_hom.map_nat_cast n
 
-instance : linear_order ℝ≥0 :=
-linear_order.lift (coe : ℝ≥0 → ℝ) nnreal.coe_injective
+example : linear_order ℝ≥0 := by apply_instance
 
 @[simp, norm_cast] protected lemma coe_le_coe {r₁ r₂ : ℝ≥0} : (r₁ : ℝ) ≤ r₂ ↔ r₁ ≤ r₂ := iff.rfl
 @[simp, norm_cast] protected lemma coe_lt_coe {r₁ r₂ : ℝ≥0} : (r₁ : ℝ) < r₂ ↔ r₁ < r₂ := iff.rfl
@@ -261,47 +261,21 @@ protected def gi : galois_insertion real.to_nnreal coe :=
 galois_insertion.monotone_intro nnreal.coe_mono real.to_nnreal_mono
   real.le_coe_to_nnreal (λ _, real.to_nnreal_coe)
 
-instance : order_bot ℝ≥0 :=
-{ bot := ⊥, bot_le := assume ⟨a, h⟩, h, .. nnreal.linear_order }
+example : order_bot ℝ≥0 := by apply_instance
 
-instance : canonically_linear_ordered_add_monoid ℝ≥0 :=
-{ add_le_add_left       := assume a b h c,
-    nnreal.coe_le_coe.mp $ (add_le_add_left (nnreal.coe_le_coe.mpr h) c),
-  le_iff_exists_add     := assume ⟨a, ha⟩ ⟨b, hb⟩,
-    iff.intro
-      (assume h : a ≤ b,
-        ⟨⟨b - a, le_sub_iff_add_le.2 $ (zero_add _).le.trans h⟩,
-          nnreal.eq $ show b = a + (b - a), from (add_sub_cancel'_right _ _).symm⟩)
-      (assume ⟨⟨c, hc⟩, eq⟩, eq.symm ▸ show a ≤ a + c, from (le_add_iff_nonneg_right a).2 hc),
-  ..nnreal.comm_semiring,
-  ..nnreal.order_bot,
-  ..nnreal.linear_order }
+example : canonically_linear_ordered_add_monoid ℝ≥0 := by apply_instance
 
-instance : linear_ordered_add_comm_monoid ℝ≥0 :=
-{ .. nnreal.comm_semiring,
-  .. nnreal.canonically_linear_ordered_add_monoid }
+example : linear_ordered_add_comm_monoid ℝ≥0 := by apply_instance
 
-instance : distrib_lattice ℝ≥0 := by apply_instance
+example : distrib_lattice ℝ≥0 := by apply_instance
 
-instance : semilattice_inf_bot ℝ≥0 :=
-{ .. nnreal.order_bot, .. nnreal.distrib_lattice }
+example : semilattice_inf_bot ℝ≥0 := by apply_instance
 
-instance : semilattice_sup_bot ℝ≥0 :=
-{ .. nnreal.order_bot, .. nnreal.distrib_lattice }
+example : semilattice_sup_bot ℝ≥0 := by apply_instance
 
-instance : linear_ordered_semiring ℝ≥0 :=
-{ add_left_cancel            := assume a b c h, nnreal.eq $
-    @add_left_cancel ℝ _ a b c (nnreal.eq_iff.2 h),
-  le_of_add_le_add_left      := assume a b c, @le_of_add_le_add_left ℝ _ _ _ a b c,
-  mul_lt_mul_of_pos_left     := assume a b c, @mul_lt_mul_of_pos_left ℝ _ a b c,
-  mul_lt_mul_of_pos_right    := assume a b c, @mul_lt_mul_of_pos_right ℝ _ a b c,
-  zero_le_one                := @zero_le_one ℝ _,
-  exists_pair_ne             := ⟨0, 1, ne_of_lt (@zero_lt_one ℝ _ _)⟩,
-  .. nnreal.canonically_linear_ordered_add_monoid,
-  .. nnreal.comm_semiring }
+example : linear_ordered_semiring ℝ≥0 := by apply_instance
 
-instance : ordered_comm_semiring ℝ≥0 :=
-{ .. nnreal.linear_ordered_semiring, .. nnreal.comm_semiring }
+example : ordered_comm_semiring ℝ≥0 := by apply_instance
 
 instance : linear_ordered_comm_group_with_zero ℝ≥0 :=
 { mul_le_mul_left := assume a b h c, mul_le_mul (le_refl c) h (zero_le a) (zero_le c),
@@ -309,18 +283,11 @@ instance : linear_ordered_comm_group_with_zero ℝ≥0 :=
   .. nnreal.linear_ordered_semiring,
   .. nnreal.comm_group_with_zero }
 
-instance : canonically_ordered_comm_semiring ℝ≥0 :=
-{ .. nnreal.canonically_linear_ordered_add_monoid,
-  .. nnreal.comm_semiring,
-  .. (show no_zero_divisors ℝ≥0, by apply_instance),
-  .. nnreal.comm_group_with_zero }
+example : canonically_ordered_comm_semiring ℝ≥0 := by apply_instance
 
-instance : densely_ordered ℝ≥0 :=
-⟨assume a b (h : (a : ℝ) < b), let ⟨c, hac, hcb⟩ := exists_between h in
-  ⟨⟨c, le_trans a.property $ le_of_lt $ hac⟩, hac, hcb⟩⟩
+example : densely_ordered ℝ≥0 := by apply_instance
 
-instance : no_top_order ℝ≥0 :=
-⟨assume a, let ⟨b, hb⟩ := no_top (a:ℝ) in ⟨⟨b, le_trans a.property $ le_of_lt $ hb⟩, hb⟩⟩
+example : no_top_order ℝ≥0 := by apply_instance
 
 lemma bdd_above_coe {s : set ℝ≥0} : bdd_above ((coe : ℝ≥0 → ℝ) '' s) ↔ bdd_above s :=
 iff.intro
@@ -331,7 +298,7 @@ iff.intro
 lemma bdd_below_coe (s : set ℝ≥0) : bdd_below ((coe : ℝ≥0 → ℝ) '' s) :=
 ⟨0, assume r ⟨q, _, eq⟩, eq ▸ q.2⟩
 
-instance : conditionally_complete_linear_order_bot ℝ≥0 :=
+example : conditionally_complete_linear_order_bot ℝ≥0 :=
 { cSup_empty := (function.funext_iff.1
     (@subset_Sup_def ℝ (set.Ici (0 : ℝ)) _ ⟨(0 : ℝ≥0)⟩) ∅).trans $ nnreal.eq $ by simp,
   .. nnreal.order_bot,
@@ -545,9 +512,7 @@ lemma sub_def {r p : ℝ≥0} : r - p = real.to_nnreal (r - p) := rfl
 
 lemma coe_sub_def {r p : ℝ≥0} : ↑(r - p) = max (r - p : ℝ) 0 := rfl
 
-instance : has_ordered_sub ℝ≥0 :=
-⟨λ a b c, by simp only [← nnreal.coe_le_coe, nnreal.coe_add, coe_sub_def, max_le_iff, c.coe_nonneg,
-  and_true, sub_le_iff_le_add]⟩
+example : has_ordered_sub ℝ≥0 := by apply_instance
 
 lemma sub_div (a b c : ℝ≥0) : (a - b) / c = a / c - b / c :=
 by simp only [div_eq_mul_inv, sub_mul']

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -48,9 +48,9 @@ open_locale classical big_operators
 
 /-- Nonnegative real numbers. -/
 @[derive [semilattice_inf_bot, densely_ordered,
-  linear_ordered_add_comm_monoid, linear_ordered_semiring, ordered_comm_semiring,
-  canonically_linear_ordered_add_monoid, canonically_ordered_comm_semiring,
-  has_sub, has_ordered_sub, linear_ordered_comm_group_with_zero, has_div, inhabited, archimedean]]
+  canonically_linear_ordered_add_monoid, linear_ordered_comm_group_with_zero, archimedean,
+  linear_ordered_semiring, ordered_comm_semiring, canonically_ordered_comm_semiring,
+  has_sub, has_ordered_sub, has_div, inhabited]]
 def nnreal := {r : ℝ // 0 ≤ r}
 localized "notation ` ℝ≥0 ` := nnreal" in nnreal
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -51,7 +51,7 @@ open_locale classical big_operators
 @[derive [semilattice_inf_bot, densely_ordered,
   linear_ordered_add_comm_monoid, linear_ordered_semiring, ordered_comm_semiring,
   canonically_linear_ordered_add_monoid, canonically_ordered_comm_semiring,
-  has_sub, has_ordered_sub, has_inv, has_div, inhabited]]
+  has_sub, has_ordered_sub, linear_ordered_comm_group_with_zero, has_div, inhabited, archimedean]]
 def nnreal := {r : ℝ // 0 ≤ r}
 localized "notation ` ℝ≥0 ` := nnreal" in nnreal
 
@@ -103,12 +103,12 @@ example : nontrivial ℝ≥0 := by apply_instance
 protected lemma coe_injective : function.injective (coe : ℝ≥0 → ℝ) := subtype.coe_injective
 @[simp, norm_cast] protected lemma coe_eq {r₁ r₂ : ℝ≥0} : (r₁ : ℝ) = r₂ ↔ r₁ = r₂ :=
 nnreal.coe_injective.eq_iff
-@[simp, norm_cast] protected lemma coe_zero : ((0 : ℝ≥0) : ℝ) = 0 := rfl
-@[simp, norm_cast] protected lemma coe_one  : ((1 : ℝ≥0) : ℝ) = 1 := rfl
-@[simp, norm_cast] protected lemma coe_add (r₁ r₂ : ℝ≥0) : ((r₁ + r₂ : ℝ≥0) : ℝ) = r₁ + r₂ := rfl
-@[simp, norm_cast] protected lemma coe_mul (r₁ r₂ : ℝ≥0) : ((r₁ * r₂ : ℝ≥0) : ℝ) = r₁ * r₂ := rfl
-@[simp, norm_cast] protected lemma coe_inv (r : ℝ≥0) : ((r⁻¹ : ℝ≥0) : ℝ) = r⁻¹ := rfl
-@[simp, norm_cast] protected lemma coe_div (r₁ r₂ : ℝ≥0) : ((r₁ / r₂ : ℝ≥0) : ℝ) = r₁ / r₂ := rfl
+protected lemma coe_zero : ((0 : ℝ≥0) : ℝ) = 0 := rfl
+protected lemma coe_one  : ((1 : ℝ≥0) : ℝ) = 1 := rfl
+protected lemma coe_add (r₁ r₂ : ℝ≥0) : ((r₁ + r₂ : ℝ≥0) : ℝ) = r₁ + r₂ := rfl
+protected lemma coe_mul (r₁ r₂ : ℝ≥0) : ((r₁ * r₂ : ℝ≥0) : ℝ) = r₁ * r₂ := rfl
+protected lemma coe_inv (r : ℝ≥0) : ((r⁻¹ : ℝ≥0) : ℝ) = r⁻¹ := rfl
+protected lemma coe_div (r₁ r₂ : ℝ≥0) : ((r₁ / r₂ : ℝ≥0) : ℝ) = r₁ / r₂ := rfl
 @[simp, norm_cast] protected lemma coe_bit0 (r : ℝ≥0) : ((bit0 r : ℝ≥0) : ℝ) = bit0 r := rfl
 @[simp, norm_cast] protected lemma coe_bit1 (r : ℝ≥0) : ((bit1 r : ℝ≥0) : ℝ) = bit1 r := rfl
 
@@ -175,13 +175,7 @@ example : distrib_mul_action (units ℝ≥0) ℝ := by apply_instance
 
 end actions
 
-instance : comm_group_with_zero ℝ≥0 :=
-{ zero := 0,
-  mul := (*),
-  one := 1,
-  inv := has_inv.inv,
-  div := (/),
-  .. nnreal.coe_injective.comm_group_with_zero _ rfl rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) }
+example : comm_group_with_zero ℝ≥0 := by apply_instance
 
 @[simp, norm_cast] lemma coe_indicator {α} (s : set α) (f : α → ℝ≥0) (a : α) :
   ((s.indicator f a : ℝ≥0) : ℝ) = s.indicator (λ x, f x) a :=
@@ -230,8 +224,8 @@ begin
   exact finset.prod_congr rfl (λ x hxs, by rw real.coe_to_nnreal _ (hf x hxs)),
 end
 
-@[norm_cast] lemma nsmul_coe (r : ℝ≥0) (n : ℕ) : ↑(n • r) = n • (r:ℝ) :=
-to_real_hom.to_add_monoid_hom.map_nsmul _ _
+lemma nsmul_coe (r : ℝ≥0) (n : ℕ) : ↑(n • r) = n • (r:ℝ) :=
+by norm_cast
 
 @[simp, norm_cast] protected lemma coe_nat_cast (n : ℕ) : (↑(↑n : ℝ≥0) : ℝ) = n :=
 to_real_hom.map_nat_cast n
@@ -262,31 +256,18 @@ galois_insertion.monotone_intro nnreal.coe_mono real.to_nnreal_mono
   real.le_coe_to_nnreal (λ _, real.to_nnreal_coe)
 
 example : order_bot ℝ≥0 := by apply_instance
-
 example : canonically_linear_ordered_add_monoid ℝ≥0 := by apply_instance
-
 example : linear_ordered_add_comm_monoid ℝ≥0 := by apply_instance
-
 example : distrib_lattice ℝ≥0 := by apply_instance
-
 example : semilattice_inf_bot ℝ≥0 := by apply_instance
-
 example : semilattice_sup_bot ℝ≥0 := by apply_instance
-
 example : linear_ordered_semiring ℝ≥0 := by apply_instance
-
 example : ordered_comm_semiring ℝ≥0 := by apply_instance
-
-instance : linear_ordered_comm_group_with_zero ℝ≥0 :=
-{ mul_le_mul_left := assume a b h c, mul_le_mul (le_refl c) h (zero_le a) (zero_le c),
-  zero_le_one := zero_le 1,
-  .. nnreal.linear_ordered_semiring,
-  .. nnreal.comm_group_with_zero }
-
+example : linear_ordered_comm_monoid  ℝ≥0 := by apply_instance
+example : linear_ordered_comm_monoid_with_zero ℝ≥0 := by apply_instance
+example : linear_ordered_comm_group_with_zero ℝ≥0 := by apply_instance
 example : canonically_ordered_comm_semiring ℝ≥0 := by apply_instance
-
 example : densely_ordered ℝ≥0 := by apply_instance
-
 example : no_top_order ℝ≥0 := by apply_instance
 
 lemma bdd_above_coe {s : set ℝ≥0} : bdd_above ((coe : ℝ≥0 → ℝ) '' s) ↔ bdd_above s :=
@@ -298,10 +279,10 @@ iff.intro
 lemma bdd_below_coe (s : set ℝ≥0) : bdd_below ((coe : ℝ≥0 → ℝ) '' s) :=
 ⟨0, assume r ⟨q, _, eq⟩, eq ▸ q.2⟩
 
-example : conditionally_complete_linear_order_bot ℝ≥0 :=
+instance : conditionally_complete_linear_order_bot ℝ≥0 :=
 { cSup_empty := (function.funext_iff.1
     (@subset_Sup_def ℝ (set.Ici (0 : ℝ)) _ ⟨(0 : ℝ≥0)⟩) ∅).trans $ nnreal.eq $ by simp,
-  .. nnreal.order_bot,
+  .. (by apply_instance : order_bot ℝ≥0),
   .. @ord_connected_subset_conditionally_complete_linear_order ℝ (set.Ici (0 : ℝ)) _ ⟨(0 : ℝ≥0)⟩ _ }
 
 lemma coe_Sup (s : set ℝ≥0) : (↑(Sup s) : ℝ) = Sup ((coe : ℝ≥0 → ℝ) '' s) :=
@@ -312,10 +293,7 @@ lemma coe_Inf (s : set ℝ≥0) : (↑(Inf s) : ℝ) = Inf ((coe : ℝ≥0 → �
 eq.symm $ @subset_Inf_of_within ℝ (set.Ici 0) _ ⟨(0 : ℝ≥0)⟩ s $
   real.Inf_nonneg _ $ λ y ⟨x, _, hy⟩, hy ▸ x.2
 
-instance : archimedean ℝ≥0 :=
-⟨ assume x y pos_y,
-  let ⟨n, hr⟩ := archimedean.arch (x:ℝ) (pos_y : (0 : ℝ) < y) in
-  ⟨n, show (x:ℝ) ≤ (n • y : ℝ≥0), by simp [*, -nsmul_eq_mul, nsmul_coe]⟩ ⟩
+example : archimedean ℝ≥0 := by apply_instance
 
 lemma le_of_forall_pos_le_add {a b : ℝ≥0} (h : ∀ε, 0 < ε → a ≤ b + ε) : a ≤ b :=
 le_of_forall_le_of_dense $ assume x hxb,
@@ -504,8 +482,8 @@ section sub
 /-!
 ### Lemmas about subtraction
 
-In this section we provide the instance `nnreal.has_ordered_sub` and a few lemmas about subtraction
-that do not fit well into any other typeclass. For lemmas about subtraction and addition see lemmas
+In this section we provide a few lemmas about subtraction that do not fit well into any other
+typeclass. For lemmas about subtraction and addition see lemmas
 about `has_ordered_sub` in the file `algebra.order.sub`. See also `mul_sub'` and `sub_mul'`. -/
 
 lemma sub_def {r p : ℝ≥0} : r - p = real.to_nnreal (r - p) := rfl

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import algebra.order.with_zero
 import algebra.big_operators.ring
 import data.real.basic
 import algebra.indicator_function

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -24,10 +24,14 @@ a.k.a. the interval `[0, ∞)`. We also define the following operations and stru
   the following instances instead:
 
   - `linear_ordered_semiring ℝ≥0`;
-  - `comm_semiring ℝ≥0`;
+  - `ordered_comm_semiring ℝ≥0`;
   - `canonically_ordered_comm_semiring ℝ≥0`;
   - `linear_ordered_comm_group_with_zero ℝ≥0`;
+  - `canonically_linear_ordered_add_monoid ℝ≥0`
   - `archimedean ℝ≥0`.
+
+  These instances are derived from corresponding instances about the type `{x : α // 0 ≤ x}` in an
+  appropriate ordered field/ring/group/monoid `α`. See `algebra/order/nonneg`.
 
 * `real.to_nnreal x` is defined as `⟨max x 0, _⟩`, i.e. `↑(real.to_nnreal x) = x` when `0 ≤ x` and
   `↑(real.to_nnreal x) = 0` otherwise.

--- a/src/measure_theory/decomposition/jordan.lean
+++ b/src/measure_theory/decomposition/jordan.lean
@@ -185,8 +185,8 @@ let hi := some_spec s.exists_compl_positive_negative in
   mutually_singular :=
   begin
     refine ⟨iᶜ, hi.1.compl, _, _⟩,
-    { rw [to_measure_of_zero_le_apply _ _ hi.1 hi.1.compl], simpa },
-    { rw [to_measure_of_le_zero_apply _ _ hi.1.compl hi.1.compl.compl], simpa }
+    { rw [to_measure_of_zero_le_apply _ _ hi.1 hi.1.compl], simp },
+    { rw [to_measure_of_le_zero_apply _ _ hi.1.compl hi.1.compl.compl], simp }
   end }
 
 lemma to_jordan_decomposition_spec (s : signed_measure α) :
@@ -492,8 +492,7 @@ begin
         to_measure_of_zero_le_apply _ _ _ hS₁, to_measure_of_le_zero_apply _ _ _ hS₁],
     rw ← vector_measure.absolutely_continuous.ennreal_to_measure at h,
     simp [h (measure_mono_null (i.inter_subset_right S) hS₂),
-          h (measure_mono_null (iᶜ.inter_subset_right S) hS₂)],
-    refl },
+          h (measure_mono_null (iᶜ.inter_subset_right S) hS₂)] },
   { refine vector_measure.absolutely_continuous.mk (λ S hS₁ hS₂, _),
     rw ← vector_measure.ennreal_to_measure_apply hS₁ at hS₂,
     exact null_of_total_variation_zero s (h hS₂) }
@@ -524,11 +523,11 @@ begin
     refine ⟨u, hmeas, _, _⟩,
     { rw [total_variation, measure.add_apply, hipos, hineg,
       to_measure_of_zero_le_apply _ _ _ hmeas, to_measure_of_le_zero_apply _ _ _ hmeas],
-      simpa [hu₁ _ (set.inter_subset_right _ _)] },
+      simp [hu₁ _ (set.inter_subset_right _ _)] },
     { rw [total_variation, measure.add_apply, hjpos, hjneg,
           to_measure_of_zero_le_apply _ _ _ hmeas.compl,
           to_measure_of_le_zero_apply _ _ _ hmeas.compl],
-      simpa [hu₂ _ (set.inter_subset_right _ _)] } },
+      simp [hu₂ _ (set.inter_subset_right _ _)] } },
   { rintro ⟨u, hmeas, hu₁, hu₂⟩,
     exact ⟨u, hmeas,
       (λ t htu, null_of_total_variation_zero _ (measure_mono_null htu hu₁)),
@@ -544,7 +543,7 @@ begin
     refine ⟨u, hmeas, _, _⟩,
     { rw [total_variation, measure.add_apply, hpos, hneg,
           to_measure_of_zero_le_apply _ _ _ hmeas, to_measure_of_le_zero_apply _ _ _ hmeas],
-      simpa [hu₁ _ (set.inter_subset_right _ _)] },
+      simp [hu₁ _ (set.inter_subset_right _ _)] },
     { rw vector_measure.ennreal_to_measure_apply hmeas.compl,
       exact hu₂ _ (set.subset.refl _) } },
   { rintro ⟨u, hmeas, hu₁, hu₂⟩,

--- a/src/order/lattice_intervals.lean
+++ b/src/order/lattice_intervals.lean
@@ -118,6 +118,9 @@ instance [order_bot α] : order_bot (Iic a) :=
 
 @[simp] lemma coe_bot [order_bot α] {a : α} : ↑(⊥ : Iic a) = (⊥ : α) := rfl
 
+instance [partial_order α] [no_bot_order α] {a : α} : no_bot_order (Iic a) :=
+⟨λ x, let ⟨y, hy⟩ := no_bot x.1 in ⟨⟨y, le_trans hy.le x.2⟩, hy⟩ ⟩
+
 instance [semilattice_inf_bot α] : semilattice_inf_bot (Iic a) :=
 { .. (Iic.semilattice_inf),
   .. (Iic.order_bot) }
@@ -167,6 +170,9 @@ instance [order_top α] : order_top (Ici a) :=
   .. (infer_instance : partial_order (Ici a)) }
 
 @[simp] lemma coe_top [order_top α] {a : α} : ↑(⊤ : Ici a) = (⊤ : α) := rfl
+
+instance [partial_order α] [no_top_order α] {a : α} : no_top_order (Ici a) :=
+⟨λ x, let ⟨y, hy⟩ := no_top x.1 in ⟨⟨y, le_trans x.2 hy.le⟩, hy⟩ ⟩
 
 instance [semilattice_sup_top α] : semilattice_sup_top (Ici a) :=
 { .. (Ici.semilattice_sup),

--- a/src/order/lattice_intervals.lean
+++ b/src/order/lattice_intervals.lean
@@ -118,9 +118,6 @@ instance [order_bot α] : order_bot (Iic a) :=
 
 @[simp] lemma coe_bot [order_bot α] {a : α} : ↑(⊥ : Iic a) = (⊥ : α) := rfl
 
-instance [partial_order α] [no_bot_order α] {a : α} : no_bot_order (Iic a) :=
-⟨λ x, let ⟨y, hy⟩ := no_bot x.1 in ⟨⟨y, le_trans hy.le x.2⟩, hy⟩ ⟩
-
 instance [semilattice_inf_bot α] : semilattice_inf_bot (Iic a) :=
 { .. (Iic.semilattice_inf),
   .. (Iic.order_bot) }
@@ -170,9 +167,6 @@ instance [order_top α] : order_top (Ici a) :=
   .. (infer_instance : partial_order (Ici a)) }
 
 @[simp] lemma coe_top [order_top α] {a : α} : ↑(⊤ : Ici a) = (⊤ : α) := rfl
-
-instance [partial_order α] [no_top_order α] {a : α} : no_top_order (Ici a) :=
-⟨λ x, let ⟨y, hy⟩ := no_top x.1 in ⟨⟨y, le_trans x.2 hy.le⟩, hy⟩ ⟩
 
 instance [semilattice_sup_top α] : semilattice_sup_top (Ici a) :=
 { .. (Ici.semilattice_sup),


### PR DESCRIPTION
* Provide various classes on the type `{x : α // 0 ≤ x}` where `α` has some order (and algebraic) structure.
* Use this to automatically derive the classes on `nnreal`.
* We currently do not yet define `conditionally_complete_linear_order_bot nnreal` using nonneg, since that causes some errors (I think Lean then thinks that there are two orders that are not definitionally equal (unfolding only instances)).
* We leave a bunch of `example` lines in `nnreal` to show that `nnreal` has all the old classes. These could also be removed, if desired.
* We currently only give some instances and simp/norm_cast lemmas. This could be expanded in the future.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
