### PR TITLE
[Merged by Bors] - feat(topology/connected.lean): add theorems about connectedness o…

### DIFF
--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -148,7 +148,7 @@ is_preconnected.subset_closure H subset_closure $ subset.refl $ closure s
 
 theorem is_connected.closure {s : set α} (H : is_connected s) :
   is_connected (closure s) :=
-is_connected.subset_closure H subset_closure (subset.refl (closure s))
+is_connected.subset_closure H subset_closure $ subset.refl $ closure s
 
 /-- The image of a (pre)connected set is (pre)connected as well. -/
 theorem is_preconnected.image [topological_space β] {s : set α} (H : is_preconnected s)

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -122,7 +122,35 @@ begin
     Hs.is_preconnected Ht.is_preconnected
 end
 
+/-- Theorem of bark and tree : if a set is within a (pre)connected set and its closure,
+then it is (pre)connected as well. -/
+theorem is_preconnected.inclosure {s : set α} {t : set α}
+  (H : is_preconnected s) (Kst : s ⊆ t) (Ktcs : t ⊆ closure s) :
+  is_preconnected (t) :=
+λ u v hu hv htuv ⟨y, hyt, hyu⟩ ⟨z, hzt, hzv⟩ ,
+let ⟨p, hpu, hps⟩ := mem_closure_iff.1 (Ktcs hyt) u hu hyu in
+let ⟨q, hqv, hqs⟩ := mem_closure_iff.1 (Ktcs hzt) v hv hzv in
+let ⟨r, hrs, hruv⟩ := H u v hu hv (subset.trans Kst htuv)
+  ⟨p, hps, hpu⟩ ⟨q, hqs, hqv⟩ in ⟨r, Kst hrs, hruv⟩
+
+theorem is_connected.inclosure {s : set α}  {t : set α}
+  (H : is_connected s) (Kst : s ⊆ t) (Ktcs : t ⊆ closure s): is_connected (t) :=
+  let hsne := H.left  in
+  let ht := Kst in
+  let htne := nonempty.mono ht hsne in
+    ⟨nonempty.mono Kst H.left ,
+      is_preconnected.inclosure H.right Kst Ktcs ⟩
+
+/-- The closure of a (pre)connected set is (pre)connected as well. -/
 theorem is_preconnected.closure {s : set α} (H : is_preconnected s) :
+  is_preconnected (closure s) :=
+  is_preconnected.inclosure H (subset_closure) (subset.refl (closure s))
+
+theorem is_connected.closure {s : set α} (H : is_connected s) :
+  is_connected (closure s) :=
+    is_connected.inclosure H (subset_closure) (subset.refl (closure s))
+
+/-- theorem is_preconnected.closure {s : set α} (H : is_preconnected s) :
   is_preconnected (closure s) :=
 λ u v hu hv hcsuv ⟨y, hycs, hyu⟩ ⟨z, hzcs, hzv⟩,
 let ⟨p, hpu, hps⟩ := mem_closure_iff.1 hycs u hu hyu in
@@ -133,7 +161,9 @@ let ⟨r, hrs, hruv⟩ := H u v hu hv (subset.trans subset_closure hcsuv) ⟨p, 
 theorem is_connected.closure {s : set α} (H : is_connected s) :
   is_connected (closure s) :=
 ⟨H.nonempty.closure, H.is_preconnected.closure⟩
+-/
 
+/- The image of a (pre)connected set is (pre)connected as well -/
 theorem is_preconnected.image [topological_space β] {s : set α} (H : is_preconnected s)
   (f : α → β) (hf : continuous_on f s) : is_preconnected (f '' s) :=
 begin

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -122,48 +122,33 @@ begin
     Hs.is_preconnected Ht.is_preconnected
 end
 
-/-- Theorem of bark and tree : if a set is within a (pre)connected set and its closure,
-then it is (pre)connected as well. -/
+/-- Theorem of bark and tree : if a set is within a (pre)connected set and its closure, then it is (pre)connected as well. -/
 theorem is_preconnected.inclosure {s : set α} {t : set α}
   (H : is_preconnected s) (Kst : s ⊆ t) (Ktcs : t ⊆ closure s) :
