### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal): the product and infimum of principal ideals

### DIFF
--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -31,6 +31,7 @@ multiplication of submodules, division of subodules, submodule semiring
 universes uι u v
 
 open algebra set
+open_locale big_operators
 open_locale pointwise
 
 namespace submodule
@@ -266,6 +267,20 @@ le_antisymm (mul_le.2 $ λ r hrm s hsn, mul_mem_mul_rev hsn hrm)
 instance : comm_semiring (submodule R A) :=
 { mul_comm := submodule.mul_comm,
   .. submodule.semiring }
+
+lemma prod_span {ι : Type*} (s : finset ι) (M : ι → set A) :
+  (∏ i in s, submodule.span R (M i)) = submodule.span R (∏ i in s, M i) :=
+begin
+  letI := classical.dec_eq ι,
+  refine finset.induction_on s _ _,
+  { simp [one_eq_span, set.singleton_one] },
+  { intros _ _ H ih,
+    rw [finset.prod_insert H, finset.prod_insert H, ih, span_mul_span] }
+end
+
+lemma prod_span_singleton {ι : Type*} (s : finset ι) (x : ι → A) :
+  (∏ i in s, span R ({x i} : set A)) = span R {∏ i in s, x i} :=
+by rw [prod_span, set.finset_prod_singleton]
 
 variables (R A)
 

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -169,6 +169,16 @@ instance : complete_lattice (submodule R M) :=
 
 @[simp] theorem Inf_coe (P : set (submodule R M)) : (↑(Inf P) : set M) = ⋂ p ∈ P, ↑p := rfl
 
+@[simp] theorem finset_inf_coe {ι} (s : finset ι) (p : ι → submodule R M) :
+  (↑(s.inf p) : set M) = ⋂ i ∈ s, ↑(p i) :=
+begin
+  letI := classical.dec_eq ι,
+  refine s.induction_on _ (λ i s hi ih, _),
+  { simp },
+  { rw [finset.inf_insert, inf_coe, ih],
+    simp },
+end
+
 @[simp] theorem infi_coe {ι} (p : ι → submodule R M) :
   (↑⨅ i, p i : set M) = ⋂ i, ↑(p i) :=
 by rw [infi, Inf_coe]; ext a; simp; exact
@@ -180,6 +190,10 @@ set.mem_bInter_iff
 @[simp] theorem mem_infi {ι} (p : ι → submodule R M) {x} :
   x ∈ (⨅ i, p i) ↔ ∀ i, x ∈ p i :=
 by rw [← set_like.mem_coe, infi_coe, set.mem_Inter]; refl
+
+@[simp] theorem mem_finset_inf {ι} {s : finset ι} {p : ι → submodule R M} {x : M} :
+  x ∈ s.inf p ↔ ∀ i ∈ s, x ∈ p i :=
+by simp only [← set_like.mem_coe, finset_inf_coe, set.mem_Inter]
 
 lemma mem_sup_left {S T : submodule R M} : ∀ {x : M}, x ∈ S → x ∈ S ⊔ T :=
 show S ≤ S ⊔ T, from le_sup_left

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -337,6 +337,18 @@ begin
   exact ⟨g, λ i hi, hf hi $ hg hi, rfl⟩
 end
 
