### PR TITLE
[Merged by Bors] - refactor(linear_algebra/dimension): remove some nontrivial assumptions

### DIFF
--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -734,8 +734,10 @@ by {haveI := nontrivial_of_invariant_basis_number R,
 
 theorem basis.mk_eq_dim (v : basis ι R M) :
   cardinal.lift.{v} (#ι) = cardinal.lift.{w} (module.rank R M) :=
-by { haveI := nontrivial_of_invariant_basis_number R,
-  rw [←v.mk_range_eq_dim, cardinal.mk_range_eq_of_injective v.injective] }
+begin
+  haveI := nontrivial_of_invariant_basis_number R,
+  rw [←v.mk_range_eq_dim, cardinal.mk_range_eq_of_injective v.injective]
+end
 
 theorem {m} basis.mk_eq_dim' (v : basis ι R M) :
   cardinal.lift.{(max v m)} (#ι) = cardinal.lift.{(max w m)} (module.rank R M) :=
@@ -764,9 +766,11 @@ finite_def.2 (b.nonempty_fintype_index_of_dim_lt_omega h)
 
 lemma dim_span {v : ι → M} (hv : linear_independent R v) :
   module.rank R ↥(span R (range v)) = #(range v) :=
-by { haveI := nontrivial_of_invariant_basis_number R,
+begin
+  haveI := nontrivial_of_invariant_basis_number R,
   rw [←cardinal.lift_inj, ← (basis.span hv).mk_eq_dim,
-  cardinal.mk_range_eq_of_injective (@linear_independent.injective ι R M v _ _ _ _ hv)] }
+    cardinal.mk_range_eq_of_injective (@linear_independent.injective ι R M v _ _ _ _ hv)]
+end
 
 lemma dim_span_set {s : set M} (hs : linear_independent R (λ x, x : s → M)) :
   module.rank R ↥(span R s) = #s :=

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -423,7 +423,7 @@ end
 
 section invariant_basis_number
 
-variables {R : Type u} [ring R] [nontrivial R] [invariant_basis_number R]
+variables {R : Type u} [ring R] [invariant_basis_number R]
 variables {M : Type v} [add_comm_group M] [module R M]
 
 /-- The dimension theorem: if `v` and `v'` are two bases, their index types
@@ -431,6 +431,7 @@ have the same cardinalities. -/
 theorem mk_eq_mk_of_basis (v : basis ι R M) (v' : basis ι' R M) :
   cardinal.lift.{w'} (#ι) = cardinal.lift.{w} (#ι') :=
 begin
+  haveI := nontrivial_of_invariant_basis_number R,
   by_cases h : #ι < ω,
   { -- `v` is a finite basis, so by `basis_fintype_of_finite_spans` so is `v'`.
     haveI : fintype ι := (cardinal.lt_omega_iff_fintype.mp h).some,
@@ -500,8 +501,6 @@ begin
     simpa using s, },
 end
 
-variables [nontrivial R]
-
 /--
 Another auxiliary lemma for `basis.le_span`, which does not require assuming the basis is finite,
 but still assumes we have a finite spanning set.
@@ -510,6 +509,7 @@ lemma basis_le_span' {ι : Type*} (b : basis ι R M)
   {w : set M} [fintype w] (s : span R w = ⊤) :
   #ι ≤ fintype.card w :=
 begin
+  haveI := nontrivial_of_invariant_basis_number R,
   haveI := basis_fintype_of_finite_spans w s b,
   rw cardinal.fintype_card ι,
   simp only [cardinal.nat_cast_le],
@@ -525,6 +525,7 @@ then the cardinality of any basis is bounded by the cardinality of any spanning 
 theorem basis.le_span {J : set M} (v : basis ι R M)
    (hJ : span R J = ⊤) : #(range v) ≤ #J :=
 begin
+  haveI := nontrivial_of_invariant_basis_number R,
   cases le_or_lt ω (#J) with oJ oJ,
   { have := cardinal.mk_range_eq_of_injective v.injective,
     let S : J → set ι := λ j, ↑(v.repr j).support,
@@ -701,11 +702,10 @@ begin
     exact infinite_basis_le_maximal_linear_independent b v i m, }
 end
 
-variables [nontrivial R]
-
 theorem basis.mk_eq_dim'' {ι : Type v} (v : basis ι R M) :
   #ι = module.rank R M :=
 begin
+  haveI := nontrivial_of_invariant_basis_number R,
   apply le_antisymm,
   { transitivity,
     swap,
@@ -729,12 +729,13 @@ v.reindex_range.mk_eq_dim''
 cardinality of the basis. -/
 lemma dim_eq_card_basis {ι : Type w} [fintype ι] (h : basis ι R M) :
   module.rank R M = fintype.card ι :=
-by rw [←h.mk_range_eq_dim, cardinal.fintype_card,
-       set.card_range_of_injective h.injective]
+by {haveI := nontrivial_of_invariant_basis_number R,
+  rw [←h.mk_range_eq_dim, cardinal.fintype_card, set.card_range_of_injective h.injective] }
 
 theorem basis.mk_eq_dim (v : basis ι R M) :
   cardinal.lift.{v} (#ι) = cardinal.lift.{w} (module.rank R M) :=
-by rw [←v.mk_range_eq_dim, cardinal.mk_range_eq_of_injective v.injective]
+by { haveI := nontrivial_of_invariant_basis_number R,
+  rw [←v.mk_range_eq_dim, cardinal.mk_range_eq_of_injective v.injective] }
 
 theorem {m} basis.mk_eq_dim' (v : basis ι R M) :
   cardinal.lift.{(max v m)} (#ι) = cardinal.lift.{(max w m)} (module.rank R M) :=
@@ -763,8 +764,9 @@ finite_def.2 (b.nonempty_fintype_index_of_dim_lt_omega h)
 
 lemma dim_span {v : ι → M} (hv : linear_independent R v) :
   module.rank R ↥(span R (range v)) = #(range v) :=
-by rw [←cardinal.lift_inj, ← (basis.span hv).mk_eq_dim,
-    cardinal.mk_range_eq_of_injective (@linear_independent.injective ι R M v _ _ _ _ hv)]
+by { haveI := nontrivial_of_invariant_basis_number R,
+  rw [←cardinal.lift_inj, ← (basis.span hv).mk_eq_dim,
+  cardinal.mk_range_eq_of_injective (@linear_independent.injective ι R M v _ _ _ _ hv)] }
 
 lemma dim_span_set {s : set M} (hs : linear_independent R (λ x, x : s → M)) :
   module.rank R ↥(span R s) = #s :=

--- a/src/linear_algebra/invariant_basis_number.lean
+++ b/src/linear_algebra/invariant_basis_number.lean
@@ -183,6 +183,12 @@ begin
   refine { .. }; { intros, exact 0 } <|> tidy
 end
 
+@[nontriviality]
+lemma not_subsingleton_of_invariant_basis_number {R : Type*} [ring R] [invariant_basis_number R] :
+  subsingleton R ↔ false :=
+⟨λ h, (not_nontrivial_iff_subsingleton.2 h) (nontrivial_of_invariant_basis_number _),
+  λ h, false.rec _ h⟩
+
 end
 
 section

--- a/src/linear_algebra/invariant_basis_number.lean
+++ b/src/linear_algebra/invariant_basis_number.lean
@@ -183,12 +183,6 @@ begin
   refine { .. }; { intros, exact 0 } <|> tidy
 end
 
-@[nontriviality]
-lemma not_subsingleton_of_invariant_basis_number {R : Type*} [ring R] [invariant_basis_number R] :
-  subsingleton R ↔ false :=
-⟨λ h, (not_nontrivial_iff_subsingleton.2 h) (nontrivial_of_invariant_basis_number _),
-  λ h, false.rec _ h⟩
-
 end
 
 section


### PR DESCRIPTION
We remove some `nontrivial R` assumptions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
