### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/normed_group_hom): add norm_noninc.neg

### DIFF
--- a/src/analysis/normed_space/normed_group_hom.lean
+++ b/src/analysis/normed_space/normed_group_hom.lean
@@ -548,6 +548,9 @@ lemma comp {g : normed_group_hom V₂ V₃} {f : normed_group_hom V₁ V₂}
   (g.comp f).norm_noninc :=
 λ v, (hg (f v)).trans (hf v)
 
+lemma neg {f : normed_group_hom V₁ V₂} (hf : f.norm_noninc) : (-f).norm_noninc :=
+λ x, (norm_neg (f x)).le.trans (hf x)
+
 end norm_noninc
 
 section isometry

--- a/src/analysis/normed_space/normed_group_hom.lean
+++ b/src/analysis/normed_space/normed_group_hom.lean
@@ -548,8 +548,8 @@ lemma comp {g : normed_group_hom V₂ V₃} {f : normed_group_hom V₁ V₂}
   (g.comp f).norm_noninc :=
 λ v, (hg (f v)).trans (hf v)
 
-lemma neg {f : normed_group_hom V₁ V₂} (hf : f.norm_noninc) : (-f).norm_noninc :=
-λ x, (norm_neg (f x)).le.trans (hf x)
+@[simp] lemma neg_iff {f : normed_group_hom V₁ V₂} : (-f).norm_noninc ↔ f.norm_noninc :=
+⟨λ h x, by { simpa using h x }, λ h x, (norm_neg (f x)).le.trans (h x)⟩
 
 end norm_noninc
 


### PR DESCRIPTION
From LTE.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
