### PR TITLE
[Merged by Bors] - refactor(order/filter/bases): turn `is_countably_generated` into a class

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -229,7 +229,7 @@ Topology:
   Metric spaces:
     metric space: 'metric_space'
     ball: 'metric.ball'
-    sequential compactness is equivalent to compactness (Bolzano-Weierstrass): 'metric.compact_iff_seq_compact'
+    sequential compactness is equivalent to compactness (Bolzano-Weierstrass): 'uniform_space.compact_iff_seq_compact'
     Heine-Borel theorem (proper metric space version): 'metric.compact_iff_closed_bounded'
     Lipschitz continuity: 'lipschitz_with'
     Hölder continuity: 'holder_with'

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -402,7 +402,7 @@ Topology:
     continuous functions: 'continuous'
     homeomorphisms: 'homeomorph'
     compactness in terms of open covers (Borel-Lebesgue): 'is_compact_iff_finite_subcover'
-    sequential compactness is equivalent to compactness (Bolzano-Weierstrass): 'metric.compact_iff_seq_compact'
+    sequential compactness is equivalent to compactness (Bolzano-Weierstrass): 'uniform_space.compact_iff_seq_compact'
     connectedness: 'connected_space'
     connected components: 'connected_component'
     path connectedness: 'is_path_connected'

