### PR TITLE
[Merged by Bors] - refactor(data/set/pairwise): generalize `pairwise_disjoint` to `semilattice_inf_bot`

### DIFF
--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -29,8 +29,6 @@ for `set α`, and some more set constructions.
   `f ⁻¹ y ⊆ s`.
 * `set.seq`: Union of the image of a set under a **seq**uence of functions. `seq s t` is the union
   of `f '' t` over all `f ∈ s`, where `t : set α` and `s : set (α → β)`.
-* `set.pairwise_disjoint`: `pairwise_disjoint s` states that all sets in `s` are either equal or
-  disjoint.
 * `set.Union_eq_sigma_of_disjoint`: Equivalence between `⋃ i, t i` and `Σ i, t i`, where `t` is an
   indexed family of disjoint sets.
 
@@ -1524,31 +1522,6 @@ disjoint_right
 end set
 
 end disjoint
-
-namespace set
-
-/-- A collection of sets is `pairwise_disjoint`, if any two different sets in this collection
-are disjoint. -/
-def pairwise_disjoint (s : set (set α)) : Prop :=
-pairwise_on s disjoint
-
-lemma pairwise_disjoint.subset {s t : set (set α)} (h : s ⊆ t)
-  (ht : pairwise_disjoint t) : pairwise_disjoint s :=
-pairwise_on.mono h ht
-
-lemma pairwise_disjoint.range {s : set (set α)} (f : s → set α) (hf : ∀ (x : s), f x ⊆ x.1)
-  (ht : pairwise_disjoint s) : pairwise_disjoint (range f) :=
-begin
-  rintro _ ⟨x, rfl⟩ _ ⟨y, rfl⟩ hxy, refine (ht _ x.2 _ y.2 _).mono (hf x) (hf y),
-  intro h, apply hxy, apply congr_arg f, exact subtype.eq h
-end
-
--- classical
-lemma pairwise_disjoint.elim {s : set (set α)} (h : pairwise_disjoint s) {x y : set α}
-  (hx : x ∈ s) (hy : y ∈ s) (z : α) (hzx : z ∈ x) (hzy : z ∈ y) : x = y :=
-not_not.1 $ λ h', h x hx y hy h' ⟨hzx, hzy⟩
-
-end set
 
 namespace set
 variables (t : α → set β)

