### PR TITLE
[Merged by Bors] - chore(data/equiv/ring): add big operator lemmas for ring equivs

### DIFF
--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -364,31 +364,23 @@ end semiring_hom
 
 section big_operators
 
-lemma ring_equiv.map_list_prod [semiring R] [semiring S] (f : R ≃+* S) (l : list R) :
-  f l.prod = (l.map f).prod :=
-f.to_ring_hom.map_list_prod l
+lemma map_list_prod [semiring R] [semiring S] (f : R ≃+* S) (l : list R) :
+  f l.prod = (l.map f).prod := f.to_ring_hom.map_list_prod l
 
-lemma ring_equiv.map_list_sum [non_assoc_semiring R] [non_assoc_semiring S]
-  (f : R ≃+* S) (l : list R) :
-  f l.sum = (l.map f).sum :=
-f.to_add_monoid_hom.map_list_sum l
+lemma map_list_sum [non_assoc_semiring R] [non_assoc_semiring S] (f : R ≃+* S) (l : list R) :
+  f l.sum = (l.map f).sum := f.to_add_monoid_hom.map_list_sum l
 
-lemma ring_equiv.map_multiset_prod [comm_semiring R] [comm_semiring S] (f : R ≃+* S)
-  (s : multiset R) :
-  f s.prod = (s.map f).prod :=
-f.to_monoid_hom.map_multiset_prod s
+lemma map_multiset_prod [comm_semiring R] [comm_semiring S] (f : R ≃+* S) (s : multiset R) :
+  f s.prod = (s.map f).prod := f.to_monoid_hom.map_multiset_prod s
 
-lemma ring_equiv.map_multiset_sum [non_assoc_semiring R] [non_assoc_semiring S]
-  (f : R ≃+* S) (s : multiset R) :
-  f s.sum = (s.map f).sum :=
-f.to_add_monoid_hom.map_multiset_sum s
+lemma map_multiset_sum [non_assoc_semiring R] [non_assoc_semiring S]
+  (f : R ≃+* S) (s : multiset R) : f s.sum = (s.map f).sum := f.to_add_monoid_hom.map_multiset_sum s
 
-lemma ring_equiv.map_prod {α : Type*} [comm_semiring R] [comm_semiring S] (g : R ≃+* S) (f : α → R)
-  (s : finset α) :
-  g (∏ x in s, f x) = ∏ x in s, g (f x) :=
+lemma map_prod {α : Type*} [comm_semiring R] [comm_semiring S] (g : R ≃+* S) (f : α → R)
+  (s : finset α) : g (∏ x in s, f x) = ∏ x in s, g (f x) :=
 g.to_monoid_hom.map_prod f s
 
-lemma ring_equiv.map_sum {α : Type*} [non_assoc_semiring R] [non_assoc_semiring S]
+lemma map_sum {α : Type*} [non_assoc_semiring R] [non_assoc_semiring S]
   (g : R ≃+* S) (f : α → R) (s : finset α) : g (∑ x in s, f x) = ∑ x in s, g (f x) :=
 g.to_add_monoid_hom.map_sum f s
 

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 import data.equiv.mul_add
 import algebra.field
 import algebra.opposites
+import algebra.big_operators.basic
 
 /-!
 # (Semi)ring equivs
@@ -34,6 +35,8 @@ multiplication in `equiv.perm`, and multiplication in `category_theory.End`, not
 
 equiv, mul_equiv, add_equiv, ring_equiv, mul_aut, add_aut, ring_aut
 -/
+
+open_locale big_operators
 
 variables {R : Type*} {S : Type*} {S' : Type*}
 
@@ -358,6 +361,38 @@ lemma of_hom_inv_symm_apply (hom : R →+* S) (inv : S →+* R) (hom_inv_id inv_
   (of_hom_inv hom inv hom_inv_id inv_hom_id).symm s = inv s := rfl
 
 end semiring_hom
+
+section big_operators
+
+lemma ring_equiv.map_list_prod [semiring R] [semiring S] (f : R ≃+* S) (l : list R) :
+  f l.prod = (l.map f).prod :=
+f.to_ring_hom.map_list_prod l
+
+lemma ring_equiv.map_list_sum [non_assoc_semiring R] [non_assoc_semiring S]
+  (f : R ≃+* S) (l : list R) :
+  f l.sum = (l.map f).sum :=
+f.to_add_monoid_hom.map_list_sum l
+
+lemma ring_equiv.map_multiset_prod [comm_semiring R] [comm_semiring S] (f : R ≃+* S)
+  (s : multiset R) :
+  f s.prod = (s.map f).prod :=
+f.to_monoid_hom.map_multiset_prod s
+
+lemma ring_equiv.map_multiset_sum [non_assoc_semiring R] [non_assoc_semiring S]
+  (f : R ≃+* S) (s : multiset R) :
+  f s.sum = (s.map f).sum :=
+f.to_add_monoid_hom.map_multiset_sum s
+
+lemma ring_equiv.map_prod {α : Type*} [comm_semiring R] [comm_semiring S] (g : R ≃+* S) (f : α → R)
+  (s : finset α) :
+  g (∏ x in s, f x) = ∏ x in s, g (f x) :=
+g.to_monoid_hom.map_prod f s
+
+lemma ring_equiv.map_sum {α : Type*} [non_assoc_semiring R] [non_assoc_semiring S]
+  (g : R ≃+* S) (f : α → R) (s : finset α) : g (∑ x in s, f x) = ∑ x in s, g (f x) :=
+g.to_add_monoid_hom.map_sum f s
+
+end big_operators
 
 end ring_equiv
 

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -368,21 +368,21 @@ lemma map_list_prod [semiring R] [semiring S] (f : R ≃+* S) (l : list R) :
   f l.prod = (l.map f).prod := f.to_ring_hom.map_list_prod l
 
 lemma map_list_sum [non_assoc_semiring R] [non_assoc_semiring S] (f : R ≃+* S) (l : list R) :
-  f l.sum = (l.map f).sum := f.to_add_monoid_hom.map_list_sum l
+  f l.sum = (l.map f).sum := f.to_ring_hom.map_list_sum l
 
 lemma map_multiset_prod [comm_semiring R] [comm_semiring S] (f : R ≃+* S) (s : multiset R) :
-  f s.prod = (s.map f).prod := f.to_monoid_hom.map_multiset_prod s
+  f s.prod = (s.map f).prod := f.to_ring_hom.map_multiset_prod s
 
 lemma map_multiset_sum [non_assoc_semiring R] [non_assoc_semiring S]
-  (f : R ≃+* S) (s : multiset R) : f s.sum = (s.map f).sum := f.to_add_monoid_hom.map_multiset_sum s
+  (f : R ≃+* S) (s : multiset R) : f s.sum = (s.map f).sum := f.to_ring_hom.map_multiset_sum s
 
 lemma map_prod {α : Type*} [comm_semiring R] [comm_semiring S] (g : R ≃+* S) (f : α → R)
   (s : finset α) : g (∏ x in s, f x) = ∏ x in s, g (f x) :=
-g.to_monoid_hom.map_prod f s
+g.to_ring_hom.map_prod f s
 
 lemma map_sum {α : Type*} [non_assoc_semiring R] [non_assoc_semiring S]
   (g : R ≃+* S) (f : α → R) (s : finset α) : g (∑ x in s, f x) = ∑ x in s, g (f x) :=
-g.to_add_monoid_hom.map_sum f s
+g.to_ring_hom.map_sum f s
 
 end big_operators
 


### PR DESCRIPTION
This PR adds lemmas involving big operators (such as `map_sum`, `map_prod`, etc) for `ring_equiv`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
