### PR TITLE
[Merged by Bors] - feat(algebra/gcd_monoid): trivial `gcd` on `comm_group_with_zero`s

### DIFF
--- a/src/algebra/gcd_monoid/basic.lean
+++ b/src/algebra/gcd_monoid/basic.lean
@@ -163,25 +163,6 @@ units.mul_right_dvd
 
 end normalization_monoid
 
-namespace comm_group_with_zero
-variables [decidable_eq α] [comm_group_with_zero α]
-
-@[priority 100] -- see Note [lower instance priority]
-instance : normalization_monoid α :=
-{ norm_unit := λ x, if h : x = 0 then 1 else (units.mk0 x h)⁻¹,
-  norm_unit_zero := dif_pos rfl,
-  norm_unit_mul := λ x y x0 y0, units.eq_iff.1 (by simp [x0, y0, mul_comm]),
-  norm_unit_coe_units := λ u, by { rw [dif_neg (units.ne_zero _), units.mk0_coe], apply_instance } }
-
-@[simp]
-lemma coe_norm_unit {a : α} (h0 : a ≠ 0) : (↑(norm_unit a) : α) = a⁻¹ :=
-by simp [norm_unit, h0]
-
-lemma normalize_eq_one {a : α} (h0 : a ≠ 0) : normalize a = 1 :=
-by simp [norm_unit, h0]
-
-end comm_group_with_zero
-
 namespace associates
 variables [comm_cancel_monoid_with_zero α] [normalization_monoid α]
 
@@ -1064,8 +1045,12 @@ namespace comm_group_with_zero
 variables (G₀ : Type*) [comm_group_with_zero G₀] [decidable_eq G₀]
 
 @[priority 100] -- see Note [lower instance priority]
-instance : gcd_monoid G₀ :=
-{ gcd := λ a b, if a = 0 ∧ b = 0 then 0 else 1,
+instance : normalized_gcd_monoid G₀ :=
+{ norm_unit := λ x, if h : x = 0 then 1 else (units.mk0 x h)⁻¹,
+  norm_unit_zero := dif_pos rfl,
+  norm_unit_mul := λ x y x0 y0, units.eq_iff.1 (by simp [x0, y0, mul_comm]),
+  norm_unit_coe_units := λ u, by { rw [dif_neg (units.ne_zero _), units.mk0_coe], apply_instance },
+  gcd := λ a b, if a = 0 ∧ b = 0 then 0 else 1,
   lcm := λ a b, if a = 0 ∨ b = 0 then 0 else 1,
   gcd_dvd_left := λ a b, by { split_ifs with h, { rw h.1 }, { exact one_dvd _ } },
   gcd_dvd_right := λ a b, by { split_ifs with h, { rw h.2 }, { exact one_dvd _ } },
@@ -1082,13 +1067,16 @@ instance : gcd_monoid G₀ :=
     exact (associated_one_iff_is_unit.mpr ((is_unit.mk0 _ ha).mul (is_unit.mk0 _ hb))).symm
   end,
   lcm_zero_left := λ b, if_pos (or.inl rfl),
-  lcm_zero_right := λ a, if_pos (or.inr rfl) }
+  lcm_zero_right := λ a, if_pos (or.inr rfl),
+  -- `split_ifs` wants to split `normalize`, so handle the cases manually
+  normalize_gcd := λ a b, if h : a = 0 ∧ b = 0 then by simp [if_pos h] else by simp [if_neg h],
+  normalize_lcm := λ a b, if h : a = 0 ∨ b = 0 then by simp [if_pos h] else by simp [if_neg h] }
 
-@[priority 100] -- see Note [lower instance priority]
-instance : normalized_gcd_monoid G₀ :=
-{ normalize_gcd := λ a b, by { unfold gcd, split_ifs; simp },
-  normalize_lcm := λ a b, by { unfold lcm, split_ifs; simp },
-  .. comm_group_with_zero.gcd_monoid G₀,
-  .. comm_group_with_zero.normalization_monoid }
+@[simp]
+lemma coe_norm_unit {a : G₀} (h0 : a ≠ 0) : (↑(norm_unit a) : G₀) = a⁻¹ :=
+by simp [norm_unit, normalized_gcd_monoid.norm_unit, h0]
+
+lemma normalize_eq_one {a : G₀} (h0 : a ≠ 0) : normalize a = 1 :=
+by simp [normalize_apply, h0]
 
 end comm_group_with_zero

