### PR TITLE
[Merged by Bors] - refactor(data/list/defs): move defs about rb_map

### DIFF
--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -919,6 +919,17 @@ def take_list {α} : list α → list ℕ → list (list α) × list α
   let ⟨xss, rest⟩ := take_list xs₂ ns in
   (xs₁ :: xss, rest)
 
+/--
+`to_rbmap as` is the map that associates each index `i` of `as` with the
+corresponding element of `as`.
+
+```
+to_rbmap ['a', 'b', 'c'] = rbmap_of [(0, 'a'), (1, 'b'), (2, 'c')]
+```
+-/
+def to_rbmap {α : Type*} : list α → rbmap ℕ α :=
+foldl_with_index (λ i mapp a, mapp.insert i a) (mk_rbmap ℕ α)
+
 /-- Auxliary definition used to define `to_chunks`.
 
   `to_chunks_aux n xs i` returns `(xs.take i, (xs.drop i).to_chunks (n+1))`,
@@ -974,16 +985,5 @@ def zip_with4 (f : α → β → γ → δ → ε) : list α → list β → lis
 def zip_with5 (f : α → β → γ → δ → ε → ζ) : list α → list β → list γ → list δ → list ε → list ζ
 | (x::xs) (y::ys) (z::zs) (u::us) (v::vs) := f x y z u v :: zip_with5 xs ys zs us vs
 | _       _       _       _       _       := []
-
-/--
-`to_rbmap as` is the map that associates each index `i` of `as` with the
-corresponding element of `as`.
-
-```
-to_rbmap ['a', 'b', 'c'] = rbmap_of [(0, 'a'), (1, 'b'), (2, 'c')]
-```
--/
-def to_rbmap {α : Type*} : list α → rbmap ℕ α :=
-foldl_with_index (λ i mapp a, mapp.insert i a) (mk_rbmap ℕ α)
 
 end list

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -919,29 +919,6 @@ def take_list {α} : list α → list ℕ → list (list α) × list α
   let ⟨xss, rest⟩ := take_list xs₂ ns in
   (xs₁ :: xss, rest)
 
-/--
-`to_rbmap as` is the map that associates each index `i` of `as` with the
-corresponding element of `as`.
-
-```
-to_rbmap ['a', 'b', 'c'] = rbmap_of [(0, 'a'), (1, 'b'), (2, 'c')]
-```
--/
-def to_rbmap : list α → rbmap ℕ α :=
-foldl_with_index (λ i mapp a, mapp.insert i a) (mk_rbmap ℕ α)
-
-/--
-`to_rb_map as` is the map that associates each index `i` of `as` with the
-corresponding element of `as`.
-
-```
-to_rb_map ['a', 'b', 'c'] = rb_map.of_list [(0, 'a'), (1, 'b'), (2, 'c')]
-```
--/
-meta def to_rb_map {α : Type} : list α → rb_map ℕ α :=
-foldl_with_index (λ i mapp a, mapp.insert i a) mk_rb_map
-
-
 /-- Auxliary definition used to define `to_chunks`.
 
   `to_chunks_aux n xs i` returns `(xs.take i, (xs.drop i).to_chunks (n+1))`,

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -975,4 +975,15 @@ def zip_with5 (f : α → β → γ → δ → ε → ζ) : list α → list β 
 | (x::xs) (y::ys) (z::zs) (u::us) (v::vs) := f x y z u v :: zip_with5 xs ys zs us vs
 | _       _       _       _       _       := []
 
+/--
+`to_rbmap as` is the map that associates each index `i` of `as` with the
+corresponding element of `as`.
+
+```
+to_rbmap ['a', 'b', 'c'] = rbmap_of [(0, 'a'), (1, 'b'), (2, 'c')]
+```
+-/
+def to_rbmap {α : Type*} : list α → rbmap ℕ α :=
+foldl_with_index (λ i mapp a, mapp.insert i a) (mk_rbmap ℕ α)
+
 end list

--- a/src/meta/rb_map.lean
+++ b/src/meta/rb_map.lean
@@ -218,3 +218,29 @@ meta def local_set_to_name_set (lcs : expr_set) : name_set :=
 lcs.fold mk_name_set $ λ h ns, ns.insert h.local_uniq_name
 
 end expr_set
+
+namespace list
+
+/--
+`to_rbmap as` is the map that associates each index `i` of `as` with the
+corresponding element of `as`.
+
+```
+to_rbmap ['a', 'b', 'c'] = rbmap_of [(0, 'a'), (1, 'b'), (2, 'c')]
+```
+-/
+def to_rbmap {α : Type*} : list α → rbmap ℕ α :=
+foldl_with_index (λ i mapp a, mapp.insert i a) (mk_rbmap ℕ α)
+
+/--
+`to_rb_map as` is the map that associates each index `i` of `as` with the
+corresponding element of `as`.
+
+```
+to_rb_map ['a', 'b', 'c'] = rb_map.of_list [(0, 'a'), (1, 'b'), (2, 'c')]
+```
+-/
+meta def to_rb_map {α : Type} : list α → native.rb_map ℕ α :=
+foldl_with_index (λ i mapp a, mapp.insert i a) native.mk_rb_map
+
+end list

--- a/src/meta/rb_map.lean
+++ b/src/meta/rb_map.lean
@@ -222,17 +222,6 @@ end expr_set
 namespace list
 
 /--
-`to_rbmap as` is the map that associates each index `i` of `as` with the
-corresponding element of `as`.
-
-```
-to_rbmap ['a', 'b', 'c'] = rbmap_of [(0, 'a'), (1, 'b'), (2, 'c')]
-```
--/
-def to_rbmap {α : Type*} : list α → rbmap ℕ α :=
-foldl_with_index (λ i mapp a, mapp.insert i a) (mk_rbmap ℕ α)
-
-/--
 `to_rb_map as` is the map that associates each index `i` of `as` with the
 corresponding element of `as`.
 


### PR DESCRIPTION
There is nothing intrinsically `meta` about `rb_map`, but in practice in mathlib we prove nothing about it and only use it in tactic infrastructure. This PR moves a definition involving `rb_map` out of `data.list.defs` and into `meta.rb_map` (where many others already exist).

(motivated by mathport; rb_map is of course disappearing/changing, so better to quarantine this stuff off with other things that aren't being automatically ported)

`rbmap` is not related to `rb_map`. It can likely be moved from core to mathlib entirely.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
