### PR TITLE
[Merged by Bors] - feat(topology/G_delta): add lemmas, minor golf

### DIFF
--- a/src/topology/G_delta.lean
+++ b/src/topology/G_delta.lean
@@ -32,7 +32,7 @@ Gδ set, residual set
 -/
 
 noncomputable theory
-open_locale classical topological_space filter
+open_locale classical topological_space filter uniformity
 
 open filter encodable set
 
@@ -49,9 +49,9 @@ def is_Gδ (s : set α) : Prop :=
 lemma is_open.is_Gδ {s : set α} (h : is_open s) : is_Gδ s :=
 ⟨{s}, by simp [h], countable_singleton _, (set.sInter_singleton _).symm⟩
 
-lemma is_Gδ_empty : is_Gδ (∅ : set α) := is_open_empty.is_Gδ
+@[simp] lemma is_Gδ_empty : is_Gδ (∅ : set α) := is_open_empty.is_Gδ
 
-lemma is_Gδ_univ : is_Gδ (univ : set α) := is_open_univ.is_Gδ
+@[simp] lemma is_Gδ_univ : is_Gδ (univ : set α) := is_open_univ.is_Gδ
 
 lemma is_Gδ_bInter_of_open {I : set ι} (hI : countable I) {f : ι → set α}
   (hf : ∀i ∈ I, is_open (f i)) : is_Gδ (⋂i∈I, f i) :=
@@ -64,7 +64,8 @@ lemma is_Gδ_Inter_of_open [encodable ι] {f : ι → set α}
 /-- The intersection of an encodable family of Gδ sets is a Gδ set. -/
 lemma is_Gδ_Inter [encodable ι]  {s : ι → set α} (hs : ∀ i, is_Gδ (s i)) : is_Gδ (⋂ i, s i) :=
 begin
-  choose T hTo hTc hTs using hs, obtain rfl : s = λ i, ⋂₀ T i := funext hTs,
+  choose T hTo hTc hTs using hs,
+  obtain rfl : s = λ i, ⋂₀ T i := funext hTs,
   refine ⟨⋃ i, T i, _, countable_Union hTc, (sInter_Union _).symm⟩,
   simpa [@forall_swap ι] using hTo
 end
@@ -79,10 +80,7 @@ end
 
 /-- A countable intersection of Gδ sets is a Gδ set. -/
 lemma is_Gδ_sInter {S : set (set α)} (h : ∀s∈S, is_Gδ s) (hS : countable S) : is_Gδ (⋂₀ S) :=
-begin
-  rw sInter_eq_bInter,
-  exact is_Gδ_bInter hS h
-end
+by simpa only [sInter_eq_bInter] using is_Gδ_bInter hS h
 
 lemma is_Gδ.inter {s t : set α} (hs : is_Gδ s) (ht : is_Gδ t) : is_Gδ (s ∩ t) :=
 by { rw inter_eq_Inter, exact is_Gδ_Inter (bool.forall_bool.2 ⟨ht, hs⟩) }
@@ -94,9 +92,30 @@ begin
   rcases ht with ⟨T, Topen, Tcount, rfl⟩,
   rw [sInter_union_sInter],
   apply is_Gδ_bInter_of_open (Scount.prod Tcount),
-  rintros ⟨a, b⟩ hab,
-  exact is_open.union (Sopen a hab.1) (Topen b hab.2)
+  rintros ⟨a, b⟩ ⟨ha, hb⟩,
+  exact (Sopen a ha).union (Topen b hb)
 end
