### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space/finite_dimensional): upgrade `affine_independent.affine_span_eq_top_of_card_eq_finrank_add_one` to an iff

### DIFF
--- a/src/algebra/add_torsor.lean
+++ b/src/algebra/add_torsor.lean
@@ -427,3 +427,10 @@ lemma injective_point_reflection_left_of_injective_bit0 {G P : Type*} [add_comm_
     h.eq_iff, vsub_eq_zero_iff_eq] at hy
 
 end equiv
+
+lemma add_torsor.subsingleton_iff (G P : Type*) [add_group G] [add_torsor G P] :
+  subsingleton G ↔ subsingleton P :=
+begin
+  inhabit P,
+  exact (equiv.vadd_const (default P)).subsingleton_congr,
+end

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -678,12 +678,51 @@ begin
   exact set.empty_ne_univ contra,
 end
 
+protected lemma nontrivial : nontrivial (affine_subspace k P) := ⟨⟨⊥, ⊤, bot_ne_top k V P⟩⟩
+
 lemma nonempty_of_affine_span_eq_top {s : set P} (h : affine_span k s = ⊤) : s.nonempty :=
 begin
   rw ← set.ne_empty_iff_nonempty,
   rintros rfl,
   rw affine_subspace.span_empty at h,
   exact bot_ne_top k V P h,
+end
+
+/-- If the affine span of a set is `⊤`, then the vector span of the same set is the `⊤`. -/
+lemma vector_span_eq_top_of_affine_span_eq_top {s : set P} (h : affine_span k s = ⊤) :
+  vector_span k s = ⊤ :=
+by rw [← direction_affine_span, h, direction_top]
+
+/-- For a nonempty set, the affine span is `⊤` iff its vector span is `⊤`. -/
+lemma affine_span_eq_top_iff_vector_span_eq_top_of_nonempty {s : set P} (hs : s.nonempty) :
+  affine_span k s = ⊤ ↔ vector_span k s = ⊤ :=
+begin
+  refine ⟨vector_span_eq_top_of_affine_span_eq_top k V P, _⟩,
+  intros h,
+  suffices : nonempty (affine_span k s),
+  { obtain ⟨p, hp : p ∈ affine_span k s⟩ := this,
+    rw [eq_iff_direction_eq_of_mem hp (mem_top k V p), direction_affine_span, h, direction_top] },
+  obtain ⟨x, hx⟩ := hs,
+  exact ⟨⟨x, mem_affine_span k hx⟩⟩,
+end
+
+/-- For a non-trivial space, the affine span of a set is `⊤` iff its vector span is `⊤`. -/
+lemma affine_span_eq_top_iff_vector_span_eq_top_of_nontrivial {s : set P} [nontrivial P] :
+  affine_span k s = ⊤ ↔ vector_span k s = ⊤ :=
+begin
+  cases s.eq_empty_or_nonempty with hs hs,
+  { simpa [hs, subsingleton_iff_bot_eq_top, add_torsor.subsingleton_iff V P,
+      affine_subspace.nontrivial k V P, ← @not_nontrivial_iff_subsingleton (affine_subspace k P),
+      ← @not_nontrivial_iff_subsingleton P], },
+  { rw affine_span_eq_top_iff_vector_span_eq_top_of_nonempty k V P hs, },
+end
+
+lemma card_pos_of_affine_span_eq_top {ι : Type*} [fintype ι] {p : ι → P}
+  (h : affine_span k (range p) = ⊤) :
+  0 < fintype.card ι :=
+begin
+  obtain ⟨-, ⟨i, -⟩⟩ := nonempty_of_affine_span_eq_top k V P h,
+  exact fintype.card_pos_iff.mpr ⟨i⟩,
 end
 
 variables {P}

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -678,7 +678,7 @@ begin
   exact set.empty_ne_univ contra,
 end
 
-protected lemma nontrivial : nontrivial (affine_subspace k P) := ⟨⟨⊥, ⊤, bot_ne_top k V P⟩⟩
+instance : nontrivial (affine_subspace k P) := ⟨⟨⊥, ⊤, bot_ne_top k V P⟩⟩
 
 lemma nonempty_of_affine_span_eq_top {s : set P} (h : affine_span k s = ⊤) : s.nonempty :=
 begin
@@ -711,9 +711,7 @@ lemma affine_span_eq_top_iff_vector_span_eq_top_of_nontrivial {s : set P} [nontr
   affine_span k s = ⊤ ↔ vector_span k s = ⊤ :=
 begin
   cases s.eq_empty_or_nonempty with hs hs,
-  { simpa [hs, subsingleton_iff_bot_eq_top, add_torsor.subsingleton_iff V P,
-      affine_subspace.nontrivial k V P, ← @not_nontrivial_iff_subsingleton (affine_subspace k P),
-      ← @not_nontrivial_iff_subsingleton P], },
+  { simp [hs, subsingleton_iff_bot_eq_top, add_torsor.subsingleton_iff V P, not_subsingleton], },
   { rw affine_span_eq_top_iff_vector_span_eq_top_of_nonempty k V P hs, },
 end
 

--- a/src/linear_algebra/affine_space/finite_dimensional.lean
+++ b/src/linear_algebra/affine_space/finite_dimensional.lean
@@ -157,15 +157,22 @@ lemma affine_independent.vector_span_eq_top_of_card_eq_finrank_add_one [finite_d
   vector_span k (set.range p) = ⊤ :=
 eq_top_of_finrank_eq $ hi.finrank_vector_span hc
 
-/-- The `affine_span` of a finite affinely independent family whose
-cardinality is one more than that of the finite-dimensional space is
-`⊤`. -/
-lemma affine_independent.affine_span_eq_top_of_card_eq_finrank_add_one [finite_dimensional k V]
-  [fintype ι] {p : ι → P} (hi : affine_independent k p) (hc : fintype.card ι = finrank k V + 1) :
-  affine_span k (set.range p) = ⊤ :=
+/-- The `affine_span` of a finite affinely independent family is `⊤` iff the
+family's cardinality is one more than that of the finite-dimensional space. -/
+lemma affine_independent.affine_span_eq_top_iff_card_eq_finrank_add_one [finite_dimensional k V]
+  [fintype ι] {p : ι → P} (hi : affine_independent k p) :
+  affine_span k (set.range p) = ⊤ ↔ fintype.card ι = finrank k V + 1 :=
 begin
-  rw [←finrank_top, ←direction_top k V P] at hc,
-  exact hi.affine_span_eq_of_le_of_card_eq_finrank_add_one le_top hc
+  split,
+  { intros h_tot,
+    let n := fintype.card ι - 1,
+    have hn : fintype.card ι = n + 1,
+    { exact (nat.succ_pred_eq_of_pos (card_pos_of_affine_span_eq_top k V P h_tot)).symm, },
+    rw [hn, ← finrank_top, ← (vector_span_eq_top_of_affine_span_eq_top k V P) h_tot,
+      ← hi.finrank_vector_span hn], },
+  { intros hc,
+    rw [← finrank_top, ← direction_top k V P] at hc,
+    exact hi.affine_span_eq_of_le_of_card_eq_finrank_add_one le_top hc, },
 end
 
 variables (k)


### PR DESCRIPTION
Also including some related, but strictly speaking independent, lemmas such as `affine_subspace.affine_span_eq_top_iff_vector_span_eq_top_of_nontrivial`.

Formalized as part of the Sphere Eversion project.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
