### PR TITLE
[Merged by Bors] - refactor(algebra/continued_fractions): remove use of open ... as

### DIFF
--- a/src/algebra/continued_fractions/basic.lean
+++ b/src/algebra/continued_fractions/basic.lean
@@ -46,18 +46,19 @@ variable (α : Type*)
 @[derive inhabited]
 protected structure generalized_continued_fraction.pair := (a : α) (b : α)
 
+open generalized_continued_fraction
+
 /-! Interlude: define some expected coercions and instances. -/
 namespace generalized_continued_fraction.pair
-open generalized_continued_fraction as gcf
 
 variable {α}
 
 /-- Make a `gcf.pair` printable. -/
-instance [has_repr α] : has_repr (gcf.pair α) :=
+instance [has_repr α] : has_repr (pair α) :=
 ⟨λ p, "(a : " ++ (repr p.a) ++ ", b : " ++ (repr p.b) ++ ")"⟩
 
 /-- Maps a function `f` on both components of a given pair. -/
-def map {β : Type*} (f : α → β) (gp : gcf.pair α) : gcf.pair β :=
+def map {β : Type*} (f : α → β) (gp : pair α) : pair β :=
 ⟨f gp.a, f gp.b⟩
 
 section coe
@@ -65,14 +66,12 @@ section coe
 variables {β : Type*} [has_coe α β]
 
 /-- Coerce a pair by elementwise coercion. -/
-instance has_coe_to_generalized_continued_fraction_pair :
-  has_coe (gcf.pair α) (gcf.pair β) :=
+instance has_coe_to_generalized_continued_fraction_pair : has_coe (pair α) (pair β) :=
 ⟨map coe⟩
 
 @[simp, norm_cast]
 lemma coe_to_generalized_continued_fraction_pair {a b : α} :
-  (↑(gcf.pair.mk a b) : gcf.pair β) = gcf.pair.mk (a : β) (b : β) :=
-rfl
+  (↑(pair.mk a b) : pair β) = pair.mk (a : β) (b : β) := rfl
 
 end coe
 end generalized_continued_fraction.pair
@@ -99,33 +98,35 @@ generalized_continued_fraction.pairs `s`.
 For convenience, one often writes `[h; (a₀, b₀), (a₁, b₁), (a₂, b₂),...]`.
 -/
 structure generalized_continued_fraction :=
-(h : α) (s : seq $ generalized_continued_fraction.pair α)
+(h : α) (s : seq $ pair α)
 
 variable {α}
 
 namespace generalized_continued_fraction
-open generalized_continued_fraction as gcf
 
 /-- Constructs a generalized continued fraction without fractional part. -/
-def of_integer (a : α) : gcf α :=
+def of_integer (a : α) : generalized_continued_fraction α :=
 ⟨a, seq.nil⟩
 
-instance [inhabited α] : inhabited (gcf α) := ⟨of_integer (default _)⟩
+instance [inhabited α] : inhabited (generalized_continued_fraction α) := ⟨of_integer (default _)⟩
 
 /-- Returns the sequence of partial numerators `aᵢ` of `g`. -/
-def partial_numerators (g : gcf α) : seq α := g.s.map gcf.pair.a
+def partial_numerators (g : generalized_continued_fraction α) : seq α :=
+g.s.map pair.a
 /-- Returns the sequence of partial denominators `bᵢ` of `g`. -/
-def partial_denominators (g : gcf α) : seq α := g.s.map gcf.pair.b
+def partial_denominators (g : generalized_continued_fraction α) : seq α :=
+g.s.map pair.b
 
 /-- A gcf terminated at position `n` if its sequence terminates at position `n`. -/
-def terminated_at (g : gcf α) (n : ℕ) : Prop := g.s.terminated_at n
+def terminated_at (g : generalized_continued_fraction α) (n : ℕ) : Prop := g.s.terminated_at n
 
 /-- It is decidable whether a gcf terminated at a given position. -/
-instance terminated_at_decidable (g : gcf α) (n : ℕ) : decidable (g.terminated_at n) :=
+instance terminated_at_decidable (g : generalized_continued_fraction α) (n : ℕ) :
+  decidable (g.terminated_at n) :=
 by { unfold terminated_at, apply_instance }
 
 /-- A gcf terminates if its sequence terminates. -/
-def terminates (g : gcf α) : Prop := g.s.terminates
+def terminates (g : generalized_continued_fraction α) : Prop := g.s.terminates
 
 section coe
 /-! Interlude: define some expected coercions. -/
@@ -133,12 +134,14 @@ section coe
 variables {β : Type*} [has_coe α β]
 
 /-- Coerce a gcf by elementwise coercion. -/
-instance has_coe_to_generalized_continued_fraction : has_coe (gcf α) (gcf β) :=
-⟨λ g, ⟨(g.h : β), (g.s.map coe : seq $ gcf.pair β)⟩⟩
+instance has_coe_to_generalized_continued_fraction :
+  has_coe (generalized_continued_fraction α) (generalized_continued_fraction β) :=
+⟨λ g, ⟨(g.h : β), (g.s.map coe : seq $ pair β)⟩⟩
 
 @[simp, norm_cast]
-lemma coe_to_generalized_continued_fraction {g : gcf α} :
-  (↑(g : gcf α) : gcf β) = ⟨(g.h : β), (g.s.map coe : seq $ gcf.pair β)⟩ :=
+lemma coe_to_generalized_continued_fraction {g : generalized_continued_fraction α} :
+  (↑(g : generalized_continued_fraction α) : generalized_continued_fraction β) =
+    ⟨(g.h : β), (g.s.map coe : seq $ pair β)⟩ :=
 rfl
 
 end coe
@@ -188,21 +191,22 @@ def simple_continued_fraction [has_one α] :=
 variable {α}
 /- Interlude: define some expected coercions. -/
 namespace simple_continued_fraction
-open generalized_continued_fraction as gcf
-open simple_continued_fraction as scf
+
 variable [has_one α]
 
 /-- Constructs a simple continued fraction without fractional part. -/
-def of_integer (a : α) : scf α :=
-⟨gcf.of_integer a, λ n aₙ h, by cases h⟩
+def of_integer (a : α) : simple_continued_fraction α :=
+⟨generalized_continued_fraction.of_integer a, λ n aₙ h, by cases h⟩
 
-instance : inhabited (scf α) := ⟨of_integer 1⟩
+instance : inhabited (simple_continued_fraction α) := ⟨of_integer 1⟩
 
 /-- Lift a scf to a gcf using the inclusion map. -/
-instance has_coe_to_generalized_continued_fraction : has_coe (scf α) (gcf α) :=
-by {unfold scf, apply_instance}
+instance has_coe_to_generalized_continued_fraction :
+  has_coe (simple_continued_fraction α) (generalized_continued_fraction α) :=
+by {unfold simple_continued_fraction, apply_instance}
 
-lemma coe_to_generalized_continued_fraction {s : scf α} : (↑s : gcf α) = s.val := rfl
+lemma coe_to_generalized_continued_fraction {s : simple_continued_fraction α} :
+  (↑s : generalized_continued_fraction α) = s.val := rfl
 
 end simple_continued_fraction
 
@@ -229,27 +233,30 @@ variable {α}
 
 /-! Interlude: define some expected coercions. -/
 namespace continued_fraction
-open generalized_continued_fraction as gcf
-open simple_continued_fraction as scf
-open continued_fraction as cf
+
 variables [has_one α] [has_zero α] [has_lt α]
 
 /-- Constructs a continued fraction without fractional part. -/
-def of_integer (a : α) : cf α :=
-⟨scf.of_integer a, λ n bₙ h, by cases h⟩
+def of_integer (a : α) : continued_fraction α :=
+⟨simple_continued_fraction.of_integer a, λ n bₙ h, by cases h⟩
 
-instance : inhabited (cf α) := ⟨of_integer 0⟩
-
-/-- Lift a cf to a scf using the inclusion map. -/
-instance has_coe_to_simple_continued_fraction : has_coe (cf α) (scf α) :=
-by {unfold cf, apply_instance}
-
-lemma coe_to_simple_continued_fraction {c : cf α} : (↑c : scf α) = c.val := rfl
+instance : inhabited (continued_fraction α) := ⟨of_integer 0⟩
 
 /-- Lift a cf to a scf using the inclusion map. -/
-instance has_coe_to_generalized_continued_fraction : has_coe (cf α) (gcf α) := ⟨λ c, ↑(↑c : scf α)⟩
+instance has_coe_to_simple_continued_fraction :
+  has_coe (continued_fraction α) (simple_continued_fraction α) :=
+by {unfold continued_fraction, apply_instance}
 
-lemma coe_to_generalized_continued_fraction {c : cf α} : (↑c : gcf α) = c.val := rfl
+lemma coe_to_simple_continued_fraction {c : continued_fraction α} :
+  (↑c : simple_continued_fraction α) = c.val := rfl
+
+/-- Lift a cf to a scf using the inclusion map. -/
+instance has_coe_to_generalized_continued_fraction :
+  has_coe (continued_fraction α) (generalized_continued_fraction α) :=
+⟨λ c, ↑(↑c : simple_continued_fraction α)⟩
+
+lemma coe_to_generalized_continued_fraction {c : continued_fraction α} :
+  (↑c : generalized_continued_fraction α) = c.val := rfl
 
 end continued_fraction
 
@@ -262,7 +269,6 @@ directly evaluating the (infinite) fraction described by the gcf or using a recu
 For (r)cfs, these computations are equivalent as shown in
 `algebra.continued_fractions.convergents_equiv`.
 -/
-open generalized_continued_fraction as gcf
 
 -- Fix a division ring for the computations.
 variables {K : Type*} [division_ring K]
@@ -292,11 +298,11 @@ def next_denominator (aₙ bₙ ppredB predB : K) : K := bₙ * predB + aₙ * p
 Returns the next continuants `⟨Aₙ, Bₙ⟩` using `next_numerator` and `next_denominator`, where `pred`
 is `⟨Aₙ₋₁, Bₙ₋₁⟩`, `ppred` is `⟨Aₙ₋₂, Bₙ₋₂⟩`, `a` is `aₙ₋₁`, and `b` is `bₙ₋₁`.
 -/
-def next_continuants (a b : K) (ppred pred : gcf.pair K) : gcf.pair K :=
+def next_continuants (a b : K) (ppred pred : pair K) : pair K :=
 ⟨next_numerator a b ppred.a pred.a, next_denominator a b ppred.b pred.b⟩
 
 /-- Returns the continuants `⟨Aₙ₋₁, Bₙ₋₁⟩` of `g`. -/
-def continuants_aux (g : gcf K) : stream (gcf.pair K)
+def continuants_aux (g : generalized_continued_fraction K) : stream (pair K)
 | 0 := ⟨1, 0⟩
 | 1 := ⟨g.h, 1⟩
 | (n + 2) :=
