### PR TITLE
[Merged by Bors] - feat(order/succ_pred): `succ`-Archimedean orders

### DIFF
--- a/src/logic/function/iterate.lean
+++ b/src/logic/function/iterate.lean
@@ -144,8 +144,7 @@ def iterate.rec (p : α → Sort*) {f : α → α} (h : ∀ a, p a → p (f a)) 
   p (f^[n] a) :=
 nat.rec ha (λ m, by { rw iterate_succ', exact h _ }) n
 
-lemma iterate.rec_zero (p : α → Sort*) {f : α → α} (h : ∀ a, p a → p (f a)) {a : α} (ha : p a)
-  (n : ℕ) :
+lemma iterate.rec_zero (p : α → Sort*) {f : α → α} (h : ∀ a, p a → p (f a)) {a : α} (ha : p a) :
   iterate.rec p h ha 0 = ha :=
 rfl
 

--- a/src/logic/function/iterate.lean
+++ b/src/logic/function/iterate.lean
@@ -139,6 +139,16 @@ by rw [← iterate_succ, nat.succ_pred_eq_of_pos hn]
 theorem comp_iterate_pred_of_pos {n : ℕ} (hn : 0 < n) : f ∘ (f^[n.pred]) = (f^[n]) :=
 by rw [← iterate_succ', nat.succ_pred_eq_of_pos hn]
 
+/-- A recursor for the iterate of a function. -/
+def iterate.rec (p : α → Sort*) {f : α → α} (h : ∀ a, p a → p (f a)) {a : α} (ha : p a) (n : ℕ) :
+  p (f^[n] a) :=
+nat.rec ha (λ m, by { rw iterate_succ', exact h _ }) n
+
+lemma iterate.rec_zero (p : α → Sort*) {f : α → α} (h : ∀ a, p a → p (f a)) {a : α} (ha : p a)
+  (n : ℕ) :
+  iterate.rec p h ha 0 = ha :=
+rfl
+
 variable {f}
 
 theorem left_inverse.iterate {g : α → α} (hg : left_inverse g f) (n : ℕ) :

--- a/src/order/succ_pred.lean
+++ b/src/order/succ_pred.lean
@@ -799,9 +799,6 @@ variables [pred_order α] [is_pred_archimedean α] {a b : α}
 lemma has_le.le.exists_pred_iterate (h : a ≤ b) : ∃ n, pred^[n] b = a :=
 exists_pred_iterate_of_le h
 
-instance : is_succ_archimedean (order_dual α) :=
-{ exists_succ_iterate_of_le := λ a b h, by convert @exists_pred_iterate_of_le α _ _ _ _ _ h }
-
 lemma pred.rec {p : α → Prop} (hsucc : ∀ a, p a → p (pred a)) {a b : α} (h : b ≤ a) (ha : p a) :
   p b :=
 @succ.rec (order_dual α) _ _ _ _ hsucc _ _ h ha
@@ -809,6 +806,9 @@ lemma pred.rec {p : α → Prop} (hsucc : ∀ a, p a → p (pred a)) {a b : α} 
 lemma pred.rec_iff {p : α → Prop} (hsucc : ∀ a, p a ↔ p (pred a)) {a b : α} (h : a ≤ b) :
   p a ↔ p b :=
 (@succ.rec_iff (order_dual α) _ _ _ _ hsucc _ _ h).symm
+
+instance : is_succ_archimedean (order_dual α) :=
+{ exists_succ_iterate_of_le := λ a b h, by convert @exists_pred_iterate_of_le α _ _ _ _ _ h }
 
 end pred_order
 end preorder

--- a/src/order/succ_pred.lean
+++ b/src/order/succ_pred.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies
 -/
 import order.bounded_lattice
 import order.galois_connection
+import order.iterate
 import tactic.monotonicity
 
 /-!
@@ -19,6 +20,10 @@ order...
 
 * `succ_order`: Order equipped with a sensible successor function.
 * `pred_order`: Order equipped with a sensible predecessor function.
+* `is_succ_archimedean`: `succ_order` where `succ` iterated to an element gives all the greater
+  ones.
+* `is_pred_archimedean`: `pred_order` where `pred` iterated to an element gives all the greater
+  ones.
 
 ## Implementation notes
 
@@ -737,3 +742,115 @@ instance pred_order_of_no_bot [partial_order α] [no_bot_order α] [pred_order �
   end }
 
 end with_bot
+
+/-! ### Archimedeanness -/
+
+/-- A `succ_order` is succ-archimedean if one can go from any two comparable elements by iterating
+`succ` -/
+class is_succ_archimedean (α : Type*) [preorder α] [succ_order α] : Prop :=
+(exists_succ_iterate_of_le {a b : α} (h : a ≤ b) : ∃ n, succ^[n] a = b)
+
+/-- A `pred_order` is pred-archimedean if one can go from any two comparable elements by iterating
+`pred` -/
+class is_pred_archimedean (α : Type*) [preorder α] [pred_order α] : Prop :=
+(exists_pred_iterate_of_le {a b : α} (h : a ≤ b) : ∃ n, pred^[n] b = a)
+
+export is_succ_archimedean (exists_succ_iterate_of_le)
+export is_pred_archimedean (exists_pred_iterate_of_le)
+
+section preorder
+variables [preorder α]
+
+section succ_order
+variables [succ_order α] [is_succ_archimedean α] {a b : α}
+
+lemma has_le.le.exists_succ_iterate (h : a ≤ b) : ∃ n, succ^[n] a = b :=
+exists_succ_iterate_of_le h
+
+lemma exists_succ_iterate_iff_le : (∃ n, succ^[n] a = b) ↔ a ≤ b :=
+begin
+  refine ⟨_, exists_succ_iterate_of_le⟩,
+  rintro ⟨n, rfl⟩,
+  exact id_le_iterate_of_id_le le_succ n a,
+end
+
+lemma succ.rec {p : α → Prop} (hsucc : ∀ a, p a → p (succ a)) {a b : α} (h : a ≤ b) (ha : p a) :
+  p b :=
+begin
+  obtain ⟨n, rfl⟩ := h.exists_succ_iterate,
+  exact iterate.rec _ hsucc ha n,
+end
+
+lemma succ.rec_iff {p : α → Prop} (hsucc : ∀ a, p a ↔ p (succ a)) {a b : α} (h : a ≤ b) :
+  p a ↔ p b :=
+begin
+  obtain ⟨n, rfl⟩ := h.exists_succ_iterate,
+  exact iterate.rec (λ b, p a ↔ p b) (λ c hc, hc.trans (hsucc _)) iff.rfl n,
+end
+
+instance : is_pred_archimedean (order_dual α) :=
+{ exists_pred_iterate_of_le := λ a b h, by convert @exists_succ_iterate_of_le α _ _ _ _ _ h }
+
+end succ_order
+
+section pred_order
+variables [pred_order α] [is_pred_archimedean α] {a b : α}
+
+lemma has_le.le.exists_pred_iterate (h : a ≤ b) : ∃ n, pred^[n] b = a :=
+exists_pred_iterate_of_le h
+
+instance : is_succ_archimedean (order_dual α) :=
+{ exists_succ_iterate_of_le := λ a b h, by convert @exists_pred_iterate_of_le α _ _ _ _ _ h }
+
+lemma pred.rec {p : α → Prop} (hsucc : ∀ a, p a → p (pred a)) {a b : α} (h : b ≤ a) (ha : p a) :
+  p b :=
+@succ.rec (order_dual α) _ _ _ _ hsucc _ _ h ha
+
+lemma pred.rec_iff {p : α → Prop} (hsucc : ∀ a, p a ↔ p (pred a)) {a b : α} (h : a ≤ b) :
+  p a ↔ p b :=
+(@succ.rec_iff (order_dual α) _ _ _ _ hsucc _ _ h).symm
+
+end pred_order
+end preorder
+
+section linear_order
+variables [linear_order α]
+
+section succ_order
+variables [succ_order α] [is_succ_archimedean α] {a b : α}
+
+lemma exists_succ_iterate_or : (∃ n, succ^[n] a = b) ∨ ∃ n, succ^[n] b = a :=
+(le_total a b).imp exists_succ_iterate_of_le exists_succ_iterate_of_le
+
+lemma succ.rec_linear {p : α → Prop} (hsucc : ∀ a, p a ↔ p (succ a)) (a b : α) : p a ↔ p b :=
+(le_total a b).elim (succ.rec_iff hsucc) (λ h, (succ.rec_iff hsucc h).symm)
+
+end succ_order
+
+section pred_order
+variables [pred_order α] [is_pred_archimedean α] {a b : α}
+
+lemma exists_pred_iterate_or : (∃ n, pred^[n] b = a) ∨ ∃ n, pred^[n] a = b :=
+(le_total a b).imp exists_pred_iterate_of_le exists_pred_iterate_of_le
+
+lemma pred.rec_linear {p : α → Prop} (hsucc : ∀ a, p a ↔ p (pred a)) (a b : α) : p a ↔ p b :=
+(le_total a b).elim (pred.rec_iff hsucc) (λ h, (pred.rec_iff hsucc h).symm)
+
+end pred_order
+end linear_order
+
+section order_bot
+variables [order_bot α] [succ_order α] [is_succ_archimedean α]
+
+lemma succ.rec_bot (p : α → Prop) (hbot : p ⊥) (hsucc : ∀ a, p a → p (succ a)) (a : α) : p a :=
+succ.rec hsucc bot_le hbot
+
+end order_bot
+
+section order_top
+variables [order_top α] [pred_order α] [is_pred_archimedean α]
+
+lemma pred.rec_top (p : α → Prop) (htop : p ⊤) (hpred : ∀ a, p a → p (pred a)) (a : α) : p a :=
+pred.rec hpred le_top htop
+
+end order_top

--- a/src/order/succ_pred.lean
+++ b/src/order/succ_pred.lean
@@ -764,6 +764,9 @@ variables [preorder α]
 section succ_order
 variables [succ_order α] [is_succ_archimedean α] {a b : α}
 
+instance : is_pred_archimedean (order_dual α) :=
+{ exists_pred_iterate_of_le := λ a b h, by convert @exists_succ_iterate_of_le α _ _ _ _ _ h }
+
 lemma has_le.le.exists_succ_iterate (h : a ≤ b) : ∃ n, succ^[n] a = b :=
 exists_succ_iterate_of_le h
 
@@ -788,16 +791,19 @@ begin
   exact iterate.rec (λ b, p a ↔ p b) (λ c hc, hc.trans (hsucc _)) iff.rfl n,
 end
 
-instance : is_pred_archimedean (order_dual α) :=
-{ exists_pred_iterate_of_le := λ a b h, by convert @exists_succ_iterate_of_le α _ _ _ _ _ h }
-
 end succ_order
 
 section pred_order
 variables [pred_order α] [is_pred_archimedean α] {a b : α}
 
+instance : is_succ_archimedean (order_dual α) :=
+{ exists_succ_iterate_of_le := λ a b h, by convert @exists_pred_iterate_of_le α _ _ _ _ _ h }
+
 lemma has_le.le.exists_pred_iterate (h : a ≤ b) : ∃ n, pred^[n] b = a :=
 exists_pred_iterate_of_le h
+
+lemma exists_pred_iterate_iff_le : (∃ n, pred^[n] b = a) ↔ a ≤ b :=
+@exists_succ_iterate_iff_le (order_dual α) _ _ _ _ _
 
 lemma pred.rec {p : α → Prop} (hsucc : ∀ a, p a → p (pred a)) {a b : α} (h : b ≤ a) (ha : p a) :
   p b :=
@@ -806,9 +812,6 @@ lemma pred.rec {p : α → Prop} (hsucc : ∀ a, p a → p (pred a)) {a b : α} 
 lemma pred.rec_iff {p : α → Prop} (hsucc : ∀ a, p a ↔ p (pred a)) {a b : α} (h : a ≤ b) :
   p a ↔ p b :=
 (@succ.rec_iff (order_dual α) _ _ _ _ hsucc _ _ h).symm
-
-instance : is_succ_archimedean (order_dual α) :=
-{ exists_succ_iterate_of_le := λ a b h, by convert @exists_pred_iterate_of_le α _ _ _ _ _ h }
 
 end pred_order
 end preorder


### PR DESCRIPTION
This defines `succ`-Archimedean orders: orders in which `a ≤ b` means that `succ^[n] a = b` for some `n`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
I am not terribly sure of the utility of `function.iterate.rec`, notably because of that ugly `rw`. It really feels like `nat.iterate` is the wrong way around...

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
