### PR TITLE
[Merged by Bors] - chore(field_theory/galois): speedup a slow convert

### DIFF
--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -104,8 +104,10 @@ begin
   have h_sep : (minpoly F α).separable := is_galois.separable F α,
   have h_splits : (minpoly F α).splits (algebra_map F E) := is_galois.splits F α,
   replace h_splits : polynomial.splits (algebra_map F F⟮α⟯) (minpoly F α),
-  { convert polynomial.splits_comp_of_splits
-    (algebra_map F E) iso.symm.to_alg_hom.to_ring_hom h_splits },
+  { have p : iso.symm.to_alg_hom.to_ring_hom.comp (algebra_map F E) = (algebra_map F ↥F⟮α⟯),
+    { ext, simp, },
+    simpa [p] using polynomial.splits_comp_of_splits
+      (algebra_map F E) iso.symm.to_alg_hom.to_ring_hom h_splits, },
   rw ← linear_equiv.finrank_eq iso.to_linear_equiv,
   rw ← intermediate_field.adjoin_simple.card_aut_eq_finrank F E H h_sep h_splits,
   apply fintype.card_congr,


### PR DESCRIPTION
This was broken by a deterministic timeout in another branch. This replaces a `convert` with an explicit `simp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
