### PR TITLE
[Merged by Bors] - feat(ring_theory/polynomial/cyclotomic): add cyclotomic_prime_pow_eq_geom_sum and supporting lemmas

### DIFF
--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -316,16 +316,16 @@ begin
   refine ⟨one_dvd _, nat.succ_lt_succ (nat.succ_pos _)⟩,
 end
 
-@[simp]
-lemma prime.sum_proper_divisors {α : Type*} [add_comm_monoid α] {p : ℕ} {f : ℕ → α} (h : p.prime) :
-  ∑ x in p.proper_divisors, f x = f 1 :=
+@[simp, to_additive]
+lemma prime.prod_proper_divisors {α : Type*} [comm_monoid α] {p : ℕ} {f : ℕ → α} (h : p.prime) :
+  ∏ x in p.proper_divisors, f x = f 1 :=
 by simp [h.proper_divisors]
 
-@[simp]
-lemma prime.sum_divisors {α : Type*} [add_comm_monoid α] {p : ℕ} {f : ℕ → α} (h : p.prime) :
-  ∑ x in p.divisors, f x = f p + f 1 :=
+@[simp, to_additive]
+lemma prime.prod_divisors {α : Type*} [comm_monoid α] {p : ℕ} {f : ℕ → α} (h : p.prime) :
+  ∏ x in p.divisors, f x = f p * f 1 :=
 by rw [divisors_eq_proper_divisors_insert_self_of_pos h.pos,
-       sum_insert proper_divisors.not_self_mem, h.sum_proper_divisors]
+       prod_insert proper_divisors.not_self_mem, h.prod_proper_divisors]
 
 lemma proper_divisors_eq_singleton_one_iff_prime :
   n.proper_divisors = {1} ↔ n.prime :=
@@ -357,20 +357,35 @@ begin
     (eq.trans sum_singleton h.symm)
 end
 
-@[simp]
-lemma prod_divisors_prime {α : Type*} [comm_monoid α] {p : ℕ} {f : ℕ → α} (h : p.prime) :
-  ∏ x in p.divisors, f x = f p * f 1 :=
-@prime.sum_divisors (additive α) _ _ _ h
+lemma mem_proper_divisors_prime_pow {p : ℕ} (pp : p.prime) (k : ℕ) {x : ℕ} :
+  x ∈ proper_divisors (p ^ k) ↔ ∃ (j : ℕ) (H : j < k), x = p ^ j :=
+begin
+  rw [mem_proper_divisors, nat.dvd_prime_pow pp, ← exists_and_distrib_right],
+  simp only [exists_prop, and_assoc],
+  apply exists_congr,
+  intro a,
+  split; intro h,
+  { rcases h with ⟨h_left, rfl, h_right⟩,
+    rwa pow_lt_pow_iff pp.one_lt at h_right,
+    simpa, },
+  { rcases h with ⟨h_left, rfl⟩,
+    rwa pow_lt_pow_iff pp.one_lt,
+    simp [h_left, le_of_lt], },
+end
 
-@[simp]
-lemma sum_divisors_prime_pow {α : Type*} [add_comm_monoid α] {k p : ℕ} {f : ℕ → α} (h : p.prime) :
-  ∑ x in (p ^ k).divisors, f x = ∑ x in range (k + 1), f (p ^ x) :=
-by simp [h, divisors_prime_pow]
+lemma proper_divisors_prime_pow {p : ℕ} (pp : p.prime) (k : ℕ) :
+  proper_divisors (p ^ k) = (finset.range k).map ⟨pow p, pow_right_injective pp.two_le⟩ :=
+by { ext, simp [mem_proper_divisors_prime_pow, pp, nat.lt_succ_iff, @eq_comm _ a], }
 
-@[simp]
+@[simp, to_additive]
+lemma prod_proper_divisors_prime_pow {α : Type*} [comm_monoid α] {k p : ℕ} {f : ℕ → α} (h : p.prime) :
+  ∏ x in (p ^ k).proper_divisors, f x = ∏ x in range k, f (p ^ x) :=
+by simp [h, proper_divisors_prime_pow]
+
+@[simp, to_additive]
 lemma prod_divisors_prime_pow {α : Type*} [comm_monoid α] {k p : ℕ} {f : ℕ → α} (h : p.prime) :
   ∏ x in (p ^ k).divisors, f x = ∏ x in range (k + 1), f (p ^ x) :=
-@sum_divisors_prime_pow (additive α) _ _ _ _ h
+by simp [h, divisors_prime_pow]
 
 @[simp]
 lemma filter_dvd_eq_divisors {n : ℕ} (h : n ≠ 0) :

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -378,8 +378,8 @@ lemma proper_divisors_prime_pow {p : ℕ} (pp : p.prime) (k : ℕ) :
 by { ext, simp [mem_proper_divisors_prime_pow, pp, nat.lt_succ_iff, @eq_comm _ a], }
 
 @[simp, to_additive]
-lemma prod_proper_divisors_prime_pow {α : Type*} [comm_monoid α] {k p : ℕ} {f : ℕ → α} (h : p.prime) :
-  ∏ x in (p ^ k).proper_divisors, f x = ∏ x in range k, f (p ^ x) :=
+lemma prod_proper_divisors_prime_pow {α : Type*} [comm_monoid α] {k p : ℕ} {f : ℕ → α}
+  (h : p.prime) : ∏ x in (p ^ k).proper_divisors, f x = ∏ x in range k, f (p ^ x) :=
 by simp [h, proper_divisors_prime_pow]
 
 @[simp, to_additive]

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -526,6 +526,25 @@ begin
   simp only [nat.prime.proper_divisors hp, geom_sum_mul, finset.prod_singleton, cyclotomic_one],
 end
 
+/-- If `p ^ k` is prime power, then `cyclotomic (p ^ (n + 1)) R = geom_sum (X ^ p ^ n) p`. -/
+lemma cyclotomic_prime_pow_eq_geom_sum {R : Type*} [comm_ring R] {p n : ℕ} (hp : nat.prime p) :
+  cyclotomic (p ^ (n + 1)) R = geom_sum (X ^ p ^ n) p :=
+begin
+  have : ∀ m, cyclotomic (p ^ (m + 1)) R = geom_sum (X ^ (p ^ m)) p ↔
+    geom_sum (X ^ p ^ m) p * ∏ (x : ℕ) in finset.range (m + 1),
+      cyclotomic (p ^ x) R = X ^ p ^ (m + 1) - 1,
+  { intro m,
+    have := eq_cyclotomic_iff (pow_pos hp.pos (m + 1)) _,
+    rw eq_comm at this,
+    rw [this, nat.prod_proper_divisors_prime_pow hp], },
+  induction n with n_n n_ih,
+  { simp [cyclotomic_eq_geom_sum hp], },
+  rw ((eq_cyclotomic_iff (pow_pos hp.pos (n_n.succ + 1)) _).mpr _).symm,
+  rw [nat.prod_proper_divisors_prime_pow hp, finset.prod_range_succ, n_ih],
+  rw this at n_ih,
+  rw [mul_comm _ (geom_sum _ _), n_ih, geom_sum_mul, sub_left_inj, ← pow_mul, pow_add, pow_one],
+end
+
 /-- The constant term of `cyclotomic n R` is `1` if `2 ≤ n`. -/
 lemma cyclotomic_coeff_zero (R : Type*) [comm_ring R] {n : ℕ} (hn : 2 ≤ n) :
   (cyclotomic n R).coeff 0 = 1 :=


### PR DESCRIPTION
Clean up a little bit in src/number_theory/divisors.lean using to_additive too.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
