### PR TITLE
[Merged by Bors] - feat(order/min_max): min_cases and max_cases lemmata

### DIFF
--- a/src/order/min_max.lean
+++ b/src/order/min_max.lean
@@ -47,6 +47,24 @@ lemma min_le_max : min a b ≤ max a b := le_trans (min_le_left a b) (le_max_lef
 @[simp] lemma max_eq_left_iff : max a b = a ↔ b ≤ a := sup_eq_left
 @[simp] lemma max_eq_right_iff : max a b = b ↔ a ≤ b := sup_eq_right
 
+/-- For elements `a` and `b` of a linear order, either `min a b = a` and `a ≤ b`,
+    or `min a b = b` and `b < a`.
+    Use cases on this lemma to automate linarith in inequalities -/
+lemma min_cases (a b : α) : min a b = a ∧ a ≤ b ∨ min a b = b ∧ b < a :=
+begin
+  by_cases a ≤ b,
+  { left,
+    exact ⟨min_eq_left h, h⟩ },
+  { right,
+    exact ⟨min_eq_right (le_of_lt (not_le.mp h)), (not_le.mp h)⟩ }
+end
+
+/-- For elements `a` and `b` of a linear order, either `max a b = a` and `b ≤ a`,
+    or `max a b = b` and `a < b`.
+    Use cases on this lemma to automate linarith in inequalities -/
+lemma max_cases (a b : α) : max a b = a ∧ b ≤ a ∨ max a b = b ∧ a < b :=
+@min_cases (order_dual α) _ a b
+
 lemma min_eq_iff : min a b = c ↔ a = c ∧ a ≤ b ∨ b = c ∧ b ≤ a :=
 begin
   split,


### PR DESCRIPTION
These lemmata make the following type of argument work seamlessly:

```lean
example (h1 : 0 ≤ x) (h2 : x ≤ 1) : min 1 x ≤ max x 0 := by cases min_cases 1 x; cases max_cases x 0; linarith
```

See similar PR #8124

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
