### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space/independent): affine equivalences preserve affine independence of sets of points

### DIFF
--- a/src/data/equiv/set.lean
+++ b/src/data/equiv/set.lean
@@ -119,6 +119,8 @@ subtype_equiv_prop h
 
 /--
 A set is equivalent to its image under an equivalence.
+
+See also `equiv.set.image_of_eq`.
 -/
 -- We could construct this using `equiv.set.image e s e.injective`,
 -- but this definition provides an explicit inverse.
@@ -199,6 +201,11 @@ protected def of_eq {α : Type u} {s t : set α} (h : s = t) : s ≃ t :=
   inv_fun := λ x, ⟨x, h.symm ▸ x.2⟩,
   left_inv := λ _, subtype.eq rfl,
   right_inv := λ _, subtype.eq rfl }
+
+@[simps apply symm_apply]
+protected def image_of_eq {α β} {s : set α} {t : set β} (e : α ≃ β) (h : e '' s = t) :
+  s ≃ t :=
+(e.image s).trans (equiv.set.of_eq h)
 
 /-- If `a ∉ s`, then `insert a s` is equivalent to `s ⊕ punit`. -/
 protected def insert {α} {s : set.{u} α} [decidable_pred (∈ s)] {a : α} (H : a ∉ s) :

--- a/src/data/equiv/set.lean
+++ b/src/data/equiv/set.lean
@@ -119,8 +119,6 @@ subtype_equiv_prop h
 
 /--
 A set is equivalent to its image under an equivalence.
-
-See also `equiv.set.image_of_eq`.
 -/
 -- We could construct this using `equiv.set.image e s e.injective`,
 -- but this definition provides an explicit inverse.
@@ -201,11 +199,6 @@ protected def of_eq {α : Type u} {s t : set α} (h : s = t) : s ≃ t :=
   inv_fun := λ x, ⟨x, h.symm ▸ x.2⟩,
   left_inv := λ _, subtype.eq rfl,
   right_inv := λ _, subtype.eq rfl }
-
-@[simps apply symm_apply]
-protected def image_of_eq {α β} {s : set α} {t : set β} (e : α ≃ β) (h : e '' s = t) :
-  s ≃ t :=
-(e.image s).trans (equiv.set.of_eq h)
 
 /-- If `a ∉ s`, then `insert a s` is equivalent to `s ⊕ punit`. -/
 protected def insert {α} {s : set.{u} α} [decidable_pred (∈ s)] {a : α} (H : a ∉ s) :

--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -356,11 +356,10 @@ lemma affine_equiv.affine_independent_iff {p : ι → P} (e : P ≃ᵃ[k] P₂) 
 e.to_affine_map.affine_independent_iff e.to_equiv.injective
 
 /-- Affine equivalences preserve affine independence of subsets. -/
-lemma affine_equiv.affine_independent_set_of_eq_iff {s : set P} {t : set P₂} (e : P ≃ᵃ[k] P₂)
-  (h : e '' s = t) :
-  affine_independent k (coe : t → P₂) ↔ affine_independent k (coe : s → P) :=
+lemma affine_equiv.affine_independent_set_of_eq_iff {s : set P} (e : P ≃ᵃ[k] P₂) :
+  affine_independent k (coe : (e '' s) → P₂) ↔ affine_independent k (coe : s → P) :=
 begin
-  have : e ∘ (coe : s → P) = (coe : t → P₂) ∘ (equiv.set.image_of_eq (e : P ≃ P₂) h), { refl, },
+  have : e ∘ (coe : s → P) = (coe : e '' s → P₂) ∘ ((e : P ≃ P₂).image s) := rfl,
   rw [← e.affine_independent_iff, this, affine_independent_equiv],
 end
 

--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -288,6 +288,16 @@ begin
   simp [hf]
 end
 
+lemma affine_independent_equiv {ι' : Type*} (e : ι ≃ ι') {p : ι' → P} :
+  affine_independent k (p ∘ e) ↔ affine_independent k p :=
+begin
+  refine ⟨_, affine_independent.comp_embedding e.to_embedding⟩,
+  intros h,
+  have : p = p ∘ e ∘ e.symm.to_embedding, { ext, simp, },
+  rw this,
+  exact h.comp_embedding e.symm.to_embedding,
+end
+
 /-- If a set of points is affinely independent, so is any subset. -/
 protected lemma affine_independent.mono {s t : set P}
   (ha : affine_independent k (λ x, x : t → P)) (hs : s ⊆ t) :
@@ -340,18 +350,19 @@ lemma affine_map.affine_independent_iff {p : ι → P} (f : P →ᵃ[k] P₂) (h
   affine_independent k (f ∘ p) ↔ affine_independent k p :=
 ⟨affine_independent.of_comp f, λ hai, affine_independent.map' hai f hf⟩
 
-/-- In particular, affine equivalences preserve affine independence. -/
+/-- Affine equivalences preserve affine independence of families of points. -/
 lemma affine_equiv.affine_independent_iff {p : ι → P} (e : P ≃ᵃ[k] P₂) :
   affine_independent k (e ∘ p) ↔ affine_independent k p :=
 e.to_affine_map.affine_independent_iff e.to_equiv.injective
 
-omit V₂
-
-/-- In particular, homotheties preserve affine independence (when the scale factor is a unit). -/
-lemma affine_map.homothety_affine_independent_iff {k : Type*} [comm_ring k] [module k V]
-  {p : ι → P} {q : P} {t : units k} :
-  affine_independent k ((affine_map.homothety q (t : k)) ∘ p) ↔ affine_independent k p :=
-(affine_equiv.homothety_units_mul_hom q t).affine_independent_iff
+/-- Affine equivalences preserve affine independence of subsets. -/
+lemma affine_equiv.affine_independent_set_of_eq_iff {s : set P} {t : set P₂} (e : P ≃ᵃ[k] P₂)
+  (h : e '' s = t) :
+  affine_independent k (coe : t → P₂) ↔ affine_independent k (coe : s → P) :=
+begin
+  have : e ∘ (coe : s → P) = (coe : t → P₂) ∘ (equiv.set.image_of_eq (e : P ≃ P₂) h), { refl, },
+  rw [← e.affine_independent_iff, this, affine_independent_equiv],
+end
 
 end composition
 


### PR DESCRIPTION
The key addition is `affine_equiv.affine_independent_set_of_eq_iff`.

Formalized as part of the Sphere Eversion project.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
