### PR TITLE
[Merged by Bors] - chore(data/real): make more instances on real, nnreal, and ennreal computable

### DIFF
--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -150,6 +150,14 @@ instance ordered_comm_semiring [ordered_comm_semiring α] : ordered_comm_semirin
 subtype.coe_injective.ordered_comm_semiring
   (coe : {x : α // 0 ≤ x} → α) rfl rfl (λ x y, rfl) (λ x y, rfl)
 
+-- These prevent noncomputable instances being found, as it does not require `linear_order` which
+-- is frequently non-computable.
+instance monoid_with_zero [ordered_semiring α] : monoid_with_zero {x : α // 0 ≤ x} :=
+by apply_instance
+
+instance comm_monoid_with_zero [ordered_comm_semiring α] : comm_monoid_with_zero {x : α // 0 ≤ x} :=
+by apply_instance
+
 instance nontrivial [linear_ordered_semiring α] : nontrivial {x : α // 0 ≤ x} :=
 ⟨ ⟨0, 1, λ h, zero_ne_one (congr_arg subtype.val h)⟩ ⟩
 

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -87,6 +87,8 @@ end
 instance : ring ℝ               := by apply_instance
 instance : comm_semiring ℝ      := by apply_instance
 instance : semiring ℝ           := by apply_instance
+instance : comm_monoid_with_zero ℝ := by apply_instance
+instance : monoid_with_zero ℝ   := by apply_instance
 instance : add_comm_group ℝ     := by apply_instance
 instance : add_group ℝ          := by apply_instance
 instance : add_comm_monoid ℝ    := by apply_instance
@@ -198,7 +200,7 @@ begin
   simpa only [mk_lt, mk_pos, ← mk_mul] using cau_seq.mul_pos
 end
 
-instance : ordered_ring ℝ :=
+instance : ordered_comm_ring ℝ :=
 { add_le_add_left :=
   begin
     simp only [le_iff_eq_or_lt],
@@ -210,6 +212,7 @@ instance : ordered_ring ℝ :=
   mul_pos     := @real.mul_pos,
   .. real.comm_ring, .. real.partial_order, .. real.semiring }
 
+instance : ordered_ring ℝ               := by apply_instance
 instance : ordered_semiring ℝ           := by apply_instance
 instance : ordered_add_comm_group ℝ     := by apply_instance
 instance : ordered_cancel_add_comm_monoid ℝ := by apply_instance

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -265,27 +265,24 @@ noncomputable def of_nnreal_hom : ℝ≥0 →+* ℝ≥0∞ :=
 
 section actions
 
-instance {M : Type*} [has_scalar ℝ≥0∞ M] : has_scalar ℝ≥0 M :=
-has_scalar.comp M (coe : ℝ≥0 → ℝ≥0∞)
-
-lemma smul_def {M : Type*} [has_scalar ℝ≥0∞ M] (c : ℝ≥0) (x : M) :
-  c • x = (c : ℝ≥0∞) • x := rfl
-
-instance {M N : Type*} [has_scalar ℝ≥0∞ M] [has_scalar ℝ≥0∞ N] [has_scalar M N]
-  [is_scalar_tower ℝ≥0∞ M N] : is_scalar_tower ℝ≥0 M N :=
-{ smul_assoc := λ r, (smul_assoc (r : ℝ≥0∞) : _)}
-
-instance smul_comm_class_left {M N : Type*} [has_scalar ℝ≥0∞ N] [has_scalar M N]
-  [smul_comm_class ℝ≥0∞ M N] : smul_comm_class ℝ≥0 M N :=
-{ smul_comm := λ r, (smul_comm (r : ℝ≥0∞) : _)}
-
-instance smul_comm_class_right {M N : Type*} [has_scalar ℝ≥0∞ N] [has_scalar M N]
-  [smul_comm_class M ℝ≥0∞ N] : smul_comm_class M ℝ≥0 N :=
-{ smul_comm := λ m r, (smul_comm m (r : ℝ≥0∞) : _)}
-
 /-- A `mul_action` over `ℝ≥0∞` restricts to a `mul_action` over `ℝ≥0`. -/
 noncomputable instance {M : Type*} [mul_action ℝ≥0∞ M] : mul_action ℝ≥0 M :=
 mul_action.comp_hom M of_nnreal_hom.to_monoid_hom
+
+lemma smul_def {M : Type*} [mul_action ℝ≥0∞ M] (c : ℝ≥0) (x : M) :
+  c • x = (c : ℝ≥0∞) • x := rfl
+
+instance {M N : Type*} [mul_action ℝ≥0∞ M] [mul_action ℝ≥0∞ N] [has_scalar M N]
+  [is_scalar_tower ℝ≥0∞ M N] : is_scalar_tower ℝ≥0 M N :=
+{ smul_assoc := λ r, (smul_assoc (r : ℝ≥0∞) : _)}
+
+instance smul_comm_class_left {M N : Type*} [mul_action ℝ≥0∞ N] [has_scalar M N]
+  [smul_comm_class ℝ≥0∞ M N] : smul_comm_class ℝ≥0 M N :=
+{ smul_comm := λ r, (smul_comm (r : ℝ≥0∞) : _)}
+
+instance smul_comm_class_right {M N : Type*} [mul_action ℝ≥0∞ N] [has_scalar M N]
+  [smul_comm_class M ℝ≥0∞ N] : smul_comm_class M ℝ≥0 N :=
+{ smul_comm := λ m r, (smul_comm m (r : ℝ≥0∞) : _)}
 
 /-- A `distrib_mul_action` over `ℝ≥0∞` restricts to a `distrib_mul_action` over `ℝ≥0`. -/
 noncomputable instance {M : Type*} [add_monoid M] [distrib_mul_action ℝ≥0∞ M] :
@@ -310,11 +307,8 @@ noncomputable example : distrib_mul_action (units ℝ≥0) ℝ≥0∞ := by appl
 lemma coe_smul {R} (r : R) (s : ℝ≥0) [has_scalar R ℝ≥0] [has_scalar R ℝ≥0∞]
   [is_scalar_tower R ℝ≥0 ℝ≥0] [is_scalar_tower R ℝ≥0 ℝ≥0∞] :
   (↑(r • s) : ℝ≥0∞) = r • ↑s :=
-begin
-  rw ←smul_one_smul ℝ≥0 r (s: ℝ≥0∞),
-  change ↑(r • s) = ↑(r • (1 : ℝ≥0)) * ↑s,
-  rw [←ennreal.coe_mul, smul_mul_assoc, one_mul],
-end
+by rw [←smul_one_smul ℝ≥0 r (s: ℝ≥0∞), smul_def, smul_eq_mul, ←ennreal.coe_mul, smul_mul_assoc,
+    one_mul]
 
 end actions
 

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -68,7 +68,6 @@ context, or if we have `(f : α → ℝ≥0∞) (hf : ∀ x, f x ≠ ∞)`.
 * `∞`: a localized notation in `ℝ≥0∞` for `⊤ : ℝ≥0∞`.
 
 -/
-noncomputable theory
 open classical set
 
 open_locale classical big_operators nnreal
@@ -76,14 +75,16 @@ variables {α : Type*} {β : Type*}
 
 /-- The extended nonnegative real numbers. This is usually denoted [0, ∞],
   and is relevant as the codomain of a measure. -/
-@[derive [canonically_ordered_comm_semiring, complete_linear_order, densely_ordered, nontrivial,
+@[derive [
+  has_zero, add_comm_monoid,
+  canonically_ordered_comm_semiring, complete_linear_order, densely_ordered, nontrivial,
   canonically_linear_ordered_add_monoid, has_sub, has_ordered_sub]]
 def ennreal := with_top ℝ≥0
 
 localized "notation `ℝ≥0∞` := ennreal" in ennreal
 localized "notation `∞` := (⊤ : ennreal)" in ennreal
 
-instance : linear_ordered_add_comm_monoid ℝ≥0∞ :=
+noncomputable instance : linear_ordered_add_comm_monoid ℝ≥0∞ :=
 { .. ennreal.canonically_ordered_comm_semiring,
   .. ennreal.complete_linear_order }
 
@@ -111,7 +112,7 @@ protected def to_nnreal : ℝ≥0∞ → ℝ≥0
 protected def to_real (a : ℝ≥0∞) : real := coe (a.to_nnreal)
 
 /-- `of_real x` returns `x` if it is nonnegative, `0` otherwise. -/
-protected def of_real (r : real) : ℝ≥0∞ := coe (real.to_nnreal r)
+protected noncomputable def of_real (r : real) : ℝ≥0∞ := coe (real.to_nnreal r)
 
 @[simp, norm_cast] lemma to_nnreal_coe : (r : ℝ≥0∞).to_nnreal = r := rfl
 
@@ -257,52 +258,56 @@ lemma supr_ennreal {α : Type*} [complete_lattice α] {f : ℝ≥0∞ → α} :
 @[simp] lemma top_add : ∞ + a = ∞ := with_top.top_add
 
 /-- Coercion `ℝ≥0 → ℝ≥0∞` as a `ring_hom`. -/
-def of_nnreal_hom : ℝ≥0 →+* ℝ≥0∞ :=
+noncomputable def of_nnreal_hom : ℝ≥0 →+* ℝ≥0∞ :=
 ⟨coe, coe_one, λ _ _, coe_mul, coe_zero, λ _ _, coe_add⟩
 
 @[simp] lemma coe_of_nnreal_hom : ⇑of_nnreal_hom = coe := rfl
 
 section actions
 
-/-- A `mul_action` over `ℝ≥0∞` restricts to a `mul_action` over `ℝ≥0`. -/
-instance {M : Type*} [mul_action ℝ≥0∞ M] : mul_action ℝ≥0 M :=
-mul_action.comp_hom M of_nnreal_hom.to_monoid_hom
+instance {M : Type*} [has_scalar ℝ≥0∞ M] : has_scalar ℝ≥0 M :=
+has_scalar.comp M (coe : ℝ≥0 → ℝ≥0∞)
 
-lemma smul_def {M : Type*} [mul_action ℝ≥0∞ M] (c : ℝ≥0) (x : M) :
+lemma smul_def {M : Type*} [has_scalar ℝ≥0∞ M] (c : ℝ≥0) (x : M) :
   c • x = (c : ℝ≥0∞) • x := rfl
 
-instance {M N : Type*} [mul_action ℝ≥0∞ M] [mul_action ℝ≥0∞ N] [has_scalar M N]
+instance {M N : Type*} [has_scalar ℝ≥0∞ M] [has_scalar ℝ≥0∞ N] [has_scalar M N]
   [is_scalar_tower ℝ≥0∞ M N] : is_scalar_tower ℝ≥0 M N :=
 { smul_assoc := λ r, (smul_assoc (r : ℝ≥0∞) : _)}
 
-instance smul_comm_class_left {M N : Type*} [mul_action ℝ≥0∞ N] [has_scalar M N]
+instance smul_comm_class_left {M N : Type*} [has_scalar ℝ≥0∞ N] [has_scalar M N]
   [smul_comm_class ℝ≥0∞ M N] : smul_comm_class ℝ≥0 M N :=
 { smul_comm := λ r, (smul_comm (r : ℝ≥0∞) : _)}
 
-instance smul_comm_class_right {M N : Type*} [mul_action ℝ≥0∞ N] [has_scalar M N]
+instance smul_comm_class_right {M N : Type*} [has_scalar ℝ≥0∞ N] [has_scalar M N]
   [smul_comm_class M ℝ≥0∞ N] : smul_comm_class M ℝ≥0 N :=
 { smul_comm := λ m r, (smul_comm m (r : ℝ≥0∞) : _)}
 
+/-- A `mul_action` over `ℝ≥0∞` restricts to a `mul_action` over `ℝ≥0`. -/
+noncomputable instance {M : Type*} [mul_action ℝ≥0∞ M] : mul_action ℝ≥0 M :=
+mul_action.comp_hom M of_nnreal_hom.to_monoid_hom
+
 /-- A `distrib_mul_action` over `ℝ≥0∞` restricts to a `distrib_mul_action` over `ℝ≥0`. -/
-instance {M : Type*} [add_monoid M] [distrib_mul_action ℝ≥0∞ M] : distrib_mul_action ℝ≥0 M :=
+noncomputable instance {M : Type*} [add_monoid M] [distrib_mul_action ℝ≥0∞ M] :
+  distrib_mul_action ℝ≥0 M :=
 distrib_mul_action.comp_hom M of_nnreal_hom.to_monoid_hom
 
 /-- A `module` over `ℝ≥0∞` restricts to a `module` over `ℝ≥0`. -/
-instance {M : Type*} [add_comm_monoid M] [module ℝ≥0∞ M] : module ℝ≥0 M :=
+noncomputable instance {M : Type*} [add_comm_monoid M] [module ℝ≥0∞ M] : module ℝ≥0 M :=
 module.comp_hom M of_nnreal_hom
 
 /-- An `algebra` over `ℝ≥0∞` restricts to an `algebra` over `ℝ≥0`. -/
-instance {A : Type*} [semiring A] [algebra ℝ≥0∞ A] : algebra ℝ≥0 A :=
+noncomputable instance {A : Type*} [semiring A] [algebra ℝ≥0∞ A] : algebra ℝ≥0 A :=
 { smul := (•),
   commutes' := λ r x, by simp [algebra.commutes],
   smul_def' := λ r x, by simp [←algebra.smul_def (r : ℝ≥0∞) x, smul_def],
   to_ring_hom := ((algebra_map ℝ≥0∞ A).comp (of_nnreal_hom : ℝ≥0 →+* ℝ≥0∞)) }
 
 -- verify that the above produces instances we might care about
-example : algebra ℝ≥0 ℝ≥0∞ := by apply_instance
-example : distrib_mul_action (units ℝ≥0) ℝ≥0∞ := by apply_instance
+noncomputable example : algebra ℝ≥0 ℝ≥0∞ := by apply_instance
+noncomputable example : distrib_mul_action (units ℝ≥0) ℝ≥0∞ := by apply_instance
 
-lemma coe_smul {R} [monoid R] (r : R) (s : ℝ≥0) [mul_action R ℝ≥0] [has_scalar R ℝ≥0∞]
+lemma coe_smul {R} (r : R) (s : ℝ≥0) [has_scalar R ℝ≥0] [has_scalar R ℝ≥0∞]
   [is_scalar_tower R ℝ≥0 ℝ≥0] [is_scalar_tower R ℝ≥0 ℝ≥0∞] :
   (↑(r • s) : ℝ≥0∞) = r • ↑s :=
 begin
@@ -971,6 +976,8 @@ by unfold bit1; rw add_eq_top; simp
 end bit
 
 section inv
+noncomputable theory
+
 instance : has_inv ℝ≥0∞ := ⟨λa, Inf {b | 1 ≤ a * b}⟩
 
 instance : div_inv_monoid ℝ≥0∞ :=

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -46,12 +46,12 @@ of `x` with `↑x`. This tactic also works for a function `f : α → ℝ` with 
 This file defines `ℝ≥0` as a localized notation for `nnreal`.
 -/
 
-noncomputable theory
-
 open_locale classical big_operators
 
 /-- Nonnegative real numbers. -/
-@[derive [semilattice_inf_bot, densely_ordered,
+@[derive [
+  ordered_semiring, comm_monoid_with_zero, -- to ensure these instance are computable
+  semilattice_inf_bot, densely_ordered,
   canonically_linear_ordered_add_monoid, linear_ordered_comm_group_with_zero, archimedean,
   linear_ordered_semiring, ordered_comm_semiring, canonically_ordered_comm_semiring,
   has_sub, has_ordered_sub, has_div, inhabited]]
@@ -79,7 +79,7 @@ lemma ne_iff {x y : ℝ≥0} : (x : ℝ) ≠ (y : ℝ) ↔ x ≠ y :=
 not_iff_not_of_iff $ nnreal.eq_iff
 
 /-- Reinterpret a real number `r` as a non-negative real number. Returns `0` if `r < 0`. -/
-def _root_.real.to_nnreal (r : ℝ) : ℝ≥0 := ⟨max r 0, le_max_right _ _⟩
+noncomputable def _root_.real.to_nnreal (r : ℝ) : ℝ≥0 := ⟨max r 0, le_max_right _ _⟩
 
 lemma _root_.real.coe_to_nnreal (r : ℝ) (hr : 0 ≤ r) : (real.to_nnreal r : ℝ) = r :=
 max_eq_left hr
@@ -94,11 +94,11 @@ theorem coe_mk (a : ℝ) (ha) : ((⟨a, ha⟩ : ℝ≥0) : ℝ) = a := rfl
 example : has_zero ℝ≥0  := by apply_instance
 example : has_one ℝ≥0   := by apply_instance
 example : has_add ℝ≥0   := by apply_instance
-example : has_sub ℝ≥0   := by apply_instance
+noncomputable example : has_sub ℝ≥0   := by apply_instance
 example : has_mul ℝ≥0   := by apply_instance
-example : has_inv ℝ≥0   := by apply_instance
-example : has_div ℝ≥0   := by apply_instance
-example : has_le ℝ≥0    := by apply_instance
+noncomputable example : has_inv ℝ≥0   := by apply_instance
+noncomputable example : has_div ℝ≥0   := by apply_instance
+noncomputable example : has_le ℝ≥0    := by apply_instance
 example : has_bot ℝ≥0   := by apply_instance
 example : inhabited ℝ≥0 := by apply_instance
 example : nontrivial ℝ≥0 := by apply_instance
@@ -178,7 +178,9 @@ example : distrib_mul_action (units ℝ≥0) ℝ := by apply_instance
 
 end actions
 
-example : comm_group_with_zero ℝ≥0 := by apply_instance
+example : monoid_with_zero ℝ≥0 := by apply_instance
+example : comm_monoid_with_zero ℝ≥0 := by apply_instance
+noncomputable example : comm_group_with_zero ℝ≥0 := by apply_instance
 
 @[simp, norm_cast] lemma coe_indicator {α} (s : set α) (f : α → ℝ≥0) (a : α) :
   ((s.indicator f a : ℝ≥0) : ℝ) = s.indicator (λ x, f x) a :=
@@ -233,7 +235,7 @@ by norm_cast
 @[simp, norm_cast] protected lemma coe_nat_cast (n : ℕ) : (↑(↑n : ℝ≥0) : ℝ) = n :=
 to_real_hom.map_nat_cast n
 
-example : linear_order ℝ≥0 := by apply_instance
+noncomputable example : linear_order ℝ≥0 := by apply_instance
 
 @[simp, norm_cast] protected lemma coe_le_coe {r₁ r₂ : ℝ≥0} : (r₁ : ℝ) ≤ r₂ ↔ r₁ ≤ r₂ := iff.rfl
 @[simp, norm_cast] protected lemma coe_lt_coe {r₁ r₂ : ℝ≥0} : (r₁ : ℝ) < r₂ ↔ r₁ < r₂ := iff.rfl
@@ -254,21 +256,24 @@ nnreal.eq (nnreal.coe_nat_cast n).symm
 nnreal.eq $ by simp [real.coe_to_nnreal]
 
 /-- `real.to_nnreal` and `coe : ℝ≥0 → ℝ` form a Galois insertion. -/
-protected def gi : galois_insertion real.to_nnreal coe :=
+noncomputable def gi : galois_insertion real.to_nnreal coe :=
 galois_insertion.monotone_intro nnreal.coe_mono real.to_nnreal_mono
   real.le_coe_to_nnreal (λ _, real.to_nnreal_coe)
 
+-- note that anything involving the (decidability of the) linear order, including `⊔`/`⊓` (min, max)
+-- will be noncomputable, everything else should not be.
 example : order_bot ℝ≥0 := by apply_instance
-example : canonically_linear_ordered_add_monoid ℝ≥0 := by apply_instance
-example : linear_ordered_add_comm_monoid ℝ≥0 := by apply_instance
-example : distrib_lattice ℝ≥0 := by apply_instance
-example : semilattice_inf_bot ℝ≥0 := by apply_instance
-example : semilattice_sup_bot ℝ≥0 := by apply_instance
-example : linear_ordered_semiring ℝ≥0 := by apply_instance
+example : partial_order ℝ≥0 := by apply_instance
+noncomputable example : canonically_linear_ordered_add_monoid ℝ≥0 := by apply_instance
+noncomputable example : linear_ordered_add_comm_monoid ℝ≥0 := by apply_instance
+noncomputable example : distrib_lattice ℝ≥0 := by apply_instance
+noncomputable example : semilattice_inf_bot ℝ≥0 := by apply_instance
+noncomputable example : semilattice_sup_bot ℝ≥0 := by apply_instance
+noncomputable example : linear_ordered_semiring ℝ≥0 := by apply_instance
 example : ordered_comm_semiring ℝ≥0 := by apply_instance
-example : linear_ordered_comm_monoid  ℝ≥0 := by apply_instance
-example : linear_ordered_comm_monoid_with_zero ℝ≥0 := by apply_instance
-example : linear_ordered_comm_group_with_zero ℝ≥0 := by apply_instance
+noncomputable example : linear_ordered_comm_monoid  ℝ≥0 := by apply_instance
+noncomputable example : linear_ordered_comm_monoid_with_zero ℝ≥0 := by apply_instance
+noncomputable example : linear_ordered_comm_group_with_zero ℝ≥0 := by apply_instance
 example : canonically_ordered_comm_semiring ℝ≥0 := by apply_instance
 example : densely_ordered ℝ≥0 := by apply_instance
 example : no_top_order ℝ≥0 := by apply_instance
@@ -282,7 +287,7 @@ iff.intro
 lemma bdd_below_coe (s : set ℝ≥0) : bdd_below ((coe : ℝ≥0 → ℝ) '' s) :=
 ⟨0, assume r ⟨q, _, eq⟩, eq ▸ q.2⟩
 
-instance : conditionally_complete_linear_order_bot ℝ≥0 :=
+noncomputable instance : conditionally_complete_linear_order_bot ℝ≥0 :=
 { cSup_empty := (function.funext_iff.1
     (@subset_Sup_def ℝ (set.Ici (0 : ℝ)) _ ⟨(0 : ℝ≥0)⟩) ∅).trans $ nnreal.eq $ by simp,
   .. (by apply_instance : order_bot ℝ≥0),
@@ -307,10 +312,10 @@ end
 
 -- TODO: generalize to some ordered add_monoids, based on #6145
 lemma le_of_add_le_left {a b c : ℝ≥0} (h : a + b ≤ c) : a ≤ c :=
-by { refine le_trans _ h, simp }
+by { refine le_trans _ h, exact (le_add_iff_nonneg_right _).mpr zero_le' }
 
 lemma le_of_add_le_right {a b c : ℝ≥0} (h : a + b ≤ c) : b ≤ c :=
-by { refine le_trans _ h, simp }
+by { refine le_trans _ h, exact (le_add_iff_nonneg_left _).mpr zero_le' }
 
 lemma lt_iff_exists_rat_btwn (a b : ℝ≥0) :
   a < b ↔ (∃q:ℚ, 0 ≤ q ∧ a < real.to_nnreal q ∧ real.to_nnreal q < b) :=
@@ -493,7 +498,7 @@ lemma sub_def {r p : ℝ≥0} : r - p = real.to_nnreal (r - p) := rfl
 
 lemma coe_sub_def {r p : ℝ≥0} : ↑(r - p) = max (r - p : ℝ) 0 := rfl
 
-example : has_ordered_sub ℝ≥0 := by apply_instance
+noncomputable example : has_ordered_sub ℝ≥0 := by apply_instance
 
 lemma sub_div (a b c : ℝ≥0) : (a - b) / c = a / c - b / c :=
 by simp only [div_eq_mul_inv, sub_mul']
@@ -660,14 +665,14 @@ end nnreal
 namespace real
 
 /-- The absolute value on `ℝ` as a map to `ℝ≥0`. -/
-@[pp_nodot] def nnabs : monoid_with_zero_hom ℝ ℝ≥0 :=
+@[pp_nodot] noncomputable def nnabs : monoid_with_zero_hom ℝ ℝ≥0 :=
 { to_fun := λ x, ⟨|x|, abs_nonneg x⟩,
   map_zero' := by { ext, simp },
   map_one' := by { ext, simp },
   map_mul' := λ x y, by { ext, simp [abs_mul] } }
 
 @[norm_cast, simp] lemma coe_nnabs (x : ℝ) : (nnabs x : ℝ) = |x| :=
-by simp [nnabs]
+rfl
 
 @[simp] lemma nnabs_of_nonneg {x : ℝ} (h : 0 ≤ x) : nnabs x = to_nnreal x :=
 by { ext, simp [coe_to_nnreal x h, abs_of_nonneg h] }


### PR DESCRIPTION
This makes it possible to talk about the add_monoid structure of nnreal and ennreal without worrying about computability.

To make it clear exactly which operations are computable, we remove `noncomputable theory`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