+@[to_additive]
+lemma finset_prod_singleton {M ι : Type*} [comm_monoid M] (s : finset ι) (I : ι → M) :
+  ∏ (i : ι) in s, ({I i} : set M) = {∏ (i : ι) in s, I i} :=
+begin
+  letI := classical.dec_eq ι,
+  refine finset.induction_on s _ _,
+  { simpa },
+  { intros _ _ H ih,
+    rw [finset.prod_insert H, finset.prod_insert H, ih],
+    simp }
+end
+
 /-! TODO: define `decidable_mem_finset_prod` and `decidable_mem_finset_sum`. -/
 
 end big_operators

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -314,20 +314,11 @@ by simp only [le_antisymm_iff, span_singleton_mul_le_span_singleton_mul, eq_comm
 
 lemma prod_span {ι : Type*} (s : finset ι) (I : ι → set R) :
   (∏ i in s, ideal.span (I i)) = ideal.span (∏ i in s, I i) :=
-begin
-  letI := classical.dec_eq ι,
-  refine finset.induction_on s _ _,
-  { simp },
-  { intros _ _ H ih,
-    rw [finset.prod_insert H, finset.prod_insert H, ih, ideal.span_mul_span],
-    congr' 1,
-    ext x,
-    simp [set.mem_mul, eq_comm] }
-end
+submodule.prod_span s I
 
 lemma prod_span_singleton {ι : Type*} (s : finset ι) (I : ι → R) :
   (∏ i in s, ideal.span ({I i} : set R)) = ideal.span {∏ i in s, I i} :=
-by rw [prod_span, set.finset_prod_singleton]
+submodule.prod_span_singleton s I
 
 lemma finset_inf_span_singleton {ι : Type*} (s : finset ι) (I : ι → R)
   (hI : set.pairwise ↑s (is_coprime on I)) :

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -327,16 +327,7 @@ end
 
 lemma prod_span_singleton {ι : Type*} (s : finset ι) (I : ι → R) :
   (∏ i in s, ideal.span ({I i} : set R)) = ideal.span {∏ i in s, I i} :=
-begin
-  letI := classical.dec_eq ι,
-  refine finset.induction_on s _ _,
-  { simp },
-  { intros _ _ H ih,
-    rw [finset.prod_insert H, finset.prod_insert H, ih, ideal.span_mul_span],
-    congr' 1,
-    ext x,
-    simp [set.mem_mul, eq_comm] }
-end
+by rw [prod_span, set.finset_prod_singleton]
 
 lemma infi_span_singleton {ι : Type*} [fintype ι] (I : ι → R)
   (hI : ∀ i j (hij : i ≠ j), is_coprime (I i) (I j)):

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -7,6 +7,7 @@ import algebra.algebra.operations
 import algebra.algebra.tower
 import data.equiv.ring
 import data.nat.choose.sum
+import ring_theory.coprime.lemmas
 import ring_theory.ideal.quotient
 import ring_theory.non_zero_divisors
 /-!
@@ -310,6 +311,43 @@ lemma span_singleton_mul_eq_span_singleton_mul {x y : R} (I J : ideal R) :
     ((∀ zI ∈ I, ∃ zJ ∈ J, x * zI = y * zJ) ∧
      (∀ zJ ∈ J, ∃ zI ∈ I, x * zI = y * zJ)) :=
 by simp only [le_antisymm_iff, span_singleton_mul_le_span_singleton_mul, eq_comm]
+
+lemma prod_span {ι : Type*} (s : finset ι) (I : ι → set R) :
+  (∏ i in s, ideal.span (I i)) = ideal.span (∏ i in s, I i) :=
+begin
+  letI := classical.dec_eq ι,
+  refine finset.induction_on s _ _,
+  { simp },
+  { intros _ _ H ih,
+    rw [finset.prod_insert H, finset.prod_insert H, ih, ideal.span_mul_span],
+    congr' 1,
+    ext x,
+    simp [set.mem_mul, eq_comm] }
+end
+
+lemma prod_span_singleton {ι : Type*} (s : finset ι) (I : ι → R) :
+  (∏ i in s, ideal.span ({I i} : set R)) = ideal.span {∏ i in s, I i} :=
+begin
+  letI := classical.dec_eq ι,
+  refine finset.induction_on s _ _,
+  { simp },
+  { intros _ _ H ih,
+    rw [finset.prod_insert H, finset.prod_insert H, ih, ideal.span_mul_span],
+    congr' 1,
+    ext x,
+    simp [set.mem_mul, eq_comm] }
+end
+
+lemma infi_span_singleton {ι : Type*} [fintype ι] (I : ι → R)
+  (hI : ∀ i j (hij : i ≠ j), is_coprime (I i) (I j)):
+  (⨅ i, ideal.span ({I i} : set R)) = ideal.span {∏ i, I i} :=
+begin
+  letI := classical.dec_eq ι,
+  ext x,
+  simp only [submodule.mem_infi, ideal.mem_span_singleton],
+  exact ⟨fintype.prod_dvd_of_coprime hI,
+    λ h i, dvd_trans (finset.dvd_prod_of_mem _ (finset.mem_univ _)) h⟩
+end
 
 theorem mul_le_inf : I * J ≤ I ⊓ J :=
 mul_le.2 $ λ r hri s hsj, ⟨I.mul_mem_right s hri, J.mul_mem_left r hsj⟩

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -329,15 +329,22 @@ lemma prod_span_singleton {ι : Type*} (s : finset ι) (I : ι → R) :
   (∏ i in s, ideal.span ({I i} : set R)) = ideal.span {∏ i in s, I i} :=
 by rw [prod_span, set.finset_prod_singleton]
 
+lemma finset_inf_span_singleton {ι : Type*} (s : finset ι) (I : ι → R)
+  (hI : set.pairwise ↑s (is_coprime on I)) :
+  (s.inf $ λ i, ideal.span ({I i} : set R)) = ideal.span {∏ i in s, I i} :=
+begin
+  ext x,
+  simp only [submodule.mem_finset_inf, ideal.mem_span_singleton],
+  exact ⟨finset.prod_dvd_of_coprime hI,
+    λ h i hi, (finset.dvd_prod_of_mem _ hi).trans h⟩
+end
+
 lemma infi_span_singleton {ι : Type*} [fintype ι] (I : ι → R)
   (hI : ∀ i j (hij : i ≠ j), is_coprime (I i) (I j)):
   (⨅ i, ideal.span ({I i} : set R)) = ideal.span {∏ i, I i} :=
 begin
-  letI := classical.dec_eq ι,
-  ext x,
-  simp only [submodule.mem_infi, ideal.mem_span_singleton],
-  exact ⟨fintype.prod_dvd_of_coprime hI,
-    λ h i, dvd_trans (finset.dvd_prod_of_mem _ (finset.mem_univ _)) h⟩
+  rw [← finset.inf_univ_eq_infi, finset_inf_span_singleton],
+  rwa [finset.coe_univ, set.pairwise_univ]
 end
 
 theorem mul_le_inf : I * J ≤ I ⊓ J :=

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -382,8 +382,9 @@ have hdiv : p ^ (get (multiplicity p a) ((finite_mul_iff hp).1 h).1 +
   by rw [hpoweq]; apply mul_dvd_mul; assumption,
 have hsucc : ¬p ^ ((get (multiplicity p a) ((finite_mul_iff hp).1 h).1 +
     get (multiplicity p b) ((finite_mul_iff hp).1 h).2) + 1) ∣ a * b,
-  from λ h, not_or (is_greatest' _ (lt_succ_self _)) (is_greatest' _ (lt_succ_self _))
-    (by exact succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul hp hdiva hdivb h),
+  from λ h, by exact
+    not_or (is_greatest' _ (lt_succ_self _)) (is_greatest' _ (lt_succ_self _))
+      (_root_.succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul hp hdiva hdivb h),
 by rw [← enat.coe_inj, enat.coe_get, eq_coe_iff];
   exact ⟨hdiv, hsucc⟩
 


### PR DESCRIPTION
Three useful lemmas for applying the Chinese remainder theorem when an ideal is generated by one, non-prime, element.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