@@ -306,23 +312,27 @@ def continuants_aux (g : gcf K) : stream (gcf.pair K)
   end
 
 /-- Returns the continuants `⟨Aₙ, Bₙ⟩` of `g`. -/
-def continuants (g : gcf K) : stream (gcf.pair K) := g.continuants_aux.tail
+def continuants (g : generalized_continued_fraction K) : stream (pair K) :=
+g.continuants_aux.tail
 
 /-- Returns the numerators `Aₙ` of `g`. -/
-def numerators (g : gcf K) : stream K := g.continuants.map gcf.pair.a
+def numerators (g : generalized_continued_fraction K) : stream K :=
+g.continuants.map pair.a
 
 /-- Returns the denominators `Bₙ` of `g`. -/
-def denominators (g : gcf K) : stream K := g.continuants.map gcf.pair.b
+def denominators (g : generalized_continued_fraction K) : stream K :=
+g.continuants.map pair.b
 
 /-- Returns the convergents `Aₙ / Bₙ` of `g`, where `Aₙ, Bₙ` are the nth continuants of `g`. -/
-def convergents (g : gcf K) : stream K := λ (n : ℕ), (g.numerators n) / (g.denominators n)
+def convergents (g : generalized_continued_fraction K) : stream K :=
+λ (n : ℕ), (g.numerators n) / (g.denominators n)
 
 /--
 Returns the approximation of the fraction described by the given sequence up to a given position n.
 For example, `convergents'_aux [(1, 2), (3, 4), (5, 6)] 2 = 1 / (2 + 3 / 4)` and
 `convergents'_aux [(1, 2), (3, 4), (5, 6)] 0 = 0`.
 -/
-def convergents'_aux : seq (gcf.pair K) → ℕ → K
+def convergents'_aux : seq (pair K) → ℕ → K
 | s 0 := 0
 | s (n + 1) := match s.head with
   | none := 0
@@ -334,20 +344,21 @@ Returns the convergents of `g` by evaluating the fraction described by `g` up to
 position `n`. For example, `convergents' [9; (1, 2), (3, 4), (5, 6)] 2 = 9 + 1 / (2 + 3 / 4)` and
 `convergents' [9; (1, 2), (3, 4), (5, 6)] 0 = 9`
 -/
-def convergents' (g : gcf K) (n : ℕ) : K := g.h + convergents'_aux g.s n
+def convergents' (g : generalized_continued_fraction K) (n : ℕ) : K := g.h + convergents'_aux g.s n
 
 end generalized_continued_fraction
 
 -- Now, some basic, general theorems
 namespace generalized_continued_fraction
-open generalized_continued_fraction as gcf
 
 /-- Two gcfs `g` and `g'` are equal if and only if their components are equal. -/
