### PR TITLE
[Merged by Bors] - feat(data/dfinsupp, algebra/direct_sum/module): direct sum on fintype

### DIFF
--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -122,6 +122,41 @@ to_module R _ _ $ λ i, lof R T (λ (i : subtype T), M i) ⟨i, H i.prop⟩
 
 omit dec_ι
 
+variables (ι M)
+/-- Given `fintype α`, `linear_equiv_fun_on_fintype R` is the natural `R`-linear equivalence between
+`⨁ i, M i` and `Π i, M i`. -/
+@[simps apply] noncomputable def linear_equiv_fun_on_fintype
+  [fintype ι] [decidable_eq ι] [Π i, decidable_eq (M i)]:
+  (⨁ i, M i) ≃ₗ[R] (Π i, M i) :=
+{ to_fun := coe_fn,
+  map_add' := λ f g, by { ext, simp only [add_apply, pi.add_apply] },
+  map_smul' := λ c f, by { ext, simp only [dfinsupp.coe_smul, ring_hom.id_apply] },
+  .. dfinsupp.equiv_fun_on_fintype }
+
+variables {ι M}
+@[simp] lemma linear_equiv_fun_on_fintype_lof
+  [fintype ι] [decidable_eq ι] [Π i, decidable_eq (M i)] (i : ι) (m : M i) :
+  (linear_equiv_fun_on_fintype R ι M) (lof R ι M i m) = pi.single i m :=
+begin
+  ext a,
+  change (dfinsupp.equiv_fun_on_fintype (lof R ι M i m)) a = _,
+  convert _root_.congr_fun (equiv_fun_on_fintype_single x m) a,
+end
+
+@[simp] lemma linear_equiv_fun_on_fintype_symm_lof
+  [fintype ι] [decidable_eq ι] [Π i, decidable_eq (M i)] (i : ι) (m : M i) :
+  (linear_equiv_fun_on_fintype R ι M).symm (pi.single i m) = lof R ι M i m :=
+begin
+  ext a,
+  change (dfinsupp.equiv_fun_on_fintype.symm (pi.single i m)) a = _,
+  convert congr_fun (equiv_fun_on_fintype_symm_single x m) a,
+end
+
+@[simp] lemma linear_equiv_fun_on_fintype_symm_coe
+  [fintype ι] [decidable_eq ι] [Π i, decidable_eq (M i)] (f : ⨁ i, M i) :
+  (linear_equiv_fun_on_fintype R ι M).symm f = f :=
+by { ext, simp [linear_equiv_fun_on_fintype], }
+
 /-- The natural linear equivalence between `⨁ _ : ι, M` and `M` when `unique ι`. -/
 protected def lid (M : Type v) (ι : Type* := punit) [add_comm_monoid M] [module R M]
   [unique ι] :

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -125,8 +125,7 @@ omit dec_ι
 variables (ι M)
 /-- Given `fintype α`, `linear_equiv_fun_on_fintype R` is the natural `R`-linear equivalence
 between `⨁ i, M i` and `Π i, M i`. -/
-@[simps apply] def linear_equiv_fun_on_fintype
-  [fintype ι] [decidable_eq ι] [Π i, decidable_eq (M i)]:
+@[simps apply] def linear_equiv_fun_on_fintype [fintype ι] :
   (⨁ i, M i) ≃ₗ[R] (Π i, M i) :=
 { to_fun := coe_fn,
   map_add' := λ f g, by { ext, simp only [add_apply, pi.add_apply] },
@@ -134,8 +133,7 @@ between `⨁ i, M i` and `Π i, M i`. -/
   .. dfinsupp.equiv_fun_on_fintype }
 
 variables {ι M}
-@[simp] lemma linear_equiv_fun_on_fintype_lof
-  [fintype ι] [decidable_eq ι] [Π i, decidable_eq (M i)] (i : ι) (m : M i) :
+@[simp] lemma linear_equiv_fun_on_fintype_lof [fintype ι] [decidable_eq ι] (i : ι) (m : M i) :
   (linear_equiv_fun_on_fintype R ι M) (lof R ι M i m) = pi.single i m :=
 begin
   ext a,
@@ -143,8 +141,8 @@ begin
   convert _root_.congr_fun (dfinsupp.equiv_fun_on_fintype_single i m) a,
 end
 
