### PR TITLE
[Merged by Bors] - refactor(ring_theory/fractional_ideal): speedup a proof

### DIFF
--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -1239,8 +1239,10 @@ begin
   let y' : units (fractional_ideal R₁⁰ K) := units.mk_of_mul_eq_one _ _ this,
   have coe_y' : ↑y' = span_singleton R₁⁰ (is_localization.mk' K 1 ⟨y, hy⟩) := rfl,
   refine iff.trans _ (y'.mul_right_inj.trans inj.eq_iff),
-  simp only [coe_ideal_mul, coe_ideal_span_singleton, ← mul_assoc, coe_y',
-    span_singleton_mul_span_singleton, mul_comm, ← is_localization.mk'_eq_mul_mk'_one,
+  rw [coe_y', coe_ideal_mul, coe_ideal_span_singleton, coe_ideal_mul, coe_ideal_span_singleton,
+    ←mul_assoc, span_singleton_mul_span_singleton, ←mul_assoc, span_singleton_mul_span_singleton,
+    mul_comm (mk' _ _ _), ← is_localization.mk'_eq_mul_mk'_one,
+    mul_comm (mk' _ _ _), ← is_localization.mk'_eq_mul_mk'_one,
     is_localization.mk'_self, span_singleton_one, one_mul],
 end
 


### PR DESCRIPTION
This was timing out on another branch. Just replaces a `simp only []` with a `rw []`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
