### PR TITLE
[Merged by Bors] - feat(group_theory/index): `relindex_dvd_of_le_left`

### DIFF
--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -90,6 +90,25 @@ end
 
 variables (H K L)
 
+lemma inf_relindex_right : (H ⊓ K).relindex K = H.relindex K :=
+by rw [←subgroup_of_map_subtype, relindex, relindex, subgroup_of,
+  comap_map_eq_self_of_injective (show function.injective K.subtype, from subtype.coe_injective)]
+
+lemma inf_relindex_left : (H ⊓ K).relindex H = K.relindex H :=
+by rw [inf_comm, inf_relindex_right]
+
+variables {H K}
+
+lemma relindex_dvd_of_le_left (hHK : H ≤ K) :
+  K.relindex L ∣ H.relindex L :=
+begin
+  apply dvd_of_mul_left_eq ((H ⊓ L).relindex (K ⊓ L)),
+  rw [←inf_relindex_right H L, ←inf_relindex_right K L,
+      relindex_mul_relindex (inf_le_inf_right L hHK) inf_le_right],
+end
+
+variables (H K)
+
 @[to_additive] lemma index_eq_card [fintype (quotient_group.quotient H)] :
   H.index = fintype.card (quotient_group.quotient H) :=
 cardinal.mk_to_nat_eq_card

--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -93,8 +93,10 @@ end
 variables (H K L)
 
 lemma inf_relindex_right : (H ⊓ K).relindex K = H.relindex K :=
-by rw [←subgroup_of_map_subtype, relindex, relindex, subgroup_of,
-  comap_map_eq_self_of_injective (show function.injective K.subtype, from subtype.coe_injective)]
+begin
+  rw [←subgroup_of_map_subtype, relindex, relindex, subgroup_of, comap_map_eq_self_of_injective],
+  exact subtype.coe_injective,
+end
 
 lemma inf_relindex_left : (H ⊓ K).relindex H = K.relindex H :=
 by rw [inf_comm, inf_relindex_right]
@@ -105,8 +107,8 @@ lemma relindex_dvd_of_le_left (hHK : H ≤ K) :
   K.relindex L ∣ H.relindex L :=
 begin
   apply dvd_of_mul_left_eq ((H ⊓ L).relindex (K ⊓ L)),
-  rw [←inf_relindex_right H L, ←inf_relindex_right K L,
-      relindex_mul_relindex (inf_le_inf_right L hHK) inf_le_right],
+  rw [←inf_relindex_right H L, ←inf_relindex_right K L],
+  exact relindex_mul_relindex (inf_le_inf_right L hHK) inf_le_right,
 end
 
 variables (H K)


### PR DESCRIPTION
If `H ≤ K`, then `K.relindex L ∣ H.relindex L`.

Caution: `relindex_dvd_of_le_right` is not true. `relindex_le_of_le_right` is true, but it is harder to prove, and harder to state (because you have to be careful about `relindex = 0`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
