### PR TITLE
[Merged by Bors] - feat(group_theory/sylow): Frattini's Argument

### DIFF
--- a/src/group_theory/group_action/conj_act.lean
+++ b/src/group_theory/group_action/conj_act.lean
@@ -141,7 +141,7 @@ by { change _ * (_)⁻¹⁻¹ = _, rw inv_inv, refl }
 mul_aut.conj_normal_symm_apply g h
 
 lemma _root_.mul_aut.conj_normal_coe {H : subgroup G} [H.normal] {h : H} :
-  mul_aut.conj_normal ↑g = mul_aut.conj g :=
+  mul_aut.conj_normal ↑h = mul_aut.conj h :=
 mul_equiv.ext (λ x, rfl)
 
 end conj_act

--- a/src/group_theory/group_action/conj_act.lean
+++ b/src/group_theory/group_action/conj_act.lean
@@ -140,4 +140,8 @@ by { change _ * (_)⁻¹⁻¹ = _, rw inv_inv, refl }
   ↑((mul_aut.conj_normal g)⁻¹ h) = g⁻¹ * h * g :=
 mul_aut.conj_normal_symm_apply g h
 
+lemma _root_.mul_aut.conj_normal_coe {H : subgroup G} [H.normal] {h : H} :
+  mul_aut.conj_normal ↑g = mul_aut.conj g :=
+mul_equiv.ext (λ x, rfl)
+
 end conj_act

--- a/src/group_theory/subgroup/pointwise.lean
+++ b/src/group_theory/subgroup/pointwise.lean
@@ -42,6 +42,9 @@ protected def pointwise_mul_action : mul_action α (subgroup G) :=
 localized "attribute [instance] subgroup.pointwise_mul_action" in pointwise
 open_locale pointwise
 
+lemma pointwise_smul_def {a : α} (S : subgroup G) :
+  a • S = S.map (mul_distrib_mul_action.to_monoid_End _ _ a) := rfl
+
 @[simp] lemma coe_pointwise_smul (a : α) (S : subgroup G) : ↑(a • S) = a • (S : set G) := rfl
 
 @[simp] lemma pointwise_smul_to_submonoid (a : α) (S : subgroup G) :

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -98,11 +98,13 @@ instance sylow.pointwise_mul_action {α : Type*} [group α] [mul_distrib_mul_act
   one_smul := λ P, sylow.ext (one_smul α P),
   mul_smul := λ g h P, sylow.ext (mul_smul g h P) }
 
-lemma sylow.smul_def {α : Type*} [group α] [mul_distrib_mul_action α G]
+lemma sylow.pointwise_smul_def {α : Type*} [group α] [mul_distrib_mul_action α G]
   {g : α} {P : sylow p G} : ↑(g • P) = g • (P : subgroup G) := rfl
 
 instance sylow.mul_action : mul_action G (sylow p G) :=
 comp_hom _ mul_aut.conj
+
+lemma sylow.smul_def {g : G} {P : sylow p G} : g • P = mul_aut.conj g • P := rfl
 
 lemma sylow.coe_subgroup_smul {g : G} {P : sylow p G} :
   ↑(g • P) = mul_aut.conj g • (P : subgroup G) := rfl
@@ -202,28 +204,20 @@ lemma card_sylow_dvd_index [fact p.prime] [fintype (sylow p G)] (P : sylow p G) 
   card (sylow p G) ∣ P.1.index :=
 ((congr_arg _ (card_sylow_eq_index_normalizer P)).mp dvd_rfl).trans (index_dvd_of_le le_normalizer)
 
-lemma conj_normal_coe {G : Type*} [group G] {N : subgroup G} [N.normal] {g : N} :
-  mul_aut.conj_normal ↑g = mul_aut.conj g :=
-mul_equiv.ext (λ x, rfl)
-
 /-- Frattini's Argument -/
 lemma sylow.normalizer_sup_eq_top {p : ℕ} [fact p.prime] {N : subgroup G} [N.normal]
-  [fintype (sylow p N)] (P : sylow p N) : (P.1.map N.subtype).normalizer ⊔ N = ⊤ :=
+  [fintype (sylow p N)] (P : sylow p N) : ((↑P : subgroup N).map N.subtype).normalizer ⊔ N = ⊤ :=
 begin
   refine top_le_iff.mp (λ g hg, _),
   obtain ⟨n, hn⟩ := exists_smul_eq N ((mul_aut.conj_normal g : mul_aut N) • P) P,
