### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space/affine_subspace): add lemma `affine_equiv.span_eq_top_iff`

### DIFF
--- a/src/algebra/add_torsor.lean
+++ b/src/algebra/add_torsor.lean
@@ -193,6 +193,10 @@ lemma vsub_mem_vsub {ps pt : P} (hs : ps ∈ s) (ht : pt ∈ t) :
   (ps -ᵥ pt) ∈ s -ᵥ t :=
 mem_image2_of_mem hs ht
 
+@[simp] lemma mem_vsub {s t : set P} (g : G) :
+  g ∈ s -ᵥ t ↔ ∃ (x y : P) (hx : x ∈ s) (hy : y ∈ t), x -ᵥ y = g :=
+by simp [has_vsub.vsub]
+
 /-- `s -ᵥ t` is monotone in both arguments. -/
 @[mono] lemma vsub_subset_vsub {s' t' : set P} (hs : s ⊆ s') (ht : t ⊆ t') :
   s -ᵥ t ⊆ s' -ᵥ t' :=

--- a/src/algebra/add_torsor.lean
+++ b/src/algebra/add_torsor.lean
@@ -194,8 +194,8 @@ lemma vsub_mem_vsub {ps pt : P} (hs : ps ∈ s) (ht : pt ∈ t) :
 mem_image2_of_mem hs ht
 
 @[simp] lemma mem_vsub {s t : set P} (g : G) :
-  g ∈ s -ᵥ t ↔ ∃ (x y : P) (hx : x ∈ s) (hy : y ∈ t), x -ᵥ y = g :=
-by simp [has_vsub.vsub]
+  g ∈ s -ᵥ t ↔ ∃ (x y : P), x ∈ s ∧ y ∈ t ∧ x -ᵥ y = g :=
+mem_image2
 
 /-- `s -ᵥ t` is monotone in both arguments. -/
 @[mono] lemma vsub_subset_vsub {s' t' : set P} (hs : s ⊆ s') (ht : t ⊆ t') :

--- a/src/linear_algebra/affine_space/affine_map.lean
+++ b/src/linear_algebra/affine_space/affine_map.lean
@@ -308,6 +308,20 @@ begin
   rw [h, equiv.comp_surjective, equiv.surjective_comp],
 end
 
+@[simp] lemma image_vsub_image {s t : set P1} (f : P1 →ᵃ[k] P2) :
+  (f '' s) -ᵥ (f '' t) = f.linear '' (s -ᵥ t) :=
+begin
+  ext v,
+  suffices : (∃ x, x ∈ s ∧ ∃ y, y ∈ t ∧ f.linear (x -ᵥ y) = v) ↔
+             ∃ w, (∃ x, x ∈ s ∧ ∃ y, y ∈ t ∧ x -ᵥ y = w) ∧ f.linear w = v,
+  { simp [this, -linear_map_vsub, ← f.linear_map_vsub], },
+  split,
+  { rintros ⟨x, hx, y, hy, hv⟩,
+    exact ⟨x -ᵥ y, ⟨x, hx, y, hy, rfl⟩, hv⟩, },
+  { rintros ⟨-, ⟨x, hx, y, hy, rfl⟩, rfl⟩,
+    exact ⟨x, hx, y, hy, rfl⟩, },
+end
+
 omit V2
 
 /-! ### Definition of `affine_map.line_map` and lemmas about it -/

--- a/src/linear_algebra/affine_space/affine_map.lean
+++ b/src/linear_algebra/affine_space/affine_map.lean
@@ -308,13 +308,12 @@ begin
   rw [h, equiv.comp_surjective, equiv.surjective_comp],
 end
 
-@[simp] lemma image_vsub_image {s t : set P1} (f : P1 →ᵃ[k] P2) :
+lemma image_vsub_image {s t : set P1} (f : P1 →ᵃ[k] P2) :
   (f '' s) -ᵥ (f '' t) = f.linear '' (s -ᵥ t) :=
 begin
   ext v,
-  suffices : (∃ x, x ∈ s ∧ ∃ y, y ∈ t ∧ f.linear (x -ᵥ y) = v) ↔
-             ∃ w, (∃ x, x ∈ s ∧ ∃ y, y ∈ t ∧ x -ᵥ y = w) ∧ f.linear w = v,
-  { simp [this, -linear_map_vsub, ← f.linear_map_vsub], },
+  simp only [set.mem_vsub, set.mem_image, exists_exists_and_eq_and, exists_and_distrib_left,
+    ← f.linear_map_vsub],
   split,
   { rintros ⟨x, hx, y, hy, hv⟩,
     exact ⟨x -ᵥ y, ⟨x, hx, y, hy, rfl⟩, hv⟩, },

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 -/
-import linear_algebra.affine_space.basic
+import linear_algebra.affine_space.affine_equiv
 import linear_algebra.tensor_product
 import data.set.intervals.unordered_interval
 
@@ -1175,3 +1175,44 @@ begin
 end
 
 end affine_subspace
