### PR TITLE
[Merged by Bors] - chore(algebra/order/sub): generalize 2 lemmas

### DIFF
--- a/src/algebra/order/sub.lean
+++ b/src/algebra/order/sub.lean
@@ -294,6 +294,17 @@ variables {a b c d : α} [linear_order α] [add_comm_monoid α] [has_sub α] [ha
 lemma lt_of_sub_lt_sub_right (h : a - c < b - c) : a < b :=
 lt_imp_lt_of_le_imp_le (λ h, sub_le_sub_right' h c) h
 
+/-- See `lt_sub_iff_right_of_le` for a weaker statement in a partial order. -/
+lemma lt_sub_iff_right : a < b - c ↔ a + c < b :=
+lt_iff_lt_of_le_iff_le sub_le_iff_right
+
+/-- See `lt_sub_iff_left_of_le` for a weaker statement in a partial order. -/
+lemma lt_sub_iff_left : a < b - c ↔ c + a < b :=
+lt_iff_lt_of_le_iff_le sub_le_iff_left
+
+lemma lt_sub_comm : a < b - c ↔ c < b - a :=
+lt_sub_iff_left.trans lt_sub_iff_right.symm
+
 section cov
 variable [covariant_class α α (+) (≤)]
 
@@ -659,16 +670,6 @@ end add_le_cancellable
 
 section contra
 variable [contravariant_class α α (+) (≤)]
-
-/-- See `lt_sub_iff_right_of_le` for a weaker statement in a partial order.
-This lemma also holds for `ennreal`, but we need a different proof for that. -/
-lemma lt_sub_iff_right : a < b - c ↔ a + c < b :=
-contravariant.add_le_cancellable.lt_sub_iff_right
-
-/-- See `lt_sub_iff_left_of_le` for a weaker statement in a partial order.
-This lemma also holds for `ennreal`, but we need a different proof for that. -/
-lemma lt_sub_iff_left : a < b - c ↔ c + a < b :=
-contravariant.add_le_cancellable.lt_sub_iff_left
 
 /-- This lemma also holds for `ennreal`, but we need a different proof for that. -/
 lemma sub_lt_sub_iff_right' (h : c ≤ a) : a - c < b - c ↔ a < b :=

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -790,16 +790,14 @@ mt sub_eq_top_iff.mp $ mt and.left ha
 lemma sub_le_sub_add_sub : a - c ≤ a - b + (b - c) :=
 sub_le_sub_add_sub
 
+lemma lt_sub_iff_add_lt : a < b - c ↔ a + c < b := lt_sub_iff_right
+
+lemma lt_sub_comm : a < b - c ↔ c < b - a := lt_sub_comm
+
 /-! The following lemmas cannot be directly replaced by the general lemmas. -/
 
 protected lemma sub_lt_of_lt_add (hac : c ≤ a) (h : a < b + c) : a - c < b :=
 ((cancel_of_lt' $ hac.trans_lt h).sub_lt_iff_right hac).mpr h
-
-lemma lt_sub_iff_add_lt : a < b - c ↔ a + c < b :=
-by { cases c, { simp }, exact cancel_coe.lt_sub_iff_right }
-
-lemma lt_sub_comm : a < b - c ↔ c < b - a :=
-by rw [lt_sub_iff_add_lt, lt_sub_iff_add_lt, add_comm]
 
 @[simp] lemma add_sub_self (hb : b ≠ ∞) : (a + b) - b = a :=
 (cancel_of_ne hb).add_sub_cancel_right


### PR DESCRIPTION
* generalize `lt_sub_iff_left` and `lt_sub_iff_right`;
* use general lemmas in `data.real.ennreal`.

---

See also https://github.com/leanprover-community/mathlib/pull/9582#discussion_r723787263
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)