### PR TITLE
[Merged by Bors] - fix(algebra/module/submodule_lattice): correct bad lemma

### DIFF
--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -155,7 +155,7 @@ instance : complete_lattice (submodule R M) :=
   ..submodule.order_top,
   ..submodule.order_bot }
 
-@[simp] theorem inf_coe : (p ⊓ q : set M) = p ∩ q := rfl
+@[simp] theorem inf_coe : ↑(p ⊓ q) = (p ∩ q : set M) := rfl
 
 @[simp] theorem mem_inf {p q : submodule R M} {x : M} :
   x ∈ p ⊓ q ↔ x ∈ p ∧ x ∈ q := iff.rfl


### PR DESCRIPTION
This lemma was accidentally stating that inf and inter are the same on sets, and wasn't about submodule at all.

The old statement was `↑p ⊓ ↑q = ↑p ∩ ↑q`, the new one is `↑(p ⊓ q) = ↑p ∩ ↑q`



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
