### PR TITLE
 feat(ring_theory/roots_of_unity): an explicit construction for primitive roots

### DIFF
--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -769,6 +769,31 @@ lemma nth_roots_one_eq_bUnion_primitive_roots {ζ : R} {n : ℕ} (hpos : 0 < n)
   nth_roots_finset n R = (nat.divisors n).bUnion (λ i, (primitive_roots i R)) :=
 @nth_roots_one_eq_bUnion_primitive_roots' _ _ _ ⟨n, hpos⟩ h
 
+lemma generator_is_primitive_root_iff_card_roots_of_unity' {n : ℕ+} :
+  is_primitive_root (roots_of_unity.is_cyclic R n).exists_generator.some.val.val n ↔
+  fintype.card (roots_of_unity n R) = n :=
+begin
+  rw [subtype.val_eq_coe, units.val_eq_coe],
+  let hζ := (roots_of_unity.is_cyclic R n).exists_generator.some_spec,
+  refine ⟨λ hζ, is_primitive_root.card_roots_of_unity hζ,
+          λ hn, is_primitive_root.mk_of_lt _ _ _ (λ l hl' hl h, _)⟩,
+  { rw [←hn, fintype.card_pos_iff],
+    exact ⟨(roots_of_unity.is_cyclic R n).exists_generator.some⟩ },
+  { convert pow_order_of_eq_one _,
+    rw [←hn, order_of_units, order_of_subgroup, order_of_eq_card_of_forall_mem_gpowers hζ] },
+  rw ←order_of_eq_card_of_forall_mem_gpowers hζ at hn,
+  norm_cast at h,
+  rw [units.coe_eq_one] at h,
+  norm_cast at h,
+  exact pow_eq_one_of_lt_order_of' hl'.ne' (by rwa hn) h
+end
+
+lemma generator_is_primitive_root_iff_card_roots_of_unity {n : ℕ+} :
+  is_primitive_root (roots_of_unity.is_cyclic R n).exists_generator.some n ↔
+  fintype.card (roots_of_unity n R) = n :=
+by rw [←generator_is_primitive_root_iff_card_roots_of_unity', subtype.val_eq_coe, units.val_eq_coe,
+       is_primitive_root.coe_units_iff, is_primitive_root.coe_subgroup_iff]
+
 end integral_domain
 
 section minpoly


### PR DESCRIPTION
this one has some pretty horrific casting issues that are being checked on Zulip, c.f. https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60norm_cast.60.20not.20playing.20ball.20.3A.28

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #9777

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
