### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/exp_log): Classify when log is zero

### DIFF
--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -572,14 +572,17 @@ log_inj_on_pos (set.mem_Ioi.2 h₁) (set.mem_Ioi.2 zero_lt_one) (h₂.trans real
 lemma log_ne_zero_of_pos_of_ne_one {x : ℝ} (hx_pos : 0 < x) (hx : x ≠ 1) : log x ≠ 0 :=
 mt (eq_one_of_pos_of_log_eq_zero hx_pos) hx
 
-lemma log_eq_zero {x : ℝ} (h : log x = 0) : x = 0 ∨ x = 1 ∨ x = -1 :=
+@[simp] lemma log_eq_zero {x : ℝ} : log x = 0 ↔ x = 0 ∨ x = 1 ∨ x = -1 :=
 begin
-  rcases lt_trichotomy x 0 with x_lt_zero | rfl | x_gt_zero,
-  { refine or.inr (or.inr (eq_neg_iff_eq_neg.mp _)),
-    rw [←log_neg_eq_log x] at h,
-    exact (eq_one_of_pos_of_log_eq_zero (neg_pos.mpr x_lt_zero) h).symm, },
-  { exact or.inl rfl },
-  { exact or.inr (or.inl (eq_one_of_pos_of_log_eq_zero x_gt_zero h)), }
+  split,
+  { intros h,
+    rcases lt_trichotomy x 0 with x_lt_zero | rfl | x_gt_zero,
+    { refine or.inr (or.inr (eq_neg_iff_eq_neg.mp _)),
+      rw [←log_neg_eq_log x] at h,
+      exact (eq_one_of_pos_of_log_eq_zero (neg_pos.mpr x_lt_zero) h).symm, },
+    { exact or.inl rfl },
+    { exact or.inr (or.inl (eq_one_of_pos_of_log_eq_zero x_gt_zero h)), }, },
+  { rintro (rfl|rfl|rfl); simp only [log_one, log_zero, log_neg_eq_log], }
 end
 
 /-- The real logarithm function tends to `+∞` at `+∞`. -/

--- a/src/analysis/special_functions/exp_log.lean
+++ b/src/analysis/special_functions/exp_log.lean
@@ -572,6 +572,16 @@ log_inj_on_pos (set.mem_Ioi.2 h₁) (set.mem_Ioi.2 zero_lt_one) (h₂.trans real
 lemma log_ne_zero_of_pos_of_ne_one {x : ℝ} (hx_pos : 0 < x) (hx : x ≠ 1) : log x ≠ 0 :=
 mt (eq_one_of_pos_of_log_eq_zero hx_pos) hx
 
+lemma log_eq_zero {x : ℝ} (h : log x = 0) : x = 0 ∨ x = 1 ∨ x = -1 :=
+begin
+  rcases lt_trichotomy x 0 with x_lt_zero | rfl | x_gt_zero,
+  { refine or.inr (or.inr (eq_neg_iff_eq_neg.mp _)),
+    rw [←log_neg_eq_log x] at h,
+    exact (eq_one_of_pos_of_log_eq_zero (neg_pos.mpr x_lt_zero) h).symm, },
+  { exact or.inl rfl },
+  { exact or.inr (or.inl (eq_one_of_pos_of_log_eq_zero x_gt_zero h)), }
+end
+
 /-- The real logarithm function tends to `+∞` at `+∞`. -/
 lemma tendsto_log_at_top : tendsto log at_top at_top :=
 tendsto_comp_exp_at_top.1 $ by simpa only [log_exp] using tendsto_id


### PR DESCRIPTION
Classify when the real `log` function is zero.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I'm not sure what name this should have. I also believe mathlib convention would be to phrase this as an iff, but really when is the converse going to be useful? There are already simp lemmas for each case of the converse.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