-@[simp] lemma linear_equiv_fun_on_fintype_symm_single
-  [fintype ι] [decidable_eq ι] [Π i, decidable_eq (M i)] (i : ι) (m : M i) :
+@[simp] lemma linear_equiv_fun_on_fintype_symm_single [fintype ι] [decidable_eq ι]
+  (i : ι) (m : M i) :
   (linear_equiv_fun_on_fintype R ι M).symm (pi.single i m) = lof R ι M i m :=
 begin
   ext a,
@@ -153,8 +151,7 @@ begin
   refl
 end
 
-@[simp] lemma linear_equiv_fun_on_fintype_symm_coe
-  [fintype ι] [decidable_eq ι] [Π i, decidable_eq (M i)] (f : ⨁ i, M i) :
+@[simp] lemma linear_equiv_fun_on_fintype_symm_coe [fintype ι] (f : ⨁ i, M i) :
   (linear_equiv_fun_on_fintype R ι M).symm f = f :=
 by { ext, simp [linear_equiv_fun_on_fintype], }
 

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -143,7 +143,7 @@ begin
   convert _root_.congr_fun (dfinsupp.equiv_fun_on_fintype_single i m) a,
 end
 
-@[simp] lemma linear_equiv_fun_on_fintype_symm_lof
+@[simp] lemma linear_equiv_fun_on_fintype_symm_single
   [fintype ι] [decidable_eq ι] [Π i, decidable_eq (M i)] (i : ι) (m : M i) :
   (linear_equiv_fun_on_fintype R ι M).symm (pi.single i m) = lof R ι M i m :=
 begin

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -123,9 +123,9 @@ to_module R _ _ $ λ i, lof R T (λ (i : subtype T), M i) ⟨i, H i.prop⟩
 omit dec_ι
 
 variables (ι M)
