### PR TITLE
[Merged by Bors] - refactor(ring_theory/finiteness): replace fragile convert with rewrites

### DIFF
--- a/src/algebra/algebra/tower.lean
+++ b/src/algebra/algebra/tower.lean
@@ -227,6 +227,9 @@ def restrict_scalars (U : subalgebra S A) : subalgebra R A :=
 { algebra_map_mem' := λ x, by { rw algebra_map_apply R S A, exact U.algebra_map_mem _ },
   .. U }
 
+@[simp] lemma coe_restrict_scalars {U : subalgebra S A} :
+  (restrict_scalars R U : set A) = (U : set A) := rfl
+
 @[simp] lemma restrict_scalars_top : restrict_scalars R (⊤ : subalgebra S A) = ⊤ :=
 set_like.coe_injective rfl
 

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -160,8 +160,11 @@ lemma of_restrict_scalars_finite_type [algebra A B] [is_scalar_tower R A B] [hB 
 begin
   obtain ⟨S, hS⟩ := hB.out,
   refine ⟨⟨S, eq_top_iff.2 (λ b, _)⟩⟩,
-  convert (algebra.adjoin_le algebra.subset_adjoin :
-    adjoin R (S : set B) ≤  subalgebra.restrict_scalars R (adjoin A S)) (eq_top_iff.1 hS b)
+  have le : adjoin R (S : set B) ≤ subalgebra.restrict_scalars R (adjoin A S),
+  { apply (algebra.adjoin_le _ : _ ≤ (subalgebra.restrict_scalars R (adjoin A ↑S))),
+    simp only [subalgebra.coe_restrict_scalars],
+    exact algebra.subset_adjoin, },
+  exact le (eq_top_iff.1 hS b),
 end
 
 variables {R A B}


### PR DESCRIPTION

---

Making a `convert` that broke in a hard-to-diagnose way in another branch more explicit.