+
+/-- The union of finitely many Gδ sets is a Gδ set. -/
+lemma is_Gδ_bUnion {s : set ι} (hs : s.finite) {f : ι → set α} (h : ∀ i ∈ s, is_Gδ (f i)) :
+  is_Gδ (⋃ i ∈ s, f i) :=
+begin
+  refine finite.induction_on hs (by simp) _ h,
+  simp only [ball_insert_iff, bUnion_insert],
+  exact λ a s _ _ ihs H, H.1.union (ihs H.2)
+end
+
+lemma is_closed.is_Gδ' {α} [uniform_space α] {s : set α} (hs : is_closed s)
+  (H : (𝓤 α).is_countably_generated) : is_Gδ s :=
+begin
+  rcases H.exists_antitone_subbasis uniformity_has_basis_open with ⟨U, hUo, hU, -, -⟩,
+  rw [← hs.closure_eq, ← hU.bInter_bUnion_ball],
+  refine is_Gδ_bInter (countable_encodable _) (λ n hn, is_open.is_Gδ _),
+  exact is_open_bUnion (λ x hx, uniform_space.is_open_ball _ (hUo _).2)
+end
+
+lemma is_closed.is_Gδ {α} [pseudo_emetric_space α] {s : set α} (hs : is_closed s) : is_Gδ s :=
+hs.is_Gδ' emetric.uniformity_has_countable_basis
 
 section t1_space
 
@@ -162,7 +181,7 @@ begin
 end
 
 /-- The set of points where a function is continuous is a Gδ set. -/
-lemma is_Gδ_set_of_continuous_at [emetric_space β] (f : α → β) :
+lemma is_Gδ_set_of_continuous_at [pseudo_emetric_space β] (f : α → β) :
   is_Gδ {x | continuous_at f x} :=
 is_Gδ_set_of_continuous_at_of_countably_generated_uniformity
   emetric.uniformity_has_countable_basis _

--- a/src/topology/G_delta.lean
+++ b/src/topology/G_delta.lean
@@ -62,7 +62,7 @@ lemma is_Gδ_Inter_of_open [encodable ι] {f : ι → set α}
 ⟨range f, by rwa forall_range_iff, countable_range _, by rw sInter_range⟩
 
 /-- The intersection of an encodable family of Gδ sets is a Gδ set. -/
-lemma is_Gδ_Inter [encodable ι]  {s : ι → set α} (hs : ∀ i, is_Gδ (s i)) : is_Gδ (⋂ i, s i) :=
+lemma is_Gδ_Inter [encodable ι] {s : ι → set α} (hs : ∀ i, is_Gδ (s i)) : is_Gδ (⋂ i, s i) :=
 begin
   choose T hTo hTc hTs using hs,
   obtain rfl : s = λ i, ⋂₀ T i := funext hTs,

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -945,13 +945,13 @@ theorem mem_closure_iff_comap_ne_bot {A : set α} {x : α} :
   x ∈ closure A ↔ ne_bot (comap (coe : A → α) (𝓝 x)) :=
 by simp_rw [mem_closure_iff_nhds, comap_ne_bot_iff, set.nonempty_inter_iff_exists_right]
 
-theorem mem_closure_iff_nhds_basis' {a : α} {p : β → Prop} {s : β → set α} (h : (𝓝 a).has_basis p s)
+theorem mem_closure_iff_nhds_basis' {a : α} {p : ι → Prop} {s : ι → set α} (h : (𝓝 a).has_basis p s)
   {t : set α} :
   a ∈ closure t ↔ ∀ i, p i → (s i ∩ t).nonempty :=
 mem_closure_iff_cluster_pt.trans $ (h.cluster_pt_iff (has_basis_principal _)).trans $
   by simp only [exists_prop, forall_const]
 