-  suffices : ↑n * g ∈ (P.1.map N.subtype).normalizer,
-  { rw ← inv_mul_cancel_left ↑n g,
-    exact mul_mem _ (inv_mem _ (mem_sup_right n.2)) (mem_sup_left this) },
-  rw [sylow.smul_def, ←mul_smul, ←conj_normal_coe, ←mul_aut.conj_normal.map_mul] at hn,
-  intro x,
-  suffices : (mul_aut.conj_normal (↑n * g) • P).1.map N.subtype =
-    (P.1.map N.subtype).map (mul_aut.conj (↑n * g)).to_monoid_hom,
-  { conv_rhs { rw ← hn },
-    rw this,
-    refine (mem_map_iff_mem _).symm,
-    exact (mul_aut.conj (↑n * g)).injective, },
-  exact (P.1.map_map _ _).trans ((P.1.map_map _ _).trans (by refl)).symm,
+  rw ← inv_mul_cancel_left ↑n g,
+  refine mul_mem _ (inv_mem _ (mem_sup_right n.2)) (mem_sup_left _),
+  rw [sylow.smul_def, ←mul_smul, ←conj_normal_coe, ←mul_aut.conj_normal.map_mul,
+      sylow.ext_iff, sylow.pointwise_smul_def, pointwise_smul_def] at hn,
+  refine λ x, (mem_map_iff_mem (show function.injective (mul_aut.conj (↑n * g)).to_monoid_hom,
+    from (mul_aut.conj (↑n * g)).injective)).symm.trans _,
+  rw [map_map, ←(congr_arg (map N.subtype) hn), map_map],
+  refl,
 end
 
 end infinite_sylow

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -98,6 +98,9 @@ instance sylow.pointwise_mul_action {α : Type*} [group α] [mul_distrib_mul_act
   one_smul := λ P, sylow.ext (one_smul α P),
   mul_smul := λ g h P, sylow.ext (mul_smul g h P) }
 
+lemma sylow.smul_def {α : Type*} [group α] [mul_distrib_mul_action α G]
+  {g : α} {P : sylow p G} : ↑(g • P) = g • (P : subgroup G) := rfl
+
 instance sylow.mul_action : mul_action G (sylow p G) :=
 comp_hom _ mul_aut.conj
 
@@ -199,26 +202,28 @@ lemma card_sylow_dvd_index [fact p.prime] [fintype (sylow p G)] (P : sylow p G) 
   card (sylow p G) ∣ P.1.index :=
 ((congr_arg _ (card_sylow_eq_index_normalizer P)).mp dvd_rfl).trans (index_dvd_of_le le_normalizer)
 
+lemma conj_normal_coe {G : Type*} [group G] {N : subgroup G} [N.normal] {g : N} :
+  mul_aut.conj_normal ↑g = mul_aut.conj g :=
+mul_equiv.ext (λ x, rfl)
+
 /-- Frattini's Argument -/
 lemma sylow.normalizer_sup_eq_top {p : ℕ} [fact p.prime] {N : subgroup G} [N.normal]
   [fintype (sylow p N)] (P : sylow p N) : (P.1.map N.subtype).normalizer ⊔ N = ⊤ :=
 begin
-  let ψ : G →* mul_aut N := mul_aut.conj_normal,
-  letI : mul_action G (sylow p N) := comp_hom (sylow p N) ψ,
   refine top_le_iff.mp (λ g hg, _),
-  obtain ⟨n, hn⟩ := exists_smul_eq N (g • P) P,
-  replace hn := (mul_smul _ _ P).trans hn,
-  rw [show mul_aut.conj n = ψ n, by ext; refl, ←ψ.map_mul] at hn,
+  obtain ⟨n, hn⟩ := exists_smul_eq N ((mul_aut.conj_normal g : mul_aut N) • P) P,
   suffices : ↑n * g ∈ (P.1.map N.subtype).normalizer,
   { rw ← inv_mul_cancel_left ↑n g,
     exact mul_mem _ (inv_mem _ (mem_sup_right n.2)) (mem_sup_left this) },
