### PR TITLE
[Merged by Bors] - refactor(algebra/group_power/order): relax linearity condition on `one_lt_pow`

### DIFF
--- a/archive/imo/imo2013_q5.lean
+++ b/archive/imo/imo2013_q5.lean
@@ -158,7 +158,7 @@ lemma fixed_point_of_pos_nat_pow {f : ℚ → ℝ} {n : ℕ} (hn : 0 < n)
   f (a^n) = a^n :=
 begin
   have hh0 : (a : ℝ) ^ n ≤ f (a ^ n),
-  { exact_mod_cast H5 (a ^ n) (one_lt_pow ha1 (nat.succ_le_iff.mpr hn)) },
+  { exact_mod_cast H5 (a ^ n) (one_lt_pow ha1 hn.ne') },
 
   have hh1 := calc f (a^n) ≤ (f a)^n   : pow_f_le_f_pow hn ha1 H1 H4
                        ... = (a : ℝ)^n : by rw ← hae,

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -184,22 +184,9 @@ abs_fpow_even _ (even_bit0 _)
 
 end ordered_field_power
 
-lemma one_lt_pow {K} [linear_ordered_semiring K] {p : K} (hp : 1 < p) : ∀ {n : ℕ}, 1 ≤ n → 1 < p ^ n
-| 1 h := by simp; assumption
-| (k+2) h :=
-  begin
-    rw [←one_mul (1 : K), pow_succ],
-    apply mul_lt_mul,
-    { assumption },
-    { apply le_of_lt, simpa using one_lt_pow (nat.le_add_left 1 k)},
-    { apply zero_lt_one },
-    { apply le_of_lt (lt_trans zero_lt_one hp) }
-  end
-
-lemma one_lt_fpow {K}  [linear_ordered_field K] {p : K} (hp : 1 < p) :
+lemma one_lt_fpow {K} [linear_ordered_field K] {p : K} (hp : 1 < p) :
   ∀ z : ℤ, 0 < z → 1 < p ^ z
-| (n : ℕ) h := by { rw [gpow_coe_nat],
-    exact one_lt_pow hp (nat.succ_le_of_lt (int.lt_of_coe_nat_lt_coe_nat h)) }
+| (n : ℕ) h := (gpow_coe_nat p n).symm.subst (one_lt_pow hp $ int.coe_nat_ne_zero.mp h.ne')
 | -[1+ n] h := ((int.neg_succ_not_pos _).mp h).elim
 
 section ordered

--- a/src/algebra/group_power/order.lean
+++ b/src/algebra/group_power/order.lean
@@ -193,6 +193,16 @@ lemma pow_lt_pow_iff {a : R} {n m : ℕ} (h : 1 < a) : a ^ n < a ^ m ↔ n < m :
 | (k+1) := by { rw [pow_succ, pow_succ],
     exact mul_le_mul hab (pow_le_pow_of_le_left _) (pow_nonneg ha _) (le_trans ha hab) }
 
+lemma one_lt_pow [nontrivial R] {p : R} (hp : 1 < p) :
+  ∀ {n : ℕ}, n ≠ 0 → 1 < p ^ n
+| 0       h := (h rfl).elim
+| 1       h := (pow_one p).symm.subst hp
+| (n + 2) h :=
+  begin
+    rw [←one_mul (1 : R), pow_succ],
+    exact mul_lt_mul hp (one_lt_pow (nat.succ_ne_zero _)).le zero_lt_one (zero_lt_one.trans hp).le,
+  end
+
 end ordered_semiring
 
 section linear_ordered_semiring

--- a/src/number_theory/liouville/liouville_constant.lean
+++ b/src/number_theory/liouville/liouville_constant.lean
@@ -174,7 +174,7 @@ begin
   intro n,
   -- the first `n` terms sum to `p / m ^ k!`
   rcases liouville_number_rat_initial_terms (zero_lt_two.trans_le hm) n with ⟨p, hp⟩,
-  refine ⟨p, m ^ n!, one_lt_pow mZ1 n.factorial_pos, _⟩,
+  refine ⟨p, m ^ n!, one_lt_pow mZ1 n.factorial_ne_zero, _⟩,
   push_cast,
   -- separate out the sum of the first `n` terms and the rest
   rw [liouville_number_eq_initial_terms_add_tail m1 n,


### PR DESCRIPTION
`[linear_ordered_semiring R]` becomes `[ordered_semiring R] [nontrivial R]`. I also golf the proof and move ìt from `algebra.field_power` to `algebra.group_power.order`, where it belongs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
