### PR TITLE
[Merged by Bors] - chore(set_theory/cardinal): rename `is_empty`/`nonempty` lemmas

### DIFF
--- a/src/data/W/cardinal.lean
+++ b/src/data/W/cardinal.lean
@@ -55,7 +55,7 @@ lemma cardinal_mk_le_max_omega_of_fintype [Π a, fintype (β a)] : #(W_type β) 
 (is_empty_or_nonempty α).elim
   (begin
     introI h,
-    rw [@cardinal.eq_zero_of_is_empty (W_type β)],
+    rw [cardinal.mk_eq_zero (W_type β)],
     exact zero_le _
   end) $
 λ hn,

--- a/src/logic/is_empty.lean
+++ b/src/logic/is_empty.lean
@@ -98,6 +98,18 @@ end is_empty
 @[simp] lemma not_is_empty_iff : ¬ is_empty α ↔ nonempty α :=
 not_iff_comm.mp not_nonempty_iff
 
+@[simp] lemma is_empty_pi {π : α → Sort*} : is_empty (Π a, π a) ↔ ∃ a, is_empty (π a) :=
+by simp only [← not_nonempty_iff, classical.nonempty_pi, not_forall]
+
+@[simp] lemma is_empty_prod {α β : Type*} : is_empty (α × β) ↔ is_empty α ∨ is_empty β :=
+by simp only [← not_nonempty_iff, nonempty_prod, not_and_distrib]
+
+@[simp] lemma is_empty_pprod : is_empty (pprod α β) ↔ is_empty α ∨ is_empty β :=
+by simp only [← not_nonempty_iff, nonempty_pprod, not_and_distrib]
+
+@[simp] lemma is_empty_sum {α β} : is_empty (α ⊕ β) ↔ is_empty α ∧ is_empty β :=
+by simp only [← not_nonempty_iff, nonempty_sum, not_or_distrib]
+
 variables (α)
 
 lemma is_empty_or_nonempty : is_empty α ∨ nonempty α :=

--- a/src/logic/is_empty.lean
+++ b/src/logic/is_empty.lean
@@ -110,6 +110,9 @@ by simp only [← not_nonempty_iff, nonempty_pprod, not_and_distrib]
 @[simp] lemma is_empty_sum {α β} : is_empty (α ⊕ β) ↔ is_empty α ∧ is_empty β :=
 by simp only [← not_nonempty_iff, nonempty_sum, not_or_distrib]
 
+@[simp] lemma is_empty_psum {α β} : is_empty (psum α β) ↔ is_empty α ∧ is_empty β :=
+by simp only [← not_nonempty_iff, nonempty_psum, not_or_distrib]
+
 variables (α)
 
 lemma is_empty_or_nonempty : is_empty α ∨ nonempty α :=

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -145,22 +145,20 @@ instance : has_zero cardinal.{u} := ⟨#pempty⟩
 
 instance : inhabited cardinal.{u} := ⟨0⟩
 
-@[simp]
-lemma eq_zero_of_is_empty {α : Type u} [is_empty α] : #α = 0 :=
+@[simp] lemma mk_eq_zero (α : Type u) [is_empty α] : #α = 0 :=
 (equiv.equiv_pempty α).cardinal_eq
 
-lemma eq_zero_iff_is_empty {α : Type u} : #α = 0 ↔ is_empty α :=
-⟨λ e, let ⟨h⟩ := quotient.exact e in
-  equiv.equiv_empty_equiv α $ h.trans equiv.empty_equiv_pempty.symm,
-  @eq_zero_of_is_empty _⟩
+lemma mk_eq_zero_iff {α : Type u} : #α = 0 ↔ is_empty α :=
+⟨λ e, let ⟨h⟩ := quotient.exact e in h.is_empty, @mk_eq_zero α⟩
 
-theorem ne_zero_iff_nonempty {α : Type u} : #α ≠ 0 ↔ nonempty α :=
-(not_iff_not.2 eq_zero_iff_is_empty).trans not_is_empty_iff
+theorem mk_ne_zero_iff {α : Type u} : #α ≠ 0 ↔ nonempty α :=
+(not_iff_not.2 mk_eq_zero_iff).trans not_is_empty_iff
+
+@[simp] lemma mk_ne_zero (α : Type u) [nonempty α] : #α ≠ 0 := mk_ne_zero_iff.2 ‹_›
 
 instance : has_one cardinal.{u} := ⟨⟦punit⟧⟩
 
-instance : nontrivial cardinal.{u} :=
-⟨⟨1, 0, ne_zero_iff_nonempty.2 ⟨punit.star⟩⟩⟩
+instance : nontrivial cardinal.{u} := ⟨⟨1, 0, mk_ne_zero _⟩⟩
 
 theorem le_one_iff_subsingleton {α : Type u} : #α ≤ 1 ↔ subsingleton α :=
 ⟨λ ⟨f⟩, ⟨λ a b, f.injective (subsingleton.elim _ _)⟩,

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -205,6 +205,7 @@ instance : has_zero cardinal.{u} := ⟨#pempty⟩
 instance : inhabited cardinal.{u} := ⟨0⟩
 
 @[simp] lemma mk_eq_zero (α : Type u) [is_empty α] : #α = 0 :=
