### PR TITLE
feat(group_theory/sylow): A finite group has only finitely many Sylow subgroups

### DIFF
--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -57,6 +57,9 @@ by cases P; cases Q; congr'
 lemma sylow.ext_iff {P Q : sylow p G} : P = Q ↔ (P : subgroup G) = Q :=
 ⟨congr_arg coe, sylow.ext⟩
 
+noncomputable instance [fintype G] : fintype (sylow p G) :=
+fintype.of_injective (coe : sylow p G → set G) (λ P Q, sylow.ext ∘ subgroup.ext ∘ set.ext_iff.mp)
+
 /-- A generalization of **Sylow's first theorem**.
   Every `p`-subgroup is contained in a Sylow `p`-subgroup. -/
 lemma is_p_group.exists_le_sylow {P : subgroup G} (hP : is_p_group p P) :


### PR DESCRIPTION
This instance is noncomputable due to the use of `fintype.of_injective`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
