### PR TITLE
[Merged by Bors] - feat(data/real/pointwise): Inf and Sup of `a • s` for `s : set ℝ`

### DIFF
--- a/src/algebra/module/ordered.lean
+++ b/src/algebra/module/ordered.lean
@@ -151,7 +151,7 @@ end
 variables (M)
 
 /-- Left scalar multiplication as an order isomorphism. -/
-@[simps] def order_iso.smul_left_dual {c : k} (hc : c < 0) : order_dual M ≃o M :=
+@[simps] def order_iso.smul_left_dual {c : k} (hc : c < 0) : M ≃o order_dual M :=
 { to_fun := λ b, c • b,
   inv_fun := λ b, c⁻¹ • b,
   left_inv := inv_smul_smul₀ hc.ne,
@@ -249,16 +249,16 @@ section module
 variables [module k M] [ordered_smul k M] {s t : set M} {c : k}
 
 @[simp] lemma lower_bounds_smul_of_neg (hc : c < 0) : lower_bounds (c • s) = c • upper_bounds s :=
-(order_iso.smul_left_dual M hc).lower_bounds_image
-
-@[simp] lemma upper_bounds_smul_of_neg (hc : c < 0) : upper_bounds (c • s) = c • lower_bounds s :=
 (order_iso.smul_left_dual M hc).upper_bounds_image
 
+@[simp] lemma upper_bounds_smul_of_neg (hc : c < 0) : upper_bounds (c • s) = c • lower_bounds s :=
+(order_iso.smul_left_dual M hc).lower_bounds_image
+
 @[simp] lemma bdd_below_smul_iff_of_neg (hc : c < 0) : bdd_below (c • s) ↔ bdd_above s :=
-(order_iso.smul_left_dual M hc).bdd_below_image
+(order_iso.smul_left_dual M hc).bdd_above_image
 
 @[simp] lemma bdd_above_smul_iff_of_neg (hc : c < 0) : bdd_above (c • s) ↔ bdd_below s :=
-(order_iso.smul_left_dual M hc).bdd_above_image
+(order_iso.smul_left_dual M hc).bdd_below_image
 
 end module
 end linear_ordered_field

--- a/src/algebra/module/ordered.lean
+++ b/src/algebra/module/ordered.lean
@@ -20,11 +20,6 @@ In this file we provide lemmas about `ordered_smul` that hold once a module stru
 
 * https://en.wikipedia.org/wiki/Ordered_module
 
-## TODO
-
-`lower_bounds_smul_of_neg` and similar aren't proved as seamlessly as their positive counterparts.
-Maybe that shows the lemmas aren't general enough?
-
 ## Tags
 
 ordered module, ordered scalar, ordered smul, ordered action, ordered vector space
@@ -153,15 +148,17 @@ begin
   exact lt_smul_iff_of_pos (neg_pos_of_neg hc),
 end
 
+variables (M)
+
 /-- Left scalar multiplication as an order isomorphism. -/
-@[simps] def order_iso.smul_left_dual {c : k} (hc : c < 0) : M ≃o order_dual M :=
+@[simps] def order_iso.smul_left_dual {c : k} (hc : c < 0) : order_dual M ≃o M :=
 { to_fun := λ b, c • b,
   inv_fun := λ b, c⁻¹ • b,
   left_inv := inv_smul_smul₀ hc.ne,
   right_inv := smul_inv_smul₀ hc.ne,
   map_rel_iff' := λ b₁ b₂, smul_le_smul_iff_of_neg hc }
 
-variables [ordered_add_comm_group N] [module k N] [ordered_smul k N]
+variables {M} [ordered_add_comm_group N] [module k N] [ordered_smul k N]
 
 -- TODO: solve `prod.has_lt` and `prod.has_le` misalignment issue
 instance prod.ordered_smul : ordered_smul k (M × N) :=
@@ -200,12 +197,10 @@ lemma smul_upper_bounds_subset_upper_bounds_smul (hc : 0 ≤ c) :
   c • upper_bounds s ⊆ upper_bounds (c • s) :=
 (monotone_smul_left hc).image_upper_bounds_subset_upper_bounds_image
 
-lemma bdd_below.smul_of_nonneg (hs : bdd_below s) (hc : 0 ≤ c) :
-  bdd_below (c • s) :=
+lemma bdd_below.smul_of_nonneg (hs : bdd_below s) (hc : 0 ≤ c) : bdd_below (c • s) :=
 (monotone_smul_left hc).map_bdd_below hs
 
-lemma bdd_above.smul_of_nonneg (hs : bdd_above s) (hc : 0 ≤ c) :
-  bdd_above (c • s) :=
+lemma bdd_above.smul_of_nonneg (hs : bdd_above s) (hc : 0 ≤ c) : bdd_above (c • s) :=
 (monotone_smul_left hc).map_bdd_above hs
 
 end ordered_semiring
@@ -222,12 +217,10 @@ lemma smul_upper_bounds_subset_lower_bounds_smul (hc : c ≤ 0) :
   c • upper_bounds s ⊆ lower_bounds (c • s) :=
 (antitone_smul_left hc).image_upper_bounds_subset_lower_bounds_image
 
-lemma bdd_below.smul_of_nonpos (hc : c ≤ 0) (hs : bdd_below s) :
-  bdd_above (c • s) :=
+lemma bdd_below.smul_of_nonpos (hc : c ≤ 0) (hs : bdd_below s) : bdd_above (c • s) :=
 (antitone_smul_left hc).map_bdd_below hs
 
-lemma bdd_above.smul_of_nonpos (hc : c ≤ 0) (hs : bdd_above s) :
-  bdd_below (c • s) :=
+lemma bdd_above.smul_of_nonpos (hc : c ≤ 0) (hs : bdd_above s) : bdd_below (c • s) :=
 (antitone_smul_left hc).map_bdd_above hs
 
 end ordered_ring
@@ -238,60 +231,34 @@ variables [linear_ordered_field k] [ordered_add_comm_group M]
 section mul_action_with_zero
 variables [mul_action_with_zero k M] [ordered_smul k M] {s t : set M} {c : k}
 
-@[simp] lemma lower_bounds_smul_of_pos (hc : 0 < c) :
-  lower_bounds (c • s) = c • lower_bounds s :=
-(order_iso.smul_left hc).lower_bounds_image
+@[simp] lemma lower_bounds_smul_of_pos (hc : 0 < c) : lower_bounds (c • s) = c • lower_bounds s :=
+(order_iso.smul_left _ hc).lower_bounds_image
 
-@[simp] lemma upper_bounds_smul_of_pos (hc : 0 < c) :
-  upper_bounds (c • s) = c • upper_bounds s :=
-(order_iso.smul_left hc).upper_bounds_image
+@[simp] lemma upper_bounds_smul_of_pos (hc : 0 < c) : upper_bounds (c • s) = c • upper_bounds s :=
+(order_iso.smul_left _ hc).upper_bounds_image
 
-@[simp] lemma bdd_below_smul_iff_of_pos (hc : 0 < c) :
-  bdd_below (c • s) ↔ bdd_below s :=
-(order_iso.smul_left hc).bdd_below_image
+@[simp] lemma bdd_below_smul_iff_of_pos (hc : 0 < c) : bdd_below (c • s) ↔ bdd_below s :=
+(order_iso.smul_left _ hc).bdd_below_image
 
-@[simp] lemma bdd_above_smul_iff_of_pos (hc : 0 < c) :
-  bdd_above (c • s) ↔ bdd_above s :=
-(order_iso.smul_left hc).bdd_above_image
+@[simp] lemma bdd_above_smul_iff_of_pos (hc : 0 < c) : bdd_above (c • s) ↔ bdd_above s :=
+(order_iso.smul_left _ hc).bdd_above_image
 
 end mul_action_with_zero
 
 section module
 variables [module k M] [ordered_smul k M] {s t : set M} {c : k}
 
-@[simp] lemma lower_bounds_smul_of_neg (hc : c < 0) :
-  lower_bounds (c • s) = c • upper_bounds s :=
-begin
-  refine set.subset.antisymm _ (smul_upper_bounds_subset_lower_bounds_smul hc.le),
-  have h : c⁻¹ • lower_bounds (c • s) ⊆ upper_bounds (c⁻¹ • c • s) :=
-    smul_lower_bounds_subset_upper_bounds_smul (inv_nonpos.2 hc.le),
-  rwa [←subset_set_smul_iff₀ hc.ne, inv_smul_smul₀ hc.ne] at h,
-end
+@[simp] lemma lower_bounds_smul_of_neg (hc : c < 0) : lower_bounds (c • s) = c • upper_bounds s :=
+(order_iso.smul_left_dual M hc).lower_bounds_image
 
-@[simp] lemma upper_bounds_smul_of_neg (hc : c < 0) :
-  upper_bounds (c • s) = c • lower_bounds s :=
-begin
-  refine set.subset.antisymm _ (smul_lower_bounds_subset_upper_bounds_smul hc.le),
-  have h : c⁻¹ • upper_bounds (c • s) ⊆ lower_bounds (c⁻¹ • c • s) :=
-    smul_upper_bounds_subset_lower_bounds_smul (inv_nonpos.2 hc.le),
-  rwa [←subset_set_smul_iff₀ hc.ne, inv_smul_smul₀ hc.ne] at h,
-end
+@[simp] lemma upper_bounds_smul_of_neg (hc : c < 0) : upper_bounds (c • s) = c • lower_bounds s :=
+(order_iso.smul_left_dual M hc).upper_bounds_image
 
-@[simp] lemma bdd_below_smul_iff_of_neg (hc : c < 0) :
-  bdd_below (c • s) ↔ bdd_above s :=
-begin
-  refine ⟨λ h, _, bdd_above.smul_of_nonpos hc.le⟩,
-  rw ←inv_smul_smul₀ hc.ne s,
-  exact h.smul_of_nonpos (inv_nonpos.2 hc.le),
-end
+@[simp] lemma bdd_below_smul_iff_of_neg (hc : c < 0) : bdd_below (c • s) ↔ bdd_above s :=
+(order_iso.smul_left_dual M hc).bdd_below_image
 
-@[simp] lemma bdd_above_smul_iff_of_neg (hc : c < 0) :
-  bdd_above (c • s) ↔ bdd_below s :=
-begin
-  refine ⟨λ h, _, bdd_below.smul_of_nonpos hc.le⟩,
-  rw ←inv_smul_smul₀ hc.ne s,
-  exact h.smul_of_nonpos (inv_nonpos.2 hc.le),
-end
+@[simp] lemma bdd_above_smul_iff_of_neg (hc : c < 0) : bdd_above (c • s) ↔ bdd_below s :=
+(order_iso.smul_left_dual M hc).bdd_above_image
 
 end module
 end linear_ordered_field

--- a/src/algebra/order/smul.lean
+++ b/src/algebra/order/smul.lean
@@ -198,6 +198,8 @@ lemma le_smul_iff_of_pos (hc : 0 < c) : a ≤ c • b ↔ c⁻¹ • a ≤ b :=
 calc a ≤ c • b ↔ c • c⁻¹ • a ≤ c • b : by rw [smul_inv_smul₀ hc.ne']
 ... ↔ c⁻¹ • a ≤ b : smul_le_smul_iff_of_pos hc
 
+variables (M)
+
 /-- Left scalar multiplication as an order isomorphism. -/
 @[simps] def order_iso.smul_left {c : k} (hc : 0 < c) : M ≃o M :=
 { to_fun := λ b, c • b,

--- a/src/data/real/pointwise.lean
+++ b/src/data/real/pointwise.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2021 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import algebra.module.ordered
+import algebra.pointwise
+import data.real.basic
+
+/-!
+# Pointwise operations on sets of reals
+
+This file relates `Inf (a • s)`/`Sup (a • s)` with `a • Inf s`/`a • Sup s` for `s : set ℝ`.
+
+# TODO
+
+This is true more generally for conditionally complete linear order whose default value is `0`. We
+don't have those yet.
+-/
+
+open set
+open_locale pointwise
+
+variables {α : Type*} [linear_ordered_field α]
+
+section mul_action_with_zero
+variables [mul_action_with_zero α ℝ] [ordered_smul α ℝ] {a : α}
+
+lemma real.Inf_smul_of_nonneg (ha : 0 ≤ a) (s : set ℝ) : Inf (a • s) = a • Inf s :=
+begin
+  obtain rfl | hs := s.eq_empty_or_nonempty,
+  { rw [smul_set_empty, real.Inf_empty, smul_zero'] },
+  obtain rfl | ha' := ha.eq_or_lt,
+  { rw [zero_smul_set hs, zero_smul],
+    exact cInf_singleton 0 },
+  by_cases bdd_below s,
+  { rw ←order_iso.smul_left_apply ℝ ha',
+    exact ((order_iso.smul_left ℝ ha').map_cInf' hs h).symm },
+  { rw [real.Inf_of_not_bdd_below (mt (bdd_below_smul_iff_of_pos ha').1 h),
+      real.Inf_of_not_bdd_below h, smul_zero'] }
+end
+
+lemma real.Sup_smul_of_nonneg (ha : 0 ≤ a) (s : set ℝ) : Sup (a • s) = a • Sup s :=
+begin
+  obtain rfl | hs := s.eq_empty_or_nonempty,
+  { rw [smul_set_empty, real.Sup_empty, smul_zero'] },
+  obtain rfl | ha' := ha.eq_or_lt,
+  { rw [zero_smul_set hs, zero_smul],
+    exact cSup_singleton 0 },
+  by_cases bdd_above s,
+  { rw [←order_iso.smul_left_apply _ ha'],
+    exact ((order_iso.smul_left ℝ ha').map_cSup' hs h).symm },
+  { rw [real.Sup_of_not_bdd_above (mt (bdd_above_smul_iff_of_pos ha').1 h),
+      real.Sup_of_not_bdd_above h, smul_zero'] }
+end
+
+end mul_action_with_zero
+
+section module
+variables [module α ℝ] [ordered_smul α ℝ] {a : α}
+
+lemma real.Inf_smul_of_nonpos (ha : a ≤ 0) (s : set ℝ) : Inf (a • s) = a • Sup s :=
+begin
+  obtain rfl | hs := s.eq_empty_or_nonempty,
+  { rw [smul_set_empty, real.Inf_empty, real.Sup_empty, smul_zero'] },
+  obtain rfl | ha' := ha.eq_or_lt,
+  { rw [zero_smul_set hs, zero_smul],
+    exact cInf_singleton 0 },
+  by_cases bdd_above s,
+  { rw [←order_iso.smul_left_dual_apply ℝ ha'],
+    exact ((order_iso.smul_left_dual ℝ ha').map_cInf' hs h).symm },
+  { rw [real.Inf_of_not_bdd_below (mt (bdd_below_smul_iff_of_neg ha').1 h),
+      real.Sup_of_not_bdd_above h, smul_zero'] }
+end
+
+lemma real.Sup_smul_of_nonpos (ha : a ≤ 0) (s : set ℝ) : Sup (a • s) = a • Inf s :=
+begin
+  obtain rfl | hs := s.eq_empty_or_nonempty,
+  { rw [smul_set_empty, real.Sup_empty, real.Inf_empty, smul_zero] },
+  obtain rfl | ha' := ha.eq_or_lt,
+  { rw [zero_smul_set hs, zero_smul],
+    exact cSup_singleton 0 },
+  by_cases bdd_below s,
+  { rw [←order_iso.smul_left_dual_apply ℝ ha'],
+    exact ((order_iso.smul_left_dual ℝ ha').map_cSup' hs h).symm },
+  { rw [real.Sup_of_not_bdd_above (mt (bdd_above_smul_iff_of_neg ha').1 h),
+      real.Inf_of_not_bdd_below h, smul_zero] }
+end
+
+end module

--- a/src/data/real/pointwise.lean
+++ b/src/data/real/pointwise.lean
@@ -34,8 +34,7 @@ begin
   { rw [zero_smul_set hs, zero_smul],
     exact cInf_singleton 0 },
   by_cases bdd_below s,
-  { rw ←order_iso.smul_left_apply ℝ ha',
-    exact ((order_iso.smul_left ℝ ha').map_cInf' hs h).symm },
+  { exact ((order_iso.smul_left ℝ ha').map_cInf' hs h).symm },
   { rw [real.Inf_of_not_bdd_below (mt (bdd_below_smul_iff_of_pos ha').1 h),
       real.Inf_of_not_bdd_below h, smul_zero'] }
 end
@@ -48,8 +47,7 @@ begin
   { rw [zero_smul_set hs, zero_smul],
     exact cSup_singleton 0 },
   by_cases bdd_above s,
-  { rw [←order_iso.smul_left_apply _ ha'],
-    exact ((order_iso.smul_left ℝ ha').map_cSup' hs h).symm },
+  { exact ((order_iso.smul_left ℝ ha').map_cSup' hs h).symm },
   { rw [real.Sup_of_not_bdd_above (mt (bdd_above_smul_iff_of_pos ha').1 h),
       real.Sup_of_not_bdd_above h, smul_zero'] }
 end
@@ -67,8 +65,7 @@ begin
   { rw [zero_smul_set hs, zero_smul],
     exact cInf_singleton 0 },
   by_cases bdd_above s,
-  { rw [←order_iso.smul_left_dual_apply ℝ ha'],
-    exact ((order_iso.smul_left_dual ℝ ha').map_cInf' hs h).symm },
+  { exact ((order_iso.smul_left_dual ℝ ha').map_cSup' hs h).symm },
   { rw [real.Inf_of_not_bdd_below (mt (bdd_below_smul_iff_of_neg ha').1 h),
       real.Sup_of_not_bdd_above h, smul_zero'] }
 end
@@ -81,8 +78,7 @@ begin
   { rw [zero_smul_set hs, zero_smul],
     exact cSup_singleton 0 },
   by_cases bdd_below s,
-  { rw [←order_iso.smul_left_dual_apply ℝ ha'],
-    exact ((order_iso.smul_left_dual ℝ ha').map_cSup' hs h).symm },
+  { exact ((order_iso.smul_left_dual ℝ ha').map_cInf' hs h).symm },
   { rw [real.Sup_of_not_bdd_above (mt (bdd_above_smul_iff_of_neg ha').1 h),
       real.Inf_of_not_bdd_below h, smul_zero] }
 end


### PR DESCRIPTION
This relates `Inf (a • s)`/`Sup (a • s)` with `a • Inf s`/`a • Sup s` for `s : set ℝ`.

---
- [x] depends on: #9706

I expect this new file to be temporary as the lemmas hold more generally in a conditionally complete linear order whose default value is `0`. @urkud is planning on adding those.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