+(equiv.equiv_pempty α).cardinal_eq
 
 @[simp] theorem lift_zero : lift 0 = 0 :=
 quotient.sound ⟨equiv.equiv_pempty _⟩

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -94,6 +94,9 @@ localized "notation `#` := cardinal.mk" in cardinal
 instance can_lift_cardinal_Type : can_lift cardinal.{u} (Type u) :=
 ⟨mk, λ c, true, λ c _, quot.induction_on c $ λ α, ⟨α, rfl⟩⟩
 
+protected lemma induction_on {p : cardinal → Prop} (c : cardinal) (h : ∀ α, p (#α)) : p c :=
+quotient.induction_on c h
+
 protected lemma eq : #α = #β ↔ nonempty (α ≃ β) := quotient.eq
 
 @[simp] theorem mk_def (α : Type u) : @eq cardinal ⟦α⟧ (#α) := rfl
@@ -262,7 +265,8 @@ quotient.induction_on₃ a b c $ assume α β γ, quotient.sound ⟨equiv.prod_s
 protected theorem eq_zero_or_eq_zero_of_mul_eq_zero  {a b : cardinal.{u}} :
   a * b = 0 → a = 0 ∨ b = 0 :=
 begin
-  lift a to Type u using trivial, lift b to Type u using trivial,
+  induction a using cardinal.induction_on with α,
+  induction b using cardinal.induction_on with β,
   simp only [mul_def, mk_eq_zero_iff, is_empty_prod],
   exact id
 end

--- a/src/set_theory/cofinality.lean
+++ b/src/set_theory/cofinality.lean
@@ -197,7 +197,7 @@ le_antisymm (by simpa using cof_le_card 0) (cardinal.zero_le _)
 ⟨induction_on o $ λ α r _ z, by exactI
   let ⟨S, hl, e⟩ := cof_eq r in type_eq_zero_iff_is_empty.2 $
   ⟨λ a, let ⟨b, h, _⟩ := hl a in
-    (eq_zero_iff_is_empty.1 (e.trans z)).elim' ⟨_, h⟩⟩,
+    (mk_eq_zero_iff.1 (e.trans z)).elim' ⟨_, h⟩⟩,
 λ e, by simp [e]⟩
 
 @[simp] theorem cof_succ (o) : cof (succ o) = 1 :=
@@ -218,7 +218,7 @@ end
 ⟨induction_on o $ λ α r _ z, begin
   resetI,
   rcases cof_eq r with ⟨S, hl, e⟩, rw z at e,
-  cases ne_zero_iff_nonempty.1 (by rw e; exact one_ne_zero) with a,
+  cases mk_ne_zero_iff.1 (by rw e; exact one_ne_zero) with a,
   refine ⟨typein r a, eq.symm $ quotient.sound
     ⟨rel_iso.of_surjective (rel_embedding.of_monotone _
       (λ x y, _)) (λ x, _)⟩⟩,

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -150,19 +150,19 @@ by simp only [le_antisymm_iff, add_le_add_iff_right]
 @[simp] theorem card_eq_zero {o} : card o = 0 ↔ o = 0 :=
 ⟨induction_on o $ λ α r _ h, begin
   refine le_antisymm (le_of_not_lt $
-    λ hn, ne_zero_iff_nonempty.2 _ h) (ordinal.zero_le _),
+    λ hn, mk_ne_zero_iff.2 _ h) (ordinal.zero_le _),
   rw [← succ_le, succ_zero] at hn, cases hn with f,
   exact ⟨f punit.star⟩
 end, λ e, by simp only [e, card_zero]⟩
 
 @[simp] theorem type_eq_zero_of_empty [is_well_order α r] [is_empty α] : type r = 0 :=
-card_eq_zero.symm.mpr eq_zero_of_is_empty
+card_eq_zero.symm.mpr (mk_eq_zero _)
 
 @[simp] theorem type_eq_zero_iff_is_empty [is_well_order α r] : type r = 0 ↔ is_empty α :=
-(@card_eq_zero (type r)).symm.trans eq_zero_iff_is_empty
+(@card_eq_zero (type r)).symm.trans mk_eq_zero_iff
 
 theorem type_ne_zero_iff_nonempty [is_well_order α r] : type r ≠ 0 ↔ nonempty α :=
-(not_congr (@card_eq_zero (type r))).symm.trans ne_zero_iff_nonempty
+(not_congr (@card_eq_zero (type r))).symm.trans mk_ne_zero_iff
 
 protected lemma one_ne_zero : (1 : ordinal) ≠ 0 :=
 type_ne_zero_iff_nonempty.2 ⟨punit.star⟩


### PR DESCRIPTION
* add `is_empty_pi`, `is_empty_prod`, `is_empty_pprod`, `is_empty_sum`;
* rename `cardinal.eq_zero_of_is_empty` to `cardinal.mk_eq_zero`, make
  the argument `α : Type u` explicit;
* rename `cardinal.eq_zero_iff_is_empty` to `cardinal.mk_eq_zero_iff`;
* rename `cardinal.ne_zero_iff_nonempty` to `cardinal.mk_ne_zero_iff`;
* add `@[simp]` lemma `cardinal.mk_ne_zero`;
* fix compile errors caused by these changes, golf a few proofs.

---

This PR has a trivial conflict with #9669, so these two should not hit
the merge queue together.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)