--- a/src/analysis/calculus/parametric_integral.lean
+++ b/src/analysis/calculus/parametric_integral.lean
@@ -107,7 +107,6 @@ begin
   rw [has_fderiv_at_iff_tendsto, tendsto_congr' this, ← tendsto_zero_iff_norm_tendsto_zero,
       ← show ∫ (a : α), ∥x₀ - x₀∥⁻¹ • (F x₀ a - F x₀ a - (F' a) (x₀ - x₀)) ∂μ = 0, by simp],
   apply tendsto_integral_filter_of_dominated_convergence,
-  { apply is_countably_generated_nhds },
   { filter_upwards [h_ball],
     intros x x_in,
     apply ae_measurable.const_smul,

--- a/src/measure_theory/function/ae_eq_of_integral.lean
+++ b/src/measure_theory/function/ae_eq_of_integral.lean
@@ -138,7 +138,7 @@ begin
   push_neg at H h,
   obtain ⟨u, u_mono, u_lt, u_lim, -⟩ : ∃ (u : ℕ → β), strict_mono u ∧ (∀ (n : ℕ), u n < c)
       ∧ tendsto u at_top (nhds c) ∧ ∀ (n : ℕ), u n ∈ set.Iio c :=
-    H.exists_seq_strict_mono_tendsto_of_not_mem h (lt_irrefl c),
+    H.exists_seq_strict_mono_tendsto_of_not_mem (lt_irrefl c) h,
   have h_Union : {x | f x < c} = ⋃ (n : ℕ), {x | f x ≤ u n},
   { ext1 x,
     simp_rw [set.mem_Union, set.mem_set_of_eq],

--- a/src/measure_theory/integral/bochner.lean
+++ b/src/measure_theory/integral/bochner.lean
@@ -861,8 +861,8 @@ end
 
 /-- Lebesgue dominated convergence theorem for filters with a countable basis -/
 lemma tendsto_integral_filter_of_dominated_convergence {ι} {l : filter ι}
+  [l.is_countably_generated]
   {F : ι → α → E} {f : α → E} (bound : α → ℝ)
-  (hl_cb : l.is_countably_generated)
   (hF_meas : ∀ᶠ n in l, ae_measurable (F n) μ)
   (f_measurable : ae_measurable f μ)
   (h_bound : ∀ᶠ n in l, ∀ᵐ a ∂μ, ∥F n a∥ ≤ bound a)
@@ -870,25 +870,25 @@ lemma tendsto_integral_filter_of_dominated_convergence {ι} {l : filter ι}
   (h_lim : ∀ᵐ a ∂μ, tendsto (λ n, F n a) l (𝓝 (f a))) :
   tendsto (λn, ∫ a, F n a ∂μ) l (𝓝 $ ∫ a, f a ∂μ) :=
 begin
-  rw hl_cb.tendsto_iff_seq_tendsto,
-  { intros x xl,
-    have hxl, { rw tendsto_at_top' at xl, exact xl },
-    have h := inter_mem hF_meas h_bound,
-    replace h := hxl _ h,
-    rcases h with ⟨k, h⟩,
-    rw ← tendsto_add_at_top_iff_nat k,
-    refine tendsto_integral_of_dominated_convergence _ _ _ _ _ _,
-    { exact bound },
-    { intro, refine (h _ _).1, exact nat.le_add_left _ _ },
+  rw tendsto_iff_seq_tendsto,
+  intros x xl,
+  have hxl, { rw tendsto_at_top' at xl, exact xl },
+  have h := inter_mem hF_meas h_bound,
+  replace h := hxl _ h,
+  rcases h with ⟨k, h⟩,
+  rw ← tendsto_add_at_top_iff_nat k,
+  refine tendsto_integral_of_dominated_convergence _ _ _ _ _ _,
+  { exact bound },
+  { intro, refine (h _ _).1, exact nat.le_add_left _ _ },
+  { assumption },
+  { assumption },
+  { intro, refine (h _ _).2, exact nat.le_add_left _ _ },
+  { filter_upwards [h_lim],
+    assume a h_lim,
+    apply @tendsto.comp _ _ _ (λn, x (n + k)) (λn, F n a),
     { assumption },
-    { assumption },
-    { intro, refine (h _ _).2, exact nat.le_add_left _ _ },
-    { filter_upwards [h_lim],
-      assume a h_lim,
-      apply @tendsto.comp _ _ _ (λn, x (n + k)) (λn, F n a),
-      { assumption },
-      rw tendsto_add_at_top_iff_nat,
-      assumption } },
+    rw tendsto_add_at_top_iff_nat,
+    assumption }
 end
 
 variables {X : Type*} [topological_space X] [first_countable_topology X]
@@ -898,9 +898,7 @@ lemma continuous_at_of_dominated {F : X → α → E} {x₀ : X} {bound : α →
   (h_bound : ∀ᶠ x in 𝓝 x₀, ∀ᵐ a ∂μ, ∥F x a∥ ≤ bound a)
   (bound_integrable : integrable bound μ) (h_cont : ∀ᵐ a ∂μ, continuous_at (λ x, F x a) x₀) :
   continuous_at (λ x, ∫ a, F x a ∂μ) x₀ :=
-tendsto_integral_filter_of_dominated_convergence bound
-  (first_countable_topology.nhds_generated_countable x₀) ‹_›
-    (mem_of_mem_nhds hF_meas : _) ‹_› ‹_› ‹_›
+tendsto_integral_filter_of_dominated_convergence bound ‹_› (mem_of_mem_nhds hF_meas : _) ‹_› ‹_› ‹_›
 
 lemma continuous_of_dominated {F : X → α → E} {bound : α → ℝ}
   (hF_meas : ∀ x, ae_measurable (F x) μ) (h_bound : ∀ x, ∀ᵐ a ∂μ, ∥F x a∥ ≤ bound a)

--- a/src/measure_theory/integral/integral_eq_improper.lean
+++ b/src/measure_theory/integral/integral_eq_improper.lean
@@ -239,22 +239,22 @@ begin
   exact tendsto_of_tendsto_of_tendsto_of_le_of_le lim₁ lim₂ le₁ le₂
 end
 
-lemma ae_cover.lintegral_tendsto_of_countably_generated {φ : ι → set α}
-  (hφ : ae_cover μ l φ) (hcg : l.is_countably_generated) {f : α → ℝ≥0∞}
+lemma ae_cover.lintegral_tendsto_of_countably_generated [l.is_countably_generated]
+  {φ : ι → set α} (hφ : ae_cover μ l φ) {f : α → ℝ≥0∞}
   (hfm : ae_measurable f μ) : tendsto (λ i, ∫⁻ x in φ i, f x ∂μ) l (𝓝 $ ∫⁻ x, f x ∂μ) :=
-hcg.tendsto_of_seq_tendsto (λ u hu, (hφ.comp_tendsto hu).lintegral_tendsto_of_nat hfm)
+tendsto_of_seq_tendsto (λ u hu, (hφ.comp_tendsto hu).lintegral_tendsto_of_nat hfm)
 
-lemma ae_cover.lintegral_eq_of_tendsto [l.ne_bot] {φ : ι → set α} (hφ : ae_cover μ l φ)
-  (hcg : l.is_countably_generated) {f : α → ℝ≥0∞} (I : ℝ≥0∞)
+lemma ae_cover.lintegral_eq_of_tendsto [l.ne_bot] [l.is_countably_generated]
+  {φ : ι → set α} (hφ : ae_cover μ l φ) {f : α → ℝ≥0∞} (I : ℝ≥0∞)
   (hfm : ae_measurable f μ) (htendsto : tendsto (λ i, ∫⁻ x in φ i, f x ∂μ) l (𝓝 I)) :
   ∫⁻ x, f x ∂μ = I :=
-tendsto_nhds_unique (hφ.lintegral_tendsto_of_countably_generated hcg hfm) htendsto
+tendsto_nhds_unique (hφ.lintegral_tendsto_of_countably_generated hfm) htendsto
 
-lemma ae_cover.supr_lintegral_eq_of_countably_generated [nonempty ι] [l.ne_bot] {φ : ι → set α}
-  (hφ : ae_cover μ l φ) (hcg : l.is_countably_generated) {f : α → ℝ≥0∞}
+lemma ae_cover.supr_lintegral_eq_of_countably_generated [nonempty ι] [l.ne_bot]
+  [l.is_countably_generated] {φ : ι → set α} (hφ : ae_cover μ l φ) {f : α → ℝ≥0∞}
   (hfm : ae_measurable f μ) : (⨆ (i : ι), ∫⁻ x in φ i, f x ∂μ) = ∫⁻ x, f x ∂μ :=
 begin
-  have := hφ.lintegral_tendsto_of_countably_generated hcg hfm,
+  have := hφ.lintegral_tendsto_of_countably_generated hfm,
   refine csupr_eq_of_forall_le_of_forall_lt_exists_gt
     (λ i, lintegral_mono' measure.restrict_le_self (le_refl _)) (λ w hw, _),
   rcases exists_between hw with ⟨m, hm₁, hm₂⟩,
@@ -269,33 +269,33 @@ section integrable
 variables {α ι E : Type*} [measurable_space α] {μ : measure α} {l : filter ι}
   [normed_group E] [measurable_space E] [opens_measurable_space E]
 
-lemma ae_cover.integrable_of_lintegral_nnnorm_tendsto [l.ne_bot] {φ : ι → set α}
-  (hφ : ae_cover μ l φ) (hcg : l.is_countably_generated) {f : α → E} (I : ℝ)
+lemma ae_cover.integrable_of_lintegral_nnnorm_tendsto [l.ne_bot] [l.is_countably_generated]
+  {φ : ι → set α} (hφ : ae_cover μ l φ) {f : α → E} (I : ℝ)
   (hfm : ae_measurable f μ)
   (htendsto : tendsto (λ i, ∫⁻ x in φ i, nnnorm (f x) ∂μ) l (𝓝 $ ennreal.of_real I)) :
   integrable f μ :=
 begin
   refine ⟨hfm, _⟩,
   unfold has_finite_integral,
-  rw hφ.lintegral_eq_of_tendsto hcg _ (measurable_nnnorm.comp_ae_measurable hfm).coe_nnreal_ennreal
+  rw hφ.lintegral_eq_of_tendsto _ (measurable_nnnorm.comp_ae_measurable hfm).coe_nnreal_ennreal
     htendsto,
   exact ennreal.of_real_lt_top
 end
 
-lemma ae_cover.integrable_of_lintegral_nnnorm_tendsto' [l.ne_bot] {φ : ι → set α}
-  (hφ : ae_cover μ l φ) (hcg : l.is_countably_generated) {f : α → E} (I : ℝ≥0)
+lemma ae_cover.integrable_of_lintegral_nnnorm_tendsto' [l.ne_bot] [l.is_countably_generated]
+  {φ : ι → set α} (hφ : ae_cover μ l φ) {f : α → E} (I : ℝ≥0)
   (hfm : ae_measurable f μ)
   (htendsto : tendsto (λ i, ∫⁻ x in φ i, nnnorm (f x) ∂μ) l (𝓝 $ ennreal.of_real I)) :
   integrable f μ :=
-hφ.integrable_of_lintegral_nnnorm_tendsto hcg I hfm htendsto
+hφ.integrable_of_lintegral_nnnorm_tendsto I hfm htendsto
 
-lemma ae_cover.integrable_of_integral_norm_tendsto [l.ne_bot] {φ : ι → set α}
-  (hφ : ae_cover μ l φ) (hcg : l.is_countably_generated) {f : α → E}
+lemma ae_cover.integrable_of_integral_norm_tendsto [l.ne_bot] [l.is_countably_generated]
+  {φ : ι → set α} (hφ : ae_cover μ l φ) {f : α → E}
   (I : ℝ) (hfm : ae_measurable f μ) (hfi : ∀ i, integrable_on f (φ i) μ)
   (htendsto : tendsto (λ i, ∫ x in φ i, ∥f x∥ ∂μ) l (𝓝 I)) :
   integrable f μ :=
 begin
-  refine hφ.integrable_of_lintegral_nnnorm_tendsto hcg I hfm _,
+  refine hφ.integrable_of_lintegral_nnnorm_tendsto I hfm _,
   conv at htendsto in (integral _ _)
   { rw integral_eq_lintegral_of_nonneg_ae (ae_of_all _ (λ x, @norm_nonneg E _ (f x)))
     hfm.norm.restrict },
@@ -306,12 +306,12 @@ begin
   exact ne_top_of_lt (hfi i).2
 end
 
-lemma ae_cover.integrable_of_integral_tendsto_of_nonneg_ae [l.ne_bot] {φ : ι → set α}
-  (hφ : ae_cover μ l φ) (hcg : l.is_countably_generated) {f : α → ℝ} (I : ℝ)
+lemma ae_cover.integrable_of_integral_tendsto_of_nonneg_ae [l.ne_bot] [l.is_countably_generated]
+  {φ : ι → set α} (hφ : ae_cover μ l φ) {f : α → ℝ} (I : ℝ)
   (hfm : ae_measurable f μ) (hfi : ∀ i, integrable_on f (φ i) μ) (hnng : ∀ᵐ x ∂μ, 0 ≤ f x)
   (htendsto : tendsto (λ i, ∫ x in φ i, f x ∂μ) l (𝓝 I)) :
   integrable f μ :=
-hφ.integrable_of_integral_norm_tendsto hcg I hfm hfi
+hφ.integrable_of_integral_norm_tendsto I hfm hfi
   (htendsto.congr $ λ i, integral_congr_ae $ ae_restrict_of_ae $ hnng.mono $
     λ x hx, (real.norm_of_nonneg hx).symm)
 
@@ -323,34 +323,34 @@ variables {α ι E : Type*} [measurable_space α] {μ : measure α} {l : filter 
   [normed_group E] [normed_space ℝ E] [measurable_space E] [borel_space E]
   [complete_space E] [second_countable_topology E]
 
-lemma ae_cover.integral_tendsto_of_countably_generated {φ : ι → set α} (hφ : ae_cover μ l φ)
-  (hcg : l.is_countably_generated) {f : α → E} (hfm : ae_measurable f μ)
+lemma ae_cover.integral_tendsto_of_countably_generated [l.is_countably_generated]
+  {φ : ι → set α} (hφ : ae_cover μ l φ) {f : α → E} (hfm : ae_measurable f μ)
   (hfi : integrable f μ) :
   tendsto (λ i, ∫ x in φ i, f x ∂μ) l (𝓝 $ ∫ x, f x ∂μ) :=
 suffices h : tendsto (λ i, ∫ (x : α), (φ i).indicator f x ∂μ) l (𝓝 (∫ (x : α), f x ∂μ)),
 by { convert h, ext n, rw integral_indicator (hφ.measurable n) },
-tendsto_integral_filter_of_dominated_convergence (λ x, ∥f x∥) hcg
+tendsto_integral_filter_of_dominated_convergence (λ x, ∥f x∥)
   (eventually_of_forall $ λ i, hfm.indicator $ hφ.measurable i) hfm
   (eventually_of_forall $ λ i, ae_of_all _ $ λ x, norm_indicator_le_norm_self _ _)
   hfi.norm hφ.ae_tendsto_indicator
 
 /-- Slight reformulation of
     `measure_theory.ae_cover.integral_tendsto_of_countably_generated`. -/
-lemma ae_cover.integral_eq_of_tendsto [l.ne_bot] {φ : ι → set α} (hφ : ae_cover μ l φ)
-  (hcg : l.is_countably_generated) {f : α → E}
+lemma ae_cover.integral_eq_of_tendsto [l.ne_bot] [l.is_countably_generated]
+  {φ : ι → set α} (hφ : ae_cover μ l φ) {f : α → E}
   (I : E) (hfm : ae_measurable f μ) (hfi : integrable f μ)
   (h : tendsto (λ n, ∫ x in φ n, f x ∂μ) l (𝓝 I)) :
   ∫ x, f x ∂μ = I :=
-tendsto_nhds_unique (hφ.integral_tendsto_of_countably_generated hcg hfm hfi) h
+tendsto_nhds_unique (hφ.integral_tendsto_of_countably_generated hfm hfi) h
 
-lemma ae_cover.integral_eq_of_tendsto_of_nonneg_ae [l.ne_bot] {φ : ι → set α}
-  (hφ : ae_cover μ l φ) (hcg : l.is_countably_generated) {f : α → ℝ} (I : ℝ)
+lemma ae_cover.integral_eq_of_tendsto_of_nonneg_ae [l.ne_bot] [l.is_countably_generated]
+  {φ : ι → set α} (hφ : ae_cover μ l φ) {f : α → ℝ} (I : ℝ)
   (hnng : 0 ≤ᵐ[μ] f) (hfm : ae_measurable f μ) (hfi : ∀ n, integrable_on f (φ n) μ)
   (htendsto : tendsto (λ n, ∫ x in φ n, f x ∂μ) l (𝓝 I)) :
   ∫ x, f x ∂μ = I :=
 have hfi' : integrable f μ,
-  from hφ.integrable_of_integral_tendsto_of_nonneg_ae hcg I hfm hfi hnng htendsto,
-hφ.integral_eq_of_tendsto hcg I hfm hfi' htendsto
+  from hφ.integrable_of_integral_tendsto_of_nonneg_ae I hfm hfi hnng htendsto,
+hφ.integral_eq_of_tendsto I hfm hfi' htendsto
 
 end integral
 
@@ -359,11 +359,11 @@ section integrable_of_interval_integral
 variables {α ι E : Type*}
           [topological_space α] [linear_order α] [order_closed_topology α]
           [measurable_space α] [opens_measurable_space α] {μ : measure α}
-          {l : filter ι} [filter.ne_bot l] (hcg : l.is_countably_generated)
+          {l : filter ι} [filter.ne_bot l] [is_countably_generated l]
           [measurable_space E] [normed_group E] [borel_space E]
           {a b : ι → α} {f : α → E} (hfm : ae_measurable f μ)
 
-include hcg hfm
+include hfm
 
 lemma integrable_of_interval_integral_norm_tendsto [no_bot_order α] [nonempty α]
   (I : ℝ) (hfi : ∀ i, integrable_on f (Ioc (a i) (b i)) μ)
@@ -374,7 +374,7 @@ begin
   let φ := λ n, Ioc (a n) (b n),
   let c : α := classical.choice ‹_›,
   have hφ : ae_cover μ l φ := ae_cover_Ioc ha hb,
-  refine hφ.integrable_of_integral_norm_tendsto hcg _ hfm hfi (h.congr' _),
+  refine hφ.integrable_of_integral_norm_tendsto _ hfm hfi (h.congr' _),
   filter_upwards [ha.eventually (eventually_le_at_bot c), hb.eventually (eventually_ge_at_top c)],
   intros i hai hbi,
   exact interval_integral.integral_of_le (hai.trans hbi)
@@ -391,7 +391,7 @@ begin
   { intro i,
     rw [integrable_on, measure.restrict_restrict (hφ.measurable i)],
     exact hfi i },
-  refine hφ.integrable_of_integral_norm_tendsto hcg _ hfm.restrict hfi (h.congr' _),
+  refine hφ.integrable_of_integral_norm_tendsto _ hfm.restrict hfi (h.congr' _),
   filter_upwards [ha.eventually (eventually_le_at_bot b)],
   intros i hai,
   rw [interval_integral.integral_of_le hai, measure.restrict_restrict (hφ.measurable i)],
@@ -409,7 +409,7 @@ begin
   { intro i,
     rw [integrable_on, measure.restrict_restrict (hφ.measurable i), inter_comm],
     exact hfi i },
-  refine hφ.integrable_of_integral_norm_tendsto hcg _ hfm.restrict hfi (h.congr' _),
+  refine hφ.integrable_of_integral_norm_tendsto _ hfm.restrict hfi (h.congr' _),
   filter_upwards [hb.eventually (eventually_ge_at_top $ a)],
   intros i hbi,
   rw [interval_integral.integral_of_le hbi, measure.restrict_restrict (hφ.measurable i),
@@ -424,12 +424,12 @@ section integral_of_interval_integral
 variables {α ι E : Type*}
           [topological_space α] [linear_order α] [order_closed_topology α]
           [measurable_space α] [opens_measurable_space α] {μ : measure α}
-          {l : filter ι} (hcg : l.is_countably_generated)
+          {l : filter ι} [is_countably_generated l]
           [measurable_space E] [normed_group E] [normed_space ℝ E] [borel_space E]
           [complete_space E] [second_countable_topology E]
           {a b : ι → α} {f : α → E} (hfm : ae_measurable f μ)
 
-include hcg hfm
+include hfm
 
 lemma interval_integral_tendsto_integral [no_bot_order α] [nonempty α]
   (hfi : integrable f μ) (ha : tendsto a l at_bot) (hb : tendsto b l at_top) :
@@ -438,7 +438,7 @@ begin
   let φ := λ i, Ioc (a i) (b i),
   let c : α := classical.choice ‹_›,
   have hφ : ae_cover μ l φ := ae_cover_Ioc ha hb,
-  refine (hφ.integral_tendsto_of_countably_generated hcg hfm hfi).congr' _,
+  refine (hφ.integral_tendsto_of_countably_generated hfm hfi).congr' _,
   filter_upwards [ha.eventually (eventually_le_at_bot c), hb.eventually (eventually_ge_at_top c)],
   intros i hai hbi,
   exact (interval_integral.integral_of_le (hai.trans hbi)).symm
@@ -450,7 +450,7 @@ lemma interval_integral_tendsto_integral_Iic [no_bot_order α] (b : α)
 begin
   let φ := λ i, Ioi (a i),
   have hφ : ae_cover (μ.restrict $ Iic b) l φ := ae_cover_Ioi ha,
-  refine (hφ.integral_tendsto_of_countably_generated hcg hfm.restrict hfi).congr' _,
+  refine (hφ.integral_tendsto_of_countably_generated hfm.restrict hfi).congr' _,
   filter_upwards [ha.eventually (eventually_le_at_bot $ b)],
   intros i hai,
   rw [interval_integral.integral_of_le hai, measure.restrict_restrict (hφ.measurable i)],
@@ -463,7 +463,7 @@ lemma interval_integral_tendsto_integral_Ioi (a : α)
 begin
   let φ := λ i, Iic (b i),
   have hφ : ae_cover (μ.restrict $ Ioi a) l φ := ae_cover_Iic hb,
-  refine (hφ.integral_tendsto_of_countably_generated hcg hfm.restrict hfi).congr' _,
+  refine (hφ.integral_tendsto_of_countably_generated hfm.restrict hfi).congr' _,
   filter_upwards [hb.eventually (eventually_ge_at_top $ a)],
   intros i hbi,
   rw [interval_integral.integral_of_le hbi, measure.restrict_restrict (hφ.measurable i),

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -890,7 +890,6 @@ lemma continuous_within_at_of_dominated_interval
   (h_cont : ∀ᵐ t ∂(μ.restrict $ Ι a b), continuous_within_at (λ x, F x t) s x₀) :
   continuous_within_at (λ x, ∫ t in a..b, F x t ∂μ) s x₀ :=
 begin
-  have gcs := is_countably_generated_nhds_within x₀ s,
   cases bound_integrable,
   cases le_or_lt a b with hab hab;
   [{ rw interval_oc_of_le hab at *,
@@ -898,7 +897,7 @@ begin
    { rw interval_oc_of_lt hab at *,
      simp_rw interval_integral.integral_of_ge hab.le,
      refine tendsto.neg _ }];
-  apply tendsto_integral_filter_of_dominated_convergence bound gcs hF_meas hF_meas₀ h_bound,
+  apply tendsto_integral_filter_of_dominated_convergence bound hF_meas hF_meas₀ h_bound,
   exacts [bound_integrable_left, h_cont, bound_integrable_right, h_cont]
 end
 

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -1762,31 +1762,31 @@ end
 
 /-- Dominated convergence theorem for filters with a countable basis -/
 lemma tendsto_lintegral_filter_of_dominated_convergence {ι} {l : filter ι}
+  [l.is_countably_generated]
   {F : ι → α → ℝ≥0∞} {f : α → ℝ≥0∞} (bound : α → ℝ≥0∞)
-  (hl_cb : l.is_countably_generated)
   (hF_meas : ∀ᶠ n in l, measurable (F n))
   (h_bound : ∀ᶠ n in l, ∀ᵐ a ∂μ, F n a ≤ bound a)
   (h_fin : ∫⁻ a, bound a ∂μ ≠ ∞)
   (h_lim : ∀ᵐ a ∂μ, tendsto (λ n, F n a) l (𝓝 (f a))) :
   tendsto (λn, ∫⁻ a, F n a ∂μ) l (𝓝 $ ∫⁻ a, f a ∂μ) :=
 begin
-  rw hl_cb.tendsto_iff_seq_tendsto,
-  { intros x xl,
-    have hxl, { rw tendsto_at_top' at xl, exact xl },
-    have h := inter_mem hF_meas h_bound,
-    replace h := hxl _ h,
-    rcases h with ⟨k, h⟩,
-    rw ← tendsto_add_at_top_iff_nat k,
-    refine tendsto_lintegral_of_dominated_convergence _ _ _ _ _,
-    { exact bound },
-    { intro, refine (h _ _).1, exact nat.le_add_left _ _ },
-    { intro, refine (h _ _).2, exact nat.le_add_left _ _ },
+  rw tendsto_iff_seq_tendsto,
+  intros x xl,
+  have hxl, { rw tendsto_at_top' at xl, exact xl },
+  have h := inter_mem hF_meas h_bound,
+  replace h := hxl _ h,
+  rcases h with ⟨k, h⟩,
+  rw ← tendsto_add_at_top_iff_nat k,
+  refine tendsto_lintegral_of_dominated_convergence _ _ _ _ _,
+  { exact bound },
+  { intro, refine (h _ _).1, exact nat.le_add_left _ _ },
+  { intro, refine (h _ _).2, exact nat.le_add_left _ _ },
+  { assumption },
+  { refine h_lim.mono (λ a h_lim, _),
+    apply @tendsto.comp _ _ _ (λn, x (n + k)) (λn, F n a),
     { assumption },
-    { refine h_lim.mono (λ a h_lim, _),
-      apply @tendsto.comp _ _ _ (λn, x (n + k)) (λn, F n a),
-      { assumption },
-      rw tendsto_add_at_top_iff_nat,
-      assumption } },
+    rw tendsto_add_at_top_iff_nat,
+    assumption }
 end
 
 section

--- a/src/order/filter/archimedean.lean
+++ b/src/order/filter/archimedean.lean
@@ -46,40 +46,26 @@ tendsto_at_top_embedding (assume a₁ a₂, rat.cast_le) $
   assume r, let ⟨n, hn⟩ := exists_nat_ge r in ⟨(n:ℚ), by assumption_mod_cast⟩
 
 lemma at_top_countable_basis_of_archimedean [linear_ordered_semiring R] [archimedean R] :
-  (at_top : filter R).has_countable_basis (λ i, i ∈ range (coe : ℕ → R)) Ici :=
-{ countable := countable_range coe,
-  mem_iff' := λ t,
-  begin
-    rw at_top_basis.mem_iff' t,
-    simp only [exists_prop, mem_range, exists_exists_eq_and, exists_true_left],
-    split,
-    { rintro ⟨i, hi⟩,
-      rcases exists_nat_ge i with ⟨n, hn⟩,
-      exact ⟨n, trans (Ici_subset_Ici.mpr hn) hi⟩ },
-    { rintro ⟨n, hn⟩,
-      exact ⟨n, hn⟩ }
-  end }
+  (at_top : filter R).has_countable_basis (λ n : ℕ, true) (λ n, Ici n) :=
+{ countable := countable_encodable _,
+  to_has_basis := at_top_basis.to_has_basis
+    (λ x hx, let ⟨n, hn⟩ := exists_nat_ge x in ⟨n, trivial, Ici_subset_Ici.2 hn⟩)
+    (λ n hn, ⟨n, trivial, subset.rfl⟩) }
 
 lemma at_bot_countable_basis_of_archimedean [linear_ordered_ring R] [archimedean R] :
-  (at_bot : filter R).has_countable_basis (λ i, i ∈ range (coe : ℤ → R)) Iic :=
-{ countable := countable_range coe,
-  mem_iff' := λ t,
-  begin
-    rw at_bot_basis.mem_iff' t,
-    simp only [exists_prop, mem_range, exists_exists_eq_and, exists_true_left],
-    split,
-    { rintro ⟨i, hi⟩,
-      rcases exists_int_lt i with ⟨n, hn⟩,
-      exact ⟨n, trans (Iic_subset_Iic.mpr hn.le) hi⟩ },
-    { rintro ⟨n, hn⟩,
-      exact ⟨n, hn⟩ }
-  end }
+  (at_bot : filter R).has_countable_basis (λ m : ℤ, true) (λ m, Iic m) :=
+{ countable := countable_encodable _,
+  to_has_basis := at_bot_basis.to_has_basis
+    (λ x hx, let ⟨m, hm⟩ := exists_int_lt x in ⟨m, trivial, Iic_subset_Iic.2 hm.le⟩)
+    (λ m hm, ⟨m, trivial, subset.rfl⟩) }
 
-lemma at_top_countably_generated_of_archimedean [linear_ordered_semiring R] [archimedean R] :
+@[priority 100]
+instance at_top_countably_generated_of_archimedean [linear_ordered_semiring R] [archimedean R] :
   (at_top : filter R).is_countably_generated :=
 at_top_countable_basis_of_archimedean.is_countably_generated
 
-lemma at_bot_countably_generated [linear_ordered_ring R] [archimedean R] :
+@[priority 100]
+instance at_bot_countably_generated_of_archimedean [linear_ordered_ring R] [archimedean R] :
   (at_bot : filter R).is_countably_generated :=
 at_bot_countable_basis_of_archimedean.is_countably_generated
 

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -120,13 +120,15 @@ lemma at_bot_countable_basis [nonempty α] [semilattice_inf α] [encodable α] :
 { countable := countable_encodable _,
   .. at_bot_basis }
 
-lemma is_countably_generated_at_top [nonempty α] [semilattice_sup α] [encodable α] :
+@[priority 200]
+instance at_top.is_countably_generated [preorder α] [encodable α] :
   (at_top : filter $ α).is_countably_generated :=
-at_top_countable_basis.is_countably_generated
+is_countably_generated_seq _
 
-lemma is_countably_generated_at_bot [nonempty α] [semilattice_inf α] [encodable α] :
+@[priority 200]
+instance at_bot.is_countably_generated [preorder α] [encodable α] :
   (at_bot : filter $ α).is_countably_generated :=
-at_bot_countable_basis.is_countably_generated
+is_countably_generated_seq _
 
 lemma order_top.at_top_eq (α) [order_top α] : (at_top : filter α) = pure ⊤ :=
 le_antisymm (le_pure_iff.2 $ (eventually_ge_at_top ⊤).mono $ λ b, top_unique)
@@ -1214,18 +1216,15 @@ lemma has_antitone_basis.tendsto [semilattice_sup ι] [nonempty ι] {l : filter 
 (at_top_basis.tendsto_iff hl.to_has_basis).2 $ assume i hi,
   ⟨i, trivial, λ j hij, hl.decreasing hi (hl.mono hij hi) hij (h j)⟩
 
-namespace is_countably_generated
-
 /-- An abstract version of continuity of sequentially continuous functions on metric spaces:
 if a filter `k` is countably generated then `tendsto f k l` iff for every sequence `u`
 converging to `k`, `f ∘ u` tends to `l`. -/
-lemma tendsto_iff_seq_tendsto {f : α → β} {k : filter α} {l : filter β}
-  (hcb : k.is_countably_generated) :
+lemma tendsto_iff_seq_tendsto {f : α → β} {k : filter α} {l : filter β} [k.is_countably_generated] :
   tendsto f k l ↔ (∀ x : ℕ → α, tendsto x at_top k → tendsto (f ∘ x) at_top l) :=
 suffices (∀ x : ℕ → α, tendsto x at_top k → tendsto (f ∘ x) at_top l) → tendsto f k l,
   from ⟨by intros; apply tendsto.comp; assumption, by assumption⟩,
 begin
-  obtain ⟨g, gbasis, gmon, -⟩ := hcb.exists_antitone_basis,
+  obtain ⟨g, gbasis, gmon, -⟩ := k.exists_antitone_basis,
   contrapose,
   simp only [not_forall, gbasis.tendsto_left_iff, exists_const, not_exists, not_imp],
   rintro ⟨B, hBl, hfBk⟩,
@@ -1239,17 +1238,16 @@ begin
     apply (h i).right },
 end
 
-lemma tendsto_of_seq_tendsto {f : α → β} {k : filter α} {l : filter β}
-  (hcb : k.is_countably_generated) :
+lemma tendsto_of_seq_tendsto {f : α → β} {k : filter α} {l : filter β} [k.is_countably_generated] :
   (∀ x : ℕ → α, tendsto x at_top k → tendsto (f ∘ x) at_top l) → tendsto f k l :=
-hcb.tendsto_iff_seq_tendsto.2
+tendsto_iff_seq_tendsto.2
 
-lemma subseq_tendsto {f : filter α} (hf : is_countably_generated f)
+lemma subseq_tendsto_of_ne_bot {f : filter α} [is_countably_generated f]
   {u : ℕ → α}
   (hx : ne_bot (f ⊓ map u at_top)) :
   ∃ (θ : ℕ → ℕ), (strict_mono θ) ∧ (tendsto (u ∘ θ) at_top f) :=
 begin
-  obtain ⟨B, h⟩ := hf.exists_antitone_basis,
+  obtain ⟨B, h⟩ := f.exists_antitone_basis,
   have : ∀ N, ∃ n ≥ N, u n ∈ B N,
     from λ N, filter.inf_map_at_top_ne_bot_iff.mp hx _ (h.to_has_basis.mem_of_mem trivial) N,
   choose φ hφ using this,
@@ -1262,8 +1260,6 @@ begin
     from strict_mono_subseq_of_tendsto_at_top lim_φ,
   exact ⟨φ ∘ ψ, hψφ, lim_uφ.comp hψ.tendsto_at_top⟩,
 end
-
-end is_countably_generated
 
 end filter
 

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -557,6 +557,9 @@ top_unique $ by simp only [le_principal_iff, mem_top, eq_self_iff_true]
 @[simp] lemma principal_empty : 𝓟 (∅ : set α) = ⊥ :=
 bot_unique $ λ s _, empty_subset _
 
+lemma generate_eq_binfi (S : set (set α)) : generate S = ⨅ s ∈ S, 𝓟 s :=
+eq_of_forall_le_iff $ λ f, by simp [sets_iff_generate, le_principal_iff, subset_def]
+
 /-! ### Lattice equations -/
 
 lemma empty_mem_iff_bot {f : filter α} : ∅ ∈ f ↔ f = ⊥ :=

--- a/src/topology/G_delta.lean
+++ b/src/topology/G_delta.lean
@@ -105,17 +105,14 @@ begin
   exact λ a s _ _ ihs H, H.1.union (ihs H.2)
 end
 
-lemma is_closed.is_Gδ' {α} [uniform_space α] {s : set α} (hs : is_closed s)
-  (H : (𝓤 α).is_countably_generated) : is_Gδ s :=
+lemma is_closed.is_Gδ {α} [uniform_space α] [is_countably_generated (𝓤 α)]
+  {s : set α} (hs : is_closed s) : is_Gδ s :=
 begin
-  rcases H.exists_antitone_subbasis uniformity_has_basis_open with ⟨U, hUo, hU, -, -⟩,
+  rcases (@uniformity_has_basis_open α _).exists_antitone_subbasis  with ⟨U, hUo, hU, -, -⟩,
   rw [← hs.closure_eq, ← hU.bInter_bUnion_ball],
   refine is_Gδ_bInter (countable_encodable _) (λ n hn, is_open.is_Gδ _),
   exact is_open_bUnion (λ x hx, uniform_space.is_open_ball _ (hUo _).2)
 end
-
-lemma is_closed.is_Gδ {α} [pseudo_emetric_space α] {s : set α} (hs : is_closed s) : is_Gδ s :=
-hs.is_Gδ' emetric.uniformity_has_countable_basis
 
 section t1_space
 
@@ -145,8 +142,7 @@ variables [first_countable_topology α]
 
 lemma is_Gδ_singleton (a : α) : is_Gδ ({a} : set α) :=
 begin
-  rcases (is_countably_generated_nhds a).exists_antitone_subbasis (nhds_basis_opens _)
-    with ⟨U, hU, h_basis⟩,
+  rcases (nhds_basis_opens a).exists_antitone_subbasis with ⟨U, hU, h_basis⟩,
   rw [← bInter_basis_nhds h_basis.to_has_basis],
   exact is_Gδ_bInter (countable_encodable _) (λ n hn, (hU n).2.is_Gδ),
 end
@@ -165,11 +161,11 @@ open_locale uniformity
 
 variables [topological_space α]
 
-lemma is_Gδ_set_of_continuous_at_of_countably_generated_uniformity
-  [uniform_space β] (hU : is_countably_generated (𝓤 β)) (f : α → β) :
+/-- The set of points where a function is continuous is a Gδ set. -/
+lemma is_Gδ_set_of_continuous_at [uniform_space β] [is_countably_generated (𝓤 β)] (f : α → β) :
   is_Gδ {x | continuous_at f x} :=
 begin
-  obtain ⟨U, hUo, hU⟩ := hU.exists_antitone_subbasis uniformity_has_basis_open_symmetric,
+  obtain ⟨U, hUo, hU⟩ := (@uniformity_has_basis_open_symmetric β _).exists_antitone_subbasis,
   simp only [uniform.continuous_at_iff_prod, nhds_prod_eq],
   simp only [(nhds_basis_opens _).prod_self.tendsto_iff hU.to_has_basis, forall_prop_of_true,
     set_of_forall, id],
@@ -179,12 +175,6 @@ begin
   intros y hy,
   exact ⟨s, ⟨hy, hso⟩, hsU⟩
 end
-
-/-- The set of points where a function is continuous is a Gδ set. -/
-lemma is_Gδ_set_of_continuous_at [pseudo_emetric_space β] (f : α → β) :
-  is_Gδ {x | continuous_at f x} :=
-is_Gδ_set_of_continuous_at_of_countably_generated_uniformity
-  emetric.uniformity_has_countable_basis _
 
 end continuous_at
 

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -2142,8 +2142,8 @@ alias is_glb.mem_of_is_closed ← is_closed.is_glb_mem
 ### Existence of sequences tending to Inf or Sup of a given set
 -/
 
-lemma is_lub.exists_seq_strict_mono_tendsto_of_not_mem {t : set α} {x : α} [is_countably_generated (𝓝 x)]
-  (htx : is_lub t x) (not_mem : x ∉ t) (ht : t.nonempty) :
+lemma is_lub.exists_seq_strict_mono_tendsto_of_not_mem {t : set α} {x : α}
+  [is_countably_generated (𝓝 x)] (htx : is_lub t x) (not_mem : x ∉ t) (ht : t.nonempty) :
   ∃ u : ℕ → α, strict_mono u ∧ (∀ n, u n < x) ∧ tendsto u at_top (𝓝 x) ∧ (∀ n, u n ∈ t) :=
 begin
   rcases ht with ⟨l, hl⟩,

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -2142,17 +2142,15 @@ alias is_glb.mem_of_is_closed ← is_closed.is_glb_mem
 ### Existence of sequences tending to Inf or Sup of a given set
 -/
 
-lemma is_lub.exists_seq_strict_mono_tendsto_of_not_mem' {t : set α} {x : α}
-  (htx : is_lub t x) (not_mem : x ∉ t) (ht : t.nonempty) (hx : is_countably_generated (𝓝 x)) :
+lemma is_lub.exists_seq_strict_mono_tendsto_of_not_mem {t : set α} {x : α} [is_countably_generated (𝓝 x)]
+  (htx : is_lub t x) (not_mem : x ∉ t) (ht : t.nonempty) :
   ∃ u : ℕ → α, strict_mono u ∧ (∀ n, u n < x) ∧ tendsto u at_top (𝓝 x) ∧ (∀ n, u n ∈ t) :=
 begin
   rcases ht with ⟨l, hl⟩,
   have hl : l < x,
-  { rcases lt_or_eq_of_le (htx.1 hl) with h|rfl,
-    { exact h },
-    { exact (not_mem hl).elim } },
+   from (htx.1 hl).eq_or_lt.resolve_left (λ h,  (not_mem $ h ▸ hl).elim),
   obtain ⟨s, hs⟩ : ∃ s : ℕ → set α, (𝓝 x).has_basis (λ (_x : ℕ), true) s :=
-    let ⟨s, hs⟩ := hx.exists_antitone_basis in ⟨s, hs.to_has_basis⟩,
+    let ⟨s, hs⟩ := (𝓝 x).exists_antitone_basis in ⟨s, hs.to_has_basis⟩,
   have : ∀ n k, k < x → ∃ y, Icc y x ⊆ s n ∧ k < y ∧ y < x ∧ y ∈ t,
   { assume n k hk,
     obtain ⟨L, hL, h⟩ : ∃ (L : α) (hL : L ∈ Ico k x), Ioc L x ⊆ s n :=
@@ -2181,25 +2179,15 @@ begin
     { exact (hf n.succ _ (I n)).2.2.2 } }
 end
 
-lemma is_lub.exists_seq_monotone_tendsto' {t : set α} {x : α}
-  (htx : is_lub t x) (ht : t.nonempty) (hx : is_countably_generated (𝓝 x)) :
+lemma is_lub.exists_seq_monotone_tendsto {t : set α} {x : α} [is_countably_generated (𝓝 x)]
+  (htx : is_lub t x) (ht : t.nonempty) :
   ∃ u : ℕ → α, monotone u ∧ (∀ n, u n ≤ x) ∧ tendsto u at_top (𝓝 x) ∧ (∀ n, u n ∈ t) :=
 begin
   by_cases h : x ∈ t,
   { exact ⟨λ n, x, monotone_const, λ n, le_rfl, tendsto_const_nhds, λ n, h⟩ },
-  { rcases htx.exists_seq_strict_mono_tendsto_of_not_mem' h ht hx with ⟨u, hu⟩,
+  { rcases htx.exists_seq_strict_mono_tendsto_of_not_mem h ht  with ⟨u, hu⟩,
     exact ⟨u, hu.1.monotone, λ n, (hu.2.1 n).le, hu.2.2⟩ }
 end
-
-lemma is_lub.exists_seq_strict_mono_tendsto_of_not_mem [first_countable_topology α]
-  {t : set α} {x : α} (htx : is_lub t x) (ht : t.nonempty) (not_mem : x ∉ t) :
-  ∃ u : ℕ → α, strict_mono u ∧ (∀ n, u n < x) ∧ tendsto u at_top (𝓝 x) ∧ (∀ n, u n ∈ t) :=
-htx.exists_seq_strict_mono_tendsto_of_not_mem' not_mem ht (is_countably_generated_nhds x)
-
-lemma is_lub.exists_seq_monotone_tendsto [first_countable_topology α]
-  {t : set α} {x : α} (htx : is_lub t x) (ht : t.nonempty) :
-  ∃ u : ℕ → α, monotone u ∧ (∀ n, u n ≤ x) ∧ tendsto u at_top (𝓝 x) ∧ (∀ n, u n ∈ t) :=
-htx.exists_seq_monotone_tendsto' ht (is_countably_generated_nhds x)
 
 lemma exists_seq_strict_mono_tendsto' {α : Type*} [linear_order α] [topological_space α]
   [densely_ordered α] [order_topology α]
@@ -2208,7 +2196,7 @@ lemma exists_seq_strict_mono_tendsto' {α : Type*} [linear_order α] [topologica
 begin
   have hx : x ∉ Iio x := λ h, (lt_irrefl x h).elim,
   have ht : set.nonempty (Iio x) := ⟨y, hy⟩,
-  rcases is_lub_Iio.exists_seq_strict_mono_tendsto_of_not_mem ht hx with ⟨u, hu⟩,
+  rcases is_lub_Iio.exists_seq_strict_mono_tendsto_of_not_mem hx ht with ⟨u, hu⟩,
   exact ⟨u, hu.1, hu.2.1, hu.2.2.1⟩,
 end
 
@@ -2229,29 +2217,17 @@ begin
   exact ⟨u, hu.1, hu.2.2⟩,
 end
 
-lemma is_glb.exists_seq_strict_anti_tendsto_of_not_mem' {t : set α} {x : α}
-  (htx : is_glb t x) (not_mem : x ∉ t) (ht : t.nonempty) (hx : is_countably_generated (𝓝 x)) :
+lemma is_glb.exists_seq_strict_anti_tendsto_of_not_mem {t : set α} {x : α}
+  [is_countably_generated (𝓝 x)] (htx : is_glb t x) (not_mem : x ∉ t) (ht : t.nonempty) :
   ∃ u : ℕ → α, strict_anti u ∧ (∀ n, x < u n) ∧
                         tendsto u at_top (𝓝 x) ∧ (∀ n, u n ∈ t) :=
-@is_lub.exists_seq_strict_mono_tendsto_of_not_mem' (order_dual α) _ _ _ t x htx not_mem ht hx
+@is_lub.exists_seq_strict_mono_tendsto_of_not_mem (order_dual α) _ _ _ t x _ htx not_mem ht
 
-lemma is_glb.exists_seq_antitone_tendsto' {t : set α} {x : α}
-  (htx : is_glb t x) (ht : t.nonempty) (hx : is_countably_generated (𝓝 x)) :
+lemma is_glb.exists_seq_antitone_tendsto {t : set α} {x : α} [is_countably_generated (𝓝 x)]
+  (htx : is_glb t x) (ht : t.nonempty) :
   ∃ u : ℕ → α, antitone u ∧ (∀ n, x ≤ u n) ∧
                         tendsto u at_top (𝓝 x) ∧ (∀ n, u n ∈ t) :=
-@is_lub.exists_seq_monotone_tendsto' (order_dual α) _ _ _ t x htx ht hx
-
-lemma is_glb.exists_seq_strict_anti_tendsto_of_not_mem [first_countable_topology α]
-  {t : set α} {x : α} (htx : is_glb t x) (ht : t.nonempty) (not_mem : x ∉ t) :
-  ∃ u : ℕ → α, strict_anti u ∧ (∀ n, x < u n) ∧
-                        tendsto u at_top (𝓝 x) ∧ (∀ n, u n ∈ t) :=
-htx.exists_seq_strict_anti_tendsto_of_not_mem' not_mem ht (is_countably_generated_nhds x)
-
-lemma is_glb.exists_seq_antitone_tendsto [first_countable_topology α]
-  {t : set α} {x : α} (htx : is_glb t x) (ht : t.nonempty) :
-  ∃ u : ℕ → α, antitone u ∧ (∀ n, x ≤ u n) ∧
-                        tendsto u at_top (𝓝 x) ∧ (∀ n, u n ∈ t) :=
-htx.exists_seq_antitone_tendsto' ht (is_countably_generated_nhds x)
+@is_lub.exists_seq_monotone_tendsto (order_dual α) _ _ _ t x _ htx ht
 
 lemma exists_seq_strict_anti_tendsto' [densely_ordered α]
   [first_countable_topology α] {x y : α} (hy : x < y) :

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -406,6 +406,8 @@ include t
 class first_countable_topology : Prop :=
 (nhds_generated_countable : ∀a:α, (𝓝 a).is_countably_generated)
 
+attribute [instance] first_countable_topology.nhds_generated_countable
+
 namespace first_countable_topology
 variable {α}
 
@@ -414,19 +416,15 @@ is the limit of some subsequence. -/
 lemma tendsto_subseq [first_countable_topology α] {u : ℕ → α} {x : α}
   (hx : map_cluster_pt x at_top u) :
   ∃ (ψ : ℕ → ℕ), (strict_mono ψ) ∧ (tendsto (u ∘ ψ) at_top (𝓝 x)) :=
-(nhds_generated_countable x).subseq_tendsto hx
+subseq_tendsto_of_ne_bot hx
 
 end first_countable_topology
 
 variables {α}
 
-lemma is_countably_generated_nhds [first_countable_topology α] (x : α) :
-  is_countably_generated (𝓝 x) :=
-first_countable_topology.nhds_generated_countable x
-
 lemma is_countably_generated_nhds_within [first_countable_topology α] (x : α) (s : set α) :
   is_countably_generated (𝓝[s] x) :=
-(is_countably_generated_nhds x).inf_principal s
+inf.is_countably_generated _ _
 
 variable (α)
 

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -422,7 +422,7 @@ end first_countable_topology
 
 variables {α}
 
-lemma is_countably_generated_nhds_within [first_countable_topology α] (x : α) (s : set α) :
+instance is_countably_generated_nhds_within (x : α) [is_countably_generated (𝓝 x)] (s : set α) :
   is_countably_generated (𝓝[s] x) :=
 inf.is_countably_generated _ _
 

--- a/src/topology/metric_space/closeds.lean
+++ b/src/topology/metric_space/closeds.lean
@@ -311,13 +311,8 @@ begin
     let v0 := {t : set α | finite t ∧ t ⊆ s},
     let v : set (nonempty_compacts α) := {t : nonempty_compacts α | t.val ∈ v0},
     refine  ⟨⟨v, ⟨_, _⟩⟩⟩,
-    { have : countable (subtype.val '' v),
-      { refine (countable_set_of_finite_subset cs).mono (λx hx, _),
-        rcases (mem_image _ _ _).1 hx with ⟨y, ⟨hy, yx⟩⟩,
-        rw ← yx,
-        exact hy },
-      apply countable_of_injective_of_countable_image _ this,
-      apply subtype.val_injective.inj_on },
+    { have : countable v0, from countable_set_of_finite_subset cs,
+      exact this.preimage subtype.coe_injective },
     { refine λt, mem_closure_iff.2 (λε εpos, _),
       -- t is a compact nonempty set, that we have to approximate uniformly by a a set in `v`.
       rcases exists_between εpos with ⟨δ, δpos, δlt⟩,
@@ -331,7 +326,7 @@ begin
       have Fspec : ∀x, F x ∈ s ∧ edist x (F x) < δ/2 := λx, some_spec (Exy x),
 
       -- cover `t` with finitely many balls. Their centers form a set `a`
-      have : totally_bounded t.val := (compact_iff_totally_bounded_complete.1 t.property.2).1,
+      have : totally_bounded t.val := t.property.2.totally_bounded,
       rcases totally_bounded_iff.1 this (δ/2) δpos' with ⟨a, af, ta⟩,
       -- a : set α,  af : finite a,  ta : t.val ⊆ ⋃ (y : α) (H : y ∈ a), eball y (δ / 2)
       -- replace each center by a nearby approximation in `s`, giving a new set `b`
@@ -378,7 +373,7 @@ begin
       -- we have proved that `d` is a good approximation of `t` as requested
       exact ⟨d, ‹d ∈ v›, Dtc⟩ },
   end,
-  apply second_countable_of_separable,
+  apply uniform_space.second_countable_of_separable,
 end
 
 end --section

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -253,7 +253,8 @@ mem_uniformity_edist.2 ⟨ε, ε0, λ a b, id⟩
 
 namespace emetric
 
-theorem uniformity_has_countable_basis : is_countably_generated (𝓤 α) :=
+@[priority 900]
+instance : is_countably_generated (𝓤 α) :=
 is_countably_generated_of_seq ⟨_, uniformity_basis_edist_inv_nat.eq_infi⟩
 
 /-- ε-δ characterization of uniform continuity on a set for pseudoemetric spaces -/
@@ -306,13 +307,12 @@ theorem complete_of_convergent_controlled_sequences (B : ℕ → ℝ≥0∞) (hB
     ∃x, tendsto u at_top (𝓝 x)) :
   complete_space α :=
 uniform_space.complete_of_convergent_controlled_sequences
-  uniformity_has_countable_basis
   (λ n, {p:α×α | edist p.1 p.2 < B n}) (λ n, edist_mem_uniformity $ hB n) H
 
 /-- A sequentially complete pseudoemetric space is complete. -/
 theorem complete_of_cauchy_seq_tendsto :
   (∀ u : ℕ → α, cauchy_seq u → ∃a, tendsto u at_top (𝓝 a)) → complete_space α :=
-uniform_space.complete_of_cauchy_seq_tendsto uniformity_has_countable_basis
+uniform_space.complete_of_cauchy_seq_tendsto
 
 /-- Expressing locally uniform convergence on a set using `edist`. -/
 lemma tendsto_locally_uniformly_on_iff {ι : Type*} [topological_space β]
@@ -624,15 +624,6 @@ theorem totally_bounded_iff' {s : set α} :
                ⟨t, _, ft, h⟩ := H ε ε0 in
   ⟨t, ft, subset.trans h $ Union_subset_Union $ λ y, Union_subset_Union $ λ yt z, hε⟩⟩
 
-section first_countable
-
-@[priority 100] -- see Note [lower instance priority]
-instance (α : Type u) [pseudo_emetric_space α] :
-  topological_space.first_countable_topology α :=
-uniform_space.first_countable_topology uniformity_has_countable_basis
-
-end first_countable
-
 section compact
 
 /-- For a set `s` in a pseudo emetric space, if for every `ε > 0` there exists a countable
@@ -681,20 +672,12 @@ open topological_space
 
 variables (α)
 
-/-- A separable pseudoemetric space is second countable: one obtains a countable basis by taking
-the balls centered at points in a dense subset, and with rational radii. We do not register
-this as an instance, as there is already an instance going in the other direction
-from second countable spaces to separable spaces, and we want to avoid loops. -/
-lemma second_countable_of_separable [separable_space α] :
-  second_countable_topology α :=
-uniform_space.second_countable_of_separable uniformity_has_countable_basis
-
 /-- A sigma compact pseudo emetric space has second countable topology. This is not an instance
 to avoid a loop with `sigma_compact_space_of_locally_compact_second_countable`.  -/
 lemma second_countable_of_sigma_compact [sigma_compact_space α] :
   second_countable_topology α :=
 begin
-  suffices : separable_space α, by exactI second_countable_of_separable α,
+  suffices : separable_space α, by exactI uniform_space.second_countable_of_separable α,
   choose T hTsub hTc hsubT
     using λ n, subset_countable_closure_of_compact (is_compact_compact_covering α n),
   refine ⟨⟨⋃ n, T n, countable_Union hTc, λ x, _⟩⟩,
@@ -708,7 +691,7 @@ lemma second_countable_of_almost_dense_set
   (hs : ∀ ε > 0, ∃ t : set α, countable t ∧ (⋃ x ∈ t, closed_ball x ε) = univ) :
   second_countable_topology α :=
 begin
-  suffices : separable_space α, by exactI second_countable_of_separable α,
+  suffices : separable_space α, by exactI uniform_space.second_countable_of_separable α,
   rcases subset_countable_closure_of_almost_dense_set (univ : set α) (λ ε ε0, _)
     with ⟨t, -, htc, ht⟩,
   { exact ⟨⟨t, htc, λ x, ht (mem_univ x)⟩⟩ },

--- a/src/topology/sequences.lean
+++ b/src/topology/sequences.lean
@@ -153,7 +153,7 @@ instance : sequential_space α :=
   assume (p : α) (hp : p ∈ closure M),
   -- Since we are in a first-countable space, the neighborhood filter around `p` has a decreasing
   -- basis `U` indexed by `ℕ`.
-  let ⟨U, hU⟩ := (nhds_generated_countable p).exists_antitone_basis in
+  let ⟨U, hU⟩ := (𝓝 p).exists_antitone_basis in
   -- Since `p ∈ closure M`, there is an element in each `M ∩ U i`
   have hp : ∀ (i : ℕ), ∃ (y : α), y ∈ M ∧ y ∈ U i,
     by simpa using (mem_closure_iff_nhds_basis hU.1).mp hp,
@@ -234,15 +234,15 @@ open uniform_space prod
 
 variables [uniform_space β] {s : set β}
 
-lemma lebesgue_number_lemma_seq {ι : Type*} {c : ι → set β}
+lemma lebesgue_number_lemma_seq {ι : Type*} [is_countably_generated (𝓤 β)] {c : ι → set β}
   (hs : is_seq_compact s) (hc₁ : ∀ i, is_open (c i)) (hc₂ : s ⊆ ⋃ i, c i)
-  (hU : is_countably_generated (𝓤 β)) :
+  :
   ∃ V ∈ 𝓤 β, symmetric_rel V ∧ ∀ x ∈ s, ∃ i, ball x V ⊆ c i :=
 begin
   classical,
   obtain ⟨V, hV, Vsymm⟩ :
     ∃ V : ℕ → set (β × β), (𝓤 β).has_antitone_basis (λ _, true) V ∧  ∀ n, swap ⁻¹' V n = V n,
-      from uniform_space.has_seq_basis hU, clear hU,
+      from uniform_space.has_seq_basis β,
   suffices : ∃ n, ∀ x ∈ s, ∃ i, ball x (V n) ⊆ c i,
   { cases this with n hn,
     exact ⟨V n, hV.to_has_basis.mem_of_mem trivial, Vsymm n, hn⟩ },
@@ -310,14 +310,13 @@ begin
   exact hu hN,
 end
 
-protected lemma is_seq_compact.is_compact (h : is_countably_generated $ 𝓤 β)
-  (hs : is_seq_compact s) :
+protected lemma is_seq_compact.is_compact [is_countably_generated $ 𝓤 β] (hs : is_seq_compact s) :
   is_compact s :=
 begin
   classical,
   rw is_compact_iff_finite_subcover,
   intros ι U Uop s_sub,
-  rcases lebesgue_number_lemma_seq hs Uop s_sub h with ⟨V, V_in, Vsymm, H⟩,
+  rcases lebesgue_number_lemma_seq hs Uop s_sub with ⟨V, V_in, Vsymm, H⟩,
   rcases totally_bounded_iff_subset.mp hs.totally_bounded V V_in with ⟨t,t_sub, tfin,  ht⟩,
   have : ∀ x : t, ∃ (i : ι), ball x.val V ⊆ U i,
   { rintros ⟨x, x_in⟩,
@@ -336,16 +335,15 @@ begin
     exact ⟨i ⟨x, x_in⟩, finset.mem_image_of_mem _ (finset.mem_univ _), hi ⟨x, x_in⟩⟩ },
 end
 
-protected lemma uniform_space.compact_iff_seq_compact (h : is_countably_generated $ 𝓤 β) :
+/-- A version of Bolzano-Weistrass: in a uniform space with countably generated uniformity filter
+(e.g., in a metric space), a set is compact if and only if it is sequentially compact. -/
+protected lemma uniform_space.compact_iff_seq_compact [is_countably_generated $ 𝓤 β] :
  is_compact s ↔ is_seq_compact s :=
-begin
-  haveI := uniform_space.first_countable_topology h,
-  exact ⟨λ H, H.is_seq_compact, λ H, H.is_compact h⟩
-end
+⟨λ H, H.is_seq_compact, λ H, H.is_compact⟩
 
-lemma uniform_space.compact_space_iff_seq_compact_space (H : is_countably_generated $ 𝓤 β) :
+lemma uniform_space.compact_space_iff_seq_compact_space [is_countably_generated $ 𝓤 β] :
   compact_space β ↔ seq_compact_space β :=
-have key : is_compact univ ↔ is_seq_compact univ := uniform_space.compact_iff_seq_compact H,
+have key : is_compact (univ : set β) ↔ is_seq_compact univ := uniform_space.compact_iff_seq_compact,
 ⟨λ ⟨h⟩, ⟨key.mp h⟩, λ ⟨h⟩, ⟨key.mpr h⟩⟩
 
 end uniform_space_seq_compact
@@ -355,21 +353,17 @@ section metric_seq_compact
 variables [metric_space β] {s : set β}
 open metric
 
-/-- A version of Bolzano-Weistrass: in a metric space, is_compact s ↔ is_seq_compact s -/
-lemma metric.compact_iff_seq_compact : is_compact s ↔ is_seq_compact s :=
-uniform_space.compact_iff_seq_compact emetric.uniformity_has_countable_basis
-
 /-- A version of Bolzano-Weistrass: in a proper metric space (eg. $ℝ^n$),
 every bounded sequence has a converging subsequence. This version assumes only
 that the sequence is frequently in some bounded set. -/
 lemma tendsto_subseq_of_frequently_bounded [proper_space β] (hs : bounded s)
   {u : ℕ → β} (hu : ∃ᶠ n in at_top, u n ∈ s) :
-∃ b ∈ closure s, ∃ φ : ℕ → ℕ, strict_mono φ ∧ tendsto (u ∘ φ) at_top (𝓝 b) :=
+  ∃ b ∈ closure s, ∃ φ : ℕ → ℕ, strict_mono φ ∧ tendsto (u ∘ φ) at_top (𝓝 b) :=
 begin
   have hcs : is_compact (closure s) :=
     compact_iff_closed_bounded.mpr ⟨is_closed_closure, bounded_closure_of_bounded hs⟩,
   replace hcs : is_seq_compact (closure s),
-    by rwa metric.compact_iff_seq_compact at hcs,
+    from uniform_space.compact_iff_seq_compact.mp hcs,
   have hu' : ∃ᶠ n in at_top, u n ∈ closure s,
   { apply frequently.mono hu,
     intro n,
@@ -384,16 +378,12 @@ lemma tendsto_subseq_of_bounded [proper_space β] (hs : bounded s)
 ∃ b ∈ closure s, ∃ φ : ℕ → ℕ, strict_mono φ ∧ tendsto (u ∘ φ) at_top (𝓝 b) :=
 tendsto_subseq_of_frequently_bounded hs $ frequently_of_forall hu
 
-lemma metric.compact_space_iff_seq_compact_space : compact_space β ↔ seq_compact_space β :=
-uniform_space.compact_space_iff_seq_compact_space emetric.uniformity_has_countable_basis
-
 lemma seq_compact.lebesgue_number_lemma_of_metric
   {ι : Type*} {c : ι → set β} (hs : is_seq_compact s)
   (hc₁ : ∀ i, is_open (c i)) (hc₂ : s ⊆ ⋃ i, c i) :
   ∃ δ > 0, ∀ x ∈ s, ∃ i, ball x δ ⊆ c i :=
 begin
-  rcases lebesgue_number_lemma_seq hs hc₁ hc₂ emetric.uniformity_has_countable_basis
-    with ⟨V, V_in, _, hV⟩,
+  rcases lebesgue_number_lemma_seq hs hc₁ hc₂ with ⟨V, V_in, _, hV⟩,
   rcases uniformity_basis_dist.mem_iff.mp V_in with ⟨δ, δ_pos, h⟩,
   use [δ, δ_pos],
   intros x x_in,

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -851,10 +851,16 @@ begin
     symmetric_symmetrize_rel s, symmetrize_rel_subset_self s⟩
 end
 
-lemma uniform_space.has_seq_basis (h : is_countably_generated $ 𝓤 α) :
+section
+
+variable (α)
+
+lemma uniform_space.has_seq_basis [is_countably_generated $ 𝓤 α] :
   ∃ V : ℕ → set (α × α), has_antitone_basis (𝓤 α) (λ _, true) V ∧ ∀ n, symmetric_rel (V n) :=
-let ⟨U, hsym, hbasis⟩ := h.exists_antitone_subbasis uniform_space.has_basis_symmetric
+let ⟨U, hsym, hbasis⟩ :=  uniform_space.has_basis_symmetric.exists_antitone_subbasis
 in ⟨U, hbasis, λ n, (hsym n).2⟩
+
+end
 
 lemma filter.has_basis.bInter_bUnion_ball {p : ι → Prop} {U : ι → set (α × α)}
   (h : has_basis (𝓤 α) p U) (s : set α) :

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -582,9 +582,7 @@ namespace uniform_space
 
 open sequentially_complete
 
-variables (H : is_countably_generated (𝓤 α))
-
-include H
+variables [is_countably_generated (𝓤 α)]
 
 /-- A uniform space is complete provided that (a) its uniformity filter has a countable basis;
 (b) any sequence satisfying a "controlled" version of the Cauchy condition converges. -/
@@ -592,7 +590,7 @@ theorem complete_of_convergent_controlled_sequences (U : ℕ → set (α × α))
   (HU : ∀ u : ℕ → α, (∀ N m n, N ≤ m → N ≤ n → (u m, u n) ∈ U N) → ∃ a, tendsto u at_top (𝓝 a)) :
   complete_space α :=
 begin
-  obtain ⟨U', U'_mono, hU'⟩ := H.exists_antitone_seq',
+  obtain ⟨U', U'_mono, hU'⟩ := (𝓤 α).exists_antitone_seq,
   have Hmem : ∀ n, U n ∩ U' n ∈ 𝓤 α,
     from λ n, inter_mem (U_mem n) (hU'.2 ⟨n, subset.refl _⟩),
   refine ⟨λ f hf, (HU (seq hf Hmem) (λ N m n hm hn, _)).imp $
@@ -607,12 +605,15 @@ complete. -/
 theorem complete_of_cauchy_seq_tendsto
   (H' : ∀ u : ℕ → α, cauchy_seq u → ∃a, tendsto u at_top (𝓝 a)) :
   complete_space α :=
-let ⟨U', U'_mono, hU'⟩ := H.exists_antitone_seq' in
-complete_of_convergent_controlled_sequences H U' (λ n, hU'.2 ⟨n, subset.refl _⟩)
+let ⟨U', U'_mono, hU'⟩ := (𝓤 α).exists_antitone_seq in
+complete_of_convergent_controlled_sequences U' (λ n, hU'.2 ⟨n, subset.refl _⟩)
   (λ u hu, H' u $ cauchy_seq_of_controlled U' (λ s hs, hU'.1 hs) hu)
 
-protected lemma first_countable_topology : first_countable_topology α :=
-⟨λ a, by { rw nhds_eq_comap_uniformity, exact H.comap (prod.mk a) }⟩
+variable (α)
+
+@[priority 100]
+instance first_countable_topology : first_countable_topology α :=
+⟨λ a, by { rw nhds_eq_comap_uniformity, apply_instance }⟩
 
 /-- A separable uniform space with countably generated uniformity filter is second countable:
 one obtains a countable basis by taking the balls centered at points in a dense subset,
@@ -625,7 +626,7 @@ begin
   obtain ⟨t : ℕ → set (α × α),
     hto : ∀ (i : ℕ), t i ∈ (𝓤 α).sets ∧ is_open (t i) ∧ symmetric_rel (t i),
     h_basis : (𝓤 α).has_antitone_basis (λ _, true) t⟩ :=
-    H.exists_antitone_subbasis uniformity_has_basis_open_symmetric,
+    (@uniformity_has_basis_open_symmetric α _).exists_antitone_subbasis,
   refine ⟨⟨⋃ (x ∈ s), range (λ k, ball x (t k)), hsc.bUnion (λ x hx, countable_range _), _⟩⟩,
   refine (is_topological_basis_of_open_of_nhds _ _).eq_generate_from,
   { simp only [mem_bUnion_iff, mem_range],


### PR DESCRIPTION
## API changes

### Filters

* turn `filter.is_countably_generated` into a class, turn some lemmas into instances;
* remove definition/lemmas (all were in the `filter.is_countably_generated` namespace): `generating_set`, `countable_generating_set`, `eq_generate`, `countable_filter_basis`, `filter_basis_filter`, `has_countable_basis`, `exists_countable_infi_principal`, `exists_seq`;
* rename `filter.is_countably_generated.exists_antitone_subbasis` to `filter.has_basis.exists_antitone_subbasis`;
* rename `filter.is_countably_generated.exists_antitone_basis` to `filter.exists_antitone_basis`;
* rename `filter.is_countably_generated.exists_antitone_seq'` to `filter.exists_antitone_seq`;
* rename `filter.is_countably_generated.exists_seq` to `filter.exists_antitone_eq_infi_principal`;
* rename `filter.is_countably_generated.tendsto_iff_seq_tendsto` to `filter.tendsto_iff_seq_tendsto`;
* rename `filter.is_countably_generated.tendsto_of_seq_tendsto` to `filter.tendsto_of_seq_tendsto`;
* slightly generalize `is_countably_generated_at_top` and `is_countably_generated_at_bot`;
* add `filter.generate_eq_binfi`;

### Topology

* merge `is_closed.is_Gδ` with `is_closed.is_Gδ'`;
* merge `is_Gδ_set_of_continuous_at_of_countably_generated_uniformity` with `is_Gδ_set_of_continuous_at`;
* merge `is_lub.exists_seq_strict_mono_tendsto_of_not_mem'` with `is_lub.exists_seq_strict_mono_tendsto_of_not_mem`;
* merge `is_lub.exists_seq_monotone_tendsto'` with `is_lub.exists_seq_monotone_tendsto`;
* merge `is_glb.exists_seq_strict_anti_tendsto_of_not_mem'` with `is_glb.exists_seq_strict_anti_tendsto_of_not_mem`;
* merge `is_glb.exists_seq_antitone_tendsto'` with `is_glb.exists_seq_antitone_tendsto`;
* drop `emetric.first_countable_topology`, turn `uniform_space.first_countable_topology` into an instance;
* drop `emetric.second_countable_of_separable`, use `uniform_space.second_countable_of_separable` instead;
* drop `metric.compact_iff_seq_compact`, use `uniform_space.compact_iff_seq_compact` instead;
* drop `metric.compact_space_iff_seq_compact_space`, use `uniform_space.compact_space_iff_seq_compact_space` instead;

## Measure theory and integrals

Various lemmas assume `[is_countably_generated l]` instead of `(h : is_countably_generated l)`.

---

@PatrickMassot Do you want me to restore some of the deleted definitions/lemmas? Should I move lemmas that now automatically work for metric spaces (`uniform_space.second_countable_of_separable` etc) to the root namespace?

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
