### PR TITLE
[Merged by Bors] - feat(algebra/star/basic): add some helper lemmas about star

### DIFF
--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -82,6 +82,11 @@ class star_monoid (R : Type u) [monoid R] extends has_involutive_star R :=
 export star_monoid (star_mul)
 attribute [simp] star_mul
 
+/-- In a commutative ring, make `simp` prefer leaving the order unchanged. -/
+@[simp] lemma star_mul' [comm_monoid R] [star_monoid R] (x y : R) :
+  star (x * y) = star x * star y :=
+(star_mul x y).trans (mul_comm _ _)
+
 /-- `star` as an `mul_equiv` from `R` to `Rᵒᵖ` -/
 @[simps apply]
 def star_mul_equiv [monoid R] [star_monoid R] : R ≃* Rᵒᵖ :=
@@ -93,16 +98,25 @@ def star_mul_equiv [monoid R] [star_monoid R] : R ≃* Rᵒᵖ :=
 @[simps apply]
 def star_mul_aut [comm_monoid R] [star_monoid R] : mul_aut R :=
 { to_fun := star,
-  map_mul' := λ x y, (star_mul x y).trans (mul_comm _ _),
+  map_mul' := star_mul',
   ..(has_involutive_star.star_involutive.to_equiv star) }
 
 variables (R)
 
 @[simp] lemma star_one [monoid R] [star_monoid R] : star (1 : R) = 1 :=
