### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space/independent): add `exists_affine_independent`

### DIFF
--- a/src/data/equiv/set.lean
+++ b/src/data/equiv/set.lean
@@ -52,6 +52,11 @@ protected lemma subset_image {α β} (e : α ≃ β) (s : set α) (t : set β) :
   t ⊆ e '' s ↔ e.symm '' t ⊆ s :=
 by rw [set.image_subset_iff, e.image_eq_preimage]
 
+protected lemma subset_image' {α β} (e : α ≃ β) (s : set α) (t : set β) :
+  e '' s ⊆ t ↔ s ⊆ e.symm '' t :=
+calc e '' s ⊆ t ↔ e.symm.symm '' s ⊆ t : by rw e.symm_symm
+            ... ↔ s ⊆ e.symm '' t : by rw e.symm.subset_image
+
 @[simp] lemma symm_image_image {α β} (e : α ≃ β) (s : set α) : e.symm '' (e '' s) = s :=
 e.left_inverse_symm.image_image s
 

--- a/src/data/equiv/set.lean
+++ b/src/data/equiv/set.lean
@@ -48,14 +48,14 @@ lemma _root_.set.preimage_equiv_eq_image_symm {α β} (S : set α) (f : β ≃ �
   f ⁻¹' S = f.symm '' S :=
 (f.symm.image_eq_preimage S).symm
 
-protected lemma subset_image {α β} (e : α ≃ β) (s : set α) (t : set β) :
-  t ⊆ e '' s ↔ e.symm '' t ⊆ s :=
+@[simp] protected lemma subset_image {α β} (e : α ≃ β) (s : set α) (t : set β) :
+  e.symm '' t ⊆ s ↔ t ⊆ e '' s :=
 by rw [set.image_subset_iff, e.image_eq_preimage]
 
-protected lemma subset_image' {α β} (e : α ≃ β) (s : set α) (t : set β) :
-  e '' s ⊆ t ↔ s ⊆ e.symm '' t :=
-calc e '' s ⊆ t ↔ e.symm.symm '' s ⊆ t : by rw e.symm_symm
-            ... ↔ s ⊆ e.symm '' t : by rw e.symm.subset_image
+@[simp] protected lemma subset_image' {α β} (e : α ≃ β) (s : set α) (t : set β) :
+  s ⊆ e.symm '' t ↔ e '' s ⊆ t :=
+calc s ⊆ e.symm '' t ↔ e.symm.symm '' s ⊆ t : by rw e.symm.subset_image
+                 ... ↔ e '' s ⊆ t : by rw e.symm_symm
 
 @[simp] lemma symm_image_image {α β} (e : α ≃ β) (s : set α) : e.symm '' (e '' s) = s :=
 e.left_inverse_symm.image_image s

--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -436,9 +436,9 @@ end
 
 end affine_independent
 
-section field
+section division_ring
 
-variables {k : Type*} {V : Type*} {P : Type*} [field k] [add_comm_group V] [module k V]
+variables {k : Type*} {V : Type*} {P : Type*} [division_ring k] [add_comm_group V] [module k V]
 variables [affine_space V P] {ι : Type*}
 include V
 
@@ -474,7 +474,34 @@ begin
     { use [hsvi, affine_span_singleton_union_vadd_eq_top_of_span_eq_top p₁ hsvt] } }
 end
 