--- a/src/data/set/pairwise.lean
+++ b/src/data/set/pairwise.lean
@@ -65,10 +65,11 @@ theorem pairwise.pairwise_on {p : α → α → Prop} (h : pairwise p) (s : set 
 theorem pairwise_disjoint_fiber (f : α → β) : pairwise (disjoint on (λ y : β, f ⁻¹' {y})) :=
 set.pairwise_on_univ.1 $ pairwise_on_disjoint_fiber f univ
 
+namespace set
+section semilattice_inf_bot
 variables [semilattice_inf_bot α]
 
-/-- A collection of sets is `pairwise_disjoint`, if any two different sets in this collection
-are disjoint. -/
+/-- Elements of a set is `pairwise_disjoint`, if any distinct two are disjoint. -/
 def pairwise_disjoint (s : set α) : Prop :=
 pairwise_on s disjoint
 
@@ -95,7 +96,11 @@ lemma pairwise_disjoint.elim' {s : set α} (hs : pairwise_disjoint s) {x y : α}
   x = y :=
 hs.elim hx hy $ λ hxy, h hxy.eq_bot
 
+end semilattice_inf_bot
+
 -- classical
-lemma pairwise_disjoint.elim_set {s : set (set β)} (hs : pairwise_disjoint s) {x y : set β}
-  (hx : x ∈ s) (hy : y ∈ s) (z : β) (hzx : z ∈ x) (hzy : z ∈ y) : x = y :=
+lemma pairwise_disjoint.elim_set {s : set (set α)} (hs : pairwise_disjoint s) {x y : set α}
+  (hx : x ∈ s) (hy : y ∈ s) (z : α) (hzx : z ∈ x) (hzy : z ∈ y) : x = y :=
 hs.elim hx hy (not_disjoint_iff.2 ⟨z, hzx, hzy⟩)
+
+end set

--- a/src/data/set/pairwise.lean
+++ b/src/data/set/pairwise.lean
@@ -9,18 +9,19 @@ import tactic.wlog
 /-!
 # Relations holding pairwise
 
-This file defines pairwise relations.
+This file defines pairwise relations and pairwise disjoint sets.
 
 ## Main declarations
 
 * `pairwise p`: States that `p i j` for all `i ≠ j`.
+* `pairwise_disjoint`: `pairwise_disjoint s` states that all elements in `s` are either equal or
+  `disjoint`.
 -/
 
 open set
 
-universes u v w x
-variables {α : Type u} {β : Type v} {γ : Type w} {ι : Sort x}
-  {s t u : set α}
+universes u v
+variables {α : Type u} {β : Type v} {s t u : set α}
 
 /-- A relation `p` holds pairwise if `p i j` for all `i ≠ j`. -/
 def pairwise {α : Type*} (p : α → α → Prop) := ∀ i j, i ≠ j → p i j
@@ -63,3 +64,38 @@ theorem pairwise.pairwise_on {p : α → α → Prop} (h : pairwise p) (s : set 
 
 theorem pairwise_disjoint_fiber (f : α → β) : pairwise (disjoint on (λ y : β, f ⁻¹' {y})) :=
 set.pairwise_on_univ.1 $ pairwise_on_disjoint_fiber f univ
+
+variables [semilattice_inf_bot α]
+
+/-- A collection of sets is `pairwise_disjoint`, if any two different sets in this collection
+are disjoint. -/
+def pairwise_disjoint (s : set α) : Prop :=
+pairwise_on s disjoint
+
+lemma pairwise_disjoint.subset {s t : set α} (ht : pairwise_disjoint t) (h : s ⊆ t) :
+  pairwise_disjoint s :=
+pairwise_on.mono h ht
+
+lemma pairwise_disjoint.range {s : set α} (f : s → α) (hf : ∀ (x : s), f x ≤ x.1)
+  (ht : pairwise_disjoint s) : pairwise_disjoint (range f) :=
+begin
+  rintro _ ⟨x, rfl⟩ _ ⟨y, rfl⟩ hxy,
+  exact (ht _ x.2 _ y.2 $ λ h, hxy $ congr_arg f $ subtype.ext h).mono (hf x) (hf y),
+end
+
+-- classical
+lemma pairwise_disjoint.elim {s : set α} (hs : pairwise_disjoint s) {x y : α} (hx : x ∈ s)
+  (hy : y ∈ s) (h : ¬ disjoint x y) :
+  x = y :=
+of_not_not $ λ hxy, h $ hs _ hx _ hy hxy
+
+-- classical
+lemma pairwise_disjoint.elim' {s : set α} (hs : pairwise_disjoint s) {x y : α} (hx : x ∈ s)
+  (hy : y ∈ s) (h : x ⊓ y ≠ ⊥) :
+  x = y :=
+hs.elim hx hy $ λ hxy, h hxy.eq_bot
+
+-- classical
+lemma pairwise_disjoint.elim_set {s : set (set β)} (hs : pairwise_disjoint s) {x y : set β}
+  (hx : x ∈ s) (hy : y ∈ s) (z : β) (hzx : z ∈ x) (hzy : z ∈ y) : x = y :=
+hs.elim hx hy (not_disjoint_iff.2 ⟨z, hzx, hzy⟩)

--- a/src/data/setoid/partition.lean
+++ b/src/data/setoid/partition.lean
@@ -5,7 +5,7 @@ Authors: Amelia Livingston, Bryan Gin-ge Chen, Patrick Massot
 -/
 
 import data.setoid.basic
-import data.set.lattice
+import data.set.pairwise
 
 /-!
 # Equivalence relations: partitions
@@ -107,20 +107,20 @@ by { convert setoid.eqv_class_mem H, ext, rw setoid.comm' }
 
 /-- Distinct elements of a set of sets partitioning α are disjoint. -/
 lemma eqv_classes_disjoint {c : set (set α)} (H : ∀ a, ∃! b ∈ c, a ∈ b) :
-  set.pairwise_disjoint c :=
+  pairwise_disjoint c :=
 λ b₁ h₁ b₂ h₂ h, set.disjoint_left.2 $
   λ x hx1 hx2, (H x).elim2 $ λ b hc hx hb, h $ eq_of_mem_eqv_class H h₁ hx1 h₂ hx2
 
 /-- A set of disjoint sets covering α partition α (classical). -/
 lemma eqv_classes_of_disjoint_union {c : set (set α)}
-  (hu : set.sUnion c = @set.univ α) (H : set.pairwise_disjoint c) (a) :
+  (hu : set.sUnion c = @set.univ α) (H : pairwise_disjoint c) (a) :
   ∃! b ∈ c, a ∈ b :=
 let ⟨b, hc, ha⟩ := set.mem_sUnion.1 $ show a ∈ _, by rw hu; exact set.mem_univ a in
-  exists_unique.intro2 b hc ha $ λ b' hc' ha', H.elim hc' hc a ha' ha
+  exists_unique.intro2 b hc ha $ λ b' hc' ha', H.elim_set hc' hc a ha' ha
 
 /-- Makes an equivalence relation from a set of disjoints sets covering α. -/
 def setoid_of_disjoint_union {c : set (set α)} (hu : set.sUnion c = @set.univ α)
-  (H : set.pairwise_disjoint c) : setoid α :=
+  (H : pairwise_disjoint c) : setoid α :=
 setoid.mk_classes c $ eqv_classes_of_disjoint_union hu H
 
 /-- The equivalence relation made from the equivalence classes of an equivalence
@@ -149,7 +149,7 @@ lemma is_partition_classes (r : setoid α) : is_partition r.classes :=
 ⟨empty_not_mem_classes, classes_eqv_classes⟩
 
 lemma is_partition.pairwise_disjoint {c : set (set α)} (hc : is_partition c) :
-  c.pairwise_disjoint :=
+  pairwise_disjoint c :=
 eqv_classes_disjoint hc.2
 
 lemma is_partition.sUnion_eq_univ {c : set (set α)} (hc : is_partition c) :

--- a/src/data/setoid/partition.lean
+++ b/src/data/setoid/partition.lean
@@ -107,20 +107,20 @@ by { convert setoid.eqv_class_mem H, ext, rw setoid.comm' }
 
 /-- Distinct elements of a set of sets partitioning α are disjoint. -/
 lemma eqv_classes_disjoint {c : set (set α)} (H : ∀ a, ∃! b ∈ c, a ∈ b) :
-  pairwise_disjoint c :=
+  c.pairwise_disjoint :=
 λ b₁ h₁ b₂ h₂ h, set.disjoint_left.2 $
   λ x hx1 hx2, (H x).elim2 $ λ b hc hx hb, h $ eq_of_mem_eqv_class H h₁ hx1 h₂ hx2
 
 /-- A set of disjoint sets covering α partition α (classical). -/
 lemma eqv_classes_of_disjoint_union {c : set (set α)}
-  (hu : set.sUnion c = @set.univ α) (H : pairwise_disjoint c) (a) :
+  (hu : set.sUnion c = @set.univ α) (H : c.pairwise_disjoint) (a) :
   ∃! b ∈ c, a ∈ b :=
 let ⟨b, hc, ha⟩ := set.mem_sUnion.1 $ show a ∈ _, by rw hu; exact set.mem_univ a in
   exists_unique.intro2 b hc ha $ λ b' hc' ha', H.elim_set hc' hc a ha' ha
 
 /-- Makes an equivalence relation from a set of disjoints sets covering α. -/
 def setoid_of_disjoint_union {c : set (set α)} (hu : set.sUnion c = @set.univ α)
-  (H : pairwise_disjoint c) : setoid α :=
+  (H : c.pairwise_disjoint) : setoid α :=
 setoid.mk_classes c $ eqv_classes_of_disjoint_union hu H
 
 /-- The equivalence relation made from the equivalence classes of an equivalence
@@ -149,7 +149,7 @@ lemma is_partition_classes (r : setoid α) : is_partition r.classes :=
 ⟨empty_not_mem_classes, classes_eqv_classes⟩
 
 lemma is_partition.pairwise_disjoint {c : set (set α)} (hc : is_partition c) :
-  pairwise_disjoint c :=
+  c.pairwise_disjoint :=
 eqv_classes_disjoint hc.2
 
 lemma is_partition.sUnion_eq_univ {c : set (set α)} (hc : is_partition c) :


### PR DESCRIPTION
`set.pairwise_disjoint` was only defined for `set (set α)`. Now, it's defined for `set α` where `semilattice_inf_bot α`. I also
* move it to `data.set.pairwise` because it's really not about `set` anymore.
* drop the `set` namespace.
* add more general elimination rules and rename the current one to `elim_set`.

---

I'm not sure we want to get rid of the `set` namespace because it forbids dot notation, so I'll happily revert if someone else thinks so too.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