-  is_preconnected (t) :=
-λ u v hu hv htuv ⟨y, hyt, hyu⟩ ⟨z, hzt, hzv⟩ ,
-let ⟨p, hpu, hps⟩ := mem_closure_iff.1 (Ktcs hyt) u hu hyu in
-let ⟨q, hqv, hqs⟩ := mem_closure_iff.1 (Ktcs hzt) v hv hzv in
-let ⟨r, hrs, hruv⟩ := H u v hu hv (subset.trans Kst htuv)
-  ⟨p, hps, hpu⟩ ⟨q, hqs, hqv⟩ in ⟨r, Kst hrs, hruv⟩
+  is_preconnected t :=
+λ u v hu hv htuv ⟨y, hyt, hyu⟩ ⟨z, hzt, hzv⟩,
+let ⟨p, hpu, hps⟩ := mem_closure_iff.1 (Ktcs hyt) u hu hyu,
+    ⟨q, hqv, hqs⟩ := mem_closure_iff.1 (Ktcs hzt) v hv hzv,
+    ⟨r, hrs, hruv⟩ := H u v hu hv (subset.trans Kst htuv) ⟨p, hps, hpu⟩ ⟨q, hqs, hqv⟩ in
+  ⟨r, Kst hrs, hruv⟩
 
 theorem is_connected.inclosure {s : set α}  {t : set α}
   (H : is_connected s) (Kst : s ⊆ t) (Ktcs : t ⊆ closure s): is_connected (t) :=
-  let hsne := H.left  in
-  let ht := Kst in
-  let htne := nonempty.mono ht hsne in
-    ⟨nonempty.mono Kst H.left ,
-      is_preconnected.inclosure H.right Kst Ktcs ⟩
+let hsne := H.left,
+    ht := Kst,
+    htne := nonempty.mono ht hsne in
+    ⟨nonempty.mono Kst H.left, is_preconnected.inclosure H.right Kst Ktcs ⟩
 
 /-- The closure of a (pre)connected set is (pre)connected as well. -/
 theorem is_preconnected.closure {s : set α} (H : is_preconnected s) :
   is_preconnected (closure s) :=
-  is_preconnected.inclosure H (subset_closure) (subset.refl (closure s))
+is_preconnected.inclosure H (subset_closure) (subset.refl (closure s))
 
 theorem is_connected.closure {s : set α} (H : is_connected s) :
   is_connected (closure s) :=
-    is_connected.inclosure H (subset_closure) (subset.refl (closure s))
+is_connected.inclosure H subset_closure (subset.refl (closure s))
 
-/-- theorem is_preconnected.closure {s : set α} (H : is_preconnected s) :
-  is_preconnected (closure s) :=
-λ u v hu hv hcsuv ⟨y, hycs, hyu⟩ ⟨z, hzcs, hzv⟩,
-let ⟨p, hpu, hps⟩ := mem_closure_iff.1 hycs u hu hyu in
-let ⟨q, hqv, hqs⟩ := mem_closure_iff.1 hzcs v hv hzv in
-let ⟨r, hrs, hruv⟩ := H u v hu hv (subset.trans subset_closure hcsuv) ⟨p, hps, hpu⟩ ⟨q, hqs, hqv⟩ in
-⟨r, subset_closure hrs, hruv⟩
-
-theorem is_connected.closure {s : set α} (H : is_connected s) :
-  is_connected (closure s) :=
-⟨H.nonempty.closure, H.is_preconnected.closure⟩
--/
-
-/- The image of a (pre)connected set is (pre)connected as well -/
+/-- The image of a (pre)connected set is (pre)connected as well. -/
 theorem is_preconnected.image [topological_space β] {s : set α} (H : is_preconnected s)
   (f : α → β) (hf : continuous_on f s) : is_preconnected (f '' s) :=
 begin

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -122,7 +122,9 @@ begin
     Hs.is_preconnected Ht.is_preconnected
 end
 
