### PR TITLE
[Merged by Bors] - chore(analysis/normed/group): add a few convenience lemmas

### DIFF
--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -466,9 +466,21 @@ lemma lipschitz_on_with.norm_sub_le {f : E → F} {C : ℝ≥0} {s : set E} (h :
   {x y : E} (x_in : x ∈ s) (y_in : y ∈ s) : ∥f x - f y∥ ≤ C * ∥x - y∥ :=
 lipschitz_on_with_iff_norm_sub_le.mp h x x_in y y_in
 
+lemma lipschitz_on_with.norm_sub_le_of_le {f : E → F} {C : ℝ≥0} {s : set E}
+  (h : lipschitz_on_with C f s){x y : E} (x_in : x ∈ s) (y_in : y ∈ s) {d : ℝ} (hd : ∥x - y∥ ≤ d) :
+  ∥f x - f y∥ ≤ C * d :=
+(h.norm_sub_le x_in y_in).trans $ mul_le_mul_of_nonneg_left hd C.2
+
 lemma lipschitz_with_iff_norm_sub_le {f : E → F} {C : ℝ≥0} :
   lipschitz_with C f ↔ ∀ x y, ∥f x - f y∥ ≤ C * ∥x - y∥ :=
 by simp only [lipschitz_with_iff_dist_le_mul, dist_eq_norm]
+
+alias lipschitz_with_iff_norm_sub_le ↔ lipschitz_with.norm_sub_le _
+
+lemma lipschitz_with.norm_sub_le_of_le {f : E → F} {C : ℝ≥0} (h : lipschitz_with C f)
+  {x y : E} {d : ℝ} (hd : ∥x - y∥ ≤ d) :
+  ∥f x - f y∥ ≤ C * d :=
+(h.norm_sub_le x y).trans $ mul_le_mul_of_nonneg_left hd C.2
 
 /-- A homomorphism `f` of seminormed groups is continuous, if there exists a constant `C` such that
 for all `x`, one has `∥f x∥ ≤ C * ∥x∥`.


### PR DESCRIPTION
Add `lipschitz_on_with.norm_sub_le_of_le`,
`lipschitz_with.norm_sub_le`, and `lipschitz_with.norm_sub_le_of_le`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)