-  refine λ x, iff.trans _ (set_like.ext_iff.mp (congr_arg _ (sylow.ext_iff.mp hn)) _),
-  change _ ↔ _ ∈ (P.1.map _).map _,
-  rw map_map,
-  change _ ↔ _ ∈ P.1.map ((mul_aut.conj (↑n * g)).to_monoid_hom.comp N.subtype),
-  rw ←map_map,
-  refine (mem_map_iff_mem _).symm,
-  exact (mul_aut.conj (↑n * g)).injective,
+  rw [sylow.smul_def, ←mul_smul, ←conj_normal_coe, ←mul_aut.conj_normal.map_mul] at hn,
+  intro x,
+  suffices : (mul_aut.conj_normal (↑n * g) • P).1.map N.subtype =
+    (P.1.map N.subtype).map (mul_aut.conj (↑n * g)).to_monoid_hom,
+  { conv_rhs { rw ← hn },
+    rw this,
+    refine (mem_map_iff_mem _).symm,
+    exact (mul_aut.conj (↑n * g)).injective, },
+  exact (P.1.map_map _ _).trans ((P.1.map_map _ _).trans (by refl)).symm,
 end
 
 end infinite_sylow

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Thomas Browning
 -/
 
+import group_theory.group_action.conj_act
 import group_theory.p_group
 
 /-!
@@ -197,6 +198,28 @@ lemma card_sylow_eq_index_normalizer [fact p.prime] [fintype (sylow p G)] (P : s
 lemma card_sylow_dvd_index [fact p.prime] [fintype (sylow p G)] (P : sylow p G) :
   card (sylow p G) ∣ P.1.index :=
 ((congr_arg _ (card_sylow_eq_index_normalizer P)).mp dvd_rfl).trans (index_dvd_of_le le_normalizer)
+
+/-- Frattini's Argument -/
+lemma sylow.normalizer_sup_eq_top {p : ℕ} [fact p.prime] {N : subgroup G} [N.normal]
+  [fintype (sylow p N)] (P : sylow p N) : (P.1.map N.subtype).normalizer ⊔ N = ⊤ :=
+begin
+  let ψ : G →* mul_aut N := mul_aut.conj_normal,
+  letI : mul_action G (sylow p N) := comp_hom (sylow p N) ψ,
+  refine top_le_iff.mp (λ g hg, _),
+  obtain ⟨n, hn⟩ := exists_smul_eq N (g • P) P,
+  replace hn := (mul_smul _ _ P).trans hn,
+  rw [show mul_aut.conj n = ψ n, by ext; refl, ←ψ.map_mul] at hn,
+  suffices : ↑n * g ∈ (P.1.map N.subtype).normalizer,
+  { rw ← inv_mul_cancel_left ↑n g,
+    exact mul_mem _ (inv_mem _ (mem_sup_right n.2)) (mem_sup_left this) },
+  refine λ x, iff.trans _ (set_like.ext_iff.mp (congr_arg _ (sylow.ext_iff.mp hn)) _),
+  change _ ↔ _ ∈ (P.1.map _).map _,
+  rw map_map,
+  change _ ↔ _ ∈ P.1.map ((mul_aut.conj (↑n * g)).to_monoid_hom.comp N.subtype),
+  rw ←map_map,
+  refine (mem_map_iff_mem _).symm,
+  exact (mul_aut.conj (↑n * g)).injective,
+end
 
 end infinite_sylow
 

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -212,7 +212,7 @@ begin
   obtain ⟨n, hn⟩ := exists_smul_eq N ((mul_aut.conj_normal g : mul_aut N) • P) P,
   rw ← inv_mul_cancel_left ↑n g,
   refine mul_mem _ (inv_mem _ (mem_sup_right n.2)) (mem_sup_left _),
-  rw [sylow.smul_def, ←mul_smul, ←conj_normal_coe, ←mul_aut.conj_normal.map_mul,
+  rw [sylow.smul_def, ←mul_smul, ←mul_aut.conj_normal_coe, ←mul_aut.conj_normal.map_mul,
       sylow.ext_iff, sylow.pointwise_smul_def, pointwise_smul_def] at hn,
   refine λ x, (mem_map_iff_mem (show function.injective (mul_aut.conj (↑n * g)).to_monoid_hom,
     from (mul_aut.conj (↑n * g)).injective)).symm.trans _,


### PR DESCRIPTION
Frattini's argument: If `N` is a normal subgroup of `G`, and `P` is a Sylow `p`-subgroup of `N`, then `PN=G`.

The proof is an application of Sylow's second theorem (all Sylow `p`-subgroups of `N` are conjugate).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
