### PR TITLE
[Merged by Bors] - chore(*): remove uses of `universe variable`

### DIFF
--- a/src/algebraic_geometry/Spec.lean
+++ b/src/algebraic_geometry/Spec.lean
@@ -35,7 +35,7 @@ TODO: provide the unit, and prove the triangle identities.
 -/
 
 noncomputable theory
-universe variables u v
+universes u v
 
 namespace algebraic_geometry
 open opposite

--- a/src/algebraic_geometry/prime_spectrum.lean
+++ b/src/algebraic_geometry/prime_spectrum.lean
@@ -43,7 +43,7 @@ and Chris Hughes (on an earlier repository).
 noncomputable theory
 open_locale classical
 
-universe variables u v
+universes u v
 
 variables (R : Type u) [comm_ring R]
 

--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -30,7 +30,7 @@ We provide the following functions to work with these objects:
 
 -/
 
-universe variables u v
+universes u v
 
 open category_theory
 

--- a/src/control/applicative.lean
+++ b/src/control/applicative.lean
@@ -8,7 +8,7 @@ Instances for identity and composition functors
 import control.functor
 import algebra.group.basic
 
-universe variables u v w
+universes u v w
 
 section lemmas
 

--- a/src/control/functor.lean
+++ b/src/control/functor.lean
@@ -26,7 +26,7 @@ functor, applicative
 
 attribute [functor_norm] seq_assoc pure_seq_eq_map map_pure seq_map_assoc map_seq
 
-universe variables u v w
+universes u v w
 
 section functor
 

--- a/src/control/traversable/lemmas.lean
+++ b/src/control/traversable/lemmas.lean
@@ -15,7 +15,7 @@ Inspired by:
 import control.traversable.basic
 import control.applicative
 
-universe variables u
+universes u
 
 open is_lawful_traversable
 open function (hiding comp)

--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -11,7 +11,7 @@ import tactic.norm_num
 # Equivalences for `fin n`
 -/
 
-universe variables u
+universes u
 
 variables {m n : ℕ}
 

--- a/src/data/fin_enum.lean
+++ b/src/data/fin_enum.lean
@@ -12,7 +12,7 @@ than `fintype` in that it assigns each element a rank in a finite
 enumeration.
 -/
 
-universe variables u v
+universes u v
 open finset
 
 /-- `fin_enum α` means that `α` is finite and can be enumerated in some order,

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -22,7 +22,7 @@ The notation `~` is used for permutation equivalence.
 open_locale nat
 
 namespace list
-universe variables uu vv
+universes uu vv
 variables {α : Type uu} {β : Type vv}
 
 /-- `perm l₁ l₂` or `l₁ ~ l₂` asserts that `l₁` and `l₂` are permutations

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -21,8 +21,9 @@ The notation `~` is used for permutation equivalence.
 
 open_locale nat
 
-namespace list
 universes uu vv
+
+namespace list
 variables {α : Type uu} {β : Type vv}
 
 /-- `perm l₁ l₂` or `l₁ ~ l₂` asserts that `l₁` and `l₂` are permutations

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -23,7 +23,7 @@ namespace list
 -/
 
 section sorted
-universe variable uu
+universe uu
 variables {α : Type uu} {r : α → α → Prop}
 
 /-- `sorted r l` is the same as `pairwise r l`, preferred in the case that `r`
@@ -101,7 +101,7 @@ end
 end sorted
 
 section sort
-universe variable uu
+universe uu
 variables {α : Type uu} (r : α → α → Prop) [decidable_rel r]
 local infix ` ≼ ` : 50 := r
 

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -16,6 +16,8 @@ in the case that `r` is a `<` or `≤`-like relation. Then we define two sorting
 
 open list.perm
 
+universe uu
+
 namespace list
 
 /-!
@@ -23,7 +25,7 @@ namespace list
 -/
 
 section sorted
-universe uu
+
 variables {α : Type uu} {r : α → α → Prop}
 
 /-- `sorted r l` is the same as `pairwise r l`, preferred in the case that `r`
@@ -101,7 +103,6 @@ end
 end sorted
 
 section sort
-universe uu
 variables {α : Type uu} (r : α → α → Prop) [decidable_rel r]
 local infix ` ≼ ` : 50 := r
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -77,7 +77,7 @@ singleton, complement, powerset
 
 open function
 