-variables (k)
+variables (k V)
+
+lemma exists_affine_independent (s : set P) :
+  ∃ t ⊆ s, affine_span k t = affine_span k s ∧ affine_independent k (coe : t → P) :=
+begin
+  rcases s.eq_empty_or_nonempty with rfl | ⟨p, hp⟩,
+  { exact ⟨∅, set.empty_subset ∅, rfl, affine_independent_of_subsingleton k _⟩, },
+  obtain ⟨b, hb₁, hb₂, hb₃⟩ := exists_linear_independent k ((equiv.vadd_const p).symm '' s),
+  have hb₀ : ∀ (v : V), v ∈ b → v ≠ 0, { exact λ v hv, hb₃.ne_zero (⟨v, hv⟩ : b), },
+  rw linear_independent_set_iff_affine_independent_vadd_union_singleton k hb₀ p at hb₃,
+  refine ⟨{p} ∪ (equiv.vadd_const p) '' b, _, _, hb₃⟩,
+  { apply set.union_subset (set.singleton_subset_iff.mpr hp),
+    rwa (equiv.vadd_const p).subset_image' b s, },
+  { rw [equiv.coe_vadd_const_symm, ← vector_span_eq_span_vsub_set_right k hp] at hb₂,
+    apply affine_subspace.ext_of_direction_eq,
+    { have : submodule.span k b = submodule.span k (insert 0 b), { by simp, },
+      simp only [direction_affine_span, ← hb₂, equiv.coe_vadd_const, set.singleton_union,
+        vector_span_eq_span_vsub_set_right k (set.mem_insert p _), this],
+      congr,
+      change (equiv.vadd_const p).symm '' insert p ((equiv.vadd_const p) '' b) = _,
+      rw [set.image_insert_eq, ← set.image_comp],
+      simp, },
+    { use p,
+      simp only [equiv.coe_vadd_const, set.singleton_union, set.mem_inter_eq, coe_affine_span],
+      exact ⟨mem_span_points k _ _ (set.mem_insert p _), mem_span_points k _ _ hp⟩, }, },
+end
+
+variables (k) {V P}
 
 /-- Two different points are affinely independent. -/
 lemma affine_independent_of_ne {p₁ p₂ : P} (h : p₁ ≠ p₂) : affine_independent k ![p₁, p₂] :=
@@ -492,7 +519,7 @@ begin
   exact linear_independent_unique _ hz
 end
 
-end field
+end division_ring
 
 namespace affine
 

--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -486,7 +486,7 @@ begin
   rw linear_independent_set_iff_affine_independent_vadd_union_singleton k hb₀ p at hb₃,
   refine ⟨{p} ∪ (equiv.vadd_const p) '' b, _, _, hb₃⟩,
   { apply set.union_subset (set.singleton_subset_iff.mpr hp),
-    rwa (equiv.vadd_const p).subset_image' b s, },
+    rwa ← (equiv.vadd_const p).subset_image' b s, },
   { rw [equiv.coe_vadd_const_symm, ← vector_span_eq_span_vsub_set_right k hp] at hb₂,
     apply affine_subspace.ext_of_direction_eq,
     { have : submodule.span k b = submodule.span k (insert 0 b), { by simp, },

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -818,6 +818,13 @@ begin
   exact iff.rfl
 end
 
+@[simp] lemma span_insert_zero : span R (insert (0 : M) s) = span R s :=
+begin
+  refine le_antisymm _ (submodule.span_mono (set.subset_insert 0 s)),
+  rw [span_le, set.insert_subset],
+  exact ⟨by simp only [set_like.mem_coe, submodule.zero_mem], submodule.subset_span⟩,
+end
+
 alias submodule.map_span_le ← linear_map.map_span_le
 
 /- See also `span_preimage_eq` below. -/

--- a/src/order/countable_dense_linear_order.lean
+++ b/src/order/countable_dense_linear_order.lean
@@ -156,7 +156,7 @@ def defined_at_right [densely_ordered α] [no_bot_order α] [no_top_order α] [n
       change (a, b) ∈ f'.val.image _,
       rwa [←finset.mem_coe, finset.coe_image, equiv.image_eq_preimage] },
     { change _ ⊆ f'.val.image _,
-      rw [←finset.coe_subset, finset.coe_image, equiv.subset_image],
+      rw [←finset.coe_subset, finset.coe_image, ← equiv.subset_image],
       change f.val.image _ ⊆ _ at hl,
       rwa [←finset.coe_subset, finset.coe_image] at hl }
   end }


### PR DESCRIPTION
Formalized as part of the Sphere Eversion project.

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
