### PR TITLE
[Merged by Bors] - feat(group_theory/index): Relative index

### DIFF
--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -25,6 +25,7 @@ In this file we define the index of a subgroup, and prove several divisibility p
 - `index_dvd_card` : `H.index ∣ fintype.card G`
 - `index_eq_mul_of_le` : If `H ≤ K`, then `H.index = K.index * (H.subgroup_of K).index`
 - `index_dvd_of_le` : If `H ≤ K`, then `K.index ∣ H.index`
+- `rel_index_mul_rel_index` : `rel_index` is multiplicative in towers
 
 -/
 

--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -16,6 +16,8 @@ In this file we define the index of a subgroup, and prove several divisibility p
 
 - `H.index` : the index of `H : subgroup G` as a natural number,
   and returns 0 if the index is infinite.
+- `H.rel_index K` : the relative index of `H : subgroup G` in `K : subgroup G` as a natural number,
+  and returns 0 if the relative index is infinite.
 
 # Main results
 
@@ -28,13 +30,20 @@ In this file we define the index of a subgroup, and prove several divisibility p
 
 namespace subgroup
 
-variables {G : Type*} [group G] (H : subgroup G)
+variables {G : Type*} [group G] (H K L : subgroup G)
 
 /-- The index of a subgroup as a natural number, and returns 0 if the index is infinite. -/
 @[to_additive "The index of a subgroup as a natural number,
 and returns 0 if the index is infinite."]
 noncomputable def index : ℕ :=
 (cardinal.mk (quotient_group.quotient H)).to_nat
+
+/-- The relative index of a subgroup as a natural number,
+  and returns 0 if the relative index is infinite. -/
+@[to_additive "The relative index of a subgroup as a natural number,
+  and returns 0 if the relative index is infinite."]
+noncomputable def rel_index : ℕ :=
+(H.subgroup_of K).index
 
 @[to_additive] lemma index_comap_of_surjective {G' : Type*} [group G'] {f : G' →* G}
   (hf : function.surjective f) : (H.comap f).index = H.index :=
@@ -53,6 +62,33 @@ begin
     exact ⟨y, (quotient.map'_mk' f _ y).trans (congr_arg quotient.mk' hy)⟩ },
 end
 
+@[to_additive] lemma index_comap {G' : Type*} [group G'] (f : G' →* G) :
+  (H.comap f).index = H.rel_index f.range :=
+eq.trans (congr_arg index (by refl))
+  ((H.subgroup_of f.range).index_comap_of_surjective f.range_restrict_surjective)
+
+variables {H K L}
+
+@[to_additive] lemma index_eq_mul_of_le (h : H ≤ K) : H.index = K.index * H.rel_index K :=
+(congr_arg cardinal.to_nat (by exact (quotient_equiv_prod_of_le h).cardinal_eq)).trans
+  (cardinal.to_nat_mul _ _)
+
+@[to_additive] lemma index_dvd_of_le (h : H ≤ K) : K.index ∣ H.index :=
+⟨H.rel_index K, index_eq_mul_of_le h⟩
+
+@[to_additive] lemma rel_index_subgroup_of (hKL : K ≤ L) :
+  H.rel_index K = (H.subgroup_of L).rel_index (K.subgroup_of L) :=
+(index_comap (H.subgroup_of L) (inclusion hKL)).trans (congr_arg _ (inclusion_range hKL))
+
+@[to_additive] lemma rel_index_mul_rel_index (hHK : H ≤ K) (hKL : K ≤ L) :
+  H.rel_index K * K.rel_index L = H.rel_index L :=
+begin
+  rw [rel_index_subgroup_of hKL, mul_comm, eq_comm],
+  exact index_eq_mul_of_le (λ x hx, hHK hx),
+end
+
+variables (H K L)
+
 @[to_additive] lemma index_eq_card [fintype (quotient_group.quotient H)] :
   H.index = fintype.card (quotient_group.quotient H) :=
 cardinal.mk_to_nat_eq_card
@@ -70,15 +106,5 @@ begin
   classical,
   exact ⟨fintype.card H, H.index_mul_card.symm⟩,
 end
-
-variables {H} {K : subgroup G}
-
-@[to_additive] lemma index_eq_mul_of_le (h : H ≤ K) :
-  H.index = K.index * (H.subgroup_of K).index :=
-(congr_arg cardinal.to_nat (by exact (quotient_equiv_prod_of_le h).cardinal_eq)).trans
-  (cardinal.to_nat_mul _ _)
-
-@[to_additive] lemma index_dvd_of_le (h : H ≤ K) : K.index ∣ H.index :=
-⟨(H.subgroup_of K).index, index_eq_mul_of_le h⟩
 
 end subgroup

--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -70,22 +70,22 @@ eq.trans (congr_arg index (by refl))
 
 variables {H K L}
 
-@[to_additive] lemma index_eq_mul_of_le (h : H ≤ K) : H.index = K.index * H.rel_index K :=
-(congr_arg cardinal.to_nat (by exact (quotient_equiv_prod_of_le h).cardinal_eq)).trans
-  (cardinal.to_nat_mul _ _)
+@[to_additive] lemma rel_index_mul_index (h : H ≤ K) : H.rel_index K * K.index = H.index :=
+((mul_comm _ _).trans (cardinal.to_nat_mul _ _).symm).trans
+  (congr_arg cardinal.to_nat (equiv.cardinal_eq (quotient_equiv_prod_of_le h))).symm
 
 @[to_additive] lemma index_dvd_of_le (h : H ≤ K) : K.index ∣ H.index :=
-⟨H.rel_index K, index_eq_mul_of_le h⟩
+dvd_of_mul_left_eq (H.rel_index K) (rel_index_mul_index h)
 
 @[to_additive] lemma rel_index_subgroup_of (hKL : K ≤ L) :
-  H.rel_index K = (H.subgroup_of L).rel_index (K.subgroup_of L) :=
-(index_comap (H.subgroup_of L) (inclusion hKL)).trans (congr_arg _ (inclusion_range hKL))
+  (H.subgroup_of L).rel_index (K.subgroup_of L) = H.rel_index K :=
+((index_comap (H.subgroup_of L) (inclusion hKL)).trans (congr_arg _ (inclusion_range hKL))).symm
 
 @[to_additive] lemma rel_index_mul_rel_index (hHK : H ≤ K) (hKL : K ≤ L) :
   H.rel_index K * K.rel_index L = H.rel_index L :=
 begin
-  rw [rel_index_subgroup_of hKL, mul_comm, eq_comm],
-  exact index_eq_mul_of_le (λ x hx, hHK hx),
+  rw [←rel_index_subgroup_of hKL],
+  exact rel_index_mul_index (λ x hx, hHK hx),
 end
 
 variables (H K L)

--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -16,7 +16,7 @@ In this file we define the index of a subgroup, and prove several divisibility p
 
 - `H.index` : the index of `H : subgroup G` as a natural number,
   and returns 0 if the index is infinite.
-- `H.rel_index K` : the relative index of `H : subgroup G` in `K : subgroup G` as a natural number,
+- `H.relindex K` : the relative index of `H : subgroup G` in `K : subgroup G` as a natural number,
   and returns 0 if the relative index is infinite.
 
 # Main results
@@ -25,7 +25,7 @@ In this file we define the index of a subgroup, and prove several divisibility p
 - `index_dvd_card` : `H.index ∣ fintype.card G`
 - `index_eq_mul_of_le` : If `H ≤ K`, then `H.index = K.index * (H.subgroup_of K).index`
 - `index_dvd_of_le` : If `H ≤ K`, then `K.index ∣ H.index`
-- `rel_index_mul_rel_index` : `rel_index` is multiplicative in towers
+- `relindex_mul_relindex` : `relindex` is multiplicative in towers
 
 -/
 
@@ -43,7 +43,7 @@ noncomputable def index : ℕ :=
   and returns 0 if the relative index is infinite. -/
 @[to_additive "The relative index of a subgroup as a natural number,
   and returns 0 if the relative index is infinite."]
-noncomputable def rel_index : ℕ :=
+noncomputable def relindex : ℕ :=
 (H.subgroup_of K).index
 
 @[to_additive] lemma index_comap_of_surjective {G' : Type*} [group G'] {f : G' →* G}
@@ -64,28 +64,28 @@ begin
 end
 
 @[to_additive] lemma index_comap {G' : Type*} [group G'] (f : G' →* G) :
-  (H.comap f).index = H.rel_index f.range :=
+  (H.comap f).index = H.relindex f.range :=
 eq.trans (congr_arg index (by refl))
   ((H.subgroup_of f.range).index_comap_of_surjective f.range_restrict_surjective)
 
 variables {H K L}
 
-@[to_additive] lemma rel_index_mul_index (h : H ≤ K) : H.rel_index K * K.index = H.index :=
+@[to_additive] lemma relindex_mul_index (h : H ≤ K) : H.relindex K * K.index = H.index :=
 ((mul_comm _ _).trans (cardinal.to_nat_mul _ _).symm).trans
   (congr_arg cardinal.to_nat (equiv.cardinal_eq (quotient_equiv_prod_of_le h))).symm
 
 @[to_additive] lemma index_dvd_of_le (h : H ≤ K) : K.index ∣ H.index :=
-dvd_of_mul_left_eq (H.rel_index K) (rel_index_mul_index h)
+dvd_of_mul_left_eq (H.relindex K) (relindex_mul_index h)
 
-@[to_additive] lemma rel_index_subgroup_of (hKL : K ≤ L) :
-  (H.subgroup_of L).rel_index (K.subgroup_of L) = H.rel_index K :=
+@[to_additive] lemma relindex_subgroup_of (hKL : K ≤ L) :
+  (H.subgroup_of L).relindex (K.subgroup_of L) = H.relindex K :=
 ((index_comap (H.subgroup_of L) (inclusion hKL)).trans (congr_arg _ (inclusion_range hKL))).symm
 
-@[to_additive] lemma rel_index_mul_rel_index (hHK : H ≤ K) (hKL : K ≤ L) :
-  H.rel_index K * K.rel_index L = H.rel_index L :=
+@[to_additive] lemma relindex_mul_relindex (hHK : H ≤ K) (hKL : K ≤ L) :
+  H.relindex K * K.relindex L = H.relindex L :=
 begin
-  rw [←rel_index_subgroup_of hKL],
-  exact rel_index_mul_index (λ x hx, hHK hx),
+  rw [←relindex_subgroup_of hKL],
+  exact relindex_mul_index (λ x hx, hHK hx),
 end
 
 variables (H K L)


### PR DESCRIPTION
Defines relative index between subgroups, and proves that relative index is multiplicative in towers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
