### PR TITLE
[Merged by Bors] - refactor(topology/sheaves/*): Make sheaf condition a Prop

### DIFF
--- a/src/algebraic_geometry/Spec.lean
+++ b/src/algebraic_geometry/Spec.lean
@@ -81,7 +81,9 @@ The spectrum, as a contravariant functor from commutative rings to topological s
 The spectrum of a commutative ring, as a `SheafedSpace`.
 -/
 @[simps] def Spec.SheafedSpace_obj (R : CommRing) : SheafedSpace CommRing :=
-{ carrier := Spec.Top_obj R, ..structure_sheaf R }
+{ carrier := Spec.Top_obj R,
+  presheaf := (structure_sheaf R).1,
+  is_sheaf := (structure_sheaf R).2 }
 
 /--
 The induced map of a ring homomorphism on the ring spectra, as a morphism of sheafed spaces.
@@ -111,7 +113,7 @@ PresheafedSpace.ext _ _ (Spec.Top_map_comp f g) $ nat_trans.ext _ _ $ funext $ Œ
 begin
   dsimp,
   erw [Top.presheaf.pushforward.comp_inv_app, ‚Üê category.assoc, category.comp_id,
-    (structure_sheaf T).presheaf.map_id, category.comp_id, comap_comp],
+    (structure_sheaf T).1.map_id, category.comp_id, comap_comp],
   refl,
 end
 

--- a/src/algebraic_geometry/locally_ringed_space.lean
+++ b/src/algebraic_geometry/locally_ringed_space.lean
@@ -167,7 +167,7 @@ instance : reflects_isomorphisms forget_to_SheafedSpace :=
 The restriction of a locally ringed space along an open embedding.
 -/
 @[simps]
-noncomputable def restrict {U : Top} (X : LocallyRingedSpace) (f : U ⟶ X.to_Top)
+def restrict {U : Top} (X : LocallyRingedSpace) (f : U ⟶ X.to_Top)
   (h : open_embedding f) : LocallyRingedSpace :=
 { local_ring :=
   begin
@@ -182,7 +182,7 @@ noncomputable def restrict {U : Top} (X : LocallyRingedSpace) (f : U ⟶ X.to_To
 /--
 The restriction of a locally ringed space `X` to the top subspace is isomorphic to `X` itself.
 -/
-noncomputable def restrict_top_iso (X : LocallyRingedSpace) :
+def restrict_top_iso (X : LocallyRingedSpace) :
   X.restrict (opens.inclusion ⊤) (opens.open_embedding ⊤) ≅ X :=
 @iso_of_SheafedSpace_iso (X.restrict (opens.inclusion ⊤) (opens.open_embedding ⊤)) X
   X.to_SheafedSpace.restrict_top_iso

--- a/src/algebraic_geometry/sheafed_space.lean
+++ b/src/algebraic_geometry/sheafed_space.lean
@@ -33,7 +33,7 @@ namespace algebraic_geometry
 
 /-- A `SheafedSpace C` is a topological space equipped with a sheaf of `C`s. -/
 structure SheafedSpace extends PresheafedSpace C :=
-(sheaf_condition : presheaf.sheaf_condition)
+(is_sheaf : presheaf.is_sheaf)
 
 variables {C}
 
@@ -43,23 +43,21 @@ instance coe_carrier : has_coe (SheafedSpace C) Top :=
 { coe := λ X, X.carrier }
 
 /-- Extract the `sheaf C (X : Top)` from a `SheafedSpace C`. -/
-def sheaf (X : SheafedSpace C) : sheaf C (X : Top.{v}) := ⟨X.presheaf, X.sheaf_condition⟩
+def sheaf (X : SheafedSpace C) : sheaf C (X : Top.{v}) := ⟨X.presheaf, X.is_sheaf⟩
 
 @[simp] lemma as_coe (X : SheafedSpace C) : X.carrier = (X : Top.{v}) := rfl
 @[simp] lemma mk_coe (carrier) (presheaf) (h) :
-  (({ carrier := carrier, presheaf := presheaf, sheaf_condition := h } : SheafedSpace.{v} C) :
+  (({ carrier := carrier, presheaf := presheaf, is_sheaf := h } : SheafedSpace.{v} C) :
   Top.{v}) = carrier :=
 rfl
 
 instance (X : SheafedSpace.{v} C) : topological_space X := X.carrier.str
 
 /-- The trivial `punit` valued sheaf on any topological space. -/
-noncomputable
 def punit (X : Top) : SheafedSpace (discrete punit) :=
-{ sheaf_condition := presheaf.sheaf_condition_punit _,
+{ is_sheaf := presheaf.is_sheaf_punit _,
   ..@PresheafedSpace.const (discrete punit) _ X punit.star }
 
-noncomputable
 instance : inhabited (SheafedSpace (discrete _root_.punit)) := ⟨punit (Top.of pempty)⟩
 
 instance : category (SheafedSpace C) :=
@@ -109,18 +107,16 @@ open Top.presheaf
 /--
 The restriction of a sheafed space along an open embedding into the space.
 -/
-noncomputable
 def restrict {U : Top} (X : SheafedSpace C)
   (f : U ⟶ (X : Top.{v})) (h : open_embedding f) : SheafedSpace C :=
-{ sheaf_condition := λ ι 𝒰, is_limit.of_iso_limit
-    ((is_limit.postcompose_inv_equiv _ _).inv_fun (X.sheaf_condition _))
-    (sheaf_condition_equalizer_products.fork.iso_of_open_embedding h 𝒰).symm,
+{ is_sheaf := λ ι 𝒰, ⟨is_limit.of_iso_limit
+    ((is_limit.postcompose_inv_equiv _ _).inv_fun (X.is_sheaf _).some)
+    (sheaf_condition_equalizer_products.fork.iso_of_open_embedding h 𝒰).symm⟩,
   ..X.to_PresheafedSpace.restrict f h }
 
 /--
 The restriction of a sheafed space `X` to the top subspace is isomorphic to `X` itself.
 -/
-noncomputable
 def restrict_top_iso (X : SheafedSpace C) :
   X.restrict (opens.inclusion ⊤) (opens.open_embedding ⊤) ≅ X :=
 @preimage_iso _ _ _ _ forget_to_PresheafedSpace _ _

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -800,7 +800,7 @@ def basic_open_iso (f : R) : (structure_sheaf R).1.obj (op (basic_open f)) ≅
 
 @[elementwise] lemma to_global_factors : to_open R ⊤ =
   (CommRing.of_hom (algebra_map R (localization.away (1 : R)))) ≫ (to_basic_open R (1 : R)) ≫
-  (structure_sheaf R).presheaf.map (eq_to_hom (basic_open_one.symm)).op :=
+  (structure_sheaf R).1.map (eq_to_hom (basic_open_one.symm)).op :=
 begin
   change to_open R ⊤ = (to_basic_open R 1).comp _ ≫ _,
   unfold CommRing.of_hom,
@@ -817,7 +817,7 @@ begin
 end
 
 /-- The ring isomorphism between the ring `R` and the global sections `Γ(X, 𝒪ₓ)`. -/
-@[simps] def global_sections_iso : CommRing.of R ≅ (structure_sheaf R).presheaf.obj (op ⊤) :=
+@[simps] def global_sections_iso : CommRing.of R ≅ (structure_sheaf R).1.obj (op ⊤) :=
 as_iso (to_open R ⊤)
 
 @[simp] lemma global_sections_iso_hom (R : CommRing) :

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -221,7 +221,7 @@ def structure_sheaf_in_Type : sheaf (Type u) (prime_spectrum.Top R):=
 subsheaf_to_Types (is_locally_fraction R)
 
 instance comm_ring_structure_sheaf_in_Type_obj (U : (opens (prime_spectrum.Top R))ᵒᵖ) :
-  comm_ring ((structure_sheaf_in_Type R).presheaf.obj U) :=
+  comm_ring ((structure_sheaf_in_Type R).1.obj U) :=
 (sections_subring R U).to_comm_ring
 
 open prime_spectrum
@@ -232,9 +232,9 @@ structure presheaf.
 -/
 @[simps]
 def structure_presheaf_in_CommRing : presheaf CommRing (prime_spectrum.Top R) :=
-{ obj := λ U, CommRing.of ((structure_sheaf_in_Type R).presheaf.obj U),
+{ obj := λ U, CommRing.of ((structure_sheaf_in_Type R).1.obj U),
   map := λ U V i,
-  { to_fun := ((structure_sheaf_in_Type R).presheaf.map i),
+  { to_fun := ((structure_sheaf_in_Type R).1.map i),
     map_zero' := rfl,
     map_add' := λ x y, rfl,
     map_one' := rfl,
@@ -245,7 +245,7 @@ Some glue, verifying that that structure presheaf valued in `CommRing` agrees
 with the `Type` valued structure presheaf.
 -/
 def structure_presheaf_comp_forget :
-  structure_presheaf_in_CommRing R ⋙ (forget CommRing) ≅ (structure_sheaf_in_Type R).presheaf :=
+  structure_presheaf_in_CommRing R ⋙ (forget CommRing) ≅ (structure_sheaf_in_Type R).1 :=
 nat_iso.of_components
   (λ U, iso.refl _)
   (by tidy)
@@ -258,19 +258,18 @@ The structure sheaf on $Spec R$, valued in `CommRing`.
 This is provided as a bundled `SheafedSpace` as `Spec.SheafedSpace R` later.
 -/
 def structure_sheaf : sheaf CommRing (prime_spectrum.Top R) :=
-{ presheaf := structure_presheaf_in_CommRing R,
-  sheaf_condition :=
-    -- We check the sheaf condition under `forget CommRing`.
-    (sheaf_condition_equiv_sheaf_condition_comp _ _).symm
-      (sheaf_condition_equiv_of_iso (structure_presheaf_comp_forget R).symm
-        (structure_sheaf_in_Type R).sheaf_condition), }
+⟨structure_presheaf_in_CommRing R,
+  -- We check the sheaf condition under `forget CommRing`.
+  (is_sheaf_iff_is_sheaf_comp _ _).mpr
+    (is_sheaf_of_iso (structure_presheaf_comp_forget R).symm
+      (structure_sheaf_in_Type R).property)⟩
 
 
 namespace structure_sheaf
 
 @[simp] lemma res_apply (U V : opens (prime_spectrum.Top R)) (i : V ⟶ U)
-  (s : (structure_sheaf R).presheaf.obj (op U)) (x : V) :
-  ((structure_sheaf R).presheaf.map i.op s).1 x = (s.1 (i x) : _) :=
+  (s : (structure_sheaf R).1.obj (op U)) (x : V) :
+  ((structure_sheaf R).1.map i.op s).1 x = (s.1 (i x) : _) :=
 rfl
 
 /-
@@ -302,7 +301,7 @@ In the square brackets we list the dependencies of a construction on the previou
 `f/g` in the localization of `R` at `x`. -/
 def const (f g : R) (U : opens (prime_spectrum.Top R))
   (hu : ∀ x ∈ U, g ∈ (x : prime_spectrum.Top R).as_ideal.prime_compl) :
-  (structure_sheaf R).presheaf.obj (op U) :=
+  (structure_sheaf R).1.obj (op U) :=
 ⟨λ x, is_localization.mk' _ f ⟨g, hu x x.2⟩,
  λ x, ⟨U, x.2, 𝟙 _, f, g, λ y, ⟨hu y y.2, is_localization.mk'_spec _ _ _⟩⟩⟩
 
@@ -317,20 +316,20 @@ lemma const_apply' (f g : R) (U : opens (prime_spectrum.Top R))
   (const R f g U hu).1 x = is_localization.mk' _ f ⟨g, hx⟩ :=
 rfl
 
-lemma exists_const (U) (s : (structure_sheaf R).presheaf.obj (op U)) (x : prime_spectrum.Top R)
+lemma exists_const (U) (s : (structure_sheaf R).1.obj (op U)) (x : prime_spectrum.Top R)
   (hx : x ∈ U) :
   ∃ (V : opens (prime_spectrum.Top R)) (hxV : x ∈ V) (i : V ⟶ U) (f g : R) hg,
-  const R f g V hg = (structure_sheaf R).presheaf.map i.op s :=
+  const R f g V hg = (structure_sheaf R).1.map i.op s :=
 let ⟨V, hxV, iVU, f, g, hfg⟩ := s.2 ⟨x, hx⟩ in
 ⟨V, hxV, iVU, f, g, λ y hyV, (hfg ⟨y, hyV⟩).1, subtype.eq $ funext $ λ y,
 is_localization.mk'_eq_iff_eq_mul.2 $ eq.symm $ (hfg y).2⟩
 
 @[simp] lemma res_const (f g : R) (U hu V hv i) :
-  (structure_sheaf R).presheaf.map i (const R f g U hu) = const R f g V hv :=
+  (structure_sheaf R).1.map i (const R f g U hu) = const R f g V hv :=
 rfl
 
 lemma res_const' (f g : R) (V hv) :
-  (structure_sheaf R).presheaf.map (hom_of_le hv).op (const R f g (basic_open g) (λ _, id)) =
+  (structure_sheaf R).1.map (hom_of_le hv).op (const R f g (basic_open g) (λ _, id)) =
     const R f g V hv :=
 rfl
 
@@ -379,7 +378,7 @@ by rw [mul_comm, const_mul_cancel]
 /-- The canonical ring homomorphism interpreting an element of `R` as
 a section of the structure sheaf. -/
 def to_open (U : opens (prime_spectrum.Top R)) :
-  CommRing.of R ⟶ (structure_sheaf R).presheaf.obj (op U) :=
+  CommRing.of R ⟶ (structure_sheaf R).1.obj (op U) :=
 { to_fun := λ f, ⟨λ x, algebra_map R _ f,
     λ x, ⟨U, x.2, 𝟙 _, f, 1, λ y, ⟨(ideal.ne_top_iff_one _).1 y.1.2.1,
       by { rw [ring_hom.map_one, mul_one], refl } ⟩⟩⟩,
@@ -389,7 +388,7 @@ def to_open (U : opens (prime_spectrum.Top R)) :
   map_add' := λ f g, subtype.eq $ funext $ λ x, ring_hom.map_add _ _ _ }
 
 @[simp] lemma to_open_res (U V : opens (prime_spectrum.Top R)) (i : V ⟶ U) :
-  to_open R U ≫ (structure_sheaf R).presheaf.map i.op = to_open R V :=
+  to_open R U ≫ (structure_sheaf R).1.map i.op = to_open R V :=
 rfl
 
 @[simp] lemma to_open_apply (U : opens (prime_spectrum.Top R)) (f : R) (x : U) :
@@ -402,20 +401,20 @@ subtype.eq $ funext $ λ x, eq.symm $ is_localization.mk'_one _ f
 
 /-- The canonical ring homomorphism interpreting an element of `R` as an element of
 the stalk of `structure_sheaf R` at `x`. -/
-def to_stalk (x : prime_spectrum.Top R) : CommRing.of R ⟶ (structure_sheaf R).presheaf.stalk x :=
-(to_open R ⊤ ≫ (structure_sheaf R).presheaf.germ ⟨x, ⟨⟩⟩ : _)
+def to_stalk (x : prime_spectrum.Top R) : CommRing.of R ⟶ (structure_sheaf R).1.stalk x :=
+(to_open R ⊤ ≫ (structure_sheaf R).1.germ ⟨x, ⟨⟩⟩ : _)
 
 @[simp] lemma to_open_germ (U : opens (prime_spectrum.Top R)) (x : U) :
-  to_open R U ≫ (structure_sheaf R).presheaf.germ x =
+  to_open R U ≫ (structure_sheaf R).1.germ x =
   to_stalk R x :=
 by { rw [← to_open_res R ⊤ U (hom_of_le le_top : U ⟶ ⊤), category.assoc, presheaf.germ_res], refl }
 
 @[simp] lemma germ_to_open (U : opens (prime_spectrum.Top R)) (x : U) (f : R) :
-  (structure_sheaf R).presheaf.germ x (to_open R U f) = to_stalk R x f :=
+  (structure_sheaf R).1.germ x (to_open R U f) = to_stalk R x f :=
 by { rw ← to_open_germ, refl }
 
 lemma germ_to_top (x : prime_spectrum.Top R) (f : R) :
-  (structure_sheaf R).presheaf.germ (⟨x, trivial⟩ : (⊤ : opens (prime_spectrum.Top R)))
+  (structure_sheaf R).1.germ (⟨x, trivial⟩ : (⊤ : opens (prime_spectrum.Top R)))
     (to_open R ⊤ f) =
     to_stalk R x f :=
 rfl
@@ -432,7 +431,7 @@ by { erw ← germ_to_open R (basic_open (f : R)) ⟨x, f.2⟩ (f : R),
 /-- The canonical ring homomorphism from the localization of `R` at `p` to the stalk
 of the structure sheaf at the point `p`. -/
 def localization_to_stalk (x : prime_spectrum.Top R) :
-  CommRing.of (localization.at_prime x.as_ideal) ⟶ (structure_sheaf R).presheaf.stalk x :=
+  CommRing.of (localization.at_prime x.as_ideal) ⟶ (structure_sheaf R).1.stalk x :=
 show localization.at_prime x.as_ideal →+* _, from
 is_localization.lift (is_unit_to_stalk R x)
 
@@ -443,7 +442,7 @@ is_localization.lift_eq _ f
 @[simp] lemma localization_to_stalk_mk' (x : prime_spectrum.Top R) (f : R)
   (s : (as_ideal x).prime_compl) :
   localization_to_stalk R x (is_localization.mk' _ f s : localization _) =
-  (structure_sheaf R).presheaf.germ (⟨x, s.2⟩ : basic_open (s : R))
+  (structure_sheaf R).1.germ (⟨x, s.2⟩ : basic_open (s : R))
     (const R f s (basic_open s) (λ _, id)) :=
 (is_localization.lift_mk'_spec _ _ _ _).2 $
 by erw [← germ_to_open R (basic_open s) ⟨x, s.2⟩, ← germ_to_open R (basic_open s) ⟨x, s.2⟩,
@@ -454,7 +453,7 @@ implemented as a subtype of dependent functions to localizations at prime ideals
 the section on the point corresponding to a given prime ideal. -/
 def open_to_localization (U : opens (prime_spectrum.Top R)) (x : prime_spectrum.Top R)
   (hx : x ∈ U) :
-  (structure_sheaf R).presheaf.obj (op U) ⟶ CommRing.of (localization.at_prime x.as_ideal) :=
+  (structure_sheaf R).1.obj (op U) ⟶ CommRing.of (localization.at_prime x.as_ideal) :=
 { to_fun := λ s, (s.1 ⟨x, hx⟩ : _),
   map_one' := rfl,
   map_mul' := λ _ _, rfl,
@@ -464,13 +463,13 @@ def open_to_localization (U : opens (prime_spectrum.Top R)) (x : prime_spectrum.
 @[simp] lemma coe_open_to_localization (U : opens (prime_spectrum.Top R)) (x : prime_spectrum.Top R)
   (hx : x ∈ U) :
   (open_to_localization R U x hx :
-    (structure_sheaf R).presheaf.obj (op U) → localization.at_prime x.as_ideal) =
+    (structure_sheaf R).1.obj (op U) → localization.at_prime x.as_ideal) =
   (λ s, (s.1 ⟨x, hx⟩ : _)) :=
 rfl
 
 lemma open_to_localization_apply (U : opens (prime_spectrum.Top R)) (x : prime_spectrum.Top R)
   (hx : x ∈ U)
-  (s : (structure_sheaf R).presheaf.obj (op U)) :
+  (s : (structure_sheaf R).1.obj (op U)) :
   open_to_localization R U x hx s = (s.1 ⟨x, hx⟩ : _) :=
 rfl
 
@@ -478,25 +477,25 @@ rfl
 a prime ideal `p` to the localization of `R` at `p`,
 formed by gluing the `open_to_localization` maps. -/
 def stalk_to_fiber_ring_hom (x : prime_spectrum.Top R) :
-  (structure_sheaf R).presheaf.stalk x ⟶ CommRing.of (localization.at_prime x.as_ideal) :=
-limits.colimit.desc (((open_nhds.inclusion x).op) ⋙ (structure_sheaf R).presheaf)
+  (structure_sheaf R).1.stalk x ⟶ CommRing.of (localization.at_prime x.as_ideal) :=
+limits.colimit.desc (((open_nhds.inclusion x).op) ⋙ (structure_sheaf R).1)
   { X := _,
     ι :=
     { app := λ U, open_to_localization R ((open_nhds.inclusion _).obj (unop U)) x (unop U).2, } }
 
 @[simp] lemma germ_comp_stalk_to_fiber_ring_hom (U : opens (prime_spectrum.Top R)) (x : U) :
-  (structure_sheaf R).presheaf.germ x ≫ stalk_to_fiber_ring_hom R x =
+  (structure_sheaf R).1.germ x ≫ stalk_to_fiber_ring_hom R x =
   open_to_localization R U x x.2 :=
 limits.colimit.ι_desc _ _
 
 @[simp] lemma stalk_to_fiber_ring_hom_germ' (U : opens (prime_spectrum.Top R))
-  (x : prime_spectrum.Top R) (hx : x ∈ U) (s : (structure_sheaf R).presheaf.obj (op U)) :
-  stalk_to_fiber_ring_hom R x ((structure_sheaf R).presheaf.germ ⟨x, hx⟩ s) = (s.1 ⟨x, hx⟩ : _) :=
+  (x : prime_spectrum.Top R) (hx : x ∈ U) (s : (structure_sheaf R).1.obj (op U)) :
+  stalk_to_fiber_ring_hom R x ((structure_sheaf R).1.germ ⟨x, hx⟩ s) = (s.1 ⟨x, hx⟩ : _) :=
 ring_hom.ext_iff.1 (germ_comp_stalk_to_fiber_ring_hom R U ⟨x, hx⟩ : _) s
 
 @[simp] lemma stalk_to_fiber_ring_hom_germ (U : opens (prime_spectrum.Top R)) (x : U)
-  (s : (structure_sheaf R).presheaf.obj (op U)) :
-  stalk_to_fiber_ring_hom R x ((structure_sheaf R).presheaf.germ x s) = s.1 x :=
+  (s : (structure_sheaf R).1.obj (op U)) :
+  stalk_to_fiber_ring_hom R x ((structure_sheaf R).1.germ x s) = s.1 x :=
 by { cases x, exact stalk_to_fiber_ring_hom_germ' R U _ _ _ }
 
 @[simp] lemma to_stalk_comp_stalk_to_fiber_ring_hom (x : prime_spectrum.Top R) :
@@ -510,15 +509,15 @@ ring_hom.ext_iff.1 (to_stalk_comp_stalk_to_fiber_ring_hom R x) _
 /-- The ring isomorphism between the stalk of the structure sheaf of `R` at a point `p`
 corresponding to a prime ideal in `R` and the localization of `R` at `p`. -/
 @[simps] def stalk_iso (x : prime_spectrum.Top R) :
-  (structure_sheaf R).presheaf.stalk x ≅ CommRing.of (localization.at_prime x.as_ideal) :=
+  (structure_sheaf R).1.stalk x ≅ CommRing.of (localization.at_prime x.as_ideal) :=
 { hom := stalk_to_fiber_ring_hom R x,
   inv := localization_to_stalk R x,
-  hom_inv_id' := (structure_sheaf R).presheaf.stalk_hom_ext $ λ U hxU,
+  hom_inv_id' := (structure_sheaf R).1.stalk_hom_ext $ λ U hxU,
   begin
     ext s, simp only [comp_apply], rw [id_apply, stalk_to_fiber_ring_hom_germ'],
     obtain ⟨V, hxV, iVU, f, g, hg, hs⟩ := exists_const _ _ s x hxU,
     erw [← res_apply R U V iVU s ⟨x, hxV⟩, ← hs, const_apply, localization_to_stalk_mk'],
-    refine (structure_sheaf R).presheaf.germ_ext V hxV (hom_of_le hg) iVU _,
+    refine (structure_sheaf R).1.germ_ext V hxV (hom_of_le hg) iVU _,
     erw [← hs, res_const']
   end,
   inv_hom_id' := @is_localization.ring_hom_ext R _ x.as_ideal.prime_compl
@@ -531,7 +530,7 @@ corresponding to a prime ideal in `R` and the localization of `R` at `p`. -/
 /-- The canonical ring homomorphism interpreting `s ∈ R_f` as a section of the structure sheaf
 on the basic open defined by `f ∈ R`. -/
 def to_basic_open (f : R) : localization.away f →+*
-  (structure_sheaf R).presheaf.obj (op $ basic_open f) :=
+  (structure_sheaf R).1.obj (op $ basic_open f) :=
 is_localization.away.lift f (is_unit_to_basic_open_self R f)
 
 @[simp] lemma to_basic_open_mk' (s f : R) (g : submonoid.powers s) :
@@ -587,9 +586,9 @@ Auxiliary lemma for surjectivity of `to_basic_open`.
 Every section can locally be represented on basic opens `basic_opens g` as a fraction `f/g`
 -/
 lemma locally_const_basic_open (U : opens (prime_spectrum.Top R))
-  (s : (structure_sheaf R).presheaf.obj (op U)) (x : U) :
+  (s : (structure_sheaf R).1.obj (op U)) (x : U) :
   ∃ (f g : R) (i : basic_open g ⟶ U), x.1 ∈ basic_open g ∧
-    const R f g (basic_open g) (λ y hy, hy) = (structure_sheaf R).presheaf.map i.op s :=
+    const R f g (basic_open g) (λ y hy, hy) = (structure_sheaf R).1.map i.op s :=
 begin
   -- First, any section `s` can be represented as a fraction `f/g` on some open neighborhood of `x`
   -- and we may pass to a `basic_open h`, since these form a basis
@@ -628,14 +627,14 @@ A local representation of a section `s` as fractions `a i / h i` on finitely man
 `basic_open (h i)` can be "normalized" in such a way that `a i * h j = h i * a j` for all `i, j`
 -/
 lemma normalize_finite_fraction_representation (U : opens (prime_spectrum.Top R))
-  (s : (structure_sheaf R).presheaf.obj (op U)) {ι : Type*} (t : finset ι) (a h : ι → R)
+  (s : (structure_sheaf R).1.obj (op U)) {ι : Type*} (t : finset ι) (a h : ι → R)
   (iDh : Π i : ι, basic_open (h i) ⟶ U)  (h_cover : U.1 ⊆ ⋃ i ∈ t, (basic_open (h i)).1)
   (hs : ∀ i : ι, const R (a i) (h i) (basic_open (h i)) (λ y hy, hy) =
-    (structure_sheaf R).presheaf.map (iDh i).op s) :
+    (structure_sheaf R).1.map (iDh i).op s) :
   ∃ (a' h' : ι → R) (iDh' : Π i : ι, (basic_open (h' i)) ⟶ U),
     (U.1 ⊆ ⋃ i ∈ t, (basic_open (h' i)).1) ∧
     (∀ i j ∈ t, a' i * h' j = h' i * a' j) ∧
-    (∀ i ∈ t, (structure_sheaf R).presheaf.map (iDh' i).op s =
+    (∀ i ∈ t, (structure_sheaf R).1.map (iDh' i).op s =
       const R (a' i) (h' i) (basic_open (h' i)) (λ y hy, hy)) :=
 begin
   -- First we show that the fractions `(a i * h j) / (h i * h j)` and `(h i * a j) / (h i * h j)`
@@ -653,8 +652,8 @@ begin
     simp only [set_like.coe_mk],
     -- Here, both sides of the equation are equal to a restriction of `s`
     transitivity,
-    convert congr_arg ((structure_sheaf R).presheaf.map iDj.op) (hs j).symm using 1,
-    convert congr_arg ((structure_sheaf R).presheaf.map iDi.op) (hs i) using 1, swap,
+    convert congr_arg ((structure_sheaf R).1.map iDj.op) (hs j).symm using 1,
+    convert congr_arg ((structure_sheaf R).1.map iDi.op) (hs i) using 1, swap,
     all_goals { rw res_const, apply const_ext, ring },
     -- The remaining two goals were generated during the rewrite of `res_const`
     -- These can be solved immediately
@@ -769,7 +768,7 @@ begin
 
   rintro ⟨i, hi⟩,
   dsimp,
-  change (structure_sheaf R).presheaf.map _ _ = (structure_sheaf R).presheaf.map _ _,
+  change (structure_sheaf R).1.map _ _ = (structure_sheaf R).1.map _ _,
   rw [s_eq i hi, res_const],
   -- Again, `res_const` spits out an additional goal
   swap,
@@ -795,7 +794,7 @@ end
 
 /-- The ring isomorphism between the structure sheaf on `basic_open f` and the localization of `R`
 at the submonoid of powers of `f`. -/
-def basic_open_iso (f : R) : (structure_sheaf R).presheaf.obj (op (basic_open f)) ≅
+def basic_open_iso (f : R) : (structure_sheaf R).1.obj (op (basic_open f)) ≅
   CommRing.of (localization.away f) :=
 (as_iso (show CommRing.of _ ⟶ _, from to_basic_open R f)).symm
 
@@ -877,7 +876,7 @@ to the fraction `a / b`, its image on `V` evaluates on `p` to the fraction `f(a)
 -/
 def comap (f : R →+* S) (U : opens (prime_spectrum.Top R))
   (V : opens (prime_spectrum.Top S)) (hUV : V.1 ⊆ (prime_spectrum.comap f) ⁻¹' U.1) :
-  (structure_sheaf R).presheaf.obj (op U) →+* (structure_sheaf S).presheaf.obj (op V) :=
+  (structure_sheaf R).1.obj (op U) →+* (structure_sheaf S).1.obj (op V) :=
 { to_fun := λ s, ⟨comap_fun f U V hUV s.1, comap_fun_is_locally_fraction f U V hUV s.1 s.2⟩,
   map_one' := subtype.ext $ funext $ λ p, by
     { rw [subtype.coe_mk, subtype.val_eq_coe, comap_fun, (sections_subring R (op U)).coe_one,
@@ -896,7 +895,7 @@ def comap (f : R →+* S) (U : opens (prime_spectrum.Top R))
 @[simp]
 lemma comap_apply (f : R →+* S) (U : opens (prime_spectrum.Top R))
   (V : opens (prime_spectrum.Top S)) (hUV : V.1 ⊆ (prime_spectrum.comap f) ⁻¹' U.1)
-  (s : (structure_sheaf R).presheaf.obj (op U)) (p : V) :
+  (s : (structure_sheaf R).1.obj (op U)) (p : V) :
   (comap f U V hUV s).1 p =
   localization.local_ring_hom (prime_spectrum.comap f p.1).as_ideal _ f rfl
     (s.1 ⟨(prime_spectrum.comap f p.1), hUV p.2⟩ : _) :=
@@ -924,7 +923,7 @@ to OO_X(U) is the identity.
 lemma comap_id_eq_map (U V : opens (prime_spectrum.Top R)) (iVU : V ⟶ U) :
   comap (ring_hom.id R) U V
     (λ p hpV, le_of_hom iVU $ by rwa prime_spectrum.comap_id) =
-  (structure_sheaf R).presheaf.map iVU.op :=
+  (structure_sheaf R).1.map iVU.op :=
 ring_hom.ext $ λ s, subtype.eq $ funext $ λ p,
 begin
   rw comap_apply,
@@ -949,7 +948,7 @@ are not definitionally equal.
 -/
 lemma comap_id (U V : opens (prime_spectrum.Top R)) (hUV : U = V) :
   comap (ring_hom.id R) U V (λ p hpV, by rwa [hUV, prime_spectrum.comap_id]) =
-  eq_to_hom (show (structure_sheaf R).presheaf.obj (op U) = _, by rw hUV) :=
+  eq_to_hom (show (structure_sheaf R).1.obj (op U) = _, by rw hUV) :=
 by erw [comap_id_eq_map U V (eq_to_hom hUV.symm), eq_to_hom_op, eq_to_hom_map]
 
 @[simp] lemma comap_id' (U : opens (prime_spectrum.Top R)) :

--- a/src/topology/sheaves/forget.lean
+++ b/src/topology/sheaves/forget.lean
@@ -127,13 +127,13 @@ Another useful example is the forgetful functor `TopCommRing ⥤ Top`.
 See https://stacks.math.columbia.edu/tag/0073.
 In fact we prove a stronger version with arbitrary complete target category.
 -/
-def sheaf_condition_equiv_sheaf_condition_comp :
-  sheaf_condition F ≃ sheaf_condition (F ⋙ G) :=
+lemma is_sheaf_iff_is_sheaf_comp :
+  presheaf.is_sheaf F ↔ presheaf.is_sheaf (F ⋙ G) :=
 begin
-  apply equiv_of_subsingleton_of_subsingleton,
+  split,
   { intros S ι U,
     -- We have that the sheaf condition fork for `F` is a limit fork,
-    have t₁ := S U,
+    obtain ⟨t₁⟩ := S U,
     -- and since `G` preserves limits, the image under `G` of this fork is a limit fork too.
     have t₂ := @preserves_limit.preserves _ _ _ _ _ _ _ G _ _ t₁,
     -- As we established above, that image is just the sheaf condition fork
@@ -142,8 +142,9 @@ begin
     -- and as postcomposing by a natural isomorphism preserves limit cones,
     have t₄ := is_limit.postcompose_inv_equiv _ _ t₃,
     -- we have our desired conclusion.
-    exact t₄, },
+    exact ⟨t₄⟩, },
   { intros S ι U,
+    refine ⟨_⟩,
     -- Let `f` be the universal morphism from `F.obj U` to the equalizer
     -- of the sheaf condition fork, whatever it is.
     -- Our goal is to show that this is an isomorphism.
@@ -164,7 +165,7 @@ begin
       -- from the sheaf condition cone for `F ⋙ G` to the
       -- image under `G` of the equalizer cone for the sheaf condition diagram.
       let c := fork (F ⋙ G) U,
-      have hc : is_limit c := S U,
+      obtain ⟨hc⟩ := S U,
       let d := G.map_cone (equalizer.fork (left_res F U) (right_res F U)),
       have hd : is_limit d := preserves_limit.preserves (limit.is_limit _),
       -- Since both of these are limit cones

--- a/src/topology/sheaves/local_predicate.lean
+++ b/src/topology/sheaves/local_predicate.lean
@@ -166,10 +166,9 @@ open Top.presheaf
 /--
 The functions satisfying a local predicate satisfy the sheaf condition.
 -/
-def sheaf_condition
-  (P : local_predicate T) :
-  sheaf_condition (subpresheaf_to_Types P.to_prelocal_predicate) :=
-sheaf_condition_of_exists_unique_gluing _ $ λ ι U sf sf_comp, begin
+lemma is_sheaf (P : local_predicate T) :
+  (subpresheaf_to_Types P.to_prelocal_predicate).is_sheaf :=
+presheaf.is_sheaf_of_is_sheaf_unique_gluing_types _ $ λ ι U sf sf_comp, begin
   -- We show the sheaf condition in terms of unique gluing.
   -- First we obtain a family of sections for the underlying sheaf of functions,
   -- by forgetting that the prediacte holds
@@ -209,14 +208,13 @@ The subsheaf of the sheaf of all dependently typed functions satisfying the loca
 -/
 @[simps]
 def subsheaf_to_Types (P : local_predicate T) : sheaf (Type v) X :=
-{ presheaf := subpresheaf_to_Types P.to_prelocal_predicate,
-  sheaf_condition := subpresheaf_to_Types.sheaf_condition P }.
+⟨subpresheaf_to_Types P.to_prelocal_predicate, subpresheaf_to_Types.is_sheaf P⟩
 
 /--
 There is a canonical map from the stalk to the original fiber, given by evaluating sections.
 -/
 def stalk_to_fiber (P : local_predicate T) (x : X) :
-  (subsheaf_to_Types P).presheaf.stalk x ⟶ T x :=
+  (subsheaf_to_Types P).1.stalk x ⟶ T x :=
 begin
   refine colimit.desc _
     { X := T x, ι := { app := λ U f, _, naturality' := _ } },
@@ -225,7 +223,7 @@ begin
 end
 
 @[simp] lemma stalk_to_fiber_germ (P : local_predicate T) (U : opens X) (x : U) (f) :
-  stalk_to_fiber P x ((subsheaf_to_Types P).presheaf.germ x f) = f.1 x :=
+  stalk_to_fiber P x ((subsheaf_to_Types P).1.germ x f) = f.1 x :=
 begin
   dsimp [presheaf.germ, stalk_to_fiber],
   cases x,
@@ -244,7 +242,7 @@ lemma stalk_to_fiber_surjective (P : local_predicate T) (x : X)
 begin
   rcases w t with ⟨U, f, h, rfl⟩,
   fsplit,
-  { exact (subsheaf_to_Types P).presheaf.germ ⟨x, U.2⟩ ⟨f, h⟩, },
+  { exact (subsheaf_to_Types P).1.germ ⟨x, U.2⟩ ⟨f, h⟩, },
   { exact stalk_to_fiber_germ _ U.1 ⟨x, U.2⟩ ⟨f, h⟩, }
 end
 
@@ -262,8 +260,8 @@ begin
   -- We promise to provide all the ingredients of the proof later:
   let Q :
     ∃ (W : (open_nhds x)ᵒᵖ) (s : Π w : (unop W).1, T w) (hW : P.pred s),
-      tU = (subsheaf_to_Types P).presheaf.germ ⟨x, (unop W).2⟩ ⟨s, hW⟩ ∧
-      tV = (subsheaf_to_Types P).presheaf.germ ⟨x, (unop W).2⟩ ⟨s, hW⟩ := _,
+      tU = (subsheaf_to_Types P).1.germ ⟨x, (unop W).2⟩ ⟨s, hW⟩ ∧
+      tV = (subsheaf_to_Types P).1.germ ⟨x, (unop W).2⟩ ⟨s, hW⟩ := _,
   { choose W s hW e using Q,
     exact e.1.trans e.2.symm, },
   -- Then use induction to pick particular representatives of `tU tV : stalk x`
@@ -300,9 +298,8 @@ nat_iso.of_components
 The sheaf of continuous functions on `X` with values in a space `T`.
 -/
 def sheaf_to_Top (T : Top.{v}) : sheaf (Type v) X :=
-{ presheaf := presheaf_to_Top X T,
-  sheaf_condition :=
-    presheaf.sheaf_condition_equiv_of_iso (subpresheaf_continuous_prelocal_iso_presheaf_to_Top T)
-      (subpresheaf_to_Types.sheaf_condition (continuous_local X T)), }
+⟨presheaf_to_Top X T,
+  presheaf.is_sheaf_of_iso (subpresheaf_continuous_prelocal_iso_presheaf_to_Top T)
+    (subpresheaf_to_Types.is_sheaf (continuous_local X T))⟩
 
 end Top

--- a/src/topology/sheaves/sheaf.lean
+++ b/src/topology/sheaves/sheaf.lean
@@ -61,36 +61,25 @@ The sheaf condition for a `F : presheaf C X` requires that the morphism
 is the equalizer of the two morphisms
 `∏ F.obj (U i) ⟶ ∏ F.obj (U i) ⊓ (U j)`.
 -/
--- One might prefer to work with sets of opens, rather than indexed families,
--- which would reduce the universe level here to `max u v`.
--- However as it's a subsingleton the universe level doesn't matter much.
-@[derive subsingleton]
-def sheaf_condition (F : presheaf C X) : Type (max u (v+1)) :=
-Π ⦃ι : Type v⦄ (U : ι → opens X), is_limit (sheaf_condition_equalizer_products.fork F U)
+def is_sheaf (F : presheaf C X) : Prop :=
+∀ ⦃ι : Type v⦄ (U : ι → opens X), nonempty (is_limit (sheaf_condition_equalizer_products.fork F U))
 
 /--
 The presheaf valued in `punit` over any topological space is a sheaf.
 -/
-def sheaf_condition_punit (F : presheaf (category_theory.discrete punit) X) :
-  sheaf_condition F :=
-λ ι U, punit_cone_is_limit
-
--- Let's construct a trivial example, to keep the inhabited linter happy.
-instance sheaf_condition_inhabited (F : presheaf (category_theory.discrete punit) X) :
-  inhabited (sheaf_condition F) := ⟨sheaf_condition_punit F⟩
+lemma is_sheaf_punit (F : presheaf (category_theory.discrete punit) X) : F.is_sheaf :=
+λ ι U, ⟨punit_cone_is_limit⟩
 
 /--
 Transfer the sheaf condition across an isomorphism of presheaves.
 -/
-def sheaf_condition_equiv_of_iso {F G : presheaf C X} (α : F ≅ G) :
-  sheaf_condition F ≃ sheaf_condition G :=
-equiv_of_subsingleton_of_subsingleton
-(λ c ι U, is_limit.of_iso_limit
-  ((is_limit.postcompose_inv_equiv _ _).symm (c U))
-    (sheaf_condition_equalizer_products.fork.iso_of_iso U α.symm).symm)
-(λ c ι U, is_limit.of_iso_limit
-  ((is_limit.postcompose_inv_equiv _ _).symm (c U))
-    (sheaf_condition_equalizer_products.fork.iso_of_iso U α).symm)
+lemma is_sheaf_of_iso {F G : presheaf C X} (α : F ≅ G) (h : F.is_sheaf) : G.is_sheaf :=
+λ ι U, ⟨is_limit.of_iso_limit
+  ((is_limit.postcompose_inv_equiv _ _).symm (h U).some)
+  (sheaf_condition_equalizer_products.fork.iso_of_iso U α.symm).symm⟩
+
+lemma is_sheaf_iso_iff {F G : presheaf C X} (α : F ≅ G) : F.is_sheaf ↔ G.is_sheaf :=
+⟨(λ h, is_sheaf_of_iso α h), (λ h, is_sheaf_of_iso α.symm h)⟩
 
 end presheaf
 
@@ -100,15 +89,12 @@ variables (C X)
 A `sheaf C X` is a presheaf of objects from `C` over a (bundled) topological space `X`,
 satisfying the sheaf condition.
 -/
-structure sheaf :=
-(presheaf : presheaf C X)
-(sheaf_condition : presheaf.sheaf_condition)
-
-instance : category (sheaf C X) := induced_category.category sheaf.presheaf
+@[derive category]
+def sheaf : Type (max u v) := { F : presheaf C X // F.is_sheaf }
 
 -- Let's construct a trivial example, to keep the inhabited linter happy.
 instance sheaf_inhabited : inhabited (sheaf (category_theory.discrete punit) X) :=
-⟨{ presheaf := functor.star _, sheaf_condition := default _ }⟩
+⟨⟨functor.star _, presheaf.is_sheaf_punit _⟩⟩
 
 namespace sheaf
 
@@ -116,7 +102,8 @@ namespace sheaf
 The forgetful functor from sheaves to presheaves.
 -/
 @[derive [full, faithful]]
-def forget : Top.sheaf C X ⥤ Top.presheaf C X := induced_functor sheaf.presheaf
+def forget : Top.sheaf C X ⥤ Top.presheaf C X :=
+full_subcategory_inclusion presheaf.is_sheaf
 
 end sheaf
 

--- a/src/topology/sheaves/sheaf_condition/opens_le_cover.lean
+++ b/src/topology/sheaves/sheaf_condition/opens_le_cover.lean
@@ -93,9 +93,8 @@ A presheaf is a sheaf if `F` sends the cone `(opens_le_cover_cocone U).op` to a 
 (Recall `opens_le_cover_cocone U`, has cone point `supr U`,
 mapping down to any `V` which is contained in some `U i`.)
 -/
-@[derive subsingleton, nolint has_inhabited_instance]
-def sheaf_condition_opens_le_cover : Type (max u (v+1)) :=
-Π ⦃ι : Type v⦄ (U : ι → opens X), is_limit (F.map_cone (opens_le_cover_cocone U).op)
+def is_sheaf_opens_le_cover : Prop :=
+∀ ⦃ι : Type v⦄ (U : ι → opens X), nonempty (is_limit (F.map_cone (opens_le_cover_cocone U).op))
 
 namespace sheaf_condition
 
@@ -217,10 +216,10 @@ in terms of a limit diagram over all `{ V : opens X // ∃ i, V ≤ U i }`
 is equivalent to the reformulation
 in terms of a limit diagram over `U i` and `U i ⊓ U j`.
 -/
-def sheaf_condition_opens_le_cover_equiv_sheaf_condition_pairwise_intersections (F : presheaf C X) :
-  F.sheaf_condition_opens_le_cover ≃ F.sheaf_condition_pairwise_intersections :=
-equiv.Pi_congr_right $ λ ι, equiv.Pi_congr_right $ λ U,
-calc is_limit (F.map_cone (opens_le_cover_cocone U).op)
+lemma is_sheaf_opens_le_cover_iff_is_sheaf_pairwise_intersections (F : presheaf C X) :
+  F.is_sheaf_opens_le_cover ↔ F.is_sheaf_pairwise_intersections :=
+forall_congr (λ ι, forall_congr (λ U, equiv.nonempty_congr $
+  calc is_limit (F.map_cone (opens_le_cover_cocone U).op)
     ≃ is_limit ((F.map_cone (opens_le_cover_cocone U).op).whisker (pairwise_to_opens_le_cover U).op)
         : (functor.initial.is_limit_whisker_equiv (pairwise_to_opens_le_cover U).op _).symm
 ... ≃ is_limit (F.map_cone ((opens_le_cover_cocone U).op.whisker (pairwise_to_opens_le_cover U).op))
@@ -233,7 +232,7 @@ calc is_limit (F.map_cone (opens_le_cover_cocone U).op)
         : is_limit.equiv_iso_limit (functor.map_cone_postcompose_equivalence_functor _).symm
 ... ≃ is_limit (F.map_cone (pairwise.cocone U).op)
         : is_limit.equiv_iso_limit
-            ((cones.functoriality _ _).map_iso (pairwise_cocone_iso U : _).symm)
+            ((cones.functoriality _ _).map_iso (pairwise_cocone_iso U : _).symm)))
 
 variables [has_products C]
 
@@ -241,11 +240,11 @@ variables [has_products C]
 The sheaf condition in terms of an equalizer diagram is equivalent
 to the reformulation in terms of a limit diagram over all `{ V : opens X // ∃ i, V ≤ U i }`.
 -/
-def sheaf_condition_equiv_sheaf_condition_opens_le_cover (F : presheaf C X) :
-  F.sheaf_condition ≃ F.sheaf_condition_opens_le_cover :=
-equiv.trans
-  (sheaf_condition_equiv_sheaf_condition_pairwise_intersections F)
-  (sheaf_condition_opens_le_cover_equiv_sheaf_condition_pairwise_intersections F).symm
+lemma is_sheaf_iff_is_sheaf_opens_le_cover (F : presheaf C X) :
+  F.is_sheaf ↔ F.is_sheaf_opens_le_cover :=
+iff.trans
+  (is_sheaf_iff_is_sheaf_pairwise_intersections F)
+  (is_sheaf_opens_le_cover_iff_is_sheaf_pairwise_intersections F).symm
 
 end presheaf
 

--- a/src/topology/sheaves/sheaf_condition/pairwise_intersections.lean
+++ b/src/topology/sheaves/sheaf_condition/pairwise_intersections.lean
@@ -54,9 +54,8 @@ An alternative formulation of the sheaf condition
 A presheaf is a sheaf if `F` sends the cone `(pairwise.cocone U).op` to a limit cone.
 (Recall `pairwise.cocone U` has cone point `supr U`, mapping down to the `U i` and the `U i ⊓ U j`.)
 -/
-@[derive subsingleton, nolint has_inhabited_instance]
-def sheaf_condition_pairwise_intersections (F : presheaf C X) : Type (max u (v+1)) :=
-Π ⦃ι : Type v⦄ (U : ι → opens X), is_limit (F.map_cone (pairwise.cocone U).op)
+def is_sheaf_pairwise_intersections (F : presheaf C X) : Prop :=
+∀ ⦃ι : Type v⦄ (U : ι → opens X), nonempty (is_limit (F.map_cone (pairwise.cocone U).op))
 
 /--
 An alternative formulation of the sheaf condition
@@ -67,10 +66,8 @@ A presheaf is a sheaf if `F` preserves the limit of `pairwise.diagram U`.
 (Recall `pairwise.diagram U` is the diagram consisting of the pairwise intersections
 `U i ⊓ U j` mapping into the open sets `U i`. This diagram has limit `supr U`.)
 -/
-@[derive subsingleton, nolint has_inhabited_instance]
-def sheaf_condition_preserves_limit_pairwise_intersections
-  (F : presheaf C X) : Type (max u (v+1)) :=
-Π ⦃ι : Type v⦄ (U : ι → opens X), preserves_limit (pairwise.diagram U).op F
+def is_sheaf_preserves_limit_pairwise_intersections (F : presheaf C X) : Prop :=
+∀ ⦃ι : Type v⦄ (U : ι → opens X), nonempty (preserves_limit (pairwise.diagram U).op F)
 
 /-!
 The remainder of this file shows that these conditions are equivalent
@@ -372,26 +369,26 @@ open sheaf_condition_pairwise_intersections
 The sheaf condition in terms of an equalizer diagram is equivalent
 to the reformulation in terms of a limit diagram over `U i` and `U i ⊓ U j`.
 -/
-def sheaf_condition_equiv_sheaf_condition_pairwise_intersections (F : presheaf C X) :
-  F.sheaf_condition ≃ F.sheaf_condition_pairwise_intersections :=
-equiv.Pi_congr_right (λ i, equiv.Pi_congr_right (λ U,
-  equiv_of_subsingleton_of_subsingleton
-    (is_limit_map_cone_of_is_limit_sheaf_condition_fork F U)
-    (is_limit_sheaf_condition_fork_of_is_limit_map_cone F U)))
+lemma is_sheaf_iff_is_sheaf_pairwise_intersections (F : presheaf C X) :
+  F.is_sheaf ↔ F.is_sheaf_pairwise_intersections :=
+iff.intro (λ h ι U, ⟨is_limit_map_cone_of_is_limit_sheaf_condition_fork F U (h U).some⟩)
+  (λ h ι U, ⟨is_limit_sheaf_condition_fork_of_is_limit_map_cone F U (h U).some⟩)
 
 /--
 The sheaf condition in terms of an equalizer diagram is equivalent
 to the reformulation in terms of the presheaf preserving the limit of the diagram
 consisting of the `U i` and `U i ⊓ U j`.
 -/
-def sheaf_condition_equiv_sheaf_condition_preserves_limit_pairwise_intersections
-(F : presheaf C X) :
-  F.sheaf_condition ≃ F.sheaf_condition_preserves_limit_pairwise_intersections :=
-equiv.trans
-  (sheaf_condition_equiv_sheaf_condition_pairwise_intersections F)
-  (equiv.Pi_congr_right (λ i, equiv.Pi_congr_right (λ U,
-     equiv_of_subsingleton_of_subsingleton
-       (λ P, preserves_limit_of_preserves_limit_cone (pairwise.cocone_is_colimit U).op P)
-       (by { introI, exact preserves_limit.preserves (pairwise.cocone_is_colimit U).op }))))
+lemma is_sheaf_iff_is_sheaf_preserves_limit_pairwise_intersections (F : presheaf C X) :
+  F.is_sheaf ↔ F.is_sheaf_preserves_limit_pairwise_intersections :=
+begin
+  rw is_sheaf_iff_is_sheaf_pairwise_intersections,
+  split,
+  { intros h ι U,
+    exact ⟨preserves_limit_of_preserves_limit_cone (pairwise.cocone_is_colimit U).op (h U).some⟩ },
+  { intros h ι U,
+    haveI := (h U).some,
+    exact ⟨preserves_limit.preserves (pairwise.cocone_is_colimit U).op⟩ }
+end
 
 end Top.presheaf

--- a/src/topology/sheaves/sheaf_condition/unique_gluing.lean
+++ b/src/topology/sheaves/sheaf_condition/unique_gluing.lean
@@ -75,13 +75,6 @@ def is_gluing (sf : Π i : ι, F.obj (op (U i))) (s : F.obj (op (supr U))) : Pro
 ∀ i : ι, F.map (opens.le_supr U i).op s = sf i
 
 /--
-The subtype of all gluings for a given family of sections
--/
-@[nolint has_inhabited_instance]
-def gluing (sf : Π i : ι, F.obj (op (U i))) : Type v :=
-{s : F.obj (op (supr U)) // is_gluing F U sf s}
-
-/--
 The sheaf condition in terms of unique gluings. A presheaf `F : presheaf C X` satisfies this sheaf
 condition if and only if, for every compatible family of sections `sf : Π i : ι, F.obj (op (U i))`,
 there exists a unique gluing `s : F.obj (op (supr U))`.
@@ -89,10 +82,9 @@ there exists a unique gluing `s : F.obj (op (supr U))`.
 We prove this to be equivalent to the usual one below in
 `sheaf_condition_equiv_sheaf_condition_unique_gluing`
 -/
-@[derive subsingleton, nolint has_inhabited_instance]
-def sheaf_condition_unique_gluing : Type (v+1) :=
-Π ⦃ι : Type v⦄ (U : ι → opens X) (sf : Π i : ι, F.obj (op (U i))),
-  is_compatible F U sf → unique (gluing F U sf)
+def is_sheaf_unique_gluing : Prop :=
+∀ ⦃ι : Type v⦄ (U : ι → opens X) (sf : Π i : ι, F.obj (op (U i))),
+  is_compatible F U sf → ∃! s : F.obj (op (supr U)), is_gluing F U sf s
 
 end
 
@@ -150,68 +142,62 @@ end
 The "equalizer" sheaf condition can be obtained from the sheaf condition
 in terms of unique gluings.
 -/
-def sheaf_condition_of_sheaf_condition_unique_gluing_types :
-  F.sheaf_condition_unique_gluing → F.sheaf_condition := λ Fsh ι U,
+lemma is_sheaf_of_is_sheaf_unique_gluing_types (Fsh : F.is_sheaf_unique_gluing) :
+  F.is_sheaf :=
 begin
-  refine fork.is_limit.mk' _ (λ s, ⟨_, _, _⟩) ; dsimp,
+  intros ι U,
+  refine ⟨fork.is_limit.mk' _ _⟩,
+  intro s,
+  have h_compatible : ∀ x : s.X,
+    F.is_compatible U ((F.pi_opens_iso_sections_family U).hom (s.ι x)),
   { intro x,
-    refine (Fsh U ((pi_opens_iso_sections_family F U).hom (s.ι x)) _).default.1,
-    apply (compatible_iff_left_res_eq_right_res F U (s.ι x)).mpr,
+    rw compatible_iff_left_res_eq_right_res,
     convert congr_fun s.condition x, },
+  choose m m_spec m_uniq using
+    λ x : s.X, Fsh U ((pi_opens_iso_sections_family F U).hom (s.ι x)) (h_compatible x),
+  refine ⟨m, _, _⟩,
   { ext i x,
     simp [res],
-    let t : gluing F U _ := _,
-    exact t.2 i },
-  { intros m hm,
+    exact m_spec x i, },
+  { intros l hl,
     ext x,
-    refine congr_arg subtype.val
-      ((Fsh U ((pi_opens_iso_sections_family F U).hom (s.ι x)) _).uniq ⟨m x, _⟩),
-    apply (is_gluing_iff_eq_res F U _ _).mpr,
-    exact congr_fun hm x },
+    apply m_uniq,
+    rw is_gluing_iff_eq_res,
+    exact congr_fun hl x },
 end
 
 /--
 The sheaf condition in terms of unique gluings can be obtained from the usual
 "equalizer" sheaf condition.
 -/
-def sheaf_condition_unique_gluing_of_sheaf_condition_types :
-  F.sheaf_condition → F.sheaf_condition_unique_gluing := λ Fsh ι U sf hsf,
-{ default := begin
-    let sf' := (pi_opens_iso_sections_family F U).inv sf,
-    have hsf' : left_res F U sf' = right_res F U sf' := by
-      rwa [← compatible_iff_left_res_eq_right_res F U sf', inv_hom_id_apply],
-    choose s s_spec s_uniq using types.unique_of_type_equalizer _ _ (Fsh U) sf' hsf',
-    use s,
-    convert (is_gluing_iff_eq_res F U _ _).mpr s_spec,
-    rw inv_hom_id_apply
-  end,
-  uniq := begin
-    intro s,
-    /- Unfortunately, type inference doesn't yet know about the `inhabited` instance of
-    `gluing F U sf` We therefore introduce a metavariable and use unification to get our hands
-    on the default value of `gluing F U sf`. -/
-    let t : F.gluing U sf := _,
-    change s = t,
-    ext,
-    let sf' := (pi_opens_iso_sections_family F U).inv sf,
-    have hsf' : left_res F U sf' = right_res F U sf' := by
-      rwa [← compatible_iff_left_res_eq_right_res F U sf', inv_hom_id_apply],
-    choose gl gl_spec gl_uniq using types.unique_of_type_equalizer _ _ (Fsh U) sf' hsf',
-    refine eq.trans (gl_uniq s.1 _) (gl_uniq t.1 _).symm ;
-      rw [← is_gluing_iff_eq_res F U _ _, inv_hom_id_apply],
-    exacts [s.2, t.2]
-  end
-}
+lemma is_sheaf_unique_gluing_of_is_sheaf_types (Fsh : F.is_sheaf) :
+  F.is_sheaf_unique_gluing :=
+begin
+  intros ι U sf hsf,
+  let sf' := (pi_opens_iso_sections_family F U).inv sf,
+  have hsf' : left_res F U sf' = right_res F U sf',
+  { rwa [← compatible_iff_left_res_eq_right_res F U sf', inv_hom_id_apply] },
+  choose s s_spec s_uniq using types.unique_of_type_equalizer _ _ (Fsh U).some sf' hsf',
+  use s,
+  dsimp,
+  split,
+  { convert (is_gluing_iff_eq_res F U sf' _).mpr s_spec,
+    rw inv_hom_id_apply },
+  { intros y hy,
+    apply s_uniq,
+    rw ← is_gluing_iff_eq_res F U,
+    convert hy,
+    rw inv_hom_id_apply, },
+end
 
 /--
 For type-valued presheaves, the sheaf condition in terms of unique gluings is equivalent to the
 usual sheaf condition in terms of equalizer diagrams.
 -/
-def sheaf_condition_equiv_sheaf_condition_unique_gluing_types :
-  F.sheaf_condition ≃ F.sheaf_condition_unique_gluing :=
-equiv_of_subsingleton_of_subsingleton
-  F.sheaf_condition_unique_gluing_of_sheaf_condition_types
-  F.sheaf_condition_of_sheaf_condition_unique_gluing_types
+lemma is_sheaf_iff_is_sheaf_unique_gluing_types :
+  F.is_sheaf ↔ F.is_sheaf_unique_gluing :=
+iff.intro (is_sheaf_unique_gluing_of_is_sheaf_types F)
+  (is_sheaf_of_is_sheaf_unique_gluing_types F)
 
 end type_valued
 
@@ -227,33 +213,10 @@ For presheaves valued in a concrete category, whose forgetful functor reflects i
 preserves limits, the sheaf condition in terms of unique gluings is equivalent to the usual one
 in terms of equalizer diagrams.
 -/
-def sheaf_condition_equiv_sheaf_condition_unique_gluing :
-  F.sheaf_condition ≃ F.sheaf_condition_unique_gluing :=
-equiv.trans (sheaf_condition_equiv_sheaf_condition_comp (forget C) F)
-  (sheaf_condition_equiv_sheaf_condition_unique_gluing_types (F ⋙ forget C))
-
-/--
-A slightly more convenient way of obtaining the sheaf condition for sheaves of algebraic structures.
--/
-def sheaf_condition_of_exists_unique_gluing
-  (h : ∀ ⦃ι : Type v⦄ (U : ι → opens X) (sf : Π i : ι, F.obj (op (U i))),
-    is_compatible F U sf → ∃! s : F.obj (op (supr U)), is_gluing F U sf s) :
-  F.sheaf_condition :=
-(sheaf_condition_equiv_sheaf_condition_unique_gluing F).inv_fun $ λ ι U sf hsf,
-{ default := begin
-    choose gl gl_spec gl_uniq using h U sf hsf,
-    exact ⟨gl, gl_spec⟩
-  end,
-  uniq := begin
-    intro s,
-    let t : F.gluing U sf := _,
-    change s = t,
-    ext,
-    choose gl gl_spec gl_uniq using h U sf hsf,
-    refine eq.trans (gl_uniq s.1 _) (gl_uniq t.1 _).symm,
-    exacts [s.2, t.2]
-  end,
-}
+lemma is_sheaf_iff_is_sheaf_unique_gluing :
+  F.is_sheaf ↔ F.is_sheaf_unique_gluing :=
+iff.trans (is_sheaf_iff_is_sheaf_comp (forget C) F)
+  (is_sheaf_iff_is_sheaf_unique_gluing_types (F ⋙ forget C))
 
 end
 
@@ -276,46 +239,41 @@ variables {X : Top.{v}} (F : sheaf C X) {ι : Type v} (U : ι → opens X)
 /--
 A more convenient way of obtaining a unique gluing of sections for a sheaf.
 -/
-lemma exists_unique_gluing (sf : Π i : ι, F.presheaf.obj (op (U i)))
-  (h : is_compatible F.presheaf U sf ) :
-  ∃! s : F.presheaf.obj (op (supr U)), is_gluing F.presheaf U sf s :=
-begin
-  have := sheaf_condition_equiv_sheaf_condition_unique_gluing _ F.sheaf_condition U sf h,
-  refine ⟨this.default.1, this.default.2, _⟩,
-  intros s hs,
-  exact congr_arg subtype.val (this.uniq ⟨s, hs⟩),
-end
+lemma exists_unique_gluing (sf : Π i : ι, F.1.obj (op (U i)))
+  (h : is_compatible F.1 U sf ) :
+  ∃! s : F.1.obj (op (supr U)), is_gluing F.1 U sf s :=
+(is_sheaf_iff_is_sheaf_unique_gluing F.1).mp F.property U sf h
 
 /--
 In this version of the lemma, the inclusion homs `iUV` can be specified directly by the user,
 which can be more convenient in practice.
 -/
 lemma exists_unique_gluing' (V : opens X) (iUV : Π i : ι, U i ⟶ V) (hcover : V ≤ supr U)
-  (sf : Π i : ι, F.presheaf.obj (op (U i))) (h : is_compatible F.presheaf U sf) :
-  ∃! s : F.presheaf.obj (op V), ∀ i : ι, F.presheaf.map (iUV i).op s = sf i :=
+  (sf : Π i : ι, F.1.obj (op (U i))) (h : is_compatible F.1 U sf) :
+  ∃! s : F.1.obj (op V), ∀ i : ι, F.1.map (iUV i).op s = sf i :=
 begin
   have V_eq_supr_U : V = supr U := le_antisymm hcover (supr_le (λ i, (iUV i).le)),
   obtain ⟨gl, gl_spec, gl_uniq⟩ := F.exists_unique_gluing U sf h,
-  refine ⟨F.presheaf.map (eq_to_hom V_eq_supr_U).op gl, _, _⟩,
+  refine ⟨F.1.map (eq_to_hom V_eq_supr_U).op gl, _, _⟩,
   { intro i,
-    rw [← comp_apply, ← F.presheaf.map_comp],
+    rw [← comp_apply, ← F.1.map_comp],
     exact gl_spec i },
   { intros gl' gl'_spec,
-    convert congr_arg _ (gl_uniq (F.presheaf.map (eq_to_hom V_eq_supr_U.symm).op gl') (λ i,_)) ;
-      rw [← comp_apply, ← F.presheaf.map_comp],
+    convert congr_arg _ (gl_uniq (F.1.map (eq_to_hom V_eq_supr_U.symm).op gl') (λ i,_)) ;
+      rw [← comp_apply, ← F.1.map_comp],
     { rw [eq_to_hom_op, eq_to_hom_op, eq_to_hom_trans, eq_to_hom_refl,
-      F.presheaf.map_id, id_apply] },
+      F.1.map_id, id_apply] },
     { convert gl'_spec i } }
 end
 
 @[ext]
-lemma eq_of_locally_eq (s t : F.presheaf.obj (op (supr U)))
-  (h : ∀ i, F.presheaf.map (opens.le_supr U i).op s = F.presheaf.map (opens.le_supr U i).op t) :
+lemma eq_of_locally_eq (s t : F.1.obj (op (supr U)))
+  (h : ∀ i, F.1.map (opens.le_supr U i).op s = F.1.map (opens.le_supr U i).op t) :
   s = t :=
 begin
-  let sf : Π i : ι, F.presheaf.obj (op (U i)) := λ i, F.presheaf.map (opens.le_supr U i).op s,
+  let sf : Π i : ι, F.1.obj (op (U i)) := λ i, F.1.map (opens.le_supr U i).op s,
   have sf_compatible : is_compatible _ U sf,
-  { intros i j, simp_rw [← comp_apply, ← F.presheaf.map_comp], refl },
+  { intros i j, simp_rw [← comp_apply, ← F.1.map_comp], refl },
   obtain ⟨gl, -, gl_uniq⟩ := F.exists_unique_gluing U sf sf_compatible,
   transitivity gl,
   { apply gl_uniq, intro i, refl },
@@ -327,18 +285,18 @@ In this version of the lemma, the inclusion homs `iUV` can be specified directly
 which can be more convenient in practice.
 -/
 lemma eq_of_locally_eq' (V : opens X) (iUV : Π i : ι, U i ⟶ V) (hcover : V ≤ supr U)
-  (s t : F.presheaf.obj (op V))
-  (h : ∀ i, F.presheaf.map (iUV i).op s = F.presheaf.map (iUV i).op t) : s = t :=
+  (s t : F.1.obj (op V))
+  (h : ∀ i, F.1.map (iUV i).op s = F.1.map (iUV i).op t) : s = t :=
 begin
   have V_eq_supr_U : V = supr U := le_antisymm hcover (supr_le (λ i, (iUV i).le)),
-  suffices : F.presheaf.map (eq_to_hom V_eq_supr_U.symm).op s =
-             F.presheaf.map (eq_to_hom V_eq_supr_U.symm).op t,
-  { convert congr_arg (F.presheaf.map (eq_to_hom V_eq_supr_U).op) this ;
-    rw [← comp_apply, ← F.presheaf.map_comp, eq_to_hom_op, eq_to_hom_op, eq_to_hom_trans,
-      eq_to_hom_refl, F.presheaf.map_id, id_apply] },
+  suffices : F.1.map (eq_to_hom V_eq_supr_U.symm).op s =
+             F.1.map (eq_to_hom V_eq_supr_U.symm).op t,
+  { convert congr_arg (F.1.map (eq_to_hom V_eq_supr_U).op) this ;
+    rw [← comp_apply, ← F.1.map_comp, eq_to_hom_op, eq_to_hom_op, eq_to_hom_trans,
+      eq_to_hom_refl, F.1.map_id, id_apply] },
   apply eq_of_locally_eq,
   intro i,
-  rw [← comp_apply, ← comp_apply, ← F.presheaf.map_comp],
+  rw [← comp_apply, ← comp_apply, ← F.1.map_comp],
   convert h i,
 end
 

--- a/src/topology/sheaves/sheaf_of_functions.lean
+++ b/src/topology/sheaves/sheaf_of_functions.lean
@@ -50,8 +50,8 @@ form a sheaf.
 In fact, the proof is identical when we do this for dependent functions to a type family `T`,
 so we do the more general case.
 -/
-def to_Types (T : X → Type u) : sheaf_condition (presheaf_to_Types X T) :=
-sheaf_condition_of_exists_unique_gluing _ $ λ ι U sf hsf,
+lemma to_Types_is_sheaf (T : X → Type u) : (presheaf_to_Types X T).is_sheaf :=
+is_sheaf_of_is_sheaf_unique_gluing_types _ $ λ ι U sf hsf,
 -- We use the sheaf condition in terms of unique gluing
 -- U is a family of open sets, indexed by `ι` and `sf` is a compatible family of sections.
 -- In the informal comments below, I'll just write `U` to represent the union.
@@ -59,10 +59,7 @@ begin
   -- Our first goal is to define a function "lifted" to all of `U`.
   -- We do this one point at a time. Using the axiom of choice, we can pick for each
   -- `x : supr U` an index `i : ι` such that `x` lies in `U i`
-  let index : supr U → ι := λ ⟨x,mem⟩, classical.some (opens.mem_supr.mp mem),
-  have index_spec : ∀ x : supr U, x.1 ∈ U (index x) := by {
-      rintro ⟨x,mem⟩,
-      exact classical.some_spec (opens.mem_supr.mp mem), },
+  choose index index_spec using λ x : supr U, opens.mem_supr.mp x.2,
   -- Using this data, we can glue our functions together to a single section
   let s : Π x : supr U, T x := λ x, sf (index x) ⟨x.1, index_spec x⟩,
   refine ⟨s,_,_⟩,
@@ -92,8 +89,8 @@ end
 The presheaf of not-necessarily-continuous functions to
 a target type `T` satsifies the sheaf condition.
 -/
-def to_Type (T : Type u) : sheaf_condition (presheaf_to_Type X T) :=
-to_Types X (λ _, T)
+lemma to_Type_is_sheaf (T : Type u) : (presheaf_to_Type X T).is_sheaf :=
+to_Types_is_sheaf X (λ _, T)
 
 end Top.presheaf
 
@@ -104,14 +101,12 @@ The sheaf of not-necessarily-continuous functions on `X` with values in type fam
 `T : X → Type u`.
 -/
 def sheaf_to_Types (T : X → Type u) : sheaf (Type u) X :=
-{ presheaf := presheaf_to_Types X T,
-  sheaf_condition := presheaf.to_Types _ _, }
+⟨presheaf_to_Types X T, presheaf.to_Types_is_sheaf _ _⟩
 
 /--
 The sheaf of not-necessarily-continuous functions on `X` with values in a type `T`.
 -/
 def sheaf_to_Type (T : Type u) : sheaf (Type u) X :=
-{ presheaf := presheaf_to_Type X T,
-  sheaf_condition := presheaf.to_Type _ _, }
+⟨presheaf_to_Type X T, presheaf.to_Type_is_sheaf _ _⟩
 
 end Top

--- a/src/topology/sheaves/sheafify.lean
+++ b/src/topology/sheaves/sheafify.lean
@@ -68,7 +68,7 @@ The morphism from a presheaf to its sheafification,
 sending each section to its germs.
 (This forms the unit of the adjunction.)
 -/
-def to_sheafify : F ⟶ F.sheafify.presheaf :=
+def to_sheafify : F ⟶ F.sheafify.1 :=
 { app := λ U f, ⟨λ x, F.germ x f, prelocal_predicate.sheafify_of ⟨f, λ x, rfl⟩⟩,
   naturality' := λ U U' f, by { ext x ⟨u, m⟩, exact germ_res_apply F f.unop ⟨u, m⟩ x } }
 
@@ -76,7 +76,7 @@ def to_sheafify : F ⟶ F.sheafify.presheaf :=
 The natural morphism from the stalk of the sheafification to the original stalk.
 In `sheafify_stalk_iso` we show this is an isomorphism.
 -/
-def stalk_to_fiber (x : X) : F.sheafify.presheaf.stalk x ⟶ F.stalk x :=
+def stalk_to_fiber (x : X) : F.sheafify.1.stalk x ⟶ F.stalk x :=
 stalk_to_fiber (sheafify.is_locally_germ F) x
 
 lemma stalk_to_fiber_surjective (x : X) : function.surjective (F.stalk_to_fiber x) :=
@@ -121,7 +121,7 @@ end
 /--
 The isomorphism betweeen a stalk of the sheafification and the original stalk.
 -/
-def sheafify_stalk_iso (x : X) : F.sheafify.presheaf.stalk x ≅ F.stalk x :=
+def sheafify_stalk_iso (x : X) : F.sheafify.1.stalk x ≅ F.stalk x :=
 (equiv.of_bijective _ ⟨stalk_to_fiber_injective _ _, stalk_to_fiber_surjective _ _⟩).to_iso
 
 -- PROJECT functoriality, and that sheafification is the left adjoint of the forgetful functor.

--- a/src/topology/sheaves/stalks.lean
+++ b/src/topology/sheaves/stalks.lean
@@ -251,13 +251,13 @@ variables [has_limits C] [preserves_limits (forget C)] [reflects_isomorphisms (f
 Let `F` be a sheaf valued in a concrete category, whose forgetful functor reflects isomorphisms,
 preserves limits and filtered colimits. Then two sections who agree on every stalk must be equal.
 -/
-lemma section_ext (F : sheaf C X) (U : opens X) (s t : F.presheaf.obj (op U))
-  (h : ∀ x : U, F.presheaf.germ x s = F.presheaf.germ x t) :
+lemma section_ext (F : sheaf C X) (U : opens X) (s t : F.1.obj (op U))
+  (h : ∀ x : U, F.1.germ x s = F.1.germ x t) :
   s = t :=
 begin
   -- We use `germ_eq` and the axiom of choice, to pick for every point `x` a neighbourhood
   -- `V x`, such that the restrictions of `s` and `t` to `V x` coincide.
-  choose V m i₁ i₂ heq using λ x : U, F.presheaf.germ_eq x.1 x.2 x.2 s t (h x),
+  choose V m i₁ i₂ heq using λ x : U, F.1.germ_eq x.1 x.2 x.2 s t (h x),
   -- Since `F` is a sheaf, we can prove the equality locally, if we can show that these
   -- neighborhoods form a cover of `U`.
   apply F.eq_of_locally_eq' V U i₁,
@@ -274,14 +274,14 @@ imply surjectivity of the components of a sheaf morphism. However it does imply 
 is an epi, but this fact is not yet formalized.
 -/
 lemma app_injective_of_stalk_functor_map_injective {F : sheaf C X} {G : presheaf C X}
-  (f : F.presheaf ⟶ G) (h : ∀ x : X, function.injective ((stalk_functor C x).map f))
+  (f : F.1 ⟶ G) (h : ∀ x : X, function.injective ((stalk_functor C x).map f))
   (U : opens X) :
   function.injective (f.app (op U)) :=
 λ s t hst, section_ext F _ _ _ $ λ x, h x.1 $ by
   rw [stalk_functor_map_germ_apply, stalk_functor_map_germ_apply, hst]
 
 lemma app_injective_iff_stalk_functor_map_injective {F : sheaf C X}
-  {G : presheaf C X} (f : F.presheaf ⟶ G) :
+  {G : presheaf C X} (f : F.1 ⟶ G) :
   (∀ x : X, function.injective ((stalk_functor C x).map f)) ↔
   (∀ U : opens X, function.injective (f.app (op U))) :=
 ⟨app_injective_of_stalk_functor_map_injective f, stalk_functor_map_injective_of_app_injective f⟩
@@ -292,8 +292,8 @@ a neighborhood `V ≤ U` and a section `s : F.obj (op V))` such that `f.app (op 
 agree on `V`. -/
 lemma app_surjective_of_injective_of_locally_surjective {F G : sheaf C X} (f : F ⟶ G)
   (hinj : ∀ x : X, function.injective ((stalk_functor C x).map f)) (U : opens X)
-  (hsurj : ∀ (t) (x : U), ∃ (V : opens X) (m : x.1 ∈ V) (iVU : V ⟶ U) (s : F.presheaf.obj (op V)),
-    f.app (op V) s = G.presheaf.map iVU.op t) :
+  (hsurj : ∀ (t) (x : U), ∃ (V : opens X) (m : x.1 ∈ V) (iVU : V ⟶ U) (s : F.1.obj (op V)),
+    f.app (op V) s = G.1.map iVU.op t) :
   function.surjective (f.app (op U)) :=
 begin
   intro t,
@@ -319,8 +319,7 @@ begin
     -- Here, we need to use injectivity of the stalk maps.
     apply (hinj z),
     erw [stalk_functor_map_germ_apply, stalk_functor_map_germ_apply],
-    dsimp,
-    simp_rw [← comp_apply, f.naturality, comp_apply, heq, ← comp_apply, ← G.presheaf.map_comp],
+    simp_rw [← comp_apply, f.naturality, comp_apply, heq, ← comp_apply, ← G.1.map_comp],
     refl }
 end
 
@@ -331,16 +330,16 @@ begin
   refine app_surjective_of_injective_of_locally_surjective f (λ x, (h x).1) U (λ t x, _),
   -- Now we need to prove our initial claim: That we can find preimages of `t` locally.
   -- Since `f` is surjective on stalks, we can find a preimage `s₀` of the germ of `t` at `x`
-  obtain ⟨s₀,hs₀⟩ := (h x).2 (G.presheaf.germ x t),
+  obtain ⟨s₀,hs₀⟩ := (h x).2 (G.1.germ x t),
   -- ... and this preimage must come from some section `s₁` defined on some open neighborhood `V₁`
-  obtain ⟨V₁,hxV₁,s₁,hs₁⟩ := F.presheaf.germ_exist x.1 s₀,
+  obtain ⟨V₁,hxV₁,s₁,hs₁⟩ := F.1.germ_exist x.1 s₀,
   subst hs₁, rename hs₀ hs₁,
   erw stalk_functor_map_germ_apply V₁ ⟨x.1,hxV₁⟩ f s₁ at hs₁,
   -- Now, the germ of `f.app (op V₁) s₁` equals the germ of `t`, hence they must coincide on
   -- some open neighborhood `V₂`.
-  obtain ⟨V₂, hxV₂, iV₂V₁, iV₂U, heq⟩ := G.presheaf.germ_eq x.1 hxV₁ x.2 _ _ hs₁,
+  obtain ⟨V₂, hxV₂, iV₂V₁, iV₂U, heq⟩ := G.1.germ_eq x.1 hxV₁ x.2 _ _ hs₁,
   -- The restriction of `s₁` to that neighborhood is our desired local preimage.
-  use [V₂, hxV₂, iV₂U, F.presheaf.map iV₂V₁.op s₁],
+  use [V₂, hxV₂, iV₂U, F.1.map iV₂V₁.op s₁],
   rw [← comp_apply, f.naturality, comp_apply, heq],
 end
 
@@ -361,11 +360,11 @@ lemma is_iso_of_stalk_functor_map_iso {F G : sheaf C X} (f : F ⟶ G)
 begin
   -- Since the inclusion functor from sheaves to presheaves is fully faithful, it suffices to
   -- show that `f`, as a morphism between _presheaves_, is an isomorphism.
-  suffices : is_iso ((induced_functor sheaf.presheaf).map f),
-  { exactI is_iso_of_fully_faithful (induced_functor sheaf.presheaf) f },
+  suffices : is_iso ((sheaf.forget C X).map f),
+  { exactI is_iso_of_fully_faithful (sheaf.forget C X) f },
   -- We show that all components of `f` are isomorphisms.
   suffices : ∀ U : (opens X)ᵒᵖ, is_iso (f.app U),
-  { exact @nat_iso.is_iso_of_is_iso_app _ _ _ _ F.presheaf G.presheaf f this, },
+  { exact @nat_iso.is_iso_of_is_iso_app _ _ _ _ F.1 G.1 f this, },
   intro U, op_induction U,
   -- Since the forgetful functor of `C` reflects isomorphisms, it suffices to see that the
   -- underlying map between types is an isomorphism, i.e. bijective.
@@ -389,7 +388,7 @@ begin
   split,
   { intros h x, resetI,
     exact @functor.map_is_iso _ _ _ _ _ _ (stalk_functor C x) f
-      ((induced_functor sheaf.presheaf).map_is_iso f) },
+      ((sheaf.forget C X).map_is_iso f) },
   { intro h,
     exactI is_iso_of_stalk_functor_map_iso f }
 end


### PR DESCRIPTION
Make `sheaf_condition` into a `Prop` and redefine the type of sheaves on a topological space `X` as a subtype of `(opens X)ᵒᵖ ⥤ C`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Previously, sheaves on a topological space were defined as a structure with a `Type`-valued field `sheaf_condition`. Meanwhile, the sheaf condition for sheaves on sites is defined as a `Prop`. I don't have a strong preference towards either design, but for the purpose of connecting the two theories, the design should be consistent on both sides.

That said, changing the sheaf condition to a `Prop` does seem to simplify things a little, as indicated by the net negative diff. The most changes are in `unique_gluing`, where some definitions have become no longer necessary.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