-protected lemma ext_iff {g g' : gcf α} : g = g' ↔ g.h = g'.h ∧ g.s = g'.s :=
+protected lemma ext_iff {g g' : generalized_continued_fraction α} :
+  g = g' ↔ g.h = g'.h ∧ g.s = g'.s :=
 by { cases g, cases g', simp }
 
 @[ext]
-protected lemma ext {g g' : gcf α} (hyp : g.h = g'.h ∧ g.s = g'.s) : g = g' :=
+protected lemma ext {g g' : generalized_continued_fraction α} (hyp : g.h = g'.h ∧ g.s = g'.s) :
+  g = g' :=
 generalized_continued_fraction.ext_iff.elim_right hyp
 
 end generalized_continued_fraction

--- a/src/algebra/continued_fractions/computation/approximation_corollaries.lean
+++ b/src/algebra/continued_fractions/computation/approximation_corollaries.lean
@@ -37,7 +37,9 @@ convergence, fractions
 -/
 
 variables {K : Type*} (v : K) [linear_ordered_field K] [floor_ring K]
+
 open generalized_continued_fraction (of)
+open generalized_continued_fraction
 
 lemma generalized_continued_fraction.of_is_simple_continued_fraction :
   (of v).is_simple_continued_fraction :=
@@ -45,7 +47,7 @@ lemma generalized_continued_fraction.of_is_simple_continued_fraction :
 
 /-- Creates the simple continued fraction of a value. -/
 def simple_continued_fraction.of : simple_continued_fraction K :=
-⟨of v, of_is_simple_continued_fraction v⟩
+⟨of v, generalized_continued_fraction.of_is_simple_continued_fraction v⟩
 
 lemma simple_continued_fraction.of_is_continued_fraction :
   (simple_continued_fraction.of v).is_continued_fraction :=

--- a/src/algebra/continued_fractions/computation/approximation_corollaries.lean
+++ b/src/algebra/continued_fractions/computation/approximation_corollaries.lean
@@ -37,20 +37,20 @@ convergence, fractions
 -/
 
 variables {K : Type*} (v : K) [linear_ordered_field K] [floor_ring K]
-open generalized_continued_fraction as gcf
+open generalized_continued_fraction (of)
 
 lemma generalized_continued_fraction.of_is_simple_continued_fraction :
-  (gcf.of v).is_simple_continued_fraction :=
-(λ _ _ nth_part_num_eq, gcf.of_part_num_eq_one nth_part_num_eq)
+  (of v).is_simple_continued_fraction :=
+(λ _ _ nth_part_num_eq, of_part_num_eq_one nth_part_num_eq)
 
 /-- Creates the simple continued fraction of a value. -/
 def simple_continued_fraction.of : simple_continued_fraction K :=
-⟨gcf.of v, generalized_continued_fraction.of_is_simple_continued_fraction v⟩
+⟨of v, of_is_simple_continued_fraction v⟩
 
 lemma simple_continued_fraction.of_is_continued_fraction :
   (simple_continued_fraction.of v).is_continued_fraction :=
-(λ _ denom nth_part_denom_eq,
-  lt_of_lt_of_le zero_lt_one(gcf.of_one_le_nth_part_denom nth_part_denom_eq))
+(λ _ denom nth_part_denom_eq, lt_of_lt_of_le zero_lt_one
+  (of_one_le_nth_part_denom nth_part_denom_eq))
 
 /-- Creates the continued fraction of a value. -/
 def continued_fraction.of : continued_fraction K :=
@@ -58,10 +58,9 @@ def continued_fraction.of : continued_fraction K :=
 
 namespace generalized_continued_fraction
 
-open continued_fraction as cf
-
-lemma of_convergents_eq_convergents' : (gcf.of v).convergents = (gcf.of v).convergents' :=
-@cf.convergents_eq_convergents'  _ _ (continued_fraction.of v)
+lemma of_convergents_eq_convergents' :
+  (of v).convergents = (of v).convergents' :=
+@continued_fraction.convergents_eq_convergents'  _ _ (continued_fraction.of v)
 
 section convergence
 /-!
@@ -74,7 +73,7 @@ variable [archimedean K]
 open nat
 
 theorem of_convergence_epsilon :
-  ∀ (ε > (0 : K)), ∃ (N : ℕ), ∀ (n ≥ N), |v - (gcf.of v).convergents n| < ε :=
+  ∀ (ε > (0 : K)), ∃ (N : ℕ), ∀ (n ≥ N), |v - (of v).convergents n| < ε :=
 begin
   assume ε ε_pos,
   -- use the archimedean property to obtian a suitable N
@@ -82,7 +81,7 @@ begin
   let N := max N' 5, -- set minimum to 5 to have N ≤ fib N work
   existsi N,
   assume n n_ge_N,
-  let g := gcf.of v,
+  let g := of v,
   cases decidable.em (g.terminated_at n) with terminated_at_n not_terminated_at_n,
   { have : v = g.convergents n, from of_correctness_of_terminated_at terminated_at_n,
     have : v - g.convergents n = 0, from sub_eq_zero.elim_right this,
@@ -136,7 +135,7 @@ end
 local attribute [instance] preorder.topology
 
 theorem of_convergence [order_topology K] :
-  filter.tendsto ((gcf.of v).convergents) filter.at_top $ nhds v :=
+  filter.tendsto ((of v).convergents) filter.at_top $ nhds v :=
 by simpa [linear_ordered_add_comm_group.tendsto_nhds, abs_sub_comm] using (of_convergence_epsilon v)
 
 end convergence

--- a/src/algebra/continued_fractions/computation/approximations.lean
+++ b/src/algebra/continued_fractions/computation/approximations.lean
@@ -45,7 +45,7 @@ the error term indeed gets smaller. As a corollary, we will be able to show that
 -/
 
 namespace generalized_continued_fraction
-open generalized_continued_fraction as gcf int
+open generalized_continued_fraction (of) int
 
 variables {K : Type*} {v : K} {n : ℕ} [linear_ordered_field K] [floor_ring K]
 
@@ -129,10 +129,10 @@ fraction `generalized_continued_fraction.of`.
 
 /-- Shows that the integer parts of the continued fraction are at least one. -/
 lemma of_one_le_nth_part_denom {b : K}
-  (nth_part_denom_eq : (gcf.of v).partial_denominators.nth n = some b) :
+  (nth_part_denom_eq : (of v).partial_denominators.nth n = some b) :
   1 ≤ b :=
 begin
-  obtain ⟨gp_n,  nth_s_eq, ⟨-⟩⟩ : ∃ gp_n, (gcf.of v).s.nth n = some gp_n ∧ gp_n.b = b, from
+  obtain ⟨gp_n,  nth_s_eq, ⟨-⟩⟩ : ∃ gp_n, (of v).s.nth n = some gp_n ∧ gp_n.b = b, from
     exists_s_b_of_part_denom nth_part_denom_eq,
   obtain ⟨ifp_n, succ_nth_stream_eq, ifp_n_b_eq_gp_n_b⟩ :
     ∃ ifp, int_fract_pair.stream v (n + 1) = some ifp ∧ (ifp.b : K) = gp_n.b, from
@@ -145,15 +145,15 @@ end
 Shows that the partial numerators `aᵢ` of the continued fraction are equal to one and the partial
 denominators `bᵢ` correspond to integers.
 -/
-lemma of_part_num_eq_one_and_exists_int_part_denom_eq {gp : gcf.pair K}
-  (nth_s_eq : (gcf.of v).s.nth n = some gp) :
+lemma of_part_num_eq_one_and_exists_int_part_denom_eq {gp : generalized_continued_fraction.pair K}
+  (nth_s_eq : (of v).s.nth n = some gp) :
   gp.a = 1 ∧ ∃ (z : ℤ), gp.b = (z : K) :=
 begin
   obtain ⟨ifp, stream_succ_nth_eq, -⟩ :
     ∃ ifp, int_fract_pair.stream v (n + 1) = some ifp ∧ _,
       from int_fract_pair.exists_succ_nth_stream_of_gcf_of_nth_eq_some nth_s_eq,
   have : gp = ⟨1, ifp.b⟩, by
-  { have : (gcf.of v).s.nth n = some ⟨1, ifp.b⟩, from
+  { have : (of v).s.nth n = some ⟨1, ifp.b⟩, from
       nth_of_eq_some_of_succ_nth_int_fract_pair_stream stream_succ_nth_eq,
     have : some gp = some ⟨1, ifp.b⟩, by rwa nth_s_eq at this,
     injection this },
@@ -161,10 +161,10 @@ begin
 end
 
 /-- Shows that the partial numerators `aᵢ` are equal to one. -/
-lemma of_part_num_eq_one {a : K} (nth_part_num_eq : (gcf.of v).partial_numerators.nth n = some a) :
+lemma of_part_num_eq_one {a : K} (nth_part_num_eq : (of v).partial_numerators.nth n = some a) :
   a = 1 :=
 begin
-  obtain ⟨gp, nth_s_eq, gp_a_eq_a_n⟩ : ∃ gp, (gcf.of v).s.nth n = some gp ∧ gp.a = a, from
+  obtain ⟨gp, nth_s_eq, gp_a_eq_a_n⟩ : ∃ gp, (of v).s.nth n = some gp ∧ gp.a = a, from
     exists_s_a_of_part_num nth_part_num_eq,
   have : gp.a = 1, from (of_part_num_eq_one_and_exists_int_part_denom_eq nth_s_eq).left,
   rwa gp_a_eq_a_n at this
@@ -172,10 +172,10 @@ end
 
 /-- Shows that the partial denominators `bᵢ` correspond to an integer. -/
 lemma exists_int_eq_of_part_denom {b : K}
-  (nth_part_denom_eq : (gcf.of v).partial_denominators.nth n = some b) :
+  (nth_part_denom_eq : (of v).partial_denominators.nth n = some b) :
   ∃ (z : ℤ), b = (z : K) :=
 begin
-  obtain ⟨gp, nth_s_eq, gp_b_eq_b_n⟩ : ∃ gp, (gcf.of v).s.nth n = some gp ∧ gp.b = b, from
+  obtain ⟨gp, nth_s_eq, gp_b_eq_b_n⟩ : ∃ gp, (of v).s.nth n = some gp ∧ gp.b = b, from
     exists_s_b_of_part_denom nth_part_denom_eq,
   have : ∃ (z : ℤ), gp.b = (z : K), from
     (of_part_num_eq_one_and_exists_int_part_denom_eq nth_s_eq).right,
@@ -191,8 +191,8 @@ denominators `Bₙ` are bounded from below by the fibonacci sequence `nat.fib`. 
 -- open `nat` as we will make use of fibonacci numbers.
 open nat
 
-lemma fib_le_of_continuants_aux_b : (n ≤ 1 ∨ ¬(gcf.of v).terminated_at (n - 2)) →
-  (fib n : K) ≤ ((gcf.of v).continuants_aux n).b :=
+lemma fib_le_of_continuants_aux_b : (n ≤ 1 ∨ ¬(of v).terminated_at (n - 2)) →
+  (fib n : K) ≤ ((of v).continuants_aux n).b :=
 nat.strong_induction_on n
 begin
   clear n,
@@ -200,7 +200,7 @@ begin
   rcases n with _|_|n,
   { simp [fib_succ_succ, continuants_aux] }, -- case n = 0
   { simp [fib_succ_succ, continuants_aux] }, -- case n = 1
-  { let g := gcf.of v,  -- case 2 ≤ n
+  { let g := of v,  -- case 2 ≤ n
     have : ¬(n + 2 ≤ 1), by linarith,
     have not_terminated_at_n : ¬g.terminated_at n, from or.resolve_left hyp this,
     obtain ⟨gp, s_ppred_nth_eq⟩ : ∃ gp, g.s.nth n = some gp, from
@@ -236,11 +236,11 @@ end
 
 /-- Shows that the `n`th denominator is greater than or equal to the `n + 1`th fibonacci number,
 that is `nat.fib (n + 1) ≤ Bₙ`. -/
-lemma succ_nth_fib_le_of_nth_denom (hyp: n = 0 ∨ ¬(gcf.of v).terminated_at (n - 1)) :
-  (fib (n + 1) : K) ≤ (gcf.of v).denominators n :=
+lemma succ_nth_fib_le_of_nth_denom (hyp: n = 0 ∨ ¬(of v).terminated_at (n - 1)) :
+  (fib (n + 1) : K) ≤ (of v).denominators n :=
 begin
   rw [denom_eq_conts_b, nth_cont_eq_succ_nth_cont_aux],
-  have : (n + 1) ≤ 1 ∨ ¬(gcf.of v).terminated_at (n - 1), by
+  have : (n + 1) ≤ 1 ∨ ¬(of v).terminated_at (n - 1), by
   { cases n,
     case nat.zero : { exact (or.inl $ le_refl 1) },
     case nat.succ : { exact or.inr (or.resolve_left hyp n.succ_ne_zero) } },
@@ -249,9 +249,9 @@ end
 
 /-! As a simple consequence, we can now derive that all denominators are nonnegative. -/
 
-lemma zero_le_of_continuants_aux_b : 0 ≤ ((gcf.of v).continuants_aux n).b :=
+lemma zero_le_of_continuants_aux_b : 0 ≤ ((of v).continuants_aux n).b :=
 begin
-  let g := gcf.of v,
+  let g := of v,
   induction n with n IH,
   case nat.zero: { refl },
   case nat.succ:
@@ -262,20 +262,20 @@ begin
           continuants_aux_stable_step_of_terminated terminated,
         simp only [this, IH] } },
     { calc -- non-terminating case
-      (0 : K) ≤ fib (n + 1)                            : by exact_mod_cast (n + 1).fib.zero_le
-          ... ≤ ((gcf.of v).continuants_aux (n + 1)).b : fib_le_of_continuants_aux_b
-                                                           (or.inr not_terminated) } }
+      (0 : K) ≤ fib (n + 1)                        : by exact_mod_cast (n + 1).fib.zero_le
+          ... ≤ ((of v).continuants_aux (n + 1)).b : fib_le_of_continuants_aux_b
+                                                       (or.inr not_terminated) } }
 end
 
 /-- Shows that all denominators are nonnegative. -/
-lemma zero_le_of_denom : 0 ≤ (gcf.of v).denominators n :=
+lemma zero_le_of_denom : 0 ≤ (of v).denominators n :=
 by { rw [denom_eq_conts_b, nth_cont_eq_succ_nth_cont_aux], exact zero_le_of_continuants_aux_b }
 
 lemma le_of_succ_succ_nth_continuants_aux_b {b : K}
-  (nth_part_denom_eq : (gcf.of v).partial_denominators.nth n = some b) :
-  b * ((gcf.of v).continuants_aux $ n + 1).b ≤ ((gcf.of v).continuants_aux $ n + 2).b :=
+  (nth_part_denom_eq : (of v).partial_denominators.nth n = some b) :
+  b * ((of v).continuants_aux $ n + 1).b ≤ ((of v).continuants_aux $ n + 2).b :=
 begin
-  set g := gcf.of v with g_eq,
+  set g := of v with g_eq,
   obtain ⟨gp_n, nth_s_eq, gpnb_eq_b⟩ : ∃ gp_n, g.s.nth n = some gp_n ∧ gp_n.b = b, from
     exists_s_b_of_part_denom nth_part_denom_eq,
   let conts := g.continuants_aux (n + 2),
@@ -284,7 +284,8 @@ begin
   -- use the recurrence of continuants_aux and the fact that gp_n.a = 1
   suffices : gp_n.b * pconts.b ≤ ppconts.b + gp_n.b * pconts.b, by
   { have : gp_n.a = 1, from of_part_num_eq_one (part_num_eq_s_a nth_s_eq),
-    finish [gcf.continuants_aux_recurrence nth_s_eq ppconts_eq pconts_eq] },
+    finish
+      [generalized_continued_fraction.continuants_aux_recurrence nth_s_eq ppconts_eq pconts_eq] },
   have : 0 ≤ ppconts.b, from zero_le_of_continuants_aux_b,
   solve_by_elim [le_add_of_nonneg_of_le, le_refl]
 end
@@ -292,17 +293,17 @@ end
 /-- Shows that `bₙ * Bₙ ≤ Bₙ₊₁`, where `bₙ` is the `n`th partial denominator and `Bₙ₊₁` and `Bₙ` are
 the `n + 1`th and `n`th denominator of the continued fraction. -/
 theorem le_of_succ_nth_denom {b : K}
-  (nth_part_denom_eq : (gcf.of v).partial_denominators.nth n = some b) :
-  b * (gcf.of v).denominators n ≤ (gcf.of v).denominators (n + 1) :=
+  (nth_part_denom_eq : (of v).partial_denominators.nth n = some b) :
+  b * (of v).denominators n ≤ (of v).denominators (n + 1) :=
 begin
   rw [denom_eq_conts_b, nth_cont_eq_succ_nth_cont_aux],
   exact (le_of_succ_succ_nth_continuants_aux_b nth_part_denom_eq)
 end
 
 /-- Shows that the sequence of denominators is monotone, that is `Bₙ ≤ Bₙ₊₁`. -/
-theorem of_denom_mono : (gcf.of v).denominators n ≤ (gcf.of v).denominators (n + 1) :=
+theorem of_denom_mono : (of v).denominators n ≤ (of v).denominators (n + 1) :=
 begin
-  let g := gcf.of v,
+  let g := of v,
   cases (decidable.em $ g.partial_denominators.terminated_at n) with terminated not_terminated,
   { have : g.partial_denominators.nth n = none, by rwa seq.terminated_at at terminated,
     have : g.terminated_at n, from
@@ -326,16 +327,16 @@ Next we prove the so-called *determinant formula* for `generalized_continued_fra
 `Aₙ * Bₙ₊₁ - Bₙ * Aₙ₊₁ = (-1)^(n + 1)`.
 -/
 
-lemma determinant_aux (hyp: n = 0 ∨ ¬(gcf.of v).terminated_at (n - 1)) :
-    ((gcf.of v).continuants_aux n).a * ((gcf.of v).continuants_aux (n + 1)).b
-    - ((gcf.of v).continuants_aux n).b * ((gcf.of v).continuants_aux (n + 1)).a
+lemma determinant_aux (hyp: n = 0 ∨ ¬(of v).terminated_at (n - 1)) :
+    ((of v).continuants_aux n).a * ((of v).continuants_aux (n + 1)).b
+    - ((of v).continuants_aux n).b * ((of v).continuants_aux (n + 1)).a
   = (-1)^n :=
 begin
   induction n with n IH,
   case nat.zero { simp [continuants_aux] },
   case nat.succ
   { -- set up some shorthand notation
-    let g := gcf.of v,
+    let g := of v,
     let conts := continuants_aux g (n + 2),
     set pred_conts := continuants_aux g (n + 1) with pred_conts_eq,
     set ppred_conts := continuants_aux g n with ppred_conts_eq,
@@ -367,9 +368,9 @@ begin
 end
 
 /-- The determinant formula `Aₙ * Bₙ₊₁ - Bₙ * Aₙ₊₁ = (-1)^(n + 1)` -/
-lemma determinant (not_terminated_at_n : ¬(gcf.of v).terminated_at n) :
-    (gcf.of v).numerators n * (gcf.of v).denominators (n + 1)
-    - (gcf.of v).denominators n * (gcf.of v).numerators (n + 1)
+lemma determinant (not_terminated_at_n : ¬(of v).terminated_at n) :
+    (of v).numerators n * (of v).denominators (n + 1)
+    - (of v).denominators n * (of v).numerators (n + 1)
   = (-1)^(n + 1) :=
 (determinant_aux $ or.inr $ not_terminated_at_n)
 
@@ -387,21 +388,23 @@ position, i.e. bounds for the term `|v - (generalized_continued_fraction.of v).c
 by simplifying the difference. -/
 lemma sub_convergents_eq {ifp : int_fract_pair K}
   (stream_nth_eq : int_fract_pair.stream v n = some ifp) :
-  let g := gcf.of v in
+  let g := of v in
   let B := (g.continuants_aux (n + 1)).b in
   let pB := (g.continuants_aux n).b in
   v - g.convergents n = if ifp.fr = 0 then 0 else (-1)^n / (B * (ifp.fr⁻¹ * B + pB)) :=
 begin
   -- set up some shorthand notation
-  let g := gcf.of v,
+  let g := of v,
   let conts := g.continuants_aux (n + 1),
   let pred_conts := g.continuants_aux n,
-  have g_finite_correctness : v = gcf.comp_exact_value pred_conts conts ifp.fr, from
+  have g_finite_correctness :
+    v = generalized_continued_fraction.comp_exact_value pred_conts conts ifp.fr, from
     comp_exact_value_correctness_of_stream_eq_some stream_nth_eq,
   cases decidable.em (ifp.fr = 0) with ifp_fr_eq_zero ifp_fr_ne_zero,
   { suffices : v - g.convergents n = 0, by simpa [ifp_fr_eq_zero],
     replace g_finite_correctness : v = g.convergents n, by
-      simpa [gcf.comp_exact_value, ifp_fr_eq_zero] using g_finite_correctness,
+      simpa [generalized_continued_fraction.comp_exact_value, ifp_fr_eq_zero]
+        using g_finite_correctness,
     exact (sub_eq_zero.elim_right g_finite_correctness) },
   { -- more shorthand notation
     let A := conts.a,
@@ -412,8 +415,8 @@ begin
     suffices : v - A / B = (-1)^n / (B * (ifp.fr⁻¹ * B + pB)), by simpa [ifp_fr_ne_zero],
     -- now we can unfold `g.comp_exact_value` to derive the following equality for `v`
     replace g_finite_correctness : v = (pA + ifp.fr⁻¹ * A) / (pB + ifp.fr⁻¹ * B), by
-      simpa [gcf.comp_exact_value, ifp_fr_ne_zero, next_continuants, next_numerator,
-          next_denominator, add_comm] using g_finite_correctness,
+      simpa [generalized_continued_fraction.comp_exact_value, ifp_fr_ne_zero, next_continuants,
+        next_numerator, next_denominator, add_comm] using g_finite_correctness,
     -- let's rewrite this equality for `v` in our goal
     suffices : (pA + ifp.fr⁻¹ * A) / (pB + ifp.fr⁻¹ * B) - A / B
              = (-1)^n / (B * (ifp.fr⁻¹ * B + pB)), by rwa g_finite_correctness,
@@ -474,12 +477,12 @@ begin
 end
 
 /-- Shows that `|v - Aₙ / Bₙ| ≤ 1 / (Bₙ * Bₙ₊₁)` -/
-theorem abs_sub_convergents_le (not_terminated_at_n : ¬(gcf.of v).terminated_at n) :
-    |v - (gcf.of v).convergents n|
-  ≤ 1 / (((gcf.of v).denominators n) * ((gcf.of v).denominators $ n + 1)) :=
+theorem abs_sub_convergents_le (not_terminated_at_n : ¬(of v).terminated_at n) :
+    |v - (of v).convergents n|
+  ≤ 1 / (((of v).denominators n) * ((of v).denominators $ n + 1)) :=
 begin
   -- shorthand notation
-  let g := gcf.of v,
+  let g := of v,
   let nextConts := g.continuants_aux (n + 2),
   set conts := continuants_aux g (n + 1) with conts_eq,
   set pred_conts := continuants_aux g n with pred_conts_eq,
@@ -570,11 +573,11 @@ Shows that `|v - Aₙ / Bₙ| ≤ 1 / (bₙ * Bₙ * Bₙ)`. This bound is worse
 `gcf.abs_sub_convergents_le`, but sometimes it is easier to apply and sufficient for one's use case.
  -/
 lemma abs_sub_convergents_le' {b : K}
-  (nth_part_denom_eq : (gcf.of v).partial_denominators.nth n = some b) :
-    |v - (gcf.of v).convergents n|
-  ≤ 1 / (b * ((gcf.of v).denominators n) * ((gcf.of v).denominators n)) :=
+  (nth_part_denom_eq : (of v).partial_denominators.nth n = some b) :
+    |v - (of v).convergents n|
+  ≤ 1 / (b * ((of v).denominators n) * ((of v).denominators n)) :=
 begin
-  let g := gcf.of v,
+  let g := of v,
   let B := g.denominators n,
   let nB := g.denominators (n + 1),
   have not_terminated_at_n : ¬g.terminated_at n, by

--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -61,7 +61,6 @@ numerics, number theory, approximations, fractions
 -/
 
 namespace generalized_continued_fraction
-open generalized_continued_fraction as gcf
 
 -- Fix a carrier `K`.
 variable (K : Type*)
@@ -170,7 +169,8 @@ process stops when the fractional part `v - ⌊v⌋` hits 0 at some step.
 The implementation uses `int_fract_pair.stream` to obtain the partial denominators of the continued
 fraction. Refer to said function for more details about the computation process.
 -/
-protected def of [linear_ordered_field K] [floor_ring K] (v : K) : gcf K :=
+protected def of [linear_ordered_field K] [floor_ring K] (v : K) :
+  generalized_continued_fraction K :=
 let ⟨h, s⟩ := int_fract_pair.seq1 v in -- get the sequence of integer and fractional parts.
 ⟨ h.b, -- the head is just the first integer part
   s.map (λ p, ⟨1, p.b⟩) ⟩ -- the sequence consists of the remaining integer parts as the partial

--- a/src/algebra/continued_fractions/computation/correctness_terminating.lean
+++ b/src/algebra/continued_fractions/computation/correctness_terminating.lean
@@ -74,6 +74,9 @@ protected lemma comp_exact_value_correctness_of_stream_eq_some_aux_comp {a : K} 
   ((⌊a⌋ : K) * b + c) / (int.fract a) + b = (b * a + c) / int.fract a :=
 by { field_simp [fract_a_ne_zero], rw int.fract, ring }
 
+open generalized_continued_fraction
+  (comp_exact_value comp_exact_value_correctness_of_stream_eq_some_aux_comp)
+
 /--
 Shows the correctness of `comp_exact_value` in case the continued fraction
 `generalized_continued_fraction.of v` did not terminate at position `n`. That is, we obtain the

--- a/src/algebra/continued_fractions/computation/correctness_terminating.lean
+++ b/src/algebra/continued_fractions/computation/correctness_terminating.lean
@@ -44,7 +44,7 @@ information about the computation process, refer to `algebra.continued_fraction.
 -/
 
 namespace generalized_continued_fraction
-open generalized_continued_fraction as gcf
+open generalized_continued_fraction (of)
 
 variables {K : Type*} [linear_ordered_field K] {v : K} {n : ℕ}
 
@@ -58,7 +58,8 @@ This function can be used to compute the exact value approxmated by a continued 
 `generalized_continued_fraction.of v` as described in lemma
 `comp_exact_value_correctness_of_stream_eq_some`.
 -/
-protected def comp_exact_value (pconts conts : gcf.pair K) (fr : K) : K :=
+protected def comp_exact_value
+  (pconts conts : pair K) (fr : K) : K :=
 -- if the fractional part is zero, we exactly approximated the value by the last continuants
 if fr = 0 then conts.a / conts.b
 -- otherwise, we have to include the fractional part in a final continuants step.
@@ -72,8 +73,6 @@ protected lemma comp_exact_value_correctness_of_stream_eq_some_aux_comp {a : K} 
   (fract_a_ne_zero : int.fract a ≠ 0) :
   ((⌊a⌋ : K) * b + c) / (int.fract a) + b = (b * a + c) / int.fract a :=
 by { field_simp [fract_a_ne_zero], rw int.fract, ring }
-
-open generalized_continued_fraction as gcf
 
 /--
 Shows the correctness of `comp_exact_value` in case the continued fraction
@@ -93,12 +92,9 @@ corresponds exactly to the one using the recurrence equation in `comp_exact_valu
 -/
 lemma comp_exact_value_correctness_of_stream_eq_some :
   ∀ {ifp_n : int_fract_pair K}, int_fract_pair.stream v n = some ifp_n →
-    v = gcf.comp_exact_value
-          ((gcf.of v).continuants_aux  n)
-          ((gcf.of v).continuants_aux $ n + 1)
-          ifp_n.fr :=
+    v = comp_exact_value ((of v).continuants_aux  n) ((of v).continuants_aux $ n + 1) ifp_n.fr :=
 begin
-  let g := gcf.of v,
+  let g := of v,
   induction n with n IH,
   { assume ifp_zero stream_zero_eq, -- nat.zero
     have : int_fract_pair.of v = ifp_zero, by
@@ -107,13 +103,14 @@ begin
     cases this,
     cases decidable.em (int.fract v = 0) with fract_eq_zero fract_ne_zero,
     -- int.fract v = 0; we must then have `v = ⌊v⌋`
-    { suffices : v = ⌊v⌋, by simpa [continuants_aux, fract_eq_zero, gcf.comp_exact_value],
+    { suffices : v = ⌊v⌋,
+        by simpa [continuants_aux, fract_eq_zero, comp_exact_value],
       calc
           v = int.fract v + ⌊v⌋ : by rw int.fract_add_floor
         ... = ⌊v⌋           : by simp [fract_eq_zero] },
     -- int.fract v ≠ 0; the claim then easily follows by unfolding a single computation step
     { field_simp [continuants_aux, next_continuants, next_numerator, next_denominator,
-        gcf.of_h_eq_floor, gcf.comp_exact_value, fract_ne_zero] } },
+        of_h_eq_floor, comp_exact_value, fract_ne_zero] } },
   { assume ifp_succ_n succ_nth_stream_eq,  -- nat.succ
     obtain ⟨ifp_n, nth_stream_eq, nth_fract_ne_zero, -⟩ :
       ∃ ifp_n, int_fract_pair.stream v n = some ifp_n ∧ ifp_n.fr ≠ 0
@@ -126,7 +123,7 @@ begin
     cases decidable.em (ifp_succ_n.fr = 0) with ifp_succ_n_fr_eq_zero ifp_succ_n_fr_ne_zero,
     -- ifp_succ_n.fr = 0
     { suffices : v = conts.a / conts.b, by
-        simpa [gcf.comp_exact_value, ifp_succ_n_fr_eq_zero],
+        simpa [comp_exact_value, ifp_succ_n_fr_eq_zero],
       -- use the IH and the fact that ifp_n.fr⁻¹ = ⌊ifp_n.fr⁻¹⌋ to prove this case
       obtain ⟨ifp_n', nth_stream_eq', ifp_n_fract_inv_eq_floor⟩ :
         ∃ ifp_n, int_fract_pair.stream v n = some ifp_n ∧ ifp_n.fr⁻¹ = ⌊ifp_n.fr⁻¹⌋, from
@@ -134,16 +131,17 @@ begin
       have : ifp_n' = ifp_n, by injection (eq.trans (nth_stream_eq').symm nth_stream_eq),
       cases this,
       have s_nth_eq : g.s.nth n = some ⟨1, ⌊ifp_n.fr⁻¹⌋⟩, from
-        gcf.nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero nth_stream_eq nth_fract_ne_zero,
+        nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero nth_stream_eq nth_fract_ne_zero,
       rw [←ifp_n_fract_inv_eq_floor] at s_nth_eq,
-      suffices : v = gcf.comp_exact_value ppconts pconts ifp_n.fr, by
-        simpa [conts, continuants_aux, s_nth_eq,gcf.comp_exact_value, nth_fract_ne_zero] using this,
+      suffices : v = comp_exact_value ppconts pconts ifp_n.fr, by
+        simpa [conts, continuants_aux, s_nth_eq, comp_exact_value, nth_fract_ne_zero] using this,
       exact (IH nth_stream_eq) },
     -- ifp_succ_n.fr ≠ 0
     { -- use the IH to show that the following equality suffices
-      suffices : gcf.comp_exact_value ppconts pconts ifp_n.fr
-               = gcf.comp_exact_value pconts conts ifp_succ_n.fr, by
-      { have : v = gcf.comp_exact_value ppconts pconts ifp_n.fr, from IH nth_stream_eq,
+      suffices : comp_exact_value ppconts pconts ifp_n.fr =
+        comp_exact_value pconts conts ifp_succ_n.fr, by
+      { have : v = comp_exact_value ppconts pconts ifp_n.fr,
+        from IH nth_stream_eq,
         conv_lhs { rw this }, assumption },
       -- get the correspondence between ifp_n and ifp_succ_n
       obtain ⟨ifp_n', nth_stream_eq', ifp_n_fract_ne_zero, ⟨refl⟩⟩ :
@@ -153,44 +151,45 @@ begin
       have : ifp_n' = ifp_n, by injection (eq.trans (nth_stream_eq').symm nth_stream_eq),
       cases this,
       -- get the correspondence between ifp_n and g.s.nth n
-      have s_nth_eq : g.s.nth n = some ⟨1, (⌊ifp_n.fr⁻¹⌋ : K)⟩,
-        from gcf.nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero nth_stream_eq
-          ifp_n_fract_ne_zero,
+      have s_nth_eq : g.s.nth n = some ⟨1, (⌊ifp_n.fr⁻¹⌋ : K)⟩, from
+        nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero nth_stream_eq ifp_n_fract_ne_zero,
       -- the claim now follows by unfolding the definitions and tedious calculations
       -- some shorthand notation
       let ppA := ppconts.a, let ppB := ppconts.b,
       let pA := pconts.a, let pB := pconts.b,
-      have : gcf.comp_exact_value ppconts pconts ifp_n.fr
+      have : comp_exact_value ppconts pconts ifp_n.fr
           = (ppA + ifp_n.fr⁻¹ * pA) / (ppB + ifp_n.fr⁻¹ * pB), by
         -- unfold comp_exact_value and the convergent computation once
-        { field_simp [ifp_n_fract_ne_zero, gcf.comp_exact_value, next_continuants, next_numerator,
-          next_denominator], ac_refl },
+        { field_simp [ifp_n_fract_ne_zero, comp_exact_value,
+            next_continuants, next_numerator, next_denominator], ac_refl },
       rw this,
       -- two calculations needed to show the claim
-      have tmp_calc := gcf.comp_exact_value_correctness_of_stream_eq_some_aux_comp
-        pA ppA ifp_succ_n_fr_ne_zero,
-      have tmp_calc' := gcf.comp_exact_value_correctness_of_stream_eq_some_aux_comp
-        pB ppB ifp_succ_n_fr_ne_zero,
+      have tmp_calc :=
+        comp_exact_value_correctness_of_stream_eq_some_aux_comp pA ppA ifp_succ_n_fr_ne_zero,
+      have tmp_calc' :=
+        comp_exact_value_correctness_of_stream_eq_some_aux_comp pB ppB ifp_succ_n_fr_ne_zero,
       rw inv_eq_one_div at tmp_calc tmp_calc',
       have : int.fract (1 / ifp_n.fr) ≠ 0, by simpa using ifp_succ_n_fr_ne_zero,
       -- now unfold the recurrence one step and simplify both sides to arrive at the conclusion
-      field_simp [conts, gcf.comp_exact_value,
-        (gcf.continuants_aux_recurrence s_nth_eq ppconts_eq pconts_eq), next_continuants,
+      field_simp [conts, comp_exact_value,
+        (continuants_aux_recurrence s_nth_eq ppconts_eq pconts_eq), next_continuants,
         next_numerator, next_denominator, this, tmp_calc, tmp_calc'],
       ac_refl } }
 end
+
+open generalized_continued_fraction (of_terminated_at_n_iff_succ_nth_int_fract_pair_stream_eq_none)
 
 /-- The convergent of `generalized_continued_fraction.of v` at step `n - 1` is exactly `v` if the
 `int_fract_pair.stream` of the corresponding continued fraction terminated at step `n`. -/
 lemma of_correctness_of_nth_stream_eq_none
   (nth_stream_eq_none : int_fract_pair.stream v n = none) :
-  v = (gcf.of v).convergents (n - 1) :=
+  v = (of v).convergents (n - 1) :=
 begin
   induction n with n IH,
   case nat.zero { contradiction }, -- int_fract_pair.stream v 0 ≠ none
   case nat.succ
   { rename nth_stream_eq_none succ_nth_stream_eq_none,
-    let g := gcf.of v,
+    let g := of v,
     change v = g.convergents n,
     have : int_fract_pair.stream v n = none
       ∨ ∃ ifp, int_fract_pair.stream v n = some ifp ∧ ifp.fr = 0, from
@@ -199,13 +198,13 @@ begin
     { cases n with n',
       { contradiction }, -- int_fract_pair.stream v 0 ≠ none
       { have : g.terminated_at n', from
-          gcf.of_terminated_at_n_iff_succ_nth_int_fract_pair_stream_eq_none.elim_right
-          nth_stream_eq_none,
+          of_terminated_at_n_iff_succ_nth_int_fract_pair_stream_eq_none.elim_right
+            nth_stream_eq_none,
         have : g.convergents (n' + 1) = g.convergents n', from
-          gcf.convergents_stable_of_terminated n'.le_succ this,
+          convergents_stable_of_terminated n'.le_succ this,
         rw this,
         exact (IH nth_stream_eq_none) } },
-    { simpa [nth_stream_fr_eq_zero, gcf.comp_exact_value] using
+    { simpa [nth_stream_fr_eq_zero, comp_exact_value] using
       (comp_exact_value_correctness_of_stream_eq_some nth_stream_eq) } }
 end
 
@@ -213,18 +212,18 @@ end
 If `generalized_continued_fraction.of v` terminated at step `n`, then the `n`th convergent is
 exactly `v`.
 -/
-theorem of_correctness_of_terminated_at (terminated_at_n : (gcf.of v).terminated_at n) :
-  v = (gcf.of v).convergents n :=
+theorem of_correctness_of_terminated_at (terminated_at_n : (of v).terminated_at n) :
+  v = (of v).convergents n :=
 have int_fract_pair.stream v (n + 1) = none, from
-  gcf.of_terminated_at_n_iff_succ_nth_int_fract_pair_stream_eq_none.elim_left terminated_at_n,
- of_correctness_of_nth_stream_eq_none this
+  of_terminated_at_n_iff_succ_nth_int_fract_pair_stream_eq_none.elim_left terminated_at_n,
+of_correctness_of_nth_stream_eq_none this
 
 /--
 If `generalized_continued_fraction.of v` terminates, then there is `n : ℕ` such that the `n`th
 convergent is exactly `v`.
 -/
-lemma of_correctness_of_terminates (terminates : (gcf.of v).terminates) :
-  ∃ (n : ℕ), v = (gcf.of v).convergents n :=
+lemma of_correctness_of_terminates (terminates : (of v).terminates) :
+  ∃ (n : ℕ), v = (of v).convergents n :=
 exists.elim terminates
 ( assume n terminated_at_n,
   exists.intro n (of_correctness_of_terminated_at terminated_at_n) )
@@ -235,14 +234,15 @@ open filter
 If `generalized_continued_fraction.of v` terminates, then its convergents will eventually always
 be `v`.
 -/
-lemma of_correctness_at_top_of_terminates (terminates : (gcf.of v).terminates) :
-  ∀ᶠ n in at_top, v = (gcf.of v).convergents n :=
+lemma of_correctness_at_top_of_terminates (terminates : (of v).terminates) :
+  ∀ᶠ n in at_top, v = (of v).convergents n :=
 begin
   rw eventually_at_top,
-  obtain ⟨n, terminated_at_n⟩ : ∃ n, (gcf.of v).terminated_at n, from terminates,
+  obtain ⟨n, terminated_at_n⟩ : ∃ n, (of v).terminated_at n,
+    from terminates,
   use n,
   assume m m_geq_n,
-  rw (gcf.convergents_stable_of_terminated m_geq_n terminated_at_n),
+  rw (convergents_stable_of_terminated m_geq_n terminated_at_n),
   exact of_correctness_of_terminated_at terminated_at_n
 end
 

--- a/src/algebra/continued_fractions/computation/terminates_iff_rat.lean
+++ b/src/algebra/continued_fractions/computation/terminates_iff_rat.lean
@@ -28,7 +28,8 @@ rational, continued fraction, termination
 -/
 
 namespace generalized_continued_fraction
-open generalized_continued_fraction as gcf
+
+open generalized_continued_fraction (of)
 
 variables {K : Type*} [linear_ordered_field K] [floor_ring K]
 
@@ -36,7 +37,7 @@ variables {K : Type*} [linear_ordered_field K] [floor_ring K]
 We will have to constantly coerce along our structures in the following proofs using their provided
 map functions.
 -/
-local attribute [simp] gcf.pair.map gcf.int_fract_pair.mapFr
+local attribute [simp] pair.map int_fract_pair.mapFr
 
 section rat_of_terminates
 /-!
@@ -53,21 +54,22 @@ show that `v = ↑q`.
 variables (v : K) (n : ℕ)
 
 lemma exists_gcf_pair_rat_eq_of_nth_conts_aux :
-  ∃ (conts : gcf.pair ℚ), (gcf.of v).continuants_aux n = (conts.map coe : gcf.pair K) :=
+  ∃ (conts : pair ℚ),
+    (of v).continuants_aux n = (conts.map coe : pair K) :=
 nat.strong_induction_on n
 begin
   clear n,
-  let g := gcf.of v,
+  let g := of v,
   assume n IH,
   rcases n with _|_|n,
   -- n = 0
-  { suffices : ∃ (gp : gcf.pair ℚ), gcf.pair.mk (1 : K) 0 = gp.map coe, by simpa [continuants_aux],
-    use (gcf.pair.mk 1 0),
+  { suffices : ∃ (gp : pair ℚ), pair.mk (1 : K) 0 = gp.map coe, by simpa [continuants_aux],
+    use (pair.mk 1 0),
     simp },
   -- n = 1
-  { suffices : ∃ (conts : gcf.pair ℚ), gcf.pair.mk g.h 1 = conts.map coe, by
+  { suffices : ∃ (conts : pair ℚ), pair.mk g.h 1 = conts.map coe, by
       simpa [continuants_aux],
-    use (gcf.pair.mk ⌊v⌋ 1),
+    use (pair.mk ⌊v⌋ 1),
     simp },
   -- 2 ≤ n
   { cases (IH (n + 1) $ lt_add_one (n + 1)) with pred_conts pred_conts_eq, -- invoke the IH
@@ -92,17 +94,17 @@ begin
 end
 
 lemma exists_gcf_pair_rat_eq_nth_conts :
-  ∃ (conts : gcf.pair ℚ), (gcf.of v).continuants n = (conts.map coe : gcf.pair K) :=
+  ∃ (conts : pair ℚ), (of v).continuants n = (conts.map coe : pair K) :=
 by { rw [nth_cont_eq_succ_nth_cont_aux], exact (exists_gcf_pair_rat_eq_of_nth_conts_aux v $ n + 1) }
 
-lemma exists_rat_eq_nth_numerator : ∃ (q : ℚ), (gcf.of v).numerators n = (q : K) :=
+lemma exists_rat_eq_nth_numerator : ∃ (q : ℚ), (of v).numerators n = (q : K) :=
 begin
   rcases (exists_gcf_pair_rat_eq_nth_conts v n) with ⟨⟨a, _⟩, nth_cont_eq⟩,
   use a,
   simp [num_eq_conts_a, nth_cont_eq],
 end
 
-lemma exists_rat_eq_nth_denominator : ∃ (q : ℚ), (gcf.of v).denominators n = (q : K) :=
+lemma exists_rat_eq_nth_denominator : ∃ (q : ℚ), (of v).denominators n = (q : K) :=
 begin
   rcases (exists_gcf_pair_rat_eq_nth_conts v n) with ⟨⟨_, b⟩, nth_cont_eq⟩,
   use b,
@@ -110,7 +112,7 @@ begin
 end
 
 /-- Every finite convergent corresponds to a rational number. -/
-lemma exists_rat_eq_nth_convergent : ∃ (q : ℚ), (gcf.of v).convergents n = (q : K) :=
+lemma exists_rat_eq_nth_convergent : ∃ (q : ℚ), (of v).convergents n = (q : K) :=
 begin
   rcases (exists_rat_eq_nth_numerator v n) with ⟨Aₙ, nth_num_eq⟩,
   rcases (exists_rat_eq_nth_denominator v n) with ⟨Bₙ, nth_denom_eq⟩,
@@ -121,12 +123,14 @@ end
 variable {v}
 
 /-- Every terminating continued fraction corresponds to a rational number. -/
-theorem exists_rat_eq_of_terminates (terminates : (gcf.of v).terminates) : ∃ (q : ℚ), v = ↑q :=
+theorem exists_rat_eq_of_terminates
+  (terminates : (of v).terminates) :
+  ∃ (q : ℚ), v = ↑q :=
 begin
-  obtain ⟨n, v_eq_conv⟩ : ∃ n, v = (gcf.of v).convergents n, from
+  obtain ⟨n, v_eq_conv⟩ : ∃ n, v = (of v).convergents n, from
     of_correctness_of_terminates terminates,
-  obtain ⟨q, conv_eq_q⟩ : ∃ (q : ℚ), (gcf.of v).convergents n = (↑q : K), from
-    exists_rat_eq_nth_convergent v n,
+  obtain ⟨q, conv_eq_q⟩ :
+    ∃ (q : ℚ), (of v).convergents n = (↑q : K), from exists_rat_eq_nth_convergent v n,
   have : v = (↑q : K), from eq.trans v_eq_conv conv_eq_q,
   use [q, this]
 end
@@ -196,45 +200,45 @@ end int_fract_pair
 
 /-! Now we lift the coercion results to the continued fraction computation. -/
 
-lemma coe_of_h_rat_eq : (↑((gcf.of q).h : ℚ) : K) = (gcf.of v).h :=
+lemma coe_of_h_rat_eq : (↑((of q).h : ℚ) : K) = (of v).h :=
 begin
-  unfold gcf.of int_fract_pair.seq1,
+  unfold of int_fract_pair.seq1,
   rw ←(int_fract_pair.coe_of_rat_eq v_eq_q),
   simp
 end
 
 lemma coe_of_s_nth_rat_eq :
-  (((gcf.of q).s.nth n).map (gcf.pair.map coe) : option $ gcf.pair K) = (gcf.of v).s.nth n :=
+  (((of q).s.nth n).map (pair.map coe) : option $ pair K) = (of v).s.nth n :=
 begin
-  simp only [gcf.of, gcf.int_fract_pair.seq1, seq.map_nth, seq.nth_tail],
+  simp only [of, int_fract_pair.seq1, seq.map_nth, seq.nth_tail],
   simp only [seq.nth],
   rw [←(int_fract_pair.coe_stream_rat_eq v_eq_q)],
   rcases succ_nth_stream_eq : (int_fract_pair.stream q (n + 1)) with _ | ⟨_, _⟩;
   simp [stream.map, stream.nth, succ_nth_stream_eq]
 end
 
-lemma coe_of_s_rat_eq :
-  (((gcf.of q).s).map (gcf.pair.map coe) : seq $ gcf.pair K) = (gcf.of v).s :=
+lemma coe_of_s_rat_eq : (((of q).s).map (pair.map coe) : seq $ pair K) = (of v).s :=
 by { ext n, rw ←(coe_of_s_nth_rat_eq v_eq_q), refl }
 
 /-- Given `(v : K), (q : ℚ), and v = q`, we have that `gcf.of q = gcf.of v` -/
-lemma coe_of_rat_eq : (⟨(gcf.of q).h, (gcf.of q).s.map (gcf.pair.map coe)⟩ : gcf K) = gcf.of v :=
+lemma coe_of_rat_eq :
+  (⟨(of q).h, (of q).s.map (pair.map coe)⟩ : generalized_continued_fraction K) = of v :=
 begin
-  cases gcf_v_eq : (gcf.of v) with h s,
+  cases gcf_v_eq : (of v) with h s,
   have : ↑⌊↑q⌋ = h, by { rw v_eq_q at gcf_v_eq, injection gcf_v_eq },
   simp [(coe_of_h_rat_eq v_eq_q), (coe_of_s_rat_eq v_eq_q), gcf_v_eq],
   rwa [←(@rat.cast_floor K _ _ q), floor_ring_unique]
 end
 
 lemma of_terminates_iff_of_rat_terminates {v : K} {q : ℚ} (v_eq_q : v = (q : K)) :
-  (gcf.of v).terminates ↔ (gcf.of q).terminates :=
+  (of v).terminates ↔ (of q).terminates :=
 begin
   split;
   intro h;
   cases h with n h;
   use n;
   simp only [seq.terminated_at, (coe_of_s_nth_rat_eq v_eq_q n).symm] at h ⊢;
-  cases ((gcf.of q).s.nth n);
+  cases ((of q).s.nth n);
   trivial
 end
 
@@ -326,7 +330,7 @@ end int_fract_pair
 
 
 /-- The continued fraction of a rational number terminates. -/
-theorem terminates_of_rat (q : ℚ) : (gcf.of q).terminates :=
+theorem terminates_of_rat (q : ℚ) : (of q).terminates :=
 exists.elim (int_fract_pair.exists_nth_stream_eq_none_of_rat q)
 ( assume n stream_nth_eq_none,
   exists.intro n
@@ -340,16 +344,15 @@ end terminates_of_rat
 /--
 The continued fraction `generalized_continued_fraction.of v` terminates if and only if `v ∈ ℚ`.
 -/
-theorem terminates_iff_rat (v : K) :
-  (gcf.of v).terminates ↔ ∃ (q : ℚ), v = (q : K) :=
+theorem terminates_iff_rat (v : K) : (of v).terminates ↔ ∃ (q : ℚ), v = (q : K) :=
 iff.intro
-( assume terminates_v : (gcf.of v).terminates,
+( assume terminates_v : (of v).terminates,
   show ∃ (q : ℚ), v = (q : K), from exists_rat_eq_of_terminates terminates_v )
 ( assume exists_q_eq_v : ∃ (q : ℚ), v = (↑q : K),
   exists.elim exists_q_eq_v
   ( assume q,
     assume v_eq_q : v = ↑q,
-    have (gcf.of q).terminates, from terminates_of_rat q,
+    have (of q).terminates, from terminates_of_rat q,
     (of_terminates_iff_of_rat_terminates v_eq_q).elim_right this ) )
 
 end generalized_continued_fraction

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -37,7 +37,7 @@ of three sections:
 -/
 
 namespace generalized_continued_fraction
-open generalized_continued_fraction as gcf
+open generalized_continued_fraction (of)
 
 /- Fix a discrete linear ordered floor field and a value `v`. -/
 variables {K : Type*} [linear_ordered_field K] [floor_ring K] {v : K}
@@ -147,12 +147,12 @@ process.
 @[simp]
 lemma int_fract_pair.seq1_fst_eq_of : (int_fract_pair.seq1 v).fst = int_fract_pair.of v := rfl
 
-lemma of_h_eq_int_fract_pair_seq1_fst_b : (gcf.of v).h = (int_fract_pair.seq1 v).fst.b :=
-by { cases aux_seq_eq : (int_fract_pair.seq1 v), simp [gcf.of, aux_seq_eq] }
+lemma of_h_eq_int_fract_pair_seq1_fst_b : (of v).h = (int_fract_pair.seq1 v).fst.b :=
+by { cases aux_seq_eq : (int_fract_pair.seq1 v), simp [of, aux_seq_eq] }
 
 /-- The head term of the gcf of `v` is `⌊v⌋`. -/
 @[simp]
-lemma of_h_eq_floor : (gcf.of v).h = ⌊v⌋ :=
+lemma of_h_eq_floor : (of v).h = ⌊v⌋ :=
 by simp [of_h_eq_int_fract_pair_seq1_fst_b, int_fract_pair.of]
 
 end head
@@ -180,16 +180,16 @@ Let's first show how the termination of one sequence implies the termination of 
 -/
 
 lemma of_terminated_at_iff_int_fract_pair_seq1_terminated_at :
-  (gcf.of v).terminated_at n ↔ (int_fract_pair.seq1 v).snd.terminated_at n :=
+  (of v).terminated_at n ↔ (int_fract_pair.seq1 v).snd.terminated_at n :=
 begin
-  rw [gcf.terminated_at_iff_s_none, gcf.of],
+  rw [terminated_at_iff_s_none, of],
   rcases (int_fract_pair.seq1 v) with ⟨head, ⟨st⟩⟩,
   cases st_n_eq : st n;
-  simp [gcf.of, st_n_eq, seq.map, seq.nth, stream.map, seq.terminated_at, stream.nth]
+  simp [of, st_n_eq, seq.map, seq.nth, stream.map, seq.terminated_at, stream.nth]
 end
 
 lemma of_terminated_at_n_iff_succ_nth_int_fract_pair_stream_eq_none :
-  (gcf.of v).terminated_at n ↔ int_fract_pair.stream v (n + 1) = none :=
+  (of v).terminated_at n ↔ int_fract_pair.stream v (n + 1) = none :=
 by rw [of_terminated_at_iff_int_fract_pair_seq1_terminated_at, seq.terminated_at,
   int_fract_pair.nth_seq1_eq_succ_nth_stream]
 
@@ -202,13 +202,13 @@ section values
 Now let's show how the values of the sequences correspond to one another.
 -/
 
-lemma int_fract_pair.exists_succ_nth_stream_of_gcf_of_nth_eq_some {gp_n : gcf.pair K}
-  (s_nth_eq : (gcf.of v).s.nth n = some gp_n) :
+lemma int_fract_pair.exists_succ_nth_stream_of_gcf_of_nth_eq_some {gp_n : pair K}
+  (s_nth_eq : (of v).s.nth n = some gp_n) :
   ∃ (ifp : int_fract_pair K), int_fract_pair.stream v (n + 1) = some ifp ∧ (ifp.b : K) = gp_n.b :=
 begin
   obtain ⟨ifp, stream_succ_nth_eq, gp_n_eq⟩ :
-    ∃ ifp, int_fract_pair.stream v (n + 1) = some ifp ∧ gcf.pair.mk 1 (ifp.b : K) = gp_n, by
-    { unfold gcf.of int_fract_pair.seq1 at s_nth_eq,
+    ∃ ifp, int_fract_pair.stream v (n + 1) = some ifp ∧ pair.mk 1 (ifp.b : K) = gp_n, by
+    { unfold of int_fract_pair.seq1 at s_nth_eq,
       rwa [seq.map_tail, seq.nth_tail, seq.map_nth, option.map_eq_some'] at s_nth_eq },
   cases gp_n_eq,
   injection gp_n_eq with _ ifp_b_eq_gp_n_b,
@@ -222,9 +222,9 @@ integer parts of the stream of integer and fractional parts.
 -/
 lemma nth_of_eq_some_of_succ_nth_int_fract_pair_stream {ifp_succ_n : int_fract_pair K}
   (stream_succ_nth_eq : int_fract_pair.stream v (n + 1) = some ifp_succ_n) :
-  (gcf.of v).s.nth n = some ⟨1, ifp_succ_n.b⟩ :=
+  (of v).s.nth n = some ⟨1, ifp_succ_n.b⟩ :=
 begin
-  unfold gcf.of int_fract_pair.seq1,
+  unfold of int_fract_pair.seq1,
   rw [seq.map_tail, seq.nth_tail, seq.map_nth],
   simp [seq.nth, stream_succ_nth_eq]
 end
@@ -235,7 +235,7 @@ fractional parts of the stream of integer and fractional parts.
 -/
 lemma nth_of_eq_some_of_nth_int_fract_pair_stream_fr_ne_zero {ifp_n : int_fract_pair K}
   (stream_nth_eq : int_fract_pair.stream v n = some ifp_n) (nth_fr_ne_zero : ifp_n.fr ≠ 0) :
-  (gcf.of v).s.nth n = some ⟨1, (int_fract_pair.of ifp_n.fr⁻¹).b⟩ :=
+  (of v).s.nth n = some ⟨1, (int_fract_pair.of ifp_n.fr⁻¹).b⟩ :=
 have int_fract_pair.stream v (n + 1) = some (int_fract_pair.of ifp_n.fr⁻¹), by
   { cases ifp_n, simp [int_fract_pair.stream, stream_nth_eq, nth_fr_ne_zero], refl },
 nth_of_eq_some_of_succ_nth_int_fract_pair_stream this

--- a/src/algebra/continued_fractions/continuants_recurrence.lean
+++ b/src/algebra/continued_fractions/continuants_recurrence.lean
@@ -16,16 +16,18 @@ function indeed satisfies the following recurrences:
 -/
 
 namespace generalized_continued_fraction
-open generalized_continued_fraction as gcf
-variables {K : Type*} {g : gcf K} {n : ℕ} [division_ring K]
 
-lemma continuants_aux_recurrence {gp ppred pred : gcf.pair K} (nth_s_eq : g.s.nth n = some gp)
+variables {K : Type*} {g : generalized_continued_fraction K} {n : ℕ} [division_ring K]
+
+lemma continuants_aux_recurrence
+  {gp ppred pred : pair K} (nth_s_eq : g.s.nth n = some gp)
   (nth_conts_aux_eq : g.continuants_aux n = ppred)
   (succ_nth_conts_aux_eq : g.continuants_aux (n + 1) = pred) :
   g.continuants_aux (n + 2) = ⟨gp.b * pred.a + gp.a * ppred.a, gp.b * pred.b + gp.a * ppred.b⟩ :=
 by simp [*, continuants_aux, next_continuants, next_denominator, next_numerator]
 
-lemma continuants_recurrence_aux {gp ppred pred : gcf.pair K} (nth_s_eq : g.s.nth n = some gp)
+lemma continuants_recurrence_aux
+  {gp ppred pred : pair K} (nth_s_eq : g.s.nth n = some gp)
   (nth_conts_aux_eq : g.continuants_aux n = ppred)
   (succ_nth_conts_aux_eq : g.continuants_aux (n + 1) = pred) :
   g.continuants (n + 1) = ⟨gp.b * pred.a + gp.a * ppred.a, gp.b * pred.b + gp.a * ppred.b⟩ :=
@@ -33,7 +35,8 @@ by simp [nth_cont_eq_succ_nth_cont_aux,
   (continuants_aux_recurrence nth_s_eq nth_conts_aux_eq succ_nth_conts_aux_eq)]
 
 /-- Shows that `Aₙ = bₙ * Aₙ₋₁ + aₙ * Aₙ₋₂` and `Bₙ = bₙ * Bₙ₋₁ + aₙ * Bₙ₋₂`. -/
-theorem continuants_recurrence {gp ppred pred : gcf.pair K}
+theorem continuants_recurrence
+  {gp ppred pred : pair K}
   (succ_nth_s_eq : g.s.nth (n + 1) = some gp)
   (nth_conts_eq : g.continuants n = ppred)
   (succ_nth_conts_eq : g.continuants (n + 1) = pred) :
@@ -44,7 +47,7 @@ begin
 end
 
 /-- Shows that `Aₙ = bₙ * Aₙ₋₁ + aₙ * Aₙ₋₂`. -/
-lemma numerators_recurrence {gp : gcf.pair K} {ppredA predA : K}
+lemma numerators_recurrence {gp : pair K} {ppredA predA : K}
   (succ_nth_s_eq : g.s.nth (n + 1) = some gp)
   (nth_num_eq : g.numerators n = ppredA)
   (succ_nth_num_eq : g.numerators (n + 1) = predA) :
@@ -59,7 +62,7 @@ begin
 end
 
 /-- Shows that `Bₙ = bₙ * Bₙ₋₁ + aₙ * Bₙ₋₂`. -/
-lemma denominators_recurrence {gp : gcf.pair K} {ppredB predB : K}
+lemma denominators_recurrence {gp : pair K} {ppredB predB : K}
   (succ_nth_s_eq : g.s.nth (n + 1) = some gp)
   (nth_denom_eq : g.denominators n = ppredB)
   (succ_nth_denom_eq : g.denominators (n + 1) = predB) :

--- a/src/algebra/continued_fractions/convergents_equiv.lean
+++ b/src/algebra/continued_fractions/convergents_equiv.lean
@@ -68,8 +68,8 @@ fractions, recurrence, equivalence
 
 variables {K : Type*} {n : ℕ}
 namespace generalized_continued_fraction
-open generalized_continued_fraction as gcf
-variables {g : gcf K} {s : seq $ gcf.pair K}
+
+variables {g : generalized_continued_fraction K} {s : seq $ pair K}
 
 section squash
 /-!
@@ -87,7 +87,7 @@ combines `⟨aₙ, bₙ⟩` and `⟨aₙ₊₁, bₙ₊₁⟩` at position `n` t
 `squash_seq s 0 = [(a₀, bₒ + a₁ / b₁), (a₁, b₁),...]`.
 If `s.terminated_at (n + 1)`, then `squash_seq s n = s`.
 -/
-def squash_seq (s : seq $ gcf.pair K) (n : ℕ) : seq (gcf.pair K) :=
+def squash_seq (s : seq $ pair K) (n : ℕ) : seq (pair K) :=
 match prod.mk (s.nth n) (s.nth (n + 1)) with
 | ⟨some gp_n, some gp_succ_n⟩ := seq.nats.zip_with
     -- return the squashed value at position `n`; otherwise, do nothing.
@@ -108,7 +108,7 @@ end
 
 /-- If the sequence has not terminated before position `n + 1`, the value at `n + 1` gets
 squashed into position `n`. -/
-lemma squash_seq_nth_of_not_terminated {gp_n gp_succ_n : gcf.pair K}
+lemma squash_seq_nth_of_not_terminated {gp_n gp_succ_n : pair K}
   (s_nth_eq : s.nth n = some gp_n) (s_succ_nth_eq : s.nth (n + 1) = some gp_succ_n) :
   (squash_seq s n).nth n = some ⟨gp_n.a, gp_n.b + gp_succ_n.a / gp_succ_n.b⟩ :=
 by simp [*, squash_seq, (seq.zip_with_nth_some (seq.nats_nth n) s_nth_eq _)]
@@ -194,7 +194,7 @@ Given a gcf `g = [h; (a₀, bₒ), (a₁, b₁), ...]`, we have
 - `squash_nth.gcf g 0 = [h + a₀ / b₀); (a₀, bₒ), ...]`,
 - `squash_nth.gcf g (n + 1) = ⟨g.h, squash_seq g.s n⟩`
 -/
-def squash_gcf (g : gcf K) : ℕ → gcf K
+def squash_gcf (g : generalized_continued_fraction K) : ℕ → generalized_continued_fraction K
 | 0 := match g.s.nth 0 with
   | none := g
   | some gp := ⟨g.h + gp.a / gp.b, g.s⟩
@@ -336,7 +336,7 @@ positivity criterion required here. The analogous result for them
 (see `continued_fractions.convergents_eq_convergents`) hence follows directly from this theorem.
 -/
 theorem convergents_eq_convergents' [linear_ordered_field K]
-  (s_pos : ∀ {gp : gcf.pair K} {m : ℕ}, m < n → g.s.nth m = some gp → 0 < gp.a ∧ 0 < gp.b) :
+  (s_pos : ∀ {gp : pair K} {m : ℕ}, m < n → g.s.nth m = some gp → 0 < gp.a ∧ 0 < gp.b) :
   g.convergents n = g.convergents' n :=
 begin
   induction n with n IH generalizing g,
@@ -386,20 +386,19 @@ end
 end generalized_continued_fraction
 
 namespace continued_fraction
-open generalized_continued_fraction as gcf
-open simple_continued_fraction as scf
-open continued_fraction as cf
 
 /-- Shows that the recurrence relation (`convergents`) and direct evaluation (`convergents'`) of a
 (regular) continued fraction coincide. -/
-theorem convergents_eq_convergents' [linear_ordered_field K] {c : cf K} :
-  (↑c : gcf K).convergents = (↑c : gcf K).convergents' :=
+theorem convergents_eq_convergents' [linear_ordered_field K] {c : continued_fraction K} :
+  (↑c : generalized_continued_fraction K).convergents =
+    (↑c : generalized_continued_fraction K).convergents' :=
 begin
   ext n,
-  apply gcf.convergents_eq_convergents',
+  apply convergents_eq_convergents',
   assume gp m m_lt_n s_nth_eq,
-  exact ⟨zero_lt_one.trans_le ((c : scf K).property m gp.a (gcf.part_num_eq_s_a s_nth_eq)).symm.le,
-    c.property m gp.b $ gcf.part_denom_eq_s_b s_nth_eq⟩
+  exact ⟨zero_lt_one.trans_le ((c : simple_continued_fraction K).property m gp.a
+      (part_num_eq_s_a s_nth_eq)).symm.le,
+    c.property m gp.b $ part_denom_eq_s_b s_nth_eq⟩
 end
 
 end continued_fraction

--- a/src/algebra/continued_fractions/convergents_equiv.lean
+++ b/src/algebra/continued_fractions/convergents_equiv.lean
@@ -385,6 +385,8 @@ end
 
 end generalized_continued_fraction
 
+open generalized_continued_fraction
+
 namespace continued_fraction
 
 /-- Shows that the recurrence relation (`convergents`) and direct evaluation (`convergents'`) of a

--- a/src/algebra/continued_fractions/terminated_stable.lean
+++ b/src/algebra/continued_fractions/terminated_stable.lean
@@ -13,8 +13,8 @@ We show that the continuants and convergents of a gcf stabilise once the gcf ter
 -/
 
 namespace generalized_continued_fraction
-open generalized_continued_fraction as gcf
-variables {K : Type*} {g : gcf K} {n m : ℕ}
+
+variables {K : Type*} {g : generalized_continued_fraction K} {n m : ℕ}
 
 /-- If a gcf terminated at position `n`, it also terminated at `m ≥ n`.-/
 lemma terminated_stable (n_le_m : n ≤ m) (terminated_at_n : g.terminated_at n) :
@@ -46,7 +46,7 @@ begin
     exact (eq.trans this IH) }
 end
 
-lemma convergents'_aux_stable_step_of_terminated {s : seq $ gcf.pair K}
+lemma convergents'_aux_stable_step_of_terminated {s : seq $ pair K}
   (terminated_at_n : s.terminated_at n) :
   convergents'_aux s (n + 1) = convergents'_aux s n :=
 begin
@@ -62,7 +62,8 @@ begin
       simp only [convergents'_aux, s_head_eq, (IH this)] } }
 end
 
-lemma convergents'_aux_stable_of_terminated {s : seq $ gcf.pair K} (n_le_m : n ≤ m)
+lemma convergents'_aux_stable_of_terminated
+  {s : seq $ pair K} (n_le_m : n ≤ m)
   (terminated_at_n : s.terminated_at n) :
   convergents'_aux s m = convergents'_aux s n :=
 begin

--- a/src/algebra/continued_fractions/translations.lean
+++ b/src/algebra/continued_fractions/translations.lean
@@ -14,7 +14,6 @@ Some simple translation lemmas between the different definitions of functions de
 -/
 
 namespace generalized_continued_fraction
-open generalized_continued_fraction as gcf
 
 section general
 /-!
@@ -24,7 +23,7 @@ Here we give some basic translations that hold by definition between the various
 us to access the numerators and denominators of a continued fraction.
 -/
 
-variables {α : Type*} {g : gcf α} {n : ℕ}
+variables {α : Type*} {g : generalized_continued_fraction α} {n : ℕ}
 
 lemma terminated_at_iff_s_terminated_at : g.terminated_at n ↔ g.s.terminated_at n := by refl
 
@@ -42,11 +41,11 @@ by cases s_nth_eq : (g.s.nth n); simp [partial_denominators, s_nth_eq]
 lemma terminated_at_iff_part_denom_none : g.terminated_at n ↔ g.partial_denominators.nth n = none :=
 by rw [terminated_at_iff_s_none, part_denom_none_iff_s_none]
 
-lemma part_num_eq_s_a {gp : gcf.pair α} (s_nth_eq : g.s.nth n = some gp) :
+lemma part_num_eq_s_a {gp : pair α} (s_nth_eq : g.s.nth n = some gp) :
   g.partial_numerators.nth n = some gp.a :=
 by simp [partial_numerators, s_nth_eq]
 
-lemma part_denom_eq_s_b {gp : gcf.pair α} (s_nth_eq : g.s.nth n = some gp) :
+lemma part_denom_eq_s_b {gp : pair α} (s_nth_eq : g.s.nth n = some gp) :
   g.partial_denominators.nth n = some gp.b :=
 by simp [partial_denominators, s_nth_eq]
 
@@ -68,7 +67,7 @@ Here we  give some basic translations that hold by definition for the computatio
 continued fraction.
 -/
 
-variables {K : Type*} {g : gcf K} {n : ℕ} [division_ring K]
+variables {K : Type*} {g : generalized_continued_fraction K} {n : ℕ} [division_ring K]
 
 lemma nth_cont_eq_succ_nth_cont_aux : g.continuants n = g.continuants_aux (n + 1) := rfl
 lemma num_eq_conts_a : g.numerators n = (g.continuants n).a := rfl
@@ -99,24 +98,24 @@ lemma zeroth_denominator_eq_one : g.denominators 0 = 1 := rfl
 lemma zeroth_convergent_eq_h : g.convergents 0 = g.h :=
 by simp [convergent_eq_num_div_denom, num_eq_conts_a, denom_eq_conts_b, div_one]
 
-lemma second_continuant_aux_eq {gp : gcf.pair K} (zeroth_s_eq : g.s.nth 0 = some gp) :
+lemma second_continuant_aux_eq {gp : pair K} (zeroth_s_eq : g.s.nth 0 = some gp) :
   g.continuants_aux 2 = ⟨gp.b * g.h + gp.a, gp.b⟩ :=
 by simp [zeroth_s_eq, continuants_aux, next_continuants, next_denominator, next_numerator]
 
-lemma first_continuant_eq {gp : gcf.pair K} (zeroth_s_eq : g.s.nth 0 = some gp) :
+lemma first_continuant_eq {gp : pair K} (zeroth_s_eq : g.s.nth 0 = some gp) :
   g.continuants 1 = ⟨gp.b * g.h + gp.a, gp.b⟩ :=
 by simp [nth_cont_eq_succ_nth_cont_aux, (second_continuant_aux_eq zeroth_s_eq)]
 
-lemma first_numerator_eq {gp : gcf.pair K} (zeroth_s_eq : g.s.nth 0 = some gp) :
+lemma first_numerator_eq {gp : pair K} (zeroth_s_eq : g.s.nth 0 = some gp) :
   g.numerators 1 = gp.b * g.h + gp.a :=
 by simp[num_eq_conts_a, (first_continuant_eq zeroth_s_eq)]
 
-lemma first_denominator_eq {gp : gcf.pair K} (zeroth_s_eq : g.s.nth 0 = some gp) :
+lemma first_denominator_eq {gp : pair K} (zeroth_s_eq : g.s.nth 0 = some gp) :
   g.denominators 1 = gp.b :=
 by simp[denom_eq_conts_b, (first_continuant_eq zeroth_s_eq)]
 
 @[simp]
-lemma zeroth_convergent'_aux_eq_zero {s : seq $ gcf.pair K} : convergents'_aux s 0 = 0 := rfl
+lemma zeroth_convergent'_aux_eq_zero {s : seq $ pair K} : convergents'_aux s 0 = 0 := rfl
 @[simp]
 lemma zeroth_convergent'_eq_h : g.convergents' 0 = g.h := by simp [convergents']
 


### PR DESCRIPTION
Lean 4 doesn't support the use of `open ... as ...`, so let's get rid of the few uses from mathlib rather than automating it in mathport.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