--- a/src/algebra/gcd_monoid/basic.lean
+++ b/src/algebra/gcd_monoid/basic.lean
@@ -177,6 +177,9 @@ instance : normalization_monoid α :=
 lemma coe_norm_unit {a : α} (h0 : a ≠ 0) : (↑(norm_unit a) : α) = a⁻¹ :=
 by simp [norm_unit, h0]
 
+lemma normalize_eq_one {a : α} (h0 : a ≠ 0) : normalize a = 1 :=
+by simp [norm_unit, h0]
+
 end comm_group_with_zero
 
 namespace associates
@@ -1055,3 +1058,37 @@ normalized_gcd_monoid_of_lcm
   (λ a b, normalize_idem _)
 
 end constructors
+
+namespace comm_group_with_zero
+
+variables (G₀ : Type*) [comm_group_with_zero G₀] [decidable_eq G₀]
+
+@[priority 100] -- see Note [lower instance priority]
+instance : gcd_monoid G₀ :=
+{ gcd := λ a b, if a = 0 ∧ b = 0 then 0 else 1,
+  lcm := λ a b, if a = 0 ∨ b = 0 then 0 else 1,
+  gcd_dvd_left := λ a b, by { split_ifs with h, { rw h.1 }, { exact one_dvd _ } },
+  gcd_dvd_right := λ a b, by { split_ifs with h, { rw h.2 }, { exact one_dvd _ } },
+  dvd_gcd := λ a b c hac hab, begin
+    split_ifs with h, { apply dvd_zero },
+    cases not_and_distrib.mp h with h h;
+      refine is_unit_iff_dvd_one.mp (is_unit_of_dvd_unit _ (is_unit.mk0 _ h));
+      assumption
+  end,
+  gcd_mul_lcm := λ a b, begin
+    by_cases ha : a = 0, { simp [ha] },
+    by_cases hb : b = 0, { simp [hb] },
+    rw [if_neg (not_and_of_not_left _ ha), one_mul, if_neg (not_or ha hb)],
+    exact (associated_one_iff_is_unit.mpr ((is_unit.mk0 _ ha).mul (is_unit.mk0 _ hb))).symm
+  end,
+  lcm_zero_left := λ b, if_pos (or.inl rfl),
+  lcm_zero_right := λ a, if_pos (or.inr rfl) }
+
+@[priority 100] -- see Note [lower instance priority]
+instance : normalized_gcd_monoid G₀ :=
+{ normalize_gcd := λ a b, by { unfold gcd, split_ifs; simp },
+  normalize_lcm := λ a b, by { unfold lcm, split_ifs; simp },
+  .. comm_group_with_zero.gcd_monoid G₀,
+  .. comm_group_with_zero.normalization_monoid }
+
+end comm_group_with_zero

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -138,7 +138,8 @@ class unique_factorization_monoid (α : Type*) [comm_cancel_monoid_with_zero α]
   extends wf_dvd_monoid α : Prop :=
 (irreducible_iff_prime : ∀ {a : α}, irreducible a ↔ prime a)
 
-instance ufm_of_gcd_of_wf_dvd_monoid [comm_cancel_monoid_with_zero α]
+/-- Can't be an instance because it would cause a loop `ufm → wf_dvd_monoid → ufm → ...`. -/
+lemma ufm_of_gcd_of_wf_dvd_monoid [comm_cancel_monoid_with_zero α]
   [wf_dvd_monoid α] [gcd_monoid α] : unique_factorization_monoid α :=
 { irreducible_iff_prime := λ _, gcd_monoid.irreducible_iff_prime
   .. ‹wf_dvd_monoid α› }


### PR DESCRIPTION
This PR extends the `normalization_monoid` defined on `comm_group_with_zero`s (e.g. fields) to a `normalized_gcd_monoid`. This is useful if you need to take the gcd of two polynomials in a field.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
