### PR TITLE
[Merged by Bors] - chore(ring_theory/tensor_product): squeeze simps in a slow proof

### DIFF
--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -303,15 +303,15 @@ lemma mul_assoc' (mul : (A ⊗[R] B) →ₗ[R] (A ⊗[R] B) →ₗ[R] (A ⊗[R] 
 begin
     intros,
     apply tensor_product.induction_on x,
-    { simp, },
+    { simp only [linear_map.map_zero, linear_map.zero_apply], },
     apply tensor_product.induction_on y,
-    { simp, },
+    { simp only [linear_map.map_zero, forall_const, linear_map.zero_apply], },
     apply tensor_product.induction_on z,
-    { simp, },
-    { intros, simp [h], },
-    { intros, simp [linear_map.map_add, *], },
-    { intros, simp [linear_map.map_add, *], },
-    { intros, simp [linear_map.map_add, *], },
+    { simp only [linear_map.map_zero, forall_const], },
+    { intros, simp only [h], },
+    { intros, simp only [linear_map.map_add, *], },
+    { intros, simp only [linear_map.map_add, *, linear_map.add_apply], },
+    { intros, simp only [linear_map.map_add, *, linear_map.add_apply], },
 end
 
 lemma mul_assoc (x y z : A ⊗[R] B) : mul (mul x y) z = mul x (mul y z) :=


### PR DESCRIPTION
This proof just timed out in bors. Goes from 21s to 1s on my computer just by squeezing the simps.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
