### PR TITLE
[Merged by Bors] - chore(algebra/*): add missing lemmas about `copy` on subobjects

### DIFF
--- a/src/algebra/algebra/subalgebra.lean
+++ b/src/algebra/algebra/subalgebra.lean
@@ -56,6 +56,12 @@ protected def copy (S : subalgebra R A) (s : set A) (hs : s = ↑S) : subalgebra
   mul_mem' := hs.symm ▸ S.mul_mem',
   algebra_map_mem' := hs.symm ▸ S.algebra_map_mem' }
 
+@[simp] lemma coe_copy (S : subalgebra R A) (s : set A) (hs : s = ↑S) :
+  (S.copy s hs : set A) = s := rfl
+
+lemma copy_eq (S : subalgebra R A) (s : set A) (hs : s = ↑S) : S.copy s hs = S :=
+set_like.coe_injective hs
+
 variables (S : subalgebra R A)
 
 theorem algebra_map_mem (r : R) : algebra_map R A r ∈ S :=
@@ -501,7 +507,7 @@ protected def gi : galois_insertion (adjoin R : set A → subalgebra R A) coe :=
 { choice := λ s hs, (adjoin R s).copy s $ le_antisymm (algebra.gc.le_u_l s) hs,
   gc := algebra.gc,
   le_l_u := λ S, (algebra.gc (S : set A) (adjoin R S)).1 $ le_refl _,
-  choice_eq := λ _ _, set_like.coe_injective $ by { generalize_proofs h, exact h } }
+  choice_eq := λ _ _, subalgebra.copy_eq _ _ _ }
 
 instance : complete_lattice (subalgebra R A) :=
 galois_insertion.lift_complete_lattice algebra.gi

--- a/src/algebra/lie/submodule.lean
+++ b/src/algebra/lie/submodule.lean
@@ -102,6 +102,12 @@ protected def copy (s : set M) (hs : s = ↑N) : lie_submodule R L M :=
   smul_mem' := hs.symm ▸ N.smul_mem',
   lie_mem   := hs.symm ▸ N.lie_mem, }
 
+@[simp] lemma coe_copy (S : lie_submodule R L M) (s : set M) (hs : s = ↑S) :
+  (S.copy s hs : set M) = s := rfl
+
+lemma copy_eq (S : lie_submodule R L M) (s : set M) (hs : s = ↑S) : S.copy s hs = S :=
+coe_injective hs
+
 instance : lie_ring_module L N :=
 { bracket     := λ (x : L) (m : N), ⟨⁅x, m.val⁆, N.lie_mem m.property⟩,
   add_lie     := by { intros x y m, apply set_coe.ext, apply add_lie, },

--- a/src/algebra/lie/submodule.lean
+++ b/src/algebra/lie/submodule.lean
@@ -83,15 +83,15 @@ lemma mem_coe {x : M} : x ∈ (N : set M) ↔ x ∈ N := iff.rfl
   (({lie_mem := h, ..p} : lie_submodule R L M) : submodule R M) = p :=
 by { cases p, refl, }
 
+lemma coe_submodule_injective :
+  function.injective (to_submodule : lie_submodule R L M → submodule R M) :=
+λ x y h, by { cases x, cases y, congr, injection h }
+
 @[ext] lemma ext (h : ∀ m, m ∈ N ↔ m ∈ N') : N = N' :=
-by { cases N, cases N', simp only [], ext m, exact h m, }
+coe_submodule_injective $ set_like.ext h
 
 @[simp] lemma coe_to_submodule_eq_iff : (N : submodule R M) = (N' : submodule R M) ↔ N = N' :=
-begin
-  split; intros h,
-  { ext, rw [← mem_coe_submodule, h], simp, },
-  { rw h, },
-end
+coe_submodule_injective.eq_iff
 
 /-- Copy of a lie_submodule with a new `carrier` equal to the old one. Useful to fix definitional
 equalities. -/
@@ -106,7 +106,7 @@ protected def copy (s : set M) (hs : s = ↑N) : lie_submodule R L M :=
   (S.copy s hs : set M) = s := rfl
 
 lemma copy_eq (S : lie_submodule R L M) (s : set M) (hs : s = ↑S) : S.copy s hs = S :=
-coe_injective hs
+coe_submodule_injective (set_like.coe_injective hs)
 
 instance : lie_ring_module L N :=
 { bracket     := λ (x : L) (m : N), ⟨⁅x, m.val⁆, N.lie_mem m.property⟩,
@@ -220,10 +220,7 @@ section lattice_structure
 open set
 
 lemma coe_injective : function.injective (coe : lie_submodule R L M → set M) :=
-λ N N' h, by { cases N, cases N', simp only, exact h, }
-
-lemma coe_submodule_injective : function.injective (coe : lie_submodule R L M → submodule R M) :=
-λ N N' h, by { ext, rw [← mem_coe_submodule, h], refl, }
+set_like.coe_injective.comp coe_submodule_injective
 
 instance : partial_order (lie_submodule R L M) :=
 { le := λ N N', ∀ ⦃x⦄, x ∈ N → x ∈ N', -- Overriding `le` like this gives a better defeq.

--- a/src/algebra/module/submodule.lean
+++ b/src/algebra/module/submodule.lean
@@ -75,6 +75,12 @@ protected def copy (p : submodule R M) (s : set M) (hs : s = ↑p) : submodule R
   add_mem' := hs.symm ▸ p.add_mem',
   smul_mem' := hs.symm ▸ p.smul_mem' }
 
+@[simp] lemma coe_copy (S : submodule R M) (s : set M) (hs : s = ↑S) :
+  (S.copy s hs : set M) = s := rfl
+
+lemma copy_eq (S : submodule R M) (s : set M) (hs : s = ↑S) : S.copy s hs = S :=
+set_like.coe_injective hs
+
 theorem to_add_submonoid_injective :
   injective (to_add_submonoid : submodule R M → add_submonoid M) :=
 λ p q h, set_like.ext'_iff.2 (show _, from set_like.ext'_iff.1 h)

--- a/src/data/set_like/basic.lean
+++ b/src/data/set_like/basic.lean
@@ -48,6 +48,12 @@ protected def copy (p : my_subobject X) (s : set X) (hs : s = ↑p) : my_subobje
 { carrier := s,
   op_mem' := hs.symm ▸ p.op_mem' }
 
+@[simp] lemma coe_copy (p : my_subobject X) (s : set X) (hs : s = ↑p) :
+  (p.copy s hs : set X) = s := rfl
+
+lemma copy_eq (p : my_subobject X) (s : set X) (hs : s = ↑p) : p.copy s hs = p :=
+set_like.coe_injective hs
+
 end my_subobject
 ```
 

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -114,6 +114,12 @@ protected def copy (S : subfield K) (s : set K) (hs : s = ↑S) : subfield K :=
   inv_mem' := hs.symm ▸ S.inv_mem',
   ..S.to_subring.copy s hs }
 
+@[simp] lemma coe_copy (S : subfield X) (s : set X) (hs : s = ↑S) :
+  (S.copy s hs : set X) = s := rfl
+
+lemma copy_eq (S : subfield X) (s : set X) (hs : s = ↑S) : S.copy s hs = S :=
+set_like.coe_injective hs
+
 @[simp] lemma coe_to_subring (s : subfield K) : (s.to_subring : set K) = s :=
 rfl
 

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -114,10 +114,10 @@ protected def copy (S : subfield K) (s : set K) (hs : s = ↑S) : subfield K :=
   inv_mem' := hs.symm ▸ S.inv_mem',
   ..S.to_subring.copy s hs }
 
-@[simp] lemma coe_copy (S : subfield X) (s : set X) (hs : s = ↑S) :
-  (S.copy s hs : set X) = s := rfl
+@[simp] lemma coe_copy (S : subfield K) (s : set K) (hs : s = ↑S) :
+  (S.copy s hs : set K) = s := rfl
 
-lemma copy_eq (S : subfield X) (s : set X) (hs : s = ↑S) : S.copy s hs = S :=
+lemma copy_eq (S : subfield K) (s : set K) (hs : s = ↑S) : S.copy s hs = S :=
 set_like.coe_injective hs
 
 @[simp] lemma coe_to_subring (s : subfield K) : (s.to_subring : set K) = s :=

--- a/src/group_theory/group_action/sub_mul_action.lean
+++ b/src/group_theory/group_action/sub_mul_action.lean
@@ -58,6 +58,12 @@ protected def copy (p : sub_mul_action R M) (s : set M) (hs : s = ↑p) : sub_mu
 { carrier := s,
   smul_mem' := hs.symm ▸ p.smul_mem' }
 
+@[simp] lemma coe_copy (p : sub_mul_action R M) (s : set X) (hs : s = ↑p) :
+  (p.copy s hs : set X) = s := rfl
+
+lemma copy_eq (p : sub_mul_action R M) (s : set X) (hs : s = ↑p) : p.copy s hs = p :=
+set_like.coe_injective hs
+
 instance : has_bot (sub_mul_action R M) :=
 ⟨{ carrier := ∅, smul_mem' := λ c, set.not_mem_empty}⟩
 

--- a/src/group_theory/group_action/sub_mul_action.lean
+++ b/src/group_theory/group_action/sub_mul_action.lean
@@ -58,10 +58,10 @@ protected def copy (p : sub_mul_action R M) (s : set M) (hs : s = ↑p) : sub_mu
 { carrier := s,
   smul_mem' := hs.symm ▸ p.smul_mem' }
 
-@[simp] lemma coe_copy (p : sub_mul_action R M) (s : set X) (hs : s = ↑p) :
-  (p.copy s hs : set X) = s := rfl
+@[simp] lemma coe_copy (p : sub_mul_action R M) (s : set M) (hs : s = ↑p) :
+  (p.copy s hs : set M) = s := rfl
 
-lemma copy_eq (p : sub_mul_action R M) (s : set X) (hs : s = ↑p) : p.copy s hs = p :=
+lemma copy_eq (p : sub_mul_action R M) (s : set M) (hs : s = ↑p) : p.copy s hs = p :=
 set_like.coe_injective hs
 
 instance : has_bot (sub_mul_action R M) :=

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -224,6 +224,12 @@ protected def copy (K : subgroup G) (s : set G) (hs : s = K) : subgroup G :=
   mul_mem' := hs.symm ▸ K.mul_mem',
   inv_mem' := hs.symm ▸ K.inv_mem' }
 
+@[simp] lemma coe_copy (K : subgroup X) (s : set X) (hs : s = ↑K) :
+  (K.copy s hs : set X) = s := rfl
+
+lemma copy_eq (K : subgroup X) (s : set X) (hs : s = ↑K) : K.copy s hs = K :=
+set_like.coe_injective hs
+
 /-- Two subgroups are equal if they have the same elements. -/
 @[ext, to_additive "Two `add_subgroup`s are equal if they have the same elements."]
 theorem ext {H K : subgroup G} (h : ∀ x, x ∈ H ↔ x ∈ K) : H = K := set_like.ext h

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -224,10 +224,10 @@ protected def copy (K : subgroup G) (s : set G) (hs : s = K) : subgroup G :=
   mul_mem' := hs.symm ▸ K.mul_mem',
   inv_mem' := hs.symm ▸ K.inv_mem' }
 
-@[simp] lemma coe_copy (K : subgroup X) (s : set X) (hs : s = ↑K) :
-  (K.copy s hs : set X) = s := rfl
+@[simp] lemma coe_copy (K : subgroup G) (s : set G) (hs : s = ↑K) :
+  (K.copy s hs : set G) = s := rfl
 
-lemma copy_eq (K : subgroup X) (s : set X) (hs : s = ↑K) : K.copy s hs = K :=
+lemma copy_eq (K : subgroup G) (s : set G) (hs : s = ↑K) : K.copy s hs = K :=
 set_like.coe_injective hs
 
 /-- Two subgroups are equal if they have the same elements. -/

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -119,7 +119,7 @@ protected def copy (S : subring R) (s : set R) (hs : s = ↑S) : subring R :=
   (S.copy s hs : set R) = s := rfl
 
 lemma copy_eq (S : subring R) (s : set R) (hs : s = ↑S) : S.copy s hs = S :=
-coe_injective hs
+set_like.coe_injective hs
 
 lemma to_subsemiring_injective : function.injective (to_subsemiring : subring R → subsemiring R)
 | r s h := ext (set_like.ext_iff.mp h : _)

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -115,6 +115,12 @@ protected def copy (S : subring R) (s : set R) (hs : s = ↑S) : subring R :=
   neg_mem' := hs.symm ▸ S.neg_mem',
   ..S.to_subsemiring.copy s hs }
 
+@[simp] lemma coe_copy (S : subring R) (s : set R) (hs : s = ↑S) :
+  (S.copy s hs : set R) = s := rfl
+
+lemma copy_eq (S : subring R) (s : set R) (hs : s = ↑S) : S.copy s hs = S :=
+coe_injective hs
+
 lemma to_subsemiring_injective : function.injective (to_subsemiring : subring R → subsemiring R)
 | r s h := ext (set_like.ext_iff.mp h : _)
 

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -55,6 +55,12 @@ protected def copy (S : subsemiring R) (s : set R) (hs : s = ↑S) : subsemiring
   ..S.to_add_submonoid.copy s hs,
   ..S.to_submonoid.copy s hs }
 
+@[simp] lemma coe_copy (S : subsemiring R) (s : set R) (hs : s = ↑S) :
+  (S.copy s hs : set R) = s := rfl
+
+lemma copy_eq (S : subsemiring R) (s : set R) (hs : s = ↑S) : S.copy s hs = S :=
+coe_injective hs
+
 lemma to_submonoid_injective : function.injective (to_submonoid : subsemiring R → submonoid R)
 | r s h := ext (set_like.ext_iff.mp h : _)
 

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -59,7 +59,7 @@ protected def copy (S : subsemiring R) (s : set R) (hs : s = ↑S) : subsemiring
   (S.copy s hs : set R) = s := rfl
 
 lemma copy_eq (S : subsemiring R) (s : set R) (hs : s = ↑S) : S.copy s hs = S :=
-coe_injective hs
+set_like.coe_injective hs
 
 lemma to_submonoid_injective : function.injective (to_submonoid : subsemiring R → submonoid R)
 | r s h := ext (set_like.ext_iff.mp h : _)


### PR DESCRIPTION
This adds `coe_copy` and `copy_eq` to `sub{mul_action,group,ring,semiring,field,module,algebra,lie_module}`, to match the lemmas already present on `submonoid`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
