### PR TITLE
feat(analysis/normed_space/conformal_linear_map, analysis/calculus/conformal/normed_space): prove the conformality of `symm` of conformal `linear_equiv` and `local_homeomorph`

### DIFF
--- a/src/analysis/calculus/conformal/normed_space.lean
+++ b/src/analysis/calculus/conformal/normed_space.lean
@@ -23,7 +23,7 @@ if it is real differentiable at that point and its differential `is_conformal_li
 * The conformality of the composition of two conformal maps, the identity map
   and multiplications by nonzero constants
 * The conformality of the local inverse of a conformal local homeomorphism between Banach spaces
-  with surjective differential
+  with a surjective differential
 * `conformal_at_iff_is_conformal_map_fderiv`: an equivalent definition of the conformality of a map
 
 In `analysis.calculus.conformal.inner_product`:

--- a/src/analysis/calculus/conformal/normed_space.lean
+++ b/src/analysis/calculus/conformal/normed_space.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Yourong Zang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yourong Zang
 -/
+import analysis.normed_space.banach
 import analysis.normed_space.conformal_linear_map
 import analysis.calculus.fderiv
 
@@ -102,6 +103,27 @@ end
 lemma const_smul {f : X → Y} {x : X} {c : ℝ} (hc : c ≠ 0) (hf : conformal_at f x) :
   conformal_at (c • f) x :=
 (conformal_at_const_smul hc $ f x).comp x hf
+
+/-- The local inverse of a conformal local homeomorphism `f` between Banach spaces `X`, `Y` with
+    surjective differential is also conformal. -/
+lemma symm [complete_space X] [complete_space Y]
+  {f : local_homeomorph X Y} {x : X} (hx : x ∈ f.to_local_equiv.source)
+  (hf : conformal_at f x) (hf' : function.surjective (fderiv ℝ f x)) :
+  conformal_at f.symm (f x) :=
+begin
+  have A : f x ∈ f.to_local_equiv.target := f.map_source hx,
+  have hf'' := conformal_at_iff_is_conformal_map_fderiv.mp hf,
+  let f' : X ≃L[ℝ] Y := continuous_linear_equiv.of_bijective (fderiv ℝ f x)
+    (linear_map.ker_eq_bot.mpr hf''.injective) (linear_map.range_eq_top.mpr hf'),
+  have B : fderiv ℝ f x = ↑f' := (continuous_linear_equiv.coe_of_bijective _
+    (linear_map.ker_eq_bot.mpr hf''.injective) $ linear_map.range_eq_top.mpr hf').symm,
+  have C : has_fderiv_at f ↑f' (f.symm $ f x),
+  { rw [← B, f.left_inv hx],
+    exact hf.differentiable_at.has_fderiv_at },
+  refine ⟨↑f'.symm, f.has_fderiv_at_symm A C, _⟩,
+  rw B at hf'',
+  exact hf''.symm
+end
 
 end conformal_at
 

--- a/src/analysis/calculus/conformal/normed_space.lean
+++ b/src/analysis/calculus/conformal/normed_space.lean
@@ -22,6 +22,8 @@ if it is real differentiable at that point and its differential `is_conformal_li
 ## Main results
 * The conformality of the composition of two conformal maps, the identity map
   and multiplications by nonzero constants
+* The conformality of the local inverse of a conformal local homeomorphism between Banach spaces
+  with surjective differential
 * `conformal_at_iff_is_conformal_map_fderiv`: an equivalent definition of the conformality of a map
 
 In `analysis.calculus.conformal.inner_product`:

--- a/src/analysis/normed_space/conformal_linear_map.lean
+++ b/src/analysis/normed_space/conformal_linear_map.lean
@@ -87,6 +87,32 @@ begin
              function.comp_app, linear_isometry.map_smul, smul_smul],
 end
 
+/-- The inverse of a conformal, continuous linear equivalence `f'` between two semi normed spaces
+    `M'` and `N` is a continuous linear map. -/
+lemma symm {f' : M' ≃L[R] N} (hf' : is_conformal_map (f' : M' →L[R] N)) :
+  is_conformal_map (f'.symm : N →L[R] M') :=
+begin
+  rcases hf' with ⟨c, hc, li, hli⟩,
+  simp only [f'.coe_coe] at hli,
+  have surj : function.surjective li :=
+  λ y, begin
+    refine ⟨c • f'.symm y, _⟩,
+    simp only [li.coe_to_linear_map, li.map_smul],
+    have : c • li (f'.symm y) = f' (f'.symm y) := by simp only [hli, pi.smul_apply],
+    rw [this, f'.apply_symm_apply]
+  end,
+  refine ⟨c⁻¹, inv_ne_zero hc, (⟨linear_equiv.of_bijective li.to_linear_map li.injective surj,
+    by simp⟩ : M' ≃ₗᵢ[R] N).symm.to_linear_isometry, _⟩,
+  ext1 y,
+  rw [f'.symm.coe_coe, f'.symm_apply_eq, hli],
+  simp only [pi.smul_apply, function.comp_app, li.map_smul,
+    linear_isometry_equiv.coe_to_linear_isometry, linear_isometry_equiv.symm],
+  rw [linear_isometry_equiv.coe_mk, smul_smul, mul_inv_cancel hc, one_smul],
+  have : (li : M' → N) = linear_equiv.of_bijective li.to_linear_map li.injective surj :=
+    by funext x; exact (linear_equiv.of_bijective_apply li.to_linear_map _).symm,
+  rw [this, linear_equiv.apply_symm_apply]
+end
+
 lemma injective {f' : M' →L[R] N} (h : is_conformal_map f') : function.injective f' :=
 let ⟨c, hc, li, hf'⟩ := h in by simp only [hf', pi.smul_def];
   exact (smul_right_injective _ hc).comp li.injective

--- a/src/analysis/normed_space/conformal_linear_map.lean
+++ b/src/analysis/normed_space/conformal_linear_map.lean
@@ -19,6 +19,7 @@ a nonzero multiple of a linear isometry.
 
 * The conformality of the composition of two conformal linear maps, the identity map
   and multiplications by nonzero constants as continuous linear maps
+* The conformality of the inverse of a conformal linear equivalence
 * `is_conformal_map_of_subsingleton`: all continuous linear maps on singleton spaces are conformal
 * `is_conformal_map.preserves_angle`: if a continuous linear map is conformal, then it
                                       preserves all angles in the normed space


### PR DESCRIPTION
Add the conformality of the inverse of a conformal linear equivalence and the local inverse of a conformal local homeomorphism between Banach spaces with a surjective differential.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
