### PR TITLE
[Merged by Bors] - feat(data/int/succ_pred): `ℤ` is succ- and pred- archimedean

### DIFF
--- a/src/data/int/succ_pred.lean
+++ b/src/data/int/succ_pred.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2021 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import data.int.basic
+import order.succ_pred
+
+/-!
+# Successors and predecessors of integers
+
+In this file, we show that `ℤ` is both an archimedean `succ_order` and an archimedean `pred_order`.
+-/
+
+open function int
+
+@[reducible] -- so that Lean reads `int.succ` through `succ_order.succ`
+instance : succ_order ℤ :=
+{ succ := succ,
+  ..succ_order.of_succ_le_iff succ (λ a b, iff.rfl) }
+
+@[reducible] -- so that Lean reads `int.pred` through `pred_order.pred`
+instance : pred_order ℤ :=
+{ pred := pred,
+  pred_le := λ a, (sub_one_lt_of_le le_rfl).le,
+  minimal_of_le_pred := λ a ha, ((sub_one_lt_of_le le_rfl).not_le ha).elim,
+  le_pred_of_lt := λ a b, le_sub_one_of_lt,
+  le_of_pred_lt := λ a b, le_of_sub_one_lt }
+
+lemma int.succ_iterate (a : ℤ) : ∀ n, succ^[n] a = a + n
+| 0       := (add_zero a).symm
+| (n + 1) := by { rw [function.iterate_succ', int.coe_nat_succ, ←add_assoc],
+    exact congr_arg _ (int.succ_iterate n) }
+
+lemma int.pred_iterate (a : ℤ) : ∀ n, pred^[n] a = a - n
+| 0       := (sub_zero a).symm
+| (n + 1) := by { rw [function.iterate_succ', int.coe_nat_succ, ←sub_sub],
+    exact congr_arg _ (int.pred_iterate n) }
+
+instance : is_succ_archimedean ℤ :=
+⟨λ a b h, ⟨(b - a).to_nat,
+  by rw [int.succ_iterate, int.to_nat_sub_of_le h, ←add_sub_assoc, add_sub_cancel']⟩⟩
+
+instance : is_pred_archimedean ℤ :=
+⟨λ a b h, ⟨(b - a).to_nat, by rw [int.pred_iterate, int.to_nat_sub_of_le h, sub_sub_cancel]⟩⟩

--- a/src/order/succ_pred.lean
+++ b/src/order/succ_pred.lean
@@ -72,7 +72,7 @@ section preorder
 variables [preorder α]
 
 /-- A constructor for `succ_order α` usable when `α` has no maximal element. -/
-def succ_order_of_succ_le_iff_of_le_lt_succ (succ : α → α)
+def of_succ_le_iff_of_le_lt_succ (succ : α → α)
   (hsucc_le_iff : ∀ {a b}, succ a ≤ b ↔ a < b)
   (hle_of_lt_succ : ∀ {a b}, a < succ b → a ≤ b) :
   succ_order α :=
@@ -228,7 +228,7 @@ section linear_order
 variables [linear_order α]
 
 /-- A constructor for `succ_order α` usable when `α` is a linear order with no maximal element. -/
-def succ_order_of_succ_le_iff (succ : α → α) (hsucc_le_iff : ∀ {a b}, succ a ≤ b ↔ a < b) :
+def of_succ_le_iff (succ : α → α) (hsucc_le_iff : ∀ {a b}, succ a ≤ b ↔ a < b) :
   succ_order α :=
 { succ := succ,
   le_succ := λ a, (hsucc_le_iff.1 le_rfl).le,
@@ -268,7 +268,7 @@ section preorder
 variables [preorder α]
 
 /-- A constructor for `pred_order α` usable when `α` has no minimal element. -/
-def pred_order_of_le_pred_iff_of_pred_le_pred (pred : α → α)
+def of_le_pred_iff_of_pred_le_pred (pred : α → α)
   (hle_pred_iff : ∀ {a b}, a ≤ pred b ↔ a < b)
   (hle_of_pred_lt : ∀ {a b}, pred a < b → a ≤ b) :
   pred_order α :=
@@ -422,7 +422,7 @@ section linear_order
 variables [linear_order α]
 
 /-- A constructor for `pred_order α` usable when `α` is a linear order with no maximal element. -/
-def pred_order_of_le_pred_iff (pred : α → α) (hle_pred_iff : ∀ {a b}, a ≤ pred b ↔ a < b) :
+def of_le_pred_iff (pred : α → α) (hle_pred_iff : ∀ {a b}, a ≤ pred b ↔ a < b) :
   pred_order α :=
 { pred := pred,
   pred_le := λ a, (hle_pred_iff.1 le_rfl).le,
@@ -568,7 +568,7 @@ instance [order_top α] [pred_order α] : pred_order (with_top α) :=
 
 /-! #### Adding a `⊤` to a `no_top_order` -/
 
-instance succ_order_of_no_top [partial_order α] [no_top_order α] [succ_order α] :
+instance of_no_top [partial_order α] [no_top_order α] [succ_order α] :
   succ_order (with_top α) :=
 { succ := λ a, match a with
     | ⊤        := ⊤
@@ -710,7 +710,7 @@ instance [partial_order α] [no_bot_order α] [hα : nonempty α] :
     exact (le_of_lt_succ hc).not_lt (none_lt_some _) }
 end⟩
 
-instance pred_order_of_no_bot [partial_order α] [no_bot_order α] [pred_order α] :
+instance of_no_bot [partial_order α] [no_bot_order α] [pred_order α] :
   pred_order (with_bot α) :=
 { pred := λ a, match a with
     | ⊥        := ⊥


### PR DESCRIPTION
This provides the instances `succ_order ℤ`, `pred_order ℤ`, `is_succ_archimedean ℤ`, `is_pred_archimedean ℤ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
