### PR TITLE
[Merged by Bors] - [Merged by Bors] - fix(topology/sheaves/*): Fix docstrings

### DIFF
--- a/src/topology/sheaves/forget.lean
+++ b/src/topology/sheaves/forget.lean
@@ -202,9 +202,10 @@ As an example, we now have everything we need to check the sheaf condition
 for a presheaf of commutative rings, merely by checking the sheaf condition
 for the underlying sheaf of types.
 ```
-example (X : Top) (F : presheaf CommRing X) (h : sheaf_condition (F ⋙ (forget CommRing))) :
-  sheaf_condition F :=
-(sheaf_condition_equiv_sheaf_condition_forget F).symm h
+import algebra.category.CommRing.limits
+example (X : Top) (F : presheaf CommRing X) (h : presheaf.is_sheaf (F ⋙ (forget CommRing))) :
+  F.is_sheaf :=
+(is_sheaf_iff_is_sheaf_comp (forget CommRing) F).mpr h
 ```
 -/
 

--- a/src/topology/sheaves/local_predicate.lean
+++ b/src/topology/sheaves/local_predicate.lean
@@ -26,7 +26,7 @@ any collection of dependent functions on a topological space
 satisfying a "local predicate".
 
 As an application, we check that continuity is a local predicate in this sense, and provide
-* `Top.sheaf_condition.to_Top`: continuous functions into a topological space form a sheaf
+* `Top.sheaf_to_Top`: continuous functions into a topological space form a sheaf
 
 A sheaf constructed in this way has a natural map `stalk_to_fiber` from the stalks
 to the types in the ambient type family.

--- a/src/topology/sheaves/sheaf_condition/opens_le_cover.lean
+++ b/src/topology/sheaves/sheaf_condition/opens_le_cover.lean
@@ -87,7 +87,7 @@ open sheaf_condition
 /--
 An equivalent formulation of the sheaf condition
 (which we prove equivalent to the usual one below as
-`sheaf_condition_equiv_sheaf_condition_opens_le_cover`).
+`is_sheaf_iff_is_sheaf_opens_le_cover`).
 
 A presheaf is a sheaf if `F` sends the cone `(opens_le_cover_cocone U).op` to a limit cone.
 (Recall `opens_le_cover_cocone U`, has cone point `supr U`,

--- a/src/topology/sheaves/sheaf_condition/pairwise_intersections.lean
+++ b/src/topology/sheaves/sheaf_condition/pairwise_intersections.lean
@@ -49,7 +49,7 @@ variables {C : Type u} [category.{v} C]
 /--
 An alternative formulation of the sheaf condition
 (which we prove equivalent to the usual one below as
-`sheaf_condition_equiv_sheaf_condition_pairwise_intersections`).
+`is_sheaf_iff_is_sheaf_pairwise_intersections`).
 
 A presheaf is a sheaf if `F` sends the cone `(pairwise.cocone U).op` to a limit cone.
 (Recall `pairwise.cocone U` has cone point `supr U`, mapping down to the `U i` and the `U i ⊓ U j`.)
@@ -60,7 +60,7 @@ def is_sheaf_pairwise_intersections (F : presheaf C X) : Prop :=
 /--
 An alternative formulation of the sheaf condition
 (which we prove equivalent to the usual one below as
-`sheaf_condition_equiv_sheaf_condition_preserves_limit_pairwise_intersections`).
+`is_sheaf_iff_is_sheaf_preserves_limit_pairwise_intersections`).
 
 A presheaf is a sheaf if `F` preserves the limit of `pairwise.diagram U`.
 (Recall `pairwise.diagram U` is the diagram consisting of the pairwise intersections

--- a/src/topology/sheaves/sheaf_condition/unique_gluing.lean
+++ b/src/topology/sheaves/sheaf_condition/unique_gluing.lean
@@ -80,7 +80,7 @@ condition if and only if, for every compatible family of sections `sf : Π i : �
 there exists a unique gluing `s : F.obj (op (supr U))`.
 
 We prove this to be equivalent to the usual one below in
-`sheaf_condition_equiv_sheaf_condition_unique_gluing`
+`is_sheaf_iff_is_sheaf_unique_gluing`
 -/
 def is_sheaf_unique_gluing : Prop :=
 ∀ ⦃ι : Type v⦄ (U : ι → opens X) (sf : Π i : ι, F.obj (op (U i))),

--- a/src/topology/sheaves/sheaf_of_functions.lean
+++ b/src/topology/sheaves/sheaf_of_functions.lean
@@ -12,11 +12,11 @@ import topology.local_homeomorph
 # Sheaf conditions for presheaves of (continuous) functions.
 
 We show that
-* `Top.sheaf_condition.to_Type`: not-necessarily-continuous functions into a type form a sheaf
-* `Top.sheaf_condition.to_Types`: in fact, these may be dependent functions into a type family
+* `Top.presheaf.to_Type_is_sheaf`: not-necessarily-continuous functions into a type form a sheaf
+* `Top.presheaf.to_Types_is_sheaf`: in fact, these may be dependent functions into a type family
 
 For
-* `Top.sheaf_condition.to_Top`: continuous functions into a topological space form a sheaf
+* `Top.sheaf_to_Top`: continuous functions into a topological space form a sheaf
 please see `topology/sheaves/local_predicate.lean`, where we set up a general framework
 for constructing sub(pre)sheaves of the sheaf of dependent functions.
 


### PR DESCRIPTION
As noted by @alreadydone in #9607, I forgot propagate naming changes to docstrings. This PR fixes that.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