-/-- Given `fintype α`, `linear_equiv_fun_on_fintype R` is the natural `R`-linear equivalence between
-`⨁ i, M i` and `Π i, M i`. -/
-@[simps apply] noncomputable def linear_equiv_fun_on_fintype
+/-- Given `fintype α`, `linear_equiv_fun_on_fintype R` is the natural `R`-linear equivalence
+between `⨁ i, M i` and `Π i, M i`. -/
+@[simps apply] def linear_equiv_fun_on_fintype
   [fintype ι] [decidable_eq ι] [Π i, decidable_eq (M i)]:
   (⨁ i, M i) ≃ₗ[R] (Π i, M i) :=
 { to_fun := coe_fn,
@@ -140,7 +140,7 @@ variables {ι M}
 begin
   ext a,
   change (dfinsupp.equiv_fun_on_fintype (lof R ι M i m)) a = _,
-  convert _root_.congr_fun (equiv_fun_on_fintype_single x m) a,
+  convert _root_.congr_fun (dfinsupp.equiv_fun_on_fintype_single i m) a,
 end
 
 @[simp] lemma linear_equiv_fun_on_fintype_symm_lof
@@ -149,7 +149,8 @@ end
 begin
   ext a,
   change (dfinsupp.equiv_fun_on_fintype.symm (pi.single i m)) a = _,
-  convert congr_fun (equiv_fun_on_fintype_symm_single x m) a,
+  rw (dfinsupp.equiv_fun_on_fintype_symm_single i m),
+  refl
 end
 
 @[simp] lemma linear_equiv_fun_on_fintype_symm_coe

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -445,6 +445,42 @@ begin
   simpa only [dif_pos hi] using h1
 end
 
+/-- Given `fintype ι`, `equiv_fun_on_fintype` is the `equiv` between `Π₀ i, β i` and `Π i, β i`.
+  (All dependent functions on a finite type are finitely supported.) -/
+@[simps] def equiv_fun_on_fintype [fintype ι] [Π i, decidable_eq (β i)] :
+  (Π₀ i, β i) ≃ (Π i, β i) :=
+⟨λf a, f a, λf, mk (finset.univ.filter $ λa, f a ≠ 0) (λ i, f i),
+  begin
+    intro f,
+    ext a,
+    simp only [mk_apply],
+    split_ifs,
+    { refl },
+    { symmetry,
+      simpa using h },
+  end,
+  begin
+    intro f,
+    ext a,
+    simp only [mk_apply],
+    split_ifs,
+    { refl },
+    symmetry,
+    simpa using h
+  end⟩
+
+
+@[simp] lemma equiv_fun_on_fintype_symm_coe [fintype ι] [Π i, decidable_eq (β i)] (f : Π₀ i, β i) :
+  equiv_fun_on_fintype.symm f = f :=
+begin
+  ext a,
+  simp only [mk_apply, equiv_fun_on_fintype,mk_apply, equiv.coe_fn_symm_mk],
+  split_ifs,
+  { refl },
+  { symmetry,
+    simpa using h },
+end
+
 /-- The function `single i b : Π₀ i, β i` sends `i` to `b`
 and all other points to `0`. -/
 def single (i : ι) (b : β i) : Π₀ i, β i :=

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -469,8 +469,8 @@ end
     simpa using h
   end⟩
 
-@[simp] lemma equiv_fun_on_fintype_symm_coe [fintype ι] [Π i, decidable_eq (β i)] (f : Π i, β i) :
-  ⇑(equiv_fun_on_fintype.symm f) = f :=
+@[simp] lemma equiv_fun_on_fintype_symm_coe [fintype ι] [Π i, decidable_eq (β i)] (f : Π₀ i, β i) :
+  equiv_fun_on_fintype.symm f = f :=
 begin
   ext a,
   simp only [mk_apply, equiv_fun_on_fintype,mk_apply, equiv.coe_fn_symm_mk],
@@ -581,7 +581,7 @@ by { ext, simp [dfinsupp.single_eq_pi_single, dfinsupp.equiv_fun_on_fintype], }
 @[simp] lemma equiv_fun_on_fintype_symm_single
   [fintype ι] [Π i, decidable_eq (β i)] (i : ι) (m : β i) :
   (@dfinsupp.equiv_fun_on_fintype ι β _ _ _ _).symm (pi.single i m) = dfinsupp.single i m :=
-by { ext i', rw [dfinsupp.equiv_fun_on_fintype_symm_coe, dfinsupp.single_eq_pi_single] }
+by { ext i', simp only [← single_eq_pi_single, equiv_fun_on_fintype_symm_coe] }
 
 /-- Redefine `f i` to be `0`. -/
 def erase (i : ι) : (Π₀ i, β i) → Π₀ i, β i :=

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -556,7 +556,7 @@ by { cases h, refl }
 @[simp] lemma equiv_fun_on_fintype_single
   [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] (i : ι) (m : β i) :
   (@dfinsupp.equiv_fun_on_fintype ι β _ _ _ _) (dfinsupp.single i m) = pi.single i m :=
-by { ext, simp [dfinsupp.single_eq_pi_single, dfinsupp.equiv_fun_on_fintype], }
+by { ext, simp [dfinsupp.single_eq_pi_single], }
 
 @[simp] lemma equiv_fun_on_fintype_symm_single
   [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] (i : ι) (m : β i) :

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -445,19 +445,19 @@ begin
   simpa only [dif_pos hi] using h1
 end
 
+omit dec
 /-- Given `fintype ι`, `equiv_fun_on_fintype` is the `equiv` between `Π₀ i, β i` and `Π i, β i`.
   (All dependent functions on a finite type are finitely supported.) -/
-@[simps apply] def equiv_fun_on_fintype [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] :
-  (Π₀ i, β i) ≃ (Π i, β i) :=
+@[simps apply] def equiv_fun_on_fintype [fintype ι] : (Π₀ i, β i) ≃ (Π i, β i) :=
 { to_fun := coe_fn,
   inv_fun := λ f, ⟦⟨f, finset.univ.1, λ i, or.inl $ finset.mem_univ_val _⟩⟧,
   left_inv := λ x, coe_fn_injective rfl,
   right_inv := λ x, rfl }
 
-@[simp] lemma equiv_fun_on_fintype_symm_coe
-  [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] (f : Π₀ i, β i) :
+@[simp] lemma equiv_fun_on_fintype_symm_coe [fintype ι] (f : Π₀ i, β i) :
   equiv_fun_on_fintype.symm f = f :=
 equiv.symm_apply_apply _ _
+include dec
 
 /-- The function `single i b : Π₀ i, β i` sends `i` to `b`
 and all other points to `0`. -/
@@ -475,8 +475,7 @@ begin
     simp only [mk_apply, dif_neg h, dif_neg h1] }
 end
 
-lemma single_eq_pi_single [Π i (x : β i), decidable (x ≠ 0)] {i b} :
-  ⇑(single i b : Π₀ i, β i) = pi.single i b :=
+lemma single_eq_pi_single {i b} : ⇑(single i b : Π₀ i, β i) = pi.single i b :=
 begin
   ext i',
   simp only [pi.single, function.update],
@@ -553,14 +552,12 @@ lemma single_eq_of_sigma_eq
   dfinsupp.single i xi = dfinsupp.single j xj :=
 by { cases h, refl }
 
-@[simp] lemma equiv_fun_on_fintype_single
-  [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] (i : ι) (m : β i) :
-  (@dfinsupp.equiv_fun_on_fintype ι β _ _ _ _) (dfinsupp.single i m) = pi.single i m :=
+@[simp] lemma equiv_fun_on_fintype_single [fintype ι] (i : ι) (m : β i) :
+  (@dfinsupp.equiv_fun_on_fintype ι β _ _) (dfinsupp.single i m) = pi.single i m :=
 by { ext, simp [dfinsupp.single_eq_pi_single], }
 
-@[simp] lemma equiv_fun_on_fintype_symm_single
-  [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] (i : ι) (m : β i) :
-  (@dfinsupp.equiv_fun_on_fintype ι β _ _ _ _).symm (pi.single i m) = dfinsupp.single i m :=
+@[simp] lemma equiv_fun_on_fintype_symm_single [fintype ι] (i : ι) (m : β i) :
+  (@dfinsupp.equiv_fun_on_fintype ι β _ _).symm (pi.single i m) = dfinsupp.single i m :=
 by { ext i', simp only [← single_eq_pi_single, equiv_fun_on_fintype_symm_coe] }
 
 /-- Redefine `f i` to be `0`. -/

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -447,27 +447,12 @@ end
 
 /-- Given `fintype ι`, `equiv_fun_on_fintype` is the `equiv` between `Π₀ i, β i` and `Π i, β i`.
   (All dependent functions on a finite type are finitely supported.) -/
-@[simps] def equiv_fun_on_fintype [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] :
+@[simps apply] def equiv_fun_on_fintype [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] :
   (Π₀ i, β i) ≃ (Π i, β i) :=
-⟨λf a, f a, λf, mk (finset.univ.filter $ λa, f a ≠ 0) (λ i, f i),
-  begin
-    intro f,
-    ext a,
-    simp only [mk_apply],
-    split_ifs,
-    { refl },
-    { symmetry,
-      simpa using h },
-  end,
-  begin
-    intro f,
-    ext a,
-    simp only [mk_apply],
-    split_ifs,
-    { refl },
-    symmetry,
-    simpa using h
-  end⟩
+{ to_fun := coe_fn,
+  inv_fun := λ f, ⟦⟨f, finset.univ.1, λ i, or.inl $ finset.mem_univ_val _⟩⟧,
+  left_inv := λ x, coe_fn_injective rfl,
+  right_inv := λ x, rfl }
 
 @[simp] lemma equiv_fun_on_fintype_symm_coe [fintype ι] [Π i, decidable_eq (β i)] (f : Π₀ i, β i) :
   equiv_fun_on_fintype.symm f = f :=

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -454,16 +454,10 @@ end
   left_inv := λ x, coe_fn_injective rfl,
   right_inv := λ x, rfl }
 
-@[simp] lemma equiv_fun_on_fintype_symm_coe [fintype ι] [Π i, decidable_eq (β i)] (f : Π₀ i, β i) :
+@[simp] lemma equiv_fun_on_fintype_symm_coe
+  [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] (f : Π₀ i, β i) :
   equiv_fun_on_fintype.symm f = f :=
-begin
-  ext a,
-  simp only [mk_apply, equiv_fun_on_fintype,mk_apply, equiv.coe_fn_symm_mk],
-  split_ifs,
-  { refl },
-  { symmetry,
-    simpa using h },
-end
+equiv.symm_apply_apply _ _
 
 /-- The function `single i b : Π₀ i, β i` sends `i` to `b`
 and all other points to `0`. -/
@@ -481,7 +475,7 @@ begin
     simp only [mk_apply, dif_neg h, dif_neg h1] }
 end
 
-lemma single_eq_pi_single [Π i, decidable_eq (β i)] {i b} :
+lemma single_eq_pi_single [Π i (x : β i), decidable (x ≠ 0)] {i b} :
   ⇑(single i b : Π₀ i, β i) = pi.single i b :=
 begin
   ext i',
@@ -559,12 +553,13 @@ lemma single_eq_of_sigma_eq
   dfinsupp.single i xi = dfinsupp.single j xj :=
 by { cases h, refl }
 
-@[simp] lemma equiv_fun_on_fintype_single [fintype ι] [Π i, decidable_eq (β i)] (i : ι) (m : β i) :
+@[simp] lemma equiv_fun_on_fintype_single
+  [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] (i : ι) (m : β i) :
   (@dfinsupp.equiv_fun_on_fintype ι β _ _ _ _) (dfinsupp.single i m) = pi.single i m :=
 by { ext, simp [dfinsupp.single_eq_pi_single, dfinsupp.equiv_fun_on_fintype], }
 
 @[simp] lemma equiv_fun_on_fintype_symm_single
-  [fintype ι] [Π i, decidable_eq (β i)] (i : ι) (m : β i) :
+  [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] (i : ι) (m : β i) :
   (@dfinsupp.equiv_fun_on_fintype ι β _ _ _ _).symm (pi.single i m) = dfinsupp.single i m :=
 by { ext i', simp only [← single_eq_pi_single, equiv_fun_on_fintype_symm_coe] }
 

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -447,7 +447,7 @@ end
 
 /-- Given `fintype ι`, `equiv_fun_on_fintype` is the `equiv` between `Π₀ i, β i` and `Π i, β i`.
   (All dependent functions on a finite type are finitely supported.) -/
-@[simps] def equiv_fun_on_fintype [fintype ι] [Π i, decidable_eq (β i)] :
+@[simps] def equiv_fun_on_fintype [fintype ι] [Π i (x : β i), decidable (x ≠ 0)] :
   (Π₀ i, β i) ≃ (Π i, β i) :=
 ⟨λf a, f a, λf, mk (finset.univ.filter $ λa, f a ≠ 0) (λ i, f i),
   begin

--- a/src/data/dfinsupp.lean
+++ b/src/data/dfinsupp.lean
@@ -469,9 +469,8 @@ end
     simpa using h
   end⟩
 
-
-@[simp] lemma equiv_fun_on_fintype_symm_coe [fintype ι] [Π i, decidable_eq (β i)] (f : Π₀ i, β i) :
-  equiv_fun_on_fintype.symm f = f :=
+@[simp] lemma equiv_fun_on_fintype_symm_coe [fintype ι] [Π i, decidable_eq (β i)] (f : Π i, β i) :
+  ⇑(equiv_fun_on_fintype.symm f) = f :=
 begin
   ext a,
   simp only [mk_apply, equiv_fun_on_fintype,mk_apply, equiv.coe_fn_symm_mk],
@@ -495,6 +494,16 @@ begin
     simp only [mk_apply, dif_pos h, dif_pos h1], refl },
   { have h1 : i' ∉ ({i} : finset ι) := finset.not_mem_singleton.2 (ne.symm h),
     simp only [mk_apply, dif_neg h, dif_neg h1] }
+end
+
+lemma single_eq_pi_single [Π i, decidable_eq (β i)] {i b} :
+  ⇑(single i b : Π₀ i, β i) = pi.single i b :=
+begin
+  ext i',
+  simp only [pi.single, function.update],
+  split_ifs,
+  { simp [h] },
+  { simp [ne.symm h] }
 end
 
 @[simp] lemma single_zero (i) : (single i 0 : Π₀ i, β i) = 0 :=
@@ -564,6 +573,15 @@ lemma single_eq_of_sigma_eq
   {i j} {xi : β i} {xj : β j} (h : (⟨i, xi⟩ : sigma β) = ⟨j, xj⟩) :
   dfinsupp.single i xi = dfinsupp.single j xj :=
 by { cases h, refl }
+
+@[simp] lemma equiv_fun_on_fintype_single [fintype ι] [Π i, decidable_eq (β i)] (i : ι) (m : β i) :
+  (@dfinsupp.equiv_fun_on_fintype ι β _ _ _ _) (dfinsupp.single i m) = pi.single i m :=
+by { ext, simp [dfinsupp.single_eq_pi_single, dfinsupp.equiv_fun_on_fintype], }
+
+@[simp] lemma equiv_fun_on_fintype_symm_single
+  [fintype ι] [Π i, decidable_eq (β i)] (i : ι) (m : β i) :
+  (@dfinsupp.equiv_fun_on_fintype ι β _ _ _ _).symm (pi.single i m) = dfinsupp.single i m :=
+by { ext i', rw [dfinsupp.equiv_fun_on_fintype_symm_coe, dfinsupp.single_eq_pi_single] }
 
 /-- Redefine `f i` to be `0`. -/
 def erase (i : ι) : (Π₀ i, β i) → Π₀ i, β i :=


### PR DESCRIPTION
Analogues for `dfinsupp`/`direct_sum` of definitions/lemmas such as `finsupp.equiv_fun_on_fintype`:  a `dfinsupp`/`direct_sum` over a finite index set is canonically equivalent to `pi` over the same index set.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Direct.20sum.20on.20fintype

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
