### PR TITLE
[Merged by Bors] - feat(group_theory/sylow): `set_like` instance for `sylow`

### DIFF
--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes, Thomas Browning
 -/
 
 import group_theory.p_group
+import data.set_like.fintype
 
 /-!
 # Sylow theorems
@@ -47,18 +48,31 @@ structure sylow extends subgroup G :=
 
 variables {p} {G}
 
+namespace sylow
+
 instance : has_coe (sylow p G) (subgroup G) := ⟨sylow.to_subgroup⟩
 
-@[simp] lemma sylow.to_subgroup_eq_coe {P : sylow p G} : P.to_subgroup = ↑P := rfl
+@[simp] lemma to_subgroup_eq_coe {P : sylow p G} : P.to_subgroup = ↑P := rfl
 
-@[ext] lemma sylow.ext {P Q : sylow p G} (h : (P : subgroup G) = Q) : P = Q :=
+@[simp] lemma coe_mk (P) (h1) (h2) : (@sylow.mk p G _ P h1 h2 : subgroup G) = P := rfl
+
+instance : set_like (sylow p G) G :=
+{ coe := coe,
+  coe_injective' := λ P Q h,
+  begin
+    rcases P with ⟨P, hP, hP'⟩, rcases Q with ⟨Q, hQ, hQ'⟩, congr, ext,
+    simp only [coe_mk, coe_coe, set_like.coe_set_eq] at h, rw h
+  end }
+
+@[ext] lemma ext {P Q : sylow p G} (h : (P : subgroup G) = Q) : P = Q :=
 by cases P; cases Q; congr'
 
-lemma sylow.ext_iff {P Q : sylow p G} : P = Q ↔ (P : subgroup G) = Q :=
-⟨congr_arg coe, sylow.ext⟩
+lemma ext_iff {P Q : sylow p G} : P = Q ↔ (P : subgroup G) = Q :=
+⟨congr_arg coe, ext⟩
 
-noncomputable instance [fintype G] : fintype (sylow p G) :=
-fintype.of_injective (coe : sylow p G → set G) (λ P Q, sylow.ext ∘ subgroup.ext ∘ set.ext_iff.mp)
+noncomputable instance [fintype G] : fintype (sylow p G) := set_like.fintype
+
+end sylow
 
 /-- A generalization of **Sylow's first theorem**.
   Every `p`-subgroup is contained in a Sylow `p`-subgroup. -/
@@ -104,7 +118,7 @@ lemma sylow.coe_smul {g : G} {P : sylow p G} :
 lemma sylow.smul_eq_iff_mem_normalizer {g : G} {P : sylow p G} :
   g • P = P ↔ g ∈ P.1.normalizer :=
 begin
-  rw [eq_comm, sylow.ext_iff, set_like.ext_iff, ←inv_mem_iff, mem_normalizer_iff, inv_inv],
+  rw [eq_comm, set_like.ext_iff, ←inv_mem_iff, mem_normalizer_iff, inv_inv],
   exact forall_congr (λ h, iff_congr iff.rfl ⟨λ ⟨a, b, c⟩, (congr_arg _ c).mp
     ((congr_arg (∈ P.1) (mul_aut.inv_apply_self G (mul_aut.conj g) a)).mpr b),
     λ hh, ⟨(mul_aut.conj g)⁻¹ h, hh, mul_aut.apply_inv_self G (mul_aut.conj g) h⟩⟩),

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -5,7 +5,6 @@ Authors: Chris Hughes, Thomas Browning
 -/
 
 import group_theory.p_group
-import data.set_like.fintype
 
 /-!
 # Sylow theorems

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -54,23 +54,15 @@ instance : has_coe (sylow p G) (subgroup G) := ⟨sylow.to_subgroup⟩
 
 @[simp] lemma to_subgroup_eq_coe {P : sylow p G} : P.to_subgroup = ↑P := rfl
 
-@[simp] lemma coe_mk (P) (h1) (h2) : (@sylow.mk p G _ P h1 h2 : subgroup G) = P := rfl
-
-instance : set_like (sylow p G) G :=
-{ coe := coe,
-  coe_injective' := λ P Q h,
-  begin
-    rcases P with ⟨P, hP, hP'⟩, rcases Q with ⟨Q, hQ, hQ'⟩, congr, ext,
-    simp only [coe_mk, coe_coe, set_like.coe_set_eq] at h, rw h
-  end }
-
 @[ext] lemma ext {P Q : sylow p G} (h : (P : subgroup G) = Q) : P = Q :=
 by cases P; cases Q; congr'
 
 lemma ext_iff {P Q : sylow p G} : P = Q ↔ (P : subgroup G) = Q :=
 ⟨congr_arg coe, ext⟩
 
-noncomputable instance [fintype G] : fintype (sylow p G) := set_like.fintype
+instance : set_like (sylow p G) G :=
+{ coe := coe,
+  coe_injective' := λ P Q h, ext (set_like.coe_injective h) }
 
 end sylow
 

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -57,6 +57,9 @@ by cases P; cases Q; congr'
 lemma sylow.ext_iff {P Q : sylow p G} : P = Q ↔ (P : subgroup G) = Q :=
 ⟨congr_arg coe, sylow.ext⟩
 
+noncomputable instance [fintype G] : fintype (sylow p G) :=
+fintype.of_injective (coe : sylow p G → set G) (λ P Q, sylow.ext ∘ subgroup.ext ∘ set.ext_iff.mp)
+
 /-- A generalization of **Sylow's first theorem**.
   Every `p`-subgroup is contained in a Sylow `p`-subgroup. -/
 lemma is_p_group.exists_le_sylow {P : subgroup G} (hP : is_p_group p P) :


### PR DESCRIPTION
Adds a `set_like` instance for `sylow p G`.

Coauthored by @jcommelin

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
