### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal/operation): add some extra definitions in the `double_quot` section

### DIFF
--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1749,4 +1749,12 @@ def quot_quot_equiv_quot_sup : (J.map (ideal.quotient.mk I)).quotient ≃+* (I �
 ring_equiv.of_hom_inv (quot_quot_to_quot_sup I J) (lift_sup_quot_quot_mk I J)
   (by { ext z, refl }) (by { ext z, refl })
 
+/-- The obvious isomorphism `R/(I ⊔ J) → R/(J ⊔ I)`  -/
+def quot_sup_to_quot_sup_comm : (I ⊔ J).quotient ≃+* (J ⊔ I).quotient := quot_equiv_of_eq sup_comm
+
+/-- The obvious isomorphism `(R/I)/J' → (R/J)/I' `   -/
+def quot_quot_equiv_comm : (J.map I^.quotient.mk).quotient ≃+* (I.map J^.quotient.mk).quotient :=
+  ring_equiv.trans (ring_equiv.trans (quot_quot_equiv_quot_sup I J) (quot_sup_to_quot_sup_comm I J))
+  (quot_quot_equiv_quot_sup J I).symm
+
 end double_quot

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1756,8 +1756,8 @@ by rw [quot_quot_equiv_quot_sup, quot_quot_mk, ring_equiv.of_hom_inv_apply, quot
     ring_hom.comp_apply, ideal.quotient.lift_mk, quot_left_to_quot_sup, ideal.quotient.factor_mk]
 
 @[simp]
-lemma quot_quot_equiv_quot_sup_symm_quot_quot_mk (x : R) : (quot_quot_equiv_quot_sup I J).symm
-  (ideal.quotient.mk (I ⊔ J) x) = quot_quot_mk I J x :=
+lemma quot_quot_equiv_quot_sup_symm_quot_quot_mk (x : R) :
+  (quot_quot_equiv_quot_sup I J).symm (ideal.quotient.mk (I ⊔ J) x) = quot_quot_mk I J x :=
 by rw [quot_quot_equiv_quot_sup, ring_equiv.of_hom_inv_symm_apply,
   lift_sup_quot_quot_mk,ideal.quotient.lift_mk]
 

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1754,7 +1754,7 @@ def quot_sup_to_quot_sup_comm : (I ⊔ J).quotient ≃+* (J ⊔ I).quotient := q
 
 /-- The obvious isomorphism `(R/I)/J' → (R/J)/I' `   -/
 def quot_quot_equiv_comm : (J.map I^.quotient.mk).quotient ≃+* (I.map J^.quotient.mk).quotient :=
-  ring_equiv.trans (ring_equiv.trans (quot_quot_equiv_quot_sup I J) (quot_sup_to_quot_sup_comm I J))
+(quot_quot_equiv_quot_sup I J).trans $ (quot_sup_to_quot_sup_comm I J).trans $
   (quot_quot_equiv_quot_sup J I).symm
 
 end double_quot

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1750,8 +1750,8 @@ ring_equiv.of_hom_inv (quot_quot_to_quot_sup I J) (lift_sup_quot_quot_mk I J)
   (by { ext z, refl }) (by { ext z, refl })
 
 @[simp]
-lemma quot_quot_equiv_quot_sup_quot_quot_mk (x : R) : (quot_quot_equiv_quot_sup I J)
-  (quot_quot_mk I J x) = ideal.quotient.mk (I ⊔ J) x :=
+lemma quot_quot_equiv_quot_sup_quot_quot_mk (x : R) :
+  quot_quot_equiv_quot_sup I J (quot_quot_mk I J x) = ideal.quotient.mk (I ⊔ J) x :=
 by rw [quot_quot_equiv_quot_sup, quot_quot_mk, ring_equiv.of_hom_inv_apply, quot_quot_to_quot_sup,
     ring_hom.comp_apply, ideal.quotient.lift_mk, quot_left_to_quot_sup, ideal.quotient.factor_mk]
 

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1761,8 +1761,8 @@ rfl
 
 /-- The obvious isomorphism `(R/I)/J' → (R/J)/I' `   -/
 def quot_quot_equiv_comm : (J.map I^.quotient.mk).quotient ≃+* (I.map J^.quotient.mk).quotient :=
-  ((quot_quot_equiv_quot_sup I J).trans (quot_equiv_of_eq sup_comm)).trans
-    (quot_quot_equiv_quot_sup J I).symm
+((quot_quot_equiv_quot_sup I J).trans (quot_equiv_of_eq sup_comm)).trans
+  (quot_quot_equiv_quot_sup J I).symm
 
 @[simp]
 lemma quot_quot_equiv_comm_quot_quot_mk (x : R) :

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1752,8 +1752,7 @@ ring_equiv.of_hom_inv (quot_quot_to_quot_sup I J) (lift_sup_quot_quot_mk I J)
 @[simp]
 lemma quot_quot_equiv_quot_sup_quot_quot_mk (x : R) :
   quot_quot_equiv_quot_sup I J (quot_quot_mk I J x) = ideal.quotient.mk (I ⊔ J) x :=
-by rw [quot_quot_equiv_quot_sup, quot_quot_mk, ring_equiv.of_hom_inv_apply, quot_quot_to_quot_sup,
-    ring_hom.comp_apply, ideal.quotient.lift_mk, quot_left_to_quot_sup, ideal.quotient.factor_mk]
+rfl
 
 @[simp]
 lemma quot_quot_equiv_quot_sup_symm_quot_quot_mk (x : R) :

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1765,11 +1765,18 @@ def quot_quot_equiv_comm : (J.map I^.quotient.mk).quotient ≃+* (I.map J^.quoti
     (quot_quot_equiv_quot_sup J I).symm
 
 @[simp]
+lemma quot_quot_equiv_comm_quot_quot_mk (x : R) :
+  quot_quot_equiv_comm I J (quot_quot_mk I J x) = quot_quot_mk J I x :=
+rfl
+
+@[simp]
 lemma quot_quot_equiv_comm_comp_quot_quot_mk :
   ring_hom.comp ↑(quot_quot_equiv_comm I J) (quot_quot_mk I J) = quot_quot_mk J I :=
 ring_hom.ext $ quot_quot_equiv_comm_quot_quot_mk I J
-by ext x ; simp only [ring_hom.comp_apply, quot_quot_equiv_comm, ring_equiv.trans_apply,
-  quot_quot_equiv_quot_sup_quot_quot_mk, quot_equiv_of_eq_mk,
-  quot_quot_equiv_quot_sup_symm_quot_quot_mk, ring_equiv.coe_to_ring_hom]
+
+@[simp]
+lemma quot_quot_equiv_comm_symm :
+  (quot_quot_equiv_comm I J).symm = quot_quot_equiv_comm J I :=
+rfl
 
 end double_quot

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1749,12 +1749,28 @@ def quot_quot_equiv_quot_sup : (J.map (ideal.quotient.mk I)).quotient ≃+* (I �
 ring_equiv.of_hom_inv (quot_quot_to_quot_sup I J) (lift_sup_quot_quot_mk I J)
   (by { ext z, refl }) (by { ext z, refl })
 
-/-- The obvious isomorphism `R/(I ⊔ J) → R/(J ⊔ I)`  -/
-def quot_sup_to_quot_sup_comm : (I ⊔ J).quotient ≃+* (J ⊔ I).quotient := quot_equiv_of_eq sup_comm
+@[simp]
+lemma quot_quot_equiv_quot_sup_quot_quot_mk (x : R) : (quot_quot_equiv_quot_sup I J)
+  (quot_quot_mk I J x) = ideal.quotient.mk (I ⊔ J) x :=
+by rw [quot_quot_equiv_quot_sup, quot_quot_mk, ring_equiv.of_hom_inv_apply, quot_quot_to_quot_sup,
+    ring_hom.comp_apply, ideal.quotient.lift_mk, quot_left_to_quot_sup, ideal.quotient.factor_mk]
+
+@[simp]
+lemma quot_quot_equiv_quot_sup_symm_quot_quot_mk (x : R) : (quot_quot_equiv_quot_sup I J).symm
+  (ideal.quotient.mk (I ⊔ J) x) = quot_quot_mk I J x :=
+by rw [quot_quot_equiv_quot_sup, ring_equiv.of_hom_inv_symm_apply,
+  lift_sup_quot_quot_mk,ideal.quotient.lift_mk]
 
 /-- The obvious isomorphism `(R/I)/J' → (R/J)/I' `   -/
 def quot_quot_equiv_comm : (J.map I^.quotient.mk).quotient ≃+* (I.map J^.quotient.mk).quotient :=
-  ring_equiv.trans (ring_equiv.trans (quot_quot_equiv_quot_sup I J) (quot_sup_to_quot_sup_comm I J))
+  ring_equiv.trans (ring_equiv.trans (quot_quot_equiv_quot_sup I J) (quot_equiv_of_eq sup_comm))
   (quot_quot_equiv_quot_sup J I).symm
+
+@[simp]
+lemma quot_quot_equiv_comm_quot_quot_mk : ring_hom.comp ↑(quot_quot_equiv_comm I J)
+  (quot_quot_mk I J) = quot_quot_mk J I :=
+by ext x ; simp only [ring_hom.comp_apply, quot_quot_equiv_comm, ring_equiv.trans_apply,
+  quot_quot_equiv_quot_sup_quot_quot_mk, quot_equiv_of_eq_mk,
+  quot_quot_equiv_quot_sup_symm_quot_quot_mk, ring_equiv.coe_to_ring_hom]
 
 end double_quot

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1757,8 +1757,7 @@ rfl
 @[simp]
 lemma quot_quot_equiv_quot_sup_symm_quot_quot_mk (x : R) :
   (quot_quot_equiv_quot_sup I J).symm (ideal.quotient.mk (I ⊔ J) x) = quot_quot_mk I J x :=
-by rw [quot_quot_equiv_quot_sup, ring_equiv.of_hom_inv_symm_apply,
-  lift_sup_quot_quot_mk,ideal.quotient.lift_mk]
+rfl
 
 /-- The obvious isomorphism `(R/I)/J' → (R/J)/I' `   -/
 def quot_quot_equiv_comm : (J.map I^.quotient.mk).quotient ≃+* (I.map J^.quotient.mk).quotient :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1767,8 +1767,9 @@ def quot_quot_equiv_comm : (J.map I^.quotient.mk).quotient ≃+* (I.map J^.quoti
     (quot_quot_equiv_quot_sup J I).symm
 
 @[simp]
-lemma quot_quot_equiv_comm_quot_quot_mk : ring_hom.comp ↑(quot_quot_equiv_comm I J)
-  (quot_quot_mk I J) = quot_quot_mk J I :=
+lemma quot_quot_equiv_comm_comp_quot_quot_mk :
+  ring_hom.comp ↑(quot_quot_equiv_comm I J) (quot_quot_mk I J) = quot_quot_mk J I :=
+ring_hom.ext $ quot_quot_equiv_comm_quot_quot_mk I J
 by ext x ; simp only [ring_hom.comp_apply, quot_quot_equiv_comm, ring_equiv.trans_apply,
   quot_quot_equiv_quot_sup_quot_quot_mk, quot_equiv_of_eq_mk,
   quot_quot_equiv_quot_sup_symm_quot_quot_mk, ring_equiv.coe_to_ring_hom]


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
