### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space/barycentric_coords): we can recover a point from its barycentric coordinates

### DIFF
--- a/src/linear_algebra/affine_space/barycentric_coords.lean
+++ b/src/linear_algebra/affine_space/barycentric_coords.lean
@@ -108,6 +108,26 @@ begin
     hw, mul_boole, function.comp_app, smul_eq_mul, s.sum_ite_eq, s.map_affine_combination p w hw],
 end
 
+@[simp] lemma sum_barycentric_coord_apply_eq_one [fintype ι] (q : P) :
+  ∑ i, barycentric_coord h_ind h_tot i q = 1 :=
+begin
+  have hq : q ∈ affine_span k (range p), { rw h_tot, exact affine_subspace.mem_top k V q, },
+  obtain ⟨w, hw, rfl⟩ := eq_affine_combination_of_mem_affine_span_of_fintype hq,
+  convert hw,
+  ext i,
+  exact barycentric_coord_apply_combination_of_mem h_ind h_tot (finset.mem_univ i) hw,
+end
+
+@[simp] lemma affine_combination_barycentric_coord_eq_self [fintype ι] (q : P) :
+  finset.univ.affine_combination p (λ i, barycentric_coord h_ind h_tot i q) = q :=
+begin
+  have hq : q ∈ affine_span k (range p), { rw h_tot, exact affine_subspace.mem_top k V q, },
+  obtain ⟨w, hw, rfl⟩ := eq_affine_combination_of_mem_affine_span_of_fintype hq,
+  congr,
+  ext i,
+  exact barycentric_coord_apply_combination_of_mem h_ind h_tot (finset.mem_univ i) hw,
+end
+
 @[simp] lemma coe_barycentric_coord_of_subsingleton_eq_one [subsingleton ι] (i : ι) :
   (barycentric_coord h_ind h_tot i : P → k) = 1 :=
 begin

--- a/src/linear_algebra/affine_space/combination.lean
+++ b/src/linear_algebra/affine_space/combination.lean
@@ -682,7 +682,8 @@ end
 variables {k}
 
 /-- A point in the `affine_span` of an indexed family is an
-`affine_combination` with sum of weights 1. -/
+`affine_combination` with sum of weights 1. See also
+`eq_affine_combination_of_mem_affine_span_of_fintype`. -/
 lemma eq_affine_combination_of_mem_affine_span {p1 : P} {p : ι → P}
     (h : p1 ∈ affine_span k (set.range p)) :
   ∃ (s : finset ι) (w : ι → k) (hw : ∑ i in s, w i = 1), p1 = s.affine_combination p w :=
@@ -714,6 +715,18 @@ begin
   split,
   { simp [pi.add_apply, finset.sum_add_distrib, hw0, h'] },
   { rw [add_comm, ←finset.weighted_vsub_vadd_affine_combination, hw0s, hs', vsub_vadd] }
+end
+
+lemma eq_affine_combination_of_mem_affine_span_of_fintype [fintype ι] {p1 : P} {p : ι → P}
+  (h : p1 ∈ affine_span k (set.range p)) :
+  ∃ (w : ι → k) (hw : ∑ i, w i = 1), p1 = finset.univ.affine_combination p w :=
+begin
+  obtain ⟨s, w, hw, rfl⟩ := eq_affine_combination_of_mem_affine_span h,
+  refine ⟨(s : set ι).indicator w, _, finset.affine_combination_indicator_subset w p s.subset_univ⟩,
+  simp only [finset.mem_coe, set.indicator_apply, ← hw],
+  convert fintype.sum_extend_by_zero s w,
+  ext i,
+  congr,
 end
 
 variables (k V)


### PR DESCRIPTION
Formalized as part of the Sphere Eversion project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