-begin
-  have := congr_arg opposite.unop (star_mul_equiv : R ≃* Rᵒᵖ).map_one,
-  rwa [star_mul_equiv_apply, opposite.unop_op, opposite.unop_one] at this,
-end
+op_injective $ (star_mul_equiv : R ≃* Rᵒᵖ).map_one.trans (op_one _).symm
+
+@[simp] lemma star_pow [monoid R] [star_monoid R] (x : R) (n : ℕ) : star (x ^ n) = star x ^ n :=
+op_injective $
+  ((star_mul_equiv : R ≃* Rᵒᵖ).to_monoid_hom.map_pow x n).trans (op_pow (star x) n).symm
+
+@[simp] lemma star_inv [group R] [star_monoid R] (x : R) : star (x⁻¹) = (star x)⁻¹ :=
+op_injective $
+  ((star_mul_equiv : R ≃* Rᵒᵖ).to_monoid_hom.map_inv x).trans (op_inv _)
+
+@[simp] lemma star_inv' [group_with_zero R] [star_monoid R] (x : R) : star (x⁻¹) = (star x)⁻¹ :=
+op_injective $
+  ((star_mul_equiv : R ≃* Rᵒᵖ).to_monoid_hom.map_inv' x).trans (op_inv _)
 
 variables {R}
 

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -106,6 +106,8 @@ variables (R)
 @[simp] lemma star_one [monoid R] [star_monoid R] : star (1 : R) = 1 :=
 op_injective $ (star_mul_equiv : R ≃* Rᵒᵖ).map_one.trans (op_one _).symm
 
+variables {R}
+
 @[simp] lemma star_pow [monoid R] [star_monoid R] (x : R) (n : ℕ) : star (x ^ n) = star x ^ n :=
 op_injective $
   ((star_mul_equiv : R ≃* Rᵒᵖ).to_monoid_hom.map_pow x n).trans (op_pow (star x) n).symm
@@ -127,8 +129,6 @@ open_locale big_operators
 (star_mul_aut : R ≃* R).map_prod _ _
 
 end
-
-variables {R}
 
 instance [monoid R] [star_monoid R] : star_monoid (Rᵒᵖ) :=
 { star_mul := λ x y, unop_injective (star_mul y.unop x.unop) }
@@ -177,6 +177,8 @@ variables (R)
 @[simp] lemma star_zero [add_monoid R] [star_add_monoid R] : star (0 : R) = 0 :=
 (star_add_equiv : R ≃+ R).map_zero
 
+variables {R}
+
 @[simp] lemma star_neg [add_group R] [star_add_monoid R] (r : R) : star (-r) = - star r :=
 (star_add_equiv : R ≃+ R).map_neg _
 
@@ -201,8 +203,6 @@ open_locale big_operators
 (star_add_equiv : R ≃+ R).map_sum _ _
 
 end
-
-variables {R}
 
 /--
 A `*`-ring `R` is a (semi)ring with an involutive `star` operation which is additive

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -112,11 +112,17 @@ op_injective $
 
 @[simp] lemma star_inv [group R] [star_monoid R] (x : R) : star (x⁻¹) = (star x)⁻¹ :=
 op_injective $
-  ((star_mul_equiv : R ≃* Rᵒᵖ).to_monoid_hom.map_inv x).trans (op_inv _)
+  ((star_mul_equiv : R ≃* Rᵒᵖ).to_monoid_hom.map_inv x).trans (op_inv (star x)).symm
 
-@[simp] lemma star_inv' [group_with_zero R] [star_monoid R] (x : R) : star (x⁻¹) = (star x)⁻¹ :=
-op_injective $
-  ((star_mul_equiv : R ≃* Rᵒᵖ).to_monoid_hom.map_inv' x).trans (op_inv _)
+section
+open_locale big_operators
+
+@[simp] lemma star_prod [comm_monoid R] [star_monoid R] {α : Type*}
+  (s : finset α) (f : α → R):
+  star (∏ x in s, f x) = ∏ x in s, star (f x) :=
+(star_mul_aut : R ≃* R).map_prod _ _
+
+end
 
 variables {R}
 
@@ -167,6 +173,30 @@ variables (R)
 @[simp] lemma star_zero [add_monoid R] [star_add_monoid R] : star (0 : R) = 0 :=
 (star_add_equiv : R ≃+ R).map_zero
 
+@[simp] lemma star_neg [add_group R] [star_add_monoid R] (r : R) : star (-r) = - star r :=
+(star_add_equiv : R ≃+ R).map_neg _
+
+@[simp] lemma star_sub [add_group R] [star_add_monoid R] (r s : R) : star (r - s) = star r - star s :=
+(star_add_equiv : R ≃+ R).map_sub _ _
+
+@[simp] lemma star_nsmul [add_comm_monoid R] [star_add_monoid R] (x : R) (n : ℕ) :
+  star (n • x) = n • star x :=
+(star_add_equiv : R ≃+ R).to_add_monoid_hom.map_nsmul _ _
+
+@[simp] lemma star_gsmul [add_comm_group R] [star_add_monoid R] (x : R) (n : ℤ) :
+  star (n • x) = n • star x :=
+(star_add_equiv : R ≃+ R).to_add_monoid_hom.map_gsmul _ _
+
+section
+open_locale big_operators
+
+@[simp] lemma star_sum [add_comm_monoid R] [star_add_monoid R] {α : Type*}
+  (s : finset α) (f : α → R):
+  star (∑ x in s, f x) = ∑ x in s, star (f x) :=
+(star_add_equiv : R ≃+ R).map_sum _ _
+
+end
+
 variables {R}
 
 /--
@@ -198,21 +228,13 @@ def star_ring_aut [comm_semiring R] [star_ring R] : ring_aut R :=
   ..star_add_equiv,
   ..star_mul_aut }
 
-section
-open_locale big_operators
+@[simp] lemma star_inv' [division_ring R] [star_ring R] (x : R) : star (x⁻¹) = (star x)⁻¹ :=
+op_injective $
+  ((star_ring_equiv : R ≃+* Rᵒᵖ).to_ring_hom.map_inv x).trans (op_inv (star x)).symm
 
-@[simp] lemma star_sum [semiring R] [star_ring R] {α : Type*}
-  (s : finset α) (f : α → R):
-  star (∑ x in s, f x) = ∑ x in s, star (f x) :=
-(star_add_equiv : R ≃+ R).map_sum _ _
-
-end
-
-@[simp] lemma star_neg [ring R] [star_ring R] (r : R) : star (-r) = - star r :=
-(star_add_equiv : R ≃+ R).map_neg _
-
-@[simp] lemma star_sub [ring R] [star_ring R] (r s : R) : star (r - s) = star r - star s :=
-(star_add_equiv : R ≃+ R).map_sub _ _
+/-- When multiplication is commutative, `star` preserves division. -/
+@[simp] lemma star_div' [field R] [star_ring R] (x y : R) : star (x / y) = star x / star y :=
+(star_ring_aut : R ≃+* R).to_ring_hom.map_div _ _
 
 @[simp] lemma star_bit0 [ring R] [star_ring R] (r : R) : star (bit0 r) = bit0 (star r) :=
 by simp [bit0]

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -114,6 +114,10 @@ op_injective $
 op_injective $
   ((star_mul_equiv : R ≃* Rᵒᵖ).to_monoid_hom.map_inv x).trans (op_inv (star x)).symm
 
+/-- When multiplication is commutative, `star` preserves division. -/
+@[simp] lemma star_div [comm_group R] [star_monoid R] (x y : R) : star (x / y) = star x / star y :=
+(star_mul_aut : R ≃* R).to_monoid_hom.map_div _ _
+
 section
 open_locale big_operators
 

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -176,7 +176,8 @@ variables (R)
 @[simp] lemma star_neg [add_group R] [star_add_monoid R] (r : R) : star (-r) = - star r :=
 (star_add_equiv : R ≃+ R).map_neg _
 
-@[simp] lemma star_sub [add_group R] [star_add_monoid R] (r s : R) : star (r - s) = star r - star s :=
+@[simp] lemma star_sub [add_group R] [star_add_monoid R] (r s : R) :
+  star (r - s) = star r - star s :=
 (star_add_equiv : R ≃+ R).map_sub _ _
 
 @[simp] lemma star_nsmul [add_comm_monoid R] [star_add_monoid R] (x : R) (n : ℕ) :


### PR DESCRIPTION
This adds the new lemmas:
* `star_pow`
* `star_nsmul`
* `star_gsmul`
* `star_prod`
* `star_div`
* `star_div'`
* `star_inv`
* `star_inv'`
* `star_mul'`

and generalizes the typeclass assumptions from `star_ring` to `star_add_monoid` on:
* `star_neg`
* `star_sub`
* `star_sum`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

`star_fpow` and `star_gpow` are in a follow-up PR #9661, as they depend on #9659 too