+
+section maps
+
+variables {k V₁ P₁ V₂ P₂ : Type*} [ring k]
+variables [add_comm_group V₁] [module k V₁] [add_torsor V₁ P₁]
+variables [add_comm_group V₂] [module k V₂] [add_torsor V₂ P₂]
+include V₁ V₂
+
+namespace affine_map
+
+lemma vector_span_image_eq_submodule_map {s : set P₁} (f : P₁ →ᵃ[k] P₂) :
+  vector_span k (f '' s) = submodule.map f.linear (vector_span k s) :=
+by simp [vector_span_def]
+
+lemma span_eq_top_of_surjective {s : set P₁} (f : P₁ →ᵃ[k] P₂)
+  (hf : function.surjective f) (h : affine_span k s = ⊤) :
+  affine_span k (f '' s) = ⊤ :=
+begin
+  cases s.eq_empty_or_nonempty with hs hs,
+  { exfalso,
+    rw [hs, affine_subspace.span_empty] at h,
+    exact bot_ne_top h, },
+  { rw [← f.surjective_iff_linear_surjective, ← linear_map.range_eq_top] at hf,
+    rw affine_subspace.affine_span_eq_top_iff_vector_span_eq_top_of_nonempty k V₁ P₁ hs at h,
+    rw [affine_subspace.affine_span_eq_top_iff_vector_span_eq_top_of_nonempty k V₂ P₂ (hs.image f),
+      f.vector_span_image_eq_submodule_map, h, submodule.map_top, hf], },
+end
+
+end affine_map
+
+lemma affine_equiv.span_eq_top_iff {s : set P₁} (e : P₁ ≃ᵃ[k] P₂) :
+  affine_span k s = ⊤ ↔ affine_span k (e '' s) = ⊤ :=
+begin
+  refine ⟨(e : P₁ →ᵃ[k] P₂).span_eq_top_of_surjective e.surjective, _⟩,
+  intros h,
+  have : s = e.symm '' (e '' s), { simp [← image_comp], },
+  rw this,
+  exact (e.symm : P₂ →ᵃ[k] P₁).span_eq_top_of_surjective e.symm.surjective h,
+end
+
+end maps

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -1187,7 +1187,7 @@ variables (f : P₁ →ᵃ[k] P₂)
 
 @[simp] lemma affine_map.vector_span_image_eq_submodule_map {s : set P₁} :
   submodule.map f.linear (vector_span k s) = vector_span k (f '' s) :=
-by simp [vector_span_def]
+by simp [f.image_vsub_image, vector_span_def]
 
 namespace affine_subspace
 

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -181,6 +181,9 @@ include V
 instance : has_coe (affine_subspace k P) (set P) := ⟨carrier⟩
 instance : has_mem P (affine_subspace k P) := ⟨λ p s, p ∈ (s : set P)⟩
 
+instance : set_like (affine_subspace k P) P :=
+⟨affine_subspace.carrier, λ p q h, by cases p; cases q; congr'⟩
+
 /-- A point is in an affine subspace coerced to a set if and only if
 it is in that affine subspace. -/
 @[simp] lemma mem_coe (p : P) (s : affine_subspace k P) :
@@ -1225,13 +1228,13 @@ end affine_subspace
 
 namespace affine_map
 
+@[simp] lemma map_top_of_surjective (hf : function.surjective f) : affine_subspace.map f ⊤ = ⊤ :=
+set_like.coe_injective $ image_univ_of_surjective hf
+
 lemma span_eq_top_of_surjective {s : set P₁}
   (hf : function.surjective f) (h : affine_span k s = ⊤) :
   affine_span k (f '' s) = ⊤ :=
-begin
-  rw [← affine_subspace.map_span, h, ← affine_subspace.ext_iff],
-  exact image_univ_of_surjective hf,
-end
+by rw [← affine_subspace.map_span, h, map_top_of_surjective f hf]
 
 end affine_map
 

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -178,11 +178,9 @@ variables (k : Type*) {V : Type*} (P : Type*) [ring k] [add_comm_group V] [modul
           [affine_space V P]
 include V
 
+-- TODO Refactor to use `instance : set_like (affine_subspace k P) P :=` instead
 instance : has_coe (affine_subspace k P) (set P) := ⟨carrier⟩
 instance : has_mem P (affine_subspace k P) := ⟨λ p s, p ∈ (s : set P)⟩
-
-instance : set_like (affine_subspace k P) P :=
-⟨affine_subspace.carrier, λ p q h, by cases p; cases q; congr'⟩
 
 /-- A point is in an affine subspace coerced to a set if and only if
 it is in that affine subspace. -/
@@ -1229,7 +1227,10 @@ end affine_subspace
 namespace affine_map
 
 @[simp] lemma map_top_of_surjective (hf : function.surjective f) : affine_subspace.map f ⊤ = ⊤ :=
-set_like.coe_injective $ image_univ_of_surjective hf
+begin
+  rw ← affine_subspace.ext_iff,
+  exact image_univ_of_surjective hf,
+end
 
 lemma span_eq_top_of_surjective {s : set P₁}
   (hf : function.surjective f) (h : affine_span k s = ⊤) :


### PR DESCRIPTION
Together with supporting lemmas.

Formalized as part of the Sphere Eversion project.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