-theorem mem_closure_iff_nhds_basis {a : α} {p : β → Prop} {s : β → set α} (h : (𝓝 a).has_basis p s)
+theorem mem_closure_iff_nhds_basis {a : α} {p : ι → Prop} {s : ι → set α} (h : (𝓝 a).has_basis p s)
   {t : set α} :
   a ∈ closure t ↔ ∀ i, p i → ∃ y ∈ t, y ∈ s i :=
 (mem_closure_iff_nhds_basis' h).trans $

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -531,12 +531,12 @@ begin
   exact iff.rfl,
 end
 
-lemma nhds_basis_uniformity' {p : β → Prop} {s : β → set (α × α)} (h : (𝓤 α).has_basis p s)
+lemma nhds_basis_uniformity' {p : ι → Prop} {s : ι → set (α × α)} (h : (𝓤 α).has_basis p s)
   {x : α} :
   (𝓝 x).has_basis p (λ i, ball x (s i)) :=
 by { rw [nhds_eq_comap_uniformity], exact h.comap (prod.mk x) }
 
-lemma nhds_basis_uniformity {p : β → Prop} {s : β → set (α × α)} (h : (𝓤 α).has_basis p s) {x : α} :
+lemma nhds_basis_uniformity {p : ι → Prop} {s : ι → set (α × α)} (h : (𝓤 α).has_basis p s) {x : α} :
   (𝓝 x).has_basis p (λ i, {y | (y, x) ∈ s i}) :=
 begin
   replace h := h.comap prod.swap,
@@ -576,21 +576,11 @@ open uniform_space
 
 lemma uniform_space.mem_closure_iff_symm_ball {s : set α} {x} :
   x ∈ closure s ↔ ∀ {V}, V ∈ 𝓤 α → symmetric_rel V → (s ∩ ball x V).nonempty :=
-begin
-  simp [mem_closure_iff_nhds_basis (has_basis_nhds x)],
-  tauto,
-end
+by simp [mem_closure_iff_nhds_basis (has_basis_nhds x), set.nonempty]
 
 lemma uniform_space.mem_closure_iff_ball {s : set α} {x} :
   x ∈ closure s ↔ ∀ {V}, V ∈ 𝓤 α → (ball x V ∩ s).nonempty :=
-begin
-  simp_rw [mem_closure_iff_nhds, uniform_space.mem_nhds_iff],
-  split,
-  { intros h V V_in,
-    exact h (ball x V) ⟨V, V_in, subset.refl _⟩ },
-  { rintros h t ⟨V, V_in, Vt⟩,
-    exact nonempty.mono (inter_subset_inter_left s Vt) (h V_in) },
-end
+by simp [mem_closure_iff_nhds_basis' (nhds_basis_uniformity' (𝓤 α).basis_sets)]
 
 lemma uniform_space.has_basis_nhds_prod (x y : α) :
   has_basis (𝓝 (x, y)) (λ s, s ∈ 𝓤 α ∧ symmetric_rel s) $ λ s, (ball x s).prod (ball y s) :=
@@ -861,6 +851,14 @@ lemma uniform_space.has_seq_basis (h : is_countably_generated $ 𝓤 α) :
   ∃ V : ℕ → set (α × α), has_antitone_basis (𝓤 α) (λ _, true) V ∧ ∀ n, symmetric_rel (V n) :=
 let ⟨U, hsym, hbasis⟩ := h.exists_antitone_subbasis uniform_space.has_basis_symmetric
 in ⟨U, hbasis, λ n, (hsym n).2⟩
+
+lemma filter.has_basis.bInter_bUnion_ball {p : ι → Prop} {U : ι → set (α × α)}
+  (h : has_basis (𝓤 α) p U) (s : set α) :
+  (⋂ i (hi : p i), ⋃ x ∈ s, ball x (U i)) = closure s :=
+begin
+  ext x,
+  simp [mem_closure_iff_nhds_basis (nhds_basis_uniformity h), ball]
+end
 
 /-! ### Uniform continuity -/
 


### PR DESCRIPTION
* the complement to a countable set is a Gδ set;
* a closed set is a Gδ set;
* finite union of Gδ sets is a Gδ set;
* generalize some universe levels in `topology.basic`;
* golf a few proofs in `topology.uniform_space.basic`;
* add `filter.has_basis.bInter_bUnion_ball`.

---

@sgouezel Feel free to revert lemmas about `(s,b)Inter` to their previous state.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
