### PR TITLE
[Merged by Bors] - chore(algebra/big_operators): avoid 'abel' tactic

### DIFF
--- a/archive/oxford_invariants/2021summer/week3_p1.lean
+++ b/archive/oxford_invariants/2021summer/week3_p1.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies, Bhavik Mehta
 -/
 import algebra.big_operators.order
 import algebra.big_operators.ring
+import data.rat.cast
 
 /-!
 # The Oxford Invariants Puzzle Challenges - Summer 2021, Week 3, Problem 1

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -7,6 +7,7 @@ import algebra.iterate_hom
 import data.equiv.ring_aut
 import algebra.module.basic
 import linear_algebra.basic
+import tactic.abel
 
 /-!
 # Algebras over commutative semirings

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -4,9 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 
-import data.finset.fold
+import algebra.group.pi
 import data.equiv.mul_add
-import tactic.abel
+import data.finset.fold
+import data.fintype.basic
 
 /-!
 # Big operators
@@ -901,11 +902,11 @@ lemma sum_range_induction {M : Type*} [add_comm_monoid M]
 reduces to the difference of the last and first terms.-/
 lemma sum_range_sub {G : Type*} [add_comm_group G] (f : ℕ → G) (n : ℕ) :
   ∑ i in range n, (f (i+1) - f i) = f n - f 0 :=
-by { apply sum_range_induction; abel, simp }
+by { apply sum_range_induction; simp }
 
 lemma sum_range_sub' {G : Type*} [add_comm_group G] (f : ℕ → G) (n : ℕ) :
   ∑ i in range n, (f i - f (i+1)) = f 0 - f n :=
-by { apply sum_range_induction; abel, simp }
+by { apply sum_range_induction; simp }
 
 /-- A telescoping product along `{0, ..., n-1}` of a commutative group valued function
 reduces to the ratio of the last and first factors.-/
@@ -1204,7 +1205,7 @@ over `b ∈ s.image g` of `f b` times of the cardinality of the fibre of `b`. Se
 
 lemma eq_sum_range_sub [add_comm_group β] (f : ℕ → β) (n : ℕ) :
   f n = f 0 + ∑ i in range n, (f (i+1) - f i) :=
-by { rw finset.sum_range_sub, abel }
+by rw [finset.sum_range_sub, add_sub_cancel'_right]
 
 lemma eq_sum_range_sub' [add_comm_group β] (f : ℕ → β) (n : ℕ) :
   f n = ∑ i in range (n + 1), if i = 0 then f 0 else f i - f (i - 1) :=

--- a/src/algebra/geom_sum.lean
+++ b/src/algebra/geom_sum.lean
@@ -8,6 +8,7 @@ import algebra.group_with_zero.power
 import algebra.big_operators.order
 import algebra.big_operators.ring
 import algebra.big_operators.intervals
+import tactic.abel
 
 /-!
 # Partial sums of geometric series

--- a/src/algebra/homology/homotopy.lean
+++ b/src/algebra/homology/homotopy.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import algebra.homology.additive
+import tactic.abel
 
 /-!
 # Chain homotopies

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -6,6 +6,7 @@ Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
 import algebra.big_operators.basic
 import algebra.smul_with_zero
 import group_theory.group_action.group
+import tactic.norm_num
 
 /-!
 # Modules over a ring

--- a/src/data/int/interval.lean
+++ b/src/data/int/interval.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import algebra.char_zero
 import data.int.basic
 import data.nat.interval
 

--- a/src/data/pnat/interval.lean
+++ b/src/data/pnat/interval.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import data.nat.interval
+import data.pnat.basic
 
 /-!
 # Finite intervals of positive naturals

--- a/src/linear_algebra/affine_space/affine_map.lean
+++ b/src/linear_algebra/affine_space/affine_map.lean
@@ -8,6 +8,7 @@ import linear_algebra.tensor_product
 import linear_algebra.prod
 import linear_algebra.pi
 import data.set.intervals.unordered_interval
+import tactic.abel
 
 /-!
 # Affine maps

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -5,6 +5,7 @@ Authors: Andreas Swerdlow
 -/
 import ring_theory.ring_invo
 import algebra.module.linear_map
+import tactic.abel
 
 /-!
 # Sesquilinear form

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -8,6 +8,7 @@ import linear_algebra.quotient
 import order.zorn
 import order.atoms
 import order.compactly_generated
+import tactic.abel
 /-!
 
 # Ideals over a ring


### PR DESCRIPTION
I'd like to add an import ` algebra.euclidean_domain` → `algebra.associated` in #9606, so this removes the dependency in the other direction (`algebra.associated` → `algebra.big_operators.basic` → `tactic.abel` → `tactic.norm_num` → `data.rat.cast` → `data.rat.order` → `data.rat.basic` → ` algebra.euclidean_domain`). Fortunately, the dependency on `abel` was quite shallow here.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