-universe variables u v w x
+universes u v w x
 
 run_cmd do e ← tactic.get_env,
   tactic.set_env $ e.mk_protected `set.compl

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -30,6 +30,8 @@ local attribute [instance, priority 100] classical.prop_decidable
 open set linear_map submodule
 open_locale cardinal
 
+universes u v w
+
 namespace finsupp
 
 section ring
@@ -121,7 +123,6 @@ funext $ λ i, basis.apply_eq_iff.mpr rfl
 end ring
 
 section dim
-universes u v
 variables {K : Type u} {V : Type v} {ι : Type v}
 variables [field K] [add_comm_group V] [module K V]
 
@@ -139,11 +140,6 @@ end dim
 end finsupp
 
 section module
-/- We use `universe variables` instead of `universes` here because universes introduced by the
-   `universes` keyword do not get replaced by metavariables once a lemma has been proven. So if you
-   prove a lemma using universe `u`, you can only apply it to universe `u` in other lemmas of the
-   same section. -/
-universes u v w
 variables {K : Type u} {V V₁ V₂ : Type v} {V' : Type w}
 variables [field K]
 variables [add_comm_group V] [module K V]
@@ -190,7 +186,6 @@ end
 end module
 
 section module
-universes u
 
 open module
 

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -143,7 +143,7 @@ section module
    `universes` keyword do not get replaced by metavariables once a lemma has been proven. So if you
    prove a lemma using universe `u`, you can only apply it to universe `u` in other lemmas of the
    same section. -/
-universe variables u v w
+universes u v w
 variables {K : Type u} {V V₁ V₂ : Type v} {V' : Type w}
 variables [field K]
 variables [add_comm_group V] [module K V]

--- a/src/linear_algebra/free_algebra.lean
+++ b/src/linear_algebra/free_algebra.lean
@@ -13,7 +13,7 @@ This file provides a `free_monoid X` basis on the `free_algebra R X`, and uses i
 dimension of the algebra is the cardinality of `list X`
 -/
 
-universe variables u v
+universes u v
 
 namespace free_algebra
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1305,8 +1305,7 @@ decidable.by_cases (λ h, or.inl (if_pos h)) (λ h, or.inr (if_neg h))
 /-! ### Declarations about `nonempty` -/
 
 section nonempty
-universes u v w
-variables {α : Type u} {β : Type v} {γ : α → Type w}
+variables {α β : Type*} {γ : α → Type*}
 
 attribute [simp] nonempty_of_inhabited
 
@@ -1327,14 +1326,13 @@ lemma not_nonempty_iff_imp_false {α : Sort*} : ¬ nonempty α ↔ α → false 
 @[simp] lemma nonempty_sigma : nonempty (Σa:α, γ a) ↔ (∃a:α, nonempty (γ a)) :=
 iff.intro (assume ⟨⟨a, c⟩⟩, ⟨a, ⟨c⟩⟩) (assume ⟨a, ⟨c⟩⟩, ⟨⟨a, c⟩⟩)
 
-@[simp] lemma nonempty_subtype {α : Sort u} {p : α → Prop} : nonempty (subtype p) ↔ (∃a:α, p a) :=
+@[simp] lemma nonempty_subtype {α} {p : α → Prop} : nonempty (subtype p) ↔ (∃a:α, p a) :=
 iff.intro (assume ⟨⟨a, h⟩⟩, ⟨a, h⟩) (assume ⟨a, h⟩, ⟨⟨a, h⟩⟩)
 
 @[simp] lemma nonempty_prod : nonempty (α × β) ↔ (nonempty α ∧ nonempty β) :=
 iff.intro (assume ⟨⟨a, b⟩⟩, ⟨⟨a⟩, ⟨b⟩⟩) (assume ⟨⟨a⟩, ⟨b⟩⟩, ⟨⟨a, b⟩⟩)
 
-@[simp] lemma nonempty_pprod {α : Sort u} {β : Sort v} :
-  nonempty (pprod α β) ↔ (nonempty α ∧ nonempty β) :=
+@[simp] lemma nonempty_pprod {α β} : nonempty (pprod α β) ↔ (nonempty α ∧ nonempty β) :=
 iff.intro (assume ⟨⟨a, b⟩⟩, ⟨⟨a⟩, ⟨b⟩⟩) (assume ⟨⟨a⟩, ⟨b⟩⟩, ⟨⟨a, b⟩⟩)
 
 @[simp] lemma nonempty_sum : nonempty (α ⊕ β) ↔ (nonempty α ∨ nonempty β) :=
@@ -1342,14 +1340,12 @@ iff.intro
   (assume ⟨h⟩, match h with sum.inl a := or.inl ⟨a⟩ | sum.inr b := or.inr ⟨b⟩ end)
   (assume h, match h with or.inl ⟨a⟩ := ⟨sum.inl a⟩ | or.inr ⟨b⟩ := ⟨sum.inr b⟩ end)
 
-@[simp] lemma nonempty_psum {α : Sort u} {β : Sort v} :
-  nonempty (psum α β) ↔ (nonempty α ∨ nonempty β) :=
+@[simp] lemma nonempty_psum {α β} : nonempty (psum α β) ↔ (nonempty α ∨ nonempty β) :=
 iff.intro
   (assume ⟨h⟩, match h with psum.inl a := or.inl ⟨a⟩ | psum.inr b := or.inr ⟨b⟩ end)
   (assume h, match h with or.inl ⟨a⟩ := ⟨psum.inl a⟩ | or.inr ⟨b⟩ := ⟨psum.inr b⟩ end)
 
-@[simp] lemma nonempty_psigma {α : Sort u} {β : α → Sort v} :
-  nonempty (psigma β) ↔ (∃a:α, nonempty (β a)) :=
+@[simp] lemma nonempty_psigma {α} {β : α → Sort*} : nonempty (psigma β) ↔ (∃a:α, nonempty (β a)) :=
 iff.intro (assume ⟨⟨a, c⟩⟩, ⟨a, ⟨c⟩⟩) (assume ⟨a, ⟨c⟩⟩, ⟨⟨a, c⟩⟩)
 
 @[simp] lemma nonempty_empty : ¬ nonempty empty :=
@@ -1358,45 +1354,42 @@ assume ⟨h⟩, h.elim
 @[simp] lemma nonempty_ulift : nonempty (ulift α) ↔ nonempty α :=
 iff.intro (assume ⟨⟨a⟩⟩, ⟨a⟩) (assume ⟨a⟩, ⟨⟨a⟩⟩)
 
-@[simp] lemma nonempty_plift {α : Sort u} : nonempty (plift α) ↔ nonempty α :=
+@[simp] lemma nonempty_plift {α} : nonempty (plift α) ↔ nonempty α :=
 iff.intro (assume ⟨⟨a⟩⟩, ⟨a⟩) (assume ⟨a⟩, ⟨⟨a⟩⟩)
 
-@[simp] lemma nonempty.forall {α : Sort u} {p : nonempty α → Prop} :
-  (∀h:nonempty α, p h) ↔ (∀a, p ⟨a⟩) :=
+@[simp] lemma nonempty.forall {α} {p : nonempty α → Prop} : (∀h:nonempty α, p h) ↔ (∀a, p ⟨a⟩) :=
 iff.intro (assume h a, h _) (assume h ⟨a⟩, h _)
 
-@[simp] lemma nonempty.exists {α : Sort u} {p : nonempty α → Prop} :
-  (∃h:nonempty α, p h) ↔ (∃a, p ⟨a⟩) :=
+@[simp] lemma nonempty.exists {α} {p : nonempty α → Prop} : (∃h:nonempty α, p h) ↔ (∃a, p ⟨a⟩) :=
 iff.intro (assume ⟨⟨a⟩, h⟩, ⟨a, h⟩) (assume ⟨a, h⟩, ⟨⟨a⟩, h⟩)
 
-lemma classical.nonempty_pi {α : Sort u} {β : α → Sort v} :
-  nonempty (Πa:α, β a) ↔ (∀a:α, nonempty (β a)) :=
+lemma classical.nonempty_pi {α} {β : α → Sort*} : nonempty (Πa:α, β a) ↔ (∀a:α, nonempty (β a)) :=
 iff.intro (assume ⟨f⟩ a, ⟨f a⟩) (assume f, ⟨assume a, classical.choice $ f a⟩)
 
 /-- Using `classical.choice`, lifts a (`Prop`-valued) `nonempty` instance to a (`Type`-valued)
   `inhabited` instance. `classical.inhabited_of_nonempty` already exists, in
   `core/init/classical.lean`, but the assumption is not a type class argument,
   which makes it unsuitable for some applications. -/
-noncomputable def classical.inhabited_of_nonempty' {α : Sort u} [h : nonempty α] : inhabited α :=
+noncomputable def classical.inhabited_of_nonempty' {α} [h : nonempty α] : inhabited α :=
 ⟨classical.choice h⟩
 
 /-- Using `classical.choice`, extracts a term from a `nonempty` type. -/
-@[reducible] protected noncomputable def nonempty.some {α : Sort u} (h : nonempty α) : α :=
+@[reducible] protected noncomputable def nonempty.some {α} (h : nonempty α) : α :=
 classical.choice h
 
 /-- Using `classical.choice`, extracts a term from a `nonempty` type. -/
-@[reducible] protected noncomputable def classical.arbitrary (α : Sort u) [h : nonempty α] : α :=
+@[reducible] protected noncomputable def classical.arbitrary (α) [h : nonempty α] : α :=
 classical.choice h
 
 /-- Given `f : α → β`, if `α` is nonempty then `β` is also nonempty.
   `nonempty` cannot be a `functor`, because `functor` is restricted to `Type`. -/
-lemma nonempty.map {α : Sort u} {β : Sort v} (f : α → β) : nonempty α → nonempty β
+lemma nonempty.map {α β} (f : α → β) : nonempty α → nonempty β
 | ⟨h⟩ := ⟨f h⟩
 
 protected lemma nonempty.map2 {α β γ : Sort*} (f : α → β → γ) : nonempty α → nonempty β → nonempty γ
 | ⟨x⟩ ⟨y⟩ := ⟨f x y⟩
 
-protected lemma nonempty.congr {α : Sort u} {β : Sort v} (f : α → β) (g : β → α) :
+protected lemma nonempty.congr {α β} (f : α → β) (g : β → α) :
   nonempty α ↔ nonempty β :=
 ⟨nonempty.map f, nonempty.map g⟩
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1305,7 +1305,7 @@ decidable.by_cases (λ h, or.inl (if_pos h)) (λ h, or.inr (if_neg h))
 /-! ### Declarations about `nonempty` -/
 
 section nonempty
-universe variables u v w
+universes u v w
 variables {α : Type u} {β : Type v} {γ : α → Type w}
 
 attribute [simp] nonempty_of_inhabited

--- a/src/logic/relator.lean
+++ b/src/logic/relator.lean
@@ -9,7 +9,7 @@ Relator for functions, pairs, sums, and lists.
 import logic.basic
 
 namespace relator
-universe variables u₁ u₂ v₁ v₂
+universes u₁ u₂ v₁ v₂
 
 /- TODO(johoelzl):
  * should we introduce relators of datatypes as recursive function or as inductive

--- a/src/measure_theory/measure/content.lean
+++ b/src/measure_theory/measure/content.lean
@@ -48,7 +48,7 @@ We prove that, on a locally compact space, the measure `μ.measure` is regular.
 * <https://en.wikipedia.org/wiki/Content_(measure_theory)>
 -/
 
-universe variables u v w
+universes u v w
 noncomputable theory
 
 open set topological_space

--- a/src/model_theory/basic.lean
+++ b/src/model_theory/basic.lean
@@ -37,7 +37,7 @@ For the Flypitch project:
 the continuum hypothesis*][flypitch_itp]
 
 -/
-universe variables u v
+universes u v
 
 namespace first_order
 

--- a/src/order/category/NonemptyFinLinOrd.lean
+++ b/src/order/category/NonemptyFinLinOrd.lean
@@ -12,7 +12,7 @@ import order.category.LinearOrder
 Nonempty finite linear orders form the index category for simplicial objects.
 -/
 
-universe variables u v
+universes u v
 
 open category_theory
 

--- a/src/order/copy.lean
+++ b/src/order/copy.lean
@@ -13,7 +13,7 @@ where one replaces the data parts with provably equal definitions
 that have better definitional properties.
 -/
 
-universe variable u
+universe u
 
 variables {α : Type u}
 

--- a/src/ring_theory/algebraic.lean
+++ b/src/ring_theory/algebraic.lean
@@ -17,7 +17,7 @@ The main result in this file proves transitivity of algebraicity:
 a tower of algebraic field extensions is algebraic.
 -/
 
-universe variables u v
+universes u v
 
 open_locale classical
 open polynomial

--- a/src/ring_theory/flat.lean
+++ b/src/ring_theory/flat.lean
@@ -46,7 +46,7 @@ This result is not yet formalised.
 
 -/
 
-universe variables u v
+universes u v
 
 namespace module
 open function (injective)

--- a/src/ring_theory/henselian.lean
+++ b/src/ring_theory/henselian.lean
@@ -58,7 +58,7 @@ https://gist.github.com/jcommelin/47d94e4af092641017a97f7f02bf9598
 
 noncomputable theory
 
-universe variables u v
+universes u v
 
 open_locale big_operators
 

--- a/src/ring_theory/witt_vector/is_poly.lean
+++ b/src/ring_theory/witt_vector/is_poly.lean
@@ -158,7 +158,7 @@ end interactive
 end tactic
 
 namespace witt_vector
-universe variable u
+universe u
 
 variables {p : ℕ} {R S : Type u} {σ idx : Type*} [hp : fact p.prime] [comm_ring R] [comm_ring S]
 

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -14,7 +14,7 @@ import tactic.lean_core_docs
 import tactic.interactive_expr
 import system.io
 
-universe variable u
+universe u
 
 attribute [derive [has_reflect, decidable_eq]] tactic.transparency
 

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -17,7 +17,7 @@ applications the underlying type is a monoid (multiplicative or additive), we do
 the definitions.
 -/
 
-universe variables u v
+universes u v
 open classical set filter topological_space
 open_locale classical topological_space big_operators pointwise
 

--- a/src/topology/algebra/weak_dual_topology.lean
+++ b/src/topology/algebra/weak_dual_topology.lean
@@ -72,12 +72,13 @@ noncomputable theory
 open filter
 open_locale topological_space
 
+universes u v
+
 section weak_star_topology
 /-!
 ### Weak star topology on duals of topological modules
 -/
 
-universes u v
 variables (𝕜 : Type*) [topological_space 𝕜] [semiring 𝕜]
 variables (E : Type*) [topological_space E] [add_comm_monoid E] [module 𝕜 E]
 

--- a/src/topology/algebra/weak_dual_topology.lean
+++ b/src/topology/algebra/weak_dual_topology.lean
@@ -77,7 +77,7 @@ section weak_star_topology
 ### Weak star topology on duals of topological modules
 -/
 
-universe variables u v
+universes u v
 variables (𝕜 : Type*) [topological_space 𝕜] [semiring 𝕜]
 variables (E : Type*) [topological_space E] [add_comm_monoid E] [module 𝕜 E]
 

--- a/src/topology/category/Compactum.lean
+++ b/src/topology/category/Compactum.lean
@@ -69,7 +69,7 @@ We also add wrappers around structures which already exist. Here are the main on
 
 -/
 
-universe variable u
+universe u
 open category_theory filter ultrafilter topological_space category_theory.limits has_finite_inter
 open_locale classical topological_space
 

--- a/src/topology/category/Profinite/default.lean
+++ b/src/topology/category/Profinite/default.lean
@@ -41,7 +41,7 @@ profinite
 
 -/
 
-universe variable u
+universe u
 
 open category_theory
 

--- a/src/topology/category/Profinite/projective.lean
+++ b/src/topology/category/Profinite/projective.lean
@@ -25,7 +25,7 @@ Let `X` be a profinite set.
 
 noncomputable theory
 
-universe variables u v w
+universes u v w
 open category_theory function
 
 namespace Profinite

--- a/test/simps.lean
+++ b/test/simps.lean
@@ -1,7 +1,7 @@
 import tactic.simps
 import algebra.group.hom
 
-universe variables v u w
+universes v u w
 -- set_option trace.simps.verbose true
 -- set_option trace.simps.debug true
 -- set_option trace.app_builder true


### PR DESCRIPTION
Most of these uses are relics of when the distinction between `universe` and `universe variable` was more significant. There is still a difference inside sections, but it's an edge case and I don't think any of these uses are consciously trying to handle the edge case.