-/-- Theorem of bark and tree : if a set is within a (pre)connected set and its closure, then it is (pre)connected as well. -/
+/-- Theorem of bark and tree :
+if a set is within a (pre)connected set and its closure,
+then it is (pre)connected as well. -/
 theorem is_preconnected.inclosure {s : set α} {t : set α}
   (H : is_preconnected s) (Kst : s ⊆ t) (Ktcs : t ⊆ closure s) :
   is_preconnected t :=

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -135,7 +135,7 @@ let ⟨p, hpu, hps⟩ := mem_closure_iff.1 (Ktcs hyt) u hu hyu,
   ⟨r, Kst hrs, hruv⟩
 
 theorem is_connected.subset_closure {s : set α}  {t : set α}
-  (H : is_connected s) (Kst : s ⊆ t) (Ktcs : t ⊆ closure s): is_connected (t) :=
+  (H : is_connected s) (Kst : s ⊆ t) (Ktcs : t ⊆ closure s): is_connected t :=
 let hsne := H.left,
     ht := Kst,
     htne := nonempty.mono ht hsne in

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -144,7 +144,7 @@ let hsne := H.left,
 /-- The closure of a (pre)connected set is (pre)connected as well. -/
 theorem is_preconnected.closure {s : set α} (H : is_preconnected s) :
   is_preconnected (closure s) :=
-is_preconnected.subset_closure H (subset_closure) (subset.refl (closure s))
+is_preconnected.subset_closure H subset_closure $ subset.refl $ closure s
 
 theorem is_connected.closure {s : set α} (H : is_connected s) :
   is_connected (closure s) :=

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -125,7 +125,7 @@ end
 /-- Theorem of bark and tree :
 if a set is within a (pre)connected set and its closure,
 then it is (pre)connected as well. -/
-theorem is_preconnected.inclosure {s : set α} {t : set α}
+theorem is_preconnected.subset_closure {s : set α} {t : set α}
   (H : is_preconnected s) (Kst : s ⊆ t) (Ktcs : t ⊆ closure s) :
   is_preconnected t :=
 λ u v hu hv htuv ⟨y, hyt, hyu⟩ ⟨z, hzt, hzv⟩,
@@ -134,21 +134,21 @@ let ⟨p, hpu, hps⟩ := mem_closure_iff.1 (Ktcs hyt) u hu hyu,
     ⟨r, hrs, hruv⟩ := H u v hu hv (subset.trans Kst htuv) ⟨p, hps, hpu⟩ ⟨q, hqs, hqv⟩ in
   ⟨r, Kst hrs, hruv⟩
 
-theorem is_connected.inclosure {s : set α}  {t : set α}
+theorem is_connected.subset_closure {s : set α}  {t : set α}
   (H : is_connected s) (Kst : s ⊆ t) (Ktcs : t ⊆ closure s): is_connected (t) :=
 let hsne := H.left,
     ht := Kst,
     htne := nonempty.mono ht hsne in
-    ⟨nonempty.mono Kst H.left, is_preconnected.inclosure H.right Kst Ktcs ⟩
+    ⟨nonempty.mono Kst H.left, is_preconnected.subset_closure H.right Kst Ktcs ⟩
 
 /-- The closure of a (pre)connected set is (pre)connected as well. -/
 theorem is_preconnected.closure {s : set α} (H : is_preconnected s) :
   is_preconnected (closure s) :=
-is_preconnected.inclosure H (subset_closure) (subset.refl (closure s))
+is_preconnected.subset_closure H (subset_closure) (subset.refl (closure s))
 
 theorem is_connected.closure {s : set α} (H : is_connected s) :
   is_connected (closure s) :=
-is_connected.inclosure H subset_closure (subset.refl (closure s))
+is_connected.subset_closure H subset_closure (subset.refl (closure s))
 
 /-- The image of a (pre)connected set is (pre)connected as well. -/
 theorem is_preconnected.image [topological_space β] {s : set α} (H : is_preconnected s)


### PR DESCRIPTION
feat(src/topology/connected.lean): add theorems about connectedness of closure

add two theorems is_preconnected.inclosure and is_connected.closure
	which formalize that if a set s is (pre)connected
	and a set t satisfies s ⊆ t ⊆ closure s,
	then t is (pre)connected as well
modify is_preconnected.closure and is_connected.closure
	to take these theorems into account
add a few comments for theorems in the code



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
